### PR TITLE
fix(android): stage Vulkan backend in fused native build

### DIFF
--- a/packages/app-core/scripts/aosp/compile-libllama.mjs
+++ b/packages/app-core/scripts/aosp/compile-libllama.mjs
@@ -632,6 +632,7 @@ function writeSpirvHeadersConfigShim(incRoot) {
       "if(NOT TARGET SPIRV-Headers::SPIRV-Headers)",
       "  add_library(SPIRV-Headers::SPIRV-Headers INTERFACE IMPORTED)",
       "  set_target_properties(SPIRV-Headers::SPIRV-Headers PROPERTIES",
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: CMake expands this placeholder.
       '    INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_LIST_DIR}/../..")',
       "endif()",
       "set(SPIRV-Headers_FOUND TRUE)",
@@ -1474,6 +1475,7 @@ export function buildLibllamaForAbi({
   // empty so its behavior stays byte-for-byte identical.
   extraCmakeFlags = [],
   extraBuildTargets = [],
+  targetName = "",
 }) {
   const target = ABI_TARGETS.find((t) => t.androidAbi === abi);
   if (!target) {
@@ -1737,11 +1739,12 @@ export function buildLibllamaForAbi({
   // ElizaAgentService.java).
   // Static-fuse (BUILD_SHARED_LIBS=OFF — the `*-fused` targets): llama/ggml/
   // mtmd build as STATIC `.a` archives folded into a self-contained
-  // libelizainference.so (no DT_NEEDED on libllama.so/libggml*.so). So the
-  // legacy co-copy of the shared libllama.so + ggml family is both impossible
-  // (.so don't exist) and unnecessary (nothing dlopens them) — skip it. The
-  // non-fused (BUILD_SHARED_LIBS=ON) bulk `--abi` path keeps staging the shared
-  // family verbatim for its libllama.so-loading consumers.
+  // libelizainference.so (no DT_NEEDED on libllama.so/libggml*.so). The Android
+  // Vulkan backend is the exception: ggml-vulkan is a runtime backend .so, not a
+  // folded static archive, and must ship beside libelizainference.so so the GPU
+  // backend actually loads on device. The non-fused (BUILD_SHARED_LIBS=ON) bulk
+  // `--abi` path keeps staging the shared family verbatim for its
+  // libllama.so-loading consumers.
   const isStaticFused = extraCmakeFlags.some((f) =>
     /BUILD_SHARED_LIBS\s*=\s*OFF/i.test(String(f)),
   );
@@ -1803,6 +1806,15 @@ export function buildLibllamaForAbi({
       }
     }
   }
+
+  const staticFusedRuntimeBackendOuts = isStaticFused
+    ? stageStaticFusedRuntimeBackendLibs({
+        buildDir,
+        abiAssetDir,
+        target: targetName,
+        log,
+      })
+    : [];
 
   // Locate + stage the llama-server binary. cmake puts it under
   // `<build>/bin/llama-server` for upstream b8198 (and the apothic fork
@@ -1878,6 +1890,7 @@ export function buildLibllamaForAbi({
   const stripTargets = [
     ...ggmlOuts,
     ...runtimeSiblingOuts,
+    ...staticFusedRuntimeBackendOuts,
     llamaOut,
     ...sonameAliases,
   ].filter(Boolean); // llamaOut is null under static-fuse (no shared libllama.so)
@@ -1907,10 +1920,40 @@ export function buildLibllamaForAbi({
   return {
     llama: llamaOut,
     ggml: ggmlOuts,
+    runtimeBackends: staticFusedRuntimeBackendOuts,
     llamaServer: llamaServerOut,
     elizainference: fusedLibOut,
     omnivoiceServer: fusedServerOut,
   };
+}
+
+/**
+ * Stage runtime backend shared objects that still exist in static-fused builds.
+ * Most llama/ggml products are folded into libelizainference.so under
+ * BUILD_SHARED_LIBS=OFF, but ggml-vulkan remains a dynamic backend and the
+ * verifier requires it next to the fused library.
+ */
+export function stageStaticFusedRuntimeBackendLibs({
+  buildDir,
+  abiAssetDir,
+  target,
+  log = () => {},
+}) {
+  if (!String(target).includes("vulkan")) return [];
+  const vulkanBackend = locateBuiltLib(buildDir, "libggml-vulkan.so");
+  if (!vulkanBackend) {
+    throw new Error(
+      `[compile-libllama] static-fuse Vulkan target ${target} built no libggml-vulkan.so under ${buildDir}. ` +
+        `A Vulkan fused APK must ship the ggml-vulkan runtime backend beside libelizainference.so; otherwise it silently runs CPU-only.`,
+    );
+  }
+  fs.mkdirSync(abiAssetDir, { recursive: true });
+  const out = path.join(abiAssetDir, "libggml-vulkan.so");
+  fs.copyFileSync(vulkanBackend, out);
+  log(
+    `[compile-libllama] Copied libggml-vulkan.so for ${target} (${(fs.statSync(out).size / (1024 * 1024)).toFixed(2)} MB).`,
+  );
+  return [out];
 }
 
 /**
@@ -2428,18 +2471,24 @@ export function describeAndroidTargetDryRun({
     cmakeFlags.push(...fusedExtraCmakeFlags());
   }
   log(`  cmake ${cmakeFlags.join(" ")}`);
-  const buildTargets = parsed.fused
-    ? fusedCmakeBuildTargets()
-    : ["llama", "llama-server"];
+  const buildTargets = [
+    ...(parsed.fused ? fusedCmakeBuildTargets() : ["llama", "llama-server"]),
+    ...(parsed.backend === "vulkan" ? ["ggml-vulkan"] : []),
+  ];
   log(
     `  cmake --build ${buildDir} --target ${buildTargets.join(" ")} -j ${jobs}`,
   );
   log(`  expected output layout under ${abiAssetDir}:`);
-  log(`    libllama.so libggml*.so llama-server`);
   if (parsed.fused) {
-    log(
-      `    libelizainference.so omnivoice-tts omnivoice-codec (merged-tree artifacts)`,
-    );
+    log(`    libelizainference.so`);
+    if (parsed.backend === "vulkan") {
+      log(`    libggml-vulkan.so (runtime GPU backend)`);
+    }
+  } else {
+    log(`    libllama.so libggml*.so llama-server`);
+  }
+  if (parsed.fused) {
+    log(`    omnivoice-tts omnivoice-codec (merged-tree auxiliary artifacts)`);
     log(
       `  verifyFusedSymbols outDir=${abiAssetDir} target=${parsed.target} (post-build)`,
     );
@@ -2763,6 +2812,7 @@ export async function mainTargets(args) {
           : []),
         ...(parsed.backend === "vulkan" ? ["ggml-vulkan"] : []),
       ],
+      targetName: parsed.target,
     });
 
     // Post-build: for fused targets prove libelizainference.so exports both

--- a/packages/app-core/scripts/aosp/compile-libllama.test.mjs
+++ b/packages/app-core/scripts/aosp/compile-libllama.test.mjs
@@ -6,14 +6,15 @@ import path from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
 import { resolveElizaWorkspaceRootFromImportMeta } from "../lib/repo-root.mjs";
 import {
+  describeAndroidTargetDryRun,
+  ensureZigDrivers,
+  stageStaticFusedRuntimeBackendLibs,
+} from "./compile-libllama.mjs";
+import {
   resolveAndroidNdkHostDir,
   resolveDefaultAndroidAssetsDir,
   resolveHomebrewFormulaIncludeDirs,
 } from "./compile-libllama-paths.mjs";
-import {
-  describeAndroidTargetDryRun,
-  ensureZigDrivers,
-} from "./compile-libllama.mjs";
 
 const repoRoot = resolveElizaWorkspaceRootFromImportMeta(import.meta.url);
 const cleanupHelperScript = path.join(
@@ -188,7 +189,7 @@ describe("compile-libllama Zig driver generation", () => {
     const logs = [];
 
     describeAndroidTargetDryRun({
-      target: "android-arm64-vulkan",
+      target: "android-arm64-vulkan-fused",
       srcDir,
       cacheDir,
       abiAssetDir,
@@ -202,5 +203,52 @@ describe("compile-libllama Zig driver generation", () => {
     expect(output).toContain(
       `-DCMAKE_RANLIB=${path.join(driverDir, "zig-ranlib")}`,
     );
+    expect(output).toContain("ggml-vulkan");
+    expect(output).toContain("libggml-vulkan.so (runtime GPU backend)");
+  });
+});
+
+describe("compile-libllama static-fused runtime backend staging", () => {
+  test("copies libggml-vulkan beside libelizainference for Android Vulkan fused builds", () => {
+    const buildDir = makeTmpDir();
+    const abiAssetDir = makeTmpDir();
+    const nestedBackendDir = path.join(buildDir, "ggml", "src");
+    fs.mkdirSync(nestedBackendDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(nestedBackendDir, "libggml-vulkan.so"),
+      "vulkan-backend",
+    );
+    const logs = [];
+
+    const staged = stageStaticFusedRuntimeBackendLibs({
+      buildDir,
+      abiAssetDir,
+      target: "android-arm64-vulkan-fused",
+      log: (line) => logs.push(line),
+    });
+
+    expect(staged).toEqual([path.join(abiAssetDir, "libggml-vulkan.so")]);
+    expect(fs.readFileSync(staged[0], "utf8")).toBe("vulkan-backend");
+    expect(logs.join("\n")).toContain("Copied libggml-vulkan.so");
+  });
+
+  test("does not stage a Vulkan backend for CPU fused builds", () => {
+    const staged = stageStaticFusedRuntimeBackendLibs({
+      buildDir: makeTmpDir(),
+      abiAssetDir: makeTmpDir(),
+      target: "android-x86_64-cpu-fused",
+    });
+
+    expect(staged).toEqual([]);
+  });
+
+  test("fails closed when a Vulkan fused build has no runtime backend", () => {
+    expect(() =>
+      stageStaticFusedRuntimeBackendLibs({
+        buildDir: makeTmpDir(),
+        abiAssetDir: makeTmpDir(),
+        target: "android-arm64-vulkan-fused",
+      }),
+    ).toThrow(/libggml-vulkan\.so/);
   });
 });


### PR DESCRIPTION
## Summary
- fix `compile-libllama.mjs` static-fused Android Vulkan staging so `libggml-vulkan.so` is copied beside `libelizainference.so`
- keep CPU fused builds self-contained/no-op for backend siblings
- align dry-run output with the real `ggml-vulkan` build target and expected artifact layout
- add regression coverage for staging, no-op CPU behavior, and fail-closed missing backend behavior

Fixes the current `build-llama-ffi-android.yml` failure mode from #15540: run 28982692479 built `libelizainference.so` successfully but failed verifier because `libggml-vulkan.so` was missing next to it.

## Verification
- `bun run --cwd packages/app-core test scripts/aosp/compile-libllama.test.mjs` (11 pass; used a temporary node_modules symlink to the main checkout, removed after run)
- `bunx biome check packages/app-core/scripts/aosp/compile-libllama.mjs packages/app-core/scripts/aosp/compile-libllama.test.mjs`
- `git diff --check`
- `bun run audit:error-policy-ratchet`
- `node packages/app-core/scripts/aosp/compile-libllama.mjs --target android-arm64-vulkan-fused --src-dir plugins/plugin-local-inference/native/llama.cpp --assets-dir /tmp/eliza-android-vulkan-stage-dry --dry-run | rg "ggml-vulkan|expected output|target=android-arm64-vulkan-fused"`

N/A: full Android native cross-compile was not run locally; the failing CI run already proved the build reaches the staging/verifier step, and this patch addresses that exact missing staged artifact.