### PR TITLE
fix(ui): keep loading spinners animating under prefers-reduced-motion (frozen-spinner bug)

### DIFF
--- a/packages/ui/src/styles/reduced-motion-loaders.test.ts
+++ b/packages/ui/src/styles/reduced-motion-loaders.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Regression guard: reduced-motion must not freeze functional loading spinners.
+ *
+ * `styles.css` ships the standard universal reduced-motion reset
+ * (`@media (prefers-reduced-motion: reduce) { *, ::before, ::after {
+ * animation-duration: 0.01ms !important } }`). That reset is correct for
+ * decorative motion, but with no exemption it also collapses loading spinners /
+ * progress bars to a single 0.01ms frame — so for any user with OS/browser
+ * "Reduce Motion" enabled, every spinner freezes and the app looks hung / broken
+ * with no loading feedback (reported live on prod, nubsontopgang@gmail.com).
+ *
+ * The fix re-enables the small functional loaders inside the same media query.
+ * This test pins that exemption so the reset can't silently swallow it again on
+ * a future edit — the failure is only observable in a real browser under
+ * reduce-motion, so nothing else in CI catches its removal.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const cssPath = resolve(here, "styles.css");
+const css = readFileSync(cssPath, "utf8");
+
+/** Extract the body of the universal `prefers-reduced-motion: reduce` block. */
+function reducedMotionBlock(): string {
+  const start = css.indexOf("@media (prefers-reduced-motion: reduce)");
+  expect(start, "styles.css must contain a reduced-motion media block").toBeGreaterThanOrEqual(0);
+  // Walk braces from the media query open to its matching close.
+  const open = css.indexOf("{", start);
+  let depth = 0;
+  let i = open;
+  for (; i < css.length; i++) {
+    if (css[i] === "{") depth++;
+    else if (css[i] === "}") {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  return css.slice(open, i + 1);
+}
+
+describe("reduced-motion functional-loader exemption", () => {
+  const block = reducedMotionBlock();
+
+  it("still applies the universal reset (accessibility intent preserved)", () => {
+    expect(block).toMatch(/animation-duration:\s*0\.01ms\s*!important/);
+  });
+
+  it("exempts .animate-spin so loading spinners keep animating under reduce-motion", () => {
+    // The exemption must both target the spinner AND restore an infinite,
+    // non-collapsed duration — otherwise the spinner still freezes.
+    expect(block, "reduced-motion block must re-enable .animate-spin").toMatch(
+      /\.animate-spin/,
+    );
+    expect(block, "exempted loaders must run infinitely, not a single 0.01ms frame").toMatch(
+      /animation-iteration-count:\s*infinite\s*!important/,
+    );
+    expect(block, "exempted loaders must have a real (non-collapsed) duration").toMatch(
+      /animation-duration:\s*(?!0\.01ms)[^;]+!important/,
+    );
+  });
+
+  it("keeps ARIA progress indicators animating too", () => {
+    expect(block).toMatch(/\[role="progressbar"\]/);
+  });
+});

--- a/packages/ui/src/styles/styles.css
+++ b/packages/ui/src/styles/styles.css
@@ -507,4 +507,27 @@ kbd {
     /* biome-ignore lint/complexity/noImportantStyles: reduced-motion accessibility override must win the cascade. */
     scroll-behavior: auto !important;
   }
+
+  /*
+   * Functional loading indicators must KEEP animating under reduced-motion.
+   * The universal reset above collapses every animation to 0.01ms — correct for
+   * decorative motion, but it also freezes spinners and progress bars, which
+   * then read as "hung / broken" and strip the user of loading feedback.
+   * Reduced-motion (WCAG 2.3.3) targets non-essential decorative/large motion,
+   * not essential status indicators — so re-enable the small rotational loaders.
+   * Keep this list tight: only genuinely functional in-place loaders belong here.
+   */
+  /* biome-ignore lint/style/noDescendingSpecificity: must re-win over the universal reset above. */
+  .animate-spin,
+  /* biome-ignore lint/style/noDescendingSpecificity: match Tailwind's arbitrary-variant spin utility too. */
+  [class~="animate-spin"],
+  /* biome-ignore lint/style/noDescendingSpecificity: native + ARIA progress indicators. */
+  [role="progressbar"],
+  /* biome-ignore lint/style/noDescendingSpecificity: sonner toast loading bar. */
+  .sonner-loading-bar {
+    /* biome-ignore lint/complexity/noImportantStyles: must override the universal reduced-motion reset. */
+    animation-duration: 1s !important;
+    /* biome-ignore lint/complexity/noImportantStyles: must override the universal reduced-motion reset. */
+    animation-iteration-count: infinite !important;
+  }
 }


### PR DESCRIPTION
## What

Loading spinners (and progress bars) freeze for any user with **"Reduce Motion"** enabled in their OS/browser — the whole app then looks hung/broken with no loading feedback. This exempts functional loaders from the universal reduced-motion reset so they keep spinning, while all decorative motion stays suppressed.

## Repro (found live on prod)

Reported by a real user (signed in on their own device). Reproduced with CDP by emulating `prefers-reduced-motion: reduce` on `app.elizacloud.ai`:

| `prefers-reduced-motion` | `.animate-spin` computed animation |
|---|---|
| `no-preference` | `animationName: spin, duration: 1s, running` ✅ |
| `reduce` (before fix) | `animationName: none, duration: 0.01ms` ❌ frozen |

Root cause — `packages/ui/src/styles/styles.css`:
```css
@media (prefers-reduced-motion: reduce) {
  *, ::before, ::after { animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; }
}
```
The `*` reset is right for decorative motion but also collapses spinners to a single 0.01ms frame.

## Fix

Re-enable the small **functional** in-place loaders (`.animate-spin`, `[role="progressbar"]`, `.sonner-loading-bar`) inside the same media query (`animation-duration: 1s !important; animation-iteration-count: infinite !important`). Reduced-motion (WCAG 2.3.3) targets non-essential decorative/large motion — a loading spinner is essential status feedback, not decoration. Decorative animations (fades, slides, shader background, connector-flash, etc.) stay suppressed.

## Test + evidence

`reduced-motion-loaders.test.ts` — asserts the universal reset is still present **and** that the functional-loader exemption survives (real duration + infinite iteration). This class of bug is only observable in a real browser under reduce-motion, so unit CI otherwise can't catch a regression.

- ✅ **Passes with fix**: `3 pass / 0 fail`
- ✅ **Red-on-base**: reverting the CSS exemption → `2 fail` (the exemption assertions), restoring → green.

## Notes

- Same over-aggressive reset exists in `packages/homepage/src/index.css` (marketing site). Left out of this PR (marketing has no functional spinners); flag for a follow-up if it grows any.
- Part of the fleet regression-proofing mandate: every runtime-only/media-query behavior gets a guard CI can see.
