### PR TITLE
test(ui): guard wallet connector peer dep so #15600 EVM fallback can't regress

### DIFF
--- a/packages/ui/src/cloud/public-pages/pages/login/wallet-connector-deps.test.ts
+++ b/packages/ui/src/cloud/public-pages/pages/login/wallet-connector-deps.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Regression guard for the wallet sign-in connector peer dependencies.
+ *
+ * The EVM "sign in with a wallet" button lazy-mounts wagmi + RainbowKit on
+ * click. When the user has NO injected wallet (`window.ethereum` absent — every
+ * mobile browser, and any desktop without a wallet extension), RainbowKit falls
+ * back to the MetaMask **SDK** connector for the QR / deeplink flow. That
+ * connector does a runtime `await import("@metamask/connect-evm")`
+ * (`@wagmi/connectors` metaMask.js) — a dependency wagmi *declares* but that the
+ * workspace must actually install, or the dynamic import throws
+ * `Could not resolve "@metamask/connect-evm"` at click-time and the wallet flow
+ * dead-ends (#15600, fixed by #15608).
+ *
+ * Nothing else catches a drop of this dep: it is a browser-runtime lazy import,
+ * so the app BUILDS and every jsdom unit test passes even when it is missing —
+ * the failure only surfaces when a real no-wallet browser clicks EVM. This test
+ * pins the dep in `packages/ui/package.json` so a future dependency bump that
+ * drops it fails CI here instead of silently in production onboarding.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+// packages/ui/src/cloud/public-pages/pages/login -> packages/ui
+const uiPackageJsonPath = resolve(here, "../../../../../package.json");
+
+/**
+ * Connector SDKs that `@wagmi/connectors` (via RainbowKit) resolves through a
+ * runtime `await import(...)` on the no-injected-wallet fallback path. Each MUST
+ * be a resolvable dependency of `@elizaos/ui` or the corresponding wallet button
+ * dead-ends the moment it is clicked. Keep in sync with the connectors wagmi
+ * lazy-loads (grep `@wagmi/connectors` dist for `import(` — currently
+ * metaMask.js -> @metamask/connect-evm).
+ */
+const RUNTIME_LAZY_CONNECTOR_DEPS = ["@metamask/connect-evm"] as const;
+
+describe("wallet sign-in connector peer dependencies", () => {
+  const pkg = JSON.parse(readFileSync(uiPackageJsonPath, "utf8")) as {
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+  };
+  const declared = { ...pkg.dependencies, ...pkg.devDependencies };
+
+  it.each(RUNTIME_LAZY_CONNECTOR_DEPS)(
+    "declares %s so the no-injected-wallet EVM fallback resolves at click-time (#15600)",
+    (dep) => {
+      expect(
+        declared[dep],
+        `${dep} must be a declared dependency of @elizaos/ui — wagmi/RainbowKit ` +
+          `dynamically imports it on the no-wallet EVM path; dropping it resurrects ` +
+          `the "Could not resolve ${dep}" click-time dead-end (#15600 / #15608).`,
+      ).toBeTruthy();
+    },
+  );
+});


### PR DESCRIPTION
## What

Adds a regression guard for the wallet sign-in connector peer dependency that #15608 fixed.

## Why

#15608 ("fix(ui): include MetaMask connector peer") fixed the no-injected-wallet EVM sign-in dead-end (#15600) by installing `@metamask/connect-evm` — the package wagmi/RainbowKit `await import(...)` at click-time for the MetaMask **SDK** (QR / mobile-deeplink) connector, used whenever the user has no `window.ethereum` (every mobile browser, any desktop without a wallet extension).

But #15608 shipped **dep-only, no test**. This is a nasty regression class: the failing import is a **browser-runtime lazy import**, so the app still builds and every jsdom unit test passes even when the dep is missing — the `Could not resolve "@metamask/connect-evm"` dead-end only surfaces when a real no-wallet browser clicks EVM. A future dependency bump could silently drop it and re-break mobile/no-extension wallet onboarding with green CI.

## The test

`wallet-connector-deps.test.ts` asserts the runtime-lazy connector SDKs (currently `@metamask/connect-evm`) are declared in `@elizaos/ui`. Data-driven so more wagmi lazy-import connectors can be added.

## Evidence (proven both ways)

- ✅ **Passes on develop** (fix present): `1 pass / 0 fail`
- ✅ **Red-on-base**: removing `@metamask/connect-evm` from `packages/ui/package.json` → `1 fail` with the actionable message; restoring → green again. So it genuinely catches the regression, not green-because-empty.

## Scope notes (QA, live-verified)

- **EVM works today for extension users** (injected connector preferred; never touches the missing dep) — this only ever affected the no-wallet QR/deeplink fallback.
- **Solana checked, NOT affected**: `@solana/wallet-adapter-wallets` bundles its adapters — no uninstalled dynamic-import of the same class.
- **Prod status**: the #15608 fix is on develop + in `bun.lock`, but **not yet promoted to main** — prod (`9ff78abfb`) still lacks it, so the no-wallet EVM path is still broken on prod until the next promote. Flagging for the promote lane.

Found via the live sign-in matrix sweep (#15600). Part of the fleet regression-proofing mandate.
