### PR TITLE
chore(mvp): avoid GraphQL for issue audit inventory

### DIFF
--- a/packages/scripts/__tests__/mvp-board-readiness.test.ts
+++ b/packages/scripts/__tests__/mvp-board-readiness.test.ts
@@ -112,4 +112,20 @@ describe("MVP board readiness audit", () => {
       }),
     );
   });
+
+  test("normalizes REST issue rows for the live issue inventory", () => {
+    expect(
+      board.normalizeRestIssue({
+        number: 14351,
+        title: "Verify shift rotation",
+        html_url: "https://github.com/elizaOS/eliza/issues/14351",
+        labels: [{ name: "mvp" }, { name: "needs-shaw" }],
+      }),
+    ).toEqual({
+      number: 14351,
+      title: "Verify shift rotation",
+      url: "https://github.com/elizaOS/eliza/issues/14351",
+      labels: [{ name: "mvp" }, { name: "needs-shaw" }],
+    });
+  });
 });

--- a/packages/scripts/__tests__/mvp-evidence-matrix.test.ts
+++ b/packages/scripts/__tests__/mvp-evidence-matrix.test.ts
@@ -167,4 +167,22 @@ describe("MVP evidence matrix", () => {
       "- [ ] **Per-device screenshots, recording, logs, and status JSON** (`device-artifact-bundle`)",
     );
   });
+
+  test("normalizes REST issue rows from GitHub without pull request fields", () => {
+    expect(
+      matrix.normalizeRestIssue({
+        number: 14783,
+        title: "[scenarios] Pack G1",
+        body: "Evidence body",
+        html_url: "https://github.com/elizaOS/eliza/issues/14783",
+        labels: [{ name: "mvp" }, { name: "needs-shaw" }],
+      }),
+    ).toEqual({
+      number: 14783,
+      title: "[scenarios] Pack G1",
+      body: "Evidence body",
+      url: "https://github.com/elizaOS/eliza/issues/14783",
+      labels: [{ name: "mvp" }, { name: "needs-shaw" }],
+    });
+  });
 });

--- a/packages/scripts/audit-mvp-evidence-matrix.mjs
+++ b/packages/scripts/audit-mvp-evidence-matrix.mjs
@@ -205,6 +205,7 @@ Options:
   --project-number <number>      GitHub Project number for live mode (default: ${DEFAULT_PROJECT_NUMBER}).
   --limit <n>                    GitHub issue/project limit (default: ${DEFAULT_LIMIT}).
   --markdown                     Print a GitHub-ready evidence checklist.
+  --no-project                   Skip Project status lookup when GitHub GraphQL is rate-limited.
   --output <file>                Write the selected format to a file.`;
 }
 
@@ -216,6 +217,7 @@ function parseArgs(argv) {
     limit: DEFAULT_LIMIT,
     json: false,
     markdown: false,
+    noProject: false,
   };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
@@ -223,6 +225,8 @@ function parseArgs(argv) {
       out.json = true;
     } else if (arg === "--markdown") {
       out.markdown = true;
+    } else if (arg === "--no-project") {
+      out.noProject = true;
     } else if (arg === "--help" || arg === "-h") {
       out.help = true;
     } else if (
@@ -255,6 +259,30 @@ function readJson(file) {
 
 function ghJson(args) {
   return JSON.parse(execFileSync("gh", args, { encoding: "utf8" }));
+}
+
+export function normalizeRestIssue(issue) {
+  return {
+    number: issue.number,
+    title: issue.title,
+    body: issue.body ?? "",
+    url: issue.html_url ?? issue.url,
+    labels: labelNames(issue).map((name) => ({ name })),
+  };
+}
+
+function fetchOpenMvpIssuesRest(repo, limit) {
+  const pages = ghJson([
+    "api",
+    "--paginate",
+    "--slurp",
+    `repos/${repo}/issues?state=open&labels=mvp&per_page=100`,
+  ]);
+  return pages
+    .flat()
+    .filter((issue) => !issue.pull_request)
+    .slice(0, Number(limit))
+    .map(normalizeRestIssue);
 }
 
 function labelNames(issue) {
@@ -462,33 +490,22 @@ async function main() {
 
   const issues = args.issuesJson
     ? readJson(args.issuesJson)
-    : ghJson([
-        "issue",
-        "list",
-        "--repo",
-        args.repo,
-        "--state",
-        "open",
-        "--label",
-        "mvp",
-        "--limit",
-        args.limit,
-        "--json",
-        "number,title,body,labels,url",
-      ]);
+    : fetchOpenMvpIssuesRest(args.repo, args.limit);
   const projectPayload = args.projectJson
     ? readJson(args.projectJson)
-    : ghJson([
-        "project",
-        "item-list",
-        args.projectNumber,
-        "--owner",
-        args.projectOwner,
-        "--limit",
-        args.limit,
-        "--format",
-        "json",
-      ]);
+    : args.noProject
+      ? { items: [] }
+      : ghJson([
+          "project",
+          "item-list",
+          args.projectNumber,
+          "--owner",
+          args.projectOwner,
+          "--limit",
+          args.limit,
+          "--format",
+          "json",
+        ]);
   const report = buildEvidenceMatrix(issues, projectPayload, {
     repo: args.repo,
   });

--- a/packages/scripts/check-mvp-board-readiness.mjs
+++ b/packages/scripts/check-mvp-board-readiness.mjs
@@ -90,21 +90,26 @@ function ghJson(args) {
   return output ? JSON.parse(output) : null;
 }
 
+export function normalizeRestIssue(issue) {
+  return {
+    number: issue.number,
+    title: issue.title,
+    url: issue.html_url ?? issue.url,
+    labels: labelNames(issue).map((name) => ({ name })),
+  };
+}
+
 function fetchOpenMvpIssues(repo) {
   return ghJson([
-    "issue",
-    "list",
-    "--repo",
-    repo,
-    "--state",
-    "open",
-    "--label",
-    "mvp",
-    "--limit",
-    "300",
-    "--json",
-    "number,title,labels,url",
-  ]);
+    "api",
+    "--paginate",
+    "--slurp",
+    `repos/${repo}/issues?state=open&labels=mvp&per_page=100`,
+  ])
+    .flat()
+    .filter((issue) => !issue.pull_request)
+    .slice(0, 300)
+    .map(normalizeRestIssue);
 }
 
 function fetchProjectItems(projectOwner, projectNumber) {


### PR DESCRIPTION
## Summary

- Switches the MVP evidence matrix and board-readiness scripts from `gh issue list` to REST `gh api repos/<repo>/issues` for the open MVP issue inventory.
- Adds `--no-project` to `audit-mvp-evidence-matrix.mjs` so agents can still emit issue-by-issue evidence checklists when GitHub Project GraphQL is rate-limited.
- Adds offline tests for REST issue normalization in both MVP audit scripts.

## Evidence

### Automated checks

```bash
bun test packages/scripts/__tests__/mvp-evidence-matrix.test.ts packages/scripts/__tests__/mvp-board-readiness.test.ts
# 13 pass, 0 fail

bunx @biomejs/biome check packages/scripts/audit-mvp-evidence-matrix.mjs packages/scripts/check-mvp-board-readiness.mjs packages/scripts/__tests__/mvp-evidence-matrix.test.ts packages/scripts/__tests__/mvp-board-readiness.test.ts
# Checked 4 files in 34ms. No fixes applied.

git diff --check
# passed
```

### Live smoke

```bash
node packages/scripts/audit-mvp-evidence-matrix.mjs --no-project
```

Reviewed output by hand. It fetched the open MVP issue inventory through REST despite the active GraphQL rate limit, reported `open MVP issues: 26`, `human-gated: 26`, `agent-actionable: 0`, and printed the expected evidence categories for each issue. Project status is intentionally `no project status` in this mode because Project item lookup still requires GitHub GraphQL.

### UI / screenshots / OCR / video

N/A - script-only audit tooling change. No rendered UI, app screen, device surface, or visual state changed.

### Live LLM trajectories

N/A - script-only audit tooling change. No agent prompt, model, memory, planner, or scenario behavior changed.

### Backend logs / domain artifacts

N/A - no runtime backend path or production domain data changed. The domain artifact is the live audit output summarized above.

## Evidence rows

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - script-only audit tooling change; no rendered UI surface changed.`

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - script-only audit tooling change; no rendered UI surface changed.`

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - script-only CLI/audit change; no user-facing app flow changed.`

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no runtime service path changed; verification is local CLI/test output above.`

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend runtime or browser path changed.`

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent prompt, model, memory, planner, or scenario behavior changed.`

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no production records are produced; the live audit output is summarized above.`