### PR TITLE
fix(ci): wire build-android to the fused inference lib + omnivoice headers (#15540)

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -34,6 +34,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
+      # The elizavoice-jni gradle build validates that the staged
+      # libelizainference.so's fused-voice ABI matches the omnivoice FFI header
+      # in the llama.cpp fork submodule. That submodule is not checked out by
+      # the default checkout, so init just that one path (shallow) rather than
+      # pulling every submodule (opencode/electrobun aren't needed here).
+      - name: Check out llama.cpp omnivoice headers
+        run: |
+          git submodule update --init --depth 1 \
+            plugins/plugin-local-inference/native/llama.cpp
+          test -f plugins/plugin-local-inference/native/llama.cpp/tools/omnivoice/include/eliza-inference-ffi.h \
+            || { echo "::error::omnivoice FFI header still missing after submodule init"; exit 1; }
+
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -65,6 +65,47 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      # The APK requires the fused inference lib: the :app:copyForkLlamaLib
+      # gradle task hard-errors when arm64-v8a has neither a configured lib dir
+      # nor a pre-staged jniLibs set — which is why this workflow was red on
+      # every bare CI runner (#15540). Pull the newest green artifact from
+      # build-llama-ffi-android (the canonical cross-compile of
+      # libelizainference.so) and point the gradle task at it via
+      # ELIZA_MTP_ANDROID_LIBDIR.
+      - name: Resolve latest green libelizainference build
+        id: ffi_run
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          run_id=$(gh run list --repo "$GITHUB_REPOSITORY" \
+            --workflow build-llama-ffi-android.yml --branch develop \
+            --status success --limit 1 --json databaseId --jq '.[0].databaseId // empty')
+          if [ -z "$run_id" ]; then
+            echo "::error::No successful build-llama-ffi-android run on develop — cannot stage libelizainference.so. Fix that workflow first (#15540)."
+            exit 1
+          fi
+          echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+          echo "Using libelizainference artifacts from run $run_id"
+
+      - name: Download fused inference lib (arm64-v8a)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: libelizainference-android-arm64-vulkan-fused
+          run-id: ${{ steps.ffi_run.outputs.run_id }}
+          github-token: ${{ github.token }}
+          path: ffi-libs/android-arm64-vulkan-fused
+
+      - name: Stage fused inference lib for gradle
+        run: |
+          libdir="$GITHUB_WORKSPACE/ffi-libs/android-arm64-vulkan-fused/arm64-v8a"
+          if [ ! -f "$libdir/libelizainference.so" ]; then
+            echo "::error::Downloaded artifact lacks arm64-v8a/libelizainference.so (layout changed?)"
+            find "$GITHUB_WORKSPACE/ffi-libs" -maxdepth 3 -type f | head -20
+            exit 1
+          fi
+          echo "ELIZA_MTP_ANDROID_LIBDIR=$libdir" >> "$GITHUB_ENV"
+          ls -la "$libdir"
+
       - name: Prepare Android platform
         working-directory: ${{ env.APP_DIR }}
         run: bun run build:android


### PR DESCRIPTION
## Problem

`build-android` (the APK/AAB workflow, the second red lane in #15540) has been failing since 2026-06-18. Two stacked causes, both about the fused inference lib the APK requires:

1. **No FFI artifact was ever staged.** `:app:copyForkLlamaLib` hard-errors when arm64-v8a has neither a configured lib dir nor a pre-staged `jniLibs` set — and the workflow had zero wiring to `build-llama-ffi-android`'s output.
2. **The omnivoice ABI header wasn't checked out.** Once the lib is staged, gradle's `elizavoice-jni` project evaluation validates the staged `libelizainference.so`'s fused-voice ABI against `tools/omnivoice/include/eliza-inference-ffi.h` in the llama.cpp fork submodule, which the default checkout doesn't fetch.

## Fix

- Resolve the newest green `build-llama-ffi-android` run on develop, download its `libelizainference-android-arm64-vulkan-fused` artifact, and export `ELIZA_MTP_ANDROID_LIBDIR` so gradle's existing copy path stages the `.so` set. Pointed error when no green FFI run exists.
- Shallow-init just the `plugins/plugin-local-inference/native/llama.cpp` submodule (not opencode/electrobun) so the omnivoice header is present, and assert it exists.

Depends on the FFI lane being green, which #15575 (Kokoro pin restore, merged) + tonight's static-Vulkan fixes delivered.

## Verification

- [run 28989654027](https://github.com/elizaOS/eliza/actions/runs/28989654027) on this branch (progression: earlier runs got past `copyForkLlamaLib` then past the `elizavoice-jni` ABI gate as each cause was fixed).

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots `N/A - CI workflow change, no UI surface`.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots `N/A - CI workflow change, no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video `N/A - CI workflow wiring change`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs `N/A - no runtime change; proof is CI run 28989654027 and the step-by-step failure progression quoted in the description (copyForkLlamaLib -> elizavoice-jni ABI gate -> build)`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory `N/A - CI infrastructure change`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts `N/A - the artifact is the debug APK produced by run 28989654027`.

Second half of #15540 (the first half, the FFI lib itself, is #15575).

🤖 Generated with [Claude Code](https://claude.com/claude-code)