### PR TITLE
fix(ui): fire shared→dedicated handoff for reused shared agents too (#15310 #3)

### DIFF
--- a/packages/ui/src/first-run/first-run-finish.reused-shared-handoff.test.ts
+++ b/packages/ui/src/first-run/first-run-finish.reused-shared-handoff.test.ts
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+
+/**
+ * Regression for #15310 failure mode #3: the shared→dedicated handoff branch
+ * in `bindCloudAgent` was gated on `selectedAgent.created`, so a re-login that
+ * REUSED an existing shared agent (`created:false` — e.g. after a failed first
+ * run) never re-entered the upgrade path. The user stayed permanently on the
+ * shared adapter with the provisioning tile showing.
+ *
+ * Contract under test:
+ *   - created:true                     → handoff fires (unchanged)
+ *   - created:false, no pending marker → handoff fires (the fix)
+ *   - created:false, marker present    → handoff does NOT fire here —
+ *     resumePendingCloudHandoff owns an interrupted-but-live handoff (it
+ *     verifies the target and re-arms a fresh create itself when the target is
+ *     dead); double-firing would provision a second dedicated agent.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { savePendingCloudHandoff } from "../cloud/handoff/pending-handoff-store";
+import type { FirstRunProfileDraft } from "./first-run";
+import type { FirstRunFinishPorts } from "./first-run-finish";
+import { bindCloudAgent } from "./first-run-finish";
+
+const SHARED_AGENT_BASE =
+  "https://staging.elizacloud.ai/api/v1/eliza/agents/cad3c071";
+
+const clientMock = vi.hoisted(() => ({
+  selectOrProvisionCloudAgent: vi.fn(),
+  submitFirstRun: vi.fn(async () => {}),
+  setBaseUrl: vi.fn(),
+  setToken: vi.fn(),
+  getBaseUrl: vi.fn(() => ""),
+  createCloudCompatAgent: vi.fn(),
+  startCloudAgentHandoff: vi.fn(),
+  deleteSharedBridgeAgent: vi.fn(async () => ({ success: true })),
+}));
+
+const runCloudAgentHandoffMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../api", () => ({ client: clientMock }));
+
+vi.mock("../cloud/handoff/run-cloud-agent-handoff", () => ({
+  runCloudAgentHandoff: runCloudAgentHandoffMock,
+}));
+
+vi.mock("../config/boot-config", () => ({
+  getBootConfig: () => ({
+    cloudApiBase: "https://staging.elizacloud.ai",
+    preferSharedCloudTier: true,
+  }),
+}));
+
+vi.mock("../state", () => ({
+  addAgentProfile: vi.fn(() => ({ id: "profile-1" })),
+  createPersistedActiveServer: vi.fn((v) => ({ label: "Eliza Cloud", ...v })),
+  loadPersistedActiveServer: vi.fn(() => null),
+  removeAgentProfile: vi.fn(),
+  savePersistedActiveServer: vi.fn(),
+}));
+
+vi.mock("./mobile-runtime-mode", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./mobile-runtime-mode")>()),
+  persistMobileRuntimeModeForServerTarget: vi.fn(),
+}));
+
+function draft(): FirstRunProfileDraft {
+  return {
+    agentName: "Eliza",
+    runtime: "cloud",
+    localInference: "cloud-inference",
+    remoteApiBase: "",
+    remoteToken: "",
+  };
+}
+
+function ports(): FirstRunFinishPorts {
+  return {
+    uiLanguage: "en",
+    elizaCloudConnected: true,
+    handleCloudLogin: vi.fn(async () => {}),
+    setRuntimeState: vi.fn(),
+    setTab: vi.fn(),
+    completeFirstRun: vi.fn(),
+    onStatus: vi.fn(),
+  };
+}
+
+function mockSelection(created: boolean): void {
+  clientMock.selectOrProvisionCloudAgent.mockResolvedValue({
+    agentId: "cad3c071",
+    apiBase: SHARED_AGENT_BASE,
+    requiresAgentPairing: false,
+    created,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+describe("shared→dedicated handoff firing on shared-agent completion", () => {
+  it("fires for a newly created shared agent (unchanged behavior)", async () => {
+    mockSelection(true);
+    const outcome = await bindCloudAgent(draft(), "steward-token", {}, ports());
+    expect(outcome.kind).toBe("done");
+    expect(runCloudAgentHandoffMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires for a REUSED shared agent with no pending marker (#15310 #3)", async () => {
+    mockSelection(false);
+    const outcome = await bindCloudAgent(draft(), "steward-token", {}, ports());
+    expect(outcome.kind).toBe("done");
+    expect(runCloudAgentHandoffMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT fire for a reused shared agent when a pending marker exists (resume path owns it)", async () => {
+    savePendingCloudHandoff({
+      sharedAgentId: "cad3c071",
+      dedicatedAgentId: "dedicated-1",
+      sharedApiBase: SHARED_AGENT_BASE,
+      cloudApiBase: "https://staging.elizacloud.ai",
+      startedAt: Date.now(),
+    });
+    mockSelection(false);
+    const outcome = await bindCloudAgent(draft(), "steward-token", {}, ports());
+    expect(outcome.kind).toBe("done");
+    expect(runCloudAgentHandoffMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/first-run/first-run-finish.ts
+++ b/packages/ui/src/first-run/first-run-finish.ts
@@ -21,7 +21,10 @@ import {
 import type { CloudCompatAgent } from "../api/client-types-cloud";
 import { getDesktopRuntimeMode, invokeDesktopBridgeRequest } from "../bridge";
 import { type AgentPluginLike, getAgentPlugin } from "../bridge/native-plugins";
-import { savePendingCloudHandoff } from "../cloud/handoff/pending-handoff-store";
+import {
+  loadPendingCloudHandoff,
+  savePendingCloudHandoff,
+} from "../cloud/handoff/pending-handoff-store";
 import { runCloudAgentHandoff } from "../cloud/handoff/run-cloud-agent-handoff";
 import { silentlyRepointToDedicated } from "../cloud/handoff/silent-repoint";
 import { getBootConfig } from "../config/boot-config";
@@ -603,9 +606,19 @@ export async function bindCloudAgent(
 
   // Seamless shared→dedicated cloud-agent handoff (background). Flag OFF →
   // `selectedAgent` is the dedicated agent itself and this branch is skipped.
+  //
+  // Fires for a NEWLY created shared agent AND for a REUSED one
+  // (`created:false`, e.g. re-login after a failed first run) — #15310 #3: the
+  // old `created`-only gate meant a reused shared agent never re-entered the
+  // upgrade path, stranding the user on the shared adapter with the
+  // provisioning tile forever. The one reuse case that must NOT start a fresh
+  // handoff is an interrupted-but-live one: a persisted pending marker means
+  // resumePendingCloudHandoff owns it (it verifies the target and re-arms a
+  // fresh create itself when the target is dead), and double-firing here would
+  // provision a second dedicated agent.
   if (
     getBootConfig().preferSharedCloudTier &&
-    selectedAgent.created &&
+    (selectedAgent.created || loadPendingCloudHandoff() === null) &&
     isDirectCloudSharedAgentBase(cloudAgentApiBase)
   ) {
     const sharedAgentId = selectedAgent.agentId;


### PR DESCRIPTION
## Problem

#15310 failure mode 3 — the last unfixed client-side item on that umbrella. The background shared→dedicated handoff in `bindCloudAgent` only fired when the shared agent was **newly created**:

```ts
getBootConfig().preferSharedCloudTier &&
selectedAgent.created &&            // ← re-login reuse (created:false) never upgrades
isDirectCloudSharedAgentBase(cloudAgentApiBase)
```

A re-login after a failed first run reuses the existing shared agent (`created:false`), so the upgrade never fires again — the user is permanently stranded on the shared adapter with the provisioning tile showing. Verified live on staging (org 775ba863: shared agent reused on every login, zero jobs fired, recovery required manually clearing website data).

## Fix

Fire the handoff on reuse too, with one guard: if a pending-handoff marker is already persisted, do **not** double-fire — `resumePendingCloudHandoff` owns an interrupted-but-live handoff (since 12f5df68f it verifies the target and re-arms a fresh create itself when the target is dead). Double-firing would provision a second dedicated agent (billing + orphan risk).

| state | before | after |
|---|---|---|
| created:true | fires | fires |
| created:false, no marker | **never fires (stranded)** | **fires** |
| created:false, marker present | never fires | defers to resume path |

## Verification
Full `packages/ui` first-run suite: 25 files / 302 tests pass, including 3 new cases in `first-run-finish.reused-shared-handoff.test.ts` covering the table above.

Closes the remaining client half of #15310 (items 1, 2, 4 already landed: daemon KMS preflight + #15550, marker hygiene 12f5df68f, boot reconciliation 5bb295b9d).

🤖 Generated with [Claude Code](https://claude.com/claude-code)