### PR TITLE
fix(app): reserve composer clearance in audit views

### DIFF
--- a/packages/ui/src/components/pages/BackgroundView.tsx
+++ b/packages/ui/src/components/pages/BackgroundView.tsx
@@ -17,7 +17,7 @@ export function BackgroundView() {
           is full-bleed on the transparent shell), so it owns its own bottom
           clearance: the floating-composer + bottom-nav + safe-area stack, plus
           the standard `--view-pad-top` gutter. No magic `pb-28`. */}
-      <div className="relative flex min-h-0 flex-1 flex-col items-center justify-center px-4 pt-[var(--view-pad-top)] pb-[calc(var(--eliza-mobile-nav-offset,0px)+max(var(--safe-area-bottom,0px),var(--android-gesture-inset-bottom,0px))+var(--eliza-continuous-chat-clearance,5.25rem)+1rem)]">
+      <div className="eliza-continuous-chat-scroll absolute inset-x-0 top-0 bottom-[calc(var(--eliza-mobile-nav-offset,0px)+max(var(--safe-area-bottom,0px),var(--android-gesture-inset-bottom,0px))+var(--eliza-continuous-chat-clearance,5.25rem)+1rem)] flex flex-col items-center overflow-y-auto px-4 pt-[var(--view-pad-top)] pb-4 pe-[var(--eliza-continuous-chat-side-clearance,0px)]">
         <h1 className="sr-only">Background</h1>
         <BackgroundSettingsControls />
       </div>

--- a/plugins/app-model-tester/src/ModelTesterAppView.tsx
+++ b/plugins/app-model-tester/src/ModelTesterAppView.tsx
@@ -341,7 +341,7 @@ export function ModelTesterAppView({ exitToApps, t }: OverlayAppContext) {
         </div>
       </div>
 
-      <div className="chat-native-scrollbar flex-1 overflow-y-auto px-3 pb-32 pt-2 sm:px-5">
+      <div className="chat-native-scrollbar eliza-continuous-chat-scroll mb-[calc(var(--eliza-mobile-nav-offset,0px)+max(var(--safe-area-bottom,0px),var(--android-gesture-inset-bottom,0px))+var(--eliza-continuous-chat-clearance,5.25rem)+1rem)] flex-1 overflow-y-auto px-3 pt-2 pb-4 pe-[calc(var(--eliza-continuous-chat-side-clearance,0px)+0.75rem)] sm:px-5">
         <div className="mx-auto flex max-w-5xl flex-col gap-3">
           <section className="py-2">
             <div className="grid grid-cols-3 gap-2">

--- a/plugins/plugin-training/src/ui/FineTuningView.tsx
+++ b/plugins/plugin-training/src/ui/FineTuningView.tsx
@@ -2297,8 +2297,11 @@ export function FineTuningDashboard({
   }
 
   return (
-    <ContentLayout contentHeader={contentHeader}>
-      <div data-testid="fine-tuning-view" className="space-y-4 pb-32">
+    <ContentLayout
+      contentHeader={contentHeader}
+      contentClassName="mb-[calc(var(--eliza-mobile-nav-offset,0px)+max(var(--safe-area-bottom,0px),var(--android-gesture-inset-bottom,0px))+var(--eliza-continuous-chat-clearance,5.25rem)+1rem)] pe-[var(--eliza-continuous-chat-side-clearance,0px)]"
+    >
+      <div data-testid="fine-tuning-view" className="space-y-4 pb-4">
         <section className="px-2 py-2">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div>


### PR DESCRIPTION
## Summary
- reserve continuous-chat composer clearance for Background, Model Tester, and Fine-Tuning/Training scroll containers
- move Fine-Tuning clearance onto the ContentLayout scroll boundary so controls are clipped above the floating composer
- follow-up to the #14782 audit loop after the main transcript sharing PRs were merged

## Evidence
- `bunx @biomejs/biome check packages/ui/src/components/pages/BackgroundView.tsx plugins/app-model-tester/src/ModelTesterAppView.tsx plugins/plugin-training/src/ui/FineTuningView.tsx`
- `bun run --cwd packages/ui typecheck`
- `bun run --cwd plugins/plugin-training build:views`
- `bun run --cwd plugins/app-model-tester build`
- `bun run audit:error-policy-ratchet --report`
- Scoped visual audit in main checkout after the same commit: 4 passed; `broken=0 needs-work=0 needs-eyeball=0 good=4` for `builtin-fine-tuning` and `plugin-training-gui` mobile/ipad portrait.

## Notes
- A full `bun run --cwd packages/app audit:app` was started before this follow-up fix and showed existing `needs-work` findings. A later full rerun was terminated by shared UI-smoke contention.
- The scoped audit from the clean temp worktree could not launch because that temp dependency setup failed rebuilding unrelated plugin views (`@elizaos/capacitor-phone`, `@elizaos/capacitor-messages`, `@xterm/addon-fit`). The changed training and model-tester view builds pass on the clean branch.