### PR TITLE
feat(transcripts): add permission actions

### DIFF
--- a/plugins/plugin-local-inference/src/actions/transcript-permissions.test.ts
+++ b/plugins/plugin-local-inference/src/actions/transcript-permissions.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Exercises transcript redaction/share actions through the real TranscriptStore
+ * metadata writes. The harness is in-memory, but role resolution uses normal
+ * room/world metadata so owner and admin paths match runtime authorization.
+ */
+import type { Memory, UUID, World } from "@elizaos/core";
+import type { Transcript } from "@elizaos/shared/transcripts";
+import { describe, expect, it, vi } from "vitest";
+import {
+	TRANSCRIPTS_TABLE,
+	TranscriptStore,
+	type TranscriptStoreRuntime,
+} from "../services/voice/transcript-store";
+import {
+	redactTranscriptAction,
+	shareTranscriptAction,
+} from "./transcript-permissions";
+
+const ROOM = "11111111-1111-1111-1111-111111111111" as UUID;
+const WORLD = "22222222-2222-2222-2222-222222222222" as UUID;
+const OWNER = "33333333-3333-3333-3333-333333333333" as UUID;
+const ADMIN = "44444444-4444-4444-4444-444444444444" as UUID;
+const STRANGER = "55555555-5555-5555-5555-555555555555" as UUID;
+const TARGET = "66666666-6666-6666-6666-666666666666" as UUID;
+const TRANSCRIPT_ID = "77777777-7777-7777-7777-777777777777" as UUID;
+
+type TestRuntime = TranscriptStoreRuntime & {
+	rows: Map<string, Memory>;
+	getRoom: (roomId: UUID) => Promise<{ id: UUID; worldId: UUID } | null>;
+	getWorld: (worldId: UUID) => Promise<World | null>;
+	getSetting: (key: string) => string | undefined;
+	getRelationships: () => Promise<[]>;
+	getEntityById: () => Promise<null>;
+	reportError: ReturnType<typeof vi.fn>;
+};
+
+function makeTranscript(over: Partial<Transcript> = {}): Transcript {
+	return {
+		id: TRANSCRIPT_ID,
+		title: "Payroll sync",
+		createdAt: 1000,
+		durationMs: 2000,
+		audioUrl: "/api/media/payroll.wav",
+		audioContentType: "audio/wav",
+		source: "voice-session",
+		scope: "owner-private",
+		status: "ready",
+		speakerCount: 1,
+		segments: [
+			{
+				id: "s1",
+				speakerLabel: "Alice",
+				startMs: 0,
+				endMs: 2000,
+				text: "Bob's SSN is 123-45-6789",
+				words: [{ text: "123-45-6789", startMs: 1000, endMs: 1500 }],
+			},
+		],
+		...over,
+	};
+}
+
+function makeRuntime(): TestRuntime {
+	const rows = new Map<string, Memory>();
+	const tables = new Map<string, string>();
+	return {
+		rows,
+		agentId: "99999999-9999-9999-9999-999999999999" as UUID,
+		async createMemory(memory, tableName) {
+			const id = memory.id as UUID;
+			rows.set(id, memory);
+			tables.set(id, tableName);
+			return id;
+		},
+		async getMemories({ tableName, roomId, orderDirection }) {
+			let out = [...rows.values()].filter(
+				(row) => tables.get(row.id as string) === tableName,
+			);
+			if (roomId) out = out.filter((row) => row.roomId === roomId);
+			out.sort((a, b) =>
+				orderDirection === "asc"
+					? (a.createdAt ?? 0) - (b.createdAt ?? 0)
+					: (b.createdAt ?? 0) - (a.createdAt ?? 0),
+			);
+			return out;
+		},
+		async getMemoryById(id) {
+			return rows.get(id) ?? null;
+		},
+		async updateMemory(memory) {
+			const id = memory.id as string;
+			const existing = rows.get(id);
+			if (!existing) return false;
+			rows.set(id, { ...existing, ...memory });
+			return true;
+		},
+		async deleteMemory(id) {
+			rows.delete(id);
+			tables.delete(id);
+		},
+		async getRoom(roomId) {
+			return roomId === ROOM ? { id: ROOM, worldId: WORLD } : null;
+		},
+		async getWorld(worldId) {
+			if (worldId !== WORLD) return null;
+			return {
+				id: WORLD,
+				name: "Test world",
+				agentId: "99999999-9999-9999-9999-999999999999" as UUID,
+				serverId: WORLD,
+				metadata: {
+					roles: { [ADMIN]: "ADMIN" },
+					roleSources: { [ADMIN]: "manual" },
+				},
+			} as World;
+		},
+		getSetting() {
+			return undefined;
+		},
+		async getRelationships() {
+			return [];
+		},
+		async getEntityById() {
+			return null;
+		},
+		reportError: vi.fn(),
+	};
+}
+
+function message(entityId: UUID): Memory {
+	return {
+		id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" as UUID,
+		entityId,
+		roomId: ROOM,
+		agentId: "99999999-9999-9999-9999-999999999999" as UUID,
+		content: { text: "manage transcript" },
+	} as Memory;
+}
+
+async function seed(runtime: TestRuntime, entityId: UUID = OWNER) {
+	const store = new TranscriptStore(runtime);
+	const transcript = makeTranscript();
+	await store.create({ roomId: ROOM, entityId, transcript });
+	return { store, transcript };
+}
+
+function shareGrants(row: Memory): Array<Record<string, unknown>> {
+	const share = (row.metadata as Record<string, unknown> | undefined)?.share as
+		| { grants?: Array<Record<string, unknown>> }
+		| undefined;
+	return share?.grants ?? [];
+}
+
+describe("transcript permission actions", () => {
+	it("lets the transcript owner create a redacted variant without mutating audio", async () => {
+		const runtime = makeRuntime();
+		await seed(runtime);
+		const callback = vi.fn(async () => []);
+
+		const result = await redactTranscriptAction.handler(
+			runtime,
+			message(OWNER),
+			undefined,
+			{ transcriptId: TRANSCRIPT_ID },
+			callback,
+		);
+
+		expect(result?.success).toBe(true);
+		const originalRow = runtime.rows.get(TRANSCRIPT_ID) as Memory;
+		const variantId = (originalRow.metadata as Record<string, unknown>)
+			.redactedVariantId as string;
+		expect(variantId).toBeTruthy();
+		const original = await new TranscriptStore(runtime).get(TRANSCRIPT_ID);
+		const variant = await new TranscriptStore(runtime).get(variantId as UUID);
+		expect(original?.audioUrl).toBe("/api/media/payroll.wav");
+		expect(variant?.audioUrl).toBeUndefined();
+		expect(variant?.segments[0]?.text).toBe("Bob's SSN is [SSN]");
+		expect(callback).toHaveBeenCalledWith({
+			text: "Created a redacted transcript variant.",
+			actions: ["REDACT_TRANSCRIPT_SUCCESS"],
+		});
+	});
+
+	it("denies redaction for a non-owner without admin role", async () => {
+		const runtime = makeRuntime();
+		await seed(runtime);
+
+		const result = await redactTranscriptAction.handler(
+			runtime,
+			message(STRANGER),
+			undefined,
+			{ transcriptId: TRANSCRIPT_ID },
+			vi.fn(async () => []),
+		);
+
+		expect(result?.success).toBe(false);
+		const originalRow = runtime.rows.get(TRANSCRIPT_ID) as Memory;
+		expect(
+			(originalRow.metadata as Record<string, unknown>).redactedVariantId,
+		).toBeUndefined();
+		expect(runtime.reportError).not.toHaveBeenCalled();
+	});
+
+	it("lets the owner share only the redacted transcript by default", async () => {
+		const runtime = makeRuntime();
+		await seed(runtime);
+
+		const result = await shareTranscriptAction.handler(
+			runtime,
+			message(OWNER),
+			undefined,
+			{ transcriptId: TRANSCRIPT_ID, entityId: TARGET },
+			vi.fn(async () => []),
+		);
+
+		expect(result?.success).toBe(true);
+		const originalRow = runtime.rows.get(TRANSCRIPT_ID) as Memory;
+		expect(
+			(originalRow.metadata as Record<string, unknown>).redactedVariantId,
+		).toBeTruthy();
+		expect(shareGrants(originalRow)).toMatchObject([
+			{ entityId: TARGET, mode: "redacted", grantedBy: OWNER },
+		]);
+	});
+
+	it("denies full transcript sharing by a non-admin owner", async () => {
+		const runtime = makeRuntime();
+		await seed(runtime);
+
+		const result = await shareTranscriptAction.handler(
+			runtime,
+			message(OWNER),
+			undefined,
+			{ transcriptId: TRANSCRIPT_ID, entityId: TARGET, mode: "full" },
+			vi.fn(async () => []),
+		);
+
+		expect(result?.success).toBe(false);
+		const originalRow = runtime.rows.get(TRANSCRIPT_ID) as Memory;
+		expect(shareGrants(originalRow)).toEqual([]);
+		expect(runtime.reportError).not.toHaveBeenCalled();
+	});
+
+	it("lets an admin grant full access to another entity's transcript", async () => {
+		const runtime = makeRuntime();
+		await seed(runtime, OWNER);
+
+		const result = await shareTranscriptAction.handler(
+			runtime,
+			message(ADMIN),
+			undefined,
+			{ transcriptId: TRANSCRIPT_ID, entityId: TARGET, mode: "full" },
+			vi.fn(async () => []),
+		);
+
+		expect(result?.success).toBe(true);
+		const originalRow = runtime.rows.get(TRANSCRIPT_ID) as Memory;
+		expect(shareGrants(originalRow)).toMatchObject([
+			{ entityId: TARGET, mode: "full", grantedBy: ADMIN },
+		]);
+	});
+
+	it("registers the action writes in the transcript memory partition", async () => {
+		const runtime = makeRuntime();
+		await seed(runtime);
+		await shareTranscriptAction.handler(
+			runtime,
+			message(OWNER),
+			undefined,
+			{ transcriptId: TRANSCRIPT_ID, entityId: TARGET },
+			vi.fn(async () => []),
+		);
+
+		const rows = await runtime.getMemories({ tableName: TRANSCRIPTS_TABLE });
+		expect(rows).toHaveLength(2);
+		expect(rows.every((row) => row.metadata?.source === "transcript")).toBe(
+			true,
+		);
+	});
+});

--- a/plugins/plugin-local-inference/src/actions/transcript-permissions.ts
+++ b/plugins/plugin-local-inference/src/actions/transcript-permissions.ts
@@ -1,0 +1,266 @@
+/**
+ * Transcript permissioning actions for variant-based redaction and per-viewer
+ * sharing. They are intentionally thin: authorization is checked at the action
+ * boundary, then the durable write goes through TranscriptStore so route,
+ * provider, and future UI paths all read the same metadata contract.
+ */
+
+import {
+	type Action,
+	type ActionResult,
+	type HandlerCallback,
+	hasRoleAccess,
+	type IAgentRuntime,
+	logger,
+	type Memory,
+	type UUID,
+} from "@elizaos/core";
+import {
+	TranscriptStore,
+	type TranscriptStoreRuntime,
+} from "../services/voice/transcript-store.js";
+
+type TranscriptPermissionRuntime = IAgentRuntime & TranscriptStoreRuntime;
+
+type ActionParams = Record<string, unknown>;
+
+function actionParams(options: unknown): ActionParams {
+	const direct = options && typeof options === "object" ? options : {};
+	const parameters =
+		"parameters" in direct &&
+		direct.parameters &&
+		typeof direct.parameters === "object"
+			? (direct.parameters as Record<string, unknown>)
+			: {};
+	return { ...(direct as Record<string, unknown>), ...parameters };
+}
+
+function stringParam(params: ActionParams, key: string): string | null {
+	const value = params[key];
+	return typeof value === "string" && value.trim().length > 0
+		? value.trim()
+		: null;
+}
+
+function transcriptIdFrom(params: ActionParams, message: Memory): UUID | null {
+	const value =
+		stringParam(params, "transcriptId") ??
+		stringParam(params, "id") ??
+		(typeof message.content.transcriptId === "string"
+			? message.content.transcriptId.trim()
+			: null);
+	return value ? (value as UUID) : null;
+}
+
+function shareModeFrom(params: ActionParams): "full" | "redacted" | null {
+	const raw = stringParam(params, "mode") ?? stringParam(params, "shareMode");
+	if (raw === "full" || raw === "redacted") return raw;
+	return null;
+}
+
+function logDenied(
+	action: string,
+	reason: string,
+	context: Record<string, unknown>,
+): void {
+	logger.warn({ action, reason, ...context }, `[${action}] denied`);
+}
+
+async function isOwnTranscript(
+	runtime: TranscriptPermissionRuntime,
+	transcriptId: UUID,
+	message: Memory,
+): Promise<boolean> {
+	const row = await runtime.getMemoryById(transcriptId);
+	if (!row) return false;
+	return row.entityId === message.entityId;
+}
+
+async function canManageTranscript(
+	runtime: TranscriptPermissionRuntime,
+	message: Memory,
+	transcriptId: UUID,
+): Promise<boolean> {
+	if (await isOwnTranscript(runtime, transcriptId, message)) return true;
+	return hasRoleAccess(runtime, message, "ADMIN");
+}
+
+async function redactHandler(
+	runtime: IAgentRuntime,
+	message: Memory,
+	_state?: unknown,
+	options?: unknown,
+	callback?: HandlerCallback,
+): Promise<ActionResult> {
+	const rt = runtime as TranscriptPermissionRuntime;
+	const params = actionParams(options);
+	const transcriptId = transcriptIdFrom(params, message);
+	if (!transcriptId) {
+		const text = "Transcript id is required.";
+		await callback?.({ text, actions: ["REDACT_TRANSCRIPT_FAILED"] });
+		return { success: false, text, error: "TRANSCRIPT_ID_REQUIRED" };
+	}
+
+	if (!(await canManageTranscript(rt, message, transcriptId))) {
+		logDenied("REDACT_TRANSCRIPT", "insufficient_role", {
+			transcriptId,
+			entityId: message.entityId,
+		});
+		const text = "You do not have permission to redact that transcript.";
+		await callback?.({ text, actions: ["REDACT_TRANSCRIPT_DENIED"] });
+		return { success: false, text, error: "TRANSCRIPT_REDACTION_DENIED" };
+	}
+
+	const variant = await new TranscriptStore(rt).createRedactedVariant({
+		originalId: transcriptId,
+		redactedBy: message.entityId as UUID,
+	});
+	const text = "Created a redacted transcript variant.";
+	await callback?.({ text, actions: ["REDACT_TRANSCRIPT_SUCCESS"] });
+	return {
+		success: true,
+		text,
+		data: {
+			actionName: "REDACT_TRANSCRIPT",
+			transcriptId,
+			redactedVariantId: variant.id,
+		},
+	};
+}
+
+async function shareHandler(
+	runtime: IAgentRuntime,
+	message: Memory,
+	_state?: unknown,
+	options?: unknown,
+	callback?: HandlerCallback,
+): Promise<ActionResult> {
+	const rt = runtime as TranscriptPermissionRuntime;
+	const params = actionParams(options);
+	const transcriptId = transcriptIdFrom(params, message);
+	const targetEntityId = stringParam(params, "entityId") as UUID | null;
+	const mode = shareModeFrom(params) ?? "redacted";
+	if (!transcriptId || !targetEntityId) {
+		const text = "Transcript id and target entity id are required.";
+		await callback?.({ text, actions: ["SHARE_TRANSCRIPT_FAILED"] });
+		return { success: false, text, error: "TRANSCRIPT_SHARE_PARAMS_REQUIRED" };
+	}
+
+	const hasAdmin = await hasRoleAccess(rt, message, "ADMIN");
+	if (mode === "full" && !hasAdmin) {
+		logDenied("SHARE_TRANSCRIPT", "full_grant_requires_admin", {
+			transcriptId,
+			targetEntityId,
+			entityId: message.entityId,
+		});
+		const text = "Only an admin can share the full transcript.";
+		await callback?.({ text, actions: ["SHARE_TRANSCRIPT_DENIED"] });
+		return { success: false, text, error: "TRANSCRIPT_FULL_SHARE_DENIED" };
+	}
+	if (!hasAdmin && !(await isOwnTranscript(rt, transcriptId, message))) {
+		logDenied("SHARE_TRANSCRIPT", "insufficient_role", {
+			transcriptId,
+			targetEntityId,
+			entityId: message.entityId,
+		});
+		const text = "You do not have permission to share that transcript.";
+		await callback?.({ text, actions: ["SHARE_TRANSCRIPT_DENIED"] });
+		return { success: false, text, error: "TRANSCRIPT_SHARE_DENIED" };
+	}
+
+	if (mode === "redacted") {
+		await new TranscriptStore(rt).createRedactedVariant({
+			originalId: transcriptId,
+			redactedBy: message.entityId as UUID,
+		});
+	}
+	await new TranscriptStore(rt).share({
+		transcriptId,
+		entityId: targetEntityId,
+		mode,
+		grantedBy: message.entityId as UUID,
+		grantedAtMs: Date.now(),
+	});
+	const text =
+		mode === "full"
+			? "Shared the full transcript."
+			: "Shared the redacted transcript.";
+	await callback?.({ text, actions: ["SHARE_TRANSCRIPT_SUCCESS"] });
+	return {
+		success: true,
+		text,
+		data: {
+			actionName: "SHARE_TRANSCRIPT",
+			transcriptId,
+			targetEntityId,
+			mode,
+		},
+	};
+}
+
+async function validate(
+	_runtime: IAgentRuntime,
+	message: Memory,
+): Promise<boolean> {
+	return typeof message.content.text === "string"
+		? message.content.text.trim().length > 0
+		: Boolean(message.content.transcriptId);
+}
+
+export const redactTranscriptAction: Action = {
+	name: "REDACT_TRANSCRIPT",
+	similes: ["TRANSCRIPT_REDACTION", "CREATE_REDACTED_TRANSCRIPT"],
+	description:
+		"Create a deterministic redacted variant for a stored transcript without mutating the original transcript or audio.",
+	routingHint:
+		"redact a stored meeting/voice transcript before sharing it -> REDACT_TRANSCRIPT",
+	roleGate: { minRole: "USER" },
+	validate,
+	handler: redactHandler,
+	parameters: [
+		{
+			name: "transcriptId",
+			description: "Stored transcript id to redact.",
+			required: true,
+			schema: { type: "string" as const },
+		},
+	],
+	examples: [],
+};
+
+export const shareTranscriptAction: Action = {
+	name: "SHARE_TRANSCRIPT",
+	similes: ["GRANT_TRANSCRIPT_ACCESS", "SHARE_REDACTED_TRANSCRIPT"],
+	description:
+		"Grant a person access to a transcript. USER can share their own redacted transcript; ADMIN can grant full access.",
+	routingHint:
+		"share a stored meeting/voice transcript with a person, redacted by default -> SHARE_TRANSCRIPT",
+	roleGate: { minRole: "USER" },
+	validate,
+	handler: shareHandler,
+	parameters: [
+		{
+			name: "transcriptId",
+			description: "Stored transcript id to share.",
+			required: true,
+			schema: { type: "string" as const },
+		},
+		{
+			name: "entityId",
+			description: "Target entity id receiving the grant.",
+			required: true,
+			schema: { type: "string" as const },
+		},
+		{
+			name: "mode",
+			description: "Grant mode: redacted or full. Defaults to redacted.",
+			required: false,
+			schema: {
+				type: "string" as const,
+				enum: ["redacted", "full"],
+				default: "redacted",
+			},
+		},
+	],
+	examples: [],
+};

--- a/plugins/plugin-local-inference/src/index.ts
+++ b/plugins/plugin-local-inference/src/index.ts
@@ -17,6 +17,10 @@ export {
 	identifySpeakerAction,
 } from "./actions/identify-speaker.js";
 export {
+	redactTranscriptAction,
+	shareTranscriptAction,
+} from "./actions/transcript-permissions.js";
+export {
 	emitVoiceControl,
 	startTranscriptionAction,
 	stopTranscriptionAction,

--- a/plugins/plugin-local-inference/src/provider.ts
+++ b/plugins/plugin-local-inference/src/provider.ts
@@ -39,6 +39,10 @@ import { generateMediaAction } from "./actions/generate-media.js";
 import { identifySpeakerAction } from "./actions/identify-speaker.js";
 import { localInferenceManagementAction } from "./actions/local-inference-management.js";
 import {
+	redactTranscriptAction,
+	shareTranscriptAction,
+} from "./actions/transcript-permissions.js";
+import {
 	startTranscriptionAction,
 	stopTranscriptionAction,
 } from "./actions/transcription-control.js";
@@ -1121,6 +1125,8 @@ export const localInferencePlugin: Plugin = {
 		identifySpeakerAction,
 		startTranscriptionAction,
 		stopTranscriptionAction,
+		redactTranscriptAction,
+		shareTranscriptAction,
 	],
 	events: {
 		// Round-trip half of the voice→entity binding: when the merge engine


### PR DESCRIPTION
## Summary

Adds deterministic transcript permission actions to `@elizaos/plugin-local-inference`:

- `REDACT_TRANSCRIPT` creates/refreshes the store-backed redacted variant without mutating the original transcript or audio.
- `SHARE_TRANSCRIPT` grants redacted access by default for the transcript owner and reserves full grants for ADMIN role holders.
- Registers and exports both actions from the local-inference plugin.

Part of #14779. This PR covers the deterministic action/write layer; the live-LLM trajectory and remaining end-to-end project evidence stay on #14779.

## Validation

- `bun run --cwd plugins/plugin-local-inference test src/actions/transcript-permissions.test.ts src/services/voice/transcript-store.test.ts` -> 2 files passed, 22 tests passed.
- `bun run --cwd plugins/plugin-local-inference typecheck` -> passed.
- `bunx @biomejs/biome check plugins/plugin-local-inference/src/actions/transcript-permissions.ts plugins/plugin-local-inference/src/actions/transcript-permissions.test.ts plugins/plugin-local-inference/src/provider.ts plugins/plugin-local-inference/src/index.ts` -> passed.
- `bun run --cwd plugins/plugin-local-inference build` -> passed.
- `git diff --check` -> passed.
- `bun run audit:error-policy-ratchet --report` -> passed; no new fallback-slop in touched files.

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots: `N/A - backend/plugin action registration only; no rendered UI surface changed`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots: `N/A - backend/plugin action registration only; no rendered UI surface changed`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: `N/A - no frontend/native interaction path changed in this slice`.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs: `N/A - deterministic action handlers were validated through Vitest and plugin build/typecheck; no server process was introduced for this backend-only slice`.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: `N/A - no frontend code or browser route changed`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: `N/A - this PR adds deterministic action handlers and store writes only; #14779 still tracks the live-model trajectory evidence for the full agent flow`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: `N/A - no external runtime artifact was produced; deterministic tests assert original transcript audio is retained, redacted variant audio is withheld, redacted/full share grants are written on transcript metadata, and denied attempts do not write grants`.