### PR TITLE
fix(cloud): surface unreadable moderation error bodies

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/content-safety.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/content-safety.test.ts
@@ -20,6 +20,7 @@ const ORIGINAL_CONTENT_SAFETY_MODE = process.env.CONTENT_SAFETY_MODE;
 const ORIGINAL_CONTENT_SAFETY_REQUIRE_CONFIG = process.env.CONTENT_SAFETY_REQUIRE_CONFIG;
 const ORIGINAL_CONTENT_SAFETY_FAIL_OPEN = process.env.CONTENT_SAFETY_FAIL_OPEN;
 const loggerErrors: string[] = [];
+const loggerWarnings: string[] = [];
 
 mock.module("@/lib/utils/logger", () => ({
   ...REAL_LOGGER,
@@ -29,7 +30,9 @@ mock.module("@/lib/utils/logger", () => ({
       loggerErrors.push(message);
     },
     info: () => {},
-    warn: () => {},
+    warn: (message: string) => {
+      loggerWarnings.push(message);
+    },
   },
 }));
 
@@ -46,6 +49,7 @@ afterAll(() => {
 afterEach(() => {
   globalThis.fetch = ORIGINAL_FETCH;
   loggerErrors.length = 0;
+  loggerWarnings.length = 0;
   restoreEnv("OPENAI_API_KEY", ORIGINAL_OPENAI_API_KEY);
   restoreEnv("OPENAI_MODERATION_API_KEY", ORIGINAL_OPENAI_MODERATION_API_KEY);
   restoreEnv("CONTENT_SAFETY_MODE", ORIGINAL_CONTENT_SAFETY_MODE);
@@ -167,6 +171,33 @@ describe("contentSafetyService", () => {
 
     expect(loggerErrors[0]).toContain("Incorrect API key provided: sk-[REDACTED]");
     expect(loggerErrors[0]).not.toContain("sk-test-secret-1234567890");
+  });
+
+  test("fails closed with an observable diagnostic when moderation error body is unreadable", async () => {
+    process.env.OPENAI_API_KEY = "test-key";
+    globalThis.fetch = (async () =>
+      ({
+        ok: false,
+        status: 429,
+        statusText: "Too Many Requests",
+        text: async () => {
+          throw new Error("body stream failed");
+        },
+      }) as Response) as typeof fetch;
+
+    const { contentSafetyService } = await import(
+      `../content-safety.ts?case=unreadable-body-${Date.now()}`
+    );
+
+    await expect(
+      contentSafetyService.assertSafeForPublicUse({
+        surface: "promotion_copy",
+        text: "Safe text",
+      }),
+    ).rejects.toThrow("Content safety moderation is unavailable");
+
+    expect(loggerWarnings[0]).toContain("Failed to read moderation error body");
+    expect(loggerErrors[0]).toContain("<unreadable moderation error body>");
   });
 
   test("fails closed when moderation transport rejects", async () => {

--- a/packages/cloud/shared/src/lib/services/content-safety.ts
+++ b/packages/cloud/shared/src/lib/services/content-safety.ts
@@ -96,6 +96,22 @@ function redactProviderErrorDetail(detail: string): string {
     .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]{8,}/gi, "Bearer [REDACTED]");
 }
 
+async function readModerationErrorDetail(response: Response): Promise<string> {
+  try {
+    return redactProviderErrorDetail(await response.text()).slice(0, 300);
+  } catch (error) {
+    // error-policy:J7 diagnostics-must-not-kill-the-loop — the moderation
+    // response is already failed; keep that boundary decision intact while
+    // making the lost provider detail observable.
+    logger.warn("[ContentSafety] Failed to read moderation error body", {
+      status: response.status,
+      statusText: response.statusText,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return "<unreadable moderation error body>";
+  }
+}
+
 function compactText(input: ContentSafetyInput["text"]): string {
   const values = Array.isArray(input) ? input : [input];
   return values
@@ -313,10 +329,7 @@ export class ContentSafetyService {
       // inline it in the log MESSAGE: Workers Logs drops context objects, and
       // this fail-closed path blocked staging image-gen with zero log trace
       // of the upstream rejection.
-      const upstreamDetail = await response
-        .text()
-        .then((t) => redactProviderErrorDetail(t).slice(0, 300))
-        .catch(() => "");
+      const upstreamDetail = await readModerationErrorDetail(response);
       if (env.CONTENT_SAFETY_FAIL_OPEN === "true") {
         logger.error(
           `[ContentSafety] Moderation unavailable (${response.status} ${response.statusText}) on surface ${input.surface}; allowing because fail-open is set: ${upstreamDetail}`,


### PR DESCRIPTION
## Summary
- Replace the silent `response.text().catch(() => "")` moderation diagnostic fallback with an observable J7 diagnostics path.
- Preserve fail-closed/fail-open boundary behavior while logging unreadable provider error bodies and writing an explicit `<unreadable moderation error body>` marker.
- Add a regression test for unreadable moderation error bodies.

## Evidence
- `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/content-safety.ts packages/cloud/shared/src/lib/services/__tests__/content-safety.test.ts --no-errors-on-unmatched`
- `node packages/shared/scripts/generate-keywords.mjs --target ts` (local generated prerequisite for Bun test imports)
- `bun test --coverage-reporter=lcov packages/cloud/shared/src/lib/services/__tests__/content-safety.test.ts`
- `bun run audit:error-policy-ratchet`
- `bun run --cwd packages/cloud/shared typecheck 2>&1 | rg 'content-safety|__tests__/content-safety' || true`
- `git diff --check origin/develop...HEAD && git diff --check`

## Notes
- The generated i18n files and coverage output are ignored local artifacts and are not included in this PR.
- N/A: no UI screenshots/video; backend diagnostics-only change.
- N/A: no live LLM trajectory; no agent/model prompt path changed.

Fixes part of #13415.