### PR TITLE
test(agent): cover files route disclosure state

### DIFF
--- a/packages/agent/src/api/files-disclosure.test.ts
+++ b/packages/agent/src/api/files-disclosure.test.ts
@@ -1,5 +1,5 @@
 /**
- * Contract for the Files-list per-viewer selection (#14781): OWNER/agent see
+ * Contract for the Files-list per-viewer selection (#14778): OWNER/agent see
  * the whole store; USER/GUEST get the designed restricted state (empty +
  * `restricted: true`), never a healthy-empty fabrication. Pure use-case.
  */

--- a/packages/agent/src/api/files-disclosure.ts
+++ b/packages/agent/src/api/files-disclosure.ts
@@ -1,5 +1,5 @@
 /**
- * Per-viewer selection for the Files list DTO (#14781) — the use-case the
+ * Per-viewer selection for the Files list DTO (#14778) — the use-case the
  * `/api/files` route delegates to, so no disclosure computation lives in the
  * route layer. Stored files are raw content-addressed blobs with NO reference
  * metadata of their own (doctrine #8876 AD1: no file table, no per-blob ACL),

--- a/packages/agent/src/api/files-routes.test.ts
+++ b/packages/agent/src/api/files-routes.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Route-level contract for the authenticated Files surface: GET /api/files
+ * sorts the content-addressed store newest-first and returns the viewer-aware
+ * restricted DTO for non-privileged callers. The storage service is a fake; the
+ * route handler and access-context plumbing are real.
+ */
+import type {
+  AccessContext,
+  IAgentRuntime,
+  RouteHandlerContext,
+  StoredFileListItem,
+  UUID,
+} from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { fileDeleteRoute, filesListRoute } from "./files-routes.ts";
+
+const REMOTE_FILES = "aws_s3";
+const AGENT = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" as UUID;
+const VIEWER = "cccccccc-cccc-4ccc-8ccc-cccccccccccc" as UUID;
+
+const FILES: StoredFileListItem[] = [
+  {
+    url: "/api/media/new.png",
+    hash: "new",
+    fileName: "new.png",
+    mimeType: "image/png",
+    size: 10,
+    createdAt: 2,
+  },
+  {
+    url: "/api/media/old.pdf",
+    hash: "old",
+    fileName: "old.pdf",
+    mimeType: "application/pdf",
+    size: 20,
+    createdAt: 1,
+  },
+];
+
+function fakeStorage(files: StoredFileListItem[] = FILES) {
+  return {
+    list: vi.fn(async () => [...files].reverse()),
+    delete: vi.fn(async (name: string) =>
+      files.some((file) => file.fileName === name),
+    ),
+  };
+}
+
+function makeRuntime(storage: unknown): IAgentRuntime {
+  return {
+    agentId: AGENT,
+    getService: (type: string) => (type === REMOTE_FILES ? storage : null),
+  } as unknown as IAgentRuntime;
+}
+
+function routeCtx(
+  runtime: IAgentRuntime,
+  accessContext?: AccessContext,
+): RouteHandlerContext {
+  return {
+    body: undefined,
+    params: {},
+    query: {},
+    headers: {},
+    method: "GET",
+    path: "/api/files",
+    runtime,
+    inProcess: false,
+    accessContext,
+  };
+}
+
+describe("filesRoutes", () => {
+  it("lists owner-visible files newest-first through the route handler", async () => {
+    const result = await filesListRoute.routeHandler?.(
+      routeCtx(makeRuntime(fakeStorage()), {
+        requesterEntityId: VIEWER,
+        role: "OWNER",
+        isOwner: true,
+      }),
+    );
+
+    expect(result?.status).toBe(200);
+    expect(result?.body).toEqual({ files: FILES, restricted: false });
+  });
+
+  it("returns the restricted state for USER callers instead of raw store rows", async () => {
+    const result = await filesListRoute.routeHandler?.(
+      routeCtx(makeRuntime(fakeStorage()), {
+        requesterEntityId: VIEWER,
+        role: "USER",
+      }),
+    );
+
+    expect(result?.status).toBe(200);
+    expect(result?.body).toEqual({ files: [], restricted: true });
+  });
+
+  it("reports unavailable when the storage service is absent", async () => {
+    const result = await filesListRoute.routeHandler?.(
+      routeCtx(makeRuntime(null)),
+    );
+    expect(result).toEqual({
+      status: 503,
+      body: { error: "file storage unavailable" },
+    });
+  });
+
+  it("deletes by route param through the storage service", async () => {
+    const storage = fakeStorage();
+    const result = await fileDeleteRoute.routeHandler?.({
+      ...routeCtx(makeRuntime(storage)),
+      method: "DELETE",
+      path: "/api/files/new.png",
+      params: { filename: "new.png" },
+    });
+
+    expect(result).toEqual({ status: 200, body: { deleted: true } });
+    expect(storage.delete).toHaveBeenCalledWith("new.png");
+  });
+});

--- a/packages/agent/src/api/files-routes.ts
+++ b/packages/agent/src/api/files-routes.ts
@@ -23,7 +23,7 @@ function getFileStorage(runtime: IAgentRuntime): IFileStorageService | null {
 
 /**
  * GET /api/files — list stored files (newest first), selected per viewer
- * (#14781): the single-owner boundary and OWNER/ADMIN-rank viewers see the
+ * (#14778): the single-owner boundary and OWNER/ADMIN-rank viewers see the
  * whole store; USER/GUEST viewers get the designed restricted state.
  */
 export const filesListRoute: Route = {


### PR DESCRIPTION
## Summary
- add route-level coverage for `GET /api/files` proving owner-visible files are sorted newest-first
- assert USER callers receive the designed `{ files: [], restricted: true }` state instead of raw content-addressed store rows
- correct stale Files-surface comment references from #14781 to #14778

Part of #14778. This does not close #14778; transcript/message/provider disclosure wiring and grant -> snapshot -> disclose -> revoke e2e evidence remain outstanding.

## Verification
- `bunx vitest run src/api/files-disclosure.test.ts src/api/files-routes.test.ts --config vitest.config.ts` from `packages/agent` (2 files, 9 tests passed)
- `bunx biome check packages/agent/src/api/files-disclosure.ts packages/agent/src/api/files-disclosure.test.ts packages/agent/src/api/files-routes.ts packages/agent/src/api/files-routes.test.ts`
- `bun run --cwd packages/agent build`
- `git diff --check origin/develop...HEAD`
- `bun run audit:error-policy-ratchet --report`

## Known Baseline Blocker
- `bun run --cwd packages/agent typecheck` is still red on current `origin/develop` for unrelated baseline issues: missing optional/workspace packages such as `@elizaos/plugin-app-control`, `@elizaos/plugin-streaming`, `@elizaos/cloud-routing`, `@elizaos/contracts`, plus existing `AccountWithCredentialFlag` UI property errors. The touched files are covered by the focused tests, Biome, and package build above.

## Evidence
- UI screenshots/video: N/A - route-level API test coverage only, no UI surface changed.
- Real LLM trajectories: N/A - no action/provider/prompt/model behavior changed.
- API traces/logs: covered by direct route-handler assertions for owner and USER access contexts.
