### PR TITLE
feat(training): apply optimized context config hook

### DIFF
--- a/plugins/plugin-training/src/register-runtime.test.ts
+++ b/plugins/plugin-training/src/register-runtime.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests the training runtime hook that consumes optimized contextConfig
+ * artifacts. The fake runtime captures the pipeline hook directly so the test
+ * proves provider selection/order without booting cron jobs or model services.
+ */
+import {
+  OPTIMIZED_PROMPT_SERVICE,
+  OptimizedPromptService,
+  type PipelineHookSpec,
+} from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  OPTIMIZED_CONTEXT_CONFIG_HOOK_ID,
+  registerOptimizedContextConfigHook,
+} from "./register-runtime.js";
+
+function serviceWithContextConfig(
+  task: "context_routing" | "action_planner",
+): OptimizedPromptService {
+  const service = new OptimizedPromptService();
+  const writable = service as unknown as {
+    cache: Record<string, unknown>;
+  };
+  writable.cache[task] = {
+    loadedAt: Date.now(),
+    artifact: {
+      task,
+      optimizer: "gepa",
+      baseline: "baseline",
+      prompt: "optimized",
+      score: 0.9,
+      baselineScore: 0.5,
+      datasetId: "fixture",
+      datasetSize: 3,
+      generatedAt: "2026-07-09T00:00:00.000Z",
+      lineage: [],
+      contextConfig: {
+        providerSet: ["RECENT_MESSAGES", "FACTS"],
+        providerOrder: ["FACTS", "RECENT_MESSAGES"],
+      },
+    },
+  };
+  return service;
+}
+
+function fakeRuntime(service: OptimizedPromptService): {
+  runtime: {
+    getService: (name: string) => unknown;
+    registerPipelineHook: (spec: PipelineHookSpec) => void;
+    unregisterPipelineHook: (id: string) => void;
+  };
+  hooks: PipelineHookSpec[];
+  unregistered: string[];
+} {
+  const hooks: PipelineHookSpec[] = [];
+  const unregistered: string[] = [];
+  return {
+    hooks,
+    unregistered,
+    runtime: {
+      getService(name: string) {
+        return name === OPTIMIZED_PROMPT_SERVICE ? service : null;
+      },
+      registerPipelineHook(spec: PipelineHookSpec) {
+        hooks.push(spec);
+      },
+      unregisterPipelineHook(id: string) {
+        unregistered.push(id);
+      },
+    },
+  };
+}
+
+describe("registerOptimizedContextConfigHook", () => {
+  it("registers a compose_state_providers hook that filters and orders eligible providers", async () => {
+    const { runtime, hooks, unregistered } = fakeRuntime(
+      serviceWithContextConfig("context_routing"),
+    );
+    registerOptimizedContextConfigHook(runtime as never);
+
+    expect(unregistered).toEqual([OPTIMIZED_CONTEXT_CONFIG_HOOK_ID]);
+    expect(hooks).toHaveLength(1);
+    expect(hooks[0]).toMatchObject({
+      id: OPTIMIZED_CONTEXT_CONFIG_HOOK_ID,
+      phase: "compose_state_providers",
+      mutatesPrimary: true,
+    });
+
+    const ctx = {
+      phase: "compose_state_providers" as const,
+      providers: {
+        current: ["ACTIONS", "RECENT_MESSAGES", "FACTS", "PLATFORM"],
+      },
+      onlyInclude: false,
+      activeContexts: [],
+      includeList: null,
+      message: {},
+    };
+    await hooks[0].handler(runtime as never, ctx as never);
+
+    expect(ctx.providers.current).toEqual(["FACTS", "RECENT_MESSAGES"]);
+  });
+
+  it("leaves exact include-list compose calls untouched", async () => {
+    const { runtime, hooks } = fakeRuntime(
+      serviceWithContextConfig("context_routing"),
+    );
+    registerOptimizedContextConfigHook(runtime as never);
+    const ctx = {
+      phase: "compose_state_providers" as const,
+      providers: { current: ["ACTIONS", "RECENT_MESSAGES", "FACTS"] },
+      onlyInclude: true,
+      activeContexts: [],
+      includeList: ["ACTIONS"],
+      message: {},
+    };
+
+    await hooks[0].handler(runtime as never, ctx as never);
+
+    expect(ctx.providers.current).toEqual([
+      "ACTIONS",
+      "RECENT_MESSAGES",
+      "FACTS",
+    ]);
+  });
+
+  it("falls back to action_planner contextConfig when no context_routing artifact exists", async () => {
+    const { runtime, hooks } = fakeRuntime(
+      serviceWithContextConfig("action_planner"),
+    );
+    registerOptimizedContextConfigHook(runtime as never);
+    const ctx = {
+      phase: "compose_state_providers" as const,
+      providers: { current: ["RECENT_MESSAGES", "FACTS", "ACTIONS"] },
+      onlyInclude: false,
+      activeContexts: [],
+      includeList: null,
+      message: {},
+    };
+
+    await hooks[0].handler(runtime as never, ctx as never);
+
+    expect(ctx.providers.current).toEqual(["FACTS", "RECENT_MESSAGES"]);
+  });
+});

--- a/plugins/plugin-training/src/register-runtime.ts
+++ b/plugins/plugin-training/src/register-runtime.ts
@@ -5,8 +5,13 @@
  * host must call this at agent boot — the plugin does not auto-enable. Cron
  * registration is skipped when `ELIZA_DISABLE_TRAINING_CRONS` is set.
  */
-import type { AgentRuntime, Service } from "@elizaos/core";
-import { logger, OptimizedPromptService } from "@elizaos/core";
+import type { AgentRuntime, PipelineHookSpec, Service } from "@elizaos/core";
+import {
+  applyOptimizedProviderSelection,
+  logger,
+  OptimizedPromptService,
+  resolveOptimizedContextConfigForRuntime,
+} from "@elizaos/core";
 import { registerSkillScoringCron } from "./core/skill-scoring-cron.js";
 import { registerTrajectoryExportCron } from "./core/trajectory-export-cron.js";
 import { registerTrainingConfigService } from "./services/training-config-service.js";
@@ -21,6 +26,37 @@ function trainingCronRegistrationDisabled(): boolean {
     return false;
   }
   return ["1", "true", "yes"].includes(raw.trim().toLowerCase());
+}
+
+export const OPTIMIZED_CONTEXT_CONFIG_HOOK_ID =
+  "training:optimized-context-config";
+
+export function registerOptimizedContextConfigHook(
+  runtime: AgentRuntime,
+): void {
+  runtime.unregisterPipelineHook(OPTIMIZED_CONTEXT_CONFIG_HOOK_ID);
+  const spec: PipelineHookSpec = {
+    id: OPTIMIZED_CONTEXT_CONFIG_HOOK_ID,
+    phase: "compose_state_providers",
+    position: 25,
+    mutatesPrimary: true,
+    handler: (hookRuntime, ctx) => {
+      if (ctx.phase !== "compose_state_providers") return;
+      if (ctx.onlyInclude) return;
+      const contextConfig =
+        resolveOptimizedContextConfigForRuntime(
+          hookRuntime,
+          "context_routing",
+        ) ??
+        resolveOptimizedContextConfigForRuntime(hookRuntime, "action_planner");
+      if (!contextConfig) return;
+      ctx.providers.current = applyOptimizedProviderSelection(
+        ctx.providers.current,
+        contextConfig,
+      );
+    },
+  };
+  runtime.registerPipelineHook(spec);
 }
 
 export async function registerTrainingRuntimeHooks(
@@ -51,6 +87,8 @@ export async function registerTrainingRuntimeHooks(
       `[eliza] OptimizedPromptService registration failed: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
+
+  registerOptimizedContextConfigHook(runtime);
 
   const skipCronRegistration = trainingCronRegistrationDisabled();
   if (skipCronRegistration) {


### PR DESCRIPTION
Refs #14875

## Summary
- register a training runtime `compose_state_providers` hook that consumes optimized `contextConfig` artifacts at agent boot
- apply learned provider set/order to the provider names already selected for the turn, with `context_routing` preferred and `action_planner` as a fallback
- no-op for exact include-list compose calls so curated/internal provider selections stay stable

## Evidence
<!-- evidence-row:before-screenshots -->
- N/A - backend/runtime hook change; no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- N/A - backend/runtime hook change; no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- N/A - backend/runtime hook change; no user-facing UI flow changed.
<!-- evidence-row:backend-logs -->
- N/A - no live backend deployed for this deterministic runtime-hook slice; local proof passed: `node packages/shared/scripts/generate-keywords.mjs --target ts && bun run --cwd plugins/plugin-training test -- src/register-runtime.test.ts`, `bunx @biomejs/biome check plugins/plugin-training/src/register-runtime.ts plugins/plugin-training/src/register-runtime.test.ts`, `bun run --cwd plugins/plugin-training build`, `git diff --check`, and `bun run audit:error-policy-ratchet`.
<!-- evidence-row:frontend-logs -->
- N/A - no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- N/A - deterministic hook-consumer slice; no live model run was executed. #14875 still needs provider-attributed live GEPA/scenario evidence before closure.
<!-- evidence-row:domain-artifacts -->
- N/A - no deploy artifact attached; domain behavior is asserted in `src/register-runtime.test.ts` by capturing the registered hook and proving it filters/orders eligible providers from a `contextConfig`, skips `onlyInclude` calls, and falls back from `context_routing` to `action_planner` config.