### PR TITLE
fix(memory): deepen same-room recall history window

### DIFF
--- a/packages/core/src/features/basic-capabilities/providers/recentMessages.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/recentMessages.test.ts
@@ -440,6 +440,70 @@ describe("recentMessagesProvider", () => {
 		expect(result.text).not.toContain("User: message 9");
 	});
 
+	it("deepens same-room history for recall-referential questions", async () => {
+		const memories = [
+			makeMemory("msg-1", USER_ID, "whats 23 times 19?", "discord", 1000),
+			makeMemory("msg-2", AGENT_ID, "23 times 19 is 437.", "discord", 2000),
+			makeMemory("msg-3", USER_ID, "capital of france?", "discord", 3000),
+			makeMemory("msg-4", AGENT_ID, "Paris.", "discord", 4000),
+			makeMemory(
+				"msg-5",
+				USER_ID,
+				"write a haiku about speed",
+				"discord",
+				5000,
+			),
+			makeMemory(
+				"msg-6",
+				AGENT_ID,
+				"Quick wind / bright road",
+				"discord",
+				6000,
+			),
+			makeMemory(
+				"msg-7",
+				USER_ID,
+				"python one-liner for reverse string",
+				"discord",
+				7000,
+			),
+			makeMemory("msg-8", AGENT_ID, "s[::-1]", "discord", 8000),
+			makeMemory("msg-9", USER_ID, "bitcoin price?", "discord", 9000),
+			makeMemory(
+				"msg-10",
+				AGENT_ID,
+				"I need live data for that.",
+				"discord",
+				10_000,
+			),
+		];
+		const runtime = makeRuntime(memories, { conversationLength: 4 });
+
+		const result = await recentMessagesProvider.get(
+			runtime,
+			makeMemory(
+				"current",
+				USER_ID,
+				"what did i ask you to compute in my last math question?",
+				"discord",
+				11_000,
+			),
+			{ values: {}, data: {}, text: "" },
+		);
+
+		expect(runtime.getMemories).toHaveBeenCalledWith(
+			expect.objectContaining({
+				limit: 50,
+				roomId: ROOM_ID,
+				tableName: "messages",
+			}),
+		);
+		const recentMessages = result.data?.recentMessages as Memory[];
+		expect(recentMessages.map((memory) => memory.id)).toContain("msg-1");
+		expect(result.text).toContain("User: whats 23 times 19?");
+		expect(result.text).toContain("User: bitcoin price?");
+	});
+
 	it("skips the cross-room interactions fetch on the first compose of a turn", async () => {
 		const OTHER_ROOM_ID = "00000000-0000-0000-0000-00000000000a";
 		const memories = [

--- a/packages/core/src/features/basic-capabilities/providers/recentMessages.ts
+++ b/packages/core/src/features/basic-capabilities/providers/recentMessages.ts
@@ -45,6 +45,7 @@ import { addHeader, formatMessages, formatPosts } from "../../../utils.ts";
 // Get text content from centralized specs
 const spec = requireProviderSpec("RECENT_MESSAGES");
 const MAX_RECENT_MESSAGES_LOOKBACK = 50;
+const RECALL_REFERENTIAL_MESSAGES_LOOKBACK = 50;
 const MAX_RECENT_INTERACTIONS = 20;
 const MAX_COMPACT_LEDGER_CHARS = 4000;
 const INTERNAL_TOOL_TRANSCRIPT_MARKERS = [
@@ -66,6 +67,13 @@ const SYNTHETIC_ASSISTANT_FAILURE_KINDS = new Set([
 	"no_response",
 	"transient_failure",
 ]);
+const RECALL_REFERENTIAL_PATTERNS = [
+	/\bwhat\s+(?:did|was|were)\s+(?:i|we|you)\b.*\b(?:ask|say|tell|compute|calculate|mention|discuss|talk(?:ed)?\s+about)\b/i,
+	/\b(?:my|our|the)\s+(?:last|previous|prior|earlier)\b.*\b(?:question|request|message|ask|thing|calculation|math|topic)\b/i,
+	/\b(?:last|previous|prior|earlier)\s+(?:math|calculation|question|request|message)\b/i,
+	/\b(?:earlier|previously|before)\b.*\b(?:i|we|you)\s+(?:asked|said|told|mentioned|discussed|computed|calculated)\b/i,
+	/\b(?:remind me|recall|remember)\b.*\b(?:what|when|which)\b.*\b(?:asked|said|told|mentioned|discussed|computed|calculated)\b/i,
+];
 
 function asObjectRecord(value: unknown): Record<string, unknown> | null {
 	return value && typeof value === "object" && !Array.isArray(value)
@@ -189,6 +197,11 @@ function normalizeDialogueText(memory: Memory): string {
 	return typeof memory.content.text === "string"
 		? memory.content.text.replace(/\s+/g, " ").trim()
 		: "";
+}
+
+function isRecallReferentialMessage(memory: Memory): boolean {
+	const text = normalizeDialogueText(memory);
+	return RECALL_REFERENTIAL_PATTERNS.some((pattern) => pattern.test(text));
 }
 
 function dedupeConsecutiveDialogueMessages(messages: Memory[]): Memory[] {
@@ -358,10 +371,13 @@ export const recentMessagesProvider: Provider = {
 	): Promise<ProviderResult> => {
 		try {
 			const { roomId } = message;
-			const conversationLength = Math.min(
+			const configuredConversationLength = Math.min(
 				runtime.getConversationLength(),
 				MAX_RECENT_MESSAGES_LOOKBACK,
 			);
+			const conversationLength = isRecallReferentialMessage(message)
+				? RECALL_REFERENTIAL_MESSAGES_LOOKBACK
+				: configuredConversationLength;
 
 			// The cross-room interactions fetch (identity-cluster expansion, a
 			// rooms query per identity, then a 20-row pull across every other


### PR DESCRIPTION
## Summary
- detect recall-referential current messages in RECENT_MESSAGES
- expand only those turns to the existing 50-message same-room lookback ceiling
- add a regression for the live `last math question` miss from #15586

Fixes #15586

## Verification
- `bunx biome check packages/core/src/features/basic-capabilities/providers/recentMessages.ts packages/core/src/features/basic-capabilities/providers/recentMessages.test.ts --write --unsafe --no-errors-on-unmatched`
- `bun test packages/core/src/features/basic-capabilities/providers/recentMessages.test.ts`

## Notes
- `bun run --cwd packages/core typecheck` could not start in the fresh worktree: TS2688 missing type definition file for `node` because dependencies are not installed in that worktree.
