### PR TITLE
fix(cloud): bound backup chain reconstruction

### DIFF
--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
@@ -32,12 +32,14 @@ const ensureAgentSandboxSchema = mock(async () => {});
 // `where` captures the clause into the shared `capturedWhere` so a test can
 // assert on the generated SQL, mirroring the write-side capture above.
 let selectRows: unknown[] = [];
+let selectRowBatches: unknown[][] = [];
 
 function chainableRows(): unknown[] & {
   limit: () => unknown[];
   orderBy: () => unknown[] & { limit: () => unknown[]; orderBy: () => unknown[] };
 } {
-  const rows = [...selectRows] as unknown[] & {
+  const sourceRows = selectRowBatches.length > 0 ? selectRowBatches.shift() : selectRows;
+  const rows = [...(sourceRows ?? [])] as unknown[] & {
     limit: () => unknown[];
     orderBy: () => unknown[] & { limit: () => unknown[]; orderBy: () => unknown[] };
   };
@@ -135,6 +137,9 @@ describe("AgentSandboxesRepository", () => {
   beforeEach(() => {
     useRepositoryMocks = true;
     selectRows = [];
+    selectRowBatches = [];
+    select.mockClear();
+    selectWhere.mockClear();
   });
 
   afterEach(() => {
@@ -509,6 +514,77 @@ describe("AgentSandboxesRepository", () => {
     expect(rows).toHaveLength(1);
     expect(rows[0]?.id).toBe("55555555-5555-4555-8555-555555555555");
     expect(rows[0]?.snapshot_type).toBe("auto");
+  });
+
+  test("incremental reconstruction walks only the target chain sequentially", async () => {
+    const { AgentSandboxesRepository } = await import("./agent-sandboxes");
+    const { diffBackupState, computeStateHash } = await import(
+      "../../lib/services/agent-backup-diff"
+    );
+
+    const sandboxId = "e06bb509-6c52-4c33-a9f7-66addc43e8c8";
+    const fullId = "11111111-1111-4111-8111-111111111111";
+    const incrementalId = "22222222-2222-4222-8222-222222222222";
+    const baseState = {
+      memories: [{ role: "user", text: "base", timestamp: 1 }],
+      config: { mood: "steady" },
+      workspaceFiles: { "notes.txt": "base" },
+    };
+    const nextState = {
+      memories: [
+        { role: "user", text: "base", timestamp: 1 },
+        { role: "assistant", text: "next", timestamp: 2 },
+      ],
+      config: { mood: "awake" },
+      workspaceFiles: { "notes.txt": "next" },
+    };
+    const createdAt = new Date("2026-07-09T00:00:00.000Z");
+
+    selectRowBatches = [
+      [
+        {
+          id: incrementalId,
+          sandbox_record_id: sandboxId,
+          snapshot_type: "auto",
+          state_data: diffBackupState(baseState, nextState),
+          state_data_storage: "inline",
+          state_data_key: null,
+          size_bytes: 256,
+          backup_kind: "incremental",
+          parent_backup_id: fullId,
+          content_hash: computeStateHash(nextState),
+          verification_status: null,
+          verified_at: null,
+          verification_error: null,
+          created_at: createdAt,
+        },
+      ],
+      [
+        {
+          id: fullId,
+          sandbox_record_id: sandboxId,
+          snapshot_type: "auto",
+          state_data: baseState,
+          state_data_storage: "inline",
+          state_data_key: null,
+          size_bytes: 256,
+          backup_kind: "full",
+          parent_backup_id: null,
+          content_hash: computeStateHash(baseState),
+          verification_status: null,
+          verified_at: null,
+          verification_error: null,
+          created_at: createdAt,
+        },
+      ],
+    ];
+
+    const reconstructed = await new AgentSandboxesRepository().getReconstructedBackupState(
+      incrementalId,
+    );
+
+    expect(reconstructed).toEqual(nextState);
+    expect(selectWhere).toHaveBeenCalledTimes(2);
   });
 
   // C1c attribution guard (audit §C1c): claimWarmContainer must NEVER mint a

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -6,7 +6,6 @@ import {
   type BackupChainNode,
   requireBackupDelta,
   requireBackupStateData,
-  resolveBackupChain,
   selectPrunableBackupIds,
 } from "../../lib/services/agent-backup-diff";
 import { AGENT_MANAGED_DISCORD_KEY } from "../../lib/services/eliza-agent-config";
@@ -52,6 +51,19 @@ const EMPTY_BACKUP_STATE: AgentSandboxBackup["state_data"] = {
   config: {},
   workspaceFiles: {},
 };
+const MAX_RECONSTRUCTED_BACKUP_CHAIN_DEPTH = 100;
+const MAX_RECONSTRUCTED_BACKUP_CHAIN_BYTES = 128 * 1024 * 1024;
+
+async function getStoredBackupById(
+  backupId: string,
+): Promise<StoredAgentSandboxBackup | undefined> {
+  const [row] = await dbRead
+    .select()
+    .from(agentSandboxBackups)
+    .where(eq(agentSandboxBackups.id, backupId))
+    .limit(1);
+  return row;
+}
 
 async function backupOrganizationId(sandboxRecordId: string): Promise<string> {
   const [sandbox] = await dbWrite
@@ -1321,11 +1333,7 @@ export class AgentSandboxesRepository {
   }
 
   async getBackupById(backupId: string): Promise<AgentSandboxBackup | undefined> {
-    const [r] = await dbRead
-      .select()
-      .from(agentSandboxBackups)
-      .where(eq(agentSandboxBackups.id, backupId))
-      .limit(1);
+    const r = await getStoredBackupById(backupId);
     return r ? await hydrateAgentSandboxBackup(r) : undefined;
   }
 
@@ -1369,27 +1377,46 @@ export class AgentSandboxesRepository {
    * here so incrementals are transparently materialized.
    */
   async getReconstructedBackupState(backupId: string): Promise<AgentBackupStateData | undefined> {
-    const target = await this.getBackupById(backupId);
-    if (!target) return undefined;
-    if (target.backup_kind !== "incremental") {
-      return requireBackupStateData(target.state_data, target.id);
+    const targetStored = await getStoredBackupById(backupId);
+    if (!targetStored) return undefined;
+    const chain: AgentSandboxBackup[] = [];
+    const seen = new Set<string>();
+    let chainBytes = 0;
+    let cursor: StoredAgentSandboxBackup | undefined = targetStored;
+    while (cursor) {
+      if (seen.has(cursor.id)) throw new Error(`Backup chain cycle at ${cursor.id}`);
+      seen.add(cursor.id);
+      if (cursor.sandbox_record_id !== targetStored.sandbox_record_id) {
+        throw new Error(`Backup chain row ${cursor.id} crosses sandbox boundary`);
+      }
+      chainBytes +=
+        cursor.size_bytes ?? Buffer.byteLength(JSON.stringify(cursor.state_data), "utf8");
+      if (chainBytes > MAX_RECONSTRUCTED_BACKUP_CHAIN_BYTES) {
+        throw new Error(
+          `Backup chain for ${backupId} exceeds ${MAX_RECONSTRUCTED_BACKUP_CHAIN_BYTES} bytes`,
+        );
+      }
+      chain.push(await hydrateAgentSandboxBackup(cursor));
+      if (cursor.backup_kind === "full") break;
+      if (!cursor.parent_backup_id) {
+        throw new Error(`Incremental backup ${cursor.id} has no parent`);
+      }
+      if (chain.length > MAX_RECONSTRUCTED_BACKUP_CHAIN_DEPTH) {
+        throw new Error(
+          `Backup chain for ${backupId} exceeds ${MAX_RECONSTRUCTED_BACKUP_CHAIN_DEPTH} rows`,
+        );
+      }
+      const parentBackupId = cursor.parent_backup_id;
+      cursor = await getStoredBackupById(parentBackupId);
+      if (!cursor) throw new Error(`Backup chain references missing backup ${parentBackupId}`);
     }
-    const all = await this.listBackups(target.sandbox_record_id, 1000);
-    const nodes: BackupChainNode[] = all.map((b) => ({
-      id: b.id,
-      backupKind: b.backup_kind,
-      parentBackupId: b.parent_backup_id,
-      createdAtMs: b.created_at.getTime(),
-    }));
-    const byId = new Map(all.map((b) => [b.id, b]));
+    chain.reverse();
     let state: AgentBackupStateData | undefined;
-    for (const id of resolveBackupChain(nodes, backupId)) {
-      const row = byId.get(id);
-      if (!row) throw new Error(`Backup chain row ${id} vanished mid-reconstruct`);
+    for (const row of chain) {
       if (row.backup_kind === "full") {
         state = requireBackupStateData(row.state_data, row.id);
       } else {
-        if (!state) throw new Error(`Incremental ${id} reached before a full backup`);
+        if (!state) throw new Error(`Incremental ${row.id} reached before a full backup`);
         state = applyBackupDelta(state, requireBackupDelta(row.state_data, row.id));
       }
     }


### PR DESCRIPTION
## Summary
- replace incremental backup reconstruction's full-history scan with parent-pointer traversal
- hydrate only the target backup and its ancestors, sequentially, instead of up to 1000 backups in parallel
- add chain cycle, sandbox-boundary, depth, and byte-count guards
- add a repository regression test proving an incremental restore fetches only the target chain

Fixes #15626. The missing-payload/KMS/stamping/escalation portions landed in #15640; the sampler composite index is already present on develop via `0174_agent_backup_latest_index.sql`.

## Verification
- bunx @biomejs/biome check packages/cloud/shared/src/db/repositories/agent-sandboxes.ts packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts --no-errors-on-unmatched
- bun test packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts (15 pass / 0 fail)
- bun test packages/cloud/shared/src/lib/services/agent-backup-verifier.test.ts (21 pass / 0 fail)

## Notes
- Generated local i18n keyword data was needed for tests and is ignored by git.