### PR TITLE
fix(video): auto-install bundled ffmpeg binary

### DIFF
--- a/plugins/plugin-video/AGENTS.md
+++ b/plugins/plugin-video/AGENTS.md
@@ -48,6 +48,7 @@ All vars are optional. The plugin falls back to managed-cache download when no o
 | `ELIZA_YT_DLP_PREFER_PATH` | `1` to prefer system PATH yt-dlp over the managed cache |
 | `ELIZA_DISABLE_YTDLP_AUTOUPDATE` | `1` to disable automatic yt-dlp self-update on extractor errors |
 | `ELIZA_FFMPEG_PATH` | Use this ffmpeg binary; overrides system PATH and `ffmpeg-static` |
+| `ELIZA_NODE_BIN` / `NODE_BINARY` | Node executable used when running the bundled ffmpeg installer from non-Node runtimes |
 | `ELIZA_BINARIES_DIR` | Directory where the managed yt-dlp binary and metadata are cached (default: `<stateDir>/binaries`) |
 
 `ELIZA_STATE_DIR` / `ELIZA_BINARIES_DIR` interact: `BinaryResolver` calls `resolveStateDir()` from `@elizaos/core` to find the default binaries directory.
@@ -75,7 +76,7 @@ Same pattern: create `src/providers/my-provider.ts`, export a `Provider`, and ad
 - **Service singleton per runtime.** `VideoService` keeps a serial `processingChain` promise so concurrent `processVideo` calls are queued; don't bypass this.
 - **Cache directory is `./content_cache`** relative to the process cwd. Files are never auto-deleted; callers are responsible for cleanup if storage is a concern.
 - **yt-dlp auto-update.** On extractor failures matching known error patterns (`Sign in to confirm`, `nsig extraction failed`, `HTTP Error 403`, etc.), `BinaryResolver` re-downloads yt-dlp from the GitHub releases API and retries. This is throttled to once per hour. Set `ELIZA_DISABLE_YTDLP_AUTOUPDATE=1` to disable.
-- **ffmpeg is required for audio extraction and thumbnail generation.** The plugin resolves it from `ELIZA_FFMPEG_PATH`, then system PATH, then the `ffmpeg-static` npm package. If none is found, ffmpeg operations throw at first invocation.
+- **ffmpeg is required for audio extraction and thumbnail generation.** The plugin resolves it from `ELIZA_FFMPEG_PATH`, then system PATH, then the `ffmpeg-static` npm package. If the package exists but its binary payload is missing because install scripts were skipped, the resolver runs the package installer once before declaring ffmpeg unavailable.
 - **Transcription fallback requires `ServiceType.TRANSCRIPTION`.** If no subtitles or captions exist and the video is not categorised as Music, `VideoService` calls `runtime.getService<ITranscriptionService>(ServiceType.TRANSCRIPTION)`. Load a plugin that registers an `ITranscriptionService` under `ServiceType.TRANSCRIPTION`, or this path throws "Transcription service not found".
 - **Direct MP4 URLs** are detected by extension and bypass yt-dlp for metadata; they use a simple HEAD check and fall back to yt-dlp if unreachable.
 - **`BinaryResolver` is a singleton** (`BinaryResolver.instance()`). In tests, call `BinaryResolver.resetForTests()` between cases to avoid state leakage.

--- a/plugins/plugin-video/CLAUDE.md
+++ b/plugins/plugin-video/CLAUDE.md
@@ -48,6 +48,7 @@ All vars are optional. The plugin falls back to managed-cache download when no o
 | `ELIZA_YT_DLP_PREFER_PATH` | `1` to prefer system PATH yt-dlp over the managed cache |
 | `ELIZA_DISABLE_YTDLP_AUTOUPDATE` | `1` to disable automatic yt-dlp self-update on extractor errors |
 | `ELIZA_FFMPEG_PATH` | Use this ffmpeg binary; overrides system PATH and `ffmpeg-static` |
+| `ELIZA_NODE_BIN` / `NODE_BINARY` | Node executable used when running the bundled ffmpeg installer from non-Node runtimes |
 | `ELIZA_BINARIES_DIR` | Directory where the managed yt-dlp binary and metadata are cached (default: `<stateDir>/binaries`) |
 
 `ELIZA_STATE_DIR` / `ELIZA_BINARIES_DIR` interact: `BinaryResolver` calls `resolveStateDir()` from `@elizaos/core` to find the default binaries directory.
@@ -75,7 +76,7 @@ Same pattern: create `src/providers/my-provider.ts`, export a `Provider`, and ad
 - **Service singleton per runtime.** `VideoService` keeps a serial `processingChain` promise so concurrent `processVideo` calls are queued; don't bypass this.
 - **Cache directory is `./content_cache`** relative to the process cwd. Files are never auto-deleted; callers are responsible for cleanup if storage is a concern.
 - **yt-dlp auto-update.** On extractor failures matching known error patterns (`Sign in to confirm`, `nsig extraction failed`, `HTTP Error 403`, etc.), `BinaryResolver` re-downloads yt-dlp from the GitHub releases API and retries. This is throttled to once per hour. Set `ELIZA_DISABLE_YTDLP_AUTOUPDATE=1` to disable.
-- **ffmpeg is required for audio extraction and thumbnail generation.** The plugin resolves it from `ELIZA_FFMPEG_PATH`, then system PATH, then the `ffmpeg-static` npm package. If none is found, ffmpeg operations throw at first invocation.
+- **ffmpeg is required for audio extraction and thumbnail generation.** The plugin resolves it from `ELIZA_FFMPEG_PATH`, then system PATH, then the `ffmpeg-static` npm package. If the package exists but its binary payload is missing because install scripts were skipped, the resolver runs the package installer once before declaring ffmpeg unavailable.
 - **Transcription fallback requires `ServiceType.TRANSCRIPTION`.** If no subtitles or captions exist and the video is not categorised as Music, `VideoService` calls `runtime.getService<ITranscriptionService>(ServiceType.TRANSCRIPTION)`. Load a plugin that registers an `ITranscriptionService` under `ServiceType.TRANSCRIPTION`, or this path throws "Transcription service not found".
 - **Direct MP4 URLs** are detected by extension and bypass yt-dlp for metadata; they use a simple HEAD check and fall back to yt-dlp if unreachable.
 - **`BinaryResolver` is a singleton** (`BinaryResolver.instance()`). In tests, call `BinaryResolver.resetForTests()` between cases to avoid state leakage.

--- a/plugins/plugin-video/README.md
+++ b/plugins/plugin-video/README.md
@@ -59,10 +59,11 @@ None are required. The plugin resolves binaries automatically.
 | `ELIZA_YT_DLP_PREFER_PATH` | `1` to prefer system `yt-dlp` over the managed cache | `0` |
 | `ELIZA_DISABLE_YTDLP_AUTOUPDATE` | `1` to disable automatic yt-dlp updates on failure | `0` |
 | `ELIZA_FFMPEG_PATH` | Path to a specific ffmpeg binary | Auto-resolved |
+| `ELIZA_NODE_BIN` / `NODE_BINARY` | Node executable used when running the bundled ffmpeg installer from non-Node runtimes | `node` |
 | `ELIZA_BINARIES_DIR` | Directory where managed yt-dlp is cached | `<stateDir>/binaries` |
 
 ## System dependencies
 
-- **ffmpeg** — required for audio extraction, thumbnail generation, and video conversion. Resolved from `ELIZA_FFMPEG_PATH`, then system PATH, then the bundled `ffmpeg-static` npm package.
+- **ffmpeg** — required for audio extraction, thumbnail generation, and video conversion. Resolved from `ELIZA_FFMPEG_PATH`, then system PATH, then the bundled `ffmpeg-static` npm package; if the static package is present without its downloaded binary, the plugin runs its installer once.
 - **yt-dlp** — required for YouTube/Vimeo downloads and subtitle extraction. Resolved from `ELIZA_YT_DLP_PATH`, system PATH, or automatically downloaded and cached from GitHub releases.
 - **Transcription service** — needed only for the audio-transcription fallback path. Any plugin that registers an `ITranscriptionService` under `ServiceType.TRANSCRIPTION` will work.

--- a/plugins/plugin-video/src/services/binaries.test.ts
+++ b/plugins/plugin-video/src/services/binaries.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Binary resolver unit coverage for platform-neutral helper logic. The real
+ * downloader and ffmpeg probes are covered by the opt-in integration test so
+ * the default suite stays deterministic.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  ffmpegStaticExecutableName,
+  resolveFfmpegStaticCandidatePath,
+  resolveNodeInstallRunner,
+} from "./binaries";
+
+describe("resolveNodeInstallRunner", () => {
+  it("keeps the current executable when already running under Node", () => {
+    expect(
+      resolveNodeInstallRunner({
+        env: {},
+        execPath: "/opt/node/bin/node",
+      }),
+    ).toBe("/opt/node/bin/node");
+    expect(
+      resolveNodeInstallRunner({
+        env: {},
+        execPath: "C:\\Program Files\\nodejs\\node.exe",
+      }),
+    ).toBe("C:\\Program Files\\nodejs\\node.exe");
+  });
+
+  it("uses node from PATH when invoked under Bun", () => {
+    expect(
+      resolveNodeInstallRunner({
+        env: {},
+        execPath: "/opt/homebrew/bin/bun",
+      }),
+    ).toBe("node");
+  });
+
+  it("honors an explicit Node binary override", () => {
+    expect(
+      resolveNodeInstallRunner({
+        env: { ELIZA_NODE_BIN: "/custom/node" },
+        execPath: "/opt/homebrew/bin/bun",
+      }),
+    ).toBe("/custom/node");
+    expect(
+      resolveNodeInstallRunner({
+        env: { NODE_BINARY: "/toolchain/node" },
+        execPath: "/opt/homebrew/bin/bun",
+      }),
+    ).toBe("/toolchain/node");
+  });
+});
+
+describe("resolveFfmpegStaticCandidatePath", () => {
+  it("uses the package-local ffmpeg binary path on Unix-like platforms", () => {
+    expect(
+      resolveFfmpegStaticCandidatePath({
+        packageRoot: "/repo/node_modules/ffmpeg-static",
+        platform: "linux",
+      }),
+    ).toBe("/repo/node_modules/ffmpeg-static/ffmpeg");
+    expect(ffmpegStaticExecutableName("darwin")).toBe("ffmpeg");
+  });
+
+  it("uses the package-local ffmpeg.exe path on Windows", () => {
+    expect(
+      resolveFfmpegStaticCandidatePath({
+        packageRoot: "C:\\repo\\node_modules\\ffmpeg-static",
+        platform: "win32",
+      }),
+    ).toBe("C:\\repo\\node_modules\\ffmpeg-static\\ffmpeg.exe");
+    expect(ffmpegStaticExecutableName("win32")).toBe("ffmpeg.exe");
+  });
+
+  it("returns null when ffmpeg-static is not installed", () => {
+    expect(resolveFfmpegStaticCandidatePath({ packageRoot: null })).toBeNull();
+  });
+});

--- a/plugins/plugin-video/src/services/binaries.ts
+++ b/plugins/plugin-video/src/services/binaries.ts
@@ -1,14 +1,27 @@
+/**
+ * Managed binary resolution for video extraction and transcoding tools. The
+ * service owns yt-dlp cache updates and locates ffmpeg from explicit config,
+ * the host PATH, or the packaged static binary so callers can use VideoService
+ * without depending on machine-specific setup.
+ */
+
+import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
   createWriteStream,
   constants as fsConstants,
   promises as fsp,
 } from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
+import { promisify } from "node:util";
 import { elizaLogger, resolveStateDir } from "@elizaos/core";
 import youtubeDl from "youtube-dl-exec";
+
+const require = createRequire(import.meta.url);
+const execFileAsync = promisify(execFile);
 
 export type YtDlpRunner = (
   url: string,
@@ -39,6 +52,10 @@ const YT_DLP_RELEASE_URL =
   "https://api.github.com/repos/yt-dlp/yt-dlp/releases/latest";
 const YT_DLP_UPDATE_THROTTLE_MS = 60 * 60 * 1000;
 const YT_DLP_META_FILENAME = "yt-dlp.meta.json";
+
+let ffmpegStaticInstallPromise: Promise<
+  { installed: true } | { installed: false; reason: string }
+> | null = null;
 
 interface GitHubAsset {
   name: string;
@@ -216,7 +233,13 @@ export class BinaryResolver {
     return cachePath;
   }
 
-  /** Resolution order: ELIZA_FFMPEG_PATH env → system ffmpeg → ffmpeg-static. */
+  /**
+   * Resolution order: ELIZA_FFMPEG_PATH env → system ffmpeg → ffmpeg-static.
+   *
+   * Some installs intentionally skip dependency postinstall scripts. In that
+   * case `ffmpeg-static` is present but its binary payload is absent, so this
+   * resolver runs that package's installer once before declaring ffmpeg missing.
+   */
   async getFfmpegPath(): Promise<string | null> {
     if (this.resolvedFfmpegPath !== undefined) return this.resolvedFfmpegPath;
 
@@ -232,26 +255,13 @@ export class BinaryResolver {
       return sys;
     }
 
-    try {
-      const mod: unknown = await import("ffmpeg-static");
-      const staticPath =
-        typeof mod === "string"
-          ? mod
-          : mod && typeof mod === "object" && "default" in mod
-            ? (mod.default as string | null | undefined)
-            : null;
-      if (
-        typeof staticPath === "string" &&
-        staticPath.length > 0 &&
-        (await isExecutable(staticPath))
-      ) {
-        this.resolvedFfmpegPath = staticPath;
-        return staticPath;
-      }
-    } catch (err) {
-      elizaLogger.warn(
-        `[plugin-video] ffmpeg-static not loadable: ${describeError(err)}`,
-      );
+    const bundled = await resolveBundledFfmpegPath();
+    if (bundled.path) {
+      this.resolvedFfmpegPath = bundled.path;
+      return bundled.path;
+    }
+    if (bundled.reason) {
+      elizaLogger.warn(`[plugin-video] ${bundled.reason}`);
     }
 
     this.resolvedFfmpegPath = null;
@@ -518,6 +528,27 @@ export function ytDlpFileName(): string {
   return process.platform === "win32" ? "yt-dlp.exe" : "yt-dlp";
 }
 
+function isNodeExecutable(candidate: string): boolean {
+  return /^(node|nodejs)(\.exe)?$/i.test(candidate);
+}
+
+export function resolveNodeInstallRunner({
+  env = process.env,
+  execPath = process.execPath,
+}: {
+  env?: NodeJS.ProcessEnv;
+  execPath?: string;
+} = {}): string {
+  const configured = env.ELIZA_NODE_BIN?.trim() || env.NODE_BINARY?.trim();
+  if (configured) return configured;
+
+  const posixName = path.basename(execPath);
+  const winName = path.win32.basename(execPath);
+  return isNodeExecutable(posixName) || isNodeExecutable(winName)
+    ? execPath
+    : "node";
+}
+
 async function isExecutable(p: string): Promise<boolean> {
   try {
     await fsp.access(p, fsConstants.X_OK);
@@ -526,6 +557,142 @@ async function isExecutable(p: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+export function ffmpegStaticExecutableName(
+  platform: NodeJS.Platform = process.platform,
+): string {
+  return platform === "win32" ? "ffmpeg.exe" : "ffmpeg";
+}
+
+export function resolveFfmpegStaticCandidatePath({
+  packageRoot = ffmpegStaticRoot(),
+  platform = process.platform,
+}: {
+  packageRoot?: string | null;
+  platform?: NodeJS.Platform;
+} = {}): string | null {
+  const pathApi = platform === "win32" ? path.win32 : path;
+  return packageRoot === null
+    ? null
+    : pathApi.join(packageRoot, ffmpegStaticExecutableName(platform));
+}
+
+async function ffmpegStaticPath(): Promise<{
+  path: string | null;
+  reason?: string;
+}> {
+  try {
+    const mod: unknown = await import("ffmpeg-static");
+    const staticPath =
+      typeof mod === "string"
+        ? mod
+        : mod && typeof mod === "object" && "default" in mod
+          ? (mod.default as string | null | undefined)
+          : null;
+    if (typeof staticPath === "string" && staticPath.length > 0) {
+      return { path: staticPath };
+    }
+    return {
+      path: resolveFfmpegStaticCandidatePath(),
+      reason: "ffmpeg-static did not expose a binary path",
+    };
+  } catch (err) {
+    // error-policy:J3 optional packaged binary — absence is reported by caller.
+    const candidate = resolveFfmpegStaticCandidatePath();
+    if (candidate) {
+      return {
+        path: candidate,
+        reason: `ffmpeg-static not loadable before install: ${describeError(err)}`,
+      };
+    }
+    return {
+      path: null,
+      reason: `ffmpeg-static not loadable: ${describeError(err)}`,
+    };
+  }
+}
+
+function ffmpegStaticRoot(): string | null {
+  try {
+    return path.dirname(require.resolve("ffmpeg-static/package.json"));
+  } catch (err) {
+    // error-policy:J3 optional packaged binary — absence is reported by caller.
+    void err;
+  }
+  return null;
+}
+
+async function fileExists(p: string): Promise<boolean> {
+  try {
+    await fsp.access(p, fsConstants.F_OK);
+    return true;
+  } catch {
+    // error-policy:J3 optional packaged binary — absence is reported by caller.
+    return false;
+  }
+}
+
+async function installFfmpegStaticOnce(): Promise<
+  { installed: true } | { installed: false; reason: string }
+> {
+  ffmpegStaticInstallPromise ??= (async () => {
+    const root = ffmpegStaticRoot();
+    if (root === null) {
+      return {
+        installed: false,
+        reason: "ffmpeg-static package is not installed",
+      };
+    }
+
+    const installer = path.join(root, "install.js");
+    if (!(await fileExists(installer))) {
+      return {
+        installed: false,
+        reason: "ffmpeg-static install script is missing",
+      };
+    }
+
+    try {
+      const nodeRunner = resolveNodeInstallRunner();
+      await execFileAsync(nodeRunner, [installer], {
+        cwd: root,
+        timeout: 120_000,
+      });
+      elizaLogger.log("[plugin-video] ffmpeg-static binary installed.");
+      return { installed: true };
+    } catch (err) {
+      // error-policy:J3 optional packaged binary — caller reports unavailable tool.
+      return {
+        installed: false,
+        reason: `ffmpeg-static install failed: ${describeError(err).slice(0, 160)}`,
+      };
+    }
+  })();
+
+  return ffmpegStaticInstallPromise;
+}
+
+async function resolveBundledFfmpegPath(): Promise<{
+  path: string | null;
+  reason?: string;
+}> {
+  const bundled = await ffmpegStaticPath();
+  if (!bundled.path) return bundled;
+  if (await isExecutable(bundled.path)) return bundled;
+
+  const installed = await installFfmpegStaticOnce();
+  if (!installed.installed) {
+    return { path: null, reason: installed.reason };
+  }
+
+  const installedPath = bundled.path ?? resolveFfmpegStaticCandidatePath();
+  return installedPath !== null && (await isExecutable(installedPath))
+    ? bundled
+    : {
+        path: null,
+        reason: `ffmpeg-static install completed but ${installedPath ?? "the expected binary"} is still missing or not executable`,
+      };
 }
 
 /**


### PR DESCRIPTION
Closes #15591.

## Summary

- Keep ffmpeg required for plugin-video, but make the bundled `ffmpeg-static` repair path automatic when install scripts skipped its binary payload.
- Run `ffmpeg-static/install.js` once through a deterministic Node runner when the static package is present but unusable.
- Document `ELIZA_NODE_BIN` / `NODE_BINARY` and add unit coverage for runner and bundled-path resolution.

## Evidence

- `bunx vitest run plugins/plugin-video/src/services/binaries.test.ts`
  - 1 file passed, 6 tests passed.
- `bun run --cwd plugins/plugin-video typecheck`
  - passed.
- `bunx @biomejs/biome check plugins/plugin-video/src/services/binaries.ts plugins/plugin-video/src/services/binaries.test.ts plugins/plugin-video/README.md plugins/plugin-video/CLAUDE.md plugins/plugin-video/AGENTS.md`
  - passed, no fixes applied.
- `bun run --cwd plugins/plugin-video test`
  - 2 files passed, 1 skipped; 8 tests passed, 4 skipped.
- `git diff --check origin/develop...HEAD && bun run audit:error-policy-ratchet --report`
  - passed; no new fallback-slop in touched files.
- Live resolver probe with system ffmpeg hidden from `PATH`:
  - returned `/home/shaw/milady/eliza/node_modules/.bun/ffmpeg-static@5.3.0+759ce506b1ed1a42/node_modules/ffmpeg-static/ffmpeg`.

## Evidence N/A

- UI screenshots/video: N/A - backend/plugin binary-resolution change only.
- Real-LLM trajectories: N/A - no action/provider/prompt/model behavior changed.
- OCR: N/A - no screenshots or visual artifacts were generated for this backend-only change.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend/plugin binary-resolution change; no rendered surface changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend/plugin binary-resolution change; no rendered surface changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend/plugin binary-resolution change; no UI flow to record.

<!-- evidence-row:backend-logs -->
- [ ] N/A - local validation was focused unit/typecheck/resolver execution, not a running server route.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no action/provider/prompt/model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] [15592-pr15592-domain-artifacts.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15592-pr15592-domain-artifacts.txt)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no screenshots or visual artifacts were generated for this backend-only change.
