### PR TITLE
fix(agent-image): crash-scan must also ignore the resolver's 'Could not load plugin' shape

### DIFF
--- a/packages/app-core/scripts/docker-ci-smoke.sh
+++ b/packages/app-core/scripts/docker-ci-smoke.sh
@@ -392,13 +392,17 @@ boot_verify() {
     local pattern
     # Optional-plugin load failures are non-fatal BY DESIGN (plugin-resolver
     # catches them and boot continues): their warn text embeds the loader error
-    # ("Optional plugin X failed to load: Cannot find package ..." and the
-    # "Failed plugins: X (...)" summary), which would false-match the crash
-    # signatures below and kill a healthy boot. Filter those lines out before
-    # scanning; a REAL boot crash still trips the signatures on its own lines
-    # and is additionally caught by the container-exit and health-probe gates.
+    # ("Optional plugin X failed to load: Cannot find package ...",
+    # "Could not load plugin X: Cannot find package ..." — the resolver's other
+    # message shape, which false-killed the main image build when
+    # plugin-task-coordinator hit the @elizaos/ui -> @capacitor/core import
+    # leak — and the "Failed plugins: X (...)" summary), which would
+    # false-match the crash signatures below and kill a healthy boot. Filter
+    # those lines out before scanning; a REAL boot crash still trips the
+    # signatures on its own lines and is additionally caught by the
+    # container-exit and health-probe gates.
     local filtered_file="$SMOKE_ARTIFACT_DIR/container-scan.log"
-    grep -viE 'Optional plugin .* failed to load|Failed plugins:' "$logs_file" >"$filtered_file" 2>/dev/null || cp "$logs_file" "$filtered_file" 2>/dev/null || true
+    grep -viE 'Optional plugin .* failed to load|Could not load plugin|skipped after [0-9]+ms: module unavailable|Failed plugins:' "$logs_file" >"$filtered_file" 2>/dev/null || cp "$logs_file" "$filtered_file" 2>/dev/null || true
     for pattern in "${BOOT_CRASH_PATTERNS[@]}"; do
       if grep -qiF "$pattern" "$filtered_file" 2>/dev/null; then
         printf '%s' "$pattern"


### PR DESCRIPTION
## Problem

The **main-branch `Build Agent Image` run failed** ([28983153923](https://github.com/elizaOS/eliza/actions/runs/28983153923)) — this is the `:stable` rebuild that finally carries the #15228 PGlite-lock + crash-scan fixes, i.e. the image the fleet rollout is waiting on.

The docker-ci-smoke crash-scan matched `Cannot find package` inside a **non-fatal, by-design optional-plugin skip**:

```
Info [eliza] Could not load plugin @elizaos/plugin-task-coordinator: Cannot find package '@capacitor/core' imported from /app/packages/ui/dist/first-run/local-agent-token.js
Warn [boot] @elizaos/plugin-task-coordinator skipped after 94ms: module unavailable
```

Boot continued right past it (subsequent plugins kept loading). This is the exact false-kill class 61a7ee2b924 fixed — but that filter only covers the `Optional plugin .* failed to load` message shape, not the resolver's `Could not load plugin ...` shape.

## Fix

Add `Could not load plugin` + the paired `skipped after Nms: module unavailable` warn to the scan filter. Verified with the actual log lines: benign shapes filtered, while a real top-level `Cannot find package` crash line still matches; container-exit and health-probe gates remain the backstops.

## Follow-up (separate)

The underlying leak — `plugin-task-coordinator` importing the `@elizaos/ui` barrel, which statically evaluates `@capacitor/core` in a Node context — silently costs cloud agents the task coordinator. Tracked as its own fix (Node-safe subpath export or lazy capacitor import).

After merge this needs to reach `main` via the next promote so the `:stable` image build goes green (#15228 rollout unblock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - CI shell smoke filter only; no rendered UI surface changes`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - CI shell smoke filter only; no rendered UI surface changes`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - CI shell smoke filter only; no user-facing UI flow`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - this PR filters known benign boot log lines; failing Build Agent Image log excerpt and benign lines are included in the PR problem statement`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend runtime changes`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no agent/action/provider/prompt/model behavior changes`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - no domain artifacts; docker smoke log-shape verification is the relevant artifact`.

# Testing

The PR body includes the actual failing Build Agent Image log shape and describes the local log-filter check: benign `Could not load plugin ... Cannot find package ...` and `skipped after Nms: module unavailable` lines are filtered while a real top-level `Cannot find package` crash line still matches. Existing PR checks also show Develop PR lint/build and coverage-gate passed; typecheck was still running when this evidence row was patched.

# Known gaps / failures

Full repo `bun run verify` was not run for this shell-filter-only PR. The remaining Develop PR typecheck job was still running at patch time; merging is proceeding under the standing instruction not to block on build/check completion.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots `N/A - CI shell-script change (docker-ci-smoke.sh crash-scan filter), no UI surface`.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots `N/A - CI shell-script change, no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video `N/A - one-line grep filter change in a CI gate script`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs `N/A - no backend runtime change; the failing signal is the main-branch Build Agent Image run 28983153923, whose container log lines ("Could not load plugin @elizaos/plugin-task-coordinator: Cannot find package ..." followed by continued healthy boot) are quoted verbatim in the PR description, and the filter behavior was verified by piping those exact lines through the new grep (benign lines filtered, real top-level crash line still matches)`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory `N/A - CI infrastructure change, no agent/LLM behavior involved`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts `N/A - the artifact is the crash-scan filter itself; bash -n syntax check + the grep verification in the description are the domain proof`.
