### PR TITLE
fix(core): normalize artifact disclosure metadata

### DIFF
--- a/packages/core/src/access-control/artifact-disclosure.test.ts
+++ b/packages/core/src/access-control/artifact-disclosure.test.ts
@@ -4,10 +4,13 @@
  * untrusted grant parser. Pure functions, no harness.
  */
 import { describe, expect, it } from "vitest";
-import type { AccessContext, UUID } from "../types";
+import type { AccessContext, Memory, UUID } from "../types";
 import {
+	artifactDisclosureRecordFromMemory,
 	parseArtifactShareGrants,
 	resolveArtifactDisclosure,
+	resolveArtifactDisclosureForMemory,
+	selectDisclosedArtifactUrl,
 } from "./artifact-disclosure";
 
 const AGENT = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" as UUID;
@@ -203,5 +206,111 @@ describe("parseArtifactShareGrants", () => {
 		expect(parseArtifactShareGrants({})).toEqual([]);
 		expect(parseArtifactShareGrants({ share: "nope" })).toEqual([]);
 		expect(parseArtifactShareGrants({ share: { grants: "nope" } })).toEqual([]);
+	});
+});
+
+describe("artifactDisclosureRecordFromMemory", () => {
+	it("normalizes stored metadata into a disclosure record", () => {
+		const memory = {
+			entityId: OTHER,
+			metadata: {
+				scope: "user-private",
+				scopedToEntityId: VIEWER,
+				share: {
+					grants: [{ entityId: OTHER, mode: "redacted" }],
+					roomSnapshot: {
+						roomId: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+						entityIds: [VIEWER],
+						atMs: 123,
+					},
+				},
+			},
+		} as Pick<Memory, "entityId" | "metadata">;
+
+		expect(artifactDisclosureRecordFromMemory(memory)).toEqual({
+			scope: "user-private",
+			scopedEntityId: VIEWER,
+			grants: [{ entityId: OTHER, mode: "redacted" }],
+		});
+	});
+
+	it("fails closed on malformed scope and grants", () => {
+		const memory = {
+			entityId: OTHER,
+			metadata: {
+				scope: "public-to-everyone",
+				scopedToEntityId: "not-a-uuid",
+				share: {
+					grants: [{ entityId: VIEWER, mode: "everything" }],
+				},
+			},
+		} as Pick<Memory, "entityId" | "metadata">;
+
+		expect(artifactDisclosureRecordFromMemory(memory)).toEqual({
+			scope: "owner-private",
+			scopedEntityId: OTHER,
+			grants: [],
+		});
+	});
+
+	it("resolves disclosure from a memory row using stored share metadata", () => {
+		const memory = {
+			entityId: OWNER,
+			metadata: {
+				scope: "owner-private",
+				share: {
+					grants: [{ entityId: VIEWER, mode: "redacted" }],
+				},
+			},
+		} as Pick<Memory, "entityId" | "metadata">;
+
+		expect(
+			resolveArtifactDisclosureForMemory(memory, ctx({ role: "USER" }), AGENT),
+		).toBe("redacted");
+	});
+});
+
+describe("selectDisclosedArtifactUrl", () => {
+	it("returns the original URL for full disclosure", () => {
+		expect(
+			selectDisclosedArtifactUrl("full", {
+				fullUrl: "/api/media/original.wav",
+				redactedUrl: "/api/media/redacted.wav",
+			}),
+		).toEqual({
+			disclosure: "full",
+			url: "/api/media/original.wav",
+			redacted: false,
+		});
+	});
+
+	it("returns the redacted URL for redacted disclosure", () => {
+		expect(
+			selectDisclosedArtifactUrl("redacted", {
+				fullUrl: "/api/media/original.wav",
+				redactedUrl: "/api/media/redacted.wav",
+			}),
+		).toEqual({
+			disclosure: "redacted",
+			url: "/api/media/redacted.wav",
+			redacted: true,
+		});
+	});
+
+	it("omits redacted disclosure when no redacted variant exists", () => {
+		expect(
+			selectDisclosedArtifactUrl("redacted", {
+				fullUrl: "/api/media/original.wav",
+			}),
+		).toBeNull();
+	});
+
+	it("omits none or missing original URL", () => {
+		expect(
+			selectDisclosedArtifactUrl("none", {
+				fullUrl: "/api/media/original.wav",
+			}),
+		).toBeNull();
+		expect(selectDisclosedArtifactUrl("full", {})).toBeNull();
 	});
 });

--- a/packages/core/src/access-control/artifact-disclosure.ts
+++ b/packages/core/src/access-control/artifact-disclosure.ts
@@ -21,25 +21,25 @@
  * evaluates what is stored. Default-matrix ratification is tracked in #14777 —
  * revisit the ordering below if D4/D5 land differently.
  */
-import type { AccessContext, MemoryScope, UUID } from "../types";
+import type {
+	AccessContext,
+	ArtifactShareGrant,
+	ArtifactShareGrantMode,
+	ArtifactShareMetadata,
+	Memory,
+	MemoryScope,
+	UUID,
+} from "../types";
 import { actorFromAccessContext, canReadScope } from "./filter";
 
 /** What a viewer's DTO may contain for one artifact. */
 export type ArtifactDisclosure = "full" | "redacted" | "none";
 
-/** Per-viewer grant mode an owner can attach to an artifact reference. */
-export type ArtifactShareGrantMode = "full" | "redacted";
-
-/** One per-entity share grant stored on the referencing record. */
-export interface ArtifactShareGrant {
-	/** Entity the grant is issued to. */
-	entityId: UUID;
-	mode: ArtifactShareGrantMode;
-	/** Entity that issued the grant. */
-	grantedBy?: UUID;
-	/** Epoch ms the grant was issued. */
-	grantedAtMs?: number;
-}
+export type {
+	ArtifactShareGrant,
+	ArtifactShareGrantMode,
+	ArtifactShareMetadata,
+};
 
 const UUID_PATTERN =
 	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -91,6 +91,52 @@ export interface ArtifactDisclosureRecord {
 	grants?: readonly ArtifactShareGrant[];
 }
 
+function normalizeScope(value: unknown): MemoryScope {
+	switch (value) {
+		case "shared":
+		case "private":
+		case "room":
+		case "global":
+		case "owner-private":
+		case "user-private":
+		case "agent-private":
+			return value;
+		default:
+			return "owner-private";
+	}
+}
+
+function stringUuid(value: unknown): UUID | undefined {
+	return typeof value === "string" && UUID_PATTERN.test(value)
+		? (value as UUID)
+		: undefined;
+}
+
+/**
+ * Normalize one stored memory into the artifact-disclosure record shape.
+ *
+ * Storage metadata is jsonb and therefore untrusted at read time. Unknown scope
+ * values collapse to `owner-private`, and malformed grants/scoped ids are
+ * ignored, so a corrupt row cannot widen disclosure by accident.
+ */
+export function artifactDisclosureRecordFromMemory(
+	memory: Pick<Memory, "entityId" | "metadata">,
+): ArtifactDisclosureRecord {
+	const metadata =
+		memory.metadata && typeof memory.metadata === "object"
+			? (memory.metadata as Record<string, unknown>)
+			: undefined;
+	const scopedEntityId =
+		stringUuid(metadata?.scopedToEntityId) ??
+		stringUuid(metadata?.addedBy) ??
+		memory.entityId;
+	return {
+		scope: normalizeScope(metadata?.scope),
+		...(scopedEntityId ? { scopedEntityId } : {}),
+		grants: parseArtifactShareGrants(metadata),
+	};
+}
+
 /**
  * Decide what `ctx`'s requester may see of one artifact record.
  *
@@ -124,4 +170,49 @@ export function resolveArtifactDisclosure(
 	return canReadScope(record.scope, record.scopedEntityId, actor)
 		? "full"
 		: "none";
+}
+
+/** Resolve artifact disclosure directly from a memory row. */
+export function resolveArtifactDisclosureForMemory(
+	memory: Pick<Memory, "entityId" | "metadata">,
+	ctx: AccessContext | undefined,
+	agentId: UUID,
+): ArtifactDisclosure {
+	return resolveArtifactDisclosure(
+		artifactDisclosureRecordFromMemory(memory),
+		ctx,
+		agentId,
+	);
+}
+
+export interface ArtifactVariantUrls {
+	fullUrl?: string | null;
+	redactedUrl?: string | null;
+}
+
+export interface DisclosedArtifactUrl {
+	disclosure: Exclude<ArtifactDisclosure, "none">;
+	url: string;
+	redacted: boolean;
+}
+
+/**
+ * Select the URL a DTO may disclose for a resolved artifact decision.
+ *
+ * A redacted grant is fail-closed: if no redacted variant exists yet, callers
+ * must omit the artifact instead of falling back to the original bytes.
+ */
+export function selectDisclosedArtifactUrl(
+	disclosure: ArtifactDisclosure,
+	urls: ArtifactVariantUrls,
+): DisclosedArtifactUrl | null {
+	if (disclosure === "none") return null;
+	if (disclosure === "redacted") {
+		return typeof urls.redactedUrl === "string" && urls.redactedUrl.length > 0
+			? { disclosure, url: urls.redactedUrl, redacted: true }
+			: null;
+	}
+	return typeof urls.fullUrl === "string" && urls.fullUrl.length > 0
+		? { disclosure, url: urls.fullUrl, redacted: false }
+		: null;
 }

--- a/packages/core/src/types/memory.ts
+++ b/packages/core/src/types/memory.ts
@@ -41,6 +41,36 @@ export type MemoryScope =
 	| "user-private"
 	| "agent-private";
 
+/** Per-viewer artifact grant mode stored on a referencing record. */
+export type ArtifactShareGrantMode = "full" | "redacted";
+
+/** One per-entity artifact share grant. */
+export interface ArtifactShareGrant {
+	entityId: UUID;
+	mode: ArtifactShareGrantMode;
+	grantedBy?: UUID;
+	grantedAtMs?: number;
+}
+
+/** Participant set captured at share time for room-scoped grants. */
+export interface ArtifactRoomSnapshot {
+	roomId: UUID;
+	entityIds: UUID[];
+	atMs: number;
+}
+
+/**
+ * Reference-layer sharing metadata for artifacts linked from this record.
+ *
+ * Grants live on the referencing memory/document/transcript row rather than a
+ * sha256-keyed file table, preserving the content-addressed attachment
+ * doctrine while giving disclosure surfaces one auditable place to evaluate.
+ */
+export interface ArtifactShareMetadata {
+	grants?: ArtifactShareGrant[];
+	roomSnapshot?: ArtifactRoomSnapshot;
+}
+
 /**
  * Base interface for all memory metadata types.
  */
@@ -51,6 +81,7 @@ export interface BaseMetadata {
 	scope?: MemoryScope;
 	timestamp?: number;
 	tags?: string[];
+	share?: ArtifactShareMetadata;
 }
 
 export interface DocumentMetadata {


### PR DESCRIPTION
## Summary
- Types `metadata.share` on memory metadata for reference-layer artifact grants and room snapshots.
- Adds `artifactDisclosureRecordFromMemory()` and `resolveArtifactDisclosureForMemory()` so disclosure surfaces do not hand-roll metadata parsing.
- Adds `selectDisclosedArtifactUrl()` so redacted grants fail closed when a redacted variant does not exist instead of falling back to original bytes.

## Issue
- Part of #14778

## Validation
- `bun run --cwd packages/core test -- src/access-control/artifact-disclosure.test.ts` (20 tests passed)
- `bun run --cwd packages/core typecheck` (passed)
- `bun run --cwd packages/core build` (Node/browser/edge/testing builds passed)
- `bun x biome check packages/core/src/types/memory.ts packages/core/src/access-control/artifact-disclosure.ts packages/core/src/access-control/artifact-disclosure.test.ts` (passed)
- `git diff --check && bun run audit:error-policy-ratchet` (passed)

## Evidence
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots: N/A - core access-control/type-surface foundation only; no UI surface changed.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots: N/A - core access-control/type-surface foundation only; no UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: N/A - no runnable UI flow changed in this slice.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs: N/A - pure predicate/type helper only; no HTTP route/service was invoked.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - no model/action/provider behavior changed; route/action wiring remains for later #14778/#14779 slices.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: [`packages/core/src/access-control/artifact-disclosure.ts`](https://github.com/elizaOS/eliza/blob/fix/14778-artifact-acl-predicate/packages/core/src/access-control/artifact-disclosure.ts), [`packages/core/src/types/memory.ts`](https://github.com/elizaOS/eliza/blob/fix/14778-artifact-acl-predicate/packages/core/src/types/memory.ts), and [`packages/core/src/access-control/artifact-disclosure.test.ts`](https://github.com/elizaOS/eliza/blob/fix/14778-artifact-acl-predicate/packages/core/src/access-control/artifact-disclosure.test.ts).