### PR TITLE
fix(ci): repair cloud api type fixtures

### DIFF
--- a/packages/cloud/api/__tests__/stripe-connect-webhook-route.test.ts
+++ b/packages/cloud/api/__tests__/stripe-connect-webhook-route.test.ts
@@ -242,7 +242,7 @@ describe("Stripe Connect payout webhook route", () => {
 // issue describes (#10117). Signature ops are local HMAC-SHA256 — no network.
 describe("Stripe Connect webhook — real signature verification (no mock)", () => {
   const realStripe = new Stripe("sk_test_dummy_for_signature_only", {
-    apiVersion: "2026-06-24.dahlia",
+    apiVersion: "2026-05-27.dahlia",
   });
   const secret = "whsec_connect_realtest";
   const payload = JSON.stringify(accountUpdatedEvent);

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
@@ -453,6 +453,9 @@ describe("AgentSandboxesRepository", () => {
         backup_kind: "full",
         parent_backup_id: null,
         content_hash: "hash",
+        verification_status: null,
+        verified_at: null,
+        verification_error: null,
         created_at: createdAt,
       });
 
@@ -490,6 +493,9 @@ describe("AgentSandboxesRepository", () => {
         backup_kind: "full",
         parent_backup_id: null,
         content_hash: "hash",
+        verification_status: null,
+        verified_at: null,
+        verification_error: null,
         created_at: new Date("2026-06-20T00:00:00.000Z"),
       },
     ];


### PR DESCRIPTION
## Summary
- align the Stripe Connect real-signature fixture API version with the installed Stripe SDK type (`2026-05-27.dahlia`)
- include backup verification metadata fields in hand-built agent-sandbox backup rows after the restorability verification schema addition
- clears the focused cloud API type/build break introduced by recent fixture/schema drift

## Verification
- `bunx biome check packages/cloud/api/__tests__/stripe-connect-webhook-route.test.ts packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts --no-errors-on-unmatched`
- `bun test packages/cloud/api/__tests__/stripe-connect-webhook-route.test.ts` (13 pass / 0 fail / 35 expects; coverage output redirected during final rerun to avoid tool pipe overflow)
- `bun test packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts` (14 pass / 0 fail / 120 expects; coverage output redirected during final rerun to avoid tool pipe overflow)
- `bun run --cwd packages/cloud/api build`
