### PR TITLE
fix(cloud): guard docker node scheduling by environment

### DIFF
--- a/packages/cloud/api/v1/admin/docker-nodes/bootstrap-callback/route.ts
+++ b/packages/cloud/api/v1/admin/docker-nodes/bootstrap-callback/route.ts
@@ -1,4 +1,6 @@
-// Handles admin cloud API v1 admin docker nodes bootstrap callback route traffic with privileged auth expectations.
+/**
+ * Registers Docker node bootstrap callbacks from provisioned control-plane hosts.
+ */
 import { Hono } from "hono";
 
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -27,7 +29,10 @@ import type { AppEnv } from "@/types/cloud-worker-env";
  */
 
 import { z } from "zod";
-import { dockerNodesRepository } from "@/db/repositories/docker-nodes";
+import {
+  dockerNodesRepository,
+  stampDockerNodeEnvironmentMetadata,
+} from "@/db/repositories/docker-nodes";
 import { logger } from "@/lib/utils/logger";
 
 const callbackSchema = z.object({
@@ -160,10 +165,10 @@ async function __hono_POST(request: Request) {
           ? existing.host_key_fingerprint
           : hostKeyFingerprint,
         status: "unknown",
-        metadata: {
+        metadata: stampDockerNodeEnvironmentMetadata({
           ...((existing.metadata as Record<string, unknown>) ?? {}),
           lastBootstrapAt: new Date().toISOString(),
-        },
+        }),
       });
       logger.info(
         "[admin/docker-nodes/bootstrap-callback] re-bootstrapped existing node",
@@ -193,10 +198,10 @@ async function __hono_POST(request: Request) {
       status: "unknown",
       allocated_count: 0,
       host_key_fingerprint: hostKeyFingerprint,
-      metadata: {
+      metadata: stampDockerNodeEnvironmentMetadata({
         provider: "operator-provisioned",
         bootstrappedAt: new Date().toISOString(),
-      },
+      }),
     });
     logger.info("[admin/docker-nodes/bootstrap-callback] registered new node", {
       nodeId,

--- a/packages/cloud/services/container-control-plane/src/index.ts
+++ b/packages/cloud/services/container-control-plane/src/index.ts
@@ -1,8 +1,13 @@
-// Owns container-control-plane index mutations that Cloudflare Workers cannot run.
+/**
+ * Owns container-control-plane index mutations that Cloudflare Workers cannot run.
+ */
 import { timingSafeEqual } from "node:crypto";
 import { agentSandboxesRepository } from "@elizaos/cloud-shared/db/repositories/agent-sandboxes";
 import { userCharactersRepository } from "@elizaos/cloud-shared/db/repositories/characters";
-import { dockerNodesRepository } from "@elizaos/cloud-shared/db/repositories/docker-nodes";
+import {
+  dockerNodesRepository,
+  stampDockerNodeEnvironmentMetadata,
+} from "@elizaos/cloud-shared/db/repositories/docker-nodes";
 import type { DockerNode } from "@elizaos/cloud-shared/db/schemas/docker-nodes";
 import {
   envelope,
@@ -607,7 +612,7 @@ async function mirrorControlPlaneNodes(nodes: DockerNode[]): Promise<void> {
       last_health_check: node.last_health_check,
       ssh_user: node.ssh_user,
       host_key_fingerprint: node.host_key_fingerprint,
-      metadata: node.metadata,
+      metadata: stampDockerNodeEnvironmentMetadata(node.metadata),
     };
 
     const existing = await dockerNodesRepository.findByNodeId(node.node_id);

--- a/packages/cloud/shared/src/db/repositories/docker-nodes.test.ts
+++ b/packages/cloud/shared/src/db/repositories/docker-nodes.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Exercises Docker node scheduling filters and metadata stamping without a live database.
+ */
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+import * as realHelpers from "../helpers";
+
+let capturedWhere: SQL | undefined;
+
+const limit = mock(() => []);
+const orderBy = mock(() => ({ limit }));
+const where = mock((clause: SQL) => {
+  capturedWhere = clause;
+  return { orderBy, limit };
+});
+const from = mock(() => ({ where }));
+const select = mock(() => ({ from }));
+
+let useRepositoryMocks = false;
+const dbReadMock = new Proxy(realHelpers.dbRead as unknown as Record<PropertyKey, unknown>, {
+  get(target, prop, receiver) {
+    if (prop === "select" && useRepositoryMocks) return select;
+    return Reflect.get(target, prop, receiver);
+  },
+});
+
+mock.module("../helpers", () => ({
+  ...realHelpers,
+  dbRead: dbReadMock,
+}));
+
+afterAll(() => {
+  mock.module("../helpers", () => realHelpers);
+});
+
+const originalEnvironment = process.env.ENVIRONMENT;
+
+describe("DockerNodesRepository environment guard", () => {
+  beforeEach(() => {
+    useRepositoryMocks = true;
+    capturedWhere = undefined;
+    process.env.ENVIRONMENT = "staging";
+  });
+
+  afterEach(() => {
+    useRepositoryMocks = false;
+    process.env.ENVIRONMENT = originalEnvironment;
+  });
+
+  test("stamps the current deployment environment without overwriting explicit provenance", async () => {
+    const { stampDockerNodeEnvironmentMetadata } = await import("./docker-nodes");
+
+    expect(stampDockerNodeEnvironmentMetadata({ provider: "operator" })).toEqual({
+      provider: "operator",
+      environment: "staging",
+    });
+    expect(
+      stampDockerNodeEnvironmentMetadata({
+        provider: "operator",
+        environment: "production",
+      }),
+    ).toEqual({
+      provider: "operator",
+      environment: "production",
+    });
+  });
+
+  test("findEnabled excludes nodes stamped for a different deployment environment", async () => {
+    const { DockerNodesRepository } = await import("./docker-nodes");
+
+    await new DockerNodesRepository().findEnabled();
+
+    if (!capturedWhere) throw new Error("findEnabled did not build a where clause");
+    const sql = new PgDialect().sqlToQuery(capturedWhere).sql.toLowerCase();
+    expect(sql).toContain("enabled");
+    expect(sql).toContain("metadata");
+    expect(sql).toContain("->>'environment'");
+    expect(sql).toContain("coalesce");
+    expect(sql).toContain("= ''");
+  });
+
+  test("findLeastLoaded applies the same environment guard to schedulable capacity", async () => {
+    const { DockerNodesRepository } = await import("./docker-nodes");
+
+    await new DockerNodesRepository().findLeastLoaded();
+
+    if (!capturedWhere) throw new Error("findLeastLoaded did not build a where clause");
+    const sql = new PgDialect().sqlToQuery(capturedWhere).sql.toLowerCase();
+    expect(sql).toContain("status");
+    expect(sql).toContain("allocated_count");
+    expect(sql).toContain("capacity");
+    expect(sql).toContain("metadata");
+    expect(sql).toContain("->>'environment'");
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/docker-nodes.ts
+++ b/packages/cloud/shared/src/db/repositories/docker-nodes.ts
@@ -1,4 +1,6 @@
-// Persists docker nodes records for cloud services through the shared DB boundary.
+/**
+ * Persists Docker node records for cloud scheduling and control-plane health.
+ */
 import { and, asc, eq, sql } from "drizzle-orm";
 import { logger } from "../../lib/utils/logger";
 import { dbRead, dbWrite } from "../helpers";
@@ -10,6 +12,33 @@ import {
 } from "../schemas/docker-nodes";
 
 export type { DockerNode, DockerNodeStatus, NewDockerNode };
+
+function currentDeploymentEnvironment(): string | null {
+  const env = typeof process !== "undefined" ? process.env.ENVIRONMENT?.trim() : undefined;
+  return env ? env : null;
+}
+
+export function stampDockerNodeEnvironmentMetadata(
+  metadata: Record<string, unknown> | null | undefined,
+  environment: string | null = currentDeploymentEnvironment(),
+): Record<string, unknown> {
+  const base =
+    metadata && typeof metadata === "object" && !Array.isArray(metadata) ? { ...metadata } : {};
+  const existing = base.environment;
+  if (!environment || (typeof existing === "string" && existing.trim().length > 0)) {
+    return base;
+  }
+  return { ...base, environment };
+}
+
+function currentEnvironmentPredicate() {
+  const environment = currentDeploymentEnvironment();
+  if (!environment) return sql`TRUE`;
+  return sql`(
+    COALESCE(${dockerNodes.metadata}->>'environment', '') = ''
+    OR ${dockerNodes.metadata}->>'environment' = ${environment}
+  )`;
+}
 
 export class DockerNodesRepository {
   // ============================================================================
@@ -24,7 +53,7 @@ export class DockerNodesRepository {
     return dbRead
       .select()
       .from(dockerNodes)
-      .where(eq(dockerNodes.enabled, true))
+      .where(and(eq(dockerNodes.enabled, true), currentEnvironmentPredicate()))
       .orderBy(asc(dockerNodes.node_id));
   }
 
@@ -54,6 +83,7 @@ export class DockerNodesRepository {
         and(
           eq(dockerNodes.enabled, true),
           eq(dockerNodes.status, "healthy"),
+          currentEnvironmentPredicate(),
           sql`${dockerNodes.allocated_count} < ${dockerNodes.capacity}`,
         ),
       )

--- a/packages/scripts/cloud/admin/onboard-docker-node.ts
+++ b/packages/scripts/cloud/admin/onboard-docker-node.ts
@@ -46,7 +46,7 @@ import { fileURLToPath } from "node:url";
 // drag in the Drizzle / plugin-sql DB stack.
 async function loadDeps() {
   const [
-    { dockerNodesRepository },
+    { dockerNodesRepository, stampDockerNodeEnvironmentMetadata },
     { ensureRegistryAccess },
     dockerUtils,
     { DockerSSHClient },
@@ -60,6 +60,7 @@ async function loadDeps() {
   ]);
   return {
     dockerNodesRepository,
+    stampDockerNodeEnvironmentMetadata,
     ensureRegistryAccess,
     buildEnsureNetworkCmd: dockerUtils.buildEnsureNetworkCmd,
     shellQuote: dockerUtils.shellQuote,
@@ -258,6 +259,7 @@ async function main(): Promise<void> {
 
   const {
     dockerNodesRepository,
+    stampDockerNodeEnvironmentMetadata,
     ensureRegistryAccess,
     buildEnsureNetworkCmd,
     shellQuote,
@@ -358,11 +360,11 @@ async function main(): Promise<void> {
           existing,
           capturedFingerprint,
         ),
-        metadata: {
+        metadata: stampDockerNodeEnvironmentMetadata({
           ...((existing.metadata as Record<string, unknown>) ?? {}),
           provider: "operator-onboarded",
           lastOnboardedAt: new Date().toISOString(),
-        },
+        }),
       });
       summary.push(`docker_nodes row updated (${args.nodeId})`);
     } else {
@@ -380,10 +382,10 @@ async function main(): Promise<void> {
           null,
           capturedFingerprint,
         ),
-        metadata: {
+        metadata: stampDockerNodeEnvironmentMetadata({
           provider: "operator-onboarded",
           onboardedAt: new Date().toISOString(),
-        },
+        }),
       });
       summary.push(`docker_nodes row created (${args.nodeId})`);
     }


### PR DESCRIPTION
## Summary
- stamp docker node metadata with the current deployment environment when nodes are onboarded, bootstrapped, or mirrored from the control plane
- make docker node scheduling queries ignore rows explicitly stamped for another environment while preserving legacy untagged rows
- add repository regression coverage for stamping and scheduler SQL guards

Fixes part of #15401.

## Verification
- node packages/shared/scripts/generate-keywords.mjs --target ts
- bunx biome check packages/cloud/shared/src/db/repositories/docker-nodes.ts packages/cloud/shared/src/db/repositories/docker-nodes.test.ts packages/cloud/services/container-control-plane/src/index.ts packages/cloud/api/v1/admin/docker-nodes/bootstrap-callback/route.ts packages/scripts/cloud/admin/onboard-docker-node.ts
- bun test packages/cloud/shared/src/db/repositories/docker-nodes.test.ts packages/scripts/cloud/admin/onboard-docker-node.test.ts packages/cloud/api/__tests__/bootstrap-callback-node-identity.test.ts -- 33 pass, 0 fail
- bun run --cwd packages/cloud/shared typecheck
- bun run audit:error-policy-ratchet
- git diff --check

Attempted: bun run --cwd packages/cloud/services/container-control-plane typecheck. It fails before this change on duplicate Drizzle type instances from the package graph (`drizzle-orm@0.45.2+4eb8acfd` vs `drizzle-orm@0.45.2+f55f2d`) in shared repository types.