### PR TITLE
chore(mvp): audit board blocker readiness

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,6 +198,7 @@
     "test:e2e:heavy": "TEST_LANE=post-merge bunx vitest run --config packages/test/vitest/real.config.ts --passWithNoTests eliza/packages/app-core/test/app/memory-relationships.real.e2e.test.ts packages/app-core/test/app/memory-relationships.real.e2e.test.ts eliza/packages/app-core/test/app/qa-checklist.real.e2e.test.ts packages/app-core/test/app/qa-checklist.real.e2e.test.ts",
     "test:e2e:live": "TEST_LANE=post-merge node packages/scripts/run-all-tests.mjs --only=e2e --no-cloud",
     "lifeops:hitl": "node scripts/lifeops/hitl-credential-dashboard.mjs",
+    "mvp:board-readiness": "node packages/scripts/check-mvp-board-readiness.mjs",
     "lifeops:verify-cerebras": "bun --bun plugins/plugin-personal-assistant/scripts/verify-cerebras-wiring.ts",
     "bench:personality": "bun --bun packages/benchmarks/personality-bench/src/runner.ts",
     "bench:personality:calibrate": "bun run --cwd packages/benchmarks/personality-bench calibrate",

--- a/packages/scripts/__tests__/mvp-board-readiness.test.ts
+++ b/packages/scripts/__tests__/mvp-board-readiness.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Offline coverage for the MVP board-readiness audit. The live CLI path talks
+ * to GitHub, but the policy is deterministic over captured issue and project
+ * rows, so regressions should be caught without network access.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+const board = await import(
+  new URL("../check-mvp-board-readiness.mjs", import.meta.url).href
+);
+
+function issue(number: number, labels: string[]) {
+  return {
+    number,
+    title: `Issue ${number}`,
+    url: `https://github.com/elizaOS/eliza/issues/${number}`,
+    labels: labels.map((name) => ({ name })),
+  };
+}
+
+function projectItem(number: number, status: string) {
+  return {
+    content: { number, title: `Issue ${number}` },
+    status,
+  };
+}
+
+describe("MVP board readiness audit", () => {
+  test("passes when every open MVP issue has a blocker and human-review status", () => {
+    const report = board.auditMvpBoardReadiness(
+      [
+        issue(14335, ["mvp", "needs-human"]),
+        issue(14783, ["mvp", "needs-shaw"]),
+      ],
+      {
+        items: [
+          projectItem(14335, "Needs human review"),
+          projectItem(14783, "Needs human review"),
+        ],
+      },
+    );
+
+    expect(report.ok).toBe(true);
+    expect(report.issueCount).toBe(2);
+    expect(report.blockerCount).toBe(2);
+    expect(report.violations).toEqual([]);
+  });
+
+  test("flags open MVP issues without a blocker label", () => {
+    const report = board.auditMvpBoardReadiness([issue(14749, ["mvp"])], {
+      items: [projectItem(14749, "Ready")],
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.violations).toContainEqual(
+      expect.objectContaining({
+        type: "missing-blocker-label",
+        number: 14749,
+      }),
+    );
+  });
+
+  test("flags blocker-labeled issues outside Needs human review", () => {
+    const report = board.auditMvpBoardReadiness(
+      [issue(14358, ["mvp", "needs-human"])],
+      { items: [projectItem(14358, "In progress")] },
+    );
+
+    expect(report.ok).toBe(false);
+    expect(report.violations).toContainEqual(
+      expect.objectContaining({
+        type: "blocked-status-mismatch",
+        number: 14358,
+        projectStatus: "In progress",
+      }),
+    );
+  });
+
+  test("flags open MVP issues missing from the project", () => {
+    const report = board.auditMvpBoardReadiness(
+      [issue(14351, ["mvp", "needs-shaw"])],
+      { items: [] },
+    );
+
+    expect(report.ok).toBe(false);
+    expect(report.violations).toContainEqual(
+      expect.objectContaining({
+        type: "missing-project-item",
+        number: 14351,
+      }),
+    );
+  });
+});

--- a/packages/scripts/__tests__/mvp-board-readiness.test.ts
+++ b/packages/scripts/__tests__/mvp-board-readiness.test.ts
@@ -19,9 +19,13 @@ function issue(number: number, labels: string[]) {
   };
 }
 
-function projectItem(number: number, status: string) {
+function projectItem(
+  number: number,
+  status: string,
+  repository = "elizaOS/eliza",
+) {
   return {
-    content: { number, title: `Issue ${number}` },
+    content: { number, repository, title: `Issue ${number}` },
     status,
   };
 }
@@ -88,6 +92,23 @@ describe("MVP board readiness audit", () => {
       expect.objectContaining({
         type: "missing-project-item",
         number: 14351,
+      }),
+    );
+  });
+
+  test("does not match project items from a different repository by number", () => {
+    const report = board.auditMvpBoardReadiness(
+      [issue(14747, ["mvp", "needs-shaw"])],
+      {
+        items: [projectItem(14747, "Needs human review", "elizaOS/other-repo")],
+      },
+    );
+
+    expect(report.ok).toBe(false);
+    expect(report.violations).toContainEqual(
+      expect.objectContaining({
+        type: "missing-project-item",
+        number: 14747,
       }),
     );
   });

--- a/packages/scripts/check-mvp-board-readiness.mjs
+++ b/packages/scripts/check-mvp-board-readiness.mjs
@@ -131,10 +131,28 @@ function projectItemNumber(item) {
   return item.content?.number ?? item.number ?? null;
 }
 
-function normalizeProjectItems(payload) {
+function normalizeRepository(value) {
+  if (typeof value !== "string" || value.length === 0) return null;
+  const githubPrefix = "https://github.com/";
+  const normalized = value.startsWith(githubPrefix)
+    ? value.slice(githubPrefix.length)
+    : value;
+  return normalized.replace(/\.git$/, "").toLowerCase();
+}
+
+function projectItemRepository(item) {
+  return normalizeRepository(
+    item.content?.repository ?? item.repository ?? item.content?.url,
+  );
+}
+
+function normalizeProjectItems(payload, repo = DEFAULT_REPO) {
   const items = Array.isArray(payload) ? payload : (payload.items ?? []);
   const byNumber = new Map();
+  const expectedRepo = normalizeRepository(repo);
   for (const item of items) {
+    const itemRepo = projectItemRepository(item);
+    if (expectedRepo && itemRepo && itemRepo !== expectedRepo) continue;
     const number = projectItemNumber(item);
     if (typeof number === "number") {
       byNumber.set(number, item);
@@ -143,8 +161,11 @@ function normalizeProjectItems(payload) {
   return byNumber;
 }
 
-export function auditMvpBoardReadiness(issues, projectPayload) {
-  const projectItems = normalizeProjectItems(projectPayload);
+export function auditMvpBoardReadiness(issues, projectPayload, options = {}) {
+  const projectItems = normalizeProjectItems(
+    projectPayload,
+    options.repo ?? DEFAULT_REPO,
+  );
   const violations = [];
   const rows = [];
 
@@ -240,7 +261,9 @@ async function main() {
   const projectPayload = args.projectJson
     ? readJson(args.projectJson)
     : fetchProjectItems(args.projectOwner, args.projectNumber);
-  const report = auditMvpBoardReadiness(issues, projectPayload);
+  const report = auditMvpBoardReadiness(issues, projectPayload, {
+    repo: args.repo,
+  });
 
   process.stdout.write(
     args.json ? `${JSON.stringify(report, null, 2)}\n` : formatText(report),

--- a/packages/scripts/check-mvp-board-readiness.mjs
+++ b/packages/scripts/check-mvp-board-readiness.mjs
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+
+/**
+ * Board-readiness audit for the LifeOps MVP project. Open MVP issues are only
+ * actionable for agents when they are either actively being implemented or
+ * clearly blocked on owner/hardware/live-evidence work; this script keeps the
+ * blocker labels and Project 15 status aligned so evidence gaps do not look
+ * like unclaimed engineering work.
+ */
+
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import process from "node:process";
+
+const DEFAULT_REPO = "elizaOS/eliza";
+const DEFAULT_PROJECT_OWNER = "elizaOS";
+const DEFAULT_PROJECT_NUMBER = "15";
+const BLOCKER_LABELS = new Set(["needs-human", "needs-shaw"]);
+const REQUIRED_BLOCKED_STATUS = "Needs human review";
+
+function usage() {
+  return `Usage:
+  node packages/scripts/check-mvp-board-readiness.mjs [--repo owner/repo] [--project-owner org] [--project-number n]
+  node packages/scripts/check-mvp-board-readiness.mjs --issues-json issues.json --project-json project-items.json
+
+Options:
+  --json          Print machine-readable report.
+  --no-fail      Exit 0 even when violations are found.`;
+}
+
+function parseArgs(argv) {
+  const out = {
+    repo: DEFAULT_REPO,
+    projectOwner: DEFAULT_PROJECT_OWNER,
+    projectNumber: DEFAULT_PROJECT_NUMBER,
+    json: false,
+    fail: true,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--json") {
+      out.json = true;
+    } else if (arg === "--no-fail") {
+      out.fail = false;
+    } else if (arg === "--help" || arg === "-h") {
+      out.help = true;
+    } else if (
+      arg === "--repo" ||
+      arg === "--project-owner" ||
+      arg === "--project-number" ||
+      arg === "--issues-json" ||
+      arg === "--project-json"
+    ) {
+      const value = argv[i + 1];
+      if (!value) throw new Error(`${arg} requires a value`);
+      out[
+        arg
+          .slice(2)
+          .replace(/-([a-z])/g, (_match, letter) => letter.toUpperCase())
+      ] = value;
+      i += 1;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return out;
+}
+
+function run(command, args) {
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    maxBuffer: 50 * 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} ${args.join(" ")} failed: ${
+        result.stderr || result.stdout || result.error?.message || "unknown"
+      }`,
+    );
+  }
+  return result.stdout.trim();
+}
+
+function readJson(file) {
+  return JSON.parse(readFileSync(file, "utf8"));
+}
+
+function ghJson(args) {
+  const output = run("gh", args);
+  return output ? JSON.parse(output) : null;
+}
+
+function fetchOpenMvpIssues(repo) {
+  return ghJson([
+    "issue",
+    "list",
+    "--repo",
+    repo,
+    "--state",
+    "open",
+    "--label",
+    "mvp",
+    "--limit",
+    "300",
+    "--json",
+    "number,title,labels,url",
+  ]);
+}
+
+function fetchProjectItems(projectOwner, projectNumber) {
+  return ghJson([
+    "project",
+    "item-list",
+    projectNumber,
+    "--owner",
+    projectOwner,
+    "--limit",
+    "300",
+    "--format",
+    "json",
+  ]);
+}
+
+function labelNames(issue) {
+  return (issue.labels ?? [])
+    .map((label) => (typeof label === "string" ? label : label?.name))
+    .filter(Boolean);
+}
+
+function projectItemNumber(item) {
+  return item.content?.number ?? item.number ?? null;
+}
+
+function normalizeProjectItems(payload) {
+  const items = Array.isArray(payload) ? payload : (payload.items ?? []);
+  const byNumber = new Map();
+  for (const item of items) {
+    const number = projectItemNumber(item);
+    if (typeof number === "number") {
+      byNumber.set(number, item);
+    }
+  }
+  return byNumber;
+}
+
+export function auditMvpBoardReadiness(issues, projectPayload) {
+  const projectItems = normalizeProjectItems(projectPayload);
+  const violations = [];
+  const rows = [];
+
+  for (const issue of issues) {
+    const labels = labelNames(issue);
+    const blockerLabels = labels.filter((label) => BLOCKER_LABELS.has(label));
+    const projectItem = projectItems.get(issue.number);
+    const status = projectItem?.status ?? null;
+    const row = {
+      number: issue.number,
+      title: issue.title,
+      url: issue.url,
+      labels,
+      blockerLabels,
+      projectStatus: status,
+    };
+    rows.push(row);
+
+    if (blockerLabels.length === 0) {
+      violations.push({
+        type: "missing-blocker-label",
+        number: issue.number,
+        title: issue.title,
+        message: `#${issue.number} is open+mvp but has neither needs-human nor needs-shaw`,
+      });
+    }
+
+    if (!projectItem) {
+      violations.push({
+        type: "missing-project-item",
+        number: issue.number,
+        title: issue.title,
+        message: `#${issue.number} is open+mvp but is not present on Project 15`,
+      });
+      continue;
+    }
+
+    if (blockerLabels.length > 0 && status !== REQUIRED_BLOCKED_STATUS) {
+      violations.push({
+        type: "blocked-status-mismatch",
+        number: issue.number,
+        title: issue.title,
+        projectStatus: status,
+        message: `#${issue.number} has ${blockerLabels.join(
+          ",",
+        )} but Project 15 status is ${status ?? "unset"}`,
+      });
+    }
+  }
+
+  return {
+    ok: violations.length === 0,
+    issueCount: issues.length,
+    blockerCount: rows.filter((row) => row.blockerLabels.length > 0).length,
+    requiredBlockedStatus: REQUIRED_BLOCKED_STATUS,
+    violations,
+    rows,
+  };
+}
+
+function formatText(report) {
+  const lines = [
+    `MVP board readiness: ${report.ok ? "PASS" : "FAIL"}`,
+    `Open MVP issues: ${report.issueCount}`,
+    `Blocked issues: ${report.blockerCount}`,
+    `Required blocked status: ${report.requiredBlockedStatus}`,
+  ];
+  if (report.violations.length > 0) {
+    lines.push("", "Violations:");
+    for (const violation of report.violations) {
+      lines.push(`- ${violation.message}`);
+    }
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(`${usage()}\n`);
+    return;
+  }
+  if (
+    (args.issuesJson && !args.projectJson) ||
+    (!args.issuesJson && args.projectJson)
+  ) {
+    throw new Error("--issues-json and --project-json must be passed together");
+  }
+
+  const issues = args.issuesJson
+    ? readJson(args.issuesJson)
+    : fetchOpenMvpIssues(args.repo);
+  const projectPayload = args.projectJson
+    ? readJson(args.projectJson)
+    : fetchProjectItems(args.projectOwner, args.projectNumber);
+  const report = auditMvpBoardReadiness(issues, projectPayload);
+
+  process.stdout.write(
+    args.json ? `${JSON.stringify(report, null, 2)}\n` : formatText(report),
+  );
+  if (args.fail && !report.ok) {
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] === new URL(import.meta.url).pathname) {
+  main().catch((error) => {
+    process.stderr.write(`check-mvp-board-readiness: ${error.message}\n`);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
# Relates to

MVP Project 15 board verification / LifeOps MVP process hardening.

- [x] This PR targets `develop` and is based on latest `origin/develop` at branch creation.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Branch created from latest fetched `origin/develop` before edits.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Adds a read-only GitHub/project audit script and offline tests; no app/runtime behavior changes.

# Background

## What does this PR do?

Adds `packages/scripts/check-mvp-board-readiness.mjs` plus root script `bun run mvp:board-readiness`.

The audit checks all open `mvp` issues and fails when:
- an open MVP issue lacks both `needs-human` and `needs-shaw`,
- an open MVP issue is missing from Project 15,
- a blocker-labeled issue is not in Project 15 status `Needs human review`.

It supports live GitHub reads via `gh` and offline `--issues-json` / `--project-json` fixture inputs for deterministic tests.

The first live run caught real board drift: #14747 had `needs-shaw` but Project 15 status `Ready`. I moved it to `Needs human review` and posted the issue comment before rerunning the audit.

## What kind of change is this?

Improvements: process/verification automation.

# Documentation changes needed?

No separate documentation needed; the root script name and CLI `--help` document usage.

# Testing

## Where should a reviewer start?

Run:

```bash
bun run mvp:board-readiness
```

## Detailed testing steps

```bash
bunx @biomejs/biome check --write packages/scripts/check-mvp-board-readiness.mjs packages/scripts/__tests__/mvp-board-readiness.test.ts package.json
bun test packages/scripts/__tests__/mvp-board-readiness.test.ts
git diff --check
bun run mvp:board-readiness
```

Live audit output after fixing #14747 board status:

```text
$ node packages/scripts/check-mvp-board-readiness.mjs
MVP board readiness: PASS
Open MVP issues: 26
Blocked issues: 26
Required blocked status: Needs human review
```

Offline test output:

```text
packages/scripts/__tests__/mvp-board-readiness.test.ts:
(pass) MVP board readiness audit > passes when every open MVP issue has a blocker and human-review status
(pass) MVP board readiness audit > flags open MVP issues without a blocker label
(pass) MVP board readiness audit > flags blocker-labeled issues outside Needs human review
(pass) MVP board readiness audit > flags open MVP issues missing from the project

4 pass
0 fail
```

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - CLI/process automation only; no UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - CLI/process automation only; no UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - CLI/process automation only; command output above is the complete reviewer flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no server/backend runtime path changed; the live `gh` audit output above proves the external read path.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code, network request, or browser state changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - domain artifact is live Project 15 state, captured inline above: `Open MVP issues: 26`, `Blocked issues: 26`, and `MVP board readiness: PASS` after #14747 was moved from `Ready` to `Needs human review`.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model behavior changed.

## Backend + frontend logs

N/A - no backend or frontend runtime changed.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI changed.

## Known gaps / failures

`bun run verify` was not run for this narrow script-only PR. Focused validation above passed. The live audit is intentionally read-only except for the separate manual Project 15 correction already posted to #14747.