### PR TITLE
feat(native): pass the hybrid cloud-inference key to the on-device agent

### DIFF
--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
@@ -2014,6 +2014,25 @@ public class ElizaAgentService extends Service {
             agentEnv.put("ELIZA_RUNTIME_MODE", "local-yolo");
             agentEnv.put("AGENT_COMMAND", "android-bridge");
             agentEnv.put("ELIZA_DISABLE_DIRECT_RUN", "1");
+            // Hybrid (local runtime + CLOUD inference): the on-device agent has
+            // no local text model on a sub-12 GB device (DeviceRamTierPolicy),
+            // so its @elizaos/plugin-elizacloud must reach Eliza Cloud (→ Cerebras)
+            // for TEXT_LARGE/TEXT_EMBEDDING. The agent is a separate process, so
+            // the credential rides in via env. The app writes the account's Eliza
+            // Cloud API key into the CapacitorStorage pref during the hybrid
+            // onboarding; absent (pure-local / not-yet-onboarded) this is a no-op
+            // and the agent boots without a cloud provider, exactly as before.
+            String cloudInferenceKey = readCloudInferenceApiKey(this);
+            if (cloudInferenceKey != null && !cloudInferenceKey.isEmpty()) {
+                agentEnv.put("ELIZAOS_CLOUD_API_KEY", cloudInferenceKey);
+                agentEnv.put("ELIZAOS_CLOUD_ENABLED", "1");
+                String cloudInferenceBase = readCloudInferenceBaseUrl(this);
+                if (cloudInferenceBase != null && !cloudInferenceBase.isEmpty()) {
+                    agentEnv.put("ELIZAOS_CLOUD_BASE_URL", cloudInferenceBase);
+                }
+                Log.i(TAG, "Hybrid cloud inference enabled: ELIZAOS_CLOUD_API_KEY"
+                    + " injected from prefs (len=" + cloudInferenceKey.length() + ")");
+            }
             // Local passwordless mode: the on-device agent trusts its own sealed
             // request socket so the single device owner never hits a login/pairing
             // gate. The per-boot bearer-token guard (ELIZA_REQUIRE_LOCAL_AUTH=1)
@@ -3765,6 +3784,37 @@ public class ElizaAgentService extends Service {
      * eliza/packages/app-core/src/first-run/mobile-runtime-mode.ts.
      */
     private static final String RUNTIME_MODE_KEY = "eliza:mobile-runtime-mode";
+
+    /**
+     * Storage keys for the hybrid cloud-inference credential the app hands the
+     * on-device agent (so plugin-elizacloud can reach Eliza Cloud → Cerebras for
+     * TEXT_LARGE on a device with no local text model). Written by the renderer
+     * during hybrid onboarding; read here into the agent process env.
+     */
+    private static final String CLOUD_INFERENCE_API_KEY_KEY =
+        "eliza:cloud-inference-api-key";
+    private static final String CLOUD_INFERENCE_BASE_URL_KEY =
+        "eliza:cloud-inference-base-url";
+
+    private static String readCloudInferenceApiKey(Context context) {
+        return readCapacitorPref(context, CLOUD_INFERENCE_API_KEY_KEY);
+    }
+
+    private static String readCloudInferenceBaseUrl(Context context) {
+        return readCapacitorPref(context, CLOUD_INFERENCE_BASE_URL_KEY);
+    }
+
+    private static String readCapacitorPref(Context context, String key) {
+        try {
+            String value = context
+                .getSharedPreferences(CAPACITOR_PREFS_GROUP, Context.MODE_PRIVATE)
+                .getString(key, null);
+            return value == null ? null : value.trim();
+        } catch (Exception e) {
+            Log.w(TAG, "Unable to read Capacitor pref " + key, e);
+            return null;
+        }
+    }
 
     /**
      * Whether the on-device agent should auto-start at app boot.


### PR DESCRIPTION
## What

Give the **on-device Bun agent** its hybrid cloud-inference credential. `ElizaAgentService` builds the agent process env but passed it **no** cloud key, so `@elizaos/plugin-elizacloud` booted unauthenticated and the agent had **no `TEXT_LARGE`/`TEXT_EMBEDDING` provider** — it couldn't generate.

## Why

On a sub-12GB device the on-device agent has **no local text model** (`DeviceRamTierPolicy` 12GB local-models floor), so hybrid mode routes inference to **Eliza Cloud → Cerebras** via `plugin-elizacloud`, which reads `ELIZAOS_CLOUD_API_KEY` from env. The agent is a **separate process**, so the credential has to ride in via the env — and nothing wired it. This is the missing plumbing that made on-device hybrid inference impossible on mobile.

## How

Read the account's Eliza Cloud API key from the `CapacitorStorage` pref `eliza:cloud-inference-api-key` (+ optional `eliza:cloud-inference-base-url`) and inject it as `ELIZAOS_CLOUD_API_KEY` / `ELIZAOS_CLOUD_ENABLED` into the agent env. **No-op when the pref is absent** (pure-local / not-yet-onboarded) — existing flows are byte-for-byte unchanged.

## Evidence (real Light Phone III, 6GB, stacked on #15576)

```
I/ElizaAgent: Hybrid cloud inference enabled: ELIZAOS_CLOUD_API_KEY injected from prefs (len=70)
[CloudAuth] Authenticated with saved API key
[CloudAuth] API key validated
[app-routes] Registered app route plugin: @elizaos/plugin-elizacloud:routes (27 routes)
```
Then, driving the app UI against the local agent (`active-server=local:app-shell`):
- **"Say hello in exactly three words" → "hello there, friend."** (on-device agent, generated via Cerebras) — screenshot attached.
- **"Take a photo…" → the planner selected `{ action: TAKE_PHOTO }`** — the agent's brain correctly chose a device action (its *execution* is a separate `plugin-vision` mobile-camera gap, filed separately).

## Scope / follow-up

This is the **native half**. The paired **renderer half** — writing the cloud key into `eliza:cloud-inference-api-key` during hybrid onboarding (the app already holds a valid `eliza_*` cloud key) — is the follow-up so the flow is automatic, not manually seeded. Depends on #15576 (which lets the agent boot on the LP3 in the first place).

Refs #14390, #15539.
