### PR TITLE
test(app): add visual qa to device status evidence

### DIFF
--- a/packages/app/scripts/devices-status.mjs
+++ b/packages/app/scripts/devices-status.mjs
@@ -33,6 +33,7 @@ import {
   readRendererManifest,
   rendererManifestPathFromAppPath,
 } from "./lib/ios-renderer-stamp.mjs";
+import { analyzeScreenshot, closeOcrEngines } from "./lib/visual-qa.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const appRoot = path.resolve(scriptDir, "..");
@@ -249,6 +250,7 @@ async function writeEvidenceArtifacts({ outputDir, rows, table, generatedAt }) {
       table: "devices-status.txt",
       json: "devices-status.json",
       screenshot: "devices-status.jpg",
+      visualQa: "devices-status.qa.json",
     },
   };
   writeFileSync(path.join(absoluteDir, "devices-status.txt"), `${table}\n`);
@@ -265,6 +267,19 @@ async function writeEvidenceArtifacts({ outputDir, rows, table, generatedAt }) {
   await sharp(Buffer.from(svg))
     .jpeg({ quality: 92 })
     .toFile(path.join(absoluteDir, "devices-status.jpg"));
+  const screenshotPath = path.join(absoluteDir, "devices-status.jpg");
+  const visualQa = await analyzeScreenshot(screenshotPath, {
+    expect: {
+      state: "devices-status",
+      require_text: ["PLATFORM", "VERDICT"],
+      forbid_text: ["undefined", "NaN", "[object Object]"],
+      max_blue_fraction: 0.02,
+    },
+  });
+  writeFileSync(
+    path.join(absoluteDir, "devices-status.qa.json"),
+    `${JSON.stringify(visualQa, null, 2)}\n`,
+  );
   return absoluteDir;
 }
 
@@ -296,8 +311,12 @@ const isDirectRun =
   process.argv[1] &&
   path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
 if (isDirectRun) {
-  main().catch((error) => {
-    console.error(error instanceof Error ? error.message : String(error));
-    process.exitCode = 1;
-  });
+  main()
+    .catch((error) => {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exitCode = 1;
+    })
+    .finally(() => {
+      closeOcrEngines();
+    });
 }


### PR DESCRIPTION
Refs #14335 and #14336. Follow-up to #14880.

## Summary
- `devices:status --evidence-dir <dir>` now writes `devices-status.qa.json` beside the terminal JPG, text table, machine JSON, and manifest.
- The QA report uses the shared visual evidence analyzer, so the device freshness screenshot carries OCR text, dominant palette, brand color fractions, and expectation checks.
- The generated manifest now names the QA artifact so agents can pick it up with the rest of the bundle.

## Current Hardware Evidence
Command:
```bash
bun run --cwd packages/app devices:status -- --no-fetch --evidence-dir /tmp/eliza-devices-status-qa-followup
```

Observed table:
```text
PLATFORM    DEVICE             KIND    BUILD         COMMIT        DEVELOP       VERDICT  LEASE  REASON
--------    ------             ----    -----         ------        -------       -------  -----  ------
android     27051JEGR10034     device  1c002882e241  90e424b3d643  6f230c0a51f5  STALE    -      installed 90e424b3d643 != develop 6f230c0a51f5
ios-sim     iOS simulator n/a  n/a     -             -             6f230c0a51f5  UNKNOWN  -      no installed renderer stamp
ios-device  physical iOS n/a   n/a     -             -             6f230c0a51f5  UNKNOWN  -      no installed renderer stamp
```

Generated files:
```text
devices-status.jpg 59209 bytes
devices-status.json 1126 bytes
devices-status.qa.json 2159 bytes
devices-status.txt 602 bytes
manifest.json 252 bytes
```

Manual review: I opened the JPG locally. It is readable, shows the stale attached Android device, and the host-unavailable iOS rows are explicit rather than hidden.

QA report excerpt:
```json
{
  "verdict": "pass",
  "size": [1637, 248],
  "ocr_note": null,
  "color_fractions": {
    "blue_fraction": 0,
    "orange_fraction": 0,
    "neutral_fraction": 1
  },
  "checks": [
    { "name": "require_text:PLATFORM", "ok": true },
    { "name": "require_text:VERDICT", "ok": true },
    { "name": "brand:no_blue", "ok": true }
  ]
}
```

## Verification
- `bun run --cwd packages/app devices:status -- --no-fetch --evidence-dir /tmp/eliza-devices-status-qa-followup` - passed and wrote JPG/JSON/TXT/QA/manifest bundle.
- `bun run --cwd packages/app test -- scripts/devices-status.test.mjs scripts/lib/visual-qa.test.ts` - passed, 2 files / 18 tests.
- `bunx @biomejs/biome check packages/app/scripts/devices-status.mjs` - passed.
- `git diff --check` - passed.
- `bun run audit:error-policy-ratchet` - passed.
- `bun run --cwd packages/app devices:status -- --json --no-fetch --require-fresh` - exited 1 for the stale attached Android device and emitted parseable JSON with one non-fresh hardware row.

## Known Gaps / Failures
- `bun run --cwd packages/app audit:app` did not reach screenshot capture in this borrowed-deps worktree. It failed during view-bundle prebuild on existing unresolved view dependencies: `@elizaos/capacitor-messages`, `@elizaos/capacitor-phone`, and `@xterm/addon-fit`.
- This does not close #14335 or #14336. They still require a hardware redeploy run showing Android FRESH and a macOS iOS simulator/physical-device run with the final inline evidence artifacts.

## Evidence
<!-- evidence-row:before-screenshots -->
- [ ] N/A - tooling-only evidence bundle enhancement; no app UI before state changed.
<!-- evidence-row:after-screenshots -->
- [x] ![devices-status evidence screenshot](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15660-devices-status.jpg)
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing app flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend runtime changed.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/prompt/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [devices-status.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15660-devices-status.txt), [devices-status.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15660-devices-status.json), [manifest.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15660-manifest.json)
<!-- evidence-row:ocr-review -->
- [x] [devices-status.qa.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15660-devices-status.qa.json)

