### PR TITLE
test(lifeops): verify G1 followup cadence scenario

### DIFF
--- a/packages/scenario-runner/src/corpus-assertion-guard.test.ts
+++ b/packages/scenario-runner/src/corpus-assertion-guard.test.ts
@@ -323,6 +323,10 @@ const EXPECTED_PR_DETERMINISTIC_SCENARIO_IDS = [
   "facewear.smartglasses-status",
   "finances.owner-finances-dashboard",
   "form.restore-stashed",
+  // LifeOps persona pack G1 (overdue-comms-apology, #14783). Keyless
+  // structural proof that overdue relationship follow-up cadence uses
+  // SCHEDULED_TASKS fields rather than prompt text.
+  "g1-followup-cadence-reset",
   "goals.owner-goals-create",
   "health.owner-health-status",
   "hyperliquid.perpetual-market-status",

--- a/packages/scripts/__tests__/lifeops-catalog-coverage.test.ts
+++ b/packages/scripts/__tests__/lifeops-catalog-coverage.test.ts
@@ -33,11 +33,11 @@ describe("LifeOps persona catalog coverage", () => {
     );
     expect(g1).toMatchObject({
       authored: 10,
-      verified: 0,
-      unverified: 10,
+      verified: 1,
+      unverified: 9,
       unverifiedBySurface: {
         "lifeops-bench": 6,
-        "scenario-runner": 4,
+        "scenario-runner": 3,
       },
     });
     expect(g1.unverifiedRows).toContainEqual(
@@ -62,7 +62,7 @@ describe("LifeOps persona catalog coverage", () => {
     expect(output).toContain("E1 29 authored (target 28, +1)");
     expect(output).toContain("F1 35 authored (target 32, +3)");
     expect(output).toContain(
-      "Total: 296 authored (target 292), 146/296 verified, 150 unverified",
+      "Total: 296 authored (target 292), 147/296 verified, 149 unverified",
     );
     expect(output).not.toContain("296/292 authored");
   });
@@ -70,13 +70,13 @@ describe("LifeOps persona catalog coverage", () => {
   test("--unverified prints a board-triage list without hiding surface blockers", () => {
     const output = runCoverage("--unverified");
     expect(output).toContain(
-      "G1 10/10 unverified (lifeops-bench:6, scenario-runner:4)",
+      "G1  9/10 unverified (lifeops-bench:6, scenario-runner:3)",
     );
     expect(output).toContain(
       "J1 10/10 unverified (lifeops-bench:3, scenario-runner:7)",
     );
     expect(output).toContain(
-      "Total: 150/296 authored rows still need verification",
+      "Total: 149/296 authored rows still need verification",
     );
   });
 

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/overdue-comms-apology.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/overdue-comms-apology.catalog.json
@@ -74,8 +74,8 @@
       "pack": "G1",
       "tier": "T3",
       "surface": "scenario-runner",
-      "status": "authored",
-      "notes": "SCEN-H: once a draft is approved or sent, reset the follow-up cadence structurally."
+      "status": "verified",
+      "notes": "SCEN-H: once a draft is approved or sent, reset the follow-up cadence structurally. Verified 2026-07-09 under the strict deterministic proxy: /tmp/eliza-14783-g1-followup-pass/report.json passed 1/1, viewer at /tmp/eliza-14783-g1-followup-pass/run/viewer/index.html, native export at /tmp/eliza-14783-g1-followup-pass/native.jsonl. The run proves SCHEDULED_TASKS create/list succeeded with a relationship-scoped followup subject, trigger.atIso, and structural dueWindow=overdue filtering."
     },
     {
       "id": "g1.overdue_comms.stale_thread_archive",

--- a/plugins/plugin-personal-assistant/test/scenarios/g1-followup-cadence-reset.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/g1-followup-cadence-reset.scenario.ts
@@ -56,7 +56,7 @@ function expectRelationshipFollowupCreatedAndListed() {
 }
 
 export default scenario({
-  lane: "live-only",
+  lane: "pr-deterministic",
   id: "g1-followup-cadence-reset",
   title: "G1 overdue communication cadence uses relationship follow-up tasks",
   domain: "lifeops.relationships",
@@ -81,27 +81,29 @@ export default scenario({
       actionName: "SCHEDULED_TASKS",
       text: "Track an overdue reply follow-up for the Mira relationship thread.",
       options: {
-        action: "create",
-        kind: "followup",
-        subjectKind: "relationship",
-        subjectId: "rel-g1-mira",
-        priority: "high",
-        promptInstructions:
-          "Follow up with Mira about the overdue reply after the owner approves a concise repair draft.",
-        trigger: {
-          kind: "once",
-          runAt: "2026-06-14T00:00:00.000Z",
+        parameters: {
+          action: "create",
+          kind: "followup",
+          subjectKind: "relationship",
+          subjectId: "rel-g1-mira",
+          priority: "high",
+          promptInstructions:
+            "Follow up with Mira about the overdue reply after the owner approves a concise repair draft.",
+          trigger: {
+            kind: "once",
+            atIso: "2026-06-14T00:00:00.000Z",
+          },
+          completionCheck: {
+            kind: "subject_updated",
+            followupAfterMinutes: 1,
+          },
+          metadata: {
+            pack: "G1",
+            relationship: "Mira",
+            cadenceDays: 14,
+          },
+          idempotencyKey: "g1-overdue-comms-mira-followup",
         },
-        completionCheck: {
-          kind: "subject_updated",
-          followupAfterMinutes: 0,
-        },
-        metadata: {
-          pack: "G1",
-          relationship: "Mira",
-          cadenceDays: 14,
-        },
-        idempotencyKey: "g1-overdue-comms-mira-followup",
       },
       assertResponse(text: string) {
         if (!/scheduled|already scheduled/i.test(text)) {
@@ -116,9 +118,11 @@ export default scenario({
       actionName: "SCHEDULED_TASKS",
       text: "List overdue follow-up tasks.",
       options: {
-        action: "list",
-        kind: "followup",
-        dueWindow: "overdue",
+        parameters: {
+          action: "list",
+          kind: "followup",
+          dueWindow: "overdue",
+        },
       },
       assertResponse(text: string) {
         if (!/scheduled item|match/i.test(text)) {


### PR DESCRIPTION
## Summary

- Promote `g1-followup-cadence-reset` to the `pr-deterministic` lane.
- Update its direct action turns to the current `SCHEDULED_TASKS` handler contract: parameters under `options.parameters`, `trigger.atIso`, and a positive `completionCheck.followupAfterMinutes`.
- Mark only that G1 catalog row verified; G1 moves from 0/10 verified to 1/10 verified.

Refs #14783. This PR does not close #14783; the other 9 G1 rows remain unverified.

## Evidence

### Commands

```bash
TZ=UTC EVAL_MODEL_PROVIDER=deterministic CEREBRAS_API_KEY= EVAL_CEREBRAS_API_KEY= ELIZA_E2E_CEREBRAS_API_KEY= SCENARIO_USE_LLM_PROXY=1 SCENARIO_LLM_PROXY_STRICT=1 bun --conditions eliza-source --tsconfig-override ./tsconfig.json packages/scenario-runner/src/cli.ts run plugins/plugin-personal-assistant/test/scenarios --scenario g1-followup-cadence-reset --report /tmp/eliza-14783-g1-followup-pass/report.json --run-dir /tmp/eliza-14783-g1-followup-pass/run --export-native /tmp/eliza-14783-g1-followup-pass/native.jsonl
```

Result: `g1-followup-cadence-reset` passed 1/1 under `deterministic-llm-proxy`. Final checks show `SCHEDULED_TASKS` succeeded 2x, relationship followup created/listed, and selected action arguments matched.

```bash
bun test packages/scenario-runner/src/corpus-assertion-guard.test.ts
```

Result: `9 pass, 0 fail, 13 expect() calls`.

```bash
bun test packages/scripts/__tests__/lifeops-catalog-coverage.test.ts
```

Result: `5 pass, 0 fail, 25 expect() calls`.

```bash
node packages/scripts/check-lifeops-persona-catalog-coverage.mjs --pack G1 --json
```

Result: G1 reports `target=10`, `authored=10`, `verified=1`, `unverified=9`, `unverifiedBySurface.lifeops-bench=6`, `unverifiedBySurface.scenario-runner=3`, `errors=[]`.

```bash
bunx biome check --write packages/scripts/__tests__/lifeops-catalog-coverage.test.ts plugins/plugin-personal-assistant/test/scenarios/g1-followup-cadence-reset.scenario.ts plugins/plugin-personal-assistant/test/scenarios/_catalogs/overdue-comms-apology.catalog.json packages/scenario-runner/src/corpus-assertion-guard.test.ts
```

Result: `Checked 4 files in 60ms. No fixes applied.`

### Required Evidence Rows

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots N/A - scenario/catalog/test-only change, no rendered UI surface changed.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots N/A - scenario/catalog/test-only change, no rendered UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video N/A - no user-facing UI flow changed.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs: [15695-g1-followup-report.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15695-g1-followup-report.json) includes the real scenario-runner action trace showing `SCHEDULED_TASKS` create/list succeeded.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs N/A - no frontend code or browser runtime changed.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory N/A - this promoted row is intentionally `pr-deterministic` and uses the strict deterministic proxy; the remaining G1 rows still require live model evidence before promotion.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: [15695-g1-followup-report.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15695-g1-followup-report.json) and [15695-g1-coverage.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15695-g1-coverage.json) show the passing scenario and G1 `1/10` verified catalog state.

### Known Local Test Blocker

`bun test packages/scenario-runner/src/__tests__/deterministic-action-coverage.test.ts` was attempted but blocked by local dependency corruption in this temp worktree: `Cannot find module './' from .../@types/react/jsx-dev-runtime.d.ts`. The focused scenario run, corpus guard, catalog reporter test, catalog gate, and Biome check all passed.
