### PR TITLE
fix(cloud): refuse memory KMS on staging and bare launches, not just production (#15310)

### DIFF
--- a/packages/cloud/shared/src/db/crypto/kms-client.test.ts
+++ b/packages/cloud/shared/src/db/crypto/kms-client.test.ts
@@ -1,11 +1,13 @@
-// Boot-time guard that refuses the ephemeral `memory` KMS backend in production.
-// Real getKmsClient() over the real @elizaos/security factory; the prod signal is
-// driven through the cloud-bindings ALS the same way the Worker sets it.
+// Boot-time guard that refuses the ephemeral `memory` KMS backend anywhere it
+// could orphan real data (#15310: staging ran memory KMS and lost every org DEK
+// on every restart). Real getKmsClient() over the real @elizaos/security
+// factory; the deployment signal is driven through the cloud-bindings ALS the
+// same way the Worker sets it.
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { ElizaError } from "@elizaos/core";
 import { runWithCloudBindings } from "../../lib/runtime/cloud-bindings";
-import { getKmsClient, resetKmsClientForTests } from "./kms-client";
+import { getKmsClient, isEphemeralKmsAllowed, resetKmsClientForTests } from "./kms-client";
 
 // A syntactically valid base64 32-byte root key so the `local` backend actually
 // constructs instead of failing on a missing key.
@@ -21,39 +23,55 @@ afterEach(() => {
   resetKmsClientForTests();
 });
 
-describe("getKmsClient production guard", () => {
+function expectMemoryRefused(bindings: Record<string, string>): void {
+  let thrown: unknown;
+  try {
+    runWithCloudBindings({ ...bindings, ELIZA_KMS_BACKEND: "memory" }, () => getKmsClient());
+  } catch (e) {
+    thrown = e;
+  }
+  expect(thrown).toBeInstanceOf(ElizaError);
+  expect((thrown as ElizaError).code).toBe("KMS_MEMORY_BACKEND_FORBIDDEN");
+  expect((thrown as Error).message).toContain("memory");
+}
+
+describe("getKmsClient ephemeral-backend guard", () => {
   test("prod + memory backend → throws a classified ElizaError at resolution", () => {
-    let thrown: unknown;
-    try {
-      runWithCloudBindings({ ENVIRONMENT: "production", ELIZA_KMS_BACKEND: "memory" }, () =>
-        getKmsClient(),
-      );
-    } catch (e) {
-      thrown = e;
-    }
-    expect(thrown).toBeInstanceOf(ElizaError);
-    expect((thrown as ElizaError).code).toBe("KMS_MEMORY_BACKEND_IN_PRODUCTION");
-    expect((thrown as Error).message).toContain("memory");
+    expectMemoryRefused({ ENVIRONMENT: "production" });
   });
 
-  test("prod + memory via ENVIRONMENT unset but NODE_ENV=production → still throws", () => {
-    // The prod signal falls back to NODE_ENV when ENVIRONMENT is absent (local
-    // Node runs), so the guard must fire on that path too.
-    let thrown: unknown;
-    try {
-      runWithCloudBindings({ NODE_ENV: "production", ELIZA_KMS_BACKEND: "memory" }, () =>
-        getKmsClient(),
-      );
-    } catch (e) {
-      thrown = e;
-    }
-    expect(thrown).toBeInstanceOf(ElizaError);
-    expect((thrown as ElizaError).code).toBe("KMS_MEMORY_BACKEND_IN_PRODUCTION");
+  test("staging + memory backend → throws (the #15310 incident class)", () => {
+    // The deployed-environment marker is authoritative even though this test
+    // process runs under NODE_ENV=test — a real staging Worker/daemon must
+    // never encrypt org DEKs with a key that dies on restart.
+    expectMemoryRefused({ ENVIRONMENT: "staging" });
+  });
+
+  test("prod via ENVIRONMENT unset but NODE_ENV=production → still throws", () => {
+    expectMemoryRefused({ NODE_ENV: "production", ENVIRONMENT: "" });
+  });
+
+  test("bare launch (neither ENVIRONMENT nor NODE_ENV) + memory → throws", () => {
+    // A daemon/sidecar started without its env file is a real deployment that
+    // forgot its config, not a test world.
+    expectMemoryRefused({ NODE_ENV: "", ENVIRONMENT: "" });
   });
 
   test("test env + memory backend → resolves normally (tests legitimately use memory)", () => {
-    // NODE_ENV=test in this runner → memory backend, not production → allowed.
+    // NODE_ENV=test in this runner → memory backend, not a deployment → allowed.
     const client = getKmsClient();
+    expect(client).toBeDefined();
+    expect(typeof client.encrypt).toBe("function");
+  });
+
+  test("local dev stack (ENVIRONMENT=local) + memory → resolves normally", () => {
+    // cloud-api-dev / sync-api-dev-vars pin ENVIRONMENT=local; the dev stack
+    // may run with NODE_ENV=production from wrangler [vars] yet still wants the
+    // throwaway backend.
+    const client = runWithCloudBindings(
+      { ENVIRONMENT: "local", NODE_ENV: "production", ELIZA_KMS_BACKEND: "memory" },
+      () => getKmsClient(),
+    );
     expect(client).toBeDefined();
     expect(typeof client.encrypt).toBe("function");
   });
@@ -69,5 +87,27 @@ describe("getKmsClient production guard", () => {
     );
     expect(client).toBeDefined();
     expect(typeof client.decrypt).toBe("function");
+  });
+});
+
+describe("isEphemeralKmsAllowed", () => {
+  test("deployed markers always forbid", () => {
+    expect(isEphemeralKmsAllowed({ ENVIRONMENT: "production", NODE_ENV: "test" })).toBe(false);
+    expect(isEphemeralKmsAllowed({ ENVIRONMENT: "staging", NODE_ENV: "test" })).toBe(false);
+  });
+
+  test("test/development NODE_ENV allows", () => {
+    expect(isEphemeralKmsAllowed({ NODE_ENV: "test" })).toBe(true);
+    expect(isEphemeralKmsAllowed({ NODE_ENV: "development" })).toBe(true);
+  });
+
+  test("explicit local stack allows", () => {
+    expect(isEphemeralKmsAllowed({ ENVIRONMENT: "local", NODE_ENV: "production" })).toBe(true);
+  });
+
+  test("bare / unknown environments forbid", () => {
+    expect(isEphemeralKmsAllowed({})).toBe(false);
+    expect(isEphemeralKmsAllowed({ NODE_ENV: "production" })).toBe(false);
+    expect(isEphemeralKmsAllowed({ ENVIRONMENT: "preview" })).toBe(false);
   });
 });

--- a/packages/cloud/shared/src/db/crypto/kms-client.ts
+++ b/packages/cloud/shared/src/db/crypto/kms-client.ts
@@ -15,7 +15,6 @@
 
 import { ElizaError } from "@elizaos/core";
 import { createKmsClient, type KmsClient, resolveKmsBackend } from "@elizaos/security/kms";
-import { isProductionDeployment } from "../../lib/config/deployment-environment";
 import { getCloudAwareEnv } from "../../lib/runtime/cloud-bindings";
 
 let _kms: KmsClient | null = null;
@@ -24,30 +23,59 @@ export function setKmsClient(client: KmsClient): void {
   _kms = client;
 }
 
+/**
+ * Whether the ephemeral `memory` KMS backend may run in this environment.
+ *
+ * `memory` derives a fresh root key on every process start, so every record it
+ * encrypts (agent pre-upgrade snapshots, API keys, BYO secrets) is permanently
+ * undecryptable after the next restart. The #15310 staging incident was exactly
+ * this: the staging worker ran `ELIZA_KMS_BACKEND=memory`, and the previous
+ * guard only refused it in *production* (`ENVIRONMENT === "production"`), so
+ * staging quietly orphaned every DEK on every bounce.
+ *
+ * Policy:
+ *  - A deployed-environment marker is authoritative: `ENVIRONMENT` of
+ *    `production` or `staging` always forbids `memory`, even if the local
+ *    process runs under NODE_ENV=test (that combination only occurs in unit
+ *    tests simulating a deployed Worker — which want the refusal).
+ *  - Otherwise `memory` is allowed only for throwaway worlds: NODE_ENV of
+ *    `test`/`development`, or the explicit local dev stack
+ *    (`ENVIRONMENT === "local"`, set by cloud-api-dev / sync-api-dev-vars).
+ *  - Anything else — including a bare daemon/sidecar launch with neither
+ *    variable set — is treated as a real deployment that forgot its config,
+ *    which is precisely the misconfig class this guards against.
+ *
+ * Exported for tests. Keep in sync with `assertKmsBackendDurable` in
+ * `packages/scripts/cloud/admin/daemons/provisioning-worker.ts`, which applies
+ * the same policy at daemon preflight (before any job is claimed).
+ */
+export function isEphemeralKmsAllowed(env: NodeJS.ProcessEnv): boolean {
+  if (env.ENVIRONMENT === "production" || env.ENVIRONMENT === "staging") {
+    return false;
+  }
+  if (env.NODE_ENV === "test" || env.NODE_ENV === "development") {
+    return true;
+  }
+  return env.ENVIRONMENT === "local";
+}
+
 export function getKmsClient(): KmsClient {
   if (!_kms) {
     const env = getCloudAwareEnv();
-    // Fail-fast: the ephemeral `memory` backend derives a fresh per-process key
-    // on every start, so everything it encrypts (agent pre-upgrade snapshots,
-    // API keys, BYO secrets) is orphaned on the next restart — the prior key is
-    // gone, and decrypt of an older record fails closed (KeyNotFoundError / AEAD
-    // auth failure). It is a test-only backend; in a real cloud deployment it
-    // silently bricks agent resume (a provisioning worker misconfigured with
-    // ELIZA_KMS_BACKEND=memory was the root cause here). Refuse to boot rather
-    // than run it in production; gated strictly on the prod signal so tests,
-    // which legitimately use `memory`, are unaffected.
-    if (isProductionDeployment(env) && resolveKmsBackend({ env }) === "memory") {
+    if (resolveKmsBackend({ env }) === "memory" && !isEphemeralKmsAllowed(env)) {
       throw new ElizaError(
-        "Refusing to start with the ephemeral 'memory' KMS backend in production: " +
-          "it rotates its key on every restart and orphans every record it encrypts. " +
-          "Set ELIZA_KMS_BACKEND=local with a persistent ELIZA_LOCAL_ROOT_KEY (or " +
+        "Refusing to start with the ephemeral 'memory' KMS backend outside " +
+          "test/development: it rotates its key on every restart and orphans " +
+          "every record it encrypts (snapshots, API keys, BYO secrets). Set " +
+          "ELIZA_KMS_BACKEND=local with a persistent ELIZA_LOCAL_ROOT_KEY (or " +
           "configure the steward backend).",
         {
-          code: "KMS_MEMORY_BACKEND_IN_PRODUCTION",
+          code: "KMS_MEMORY_BACKEND_FORBIDDEN",
           severity: "fatal",
           context: {
             backend: "memory",
-            environment: env.ENVIRONMENT ?? env.NODE_ENV ?? null,
+            environment: env.ENVIRONMENT ?? null,
+            nodeEnv: env.NODE_ENV ?? null,
           },
         },
       );


### PR DESCRIPTION
## Problem

#15310 failure mode 1: the staging worker ran `ELIZA_KMS_BACKEND=memory`, so every restart rotated the root key and permanently orphaned every org DEK — pre-upgrade snapshots failed (`key not found: org:<org>/dek/v1`) and older backups became undecryptable (`AEAD decrypt failed`). The residual ask on that issue: *the worker should REFUSE to start with memory KMS outside tests, loudly.*

The daemon got its preflight (`assertKmsBackendDurable`) — but the shared `getKmsClient()` guard still only fired on `ENVIRONMENT === "production"`, which the daemon's own comment calls out as missing staging. That guard covers the cloud-api Worker and the container-control-plane sidecar, so those surfaces could still silently run the data-loss backend on staging or on a bare launch.

## Fix

`getKmsClient()` now applies the same policy as the daemon preflight:

| environment | memory KMS |
|---|---|
| `ENVIRONMENT=production` / `staging` (authoritative, regardless of NODE_ENV) | ❌ refused |
| `NODE_ENV=test` / `development` | ✅ allowed |
| `ENVIRONMENT=local` (cloud-api-dev / sync-api-dev-vars stacks) | ✅ allowed |
| bare launch — neither set (daemon/sidecar missing its env file) | ❌ refused |

Error code renamed `KMS_MEMORY_BACKEND_IN_PRODUCTION` → `KMS_MEMORY_BACKEND_FORBIDDEN` (referenced nowhere else).

## Why the dev/e2e stacks are safe

The local mock stack pins `ENVIRONMENT=local` (sync-api-dev-vars.ts:165, cloud-api-dev.mjs:310) and the e2e harness forwards `--var NODE_ENV:test` — both stay on the allowed side. New tests cover both.

## Verification

`bun test src/db/crypto/` in `packages/cloud/shared` — 27 pass, including new cases: staging refusal, bare-launch refusal, ENVIRONMENT=local allowance, plus the pure-policy unit table.

Part of #15310.

🤖 Generated with [Claude Code](https://claude.com/claude-code)