### PR TITLE
feat(transcripts): add permissioning share sheet

### DIFF
--- a/packages/docs/ongoing-development/mvp/transcript-permissioning-ux.md
+++ b/packages/docs/ongoing-development/mvp/transcript-permissioning-ux.md
@@ -1,0 +1,51 @@
+# Transcript Permissioning UX
+
+Issue: [#14782](https://github.com/elizaOS/eliza/issues/14782)
+
+## Journey
+
+The transcript journey is one artifact with role-shaped disclosure:
+
+1. A voice or meeting capture creates an owner-private transcript row.
+2. The chat attachment opens the transcript overlay and shows a visible privacy
+   badge: `Private`, `Redacted`, or `Global`.
+3. `Share` opens an in-app access sheet, not the platform share sheet. The sheet
+   defaults to `Redacted`; `Full` is visible only to admin-tier callers.
+4. A redacted grant creates or refreshes the linked redacted variant, then writes
+   the recipient grant on the original row. The recipient still addresses the
+   original transcript id, but the server serves the redacted variant with audio
+   withheld.
+5. `Revoke` removes the selected recipient grant from the original row. It does
+   not delete copies already exported outside elizaOS, and it does not delete the
+   redacted variant row.
+6. A redacted viewer cannot re-share, edit, delete, or revoke access. The
+   server enforces this even if a client sends the request, and the overlay
+   renders the redacted view as read-only.
+
+## Simplification Inventory
+
+Current transcript affordances and their intended ownership:
+
+| Affordance | Owner | Decision |
+| --- | --- | --- |
+| Inline audio playback | Transcript overlay | Keep; recording-specific download/share stays beside the player. |
+| Copy transcript text | Transcript overlay | Keep as a local clipboard operation with explicit failure state. |
+| Download transcript markdown | Transcript overlay | Keep as local export; it is outside grant revocation once saved. |
+| Share transcript text via Web Share | None | Retire as the primary `Share`; transcript sharing now means elizaOS access grants. |
+| Share recording via Web Share | Audio player controls | Keep; it exports source audio and is separate from transcript access grants. |
+| Edit transcript text | Transcript overlay | Keep for full/private records; hide in redacted views and reject redacted-view route calls. |
+| Delete transcript | Transcript overlay | Keep as destructive owner/admin record management; hide in redacted views and reject redacted-view route calls. |
+| `TRANSCRIPT_MARKER` id round-trip | Chat attachment fallback | Temporary compatibility only; retire when chat attachments always carry the Files-surface artifact id. |
+| Share sheet recipient picker | Transcript overlay | First slice accepts an entity id; the target design is a roster/contact picker sourced from room membership plus connector contacts. |
+| Share/revoke backend | Transcript routes | Added as transcript routes so the UI calls the same artifact-disclosure store used by actions. |
+
+## States To Verify
+
+- Loading: spinner, no empty transcript claim.
+- Empty: only when a loaded transcript has no text.
+- Error: failed record/inline load renders a visible error.
+- Private full view: `Private` badge, Share enabled, redacted mode default.
+- Redacted view: `Redacted` badge, audio absent, Share disabled, edit/delete hidden, route rejects re-share/edit/delete.
+- Admin full-share path: `Full` option visible under `RoleGate`, route rejects full share below ADMIN.
+- Revoke path: grant removed, recipient GET becomes 404.
+- Mobile keyboard: recipient field remains inside the scrollable overlay body; footer stays reachable after scrolling.

--- a/packages/ui/src/api/client-transcripts.ts
+++ b/packages/ui/src/api/client-transcripts.ts
@@ -1,10 +1,11 @@
 /**
- * Transcript API client methods (#8789) — list / get / create / delete over
- * `/api/transcripts`. Declaration-merged onto `ElizaClient` (the side-effect
- * import in `client.ts` installs the prototype methods), matching the other
- * `client-*` domain modules.
+ * Transcript API client methods (#8789) — list / get / create / update /
+ * delete plus permission grants over `/api/transcripts`. Declaration-merged
+ * onto `ElizaClient` (the side-effect import in `client.ts` installs the
+ * prototype methods), matching the other `client-*` domain modules.
  */
 
+import type { ArtifactShareGrantMode } from "@elizaos/core";
 import type {
   Transcript,
   TranscriptScope,
@@ -39,6 +40,25 @@ export interface TranscriptUpdateInput {
   segments?: TranscriptSegment[];
 }
 
+export interface TranscriptShareInput {
+  entityId: string;
+  mode: ArtifactShareGrantMode;
+}
+
+export interface TranscriptShareResult {
+  ok: boolean;
+  transcriptId: string;
+  entityId: string;
+  mode: ArtifactShareGrantMode;
+  variantId?: string;
+}
+
+export interface TranscriptRevokeShareResult {
+  ok: boolean;
+  transcriptId: string;
+  entityId: string;
+}
+
 declare module "./client-base" {
   interface ElizaClient {
     listTranscripts(
@@ -53,6 +73,14 @@ declare module "./client-base" {
       input: TranscriptUpdateInput,
     ): Promise<{ transcript: Transcript }>;
     deleteTranscript(id: string): Promise<{ ok: boolean }>;
+    shareTranscript(
+      id: string,
+      input: TranscriptShareInput,
+    ): Promise<TranscriptShareResult>;
+    revokeTranscriptShare(
+      id: string,
+      entityId: string,
+    ): Promise<TranscriptRevokeShareResult>;
   }
 }
 
@@ -99,4 +127,28 @@ ElizaClient.prototype.deleteTranscript = async function (
   return this.fetch(`/api/transcripts/${encodeURIComponent(id)}`, {
     method: "DELETE",
   });
+};
+
+ElizaClient.prototype.shareTranscript = async function (
+  this: ElizaClient,
+  id: string,
+  input: TranscriptShareInput,
+) {
+  return this.fetch(`/api/transcripts/${encodeURIComponent(id)}/share`, {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+};
+
+ElizaClient.prototype.revokeTranscriptShare = async function (
+  this: ElizaClient,
+  id: string,
+  entityId: string,
+) {
+  return this.fetch(
+    `/api/transcripts/${encodeURIComponent(id)}/share/${encodeURIComponent(
+      entityId,
+    )}`,
+    { method: "DELETE" },
+  );
 };

--- a/packages/ui/src/components/chat/TranscriptViewerOverlay.test.tsx
+++ b/packages/ui/src/components/chat/TranscriptViewerOverlay.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 //
 // The maximized, editable transcript viewer: it loads the stored record, lets
-// the user edit + undo, copies, prepares share requests, and persists on save.
+// the user edit + undo, copies, grants/revokes access, and persists on save.
 
 import {
   cleanup,
@@ -13,15 +13,27 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { MessageAttachment } from "../../api/client-types-chat";
 
-const { getTranscript, updateTranscript, deleteTranscript } = vi.hoisted(
-  () => ({
-    getTranscript: vi.fn(),
-    updateTranscript: vi.fn(),
-    deleteTranscript: vi.fn(),
-  }),
-);
+const {
+  getTranscript,
+  updateTranscript,
+  deleteTranscript,
+  shareTranscript,
+  revokeTranscriptShare,
+} = vi.hoisted(() => ({
+  getTranscript: vi.fn(),
+  updateTranscript: vi.fn(),
+  deleteTranscript: vi.fn(),
+  shareTranscript: vi.fn(),
+  revokeTranscriptShare: vi.fn(),
+}));
 vi.mock("../../api", () => ({
-  client: { getTranscript, updateTranscript, deleteTranscript },
+  client: {
+    getTranscript,
+    updateTranscript,
+    deleteTranscript,
+    shareTranscript,
+    revokeTranscriptShare,
+  },
 }));
 const { navigateBrowserPath } = vi.hoisted(() => ({
   navigateBrowserPath: vi.fn(),
@@ -82,6 +94,8 @@ describe("TranscriptViewerOverlay", () => {
     getTranscript.mockReset();
     updateTranscript.mockReset();
     deleteTranscript.mockReset();
+    shareTranscript.mockReset();
+    revokeTranscriptShare.mockReset();
     navigateBrowserPath.mockReset();
     getTranscript.mockResolvedValue({
       transcript: {
@@ -93,6 +107,17 @@ describe("TranscriptViewerOverlay", () => {
     });
     updateTranscript.mockResolvedValue({ transcript: {} });
     deleteTranscript.mockResolvedValue({ ok: true });
+    shareTranscript.mockResolvedValue({
+      ok: true,
+      transcriptId: "00000000-0000-0000-0000-000000000abc",
+      entityId: "99999999-9999-9999-9999-999999999999",
+      mode: "redacted",
+    });
+    revokeTranscriptShare.mockResolvedValue({
+      ok: true,
+      transcriptId: "00000000-0000-0000-0000-000000000abc",
+      entityId: "99999999-9999-9999-9999-999999999999",
+    });
     Object.assign(navigator, {
       clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
     });
@@ -193,66 +218,72 @@ describe("TranscriptViewerOverlay", () => {
     );
   });
 
-  it("opens a redacted-by-default share panel and prepares a grant request", async () => {
-    const writeText = vi.fn().mockResolvedValue(undefined);
-    Object.assign(navigator, {
-      clipboard: { writeText },
-      share: undefined,
-    });
+  it("opens the permission sheet and grants redacted transcript access", async () => {
+    const userRole = { role: "USER" as const };
     render(
-      <TranscriptViewerOverlay
-        attachment={transcriptAttachment()}
-        onClose={() => {}}
-      />,
+      <RoleProvider {...userRole}>
+        <TranscriptViewerOverlay
+          attachment={transcriptAttachment()}
+          onClose={() => {}}
+        />
+      </RoleProvider>,
     );
     await waitFor(() => screen.getByTestId("transcript-text"));
     fireEvent.click(screen.getByTestId("transcript-share"));
-    expect(screen.getByTestId("transcript-share-panel")).toBeTruthy();
+    expect(screen.getByTestId("transcript-share-sheet")).toBeTruthy();
     expect(
       screen.getByTestId("transcript-share-mode-full-disabled"),
     ).toBeTruthy();
 
     fireEvent.change(screen.getByTestId("transcript-share-target"), {
-      target: { value: "viewer-entity" },
+      target: { value: "99999999-9999-9999-9999-999999999999" },
     });
-    fireEvent.click(screen.getByTestId("transcript-share-prepare"));
+    fireEvent.click(screen.getByTestId("transcript-grant-share"));
     await waitFor(() =>
-      expect(writeText).toHaveBeenCalledWith(
-        "Share transcriptId=00000000-0000-0000-0000-000000000abc with entityId=viewer-entity mode=redacted.",
+      expect(shareTranscript).toHaveBeenCalledWith(
+        "00000000-0000-0000-0000-000000000abc",
+        {
+          entityId: "99999999-9999-9999-9999-999999999999",
+          mode: "redacted",
+        },
       ),
     );
-    expect(screen.getByTestId("transcript-share-notice").textContent).toContain(
-      "Request copied",
+    expect(screen.getByTestId("transcript-share-success").textContent).toMatch(
+      /redacted/i,
     );
   });
 
-  it("surfaces the prepared share request when clipboard and native share are unavailable", async () => {
-    Object.assign(navigator, { clipboard: undefined, share: undefined });
+  it("surfaces route failures without claiming access changed", async () => {
+    shareTranscript.mockRejectedValueOnce(new Error("denied"));
+    const userRole = { role: "USER" as const };
     render(
-      <TranscriptViewerOverlay
-        attachment={transcriptAttachment()}
-        onClose={() => {}}
-      />,
+      <RoleProvider {...userRole}>
+        <TranscriptViewerOverlay
+          attachment={transcriptAttachment()}
+          onClose={() => {}}
+        />
+      </RoleProvider>,
     );
     await waitFor(() => screen.getByTestId("transcript-text"));
     fireEvent.click(screen.getByTestId("transcript-share"));
     fireEvent.change(screen.getByTestId("transcript-share-target"), {
-      target: { value: "viewer-entity" },
+      target: { value: "99999999-9999-9999-9999-999999999999" },
     });
-    fireEvent.click(screen.getByTestId("transcript-share-prepare"));
+    fireEvent.click(screen.getByTestId("transcript-grant-share"));
     await waitFor(() =>
       expect(
-        screen.getByTestId("transcript-share-notice").textContent,
-      ).toContain("Share transcriptId=00000000-0000-0000-0000-000000000abc"),
+        screen.getByTestId("transcript-share-error").textContent,
+      ).toContain("denied"),
     );
-    expect(screen.getByTestId("transcript-copy").textContent).toContain("Copy");
+    expect(screen.queryByTestId("transcript-share-success")).toBeNull();
   });
 
-  it("lets admins prepare a full transcript grant", async () => {
-    const writeText = vi.fn().mockResolvedValue(undefined);
-    Object.assign(navigator, {
-      clipboard: { writeText },
-      share: undefined,
+  it("lets admins grant full transcript access", async () => {
+    shareTranscript.mockResolvedValueOnce({
+      ok: true,
+      transcriptId: "00000000-0000-0000-0000-000000000abc",
+      entityId: "99999999-9999-9999-9999-999999999999",
+      mode: "full",
     });
     const adminRole = { role: "ADMIN" as const };
     render(
@@ -267,28 +298,44 @@ describe("TranscriptViewerOverlay", () => {
     fireEvent.click(screen.getByTestId("transcript-share"));
     fireEvent.click(screen.getByTestId("transcript-share-mode-full"));
     fireEvent.change(screen.getByTestId("transcript-share-target"), {
-      target: { value: "viewer-entity" },
+      target: { value: "99999999-9999-9999-9999-999999999999" },
     });
-    fireEvent.click(screen.getByTestId("transcript-share-prepare"));
+    fireEvent.click(screen.getByTestId("transcript-grant-share"));
     await waitFor(() =>
-      expect(writeText).toHaveBeenCalledWith(
-        "Share transcriptId=00000000-0000-0000-0000-000000000abc with entityId=viewer-entity mode=full.",
+      expect(shareTranscript).toHaveBeenCalledWith(
+        "00000000-0000-0000-0000-000000000abc",
+        {
+          entityId: "99999999-9999-9999-9999-999999999999",
+          mode: "full",
+        },
       ),
     );
   });
 
-  it("shows the revoke caveat in the share panel", async () => {
+  it("revokes transcript access for the entered recipient", async () => {
+    const userRole = { role: "USER" as const };
     render(
-      <TranscriptViewerOverlay
-        attachment={transcriptAttachment()}
-        onClose={() => {}}
-      />,
+      <RoleProvider {...userRole}>
+        <TranscriptViewerOverlay
+          attachment={transcriptAttachment()}
+          onClose={() => {}}
+        />
+      </RoleProvider>,
     );
     await waitFor(() => screen.getByTestId("transcript-text"));
     fireEvent.click(screen.getByTestId("transcript-share"));
-    fireEvent.click(screen.getByTestId("transcript-share-kind-revoke"));
-    expect(screen.getByTestId("transcript-share-panel").textContent).toContain(
-      "People who already opened it may have kept a copy",
+    fireEvent.change(screen.getByTestId("transcript-share-target"), {
+      target: { value: "99999999-9999-9999-9999-999999999999" },
+    });
+    fireEvent.click(screen.getByTestId("transcript-revoke-share"));
+    await waitFor(() =>
+      expect(revokeTranscriptShare).toHaveBeenCalledWith(
+        "00000000-0000-0000-0000-000000000abc",
+        "99999999-9999-9999-9999-999999999999",
+      ),
+    );
+    expect(screen.getByTestId("transcript-share-success").textContent).toMatch(
+      /revoked/i,
     );
   });
 

--- a/packages/ui/src/components/chat/TranscriptViewerOverlay.tsx
+++ b/packages/ui/src/components/chat/TranscriptViewerOverlay.tsx
@@ -17,13 +17,14 @@ import {
   Download,
   FileAudio,
   Headphones,
+  Loader2,
   LockKeyhole,
   Pencil,
   Share2,
   ShieldCheck,
   Trash2,
   Undo2,
-  UserPlus,
+  UserRoundMinus,
   X,
 } from "lucide-react";
 import * as React from "react";
@@ -89,24 +90,16 @@ type LoadState =
  */
 type CopyStatus = "idle" | "copied" | "failed";
 type ShareMode = "redacted" | "full";
-type ShareRequestKind = "grant" | "revoke";
+type ShareStatus =
+  | { kind: "idle" }
+  | { kind: "submitting" }
+  | { kind: "success"; message: string; entityId: string }
+  | { kind: "error"; message: string };
 
 function copyButtonLabel(status: CopyStatus): string {
   if (status === "copied") return "Copied";
   if (status === "failed") return "Copy failed";
   return "Copy";
-}
-
-function shareRequestText(input: {
-  kind: ShareRequestKind;
-  transcriptId: string;
-  entityId: string;
-  mode: ShareMode;
-}): string {
-  if (input.kind === "revoke") {
-    return `Revoke transcript access for transcriptId=${input.transcriptId} entityId=${input.entityId}.`;
-  }
-  return `Share transcriptId=${input.transcriptId} with entityId=${input.entityId} mode=${input.mode}.`;
 }
 
 /**
@@ -210,8 +203,9 @@ export function TranscriptViewerOverlay({
   const [shareOpen, setShareOpen] = React.useState(false);
   const [shareMode, setShareMode] = React.useState<ShareMode>("redacted");
   const [shareTarget, setShareTarget] = React.useState("");
-  const [shareKind, setShareKind] = React.useState<ShareRequestKind>("grant");
-  const [shareNotice, setShareNotice] = React.useState<string | null>(null);
+  const [shareStatus, setShareStatus] = React.useState<ShareStatus>({
+    kind: "idle",
+  });
   const [saving, setSaving] = React.useState(false);
   const [copyStatus, setCopyStatus] = React.useState<CopyStatus>("idle");
   const [confirmDelete, setConfirmDelete] = React.useState(false);
@@ -314,45 +308,61 @@ export function TranscriptViewerOverlay({
     if (!isAdmin && shareMode === "full") setShareMode("redacted");
   }, [isAdmin, shareMode]);
 
-  const handlePrepareShareRequest = React.useCallback(async () => {
+  const handleGrantShare = React.useCallback(async () => {
     if (load.status !== "ready" || !load.transcriptId) return;
     const entityId = shareTarget.trim();
     if (!entityId) {
-      setShareNotice("Add a recipient entity ID.");
+      setShareStatus({ kind: "error", message: "Add a recipient entity ID." });
       return;
     }
-    const request = shareRequestText({
-      kind: shareKind,
-      transcriptId: load.transcriptId,
-      entityId,
-      mode: shareMode,
-    });
-    const nav = navigator as Navigator & {
-      share?: (data: { title?: string; text?: string }) => Promise<void>;
-    };
-    if (nav.share) {
-      try {
-        await nav.share({ title: "Transcript access request", text: request });
-        setShareNotice("Request shared. The agent still has to confirm it.");
-        return;
-      } catch (err) {
-        // error-policy:J4 user-cancelled share is not an error; anything else
-        // falls through to the copy path below.
-        if (err instanceof DOMException && err.name === "AbortError") return;
-      }
-    }
+    setShareStatus({ kind: "submitting" });
     try {
-      if (!navigator.clipboard?.writeText) {
-        throw new Error("Clipboard unavailable");
-      }
-      await navigator.clipboard.writeText(request);
-      setShareNotice("Request copied. Send it in chat to apply it.");
-    } catch {
-      // error-policy:J4 clipboard/share unavailable — render a visible request
-      // instead of pretending access changed.
-      setShareNotice(request);
+      const result = await client.shareTranscript(load.transcriptId, {
+        entityId,
+        mode: shareMode,
+      });
+      setShareStatus({
+        kind: "success",
+        entityId: result.entityId,
+        message:
+          result.mode === "full"
+            ? "Full transcript access granted."
+            : "Redacted transcript access granted.",
+      });
+    } catch (err) {
+      setShareStatus({
+        kind: "error",
+        message:
+          err instanceof Error ? err.message : "Couldn't share transcript.",
+      });
     }
-  }, [load, shareKind, shareMode, shareTarget]);
+  }, [load, shareMode, shareTarget]);
+
+  const handleRevokeShare = React.useCallback(async () => {
+    if (load.status !== "ready" || !load.transcriptId) return;
+    const entityId =
+      shareStatus.kind === "success"
+        ? shareStatus.entityId
+        : shareTarget.trim();
+    if (!entityId) {
+      setShareStatus({ kind: "error", message: "Add a recipient entity ID." });
+      return;
+    }
+    setShareStatus({ kind: "submitting" });
+    try {
+      await client.revokeTranscriptShare(load.transcriptId, entityId);
+      setShareStatus({
+        kind: "success",
+        entityId,
+        message: "Transcript access revoked for that recipient.",
+      });
+    } catch (err) {
+      setShareStatus({
+        kind: "error",
+        message: err instanceof Error ? err.message : "Couldn't revoke access.",
+      });
+    }
+  }, [load, shareStatus, shareTarget]);
 
   const handleSaveToFiles = React.useCallback(() => {
     const safe = title.replace(/[^\w.-]+/g, "_").slice(0, 80) || "transcript";
@@ -546,37 +556,13 @@ export function TranscriptViewerOverlay({
           {shareOpen ? (
             <div
               className="mt-4 rounded-sm border border-border bg-bg/45 p-3"
-              data-testid="transcript-share-panel"
+              data-testid="transcript-share-sheet"
             >
               <div className="flex flex-wrap items-center gap-2">
-                <UserPlus className="h-4 w-4 text-muted" aria-hidden />
+                <Share2 className="h-4 w-4 text-muted" aria-hidden />
                 <p className="min-w-0 flex-1 text-xs font-medium text-txt">
                   Share access
                 </p>
-                <Button
-                  variant={shareKind === "grant" ? "default" : "ghost"}
-                  size="sm"
-                  className="h-7 px-2 text-xs"
-                  onClick={() => {
-                    setShareKind("grant");
-                    setShareNotice(null);
-                  }}
-                  data-testid="transcript-share-kind-grant"
-                >
-                  Grant
-                </Button>
-                <Button
-                  variant={shareKind === "revoke" ? "default" : "ghost"}
-                  size="sm"
-                  className="h-7 px-2 text-xs"
-                  onClick={() => {
-                    setShareKind("revoke");
-                    setShareNotice(null);
-                  }}
-                  data-testid="transcript-share-kind-revoke"
-                >
-                  Revoke
-                </Button>
               </div>
               <div className="mt-3 grid gap-3 sm:grid-cols-[1fr_auto]">
                 <label
@@ -589,11 +575,12 @@ export function TranscriptViewerOverlay({
                     value={shareTarget}
                     onChange={(event) => {
                       setShareTarget(event.target.value);
-                      setShareNotice(null);
+                      setShareStatus({ kind: "idle" });
                     }}
                     placeholder="Entity ID"
                     density="compact"
                     data-testid="transcript-share-target"
+                    className="font-mono text-[11px]"
                   />
                 </label>
                 <div className="grid content-end gap-1">
@@ -607,7 +594,7 @@ export function TranscriptViewerOverlay({
                       className="h-8 rounded-sm px-3 text-xs"
                       onClick={() => {
                         setShareMode("redacted");
-                        setShareNotice(null);
+                        setShareStatus({ kind: "idle" });
                       }}
                       data-testid="transcript-share-mode-redacted"
                     >
@@ -633,7 +620,7 @@ export function TranscriptViewerOverlay({
                         className="h-8 rounded-sm px-3 text-xs"
                         onClick={() => {
                           setShareMode("full");
-                          setShareNotice(null);
+                          setShareStatus({ kind: "idle" });
                         }}
                         data-testid="transcript-share-mode-full"
                       >
@@ -647,36 +634,56 @@ export function TranscriptViewerOverlay({
                 <Button
                   variant="default"
                   size="sm"
-                  onClick={() => void handlePrepareShareRequest()}
+                  onClick={() => void handleGrantShare()}
                   disabled={
+                    shareStatus.kind === "submitting" ||
                     load.status !== "ready" ||
                     !load.transcriptId ||
                     !shareTarget.trim()
                   }
-                  data-testid="transcript-share-prepare"
+                  data-testid="transcript-grant-share"
                 >
-                  Prepare request
+                  {shareStatus.kind === "submitting" ? (
+                    <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+                  ) : (
+                    <Share2 className="mr-1.5 h-4 w-4" />
+                  )}
+                  Grant
                 </Button>
                 <Button
                   variant="ghost"
                   size="sm"
-                  onClick={() => setShareOpen(false)}
-                  data-testid="transcript-share-close"
+                  onClick={() => void handleRevokeShare()}
+                  disabled={
+                    shareStatus.kind === "submitting" ||
+                    load.status !== "ready" ||
+                    !load.transcriptId ||
+                    !shareTarget.trim()
+                  }
+                  data-testid="transcript-revoke-share"
                 >
-                  Close
+                  <UserRoundMinus className="mr-1.5 h-4 w-4" />
+                  Revoke
                 </Button>
                 <p className="min-w-[12rem] flex-1 text-xs text-muted">
-                  {shareKind === "revoke"
-                    ? "People who already opened it may have kept a copy. Delete-for-everyone removes the file for all."
-                    : "Room roster and connector contacts are unavailable here; use an entity ID."}
+                  Room roster and connector contacts are unavailable here; use
+                  an entity ID. People who already opened it may have kept a
+                  copy.
                 </p>
               </div>
-              {shareNotice ? (
+              {shareStatus.kind === "error" ? (
                 <p
-                  className="mt-2 break-words text-xs text-muted"
-                  data-testid="transcript-share-notice"
+                  className="mt-2 break-words text-xs text-danger"
+                  data-testid="transcript-share-error"
                 >
-                  {shareNotice}
+                  {shareStatus.message}
+                </p>
+              ) : shareStatus.kind === "success" ? (
+                <p
+                  className="mt-2 break-words text-xs text-status-success"
+                  data-testid="transcript-share-success"
+                >
+                  {shareStatus.message}
                 </p>
               ) : null}
             </div>
@@ -732,7 +739,7 @@ export function TranscriptViewerOverlay({
             size="sm"
             onClick={() => {
               setShareOpen((open) => !open);
-              setShareNotice(null);
+              setShareStatus({ kind: "idle" });
             }}
             data-testid="transcript-share"
           >

--- a/plugins/plugin-local-inference/src/routes/transcripts-routes.test.ts
+++ b/plugins/plugin-local-inference/src/routes/transcripts-routes.test.ts
@@ -22,6 +22,7 @@ const WORLD = "00000000-0000-0000-0000-0000000000ww" as UUID;
 const ROOM = "11111111-1111-1111-1111-111111111111" as UUID;
 const ENTITY = "22222222-2222-2222-2222-222222222222" as UUID;
 const OTHER_ENTITY = "33333333-3333-3333-3333-333333333333" as UUID;
+const THIRD_ENTITY = "44444444-4444-4444-4444-444444444444" as UUID;
 
 const segments: TranscriptSegment[] = [
 	{
@@ -95,6 +96,12 @@ const adminAccess = (requesterEntityId: UUID): AccessContext => ({
 	requesterEntityId,
 	worldId: WORLD,
 	role: "ADMIN",
+});
+
+const ownerAccess = (requesterEntityId: UUID): AccessContext => ({
+	requesterEntityId,
+	worldId: WORLD,
+	role: "OWNER",
 });
 
 describe("buildTranscriptFromRequest", () => {
@@ -557,5 +564,167 @@ describe("transcripts routes", () => {
 		expect(
 			(strangerList.body as { transcripts: unknown[] }).transcripts,
 		).toEqual([]);
+	});
+
+	it("shares and revokes redacted transcript access through the real routes (#14782)", async () => {
+		const { runtime } = fakeRuntime();
+		const post = handlerFor("POST", "/api/transcripts");
+		const share = handlerFor("POST", "/api/transcripts/:id/share");
+		const revoke = handlerFor("DELETE", "/api/transcripts/:id/share/:entityId");
+		const get = handlerFor("GET", "/api/transcripts/:id");
+		const update = handlerFor("PUT", "/api/transcripts/:id");
+		const del = handlerFor("DELETE", "/api/transcripts/:id");
+
+		const created = await post(
+			ctx({
+				runtime: runtime as never,
+				body: {
+					title: "Benefits",
+					roomId: ROOM,
+					entityId: ENTITY,
+					scope: "owner-private",
+					segments: [
+						{
+							id: "s1",
+							speakerLabel: "Alice",
+							startMs: 0,
+							endMs: 1000,
+							text: "Bob email bob@example.com",
+							words: [],
+						},
+					],
+				},
+			}),
+		);
+		const transcriptId = (created.body as { transcript: { id: string } })
+			.transcript.id;
+
+		const shared = await share(
+			ctx({
+				runtime: runtime as never,
+				params: { id: transcriptId },
+				accessContext: adminAccess(ENTITY),
+				body: { entityId: OTHER_ENTITY, mode: "redacted" },
+			}),
+		);
+		expect(shared.status).toBe(200);
+		expect(shared.body).toMatchObject({
+			ok: true,
+			transcriptId,
+			entityId: OTHER_ENTITY,
+			mode: "redacted",
+		});
+
+		const fullShareByUser = await share(
+			ctx({
+				runtime: runtime as never,
+				params: { id: transcriptId },
+				accessContext: access(ENTITY),
+				body: { entityId: OTHER_ENTITY, mode: "full" },
+			}),
+		);
+		expect(fullShareByUser.status).toBe(403);
+
+		const fullShareByOwner = await share(
+			ctx({
+				runtime: runtime as never,
+				params: { id: transcriptId },
+				accessContext: ownerAccess(ENTITY),
+				body: { entityId: THIRD_ENTITY, mode: "full" },
+			}),
+		);
+		expect(fullShareByOwner.status).toBe(200);
+		expect(fullShareByOwner.body).toMatchObject({
+			ok: true,
+			transcriptId,
+			entityId: THIRD_ENTITY,
+			mode: "full",
+		});
+		expect(
+			"variantId" in (fullShareByOwner.body as Record<string, unknown>),
+		).toBe(false);
+
+		const fullViewerGet = await get(
+			ctx({
+				runtime: runtime as never,
+				params: { id: transcriptId },
+				accessContext: access(THIRD_ENTITY),
+			}),
+		);
+		expect(fullViewerGet.status).toBe(200);
+		expect(
+			(fullViewerGet.body as { transcript: { redacted?: true } }).transcript
+				.redacted,
+		).toBeUndefined();
+
+		const viewerGet = await get(
+			ctx({
+				runtime: runtime as never,
+				params: { id: transcriptId },
+				accessContext: access(OTHER_ENTITY),
+			}),
+		);
+		expect(viewerGet.status).toBe(200);
+		expect(
+			(viewerGet.body as { transcript: { redacted?: true } }).transcript
+				.redacted,
+		).toBe(true);
+
+		const resharedByRedactedViewer = await share(
+			ctx({
+				runtime: runtime as never,
+				params: { id: transcriptId },
+				accessContext: access(OTHER_ENTITY),
+				body: { entityId: ENTITY, mode: "redacted" },
+			}),
+		);
+		expect(resharedByRedactedViewer.status).toBe(403);
+
+		const editedByRedactedViewer = await update(
+			ctx({
+				runtime: runtime as never,
+				params: { id: transcriptId },
+				accessContext: access(OTHER_ENTITY),
+				body: {
+					segments: [
+						{
+							id: "s1",
+							speakerLabel: "Alice",
+							startMs: 0,
+							endMs: 1000,
+							text: "mutated",
+							words: [],
+						},
+					],
+				},
+			}),
+		);
+		expect(editedByRedactedViewer.status).toBe(403);
+
+		const deletedByRedactedViewer = await del(
+			ctx({
+				runtime: runtime as never,
+				params: { id: transcriptId },
+				accessContext: access(OTHER_ENTITY),
+			}),
+		);
+		expect(deletedByRedactedViewer.status).toBe(403);
+
+		const revoked = await revoke(
+			ctx({
+				runtime: runtime as never,
+				params: { id: transcriptId, entityId: OTHER_ENTITY },
+				accessContext: adminAccess(ENTITY),
+			}),
+		);
+		expect(revoked.status).toBe(200);
+		const hidden = await get(
+			ctx({
+				runtime: runtime as never,
+				params: { id: transcriptId },
+				accessContext: access(OTHER_ENTITY),
+			}),
+		);
+		expect(hidden.status).toBe(404);
 	});
 });

--- a/plugins/plugin-local-inference/src/routes/transcripts-routes.ts
+++ b/plugins/plugin-local-inference/src/routes/transcripts-routes.ts
@@ -9,11 +9,13 @@
  */
 
 import type {
+	ArtifactShareGrantMode,
 	Route,
 	RouteHandlerContext,
 	RouteHandlerResult,
 	UUID,
 } from "@elizaos/core";
+import { isAdminRank } from "@elizaos/core";
 import {
 	type MeetingArtifact,
 	type Transcript,
@@ -28,10 +30,15 @@ import {
 	TranscriptService,
 	type TranscriptServiceRuntime,
 } from "../services/voice/transcript-service.js";
+import { TranscriptStore } from "../services/voice/transcript-store.js";
 import { persistTranscriptAudioWav } from "./transcript-audio-store.js";
 
 function service(ctx: RouteHandlerContext): TranscriptService {
 	return new TranscriptService(ctx.runtime as TranscriptServiceRuntime);
+}
+
+function store(ctx: RouteHandlerContext): TranscriptStore {
+	return new TranscriptStore(ctx.runtime as TranscriptServiceRuntime);
 }
 
 /** The body a recording session POSTs to create a transcript record. */
@@ -137,6 +144,17 @@ const deleteRoute: Route = {
 	path: "/api/transcripts/:id",
 	rawPath: true,
 	routeHandler: async (ctx): Promise<RouteHandlerResult> => {
+		const transcript = await service(ctx).get(
+			ctx.params.id as UUID,
+			ctx.accessContext,
+		);
+		if (!transcript) return { status: 404, body: { error: "not found" } };
+		if (transcript.redacted) {
+			return {
+				status: 403,
+				body: { error: "redacted transcript views cannot be deleted" },
+			};
+		}
 		await service(ctx).delete(ctx.params.id as UUID);
 		return { status: 200, body: { ok: true } };
 	},
@@ -151,6 +169,11 @@ export interface UpdateTranscriptRequest {
 	segments?: TranscriptSegment[];
 }
 
+export interface ShareTranscriptRequest {
+	entityId?: UUID;
+	mode?: ArtifactShareGrantMode;
+}
+
 const updateRoute: Route = {
 	type: "PUT",
 	path: "/api/transcripts/:id",
@@ -162,6 +185,17 @@ const updateRoute: Route = {
 		}
 		if (body.segments !== undefined && !Array.isArray(body.segments)) {
 			return { status: 400, body: { error: "segments must be an array" } };
+		}
+		const existing = await service(ctx).get(
+			ctx.params.id as UUID,
+			ctx.accessContext,
+		);
+		if (!existing) return { status: 404, body: { error: "not found" } };
+		if (existing.redacted) {
+			return {
+				status: 403,
+				body: { error: "redacted transcript views cannot be edited" },
+			};
 		}
 		const agentId = ctx.runtime.agentId as UUID;
 		const updated = await service(ctx).update(ctx.params.id as UUID, {
@@ -222,10 +256,108 @@ const createRoute: Route = {
 	},
 };
 
+const shareRoute: Route = {
+	type: "POST",
+	path: "/api/transcripts/:id/share",
+	rawPath: true,
+	routeHandler: async (ctx): Promise<RouteHandlerResult> => {
+		const body = (ctx.body ?? {}) as ShareTranscriptRequest;
+		const entityId =
+			typeof body.entityId === "string" && body.entityId.trim().length > 0
+				? (body.entityId.trim() as UUID)
+				: null;
+		const mode = body.mode ?? "redacted";
+		if (!entityId) {
+			return { status: 400, body: { error: "entityId is required" } };
+		}
+		if (mode !== "full" && mode !== "redacted") {
+			return { status: 400, body: { error: "mode must be full or redacted" } };
+		}
+		if (mode === "full" && !isAdminRank(ctx.accessContext?.role)) {
+			return {
+				status: 403,
+				body: { error: "full transcript sharing requires ADMIN" },
+			};
+		}
+
+		const transcript = await service(ctx).get(
+			ctx.params.id as UUID,
+			ctx.accessContext,
+		);
+		if (!transcript) return { status: 404, body: { error: "not found" } };
+		if (transcript.redacted) {
+			return {
+				status: 403,
+				body: { error: "redacted transcript views cannot be re-shared" },
+			};
+		}
+
+		let variantId: string | undefined;
+		const transcriptStore = store(ctx);
+		if (mode === "redacted") {
+			const variant = await transcriptStore.createRedactedVariant({
+				originalId: ctx.params.id as UUID,
+				redactedBy: ctx.accessContext?.requesterEntityId,
+			});
+			variantId = variant.id;
+		}
+		await transcriptStore.share({
+			transcriptId: ctx.params.id as UUID,
+			entityId,
+			mode,
+			grantedBy: ctx.accessContext?.requesterEntityId,
+			grantedAtMs: Date.now(),
+		});
+		return {
+			status: 200,
+			body: {
+				ok: true,
+				transcriptId: ctx.params.id,
+				entityId,
+				mode,
+				...(variantId ? { variantId } : {}),
+			},
+		};
+	},
+};
+
+const revokeShareRoute: Route = {
+	type: "DELETE",
+	path: "/api/transcripts/:id/share/:entityId",
+	rawPath: true,
+	routeHandler: async (ctx): Promise<RouteHandlerResult> => {
+		const transcript = await service(ctx).get(
+			ctx.params.id as UUID,
+			ctx.accessContext,
+		);
+		if (!transcript) return { status: 404, body: { error: "not found" } };
+		if (transcript.redacted) {
+			return {
+				status: 403,
+				body: { error: "redacted transcript views cannot revoke grants" },
+			};
+		}
+		await store(ctx).revokeShare({
+			transcriptId: ctx.params.id as UUID,
+			entityId: ctx.params.entityId as UUID,
+		});
+		return {
+			status: 200,
+			body: {
+				ok: true,
+				transcriptId: ctx.params.id,
+				entityId: ctx.params.entityId,
+			},
+		};
+	},
+};
+
 export const transcriptsRoutes: Route[] = [
 	listRoute,
 	createRoute,
 	getRoute,
+	shareRoute,
+	revokeShareRoute,
 	updateRoute,
 	deleteRoute,
 ];

--- a/plugins/plugin-local-inference/src/services/voice/transcript-store.ts
+++ b/plugins/plugin-local-inference/src/services/voice/transcript-store.ts
@@ -89,6 +89,11 @@ export interface ShareTranscriptGrantInput {
 	grantedAtMs?: number;
 }
 
+export interface RevokeTranscriptGrantInput {
+	transcriptId: UUID;
+	entityId: UUID;
+}
+
 /** Pull the stored {@link Transcript} back out of a memory row (parses the
  *  JSON blob; a corrupt/legacy row yields null and is skipped by the list). */
 function rowToTranscript(row: Memory): Transcript | null {
@@ -475,6 +480,35 @@ export class TranscriptStore {
 				source: TRANSCRIPT_METADATA_TYPE,
 				share: {
 					grants: mergedGrant(grants, nextGrant),
+				} as unknown as JsonObject,
+			} as MemoryMetadata,
+		});
+		if (!ok) {
+			throw new Error(`transcript ${input.transcriptId} not found`);
+		}
+	}
+
+	/** Remove one per-entity share grant from the original transcript row. */
+	async revokeShare(input: RevokeTranscriptGrantInput): Promise<void> {
+		const row = await this.runtime.getMemoryById(input.transcriptId);
+		if (!row) {
+			throw new Error(`transcript ${input.transcriptId} not found`);
+		}
+		if (redactionOriginalId(row)) {
+			throw new Error(
+				"share grants must be revoked from the original transcript",
+			);
+		}
+		const metadata = row.metadata as Record<string, unknown> | undefined;
+		const grants = parseArtifactShareGrants(metadata);
+		const ok = await this.runtime.updateMemory({
+			id: input.transcriptId,
+			metadata: {
+				...(metadata ?? {}),
+				type: "custom",
+				source: TRANSCRIPT_METADATA_TYPE,
+				share: {
+					grants: grants.filter((grant) => grant.entityId !== input.entityId),
 				} as unknown as JsonObject,
 			} as MemoryMetadata,
 		});


### PR DESCRIPTION
Resolves #14782.

## Summary
- Adds route-backed transcript share and revoke operations for per-entity redacted/full access grants.
- Replaces the transcript viewer's copy-only permission request with a RoleGate-aware grant/revoke share sheet and explicit success/error states.
- Documents the MVP permissioning journey, simplification inventory, and verification states.

## Verification
- `bun run --cwd packages/ui test src/components/chat/TranscriptViewerOverlay.test.tsx` - passed
- `bun run --cwd plugins/plugin-local-inference test src/routes/transcripts-routes.test.ts src/services/voice/transcript-store.test.ts` - passed
- `bun run --cwd plugins/plugin-local-inference typecheck` - passed
- `bunx @biomejs/biome check --write <touched files>` - passed
- `bun run --cwd packages/app audit:app` - passed: 241 Playwright tests; 217 good, 16 needs-eyeball, 7 needs-work, 0 broken, 0 undebted needs-work/broken. The needs-work items are existing/debted views outside transcripts.
- Manual visual review: before desktop, after desktop grant/revoke, after mobile focus, and MP4 walkthrough reviewed locally.

## Evidence
<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/transcript-share-before-desktop.png)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/transcript-share-mobile-keyboard-focus.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence/transcript-share-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [x] [transcript-share-after-flow.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/transcript-share-after-flow.txt)

<!-- evidence-row:frontend-logs -->
- [x] [transcript-share-before-desktop.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/transcript-share-before-desktop.txt)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt, model, provider, or agent-planning behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] [report.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence/report.json)

<!-- evidence-row:ocr-review -->
- [x] [ocr-triage.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence/ocr-triage.json)
