### PR TITLE
fix(discord): dedupe tool reply delivery paths

### DIFF
--- a/plugins/plugin-discord/__tests__/messages-component-delivery.test.ts
+++ b/plugins/plugin-discord/__tests__/messages-component-delivery.test.ts
@@ -72,7 +72,7 @@ function makeRuntime(
 				_message: Memory,
 				callback: (content: Content) => Promise<unknown>,
 			) => {
-				await callback(replyContent);
+				await callback(structuredClone(replyContent));
 			},
 		},
 	} as unknown as ICompatRuntime;
@@ -90,9 +90,13 @@ function makeSentMessage(id: string, options: CapturedSend) {
 	};
 }
 
-function makeInbound(channel: unknown, authorId: string): DiscordMessage {
+function makeInbound(
+	channel: unknown,
+	authorId: string,
+	messageId = "666000000000000000",
+): DiscordMessage {
 	return {
-		id: "666000000000000000",
+		id: messageId,
 		content: "which one?",
 		createdTimestamp: Date.now(),
 		author: {
@@ -224,7 +228,9 @@ describe("Discord outbound component delivery (#14527)", () => {
 			DISCORD_DRAFT_STREAMING: "true",
 		});
 		const manager = new MessageManager(makeDiscordService(client), runtime);
-		await manager.handleMessage(makeInbound(channel, "555000111222333444"));
+		await manager.handleMessage(
+			makeInbound(channel, "555000111222333444", "666000000000000001"),
+		);
 
 		expect(errors).toEqual([]);
 		expect(channelSends).toHaveLength(1);

--- a/plugins/plugin-discord/actions/messageConnector.test.ts
+++ b/plugins/plugin-discord/actions/messageConnector.test.ts
@@ -34,6 +34,9 @@ function createRuntime() {
 			warn: vi.fn(),
 			error: vi.fn(),
 		},
+		ensureConnection: vi.fn().mockResolvedValue(undefined),
+		createMemory: vi.fn().mockImplementation(async (memory) => memory.id),
+		getMemoryById: vi.fn().mockResolvedValue(null),
 		getRoom: vi.fn(),
 		getEntityById: vi.fn(),
 		getRelationships: vi.fn().mockResolvedValue([]),
@@ -341,5 +344,76 @@ describe("Discord message connector adapter", () => {
 			reply: { messageReference: "1506947499212935208" },
 			files: undefined,
 		});
+	});
+
+	it("suppresses identical connector sends that race the inbound callback", async () => {
+		const runtime = Object.assign(createRuntime(), {
+			getRoom: vi.fn().mockResolvedValue({
+				channelId: "222222222222222223",
+			}),
+		});
+		const send = vi.fn(async (options: unknown) => ({
+			id: `44444444444444444${send.mock.calls.length}`,
+			content:
+				typeof options === "object" && options
+					? String((options as { content?: string }).content ?? "")
+					: String(options ?? ""),
+			attachments: { size: 0 },
+			url: "https://discord.com/channels/111/223/444",
+			createdTimestamp: 123,
+		}));
+		const channel = {
+			id: "222222222222222223",
+			name: "general",
+			guild: { id: "111111111111111111", name: "Eliza" },
+			isTextBased: () => true,
+			isVoiceBased: () => false,
+			send,
+		};
+		const client = {
+			isReady: () => true,
+			channels: { fetch: vi.fn().mockResolvedValue(channel) },
+			user: {
+				id: "999999999999999999",
+				username: "bot",
+				displayName: "Bot",
+			},
+		};
+		const accountPool = new DiscordAccountClientPool();
+		accountPool.set({
+			accountId: DEFAULT_ACCOUNT_ID,
+			account: { id: DEFAULT_ACCOUNT_ID, token: "token", enabled: true },
+			client,
+			settings: {},
+			dynamicChannelIds: new Set<string>(),
+			clientReadyPromise: null,
+			loginFailed: false,
+		} as never);
+		const service = createDiscordConnectorTestService({
+			runtime,
+			accountPool,
+			defaultAccountId: DEFAULT_ACCOUNT_ID,
+			getChannelType: vi.fn().mockResolvedValue("GROUP"),
+		});
+		const target = {
+			source: "discord",
+			roomId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+		};
+		const content = {
+			text: "Bitcoin is currently at $61,984 USD.",
+			inReplyTo: "1506947499212935209",
+		};
+
+		await service.handleSendMessage(runtime, target, content);
+		await service.handleSendMessage(runtime, target, content);
+
+		expect(send).toHaveBeenCalledOnce();
+		expect(runtime.logger.debug).toHaveBeenCalledWith(
+			expect.objectContaining({
+				src: "plugin:discord",
+				channelId: "222222222222222223",
+			}),
+			"Suppressing duplicate Discord connector delivery",
+		);
 	});
 });

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -190,6 +190,10 @@ const ACTIVE_TASK_AGENT_STATUSES = new Set([
 	"blocked",
 	"tool_running",
 ]);
+const DISCORD_OUTBOUND_DEDUPE_WINDOW_MS = 2000;
+const DISCORD_OUTBOUND_DEDUPE_MAX_KEYS = 512;
+
+const recentOutboundDiscordDeliveries = new Map<string, number>();
 
 function asRecord(value: unknown): Record<string, unknown> | null {
 	return value && typeof value === "object" && !Array.isArray(value)
@@ -244,6 +248,117 @@ export function shouldSuppressTimeoutForInFlightDispatchForTests({
 	responseDispatchInFlight: boolean;
 }): boolean {
 	return generationTimedOut && responseDispatchInFlight;
+}
+
+export interface DiscordOutboundDeliveryReservation {
+	commit(): void;
+	release(): void;
+}
+
+export type BeginDiscordOutboundDeliveryResult =
+	| { kind: "duplicate" }
+	| { kind: "deliver"; reservation: DiscordOutboundDeliveryReservation };
+
+export interface DiscordOutboundDeliveryParams {
+	accountId?: string;
+	channelId: string;
+	replyToMessageId?: string;
+	text?: string;
+	attachmentUrls?: readonly string[];
+	now?: number;
+	windowMs?: number;
+	state?: Map<string, number>;
+}
+
+function normalizeOutboundText(text: string | undefined): string {
+	return typeof text === "string"
+		? text.replace(/\s+/g, " ").trim().toLowerCase()
+		: "";
+}
+
+function outboundAttachmentIdentity(
+	attachmentUrls: readonly string[] | undefined,
+): string {
+	return attachmentUrls?.filter(Boolean).sort().join(",") ?? "";
+}
+
+function pruneOutboundDedupeState(
+	state: Map<string, number>,
+	now: number,
+	windowMs: number,
+): void {
+	for (const [key, timestamp] of state) {
+		if (now - Math.abs(timestamp) > windowMs) {
+			state.delete(key);
+		}
+	}
+	if (state.size <= DISCORD_OUTBOUND_DEDUPE_MAX_KEYS) return;
+	const overflow = state.size - DISCORD_OUTBOUND_DEDUPE_MAX_KEYS;
+	let removed = 0;
+	for (const key of state.keys()) {
+		if (removed >= overflow) break;
+		state.delete(key);
+		removed += 1;
+	}
+}
+
+/**
+ * Reserve one outbound Discord delivery. Discord can receive the same logical
+ * tool-backed answer through the inbound response callback and the generic
+ * message-connector send path in the same event-loop burst; this guard shares a
+ * short process-local window across both paths so the first REST send wins.
+ */
+export function beginDiscordOutboundDelivery(
+	params: DiscordOutboundDeliveryParams,
+): BeginDiscordOutboundDeliveryResult {
+	const text = normalizeOutboundText(params.text);
+	const attachments = outboundAttachmentIdentity(params.attachmentUrls);
+	if (!text && !attachments) {
+		return {
+			kind: "deliver",
+			reservation: { commit() {}, release() {} },
+		};
+	}
+
+	const now = params.now ?? Date.now();
+	const windowMs = params.windowMs ?? DISCORD_OUTBOUND_DEDUPE_WINDOW_MS;
+	const state = params.state ?? recentOutboundDiscordDeliveries;
+	const key = [
+		params.accountId ?? "default",
+		params.channelId,
+		params.replyToMessageId ?? "",
+		attachments,
+		text,
+	].join("\u0000");
+
+	pruneOutboundDedupeState(state, now, windowMs);
+	const previous = state.get(key);
+	if (
+		previous !== undefined &&
+		Math.abs(now - Math.abs(previous)) <= windowMs
+	) {
+		return { kind: "duplicate" };
+	}
+
+	state.set(key, -now);
+	let settled = false;
+	return {
+		kind: "deliver",
+		reservation: {
+			commit() {
+				if (settled) return;
+				settled = true;
+				state.set(key, now);
+			},
+			release() {
+				if (settled) return;
+				settled = true;
+				if (state.get(key) === -now) {
+					state.delete(key);
+				}
+			},
+		},
+	};
 }
 
 /**
@@ -1102,6 +1217,7 @@ export class MessageManager {
 			statusReactions?.setThinking();
 
 			const callback: HandlerCallback = async (content: Content) => {
+				let outboundReservation: DiscordOutboundDeliveryReservation | undefined;
 				try {
 					const pendingAttachmentCount = Array.isArray(content.attachments)
 						? content.attachments.filter((media) => Boolean(media?.url)).length
@@ -1229,6 +1345,37 @@ export class MessageManager {
 						callbackDedup._elizaSentReplyKeys.add(dedupKey);
 					}
 
+					const outboundDedupe = beginDiscordOutboundDelivery({
+						accountId: this.accountId,
+						channelId: channel.id,
+						replyToMessageId:
+							outboundReplyToMessageId ??
+							(typeof content.inReplyTo === "string"
+								? content.inReplyTo
+								: undefined),
+						text: textContent,
+						attachmentUrls: content.attachments
+							?.map((media) => media.url)
+							.filter((url): url is string => typeof url === "string"),
+					});
+					if (outboundDedupe.kind === "duplicate") {
+						this.runtime.logger.debug(
+							{
+								src: "plugin:discord",
+								agentId: this.runtime.agentId,
+								channelId: channel.id,
+								messageId: message.id,
+								textPreview: textContent
+									.replace(/\s+/g, " ")
+									.trim()
+									.slice(0, 200),
+							},
+							"Suppressing duplicate Discord outbound delivery",
+						);
+						return [];
+					}
+					outboundReservation = outboundDedupe.reservation;
+
 					const files: AttachmentBuilder[] = [];
 					if (content.attachments && content.attachments.length > 0) {
 						for (const media of content.attachments) {
@@ -1340,6 +1487,10 @@ export class MessageManager {
 							"Discord response callback completed without sending any messages",
 						);
 					}
+					if (messages.length > 0) {
+						outboundReservation.commit();
+						outboundReservation = undefined;
+					}
 
 					const memories: Memory[] = [];
 					for (const m of messages) {
@@ -1409,6 +1560,7 @@ export class MessageManager {
 
 					return memories;
 				} catch (error) {
+					outboundReservation?.release();
 					this.runtime.logger.error(
 						{
 							src: "plugin:discord",

--- a/plugins/plugin-discord/service.ts
+++ b/plugins/plugin-discord/service.ts
@@ -142,7 +142,12 @@ import {
 	resolveDiscordRuntimeEntityId,
 	resolveElizaOwnerEntityId,
 } from "./identity";
-import { createDiscordMessageMemoryOnce, MessageManager } from "./messages";
+import {
+	beginDiscordOutboundDelivery,
+	createDiscordMessageMemoryOnce,
+	type DiscordOutboundDeliveryReservation,
+	MessageManager,
+} from "./messages";
 import type {
 	BuildMemoryFromMessageOptions,
 	ChannelHistoryOptions,
@@ -1582,6 +1587,7 @@ export class DiscordService extends Service implements IDiscordService {
 		target: TargetInfo,
 		content: Content,
 	): Promise<Memory | undefined> {
+		let outboundReservation: DiscordOutboundDeliveryReservation | undefined;
 		// Resolve the connector account this outbound message must use.
 		// Priority: explicit target.accountId > this service instance's default.
 		// `Content.metadata` is intentionally NOT consulted because it may be
@@ -1701,6 +1707,36 @@ export class DiscordService extends Service implements IDiscordService {
 					const outboundReplyToMessageId =
 						discordReplyReferenceFromContent(content);
 					if (textContent || files.length > 0) {
+						const outboundDedupe = beginDiscordOutboundDelivery({
+							accountId,
+							channelId: targetChannel.id,
+							replyToMessageId:
+								outboundReplyToMessageId ??
+								(typeof content.inReplyTo === "string"
+									? content.inReplyTo
+									: undefined),
+							text: textContent,
+							attachmentUrls: content.attachments
+								?.map((media) => media.url)
+								.filter((url): url is string => typeof url === "string"),
+						});
+						if (outboundDedupe.kind === "duplicate") {
+							runtime.logger.debug(
+								{
+									src: "plugin:discord",
+									agentId: runtime.agentId,
+									channelId: targetChannel.id,
+									accountId,
+									textPreview: textContent
+										.replace(/\s+/g, " ")
+										.trim()
+										.slice(0, 200),
+								},
+								"Suppressing duplicate Discord connector delivery",
+							);
+							return;
+						}
+						outboundReservation = outboundDedupe.reservation;
 						if (textContent) {
 							const chunks = splitMessage(textContent, MAX_MESSAGE_LENGTH);
 							if (chunks.length > 1) {
@@ -1756,7 +1792,13 @@ export class DiscordService extends Service implements IDiscordService {
 							});
 							sentMessages.push(sent);
 						}
+						if (sentMessages.length > 0) {
+							outboundReservation.commit();
+							outboundReservation = undefined;
+						}
 					} else {
+						outboundReservation?.release();
+						outboundReservation = undefined;
 						runtime.logger.warn("No text content or attachments provided");
 					}
 
@@ -1858,6 +1900,7 @@ export class DiscordService extends Service implements IDiscordService {
 				);
 			}
 		} catch (error) {
+			outboundReservation?.release();
 			runtime.logger.error(
 				`Error sending message to ${JSON.stringify(target)}: ${error instanceof Error ? error.message : String(error)}`,
 			);


### PR DESCRIPTION
## Summary
- add a shared short-window Discord outbound delivery reservation used by both the inbound response callback and connector send path
- release reservations on failed/no-content sends and commit only after Discord accepts a message
- cover the connector race with a regression test and isolate component-delivery test payload mutation

Fixes #15585

## Verification
- `git diff --check`
- `bunx biome check plugins/plugin-discord/messages.ts plugins/plugin-discord/service.ts plugins/plugin-discord/actions/messageConnector.test.ts plugins/plugin-discord/__tests__/messages-component-delivery.test.ts --no-errors-on-unmatched`
- `bunx vitest run --config vitest.config.ts actions/messageConnector.test.ts __tests__/messages-component-delivery.test.ts __tests__/generation-timeout-dispatch.test.ts`
- `bun run --cwd plugins/plugin-discord typecheck`

## Evidence
<!-- evidence-row:real-llm-trajectories -->
N/A - Discord delivery plumbing change; no agent prompt/model behavior changed.

<!-- evidence-row:backend-logs -->
Targeted Vitest coverage exercises the duplicate connector race and asserts the duplicate-suppression log path.

<!-- evidence-row:frontend-logs -->
N/A - server-side Discord connector/runtime path only; no browser frontend involved.

<!-- evidence-row:before-screenshots -->
N/A - no UI pixels changed.

<!-- evidence-row:after-screenshots -->
N/A - no UI pixels changed.

<!-- evidence-row:video-walkthrough -->
N/A - no UI flow changed. Live Discord credential evidence was not captured in this workspace; regression coverage uses the plugin's connector harness.

<!-- evidence-row:domain-artifacts -->
N/A - no persistent domain artifact schema or migration changed.
