### PR TITLE
fix(ci): enable Android device smoke on develop PRs

### DIFF
--- a/.github/workflows/android-device-e2e.yml
+++ b/.github/workflows/android-device-e2e.yml
@@ -43,13 +43,14 @@ on:
       api-level:
         description: "Android emulator API level"
         default: "34"
-  # Reachable on a PR, but only when explicitly opted in with the `ci:device`
-  # label (issue #9943) — booting an emulator is slow/heavy, so we never burn a
-  # runner on every PR. The pr-device-smoke job below is gated on that label and
-  # runs a MINIMAL slice (build + install + WebView attach + onboarding→home +
-  # one host-backed chat turn); the full dispatch matrix above is unchanged.
+  # Reachable on normal develop PRs and release-promotion PRs, but only when
+  # explicitly opted in with the `ci:device` label (issue #9943) — booting an
+  # emulator is slow/heavy, so we never burn a runner on every PR. The
+  # pr-device-smoke job below is gated on that label and runs a MINIMAL slice
+  # (build + install + WebView attach + onboarding→home + one host-backed chat
+  # turn); the full dispatch matrix above is unchanged.
   pull_request:
-    branches: [main]
+    branches: [develop, main]
     types: [opened, synchronize, reopened, labeled]
 
 concurrency:


### PR DESCRIPTION
## Summary

- lets `android-device-e2e` listen to normal `develop` PRs as well as release-promotion `main` PRs
- keeps the existing `ci:device` label gate, so the emulator still only runs when explicitly opted in
- updates the workflow comment so elizaOS/eliza#13580/#13581 PR-smoke coverage matches the repo's PR-to-develop workflow

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/android-device-e2e.yml"); puts "yaml ok"'`\n- `actionlint .github/workflows/android-device-e2e.yml`\n- `git diff --check`\n\nCloses the develop-PR reachability slice of elizaOS/eliza#13580.