### PR TITLE
ci(mobile): gate build smoke timings

### DIFF
--- a/.github/workflows/mobile-build-smoke.yml
+++ b/.github/workflows/mobile-build-smoke.yml
@@ -131,7 +131,26 @@ jobs:
           ELIZA_IOS_FULL_BUN_ENGINE: "0"
           ELIZA_IOS_BUILD_DESTINATION: "generic/platform=iOS Simulator"
           ELIZA_IOS_BUILD_SDK: "iphonesimulator"
+          ELIZA_MOBILE_BUILD_TIMING_OUT: ${{ runner.temp }}/ios-simulator-build-timing.json
+          ELIZA_MOBILE_BUILD_TIMING_TARGET: ios-ipa
           NODE_OPTIONS: "--max-old-space-size=8192"
+
+      - name: Check iOS simulator build-time budget
+        run: |
+          bun run --cwd packages/app perf:startup-budget -- \
+            --build-timing "$RUNNER_TEMP/ios-simulator-build-timing.json" \
+            --out "$RUNNER_TEMP/ios-simulator-build-budget-report.json"
+
+      - name: Upload iOS simulator build budget report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: ios-simulator-build-budget
+          path: |
+            ${{ runner.temp }}/ios-simulator-build-timing.json
+            ${{ runner.temp }}/ios-simulator-build-budget-report.json
+          if-no-files-found: warn
+          retention-days: 7
 
       - name: Verify .app exists
         run: |
@@ -364,7 +383,26 @@ jobs:
           ELIZA_IOS_FULL_BUN_ENGINE: "1"
           ELIZA_IOS_BUILD_DESTINATION: "generic/platform=iOS Simulator"
           ELIZA_IOS_BUILD_SDK: "iphonesimulator"
+          ELIZA_MOBILE_BUILD_TIMING_OUT: ${{ runner.temp }}/ios-full-bun-build-timing.json
+          ELIZA_MOBILE_BUILD_TIMING_TARGET: ios-ipa
           NODE_OPTIONS: "--max-old-space-size=8192"
+
+      - name: Check iOS full-Bun build-time budget
+        run: |
+          bun run --cwd packages/app perf:startup-budget -- \
+            --build-timing "$RUNNER_TEMP/ios-full-bun-build-timing.json" \
+            --out "$RUNNER_TEMP/ios-full-bun-build-budget-report.json"
+
+      - name: Upload iOS full-Bun build budget report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: ios-full-bun-build-budget
+          path: |
+            ${{ runner.temp }}/ios-full-bun-build-timing.json
+            ${{ runner.temp }}/ios-full-bun-build-budget-report.json
+          if-no-files-found: warn
+          retention-days: 7
 
       - name: Verify .app exists
         run: |
@@ -595,6 +633,25 @@ jobs:
           # Real local/AOSP Android builds still fail if fork llama libs are
           # missing; the opt-out only lets CI validate Capacitor/Gradle wiring.
           ELIZA_ANDROID_SKIP_FORK_LLAMA_LIB: "1"
+          ELIZA_MOBILE_BUILD_TIMING_OUT: ${{ runner.temp }}/android-cloud-debug-build-timing.json
+          ELIZA_MOBILE_BUILD_TIMING_TARGET: android-apk
+
+      - name: Check Android cloud-debug build-time budget
+        run: |
+          bun run --cwd packages/app perf:startup-budget -- \
+            --build-timing "$RUNNER_TEMP/android-cloud-debug-build-timing.json" \
+            --out "$RUNNER_TEMP/android-cloud-debug-build-budget-report.json"
+
+      - name: Upload Android cloud-debug build budget report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: android-cloud-debug-build-budget
+          path: |
+            ${{ runner.temp }}/android-cloud-debug-build-timing.json
+            ${{ runner.temp }}/android-cloud-debug-build-budget-report.json
+          if-no-files-found: warn
+          retention-days: 7
 
       - name: Verify APK exists
         run: |


### PR DESCRIPTION
# Relates to

Refs #14414.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on the latest `origin/develop` available before PR creation.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Branched from current `origin/develop` (`39d18c489592f7ed7f34d559805a5f520c85eef5`).
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low to medium. This turns the existing mobile build-time budget CLI into a real gate in `mobile-build-smoke.yml`. If a hosted iOS or Android mobile build exceeds `packages/app/perf-budgets.json`, the smoke job now fails and uploads the timing/report JSON.

# Background

## What does this PR do?

`run-mobile-build.mjs` already supports `ELIZA_MOBILE_BUILD_TIMING_OUT`, and `packages/app/scripts/check-startup-budget.mjs` already grades build timings against `packages/app/perf-budgets.json`. The mobile smoke workflow was not using that path, so the #14414 build-time budget existed mostly as a manual CLI.

This PR wires the existing gate into the real mobile build smoke jobs:

- iOS simulator build emits `ios-simulator-build-timing.json`, checks it as `build/ios-ipa`, and uploads the timing/report artifacts.
- iOS full-Bun simulator build emits `ios-full-bun-build-timing.json`, checks it as `build/ios-ipa`, and uploads the timing/report artifacts.
- Android cloud-debug build emits `android-cloud-debug-build-timing.json`, checks it as `build/android-apk`, and uploads the timing/report artifacts.

This does not claim to close #14414. It advances the fourth Done-when item: build-time + TTI budget with a regression gate.

## What kind of change is this?

CI/workflow hardening for mobile performance regression detection.

# Documentation changes needed?

No user-facing documentation change. The workflow step names and artifact names document the CI behavior.

# Testing

## Where should a reviewer start?

Start with `.github/workflows/mobile-build-smoke.yml`, then inspect `packages/app/scripts/check-startup-budget.mjs` and `packages/app/perf-budgets.json` for the existing budget behavior this workflow now invokes.

## Detailed testing steps

```bash
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/mobile-build-smoke.yml"); puts "yaml ok"'
actionlint .github/workflows/mobile-build-smoke.yml
git diff --check

tmpdir=$(mktemp -d)
printf '{"target":"android-apk","buildMs":1000}\n' > "$tmpdir/android.json"
printf '{"target":"ios-ipa","buildMs":1000}\n' > "$tmpdir/ios.json"
bun run --cwd packages/app perf:startup-budget -- --build-timing "$tmpdir/android.json" --out "$tmpdir/android-report.json"
bun run --cwd packages/app perf:startup-budget -- --build-timing "$tmpdir/ios.json" --out "$tmpdir/ios-report.json"
```

Observed command output included:

```text
yaml ok
build/android-apk:pass
build/ios-ipa:pass
```

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - CI workflow only; no rendered UI surface changes`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - CI workflow only; no rendered UI surface changes`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - CI workflow only; no user-facing UI flow`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - no backend service path changes; local budget CLI output included above`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend runtime changes`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no agent/action/provider/prompt/model behavior changes`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - no domain artifacts; generated CI timing/report JSON artifacts are uploaded by the workflow on real runs`.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model behavior changes.

## Backend + frontend logs

N/A - no backend or frontend runtime path changes. Focused local budget CLI output is included in Testing.

## Screenshots (before / after) + video walkthrough

### Before

N/A - CI workflow only; no rendered UI surface changes.

### After

N/A - CI workflow only; no rendered UI surface changes.

### Walkthrough video

N/A - CI workflow only; no user-facing UI flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice changes.

## Known gaps / failures

`bun run verify` was not run because this is a focused workflow-only change and the relevant validation is workflow syntax plus the exact budget CLI command shape. The real mobile build jobs must run in GitHub Actions to produce the new timing artifacts.

This PR does not close #14414. Remaining issue work still includes renderer-only device dev loop without full native rebuild, measured cold-boot speedups with before/after traces, and deferral of eager boot work off the critical path.