### PR TITLE
fix(test): fail silent PGlite harness skips

### DIFF
--- a/packages/cloud/shared/src/db/__tests__/pglite-readiness-guards.test.ts
+++ b/packages/cloud/shared/src/db/__tests__/pglite-readiness-guards.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Regression guard for PGlite-backed cloud tests that must not green-pass when
+ * their in-process database harness fails to initialize. A skipped setup is a
+ * broken test environment, so suites may explicitly fail or explicitly skip,
+ * but they must never return from every test body with zero assertions.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const SHARED_SRC_DIR = join(import.meta.dirname, "..", "..");
+
+function* walkFiles(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    const stat = statSync(path);
+    if (stat.isDirectory()) {
+      yield* walkFiles(path);
+      continue;
+    }
+    if (path.endsWith(".test.ts") || path.endsWith(".integration.test.ts")) {
+      yield path;
+    }
+  }
+}
+
+describe("PGlite readiness guards", () => {
+  test("PGlite-gated cloud shared tests fail or skip observably", () => {
+    const offenders: string[] = [];
+
+    for (const path of walkFiles(SHARED_SRC_DIR)) {
+      const source = readFileSync(path, "utf8");
+      if (!source.includes("pgliteReady")) continue;
+
+      const hasSilentReturn = /if\s*\(!pgliteReady\)\s*return\s*;/u.test(source);
+      if (!hasSilentReturn) continue;
+
+      const hasLoudFailure =
+        /expect\s*\(\s*pgliteReady\s*\)\s*\.\s*toBe\s*\(\s*true\s*\)/u.test(source) ||
+        /if\s*\(!pgliteReady\)\s*throw\b/u.test(source);
+      const hasExplicitSkip = /(?:test|it|describe)\.skipIf\s*\(/u.test(source);
+
+      if (!hasLoudFailure && !hasExplicitSkip) {
+        offenders.push(relative(SHARED_SRC_DIR, path));
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/cloud/shared/src/db/inference-pending-charges-migration.test.ts
+++ b/packages/cloud/shared/src/db/inference-pending-charges-migration.test.ts
@@ -88,7 +88,7 @@ describe("inference_pending_charges migration applies to a real DB (#9899)", () 
       await dbWrite.execute(`DROP TABLE IF EXISTS inference_pending_charges`);
     } catch (error) {
       pgliteReady = false;
-      console.warn("[migration] PGlite unavailable, skipping DB apply:", error);
+      console.warn("[migration] PGlite unavailable, failing DB apply:", error);
     }
   }, 60000);
 
@@ -97,7 +97,7 @@ describe("inference_pending_charges migration applies to a real DB (#9899)", () 
   });
 
   it("applies cleanly and creates the table, PK, and both partial indexes", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     await applyMigration();
 
     const cols = await dbWrite.execute(
@@ -130,7 +130,7 @@ describe("inference_pending_charges migration applies to a real DB (#9899)", () 
   }, 60000);
 
   it("is idempotent — re-applying the same file is a no-op (no duplicate-object error)", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     await applyMigration(); // second time
     const t = await dbWrite.execute(
       `SELECT count(*)::int AS n FROM information_schema.tables WHERE table_name = 'inference_pending_charges'`,

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-billing-numeric.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-billing-numeric.test.ts
@@ -30,7 +30,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 
 // PGlite isolation harness (mirrors agent-billing-reactivation.test.ts): the
-// wiring suite self-skips LOUDLY against a shared non-PGlite Postgres.
+// wiring suite fails LOUDLY against a shared non-PGlite Postgres.
 const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
 const CAN_USE_ISOLATED_PGLITE =
   AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
@@ -104,7 +104,7 @@ describe("AgentBillingRepository.getOrganizationCreditBalance fail-closed wiring
     if (!CAN_USE_ISOLATED_PGLITE) {
       pgliteReady = false;
       console.warn(
-        "[agent-billing-numeric.test] DATABASE_URL is a non-PGlite Postgres (shared CI DB); this in-process-PGlite wiring suite self-skips — pushSchema against a shared connection crashes the bun runner and would mutate the shared schema. Parser suite above still runs.",
+        "[agent-billing-numeric.test] DATABASE_URL is a non-PGlite Postgres (shared CI DB); this in-process-PGlite wiring suite fails — pushSchema against a shared connection crashes the bun runner and would mutate the shared schema. Parser suite above still runs.",
       );
       return;
     }
@@ -122,7 +122,7 @@ describe("AgentBillingRepository.getOrganizationCreditBalance fail-closed wiring
   }, PGLITE_TIMEOUT);
 
   beforeEach(async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     await dbWrite.delete(organizations);
   });
 
@@ -131,7 +131,7 @@ describe("AgentBillingRepository.getOrganizationCreditBalance fail-closed wiring
   });
 
   test("a real credit_balance read routes through the parser (healthy path)", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const [org] = await dbWrite
       .insert(organizations)
       .values({ name: "Billing Org", slug: uniq("org"), credit_balance: "123.450000" })
@@ -143,7 +143,7 @@ describe("AgentBillingRepository.getOrganizationCreditBalance fail-closed wiring
   });
 
   test("a genuinely-missing org returns null — NOT a fabricated 0", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const balance = await agentBillingRepository.getOrganizationCreditBalance(
       "00000000-0000-0000-0000-000000000000",
     );
@@ -151,7 +151,7 @@ describe("AgentBillingRepository.getOrganizationCreditBalance fail-closed wiring
   });
 
   test("an explicit zero balance reads as 0, distinguishable from a missing org's null", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const [org] = await dbWrite
       .insert(organizations)
       .values({ name: "Depleted Org", slug: uniq("org"), credit_balance: "0" })

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-billing-reactivation.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-billing-reactivation.test.ts
@@ -10,7 +10,7 @@
  *
  * Harness mirrors `repositories/__tests__/apps.test.ts`: drizzle-kit `pushSchema`
  * generates the EXACT DDL from the real schema objects and applies it to the same
- * PGlite connection the repository queries through. Self-skips LOUDLY (never
+ * PGlite connection the repository queries through. Fails LOUDLY (never
  * silently passes) when a shared non-PGlite Postgres is the ambient DATABASE_URL.
  */
 
@@ -99,7 +99,7 @@ beforeAll(async () => {
   if (!CAN_USE_ISOLATED_PGLITE) {
     pgliteReady = false;
     console.warn(
-      "[agent-billing-reactivation.test] DATABASE_URL is a non-PGlite Postgres (shared CI DB); this in-process-PGlite isolation suite self-skips — drizzle-kit pushSchema against a shared connection crashes the bun runner and would mutate the shared schema.",
+      "[agent-billing-reactivation.test] DATABASE_URL is a non-PGlite Postgres (shared CI DB); this in-process-PGlite isolation suite fails — drizzle-kit pushSchema against a shared connection crashes the bun runner and would mutate the shared schema.",
     );
     return;
   }
@@ -110,14 +110,14 @@ beforeAll(async () => {
   } catch (error) {
     pgliteReady = false;
     console.error(
-      "[agent-billing-reactivation.test] PGlite/pushSchema unavailable — cannot drive AgentBillingRepository against a real DB. Skipping all cases.",
+      "[agent-billing-reactivation.test] PGlite/pushSchema unavailable — cannot drive AgentBillingRepository against a real DB. Failing all cases.",
       error,
     );
   }
 }, PGLITE_TIMEOUT);
 
 beforeEach(async () => {
-  if (!pgliteReady) return;
+  expect(pgliteReady).toBe(true);
   await dbWrite.delete(agentSandboxes);
   await dbWrite.delete(userCharacters);
   await dbWrite.delete(users);
@@ -130,7 +130,7 @@ afterAll(async () => {
 
 describe("AgentBillingRepository.reactivateSandboxBillingAfterFunding", () => {
   test("a suspended running agent is EXCLUDED from the billable set until reactivated", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const { organizationId, userId } = await seedOrgAndUser();
     const sandboxId = await seedSandbox(organizationId, userId, "suspended");
 
@@ -156,7 +156,7 @@ describe("AgentBillingRepository.reactivateSandboxBillingAfterFunding", () => {
   });
 
   test("an EXEMPT agent is never forced into billing by reactivation", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const { organizationId, userId } = await seedOrgAndUser();
     const sandboxId = await seedSandbox(organizationId, userId, "exempt");
 

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-sandboxes-fleet-candidate-repo.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-sandboxes-fleet-candidate-repo.test.ts
@@ -11,7 +11,7 @@
  *
  * Harness mirrors `__tests__/agent-billing-reactivation.test.ts`: drizzle-kit
  * `pushSchema` applies the exact DDL from the real schema objects to the same
- * PGlite connection the repository queries through. Self-skips LOUDLY (never
+ * PGlite connection the repository queries through. Fails LOUDLY (never
  * silently passes) when a shared non-PGlite Postgres is the ambient DATABASE_URL.
  */
 
@@ -96,7 +96,7 @@ beforeAll(async () => {
   if (!CAN_USE_ISOLATED_PGLITE) {
     pgliteReady = false;
     console.warn(
-      "[agent-sandboxes-fleet-candidate-repo.test] DATABASE_URL is a non-PGlite Postgres (shared CI DB); this in-process-PGlite isolation suite self-skips — drizzle-kit pushSchema against a shared connection crashes the bun runner and would mutate the shared schema.",
+      "[agent-sandboxes-fleet-candidate-repo.test] DATABASE_URL is a non-PGlite Postgres (shared CI DB); this in-process-PGlite isolation suite fails — drizzle-kit pushSchema against a shared connection crashes the bun runner and would mutate the shared schema.",
     );
     return;
   }
@@ -107,14 +107,14 @@ beforeAll(async () => {
   } catch (error) {
     pgliteReady = false;
     console.error(
-      "[agent-sandboxes-fleet-candidate-repo.test] PGlite/pushSchema unavailable — cannot drive AgentSandboxesRepository against a real DB. Skipping all cases.",
+      "[agent-sandboxes-fleet-candidate-repo.test] PGlite/pushSchema unavailable — cannot drive AgentSandboxesRepository against a real DB. Failing all cases.",
       error,
     );
   }
 }, PGLITE_TIMEOUT);
 
 beforeEach(async () => {
-  if (!pgliteReady) return;
+  expect(pgliteReady).toBe(true);
   await dbWrite.delete(agentSandboxes);
 });
 
@@ -124,7 +124,7 @@ afterAll(async () => {
 
 describe("fleet candidate selection matches default image by repo (#15101)", () => {
   test("listRunningWithDigestOtherThan selects same-repo agents pinned to a different tag/digest", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const { organizationId, userId } = await seedOrgAndUser();
 
     // Same repo, older tag — this is the row the pre-fix full-ref compare wrongly skipped.
@@ -164,7 +164,7 @@ describe("fleet candidate selection matches default image by repo (#15101)", () 
   });
 
   test("a registry port in the repo is not mistaken for a tag", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const { organizationId, userId } = await seedOrgAndUser();
     const targetImage = "ghcr.io:443/elizaos/eliza-agent:prod";
 
@@ -187,7 +187,7 @@ describe("fleet candidate selection matches default image by repo (#15101)", () 
   });
 
   test("listRollbackEligibleForDigest matches same-repo agents by repo, excludes custom", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const { organizationId, userId } = await seedOrgAndUser();
 
     // Rollback-eligible: on the current digest, has a previous digest, same repo
@@ -221,7 +221,7 @@ describe("fleet candidate selection matches default image by repo (#15101)", () 
 
 describe("imageRepoSql matches imageRepo across ref shapes (#15101)", () => {
   test("SQL normalization agrees with the JS guard for every ref shape", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const { imageRepo, imageRepoSql } = await import("../../utils/docker-image-ref");
     const cases = [
       "ghcr.io/elizaos/eliza-agent:prod",

--- a/packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts
@@ -12,7 +12,7 @@
  * Run:
  *   bun test packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts
  *
- * Self-skips LOUDLY if PGlite / drizzle-kit `pushSchema` cannot apply the schema
+ * Fails LOUDLY if PGlite / drizzle-kit `pushSchema` cannot apply the schema
  * here (the repo cannot be driven against a real DB) — it never silently passes.
  */
 
@@ -24,7 +24,7 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 // DB — and running drizzle-kit `pushSchema` against that shared connection both
 // crashes the bun test runner ("Pulling schema from database…" → hard exit) AND
 // would mutate the shared schema other suites depend on. Detect that here and
-// self-skip LOUDLY below (the file's stated contract: never silently pass).
+// fail LOUDLY below (the file's stated contract: never silently pass).
 const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
 const CAN_USE_ISOLATED_PGLITE =
   AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
@@ -97,7 +97,7 @@ beforeAll(async () => {
   if (!CAN_USE_ISOLATED_PGLITE) {
     pgliteReady = false;
     console.warn(
-      "[apps.test] DATABASE_URL is a non-PGlite Postgres (shared CI DB); this in-process-PGlite isolation suite self-skips — drizzle-kit pushSchema against a shared connection crashes the bun runner and would mutate the shared schema.",
+      "[apps.test] DATABASE_URL is a non-PGlite Postgres (shared CI DB); this in-process-PGlite isolation suite fails — drizzle-kit pushSchema against a shared connection crashes the bun runner and would mutate the shared schema.",
     );
     return;
   }
@@ -128,7 +128,7 @@ beforeAll(async () => {
     pgliteReady = false;
     // Loud skip: a real DB is required for these assertions; never pass silently.
     console.error(
-      "[apps.test] PGlite/pushSchema unavailable — cannot drive AppsRepository against a real DB. Skipping all cases.",
+      "[apps.test] PGlite/pushSchema unavailable — cannot drive AppsRepository against a real DB. Failing all cases.",
       error,
     );
   }
@@ -157,7 +157,7 @@ async function createApp(
 
 describe("AppsRepository.create + reads", () => {
   test("create returns a persisted App with id/slug/api_key_id; reads find it", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const { organizationId, userId } = await seedOrgAndUser();
     const apiKeyId = crypto.randomUUID();
 
@@ -190,7 +190,7 @@ describe("AppsRepository.create + reads", () => {
   });
 
   test("reads for non-existent identifiers return undefined", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     expect(await appsRepository.findById(FRESH_UUID)).toBeUndefined();
     // Malformed (non-UUID) id short-circuits to undefined before hitting the DB.
     expect(await appsRepository.findById("not-a-uuid")).toBeUndefined();
@@ -201,7 +201,7 @@ describe("AppsRepository.create + reads", () => {
 
 describe("AppsRepository.update", () => {
   test("update returns the merged App and a fresh read reflects the change", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const { organizationId, userId } = await seedOrgAndUser();
     const created = await createApp({
       name: "Before",
@@ -231,12 +231,12 @@ describe("AppsRepository.update", () => {
   });
 
   test("update of a non-existent id returns undefined", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     expect(await appsRepository.update(FRESH_UUID, { name: "ghost" })).toBeUndefined();
   });
 
   test("update evicts the service read-cache (fresh read returns NEW value, not stale)", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const { organizationId, userId } = await seedOrgAndUser();
     const created = await createApp({
       name: "Cache Warm",
@@ -260,7 +260,7 @@ describe("AppsRepository.update", () => {
 
 describe("AppsRepository.delete", () => {
   test("delete removes the row (findById -> undefined) and evicts the cache", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const { organizationId, userId } = await seedOrgAndUser();
     const created = await createApp({
       name: "To Delete",
@@ -281,7 +281,7 @@ describe("AppsRepository.delete", () => {
 
 describe("AppsRepository.listByOrganization", () => {
   test("returns only that org's apps, ordered updated_at DESC, respecting limit/offset", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const orgA = await seedOrg();
     const orgB = await seedOrg();
     const userA = await seedUser(orgA);
@@ -348,7 +348,7 @@ describe("AppsRepository.listByOrganization", () => {
 
 describe("App-auth attribution grants", () => {
   test("connectUser upgrades an existing analytics-created app user to an OAuth grant", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const appOrg = await seedOrg();
     const callerOrg = await seedOrg();
     const appOwner = await seedUser(appOrg);
@@ -381,7 +381,7 @@ describe("App-auth attribution grants", () => {
   });
 
   test("monetized X-App-Id inference attribution is public to authenticated callers", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const appOrg = await seedOrg();
     const callerOrg = await seedOrg();
     const appOwner = await seedUser(appOrg);
@@ -442,7 +442,7 @@ describe("App-auth attribution grants", () => {
 
 describe("AppsRepository.listAll", () => {
   test("filters by is_active / is_approved", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const { organizationId, userId } = await seedOrgAndUser();
 
     const active = await createApp({
@@ -480,7 +480,7 @@ describe("AppsRepository.listAll", () => {
 
 describe("AppsRepository.checkNameAvailability", () => {
   test("available for a fresh name", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const result = await appsRepository.checkNameAvailability(uniq("Totally Fresh Name"));
     expect(result.available).toBe(true);
     expect(result.conflictType).toBeUndefined();
@@ -488,7 +488,7 @@ describe("AppsRepository.checkNameAvailability", () => {
   });
 
   test("taken (app slug) -> available:false + slug + conflictType 'app'", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const { organizationId, userId } = await seedOrgAndUser();
     // Create an app whose slug equals slug("Taken Brand Name").
     await createApp({
@@ -505,7 +505,7 @@ describe("AppsRepository.checkNameAvailability", () => {
   });
 
   test("subdomain-collision path -> available:false + conflictType 'subdomain'", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const { organizationId, userId } = await seedOrgAndUser();
     const anchor = await createApp({
       name: "Anchor For Subdomain",
@@ -526,7 +526,7 @@ describe("AppsRepository.checkNameAvailability", () => {
 
 describe("jsonb + scalar round-trips", () => {
   test("metadata { viewKind, foo } persists and reads back through the jsonb column", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const { organizationId, userId } = await seedOrgAndUser();
     const created = await createApp({
       name: "View Deploy App",
@@ -550,7 +550,7 @@ describe("jsonb + scalar round-trips", () => {
   });
 
   test("affiliate_code + app_url round-trip", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const { organizationId, userId } = await seedOrgAndUser();
     const affiliateCode = uniq("aff");
     const created = await createApp({
@@ -581,7 +581,7 @@ describe("jsonb + scalar round-trips", () => {
 
 describe("AppsService.isNameAvailable", () => {
   test("taken name -> available:false + a suggestedName", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const { organizationId, userId } = await seedOrgAndUser();
     await createApp({
       name: "Service Taken",
@@ -599,7 +599,7 @@ describe("AppsService.isNameAvailable", () => {
   });
 
   test("available name -> available:true and no suggestedName", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const result = await appsService.isNameAvailable(uniq("Service Fresh Name"));
     expect(result.available).toBe(true);
     expect(result.suggestedName).toBeUndefined();
@@ -608,7 +608,7 @@ describe("AppsService.isNameAvailable", () => {
 
 describe("AppsService.create organization cap", () => {
   test("treats malformed cap values as invalid and falls back to the default", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const previousLimit = process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG;
     process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG = "1abc";
     try {
@@ -638,7 +638,7 @@ describe("AppsService.create organization cap", () => {
   });
 
   test("rejects before API key creation when the org is already at the configured app cap", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const previousLimit = process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG;
     process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG = "1";
     try {
@@ -676,7 +676,7 @@ describe("AppsService.create organization cap", () => {
   });
 
   test("allows creation below the configured cap and persists the generated API key", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const previousLimit = process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG;
     process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG = "2";
     try {
@@ -707,7 +707,7 @@ describe("AppsService.create organization cap", () => {
   });
 
   test("cleans up the generated API key when the transactional cap check rejects", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const previousLimit = process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG;
     const originalCreateIfBelowLimit = appsRepository.createIfOrganizationBelowLimit;
     process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG = "25";
@@ -745,7 +745,7 @@ describe("AppsService.create organization cap", () => {
 
 describe("AppAnalyticsService session analytics from app_requests", () => {
   test("groups real pageview rows into sessions and ordered funnel steps", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const { organizationId, userId } = await seedOrgAndUser();
     const app = await createApp({
       name: "Session Analytics App",

--- a/packages/cloud/shared/src/db/repositories/__tests__/conversations-total-cost.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/conversations-total-cost.test.ts
@@ -25,7 +25,7 @@
  * the guard fires INSIDE the transaction — rolling back both the message insert
  * and the stats update atomically — instead of committing a poisoned total,
  * while a legitimate $0 / well-formed cost still accumulates. DB cases
- * self-skip if PGlite is unavailable.
+ * fail if PGlite is unavailable.
  */
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
@@ -185,7 +185,7 @@ describe("addMessageWithSequence total_cost accumulator", () => {
   test(
     "healthy row: accumulates a well-formed cost and bumps message_count",
     async () => {
-      if (!pgliteReady) return;
+      expect(pgliteReady).toBe(true);
       await seedConversation(CONV_HEALTHY, "1.25");
 
       await conversationsRepository.addMessageWithSequence(CONV_HEALTHY, {
@@ -205,7 +205,7 @@ describe("addMessageWithSequence total_cost accumulator", () => {
   test(
     "missing per-message cost is a legitimate $0 contribution (preserves `cost || 0` semantics)",
     async () => {
-      if (!pgliteReady) return;
+      expect(pgliteReady).toBe(true);
       // reuse the healthy conversation: total is 2.00, add a costless message.
       await conversationsRepository.addMessageWithSequence(CONV_HEALTHY, {
         role: "user",
@@ -223,7 +223,7 @@ describe("addMessageWithSequence total_cost accumulator", () => {
   test(
     "corrupt stored total_cost ('NaN'::numeric) FAILS CLOSED and rolls back — no message, no poison",
     async () => {
-      if (!pgliteReady) return;
+      expect(pgliteReady).toBe(true);
       await seedConversation(CONV_CORRUPT, "NaN"); // Postgres NUMERIC can hold NaN.
       // Sanity: the stored value really reads back as the string "NaN".
       const before = await readStats(CONV_CORRUPT);
@@ -252,7 +252,7 @@ describe("addMessageWithSequence total_cost accumulator", () => {
   test(
     "non-finite per-message cost FAILS CLOSED and rolls back — no message, healthy total untouched",
     async () => {
-      if (!pgliteReady) return;
+      expect(pgliteReady).toBe(true);
       await seedConversation(CONV_BADCOST, "5.00");
 
       // A caller cost of "NaN" (or "Infinity") would have produced

--- a/packages/cloud/shared/src/db/repositories/__tests__/domain-purchase-ownership.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/domain-purchase-ownership.test.ts
@@ -67,30 +67,30 @@ afterAll(async () => {
 
 describe("hasUnrefundedDomainPurchase", () => {
   beforeEach(async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     await dbWrite.execute(`DELETE FROM credit_transactions;`);
   });
 
   test("no transactions → false", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     expect(await repo.hasUnrefundedDomainPurchase(ORG_A, "example.com")).toBe(false);
   });
 
   test("an unrefunded domain_purchase debit → true", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     await addTxn(ORG_A, "debit", { type: "domain_purchase", domain: "example.com" });
     expect(await repo.hasUnrefundedDomainPurchase(ORG_A, "example.com")).toBe(true);
   });
 
   test("debit fully refunded → false", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     await addTxn(ORG_A, "debit", { type: "domain_purchase", domain: "example.com" });
     await addTxn(ORG_A, "refund", { type: "domain_purchase_refund", domain: "example.com" });
     expect(await repo.hasUnrefundedDomainPurchase(ORG_A, "example.com")).toBe(false);
   });
 
   test("re-purchased after a refund (debits > refunds) → true", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     await addTxn(ORG_A, "debit", { type: "domain_purchase", domain: "example.com" });
     await addTxn(ORG_A, "refund", { type: "domain_purchase_refund", domain: "example.com" });
     await addTxn(ORG_A, "debit", { type: "domain_purchase", domain: "example.com" });
@@ -98,14 +98,14 @@ describe("hasUnrefundedDomainPurchase", () => {
   });
 
   test("a different org's purchase does not grant ownership", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     await addTxn(ORG_A, "debit", { type: "domain_purchase", domain: "example.com" });
     // Org B never bought example.com — must be denied (cross-tenant guard).
     expect(await repo.hasUnrefundedDomainPurchase(ORG_B, "example.com")).toBe(false);
   });
 
   test("a purchase of a different domain does not match", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     await addTxn(ORG_A, "debit", { type: "domain_purchase", domain: "other.com" });
     expect(await repo.hasUnrefundedDomainPurchase(ORG_A, "example.com")).toBe(false);
   });

--- a/packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts
@@ -104,12 +104,12 @@ afterAll(async () => {
 
 describe("jobsRepository.recoverStaleJobs", () => {
   beforeEach(async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     await dbWrite.execute("DELETE FROM jobs;");
   });
 
   test("uses each stale row's max_attempts instead of a caller-wide fallback", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const singleAttemptJobId = "00000000-0000-4000-8000-000000010854";
     const retryableJobId = "00000000-0000-4000-8000-000000020854";
     await seedJob({ id: singleAttemptJobId, maxAttempts: 1 });
@@ -147,7 +147,7 @@ describe("jobsRepository.recoverStaleJobs", () => {
   });
 
   test("recovers in-progress rows claimed before a replacement worker started", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const interruptedJobId = "00000000-0000-4000-8000-000000030854";
     const currentJobId = "00000000-0000-4000-8000-000000040854";
 

--- a/packages/cloud/shared/src/db/repositories/__tests__/payment-requests-numeric.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/payment-requests-numeric.test.ts
@@ -27,7 +27,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 
 // PGlite isolation harness (mirrors agent-billing-numeric.test.ts): the wiring
-// suite self-skips LOUDLY against a shared non-PGlite Postgres.
+// suite fails LOUDLY against a shared non-PGlite Postgres.
 const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
 const CAN_USE_ISOLATED_PGLITE =
   AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
@@ -138,7 +138,7 @@ describe("PaymentRequestsRepository.getPaymentRequest fail-closed wiring", () =>
     if (!CAN_USE_ISOLATED_PGLITE) {
       pgliteReady = false;
       console.warn(
-        "[payment-requests-numeric.test] DATABASE_URL is a non-PGlite Postgres (shared CI DB); this in-process-PGlite wiring suite self-skips — pushSchema against a shared connection crashes the bun runner and would mutate the shared schema. Parser suite above still runs.",
+        "[payment-requests-numeric.test] DATABASE_URL is a non-PGlite Postgres (shared CI DB); this in-process-PGlite wiring suite fails — pushSchema against a shared connection crashes the bun runner and would mutate the shared schema. Parser suite above still runs.",
       );
       return;
     }
@@ -164,7 +164,7 @@ describe("PaymentRequestsRepository.getPaymentRequest fail-closed wiring", () =>
   }, PGLITE_TIMEOUT);
 
   beforeEach(async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     await dbWrite.delete(paymentRequests);
     await dbWrite.delete(organizations);
   });
@@ -182,7 +182,7 @@ describe("PaymentRequestsRepository.getPaymentRequest fail-closed wiring", () =>
   };
 
   test("a real amount_cents read routes through the parser (healthy path)", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const orgId = await seedOrg();
     const created = await repo.createPaymentRequest({
       organizationId: orgId,
@@ -200,7 +200,7 @@ describe("PaymentRequestsRepository.getPaymentRequest fail-closed wiring", () =>
   });
 
   test("a large-but-safe amount round-trips without precision loss", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const orgId = await seedOrg();
     // 9,999,999,999,99 cents (~$100B) — well within safe-integer range but far
     // larger than a typical charge; proves the bigint read stays exact.
@@ -219,13 +219,13 @@ describe("PaymentRequestsRepository.getPaymentRequest fail-closed wiring", () =>
   });
 
   test("a genuinely-missing request returns null — NOT a fabricated row", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const fetched = await repo.getPaymentRequest("00000000-0000-0000-0000-000000000000");
     expect(fetched).toBeNull();
   });
 
   test("an explicit zero amount reads as 0 (distinguishable from a missing row's null)", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const orgId = await seedOrg();
     const created = await repo.createPaymentRequest({
       organizationId: orgId,

--- a/packages/cloud/shared/src/db/repositories/anonymous-sessions.test.ts
+++ b/packages/cloud/shared/src/db/repositories/anonymous-sessions.test.ts
@@ -42,18 +42,18 @@ beforeAll(async () => {
 });
 
 beforeEach(async () => {
-  if (!pgliteReady) return;
+  expect(pgliteReady).toBe(true);
   await dbWrite.execute(sql`DELETE FROM anonymous_sessions`);
 });
 
 afterAll(async () => {
-  if (!pgliteReady) return;
+  expect(pgliteReady).toBe(true);
   await dbWrite.execute(sql`DROP TABLE IF EXISTS anonymous_sessions`);
 });
 
 describe("AnonymousSessionsRepository free-message reservations", () => {
   test("reserves a message slot atomically at the configured limit", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
 
     const sessionId = "00000000-0000-4000-8000-000000000101";
     await dbWrite.execute(sql`
@@ -88,7 +88,7 @@ describe("AnonymousSessionsRepository free-message reservations", () => {
   });
 
   test("refunds a reserved slot without underflowing the counter", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
 
     const sessionId = "00000000-0000-4000-8000-000000000102";
     await dbWrite.execute(sql`

--- a/packages/cloud/shared/src/lib/services/__tests__/eliza-sandbox-coding-container-quota.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/eliza-sandbox-coding-container-quota.test.ts
@@ -23,7 +23,7 @@
  * eliza-sandbox-create-idempotency.test.ts; this file proves the behavioral
  * quota semantics end-to-end on real SQL.
  *
- * Self-skips LOUDLY if PGlite/pushSchema is unavailable (never silently passes).
+ * Fails LOUDLY if PGlite/pushSchema is unavailable (never silently passes).
  */
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
@@ -87,9 +87,7 @@ async function setAgentStatus(agentId: string, status: AgentSandboxStatus): Prom
 beforeAll(async () => {
   if (!CAN_USE_ISOLATED_PGLITE) {
     pgliteReady = false;
-    console.warn(
-      "[eliza-sandbox-coding-container-quota.test] non-PGlite DATABASE_URL; self-skipping.",
-    );
+    console.warn("[eliza-sandbox-coding-container-quota.test] non-PGlite DATABASE_URL; failing.");
     return;
   }
   try {
@@ -102,7 +100,7 @@ beforeAll(async () => {
   } catch (error) {
     pgliteReady = false;
     console.error(
-      "[eliza-sandbox-coding-container-quota.test] PGlite/pushSchema unavailable — skipping.",
+      "[eliza-sandbox-coding-container-quota.test] PGlite/pushSchema unavailable — failing.",
       error,
     );
   }
@@ -116,7 +114,7 @@ describe("createCodingContainerAgent — per-org quota (#11023)", () => {
   test(
     "the distinct-image DoS is dead: 6 distinct-image creates at cap 3 → exactly 3 rows, surplus throw AgentQuotaExceededError",
     async () => {
-      if (!pgliteReady) return;
+      expect(pgliteReady).toBe(true);
       const orgId = await seedOrg();
       const userId = await seedUser(orgId);
       const svc = new ElizaSandboxService();
@@ -151,7 +149,7 @@ describe("createCodingContainerAgent — per-org quota (#11023)", () => {
   test(
     "same-image retry at the cap reuses the active row (idempotent, no throw)",
     async () => {
-      if (!pgliteReady) return;
+      expect(pgliteReady).toBe(true);
       const orgId = await seedOrg();
       const userId = await seedUser(orgId);
       const svc = new ElizaSandboxService();
@@ -188,7 +186,7 @@ describe("createCodingContainerAgent — per-org quota (#11023)", () => {
   test(
     "unset cap stays uncapped (trusted internal callers) — mints past any ceiling",
     async () => {
-      if (!pgliteReady) return;
+      expect(pgliteReady).toBe(true);
       const orgId = await seedOrg();
       const userId = await seedUser(orgId);
       const svc = new ElizaSandboxService();
@@ -212,7 +210,7 @@ describe("createCodingContainerAgent — per-org quota (#11023)", () => {
   test(
     "quota is per-org: org A at the cap does not block org B",
     async () => {
-      if (!pgliteReady) return;
+      expect(pgliteReady).toBe(true);
       const orgA = await seedOrg();
       const userA = await seedUser(orgA);
       const orgB = await seedOrg();
@@ -247,7 +245,7 @@ describe("createCodingContainerAgent — per-org quota (#11023)", () => {
   test(
     "createAgent (forceCreate) and createCodingContainerAgent share ONE per-org ceiling",
     async () => {
-      if (!pgliteReady) return;
+      expect(pgliteReady).toBe(true);
       const orgId = await seedOrg();
       const userId = await seedUser(orgId);
       const svc = new ElizaSandboxService();
@@ -295,7 +293,7 @@ describe("suspend/sleep quota residual (#11023 F3)", () => {
   test(
     "stopped + sleeping rows still hold their quota slot: both capped create paths throw",
     async () => {
-      if (!pgliteReady) return;
+      expect(pgliteReady).toBe(true);
       const orgId = await seedOrg();
       const userId = await seedUser(orgId);
       const svc = new ElizaSandboxService();
@@ -344,7 +342,7 @@ describe("suspend/sleep quota residual (#11023 F3)", () => {
   test(
     "the create→suspend→create loop is dead: the NORMAL reuse path throws when every existing agent is suspended/sleeping",
     async () => {
-      if (!pgliteReady) return;
+      expect(pgliteReady).toBe(true);
       const orgId = await seedOrg();
       const userId = await seedUser(orgId);
       const svc = new ElizaSandboxService();
@@ -385,7 +383,7 @@ describe("suspend/sleep quota residual (#11023 F3)", () => {
   test(
     "reuse semantics unchanged: at the cap a LIVE agent is still handed back (never a suspended row, never a throw)",
     async () => {
-      if (!pgliteReady) return;
+      expect(pgliteReady).toBe(true);
       const orgId = await seedOrg();
       const userId = await seedUser(orgId);
       const svc = new ElizaSandboxService();
@@ -421,7 +419,7 @@ describe("suspend/sleep quota residual (#11023 F3)", () => {
   test(
     "terminal states stay excluded: error / deletion_pending rows free their quota slot",
     async () => {
-      if (!pgliteReady) return;
+      expect(pgliteReady).toBe(true);
       const orgId = await seedOrg();
       const userId = await seedUser(orgId);
       const svc = new ElizaSandboxService();

--- a/packages/cloud/shared/src/lib/services/__tests__/eliza-sandbox-deletion-failed-quota.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/eliza-sandbox-deletion-failed-quota.test.ts
@@ -11,7 +11,7 @@
  * flipped to `deletion_failed` exactly as the AGENT_DELETE permanent-failure
  * writeback does (provisioning-jobs.ts): status + error_message + error_count.
  *
- * Self-skips LOUDLY if PGlite/pushSchema is unavailable (never silently passes).
+ * Fails LOUDLY if PGlite/pushSchema is unavailable (never silently passes).
  */
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
@@ -117,9 +117,7 @@ async function seedOrgAtCap(): Promise<{ orgId: string; userId: string; ids: str
 beforeAll(async () => {
   if (!CAN_USE_ISOLATED_PGLITE) {
     pgliteReady = false;
-    console.warn(
-      "[eliza-sandbox-deletion-failed-quota.test] non-PGlite DATABASE_URL; self-skipping.",
-    );
+    console.warn("[eliza-sandbox-deletion-failed-quota.test] non-PGlite DATABASE_URL; failing.");
     return;
   }
   try {
@@ -132,7 +130,7 @@ beforeAll(async () => {
   } catch (error) {
     pgliteReady = false;
     console.error(
-      "[eliza-sandbox-deletion-failed-quota.test] PGlite/pushSchema unavailable — skipping.",
+      "[eliza-sandbox-deletion-failed-quota.test] PGlite/pushSchema unavailable — failing.",
       error,
     );
   }
@@ -146,7 +144,7 @@ describe("deletion_failed frees the org's quota slot (#15603 C8)", () => {
   test(
     "org at capacity with one deletion_failed row can mint a replacement; the stuck row stays for ops",
     async () => {
-      if (!pgliteReady) return;
+      expect(pgliteReady).toBe(true);
       const { orgId, userId, ids } = await seedOrgAtCap();
       const svc = new ElizaSandboxService();
 
@@ -174,7 +172,7 @@ describe("deletion_failed frees the org's quota slot (#15603 C8)", () => {
   test(
     "the NORMAL reuse path never resurrects a deletion_failed row — it mints a fresh agent instead",
     async () => {
-      if (!pgliteReady) return;
+      expect(pgliteReady).toBe(true);
       const { orgId, userId, ids } = await seedOrgAtCap();
       const svc = new ElizaSandboxService();
 
@@ -201,7 +199,7 @@ describe("deletion_failed frees the org's quota slot (#15603 C8)", () => {
   test(
     "a re-armed delete (deletion_failed -> deletion_pending) still frees the slot mid-recovery",
     async () => {
-      if (!pgliteReady) return;
+      expect(pgliteReady).toBe(true);
       const { orgId, userId, ids } = await seedOrgAtCap();
       const svc = new ElizaSandboxService();
 
@@ -227,7 +225,7 @@ describe("deletion_failed frees the org's quota slot (#15603 C8)", () => {
   test(
     "coding-container path shares the exclusion: deletion_failed frees a slot there too",
     async () => {
-      if (!pgliteReady) return;
+      expect(pgliteReady).toBe(true);
       const orgId = await seedOrg();
       const userId = await seedUser(orgId);
       const svc = new ElizaSandboxService();
@@ -265,7 +263,7 @@ describe("the exclusion cannot be gamed into unbounded live containers", () => {
   test(
     "genuinely-running rows still hold their slot: org at cap of running agents is refused",
     async () => {
-      if (!pgliteReady) return;
+      expect(pgliteReady).toBe(true);
       const { orgId, userId, ids } = await seedOrgAtCap();
       const svc = new ElizaSandboxService();
 
@@ -290,7 +288,7 @@ describe("the exclusion cannot be gamed into unbounded live containers", () => {
   test(
     "one deletion_failed row frees exactly ONE slot: the replacement fills it and the next create is refused with the live count",
     async () => {
-      if (!pgliteReady) return;
+      expect(pgliteReady).toBe(true);
       const { orgId, userId, ids } = await seedOrgAtCap();
       const svc = new ElizaSandboxService();
 

--- a/packages/cloud/shared/src/lib/services/agent-backup-verifier.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-verifier.test.ts
@@ -8,7 +8,7 @@
  *
  * Harness mirrors `db/repositories/__tests__/agent-sandboxes-fleet-candidate-repo.test.ts`:
  * drizzle-kit `pushSchema` applies the real DDL to the PGlite connection the
- * service queries through; self-skips LOUDLY when the ambient DATABASE_URL is a
+ * service queries through; fails LOUDLY when the ambient DATABASE_URL is a
  * shared non-PGlite Postgres.
  */
 
@@ -207,7 +207,7 @@ beforeAll(async () => {
   if (!CAN_USE_ISOLATED_PGLITE) {
     pgliteReady = false;
     console.warn(
-      "[agent-backup-verifier.test] DATABASE_URL is a non-PGlite Postgres (shared CI DB); this in-process-PGlite isolation suite self-skips — drizzle-kit pushSchema against a shared connection crashes the bun runner and would mutate the shared schema.",
+      "[agent-backup-verifier.test] DATABASE_URL is a non-PGlite Postgres (shared CI DB); this in-process-PGlite isolation suite fails — drizzle-kit pushSchema against a shared connection crashes the bun runner and would mutate the shared schema.",
     );
     return;
   }
@@ -218,14 +218,14 @@ beforeAll(async () => {
   } catch (error) {
     pgliteReady = false;
     console.error(
-      "[agent-backup-verifier.test] PGlite/pushSchema unavailable — cannot drive the backup verifier against a real DB. Skipping all cases.",
+      "[agent-backup-verifier.test] PGlite/pushSchema unavailable — cannot drive the backup verifier against a real DB. Failing all cases.",
       error,
     );
   }
 }, PGLITE_TIMEOUT);
 
 beforeEach(async () => {
-  if (!pgliteReady) return;
+  expect(pgliteReady).toBe(true);
   await dbWrite.delete(agentSandboxBackups);
   await dbWrite.delete(agentSandboxes);
 });
@@ -291,7 +291,7 @@ describe("classifyCryptoError", () => {
 
 describe("runBackupVerificationCycle (real PGlite + real memory KMS)", () => {
   test("happy path: decrypts, matches content_hash, stamps verified, no alert", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const sandboxId = await seedSandbox();
     const backupId = await seedFullBackup(sandboxId, sampleState("happy"));
     const { alerts, alert } = makeAlertSpy();
@@ -307,7 +307,7 @@ describe("runBackupVerificationCycle (real PGlite + real memory KMS)", () => {
   });
 
   test("manifest-bearing backup: per-file + component hashes validated", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const sandboxId = await seedSandbox();
     const state: AgentBackupStateData = {
       ...sampleState("manifest"),
@@ -326,7 +326,7 @@ describe("runBackupVerificationCycle (real PGlite + real memory KMS)", () => {
   });
 
   test("manifest whose file bytes do not match its claimed sha256 fails as hash-mismatch", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const sandboxId = await seedSandbox();
     const manifest = fixtureManifest(sandboxId);
     // The capture lied: claimed hash for real bytes it never had.
@@ -347,7 +347,7 @@ describe("runBackupVerificationCycle (real PGlite + real memory KMS)", () => {
   });
 
   test("corrupted ciphertext: AEAD failure is stamped decrypt-failed and alerts fire", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const sandboxId = await seedSandbox();
     const backupId = await seedFullBackup(sandboxId, sampleState("corrupt"));
 
@@ -382,7 +382,7 @@ describe("runBackupVerificationCycle (real PGlite + real memory KMS)", () => {
   });
 
   test("wrong KMS key (fresh memory backend, #15310): key-unavailable + systemic escalation", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const sandboxA = await seedSandbox();
     const sandboxB = await seedSandbox();
     const backupA = await seedFullBackup(sandboxA, sampleState("kms-a"));
@@ -410,7 +410,7 @@ describe("runBackupVerificationCycle (real PGlite + real memory KMS)", () => {
   });
 
   test("content_hash drift on an otherwise-decryptable backup is stamped hash-mismatch", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const sandboxId = await seedSandbox();
     const backupId = await seedFullBackup(sandboxId, sampleState("drift"), {
       contentHash: computeStateHash(sampleState("some other state")),
@@ -427,7 +427,7 @@ describe("runBackupVerificationCycle (real PGlite + real memory KMS)", () => {
   });
 
   test("legacy row without content_hash still verifies decryptability (hash check skipped)", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const sandboxId = await seedSandbox();
     const backupId = await seedFullBackup(sandboxId, sampleState("legacy"), { contentHash: null });
 
@@ -439,7 +439,7 @@ describe("runBackupVerificationCycle (real PGlite + real memory KMS)", () => {
   });
 
   test("incremental backup: chain replays through the parent and verifies the reconstructed hash", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const sandboxId = await seedSandbox();
     const base = sampleState("chain-base");
     const next: AgentBackupStateData = {
@@ -475,7 +475,7 @@ describe("runBackupVerificationCycle (real PGlite + real memory KMS)", () => {
   });
 
   test("incremental backup with a corrupted PARENT fails: the restore chain is dead", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const sandboxId = await seedSandbox();
     const base = sampleState("chain-corrupt");
     const next: AgentBackupStateData = { ...base, config: { ...base.config, changed: 1 } };
@@ -510,7 +510,7 @@ describe("runBackupVerificationCycle (real PGlite + real memory KMS)", () => {
   });
 
   test("fleet-coverage sampling honors the re-verify interval and newest-per-agent", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const sandboxA = await seedSandbox();
     const sandboxB = await seedSandbox();
     // Agent A has an OLD unverified backup and a NEW recently-verified one;
@@ -552,7 +552,7 @@ describe("runBackupVerificationCycle (real PGlite + real memory KMS)", () => {
   });
 
   test("batch size bounds a cycle; the next cycle picks up the remainder", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     for (let i = 0; i < 3; i++) {
       const sandboxId = await seedSandbox();
       await seedFullBackup(sandboxId, sampleState(`batch-${i}`));
@@ -572,7 +572,7 @@ describe("runBackupVerificationCycle (real PGlite + real memory KMS)", () => {
   });
 
   test("disabled config is a no-op", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const sandboxId = await seedSandbox();
     const backupId = await seedFullBackup(sandboxId, sampleState("disabled"));
     const { alerts, alert } = makeAlertSpy();


### PR DESCRIPTION
## Summary
- replace silent `if (!pgliteReady) return` guards in cloud shared PGlite suites with explicit readiness assertions
- update affected comments/logs from skip language to fail-fast language
- add a static regression test that rejects new PGlite-gated suites that can silently green-pass

Fixes #15625

## Verification
- `bunx @biomejs/biome check <touched files> --no-errors-on-unmatched`
- `bun test packages/cloud/shared/src/db/__tests__/pglite-readiness-guards.test.ts packages/cloud/shared/src/db/inference-pending-charges-migration.test.ts` — 7 pass / 0 fail after generating core keyword data locally
- DB-side changed suite batch — 58 pass / 0 fail across 10 files
- service-side changed suite batch — 32 pass / 0 fail across 3 files

## Failure-mode proof
- Before generating `packages/core/src/i18n/generated/validation-keyword-data.ts`, the changed PGlite suites failed on the missing generated core import instead of returning green with zero assertions. That reproduces the false-green class described in #15625 and proves the guard now surfaces it.

## Notes
- Generated keyword files were produced locally only for verification and are ignored; they are not included in this PR.
