### PR TITLE
fix(ci): keep app aesthetic audit advisory

### DIFF
--- a/.github/workflows/app-aesthetic-audit.yml
+++ b/.github/workflows/app-aesthetic-audit.yml
@@ -37,6 +37,7 @@ jobs:
   aesthetic-audit:
     runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 45
+    continue-on-error: true
     env:
       # Keyless: the ui-smoke stub is forced when CI=true (shouldForceStubStack).
       ELIZA_UI_SMOKE_FORCE_STUB: "1"
@@ -84,6 +85,7 @@ jobs:
     needs: aesthetic-audit
     runs-on: macos-15
     timeout-minutes: 20
+    continue-on-error: true
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
@@ -104,6 +106,7 @@ jobs:
           no-vision-deps: "true"
 
       - name: Download aesthetic-audit artifacts
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: app-aesthetic-audit-output

--- a/packages/scripts/__tests__/app-aesthetic-audit-workflow.test.ts
+++ b/packages/scripts/__tests__/app-aesthetic-audit-workflow.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Static contract for the app visual-audit workflow. The audit is valuable
+ * reviewer evidence, but it is deliberately advisory for develop throughput:
+ * failures must stay visible in logs and artifacts without turning the
+ * non-required workflow into a merge-blocking queue drain (#14051).
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const workflowText = readFileSync(
+  new URL(
+    "../../../.github/workflows/app-aesthetic-audit.yml",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+function jobBlock(jobId: string): string {
+  const lines = workflowText.split(/\r?\n/);
+  const start = lines.indexOf(`  ${jobId}:`);
+  if (start < 0) {
+    throw new Error(`Missing app aesthetic workflow job: ${jobId}`);
+  }
+
+  const end = lines.findIndex(
+    (line, index) => index > start && /^ {2}[A-Za-z0-9_-]+:\s*$/.test(line),
+  );
+  return lines.slice(start + 1, end < 0 ? undefined : end).join("\n");
+}
+
+describe("app-aesthetic-audit workflow", () => {
+  test("keeps visual audit jobs advisory at the job boundary", () => {
+    expect(jobBlock("aesthetic-audit")).toMatch(
+      /^\s{4}continue-on-error:\s*true$/m,
+    );
+    expect(jobBlock("ocr-content-audit")).toMatch(
+      /^\s{4}continue-on-error:\s*true$/m,
+    );
+  });
+
+  test("does not fail OCR triage when the advisory screenshot artifact is absent", () => {
+    expect(jobBlock("ocr-content-audit")).toMatch(
+      /name: Download aesthetic-audit artifacts\n\s+continue-on-error:\s*true/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- keep `app-aesthetic-audit.yml` advisory at the job boundary so strict visual evidence cannot become an accidental merge-blocking queue drain (#14051)
- let OCR triage continue when the advisory screenshot artifact is absent
- add a static workflow regression test for the advisory contract

## Verification
- `bunx @biomejs/biome check packages/scripts/__tests__/app-aesthetic-audit-workflow.test.ts --no-errors-on-unmatched`
- `bun test packages/scripts/__tests__/app-aesthetic-audit-workflow.test.ts packages/scripts/__tests__/ci-workflow-dedup-contract.test.ts packages/scripts/__tests__/ci-merge-gate-contract.test.ts`
- `node packages/scripts/ci-workflow-dedup-contract.mjs`
- `node packages/scripts/ci-merge-gate-contract.mjs`
- `actionlint .github/workflows/app-aesthetic-audit.yml`
- `git diff --check origin/develop...HEAD && git diff --check`