### PR TITLE
feat(lifeops): project sent mail commitments

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/resolve-request.ts
+++ b/plugins/plugin-personal-assistant/src/actions/resolve-request.ts
@@ -39,6 +39,8 @@ import {
   ApprovalStateTransitionError,
   ApprovalTransitionConflictError,
 } from "../lifeops/approval-queue.types.js";
+import { extractCommitmentLedgerRecords } from "../lifeops/commitments/index.js";
+import { LifeOpsRepository } from "../lifeops/repository.js";
 import { LifeOpsService } from "../lifeops/service.js";
 import { executeApprovedBookTravel } from "./book-travel.js";
 import { dispatchApprovedSignatureRequest } from "./document.js";
@@ -221,6 +223,58 @@ function approvalChannelToCrossChannelSend(
   }
 }
 
+async function persistSentMailCommitments(args: {
+  runtime: IAgentRuntime;
+  request: ApprovalRequest;
+  sentAt: Date;
+}): Promise<void> {
+  if (args.request.action !== "send_email") return;
+  const payload = args.request.payload;
+  if (payload.action !== "send_email") return;
+  const adapter = (args.runtime as { adapter?: { db?: unknown } }).adapter;
+  if (!adapter?.db) {
+    logger.debug(
+      `[approval] commitment ledger unavailable for sent email approval ${args.request.id}; runtime has no SQL adapter`,
+    );
+    return;
+  }
+
+  const records = extractCommitmentLedgerRecords({
+    agentId: args.runtime.agentId,
+    source: "sent_mail",
+    sourceKey: `approval:${args.request.id}`,
+    text: payload.body,
+    observedAt: args.sentAt.toISOString(),
+    counterparty: payload.to.join(", ") || null,
+    metadata: {
+      approvalRequestId: args.request.id,
+      subject: payload.subject,
+      to: payload.to,
+      cc: payload.cc,
+      bcc: payload.bcc,
+      replyToMessageId: payload.replyToMessageId,
+    },
+  });
+  if (records.length === 0) return;
+
+  const repository = new LifeOpsRepository(args.runtime);
+  try {
+    for (const record of records) {
+      await repository.upsertCommitmentLedgerRecord(record);
+    }
+  } catch (error) {
+    // error-policy:J7 the sent email is already committed externally; report the
+    // projection failure without making the approval retriable and duplicating mail.
+    logger.warn(
+      `[approval] failed to project sent email approval ${args.request.id} into commitment ledger`,
+      error,
+    );
+    args.runtime.reportError?.("lifeops:commitment-ledger:sent-mail", error, {
+      requestId: args.request.id,
+    });
+  }
+}
+
 export async function executeApprovedRequest(args: {
   runtime: IAgentRuntime;
   queue: ApprovalQueue;
@@ -261,6 +315,11 @@ export async function executeApprovedRequest(args: {
       });
     }
     const done = await args.queue.markDone(args.request.id);
+    await persistSentMailCommitments({
+      runtime: args.runtime,
+      request: args.request,
+      sentAt: done.updatedAt,
+    });
     const text =
       payload.to.length > 0
         ? `Approved and sent email to ${payload.to.join(", ")}.`

--- a/plugins/plugin-personal-assistant/test/resolve-request-executor.test.ts
+++ b/plugins/plugin-personal-assistant/test/resolve-request-executor.test.ts
@@ -125,6 +125,7 @@ import type {
   ApprovalRequestState,
   ApprovalResolution,
 } from "../src/lifeops/approval-queue.types.js";
+import { LifeOpsRepository } from "../src/lifeops/repository.js";
 import { LifeOpsService } from "../src/lifeops/service.js";
 
 function makeRuntime(): IAgentRuntime {
@@ -401,6 +402,64 @@ describe("executeApprovedRequest", () => {
       executeApprovedRequest({ runtime, queue, request }),
     ).rejects.toThrow("Google Calendar is not connected");
     expect(queue.transitions).toEqual(["executing"]);
+  });
+
+  it("send_email approval projects sent-mail commitments into the ledger after delivery", async () => {
+    const runtime = {
+      ...makeRuntime(),
+      adapter: { db: {} },
+      reportError: vi.fn(),
+    } as unknown as IAgentRuntime;
+    const request = approvedRequest({
+      action: "send_email",
+      payload: {
+        action: "send_email",
+        to: ["mira@example.com"],
+        cc: [],
+        bcc: [],
+        subject: "Launch deck",
+        body: "I'll send the deck by 2026-07-10 and include the pricing appendix.",
+        replyToMessageId: null,
+      },
+    });
+    const queue = new RecordingQueue(request);
+    const sendSpy = vi
+      .spyOn(LifeOpsService.prototype, "sendGmailMessage")
+      .mockResolvedValue({ ok: true });
+    const upsertSpy = vi
+      .spyOn(LifeOpsRepository.prototype, "upsertCommitmentLedgerRecord")
+      .mockResolvedValue();
+    const { texts, callback } = collectTexts();
+
+    const result = await executeApprovedRequest({
+      runtime,
+      queue,
+      request,
+      callback,
+    });
+
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(queue.transitions).toEqual(["executing", "done"]);
+    expect(upsertSpy).toHaveBeenCalledTimes(1);
+    expect(upsertSpy.mock.calls[0]?.[0]).toMatchObject({
+      agentId: runtime.agentId,
+      source: "sent_mail",
+      sourceKey: `approval:${request.id}`,
+      kind: "commitment",
+      counterparty: "mira@example.com",
+      dueAt: "2026-07-10T17:00:00.000Z",
+      status: "open",
+      scheduledTaskId: null,
+      metadata: {
+        approvalRequestId: request.id,
+        subject: "Launch deck",
+        to: ["mira@example.com"],
+      },
+    });
+    expect(upsertSpy.mock.calls[0]?.[0].summary).toContain("send the deck");
+    expect(runtime.reportError).not.toHaveBeenCalled();
+    expect(result.success).toBe(true);
+    expect(texts.join(" ")).toContain("mira@example.com");
   });
 
   it("make_call approval without Twilio credentials fails honestly and stays retriable", async () => {


### PR DESCRIPTION
Refs #14864

## Summary
- project successfully approved Gmail sends into the commitment ledger when the sent body contains a concrete promise
- use `source: "sent_mail"` with `approval:<requestId>` source keys and preserve approval metadata (subject, recipients, reply id) on the ledger row
- keep already-sent email non-retriable if the ledger projection fails by marking the approval done first and reporting the projection failure through `runtime.reportError`

## Evidence
<!-- evidence-row:before-screenshots -->
- N/A - backend/domain approval execution change; no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- N/A - backend/domain approval execution change; no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- N/A - backend/domain approval execution change; no user-facing UI flow changed.
<!-- evidence-row:backend-logs -->
- N/A - no live backend deployed for this deterministic persistence slice; local proof passed: `meeting` not involved, `resolve-request-executor.test.ts` + `commitment-ledger.test.ts` 20 tests, `bun run --cwd plugins/plugin-personal-assistant build`, `git diff --check`, and `bun run audit:error-policy-ratchet`.
<!-- evidence-row:frontend-logs -->
- N/A - no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- N/A - deterministic sent-mail projection slice; no model prompt/action/provider behavior changed. #14864 still needs live model extraction trajectories before closure.
<!-- evidence-row:domain-artifacts -->
- N/A - no deploy artifact attached; domain artifact was asserted in `resolve-request-executor.test.ts` by approving a `send_email` request and inspecting the `LifeOpsRepository.upsertCommitmentLedgerRecord` row for `source: "sent_mail"`, `sourceKey: approval:<requestId>`, due date `2026-07-10T17:00:00.000Z`, recipient counterparty, and approval metadata.