### PR TITLE
fix(cloud): preserve app image namespace lookup failures

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/app-deploy-runner.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-deploy-runner.test.ts
@@ -268,7 +268,7 @@ describe("resolveImageRef: per-org namespace extension", () => {
     expect(called).toBe(false);
   });
 
-  test("a throwing lookup fails CLOSED (deny), never propagates", async () => {
+  test("a throwing lookup fails closed with the lookup failure preserved", async () => {
     const deps = depsWithOrgNamespaces(async () => {
       throw new Error("db down");
     });
@@ -278,7 +278,11 @@ describe("resolveImageRef: per-org namespace extension", () => {
         organizationId: "org-1",
         metadata: { imageTag: ORG_IMAGE },
       }),
-    ).rejects.toThrow(/is not permitted/);
+    ).rejects.toMatchObject({
+      message:
+        "Failed to resolve app deploy image namespaces for organization org-1 while deploying app app-1",
+      cause: expect.objectContaining({ message: "db down" }),
+    });
   });
 
   test("an env-allowlisted image never consults the org lookup (fast path)", async () => {

--- a/packages/cloud/shared/src/lib/services/app-deploy-runner.ts
+++ b/packages/cloud/shared/src/lib/services/app-deploy-runner.ts
@@ -168,7 +168,16 @@ export async function resolveImageRef(
   let imageAllowed = isCodingContainerImageAllowed(image, allowlist);
   if (!imageAllowed && app.organizationId) {
     const lookup = deps.orgImageNamespaces ?? getOrgImageNamespaces;
-    const orgNamespaces = await lookup(app.organizationId).catch(() => []);
+    let orgNamespaces: string[];
+    try {
+      orgNamespaces = await lookup(app.organizationId);
+    } catch (error) {
+      // error-policy:J2 context-adding rethrow; a failed namespace lookup is an internal authorization failure, not "no grant".
+      throw new Error(
+        `Failed to resolve app deploy image namespaces for organization ${app.organizationId} while deploying app ${app.id}`,
+        { cause: error },
+      );
+    }
     imageAllowed = isCodingContainerImageAllowed(image, orgNamespaces);
   }
   if (!imageAllowed) {


### PR DESCRIPTION
## Summary
- replace the app deploy per-org image namespace `lookup(...).catch(() => [])` fallback with a J2 context-adding rethrow
- keep “no org grant” distinct from “namespace lookup failed” during app image authorization
- update the existing app deploy runner regression to assert the original lookup error survives in `cause`

## Evidence
- `bun test src/lib/services/__tests__/app-deploy-runner.test.ts` from `packages/cloud/shared` with a temporary package-local bunfig disabling root coverage: 28 pass, 0 fail, 35 expects
- `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/app-deploy-runner.ts packages/cloud/shared/src/lib/services/__tests__/app-deploy-runner.test.ts --no-errors-on-unmatched`
- `bun run audit:error-policy-ratchet`
- `bun run --cwd packages/cloud/shared typecheck 2>&1 | rg "app-deploy-runner" || true`
- `git diff --check origin/develop...HEAD && git diff --check`

Note: the repo root bunfig forces coverage; direct root `bun test ...` printed all 28 passing tests but hung while writing the coverage report, so the clean-exit evidence run used a temporary package-local no-coverage bunfig and then removed it before commit.

N/A: no UI artifacts; backend service authorization/error-handling only.
N/A: no live LLM trajectory; no prompt/model/action path changed.

Refs #13415