### PR TITLE
chore(mvp): allow project-board audit without project data

### DIFF
--- a/packages/scripts/__tests__/audit-mvp-project-board.test.ts
+++ b/packages/scripts/__tests__/audit-mvp-project-board.test.ts
@@ -74,6 +74,36 @@ const projectItems = [
   },
 ];
 
+const restOpenIssues = [
+  {
+    number: 10,
+    title: "Needs owner device",
+    html_url: "https://github.com/elizaOS/eliza/issues/10",
+    labels: [{ name: "mvp" }, { name: "needs-human" }],
+  },
+  {
+    number: 11,
+    title: "Ready for agent",
+    html_url: "https://github.com/elizaOS/eliza/issues/11",
+    labels: [{ name: "mvp" }, { name: "testing" }],
+  },
+  {
+    number: 12,
+    title: "Different lane",
+    html_url: "https://github.com/elizaOS/eliza/issues/12",
+    labels: [{ name: "testing" }],
+  },
+];
+
+const restClosedIssues = [
+  {
+    number: 13,
+    title: "Closed MVP row",
+    html_url: "https://github.com/elizaOS/eliza/issues/13",
+    labels: ["mvp"],
+  },
+];
+
 describe("audit-mvp-project-board", () => {
   test("summarizeMvpBoard separates stale, human-gated, and actionable rows", () => {
     const summary = board.summarizeMvpBoard({
@@ -124,6 +154,46 @@ describe("audit-mvp-project-board", () => {
       expect.objectContaining({ type: "agent-actionable-open", count: 1 }),
       expect.objectContaining({ type: "open-done", count: 1 }),
     ]);
+  });
+
+  test("summarizeMvpIssuesOnly reports partial label state without project buckets", () => {
+    const summary = board.summarizeMvpIssuesOnly({
+      openIssues: restOpenIssues,
+      closedIssues: restClosedIssues,
+    });
+
+    expect(summary.projectCheckSkipped).toBe(true);
+    expect(summary.counts).toEqual({
+      openMvpIssues: 2,
+      closedMvpIssues: 1,
+      humanGated: 1,
+      agentActionable: 1,
+    });
+    expect(summary.humanGated.map((issue) => issue.number)).toEqual([10]);
+    expect(summary.agentActionable.map((issue) => issue.number)).toEqual([11]);
+    expect(board.strictViolations(summary)).toEqual([
+      expect.objectContaining({
+        type: "agent-actionable-open",
+        message: "1 open MVP issue(s) are not human-gated",
+      }),
+    ]);
+  });
+
+  test("formatSummary makes issues-only Project status omission explicit", () => {
+    const text = board.formatSummary(
+      board.summarizeMvpIssuesOnly({
+        openIssues: restOpenIssues,
+        closedIssues: restClosedIssues,
+      }),
+    );
+
+    expect(text).toContain("Project status check: SKIPPED (--issues-only)");
+    expect(text).toContain(
+      "open MVP issues: 2 (1 human-gated, 1 agent-actionable)",
+    );
+    expect(text).toContain("Open MVP issues not human-gated");
+    expect(text).toContain("#11 — Ready for agent");
+    expect(text).not.toContain("closed-not-Done");
   });
 
   test("CLI fixture mode exits non-zero in strict mode and prints JSON violations", () => {
@@ -209,6 +279,83 @@ describe("audit-mvp-project-board", () => {
     expect(result.status).toBe(0);
     expect(result.stderr).toBe("");
     const parsed = JSON.parse(result.stdout);
+    expect(parsed.strictViolations).toEqual([]);
+    expect(parsed.counts.humanGated).toBe(1);
+  });
+
+  test("CLI issues-only fixture mode skips project data and fails only actionable open MVP issues", () => {
+    const dir = mkdtempSync(join(tmpdir(), "mvp-board-audit-issues-only-"));
+    const openJson = join(dir, "open.json");
+    const closedJson = join(dir, "closed.json");
+    writeFileSync(openJson, JSON.stringify(restOpenIssues));
+    writeFileSync(closedJson, JSON.stringify(restClosedIssues));
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        scriptPath,
+        "--issues-only",
+        "--open-json",
+        openJson,
+        "--closed-json",
+        closedJson,
+        "--json",
+        "--strict",
+      ],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("strict failed");
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.projectCheckSkipped).toBe(true);
+    expect(parsed.strictViolations).toEqual([
+      expect.objectContaining({ type: "agent-actionable-open", count: 1 }),
+    ]);
+    expect(parsed.strictViolations).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "closed-not-done" }),
+        expect.objectContaining({ type: "open-done" }),
+      ]),
+    );
+  });
+
+  test("CLI issues-only fixture mode exits zero when all open MVP issues are human-gated", () => {
+    const dir = mkdtempSync(join(tmpdir(), "mvp-board-audit-issues-clean-"));
+    const openJson = join(dir, "open.json");
+    const closedJson = join(dir, "closed.json");
+    writeFileSync(
+      openJson,
+      JSON.stringify([
+        {
+          number: 10,
+          title: "Needs owner device",
+          html_url: "https://github.com/elizaOS/eliza/issues/10",
+          labels: [{ name: "mvp" }, { name: "needs-shaw" }],
+        },
+      ]),
+    );
+    writeFileSync(closedJson, JSON.stringify(restClosedIssues));
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        scriptPath,
+        "--issues-only",
+        "--open-json",
+        openJson,
+        "--closed-json",
+        closedJson,
+        "--json",
+        "--strict",
+      ],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.projectCheckSkipped).toBe(true);
     expect(parsed.strictViolations).toEqual([]);
     expect(parsed.counts.humanGated).toBe(1);
   });

--- a/packages/scripts/audit-mvp-project-board.mjs
+++ b/packages/scripts/audit-mvp-project-board.mjs
@@ -20,12 +20,14 @@ function usage() {
   return `Usage:
   node packages/scripts/audit-mvp-project-board.mjs [--json] [--strict]
   node packages/scripts/audit-mvp-project-board.mjs --project-json project.json --open-json open.json --closed-json closed.json [--json] [--strict]
+  node packages/scripts/audit-mvp-project-board.mjs --issues-only [--json] [--strict]
 
 Options:
   --owner <org>        GitHub Project owner for live mode (default: ${DEFAULT_OWNER}).
   --project <number>  GitHub Project number for live mode (default: ${DEFAULT_PROJECT}).
   --repo <owner/repo> GitHub repo for live mode (default: ${DEFAULT_REPO}).
   --limit <n>         GitHub item/page limit (default: ${DEFAULT_LIMIT}).
+  --issues-only       Skip Project status lookup and report only MVP issue label state.
   --strict            Exit 1 when any stale/actionable bucket is non-empty.`;
 }
 
@@ -36,12 +38,15 @@ function parseArgs(argv) {
     project: DEFAULT_PROJECT,
     limit: DEFAULT_LIMIT,
     json: false,
+    issuesOnly: false,
     strict: false,
   };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--json") {
       out.json = true;
+    } else if (arg === "--issues-only") {
+      out.issuesOnly = true;
     } else if (arg === "--strict") {
       out.strict = true;
     } else if (arg === "--help" || arg === "-h") {
@@ -91,7 +96,12 @@ function parseArgs(argv) {
 }
 
 function ghJson(args) {
-  return JSON.parse(execFileSync("gh", args, { encoding: "utf8" }));
+  return JSON.parse(
+    execFileSync("gh", args, {
+      encoding: "utf8",
+      maxBuffer: 50 * 1024 * 1024,
+    }),
+  );
 }
 
 function readJson(file) {
@@ -110,6 +120,29 @@ export function normalizeProjectIssue(item) {
     status: item.status ?? null,
     labels: labels.filter(Boolean),
   };
+}
+
+export function normalizeRestIssue(issue) {
+  return {
+    number: issue.number,
+    title: issue.title,
+    url: issue.html_url ?? issue.url,
+    labels: (issue.labels ?? [])
+      .map((label) => (typeof label === "string" ? label : label?.name))
+      .filter(Boolean),
+  };
+}
+
+function fetchMvpIssuesByState(repo, state) {
+  return ghJson([
+    "api",
+    "--paginate",
+    "--slurp",
+    `repos/${repo}/issues?state=${state}&labels=mvp&per_page=100`,
+  ])
+    .flat()
+    .filter((issue) => !issue.pull_request)
+    .map(normalizeRestIssue);
 }
 
 function byNumber(items) {
@@ -161,9 +194,43 @@ export function summarizeMvpBoard({ projectItems, openIssues, closedIssues }) {
   };
 }
 
+export function summarizeMvpIssuesOnly({ openIssues, closedIssues }) {
+  const openMvpIssues = openIssues
+    .map(normalizeRestIssue)
+    .filter((issue) => issue.labels.includes("mvp"));
+  const closedMvpIssues = closedIssues
+    .map(normalizeRestIssue)
+    .filter((issue) => issue.labels.includes("mvp"));
+  const humanGated = openMvpIssues.filter((issue) =>
+    issue.labels.some(
+      (label) => label === "needs-human" || label === "needs-shaw",
+    ),
+  );
+  const agentActionable = openMvpIssues.filter(
+    (issue) =>
+      !issue.labels.some(
+        (label) => label === "needs-human" || label === "needs-shaw",
+      ),
+  );
+
+  return {
+    projectCheckSkipped: true,
+    counts: {
+      openMvpIssues: openMvpIssues.length,
+      closedMvpIssues: closedMvpIssues.length,
+      humanGated: humanGated.length,
+      agentActionable: agentActionable.length,
+    },
+    openMvpIssues,
+    closedMvpIssues,
+    humanGated,
+    agentActionable,
+  };
+}
+
 export function strictViolations(summary) {
   const violations = [];
-  if (summary.closedNotDone.length > 0) {
+  if (summary.closedNotDone?.length > 0) {
     violations.push({
       type: "closed-not-done",
       count: summary.closedNotDone.length,
@@ -174,10 +241,12 @@ export function strictViolations(summary) {
     violations.push({
       type: "agent-actionable-open",
       count: summary.agentActionable.length,
-      message: `${summary.agentActionable.length} open MVP issue(s) are neither Done nor human-gated`,
+      message: summary.projectCheckSkipped
+        ? `${summary.agentActionable.length} open MVP issue(s) are not human-gated`
+        : `${summary.agentActionable.length} open MVP issue(s) are neither Done nor human-gated`,
     });
   }
-  if (summary.openDone.length > 0) {
+  if (summary.openDone?.length > 0) {
     violations.push({
       type: "open-done",
       count: summary.openDone.length,
@@ -192,7 +261,16 @@ function formatIssue(issue) {
   return `#${issue.number} ${issue.status ?? "(no status)"} — ${issue.title}${labels}`;
 }
 
+function formatIssueOnly(issue) {
+  const labels = issue.labels.length > 0 ? ` [${issue.labels.join(",")}]` : "";
+  return `#${issue.number} — ${issue.title}${labels}`;
+}
+
 export function formatSummary(summary) {
+  if (summary.projectCheckSkipped) {
+    return formatIssuesOnlySummary(summary);
+  }
+
   const lines = [
     "LifeOps MVP project-board audit",
     `project issues: ${summary.counts.projectIssues}; mvp issues: ${summary.counts.mvpIssues}`,
@@ -220,6 +298,45 @@ export function formatSummary(summary) {
   return lines.join("\n");
 }
 
+function formatIssuesOnlySummary(summary) {
+  const lines = [
+    "LifeOps MVP project-board audit",
+    "Project status check: SKIPPED (--issues-only)",
+    `open MVP issues: ${summary.counts.openMvpIssues} (${summary.counts.humanGated} human-gated, ${summary.counts.agentActionable} agent-actionable)`,
+    `closed MVP issues: ${summary.counts.closedMvpIssues}`,
+  ];
+
+  const section = (title, rows) => {
+    lines.push("", title);
+    if (rows.length === 0) {
+      lines.push("  (none)");
+      return;
+    }
+    for (const row of rows) lines.push(`  ${formatIssueOnly(row)}`);
+  };
+
+  section("Open MVP issues not human-gated", summary.agentActionable);
+  section("Open MVP issues human-gated", summary.humanGated);
+  return lines.join("\n");
+}
+
+function writeSummary(summary, args) {
+  const violations = strictViolations(summary);
+  process.stdout.write(
+    args.json
+      ? `${JSON.stringify({ ...summary, strictViolations: violations }, null, 2)}\n`
+      : `${formatSummary(summary)}\n`,
+  );
+  if (args.strict && violations.length > 0) {
+    process.stderr.write(
+      `[audit-mvp-project-board] strict failed: ${violations
+        .map((violation) => violation.message)
+        .join("; ")}\n`,
+    );
+    process.exitCode = 1;
+  }
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   if (args.help) {
@@ -232,9 +349,33 @@ async function main() {
     args.closedJson,
   ].filter(Boolean);
   if (fixtureInputs.length > 0 && fixtureInputs.length !== 3) {
+    if (
+      args.issuesOnly &&
+      !args.projectJson &&
+      args.openJson &&
+      args.closedJson
+    ) {
+      const openIssues = readJson(args.openJson);
+      const closedIssues = readJson(args.closedJson);
+      const summary = summarizeMvpIssuesOnly({ openIssues, closedIssues });
+      writeSummary(summary, args);
+      return;
+    }
     throw new Error(
       "--project-json, --open-json, and --closed-json must be passed together",
     );
+  }
+
+  if (args.issuesOnly) {
+    const openIssues = args.openJson
+      ? readJson(args.openJson)
+      : fetchMvpIssuesByState(args.repo, "open");
+    const closedIssues = args.closedJson
+      ? readJson(args.closedJson)
+      : fetchMvpIssuesByState(args.repo, "closed");
+    const summary = summarizeMvpIssuesOnly({ openIssues, closedIssues });
+    writeSummary(summary, args);
+    return;
   }
 
   const projectData = args.projectJson
@@ -288,23 +429,7 @@ async function main() {
     openIssues,
     closedIssues,
   });
-  const violations = strictViolations(summary);
-  const output = args.json
-    ? { ...summary, strictViolations: violations }
-    : null;
-  process.stdout.write(
-    args.json
-      ? `${JSON.stringify(output, null, 2)}\n`
-      : `${formatSummary(summary)}\n`,
-  );
-  if (args.strict && violations.length > 0) {
-    process.stderr.write(
-      `[audit-mvp-project-board] strict failed: ${violations
-        .map((violation) => violation.message)
-        .join("; ")}\n`,
-    );
-    process.exitCode = 1;
-  }
+  writeSummary(summary, args);
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {


### PR DESCRIPTION
## Summary
- Add `--issues-only` to `packages/scripts/audit-mvp-project-board.mjs` so closeout audits can run from REST issue labels when Project GraphQL is unavailable.
- Make issues-only output explicitly partial with `projectCheckSkipped: true`, no closed-not-Done/open-Done Project buckets, and strict failures only for open MVP issues lacking `needs-human`/`needs-shaw`.
- Cover REST-style fixture labels, text output, JSON strict output, and clean all-human-gated strict mode.

## Verification
- `bun test packages/scripts/__tests__/audit-mvp-project-board.test.ts` -> 9 pass
- `bunx @biomejs/biome@2.5.3 check packages/scripts/audit-mvp-project-board.mjs packages/scripts/__tests__/audit-mvp-project-board.test.ts` -> checked 2 files, no fixes
- `node packages/scripts/audit-mvp-project-board.mjs --issues-only --json | <summary parser>` -> `{ "projectCheckSkipped": true, "counts": { "openMvpIssues": 26, "closedMvpIssues": 157, "humanGated": 26, "agentActionable": 0 }, "strictViolations": [] }`
- `git diff --check` -> pass
- `bun run audit:error-policy-ratchet` -> no new fallback-slop in touched files

## Evidence
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - CLI audit tooling only; no agent/action/provider/prompt/model behavior changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - CLI/test command outputs are included inline above.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend path changed.
<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no rendered UI changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - live issues-only audit counts are included inline above.