### PR TITLE
fix(cloud): gate provisioning health at enqueue

### DIFF
--- a/packages/cloud/api/__tests__/eliza-agents-create-idempotency.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-create-idempotency.test.ts
@@ -23,10 +23,6 @@ const requireUserOrApiKeyWithOrg = mock(async () => ({
 const createAgent = mock();
 const updateAgentEnvironment = mock(async () => undefined);
 const listAgents = mock(async () => []);
-// Default false = the org has no reusable agent, so the worker-health gate
-// runs exactly as it did before the #15516 reuse-peek — existing tests keep
-// their original gate semantics.
-const hasReusableNonTerminalAgent = mock(async () => false);
 
 const enqueueAgentProvision = mock(async () => ({
   id: "job-1",
@@ -57,9 +53,14 @@ const loggerError = mock(() => undefined);
 
 const claimWarmContainer = mock(async () => null);
 const listByOrganization = mock(async () => []);
+const sandboxDelete = mock(async () => undefined);
 
 mock.module("@/db/repositories/agent-sandboxes", () => ({
-  agentSandboxesRepository: { claimWarmContainer, listByOrganization },
+  agentSandboxesRepository: {
+    claimWarmContainer,
+    listByOrganization,
+    delete: sandboxDelete,
+  },
 }));
 
 mock.module("@/db/repositories/characters", () => ({
@@ -103,7 +104,6 @@ mock.module("@/lib/services/eliza-sandbox", () => ({
     createAgent,
     updateAgentEnvironment,
     listAgents,
-    hasReusableNonTerminalAgent,
   },
   AgentImageNotAllowedError,
   AgentQuotaExceededError,
@@ -171,8 +171,7 @@ describe("POST /api/v1/eliza/agents — reuse idempotency", () => {
     checkAgentCreditGate.mockClear();
     checkProvisioningWorkerHealth.mockClear();
     checkProvisioningWorkerHealth.mockResolvedValue({ ok: true });
-    hasReusableNonTerminalAgent.mockClear();
-    hasReusableNonTerminalAgent.mockResolvedValue(false);
+    sandboxDelete.mockClear();
     prepareManagedElizaEnvironment.mockClear();
     loggerInfo.mockClear();
   });
@@ -381,10 +380,9 @@ describe("POST /api/v1/eliza/agents — reuse idempotency", () => {
 
   test("#15516: a provisioning-worker outage does NOT block reuse — reusable agent exists → gate skipped, 200 with the existing agent", async () => {
     // Reuse enqueues nothing, so worker capacity is irrelevant to it. The
-    // route must resolve reuse candidacy BEFORE the health gate; otherwise a
-    // heartbeat gap 503s first-run onboarding for a user whose one healthy
-    // agent needed no provisioning at all (the #15516 dead-end).
-    hasReusableNonTerminalAgent.mockResolvedValue(true);
+    // route must return before the enqueue boundary; otherwise a heartbeat gap
+    // 503s first-run onboarding for a user whose one healthy agent needed no
+    // provisioning at all (the #15516 dead-end).
     checkProvisioningWorkerHealth.mockResolvedValue({
       ok: false,
       status: 503,
@@ -406,13 +404,14 @@ describe("POST /api/v1/eliza/agents — reuse idempotency", () => {
     expect(enqueueAgentProvision).not.toHaveBeenCalled();
   });
 
-  test("#15516: worker outage with NO reusable agent still fails closed → 503, createAgent never runs", async () => {
-    hasReusableNonTerminalAgent.mockResolvedValue(false);
+  test("#15516: worker outage with NO reusable agent still fails closed → 503, pending row rolled back", async () => {
     checkProvisioningWorkerHealth.mockResolvedValue({
       ok: false,
       status: 503,
       code: "PROVISIONING_WORKER_UNHEALTHY",
     });
+    const agent = { ...pendingAgent(), status: "pending" };
+    createAgent.mockResolvedValue({ agent, idempotent: false });
 
     const res = await postCreate({
       agentName: "alpha",
@@ -423,19 +422,26 @@ describe("POST /api/v1/eliza/agents — reuse idempotency", () => {
     const body = (await res.json()) as { success: boolean; code: string };
     expect(body.success).toBe(false);
     expect(body.code).toBe("PROVISIONING_WORKER_UNHEALTHY");
-    expect(createAgent).not.toHaveBeenCalled();
+    expect(createAgent).toHaveBeenCalledTimes(1);
     expect(enqueueAgentProvision).not.toHaveBeenCalled();
+    expect(sandboxDelete).toHaveBeenCalledTimes(1);
+    expect(sandboxDelete).toHaveBeenCalledWith(agent.id, "org-1");
   });
 
-  test("#15516: forceCreate never skips the gate — a fresh mint during a worker outage 503s even when a reusable agent exists", async () => {
+  test("#15516: forceCreate never skips the enqueue gate during a worker outage even when a reusable agent exists", async () => {
     // forceCreate explicitly opts out of reuse, so its create WILL enqueue —
     // the worker gate must keep protecting it regardless of reuse candidacy.
-    hasReusableNonTerminalAgent.mockResolvedValue(true);
     checkProvisioningWorkerHealth.mockResolvedValue({
       ok: false,
       status: 503,
       code: "PROVISIONING_WORKER_UNHEALTHY",
     });
+    const agent = {
+      ...pendingAgent(),
+      id: "dedicated-fresh",
+      status: "pending",
+    };
+    createAgent.mockResolvedValue({ agent, idempotent: false });
 
     const res = await postCreate({
       agentName: "alpha",
@@ -444,7 +450,9 @@ describe("POST /api/v1/eliza/agents — reuse idempotency", () => {
     });
 
     expect(res.status).toBe(503);
-    expect(createAgent).not.toHaveBeenCalled();
+    expect(createAgent).toHaveBeenCalledTimes(1);
     expect(enqueueAgentProvision).not.toHaveBeenCalled();
+    expect(sandboxDelete).toHaveBeenCalledTimes(1);
+    expect(sandboxDelete).toHaveBeenCalledWith(agent.id, "org-1");
   });
 });

--- a/packages/cloud/api/__tests__/eliza-agents-orphan-cleanup.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-orphan-cleanup.test.ts
@@ -84,9 +84,6 @@ mock.module("@/lib/services/eliza-sandbox", () => ({
     createAgent,
     updateAgentEnvironment,
     listAgents: mock(async () => []),
-    // #15516 reuse-peek: false = no reusable agent, so the worker-health gate
-    // behaves exactly as before the peek existed.
-    hasReusableNonTerminalAgent: mock(async () => false),
   },
 }));
 

--- a/packages/cloud/api/__tests__/eliza-agents-warm-pool-empty-on-claim.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-warm-pool-empty-on-claim.test.ts
@@ -87,9 +87,6 @@ mock.module("@/lib/services/eliza-sandbox", () => ({
     createAgent,
     updateAgentEnvironment,
     listAgents,
-    // #15516 reuse-peek: false = no reusable agent, so the worker-health gate
-    // behaves exactly as before the peek existed.
-    hasReusableNonTerminalAgent: mock(async () => false),
   },
   AgentQuotaExceededError,
   AgentImageNotAllowedError,

--- a/packages/cloud/api/v1/eliza/agents/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/route.ts
@@ -366,32 +366,9 @@ app.post("/", async (c) => {
       );
     }
 
-    // The worker-health gate protects only FRESH provisions (a create that
-    // enqueues a job no worker will run). When the org already has a reusable
-    // non-terminal agent, `createAgent` below hands it back without touching
-    // the provisioning queue — so a worker outage must not 503 that caller
-    // (#15516: first-run onboarding dead-ended for a user whose one healthy
-    // agent needed no provisioning at all). The peek is advisory; if the
-    // candidate vanishes before `createAgent`'s locked re-check, the fresh
-    // create's job just waits in the queue for the worker to recover.
-    const reuseWouldServe =
-      !parsed.data.forceCreate &&
-      (await elizaSandboxService.hasReusableNonTerminalAgent(
-        user.organization_id,
-      ));
-    if (!reuseWouldServe) {
-      const workerHealth = await checkProvisioningWorkerHealth();
-      if (!workerHealth.ok) {
-        logger.warn("[agent-api] Agent creation blocked: worker unavailable", {
-          orgId: user.organization_id,
-          code: workerHealth.code,
-        });
-        return c.json(
-          provisioningWorkerFailureBody(workerHealth),
-          workerHealth.status,
-        );
-      }
-    }
+    // Worker health is checked at the enqueue boundary below. Earlier checks
+    // can block reuse, shared-tier, and warm-pool paths that do not need a
+    // provisioning worker.
   }
 
   let created: Awaited<ReturnType<typeof elizaSandboxService.createAgent>>;
@@ -626,6 +603,27 @@ app.post("/", async (c) => {
     }
 
     // ── Async path (default) ──────────────────────────────────────────────
+    // Only the cold provisioning job requires a live worker. Checking here
+    // keeps reuse, shared-tier creates, non-eager creates, and warm-pool claims
+    // available through heartbeat gaps, while still failing closed before a job
+    // is enqueued.
+    const workerHealth = await checkProvisioningWorkerHealth();
+    if (!workerHealth.ok) {
+      await agentSandboxesRepository.delete(agent.id, user.organization_id);
+      logger.warn(
+        "[agent-api] Agent provisioning blocked: worker unavailable; row rolled back",
+        {
+          agentId: agent.id,
+          orgId: user.organization_id,
+          code: workerHealth.code,
+        },
+      );
+      return c.json(
+        provisioningWorkerFailureBody(workerHealth),
+        workerHealth.status,
+      );
+    }
+
     // `expectedUpdatedAt` is intentionally omitted: the row was just created
     // (and possibly touched by the managed-env update above), so there is no
     // concurrent handle to guard against — passing the stale create timestamp

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -175,31 +175,6 @@ export class AgentSandboxesRepository {
       .orderBy(desc(agentSandboxes.created_at));
   }
 
-  /**
-   * Read-only peek at whether `createAgent`'s idempotent-reuse guard would
-   * hand back an existing agent for this org. Mirrors that guard's predicate
-   * EXACTLY (org-scoped, `pool_status IS NULL`, status
-   * pending/provisioning/running — see eliza-sandbox.ts `createAgent`); keep
-   * the two in sync. Advisory: the guard re-checks under its org advisory
-   * lock, so this may only ever be used to soften capacity gates (#15516),
-   * never as the reuse decision itself.
-   */
-  async hasReusableNonTerminalByOrganization(orgId: string): Promise<boolean> {
-    await ensureAgentSandboxSchema();
-    const [existing] = await dbRead
-      .select({ id: agentSandboxes.id })
-      .from(agentSandboxes)
-      .where(
-        and(
-          eq(agentSandboxes.organization_id, orgId),
-          sql`${agentSandboxes.pool_status} IS NULL`,
-          sql`${agentSandboxes.status} IN ('pending', 'provisioning', 'running')`,
-        ),
-      )
-      .limit(1);
-    return Boolean(existing);
-  }
-
   async findBySandboxId(sandboxId: string): Promise<AgentSandbox | undefined> {
     await ensureAgentSandboxSchema();
     const [r] = await dbRead

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -962,20 +962,6 @@ export class ElizaSandboxService {
     }
   }
 
-  /**
-   * Read-only peek at `createAgent`'s idempotent-reuse guard: would a
-   * `reuseExistingNonTerminal` create hand back an existing agent instead of
-   * inserting one? Routes use this to skip capacity gates (the
-   * provisioning-worker health 503) when no new provision would be enqueued:
-   * reuse needs no provisioning capacity, so a worker outage must not block a
-   * user who already has an agent (#15516). Advisory only — `createAgent`
-   * re-checks under its org advisory lock; a candidate deleted in the gap
-   * means a fresh create whose provision job simply waits in the queue.
-   */
-  async hasReusableNonTerminalAgent(organizationId: string): Promise<boolean> {
-    return agentSandboxesRepository.hasReusableNonTerminalByOrganization(organizationId);
-  }
-
   async createAgent(params: CreateAgentParams): Promise<{
     agent: AgentSandbox;
     idempotent: boolean;


### PR DESCRIPTION
## Summary
- moves the provisioning-worker health check to the cold provision-job enqueue boundary, after idempotent reuse, shared-tier, non-eager, and warm-pool paths have had a chance to succeed
- rolls back the just-created pending sandbox row before returning the canonical worker-unhealthy 503 body
- removes the now-unused advisory reuse peek helper from cloud-shared and stale mocks from the sibling route tests

This preserves #15541's source-side fix for #15516 while taking the stronger enqueue-boundary placement from the now-conflicting #15542 shape.

## Verification
- `bun test packages/cloud/api/__tests__/eliza-agents-create-idempotency.test.ts` -> 12 pass
- `bun test packages/cloud/api/__tests__/eliza-agents-warm-pool-empty-on-claim.test.ts` -> 2 pass
- `node packages/app-core/scripts/ensure-shared-i18n-data.mjs`
- `bun -c .tmp-bunfig-no-coverage.toml test ./packages/cloud/api/__tests__/eliza-agents-orphan-cleanup.test.ts` -> exit 0; temp config removed after run; no repo diff left
- `bunx @biomejs/biome check packages/cloud/api/v1/eliza/agents/route.ts packages/cloud/api/__tests__/eliza-agents-create-idempotency.test.ts packages/cloud/api/__tests__/eliza-agents-warm-pool-empty-on-claim.test.ts packages/cloud/api/__tests__/eliza-agents-orphan-cleanup.test.ts packages/cloud/shared/src/lib/services/eliza-sandbox.ts packages/cloud/shared/src/db/repositories/agent-sandboxes.ts --no-errors-on-unmatched`
- `git diff --check`
- `bun run audit:error-policy-ratchet`

Package typecheck caveat: `bun run --cwd packages/cloud/api typecheck` still fails on pre-existing unrelated errors in `__tests__/stripe-connect-webhook-route.test.ts` (`2026-06-24.dahlia` vs `2026-05-27.dahlia`) and `fal/proxy/route.ts` Hono 4.12.18/4.12.27 type mismatches; no touched file appears in that failure.

## Evidence rows
<!-- evidence-row:before-screenshots -->
- [x] N/A - backend route ordering only; no rendered UI change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend route ordering only; no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI flow changed in this source patch; device re-verification remains tracked on #15516.
<!-- evidence-row:backend-logs -->
- [x] Focused route tests assert the exact backend responses and repository calls: reuse returns 200 without worker-health check; worker-unhealthy cold create returns 503 and deletes the pending row.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model/action/provider/prompt behavior change.
<!-- evidence-row:domain-artifacts -->
- [x] Route tests assert the domain artifact behavior: no provision job is enqueued during worker outage, and the pending sandbox row is rolled back before returning 503.

Fixes #15516 server-side residual; supersedes the conflicting server-half shape in #15542.