### PR TITLE
fix(cloud): preserve Headscale error body read failures

### DIFF
--- a/packages/cloud/shared/src/lib/services/headscale-client.test.ts
+++ b/packages/cloud/shared/src/lib/services/headscale-client.test.ts
@@ -1,6 +1,8 @@
 // Exercises headscale client behavior with deterministic cloud-shared lib fixtures.
-import { afterEach, describe, expect, it } from "vitest";
-import { resolvePreAuthTtlMs } from "./headscale-client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HeadscaleClient, resolvePreAuthTtlMs } from "./headscale-client";
+
+const originalFetch = globalThis.fetch;
 
 /**
  * The headscale pre-auth key TTL gates the provisioning-E2E reachable path: the
@@ -33,5 +35,42 @@ describe("resolvePreAuthTtlMs (headscale pre-auth key TTL)", () => {
       process.env.HEADSCALE_PREAUTH_TTL_MIN = bad;
       expect(resolvePreAuthTtlMs()).toBe(60 * 60 * 1000);
     }
+  });
+});
+
+describe("HeadscaleClient upstream errors", () => {
+  beforeEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("preserves unreadable Headscale error bodies as the thrown cause", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      return {
+        ok: false,
+        status: 502,
+        statusText: "Bad Gateway",
+        text: async () => {
+          throw new Error("body stream failed");
+        },
+        headers: new Headers(),
+      } as Response;
+    }) as typeof fetch;
+
+    const client = new HeadscaleClient({
+      apiUrl: "https://headscale.example",
+      apiKey: "secret",
+      user: "1",
+    });
+
+    await expect(client.createPreAuthKey()).rejects.toMatchObject({
+      message:
+        "Headscale API POST /api/v1/preauthkey failed: 502 Bad Gateway; error body could not be read",
+      cause: expect.objectContaining({ message: "body stream failed" }),
+    });
   });
 });

--- a/packages/cloud/shared/src/lib/services/headscale-client.ts
+++ b/packages/cloud/shared/src/lib/services/headscale-client.ts
@@ -19,6 +19,22 @@ const DEFAULT_TIMEOUT_MS = 10_000;
 /** Timeout for health checks (ms) */
 const HEALTH_TIMEOUT_MS = 5_000;
 
+async function readHeadscaleErrorBody(
+  resp: Response,
+  method: string,
+  path: string,
+): Promise<string> {
+  try {
+    return await resp.text();
+  } catch (error) {
+    // error-policy:J2 context-adding rethrow; an unreadable upstream body is part of the failure.
+    throw new Error(
+      `Headscale API ${method} ${path} failed: ${resp.status} ${resp.statusText}; error body could not be read`,
+      { cause: error },
+    );
+  }
+}
+
 /**
  * Pre-auth key TTL window (ms): how long a freshly-created key stays valid for a
  * container to boot AND finish VPN enrollment. 10 min proved too tight on slow
@@ -318,7 +334,7 @@ export class HeadscaleClient {
     const resp = await fetch(url, init);
 
     if (!resp.ok) {
-      const text = await resp.text().catch(() => "");
+      const text = await readHeadscaleErrorBody(resp, method, path);
       // Log raw body at debug level only — don't leak it into error messages
       logger.debug(`[headscale] API error body for ${method} ${path}:`, {
         body: text,


### PR DESCRIPTION
## Summary
- replace the Headscale upstream-error `resp.text().catch(() => "")` swallow with a J2 context-adding rethrow
- preserve the original body stream failure in `cause` while keeping readable upstream error behavior unchanged
- add regression coverage through `HeadscaleClient.createPreAuthKey()`

## Evidence
- `bun test --coverage-reporter=lcov packages/cloud/shared/src/lib/services/headscale-client.test.ts`
- `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/headscale-client.ts packages/cloud/shared/src/lib/services/headscale-client.test.ts --no-errors-on-unmatched`
- `bun run audit:error-policy-ratchet`
- `bun run --cwd packages/cloud/shared typecheck 2>&1 | rg "headscale-client" || true`
- `git diff --check origin/develop...HEAD && git diff --check`

N/A: no UI artifacts; backend service error-handling only.
N/A: no live LLM trajectory; no prompt/model/action path changed.

Refs #13415