### PR TITLE
feat(lifeops): persist delegation contracts

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/delegation-contracts/index.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/delegation-contracts/index.ts
@@ -85,6 +85,20 @@ export interface DelegationContract {
   readonly sla?: DelegationSlaPolicy;
 }
 
+export type DelegationContractStatus =
+  | "active"
+  | "paused"
+  | "completed"
+  | "revoked"
+  | "expired";
+
+export interface LifeOpsDelegationContractRecord extends DelegationContract {
+  readonly agentId: string;
+  readonly status: DelegationContractStatus;
+  readonly metadata: Record<string, unknown>;
+  readonly updatedAt: string;
+}
+
 export interface DelegationInboundTurn {
   readonly channel: DelegationChannel;
   readonly threadId: string;
@@ -145,6 +159,44 @@ export interface DelegationEvaluation {
     readonly matchedTripwire: string | null;
     readonly reason: string;
   };
+}
+
+export function createLifeOpsDelegationContractRecord(
+  input: DelegationContract & {
+    readonly agentId: string;
+    readonly status?: DelegationContractStatus;
+    readonly metadata?: Record<string, unknown>;
+    readonly updatedAt?: string;
+  },
+): LifeOpsDelegationContractRecord {
+  return {
+    ...input,
+    status: input.status ?? "active",
+    metadata: input.metadata ?? {},
+    updatedAt: input.updatedAt ?? input.createdAt,
+  };
+}
+
+export function renderDelegationContractsProviderText(
+  contracts: readonly LifeOpsDelegationContractRecord[],
+): string {
+  const active = contracts.filter((contract) => contract.status === "active");
+  if (active.length === 0) return "";
+  const lines = active.slice(0, 5).map((contract) => {
+    const scope =
+      contract.scope.kind === "thread"
+        ? `${contract.scope.channel} thread ${contract.scope.threadId}`
+        : `${contract.scope.channel} sender class ${contract.scope.senderClass}`;
+    const tripwires = contract.tripwires
+      .map((tripwire) => tripwire.label)
+      .join(", ");
+    const tripwireText = tripwires.length > 0 ? tripwires : "no tripwire";
+    return `- ${contract.contractId}: ${contract.objective}; scope=${scope}; autonomy=${contract.autonomyLevel}; escalate on ${tripwireText}; expires ${contract.expiresAt}`;
+  });
+  if (active.length > 5) {
+    lines.push(`(+${active.length - 5} more active delegation contracts)`);
+  }
+  return ["Active delegation contracts:", ...lines].join("\n");
 }
 
 function normalize(value: string): string {

--- a/plugins/plugin-personal-assistant/src/lifeops/repository.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/repository.ts
@@ -116,6 +116,13 @@ import type {
   LifeOpsCommitmentSource,
   LifeOpsCommitmentStatus,
 } from "./commitments/index.js";
+import type {
+  DelegationAutonomyLevel,
+  DelegationScope,
+  DelegationSlaPolicy,
+  DelegationTripwire,
+  LifeOpsDelegationContractRecord,
+} from "./delegation-contracts/index.js";
 import {
   createConnectorAccountPrivacyPolicy,
   deriveConnectorAccountId,
@@ -639,6 +646,41 @@ function parseCommitmentLedgerRecord(
     metadata: parseJsonRecord(row.metadata_json),
     createdAt: toText(row.created_at),
     updatedAt: toText(row.updated_at),
+  };
+}
+
+function parseDelegationContractRecord(
+  row: Record<string, unknown>,
+): LifeOpsDelegationContractRecord {
+  const scope = parseJsonValue<DelegationScope | null>(row.scope_json, null);
+  if (!scope) {
+    throw new Error("[LifeOpsRepository] delegation contract missing scope.");
+  }
+  const tripwires = parseJsonValue<readonly DelegationTripwire[]>(
+    row.tripwires_json,
+    [],
+  );
+  const sla = parseJsonValue<DelegationSlaPolicy | null>(row.sla_json, null);
+  const state = parseJsonRecord(row.state_json);
+  return {
+    contractId: toText(row.id),
+    agentId: toText(row.agent_id),
+    status: toText(
+      row.status,
+      "active",
+    ) as LifeOpsDelegationContractRecord["status"],
+    objective: toText(row.objective),
+    scope,
+    autonomyLevel: toText(row.autonomy_level) as DelegationAutonomyLevel,
+    tripwires,
+    ownerUserId: toText(row.owner_user_id),
+    requestedBy: toText(row.requested_by),
+    state: state as NonNullable<LifeOpsDelegationContractRecord["state"]>,
+    ...(sla ? { sla } : {}),
+    metadata: parseJsonRecord(row.metadata_json),
+    createdAt: toText(row.created_at),
+    updatedAt: toText(row.updated_at),
+    expiresAt: toText(row.expires_at),
   };
 }
 
@@ -3571,6 +3613,92 @@ export class LifeOpsRepository {
         ORDER BY due_at ASC NULLS LAST, created_at ASC`,
     );
     return rows.map(parseCommitmentLedgerRecord);
+  }
+
+  async upsertDelegationContract(
+    record: LifeOpsDelegationContractRecord,
+  ): Promise<void> {
+    await executeRawSql(
+      this.runtime,
+      `INSERT INTO app_lifeops.life_delegation_contracts (
+        id, agent_id, status, objective, scope_json, autonomy_level,
+        tripwires_json, owner_user_id, requested_by, sla_json, state_json,
+        metadata_json, created_at, updated_at, expires_at
+      ) VALUES (
+        ${sqlQuote(record.contractId)},
+        ${sqlQuote(record.agentId)},
+        ${sqlQuote(record.status)},
+        ${sqlQuote(record.objective)},
+        ${sqlJson(record.scope)},
+        ${sqlQuote(record.autonomyLevel)},
+        ${sqlJson(record.tripwires)},
+        ${sqlQuote(record.ownerUserId)},
+        ${sqlQuote(record.requestedBy)},
+        ${record.sla ? sqlJson(record.sla) : "NULL"},
+        ${sqlJson(record.state ?? {})},
+        ${sqlJson(record.metadata)},
+        ${sqlQuote(record.createdAt)},
+        ${sqlQuote(record.updatedAt)},
+        ${sqlQuote(record.expiresAt)}
+      )
+      ON CONFLICT(id)
+      DO UPDATE SET
+        status = EXCLUDED.status,
+        objective = EXCLUDED.objective,
+        scope_json = EXCLUDED.scope_json,
+        autonomy_level = EXCLUDED.autonomy_level,
+        tripwires_json = EXCLUDED.tripwires_json,
+        owner_user_id = EXCLUDED.owner_user_id,
+        requested_by = EXCLUDED.requested_by,
+        sla_json = EXCLUDED.sla_json,
+        state_json = EXCLUDED.state_json,
+        metadata_json = EXCLUDED.metadata_json,
+        updated_at = EXCLUDED.updated_at,
+        expires_at = EXCLUDED.expires_at`,
+    );
+  }
+
+  async getDelegationContract(
+    agentId: string,
+    contractId: string,
+  ): Promise<LifeOpsDelegationContractRecord | null> {
+    const rows = await executeRawSql(
+      this.runtime,
+      `SELECT *
+         FROM app_lifeops.life_delegation_contracts
+        WHERE agent_id = ${sqlQuote(agentId)}
+          AND id = ${sqlQuote(contractId)}
+        LIMIT 1`,
+    );
+    const row = rows[0];
+    return row ? parseDelegationContractRecord(row) : null;
+  }
+
+  async listDelegationContracts(
+    agentId: string,
+    filter: {
+      statuses?: LifeOpsDelegationContractRecord["status"][];
+      activeAtIso?: string;
+    } = {},
+  ): Promise<LifeOpsDelegationContractRecord[]> {
+    const clauses = [`agent_id = ${sqlQuote(agentId)}`];
+    if (filter.statuses?.length) {
+      clauses.push(
+        `status IN (${filter.statuses.map((status) => sqlQuote(status)).join(", ")})`,
+      );
+    }
+    if (filter.activeAtIso) {
+      clauses.push(`created_at <= ${sqlQuote(filter.activeAtIso)}`);
+      clauses.push(`expires_at >= ${sqlQuote(filter.activeAtIso)}`);
+    }
+    const rows = await executeRawSql(
+      this.runtime,
+      `SELECT *
+         FROM app_lifeops.life_delegation_contracts
+        WHERE ${clauses.join(" AND ")}
+        ORDER BY expires_at ASC, created_at ASC`,
+    );
+    return rows.map(parseDelegationContractRecord);
   }
 
   // ---------------------------------------------------------------------

--- a/plugins/plugin-personal-assistant/src/lifeops/schema.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/schema.ts
@@ -351,6 +351,34 @@ export const lifeCommitmentLedger = appLifeopsPgSchema.table(
   ],
 );
 
+export const lifeDelegationContracts = appLifeopsPgSchema.table(
+  "life_delegation_contracts",
+  {
+    id: text("id").primaryKey(),
+    agentId: text("agent_id").notNull(),
+    status: text("status").notNull().default("active"),
+    objective: text("objective").notNull(),
+    scopeJson: text("scope_json").notNull(),
+    autonomyLevel: text("autonomy_level").notNull(),
+    tripwiresJson: text("tripwires_json").notNull().default("[]"),
+    ownerUserId: text("owner_user_id").notNull(),
+    requestedBy: text("requested_by").notNull(),
+    slaJson: text("sla_json"),
+    stateJson: text("state_json").notNull().default("{}"),
+    metadataJson: text("metadata_json").notNull().default("{}"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+    expiresAt: text("expires_at").notNull(),
+  },
+  (t) => [
+    index("idx_life_delegation_agent_status_expires").on(
+      t.agentId,
+      t.status,
+      t.expiresAt,
+    ),
+  ],
+);
+
 // Finance tables (life_payment_*, life_subscription_*) moved to
 // @elizaos/plugin-finances under pgSchema("app_finances"). PA no longer creates
 // them in app_lifeops; the finances plugin owns + migrates them. PA's raw
@@ -1633,6 +1661,7 @@ export const lifeOpsSchema = {
   lifeReminderAttempts,
   lifeAuditEvents,
   lifeCommitmentLedger,
+  lifeDelegationContracts,
   lifeEmailUnsubscribes,
   lifeActivitySignals,
   lifeHealthMetricSamples,

--- a/plugins/plugin-personal-assistant/test/delegation-contracts.test.ts
+++ b/plugins/plugin-personal-assistant/test/delegation-contracts.test.ts
@@ -6,11 +6,18 @@
  * connector events.
  */
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
+  createLifeOpsDelegationContractRecord,
   type DelegationContract,
   evaluateDelegationContract,
+  renderDelegationContractsProviderText,
 } from "../src/lifeops/delegation-contracts/index.js";
+import { LifeOpsRepository } from "../src/lifeops/index.js";
+import {
+  createLifeOpsTestRuntime,
+  type RealTestRuntimeResult,
+} from "./helpers/runtime.ts";
 
 function vendorContract(
   overrides: Partial<DelegationContract> = {},
@@ -193,5 +200,69 @@ describe("delegation contract evaluator", () => {
     expect(suppressed.audit.reason).toBe(
       "owner replied before the holding-reply SLA elapsed",
     );
+  });
+});
+
+describe("delegation contract repository", () => {
+  let runtimeResult: RealTestRuntimeResult | null = null;
+
+  afterEach(async () => {
+    await runtimeResult?.cleanup();
+    runtimeResult = null;
+  });
+
+  it("persists active thread contracts and their evaluator state", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    await LifeOpsRepository.bootstrapSchema(runtime);
+    const repo = new LifeOpsRepository(runtime);
+    const record = createLifeOpsDelegationContractRecord({
+      ...vendorContract(),
+      agentId: runtime.agentId,
+      metadata: { sourceThread: "gmail:thread-vendor-1" },
+    });
+
+    await repo.upsertDelegationContract(record);
+
+    const rows = await repo.listDelegationContracts(runtime.agentId, {
+      statuses: ["active"],
+      activeAtIso: "2026-07-06T16:30:00.000Z",
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      contractId: "delegation:vendor-thread",
+      status: "active",
+      autonomyLevel: "approval_gated",
+      metadata: { sourceThread: "gmail:thread-vendor-1" },
+    });
+    expect(renderDelegationContractsProviderText(rows)).toContain(
+      "Handle the vendor renewal thread",
+    );
+
+    const evaluated = evaluateDelegationContract({
+      contract: rows[0],
+      nowIso: "2026-07-06T16:45:00.000Z",
+      turn: {
+        channel: "email",
+        threadId: "thread-vendor-1",
+        sender: "Riley Vendor",
+        senderEmail: "riley@vendor.example",
+        subject: "Renewal",
+        text: "The price is too high; we need a discount.",
+        receivedAt: "2026-07-06T16:42:00.000Z",
+      },
+    });
+
+    await repo.upsertDelegationContract({
+      ...rows[0],
+      state: evaluated.contract.state,
+      updatedAt: "2026-07-06T16:45:00.000Z",
+    });
+
+    const reloaded = await repo.getDelegationContract(
+      runtime.agentId,
+      "delegation:vendor-thread",
+    );
+    expect(reloaded?.state?.escalatedAt).toBe("2026-07-06T16:42:00.000Z");
   });
 });


### PR DESCRIPTION
## Summary

Refs #14856.

This PR adds the durable storage layer for LifeOps delegation contracts so the pure evaluator from #15111 can be backed by real `app_lifeops` rows:

- adds `app_lifeops.life_delegation_contracts` to the PA schema;
- adds a persisted `LifeOpsDelegationContractRecord` shape plus a compact active-contract renderer for planner/provider context;
- adds `LifeOpsRepository` upsert/get/list methods for active delegation contracts;
- extends the delegation-contract test with a PGlite-backed persistence path that stores a thread contract, lists it for the active window, evaluates a price-pushback tripwire, persists evaluator state, and reloads the escalation timestamp.

## Evidence

Validation run locally on 2026-07-09 from `/tmp/eliza-14856-delegation-persistence`:

```bash
node packages/shared/scripts/generate-keywords.mjs --target ts
bun run --cwd plugins/plugin-personal-assistant test -- test/delegation-contracts.test.ts
# 1 file passed, 4 tests passed

bun x biome check \
  plugins/plugin-personal-assistant/src/lifeops/schema.ts \
  plugins/plugin-personal-assistant/src/lifeops/repository.ts \
  plugins/plugin-personal-assistant/src/lifeops/delegation-contracts/index.ts \
  plugins/plugin-personal-assistant/test/delegation-contracts.test.ts
# checked 4 files, no fixes applied

bun run --cwd plugins/plugin-personal-assistant build
# build:js and build:types passed

git diff --check
bun run audit:error-policy-ratchet
# no new fallback-slop
```

## Remaining for #14856

This PR still does not claim the full issue acceptance bar. Remaining work for the card:

- live connector inbound event wiring into these rows;
- approval-queue draft creation from live delegated turns;
- delegation-map artifacts from a running agent;
- live model trajectories and hand-reviewed domain artifacts posted inline.

## PR Evidence Rows

<!-- evidence-row:before-screenshots -->
- N/A - backend/schema/repository-only LifeOps persistence change; no rendered UI surface changed.

<!-- evidence-row:after-screenshots -->
- N/A - backend/schema/repository-only LifeOps persistence change; no rendered UI surface changed.

<!-- evidence-row:walkthrough-video -->
- N/A - no user-facing UI flow changed in this slice.

<!-- evidence-row:backend-logs -->
- N/A - deterministic local repository test only; command output is summarized in the Evidence section and no external backend log artifact was generated.

<!-- evidence-row:frontend-logs -->
- N/A - no frontend code path changed.

<!-- evidence-row:llm-trajectory -->
- N/A - this PR adds deterministic persistence for delegation contracts; live model delegation trajectories remain required for #14856 after connector wiring.

<!-- evidence-row:domain-artifacts -->
- N/A - domain artifact is the PGlite row round trip asserted in `test/delegation-contracts.test.ts`; no external artifact file was generated for this persistence-only slice.