### PR TITLE
fix(cloud): preserve retry budget for transport-unresolved provisions

### DIFF
--- a/packages/cloud/shared/src/db/repositories/jobs.ts
+++ b/packages/cloud/shared/src/db/repositories/jobs.ts
@@ -633,6 +633,44 @@ export class JobsRepository {
   }
 
   /**
+   * Requeues a job after a transient worker-side ambiguity without consuming
+   * its finite retry budget. This is for cases where the job left the target
+   * resource in a recoverable in-between state and a later worker pass should
+   * re-check/adopt that state instead of counting it as a failed attempt.
+   */
+  async retryLaterWithoutIncrementingAttempts(
+    id: string,
+    error: string,
+    delayMs: number,
+  ): Promise<Job | undefined> {
+    const job = await this.findById(id);
+    if (!job) return undefined;
+
+    const scheduledFor = new Date(Date.now() + delayMs);
+    const payload = await prepareJobPayload(
+      { error },
+      {
+        id: job.id,
+        organization_id: job.organization_id,
+        created_at: job.created_at,
+      },
+    );
+
+    const [updated] = await dbWrite
+      .update(jobs)
+      .set({
+        status: "pending",
+        ...payload,
+        updated_at: new Date(),
+        scheduled_for: scheduledFor,
+      })
+      .where(eq(jobs.id, id))
+      .returning();
+
+    return updated ? await hydrateJob(updated) : undefined;
+  }
+
+  /**
    * Deletes a job.
    *
    * @param id - Job ID to delete.

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-delete-lifecycle.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-delete-lifecycle.test.ts
@@ -33,7 +33,13 @@ function makeJob(type: ProvisioningJobType, extraData: Record<string, unknown> =
     id: "44444444-4444-4444-8444-444444444444",
     type,
     status: "in_progress",
-    data: { agentId: AGENT, organizationId: ORG, userId: USER, ...extraData },
+    data: {
+      agentId: AGENT,
+      organizationId: ORG,
+      userId: USER,
+      agentName: "Test Agent",
+      ...extraData,
+    },
     data_storage: "inline",
     data_key: null,
     agent_id: AGENT,
@@ -74,6 +80,10 @@ function withClaimedJob(type: ProvisioningJobType, extraData: Record<string, unk
   const updateStatusSpy = spyOn(jobsRepository, "updateStatus").mockResolvedValue(undefined);
   const updateSpy = spyOn(jobsRepository, "update").mockResolvedValue(undefined as never);
   const incrementSpy = spyOn(jobsRepository, "incrementAttempt").mockResolvedValue(undefined);
+  const retryLaterSpy = spyOn(
+    jobsRepository,
+    "retryLaterWithoutIncrementingAttempts",
+  ).mockResolvedValue(undefined);
   return {
     job,
     claimSpy,
@@ -81,12 +91,14 @@ function withClaimedJob(type: ProvisioningJobType, extraData: Record<string, unk
     updateStatusSpy,
     updateSpy,
     incrementSpy,
+    retryLaterSpy,
     restore() {
       claimSpy.mockRestore();
       recoverSpy.mockRestore();
       updateStatusSpy.mockRestore();
       updateSpy.mockRestore();
       incrementSpy.mockRestore();
+      retryLaterSpy.mockRestore();
     },
   };
 }
@@ -132,6 +144,56 @@ describe("ProvisioningJobService — Agent-not-found is a terminal no-op", () =>
       }
     });
   }
+});
+
+describe("ProvisioningJobService — retryable readiness transport does not burn attempts", () => {
+  test("agent_provision retryable false-negative is requeued without terminal failure", async () => {
+    const ctx = withClaimedJob(JOB_TYPES.AGENT_PROVISION);
+    const svcSpy = spyOn(elizaSandboxService, "provision").mockResolvedValue({
+      success: false,
+      retryable: true,
+      error: "readiness probe transport_unresolved",
+      sandboxRecord: {
+        id: AGENT,
+        organization_id: ORG,
+        user_id: USER,
+        status: "provisioning",
+      },
+    } as never);
+
+    try {
+      const res = await provisioningJobService.processPendingJobs(1, {
+        jobTypes: [JOB_TYPES.AGENT_PROVISION],
+      });
+
+      expect(res.claimed).toBe(1);
+      expect(res.succeeded).toBe(0);
+      expect(res.retried).toBe(1);
+      expect(res.failed).toBe(0);
+      expect(ctx.updateSpy).toHaveBeenCalledWith(
+        ctx.job.id,
+        expect.objectContaining({
+          result: expect.objectContaining({
+            cloudAgentId: AGENT,
+            status: "provisioning",
+            error: "readiness probe transport_unresolved",
+          }),
+        }),
+      );
+      expect(ctx.retryLaterSpy).toHaveBeenCalledTimes(1);
+      expect(ctx.retryLaterSpy.mock.calls[0]?.[0]).toBe(ctx.job.id);
+      expect(ctx.retryLaterSpy.mock.calls[0]?.[1]).toBe("readiness probe transport_unresolved");
+      expect(ctx.incrementSpy).not.toHaveBeenCalled();
+      expect(ctx.updateStatusSpy).not.toHaveBeenCalledWith(
+        ctx.job.id,
+        "completed",
+        expect.anything(),
+      );
+    } finally {
+      svcSpy.mockRestore();
+      ctx.restore();
+    }
+  });
 });
 
 describe("ProvisioningJobService — auto snapshot of an idle agent is a terminal SKIP", () => {

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -739,6 +739,7 @@ const COLD_BOOT_JOB_TYPES: ReadonlySet<ProvisioningJobType> = new Set([
   JOB_TYPES.AGENT_UPGRADE,
   JOB_TYPES.AGENT_DOWNGRADE,
 ]);
+const PROVISION_TRANSPORT_RETRY_DELAY_MS = 2 * 60 * 1000;
 
 /**
  * Per-job execution timeout for the `withTimeout(executeJob(job), …)` wrap,
@@ -830,6 +831,13 @@ export class UpgradeFailedError extends Error {
     this.name = "UpgradeFailedError";
     this.rolledBack = opts.rolledBack;
     this.toDigest = opts.toDigest;
+  }
+}
+
+class RetryableProvisionTransportError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RetryableProvisionTransportError";
   }
 }
 
@@ -1649,6 +1657,7 @@ export class ProvisioningJobService {
     const result: ProcessingResult = {
       claimed: 0,
       succeeded: 0,
+      retried: 0,
       failed: 0,
       errors: [],
     };
@@ -1731,9 +1740,25 @@ export class ProvisioningJobService {
         );
         result.succeeded++;
       } catch (err) {
-        result.failed++;
         const errorMsg = err instanceof Error ? err.message : String(err);
         result.errors.push({ jobId: job.id, error: errorMsg });
+
+        if (err instanceof RetryableProvisionTransportError) {
+          result.retried++;
+          await jobsRepository.retryLaterWithoutIncrementingAttempts(
+            job.id,
+            errorMsg,
+            PROVISION_TRANSPORT_RETRY_DELAY_MS,
+          );
+          logger.warn("[provisioning-jobs] Requeued retryable provision transport failure", {
+            jobId: job.id,
+            delayMs: PROVISION_TRANSPORT_RETRY_DELAY_MS,
+            error: errorMsg,
+          });
+          continue;
+        }
+
+        result.failed++;
 
         // When retries are exhausted (permanent failure) the dependent
         // status row must flip too — and it must flip ATOMICALLY with the
@@ -2836,6 +2861,9 @@ export class ProvisioningJobService {
           error: provResult.error,
         }),
       });
+      if (provResult.retryable) {
+        throw new RetryableProvisionTransportError(provResult.error);
+      }
       throw new Error(provResult.error);
     }
 
@@ -3292,6 +3320,7 @@ export interface RecoveryResult {
 export interface ProcessingResult {
   claimed: number;
   succeeded: number;
+  retried: number;
   failed: number;
   errors: Array<{ jobId: string; error: string }>;
 }


### PR DESCRIPTION
Fixes the residual #15310 / #15377 retry-budget hole where `elizaSandboxService.provision()` correctly returned `retryable: true` for a readiness-probe `transport_unresolved`, but the generic job catch still called `incrementAttempt()`. After enough transient transport false-negatives, the job could exhaust max attempts and terminally mark the sandbox `error` even though the container handle was intentionally preserved for retry/reconciliation.

Changes:
- adds `jobsRepository.retryLaterWithoutIncrementingAttempts()` for transient ambiguous worker outcomes
- routes only retryable `agent_provision` transport failures through that path
- records the provisioning result, exposes `retried` in the processing summary, and keeps real failures on the existing `incrementAttempt()` path
- adds a regression test proving retryable provision false-negatives do not call `incrementAttempt()`

Verification:
- `node packages/shared/scripts/generate-keywords.mjs --target ts` (local generated test prerequisite only)
- `bun test packages/cloud/shared/src/lib/services/provisioning-jobs-delete-lifecycle.test.ts packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts packages/cloud/shared/src/lib/services/provisioning-jobs-stuck-reconcile.test.ts` — 108 pass, 0 fail
- `bunx biome check packages/cloud/shared/src/lib/services/provisioning-jobs.ts packages/cloud/shared/src/lib/services/provisioning-jobs-delete-lifecycle.test.ts packages/cloud/shared/src/db/repositories/jobs.ts`
- `bun run --cwd packages/cloud/shared typecheck`
- `bun run audit:error-policy-ratchet`
- `git diff --check`
