### PR TITLE
test(app-core): stop mock-heavy suites leaking mocks across the isolate:false registry

### DIFF
--- a/packages/app-core/src/api/__tests__/ensure-route-min-role.test.ts
+++ b/packages/app-core/src/api/__tests__/ensure-route-min-role.test.ts
@@ -9,7 +9,15 @@
  */
 import http from "node:http";
 import { Socket } from "node:net";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import { ensureRouteAuthorized, ensureRouteMinRole } from "../auth.js";
 
 const mocks = vi.hoisted(() => {
@@ -84,6 +92,15 @@ vi.mock("../../services/auth-store.js", () => ({
 const STATE_WITH_DB = {
   current: { adapter: { db: {} } },
 };
+
+// Under `isolate: false` app-core suites share one module registry. This file
+// installs a full-replacement `@elizaos/shared` mock plus `../auth/sessions`
+// and `../../services/auth-store` mocks; clear the registry on teardown so those
+// stripped/mocked modules cannot leak into a later real-module suite (e.g.
+// first-run-persistence, which imports the genuine `@elizaos/shared` normalizers).
+afterAll(() => {
+  vi.resetModules();
+});
 
 function makeReq(options: {
   method?: string;

--- a/packages/app-core/src/api/auth-pairing-routes.test.ts
+++ b/packages/app-core/src/api/auth-pairing-routes.test.ts
@@ -18,6 +18,7 @@ import {
   setBootConfig,
 } from "@elizaos/shared";
 import {
+  afterAll,
   afterEach,
   beforeAll,
   beforeEach,
@@ -262,6 +263,16 @@ describe("auth pairing pair-code route", () => {
     const routeModule = await import("./auth-pairing-routes");
     handleAuthPairingCompatRoutes = routeModule.handleAuthPairingCompatRoutes;
     resetAuthPairingStateForTests = routeModule._resetAuthPairingStateForTests;
+  });
+
+  // Under `isolate: false` app-core suites share one module registry. This file
+  // mocks `./auth/sessions` (incl. a stubbed `createMachineSession`) and
+  // `../services/auth-store`; clear the registry on teardown so those mocks
+  // cannot leak into a later real-module suite — e.g. auth-pairing-flow, which
+  // mints a session through the genuine AuthStore and would otherwise read the
+  // stub's unpersisted session id back as null.
+  afterAll(() => {
+    vi.resetModules();
   });
 
   beforeEach(() => {

--- a/packages/app-core/src/api/database-rows-compat-routes.test.ts
+++ b/packages/app-core/src/api/database-rows-compat-routes.test.ts
@@ -8,7 +8,15 @@
  */
 import http from "node:http";
 import { Socket } from "node:net";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import { handleDatabaseRowsCompatRoute } from "./database-rows-compat-routes";
 
 // This suite drives the REAL `ensureRouteMinRole` (via the real `./auth.ts`)
@@ -220,6 +228,15 @@ beforeEach(() => {
 afterEach(() => {
   delete process.env.ELIZA_API_TOKEN;
   delete process.env.ELIZA_REQUIRE_LOCAL_AUTH;
+});
+
+// Under `isolate: false` app-core suites share one module registry. This file
+// installs a full-replacement `@elizaos/shared` mock plus `../auth/sessions`
+// and `../../services/auth-store` mocks; clear the registry on teardown so those
+// stripped/mocked modules cannot leak into a later real-module suite (e.g.
+// first-run-persistence, which imports the genuine `@elizaos/shared` normalizers).
+afterAll(() => {
+  vi.resetModules();
 });
 
 describe("handleDatabaseRowsCompatRoute", () => {

--- a/packages/app-core/src/api/drop-status-compat-route.test.ts
+++ b/packages/app-core/src/api/drop-status-compat-route.test.ts
@@ -6,7 +6,7 @@
  */
 import http from "node:http";
 import { Socket } from "node:net";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   ensureCompatSensitiveRouteAuthorized: vi.fn(),
@@ -64,6 +64,14 @@ async function loadRoute() {
   const mod = await import("./drop-status-compat-route");
   return mod.handleDropStatusCompatRoute;
 }
+
+// Under `isolate: false` all app-core suites share one module registry. This
+// file's `./auth` / `./auth.ts` mocks are re-imported into that shared registry
+// by `loadRoute`; clear it on teardown so the mocked auth gate cannot leak into
+// a later real-module suite that imports the genuine `./auth`.
+afterAll(() => {
+  vi.resetModules();
+});
 
 describe("handleDropStatusCompatRoute", () => {
   beforeEach(() => {

--- a/packages/app-core/src/api/ios-local-agent-transport.test.ts
+++ b/packages/app-core/src/api/ios-local-agent-transport.test.ts
@@ -7,7 +7,15 @@
  * path extraction (incl. Chromium custom-scheme URLs), and the #11030 hostile
  * Capacitor-proxy deadlock guard.
  */
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 
 const originalGlobalFetch = globalThis.fetch;
 
@@ -140,6 +148,14 @@ describe("iOS local agent transport bridge", () => {
     vi.unstubAllEnvs();
     vi.unstubAllGlobals();
     Reflect.deleteProperty(globalThis, BOOT_CONFIG_STORE_KEY);
+  });
+
+  // Under `isolate: false` app-core suites share one module registry. This file
+  // resets and re-imports the transport per test against Capacitor / build-variant
+  // / kernel mocks; clear the registry once more on teardown so those mocks cannot
+  // leak into a later suite that imports the genuine modules.
+  afterAll(() => {
+    vi.resetModules();
   });
 
   it("installs a native-callable path-only request handler", async () => {


### PR DESCRIPTION
## Problem

`packages/app-core` runs vitest with `isolate: false` (`maxWorkers: 1`) — a single shared module registry across every test file in the lane (chosen deliberately for PGlite worker-fork stability; see the config comment). Under that model, a handful of suites install **module-level mocks of shared modules** and re-import them into the shared registry via `vi.resetModules()` for their own self-defense — but **none clear the registry on teardown**. So the mocked modules persist in the cache after the file finishes and leak into whichever real-module suite the sequencer runs next.

This surfaces as an intermittent CI failure whose **victim is non-deterministic** (vitest's default sequencer orders files by size, and the timing cache shifts run-to-run). Observed on the current tree:

- Run A: `src/api/auth-pairing-flow.test.ts:293` — `expected null not to be null`
- Run B: `src/api/first-run-persistence.restart.test.ts` — runtime-mode assertion fails

### Root cause per leak

- **`ensure-route-min-role` / `database-rows-compat-routes`** install a *full-replacement* `@elizaos/shared` mock (no `...actual`), which strips the real `normalizeDeploymentTargetConfig` / `normalizeServiceRoutingConfig`. When that leaks, `first-run-persistence.restart` (a real-module suite importing those normalizers) breaks.
- **`auth-pairing-routes`** mocks `./auth/sessions` (with a stubbed `createMachineSession`) and `../services/auth-store`. When that leaks, `auth-pairing-flow` (real DB + real AuthStore) mints a session through what is actually the stub, so `harness.store.findSession(sessionId)` reads back `null`.

Removing the setup-time `vi.resetModules()` calls is **not** a valid fix: `ensure-route-min-role` and `database-rows` need module isolation to bind their own auth-graph mocks and break each other without it, and removing them does not stop the leak.

## Fix

Fix at the correct layer — each mock-heavy suite clears the shared module registry **on teardown** so its mocks cannot outlive the file:

```ts
afterAll(() => {
  vi.resetModules();
});
```

Applied to the five suites that install module-level mocks under `isolate: false`: `ensure-route-min-role`, `database-rows-compat-routes`, `auth-pairing-routes`, `drop-status-compat-route`, `ios-local-agent-transport`. No assertion, HTTP status code, or mock behavior is changed — this is purely test-isolation hygiene (a J6-style teardown cleanup of shared global state).

## Verification

- **Full app-core lane green 3/3 consecutive runs** (`bun run --cwd packages/app-core test`): `164 passed | 1 skipped`, 0 fail, ~58s (no perf regression vs baseline).
- Baseline (pre-fix) reproduced the failure at `auth-pairing-flow.test.ts:293` and, on a second run, at `first-run-persistence.restart.test.ts` — confirming the non-determinism.
- Each of the 5 modified suites passes standalone.
- All 5 polluters + both former victims pass in one combined invocation (70/70).
- `biome check` clean on all touched files; `audit:error-policy-ratchet` clean (0 changed production source files — diff is test-only).

## Notes for reviewers

- The original diagnosis for this lane referenced `credential-tunnel-routes.test.ts:297,313` (`expected 401 to be 400`); `develop` has since drifted (those lines are now error-code mapping and that suite passes). The **mechanism** is identical — `isolate:false` + module-level mocks leaking across the shared registry — only the sequencer-dependent victim changed.
- A package-scoped `tsgo` typecheck reports pre-existing `@elizaos/capacitor-*` module-resolution errors in untouched `*.ts` source files; these stem from native capacitor packages not being built in the local sandbox and resolve in CI's full build. The diff itself is 100% `*.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)