### PR TITLE
fix(auth): harden cloud sign-in edges

### DIFF
--- a/packages/cloud/api/auth/siwe/nonce/route.test.ts
+++ b/packages/cloud/api/auth/siwe/nonce/route.test.ts
@@ -1,0 +1,39 @@
+/**
+ * SIWE nonce route coverage proves Redis write failures are surfaced as a
+ * retryable auth dependency outage instead of leaking a generic Worker 500.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+const setex = mock(async () => {
+  throw new Error("redis unavailable");
+});
+
+mock.module("@/lib/cache/redis-factory", () => ({
+  buildRedisClient: () => ({ setex }),
+}));
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STRICT: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { warn: mock(() => undefined) },
+}));
+
+const { default: app } = await import("./route");
+
+describe("GET /api/auth/siwe/nonce", () => {
+  test("returns retryable 503 when nonce persistence fails", async () => {
+    const res = await app.request("/", { method: "GET" }, {});
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("5");
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    await expect(res.json()).resolves.toEqual({
+      error: "Nonce storage unavailable",
+      code: "nonce_storage_unavailable",
+    });
+  });
+});

--- a/packages/cloud/api/auth/siwe/nonce/route.ts
+++ b/packages/cloud/api/auth/siwe/nonce/route.ts
@@ -16,6 +16,7 @@ import {
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { getAppHost, getAppUrl } from "@/lib/utils/app-url";
+import { logger } from "@/lib/utils/logger";
 import { issueNonce } from "@/lib/utils/siwe-helpers";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -34,7 +35,21 @@ app.get("/", async (c) => {
 
   const uri = getAppUrl(c.env);
   const resolvedChainId = Number.isNaN(chainId) ? 1 : chainId;
-  const nonce = await issueNonce(redis, { uri, chainId: resolvedChainId });
+  let nonce: string;
+  try {
+    nonce = await issueNonce(redis, { uri, chainId: resolvedChainId });
+  } catch (error) {
+    // error-policy:J1 boundary translation — nonce storage is an auth dependency;
+    // callers should retry instead of seeing a generic internal-error shape.
+    logger.warn("[AuthNonce] SIWE nonce storage unavailable", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return c.json(
+      { error: "Nonce storage unavailable", code: "nonce_storage_unavailable" },
+      503,
+      { "Cache-Control": "no-store", "Retry-After": "5" },
+    );
+  }
 
   return c.json(
     {

--- a/packages/cloud/api/auth/siws/nonce/route.test.ts
+++ b/packages/cloud/api/auth/siws/nonce/route.test.ts
@@ -1,0 +1,39 @@
+/**
+ * SIWS nonce route coverage mirrors SIWE so Solana sign-in treats Redis write
+ * failures as retryable auth dependency outages.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+const setex = mock(async () => {
+  throw new Error("redis unavailable");
+});
+
+mock.module("@/lib/cache/redis-factory", () => ({
+  buildRedisClient: () => ({ setex }),
+}));
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STRICT: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { warn: mock(() => undefined) },
+}));
+
+const { default: app } = await import("./route");
+
+describe("GET /api/auth/siws/nonce", () => {
+  test("returns retryable 503 when nonce persistence fails", async () => {
+    const res = await app.request("/", { method: "GET" }, {});
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("5");
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    await expect(res.json()).resolves.toEqual({
+      error: "Nonce storage unavailable",
+      code: "nonce_storage_unavailable",
+    });
+  });
+});

--- a/packages/cloud/api/auth/siws/nonce/route.ts
+++ b/packages/cloud/api/auth/siws/nonce/route.ts
@@ -11,6 +11,7 @@ import {
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { getAppHost, getAppUrl } from "@/lib/utils/app-url";
+import { logger } from "@/lib/utils/logger";
 import { issueSiwsNonce } from "@/lib/utils/siws-helpers";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -27,7 +28,21 @@ app.get("/", async (c) => {
   }
 
   const uri = getAppUrl(c.env);
-  const nonce = await issueSiwsNonce(redis, { uri, chainId });
+  let nonce: string;
+  try {
+    nonce = await issueSiwsNonce(redis, { uri, chainId });
+  } catch (error) {
+    // error-policy:J1 boundary translation — nonce storage is an auth dependency;
+    // callers should retry instead of seeing a generic internal-error shape.
+    logger.warn("[AuthNonce] SIWS nonce storage unavailable", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return c.json(
+      { error: "Nonce storage unavailable", code: "nonce_storage_unavailable" },
+      503,
+      { "Cache-Control": "no-store", "Retry-After": "5" },
+    );
+  }
 
   return c.json(
     {

--- a/packages/cloud/shared/src/lib/api/cloud-worker-errors.ts
+++ b/packages/cloud/shared/src/lib/api/cloud-worker-errors.ts
@@ -22,6 +22,7 @@ export type ApiErrorCode =
   | "agent_quota_exceeded"
   | "agent_image_not_allowed"
   | "agent_image_not_digest_pinned"
+  | "service_unavailable"
   | "internal_error";
 
 export interface ApiErrorOptions {

--- a/packages/cloud/shared/src/lib/auth.ts
+++ b/packages/cloud/shared/src/lib/auth.ts
@@ -165,9 +165,9 @@ export async function getCurrentUserFromRequest(
     if (user.organization_id) {
       void trackSessionActivity(user.id, user.organization_id, stewardToken);
       // Opportunistic self-heal for accounts that predate mint-at-provision
-      // (or whose mint failed): idempotent and swallows its own errors, so
-      // fire-and-forget is safe here.
-      void apiKeysService.ensureUserHasApiKey(user.id, user.organization_id);
+      // (or whose mint failed). Awaited on Workers: an un-awaited promise may
+      // be cancelled as soon as the response is returned.
+      await apiKeysService.ensureUserHasApiKey(user.id, user.organization_id);
       // Self-heal a missing default Eliza character: its only create site is
       // the one-time new-user signup branch in steward-sync, where a failed
       // create is swallowed so the signup itself survives — without this

--- a/packages/cloud/shared/src/lib/auth/workers-hono-auth.api-key.test.ts
+++ b/packages/cloud/shared/src/lib/auth/workers-hono-auth.api-key.test.ts
@@ -1,0 +1,67 @@
+/**
+ * API-key auth boundary coverage keeps storage outages distinct from invalid
+ * credentials so clients retry instead of prompting users to rotate good keys.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+const validateApiKey = mock(async () => {
+  throw new Error("database unavailable");
+});
+
+mock.module("../services/api-keys", () => ({
+  apiKeysService: {
+    validateApiKey,
+    incrementUsageDebounced: mock(async () => undefined),
+  },
+}));
+
+mock.module("../services/users", () => ({
+  usersService: {
+    getWithOrganization: mock(async () => null),
+  },
+}));
+
+mock.module("./steward-client", () => ({
+  verifyStewardTokenCached: mock(async () => null),
+}));
+
+mock.module("./playwright-test-session", () => ({
+  PLAYWRIGHT_TEST_SESSION_COOKIE_NAME: "pw-test-session",
+  verifyPlaywrightTestSessionToken: mock(() => null),
+}));
+
+mock.module("../utils/logger", () => ({
+  logger: {
+    error: mock(() => undefined),
+    warn: mock(() => undefined),
+  },
+}));
+
+const { requireUserOrApiKey } = await import("./workers-hono-auth");
+
+function contextWithApiKey(apiKey: string) {
+  const state = new Map<string, unknown>();
+  return {
+    env: {},
+    executionCtx: { waitUntil: mock(() => undefined) },
+    req: {
+      url: "https://api.example.test/v1/models",
+      header: (name: string) => (name.toLowerCase() === "x-api-key" ? apiKey : null),
+    },
+    get: (key: string) => state.get(key),
+    set: (key: string, value: unknown) => state.set(key, value),
+  };
+}
+
+describe("Workers API-key auth", () => {
+  test("returns a service-unavailable error when API-key storage throws", async () => {
+    await expect(
+      requireUserOrApiKey(contextWithApiKey("eliza_live_key") as never),
+    ).rejects.toMatchObject({
+      status: 503,
+      code: "service_unavailable",
+      message: "API key validation is temporarily unavailable. Please retry.",
+    });
+  });
+});

--- a/packages/cloud/shared/src/lib/auth/workers-hono-auth.ts
+++ b/packages/cloud/shared/src/lib/auth/workers-hono-auth.ts
@@ -110,6 +110,28 @@ function trackApiKeyUsage(c: AppContext, id: string, increment: () => Promise<vo
   }
 }
 
+async function validateApiKeyOrServiceUnavailable(
+  apiKey: string,
+): Promise<
+  Awaited<ReturnType<typeof import("../services/api-keys").apiKeysService.validateApiKey>>
+> {
+  const { apiKeysService } = await import("../services/api-keys");
+  try {
+    return await apiKeysService.validateApiKey(apiKey);
+  } catch (error) {
+    // error-policy:J1 boundary translation — API key storage is a dependency
+    // boundary. A backend outage must not be reported as invalid credentials.
+    logger.error("[Auth] API key validation backend unavailable", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw new ApiError(
+      503,
+      "service_unavailable",
+      "API key validation is temporarily unavailable. Please retry.",
+    );
+  }
+}
+
 function testAuthEnv(env: Bindings): PlaywrightTestAuthEnv {
   return {
     PLAYWRIGHT_TEST_AUTH:
@@ -238,7 +260,7 @@ export async function requireUserOrApiKeyWithOrg(c: AppContext): Promise<
 
   if (apiKey) {
     const { apiKeysService } = await import("../services/api-keys");
-    const validated = await apiKeysService.validateApiKey(apiKey);
+    const validated = await validateApiKeyOrServiceUnavailable(apiKey);
     if (!validated) throw AuthenticationError("Invalid or expired API key");
     if (!validated.is_active) throw ForbiddenError("API key is inactive");
     if (validated.expires_at && new Date(validated.expires_at) < new Date()) {
@@ -275,7 +297,7 @@ export async function requireUserOrApiKey(c: AppContext): Promise<AuthedUser> {
 
   if (apiKey) {
     const { apiKeysService } = await import("../services/api-keys");
-    const validated = await apiKeysService.validateApiKey(apiKey);
+    const validated = await validateApiKeyOrServiceUnavailable(apiKey);
     if (!validated) throw AuthenticationError("Invalid or expired API key");
     if (!validated.is_active) throw ForbiddenError("API key is inactive");
     if (validated.expires_at && new Date(validated.expires_at) < new Date()) {

--- a/packages/cloud/shared/src/lib/services/signup-grant-guard.ts
+++ b/packages/cloud/shared/src/lib/services/signup-grant-guard.ts
@@ -147,9 +147,10 @@ export async function runWithSignupGrantIpCap(
 export async function runWithSignupGrantIpCapDetailed(
   ip: string | undefined,
   grant: (tx?: DbTransaction) => Promise<void>,
+  existingTx?: DbTransaction,
 ): Promise<SignupGrantDecision> {
   if (!ip) {
-    await grant();
+    await grant(existingTx);
     return { granted: true };
   }
 
@@ -157,7 +158,7 @@ export async function runWithSignupGrantIpCapDetailed(
   const cap = FREE_GRANT_IP_LIMITS.MAX_FREE_GRANTS_PER_IP_DAILY;
   const dayAgo = new Date(Date.now() - windowHours * 60 * 60 * 1000);
 
-  return await dbWrite.transaction(async (tx) => {
+  const run = async (tx: DbTransaction): Promise<SignupGrantDecision> => {
     // Serialize same-IP grant attempts: the lock is held for the whole
     // transaction, so a concurrent racer blocks here until we commit our grant
     // row (released on commit), then re-reads the count below and sees it.
@@ -220,5 +221,7 @@ export async function runWithSignupGrantIpCapDetailed(
 
     await grant(tx);
     return { granted: true };
-  });
+  };
+
+  return existingTx ? await run(existingTx) : await dbWrite.transaction(run);
 }

--- a/packages/cloud/shared/src/lib/services/wallet-signup.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/wallet-signup.error-policy.test.ts
@@ -24,7 +24,37 @@ mock.module("../../db/repositories/organizations", () => ({
   organizationsRepository: { findBySlug: (s: string) => findBySlug(s) },
 }));
 mock.module("../../db/repositories/users", () => ({
-  usersRepository: { create: (i: { organization_id: string; role: string }) => userCreate(i) },
+  usersRepository: {
+    create: (i: { organization_id: string; role: string }) => userCreate(i),
+    findBySolanaWalletAddressWithOrganization: (a: string) => getByWallet(a),
+  },
+}));
+mock.module("../../db/helpers", () => ({
+  writeTransaction: async (fn: (tx: unknown) => Promise<unknown>) =>
+    fn({
+      query: {
+        organizations: {
+          findFirst: () => findBySlug("wallet-slug"),
+        },
+        users: {
+          findFirst: () => getByWallet(EVM_ADDRESS),
+        },
+      },
+      insert: () => ({
+        values: (input: { slug?: string; organization_id?: string; role?: string }) => ({
+          onConflictDoNothing: () => ({
+            returning: async () => {
+              if (input.slug) {
+                const org = await orgCreate(input);
+                return org ? [org] : [];
+              }
+              const user = await userCreate(input as { organization_id: string; role: string });
+              return user ? [user] : [];
+            },
+          }),
+        }),
+      }),
+    }),
 }));
 mock.module("./organizations", () => ({
   organizationsService: { create: (i: unknown) => orgCreate(i) },
@@ -63,9 +93,7 @@ beforeEach(() => {
   // Sensible defaults; individual tests override.
   getByWallet = async () => null;
   findBySlug = async () => null;
-  orgCreate = async () => {
-    throw new Error("orgCreate not configured");
-  };
+  orgCreate = async () => null;
   userCreate = async () => {
     throw new Error("userCreate not configured");
   };
@@ -104,14 +132,11 @@ describe("wallet-signup fail-closed error policy", () => {
     ).rejects.toThrow("connection terminated unexpectedly");
   });
 
-  test("unique-violation on org create is a DESIGNED race recovery to the winning org", async () => {
+  test("org create conflict is a DESIGNED race recovery to the winning org", async () => {
     const racedOrg = { id: "org-raced", slug: "wallet-slug" };
-    let slugCalls = 0;
     getByWallet = async () => null;
-    findBySlug = async () => (slugCalls++ === 0 ? null : racedOrg);
-    orgCreate = async () => {
-      throw new Error("duplicate key value violates unique constraint");
-    };
+    findBySlug = async () => racedOrg;
+    orgCreate = async () => null;
     userCreate = async (input) => ({
       id: "user-1",
       organization_id: input.organization_id,
@@ -140,7 +165,7 @@ describe("wallet-signup fail-closed error policy", () => {
     ).rejects.toThrow("deadlock detected");
   });
 
-  test("user-create unique-violation with unrecoverable re-fetch RETHROWS (never fabricates a user)", async () => {
+  test("user-create conflict with unrecoverable re-fetch RETHROWS (never fabricates a user)", async () => {
     const org = { id: "org-1", slug: "wallet-slug" };
     // Both the initial lookup and the post-race re-fetch return null: the race
     // handler must not invent a user, it must rethrow the original error.

--- a/packages/cloud/shared/src/lib/services/wallet-signup.ts
+++ b/packages/cloud/shared/src/lib/services/wallet-signup.ts
@@ -4,15 +4,18 @@
  * handling are consistent. WHY one path: avoids drift between SIWE/topup/wallet-auth.
  */
 
+import { eq } from "drizzle-orm";
 import { getAddress } from "viem";
+import type { DbTransaction } from "../../db/client";
+import { writeTransaction } from "../../db/helpers";
 import type { Organization } from "../../db/repositories/organizations";
-import { organizationsRepository } from "../../db/repositories/organizations";
 import type { UserWithOrganization } from "../../db/repositories/users";
 import { usersRepository } from "../../db/repositories/users";
+import { organizations } from "../../db/schemas/organizations";
+import { users } from "../../db/schemas/users";
 import { getClientIp } from "../runtime/request-context";
 import { logger } from "../utils/logger";
 import { creditsService } from "./credits";
-import { organizationsService } from "./organizations";
 import {
   runWithSignupGrantIpCapDetailed,
   type SignupGrantWithheldReason,
@@ -54,6 +57,7 @@ async function grantWalletSignupCredits(params: {
   chain: "evm" | "solana";
   idempotencyKey: string;
   requireInitialCredits: boolean;
+  db?: DbTransaction;
 }): Promise<InitialCreditGrantMetadata> {
   if (params.amount <= 0) {
     return { initialCreditsGranted: false, initialFreeCreditsUsd: 0 };
@@ -64,16 +68,20 @@ async function grantWalletSignupCredits(params: {
   // concurrent same-IP signups cannot each pass the cap before any commits.
   const signupIp = getClientIp();
   try {
-    const decision = await runWithSignupGrantIpCapDetailed(signupIp, async (tx) => {
-      await creditsService.addCredits({
-        organizationId: params.organizationId,
-        amount: params.amount,
-        description: "Wallet sign-up bonus",
-        stripePaymentIntentId: params.idempotencyKey,
-        metadata: { type: "wallet_signup", chain: params.chain, ip_address: signupIp },
-        db: tx,
-      });
-    });
+    const decision = await runWithSignupGrantIpCapDetailed(
+      signupIp,
+      async (tx) => {
+        await creditsService.addCredits({
+          organizationId: params.organizationId,
+          amount: params.amount,
+          description: "Wallet sign-up bonus",
+          stripePaymentIntentId: params.idempotencyKey,
+          metadata: { type: "wallet_signup", chain: params.chain, ip_address: signupIp },
+          db: tx,
+        });
+      },
+      params.db,
+    );
     return {
       initialCreditsGranted: decision.granted,
       initialFreeCreditsUsd: decision.granted ? params.amount : 0,
@@ -130,6 +138,69 @@ export async function grantInitialCreditsToWalletAccount(params: {
   return grantResult;
 }
 
+function isUniqueViolation(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.message.includes("unique") || error.message.includes("duplicate"))
+  );
+}
+
+async function findOrgBySlugForWrite(
+  tx: DbTransaction,
+  slug: string,
+): Promise<Organization | null> {
+  return (
+    (await tx.query.organizations.findFirst({
+      where: eq(organizations.slug, slug),
+    })) ?? null
+  );
+}
+
+async function createOrFindWalletOrg(params: {
+  tx: DbTransaction;
+  slug: string;
+  name: string;
+}): Promise<Organization> {
+  const [created] = await params.tx
+    .insert(organizations)
+    .values({
+      name: params.name,
+      slug: params.slug,
+      credit_balance: "0.00",
+    })
+    .onConflictDoNothing()
+    .returning();
+  const org = created ?? (await findOrgBySlugForWrite(params.tx, params.slug));
+  if (!org) {
+    throw new Error("Organization creation failed and could not find existing org");
+  }
+  return org;
+}
+
+async function findEvmUserForWrite(
+  tx: DbTransaction,
+  normalizedAddress: string,
+): Promise<UserWithOrganization | null> {
+  return (
+    (await tx.query.users.findFirst({
+      where: eq(users.wallet_address, normalizedAddress),
+      with: { organization: true },
+    })) ?? null
+  );
+}
+
+async function findSolanaUserForWrite(
+  tx: DbTransaction,
+  address: string,
+): Promise<UserWithOrganization | null> {
+  return (
+    (await tx.query.users.findFirst({
+      where: eq(users.wallet_address, address),
+      with: { organization: true },
+    })) ?? null
+  );
+}
+
 /**
  * Find user by wallet, or create org + user and return.
  * Address can be any case; stored and slug use lowercase.
@@ -159,63 +230,66 @@ export async function findOrCreateUserByWalletAddress(
 
   /* WHY slug wallet-${normalized}: consistent with topup and SIWE; lowercase for unique indexing. */
   const slug = `wallet-${normalized}`;
-  let org: Organization | null = (await organizationsRepository.findBySlug(slug)) ?? null;
-  if (!org) {
-    try {
-      org = await organizationsService.create({
-        name: `Wallet ${address.slice(0, 6)}...${address.slice(-4)}`,
-        slug,
-        credit_balance: "0.00",
-      });
-    } catch (e) {
-      // error-policy:J3 unique-violation race recovery — retry only the expected
-      // concurrent org-create collision; all other creation failures propagate.
-      const isUniqueViolation =
-        e instanceof Error && (e.message.includes("unique") || e.message.includes("duplicate"));
-      if (!isUniqueViolation) throw e;
-
-      org = (await organizationsRepository.findBySlug(slug)) ?? null;
-      if (!org) {
-        throw new Error("Organization creation failed and could not find existing org");
-      }
-    }
-  }
-  const initialCreditGrant =
-    grantInitialCredits && INITIAL_FREE_CREDITS > 0
-      ? await grantWalletSignupCredits({
-          organizationId: org.id,
-          amount: INITIAL_FREE_CREDITS,
-          chain: "evm",
-          idempotencyKey: `wallet-signup:evm:${normalized}`,
-          requireInitialCredits,
-        })
-      : { initialCreditsGranted: false, initialFreeCreditsUsd: 0 };
-
   try {
-    const created = await usersRepository.create({
-      steward_user_id: `wallet:evm:${normalized}`,
-      wallet_address: normalized,
-      wallet_chain_type: "evm",
-      wallet_verified: true,
-      organization_id: org.id,
-      // The signup creates this org for the wallet — its creator manages it
-      // (matches the anonymous-migration path in session.ts). Without this the
-      // sole member of a fresh wallet org is a plain "member" and can never
-      // invite teammates or manage the org they own.
-      role: "owner",
+    return await writeTransaction(async (tx) => {
+      const racedExisting = await findEvmUserForWrite(tx, normalized);
+      if (racedExisting) {
+        return { user: racedExisting, isNewAccount: false };
+      }
+
+      const org = await createOrFindWalletOrg({
+        tx,
+        slug,
+        name: `Wallet ${address.slice(0, 6)}...${address.slice(-4)}`,
+      });
+      const initialCreditGrant =
+        grantInitialCredits && INITIAL_FREE_CREDITS > 0
+          ? await grantWalletSignupCredits({
+              organizationId: org.id,
+              amount: INITIAL_FREE_CREDITS,
+              chain: "evm",
+              idempotencyKey: `wallet-signup:evm:${normalized}`,
+              requireInitialCredits,
+              db: tx,
+            })
+          : { initialCreditsGranted: false, initialFreeCreditsUsd: 0 };
+
+      const [created] = await tx
+        .insert(users)
+        .values({
+          steward_user_id: `wallet:evm:${normalized}`,
+          wallet_address: normalized,
+          wallet_chain_type: "evm",
+          wallet_verified: true,
+          organization_id: org.id,
+          // The signup creates this org for the wallet — its creator manages it
+          // (matches the anonymous-migration path in session.ts). Without this the
+          // sole member of a fresh wallet org is a plain "member" and can never
+          // invite teammates or manage the org they own.
+          role: "owner",
+        })
+        .onConflictDoNothing()
+        .returning();
+
+      if (!created) {
+        const raced = await findEvmUserForWrite(tx, normalized);
+        if (!raced) {
+          throw new Error("User creation conflicted but could not find existing wallet user");
+        }
+        return { user: raced, isNewAccount: false };
+      }
+
+      const user: UserWithOrganization = { ...created, organization: org };
+      return {
+        user,
+        isNewAccount: true,
+        ...initialCreditGrant,
+      };
     });
-    const user: UserWithOrganization = { ...created, organization: org };
-    return {
-      user,
-      isNewAccount: true,
-      ...initialCreditGrant,
-    };
   } catch (e) {
     // error-policy:J3 unique-violation race recovery — the losing concurrent
     // signup returns the winner's row; missing re-fetch rethrows the original.
-    const isUniqueViolation =
-      e instanceof Error && (e.message.includes("unique") || e.message.includes("duplicate"));
-    if (!isUniqueViolation) throw e;
+    if (!isUniqueViolation(e)) throw e;
     const raced = await usersService.getByWalletAddressWithOrganization(address);
     if (!raced) throw e;
     return { user: raced, isNewAccount: false };
@@ -252,60 +326,63 @@ export async function findOrCreateSolanaUserByWalletAddress(
   }
 
   const slug = `wallet-solana-${address}`;
-  let org: Organization | null = (await organizationsRepository.findBySlug(slug)) ?? null;
-  if (!org) {
-    try {
-      org = await organizationsService.create({
-        name: `Solana Wallet ${address.slice(0, 6)}...${address.slice(-4)}`,
-        slug,
-        credit_balance: "0.00",
-      });
-    } catch (e) {
-      // error-policy:J3 unique-violation race recovery — retry only the expected
-      // concurrent org-create collision; all other creation failures propagate.
-      const isUniqueViolation =
-        e instanceof Error && (e.message.includes("unique") || e.message.includes("duplicate"));
-      if (!isUniqueViolation) throw e;
-
-      org = (await organizationsRepository.findBySlug(slug)) ?? null;
-      if (!org) {
-        throw new Error("Organization creation failed and could not find existing Solana org");
-      }
-    }
-  }
-  const initialCreditGrant =
-    grantInitialCredits && INITIAL_FREE_CREDITS > 0
-      ? await grantWalletSignupCredits({
-          organizationId: org.id,
-          amount: INITIAL_FREE_CREDITS,
-          chain: "solana",
-          idempotencyKey: `wallet-signup:solana:${address}`,
-          requireInitialCredits,
-        })
-      : { initialCreditsGranted: false, initialFreeCreditsUsd: 0 };
-
   try {
-    const created = await usersRepository.create({
-      steward_user_id: `wallet:solana:${address}`,
-      wallet_address: address,
-      wallet_chain_type: "solana",
-      wallet_verified: true,
-      organization_id: org.id,
-      // Creator of the fresh wallet org manages it — see the EVM path above.
-      role: "owner",
+    return await writeTransaction(async (tx) => {
+      const racedExisting = await findSolanaUserForWrite(tx, address);
+      if (racedExisting) {
+        return { user: racedExisting, isNewAccount: false };
+      }
+
+      const org = await createOrFindWalletOrg({
+        tx,
+        slug,
+        name: `Solana Wallet ${address.slice(0, 6)}...${address.slice(-4)}`,
+      });
+      const initialCreditGrant =
+        grantInitialCredits && INITIAL_FREE_CREDITS > 0
+          ? await grantWalletSignupCredits({
+              organizationId: org.id,
+              amount: INITIAL_FREE_CREDITS,
+              chain: "solana",
+              idempotencyKey: `wallet-signup:solana:${address}`,
+              requireInitialCredits,
+              db: tx,
+            })
+          : { initialCreditsGranted: false, initialFreeCreditsUsd: 0 };
+
+      const [created] = await tx
+        .insert(users)
+        .values({
+          steward_user_id: `wallet:solana:${address}`,
+          wallet_address: address,
+          wallet_chain_type: "solana",
+          wallet_verified: true,
+          organization_id: org.id,
+          // Creator of the fresh wallet org manages it — see the EVM path above.
+          role: "owner",
+        })
+        .onConflictDoNothing()
+        .returning();
+
+      if (!created) {
+        const raced = await findSolanaUserForWrite(tx, address);
+        if (!raced) {
+          throw new Error("User creation conflicted but could not find existing Solana user");
+        }
+        return { user: raced, isNewAccount: false };
+      }
+
+      const user: UserWithOrganization = { ...created, organization: org };
+      return {
+        user,
+        isNewAccount: true,
+        ...initialCreditGrant,
+      };
     });
-    const user: UserWithOrganization = { ...created, organization: org };
-    return {
-      user,
-      isNewAccount: true,
-      ...initialCreditGrant,
-    };
   } catch (e) {
     // error-policy:J3 unique-violation race recovery — the losing concurrent
     // signup returns the winner's row; missing re-fetch rethrows the original.
-    const isUniqueViolation =
-      e instanceof Error && (e.message.includes("unique") || e.message.includes("duplicate"));
-    if (!isUniqueViolation) throw e;
+    if (!isUniqueViolation(e)) throw e;
     const raced = await usersRepository.findBySolanaWalletAddressWithOrganization(address);
     if (!raced) throw e;
     return { user: raced, isNewAccount: false };

--- a/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.test.tsx
@@ -186,7 +186,7 @@ describe("CliLoginPage", () => {
     );
     expect(postMessage).toHaveBeenCalledWith(
       { type: "eliza-cloud-auth-complete", sessionId: "sess-1" },
-      "*",
+      window.location.origin,
     );
     expect(screen.getByRole("button", { name: "Close window" })).toBeTruthy();
     expect(
@@ -211,6 +211,11 @@ describe("CliLoginPage", () => {
     apiFetchMock.mockResolvedValue({
       json: async () => ({ keyPrefix: "ek_live_abc" }),
     });
+    const postMessage = vi.fn();
+    Object.defineProperty(window, "opener", {
+      value: { postMessage },
+      configurable: true,
+    });
     const replace = stubLocationReplace();
     const closeSpy = vi.spyOn(window, "close").mockImplementation(() => {});
 
@@ -220,6 +225,10 @@ describe("CliLoginPage", () => {
       expect(replace).toHaveBeenCalledWith(
         "http://localhost:2138/chat?firstRun=1",
       ),
+    );
+    expect(postMessage).toHaveBeenCalledWith(
+      { type: "eliza-cloud-auth-complete", sessionId: "sess-1" },
+      "http://localhost:2138",
     );
     expect(closeSpy).toHaveBeenCalledTimes(1);
     expect(screen.getByText("Returning to app")).toBeTruthy();

--- a/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.tsx
@@ -80,6 +80,12 @@ function sanitizeCliLoginReturnTo(value: string | null): string | null {
   }
 }
 
+function resolveCliLoginMessageTargetOrigin(returnTo: string | null): string {
+  if (typeof window === "undefined") return "https://elizacloud.ai";
+  if (!returnTo) return window.location.origin;
+  return new URL(returnTo).origin;
+}
+
 function getPageState({
   authenticated,
   completion,
@@ -198,7 +204,7 @@ export default function CliLoginPage() {
         const data = (await response.json()) as { keyPrefix: string };
         window.opener?.postMessage(
           { type: "eliza-cloud-auth-complete", sessionId },
-          "*",
+          resolveCliLoginMessageTargetOrigin(launchReturnTo),
         );
         if (launchReturnTo) {
           setCompletion({ status: "redirecting" });


### PR DESCRIPTION
## Summary
- return retryable 503 responses when SIWE/SIWS nonce persistence fails
- keep API-key storage outages distinct from invalid credentials
- make wallet signup org/user/credit grant atomic and await default API key creation
- restrict CLI login completion postMessage to the sanitized return origin

Closes #15610.

## Verification
- `bunx biome check packages/cloud/api/auth/siwe/nonce/route.ts packages/cloud/api/auth/siwe/nonce/route.test.ts packages/cloud/api/auth/siws/nonce/route.ts packages/cloud/api/auth/siws/nonce/route.test.ts packages/cloud/shared/src/lib/api/cloud-worker-errors.ts packages/cloud/shared/src/lib/auth.ts packages/cloud/shared/src/lib/auth/workers-hono-auth.ts packages/cloud/shared/src/lib/auth/workers-hono-auth.api-key.test.ts packages/cloud/shared/src/lib/services/signup-grant-guard.ts packages/cloud/shared/src/lib/services/wallet-signup.ts packages/cloud/shared/src/lib/services/wallet-signup.error-policy.test.ts packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.tsx packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.test.tsx --no-errors-on-unmatched`
- `bun test packages/cloud/api/auth/siwe/nonce/route.test.ts packages/cloud/api/auth/siws/nonce/route.test.ts packages/cloud/shared/src/lib/auth/workers-hono-auth.api-key.test.ts`
- `bun run --cwd packages/ui test -- src/cloud/public-pages/pages/auth/cli-login-page.test.tsx`
- `bun test packages/cloud/shared/src/lib/services/wallet-signup.error-policy.test.ts`
- `mkdir -p .eliza && bun test packages/cloud/shared/src/lib/services/__tests__/wallet-signup-owner-role.test.ts`
- `bun run --cwd packages/cloud/shared typecheck`
- `bun run --cwd packages/ui typecheck`

Known unrelated failure:
- `bun run --cwd packages/cloud/api build` fails in `__tests__/stripe-connect-webhook-route.test.ts:245` because the fixture uses Stripe API version `2026-06-24.dahlia` where the generated type expects `2026-05-27.dahlia`.
