### PR TITLE
[codex] fix cloud chat dedicated runtime

### DIFF
--- a/packages/ui/src/api/client-agent-dedicated-status-404.test.ts
+++ b/packages/ui/src/api/client-agent-dedicated-status-404.test.ts
@@ -101,4 +101,33 @@ describe("ElizaClient.getStatus — dedicated agent shared-resolver 404 (#15310 
 
     await expect(client.getStatus()).rejects.toThrow();
   });
+
+  it("omits dedicated-CORS-blocked automatic headers while keeping Authorization", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () => {
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const client = makeClient(DEDICATED_BASE, request);
+    client.setUiLanguage("en");
+
+    await client.fetch("/api/status", {
+      headers: {
+        "X-ElizaOS-Client-Id": "manual-client-id",
+        "X-ElizaOS-UI-Language": "es",
+      },
+    });
+
+    const headers = request.mock.calls[0]?.[1].headers as Record<
+      string,
+      string
+    >;
+    expect(headers.Authorization).toBe("Bearer token");
+    const lowerHeaderNames = Object.keys(headers).map((key) =>
+      key.toLowerCase(),
+    );
+    expect(lowerHeaderNames).not.toContain("x-elizaos-client-id");
+    expect(lowerHeaderNames).not.toContain("x-elizaos-ui-language");
+  });
 });

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -66,6 +66,14 @@ const ELIZA_CLOUD_CONTROL_PLANE_HOSTS = new Set([
   "elizacloud.ai",
   "www.elizacloud.ai",
   "dev.elizacloud.ai",
+  "app.elizacloud.ai",
+  "staging.elizacloud.ai",
+  "api-staging.elizacloud.ai",
+  "app-staging.elizacloud.ai",
+]);
+const DEDICATED_CLOUD_CORS_BLOCKED_HEADERS = new Set([
+  "x-elizaos-client-id",
+  "x-elizaos-ui-language",
 ]);
 const REPLAYABLE_WS_EVENT_TYPES: ReadonlySet<string> = new Set([
   SHELL_NAVIGATE_VIEW_WS_EVENT,
@@ -232,6 +240,25 @@ function isElizaCloudControlPlaneBase(
     // error-policy:J3 malformed base URL reads as "not the control plane".
     return false;
   }
+}
+
+function requestHeadersToRecord(
+  headers: HeadersInit | undefined,
+): Record<string, string> {
+  if (!headers) return {};
+  if (typeof Headers !== "undefined" && headers instanceof Headers) {
+    const out: Record<string, string> = {};
+    headers.forEach((value, key) => {
+      out[key] = value;
+    });
+    return out;
+  }
+  if (Array.isArray(headers)) {
+    const out: Record<string, string> = {};
+    for (const [key, value] of headers) out[key] = value;
+    return out;
+  }
+  return { ...(headers as Record<string, string>) };
 }
 
 function findSseEventBreak(
@@ -1045,7 +1072,12 @@ export class ElizaClient {
     }
 
     try {
-      const requestInit = this.rawRequestInit(init, abortController, token);
+      const requestInit = this.rawRequestInit(
+        init,
+        abortController,
+        token,
+        requestUrl,
+      );
       const transport = await this.rawRequestTransport(requestUrl);
       return await transport.request(requestUrl, requestInit, { timeoutMs });
     } catch (err) {
@@ -1070,18 +1102,30 @@ export class ElizaClient {
     init: RequestInit | undefined,
     abortController: AbortController,
     token: string | null,
+    requestUrl: string,
   ): RequestInit {
+    const isDedicatedCloudRequest = isDedicatedCloudAgentBase(requestUrl);
+    const headers: Record<string, string> = {
+      ...(!isDedicatedCloudRequest
+        ? { "X-ElizaOS-Client-Id": this.clientId }
+        : {}),
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(!isDedicatedCloudRequest && this._uiLanguage
+        ? { "X-ElizaOS-UI-Language": this._uiLanguage }
+        : {}),
+      ...requestHeadersToRecord(init?.headers),
+    };
+    if (isDedicatedCloudRequest) {
+      for (const key of Object.keys(headers)) {
+        if (DEDICATED_CLOUD_CORS_BLOCKED_HEADERS.has(key.toLowerCase())) {
+          delete headers[key];
+        }
+      }
+    }
     return {
       ...init,
       signal: abortController.signal,
-      headers: {
-        "X-ElizaOS-Client-Id": this.clientId,
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-        ...(this._uiLanguage
-          ? { "X-ElizaOS-UI-Language": this._uiLanguage }
-          : {}),
-        ...init?.headers,
-      },
+      headers,
     };
   }
 

--- a/packages/ui/src/api/client-cloud-select-or-provision.test.ts
+++ b/packages/ui/src/api/client-cloud-select-or-provision.test.ts
@@ -52,13 +52,21 @@ function fakeClient() {
   const getCloudCompatAgents = vi.fn();
   const createCloudCompatAgent = vi.fn();
   const getCloudCompatAgent = vi.fn();
+  const resumeCloudCompatAgent = vi.fn(async () => ({ success: true }));
   const client = Object.create(ElizaClient.prototype) as ElizaClient;
   Object.assign(client, {
     getCloudCompatAgents,
     createCloudCompatAgent,
     getCloudCompatAgent,
+    resumeCloudCompatAgent,
   });
-  return { client, getCloudCompatAgents, createCloudCompatAgent };
+  return {
+    client,
+    getCloudCompatAgents,
+    createCloudCompatAgent,
+    getCloudCompatAgent,
+    resumeCloudCompatAgent,
+  };
 }
 
 const BASE_OPTS = {
@@ -134,7 +142,7 @@ describe("selectOrProvisionCloudAgent — never duplicate on a failed lookup", (
     expect(createCloudCompatAgent).toHaveBeenCalledTimes(1);
   });
 
-  it("marks real dedicated Eliza Cloud agent subdomains as requiring pairing", async () => {
+  it("reuses real dedicated Eliza Cloud agent subdomains without pairing", async () => {
     const { client, getCloudCompatAgents } = fakeClient();
     getCloudCompatAgents.mockResolvedValue({
       success: true,
@@ -150,7 +158,7 @@ describe("selectOrProvisionCloudAgent — never duplicate on a failed lookup", (
     const result = await client.selectOrProvisionCloudAgent(BASE_OPTS);
 
     expect(result.apiBase).toBe("https://agent-dedicated.elizacloud.ai");
-    expect(result.requiresAgentPairing).toBe(true);
+    expect(result.requiresAgentPairing).toBe(false);
   });
 
   it("can reuse a dedicated agent through the Steward-token REST adapter without pairing", async () => {
@@ -451,16 +459,18 @@ describe("selectOrProvisionCloudAgent — never duplicate on a failed lookup", (
     expect(result.agentId).toBe("agent-legacy");
   });
 
-  // First-run handoff: a freshly-created dedicated agent whose container is still
-  // provisioning must start on the SHARED REST adapter base (the always-on
-  // in-Worker runtime serves the first turn instantly) — NOT on the dedicated
-  // subdomain, which 202s "starting" until the container boots and made the first
-  // message time out. finishCloud's handoff supervisor switches to the subdomain
-  // once it reports running. The shared base is what `isDirectCloudSharedAgentBase`
-  // matches, which is what gates that supervisor.
-  it("starts a still-provisioning new agent on the shared adapter base (handoff fires)", async () => {
-    const { client, getCloudCompatAgents, createCloudCompatAgent } =
-      fakeClient();
+  // Default first-run: a freshly-created dedicated agent whose container is
+  // still provisioning waits for the dedicated runtime instead of binding chat
+  // to the shared adapter, which returns "Not a shared-runtime agent" for
+  // dedicated ids.
+  it("waits for a still-provisioning new dedicated agent and returns its dedicated subdomain", async () => {
+    const {
+      client,
+      getCloudCompatAgents,
+      createCloudCompatAgent,
+      getCloudCompatAgent,
+      resumeCloudCompatAgent,
+    } = fakeClient();
     getCloudCompatAgents.mockResolvedValue({ success: true, data: [] });
     createCloudCompatAgent.mockResolvedValue({
       success: true,
@@ -473,24 +483,40 @@ describe("selectOrProvisionCloudAgent — never duplicate on a failed lookup", (
         message: "",
       },
     });
-    (client.getCloudCompatAgent as ReturnType<typeof vi.fn>).mockResolvedValue({
-      success: true,
-      data: makeAgent({
-        agent_id: "agent-new",
-        status: "provisioning",
-        bridge_url: null,
-        web_ui_url: "https://agent-new.example.test",
-        webUiUrl: "https://agent-new.example.test",
-      }),
-    });
+    getCloudCompatAgent
+      .mockResolvedValueOnce({
+        success: true,
+        data: makeAgent({
+          agent_id: "agent-new",
+          status: "provisioning",
+          bridge_url: null,
+          web_ui_url: "https://agent-new.elizacloud.ai",
+          webUiUrl: "https://agent-new.elizacloud.ai",
+        }),
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        data: makeAgent({
+          agent_id: "agent-new",
+          status: "running",
+          bridge_url: null,
+          web_ui_url: "https://agent-new.elizacloud.ai",
+          webUiUrl: "https://agent-new.elizacloud.ai",
+        }),
+      });
+    resumeCloudCompatAgent.mockResolvedValue({ success: true });
 
-    const result = await client.selectOrProvisionCloudAgent(BASE_OPTS);
+    const result = await client.selectOrProvisionCloudAgent({
+      ...BASE_OPTS,
+      wakePollIntervalMs: 1,
+      wakeTimeoutMs: 50,
+    });
 
     expect(result.created).toBe(true);
     expect(result.agentId).toBe("agent-new");
-    // Shared REST adapter base, not the dedicated subdomain.
-    expect(result.apiBase).toMatch(/\/api\/v1\/eliza\/agents\/agent-new$/);
-    expect(result.apiBase).not.toContain("agent-new.example.test");
+    expect(result.apiBase).toBe("https://agent-new.elizacloud.ai");
+    expect(result.requiresAgentPairing).toBe(false);
+    expect(resumeCloudCompatAgent).toHaveBeenCalledWith("agent-new");
   });
 
   // The warm-pool path returns a brand-new agent already `running` with a
@@ -524,7 +550,7 @@ describe("selectOrProvisionCloudAgent — never duplicate on a failed lookup", (
 
     expect(result.created).toBe(true);
     expect(result.apiBase).toContain("agent-warm.elizacloud.ai");
-    expect(result.requiresAgentPairing).toBe(true);
+    expect(result.requiresAgentPairing).toBe(false);
   });
 
   it("keeps a warm newly-created agent on the Steward-token REST adapter when requested", async () => {

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -18,6 +18,7 @@ import {
 import { getBootConfig } from "../config/boot-config";
 import {
   buildCloudSharedAgentApiBase,
+  buildDedicatedCloudAgentApiBase,
   isDedicatedCloudAgentBase,
   isElizaCloudControlPlaneAgentlessBase,
   normalizeDirectCloudSharedAgentApiBase,
@@ -3027,6 +3028,17 @@ function resolveDirectCloudAgentBridgeUrl(
   return `${cloudApiBase.replace(/\/+$/, "")}/api/v1/eliza/agents/${encodeURIComponent(agentId)}/bridge`;
 }
 
+function resolveDedicatedCloudAgentApiBase(args: {
+  bridgeUrl: string | null;
+  webUiUrl?: string | null;
+  agentId: string;
+  cloudApiBase: string;
+}): string {
+  const resolved = resolveCloudAgentApiBase(args);
+  if (!isDirectCloudSharedAgentBase(resolved)) return resolved;
+  return buildDedicatedCloudAgentApiBase(args.agentId) ?? resolved;
+}
+
 /**
  * True when `url` is a direct cloud shared-runtime agent base — either the REST
  * adapter base `<cloudApiBase>/api/v1/eliza/agents/<agentId>` (where #8527's
@@ -3417,9 +3429,12 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
           ...(onProgress ? { onProgress } : {}),
         });
       }
-      const apiBase = preferStewardAgentAdapter
+      const useSharedAdapter = Boolean(
+        preferSharedTier || preferStewardAgentAdapter,
+      );
+      const apiBase = useSharedAdapter
         ? buildCloudSharedAgentApiBase(resolvedCloudApiBase, agent.agent_id)
-        : resolveCloudAgentApiBase({
+        : resolveDedicatedCloudAgentApiBase({
             bridgeUrl: agent.bridge_url,
             webUiUrl: agent.web_ui_url ?? agent.webUiUrl,
             agentId: agent.agent_id,
@@ -3432,8 +3447,7 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
         apiBase,
         bridgeUrl: agent.bridge_url,
         created: false,
-        requiresAgentPairing:
-          !preferStewardAgentAdapter && isDedicatedCloudAgentBase(apiBase),
+        requiresAgentPairing: false,
       };
     }
   }
@@ -3446,7 +3460,8 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
   // the base from the agent's web_ui_url exactly like the reuse branch above.
   // The subdomain is returned as soon as the agent record exists (before the
   // container finishes booting), so re-read the created agent to pick it up;
-  // if that lookup fails or has no URL yet, fall back to the shared-adapter base.
+  // if that lookup fails or has no URL yet, fall back to the standard dedicated
+  // subdomain for the known agent id.
   onProgress?.("creating", `Creating ${name}...`);
   const created = await this.createCloudCompatAgent({
     agentName: name,
@@ -3461,29 +3476,47 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
   }
   const agentId = created.data.agentId;
   // error-policy:J4 detail is an optimization probe (warm-pool fast path);
-  // on failure the shared REST adapter base below is always usable.
+  // on failure the standard dedicated subdomain is still the desired default.
   const detail = await this.getCloudCompatAgent(agentId).catch(() => null);
-  const detailAgent = detail?.success ? detail.data : null;
-  // A freshly-created dedicated agent's subdomain is populated immediately, but
-  // its container takes ~30-120s to boot — chatting against it during that window
-  // 202s "starting" and the first message times out (the reported first-run bug).
-  // So start on the shared REST adapter base (the always-on in-Worker shared
-  // runtime serves the user instantly); finishCloud's handoff supervisor switches
-  // to the dedicated subdomain once it reports `running`. Only use the subdomain
-  // up-front when the agent is ALREADY running (warm-pool claim) — no boot gap.
-  const isRunning = detailAgent?.status === "running";
-  const hasDedicatedUrl = Boolean(
-    detailAgent?.web_ui_url || detailAgent?.bridge_url,
+  let detailAgent = detail?.success ? detail.data : null;
+  const useSharedAdapter = Boolean(
+    preferSharedTier || preferStewardAgentAdapter,
   );
-  const apiBase =
-    !preferStewardAgentAdapter && isRunning && hasDedicatedUrl
-      ? resolveCloudAgentApiBase({
-          bridgeUrl: detailAgent.bridge_url,
-          webUiUrl: detailAgent.web_ui_url ?? detailAgent.webUiUrl,
-          agentId,
-          cloudApiBase: resolvedCloudApiBase,
-        })
-      : buildCloudSharedAgentApiBase(resolvedCloudApiBase, agentId);
+  // A freshly-created dedicated agent's subdomain is populated immediately, but
+  // its container takes ~30-120s to boot. When the caller wants a dedicated
+  // runtime, wait here so the first chat request does not land on the shared
+  // adapter for a non-shared agent or race the container cold boot.
+  const initialDedicatedApiBase = resolveDedicatedCloudAgentApiBase({
+    bridgeUrl: detailAgent?.bridge_url ?? null,
+    webUiUrl: detailAgent?.web_ui_url ?? detailAgent?.webUiUrl,
+    agentId,
+    cloudApiBase: resolvedCloudApiBase,
+  });
+  if (
+    !useSharedAdapter &&
+    detailAgent &&
+    detailAgent.status !== "running" &&
+    isDedicatedCloudAgentBase(initialDedicatedApiBase)
+  ) {
+    detailAgent = await waitForCloudAgentRunning(this, {
+      agentId,
+      ...(typeof options.wakePollIntervalMs === "number"
+        ? { pollIntervalMs: options.wakePollIntervalMs }
+        : {}),
+      ...(typeof options.wakeTimeoutMs === "number"
+        ? { timeoutMs: options.wakeTimeoutMs }
+        : {}),
+      ...(onProgress ? { onProgress } : {}),
+    });
+  }
+  const apiBase = useSharedAdapter
+    ? buildCloudSharedAgentApiBase(resolvedCloudApiBase, agentId)
+    : resolveDedicatedCloudAgentApiBase({
+        bridgeUrl: detailAgent?.bridge_url ?? null,
+        webUiUrl: detailAgent?.web_ui_url ?? detailAgent?.webUiUrl,
+        agentId,
+        cloudApiBase: resolvedCloudApiBase,
+      });
   onProgress?.("ready", "Cloud agent ready!");
   return {
     agentId,
@@ -3497,8 +3530,7 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
     // explicit `false` demotes to reuse; an absent flag (older worker) stays
     // `true` so the pre-existing create UX is unchanged.
     created: created.created !== false,
-    requiresAgentPairing:
-      !preferStewardAgentAdapter && isDedicatedCloudAgentBase(apiBase),
+    requiresAgentPairing: false,
   };
 };
 

--- a/packages/ui/src/cloud/handoff/resume-pending-handoff.test.ts
+++ b/packages/ui/src/cloud/handoff/resume-pending-handoff.test.ts
@@ -28,6 +28,9 @@ const mocks = vi.hoisted(() => ({
   isDirectCloudSharedAgentBase: vi.fn((base: string) =>
     base.includes("/api/v1/eliza/agents/"),
   ),
+  resolveDirectCloudAuthApiBase: vi.fn((base: string) =>
+    base === "https://elizacloud.ai" ? "https://api.elizacloud.ai" : base,
+  ),
   loadPersistedActiveServer: vi.fn((): Record<string, unknown> | null => null),
   runAgentSessionRecovery: vi.fn<
     (_opts?: unknown) => Promise<{
@@ -70,6 +73,7 @@ vi.mock("../../api", () => ({
 vi.mock("../../api/client-cloud", () => ({
   getCloudAuthToken: mocks.getCloudAuthToken,
   isDirectCloudSharedAgentBase: mocks.isDirectCloudSharedAgentBase,
+  resolveDirectCloudAuthApiBase: mocks.resolveDirectCloudAuthApiBase,
 }));
 
 // resume-pending-handoff imports loadPersistedActiveServer directly from the
@@ -197,14 +201,12 @@ describe("resumePendingCloudHandoff", () => {
       cloudApiBase: "https://elizacloud.ai",
       authToken: "cloud-token",
     });
-    expect(mocks.runAgentSessionRecovery).toHaveBeenCalledWith(
-      expect.objectContaining({
-        cloudApiBase: "https://elizacloud.ai",
-        agentId: "dedicated-1",
-        cloudToken: "cloud-token",
-        navigate: expect.any(Function),
-      }),
-    );
+    expect(mocks.runAgentSessionRecovery).not.toHaveBeenCalled();
+    expect(mocks.silentlyRepointToDedicated).toHaveBeenCalledWith({
+      containerBase: "https://dedicated-1.elizacloud.ai",
+      dedicatedAgentId: "dedicated-1",
+      authToken: "cloud-token",
+    });
     // Success terminal → the shared bridge row is deleted.
     expect(mocks.deleteSharedBridgeAgent).toHaveBeenCalledWith("shared-1", {
       cloudApiBase: "https://elizacloud.ai",
@@ -212,22 +214,12 @@ describe("resumePendingCloudHandoff", () => {
     });
   });
 
-  it("native resume consumes the pair redirect in-process and repoints with the exchanged agent key", async () => {
+  it("native resume also keeps the live app on the dedicated runtime after switch", async () => {
     (globalThis as { Capacitor?: unknown }).Capacitor = {
       isNativePlatform: () => true,
     };
     savePendingCloudHandoff(pending());
     mocks.loadPersistedActiveServer.mockReturnValue(activeSharedServer());
-    mocks.runAgentSessionRecovery.mockImplementationOnce(async (opts) => {
-      (
-        opts as { onPairedInProcess?: (apiToken: string) => void }
-      ).onPairedInProcess?.("agent-api-key");
-      return {
-        ok: true as const,
-        redirectUrl: "https://dedicated-1.elizacloud.ai/pair?token=pairing",
-        mode: "in-process" as const,
-      };
-    });
     mocks.startCloudAgentHandoff.mockImplementation(async (opts) => {
       await (opts as { onSwitch?: (base: string) => Promise<void> }).onSwitch?.(
         "https://dedicated-1.elizacloud.ai",
@@ -238,16 +230,11 @@ describe("resumePendingCloudHandoff", () => {
     expect(resumePendingCloudHandoff()).toBe(true);
     await settle();
 
-    expect(mocks.runAgentSessionRecovery).toHaveBeenCalledWith(
-      expect.objectContaining({
-        consumeRedirectInProcess: true,
-        onPairedInProcess: expect.any(Function),
-      }),
-    );
+    expect(mocks.runAgentSessionRecovery).not.toHaveBeenCalled();
     expect(mocks.silentlyRepointToDedicated).toHaveBeenCalledWith({
       containerBase: "https://dedicated-1.elizacloud.ai",
       dedicatedAgentId: "dedicated-1",
-      authToken: "agent-api-key",
+      authToken: "cloud-token",
     });
   });
 

--- a/packages/ui/src/cloud/handoff/resume-pending-handoff.ts
+++ b/packages/ui/src/cloud/handoff/resume-pending-handoff.ts
@@ -12,7 +12,6 @@ import {
   type CloudHandoffRetryDetail,
   dispatchCloudHandoffPhase,
 } from "../../events";
-import { runAgentSessionRecovery } from "../../state/agent-session-recovery-runner";
 import { loadPersistedActiveServer } from "../../state/persistence";
 import {
   clearPendingCloudHandoff,
@@ -30,17 +29,6 @@ let resumeAttemptedThisSession = false;
  * leaking them.
  */
 const deadTargetRetryListeners = new Set<AbortController>();
-
-function isCapacitorNative(): boolean {
-  try {
-    const cap = (globalThis as Record<string, unknown>).Capacitor as
-      | { isNativePlatform?: () => boolean }
-      | undefined;
-    return Boolean(cap?.isNativePlatform?.());
-  } catch {
-    return false;
-  }
-}
 
 /** Test-only: allow a fresh resume attempt in the next call. */
 export function __resetResumeForTests(): void {
@@ -83,40 +71,6 @@ async function dedicatedHandoffTargetState(
     // assumption.
     const status = (err as { status?: unknown } | null)?.status;
     return status === 404 ? "gone" : "unknown";
-  }
-}
-
-async function pairDedicatedCloudAgentInCurrentWindow(opts: {
-  cloudApiBase: string;
-  agentId: string;
-  cloudToken: string;
-  containerBase?: string;
-}): Promise<void> {
-  if (typeof window === "undefined") {
-    throw new Error("Cloud agent sign-in requires a browser window.");
-  }
-  const result = await runAgentSessionRecovery({
-    cloudApiBase: opts.cloudApiBase,
-    agentId: opts.agentId,
-    cloudToken: opts.cloudToken,
-    consumeRedirectInProcess: isCapacitorNative(),
-    onPairedInProcess: (apiToken) => {
-      if (opts.containerBase) {
-        silentlyRepointToDedicated({
-          containerBase: opts.containerBase,
-          dedicatedAgentId: opts.agentId,
-          authToken: apiToken,
-        });
-      } else {
-        client.setToken(apiToken);
-      }
-    },
-    navigate: (url) => {
-      window.location.replace(url);
-    },
-  });
-  if (!result.ok) {
-    throw new Error(result.message);
   }
 }
 
@@ -209,11 +163,10 @@ export function resumePendingCloudHandoff(): boolean {
           cloudApiBase: pending.cloudApiBase,
           authToken,
           onSwitch: async (containerBase) => {
-            await pairDedicatedCloudAgentInCurrentWindow({
-              cloudApiBase: pending.cloudApiBase,
-              agentId: pending.dedicatedAgentId,
-              cloudToken: authToken,
+            silentlyRepointToDedicated({
               containerBase,
+              dedicatedAgentId: pending.dedicatedAgentId,
+              authToken,
             });
           },
         }),
@@ -312,11 +265,10 @@ async function runFreshDedicatedHandoff(
           cloudApiBase: pending.cloudApiBase,
           authToken,
           onSwitch: async (containerBase) => {
-            await pairDedicatedCloudAgentInCurrentWindow({
-              cloudApiBase: pending.cloudApiBase,
-              agentId: dedicatedAgentId,
-              cloudToken: authToken,
+            silentlyRepointToDedicated({
               containerBase,
+              dedicatedAgentId,
+              authToken,
             });
           },
         }),

--- a/packages/ui/src/cloud/handoff/silent-repoint.test.ts
+++ b/packages/ui/src/cloud/handoff/silent-repoint.test.ts
@@ -100,4 +100,18 @@ describe("silentlyRepointToDedicated", () => {
       }),
     );
   });
+
+  it("never rewrites the dedicated target to a shared REST adapter", () => {
+    silentlyRepointToDedicated(ARGS);
+
+    for (const fn of [
+      mocks.repointBaseUrl,
+      mocks.createPersistedActiveServer,
+      mocks.addAgentProfile,
+    ]) {
+      expect(JSON.stringify(fn.mock.calls)).not.toContain(
+        "/api/v1/eliza/agents/",
+      );
+    }
+  });
 });

--- a/packages/ui/src/first-run/first-run-finish.force-fresh.test.ts
+++ b/packages/ui/src/first-run/first-run-finish.force-fresh.test.ts
@@ -128,7 +128,7 @@ describe("bindCloudAgent clears the durable force-fresh flag on completion", () 
     // The shared-agent path must NOT POST /api/first-run.
     expect(clientMock.submitFirstRun).not.toHaveBeenCalled();
     expect(clientMock.selectOrProvisionCloudAgent).toHaveBeenCalledWith(
-      expect.objectContaining({ preferStewardAgentAdapter: true }),
+      expect.objectContaining({ preferStewardAgentAdapter: false }),
     );
   });
 

--- a/packages/ui/src/first-run/first-run-finish.ts
+++ b/packages/ui/src/first-run/first-run-finish.ts
@@ -525,7 +525,7 @@ export async function bindCloudAgent(
     ...(opts.preferAgentId ? { preferAgentId: opts.preferAgentId } : {}),
     ...(opts.forceCreate ? { forceCreate: true } : {}),
     ...(opts.knownAgents ? { knownAgents: opts.knownAgents } : {}),
-    preferStewardAgentAdapter: true,
+    preferStewardAgentAdapter: Boolean(getBootConfig().preferSharedCloudTier),
     ...(getBootConfig().preferSharedCloudTier
       ? { preferSharedTier: true }
       : {}),
@@ -653,11 +653,10 @@ export async function bindCloudAgent(
           cloudApiBase,
           authToken,
           onSwitch: async (containerBase) => {
-            await pairDedicatedCloudAgentInCurrentWindow({
-              cloudApiBase,
-              agentId: dedicatedAgentId,
-              cloudToken: authToken,
+            silentlyRepointToDedicated({
               containerBase,
+              dedicatedAgentId,
+              authToken,
             });
           },
         });

--- a/packages/ui/src/state/persistence-cloud-active-server.test.ts
+++ b/packages/ui/src/state/persistence-cloud-active-server.test.ts
@@ -180,6 +180,64 @@ describe("Cloud active server persistence", () => {
     ).toBe(true);
   });
 
+  it("keeps a dedicated Eliza Cloud active server dedicated on restore", async () => {
+    const server = createPersistedActiveServer({
+      kind: "cloud",
+      id: "cloud:agent-dedicated",
+      label: "Demo Agent",
+      apiBase: "https://agent-dedicated.elizacloud.ai/",
+      accessToken: "cloud-token",
+    });
+    savePersistedActiveServer(server);
+    const setBaseUrl = vi.fn();
+    const setToken = vi.fn();
+
+    await applyRestoredConnection({
+      restoredActiveServer: server,
+      clientRef: { setBaseUrl, setToken },
+    });
+
+    const expectedApiBase = "https://agent-dedicated.elizacloud.ai";
+    expect(setBaseUrl).toHaveBeenCalledWith(expectedApiBase);
+    expect(setToken).toHaveBeenCalledWith("cloud-token");
+    expect(loadPersistedActiveServer()).toEqual(
+      expect.objectContaining({
+        id: "cloud:agent-dedicated",
+        kind: "cloud",
+        apiBase: expectedApiBase,
+      }),
+    );
+  });
+
+  it("repairs a stale shared-adapter cloud active server back to the dedicated runtime on restore", async () => {
+    const server = createPersistedActiveServer({
+      kind: "cloud",
+      id: "cloud:agent-dedicated",
+      label: "Demo Agent",
+      apiBase: "https://api.elizacloud.ai/api/v1/eliza/agents/agent-dedicated",
+      accessToken: "cloud-token",
+    });
+    savePersistedActiveServer(server);
+    const setBaseUrl = vi.fn();
+    const setToken = vi.fn();
+
+    await applyRestoredConnection({
+      restoredActiveServer: server,
+      clientRef: { setBaseUrl, setToken },
+    });
+
+    const expectedApiBase = "https://agent-dedicated.elizacloud.ai";
+    expect(setBaseUrl).toHaveBeenCalledWith(expectedApiBase);
+    expect(setToken).toHaveBeenCalledWith("cloud-token");
+    expect(loadPersistedActiveServer()).toEqual(
+      expect.objectContaining({
+        id: "cloud:agent-dedicated",
+        kind: "cloud",
+        apiBase: expectedApiBase,
+      }),
+    );
+  });
+
   it("preserves the injected desktop API base when restoring a local session", async () => {
     setBootConfig({
       ...DEFAULT_BOOT_CONFIG,

--- a/packages/ui/src/state/startup-phase-restore.ts
+++ b/packages/ui/src/state/startup-phase-restore.ts
@@ -15,6 +15,7 @@ import {
 import { client, type FirstRunOptions } from "../api";
 import {
   cloudTokenSecsRemaining,
+  isDirectCloudSharedAgentBase,
   refreshCloudStewardSession,
 } from "../api/client-cloud";
 import {
@@ -22,6 +23,7 @@ import {
   invokeDesktopBridgeRequestWithTimeout,
   isElectrobunRuntime,
 } from "../bridge";
+import { loadPendingCloudHandoff } from "../cloud/handoff/pending-handoff-store";
 import { getBootConfig } from "../config/boot-config";
 import {
   ANDROID_LOCAL_AGENT_IPC_BASE,
@@ -44,10 +46,10 @@ import {
   isOnboardingReplayRequested,
 } from "../platform";
 import {
-  buildCloudSharedAgentApiBase,
+  buildDedicatedCloudAgentApiBase,
+  dedicatedCloudAgentIdFromBase,
   isDedicatedCloudAgentBase,
   isElizaCloudControlPlaneAgentlessBase,
-  normalizeDirectCloudSharedAgentApiBase,
 } from "../utils/cloud-agent-base";
 import { getElizaApiBase } from "../utils/eliza-globals";
 import { detectExistingFirstRunConnection } from "./first-run-bootstrap";
@@ -64,10 +66,6 @@ import { isTrustedRestoreApiBaseUrl } from "./runtime-url-trust";
 import type { StartupEvent } from "./startup-coordinator";
 import { buildStaticFirstRunOptions } from "./startup-first-run-options";
 
-// Direct elizaCloud API base used to backfill a missing apiBase on a
-// persisted cloud active-server. Mirrors DEFAULT_DIRECT_CLOUD_API_BASE_URL
-// in api/client-cloud.ts; kept inline because that constant is module-private.
-const DIRECT_CLOUD_API_BASE = "https://api.elizacloud.ai";
 const DESKTOP_RESTORE_RPC_TIMEOUT_MS = 5_000;
 
 /**
@@ -90,81 +88,47 @@ const STEWARD_REFRESH_PATH = "/api/auth/steward-refresh";
 /** Default direct Cloud site base used to derive the native refresh endpoint. */
 const RESTORE_DEFAULT_DIRECT_CLOUD_BASE_URL = "https://elizacloud.ai";
 
+function recoverCloudAgentId(active: PersistedActiveServer): string | null {
+  const rawId = active.id?.startsWith("cloud:")
+    ? active.id.slice("cloud:".length).trim()
+    : "";
+  if (rawId && !rawId.includes("/")) return rawId;
+  return dedicatedCloudAgentIdFromBase(active.apiBase);
+}
+
 function isDevUiPort(): boolean {
   return typeof window !== "undefined" && window.location.port === "2138";
 }
 
 /**
- * Repair a restored cloud active-server whose apiBase is missing OR is the
- * unusable agent-id-less collection URL (`.../api/v1/eliza/agents`, a broken
- * state from earlier builds that completed firstRun without a per-agent base).
- * Re-derive the per-agent REST adapter base from the persisted `cloud:<agentId>`
- * id — preferring the server-reported url, falling back to deriving it directly
- * from the id. Returns the up-to-date active server, or the input unchanged when
- * no real agent id can be recovered (the startup gate then routes to agent
- * selection instead of dead-ending on "Backend Unreachable").
+ * Repair a restored cloud active-server whose apiBase is missing or is the
+ * unusable agent-id-less collection URL (`.../api/v1/eliza/agents`). Dedicated
+ * Cloud agents must restore to their own subdomain; the shared runtime adapter
+ * answers "Not a shared-runtime agent" for those ids.
  */
 async function backfillCloudApiBase(
   active: PersistedActiveServer,
 ): Promise<PersistedActiveServer> {
   if (active.kind !== "cloud") return active;
-  // A concrete per-agent base is fine — only act on a missing or id-less base.
-  if (
-    active.apiBase &&
-    !isElizaCloudControlPlaneAgentlessBase(active.apiBase)
-  ) {
-    return active;
-  }
-  const rawId = active.id?.startsWith("cloud:")
-    ? active.id.slice("cloud:".length).trim()
-    : "";
-  // A real agent id has no path separators. Older builds mistakenly stored the
-  // collection URL itself as the id (`cloud:https://.../agents`) — that can't be
-  // recovered here; leave it for the startup gate's agent-selection fallback.
-  const agentId = rawId && !rawId.includes("/") ? rawId : null;
-  if (!agentId) return active;
+  const agentId = recoverCloudAgentId(active);
+  const pending = loadPendingCloudHandoff();
+  const isPendingSharedRuntime =
+    Boolean(pending && agentId === pending.sharedAgentId) &&
+    active.apiBase === pending?.sharedApiBase;
+  const shouldRepair =
+    !active.apiBase ||
+    isElizaCloudControlPlaneAgentlessBase(active.apiBase) ||
+    (isDirectCloudSharedAgentBase(active.apiBase) && !isPendingSharedRuntime);
+  // A concrete per-agent base is fine, including a dedicated subdomain.
+  if (!shouldRepair) return active;
 
-  const priorBaseUrl = client.getBaseUrl();
-  const priorToken = client.hasToken();
-  const derivedApiBase = buildCloudSharedAgentApiBase(
-    DIRECT_CLOUD_API_BASE,
-    agentId,
-  );
-  client.setBaseUrl(DIRECT_CLOUD_API_BASE);
-  try {
-    if (active.accessToken) client.setToken(active.accessToken);
-    // error-policy:J4 lookup probe — on failure the restore falls back to the
-    // id-derived api base below rather than blocking session restore
-    const res = await client.getCloudCompatAgent(agentId).catch(() => null);
-    const data = res?.success ? res.data : null;
-    const rawApiBase = data
-      ? (data.web_ui_url ?? data.webUiUrl ?? data.bridge_url)
-      : null;
-    const serverApiBase = rawApiBase
-      ? normalizeDirectCloudSharedAgentApiBase(rawApiBase)
-      : "";
-    // Prefer a concrete server-reported base; otherwise derive from the id.
-    const apiBase =
-      serverApiBase && !isElizaCloudControlPlaneAgentlessBase(serverApiBase)
-        ? serverApiBase
-        : derivedApiBase;
-    const updated: PersistedActiveServer = { ...active, apiBase };
-    savePersistedActiveServer(updated);
-    return updated;
-  } catch {
-    // Even if the lookup fails, never restore the broken base — derive from id.
-    const updated: PersistedActiveServer = {
-      ...active,
-      apiBase: derivedApiBase,
-    };
-    savePersistedActiveServer(updated);
-    return updated;
-  } finally {
-    // Restore prior client state — applyRestoredConnection sets the final
-    // baseUrl below based on the (possibly backfilled) active server.
-    client.setBaseUrl(priorBaseUrl || null);
-    if (!priorToken) client.setToken(null);
-  }
+  if (!agentId) return active;
+  const apiBase = buildDedicatedCloudAgentApiBase(agentId);
+  if (!apiBase) return active;
+
+  const updated: PersistedActiveServer = { ...active, apiBase };
+  savePersistedActiveServer(updated);
+  return updated;
 }
 
 export interface RestoringSessionDeps {

--- a/packages/ui/src/utils/cloud-agent-base.ts
+++ b/packages/ui/src/utils/cloud-agent-base.ts
@@ -60,12 +60,14 @@ export const ELIZA_CLOUD_CONTROL_PLANE_HOSTS = new Set([
   "elizacloud.ai",
   "www.elizacloud.ai",
   "dev.elizacloud.ai",
+  "app.elizacloud.ai",
   // Staging apex + API. Without these, `staging.elizacloud.ai` ends with
   // `.elizacloud.ai` but isn't in the set, so isDedicatedCloudAgentBase
   // mis-classifies the staging console as a per-agent subdomain (and the apex
   // login redirect never fires on staging — so staging can't validate it).
   "staging.elizacloud.ai",
   "api-staging.elizacloud.ai",
+  "app-staging.elizacloud.ai",
 ]);
 
 /**
@@ -80,6 +82,22 @@ export function buildCloudSharedAgentApiBase(
 ): string {
   const base = stripTrailingSlash(cloudApiBase.trim());
   return `${base}/api/v1/eliza/agents/${encodeURIComponent(agentId.trim())}`;
+}
+
+/**
+ * Build the dedicated Cloud agent REST base for the standard
+ * `<agentId>.elizacloud.ai` ingress. Returns null when the id cannot be a
+ * single DNS label; callers should then fall back to a server-reported URL
+ * instead of producing a malformed host.
+ */
+export function buildDedicatedCloudAgentApiBase(
+  agentId: string | null | undefined,
+): string | null {
+  const label = agentId?.trim().toLowerCase() ?? "";
+  if (!/^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(label)) {
+    return null;
+  }
+  return `https://${label}.elizacloud.ai`;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Keep default Cloud onboarding and restore paths on dedicated agent subdomains instead of routing dedicated agents through the shared-runtime adapter.
- Strip automatic `x-elizaos-client-id` and `x-elizaos-ui-language` headers from dedicated Cloud `/api/*` requests so browser preflights match the dedicated host CORS policy.
- Repair stale persisted shared-adapter active-server records back to the dedicated subdomain, while preserving pending shared-to-dedicated handoff recovery.

## Root Cause

A dedicated Cloud agent could be restored or selected through `https://api.elizacloud.ai/api/v1/eliza/agents/:id`, which is the shared-runtime adapter. Dedicated agents answer on `https://:agentId.elizacloud.ai`, so the shared path produced `Not a shared-runtime agent` 401/404s. The earlier direct dedicated path also sent automatic UI/client headers that the dedicated ingress does not allow in CORS preflight.

## Validation

- `bun run --cwd packages/ui test src/api/client-agent-dedicated-status-404.test.ts src/api/client-cloud-select-or-provision.test.ts src/cloud/handoff/silent-repoint.test.ts src/cloud/handoff/resume-pending-handoff.test.ts src/state/persistence-cloud-active-server.test.ts src/first-run/first-run-finish.force-fresh.test.ts`
- `bun run --cwd packages/ui typecheck`
- `bunx @biomejs/biome check ...focused Cloud UI files...`
- `git diff --check HEAD`
- Playwright smoke against `localhost:2138/chat`: stale shared active-server repaired to dedicated subdomain, zero shared-adapter requests, no blocked CORS headers, chat stream POST observed, no visible connection error.
