### PR TITLE
feat(lifeops): surface delegation contracts to planner

### DIFF
--- a/plugins/plugin-personal-assistant/AGENTS.md
+++ b/plugins/plugin-personal-assistant/AGENTS.md
@@ -57,6 +57,7 @@ The plugin is opt-in; add `@elizaos/plugin-personal-assistant` to the agent's pl
 | `ftuGoal` | `src/providers/ftu-goal.ts` | Post-first-run goal-discovery affordance; silent once the owner's primary goal is known |
 | `roomPolicy` | `src/providers/room-policy.ts` | Per-room handoff/policy state |
 | `lifeops` | `src/providers/lifeops.ts` | Aggregated owner context for assistant planning |
+| `delegationContracts` | `src/providers/delegation-contracts.ts` | Active delegation contracts for thread ownership, tripwires, and sender-class SLAs |
 | `pendingPrompts` | `src/providers/pending-prompts.ts` | Pending questions waiting for owner input |
 | `workThreads` | `src/providers/work-threads.ts` | Active work-thread state |
 | `recentTaskStates` | `src/providers/recent-task-states.ts` | Recent scheduled-task execution results |

--- a/plugins/plugin-personal-assistant/CLAUDE.md
+++ b/plugins/plugin-personal-assistant/CLAUDE.md
@@ -57,6 +57,7 @@ The plugin is opt-in; add `@elizaos/plugin-personal-assistant` to the agent's pl
 | `ftuGoal` | `src/providers/ftu-goal.ts` | Post-first-run goal-discovery affordance; silent once the owner's primary goal is known |
 | `roomPolicy` | `src/providers/room-policy.ts` | Per-room handoff/policy state |
 | `lifeops` | `src/providers/lifeops.ts` | Aggregated owner context for assistant planning |
+| `delegationContracts` | `src/providers/delegation-contracts.ts` | Active delegation contracts for thread ownership, tripwires, and sender-class SLAs |
 | `pendingPrompts` | `src/providers/pending-prompts.ts` | Pending questions waiting for owner input |
 | `workThreads` | `src/providers/work-threads.ts` | Active work-thread state |
 | `recentTaskStates` | `src/providers/recent-task-states.ts` | Recent scheduled-task execution results |

--- a/plugins/plugin-personal-assistant/src/index.ts
+++ b/plugins/plugin-personal-assistant/src/index.ts
@@ -76,6 +76,7 @@ export type {
 export {
   BrowserBridgePluginService,
   browserBridgeProvider,
+  delegationContractsProvider,
   ensureLifeOpsSchedulerTask,
   executeLifeOpsSchedulerTask,
   handleLifeOpsRoutes,

--- a/plugins/plugin-personal-assistant/src/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.ts
@@ -189,6 +189,7 @@ import { browserBridgeProvider } from "./provider.js";
 // Activity-profile (proactive agent: GM/GN/nudges)
 import { activityProfileProvider } from "./providers/activity-profile.js";
 import { crossChannelContextProvider } from "./providers/cross-channel-context.js";
+import { delegationContractsProvider } from "./providers/delegation-contracts.js";
 // LifeOps core providers
 import { firstRunProvider } from "./providers/first-run.js";
 import { ftuGoalProvider } from "./providers/ftu-goal.js";
@@ -690,6 +691,7 @@ const rawPersonalAssistantPlugin: Plugin = {
     roomPolicyProvider,
     lifeOpsProvider,
     pendingApprovalsProvider,
+    delegationContractsProvider,
     pendingPromptsProvider,
     workThreadsProvider,
     recentTaskStatesProvider,
@@ -1370,6 +1372,7 @@ export {
   type WorkThreadStatus,
   type WorkThreadStore,
 } from "./lifeops/work-threads/index.js";
+export { delegationContractsProvider } from "./providers/delegation-contracts.js";
 export type { FirstRunAffordance } from "./providers/first-run.js";
 export { firstRunProvider } from "./providers/first-run.js";
 export type { FtuGoalAffordance } from "./providers/ftu-goal.js";

--- a/plugins/plugin-personal-assistant/src/providers/delegation-contracts.ts
+++ b/plugins/plugin-personal-assistant/src/providers/delegation-contracts.ts
@@ -1,0 +1,87 @@
+/**
+ * Active delegation-contract provider for thread ownership and sender-class
+ * SLA policies. The evaluator and repository persist what the owner delegated;
+ * this provider makes those rows visible to the planner on the turns where an
+ * inbound message might be handled silently, escalated, or turned into a
+ * holding-reply draft.
+ */
+
+import { hasOwnerAccess } from "@elizaos/agent";
+import type {
+  IAgentRuntime,
+  Memory,
+  Provider,
+  ProviderResult,
+  State,
+} from "@elizaos/core";
+import {
+  type LifeOpsDelegationContractRecord,
+  renderDelegationContractsProviderText,
+} from "../lifeops/delegation-contracts/index.js";
+import { LifeOpsRepository } from "../lifeops/repository.js";
+
+const EMPTY: ProviderResult = {
+  text: "",
+  values: { activeDelegationContractCount: 0 },
+  data: { delegationContracts: [] },
+};
+
+const CONTRACT_QUERY_LIMIT = 20;
+
+export const delegationContractsProvider: Provider = {
+  name: "delegationContracts",
+  description:
+    "Surfaces active owner delegation contracts for thread ownership, loop-me-if tripwires, and sender-class reply SLAs.",
+  descriptionCompressed:
+    "Active delegation contracts - thread autonomy, tripwires, reply SLAs.",
+  dynamic: true,
+  position: 11.5,
+  cacheScope: "turn",
+  contexts: ["messaging", "email", "tasks", "automation", "general"],
+  contextGate: {
+    anyOf: ["messaging", "email", "tasks", "automation", "general"],
+  },
+  roleGate: { minRole: "OWNER" },
+
+  async get(
+    runtime: IAgentRuntime,
+    message: Memory,
+    _state: State,
+  ): Promise<ProviderResult> {
+    if (!(await hasOwnerAccess(runtime, message))) {
+      return EMPTY;
+    }
+
+    let contracts: LifeOpsDelegationContractRecord[];
+    try {
+      const repo = new LifeOpsRepository(runtime);
+      contracts = (
+        await repo.listDelegationContracts(runtime.agentId, {
+          statuses: ["active"],
+          activeAtIso: new Date().toISOString(),
+        })
+      ).slice(0, CONTRACT_QUERY_LIMIT);
+    } catch (error) {
+      // error-policy:J4 explicit user-facing degrade - omit the block when the
+      // backing store is unavailable, but report the failure so a broken
+      // delegation pipeline does not masquerade as "no active contracts."
+      runtime.reportError?.("delegation-contracts.provider", error);
+      return EMPTY;
+    }
+
+    if (contracts.length === 0) return EMPTY;
+
+    return {
+      text: renderDelegationContractsProviderText(contracts),
+      values: {
+        activeDelegationContractCount: contracts.length,
+        activeDelegationContractIds: contracts.map(
+          (contract) => contract.contractId,
+        ),
+      },
+      data: { delegationContracts: contracts },
+    };
+  },
+};
+
+export default delegationContractsProvider;

--- a/plugins/plugin-personal-assistant/test/delegation-contracts.test.ts
+++ b/plugins/plugin-personal-assistant/test/delegation-contracts.test.ts
@@ -14,6 +14,7 @@ import {
   renderDelegationContractsProviderText,
 } from "../src/lifeops/delegation-contracts/index.js";
 import { LifeOpsRepository } from "../src/lifeops/index.js";
+import { delegationContractsProvider } from "../src/providers/delegation-contracts.js";
 import {
   createLifeOpsTestRuntime,
   type RealTestRuntimeResult,
@@ -264,5 +265,37 @@ describe("delegation contract repository", () => {
       "delegation:vendor-thread",
     );
     expect(reloaded?.state?.escalatedAt).toBe("2026-07-06T16:42:00.000Z");
+  });
+
+  it("surfaces active contracts to the planner provider", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    await LifeOpsRepository.bootstrapSchema(runtime);
+    const repo = new LifeOpsRepository(runtime);
+    await repo.upsertDelegationContract(
+      createLifeOpsDelegationContractRecord({
+        ...vendorContract(),
+        agentId: runtime.agentId,
+        metadata: { sourceThread: "gmail:thread-vendor-1" },
+      }),
+    );
+
+    const result = await delegationContractsProvider.get(
+      runtime,
+      {
+        entityId: "owner-entity-1",
+        roomId: "room-1",
+        content: { text: "new vendor reply" },
+      } as never,
+      {} as never,
+    );
+
+    expect(result.text).toContain("Active delegation contracts:");
+    expect(result.text).toContain("Handle the vendor renewal thread");
+    expect(result.values).toMatchObject({
+      activeDelegationContractCount: 1,
+      activeDelegationContractIds: ["delegation:vendor-thread"],
+    });
+    expect(result.data?.delegationContracts).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

- adds a `delegationContracts` LifeOps provider that reads active persisted delegation contracts and surfaces them to the planner
- registers/exports the provider and documents it in the package provider table
- adds PGlite-backed coverage proving an active thread contract appears in provider text, values, and data

## Evidence
<!-- evidence-row:before-screenshots -->
- N/A - backend/provider-only LifeOps context change; no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- N/A - backend/provider-only LifeOps context change; no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- N/A - no app UI or user-visible screen flow changed.
<!-- evidence-row:backend-logs -->
- N/A - no live backend deployed for this deterministic provider slice; local proof passed: `bun run --cwd plugins/plugin-personal-assistant test -- test/delegation-contracts.test.ts` (1 file, 5 tests), `bun run --cwd plugins/plugin-personal-assistant build`, `bun x biome check` on touched files, `git diff --check`, and `bun run audit:error-policy-ratchet`.
<!-- evidence-row:frontend-logs -->
- N/A - no frontend runtime path changed.
<!-- evidence-row:llm-trajectory -->
- N/A - no prompt/model behavior was executed here; this only exposes persisted contract rows to provider context. Live connector/model trajectories are still required before #14856 can close.
<!-- evidence-row:domain-artifacts -->
- N/A - domain artifact is asserted locally by PGlite-backed test persistence: `delegation:vendor-thread` is written to `app_lifeops.life_delegation_contracts`; provider output includes `Active delegation contracts:`, `activeDelegationContractCount: 1`, and `activeDelegationContractIds: ["delegation:vendor-thread"]`.

## Validation

- `bun x biome check plugins/plugin-personal-assistant/src/providers/delegation-contracts.ts plugins/plugin-personal-assistant/src/plugin.ts plugins/plugin-personal-assistant/src/index.ts plugins/plugin-personal-assistant/test/delegation-contracts.test.ts plugins/plugin-personal-assistant/CLAUDE.md plugins/plugin-personal-assistant/AGENTS.md`
- `bun run --cwd plugins/plugin-personal-assistant test -- test/delegation-contracts.test.ts`
- `bun run --cwd plugins/plugin-personal-assistant build`
- `git diff --check`
- `bun run audit:error-policy-ratchet`

Closes part of #14856.