### PR TITLE
chore(mvp): allow issue-only board readiness audit

### DIFF
--- a/packages/scripts/__tests__/mvp-board-readiness.test.ts
+++ b/packages/scripts/__tests__/mvp-board-readiness.test.ts
@@ -96,6 +96,41 @@ describe("MVP board readiness audit", () => {
     );
   });
 
+  test("issues-only mode skips project violations but keeps blocker violations", () => {
+    const report = board.auditMvpBoardReadiness(
+      [issue(14351, ["mvp", "needs-shaw"]), issue(14749, ["mvp"])],
+      { items: [] },
+      { projectCheckSkipped: true },
+    );
+
+    expect(report.ok).toBe(false);
+    expect(report.projectCheckSkipped).toBe(true);
+    expect(report.violations).toEqual([
+      expect.objectContaining({
+        type: "missing-blocker-label",
+        number: 14749,
+      }),
+    ]);
+    expect(
+      report.violations.some(
+        (violation: { type: string }) =>
+          violation.type === "missing-project-item",
+      ),
+    ).toBe(false);
+  });
+
+  test("issues-only mode passes when all open MVP issues have blockers", () => {
+    const report = board.auditMvpBoardReadiness(
+      [issue(14351, ["mvp", "needs-shaw"])],
+      { items: [] },
+      { projectCheckSkipped: true },
+    );
+
+    expect(report.ok).toBe(true);
+    expect(report.projectCheckSkipped).toBe(true);
+    expect(report.rows[0].projectCheckSkipped).toBe(true);
+  });
+
   test("does not match project items from a different repository by number", () => {
     const report = board.auditMvpBoardReadiness(
       [issue(14747, ["mvp", "needs-shaw"])],

--- a/packages/scripts/check-mvp-board-readiness.mjs
+++ b/packages/scripts/check-mvp-board-readiness.mjs
@@ -25,6 +25,7 @@ function usage() {
 
 Options:
   --json          Print machine-readable report.
+  --issues-only   Skip Project status lookup and check only open MVP blocker labels.
   --no-fail      Exit 0 even when violations are found.`;
 }
 
@@ -35,11 +36,14 @@ function parseArgs(argv) {
     projectNumber: DEFAULT_PROJECT_NUMBER,
     json: false,
     fail: true,
+    issuesOnly: false,
   };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--json") {
       out.json = true;
+    } else if (arg === "--issues-only") {
+      out.issuesOnly = true;
     } else if (arg === "--no-fail") {
       out.fail = false;
     } else if (arg === "--help" || arg === "-h") {
@@ -167,6 +171,7 @@ function normalizeProjectItems(payload, repo = DEFAULT_REPO) {
 }
 
 export function auditMvpBoardReadiness(issues, projectPayload, options = {}) {
+  const projectCheckSkipped = options.projectCheckSkipped ?? false;
   const projectItems = normalizeProjectItems(
     projectPayload,
     options.repo ?? DEFAULT_REPO,
@@ -186,6 +191,7 @@ export function auditMvpBoardReadiness(issues, projectPayload, options = {}) {
       labels,
       blockerLabels,
       projectStatus: status,
+      projectCheckSkipped,
     };
     rows.push(row);
 
@@ -196,6 +202,10 @@ export function auditMvpBoardReadiness(issues, projectPayload, options = {}) {
         title: issue.title,
         message: `#${issue.number} is open+mvp but has neither needs-human nor needs-shaw`,
       });
+    }
+
+    if (projectCheckSkipped) {
+      continue;
     }
 
     if (!projectItem) {
@@ -225,6 +235,7 @@ export function auditMvpBoardReadiness(issues, projectPayload, options = {}) {
     ok: violations.length === 0,
     issueCount: issues.length,
     blockerCount: rows.filter((row) => row.blockerLabels.length > 0).length,
+    projectCheckSkipped,
     requiredBlockedStatus: REQUIRED_BLOCKED_STATUS,
     violations,
     rows,
@@ -236,8 +247,11 @@ function formatText(report) {
     `MVP board readiness: ${report.ok ? "PASS" : "FAIL"}`,
     `Open MVP issues: ${report.issueCount}`,
     `Blocked issues: ${report.blockerCount}`,
-    `Required blocked status: ${report.requiredBlockedStatus}`,
+    `Project status check: ${report.projectCheckSkipped ? "SKIPPED" : "checked"}`,
   ];
+  if (!report.projectCheckSkipped) {
+    lines.push(`Required blocked status: ${report.requiredBlockedStatus}`);
+  }
   if (report.violations.length > 0) {
     lines.push("", "Violations:");
     for (const violation of report.violations) {
@@ -254,10 +268,12 @@ async function main() {
     return;
   }
   if (
-    (args.issuesJson && !args.projectJson) ||
+    (args.issuesJson && !args.projectJson && !args.issuesOnly) ||
     (!args.issuesJson && args.projectJson)
   ) {
-    throw new Error("--issues-json and --project-json must be passed together");
+    throw new Error(
+      "--issues-json and --project-json must be passed together unless --issues-only is used",
+    );
   }
 
   const issues = args.issuesJson
@@ -265,9 +281,12 @@ async function main() {
     : fetchOpenMvpIssues(args.repo);
   const projectPayload = args.projectJson
     ? readJson(args.projectJson)
-    : fetchProjectItems(args.projectOwner, args.projectNumber);
+    : args.issuesOnly
+      ? { items: [] }
+      : fetchProjectItems(args.projectOwner, args.projectNumber);
   const report = auditMvpBoardReadiness(issues, projectPayload, {
     repo: args.repo,
+    projectCheckSkipped: args.issuesOnly,
   });
 
   process.stdout.write(


### PR DESCRIPTION
## Summary

- Adds `--issues-only` to `check-mvp-board-readiness.mjs` so blocker-label readiness can still be audited when GitHub Project GraphQL is unavailable.
- Marks the report with `projectCheckSkipped: true` and prints `Project status check: SKIPPED` so the partial audit does not overclaim full Project readiness.
- Keeps missing blocker labels as failures in issue-only mode and skips only Project item/status violations.

## Evidence

### Automated checks

```bash
bun test packages/scripts/__tests__/mvp-board-readiness.test.ts
# 8 pass, 0 fail

bunx @biomejs/biome check packages/scripts/check-mvp-board-readiness.mjs packages/scripts/__tests__/mvp-board-readiness.test.ts
# Checked 2 files in 29ms. No fixes applied.

git diff --check
# passed
```

### Live smoke

```bash
node packages/scripts/check-mvp-board-readiness.mjs --issues-only --json --no-fail
```

Reviewed output by hand. It reported `ok: true`, `issueCount: 26`, `blockerCount: 26`, `projectCheckSkipped: true`, and no violations. Every row carries `projectCheckSkipped: true`, so the output is explicit that Project status was not verified in this fallback mode.

### UI / screenshots / OCR / video

N/A - script-only audit tooling change. No rendered UI, app screen, device surface, or visual state changed.

### Live LLM trajectories

N/A - script-only audit tooling change. No agent prompt, model, memory, planner, or scenario behavior changed.

### Backend logs / domain artifacts

N/A - no runtime backend path or production domain data changed. The domain artifact is the live issue-only readiness output summarized above.

## Evidence rows

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - script-only audit tooling change; no rendered UI surface changed.`

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - script-only audit tooling change; no rendered UI surface changed.`

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - script-only CLI/audit change; no user-facing app flow changed.`

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no runtime service path changed; verification is local CLI/test output above.`

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend runtime or browser path changed.`

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent prompt, model, memory, planner, or scenario behavior changed.`

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no production records are produced; the live issue-only readiness output is summarized above.`