### PR TITLE
feat(vision): Android camera bridge — on-device agent captures via ElizaCamera

### DIFF
--- a/packages/app/src/camera-bridge-responder.ts
+++ b/packages/app/src/camera-bridge-responder.ts
@@ -1,0 +1,150 @@
+/**
+ * WebView half of the on-device-agent camera bridge.
+ *
+ * The Android agent (a Bun process) cannot reach the WebView's `ElizaCamera`
+ * plugin, so `plugin-vision`'s `FileBridgeCameraSource` drops a capture request
+ * in the agent's `vision-bridge` dir. This responder — running in the WebView,
+ * which DOES own the Capacitor camera — polls for that request, captures a
+ * photo through `ElizaCamera` (brief rear-camera preview → single frame), and
+ * writes the JPEG + an ack back for the agent to read.
+ *
+ * The shared dir is the app's `files/agent/vision-bridge`, reached here through
+ * Capacitor `Directory.Data` + `agent/vision-bridge` (the agent's `AGENT_ROOT`
+ * is `files/agent`). Single in-flight capture; request/ack correlate by id.
+ */
+
+import { Directory, Encoding, Filesystem } from "@capacitor/filesystem";
+
+const DIR = "agent/vision-bridge";
+const REQUEST_PATH = `${DIR}/capture.req`;
+const ACK_PATH = `${DIR}/capture.ack`;
+const FRAME_PATH = `${DIR}/capture.jpg`;
+const POLL_INTERVAL_MS = 400;
+
+interface ElizaCameraLike {
+  requestPermissions?: () => Promise<{ camera?: string } | unknown>;
+  startPreview: (opts: {
+    element: HTMLElement;
+    direction?: string;
+    resolution?: { width: number; height: number };
+  }) => Promise<unknown>;
+  capturePhoto: (opts?: {
+    quality?: number;
+    format?: string;
+  }) => Promise<{ base64: string }>;
+  stopPreview: () => Promise<unknown>;
+}
+
+function getCamera(): ElizaCameraLike | null {
+  const plugins = (
+    globalThis as unknown as {
+      Capacitor?: { Plugins?: Record<string, unknown> };
+    }
+  ).Capacitor?.Plugins;
+  const cam = plugins?.ElizaCamera as ElizaCameraLike | undefined;
+  return cam && typeof cam.capturePhoto === "function" ? cam : null;
+}
+
+/** Off-screen, measurable host for the CameraX preview (display:none refuses to
+ * start a preview surface, so keep it attached and 1×1 rather than hidden). */
+function makePreviewHost(): HTMLElement {
+  const el = document.createElement("div");
+  el.setAttribute("data-eliza-camera-bridge", "");
+  el.style.cssText =
+    "position:fixed;left:-9999px;top:0;width:1px;height:1px;overflow:hidden;opacity:0;pointer-events:none;";
+  document.body.appendChild(el);
+  return el;
+}
+
+async function readText(path: string): Promise<string | null> {
+  try {
+    const res = await Filesystem.readFile({
+      path,
+      directory: Directory.Data,
+      encoding: Encoding.UTF8,
+    });
+    return typeof res.data === "string" ? res.data.trim() : null;
+  } catch {
+    // Absent request/ack is the normal idle state — not an error.
+    return null;
+  }
+}
+
+async function captureOnce(camera: ElizaCameraLike): Promise<string> {
+  const host = makePreviewHost();
+  try {
+    await camera.requestPermissions?.().catch(() => {});
+    await camera.startPreview({
+      element: host,
+      direction: "rear",
+      resolution: { width: 1280, height: 720 },
+    });
+    // A frame needs the sensor warmed; one short beat avoids a black frame.
+    await new Promise((r) => setTimeout(r, 350));
+    const photo = await camera.capturePhoto({ quality: 85, format: "jpeg" });
+    return photo.base64;
+  } finally {
+    await camera.stopPreview().catch(() => {});
+    host.remove();
+  }
+}
+
+/**
+ * Start the responder loop. Idempotent per WebView; returns a stop function.
+ * Safe to call on every mobile boot — off Android (no ElizaCamera) it idles.
+ */
+export function startCameraBridgeResponder(): () => void {
+  let stopped = false;
+  let lastHandled: string | null = null;
+  let busy = false;
+
+  const tick = async () => {
+    if (stopped || busy) return;
+    const reqId = await readText(REQUEST_PATH);
+    if (!reqId || reqId === lastHandled) return;
+    const camera = getCamera();
+    if (!camera) return; // not Android / plugin absent — idle
+    busy = true;
+    lastHandled = reqId;
+    try {
+      await Filesystem.mkdir({
+        path: DIR,
+        directory: Directory.Data,
+        recursive: true,
+      }).catch(() => {});
+      const base64 = await captureOnce(camera);
+      await Filesystem.writeFile({
+        path: FRAME_PATH,
+        directory: Directory.Data,
+        data: base64, // base64 with no encoding → binary JPEG on disk
+      });
+      await Filesystem.writeFile({
+        path: ACK_PATH,
+        directory: Directory.Data,
+        data: reqId,
+        encoding: Encoding.UTF8,
+      });
+      // eslint-disable-next-line no-console
+      console.info(`[camera-bridge] served capture ${reqId}`);
+    } catch (err) {
+      // Surface the failure to the agent as an ack-less timeout rather than a
+      // silent hang; log for the WebView console trail.
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[camera-bridge] capture ${reqId} failed:`,
+        err instanceof Error ? err.message : String(err),
+      );
+    } finally {
+      busy = false;
+    }
+  };
+
+  const timer = setInterval(() => {
+    void tick();
+  }, POLL_INTERVAL_MS);
+
+  return () => {
+    stopped = true;
+    clearInterval(timer);
+  };
+}

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -413,6 +413,7 @@ const IOS_FULL_BUN_SMOKE_CHAT_TEXT =
 const CLOUD_PAIR_SESSION_TOKEN_KEY = "eliza:cloud-pair:api-token";
 
 let mobileDeviceBridgeClient: DeviceBridgeClient | null = null;
+let cameraBridgeResponderStop: (() => void) | null = null;
 let mobileDeviceBridgeStartPromise: Promise<void> | null = null;
 let mobileAgentTunnelListener: PluginListenerHandle | null = null;
 let mobileAgentTunnelStartPromise: Promise<void> | null = null;
@@ -3506,6 +3507,17 @@ async function initializeMobileDeviceBridge(): Promise<void> {
           );
         },
       });
+      // The on-device agent (Bun) can't reach ElizaCamera; serve its file-drop
+      // camera-capture requests from the WebView, which owns the plugin. Only
+      // needed on Android local/hybrid — the exact modes that run an on-device
+      // agent — and started once per session.
+      if (isAndroid && !cameraBridgeResponderStop) {
+        const { startCameraBridgeResponder } = await import(
+          "./camera-bridge-responder"
+        );
+        cameraBridgeResponderStop = startCameraBridgeResponder();
+        console.info(`${APP_LOG_PREFIX} Camera bridge responder started`);
+      }
     } catch (error) {
       // error-policy:J4 optional native module — absence logged, app degrades
       console.warn(

--- a/plugins/plugin-vision/src/mobile/file-bridge-camera.ts
+++ b/plugins/plugin-vision/src/mobile/file-bridge-camera.ts
@@ -1,0 +1,94 @@
+/**
+ * File-drop `MobileCameraSource` for the Android on-device agent.
+ *
+ * The agent runs in a Bun process with no `Capacitor.Plugins`, so it cannot
+ * call the WebView's `ElizaCamera` directly. This source bridges over the one
+ * filesystem both processes share (the agent's `AGENT_ROOT`, which is the app's
+ * `files/agent` dir and maps to Capacitor `Directory.Data` + `agent` in the
+ * WebView): the agent drops a capture request, the WebView (running
+ * `startCameraBridgeResponder`) captures via `ElizaCamera` and drops the JPEG
+ * back, and the agent reads it. Deliberately simple — a single in-flight
+ * capture at a time, request/ack by a monotonic id, bounded poll.
+ */
+
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+import { logger } from "@elizaos/core";
+import type { CameraInfo } from "../types";
+import type { MobileCameraSource } from "./capacitor-camera";
+
+const REQUEST_FILE = "capture.req";
+const ACK_FILE = "capture.ack";
+const FRAME_FILE = "capture.jpg";
+const POLL_INTERVAL_MS = 200;
+const CAPTURE_TIMEOUT_MS = 12_000;
+
+function bridgeDir(): string {
+  const root =
+    process.env.AGENT_ROOT ||
+    process.env.ELIZA_STATE_DIR ||
+    process.cwd();
+  return join(root, "vision-bridge");
+}
+
+export class FileBridgeCameraSource implements MobileCameraSource {
+  private seq = 0;
+
+  async listCameras(): Promise<CameraInfo[]> {
+    // The WebView bridge opens the back camera; expose a single stable entry so
+    // VisionService.findCamera() connects a device and routes capture here.
+    return [{ id: "back", name: "Back Camera (bridge)", connected: true }];
+  }
+
+  async open(): Promise<void> {
+    await fs.mkdir(bridgeDir(), { recursive: true });
+  }
+
+  async close(): Promise<void> {
+    // The WebView owns the camera session; nothing to tear down agent-side.
+  }
+
+  async captureJpeg(): Promise<Buffer> {
+    const dir = bridgeDir();
+    await fs.mkdir(dir, { recursive: true });
+    const id = `${Date.now()}-${++this.seq}`;
+    // Clear any stale ack so we only accept a response to THIS request.
+    await fs.rm(join(dir, ACK_FILE), { force: true }).catch(() => {});
+    await fs.writeFile(join(dir, REQUEST_FILE), id, "utf8");
+    logger.info(`[FileBridgeCameraSource] capture requested (id=${id})`);
+
+    const deadline = Date.now() + CAPTURE_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      let ack: string | null = null;
+      try {
+        ack = (await fs.readFile(join(dir, ACK_FILE), "utf8")).trim();
+      } catch {
+        // ack not written yet — the WebView responder hasn't finished; keep
+        // polling until the deadline, which throws a real timeout below.
+      }
+      if (ack === id) {
+        const frame = await fs.readFile(join(dir, FRAME_FILE));
+        logger.info(
+          `[FileBridgeCameraSource] frame received (id=${id}, ${frame.length} bytes)`,
+        );
+        return frame;
+      }
+      await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+    }
+    throw new Error(
+      `Camera bridge timed out after ${CAPTURE_TIMEOUT_MS}ms (id=${id}); is the WebView camera responder running and permitted?`,
+    );
+  }
+
+  capabilities(): {
+    supportsContinuousFrames: boolean;
+    supportsExposureLock: boolean;
+    supportsTorch: boolean;
+  } {
+    return {
+      supportsContinuousFrames: false,
+      supportsExposureLock: false,
+      supportsTorch: false,
+    };
+  }
+}

--- a/plugins/plugin-vision/src/service.ts
+++ b/plugins/plugin-vision/src/service.ts
@@ -39,6 +39,11 @@ import {
   parseVisionDataImageUrl,
 } from "./image-input";
 import { resolveArbiterFromRuntime } from "./lifecycle";
+import { FileBridgeCameraSource } from "./mobile/file-bridge-camera";
+import {
+  getMobileCameraSource,
+  registerMobileCameraSource,
+} from "./mobile/capacitor-camera";
 import { OCRService } from "./ocr-service";
 import { ScreenCaptureService } from "./screen-capture";
 import { getTestImage } from "./test-input";
@@ -415,6 +420,14 @@ export class VisionService extends Service {
     available: boolean;
     tool: string;
   }> {
+    // A registered mobile camera source (Android CameraX / iOS AVFoundation via
+    // the Capacitor bridge) captures in-process — it replaces the desktop CLI
+    // tools entirely. On a phone there is no imagesnap/fswebcam/ffmpeg, so this
+    // is the only working capture path there.
+    if (getMobileCameraSource()) {
+      return { available: true, tool: "mobile-bridge" };
+    }
+
     const platform = process.platform;
 
     try {
@@ -440,6 +453,16 @@ export class VisionService extends Service {
 
   private async initialize(): Promise<void> {
     try {
+      // On the Android on-device agent there is no desktop camera CLI and no
+      // in-process Capacitor bridge, so register the file-drop camera source
+      // that relays capture requests to the WebView's ElizaCamera. Gated on the
+      // mobile platform env ElizaAgentService sets; a no-op everywhere else.
+      // Static imports (not dynamic) so the source is in the mobile agent
+      // bundle — a code-split chunk can't be loaded there (no filesystem).
+      if (process.env.ELIZA_MOBILE_PLATFORM === "android") {
+        registerMobileCameraSource(new FileBridgeCameraSource());
+      }
+
       // Initialize the ggml YOLOv8 object detector when object detection is
       // enabled. There is no pose backend yet — pose detection falls through
       // to the heuristic path (detectPeopleFromMotion).
@@ -2103,6 +2126,13 @@ export class VisionService extends Service {
   }
 
   private async listCameras(): Promise<CameraInfo[]> {
+    // Mobile bridge (if registered) enumerates the phone's cameras; the desktop
+    // CLI probes below don't exist on Android/iOS.
+    const mobileSource = getMobileCameraSource();
+    if (mobileSource) {
+      return mobileSource.listCameras();
+    }
+
     const platform = process.platform;
 
     try {
@@ -2182,6 +2212,14 @@ export class VisionService extends Service {
       id: info.id,
       name: info.name,
       capture: async () => {
+        // Mobile: the registered bridge captures a JPEG in-process (no temp
+        // file, no CLI tool). Preferred over the desktop paths below whenever a
+        // source is registered — on a phone it is the only one that works.
+        const mobileSource = getMobileCameraSource();
+        if (mobileSource) {
+          return mobileSource.captureJpeg();
+        }
+
         const tempFile = path.join(
           process.cwd(),
           `temp_capture_${Date.now()}.jpg`,


### PR DESCRIPTION
## What

Make the on-device agent's camera actions (`VISION` / `TAKE_PHOTO` / `DESCRIBE_SCENE`) actually work on Android. `plugin-vision`'s capture path only ever shelled out to desktop CLIs (`fswebcam`/`imagesnap`/`ffmpeg`), so on a phone every capture failed — the planner would select `TAKE_PHOTO`, then `RESULT: failed`.

## Why it failed

`plugin-vision` already had a `MobileCameraSource` abstraction (`src/mobile/capacitor-camera.ts`) but it was **dead code** — `getMobileCameraSource()` was never wired into `service.ts`'s capture path, and the agent runs in a Bun process with no `Capacitor.Plugins`, so it always fell through to the desktop tools.

## How

1. **Wire `getMobileCameraSource()`** into `service.ts` `checkCameraTools` / `listCameras` / `createCameraDevice().capture()` — a registered mobile source now replaces the desktop CLIs.
2. **`FileBridgeCameraSource`** (agent side) — the Bun agent can't call `ElizaCamera` directly, so it relays a capture request through the shared `AGENT_ROOT/vision-bridge` dir (which maps to the WebView's Capacitor `Directory.Data` + `agent/vision-bridge`).
3. **`startCameraBridgeResponder`** (WebView, `packages/app/src/main.tsx`, Android local/hybrid) — polls for the request, captures via `ElizaCamera` (brief rear preview → single frame), writes the JPEG + ack back.

Registered only on `ELIZA_MOBILE_PLATFORM==="android"`; a no-op elsewhere. Uses static imports (a code-split chunk can't load in the mobile agent bundle).

## Evidence — real Light Phone III (6GB), stacked on the now-merged #15576 + #15588

```
[MobileCameraSource] registered (FileBridgeCameraSource)
[VisionService] Connected to camera: Back Camera (bridge)          ← no more fswebcam
[FileBridgeCameraSource] capture requested (id=…)
[camera-bridge] served capture …                                   ← WebView console
[FileBridgeCameraSource] frame received (id=…, 222952 bytes)
```
Pulled `vision-bridge/capture.jpg` → a valid **960×1280 color JPEG** — a real photo captured by the on-device agent through the LP3's rear camera (verified visually: it's a photo of the dev laptop). Face-down → 14 KB black frame; face-up → 222 KB real scene, exactly as expected. **The on-device agent can now see through the phone camera.**

> ⚠️ Build note (cost me a cycle): the mobile agent bundle resolves `@elizaos/plugin-*` from `dist/` (via the `default` export condition), **not** `src` — so after editing `plugin-vision/src` you must `bun run --cwd plugins/plugin-vision build` before `build:android` or the stale dist ships. Worth a look at whether the mobile resolver should honor the `eliza-source` condition.

Refs #15589.
