### PR TITLE
feat(cloud): label agent containers (user/pool/test) + label-aware disk reclaim (#15398)

### DIFF
--- a/packages/cloud/shared/src/lib/config/containers-env.ts
+++ b/packages/cloud/shared/src/lib/config/containers-env.ts
@@ -261,6 +261,24 @@ export const containersEnv = {
   },
 
   /**
+   * Org ids whose agent containers are TEST containers (QA accounts, e2e
+   * harness orgs). Containers provisioned for these orgs get the docker label
+   * `ai.elizaos.container-class=test` so fleet janitors and CI teardown can
+   * reap them without ever touching a real user's agent. Comma-separated
+   * UUIDs via `CONTAINERS_TEST_ORG_IDS` (with `ELIZA_` fallback); empty by
+   * default — unlisted orgs are always classed `user`, the safe direction.
+   */
+  testOrgIds(): string[] {
+    const env = getCloudAwareEnv();
+    const raw = pick(env.CONTAINERS_TEST_ORG_IDS, env.ELIZA_TEST_ORG_IDS);
+    if (raw === undefined) return [];
+    return raw
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0);
+  },
+
+  /**
    * First-party TEMPLATE image stamped onto a template app (one created WITHOUT a
    * user repo) at create time, so create -> deploy resolves to a prebuilt,
    * allowlisted image instead of failing with "no image to deploy".

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
@@ -11,6 +11,7 @@
 import { buildDefaultElizaCloudServiceRouting } from "@elizaos/shared/contracts/service-routing";
 import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
 import { dockerNodesRepository } from "../../db/repositories/docker-nodes";
+import { WARM_POOL_ORG_ID } from "../../db/schemas/agent-sandboxes";
 import type { DockerNode } from "../../db/schemas/docker-nodes";
 import { isAgentTokenSigningConfigured, mintAgentToken } from "../auth/agent-token";
 import { containersEnv } from "../config/containers-env";
@@ -31,6 +32,7 @@ import {
   allocatePort,
   BRIDGE_PORT_MAX,
   BRIDGE_PORT_MIN,
+  buildAgentContainerLabelFlags,
   buildEnsureNetworkCmd,
   dockerPlatformFlag,
   extractDockerCreateContainerId,
@@ -38,6 +40,7 @@ import {
   getVolumePath,
   parseDockerNodes,
   requiresDockerHostGateway,
+  resolveAgentContainerClass,
   resolveStewardContainerUrl,
   shellQuote,
   validateAgentId,
@@ -1279,6 +1282,16 @@ export class DockerSandboxProvider implements SandboxProvider {
         "docker create",
         ...platformFlags,
         `--name ${shellQuote(containerName)}`,
+        // Marking (user vs pool vs test) + managed-by, so fleet cleanup can
+        // target debris without ever touching a real user's agent container.
+        ...buildAgentContainerLabelFlags({
+          agentId,
+          organizationId,
+          containerClass: resolveAgentContainerClass(organizationId, {
+            warmPoolOrgId: WARM_POOL_ORG_ID,
+            testOrgIds: containersEnv.testOrgIds(),
+          }),
+        }),
         "--restart unless-stopped",
         `--network ${shellQuote(DOCKER_NETWORK)}`,
         ...(requiresDockerHostGateway(stewardContainerUrl) || Object.keys(proxyEnv).length > 0

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-utils.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-utils.test.ts
@@ -2,6 +2,8 @@
 import { describe, expect, test } from "vitest";
 import {
   allocatePort,
+  buildAgentContainerLabelArgs,
+  buildAgentContainerLabelFlags,
   dockerPlatformFlag,
   extractDockerCreateContainerId,
   getContainerName,
@@ -12,6 +14,7 @@ import {
   readDockerHostPortFromMetadata,
   requiredArchitectureForPlatform,
   requiresDockerHostGateway,
+  resolveAgentContainerClass,
   resolveStewardContainerUrl,
   shellQuote,
   validateAgentId,
@@ -164,5 +167,55 @@ describe("port + metadata helpers", () => {
     expect(readDockerHostPortFromMetadata({ hostPort: -1 })).toBeNull();
     expect(readDockerHostPortFromMetadata({ hostPort: "80" })).toBeNull();
     expect(readDockerHostPortFromMetadata(null)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Container labels (test-vs-user marking)
+// ---------------------------------------------------------------------------
+
+describe("agent container labels", () => {
+  const POOL_ORG = "00000000-0000-4000-8000-000000077001";
+  const TEST_ORG = "11111111-1111-4111-8111-111111111111";
+  const USER_ORG = "22222222-2222-4222-8222-222222222222";
+
+  test("resolveAgentContainerClass distinguishes user / pool / test", () => {
+    const options = { warmPoolOrgId: POOL_ORG, testOrgIds: [TEST_ORG] };
+    expect(resolveAgentContainerClass(USER_ORG, options)).toBe("user");
+    expect(resolveAgentContainerClass(POOL_ORG, options)).toBe("pool");
+    expect(resolveAgentContainerClass(TEST_ORG, options)).toBe("test");
+  });
+
+  test("unknown orgs default to user — the safe direction for cleanup tooling", () => {
+    expect(
+      resolveAgentContainerClass("unknown-org", { warmPoolOrgId: POOL_ORG, testOrgIds: [] }),
+    ).toBe("user");
+  });
+
+  test("buildAgentContainerLabelArgs emits the full marking set", () => {
+    const args = buildAgentContainerLabelArgs({
+      agentId: "agent-123",
+      organizationId: USER_ORG,
+      containerClass: "user",
+    });
+    expect(args).toEqual([
+      ["ai.elizaos.managed-by", "eliza-cloud"],
+      ["ai.elizaos.agent-id", "agent-123"],
+      ["ai.elizaos.org-id", USER_ORG],
+      ["ai.elizaos.container-class", "user"],
+    ]);
+  });
+
+  test("buildAgentContainerLabelFlags shell-quotes each --label", () => {
+    const flags = buildAgentContainerLabelFlags({
+      agentId: "abc",
+      organizationId: "org'; rm -rf /",
+      containerClass: "test",
+    });
+    expect(flags).toHaveLength(4);
+    expect(flags[0]).toBe("--label 'ai.elizaos.managed-by=eliza-cloud'");
+    // Embedded single quote must be escaped, not break out of the quoting.
+    expect(flags[2]).toContain(`'"'"'`);
+    expect(flags[3]).toBe("--label 'ai.elizaos.container-class=test'");
   });
 });

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-utils.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-utils.ts
@@ -35,6 +35,72 @@ export const MAX_AGENT_ID_LENGTH =
 export type DockerNodeArchitecture = "amd64" | "arm64";
 
 // ---------------------------------------------------------------------------
+// Container labels (test-vs-user marking + safe cleanup targeting)
+// ---------------------------------------------------------------------------
+
+/**
+ * Every provisioner-created container carries these labels so fleet tooling
+ * can distinguish REAL user agents from pool/test containers and from
+ * unmanaged debris (hand-run containers, CI leftovers) without consulting the
+ * DB. The disk-clean cycle's container prune excludes anything carrying
+ * `CONTAINER_LABEL_MANAGED_BY` — a stopped user agent container must never be
+ * reaped as a cleanup side effect (deleting it forces a full re-provision on
+ * next start, the churn class behind #15228/#15398).
+ */
+export const CONTAINER_LABEL_MANAGED_BY = "ai.elizaos.managed-by";
+export const CONTAINER_LABEL_MANAGED_BY_VALUE = "eliza-cloud";
+export const CONTAINER_LABEL_AGENT_ID = "ai.elizaos.agent-id";
+export const CONTAINER_LABEL_ORG_ID = "ai.elizaos.org-id";
+export const CONTAINER_LABEL_CLASS = "ai.elizaos.container-class";
+
+/**
+ * user — a real user's agent; must never be deleted by cleanup tooling.
+ * pool — a warm-pool entry owned by the sentinel pool org; reaped by the
+ *        pool manager only.
+ * test — created by a known test/QA org (containersEnv.testOrgIds()); CI and
+ *        fleet janitors may reap these freely.
+ */
+export type AgentContainerClass = "user" | "pool" | "test";
+
+export function resolveAgentContainerClass(
+  organizationId: string,
+  options: { warmPoolOrgId: string; testOrgIds: readonly string[] },
+): AgentContainerClass {
+  if (organizationId === options.warmPoolOrgId) return "pool";
+  if (options.testOrgIds.includes(organizationId)) return "test";
+  return "user";
+}
+
+/** Label key/value pairs shared by the remote and local docker providers. */
+export function buildAgentContainerLabelArgs(options: {
+  agentId: string;
+  organizationId: string;
+  containerClass: AgentContainerClass;
+}): Array<[string, string]> {
+  return [
+    [CONTAINER_LABEL_MANAGED_BY, CONTAINER_LABEL_MANAGED_BY_VALUE],
+    [CONTAINER_LABEL_AGENT_ID, options.agentId],
+    [CONTAINER_LABEL_ORG_ID, options.organizationId],
+    [CONTAINER_LABEL_CLASS, options.containerClass],
+  ];
+}
+
+/**
+ * `--label` flags for the remote `docker create` command string (pre-quoted).
+ * The arg-array variant for local docker spawns is
+ * `buildAgentContainerLabelArgs`.
+ */
+export function buildAgentContainerLabelFlags(options: {
+  agentId: string;
+  organizationId: string;
+  containerClass: AgentContainerClass;
+}): string[] {
+  return buildAgentContainerLabelArgs(options).map(
+    ([key, value]) => `--label ${shellQuote(`${key}=${value}`)}`,
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Shell Quoting
 // ---------------------------------------------------------------------------
 

--- a/packages/cloud/shared/src/lib/services/local-docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/local-docker-sandbox-provider.ts
@@ -17,6 +17,7 @@ import { containersEnv } from "../config/containers-env";
 import { logger } from "../utils/logger";
 import {
   allocatePort,
+  buildAgentContainerLabelArgs,
   getContainerName,
   getVolumePath,
   validateAgentId,
@@ -294,6 +295,13 @@ export class LocalDockerSandboxProvider implements SandboxProvider {
       "-d",
       "--name",
       containerName,
+      // Same marking as the remote provider — local mode is single-tenant, so
+      // everything it creates is the user's own agent.
+      ...buildAgentContainerLabelArgs({
+        agentId,
+        organizationId: config.organizationId ?? "",
+        containerClass: "user",
+      }).flatMap(([key, value]) => ["--label", `${key}=${value}`]),
       "--restart",
       "unless-stopped",
       // Make host.docker.internal resolvable on Linux Docker too; on Docker

--- a/packages/cloud/shared/src/lib/services/node-disk-manager.test.ts
+++ b/packages/cloud/shared/src/lib/services/node-disk-manager.test.ts
@@ -127,9 +127,21 @@ describe("diskHealthVerdict", () => {
 describe("buildReclaimCommand", () => {
   const cmd = buildReclaimCommand();
 
-  test("prunes the docker system WITHOUT --volumes (agent volumes preserved)", () => {
-    expect(cmd).toContain("docker system prune -af");
+  test("never prunes volumes (agent workspaces preserved)", () => {
     expect(cmd).not.toContain("--volumes");
+    expect(cmd).not.toContain("volume prune");
+  });
+
+  test("container prune excludes provisioner-managed containers (stopped user agents survive)", () => {
+    expect(cmd).toContain("docker container prune -f --filter 'label!=ai.elizaos.managed-by'");
+    // The unfiltered bulk command must be gone — it reaped stopped managed
+    // agent containers, forcing full re-provisions on next start.
+    expect(cmd).not.toContain("docker system prune");
+  });
+
+  test("prunes unreferenced images and unused networks", () => {
+    expect(cmd).toContain("docker image prune -af");
+    expect(cmd).toContain("docker network prune -f");
   });
 
   test("clears stuck containerd ingest (the actual failed-pull junk)", () => {

--- a/packages/cloud/shared/src/lib/services/node-disk-manager.ts
+++ b/packages/cloud/shared/src/lib/services/node-disk-manager.ts
@@ -13,9 +13,10 @@
  *
  * This module adds the missing self-management, in two parts:
  *   1. A prune cycle: per HEALTHY node, read `df` for the docker data root; when
- *      usage crosses the high-water mark, reclaim space (`docker system prune`
- *      WITHOUT `--volumes` + clear stuck containerd ingest + buildkit prune),
- *      with a cooldown so it doesn't prune every tick. Logs before/after `df`.
+ *      usage crosses the high-water mark, reclaim space (label-filtered
+ *      container/image/network/buildkit prunes, never volumes, never managed
+ *      agent containers + clear stuck containerd ingest), with a cooldown so it
+ *      doesn't prune every tick. Logs before/after `df`.
  *   2. A disk-aware health verdict (`diskHealthVerdict`): a node whose disk is
  *      critically full is `unhealthy` so the autoscaler drains/replaces it
  *      instead of believing a `docker info` that still answers on a full disk.
@@ -30,8 +31,11 @@
  * SAFETY INVARIANTS:
  *   1. Only `status === "healthy"` nodes are pruned (the caller runs this AFTER
  *      the node health-check, so a node failing its probe is excluded).
- *   2. `docker system prune` is run WITHOUT `--volumes` — agent host volumes
- *      (persisted workspaces) are never touched.
+ *   2. No volume prune anywhere — agent host volumes (persisted workspaces)
+ *      are never touched. Container prune excludes anything labeled
+ *      `ai.elizaos.managed-by`, so a stopped USER agent container is never
+ *      reaped either (deleting it would force a full re-provision on next
+ *      start).
  *   3. Stuck-ingest clearing only removes the containerd INGEST staging dir
  *      (half-written, not-yet-committed pull blobs); committed content blobs and
  *      running containers are never touched. It uses `find ... -mindepth 1
@@ -46,6 +50,7 @@
 import { imageRepo } from "../../db/utils/docker-image-ref";
 import { containersEnv } from "../config/containers-env";
 import { logger } from "../utils/logger";
+import { CONTAINER_LABEL_MANAGED_BY } from "./docker-sandbox-utils";
 import { DockerSSHClient } from "./docker-ssh";
 
 // ---------------------------------------------------------------------------
@@ -235,26 +240,42 @@ const RECLAIM_TIMEOUT_MS = 5 * 60_000;
  * The reclamation command run on a node when it crosses the prune threshold.
  *
  * Order matters:
- *   1. `docker system prune -af` (NO `--volumes`) — reap stopped containers,
- *      dangling + unreferenced images, build cache, unused networks. This is the
- *      bulk reclaim and is safe: agent host volumes (persisted workspaces) are
- *      preserved because we omit `--volumes`.
- *   2. `docker builder prune -af` — drop the buildkit cache `system prune`'s
- *      `-a` does not always fully clear (separate GC root on some daemons).
- *   3. Clear stuck containerd INGEST — the actual junk from failed pulls.
- *      `docker system prune` does NOT touch containerd's ingest staging dir, so
- *      half-written blobs from a `no space left on device` pull persist and
- *      re-accumulate. We remove ONLY the ingest subtree (not committed content),
- *      across both the moby and k8s.io namespaces, guarded so a missing dir is a
- *      no-op. `find ... -delete` is used (not `rm -rf <glob>`) so it is bounded
- *      to the ingest dir and never errors on an empty match.
+ *   1. `docker container prune` filtered to EXCLUDE provisioner-managed
+ *      containers (label `ai.elizaos.managed-by`, see docker-sandbox-utils) —
+ *      reap stopped unmanaged debris (CI leftovers, hand-run containers) while
+ *      never deleting a stopped user agent container. Deleting one forces a
+ *      full re-provision on its next start — the churn class behind
+ *      #15228/#15398. (Containers created before labeling shipped are not
+ *      protected by the filter; they age out as the fleet re-provisions.)
+ *   2. `docker image prune -af` — dangling + unreferenced images. Images used
+ *      by ANY container (running or stopped, including the managed containers
+ *      step 1 preserved) are never removed by docker.
+ *   3. `docker network prune -f` — unused networks (docker refuses to remove
+ *      networks with attached containers, so the shared agent bridge network
+ *      is safe while in use; the provisioner also self-heals it on create).
+ *   4. `docker builder prune -af` — drop the buildkit cache.
+ *   5. Clear stuck containerd INGEST — the actual junk from failed pulls.
+ *      Nothing above touches containerd's ingest staging dir, so half-written
+ *      blobs from a `no space left on device` pull persist and re-accumulate.
+ *      We remove ONLY the ingest subtree (not committed content), across both
+ *      the moby and k8s.io namespaces, guarded so a missing dir is a no-op.
+ *      `find ... -delete` is used (not `rm -rf <glob>`) so it is bounded to
+ *      the ingest dir and never errors on an empty match.
+ *
+ * Steps 1–4 replace the previous single `docker system prune -af`, which had
+ * no per-object filtering and would reap a stopped MANAGED agent container.
+ * Volumes are still never touched (no volume prune anywhere).
  *
  * Every step is `|| true`-guarded so one failing step (e.g. buildkit not
  * present) does not abort the rest — best-effort reclamation.
  */
 export function buildReclaimCommand(): string {
   return [
-    "docker system prune -af || true",
+    // label!=<key> matches objects NOT carrying the key at all — i.e. only
+    // unmanaged containers are pruned.
+    `docker container prune -f --filter 'label!=${CONTAINER_LABEL_MANAGED_BY}' || true`,
+    "docker image prune -af || true",
+    "docker network prune -f || true",
     "docker builder prune -af || true",
     // Clear stuck containerd ingest (half-written pull blobs) in every namespace
     // dir, ONLY the ingest subtree. -mindepth 1 keeps the ingest dir itself.


### PR DESCRIPTION
## Problem

Two gaps from the #15398 / launch-hardening arc:

1. **Agent containers carry no docker labels.** Fleet tooling (disk-clean cycle, janitors, operators SSH'd into a node) cannot distinguish a real user's agent from a warm-pool entry, a QA/e2e agent, or unmanaged debris without joining against the DB. User-vs-test marking is a hard requirement for safe cleanup.
2. **The disk-clean cycle's `docker system prune -af` reaps ALL stopped containers** — including a stopped *user agent* container. Deleting one forces a full re-provision on its next start, feeding exactly the provisioning-churn class from #15228.

## Change

**Labels on every provisioner-created container** (remote + local providers):

| label | value |
|---|---|
| `ai.elizaos.managed-by` | `eliza-cloud` |
| `ai.elizaos.agent-id` | sandbox agent id |
| `ai.elizaos.org-id` | owning org |
| `ai.elizaos.container-class` | `user` \| `pool` \| `test` |

Class resolution: `pool` = `WARM_POOL_ORG_ID` sentinel org (warm-pool creator reuses the normal provision flow, so this needs no pool-side change); `test` = orgs listed in the new `CONTAINERS_TEST_ORG_IDS` env (comma-separated, empty default); `user` = everything else — unlisted orgs always class as `user`, the safe direction.

**Label-aware reclaim** — `buildReclaimCommand()` now runs per-object prunes instead of one unfiltered `docker system prune -af`:
- `docker container prune -f --filter 'label!=ai.elizaos.managed-by'` — stopped **unmanaged** debris only; a stopped user agent container is never a cleanup casualty
- `docker image prune -af` (images referenced by preserved containers survive docker's own rule), `docker network prune -f`, `docker builder prune -af`, containerd ingest clearing — unchanged semantics
- still **no volume prune anywhere**

Containers created before labeling shipped aren't protected by the filter; they age out as the fleet re-provisions onto labeled containers.

The one-off admin tool (`prune-node-disk.ts`) reuses `buildReclaimCommand()`, so it inherits the same safety.

## Verification
- `bun test` on `docker-sandbox-utils.test.ts` + `node-disk-manager.test.ts` — 48 pass (new: class resolution, label args, shell-quoting of label values, reclaim-command safety assertions)
- `tsc --noEmit` clean on `packages/cloud/shared`

Foundation for #15398 (fleet cleanup can now target `container-class=test`/unmanaged safely) and the enterprise-grade user-container goal: cleanup tooling can no longer delete a user's container as a side effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)