### PR TITLE
fix(cloud): surface proxy debit failures

### DIFF
--- a/packages/cloud/shared/src/lib/services/proxy/birdeye-handler.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/birdeye-handler.error-policy.test.ts
@@ -139,11 +139,10 @@ describe("birdeye proxy — internal failures propagate through the J1 boundary"
   });
 });
 
-describe("birdeye proxy — money-path debit fallback (money-path-flagged, left as-is)", () => {
-  // The `deductCredits(...).catch(() => null)` on the billing path currently
-  // maps BOTH a designed insufficient-balance (`success: false`) AND an internal
-  // debit failure to the same 402. This conflation is flagged money-path-flagged
-  // and intentionally left untouched by #13415; this test pins the two shapes.
+describe("birdeye proxy — money-path debit failures stay distinct", () => {
+  // Designed insufficient balance is a user-facing 402. A thrown debit failure
+  // is an internal ledger failure and must go through the route boundary as a
+  // structured 5xx, never the same 402 as a legitimate empty balance.
   test("designed insufficient balance returns 402", async () => {
     deductCredits.mockResolvedValue({ success: false });
     const res = await handleBirdeyeMarketDataProxyGet(
@@ -154,11 +153,14 @@ describe("birdeye proxy — money-path debit fallback (money-path-flagged, left 
     expect(body.error).toContain("Insufficient credits");
   });
 
-  test("an internal debit failure is currently also mapped to 402 (flagged)", async () => {
+  test("an internal debit failure surfaces as a structured 5xx", async () => {
     deductCredits.mockRejectedValue(new Error("credits ledger write failed"));
     const res = await handleBirdeyeMarketDataProxyGet(
       makeContext("defi/price", { BIRDEYE_API_KEY: "key" }),
     );
-    expect(res.status).toBe(402);
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toBe("An unexpected error occurred");
   });
 });

--- a/packages/cloud/shared/src/lib/services/proxy/birdeye-handler.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/birdeye-handler.ts
@@ -56,22 +56,20 @@ export async function handleBirdeyeMarketDataProxyGet(c: Context<AppEnv>): Promi
     }
 
     const cost = await getServiceMethodCost("market-data", pricedMethod);
-    const deductResult = await creditsService
-      .deductCredits({
-        organizationId: organization_id,
-        amount: cost,
-        description: `API proxy: market-data — ${pricedMethod}`,
-        metadata: {
-          type: "proxy_market-data",
-          service: "market-data",
-          provider: "birdeye",
-          method: pricedMethod,
-          path: pathStr,
-        },
-      })
-      .catch(() => null);
+    const deductResult = await creditsService.deductCredits({
+      organizationId: organization_id,
+      amount: cost,
+      description: `API proxy: market-data — ${pricedMethod}`,
+      metadata: {
+        type: "proxy_market-data",
+        service: "market-data",
+        provider: "birdeye",
+        method: pricedMethod,
+        path: pathStr,
+      },
+    });
 
-    if (deductResult === null || !deductResult.success) {
+    if (!deductResult.success) {
       return c.json(
         {
           error: "Insufficient credits",

--- a/packages/cloud/shared/src/lib/services/proxy/dexscreener-handler.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/dexscreener-handler.error-policy.test.ts
@@ -143,13 +143,10 @@ describe("dexscreener proxy fail-closed boundary", () => {
   });
 });
 
-describe("dexscreener proxy — money-path debit fallback (money-path-flagged, left as-is)", () => {
-  // The `deductCredits(...).catch(() => null)` on the billing path maps BOTH a
-  // designed insufficient-balance (`success: false`) AND an internal debit
-  // failure (thrown) to the same 402. That conflation sits on the credit-debit
-  // money path, is flagged money-path-flagged, and is intentionally left
-  // untouched by #13415; these tests pin the two shapes so any future change is
-  // deliberate.
+describe("dexscreener proxy — money-path debit failures stay distinct", () => {
+  // Designed insufficient balance is a user-facing 402. A thrown debit failure
+  // is an internal ledger failure and must go through the route boundary as a
+  // structured 5xx, never the same 402 as a legitimate empty balance.
   test("designed insufficient balance returns 402", async () => {
     deductCredits.mockResolvedValue({ success: false });
 
@@ -160,12 +157,15 @@ describe("dexscreener proxy — money-path debit fallback (money-path-flagged, l
     expect(body.error).toContain("Insufficient credits");
   });
 
-  test("an internal debit failure is currently also mapped to 402 (flagged)", async () => {
+  test("an internal debit failure surfaces as a structured 5xx", async () => {
     deductCredits.mockRejectedValue(new Error("credits ledger write failed"));
 
     const res = await handleDexscreenerProxyGet(makeContext("latest/dex/pairs/x"));
 
-    expect(res.status).toBe(402);
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toBe("An unexpected error occurred");
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/proxy/dexscreener-handler.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/dexscreener-handler.ts
@@ -34,21 +34,19 @@ export async function handleDexscreenerProxyGet(c: Context<AppEnv>): Promise<Res
     const { organization_id } = user;
 
     const cost = await getServiceMethodCost("dexscreener", "getRequest");
-    const deductResult = await creditsService
-      .deductCredits({
-        organizationId: organization_id,
-        amount: cost,
-        description: "API proxy: dexscreener — getRequest",
-        metadata: {
-          type: "proxy_dexscreener",
-          service: "dexscreener",
-          method: "getRequest",
-          path: pathStr,
-        },
-      })
-      .catch(() => null);
+    const deductResult = await creditsService.deductCredits({
+      organizationId: organization_id,
+      amount: cost,
+      description: "API proxy: dexscreener — getRequest",
+      metadata: {
+        type: "proxy_dexscreener",
+        service: "dexscreener",
+        method: "getRequest",
+        path: pathStr,
+      },
+    });
 
-    if (deductResult === null || !deductResult.success) {
+    if (!deductResult.success) {
       return c.json(
         {
           error: "Insufficient credits",


### PR DESCRIPTION
## Summary
- remove `deductCredits(...).catch(() => null)` from the Birdeye and DexScreener proxy billing paths
- keep designed insufficient balance as a user-facing 402
- let internal credits-ledger debit failures reach the J1 route boundary as structured 5xx responses
- update existing #13415 error-policy tests for both proxies

## Evidence
- `bun test src/lib/services/proxy/birdeye-handler.error-policy.test.ts src/lib/services/proxy/dexscreener-handler.error-policy.test.ts` from `packages/cloud/shared` with temporary package-local bunfig disabling root coverage: 14 pass, 0 fail, 42 expects
- `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/proxy/birdeye-handler.ts packages/cloud/shared/src/lib/services/proxy/dexscreener-handler.ts packages/cloud/shared/src/lib/services/proxy/birdeye-handler.error-policy.test.ts packages/cloud/shared/src/lib/services/proxy/dexscreener-handler.error-policy.test.ts --no-errors-on-unmatched`
- `bun run audit:error-policy-ratchet`
- `bun run --cwd packages/cloud/shared typecheck 2>&1 | rg "birdeye-handler|dexscreener-handler" || true`
- `git diff --check origin/develop...HEAD && git diff --check`

N/A: no UI artifacts; backend proxy billing/error-handling only.
N/A: no live LLM trajectory; no prompt/model/action path changed.

Refs #13415