### PR TITLE
chore(mvp): guard readiness fallback counts

### DIFF
--- a/packages/scripts/__tests__/mvp-board-readiness.test.ts
+++ b/packages/scripts/__tests__/mvp-board-readiness.test.ts
@@ -137,6 +137,27 @@ describe("MVP board readiness audit", () => {
     expect(report.rows[0].projectCheckSkipped).toBe(true);
   });
 
+  test("minimum issue guard prevents vacuous fallback passes", () => {
+    const report = board.auditMvpBoardReadiness(
+      [],
+      { items: [] },
+      {
+        projectCheckSkipped: true,
+        minIssues: 1,
+      },
+    );
+
+    expect(report.ok).toBe(false);
+    expect(report.minIssues).toBe(1);
+    expect(report.violations).toEqual([
+      expect.objectContaining({
+        type: "too-few-issues",
+        minimum: 1,
+        actual: 0,
+      }),
+    ]);
+  });
+
   test("does not match project items from a different repository by number", () => {
     const report = board.auditMvpBoardReadiness(
       [issue(14747, ["mvp", "needs-shaw"])],
@@ -216,6 +237,38 @@ describe("MVP board readiness audit", () => {
     ]);
   });
 
+  test("CLI issues-only fixture mode fails when below minimum issue count", () => {
+    const dir = mkdtempSync(join(tmpdir(), "mvp-board-readiness-"));
+    const issuesJson = join(dir, "issues.json");
+    writeFileSync(issuesJson, JSON.stringify([]));
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        scriptPath,
+        "--issues-json",
+        issuesJson,
+        "--issues-only",
+        "--min-issues",
+        "1",
+        "--json",
+      ],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe("");
+    const report = JSON.parse(result.stdout);
+    expect(report.ok).toBe(false);
+    expect(report.violations).toEqual([
+      expect.objectContaining({
+        type: "too-few-issues",
+        minimum: 1,
+        actual: 0,
+      }),
+    ]);
+  });
+
   test("CLI help documents issue-only fixture mode", () => {
     const result = spawnSync(process.execPath, [scriptPath, "--help"], {
       encoding: "utf8",
@@ -227,6 +280,23 @@ describe("MVP board readiness audit", () => {
     );
     expect(result.stdout).toContain(
       "Skip Project status lookup and check only open MVP blocker labels.",
+    );
+    expect(result.stdout).toContain(
+      "--min-issues n  Fail if fewer than n open MVP issues are loaded.",
+    );
+  });
+
+  test("CLI rejects invalid minimum issue counts", () => {
+    const result = spawnSync(
+      process.execPath,
+      [scriptPath, "--issues-only", "--min-issues", "one"],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain(
+      "check-mvp-board-readiness: --min-issues must be a non-negative integer",
     );
   });
 });

--- a/packages/scripts/check-mvp-board-readiness.mjs
+++ b/packages/scripts/check-mvp-board-readiness.mjs
@@ -28,6 +28,7 @@ function usage() {
 Options:
   --json          Print machine-readable report.
   --issues-only   Skip Project status lookup and check only open MVP blocker labels.
+  --min-issues n  Fail if fewer than n open MVP issues are loaded.
   --no-fail      Exit 0 even when violations are found.`;
 }
 
@@ -39,6 +40,7 @@ function parseArgs(argv) {
     json: false,
     fail: true,
     issuesOnly: false,
+    minIssues: 0,
   };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
@@ -54,6 +56,7 @@ function parseArgs(argv) {
       arg === "--repo" ||
       arg === "--project-owner" ||
       arg === "--project-number" ||
+      arg === "--min-issues" ||
       arg === "--issues-json" ||
       arg === "--project-json"
     ) {
@@ -70,6 +73,13 @@ function parseArgs(argv) {
     }
   }
   return out;
+}
+
+function parseNonNegativeInteger(value, flag) {
+  if (!/^\d+$/.test(String(value))) {
+    throw new Error(`${flag} must be a non-negative integer`);
+  }
+  return Number(value);
 }
 
 function run(command, args) {
@@ -174,12 +184,22 @@ function normalizeProjectItems(payload, repo = DEFAULT_REPO) {
 
 export function auditMvpBoardReadiness(issues, projectPayload, options = {}) {
   const projectCheckSkipped = options.projectCheckSkipped ?? false;
+  const minIssues = options.minIssues ?? 0;
   const projectItems = normalizeProjectItems(
     projectPayload,
     options.repo ?? DEFAULT_REPO,
   );
   const violations = [];
   const rows = [];
+
+  if (issues.length < minIssues) {
+    violations.push({
+      type: "too-few-issues",
+      minimum: minIssues,
+      actual: issues.length,
+      message: `Loaded ${issues.length} open MVP issue(s), below required minimum ${minIssues}`,
+    });
+  }
 
   for (const issue of issues) {
     const labels = labelNames(issue);
@@ -238,6 +258,7 @@ export function auditMvpBoardReadiness(issues, projectPayload, options = {}) {
     issueCount: issues.length,
     blockerCount: rows.filter((row) => row.blockerLabels.length > 0).length,
     projectCheckSkipped,
+    minIssues,
     requiredBlockedStatus: REQUIRED_BLOCKED_STATUS,
     violations,
     rows,
@@ -251,6 +272,9 @@ function formatText(report) {
     `Blocked issues: ${report.blockerCount}`,
     `Project status check: ${report.projectCheckSkipped ? "SKIPPED" : "checked"}`,
   ];
+  if (report.minIssues > 0) {
+    lines.push(`Minimum issue count: ${report.minIssues}`);
+  }
   if (!report.projectCheckSkipped) {
     lines.push(`Required blocked status: ${report.requiredBlockedStatus}`);
   }
@@ -281,6 +305,7 @@ async function main() {
   const issues = args.issuesJson
     ? readJson(args.issuesJson)
     : fetchOpenMvpIssues(args.repo);
+  const minIssues = parseNonNegativeInteger(args.minIssues, "--min-issues");
   const projectPayload = args.projectJson
     ? readJson(args.projectJson)
     : args.issuesOnly
@@ -289,6 +314,7 @@ async function main() {
   const report = auditMvpBoardReadiness(issues, projectPayload, {
     repo: args.repo,
     projectCheckSkipped: args.issuesOnly,
+    minIssues,
   });
 
   process.stdout.write(


### PR DESCRIPTION
## Summary
- add `--min-issues <n>` to the MVP board-readiness audit
- fail fallback/fixture audits when too few open MVP issues are loaded, avoiding vacuous green checks from bad labels, empty fixtures, or API hiccups
- cover the new guard at both pure-function and CLI levels, including invalid argument handling

## Verification
- `bun test packages/scripts/__tests__/mvp-board-readiness.test.ts`
- `bunx @biomejs/biome check --write packages/scripts/check-mvp-board-readiness.mjs packages/scripts/__tests__/mvp-board-readiness.test.ts`
- `git diff --check HEAD~1..HEAD`
- `node packages/scripts/check-mvp-board-readiness.mjs --issues-only --min-issues 1 --json --no-fail` reported `ok: true`, `issueCount: 26`, `minIssues: 1`, `blockerCount: 26`, `projectCheckSkipped: true`, and `violations: 0`

## Evidence
<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - script-only audit tooling/test change; no rendered UI surface changed.

<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - script-only audit tooling/test change; no rendered UI surface changed.

<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - no user-facing runtime flow changed.

<!-- evidence-row:backend-logs -->
- Backend logs: N/A - no runtime server path changed; verification is local CLI/test output above.

<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A - no frontend runtime or browser path changed.

<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: N/A - no agent prompt, planner, memory, model, or scenario behavior changed.

<!-- evidence-row:domain-artifacts -->
- Domain artifacts: N/A - no production records are produced; the live guarded issue-only readiness output is summarized in Verification.