### PR TITLE
test(ui): add Safari chat sheet coverage

### DIFF
--- a/.github/workflows/chat-shell-gestures.yml
+++ b/.github/workflows/chat-shell-gestures.yml
@@ -129,6 +129,8 @@ jobs:
       # The iOS-style chat-sheet detent/gesture state machine (mouse + touch).
       - name: Chat-sheet gesture e2e
         run: bun run --cwd packages/ui test:chat-sheet-e2e
+      - name: Chat-sheet Safari/WebKit gesture smoke
+        run: bun run --cwd packages/ui test:chat-sheet-safari-e2e
 
       # "can't scroll chat on web" repro (#chat-scroll-web): seeds a long
       # transcript, opens the sheet to FULL, and asserts the transcript scroller
@@ -218,6 +220,7 @@ jobs:
           name: chat-shell-gesture-artifacts
           path: |
             packages/ui/src/components/shell/__e2e__/output/
+            packages/ui/src/components/shell/__e2e__/output-webkit/
             packages/ui/src/components/shell/__e2e__/output-chatux/
             packages/ui/src/components/shell/__e2e__/output-home/
             packages/ui/src/components/shell/__e2e__/output-launcher-loop/

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ packages/ui/src/components/chat/__e2e__/output-activity-feedback/
 packages/ui/src/components/chat/widgets/__e2e__/output/
 # Chat-sheet e2e output (screenshots + webm + html bundle — regenerate via test:chat-sheet-e2e)
 packages/ui/src/components/shell/__e2e__/output/
+packages/ui/src/components/shell/__e2e__/output-webkit/
+packages/ui/src/components/shell/__e2e__/output-mobile-safari/
 packages/ui/src/components/shell/__e2e__/output-frame-glitch/
 
 .next/

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -33,6 +33,8 @@
     "test:e2e": "bun run test:slow",
     "test:agent-surface-e2e": "bun run --cwd ../.. packages/ui/src/agent-surface/__e2e__/run-e2e.mjs",
     "test:chat-sheet-e2e": "bun run --cwd ../.. packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs",
+    "test:chat-sheet-safari-e2e": "bun run --cwd ../.. packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs --browser=webkit --smoke",
+    "test:chat-sheet-mobile-safari-smoke": "bun run --cwd ../.. packages/ui/src/components/shell/__e2e__/run-chat-sheet-mobile-safari-smoke.mjs",
     "test:settings-e2e": "bun run --cwd ../.. packages/ui/src/components/pages/__e2e__/run-settings-e2e.mjs",
     "test:chat-scroll-web-e2e": "bun run --cwd ../.. packages/ui/src/components/shell/__e2e__/run-chat-scroll-web-e2e.mjs",
     "test:widget-cert-e2e": "bun run --cwd ../.. packages/ui/src/testing/__e2e__/run-widget-cert-e2e.mjs",

--- a/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
@@ -1,7 +1,8 @@
 /**
  * Real-browser e2e for the iOS-style three-detent continuous-chat sheet — no app
  * server. Bundles chat-sheet-fixture.tsx with esbuild, loads it in headless
- * chromium via Playwright, and drives the sheet with REAL pointer gestures.
+ * chromium/webkit via Playwright, and drives the sheet with REAL pointer
+ * gestures.
  *
  * Coverage (the user asked for exhaustive interaction + state testing):
  *   - DETENTS: peek (76px) → half (46vh) → full (72vh), stepped by pulls.
@@ -26,15 +27,17 @@
  *   - Screenshots every state; captures the browser console and fails on any
  *     page error or error-level log.
  *
- * Run: bun run --cwd packages/ui test:chat-sheet-e2e
- *      bun run --cwd packages/ui test:chat-sheet-e2e -- --only-autoscroll
+ * Run:
+ *   bun run --cwd packages/ui test:chat-sheet-e2e
+ *   bun run --cwd packages/ui test:chat-sheet-safari-e2e
+ *   bun run --cwd packages/ui test:chat-sheet-e2e -- --only-autoscroll
  * Exits non-zero on any failed assertion / console error.
  */
 
 import { mkdir } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { chromium } from "playwright";
+import { chromium, webkit } from "playwright";
 import { PNG } from "pngjs";
 import {
   renameRecordedVideo,
@@ -49,7 +52,12 @@ import {
 } from "../../../testing/real-touch-gestures.ts";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const outDir = join(here, "output");
+const browserName = process.argv.includes("--browser=webkit")
+  ? "webkit"
+  : "chromium";
+const smokeMode = process.argv.includes("--smoke");
+const browserType = browserName === "webkit" ? webkit : chromium;
+const outDir = join(here, browserName === "webkit" ? "output-webkit" : "output");
 const videoDir = join(outDir, "video");
 const ONLY_AUTOSCROLL =
   process.argv.includes("--only-autoscroll") ||
@@ -1281,7 +1289,8 @@ async function runAutoScrollSuite(p, pointer, tag) {
   await snap(p, `${tag}-autoscroll-jump-repinned`);
 }
 
-const browser = await chromium.launch();
+console.log(`\nCHAT-SHEET E2E using Playwright ${browserName}`);
+const browser = await browserType.launch();
 const sink = { logs: [], errors: [] };
 
 // FINGER-SYNC DIAGNOSTIC (env FINGER_PROBE=1): grab the pill and drag SLOWLY to
@@ -1789,6 +1798,75 @@ if (process.env.FINGER_PROBE) {
 }
 
 try {
+  if (smokeMode) {
+    // Safari/WebKit smoke: focused cross-engine coverage for the state machine
+    // without importing Chromium's full pixel/animation tolerance matrix. This
+    // still mounts the real overlay, captures screenshots, and drives WebKit
+    // pointer paths through the grabber/composer controls in desktop and mobile
+    // viewports. Mobile Safari visual coverage lives in
+    // run-chat-sheet-mobile-safari-smoke.mjs because Playwright WebKit does not
+    // expose Chromium's low-level touch-drag injection API.
+    const desktop = await browser.newPage({ viewport: { width: 1180, height: 820 } });
+    attachConsole(desktop, sink);
+    await gotoFixture(desktop);
+    await desktop.waitForSelector('[data-testid="chat-sheet"]');
+    await desktop.waitForTimeout(700);
+    assert((await variant(desktop)) === "closed", "[webkit mouse] starts closed");
+    await snap(desktop, "safari-desktop-collapsed");
+    await gesture(desktop, 140, { pointer: "mouse", slow: false, steps: 3 });
+    await desktop.waitForTimeout(SETTLE);
+    assert((await variant(desktop)) === "open", "[webkit mouse] flick opens the sheet");
+    assert(await headerShown(desktop), "[webkit mouse] open sheet exposes the header strip");
+    assert(
+      await desktop.getByTestId("chat-composer-textarea").isVisible(),
+      "[webkit mouse] open sheet keeps the composer usable",
+    );
+    await snap(desktop, "safari-desktop-open");
+    const draft = desktop.getByTestId("chat-composer-textarea");
+    await draft.fill("webkit smoke message");
+    await desktop.waitForTimeout(150);
+    assert(
+      await desktop.getByTestId("chat-composer-action").isVisible(),
+      "[webkit mouse] typing swaps the trailing control to send",
+    );
+    await desktop.getByTestId("chat-composer-action").click({ force: true });
+    await desktop.waitForTimeout(200);
+    assert(
+      sink.logs.some((l) => l.includes("[fixture] send:")),
+      "[webkit mouse] send routes through the fixture controller",
+    );
+    await desktop.close();
+
+    const mobileCtx = await browser.newContext({
+      viewport: { width: 402, height: 874 },
+      hasTouch: true,
+      isMobile: true,
+      deviceScaleFactor: 2,
+    });
+    const mobile = await mobileCtx.newPage();
+    attachConsole(mobile, sink);
+    await gotoFixture(mobile);
+    await mobile.waitForSelector('[data-testid="chat-sheet"]');
+    await mobile.waitForTimeout(700);
+    assert((await variant(mobile)) === "closed", "[webkit mobile] starts closed");
+    await gesture(mobile, 140, { pointer: "mouse", slow: false, steps: 3 });
+    await mobile.waitForTimeout(SETTLE);
+    assert((await variant(mobile)) === "open", "[webkit mobile] flick opens the sheet");
+    assert(
+      await mobile.getByTestId("chat-composer-textarea").isVisible(),
+      "[webkit mobile] open sheet keeps the composer usable",
+    );
+    await snap(mobile, "safari-mobile-open");
+    await gesture(mobile, -180, { pointer: "mouse", slow: false, steps: 3 });
+    await mobile.waitForTimeout(SETTLE);
+    assert(
+      ["closed", "open"].includes(await variant(mobile)),
+      `[webkit mobile] downward flick settles to a valid state (${await variant(mobile)})`,
+    );
+    await snap(mobile, "safari-mobile-after-close-flick");
+    await mobile.close();
+    await mobileCtx.close();
+  } else {
   if (!ONLY_AUTOSCROLL) {
     // ===== DESKTOP + MOUSE =====
     const desktop = await browser.newPage({ viewport: { width: 1180, height: 820 } });
@@ -3551,6 +3629,7 @@ try {
     await p.close();
   }
   }
+  }
 } finally {
   await browser.close();
 }
@@ -3563,7 +3642,7 @@ assert(sink.errors.length === 0, `no uncaught page errors (${sink.errors.length}
 if (sink.errors.length) for (const e of sink.errors) console.error(`  ⚠ ${e}`);
 assert(errorLevel.length === 0, `no error-level console messages (${errorLevel.length})`);
 if (errorLevel.length) for (const e of errorLevel) console.error(`  ⚠ ${e}`);
-if (!ONLY_AUTOSCROLL) {
+if (!ONLY_AUTOSCROLL && !smokeMode) {
   assert(
     sink.logs.some(
       (l) =>

--- a/packages/ui/src/components/shell/__e2e__/run-chat-sheet-mobile-safari-smoke.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-sheet-mobile-safari-smoke.mjs
@@ -1,0 +1,210 @@
+/**
+ * Real Mobile Safari visual smoke for the continuous-chat sheet.
+ *
+ * This is intentionally a visual simulator smoke, not a gesture automation
+ * suite: plain `xcrun simctl` can boot/open/capture Mobile Safari, but does not
+ * expose tap/swipe primitives. Gesture assertions stay in the Playwright WebKit
+ * lane; this script proves the generated fixture renders in actual Mobile
+ * Safari chrome on an iOS Simulator and captures the screen as evidence.
+ *
+ * Run:
+ *   bun run --cwd packages/ui test:chat-sheet-mobile-safari-smoke
+ *
+ * Optional env:
+ *   IOS_SIMULATOR_UDID=<device udid>
+ *   IOS_SIMULATOR_NAME="iPhone 16 Pro"
+ *   MOBILE_SAFARI_SMOKE_PORT=8765
+ *   MOBILE_SAFARI_SMOKE_HOST=<host address visible to the simulator>
+ */
+
+import { createServer } from "node:http";
+import { mkdir, readFile, stat } from "node:fs/promises";
+import { networkInterfaces } from "node:os";
+import { basename, dirname, extname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+import { PNG } from "pngjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, "../../../../../..");
+const fixtureDir = join(here, "output-webkit");
+const fixtureHtml = join(fixtureDir, "chat-sheet.html");
+const mobileOutputDir = join(here, "output-mobile-safari");
+const screenshotPath = join(mobileOutputDir, "mobile-safari-closed.png");
+const port = Number.parseInt(process.env.MOBILE_SAFARI_SMOKE_PORT ?? "8765", 10);
+const requestedName = process.env.IOS_SIMULATOR_NAME ?? "iPhone 16 Pro";
+
+function log(message) {
+  console.log(`[mobile-safari] ${message}`);
+}
+
+function run(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd ?? repoRoot,
+      stdio: options.capture ? ["ignore", "pipe", "pipe"] : "inherit",
+      env: process.env,
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0 || options.allowFailure) {
+        resolve({ code, stdout, stderr });
+      } else {
+        const rendered = [command, ...args].join(" ");
+        reject(new Error(`${rendered} exited with ${code}\n${stderr}`));
+      }
+    });
+  });
+}
+
+function hostAddress() {
+  if (process.env.MOBILE_SAFARI_SMOKE_HOST) {
+    return process.env.MOBILE_SAFARI_SMOKE_HOST;
+  }
+  for (const addrs of Object.values(networkInterfaces())) {
+    for (const addr of addrs ?? []) {
+      if (addr.family === "IPv4" && !addr.internal) return addr.address;
+    }
+  }
+  return "localhost";
+}
+
+async function selectDevice() {
+  if (process.env.IOS_SIMULATOR_UDID) return process.env.IOS_SIMULATOR_UDID;
+
+  const { stdout } = await run(
+    "xcrun",
+    ["simctl", "list", "devices", "available", "--json"],
+    { capture: true },
+  );
+  const parsed = JSON.parse(stdout);
+  const runtimes = Object.entries(parsed.devices ?? {}).filter(([runtime]) =>
+    runtime.includes("iOS"),
+  );
+  const allIosDevices = runtimes.flatMap(([, devices]) => devices);
+  const named = allIosDevices.find((device) => device.name === requestedName);
+  const fallback = allIosDevices.find((device) => device.name?.startsWith("iPhone"));
+  const selected = named ?? fallback;
+  if (!selected?.udid) {
+    throw new Error(
+      `No available iOS Simulator found. Tried IOS_SIMULATOR_NAME=${JSON.stringify(
+        requestedName,
+      )}.`,
+    );
+  }
+  return selected.udid;
+}
+
+function contentType(path) {
+  switch (extname(path)) {
+    case ".html":
+      return "text/html; charset=utf-8";
+    case ".js":
+      return "text/javascript; charset=utf-8";
+    case ".css":
+      return "text/css; charset=utf-8";
+    case ".png":
+      return "image/png";
+    default:
+      return "application/octet-stream";
+  }
+}
+
+async function serveFixture() {
+  const server = createServer(async (request, response) => {
+    const url = new URL(request.url ?? "/", `http://127.0.0.1:${port}`);
+    const name = basename(url.pathname === "/" ? "chat-sheet.html" : url.pathname);
+    const file = join(fixtureDir, name);
+    try {
+      const body = await readFile(file);
+      response.writeHead(200, {
+        "content-type": contentType(file),
+        "cache-control": "no-store",
+      });
+      response.end(request.method === "HEAD" ? undefined : body);
+    } catch {
+      response.writeHead(404, { "content-type": "text/plain; charset=utf-8" });
+      response.end("not found");
+    }
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, "0.0.0.0", resolve);
+  });
+  return server;
+}
+
+async function assertRenderedContent(path) {
+  const image = PNG.sync.read(await readFile(path));
+  let darkPixels = 0;
+  let saturatedPixels = 0;
+  for (let y = 120; y < image.height - 260; y += 1) {
+    for (let x = 0; x < image.width; x += 1) {
+      const offset = (image.width * y + x) << 2;
+      const r = image.data[offset];
+      const g = image.data[offset + 1];
+      const b = image.data[offset + 2];
+      if (r < 80 && g < 80 && b < 110) darkPixels += 1;
+      if (Math.max(r, g, b) - Math.min(r, g, b) > 40) saturatedPixels += 1;
+    }
+  }
+  if (darkPixels < 10_000 && saturatedPixels < 10_000) {
+    throw new Error(
+      `Mobile Safari screenshot appears blank or did not render the fixture (darkPixels=${darkPixels}, saturatedPixels=${saturatedPixels})`,
+    );
+  }
+}
+
+async function main() {
+  log("building WebKit fixture via Playwright smoke");
+  await run(process.execPath, ["run", "--cwd", "packages/ui", "test:chat-sheet-safari-e2e"]);
+  await stat(fixtureHtml);
+
+  const udid = await selectDevice();
+  log(`using simulator ${udid}`);
+
+  log("booting simulator");
+  const boot = await run("xcrun", ["simctl", "boot", udid], {
+    allowFailure: true,
+    capture: true,
+  });
+  if (boot.code !== 0 && !/current state: Booted|Unable to boot device in current state/i.test(boot.stderr)) {
+    throw new Error(`xcrun simctl boot failed:\n${boot.stderr}`);
+  }
+  await run("xcrun", ["simctl", "bootstatus", udid, "-b"]);
+
+  await mkdir(mobileOutputDir, { recursive: true });
+  const server = await serveFixture();
+  try {
+    const url = `http://${hostAddress()}:${port}/chat-sheet.html`;
+    log(`opening Mobile Safari: ${url}`);
+    await run("xcrun", ["simctl", "openurl", udid, url]);
+    await new Promise((resolve) => setTimeout(resolve, 3500));
+
+    log(`capturing screenshot: ${screenshotPath}`);
+    await run("xcrun", ["simctl", "io", udid, "screenshot", screenshotPath]);
+    const shot = await stat(screenshotPath);
+    if (shot.size < 10_000) {
+      throw new Error(`screenshot looked too small (${shot.size} bytes)`);
+    }
+    await assertRenderedContent(screenshotPath);
+    log(`PASS: Mobile Safari screenshot written to ${screenshotPath}`);
+    log("Note: simctl cannot automate Safari gestures; use Playwright WebKit for gesture assertions.");
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/ui/src/components/shell/use-pull-gesture.test.ts
+++ b/packages/ui/src/components/shell/use-pull-gesture.test.ts
@@ -228,6 +228,34 @@ describe("usePullGesture rAF coalescing (#9141)", () => {
     expect(onSettleFree).not.toHaveBeenCalled();
   });
 
+  it("uses pointer event timestamps for short flick velocity", () => {
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((cb: FrameRequestCallback) => {
+        cb(0);
+        return 1;
+      }),
+    );
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+    vi.spyOn(performance, "now")
+      .mockReturnValueOnce(1000)
+      .mockReturnValueOnce(1300);
+
+    const onPullUp = vi.fn();
+    const onDragReset = vi.fn();
+    const { result } = renderHook(() =>
+      usePullGesture({ onPullUp, onDragReset }),
+    );
+    const b = result.current;
+
+    b.onPointerDown(pointer(100, 300, 1, undefined, { timeStamp: 10 }));
+    b.onPointerMove(pointer(100, 260, 1, undefined, { timeStamp: 50 }));
+    b.onPointerUp(pointer(100, 252, 1, undefined, { timeStamp: 70 }));
+
+    expect(onPullUp).toHaveBeenCalledTimes(1);
+    expect(onDragReset).not.toHaveBeenCalled();
+  });
+
   it("uses the tracked touch sample when pointerup reports stale coordinates", () => {
     vi.stubGlobal(
       "requestAnimationFrame",

--- a/packages/ui/src/components/shell/use-pull-gesture.ts
+++ b/packages/ui/src/components/shell/use-pull-gesture.ts
@@ -166,6 +166,11 @@ export function usePullGesture(
       drag.schedule({ axis: nextAxis, value }),
     [drag],
   );
+  const eventTime = React.useCallback((event: React.PointerEvent): number => {
+    return Number.isFinite(event.timeStamp) && event.timeStamp > 0
+      ? event.timeStamp
+      : performance.now();
+  }, []);
 
   const onPointerDown = React.useCallback(
     (event: React.PointerEvent) => {
@@ -188,7 +193,7 @@ export function usePullGesture(
       start.current = {
         x: event.clientX,
         y: event.clientY,
-        t: performance.now(),
+        t: eventTime(event),
         pointerId: event.pointerId,
       };
       axis.current = null;
@@ -207,7 +212,7 @@ export function usePullGesture(
         }
       }
     },
-    [hasSwipe, hasVerticalPull, onStart],
+    [hasSwipe, hasVerticalPull, onStart, eventTime],
   );
 
   const onPointerMove = React.useCallback(
@@ -218,7 +223,7 @@ export function usePullGesture(
       last.current = {
         x: event.clientX,
         y: event.clientY,
-        t: performance.now(),
+        t: eventTime(event),
       };
       const dy = s.y - event.clientY; // up positive
       const dx = s.x - event.clientX; // left positive
@@ -266,7 +271,15 @@ export function usePullGesture(
         scheduleDrag("y", dy); // pre-commit: drive the vertical sheet
       }
     },
-    [hasSwipe, hasVerticalPull, onDragReset, onDragX, scheduleDrag, drag],
+    [
+      hasSwipe,
+      hasVerticalPull,
+      onDragReset,
+      onDragX,
+      scheduleDrag,
+      drag,
+      eventTime,
+    ],
   );
 
   const finish = React.useCallback(
@@ -303,7 +316,7 @@ export function usePullGesture(
       const deltaLeft = useLastSample ? lastDeltaLeft : eventDeltaLeft;
       const elapsed = Math.max(
         1,
-        (useLastSample && lastSample ? lastSample.t : performance.now()) - s.t,
+        (useLastSample && lastSample ? lastSample.t : eventTime(event)) - s.t,
       );
       const velocityUp = deltaUp / elapsed;
       const velocityLeft = deltaLeft / elapsed;
@@ -415,6 +428,7 @@ export function usePullGesture(
       velocityThreshold,
       distanceThresholdX,
       velocityThresholdX,
+      eventTime,
     ],
   );
 


### PR DESCRIPTION
## Summary

- Add a Playwright WebKit smoke lane for the chat-sheet gesture fixture and wire it into the chat shell gesture workflow artifact upload.
- Add a local Mobile Safari simulator visual smoke helper that serves the WebKit fixture, opens it in Mobile Safari, captures a screenshot, and fails on blank captures.
- Use pointer event timestamps in `usePullGesture` velocity calculations so Safari/WebKit short flicks do not get diluted by stale `performance.now()` timing, with a regression test.

## Notes

- Playwright WebKit does not expose Chromium CDP touch-drag injection, so CI covers WebKit pointer gestures in desktop and mobile viewports. The Mobile Safari helper is a real simulator visual smoke, not gesture automation.
- The Mobile Safari smoke now opens the Mac's reachable interface by default and supports `MOBILE_SAFARI_SMOKE_HOST` when a specific host is needed.

## Verification

- `bunx vitest run packages/ui/src/components/shell/use-pull-gesture.test.ts`
- `bun run --cwd packages/ui test:chat-sheet-safari-e2e`
- `bun run --cwd packages/ui test:chat-sheet-mobile-safari-smoke`
- `bunx @biomejs/biome check .gitignore packages/ui/package.json packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs packages/ui/src/components/shell/__e2e__/run-chat-sheet-mobile-safari-smoke.mjs packages/ui/src/components/shell/use-pull-gesture.ts packages/ui/src/components/shell/use-pull-gesture.test.ts`
- `git diff --check -- .github/workflows/chat-shell-gestures.yml .gitignore packages/ui/package.json packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs packages/ui/src/components/shell/__e2e__/run-chat-sheet-mobile-safari-smoke.mjs packages/ui/src/components/shell/use-pull-gesture.ts packages/ui/src/components/shell/use-pull-gesture.test.ts`

