### PR TITLE
fix(ci): fail Hetzner chat on canned replies

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-message-send.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-message-send.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Message-send bridge coverage for the cloud-to-sandbox fallback ladder.
+ * The first transport is the conversation route; when it returns a structured
+ * chat failure, the bridge must preserve that failure instead of masking it
+ * with a later compatibility transport.
+ */
+
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import type { AgentSandbox } from "../../db/repositories/agent-sandboxes";
+import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
+import { type BridgeServiceDeps, ElizaSandboxBridgeService } from "./eliza-sandbox-bridge";
+
+const originalFetch = globalThis.fetch;
+const restoreFns: Array<() => void> = [];
+
+function trackRestore(fn: () => void): void {
+  restoreFns.push(fn);
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  for (const restore of restoreFns.splice(0).toReversed()) {
+    restore();
+  }
+});
+
+function sandbox(): AgentSandbox {
+  return {
+    id: "11111111-1111-4111-8111-111111111111",
+    organization_id: "22222222-2222-4222-8222-222222222222",
+    user_id: "33333333-3333-4333-8333-333333333333",
+    character_id: null,
+    sandbox_id: "sandbox-1",
+    status: "running",
+    execution_tier: "custom",
+    bridge_url: "https://agent.local",
+    health_url: "https://agent.local/health",
+    agent_name: "Eliza",
+    agent_config: {},
+    database_uri: "postgres://agent-db.example",
+    database_status: "ready",
+    database_error: null,
+    snapshot_id: null,
+    last_backup_at: null,
+    last_heartbeat_at: null,
+    error_message: null,
+    error_count: 0,
+    environment_vars: { ELIZA_API_TOKEN: "agent-token" },
+    node_id: "node-1",
+    container_name: "agent-1",
+    bridge_port: 18923,
+    web_ui_port: 23816,
+    headscale_ip: "100.64.0.10",
+    docker_image: "ghcr.io/elizaos/agent:latest",
+    image_digest: null,
+    previous_image_digest: null,
+    previous_docker_image: null,
+    target_docker_image: null,
+    target_image_digest: null,
+    upgrade_status: null,
+    upgrade_error: null,
+    upgrade_attempted_at: null,
+    upgrade_completed_at: null,
+    provisioning_started_at: null,
+    provisioning_completed_at: null,
+    provision_job_id: null,
+    provision_claimed_at: null,
+    provision_claim_token: null,
+    provision_fail_code: null,
+    provision_attempts: 0,
+    wake_requested_at: null,
+    last_wake_at: null,
+    sleep_requested_at: null,
+    last_sleep_at: null,
+    created_at: new Date("2026-07-09T00:00:00.000Z"),
+    updated_at: new Date("2026-07-09T00:00:00.000Z"),
+  } as AgentSandbox;
+}
+
+function deps(): BridgeServiceDeps {
+  return {
+    getAgentApiEndpoint: async (_rec, path) => `https://agent.local${path}`,
+    getAgentJsonHeaders: () => ({ authorization: "Bearer agent-token" }),
+    listRuntimeAgents: async () => ({ supported: true, agents: [] }),
+    selectRuntimeAgent: () => undefined,
+    isRuntimeAgentReady: () => false,
+    ensureRuntimeAgentStarted: async () => null,
+  };
+}
+
+function response(body: Record<string, unknown>, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("ElizaSandboxBridgeService message.send", () => {
+  test("preserves conversation-route failureKind and does not mask it with fallback transports", async () => {
+    const rec = sandbox();
+    const repoSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockResolvedValue(rec);
+    trackRestore(() => repoSpy.mockRestore());
+
+    const urls: string[] = [];
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      urls.push(url);
+      if (url.endsWith("/api/conversations")) {
+        return response({ conversation: { id: "conv-1" } });
+      }
+      if (url.endsWith("/api/conversations/conv-1/messages")) {
+        return response({
+          text: "Sorry, I'm having a provider issue",
+          failureKind: "provider_issue",
+          agentName: "Eliza",
+        });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }) as unknown as typeof fetch;
+
+    const bridge = new ElizaSandboxBridgeService(deps());
+    const result = await bridge.bridge(rec.id, rec.organization_id, {
+      jsonrpc: "2.0",
+      id: "test",
+      method: "message.send",
+      params: {
+        text: "Reply with a live token",
+        roomId: "room-1",
+        userId: "user-1",
+      },
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.result).toMatchObject({
+      text: "Sorry, I'm having a provider issue",
+      failureKind: "provider_issue",
+      transport: "conversation",
+      conversationId: "conv-1",
+    });
+    expect(urls).toEqual([
+      "https://agent.local/api/conversations",
+      "https://agent.local/api/conversations/conv-1/messages",
+    ]);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge.ts
@@ -89,6 +89,7 @@ export interface BridgeServiceDeps {
 }
 
 const DEFAULT_CENTRAL_SERVER_ID = "00000000-0000-0000-0000-000000000000";
+const BRIDGE_FAILURE_RESULT_FIELDS = ["failureKind", "fallback"] as const;
 
 class BridgeRouteUnavailableError extends Error {
   constructor(
@@ -407,7 +408,10 @@ export class ElizaSandboxBridgeService {
     for (const attempt of attempts) {
       try {
         const response = await attempt();
-        if (this.bridgeResponseHasText(response)) {
+        if (this.bridgeResponseIsFailure(response)) {
+          return response;
+        }
+        if (this.bridgeResponseHasUsableText(response)) {
           return response;
         }
         lastResponse = response;
@@ -429,6 +433,7 @@ export class ElizaSandboxBridgeService {
         id: rpc.id,
         result: {
           text: fallbackText,
+          transport: "bridge_no_reply_fallback",
           fallback: true,
           reason: "agent_no_reply",
         },
@@ -446,6 +451,16 @@ export class ElizaSandboxBridgeService {
 
   private bridgeResponseHasText(response: BridgeResponse): boolean {
     return typeof response.result?.text === "string" && response.result.text.trim().length > 0;
+  }
+
+  private bridgeResponseHasUsableText(response: BridgeResponse): boolean {
+    return this.bridgeResponseHasText(response) && !this.bridgeResponseIsFailure(response);
+  }
+
+  private bridgeResponseIsFailure(response: BridgeResponse): boolean {
+    const result = response.result;
+    if (!result) return false;
+    return BRIDGE_FAILURE_RESULT_FIELDS.some((field) => result[field] !== undefined);
   }
 
   private async bridgeConversationMessageSend(
@@ -478,6 +493,8 @@ export class ElizaSandboxBridgeService {
       id: rpc.id,
       result: {
         text: this.extractBridgeMessageText(body) ?? "",
+        transport: "conversation",
+        ...(typeof body.failureKind === "string" ? { failureKind: body.failureKind } : {}),
         agentName: typeof body.agentName === "string" ? body.agentName : undefined,
         conversationId,
       },
@@ -535,6 +552,7 @@ export class ElizaSandboxBridgeService {
       id: rpc.id,
       result: {
         text: agentText ?? "",
+        transport: "central_channel",
         accepted: true,
         runtimeAgentId: runtimeAgent.id,
         agentName: runtimeAgent.name,
@@ -570,6 +588,7 @@ export class ElizaSandboxBridgeService {
       id: rpc.id,
       result: {
         text: this.extractOpenAiChatCompletionText(body) ?? "",
+        transport: "openai_chat_completion",
         model: typeof body.model === "string" ? body.model : undefined,
         completionId: typeof body.id === "string" ? body.id : undefined,
       },

--- a/packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-chat.ts
+++ b/packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-chat.ts
@@ -44,10 +44,34 @@ interface BridgeChatEnvelope {
     text?: unknown;
     fallback?: unknown;
     reason?: unknown;
+    failureKind?: unknown;
+    transport?: unknown;
     agentName?: unknown;
     conversationId?: unknown;
   };
   error?: { code?: number; message?: string };
+}
+
+const CANNED_FAILURE_REPLY_PATTERNS = [
+  /\bprovider issue\b/i,
+  /\bi don't have a reply for that\b/i,
+  /\bbeing rate-limited\b/i,
+  /\binsufficient credits\b/i,
+  /\bconnect an llm provider\b/i,
+  /\bagent runtime is online, but no model response was produced\b/i,
+] as const;
+
+function rejectCannedFailureReply(reply: string): void {
+  const matched = CANNED_FAILURE_REPLY_PATTERNS.find((pattern) =>
+    pattern.test(reply),
+  );
+  if (!matched) return;
+  throw new Error(
+    `Bridge returned a canned failure reply (${matched.source}): ${reply.slice(
+      0,
+      300,
+    )}`,
+  );
 }
 
 async function sendChatTurn(
@@ -103,12 +127,25 @@ async function sendChatTurn(
       )}) — the agent produced no real reply`,
     );
   }
+  if (typeof result.failureKind === "string" && result.failureKind) {
+    throw new Error(
+      `Bridge returned chat failureKind=${result.failureKind} via ${String(
+        result.transport ?? "unknown transport",
+      )}: ${JSON.stringify(result).slice(0, 300)}`,
+    );
+  }
   const reply = typeof result.text === "string" ? result.text.trim() : "";
   if (!reply) {
     throw new Error(
       `Bridge reply was empty: ${JSON.stringify(result).slice(0, 300)}`,
     );
   }
+  rejectCannedFailureReply(reply);
+  console.log(
+    `[hetzner-e2e-chat] bridge transport: ${String(
+      result.transport ?? "unknown",
+    )}`,
+  );
   return reply;
 }
 
@@ -165,10 +202,11 @@ async function main(): Promise<void> {
           `(${reply.length} chars, token echoed: ${echoedToken}): ${reply.slice(0, 300)}`,
       );
       if (!echoedToken) {
-        // A live model occasionally paraphrases; a real non-fallback reply
-        // still proves the chat path. Surface the miss for the run log.
-        console.log(
-          `::warning::[hetzner-e2e-chat] reply did not echo token ${token} — real reply accepted, but inspect the run if this recurs.`,
+        throw new Error(
+          `Bridge reply did not echo required token ${token}: ${reply.slice(
+            0,
+            300,
+          )}`,
         );
       }
       return;

--- a/packages/scripts/cloud/admin/live-cloud-provision-smoke.ts
+++ b/packages/scripts/cloud/admin/live-cloud-provision-smoke.ts
@@ -58,6 +58,51 @@ function describeBody(body: unknown): string {
   return JSON.stringify(parts);
 }
 
+const CANNED_FAILURE_REPLY_PATTERNS = [
+  /\bprovider issue\b/i,
+  /\bi don't have a reply for that\b/i,
+  /\bbeing rate-limited\b/i,
+  /\binsufficient credits\b/i,
+  /\bconnect an llm provider\b/i,
+  /\bagent runtime is online, but no model response was produced\b/i,
+] as const;
+
+function assertRealBridgeReply(message: JsonObject, token: string): string {
+  if (message.fallback === true) {
+    throw new Error(
+      `Bridge returned fabricated fallback text: ${JSON.stringify(message).slice(0, 500)}`,
+    );
+  }
+  if (typeof message.failureKind === "string" && message.failureKind) {
+    throw new Error(
+      `Bridge returned chat failureKind=${message.failureKind}: ${JSON.stringify(
+        message,
+      ).slice(0, 500)}`,
+    );
+  }
+
+  const reply = typeof message.text === "string" ? message.text.trim() : "";
+  if (!reply) {
+    throw new Error(
+      `Bridge message send failed: ${JSON.stringify(message).slice(0, 500)}`,
+    );
+  }
+  const canned = CANNED_FAILURE_REPLY_PATTERNS.find((pattern) =>
+    pattern.test(reply),
+  );
+  if (canned) {
+    throw new Error(
+      `Bridge returned canned failure reply (${canned.source}): ${reply.slice(0, 300)}`,
+    );
+  }
+  if (!reply.includes(token)) {
+    throw new Error(
+      `Bridge reply did not echo required token ${token}: ${reply.slice(0, 300)}`,
+    );
+  }
+  return reply;
+}
+
 async function requestJson(
   path: string,
   init: RequestInit = {},
@@ -414,19 +459,21 @@ async function assertBridge(): Promise<void> {
     throw new Error(`Bridge heartbeat failed: ${describeBody(heartbeat)}`);
   }
 
+  const token = `cloud-smoke-pong-${runId}`;
   const message = await jsonRpc("message.send", {
-    text: `Please reply with the exact words: cloud smoke pong ${runId}`,
+    text:
+      "You are part of an automated cloud smoke test. " +
+      `Reply with one short sentence that contains the token ${token}.`,
     roomId: `cloud-smoke-room-${runId}`,
     userId: `cloud-smoke-user-${runId}`,
     mode: "simple",
   });
-  const reply = typeof message.text === "string" ? message.text.trim() : "";
-  if (!reply) {
-    throw new Error(
-      `Bridge message send failed: ${JSON.stringify(message).slice(0, 500)}`,
-    );
-  }
-  console.log(`[smoke] bridge reply ${reply.length} chars`);
+  const reply = assertRealBridgeReply(message, token);
+  console.log(
+    `[smoke] bridge reply ${reply.length} chars via ${String(
+      message.transport ?? "unknown",
+    )}`,
+  );
 }
 
 function parseSseBlock(


### PR DESCRIPTION
## Summary
- fixes #15616
- preserves `failureKind` and `transport` in cloud sandbox bridge `message.send` results so conversation-route failures cannot be masked by later fallback transports
- makes Hetzner e2e chat and live cloud provision smoke fail on `failureKind`, bridge fallback results, canned failure text, or missing per-run token echo
- removes the live smoke `exact words:` prompt shape that could match bridge fallback extraction

## Verification
- `bunx biome check packages/cloud/shared/src/lib/services/eliza-sandbox-bridge.ts packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-message-send.test.ts packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-chat.ts packages/scripts/cloud/admin/live-cloud-provision-smoke.ts --no-errors-on-unmatched` (passes with pre-existing undeclared-env warnings in the two scripts)
- `bun test packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-message-send.test.ts` (1 pass / 0 fail; coverage output redirected to avoid tool pipe overflow)
- `bun test packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-delta-sse.test.ts` (8 pass / 0 fail; coverage output redirected to avoid tool pipe overflow)
- `bun run --cwd packages/cloud/shared typecheck`

## Notes
- The live Hetzner credential problem from #15616 remains operator-gated: `HCLOUD_TOKEN_CI` must still be refreshed in the `ci-hetzner-e2e` environment before the scheduled real-infra lane can prove the full lifecycle again.
