### PR TITLE
test(app): require captured MVP visual states

### DIFF
--- a/packages/app/scripts/mvp-visual-verify.mjs
+++ b/packages/app/scripts/mvp-visual-verify.mjs
@@ -18,6 +18,7 @@
  * Usage:
  *   node scripts/mvp-visual-verify.mjs [--input <dir>] [--baseline <dir>]
  *                                      [--update-baseline] [--viewport <name>]...
+ *                                      [--require-state <slug[@viewport]>]...
  *                                      [--strict]
  * Env: ELIZA_AUDIT_APP_DIR overrides the input dir (matches the audit spec);
  * ELIZA_MVP_VISUAL_BASELINE_DIR overrides the committed baseline directory.
@@ -46,12 +47,18 @@ function log(msg) {
 }
 
 export function parseArgs(argv) {
-  const args = { viewports: [], updateBaseline: false, strict: false };
+  const args = {
+    viewports: [],
+    requiredStates: [],
+    updateBaseline: false,
+    strict: false,
+  };
   for (let i = 0; i < argv.length; i += 1) {
     const a = argv[i];
     if (a === "--input") args.input = argv[++i];
     else if (a === "--baseline") args.baseline = argv[++i];
     else if (a === "--viewport") args.viewports.push(argv[++i]);
+    else if (a === "--require-state") args.requiredStates.push(argv[++i]);
     else if (a === "--update-baseline") args.updateBaseline = true;
     else if (a === "--strict") args.strict = true;
     else if (a === "--help" || a === "-h") args.help = true;
@@ -103,7 +110,7 @@ async function main() {
   const args = parseArgs(process.argv.slice(2));
   if (args.help) {
     log(
-      "post-processes audit:app screenshots into mvp-verify/ (OCR + palette + diff + expectations)",
+      "post-processes audit:app screenshots into mvp-verify/ (OCR + palette + diff + expectations + required-state coverage)",
     );
     return 0;
   }
@@ -253,12 +260,20 @@ async function main() {
       : a.slug.localeCompare(b.slug),
   );
 
+  const missingRequiredStates = computeMissingRequiredStates(
+    args.requiredStates,
+    results,
+  );
   const expectationSkips = countExpectationChecks(results, "skip");
   const expectationFailures = results.filter((r) => !r.expectation.pass).length;
   const newBaselines = results.filter((r) => r.diff.status === "new").length;
   const emptyRunFailures = results.length === 0 ? 1 : 0;
   const strictFailures =
-    expectationFailures + expectationSkips + newBaselines + emptyRunFailures;
+    expectationFailures +
+    expectationSkips +
+    newBaselines +
+    emptyRunFailures +
+    missingRequiredStates.length;
 
   const summary = {
     generatedAt: new Date().toISOString(),
@@ -271,6 +286,8 @@ async function main() {
     auditReportPresent: reportPresent,
     expectationFailures,
     expectationSkips,
+    requiredStates: args.requiredStates,
+    missingRequiredStates,
     newBaselines,
     overflowStates: results.filter((r) => (r.horizontalOverflowPx ?? 0) > 2)
       .length,
@@ -292,7 +309,7 @@ async function main() {
     `wrote ${results.length} states → ${path.join(outDir, "report.json")} + contact-sheet.html`,
   );
   log(
-    `expectation failures: ${summary.expectationFailures} | expectation skips: ${summary.expectationSkips} | overflow states: ${summary.overflowStates} | new baselines: ${summary.newBaselines}`,
+    `expectation failures: ${summary.expectationFailures} | expectation skips: ${summary.expectationSkips} | missing required states: ${summary.missingRequiredStates.length} | overflow states: ${summary.overflowStates} | new baselines: ${summary.newBaselines}`,
   );
   if (summary.expectationFailures > 0) {
     for (const r of results.filter((r) => !r.expectation.pass)) {
@@ -315,9 +332,42 @@ async function main() {
     if (summary.expectationSkips > 0) {
       log(`  FAIL ${summary.expectationSkips} expectation check(s) skipped`);
     }
+    if (summary.missingRequiredStates.length > 0) {
+      log(
+        `  FAIL ${summary.missingRequiredStates.length} required screenshot state(s) missing`,
+      );
+      for (const state of summary.missingRequiredStates) {
+        log(
+          `    missing ${state.slug}${state.viewport ? ` @ ${state.viewport}` : ""}`,
+        );
+      }
+    }
     return 1;
   }
   return 0;
+}
+
+export function parseRequiredState(value) {
+  const [slug, viewport, extra] = String(value).split("@");
+  if (!slug || extra !== undefined) {
+    throw new Error(
+      `invalid --require-state value "${value}"; expected slug or slug@viewport`,
+    );
+  }
+  return { slug, viewport: viewport || null };
+}
+
+export function computeMissingRequiredStates(requiredStates, results) {
+  if (!requiredStates?.length) return [];
+  const presentPairs = new Set(results.map((r) => `${r.slug}@${r.viewport}`));
+  const presentSlugs = new Set(results.map((r) => r.slug));
+  return requiredStates
+    .map(parseRequiredState)
+    .filter((required) =>
+      required.viewport
+        ? !presentPairs.has(`${required.slug}@${required.viewport}`)
+        : !presentSlugs.has(required.slug),
+    );
 }
 
 export function countExpectationChecks(results, status) {
@@ -388,14 +438,25 @@ function renderContactSheet(summary, results) {
   .pass{color:#0a7d3c;font-weight:700} .fail{color:#c0392b;font-weight:700} .na{color:#b58900}
   .row-fail{background:#fff4f2} .checks{margin-top:4px}
   .chk{font-size:11px;padding:1px 0} .chk.pass{color:#0a7d3c} .chk.fail{color:#c0392b} .chk.skip{color:#8a8378}
-  .new{color:#b58900;font-weight:600}
+  .new{color:#b58900;font-weight:600} .missing{margin-top:6px;color:#c0392b;font-weight:600}
 </style>
 <h1>mvp visual verify</h1>
 <div class="summary">
   ${esc(summary.states)} states · OCR: ${esc(summary.ocrEngine)} · expectation failures: <b>${summary.expectationFailures}</b> ·
-  skipped checks: <b>${summary.expectationSkips}</b> · overflow states: <b>${summary.overflowStates}</b> ·
+  skipped checks: <b>${summary.expectationSkips}</b> · missing required states: <b>${summary.missingRequiredStates.length}</b> · overflow states: <b>${summary.overflowStates}</b> ·
   new baselines: ${summary.newBaselines} · audit report: ${summary.auditReportPresent ? "loaded" : "ABSENT"} ·
   baseline: ${esc(summary.baselineDir)} · ${esc(summary.generatedAt)}
+  ${
+    summary.missingRequiredStates.length
+      ? `<div class="missing">Missing required: ${esc(
+          summary.missingRequiredStates
+            .map((state) =>
+              state.viewport ? `${state.slug}@${state.viewport}` : state.slug,
+            )
+            .join(", "),
+        )}</div>`
+      : ""
+  }
 </div>
 <table>
   <tr><th>state</th><th>screenshot</th><th>OCR text</th><th>palette</th><th>diff vs baseline</th><th>expectations</th></tr>

--- a/packages/app/test/audit/mvp-visual-verify.test.ts
+++ b/packages/app/test/audit/mvp-visual-verify.test.ts
@@ -27,6 +27,8 @@ import {
 } from "../../scripts/mvp-visual-verify/expectation-eval.mjs";
 import { bucket as auditBucket } from "../ui-smoke/aesthetic-audit-rules";
 
+const visualVerify = await import("../../scripts/mvp-visual-verify.mjs");
+
 const appPackageJson = JSON.parse(
   readFileSync(path.resolve(__dirname, "../../package.json"), "utf8"),
 ) as { scripts: Record<string, string> };
@@ -425,6 +427,28 @@ describe("sparse-home OCR regression guard (#14343)", () => {
 });
 
 describe("mvp-visual-verify CLI", () => {
+  it("computes missing required states by slug or viewport-specific key", () => {
+    const results = [
+      { slug: "builtin-chat", viewport: "desktop" },
+      { slug: "builtin-settings", viewport: "mobile-portrait" },
+    ];
+
+    expect(
+      visualVerify.computeMissingRequiredStates(
+        [
+          "builtin-chat",
+          "builtin-chat@mobile-portrait",
+          "builtin-settings@mobile-portrait",
+          "plugin-goals@desktop",
+        ],
+        results,
+      ),
+    ).toEqual([
+      { slug: "builtin-chat", viewport: "mobile-portrait" },
+      { slug: "plugin-goals", viewport: "desktop" },
+    ]);
+  });
+
   it("strict mode fails when the run has skipped checks or first-run baselines", async () => {
     const dir = mkdtempSync(path.join(tmpdir(), "eliza-mvp-visual-verify-"));
     const baselineDir = path.join(dir, "empty-baseline");
@@ -471,6 +495,65 @@ describe("mvp-visual-verify CLI", () => {
     );
     expect(report.summary.newBaselines).toBe(1);
     expect(report.summary.expectationSkips).toBeGreaterThan(0);
+  });
+
+  it("strict mode reports missing required screenshot states", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "eliza-mvp-visual-required-"));
+    const baselineDir = path.join(dir, "baseline");
+    const viewportDir = path.join(dir, "mobile-portrait");
+    mkdirSync(path.join(baselineDir, "mobile-portrait"), { recursive: true });
+    mkdirSync(viewportDir);
+    for (const target of [
+      path.join(viewportDir, "builtin-chat.png"),
+      path.join(baselineDir, "mobile-portrait", "builtin-chat.png"),
+    ]) {
+      await sharp({
+        create: {
+          width: 2,
+          height: 2,
+          channels: 4,
+          background: { r: 255, g: 88, b: 0, alpha: 1 },
+        },
+      })
+        .png()
+        .toFile(target);
+    }
+
+    let failed = false;
+    try {
+      execFileSync(
+        process.execPath,
+        [
+          path.resolve(__dirname, "../../scripts/mvp-visual-verify.mjs"),
+          "--input",
+          dir,
+          "--baseline",
+          baselineDir,
+          "--require-state",
+          "builtin-chat@mobile-portrait",
+          "--require-state",
+          "builtin-chat@desktop",
+          "--strict",
+        ],
+        {
+          cwd: path.resolve(__dirname, "../.."),
+          encoding: "utf8",
+          stdio: "pipe",
+        },
+      );
+    } catch (error) {
+      failed = true;
+      expect(error.status).toBe(1);
+    }
+
+    expect(failed).toBe(true);
+    const report = JSON.parse(
+      readFileSync(path.join(dir, "mvp-verify", "report.json"), "utf8"),
+    );
+    expect(report.summary.missingRequiredStates).toEqual([
+      { slug: "builtin-chat", viewport: "desktop" },
+    ]);
+    expect(report.summary.strictFailures).toBeGreaterThanOrEqual(1);
   });
 });
 


### PR DESCRIPTION
# Relates to

MVP visual verification automation: screenshot/OCR/color/diff evidence completeness.

- [x] This PR targets `develop` and is based on latest `origin/develop` at branch creation.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Branch created from latest fetched `origin/develop`; zero conflicts at branch creation.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. This changes only the visual-evidence post-processor and its focused test. It does not change rendered app UI or runtime behavior.

# Background

## What does this PR do?

Adds required-state coverage to `packages/app/scripts/mvp-visual-verify.mjs`.

`audit:app` captures screenshots, and `mvp:visual-verify` already OCRs them, computes dominant palette, compares baselines, and evaluates expectations. The missing piece was capture completeness: strict mode could only evaluate screenshots that happened to exist.

This PR adds repeated `--require-state <slug[@viewport]>` flags so a reviewer can require critical stages, for example:

```bash
bun run --cwd packages/app mvp:visual-verify -- \
  --require-state builtin-chat@desktop \
  --require-state builtin-chat@mobile-portrait \
  --strict
```

Missing required states are now included in `mvp-verify/report.json`, surfaced in `contact-sheet.html`, logged in strict mode, and counted in `strictFailures`.

## What kind of change is this?

Improvements: visual QA / evidence automation.

# Documentation changes needed?

No separate docs needed; the script usage header now includes `--require-state <slug[@viewport]>`.

# Testing

## Where should a reviewer start?

Run the focused test:

```bash
/home/shaw/milady/eliza/node_modules/.bin/vitest run --config packages/app/vitest.config.ts packages/app/test/audit/mvp-visual-verify.test.ts
```

## Detailed testing steps

```bash
bunx @biomejs/biome check --write packages/app/scripts/mvp-visual-verify.mjs packages/app/test/audit/mvp-visual-verify.test.ts
/home/shaw/milady/eliza/node_modules/.bin/vitest run --config packages/app/vitest.config.ts packages/app/test/audit/mvp-visual-verify.test.ts
node packages/app/scripts/mvp-visual-verify.mjs --help
git diff --check
```

Focused test output:

```text
RUN  v4.1.5 /tmp/eliza-mvp-visual-required/packages/app

Test Files  1 passed (1)
Tests  27 passed (27)
Duration  2.51s
```

Help smoke output:

```text
[mvp-visual-verify] post-processes audit:app screenshots into mvp-verify/ (OCR + palette + diff + expectations + required-state coverage)
```

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - visual evidence tooling only; no rendered app UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - visual evidence tooling only; no rendered app UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - visual evidence tooling only; no user-facing flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend runtime path changed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime/browser state changed; this is a Node post-processing tool.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - generated evidence artifact shape is verified by focused tests: missing required states are written to `mvp-verify/report.json` and counted in strict failures.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model behavior changed.

## Backend + frontend logs

N/A - no backend or frontend runtime changed.

## Screenshots (before / after) + video walkthrough

N/A - this PR improves screenshot-review tooling but does not change rendered UI.

## Known gaps / failures

`bun run --cwd packages/app test -- test/audit/mvp-visual-verify.test.ts` failed in the clean worktree because the worktree had no `node_modules` and `vitest` was not on PATH. For validation only, I symlinked the main checkout's installed `node_modules` into the worktree and ran the same test through the installed Vitest binary; it passed 27/27. `bun run verify` was not run for this narrow tool-only change.