### PR TITLE
fix(app-core): propagate cloud agent bridge failure kind

### DIFF
--- a/packages/app-core/deploy/cloud-agent-shared.test.ts
+++ b/packages/app-core/deploy/cloud-agent-shared.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Exercises cloud-agent bridge result shaping without booting a full runtime.
+ * The deployed image relies on these helpers to preserve model failure
+ * discriminators across the native JSON-RPC bridge.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  appendBridgeCallbackContent,
+  type BridgeMessageResult,
+  bridgeResultText,
+} from "./cloud-agent-shared";
+
+describe("cloud-agent bridge callback results", () => {
+  it("accumulates text while preserving the runtime failure discriminator", () => {
+    const result: BridgeMessageResult = { text: "" };
+
+    appendBridgeCallbackContent(result, { text: "provider " });
+    appendBridgeCallbackContent(result, {
+      text: "unavailable",
+      failureKind: "provider_issue",
+    });
+    appendBridgeCallbackContent(result, {
+      text: " ignored discriminator",
+      failureKind: "rate_limited",
+    });
+
+    expect(result).toEqual({
+      text: "provider unavailable ignored discriminator",
+      failureKind: "provider_issue",
+    });
+  });
+
+  it("uses the native no-response text without dropping failureKind", () => {
+    const result: BridgeMessageResult = { text: "" };
+
+    appendBridgeCallbackContent(result, { failureKind: "no_response" });
+
+    expect(bridgeResultText(result)).toBe("(no response)");
+    expect(result.failureKind).toBe("no_response");
+  });
+});

--- a/packages/app-core/deploy/cloud-agent-shared.ts
+++ b/packages/app-core/deploy/cloud-agent-shared.ts
@@ -85,6 +85,35 @@ export type NormalizedBridgeMessage = {
   metadata?: Record<string, unknown>;
 };
 
+export type BridgeMessageResult = {
+  text: string;
+  failureKind?: string;
+};
+
+type BridgeCallbackContent = {
+  text?: unknown;
+  failureKind?: unknown;
+};
+
+export function appendBridgeCallbackContent(
+  result: BridgeMessageResult,
+  content: BridgeCallbackContent,
+): BridgeMessageResult {
+  if (typeof content.text === "string") result.text += content.text;
+  if (
+    !result.failureKind &&
+    typeof content.failureKind === "string" &&
+    content.failureKind.trim()
+  ) {
+    result.failureKind = content.failureKind.trim();
+  }
+  return result;
+}
+
+export function bridgeResultText(result: BridgeMessageResult): string {
+  return result.text || "(no response)";
+}
+
 export function normalizeBridgeMessage(
   params?: BridgeRpcParams,
 ): NormalizedBridgeMessage {
@@ -155,11 +184,11 @@ export interface CloudAgentConfig {
 }
 
 interface AgentRuntime {
-  processMessage: (params: BridgeRpcParams) => Promise<string>;
+  processMessage: (params: BridgeRpcParams) => Promise<BridgeMessageResult>;
   processMessageStream: (
     params: BridgeRpcParams,
     onChunk: (chunk: string) => void,
-  ) => Promise<string>;
+  ) => Promise<BridgeMessageResult>;
   getMemories: () => Array<Record<string, unknown>>;
   getConfig: () => Record<string, unknown>;
 }
@@ -397,7 +426,9 @@ export function startCloudAgent(userConfig: CloudAgentConfig = {}): void {
       };
 
       agentRuntime = {
-        processMessage: async (params: BridgeRpcParams): Promise<string> => {
+        processMessage: async (
+          params: BridgeRpcParams,
+        ): Promise<BridgeMessageResult> => {
           const { normalized, entityId, roomId, channelType } =
             await ensureBridgeContext(params);
           const message = createMessageMemory({
@@ -418,12 +449,15 @@ export function startCloudAgent(userConfig: CloudAgentConfig = {}): void {
             },
           });
 
-          let responseText = "";
+          const response: BridgeMessageResult = { text: "" };
           await runtime.messageService?.handleMessage(
             runtime,
             message,
             async (content) => {
-              if (content.text) responseText += content.text;
+              appendBridgeCallbackContent(
+                response,
+                content as BridgeCallbackContent,
+              );
               return [];
             },
           );
@@ -438,17 +472,25 @@ export function startCloudAgent(userConfig: CloudAgentConfig = {}): void {
           });
           state.memories.push({
             role: "assistant",
-            text: responseText,
+            text: bridgeResultText(response),
             timestamp: Date.now(),
+            ...(response.failureKind
+              ? { failureKind: response.failureKind }
+              : {}),
           });
           trimMemories();
 
-          return responseText || "(no response)";
+          return {
+            text: bridgeResultText(response),
+            ...(response.failureKind
+              ? { failureKind: response.failureKind }
+              : {}),
+          };
         },
         processMessageStream: async (
           params: BridgeRpcParams,
           onChunk: (chunk: string) => void,
-        ): Promise<string> => {
+        ): Promise<BridgeMessageResult> => {
           const { normalized, entityId, roomId, channelType } =
             await ensureBridgeContext(params);
           const message = createMessageMemory({
@@ -469,14 +511,18 @@ export function startCloudAgent(userConfig: CloudAgentConfig = {}): void {
             },
           });
 
-          let responseText = "";
+          const response: BridgeMessageResult = { text: "" };
           await runtime.messageService?.handleMessage(
             runtime,
             message,
             async (content) => {
-              if (content.text) {
-                responseText += content.text;
-                onChunk(content.text);
+              const previousTextLength = response.text.length;
+              appendBridgeCallbackContent(
+                response,
+                content as BridgeCallbackContent,
+              );
+              if (response.text.length > previousTextLength) {
+                onChunk(response.text.slice(previousTextLength));
               }
               return [];
             },
@@ -492,12 +538,20 @@ export function startCloudAgent(userConfig: CloudAgentConfig = {}): void {
           });
           state.memories.push({
             role: "assistant",
-            text: responseText,
+            text: bridgeResultText(response),
             timestamp: Date.now(),
+            ...(response.failureKind
+              ? { failureKind: response.failureKind }
+              : {}),
           });
           trimMemories();
 
-          return responseText || "(no response)";
+          return {
+            text: bridgeResultText(response),
+            ...(response.failureKind
+              ? { failureKind: response.failureKind }
+              : {}),
+          };
         },
         getMemories: () => state.memories,
         getConfig: () => state.config,
@@ -507,7 +561,9 @@ export function startCloudAgent(userConfig: CloudAgentConfig = {}): void {
     } else {
       logger.warn("@elizaos/core not available, running in echo mode");
       agentRuntime = {
-        processMessage: async (params: BridgeRpcParams): Promise<string> => {
+        processMessage: async (
+          params: BridgeRpcParams,
+        ): Promise<BridgeMessageResult> => {
           const normalized = normalizeBridgeMessage(params);
           state.memories.push({
             role: "user",
@@ -523,12 +579,12 @@ export function startCloudAgent(userConfig: CloudAgentConfig = {}): void {
             timestamp: Date.now(),
           });
           trimMemories();
-          return reply;
+          return { text: reply };
         },
         processMessageStream: async (
           params: BridgeRpcParams,
           onChunk: (chunk: string) => void,
-        ): Promise<string> => {
+        ): Promise<BridgeMessageResult> => {
           const normalized = normalizeBridgeMessage(params);
           state.memories.push({
             role: "user",
@@ -545,7 +601,7 @@ export function startCloudAgent(userConfig: CloudAgentConfig = {}): void {
             timestamp: Date.now(),
           });
           trimMemories();
-          return reply;
+          return { text: reply };
         },
         getMemories: () => state.memories,
         getConfig: () => state.config,
@@ -700,14 +756,18 @@ export function startCloudAgent(userConfig: CloudAgentConfig = {}): void {
 
       sendEvent("connected", { rpcId: rpc.id, timestamp: Date.now() });
 
-      await agentRuntime.processMessageStream(
+      const response = await agentRuntime.processMessageStream(
         rpc.params ?? {},
         (chunk: string) => {
           sendEvent("chunk", { text: chunk });
         },
       );
 
-      sendEvent("done", { rpcId: rpc.id, timestamp: Date.now() });
+      sendEvent("done", {
+        rpcId: rpc.id,
+        timestamp: Date.now(),
+        ...(response.failureKind ? { failureKind: response.failureKind } : {}),
+      });
       res.end();
       return;
     }
@@ -743,17 +803,23 @@ export function startCloudAgent(userConfig: CloudAgentConfig = {}): void {
           );
           return;
         }
-        const responseText = await agentRuntime.processMessage(
-          rpc.params ?? {},
-        );
+        const response = await agentRuntime.processMessage(rpc.params ?? {});
         res.writeHead(200);
         res.end(
           JSON.stringify({
             jsonrpc: "2.0",
             id: rpc.id,
             result: {
-              text: responseText,
-              metadata: { timestamp: Date.now() },
+              text: response.text,
+              ...(response.failureKind
+                ? { failureKind: response.failureKind }
+                : {}),
+              metadata: {
+                timestamp: Date.now(),
+                ...(response.failureKind
+                  ? { failureKind: response.failureKind }
+                  : {}),
+              },
             },
           }),
         );


### PR DESCRIPTION
## Summary
- preserve `failureKind` emitted by runtime message callbacks in the cloud-agent native JSON-RPC bridge
- keep `result.text` backward-compatible while adding `result.failureKind` and metadata failureKind for non-streaming callers
- include `failureKind` on the streaming `done` event and cover the result accumulator with a focused test

Fixes part of #15616.

## Verification
- `bunx @biomejs/biome check packages/app-core/deploy/cloud-agent-shared.ts packages/app-core/deploy/cloud-agent-shared.test.ts`
- `bun run --cwd packages/app-core test deploy/cloud-agent-shared.test.ts`
- `git diff --check`
- `bun run --cwd packages/shared build:i18n && bun run --cwd packages/app-core typecheck`

Note: app-core typecheck in a fresh worktree initially failed because generated i18n keyword artifacts were absent; generated them with the documented shared build:i18n command, then typecheck passed.