### PR TITLE
fix(ui): quiet dedicated cloud probe noise

### DIFF
--- a/packages/ui/src/api/client-agent-dedicated-status-404.test.ts
+++ b/packages/ui/src/api/client-agent-dedicated-status-404.test.ts
@@ -1,17 +1,14 @@
 /**
  * #15310 failure #4: a RETURNING user whose existing Eliza Cloud agent is
  * DEDICATED (its own `<id>.elizacloud.ai` subdomain) is bound to that subdomain
- * base, but the cloud agent-router proxies `/api/status` through the
- * shared-runtime resolver, which answers `404 { error: "Not a shared-runtime
- * agent" }` for a dedicated agent. Before the fix, that 404 threw out of
- * `getStatus()`, the readiness poll swallowed it, and the launcher wedged on
- * "Initializing agent…" FOREVER — the reported first-run hang for returning
- * accounts with an existing ready agent.
+ * base, but the dedicated agent ingress does not expose every local-agent probe
+ * endpoint (`/api/status`, `/api/config`) to browser clients. Before the fix,
+ * those probes produced noisy 401/404 console entries even though dedicated REST
+ * chat was live.
  *
- * `getStatus()` must instead treat that specific shared-resolver 404 (only when
- * bound to a dedicated cloud agent base) as RUNNING, so startup proceeds to
- * chat. Any OTHER 404 / 5xx / network error still propagates so a genuinely
- * broken agent surfaces honestly.
+ * `getStatus()` must instead treat a dedicated cloud base like the shared REST
+ * adapter: RUNNING without probing `/api/status`. Startup still uses
+ * `/api/conversations` as the authoritative warm-passthrough gate before chat.
  *
  * Transport stubbed, no live agent, no desktop RPC (plain HTTP status path).
  */
@@ -24,8 +21,9 @@ import type { AgentRequestTransport } from "./transport";
 function makeClient(
   baseUrl: string,
   handler: AgentRequestTransport["request"],
+  token = "token",
 ): ElizaClient {
-  const client = new ElizaClient(baseUrl, "token");
+  const client = new ElizaClient(baseUrl, token);
   client.setRequestTransport({ request: vi.fn(handler) });
   return client;
 }
@@ -51,42 +49,30 @@ describe("ElizaClient.getStatus — dedicated agent shared-resolver 404 (#15310 
     Reflect.deleteProperty(globalThis, "window");
   });
 
-  it("treats the dedicated 'Not a shared-runtime agent' 404 as RUNNING (no wedge)", async () => {
-    let statusCalls = 0;
-    const client = makeClient(DEDICATED_BASE, async (url) => {
-      const path = new URL(url).pathname;
-      if (path === "/api/status") {
-        statusCalls += 1;
-        return sharedResolver404();
-      }
-      return new Response("{}", { status: 200 });
+  it("short-circuits authenticated dedicated status as RUNNING without probing /api/status", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () => {
+      throw new Error("/api/status should not be probed for dedicated cloud");
     });
+    const client = makeClient(DEDICATED_BASE, request);
 
     const status = await client.getStatus();
 
-    // The returning user's dedicated agent is provisioned + serving chat over
-    // REST — report running so the readiness poll advances to chat.
     expect(status.state).toBe("running");
     expect(status.canRespond).toBe(true);
-    expect(statusCalls).toBe(1);
+    expect(request).not.toHaveBeenCalled();
   });
 
-  it("does NOT mask a generic 404 from a dedicated agent (only the shared-resolver signal is running)", async () => {
-    const client = makeClient(DEDICATED_BASE, async (url) => {
-      const path = new URL(url).pathname;
-      if (path === "/api/status") {
-        return new Response(JSON.stringify({ error: "Not Found" }), {
-          status: 404,
-          headers: { "content-type": "application/json" },
-        });
-      }
-      return new Response("{}", { status: 200 });
+  it("short-circuits dedicated status even before token hydration", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () => {
+      throw new Error("/api/status should not be probed for dedicated cloud");
     });
+    const client = makeClient(DEDICATED_BASE, request, "");
 
-    // A generic 404 (a genuinely missing/broken status endpoint) still throws —
-    // it must NOT be swallowed as "running", or a truly broken agent would look
-    // healthy.
-    await expect(client.getStatus()).rejects.toThrow();
+    const status = await client.getStatus();
+
+    expect(status.state).toBe("running");
+    expect(status.canRespond).toBe(true);
+    expect(request).not.toHaveBeenCalled();
   });
 
   it("does NOT treat the shared-resolver 404 as running for a NON-dedicated base", async () => {
@@ -129,5 +115,15 @@ describe("ElizaClient.getStatus — dedicated agent shared-resolver 404 (#15310 
     );
     expect(lowerHeaderNames).not.toContain("x-elizaos-client-id");
     expect(lowerHeaderNames).not.toContain("x-elizaos-ui-language");
+  });
+
+  it("short-circuits authenticated dedicated config as empty without probing /api/config", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () => {
+      throw new Error("/api/config should not be probed for dedicated cloud");
+    });
+    const client = makeClient(DEDICATED_BASE, request);
+
+    await expect(client.getConfig()).resolves.toEqual({});
+    expect(request).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/api/client-agent.ts
+++ b/packages/ui/src/api/client-agent.ts
@@ -1359,6 +1359,19 @@ function isSharedResolverMissForDedicatedAgent(err: unknown): boolean {
   return /not a shared-runtime agent/i.test(err.message);
 }
 
+function cloudRestRunningStatus(): AgentStatus {
+  return {
+    state: "running",
+    agentName: "Eliza",
+    model: undefined,
+    // Cloud REST agents are provisioned + serving cloud-side — first-turn
+    // capability is online, so the composer should be live immediately.
+    canRespond: true,
+    uptime: undefined,
+    startedAt: undefined,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Prototype augmentation
 // ---------------------------------------------------------------------------
@@ -1370,16 +1383,15 @@ ElizaClient.prototype.getStatus = async function (this: ElizaClient) {
   // status:"running") so startup proceeds to chat — its REST adapter already
   // serves /api/conversations + /api/conversations/:id/messages.
   if (isDirectCloudSharedAgentBase(this.getBaseUrl())) {
-    return {
-      state: "running",
-      agentName: "Eliza",
-      model: undefined,
-      // Cloud-shared agent is provisioned + serving cloud-side — first-turn
-      // capability is online, so the composer should be live immediately.
-      canRespond: true,
-      uptime: undefined,
-      startedAt: undefined,
-    };
+    return cloudRestRunningStatus();
+  }
+  // Dedicated cloud agents serve chat on their own subdomain, but live cloud
+  // currently rejects `/api/status` for browser clients even when `/api/*` chat
+  // endpoints are usable. Startup already uses `/api/conversations` as the
+  // authoritative warm-passthrough probe before calling this, so skip the noisy
+  // status probe for dedicated bases.
+  if (isDedicatedCloudAgentBase(this.getBaseUrl())) {
+    return cloudRestRunningStatus();
   }
   try {
     const viaRpc = await getDesktopStatusRpc<AgentStatus>(
@@ -1969,6 +1981,13 @@ ElizaClient.prototype.getConfig = async function (this: ElizaClient) {
   logSettingsClient("GET /api/config → start", {
     baseUrl: this.getBaseUrl(),
   });
+  if (isDedicatedCloudAgentBase(this.getBaseUrl())) {
+    // Dedicated cloud chat runs through the per-agent REST surface, but the
+    // config endpoint is not exposed there today. Returning the empty config
+    // mirrors callers' existing "config unavailable" fallback without producing
+    // browser-visible 401 noise on every boot.
+    return {};
+  }
   let viaRpc: AppConfigResponse | null = null;
   try {
     viaRpc = await invokeLocalDesktopAgentRpc<AppConfigResponse>(


### PR DESCRIPTION
## Summary
- skip unsupported `/api/status` probes for dedicated Eliza Cloud agent subdomains and report the REST runtime as running after the startup warm-passthrough gate
- return an empty config for dedicated cloud bases instead of probing `/api/config`, avoiding browser-visible 401 noise while preserving existing config-unavailable fallbacks
- keep dedicated cloud requests on the dedicated subdomain; no shared-runtime/API-router fallback is introduced

## Validation
- `bun run --cwd packages/ui test src/api/client-agent-dedicated-status-404.test.ts src/api/client-cloud-connect-mock-cloud.test.ts src/api/client-cloud-select-or-provision.test.ts src/api/android-native-agent-transport.test.ts src/first-run/first-run-finish.reused-shared-handoff.test.ts src/first-run/use-first-run-conductor.test.ts src/state/useCloudState.same-tab-login.test.tsx`
- `bun run --cwd packages/ui typecheck`
- `bunx @biomejs/biome check --write packages/ui/src/api/client-agent.ts packages/ui/src/api/client-agent-dedicated-status-404.test.ts`
- Playwright full-stack smoke on `http://localhost:2138/chat?smoke=1783562286868` using a temporary copy of the Chrome Default profile: dedicated cloud message sent and response rendered; 0 bad HTTP responses; 0 CORS/shared-runtime/API-router signatures; only the known local browser Network plugin warning remained

## Evidence
<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15582-before-dedicated-cloud.png)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15582-after-dedicated-cloud.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence/15582-eliza-dedicated-cloud-walkthrough.webm

<!-- evidence-row:backend-logs -->
- [x] [15582-eliza-dedicated-cloud-backend-status.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15582-eliza-dedicated-cloud-backend-status.json)

<!-- evidence-row:frontend-logs -->
- [x] [15582-eliza-dedicated-cloud-frontend-logs.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15582-eliza-dedicated-cloud-frontend-logs.json)

<!-- evidence-row:llm-trajectory -->
- [x] [15582-eliza-dedicated-cloud-llm-trajectory.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15582-eliza-dedicated-cloud-llm-trajectory.json)

<!-- evidence-row:domain-artifacts -->
- [x] [15582-eliza-dedicated-cloud-domain-artifacts.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15582-eliza-dedicated-cloud-domain-artifacts.json)

<!-- evidence-row:ocr-review -->
- [x] [15582-eliza-dedicated-cloud-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15582-eliza-dedicated-cloud-ocr-review.txt)
