### PR TITLE
fix(ui): map transcript share mutations to action ratchet

### DIFF
--- a/packages/scripts/view-action-ratchet.registry.json
+++ b/packages/scripts/view-action-ratchet.registry.json
@@ -167,6 +167,11 @@
     "requestMeetingBot": { "action": "JOIN_MEETING" },
     "stopMeeting": { "action": "LEAVE_MEETING" },
     "createTranscript": { "action": "START_TRANSCRIPTION" },
+    "shareTranscript": { "action": "SHARE_TRANSCRIPT" },
+    "revokeTranscriptShare": {
+      "action": "SHARE_TRANSCRIPT",
+      "note": "SHARE_TRANSCRIPT owns transcript grant management; revoke is the inverse operation on the same permission surface"
+    },
     "updatePlugin": {
       "action": "PLUGIN",
       "note": "agent-rendered plugin card in chat MessageContent; PLUGIN is the enable/configure twin"


### PR DESCRIPTION
Follow-up to #15641 / #14782.

## Summary
- Maps `client.shareTranscript()` and `client.revokeTranscriptShare()` to the registered `SHARE_TRANSCRIPT` chat twin in `view-action-ratchet.registry.json`.
- Repairs the view-action ratchet failure introduced by the merged transcript permissioning UI.

## Verification
- `node packages/scripts/view-action-ratchet.mjs` - passed
- `bun run audit:test-integrity:lane-coverage` - passed

## Evidence
<!-- evidence-row:before-screenshots -->
N/A - registry-only CI ratchet mapping; no UI pixels changed.

<!-- evidence-row:after-screenshots -->
N/A - registry-only CI ratchet mapping; no UI pixels changed.

<!-- evidence-row:walkthrough-video -->
N/A - registry-only CI ratchet mapping; no UI flow changed.

<!-- evidence-row:backend-logs -->
N/A - no backend runtime behavior changed.

<!-- evidence-row:frontend-logs -->
N/A - no frontend runtime behavior changed.

<!-- evidence-row:llm-trajectory -->
N/A - no prompt, model, provider, or agent-planning behavior changed.

<!-- evidence-row:domain-artifacts -->
N/A - registry-only CI ratchet mapping; local `node packages/scripts/view-action-ratchet.mjs` and `bun run audit:test-integrity:lane-coverage` passed.