### PR TITLE
fix(ui): keep onboarding transcript scrollable

### DIFF
--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -5286,15 +5286,15 @@ export function ContinuousChatOverlay({
                   {/* `mt-auto` keeps the latest line at the bottom (nearest the
                   input) until the thread overflows, then it scrolls. During
                   onboarding only the current first-run turn is displayed, so
-                  center that setup card in the available full-screen chat space
-                  and bias it above the locked composer. */}
+                  keep short setup cards centered while letting tall cards grow
+                  past the viewport so the scrollport owns the overflow. */}
                   <div
                     ref={threadContentRef}
                     className={cn(
                       "flex flex-col pb-3 pt-1",
                       !firstRunOpen && "mt-auto",
                       firstRunOpen &&
-                        "min-h-full justify-center pb-[18vh] pt-0",
+                        "min-h-full shrink-0 justify-center pb-[18vh] pt-0",
                     )}
                   >
                     {/* Top sentinel for infinite upward scroll (#13532, #14279):

--- a/packages/ui/src/components/shell/__e2e__/chat-sheet-fixture.tsx
+++ b/packages/ui/src/components/shell/__e2e__/chat-sheet-fixture.tsx
@@ -91,6 +91,7 @@ const startEmpty = params.has("empty");
 // behavior (few messages sit near the composer, first fades into the top edge)
 // is visible instead of a long scrolling transcript.
 const firstRun = params.has("firstrun");
+const tallFirstRun = firstRun && params.has("tall");
 const fewMessages = params.has("few") || firstRun;
 // `?many` seeds a LONG transcript (far taller than any detent) so the scroll
 // container's overflow can be reproduced/measured in a real browser: at the FULL
@@ -123,6 +124,23 @@ const FEW_SEED: ShellMessage[] = [
     role: "user",
     content: "let's do the tour",
     createdAt: 2,
+    source: "first_run",
+  },
+];
+const TALL_FIRST_RUN_SEED: ShellMessage[] = [
+  {
+    id: "first-run-tall",
+    role: "assistant",
+    content: [
+      "Welcome back. Before sign-in, this setup message needs enough room to explain what changed and why the next choice matters.",
+      "",
+      ...Array.from(
+        { length: 18 },
+        (_, i) =>
+          `Setup detail ${i + 1}: this line deliberately makes the onboarding bubble taller than a short mobile viewport so the transcript must expose native vertical scrolling instead of clipping the top of the message.`,
+      ),
+    ].join("\n\n"),
+    createdAt: 1,
     source: "first_run",
   },
 ];
@@ -182,7 +200,9 @@ function Harness(): React.JSX.Element {
               },
             ]
           : MANY_SEED
-        : fewMessages
+        : tallFirstRun
+          ? TALL_FIRST_RUN_SEED
+          : fewMessages
           ? FEW_SEED
           : streaming
             ? [

--- a/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
@@ -3408,6 +3408,31 @@ try {
   // sheet settles to HALF so the home appears behind the top half while the
   // conversation stays in hand.
   {
+    const short = await ctrl();
+    attachConsole(short, sink);
+    await short.setViewportSize({ width: 1080, height: 1240 });
+    await gotoFixture(short, `${url}?firstrun&tall`);
+    await short.waitForSelector('[data-testid="chat-thread-scroll"]');
+    await short.waitForTimeout(700);
+    const tallState = await threadScrollState(short);
+    assert(
+      !!tallState && tallState.scrollHeight > tallState.clientHeight + 120,
+      `ONBOARDING: tall first-run message overflows the transcript on a short viewport (scrollHeight=${Math.round(tallState?.scrollHeight ?? 0)}, clientHeight=${Math.round(tallState?.clientHeight ?? 0)})`,
+    );
+    const tallMoved = await short.evaluate(() => {
+      const el = document.querySelector('[data-testid="chat-thread-scroll"]');
+      if (!el) return null;
+      el.scrollTop = 0;
+      const atTop = el.scrollTop;
+      el.scrollTop = Math.max(0, el.scrollHeight - el.clientHeight);
+      return { atTop, after: el.scrollTop };
+    });
+    assert(
+      !!tallMoved && tallMoved.atTop === 0 && tallMoved.after > 120,
+      `ONBOARDING: tall first-run transcript can scroll from top to bottom (top=${Math.round(tallMoved?.atTop ?? -1)}, bottom=${Math.round(tallMoved?.after ?? -1)})`,
+    );
+    await short.close();
+
     const p = await ctrl();
     attachConsole(p, sink);
     await gotoFixture(p, `${url}?firstrun`);


### PR DESCRIPTION
## Summary
- keep the first-run transcript content from shrinking inside the scrollport so tall onboarding messages produce real vertical overflow
- add a `?firstrun&tall` chat-sheet fixture state for short-viewport onboarding regression coverage
- assert in the browser e2e that the tall onboarding transcript has scroll overflow and can move from top to bottom

## Verification
- `node packages/shared/scripts/generate-keywords.mjs --target ts` (local generated artifacts for tests only)
- `bun run --cwd packages/ui test src/components/shell/ContinuousChatOverlay.firstrun.test.tsx`
- `bun run --cwd packages/ui test:chat-sheet-e2e` (rebased commit; 72 screenshots, no page errors, no error-level console logs)
- `bunx biome check packages/ui/src/components/shell/ContinuousChatOverlay.tsx packages/ui/src/components/shell/__e2e__/chat-sheet-fixture.tsx packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs`
- `git diff --check origin/develop...HEAD`
- `bun run --cwd packages/ui typecheck`
- `bun run audit:error-policy-ratchet`

## App audit
- `bun run --cwd packages/app audit:app` attempted twice. It failed before rendering because the clean worktree lacks Bun package-local links such as `packages/ui/node_modules/lucide-react`; Vite errored with `Could not load .../packages/ui/node_modules/lucide-react`. The targeted real-browser chat-sheet e2e above passed on the rebased commit.

Fixes #15545