### PR TITLE
fix(ui): import wallet modal stylesheets so /login EVM + Solana modals render styled (#15600)

### DIFF
--- a/packages/ui/src/cloud-ui/index.css
+++ b/packages/ui/src/cloud-ui/index.css
@@ -1,3 +1,10 @@
 @import "tailwindcss";
+/* Wallet-modal vendor styles. steward-wallet-providers.tsx is CSS-import-free
+   by design (its dist must stay Node-loadable), so this host CSS entry owns
+   them: without these imports the RainbowKit connect modal (EVM no-wallet
+   fallback) and the Solana wallet-adapter modal render unstyled — the Solana
+   modal is invisible black-on-black at the document tail (#15600). */
+@import "@rainbow-me/rainbowkit/styles.css";
+@import "@solana/wallet-adapter-react-ui/styles.css";
 @import "../styles/base.css";
 @import "../styles/tailwind-theme.css";

--- a/packages/ui/src/cloud/billing/wallet/steward-wallet-providers.tsx
+++ b/packages/ui/src/cloud/billing/wallet/steward-wallet-providers.tsx
@@ -4,10 +4,19 @@
  * Loaded only behind {@link ConditionalWalletProviders}'s lazy boundary so the
  * heavy wallet vendor chunks never enter the entry bundle.
  *
- * NOTE: RainbowKit's stylesheet (`@rainbow-me/rainbowkit/styles.css`) is NOT
- * imported here — the app shell owns CSS and this module is `index.ts`-free by
- * design; the host/cloud-ui CSS entry must `@import` the RainbowKit styles for
- * the modal to render styled.
+ * NOTE: no stylesheet is imported here — the app shell owns CSS and this
+ * module is `index.ts`-free by design. The wallet modal styles (RainbowKit's
+ * `styles.css` and `@solana/wallet-adapter-react-ui/styles.css`) are
+ * `@import`ed by `cloud-ui/index.css`; without them both modals render
+ * unstyled (#15600).
+ *
+ * NOTE: `@wagmi/connectors` reaches its wallet SDKs (`@metamask/connect-evm`,
+ * `@walletconnect/ethereum-provider`, `@coinbase/wallet-sdk`, …) through
+ * dynamic imports of *optional* peer deps. Any peer missing from the install
+ * is compiled by Vite into a stub that throws
+ * `Could not resolve "<pkg>" imported by "@wagmi/connectors"` at click time
+ * (#15600 — MetaMask). package.json therefore declares `@metamask/connect-evm`
+ * even though no source file imports it (guarded by wallet-connector-deps.test.ts).
  */
 
 import { BRAND_COLORS } from "@elizaos/shared/brand";

--- a/packages/ui/src/cloud/public-pages/pages/login/wallet-connector-deps.test.ts
+++ b/packages/ui/src/cloud/public-pages/pages/login/wallet-connector-deps.test.ts
@@ -16,11 +16,17 @@
  * the failure only surfaces when a real no-wallet browser clicks EVM. This test
  * pins the dep in `packages/ui/package.json` so a future dependency bump that
  * drops it fails CI here instead of silently in production onboarding.
+ *
+ * Same family: the wallet modals' vendor stylesheets (RainbowKit and the Solana
+ * wallet-adapter modal) are owned by the host CSS entry (`cloud-ui/index.css`)
+ * because `steward-wallet-providers.tsx` is CSS-import-free by design. Without
+ * those `@import`s the Solana modal renders invisible (unstyled, black-on-black
+ * at the document tail) — also unreachable by jsdom tests, so it is pinned here.
  */
 
 import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -44,15 +50,35 @@ describe("wallet sign-in connector peer dependencies", () => {
   };
   const declared = { ...pkg.dependencies, ...pkg.devDependencies };
 
-  it.each(RUNTIME_LAZY_CONNECTOR_DEPS)(
-    "declares %s so the no-injected-wallet EVM fallback resolves at click-time (#15600)",
-    (dep) => {
-      expect(
-        declared[dep],
-        `${dep} must be a declared dependency of @elizaos/ui — wagmi/RainbowKit ` +
-          `dynamically imports it on the no-wallet EVM path; dropping it resurrects ` +
-          `the "Could not resolve ${dep}" click-time dead-end (#15600 / #15608).`,
-      ).toBeTruthy();
-    },
-  );
+  it.each(
+    RUNTIME_LAZY_CONNECTOR_DEPS,
+  )("declares %s so the no-injected-wallet EVM fallback resolves at click-time (#15600)", (dep) => {
+    expect(
+      declared[dep],
+      `${dep} must be a declared dependency of @elizaos/ui — wagmi/RainbowKit ` +
+        `dynamically imports it on the no-wallet EVM path; dropping it resurrects ` +
+        `the "Could not resolve ${dep}" click-time dead-end (#15600 / #15608).`,
+    ).toBeTruthy();
+  });
+
+  // The wallet modal stylesheets live in the host CSS entry (see the header).
+  // jsdom cannot see an unstyled portal, so pin the @imports statically.
+  const WALLET_MODAL_STYLESHEETS = [
+    "@rainbow-me/rainbowkit/styles.css",
+    "@solana/wallet-adapter-react-ui/styles.css",
+  ] as const;
+
+  const cloudCssEntryPath = resolve(here, "../../../../cloud-ui/index.css");
+  const cloudCssEntry = readFileSync(cloudCssEntryPath, "utf8");
+
+  it.each(
+    WALLET_MODAL_STYLESHEETS,
+  )("cloud-ui/index.css imports %s so the wallet modals render styled (#15600)", (sheet) => {
+    expect(
+      cloudCssEntry.includes(`@import "${sheet}";`),
+      `cloud-ui/index.css must \`@import "${sheet}"\` — steward-wallet-providers ` +
+        `is CSS-import-free by design, so dropping this import leaves the wallet ` +
+        `modal unstyled (the Solana modal renders invisible, #15600).`,
+    ).toBe(true);
+  });
 });


### PR DESCRIPTION
Closes the residual half of #15600 (the "check Solana too" half). The dependency half — `Could not resolve "@metamask/connect-evm" imported by "@wagmi/connectors"` on EVM click — was fixed on develop by #15608 and regression-guarded by #15615; prod still needs the promote for that.

## Root cause (what this PR fixes)

The wallet modal **vendor stylesheets are imported nowhere**. `steward-wallet-providers.tsx` is CSS-import-free by design (its dist must stay Node-loadable) and its header says the host CSS entry must `@import` the RainbowKit styles — but no host CSS entry ever did, and the Solana wallet-adapter stylesheet was equally missing. Verified against a build off current develop (`cf2e8a7d2b9`): neither `wallet-adapter-modal` rules nor RainbowKit's class rules appear in any built CSS asset.

Consequence on /login:

- **Solana**: clicking Solana opens the wallet-adapter modal **invisible** — with no CSS its portal DOM lands in normal document flow at the page tail, black-on-black. The click looks like a dead-end even though the chunk resolves fine (screenshot below).
- **EVM**: the RainbowKit connect modal (the no-injected-wallet fallback when every connector is exhausted) renders unstyled the same way.

## Fix

- `packages/ui/src/cloud-ui/index.css` — `@import "@rainbow-me/rainbowkit/styles.css"` + `@import "@solana/wallet-adapter-react-ui/styles.css"` (this is the entry `packages/app/src/main.tsx` pulls via `@elizaos/ui/styles`), per the contract `steward-wallet-providers.tsx` already documents.
- `wallet-connector-deps.test.ts` (from #15615) — extended to pin both `@import`s. **Proven red-on-base**: with the CSS imports reverted the two new tests fail; with them, 3/3 pass. Like the dep it guards, this failure class is invisible to jsdom and to the build.
- `steward-wallet-providers.tsx` — header updated to point at the actual owner (`cloud-ui/index.css`) and to document the `@wagmi/connectors` optional-peer-dep trap (`Could not resolve "<pkg>" imported by "@wagmi/connectors"` thrown at click time by Vite's optional-peer stub) so the next reader doesn't have to rediscover #15600.

## Verification (build off develop + this PR, served dist, headless Chromium click-through)

Harness: full `packages/app` Vite build, dist served with SPA fallback, Playwright Chromium with service workers blocked, Steward `GET /steward/auth/providers` fulfilled with `siwe/siws: true` (as on prod). It fails on any `Could not resolve "<pkg>" imported by "<pkg>"` in page text, console, or pageerrors.

| check | result |
| --- | --- |
| EVM click, no wallet extension | no resolution error; reaches wagmi connect (designed error state) |
| Solana click | wallet-adapter modal renders **styled** with Phantom + Solflare |
| EVM click with injected EIP-1193 wallet | full SIWE sign-in completes: `GET /auth/nonce` → `personal_sign` → `POST /auth/verify` → token persisted → redirected off /login |
| built CSS | `wallet-adapter-modal` + RainbowKit rules present in `main-*.css` |
| stub scan of all built JS | zero `Could not resolve "…" imported by "…"` stubs |

**/login at rest** (wallet section rendered):

![login rest](https://gist.githubusercontent.com/lalalune/917d3bba0894fda970e6338fa30cd11b/raw/login-rest.jpg)

**Solana click — BEFORE this PR** (develop build: modal open per DOM/innerText, but invisible — unstyled, black-on-black):

![solana unstyled](https://gist.githubusercontent.com/lalalune/917d3bba0894fda970e6338fa30cd11b/raw/login-solana-unstyled.jpg)

**Solana click — AFTER** (styled modal, Phantom/Solflare):

![solana styled](https://gist.githubusercontent.com/lalalune/917d3bba0894fda970e6338fa30cd11b/raw/login-solana-clicked.jpg)

**EVM click, walletless browser** (no resolution error; wagmi's real connect ran and surfaced its designed error — on prod the QR/deeplink path serves this case with #15608's dep in place):

![evm clicked](https://gist.githubusercontent.com/lalalune/917d3bba0894fda970e6338fa30cd11b/raw/login-evm-clicked.jpg)

**EVM SIWE sign-in with injected wallet** (completed; mid-redirect off /login to /join — the post-auth surface then talks to the agent API, which the static evidence server doesn't implement):

![evm signin](https://gist.githubusercontent.com/lalalune/917d3bba0894fda970e6338fa30cd11b/raw/login-evm-signin-success.jpg)

<details>
<summary>Verification run log (final, develop + this PR)</summary>

```
[serve] dist on http://127.0.0.1:41739
[evm] body excerpt: "… or sign in with a wallet\nEVM\nSolana\n\nProvider not found. Version: @wagmi/core@3.5.5 …"
[solana] body excerpt: "… Connect a wallet on Solana to continue\nPhantom\nSolflare"
[evm-signin] siwe calls: GET /auth/nonce, POST /auth/verify
[evm-signin] final url: http://127.0.0.1:41739/join
PASS: no connector-chunk resolution errors on EVM or Solana click; EVM SIWE sign-in completed end-to-end
```

</details>

<details>
<summary>Red-on-base proof for the new guard tests</summary>

```
# with cloud-ui/index.css reverted to develop:
 ❯ src/cloud/public-pages/pages/login/wallet-connector-deps.test.ts (3 tests | 2 failed)
     × cloud-ui/index.css imports @rainbow-me/rainbowkit/styles.css so the wallet modals render styled (#15600)
     × cloud-ui/index.css imports @solana/wallet-adapter-react-ui/styles.css so the wallet modals render styled (#15600)
# with this PR:
      Tests  3 passed (3)
```

</details>

Scoped checks: `packages/ui` typecheck (tsgo) clean, biome clean on touched files, `audit:error-policy-ratchet` clean, guard suite 3/3.

Other evidence rows: video walkthrough **N/A** — the change is two CSS imports + a static guard test; the before/after screenshots above capture the entire user-visible delta of the affected flow. Real-LLM trajectories **N/A** — no agent/model surface. Backend logs **N/A** — no backend path changed (Steward endpoints were network-fulfilled at the boundary to drive the client flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)