### PR TITLE
fix(lifeops): restore personal assistant typecheck

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/resolve-request.ts
+++ b/plugins/plugin-personal-assistant/src/actions/resolve-request.ts
@@ -266,8 +266,7 @@ async function persistSentMailCommitments(args: {
     // error-policy:J7 the sent email is already committed externally; report the
     // projection failure without making the approval retriable and duplicating mail.
     logger.warn(
-      { error },
-      `[approval] failed to project sent email approval ${args.request.id} into commitment ledger`,
+      `[approval] failed to project sent email approval ${args.request.id} into commitment ledger: ${error instanceof Error ? error.message : String(error)}`,
     );
     args.runtime.reportError?.("lifeops:commitment-ledger:sent-mail", error, {
       requestId: args.request.id,

--- a/plugins/plugin-personal-assistant/src/lifeops/meeting-ghost/index.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/meeting-ghost/index.ts
@@ -434,16 +434,18 @@ export function analyzeMeetingGhostTranscript(input: {
       buildCalendarIntent(input.transcript, input.owner, commitment),
     )
     .filter((entry): entry is MeetingGhostCalendarIntent => entry !== null);
-  const agentId = input.agentId;
-  const commitmentLedgerRecords = agentId
-    ? commitments.map((commitment) =>
+  const commitmentLedgerRecords: LifeOpsCommitmentLedgerRecord[] = [];
+  if (input.agentId) {
+    for (const commitment of commitments) {
+      commitmentLedgerRecords.push(
         createMeetingGhostCommitmentLedgerRecord({
-          agentId,
+          agentId: input.agentId,
           transcript: input.transcript,
           commitment,
         }),
-      )
-    : [];
+      );
+    }
+  }
 
   return {
     meetingId: input.transcript.meetingId,


### PR DESCRIPTION
## Summary

Fixes the current `@elizaos/plugin-personal-assistant` typecheck failure that is blocking MVP automation PRs:

- keeps the sent-mail commitment projection warning string-typed while preserving error detail
- builds meeting-ghost commitment ledger records only after `agentId` is narrowed, avoiding optional-to-required leakage inside a callback

## Verification

- `node packages/scripts/run-turbo.mjs run typecheck --filter=@elizaos/plugin-personal-assistant` — pass, 76/76 tasks successful
- `bunx @biomejs/biome check plugins/plugin-personal-assistant/src/actions/resolve-request.ts plugins/plugin-personal-assistant/src/lifeops/meeting-ghost/index.ts` — pass
- `bun test plugins/plugin-personal-assistant/test/meeting-ghost.test.ts` — pass, 8 tests / 24 assertions
- `git diff --check` — pass

`bun test plugins/plugin-personal-assistant/test/resolve-request-executor.test.ts` was attempted after dependency builds and failed before running tests on an unrelated Bun/@types/react resolution error: `Cannot find module './' from .../@types/react/jsx-runtime.d.ts`.

<!-- evidence-row:before-screenshots -->
Before screenshots: N/A - backend TypeScript-only repair; no rendered UI changed.

<!-- evidence-row:after-screenshots -->
After screenshots: N/A - backend TypeScript-only repair; no rendered UI changed.

<!-- evidence-row:walkthrough-video -->
Walkthrough video: N/A - backend TypeScript-only repair; no user-facing workflow changed.

<!-- evidence-row:backend-logs -->
Backend logs: N/A - no backend runtime path changed; verification is compile-time only and the typecheck command output is summarized above.

<!-- evidence-row:frontend-logs -->
Frontend console/network logs: N/A - no frontend runtime or network behavior changed.

<!-- evidence-row:llm-trajectory -->
Real-LLM trajectory: N/A - no prompt, model, action planning, or trajectory behavior changed.

<!-- evidence-row:domain-artifacts -->
Domain artifacts: N/A - no domain rows or user data artifacts are produced; the artifact is the passing affected package typecheck summarized above.