### PR TITLE
fix(test): rename bridge-verdict fixture token so it is not credential-shaped

### DIFF
--- a/packages/scripts/cloud/admin/bridge-reply-verdict.test.ts
+++ b/packages/scripts/cloud/admin/bridge-reply-verdict.test.ts
@@ -11,7 +11,7 @@ import {
   KNOWN_CANNED_FAILURE_REPLIES,
 } from "./bridge-reply-verdict";
 
-const TOKEN = "hetzner-pong-abc123";
+const TOKEN = "nightly proof phrase";
 
 describe("classifyBridgeReply", () => {
   test("genuine reply echoing the token passes and reports its transport", () => {


### PR DESCRIPTION
Post-merge review of #15627 (B1): `const TOKEN = "hetzner-pong-abc123"` in `packages/scripts/cloud/admin/bridge-reply-verdict.test.ts:14` trips gitleaks' `generic-api-key` rule (fingerprint `15ccd4c…:bridge-reply-verdict.test.ts:generic-api-key:14`). Renamed to `"nightly proof phrase"` — non-credential-shaped, still exercises the includes() token check (classifier suite 12 pass / 0 fail, 35 expect calls).

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - one-line test fixture rename; no user-facing UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - one-line test fixture rename; no user-facing UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: N/A - one-line test fixture rename; no runtime user flow changes.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - test fixture rename only; no backend runtime path changes.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - test fixture rename only; no frontend runtime path changes.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent/action/provider/prompt/model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no domain artifacts are produced by a test fixture rename.

## Verification

- `bun test packages/scripts/cloud/admin/bridge-reply-verdict.test.ts` — 12 pass / 0 fail / 35 expect calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
