### PR TITLE
fix(cloud-apps): keep deploy fact metadata typed

### DIFF
--- a/plugins/plugin-cloud-apps/src/app-facts.ts
+++ b/plugins/plugin-cloud-apps/src/app-facts.ts
@@ -101,7 +101,7 @@ export async function recordAppDeployFact(
     kind: "durable" as const,
     confidence: 1,
     deployedAt: new Date().toISOString(),
-  };
+  } satisfies Memory["metadata"];
 
   try {
     const existing = await findExistingDeployFact(runtime, message, app.id);
@@ -109,10 +109,7 @@ export async function recordAppDeployFact(
       await runtime.updateMemory({
         id: existing.id,
         content: { text, type: "fact" },
-        metadata: {
-          ...(existing.metadata ?? {}),
-          ...metadata,
-        } as Memory["metadata"],
+        metadata,
       });
       return { written: true, updated: true, memoryId: existing.id };
     }


### PR DESCRIPTION
## Summary

Fixes the repo-level typecheck failure surfaced while validating #15597. `recordAppDeployFact()` now updates the durable deploy fact with the typed custom fact metadata only, instead of spreading arbitrary existing memory metadata back into a `type: custom` memory.

That avoids pulling message-only metadata shapes like `sender` into `CustomMetadata`, which fails against the tightened core metadata type.

## Verification

```bash
bun run install:light
node packages/shared/scripts/generate-keywords.mjs --target ts
bunx @biomejs/biome check --write plugins/plugin-cloud-apps/src/app-facts.ts
# pass

bun run --cwd packages/cloud/api typecheck
# pass, including wrangler production dry run

git diff --check
# pass

bun run audit:error-policy-ratchet --report
# pass; no new fallback-slop

bun test plugins/plugin-cloud-apps/__tests__/app-facts.test.ts
# not run to completion locally: Bun test cannot resolve @elizaos/core from plugin-cloud-apps before app-facts assertions execute, despite workspace symlinks existing.
```

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] N/A - type-only server/plugin metadata boundary fix; no UI changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - type-only server/plugin metadata boundary fix; no UI changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no runtime route executed; `packages/cloud/api` typecheck and Worker dry run exercise the failing compile boundary.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model/action/provider/prompt behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifact: [`app-facts.ts`](https://github.com/elizaOS/eliza/blob/fix/cloud-apps-deploy-fact-metadata/plugins/plugin-cloud-apps/src/app-facts.ts), with local `packages/cloud/api typecheck` proving the deploy-fact metadata boundary against the tightened core metadata type.