### PR TITLE
fix(ci): skip hetzner e2e teardown sweep on rejected token when nothing was provisioned

### DIFF
--- a/.github/workflows/hetzner-e2e.yml
+++ b/.github/workflows/hetzner-e2e.yml
@@ -43,6 +43,8 @@ jobs:
     runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     environment: ci-hetzner-e2e
     timeout-minutes: 25
+    outputs:
+      provisioned: ${{ steps.provision.outputs.provisioned }}
     env:
       HCLOUD_TOKEN_CI: ${{ secrets.HCLOUD_TOKEN_CI }}
       CLOUD_E2E_API_KEY: ${{ secrets.CLOUD_E2E_API_KEY || secrets.ELIZACLOUD_API_KEY }}
@@ -416,4 +418,9 @@ jobs:
 
       - name: Teardown
         if: steps.secret_config.outputs.configured == 'true'
+        env:
+          # Lets the teardown script distinguish "dead token, nothing was
+          # provisioned, nothing can leak" (soft-skip) from "dead token but a
+          # server exists" (hard fail so the leak is never silent).
+          DEPLOY_PROVISIONED: ${{ needs.deploy.outputs.provisioned }}
         run: bun run packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-teardown.ts

--- a/packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-teardown.ts
+++ b/packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-teardown.ts
@@ -3,9 +3,17 @@
  * Tear down the throwaway server. Idempotent: 404 is treated as
  * success. If the state file is missing or has no server_id, falls
  * back to a label-selector sweep (ci=true,workflow=hetzner-e2e,run=<runId>).
+ *
+ * A rejected HCLOUD_TOKEN_CI only soft-skips the sweep when nothing was
+ * provisioned this run (no state file and DEPLOY_PROVISIONED != true) —
+ * a dead token can't have created a server, so there is nothing to leak.
+ * If a server is known to exist, a rejected token stays a hard failure.
  */
 
-import { HetznerCloudClient } from "@elizaos/cloud-shared/lib/services/containers/hetzner-cloud-api";
+import {
+  HetznerCloudClient,
+  HetznerCloudError,
+} from "@elizaos/cloud-shared/lib/services/containers/hetzner-cloud-api";
 import { readState } from "./state-file";
 
 function requireEnv(name: string): string {
@@ -55,11 +63,35 @@ async function main(): Promise<void> {
   console.log(
     `[hetzner-e2e-teardown] state file missing; sweeping by label run=${runId}`,
   );
-  const servers = await client.listServers({
-    ci: "true",
-    workflow: "hetzner-e2e",
-    run: String(runId),
-  });
+  let servers: Awaited<ReturnType<typeof client.listServers>>;
+  try {
+    servers = await client.listServers({
+      ci: "true",
+      workflow: "hetzner-e2e",
+      run: String(runId),
+    });
+  } catch (err) {
+    // error-policy:J4 Scheduled cleanup must not page on absent or revoked CI credentials.
+    if (err instanceof HetznerCloudError && err.code === "missing_token") {
+      if (process.env.DEPLOY_PROVISIONED === "true") {
+        console.error(
+          "[hetzner-e2e-teardown] HCLOUD_TOKEN_CI rejected but the deploy job provisioned a server this run — a CI server may be leaking. Refresh HCLOUD_TOKEN_CI in the ci-hetzner-e2e environment and re-run teardown (or let the reaper sweep once the token works).",
+        );
+        throw err;
+      }
+      if (process.env.GITHUB_EVENT_NAME === "workflow_dispatch") {
+        console.error(
+          "[hetzner-e2e-teardown] HCLOUD_TOKEN_CI rejected by Hetzner; failing loudly on manual dispatch. Refresh the token in the ci-hetzner-e2e environment.",
+        );
+        throw err;
+      }
+      console.warn(
+        "[hetzner-e2e-teardown] HCLOUD_TOKEN_CI rejected by Hetzner; nothing was provisioned this run, so nothing can leak. Skipping sweep. Operator: refresh HCLOUD_TOKEN_CI in the ci-hetzner-e2e environment.",
+      );
+      return;
+    }
+    throw err;
+  }
   for (const server of servers) {
     await deleteOne(client, server.id);
   }


### PR DESCRIPTION
## Problem

`Hetzner Agent E2E` has failed on every develop push/schedule today. The deploy job soft-skips when Hetzner rejects `HCLOUD_TOKEN_CI` (HTTP 401 — the secret is currently expired/revoked), so nothing is provisioned — but the teardown job's label sweep still hard-fails on the same 401. Runs: 28981818928, 28981597489, 28981121121, and 5+ more today.

739301616 fixed the identical failure in the reaper but did not touch teardown.

## Fix

Mirror the reaper's `error-policy:J4` handling in the teardown label sweep — a dead token cannot have created a server, so there is nothing to leak — with two guards so a real leak is never silently skipped:

- **New `provisioned` job output on the deploy job**, passed to teardown as `DEPLOY_PROVISIONED`. If a server was actually provisioned this run and the token is rejected at teardown time (rotated mid-run), teardown still hard-fails so the leak is loud.
- **Manual `workflow_dispatch` runs still fail loudly**, matching the deploy job's policy for operator-triggered runs.

The state-file path (known `server_id`) is unchanged — a 401 there remains a hard failure.

## Operator follow-up (not in this PR)

`HCLOUD_TOKEN_CI` in the `ci-hetzner-e2e` environment needs a fresh read-write token from the Hetzner CI project; until then the e2e is effectively disabled (it now skips cleanly instead of failing).

## Verification
- `bun build --target=bun` parses the modified script and resolves imports
- YAML validated
- Teardown sweep policy: token-rejected + nothing provisioned → warn+skip; token-rejected + `DEPLOY_PROVISIONED=true` → hard fail; token-rejected + dispatch → hard fail

Related to the CI-hygiene sweep for #15398 / launch QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)