### PR TITLE
fix(ci): generate i18n data before scoped typechecks

### DIFF
--- a/packages/cloud/shared/package.json
+++ b/packages/cloud/shared/package.json
@@ -25,7 +25,7 @@
     "lint:fix": "bunx @biomejs/biome check --write --unsafe .",
     "format": "bunx @biomejs/biome format --write .",
     "format:check": "bunx @biomejs/biome format .",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "node ../../shared/scripts/generate-keywords.mjs --target ts && tsgo --noEmit",
     "check:tenant-scope": "bun scripts/check-tenant-scope.ts",
     "check:tenant-scope:self-test": "bun test scripts/check-tenant-scope.test.ts",
     "verify:tenant-isolation": "bun scripts/verify-tenant-db-isolation.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -123,7 +123,7 @@
 		"test:watch": "node ../scripts/run-vitest.mjs",
 		"lint": "bunx @biomejs/biome check --write ./src",
 		"lint:check": "bunx @biomejs/biome check ./src",
-		"typecheck": "tsgo --noEmit -p ./tsconfig.json",
+		"typecheck": "node ../shared/scripts/generate-keywords.mjs --target ts && tsgo --noEmit -p ./tsconfig.json",
 		"format": "bunx @biomejs/biome format --write ./src",
 		"format:check": "bunx @biomejs/biome format ./src"
 	},

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -31,7 +31,7 @@
     "prepublishOnly": "bun run build",
     "build": "bun run build:i18n && bun run build:dist",
     "build:i18n": "node scripts/generate-keywords.mjs --target ts",
-    "typecheck": "tsgo --noEmit -p tsconfig.json",
+    "typecheck": "bun run build:i18n && tsgo --noEmit -p tsconfig.json",
     "test": "node ../scripts/run-vitest.mjs run --config ./vitest.config.ts",
     "lint": "bunx @biomejs/biome check --write src",
     "lint:check": "bunx @biomejs/biome check src",


### PR DESCRIPTION
## Summary
- makes package-local typecheck commands regenerate the ignored i18n keyword module before running TypeScript
- covers @elizaos/shared, @elizaos/core, and @elizaos/cloud-shared scoped typechecks
- fixes the fresh-worktree / ignore-scripts failure shape where imports through core/shared crash on missing validation-keyword-data

Advances #14051.

## Verification
- removed ignored packages/shared/src/i18n/generated and packages/core/src/i18n/generated, then ran `bun run --cwd packages/cloud/shared typecheck` successfully
- `bun run --cwd packages/shared typecheck`
- `bun run --cwd packages/core typecheck`
- `bunx biome check packages/shared/package.json packages/core/package.json packages/cloud/shared/package.json`
- `git diff --check`
- `bun run audit:error-policy-ratchet`

## Evidence N/A
- UI screenshots/video: N/A - package-script CI reliability change only
- live LLM trajectory: N/A - no model/action/provider behavior changed
- DB/domain artifacts: N/A - no runtime persistence behavior changed