### PR TITLE
chore(mvp): add project board audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "audit:ui-determinism": "node packages/scripts/audit-ui-determinism.mjs",
     "audit:ui-determinism:self-test": "node packages/scripts/audit-ui-determinism.mjs --self-test",
     "audit:ui-determinism:update": "node packages/scripts/audit-ui-determinism.mjs --update-baseline",
+    "audit:mvp-board": "node packages/scripts/audit-mvp-project-board.mjs",
     "audit:focused-tests": "node packages/scripts/audit-focused-skipped-tests.mjs",
     "audit:focused-tests:self-test": "node packages/scripts/audit-focused-skipped-tests.mjs --self-test",
     "audit:type-duplication": "node packages/scripts/type-duplication-audit.mjs",

--- a/packages/scripts/__tests__/audit-mvp-project-board.test.ts
+++ b/packages/scripts/__tests__/audit-mvp-project-board.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Fixture coverage for the LifeOps MVP project-board audit. Live GitHub state
+ * belongs to the CLI; these tests pin the stale-card buckets agents use during
+ * closeout review.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+const board = await import(
+  new URL("../audit-mvp-project-board.mjs", import.meta.url).href
+);
+
+const projectItems = [
+  {
+    content: {
+      type: "Issue",
+      number: 1,
+      title: "Closed implementation",
+      url: "https://github.com/elizaOS/eliza/issues/1",
+    },
+    title: "Closed implementation",
+    status: "In progress",
+    labels: ["mvp", "testing"],
+  },
+  {
+    content: {
+      type: "Issue",
+      number: 2,
+      title: "Needs device evidence",
+      url: "https://github.com/elizaOS/eliza/issues/2",
+    },
+    title: "Needs device evidence",
+    status: "Needs human review",
+    labels: ["mvp", "needs-human"],
+  },
+  {
+    content: {
+      type: "Issue",
+      number: 3,
+      title: "Agent tractable",
+      url: "https://github.com/elizaOS/eliza/issues/3",
+    },
+    title: "Agent tractable",
+    status: "In progress",
+    labels: ["mvp", "testing"],
+  },
+  {
+    content: {
+      type: "Issue",
+      number: 4,
+      title: "Open but done",
+      url: "https://github.com/elizaOS/eliza/issues/4",
+    },
+    title: "Open but done",
+    status: "Done",
+    labels: ["mvp"],
+  },
+  {
+    content: {
+      type: "PullRequest",
+      number: 5,
+      title: "Ignored PR",
+      url: "https://github.com/elizaOS/eliza/pull/5",
+    },
+    title: "Ignored PR",
+    status: "In progress",
+    labels: ["mvp"],
+  },
+];
+
+describe("audit-mvp-project-board", () => {
+  test("summarizeMvpBoard separates stale, human-gated, and actionable rows", () => {
+    const summary = board.summarizeMvpBoard({
+      projectItems,
+      openIssues: [{ number: 2 }, { number: 3 }, { number: 4 }],
+      closedIssues: [{ number: 1 }],
+    });
+
+    expect(summary.counts).toEqual({
+      projectIssues: 4,
+      mvpIssues: 4,
+      closedNotDone: 1,
+      openNotDone: 2,
+      humanGated: 1,
+      agentActionable: 1,
+      openDone: 1,
+    });
+    expect(summary.closedNotDone.map((issue) => issue.number)).toEqual([1]);
+    expect(summary.humanGated.map((issue) => issue.number)).toEqual([2]);
+    expect(summary.agentActionable.map((issue) => issue.number)).toEqual([3]);
+    expect(summary.openDone.map((issue) => issue.number)).toEqual([4]);
+  });
+
+  test("formatSummary includes each actionable section", () => {
+    const text = board.formatSummary(
+      board.summarizeMvpBoard({
+        projectItems,
+        openIssues: [{ number: 2 }, { number: 3 }, { number: 4 }],
+        closedIssues: [{ number: 1 }],
+      }),
+    );
+
+    expect(text).toContain("Closed MVP issues not marked Done");
+    expect(text).toContain("Open MVP issues not Done and not human-gated");
+    expect(text).toContain("#3 In progress — Agent tractable");
+    expect(text).toContain("open-but-Done: 1");
+  });
+});

--- a/packages/scripts/audit-mvp-project-board.mjs
+++ b/packages/scripts/audit-mvp-project-board.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+/**
+ * Read-only audit for the LifeOps MVP project board. The GitHub Project is the
+ * live kanban, but closeout work needs a compact stale-state report instead of
+ * a raw 195-item dump: closed issues that are not Done, open MVP issues still
+ * active, and the subset that is explicitly human-gated.
+ */
+
+import { execFileSync } from "node:child_process";
+import process from "node:process";
+
+const DEFAULT_OWNER = "elizaOS";
+const DEFAULT_REPO = "elizaOS/eliza";
+const DEFAULT_PROJECT = "15";
+const DEFAULT_LIMIT = "500";
+const DONE_STATUS = "Done";
+
+function argValue(name, fallback) {
+  const index = process.argv.indexOf(name);
+  if (index !== -1) return process.argv[index + 1] ?? fallback;
+  const inline = process.argv.find((arg) => arg.startsWith(`${name}=`));
+  return inline ? inline.slice(name.length + 1) : fallback;
+}
+
+function ghJson(args) {
+  return JSON.parse(execFileSync("gh", args, { encoding: "utf8" }));
+}
+
+export function normalizeProjectIssue(item) {
+  if (item?.content?.type !== "Issue") return null;
+  const labels = (item.labels ?? []).map((label) =>
+    typeof label === "string" ? label : label.name,
+  );
+  return {
+    number: item.content.number,
+    title: item.title ?? item.content.title,
+    url: item.content.url,
+    status: item.status ?? null,
+    labels: labels.filter(Boolean),
+  };
+}
+
+function byNumber(items) {
+  return new Map(items.map((item) => [item.number, item]));
+}
+
+export function summarizeMvpBoard({ projectItems, openIssues, closedIssues }) {
+  const openByNumber = byNumber(openIssues);
+  const closedNumbers = new Set(closedIssues.map((issue) => issue.number));
+  const issues = projectItems.map(normalizeProjectIssue).filter(Boolean);
+  const mvpIssues = issues.filter((issue) => issue.labels.includes("mvp"));
+
+  const closedNotDone = mvpIssues.filter(
+    (issue) => closedNumbers.has(issue.number) && issue.status !== DONE_STATUS,
+  );
+  const openOnBoard = mvpIssues.filter(
+    (issue) => openByNumber.has(issue.number) && issue.status !== DONE_STATUS,
+  );
+  const humanGated = openOnBoard.filter((issue) =>
+    issue.labels.some(
+      (label) => label === "needs-human" || label === "needs-shaw",
+    ),
+  );
+  const agentActionable = openOnBoard.filter(
+    (issue) =>
+      !issue.labels.some(
+        (label) => label === "needs-human" || label === "needs-shaw",
+      ),
+  );
+  const openDone = mvpIssues.filter(
+    (issue) => openByNumber.has(issue.number) && issue.status === DONE_STATUS,
+  );
+
+  return {
+    counts: {
+      projectIssues: issues.length,
+      mvpIssues: mvpIssues.length,
+      closedNotDone: closedNotDone.length,
+      openNotDone: openOnBoard.length,
+      humanGated: humanGated.length,
+      agentActionable: agentActionable.length,
+      openDone: openDone.length,
+    },
+    closedNotDone,
+    openNotDone: openOnBoard,
+    humanGated,
+    agentActionable,
+    openDone,
+  };
+}
+
+function formatIssue(issue) {
+  const labels = issue.labels.length > 0 ? ` [${issue.labels.join(",")}]` : "";
+  return `#${issue.number} ${issue.status ?? "(no status)"} — ${issue.title}${labels}`;
+}
+
+export function formatSummary(summary) {
+  const lines = [
+    "LifeOps MVP project-board audit",
+    `project issues: ${summary.counts.projectIssues}; mvp issues: ${summary.counts.mvpIssues}`,
+    `closed-not-Done: ${summary.counts.closedNotDone}`,
+    `open-not-Done: ${summary.counts.openNotDone} (${summary.counts.humanGated} human-gated, ${summary.counts.agentActionable} agent-actionable)`,
+    `open-but-Done: ${summary.counts.openDone}`,
+  ];
+
+  const section = (title, rows) => {
+    lines.push("", title);
+    if (rows.length === 0) {
+      lines.push("  (none)");
+      return;
+    }
+    for (const row of rows) lines.push(`  ${formatIssue(row)}`);
+  };
+
+  section("Closed MVP issues not marked Done", summary.closedNotDone);
+  section(
+    "Open MVP issues not Done and not human-gated",
+    summary.agentActionable,
+  );
+  section("Open MVP issues not Done and human-gated", summary.humanGated);
+  section("Open MVP issues already marked Done", summary.openDone);
+  return lines.join("\n");
+}
+
+async function main() {
+  const owner = argValue("--owner", DEFAULT_OWNER);
+  const project = argValue("--project", DEFAULT_PROJECT);
+  const repo = argValue("--repo", DEFAULT_REPO);
+  const limit = argValue("--limit", DEFAULT_LIMIT);
+  const jsonMode = process.argv.includes("--json");
+
+  const projectData = ghJson([
+    "project",
+    "item-list",
+    project,
+    "--owner",
+    owner,
+    "--format",
+    "json",
+    "--limit",
+    limit,
+  ]);
+  const openIssues = ghJson([
+    "issue",
+    "list",
+    "--repo",
+    repo,
+    "--state",
+    "open",
+    "--label",
+    "mvp",
+    "--limit",
+    limit,
+    "--json",
+    "number,title,labels,url",
+  ]);
+  const closedIssues = ghJson([
+    "issue",
+    "list",
+    "--repo",
+    repo,
+    "--state",
+    "closed",
+    "--label",
+    "mvp",
+    "--limit",
+    limit,
+    "--json",
+    "number,title,labels,url",
+  ]);
+
+  const summary = summarizeMvpBoard({
+    projectItems: projectData.items ?? [],
+    openIssues,
+    closedIssues,
+  });
+  process.stdout.write(
+    jsonMode
+      ? `${JSON.stringify(summary, null, 2)}\n`
+      : `${formatSummary(summary)}\n`,
+  );
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    process.stderr.write(
+      `[audit-mvp-project-board] ${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `bun run audit:mvp-board`, a read-only Project 15 audit for LifeOps MVP closeout.
- Buckets stale board state into closed MVP issues not marked Done, open MVP issues not Done, human-gated rows, agent-actionable rows, and open issues already marked Done.
- Adds fixture coverage for the pure summarizer so the live CLI can stay thin around `gh`.

## Current Board Evidence
Live read-only run:
```bash
bun run audit:mvp-board -- --json
```

Current summary:
```json
{
  "counts": {
    "projectIssues": 194,
    "mvpIssues": 162,
    "closedNotDone": 5,
    "openNotDone": 26,
    "humanGated": 26,
    "agentActionable": 0,
    "openDone": 0
  },
  "closedNotDone": [14724, 14714, 14708, 14355, 14782],
  "agentActionable": []
}
```

This makes the current MVP review state explicit: no open non-human-gated MVP board cards remain, and five closed issues still need project status cleanup by someone with board authority.

## Verification
- `bun test packages/scripts/__tests__/audit-mvp-project-board.test.ts` - passed, 2 tests.
- `bunx @biomejs/biome check package.json packages/scripts/audit-mvp-project-board.mjs packages/scripts/__tests__/audit-mvp-project-board.test.ts` - passed.
- `bun run audit:mvp-board -- --json` - passed and produced parseable JSON.
- `git diff --check` - passed.
- `bun run audit:error-policy-ratchet` - passed.

## Evidence
<!-- evidence-row:before-screenshots -->
- [ ] N/A - process/CLI audit change; no rendered app UI changed.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - process/CLI audit change; no rendered app UI changed.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing app flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend runtime changed.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/prompt/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [mvp-board-audit.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15664-mvp-board-audit.txt), [mvp-board-audit.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15664-mvp-board-audit.json)

