### PR TITLE
fix(ci): run cloud services tests in the cloud lane + schedule sleep-wake smoke (#15603)

### DIFF
--- a/.github/workflows/hetzner-sleep-wake-smoke.yml
+++ b/.github/workflows/hetzner-sleep-wake-smoke.yml
@@ -7,8 +7,26 @@ name: Hetzner Sleep-Wake Smoke
 # runner filesystem standing in for S3/R2 (CI has HCLOUD + SSH, not R2) — the
 # point is to authentically exercise the provision -> capture state ->
 # DESTROY THE BOX -> provision a NEW box -> restore -> verify cycle end to end.
+#
+# Secret gating mirrors hetzner-e2e.yml: on schedule/push, missing or rejected
+# HCLOUD_TOKEN_CI / SSH secrets skip cleanly (exit 0 + loud warning and step
+# summary) so the nightly run can't crash-loop red on forks or stale tokens;
+# a manual workflow_dispatch still fails loudly so an operator sees the
+# broken secret.
+#
+# Required secrets (GitHub environment: ci-hetzner-e2e):
+#   HCLOUD_TOKEN_CI        - Hetzner Cloud API token (CI-scoped project)
+#   CI_SSH_PRIVATE_KEY     - OpenSSH private key (matches the public key
+#                            uploaded to Hetzner)
+#   CI_SSH_PUBLIC_KEY_ID   - Numeric Hetzner SSH key id for the above
 
 on:
+  schedule:
+    # 06:00 UTC nightly — an hour before hetzner-e2e's 07:00 slot. Both
+    # workflows share the `hetzner-e2e` concurrency group (no cancel), so a
+    # long sleep-wake run queues the agent e2e instead of racing it for the
+    # CI project's server quota.
+    - cron: '0 6 * * *'
   workflow_dispatch:
   push:
     branches: [claude/hetzner-provision-smoke]
@@ -35,35 +53,184 @@ jobs:
       HETZNER_E2E_LOCATION: nbg1
       SSH_OPTS: -i /tmp/ci_ssh_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=15 -o BatchMode=yes
     steps:
-      - name: Check secrets
+      - name: Check secret configuration
+        id: secret_config
         run: |
-          for s in HCLOUD_TOKEN_CI CI_SSH_PRIVATE_KEY CI_SSH_PUBLIC_KEY_ID; do
-            [ -z "${!s}" ] && { echo "::error::missing $s"; exit 1; }
-          done; echo ok
+          missing=()
+          [ -z "$HCLOUD_TOKEN_CI" ] && missing+=("HCLOUD_TOKEN_CI")
+          [ -z "$CI_SSH_PRIVATE_KEY" ] && missing+=("CI_SSH_PRIVATE_KEY")
+          [ -z "$CI_SSH_PUBLIC_KEY_ID" ] && missing+=("CI_SSH_PUBLIC_KEY_ID")
+          if [ "${#missing[@]}" -ne 0 ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Missing secrets: ${missing[*]}; skipping Hetzner sleep-wake smoke."
+            {
+              echo "### Hetzner sleep-wake smoke skipped"
+              echo ""
+              echo "Missing secrets in GitHub environment \`ci-hetzner-e2e\`:"
+              for s in "${missing[@]}"; do echo "- \`$s\`"; done
+              echo ""
+              echo "See \`packages/scripts/cloud/admin/hetzner-e2e/README.md\` for setup."
+            } >> "$GITHUB_STEP_SUMMARY"
+            if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+              echo "::error::Manual dispatch requires all hetzner-e2e secrets."
+              exit 1
+            fi
+            exit 0
+          fi
+          echo "configured=true" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+      - name: Checkout
+        if: steps.secret_config.outputs.configured == 'true'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Setup Bun
+        if: steps.secret_config.outputs.configured == 'true'
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: canary
+
       - name: Install deps
+        if: steps.secret_config.outputs.configured == 'true'
         run: bun install --no-save --ignore-scripts
 
       - name: Ensure generated shared i18n data
+        if: steps.secret_config.outputs.configured == 'true'
         run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
 
+      - name: Check Hetzner API token
+        id: hcloud_auth
+        if: steps.secret_config.outputs.configured == 'true'
+        run: |
+          set +e
+          response="$(
+            bun -e '
+              const response = await fetch("https://api.hetzner.cloud/v1/ssh_keys?per_page=1", {
+                headers: {
+                  authorization: `Bearer ${process.env.HCLOUD_TOKEN_CI ?? ""}`,
+                  accept: "application/json",
+                  "user-agent": "hetzner-sleep-wake-preflight/1.0",
+                },
+                signal: AbortSignal.timeout(30_000),
+              });
+              const text = await response.text();
+              console.log(JSON.stringify({ status: response.status, body: text.slice(0, 500) }));
+            '
+          )"
+          status=$?
+          set -e
+          if [ "$status" -ne 0 ]; then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Hetzner API token preflight could not reach api.hetzner.cloud; skipping sleep-wake smoke."
+            {
+              echo "### Hetzner sleep-wake smoke skipped"
+              echo ""
+              echo "Hetzner API token preflight could not reach \`api.hetzner.cloud\` before provisioning capacity."
+              echo ""
+              echo "\`\`\`json"
+              echo "$response"
+              echo "\`\`\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+            if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+              exit 1
+            fi
+            exit 0
+          fi
+
+          status_code="$(printf '%s' "$response" | bun -e 'const chunks=[]; for await (const chunk of Bun.stdin.stream()) chunks.push(Buffer.from(chunk)); const data = JSON.parse(Buffer.concat(chunks).toString() || "{}"); console.log(data.status ?? "");')"
+          if [ "$status_code" = "401" ] || [ "$status_code" = "403" ]; then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Hetzner rejected HCLOUD_TOKEN_CI with HTTP $status_code; skipping sleep-wake smoke before provisioning."
+            {
+              echo "### Hetzner sleep-wake smoke skipped"
+              echo ""
+              echo "Hetzner rejected \`HCLOUD_TOKEN_CI\` with HTTP \`$status_code\` before provisioning capacity."
+              echo ""
+              echo "Refresh \`HCLOUD_TOKEN_CI\` in the \`ci-hetzner-e2e\` environment, or confirm the Hetzner project is still active."
+            } >> "$GITHUB_STEP_SUMMARY"
+            if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+              exit 1
+            fi
+            exit 0
+          fi
+
+          if [ "${status_code#2}" != "$status_code" ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${status_code#5}" != "$status_code" ]; then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Hetzner API token preflight returned HTTP $status_code; skipping sleep-wake smoke before provisioning."
+            {
+              echo "### Hetzner sleep-wake smoke skipped"
+              echo ""
+              echo "Hetzner API token preflight returned HTTP \`$status_code\` before provisioning capacity."
+              echo ""
+              echo "\`\`\`json"
+              echo "$response"
+              echo "\`\`\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+            if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+              exit 1
+            fi
+            exit 0
+          fi
+
+          echo "::error::Unexpected Hetzner API token preflight response: $response"
+          exit 1
+
       - name: Write SSH key
+        if: steps.secret_config.outputs.configured == 'true' && steps.hcloud_auth.outputs.ready == 'true'
         run: |
           printf '%s\n' "$CI_SSH_PRIVATE_KEY" > /tmp/ci_ssh_key
           chmod 600 /tmp/ci_ssh_key
 
       # ── Provision box A + boot ──────────────────────────────────────────
       - name: Provision box A
-        run: bun run packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-provision.ts
+        id: provision_a
+        if: steps.secret_config.outputs.configured == 'true' && steps.hcloud_auth.outputs.ready == 'true'
+        run: |
+          log=/tmp/hetzner-sleep-wake-provision.log
+          set +e
+          bun run packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-provision.ts 2>&1 | tee "$log"
+          rc=${PIPESTATUS[0]}
+          set -e
+          if [ "$rc" -eq 0 ]; then
+            echo "provisioned=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # A rejected / expired / read-only HCLOUD_TOKEN_CI (or a deactivated
+          # project) surfaces as HTTP 401/403 when CREATING the server — the
+          # read-only preflight above can pass while this write fails. That is
+          # an operator secret problem, not a code regression: warn + skip on
+          # push/schedule, fail loudly on manual dispatch (same policy as
+          # hetzner-e2e.yml).
+          if grep -qE "Hetzner rejected the token|missing_token|permission denied|HTTP 401|HTTP 403|status: 401|status: 403" "$log"; then
+            echo "provisioned=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Hetzner rejected HCLOUD_TOKEN_CI (HTTP 401/403); skipping sleep-wake smoke. Refresh the token in the ci-hetzner-e2e environment."
+            {
+              echo "### Hetzner sleep-wake smoke skipped"
+              echo ""
+              echo "Hetzner rejected \`HCLOUD_TOKEN_CI\` (HTTP 401/403 \`missing_token\` / permission denied) when creating the server."
+              echo ""
+              echo "The token may be read-only or expired for writes. Refresh \`HCLOUD_TOKEN_CI\` in the \`ci-hetzner-e2e\` environment with a read-write CI token, or confirm the project is active."
+            } >> "$GITHUB_STEP_SUMMARY"
+            if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+              exit 1
+            fi
+            exit 0
+          fi
+          # Any other provision failure is real — surface it (red).
+          echo "provisioned=false" >> "$GITHUB_OUTPUT"
+          exit "$rc"
+
       - name: Wait A ready
+        if: steps.provision_a.outputs.provisioned == 'true'
         run: bun run packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-wait-ready.ts
 
       # ── Write agent state on A, then BACK IT UP off-box ─────────────────
       - name: Write + back up agent state from A
+        if: steps.provision_a.outputs.provisioned == 'true'
         run: |
           IP_A=$(jq -r .ip "$HETZNER_E2E_STATE_FILE"); ID_A=$(jq -r .id "$HETZNER_E2E_STATE_FILE")
           echo "box A: id=$ID_A ip=$IP_A"
@@ -79,6 +246,7 @@ jobs:
 
       # ── SLEEP: de-provision (destroy) box A ─────────────────────────────
       - name: Sleep — de-provision (destroy) box A
+        if: steps.provision_a.outputs.provisioned == 'true'
         run: |
           bun run packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-teardown.ts
           ID_A=$(cat /tmp/box-a-id)
@@ -88,10 +256,13 @@ jobs:
 
       # ── WAKE: re-provision a NEW box B + restore from backup ────────────
       - name: Wake — re-provision box B
+        if: steps.provision_a.outputs.provisioned == 'true'
         run: bun run packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-provision.ts
       - name: Wait B ready
+        if: steps.provision_a.outputs.provisioned == 'true'
         run: bun run packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-wait-ready.ts
       - name: Restore backup onto B + verify state survived
+        if: steps.provision_a.outputs.provisioned == 'true'
         run: |
           IP_B=$(jq -r .ip "$HETZNER_E2E_STATE_FILE"); ID_B=$(jq -r .id "$HETZNER_E2E_STATE_FILE")
           ID_A=$(cat /tmp/box-a-id)
@@ -104,6 +275,14 @@ jobs:
           ssh $SSH_OPTS root@"$IP_B" "grep -q orbital-mango-4417 /root/agent-state-restored.json" \
             && echo "PASS: agent state survived sleep(destroy A) -> wake(new box B) -> restore"
 
+      # Runs whenever provisioning was ATTEMPTED (success or failure — a failed
+      # create can still leak a server), and skips only when provisioning never
+      # started. DEPLOY_PROVISIONED lets the teardown script distinguish "dead
+      # token, nothing was provisioned, nothing can leak" (soft-skip) from
+      # "dead token but a server exists" (hard fail so the leak is never
+      # silent) — same contract as hetzner-e2e.yml's teardown job.
       - name: Teardown box B (always)
-        if: always()
+        if: always() && steps.provision_a.outcome != 'skipped'
+        env:
+          DEPLOY_PROVISIONED: ${{ steps.provision_a.outputs.provisioned }}
         run: bun run packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-teardown.ts

--- a/packages/cloud/services/container-control-plane/AGENTS.md
+++ b/packages/cloud/services/container-control-plane/AGENTS.md
@@ -43,9 +43,13 @@ bun run --cwd packages/cloud/services/container-control-plane start      # bun r
 bun run --cwd packages/cloud/services/container-control-plane dev        # --watch
 bun run --cwd packages/cloud/services/container-control-plane typecheck  # tsgo --noEmit
 bun run --cwd packages/cloud/services/container-control-plane lint       # biome check
+bun run --cwd packages/cloud/services/container-control-plane test       # bun test (src/*.test.ts)
 ```
 
-There are no tests in this package.
+Tests are colocated bun:test files under `src/` (e.g.
+`src/require-internal-token.test.ts`, the H4 fail-closed token-gate proof).
+They run in the PR-lane cloud sweep (`bun run test:cloud` via
+`packages/scripts/test-cloud-run.mjs`) and in the workspace `test` script.
 
 ## Conventions / gotchas
 

--- a/packages/cloud/services/container-control-plane/CLAUDE.md
+++ b/packages/cloud/services/container-control-plane/CLAUDE.md
@@ -43,9 +43,13 @@ bun run --cwd packages/cloud/services/container-control-plane start      # bun r
 bun run --cwd packages/cloud/services/container-control-plane dev        # --watch
 bun run --cwd packages/cloud/services/container-control-plane typecheck  # tsgo --noEmit
 bun run --cwd packages/cloud/services/container-control-plane lint       # biome check
+bun run --cwd packages/cloud/services/container-control-plane test       # bun test (src/*.test.ts)
 ```
 
-There are no tests in this package.
+Tests are colocated bun:test files under `src/` (e.g.
+`src/require-internal-token.test.ts`, the H4 fail-closed token-gate proof).
+They run in the PR-lane cloud sweep (`bun run test:cloud` via
+`packages/scripts/test-cloud-run.mjs`) and in the workspace `test` script.
 
 ## Conventions / gotchas
 

--- a/packages/cloud/services/container-control-plane/package.json
+++ b/packages/cloud/services/container-control-plane/package.json
@@ -8,6 +8,7 @@
     "dev": "bun --watch run src/index.ts",
     "start": "bun run src/index.ts",
     "typecheck": "tsgo --noEmit",
+    "test": "bun test",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
     "lint:check": "bunx @biomejs/biome check .",
     "lint:fix": "bunx @biomejs/biome check --write --unsafe .",

--- a/packages/cloud/services/operator/AGENTS.md
+++ b/packages/cloud/services/operator/AGENTS.md
@@ -43,7 +43,7 @@ bun run --cwd packages/cloud/services/operator lint         # biome check .
 bun run --cwd packages/cloud/services/operator lint:fix     # biome check --write .
 bun run --cwd packages/cloud/services/operator build        # node ./scripts/build.mjs (pepr build)
 bun run --cwd packages/cloud/services/operator dev          # bunx pepr dev (needs a cluster)
-bun test --cwd packages/cloud/services/operator             # capabilities/__tests__ (bun:test)
+bun run --cwd packages/cloud/services/operator test         # bun test — capabilities/__tests__; also swept by the PR-lane `bun run test:cloud`
 ```
 
 `deploy:local` runs `pepr build` (with `ELIZA_OPERATOR_SKIP_CRD_REGISTER=1`)

--- a/packages/cloud/services/operator/CLAUDE.md
+++ b/packages/cloud/services/operator/CLAUDE.md
@@ -43,7 +43,7 @@ bun run --cwd packages/cloud/services/operator lint         # biome check .
 bun run --cwd packages/cloud/services/operator lint:fix     # biome check --write .
 bun run --cwd packages/cloud/services/operator build        # node ./scripts/build.mjs (pepr build)
 bun run --cwd packages/cloud/services/operator dev          # bunx pepr dev (needs a cluster)
-bun test --cwd packages/cloud/services/operator             # capabilities/__tests__ (bun:test)
+bun run --cwd packages/cloud/services/operator test         # bun test — capabilities/__tests__; also swept by the PR-lane `bun run test:cloud`
 ```
 
 `deploy:local` runs `pepr build` (with `ELIZA_OPERATOR_SKIP_CRD_REGISTER=1`)

--- a/packages/cloud/services/operator/capabilities/__tests__/reconciler-previous-agents.test.ts
+++ b/packages/cloud/services/operator/capabilities/__tests__/reconciler-previous-agents.test.ts
@@ -6,7 +6,7 @@
  */
 import { describe, expect, test } from "bun:test";
 import type { Server } from "../crd/generated/server-v1alpha1";
-import { getPreviousAgentIds } from "../reconciler";
+import { getPreviousAgentIds } from "../previous-agents";
 
 function serverWithAnnotation(value: string | undefined): Server {
   return {

--- a/packages/cloud/services/operator/capabilities/previous-agents.ts
+++ b/packages/cloud/services/operator/capabilities/previous-agents.ts
@@ -1,0 +1,36 @@
+/**
+ * Parses the `eliza.ai/previous-agents` annotation the reconciler stamps on a
+ * Server CR so the next reconcile can diff away agents that were removed from
+ * the spec. Lives apart from reconciler.ts so the parsing contract is unit
+ * testable without loading the pepr/kubernetes-fluent-client runtime graph
+ * (pepr's CJS bundle `require()`s kubernetes-fluent-client, whose top-level
+ * await makes that require fail under bun's per-file test isolation).
+ */
+import type { Server } from "./crd/generated/server-v1alpha1";
+
+export function getPreviousAgentIds(instance: Server): string[] {
+  const annotation =
+    instance.metadata?.annotations?.["eliza.ai/previous-agents"];
+  // Absent annotation legitimately means "no prior agents" (first reconcile).
+  if (!annotation) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(annotation);
+  } catch (err) {
+    // A corrupt annotation must NOT read as "no previous agents": that would
+    // silently skip removeAgentServer() for agents dropped since the last
+    // reconcile, leaking stale Redis routing keys. Throw to the reconcile
+    // loop's J1 boundary so the failure is logged and the annotation is not
+    // overwritten with a lie.
+    throw new Error(
+      `Server ${instance.metadata?.name ?? "<unknown>"}: corrupt eliza.ai/previous-agents annotation`,
+      { cause: err },
+    );
+  }
+  if (!Array.isArray(parsed) || parsed.some((id) => typeof id !== "string")) {
+    throw new Error(
+      `Server ${instance.metadata?.name ?? "<unknown>"}: eliza.ai/previous-agents annotation is not a string array`,
+    );
+  }
+  return parsed;
+}

--- a/packages/cloud/services/operator/capabilities/reconciler.ts
+++ b/packages/cloud/services/operator/capabilities/reconciler.ts
@@ -2,6 +2,7 @@
 import { K8s, Log } from "pepr";
 import { applyResources } from "./controller/generators";
 import { Server } from "./crd/generated/server-v1alpha1";
+import { getPreviousAgentIds } from "./previous-agents";
 import {
   cleanupServer,
   removeAgentServer,
@@ -102,33 +103,6 @@ export async function finalizer(instance: Server) {
   await cleanupServer(name, agentIds);
 
   Log.info(`Server ${name}: Redis cleanup complete`);
-}
-
-export function getPreviousAgentIds(instance: Server): string[] {
-  const annotation =
-    instance.metadata?.annotations?.["eliza.ai/previous-agents"];
-  // Absent annotation legitimately means "no prior agents" (first reconcile).
-  if (!annotation) return [];
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(annotation);
-  } catch (err) {
-    // A corrupt annotation must NOT read as "no previous agents": that would
-    // silently skip removeAgentServer() for agents dropped since the last
-    // reconcile, leaking stale Redis routing keys. Throw to the reconcile
-    // loop's J1 boundary (below) so the failure is logged and the annotation
-    // is not overwritten with a lie.
-    throw new Error(
-      `Server ${instance.metadata?.name ?? "<unknown>"}: corrupt eliza.ai/previous-agents annotation`,
-      { cause: err },
-    );
-  }
-  if (!Array.isArray(parsed) || parsed.some((id) => typeof id !== "string")) {
-    throw new Error(
-      `Server ${instance.metadata?.name ?? "<unknown>"}: eliza.ai/previous-agents annotation is not a string array`,
-    );
-  }
-  return parsed;
 }
 
 async function updateStatus(instance: Server, status: Server["status"]) {

--- a/packages/cloud/services/operator/capabilities/redis.ts
+++ b/packages/cloud/services/operator/capabilities/redis.ts
@@ -8,7 +8,12 @@ const AGENT_ROUTING_TTL_SECONDS = 30 * 24 * 3600;
 let client: Redis | null = null;
 
 function createMockRedis(): Redis {
-  const requireCJS = createRequire(`${process.cwd()}/package.json`);
+  // Resolve ioredis-mock from THIS module's location, not the process cwd:
+  // the cloud test lane (packages/scripts/test-cloud-run.mjs) runs bun test
+  // from a staging directory where a cwd-based require can't see the
+  // operator's node_modules. The mock branch is test-only (MOCK_REDIS=1), so
+  // the pepr/esbuild CJS bundle never executes it in production.
+  const requireCJS = createRequire(import.meta.url);
   // biome-ignore lint/suspicious/noExplicitAny: ESM/CJS interop with ioredis-mock
   const mod = requireCJS("ioredis-mock") as any;
   const Ctor = mod?.default ?? mod;

--- a/packages/cloud/services/operator/package.json
+++ b/packages/cloud/services/operator/package.json
@@ -38,6 +38,7 @@
     "format": "bunx @biomejs/biome format --write .",
     "format:check": "bunx @biomejs/biome format .",
     "typecheck": "tsgo --noEmit",
+    "test": "bun test",
     "build": "node ./scripts/build.mjs",
     "clean": "rm -rf dist",
     "dev": "bunx pepr dev",

--- a/packages/scripts/test-cloud-run.mjs
+++ b/packages/scripts/test-cloud-run.mjs
@@ -84,6 +84,17 @@ const cloudInfraTests = path.join(
   "infra",
   "tests",
 );
+// The deployable cloud services (agent-server, container-control-plane,
+// operator, gateways, coding-remote-runner, _common) carry bun:test suites,
+// and cloud-tests.yml triggers on `packages/cloud/services/**` — but this
+// runner never swept them, and container-control-plane/operator had no `test`
+// script either, so their suites (the H4 fail-closed token gate, the #12268
+// annotation-corruption proof) executed in NO CI lane: a services change went
+// green without its tests running (#15603). Sweep the whole directory. The
+// gateway suites also run in their dedicated workflows
+// (cloud-gateway-discord/-webhook); they are self-contained bun:test files,
+// so the duplicate coverage here is cheap and keeps this gate layout-proof.
+const cloudServicesRoot = path.join(repoRoot, "packages", "cloud", "services");
 
 // Fail loud if a test root is missing. `bun test <nonexistent-dir>` exits 0 with
 // no tests run, so a stale path (e.g. after a package move) turns this gate into
@@ -116,6 +127,7 @@ const testRoots = {
   cloudScriptsTests,
   cloudRoutingTests,
   cloudInfraTests,
+  cloudServicesRoot,
 };
 const missing = Object.entries(testRoots)
   .filter(([, dir]) => !existsSync(dir))
@@ -142,6 +154,19 @@ if (cloudApiUnitTests.length === 0) {
   process.exit(1);
 }
 
+const cloudServicesTests = walkTests(cloudServicesRoot, EXCLUDED_DIRS).sort();
+
+// Same fail-loud guard as cloud/api: if a reorg moves the services suites,
+// this gate must break instead of silently running zero services tests.
+if (cloudServicesTests.length === 0) {
+  console.error(
+    `[test:cloud] no cloud/services tests found under ${cloudServicesRoot} — ` +
+      "the gate would silently run zero services tests. Update packages/scripts/test-cloud-run.mjs " +
+      "to match the current package layout.",
+  );
+  process.exit(1);
+}
+
 // The full unit set is ~700 files. bun's `--isolate` gives each file a fresh
 // global but keeps ONE process, so JS heap plus external (pglite/WASM) memory
 // accumulates monotonically across the whole run — RSS climbs past 7 GB. On the
@@ -158,6 +183,7 @@ const allTestFiles = [
   ...walkTests(cloudScriptsTests, EXCLUDED_DIRS),
   ...walkTests(cloudRoutingTests, EXCLUDED_DIRS),
   ...walkTests(cloudInfraTests, EXCLUDED_DIRS),
+  ...cloudServicesTests,
 ];
 if (allTestFiles.length === 0) {
   console.error(


### PR DESCRIPTION
> **Description corrected post-merge** — the original body was pasted from a different work item (#15603 B5, the backup verifier) and described none of this PR's changes. Below is what this PR actually does, with the real evidence. Flagged in the post-merge adversarial review.

Epic #15603, items A1 + A2: kill the cloud-services CI false-green and put the real-infra crash/restore drill on a schedule.

## Problem

`cloud-tests.yml` triggers on `packages/cloud/services/**` paths, but the cloud lane (`packages/scripts/test-cloud-run.mjs`) never swept those directories, and `container-control-plane` + `operator` had no `test` script — so their tests executed in **no CI lane at all**. A change there could pass CI without its tests ever running. Separately, `hetzner-sleep-wake-smoke.yml` — the only real-infra backup→destroy→restore proof — was dispatch-only.

## Changes

- `packages/scripts/test-cloud-run.mjs`: sweeps `packages/cloud/services/**` (10 services, 20 bun:test files, 162 tests) with the same fail-loud missing-root/zero-tests guards as existing roots.
- `container-control-plane/package.json`, `operator/package.json`: `"test": "bun test"` (agent-server's pattern); package docs corrected (container-control-plane's doc falsely claimed it had no tests).
- Two real test fixes uncovered by the sweep, fixed at the root:
  - operator: extracted `getPreviousAgentIds` into pepr-free `capabilities/previous-agents.ts` (the test statically imported the reconciler graph; pepr's CJS bundle `require()`s a top-level-await ESM module that bun's per-file isolation can't load). `pepr build` verified green, function present in the built bundle.
  - operator `capabilities/redis.ts`: `createRequire(import.meta.url)` instead of `createRequire(process.cwd()+"/package.json")` so `ioredis-mock` resolves under the lane's staging cwd — mock branch remains test-only behind `MOCK_REDIS=1`; production Redis path untouched (verified in built bundle).
- `.github/workflows/hetzner-sleep-wake-smoke.yml`: nightly cron `0 6 * * *` (one hour before hetzner-e2e; shared no-cancel `hetzner-e2e` concurrency group so they queue). Honest-skip secret gating mirrored block-for-block from `hetzner-e2e.yml` (green-skip + warning on schedule/push when secrets missing/rejected; hard-fail on manual dispatch). Teardown runs whenever provisioning was attempted; the half-hourly reaper covers leaks (shared `ci=true,workflow=hetzner-e2e` labels).

## Evidence

<details><summary>Full cloud lane under CI's pinned bun 1.3.14 — exit 0, 10/10 batches, 5,750 tests / 0 fail across 724 files (services in batches 9–10)</summary>

Reproduced by the post-merge adversarial review with the exact lane semantics (staging cwd, `DATABASE_URL=pglite://memory`, `--isolate`): 162 pass / 0 fail across 20 services files in 7.7s. Standalone: operator 6/6, container-control-plane 8/8. `actionlint` clean on the workflow. `pepr build` green.
</details>

- Video walkthrough: **N/A** - CI/test-harness change; no UI surface.
- Before screenshots (desktop + mobile): **N/A** - no rendered UI.
- After screenshots (desktop + mobile): **N/A** - no rendered UI.
- Frontend console + network logs: **N/A** - no frontend change.
- Real-LLM trajectories: **N/A** - no agent/model behavior touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)