### PR TITLE
fix(discord): collapse numeric single-fact double-posts by content signature (#15585)

### DIFF
--- a/plugins/plugin-discord/__tests__/numeric-fact-dedup.test.ts
+++ b/plugins/plugin-discord/__tests__/numeric-fact-dedup.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit tests for the connector-level numeric-fact paraphrase dedup (#15585):
+ * the guard that collapses a tool-turn's redundant second bubble (an action
+ * relaying the raw value plus the planner restating it as a sentence) at the
+ * one point every delivery converges. Pure functions, no Discord client.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	isSubsetOrEqual,
+	numericFactSignatureTokens,
+} from "../messages.ts";
+
+describe("numericFactSignatureTokens (#15585)", () => {
+	it("gives a sentence and its bare-value restatement overlapping signatures", () => {
+		const sentence = numericFactSignatureTokens(
+			"Bitcoin is currently priced at $61,883 USD.",
+		);
+		const raw = numericFactSignatureTokens("$61,883 USD");
+		expect(sentence).not.toBeNull();
+		expect(raw).not.toBeNull();
+		// The bare value's tokens are a subset of the sentence's — the guard's
+		// subset check treats them as the same fact.
+		expect(isSubsetOrEqual(raw as Set<string>, sentence as Set<string>)).toBe(
+			true,
+		);
+	});
+
+	it("gives two full-sentence paraphrases signatures in a subset relationship", () => {
+		const a = numericFactSignatureTokens(
+			"Ethereum is currently priced at $1,727.62 USD.",
+		);
+		const b = numericFactSignatureTokens(
+			"The current price of Ethereum is $1,727.62 USD.",
+		);
+		expect(a).not.toBeNull();
+		expect(b).not.toBeNull();
+		const dup =
+			isSubsetOrEqual(a as Set<string>, b as Set<string>) ||
+			isSubsetOrEqual(b as Set<string>, a as Set<string>);
+		expect(dup).toBe(true);
+	});
+
+	it("returns null for a reply with no number (never collapses non-numeric answers)", () => {
+		expect(numericFactSignatureTokens("Madrid")).toBeNull();
+		expect(
+			numericFactSignatureTokens("The capital of Spain is Madrid."),
+		).toBeNull();
+	});
+
+	it("returns null for long replies (never collapses rich content)", () => {
+		const long =
+			"Current weather in Paris is clear at 22C feeling like 25C with 69% humidity and a light ENE wind, and showers are forecast for later this week across the region.";
+		expect(long.length).toBeGreaterThan(160);
+		expect(numericFactSignatureTokens(long)).toBeNull();
+	});
+
+	it("does NOT collapse replies about different numeric facts", () => {
+		const eth = numericFactSignatureTokens("Ethereum is at $1,727 USD.");
+		const btc = numericFactSignatureTokens("Bitcoin is at $61,934 USD.");
+		expect(eth).not.toBeNull();
+		expect(btc).not.toBeNull();
+		expect(
+			isSubsetOrEqual(eth as Set<string>, btc as Set<string>) ||
+				isSubsetOrEqual(btc as Set<string>, eth as Set<string>),
+		).toBe(false);
+	});
+
+	it("does NOT suppress a follow-up that adds a genuinely new number (directional)", () => {
+		const answer = numericFactSignatureTokens("Ethereum is at $1,727 USD.");
+		const withChange = numericFactSignatureTokens(
+			"Ethereum is at $1,727 USD, up 3 percent today.",
+		);
+		expect(answer).not.toBeNull();
+		expect(withChange).not.toBeNull();
+		// The guard suppresses a NEW reply only when its tokens are a subset of a
+		// prior one. The additive follow-up carries "3"/"percent"/"today" the
+		// answer lacks, so as the new delivery it is NOT a subset → delivered.
+		expect(
+			isSubsetOrEqual(withChange as Set<string>, answer as Set<string>),
+		).toBe(false);
+	});
+
+	it("isSubsetOrEqual is directional and correct", () => {
+		expect(isSubsetOrEqual(new Set(["a"]), new Set(["a", "b"]))).toBe(true);
+		expect(isSubsetOrEqual(new Set(["a", "b"]), new Set(["a"]))).toBe(false);
+		expect(isSubsetOrEqual(new Set(["a"]), new Set(["a"]))).toBe(true);
+	});
+});

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -85,6 +85,82 @@ import {
 
 const INTERACTION_ONLY_FALLBACK_TEXT = "Choose an option:";
 
+// Filler tokens carrying no answer content — two single-fact replies differing
+// only in these words are the same fact reworded.
+const NUMERIC_FACT_STOPWORDS = new Set<string>([
+	"the",
+	"is",
+	"are",
+	"was",
+	"at",
+	"of",
+	"to",
+	"in",
+	"on",
+	"for",
+	"it",
+	"its",
+	"that",
+	"this",
+	"and",
+	"currently",
+	"current",
+	"now",
+	"right",
+	"about",
+	"approximately",
+	"around",
+	"price",
+	"priced",
+	"cost",
+	"costs",
+	"value",
+	"trading",
+	"worth",
+	"usd",
+	"dollars",
+]);
+
+// Only guard short single-fact replies; longer output can restate context while
+// adding new information.
+const NUMERIC_FACT_MAX_LEN = 160;
+
+/**
+ * Significant tokens of a short numeric single-fact reply (a number plus its
+ * subject), or null when the reply is long or carries no number. Two replies
+ * whose token sets are in a subset relationship are the same fact reworded —
+ * the tool-turn double where an action relays the raw value ("$61,883 USD") and
+ * the planner restates it as a sentence ("Bitcoin is currently priced at
+ * $61,883 USD"). The connector is the one point every delivery converges, so
+ * catching it here covers the multiple independent runtime delivery paths that
+ * #15601's exact-text reservation cannot (the two texts differ). Conservative:
+ * requires a number, so only single-fact answers (prices, counts, temps) are
+ * ever collapsed; additive replies carry new numbers/entities and pass.
+ */
+export function numericFactSignatureTokens(text: string): Set<string> | null {
+	const trimmed = text.trim();
+	if (trimmed.length === 0 || trimmed.length > NUMERIC_FACT_MAX_LEN) return null;
+	const tokens = trimmed
+		.toLowerCase()
+		.replace(/[^a-z0-9., ]+/g, " ")
+		.split(/\s+/)
+		.map((token) => token.replace(/^[.,]+/, "").replace(/[.,]+$/, ""))
+		.filter(
+			(token) =>
+				token.length > 0 &&
+				(/[0-9]/.test(token) || token.length >= 4) &&
+				!NUMERIC_FACT_STOPWORDS.has(token),
+		);
+	const set = new Set(tokens);
+	const hasNumber = [...set].some((token) => /[0-9]/.test(token));
+	return hasNumber && set.size > 0 ? set : null;
+}
+
+export function isSubsetOrEqual(a: Set<string>, b: Set<string>): boolean {
+	for (const token of a) if (!b.has(token)) return false;
+	return true;
+}
+
 export function resolveGenerationTimeoutMs(
 	timeoutSetting: unknown,
 	fallbackSetting: unknown,
@@ -1325,24 +1401,45 @@ export class MessageManager {
 						const dedupKey = `${content.inReplyTo}::${textContent.replace(/\s+/g, " ").trim()}`;
 						const callbackDedup = message as DiscordMessage & {
 							_elizaSentReplyKeys?: Set<string>;
+							_elizaSentFactSignatures?: Array<Set<string>>;
 						};
 						callbackDedup._elizaSentReplyKeys ??= new Set();
-						if (callbackDedup._elizaSentReplyKeys.has(dedupKey)) {
+						callbackDedup._elizaSentFactSignatures ??= [];
+						// Paraphrase/subset guard (#15585): a short numeric single-fact
+						// reply that restates one already sent for this inbound message —
+						// even in different words or as the bare value — is a redundant
+						// second bubble the exact-text key above cannot catch.
+						// Directional: suppress only when the NEW reply adds nothing over
+						// an already-sent one (its tokens ⊆ a prior's). This drops the
+						// bare-value/paraphrase second bubble while always letting a
+						// genuinely-additive follow-up (which carries a token the prior
+						// lacks) through, regardless of delivery order.
+						const factSignature = numericFactSignatureTokens(textContent);
+						const repeatsPriorFact =
+							factSignature !== null &&
+							callbackDedup._elizaSentFactSignatures.some((prior) =>
+								isSubsetOrEqual(factSignature, prior),
+							);
+						if (callbackDedup._elizaSentReplyKeys.has(dedupKey) || repeatsPriorFact) {
 							this.runtime.logger.debug(
 								{
 									src: "plugin:discord",
 									agentId: this.runtime.agentId,
 									messageId: message.id,
+									reason: repeatsPriorFact ? "fact-signature" : "identical-text",
 									textPreview: textContent
 										.replace(/\s+/g, " ")
 										.trim()
 										.slice(0, 200),
 								},
-								"Suppressing duplicate callback reply with identical text",
+								"Suppressing duplicate callback reply",
 							);
 							return [];
 						}
 						callbackDedup._elizaSentReplyKeys.add(dedupKey);
+						if (factSignature !== null) {
+							callbackDedup._elizaSentFactSignatures.push(factSignature);
+						}
 					}
 
 					const outboundDedupe = beginDiscordOutboundDelivery({


### PR DESCRIPTION
Fixes the residual double-post left by #15601 (#15585).

## The bug
Tool turns that answer a live-info question deliver the fact **twice**: an action relays the raw value (`$61,883 USD`) and the planner restates it as a sentence (`Bitcoin is currently priced at $61,883 USD.`). The two bubbles reach the connector through **independent runtime delivery paths** and carry **different text**, so #15601's exact-text delivery reservation can't catch them. (Also covers the two-paraphrase variant: "priced at $X" + "current price is $X".)

Root-caused live: the two deliveries share no dedup state in core (I verified a core-level guard fired 0 times) — they only converge at the connector, which is exactly where #15601 already dedups. So the fix belongs here.

## The fix
Extend the existing per-message dedup with a conservative **numeric-fact signature**: the significant tokens (a number plus its subject, minus filler words) of a *short* single-fact reply. A NEW reply whose tokens are a **subset** of one already sent this turn adds nothing → dropped.

- **Directional** (`new ⊆ prior`): an additive follow-up (`$X, up 3% today`) carries a token the prior lacks, so it's never suppressed — regardless of delivery order.
- **Number-required**: non-numeric answers (names, single words, prose) never get a signature and are never collapsed.
- **Length-capped (160)**: long/rich replies are never collapsed.

## Proof (live, Discord)
- Before: `Bitcoin is currently priced at $61,883 USD.` + `$61,883 USD` (two bubbles)
- After: one clean reply per price/crypto turn (2 `fact-signature` suppressions logged)
- No over-suppression: plain math (`81`), single-word factual (`Madrid`), and additive replies all delivered once, untouched.

<details><summary>live log</summary>

```
[BASIC-CAPABILITIES] Message sent (text=Bitcoin is currently at $61,949 USD.)   ← one, not two
[plugin:discord] Suppressing duplicate callback reply {reason: "fact-signature", ...}
```
</details>

## Tests
`numeric-fact-dedup.test.ts` — 7 cases: sentence↔bare-value subset, two-paraphrase subset, non-numeric → null, long → null, different-fact → not collapsed, additive → not suppressed (directional), subset helper correctness. Plugin build + typecheck clean; existing messages suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
