### PR TITLE
chore(mvp): report unverified scenario catalog rows

### DIFF
--- a/packages/scripts/__tests__/lifeops-catalog-coverage.test.ts
+++ b/packages/scripts/__tests__/lifeops-catalog-coverage.test.ts
@@ -1,0 +1,57 @@
+// Exercises tests lifeops catalog coverage.test automation behavior against the real MVP scenario ledgers.
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+
+const scriptPath = join(
+  import.meta.dirname,
+  "../check-lifeops-persona-catalog-coverage.mjs",
+);
+
+function runCoverage(...args: string[]) {
+  const result = spawnSync(process.execPath, [scriptPath, ...args], {
+    encoding: "utf8",
+  });
+  expect(result.stderr).toBe("");
+  expect(result.status).toBe(0);
+  return result.stdout;
+}
+
+describe("LifeOps persona catalog coverage", () => {
+  test("JSON output includes unverified rows grouped by surface", () => {
+    const report = JSON.parse(runCoverage("--json"));
+    expect(report.errors).toEqual([]);
+
+    const g1 = report.packs.find(
+      (pack: { pack: string }) => pack.pack === "G1",
+    );
+    expect(g1).toMatchObject({
+      authored: 10,
+      verified: 0,
+      unverified: 10,
+      unverifiedBySurface: {
+        "lifeops-bench": 6,
+        "scenario-runner": 4,
+      },
+    });
+    expect(g1.unverifiedRows).toContainEqual(
+      expect.objectContaining({
+        id: "g1-apology-draft-requires-approval",
+        surface: "scenario-runner",
+      }),
+    );
+  });
+
+  test("--unverified prints a board-triage list without hiding surface blockers", () => {
+    const output = runCoverage("--unverified");
+    expect(output).toContain(
+      "G1 10/10 unverified (lifeops-bench:6, scenario-runner:4)",
+    );
+    expect(output).toContain(
+      "J1 10/10 unverified (lifeops-bench:3, scenario-runner:7)",
+    );
+    expect(output).toContain(
+      "Total: 150/296 authored rows still need verification",
+    );
+  });
+});

--- a/packages/scripts/check-lifeops-persona-catalog-coverage.mjs
+++ b/packages/scripts/check-lifeops-persona-catalog-coverage.mjs
@@ -49,6 +49,7 @@ const VALID_TIERS = new Set(["T1", "T2", "T3", "T4"]);
 const VALID_SURFACES = new Set(["lifeops-bench", "scenario-runner"]);
 const VALID_STATUSES = new Set(["planned", "authored", "verified"]);
 const JSON_MODE = process.argv.includes("--json");
+const UNVERIFIED_MODE = process.argv.includes("--unverified");
 
 function toPosix(value) {
   return value.replace(/\\/g, "/");
@@ -185,6 +186,8 @@ function summarize() {
     const entries = Array.isArray(catalog.scenarios) ? catalog.scenarios : [];
     let authored = 0;
     let verified = 0;
+    const unverified = [];
+    const unverifiedBySurface = {};
     for (const [index, entry] of entries.entries()) {
       const where = `${fileName}:scenarios[${index}]`;
       if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
@@ -217,7 +220,20 @@ function summarize() {
           errors.push(`${where}: ${surface} id "${id}" was not found`);
         }
       }
-      if (status === "verified") verified += 1;
+      if (status === "verified") {
+        verified += 1;
+      } else if (status === "authored") {
+        unverified.push({
+          id,
+          tier,
+          surface,
+          notes:
+            typeof entry.notes === "string" && entry.notes.trim().length > 0
+              ? entry.notes.trim()
+              : null,
+        });
+        unverifiedBySurface[surface] = (unverifiedBySurface[surface] ?? 0) + 1;
+      }
     }
     packs.push({
       file: fileName,
@@ -225,6 +241,9 @@ function summarize() {
       target: expectedTarget,
       authored,
       verified,
+      unverified: unverified.length,
+      unverifiedBySurface,
+      unverifiedRows: unverified,
     });
   }
 
@@ -238,6 +257,23 @@ function main() {
   const result = summarize();
   if (JSON_MODE) {
     console.log(JSON.stringify(result, null, 2));
+  } else if (UNVERIFIED_MODE) {
+    console.log("LifeOps persona scenario unverified rows");
+    for (const pack of result.packs.filter((entry) => entry.unverified > 0)) {
+      const bySurface = Object.entries(pack.unverifiedBySurface)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([surface, count]) => `${surface}:${count}`)
+        .join(", ");
+      console.log(
+        `${pack.pack.padEnd(2)} ${String(pack.unverified).padStart(2)}/${String(pack.authored).padEnd(2)} unverified (${bySurface}) ${pack.file}`,
+      );
+      for (const row of pack.unverifiedRows) {
+        console.log(`   - ${row.id} [${row.tier}, ${row.surface}]`);
+      }
+    }
+    console.log(
+      `Total: ${result.authored - result.verified}/${result.authored} authored rows still need verification`,
+    );
   } else {
     console.log("LifeOps persona scenario catalog coverage");
     for (const pack of result.packs) {


### PR DESCRIPTION
## Summary
- Extends `check-lifeops-persona-catalog-coverage.mjs --json` with `unverified`, `unverifiedBySurface`, and `unverifiedRows` per pack.
- Adds `--unverified` text mode so MVP board triage can see exactly which authored rows still need verification and whether each blocker is LifeOpsBench or scenario-runner surface.
- Adds a regression test for the G1/J1 breakdown and total unverified count.

## Verification
- `bun test packages/scripts/__tests__/lifeops-catalog-coverage.test.ts` - passed, 2 tests
- `node packages/scripts/check-lifeops-persona-catalog-coverage.mjs --json` - passed, `errors: []`
- `node packages/scripts/check-lifeops-persona-catalog-coverage.mjs --unverified` - passed, reports `150/296 authored rows still need verification`
- `bunx @biomejs/biome check --write packages/scripts/check-lifeops-persona-catalog-coverage.mjs packages/scripts/__tests__/lifeops-catalog-coverage.test.ts` - passed
- `git diff --check` - passed

## Evidence
<!-- evidence-row:before-screenshots -->
N/A - CLI/catalog verifier change; no UI pixels changed.

<!-- evidence-row:after-screenshots -->
N/A - CLI/catalog verifier change; no UI pixels changed.

<!-- evidence-row:walkthrough-video -->
N/A - CLI/catalog verifier change; no UI flow changed.

<!-- evidence-row:backend-logs -->
N/A - no backend runtime behavior changed.

<!-- evidence-row:frontend-logs -->
N/A - no frontend runtime behavior changed.

<!-- evidence-row:llm-trajectory -->
N/A - no prompt, model, provider, or agent-planning behavior changed.

<!-- evidence-row:domain-artifacts -->
N/A - CLI verifier artifact; `node packages/scripts/check-lifeops-persona-catalog-coverage.mjs --unverified` reports G1 `lifeops-bench:6, scenario-runner:4`, J1 `lifeops-bench:3, scenario-runner:7`, and total `150/296 authored rows still need verification`.