### PR TITLE
fix(ui): keep home locale e2e browser bundle lean

### DIFF
--- a/packages/ui/src/components/shell/__e2e__/run-home-locale-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-home-locale-e2e.mjs
@@ -17,6 +17,10 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { build } from "esbuild";
 import { chromium } from "playwright";
+import {
+  stubElizaCore,
+  stubNodeBuiltins,
+} from "../../../testing/e2e-runner/esbuild-stubs.ts";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const stylesDir = join(here, "../../../styles");
@@ -46,6 +50,43 @@ const stubState = {
     b.onResolve({ filter: /\/state$/ }, () => ({ path: stateStub }));
   },
 };
+const stubWeatherDeps = {
+  name: "stub-weather-deps",
+  setup(b) {
+    b.onResolve({ filter: /^@elizaos\/logger$/ }, () => ({
+      path: "logger-stub",
+      namespace: "home-locale-stub",
+    }));
+    b.onResolve({ filter: /\/api\/client$/ }, () => ({
+      path: "api-client-stub",
+      namespace: "home-locale-stub",
+    }));
+    b.onResolve({ filter: /\/surface-realm-channel$/ }, () => ({
+      path: "surface-realm-channel-stub",
+      namespace: "home-locale-stub",
+    }));
+    b.onLoad({ filter: /^logger-stub$/, namespace: "home-locale-stub" }, () => ({
+      contents:
+        "export const logger = { warn() {}, error() {}, info() {}, debug() {} };",
+      loader: "js",
+    }));
+    b.onLoad(
+      { filter: /^api-client-stub$/, namespace: "home-locale-stub" },
+      () => ({
+        contents:
+          "export const client = { fetch: async () => ({ lat: 37.77, lon: -122.42 }) };",
+        loader: "js",
+      }),
+    );
+    b.onLoad(
+      { filter: /^surface-realm-channel-stub$/, namespace: "home-locale-stub" },
+      () => ({
+        contents: "export const shellLocalStorage = window.localStorage;",
+        loader: "js",
+      }),
+    );
+  },
+};
 
 const result = await build({
   entryPoints: [join(here, "home-locale-fixture.tsx")],
@@ -55,7 +96,7 @@ const result = await build({
   jsx: "automatic",
   loader: { ".tsx": "tsx", ".ts": "ts" },
   define: { "process.env.NODE_ENV": '"production"' },
-  plugins: [stubState],
+  plugins: [stubState, stubWeatherDeps, stubElizaCore(), stubNodeBuiltins()],
   write: false,
 });
 const js = result.outputFiles[0].text;
@@ -63,6 +104,7 @@ const html = `<!doctype html><html class="dark"><head><meta charset="utf-8"><tit
 <script src="https://cdn.tailwindcss.com"></script>
 <style>${baseCss}</style><style>${TOKEN_SHIM}</style>
 <style>html,body{margin:0;height:100%}</style>
+<script>window.process=window.process||{env:{NODE_ENV:"production"},platform:"browser",cwd:function(){return "/"}};window.global=window.global||window;</script>
 </head><body><div id="root"></div><script>${js}</script></body></html>`;
 const htmlPath = join(outDir, "home-locale.html");
 await writeFile(htmlPath, html);

--- a/packages/ui/src/testing/e2e-runner/esbuild-stubs.ts
+++ b/packages/ui/src/testing/e2e-runner/esbuild-stubs.ts
@@ -65,8 +65,73 @@ export function stubNodeBuiltins(): Plugin {
         return null;
       });
       build.onLoad({ filter: /.*/, namespace: "node-stub" }, () => ({
-        contents:
-          "const n=()=>noop;const noop=new Proxy(n,{get:()=>noop});module.exports=noop;",
+        contents: `function anyfn() { return anyfn; }
+export default anyfn;
+export const createRequire = () => anyfn;
+export const homedir = anyfn;
+export const tmpdir = anyfn;
+export const platform = anyfn;
+export const isAbsolute = anyfn;
+export const join = anyfn;
+export const resolve = anyfn;
+export const dirname = anyfn;
+export const basename = anyfn;
+export const extname = anyfn;
+export const sep = "/";
+export const createHash = () => ({ update: () => ({ digest: () => "" }) });
+export const randomBytes = anyfn;
+export const randomUUID = () => "00000000-0000-0000-0000-000000000000";
+export const Buffer = {
+  from: () => ({}),
+  isBuffer: () => false,
+  alloc: () => ({}),
+  byteLength: () => 0,
+};
+export const promises = {};
+export const existsSync = () => false;
+export const readFileSync = anyfn;
+export const writeFileSync = anyfn;
+export const mkdirSync = anyfn;
+export const readdirSync = () => [];
+export const statSync = anyfn;
+export const realpathSync = anyfn;
+export const renameSync = anyfn;
+export const unlinkSync = anyfn;
+export const EventEmitter = class {};
+export const fileURLToPath = anyfn;
+export const pathToFileURL = anyfn;
+export const lookup = anyfn;
+export const request = anyfn;
+export const createHmac = () => ({ update: () => ({ digest: () => "" }) });
+export const timingSafeEqual = () => false;
+export const createCipheriv = anyfn;
+export const createDecipheriv = anyfn;
+export const pbkdf2Sync = anyfn;
+export const scryptSync = anyfn;
+export const execFile = anyfn;
+export const exec = anyfn;
+export const promisify = () => anyfn;
+export const readFile = anyfn;
+export const readlink = anyfn;
+export const rename = anyfn;
+export const rm = anyfn;
+export const symlink = anyfn;
+export const unlink = anyfn;
+export const writeFile = anyfn;
+export const mkdir = anyfn;
+export const stat = anyfn;
+export const readdir = () => [];
+export const isIP = () => 0;
+export const statfsSync = anyfn;
+export const cp = anyfn;
+export class AsyncLocalStorage {
+  run(_store, fn, ...args) {
+    return fn(...args);
+  }
+  getStore() {
+    return undefined;
+  }
+}`,
         loader: "js",
       }));
     },


### PR DESCRIPTION
## Summary
- fixes the current develop UI Fixture E2E failure in `test:home-locale-e2e` where raw esbuild pulled Node/server modules into the browser IIFE and failed on Node builtins
- reuses the shared core/builtin stubs and stubs only the home weather runner's unused API/logger/storage edges
- makes the shared node-builtin esbuild stub expose concrete named exports so browser fixtures can survive dead Node-style imports during module evaluation

Failed run investigated: https://github.com/elizaOS/eliza/actions/runs/28995747230 (`Home locale e2e`, `Could not resolve node:os` / Node builtins in browser bundle).

## Verification
- `bun run --cwd packages/ui test:home-locale-e2e`
- `node packages/app-core/scripts/ensure-shared-i18n-data.mjs && bun run --cwd packages/ui test:home-screen-e2e`
- `bunx @biomejs/biome check packages/ui/src/components/shell/__e2e__/run-home-locale-e2e.mjs packages/ui/src/testing/e2e-runner/esbuild-stubs.ts --no-errors-on-unmatched`
- `git diff --check`

## Evidence
- UI fixture only; generated screenshots/video were reviewed locally and not committed.
- N/A: live model trajectories, backend logs, network logs. This is a deterministic browser fixture bundling fix.