### PR TITLE
perf(cloud): lease Hono rate-limit hot path

### DIFF
--- a/packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts
@@ -10,6 +10,7 @@
 import type { Context, MiddlewareHandler } from "hono";
 import type { AppContext, AppEnv, Bindings } from "../../types/cloud-worker-env";
 import { buildRedisClient, type CompatibleRedis } from "../cache/redis-factory";
+import { isHotPathCachesEnabled } from "../services/inference-hot-path-caches";
 import { logger } from "../utils/logger";
 
 export interface RateLimitConfig {
@@ -155,6 +156,92 @@ interface LocalFallbackBucket {
 
 const redisUnavailableFallbackBuckets = new Map<string, LocalFallbackBucket>();
 
+const HONO_RATE_LIMIT_LEASE_TTL_MS = 5_000;
+const HONO_RATE_LIMIT_LEASE_MAX_KEYS = 4096;
+
+interface HonoRateLimitLease {
+  result: CheckResult;
+  localUsed: number;
+  localBudget: number;
+  expiresAt: number;
+  flushToken?: symbol;
+}
+
+const honoRateLimitLeases = new Map<string, HonoRateLimitLease>();
+
+function honoLeaseKey(key: string, config: RateLimitConfig): string {
+  return `${key}:${config.windowMs}:${config.maxRequests}`;
+}
+
+function evictSettledHonoLeases(now: number): void {
+  if (honoRateLimitLeases.size < HONO_RATE_LIMIT_LEASE_MAX_KEYS) return;
+  for (const [key, lease] of honoRateLimitLeases) {
+    if (lease.expiresAt <= now && lease.localUsed === 0) {
+      honoRateLimitLeases.delete(key);
+    }
+  }
+}
+
+function startHonoLeaseFlush(leaseKey: string): {
+  lease?: HonoRateLimitLease;
+  carriedCount: number;
+  flushToken: symbol;
+  ownsLeaseFlush: boolean;
+} {
+  const lease = honoRateLimitLeases.get(leaseKey);
+  const flushToken = Symbol(leaseKey);
+  if (!lease || lease.flushToken) {
+    return { lease, carriedCount: 0, flushToken, ownsLeaseFlush: false };
+  }
+  const carriedCount = lease.localUsed;
+  lease.localUsed = 0;
+  lease.flushToken = flushToken;
+  return { lease, carriedCount, flushToken, ownsLeaseFlush: true };
+}
+
+function restoreHonoLeaseCarry(
+  lease: HonoRateLimitLease | undefined,
+  flushToken: symbol,
+  carriedCount: number,
+): void {
+  if (!lease || lease.flushToken !== flushToken) return;
+  lease.localUsed += carriedCount;
+  lease.flushToken = undefined;
+}
+
+function publishHonoLease(opts: {
+  leaseKey: string;
+  lease?: HonoRateLimitLease;
+  flushToken: symbol;
+  ownsLeaseFlush: boolean;
+  result: CheckResult;
+  config: RateLimitConfig;
+  now: number;
+  enabled: boolean;
+}): void {
+  const { leaseKey, lease, flushToken, ownsLeaseFlush, result, config, now, enabled } = opts;
+  if (!enabled) {
+    if (lease && ownsLeaseFlush && lease.flushToken === flushToken) {
+      honoRateLimitLeases.delete(leaseKey);
+    }
+    return;
+  }
+
+  evictSettledHonoLeases(now);
+  const currentLease = honoRateLimitLeases.get(leaseKey);
+  if (!lease || (ownsLeaseFlush && currentLease === lease && lease.flushToken === flushToken)) {
+    honoRateLimitLeases.set(leaseKey, {
+      result,
+      localUsed: lease && currentLease === lease ? lease.localUsed : 0,
+      localBudget: Math.min(
+        result.remaining,
+        Math.ceil((config.maxRequests * HONO_RATE_LIMIT_LEASE_TTL_MS) / config.windowMs),
+      ),
+      expiresAt: now + HONO_RATE_LIMIT_LEASE_TTL_MS,
+    });
+  }
+}
+
 function resolvedFallbackConfig(
   config: RateLimitConfig,
 ): { namespace: string; windowMs: number; maxRequests: number } | null {
@@ -219,8 +306,13 @@ export async function checkUpstash(
   key: string,
   windowMs: number,
   maxRequests: number,
+  options?: { carriedCount?: number },
 ): Promise<CheckResult> {
   const fullKey = `ratelimit:${key}`;
+  const carriedCount = Math.max(0, Math.floor(options?.carriedCount ?? 0));
+  for (let i = 0; i < carriedCount; i++) {
+    await redis.incr(fullKey);
+  }
   const count = await redis.incr(fullKey);
   let ttl = count === 1 ? null : await redis.pttl(fullKey);
   if (count === 1 || ttl === null || ttl < 0) {
@@ -283,6 +375,38 @@ export function rateLimit(config: RateLimitConfig): MiddlewareHandler<AppEnv> {
     let result: CheckResult;
     let policy = "redis";
     let headersConfig = effectiveConfig;
+    const leaseEnabled = isHotPathCachesEnabled(env);
+    const leaseKey = honoLeaseKey(key, effectiveConfig);
+    const now = Date.now();
+    const lease = honoRateLimitLeases.get(leaseKey);
+
+    if (leaseEnabled && lease && lease.expiresAt > now) {
+      if (!lease.result.allowed) {
+        result = lease.result;
+        const headers = rateLimitHeaders(headersConfig, result, "redis-lease");
+        return c.json(
+          {
+            success: false,
+            error: "Too many requests",
+            code: "rate_limit_exceeded" as const,
+            message: `Rate limit exceeded. Maximum ${headersConfig.maxRequests} requests per ${Math.ceil(
+              headersConfig.windowMs / 1000,
+            )} seconds.`,
+            retryAfter: result.retryAfter,
+          },
+          429,
+          { ...headers, "Retry-After": String(result.retryAfter ?? 60) },
+        );
+      }
+      if (!lease.flushToken && lease.localUsed < lease.localBudget) {
+        lease.localUsed++;
+        await next();
+        applyRateLimitHeaders(c, rateLimitHeaders(headersConfig, lease.result, "redis-lease"));
+        return;
+      }
+    }
+
+    const flush = startHonoLeaseFlush(leaseKey);
 
     try {
       result = await checkUpstash(
@@ -290,8 +414,20 @@ export function rateLimit(config: RateLimitConfig): MiddlewareHandler<AppEnv> {
         key,
         effectiveConfig.windowMs,
         effectiveConfig.maxRequests,
+        { carriedCount: flush.carriedCount },
       );
+      publishHonoLease({
+        leaseKey,
+        lease: flush.lease,
+        flushToken: flush.flushToken,
+        ownsLeaseFlush: flush.ownsLeaseFlush,
+        result,
+        config: effectiveConfig,
+        now,
+        enabled: leaseEnabled,
+      });
     } catch (error) {
+      restoreHonoLeaseCarry(flush.lease, flush.flushToken, flush.carriedCount);
       const message = error instanceof Error ? error.message : String(error);
       if (effectiveConfig.redisUnavailableFallback) {
         logger.warn("[RateLimit] Redis unavailable; using local fallback limiter", {
@@ -372,3 +508,4 @@ export const RateLimitPresets = {
 export { getDefaultKey, getIpKey, getRequestIp };
 export const _multiplier = multiplier;
 export const _resetRedisUnavailableFallbackBuckets = () => redisUnavailableFallbackBuckets.clear();
+export const _resetHonoRateLimitLeases = () => honoRateLimitLeases.clear();

--- a/packages/cloud/shared/src/lib/middleware/rate-limit-hono-lease.test.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-hono-lease.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Focused coverage for the Hono rate-limit in-isolate lease used on the
+ * inference gateway hot path. The Redis client is fake, but the Hono middleware
+ * and lease accounting are real: flag-off behavior stays authoritative, repeat
+ * allowed decisions skip Redis, carried usage flushes into the next Redis
+ * check, and denials lease without repeated backend round-trips.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+class FakeRedis {
+  count = 0;
+  incrCalls = 0;
+  expireCalls = 0;
+  ttl = -1;
+
+  async incr(): Promise<number> {
+    this.incrCalls++;
+    this.count++;
+    return this.count;
+  }
+
+  async pttl(): Promise<number> {
+    return this.ttl;
+  }
+
+  async pexpire(_key: string, windowMs: number): Promise<number> {
+    this.expireCalls++;
+    this.ttl = windowMs;
+    return 1;
+  }
+}
+
+const redis = new FakeRedis();
+
+mock.module("../cache/redis-factory", () => ({
+  buildRedisClient: () => redis,
+  hasRedisConfig: () => true,
+  isCloudflareWorkerRuntime: () => false,
+}));
+
+mock.module("../utils/logger", () => ({
+  logger: {
+    debug: mock(() => undefined),
+    error: mock(() => undefined),
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+  },
+}));
+
+const { rateLimit, _resetHonoRateLimitLeases } = await import("./rate-limit-hono-cloudflare");
+
+const BASE_ENV = {
+  NODE_ENV: "production",
+  REDIS_RATE_LIMITING: "true",
+  REDIS_URL: "redis://mock:6379",
+};
+
+function makeApp(config: Parameters<typeof rateLimit>[0]) {
+  const app = new Hono();
+  app.use(rateLimit(config));
+  app.get("/", (c) => c.json({ ok: true }));
+  return app;
+}
+
+function req(id = "client-a") {
+  return new Request("https://api.example.test/", {
+    headers: { "x-api-key": `eliza_${id}` },
+  });
+}
+
+describe("Hono rateLimit lease (#15428)", () => {
+  beforeEach(() => {
+    redis.count = 0;
+    redis.incrCalls = 0;
+    redis.expireCalls = 0;
+    redis.ttl = -1;
+    _resetHonoRateLimitLeases();
+  });
+
+  test("INFERENCE_HOT_PATH_CACHES off keeps every request authoritative", async () => {
+    const app = makeApp({ windowMs: 60_000, maxRequests: 20 });
+    const env = { ...BASE_ENV, INFERENCE_HOT_PATH_CACHES: "false" };
+
+    for (let i = 0; i < 4; i++) {
+      const res = await app.fetch(req(), env);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("X-RateLimit-Policy")).toBe("redis");
+    }
+
+    expect(redis.incrCalls).toBe(4);
+  });
+
+  test("flag-on repeats within budget skip Redis and advertise the lease policy", async () => {
+    const app = makeApp({ windowMs: 60_000, maxRequests: 60 });
+    const env = { ...BASE_ENV, INFERENCE_HOT_PATH_CACHES: "true" };
+
+    const first = await app.fetch(req(), env);
+    expect(first.status).toBe(200);
+    expect(first.headers.get("X-RateLimit-Policy")).toBe("redis");
+    expect(redis.incrCalls).toBe(1);
+
+    for (let i = 0; i < 3; i++) {
+      const res = await app.fetch(req(), env);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("X-RateLimit-Policy")).toBe("redis-lease");
+    }
+
+    expect(redis.incrCalls).toBe(1);
+  });
+
+  test("spent local budget carries leased requests into the next Redis check", async () => {
+    const app = makeApp({ windowMs: 10_000, maxRequests: 4 });
+    const env = { ...BASE_ENV, INFERENCE_HOT_PATH_CACHES: "true" };
+
+    expect((await app.fetch(req(), env)).status).toBe(200); // authoritative
+    expect((await app.fetch(req(), env)).headers.get("X-RateLimit-Policy")).toBe("redis-lease");
+    expect((await app.fetch(req(), env)).headers.get("X-RateLimit-Policy")).toBe("redis-lease");
+    expect(redis.incrCalls).toBe(1);
+
+    const flushed = await app.fetch(req(), env);
+    expect(flushed.status).toBe(200);
+    expect(flushed.headers.get("X-RateLimit-Policy")).toBe("redis");
+
+    // First authoritative hit + two carried INCRs + current authoritative hit.
+    expect(redis.incrCalls).toBe(4);
+  });
+
+  test("denials are leased instead of hammering Redis", async () => {
+    const app = makeApp({ windowMs: 60_000, maxRequests: 1 });
+    const env = { ...BASE_ENV, INFERENCE_HOT_PATH_CACHES: "true" };
+
+    expect((await app.fetch(req(), env)).status).toBe(200);
+    expect(redis.incrCalls).toBe(1);
+
+    const denied = await app.fetch(req(), env);
+    expect(denied.status).toBe(429);
+    expect(denied.headers.get("X-RateLimit-Policy")).toBe("redis");
+    expect(redis.incrCalls).toBe(2);
+
+    const leasedDenied = await app.fetch(req(), env);
+    expect(leasedDenied.status).toBe(429);
+    expect(leasedDenied.headers.get("X-RateLimit-Policy")).toBe("redis-lease");
+    expect(redis.incrCalls).toBe(2);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/inference-hot-path-caches.ts
+++ b/packages/cloud/shared/src/lib/services/inference-hot-path-caches.ts
@@ -14,8 +14,9 @@
 
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 
-type StringEnv = Record<string, string | undefined>;
+type EnvLike = Record<string, unknown>;
 
-export function isHotPathCachesEnabled(env: StringEnv = getCloudAwareEnv()): boolean {
-  return (env.INFERENCE_HOT_PATH_CACHES ?? "").trim() === "true";
+export function isHotPathCachesEnabled(env: EnvLike = getCloudAwareEnv()): boolean {
+  const flag = env.INFERENCE_HOT_PATH_CACHES;
+  return typeof flag === "string" && flag.trim() === "true";
 }


### PR DESCRIPTION
## Summary
- adds a short in-isolate lease for route-mounted Hono rate limits when INFERENCE_HOT_PATH_CACHES=true
- carries locally leased usage into the next authoritative Redis check so the lease stays bounded
- leases Redis denials briefly to avoid repeated backend round-trips during hot 429 paths

Advances #15428 and #15404.

## Verification
- bunx biome check packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts packages/cloud/shared/src/lib/middleware/rate-limit-hono-lease.test.ts packages/cloud/shared/src/lib/services/inference-hot-path-caches.ts
- git diff --check
- bun run audit:error-policy-ratchet
- bun test --coverage-reporter=lcov packages/cloud/shared/src/lib/middleware/rate-limit-hono-lease.test.ts packages/cloud/shared/src/lib/middleware/rate-limit-fail-closed.test.ts packages/cloud/shared/src/lib/middleware/rate-limit-org-lease.test.ts

## Note
- bun run --cwd packages/cloud/shared typecheck is still blocked on develop by missing generated i18n modules under core/shared; the new middleware typing error found during the run was fixed in this PR.