### PR TITLE
test(mvp): cover readiness issue-only CLI

### DIFF
--- a/packages/scripts/__tests__/mvp-board-readiness.test.ts
+++ b/packages/scripts/__tests__/mvp-board-readiness.test.ts
@@ -5,10 +5,16 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const board = await import(
   new URL("../check-mvp-board-readiness.mjs", import.meta.url).href
 );
+const scriptPath = new URL("../check-mvp-board-readiness.mjs", import.meta.url)
+  .pathname;
 
 function issue(number: number, labels: string[]) {
   return {
@@ -162,5 +168,65 @@ describe("MVP board readiness audit", () => {
       url: "https://github.com/elizaOS/eliza/issues/14351",
       labels: [{ name: "mvp" }, { name: "needs-shaw" }],
     });
+  });
+
+  test("CLI issues-only fixture mode reports skipped Project checks", () => {
+    const dir = mkdtempSync(join(tmpdir(), "mvp-board-readiness-"));
+    const issuesJson = join(dir, "issues.json");
+    writeFileSync(
+      issuesJson,
+      JSON.stringify([issue(14351, ["mvp", "needs-shaw"])]),
+    );
+
+    const result = spawnSync(
+      process.execPath,
+      [scriptPath, "--issues-json", issuesJson, "--issues-only", "--json"],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    const report = JSON.parse(result.stdout);
+    expect(report.ok).toBe(true);
+    expect(report.projectCheckSkipped).toBe(true);
+    expect(report.rows[0].projectCheckSkipped).toBe(true);
+  });
+
+  test("CLI issues-only fixture mode still fails missing blocker labels", () => {
+    const dir = mkdtempSync(join(tmpdir(), "mvp-board-readiness-"));
+    const issuesJson = join(dir, "issues.json");
+    writeFileSync(issuesJson, JSON.stringify([issue(14749, ["mvp"])]));
+
+    const result = spawnSync(
+      process.execPath,
+      [scriptPath, "--issues-json", issuesJson, "--issues-only", "--json"],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe("");
+    const report = JSON.parse(result.stdout);
+    expect(report.ok).toBe(false);
+    expect(report.projectCheckSkipped).toBe(true);
+    expect(report.violations).toEqual([
+      expect.objectContaining({
+        type: "missing-blocker-label",
+        number: 14749,
+      }),
+    ]);
+  });
+
+  test("CLI help documents issue-only fixture mode", () => {
+    const result = spawnSync(process.execPath, [scriptPath, "--help"], {
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(
+      "--issues-json issues.json --issues-only [--json]",
+    );
+    expect(result.stdout).toContain(
+      "Skip Project status lookup and check only open MVP blocker labels.",
+    );
   });
 });

--- a/packages/scripts/check-mvp-board-readiness.mjs
+++ b/packages/scripts/check-mvp-board-readiness.mjs
@@ -22,6 +22,8 @@ function usage() {
   return `Usage:
   node packages/scripts/check-mvp-board-readiness.mjs [--repo owner/repo] [--project-owner org] [--project-number n]
   node packages/scripts/check-mvp-board-readiness.mjs --issues-json issues.json --project-json project-items.json
+  node packages/scripts/check-mvp-board-readiness.mjs --issues-json issues.json --issues-only [--json]
+  node packages/scripts/check-mvp-board-readiness.mjs --issues-only [--json]
 
 Options:
   --json          Print machine-readable report.


### PR DESCRIPTION
## Summary
- document the valid `--issues-json ... --issues-only` board-readiness fixture mode in CLI help
- add CLI-level coverage for issue-only JSON output, skipped Project checks, and missing-blocker failures
- keep the fallback audit honest while GitHub Project GraphQL is unavailable

## Verification
- `bun test packages/scripts/__tests__/mvp-board-readiness.test.ts`
- `bunx @biomejs/biome check --write packages/scripts/check-mvp-board-readiness.mjs packages/scripts/__tests__/mvp-board-readiness.test.ts`
- `git diff --check HEAD~1..HEAD`
- `node packages/scripts/check-mvp-board-readiness.mjs --issues-only --json --no-fail` reported `ok: true`, `issueCount: 26`, `blockerCount: 26`, `projectCheckSkipped: true`, and `violations: 0`

## Evidence
<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - script-only audit tooling/test change; no rendered UI surface changed.

<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - script-only audit tooling/test change; no rendered UI surface changed.

<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - no user-facing runtime flow changed.

<!-- evidence-row:backend-logs -->
- Backend logs: N/A - no runtime server path changed; verification is local CLI/test output above.

<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A - no frontend runtime or browser path changed.

<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: N/A - no agent prompt, planner, memory, model, or scenario behavior changed.

<!-- evidence-row:domain-artifacts -->
- Domain artifacts: N/A - no production records are produced; the live issue-only readiness output is summarized in Verification.