### PR TITLE
perf(cloud): Smart Placement on production (#15513 prod leg)

### DIFF
--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -440,6 +440,14 @@ id = "f7e24faaff734e7c8cd8e12b093c3571"
 
 [env.production]
 name = "eliza-cloud-api-prod"
+# Smart Placement (#15513, prod leg): staging soak showed mode=smart applied
+# cleanly but staging traffic is too thin for Cloudflare's placement analyzer
+# to ever qualify it — prod volume is what it learns from. Fail-safe by
+# design: CF only moves execution when its analysis concludes it improves
+# performance (back-end-heavy requests to api.cerebras.ai / api.openai.com /
+# Hyperdrive); otherwise requests keep default placement. Rollback = delete
+# this line + redeploy.
+placement = { mode = "smart" }
 workers_dev = false
 # The `*.elizacloud.ai/*` wildcard makes this Worker the default origin for
 # EVERY elizacloud.ai subdomain. Surfaces served by a different origin (e.g. the


### PR DESCRIPTION
Prod leg of #15513 (nubs green-lit full-send; staging leg #15521 merged earlier tonight).

## Soak findings (staging, ~1.5h)
- `placement: {"mode":"smart"}` confirmed applied on `eliza-cloud-api-staging` via the Workers settings API
- No measurable ttfb change yet — **staging traffic is too thin for Cloudflare's placement analyzer to qualify the Worker** (analysis is traffic-driven). Prod's real volume is what it actually learns from, so the soak can't conclude on staging alone.

## Why shipping to prod is safe anyway
Smart Placement is **fail-safe by design**: Cloudflare runs its analysis and only moves execution when it concludes performance improves for the observed request shape (ours is back-end-heavy: api.cerebras.ai / api.openai.com / Hyperdrive subrequests per turn); requests keep default placement otherwise. Worst case = no change. Expected best case = the residual ~0.5s Worker→origin hop collapses on inference calls.

## Verification plan (post-deploy)
Warm ttfb trend on `elizacloud.ai/api/v1/chat/completions` over the next hours (baseline tonight: 0.76–1.1s) + the placement status via the settings API. Rollback = delete the line + redeploy (instant).

`bunx wrangler deploy --env production --dry-run` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
