### PR TITLE
feat(ops): reconcile ELIZA_AGENT_IMAGE onto the CP via the deploy workflow (#15228, #15401)

### DIFF
--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -110,6 +110,17 @@ jobs:
       # reconcile semantics below preserve hand-set values until the secret is
       # wired for an environment.
       SECRETS_MASTER_KEY: ${{ secrets.SECRETS_MASTER_KEY }}
+      # Operator pin for the canonical managed-agent image
+      # (containersEnv.defaultAgentImageOverride; falls back to
+      # ghcr.io/elizaos/eliza:stable when unset everywhere). This pin decides
+      # which image every NEW provision and warm-pool replenish boots — it is
+      # exactly the knob the #15228 crash-loop rollout needed. Before this it
+      # lived ONLY hand-set on the CP box (the same drift class as
+      # DATABASE_URL/#15160, tracked in the #15401 ledger): a CP re-arm lost
+      # it silently. Set the GitHub environment VARIABLE (not secret — an
+      # image ref is auditable config) to roll the fleet pin via deploy;
+      # leave it unset to preserve whatever is hand-set on the box.
+      ELIZA_AGENT_IMAGE: ${{ vars.ELIZA_AGENT_IMAGE }}
     steps:
       - name: Check deploy configuration
         id: deploy_config
@@ -187,7 +198,7 @@ jobs:
           username: deploy
           key: ${{ env.DEPLOY_SSH_KEY }}
           command_timeout: 10m
-          envs: DEPLOY_BRANCH,SYSTEMD_UNIT,HEADSCALE_API_URL,HEADSCALE_PUBLIC_URL,HEADSCALE_API_KEY,SANDBOX_REGISTRY_REDIS_URL,DATABASE_URL,SECRETS_MASTER_KEY
+          envs: DEPLOY_BRANCH,SYSTEMD_UNIT,HEADSCALE_API_URL,HEADSCALE_PUBLIC_URL,HEADSCALE_API_KEY,SANDBOX_REGISTRY_REDIS_URL,DATABASE_URL,SECRETS_MASTER_KEY,ELIZA_AGENT_IMAGE
           script: |
             set -euo pipefail
             echo "=== Deploying eliza-provisioning-worker (branch: $DEPLOY_BRANCH) ==="
@@ -356,7 +367,8 @@ jobs:
               "HEADSCALE_API_KEY=$HEADSCALE_API_KEY" \
               "SANDBOX_REGISTRY_REDIS_URL=$SANDBOX_REGISTRY_REDIS_URL" \
               "DATABASE_URL=$DATABASE_URL" \
-              "SECRETS_MASTER_KEY=$SECRETS_MASTER_KEY"; do
+              "SECRETS_MASTER_KEY=$SECRETS_MASTER_KEY" \
+              "ELIZA_AGENT_IMAGE=$ELIZA_AGENT_IMAGE"; do
               key="${kv%%=*}"
               val="${kv#*=}"
               [ -n "$val" ] || continue


### PR DESCRIPTION
## Problem

Two issues converge on the same missing plumbing:

- **#15228** (P0 crash-loop): the code fixes are all merged; the remaining action is *rolling the fleet image pin* (`ELIZA_AGENT_IMAGE`, currently a pre-fix `sha-7f09ec2`) to a post-fix build. There was no mechanism to do that except hand-editing `/opt/eliza/cloud/.env.local` on the CP box.
- **#15401** (config-drift ledger): hand-set CP env values are exactly the drift class that caused #15160 (CP silently polling an abandoned Neon DB for 3 weeks). `DATABASE_URL` got a durable home via the deploy workflow's reconciled-env mechanism; the image pin had none.

## Change

`ELIZA_AGENT_IMAGE` joins the deploy workflow's reconciled env set:

- sourced from the GitHub **environment variable** `ELIZA_AGENT_IMAGE` (a variable, not a secret — an image ref is auditable config and shows up in run logs for traceability)
- same skip-when-empty semantics as `HEADSCALE_*` / `DATABASE_URL` / `SECRETS_MASTER_KEY`: unset ⇒ the box keeps its current hand-set value; set ⇒ CI is the source of truth and the box self-heals on every deploy

**Operator flow to finish #15228:** set `ELIZA_AGENT_IMAGE` on the `production` GitHub environment to a develop-built post-fix image (current `:stable` — promoted today from `89f673c61` — contains the PGlite lock fix + crash-scan fix), dispatch this workflow, verify a canary unclean-kill self-recovers, then close #15228. Existing running agents are untouched (pin affects new provisions/replenishes only, per the image-swap runbook).

## Verification
- YAML validated
- Reconcile loop semantics unchanged for existing keys (pure addition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)