### PR TITLE
fix(app): clear chat overlay in audit views

### DIFF
--- a/plugins/app-model-tester/src/ModelTesterAppView.tsx
+++ b/plugins/app-model-tester/src/ModelTesterAppView.tsx
@@ -341,7 +341,7 @@ export function ModelTesterAppView({ exitToApps, t }: OverlayAppContext) {
         </div>
       </div>
 
-      <div className="chat-native-scrollbar eliza-continuous-chat-scroll mb-[calc(var(--eliza-mobile-nav-offset,0px)+max(var(--safe-area-bottom,0px),var(--android-gesture-inset-bottom,0px))+var(--eliza-continuous-chat-clearance,5.25rem)+1rem)] flex-1 overflow-y-auto px-3 pt-2 pb-4 pe-[calc(var(--eliza-continuous-chat-side-clearance,0px)+0.75rem)] sm:px-5">
+      <div className="chat-native-scrollbar eliza-continuous-chat-scroll max-h-[calc(100%-var(--eliza-mobile-nav-offset,0px)-max(var(--safe-area-bottom,0px),var(--android-gesture-inset-bottom,0px))-var(--eliza-continuous-chat-clearance,5.25rem)-1rem)] flex-1 overflow-y-auto ps-3 pt-2 pb-[calc(var(--eliza-mobile-nav-offset,0px)+max(var(--safe-area-bottom,0px),var(--android-gesture-inset-bottom,0px))+var(--eliza-continuous-chat-clearance,5.25rem)+1rem)] pe-[calc(var(--eliza-continuous-chat-side-clearance,0px)+0.75rem)] [@media(orientation:landscape)_and_(max-height:520px)]:pe-[15rem] sm:ps-5">
         <div className="mx-auto flex max-w-5xl flex-col gap-3">
           <section className="py-2">
             <div className="grid grid-cols-3 gap-2">
@@ -451,7 +451,7 @@ export function ModelTesterAppView({ exitToApps, t }: OverlayAppContext) {
               const urls = id === "image" ? generatedImageUrls(result) : [];
               return (
                 <section key={id} className="py-3">
-                  <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div className="flex flex-wrap items-center justify-start gap-3">
                     <div className="flex min-w-0 items-center gap-3">
                       <div className="grid h-9 w-9 shrink-0 place-items-center">
                         <Icon className="h-5 w-5 text-txt" />

--- a/plugins/plugin-training/src/ui/FineTuningView.tsx
+++ b/plugins/plugin-training/src/ui/FineTuningView.tsx
@@ -2299,9 +2299,16 @@ export function FineTuningDashboard({
   return (
     <ContentLayout
       contentHeader={contentHeader}
-      contentClassName="mb-[calc(var(--eliza-mobile-nav-offset,0px)+max(var(--safe-area-bottom,0px),var(--android-gesture-inset-bottom,0px))+var(--eliza-continuous-chat-clearance,5.25rem)+1rem)] pe-[var(--eliza-continuous-chat-side-clearance,0px)]"
+      contentClassName="pe-[var(--eliza-continuous-chat-side-clearance,0px)]"
     >
-      <div data-testid="fine-tuning-view" className="space-y-4 pb-4">
+      <div
+        data-testid="fine-tuning-view"
+        className="chat-native-scrollbar eliza-continuous-chat-scroll space-y-4 overflow-y-auto pb-[calc(var(--eliza-mobile-nav-offset,0px)+max(var(--safe-area-bottom,0px),var(--android-gesture-inset-bottom,0px))+var(--eliza-continuous-chat-clearance,5.25rem)+1rem)]"
+        style={{
+          maxHeight:
+            "calc(100dvh - var(--eliza-mobile-nav-offset, 0px) - max(var(--safe-area-bottom, 0px), var(--android-gesture-inset-bottom, 0px)) - var(--eliza-continuous-chat-clearance, 5.25rem) - 3rem)",
+        }}
+      >
         <section className="px-2 py-2">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div>


### PR DESCRIPTION
## Summary
- clips the fine-tuning/training scroll body above the continuous chat composer
- keeps model-tester probe run controls away from the landscape composer

Fixes #13598.

## Validation
- `bunx @biomejs/biome check plugins/plugin-training/src/ui/FineTuningView.tsx plugins/app-model-tester/src/ModelTesterAppView.tsx`
- `bun run --cwd plugins/plugin-training build:views`
- `bun run --cwd plugins/app-model-tester build:views`
- `bun run --cwd packages/app audit:app`
  - Playwright: 241 passed
  - aesthetic report: broken=0, needs-work=0, needs-eyeball=11, good=229
  - OCR: 240 views, verified=92, broken=0, needs-eyeball=148
- `bun run audit:error-policy-ratchet`

## Evidence
<!-- evidence-row:before-screenshots -->
- [x] ![before screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15686-13598-before-overlay-clearance.png)

<!-- evidence-row:after-screenshots -->
- [x] ![after screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15686-13598-after-overlay-clearance.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence/15686-13598-overlay-clearance-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [ ] N/A - rendered UI layout-only change; no backend code path changed

<!-- evidence-row:frontend-logs -->
- [x] [`aesthetic-report.json`](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15686-aesthetic-report.json) from `bun run --cwd packages/app audit:app`: Playwright 241 passed, broken=0, needs-work=0

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model behavior changed

<!-- evidence-row:domain-artifacts -->
- [x] [`aesthetic-report.json`](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15686-aesthetic-report.json) and [`ocr-triage.json`](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15686-ocr-triage.json) generated from the final audit run

<!-- evidence-row:ocr-review -->
- [x] [`ocr-triage.json`](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15686-ocr-triage.json): total=240, verified=92, broken=0, newRegressions=0
