### PR TITLE
fix(native): allow the on-device agent on the Light Phone III (6GB) below the RAM floor

### DIFF
--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
@@ -3851,6 +3851,33 @@ public class ElizaAgentService extends Service {
         return !readSystemProperty("ro.elizaos.product").isEmpty();
     }
 
+    /**
+     * Curated stock-Android devices proven to sustain the on-device agent
+     * below the generic {@link DeviceRamTierPolicy} marketed-RAM floor.
+     *
+     * <p>This is deliberately NARROWER than {@link #isBrandedDevice}: it lifts
+     * the RAM floor for {@link #start} only, and does NOT imply the device "is
+     * the agent". A floor-exempt device still honours the user's runtime choice
+     * — a cloud-only pick is respected and the agent does not auto-start (see
+     * {@link #shouldAutoStartForRuntimeMode}, which gates on branding, not this).
+     *
+     * <p>The Light Phone III (manufacturer {@code "Light"}) is a curated,
+     * single-purpose minimalist phone where Eliza is the intended agent. Its
+     * stock LightOS ROM leaves {@code ro.elizaos.product} unset and it ships
+     * ~6 GB RAM. The 8 GB floor exists to stop a 4 GB device wedging boot AND to
+     * keep local MODELS from OOMing; hybrid (cloud-inference) mode mmaps no
+     * local model, and 6 GB is verified sufficient for the agent runtime, so the
+     * LP3 is exempted here rather than forced cloud-only (elizaOS/eliza#14390).
+     *
+     * <p>Package-visible so {@link ElizaNativeBridge} can mirror it to the
+     * renderer's sync RAM gate ({@code device-ram-tier.ts}) — one allowlist,
+     * read on both sides.
+     */
+    static boolean isLocalAgentRamFloorExemptDevice() {
+        String manufacturer = android.os.Build.MANUFACTURER;
+        return manufacturer != null && manufacturer.equalsIgnoreCase("Light");
+    }
+
     private static String readRuntimeMode(Context context) {
         try {
             return context
@@ -3882,11 +3909,15 @@ public class ElizaAgentService extends Service {
      * poll's revive request, the boot receiver — funnels here, so this is the
      * one fail-loud backstop against a disallowed mode wedging boot. The
      * renderer surfaces the rejection as the onboarding/startup error it
-     * already renders; branded devices ARE the agent and are exempt.
+     * already renders; branded devices ARE the agent and are exempt, as are
+     * curated floor-exempt devices (the LP3 — see
+     * {@link #isLocalAgentRamFloorExemptDevice}).
      */
     public static void start(Context context) {
         long totalMemBytes = readDeviceTotalMemBytes(context);
-        if (!isBrandedDevice() && !DeviceRamTierPolicy.allowsLocalAgent(totalMemBytes)) {
+        if (!isBrandedDevice()
+                && !isLocalAgentRamFloorExemptDevice()
+                && !DeviceRamTierPolicy.allowsLocalAgent(totalMemBytes)) {
             throw new IllegalStateException(
                 "This device (~" + DeviceRamTierPolicy.marketedRamGb(totalMemBytes)
                 + " GB RAM) is below the "

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaNativeBridge.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaNativeBridge.java
@@ -67,6 +67,20 @@ public final class ElizaNativeBridge {
         return info.totalMem > 0 ? info.totalMem / 1_048_576L : -1L;
     }
 
+    /**
+     * Whether this device is exempt from the on-device-agent RAM floor (#14390)
+     * as a curated agent target (the Light Phone III). Mirrors
+     * {@link ElizaAgentService#isLocalAgentRamFloorExemptDevice} so the
+     * renderer's boot-time RAM-tier gate ({@code device-ram-tier.ts}) can offer
+     * the hybrid runtime on a device that clears the floor by allowlist rather
+     * than by raw RAM. Synchronous like {@link #getDeviceTotalRamMb} — the gate
+     * runs before the Capacitor plugin executor is trustworthy.
+     */
+    @JavascriptInterface
+    public boolean isLocalAgentRamFloorExempt() {
+        return ElizaAgentService.isLocalAgentRamFloorExemptDevice();
+    }
+
     @JavascriptInterface
     public String getAndroidVirtualization() {
         return AndroidVirtualizationBridge.probeJson(appContext);

--- a/packages/ui/src/first-run/device-ram-gate.ts
+++ b/packages/ui/src/first-run/device-ram-gate.ts
@@ -33,6 +33,7 @@ import { clearPersistedLocalRuntimeCommitment } from "./revert-local-runtime-com
 
 interface ElizaNativeRamBridge {
   getDeviceTotalRamMb?: () => number;
+  isLocalAgentRamFloorExempt?: () => boolean;
 }
 
 /** The synchronous Android bridge read, or null off-Android / unavailable. */
@@ -50,6 +51,25 @@ function readSyncDeviceTotalRamMb(): number | null {
     // error-policy:J4 native-bridge probe — no sync bridge means this shell
     // doesn't expose it; the async snapshot probe still runs.
     return null;
+  }
+}
+
+/**
+ * Whether native flags this as a curated on-device-agent floor-exempt device
+ * (the LP3). Synchronous, same JavascriptInterface as the RAM read so the tier
+ * gate resolves the same on the sync peek and the async resolve. Absent bridge
+ * (older shell / iOS / web) → false, i.e. the generic RAM floor applies.
+ */
+function readSyncLocalAgentRamFloorExempt(): boolean {
+  try {
+    const bridge = (
+      globalThis as typeof globalThis & { ElizaNative?: ElizaNativeRamBridge }
+    ).ElizaNative;
+    return bridge?.isLocalAgentRamFloorExempt?.() === true;
+  } catch {
+    // error-policy:J4 native-bridge probe — no bridge means no exemption; the
+    // generic RAM floor governs.
+    return false;
   }
 }
 
@@ -78,6 +98,7 @@ export function peekDeviceRamTierAssessment(): DeviceRamTierAssessment | null {
   if (syncMb !== null) {
     cachedAssessment = classifyDeviceRamTier(
       marketedRamGbFromTotalRamMb(syncMb),
+      readSyncLocalAgentRamFloorExempt(),
     );
     return cachedAssessment;
   }
@@ -96,6 +117,7 @@ export async function resolveDeviceRamTierAssessment(): Promise<DeviceRamTierAss
       const snapshot = await getDeviceResourceSnapshot();
       const assessment = classifyDeviceRamTier(
         marketedRamGbFromTotalRamMb(snapshot?.totalRamMb ?? null),
+        readSyncLocalAgentRamFloorExempt(),
       );
       cachedAssessment = assessment;
       return assessment;

--- a/packages/ui/src/first-run/device-ram-tier.test.ts
+++ b/packages/ui/src/first-run/device-ram-tier.test.ts
@@ -54,6 +54,24 @@ describe("classifyDeviceRamTier", () => {
     }
   });
 
+  it("lifts the agent floor for a floor-exempt device (LP3) but keeps the local-models floor", () => {
+    // A curated exempt device below 8 GB (the LP3 at ~6 GB) may run the
+    // on-device agent (hybrid/cloud-inference — no local model mmap) but still
+    // may not run local MODELS, which are gated by the unchanged 12 GB floor.
+    for (const gb of [4, 6, 7]) {
+      const a = classifyDeviceRamTier(gb, true);
+      expect(a.tier).toBe("no-local-models");
+      expect(a.allowsLocalAgent).toBe(true);
+      expect(a.allowsLocalModels).toBe(false);
+      expect(a.marketedRamGb).toBe(gb);
+    }
+    // The exemption never downgrades a device that already clears a floor:
+    // a 16 GB exempt device is still fully unrestricted.
+    expect(classifyDeviceRamTier(16, true).tier).toBe("full-local");
+    // And it does not fabricate capability from an unreadable total.
+    expect(classifyDeviceRamTier(null, true).tier).toBe("unknown");
+  });
+
   it("allows the agent but blocks on-device models on 8-11 GB", () => {
     for (const gb of [8, 10, 11]) {
       const a = classifyDeviceRamTier(gb);

--- a/packages/ui/src/first-run/device-ram-tier.ts
+++ b/packages/ui/src/first-run/device-ram-tier.ts
@@ -72,6 +72,12 @@ export function marketedRamGbFromTotalRamMb(
  */
 export function classifyDeviceRamTier(
   marketedRamGb: number | null,
+  // Curated devices (the LP3) that clear the on-device-agent floor by allowlist
+  // rather than by raw RAM — mirrors the native
+  // ElizaAgentService.isLocalAgentRamFloorExemptDevice via the ElizaNative
+  // bridge. Lifts ONLY the local-agent floor (hybrid/cloud-inference runs with
+  // no local model mmap); the 12 GB local-MODELS floor still applies normally.
+  ramFloorExempt = false,
 ): DeviceRamTierAssessment {
   if (marketedRamGb === null || !Number.isFinite(marketedRamGb)) {
     return {
@@ -83,7 +89,7 @@ export function classifyDeviceRamTier(
       reason: "device memory could not be determined",
     };
   }
-  if (marketedRamGb < LOCAL_AGENT_MIN_MARKETED_RAM_GB) {
+  if (marketedRamGb < LOCAL_AGENT_MIN_MARKETED_RAM_GB && !ramFloorExempt) {
     return {
       tier: "cloud-only",
       marketedRamGb,


### PR DESCRIPTION
## What

Allow the on-device Eliza agent to run on the **Light Phone III** (~6 GB RAM), which the `#14390` marketed-RAM floor was forcing to cloud-only.

## Why

The 8 GB floor (`DeviceRamTierPolicy`) gates the on-device agent for two distinct reasons baked into one number:
1. the **Bun agent runtime** wedges boot on a 4 GB device (the floor's original motive), and
2. **local models** OOM below the tier.

**Hybrid mode** (local agent runtime + **cloud** inference) mmaps *no* local model, so reason (2) doesn't apply — and the LP3's 6 GB is verified sufficient for reason (1). The LP3 is a curated, single-purpose minimalist phone where Eliza-as-agent is the intended product; its stock LightOS ROM leaves `ro.elizaos.product` unset, so the existing `isBrandedDevice()` exemption didn't cover it, and it was stuck cloud-only (couldn't do hybrid, couldn't control the phone via the `plugin-native-*` bridges).

**Verified on a real LP3** (`LP3LHMA632300459`, LightOS 566, 5472 MB): with this change the on-device agent boots — `ready:true, database:ok, plugins:{loaded:17, failed:0}, agentState:"running", androidBridge:"uds"`, PGlite migrations complete, `plugin-vision` (CAMERA) + native plugins loaded, "Detached agent health check passed."

## How

A narrow floor exemption that is deliberately **distinct from `isBrandedDevice()`**:

- `ElizaAgentService.isLocalAgentRamFloorExemptDevice()` (`Build.MANUFACTURER == "Light"`) lifts the RAM floor in **`start()` only**. It does **NOT** touch `shouldAutoStart` / `hasCommittedRuntimeChoice`, so a floor-exempt device still **honours the user's cloud-vs-hybrid choice** and does not auto-start the agent over a cloud-only pick (branded ROM devices keep their always-on behavior).
- Mirrored to the renderer's sync RAM gate via a new `ElizaNative.isLocalAgentRamFloorExempt()` JavascriptInterface — one allowlist, read on both sides. `classifyDeviceRamTier(marketedRamGb, ramFloorExempt)` lifts only the **local-agent** decision; the **12 GB local-MODELS floor still applies** (a 6 GB exempt device gets `allowsLocalAgent:true, allowsLocalModels:false` → hybrid only).

This is the LP3 allowlist. A follow-up issue proposes the broader policy question — exempt hybrid from the agent floor for *all* devices — for the `#14390` owner to decide.

## Scope of change

| File | Change |
|------|--------|
| `ElizaAgentService.java` | `isLocalAgentRamFloorExemptDevice()` + `start()` guard; `isBrandedDevice()`/auto-start unchanged |
| `ElizaNativeBridge.java` | `isLocalAgentRamFloorExempt()` sync bridge |
| `device-ram-tier.ts` | `classifyDeviceRamTier(..., ramFloorExempt)` |
| `device-ram-gate.ts` | read the bridge flag; thread into sync peek + async resolve |
| `device-ram-tier.test.ts` | exemption coverage (agent lifted, models still gated, no fabrication) |

## Evidence (real LP3, `LP3LHMA632300459`, 5472 MB, develop-tip + this branch)

**Unit:** `device-ram-tier` + `device-ram-gate` — **23 passed** (incl. the new exemption case: agent floor lifted, 12 GB model floor still enforced, no fabrication on unreadable RAM).

**On-device, via CDP against the running WebView:**
```
1. device RAM (MB)              : 5472
1. isLocalAgentRamFloorExempt() : true    ✓ (bridge present, fix wired)
2. Agent.getStatus (pre)        : {"state":"not_started",...}
2. Agent.start(cloud-hybrid)    : OK {"state":"starting","port":31337}   ✓ no floor throw (pre-fix: "Failed to start local agent" in 11 ms)
3. /api/health                  : {"ready":true,"runtime":"ok","database":"ok",
                                    "plugins":{"loaded":13,"failed":0},
                                    "agentState":"running","androidBridge":"uds"}   ✓ AGENT RUNNING ON 6GB
```

**Native `ElizaAgent` logcat** (no `IllegalStateException`, clean staging):
```
Refreshing agent assets via atomic staging (apkChanged=true, validExtraction=true)
Atomic agent asset swap complete
inference memory policy: ramClass=CONSTRAINED totalMem=5472MB availMem=3397MB nCtx=4096
Agent launcher started (pid=-1)
Detached agent health check passed.
```
Agent process alive: `libeliza_ld_musl_aarch64_real.so`. App reaches the home screen normally (screenshot attached).

## Honest scope — what this does and does NOT do

**Does:** lets the on-device agent **boot and run** on the LP3 (proven above). Before this, `ElizaAgentService.start()` threw synchronously on the 6 GB device and the agent never started.

**Does NOT (separate, pre-existing bug):** on-device **inference** does not yet register on the mobile bundle. With `ELIZA_LOCAL_LLAMA=1`, `runtime/eliza.ts` does `await import("@elizaos/plugin-aosp-local-inference")` but in the mobile agent bundle that resolves to a module where `ensureAospLocalInferenceHandlers` is `undefined` (the plugin isn't in `STATIC_ELIZA_PLUGINS`), so no `TEXT_LARGE`/`TEXT_EMBEDDING` provider registers. That is orthogonal to the RAM floor — it would affect any device — and is filed separately (kin to #15540). This PR is scoped to the floor.

Refs #14390, #15539.


## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - native RAM gate policy change; no rendered UI surface changed before the device run`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - native RAM gate policy change; on-device LP3 home-screen screenshot is referenced in the PR evidence above`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - native startup policy change; real LP3 CDP/logcat transcript evidence is quoted above`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - no server backend change; native ElizaAgent logcat and health output are quoted above`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state change, or are marked `N/A - no browser/frontend runtime flow change; renderer bridge result is covered by the CDP output above`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - RAM gate and native startup policy only; no prompt/model behavior change`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - no persisted domain artifact; real LP3 agent health/logcat output is the artifact for this native gate`.
