### PR TITLE
chore(plugin-cli-inference): bump stale claude default opus-4-7 → opus-4-8

### DIFF
--- a/plugins/plugin-cli-inference/AGENTS.md
+++ b/plugins/plugin-cli-inference/AGENTS.md
@@ -139,7 +139,7 @@ plugins/plugin-cli-inference/
 
 ## GenerateTextParams -> CLI mapping (HARD REQ: forward BOTH system AND messages/prompt)
 
-- **claude:** `[claude, -p <flattened body>, --system-prompt <params.system FULL REPLACE>, --exclude-dynamic-system-prompt-sections, --output-format text, --model <ELIZA_CLI_CLAUDE_MODEL || claude-opus-4-7>]`, stdin `/dev/null`, cwd = isolated empty tmpdir, env = `filterEnv(process.env)`.
+- **claude:** `[claude, -p <flattened body>, --system-prompt <params.system FULL REPLACE>, --exclude-dynamic-system-prompt-sections, --output-format text, --model <ELIZA_CLI_CLAUDE_MODEL || claude-opus-4-8>]`, stdin `/dev/null`, cwd = isolated empty tmpdir, env = `filterEnv(process.env)`.
 - **codex:** `[codex, exec, -m <ELIZA_CLI_CODEX_MODEL || gpt-5.5>, -s read-only, --skip-git-repo-check, -C <cwd>, --color never, --json, <system folded on top of flattened body>]`.
 
 `prompt-flatten` re-routes system/developer roles to the system slot and flattens user/assistant/tool turns into the body; messages are NEVER dropped (would strip skills/memory/recent-convo/grammar).
@@ -149,7 +149,7 @@ plugins/plugin-cli-inference/
 | Var | Required | Default | Description |
 |---|---|---|---|
 | `ELIZA_CHAT_VIA_CLI` | — | (unset = inert) | `claude`, `claude-sdk`, or `codex` — the single enable gate |
-| `ELIZA_CLI_CLAUDE_MODEL` | No | `claude-opus-4-7` | claude large-tier model (`--model` / SDK large tier) |
+| `ELIZA_CLI_CLAUDE_MODEL` | No | `claude-opus-4-8` | claude large-tier model (`--model` / SDK large tier) |
 | `ELIZA_CLI_CLAUDE_PLANNER_MODEL` | No | (falls back to large) | `claude-sdk` small/planner tier model (e.g. sonnet) |
 | `ELIZA_CLI_CLAUDE_BIN` | No | (SDK default) | `claude-sdk`: path to the Claude Code executable the SDK drives |
 | `ELIZA_CLI_SDK_RESTART_AFTER_TURNS` | No | `20` | `claude-sdk`: restart a warm session after N turns (bounds context) |

--- a/plugins/plugin-cli-inference/CLAUDE.md
+++ b/plugins/plugin-cli-inference/CLAUDE.md
@@ -139,7 +139,7 @@ plugins/plugin-cli-inference/
 
 ## GenerateTextParams -> CLI mapping (HARD REQ: forward BOTH system AND messages/prompt)
 
-- **claude:** `[claude, -p <flattened body>, --system-prompt <params.system FULL REPLACE>, --exclude-dynamic-system-prompt-sections, --output-format text, --model <ELIZA_CLI_CLAUDE_MODEL || claude-opus-4-7>]`, stdin `/dev/null`, cwd = isolated empty tmpdir, env = `filterEnv(process.env)`.
+- **claude:** `[claude, -p <flattened body>, --system-prompt <params.system FULL REPLACE>, --exclude-dynamic-system-prompt-sections, --output-format text, --model <ELIZA_CLI_CLAUDE_MODEL || claude-opus-4-8>]`, stdin `/dev/null`, cwd = isolated empty tmpdir, env = `filterEnv(process.env)`.
 - **codex:** `[codex, exec, -m <ELIZA_CLI_CODEX_MODEL || gpt-5.5>, -s read-only, --skip-git-repo-check, -C <cwd>, --color never, --json, <system folded on top of flattened body>]`.
 
 `prompt-flatten` re-routes system/developer roles to the system slot and flattens user/assistant/tool turns into the body; messages are NEVER dropped (would strip skills/memory/recent-convo/grammar).
@@ -149,7 +149,7 @@ plugins/plugin-cli-inference/
 | Var | Required | Default | Description |
 |---|---|---|---|
 | `ELIZA_CHAT_VIA_CLI` | — | (unset = inert) | `claude`, `claude-sdk`, or `codex` — the single enable gate |
-| `ELIZA_CLI_CLAUDE_MODEL` | No | `claude-opus-4-7` | claude large-tier model (`--model` / SDK large tier) |
+| `ELIZA_CLI_CLAUDE_MODEL` | No | `claude-opus-4-8` | claude large-tier model (`--model` / SDK large tier) |
 | `ELIZA_CLI_CLAUDE_PLANNER_MODEL` | No | (falls back to large) | `claude-sdk` small/planner tier model (e.g. sonnet) |
 | `ELIZA_CLI_CLAUDE_BIN` | No | (SDK default) | `claude-sdk`: path to the Claude Code executable the SDK drives |
 | `ELIZA_CLI_SDK_RESTART_AFTER_TURNS` | No | `20` | `claude-sdk`: restart a warm session after N turns (bounds context) |

--- a/plugins/plugin-cli-inference/__tests__/claude-sdk-session.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/claude-sdk-session.test.ts
@@ -116,6 +116,19 @@ function makeSession(
 }
 
 describe("ClaudeSdkSession — TEXT mode", () => {
+  it("defaults to the current Opus model when no model is configured", async () => {
+    const { sdk, queryOptions } = makeFakeSdk([{ text: "hello world", subtype: "success" }]);
+    const session = new ClaudeSdkSession({
+      systemPrompt: "test system",
+      sdkModule: sdk,
+      zodModule: fakeZod,
+    });
+
+    expect(await session.generate("hi")).toBe("hello world");
+    expect(queryOptions()[0].model).toBe("claude-opus-4-8");
+    await session.dispose();
+  });
+
   it("returns streamed assistant text", async () => {
     const { session } = makeSession([{ text: "hello world", subtype: "success" }]);
     expect(await session.generate("hi")).toBe("hello world");

--- a/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
@@ -7,11 +7,13 @@
  * allowlist on this box.
  */
 import type { ChatMessage, PluginAutoEnableContext } from "@elizaos/core";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { shouldEnable } from "../auto-enable";
 import {
   buildModels,
   ClaudeCli,
+  ClaudeSdkSession,
+  CodexSdkSession,
   cliInferencePlugin,
   LARGE_TIER_MODEL_TYPES,
   resolveCliBackend,
@@ -78,6 +80,9 @@ function recordingSpawn(result: Partial<SpawnResult>) {
 
 afterEach(() => {
   delete process.env.ELIZA_CHAT_VIA_CLI;
+  delete process.env.ELIZA_PLANNER_NATIVE_TOOLS;
+  delete process.env.ELIZA_ENABLE_CLAUDE_STEALTH;
+  vi.restoreAllMocks();
 });
 
 describe("flattenPrompt", () => {
@@ -426,6 +431,128 @@ describe("models map gating (large-tier only)", () => {
       buildModels({ ELIZA_CHAT_VIA_CLI: "claude-sdk" }) as Record<string, unknown>
     );
     expect(keys.sort()).toEqual([...LARGE_TIER_MODEL_TYPES].sort());
+  });
+
+  it("routes cold Claude model handlers through the configured backend", async () => {
+    const { calls, fn } = recordingSpawn({ stdout: "from claude" });
+    const restore = __setClaudeSpawn(fn);
+    try {
+      const models = buildModels({ ELIZA_CHAT_VIA_CLI: "claude" }) as Record<
+        string,
+        (
+          runtime: { getSetting: (key: string) => string | undefined },
+          params: unknown
+        ) => Promise<string>
+      >;
+      const runtime = {
+        getSetting: (key: string) => (key === "ELIZA_CHAT_VIA_CLI" ? "claude" : undefined),
+      };
+
+      await expect(models.TEXT_LARGE(runtime, { prompt: "hello" })).resolves.toBe("from claude");
+
+      const argv = calls[0].argv;
+      expect(argv[argv.indexOf("--model") + 1]).toBe("claude-opus-4-8");
+    } finally {
+      restore();
+    }
+  });
+
+  it("routes warm Claude SDK handlers through the current default Opus model", async () => {
+    let captured: { model?: string; body?: string } = {};
+    vi.spyOn(ClaudeSdkSession.prototype, "generate").mockImplementation(function (
+      this: ClaudeSdkSession,
+      body: string
+    ) {
+      captured = {
+        model: (this as unknown as { model?: string }).model,
+        body,
+      };
+      return Promise.resolve("from sdk");
+    });
+    const models = buildModels({ ELIZA_CHAT_VIA_CLI: "claude-sdk" }) as Record<
+      string,
+      (
+        runtime: { getSetting: (key: string) => string | undefined },
+        params: unknown
+      ) => Promise<string>
+    >;
+    const runtime = {
+      getSetting: (key: string) =>
+        key === "ELIZA_CHAT_VIA_CLI"
+          ? "claude-sdk"
+          : key === "ELIZA_CLI_CLAUDE_MODEL"
+            ? ""
+            : undefined,
+    };
+
+    await expect(models.TEXT_LARGE(runtime, { prompt: "hello" })).resolves.toBe("from sdk");
+
+    expect(captured.model).toBe("claude-opus-4-8");
+    expect(captured.body).toContain("hello");
+  });
+
+  it("registers and routes ACTION_PLANNER only in text-planner mode", async () => {
+    process.env.ELIZA_PLANNER_NATIVE_TOOLS = "0";
+    const { calls, fn } = recordingSpawn({ stdout: '{"action":"NONE","params":{}}' });
+    const restore = __setClaudeSpawn(fn);
+    try {
+      const models = buildModels({ ELIZA_CHAT_VIA_CLI: "claude" }) as Record<
+        string,
+        (
+          runtime: { getSetting: (key: string) => string | undefined },
+          params: unknown
+        ) => Promise<string>
+      >;
+      const runtime = {
+        getSetting: (key: string) => (key === "ELIZA_CHAT_VIA_CLI" ? "claude" : undefined),
+      };
+
+      expect(models.ACTION_PLANNER).toBeTypeOf("function");
+      await expect(models.ACTION_PLANNER(runtime, { prompt: "pick an action" })).resolves.toContain(
+        "NONE"
+      );
+      expect(calls).toHaveLength(1);
+    } finally {
+      restore();
+    }
+  });
+
+  it("routes warm Codex SDK handlers through the default Codex model", async () => {
+    let captured: { model?: string; body?: string } = {};
+    vi.spyOn(CodexSdkSession.prototype, "generate").mockImplementation(function (
+      this: CodexSdkSession,
+      body: string
+    ) {
+      captured = {
+        model: (this as unknown as { model?: string }).model,
+        body,
+      };
+      return Promise.resolve("from codex sdk");
+    });
+    const models = buildModels({ ELIZA_CHAT_VIA_CLI: "codex-sdk" }) as Record<
+      string,
+      (
+        runtime: { getSetting: (key: string) => string | undefined },
+        params: unknown
+      ) => Promise<string>
+    >;
+    const runtime = {
+      getSetting: (key: string) => (key === "ELIZA_CHAT_VIA_CLI" ? "codex-sdk" : undefined),
+    };
+
+    await expect(models.TEXT_LARGE(runtime, { prompt: "hello" })).resolves.toBe("from codex sdk");
+
+    expect(captured.model).toBe("gpt-5.5");
+    expect(captured.body).toContain("hello");
+  });
+
+  it("keeps init inert when disabled and rejects colliding Claude routes", async () => {
+    delete process.env.ELIZA_CHAT_VIA_CLI;
+    await expect(cliInferencePlugin.init?.({} as never)).resolves.toBeUndefined();
+
+    process.env.ELIZA_CHAT_VIA_CLI = "claude-sdk";
+    process.env.ELIZA_ENABLE_CLAUDE_STEALTH = "1";
+    await expect(cliInferencePlugin.init?.({} as never)).rejects.toThrow(/collides/);
   });
 
   it("resolveCliBackend accepts claude|codex|claude-sdk (case-insensitive)", () => {

--- a/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
@@ -117,7 +117,7 @@ describe("claude CLI variant", () => {
     const restore = __setClaudeSpawn(fn);
     try {
       const cli = new ClaudeCli({
-        model: "claude-opus-4-7",
+        model: "claude-opus-4-8",
         env: { PATH: process.env.PATH },
         binaryPath: FAKE_CLAUDE,
       });
@@ -144,7 +144,7 @@ describe("claude CLI variant", () => {
       expect(argv[ofIdx + 1]).toBe("text");
       expect(argv).toContain("--exclude-dynamic-system-prompt-sections");
       const mIdx = argv.indexOf("--model");
-      expect(argv[mIdx + 1]).toBe("claude-opus-4-7");
+      expect(argv[mIdx + 1]).toBe("claude-opus-4-8");
 
       // stdin from /dev/null, isolated tmpdir cwd
       expect(opts.stdinPath).toBe("/dev/null");

--- a/plugins/plugin-cli-inference/index.ts
+++ b/plugins/plugin-cli-inference/index.ts
@@ -130,7 +130,7 @@ function resolveSdkModel(runtime: IAgentRuntime, modelType: string): string {
   const large = getSetting(runtime, "ELIZA_CLI_CLAUDE_MODEL");
   const small = getSetting(runtime, "ELIZA_CLI_CLAUDE_PLANNER_MODEL");
   const isSmallTier = modelType === ModelType.ACTION_PLANNER || modelType === ModelType.TEXT_SMALL;
-  return ((isSmallTier ? small : large) || large || "claude-opus-4-7").trim();
+  return ((isSmallTier ? small : large) || large || "claude-opus-4-8").trim();
 }
 
 function shortHash(value: string): string {

--- a/plugins/plugin-cli-inference/package.json
+++ b/plugins/plugin-cli-inference/package.json
@@ -90,9 +90,9 @@
       },
       "ELIZA_CLI_CLAUDE_MODEL": {
         "type": "string",
-        "description": "Model id passed to `claude --model`. Defaults to claude-opus-4-7.",
+        "description": "Model id passed to `claude --model`. Defaults to claude-opus-4-8.",
         "required": false,
-        "default": "claude-opus-4-7",
+        "default": "claude-opus-4-8",
         "sensitive": false
       },
       "ELIZA_CLI_CLAUDE_PLANNER_MODEL": {

--- a/plugins/plugin-cli-inference/registry-entry.json
+++ b/plugins/plugin-cli-inference/registry-entry.json
@@ -24,7 +24,7 @@
       "type": "string",
       "required": false,
       "sensitive": false,
-      "default": "claude-opus-4-7",
+      "default": "claude-opus-4-8",
       "label": "Claude CLI Model",
       "help": "Model passed to claude --print.",
       "advanced": true

--- a/plugins/plugin-cli-inference/src/claude-cli.ts
+++ b/plugins/plugin-cli-inference/src/claude-cli.ts
@@ -20,7 +20,7 @@ import { filterEnv, redactStderr, resolveSafeBinary, resolveSafeCwd } from "./sa
  * and stays on a never-commit branch.
  */
 
-const DEFAULT_MODEL = "claude-opus-4-7";
+const DEFAULT_MODEL = "claude-opus-4-8";
 const DEFAULT_TIMEOUT_MS = 120_000;
 const CLAUDE_BINARY = "claude";
 

--- a/plugins/plugin-cli-inference/src/claude-sdk-session.ts
+++ b/plugins/plugin-cli-inference/src/claude-sdk-session.ts
@@ -46,7 +46,7 @@ import { logger } from "@elizaos/core";
 import type { RotationSubprocessEnv } from "./account-rotation";
 import { ProviderApiError, parseProviderApiErrorText } from "./provider-errors";
 
-const DEFAULT_MODEL = "claude-opus-4-7";
+const DEFAULT_MODEL = "claude-opus-4-8";
 const DEFAULT_RESTART_AFTER_TURNS = 20;
 const DEFAULT_TURN_TIMEOUT_MS = 90_000;
 /** Fully-qualified name the SDK assigns our in-process MCP tool. */


### PR DESCRIPTION
## Summary
- bump the bare Claude CLI / Claude Agent SDK large-tier default from `claude-opus-4-7` to `claude-opus-4-8`
- update plugin registry metadata, `package.json` env schema, and package docs so config surfaces advertise the same default the code uses
- add public-surface tests for cold Claude, warm Claude SDK, Codex SDK routing, text-planner registration, plugin init guards, and the SDK no-model default

Anthropic's current model overview lists `claude-opus-4-8` as the Claude API ID for Claude Opus 4.8: https://platform.claude.com/docs/en/about-claude/models/overview

## Validation
- `bun run --cwd plugins/plugin-cli-inference test` -> 100 passed
- `bunx biome check --write plugins/plugin-cli-inference/__tests__/cli-inference.test.ts plugins/plugin-cli-inference/__tests__/claude-sdk-session.test.ts --no-errors-on-unmatched`
- `bunx biome check plugins/plugin-cli-inference/index.ts plugins/plugin-cli-inference/src/claude-cli.ts plugins/plugin-cli-inference/src/claude-sdk-session.ts plugins/plugin-cli-inference/__tests__/cli-inference.test.ts plugins/plugin-cli-inference/package.json plugins/plugin-cli-inference/registry-entry.json plugins/plugin-cli-inference/CLAUDE.md plugins/plugin-cli-inference/AGENTS.md --no-errors-on-unmatched`
- Changed-test coverage reproduction with `cli-inference.test.ts` + `claude-sdk-session.test.ts`: `index.ts` 62.41%, `claude-cli.ts` 88.57%, `claude-sdk-session.ts` 78.71%
- `git diff --check origin/develop...HEAD`

## Evidence
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - model default/config metadata change; no rendered UI surface changed`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - model default/config metadata change; no rendered UI surface changed`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no interactive UI flow changed; behavior is covered by the plugin unit tests listed above`.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no server runtime was started; this is a plugin default/config change verified by unit tests`.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend runtime behavior changed`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no prompt/action/provider behavior changed beyond the configured default model id; no live model call was required to verify the literal default`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no persisted DB row, memory, scheduled task, wallet result, generated file, or external domain artifact is produced by this default-model bump`.

