### PR TITLE
fix(transcripts): scope redacted variant seed ids

### DIFF
--- a/plugins/plugin-local-inference/src/services/voice/transcript-store.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/transcript-store.test.ts
@@ -434,6 +434,42 @@ describe("TranscriptStore", () => {
 			expect(variantMeta.redactedBy).toBe(VIEWER);
 		});
 
+		it("keeps seeded redacted variant ids scoped to the original transcript", async () => {
+			const rt = fakeRuntime();
+			const store = new TranscriptStore(rt);
+			const firstId = "00000000-0000-4000-8000-000000000101";
+			const secondId = "00000000-0000-4000-8000-000000000202";
+			await store.create({
+				roomId: ROOM,
+				entityId: ENTITY,
+				transcript: makeTranscript({ id: firstId }),
+			});
+			await store.create({
+				roomId: ROOM,
+				entityId: ENTITY,
+				transcript: makeTranscript({ id: secondId }),
+			});
+
+			const first = await store.createRedactedVariant({
+				originalId: firstId as UUID,
+				seed: "same-seed",
+				nowMs: 3000,
+			});
+			const second = await store.createRedactedVariant({
+				originalId: secondId as UUID,
+				seed: "same-seed",
+				nowMs: 3000,
+			});
+
+			expect(first.id).not.toBe(second.id);
+			expect((rt.rows.get(firstId) as Memory).metadata).toMatchObject({
+				redactedVariantId: first.id,
+			});
+			expect((rt.rows.get(secondId) as Memory).metadata).toMatchObject({
+				redactedVariantId: second.id,
+			});
+		});
+
 		it("adds and replaces transcript share grants on the original row", async () => {
 			const rt = fakeRuntime();
 			const store = new TranscriptStore(rt);

--- a/plugins/plugin-local-inference/src/services/voice/transcript-store.ts
+++ b/plugins/plugin-local-inference/src/services/voice/transcript-store.ts
@@ -377,7 +377,7 @@ export class TranscriptStore {
 		const variantId =
 			existingVariantId ??
 			(stringToUuid(
-				`transcript-redaction:${input.seed ?? input.originalId}`,
+				`transcript-redaction:${input.originalId}:${input.seed ?? ""}`,
 			) as UUID);
 		const nowMs = input.nowMs ?? Date.now();
 		const variant = {


### PR DESCRIPTION
## Summary
- fix `createRedactedVariant()` so deterministic seed overrides are still namespaced by the original transcript id
- add a regression test proving two different originals using the same seed produce different redacted variant ids and keep their own `redactedVariantId` links

Part of #14779. This is a follow-up to merged #15597 and does not close the action/live-LLM acceptance work.

## Why
The #15597 implementation used `transcript-redaction:${seed}` whenever a seed was supplied. That made deterministic test/action seeds collide across different original transcripts. The namespace now uses `transcript-redaction:${originalId}:${seed ?? ""}`.

## Verification
- `bun run --cwd plugins/plugin-local-inference test src/services/voice/transcript-store.test.ts` (1 file, 17 tests passed)
- `bunx biome check plugins/plugin-local-inference/src/services/voice/transcript-store.ts plugins/plugin-local-inference/src/services/voice/transcript-store.test.ts`
- `git diff --check origin/develop...HEAD`
- `bun run audit:error-policy-ratchet --report`

## Known Baseline Blocker
- `bun run --cwd plugins/plugin-local-inference typecheck` remains blocked on current `develop` by an unrelated missing optional package import: `src/local-inference-routes.ts(125,3): Cannot find module @elizaos/plugin-aosp-local-inference`.

## Evidence
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots: `N/A - store-level transcript persistence fix only; no UI surface changed`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots: `N/A - store-level transcript persistence fix only; no UI surface changed`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: `N/A - no user-facing flow is wired in this slice`.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs: `N/A - no HTTP route/service runtime path is invoked in this slice; focused store tests exercise the domain write/read behavior directly`.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: `N/A - no frontend code changed`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: `N/A - no action/provider/prompt/model path changed`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: [`transcript-store.test.ts`](https://github.com/elizaOS/eliza/blob/fix/14779-redacted-variant-seed-scope/plugins/plugin-local-inference/src/services/voice/transcript-store.test.ts) plus `bun run --cwd plugins/plugin-local-inference test src/services/voice/transcript-store.test.ts` prove separate memory rows and separate `redactedVariantId` links for two originals sharing the same deterministic seed.