### PR TITLE
fix(cloud-apps): replace deploy fact metadata on update

### DIFF
--- a/plugins/plugin-cloud-apps/src/app-facts.ts
+++ b/plugins/plugin-cloud-apps/src/app-facts.ts
@@ -109,10 +109,7 @@ export async function recordAppDeployFact(
       await runtime.updateMemory({
         id: existing.id,
         content: { text, type: "fact" },
-        metadata: {
-          ...(existing.metadata ?? {}),
-          ...metadata,
-        } as Memory["metadata"],
+        metadata,
       });
       return { written: true, updated: true, memoryId: existing.id };
     }


### PR DESCRIPTION
## Summary
- replace existing deploy-fact metadata instead of merging arbitrary previous memory metadata
- keep the durable cloud app deploy fact on its controlled custom metadata shape
- unblock the cloud API typecheck failure seen on #15602 when existing memory metadata can include structured message-only fields like `sender`

## Verification
- `node packages/shared/scripts/generate-keywords.mjs --target ts`
- `bun run --cwd packages/cloud/api typecheck` completed through `wrangler deploy --env production --dry-run --outdir .wrangler-dry-run`
- `bunx biome check plugins/plugin-cloud-apps/src/app-facts.ts`
- `git diff --check`
- `bun run audit:error-policy-ratchet --report`

## Evidence
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots: `N/A - non-UI typecheck repair only; no rendered surface changed`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots: `N/A - non-UI typecheck repair only; no rendered surface changed`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: `N/A - no user-facing flow changed`.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs: `N/A - no runtime backend path changed; verification is compile-time`.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: `N/A - no frontend code changed`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: `N/A - no action, prompt, model, or planner behavior changed`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: [`plugins/plugin-cloud-apps/src/app-facts.ts`](https://github.com/elizaOS/eliza/blob/fix/cloud-app-facts-memory-metadata/plugins/plugin-cloud-apps/src/app-facts.ts) plus `bun run --cwd packages/cloud/api typecheck` prove the changed metadata shape compiles through the affected cloud API lane.