### PR TITLE
fix: harden agent deactivation follow-ups

### DIFF
--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -64,6 +64,9 @@ jobs:
                   if grep -Eq "from ['\"]vitest['\"]|require\\(['\"]vitest['\"]\\)" "$file"; then
                     continue
                   fi
+                  if grep -Eq "from ['\"]@playwright/test['\"]|require\\(['\"]@playwright/test['\"]\\)" "$file"; then
+                    continue
+                  fi
                   echo "$file"
                 done
             echo 'EOF'
@@ -76,6 +79,9 @@ jobs:
                   case "$file" in
                     *.e2e.test.*|*.live.test.*) continue ;;
                   esac
+                  if grep -Eq "from ['\"]@playwright/test['\"]|require\\(['\"]@playwright/test['\"]\\)" "$file"; then
+                    continue
+                  fi
                   if grep -Eq "from ['\"]vitest['\"]|require\\(['\"]vitest['\"]\\)" "$file"; then
                     echo "$file"
                   fi

--- a/packages/cloud/sdk/src/types.cloud-api.ts
+++ b/packages/cloud/sdk/src/types.cloud-api.ts
@@ -80,7 +80,10 @@ export type AgentSandboxStatus =
   | "provisioning"
   | "running"
   | "stopped"
+  | "sleeping"
   | "disconnected"
+  | "deletion_pending"
+  | "deletion_failed"
   | "error";
 
 export type AgentDatabaseStatus = "none" | "provisioning" | "ready" | "error";

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -571,6 +571,55 @@ describe("ElizaSandboxService wake", () => {
   );
 });
 
+describe("ElizaSandboxService sleep", () => {
+  test("aborts deactivation when no durable backup can be created or found", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const rec = customSandbox();
+    const provider: SandboxProvider = {
+      create: mock(async () => ({
+        sandboxId: "agent-e06bb509",
+        bridgeUrl: "https://runtime.example",
+        healthUrl: "https://runtime.example/health",
+      })),
+      stop: mock(async () => {}),
+      checkHealth: mock(async () => true),
+    };
+    globalThis.fetch = mock(async () => {
+      throw new Error("snapshot unavailable");
+    });
+    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrgForWrite").mockResolvedValue(
+      rec,
+    );
+    const latestBackupSpy = spyOn(agentSandboxesRepository, "getLatestBackup").mockResolvedValue(
+      undefined,
+    );
+    const createBackupSpy = spyOn(agentSandboxesRepository, "createBackup");
+    const updateSpy = spyOn(agentSandboxesRepository, "update");
+
+    try {
+      const result = await new ElizaSandboxService(provider).executeSleep(
+        rec.id,
+        rec.organization_id,
+      );
+
+      expect(result).toEqual({
+        success: false,
+        containerRemoved: false,
+        error:
+          "Unable to create or find a durable backup before deactivation; agent was left running.",
+      });
+      expect(provider.stop).not.toHaveBeenCalled();
+      expect(createBackupSpy).not.toHaveBeenCalled();
+      expect(updateSpy).not.toHaveBeenCalled();
+    } finally {
+      findSpy.mockRestore();
+      latestBackupSpy.mockRestore();
+      createBackupSpy.mockRestore();
+      updateSpy.mockRestore();
+    }
+  });
+});
+
 // C1b attribution guard (audit §C1b/§C5): provision() must NOT flip a docker-
 // backed sandbox to `running` when the provider handle carries no durable
 // node_id (metadata shape drift, or an empty-string nodeId). Such a row would be

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -4933,9 +4933,8 @@ export class ElizaSandboxService {
    * `agent_suspend` (which keeps the row's `sandbox_id` + managed DB for an
    * in-place resume), sleep frees the compute identity entirely:
    *   1. Capture a durable backup. A live `/api/snapshot` pull when the agent
-   *      is reachable, otherwise the agent's persisted config, otherwise the
-   *      latest existing backup — a restore point ALWAYS exists before we
-   *      destroy compute, so sleep never loses recoverable state.
+   *      is reachable, otherwise the latest existing backup. If neither exists,
+   *      sleep fails and leaves compute running so missing state is observable.
    *   2. Stop + drop the container (the provider `stop` removes it from the
    *      node).
    *   3. Clear the compute identity (`sandbox_id`, `node_id`, `container_name`,
@@ -4981,7 +4980,7 @@ export class ElizaSandboxService {
         });
         backupId = backup.id;
       } catch (error) {
-        logger.warn("[agent-sandbox] Sleep snapshot fetch failed; using fallback", {
+        logger.warn("[agent-sandbox] Sleep snapshot fetch failed; checking latest durable backup", {
           agentId,
           error: error instanceof Error ? error.message : String(error),
         });
@@ -4992,16 +4991,16 @@ export class ElizaSandboxService {
       if (existing) {
         backupId = existing.id;
       } else {
-        const fallback: AgentBackupStateData = {
-          memories: [],
-          config: (rec.agent_config as Record<string, unknown> | null) ?? {},
-          workspaceFiles: {},
+        logger.error("[agent-sandbox] Sleep aborted: no durable backup available", {
+          agentId,
+          sandboxRecordId: rec.id,
+        });
+        return {
+          success: false,
+          containerRemoved: false,
+          error:
+            "Unable to create or find a durable backup before deactivation; agent was left running.",
         };
-        const sizeBytes = Buffer.byteLength(JSON.stringify(fallback), "utf-8");
-        const backup = await agentSandboxesRepository.createBackup(
-          await this.buildBackupInput(rec.id, "pre-shutdown", fallback, sizeBytes),
-        );
-        backupId = backup.id;
       }
     }
 

--- a/packages/ui/src/cloud-ui/types/cloud-api.ts
+++ b/packages/ui/src/cloud-ui/types/cloud-api.ts
@@ -368,7 +368,10 @@ export type AgentSandboxStatus =
   | "provisioning"
   | "running"
   | "stopped"
+  | "sleeping"
   | "disconnected"
+  | "deletion_pending"
+  | "deletion_failed"
   | "error";
 
 export type AgentDatabaseStatus = "none" | "provisioning" | "ready" | "error";

--- a/packages/ui/src/cloud/instances/components/agent-actions.tsx
+++ b/packages/ui/src/cloud/instances/components/agent-actions.tsx
@@ -302,7 +302,7 @@ export function ElizaAgentActions({
             >
               {t("cloud.containers.agentActions.deactivatedPanel", {
                 defaultValue:
-                  "This agent is deactivated. It is not running and is not consuming hourly credits; its data is kept in an encrypted backup. Reactivate it anytime.",
+                  "This agent is deactivated. It is not running and is not consuming hourly credits; its data is kept in an encrypted backup. Reactivation restores the backup and requires available credits.",
               })}
             </p>
           </div>
@@ -544,13 +544,13 @@ export function ElizaAgentActions({
               <span className="block mt-2">
                 {t("cloud.containers.agentActions.deactivateBody2", {
                   defaultValue:
-                    "All of its data is saved in an encrypted backup — nothing is deleted.",
+                    "Before deactivation, Eliza saves an encrypted backup. If the backup cannot be saved, the agent stays running and billing continues.",
                 })}
               </span>
               <span className="block mt-2">
                 {t("cloud.containers.agentActions.deactivateBody3", {
                   defaultValue:
-                    "You can reactivate it anytime. Reactivation restores the backup and can take a few minutes.",
+                    "Reactivation restores the backup and can take a few minutes; it requires available credits.",
                 })}
               </span>
             </AlertDialogDescription>

--- a/packages/ui/src/cloud/instances/components/agent-cost-badge.tsx
+++ b/packages/ui/src/cloud/instances/components/agent-cost-badge.tsx
@@ -20,6 +20,11 @@ interface AgentCostBadgeProps {
   status: string;
 }
 
+function formatBadgeHourlyRate(rate: number, isIdle: boolean) {
+  if (isIdle && rate > 0 && rate < 0.01) return "<$0.01/hr";
+  return formatHourlyRate(rate);
+}
+
 export function AgentCostBadge({ status }: AgentCostBadgeProps) {
   const t = useT();
   const isRunning = status === "running" || status === "provisioning";
@@ -33,6 +38,7 @@ export function AgentCostBadge({ status }: AgentCostBadgeProps) {
     : isIdle
       ? AGENT_PRICING.IDLE_HOURLY_RATE
       : 0;
+  const hourlyRateLabel = formatBadgeHourlyRate(rate, isIdle);
 
   return (
     <Tooltip>
@@ -41,7 +47,7 @@ export function AgentCostBadge({ status }: AgentCostBadgeProps) {
           <span
             className={`inline-block size-1 rounded-full ${isRunning ? "bg-green-500/60" : "bg-white/40"}`}
           />
-          {formatHourlyRate(rate)}
+          {hourlyRateLabel}
         </span>
       </TooltipTrigger>
       <TooltipContent className="bg-neutral-900 border-white/10 text-xs">
@@ -72,7 +78,7 @@ export function AgentCostBadge({ status }: AgentCostBadgeProps) {
               {t("cloud.containers.costBadge.agent", { defaultValue: "agent" })}
             </p>
             <p className="text-white/60">
-              {formatHourlyRate(rate)} · {formatMonthlyEstimate(rate)}
+              {hourlyRateLabel} · {formatMonthlyEstimate(rate)}
             </p>
           </>
         )}

--- a/packages/ui/src/cloud/instances/components/eliza-agents-table.render.test.tsx
+++ b/packages/ui/src/cloud/instances/components/eliza-agents-table.render.test.tsx
@@ -107,9 +107,9 @@ describe("ElizaAgentsTable per-row view model", () => {
     ).toBe("notProvisioned");
     // Deactivation releases the container (sandbox_id cleared) but the agent
     // remains an established sandbox — never "Not provisioned".
-    expect(
-      derive({ status: "sleeping", sandbox_id: null }).runtimeKind,
-    ).toBe("sandbox");
+    expect(derive({ status: "sleeping", sandbox_id: null }).runtimeKind).toBe(
+      "sandbox",
+    );
   });
 
   it("hides standalone Web UI for shared rows even when the API returns a URL", () => {
@@ -174,7 +174,7 @@ describe("ElizaAgentsTable per-row view model", () => {
     expect(busyRunning.canSleep).toBe(false);
   });
 
-  it("renders a sleeping row as a designed state with a Reactivate action and zero-cost badge", () => {
+  it("renders sleeping and idle rates without conflating deactivated and idle billing", () => {
     const queryClient = new QueryClient({
       defaultOptions: {
         queries: { retry: false },
@@ -185,7 +185,13 @@ describe("ElizaAgentsTable per-row view model", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <ElizaAgentsTable
-          sandboxes={[row({ status: "sleeping", canonical_web_ui_url: null })]}
+          sandboxes={[
+            row({ status: "sleeping", canonical_web_ui_url: null }),
+            row({
+              id: "00000000-1111-2222-3333-555555555555",
+              status: "stopped",
+            }),
+          ]}
         />
       </QueryClientProvider>,
     );
@@ -201,6 +207,9 @@ describe("ElizaAgentsTable per-row view model", () => {
     ).toBeNull();
     // Billing transparency on the card itself: an explicit $0.00/hr.
     expect(screen.getAllByText("$0.00/hr").length).toBeGreaterThanOrEqual(1);
+    // Idle agents still bill at a low hourly rate, so they must not visually
+    // collapse to the deactivated zero-cost badge.
+    expect(screen.getAllByText("<$0.01/hr").length).toBeGreaterThanOrEqual(1);
   });
 
   it("requires a billing-transparency confirm before deactivating", async () => {
@@ -228,9 +237,11 @@ describe("ElizaAgentsTable per-row view model", () => {
       within(dialog).getByText(/stops consuming hourly credits/),
     ).toBeTruthy();
     expect(
-      within(dialog).getByText(/encrypted backup — nothing is deleted/),
+      within(dialog).getByText(/if the backup cannot be saved/i),
     ).toBeTruthy();
-    expect(within(dialog).getByText(/reactivate it anytime/i)).toBeTruthy();
+    expect(
+      within(dialog).getByText(/requires available credits/i),
+    ).toBeTruthy();
 
     // Cancel is a real exit: no job fired, dialog gone.
     await user.click(within(dialog).getByRole("button", { name: "Cancel" }));

--- a/packages/ui/src/cloud/instances/components/eliza-agents-table.tsx
+++ b/packages/ui/src/cloud/instances/components/eliza-agents-table.tsx
@@ -759,6 +759,7 @@ export function ElizaAgentsTable({
       toast.success(labels.alreadyDone);
       void refreshData();
     } catch (err) {
+      void refreshData();
       onError(err);
     } finally {
       setActionInProgress(null);
@@ -857,7 +858,7 @@ export function ElizaAgentsTable({
           defaultValue: "Agent deactivation",
         }),
         inProgress: t("cloud.elizaAgentsTable.deactivateInProgress", {
-          defaultValue: "Deactivation already in progress",
+          defaultValue: "Agent provisioning is still in progress",
         }),
         failed: t("cloud.elizaAgentsTable.deactivateFailed", {
           defaultValue: "Deactivate failed",
@@ -1749,13 +1750,13 @@ export function ElizaAgentsTable({
               <span className="block mt-2">
                 {t("cloud.containers.agentActions.deactivateBody2", {
                   defaultValue:
-                    "All of its data is saved in an encrypted backup — nothing is deleted.",
+                    "Before deactivation, Eliza saves an encrypted backup. If the backup cannot be saved, the agent stays running and billing continues.",
                 })}
               </span>
               <span className="block mt-2">
                 {t("cloud.containers.agentActions.deactivateBody3", {
                   defaultValue:
-                    "You can reactivate it anytime. Reactivation restores the backup and can take a few minutes.",
+                    "Reactivation restores the backup and can take a few minutes; it requires available credits.",
                 })}
               </span>
             </AlertDialogDescription>


### PR DESCRIPTION
Closes #15648

## Summary
- fail deactivation when no live snapshot or prior durable backup exists, leaving compute running instead of fabricating an empty backup
- refresh optimistic table rows after lifecycle request failures and tighten deactivation copy around backup failure and credit-gated reactivation
- distinguish idle low-rate billing from deactivated zero-rate billing, refresh stale status unions, and keep Playwright specs out of the coverage gate changed-test runners

## Tests
- bunx @biomejs/biome check --write packages/cloud/shared/src/lib/services/eliza-sandbox.ts packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts packages/ui/src/cloud/instances/components/agent-cost-badge.tsx packages/ui/src/cloud/instances/components/eliza-agents-table.tsx packages/ui/src/cloud/instances/components/agent-actions.tsx packages/ui/src/cloud/instances/components/eliza-agents-table.render.test.tsx packages/ui/src/cloud-ui/types/cloud-api.ts packages/cloud/sdk/src/types.cloud-api.ts
- git diff --check
- bun run --cwd packages/ui test src/cloud/instances/components/eliza-agents-table.render.test.tsx
- bun test packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts -t "aborts deactivation" (assertion passed; command exits after a root bunfig coverage WriteFailed while dumping the coverage table)

## Evidence
N/A - backend/UI unit regression only; no live cloud agent was deactivated in this branch.