### PR TITLE
test(cloud-apps): cover deploy fact metadata refresh

### DIFF
--- a/plugins/plugin-cloud-apps/__tests__/app-facts.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/app-facts.test.ts
@@ -1,12 +1,22 @@
 /**
  * Tests for record/removeAppDeployFact — the durable "app is live at <url>" memory facts. Runs against the runtime's in-memory memory store; no SDK involved.
  */
-import { describe, expect, it } from "bun:test";
-import { recordAppDeployFact, removeAppDeployFact } from "../src/app-facts.ts";
+import { describe, expect, it, mock } from "bun:test";
 import { makeApp, makeRoomMessage, memoryRuntime } from "./helpers";
+
+mock.module("@elizaos/core", () => ({
+  logger: { warn: () => undefined },
+  MemoryType: { CUSTOM: "custom" },
+}));
+
+const { recordAppDeployFact, removeAppDeployFact } = await import(
+  "../src/app-facts.ts"
+);
 
 const appIdOf = (m: { metadata?: unknown }) =>
   (m.metadata as { appId?: string } | undefined)?.appId;
+const metadataOf = (m: { metadata?: unknown }) =>
+  m.metadata as Record<string, unknown> | undefined;
 
 describe("app deploy facts", () => {
   it("records a durable deploy fact, then removeAppDeployFact purges it", async () => {
@@ -46,6 +56,11 @@ describe("app deploy facts", () => {
       app,
       "https://x-1.apps.elizacloud.ai",
     );
+    runtime.__facts[0].metadata = {
+      ...metadataOf(runtime.__facts[0]),
+      sender: { id: "sender-1" },
+    };
+
     const second = await recordAppDeployFact(
       runtime,
       message,
@@ -54,6 +69,10 @@ describe("app deploy facts", () => {
     );
     expect(second.updated).toBe(true);
     expect(runtime.__facts.filter((m) => appIdOf(m) === "id-x").length).toBe(1);
+    expect(metadataOf(runtime.__facts[0])?.appUrl).toBe(
+      "https://x-2.apps.elizacloud.ai",
+    );
+    expect(metadataOf(runtime.__facts[0])?.sender).toBeUndefined();
 
     expect(await removeAppDeployFact(runtime, message, "id-x")).toBe(true);
     expect(runtime.__facts.length).toBe(0);


### PR DESCRIPTION
## Summary

Follow-up to merged #15607. Adds a regression assertion for `recordAppDeployFact()`'s redeploy/update path so stale arbitrary memory metadata, such as a message `sender`, is not carried forward when refreshing the durable custom deploy fact.

The test now mocks the small runtime surface imported from `@elizaos/core` before loading `app-facts.ts`, which lets the Bun-native coverage lane run without a prebuilt core dist.

## Verification

```bash
bunx @biomejs/biome check --write plugins/plugin-cloud-apps/__tests__/app-facts.test.ts
# pass

bun test plugins/plugin-cloud-apps/__tests__/app-facts.test.ts --coverage --coverage-reporter=lcov --coverage-dir=coverage/bun
# 3 pass, 0 fail

git diff --check origin/develop...HEAD
# pass
```

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only change; no UI changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only change; no UI changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only regression coverage for merged #15607; command output above proves the Bun-native test path.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model/action/provider/prompt behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifact: [`app-facts.test.ts`](https://github.com/elizaOS/eliza/blob/test/cloud-apps-deploy-fact-metadata/plugins/plugin-cloud-apps/__tests__/app-facts.test.ts), covering deploy fact metadata refresh and stale `sender` removal on redeploy.