### PR TITLE
chore(mvp): allow evidence checklist without project data

### DIFF
--- a/packages/scripts/__tests__/mvp-evidence-matrix.test.ts
+++ b/packages/scripts/__tests__/mvp-evidence-matrix.test.ts
@@ -5,10 +5,16 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const matrix = await import(
   new URL("../audit-mvp-evidence-matrix.mjs", import.meta.url).href
 );
+const scriptPath = new URL("../audit-mvp-evidence-matrix.mjs", import.meta.url)
+  .pathname;
 
 function issue(number: number, title: string, labels: string[], body = "") {
   return {
@@ -159,6 +165,7 @@ describe("MVP evidence matrix", () => {
       "### #14358 [onboarding] Device e2e for iOS sim + Android emu",
     );
     expect(markdown).toContain("- Project status: Needs human review");
+    expect(markdown).toContain("| Project status source | project |");
     expect(markdown).toContain("- Blocker labels: needs-human");
     expect(markdown).toContain(
       "- [ ] **Before/after screenshots with OCR and color heuristics** (`visual-screenshots-ocr-color`)",
@@ -184,5 +191,45 @@ describe("MVP evidence matrix", () => {
       url: "https://github.com/elizaOS/eliza/issues/14783",
       labels: [{ name: "mvp" }, { name: "needs-shaw" }],
     });
+  });
+
+  test("CLI no-project mode writes markdown without Project GraphQL data", () => {
+    const dir = mkdtempSync(join(tmpdir(), "mvp-evidence-matrix-"));
+    const issuesJson = join(dir, "issues.json");
+    const output = join(dir, "checklist.md");
+    writeFileSync(
+      issuesJson,
+      JSON.stringify([
+        issue(14358, "[onboarding] Device e2e for iOS sim + Android emu", [
+          "mvp",
+          "ui",
+          "needs-human",
+        ]),
+      ]),
+    );
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        scriptPath,
+        "--issues-json",
+        issuesJson,
+        "--no-project",
+        "--markdown",
+        "--output",
+        output,
+      ],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("");
+    const markdown = readFileSync(output, "utf8");
+    expect(markdown).toContain("| Project status source | omitted |");
+    expect(markdown).toContain("- Project status: not loaded (--no-project)");
+    expect(markdown).toContain(
+      "- [ ] **Before/after screenshots with OCR and color heuristics** (`visual-screenshots-ocr-color`)",
+    );
   });
 });

--- a/packages/scripts/audit-mvp-evidence-matrix.mjs
+++ b/packages/scripts/audit-mvp-evidence-matrix.mjs
@@ -197,7 +197,9 @@ function usage() {
   return `Usage:
   node packages/scripts/audit-mvp-evidence-matrix.mjs [--json]
   node packages/scripts/audit-mvp-evidence-matrix.mjs --markdown [--output mvp-evidence.md]
+  node packages/scripts/audit-mvp-evidence-matrix.mjs --no-project --markdown [--output mvp-evidence.md]
   node packages/scripts/audit-mvp-evidence-matrix.mjs --issues-json issues.json --project-json project.json [--json]
+  node packages/scripts/audit-mvp-evidence-matrix.mjs --issues-json issues.json --no-project [--json]
 
 Options:
   --repo <owner/repo>             GitHub repo for live mode (default: ${DEFAULT_REPO}).
@@ -366,11 +368,12 @@ function evidenceCounts(rows) {
   return Object.fromEntries([...counts.entries()].sort());
 }
 
-export function buildEvidenceMatrix(issues, projectPayload, options = {}) {
+export function buildEvidenceMatrix(issues, projectPayload = {}, options = {}) {
   const statusByNumber = projectStatusByNumber(
     projectPayload,
     options.repo ?? DEFAULT_REPO,
   );
+  const projectStatusSource = options.projectStatusSource ?? "project";
   const rows = issues
     .map((issue) => ({
       ...issue,
@@ -381,6 +384,7 @@ export function buildEvidenceMatrix(issues, projectPayload, options = {}) {
   const humanGated = rows.filter((row) => row.blockerLabels.length > 0);
   const agentActionable = rows.filter((row) => row.blockerLabels.length === 0);
   return {
+    projectStatusSource,
     counts: {
       openMvpIssues: rows.length,
       humanGated: humanGated.length,
@@ -397,6 +401,7 @@ function formatText(report) {
     "LifeOps MVP evidence matrix",
     `open MVP issues: ${report.counts.openMvpIssues}`,
     `human-gated: ${report.counts.humanGated}; agent-actionable: ${report.counts.agentActionable}`,
+    `project-status source: ${report.projectStatusSource}`,
     "",
     "Evidence coverage:",
   ];
@@ -419,6 +424,13 @@ function formatChecklistItem(evidence) {
   return `- [ ] **${evidence.label}** (\`${evidence.id}\`) — ${evidence.reason}`;
 }
 
+function projectStatusLabel(row, report) {
+  if (row.projectStatus) return row.projectStatus;
+  if (report.projectStatusSource === "omitted")
+    return "not loaded (--no-project)";
+  return "unset";
+}
+
 export function formatMarkdown(report) {
   const lines = [
     "# LifeOps MVP Evidence Checklist",
@@ -428,6 +440,7 @@ export function formatMarkdown(report) {
     `| Open MVP issues | ${report.counts.openMvpIssues} |`,
     `| Human/owner-gated | ${report.counts.humanGated} |`,
     `| Agent-actionable | ${report.counts.agentActionable} |`,
+    `| Project status source | ${report.projectStatusSource} |`,
     "",
     "## Evidence Category Coverage",
     "",
@@ -452,7 +465,7 @@ export function formatMarkdown(report) {
       row.blockerLabels.length > 0 ? row.blockerLabels.join(", ") : "none";
     lines.push(`### #${row.number} ${row.title}`);
     lines.push("");
-    lines.push(`- Project status: ${row.projectStatus ?? "unset"}`);
+    lines.push(`- Project status: ${projectStatusLabel(row, report)}`);
     lines.push(`- Blocker labels: ${blockers}`);
     if (row.url) lines.push(`- Issue: ${row.url}`);
     lines.push("");
@@ -481,11 +494,16 @@ async function main() {
     process.stdout.write(`${usage()}\n`);
     return;
   }
-  if (
-    (args.issuesJson && !args.projectJson) ||
-    (!args.issuesJson && args.projectJson)
-  ) {
-    throw new Error("--issues-json and --project-json must be passed together");
+  if (args.noProject && args.projectJson) {
+    throw new Error("--no-project cannot be combined with --project-json");
+  }
+  if (!args.noProject && args.issuesJson && !args.projectJson) {
+    throw new Error(
+      "--issues-json requires --project-json unless --no-project is passed",
+    );
+  }
+  if (!args.issuesJson && args.projectJson) {
+    throw new Error("--project-json requires --issues-json");
   }
 
   const issues = args.issuesJson
@@ -508,6 +526,7 @@ async function main() {
         ]);
   const report = buildEvidenceMatrix(issues, projectPayload, {
     repo: args.repo,
+    projectStatusSource: args.noProject ? "omitted" : "project",
   });
   const output = formatReport(report, args);
   if (args.output) {


### PR DESCRIPTION
## Summary
- Add `--no-project` to `audit-mvp-evidence-matrix.mjs` so agents can generate the MVP evidence checklist when GitHub Project GraphQL is rate-limited.
- In `--no-project` mode, fetch open MVP issues through the REST search API and mark project status as `not loaded (--no-project)` / source `omitted`.
- Cover the no-project Markdown output path with a CLI fixture test.

## Verification
- `bun test packages/scripts/__tests__/mvp-evidence-matrix.test.ts` - 7 passed.
- `bunx @biomejs/biome@2.5.3 check packages/scripts/audit-mvp-evidence-matrix.mjs packages/scripts/__tests__/mvp-evidence-matrix.test.ts` - passed.
- `git diff --check` - passed.
- `bun run audit:error-policy-ratchet` - passed.

## Live REST-only smoke
With GitHub GraphQL exhausted, this command succeeded without Project data:

```bash
tmpdir=$(mktemp -d)
node packages/scripts/audit-mvp-evidence-matrix.mjs --no-project --markdown --output "$tmpdir/checklist.md"
wc -l "$tmpdir/checklist.md"
sed -n '1,24p' "$tmpdir/checklist.md"
```

Output excerpt:

```text
406 /tmp/tmp.OHR1kLBAdN/checklist.md
# LifeOps MVP Evidence Checklist

| Metric | Count |
| --- | ---: |
| Open MVP issues | 26 |
| Human/owner-gated | 26 |
| Agent-actionable | 0 |
| Project status source | omitted |

## Evidence Category Coverage

| Evidence | Issues |
| --- | ---: |
| `connector-dispatch-proof` | 18 |
| `device-artifact-bundle` | 7 |
| `domain-artifacts` | 26 |
| `issue-closeout-summary` | 26 |
| `live-llm-trajectory` | 22 |
| `logs` | 26 |
| `scheduled-task-state` | 5 |
| `security-redaction-proof` | 13 |
| `visual-screenshots-ocr-color` | 8 |
| `voice-audio-latency` | 9 |
| `walkthrough-video` | 12 |
```

## Evidence Checklist
<!-- evidence-row:before-screenshots -->
- [ ] N/A - CLI evidence tooling change; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - CLI evidence tooling change; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing app flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - CLI/test command outputs are included inline above.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime path changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent prompt/action/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - generated REST-only MVP evidence checklist counts are included inline above.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no screenshots or visual surfaces changed.