### PR TITLE
test(lifeops): verify G2 cadence watcher scenario

### DIFF
--- a/packages/scenario-runner/src/corpus-assertion-guard.test.ts
+++ b/packages/scenario-runner/src/corpus-assertion-guard.test.ts
@@ -327,6 +327,9 @@ const EXPECTED_PR_DETERMINISTIC_SCENARIO_IDS = [
   // structural proof that overdue relationship follow-up cadence uses
   // SCHEDULED_TASKS fields rather than prompt text.
   "g1-followup-cadence-reset",
+  // LifeOps persona pack G2 (reconnect-old-friends, #14784). Keyless
+  // structural proof for relationship-cadence follow-up creation.
+  "g2-cadence-watcher-due",
   "goals.owner-goals-create",
   "health.owner-health-status",
   "hyperliquid.perpetual-market-status",

--- a/packages/scripts/__tests__/lifeops-catalog-coverage.test.ts
+++ b/packages/scripts/__tests__/lifeops-catalog-coverage.test.ts
@@ -62,7 +62,7 @@ describe("LifeOps persona catalog coverage", () => {
     expect(output).toContain("E1 29 authored (target 28, +1)");
     expect(output).toContain("F1 35 authored (target 32, +3)");
     expect(output).toContain(
-      "Total: 296 authored (target 292), 147/296 verified, 149 unverified",
+      "Total: 296 authored (target 292), 148/296 verified, 148 unverified",
     );
     expect(output).not.toContain("296/292 authored");
   });
@@ -76,7 +76,7 @@ describe("LifeOps persona catalog coverage", () => {
       "J1 10/10 unverified (lifeops-bench:3, scenario-runner:7)",
     );
     expect(output).toContain(
-      "Total: 149/296 authored rows still need verification",
+      "Total: 148/296 authored rows still need verification",
     );
   });
 

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/reconnect-old-friends.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/reconnect-old-friends.catalog.json
@@ -39,7 +39,8 @@
       "pack": "G2",
       "tier": "T3",
       "surface": "scenario-runner",
-      "status": "authored"
+      "status": "verified",
+      "notes": "Verified 2026-07-09 under the strict deterministic proxy: /tmp/eliza-14784-g2-cadence/report.json passed 1/1, viewer at /tmp/eliza-14784-g2-cadence/run/viewer/index.html, native export at /tmp/eliza-14784-g2-cadence/native.jsonl. The run proves SCHEDULED_TASKS create/list succeeded for a relationship-scoped followup subject, trigger.atIso, cadence metadata, and structural dueWindow=overdue filtering."
     },
     {
       "id": "g2.reconnect.respect_recent_silence",

--- a/plugins/plugin-personal-assistant/test/scenarios/g2-cadence-watcher-due.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/g2-cadence-watcher-due.scenario.ts
@@ -54,7 +54,7 @@ function expectStaleEdgeFollowup() {
 }
 
 export default scenario({
-  lane: "live-only",
+  lane: "pr-deterministic",
   id: "g2-cadence-watcher-due",
   title:
     "G2 cadence watcher emits a relationship follow-up for stale friend edge",
@@ -77,27 +77,29 @@ export default scenario({
       actionName: "SCHEDULED_TASKS",
       text: "Create a stale relationship follow-up for Zane.",
       options: {
-        action: "create",
-        kind: "followup",
-        subjectKind: "relationship",
-        subjectId: "rel-g2-zane",
-        priority: "medium",
-        promptInstructions:
-          "Reconnect with Zane after a stale eight-month relationship cadence gap.",
-        trigger: {
-          kind: "once",
-          runAt: "2025-11-06T00:00:00.000Z",
+        parameters: {
+          action: "create",
+          kind: "followup",
+          subjectKind: "relationship",
+          subjectId: "rel-g2-zane",
+          priority: "medium",
+          promptInstructions:
+            "Reconnect with Zane after a stale eight-month relationship cadence gap.",
+          trigger: {
+            kind: "once",
+            atIso: "2025-11-06T00:00:00.000Z",
+          },
+          completionCheck: {
+            kind: "subject_updated",
+            followupAfterMinutes: 1,
+          },
+          metadata: {
+            pack: "G2",
+            cadenceDays: 180,
+            lastInteractionIso: "2025-11-06T00:00:00.000Z",
+          },
+          idempotencyKey: "g2-zane-stale-edge-followup",
         },
-        completionCheck: {
-          kind: "subject_updated",
-          followupAfterMinutes: 0,
-        },
-        metadata: {
-          pack: "G2",
-          cadenceDays: 180,
-          lastInteractionIso: "2025-11-06T00:00:00.000Z",
-        },
-        idempotencyKey: "g2-zane-stale-edge-followup",
       },
     },
     {
@@ -107,10 +109,12 @@ export default scenario({
       actionName: "SCHEDULED_TASKS",
       text: "List overdue relationship follow-ups.",
       options: {
-        action: "list",
-        kind: "followup",
-        subjectKind: "relationship",
-        dueWindow: "overdue",
+        parameters: {
+          action: "list",
+          kind: "followup",
+          subjectKind: "relationship",
+          dueWindow: "overdue",
+        },
       },
     },
   ],


### PR DESCRIPTION
## Summary

- Promote `g2-cadence-watcher-due` to the `pr-deterministic` lane.
- Update its direct `SCHEDULED_TASKS` action turns to the current handler contract: `options.parameters`, `trigger.atIso`, and positive `completionCheck.followupAfterMinutes`.
- Mark only that G2 catalog row verified; G2 moves from 0/8 verified to 1/8 verified.

Refs #14784. This PR does not close #14784; the other 7 G2 rows remain unverified.

## Evidence

### Commands

```bash
TZ=UTC EVAL_MODEL_PROVIDER=deterministic CEREBRAS_API_KEY= EVAL_CEREBRAS_API_KEY= ELIZA_E2E_CEREBRAS_API_KEY= SCENARIO_USE_LLM_PROXY=1 SCENARIO_LLM_PROXY_STRICT=1 bun --conditions eliza-source --tsconfig-override ./tsconfig.json packages/scenario-runner/src/cli.ts run plugins/plugin-personal-assistant/test/scenarios --scenario g2-cadence-watcher-due --report /tmp/eliza-14784-g2-cadence/report.json --run-dir /tmp/eliza-14784-g2-cadence/run --export-native /tmp/eliza-14784-g2-cadence/native.jsonl
```

Result: `g2-cadence-watcher-due` passed 1/1 under `deterministic-llm-proxy`. Final checks show `SCHEDULED_TASKS` succeeded 2x, stale edge followup created/listed, and selected action arguments matched.

```bash
bun test packages/scenario-runner/src/corpus-assertion-guard.test.ts
```

Result: `9 pass, 0 fail, 13 expect() calls`.

```bash
bun test packages/scripts/__tests__/lifeops-catalog-coverage.test.ts
```

Result: `5 pass, 0 fail, 25 expect() calls`.

```bash
node packages/scripts/check-lifeops-persona-catalog-coverage.mjs --pack G2 --json
```

Result: G2 reports `target=8`, `authored=8`, `verified=1`, `unverified=7`, `unverifiedBySurface.lifeops-bench=4`, `unverifiedBySurface.scenario-runner=3`, `errors=[]`.

```bash
bunx biome check --write packages/scripts/__tests__/lifeops-catalog-coverage.test.ts plugins/plugin-personal-assistant/test/scenarios/g2-cadence-watcher-due.scenario.ts plugins/plugin-personal-assistant/test/scenarios/_catalogs/reconnect-old-friends.catalog.json packages/scenario-runner/src/corpus-assertion-guard.test.ts
```

Result: `Checked 4 files in 58ms. No fixes applied.`

### Required Evidence Rows

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots N/A - scenario/catalog/test-only change, no rendered UI surface changed.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots N/A - scenario/catalog/test-only change, no rendered UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video N/A - no user-facing UI flow changed.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs: [15697-g2-cadence-report.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15697-g2-cadence-report.json) includes the real scenario-runner action trace showing `SCHEDULED_TASKS` create/list succeeded.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs N/A - no frontend code or browser runtime changed.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory N/A - this promoted row is intentionally `pr-deterministic` and uses the strict deterministic proxy; the remaining G2 rows still require live model evidence before promotion.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: [15697-g2-cadence-report.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15697-g2-cadence-report.json) and [15697-g2-coverage.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15697-g2-coverage.json) show the passing scenario and G2 `1/8` verified catalog state.
