### PR TITLE
fix(core): gate attachment model context disclosure

### DIFF
--- a/packages/core/src/features/basic-capabilities/providers/attachments.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/attachments.test.ts
@@ -16,6 +16,8 @@ import {
 import { attachmentsProvider } from "./attachments.ts";
 
 const roomId = "00000000-0000-0000-0000-000000000001" as UUID;
+const agentId = "00000000-0000-0000-0000-0000000000a9" as UUID;
+const userId = "00000000-0000-0000-0000-000000000002" as UUID;
 
 function attachmentMemory(createdAt = 1): Memory {
 	return {
@@ -44,25 +46,63 @@ function makeRuntime(
 	options: { hasImageDescriptionModel?: boolean } = {},
 ): IAgentRuntime {
 	return {
+		agentId,
 		getConversationLength: () => 20,
 		getMemories: async () => recentMessages,
+		getRoom: async () => null,
 		getModel: (modelType: string) =>
 			options.hasImageDescriptionModel &&
 			modelType === ModelType.IMAGE_DESCRIPTION
 				? async () => ({ title: "", description: "" })
 				: undefined,
+		logger: { warn: () => undefined },
 	} as unknown as IAgentRuntime;
 }
 
 function makeMessage(content: Partial<Memory["content"]>): Memory {
 	return {
 		id: "00000000-0000-0000-0000-000000000012" as UUID,
-		entityId: "00000000-0000-0000-0000-000000000003" as UUID,
+		entityId: userId,
 		roomId,
 		createdAt: 2,
 		content: {
 			text: "can you try this?",
 			...content,
+		},
+	} as Memory;
+}
+
+function ownerPrivateAttachmentMemory(granted = false): Memory {
+	return {
+		...attachmentMemory(1),
+		metadata: {
+			scope: "owner-private",
+			share: granted
+				? {
+						grants: [
+							{
+								entityId: userId,
+								mode: "redacted",
+							},
+						],
+					}
+				: undefined,
+		},
+		content: {
+			text: "private image",
+			attachments: [
+				{
+					id: "private-image",
+					url: "https://example.test/private-original.jpg",
+					redactedUrl: "https://example.test/private-redacted.jpg",
+					thumbnailUrl: "https://example.test/private-thumb.jpg",
+					title: "Private Image",
+					source: "Image",
+					contentType: "image",
+					text: "original visible text",
+					description: "original description",
+				},
+			],
 		},
 	} as Memory;
 }
@@ -211,6 +251,29 @@ describe("attachmentsProvider", () => {
 			}),
 		);
 
+		expect(result.text).toContain("Stored Content: none");
+	});
+
+	it("omits owner-private recent attachments from model prompt context without a grant", async () => {
+		const result = await attachmentsProvider.get(
+			makeRuntime([ownerPrivateAttachmentMemory(false)]),
+			makeMessage({ text: "can you inspect the image attachment?" }),
+		);
+
+		expect(result.text).toBe("");
+		expect(result.data?.visibleAttachments).toEqual([]);
+	});
+
+	it("renders only the redacted URL for a redacted attachment grant", async () => {
+		const result = await attachmentsProvider.get(
+			makeRuntime([ownerPrivateAttachmentMemory(true)]),
+			makeMessage({ text: "can you inspect the image attachment?" }),
+		);
+
+		expect(result.text).toContain("private-image");
+		expect(result.text).toContain("https://example.test/private-redacted.jpg");
+		expect(result.text).not.toContain("private-original");
+		expect(result.text).not.toContain("private-thumb");
 		expect(result.text).toContain("Stored Content: none");
 	});
 });

--- a/packages/core/src/features/basic-capabilities/providers/attachments.ts
+++ b/packages/core/src/features/basic-capabilities/providers/attachments.ts
@@ -25,6 +25,7 @@ import {
 } from "../../../types/index.ts";
 import { MESSAGE_SOURCE_SUB_AGENT } from "../../../types/message-source.ts";
 import { addHeader } from "../../../utils.ts";
+import { listConversationAttachments } from "../../working-memory/attachmentContext.ts";
 
 // Get text content from centralized specs
 const spec = requireProviderSpec("ATTACHMENTS");
@@ -34,42 +35,6 @@ const ATTACHMENT_REFERENCE_RE =
 	/\b(?:attachments?|files?|documents?|pdfs?|images?|photos?|pictures?|screenshots?|videos?|audio|recordings?|links?|urls?)\b|https?:\/\/\S+/iu;
 const ATTACHMENT_INSPECTION_RE =
 	/\b(?:what|see|view|look(?:ing)?(?:\s+at)?|read|open|inspect|analy[sz]e|describe|summari[sz]e|transcribe|ocr|shown?|showing|contains?|content|find|found|anything|result|results|thoughts?|think|opinion|take)\b/iu;
-
-type AttachmentWithCreatedAt = Media & {
-	_createdAt?: number;
-};
-
-function mergeConversationAttachments(
-	message: Memory,
-	recentMessages: Memory[] | null | undefined,
-): AttachmentWithCreatedAt[] {
-	const attachmentsById = new Map<string, AttachmentWithCreatedAt>();
-
-	const rememberAttachment = (attachment: Media, createdAt: number): void => {
-		const existing = attachmentsById.get(attachment.id);
-		if (existing && (existing._createdAt ?? 0) >= createdAt) {
-			return;
-		}
-		attachmentsById.set(attachment.id, {
-			...attachment,
-			_createdAt: createdAt,
-		});
-	};
-
-	for (const attachment of message.content.attachments ?? []) {
-		rememberAttachment(attachment, message.createdAt ?? Date.now());
-	}
-
-	for (const recentMessage of recentMessages ?? []) {
-		for (const attachment of recentMessage.content.attachments ?? []) {
-			rememberAttachment(attachment, recentMessage.createdAt ?? Date.now());
-		}
-	}
-
-	return Array.from(attachmentsById.values()).sort(
-		(left, right) => (right._createdAt ?? 0) - (left._createdAt ?? 0),
-	);
-}
 
 /**
  * Render an attachment URL for the prompt without dumping raw bytes into
@@ -105,7 +70,7 @@ function messageTextForAttachmentRelevance(message: Memory): string {
 
 function shouldRenderAttachmentPromptText(
 	message: Memory,
-	allAttachments: readonly AttachmentWithCreatedAt[],
+	allAttachments: readonly Media[],
 ): boolean {
 	if (allAttachments.length === 0) return false;
 	if ((message.content.attachments ?? []).length > 0) return true;
@@ -131,22 +96,12 @@ export const attachmentsProvider: Provider = {
 		message: Memory,
 	): Promise<ProviderResult> => {
 		try {
-			const { roomId } = message;
-			const conversationLength = Math.min(
-				runtime.getConversationLength(),
-				MAX_ATTACHMENT_MEMORY_LOOKBACK,
-			);
-
-			const recentMessagesData = await runtime.getMemories({
-				roomId,
-				limit: conversationLength,
-				unique: false,
-				tableName: "messages",
-			});
-
-			const allAttachments = mergeConversationAttachments(
+			const allAttachments = await listConversationAttachments(
+				runtime,
 				message,
-				Array.isArray(recentMessagesData) ? recentMessagesData : [],
+				{
+					maxLookback: MAX_ATTACHMENT_MEMORY_LOOKBACK,
+				},
 			);
 			const visibleAttachments = allAttachments.slice(
 				0,

--- a/packages/core/src/features/working-memory/attachmentContext.test.ts
+++ b/packages/core/src/features/working-memory/attachmentContext.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Deterministic coverage for conversation attachment gathering: access-scoped
+ * message rows must be filtered before the ATTACHMENT action can read stored
+ * text or original URLs. The harness stubs runtime memory/world access; no live
+ * model or database is involved.
+ */
+import { describe, expect, it } from "vitest";
+import type { IAgentRuntime, Memory, UUID } from "../../types/index.ts";
+import {
+	listConversationAttachments,
+	readAttachmentRecords,
+} from "./attachmentContext.ts";
+
+const agentId = "00000000-0000-0000-0000-0000000000a9" as UUID;
+const userId = "00000000-0000-0000-0000-000000000002" as UUID;
+const ownerId = "00000000-0000-0000-0000-000000000003" as UUID;
+const roomId = "00000000-0000-0000-0000-000000000004" as UUID;
+
+function makeRuntime(recentMessages: Memory[]): IAgentRuntime {
+	return {
+		agentId,
+		getConversationLength: () => 20,
+		getMemories: async () => recentMessages,
+		getRoom: async () => null,
+		logger: { warn: () => undefined },
+	} as unknown as IAgentRuntime;
+}
+
+function viewerMessage(text = "read the attachment"): Memory {
+	return {
+		id: "00000000-0000-0000-0000-000000000005" as UUID,
+		entityId: userId,
+		roomId,
+		content: { text },
+		createdAt: 2,
+	} as Memory;
+}
+
+function privateAttachmentMemory(granted = false): Memory {
+	return {
+		id: "00000000-0000-0000-0000-000000000006" as UUID,
+		entityId: ownerId,
+		roomId,
+		createdAt: 1,
+		metadata: {
+			scope: "owner-private",
+			share: granted
+				? {
+						grants: [
+							{
+								entityId: userId,
+								mode: "redacted",
+							},
+						],
+					}
+				: undefined,
+		},
+		content: {
+			text: "private attachment",
+			attachments: [
+				{
+					id: "private-image",
+					url: "https://example.test/original.jpg",
+					redactedUrl: "https://example.test/redacted.jpg",
+					thumbnailUrl: "https://example.test/thumb.jpg",
+					title: "Private Image",
+					source: "Image",
+					contentType: "document",
+					text: "full extracted text",
+					description: "full description",
+				},
+			],
+		},
+	} as Memory;
+}
+
+describe("attachmentContext disclosure", () => {
+	it("omits owner-private attachments for an ungranted requester", async () => {
+		const attachments = await listConversationAttachments(
+			makeRuntime([privateAttachmentMemory(false)]),
+			viewerMessage(),
+		);
+
+		expect(attachments).toEqual([]);
+	});
+
+	it("downgrades a redacted grant before ATTACHMENT action content reads", async () => {
+		const records = await readAttachmentRecords(
+			makeRuntime([privateAttachmentMemory(true)]),
+			viewerMessage("read private-image"),
+			"private-image",
+		);
+
+		expect(records).toHaveLength(1);
+		expect(records[0]?.attachment.url).toBe(
+			"https://example.test/redacted.jpg",
+		);
+		expect(records[0]?.attachment.redacted).toBe(true);
+		expect(records[0]?.attachment.thumbnailUrl).toBeUndefined();
+		expect(records[0]?.attachment.text).toBeUndefined();
+		expect(records[0]?.content).toBe("");
+	});
+});

--- a/packages/core/src/features/working-memory/attachmentContext.ts
+++ b/packages/core/src/features/working-memory/attachmentContext.ts
@@ -9,18 +9,28 @@
  * Consumed by readAttachmentAction.ts; the `_data`/`_mimeType`/`_createdAt` fields
  * are inline-transport and ordering extensions carried alongside `Media`.
  */
+import { buildAccessContext } from "../../access-context.ts";
+import {
+	parseArtifactShareGrants,
+	resolveArtifactDisclosure,
+	selectDisclosedArtifactUrl,
+} from "../../access-control/artifact-disclosure.ts";
 import { describeImageCached } from "../../media/index.ts";
 import {
+	type AccessContext,
 	ContentType,
 	type IAgentRuntime,
 	type Media,
 	type Memory,
+	type MemoryScope,
+	type UUID,
 } from "../../types/index.ts";
 
 type AttachmentWithInlineData = Media & {
 	_data?: string;
 	_mimeType?: string;
 	_createdAt?: number;
+	redacted?: true;
 };
 
 type ReadAttachmentResult = {
@@ -56,6 +66,95 @@ function attachmentStoredContent(attachment: Media): string {
 		)
 		.join("\n\n")
 		.trim();
+}
+
+const MEMORY_SCOPES: ReadonlySet<string> = new Set<MemoryScope>([
+	"global",
+	"shared",
+	"room",
+	"private",
+	"owner-private",
+	"user-private",
+	"agent-private",
+]);
+
+function attachmentMessageScope(memory: Memory): MemoryScope {
+	const rawScope = (memory.metadata as Record<string, unknown> | undefined)
+		?.scope;
+	if (rawScope === undefined) return "room";
+	return typeof rawScope === "string" && MEMORY_SCOPES.has(rawScope)
+		? (rawScope as MemoryScope)
+		: "owner-private";
+}
+
+async function buildAttachmentAccessContext(
+	runtime: IAgentRuntime,
+	message: Memory,
+): Promise<AccessContext | undefined> {
+	const agentId = runtime.agentId as UUID | undefined;
+	if (!agentId || !message.entityId || message.entityId === agentId) {
+		return undefined;
+	}
+	try {
+		return await buildAccessContext(runtime, message);
+	} catch (error) {
+		// error-policy:J3 access-context resolution is an auth boundary input;
+		// failure degrades to requester-only USER disclosure, never unrestricted.
+		runtime.logger?.warn(
+			{
+				src: "attachment-context",
+				error: error instanceof Error ? error.message : String(error),
+			},
+			"Access-context resolution failed; falling back to requester-only attachment disclosure",
+		);
+		return { requesterEntityId: message.entityId as UUID };
+	}
+}
+
+function selectAttachmentForRequester(
+	memory: Memory,
+	attachment: AttachmentWithInlineData,
+	accessContext: AccessContext | undefined,
+	agentId: UUID | undefined,
+): AttachmentWithInlineData | null {
+	if (!accessContext || !agentId) return attachment;
+	const metadata = memory.metadata as Record<string, unknown> | undefined;
+	const scopedTo = metadata?.scopedToEntityId;
+	const addedBy = metadata?.addedBy;
+	const disclosure = resolveArtifactDisclosure(
+		{
+			scope: attachmentMessageScope(memory),
+			scopedEntityId:
+				typeof scopedTo === "string"
+					? (scopedTo as UUID)
+					: typeof addedBy === "string"
+						? (addedBy as UUID)
+						: memory.entityId,
+			grants: parseArtifactShareGrants(metadata),
+		},
+		accessContext,
+		agentId,
+	);
+	const selected = selectDisclosedArtifactUrl(disclosure, {
+		fullUrl: attachment.url,
+		redactedUrl: attachment.redactedUrl,
+	});
+	if (!selected) return null;
+	if (!selected.redacted) return attachment;
+	const {
+		description: _description,
+		text: _text,
+		thumbnailUrl: _thumbnailUrl,
+		_data,
+		_mimeType,
+		notProcessed: _notProcessed,
+		...rest
+	} = attachment;
+	return {
+		...rest,
+		url: selected.url,
+		redacted: true,
+	};
 }
 
 async function describeImageAttachment(
@@ -98,10 +197,16 @@ async function readableAttachmentContent(
 export async function listConversationAttachments(
 	runtime: IAgentRuntime,
 	message: Memory,
+	options: { maxLookback?: number } = {},
 ): Promise<AttachmentWithInlineData[]> {
 	const currentMessageAttachments = (message.content.attachments ??
 		[]) as AttachmentWithInlineData[];
-	const conversationLength = runtime.getConversationLength();
+	const conversationLength =
+		typeof options.maxLookback === "number"
+			? Math.min(runtime.getConversationLength(), options.maxLookback)
+			: runtime.getConversationLength();
+	const accessContext = await buildAttachmentAccessContext(runtime, message);
+	const agentId = runtime.agentId as UUID | undefined;
 	const recentMessages = await runtime.getMemories({
 		roomId: message.roomId,
 		count: conversationLength,
@@ -114,10 +219,18 @@ export async function listConversationAttachments(
 		!Array.isArray(recentMessages) ||
 		recentMessages.length === 0
 	) {
-		return currentMessageAttachments.map((attachment) => ({
-			...attachment,
-			_createdAt: message.createdAt ?? Date.now(),
-		}));
+		return currentMessageAttachments
+			.map((attachment) =>
+				selectAttachmentForRequester(
+					message,
+					{ ...attachment, _createdAt: message.createdAt ?? Date.now() },
+					accessContext,
+					agentId,
+				),
+			)
+			.filter((attachment): attachment is AttachmentWithInlineData =>
+				Boolean(attachment),
+			);
 	}
 
 	const attachmentsById = new Map<string, AttachmentWithInlineData>();
@@ -137,7 +250,13 @@ export async function listConversationAttachments(
 	};
 
 	for (const attachment of currentMessageAttachments) {
-		rememberAttachment(attachment, message.createdAt ?? Date.now());
+		const selected = selectAttachmentForRequester(
+			message,
+			attachment,
+			accessContext,
+			agentId,
+		);
+		if (selected) rememberAttachment(selected, message.createdAt ?? Date.now());
 	}
 
 	for (const recentMessage of recentMessages) {
@@ -145,7 +264,13 @@ export async function listConversationAttachments(
 			[]) as AttachmentWithInlineData[];
 		const createdAt = recentMessage.createdAt ?? Date.now();
 		for (const attachment of messageAttachments) {
-			rememberAttachment(attachment, createdAt);
+			const selected = selectAttachmentForRequester(
+				recentMessage,
+				attachment,
+				accessContext,
+				agentId,
+			);
+			if (selected) rememberAttachment(selected, createdAt);
 		}
 	}
 
@@ -228,12 +353,18 @@ export async function readAttachmentRecords(
 		[]) as AttachmentWithInlineData[];
 	if (currentAttachments.length > 0) {
 		const createdAt = message.createdAt ?? Date.now();
+		const attachments = await listConversationAttachments(runtime, message);
+		const currentIds = new Set(
+			currentAttachments.map((attachment) => attachment.id),
+		);
 		return Promise.all(
-			currentAttachments.map(async (attachment) => ({
-				attachment: { ...attachment, _createdAt: createdAt },
-				content: await readableAttachmentContent(runtime, attachment),
-				autoSelected: true,
-			})),
+			attachments
+				.filter((attachment) => currentIds.has(attachment.id))
+				.map(async (attachment) => ({
+					attachment: { ...attachment, _createdAt: createdAt },
+					content: await readableAttachmentContent(runtime, attachment),
+					autoSelected: true,
+				})),
 		);
 	}
 


### PR DESCRIPTION
## Summary

Follow-up slice for #14778 after #15590 merged:

- routes the ATTACHMENTS provider through the shared conversation attachment context helper instead of its own duplicate recent-message merge
- applies the core artifact-disclosure predicate before model prompt context or ATTACHMENT action reads can see recent attachments
- downgrades redacted grants to `Media.redactedUrl`, strips original-derived text/description/thumbnail/inline bytes, and omits redacted grants with no redacted variant
- keeps unmarked chat messages at the existing `room` default while malformed/marked scopes fail closed

## Evidence

<!-- evidence-row:before-screenshots -->
Before screenshots: N/A - backend-only core filtering change; no rendered UI surface changed.

<!-- evidence-row:after-screenshots -->
After screenshots: N/A - backend-only core filtering change; no rendered UI surface changed.

<!-- evidence-row:walkthrough-video -->
Walkthrough video: N/A - no user-facing UI flow changed in this slice.

<!-- evidence-row:backend-logs -->
Backend logs: N/A - no server route/runtime was started for this deterministic core unit slice; local backend/core gate output is included below instead.

```text
bun run --cwd packages/core test -- src/features/basic-capabilities/providers/attachments.test.ts src/features/working-memory/attachmentContext.test.ts src/access-control/artifact-disclosure.test.ts
Result: passed, 3 files / 32 tests.

bun run --cwd packages/core typecheck
Result: passed.

bun run --cwd packages/core build
Result: passed across Node/browser/edge/testing builds and declaration generation.

git diff --check && bun run audit:error-policy-ratchet
Result: passed; ratchet reported 2 changed production files and no new empty catches or server console calls.
```

<!-- evidence-row:frontend-logs -->
Frontend console/network logs: N/A - no frontend code or browser/network path changed.

<!-- evidence-row:llm-trajectory -->
Real-LLM trajectory: N/A - this slice does not change prompts, planner instructions, model selection, or generated wording. Deterministic tests assert the exact context exposed to the model/action before any model call.

<!-- evidence-row:domain-artifacts -->
Domain artifacts: N/A - this slice changes disclosure filtering logic only and does not write memories, documents, DB rows, scheduled tasks, files, or connector artifacts. Deterministic coverage below asserts the domain-visible artifact DTO/context shape.

```text
src/features/basic-capabilities/providers/attachments.test.ts
- ungranted owner-private recent attachment is omitted from ATTACHMENTS provider prompt/data
- redacted grant renders only redactedUrl and withholds original URL/thumbnail/readable content

src/features/working-memory/attachmentContext.test.ts
- ungranted owner-private attachment is omitted before ATTACHMENT action selection
- redacted grant downgrades URL and strips original-derived text before action content reads
```

Additional static check:

```text
bun x biome check packages/core/src/features/working-memory/attachmentContext.ts packages/core/src/features/working-memory/attachmentContext.test.ts packages/core/src/features/basic-capabilities/providers/attachments.ts packages/core/src/features/basic-capabilities/providers/attachments.test.ts
Result: passed.
```

## Notes

This still does not close #14778 by itself. It wires one disclosure surface family: model-facing attachment provider context plus ATTACHMENT action reads. Remaining work includes transcript/document/list DTO variants, share/revoke write paths, audit/API traces, and the grant -> snapshot -> disclose -> revoke -> variant e2e evidence.