### PR TITLE
fix(cloud): propagate bridge failureKind; e2e chat rejects canned failure replies (#15616)

### DIFF
--- a/.github/workflows/scenario-pr.yml
+++ b/.github/workflows/scenario-pr.yml
@@ -859,6 +859,13 @@ jobs:
       - name: Per-plugin keyless e2e coverage self-test
         run: bun test packages/scripts/e2e-coverage/check-e2e-coverage.test.ts
 
+      # #15616: pass/fail classifier for the live cloud chat smokes
+      # (hetzner-e2e-chat, live-cloud-provision-smoke). packages/scripts is
+      # outside workspace test discovery, so keep this explicit or canned
+      # failure replies can silently start passing the nightly again.
+      - name: Bridge chat-reply verdict classifier
+        run: bun test packages/scripts/cloud/admin/bridge-reply-verdict.test.ts
+
       - name: Per-plugin keyless e2e coverage gate
         run: bun run audit:e2e-coverage
 

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-failurekind.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-failurekind.test.ts
@@ -1,0 +1,142 @@
+/**
+ * The bridge `message.send` ladder must propagate the runtime's `failureKind`
+ * discriminator and tag which rung replied (#15616).
+ *
+ * The agent runtime answers HTTP 200 with canned text plus `failureKind` when
+ * its model path is dead; the bridge used to extract only `text`, so its
+ * `fallback: true` fabrication flag never fired and e2e chat checks passed on
+ * canned failures. Both ladder implementations (the standalone bridge service
+ * and the duplicate on the host service — the one production `bridge()` runs)
+ * must now surface `failureKind` and a `transport` tag, while KEEPING the
+ * text-short-circuit semantics: a canned failure reply still ends the ladder
+ * so gateway/REST consumers deliver the designed failure text instead of the
+ * fabricated generic fallback. Real ladder methods; only the sandbox-side HTTP
+ * boundary (fetch) is stubbed.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import type { AgentSandbox } from "../../db/repositories/agent-sandboxes";
+import { ElizaSandboxService } from "./eliza-sandbox";
+import type { BridgeRequest, BridgeResponse } from "./eliza-sandbox-bridge";
+import { ElizaSandboxBridgeService } from "./eliza-sandbox-bridge";
+
+type MessageSender = {
+  bridgeMessageSend(rec: AgentSandbox, rpc: BridgeRequest): Promise<BridgeResponse>;
+};
+
+const rec = {
+  id: "sandbox-1",
+  bridge_url: "http://sandbox.test",
+  environment_vars: {},
+} as unknown as AgentSandbox;
+
+const rpc: BridgeRequest = {
+  jsonrpc: "2.0",
+  id: "test-1",
+  method: "message.send",
+  params: {
+    text: "Reply with one short sentence that contains the token pong-123.",
+    roomId: "room-1",
+  },
+};
+
+const endpointStubs = {
+  getAgentApiEndpoint: async (_rec: unknown, path: string) => `http://sandbox.test${path}`,
+  getAgentJsonHeaders: () => ({ "content-type": "application/json" }),
+  ensureRuntimeAgentStarted: async () => ({ id: "runtime-agent-1", name: "Smoke" }),
+};
+
+// The host service's ladder duplicate is what production bridge() dispatches
+// to; shadow its private endpoint helpers so no tailnet lookup happens.
+const senders: Array<[string, () => MessageSender]> = [
+  [
+    "ElizaSandboxBridgeService",
+    () => new ElizaSandboxBridgeService(endpointStubs as never) as unknown as MessageSender,
+  ],
+  [
+    "ElizaSandboxService",
+    () => {
+      const hostService = new ElizaSandboxService() as unknown as MessageSender &
+        Record<string, unknown>;
+      Object.assign(hostService, endpointStubs);
+      return hostService;
+    },
+  ],
+];
+
+/**
+ * Stub the sandbox HTTP surface: the native /bridge and every REST rung except
+ * the conversation route 404 (legacy-image shape), the conversation route
+ * returns `messageBody`. Records every requested path for ladder assertions.
+ */
+function installFetchStub(messageBody: Record<string, unknown>): string[] {
+  const paths: string[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    const path = new URL(url).pathname;
+    paths.push(path);
+    if (path === "/api/conversations") {
+      return Response.json({ conversation: { id: "conv-1" } });
+    }
+    if (path === "/api/conversations/conv-1/messages") {
+      return Response.json(messageBody);
+    }
+    return new Response("not found", { status: 404 });
+  }) as typeof fetch;
+  return paths;
+}
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+for (const [label, make] of senders) {
+  describe(`${label}.bridgeMessageSend failureKind propagation`, () => {
+    test("canned failure reply keeps its text, carries failureKind, and still ends the ladder", async () => {
+      const paths = installFetchStub({
+        text: "Sorry, I'm having a provider issue",
+        agentName: "Smoke",
+        failureKind: "provider_issue",
+      });
+
+      const response = await make().bridgeMessageSend(rec, rpc);
+
+      expect(response.error).toBeUndefined();
+      expect(response.result?.text).toBe("Sorry, I'm having a provider issue");
+      expect(response.result?.failureKind).toBe("provider_issue");
+      expect(response.result?.transport).toBe("conversation-rest");
+      // NOT the bridge's own fabrication — the runtime really replied.
+      expect(response.result?.fallback).toBeUndefined();
+      // Production semantics kept: the canned text short-circuits the ladder,
+      // so the slower OpenAI-compat / central-channel rungs never fire.
+      expect(paths).not.toContain("/v1/chat/completions");
+      expect(paths.some((p) => p.startsWith("/api/messaging/central-channels/"))).toBe(false);
+    });
+
+    test("genuine reply is unchanged apart from the additive transport tag", async () => {
+      installFetchStub({
+        text: "Sure — the token is pong-123.",
+        agentName: "Smoke",
+      });
+
+      const response = await make().bridgeMessageSend(rec, rpc);
+
+      expect(response.result?.text).toBe("Sure — the token is pong-123.");
+      expect(response.result?.failureKind).toBeUndefined();
+      expect(response.result?.fallback).toBeUndefined();
+      expect(response.result?.transport).toBe("conversation-rest");
+    });
+
+    test("empty reply still falls through the ladder into the flagged fabrication", async () => {
+      const paths = installFetchStub({ text: "" });
+
+      const response = await make().bridgeMessageSend(rec, rpc);
+
+      // Every rung came up empty, so the bridge fabricates — and says so.
+      expect(response.result?.fallback).toBe(true);
+      expect(response.result?.reason).toBe("agent_no_reply");
+      expect(response.result?.transport).toBe("fallback");
+      expect(paths).toContain("/v1/chat/completions");
+    });
+  });
+}

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge.ts
@@ -431,6 +431,7 @@ export class ElizaSandboxBridgeService {
           text: fallbackText,
           fallback: true,
           reason: "agent_no_reply",
+          transport: "fallback",
         },
       };
     }
@@ -444,8 +445,28 @@ export class ElizaSandboxBridgeService {
     };
   }
 
+  // Deliberately text-only: a runtime-side canned failure reply (result carries
+  // `failureKind`, e.g. "provider issue" / credits-depleted text from
+  // packages/agent chat routes) still short-circuits the ladder. Production
+  // consumers (agent-gateway connectors, provisioning jobs, the REST adapters)
+  // surface that designed failure text to end users; falling through would
+  // replace it with the fabricated generic fallback and add up to ~50s of
+  // central-channel polling per failed turn. Strict callers (the e2e chat
+  // scripts) reject on the propagated `failureKind` instead (#15616).
   private bridgeResponseHasText(response: BridgeResponse): boolean {
     return typeof response.result?.text === "string" && response.result.text.trim().length > 0;
+  }
+
+  /**
+   * The agent runtime's conversation route answers HTTP 200 with canned text
+   * plus a `failureKind` discriminator when the model path is dead (provider
+   * issue, rate limit, credit exhaustion, no provider). Surface it so callers
+   * can tell a genuine model reply from a canned failure (#15616).
+   */
+  private extractBridgeFailureKind(body: Record<string, unknown>): string | undefined {
+    return typeof body.failureKind === "string" && body.failureKind.trim()
+      ? body.failureKind.trim()
+      : undefined;
   }
 
   private async bridgeConversationMessageSend(
@@ -473,6 +494,7 @@ export class ElizaSandboxBridgeService {
     }
 
     const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    const failureKind = this.extractBridgeFailureKind(body);
     return {
       jsonrpc: "2.0",
       id: rpc.id,
@@ -480,6 +502,8 @@ export class ElizaSandboxBridgeService {
         text: this.extractBridgeMessageText(body) ?? "",
         agentName: typeof body.agentName === "string" ? body.agentName : undefined,
         conversationId,
+        transport: "conversation-rest",
+        ...(failureKind ? { failureKind } : {}),
       },
     };
   }
@@ -539,6 +563,7 @@ export class ElizaSandboxBridgeService {
         runtimeAgentId: runtimeAgent.id,
         agentName: runtimeAgent.name,
         channelId,
+        transport: "central-channel",
         messageId:
           typeof data.id === "string" ? data.id : typeof body.id === "string" ? body.id : undefined,
       },
@@ -572,6 +597,7 @@ export class ElizaSandboxBridgeService {
         text: this.extractOpenAiChatCompletionText(body) ?? "",
         model: typeof body.model === "string" ? body.model : undefined,
         completionId: typeof body.id === "string" ? body.id : undefined,
+        transport: "openai-compat",
       },
     };
   }

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -435,6 +435,7 @@ describe("ElizaSandboxService shared runtime bridge", () => {
             model: "none",
             degraded: true,
             runtime: "shared",
+            transport: "shared-runtime",
           },
         });
         expect(historyGetSpy).toHaveBeenCalled();

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -2459,6 +2459,7 @@ export class ElizaSandboxService {
           model: turn.model,
           degraded: turn.degraded,
           runtime: "shared",
+          transport: "shared-runtime",
         },
       };
     } catch (settleError) {
@@ -2729,6 +2730,7 @@ export class ElizaSandboxService {
           text: fallbackText,
           fallback: true,
           reason: "agent_no_reply",
+          transport: "fallback",
         },
       };
     }
@@ -2742,8 +2744,28 @@ export class ElizaSandboxService {
     };
   }
 
+  // Deliberately text-only: a runtime-side canned failure reply (result carries
+  // `failureKind`, e.g. "provider issue" / credits-depleted text from
+  // packages/agent chat routes) still short-circuits the ladder. Production
+  // consumers (agent-gateway connectors, provisioning jobs, the REST adapters)
+  // surface that designed failure text to end users; falling through would
+  // replace it with the fabricated generic fallback and add up to ~50s of
+  // central-channel polling per failed turn. Strict callers (the e2e chat
+  // scripts) reject on the propagated `failureKind` instead (#15616).
   private bridgeResponseHasText(response: BridgeResponse): boolean {
     return typeof response.result?.text === "string" && response.result.text.trim().length > 0;
+  }
+
+  /**
+   * The agent runtime's conversation route answers HTTP 200 with canned text
+   * plus a `failureKind` discriminator when the model path is dead (provider
+   * issue, rate limit, credit exhaustion, no provider). Surface it so callers
+   * can tell a genuine model reply from a canned failure (#15616).
+   */
+  private extractBridgeFailureKind(body: Record<string, unknown>): string | undefined {
+    return typeof body.failureKind === "string" && body.failureKind.trim()
+      ? body.failureKind.trim()
+      : undefined;
   }
 
   /**
@@ -2797,7 +2819,14 @@ export class ElizaSandboxService {
     return {
       jsonrpc: "2.0",
       id: rpc.id,
-      ...(body.result ? { result: body.result as BridgeResponse["result"] } : {}),
+      ...(body.result
+        ? {
+            result: {
+              ...(body.result as Record<string, unknown>),
+              transport: "native-jsonrpc",
+            } as BridgeResponse["result"],
+          }
+        : {}),
       ...(body.error ? { error: body.error as BridgeResponse["error"] } : {}),
     };
   }
@@ -2827,6 +2856,7 @@ export class ElizaSandboxService {
     }
 
     const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    const failureKind = this.extractBridgeFailureKind(body);
     return {
       jsonrpc: "2.0",
       id: rpc.id,
@@ -2834,6 +2864,8 @@ export class ElizaSandboxService {
         text: this.extractBridgeMessageText(body) ?? "",
         agentName: typeof body.agentName === "string" ? body.agentName : undefined,
         conversationId,
+        transport: "conversation-rest",
+        ...(failureKind ? { failureKind } : {}),
       },
     };
   }
@@ -2942,6 +2974,7 @@ export class ElizaSandboxService {
         runtimeAgentId: runtimeAgent.id,
         agentName: runtimeAgent.name,
         channelId,
+        transport: "central-channel",
         messageId:
           typeof data.id === "string" ? data.id : typeof body.id === "string" ? body.id : undefined,
       },
@@ -2975,6 +3008,7 @@ export class ElizaSandboxService {
         text: this.extractOpenAiChatCompletionText(body) ?? "",
         model: typeof body.model === "string" ? body.model : undefined,
         completionId: typeof body.id === "string" ? body.id : undefined,
+        transport: "openai-compat",
       },
     };
   }

--- a/packages/scripts/cloud/admin/bridge-reply-verdict.test.ts
+++ b/packages/scripts/cloud/admin/bridge-reply-verdict.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Pass/fail contract for the e2e chat scripts' bridge-reply classifier
+ * (#15616): a genuine token echo passes; every fabrication shape the bridge
+ * and runtime can produce — fallback:true, failureKind-tagged canned text,
+ * bare canned strings, degraded shared turns, cloud-agent echoes, empty —
+ * fails. Pure classifier, no network.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  classifyBridgeReply,
+  KNOWN_CANNED_FAILURE_REPLIES,
+} from "./bridge-reply-verdict";
+
+const TOKEN = "hetzner-pong-abc123";
+
+describe("classifyBridgeReply", () => {
+  test("genuine reply echoing the token passes and reports its transport", () => {
+    const verdict = classifyBridgeReply(
+      {
+        text: `Sure — here is the token ${TOKEN} as requested.`,
+        agentName: "Smoke",
+        transport: "conversation-rest",
+      },
+      TOKEN,
+    );
+    expect(verdict.ok).toBe(true);
+    expect(verdict.reason).toBeNull();
+    expect(verdict.transport).toBe("conversation-rest");
+  });
+
+  test("pre-#15616 bridges without a transport tag report unknown", () => {
+    const verdict = classifyBridgeReply(
+      { text: `token ${TOKEN} echoed` },
+      TOKEN,
+    );
+    expect(verdict.ok).toBe(true);
+    expect(verdict.transport).toBe("unknown");
+  });
+
+  test("fallback:true fabrication fails even when the text looks plausible", () => {
+    const verdict = classifyBridgeReply(
+      {
+        text: `pong ${TOKEN}`,
+        fallback: true,
+        reason: "agent_no_reply",
+      },
+      TOKEN,
+    );
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toContain("fabricated fallback");
+    expect(verdict.reason).toContain("agent_no_reply");
+  });
+
+  test("failureKind-tagged reply fails even if the token were present", () => {
+    const verdict = classifyBridgeReply(
+      {
+        text: `Sorry, I'm having a provider issue with ${TOKEN}`,
+        failureKind: "provider_issue",
+        transport: "conversation-rest",
+      },
+      TOKEN,
+    );
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toContain("failureKind: provider_issue");
+    expect(verdict.transport).toBe("conversation-rest");
+  });
+
+  test("every known canned failure string fails without needing a flag", () => {
+    for (const canned of KNOWN_CANNED_FAILURE_REPLIES) {
+      const verdict = classifyBridgeReply({ text: canned }, TOKEN);
+      expect(verdict.ok).toBe(false);
+    }
+  });
+
+  test("smart-quote and whitespace drift cannot dodge the canned-string match", () => {
+    const verdict = classifyBridgeReply(
+      { text: "  Sorry,  I’m having a provider issue " },
+      TOKEN,
+    );
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toContain("canned failure string");
+  });
+
+  test("degraded shared-runtime turn fails", () => {
+    const verdict = classifyBridgeReply(
+      {
+        text: "Smoke is temporarily unavailable (no shared model configured).",
+        degraded: true,
+        transport: "shared-runtime",
+      },
+      TOKEN,
+    );
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toContain("degraded");
+  });
+
+  test("shared-runtime unavailable notice fails even without the degraded flag", () => {
+    const verdict = classifyBridgeReply(
+      {
+        text: "Smoke is temporarily unavailable (no shared model configured).",
+      },
+      TOKEN,
+    );
+    expect(verdict.ok).toBe(false);
+  });
+
+  test("cloud-agent echo mode fails despite containing the token", () => {
+    const verdict = classifyBridgeReply(
+      {
+        text: `[echo] Reply with one short sentence that contains the token ${TOKEN}.`,
+      },
+      TOKEN,
+    );
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toContain("echo");
+  });
+
+  test("a real reply that paraphrases the token away fails", () => {
+    const verdict = classifyBridgeReply(
+      { text: "Happy to help with your end-to-end test!" },
+      TOKEN,
+    );
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toContain("proof token");
+  });
+
+  test("empty text fails", () => {
+    expect(classifyBridgeReply({ text: "" }, TOKEN).ok).toBe(false);
+    expect(classifyBridgeReply({ text: "   " }, TOKEN).ok).toBe(false);
+  });
+
+  test("missing or malformed result fails", () => {
+    expect(classifyBridgeReply(undefined, TOKEN).ok).toBe(false);
+    expect(classifyBridgeReply(null, TOKEN).ok).toBe(false);
+    expect(classifyBridgeReply("text", TOKEN).ok).toBe(false);
+    expect(classifyBridgeReply([], TOKEN).ok).toBe(false);
+    expect(classifyBridgeReply({}, TOKEN).ok).toBe(false);
+  });
+});

--- a/packages/scripts/cloud/admin/bridge-reply-verdict.ts
+++ b/packages/scripts/cloud/admin/bridge-reply-verdict.ts
@@ -1,0 +1,148 @@
+/**
+ * Pass/fail classifier for a cloud-bridge `message.send` reply, shared by the
+ * live e2e chat scripts (hetzner-e2e-chat.ts, live-cloud-provision-smoke.ts).
+ *
+ * The agent runtime answers HTTP 200 with canned text when its model path is
+ * dead — "Sorry, I'm having a provider issue", credits-depleted, rate-limited,
+ * no-provider — tagged with a `failureKind` discriminator that the bridge
+ * propagates (#15616). The bridge itself fabricates text (`fallback: true`),
+ * the cloud-agent image echoes the prompt when @elizaos/core is missing
+ * (`[echo] …` — which would even contain the proof token), and the shared
+ * runtime marks designed-unavailable turns `degraded: true`. A smoke pass must
+ * mean a real model round-trip, so every one of those shapes is a failure here:
+ * the structured flags are the primary signal and the canned-string list is
+ * belt-and-braces for runtimes that predate `failureKind`.
+ *
+ * The canned strings mirror packages/agent/src/api/chat-routes.ts,
+ * packages/core/src/services/message/fallback-reply.ts, and the bridge
+ * fallback in packages/cloud/shared/src/lib/services/eliza-sandbox.ts. They are
+ * duplicated (not imported) so these scripts stay runnable with plain `bun run`
+ * on a CI box without a workspace build.
+ */
+
+/** Verbatim canned failure replies the runtime/bridge can return with HTTP 200. */
+export const KNOWN_CANNED_FAILURE_REPLIES: readonly string[] = [
+  // packages/agent chat routes (dead model path, HTTP 200 + failureKind)
+  "Sorry, I'm having a provider issue",
+  "I don't have a reply for that — try rephrasing?",
+  "I'm being rate-limited right now — give it a few seconds and try again.",
+  "Connect an LLM provider to start chatting. Open Settings → Providers, " +
+    "or choose Eliza Cloud during first-run setup.",
+  "Something went wrong on my end. Please try again.",
+  // packages/core fallback-reply.ts (shared with connectors)
+  "Eliza Cloud credits are depleted. Top up the cloud balance and try again.",
+  // the bridge's own no-reply fabrication (also flagged fallback:true)
+  "Agent runtime is online, but no model response was produced before the cloud bridge timeout.",
+  // cloud-agent native /bridge with an empty handleMessage callback
+  "(no response)",
+];
+
+export interface BridgeReplyVerdict {
+  ok: boolean;
+  /** Trimmed reply text ("" when absent). */
+  reply: string;
+  /** Which bridge rung produced the reply ("unknown" for pre-#15616 bridges). */
+  transport: string;
+  /** Why the reply was rejected; null when ok. */
+  reason: string | null;
+}
+
+// Mirrors classifySyntheticChatFailureText in packages/agent chat-routes.ts so
+// smart-quote / whitespace drift can't dodge the canned-string match.
+function normalizeReply(text: string): string {
+  return text.trim().toLowerCase().replace(/[’]/g, "'").replace(/\s+/g, " ");
+}
+
+const NORMALIZED_CANNED_REPLIES = new Set(
+  KNOWN_CANNED_FAILURE_REPLIES.map(normalizeReply),
+);
+
+function fail(
+  reason: string,
+  reply: string,
+  transport: string,
+): BridgeReplyVerdict {
+  return { ok: false, reply, transport, reason };
+}
+
+/**
+ * Judge a bridge `message.send` result. Passes only a non-empty reply that is
+ * not flagged (`fallback`/`failureKind`/`degraded`), does not match a known
+ * canned failure string, is not a cloud-agent echo, and contains `token` — the
+ * per-run proof that a live model round-tripped THIS prompt.
+ */
+export function classifyBridgeReply(
+  result: unknown,
+  token: string,
+): BridgeReplyVerdict {
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return fail("bridge response carried no result object", "", "unknown");
+  }
+  const record = result as Record<string, unknown>;
+  const transport =
+    typeof record.transport === "string" && record.transport.trim()
+      ? record.transport.trim()
+      : "unknown";
+  const reply = typeof record.text === "string" ? record.text.trim() : "";
+
+  if (record.fallback === true) {
+    return fail(
+      `bridge fabricated fallback text (reason: ${String(record.reason ?? "unknown")})`,
+      reply,
+      transport,
+    );
+  }
+  if (typeof record.failureKind === "string" && record.failureKind.trim()) {
+    return fail(
+      `runtime returned a canned failure reply (failureKind: ${record.failureKind.trim()})`,
+      reply,
+      transport,
+    );
+  }
+  if (record.degraded === true) {
+    return fail(
+      "shared runtime returned a degraded (designed-unavailable) turn",
+      reply,
+      transport,
+    );
+  }
+  if (!reply) {
+    return fail("bridge reply was empty", reply, transport);
+  }
+
+  const normalized = normalizeReply(reply);
+  if (NORMALIZED_CANNED_REPLIES.has(normalized)) {
+    return fail(
+      "reply matches a known canned failure string",
+      reply,
+      transport,
+    );
+  }
+  // Echo-mode cloud-agent (core unavailable) parrots the prompt back — it
+  // would contain the proof token, so it must be rejected before the token check.
+  if (normalized.startsWith("[echo]")) {
+    return fail(
+      "reply is a cloud-agent echo (runtime core unavailable)",
+      reply,
+      transport,
+    );
+  }
+  if (
+    /is temporarily unavailable \(no shared model configured\)\.?$/.test(reply)
+  ) {
+    return fail(
+      "reply is the shared-runtime no-model-configured notice",
+      reply,
+      transport,
+    );
+  }
+  if (!reply.includes(token)) {
+    return fail(
+      `reply did not echo the proof token ${token}`,
+      reply,
+      transport,
+    );
+  }
+
+  return { ok: true, reply, transport, reason: null };
+}

--- a/packages/scripts/cloud/admin/hetzner-e2e/README.md
+++ b/packages/scripts/cloud/admin/hetzner-e2e/README.md
@@ -3,8 +3,9 @@
 Nightly end-to-end smoke that provisions a real Hetzner cpx11 server,
 deploys a trivial agent via the Eliza Cloud staging API, runs a
 bridge-ping healthcheck plus one real chat turn (a `message.send`
-JSON-RPC through the production Worker bridge path, requiring a
-non-fallback assistant reply), and tears everything down. A reaper
+JSON-RPC through the production Worker bridge path, requiring a reply
+that echoes a per-run proof token and carries no fabrication flag),
+and tears everything down. A reaper
 workflow sweeps any servers older than 60 minutes every half hour as a
 safety net.
 
@@ -76,9 +77,14 @@ intend to create a real billable server.
 - `hetzner-e2e-wait-ready.ts` — SSH-poll for cloud-init + Docker
 - `hetzner-e2e-deploy-agent.ts` — create + provision a trivial agent
 - `hetzner-e2e-healthcheck.ts` — single `status.get` bridge ping
-- `hetzner-e2e-chat.ts` — one real `message.send` chat turn; fails on
-  empty or bridge-fabricated (`fallback: true`) replies so "provisioned
-  but chat dead-ends" regressions (#15347) go red
+- `hetzner-e2e-chat.ts` — one real `message.send` chat turn, judged by
+  `../bridge-reply-verdict.ts` (#15616): the reply must echo the
+  per-run proof token within the retry budget and must not be
+  bridge-fabricated (`fallback: true`), runtime-canned (`failureKind`,
+  known canned strings), or an `[echo]` parroting — so "provisioned
+  but chat dead-ends" regressions (#15347) go red. Logs which bridge
+  rung (conversation REST / OpenAI-compat / central-channel / …)
+  produced the reply
 - `hetzner-e2e-teardown.ts` — delete the server (idempotent, falls
   back to label sweep if state artifact missing)
 - `hetzner-e2e-reaper.ts` — list+delete servers older than 60min

--- a/packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-chat.ts
+++ b/packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-chat.ts
@@ -8,21 +8,27 @@
  * chat dead-ends" regressions (#15347) pass the nightly — this step closes
  * that gap by requiring an actual assistant reply. Exit 0 = the agent replied.
  *
- * The bridge fabricates `result.text` with `fallback: true` /
- * `reason: "agent_no_reply"` when the runtime is reachable but produced no
- * reply — exactly the dead-end this step exists to catch — so a fallback
- * reply is treated as a failure, never a pass. Attempts retry until
- * HETZNER_E2E_CHAT_TIMEOUT_MS (default 240s) to absorb a cold model path
- * right after provisioning.
+ * The runtime answers HTTP 200 with canned text (`failureKind` set) when its
+ * model path is dead, and the bridge fabricates text (`fallback: true`) when
+ * the runtime produced no reply — exactly the dead-ends this step exists to
+ * catch (#15616). classifyBridgeReply rejects both, rejects known canned
+ * strings from pre-`failureKind` runtimes, and requires the per-run proof
+ * token in the reply — so a pass means a live model round-tripped THIS
+ * message. Attempts retry until HETZNER_E2E_CHAT_TIMEOUT_MS (default 240s) to
+ * absorb a cold model path and the occasional paraphrase that drops the token.
+ * The success log names which bridge rung (conversation REST, OpenAI-compat,
+ * central-channel, …) replied, so a conversation-route-only regression cannot
+ * hide behind a fallback rung.
  */
 
 import { randomBytes } from "node:crypto";
+import { classifyBridgeReply } from "../bridge-reply-verdict";
 import { readState } from "./state-file";
 
 const DEFAULT_BASE_URL = "https://api-staging.elizacloud.ai";
 const DEFAULT_TIMEOUT_MS = 240_000;
 const RETRY_DELAY_MS = 5_000;
-// Per-attempt cap: the Worker's bridge tries up to three inner transports at
+// Per-attempt cap: the Worker's bridge tries up to four inner transports at
 // 60-120s each, so a single POST can legitimately take minutes.
 const ATTEMPT_TIMEOUT_MS = 130_000;
 
@@ -40,13 +46,7 @@ function sleep(ms: number): Promise<void> {
 }
 
 interface BridgeChatEnvelope {
-  result?: {
-    text?: unknown;
-    fallback?: unknown;
-    reason?: unknown;
-    agentName?: unknown;
-    conversationId?: unknown;
-  };
+  result?: Record<string, unknown>;
   error?: { code?: number; message?: string };
 }
 
@@ -56,7 +56,8 @@ async function sendChatTurn(
   agentId: string,
   prompt: string,
   roomId: string,
-): Promise<string> {
+  token: string,
+): Promise<{ reply: string; transport: string }> {
   const response = await fetch(
     `${baseUrl}/api/v1/eliza/agents/${agentId}/bridge`,
     {
@@ -92,24 +93,14 @@ async function sendChatTurn(
       `Chat JSON-RPC error: ${JSON.stringify(body.error).slice(0, 300)}`,
     );
   }
-  const result = body.result;
-  if (!result || typeof result !== "object") {
-    throw new Error(`Chat response missing result: ${text.slice(0, 300)}`);
-  }
-  if (result.fallback === true) {
+  const verdict = classifyBridgeReply(body.result, token);
+  if (!verdict.ok) {
     throw new Error(
-      `Bridge returned fabricated fallback text (reason: ${String(
-        result.reason ?? "unknown",
-      )}) — the agent produced no real reply`,
+      `${verdict.reason} (transport: ${verdict.transport})` +
+        (verdict.reply ? ` — reply: ${verdict.reply.slice(0, 200)}` : ""),
     );
   }
-  const reply = typeof result.text === "string" ? result.text.trim() : "";
-  if (!reply) {
-    throw new Error(
-      `Bridge reply was empty: ${JSON.stringify(result).slice(0, 300)}`,
-    );
-  }
-  return reply;
+  return { reply: verdict.reply, transport: verdict.transport };
 }
 
 async function main(): Promise<void> {
@@ -152,25 +143,18 @@ async function main(): Promise<void> {
   while (Date.now() < deadline) {
     attempt += 1;
     try {
-      const reply = await sendChatTurn(
+      const { reply, transport } = await sendChatTurn(
         baseUrl,
         apiKey,
         agentId,
         prompt,
         roomId,
+        token,
       );
-      const echoedToken = reply.includes(token);
       console.log(
         `[hetzner-e2e-chat] agent replied on attempt ${attempt} ` +
-          `(${reply.length} chars, token echoed: ${echoedToken}): ${reply.slice(0, 300)}`,
+          `(${reply.length} chars, transport: ${transport}, token echoed): ${reply.slice(0, 300)}`,
       );
-      if (!echoedToken) {
-        // A live model occasionally paraphrases; a real non-fallback reply
-        // still proves the chat path. Surface the miss for the run log.
-        console.log(
-          `::warning::[hetzner-e2e-chat] reply did not echo token ${token} — real reply accepted, but inspect the run if this recurs.`,
-        );
-      }
       return;
     } catch (error) {
       // error-policy:J1 retry boundary — each failed attempt is logged and the
@@ -185,7 +169,7 @@ async function main(): Promise<void> {
   }
 
   throw new Error(
-    `Agent ${agentId} never produced a real chat reply within ${timeoutMs}ms ` +
+    `Agent ${agentId} never produced a real chat reply echoing ${token} within ${timeoutMs}ms ` +
       `(${attempt} attempt${attempt === 1 ? "" : "s"}). Last failure: ${lastFailure}`,
   );
 }

--- a/packages/scripts/cloud/admin/live-cloud-provision-smoke.ts
+++ b/packages/scripts/cloud/admin/live-cloud-provision-smoke.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env bun
-// Drives cloud admin cloud admin live cloud provision smoke automation with explicit environment and CI invariants.
+// Live provisioning smoke against a deployed cloud stack: disposable identity,
+// agent create/provision, bridge + stream chat turns (classifyBridgeReply
+// rejects canned/fabricated failure replies and requires a per-run proof
+// token, #15616), pairing token, and delete.
 
 import { randomBytes } from "node:crypto";
 import { dbWrite } from "@elizaos/cloud-shared/db/helpers";
@@ -8,6 +11,7 @@ import { users } from "@elizaos/cloud-shared/db/schemas/users";
 import { apiKeysService } from "@elizaos/cloud-shared/lib/services/api-keys";
 import { eq } from "drizzle-orm";
 import { privateKeyToAccount } from "viem/accounts";
+import { classifyBridgeReply } from "./bridge-reply-verdict";
 import { SMOKE_AGENT_PLUGINS } from "./smoke-agent-plugins";
 
 type JsonObject = Record<string, unknown>;
@@ -403,6 +407,39 @@ async function assertAgentRunning(): Promise<void> {
   }
 }
 
+/**
+ * Retry `attempt` until it resolves or the deadline passes; a fresh
+ * provision's model path can be cold, and a live model occasionally
+ * paraphrases the proof token out of its first reply.
+ */
+async function retryChatTurn<T>(
+  label: string,
+  attempt: () => Promise<T>,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  let attempts = 0;
+  let lastFailure = "no attempt completed";
+  while (Date.now() < deadline) {
+    attempts += 1;
+    try {
+      return await attempt();
+    } catch (error) {
+      // error-policy:J1 retry boundary — each failed attempt is logged and the
+      // loop fails loudly at the deadline with the last observed failure.
+      lastFailure = error instanceof Error ? error.message : String(error);
+      console.log(
+        `[smoke] ${label} attempt ${attempts} failed: ${lastFailure}`,
+      );
+    }
+    if (Date.now() + pollIntervalMs >= deadline) break;
+    await sleep(pollIntervalMs);
+  }
+  throw new Error(
+    `${label} never produced a real reply within ${timeoutMs}ms ` +
+      `(${attempts} attempt${attempts === 1 ? "" : "s"}). Last failure: ${lastFailure}`,
+  );
+}
+
 async function assertBridge(): Promise<void> {
   const status = await jsonRpc("status.get");
   if (status.ready !== true) {
@@ -414,19 +451,27 @@ async function assertBridge(): Promise<void> {
     throw new Error(`Bridge heartbeat failed: ${describeBody(heartbeat)}`);
   }
 
-  const message = await jsonRpc("message.send", {
-    text: `Please reply with the exact words: cloud smoke pong ${runId}`,
-    roomId: `cloud-smoke-room-${runId}`,
-    userId: `cloud-smoke-user-${runId}`,
-    mode: "simple",
-  });
-  const reply = typeof message.text === "string" ? message.text.trim() : "";
-  if (!reply) {
-    throw new Error(
-      `Bridge message send failed: ${JSON.stringify(message).slice(0, 500)}`,
+  // Token phrased without quotes or "exact words:" so it can never match the
+  // bridge's fallback-text extraction patterns and be fabricated back at us.
+  const token = `cloud-smoke-pong-${runId}`;
+  await retryChatTurn("bridge chat turn", async () => {
+    const message = await jsonRpc("message.send", {
+      text: `Reply with one short sentence that contains the token ${token}.`,
+      roomId: `cloud-smoke-room-${runId}`,
+      userId: `cloud-smoke-user-${runId}`,
+      mode: "simple",
+    });
+    const verdict = classifyBridgeReply(message, token);
+    if (!verdict.ok) {
+      throw new Error(
+        `${verdict.reason} (transport: ${verdict.transport})` +
+          (verdict.reply ? ` — reply: ${verdict.reply.slice(0, 200)}` : ""),
+      );
+    }
+    console.log(
+      `[smoke] bridge reply ${verdict.reply.length} chars (transport: ${verdict.transport}, token echoed)`,
     );
-  }
-  console.log(`[smoke] bridge reply ${reply.length} chars`);
+  });
 }
 
 function parseSseBlock(
@@ -484,6 +529,16 @@ function extractSseText(event: string, data: JsonObject | null): string {
 
 async function assertStreamReply(): Promise<void> {
   if (!agentId) throw new Error("Agent not initialized");
+  // Token phrased without quotes or "exact words:" — the stream path has its
+  // own no-reply fabrication (an SSE frame indistinguishable from a real
+  // reply), so the proof token missing from the fabricated text is the only
+  // reliable tell (#15616).
+  const token = `cloud-stream-pong-${runId}`;
+  await retryChatTurn("stream chat turn", () => streamChatTurn(token));
+}
+
+async function streamChatTurn(token: string): Promise<void> {
+  if (!agentId) throw new Error("Agent not initialized");
   const response = await requestStream(
     `/api/v1/eliza/agents/${agentId}/stream`,
     {
@@ -493,7 +548,7 @@ async function assertStreamReply(): Promise<void> {
         id: `stream-${Date.now()}`,
         method: "message.send",
         params: {
-          text: `Please reply with the exact words: cloud stream smoke pong ${runId}`,
+          text: `Reply with one short sentence that contains the token ${token}.`,
           roomId: `cloud-smoke-stream-room-${runId}`,
           mode: "simple",
         },
@@ -545,7 +600,14 @@ async function assertStreamReply(): Promise<void> {
       `Stream did not return assistant text${sawDone ? "" : " before timeout"}`,
     );
   }
-  console.log(`[smoke] stream reply ${trimmed.length} chars`);
+  // SSE frames carry no fallback/failureKind flags, so judge the accumulated
+  // text: canned failure strings, echo-mode replies, and a missing proof
+  // token all reject.
+  const verdict = classifyBridgeReply({ text: trimmed }, token);
+  if (!verdict.ok) {
+    throw new Error(`${verdict.reason} — reply: ${trimmed.slice(0, 200)}`);
+  }
+  console.log(`[smoke] stream reply ${trimmed.length} chars (token echoed)`);
 }
 
 async function assertPairingToken(): Promise<void> {


### PR DESCRIPTION
Fixes part **(a)** of #15616 (epic #15603, follow-up to #15612).

## Problem

The agent runtime returns **HTTP 200 with canned text** when the model path is dead — `{text: getChatFailureReply(err), failureKind}` from `packages/agent/src/api/conversation-routes.ts`, plus `NO_RESPONSE_FALLBACK_REPLY` / `PROVIDER_ISSUE_CHAT_REPLY` / rate-limit / insufficient-credit variants in `chat-routes.ts`. The sandbox bridge's conversation-REST rung extracted only `text` and **dropped `failureKind`**, so its `fallback:true` fabrication flag never fired for runtime-side canned failures, and:

- `hetzner-e2e-chat.ts` hard-passed on any non-empty, non-`fallback:true` text; the token-echo miss was only a warning. Provider outage, broken credential injection, credit exhaustion, or planner-IGNORE kept the nightly green.
- `live-cloud-provision-smoke.ts` had the same hole — worse, its `exact words:` prompts match the bridge's fallback-text extractor, so the bridge could fabricate the expected pong verbatim.
- The bridge's fallback ladder (native JSON-RPC → conversation REST → OpenAI-compat → central-channel) could mask a conversation-route-only regression by passing via a different rung, invisibly.

## Fix

**Bridge — in BOTH ladder implementations** (`eliza-sandbox-bridge.ts`, the extracted service, and the duplicate inside `eliza-sandbox.ts`, which is what production `bridge()` actually dispatches to — the same dual-implementation contract the delta-SSE test already enforces):

- The conversation-REST rung now propagates `failureKind` from the runtime reply (**additive** field).
- Every rung tags its result with `transport`: `conversation-rest`, `native-jsonrpc`, `openai-compat`, `central-channel`, `shared-runtime`, or `fallback` (**additive**), so callers and CI logs can see which rung replied.

### Semantics choice for `bridgeResponseHasText`: **kept as-is** (text-only)

A canned failure reply still short-circuits the ladder. Flipping it (treating `failureKind` replies as no-text) was audited and rejected as a production regression:

| Consumer | Reads | Impact if flipped |
|---|---|---|
| `packages/cloud/api/v1/eliza/agents/[agentId]/bridge/route.ts` | pass-through JSON | additive-safe |
| `packages/cloud/services/container-control-plane/src/index.ts` | pass-through JSON | additive-safe |
| `packages/cloud/shared/src/lib/services/agent-gateway-router.ts` (`extractReplyText`) | `result.text` → delivered to Telegram/Discord/WhatsApp users | users would get the fabricated generic fallback instead of the **designed** failure text ("top up credits", "provider issue") |
| `packages/cloud/shared/src/lib/services/provisioning-jobs.ts` (`executeAgentMessage`) | `result.text`/`reason` → job result + webhook | stored/webhooked text degrades the same way |
| `packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts` | `result.text` | same |
| `plugins/plugin-elizacloud/src/cloud/bridge-client.ts` (`sendMessage`) | `result.text` | same |
| e2e scripts | full result | want strictness — now get it via `failureKind` |

Flipping would also add up to **~50 s of central-channel polling** (20 × 2.5 s) per failed turn before fabricating, and would *lose* the failureKind information entirely at the fallback stage. So production keeps the informative canned reply; **callers decide** via the new additive `failureKind` — and the e2e scripts now reject it. The decision is documented on `bridgeResponseHasText` in both files.

**Scripts** — new shared classifier `packages/scripts/cloud/admin/bridge-reply-verdict.ts` (`classifyBridgeReply`), used by both scripts:

- **Token echo is mandatory** within the retry budget (240 s default; retries absorb paraphrase flake — the smoke agent is explicitly asked to echo a per-run token).
- Rejects `failureKind`-tagged replies, `fallback:true` fabrications, `degraded:true` shared turns, the known canned strings (belt-and-braces for pre-`failureKind` runtimes; smart-quote/whitespace-normalized), and cloud-agent `[echo] …` parroting — which **would otherwise pass the token check**.
- Logs the winning bridge rung (`transport: conversation-rest`, …) on success and in every rejection, so a conversation-route-only regression can't hide behind a fallback rung.
- `live-cloud-provision-smoke.ts`: bridge **and** stream prompts rephrased off the `exact words:` pattern (the fallback extractor can no longer fabricate the expected reply), same classifier applied to the accumulated stream text, both wrapped in the retry budget.

## Tests

- `packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-failurekind.test.ts` — runs the **real ladder methods of both implementations** against a stubbed sandbox HTTP boundary: canned-failure reply → text preserved + `failureKind` propagated + `transport: conversation-rest` + ladder still short-circuits (no OpenAI-compat/central-channel calls); genuine reply → unchanged apart from the additive transport tag; empty reply → still falls through to the `fallback:true` fabrication. **6 pass.**
- `packages/scripts/cloud/admin/bridge-reply-verdict.test.ts` — classifier contract: genuine echo, missing-transport compat, `fallback:true`, `failureKind`-tagged (even with token present), every known canned string, smart-quote drift, degraded turn, unavailable-notice, `[echo]` mode (token present!), paraphrase-without-token, empty, malformed. **12 pass, 100% line coverage.** Wired into `scenario-pr.yml` (packages/scripts is outside workspace test discovery).
- Existing suites: `eliza-sandbox.test.ts` 91 pass (one exact-shape assertion extended with the additive `transport` field), delta-SSE + SSRF + agent-gateway-router 23 pass, cloud-api bridge-route suites pass (the 2 cross-file-interference failures in a combined run reproduce identically on the merge-base with my sources reverted — pre-existing, isolated runs green).

## Verification

```
bun test packages/scripts/cloud/admin/bridge-reply-verdict.test.ts        # 12 pass
cd packages/cloud/shared && bun test src/lib/services/eliza-sandbox-bridge-failurekind.test.ts  # 6 pass
cd packages/cloud/shared && bun test src/lib/services/eliza-sandbox.test.ts # 91 pass
bun run audit:error-policy-ratchet                                          # green
biome + tsc on touched files                                                # clean
```

<details>
<summary>Test + audit logs</summary>

```
$ bun test packages/scripts/cloud/admin/bridge-reply-verdict.test.ts
 12 pass / 0 fail — 35 expect() calls — 100.00% funcs / 100.00% lines of bridge-reply-verdict.ts

$ cd packages/cloud/shared && bun test src/lib/services/eliza-sandbox-bridge-failurekind.test.ts
 6 pass / 0 fail — 30 expect() calls
 (3 scenarios x [ElizaSandboxBridgeService, ElizaSandboxService])

$ cd packages/cloud/shared && bun test src/lib/services/eliza-sandbox.test.ts
 91 pass / 0 fail — 418 expect() calls

$ cd packages/cloud/shared && bun test src/lib/services/eliza-sandbox-bridge-delta-sse.test.ts \
    src/lib/services/eliza-sandbox-bridge-ssrf.test.ts src/lib/services/agent-gateway-router.test.ts
 23 pass / 0 fail — 56 expect() calls

$ cd packages/cloud/api && bun test __tests__/agent-bridge-runtime-routing.test.ts   # 2 pass
$ cd packages/cloud/api && bun test __tests__/shared-agent-messages-route.test.ts    # 4 pass
$ cd packages/cloud/api && bun test __tests__/shared-agent-messages-stream.test.ts   # 8 pass
  (combined 3-file run shows 2 pre-existing cross-file mock-interference failures;
   reproduced byte-identically with this branch's sources reverted to the merge-base)

$ bun run audit:error-policy-ratchet
 [error-policy-ratchet] base origin/develop (5f73c587a6); 0 changed production source file(s)
 [error-policy-ratchet] no new fallback-slop in touched files

$ bun packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-chat.ts
 [hetzner-e2e-chat] missing env: CLOUD_E2E_API_KEY   # parses + fails fast without env

$ bun build --target=bun packages/scripts/cloud/admin/live-cloud-provision-smoke.ts  # bundle OK

$ cd packages/cloud/shared && bun run lint    # Checked 1603 files — no fixes
$ cd packages/cloud/shared && bun run typecheck | grep -E "eliza-sandbox|bridge"     # no errors in touched files
```
</details>

## Evidence

- **Video walkthrough / before-after screenshots (desktop + mobile) / frontend console + network logs:** N/A — backend bridge service + CI script change; no user-exercisable UI surface.
- **Real-LLM trajectories:** N/A — no agent/action/provider/prompt/model behavior change; the runtime's reply generation is untouched. The change is judged by the deterministic classifier contract above and will be exercised live by the nightly `hetzner-e2e.yml` chat turn — which is currently soft-skipping on the dead `HCLOUD_TOKEN_CI` (part **(b)** of #15616, needs-human credentials). Once the token is refreshed, the Chat-turn step log will show `transport:` + `token echoed` from real infra.
- **Backend structured logs:** the bridge rung + verdict now appear in the scripts' own step logs (`[hetzner-e2e-chat] agent replied … transport: conversation-rest, token echoed`), see classifier output in the logs above.
- **Domain artifacts:** the test run output above (opened and reviewed by hand), including the ladder short-circuit assertion proving production semantics are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)