### PR TITLE
fix(cloud): deletion_failed sandboxes no longer consume org agent capacity (#15603)

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/eliza-sandbox-deletion-failed-quota.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/eliza-sandbox-deletion-failed-quota.test.ts
@@ -1,0 +1,333 @@
+/**
+ * Real-DB proof that `deletion_failed` / `deletion_pending` sandboxes do not
+ * consume org agent capacity (#15603 C8): an org whose delete exhausted its
+ * retries (e.g. the node was SSH-unreachable) can still mint a replacement
+ * agent, while genuinely-live rows keep holding their quota slot — so the
+ * exclusion cannot be gamed into unbounded live containers.
+ *
+ * Drives the REAL createAgent / createCodingContainerAgent against in-process
+ * PGlite (real Drizzle schema via pushSchema, same harness as
+ * eliza-sandbox-coding-container-quota.test.ts) with NOTHING mocked. Rows are
+ * flipped to `deletion_failed` exactly as the AGENT_DELETE permanent-failure
+ * writeback does (provisioning-jobs.ts): status + error_message + error_count.
+ *
+ * Self-skips LOUDLY if PGlite/pushSchema is unavailable (never silently passes).
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
+const CAN_USE_ISOLATED_PGLITE =
+  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { pushSchema } from "drizzle-kit/api";
+import { eq, sql } from "drizzle-orm";
+import { type AgentSandboxStatus, agentSandboxes } from "../../../db/schemas/agent-sandboxes";
+import { organizations } from "../../../db/schemas/organizations";
+import { userCharacters } from "../../../db/schemas/user-characters";
+import { users } from "../../../db/schemas/users";
+
+const PGLITE_TIMEOUT = 60_000;
+const CAP = 3;
+let pgliteReady = true;
+
+let dbWrite: typeof import("../../../db/client").dbWrite;
+let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
+let ElizaSandboxService: typeof import("../eliza-sandbox").ElizaSandboxService;
+let AgentQuotaExceededError: typeof import("../eliza-sandbox").AgentQuotaExceededError;
+
+let seq = 0;
+function uniq(p: string): string {
+  seq += 1;
+  return `${p}-${seq}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function seedOrg(): Promise<string> {
+  const [org] = await dbWrite
+    .insert(organizations)
+    .values({ name: "Org", slug: uniq("org"), credit_balance: "5.000000" })
+    .returning();
+  return org.id;
+}
+
+async function seedUser(organizationId: string): Promise<string> {
+  const [user] = await dbWrite
+    .insert(users)
+    .values({ steward_user_id: uniq("steward"), organization_id: organizationId })
+    .returning();
+  return user.id;
+}
+
+async function countOrgRows(organizationId: string): Promise<number> {
+  const rows = await dbWrite.query.agentSandboxes.findMany({
+    where: eq(agentSandboxes.organization_id, organizationId),
+  });
+  return rows.length;
+}
+
+async function getStatus(agentId: string): Promise<AgentSandboxStatus | undefined> {
+  const row = await dbWrite.query.agentSandboxes.findFirst({
+    where: eq(agentSandboxes.id, agentId),
+  });
+  return row?.status;
+}
+
+async function setAgentStatus(agentId: string, status: AgentSandboxStatus): Promise<void> {
+  await dbWrite.update(agentSandboxes).set({ status }).where(eq(agentSandboxes.id, agentId));
+}
+
+/**
+ * Flip a row to `deletion_failed` the way the AGENT_DELETE permanent-failure
+ * writeback does — the state a sandbox lands in when the delete job exhausted
+ * its retries against an unreachable/failing node and the row is kept for ops.
+ */
+async function markDeletionFailed(agentId: string): Promise<void> {
+  await dbWrite
+    .update(agentSandboxes)
+    .set({
+      status: "deletion_failed",
+      error_message: "Deletion permanently failed after 3 attempts: SSH connect timed out",
+      error_count: sql`${agentSandboxes.error_count} + 1`,
+      updated_at: new Date(),
+    })
+    .where(eq(agentSandboxes.id, agentId));
+}
+
+async function seedOrgAtCap(): Promise<{ orgId: string; userId: string; ids: string[] }> {
+  const orgId = await seedOrg();
+  const userId = await seedUser(orgId);
+  const svc = new ElizaSandboxService();
+  const ids: string[] = [];
+  for (let i = 0; i < CAP; i++) {
+    const res = await svc.createAgent({
+      organizationId: orgId,
+      userId,
+      agentName: `agent-${i}`,
+      executionTier: "dedicated-always",
+      maxNonTerminalAgents: CAP,
+    });
+    ids.push(res.agent.id);
+  }
+  return { orgId, userId, ids };
+}
+
+beforeAll(async () => {
+  if (!CAN_USE_ISOLATED_PGLITE) {
+    pgliteReady = false;
+    console.warn(
+      "[eliza-sandbox-deletion-failed-quota.test] non-PGlite DATABASE_URL; self-skipping.",
+    );
+    return;
+  }
+  try {
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
+    ({ ElizaSandboxService, AgentQuotaExceededError } = await import("../eliza-sandbox"));
+
+    const schema = { organizations, users, userCharacters, agentSandboxes };
+    const { apply } = await pushSchema(schema as never, dbWrite as never);
+    await apply();
+  } catch (error) {
+    pgliteReady = false;
+    console.error(
+      "[eliza-sandbox-deletion-failed-quota.test] PGlite/pushSchema unavailable — skipping.",
+      error,
+    );
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+describe("deletion_failed frees the org's quota slot (#15603 C8)", () => {
+  test(
+    "org at capacity with one deletion_failed row can mint a replacement; the stuck row stays for ops",
+    async () => {
+      if (!pgliteReady) return;
+      const { orgId, userId, ids } = await seedOrgAtCap();
+      const svc = new ElizaSandboxService();
+
+      await markDeletionFailed(ids[0]);
+
+      // The user whose delete failed through no fault of their own is NOT
+      // locked out: the capped (forceCreate) path mints a replacement.
+      const res = await svc.createAgent({
+        organizationId: orgId,
+        userId,
+        agentName: "agent-replacement",
+        executionTier: "dedicated-always",
+        maxNonTerminalAgents: CAP,
+      });
+      expect(res.idempotent).toBe(false);
+
+      // The dying row is retained (ops visibility + the re-enqueue sweep needs
+      // it) — the org now has CAP+1 rows but only CAP quota-holding ones.
+      expect(await countOrgRows(orgId)).toBe(CAP + 1);
+      expect(await getStatus(ids[0])).toBe("deletion_failed");
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "the NORMAL reuse path never resurrects a deletion_failed row — it mints a fresh agent instead",
+    async () => {
+      if (!pgliteReady) return;
+      const { orgId, userId, ids } = await seedOrgAtCap();
+      const svc = new ElizaSandboxService();
+
+      // Every agent is on its way out: the reuse guard must find nothing to
+      // hand back (returning a dying row would resurrect a deleted agent).
+      for (const id of ids) {
+        await markDeletionFailed(id);
+      }
+
+      const res = await svc.createAgent({
+        organizationId: orgId,
+        userId,
+        agentName: "agent-fresh",
+        executionTier: "dedicated-always",
+        reuseExistingNonTerminal: true,
+        maxNonTerminalAgents: CAP,
+      });
+      expect(res.idempotent).toBe(false);
+      expect(ids).not.toContain(res.agent.id);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a re-armed delete (deletion_failed -> deletion_pending) still frees the slot mid-recovery",
+    async () => {
+      if (!pgliteReady) return;
+      const { orgId, userId, ids } = await seedOrgAtCap();
+      const svc = new ElizaSandboxService();
+
+      // reEnqueueFailedDeletions flips a stuck row back to deletion_pending
+      // when it re-arms the delete; the org must stay unblocked through that
+      // transition, not only in the failed terminal state.
+      await markDeletionFailed(ids[0]);
+      await setAgentStatus(ids[0], "deletion_pending");
+
+      const res = await svc.createAgent({
+        organizationId: orgId,
+        userId,
+        agentName: "agent-during-recovery",
+        executionTier: "dedicated-always",
+        maxNonTerminalAgents: CAP,
+      });
+      expect(res.idempotent).toBe(false);
+      expect(await countOrgRows(orgId)).toBe(CAP + 1);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "coding-container path shares the exclusion: deletion_failed frees a slot there too",
+    async () => {
+      if (!pgliteReady) return;
+      const orgId = await seedOrg();
+      const userId = await seedUser(orgId);
+      const svc = new ElizaSandboxService();
+
+      const ids: string[] = [];
+      for (let i = 0; i < CAP; i++) {
+        const res = await svc.createCodingContainerAgent({
+          organizationId: orgId,
+          userId,
+          agentName: `cc-${i}`,
+          dockerImage: `ghcr.io/elizaos/tool:v${i}`,
+          executionTier: "custom",
+          maxNonTerminalAgents: CAP,
+        });
+        ids.push(res.agent.id);
+      }
+      await markDeletionFailed(ids[0]);
+
+      const res = await svc.createCodingContainerAgent({
+        organizationId: orgId,
+        userId,
+        agentName: "cc-replacement",
+        dockerImage: "ghcr.io/elizaos/tool:v99",
+        executionTier: "custom",
+        maxNonTerminalAgents: CAP,
+      });
+      expect(res.idempotent).toBe(false);
+      expect(await countOrgRows(orgId)).toBe(CAP + 1);
+    },
+    PGLITE_TIMEOUT,
+  );
+});
+
+describe("the exclusion cannot be gamed into unbounded live containers", () => {
+  test(
+    "genuinely-running rows still hold their slot: org at cap of running agents is refused",
+    async () => {
+      if (!pgliteReady) return;
+      const { orgId, userId, ids } = await seedOrgAtCap();
+      const svc = new ElizaSandboxService();
+
+      for (const id of ids) {
+        await setAgentStatus(id, "running");
+      }
+
+      await expect(
+        svc.createAgent({
+          organizationId: orgId,
+          userId,
+          agentName: "agent-past-cap",
+          executionTier: "dedicated-always",
+          maxNonTerminalAgents: CAP,
+        }),
+      ).rejects.toBeInstanceOf(AgentQuotaExceededError);
+      expect(await countOrgRows(orgId)).toBe(CAP);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "one deletion_failed row frees exactly ONE slot: the replacement fills it and the next create is refused with the live count",
+    async () => {
+      if (!pgliteReady) return;
+      const { orgId, userId, ids } = await seedOrgAtCap();
+      const svc = new ElizaSandboxService();
+
+      for (const id of ids) {
+        await setAgentStatus(id, "running");
+      }
+      await markDeletionFailed(ids[0]);
+
+      // Slot freed by the stuck delete → one replacement goes through...
+      const replacement = await svc.createAgent({
+        organizationId: orgId,
+        userId,
+        agentName: "agent-replacement",
+        executionTier: "dedicated-always",
+        maxNonTerminalAgents: CAP,
+      });
+      expect(replacement.idempotent).toBe(false);
+
+      // ...and the org is back at the ceiling: the next create is refused, and
+      // the reported count is the LIVE count (CAP), not the raw row count
+      // (CAP+1 with the dying row still present).
+      let quotaError: unknown;
+      try {
+        await svc.createAgent({
+          organizationId: orgId,
+          userId,
+          agentName: "agent-one-too-many",
+          executionTier: "dedicated-always",
+          maxNonTerminalAgents: CAP,
+        });
+      } catch (error) {
+        quotaError = error;
+      }
+      expect(quotaError).toBeInstanceOf(AgentQuotaExceededError);
+      expect((quotaError as InstanceType<typeof AgentQuotaExceededError>).count).toBe(CAP);
+      expect(await countOrgRows(orgId)).toBe(CAP + 1);
+    },
+    PGLITE_TIMEOUT,
+  );
+});

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -135,9 +135,16 @@ export interface CreateAgentParams {
  * must not mint fresh agents (and fresh managed DBs) past the ceiling
  * (#11023 residual). Terminal/deletion states (`error`, `disconnected`,
  * `deletion_pending`, `deletion_failed`) hold no reusable resources and stay
- * excluded. Intentionally BROADER than the reuse-guard SELECTs, which must
- * keep returning only a LIVE agent — handing back a stopped/sleeping row
- * would silently turn an idempotent create into an implicit resume.
+ * excluded. `deletion_failed` in particular must not count (#15603): the
+ * delete exhausted its retries — usually a node fault, not the user's — and
+ * counting it would lock the org out of a replacement until ops intervene. A
+ * container that survived the failed teardown is reclaimed independently of
+ * this count (`reEnqueueFailedDeletions` re-arms the delete; the orphan
+ * reconciler treats `deletion_failed` as reapable), and a user cannot drive a
+ * row into that state on demand, so the freed slot stays bounded. Intentionally
+ * BROADER than the reuse-guard SELECTs, which must keep returning only a LIVE
+ * agent — handing back a stopped/sleeping row would silently turn an
+ * idempotent create into an implicit resume.
  */
 const QUOTA_COUNTED_STATUSES: AgentSandboxStatus[] = [
   "pending",

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -3062,13 +3062,14 @@ export class ProvisioningJobService {
    *
    * `deletion_failed` is otherwise a dead-end: the agent_delete job exhausted
    * its retries (e.g. the core was down for a deploy), so the row sits forever
-   * — visible to ops but never auto-recovered, and still counting against the
-   * org's agent capacity. This low-frequency sweep finds rows that have been
-   * `deletion_failed` longer than `minAgeMs` and enqueues a FRESH agent_delete
-   * for each. `enqueueAgentDeleteOnce` is idempotent (it dedups an in-flight
-   * delete and re-flips the row to `deletion_pending`), so a node that has
-   * since come back will finally drop the container + row. `minAgeMs` keeps
-   * this from fighting the live retry loop right after a failure.
+   * — visible to ops but never auto-recovered, and any container that survived
+   * the failed teardown keeps leaking on its node. This low-frequency sweep
+   * finds rows that have been `deletion_failed` longer than `minAgeMs` and
+   * enqueues a FRESH agent_delete for each. `enqueueAgentDeleteOnce` is
+   * idempotent (it dedups an in-flight delete and re-flips the row to
+   * `deletion_pending`), so a node that has since come back will finally drop
+   * the container + row. `minAgeMs` keeps this from fighting the live retry
+   * loop right after a failure.
    *
    * Circuit-breaker: a permanently-dead node would otherwise be re-armed every
    * sweep forever. Each exhausted agent_delete bumps the sandbox's `error_count`
@@ -3077,9 +3078,13 @@ export class ProvisioningJobService {
    * `event: "deletion.abandoned_candidate"` for ops to investigate (the
    * container likely needs a manual node-level teardown) rather than looping.
    *
-   * NOTE (follow-up): capacity accounting still counts `deletion_failed` rows
-   * until they are actually removed; excluding them from capacity is a separate
-   * change in the agent-creation path.
+   * Capacity: `deletion_failed`/`deletion_pending` rows do NOT count toward the
+   * org's agent ceiling (`QUOTA_COUNTED_STATUSES` in eliza-sandbox.ts), so a
+   * stuck delete never blocks the org from creating a replacement. This sweep —
+   * together with the orphan-container reconciler, which treats
+   * `deletion_failed` as reapable — is what eventually reclaims the container
+   * behind that freed slot, so the exclusion cannot compound into unbounded
+   * live containers.
    */
   async reEnqueueFailedDeletions(params?: {
     minAgeMs?: number;


### PR DESCRIPTION
Work item **C8** of epic #15603: agent sandboxes stuck in `deletion_failed` (delete exhausted retries, e.g. node SSH-unreachable; row kept for ops) must not block the org from creating a replacement agent.

## Finding

The in-code follow-up note at `provisioning-jobs.ts:3080-3082` ("capacity accounting still counts `deletion_failed` rows … excluding them from capacity is a separate change in the agent-creation path") is **stale relative to the enforcement code**. Every user-facing create path (`POST /api/v1/eliza/agents`, `POST /api/v1/coding-containers`, `POST /api/compat/agents`) funnels through `elizaSandboxService.createAgent` / `createCodingContainerAgent` → `assertOrgAgentQuota`, which counts only `QUOTA_COUNTED_STATUSES = pending | provisioning | running | stopped | sleeping` — `deletion_pending` and `deletion_failed` are already excluded (`packages/cloud/shared/src/lib/services/eliza-sandbox.ts:142`). There is no other org-capacity gate over `agent_sandboxes` (verified: the `/api/v1/app/agents` quota counts `user_characters`, not sandboxes; node-level `allocated_count` was fixed separately in #15380).

What was actually missing:
- **Zero test coverage** for `deletion_failed` quota semantics (the existing #11023 suite covers `error`/`deletion_pending` only), so nothing stops a regression re-introducing exactly this lockout.
- The **stale note** (and a doc sentence above it claiming the rows "still count against the org's agent capacity"), which is how the epic inherited the bug claim.

This PR pins the semantics with a real-DB regression suite and resolves the note with the durable behavior.

## Chosen semantics + why

**`deletion_failed` and `deletion_pending` rows free their org quota slot unconditionally** (the shipped behavior, now asserted), even though the container in `deletion_failed` may still exist — reading `executeAgentDelete` (`provisioning-jobs.ts`) and `deleteAgent` (`eliza-sandbox.ts`): the row reaches `deletion_failed` when the bounded stop failed non-ignorably and the job exhausted retries, so the container can be alive, partially stopped, or already gone.

Why exclude anyway, instead of "count until container confirmed removed" or "count + auto-expire":
- **Confirming container removal** would re-block the exact victim this bug is about (SSH-unreachable node → no confirmation possible), and would need the delete job's `containerStopped` result joined into the quota count — fragile against job-row pruning.
- **Count + auto-expire** duplicates machinery that already exists: `reEnqueueFailedDeletions` re-arms a fresh `agent_delete` every sweep (30m cadence) until the teardown succeeds, circuit-breaking after `maxReEnqueues` into an `deletion.abandoned_candidate` ops alert; the orphan-container reconciler treats `deletion_failed` as reapable (`TERMINAL_SANDBOX_STATUSES`, `docker-node-workloads.ts`); node `allocated_count` already excludes these rows (#15380). The fleet consistently treats `deletion_failed` as "this container must not be running".
- **Abuse edge is bounded:** a user cannot drive a row into `deletion_failed` on demand — it requires the delete job to exhaust retries against an infra-level failure. Worst case is a transient window where a not-yet-reaped container coexists with its replacement until the sweep/reconciler reaps it; every replacement create still passes the credit gate, rate limit, and the same org ceiling (the freed slot is exactly one — asserted). Permanently-dead teardowns escalate to ops via the circuit breaker instead of silently blocking the org forever.

## Changes

- `packages/cloud/shared/src/lib/services/__tests__/eliza-sandbox-deletion-failed-quota.test.ts` — new real-PGlite suite (same harness as the #11023 quota suite: real Drizzle schema via `pushSchema`, real `createAgent`/`createCodingContainerAgent`, nothing mocked; rows flipped to `deletion_failed` exactly as the AGENT_DELETE permanent-failure writeback does).
- `eliza-sandbox.ts` — `QUOTA_COUNTED_STATUSES` comment now carries the `deletion_failed` rationale + abuse-edge reasoning (comment-only).
- `provisioning-jobs.ts` — resolved the stale follow-up note; the `reEnqueueFailedDeletions` doc now states the durable capacity behavior (comment-only).

## Evidence

**Test run** (`bun test --isolate` in `packages/cloud/shared`; new suite + both adjacent quota/idempotency suites):

<details><summary>26 pass / 0 fail across 3 files</summary>

```
bun test v1.4.0-canary.1 (64ae83c2f)

src/lib/services/__tests__/eliza-sandbox-deletion-failed-quota.test.ts:
(pass) deletion_failed frees the org's quota slot (#15603 C8) > org at capacity with one deletion_failed row can mint a replacement; the stuck row stays for ops
(pass) deletion_failed frees the org's quota slot (#15603 C8) > the NORMAL reuse path never resurrects a deletion_failed row — it mints a fresh agent instead
(pass) deletion_failed frees the org's quota slot (#15603 C8) > a re-armed delete (deletion_failed -> deletion_pending) still frees the slot mid-recovery
(pass) deletion_failed frees the org's quota slot (#15603 C8) > coding-container path shares the exclusion: deletion_failed frees a slot there too
(pass) the exclusion cannot be gamed into unbounded live containers > genuinely-running rows still hold their slot: org at cap of running agents is refused
(pass) the exclusion cannot be gamed into unbounded live containers > one deletion_failed row frees exactly ONE slot: the replacement fills it and the next create is refused with the live count

src/lib/services/__tests__/eliza-sandbox-coding-container-quota.test.ts: 9 pass
src/lib/services/eliza-sandbox-create-idempotency.test.ts: 11 pass

 26 pass
 0 fail
 104 expect() calls
Ran 26 tests across 3 files. [8.01s]
```

</details>

**Mutation check (the tests bite):** temporarily adding `"deletion_failed"` to `QUOTA_COUNTED_STATUSES` makes 4 of the 6 new tests fail (replacement-at-cap, reuse-path, coding-container, exactly-one-slot); reverting restores 6/6 green.

**Also run:** `provisioning-jobs-recovery.test.ts` 3 pass / 0 fail; `bun run --cwd packages/cloud/shared lint` clean (1603 files); `bun run audit:error-policy-ratchet` clean ("no new fallback-slop in touched files"); package `typecheck` has 17 pre-existing errors in unrelated files (`docker-ssh.ts`/`email.ts`/`blog.ts`/transitive plugin imports — identical count on the untouched `origin/develop` baseline, verified by stash/compare; none in the files this PR touches).

- Video walkthrough: N/A - backend-only quota/service change, no UI surface
- Before/after screenshots (desktop + mobile): N/A - no rendered UI change
- Frontend console/network logs: N/A - no frontend code path touched
- Real-LLM trajectories: N/A - no agent/action/provider/prompt/model behavior change; quota gate is pre-model
- Domain artifacts: DB rows driven and asserted directly by the PGlite suite (org rows at CAP+1 with the `deletion_failed` row retained for ops; quota error reports the live count)

🤖 Generated with [Claude Code](https://claude.com/claude-code)