### PR TITLE
fix(cloud): restore backup-verifier hardening dropped in the #15643/#15640 merge race

### DIFF
--- a/packages/cloud/shared/src/lib/services/agent-backup-verifier.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-verifier.test.ts
@@ -41,6 +41,7 @@ import {
 import { organizations } from "../../db/schemas/organizations";
 import { userCharacters } from "../../db/schemas/user-characters";
 import { users } from "../../db/schemas/users";
+import { type RuntimeR2Bucket, setRuntimeR2Bucket } from "../storage/r2-runtime-binding";
 import { resetObjectStorageClientForTests } from "../storage/s3-compatible-client";
 import { computeStateHash, diffBackupState } from "./agent-backup-diff";
 import {
@@ -66,9 +67,7 @@ const CONFIG: BackupVerifierConfig = {
   batchSize: 10,
   reVerifyIntervalMs: 24 * 3_600_000,
   escalationThresholdPct: 50,
-  // Floor of 1 so the small-sample escalation tests exercise the threshold
-  // semantics; the production floor (default 5) is pinned by its own test.
-  minSystemicSample: 1,
+  minSystemicSample: 5,
   maxDecryptBytesPerCycle: 256 * 1024 * 1024,
   erroredAlertStreak: 3,
 };
@@ -277,11 +276,13 @@ beforeAll(async () => {
 
 beforeEach(async () => {
   expect(pgliteReady).toBe(true);
+  setRuntimeR2Bucket(null);
   await dbWrite.delete(agentSandboxBackups);
   await dbWrite.delete(agentSandboxes);
 });
 
 afterAll(async () => {
+  setRuntimeR2Bucket(null);
   await closeDatabaseConnectionsForTests();
 });
 
@@ -337,6 +338,15 @@ describe("classifyCryptoError", () => {
     expect(classifyCryptoError(error)?.kind).toBe("key-unavailable");
   });
 
+  test("steward KMS 404 → key-unavailable", () => {
+    const error = new Error("steward KMS returned 404 for org key");
+    error.name = "KmsError";
+    (error as { $metadata?: { httpStatusCode: number } }).$metadata = {
+      httpStatusCode: 404,
+    };
+    expect(classifyCryptoError(error)?.kind).toBe("key-unavailable");
+  });
+
   test("AEAD auth failure → decrypt-failed", () => {
     const error = new Error(
       "AEAD decrypt failed: Unsupported state or unable to authenticate data",
@@ -350,20 +360,12 @@ describe("classifyCryptoError", () => {
     expect(classifyCryptoError("boom")).toBeNull();
   });
 
-  test("steward KmsError 404 → key-unavailable (structured status and message fallback)", () => {
+  test("steward KmsError 404 → key-unavailable via the structured status", () => {
     const structured = new KmsError(
       "Steward KMS POST /v1/kms/keys/org%3Aabc%2Fdek/decrypt failed (404 Not Found): no such key material",
       404,
     );
     expect(classifyCryptoError(structured)?.kind).toBe("key-unavailable");
-
-    // A KmsError serialized without the structured status still classifies
-    // from the message the adapter formats.
-    const messageOnly = new Error(
-      "Steward KMS POST /v1/kms/keys/org%3Aabc%2Fdek/decrypt failed (404)",
-    );
-    messageOnly.name = "KmsError";
-    expect(classifyCryptoError(messageOnly)?.kind).toBe("key-unavailable");
   });
 
   test("steward KmsError with a non-404 status stays unclassified (transport breakage, not a bad key)", () => {
@@ -378,11 +380,13 @@ describe("classifyCryptoError", () => {
     const adapter = new StewardKmsAdapter({
       baseUrl: "https://steward.example.test",
       tokenProvider: async () => "token-1",
-      // Body deliberately avoids the words "key not found" so the test proves
-      // the 404 classification, not the message-substring fallback.
+      // Body deliberately avoids the words "key not found" so classification
+      // cannot ride the KeyNotFoundError message heuristic; the structured
+      // status assertion below pins the real steward wire contract.
       fetch: async () =>
         new Response(JSON.stringify({ error: "no such key material" }), {
           status: 404,
+          statusText: "",
           headers: { "content-type": "application/json" },
         }),
     });
@@ -394,6 +398,8 @@ describe("classifyCryptoError", () => {
         },
         (err: unknown) => err,
       );
+    expect(error).toBeInstanceOf(KmsError);
+    expect((error as KmsError).status).toBe(404);
     expect(classifyCryptoError(error)?.kind).toBe("key-unavailable");
   });
 });
@@ -481,16 +487,11 @@ describe("runBackupVerificationCycle (real PGlite + real memory KMS)", () => {
     expect(row.verification_status).toBe("failed");
     expect(row.verification_error).toStartWith("decrypt-failed:");
     expect(row.verification_error).toContain("AEAD decrypt failed");
-    // 1/1 failed ≥ 50% threshold → both the failure alert and the systemic
-    // escalation fire, on distinct dedup keys.
-    expect(summary.escalated).toBe(true);
-    expect(alerts.map((a) => a.dedupKey)).toEqual([
-      "agent-backup-verification-failure",
-      "agent-backup-verification-systemic",
-    ]);
+    expect(summary.escalated).toBe(false);
+    expect(alerts.map((a) => a.dedupKey)).toEqual(["agent-backup-verification-failure"]);
   });
 
-  test("wrong KMS key (fresh memory backend, #15310): key-unavailable + systemic escalation", async () => {
+  test("wrong KMS key (fresh memory backend, #15310): key-unavailable below escalation floor", async () => {
     expect(pgliteReady).toBe(true);
     const sandboxA = await seedSandbox();
     const sandboxB = await seedSandbox();
@@ -511,11 +512,118 @@ describe("runBackupVerificationCycle (real PGlite + real memory KMS)", () => {
       expect(row.verification_status).toBe("failed");
       expect(row.verification_error).toStartWith("key-unavailable:");
     }
-    expect(summary.escalated).toBe(true);
+    expect(summary.escalated).toBe(false);
+    expect(alerts.map((a) => a.dedupKey)).toEqual(["agent-backup-verification-failure"]);
+  });
+
+  test("systemic escalation waits for a minimum sample floor", async () => {
+    expect(pgliteReady).toBe(true);
+    const backupIds: string[] = [];
+    for (let i = 0; i < 5; i += 1) {
+      const sandboxId = await seedSandbox();
+      backupIds.push(await seedFullBackup(sandboxId, sampleState(`kms-floor-${i}`)));
+    }
+    resetKmsClientForTests();
+
+    const { alerts, alert } = makeAlertSpy();
+    const summary = await runBackupVerificationCycle({ config: CONFIG, alert });
+
+    expect(summary).toMatchObject({ sampled: 5, verified: 0, failed: 5, escalated: true });
+    expect(summary.failures.map((f) => f.kind)).toEqual([
+      "key-unavailable",
+      "key-unavailable",
+      "key-unavailable",
+      "key-unavailable",
+      "key-unavailable",
+    ]);
+    for (const backupId of backupIds) {
+      expect((await readBackupRow(backupId)).verification_error).toStartWith("key-unavailable:");
+    }
     const systemic = alerts.find((a) => a.dedupKey === "agent-backup-verification-systemic");
     expect(systemic).toBeDefined();
     expect(systemic?.message).toContain("KMS misconfiguration");
-    expect(systemic?.details.keyUnavailable).toBe(2);
+    expect(systemic?.details.keyUnavailable).toBe(5);
+  });
+
+  test("missing R2 payload thrown as NoSuchKey is stamped payload-missing and cannot wedge sampling", async () => {
+    expect(pgliteReady).toBe(true);
+    const sandboxId = await seedSandbox();
+    const missingKey = "agent-backups/missing/state_data.json";
+    const missingError = new Error("NoSuchKey: object does not exist");
+    missingError.name = "NoSuchKey";
+    setRuntimeR2Bucket({
+      async get() {
+        throw missingError;
+      },
+      async put() {},
+      async delete() {},
+    } satisfies RuntimeR2Bucket);
+    const [backup] = await dbWrite
+      .insert(agentSandboxBackups)
+      .values({
+        sandbox_record_id: sandboxId,
+        snapshot_type: "auto",
+        state_data: sampleState("r2-preview"),
+        state_data_storage: "r2",
+        state_data_key: missingKey,
+        size_bytes: 1024,
+        backup_kind: "full",
+        content_hash: computeStateHash(sampleState("r2-preview")),
+      })
+      .returning();
+    expect(backup).toBeDefined();
+    const now = new Date("2026-07-09T00:00:00Z");
+    const { alerts, alert } = makeAlertSpy();
+
+    const summary = await runBackupVerificationCycle({ config: CONFIG, alert, now: () => now });
+
+    expect(summary).toMatchObject({ sampled: 1, verified: 0, failed: 1, errored: 0 });
+    expect(summary.failures[0]).toMatchObject({
+      backupId: backup.id,
+      kind: "payload-missing",
+    });
+    const row = await readBackupRow(backup.id);
+    expect(row.verification_status).toBe("failed");
+    expect(row.verified_at?.getTime()).toBe(now.getTime());
+    expect(row.verification_error).toStartWith("payload-missing:");
+    expect(alerts.map((a) => a.dedupKey)).toEqual(["agent-backup-verification-failure"]);
+  });
+
+  test("verifier infrastructure errors stamp verified_at and alert without marking backup failed", async () => {
+    expect(pgliteReady).toBe(true);
+    const sandboxId = await seedSandbox();
+    const [backup] = await dbWrite
+      .insert(agentSandboxBackups)
+      .values({
+        sandbox_record_id: sandboxId,
+        snapshot_type: "auto",
+        state_data: sampleState("r2-preview"),
+        state_data_storage: "r2",
+        state_data_key: "agent-backups/configured-nowhere/state_data.json",
+        size_bytes: 1024,
+        backup_kind: "full",
+        content_hash: computeStateHash(sampleState("r2-preview")),
+      })
+      .returning();
+    expect(backup).toBeDefined();
+    const now = new Date("2026-07-09T01:00:00Z");
+    const { alerts, alert } = makeAlertSpy();
+
+    // Force inline heavy-payload mode so resolving the r2 row is a
+    // deterministic no-object-storage-configured infra error on this host.
+    let summary: Awaited<ReturnType<typeof runBackupVerificationCycle>> | undefined;
+    await withEnv({ SQL_HEAVY_PAYLOAD_STORAGE: "inline" }, async () => {
+      summary = await runBackupVerificationCycle({ config: CONFIG, alert, now: () => now });
+    });
+
+    expect(summary).toMatchObject({ sampled: 1, verified: 0, failed: 0, errored: 1 });
+    const row = await readBackupRow(backup.id);
+    // `errored`, never `failed`: the backup itself may be healthy. The
+    // bracketed counter is the row's consecutive-attempt error streak.
+    expect(row.verification_status).toBe("errored");
+    expect(row.verified_at?.getTime()).toBe(now.getTime());
+    expect(row.verification_error).toStartWith("infra-error[1]:");
+    expect(alerts.map((a) => a.dedupKey)).toEqual(["agent-backup-verification-error"]);
   });
 
   test("content_hash drift on an otherwise-decryptable backup is stamped hash-mismatch", async () => {
@@ -696,10 +804,10 @@ describe("runBackupVerificationCycle (real PGlite + real memory KMS)", () => {
     expect(alerts).toHaveLength(0);
   });
 
-  test("systemic floor: 1-of-1 failure fires the per-row alert but NOT the systemic page", async () => {
-    if (!pgliteReady) return;
+  test("systemic floor is tunable: with a floor of 1, a 1-of-1 failure escalates", async () => {
+    expect(pgliteReady).toBe(true);
     const sandboxId = await seedSandbox();
-    const backupId = await seedFullBackup(sandboxId, sampleState("floor"));
+    const backupId = await seedFullBackup(sandboxId, sampleState("floor-tuned"));
     const stored = await readBackupRow(backupId);
     const envelope = stored.state_data as EncryptedAgentBackupStateData;
     const tampered =
@@ -712,17 +820,19 @@ describe("runBackupVerificationCycle (real PGlite + real memory KMS)", () => {
 
     const { alerts, alert } = makeAlertSpy();
     const summary = await runBackupVerificationCycle({
-      config: { ...CONFIG, minSystemicSample: 5 },
+      config: { ...CONFIG, minSystemicSample: 1 },
       alert,
     });
 
-    // 100% failure rate, but one sampled row is no fleet-wide signature.
-    expect(summary).toMatchObject({ sampled: 1, failed: 1, escalated: false });
-    expect(alerts.map((a) => a.dedupKey)).toEqual(["agent-backup-verification-failure"]);
+    expect(summary).toMatchObject({ sampled: 1, failed: 1, escalated: true });
+    expect(alerts.map((a) => a.dedupKey)).toEqual([
+      "agent-backup-verification-failure",
+      "agent-backup-verification-systemic",
+    ]);
   });
 
   test("errored row is stamped with the attempt and cannot head-of-line-block the next cycle", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const sandboxBad = await seedSandbox();
     const sandboxGood = await seedSandbox();
     const now = new Date();
@@ -740,8 +850,6 @@ describe("runBackupVerificationCycle (real PGlite + real memory KMS)", () => {
     const config = { ...CONFIG, batchSize: 1 };
     const { alerts, alert } = makeAlertSpy();
 
-    // Force inline heavy-payload mode so resolving the r2 row is a
-    // deterministic no-object-storage-configured infra error on this host.
     await withEnv({ SQL_HEAVY_PAYLOAD_STORAGE: "inline" }, async () => {
       // Cycle 1 samples the older broken row: infra error, stamped `errored`
       // with the attempt timestamp — NOT `failed`.
@@ -759,13 +867,14 @@ describe("runBackupVerificationCycle (real PGlite + real memory KMS)", () => {
       expect((await readBackupRow(good.id)).verification_status).toBe("verified");
     });
 
-    // Infra errors are not backup failures: no failure/systemic alert, and
-    // the errored-streak alert has not reached its threshold yet.
-    expect(alerts).toHaveLength(0);
+    // Infra errors are not backup failures: only the cycle-level infra alert
+    // fired (from cycle 1); no failure/systemic alert, and the per-row
+    // persistent-error alert has not reached its streak threshold.
+    expect(alerts.map((a) => a.dedupKey)).toEqual(["agent-backup-verification-error"]);
   });
 
-  test("a row that errors N consecutive attempts raises the errored-streak alert", async () => {
-    if (!pgliteReady) return;
+  test("a row that errors N consecutive attempts raises the persistent-error alert", async () => {
+    expect(pgliteReady).toBe(true);
     const sandboxId = await seedSandbox();
     const t0 = new Date();
     const badId = await seedUnfetchableR2Backup(sandboxId, new Date(t0.getTime() - 60_000));
@@ -775,7 +884,7 @@ describe("runBackupVerificationCycle (real PGlite + real memory KMS)", () => {
     await withEnv({ SQL_HEAVY_PAYLOAD_STORAGE: "inline" }, async () => {
       const first = await runBackupVerificationCycle({ config, alert, now: () => t0 });
       expect(first.errored).toBe(1);
-      expect(alerts).toHaveLength(0);
+      expect(alerts.map((a) => a.dedupKey)).toEqual(["agent-backup-verification-error"]);
 
       // The next attempt happens a re-verify interval later and errors again.
       const t1 = new Date(t0.getTime() + config.reVerifyIntervalMs + 60_000);
@@ -785,14 +894,22 @@ describe("runBackupVerificationCycle (real PGlite + real memory KMS)", () => {
 
     const row = await readBackupRow(badId);
     expect(row.verification_error).toStartWith("infra-error[2]:");
-    expect(alerts).toHaveLength(1);
-    expect(alerts[0].dedupKey).toBe("agent-backup-verification-errored");
-    expect(alerts[0].details.streak).toBe(2);
-    expect(alerts[0].details.backupId).toBe(badId);
+    // Cycle 2 adds the per-row persistent-error alert (streak threshold hit)
+    // ahead of its cycle-level infra alert.
+    expect(alerts.map((a) => a.dedupKey)).toEqual([
+      "agent-backup-verification-error",
+      "agent-backup-verification-persistent-error",
+      "agent-backup-verification-error",
+    ]);
+    const persistent = alerts.find(
+      (a) => a.dedupKey === "agent-backup-verification-persistent-error",
+    );
+    expect(persistent?.details.streak).toBe(2);
+    expect(persistent?.details.backupId).toBe(badId);
   });
 
   test("payload larger than the whole cycle budget is a bounded skip stamped errored", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const sandboxId = await seedSandbox();
     const backupId = await seedFullBackup(sandboxId, sampleState("oversize"));
     const config = { ...CONFIG, maxDecryptBytesPerCycle: 16 };
@@ -814,6 +931,7 @@ describe("runBackupVerificationCycle (real PGlite + real memory KMS)", () => {
     expect(row.verification_error).toMatch(
       /^infra-error\[1\]: stored payload of \d+ bytes exceeds BACKUP_VERIFICATION_MAX_DECRYPT_BYTES=16$/,
     );
+    // A bounded skip is neither a failure nor a cycle-level infra error.
     expect(alerts).toHaveLength(0);
 
     // Stamped: the next cycle inside the re-verify interval moves on.
@@ -822,7 +940,7 @@ describe("runBackupVerificationCycle (real PGlite + real memory KMS)", () => {
   });
 
   test("cycle budget exhaustion defers the remainder, unstamped, to the next cycle", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const sandboxA = await seedSandbox();
     const sandboxB = await seedSandbox();
     const now = new Date();
@@ -946,7 +1064,7 @@ describe("r2-offloaded backups (real S3 client against a local object-store stub
   }
 
   test("R2 payload lost out from under the row (NoSuchKey) stamps payload-missing and alerts", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const sandboxId = await seedSandbox();
     const state = sampleState("r2-missing");
     const backup = await agentSandboxesRepository.createBackup({
@@ -972,11 +1090,11 @@ describe("r2-offloaded backups (real S3 client against a local object-store stub
     expect(row.verified_at).not.toBeNull();
     expect(row.verification_error).toStartWith("payload-missing:");
     expect(row.verification_error).toContain(key);
-    expect(alerts.map((a) => a.dedupKey)).toContain("agent-backup-verification-failure");
+    expect(alerts.map((a) => a.dedupKey)).toEqual(["agent-backup-verification-failure"]);
   });
 
   test("r2-offloaded backup verifies end to end through download + decrypt", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const sandboxId = await seedSandbox();
     const state = sampleState("r2-happy");
     const backup = await agentSandboxesRepository.createBackup({
@@ -998,7 +1116,7 @@ describe("r2-offloaded backups (real S3 client against a local object-store stub
   });
 
   test("incremental verification fetches ONLY chain members from object storage", async () => {
-    if (!pgliteReady) return;
+    expect(pgliteReady).toBe(true);
     const sandboxId = await seedSandbox();
     const now = Date.now();
 

--- a/packages/cloud/shared/src/lib/services/agent-backup-verifier.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-verifier.ts
@@ -30,8 +30,10 @@
  *
  * Verifier-infrastructure errors (DB/object-storage/KMS transport breakage)
  * are stamped `errored` with the attempt timestamp so a persistently-broken
- * row cannot occupy the head of the nulls-first sampler forever (#15626); a
- * row that keeps erroring across consecutive attempts raises its own alert.
+ * row cannot occupy the head of the nulls-first sampler forever (#15626).
+ * Two alerts cover them: a cycle-level alert whenever a sweep hit infra
+ * errors (immediate signal that the verifier host is broken), and a per-row
+ * alert when the SAME row keeps erroring across consecutive attempts.
  * Incremental chains are reconstructed here chain-only and sequentially —
  * NOT via the repository's `getReconstructedBackupState`, which hydrates and
  * decrypts every retained backup in parallel for the restore path — and all
@@ -121,9 +123,8 @@ export interface BackupVerifierConfig {
   /**
    * `BACKUP_VERIFICATION_ERRORED_ALERT_STREAK` — alert when the same backup
    * row hits a verifier-infrastructure error this many verification attempts
-   * in a row. Infra errors are not stamped `failed` (the backup may be fine),
-   * so without this a row stuck behind broken storage/KMS transport would
-   * never surface anywhere but the logs.
+   * in a row. The cycle-level infra alert says "this sweep hit errors"; this
+   * one says "this specific backup has been unverifiable for N attempts".
    */
   erroredAlertStreak: number;
 }
@@ -229,19 +230,35 @@ export function classifyCryptoError(error: unknown): BackupVerificationFailure |
   if (error.name === "KeyNotFoundError" || /key not found/i.test(error.message)) {
     return { kind: "key-unavailable", message: error.message };
   }
-  // The steward backend reports a missing key as a generic KmsError with an
-  // HTTP 404 — same #15310 signature as the memory backend's
-  // KeyNotFoundError, so it must classify the same way instead of falling
-  // through to unstamped infra-error. Message match is the fallback for
-  // KmsError instances serialized without the structured status.
-  if (error.name === "KmsError") {
-    const status = (error as { status?: unknown }).status;
-    if (status === 404 || /failed \(404[\s)]/.test(error.message)) {
-      return { kind: "key-unavailable", message: error.message };
-    }
+  // The steward backend reports a missing key as a generic KmsError carrying
+  // the HTTP status — same #15310 signature as the memory backend's
+  // KeyNotFoundError. Message text is the fallback for errors serialized
+  // without the structured status.
+  const kmsShaped = error as { status?: unknown; $metadata?: { httpStatusCode?: unknown } };
+  const maybeStatus = kmsShaped.status ?? kmsShaped.$metadata?.httpStatusCode;
+  if (
+    error.name === "KmsError" &&
+    (maybeStatus === 404 || /\b404\b|not found/i.test(error.message))
+  ) {
+    return { kind: "key-unavailable", message: error.message };
   }
   if (error.name === "AeadError" || /AEAD decrypt failed/i.test(error.message)) {
     return { kind: "decrypt-failed", message: error.message };
+  }
+  return null;
+}
+
+function classifyMissingObjectPayload(error: unknown): BackupVerificationFailure | null {
+  if (!(error instanceof Error)) return null;
+  const maybeStatus = (error as { $metadata?: { httpStatusCode?: unknown }; status?: unknown })
+    .$metadata?.httpStatusCode;
+  if (
+    error.name === "NoSuchKey" ||
+    error.name === "NotFound" ||
+    maybeStatus === 404 ||
+    /no such key|not found/i.test(error.message)
+  ) {
+    return { kind: "payload-missing", message: error.message };
   }
   return null;
 }
@@ -250,6 +267,8 @@ export function classifyCryptoError(error: unknown): BackupVerificationFailure |
 function classifyChainError(error: unknown): BackupVerificationFailure | null {
   const crypto = classifyCryptoError(error);
   if (crypto) return crypto;
+  const missingPayload = classifyMissingObjectPayload(error);
+  if (missingPayload) return missingPayload;
   if (!(error instanceof Error)) return null;
   if (/payload not found|missing state_data_key/i.test(error.message)) {
     return { kind: "payload-missing", message: error.message };
@@ -427,19 +446,6 @@ export function verifyManifestIntegrity(manifest: AgentBackupManifest): string[]
 // =============================================================================
 
 /**
- * True for the S3/R2 "object does not exist" error family (AWS SDK v3 throws
- * `NoSuchKey` from GetObject, `NotFound` from HeadObject, both HTTP 404). The
- * daemon path's `getObjectText` throws these instead of returning null, and a
- * lost payload is a broken BACKUP (stamped + alerted), not verifier breakage.
- */
-function isObjectStorageMissingError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-  if (error.name === "NoSuchKey" || error.name === "NotFound") return true;
-  const meta = (error as { $metadata?: { httpStatusCode?: number } }).$metadata;
-  return meta?.httpStatusCode === 404;
-}
-
-/**
  * Byte budget shared by every download+decrypt in one verification cycle.
  * Charged with the STORED payload size (ciphertext ≈ plaintext for AES-GCM),
  * measured before decrypting, so the bound holds even for payloads that would
@@ -508,13 +514,14 @@ async function resolveStoredPayload(
   try {
     raw = await getObjectText(row.state_data_key);
   } catch (error) {
-    if (isObjectStorageMissingError(error)) {
+    const missingPayload = classifyMissingObjectPayload(error);
+    if (missingPayload) {
+      // Name the lost key: the stamped verification_error is an operator's
+      // only lead when triaging which object vanished.
       return {
         failure: {
           kind: "payload-missing",
-          message: `object storage has no payload for ${row.state_data_key}: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
+          message: `object storage has no payload for ${row.state_data_key}: ${missingPayload.message}`,
         },
       };
     }
@@ -763,8 +770,8 @@ export interface BackupVerificationCycleSummary {
   failed: number;
   /**
    * Verifier-infrastructure errors — stamped `errored` (never `failed`) with
-   * the attempt timestamp so they cannot starve the sampler; alerted when the
-   * same row keeps erroring.
+   * the attempt timestamp so they cannot starve the sampler; alerted at cycle
+   * level, and per-row once the same row keeps erroring.
    */
   errored: number;
   /** Rows whose payload can never fit the cycle decrypt budget (stamped `errored`). */
@@ -779,8 +786,9 @@ export interface BackupVerificationCycleSummary {
 }
 
 const FAILURE_ALERT_DEDUP_KEY = "agent-backup-verification-failure";
+const ERROR_ALERT_DEDUP_KEY = "agent-backup-verification-error";
 const SYSTEMIC_ALERT_DEDUP_KEY = "agent-backup-verification-systemic";
-const ERRORED_ALERT_DEDUP_KEY = "agent-backup-verification-errored";
+const PERSISTENT_ERROR_ALERT_DEDUP_KEY = "agent-backup-verification-persistent-error";
 
 /**
  * `verification_error` prefix for infra-error stamps. The bracketed integer is
@@ -857,7 +865,8 @@ export async function runBackupVerificationCycle(
   // Stamp an infra-error attempt: status `errored` (never `failed` — the
   // backup itself may be healthy), attempt timestamp so the nulls-first
   // sampler moves on, and a persisted consecutive-attempt streak that raises
-  // its own alert once it crosses the configured threshold.
+  // a per-row alert once it crosses the configured threshold (the cycle-level
+  // infra alert at the end of the sweep covers the immediate signal).
   const stampInfraError = async (row: StoredAgentSandboxBackup, message: string) => {
     const streak = consecutiveInfraErrorStreak(row) + 1;
     await dbWrite
@@ -882,7 +891,7 @@ export async function runBackupVerificationCycle(
           streak,
           error: message,
         },
-        dedupKey: ERRORED_ALERT_DEDUP_KEY,
+        dedupKey: PERSISTENT_ERROR_ALERT_DEDUP_KEY,
       });
     }
     return streak;
@@ -901,7 +910,7 @@ export async function runBackupVerificationCycle(
       summary.errored += 1;
       const message = error instanceof Error ? error.message : String(error);
       const streak = await stampInfraError(row, message);
-      logger.error("[AgentBackupVerifier] verification errored (infrastructure, stamped errored)", {
+      logger.error("[AgentBackupVerifier] verification errored (infrastructure)", {
         backupId: row.id,
         sandboxRecordId: row.sandbox_record_id,
         erroredStreak: streak,
@@ -1025,6 +1034,21 @@ export async function runBackupVerificationCycle(
         dedupKey: SYSTEMIC_ALERT_DEDUP_KEY,
       });
     }
+  }
+
+  if (summary.errored > 0) {
+    await alert({
+      title: `${summary.errored}/${summary.sampled} sampled agent backups could not be verified`,
+      message:
+        "Backup verification hit infrastructure errors. Rows were stamped with " +
+        "verified_at so they do not permanently wedge the sampler head; inspect " +
+        "verification_error for the exact infra failure and fix the verifier host.",
+      details: {
+        sampled: summary.sampled,
+        errored: summary.errored,
+      },
+      dedupKey: ERROR_ALERT_DEDUP_KEY,
+    });
   }
 
   return summary;


### PR DESCRIPTION
Follow-up to #15626. Restores hardening that was silently dropped by a merge race.

## What happened

Two PRs for issue #15626 landed on develop ~10 minutes apart:

- **#15640** (`fix/15626-backup-verifier-hardening`): NoSuchKey → payload-missing, steward 404 → key-unavailable, infra stamping, hardcoded systemic floor.
- **#15643** (`fix/backup-verifier-holes`): the full close-out — `errored` status stamping with persisted `infra-error[N]` streaks + streak alert, chain-only sequential reconstruction, per-cycle decrypt budget with bounded skips, env-tunable floor, ensure-schema index mirror, steward `KmsError.status`, S3-stub tests.

The #15643 merge commit (`0962f798b1b`) resolved the two overlapping files to its own side wholesale, which **dropped #15640's unique contributions** and also reverted this test file's #15636 hard-fail PGlite guards. Develop is currently green but missing that coverage.

## What this restores (the deliberate union)

- **`classifyCryptoError`**: KmsError 404 detection accepts the AWS-style `$metadata.httpStatusCode` shape and the broader `\b404\b` / `not found` message fallback, in addition to #15643's structured `KmsError.status`.
- **`classifyMissingObjectPayload`** (#15640's broader NoSuchKey/NotFound/404/message matcher) replaces the narrower local helper and is consulted by `classifyChainError` too.
- **Cycle-level infra alert restored** (`agent-backup-verification-error`): a sweep that hit verifier-infrastructure errors alerts immediately — the per-row streak alert alone would take N re-verify intervals (days) to notice a globally-broken verifier host. The per-row streak alert's dedup key is renamed `agent-backup-verification-persistent-error` so the two keys are not near-identical (`…-error` vs `…-errored`).
- **#15640's tests restored**, reconciled with the richer `errored` semantics: runtime-R2-binding NoSuchKey path (complements #15643's real-S3-client stub path), steward `$metadata` classification, infra stamping (now asserting `verification_status='errored'` + `infra-error[1]` prefix), 5-sample systemic escalation; small-sample escalation tests now use the production floor of 5, with an explicit test that the floor is tunable.
- **#15636's hard-fail guards** back in this test file (`expect(pgliteReady).toBe(true)`, no silent skips).

## Evidence

<details>
<summary>Verifier suite — 32/32 on real PGlite + real memory KMS + real S3 client vs local object-store stub</summary>

```
bun test src/lib/services/agent-backup-verifier.test.ts
 32 pass
 0 fail
 212 expect() calls
Ran 32 tests across 1 file. [4.90s]
```
</details>

<details>
<summary>Verify</summary>

```
biome check (2 files): clean
cloud/shared typecheck: no diagnostics in touched files
audit:error-policy-ratchet: no new fallback-slop in touched files
```
</details>

- Video walkthrough / screenshots / frontend logs / trajectories: N/A - backend daemon/service change, no UI or model-behavior surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)