### PR TITLE
feat(lifeops): persist meeting commitments to ledger

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/meeting-ghost/consumer.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/meeting-ghost/consumer.ts
@@ -1,25 +1,30 @@
 /**
  * Runtime consumer that turns a finalized meeting transcript into queued owner
- * approvals — the reachable path that makes `analyzeMeetingGhostTranscript`
- * (a pure function in `./index.ts`) act on the system.
+ * approvals and commitment-ledger rows — the reachable path that makes
+ * `analyzeMeetingGhostTranscript` (a pure function in `./index.ts`) act on the
+ * system.
  *
  * A caller (the meeting post-processing hook, or a scheduled-task watcher that
  * reads finalized `TranscriptSegment[]` off the `transcripts` memory table)
  * hands us the diarized transcript the owner skipped plus their context. We
  * derive the follow-up emails and calendar-deadline events the owner would send
- * if they had attended, and enqueue each as an owner-approval request through
- * the shared `ApprovalQueue` — every meeting-ghost side effect stays behind the
- * owner's one-tap approve/reject, never auto-sent.
+ * if they had attended, enqueue each as an owner-approval request through the
+ * shared `ApprovalQueue`, then persist the extracted promises to the shared
+ * commitment ledger. External effects stay behind the owner's one-tap
+ * approve/reject, never auto-sent; ledger rows make the owed follow-ups
+ * auditable even before approval.
  *
- * `analyzeMeetingGhostTranscript` already emits `ApprovalEnqueueInput[]`, so
- * this is a thin routing pass: analyze, then `enqueue` each request. Enqueue
- * failures surface (no swallow) so a broken approval pipeline is observable.
+ * `analyzeMeetingGhostTranscript` already emits `ApprovalEnqueueInput[]` and
+ * ledger records, so this is a routing pass: analyze, then write each side
+ * effect. Failures surface (no swallow) so a broken approval or ledger pipeline
+ * is observable.
  */
 
 import type { IAgentRuntime } from "@elizaos/core";
 import { logger } from "@elizaos/core";
 import { createApprovalQueue } from "../approval-queue.js";
 import type { ApprovalRequest } from "../approval-queue.types.js";
+import { LifeOpsRepository } from "../repository.js";
 import {
   analyzeMeetingGhostTranscript,
   type MeetingGhostAnalysis,
@@ -37,6 +42,8 @@ export interface MeetingGhostRunResult {
   readonly analysis: MeetingGhostAnalysis;
   /** Approval requests created in the queue (follow-ups then calendar deadlines). */
   readonly enqueued: readonly ApprovalRequest[];
+  /** Commitment ledger ids persisted for extracted transcript commitments. */
+  readonly commitmentLedgerIds: readonly string[];
 }
 
 /**
@@ -50,6 +57,7 @@ export async function runMeetingGhostForTranscript(
   input: RunMeetingGhostInput,
 ): Promise<MeetingGhostRunResult> {
   const analysis = analyzeMeetingGhostTranscript({
+    agentId: input.agentId,
     transcript: input.transcript,
     owner: input.owner,
   });
@@ -65,9 +73,23 @@ export async function runMeetingGhostForTranscript(
     enqueued.push(await queue.enqueue(request));
   }
 
+  const adapter = (runtime as { adapter?: { db?: unknown } }).adapter;
+  const commitmentLedgerIds: string[] = [];
+  if (adapter?.db) {
+    const repository = new LifeOpsRepository(runtime);
+    for (const record of analysis.commitmentLedgerRecords) {
+      await repository.upsertCommitmentLedgerRecord(record);
+      commitmentLedgerIds.push(record.id);
+    }
+  } else if (analysis.commitmentLedgerRecords.length > 0) {
+    logger.debug(
+      `[meeting-ghost] commitment ledger unavailable for ${input.transcript.meetingId}; runtime has no SQL adapter`,
+    );
+  }
+
   logger.info(
-    `[meeting-ghost] ${input.transcript.meetingId}: ${analysis.decisions.length} decisions, ${analysis.commitments.length} commitments, ${enqueued.length} approvals queued`,
+    `[meeting-ghost] ${input.transcript.meetingId}: ${analysis.decisions.length} decisions, ${analysis.commitments.length} commitments, ${enqueued.length} approvals queued, ${commitmentLedgerIds.length} ledger rows persisted`,
   );
 
-  return { analysis, enqueued };
+  return { analysis, enqueued, commitmentLedgerIds };
 }

--- a/plugins/plugin-personal-assistant/src/lifeops/meeting-ghost/index.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/meeting-ghost/index.ts
@@ -5,11 +5,11 @@
  * `TranscriptSegment[]` that `@elizaos/plugin-meetings`' pipeline `finalize()`
  * produces) plus owner context, this module derives the deterministic
  * post-meeting shape LifeOps acts on: decisions, care-about hits, extracted
- * commitments, a short digest, and — the part that leaves the module —
- * owner-approval requests as `ApprovalEnqueueInput[]` that feed
- * `ApprovalQueue.enqueue()` directly (no re-mapping at the call site). The
+ * commitments, commitment-ledger rows, a short digest, and — the part that
+ * leaves the module — owner-approval requests as `ApprovalEnqueueInput[]` that
+ * feed `ApprovalQueue.enqueue()` directly (no re-mapping at the call site). The
  * scheduled-task consumer that runs this on a real transcript and routes the
- * approvals lives in `./consumer.ts`.
+ * side effects lives in `./consumer.ts`.
  *
  * It is deliberately pure so tests can pin care-about filtering and commitment
  * extraction against a realistic diarized fixture without mocking connectors.
@@ -22,6 +22,8 @@ import type {
   ApprovalEnqueueInput,
   ApprovalPayload,
 } from "../approval-queue.types.js";
+import type { LifeOpsCommitmentLedgerRecord } from "../commitments/index.js";
+import { createLifeOpsCommitmentLedgerRecord } from "../commitments/index.js";
 
 export interface MeetingGhostAttendee {
   readonly name: string;
@@ -82,6 +84,7 @@ export interface MeetingGhostAnalysis {
   readonly meetingId: string;
   readonly decisions: readonly MeetingGhostDecision[];
   readonly commitments: readonly MeetingGhostCommitment[];
+  readonly commitmentLedgerRecords: readonly LifeOpsCommitmentLedgerRecord[];
   readonly careHits: readonly MeetingGhostCareHit[];
   /** Ready to feed `ApprovalQueue.enqueue()` directly. */
   readonly followUpApprovals: readonly ApprovalEnqueueInput[];
@@ -248,6 +251,12 @@ function parseDueDate(
   return null;
 }
 
+function dueDateToLedgerDueAt(dueDate: string | null): string | null {
+  if (!dueDate) return null;
+  const due = new Date(`${dueDate}T17:00:00.000Z`);
+  return Number.isNaN(due.getTime()) ? null : due.toISOString();
+}
+
 function parseCommitment(
   transcript: MeetingGhostTranscript,
   segment: TranscriptSegment,
@@ -352,7 +361,37 @@ function buildDigestLines(
   return lines.slice(0, 3);
 }
 
+export function createMeetingGhostCommitmentLedgerRecord(input: {
+  readonly agentId: string;
+  readonly transcript: MeetingGhostTranscript;
+  readonly commitment: MeetingGhostCommitment;
+}): LifeOpsCommitmentLedgerRecord {
+  return createLifeOpsCommitmentLedgerRecord({
+    agentId: input.agentId,
+    source: "transcript",
+    sourceKey: `${input.transcript.meetingId}:${input.commitment.id}`,
+    kind: "commitment",
+    summary: input.commitment.what,
+    counterparty: input.commitment.who,
+    dueAt: dueDateToLedgerDueAt(input.commitment.dueDate),
+    confidence: input.commitment.dueDate ? 0.86 : 0.78,
+    metadata: {
+      meetingId: input.transcript.meetingId,
+      meetingTitle: input.transcript.title,
+      meetingStartedAt: input.transcript.startedAt,
+      commitmentId: input.commitment.id,
+      sourceText: input.commitment.sourceText,
+      sourceOffsetMs: input.commitment.sourceOffsetMs,
+      dueText: input.commitment.dueText,
+      recipientEmail: input.commitment.recipientEmail,
+    },
+    createdAt: input.transcript.startedAt,
+    updatedAt: input.transcript.startedAt,
+  });
+}
+
 export function analyzeMeetingGhostTranscript(input: {
+  readonly agentId?: string;
   readonly transcript: MeetingGhostTranscript;
   readonly owner: MeetingGhostOwnerContext;
 }): MeetingGhostAnalysis {
@@ -395,11 +434,21 @@ export function analyzeMeetingGhostTranscript(input: {
       buildCalendarIntent(input.transcript, input.owner, commitment),
     )
     .filter((entry): entry is MeetingGhostCalendarIntent => entry !== null);
+  const commitmentLedgerRecords = input.agentId
+    ? commitments.map((commitment) =>
+        createMeetingGhostCommitmentLedgerRecord({
+          agentId: input.agentId,
+          transcript: input.transcript,
+          commitment,
+        }),
+      )
+    : [];
 
   return {
     meetingId: input.transcript.meetingId,
     decisions,
     commitments,
+    commitmentLedgerRecords,
     careHits,
     followUpApprovals,
     calendarIntents,

--- a/plugins/plugin-personal-assistant/test/meeting-ghost.integration.test.ts
+++ b/plugins/plugin-personal-assistant/test/meeting-ghost.integration.test.ts
@@ -23,6 +23,7 @@ import { createRealTestRuntime } from "../../../packages/test/helpers/real-runti
 import { createApprovalQueue } from "../src/lifeops/approval-queue.js";
 import type { ApprovalQueue } from "../src/lifeops/approval-queue.types.js";
 import { runMeetingGhostForTranscript } from "../src/lifeops/meeting-ghost/consumer.js";
+import { LifeOpsRepository } from "../src/lifeops/repository.js";
 import { personalAssistantPlugin } from "../src/plugin.js";
 
 let runtime: AgentRuntime;
@@ -144,6 +145,7 @@ describe("meeting-ghost consumer (real approval queue)", () => {
     // Two commitments → two follow-up emails + two dated calendar deadlines.
     expect(result.analysis.commitments).toHaveLength(2);
     expect(result.enqueued).toHaveLength(4);
+    expect(result.commitmentLedgerIds).toHaveLength(2);
     expect(result.enqueued.every((r) => r.state === "pending")).toBe(true);
 
     const actions = result.enqueued.map((r) => r.action).sort();
@@ -162,6 +164,34 @@ describe("meeting-ghost consumer (real approval queue)", () => {
       limit: 20,
     });
     expect(pending.length).toBeGreaterThanOrEqual(4);
+
+    const repo = new LifeOpsRepository(runtime);
+    const ledgerRows = await repo.listCommitmentLedgerRecords(runtime.agentId, {
+      source: "transcript",
+    });
+    const meetingRows = ledgerRows.filter((row) =>
+      row.sourceKey.startsWith("ops-sync-integration:"),
+    );
+    expect(meetingRows).toHaveLength(2);
+    expect(meetingRows.map((row) => row.summary).sort()).toEqual([
+      "send the launch-date rollback plan",
+      "update the public calendar",
+    ]);
+    expect(meetingRows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          counterparty: "Ava",
+          dueAt: "2026-07-10T17:00:00.000Z",
+          status: "open",
+          metadata: expect.objectContaining({
+            meetingId: "ops-sync-integration",
+            meetingTitle: "Ops Sync",
+            sourceText:
+              "Ava will send the launch-date rollback plan by 2026-07-10.",
+          }),
+        }),
+      ]),
+    );
 
     const firstEmail = result.enqueued.find((r) => r.action === "send_email");
     if (!firstEmail) throw new Error("expected a send_email approval");

--- a/plugins/plugin-personal-assistant/test/meeting-ghost.test.ts
+++ b/plugins/plugin-personal-assistant/test/meeting-ghost.test.ts
@@ -14,7 +14,10 @@
 
 import type { TranscriptSegment } from "@elizaos/shared";
 import { describe, expect, it } from "vitest";
-import { analyzeMeetingGhostTranscript } from "../src/lifeops/meeting-ghost/index.js";
+import {
+  analyzeMeetingGhostTranscript,
+  createMeetingGhostCommitmentLedgerRecord,
+} from "../src/lifeops/meeting-ghost/index.js";
 
 const approvalExpiresAt = new Date("2026-07-06T20:00:00.000Z");
 
@@ -161,6 +164,72 @@ describe("meeting ghost transcript analysis", () => {
         sourceOffsetMs: 360_000,
       }),
     ]);
+  });
+
+  it("normalizes transcript commitments into ledger rows with meeting provenance", () => {
+    const analysis = analyzeMeetingGhostTranscript({
+      agentId: "agent-meeting-1",
+      owner: {
+        ownerUserId: "owner-1",
+        ownerDisplayName: "Shaw",
+        requestedBy: "meeting-ghost",
+        careAbouts: ["launch date"],
+        calendarId: "primary",
+        approvalExpiresAt,
+      },
+      transcript: {
+        meetingId: "ops-sync-2026-07-06",
+        title: "Ops Sync",
+        startedAt: "2026-07-06T16:00:00.000Z",
+        attendees: [{ name: "Ava", email: "ava@example.com" }],
+        segments: [
+          seg(
+            "Mira",
+            240_000,
+            "Ava will send the launch-date rollback plan by Friday.",
+          ),
+        ],
+      },
+    });
+
+    expect(analysis.commitmentLedgerRecords).toHaveLength(1);
+    expect(analysis.commitmentLedgerRecords[0]).toMatchObject({
+      agentId: "agent-meeting-1",
+      source: "transcript",
+      sourceKey: `ops-sync-2026-07-06:${analysis.commitments[0].id}`,
+      kind: "commitment",
+      summary: "send the launch-date rollback plan",
+      counterparty: "Ava",
+      dueAt: "2026-07-10T17:00:00.000Z",
+      confidence: 0.86,
+      status: "open",
+      scheduledTaskId: null,
+      metadata: {
+        meetingId: "ops-sync-2026-07-06",
+        meetingTitle: "Ops Sync",
+        meetingStartedAt: "2026-07-06T16:00:00.000Z",
+        commitmentId: analysis.commitments[0].id,
+        sourceText: "Ava will send the launch-date rollback plan by Friday.",
+        sourceOffsetMs: 240_000,
+        dueText: "Friday",
+        recipientEmail: "ava@example.com",
+      },
+      createdAt: "2026-07-06T16:00:00.000Z",
+      updatedAt: "2026-07-06T16:00:00.000Z",
+    });
+
+    const rebuilt = createMeetingGhostCommitmentLedgerRecord({
+      agentId: "agent-meeting-1",
+      transcript: {
+        meetingId: "ops-sync-2026-07-06",
+        title: "Ops Sync",
+        startedAt: "2026-07-06T16:00:00.000Z",
+        attendees: [{ name: "Ava", email: "ava@example.com" }],
+        segments: [],
+      },
+      commitment: analysis.commitments[0],
+    });
+    expect(rebuilt.id).toBe(analysis.commitmentLedgerRecords[0].id);
   });
 
   it("emits canonical ApprovalEnqueueInput follow-ups ready for the approval queue", () => {

--- a/plugins/plugin-personal-assistant/vitest.src-integration.config.ts
+++ b/plugins/plugin-personal-assistant/vitest.src-integration.config.ts
@@ -18,9 +18,10 @@
 // plugin barrel (its `@elizaos/core` string alias breaks the `/node` subpath
 // import that `@elizaos/plugin-x`'s dist pulls in), and the package's
 // test:integration script only names two test/ files there — so the pause
-// test never ran anywhere before this wiring. Approval-queue integration specs
-// are included by name for the same reason: they boot the real PGlite runtime
-// and need this package's first-party source aliases instead of dist entries.
+// test never ran anywhere before this wiring. Approval-queue and meeting-ghost
+// integration specs are included by name for the same reason: they boot the
+// real PGlite runtime and need this package's first-party source aliases
+// instead of dist entries.
 
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -46,6 +47,7 @@ export default defineConfig({
       `${packageRootFromRepo}/test/global-pause.integration.test.ts`,
       `${packageRootFromRepo}/test/approval-queue.integration.test.ts`,
       `${packageRootFromRepo}/test/approval-queue-notify-error.integration.test.ts`,
+      `${packageRootFromRepo}/test/meeting-ghost.integration.test.ts`,
       `${packageRootFromRepo}/test/resolve-referent-action.integration.test.ts`,
     ],
     exclude: [


### PR DESCRIPTION
Refs #14870

## Summary
- normalize meeting-ghost transcript commitments into durable `source: "transcript"` commitment-ledger records with meeting provenance, due dates, and counterparty metadata
- persist those ledger rows from `runMeetingGhostForTranscript` whenever the runtime has a SQL adapter, while preserving no-DB deterministic analysis/approval behavior
- add meeting-ghost integration coverage to the package source-integration allowlist and assert PGlite ledger rows alongside approval queue rows

## Evidence
<!-- evidence-row:before-screenshots -->
- N/A - backend/domain persistence change; no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- N/A - backend/domain persistence change; no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- N/A - backend/domain persistence change; no user-facing UI flow changed.
<!-- evidence-row:backend-logs -->
- N/A - no live backend deployed for this deterministic persistence slice; local backend-equivalent proof passed: `meeting-ghost.test.ts` 8 tests, `meeting-ghost.integration.test.ts` 1 PGlite runtime test, `bun run --cwd plugins/plugin-personal-assistant build`, `git diff --check`, and `bun run audit:error-policy-ratchet`.
<!-- evidence-row:frontend-logs -->
- N/A - no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- N/A - deterministic transcript extractor/persistence slice; no model prompt/action behavior changed in this PR. #14870 still needs live meeting/model trajectory evidence before closure.
<!-- evidence-row:domain-artifacts -->
- N/A - no deploy artifact attached; domain artifact was inspected in the real PGlite integration test via `LifeOpsRepository.listCommitmentLedgerRecords(runtime.agentId, { source: "transcript" })`, filtering `ops-sync-integration:*` and asserting persisted summaries, due date `2026-07-10T17:00:00.000Z`, counterparty, status, and meeting/source-text metadata.