### PR TITLE
fix(ci): match coverage gate paths exactly

### DIFF
--- a/scripts/security/coverage-gate.awk
+++ b/scripts/security/coverage-gate.awk
@@ -15,8 +15,26 @@ BEGIN {
   # Split changed files into a lookup table.
   n = split(changed, parts, "\n")
   for (i = 1; i <= n; i++) {
-    if (parts[i] != "") changed_map[parts[i]] = 1
+    if (parts[i] != "") {
+      gsub(/\\/, "/", parts[i])
+      changed_map[parts[i]] = 1
+    }
   }
+}
+
+function path_matches_lcov(current_path, changed_path,    current_len, changed_len, prefix_len) {
+  gsub(/\\/, "/", current_path)
+  gsub(/\\/, "/", changed_path)
+  if (current_path == changed_path) return 1
+
+  current_len = length(current_path)
+  changed_len = length(changed_path)
+  if (current_len <= changed_len) return 0
+
+  prefix_len = current_len - changed_len
+  return \
+    substr(current_path, prefix_len + 1) == changed_path && \
+    substr(current_path, prefix_len, 1) == "/"
 }
 
 /^SF:/ {
@@ -39,11 +57,12 @@ BEGIN {
 /^end_of_record/ {
   if (lines_found > 0) {
     pct = (lines_hit / lines_found) * 100
-    # Check if this file is in changed list (suffix match, since lcov paths
-    # may be absolute and the changed list is relative).
+    # Check if this file is in changed list. LCOV paths may be absolute while
+    # the changed list is repo-relative, so accept only exact path-segment
+    # suffixes; raw substring matching lets foo.ts pass via foo.tsx.
     matched = ""
     for (cf in changed_map) {
-      if (index(current, cf) > 0) { matched = cf; break }
+      if (path_matches_lcov(current, cf)) { matched = cf; break }
     }
     if (matched != "") {
       changed_count++

--- a/scripts/security/coverage-gate.self-test.mjs
+++ b/scripts/security/coverage-gate.self-test.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * Regression checks for the changed-file LCOV matcher used by the coverage
+ * gate. The gate compares repo-relative changed paths with LCOV paths that may
+ * be absolute, so these cases pin the exact path-boundary behavior rather than
+ * a permissive substring match.
+ */
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const root = new URL("../..", import.meta.url).pathname;
+const awkScript = join(root, "scripts/security/coverage-gate.awk");
+
+function writeLcov(dir, sourcePath, found = 2, hit = 2) {
+  const file = join(dir, "lcov.info");
+  writeFileSync(
+    file,
+    [`SF:${sourcePath}`, `LF:${found}`, `LH:${hit}`, "end_of_record", ""].join(
+      "\n",
+    ),
+  );
+  return file;
+}
+
+function runGate({ changed, lcov, enforce = true, threshold = 50 }) {
+  return spawnSync(
+    "awk",
+    [
+      "-v",
+      `changed=${changed}`,
+      "-v",
+      `threshold=${threshold}`,
+      "-f",
+      awkScript,
+      lcov,
+    ],
+    {
+      cwd: root,
+      env: { ...process.env, COVERAGE_GATE_ENFORCE: enforce ? "1" : "" },
+      encoding: "utf8",
+    },
+  );
+}
+
+function assertGate(name, fn) {
+  try {
+    fn();
+    console.log(`ok - ${name}`);
+  } catch (error) {
+    console.error(`not ok - ${name}`);
+    throw error;
+  }
+}
+
+const dir = mkdtempSync(join(tmpdir(), "coverage-gate-"));
+try {
+  assertGate("matches identical repo-relative path", () => {
+    const lcov = writeLcov(dir, "packages/demo/src/foo.ts");
+    const result = runGate({ changed: "packages/demo/src/foo.ts", lcov });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /coverage gate OK/);
+  });
+
+  assertGate("matches absolute LCOV path at path boundary", () => {
+    const lcov = writeLcov(dir, "/workspace/eliza/packages/demo/src/foo.ts");
+    const result = runGate({ changed: "packages/demo/src/foo.ts", lcov });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /coverage gate OK/);
+  });
+
+  assertGate("does not match similar filename substring", () => {
+    const lcov = writeLcov(dir, "/workspace/eliza/packages/demo/src/foo.tsx");
+    const result = runGate({ changed: "packages/demo/src/foo.ts", lcov });
+    assert.equal(result.status, 1, result.stdout);
+    assert.match(result.stdout, /changed source missing from LCOV/);
+  });
+
+  assertGate("does not match longer path segment prefix", () => {
+    const lcov = writeLcov(dir, "/workspace/eliza/packages/demo/src/notfoo.ts");
+    const result = runGate({ changed: "packages/demo/src/foo.ts", lcov });
+    assert.equal(result.status, 1, result.stdout);
+    assert.match(result.stdout, /changed source missing from LCOV/);
+  });
+} finally {
+  rmSync(dir, { recursive: true, force: true });
+}


### PR DESCRIPTION
# Relates to

Fixes part of #13620.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on the latest `origin/develop` available before PR update; rebased again after opening (`git fetch origin develop && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased onto latest `origin/develop` after PR creation; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. This only changes the coverage-gate LCOV path matcher and adds a focused self-test. The risk is that a PR whose changed file was previously matched by a similarly named LCOV path now fails correctly as uncovered.

# Background

## What does this PR do?

`coverage-gate.awk` previously matched changed files against LCOV sources with `index(current, cf) > 0`. That raw substring match could treat `packages/demo/src/foo.ts` as covered when the LCOV report only contained `packages/demo/src/foo.tsx` or another longer path segment.

This PR changes the matcher to accept only:

- exact path equality, or
- an LCOV absolute path ending in `/<changed-file>`.

It also normalizes backslashes and adds `scripts/security/coverage-gate.self-test.mjs` to pin the exact matching behavior.

## What kind of change is this?

Bug fix for CI/test enforcement.

# Documentation changes needed?

No project documentation change required; the self-test documents the matcher contract.

# Testing

## Where should a reviewer start?

Start with `scripts/security/coverage-gate.self-test.mjs`, then inspect `scripts/security/coverage-gate.awk`.

## Detailed testing steps

```bash
node scripts/security/coverage-gate.self-test.mjs
git diff --check
bunx biome check scripts/security/coverage-gate.self-test.mjs --no-errors-on-unmatched
```

Observed focused self-test output:

```text
ok - matches identical repo-relative path
ok - matches absolute LCOV path at path boundary
ok - does not match similar filename substring
ok - does not match longer path segment prefix
```

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - CI script only; no rendered UI surface changes`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - CI script only; no rendered UI surface changes`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - CI script only; no user-facing UI flow`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - no backend service path changes; deterministic local CI self-test output included above`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend runtime changes`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no agent/action/provider/prompt/model behavior changes`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - no domain artifacts; CI matcher regression output is the artifact`.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model behavior changes.

## Backend + frontend logs

N/A - no backend or frontend runtime path changes. Focused CI matcher output is in Testing.

## Screenshots (before / after) + video walkthrough

### Before

N/A - CI script only; no rendered UI surface changes.

### After

N/A - CI script only; no rendered UI surface changes.

### Walkthrough video

N/A - CI script only; no user-facing UI flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice changes.

## Known gaps / failures

`bun run verify` was not run because this is a focused CI-script patch and full repo verification is currently expensive/unstable in this lane. Targeted validation for the changed matcher passed:

- `node scripts/security/coverage-gate.self-test.mjs`
- `git diff --check`
- `bunx biome check scripts/security/coverage-gate.self-test.mjs --no-errors-on-unmatched`
