### PR TITLE
fix(ci): align Stripe webhook test API version

### DIFF
--- a/packages/cloud/api/__tests__/stripe-connect-webhook-route.test.ts
+++ b/packages/cloud/api/__tests__/stripe-connect-webhook-route.test.ts
@@ -1,4 +1,6 @@
-// Exercises cloud API tests stripe connect webhook route.test behavior with deterministic Worker route fixtures.
+/**
+ * Exercises the Stripe Connect webhook route with deterministic Worker route fixtures.
+ */
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 // The REAL Stripe SDK — used (un-mocked) in the "real crypto" suite below to
 // prove the actual signature verification the route relies on rejects forgeries.
@@ -240,7 +242,7 @@ describe("Stripe Connect payout webhook route", () => {
 // issue describes (#10117). Signature ops are local HMAC-SHA256 — no network.
 describe("Stripe Connect webhook — real signature verification (no mock)", () => {
   const realStripe = new Stripe("sk_test_dummy_for_signature_only", {
-    apiVersion: "2026-06-24.dahlia",
+    apiVersion: "2026-05-27.dahlia",
   });
   const secret = "whsec_connect_realtest";
   const payload = JSON.stringify(accountUpdatedEvent);


### PR DESCRIPTION
## Summary
- align the Stripe Connect webhook real-crypto test helper with the Stripe SDK constructor API version accepted by the current lockfile
- keep the route behavior unchanged; this fixes the `@elizaos/cloud-api` typecheck failure seen in Develop PR run `28983316386`
- update the touched test file header to the repository comment format

## Verification
- `node packages/shared/scripts/generate-keywords.mjs --target ts`
- `bun run --cwd packages/cloud/api build`
- `bunx biome check packages/cloud/api/__tests__/stripe-connect-webhook-route.test.ts`
- `git diff --check`
- `bun run audit:error-policy-ratchet`
- `bun test packages/cloud/api/__tests__/stripe-connect-webhook-route.test.ts` showed 13 passing assertions, then the repo-forced coverage table hit Bun internal `WriteFailed` on this terminal; reran with a temporary no-coverage bun config and the focused test command exited 0.

Attempted `bun run --cwd packages/cloud/api typecheck`; the TypeScript half passed, then `check:worker-bundle` failed locally because `wrangler` is not installed on PATH in this worktree.

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - backend test-only CI typecheck fix; no rendered UI surface changed`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - backend test-only CI typecheck fix; no rendered UI surface changed`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no user-facing flow changed; this only aligns a test helper literal with installed Stripe SDK types`.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no runtime endpoint behavior changed; compile failure was in a local webhook-signature test helper`.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend code or browser flow changed`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no model, prompt, provider, action, or trajectory behavior changed`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no Stripe account, payout, DB row, or external webhook artifact changed; the focused local webhook HMAC test assertions passed`.