### PR TITLE
fix(core): dedupe rewritten action callbacks

### DIFF
--- a/packages/core/src/__tests__/planner-happy-path.test.ts
+++ b/packages/core/src/__tests__/planner-happy-path.test.ts
@@ -11,7 +11,10 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS } from "../runtime/builtin-field-evaluators";
 import { ResponseHandlerFieldRegistry } from "../runtime/response-handler-field-registry";
-import { runV5MessageRuntimeStage1 } from "../services/message";
+import {
+	runV5MessageRuntimeStage1,
+	wrapSingleTurnVisibleCallback,
+} from "../services/message";
 import type {
 	Action,
 	ActionResult,
@@ -611,6 +614,90 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 				"Root disk: 65% used, 138G available. Biggest cleanup candidate: /home/example/.bun (19G).",
 			);
 		}
+	});
+
+	it("suppresses planner echo after an action callback is voice-rewritten", async () => {
+		const rawPayload = '{"status":"ok","taskId":"abc123"}';
+		const rewritten = "I created the task and kept its ID handy: abc123.";
+		const delivered: string[] = [];
+		const deliveredVisibleTexts = new Set<string>();
+		const action = makeMockAction({
+			name: "CREATE_TASK",
+			parameters: [],
+			handler: async (_runtime, _message, _state, _options, callback) => {
+				await callback?.({ text: rawPayload }, "CREATE_TASK");
+				return {
+					success: true,
+					text: rawPayload,
+					data: { actionName: "CREATE_TASK" },
+				};
+			},
+		});
+		const runtime = makeRuntime({
+			actions: [action],
+			responses: [
+				{
+					expectModelType: ModelType.RESPONSE_HANDLER,
+					body: stage1Response({
+						contexts: ["general"],
+						candidateActionNames: ["CREATE_TASK"],
+						thought: "Creating the task needs a tool.",
+					}),
+				},
+				{
+					expectModelType: ModelType.ACTION_PLANNER,
+					body: {
+						text: "Creating the task.",
+						toolCalls: [{ id: "call-1", name: "CREATE_TASK", args: {} }],
+					},
+				},
+				{
+					expectModelType: ModelType.TEXT_SMALL,
+					body: JSON.stringify({ response: rewritten }),
+				},
+				{
+					expectModelType: ModelType.RESPONSE_HANDLER,
+					body: JSON.stringify({
+						success: true,
+						decision: "FINISH",
+						thought: "The action callback already told the user.",
+						messageToUser: rewritten,
+					}),
+				},
+			],
+		});
+		const callback = vi.fn(async (content: { text?: string }) => {
+			if (content.text) delivered.push(content.text);
+			return [];
+		});
+		const wrappedCallback = wrapSingleTurnVisibleCallback(
+			runtime,
+			makeMessage("create that task"),
+			callback,
+			(text) => deliveredVisibleTexts.add(text.toLowerCase()),
+		);
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage("create that task"),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+			callback: wrappedCallback,
+			deliveredVisibleTexts,
+		});
+
+		expect(delivered).toEqual([rewritten]);
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind === "planned_reply") {
+			expect(result.result.responseContent).toBeNull();
+		}
+		expect(callback).toHaveBeenCalledTimes(1);
+		expect(getCalls(runtime).map((c) => c.modelType)).toEqual([
+			ModelType.RESPONSE_HANDLER,
+			ModelType.ACTION_PLANNER,
+			ModelType.TEXT_SMALL,
+			ModelType.RESPONSE_HANDLER,
+		]);
 	});
 
 	it("records terminal task failure separately from evaluator failures", async () => {

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -6236,6 +6236,7 @@ export async function runV5MessageRuntimeStage1(args: {
 	state: State;
 	responseId: UUID;
 	callback?: HandlerCallback;
+	deliveredVisibleTexts?: Set<string>;
 	plannerLoopConfig?: PlannerLoopParams["config"];
 	onResponseHandlerEarlyReply?: (
 		event: ResponseHandlerEarlyReplyEvent,
@@ -7205,22 +7206,13 @@ export async function runV5MessageRuntimeStage1(args: {
 			);
 
 		// Track visible text an action already delivered to the user through the
-		// callback during this planner run. An action that both emits its own
-		// user-facing callback AND leaves the planner to emit a `finalMessage`
-		// duplicating that text would otherwise deliver the same string twice (the
-		// action reply, then an identical "simple" planner reply). This mirrors the
-		// early-reply dedup below — the planner reply is suppressed only when it is
-		// an exact (normalized) repeat of what the user already saw.
-		const deliveredVisibleTexts = new Set<string>();
+		// callback during this planner run. The set is populated by the outer
+		// instrumented callback after voice rewrite / verbosity shaping, so it
+		// matches the string the connector actually sent.
+		const deliveredVisibleTexts =
+			args.deliveredVisibleTexts ?? new Set<string>();
 		const recordingCallback: HandlerCallback | undefined = args.callback
-			? async (content, ...rest) => {
-					if (typeof content?.text === "string" && content.text.trim()) {
-						deliveredVisibleTexts.add(
-							normalizeVisibleTextForDuplicateCheck(content.text),
-						);
-					}
-					return args.callback?.(content, ...rest) ?? [];
-				}
+			? async (content, ...rest) => args.callback?.(content, ...rest) ?? []
 			: undefined;
 
 		let plannerResult: PlannerLoopResult;
@@ -8468,15 +8460,22 @@ export function wrapSingleTurnVisibleCallback(
 		},
 	message: Pick<Memory, "id" | "roomId" | "entityId">,
 	callback?: HandlerCallback,
+	recordDeliveredVisibleText?: (text: string) => void,
 ): HandlerCallback | undefined {
 	if (!callback) return callback;
 	const fullRuntime = runtime as IAgentRuntime;
+	const deliver = async (response: Content, actionName?: string) => {
+		if (typeof response?.text === "string" && response.text.trim()) {
+			recordDeliveredVisibleText?.(response.text);
+		}
+		return callback(response, actionName);
+	};
 	// The character-voice rewrite spends a TEXT_SMALL call per action callback and
 	// restyles the delivered text. Deterministic harnesses (the scenario runner)
 	// assert the raw action-callback contract and strict-fixture every model call,
 	// so they opt out via ACTION_CALLBACK_VOICE_REWRITE=false; production turns
 	// leave it on by default.
-	if (!actionCallbackVoiceRewriteEnabled(fullRuntime)) return callback;
+	if (!actionCallbackVoiceRewriteEnabled(fullRuntime)) return deliver;
 	const voiceActionReply = async (
 		response: Content,
 		actionName?: string,
@@ -8514,7 +8513,7 @@ export function wrapSingleTurnVisibleCallback(
 
 	if (typeof fullRuntime.getService !== "function") {
 		return async (response, actionName) =>
-			callback(await voiceActionReply(response, actionName), actionName);
+			deliver(await voiceActionReply(response, actionName), actionName);
 	}
 	// Resolve verbosity once per turn — cheap because PersonalityStore is
 	// in-memory. Returning the original callback when no override is set
@@ -8522,7 +8521,7 @@ export function wrapSingleTurnVisibleCallback(
 	const store = getPersonalityStore(fullRuntime);
 	if (!store) {
 		return async (response, actionName) =>
-			callback(await voiceActionReply(response, actionName), actionName);
+			deliver(await voiceActionReply(response, actionName), actionName);
 	}
 	const userSlot =
 		message.entityId && message.entityId !== fullRuntime.agentId
@@ -8532,7 +8531,7 @@ export function wrapSingleTurnVisibleCallback(
 	const verbosity = userSlot?.verbosity ?? globalSlot?.verbosity ?? null;
 	if (verbosity !== "terse") {
 		return async (response, actionName) =>
-			callback(await voiceActionReply(response, actionName), actionName);
+			deliver(await voiceActionReply(response, actionName), actionName);
 	}
 
 	const wrapped: HandlerCallback = async (response, actionName) => {
@@ -8553,7 +8552,7 @@ export function wrapSingleTurnVisibleCallback(
 				response = { ...response, text: result.text };
 			}
 		}
-		return callback(response, actionName);
+		return deliver(response, actionName);
 	};
 	return wrapped;
 }
@@ -9175,10 +9174,17 @@ export class DefaultMessageService implements IMessageService {
 					...(options?.abortSignal ? { abortSignal: options.abortSignal } : {}),
 				};
 
+				const deliveredVisibleTexts = new Set<string>();
+				const recordDeliveredVisibleText = (text: string) => {
+					deliveredVisibleTexts.add(
+						normalizeVisibleTextForDuplicateCheck(text),
+					);
+				};
 				const instrumentedCallback = wrapSingleTurnVisibleCallback(
 					runtime,
 					message,
 					callback,
+					recordDeliveredVisibleText,
 				);
 
 				// Set up timeout monitoring
@@ -9355,6 +9361,7 @@ export class DefaultMessageService implements IMessageService {
 										runtime,
 										message,
 										instrumentedCallback,
+										deliveredVisibleTexts,
 										responseId,
 										runId,
 										startTime,
@@ -9481,6 +9488,7 @@ export class DefaultMessageService implements IMessageService {
 		runtime: IAgentRuntime,
 		message: Memory,
 		callback: HandlerCallback | undefined,
+		deliveredVisibleTexts: Set<string>,
 		responseId: UUID,
 		runId: UUID,
 		startTime: number,
@@ -9961,6 +9969,7 @@ export class DefaultMessageService implements IMessageService {
 						state,
 						responseId,
 						...(callback ? { callback } : {}),
+						deliveredVisibleTexts,
 						onResponseHandlerEarlyReply: deliverResponseHandlerEarlyReply,
 					}),
 					runtime.applyPipelineHooks(


### PR DESCRIPTION
## Summary
- record action callback text after voice rewrite / verbosity shaping, matching what connectors actually deliver
- keep planner echo suppression based on the delivered text instead of the raw pre-rewrite payload
- add deterministic planner regression coverage for raw action payload P rewritten to R with finalMessage R

Closes #15618.

## Verification
- `bunx biome check packages/core/src/services/message.ts packages/core/src/__tests__/planner-happy-path.test.ts packages/core/src/services/__tests__/action-callback-voice.test.ts --no-errors-on-unmatched`
- `bun run --cwd packages/core test -- src/__tests__/planner-happy-path.test.ts`
- `bun run --cwd packages/core test -- src/services/__tests__/action-callback-voice.test.ts`
- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/core build:node`
- `bun run --cwd packages/core build`

## Evidence notes
- No UI surface: screenshots/video N/A.
- Runtime live-LLM trajectory N/A for this patch: regression is a deterministic duplicate-delivery bug in callback plumbing; the test drives the real Stage 1/planner/action/evaluator pipeline with canned model outputs so the exact pre-rewrite and post-rewrite strings are controlled and observable.
