### PR TITLE
fix(core): type artifact share metadata on memories

### DIFF
--- a/packages/core/src/access-control/artifact-disclosure.test.ts
+++ b/packages/core/src/access-control/artifact-disclosure.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit contract for the role-aware artifact disclosure decision (#14781):
+ * Unit contract for the role-aware artifact disclosure decision (#14778):
  * the OWNER/ADMIN-full / USER-grant-driven / fail-closed matrix and the
  * untrusted grant parser. Pure functions, no harness.
  */
@@ -17,6 +17,17 @@ const AGENT = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" as UUID;
 const OWNER = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb" as UUID;
 const VIEWER = "cccccccc-cccc-4ccc-8ccc-cccccccccccc" as UUID;
 const OTHER = "dddddddd-dddd-4ddd-8ddd-dddddddddddd" as UUID;
+
+const typedShareMemory: Pick<Memory, "entityId" | "metadata"> = {
+	entityId: OTHER,
+	metadata: {
+		type: "message",
+		scope: "owner-private",
+		share: {
+			grants: [{ entityId: VIEWER, mode: "redacted" }],
+		},
+	},
+};
 
 const ctx = (over: Partial<AccessContext> = {}): AccessContext => ({
 	requesterEntityId: VIEWER,
@@ -210,6 +221,14 @@ describe("parseArtifactShareGrants", () => {
 });
 
 describe("artifactDisclosureRecordFromMemory", () => {
+	it("types top-level memory.metadata.share for referencing records", () => {
+		expect(artifactDisclosureRecordFromMemory(typedShareMemory)).toEqual({
+			scope: "owner-private",
+			scopedEntityId: OTHER,
+			grants: [{ entityId: VIEWER, mode: "redacted" }],
+		});
+	});
+
 	it("normalizes stored metadata into a disclosure record", () => {
 		const memory = {
 			entityId: OTHER,

--- a/packages/core/src/access-control/artifact-disclosure.ts
+++ b/packages/core/src/access-control/artifact-disclosure.ts
@@ -1,7 +1,7 @@
 /**
  * Role-aware artifact disclosure decision for shared artifacts (transcripts,
  * stored files, chat attachments, meeting sessions) — the read-side selector
- * behind #14781, designed inside the #8876 attachments doctrine: bytes stay on
+ * behind #14778, designed inside the #8876 attachments doctrine: bytes stay on
  * the pre-auth content-addressed store (the sha256 URL is the capability), so
  * "permission" here means URL/DTO disclosure on the REFERENCING record, never
  * a byte-serve gate. Redacted variants are separate records/media objects; this

--- a/packages/core/src/features/advanced-capabilities/actions/message.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.ts
@@ -1795,10 +1795,10 @@ async function persistOutboundMemory(params: {
 					sentMemory?.content?.channelType ?? channelTypeForKind(kind),
 			},
 			metadata: {
+				...(sentMemory?.metadata ?? {}),
 				type: "message",
 				source,
 				provider: source,
-				...(sentMemory?.metadata ?? {}),
 				...(platformMessageId ? { messageIdFull: platformMessageId } : {}),
 			},
 			createdAt: sentMemory?.createdAt ?? Date.now(),

--- a/packages/core/src/features/advanced-capabilities/actions/post.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/post.ts
@@ -275,10 +275,10 @@ async function persistPostMemory(
 			channelType: ChannelType.FEED,
 		},
 		metadata: {
+			...(sentMemory?.metadata ?? {}),
 			type: "message",
 			source: connector.source,
 			provider: connector.source,
-			...(sentMemory?.metadata ?? {}),
 		},
 		createdAt: sentMemory?.createdAt ?? Date.now(),
 	};

--- a/packages/core/src/types/memory.ts
+++ b/packages/core/src/types/memory.ts
@@ -491,6 +491,7 @@ interface MemoryMetadataBase {
 	scope?: MemoryScope;
 	timestamp?: number;
 	platformMessageId?: string;
+	share?: ArtifactShareMetadata;
 }
 
 export type MemoryMetadata = (


### PR DESCRIPTION
## Summary
- type top-level `memory.metadata.share` on `MemoryMetadataBase` so referencing records can carry artifact grants without falling back to structural inference
- add a compile-visible artifact disclosure fixture that proves `memory.metadata.share` is accepted and normalized
- correct the artifact-disclosure issue reference to #14778 and keep outbound message/post metadata from overriding the required `type/source/provider` fields

Part of #14778. This does not close #14778; disclosure-point wiring and the grant -> snapshot -> disclose -> revoke e2e flow remain outstanding.

## Verification
```bash
bun run --cwd packages/core test -- src/access-control/artifact-disclosure.test.ts
# 1 file passed, 21 tests passed

node packages/shared/scripts/generate-keywords.mjs --target ts
bun run --cwd packages/core typecheck
# pass

bunx biome check packages/core/src/types/memory.ts packages/core/src/access-control/artifact-disclosure.ts packages/core/src/access-control/artifact-disclosure.test.ts packages/core/src/features/advanced-capabilities/actions/message.ts packages/core/src/features/advanced-capabilities/actions/post.ts
# pass

git diff --check origin/develop...HEAD
# pass

bun run audit:error-policy-ratchet --report
# pass; no new fallback-slop
```

## Evidence
<!-- evidence-row:before-screenshots -->
N/A - pure core type/helper foundation only; no UI pixels changed.

<!-- evidence-row:after-screenshots -->
N/A - pure core type/helper foundation only; no UI pixels changed.

<!-- evidence-row:walkthrough-video -->
N/A - no runnable UI flow changed in this slice.

<!-- evidence-row:backend-logs -->
N/A - no HTTP route/service was invoked; focused typecheck/build and pure unit tests are the relevant evidence for this type-surface fix.

<!-- evidence-row:frontend-logs -->
N/A - no frontend code changed.

<!-- evidence-row:llm-trajectory -->
N/A - no model/action/provider/prompt behavior changed; route/action wiring remains for later #14778/#14779 slices.

<!-- evidence-row:domain-artifacts -->
N/A - this slice creates no persisted runtime artifact; the domain contract is the compile-visible `memory.metadata.share` fixture plus focused artifact-disclosure unit-test output recorded above.
