### PR TITLE
fix(ci): ignore nested codex worktrees in live manifest scan

### DIFF
--- a/packages/scripts/__tests__/real-live-suites.test.ts
+++ b/packages/scripts/__tests__/real-live-suites.test.ts
@@ -20,6 +20,7 @@
 
 import { describe, expect, test } from "bun:test";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
 import {
@@ -62,6 +63,44 @@ function owningPackageDir(file: string): string {
 }
 
 describe("real/live guarded-suite manifest (#9310 §E)", () => {
+  test("discovery ignores nested agent worktree directories", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "real-live-discovery-"));
+    try {
+      const realSuite = path.join(
+        root,
+        "packages",
+        "core",
+        "live.real.test.ts",
+      );
+      const nestedCodexSuite = path.join(
+        root,
+        ".codex-worktrees",
+        "branch",
+        "packages",
+        "core",
+        "duplicate.real.test.ts",
+      );
+      const nestedCodexPrSuite = path.join(
+        root,
+        ".codex-pr-worktrees",
+        "pr-1",
+        "packages",
+        "core",
+        "duplicate.live.test.ts",
+      );
+      for (const file of [realSuite, nestedCodexSuite, nestedCodexPrSuite]) {
+        fs.mkdirSync(path.dirname(file), { recursive: true });
+        fs.writeFileSync(file, "describe.skip('guarded', () => {});\n");
+      }
+
+      expect(discoverGuardedRealLiveFiles(root)).toEqual([
+        "packages/core/live.real.test.ts",
+      ]);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test("manifest matches the on-disk guarded set (no drift)", () => {
     const drift = diffRealLiveManifest(discoverGuardedRealLiveFiles(repoRoot));
     expect(

--- a/packages/scripts/lib/real-live-suites.mjs
+++ b/packages/scripts/lib/real-live-suites.mjs
@@ -49,6 +49,8 @@ const DISCOVERY_SKIP_DIRS = new Set([
   ".git",
   ".turbo",
   ".claude",
+  ".codex-pr-worktrees",
+  ".codex-worktrees",
   "coverage",
   "dist",
   "node_modules",


### PR DESCRIPTION
## Summary
- excludes `.codex-worktrees` and `.codex-pr-worktrees` from guarded real/live suite discovery
- prevents local/agent worktrees from producing false post-merge manifest drift
- adds a fixture test that proves nested Codex worktree suites are ignored while real repo suites are still discovered

Advances #13620.

## Verification
- `bun test --coverage-reporter=lcov packages/scripts/__tests__/real-live-suites.test.ts` (8 pass, 0 fail)
- `bunx biome check packages/scripts/lib/real-live-suites.mjs packages/scripts/__tests__/real-live-suites.test.ts`
- `TEST_LANE=post-merge node packages/scripts/run-all-tests.mjs --plan=json --all --no-cloud --min-tasks=100` => succeeds and reports 264 tasks; locally prints expected missing-live-secret warnings
- `git diff --check`
- `bun run audit:error-policy-ratchet`

## Evidence N/A
- UI screenshots/video: N/A - CI discovery script fix only
- live LLM trajectory: N/A - no model/action/provider behavior changed
- DB/domain artifacts: N/A - no persistence behavior changed