### PR TITLE
fix(core): add artifact share disclosure metadata helpers

### DIFF
--- a/packages/core/src/access-control/artifact-disclosure.test.ts
+++ b/packages/core/src/access-control/artifact-disclosure.test.ts
@@ -7,9 +7,12 @@ import { describe, expect, it } from "vitest";
 import type { AccessContext, Memory, UUID } from "../types";
 import {
 	artifactDisclosureRecordFromMemory,
+	canAccessArtifact,
 	parseArtifactShareGrants,
+	parseArtifactShareMetadata,
 	resolveArtifactDisclosure,
 	resolveArtifactDisclosureForMemory,
+	selectArtifactVariant,
 	selectDisclosedArtifactUrl,
 } from "./artifact-disclosure";
 
@@ -58,6 +61,20 @@ describe("resolveArtifactDisclosure", () => {
 					scope: "owner-private",
 					scopedEntityId: OWNER,
 					grants: [{ entityId: VIEWER, mode: "full" }],
+				},
+				ctx({ role: "USER" }),
+				AGENT,
+			),
+		).toBe("full");
+	});
+
+	it("accepts the typed share metadata contract directly", () => {
+		expect(
+			resolveArtifactDisclosure(
+				{
+					scope: "owner-private",
+					scopedEntityId: OWNER,
+					share: { grants: [{ entityId: VIEWER, mode: "full" }] },
 				},
 				ctx({ role: "USER" }),
 				AGENT,
@@ -158,6 +175,72 @@ describe("resolveArtifactDisclosure", () => {
 				AGENT,
 			),
 		).toBe("none");
+	});
+});
+
+describe("canAccessArtifact", () => {
+	it("returns true for full and redacted disclosures, false for omitted rows", () => {
+		expect(
+			canAccessArtifact(
+				{
+					scope: "owner-private",
+					grants: [{ entityId: VIEWER, mode: "full" }],
+				},
+				ctx({ role: "USER" }),
+				AGENT,
+			),
+		).toBe(true);
+		expect(
+			canAccessArtifact(
+				{
+					scope: "owner-private",
+					grants: [{ entityId: VIEWER, mode: "redacted" }],
+				},
+				ctx({ role: "USER" }),
+				AGENT,
+			),
+		).toBe(true);
+		expect(
+			canAccessArtifact(
+				{ scope: "owner-private", scopedEntityId: OWNER },
+				ctx({ role: "USER" }),
+				AGENT,
+			),
+		).toBe(false);
+	});
+});
+
+describe("selectArtifactVariant", () => {
+	it("selects full references only for full disclosure", () => {
+		expect(
+			selectArtifactVariant("full", {
+				full: "/api/media/full.wav",
+				redacted: "/api/media/redacted.txt",
+			}),
+		).toEqual({ disclosure: "full", value: "/api/media/full.wav" });
+	});
+
+	it("selects redacted references without falling back to full bytes", () => {
+		expect(
+			selectArtifactVariant("redacted", {
+				full: "/api/media/full.wav",
+				redacted: "/api/media/redacted.txt",
+			}),
+		).toEqual({ disclosure: "redacted", value: "/api/media/redacted.txt" });
+		expect(
+			selectArtifactVariant("redacted", {
+				full: "/api/media/full.wav",
+			}),
+		).toBeNull();
+	});
+
+	it("omits artifacts for none disclosure", () => {
+		expect(
+			selectArtifactVariant("none", {
+				full: "/api/media/full.wav",
+				redacted: "/api/media/redacted.txt",
+			}),
+		).toBeNull();
 	});
 });
 
@@ -312,5 +395,46 @@ describe("selectDisclosedArtifactUrl", () => {
 			}),
 		).toBeNull();
 		expect(selectDisclosedArtifactUrl("full", {})).toBeNull();
+	});
+});
+
+describe("parseArtifactShareMetadata", () => {
+	it("parses grants and the room snapshot contract", () => {
+		expect(
+			parseArtifactShareMetadata({
+				share: {
+					grants: [{ entityId: VIEWER, mode: "full" }],
+					roomSnapshot: {
+						roomId: OWNER,
+						entityIds: [VIEWER, OTHER],
+						atMs: 456,
+					},
+				},
+			}),
+		).toEqual({
+			grants: [{ entityId: VIEWER, mode: "full" }],
+			roomSnapshot: {
+				roomId: OWNER,
+				entityIds: [VIEWER, OTHER],
+				atMs: 456,
+			},
+		});
+	});
+
+	it("drops malformed room snapshots without dropping valid grants", () => {
+		expect(
+			parseArtifactShareMetadata({
+				share: {
+					grants: [{ entityId: VIEWER, mode: "redacted" }],
+					roomSnapshot: {
+						roomId: OWNER,
+						entityIds: [VIEWER, "not-a-uuid"],
+						atMs: 789,
+					},
+				},
+			}),
+		).toEqual({
+			grants: [{ entityId: VIEWER, mode: "redacted" }],
+		});
 	});
 });

--- a/packages/core/src/access-control/artifact-disclosure.ts
+++ b/packages/core/src/access-control/artifact-disclosure.ts
@@ -23,6 +23,7 @@
  */
 import type {
 	AccessContext,
+	ArtifactRoomSnapshot,
 	ArtifactShareGrant,
 	ArtifactShareGrantMode,
 	ArtifactShareMetadata,
@@ -36,10 +37,32 @@ import { actorFromAccessContext, canReadScope } from "./filter";
 export type ArtifactDisclosure = "full" | "redacted" | "none";
 
 export type {
+	ArtifactRoomSnapshot,
 	ArtifactShareGrant,
 	ArtifactShareGrantMode,
 	ArtifactShareMetadata,
 };
+
+/** Full and redacted artifact references carried by a DTO-capable record. */
+export interface ArtifactVariantReferences<TFull, TRedacted = TFull> {
+	full: TFull;
+	redacted?: TRedacted | null;
+}
+
+/** The concrete reference a disclosure DTO should emit. */
+export interface ResolvedArtifactVariant<T> {
+	disclosure: Exclude<ArtifactDisclosure, "none">;
+	value: T;
+}
+
+/** Room roster captured with a share so later disclosure can be replayed. */
+export type ArtifactShareRoomSnapshot = ArtifactRoomSnapshot;
+
+/** Typed share metadata parsed from a record's jsonb metadata. */
+export interface ParsedArtifactShareMetadata {
+	grants: ArtifactShareGrant[];
+	roomSnapshot?: ArtifactShareRoomSnapshot;
+}
 
 const UUID_PATTERN =
 	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -51,34 +74,70 @@ const UUID_PATTERN =
  */
 // error-policy:J3 untrusted-input sanitizing — stored jsonb is untyped at rest;
 // invalid grant entries yield an explicit empty result, never a fake grant.
+export function parseArtifactShareMetadata(
+	metadata: unknown,
+): ParsedArtifactShareMetadata {
+	if (!metadata || typeof metadata !== "object") return { grants: [] };
+	const share = (metadata as { share?: unknown }).share;
+	if (!share || typeof share !== "object") return { grants: [] };
+	const grants = (share as { grants?: unknown }).grants;
+	const out: ArtifactShareGrant[] = [];
+	if (Array.isArray(grants)) {
+		for (const entry of grants) {
+			if (!entry || typeof entry !== "object") continue;
+			const g = entry as Record<string, unknown>;
+			const entityId = typeof g.entityId === "string" ? g.entityId : "";
+			const mode = g.mode;
+			if (!UUID_PATTERN.test(entityId)) continue;
+			if (mode !== "full" && mode !== "redacted") continue;
+			out.push({
+				entityId: entityId as UUID,
+				mode,
+				...(typeof g.grantedBy === "string" && UUID_PATTERN.test(g.grantedBy)
+					? { grantedBy: g.grantedBy as UUID }
+					: {}),
+				...(typeof g.grantedAtMs === "number"
+					? { grantedAtMs: g.grantedAtMs }
+					: {}),
+			});
+		}
+	}
+	const roomSnapshot = parseArtifactShareRoomSnapshot(
+		(share as { roomSnapshot?: unknown }).roomSnapshot,
+	);
+	return {
+		grants: out,
+		...(roomSnapshot ? { roomSnapshot } : {}),
+	};
+}
+
 export function parseArtifactShareGrants(
 	metadata: unknown,
 ): ArtifactShareGrant[] {
-	if (!metadata || typeof metadata !== "object") return [];
-	const share = (metadata as { share?: unknown }).share;
-	if (!share || typeof share !== "object") return [];
-	const grants = (share as { grants?: unknown }).grants;
-	if (!Array.isArray(grants)) return [];
-	const out: ArtifactShareGrant[] = [];
-	for (const entry of grants) {
-		if (!entry || typeof entry !== "object") continue;
-		const g = entry as Record<string, unknown>;
-		const entityId = typeof g.entityId === "string" ? g.entityId : "";
-		const mode = g.mode;
-		if (!UUID_PATTERN.test(entityId)) continue;
-		if (mode !== "full" && mode !== "redacted") continue;
-		out.push({
-			entityId: entityId as UUID,
-			mode,
-			...(typeof g.grantedBy === "string" && UUID_PATTERN.test(g.grantedBy)
-				? { grantedBy: g.grantedBy as UUID }
-				: {}),
-			...(typeof g.grantedAtMs === "number"
-				? { grantedAtMs: g.grantedAtMs }
-				: {}),
-		});
-	}
-	return out;
+	return parseArtifactShareMetadata(metadata).grants;
+}
+
+function parseArtifactShareRoomSnapshot(
+	value: unknown,
+): ArtifactShareRoomSnapshot | undefined {
+	if (!value || typeof value !== "object") return undefined;
+	const snapshot = value as Record<string, unknown>;
+	const roomId = typeof snapshot.roomId === "string" ? snapshot.roomId : "";
+	if (!UUID_PATTERN.test(roomId)) return undefined;
+	const atMs = snapshot.atMs;
+	if (typeof atMs !== "number") return undefined;
+	const entityIds = snapshot.entityIds;
+	if (!Array.isArray(entityIds)) return undefined;
+	const validEntityIds = entityIds.filter(
+		(entityId): entityId is UUID =>
+			typeof entityId === "string" && UUID_PATTERN.test(entityId),
+	);
+	if (validEntityIds.length !== entityIds.length) return undefined;
+	return {
+		roomId: roomId as UUID,
+		entityIds: validEntityIds,
+		atMs,
+	};
 }
 
 /** The disclosure-relevant fields of one artifact-referencing record. */
@@ -89,6 +148,8 @@ export interface ArtifactDisclosureRecord {
 	scopedEntityId?: UUID;
 	/** Parsed share grants from the record's metadata. */
 	grants?: readonly ArtifactShareGrant[];
+	/** Full typed share metadata when callers already carry the parsed contract. */
+	share?: ParsedArtifactShareMetadata | ArtifactShareMetadata;
 }
 
 function normalizeScope(value: unknown): MemoryScope {
@@ -163,9 +224,8 @@ export function resolveArtifactDisclosure(
 	if (ctx.requesterEntityId === agentId) return "full";
 	const actor = actorFromAccessContext(ctx, agentId);
 	if (actor.role !== "USER") return "full";
-	const grant = record.grants?.find(
-		(g) => g.entityId === ctx.requesterEntityId,
-	);
+	const grants = record.grants ?? record.share?.grants;
+	const grant = grants?.find((g) => g.entityId === ctx.requesterEntityId);
 	if (grant) return grant.mode === "full" ? "full" : "redacted";
 	return canReadScope(record.scope, record.scopedEntityId, actor)
 		? "full"
@@ -215,4 +275,31 @@ export function selectDisclosedArtifactUrl(
 	return typeof urls.fullUrl === "string" && urls.fullUrl.length > 0
 		? { disclosure, url: urls.fullUrl, redacted: false }
 		: null;
+}
+
+/** Boolean artifact predicate for disclosure points that only need allow/deny. */
+export function canAccessArtifact(
+	record: ArtifactDisclosureRecord,
+	ctx: AccessContext | undefined,
+	agentId: UUID,
+): boolean {
+	return resolveArtifactDisclosure(record, ctx, agentId) !== "none";
+}
+
+/**
+ * Select the concrete full/redacted reference for a DTO after the caller has
+ * resolved disclosure. A redacted grant never falls back to full bytes; if no
+ * redacted variant exists the artifact is omitted until the variant writer
+ * catches up.
+ */
+export function selectArtifactVariant<TFull, TRedacted = TFull>(
+	disclosure: ArtifactDisclosure,
+	references: ArtifactVariantReferences<TFull, TRedacted>,
+): ResolvedArtifactVariant<TFull | TRedacted> | null {
+	if (disclosure === "none") return null;
+	if (disclosure === "full") {
+		return { disclosure: "full", value: references.full };
+	}
+	if (references.redacted == null) return null;
+	return { disclosure: "redacted", value: references.redacted };
 }

--- a/packages/core/src/types/memory.ts
+++ b/packages/core/src/types/memory.ts
@@ -491,6 +491,7 @@ interface MemoryMetadataBase {
 	scope?: MemoryScope;
 	timestamp?: number;
 	platformMessageId?: string;
+	share?: ArtifactShareMetadata;
 }
 
 export type MemoryMetadata = (


### PR DESCRIPTION
## Summary

Replacement for closed #15593 after resolving the overlap with #15590 on current develop. Keeps the already-merged artifact disclosure memory-row helpers and adds the typed share metadata parser, boolean artifact predicate, and generic variant selector without removing existing public helpers.

## Verification

```bash
bunx vitest run --config packages/core/vitest.config.ts packages/core/src/access-control/artifact-disclosure.test.ts packages/core/src/access-control/filter.test.ts
# 2 files passed, 47 tests passed

bunx biome check packages/core/src/access-control/artifact-disclosure.ts packages/core/src/access-control/artifact-disclosure.test.ts packages/core/src/types/memory.ts --no-errors-on-unmatched
# pass

git diff --check origin/develop...HEAD
# pass
```

## Evidence

<!-- evidence-row:before-screenshots -->
N/A - pure core access-control/type helper change; no UI pixels changed.

<!-- evidence-row:after-screenshots -->
N/A - pure core access-control/type helper change; no UI pixels changed.

<!-- evidence-row:walkthrough-video -->
N/A - no user-facing UI flow changed.

<!-- evidence-row:backend-logs -->
N/A - no server route/runtime path is invoked; focused pure-function tests are the relevant evidence.

<!-- evidence-row:frontend-logs -->
N/A - no frontend code changed.

<!-- evidence-row:llm-trajectory -->
N/A - no model/action/provider/evaluator path changed.

<!-- evidence-row:domain-artifacts -->
Unit-contract output above: typed share metadata parsing, disclosure allow/deny predicate, redacted variant selection, memory-row normalization, and URL selection are covered by focused tests.
