### PR TITLE
fix: stabilize LifeOps bench build and music routing

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2311,6 +2311,7 @@
       "dependencies": {
         "@elizaos/agent": "workspace:*",
         "@elizaos/core": "workspace:*",
+        "@elizaos/plugin-groq": "workspace:*",
         "@elizaos/shared": "workspace:*",
         "dotenv": "^17.2.3",
         "zod": "^4.4.3",

--- a/bun.lock
+++ b/bun.lock
@@ -2312,6 +2312,7 @@
         "@elizaos/agent": "workspace:*",
         "@elizaos/core": "workspace:*",
         "@elizaos/plugin-groq": "workspace:*",
+        "@elizaos/plugin-local-inference": "workspace:*",
         "@elizaos/shared": "workspace:*",
         "dotenv": "^17.2.3",
         "zod": "^4.4.3",

--- a/packages/lifeops-bench/package.json
+++ b/packages/lifeops-bench/package.json
@@ -16,6 +16,7 @@
     "@elizaos/agent": "workspace:*",
     "@elizaos/core": "workspace:*",
     "@elizaos/plugin-groq": "workspace:*",
+    "@elizaos/plugin-local-inference": "workspace:*",
     "@elizaos/shared": "workspace:*",
     "dotenv": "^17.2.3",
     "zod": "^4.4.3"

--- a/packages/lifeops-bench/package.json
+++ b/packages/lifeops-bench/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@elizaos/agent": "workspace:*",
     "@elizaos/core": "workspace:*",
+    "@elizaos/plugin-groq": "workspace:*",
     "@elizaos/shared": "workspace:*",
     "dotenv": "^17.2.3",
     "zod": "^4.4.3"

--- a/packages/lifeops-bench/src/type-boundary.test.ts
+++ b/packages/lifeops-bench/src/type-boundary.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Guards the benchmark typecheck boundary from traversing the agent's optional-plugin source graph.
+ * Runtime resolution still uses the agent package exports; only compile-time types use built declarations.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+interface BenchTypeScriptConfig {
+  compilerOptions?: {
+    paths?: Record<string, string[]>;
+  };
+}
+
+describe("LifeOps bench type boundary", () => {
+  it("resolves narrow agent imports through built declarations", () => {
+    const configPath = fileURLToPath(
+      new URL("../tsconfig.json", import.meta.url),
+    );
+    const config = JSON.parse(
+      readFileSync(configPath, "utf8"),
+    ) as BenchTypeScriptConfig;
+
+    expect(config.compilerOptions?.paths).toEqual({
+      "@elizaos/agent/runtime/core-plugins": [
+        "../agent/dist/runtime/core-plugins.d.ts",
+      ],
+      "@elizaos/agent/runtime/plugin-types": [
+        "../agent/dist/runtime/plugin-types.d.ts",
+      ],
+      "@elizaos/plugin-local-inference/runtime": [
+        "../../plugins/plugin-local-inference/dist/runtime/index.d.ts",
+      ],
+    });
+  });
+});

--- a/packages/lifeops-bench/tsconfig.json
+++ b/packages/lifeops-bench/tsconfig.json
@@ -9,6 +9,17 @@
     "noEmit": true,
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
+    "paths": {
+      "@elizaos/agent/runtime/core-plugins": [
+        "../agent/dist/runtime/core-plugins.d.ts"
+      ],
+      "@elizaos/agent/runtime/plugin-types": [
+        "../agent/dist/runtime/plugin-types.d.ts"
+      ],
+      "@elizaos/plugin-local-inference/runtime": [
+        "../../plugins/plugin-local-inference/dist/runtime/index.d.ts"
+      ]
+    },
     "types": ["node"]
   },
   "include": ["src/**/*.ts"]

--- a/plugins/plugin-music/src/actions/manageRouting.ts
+++ b/plugins/plugin-music/src/actions/manageRouting.ts
@@ -15,6 +15,7 @@ import type {
 } from "@elizaos/core";
 import { logger } from "@elizaos/core";
 import type { AudioRouter, AudioRoutingMode, ZoneManager } from "../router";
+import { selectedContextMatches } from "../utils/selectedContextMatches";
 
 type RoutingCommand =
   | { action: "set_mode"; mode: AudioRoutingMode }
@@ -58,34 +59,6 @@ interface MusicRoutingService extends Service {
 }
 
 const ROUTING_CONTEXTS = ["media", "automation", "settings"] as const;
-function selectedContextMatches(
-  state: State | undefined,
-  contexts: readonly string[],
-): boolean {
-  const selected = new Set<string>();
-  const collect = (value: unknown) => {
-    if (!Array.isArray(value)) return;
-    for (const item of value) {
-      if (typeof item === "string") selected.add(item);
-    }
-  };
-  collect(
-    (state?.values as Record<string, unknown> | undefined)?.selectedContexts,
-  );
-  collect(
-    (state?.data as Record<string, unknown> | undefined)?.selectedContexts,
-  );
-  const contextObject = (state?.data as Record<string, unknown> | undefined)
-    ?.contextObject as
-    | {
-        trajectoryPrefix?: { selectedContexts?: unknown };
-        metadata?: { selectedContexts?: unknown };
-      }
-    | undefined;
-  collect(contextObject?.trajectoryPrefix?.selectedContexts);
-  collect(contextObject?.metadata?.selectedContexts);
-  return contexts.some((context) => selected.has(context));
-}
 
 async function emit(
   callback: HandlerCallback | undefined,

--- a/plugins/plugin-music/src/actions/manageZones.ts
+++ b/plugins/plugin-music/src/actions/manageZones.ts
@@ -15,6 +15,7 @@ import type {
 } from "@elizaos/core";
 import { logger } from "@elizaos/core";
 import type { ZoneManager } from "../router";
+import { selectedContextMatches } from "../utils/selectedContextMatches";
 
 type ZoneCommand =
   | { operation: "create"; zoneName: string; targetIds: string[] }
@@ -31,34 +32,6 @@ interface MusicZoneService extends Service {
 }
 
 const ZONE_CONTEXTS = ["media", "automation", "settings"] as const;
-function selectedContextMatches(
-  state: State | undefined,
-  contexts: readonly string[],
-): boolean {
-  const selected = new Set<string>();
-  const collect = (value: unknown) => {
-    if (!Array.isArray(value)) return;
-    for (const item of value) {
-      if (typeof item === "string") selected.add(item);
-    }
-  };
-  collect(
-    (state?.values as Record<string, unknown> | undefined)?.selectedContexts,
-  );
-  collect(
-    (state?.data as Record<string, unknown> | undefined)?.selectedContexts,
-  );
-  const contextObject = (state?.data as Record<string, unknown> | undefined)
-    ?.contextObject as
-    | {
-        trajectoryPrefix?: { selectedContexts?: unknown };
-        metadata?: { selectedContexts?: unknown };
-      }
-    | undefined;
-  collect(contextObject?.trajectoryPrefix?.selectedContexts);
-  collect(contextObject?.metadata?.selectedContexts);
-  return contexts.some((context) => selected.has(context));
-}
 
 async function emit(
   callback: HandlerCallback | undefined,

--- a/plugins/plugin-music/src/actions/music.ts
+++ b/plugins/plugin-music/src/actions/music.ts
@@ -15,13 +15,9 @@ import type {
   Memory,
   State,
 } from "@elizaos/core";
-import {
-  CONTEXT_ROUTING_STATE_KEY,
-  logger,
-  ModelType,
-  parseKeyValueXml,
-} from "@elizaos/core";
+import { logger, ModelType, parseKeyValueXml } from "@elizaos/core";
 import { sunoGenerateMusicHandler } from "@elizaos/plugin-suno";
+import { selectedContextMatches } from "../utils/selectedContextMatches";
 import { mergedOptions } from "./confirmation";
 import { manageRouting } from "./manageRouting";
 import { manageZones } from "./manageZones";
@@ -564,45 +560,6 @@ function ensurePlaybackMerged(
   return out;
 }
 
-function selectedContextMatches(
-  state: State | undefined,
-  contexts: readonly string[],
-): boolean {
-  const selected = new Set<string>();
-  const collectOne = (value: unknown) => {
-    if (typeof value === "string") selected.add(value);
-  };
-  const collect = (value: unknown) => {
-    if (!Array.isArray(value)) return;
-    for (const item of value) collectOne(item);
-  };
-  collect(
-    (state?.values as Record<string, unknown> | undefined)?.selectedContexts,
-  );
-  collect(
-    (state?.data as Record<string, unknown> | undefined)?.selectedContexts,
-  );
-  const contextObject = (state?.data as Record<string, unknown> | undefined)
-    ?.contextObject as
-    | {
-        trajectoryPrefix?: { selectedContexts?: unknown };
-        metadata?: { selectedContexts?: unknown };
-      }
-    | undefined;
-  collect(contextObject?.trajectoryPrefix?.selectedContexts);
-  collect(contextObject?.metadata?.selectedContexts);
-  // The v5 planner writes its routing decision to `state.values.__contextRouting`
-  // ({ primaryContext, secondaryContexts }) — never to `selectedContexts` — so
-  // this is the only context signal present when `validate()` runs at planner
-  // action-exposure time. See @elizaos/core CONTEXT_ROUTING_STATE_KEY.
-  const routing = (state?.values as Record<string, unknown> | undefined)?.[
-    CONTEXT_ROUTING_STATE_KEY
-  ] as { primaryContext?: unknown; secondaryContexts?: unknown } | undefined;
-  collectOne(routing?.primaryContext);
-  collect(routing?.secondaryContexts);
-  return contexts.some((context) => selected.has(context));
-}
-
 const musicExamples: ActionExample[][] = [
   ...(musicLibraryAction.examples ?? []),
   ...(playbackOp.examples ?? []),
@@ -776,7 +733,9 @@ export const musicAction: Action = {
   ): Promise<boolean> => {
     const merged = mergedOptions(options);
     if (readExplicitSubaction(merged)) return true;
-    return selectedContextMatches(state, MUSIC_CONTEXTS);
+    return selectedContextMatches(state, MUSIC_CONTEXTS, {
+      includeContextRouting: true,
+    });
   },
   handler: async (
     runtime: IAgentRuntime,

--- a/plugins/plugin-music/src/actions/musicLibrary.ts
+++ b/plugins/plugin-music/src/actions/musicLibrary.ts
@@ -14,6 +14,7 @@ import type {
   Memory,
   State,
 } from "@elizaos/core";
+import { selectedContextMatches } from "../utils/selectedContextMatches";
 import { mergedOptions } from "./confirmation";
 import {
   downloadMusicExamples,
@@ -133,35 +134,6 @@ export function readExplicitMusicLibraryOp(
     normalizeMusicLibraryOp(options.action) ??
     normalizeMusicLibraryOp(options.subaction)
   );
-}
-
-function selectedContextMatches(
-  state: State | undefined,
-  contexts: readonly string[],
-): boolean {
-  const selected = new Set<string>();
-  const collect = (value: unknown) => {
-    if (!Array.isArray(value)) return;
-    for (const item of value) {
-      if (typeof item === "string") selected.add(item);
-    }
-  };
-  collect(
-    (state?.values as Record<string, unknown> | undefined)?.selectedContexts,
-  );
-  collect(
-    (state?.data as Record<string, unknown> | undefined)?.selectedContexts,
-  );
-  const contextObject = (state?.data as Record<string, unknown> | undefined)
-    ?.contextObject as
-    | {
-        trajectoryPrefix?: { selectedContexts?: unknown };
-        metadata?: { selectedContexts?: unknown };
-      }
-    | undefined;
-  collect(contextObject?.trajectoryPrefix?.selectedContexts);
-  collect(contextObject?.metadata?.selectedContexts);
-  return contexts.some((context) => selected.has(context));
 }
 
 export async function inferMusicLibraryOp(

--- a/plugins/plugin-music/src/actions/playAudio.ts
+++ b/plugins/plugin-music/src/actions/playAudio.ts
@@ -24,6 +24,7 @@ import {
 import { MusicService } from "../service";
 import { isPlaybackTransportControlOnlyMessage } from "../utils/playbackTransportIntent";
 import { ProgressiveMessage } from "../utils/progressiveMessage";
+import { selectedContextMatches } from "../utils/selectedContextMatches";
 import { mergedOptions, requireMusicConfirmation } from "./confirmation";
 import { MUSIC_PLAYER_ACTION_DOCS } from "./music-player-action-docs";
 
@@ -112,34 +113,6 @@ function failureResult(
 }
 
 const PLAY_AUDIO_CONTEXTS = ["media", "automation"] as const;
-function selectedContextMatches(
-  state: State | undefined,
-  contexts: readonly string[],
-): boolean {
-  const selected = new Set<string>();
-  const collect = (value: unknown) => {
-    if (!Array.isArray(value)) return;
-    for (const item of value) {
-      if (typeof item === "string") selected.add(item);
-    }
-  };
-  collect(
-    (state?.values as Record<string, unknown> | undefined)?.selectedContexts,
-  );
-  collect(
-    (state?.data as Record<string, unknown> | undefined)?.selectedContexts,
-  );
-  const contextObject = (state?.data as Record<string, unknown> | undefined)
-    ?.contextObject as
-    | {
-        trajectoryPrefix?: { selectedContexts?: unknown };
-        metadata?: { selectedContexts?: unknown };
-      }
-    | undefined;
-  collect(contextObject?.trajectoryPrefix?.selectedContexts);
-  collect(contextObject?.metadata?.selectedContexts);
-  return contexts.some((context) => selected.has(context));
-}
 
 /**
  * Extract Spotify track/album/playlist info from URL

--- a/plugins/plugin-music/src/actions/playbackOp.ts
+++ b/plugins/plugin-music/src/actions/playbackOp.ts
@@ -22,6 +22,7 @@ import {
 import { classifyPlaybackTransportIntent } from "../utils/playbackTransportIntent";
 import { ProgressiveMessage } from "../utils/progressiveMessage";
 import { resolveMusicGuildIdForPlayback } from "../utils/resolveMusicGuildId";
+import { selectedContextMatches } from "../utils/selectedContextMatches";
 import { mergedOptions, requireMusicConfirmation } from "./confirmation";
 
 function formatFetchProgressDetails(details: unknown): string | undefined {
@@ -47,35 +48,6 @@ function failureResult(
   data?: ActionResultData,
 ): ActionResult {
   return { success: false, text, error, data };
-}
-
-function selectedContextMatches(
-  state: State | undefined,
-  contexts: readonly string[],
-): boolean {
-  const selected = new Set<string>();
-  const collect = (value: unknown) => {
-    if (!Array.isArray(value)) return;
-    for (const item of value) {
-      if (typeof item === "string") selected.add(item);
-    }
-  };
-  collect(
-    (state?.values as Record<string, unknown> | undefined)?.selectedContexts,
-  );
-  collect(
-    (state?.data as Record<string, unknown> | undefined)?.selectedContexts,
-  );
-  const contextObject = (state?.data as Record<string, unknown> | undefined)
-    ?.contextObject as
-    | {
-        trajectoryPrefix?: { selectedContexts?: unknown };
-        metadata?: { selectedContexts?: unknown };
-      }
-    | undefined;
-  collect(contextObject?.trajectoryPrefix?.selectedContexts);
-  collect(contextObject?.metadata?.selectedContexts);
-  return contexts.some((context) => selected.has(context));
 }
 
 function normalizeOp(value: unknown): PlaybackOp | null {

--- a/plugins/plugin-music/src/utils/selectedContextMatches.test.ts
+++ b/plugins/plugin-music/src/utils/selectedContextMatches.test.ts
@@ -5,15 +5,9 @@
  * service lookup or model extraction, so these tests pin the state contracts
  * that can expose music actions.
  */
-import type { State } from "@elizaos/core";
-import { describe, expect, it, vi } from "vitest";
+import { CONTEXT_ROUTING_STATE_KEY, type State } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
 import { selectedContextMatches } from "./selectedContextMatches";
-
-vi.mock("@elizaos/core", () => ({
-  CONTEXT_ROUTING_STATE_KEY: "__contextRouting",
-}));
-
-const CONTEXT_ROUTING_STATE_KEY = "__contextRouting";
 
 function state(values?: State["values"], data?: State["data"]): State {
   return { values, data } as State;

--- a/plugins/plugin-music/src/utils/selectedContextMatches.test.ts
+++ b/plugins/plugin-music/src/utils/selectedContextMatches.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Context-selection tests for music action exposure.
+ *
+ * The helper is intentionally pure because action validators call it before
+ * service lookup or model extraction, so these tests pin the state contracts
+ * that can expose music actions.
+ */
+import type { State } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { selectedContextMatches } from "./selectedContextMatches";
+
+vi.mock("@elizaos/core", () => ({
+  CONTEXT_ROUTING_STATE_KEY: "__contextRouting",
+}));
+
+const CONTEXT_ROUTING_STATE_KEY = "__contextRouting";
+
+function state(values?: State["values"], data?: State["data"]): State {
+  return { values, data } as State;
+}
+
+describe("selectedContextMatches", () => {
+  it("matches selected contexts from values", () => {
+    expect(
+      selectedContextMatches(
+        state({ selectedContexts: ["media", "knowledge"] }),
+        ["media"],
+      ),
+    ).toBe(true);
+  });
+
+  it("matches selected contexts from data", () => {
+    expect(
+      selectedContextMatches(
+        state(undefined, { selectedContexts: ["media"] }),
+        ["media"],
+      ),
+    ).toBe(true);
+  });
+
+  it("matches selected contexts from context object trajectory and metadata", () => {
+    const contextObject = {
+      trajectoryPrefix: { selectedContexts: ["knowledge"] },
+      metadata: { selectedContexts: ["media"] },
+    };
+
+    expect(
+      selectedContextMatches(state(undefined, { contextObject }), [
+        "knowledge",
+      ]),
+    ).toBe(true);
+    expect(
+      selectedContextMatches(state(undefined, { contextObject }), ["media"]),
+    ).toBe(true);
+  });
+
+  it("ignores planner routing unless explicitly enabled", () => {
+    const routedState = state({
+      [CONTEXT_ROUTING_STATE_KEY]: {
+        primaryContext: "media",
+        secondaryContexts: ["knowledge"],
+      },
+    });
+
+    expect(selectedContextMatches(routedState, ["media"])).toBe(false);
+    expect(
+      selectedContextMatches(routedState, ["media"], {
+        includeContextRouting: true,
+      }),
+    ).toBe(true);
+    expect(
+      selectedContextMatches(routedState, ["knowledge"], {
+        includeContextRouting: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("ignores malformed and missing state without fabricating a match", () => {
+    expect(selectedContextMatches(undefined, ["media"])).toBe(false);
+    expect(
+      selectedContextMatches(
+        state(
+          { selectedContexts: ["media", 123] },
+          { selectedContexts: "media" },
+        ),
+        ["media"],
+      ),
+    ).toBe(true);
+    expect(
+      selectedContextMatches(
+        state(
+          {
+            selectedContexts: [123],
+            [CONTEXT_ROUTING_STATE_KEY]: {
+              primaryContext: 456,
+              secondaryContexts: ["files"],
+            },
+          },
+          { selectedContexts: "media" },
+        ),
+        ["media"],
+        { includeContextRouting: true },
+      ),
+    ).toBe(false);
+  });
+});

--- a/plugins/plugin-music/src/utils/selectedContextMatches.ts
+++ b/plugins/plugin-music/src/utils/selectedContextMatches.ts
@@ -1,0 +1,53 @@
+import { CONTEXT_ROUTING_STATE_KEY, type State } from "@elizaos/core";
+
+interface ContextRoutingState {
+  primaryContext?: unknown;
+  secondaryContexts?: unknown;
+}
+
+interface SelectedContextOptions {
+  includeContextRouting?: boolean;
+}
+
+export function selectedContextMatches(
+  state: State | undefined,
+  contexts: readonly string[],
+  options: SelectedContextOptions = {},
+): boolean {
+  const selected = new Set<string>();
+  const collectOne = (value: unknown) => {
+    if (typeof value === "string") selected.add(value);
+  };
+  const collect = (value: unknown) => {
+    if (!Array.isArray(value)) return;
+    for (const item of value) collectOne(item);
+  };
+
+  collect(
+    (state?.values as Record<string, unknown> | undefined)?.selectedContexts,
+  );
+  collect(
+    (state?.data as Record<string, unknown> | undefined)?.selectedContexts,
+  );
+
+  const contextObject = (state?.data as Record<string, unknown> | undefined)
+    ?.contextObject as
+    | {
+        trajectoryPrefix?: { selectedContexts?: unknown };
+        metadata?: { selectedContexts?: unknown };
+      }
+    | undefined;
+  collect(contextObject?.trajectoryPrefix?.selectedContexts);
+  collect(contextObject?.metadata?.selectedContexts);
+
+  // The planner stores action-exposure routing here, not in selectedContexts.
+  if (options.includeContextRouting) {
+    const routing = (state?.values as Record<string, unknown> | undefined)?.[
+      CONTEXT_ROUTING_STATE_KEY
+    ] as ContextRoutingState | undefined;
+    collectOne(routing?.primaryContext);
+    collect(routing?.secondaryContexts);
+  }
+
+  return contexts.some((context) => selected.has(context));
+}

--- a/plugins/plugin-music/src/utils/selectedContextMatches.ts
+++ b/plugins/plugin-music/src/utils/selectedContextMatches.ts
@@ -1,3 +1,10 @@
+/**
+ * Context-selection predicate shared by music action validators.
+ *
+ * The planner and older callers expose selected contexts through different
+ * state slots, so this helper keeps action routing consistent without each
+ * handler duplicating the compatibility scan.
+ */
 import { CONTEXT_ROUTING_STATE_KEY, type State } from "@elizaos/core";
 
 interface ContextRoutingState {

--- a/turbo.json
+++ b/turbo.json
@@ -88,6 +88,10 @@
       "dependsOn": ["@elizaos/core#build", "^build"],
       "outputs": []
     },
+    "@elizaos/lifeops-bench#build": {
+      "dependsOn": ["@elizaos/core#build", "^build"],
+      "outputs": []
+    },
     "@elizaos/example-browser-extension-safari#build": {
       "dependsOn": ["@elizaos/core#build", "^build"],
       "outputs": []


### PR DESCRIPTION
## Summary

- mark `@elizaos/lifeops-bench` as an outputless Turbo build because its build is a typecheck and intentionally emits no artifacts
- declare the bench server's direct runtime imports of `@elizaos/plugin-groq` and `@elizaos/plugin-local-inference`
- keep the bench typecheck inside its package boundary by resolving its three narrow runtime imports through dependency declarations that Turbo builds first, rather than traversing the agent's full optional-plugin source graph
- guard that type boundary with a deterministic regression test
- share one context-selection predicate across six `@elizaos/plugin-music` action handlers and test it against the real `CONTEXT_ROUTING_STATE_KEY` export

The review reconstruction excludes the obsolete Biome downgrade and two unrelated cloud billing commits from the original branch. Current `develop` owns those concerns, and retaining them here would regress the workspace toolchain or broaden this PR beyond its build/music scope.

## Verification

- cold `bunx turbo run build --filter=@elizaos/lifeops-bench --force` — 61/61 tasks passed, including fresh agent and local-inference declarations followed by the bench typecheck
- `bun run --cwd packages/lifeops-bench test` — 102/102 passed across 8 files
- `bun run --cwd plugins/plugin-music typecheck` — passed
- `bun run --cwd plugins/plugin-music lint:check` — passed
- selected-context routing tests — 5/5 passed
- `git diff --check` — passed
- `bun run audit:error-policy-ratchet` — passed

## Evidence

<!-- evidence-row:before-screenshots -->
Before screenshots: N/A - package dependency metadata, Turbo task metadata, and server-side action routing do not alter rendered UI or native visuals.

<!-- evidence-row:after-screenshots -->
After screenshots: N/A - no rendered UI, app screen, native screen, or visual asset changed.

<!-- evidence-row:walkthrough-video -->
Walkthrough video: N/A - no user-facing visual flow changed; the behavior is exercised by the cold build and deterministic routing tests above.

<!-- evidence-row:backend-logs -->
Backend logs: N/A - no server request/response or external-service behavior changed; the relevant execution proof is the successful 61-task cold dependency-graph build reported above and repeated by CI.

<!-- evidence-row:frontend-logs -->
Frontend console/network logs: N/A - no frontend package, route, component, or browser-visible behavior changed.

<!-- evidence-row:llm-trajectory -->
Real-LLM trajectory: N/A - no model prompt, provider output, action selection policy, or LLM call path changed; the helper reads already-computed routing state.

<!-- evidence-row:domain-artifacts -->
Domain artifacts: N/A - dependency lockfile, build metadata, and a pure routing predicate produce no persistent memories, DB rows, files, audio, or external-service artifacts.