### PR TITLE
test(scripts): gate LifeOps catalog packs individually

### DIFF
--- a/packages/scripts/__tests__/lifeops-catalog-coverage.test.ts
+++ b/packages/scripts/__tests__/lifeops-catalog-coverage.test.ts
@@ -17,6 +17,12 @@ function runCoverage(...args: string[]) {
   return result.stdout;
 }
 
+function runCoverageResult(...args: string[]) {
+  return spawnSync(process.execPath, [scriptPath, ...args], {
+    encoding: "utf8",
+  });
+}
+
 describe("LifeOps persona catalog coverage", () => {
   test("JSON output includes unverified rows grouped by surface", () => {
     const report = JSON.parse(runCoverage("--json"));
@@ -71,6 +77,38 @@ describe("LifeOps persona catalog coverage", () => {
     );
     expect(output).toContain(
       "Total: 150/296 authored rows still need verification",
+    );
+  });
+
+  test("--pack narrows the report to a specific persona pack", () => {
+    const report = JSON.parse(runCoverage("--pack", "B2", "--json"));
+
+    expect(report.packs).toHaveLength(1);
+    expect(report).toMatchObject({
+      target: 22,
+      authored: 22,
+      verified: 6,
+      errors: [],
+    });
+    expect(report.packs[0]).toMatchObject({
+      pack: "B2",
+      file: "shift-rotation.catalog.json",
+      unverified: 16,
+      unverifiedBySurface: {
+        "lifeops-bench": 16,
+      },
+    });
+  });
+
+  test("--require-verified fails a selected pack until every authored row is verified", () => {
+    const result = runCoverageResult("--pack", "B2", "--require-verified");
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain(
+      "B2 22 authored (target 22), 6/22 verified",
+    );
+    expect(result.stderr).toContain(
+      "B2: 6/22 verified; --require-verified requires every authored row to be verified",
     );
   });
 });

--- a/packages/scripts/check-lifeops-persona-catalog-coverage.mjs
+++ b/packages/scripts/check-lifeops-persona-catalog-coverage.mjs
@@ -50,9 +50,20 @@ const VALID_SURFACES = new Set(["lifeops-bench", "scenario-runner"]);
 const VALID_STATUSES = new Set(["planned", "authored", "verified"]);
 const JSON_MODE = process.argv.includes("--json");
 const UNVERIFIED_MODE = process.argv.includes("--unverified");
+const REQUIRE_VERIFIED = process.argv.includes("--require-verified");
+const PACK_FILTER = readOption("--pack")?.toUpperCase();
 
 function toPosix(value) {
   return value.replace(/\\/g, "/");
+}
+
+function readOption(name) {
+  const equalsPrefix = `${name}=`;
+  const inline = process.argv.find((arg) => arg.startsWith(equalsPrefix));
+  if (inline) return inline.slice(equalsPrefix.length);
+  const index = process.argv.indexOf(name);
+  if (index === -1) return null;
+  return process.argv[index + 1] ?? null;
 }
 
 function readJson(file) {
@@ -176,8 +187,17 @@ function summarize() {
   const lifeOpsBenchIds = loadLifeOpsBenchIds();
   const errors = [];
   const packs = [];
+  const expectedCatalogs = PACK_FILTER
+    ? EXPECTED_CATALOGS.filter(([, pack]) => pack === PACK_FILTER)
+    : EXPECTED_CATALOGS;
 
-  for (const [fileName, expectedPack, expectedTarget] of EXPECTED_CATALOGS) {
+  if (PACK_FILTER && expectedCatalogs.length === 0) {
+    errors.push(
+      `--pack ${PACK_FILTER} did not match a known LifeOps persona pack`,
+    );
+  }
+
+  for (const [fileName, expectedPack, expectedTarget] of expectedCatalogs) {
     const file = path.join(CATALOG_DIR, fileName);
     const catalog = readJson(file);
     errors.push(
@@ -246,6 +266,20 @@ function summarize() {
       unverifiedBySurface,
       unverifiedRows: unverified,
     });
+  }
+  if (REQUIRE_VERIFIED) {
+    for (const pack of packs) {
+      if (pack.authored < pack.target) {
+        errors.push(
+          `${pack.pack}: ${pack.authored}/${pack.target} authored; --require-verified requires the pack target to be fully authored`,
+        );
+      }
+      if (pack.verified < pack.authored) {
+        errors.push(
+          `${pack.pack}: ${pack.verified}/${pack.authored} verified; --require-verified requires every authored row to be verified`,
+        );
+      }
+    }
   }
 
   const target = packs.reduce((sum, pack) => sum + pack.target, 0);


### PR DESCRIPTION
## Summary

- Add `--pack <packId>` to `check-lifeops-persona-catalog-coverage.mjs` so a single MVP persona pack can be audited directly.
- Add `--require-verified` so issue acceptance checks can fail until every authored row in the selected pack is verified.
- Pin the B2 shift-rotation state in tests: 22 authored, 6 verified, 16 LifeOpsBench rows still unverified.

Refs #14351. This PR does not close #14351; it gives the issue a precise B2 22/22 gate and documents the current blocker.

## Verification

- `bunx biome check --write packages/scripts/check-lifeops-persona-catalog-coverage.mjs packages/scripts/__tests__/lifeops-catalog-coverage.test.ts` passed: `Checked 2 files in 46ms. No fixes applied.`
- `bun test packages/scripts/__tests__/lifeops-catalog-coverage.test.ts` passed: `5 pass, 0 fail, 25 expect() calls`.
- `node packages/scripts/check-lifeops-persona-catalog-coverage.mjs --pack B2 --json` reported `target: 22`, `authored: 22`, `verified: 6`, `unverified: 16`, `unverifiedBySurface.lifeops-bench: 16`, `errors: []`.
- `node packages/scripts/check-lifeops-persona-catalog-coverage.mjs --pack B2 --require-verified` failed as expected with `B2: 6/22 verified; --require-verified requires every authored row to be verified`.

## Live-Key Blocker for #14351

This environment has no `CEREBRAS_API_KEY`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GROQ_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`, or `OPENROUTER_API_KEY`. The remaining B2 rows are all LifeOpsBench rows whose catalog notes require real-LLM LifeOpsBench capture and hand review before promotion to `verified`.

## Evidence
<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - script-only catalog coverage gate; no rendered UI surface changed.

<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - script-only catalog coverage gate; no rendered UI surface changed.

<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - no user-facing runtime flow changed.

<!-- evidence-row:backend-logs -->
- Backend logs: N/A - no server/runtime path changed; verification is local CLI/test output above.

<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A - no frontend runtime or browser path changed.

<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: N/A - this PR only changes the offline catalog coverage gate. #14351 still needs live LifeOpsBench model evidence before rows can be promoted.

<!-- evidence-row:domain-artifacts -->
- Domain artifacts: N/A - no production records are produced; `node packages/scripts/check-lifeops-persona-catalog-coverage.mjs --pack B2 --json` output is summarized in Verification as the current B2 catalog artifact state.