### PR TITLE
fix(ci): build-android stages fused inference libs + checks out the llama.cpp submodule

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -31,8 +31,15 @@ jobs:
       contents: write
 
     steps:
-      - name: Checkout
+      - name: Checkout (with the llama.cpp fork submodule)
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          # The elizavoice JNI wrapper compiles against the omnivoice headers
+          # inside plugins/plugin-local-inference/native/llama.cpp — the staged
+          # fused lib exports the fused-voice ABI, so the headers must be
+          # checked out or build:android fails at [elizavoice-jni] (#15540).
+          submodules: recursive
+          show-progress: false
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -65,6 +65,45 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      # Gradle's copyForkLlamaLib hard-requires the fused inference lib for
+      # arm64-v8a (libelizainference.so + its backend .so siblings) and fails
+      # the whole APK build without it (#15540). CI has no ~/.eliza staging
+      # and no NDK cross-compile here — the fused libs are built by the
+      # build-llama-ffi-android workflow — so stage its latest green artifacts
+      # and point ELIZA_MTP_ANDROID_LIBDIR{,_X86_64} at them.
+      - name: Stage fused inference libs (from build-llama-ffi-android)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          run_id=$(gh api "repos/${{ github.repository }}/actions/workflows/build-llama-ffi-android.yml/runs?status=success&per_page=1" \
+            --jq '.workflow_runs[0].id // empty')
+          if [ -z "$run_id" ]; then
+            echo "::error::no successful build-llama-ffi-android run found — fix that workflow first (its fused artifacts feed this build)" >&2
+            exit 1
+          fi
+          echo "staging fused libs from build-llama-ffi-android run $run_id"
+          stage="$RUNNER_TEMP/elizainference"
+          mkdir -p "$stage/arm64" "$stage/x86_64"
+          gh run download "$run_id" -R "${{ github.repository }}" \
+            -n libelizainference-android-arm64-vulkan-fused -D "$stage/arm64"
+          # x86_64 is optional: gradle skips absent non-arm64 ABIs.
+          gh run download "$run_id" -R "${{ github.repository }}" \
+            -n libelizainference-android-x86_64-cpu-fused -D "$stage/x86_64" || true
+          arm64_so=$(find "$stage/arm64" -name libelizainference.so | head -1)
+          if [ -z "$arm64_so" ]; then
+            echo "::error::arm64 artifact downloaded but contains no libelizainference.so" >&2
+            find "$stage/arm64" -type f | head -20 >&2
+            exit 1
+          fi
+          echo "ELIZA_MTP_ANDROID_LIBDIR=$(dirname "$arm64_so")" >> "$GITHUB_ENV"
+          x86_so=$(find "$stage/x86_64" -name libelizainference.so 2>/dev/null | head -1 || true)
+          if [ -n "$x86_so" ]; then
+            echo "ELIZA_MTP_ANDROID_LIBDIR_X86_64=$(dirname "$x86_so")" >> "$GITHUB_ENV"
+          fi
+          echo "arm64 libdir contents:"
+          ls -la "$(dirname "$arm64_so")"
+
       - name: Prepare Android platform
         working-directory: ${{ env.APP_DIR }}
         run: bun run build:android


### PR DESCRIPTION
## What & why (#15540 — the `build-android.yml` half)

`build-android.yml` had been red since 06-18. Fresh dispatch on develop reproduced two stacked gaps (fixed here, one commit each, proven by a green run):

1. **No fused-lib staging in CI.** Gradle's `:app:copyForkLlamaLib` hard-requires the fused `libelizainference.so` set for arm64-v8a (resolution: `-P` prop → `ELIZA_MTP_ANDROID_LIBDIR` env → `~/.eliza/...`); CI had none of the three. New step downloads the fused artifacts from the **latest green `build-llama-ffi-android` run** (green again since #15565) and exports `ELIZA_MTP_ANDROID_LIBDIR{,_X86_64}` — locating `libelizainference.so` dynamically so the artifact's inner layout can't silently break it, and failing loud with a pointer at the ffi workflow when no green run exists.
2. **llama.cpp submodule never checked out.** With the fused-voice ABI staged, the elizavoice JNI wrapper compiles against the omnivoice headers inside `plugins/plugin-local-inference/native/llama.cpp` — added `submodules: recursive` to checkout (same config as the ffi workflow).

## Proof — full green run on this branch
Run https://github.com/elizaOS/eliza/actions/runs/28988800500 (workflow_dispatch on this branch): **completed/success**, all steps green including `Stage fused inference libs`, `Prepare Android platform` (the previously-failing step), preflight, debug APK, release APK/AAB + checksums. Iteration history: run 28988357785 proved layer 1 (staging step green, JNI headers then failed) → layer 2 fix → full green.

Unblocks: CI APK artifacts with the complete fused voice/inference lib — @lightphone-agent's LP3 on-device inference ask.

## Evidence rows
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - CI workflow change only; no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - CI workflow change only; no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - CI workflow change; the walkthrough is the green Actions run linked above`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs: the failing→passing step logs are in the linked runs: red baseline https://github.com/elizaOS/eliza/actions/runs/28987810666 (copyForkLlamaLib GradleException), layer-2 https://github.com/elizaOS/eliza/actions/runs/28988357785 (elizavoice-jni missing headers), green https://github.com/elizaOS/eliza/actions/runs/28988800500
<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent/model behavior change; CI packaging only`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: the green run's APK/AAB artifacts (debug + release + checksums) on https://github.com/elizaOS/eliza/actions/runs/28988800500 — the exact deliverable #15540 asked for
<!-- evidence-row:ocr-review -->
- [ ] OCR visual text review `N/A - no media artifacts`.

Fixes #15540 (the ffi half was fixed by #15565; this completes the issue). `[cloud-agent]`
