### PR TITLE
fix(mvp): clarify persona catalog coverage totals

### DIFF
--- a/packages/scripts/__tests__/lifeops-catalog-coverage.test.ts
+++ b/packages/scripts/__tests__/lifeops-catalog-coverage.test.ts
@@ -1,4 +1,4 @@
-// Exercises tests lifeops catalog coverage.test automation behavior against the real MVP scenario ledgers.
+// Exercises the catalog coverage reporter against the real MVP scenario ledgers.
 import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import { join } from "node:path";
@@ -40,6 +40,25 @@ describe("LifeOps persona catalog coverage", () => {
         surface: "scenario-runner",
       }),
     );
+
+    const e1 = report.packs.find(
+      (pack: { pack: string }) => pack.pack === "E1",
+    );
+    expect(e1).toMatchObject({
+      target: 28,
+      authored: 29,
+      overTarget: 1,
+    });
+  });
+
+  test("default summary separates planning targets from authored-row counts", () => {
+    const output = runCoverage();
+    expect(output).toContain("E1 29 authored (target 28, +1)");
+    expect(output).toContain("F1 35 authored (target 32, +3)");
+    expect(output).toContain(
+      "Total: 296 authored (target 292), 146/296 verified, 150 unverified",
+    );
+    expect(output).not.toContain("296/292 authored");
   });
 
   test("--unverified prints a board-triage list without hiding surface blockers", () => {

--- a/packages/scripts/check-lifeops-persona-catalog-coverage.mjs
+++ b/packages/scripts/check-lifeops-persona-catalog-coverage.mjs
@@ -241,6 +241,7 @@ function summarize() {
       target: expectedTarget,
       authored,
       verified,
+      overTarget: Math.max(0, authored - expectedTarget),
       unverified: unverified.length,
       unverifiedBySurface,
       unverifiedRows: unverified,
@@ -278,11 +279,11 @@ function main() {
     console.log("LifeOps persona scenario catalog coverage");
     for (const pack of result.packs) {
       console.log(
-        `${pack.pack.padEnd(2)} ${pack.authored}/${pack.target} authored, ${pack.verified}/${pack.authored} verified (${pack.file})`,
+        `${pack.pack.padEnd(2)} ${pack.authored} authored (target ${pack.target}${pack.overTarget > 0 ? `, +${pack.overTarget}` : ""}), ${pack.verified}/${pack.authored} verified (${pack.file})`,
       );
     }
     console.log(
-      `Total: ${result.authored}/${result.target} authored, ${result.verified}/${result.target} verified`,
+      `Total: ${result.authored} authored (target ${result.target}), ${result.verified}/${result.authored} verified, ${result.authored - result.verified} unverified`,
     );
   }
   if (result.errors.length > 0) {


### PR DESCRIPTION
Refs #14351.

## Summary
- Separates persona catalog planning targets from actual authored-row counts in the default coverage summary.
- Adds `overTarget` to the JSON report so MVP triage can see packs that intentionally or accidentally grew past their target count.
- Extends the focused test to prevent impossible summaries like `296/292 authored` from returning.

## Evidence

Before this fix, the default report printed target-count fractions even when catalogs had more authored rows than their planning target:

```text
E1 29/28 authored, 26/29 verified
F1 35/32 authored, 33/35 verified
Total: 296/292 authored, 146/292 verified
```

After this fix:

```text
E1 29 authored (target 28, +1), 26/29 verified (low-activation-reengagement.catalog.json)
F1 35 authored (target 32, +3), 33/35 verified (neurotypical-control-adversarial.catalog.json)
Total: 296 authored (target 292), 146/296 verified, 150 unverified
```

JSON now exposes the over-target packs directly:

```json
{
  "target": 292,
  "authored": 296,
  "verified": 146,
  "unverified": 150,
  "overTargetPacks": [
    { "pack": "E1", "target": 28, "authored": 29, "overTarget": 1 },
    { "pack": "F1", "target": 32, "authored": 35, "overTarget": 3 }
  ],
  "errors": []
}
```

## Verification
- `bun test packages/scripts/__tests__/lifeops-catalog-coverage.test.ts` - passed, 3 tests / 17 assertions.
- `node packages/scripts/check-lifeops-persona-catalog-coverage.mjs` - passed and prints authored-row totals without impossible fractions.
- `node packages/scripts/check-lifeops-persona-catalog-coverage.mjs --json | jq ...` - passed and reports E1/F1 `overTarget` details with `errors: []`.
- `bunx @biomejs/biome check packages/scripts/check-lifeops-persona-catalog-coverage.mjs packages/scripts/__tests__/lifeops-catalog-coverage.test.ts` - passed.
- `git diff --check` - passed.

## Evidence Rows
<!-- evidence-row:before-screenshots -->
- [ ] N/A - CLI verifier output only; no app UI changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - CLI verifier output only; no app UI changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend runtime changed.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - verifier/reporting change only; no model, prompt, or agent behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - verifier/reporting change only; command output and JSON report excerpts are included inline above.