### PR TITLE
fix(lifeops): process delegated inbound SLA turns

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/delegation-contracts/index.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/delegation-contracts/index.ts
@@ -8,6 +8,11 @@
  * embedding policy decisions in transport adapters.
  */
 
+import type {
+  ApprovalQueue,
+  ApprovalRequest,
+} from "../approval-queue.types.js";
+
 export type DelegationAutonomyLevel =
   | "draft_only"
   | "approval_gated"
@@ -159,6 +164,24 @@ export interface DelegationEvaluation {
     readonly matchedTripwire: string | null;
     readonly reason: string;
   };
+}
+
+export interface DelegationContractRepository {
+  listDelegationContracts(
+    agentId: string,
+    options?: {
+      readonly statuses?: LifeOpsDelegationContractRecord["status"][];
+      readonly activeAtIso?: string;
+    },
+  ): Promise<LifeOpsDelegationContractRecord[]>;
+  upsertDelegationContract(
+    record: LifeOpsDelegationContractRecord,
+  ): Promise<void>;
+}
+
+export interface DelegationInboundProcessingResult {
+  readonly evaluations: readonly DelegationEvaluation[];
+  readonly enqueuedApprovals: readonly ApprovalRequest[];
 }
 
 export function createLifeOpsDelegationContractRecord(
@@ -480,4 +503,74 @@ export function evaluateDelegationContract(input: {
       reason: "turn is in bounds for delegated handling",
     },
   };
+}
+
+function approvalExpiryFrom(nowIso: string): Date {
+  return new Date(parseTime(nowIso, "nowIso") + 24 * 60 * 60 * 1_000);
+}
+
+function shouldPersistEvaluation(evaluation: DelegationEvaluation): boolean {
+  return (
+    evaluation.outcome === "in_bounds" ||
+    evaluation.outcome === "escalate_owner" ||
+    evaluation.outcome === "holding_reply_due"
+  );
+}
+
+/**
+ * Runtime-facing processor for connector turns. Transport adapters supply the
+ * normalized turn; this function owns the contract-policy fanout, persistence,
+ * and approval-queue handoff so connectors do not learn LifeOps delegation
+ * rules.
+ */
+export async function processDelegationInboundTurn(input: {
+  readonly agentId: string;
+  readonly turn: DelegationInboundTurn;
+  readonly nowIso: string;
+  readonly repository: DelegationContractRepository;
+  readonly approvalQueue: ApprovalQueue;
+  readonly approvalExpiresAt?: Date;
+}): Promise<DelegationInboundProcessingResult> {
+  const contracts = await input.repository.listDelegationContracts(
+    input.agentId,
+    {
+      statuses: ["active"],
+      activeAtIso: input.turn.receivedAt,
+    },
+  );
+  const evaluations: DelegationEvaluation[] = [];
+  const enqueuedApprovals: ApprovalRequest[] = [];
+  for (const contract of contracts) {
+    const evaluation = evaluateDelegationContract({
+      contract,
+      turn: input.turn,
+      nowIso: input.nowIso,
+    });
+    if (evaluation.outcome === "out_of_scope") {
+      continue;
+    }
+    evaluations.push(evaluation);
+    if (evaluation.draftIntent) {
+      enqueuedApprovals.push(
+        await input.approvalQueue.enqueue({
+          requestedBy: evaluation.draftIntent.requestedBy,
+          subjectUserId: evaluation.draftIntent.subjectUserId,
+          action: evaluation.draftIntent.action,
+          payload: evaluation.draftIntent.payload,
+          channel: evaluation.draftIntent.channel,
+          reason: evaluation.draftIntent.reason,
+          expiresAt:
+            input.approvalExpiresAt ?? approvalExpiryFrom(input.nowIso),
+        }),
+      );
+    }
+    if (shouldPersistEvaluation(evaluation)) {
+      await input.repository.upsertDelegationContract({
+        ...contract,
+        state: evaluation.contract.state,
+        updatedAt: input.nowIso,
+      });
+    }
+  }
+  return { evaluations, enqueuedApprovals };
 }

--- a/plugins/plugin-personal-assistant/test/delegation-contracts.test.ts
+++ b/plugins/plugin-personal-assistant/test/delegation-contracts.test.ts
@@ -7,10 +7,12 @@
  */
 
 import { afterEach, describe, expect, it } from "vitest";
+import { createApprovalQueue } from "../src/lifeops/approval-queue.js";
 import {
   createLifeOpsDelegationContractRecord,
   type DelegationContract,
   evaluateDelegationContract,
+  processDelegationInboundTurn,
   renderDelegationContractsProviderText,
 } from "../src/lifeops/delegation-contracts/index.js";
 import { LifeOpsRepository } from "../src/lifeops/index.js";
@@ -298,4 +300,105 @@ describe("delegation contract repository", () => {
     });
     expect(result.data?.delegationContracts).toHaveLength(1);
   });
+
+  it("turns a delegated sender-class SLA into one real pending approval", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    await LifeOpsRepository.bootstrapSchema(runtime);
+    const repo = new LifeOpsRepository(runtime);
+    const queue = createApprovalQueue(runtime, { agentId: runtime.agentId });
+    await repo.upsertDelegationContract(
+      createLifeOpsDelegationContractRecord({
+        ...vendorContract({
+          contractId: "delegation:board-sla",
+          objective: "Board member holding reply",
+          scope: {
+            kind: "sender_class",
+            channel: "email",
+            senderClass: "board_member",
+          },
+          tripwires: [],
+          sla: {
+            holdingReplyAfterMinutes: 60,
+            subjectPrefix: "Re:",
+            holdingReplyBody:
+              "Thanks, I have this and will come back with a proper answer shortly.",
+          },
+        }),
+        agentId: runtime.agentId,
+        metadata: { policy: "board-member-one-hour-hold" },
+      }),
+    );
+
+    const processed = await processDelegationInboundTurn({
+      agentId: runtime.agentId,
+      repository: repo,
+      approvalQueue: queue,
+      nowIso: "2026-07-06T18:05:00.000Z",
+      turn: {
+        channel: "email",
+        threadId: "thread-board-1",
+        sender: "Dana Board",
+        senderClass: "board_member",
+        senderEmail: "dana@board.example",
+        subject: "Quarterly update",
+        text: "Can you send the latest numbers?",
+        receivedAt: "2026-07-06T17:00:00.000Z",
+      },
+    });
+
+    expect(processed.evaluations.map((entry) => entry.outcome)).toEqual([
+      "holding_reply_due",
+    ]);
+    expect(processed.enqueuedApprovals).toHaveLength(1);
+    expect(processed.enqueuedApprovals[0]).toMatchObject({
+      state: "pending",
+      requestedBy: "delegation-contracts",
+      subjectUserId: "owner-1",
+      action: "send_email",
+      channel: "email",
+      reason: "SLA holding reply for delegated Board member holding reply",
+      payload: {
+        action: "send_email",
+        to: ["dana@board.example"],
+        subject: "Re: Quarterly update",
+        body: "Thanks, I have this and will come back with a proper answer shortly.",
+        threadId: "thread-board-1",
+      },
+    });
+
+    const saved = await repo.getDelegationContract(
+      runtime.agentId,
+      "delegation:board-sla",
+    );
+    expect(saved?.state?.holdingReplyQueuedAt).toBe("2026-07-06T18:05:00.000Z");
+
+    const replayed = await processDelegationInboundTurn({
+      agentId: runtime.agentId,
+      repository: repo,
+      approvalQueue: queue,
+      nowIso: "2026-07-06T18:10:00.000Z",
+      turn: {
+        channel: "email",
+        threadId: "thread-board-1",
+        sender: "Dana Board",
+        senderClass: "board_member",
+        senderEmail: "dana@board.example",
+        subject: "Quarterly update",
+        text: "Can you send the latest numbers?",
+        receivedAt: "2026-07-06T17:00:00.000Z",
+      },
+    });
+
+    expect(replayed.evaluations).toHaveLength(1);
+    expect(replayed.evaluations[0]?.outcome).toBe("in_bounds");
+    expect(replayed.enqueuedApprovals).toHaveLength(0);
+    const pending = await queue.list({
+      subjectUserId: "owner-1",
+      state: "pending",
+      action: "send_email",
+      limit: 10,
+    });
+    expect(pending).toHaveLength(1);
+  }, 60_000);
 });


### PR DESCRIPTION
Refs #14856.

## Summary
- Add `processDelegationInboundTurn()` as the runtime-facing delegation-contract consumer for normalized connector turns.
- The processor lists active contracts, evaluates the inbound turn, persists contract state, and enqueues approval-gated holding replies through the real approval queue.
- Add regression coverage proving a board-member SLA turn creates one pending `send_email` approval and replaying the same turn does not duplicate it.

## Verification
- `ELIZA_SKIP_ARTIFACT_SYNC=1 bun run install:light` (needed in the isolated worktree to restore missing package links; artifact sync skipped).
- `node packages/shared/scripts/generate-keywords.mjs --target ts`.
- `bun run --cwd plugins/plugin-personal-assistant test -- test/delegation-contracts.test.ts` (1 file, 6 tests passed; warning-only sourcemap noise from dependencies).
- `bunx @biomejs/biome check plugins/plugin-personal-assistant/src/lifeops/delegation-contracts/index.ts plugins/plugin-personal-assistant/test/delegation-contracts.test.ts`.
- `git diff --check`.
- `bun run audit:error-policy-ratchet`.
- `bun run --cwd plugins/plugin-personal-assistant build`.

Still not claiming full #14856 closure: live connector inbound event wiring, delegation-map artifacts, and live model/connector trajectories remain required for final issue acceptance.

## Evidence
<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - backend/runtime LifeOps delegation processor only; no UI, browser, native, or rendered surface changed.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - backend/runtime LifeOps delegation processor only; no UI, browser, native, or rendered surface changed.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no user-facing UI flow changed.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no server process was run; focused real-runtime/PGlite test exercises the repository and approval queue path directly.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend runtime path changed.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no prompt, model, provider, or planner behavior changed; live connector/model trajectories remain as #14856 acceptance evidence.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - deterministic domain artifact is the test assertion itself: one persisted `approval_requests` pending `send_email` row plus persisted `life_delegation_contracts.state.holdingReplyQueuedAt`, with replay proving no duplicate approval.
