### PR TITLE
chore(mvp): add strict board audit mode

### DIFF
--- a/packages/scripts/__tests__/audit-mvp-project-board.test.ts
+++ b/packages/scripts/__tests__/audit-mvp-project-board.test.ts
@@ -5,10 +5,16 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const board = await import(
   new URL("../audit-mvp-project-board.mjs", import.meta.url).href
 );
+const scriptPath = new URL("../audit-mvp-project-board.mjs", import.meta.url)
+  .pathname;
 
 const projectItems = [
   {
@@ -104,5 +110,106 @@ describe("audit-mvp-project-board", () => {
     expect(text).toContain("Open MVP issues not Done and not human-gated");
     expect(text).toContain("#3 In progress — Agent tractable");
     expect(text).toContain("open-but-Done: 1");
+  });
+
+  test("strictViolations returns the stale buckets that should fail closeout", () => {
+    const summary = board.summarizeMvpBoard({
+      projectItems,
+      openIssues: [{ number: 2 }, { number: 3 }, { number: 4 }],
+      closedIssues: [{ number: 1 }],
+    });
+
+    expect(board.strictViolations(summary)).toEqual([
+      expect.objectContaining({ type: "closed-not-done", count: 1 }),
+      expect.objectContaining({ type: "agent-actionable-open", count: 1 }),
+      expect.objectContaining({ type: "open-done", count: 1 }),
+    ]);
+  });
+
+  test("CLI fixture mode exits non-zero in strict mode and prints JSON violations", () => {
+    const dir = mkdtempSync(join(tmpdir(), "mvp-board-audit-"));
+    const projectJson = join(dir, "project.json");
+    const openJson = join(dir, "open.json");
+    const closedJson = join(dir, "closed.json");
+    writeFileSync(projectJson, JSON.stringify({ items: projectItems }));
+    writeFileSync(
+      openJson,
+      JSON.stringify([{ number: 2 }, { number: 3 }, { number: 4 }]),
+    );
+    writeFileSync(closedJson, JSON.stringify([{ number: 1 }]));
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        scriptPath,
+        "--project-json",
+        projectJson,
+        "--open-json",
+        openJson,
+        "--closed-json",
+        closedJson,
+        "--json",
+        "--strict",
+      ],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("strict failed");
+    const parsed = JSON.parse(result.stdout);
+    expect(
+      parsed.strictViolations.map(
+        (violation: { type: string }) => violation.type,
+      ),
+    ).toEqual(["closed-not-done", "agent-actionable-open", "open-done"]);
+  });
+
+  test("CLI fixture mode exits zero in strict mode when only human-gated rows remain", () => {
+    const dir = mkdtempSync(join(tmpdir(), "mvp-board-audit-clean-"));
+    const projectJson = join(dir, "project.json");
+    const openJson = join(dir, "open.json");
+    const closedJson = join(dir, "closed.json");
+    writeFileSync(
+      projectJson,
+      JSON.stringify({
+        items: [
+          {
+            content: {
+              type: "Issue",
+              number: 2,
+              title: "Needs device evidence",
+              url: "https://github.com/elizaOS/eliza/issues/2",
+            },
+            title: "Needs device evidence",
+            status: "Needs human review",
+            labels: ["mvp", "needs-human"],
+          },
+        ],
+      }),
+    );
+    writeFileSync(openJson, JSON.stringify([{ number: 2 }]));
+    writeFileSync(closedJson, JSON.stringify([]));
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        scriptPath,
+        "--project-json",
+        projectJson,
+        "--open-json",
+        openJson,
+        "--closed-json",
+        closedJson,
+        "--json",
+        "--strict",
+      ],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.strictViolations).toEqual([]);
+    expect(parsed.counts.humanGated).toBe(1);
   });
 });

--- a/packages/scripts/audit-mvp-project-board.mjs
+++ b/packages/scripts/audit-mvp-project-board.mjs
@@ -7,6 +7,7 @@
  */
 
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import process from "node:process";
 
 const DEFAULT_OWNER = "elizaOS";
@@ -15,15 +16,86 @@ const DEFAULT_PROJECT = "15";
 const DEFAULT_LIMIT = "500";
 const DONE_STATUS = "Done";
 
-function argValue(name, fallback) {
-  const index = process.argv.indexOf(name);
-  if (index !== -1) return process.argv[index + 1] ?? fallback;
-  const inline = process.argv.find((arg) => arg.startsWith(`${name}=`));
-  return inline ? inline.slice(name.length + 1) : fallback;
+function usage() {
+  return `Usage:
+  node packages/scripts/audit-mvp-project-board.mjs [--json] [--strict]
+  node packages/scripts/audit-mvp-project-board.mjs --project-json project.json --open-json open.json --closed-json closed.json [--json] [--strict]
+
+Options:
+  --owner <org>        GitHub Project owner for live mode (default: ${DEFAULT_OWNER}).
+  --project <number>  GitHub Project number for live mode (default: ${DEFAULT_PROJECT}).
+  --repo <owner/repo> GitHub repo for live mode (default: ${DEFAULT_REPO}).
+  --limit <n>         GitHub item/page limit (default: ${DEFAULT_LIMIT}).
+  --strict            Exit 1 when any stale/actionable bucket is non-empty.`;
+}
+
+function parseArgs(argv) {
+  const out = {
+    owner: DEFAULT_OWNER,
+    repo: DEFAULT_REPO,
+    project: DEFAULT_PROJECT,
+    limit: DEFAULT_LIMIT,
+    json: false,
+    strict: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--json") {
+      out.json = true;
+    } else if (arg === "--strict") {
+      out.strict = true;
+    } else if (arg === "--help" || arg === "-h") {
+      out.help = true;
+    } else if (
+      arg === "--owner" ||
+      arg === "--project" ||
+      arg === "--repo" ||
+      arg === "--limit" ||
+      arg === "--project-json" ||
+      arg === "--open-json" ||
+      arg === "--closed-json"
+    ) {
+      const value = argv[i + 1];
+      if (!value) throw new Error(`${arg} requires a value`);
+      out[
+        arg
+          .slice(2)
+          .replace(/-([a-z])/g, (_match, letter) => letter.toUpperCase())
+      ] = value;
+      i += 1;
+    } else if (arg.includes("=")) {
+      const [name, value] = arg.split(/=(.*)/s);
+      if (
+        ![
+          "--owner",
+          "--project",
+          "--repo",
+          "--limit",
+          "--project-json",
+          "--open-json",
+          "--closed-json",
+        ].includes(name)
+      ) {
+        throw new Error(`Unknown argument: ${arg}`);
+      }
+      out[
+        name
+          .slice(2)
+          .replace(/-([a-z])/g, (_match, letter) => letter.toUpperCase())
+      ] = value;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return out;
 }
 
 function ghJson(args) {
   return JSON.parse(execFileSync("gh", args, { encoding: "utf8" }));
+}
+
+function readJson(file) {
+  return JSON.parse(readFileSync(file, "utf8"));
 }
 
 export function normalizeProjectIssue(item) {
@@ -89,6 +161,32 @@ export function summarizeMvpBoard({ projectItems, openIssues, closedIssues }) {
   };
 }
 
+export function strictViolations(summary) {
+  const violations = [];
+  if (summary.closedNotDone.length > 0) {
+    violations.push({
+      type: "closed-not-done",
+      count: summary.closedNotDone.length,
+      message: `${summary.closedNotDone.length} closed MVP issue(s) are not marked Done`,
+    });
+  }
+  if (summary.agentActionable.length > 0) {
+    violations.push({
+      type: "agent-actionable-open",
+      count: summary.agentActionable.length,
+      message: `${summary.agentActionable.length} open MVP issue(s) are neither Done nor human-gated`,
+    });
+  }
+  if (summary.openDone.length > 0) {
+    violations.push({
+      type: "open-done",
+      count: summary.openDone.length,
+      message: `${summary.openDone.length} open MVP issue(s) are already marked Done`,
+    });
+  }
+  return violations;
+}
+
 function formatIssue(issue) {
   const labels = issue.labels.length > 0 ? ` [${issue.labels.join(",")}]` : "";
   return `#${issue.number} ${issue.status ?? "(no status)"} — ${issue.title}${labels}`;
@@ -123,62 +221,90 @@ export function formatSummary(summary) {
 }
 
 async function main() {
-  const owner = argValue("--owner", DEFAULT_OWNER);
-  const project = argValue("--project", DEFAULT_PROJECT);
-  const repo = argValue("--repo", DEFAULT_REPO);
-  const limit = argValue("--limit", DEFAULT_LIMIT);
-  const jsonMode = process.argv.includes("--json");
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(`${usage()}\n`);
+    return;
+  }
+  const fixtureInputs = [
+    args.projectJson,
+    args.openJson,
+    args.closedJson,
+  ].filter(Boolean);
+  if (fixtureInputs.length > 0 && fixtureInputs.length !== 3) {
+    throw new Error(
+      "--project-json, --open-json, and --closed-json must be passed together",
+    );
+  }
 
-  const projectData = ghJson([
-    "project",
-    "item-list",
-    project,
-    "--owner",
-    owner,
-    "--format",
-    "json",
-    "--limit",
-    limit,
-  ]);
-  const openIssues = ghJson([
-    "issue",
-    "list",
-    "--repo",
-    repo,
-    "--state",
-    "open",
-    "--label",
-    "mvp",
-    "--limit",
-    limit,
-    "--json",
-    "number,title,labels,url",
-  ]);
-  const closedIssues = ghJson([
-    "issue",
-    "list",
-    "--repo",
-    repo,
-    "--state",
-    "closed",
-    "--label",
-    "mvp",
-    "--limit",
-    limit,
-    "--json",
-    "number,title,labels,url",
-  ]);
+  const projectData = args.projectJson
+    ? readJson(args.projectJson)
+    : ghJson([
+        "project",
+        "item-list",
+        args.project,
+        "--owner",
+        args.owner,
+        "--format",
+        "json",
+        "--limit",
+        args.limit,
+      ]);
+  const openIssues = args.openJson
+    ? readJson(args.openJson)
+    : ghJson([
+        "issue",
+        "list",
+        "--repo",
+        args.repo,
+        "--state",
+        "open",
+        "--label",
+        "mvp",
+        "--limit",
+        args.limit,
+        "--json",
+        "number,title,labels,url",
+      ]);
+  const closedIssues = args.closedJson
+    ? readJson(args.closedJson)
+    : ghJson([
+        "issue",
+        "list",
+        "--repo",
+        args.repo,
+        "--state",
+        "closed",
+        "--label",
+        "mvp",
+        "--limit",
+        args.limit,
+        "--json",
+        "number,title,labels,url",
+      ]);
 
   const summary = summarizeMvpBoard({
     projectItems: projectData.items ?? [],
     openIssues,
     closedIssues,
   });
+  const violations = strictViolations(summary);
+  const output = args.json
+    ? { ...summary, strictViolations: violations }
+    : null;
   process.stdout.write(
-    jsonMode
-      ? `${JSON.stringify(summary, null, 2)}\n`
+    args.json
+      ? `${JSON.stringify(output, null, 2)}\n`
       : `${formatSummary(summary)}\n`,
   );
+  if (args.strict && violations.length > 0) {
+    process.stderr.write(
+      `[audit-mvp-project-board] strict failed: ${violations
+        .map((violation) => violation.message)
+        .join("; ")}\n`,
+    );
+    process.exitCode = 1;
+  }
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {


### PR DESCRIPTION
# Relates to

MVP Project 15 verification automation / closeout process hardening.

- [x] This PR targets `develop` and is based on latest `origin/develop` at branch creation.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Branch created from latest fetched `origin/develop`; zero conflicts at branch creation.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. This changes a read-only audit script and its offline tests. It does not change app/runtime behavior.

# Background

## What does this PR do?

Strengthens `bun run audit:mvp-board` so it can be used as a strict closeout gate, not only a passive report.

Added:
- `--strict`, which exits non-zero when any stale closeout bucket is present:
  - closed MVP issues not marked `Done`,
  - open MVP issues that are not `Done` and not human-gated,
  - open MVP issues already marked `Done`.
- `--project-json`, `--open-json`, and `--closed-json` fixture inputs so agents and tests can validate the policy without live GitHub access.
- JSON output now includes `strictViolations`.
- Offline tests cover strict pass and fail paths.

## What kind of change is this?

Improvements: process/verification automation.

# Documentation changes needed?

No separate docs needed; `--help` documents usage and the root script already exists.

# Testing

## Where should a reviewer start?

Run:

```bash
bun test packages/scripts/__tests__/audit-mvp-project-board.test.ts
```

## Detailed testing steps

```bash
bunx @biomejs/biome check --write packages/scripts/audit-mvp-project-board.mjs packages/scripts/__tests__/audit-mvp-project-board.test.ts
bun test packages/scripts/__tests__/audit-mvp-project-board.test.ts
git diff --check
```

Focused test output:

```text
packages/scripts/__tests__/audit-mvp-project-board.test.ts:
(pass) audit-mvp-project-board > summarizeMvpBoard separates stale, human-gated, and actionable rows
(pass) audit-mvp-project-board > formatSummary includes each actionable section
(pass) audit-mvp-project-board > strictViolations returns the stale buckets that should fail closeout
(pass) audit-mvp-project-board > CLI fixture mode exits non-zero in strict mode and prints JSON violations
(pass) audit-mvp-project-board > CLI fixture mode exits zero in strict mode when only human-gated rows remain

5 pass
0 fail
```

Live GitHub note: `gh project item-list 15 --owner elizaOS` currently returns `unknown owner type` while this account's GraphQL bucket is exhausted (`remaining: 0`, reset `1783573839`). The new fixture mode is specifically added so this policy can still be validated deterministically when live Project API access is unavailable.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - CLI/process automation only; no UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - CLI/process automation only; no UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - CLI/process automation only; focused command output above is the reviewer flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend runtime path changed; the CLI exits are covered by offline fixture tests above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code, browser state, or network path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain data was modified; this PR adds a stricter read-only Project 15 audit mode with fixture-proven pass/fail artifacts in the test output above.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model behavior changed.

## Backend + frontend logs

N/A - no backend or frontend runtime changed.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI changed.

## Known gaps / failures

`bun run verify` was not run for this narrow script-only PR. Focused validation passed. Live `audit:mvp-board` is temporarily blocked by the GitHub GraphQL rate bucket for this account, so this PR validates the new strict policy through fixture-mode CLI tests.