### PR TITLE
fix(homepage): keep reduced-motion loaders animated

### DIFF
--- a/packages/homepage/src/index.css
+++ b/packages/homepage/src/index.css
@@ -1183,4 +1183,19 @@ article {
     /* biome-ignore lint/complexity/noImportantStyles: Reduced-motion overrides must win over component animations and transitions. */
     scroll-behavior: auto !important;
   }
+
+  /*
+   * Functional loading indicators must continue animating under reduced motion.
+   * The universal reset above suppresses decorative motion, but a frozen
+   * in-place spinner or progress bar reads as a stalled load rather than an
+   * accessibility accommodation.
+   */
+  .animate-spin,
+  [class~="animate-spin"],
+  [role="progressbar"] {
+    /* biome-ignore lint/complexity/noImportantStyles: must override the universal reduced-motion reset. */
+    animation-duration: 1s !important;
+    /* biome-ignore lint/complexity/noImportantStyles: must override the universal reduced-motion reset. */
+    animation-iteration-count: infinite !important;
+  }
 }

--- a/packages/homepage/tests/smoke.node.test.mjs
+++ b/packages/homepage/tests/smoke.node.test.mjs
@@ -13,6 +13,7 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const marketingPath = resolve(__dirname, "../src/pages/marketing.tsx");
+const globalStylesPath = resolve(__dirname, "../src/index.css");
 
 test("marketing.tsx exports a default function component", () => {
   const src = readFileSync(marketingPath, "utf8");
@@ -20,5 +21,27 @@ test("marketing.tsx exports a default function component", () => {
     src,
     /export\s+default\s+function\s+\w+/,
     "expected `export default function ...` in marketing.tsx",
+  );
+});
+
+test("reduced-motion keeps functional loading indicators animated", () => {
+  const css = readFileSync(globalStylesPath, "utf8");
+  const reducedMotionStart = css.indexOf(
+    "@media (prefers-reduced-motion: reduce)",
+  );
+
+  assert.notEqual(
+    reducedMotionStart,
+    -1,
+    "expected a reduced-motion override block",
+  );
+  const reducedMotionBlock = css.slice(reducedMotionStart);
+  assert.match(reducedMotionBlock, /\.animate-spin/);
+  assert.match(reducedMotionBlock, /\[class~="animate-spin"\]/);
+  assert.match(reducedMotionBlock, /\[role="progressbar"\]/);
+  assert.match(reducedMotionBlock, /animation-duration:\s*1s\s*!important/);
+  assert.match(
+    reducedMotionBlock,
+    /animation-iteration-count:\s*infinite\s*!important/,
   );
 });


### PR DESCRIPTION
## Summary
- mirror the reduced-motion loader exception from #15629 into the homepage CSS
- keep `.animate-spin` and `[role=progressbar]` functional under reduced motion while preserving the global decorative-motion reset
- add a source-level smoke assertion so the selector does not regress

Fixes #15630

## Verification
- `bunx @biomejs/biome check packages/homepage/src/index.css packages/homepage/tests/smoke.node.test.mjs --write --unsafe --no-errors-on-unmatched`
- `bun run --cwd packages/homepage test`

## Evidence notes
- Screenshot/video: N/A for this narrow CSS regression; the changed behavior is a loading animation under OS reduced-motion and is covered by the source-level assertion.
