### PR TITLE
perf(cloud-api): defer embeddings admission

### DIFF
--- a/packages/cloud/api/__tests__/embeddings-optimistic-billing.test.ts
+++ b/packages/cloud/api/__tests__/embeddings-optimistic-billing.test.ts
@@ -34,6 +34,7 @@ import * as pricingActual from "@/lib/pricing";
 import * as languageModelActual from "@/lib/providers/language-model";
 import * as aiBillingActual from "@/lib/services/ai-billing";
 import * as inferenceAuthActual from "@/lib/services/inference-auth-context";
+import * as billingDeferredActual from "@/lib/services/inference-billing-deferred";
 import * as fastPathActual from "@/lib/services/inference-billing-fast-path";
 import * as ledgerActual from "@/lib/services/inference-billing-ledger";
 import * as usageActual from "@/lib/services/usage";
@@ -58,6 +59,7 @@ let gateBalanceUsd = 100;
 let thresholdUsd = 5;
 let backstopPersists = true;
 let billingLedger = "kv"; // anything but "db" → the KV backstop branch
+let deferredEnabled = false;
 
 // --- spies on the two terminal billing paths --------------------------------
 const writePendingInferenceCharge = mock(
@@ -70,7 +72,9 @@ const reserveCredits = mock(async () => ({
   reservedAmount: 0,
   reconcile: async () => undefined,
 }));
-const createOptimisticDebitSettler = mock(() => async () => undefined);
+const optimisticInnerSettler = mock(async (_actualCost: number) => null);
+const ledgerInnerSettler = mock(async (_actualCost: number) => null);
+const createOptimisticDebitSettler = mock(() => optimisticInnerSettler);
 
 // Auth: resolve straight to an authorized org user via the hot-path resolver.
 mock.module("@/lib/services/inference-auth-context", () => ({
@@ -125,12 +129,19 @@ mock.module("@/lib/services/inference-billing-fast-path", () => ({
 const admitInferenceChargeViaLedger = mock(
   async () => ({ admitted: true }) as never,
 );
-const createLedgerDebitSettler = mock(() => async () => undefined);
+const createLedgerDebitSettler = mock(() => ledgerInnerSettler);
 mock.module("@/lib/services/inference-billing-ledger", () => ({
   ...ledgerActual,
   resolveInferenceBillingLedger: () => billingLedger,
   admitInferenceChargeViaLedger,
   createLedgerDebitSettler,
+}));
+
+// Tier-3 deferred admission: keep the settler/refusal behavior real and only
+// control the flag so the route exercises the same ordering as production.
+mock.module("@/lib/services/inference-billing-deferred", () => ({
+  ...billingDeferredActual,
+  isDeferredAdmissionEnabled: () => deferredEnabled,
 }));
 
 // Synchronous reserve path — spied so we can prove it is the fallback. billUsage
@@ -193,6 +204,10 @@ afterAll(() => {
     () => fastPathActual,
   );
   mock.module("@/lib/services/inference-billing-ledger", () => ledgerActual);
+  mock.module(
+    "@/lib/services/inference-billing-deferred",
+    () => billingDeferredActual,
+  );
   mock.module("@/lib/services/ai-billing", () => aiBillingActual);
   mock.module("@/lib/services/usage", () => usageActual);
   mock.module("ai", () => aiActual);
@@ -237,11 +252,15 @@ describe("POST /api/v1/embeddings optimistic-billing route decision (#9899/#1010
     thresholdUsd = 5;
     backstopPersists = true;
     billingLedger = "kv";
+    deferredEnabled = false;
+    billingDeferredActual.__clearDeferredAdmissionState();
     writePendingInferenceCharge.mockClear();
     reserveCredits.mockClear();
     createOptimisticDebitSettler.mockClear();
+    optimisticInnerSettler.mockClear();
     admitInferenceChargeViaLedger.mockClear();
     createLedgerDebitSettler.mockClear();
+    ledgerInnerSettler.mockClear();
   });
 
   test("eligible org takes the optimistic path: writes backstop, skips the synchronous reserve", async () => {
@@ -423,5 +442,66 @@ describe("POST /api/v1/embeddings optimistic-billing route decision (#9899/#1010
       [{ affiliateCode?: string | null }]
     >;
     expect(reserveCalls[0]?.[0]?.affiliateCode).toBe("PARTNER1000");
+  });
+
+  describe("Tier-3 deferred admission (#9899)", () => {
+    test("KV backend starts admission under waitUntil and settles through the exactly-once settler", async () => {
+      deferredEnabled = true;
+      const { ctx, scheduled } = makeExecutionCtx();
+
+      const res = await post(
+        { model: "text-embedding-3-small", input: "hi" },
+        ctx,
+      );
+
+      expect(res.status).toBe(200);
+      expect(writePendingInferenceCharge).toHaveBeenCalledTimes(1);
+      expect(scheduled).toHaveLength(2);
+      await expect(scheduled[0]).resolves.toEqual({ admitted: true });
+      await Promise.all(scheduled);
+      expect(reserveCredits).not.toHaveBeenCalled();
+      expect(createOptimisticDebitSettler).toHaveBeenCalledTimes(1);
+      expect(optimisticInnerSettler).toHaveBeenCalledTimes(1);
+      expect(optimisticInnerSettler).toHaveBeenCalledWith(BACKSTOP_COST);
+    });
+
+    test("DB ledger backend defers admission once and skips the synchronous ledger branch", async () => {
+      deferredEnabled = true;
+      billingLedger = "db";
+      const { ctx, scheduled } = makeExecutionCtx();
+
+      const res = await post(
+        { model: "text-embedding-3-small", input: "hi" },
+        ctx,
+      );
+
+      expect(res.status).toBe(200);
+      expect(admitInferenceChargeViaLedger).toHaveBeenCalledTimes(1);
+      expect(scheduled).toHaveLength(2);
+      await expect(scheduled[0]).resolves.toEqual({ admitted: true });
+      await Promise.all(scheduled);
+      expect(reserveCredits).not.toHaveBeenCalled();
+      expect(writePendingInferenceCharge).not.toHaveBeenCalled();
+      expect(createLedgerDebitSettler).toHaveBeenCalledTimes(1);
+      expect(ledgerInnerSettler).toHaveBeenCalledTimes(1);
+      expect(ledgerInnerSettler).toHaveBeenCalledWith(BACKSTOP_COST);
+    });
+
+    test("executionCtx without waitUntil leaves the existing Tier-2 admission path unchanged", async () => {
+      deferredEnabled = true;
+
+      const res = await post(
+        {
+          model: "text-embedding-3-small",
+          input: "hi",
+        },
+        {} as ExecutionContext,
+      );
+
+      expect(res.status).toBe(200);
+      expect(writePendingInferenceCharge).toHaveBeenCalledTimes(1);
+      expect(createOptimisticDebitSettler).toHaveBeenCalledTimes(1);
+      expect(reserveCredits).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/cloud/api/__tests__/stripe-connect-webhook-route.test.ts
+++ b/packages/cloud/api/__tests__/stripe-connect-webhook-route.test.ts
@@ -242,7 +242,7 @@ describe("Stripe Connect payout webhook route", () => {
 // issue describes (#10117). Signature ops are local HMAC-SHA256 — no network.
 describe("Stripe Connect webhook — real signature verification (no mock)", () => {
   const realStripe = new Stripe("sk_test_dummy_for_signature_only", {
-    apiVersion: "2026-06-24.dahlia",
+    apiVersion: "2026-05-27.dahlia",
   });
   const secret = "whsec_connect_realtest";
   const payload = JSON.stringify(accountUpdatedEvent);

--- a/packages/cloud/api/v1/embeddings/route.ts
+++ b/packages/cloud/api/v1/embeddings/route.ts
@@ -37,6 +37,12 @@ import {
 } from "@/lib/services/ai-billing";
 import { resolveInferenceAuthContext } from "@/lib/services/inference-auth-context";
 import {
+  createDeferredAdmissionSettler,
+  type DeferredAdmissionOutcome,
+  isDeferredAdmissionEnabled,
+  isOrgAdmissionRefused,
+} from "@/lib/services/inference-billing-deferred";
+import {
   createOptimisticDebitSettler,
   getGateBalanceUsd,
   isOptimisticBackstopAvailable,
@@ -120,20 +126,19 @@ app.post("/", async (c) => {
       apiKeyId = c.get("apiKeyId") ?? null;
     }
 
-    if (user.organization_id) {
-      const orgRateLimited = await enforceOrgRateLimit(
-        user.organization_id,
-        "embeddings",
-      );
-      if (orgRateLimited) return orgRateLimited;
-    }
+    const orgRateLimitPromise = user.organization_id
+      ? enforceOrgRateLimit(user.organization_id, "embeddings")
+      : Promise.resolve(null);
 
     // Guard a malformed/empty body to a 400 instead of a 500 (mirrors the agents
     // routes). An unguarded parse throws a SyntaxError that failureResponse maps
     // to 500 on this always-on agent-recall hot path.
-    const request = (await c.req
+    const requestPromise = c.req
       .json()
-      .catch(() => null)) as EmbeddingsRequest | null;
+      .catch(() => null) as Promise<EmbeddingsRequest | null>;
+    const orgRateLimited = await orgRateLimitPromise;
+    if (orgRateLimited) return orgRateLimited;
+    const request = await requestPromise;
 
     if (!request?.model || !request.input) {
       return c.json(
@@ -254,7 +259,85 @@ app.post("/", async (c) => {
       optimisticAllowedForRequest &&
       resolveInferenceBillingLedger() === "db";
 
-    if (useDbLedger) {
+    // #9899 Tier-3 deferred admission: with a Workers executionCtx, start the
+    // durable ledger/KV admission write now and let it run under waitUntil while
+    // the provider call is in flight. The response path keeps only the cached
+    // balance/refusal gate; the post-response settler awaits admission before
+    // delegating to the existing exactly-once ledger/KV settler.
+    const deferAdmission =
+      !!orgId &&
+      optimisticAllowedForRequest &&
+      isDeferredAdmissionEnabled() &&
+      typeof c.executionCtx?.waitUntil === "function" &&
+      (useDbLedger || isOptimisticBackstopAvailable()) &&
+      !isOrgAdmissionRefused(orgId);
+
+    if (deferAdmission) {
+      const { totalCost: backstopEstimateUsd } = await calculateCost(
+        model,
+        provider,
+        estimatedInputTokens,
+        0,
+        billingSource,
+      );
+      const thresholdUsd = resolveSafeBalanceThresholdUsd();
+      const balanceUsd = await getGateBalanceUsd(orgId);
+      const useOptimistic = isOptimisticEligible({
+        enabled: true,
+        useAppCredits: false,
+        balanceUsd,
+        thresholdUsd,
+        estimatedCostUsd: backstopEstimateUsd,
+      });
+      if (useOptimistic) {
+        const chargeCtx = {
+          requestId,
+          organizationId: orgId,
+          userId: user.id,
+          apiKeyId,
+          model,
+          provider,
+          billingSource: billingSource ?? "",
+        };
+        const admission: Promise<DeferredAdmissionOutcome> = useDbLedger
+          ? admitInferenceChargeViaLedger({
+              charge: chargeCtx,
+              estimatedCostUsd: backstopEstimateUsd,
+              thresholdUsd,
+            })
+          : writePendingInferenceCharge(
+              { ...chargeCtx, estimatedCostUsd: backstopEstimateUsd },
+              Date.now(),
+            ).then((persisted) => ({ admitted: persisted }));
+        c.executionCtx?.waitUntil(admission);
+
+        const debitCtx = {
+          requestId,
+          organizationId: orgId,
+          userId: user.id,
+          model,
+          provider,
+          billingSource: billingSource ?? "",
+        };
+        const deferredSettler = createDeferredAdmissionSettler({
+          admission,
+          onAdmitted: useDbLedger
+            ? createLedgerDebitSettler(chargeCtx)
+            : createOptimisticDebitSettler(debitCtx),
+          fallback: debitCtx,
+        });
+        reservation = {
+          reservedAmount: 0,
+          reservationTransactionId: null,
+          reconcile: async (actualCost: number) => {
+            await deferredSettler(actualCost);
+          },
+        };
+        optimisticReady = true;
+      }
+    }
+
+    if (!optimisticReady && useDbLedger) {
       const { totalCost: backstopEstimateUsd } = await calculateCost(
         model,
         provider,


### PR DESCRIPTION
## Summary
- add Tier-3 deferred admission to /v1/embeddings for KV and DB-ledger optimistic billing
- parallelize org rate-limit admission with JSON body parsing on the embeddings hot path
- update the Stripe Connect webhook signature test fixture to the installed Stripe SDK API version so cloud-api typecheck passes

## Verification
- bun test --coverage-reporter=lcov packages/cloud/api/__tests__/embeddings-optimistic-billing.test.ts
- bun test --coverage-reporter=lcov packages/cloud/api/__tests__/embeddings-route-billing.test.ts
- bun test --coverage-reporter=lcov packages/cloud/api/__tests__/embeddings-passthrough.test.ts
- bun test --coverage-reporter=lcov packages/cloud/api/__tests__/embeddings-affiliate-reserve.test.ts
- bun test --coverage-reporter=lcov packages/cloud/api/__tests__/stripe-connect-webhook-route.test.ts
- bun run --cwd packages/cloud/api build
- bunx biome check packages/cloud/api/v1/embeddings/route.ts packages/cloud/api/__tests__/embeddings-optimistic-billing.test.ts packages/cloud/api/__tests__/stripe-connect-webhook-route.test.ts
- git diff --check
- bun run audit:error-policy-ratchet

Note: the embeddings route suites pass isolated. A combined multi-file run including passthrough + affiliate reserve still exposes pre-existing Bun mock.module route-import leakage between suites.