### PR TITLE
chore(mvp): emit evidence checklist markdown

### DIFF
--- a/packages/scripts/__tests__/mvp-evidence-matrix.test.ts
+++ b/packages/scripts/__tests__/mvp-evidence-matrix.test.ts
@@ -138,4 +138,33 @@ describe("MVP evidence matrix", () => {
 
     expect(report.rows[0].projectStatus).toBeNull();
   });
+
+  test("renders a GitHub-ready markdown checklist for issue evidence", () => {
+    const report = matrix.buildEvidenceMatrix(
+      [
+        issue(14358, "[onboarding] Device e2e for iOS sim + Android emu", [
+          "mvp",
+          "ui",
+          "needs-human",
+        ]),
+      ],
+      { items: [projectItem(14358)] },
+    );
+
+    const markdown = matrix.formatMarkdown(report);
+
+    expect(markdown).toContain("# LifeOps MVP Evidence Checklist");
+    expect(markdown).toContain("| Open MVP issues | 1 |");
+    expect(markdown).toContain(
+      "### #14358 [onboarding] Device e2e for iOS sim + Android emu",
+    );
+    expect(markdown).toContain("- Project status: Needs human review");
+    expect(markdown).toContain("- Blocker labels: needs-human");
+    expect(markdown).toContain(
+      "- [ ] **Before/after screenshots with OCR and color heuristics** (`visual-screenshots-ocr-color`)",
+    );
+    expect(markdown).toContain(
+      "- [ ] **Per-device screenshots, recording, logs, and status JSON** (`device-artifact-bundle`)",
+    );
+  });
 });

--- a/packages/scripts/audit-mvp-evidence-matrix.mjs
+++ b/packages/scripts/audit-mvp-evidence-matrix.mjs
@@ -7,7 +7,7 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import process from "node:process";
 
 const DEFAULT_REPO = "elizaOS/eliza";
@@ -196,13 +196,16 @@ const RULES = [
 function usage() {
   return `Usage:
   node packages/scripts/audit-mvp-evidence-matrix.mjs [--json]
+  node packages/scripts/audit-mvp-evidence-matrix.mjs --markdown [--output mvp-evidence.md]
   node packages/scripts/audit-mvp-evidence-matrix.mjs --issues-json issues.json --project-json project.json [--json]
 
 Options:
   --repo <owner/repo>             GitHub repo for live mode (default: ${DEFAULT_REPO}).
   --project-owner <org>          GitHub Project owner for live mode (default: ${DEFAULT_PROJECT_OWNER}).
   --project-number <number>      GitHub Project number for live mode (default: ${DEFAULT_PROJECT_NUMBER}).
-  --limit <n>                    GitHub issue/project limit (default: ${DEFAULT_LIMIT}).`;
+  --limit <n>                    GitHub issue/project limit (default: ${DEFAULT_LIMIT}).
+  --markdown                     Print a GitHub-ready evidence checklist.
+  --output <file>                Write the selected format to a file.`;
 }
 
 function parseArgs(argv) {
@@ -212,11 +215,14 @@ function parseArgs(argv) {
     projectNumber: DEFAULT_PROJECT_NUMBER,
     limit: DEFAULT_LIMIT,
     json: false,
+    markdown: false,
   };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--json") {
       out.json = true;
+    } else if (arg === "--markdown") {
+      out.markdown = true;
     } else if (arg === "--help" || arg === "-h") {
       out.help = true;
     } else if (
@@ -224,6 +230,7 @@ function parseArgs(argv) {
       arg === "--project-owner" ||
       arg === "--project-number" ||
       arg === "--limit" ||
+      arg === "--output" ||
       arg === "--issues-json" ||
       arg === "--project-json"
     ) {
@@ -380,6 +387,66 @@ function formatText(report) {
   return `${lines.join("\n")}\n`;
 }
 
+function formatChecklistItem(evidence) {
+  return `- [ ] **${evidence.label}** (\`${evidence.id}\`) — ${evidence.reason}`;
+}
+
+export function formatMarkdown(report) {
+  const lines = [
+    "# LifeOps MVP Evidence Checklist",
+    "",
+    "| Metric | Count |",
+    "| --- | ---: |",
+    `| Open MVP issues | ${report.counts.openMvpIssues} |`,
+    `| Human/owner-gated | ${report.counts.humanGated} |`,
+    `| Agent-actionable | ${report.counts.agentActionable} |`,
+    "",
+    "## Evidence Category Coverage",
+    "",
+    "| Evidence | Issues |",
+    "| --- | ---: |",
+  ];
+
+  for (const [id, count] of Object.entries(report.evidenceCounts)) {
+    lines.push(`| \`${id}\` | ${count} |`);
+  }
+
+  if (report.agentActionable.length > 0) {
+    lines.push("", "## Agent-Actionable Open Rows", "");
+    for (const row of report.agentActionable) {
+      lines.push(`- #${row.number} ${row.title}`);
+    }
+  }
+
+  lines.push("", "## Issue Checklists", "");
+  for (const row of report.rows) {
+    const blockers =
+      row.blockerLabels.length > 0 ? row.blockerLabels.join(", ") : "none";
+    lines.push(`### #${row.number} ${row.title}`);
+    lines.push("");
+    lines.push(`- Project status: ${row.projectStatus ?? "unset"}`);
+    lines.push(`- Blocker labels: ${blockers}`);
+    if (row.url) lines.push(`- Issue: ${row.url}`);
+    lines.push("");
+    lines.push("Required evidence before closeout:");
+    for (const evidence of row.evidence) {
+      lines.push(formatChecklistItem(evidence));
+    }
+    lines.push("");
+  }
+
+  return `${lines.join("\n").trimEnd()}\n`;
+}
+
+function formatReport(report, args) {
+  if (args.json && args.markdown) {
+    throw new Error("--json and --markdown are mutually exclusive");
+  }
+  if (args.json) return `${JSON.stringify(report, null, 2)}\n`;
+  if (args.markdown) return formatMarkdown(report);
+  return formatText(report);
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   if (args.help) {
@@ -425,9 +492,12 @@ async function main() {
   const report = buildEvidenceMatrix(issues, projectPayload, {
     repo: args.repo,
   });
-  process.stdout.write(
-    args.json ? `${JSON.stringify(report, null, 2)}\n` : formatText(report),
-  );
+  const output = formatReport(report, args);
+  if (args.output) {
+    writeFileSync(args.output, output);
+  } else {
+    process.stdout.write(output);
+  }
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {


### PR DESCRIPTION
## Summary

- Adds `--markdown` to `audit-mvp-evidence-matrix.mjs` so the MVP evidence matrix can produce a GitHub-ready issue checklist.
- Adds `--output <file>` so agents can persist the selected text/JSON/Markdown report without shell redirection.
- Covers the Markdown renderer with an offline deterministic test.

## Evidence

### Automated checks

```bash
bun test packages/scripts/__tests__/mvp-evidence-matrix.test.ts
# 6 pass, 0 fail

bunx @biomejs/biome check packages/scripts/audit-mvp-evidence-matrix.mjs packages/scripts/__tests__/mvp-evidence-matrix.test.ts
# Checked 2 files in 33ms. No fixes applied.

git diff --check
# passed
```

### Smoke test

Offline fixture smoke test proving `--markdown --output` writes the GitHub-ready checklist:

```bash
node packages/scripts/audit-mvp-evidence-matrix.mjs \
  --issues-json "$tmpdir/issues.json" \
  --project-json "$tmpdir/project.json" \
  --markdown \
  --output "$tmpdir/checklist.md"
```

Reviewed generated output by hand. It included the issue metrics table, evidence category counts, project status, blocker labels, issue URL, and required closeout checklist items including OCR/color screenshots, MP4 walkthrough, logs, domain artifacts, and device bundle evidence for a device onboarding row.

### Live GitHub check

Attempted live board smoke:

```bash
node packages/scripts/audit-mvp-evidence-matrix.mjs --markdown --output /tmp/mvp-evidence-checklist.md
```

Result: blocked by GitHub GraphQL API rate limit on `gh project item-list 15 --owner elizaOS --limit 300 --format json`. The code path is covered by the offline test and fixture smoke; live Project reads are external-state limited in this shell right now.

## Evidence rows

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - script-only evidence tooling change; no rendered UI surface changed.`

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - script-only evidence tooling change; no rendered UI surface changed.`

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - script-only CLI/reporting change; no user-facing app flow changed.`

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no runtime service path changed; verification is local CLI/test output above.`

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend runtime or browser path changed.`

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent prompt, planner, model, memory, or scenario behavior changed.`

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no production domain records are produced; the generated Markdown checklist smoke output is summarized above.`