### PR TITLE
fix(cloud): harden backup verifier infra failures

### DIFF
--- a/packages/cloud/shared/src/lib/services/agent-backup-verifier.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-verifier.test.ts
@@ -40,6 +40,7 @@ import {
 import { organizations } from "../../db/schemas/organizations";
 import { userCharacters } from "../../db/schemas/user-characters";
 import { users } from "../../db/schemas/users";
+import { type RuntimeR2Bucket, setRuntimeR2Bucket } from "../storage/r2-runtime-binding";
 import { computeStateHash, diffBackupState } from "./agent-backup-diff";
 import {
   type BackupVerifierConfig,
@@ -226,11 +227,13 @@ beforeAll(async () => {
 
 beforeEach(async () => {
   expect(pgliteReady).toBe(true);
+  setRuntimeR2Bucket(null);
   await dbWrite.delete(agentSandboxBackups);
   await dbWrite.delete(agentSandboxes);
 });
 
 afterAll(async () => {
+  setRuntimeR2Bucket(null);
   await closeDatabaseConnectionsForTests();
 });
 
@@ -272,6 +275,15 @@ describe("classifyCryptoError", () => {
   test("KeyNotFoundError → key-unavailable (the #15310 signature)", () => {
     const error = new Error("key not found: org:abc/dek v1");
     error.name = "KeyNotFoundError";
+    expect(classifyCryptoError(error)?.kind).toBe("key-unavailable");
+  });
+
+  test("steward KMS 404 → key-unavailable", () => {
+    const error = new Error("steward KMS returned 404 for org key");
+    error.name = "KmsError";
+    (error as { $metadata?: { httpStatusCode: number } }).$metadata = {
+      httpStatusCode: 404,
+    };
     expect(classifyCryptoError(error)?.kind).toBe("key-unavailable");
   });
 
@@ -372,16 +384,11 @@ describe("runBackupVerificationCycle (real PGlite + real memory KMS)", () => {
     expect(row.verification_status).toBe("failed");
     expect(row.verification_error).toStartWith("decrypt-failed:");
     expect(row.verification_error).toContain("AEAD decrypt failed");
-    // 1/1 failed ≥ 50% threshold → both the failure alert and the systemic
-    // escalation fire, on distinct dedup keys.
-    expect(summary.escalated).toBe(true);
-    expect(alerts.map((a) => a.dedupKey)).toEqual([
-      "agent-backup-verification-failure",
-      "agent-backup-verification-systemic",
-    ]);
+    expect(summary.escalated).toBe(false);
+    expect(alerts.map((a) => a.dedupKey)).toEqual(["agent-backup-verification-failure"]);
   });
 
-  test("wrong KMS key (fresh memory backend, #15310): key-unavailable + systemic escalation", async () => {
+  test("wrong KMS key (fresh memory backend, #15310): key-unavailable below escalation floor", async () => {
     expect(pgliteReady).toBe(true);
     const sandboxA = await seedSandbox();
     const sandboxB = await seedSandbox();
@@ -402,11 +409,111 @@ describe("runBackupVerificationCycle (real PGlite + real memory KMS)", () => {
       expect(row.verification_status).toBe("failed");
       expect(row.verification_error).toStartWith("key-unavailable:");
     }
-    expect(summary.escalated).toBe(true);
+    expect(summary.escalated).toBe(false);
+    expect(alerts.map((a) => a.dedupKey)).toEqual(["agent-backup-verification-failure"]);
+  });
+
+  test("systemic escalation waits for a minimum sample floor", async () => {
+    expect(pgliteReady).toBe(true);
+    const backupIds: string[] = [];
+    for (let i = 0; i < 5; i += 1) {
+      const sandboxId = await seedSandbox();
+      backupIds.push(await seedFullBackup(sandboxId, sampleState(`kms-floor-${i}`)));
+    }
+    resetKmsClientForTests();
+
+    const { alerts, alert } = makeAlertSpy();
+    const summary = await runBackupVerificationCycle({ config: CONFIG, alert });
+
+    expect(summary).toMatchObject({ sampled: 5, verified: 0, failed: 5, escalated: true });
+    expect(summary.failures.map((f) => f.kind)).toEqual([
+      "key-unavailable",
+      "key-unavailable",
+      "key-unavailable",
+      "key-unavailable",
+      "key-unavailable",
+    ]);
+    for (const backupId of backupIds) {
+      expect((await readBackupRow(backupId)).verification_error).toStartWith("key-unavailable:");
+    }
     const systemic = alerts.find((a) => a.dedupKey === "agent-backup-verification-systemic");
     expect(systemic).toBeDefined();
     expect(systemic?.message).toContain("KMS misconfiguration");
-    expect(systemic?.details.keyUnavailable).toBe(2);
+    expect(systemic?.details.keyUnavailable).toBe(5);
+  });
+
+  test("missing R2 payload thrown as NoSuchKey is stamped payload-missing and cannot wedge sampling", async () => {
+    expect(pgliteReady).toBe(true);
+    const sandboxId = await seedSandbox();
+    const missingKey = "agent-backups/missing/state_data.json";
+    const missingError = new Error("NoSuchKey: object does not exist");
+    missingError.name = "NoSuchKey";
+    setRuntimeR2Bucket({
+      async get() {
+        throw missingError;
+      },
+      async put() {},
+      async delete() {},
+    } satisfies RuntimeR2Bucket);
+    const [backup] = await dbWrite
+      .insert(agentSandboxBackups)
+      .values({
+        sandbox_record_id: sandboxId,
+        snapshot_type: "auto",
+        state_data: sampleState("r2-preview"),
+        state_data_storage: "r2",
+        state_data_key: missingKey,
+        size_bytes: 1024,
+        backup_kind: "full",
+        content_hash: computeStateHash(sampleState("r2-preview")),
+      })
+      .returning();
+    expect(backup).toBeDefined();
+    const now = new Date("2026-07-09T00:00:00Z");
+    const { alerts, alert } = makeAlertSpy();
+
+    const summary = await runBackupVerificationCycle({ config: CONFIG, alert, now: () => now });
+
+    expect(summary).toMatchObject({ sampled: 1, verified: 0, failed: 1, errored: 0 });
+    expect(summary.failures[0]).toMatchObject({
+      backupId: backup.id,
+      kind: "payload-missing",
+    });
+    const row = await readBackupRow(backup.id);
+    expect(row.verification_status).toBe("failed");
+    expect(row.verified_at?.getTime()).toBe(now.getTime());
+    expect(row.verification_error).toStartWith("payload-missing:");
+    expect(alerts.map((a) => a.dedupKey)).toEqual(["agent-backup-verification-failure"]);
+  });
+
+  test("verifier infrastructure errors stamp verified_at and alert without marking backup failed", async () => {
+    expect(pgliteReady).toBe(true);
+    const sandboxId = await seedSandbox();
+    const [backup] = await dbWrite
+      .insert(agentSandboxBackups)
+      .values({
+        sandbox_record_id: sandboxId,
+        snapshot_type: "auto",
+        state_data: sampleState("r2-preview"),
+        state_data_storage: "r2",
+        state_data_key: "agent-backups/configured-nowhere/state_data.json",
+        size_bytes: 1024,
+        backup_kind: "full",
+        content_hash: computeStateHash(sampleState("r2-preview")),
+      })
+      .returning();
+    expect(backup).toBeDefined();
+    const now = new Date("2026-07-09T01:00:00Z");
+    const { alerts, alert } = makeAlertSpy();
+
+    const summary = await runBackupVerificationCycle({ config: CONFIG, alert, now: () => now });
+
+    expect(summary).toMatchObject({ sampled: 1, verified: 0, failed: 0, errored: 1 });
+    const row = await readBackupRow(backup.id);
+    expect(row.verification_status).toBeNull();
+    expect(row.verified_at?.getTime()).toBe(now.getTime());
+    expect(row.verification_error).toStartWith("infra-error:");
+    expect(alerts.map((a) => a.dedupKey)).toEqual(["agent-backup-verification-error"]);
   });
 
   test("content_hash drift on an otherwise-decryptable backup is stamped hash-mismatch", async () => {

--- a/packages/cloud/shared/src/lib/services/agent-backup-verifier.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-verifier.ts
@@ -89,6 +89,7 @@ export interface BackupVerifierConfig {
 const DEFAULT_BATCH_SIZE = 10;
 const DEFAULT_REVERIFY_HOURS = 24;
 const DEFAULT_ESCALATION_PCT = 50;
+const MIN_SYSTEMIC_ESCALATION_SAMPLE = 5;
 
 function parsePositiveInt(value: string | undefined, fallback: number): number {
   if (!value) return fallback;
@@ -164,8 +165,31 @@ export function classifyCryptoError(error: unknown): BackupVerificationFailure |
   if (error.name === "KeyNotFoundError" || /key not found/i.test(error.message)) {
     return { kind: "key-unavailable", message: error.message };
   }
+  const maybeStatus = (error as { status?: unknown; $metadata?: { httpStatusCode?: unknown } })
+    .$metadata?.httpStatusCode;
+  if (
+    error.name === "KmsError" &&
+    (maybeStatus === 404 || /\b404\b|not found/i.test(error.message))
+  ) {
+    return { kind: "key-unavailable", message: error.message };
+  }
   if (error.name === "AeadError" || /AEAD decrypt failed/i.test(error.message)) {
     return { kind: "decrypt-failed", message: error.message };
+  }
+  return null;
+}
+
+function classifyMissingObjectPayload(error: unknown): BackupVerificationFailure | null {
+  if (!(error instanceof Error)) return null;
+  const maybeStatus = (error as { $metadata?: { httpStatusCode?: unknown }; status?: unknown })
+    .$metadata?.httpStatusCode;
+  if (
+    error.name === "NoSuchKey" ||
+    error.name === "NotFound" ||
+    maybeStatus === 404 ||
+    /no such key|not found/i.test(error.message)
+  ) {
+    return { kind: "payload-missing", message: error.message };
   }
   return null;
 }
@@ -174,6 +198,8 @@ export function classifyCryptoError(error: unknown): BackupVerificationFailure |
 function classifyChainError(error: unknown): BackupVerificationFailure | null {
   const crypto = classifyCryptoError(error);
   if (crypto) return crypto;
+  const missingPayload = classifyMissingObjectPayload(error);
+  if (missingPayload) return missingPayload;
   if (!(error instanceof Error)) return null;
   if (/payload not found|missing state_data_key/i.test(error.message)) {
     return { kind: "payload-missing", message: error.message };
@@ -370,7 +396,14 @@ async function resolveStoredPayload(
       "backup payload is in object storage but no object storage is configured on this host",
     );
   }
-  const raw = await getObjectText(row.state_data_key);
+  let raw: string | null;
+  try {
+    raw = await getObjectText(row.state_data_key);
+  } catch (error) {
+    const missingPayload = classifyMissingObjectPayload(error);
+    if (missingPayload) return { failure: missingPayload };
+    throw error;
+  }
   if (raw === null) {
     return {
       failure: {
@@ -505,6 +538,7 @@ export interface BackupVerificationCycleSummary {
 }
 
 const FAILURE_ALERT_DEDUP_KEY = "agent-backup-verification-failure";
+const ERROR_ALERT_DEDUP_KEY = "agent-backup-verification-error";
 const SYSTEMIC_ALERT_DEDUP_KEY = "agent-backup-verification-systemic";
 
 /**
@@ -565,11 +599,20 @@ export async function runBackupVerificationCycle(
       // breakage (DB/object-storage unreachable) is logged loudly but must not
       // stamp a healthy backup as failed nor abort the rest of the batch.
       summary.errored += 1;
-      logger.error("[AgentBackupVerifier] verification errored (infrastructure, not stamped)", {
+      logger.error("[AgentBackupVerifier] verification errored (infrastructure)", {
         backupId: row.id,
         sandboxRecordId: row.sandbox_record_id,
         error: error instanceof Error ? error.message : String(error),
       });
+      await dbWrite
+        .update(agentSandboxBackups)
+        .set({
+          verified_at: now,
+          verification_error: `infra-error: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        })
+        .where(eq(agentSandboxBackups.id, row.id));
       continue;
     }
 
@@ -624,7 +667,10 @@ export async function runBackupVerificationCycle(
     });
 
     const failurePct = (summary.failed / summary.sampled) * 100;
-    if (failurePct >= config.escalationThresholdPct) {
+    if (
+      summary.sampled >= MIN_SYSTEMIC_ESCALATION_SAMPLE &&
+      failurePct >= config.escalationThresholdPct
+    ) {
       summary.escalated = true;
       const keyUnavailable = summary.failures.filter((f) => f.kind === "key-unavailable").length;
       await alert({
@@ -645,6 +691,21 @@ export async function runBackupVerificationCycle(
         dedupKey: SYSTEMIC_ALERT_DEDUP_KEY,
       });
     }
+  }
+
+  if (summary.errored > 0) {
+    await alert({
+      title: `${summary.errored}/${summary.sampled} sampled agent backups could not be verified`,
+      message:
+        "Backup verification hit infrastructure errors. Rows were stamped with " +
+        "verified_at so they do not permanently wedge the sampler head; inspect " +
+        "verification_error for the exact infra failure and fix the verifier host.",
+      details: {
+        sampled: summary.sampled,
+        errored: summary.errored,
+      },
+      dedupKey: ERROR_ALERT_DEDUP_KEY,
+    });
   }
 
   return summary;


### PR DESCRIPTION
## Summary
- classify missing object-storage payload errors such as S3/R2 NoSuchKey as payload-missing instead of infrastructure errors
- classify steward KMS 404s as key-unavailable
- stamp verifier infrastructure errors with verified_at and an infra-error message so nulls-first sampling cannot wedge permanently
- add an infra-error alert and require a minimum sample floor before systemic escalation

Refs #15626. This PR covers the missing-payload, KMS 404, infra-stamping, and systemic-floor portions. The chain reconstruction concurrency cap and sampler index remain separate follow-up work on the issue.

## Verification
- bunx @biomejs/biome check packages/cloud/shared/src/lib/services/agent-backup-verifier.ts packages/cloud/shared/src/lib/services/agent-backup-verifier.test.ts --no-errors-on-unmatched
- bun test packages/cloud/shared/src/lib/services/agent-backup-verifier.test.ts (21 pass / 0 fail)

## Notes
- The first direct PTY test run passed the test assertions but Bun hit an internal WriteFailed while dumping the large coverage table. Rerunning with output redirected exited 0.