### PR TITLE
fix(lifeops): avoid duplicate meeting ghost approvals

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/meeting-ghost/consumer.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/meeting-ghost/consumer.ts
@@ -23,7 +23,10 @@
 import type { IAgentRuntime } from "@elizaos/core";
 import { logger } from "@elizaos/core";
 import { createApprovalQueue } from "../approval-queue.js";
-import type { ApprovalRequest } from "../approval-queue.types.js";
+import type {
+  ApprovalEnqueueInput,
+  ApprovalRequest,
+} from "../approval-queue.types.js";
 import { LifeOpsRepository } from "../repository.js";
 import {
   analyzeMeetingGhostTranscript,
@@ -40,10 +43,56 @@ export interface RunMeetingGhostInput {
 
 export interface MeetingGhostRunResult {
   readonly analysis: MeetingGhostAnalysis;
-  /** Approval requests created in the queue (follow-ups then calendar deadlines). */
+  /**
+   * Approval requests for this run (follow-ups then calendar deadlines). A
+   * retry returns matching existing requests instead of duplicating owner prompts.
+   */
   readonly enqueued: readonly ApprovalRequest[];
   /** Commitment ledger ids persisted for extracted transcript commitments. */
   readonly commitmentLedgerIds: readonly string[];
+}
+
+function stablePayloadJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stablePayloadJson).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stablePayloadJson(record[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function sameApprovalRequest(
+  request: ApprovalRequest,
+  input: ApprovalEnqueueInput,
+): boolean {
+  return (
+    request.requestedBy === input.requestedBy &&
+    request.subjectUserId === input.subjectUserId &&
+    request.action === input.action &&
+    request.channel === input.channel &&
+    request.reason === input.reason &&
+    stablePayloadJson(request.payload) === stablePayloadJson(input.payload)
+  );
+}
+
+async function enqueueOrReuseApproval(
+  queue: ReturnType<typeof createApprovalQueue>,
+  request: ApprovalEnqueueInput,
+): Promise<ApprovalRequest> {
+  const existing = await queue.list({
+    subjectUserId: request.subjectUserId,
+    state: null,
+    action: request.action,
+    limit: 500,
+  });
+  const match = existing.find((entry) => sameApprovalRequest(entry, request));
+  if (match) return match;
+  return queue.enqueue(request);
 }
 
 /**
@@ -70,7 +119,7 @@ export async function runMeetingGhostForTranscript(
   const queue = createApprovalQueue(runtime, { agentId: input.agentId });
   const enqueued: ApprovalRequest[] = [];
   for (const request of requests) {
-    enqueued.push(await queue.enqueue(request));
+    enqueued.push(await enqueueOrReuseApproval(queue, request));
   }
 
   const adapter = (runtime as { adapter?: { db?: unknown } }).adapter;

--- a/plugins/plugin-personal-assistant/test/meeting-ghost.integration.test.ts
+++ b/plugins/plugin-personal-assistant/test/meeting-ghost.integration.test.ts
@@ -193,6 +193,61 @@ describe("meeting-ghost consumer (real approval queue)", () => {
       ]),
     );
 
+    const rerun = await runMeetingGhostForTranscript(runtime, {
+      agentId: runtime.agentId,
+      owner: {
+        ownerUserId: "owner-mtg-1",
+        ownerDisplayName: "Shaw",
+        requestedBy: "meeting-ghost",
+        careAbouts: ["launch date"],
+        calendarId: "primary",
+        approvalExpiresAt,
+      },
+      transcript: {
+        meetingId: "ops-sync-integration",
+        title: "Ops Sync",
+        startedAt: "2026-07-06T16:00:00.000Z",
+        attendees: [
+          { name: "Ava", email: "ava@example.com" },
+          { name: "Ben", email: "ben@example.com" },
+        ],
+        segments: [
+          seg("Ava", 0, "Morning, nothing blocking on my side."),
+          seg(
+            "Mira",
+            60_000,
+            "Ava will send the launch-date rollback plan by 2026-07-10.",
+          ),
+          seg(
+            "Mira",
+            120_000,
+            "Ben is going to update the public calendar by 2026-07-10.",
+          ),
+        ],
+      },
+    });
+    expect(rerun.enqueued.map((request) => request.id).sort()).toEqual(
+      result.enqueued.map((request) => request.id).sort(),
+    );
+    const pendingAfterRerun = await queue.list({
+      subjectUserId: "owner-mtg-1",
+      state: "pending",
+      action: null,
+      limit: 20,
+    });
+    expect(pendingAfterRerun).toHaveLength(pending.length);
+    const ledgerRowsAfterRerun = await repo.listCommitmentLedgerRecords(
+      runtime.agentId,
+      {
+        source: "transcript",
+      },
+    );
+    expect(
+      ledgerRowsAfterRerun.filter((row) =>
+        row.sourceKey.startsWith("ops-sync-integration:"),
+      ),
+    ).toHaveLength(2);
+
     const firstEmail = result.enqueued.find((r) => r.action === "send_email");
     if (!firstEmail) throw new Error("expected a send_email approval");
     const approved = await queue.approve(firstEmail.id, {


### PR DESCRIPTION
Refs #14870 and follows #15651.

## Summary
- Reuses matching existing meeting-ghost approval requests on transcript reruns instead of duplicating owner prompts.
- Keeps ledger persistence idempotent and adds real-runtime/PGlite coverage that rerunning the same transcript returns the same approval IDs and leaves the meeting ledger at two rows.

## Verification
- `bunx @biomejs/biome check plugins/plugin-personal-assistant/src/lifeops/meeting-ghost/consumer.ts plugins/plugin-personal-assistant/test/meeting-ghost.integration.test.ts` - passed.
- `bun run --cwd plugins/plugin-personal-assistant test -- test/meeting-ghost.test.ts` - passed, 8 tests.
- `bunx vitest run --config plugins/plugin-personal-assistant/vitest.src-integration.config.ts plugins/plugin-personal-assistant/test/meeting-ghost.integration.test.ts` - passed, 1 real-runtime/PGlite test.
- `git diff --check` - passed.
- `bun run audit:error-policy-ratchet` - passed.

## Known gaps
- In the temporary `/tmp` worktree, `bun run --cwd plugins/plugin-personal-assistant build` could not resolve the package-local `tsup` bin, and `typecheck` hit existing unresolved workspace declaration errors from the borrowed dependency tree. The focused changed-file tests above ran successfully.

## Evidence
<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend/domain retry-idempotency change; no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend/domain retry-idempotency change; no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing UI flow changed.
<!-- evidence-row:backend-logs -->
- [x] [15654-backend-verification.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15654-backend-verification.log)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model/prompt/action behavior changed; deterministic retry guard only.
<!-- evidence-row:domain-artifacts -->
- [x] [15654-domain-artifacts.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15654-domain-artifacts.log)
