### PR TITLE
fix(native): keep Steward sign-in on cloud transport

### DIFF
--- a/packages/ui/src/api/android-native-agent-transport.test.ts
+++ b/packages/ui/src/api/android-native-agent-transport.test.ts
@@ -108,6 +108,7 @@ describe("androidNativeAgentTransportForUrl", { timeout: 15_000 }, () => {
     globalThis.localStorage?.removeItem("eliza:mobile-runtime-mode");
     setBootConfig(DEFAULT_BOOT_CONFIG);
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   it("routes Android local-agent requests through the native Agent plugin", async () => {
@@ -249,6 +250,74 @@ describe("androidNativeAgentTransportForUrl", { timeout: 15_000 }, () => {
     });
     expect(fetchMock).not.toHaveBeenCalled();
     await expect(response.json()).resolves.toEqual({ ready: true });
+  });
+
+  it("does not bridge /api fetches to local when a cloud Steward token exists and no runtime mode is persisted", async () => {
+    const fetchMock = vi.fn(
+      async () => new Response(JSON.stringify({ cloud: true })),
+    );
+    const storage = new Map<string, string>();
+    const localStorage = {
+      getItem: (key: string) => storage.get(key) ?? null,
+      removeItem: (key: string) => {
+        storage.delete(key);
+      },
+      setItem: (key: string, value: string) => {
+        storage.set(key, value);
+      },
+    };
+    vi.stubEnv("VITE_ELIZA_ANDROID_RUNTIME_MODE", "local");
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("window", {
+      location: {
+        href: "https://app.elizacloud.ai/",
+        origin: "https://app.elizacloud.ai",
+      },
+      localStorage,
+    });
+    localStorage.setItem("steward_session_token", "cloud-token");
+
+    installAndroidNativeAgentFetchBridge();
+
+    const response = await fetch("/api/status?source=direct", {
+      method: "GET",
+    });
+
+    expect(agentRequestMock).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await expect(response.json()).resolves.toEqual({ cloud: true });
+  });
+
+  it("does not bridge absolute cloud-origin /api fetches in Android local mode", async () => {
+    const fetchMock = vi.fn(
+      async () => new Response(JSON.stringify({ cloud: true })),
+    );
+    const storage = new Map<string, string>();
+    const localStorage = {
+      getItem: (key: string) => storage.get(key) ?? null,
+      removeItem: (key: string) => {
+        storage.delete(key);
+      },
+      setItem: (key: string, value: string) => {
+        storage.set(key, value);
+      },
+    };
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("window", {
+      location: { href: "http://localhost/", origin: "http://localhost" },
+      localStorage,
+    });
+    localStorage.setItem("eliza:mobile-runtime-mode", "local");
+
+    installAndroidNativeAgentFetchBridge();
+
+    const response = await fetch("https://api.elizacloud.ai/api/v1/agents", {
+      method: "GET",
+    });
+
+    expect(agentRequestMock).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await expect(response.json()).resolves.toEqual({ cloud: true });
   });
 
   it("bridges direct /api fetches when the configured Android base is IPC", async () => {

--- a/packages/ui/src/api/android-native-agent-transport.ts
+++ b/packages/ui/src/api/android-native-agent-transport.ts
@@ -4,6 +4,7 @@
  * including native streaming. Selected when the API base is an Android local URL.
  */
 import { Capacitor } from "@capacitor/core";
+import { readStoredStewardToken } from "@elizaos/shared/steward-session-client";
 import { getBootConfig } from "../config/boot-config";
 import { isAndroidLocalAgentUrl } from "../first-run/local-agent-token";
 import {
@@ -149,6 +150,7 @@ function readRuntimeMode(): string | null {
   } catch {
     // localStorage can be unavailable in tests and early native startup.
   }
+  if (hasStoredCloudSession()) return "cloud";
   const env = (
     import.meta as ImportMeta & {
       env?: Record<string, string | boolean | undefined>;
@@ -163,6 +165,16 @@ function readRuntimeMode(): string | null {
       ? env.VITE_ELIZA_MOBILE_RUNTIME_MODE.trim()
       : "";
   return androidRuntimeMode || mobileRuntimeMode || null;
+}
+
+function hasStoredCloudSession(): boolean {
+  try {
+    return Boolean(readStoredStewardToken()?.trim());
+  } catch {
+    // error-policy:J4 token storage is a capability probe here; failing closed
+    // lets explicit local-mode config keep the native transport available.
+    return false;
+  }
 }
 
 function configuredApiBaseIsAndroidLocal(): boolean {
@@ -204,7 +216,22 @@ function shouldBridgeFetchUrl(url: URL, rawUrl: string): boolean {
     return true;
   }
   if (!url.pathname.startsWith("/api/")) return false;
+  if (!isSameOriginFetchTarget(url)) return false;
+  if (hasStoredCloudSession()) return readRuntimeMode() === "local";
   return readRuntimeMode() === "local" || configuredApiBaseIsAndroidLocal();
+}
+
+function isSameOriginFetchTarget(url: URL): boolean {
+  if (typeof window === "undefined") return true;
+  try {
+    const locationOrigin =
+      window.location.origin || new URL(window.location.href).origin;
+    return url.origin === locationOrigin;
+  } catch {
+    // error-policy:J3 malformed/missing window.location means this is not a
+    // confidently same-origin request, so do not bridge it to local IPC.
+    return false;
+  }
 }
 
 function localAgentUrlForFetch(url: URL, rawUrl: string): string {

--- a/packages/ui/src/first-run/use-first-run-conductor.test.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.test.ts
@@ -119,6 +119,7 @@ vi.mock("../state/cloud-login-launch", async (importOriginal) => {
 });
 
 import type { ConversationMessage, LocalAgentBackupMetadata } from "../api";
+import { APP_RESUME_EVENT } from "../events";
 import { __setAppValueForTests } from "../state/app-store";
 import {
   ConversationMessagesCtx,
@@ -1645,6 +1646,44 @@ describe("cloud-only onboarding (runtime chooser off — the production default)
       },
       { timeout: 3_000 },
     );
+    await waitFor(
+      () => {
+        expect(spies.completeFirstRun).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 3_000 },
+    );
+    await waitForTurn(turn, "first-run:cloud-done");
+    unmount();
+  });
+
+  it("native resume re-checks a Steward token that landed while sign-in was busy", async () => {
+    localStorage.removeItem("steward_session_token");
+    mocks.client.getCloudStatus.mockResolvedValue({ connected: false });
+    let finishLogin: () => void = () => {};
+    const handleCloudLogin = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishLogin = resolve;
+        }),
+    );
+    const spies = seedAppStore({
+      elizaCloudConnected: false,
+      handleCloudLogin,
+    });
+    const { turn, unmount } = renderConductor();
+    await waitForTurn(turn, "first-run:greeting");
+
+    expect(tryHandleFirstRunAction("__first_run__:runtime:cloud")).toBe(true);
+    await waitFor(() => {
+      expect(handleCloudLogin).toHaveBeenCalledTimes(1);
+    });
+    localStorage.setItem("steward_session_token", "cloud-token");
+    await new Promise((resolve) => setTimeout(resolve, 650));
+    expect(spies.completeFirstRun).not.toHaveBeenCalled();
+
+    finishLogin();
+    document.dispatchEvent(new Event(APP_RESUME_EVENT));
+
     await waitFor(
       () => {
         expect(spies.completeFirstRun).toHaveBeenCalledTimes(1);

--- a/packages/ui/src/first-run/use-first-run-conductor.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.ts
@@ -71,6 +71,7 @@ import {
   getCloudAuthToken,
   refreshCloudStewardSession,
 } from "../api/client-cloud";
+import { APP_RESUME_EVENT } from "../events";
 import { ACCENT_PRESETS, useAppSelectorShallow } from "../state";
 import { useConversationMessages } from "../state/ConversationMessagesContext.hooks";
 import { preOpenCloudLoginWindow } from "../state/cloud-login-launch";
@@ -1342,6 +1343,25 @@ export function useFirstRunConductor(): void {
       pendingCloudResumeRef.current = "cloud";
       let tokenPoll: ReturnType<typeof setInterval> | null = null;
       let cancelled = false;
+      const stopTokenPoll = () => {
+        if (tokenPoll) clearInterval(tokenPoll);
+        tokenPoll = null;
+      };
+      const resumeStoredToken = () => {
+        if (provisionedRef.current) {
+          stopTokenPoll();
+          return;
+        }
+        if (busyRef.current || bindInFlightRef.current) return;
+        if (!hasUsableStoredStewardToken()) return;
+        stopTokenPoll();
+        seedTurn(makeTurn("first-run:cloud-signin", CLOUD_WELCOME_BACK));
+        runCloudResumeRef.current("cloud");
+      };
+      const startTokenPoll = () => {
+        if (tokenPoll) return;
+        tokenPoll = setInterval(resumeStoredToken, 500);
+      };
       // Degrade target shared by the no-session path and a failed cookie
       // recovery: the sign-in greeting plus a cheap localStorage poll. A
       // usable session can LAND after mount without any elizaCloudConnected
@@ -1359,21 +1379,19 @@ export function useFirstRunConductor(): void {
             `${CLOUD_SIGN_IN_GREETING}\n\n${CLOUD_SIGN_IN_CHOICE}`,
           ),
         );
-        tokenPoll = setInterval(() => {
-          if (
-            busyRef.current ||
-            bindInFlightRef.current ||
-            provisionedRef.current
-          ) {
-            if (tokenPoll) clearInterval(tokenPoll);
-            return;
-          }
-          if (!hasUsableStoredStewardToken()) return;
-          if (tokenPoll) clearInterval(tokenPoll);
-          seedTurn(makeTurn("first-run:cloud-signin", CLOUD_WELCOME_BACK));
-          runCloudResumeRef.current("cloud");
-        }, 500);
+        startTokenPoll();
       };
+      const onNativeResume = () => {
+        if (cancelled) return;
+        startTokenPoll();
+        resumeStoredToken();
+      };
+      const onVisibilityChange = () => {
+        if (typeof document !== "undefined" && document.hidden) return;
+        onNativeResume();
+      };
+      document.addEventListener(APP_RESUME_EVENT, onNativeResume);
+      document.addEventListener("visibilitychange", onVisibilityChange);
       if (elizaCloudConnectedRef.current || hasUsableStoredStewardToken()) {
         silentCloudEntryRef.current = true;
         runCloudResumeRef.current("cloud");
@@ -1427,7 +1445,9 @@ export function useFirstRunConductor(): void {
       }
       return () => {
         cancelled = true;
-        if (tokenPoll) clearInterval(tokenPoll);
+        stopTokenPoll();
+        document.removeEventListener(APP_RESUME_EVENT, onNativeResume);
+        document.removeEventListener("visibilitychange", onVisibilityChange);
         setFirstRunActionHandler(null);
         setFirstRunTextHandler(null);
       };

--- a/packages/ui/src/state/useCloudState.same-tab-login.test.tsx
+++ b/packages/ui/src/state/useCloudState.same-tab-login.test.tsx
@@ -313,6 +313,59 @@ describe("useCloudState — handleCloudLogin same-tab fallback on hosted web", (
     }
   });
 
+  it("does one final direct cloud poll at the timeout boundary before timing out", async () => {
+    vi.useFakeTimers();
+    const popup = {
+      closed: false,
+      close: vi.fn(() => {
+        (popup as { closed: boolean }).closed = true;
+      }),
+      location: { href: "" },
+      opener: {},
+    } as unknown as Window;
+    vi.spyOn(window, "open").mockReturnValue(popup);
+    cloudLoginDirectSpy.mockResolvedValue({
+      ok: true,
+      apiBase: "https://api.elizacloud.ai",
+      browserUrl: "https://elizacloud.ai/auth/cli-login?session=sess-last",
+      sessionId: "sess-last",
+    });
+    cloudLoginPollDirectSpy.mockResolvedValue({
+      status: "authenticated",
+      token: "last-poll-token",
+      userId: "user-1",
+    });
+
+    try {
+      const { result, unmount } = renderHook(() => useCloudState(makeParams()));
+      let login: Promise<void> = Promise.resolve();
+      await act(async () => {
+        login = result.current.handleCloudLogin(popup);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300_000);
+        await login;
+      });
+
+      expect(cloudLoginPollDirectSpy).toHaveBeenCalledWith(
+        "https://api.elizacloud.ai",
+        "sess-last",
+      );
+      expect(localStorage.getItem("steward_session_token")).toBe(
+        "last-poll-token",
+      );
+      expect(result.current.elizaCloudLoginError).toBeNull();
+
+      unmount();
+      vi.clearAllTimers();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("uses a closeable named popup for localhost direct cloud login without a pre-opened handle", async () => {
     vi.useFakeTimers();
     Object.defineProperty(window, "location", {

--- a/packages/ui/src/state/useCloudState.ts
+++ b/packages/ui/src/state/useCloudState.ts
@@ -946,12 +946,6 @@ export function useCloudState({
         // Start polling
         elizaCloudLoginPollTimer.current = window.setInterval(async () => {
           if (!elizaCloudLoginPollTimer.current || pollInFlight) return;
-          if (Date.now() >= pollDeadline) {
-            stopCloudLoginPolling(
-              "Eliza Cloud login timed out. Please try again.",
-            );
-            return;
-          }
 
           pollInFlight = true;
           try {
@@ -1028,6 +1022,10 @@ export function useCloudState({
             } else if (poll.status === "expired" || poll.status === "error") {
               stopCloudLoginPolling(
                 poll.error ?? "Login session expired. Please try again.",
+              );
+            } else if (Date.now() >= pollDeadline) {
+              stopCloudLoginPolling(
+                "Eliza Cloud login timed out. Please try again.",
               );
             }
           } catch (pollErr) {


### PR DESCRIPTION
## Summary
- keep Android /api fetch bridging from falling back to local IPC when no runtime mode is persisted but a Steward cloud session exists
- prevent absolute cloud-origin /api requests from being hijacked by the Android local-agent bridge
- re-arm cloud-only first-run token resume on native foreground/visibility resume and perform one final cloud-login poll at the timeout boundary

Fixes #15539.

## Verification
- bun run --cwd packages/ui test src/api/android-native-agent-transport.test.ts src/first-run/use-first-run-conductor.test.ts src/state/useCloudState.same-tab-login.test.tsx
- bun run --cwd packages/ui typecheck
- bun run audit:error-policy-ratchet
- bunx biome check packages/ui/src/api/android-native-agent-transport.ts packages/ui/src/api/android-native-agent-transport.test.ts packages/ui/src/first-run/use-first-run-conductor.ts packages/ui/src/first-run/use-first-run-conductor.test.ts packages/ui/src/state/useCloudState.ts packages/ui/src/state/useCloudState.same-tab-login.test.tsx
- git diff --check