### PR TITLE
fix(cloud): fail closed A2A credits summary

### DIFF
--- a/packages/cloud/shared/src/lib/api/a2a/platform-cloud.test.ts
+++ b/packages/cloud/shared/src/lib/api/a2a/platform-cloud.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Regression coverage for the Cloud platform A2A account skills. The harness
+ * keeps auth, storage, and repositories deterministic while exercising the real
+ * A2A task shaping and JSON-RPC boundary.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { AppContext } from "../../../types/cloud-worker-env";
+import type { JSONRPCErrorResponse, JSONRPCSuccessResponse, Task } from "../../types/a2a";
+
+const organizationsRepository = {
+  findById: mock(),
+};
+const creditsService = {
+  listTransactionsByOrganization: mock(),
+};
+const executeCloudCapabilityRest = mock();
+const requireUserOrApiKeyWithOrg = mock();
+const taskStoreSet = mock();
+const loggerError = mock();
+
+mock.module("../../cloud-capabilities", () => ({
+  executeCloudCapabilityRest,
+  getCloudCapabilities: () => [
+    {
+      id: "credits-summary",
+      title: "Credits summary",
+      summary: "Read credits summary",
+      category: "billing",
+      auth: { adminOnly: false, modes: ["bearer"] },
+      billing: null,
+      surfaces: {
+        a2a: { skill: "cloud.credits.summary" },
+        mcp: { tool: "cloud_credits_summary" },
+        rest: { method: "GET", path: "/api/credits/summary" },
+      },
+    },
+  ],
+}));
+
+mock.module("../../../db/repositories", () => ({
+  organizationsRepository,
+}));
+
+mock.module("../../auth/workers-hono-auth", () => ({
+  requireAdmin: mock(async () => undefined),
+  requireUserOrApiKeyWithOrg,
+}));
+
+mock.module("../../services/credits", () => ({
+  creditsService,
+}));
+
+mock.module("../../services/active-billing", () => ({
+  activeBillingService: {
+    listActiveResources: mock(),
+    listLedger: mock(),
+    cancelResource: mock(),
+  },
+}));
+
+mock.module("../../services/containers", () => ({
+  containersService: {
+    listByOrganization: mock(),
+    checkQuota: mock(),
+  },
+}));
+
+mock.module("../../services/a2a-task-store", () => ({
+  a2aTaskStoreService: {
+    set: taskStoreSet,
+    get: mock(),
+    updateTaskState: mock(),
+  },
+}));
+
+mock.module("../../utils/logger", () => ({
+  logger: { error: loggerError, warn: mock(), info: mock(), debug: mock() },
+}));
+
+const { handlePlatformA2aJsonRpc, handlePlatformMessageSend } = await import("./platform-cloud");
+
+const context = {
+  env: { NEXT_PUBLIC_APP_URL: "https://cloud.test" },
+  req: { url: "https://cloud.test/api/a2a" },
+} as AppContext;
+
+const user = {
+  id: "user-1",
+  email: "user@example.com",
+  wallet_address: null,
+  organization_id: "org-1",
+  organization: { id: "org-1", name: "Org One" },
+  role: "user",
+};
+
+function creditsSummaryParams() {
+  return {
+    message: {
+      role: "user",
+      parts: [{ type: "data", data: { skill: "cloud.credits.summary" } }],
+    },
+  };
+}
+
+function creditsSummaryData(task: Task) {
+  const messagePart = task.status.message?.parts.find((part) => part.type === "data");
+  if (messagePart?.type !== "data") throw new Error("credits summary result missing data part");
+  return messagePart.data as {
+    organizationId: string;
+    balance: number;
+    recentTransactions: unknown[];
+  };
+}
+
+beforeEach(() => {
+  organizationsRepository.findById.mockReset();
+  creditsService.listTransactionsByOrganization.mockReset();
+  requireUserOrApiKeyWithOrg.mockReset();
+  taskStoreSet.mockReset();
+  loggerError.mockReset();
+
+  requireUserOrApiKeyWithOrg.mockResolvedValue(user);
+  creditsService.listTransactionsByOrganization.mockResolvedValue([{ id: "txn-1" }]);
+  taskStoreSet.mockResolvedValue(undefined);
+});
+
+describe("Cloud platform A2A credits summary", () => {
+  test("reads Postgres NUMERIC credit_balance as a decimal instead of fabricating task data", async () => {
+    organizationsRepository.findById.mockResolvedValue({ id: "org-1", credit_balance: "10.50" });
+
+    const task = await handlePlatformMessageSend(context, creditsSummaryParams());
+
+    expect(creditsSummaryData(task)).toEqual({
+      organizationId: "org-1",
+      balance: 10.5,
+      recentTransactions: [{ id: "txn-1" }],
+    });
+    expect(taskStoreSet).toHaveBeenCalledTimes(1);
+  });
+
+  test("throws on corrupt credit_balance rather than returning NaN", async () => {
+    organizationsRepository.findById.mockResolvedValue({ id: "org-1", credit_balance: "NaN" });
+
+    await expect(handlePlatformMessageSend(context, creditsSummaryParams())).rejects.toThrow(
+      /credit_balance/,
+    );
+    expect(taskStoreSet).not.toHaveBeenCalled();
+  });
+
+  test("JSON-RPC boundary reports a missing organization instead of returning balance zero", async () => {
+    organizationsRepository.findById.mockResolvedValue(undefined);
+
+    const response = (await handlePlatformA2aJsonRpc(context, {
+      id: "rpc-1",
+      method: "message/send",
+      params: creditsSummaryParams(),
+    })) as JSONRPCSuccessResponse<Task> | JSONRPCErrorResponse;
+
+    expect("result" in response).toBe(false);
+    expect((response as JSONRPCErrorResponse).error).toMatchObject({
+      code: -32000,
+      message: "Organization not found for credits summary: org-1",
+    });
+    expect(taskStoreSet).not.toHaveBeenCalled();
+    expect(loggerError).toHaveBeenCalledWith(
+      "[A2A Platform] JSON-RPC dispatch failed",
+      expect.objectContaining({
+        method: "message/send",
+        error: "Organization not found for credits summary: org-1",
+      }),
+    );
+  });
+});

--- a/packages/cloud/shared/src/lib/api/a2a/platform-cloud.ts
+++ b/packages/cloud/shared/src/lib/api/a2a/platform-cloud.ts
@@ -1,5 +1,13 @@
-// Defines cloud API platform cloud helpers shared across worker routes.
+/**
+ * Cloud API platform agent helpers shared across A2A worker routes.
+ *
+ * The dispatcher translates platform skills into the same service and
+ * repository calls used by REST surfaces, then wraps successful results as A2A
+ * tasks. Failures are allowed to reach the JSON-RPC boundary so broken billing
+ * or account reads become observable errors instead of fabricated task data.
+ */
 import { organizationsRepository } from "../../../db/repositories";
+import { parseOrganizationCreditBalance } from "../../../db/repositories/organizations-credit-balance-numeric";
 import type { AppContext } from "../../../types/cloud-worker-env";
 import { requireAdmin, requireUserOrApiKeyWithOrg } from "../../auth/workers-hono-auth";
 import { executeCloudCapabilityRest, getCloudCapabilities } from "../../cloud-capabilities";
@@ -134,9 +142,12 @@ async function executePlatformSkill(c: AppContext, skill: string, args: Record<s
         organizationsRepository.findById(user.organization_id),
         creditsService.listTransactionsByOrganization(user.organization_id, 10),
       ]);
+      if (!org) {
+        throw new Error(`Organization not found for credits summary: ${user.organization_id}`);
+      }
       return {
         organizationId: user.organization_id,
-        balance: Number(org?.credit_balance ?? 0),
+        balance: parseOrganizationCreditBalance(org.credit_balance, "credit_balance"),
         recentTransactions: transactions,
       };
     }


### PR DESCRIPTION
## Summary
- fail closed `cloud.credits.summary` when the authenticated organization row is missing
- parse `organizations.credit_balance` with the shared NUMERIC guard instead of `Number(org?.credit_balance ?? 0)`
- add deterministic A2A coverage for decimal balances, corrupt `NaN` balances, and missing-org JSON-RPC errors

Fixes part of #13415.

## Verification
- `bun test packages/cloud/shared/src/lib/api/a2a/platform-cloud.test.ts`
- `bunx biome check packages/cloud/shared/src/lib/api/a2a/platform-cloud.ts packages/cloud/shared/src/lib/api/a2a/platform-cloud.test.ts`
- `git diff --check`
- `bun run audit:error-policy-ratchet`
- `bun run --cwd packages/cloud/shared typecheck 2>&1 | rg "platform-cloud|organizations-credit-balance|error TS"` currently stops on pre-existing generated i18n data misses in `packages/core/src/i18n/*` and `packages/shared/src/i18n/keyword-matching.ts`, with no platform-cloud-specific diagnostics emitted before that blocker.