### PR TITLE
fix(ci): scrub deprecated bridge fallback on provisioning deploy

### DIFF
--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -345,6 +345,11 @@ jobs:
             # never blanked.
             sudo sed -i "/^PROVISIONING_JOB_LANES=/d" "$ENV_FILE"
             printf 'PROVISIONING_JOB_LANES=%s\n' "agent" | sudo tee -a "$ENV_FILE" >/dev/null
+            # Headscale is the required dedicated-agent ingress. Bridge-host
+            # fallback was a legacy escape hatch; if it remains hand-set on the
+            # box, docker-sandbox-provider deliberately disables VPN injection
+            # and fresh staging agents never receive a headscale_ip (#15347).
+            sudo sed -i "/^AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK=/d" "$ENV_FILE"
             for kv in \
               "HEADSCALE_API_URL=$HEADSCALE_API_URL" \
               "HEADSCALE_PUBLIC_URL=$HEADSCALE_PUBLIC_URL" \

--- a/packages/scripts/cloud/admin/daemons/provisioning-worker-env-reconcile.test.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker-env-reconcile.test.ts
@@ -23,6 +23,7 @@ const workflow = readFileSync(workflowPath, "utf8");
 
 const ENV_KEY = "SANDBOX_REGISTRY_REDIS_URL";
 const FIELD_ENCRYPTION_KEY = "SECRETS_MASTER_KEY";
+const BRIDGE_FALLBACK_KEY = "AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK";
 
 // The reconcile loop runs the workflow's VERBATIM bash, which uses GNU
 // `sed -i "/^KEY=/d"` (no backup-suffix argument). BSD/macOS `sed -i` parses
@@ -90,12 +91,26 @@ describe("deploy-eliza-provisioning-worker.yml SANDBOX_REGISTRY_REDIS_URL wiring
       `"${FIELD_ENCRYPTION_KEY}=$${FIELD_ENCRYPTION_KEY}"`,
     );
   });
+
+  it("scrubs the deprecated bridge-host fallback flag during env reconciliation", () => {
+    expect(workflow).toContain(
+      `sed -i "/^${BRIDGE_FALLBACK_KEY}=/d" "$ENV_FILE"`,
+    );
+    const lanePinIdx = workflow.indexOf('sed -i "/^PROVISIONING_JOB_LANES=/d"');
+    const scrubIdx = workflow.indexOf(`${BRIDGE_FALLBACK_KEY}=/d`);
+    const secretLoopIdx = workflow.indexOf("for kv in \\");
+    expect(lanePinIdx).toBeGreaterThan(-1);
+    expect(scrubIdx).toBeGreaterThan(-1);
+    expect(secretLoopIdx).toBeGreaterThan(-1);
+    expect(lanePinIdx).toBeLessThan(scrubIdx);
+    expect(scrubIdx).toBeLessThan(secretLoopIdx);
+  });
 });
 
 // Extract the exact reconcile loop body from the workflow and run it in a
 // scratch dir so the test exercises the real bash, not a re-implementation.
 function extractReconcileLoop(): string {
-  const start = workflow.indexOf("for kv in \\");
+  const start = workflow.indexOf('sudo sed -i "/^PROVISIONING_JOB_LANES=/d"');
   expect(start).toBeGreaterThan(-1);
   const tail = workflow.slice(start);
   const doneIdx = tail.indexOf("\n            done");
@@ -113,6 +128,7 @@ function extractReconcileLoop(): string {
   expect(loop).toContain("sed -i");
   expect(loop).toContain("tee -a");
   expect(loop).toContain(ENV_KEY);
+  expect(loop).toContain(BRIDGE_FALLBACK_KEY);
   return loop;
 }
 
@@ -209,6 +225,16 @@ executedDescribe(
     it("skips the key when the secret is the empty string", () => {
       const out = runReconcile({ redisUrl: "" });
       expect(out).not.toContain(ENV_KEY);
+    });
+
+    it("removes the deprecated bridge-host fallback flag on every deploy", () => {
+      const out = runReconcile({
+        redisUrl: undefined,
+        seedEnvFile: `${BRIDGE_FALLBACK_KEY}=1\nOTHER=keep\n`,
+      });
+      expect(out).not.toContain(BRIDGE_FALLBACK_KEY);
+      expect(out).toContain("PROVISIONING_JOB_LANES=agent\n");
+      expect(out).toContain("OTHER=keep\n");
     });
   },
 );


### PR DESCRIPTION
## Problem

#15347 pinned the staging headscale outage to a hand-set `AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK=1` on the control-plane host. Removing it manually let fresh provisions use Headscale again, but the provisioning-worker deploy reconcile loop only adds known-good env keys; it did not remove this deprecated escape hatch if it reappeared in `/opt/eliza/cloud/.env.local`.

## Fix

- Make `.github/workflows/deploy-eliza-provisioning-worker.yml` scrub `AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK` on every provisioning-worker deploy, next to the existing `PROVISIONING_JOB_LANES=agent` pin.
- Extend `provisioning-worker-env-reconcile.test.ts` so the workflow must contain the scrub and the executed GNU-sed reconcile block includes it.

This is a durability guard: Headscale remains the required dedicated-agent ingress, and future deploys should not preserve a stale bridge-host fallback flag that disables VPN injection.

## Verification

- `bun test packages/scripts/cloud/admin/daemons/provisioning-worker-env-reconcile.test.ts`
  - local macOS: 5 pass, 5 skip; executed bash cases still skip without GNU sed, matching existing test behavior
- `bunx @biomejs/biome check .github/workflows/deploy-eliza-provisioning-worker.yml packages/scripts/cloud/admin/daemons/provisioning-worker-env-reconcile.test.ts --no-errors-on-unmatched`
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "yaml ok"' .github/workflows/deploy-eliza-provisioning-worker.yml`\n- `bun run audit:error-policy-ratchet`\n\nRelated: #15347