### PR TITLE
fix(cloud): harden sign-in/signup failure boundaries (#15610)

### DIFF
--- a/packages/app-core/src/cli/program/register.auth.dev-login.test.ts
+++ b/packages/app-core/src/cli/program/register.auth.dev-login.test.ts
@@ -3,10 +3,22 @@
  * ephemeral Ethereum wallet, sign the SIWE challenge, and exchange it for a
  * cloud API key with no browser/OAuth. A fixed private key plus a mocked fetch
  * keep the suite offline and deterministic; covers the mint-without-save happy
- * path, a transient nonce-failure retry, and a verify rejection.
+ * path, a transient nonce-failure retry, a verify rejection, and the loud
+ * failed-persist warning (config write throws → saveError + manual-save
+ * instructions, never a silent muted aside).
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { runDevWalletLogin } from "./register.auth";
+
+// The persist path dynamically imports these; the throwing saveConfig drives
+// the failed-persist test (the other tests run with save:false and never reach it).
+vi.mock("./register.setup", () => ({
+  resolveConfigPath: () => "/nonexistent/eliza/eliza.json",
+  loadConfig: () => ({}),
+  saveConfig: () => {
+    throw new Error("EACCES: permission denied");
+  },
+}));
 
 const FIXED_PK =
   "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
@@ -114,5 +126,29 @@ describe("auth dev-login (SIWE wallet)", () => {
     });
     expect(result.ok).toBe(false);
     expect(result.message).toContain("verify failed (401)");
+  });
+
+  it("a failed key persist is LOUD: warns, returns saveError, and prints manual-save instructions", async () => {
+    const lines: string[] = [];
+    const result = await runDevWalletLogin({
+      privateKey: FIXED_PK,
+      // save defaults to true → the mocked saveConfig throws EACCES.
+      log: (line) => lines.push(line),
+      fetchImpl: mockFetch(),
+    });
+
+    // The mint itself still succeeds and the key is returned.
+    expect(result.ok).toBe(true);
+    expect(result.apiKey).toBe("eliza_devkey_TESTKEY");
+    // The failure is a first-class result field, not a swallowed aside.
+    expect(result.savedTo).toBeNull();
+    expect(result.saveError).toContain("EACCES: permission denied");
+    // And the user is told, loudly, with a copy-pasteable remedy.
+    const output = lines.join("\n");
+    expect(output).toContain("WARNING: failed to save ELIZAOS_CLOUD_API_KEY");
+    expect(output).toContain("NOT saved");
+    expect(output).toContain(
+      "export ELIZAOS_CLOUD_API_KEY=eliza_devkey_TESTKEY",
+    );
   });
 });

--- a/packages/app-core/src/cli/program/register.auth.ts
+++ b/packages/app-core/src/cli/program/register.auth.ts
@@ -333,6 +333,8 @@ export interface DevWalletLoginResult {
   isNewAccount?: boolean;
   organizationId?: string | null;
   savedTo?: string | null;
+  /** Set when persisting the key to the config was requested but FAILED. */
+  saveError?: string;
   message?: string;
 }
 
@@ -455,6 +457,7 @@ export async function runDevWalletLogin(
 
   // 4. Persist (default) so the local agent routes to Eliza Cloud.
   let savedTo: string | null = null;
+  let saveError: string | undefined;
   if (params.save !== false) {
     try {
       const { resolveConfigPath, loadConfig, saveConfig } = await import(
@@ -472,10 +475,26 @@ export async function runDevWalletLogin(
       saveConfig(configPath, config);
       savedTo = configPath;
     } catch (err) {
+      // error-policy:J4 explicit user-facing degrade — the key was minted and
+      // is still returned/printed, but a failed persist must be LOUD: a muted
+      // aside here left users believing the agent was cloud-connected while
+      // every boot ran without ELIZAOS_CLOUD_API_KEY.
+      saveError = err instanceof Error ? err.message : String(err);
       log(
-        theme.muted(
-          `(could not persist key to config: ${err instanceof Error ? err.message : String(err)})`,
+        theme.error(
+          `WARNING: failed to save ELIZAOS_CLOUD_API_KEY to the eliza config: ${saveError}`,
         ),
+      );
+      log(
+        theme.error(
+          "Your API key was NOT saved — the agent will not use Eliza Cloud until you save it.",
+        ),
+      );
+      log(
+        `${theme.muted("Save it manually with:")} ${theme.command(`export ELIZAOS_CLOUD_API_KEY=${apiKey}`)}`,
+      );
+      log(
+        `${theme.muted("or re-run")} ${theme.command("eliza auth dev-login")} ${theme.muted("after fixing the config path above.")}`,
       );
     }
   }
@@ -487,6 +506,7 @@ export async function runDevWalletLogin(
     isNewAccount: verified.isNewAccount,
     organizationId: orgId,
     savedTo,
+    ...(saveError !== undefined ? { saveError } : {}),
   };
 }
 
@@ -549,8 +569,15 @@ export function registerAuthCommand(program: Command) {
               `${theme.success("✓")} saved ELIZAOS_CLOUD_API_KEY to ${theme.command(result.savedTo)} — the agent will use Eliza Cloud`,
             );
           } else {
+            // A failed persist restates the loud warning runDevWalletLogin
+            // already printed, so it cannot scroll past unnoticed; --no-save
+            // keeps the neutral hint.
             console.log(
-              `${theme.muted("→")} not saved (use without --no-save to persist, or export ELIZAOS_CLOUD_API_KEY=<key>)`,
+              result.saveError
+                ? theme.error(
+                    `✗ ELIZAOS_CLOUD_API_KEY was NOT saved (${result.saveError}) — save it manually (see above)`,
+                  )
+                : `${theme.muted("→")} not saved (use without --no-save to persist, or export ELIZAOS_CLOUD_API_KEY=<key>)`,
             );
           }
         });

--- a/packages/cloud/api/auth/siwe/nonce/siwe-nonce-redis-outage.test.ts
+++ b/packages/cloud/api/auth/siwe/nonce/siwe-nonce-redis-outage.test.ts
@@ -1,0 +1,145 @@
+/**
+ * SIWE nonce route integration coverage: a THROWING Redis (transport/auth
+ * outage) must return the same retryable 503 as a missing client — never a
+ * `500 internal_error` (the mapping that broke staging wallet sign-in,
+ * CLOUD_ONBOARDING_PROVISIONING_REVIEW.md §8c). Unlike the colocated unit test
+ * (route.test.ts, which stubs the rate limiter), this drives the REAL
+ * rate-limit middleware alongside the route and also proves the healthy path
+ * issues + persists a bound nonce; only the Redis factory is swapped.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+type RedisMode = "throwing" | "null" | "healthy";
+let redisMode: RedisMode = "healthy";
+
+const stored = new Map<string, string>();
+
+const throwingRedis = new Proxy(
+  {},
+  {
+    get:
+      () =>
+      async (..._args: unknown[]) => {
+        throw new Error("ECONNREFUSED: redis down");
+      },
+  },
+);
+
+const healthyRedis = {
+  incr: async () => 1,
+  pttl: async () => 60_000,
+  pexpire: async () => 1,
+  expire: async () => 1,
+  setex: async (key: string, _ttl: number, value: string) => {
+    stored.set(key, value);
+    return "OK";
+  },
+  get: async (key: string) => stored.get(key) ?? null,
+  del: async (key: string) => (stored.delete(key) ? 1 : 0),
+};
+
+mock.module("@/lib/cache/redis-factory", () => ({
+  buildRedisClient: () => {
+    if (redisMode === "null") return null;
+    return redisMode === "throwing" ? throwingRedis : healthyRedis;
+  },
+  hasRedisConfig: () => redisMode !== "null",
+  isCloudflareWorkerRuntime: () => false,
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    debug: mock(() => undefined),
+    error: mock(() => undefined),
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+  },
+}));
+
+const { default: nonceRoute } = await import("./route");
+const { _resetRedisUnavailableFallbackBuckets } = await import(
+  "@/lib/middleware/rate-limit-hono-cloudflare"
+);
+
+const ENV = {
+  ENVIRONMENT: "staging",
+  NODE_ENV: "production",
+  REDIS_URL: "redis://mock:6379",
+  NEXT_PUBLIC_APP_URL: "https://staging.elizacloud.ai",
+};
+
+function getNonce(query = "") {
+  const app = new Hono();
+  app.route("/api/auth/siwe/nonce", nonceRoute);
+  return app.fetch(
+    new Request(
+      `https://api-staging.elizacloud.ai/api/auth/siwe/nonce${query}`,
+      {
+        headers: { "cf-connecting-ip": "203.0.113.20" },
+      },
+    ),
+    ENV,
+  );
+}
+
+beforeEach(() => {
+  redisMode = "healthy";
+  stored.clear();
+  _resetRedisUnavailableFallbackBuckets();
+});
+
+describe("GET /api/auth/siwe/nonce — Redis failure boundary", () => {
+  test("throwing Redis returns a retryable 503, not 500 — with the real rate limiter in front", async () => {
+    redisMode = "throwing";
+    const res = await getNonce();
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("5");
+    await expect(res.json()).resolves.toMatchObject({
+      error: "Nonce storage unavailable",
+      code: "nonce_storage_unavailable",
+    });
+  });
+
+  test("missing Redis client returns the same 503 outage signal", async () => {
+    redisMode = "null";
+    const res = await getNonce();
+    expect(res.status).toBe(503);
+    await expect(res.json()).resolves.toMatchObject({
+      error: "Nonce storage unavailable",
+    });
+  });
+
+  test("healthy Redis issues a nonce (200) with the SIWE parameters", async () => {
+    const res = await getNonce("?chainId=5");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    const body = (await res.json()) as {
+      nonce: string;
+      domain: string;
+      uri: string;
+      chainId: number;
+      version: string;
+    };
+    expect(body.nonce).toMatch(/^[0-9a-f]{32}$/);
+    expect(body.domain).toBe("staging.elizacloud.ai");
+    expect(body.uri).toBe("https://staging.elizacloud.ai");
+    expect(body.chainId).toBe(5);
+    expect(body.version).toBe("1");
+    // The nonce was actually persisted with its issued binding.
+    expect(stored.size).toBe(1);
+    const [storedValue] = stored.values();
+    expect(JSON.parse(storedValue)).toMatchObject({
+      uri: "https://staging.elizacloud.ai",
+      chainId: 5,
+    });
+  });
+
+  test("malformed chainId falls back to mainnet (1) instead of erroring", async () => {
+    const res = await getNonce("?chainId=not-a-number");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { chainId: number };
+    expect(body.chainId).toBe(1);
+  });
+});

--- a/packages/cloud/api/auth/siws/nonce/siws-nonce-redis-outage.test.ts
+++ b/packages/cloud/api/auth/siws/nonce/siws-nonce-redis-outage.test.ts
@@ -1,0 +1,137 @@
+/**
+ * SIWS (Solana) nonce route integration coverage: a THROWING Redis must return
+ * the same retryable 503 as a missing client — never `500 internal_error`
+ * (staging outage class: CLOUD_ONBOARDING_PROVISIONING_REVIEW.md §8c). Unlike
+ * the colocated unit test (route.test.ts, which stubs the rate limiter), this
+ * drives the REAL rate-limit middleware alongside the route and also proves
+ * the healthy path issues + persists a bound nonce; only the Redis factory is
+ * swapped.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+type RedisMode = "throwing" | "null" | "healthy";
+let redisMode: RedisMode = "healthy";
+
+const stored = new Map<string, string>();
+
+const throwingRedis = new Proxy(
+  {},
+  {
+    get:
+      () =>
+      async (..._args: unknown[]) => {
+        throw new Error("ECONNREFUSED: redis down");
+      },
+  },
+);
+
+const healthyRedis = {
+  incr: async () => 1,
+  pttl: async () => 60_000,
+  pexpire: async () => 1,
+  expire: async () => 1,
+  setex: async (key: string, _ttl: number, value: string) => {
+    stored.set(key, value);
+    return "OK";
+  },
+  get: async (key: string) => stored.get(key) ?? null,
+  del: async (key: string) => (stored.delete(key) ? 1 : 0),
+};
+
+mock.module("@/lib/cache/redis-factory", () => ({
+  buildRedisClient: () => {
+    if (redisMode === "null") return null;
+    return redisMode === "throwing" ? throwingRedis : healthyRedis;
+  },
+  hasRedisConfig: () => redisMode !== "null",
+  isCloudflareWorkerRuntime: () => false,
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    debug: mock(() => undefined),
+    error: mock(() => undefined),
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+  },
+}));
+
+const { default: nonceRoute } = await import("./route");
+const { _resetRedisUnavailableFallbackBuckets } = await import(
+  "@/lib/middleware/rate-limit-hono-cloudflare"
+);
+
+const ENV = {
+  ENVIRONMENT: "staging",
+  NODE_ENV: "production",
+  REDIS_URL: "redis://mock:6379",
+  NEXT_PUBLIC_APP_URL: "https://staging.elizacloud.ai",
+};
+
+function getNonce(query = "") {
+  const app = new Hono();
+  app.route("/api/auth/siws/nonce", nonceRoute);
+  return app.fetch(
+    new Request(
+      `https://api-staging.elizacloud.ai/api/auth/siws/nonce${query}`,
+      {
+        headers: { "cf-connecting-ip": "203.0.113.21" },
+      },
+    ),
+    ENV,
+  );
+}
+
+beforeEach(() => {
+  redisMode = "healthy";
+  stored.clear();
+  _resetRedisUnavailableFallbackBuckets();
+});
+
+describe("GET /api/auth/siws/nonce — Redis failure boundary", () => {
+  test("throwing Redis returns a retryable 503, not 500 — with the real rate limiter in front", async () => {
+    redisMode = "throwing";
+    const res = await getNonce();
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("5");
+    await expect(res.json()).resolves.toMatchObject({
+      error: "Nonce storage unavailable",
+      code: "nonce_storage_unavailable",
+    });
+  });
+
+  test("missing Redis client returns the same 503 outage signal", async () => {
+    redisMode = "null";
+    const res = await getNonce();
+    expect(res.status).toBe(503);
+    await expect(res.json()).resolves.toMatchObject({
+      error: "Nonce storage unavailable",
+    });
+  });
+
+  test("healthy Redis issues a nonce (200) with the SIWS parameters", async () => {
+    const res = await getNonce();
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    const body = (await res.json()) as {
+      nonce: string;
+      domain: string;
+      uri: string;
+      chainId: string;
+      version: string;
+    };
+    expect(body.nonce).toMatch(/^[0-9a-f]{32}$/);
+    expect(body.domain).toBe("staging.elizacloud.ai");
+    expect(body.chainId).toBe("solana:mainnet");
+    expect(body.version).toBe("1");
+    // The nonce was actually persisted with its issued binding.
+    expect(stored.size).toBe(1);
+    const [storedValue] = stored.values();
+    expect(JSON.parse(storedValue)).toMatchObject({
+      uri: "https://staging.elizacloud.ai",
+      chainId: "solana:mainnet",
+    });
+  });
+});

--- a/packages/cloud/shared/src/lib/auth-default-character-selfheal.test.ts
+++ b/packages/cloud/shared/src/lib/auth-default-character-selfheal.test.ts
@@ -66,12 +66,20 @@ mock.module("./services/users", () => ({
     upsertStewardIdentity: async () => undefined,
   },
 }));
-// The user already has their default API key, isolating the character heal.
+// Records the API-key heal and settles on a LATER tick: if session resolution
+// void-fired it instead of awaiting, `apiKeyHealSettled` would still be false
+// when getCurrentUserFromRequest resolves (the Workers cancellation hazard).
+let apiKeyHealCalls: Array<[string, string]> = [];
+let apiKeyHealSettled = false;
 mock.module("./services/api-keys", () => ({
   apiKeysService: {
     listByOrganization: async () => [{ user_id: "user-1" }],
     create: async () => ({ id: "key-1" }),
-    ensureUserHasApiKey: async () => undefined,
+    ensureUserHasApiKey: async (userId: string, organizationId: string) => {
+      apiKeyHealCalls.push([userId, organizationId]);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      apiKeyHealSettled = true;
+    },
     validateApiKey: async () => null,
     incrementUsageDebounced: () => undefined,
   },
@@ -126,5 +134,21 @@ describe("session-resolution default-character self-heal", () => {
     expect(characterCreateCalls[0].name).toBe("Eliza");
     expect(characterCreateCalls[0].user_id).toBe("user-1");
     expect(characterCreateCalls[0].organization_id).toBe("org-1");
+  });
+
+  test("the default API-key self-heal is AWAITED, not void-fired (Workers cancels un-awaited promises)", async () => {
+    apiKeyHealCalls = [];
+    apiKeyHealSettled = false;
+
+    const request = new Request("http://localhost/api/anything", {
+      headers: { cookie: "steward-token=tok-abc" },
+    });
+
+    const user = await getCurrentUserFromRequest(request);
+    expect(user?.id).toBe("user-1");
+
+    expect(apiKeyHealCalls).toEqual([["user-1", "org-1"]]);
+    // Settles on a later tick: only an awaited call can have completed here.
+    expect(apiKeyHealSettled).toBe(true);
   });
 });

--- a/packages/cloud/shared/src/lib/auth/workers-hono-auth.api-key.test.ts
+++ b/packages/cloud/shared/src/lib/auth/workers-hono-auth.api-key.test.ts
@@ -1,13 +1,16 @@
 /**
  * API-key auth boundary coverage keeps storage outages distinct from invalid
- * credentials so clients retry instead of prompting users to rotate good keys.
+ * credentials so clients retry instead of prompting users to rotate good keys:
+ * a validateApiKey THROW (datastore down) must map to 503 on BOTH guards, while
+ * a null return (genuinely invalid key) stays a 401.
  */
 
-import { describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-const validateApiKey = mock(async () => {
+let validateBehavior: () => Promise<unknown> = async () => {
   throw new Error("database unavailable");
-});
+};
+const validateApiKey = mock(() => validateBehavior());
 
 mock.module("../services/api-keys", () => ({
   apiKeysService: {
@@ -38,7 +41,7 @@ mock.module("../utils/logger", () => ({
   },
 }));
 
-const { requireUserOrApiKey } = await import("./workers-hono-auth");
+const { requireUserOrApiKey, requireUserOrApiKeyWithOrg } = await import("./workers-hono-auth");
 
 function contextWithApiKey(apiKey: string) {
   const state = new Map<string, unknown>();
@@ -54,6 +57,12 @@ function contextWithApiKey(apiKey: string) {
   };
 }
 
+beforeEach(() => {
+  validateBehavior = async () => {
+    throw new Error("database unavailable");
+  };
+});
+
 describe("Workers API-key auth", () => {
   test("returns a service-unavailable error when API-key storage throws", async () => {
     await expect(
@@ -62,6 +71,35 @@ describe("Workers API-key auth", () => {
       status: 503,
       code: "service_unavailable",
       message: "API key validation is temporarily unavailable. Please retry.",
+    });
+  });
+
+  test("requireUserOrApiKeyWithOrg maps the same storage throw to 503", async () => {
+    await expect(
+      requireUserOrApiKeyWithOrg(contextWithApiKey("eliza_live_key") as never),
+    ).rejects.toMatchObject({
+      status: 503,
+      code: "service_unavailable",
+    });
+  });
+
+  test("a null validation result stays 401 invalid-key on requireUserOrApiKey", async () => {
+    validateBehavior = async () => null;
+    await expect(
+      requireUserOrApiKey(contextWithApiKey("eliza_bad_key") as never),
+    ).rejects.toMatchObject({
+      status: 401,
+      code: "authentication_required",
+    });
+  });
+
+  test("a null validation result stays 401 invalid-key on requireUserOrApiKeyWithOrg", async () => {
+    validateBehavior = async () => null;
+    await expect(
+      requireUserOrApiKeyWithOrg(contextWithApiKey("eliza_bad_key") as never),
+    ).rejects.toMatchObject({
+      status: 401,
+      code: "authentication_required",
     });
   });
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/wallet-signup-orphan-org.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/wallet-signup-orphan-org.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Wallet signup must be atomic AND degrade-safe: a user-create failure leaves
+ * NO orphan org (and no committed welcome-credit grant), a retry converges
+ * cleanly on one org + one idempotent grant, and a failing OPTIONAL welcome
+ * grant is contained in a savepoint so the signup still completes without the
+ * bonus instead of aborting the whole transaction.
+ *
+ * These tests run the REAL signup path (real transaction, real credits CTE,
+ * real signup-grant guard with its per-IP advisory lock) against in-process
+ * PGlite. Failures are injected in the DATABASE — plpgsql BEFORE INSERT
+ * triggers armed via a flag table — so the rollback/savepoint behavior under
+ * test is the real one, not a mocked seam. Fails loudly if PGlite cannot
+ * initialize; never a silent skip.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+process.env.INITIAL_FREE_CREDITS = "5";
+
+const PGLITE_TIMEOUT = 120_000;
+const CLIENT_IP = "203.0.113.77";
+
+const EVM_ADDRESS = `0x${"ab".repeat(20)}`;
+const EVM_ADDRESS_2 = `0x${"cd".repeat(20)}`;
+// Distinct address for the grant-containment test: the users service caches
+// wallet lookups (in-memory under MOCK_REDIS), so reusing an address a prior
+// test signed in with would short-circuit at the existing-user pre-check.
+const EVM_ADDRESS_3 = `0x${"ef".repeat(20)}`;
+const SOLANA_ADDRESS = "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin";
+
+let pgliteReady = true;
+let pgliteError: unknown;
+let dbWrite: typeof import("../../../db/client").dbWrite;
+let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
+let walletSignup: typeof import("../wallet-signup");
+let runWithRequestContext: typeof import("../../runtime/request-context").runWithRequestContext;
+let flushWalletLookupCache: () => Promise<void>;
+
+async function armUserInsertFailure(): Promise<void> {
+  await dbWrite.execute(`INSERT INTO test_fail_flags (name) VALUES ('users_insert')
+    ON CONFLICT (name) DO NOTHING;`);
+}
+
+async function armCreditInsertFailure(): Promise<void> {
+  await dbWrite.execute(`INSERT INTO test_fail_flags (name) VALUES ('credits_insert')
+    ON CONFLICT (name) DO NOTHING;`);
+}
+
+async function disarmFailures(): Promise<void> {
+  await dbWrite.execute(`DELETE FROM test_fail_flags;`);
+}
+
+async function countRows(table: "organizations" | "users" | "credit_transactions") {
+  const r = await dbWrite.execute(`SELECT count(*)::int AS n FROM ${table};`);
+  return (r.rows[0] as { n: number }).n;
+}
+
+async function orgBalanceBySlug(slug: string): Promise<number> {
+  const r = await dbWrite.execute(
+    `SELECT credit_balance FROM organizations WHERE slug = '${slug}';`,
+  );
+  return Number((r.rows[0] as { credit_balance: string }).credit_balance);
+}
+
+/** Run signup inside a request context so the per-IP grant guard path is real. */
+function signupEvm(address: string) {
+  return runWithRequestContext({ clientIp: CLIENT_IP }, () =>
+    walletSignup.findOrCreateUserByWalletAddress(address),
+  );
+}
+
+/**
+ * Assert `promise` rejects with the trigger's exception somewhere in the cause
+ * chain — drizzle wraps driver errors in DrizzleQueryError (message = the
+ * failed SQL), so the injected message only appears on a nested `cause`.
+ */
+async function expectRejectsFromTrigger(promise: Promise<unknown>): Promise<void> {
+  let thrown: unknown;
+  try {
+    await promise;
+  } catch (e) {
+    thrown = e;
+  }
+  expect(thrown).toBeInstanceOf(Error);
+  const chain: string[] = [];
+  let current: unknown = thrown;
+  for (let depth = 0; current instanceof Error && depth < 5; depth += 1) {
+    chain.push(current.message);
+    current = current.cause;
+  }
+  expect(chain.join(" | ")).toContain("simulated transient user insert failure");
+}
+
+beforeAll(async () => {
+  try {
+    const dbClient = await import("../../../db/client");
+    dbWrite = dbClient.dbWrite;
+    closeDb = dbClient.closeDatabaseConnectionsForTests;
+    const { organizations } = await import("../../../db/schemas/organizations");
+    const { users } = await import("../../../db/schemas/users");
+    const { creditTransactions } = await import("../../../db/schemas/credit-transactions");
+    const { pushSchema } = await import("../../../db/push-schema-for-tests");
+    const { apply } = await pushSchema(
+      { organizations, users, creditTransactions } as never,
+      dbClient.dbWrite as never,
+    );
+    await apply();
+
+    // In-database failure injection: BEFORE INSERT triggers that raise while a
+    // flag row exists — the real SQL failure shapes the transactional signup
+    // must roll back from (users) or contain in a savepoint (credits).
+    await dbWrite.execute(`CREATE TABLE IF NOT EXISTS test_fail_flags (name text PRIMARY KEY);`);
+    await dbWrite.execute(`
+      CREATE OR REPLACE FUNCTION test_users_insert_gate() RETURNS trigger AS $$
+      BEGIN
+        IF EXISTS (SELECT 1 FROM test_fail_flags WHERE name = 'users_insert') THEN
+          RAISE EXCEPTION 'simulated transient user insert failure';
+        END IF;
+        RETURN NEW;
+      END $$ LANGUAGE plpgsql;`);
+    await dbWrite.execute(`
+      CREATE TRIGGER test_users_insert_gate_trg BEFORE INSERT ON users
+        FOR EACH ROW EXECUTE FUNCTION test_users_insert_gate();`);
+    await dbWrite.execute(`
+      CREATE OR REPLACE FUNCTION test_credits_insert_gate() RETURNS trigger AS $$
+      BEGIN
+        IF EXISTS (SELECT 1 FROM test_fail_flags WHERE name = 'credits_insert') THEN
+          RAISE EXCEPTION 'simulated transient credit insert failure';
+        END IF;
+        RETURN NEW;
+      END $$ LANGUAGE plpgsql;`);
+    await dbWrite.execute(`
+      CREATE TRIGGER test_credits_insert_gate_trg BEFORE INSERT ON credit_transactions
+        FOR EACH ROW EXECUTE FUNCTION test_credits_insert_gate();`);
+
+    walletSignup = await import("../wallet-signup");
+    ({ runWithRequestContext } = await import("../../runtime/request-context"));
+
+    // The users service caches wallet lookups (in-memory under MOCK_REDIS);
+    // the DB wipe in beforeEach must be mirrored in the cache or a later test
+    // reusing an address would short-circuit at the existing-user pre-check.
+    const { cache } = await import("../../cache/client");
+    const { CacheKeys } = await import("../../cache/keys");
+    const { getAddress } = await import("viem");
+    flushWalletLookupCache = async () => {
+      for (const addr of [EVM_ADDRESS, EVM_ADDRESS_2, EVM_ADDRESS_3]) {
+        await cache.del(CacheKeys.user.byWalletAddressWithOrg(getAddress(addr)));
+      }
+    };
+  } catch (err) {
+    pgliteReady = false;
+    pgliteError = err;
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  await closeDb?.();
+});
+
+beforeEach(async () => {
+  if (!pgliteReady) return;
+  await disarmFailures();
+  await dbWrite.execute(`DELETE FROM credit_transactions;`);
+  await dbWrite.execute(`DELETE FROM users;`);
+  await dbWrite.execute(`DELETE FROM organizations;`);
+  await flushWalletLookupCache();
+});
+
+describe("wallet signup — no orphan org on user-create failure", () => {
+  test("PGlite harness is up (fail loudly, never skip silently)", () => {
+    if (!pgliteReady) throw pgliteError;
+    expect(pgliteReady).toBe(true);
+  });
+
+  test(
+    "EVM: user-create failure rolls back the org AND the welcome grant, then a retry succeeds with exactly one grant",
+    async () => {
+      if (!pgliteReady) throw pgliteError;
+
+      await armUserInsertFailure();
+      await expectRejectsFromTrigger(signupEvm(EVM_ADDRESS));
+
+      // The failing attempt must leave NOTHING durable behind.
+      expect(await countRows("organizations")).toBe(0);
+      expect(await countRows("credit_transactions")).toBe(0);
+      expect(await countRows("users")).toBe(0);
+
+      await disarmFailures();
+      const retry = await signupEvm(EVM_ADDRESS);
+
+      expect(retry.isNewAccount).toBe(true);
+      expect(retry.user.role).toBe("owner");
+      expect(retry.initialCreditsGranted).toBe(true);
+      expect(retry.initialFreeCreditsUsd).toBe(5);
+
+      const slug = `wallet-${EVM_ADDRESS.toLowerCase()}`;
+      expect(await countRows("organizations")).toBe(1);
+      expect(await countRows("users")).toBe(1);
+      expect(await countRows("credit_transactions")).toBe(1);
+      expect(await orgBalanceBySlug(slug)).toBeCloseTo(5, 6);
+      const grantRow = await dbWrite.execute(
+        `SELECT stripe_payment_intent_id FROM credit_transactions;`,
+      );
+      expect(
+        (grantRow.rows[0] as { stripe_payment_intent_id: string }).stripe_payment_intent_id,
+      ).toBe(`wallet-signup:evm:${EVM_ADDRESS.toLowerCase()}`);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "Solana: user-create failure rolls back the org and grant; retry succeeds",
+    async () => {
+      if (!pgliteReady) throw pgliteError;
+
+      await armUserInsertFailure();
+      await expectRejectsFromTrigger(
+        runWithRequestContext({ clientIp: CLIENT_IP }, () =>
+          walletSignup.findOrCreateSolanaUserByWalletAddress(SOLANA_ADDRESS),
+        ),
+      );
+
+      expect(await countRows("organizations")).toBe(0);
+      expect(await countRows("credit_transactions")).toBe(0);
+
+      await disarmFailures();
+      const retry = await runWithRequestContext({ clientIp: CLIENT_IP }, () =>
+        walletSignup.findOrCreateSolanaUserByWalletAddress(SOLANA_ADDRESS),
+      );
+
+      expect(retry.isNewAccount).toBe(true);
+      expect(retry.user.wallet_address).toBe(SOLANA_ADDRESS);
+      expect(retry.initialCreditsGranted).toBe(true);
+      expect(await countRows("organizations")).toBe(1);
+      expect(await countRows("credit_transactions")).toBe(1);
+      expect(await orgBalanceBySlug(`wallet-solana-${SOLANA_ADDRESS}`)).toBeCloseTo(5, 6);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a pre-leaked org + committed grant (pre-fix state) is reused WITHOUT double-granting",
+    async () => {
+      if (!pgliteReady) throw pgliteError;
+
+      // Simulate the exact residue the old non-transactional path could leak:
+      // org committed, welcome grant committed under the idempotency key, no
+      // user row. A retry must adopt the org and must NOT grant again.
+      const normalized = EVM_ADDRESS_2.toLowerCase();
+      const slug = `wallet-${normalized}`;
+      const idempotencyKey = `wallet-signup:evm:${normalized}`;
+      await dbWrite.execute(
+        `INSERT INTO organizations (name, slug, credit_balance) VALUES ('Leaked', '${slug}', '5');`,
+      );
+      await dbWrite.execute(
+        `INSERT INTO credit_transactions (organization_id, amount, type, description, metadata, stripe_payment_intent_id)
+         SELECT id, '5', 'credit', 'Wallet sign-up bonus',
+                '{"type":"wallet_signup","chain":"evm"}'::jsonb, '${idempotencyKey}'
+         FROM organizations WHERE slug = '${slug}';`,
+      );
+
+      const res = await signupEvm(EVM_ADDRESS_2);
+
+      expect(res.isNewAccount).toBe(true);
+      expect(res.user.role).toBe("owner");
+      expect(res.user.organization?.slug).toBe(slug);
+      // Idempotency: still one grant row, balance unchanged at 5 (not 10).
+      expect(await countRows("organizations")).toBe(1);
+      expect(await countRows("credit_transactions")).toBe(1);
+      expect(await orgBalanceBySlug(slug)).toBeCloseTo(5, 6);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "second sign-in returns the existing user without creating anything new",
+    async () => {
+      if (!pgliteReady) throw pgliteError;
+
+      const first = await signupEvm(EVM_ADDRESS);
+      const again = await signupEvm(EVM_ADDRESS);
+
+      expect(first.isNewAccount).toBe(true);
+      expect(again.isNewAccount).toBe(false);
+      expect(again.user.id).toBe(first.user.id);
+      expect(await countRows("organizations")).toBe(1);
+      expect(await countRows("users")).toBe(1);
+      expect(await countRows("credit_transactions")).toBe(1);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a failing OPTIONAL welcome grant is contained: signup still completes without the bonus",
+    async () => {
+      if (!pgliteReady) throw pgliteError;
+
+      // The grant runs in a savepoint inside the signup transaction. Without
+      // it, this injected credit-insert failure would abort the enclosing
+      // Postgres transaction and the signup would fail entirely — the
+      // designed continue-without-bonus degrade could never fire.
+      await armCreditInsertFailure();
+      const res = await signupEvm(EVM_ADDRESS_3);
+
+      expect(res.isNewAccount).toBe(true);
+      expect(res.initialCreditsGranted).toBe(false);
+      expect(res.welcomeBonusWithheld).toBe(true);
+      expect(await countRows("organizations")).toBe(1);
+      expect(await countRows("users")).toBe(1);
+      expect(await countRows("credit_transactions")).toBe(0);
+      expect(await orgBalanceBySlug(`wallet-${EVM_ADDRESS_3.toLowerCase()}`)).toBeCloseTo(0, 6);
+    },
+    PGLITE_TIMEOUT,
+  );
+});

--- a/packages/cloud/shared/src/lib/services/signup-grant-guard.ts
+++ b/packages/cloud/shared/src/lib/services/signup-grant-guard.ts
@@ -143,6 +143,16 @@ export async function runWithSignupGrantIpCap(
  * Detailed variant of `runWithSignupGrantIpCap` for signup routes that must
  * tell the caller whether a $0 new org means "empty balance" or "welcome
  * bonus withheld by anti-sybil policy".
+ *
+ * With `existingTx` (the atomic wallet-signup transaction) the count + grant
+ * run in a SAVEPOINT inside it, not directly on it: a failed grant statement
+ * would otherwise abort the enclosing Postgres transaction, so the caller's
+ * designed continue-without-bonus degrade (`grantWalletSignupCredits`'s J4
+ * catch) could never work — the subsequent user insert would fail with
+ * "current transaction is aborted" and the whole signup would break for an
+ * optional bonus. An advisory xact lock acquired inside the savepoint is held
+ * until the OUTER transaction commits, which still upholds (in fact
+ * strengthens) the per-IP serialization this guard needs.
  */
 export async function runWithSignupGrantIpCapDetailed(
   ip: string | undefined,
@@ -150,7 +160,14 @@ export async function runWithSignupGrantIpCapDetailed(
   existingTx?: DbTransaction,
 ): Promise<SignupGrantDecision> {
   if (!ip) {
-    await grant(existingTx);
+    if (existingTx) {
+      // Savepoint even without a cap check so a failing grant stays containable.
+      return await existingTx.transaction(async (tx) => {
+        await grant(tx);
+        return { granted: true };
+      });
+    }
+    await grant();
     return { granted: true };
   }
 
@@ -223,5 +240,7 @@ export async function runWithSignupGrantIpCapDetailed(
     return { granted: true };
   };
 
-  return existingTx ? await run(existingTx) : await dbWrite.transaction(run);
+  // `existingTx.transaction(run)` opens a savepoint; `dbWrite.transaction(run)`
+  // opens a top-level transaction. Either way `run` sees a rollback-able tx.
+  return existingTx ? await existingTx.transaction(run) : await dbWrite.transaction(run);
 }

--- a/packages/cloud/shared/src/lib/services/wallet-signup.ts
+++ b/packages/cloud/shared/src/lib/services/wallet-signup.ts
@@ -138,11 +138,20 @@ export async function grantInitialCreditsToWalletAccount(params: {
   return grantResult;
 }
 
+/**
+ * Unique-violation detection that survives driver wrapping: drizzle raises
+ * `DrizzleQueryError` whose message is the failed SQL, with the Postgres error
+ * underneath as `cause` — a top-level message check alone misses it. Walks the
+ * cause chain for the SQLSTATE (23505) and the message shapes.
+ */
 function isUniqueViolation(error: unknown): boolean {
-  return (
-    error instanceof Error &&
-    (error.message.includes("unique") || error.message.includes("duplicate"))
-  );
+  let current: unknown = error;
+  for (let depth = 0; current instanceof Error && depth < 5; depth += 1) {
+    if ((current as Error & { code?: unknown }).code === "23505") return true;
+    if (current.message.includes("unique") || current.message.includes("duplicate")) return true;
+    current = current.cause;
+  }
+  return false;
 }
 
 async function findOrgBySlugForWrite(


### PR DESCRIPTION
Follow-up to #15610. PR #15617 landed the first four fixes (nonce 503 boundary, `validateApiKey` 503, transactional wallet signup, awaited `ensureUserHasApiKey`, postMessage origin) while this lane was in flight; this PR closes the **residual gaps** that survived it, with real-DB proofs.

## Root causes and fixes

### 1. A failing optional welcome grant aborted the whole signup (savepoint containment)
`runWithSignupGrantIpCapDetailed` ran the per-IP count + credit grant **directly on** the wallet-signup transaction (`existingTx`). In Postgres, any failed statement aborts the enclosing transaction — so when the optional bonus grant failed, `grantWalletSignupCredits`'s designed J4 continue-without-bonus catch could never work: the subsequent user insert died with "current transaction is aborted" and the signup failed entirely for an optional bonus.

**Fix:** `packages/cloud/shared/src/lib/services/signup-grant-guard.ts` runs the count + grant in a **SAVEPOINT** (`existingTx.transaction(run)`) when given an enclosing transaction. A failed grant rolls back only the savepoint; signup completes without the bonus. The advisory xact lock is held until the outer transaction commits, which strengthens (never weakens) the per-IP serialization. Proven **red on develop** by the new containment test, green with the fix.

### 2. Unique-violation race recovery missed drizzle-wrapped errors
`isUniqueViolation` in `wallet-signup.ts` checked only the top-level `error.message`. Drizzle raises `DrizzleQueryError` whose message is the failed SQL — the Postgres "duplicate key value violates unique constraint" text lives on `cause`, so a wrapped unique violation was rethrown instead of recovered. Observed concretely in the PGlite runs for this PR.

**Fix:** walk the error `cause` chain and also accept SQLSTATE `23505`.

### 3. Silent config-persist degrade in `eliza auth dev-login` (issue spot 5 — untouched by #15617)
`packages/app-core/src/cli/program/register.auth.ts` logged a **muted aside** when it could not write `ELIZAOS_CLOUD_API_KEY`, then the summary printed the same "not saved (use without --no-save …)" hint as a deliberate `--no-save` — the user believed the agent was cloud-connected while every boot ran without the key.

**Fix (error-policy:J4):** a failed persist is loud — explicit WARNING that the key was **NOT saved**, a copy-pasteable `export ELIZAOS_CLOUD_API_KEY=<key>` remedy, a distinct error-styled summary line, and a first-class `saveError` field on the result (visible to `--json` consumers).

### 4. Real-DB proofs the merged transactional signup lacked
#15617's wallet-signup tests run against a **mocked** `writeTransaction`; nothing proved the actual rollback/no-orphan/idempotent-retry semantics on a real database. New suite `packages/cloud/shared/src/lib/services/__tests__/wallet-signup-orphan-org.test.ts` drives the REAL signup path (real transaction, real credits CTE, real grant guard + advisory lock) against in-process PGlite, with failures injected **in the database** via plpgsql BEFORE INSERT triggers (no mocked seams):
- user-create failure leaves **zero** orgs/users/credit rows (EVM + Solana), and a retry converges with exactly one idempotency-keyed grant;
- pre-fix leaked residue (org + committed grant, no user) is adopted **without double-granting** (balance stays 5, one credit row);
- a second sign-in returns the existing user, creating nothing;
- a failing optional grant is contained: signup completes, `welcomeBonusWithheld: true`, zero credit rows (the savepoint proof).

### 5. Test-coverage gaps in the merged boundary fixes
- `workers-hono-auth.api-key.test.ts`: extended to cover `requireUserOrApiKeyWithOrg` (the guard actually named in the review doc §7b) and the null→**401** invalid-key contrast on both guards — proving the 503 translation didn't swallow the 401 path.
- `auth-default-character-selfheal.test.ts`: proves `ensureUserHasApiKey` is **awaited** (settles on a later tick before session resolution returns — a void-fire would fail the assertion; Workers cancels un-awaited promises).
- `siwe`/`siws` nonce **integration** tests: unlike the merged unit tests (rate limiter stubbed), these run the REAL rate-limit middleware in front of the route and cover the healthy path (nonce issued + binding persisted), the null-client 503, the throwing-Redis 503 (+`Retry-After`), and malformed `chainId` fallback.

## Test evidence

<details>
<summary>cloud/shared — wallet-signup PGlite + guards + selfheal (27 pass / 0 fail)</summary>

```
$ bun test --isolate src/lib/services/__tests__/wallet-signup-orphan-org.test.ts \
    src/lib/services/wallet-signup.error-policy.test.ts \
    src/lib/services/__tests__/wallet-signup-owner-role.test.ts \
    src/lib/auth/workers-hono-auth.api-key.test.ts \
    src/lib/auth-default-character-selfheal.test.ts \
    src/lib/signup-grant-amount.test.ts

 27 pass
 0 fail
 82 expect() calls
Ran 27 tests across 6 files. [9.20s]
```

Red/green proof for the savepoint fix — same suite with develop's (unfixed) signup-grant-guard.ts swapped in:

```
(fail) wallet signup — no orphan org on user-create failure > a failing OPTIONAL
       welcome grant is contained: signup still completes without the bonus
 5 pass
 1 fail
```

…and green again with the fix restored:

```
 6 pass
 0 fail
 44 expect() calls
```
</details>

<details>
<summary>cloud/api — nonce route unit + integration suites (all 4 files pass)</summary>

```
$ node test/run-unit-isolated.mjs nonce
[cloud-api unit] running 4 file(s) isolated (one bun process each)
... route.test.ts (siwe): 1 pass / route.test.ts (siws): 1 pass
... siwe-nonce-redis-outage.test.ts: 4 pass
... siws-nonce-redis-outage.test.ts: 3 pass
[cloud-api unit] all 4 file(s) passed (isolated)
```
</details>

<details>
<summary>app-core — dev-login (4 pass, incl. loud failed-persist)</summary>

```
$ bunx vitest run src/cli/program/register.auth.dev-login.test.ts
 Test Files  1 passed (1)
      Tests  4 passed (4)
```
The new case injects a throwing `saveConfig` (EACCES) and asserts: mint still succeeds, `saveError` set, output contains "WARNING: failed to save ELIZAOS_CLOUD_API_KEY", "NOT saved", and the exact `export ELIZAOS_CLOUD_API_KEY=<key>` remedy.
</details>

<details>
<summary>typecheck / lint / error-policy ratchet</summary>

- `bun run --cwd packages/cloud/shared typecheck` — zero errors in touched files (`grep`-filtered per package guide); the surviving errors (`packages/logger/src/logger.ts`, `plugins/plugin-cloud-apps/src/app-facts.ts`, `db/repositories/agents/*`) reproduce identically on a clean `origin/develop` baseline worktree — pre-existing drift, untouched by this PR.
- `bunx biome check` clean on all 9 touched files.
- `node packages/scripts/error-policy-ratchet.mjs` — "no new fallback-slop in touched files".
</details>

## UI evidence rows

- Video walkthrough: **N/A** — backend/service + CLI-output change; no web/desktop/mobile UI surface changed.
- Before/after full-page screenshots (desktop + mobile): **N/A** — no rendered UI change (the only user-visible change is CLI terminal output, covered by the dev-login test assertions above).
- Frontend console + network logs: **N/A** — no frontend change in this PR (the cli-login postMessage fix already shipped in #15617).
- Real-LLM trajectories: **N/A** — no agent/action/provider/prompt/model behavior touched.
- Backend structured logs: covered by the suites above (`[SignupGrantGuard]`/`[WalletSignup]` warn/error paths fire in the failure-injection tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)