### PR TITLE
fix(agent): bundle AOSP local inference bootstrap

### DIFF
--- a/packages/agent/scripts/build-mobile-bundle.mjs
+++ b/packages/agent/scripts/build-mobile-bundle.mjs
@@ -494,15 +494,6 @@ const optionalPluginStubs = {
   "@elizaos/plugin-agent-orchestrator": path.join(stubsDir, "null-plugin.cjs"),
   "@elizaos/plugin-shell": path.join(stubsDir, "null-plugin.cjs"),
   "@elizaos/plugin-coding-tools": path.join(stubsDir, "null-plugin.cjs"),
-  // AOSP-only companion, reached via a lazy `import(...)` gated on
-  // ELIZA_LOCAL_LLAMA (getAospLocalInferenceApi in local-inference-routes +
-  // agent cli). It is not a declared dependency (present only on AOSP
-  // images), so the stock mobile bundle must stub it or Bun.build fails to
-  // resolve it. The gate never fires on stock, so the stub is never invoked.
-  "@elizaos/plugin-aosp-local-inference": path.join(
-    stubsDir,
-    "null-plugin.cjs",
-  ),
   // NOTE: @elizaos/plugin-commands is intentionally NOT stubbed. Its only
   // dependency is `@elizaos/core` (workspace:*), so it does not drag an
   // incompatible core into the bundle, and `api/commands-routes.ts` imports the

--- a/packages/agent/src/runtime/mobile-bundle-anchors.test.ts
+++ b/packages/agent/src/runtime/mobile-bundle-anchors.test.ts
@@ -35,6 +35,10 @@ const DEAD_GLOBALS = [
 describe("mobile bundle anchors (no write-only globalThis pinning)", () => {
   const binSource = read("bin.ts");
   const androidSource = read("runtime/android-app-plugins.ts");
+  const mobileBuildScript = readFileSync(
+    path.resolve(agentSrc, "..", "scripts", "build-mobile-bundle.mjs"),
+    "utf8",
+  );
 
   it("removes every write-only plugin-pinning global", () => {
     const haystack = `${binSource}\n${androidSource}`;
@@ -53,6 +57,12 @@ describe("mobile bundle anchors (no write-only globalThis pinning)", () => {
     );
     expect(binSource).toContain(
       '"@elizaos/plugin-capacitor-bridge/mobile-device-bridge-bootstrap"',
+    );
+  });
+
+  it("does not null-stub the AOSP local-inference bootstrap package", () => {
+    expect(mobileBuildScript).not.toMatch(
+      /"@elizaos\/plugin-aosp-local-inference"\s*:\s*path\.join\(\s*stubsDir\s*,\s*"null-plugin\.cjs"\s*\)/,
     );
   });
 });


### PR DESCRIPTION
# Relates to

Fixes the bundle-stub root cause for #15579.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on the latest `origin/develop` available before PR creation.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Branched from current `origin/develop` after #15580 (`63bd71031b4`).
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low to medium. This removes one stale mobile-bundle null-stub alias so the Android/AOSP local-inference bootstrap package is actually bundled. The package is already a declared `@elizaos/agent` workspace dependency and self-gates on `ELIZA_LOCAL_LLAMA=1`, so non-AOSP and cloud/hybrid paths should continue to no-op.

# Background

## What does this PR do?

`packages/agent/src/bin.ts` intentionally imports `@elizaos/plugin-aosp-local-inference` to anchor the package in the Android mobile agent bundle. But `packages/agent/scripts/build-mobile-bundle.mjs` still force-aliased that same package to `null-plugin.cjs`, from an older era when the package was not a declared dependency.

That meant the mobile bundle could resolve `await import("@elizaos/plugin-aosp-local-inference")`, but the namespace was the null proxy, so `ensureAospLocalInferenceHandlers` was `undefined` and all-local Android devices never registered local text/embedding handlers.

This PR removes that stale stub and adds a source-level guard to `mobile-bundle-anchors.test.ts` so the AOSP bootstrap package cannot be null-stubbed while `bin.ts` imports it as a bundle anchor.

## What kind of change is this?

Mobile runtime / bundle correctness fix.

# Testing

## Where should a reviewer start?

Start with `packages/agent/scripts/build-mobile-bundle.mjs` around `optionalPluginStubs`, then `packages/agent/src/runtime/mobile-bundle-anchors.test.ts`.

## Detailed testing steps

```bash
bunx vitest run packages/agent/src/runtime/mobile-bundle-anchors.test.ts --coverage.enabled=false
bunx biome check packages/agent/scripts/build-mobile-bundle.mjs packages/agent/src/runtime/mobile-bundle-anchors.test.ts --no-errors-on-unmatched
git diff --check
node --check packages/agent/scripts/build-mobile-bundle.mjs
bun run --cwd plugins/plugin-aosp-local-inference build
bun run --cwd packages/agent build:mobile
node -e 'const m=require("./packages/agent/dist-mobile/plugins-manifest.json"); console.log(JSON.stringify({hasAospStub:m.externalsAsStubs.includes("@elizaos/plugin-aosp-local-inference"), stubs:m.externalsAsStubs.filter(s=>s.includes("aosp")), aospOnly:m.plugins.aospOnly}, null, 2))'
rg -n "ensureAospLocalInferenceHandlers|aosp-local-inference\\] bootstrap entered|plugin-aosp-local-inference" packages/agent/dist-mobile/agent-bundle.js | sed -n '1,80p'
```

Observed outputs:

```text
mobile-bundle-anchors.test.ts: 4 passed
biome: Checked 2 files. No fixes applied.
plugin-aosp-local-inference build: tsc --noCheck --noEmit passed
build:mobile: load smoke passed: module init OK
manifest check: { "hasAospStub": false, "stubs": [] }
bundle grep: ensureAospLocalInferenceHandlers function and export are present in dist-mobile/agent-bundle.js
```

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - mobile agent bundle/runtime plumbing only; no rendered UI surface changed`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - mobile agent bundle/runtime plumbing only; no rendered UI surface changed`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - no user-facing UI flow; bundle build/load-smoke proof included above`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - no server backend route change; Android mobile bundle build/load-smoke output and generated bundle grep are included above`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend runtime changes`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no prompt/model behavior change; this restores mobile bundle reachability of the existing AOSP local-inference handler`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - generated domain artifact is the Android dist-mobile bundle/manifest inspected in Testing; not committed`.

# Evidence Details

## Real LLM-call trajectory

N/A - no prompt/model behavior change. This restores reachability of the existing handler in the Android mobile bundle; a real local-model generation on device still needs an Android/AOSP all-local run with staged GGUF.

## Backend + frontend logs

N/A - no server route or frontend runtime path changes. Bundle build/load-smoke and bundle grep output are in Testing.

## Screenshots (before / after) + video walkthrough

### Before

N/A - mobile agent bundle/runtime plumbing only; no rendered UI surface changed.

### After

N/A - mobile agent bundle/runtime plumbing only; no rendered UI surface changed.

### Walkthrough video

N/A - no user-facing UI flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice changes.

## Known gaps / failures

`bun run verify` was not run; this is a focused mobile bundle fix and the targeted checks plus real Android `build:mobile` load smoke passed.

A full all-local Android device chat/embedding proof is not available on this machine. The PR proves the package is no longer null-stubbed and `ensureAospLocalInferenceHandlers` is present in the produced Android mobile bundle; on-device model execution still requires AOSP hardware/emulator with staged local GGUF.