### PR TITLE
feat(ci): real chat turn in nightly hetzner-e2e (#15603)

### DIFF
--- a/.github/workflows/hetzner-e2e.yml
+++ b/.github/workflows/hetzner-e2e.yml
@@ -2,8 +2,9 @@ name: Hetzner Agent E2E
 
 # Nightly end-to-end smoke that provisions a fresh Hetzner cpx11 server,
 # waits for cloud-init, deploys a trivial agent via the Eliza Cloud
-# staging API, runs a single bridge-ping healthcheck, then tears
-# everything down. Gracefully skips when the required secrets are
+# staging API, runs a bridge-ping healthcheck plus one REAL chat turn
+# (message.send through the production bridge path — #15603 A3), then
+# tears everything down. Gracefully skips when the required secrets are
 # unset (so this workflow can land on develop and be activated later).
 #
 # Required secrets / config (GitHub environment: ci-hetzner-e2e):
@@ -348,6 +349,14 @@ jobs:
       - name: Healthcheck
         if: steps.provision.outputs.provisioned == 'true'
         run: bun run packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-healthcheck.ts
+
+      # A real user-message round-trip through the same Worker bridge path a
+      # production chat takes. status.get alone lets "provisioned but chat
+      # dead-ends" regressions (#15347) pass the nightly. Failure here fails
+      # the deploy job; the teardown job runs regardless (needs+always()).
+      - name: Chat turn
+        if: steps.provision.outputs.provisioned == 'true'
+        run: bun run packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-chat.ts
 
       - name: Upload state artifact
         if: always() && steps.provision.outputs.provisioned == 'true'

--- a/packages/scripts/cloud/admin/hetzner-e2e/README.md
+++ b/packages/scripts/cloud/admin/hetzner-e2e/README.md
@@ -1,10 +1,12 @@
 # Hetzner Agent E2E
 
 Nightly end-to-end smoke that provisions a real Hetzner cpx11 server,
-deploys a trivial agent via the Eliza Cloud staging API, runs a single
-bridge-ping healthcheck, and tears everything down. A reaper workflow
-sweeps any servers older than 60 minutes every half hour as a safety
-net.
+deploys a trivial agent via the Eliza Cloud staging API, runs a
+bridge-ping healthcheck plus one real chat turn (a `message.send`
+JSON-RPC through the production Worker bridge path, requiring a
+non-fallback assistant reply), and tears everything down. A reaper
+workflow sweeps any servers older than 60 minutes every half hour as a
+safety net.
 
 The workflow gracefully skips when secrets are unset, so it can land
 on `develop` and be activated later by adding secrets. Once secrets
@@ -74,6 +76,9 @@ intend to create a real billable server.
 - `hetzner-e2e-wait-ready.ts` — SSH-poll for cloud-init + Docker
 - `hetzner-e2e-deploy-agent.ts` — create + provision a trivial agent
 - `hetzner-e2e-healthcheck.ts` — single `status.get` bridge ping
+- `hetzner-e2e-chat.ts` — one real `message.send` chat turn; fails on
+  empty or bridge-fabricated (`fallback: true`) replies so "provisioned
+  but chat dead-ends" regressions (#15347) go red
 - `hetzner-e2e-teardown.ts` — delete the server (idempotent, falls
   back to label sweep if state artifact missing)
 - `hetzner-e2e-reaper.ts` — list+delete servers older than 60min

--- a/packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-chat.ts
+++ b/packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-chat.ts
@@ -1,0 +1,193 @@
+#!/usr/bin/env bun
+/**
+ * One real chat turn against the deployed E2E agent, through the production
+ * message path: the cloud Worker's bridge route (`POST
+ * /api/v1/eliza/agents/{agentId}/bridge`, JSON-RPC `message.send`) forwards to
+ * the sandbox bridge, which reaches the agent runtime on the Hetzner box over
+ * the tailnet. The `status.get` healthcheck alone lets "agent provisioned but
+ * chat dead-ends" regressions (#15347) pass the nightly — this step closes
+ * that gap by requiring an actual assistant reply. Exit 0 = the agent replied.
+ *
+ * The bridge fabricates `result.text` with `fallback: true` /
+ * `reason: "agent_no_reply"` when the runtime is reachable but produced no
+ * reply — exactly the dead-end this step exists to catch — so a fallback
+ * reply is treated as a failure, never a pass. Attempts retry until
+ * HETZNER_E2E_CHAT_TIMEOUT_MS (default 240s) to absorb a cold model path
+ * right after provisioning.
+ */
+
+import { randomBytes } from "node:crypto";
+import { readState } from "./state-file";
+
+const DEFAULT_BASE_URL = "https://api-staging.elizacloud.ai";
+const DEFAULT_TIMEOUT_MS = 240_000;
+const RETRY_DELAY_MS = 5_000;
+// Per-attempt cap: the Worker's bridge tries up to three inner transports at
+// 60-120s each, so a single POST can legitimately take minutes.
+const ATTEMPT_TIMEOUT_MS = 130_000;
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`[hetzner-e2e-chat] missing env: ${name}`);
+    process.exit(1);
+  }
+  return value;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+interface BridgeChatEnvelope {
+  result?: {
+    text?: unknown;
+    fallback?: unknown;
+    reason?: unknown;
+    agentName?: unknown;
+    conversationId?: unknown;
+  };
+  error?: { code?: number; message?: string };
+}
+
+async function sendChatTurn(
+  baseUrl: string,
+  apiKey: string,
+  agentId: string,
+  prompt: string,
+  roomId: string,
+): Promise<string> {
+  const response = await fetch(
+    `${baseUrl}/api/v1/eliza/agents/${agentId}/bridge`,
+    {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        "content-type": "application/json",
+        accept: "application/json",
+        "user-agent": "hetzner-e2e/1.0",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: `chat-${Date.now()}`,
+        method: "message.send",
+        params: {
+          text: prompt,
+          roomId,
+          userId: `${roomId}-user`,
+          source: "hetzner-e2e",
+          mode: "simple",
+        },
+      }),
+      signal: AbortSignal.timeout(ATTEMPT_TIMEOUT_MS),
+    },
+  );
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`Chat HTTP ${response.status}: ${text.slice(0, 300)}`);
+  }
+  const body = JSON.parse(text) as BridgeChatEnvelope;
+  if (body.error) {
+    throw new Error(
+      `Chat JSON-RPC error: ${JSON.stringify(body.error).slice(0, 300)}`,
+    );
+  }
+  const result = body.result;
+  if (!result || typeof result !== "object") {
+    throw new Error(`Chat response missing result: ${text.slice(0, 300)}`);
+  }
+  if (result.fallback === true) {
+    throw new Error(
+      `Bridge returned fabricated fallback text (reason: ${String(
+        result.reason ?? "unknown",
+      )}) — the agent produced no real reply`,
+    );
+  }
+  const reply = typeof result.text === "string" ? result.text.trim() : "";
+  if (!reply) {
+    throw new Error(
+      `Bridge reply was empty: ${JSON.stringify(result).slice(0, 300)}`,
+    );
+  }
+  return reply;
+}
+
+async function main(): Promise<void> {
+  const apiKey = requireEnv("CLOUD_E2E_API_KEY");
+  const baseUrl = (
+    process.env.CLOUD_SMOKE_BASE_URL ?? DEFAULT_BASE_URL
+  ).replace(/\/+$/, "");
+  const timeoutMs = Number.parseInt(
+    process.env.HETZNER_E2E_CHAT_TIMEOUT_MS ?? String(DEFAULT_TIMEOUT_MS),
+    10,
+  );
+
+  const state = readState();
+  const agentId = state.agent_id;
+  if (!agentId) {
+    throw new Error(
+      "state file missing agent_id; deploy-agent step must run first",
+    );
+  }
+
+  const runId =
+    state.run_id ??
+    `${Date.now().toString(36)}${randomBytes(3).toString("hex")}`;
+  const roomId = `hetzner-e2e-chat-${runId}`;
+  // A per-run token proves the reply is a live model round-trip of THIS
+  // message, not a canned string. Phrased without quotes so it cannot match
+  // the bridge's fallback-text extraction patterns.
+  const token = `hetzner-pong-${runId}`;
+  const prompt =
+    `You are part of an automated end-to-end test. ` +
+    `Reply with one short sentence that contains the token ${token}.`;
+
+  console.log(
+    `[hetzner-e2e-chat] sending chat turn to agent ${agentId} (room ${roomId}, timeout ${timeoutMs}ms)`,
+  );
+
+  const deadline = Date.now() + timeoutMs;
+  let attempt = 0;
+  let lastFailure = "no attempt completed";
+  while (Date.now() < deadline) {
+    attempt += 1;
+    try {
+      const reply = await sendChatTurn(
+        baseUrl,
+        apiKey,
+        agentId,
+        prompt,
+        roomId,
+      );
+      const echoedToken = reply.includes(token);
+      console.log(
+        `[hetzner-e2e-chat] agent replied on attempt ${attempt} ` +
+          `(${reply.length} chars, token echoed: ${echoedToken}): ${reply.slice(0, 300)}`,
+      );
+      if (!echoedToken) {
+        // A live model occasionally paraphrases; a real non-fallback reply
+        // still proves the chat path. Surface the miss for the run log.
+        console.log(
+          `::warning::[hetzner-e2e-chat] reply did not echo token ${token} — real reply accepted, but inspect the run if this recurs.`,
+        );
+      }
+      return;
+    } catch (error) {
+      // error-policy:J1 retry boundary — each failed attempt is logged and the
+      // loop fails loudly at the deadline with the last observed failure.
+      lastFailure = error instanceof Error ? error.message : String(error);
+      console.log(
+        `[hetzner-e2e-chat] attempt ${attempt} failed: ${lastFailure}`,
+      );
+    }
+    if (Date.now() + RETRY_DELAY_MS >= deadline) break;
+    await sleep(RETRY_DELAY_MS);
+  }
+
+  throw new Error(
+    `Agent ${agentId} never produced a real chat reply within ${timeoutMs}ms ` +
+      `(${attempt} attempt${attempt === 1 ? "" : "s"}). Last failure: ${lastFailure}`,
+  );
+}
+
+await main();


### PR DESCRIPTION
Work item **A3** of epic #15603.

## Problem

The nightly real-infra e2e (`.github/workflows/hetzner-e2e.yml`) provisions a real Hetzner box, deploys a trivial agent via the staging Cloud API, then healthchecks it with **one** bridge JSON-RPC `status.get` and tears down. It never exercises a chat turn — so "agent provisioned but chat dead-ends" regressions (exactly the #15347 class) pass the nightly green.

## Change

- **New `packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-chat.ts`** — sends one real user message to the deployed agent and requires a genuine assistant reply:
  - **Transport is the production user path, not a fake:** `POST /api/v1/eliza/agents/{agentId}/bridge` (staging Worker) with JSON-RPC `message.send { text, roomId, userId, mode: "simple" }` → `elizaSandboxService.bridge()` → `ElizaSandboxBridgeService.bridgeMessageSend()` → the agent runtime on the Hetzner box over the tailnet (conversation REST adapter, with the bridge's own OpenAI-compat / central-channel fallbacks). Same route + service chain the cloud client uses for a user chat message to a dedicated agent (`packages/cloud/api/v1/eliza/agents/[agentId]/bridge/route.ts`, `packages/cloud/shared/src/lib/services/eliza-sandbox-bridge.ts`).
  - **Fabricated replies are a failure, not a pass.** The bridge fabricates `result.text` with `fallback: true` / `reason: "agent_no_reply"` when the runtime is reachable but produced no reply — the exact dead-end this step exists to catch. The script rejects `fallback: true` and empty text explicitly. (Note: the existing `live-cloud-provision-smoke.ts` assertion would accept that fabricated fallback, because its "exact words:" prompt matches the bridge's fallback-text extraction; this script's prompt deliberately avoids those patterns and checks the flag.)
  - **Model/reply strategy:** the deployed trivial agent runs `@elizaos/plugin-sql` + `@elizaos/plugin-elizacloud` (`smoke-agent-plugins.ts`). plugin-elizacloud registers the TEXT_* chat-brain handlers routed through Eliza Cloud inference (`/responses`) with cloud credentials injected at provisioning — so the reply is a **real live-model turn**, no per-agent provider key needed and no deterministic/echo stub. The prompt carries a per-run token (`hetzner-pong-<runId>`); token echo is logged (warn-only, since a live model may paraphrase) while the hard pass condition is a non-empty, non-fallback reply.
  - Retries until `HETZNER_E2E_CHAT_TIMEOUT_MS` (default 240 s, per-attempt 130 s cap matching the Worker bridge's inner-transport budget) to absorb a cold model path right after provisioning, then fails loudly with the last observed failure.
- **`.github/workflows/hetzner-e2e.yml`** — new `Chat turn` step between `Healthcheck` and `Upload state artifact`, gated by the same `steps.provision.outputs.provisioned == 'true'` condition, so the honest-skip secret gating is preserved. Teardown is a separate job with `needs: deploy` + `if: always()`, so it still runs when the chat step fails; the state artifact upload also stays `always()`.
- **README** updated (files list + description).

## What I could not verify from here — and how the reviewer proves it

I cannot provision real Hetzner capacity or reach the staging bridge from this environment (no `HCLOUD_TOKEN_CI` / `CLOUD_E2E_API_KEY`). **The proof is the next scheduled/dispatched run.** Two paths:

1. Merging this PR auto-triggers the workflow — its `push` trigger watches `develop` for `.github/workflows/hetzner-e2e.yml` and `packages/scripts/cloud/admin/hetzner-e2e/**`, both touched here.
2. Manual dispatch after merge: `gh workflow run hetzner-e2e.yml` (dispatch is strict: missing secrets fail instead of skipping). Look for the `Chat turn` step log: `[hetzner-e2e-chat] agent replied on attempt N (… chars, token echoed: …)`.

## Local verification (evidence)

Typecheck (`tsc --noEmit`, strict) — clean. `biome check` — clean (the one `noUndeclaredEnvVars` warning class matches the pre-existing baseline on the sibling `hetzner-e2e-healthcheck.ts`). `actionlint` on the workflow — clean. `bun run audit:error-policy-ratchet` — `no new fallback-slop in touched files`. Workflow YAML parsed; deploy step order confirmed: `… Healthcheck → Chat turn → Upload state artifact`.

Dry-run of arg/env parsing and the full request/response handling against a local stand-in bridge endpoint (verification of the script's logic only — the workflow run uses the real transport):

<details>
<summary>Script output — env/state guards + success/fallback/rpc-error/empty modes</summary>

```
=== 1. missing env ===
[hetzner-e2e-chat] missing env: CLOUD_E2E_API_KEY
exit: 1

=== 2. env set, no state file ===
error: state file missing agent_id; deploy-agent step must run first
exit: 1

=== mode=success ===
[hetzner-e2e-chat] sending chat turn to agent 0f9f9d2e-1111-4222-a333-444455556666 (room hetzner-e2e-chat-dryrun01abc, timeout 240000ms)
[hetzner-e2e-chat] agent replied on attempt 1 (78 chars, token echoed: true): Hello from the mock agent — hetzner-pong-dryrun01abc. received loud and clear.
exit: 0

=== mode=fallback ===
[hetzner-e2e-chat] attempt 1 failed: Bridge returned fabricated fallback text (reason: agent_no_reply) — the agent produced no real reply
[hetzner-e2e-chat] attempt 2 failed: Bridge returned fabricated fallback text (reason: agent_no_reply) — the agent produced no real reply
error: Agent 0f9f9d2e-… never produced a real chat reply within 8000ms (2 attempts). Last failure: Bridge returned fabricated fallback text (reason: agent_no_reply) — the agent produced no real reply
exit: 1

=== mode=rpc-error ===
[hetzner-e2e-chat] attempt 1 failed: Chat JSON-RPC error: {"code":-32000,"message":"Sandbox is not running"}
[hetzner-e2e-chat] attempt 2 failed: Chat JSON-RPC error: {"code":-32000,"message":"Sandbox is not running"}
error: Agent 0f9f9d2e-… never produced a real chat reply within 8000ms (2 attempts). Last failure: Chat JSON-RPC error: {"code":-32000,"message":"Sandbox is not running"}
exit: 1

=== mode=empty ===
[hetzner-e2e-chat] attempt 1 failed: Bridge reply was empty: {"text":"","conversationId":"c-1"}
[hetzner-e2e-chat] attempt 2 failed: Bridge reply was empty: {"text":"","conversationId":"c-1"}
error: Agent 0f9f9d2e-… never produced a real chat reply within 8000ms (2 attempts). Last failure: Bridge reply was empty: {"text":"","conversationId":"c-1"}
exit: 1
```

</details>

## Evidence matrix

| Evidence | Status |
| --- | --- |
| Script dry-run output | Attached above |
| Real staging/Hetzner run | N/A pre-merge — no CI secrets in this environment; proof is the next scheduled run or `gh workflow run hetzner-e2e.yml` post-merge (the touched paths auto-trigger the workflow on merge to develop) |
| Video walkthrough | N/A - CI-only change, no UI surface |
| Before/after screenshots (desktop + mobile) | N/A - CI-only change, no UI surface |
| Frontend console/network logs | N/A - CI-only change, no UI surface |
| Real-LLM trajectories | N/A locally - the live-model turn happens inside the nightly run itself; the `Chat turn` step log is the trajectory evidence (reply text + token echo logged) |
| Backend logs | N/A locally - Worker-side `[agent-sandbox]` logs are emitted on staging during the run |

🤖 Generated with [Claude Code](https://claude.com/claude-code)