### PR TITLE
feat(transcripts): add redacted variant write primitives

### DIFF
--- a/plugins/plugin-local-inference/src/services/voice/transcript-store.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/transcript-store.test.ts
@@ -367,5 +367,120 @@ describe("TranscriptStore", () => {
 				true,
 			);
 		});
+
+		it("creates a deterministic redacted variant without mutating the original or audio", async () => {
+			const rt = fakeRuntime();
+			const store = new TranscriptStore(rt);
+			const original = makeTranscript({
+				id: ORIGINAL_ID,
+				title: "Payroll sync",
+				audioUrl: "/api/media/original.wav",
+				audioContentType: "audio/wav",
+				segments: [
+					{
+						id: "s1",
+						speakerLabel: "Alice",
+						startMs: 0,
+						endMs: 2000,
+						text: "Email bob@example.com and use SSN 123-45-6789.",
+						words: [
+							{
+								text: "bob@example.com",
+								startMs: 0,
+								endMs: 1000,
+							},
+						],
+					},
+				],
+			});
+			await store.create({
+				roomId: ROOM,
+				entityId: ENTITY,
+				transcript: original,
+			});
+
+			const first = await store.createRedactedVariant({
+				originalId: ORIGINAL_ID as UUID,
+				redactedBy: VIEWER,
+				seed: "fixed",
+				nowMs: 3000,
+			});
+			const second = await store.createRedactedVariant({
+				originalId: ORIGINAL_ID as UUID,
+				redactedBy: VIEWER,
+				seed: "fixed",
+				nowMs: 3000,
+			});
+
+			expect(second.id).toBe(first.id);
+			expect(first.audioUrl).toBeUndefined();
+			expect(first.audioContentType).toBeUndefined();
+			expect(first.segments[0]?.text).toContain("[EMAIL]");
+			expect(first.segments[0]?.text).toContain("[SSN]");
+			expect(first.segments[0]?.text).not.toContain("bob@example.com");
+			expect(first.segments[0]?.text).not.toContain("123-45-6789");
+			expect(first.segments[0]?.words[0]?.text).toBe("[EMAIL]");
+
+			const originalAfter = await store.get(ORIGINAL_ID as UUID);
+			expect(originalAfter).toEqual(original);
+			const originalMeta = (rt.rows.get(ORIGINAL_ID) as Memory)
+				.metadata as Record<string, unknown>;
+			expect(originalMeta.redactedVariantId).toBe(first.id);
+			const variantMeta = (rt.rows.get(first.id) as Memory).metadata as Record<
+				string,
+				unknown
+			>;
+			expect(variantMeta.redactionOf).toBe(ORIGINAL_ID);
+			expect(variantMeta.redactedBy).toBe(VIEWER);
+		});
+
+		it("adds and replaces transcript share grants on the original row", async () => {
+			const rt = fakeRuntime();
+			const store = new TranscriptStore(rt);
+			await store.create({
+				roomId: ROOM,
+				entityId: ENTITY,
+				transcript: makeTranscript({ id: ORIGINAL_ID }),
+			});
+
+			await store.share({
+				transcriptId: ORIGINAL_ID as UUID,
+				entityId: VIEWER,
+				mode: "redacted",
+				grantedBy: ENTITY,
+				grantedAtMs: 4000,
+			});
+			await store.share({
+				transcriptId: ORIGINAL_ID as UUID,
+				entityId: VIEWER,
+				mode: "full",
+				grantedBy: ENTITY,
+				grantedAtMs: 5000,
+			});
+
+			const row = rt.rows.get(ORIGINAL_ID) as Memory;
+			expect((row.metadata as Record<string, unknown>).share).toEqual({
+				grants: [
+					{
+						entityId: VIEWER,
+						mode: "full",
+						grantedBy: ENTITY,
+						grantedAtMs: 5000,
+					},
+				],
+			});
+		});
+
+		it("refuses to attach grants to a redacted variant row", async () => {
+			const rt = fakeRuntime();
+			const { store } = await seed(rt);
+			await expect(
+				store.share({
+					transcriptId: VARIANT_ID as UUID,
+					entityId: VIEWER,
+					mode: "full",
+				}),
+			).rejects.toThrow(/original transcript/);
+		});
 	});
 });

--- a/plugins/plugin-local-inference/src/services/voice/transcript-store.ts
+++ b/plugins/plugin-local-inference/src/services/voice/transcript-store.ts
@@ -14,11 +14,15 @@
 import {
 	type AccessContext,
 	type ArtifactDisclosure,
+	type ArtifactShareGrant,
+	type ArtifactShareGrantMode,
+	detectPii,
 	type JsonObject,
 	type Memory,
 	type MemoryMetadata,
 	parseArtifactShareGrants,
 	resolveArtifactDisclosure,
+	stringToUuid,
 	type UUID,
 } from "@elizaos/core";
 import type {
@@ -64,6 +68,25 @@ export interface CreateTranscriptInput {
 	entityId: UUID;
 	/** The fully-built transcript record (audio + segments + words). */
 	transcript: Transcript;
+}
+
+export interface CreateRedactedTranscriptVariantInput {
+	/** The stored original transcript id. */
+	originalId: UUID;
+	/** Entity issuing the redaction, recorded on metadata for audit context. */
+	redactedBy?: UUID;
+	/** Stable seed for deterministic tests; defaults to the original id. */
+	seed?: string;
+	/** Epoch ms override for deterministic tests. */
+	nowMs?: number;
+}
+
+export interface ShareTranscriptGrantInput {
+	transcriptId: UUID;
+	entityId: UUID;
+	mode: ArtifactShareGrantMode;
+	grantedBy?: UUID;
+	grantedAtMs?: number;
 }
 
 /** Pull the stored {@link Transcript} back out of a memory row (parses the
@@ -150,6 +173,48 @@ function serveRedactedVariant(
 		source: original.source,
 		redacted: true,
 	};
+}
+
+function redactedText(text: string): string {
+	const matches = detectPii(text);
+	if (matches.length === 0) return text;
+	let out = "";
+	let cursor = 0;
+	for (const match of [...matches].sort((a, b) => a.start - b.start)) {
+		if (match.start < cursor) continue;
+		out += text.slice(cursor, match.start);
+		out += `[${match.kind.toUpperCase()}]`;
+		cursor = match.end;
+	}
+	out += text.slice(cursor);
+	return out;
+}
+
+function redactTranscript(original: Transcript): Transcript {
+	const segments = original.segments.map((segment) => ({
+		...segment,
+		text: redactedText(segment.text),
+		words: segment.words.map((word) => ({
+			...word,
+			text: redactedText(word.text),
+		})),
+	}));
+	return {
+		...original,
+		title: `${original.title} (redacted)`,
+		audioUrl: undefined,
+		audioContentType: undefined,
+		segments,
+	};
+}
+
+function mergedGrant(
+	grants: readonly ArtifactShareGrant[],
+	next: ArtifactShareGrant,
+): ArtifactShareGrant[] {
+	const out = grants.filter((grant) => grant.entityId !== next.entityId);
+	out.push(next);
+	return out;
 }
 
 /** CRUD for transcript records over the runtime memory partition. */
@@ -290,6 +355,121 @@ export class TranscriptStore {
 		const variantRow = await this.runtime.getMemoryById(variantId);
 		if (!variantRow) return null;
 		return rowToTranscript(variantRow);
+	}
+
+	/**
+	 * Create or refresh the deterministic redacted variant linked to an original.
+	 * The original transcript and retained audio URL are never modified; only the
+	 * original row's metadata gains/updates `redactedVariantId`.
+	 */
+	async createRedactedVariant(
+		input: CreateRedactedTranscriptVariantInput,
+	): Promise<Transcript> {
+		const originalRow = await this.runtime.getMemoryById(input.originalId);
+		if (!originalRow) {
+			throw new Error(`transcript ${input.originalId} not found`);
+		}
+		const original = rowToTranscript(originalRow);
+		if (!original) {
+			throw new Error(`transcript ${input.originalId} is corrupt`);
+		}
+		const existingVariantId = redactedVariantId(originalRow);
+		const variantId =
+			existingVariantId ??
+			(stringToUuid(
+				`transcript-redaction:${input.seed ?? input.originalId}`,
+			) as UUID);
+		const nowMs = input.nowMs ?? Date.now();
+		const variant = {
+			...redactTranscript(original),
+			id: variantId,
+			createdAt: nowMs,
+			metadata: {
+				...(original.metadata ?? {}),
+				redactionOf: input.originalId,
+				redactedAtMs: nowMs,
+				...(input.redactedBy ? { redactedBy: input.redactedBy } : {}),
+			},
+		};
+		const existingVariant = await this.runtime.getMemoryById(variantId);
+		if (existingVariant) {
+			await this.update(variant);
+		} else {
+			await this.create({
+				roomId: originalRow.roomId,
+				entityId: originalRow.entityId,
+				transcript: variant,
+			});
+		}
+		const variantRow = await this.runtime.getMemoryById(variantId);
+		const variantMeta = variantRow?.metadata as
+			| Record<string, unknown>
+			| undefined;
+		const variantOk = await this.runtime.updateMemory({
+			id: variantId,
+			metadata: {
+				...(variantMeta ?? {}),
+				type: "custom",
+				source: TRANSCRIPT_METADATA_TYPE,
+				redactionOf: input.originalId,
+				redactedAtMs: nowMs,
+				...(input.redactedBy ? { redactedBy: input.redactedBy } : {}),
+			} as MemoryMetadata,
+		});
+		if (!variantOk) {
+			throw new Error(`redacted transcript variant ${variantId} not found`);
+		}
+		const meta = originalRow.metadata as Record<string, unknown> | undefined;
+		const ok = await this.runtime.updateMemory({
+			id: input.originalId,
+			metadata: {
+				...(meta ?? {}),
+				type: "custom",
+				source: TRANSCRIPT_METADATA_TYPE,
+				redactedVariantId: variantId,
+			} as MemoryMetadata,
+		});
+		if (!ok) {
+			throw new Error(`transcript ${input.originalId} not found`);
+		}
+		return variant;
+	}
+
+	/** Add or replace one per-entity share grant on the original transcript row. */
+	async share(input: ShareTranscriptGrantInput): Promise<void> {
+		const row = await this.runtime.getMemoryById(input.transcriptId);
+		if (!row) {
+			throw new Error(`transcript ${input.transcriptId} not found`);
+		}
+		if (redactionOriginalId(row)) {
+			throw new Error(
+				"share grants must be attached to the original transcript",
+			);
+		}
+		const metadata = row.metadata as Record<string, unknown> | undefined;
+		const grants = parseArtifactShareGrants(metadata);
+		const nextGrant: ArtifactShareGrant = {
+			entityId: input.entityId,
+			mode: input.mode,
+			...(input.grantedBy ? { grantedBy: input.grantedBy } : {}),
+			...(input.grantedAtMs !== undefined
+				? { grantedAtMs: input.grantedAtMs }
+				: {}),
+		};
+		const ok = await this.runtime.updateMemory({
+			id: input.transcriptId,
+			metadata: {
+				...(metadata ?? {}),
+				type: "custom",
+				source: TRANSCRIPT_METADATA_TYPE,
+				share: {
+					grants: mergedGrant(grants, nextGrant),
+				} as unknown as JsonObject,
+			} as MemoryMetadata,
+		});
+		if (!ok) {
+			throw new Error(`transcript ${input.transcriptId} not found`);
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Part of #14779. This adds the transcript-store write primitives that the redaction/share actions need:

- `createRedactedVariant()` creates or refreshes a deterministic linked transcript variant, with audio withheld and original transcript bytes/content left untouched.
- `share()` adds/replaces per-entity `metadata.share.grants` on the original transcript row and refuses to attach grants to variant rows.
- Deterministic tests cover stable variant IDs, tier-0 PII redaction, original/audio immutability, grant replacement, and variant-row refusal.
- Also fixes the current repo-level typecheck failure in `plugin-cloud-apps` by keeping deploy-fact update metadata to the typed custom fact fields instead of spreading arbitrary existing memory metadata back into a custom fact.

This intentionally does not claim the full #14779 action/live-LLM acceptance bar yet; it is the storage/use-case foundation for those actions.

## Verification

```bash
bunx @biomejs/biome check --write plugins/plugin-local-inference/src/services/voice/transcript-store.ts plugins/plugin-local-inference/src/services/voice/transcript-store.test.ts
# pass

bun run --cwd plugins/plugin-local-inference test src/services/voice/transcript-store.test.ts
# 1 file passed, 16 tests passed

bun run --cwd plugins/plugin-local-inference typecheck
# pass

git diff --check
# pass

bun run audit:error-policy-ratchet --report
# pass; no new fallback-slop

bun run --cwd packages/cloud/api typecheck
# pass, including wrangler production dry run

bun test plugins/plugin-cloud-apps/__tests__/app-facts.test.ts
# not run to completion locally: this worktree's Bun test resolver cannot resolve @elizaos/core for plugin-cloud-apps tests before the app-facts assertions execute.
```

Setup commands needed in the fresh worktree before verification:

```bash
bun run install:light
node packages/shared/scripts/generate-keywords.mjs --target ts
bun run --cwd packages/contracts build
bun run --cwd packages/cloud/routing build
```

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] N/A - store-level transcript persistence primitives only; no UI changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - store-level transcript persistence primitives only; no UI changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow is wired in this slice.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no HTTP route/service runtime path is invoked in this slice; focused store tests exercise the domain write/read behavior directly.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model/action/provider/evaluator path changed in this slice. #14779 still needs live-LLM action trajectory evidence once the agent actions are wired and provider credentials are available.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: [`transcript-store.test.ts`](https://github.com/elizaOS/eliza/blob/feat/14779-transcript-redaction-actions/plugins/plugin-local-inference/src/services/voice/transcript-store.test.ts), [`transcript-store.ts`](https://github.com/elizaOS/eliza/blob/feat/14779-transcript-redaction-actions/plugins/plugin-local-inference/src/services/voice/transcript-store.ts), and [`app-facts.ts`](https://github.com/elizaOS/eliza/blob/feat/14779-transcript-redaction-actions/plugins/plugin-cloud-apps/src/app-facts.ts), plus focused test/typecheck output above proving original transcript immutability, `redactedVariantId`, `redactionOf`, audio withholding, share-grant replacement, and the deploy-fact metadata type boundary.