### PR TITLE
feat(cloud): continuous backup restorability verification (#15603)

### DIFF
--- a/packages/cloud/shared/.env.example
+++ b/packages/cloud/shared/.env.example
@@ -631,6 +631,26 @@ PROVISIONING_ALERT_SLACK_WEBHOOK=https://hooks.slack.com/...
 PROVISIONING_ALERT_PAGERDUTY_KEY=your_pagerduty_key
 
 # ============================================================================
+# AGENT BACKUP RESTORABILITY VERIFICATION (#15603 B5)
+# ============================================================================
+# The provisioning-worker daemon periodically samples the newest backup per
+# agent, decrypts it with the CURRENT KMS keys, and validates content/manifest
+# hashes (agent-backup-verifier.ts). Exists because staging silently ran an
+# ephemeral memory KMS and every stored backup was undecryptable until restores
+# failed (#15310). Failures stamp the backup row and alert through the
+# PROVISIONING_ALERT_* channels above; when a cycle's failure rate crosses the
+# escalation threshold (the KMS-misconfig signature), a separate louder alert
+# fires. ON by default — set BACKUP_VERIFICATION_ENABLED=0 to disable.
+# BACKUP_VERIFICATION_ENABLED=1
+# Backups verified per infra-maintenance sweep (default: 10)
+# BACKUP_VERIFICATION_BATCH_SIZE=10
+# Minimum hours before a backup is re-verified (default: 24)
+# BACKUP_VERIFICATION_REVERIFY_HOURS=24
+# Failure percentage of a cycle's sample that triggers the systemic
+# KMS-misconfiguration escalation alert (default: 50)
+# BACKUP_VERIFICATION_ESCALATION_PCT=50
+
+# ============================================================================
 # MCP CONFIGURATION
 # ============================================================================
 

--- a/packages/cloud/shared/src/db/ensure-agent-sandbox-schema.ts
+++ b/packages/cloud/shared/src/db/ensure-agent-sandbox-schema.ts
@@ -43,7 +43,10 @@ async function runEnsureAgentSandboxSchema(): Promise<void> {
       ADD COLUMN IF NOT EXISTS "size_bytes" bigint,
       ADD COLUMN IF NOT EXISTS "backup_kind" text NOT NULL DEFAULT 'full',
       ADD COLUMN IF NOT EXISTS "parent_backup_id" uuid,
-      ADD COLUMN IF NOT EXISTS "content_hash" text
+      ADD COLUMN IF NOT EXISTS "content_hash" text,
+      ADD COLUMN IF NOT EXISTS "verification_status" text,
+      ADD COLUMN IF NOT EXISTS "verified_at" timestamptz,
+      ADD COLUMN IF NOT EXISTS "verification_error" text
   `);
 
   await dbWrite.execute(sql`

--- a/packages/cloud/shared/src/db/migrations/0173_agent_backup_verification.sql
+++ b/packages/cloud/shared/src/db/migrations/0173_agent_backup_verification.sql
@@ -1,0 +1,15 @@
+-- #15603 B5: continuous backup restorability verification. Staging ran an
+-- ephemeral memory KMS for weeks and every agent backup was permanently
+-- undecryptable — nobody noticed until restores failed with "AEAD decrypt
+-- failed" (#15310). The provisioning-worker daemon now periodically samples
+-- the newest backup per agent, decrypts it with the CURRENT KMS keys, and
+-- validates content/manifest hashes. These columns persist the outcome:
+--   verification_status  'verified' | 'failed' (NULL = never sampled)
+--   verified_at          last verification ATTEMPT — drives the re-verify
+--                        sampling interval so the fleet is covered over time
+--   verification_error   classified failure (key-unavailable / decrypt-failed /
+--                        hash-mismatch / …) for triage without a re-run
+ALTER TABLE "agent_sandbox_backups"
+  ADD COLUMN IF NOT EXISTS "verification_status" text,
+  ADD COLUMN IF NOT EXISTS "verified_at" timestamptz,
+  ADD COLUMN IF NOT EXISTS "verification_error" text;

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1205,6 +1205,13 @@
       "when": 1781828400000,
       "tag": "0172_web_push_subscriptions",
       "breakpoints": true
+    },
+    {
+      "idx": 172,
+      "version": "7",
+      "when": 1781914800000,
+      "tag": "0173_agent_backup_verification",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -1276,6 +1276,9 @@ export class AgentSandboxesRepository {
         backup_kind: agentSandboxBackups.backup_kind,
         parent_backup_id: agentSandboxBackups.parent_backup_id,
         content_hash: agentSandboxBackups.content_hash,
+        verification_status: agentSandboxBackups.verification_status,
+        verified_at: agentSandboxBackups.verified_at,
+        verification_error: agentSandboxBackups.verification_error,
         created_at: agentSandboxBackups.created_at,
       })
       .from(agentSandboxBackups)

--- a/packages/cloud/shared/src/db/schemas/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/schemas/agent-sandboxes.ts
@@ -199,6 +199,15 @@ export type AgentSandboxPoolStatus = "unclaimed";
 export type AgentBackupSnapshotType = "auto" | "manual" | "pre-shutdown" | "pre-upgrade";
 
 /**
+ * Outcome of the last restorability verification pass over a backup row
+ * (`agent-backup-verifier.ts`). `null`/unset means the row has never been
+ * sampled. Verification decrypts the stored payload with the CURRENT KMS keys
+ * and checks content/manifest hashes — it exists because staging silently ran
+ * an ephemeral KMS for weeks and every backup was undecryptable (#15310).
+ */
+export type AgentBackupVerificationStatus = "verified" | "failed";
+
+/**
  * Whether a backup row stores the agent's complete state (`full`) or only the
  * delta against `parent_backup_id` (`incremental`). Restoring an incremental
  * backup replays its parent chain back to the nearest `full` backup. See
@@ -321,6 +330,16 @@ export const agentSandboxBackups = pgTable(
     parent_backup_id: uuid("parent_backup_id"),
     /** sha256 of the reconstructed full state, for integrity verification. */
     content_hash: text("content_hash"),
+    /**
+     * Restorability-verification stamp (see `AgentBackupVerificationStatus`).
+     * `verified_at` records the last verification ATTEMPT (success or failure)
+     * and drives the re-verify sampling interval; `verification_error` carries
+     * the classified failure (`key-unavailable: …`, `decrypt-failed: …`) so an
+     * operator can tell a KMS misconfig from bit-rot without re-running it.
+     */
+    verification_status: text("verification_status").$type<AgentBackupVerificationStatus>(),
+    verified_at: timestamp("verified_at", { withTimezone: true }),
+    verification_error: text("verification_error"),
     created_at: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({

--- a/packages/cloud/shared/src/lib/services/agent-backup-verifier.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-verifier.test.ts
@@ -1,0 +1,589 @@
+/**
+ * Backup restorability verification (#15603 B5) against the REAL pipeline: the
+ * real Drizzle schema on in-process PGlite, the real memory KMS encrypting
+ * through `prepareAgentBackupInsertData`, real AEAD decryption, and the real
+ * sampling/stamping/alerting cycle. No mock stands in for the thing under test
+ * — corrupted-ciphertext and wrong-KMS-key cases tamper with actual stored
+ * envelopes and actual key state, reproducing the #15310 failure mode.
+ *
+ * Harness mirrors `db/repositories/__tests__/agent-sandboxes-fleet-candidate-repo.test.ts`:
+ * drizzle-kit `pushSchema` applies the real DDL to the PGlite connection the
+ * service queries through; self-skips LOUDLY when the ambient DATABASE_URL is a
+ * shared non-PGlite Postgres.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { desc, eq } from "drizzle-orm";
+
+const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
+const CAN_USE_ISOLATED_PGLITE =
+  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+process.env.SKIP_AGENT_SANDBOX_ENSURE = "1";
+
+import { pushSchema } from "drizzle-kit/api";
+import { closeDatabaseConnectionsForTests, dbWrite } from "../../db/client";
+import { resetKmsClientForTests } from "../../db/crypto/kms-client";
+import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
+import {
+  type AgentBackupFileEntry,
+  type AgentBackupFileSet,
+  type AgentBackupManifest,
+  type AgentBackupStateData,
+  agentSandboxBackups,
+  agentSandboxes,
+  type EncryptedAgentBackupStateData,
+} from "../../db/schemas/agent-sandboxes";
+import { organizations } from "../../db/schemas/organizations";
+import { userCharacters } from "../../db/schemas/user-characters";
+import { users } from "../../db/schemas/users";
+import { computeStateHash, diffBackupState } from "./agent-backup-diff";
+import {
+  type BackupVerifierConfig,
+  classifyCryptoError,
+  readBackupVerifierConfig,
+  runBackupVerificationCycle,
+  verifyBackupRestorability,
+} from "./agent-backup-verifier";
+import type { DaemonHealthAlert } from "./provisioning-worker-health-monitor";
+
+const PGLITE_TIMEOUT = 60_000;
+let pgliteReady = true;
+
+let seq = 0;
+function uniq(prefix: string): string {
+  seq += 1;
+  return `${prefix}-${seq}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+const CONFIG: BackupVerifierConfig = {
+  enabled: true,
+  batchSize: 10,
+  reVerifyIntervalMs: 24 * 3_600_000,
+  escalationThresholdPct: 50,
+};
+
+function makeAlertSpy(): { alerts: DaemonHealthAlert[]; alert: (a: DaemonHealthAlert) => void } {
+  const alerts: DaemonHealthAlert[] = [];
+  return { alerts, alert: (a) => alerts.push(a) };
+}
+
+async function seedSandbox(): Promise<string> {
+  const [org] = await dbWrite
+    .insert(organizations)
+    .values({ name: "Backup Verify Org", slug: uniq("org") })
+    .returning();
+  const [user] = await dbWrite
+    .insert(users)
+    .values({ steward_user_id: uniq("steward"), organization_id: org.id })
+    .returning();
+  const [sandbox] = await dbWrite
+    .insert(agentSandboxes)
+    .values({
+      organization_id: org.id,
+      user_id: user.id,
+      agent_name: uniq("agent"),
+      status: "running",
+    })
+    .returning();
+  return sandbox.id;
+}
+
+function sampleState(marker: string): AgentBackupStateData {
+  return {
+    memories: [{ role: "user", text: `remember ${marker}`, timestamp: 1_700_000_000_000 }],
+    config: { marker },
+    workspaceFiles: { "notes.txt": `notes for ${marker}` },
+  };
+}
+
+async function seedFullBackup(
+  sandboxRecordId: string,
+  state: AgentBackupStateData,
+  overrides: { contentHash?: string | null } = {},
+): Promise<string> {
+  const backup = await agentSandboxesRepository.createBackup({
+    sandbox_record_id: sandboxRecordId,
+    snapshot_type: "auto",
+    state_data: state,
+    size_bytes: 1024,
+    backup_kind: "full",
+    content_hash:
+      overrides.contentHash === undefined ? computeStateHash(state) : overrides.contentHash,
+  });
+  return backup.id;
+}
+
+async function readBackupRow(backupId: string) {
+  const [row] = await dbWrite
+    .select()
+    .from(agentSandboxBackups)
+    .where(eq(agentSandboxBackups.id, backupId))
+    .limit(1);
+  if (!row) throw new Error(`backup row ${backupId} not found`);
+  return row;
+}
+
+// ---------------------------------------------------------------------------
+// Independent manifest-fixture hashing. Deliberately NOT the verifier's own
+// helpers: the test computes the producer-side hashes with its own sha256 +
+// sorted-key canonical JSON (the scheme from packages/agent/src/services/
+// agent-backup.ts), so the verifier is cross-checked against a second
+// implementation instead of against itself.
+// ---------------------------------------------------------------------------
+
+function fixtureCanonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(fixtureCanonicalize);
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      out[key] = fixtureCanonicalize((value as Record<string, unknown>)[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
+function fixtureSha256(bytes: Buffer | string): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function fixtureSha256Json(value: unknown): string {
+  return fixtureSha256(JSON.stringify(fixtureCanonicalize(value)));
+}
+
+function fixtureFileEntry(path: string, content: string): AgentBackupFileEntry {
+  const bytes = Buffer.from(content, "utf8");
+  return {
+    path,
+    sha256: fixtureSha256(bytes),
+    size: bytes.length,
+    bytesBase64: bytes.toString("base64"),
+  };
+}
+
+function fixtureFileSet(files: AgentBackupFileEntry[]): AgentBackupFileSet {
+  return {
+    kind: "file-set",
+    rootLabel: "state-dir",
+    files,
+    sha256: fixtureSha256Json(files.map(({ path, sha256, size }) => ({ path, sha256, size }))),
+  };
+}
+
+function fixtureManifest(agentId: string): AgentBackupManifest {
+  const media = fixtureFileSet([fixtureFileEntry("avatar.png", "png-bytes")]);
+  const vault = fixtureFileSet([fixtureFileEntry("vault.json", '{"secrets":true}')]);
+  const stateFiles = fixtureFileSet([fixtureFileEntry("eliza.json", '{"agents":{}}')]);
+  const pglite = fixtureFileSet([fixtureFileEntry("pglite/PG_VERSION", "16")]);
+  const database = { kind: "pglite-files" as const, pglite, sha256: pglite.sha256 };
+  const runtimeCharacter = { name: "Verify Me", bio: ["backup verification fixture"] };
+  const character = {
+    runtimeCharacter,
+    sha256: fixtureSha256Json({ runtimeCharacter, configFile: undefined }),
+  };
+  return {
+    schemaVersion: 1,
+    format: "elizaos.agent-backup",
+    createdAt: new Date("2026-07-01T00:00:00Z").toISOString(),
+    agentId,
+    components: { database, media, vault, character, stateFiles },
+    integrity: {
+      componentHashes: {
+        database: database.sha256,
+        media: media.sha256,
+        vault: vault.sha256,
+        character: character.sha256,
+        stateFiles: stateFiles.sha256,
+      },
+    },
+  };
+}
+
+beforeAll(async () => {
+  if (!CAN_USE_ISOLATED_PGLITE) {
+    pgliteReady = false;
+    console.warn(
+      "[agent-backup-verifier.test] DATABASE_URL is a non-PGlite Postgres (shared CI DB); this in-process-PGlite isolation suite self-skips — drizzle-kit pushSchema against a shared connection crashes the bun runner and would mutate the shared schema.",
+    );
+    return;
+  }
+  try {
+    const schema = { organizations, users, userCharacters, agentSandboxes, agentSandboxBackups };
+    const { apply } = await pushSchema(schema as never, dbWrite as never);
+    await apply();
+  } catch (error) {
+    pgliteReady = false;
+    console.error(
+      "[agent-backup-verifier.test] PGlite/pushSchema unavailable — cannot drive the backup verifier against a real DB. Skipping all cases.",
+      error,
+    );
+  }
+}, PGLITE_TIMEOUT);
+
+beforeEach(async () => {
+  if (!pgliteReady) return;
+  await dbWrite.delete(agentSandboxBackups);
+  await dbWrite.delete(agentSandboxes);
+});
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests();
+});
+
+describe("readBackupVerifierConfig", () => {
+  test("defaults: enabled, batch 10, 24h re-verify, 50% escalation", () => {
+    const config = readBackupVerifierConfig({} as NodeJS.ProcessEnv);
+    expect(config.enabled).toBe(true);
+    expect(config.batchSize).toBe(10);
+    expect(config.reVerifyIntervalMs).toBe(24 * 3_600_000);
+    expect(config.escalationThresholdPct).toBe(50);
+  });
+
+  test("opt-out flag and tunables parse; garbage falls back to defaults", () => {
+    expect(
+      readBackupVerifierConfig({ BACKUP_VERIFICATION_ENABLED: "0" } as NodeJS.ProcessEnv).enabled,
+    ).toBe(false);
+    expect(
+      readBackupVerifierConfig({ BACKUP_VERIFICATION_ENABLED: "false" } as NodeJS.ProcessEnv)
+        .enabled,
+    ).toBe(false);
+    const tuned = readBackupVerifierConfig({
+      BACKUP_VERIFICATION_BATCH_SIZE: "3",
+      BACKUP_VERIFICATION_REVERIFY_HOURS: "6",
+      BACKUP_VERIFICATION_ESCALATION_PCT: "80",
+    } as NodeJS.ProcessEnv);
+    expect(tuned.batchSize).toBe(3);
+    expect(tuned.reVerifyIntervalMs).toBe(6 * 3_600_000);
+    expect(tuned.escalationThresholdPct).toBe(80);
+    const garbage = readBackupVerifierConfig({
+      BACKUP_VERIFICATION_BATCH_SIZE: "-5",
+      BACKUP_VERIFICATION_REVERIFY_HOURS: "banana",
+    } as NodeJS.ProcessEnv);
+    expect(garbage.batchSize).toBe(10);
+    expect(garbage.reVerifyIntervalMs).toBe(24 * 3_600_000);
+  });
+});
+
+describe("classifyCryptoError", () => {
+  test("KeyNotFoundError → key-unavailable (the #15310 signature)", () => {
+    const error = new Error("key not found: org:abc/dek v1");
+    error.name = "KeyNotFoundError";
+    expect(classifyCryptoError(error)?.kind).toBe("key-unavailable");
+  });
+
+  test("AEAD auth failure → decrypt-failed", () => {
+    const error = new Error(
+      "AEAD decrypt failed: Unsupported state or unable to authenticate data",
+    );
+    error.name = "AeadError";
+    expect(classifyCryptoError(error)?.kind).toBe("decrypt-failed");
+  });
+
+  test("unrelated errors are NOT classified (infra breakage must not stamp rows)", () => {
+    expect(classifyCryptoError(new Error("connection terminated unexpectedly"))).toBeNull();
+    expect(classifyCryptoError("boom")).toBeNull();
+  });
+});
+
+describe("runBackupVerificationCycle (real PGlite + real memory KMS)", () => {
+  test("happy path: decrypts, matches content_hash, stamps verified, no alert", async () => {
+    if (!pgliteReady) return;
+    const sandboxId = await seedSandbox();
+    const backupId = await seedFullBackup(sandboxId, sampleState("happy"));
+    const { alerts, alert } = makeAlertSpy();
+
+    const summary = await runBackupVerificationCycle({ config: CONFIG, alert });
+
+    expect(summary).toMatchObject({ sampled: 1, verified: 1, failed: 0, errored: 0 });
+    const row = await readBackupRow(backupId);
+    expect(row.verification_status).toBe("verified");
+    expect(row.verified_at).not.toBeNull();
+    expect(row.verification_error).toBeNull();
+    expect(alerts).toHaveLength(0);
+  });
+
+  test("manifest-bearing backup: per-file + component hashes validated", async () => {
+    if (!pgliteReady) return;
+    const sandboxId = await seedSandbox();
+    const state: AgentBackupStateData = {
+      ...sampleState("manifest"),
+      manifest: fixtureManifest(sandboxId),
+    };
+    const backupId = await seedFullBackup(sandboxId, state);
+
+    const result = await verifyBackupRestorability(await readBackupRow(backupId));
+
+    expect(result.ok).toBe(true);
+    expect(result.checks).toEqual({
+      decrypted: true,
+      contentHashChecked: true,
+      manifestChecked: true,
+    });
+  });
+
+  test("manifest whose file bytes do not match its claimed sha256 fails as hash-mismatch", async () => {
+    if (!pgliteReady) return;
+    const sandboxId = await seedSandbox();
+    const manifest = fixtureManifest(sandboxId);
+    // The capture lied: claimed hash for real bytes it never had.
+    manifest.components.media.files[0].sha256 = fixtureSha256("different bytes entirely");
+    const state: AgentBackupStateData = { ...sampleState("bad-manifest"), manifest };
+    const backupId = await seedFullBackup(sandboxId, state);
+    const { alerts, alert } = makeAlertSpy();
+
+    const summary = await runBackupVerificationCycle({ config: CONFIG, alert });
+
+    expect(summary.failed).toBe(1);
+    expect(summary.failures[0].kind).toBe("hash-mismatch");
+    const row = await readBackupRow(backupId);
+    expect(row.verification_status).toBe("failed");
+    expect(row.verification_error).toStartWith("hash-mismatch:");
+    expect(row.verification_error).toContain("media/avatar.png");
+    expect(alerts.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("corrupted ciphertext: AEAD failure is stamped decrypt-failed and alerts fire", async () => {
+    if (!pgliteReady) return;
+    const sandboxId = await seedSandbox();
+    const backupId = await seedFullBackup(sandboxId, sampleState("corrupt"));
+
+    // Bit-rot the stored envelope in place: same shape, tampered ciphertext.
+    const stored = await readBackupRow(backupId);
+    const envelope = stored.state_data as EncryptedAgentBackupStateData;
+    expect(envelope.kind).toBe("encrypted-agent-backup-state");
+    const tampered =
+      (envelope.ciphertext.startsWith("AAAAAAAA") ? "BBBBBBBB" : "AAAAAAAA") +
+      envelope.ciphertext.slice(8);
+    await dbWrite
+      .update(agentSandboxBackups)
+      .set({ state_data: { ...envelope, ciphertext: tampered } })
+      .where(eq(agentSandboxBackups.id, backupId));
+
+    const { alerts, alert } = makeAlertSpy();
+    const summary = await runBackupVerificationCycle({ config: CONFIG, alert });
+
+    expect(summary.failed).toBe(1);
+    expect(summary.failures[0].kind).toBe("decrypt-failed");
+    const row = await readBackupRow(backupId);
+    expect(row.verification_status).toBe("failed");
+    expect(row.verification_error).toStartWith("decrypt-failed:");
+    expect(row.verification_error).toContain("AEAD decrypt failed");
+    // 1/1 failed ≥ 50% threshold → both the failure alert and the systemic
+    // escalation fire, on distinct dedup keys.
+    expect(summary.escalated).toBe(true);
+    expect(alerts.map((a) => a.dedupKey)).toEqual([
+      "agent-backup-verification-failure",
+      "agent-backup-verification-systemic",
+    ]);
+  });
+
+  test("wrong KMS key (fresh memory backend, #15310): key-unavailable + systemic escalation", async () => {
+    if (!pgliteReady) return;
+    const sandboxA = await seedSandbox();
+    const sandboxB = await seedSandbox();
+    const backupA = await seedFullBackup(sandboxA, sampleState("kms-a"));
+    const backupB = await seedFullBackup(sandboxB, sampleState("kms-b"));
+
+    // Reproduce the incident: the memory backend "restarts" and every key it
+    // held is gone. The ciphertext rows are intact; only the keys vanished.
+    resetKmsClientForTests();
+
+    const { alerts, alert } = makeAlertSpy();
+    const summary = await runBackupVerificationCycle({ config: CONFIG, alert });
+
+    expect(summary).toMatchObject({ sampled: 2, verified: 0, failed: 2 });
+    expect(summary.failures.map((f) => f.kind)).toEqual(["key-unavailable", "key-unavailable"]);
+    for (const backupId of [backupA, backupB]) {
+      const row = await readBackupRow(backupId);
+      expect(row.verification_status).toBe("failed");
+      expect(row.verification_error).toStartWith("key-unavailable:");
+    }
+    expect(summary.escalated).toBe(true);
+    const systemic = alerts.find((a) => a.dedupKey === "agent-backup-verification-systemic");
+    expect(systemic).toBeDefined();
+    expect(systemic?.message).toContain("KMS misconfiguration");
+    expect(systemic?.details.keyUnavailable).toBe(2);
+  });
+
+  test("content_hash drift on an otherwise-decryptable backup is stamped hash-mismatch", async () => {
+    if (!pgliteReady) return;
+    const sandboxId = await seedSandbox();
+    const backupId = await seedFullBackup(sandboxId, sampleState("drift"), {
+      contentHash: computeStateHash(sampleState("some other state")),
+    });
+    const { alerts, alert } = makeAlertSpy();
+
+    const summary = await runBackupVerificationCycle({ config: CONFIG, alert });
+
+    expect(summary.failed).toBe(1);
+    expect(summary.failures[0].kind).toBe("hash-mismatch");
+    const row = await readBackupRow(backupId);
+    expect(row.verification_error).toStartWith("hash-mismatch: content_hash");
+    expect(alerts.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("legacy row without content_hash still verifies decryptability (hash check skipped)", async () => {
+    if (!pgliteReady) return;
+    const sandboxId = await seedSandbox();
+    const backupId = await seedFullBackup(sandboxId, sampleState("legacy"), { contentHash: null });
+
+    const result = await verifyBackupRestorability(await readBackupRow(backupId));
+
+    expect(result.ok).toBe(true);
+    expect(result.checks.decrypted).toBe(true);
+    expect(result.checks.contentHashChecked).toBe(false);
+  });
+
+  test("incremental backup: chain replays through the parent and verifies the reconstructed hash", async () => {
+    if (!pgliteReady) return;
+    const sandboxId = await seedSandbox();
+    const base = sampleState("chain-base");
+    const next: AgentBackupStateData = {
+      memories: [
+        ...base.memories,
+        { role: "agent", text: "delta memory", timestamp: 1_700_000_100_000 },
+      ],
+      config: { ...base.config, added: true },
+      workspaceFiles: { ...base.workspaceFiles, "new.txt": "delta file" },
+    };
+    const parentId = await seedFullBackup(sandboxId, base);
+    const incremental = await agentSandboxesRepository.createBackup({
+      sandbox_record_id: sandboxId,
+      snapshot_type: "auto",
+      state_data: diffBackupState(base, next),
+      size_bytes: 256,
+      backup_kind: "incremental",
+      parent_backup_id: parentId,
+      content_hash: computeStateHash(next),
+      // Ensure the incremental is strictly newer so DISTINCT ON picks it.
+      created_at: new Date(Date.now() + 1_000),
+    });
+    const { alerts, alert } = makeAlertSpy();
+
+    const summary = await runBackupVerificationCycle({ config: CONFIG, alert });
+
+    // Only the NEWEST backup per agent is sampled; verifying it transitively
+    // decrypts the parent it restores from.
+    expect(summary).toMatchObject({ sampled: 1, verified: 1, failed: 0 });
+    expect((await readBackupRow(incremental.id)).verification_status).toBe("verified");
+    expect((await readBackupRow(parentId)).verification_status).toBeNull();
+    expect(alerts).toHaveLength(0);
+  });
+
+  test("incremental backup with a corrupted PARENT fails: the restore chain is dead", async () => {
+    if (!pgliteReady) return;
+    const sandboxId = await seedSandbox();
+    const base = sampleState("chain-corrupt");
+    const next: AgentBackupStateData = { ...base, config: { ...base.config, changed: 1 } };
+    const parentId = await seedFullBackup(sandboxId, base);
+    const incremental = await agentSandboxesRepository.createBackup({
+      sandbox_record_id: sandboxId,
+      snapshot_type: "auto",
+      state_data: diffBackupState(base, next),
+      size_bytes: 256,
+      backup_kind: "incremental",
+      parent_backup_id: parentId,
+      content_hash: computeStateHash(next),
+      created_at: new Date(Date.now() + 1_000),
+    });
+
+    const parentRow = await readBackupRow(parentId);
+    const envelope = parentRow.state_data as EncryptedAgentBackupStateData;
+    const tampered =
+      (envelope.ciphertext.startsWith("AAAAAAAA") ? "BBBBBBBB" : "AAAAAAAA") +
+      envelope.ciphertext.slice(8);
+    await dbWrite
+      .update(agentSandboxBackups)
+      .set({ state_data: { ...envelope, ciphertext: tampered } })
+      .where(eq(agentSandboxBackups.id, parentId));
+
+    const { alert } = makeAlertSpy();
+    const summary = await runBackupVerificationCycle({ config: CONFIG, alert });
+
+    expect(summary.failed).toBe(1);
+    expect(summary.failures[0].backupId).toBe(incremental.id);
+    expect(summary.failures[0].kind).toBe("decrypt-failed");
+  });
+
+  test("fleet-coverage sampling honors the re-verify interval and newest-per-agent", async () => {
+    if (!pgliteReady) return;
+    const sandboxA = await seedSandbox();
+    const sandboxB = await seedSandbox();
+    // Agent A has an OLD unverified backup and a NEW recently-verified one;
+    // agent B has one never-verified backup.
+    await seedFullBackup(sandboxA, sampleState("a-old"));
+    const aNewId = await agentSandboxesRepository
+      .createBackup({
+        sandbox_record_id: sandboxA,
+        snapshot_type: "auto",
+        state_data: sampleState("a-new"),
+        size_bytes: 512,
+        backup_kind: "full",
+        content_hash: computeStateHash(sampleState("a-new")),
+        created_at: new Date(Date.now() + 1_000),
+      })
+      .then((b) => b.id);
+    const bId = await seedFullBackup(sandboxB, sampleState("b"));
+
+    const now = new Date();
+    await dbWrite
+      .update(agentSandboxBackups)
+      .set({ verification_status: "verified", verified_at: now })
+      .where(eq(agentSandboxBackups.id, aNewId));
+
+    const { alert } = makeAlertSpy();
+    // Within the interval: only agent B's never-verified backup is due. Agent
+    // A's OLD backup must not be sampled either — only the newest per agent.
+    const first = await runBackupVerificationCycle({ config: CONFIG, alert, now: () => now });
+    expect(first).toMatchObject({ sampled: 1, verified: 1, failed: 0 });
+    expect((await readBackupRow(bId)).verification_status).toBe("verified");
+
+    // Once the re-verify interval elapses, agent A's newest is due again.
+    const later = new Date(now.getTime() + CONFIG.reVerifyIntervalMs + 60_000);
+    const second = await runBackupVerificationCycle({ config: CONFIG, alert, now: () => later });
+    expect(second.sampled).toBe(2);
+    expect(second.verified).toBe(2);
+    const aNewRow = await readBackupRow(aNewId);
+    expect(aNewRow.verified_at?.getTime()).toBe(later.getTime());
+  });
+
+  test("batch size bounds a cycle; the next cycle picks up the remainder", async () => {
+    if (!pgliteReady) return;
+    for (let i = 0; i < 3; i++) {
+      const sandboxId = await seedSandbox();
+      await seedFullBackup(sandboxId, sampleState(`batch-${i}`));
+    }
+    const config = { ...CONFIG, batchSize: 2 };
+    const { alert } = makeAlertSpy();
+
+    const first = await runBackupVerificationCycle({ config, alert });
+    expect(first.sampled).toBe(2);
+    const second = await runBackupVerificationCycle({ config, alert });
+    expect(second.sampled).toBe(1);
+    const rows = await dbWrite
+      .select()
+      .from(agentSandboxBackups)
+      .orderBy(desc(agentSandboxBackups.created_at));
+    expect(rows.every((r) => r.verification_status === "verified")).toBe(true);
+  });
+
+  test("disabled config is a no-op", async () => {
+    if (!pgliteReady) return;
+    const sandboxId = await seedSandbox();
+    const backupId = await seedFullBackup(sandboxId, sampleState("disabled"));
+    const { alerts, alert } = makeAlertSpy();
+
+    const summary = await runBackupVerificationCycle({
+      config: { ...CONFIG, enabled: false },
+      alert,
+    });
+
+    expect(summary).toMatchObject({ enabled: false, sampled: 0 });
+    expect((await readBackupRow(backupId)).verification_status).toBeNull();
+    expect(alerts).toHaveLength(0);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/agent-backup-verifier.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-verifier.ts
@@ -1,0 +1,651 @@
+/**
+ * Continuous restorability verification for hosted-agent backups (#15603 B5).
+ *
+ * Staging ran `ELIZA_KMS_BACKEND=memory` for weeks; every 6-hourly backup in
+ * `agent_sandbox_backups` was permanently undecryptable and nobody noticed
+ * until restores failed with "AEAD decrypt failed" (#15310). A boot-refusal on
+ * the ephemeral backend now exists, but nothing proved that ALREADY-STORED
+ * backups remain decryptable with the CURRENT keys after rotations, repoints,
+ * or storage bit-rot. This module closes that gap: the provisioning-worker
+ * daemon calls `runBackupVerificationCycle` on its infra-maintenance cadence;
+ * each cycle samples the newest backup per agent (bounded batch, re-verify
+ * interval so the fleet is covered over time), decrypts the payload with the
+ * real KMS, reconstructs incremental chains, and validates the row's
+ * `content_hash` plus the full-agent manifest's per-file/per-component sha256s.
+ *
+ * What verification proves: key availability + AEAD integrity for the stored
+ * ciphertext, chain reconstructability, and hash-consistency of the decrypted
+ * artifacts. What it does NOT prove: that a container restored from the state
+ * would boot — there is deliberately no restore into a sandbox and no write to
+ * any agent state; the only writes are the verification stamps on the backup
+ * row itself.
+ *
+ * Failures are stamped on the row (`verification_status` / `verified_at` /
+ * `verification_error`), logged at ERROR, and routed through the same ops
+ * alert channels as the daemon heartbeat monitor
+ * (`provisioning-worker-health-monitor.ts`). When a cycle's failure rate
+ * crosses the escalation threshold — the fleet-wide signature of a KMS
+ * misconfiguration — a separate, louder alert fires.
+ *
+ * Manifest hashing here intentionally mirrors the producer in
+ * `packages/agent/src/services/agent-backup.ts` (canonical sorted-key JSON →
+ * sha256). Cloud-shared cannot import that package, so the canonicalization is
+ * reimplemented; if the producer's hash shapes change, this verifier must
+ * change in lockstep or the fleet will page with hash-mismatch failures.
+ */
+
+import { createHash } from "node:crypto";
+import { desc, eq, isNull, lt, or, sql } from "drizzle-orm";
+import {
+  decryptAgentBackupStateData,
+  isEncryptedAgentBackupStateData,
+} from "../../db/crypto/agent-backups";
+import { dbRead, dbWrite } from "../../db/helpers";
+import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
+import {
+  type AgentBackupFileEntry,
+  type AgentBackupFileSet,
+  type AgentBackupManifest,
+  type AgentBackupStateData,
+  type AgentBackupStoredStateData,
+  agentSandboxBackups,
+  type StoredAgentSandboxBackup,
+} from "../../db/schemas/agent-sandboxes";
+import { getObjectText, shouldUseObjectStorage } from "../storage/object-store";
+import { logger } from "../utils/logger";
+import { computeStateHash, requireBackupStateData } from "./agent-backup-diff";
+import {
+  type DaemonHealthAlert,
+  sendProvisioningWorkerAlert,
+} from "./provisioning-worker-health-monitor";
+
+// =============================================================================
+// Config
+// =============================================================================
+
+export interface BackupVerifierConfig {
+  /** `BACKUP_VERIFICATION_ENABLED` — opt-out flag; anything but `0`/`false` is on. */
+  enabled: boolean;
+  /**
+   * `BACKUP_VERIFICATION_BATCH_SIZE` — backups verified per cycle. Kept small
+   * because each verification decrypts (and for incrementals chain-replays) a
+   * potentially R2-offloaded payload inside the daemon's bounded infra phase.
+   */
+  batchSize: number;
+  /**
+   * `BACKUP_VERIFICATION_REVERIFY_HOURS` — a backup verified (or failed) more
+   * recently than this is not re-sampled. Governs fleet coverage cadence AND
+   * keeps a persistently-broken backup from re-alerting every cycle.
+   */
+  reVerifyIntervalMs: number;
+  /**
+   * `BACKUP_VERIFICATION_ESCALATION_PCT` — when at least this percentage of a
+   * cycle's sample fails, the systemic escalation alert fires (the every-backup-
+   * fails signature of a KMS misconfiguration, #15310).
+   */
+  escalationThresholdPct: number;
+}
+
+const DEFAULT_BATCH_SIZE = 10;
+const DEFAULT_REVERIFY_HOURS = 24;
+const DEFAULT_ESCALATION_PCT = 50;
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function parseBooleanDefaultTrue(value: string | undefined): boolean {
+  if (value === undefined) return true;
+  const normalized = value.trim().toLowerCase();
+  return normalized !== "0" && normalized !== "false";
+}
+
+export function readBackupVerifierConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): BackupVerifierConfig {
+  return {
+    enabled: parseBooleanDefaultTrue(env.BACKUP_VERIFICATION_ENABLED),
+    batchSize: parsePositiveInt(env.BACKUP_VERIFICATION_BATCH_SIZE, DEFAULT_BATCH_SIZE),
+    reVerifyIntervalMs:
+      parsePositiveInt(env.BACKUP_VERIFICATION_REVERIFY_HOURS, DEFAULT_REVERIFY_HOURS) * 3_600_000,
+    escalationThresholdPct: parsePositiveInt(
+      env.BACKUP_VERIFICATION_ESCALATION_PCT,
+      DEFAULT_ESCALATION_PCT,
+    ),
+  };
+}
+
+// =============================================================================
+// Failure classification
+// =============================================================================
+
+/**
+ * Why a backup failed verification. `key-unavailable` is the #15310 signature —
+ * the KMS no longer has the key the row was encrypted under (ephemeral backend
+ * bounced, root key rotated without re-wrap, wrong KMS pointed at). AEAD auth
+ * failures cannot distinguish corrupted ciphertext from wrong key MATERIAL under
+ * the same key id, so both classify as `decrypt-failed`.
+ */
+export type BackupVerificationFailureKind =
+  | "key-unavailable"
+  | "decrypt-failed"
+  | "payload-missing"
+  | "invalid-payload"
+  | "chain-broken"
+  | "hash-mismatch";
+
+export interface BackupVerificationFailure {
+  kind: BackupVerificationFailureKind;
+  message: string;
+}
+
+export interface BackupVerificationResult {
+  ok: boolean;
+  failure?: BackupVerificationFailure;
+  checks: {
+    /** The stored payload decrypted under the current KMS keys. */
+    decrypted: boolean;
+    /** `content_hash` was present and matched the reconstructed state. */
+    contentHashChecked: boolean;
+    /** A full-agent manifest was present and its hashes all matched. */
+    manifestChecked: boolean;
+  };
+}
+
+/**
+ * Map a KMS/crypto throw to a verification failure, or null when the error is
+ * not a recognized crypto failure (caller treats it as verifier infrastructure
+ * breakage, which must NOT be stamped on the backup row).
+ */
+export function classifyCryptoError(error: unknown): BackupVerificationFailure | null {
+  if (!(error instanceof Error)) return null;
+  if (error.name === "KeyNotFoundError" || /key not found/i.test(error.message)) {
+    return { kind: "key-unavailable", message: error.message };
+  }
+  if (error.name === "AeadError" || /AEAD decrypt failed/i.test(error.message)) {
+    return { kind: "decrypt-failed", message: error.message };
+  }
+  return null;
+}
+
+/** Chain-reconstruction failures thrown by the repository/diff layer. */
+function classifyChainError(error: unknown): BackupVerificationFailure | null {
+  const crypto = classifyCryptoError(error);
+  if (crypto) return crypto;
+  if (!(error instanceof Error)) return null;
+  if (/payload not found|missing state_data_key/i.test(error.message)) {
+    return { kind: "payload-missing", message: error.message };
+  }
+  if (
+    /backup chain|has no parent|did not contain|mid-reconstruct|reached before a full backup/i.test(
+      error.message,
+    )
+  ) {
+    return { kind: "chain-broken", message: error.message };
+  }
+  return null;
+}
+
+// =============================================================================
+// Manifest hash validation (mirror of packages/agent/src/services/agent-backup.ts)
+// =============================================================================
+
+type JsonRecord = Record<string, unknown>;
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object") {
+    const out: JsonRecord = {};
+    for (const key of Object.keys(value as JsonRecord).sort()) {
+      out[key] = canonicalize((value as JsonRecord)[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
+function sha256Bytes(bytes: Buffer | string): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function sha256Json(value: unknown): string {
+  return sha256Bytes(JSON.stringify(canonicalize(value)));
+}
+
+function verifyFileEntry(label: string, entry: AgentBackupFileEntry, mismatches: string[]): void {
+  const bytes = Buffer.from(entry.bytesBase64, "base64");
+  if (bytes.length !== entry.size) {
+    mismatches.push(`${label}/${entry.path}: size ${bytes.length} != manifest ${entry.size}`);
+  }
+  const actual = sha256Bytes(bytes);
+  if (actual !== entry.sha256) {
+    mismatches.push(`${label}/${entry.path}: sha256 ${actual} != manifest ${entry.sha256}`);
+  }
+}
+
+function verifyFileSet(label: string, fileSet: AgentBackupFileSet, mismatches: string[]): void {
+  for (const entry of fileSet.files) verifyFileEntry(label, entry, mismatches);
+  const expected = sha256Json(
+    fileSet.files.map(({ path, sha256, size }) => ({ path, sha256, size })),
+  );
+  if (expected !== fileSet.sha256) {
+    mismatches.push(`${label}: file-set sha256 ${expected} != manifest ${fileSet.sha256}`);
+  }
+}
+
+/**
+ * Newer agent images emit a `pglite-dump` database component the cloud-side
+ * manifest type predates; validate it structurally so those backups still get
+ * real hash coverage instead of a type-shaped blind spot.
+ */
+interface PgliteDumpLike {
+  kind: string;
+  compression: string;
+  file: AgentBackupFileEntry;
+  sha256: string;
+}
+
+function asPgliteDump(value: unknown): PgliteDumpLike | null {
+  if (!value || typeof value !== "object") return null;
+  const record = value as JsonRecord;
+  if (
+    typeof record.kind !== "string" ||
+    typeof record.compression !== "string" ||
+    typeof record.sha256 !== "string" ||
+    !record.file ||
+    typeof record.file !== "object"
+  ) {
+    return null;
+  }
+  return record as unknown as PgliteDumpLike;
+}
+
+/**
+ * Validate every recomputable hash in a full-agent backup manifest against the
+ * decrypted artifacts it describes. Returns human-readable mismatch strings
+ * (empty = manifest verified). The payload sits inside the AEAD envelope, so a
+ * mismatch here means the capture wrote inconsistent hashes or the hash scheme
+ * drifted — both must page before a restore trips over them.
+ */
+export function verifyManifestIntegrity(manifest: AgentBackupManifest): string[] {
+  const mismatches: string[] = [];
+  const { components, integrity } = manifest;
+
+  verifyFileSet("media", components.media, mismatches);
+  verifyFileSet("vault", components.vault, mismatches);
+  verifyFileSet("stateFiles", components.stateFiles, mismatches);
+
+  const database = components.database;
+  if (database.pglite) {
+    verifyFileSet("database.pglite", database.pglite, mismatches);
+    if (database.sha256 !== database.pglite.sha256) {
+      mismatches.push("database: component sha256 does not match its pglite file-set");
+    }
+  }
+  if (database.postgres) {
+    const expected = sha256Json(
+      database.postgres.tables.map(({ name, columns, rows }) => ({ name, columns, rows })),
+    );
+    if (expected !== database.postgres.sha256) {
+      mismatches.push(
+        `database.postgres: sha256 ${expected} != manifest ${database.postgres.sha256}`,
+      );
+    }
+    if (database.sha256 !== database.postgres.sha256) {
+      mismatches.push("database: component sha256 does not match its postgres dump");
+    }
+  }
+  const pgliteDump = asPgliteDump((database as JsonRecord).pgliteDump);
+  if (pgliteDump) {
+    verifyFileEntry("database.pgliteDump", pgliteDump.file, mismatches);
+    const expected = sha256Json({
+      kind: pgliteDump.kind,
+      compression: pgliteDump.compression,
+      file: {
+        path: pgliteDump.file.path,
+        sha256: pgliteDump.file.sha256,
+        size: pgliteDump.file.size,
+      },
+    });
+    if (expected !== pgliteDump.sha256) {
+      mismatches.push(`database.pgliteDump: sha256 ${expected} != manifest ${pgliteDump.sha256}`);
+    }
+    if (database.sha256 !== pgliteDump.sha256) {
+      mismatches.push("database: component sha256 does not match its pglite dump");
+    }
+  }
+
+  const character = components.character;
+  if (character.configFile)
+    verifyFileEntry("character.configFile", character.configFile, mismatches);
+  const expectedCharacter = sha256Json({
+    runtimeCharacter: character.runtimeCharacter,
+    configFile: character.configFile,
+  });
+  if (expectedCharacter !== character.sha256) {
+    mismatches.push(`character: sha256 ${expectedCharacter} != manifest ${character.sha256}`);
+  }
+
+  const componentSha256: Record<string, string> = {
+    database: components.database.sha256,
+    media: components.media.sha256,
+    vault: components.vault.sha256,
+    character: components.character.sha256,
+    stateFiles: components.stateFiles.sha256,
+  };
+  for (const [name, sha] of Object.entries(componentSha256)) {
+    if (integrity.componentHashes[name] !== sha) {
+      mismatches.push(
+        `integrity.componentHashes.${name} ${integrity.componentHashes[name]} != component ${sha}`,
+      );
+    }
+  }
+
+  return mismatches;
+}
+
+// =============================================================================
+// Single-row verification
+// =============================================================================
+
+/**
+ * Resolve the stored (still-encrypted) payload for a backup row. Inline rows
+ * carry it in `state_data`; offloaded rows fetch from object storage. Throws
+ * when the daemon host has NO object storage configured — that is verifier
+ * infrastructure breakage, not a bad backup, and must not stamp a failure.
+ */
+async function resolveStoredPayload(
+  row: StoredAgentSandboxBackup,
+): Promise<{ payload: AgentBackupStoredStateData } | { failure: BackupVerificationFailure }> {
+  if (row.state_data_storage !== "r2") return { payload: row.state_data };
+  if (!row.state_data_key) {
+    return {
+      failure: { kind: "payload-missing", message: "r2-stored backup has no state_data_key" },
+    };
+  }
+  if (!shouldUseObjectStorage()) {
+    throw new Error(
+      "backup payload is in object storage but no object storage is configured on this host",
+    );
+  }
+  const raw = await getObjectText(row.state_data_key);
+  if (raw === null) {
+    return {
+      failure: {
+        kind: "payload-missing",
+        message: `object storage returned no payload for ${row.state_data_key}`,
+      },
+    };
+  }
+  try {
+    return { payload: JSON.parse(raw) as AgentBackupStoredStateData };
+  } catch (error) {
+    return {
+      failure: {
+        kind: "invalid-payload",
+        message: `offloaded payload is not JSON: ${error instanceof Error ? error.message : String(error)}`,
+      },
+    };
+  }
+}
+
+/**
+ * Verify one stored backup row end to end: fetch payload → decrypt with the
+ * real KMS → reconstruct the full state (chain replay for incrementals) →
+ * validate `content_hash` and manifest hashes. Read-only against backup
+ * storage; never touches agent state. Throws only on verifier-infrastructure
+ * errors (DB/storage unreachable) — every backup-is-broken condition returns a
+ * classified failure instead.
+ */
+export async function verifyBackupRestorability(
+  row: StoredAgentSandboxBackup,
+): Promise<BackupVerificationResult> {
+  const checks = { decrypted: false, contentHashChecked: false, manifestChecked: false };
+  const fail = (failure: BackupVerificationFailure): BackupVerificationResult => ({
+    ok: false,
+    failure,
+    checks,
+  });
+
+  const resolved = await resolveStoredPayload(row);
+  if ("failure" in resolved) return fail(resolved.failure);
+
+  // Decrypt the sampled row itself. This is the check that would have caught
+  // #15310: it exercises the CURRENT KMS against ciphertext written earlier.
+  // Legacy plaintext rows (pre-encryption) pass through and are still
+  // hash-verified below.
+  let plain: Awaited<ReturnType<typeof decryptAgentBackupStateData>>;
+  if (isEncryptedAgentBackupStateData(resolved.payload)) {
+    try {
+      plain = await decryptAgentBackupStateData(row.id, resolved.payload);
+    } catch (error) {
+      const classified = classifyCryptoError(error);
+      if (classified) return fail(classified);
+      throw error;
+    }
+  } else {
+    plain = resolved.payload;
+  }
+  checks.decrypted = true;
+
+  // Reconstruct the full state a restore would apply. Incremental rows replay
+  // their parent chain through the repository (decrypting every ancestor —
+  // exactly the work a real restore performs, minus the container).
+  let state: AgentBackupStateData;
+  if (row.backup_kind === "incremental") {
+    try {
+      const reconstructed = await agentSandboxesRepository.getReconstructedBackupState(row.id);
+      if (!reconstructed) {
+        return fail({ kind: "chain-broken", message: "backup vanished during reconstruction" });
+      }
+      state = reconstructed;
+    } catch (error) {
+      const classified = classifyChainError(error);
+      if (classified) return fail(classified);
+      throw error;
+    }
+  } else {
+    try {
+      state = requireBackupStateData(plain, row.id);
+    } catch (error) {
+      return fail({
+        kind: "invalid-payload",
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  if (row.content_hash) {
+    const actual = computeStateHash(state);
+    if (actual !== row.content_hash) {
+      return fail({
+        kind: "hash-mismatch",
+        message: `content_hash ${row.content_hash} != reconstructed ${actual}`,
+      });
+    }
+    checks.contentHashChecked = true;
+  }
+
+  if (state.manifest) {
+    const mismatches = verifyManifestIntegrity(state.manifest);
+    if (mismatches.length > 0) {
+      return fail({
+        kind: "hash-mismatch",
+        message: `manifest integrity: ${mismatches.slice(0, 5).join("; ")}`,
+      });
+    }
+    checks.manifestChecked = true;
+  }
+
+  return { ok: true, checks };
+}
+
+// =============================================================================
+// Fleet sampling cycle
+// =============================================================================
+
+export interface BackupVerificationFailureRecord {
+  backupId: string;
+  sandboxRecordId: string;
+  kind: BackupVerificationFailureKind;
+  message: string;
+}
+
+export interface BackupVerificationCycleSummary {
+  enabled: boolean;
+  sampled: number;
+  verified: number;
+  failed: number;
+  /** Verifier-infrastructure errors — logged, NOT stamped as backup failures. */
+  errored: number;
+  escalated: boolean;
+  failures: BackupVerificationFailureRecord[];
+}
+
+const FAILURE_ALERT_DEDUP_KEY = "agent-backup-verification-failure";
+const SYSTEMIC_ALERT_DEDUP_KEY = "agent-backup-verification-systemic";
+
+/**
+ * Sample the newest backup per agent that has not been verified within the
+ * re-verify interval, verify each, stamp the outcome on the row, and alert on
+ * failures. Only the LATEST backup per sandbox is sampled because that is what
+ * a restore reaches for first (and incremental verification transitively
+ * exercises the ancestors it depends on).
+ *
+ * `now` and `alert` are injectable for tests; production uses the wall clock
+ * and the shared provisioning ops alert channels.
+ */
+export async function runBackupVerificationCycle(
+  deps: {
+    config?: BackupVerifierConfig;
+    now?: () => Date;
+    alert?: (alert: DaemonHealthAlert) => void | Promise<void>;
+  } = {},
+): Promise<BackupVerificationCycleSummary> {
+  const config = deps.config ?? readBackupVerifierConfig();
+  const alert = deps.alert ?? sendProvisioningWorkerAlert;
+  const summary: BackupVerificationCycleSummary = {
+    enabled: config.enabled,
+    sampled: 0,
+    verified: 0,
+    failed: 0,
+    errored: 0,
+    escalated: false,
+    failures: [],
+  };
+  if (!config.enabled) return summary;
+
+  const now = (deps.now ?? (() => new Date()))();
+  const cutoff = new Date(now.getTime() - config.reVerifyIntervalMs);
+
+  const latest = dbRead
+    .selectDistinctOn([agentSandboxBackups.sandbox_record_id])
+    .from(agentSandboxBackups)
+    .orderBy(agentSandboxBackups.sandbox_record_id, desc(agentSandboxBackups.created_at))
+    .as("latest_backup_per_agent");
+
+  const candidates = await dbRead
+    .select()
+    .from(latest)
+    .where(or(isNull(latest.verified_at), lt(latest.verified_at, cutoff)))
+    // Never-verified rows first, then the longest-stale, so the whole fleet
+    // converges to coverage instead of re-polishing recently-checked agents.
+    .orderBy(sql`${latest.verified_at} asc nulls first`, latest.created_at)
+    .limit(config.batchSize);
+
+  for (const row of candidates) {
+    summary.sampled += 1;
+    let result: BackupVerificationResult;
+    try {
+      result = await verifyBackupRestorability(row);
+    } catch (error) {
+      // error-policy:J7 diagnostics-must-not-kill-the-loop — verifier infra
+      // breakage (DB/object-storage unreachable) is logged loudly but must not
+      // stamp a healthy backup as failed nor abort the rest of the batch.
+      summary.errored += 1;
+      logger.error("[AgentBackupVerifier] verification errored (infrastructure, not stamped)", {
+        backupId: row.id,
+        sandboxRecordId: row.sandbox_record_id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      continue;
+    }
+
+    await dbWrite
+      .update(agentSandboxBackups)
+      .set({
+        verification_status: result.ok ? "verified" : "failed",
+        verified_at: now,
+        verification_error: result.ok
+          ? null
+          : `${result.failure?.kind}: ${result.failure?.message}`,
+      })
+      .where(eq(agentSandboxBackups.id, row.id));
+
+    if (result.ok) {
+      summary.verified += 1;
+      continue;
+    }
+
+    summary.failed += 1;
+    const failure = result.failure ?? { kind: "invalid-payload" as const, message: "unknown" };
+    summary.failures.push({
+      backupId: row.id,
+      sandboxRecordId: row.sandbox_record_id,
+      kind: failure.kind,
+      message: failure.message,
+    });
+    logger.error("[AgentBackupVerifier] backup failed restorability verification", {
+      backupId: row.id,
+      sandboxRecordId: row.sandbox_record_id,
+      snapshotType: row.snapshot_type,
+      backupKind: row.backup_kind,
+      createdAt: row.created_at.toISOString(),
+      failureKind: failure.kind,
+      error: failure.message,
+    });
+  }
+
+  if (summary.failed > 0) {
+    await alert({
+      title: `${summary.failed}/${summary.sampled} sampled agent backups are NOT restorable`,
+      message:
+        "Restorability verification decrypts stored agent backups with the current KMS keys " +
+        "and validates content hashes; these backups would fail a real restore. " +
+        "Failed rows are stamped in agent_sandbox_backups (verification_error).",
+      details: {
+        failures: summary.failures.slice(0, 10),
+        sampled: summary.sampled,
+        failed: summary.failed,
+      },
+      dedupKey: FAILURE_ALERT_DEDUP_KEY,
+    });
+
+    const failurePct = (summary.failed / summary.sampled) * 100;
+    if (failurePct >= config.escalationThresholdPct) {
+      summary.escalated = true;
+      const keyUnavailable = summary.failures.filter((f) => f.kind === "key-unavailable").length;
+      await alert({
+        title: "SYSTEMIC agent-backup verification failure — check KMS configuration",
+        message:
+          `${summary.failed}/${summary.sampled} (${failurePct.toFixed(0)}%) of this cycle's ` +
+          `sample failed (${keyUnavailable} key-unavailable). A fleet-wide failure is the ` +
+          "signature of a KMS misconfiguration (#15310: ephemeral memory backend silently " +
+          "orphaned every staging backup). Verify ELIZA_KMS_BACKEND and the root key on the " +
+          "hosts that WRITE backups before the retention window prunes the last good ones.",
+        details: {
+          sampled: summary.sampled,
+          failed: summary.failed,
+          keyUnavailable,
+          escalationThresholdPct: config.escalationThresholdPct,
+          failures: summary.failures.slice(0, 10),
+        },
+        dedupKey: SYSTEMIC_ALERT_DEDUP_KEY,
+      });
+    }
+  }
+
+  return summary;
+}

--- a/packages/cloud/shared/src/lib/services/provisioning-worker-health-monitor.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-worker-health-monitor.ts
@@ -40,10 +40,18 @@ const ALERT_PAGERDUTY_KEY_ENV = "PROVISIONING_ALERT_PAGERDUTY_KEY";
  */
 export const HEARTBEAT_MAX_AGE_MS = PROVISIONING_WORKER_HEARTBEAT_TTL_S * 1000;
 
-interface DaemonHealthAlert {
+/**
+ * Ops alert payload for daemon-domain failures. Also emitted by the backup
+ * restorability verifier (`agent-backup-verifier.ts`), which shares this
+ * module's alert channels; `dedupKey` keeps each failure domain a separate
+ * PagerDuty incident instead of collapsing into the heartbeat one.
+ */
+export interface DaemonHealthAlert {
   title: string;
   message: string;
   details: Record<string, unknown>;
+  /** PagerDuty dedup key. Defaults to the daemon-heartbeat incident key. */
+  dedupKey?: string;
 }
 
 /**
@@ -98,7 +106,7 @@ export async function sendProvisioningWorkerAlert(alert: DaemonHealthAlert): Pro
         body: JSON.stringify({
           routing_key: pagerDutyKey,
           event_action: "trigger",
-          dedup_key: "provisioning-worker-unhealthy",
+          dedup_key: alert.dedupKey ?? "provisioning-worker-unhealthy",
           payload: {
             summary: `[elizaOS Provisioning] ${alert.title}`,
             severity: "critical",

--- a/packages/scripts/cloud/admin/daemons/provisioning-worker.backup-verify.test.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker.backup-verify.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Daemon-phase wiring for the backup restorability verification cycle
+ * (#15603 B5): `processBackupVerificationCycle` must delegate to the shared
+ * `runBackupVerificationCycle` service and surface its summary unchanged. The
+ * verification behavior itself (real PGlite + real KMS) is pinned in
+ * `packages/cloud/shared/src/lib/services/agent-backup-verifier.test.ts`.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import {
+  __setDepsForTests,
+  processBackupVerificationCycle,
+} from "./provisioning-worker";
+
+afterEach(() => {
+  __setDepsForTests(null);
+});
+
+describe("processBackupVerificationCycle (daemon phase wiring)", () => {
+  test("delegates to runBackupVerificationCycle and returns its summary", async () => {
+    const summary = {
+      enabled: true,
+      sampled: 3,
+      verified: 2,
+      failed: 1,
+      errored: 0,
+      escalated: false,
+      failures: [
+        {
+          backupId: "b-1",
+          sandboxRecordId: "s-1",
+          kind: "key-unavailable" as const,
+          message: "key not found: org:x/dek v1",
+        },
+      ],
+    };
+    const runBackupVerificationCycle = mock(async () => summary);
+    __setDepsForTests({ runBackupVerificationCycle } as unknown as Parameters<
+      typeof __setDepsForTests
+    >[0]);
+
+    const result = await processBackupVerificationCycle();
+
+    expect(runBackupVerificationCycle).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(summary);
+  });
+
+  test("propagates a service throw so runBoundedPhase can log-and-isolate it", async () => {
+    const runBackupVerificationCycle = mock(async () => {
+      throw new Error("database unreachable");
+    });
+    __setDepsForTests({ runBackupVerificationCycle } as unknown as Parameters<
+      typeof __setDepsForTests
+    >[0]);
+
+    await expect(processBackupVerificationCycle()).rejects.toThrow(
+      "database unreachable",
+    );
+  });
+});

--- a/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
@@ -57,6 +57,8 @@ type WorkerWithTimeout =
   typeof import("@elizaos/cloud-shared/lib/utils/with-timeout").withTimeout;
 type WorkerProcessNodeDiskCleanup =
   typeof import("@elizaos/cloud-shared/lib/services/node-disk-manager").processNodeDiskCleanup;
+type WorkerRunBackupVerificationCycle =
+  typeof import("@elizaos/cloud-shared/lib/services/agent-backup-verifier").runBackupVerificationCycle;
 
 interface PreflightKmsClient {
   getOrCreateKey(keyId: string): Promise<unknown>;
@@ -86,6 +88,7 @@ interface WorkerDeps {
   reconcileOrphanAppContainersOnNodes: WorkerReconcileOrphanAppContainers;
   withTimeout: WorkerWithTimeout;
   processNodeDiskCleanup: WorkerProcessNodeDiskCleanup;
+  runBackupVerificationCycle: WorkerRunBackupVerificationCycle;
 }
 
 export interface ProvisioningWorkerConfig {
@@ -244,6 +247,7 @@ async function loadDeps(): Promise<WorkerDeps> {
       ),
       import("@elizaos/cloud-shared/lib/utils/with-timeout"),
       import("@elizaos/cloud-shared/lib/services/node-disk-manager"),
+      import("@elizaos/cloud-shared/lib/services/agent-backup-verifier"),
     ]).then(
       ([
         jobsModule,
@@ -260,6 +264,7 @@ async function loadDeps(): Promise<WorkerDeps> {
         appOrphanReconcilerModule,
         withTimeoutModule,
         nodeDiskManagerModule,
+        backupVerifierModule,
       ]) => ({
         provisioningJobService: jobsModule.provisioningJobService,
         logger: loggerModule.logger,
@@ -279,6 +284,8 @@ async function loadDeps(): Promise<WorkerDeps> {
           appOrphanReconcilerModule.reconcileOrphanAppContainersOnNodes,
         withTimeout: withTimeoutModule.withTimeout,
         processNodeDiskCleanup: nodeDiskManagerModule.processNodeDiskCleanup,
+        runBackupVerificationCycle:
+          backupVerifierModule.runBackupVerificationCycle,
       }),
     );
   }
@@ -679,6 +686,25 @@ async function processNodeDiskCleanupCycle(): Promise<NodeDiskCleanupSummary> {
     pruned: report.pruned,
     pruneFailed: report.pruneFailed,
   };
+}
+
+/**
+ * Verify a bounded sample of stored agent backups is actually RESTORABLE with
+ * the current KMS keys (#15603 B5): decrypt the newest backup per agent,
+ * replay incremental chains, validate content/manifest hashes, stamp the
+ * outcome, and page on failure. Exists because staging ran a memory KMS for
+ * weeks and every backup rotted undecryptable until restores failed (#15310) —
+ * the startup preflight refuses that config going forward, but only this cycle
+ * proves the backups already on disk still decrypt. Read-only against backup
+ * storage; batch/interval/escalation are env-tunable in the verifier service
+ * (`BACKUP_VERIFICATION_*`, on by default). Exported for the daemon-phase
+ * wiring test.
+ */
+export async function processBackupVerificationCycle(): Promise<
+  Awaited<ReturnType<WorkerRunBackupVerificationCycle>>
+> {
+  const { runBackupVerificationCycle } = await loadDeps();
+  return runBackupVerificationCycle();
 }
 
 /**
@@ -1484,6 +1510,32 @@ async function runInfraMaintenanceCycle(
           pruned: summary.pruned,
           pruneFailed: summary.pruneFailed,
         });
+      }
+    },
+  );
+
+  // Backup restorability verification (#15603 B5). Off the watchdog critical
+  // path like every infra phase; self-gated by BACKUP_VERIFICATION_ENABLED and
+  // bounded to a small batch per sweep, so the KMS decrypts + object-storage
+  // reads it performs cannot starve node maintenance. Failures alert through
+  // the same ops channels as the daemon heartbeat monitor.
+  await runBoundedPhase(
+    logger,
+    "backup verification cycle",
+    () => processBackupVerificationCycle(),
+    (summary) => {
+      if (summary.sampled > 0 || summary.errored > 0) {
+        logger.info(
+          "[provisioning-worker] backup verification cycle complete",
+          {
+            event: "backup_verification.cycle",
+            sampled: summary.sampled,
+            verified: summary.verified,
+            failed: summary.failed,
+            errored: summary.errored,
+            escalated: summary.escalated,
+          },
+        );
       }
     },
   );


### PR DESCRIPTION
Work item **B5** of epic #15603.

## Why

#15310: staging ran `ELIZA_KMS_BACKEND=memory` for weeks. Every 6-hourly backup written to `agent_sandbox_backups` was encrypted under keys that evaporated on the next worker restart — **every backup was permanently undecryptable, and nobody noticed until restores failed with `AEAD decrypt failed`**. A boot-refusal on the ephemeral backend now exists (`assertKmsBackendDurable`, `isEphemeralKmsAllowed`), but that only prevents the *config*; nothing continuously proved that backups **already stored** remain restorable with the *current* KMS keys after rotations, DB repoints, or storage bit-rot.

## What

A scheduled backup-verification cycle in the provisioning-worker daemon:

- **Service** `packages/cloud/shared/src/lib/services/agent-backup-verifier.ts` — `runBackupVerificationCycle()`:
  - **Sampling:** `DISTINCT ON (sandbox_record_id)` newest backup per agent → filter `verified_at IS NULL OR verified_at < now - reverify_interval` → order never-verified first, then longest-stale → bounded batch. Over successive cycles the whole fleet converges to coverage; only the newest backup per agent is sampled because that is what a restore reaches for first (and incremental verification transitively decrypts every ancestor it depends on).
  - **Verification =** resolve payload (inline jsonb or R2 offload) → **decrypt with the real KMS** (proves key availability + AEAD integrity — the check that would have caught #15310) → replay incremental parent chains → validate the row's `content_hash` against the reconstructed state → validate the full-agent manifest's per-file and per-component sha256s over the decrypted artifacts.
  - **What it proves / doesn't:** proves the stored ciphertext decrypts under the current keys, the restore chain reconstructs, and the decrypted artifacts hash-match the manifest. It does **not** boot a container from the state — deliberately no restore into a sandbox, no writes to agent state; read-only against backup storage. The only writes are the verification stamps on the backup row.
  - **Failure classification:** `key-unavailable` (KMS key id/version gone — the #15310 signature), `decrypt-failed` (AEAD auth failure: corrupt ciphertext or wrong key material), `payload-missing`, `invalid-payload`, `chain-broken`, `hash-mismatch`. Verifier-infrastructure errors (DB/object-storage unreachable) are logged loudly but never stamped as backup failures.
- **Schema** (migration `0173_agent_backup_verification.sql` + `ensure-agent-sandbox-schema.ts` idempotent guard): three nullable columns on `agent_sandbox_backups` — `verification_status` (`verified`/`failed`), `verified_at` (last attempt; drives the re-verify interval), `verification_error` (classified failure for triage without a re-run).
- **Alerting:** every failure is a structured `logger.error` + one consolidated cycle alert through the **same ops channels as `provisioning-worker-health-monitor.ts`** (`PROVISIONING_ALERT_SLACK_WEBHOOK` / `PROVISIONING_ALERT_PAGERDUTY_KEY`; `DaemonHealthAlert` gained an optional `dedupKey` so backup incidents don't collapse into the heartbeat incident). When a cycle's failure rate ≥ `BACKUP_VERIFICATION_ESCALATION_PCT` (default 50%), a **separate systemic escalation** fires naming the KMS-misconfig signature.
- **Daemon wiring** (`packages/scripts/cloud/admin/daemons/provisioning-worker.ts`): `processBackupVerificationCycle` as a `runBoundedPhase` in the infra-maintenance sweep (every `WORKER_NODE_HEALTH_INTERVAL`, default 5 min) — off the watchdog critical path, error-isolated like every other phase.
- **Config** (documented in `packages/cloud/shared/.env.example`, **on by default**): `BACKUP_VERIFICATION_ENABLED` (opt-out), `BACKUP_VERIFICATION_BATCH_SIZE` (10), `BACKUP_VERIFICATION_REVERIFY_HOURS` (24), `BACKUP_VERIFICATION_ESCALATION_PCT` (50).

Manifest hashing intentionally mirrors the producer in `packages/agent/src/services/agent-backup.ts` (canonical sorted-key JSON → sha256); cloud-shared cannot import that package, so the module header pins the lockstep requirement. The test fixtures compute producer-side hashes with an *independent* implementation so the verifier is cross-checked, not self-checked.

## Test evidence

Real pipeline end to end: real Drizzle schema pushed to in-process PGlite, real memory KMS encrypting through `prepareAgentBackupInsertData`, real AEAD decryption, real sampling/stamping SQL. No mock stands in for the thing under test — the corrupted-ciphertext case tampers with the actual stored envelope; the wrong-KMS-key case actually resets the KMS client so the keys are gone (the #15310 failure mode reproduced).

<details>
<summary><code>bun test packages/cloud/shared/src/lib/services/agent-backup-verifier.test.ts</code> — 17 pass / 0 fail</summary>

```
src/lib/services/agent-backup-verifier.test.ts:
[AgentBackupVerifier] backup failed restorability verification {
  failureKind: "hash-mismatch",
  error: "manifest integrity: media/avatar.png: sha256 ea80…3f56 != manifest 7b4c…d791; media: file-set sha256 fba5…1dd1 != manifest 0af6…3a33",
}
[AgentBackupVerifier] backup failed restorability verification {
  failureKind: "decrypt-failed",
  error: "AEAD decrypt failed: Unsupported state or unable to authenticate data",
}
[AgentBackupVerifier] backup failed restorability verification {
  failureKind: "key-unavailable",
  error: "key not found: org:a7efe5eb-82a5-42f4-8bfe-c217113e6832/dek/v1",
}
[AgentBackupVerifier] backup failed restorability verification {
  failureKind: "key-unavailable",
  error: "key not found: org:b888faf1-dac1-47b9-9c6b-7c7364d658b0/dek/v1",
}
[AgentBackupVerifier] backup failed restorability verification {
  failureKind: "hash-mismatch",
  error: "content_hash 10e2…b4a7d != reconstructed 3344…a3988",
}
[AgentBackupVerifier] backup failed restorability verification {
  backupKind: "incremental",
  failureKind: "decrypt-failed",
  error: "AEAD decrypt failed: Unsupported state or unable to authenticate data",
}

 17 pass
 0 fail
 71 expect() calls
Ran 17 tests across 1 file. [3.83s]
```

Cases: config parsing (defaults / opt-out / garbage fallback); crypto-error classification; happy path stamps `verified` with no alert; manifest-bearing backup validates per-file + component hashes; manifest whose bytes don't match its claimed sha256 → `hash-mismatch` stamped + alert; **corrupted ciphertext → `decrypt-failed` stamped, failure alert + systemic escalation on distinct PagerDuty dedup keys**; **fresh memory KMS (keys gone, #15310) → `key-unavailable` on all rows + systemic escalation with `keyUnavailable` count**; `content_hash` drift → `hash-mismatch`; legacy row without `content_hash` still proves decryptability; incremental chain replays through its parent and verifies the reconstructed hash; **incremental with a corrupted parent fails (the restore chain is dead)**; sampling honors re-verify interval + newest-per-agent; batch size bounds a cycle and the next cycle picks up the remainder; disabled config is a no-op.

</details>

<details>
<summary>Daemon wiring + regression suites — 140 pass / 0 fail total</summary>

```
bun test packages/scripts/cloud/admin/daemons/provisioning-worker.backup-verify.test.ts \
         packages/scripts/cloud/admin/daemons/provisioning-worker.test.ts \
         packages/scripts/cloud/admin/daemons/provisioning-worker.replenish.test.ts \
         packages/cloud/shared/src/lib/services/provisioning-worker-health-monitor.test.ts
 59 pass / 0 fail (125 expect() calls)

bun test packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts \
         packages/cloud/shared/src/db/repositories/__tests__/agent-sandboxes-fleet-candidate-repo.test.ts \
         packages/cloud/shared/src/lib/services/agent-backup-diff.test.ts
 48 pass / 0 fail (177 expect() calls)

# post-rebase re-run of the new suites
 19 pass / 0 fail (74 expect() calls)
```

</details>

<details>
<summary>Migration proof — full chain incl. 0173 applies on a fresh database</summary>

```
$ DATABASE_URL="pglite://$(mktemp -d)/pgdata" bun run --cwd packages/cloud/shared db:migrate
[db:migrate] applying 0170_ad_spend_caps (1 statements)
[db:migrate] applying 0171_press_release_domain (1 statements)
[db:migrate] applying 0172_web_push_subscriptions (1 statements)
[db:migrate] applying 0173_agent_backup_verification (1 statements)
[db:migrate] migrations complete
```

Stamped rows (`verification_status` / `verified_at` / `verification_error`) are asserted directly against the DB in every test case above. Down-path: columns are nullable and additive; no data backfill.

</details>

<details>
<summary>Verify (typecheck / lint / ratchets)</summary>

```
bun run --cwd packages/cloud/shared typecheck   # no errors in touched files
bun run --cwd packages/cloud/shared lint        # Checked 1604 files. No fixes applied.
bun run audit:error-policy-ratchet             # no new fallback-slop in touched files
bun run audit:type-safety-ratchet              # green (baseline unchanged by this branch)
```

</details>

## Evidence N/A rows

- Video walkthrough: **N/A** — backend daemon cycle; no UI surface. Behavior is proven by the DB-stamped rows, structured logs, and alert payloads in the test evidence above.
- Before/after screenshots (desktop + mobile): **N/A** — no rendered surface changed.
- Frontend console/network logs: **N/A** — no frontend code touched.
- Real-LLM trajectories: **N/A** — no agent/action/provider/prompt/model behavior changed; this is infra verification of stored ciphertext.

🤖 Generated with [Claude Code](https://claude.com/claude-code)