### PR TITLE
fix(cloud): preserve ElevenLabs error body read failures

### DIFF
--- a/packages/cloud/shared/src/lib/providers/audio/elevenlabs-audio-generation.test.ts
+++ b/packages/cloud/shared/src/lib/providers/audio/elevenlabs-audio-generation.test.ts
@@ -18,6 +18,7 @@ interface MockState {
 }
 
 const state: MockState = { requests: [], status: 200, errorBody: "", emptyBody: false };
+const realFetch = globalThis.fetch;
 
 const server = Bun.serve({
   port: 0,
@@ -47,6 +48,7 @@ afterAll(() => {
 });
 
 beforeEach(() => {
+  globalThis.fetch = realFetch;
   state.requests = [];
   state.status = 200;
   state.errorBody = "";
@@ -95,6 +97,33 @@ describe("generateElevenLabsAudio — music", () => {
         apiKeys,
       }),
     ).rejects.toThrow(/music generation failed \(401\).*invalid api key/);
+  });
+
+  test("unreadable upstream failure body rethrows with status and cause", async () => {
+    globalThis.fetch = (async () =>
+      ({
+        ok: false,
+        status: 502,
+        text: async () => {
+          throw new Error("body stream failed");
+        },
+      }) as Response) as typeof fetch;
+
+    try {
+      await generateElevenLabsAudio({
+        kind: "music",
+        model: "elevenlabs/music_v1",
+        prompt: "x",
+        apiKeys,
+      });
+      throw new Error("expected generateElevenLabsAudio to reject");
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      const err = error as Error;
+      expect(err.message).toMatch(/music generation failed \(502\).*body could not be read/);
+      expect(err.cause).toBeInstanceOf(Error);
+      expect((err.cause as Error).message).toBe("body stream failed");
+    }
   });
 });
 

--- a/packages/cloud/shared/src/lib/providers/audio/elevenlabs-audio-generation.ts
+++ b/packages/cloud/shared/src/lib/providers/audio/elevenlabs-audio-generation.ts
@@ -37,8 +37,21 @@ async function readAudioBody(response: Response, label: string): Promise<Uint8Ar
   return new Uint8Array(buffer);
 }
 
+async function readUpstreamErrorText(response: Response, label: string): Promise<string> {
+  try {
+    return await response.text();
+  } catch (error) {
+    // error-policy:J2 context-adding rethrow — callers need the upstream
+    // status even when the provider error stream itself fails.
+    throw new Error(
+      `ElevenLabs ${label} failed (${response.status}) and its error body could not be read`,
+      { cause: error },
+    );
+  }
+}
+
 async function throwUpstreamError(response: Response, label: string): Promise<never> {
-  const text = await response.text().catch(() => "");
+  const text = await readUpstreamErrorText(response, label);
   throw new Error(`ElevenLabs ${label} failed (${response.status}): ${text}`);
 }
 


### PR DESCRIPTION
## Summary
- Remove the `response.text().catch(() => "")` fallback from the ElevenLabs audio provider upstream-error path.
- Add a J2 context-adding rethrow when the upstream error body stream itself fails, preserving the provider status and the original stream error in `cause`.
- Add regression coverage for unreadable ElevenLabs error bodies.

## Evidence
- `bun test --coverage-reporter=lcov packages/cloud/shared/src/lib/providers/audio/elevenlabs-audio-generation.test.ts`
- `bunx @biomejs/biome check packages/cloud/shared/src/lib/providers/audio/elevenlabs-audio-generation.ts packages/cloud/shared/src/lib/providers/audio/elevenlabs-audio-generation.test.ts --no-errors-on-unmatched`
- `bun run audit:error-policy-ratchet`
- `bun run --cwd packages/cloud/shared typecheck 2>&1 | rg 'elevenlabs-audio-generation' || true`
- `git diff --check origin/develop...HEAD && git diff --check`

N/A: no UI artifacts; backend provider error-handling only.
N/A: no live LLM trajectory; no prompt/model/action path changed.

Fixes part of #13415.