### PR TITLE
fix(cloud): preserve Steward platform user parse failures

### DIFF
--- a/packages/cloud/shared/src/lib/services/steward-platform-users.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/steward-platform-users.error-policy.test.ts
@@ -1,0 +1,72 @@
+// Exercises Steward platform user provisioning failure boundaries with deterministic cloud-shared fixtures.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  isStewardPlatformConfigured,
+  provisionStewardPlatformUser,
+} from "./steward-platform-users";
+
+const originalFetch = globalThis.fetch;
+const originalStewardApiUrl = process.env.STEWARD_API_URL;
+const originalStewardPlatformKeys = process.env.STEWARD_PLATFORM_KEYS;
+
+function restoreEnv(): void {
+  if (originalStewardApiUrl === undefined) delete process.env.STEWARD_API_URL;
+  else process.env.STEWARD_API_URL = originalStewardApiUrl;
+
+  if (originalStewardPlatformKeys === undefined) delete process.env.STEWARD_PLATFORM_KEYS;
+  else process.env.STEWARD_PLATFORM_KEYS = originalStewardPlatformKeys;
+}
+
+describe("steward platform users error policy", () => {
+  beforeEach(() => {
+    restoreEnv();
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    globalThis.fetch = originalFetch;
+  });
+
+  it("returns unavailable when the platform key is not configured", () => {
+    delete process.env.STEWARD_PLATFORM_KEYS;
+
+    expect(isStewardPlatformConfigured()).toBe(false);
+  });
+
+  it("preserves malformed Steward JSON responses as the thrown cause", async () => {
+    process.env.STEWARD_API_URL = "https://steward.example";
+    process.env.STEWARD_PLATFORM_KEYS = "platform-key";
+    globalThis.fetch = vi.fn(async () => {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw new SyntaxError("Unexpected token <");
+        },
+      } as Response;
+    }) as typeof fetch;
+
+    await expect(
+      provisionStewardPlatformUser({
+        email: "USER@Example.COM",
+        emailVerified: true,
+        name: "User",
+      }),
+    ).rejects.toMatchObject({
+      message: "Steward /platform/users returned 200 and its JSON body could not be parsed",
+      cause: expect.objectContaining({ message: "Unexpected token <" }),
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://steward.example/platform/users",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "X-Steward-Platform-Key": "platform-key",
+        }),
+      }),
+    );
+  });
+});

--- a/packages/cloud/shared/src/lib/services/steward-platform-users.ts
+++ b/packages/cloud/shared/src/lib/services/steward-platform-users.ts
@@ -26,6 +26,20 @@ type StewardPlatformUserResponse =
       error?: string;
     };
 
+async function readStewardPlatformUserResponse(
+  response: Response,
+): Promise<StewardPlatformUserResponse> {
+  try {
+    return (await response.json()) as StewardPlatformUserResponse;
+  } catch (error) {
+    // error-policy:J2 context-adding rethrow; malformed Steward responses are upstream failures, not absent payloads.
+    throw new Error(
+      `Steward /platform/users returned ${response.status} and its JSON body could not be parsed`,
+      { cause: error },
+    );
+  }
+}
+
 export function getStewardApiUrl(): string {
   return resolveServerStewardApiUrlFromEnv(getCloudAwareEnv());
 }
@@ -42,6 +56,7 @@ export function isStewardPlatformConfigured(): boolean {
   try {
     return getStewardPlatformKey().length > 0;
   } catch {
+    // error-policy:J4 explicit availability probe; callers use false to hide Steward-only flows when config is absent.
     return false;
   }
 }
@@ -64,9 +79,9 @@ export async function provisionStewardPlatformUser(
     signal: AbortSignal.timeout(10_000),
   });
 
-  const payload = (await response.json().catch(() => null)) as StewardPlatformUserResponse | null;
+  const payload = await readStewardPlatformUserResponse(response);
 
-  if (!response.ok || !payload?.ok) {
+  if (!response.ok || !payload.ok) {
     const errorMessage =
       payload && "error" in payload && typeof payload.error === "string"
         ? payload.error


### PR DESCRIPTION
## Summary
- replace the Steward platform user `response.json().catch(() => null)` fallback with a J2 context-adding rethrow
- annotate the intentional Steward platform config availability probe
- add regression coverage for malformed Steward JSON preserving the parse failure in `cause`

## Evidence
- `bun test --coverage-reporter=lcov packages/cloud/shared/src/lib/services/steward-platform-users.error-policy.test.ts`
- `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/steward-platform-users.ts packages/cloud/shared/src/lib/services/steward-platform-users.error-policy.test.ts --no-errors-on-unmatched`
- `bun run audit:error-policy-ratchet`
- `bun run --cwd packages/cloud/shared typecheck 2>&1 | rg "steward-platform-users" || true`
- `git diff --check origin/develop...HEAD && git diff --check`

N/A: no UI artifacts; backend service error-handling only.
N/A: no live LLM trajectory; no prompt/model/action path changed.

Refs #13415