### PR TITLE
fix(cloud): restore api typecheck

### DIFF
--- a/packages/cloud/api/__tests__/stripe-connect-webhook-route.test.ts
+++ b/packages/cloud/api/__tests__/stripe-connect-webhook-route.test.ts
@@ -240,7 +240,7 @@ describe("Stripe Connect payout webhook route", () => {
 // issue describes (#10117). Signature ops are local HMAC-SHA256 — no network.
 describe("Stripe Connect webhook — real signature verification (no mock)", () => {
   const realStripe = new Stripe("sk_test_dummy_for_signature_only", {
-    apiVersion: "2026-06-24.dahlia",
+    apiVersion: "2026-05-27.dahlia",
   });
   const secret = "whsec_connect_realtest";
   const payload = JSON.stringify(accountUpdatedEvent);

--- a/packages/cloud/api/fal/proxy/route.ts
+++ b/packages/cloud/api/fal/proxy/route.ts
@@ -14,6 +14,7 @@ import {
   TARGET_URL_HEADER,
 } from "@fal-ai/server-proxy";
 import { createRouteHandler } from "@fal-ai/server-proxy/hono";
+import type { Context, Handler } from "hono";
 import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
@@ -36,6 +37,11 @@ const falHandler = createRouteHandler({
   isAuthenticated: async () => true,
   resolveFalAuth: resolveApiKeyFromEnv,
 });
+const invokeFalProxy = (c: Context<AppEnv>): Promise<Response> =>
+  // @fal-ai/server-proxy currently carries its own Hono type copy. The runtime
+  // context shape is the same object this route receives; the cast is only the
+  // dependency-version boundary.
+  falHandler(c as never);
 
 const app = new Hono<AppEnv>();
 
@@ -111,7 +117,7 @@ function readString(body: unknown, keys: string[]): string | undefined {
   return undefined;
 }
 
-async function priceFalMutation(c: Parameters<typeof falHandler>[0]): Promise<{
+async function priceFalMutation(c: Context<AppEnv>): Promise<{
   model: string;
   cost: Awaited<ReturnType<typeof calculateVideoGenerationCostFromCatalog>>;
 }> {
@@ -160,7 +166,7 @@ async function priceFalMutation(c: Parameters<typeof falHandler>[0]): Promise<{
   return { model, cost };
 }
 
-const handle = async (c: Parameters<typeof falHandler>[0]) => {
+const handle: Handler<AppEnv> = async (c) => {
   const isMutation = c.req.method === "POST" || c.req.method === "PUT";
   let reservation: Awaited<ReturnType<typeof creditsService.reserve>> | null =
     null;
@@ -212,7 +218,7 @@ const handle = async (c: Parameters<typeof falHandler>[0]) => {
   }
 
   try {
-    const response = await falHandler(c);
+    const response = await invokeFalProxy(c);
 
     if (reservation && pricedMutation) {
       if (response.ok) {


### PR DESCRIPTION
## Summary
- updates the Stripe Connect signature-only test to use the Stripe SDK's installed, type-valid Dahlia API version literal
- types the FAL proxy route against this package's Hono context and isolates the duplicate-Hono-package compatibility cast at the upstream proxy boundary

## Verification
- `node packages/app-core/scripts/ensure-shared-i18n-data.mjs`
- `cd packages/cloud/api && bunx tsgo --noEmit`
- `bun -c .tmp-bunfig-no-coverage.toml test ./packages/cloud/api/__tests__/stripe-connect-webhook-route.test.ts` -> exit 0; temp config removed after run
- `bunx @biomejs/biome check packages/cloud/api/__tests__/stripe-connect-webhook-route.test.ts packages/cloud/api/fal/proxy/route.ts --no-errors-on-unmatched`
- `git diff --check`
- `bun run audit:error-policy-ratchet`

`bun run --cwd packages/cloud/api typecheck` now gets past `tsgo --noEmit` and fails only at `check:worker-bundle` because this local worktree does not have `wrangler` on PATH (`/bin/bash: wrangler: command not found`).

## Evidence rows
<!-- evidence-row:before-screenshots -->
- [x] N/A - typecheck-only cloud API fix; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - typecheck-only cloud API fix; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow changed.
<!-- evidence-row:backend-logs -->
- [x] `tsgo --noEmit` passes for `packages/cloud/api`; focused Stripe webhook route test exits 0.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model/action/provider/prompt behavior change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB/migration/domain artifact changed; this restores compile-time validity for existing route/test code.