### PR TITLE
fix(android): accept static-linked Vulkan fused backend

### DIFF
--- a/packages/app-core/scripts/aosp/compile-libllama.mjs
+++ b/packages/app-core/scripts/aosp/compile-libllama.mjs
@@ -1807,14 +1807,7 @@ export function buildLibllamaForAbi({
     }
   }
 
-  const staticFusedRuntimeBackendOuts = isStaticFused
-    ? stageStaticFusedRuntimeBackendLibs({
-        buildDir,
-        abiAssetDir,
-        target: targetName,
-        log,
-      })
-    : [];
+  let staticFusedRuntimeBackendOuts = [];
 
   // Locate + stage the llama-server binary. cmake puts it under
   // `<build>/bin/llama-server` for upstream b8198 (and the apothic fork
@@ -1872,6 +1865,15 @@ export function buildLibllamaForAbi({
         `target ships — verify the elizainference cmake target built.`,
     );
   }
+  staticFusedRuntimeBackendOuts = isStaticFused
+    ? stageStaticFusedRuntimeBackendLibs({
+        buildDir,
+        abiAssetDir,
+        target: targetName,
+        fusedLibPath: fusedLibOut,
+        log,
+      })
+    : [];
   const fusedServerSrcCandidates = [
     path.join(buildDir, "bin", "llama-omnivoice-server"),
     path.join(buildDir, "llama-omnivoice-server"),
@@ -1929,23 +1931,33 @@ export function buildLibllamaForAbi({
 
 /**
  * Stage runtime backend shared objects that still exist in static-fused builds.
- * Most llama/ggml products are folded into libelizainference.so under
- * BUILD_SHARED_LIBS=OFF, but ggml-vulkan remains a dynamic backend and the
- * verifier requires it next to the fused library.
+ * Most llama/ggml products are folded into libelizainference.so when
+ * BUILD_SHARED_LIBS=OFF. If a backend still emits a separate shared object,
+ * stage it; otherwise require marker evidence that the Vulkan backend was
+ * linked into the fused library.
  */
 export function stageStaticFusedRuntimeBackendLibs({
   buildDir,
   abiAssetDir,
   target,
+  fusedLibPath = null,
   log = () => {},
 }) {
   if (!String(target).includes("vulkan")) return [];
   const vulkanBackend = locateBuiltLib(buildDir, "libggml-vulkan.so");
-  if (!vulkanBackend) {
+  if (!vulkanBackend && !staticFusedLibCarriesVulkan(fusedLibPath)) {
     throw new Error(
       `[compile-libllama] static-fuse Vulkan target ${target} built no libggml-vulkan.so under ${buildDir}. ` +
-        `A Vulkan fused APK must ship the ggml-vulkan runtime backend beside libelizainference.so; otherwise it silently runs CPU-only.`,
+        `It also lacks the static Vulkan/Mali mitigation marker in libelizainference.so. ` +
+        `A Vulkan fused APK must either ship the ggml-vulkan runtime backend beside libelizainference.so ` +
+        `or carry the statically-linked Vulkan backend inside libelizainference.so; otherwise it silently runs CPU-only.`,
     );
+  }
+  if (!vulkanBackend) {
+    log(
+      `[compile-libllama] ${target} carries ggml-vulkan statically inside libelizainference.so; no separate libggml-vulkan.so to stage.`,
+    );
+    return [];
   }
   fs.mkdirSync(abiAssetDir, { recursive: true });
   const out = path.join(abiAssetDir, "libggml-vulkan.so");
@@ -1954,6 +1966,12 @@ export function stageStaticFusedRuntimeBackendLibs({
     `[compile-libllama] Copied libggml-vulkan.so for ${target} (${(fs.statSync(out).size / (1024 * 1024)).toFixed(2)} MB).`,
   );
   return [out];
+}
+
+function staticFusedLibCarriesVulkan(fusedLibPath) {
+  if (!fusedLibPath || !fs.existsSync(fusedLibPath)) return false;
+  const bytes = fs.readFileSync(fusedLibPath);
+  return bytes.includes(Buffer.from("GGML_VK_FA_ALLOW_SUBGROUPS"));
 }
 
 /**
@@ -2482,7 +2500,9 @@ export function describeAndroidTargetDryRun({
   if (parsed.fused) {
     log(`    libelizainference.so`);
     if (parsed.backend === "vulkan") {
-      log(`    libggml-vulkan.so (runtime GPU backend)`);
+      log(
+        `    ggml-vulkan backend (separate libggml-vulkan.so if emitted, otherwise static marker in libelizainference.so)`,
+      );
     }
   } else {
     log(`    libllama.so libggml*.so llama-server`);

--- a/packages/app-core/scripts/aosp/compile-libllama.test.mjs
+++ b/packages/app-core/scripts/aosp/compile-libllama.test.mjs
@@ -204,7 +204,7 @@ describe("compile-libllama Zig driver generation", () => {
       `-DCMAKE_RANLIB=${path.join(driverDir, "zig-ranlib")}`,
     );
     expect(output).toContain("ggml-vulkan");
-    expect(output).toContain("libggml-vulkan.so (runtime GPU backend)");
+    expect(output).toContain("static marker in libelizainference.so");
   });
 });
 
@@ -232,6 +232,25 @@ describe("compile-libllama static-fused runtime backend staging", () => {
     expect(logs.join("\n")).toContain("Copied libggml-vulkan.so");
   });
 
+  test("accepts static-linked Vulkan evidence when no separate backend is emitted", () => {
+    const buildDir = makeTmpDir();
+    const abiAssetDir = makeTmpDir();
+    const fusedLibPath = path.join(abiAssetDir, "libelizainference.so");
+    fs.writeFileSync(fusedLibPath, "GGML_VK_FA_ALLOW_SUBGROUPS");
+    const logs = [];
+
+    const staged = stageStaticFusedRuntimeBackendLibs({
+      buildDir,
+      abiAssetDir,
+      target: "android-arm64-vulkan-fused",
+      fusedLibPath,
+      log: (line) => logs.push(line),
+    });
+
+    expect(staged).toEqual([]);
+    expect(logs.join("\n")).toContain("statically inside libelizainference.so");
+  });
+
   test("does not stage a Vulkan backend for CPU fused builds", () => {
     const staged = stageStaticFusedRuntimeBackendLibs({
       buildDir: makeTmpDir(),
@@ -242,12 +261,13 @@ describe("compile-libllama static-fused runtime backend staging", () => {
     expect(staged).toEqual([]);
   });
 
-  test("fails closed when a Vulkan fused build has no runtime backend", () => {
+  test("fails closed when a Vulkan fused build has no backend evidence", () => {
     expect(() =>
       stageStaticFusedRuntimeBackendLibs({
         buildDir: makeTmpDir(),
         abiAssetDir: makeTmpDir(),
         target: "android-arm64-vulkan-fused",
+        fusedLibPath: null,
       }),
     ).toThrow(/libggml-vulkan\.so/);
   });


### PR DESCRIPTION
## Summary
- stop requiring a separate `libggml-vulkan.so` for Android static-fused Vulkan builds when CMake links the backend into `libelizainference.so`
- keep the check fail-closed by requiring the `GGML_VK_FA_ALLOW_SUBGROUPS` marker inside the fused library when no separate backend exists
- update dry-run output and regression coverage for separate-backend and static-linked-backend cases

## Evidence
Latest post-#15560 FFI run `28984035474` failed in `stageStaticFusedRuntimeBackendLibs`: the arm64 Vulkan build completed `ggml-vulkan` and linked `libelizainference.so`, but `BUILD_SHARED_LIBS=OFF` produced no `libggml-vulkan.so`. Upstream `ggml_add_backend_library()` links the backend into `ggml` when `GGML_BACKEND_DL=OFF`, and `GGML_BACKEND_DL` requires `BUILD_SHARED_LIBS=ON`.

## Verification
- `bun run --cwd packages/app-core test scripts/aosp/compile-libllama.test.mjs`
- `bunx biome check packages/app-core/scripts/aosp/compile-libllama.mjs packages/app-core/scripts/aosp/compile-libllama.test.mjs`
- `node packages/app-core/scripts/aosp/compile-libllama.mjs --target android-arm64-vulkan-fused --src-dir /tmp/fake-llama --assets-dir /tmp/fake-assets --dry-run`
- `node packages/shared/scripts/generate-keywords.mjs --target ts` (local generated artifacts for typecheck only)
- `bun run --cwd packages/app-core typecheck`
- `bun run audit:error-policy-ratchet`
- `git diff --check`

Continues #15540