### PR TITLE
feat(transcripts): add permissioning agent actions

### DIFF
--- a/plugins/plugin-local-inference/src/actions/transcript-permissioning.test.ts
+++ b/plugins/plugin-local-inference/src/actions/transcript-permissioning.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Handler-level tests for transcript privacy actions. The fake runtime uses the
+ * real `TranscriptStore` against an in-memory memories partition so assertions
+ * cover the same metadata that route disclosure reads.
+ */
+
+import type { IAgentRuntime, Memory, UUID } from "@elizaos/core";
+import type { Transcript } from "@elizaos/shared/transcripts";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { localInferencePlugin } from "../provider";
+import {
+	TranscriptStore,
+	type TranscriptStoreRuntime,
+} from "../services/voice/transcript-store";
+import {
+	type RoleAccessCheck,
+	redactTranscriptAction,
+	resetTranscriptPermissioningRoleAccessForTests,
+	setTranscriptPermissioningRoleAccessForTests,
+	shareTranscriptAction,
+} from "./transcript-permissioning";
+
+const AGENT = "00000000-0000-0000-0000-0000000000aa" as UUID;
+const ROOM = "11111111-1111-1111-1111-111111111111" as UUID;
+const OWNER = "22222222-2222-2222-2222-222222222222" as UUID;
+const ADMIN = "33333333-3333-3333-3333-333333333333" as UUID;
+const VIEWER = "44444444-4444-4444-4444-444444444444" as UUID;
+const STRANGER = "55555555-5555-5555-5555-555555555555" as UUID;
+const TRANSCRIPT_ID = "66666666-6666-6666-6666-666666666666" as UUID;
+
+function makeTranscript(overrides: Partial<Transcript> = {}): Transcript {
+	return {
+		id: TRANSCRIPT_ID,
+		title: "Payroll sync",
+		createdAt: 1000,
+		durationMs: 2000,
+		audioUrl: "/api/media/original.wav",
+		audioContentType: "audio/wav",
+		source: "meeting",
+		scope: "owner-private",
+		status: "ready",
+		speakerCount: 1,
+		segments: [
+			{
+				id: "s1",
+				speakerLabel: "Alice",
+				startMs: 0,
+				endMs: 2000,
+				text: "Email bob@example.com and use SSN 123-45-6789.",
+				words: [{ text: "bob@example.com", startMs: 0, endMs: 500 }],
+			},
+		],
+		...overrides,
+	};
+}
+
+function fakeRuntime(): TranscriptStoreRuntime &
+	IAgentRuntime & {
+		rows: Map<string, Memory>;
+		reportError: ReturnType<typeof vi.fn>;
+	} {
+	const rows = new Map<string, Memory>();
+	const tables = new Map<string, string>();
+	const reportError = vi.fn();
+	return {
+		rows,
+		agentId: AGENT,
+		reportError,
+		getService: () => null,
+		async createMemory(memory, tableName) {
+			const id = memory.id as UUID;
+			rows.set(id, memory);
+			tables.set(id, tableName);
+			return id;
+		},
+		async getMemories({ tableName, roomId, orderDirection }) {
+			let out = [...rows.values()].filter(
+				(memory) => tables.get(memory.id as string) === tableName,
+			);
+			if (roomId) out = out.filter((memory) => memory.roomId === roomId);
+			out.sort((a, b) =>
+				orderDirection === "asc"
+					? (a.createdAt ?? 0) - (b.createdAt ?? 0)
+					: (b.createdAt ?? 0) - (a.createdAt ?? 0),
+			);
+			return out;
+		},
+		async getMemoryById(id) {
+			return rows.get(id) ?? null;
+		},
+		async updateMemory(memory) {
+			const existing = rows.get(memory.id);
+			if (!existing) return false;
+			rows.set(memory.id, { ...existing, ...memory });
+			return true;
+		},
+		async deleteMemory(id) {
+			rows.delete(id);
+		},
+	} as unknown as TranscriptStoreRuntime &
+		IAgentRuntime & {
+			rows: Map<string, Memory>;
+			reportError: ReturnType<typeof vi.fn>;
+		};
+}
+
+function message(entityId: UUID): Memory {
+	return {
+		id: "77777777-7777-7777-7777-777777777777" as UUID,
+		entityId,
+		roomId: ROOM,
+		agentId: AGENT,
+		content: { text: "share the transcript", source: "test" },
+	} as Memory;
+}
+
+async function seed(runtime: TranscriptStoreRuntime): Promise<TranscriptStore> {
+	const store = new TranscriptStore(runtime);
+	await store.create({
+		roomId: ROOM,
+		entityId: OWNER,
+		transcript: makeTranscript(),
+	});
+	return store;
+}
+
+function setRoles(check: RoleAccessCheck): void {
+	setTranscriptPermissioningRoleAccessForTests(check);
+}
+
+describe("transcript permission actions", () => {
+	afterEach(() => {
+		resetTranscriptPermissioningRoleAccessForTests();
+	});
+
+	it("registers redaction and share actions on the local-inference plugin", () => {
+		expect(localInferencePlugin.actions?.map((action) => action.name)).toEqual(
+			expect.arrayContaining(["REDACT_TRANSCRIPT", "SHARE_TRANSCRIPT"]),
+		);
+		expect(redactTranscriptAction.roleGate).toEqual({ minRole: "USER" });
+		expect(shareTranscriptAction.roleGate).toEqual({ minRole: "USER" });
+	});
+
+	it("creates a redacted variant before granting redacted transcript access", async () => {
+		const runtime = fakeRuntime();
+		const store = await seed(runtime);
+		setRoles(
+			async (_runtime, _message, role) => role === "USER" || role === "ADMIN",
+		);
+
+		const result = await shareTranscriptAction.handler(
+			runtime,
+			message(ADMIN),
+			undefined,
+			{
+				parameters: {
+					transcriptId: TRANSCRIPT_ID,
+					entityId: VIEWER,
+					mode: "redacted",
+				},
+			},
+		);
+
+		expect(result?.success).toBe(true);
+		expect(result?.data).toMatchObject({
+			actionName: "SHARE_TRANSCRIPT",
+			transcriptId: TRANSCRIPT_ID,
+			entityId: VIEWER,
+			mode: "redacted",
+		});
+		expect(result?.data?.variantId).toEqual(expect.any(String));
+
+		const viewerTranscript = await store.get(TRANSCRIPT_ID, {
+			requesterEntityId: VIEWER,
+			role: "USER",
+		});
+		expect(viewerTranscript?.id).toBe(TRANSCRIPT_ID);
+		expect(viewerTranscript?.redacted).toBe(true);
+		expect(viewerTranscript?.audioUrl).toBeUndefined();
+		expect(viewerTranscript?.segments[0]?.text).toContain("[EMAIL]");
+		expect(viewerTranscript?.segments[0]?.text).not.toContain(
+			"bob@example.com",
+		);
+
+		const adminTranscript = await store.get(TRANSCRIPT_ID, {
+			requesterEntityId: ADMIN,
+			role: "ADMIN",
+		});
+		expect(adminTranscript?.audioUrl).toBe("/api/media/original.wav");
+		expect(adminTranscript?.redacted).toBeUndefined();
+	});
+
+	it("lets a transcript owner create a redacted variant without changing the original", async () => {
+		const runtime = fakeRuntime();
+		const store = await seed(runtime);
+		setRoles(async (_runtime, _message, role) => role === "USER");
+
+		const result = await redactTranscriptAction.handler(
+			runtime,
+			message(OWNER),
+			undefined,
+			{ parameters: { transcriptId: TRANSCRIPT_ID } },
+		);
+
+		expect(result).toMatchObject({
+			success: true,
+			data: {
+				actionName: "REDACT_TRANSCRIPT",
+				transcriptId: TRANSCRIPT_ID,
+				redacted: true,
+				hasAudio: false,
+			},
+		});
+		expect(result?.data?.variantId).toEqual(expect.any(String));
+
+		const original = await store.get(TRANSCRIPT_ID, {
+			requesterEntityId: OWNER,
+			role: "USER",
+			isOwner: true,
+		});
+		expect(original?.audioUrl).toBe("/api/media/original.wav");
+		expect(original?.segments[0]?.text).toContain("bob@example.com");
+
+		const variantId = result?.data?.variantId as UUID;
+		const variant = await store.get(variantId, {
+			requesterEntityId: OWNER,
+			role: "USER",
+			isOwner: true,
+		});
+		expect(variant?.audioUrl).toBeUndefined();
+		expect(variant?.segments[0]?.text).toContain("[EMAIL]");
+	});
+
+	it("requires admin access for full transcript grants", async () => {
+		const runtime = fakeRuntime();
+		await seed(runtime);
+		setRoles(async (_runtime, _message, role) => role === "USER");
+
+		const result = await shareTranscriptAction.handler(
+			runtime,
+			message(OWNER),
+			undefined,
+			{
+				parameters: {
+					transcriptId: TRANSCRIPT_ID,
+					entityId: VIEWER,
+					mode: "full",
+				},
+			},
+		);
+
+		expect(result).toMatchObject({
+			success: false,
+			error: "SHARE_TRANSCRIPT_DENIED",
+		});
+		expect(runtime.reportError).toHaveBeenCalledWith(
+			"TranscriptPermissioningDenied",
+			expect.any(Error),
+			expect.objectContaining({
+				action: "SHARE_TRANSCRIPT",
+				transcriptId: TRANSCRIPT_ID,
+				entityId: VIEWER,
+				requesterEntityId: OWNER,
+			}),
+		);
+	});
+
+	it("audits role-allowed attempts to redact another user's transcript", async () => {
+		const runtime = fakeRuntime();
+		await seed(runtime);
+		setRoles(async (_runtime, _message, role) => role === "USER");
+
+		const result = await redactTranscriptAction.handler(
+			runtime,
+			message(STRANGER),
+			undefined,
+			{ parameters: { transcriptId: TRANSCRIPT_ID } },
+		);
+
+		expect(result).toMatchObject({
+			success: false,
+			error: "REDACT_TRANSCRIPT_DENIED",
+		});
+		expect(runtime.reportError).toHaveBeenCalledWith(
+			"TranscriptPermissioningDenied",
+			expect.any(Error),
+			expect.objectContaining({
+				action: "REDACT_TRANSCRIPT",
+				transcriptId: TRANSCRIPT_ID,
+				requesterEntityId: STRANGER,
+			}),
+		);
+		expect(runtime.rows.size).toBe(1);
+	});
+});

--- a/plugins/plugin-local-inference/src/actions/transcript-permissioning.ts
+++ b/plugins/plugin-local-inference/src/actions/transcript-permissioning.ts
@@ -1,0 +1,412 @@
+/**
+ * Agent actions for transcript privacy operations. Transcript bytes stay
+ * immutable: redaction creates a linked variant and sharing writes per-entity
+ * grants on the original row so routes can disclose full or redacted content
+ * through the existing artifact-disclosure predicate.
+ */
+
+import {
+	type AccessContext,
+	type Action,
+	type ActionResult,
+	type ArtifactShareGrantMode,
+	type HandlerCallback,
+	hasRoleAccess,
+	type IAgentRuntime,
+	logger,
+	type Memory,
+	type ProviderDataRecord,
+	type UUID,
+} from "@elizaos/core";
+import {
+	TranscriptStore,
+	type TranscriptStoreRuntime,
+} from "../services/voice/transcript-store.js";
+
+type RoleName = "USER" | "ADMIN";
+
+export type RoleAccessCheck = (
+	runtime: IAgentRuntime,
+	message: Memory,
+	requiredRole: RoleName,
+) => Promise<boolean>;
+
+let roleAccessCheck: RoleAccessCheck = (runtime, message, requiredRole) =>
+	hasRoleAccess(runtime, message, requiredRole);
+
+export function setTranscriptPermissioningRoleAccessForTests(
+	check: RoleAccessCheck,
+): void {
+	roleAccessCheck = check;
+}
+
+export function resetTranscriptPermissioningRoleAccessForTests(): void {
+	roleAccessCheck = (runtime, message, requiredRole) =>
+		hasRoleAccess(runtime, message, requiredRole);
+}
+
+interface HandlerOptions {
+	parameters?: Record<string, unknown>;
+}
+
+interface TranscriptPermissioningInput {
+	transcriptId: UUID;
+	entityId?: UUID;
+	mode?: ArtifactShareGrantMode;
+}
+
+function paramsFromOptions(options: unknown): Record<string, unknown> {
+	const maybe = options as HandlerOptions | undefined;
+	return maybe?.parameters && typeof maybe.parameters === "object"
+		? maybe.parameters
+		: {};
+}
+
+function nonEmptyString(value: unknown): string | null {
+	return typeof value === "string" && value.trim().length > 0
+		? value.trim()
+		: null;
+}
+
+function parseMode(value: unknown): ArtifactShareGrantMode | null {
+	return value === "full" || value === "redacted" ? value : null;
+}
+
+function parseInput(
+	parameters: Record<string, unknown>,
+	options: { requireEntity: boolean; defaultMode?: ArtifactShareGrantMode },
+): TranscriptPermissioningInput | null {
+	const transcriptId = nonEmptyString(parameters.transcriptId);
+	if (!transcriptId) return null;
+	const entityId = nonEmptyString(parameters.entityId);
+	if (options.requireEntity && !entityId) return null;
+	const mode = parseMode(parameters.mode) ?? options.defaultMode;
+	if (parameters.mode !== undefined && !parseMode(parameters.mode)) return null;
+	return {
+		transcriptId: transcriptId as UUID,
+		...(entityId ? { entityId: entityId as UUID } : {}),
+		...(mode ? { mode } : {}),
+	};
+}
+
+function transcriptStore(runtime: IAgentRuntime): TranscriptStore {
+	return new TranscriptStore(runtime as TranscriptStoreRuntime);
+}
+
+async function canManageTranscript(
+	runtime: IAgentRuntime,
+	message: Memory,
+	transcriptId: UUID,
+): Promise<boolean> {
+	if (await roleAccessCheck(runtime, message, "ADMIN")) return true;
+	if (!(await roleAccessCheck(runtime, message, "USER"))) return false;
+	const row = await (runtime as TranscriptStoreRuntime).getMemoryById(
+		transcriptId,
+	);
+	return row?.entityId === message.entityId;
+}
+
+async function accessContextForMessage(
+	runtime: IAgentRuntime,
+	message: Memory,
+	transcriptId: UUID,
+): Promise<AccessContext | undefined> {
+	if (typeof message.entityId !== "string" || message.entityId.length === 0) {
+		return undefined;
+	}
+	const isAdmin = await roleAccessCheck(runtime, message, "ADMIN");
+	const row = await (runtime as TranscriptStoreRuntime).getMemoryById(
+		transcriptId,
+	);
+	return {
+		requesterEntityId: message.entityId as UUID,
+		...(typeof message.worldId === "string"
+			? { worldId: message.worldId as UUID }
+			: {}),
+		role: isAdmin ? "ADMIN" : "USER",
+		isOwner: row?.entityId === message.entityId,
+		...(typeof message.content?.source === "string"
+			? { source: message.content.source }
+			: {}),
+	};
+}
+
+function fail(error: string, text: string): ActionResult {
+	return { success: false, error, text, data: { error } };
+}
+
+function ok(text: string, data: ProviderDataRecord): ActionResult {
+	return {
+		success: true,
+		text,
+		userFacingText: text,
+		verifiedUserFacing: true,
+		data,
+	};
+}
+
+function auditDenied(
+	runtime: IAgentRuntime,
+	action: string,
+	message: Memory,
+	input: TranscriptPermissioningInput | null,
+): void {
+	const error = new Error(`${action} denied`);
+	runtime.reportError("TranscriptPermissioningDenied", error, {
+		action,
+		transcriptId: input?.transcriptId,
+		entityId: input?.entityId,
+		requesterEntityId: message.entityId,
+	});
+	logger.warn(
+		{
+			action,
+			transcriptId: input?.transcriptId,
+			entityId: input?.entityId,
+			requesterEntityId: message.entityId,
+		},
+		"[transcript-permissioning] denied transcript privacy action",
+	);
+}
+
+async function requireFullTranscript(
+	store: TranscriptStore,
+	transcriptId: UUID,
+	accessContext: AccessContext | undefined,
+): Promise<ActionResult | null> {
+	const transcript = await store.get(transcriptId, accessContext);
+	if (!transcript) {
+		return fail(
+			"TRANSCRIPT_NOT_ACCESSIBLE",
+			"Transcript not found or not accessible.",
+		);
+	}
+	if (transcript.redacted) {
+		return fail(
+			"TRANSCRIPT_REDACTED_VIEW",
+			"Only a full transcript can be redacted or shared.",
+		);
+	}
+	return null;
+}
+
+export const redactTranscriptAction: Action = {
+	name: "REDACT_TRANSCRIPT",
+	similes: [
+		"REDACT_MEETING_TRANSCRIPT",
+		"CREATE_REDACTED_TRANSCRIPT",
+		"ANONYMIZE_TRANSCRIPT",
+	],
+	description:
+		"Create or refresh the redacted variant for a stored meeting transcript. The original transcript and audio remain unchanged, and the variant withholds audio.",
+	routingHint:
+		"user asks to redact/anonymize a meeting transcript -> REDACT_TRANSCRIPT; do not edit the original transcript text",
+	roleGate: { minRole: "USER" },
+	parameters: [
+		{
+			name: "transcriptId",
+			description: "Stored transcript id to redact.",
+			required: true,
+			schema: { type: "string" as const },
+		},
+	],
+	validate: async () => true,
+	handler: async (
+		runtime: IAgentRuntime,
+		message: Memory,
+		_state?: unknown,
+		options?: unknown,
+		callback?: HandlerCallback,
+	): Promise<ActionResult> => {
+		const input = parseInput(paramsFromOptions(options), {
+			requireEntity: false,
+		});
+		if (!input) {
+			const result = fail(
+				"REDACT_TRANSCRIPT_INVALID",
+				"REDACT_TRANSCRIPT requires transcriptId.",
+			);
+			await callback?.({ text: result.text, actions: ["REDACT_TRANSCRIPT"] });
+			return result;
+		}
+		if (!(await canManageTranscript(runtime, message, input.transcriptId))) {
+			auditDenied(runtime, "REDACT_TRANSCRIPT", message, input);
+			const result = fail(
+				"REDACT_TRANSCRIPT_DENIED",
+				"You do not have permission to redact that transcript.",
+			);
+			await callback?.({ text: result.text, actions: ["REDACT_TRANSCRIPT"] });
+			return result;
+		}
+
+		try {
+			const store = transcriptStore(runtime);
+			const accessContext = await accessContextForMessage(
+				runtime,
+				message,
+				input.transcriptId,
+			);
+			const denied = await requireFullTranscript(
+				store,
+				input.transcriptId,
+				accessContext,
+			);
+			if (denied) {
+				auditDenied(runtime, "REDACT_TRANSCRIPT", message, input);
+				await callback?.({ text: denied.text, actions: ["REDACT_TRANSCRIPT"] });
+				return denied;
+			}
+			const variant = await store.createRedactedVariant({
+				originalId: input.transcriptId,
+				redactedBy: message.entityId as UUID,
+			});
+			const result = ok("Redacted transcript variant is ready.", {
+				actionName: "REDACT_TRANSCRIPT",
+				transcriptId: input.transcriptId,
+				variantId: variant.id,
+				redacted: true,
+				hasAudio: false,
+			});
+			await callback?.({ text: result.text, actions: ["REDACT_TRANSCRIPT"] });
+			return result;
+		} catch (error) {
+			const messageText =
+				error instanceof Error ? error.message : String(error);
+			const result = fail("REDACT_TRANSCRIPT_FAILED", messageText);
+			await callback?.({ text: result.text, actions: ["REDACT_TRANSCRIPT"] });
+			return result;
+		}
+	},
+	examples: [],
+};
+
+export const shareTranscriptAction: Action = {
+	name: "SHARE_TRANSCRIPT",
+	similes: [
+		"SHARE_MEETING_TRANSCRIPT",
+		"GRANT_TRANSCRIPT_ACCESS",
+		"DISCLOSE_TRANSCRIPT",
+	],
+	description:
+		"Share a stored transcript with one entity as full or redacted content. Redacted sharing creates the linked redacted variant first; full sharing requires admin access.",
+	routingHint:
+		"user asks to share a meeting transcript -> SHARE_TRANSCRIPT with entityId and mode full|redacted; admin redacted-for-all uses redacted mode for non-privileged grants",
+	roleGate: { minRole: "USER" },
+	parameters: [
+		{
+			name: "transcriptId",
+			description: "Stored original transcript id to share.",
+			required: true,
+			schema: { type: "string" as const },
+		},
+		{
+			name: "entityId",
+			description: "Entity id receiving the transcript grant.",
+			required: true,
+			schema: { type: "string" as const },
+		},
+		{
+			name: "mode",
+			description:
+				"Disclosure mode. Use redacted for ordinary participants; full requires admin access.",
+			required: false,
+			schema: {
+				type: "string" as const,
+				enum: ["redacted", "full"],
+				default: "redacted",
+			},
+		},
+	],
+	validate: async () => true,
+	handler: async (
+		runtime: IAgentRuntime,
+		message: Memory,
+		_state?: unknown,
+		options?: unknown,
+		callback?: HandlerCallback,
+	): Promise<ActionResult> => {
+		const input = parseInput(paramsFromOptions(options), {
+			requireEntity: true,
+			defaultMode: "redacted",
+		});
+		if (!input?.entityId || !input.mode) {
+			const result = fail(
+				"SHARE_TRANSCRIPT_INVALID",
+				"SHARE_TRANSCRIPT requires transcriptId, entityId, and mode full or redacted.",
+			);
+			await callback?.({ text: result.text, actions: ["SHARE_TRANSCRIPT"] });
+			return result;
+		}
+
+		const canShare =
+			input.mode === "full"
+				? await roleAccessCheck(runtime, message, "ADMIN")
+				: await canManageTranscript(runtime, message, input.transcriptId);
+		if (!canShare) {
+			auditDenied(runtime, "SHARE_TRANSCRIPT", message, input);
+			const result = fail(
+				"SHARE_TRANSCRIPT_DENIED",
+				input.mode === "full"
+					? "Only an admin can share the full transcript."
+					: "You do not have permission to share that transcript.",
+			);
+			await callback?.({ text: result.text, actions: ["SHARE_TRANSCRIPT"] });
+			return result;
+		}
+
+		try {
+			let variantId: string | undefined;
+			const store = transcriptStore(runtime);
+			const accessContext = await accessContextForMessage(
+				runtime,
+				message,
+				input.transcriptId,
+			);
+			const denied = await requireFullTranscript(
+				store,
+				input.transcriptId,
+				accessContext,
+			);
+			if (denied) {
+				auditDenied(runtime, "SHARE_TRANSCRIPT", message, input);
+				await callback?.({ text: denied.text, actions: ["SHARE_TRANSCRIPT"] });
+				return denied;
+			}
+			if (input.mode === "redacted") {
+				const variant = await store.createRedactedVariant({
+					originalId: input.transcriptId,
+					redactedBy: message.entityId as UUID,
+				});
+				variantId = variant.id;
+			}
+			await store.share({
+				transcriptId: input.transcriptId,
+				entityId: input.entityId,
+				mode: input.mode,
+				grantedBy: message.entityId as UUID,
+				grantedAtMs: Date.now(),
+			});
+			const result = ok(
+				input.mode === "full"
+					? "Shared the full transcript."
+					: "Shared the redacted transcript.",
+				{
+					actionName: "SHARE_TRANSCRIPT",
+					transcriptId: input.transcriptId,
+					entityId: input.entityId,
+					mode: input.mode,
+					...(variantId ? { variantId } : {}),
+				},
+			);
+			await callback?.({ text: result.text, actions: ["SHARE_TRANSCRIPT"] });
+			return result;
+		} catch (error) {
+			const messageText =
+				error instanceof Error ? error.message : String(error);
+			const result = fail("SHARE_TRANSCRIPT_FAILED", messageText);
+			await callback?.({ text: result.text, actions: ["SHARE_TRANSCRIPT"] });
+			return result;
+		}
+	},
+	examples: [],
+};

--- a/plugins/plugin-local-inference/src/index.ts
+++ b/plugins/plugin-local-inference/src/index.ts
@@ -17,6 +17,13 @@ export {
 	identifySpeakerAction,
 } from "./actions/identify-speaker.js";
 export {
+	type RoleAccessCheck,
+	redactTranscriptAction,
+	resetTranscriptPermissioningRoleAccessForTests,
+	setTranscriptPermissioningRoleAccessForTests,
+	shareTranscriptAction,
+} from "./actions/transcript-permissioning.js";
+export {
 	emitVoiceControl,
 	startTranscriptionAction,
 	stopTranscriptionAction,

--- a/plugins/plugin-local-inference/src/provider.ts
+++ b/plugins/plugin-local-inference/src/provider.ts
@@ -39,6 +39,10 @@ import { generateMediaAction } from "./actions/generate-media.js";
 import { identifySpeakerAction } from "./actions/identify-speaker.js";
 import { localInferenceManagementAction } from "./actions/local-inference-management.js";
 import {
+	redactTranscriptAction,
+	shareTranscriptAction,
+} from "./actions/transcript-permissioning.js";
+import {
 	startTranscriptionAction,
 	stopTranscriptionAction,
 } from "./actions/transcription-control.js";
@@ -1119,6 +1123,8 @@ export const localInferencePlugin: Plugin = {
 		localInferenceManagementAction,
 		generateMediaAction,
 		identifySpeakerAction,
+		redactTranscriptAction,
+		shareTranscriptAction,
 		startTranscriptionAction,
 		stopTranscriptionAction,
 	],


### PR DESCRIPTION
## Summary

Part of #14779. This wires the agent-action layer on top of the merged transcript store primitives:

- registers `REDACT_TRANSCRIPT` and `SHARE_TRANSCRIPT` on the local-inference plugin;
- creates linked redacted variants before redacted transcript grants;
- requires ADMIN for full transcript grants;
- allows USER only when the requester owns the transcript row, and otherwise denies/audit-logs attempts;
- verifies redacted USER readback vs ADMIN full readback through the real `TranscriptStore` disclosure path.

This still does not claim the full #14779 acceptance bar because live-LLM trajectory evidence is not available in this shell.

## Verification

```bash
bun run --cwd plugins/plugin-local-inference test src/actions/transcript-permissioning.test.ts src/services/voice/transcript-store.test.ts
# 2 files passed, 21 tests passed

bun run --cwd plugins/plugin-local-inference typecheck
# pass

bunx @biomejs/biome check plugins/plugin-local-inference/src/actions/transcript-permissioning.ts plugins/plugin-local-inference/src/actions/transcript-permissioning.test.ts plugins/plugin-local-inference/src/provider.ts plugins/plugin-local-inference/src/index.ts
# pass

git diff --check origin/develop...HEAD && git diff --check
# pass

bun run audit:error-policy-ratchet --report
# pass; no new fallback-slop
```

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend/plugin action registration only; no UI surface changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend/plugin action registration only; no UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing UI flow is changed in this slice.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no HTTP server path is invoked; focused action tests exercise the runtime handler and memory-store behavior directly.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - live provider credentials are not available in this shell. #14779 remains open for live-LLM meeting transcript -> share redacted USER/full ADMIN trajectory evidence.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no external domain artifact is persisted by the test harness; in-memory transcript rows are asserted directly in `transcript-permissioning.test.ts` and `transcript-store.test.ts`.