### PR TITLE
fix(core): add artifact share disclosure metadata

### DIFF
--- a/packages/core/src/access-control/artifact-disclosure.test.ts
+++ b/packages/core/src/access-control/artifact-disclosure.test.ts
@@ -6,8 +6,11 @@
 import { describe, expect, it } from "vitest";
 import type { AccessContext, UUID } from "../types";
 import {
+	canAccessArtifact,
 	parseArtifactShareGrants,
+	parseArtifactShareMetadata,
 	resolveArtifactDisclosure,
+	selectArtifactVariant,
 } from "./artifact-disclosure";
 
 const AGENT = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" as UUID;
@@ -55,6 +58,20 @@ describe("resolveArtifactDisclosure", () => {
 					scope: "owner-private",
 					scopedEntityId: OWNER,
 					grants: [{ entityId: VIEWER, mode: "full" }],
+				},
+				ctx({ role: "USER" }),
+				AGENT,
+			),
+		).toBe("full");
+	});
+
+	it("accepts the typed share metadata contract directly", () => {
+		expect(
+			resolveArtifactDisclosure(
+				{
+					scope: "owner-private",
+					scopedEntityId: OWNER,
+					share: { grants: [{ entityId: VIEWER, mode: "full" }] },
 				},
 				ctx({ role: "USER" }),
 				AGENT,
@@ -158,6 +175,72 @@ describe("resolveArtifactDisclosure", () => {
 	});
 });
 
+describe("canAccessArtifact", () => {
+	it("returns true for full and redacted disclosures, false for omitted rows", () => {
+		expect(
+			canAccessArtifact(
+				{
+					scope: "owner-private",
+					grants: [{ entityId: VIEWER, mode: "full" }],
+				},
+				ctx({ role: "USER" }),
+				AGENT,
+			),
+		).toBe(true);
+		expect(
+			canAccessArtifact(
+				{
+					scope: "owner-private",
+					grants: [{ entityId: VIEWER, mode: "redacted" }],
+				},
+				ctx({ role: "USER" }),
+				AGENT,
+			),
+		).toBe(true);
+		expect(
+			canAccessArtifact(
+				{ scope: "owner-private", scopedEntityId: OWNER },
+				ctx({ role: "USER" }),
+				AGENT,
+			),
+		).toBe(false);
+	});
+});
+
+describe("selectArtifactVariant", () => {
+	it("selects full references only for full disclosure", () => {
+		expect(
+			selectArtifactVariant("full", {
+				full: "/api/media/full.wav",
+				redacted: "/api/media/redacted.txt",
+			}),
+		).toEqual({ disclosure: "full", value: "/api/media/full.wav" });
+	});
+
+	it("selects redacted references without falling back to full bytes", () => {
+		expect(
+			selectArtifactVariant("redacted", {
+				full: "/api/media/full.wav",
+				redacted: "/api/media/redacted.txt",
+			}),
+		).toEqual({ disclosure: "redacted", value: "/api/media/redacted.txt" });
+		expect(
+			selectArtifactVariant("redacted", {
+				full: "/api/media/full.wav",
+			}),
+		).toBeNull();
+	});
+
+	it("omits artifacts for none disclosure", () => {
+		expect(
+			selectArtifactVariant("none", {
+				full: "/api/media/full.wav",
+				redacted: "/api/media/redacted.txt",
+			}),
+		).toBeNull();
+	});
+});
+
 describe("parseArtifactShareGrants", () => {
 	it("parses well-formed grants and preserves issuer fields", () => {
 		const grants = parseArtifactShareGrants({
@@ -203,5 +286,46 @@ describe("parseArtifactShareGrants", () => {
 		expect(parseArtifactShareGrants({})).toEqual([]);
 		expect(parseArtifactShareGrants({ share: "nope" })).toEqual([]);
 		expect(parseArtifactShareGrants({ share: { grants: "nope" } })).toEqual([]);
+	});
+});
+
+describe("parseArtifactShareMetadata", () => {
+	it("parses grants and the room snapshot contract", () => {
+		expect(
+			parseArtifactShareMetadata({
+				share: {
+					grants: [{ entityId: VIEWER, mode: "full" }],
+					roomSnapshot: {
+						roomId: OWNER,
+						entityIds: [VIEWER, OTHER],
+						atMs: 456,
+					},
+				},
+			}),
+		).toEqual({
+			grants: [{ entityId: VIEWER, mode: "full" }],
+			roomSnapshot: {
+				roomId: OWNER,
+				entityIds: [VIEWER, OTHER],
+				atMs: 456,
+			},
+		});
+	});
+
+	it("drops malformed room snapshots without dropping valid grants", () => {
+		expect(
+			parseArtifactShareMetadata({
+				share: {
+					grants: [{ entityId: VIEWER, mode: "redacted" }],
+					roomSnapshot: {
+						roomId: OWNER,
+						entityIds: [VIEWER, "not-a-uuid"],
+						atMs: 789,
+					},
+				},
+			}),
+		).toEqual({
+			grants: [{ entityId: VIEWER, mode: "redacted" }],
+		});
 	});
 });

--- a/packages/core/src/access-control/artifact-disclosure.ts
+++ b/packages/core/src/access-control/artifact-disclosure.ts
@@ -21,11 +21,28 @@
  * evaluates what is stored. Default-matrix ratification is tracked in #14777 —
  * revisit the ordering below if D4/D5 land differently.
  */
-import type { AccessContext, MemoryScope, UUID } from "../types";
+import type {
+	AccessContext,
+	ArtifactShareMetadata,
+	MemoryScope,
+	UUID,
+} from "../types";
 import { actorFromAccessContext, canReadScope } from "./filter";
 
 /** What a viewer's DTO may contain for one artifact. */
 export type ArtifactDisclosure = "full" | "redacted" | "none";
+
+/** Full and redacted artifact references carried by a DTO-capable record. */
+export interface ArtifactVariantReferences<TFull, TRedacted = TFull> {
+	full: TFull;
+	redacted?: TRedacted | null;
+}
+
+/** The concrete reference a disclosure DTO should emit. */
+export interface ResolvedArtifactVariant<T> {
+	disclosure: Exclude<ArtifactDisclosure, "none">;
+	value: T;
+}
 
 /** Per-viewer grant mode an owner can attach to an artifact reference. */
 export type ArtifactShareGrantMode = "full" | "redacted";
@@ -41,6 +58,19 @@ export interface ArtifactShareGrant {
 	grantedAtMs?: number;
 }
 
+/** Room roster captured with a share so later disclosure can be replayed. */
+export interface ArtifactShareRoomSnapshot {
+	roomId: UUID;
+	entityIds: UUID[];
+	atMs: number;
+}
+
+/** Typed share metadata parsed from a record's jsonb metadata. */
+export interface ParsedArtifactShareMetadata {
+	grants: ArtifactShareGrant[];
+	roomSnapshot?: ArtifactShareRoomSnapshot;
+}
+
 const UUID_PATTERN =
 	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -51,34 +81,70 @@ const UUID_PATTERN =
  */
 // error-policy:J3 untrusted-input sanitizing — stored jsonb is untyped at rest;
 // invalid grant entries yield an explicit empty result, never a fake grant.
+export function parseArtifactShareMetadata(
+	metadata: unknown,
+): ParsedArtifactShareMetadata {
+	if (!metadata || typeof metadata !== "object") return { grants: [] };
+	const share = (metadata as { share?: unknown }).share;
+	if (!share || typeof share !== "object") return { grants: [] };
+	const grants = (share as { grants?: unknown }).grants;
+	const out: ArtifactShareGrant[] = [];
+	if (Array.isArray(grants)) {
+		for (const entry of grants) {
+			if (!entry || typeof entry !== "object") continue;
+			const g = entry as Record<string, unknown>;
+			const entityId = typeof g.entityId === "string" ? g.entityId : "";
+			const mode = g.mode;
+			if (!UUID_PATTERN.test(entityId)) continue;
+			if (mode !== "full" && mode !== "redacted") continue;
+			out.push({
+				entityId: entityId as UUID,
+				mode,
+				...(typeof g.grantedBy === "string" && UUID_PATTERN.test(g.grantedBy)
+					? { grantedBy: g.grantedBy as UUID }
+					: {}),
+				...(typeof g.grantedAtMs === "number"
+					? { grantedAtMs: g.grantedAtMs }
+					: {}),
+			});
+		}
+	}
+	const roomSnapshot = parseArtifactShareRoomSnapshot(
+		(share as { roomSnapshot?: unknown }).roomSnapshot,
+	);
+	return {
+		grants: out,
+		...(roomSnapshot ? { roomSnapshot } : {}),
+	};
+}
+
 export function parseArtifactShareGrants(
 	metadata: unknown,
 ): ArtifactShareGrant[] {
-	if (!metadata || typeof metadata !== "object") return [];
-	const share = (metadata as { share?: unknown }).share;
-	if (!share || typeof share !== "object") return [];
-	const grants = (share as { grants?: unknown }).grants;
-	if (!Array.isArray(grants)) return [];
-	const out: ArtifactShareGrant[] = [];
-	for (const entry of grants) {
-		if (!entry || typeof entry !== "object") continue;
-		const g = entry as Record<string, unknown>;
-		const entityId = typeof g.entityId === "string" ? g.entityId : "";
-		const mode = g.mode;
-		if (!UUID_PATTERN.test(entityId)) continue;
-		if (mode !== "full" && mode !== "redacted") continue;
-		out.push({
-			entityId: entityId as UUID,
-			mode,
-			...(typeof g.grantedBy === "string" && UUID_PATTERN.test(g.grantedBy)
-				? { grantedBy: g.grantedBy as UUID }
-				: {}),
-			...(typeof g.grantedAtMs === "number"
-				? { grantedAtMs: g.grantedAtMs }
-				: {}),
-		});
-	}
-	return out;
+	return parseArtifactShareMetadata(metadata).grants;
+}
+
+function parseArtifactShareRoomSnapshot(
+	value: unknown,
+): ArtifactShareRoomSnapshot | undefined {
+	if (!value || typeof value !== "object") return undefined;
+	const snapshot = value as Record<string, unknown>;
+	const roomId = typeof snapshot.roomId === "string" ? snapshot.roomId : "";
+	if (!UUID_PATTERN.test(roomId)) return undefined;
+	const atMs = snapshot.atMs;
+	if (typeof atMs !== "number") return undefined;
+	const entityIds = snapshot.entityIds;
+	if (!Array.isArray(entityIds)) return undefined;
+	const validEntityIds = entityIds.filter(
+		(entityId): entityId is UUID =>
+			typeof entityId === "string" && UUID_PATTERN.test(entityId),
+	);
+	if (validEntityIds.length !== entityIds.length) return undefined;
+	return {
+		roomId: roomId as UUID,
+		entityIds: validEntityIds,
+		atMs,
+	};
 }
 
 /** The disclosure-relevant fields of one artifact-referencing record. */
@@ -89,6 +155,8 @@ export interface ArtifactDisclosureRecord {
 	scopedEntityId?: UUID;
 	/** Parsed share grants from the record's metadata. */
 	grants?: readonly ArtifactShareGrant[];
+	/** Full typed share metadata when callers already carry the parsed contract. */
+	share?: ParsedArtifactShareMetadata | ArtifactShareMetadata;
 }
 
 /**
@@ -117,11 +185,37 @@ export function resolveArtifactDisclosure(
 	if (ctx.requesterEntityId === agentId) return "full";
 	const actor = actorFromAccessContext(ctx, agentId);
 	if (actor.role !== "USER") return "full";
-	const grant = record.grants?.find(
-		(g) => g.entityId === ctx.requesterEntityId,
-	);
+	const grants = record.grants ?? record.share?.grants;
+	const grant = grants?.find((g) => g.entityId === ctx.requesterEntityId);
 	if (grant) return grant.mode === "full" ? "full" : "redacted";
 	return canReadScope(record.scope, record.scopedEntityId, actor)
 		? "full"
 		: "none";
+}
+
+/** Boolean artifact predicate for disclosure points that only need allow/deny. */
+export function canAccessArtifact(
+	record: ArtifactDisclosureRecord,
+	ctx: AccessContext | undefined,
+	agentId: UUID,
+): boolean {
+	return resolveArtifactDisclosure(record, ctx, agentId) !== "none";
+}
+
+/**
+ * Select the concrete full/redacted reference for a DTO after the caller has
+ * resolved disclosure. A redacted grant never falls back to full bytes; if no
+ * redacted variant exists the artifact is omitted until the variant writer
+ * catches up.
+ */
+export function selectArtifactVariant<TFull, TRedacted = TFull>(
+	disclosure: ArtifactDisclosure,
+	references: ArtifactVariantReferences<TFull, TRedacted>,
+): ResolvedArtifactVariant<TFull | TRedacted> | null {
+	if (disclosure === "none") return null;
+	if (disclosure === "full") {
+		return { disclosure: "full", value: references.full };
+	}
+	if (references.redacted == null) return null;
+	return { disclosure: "redacted", value: references.redacted };
 }

--- a/packages/core/src/types/memory.ts
+++ b/packages/core/src/types/memory.ts
@@ -41,6 +41,31 @@ export type MemoryScope =
 	| "user-private"
 	| "agent-private";
 
+/** One entity-specific grant stored on the artifact's referencing record. */
+export interface ArtifactShareGrantMetadata {
+	entityId: UUID;
+	mode: "full" | "redacted";
+	grantedBy?: UUID;
+	grantedAtMs?: number;
+}
+
+/** Participant roster captured when a room-level artifact share is granted. */
+export interface ArtifactShareRoomSnapshotMetadata {
+	roomId: UUID;
+	entityIds: UUID[];
+	atMs: number;
+}
+
+/**
+ * Share metadata rides on the referencing record, never on the sha256 media
+ * object, so each artifact reference can choose full vs redacted disclosure
+ * without adding a file table or changing the pre-auth byte serve path.
+ */
+export interface ArtifactShareMetadata {
+	grants?: ArtifactShareGrantMetadata[];
+	roomSnapshot?: ArtifactShareRoomSnapshotMetadata;
+}
+
 /**
  * Base interface for all memory metadata types.
  */
@@ -51,6 +76,7 @@ export interface BaseMetadata {
 	scope?: MemoryScope;
 	timestamp?: number;
 	tags?: string[];
+	share?: ArtifactShareMetadata;
 }
 
 export interface DocumentMetadata {
@@ -460,6 +486,7 @@ interface MemoryMetadataBase {
 	scope?: MemoryScope;
 	timestamp?: number;
 	platformMessageId?: string;
+	share?: ArtifactShareMetadata;
 }
 
 export type MemoryMetadata = (


### PR DESCRIPTION
## Summary

Foundation slice for #14778. This adds the typed `metadata.share` contract on memory metadata, parses grants plus room-snapshot metadata fail-closed, exposes `canAccessArtifact`, and adds `selectArtifactVariant` so redacted grants cannot accidentally fall back to full bytes when a redacted variant is missing.

This intentionally does not wire every disclosure route yet; #14778 remains open until route enforcement, audit events, and grant/revoke e2e evidence are attached.

## Verification

```bash
bunx vitest run --config packages/core/vitest.config.ts packages/core/src/access-control/artifact-disclosure.test.ts packages/core/src/access-control/filter.test.ts
# 2 files passed, 40 tests passed

bunx @biomejs/biome check packages/core/src/access-control/artifact-disclosure.ts packages/core/src/access-control/artifact-disclosure.test.ts packages/core/src/types/memory.ts
# pass

git diff --check -- packages/core/src/access-control/artifact-disclosure.ts packages/core/src/access-control/artifact-disclosure.test.ts packages/core/src/types/memory.ts
# pass

bun run audit:error-policy-ratchet --report
# pass; no new fallback-slop
```

`bun run --cwd packages/core typecheck` was run. It no longer reports any artifact-disclosure export/type errors, but still fails on existing unrelated `src/features/advanced-capabilities/actions/message.ts:1798` and `post.ts:278` metadata-spread errors.

## Evidence

<!-- evidence-row:before-screenshots -->
N/A - pure core access-control/type contract; no UI pixels changed.

<!-- evidence-row:after-screenshots -->
N/A - pure core access-control/type contract; no UI pixels changed.

<!-- evidence-row:walkthrough-video -->
N/A - no user-facing UI flow in this foundation slice.

<!-- evidence-row:backend-logs -->
N/A - no server route/runtime path is invoked in this slice; focused pure-function tests are the relevant evidence.

<!-- evidence-row:frontend-logs -->
N/A - no frontend code changed.

<!-- evidence-row:llm-trajectory -->
N/A - no model/action/provider/evaluator path changed in this slice. Route/action e2e evidence remains required before #14778 can close.

<!-- evidence-row:domain-artifacts -->
N/A - this foundation slice creates no persisted runtime artifact; the domain contract is proven by the focused unit-test output above for grant parsing, room snapshot parsing, boolean predicate, and redacted variant selection.
