### PR TITLE
fix(lifeops): track standing document obligations

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/commitments/consumer.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/commitments/consumer.ts
@@ -1,0 +1,79 @@
+/**
+ * Runtime consumers for commitment-ledger producers that need to create
+ * scheduled work. Source hooks call these helpers when a standing guarantee
+ * observes a new artifact and must install both the durable obligation row and
+ * the watcher that will fire later through the shared ScheduledTask spine.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { LifeOpsRepository } from "../repository.js";
+import type { ScheduledTask } from "../scheduled-task/index.js";
+import { getScheduledTaskRunner } from "../scheduled-task/service.js";
+import {
+  createDocumentObligationLedgerRecord,
+  type DocumentObligationInput,
+  type LifeOpsCommitmentLedgerRecord,
+} from "./ledger.js";
+
+export interface TrackDocumentObligationResult {
+  readonly record: LifeOpsCommitmentLedgerRecord;
+  readonly task: ScheduledTask;
+}
+
+function requireSqlAdapter(runtime: IAgentRuntime): void {
+  const adapter = (runtime as { adapter?: { db?: unknown } }).adapter;
+  if (!adapter?.db) {
+    throw new Error(
+      "Tracking document obligations requires the LifeOps SQL adapter.",
+    );
+  }
+}
+
+function documentObligationIdempotencyKey(
+  input: DocumentObligationInput,
+): string {
+  return `commitment-ledger:document:${input.documentId}:deadline:${input.deadline}`;
+}
+
+/**
+ * Convert one newly observed document artifact into a tracked obligation.
+ * The ScheduledTask uses a stable idempotency key, so replaying the same
+ * connector/document event reuses the same watcher and upserts the same
+ * ledger row instead of creating duplicate owner work.
+ */
+export async function trackDocumentObligationArtifact(
+  runtime: IAgentRuntime,
+  input: DocumentObligationInput,
+): Promise<TrackDocumentObligationResult> {
+  requireSqlAdapter(runtime);
+  const seedRecord = createDocumentObligationLedgerRecord({
+    ...input,
+    scheduledTaskId: null,
+  });
+  const runner = getScheduledTaskRunner(runtime, { agentId: input.agentId });
+  const task = await runner.schedule({
+    kind: "watcher",
+    promptInstructions: `Document "${input.title}" obligation deadline reached. Verify ${seedRecord.kind} status for ${input.documentId} and escalate if it is still open.`,
+    trigger: { kind: "once", atIso: input.deadline },
+    priority: "medium",
+    subject: { kind: "document", id: input.documentId },
+    idempotencyKey: documentObligationIdempotencyKey(input),
+    respectsGlobalPause: true,
+    source: "plugin",
+    createdBy: input.agentId,
+    ownerVisible: true,
+    metadata: {
+      ...(input.metadata ?? {}),
+      commitmentLedgerId: seedRecord.id,
+      commitmentKind: seedRecord.kind,
+      documentId: input.documentId,
+      documentTitle: input.title,
+      standingGuarantee: true,
+    },
+  });
+  const record = createDocumentObligationLedgerRecord({
+    ...input,
+    scheduledTaskId: task.taskId,
+  });
+  await new LifeOpsRepository(runtime).upsertCommitmentLedgerRecord(record);
+  return { record, task };
+}

--- a/plugins/plugin-personal-assistant/src/lifeops/commitments/index.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/commitments/index.ts
@@ -1,2 +1,3 @@
 /** Commitment-ledger domain exports for durable obligations and regret audits. */
+export * from "./consumer.js";
 export * from "./ledger.js";

--- a/plugins/plugin-personal-assistant/test/commitment-ledger.test.ts
+++ b/plugins/plugin-personal-assistant/test/commitment-ledger.test.ts
@@ -11,6 +11,7 @@ import {
   createLifeOpsCommitmentLedgerRecord,
   extractCommitmentLedgerRecords,
   LifeOpsRepository,
+  trackDocumentObligationArtifact,
 } from "../src/lifeops/index.js";
 import {
   createLifeOpsTestRuntime,
@@ -208,6 +209,79 @@ describe("commitment ledger repository", () => {
     expect(tracked).toMatchObject({
       status: "tracked",
       scheduledTaskId: "st_deck_followup",
+    });
+  });
+
+  it("tracks a standing document guarantee with one ledger row and one watcher", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    await LifeOpsRepository.bootstrapSchema(runtime);
+    const repo = new LifeOpsRepository(runtime);
+
+    const first = await trackDocumentObligationArtifact(runtime, {
+      agentId: runtime.agentId,
+      documentId: "doc-acme-msa",
+      title: "Acme MSA contract renewal",
+      deadline: "2026-09-01T17:00:00.000Z",
+      observedAt: OBSERVED_AT,
+      counterparty: "Acme",
+      note: "Renewal notice must go out 60 days before term end.",
+      metadata: { standingGuaranteeId: "guarantee-renewals" },
+    });
+
+    expect(first.record).toMatchObject({
+      source: "document",
+      sourceKey: "doc-acme-msa",
+      kind: "renewal",
+      status: "tracked",
+      scheduledTaskId: first.task.taskId,
+    });
+    expect(first.task).toMatchObject({
+      kind: "watcher",
+      trigger: { kind: "once", atIso: "2026-09-01T17:00:00.000Z" },
+      subject: { kind: "document", id: "doc-acme-msa" },
+      idempotencyKey:
+        "commitment-ledger:document:doc-acme-msa:deadline:2026-09-01T17:00:00.000Z",
+    });
+
+    const replay = await trackDocumentObligationArtifact(runtime, {
+      agentId: runtime.agentId,
+      documentId: "doc-acme-msa",
+      title: "Acme MSA contract renewal",
+      deadline: "2026-09-01T17:00:00.000Z",
+      observedAt: OBSERVED_AT,
+      counterparty: "Acme",
+      note: "Renewal notice must go out 60 days before term end.",
+      metadata: { standingGuaranteeId: "guarantee-renewals" },
+    });
+
+    expect(replay.task.taskId).toBe(first.task.taskId);
+    expect(replay.record.id).toBe(first.record.id);
+
+    const rows = await repo.listCommitmentLedgerRecords(runtime.agentId, {
+      source: "document",
+      statuses: ["tracked"],
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: first.record.id,
+      scheduledTaskId: first.task.taskId,
+      metadata: {
+        standingGuaranteeId: "guarantee-renewals",
+      },
+    });
+
+    const persistedTask = await repo.getScheduledTask(
+      runtime.agentId,
+      first.task.taskId,
+    );
+    expect(persistedTask).toMatchObject({
+      idempotencyKey:
+        "commitment-ledger:document:doc-acme-msa:deadline:2026-09-01T17:00:00.000Z",
+      metadata: {
+        commitmentLedgerId: first.record.id,
+        standingGuarantee: true,
+      },
     });
   });
 });


### PR DESCRIPTION
Refs #14864.

## Summary
- Add `trackDocumentObligationArtifact()` as the runtime-facing standing-guarantee consumer for newly observed document artifacts.
- The helper schedules a due-date watcher through the shared ScheduledTask runner with a stable idempotency key, then persists the commitment ledger row as `tracked`.
- Add PGlite-backed regression coverage proving replaying the same artifact reuses one watcher and one ledger row.

## Verification
- `ELIZA_SKIP_ARTIFACT_SYNC=1 bun run install:light` (needed in the isolated worktree to restore missing package links; artifact sync skipped).
- `node packages/shared/scripts/generate-keywords.mjs --target ts`.
- `bun run --cwd plugins/plugin-personal-assistant test -- test/commitment-ledger.test.ts` (1 file, 7 tests passed; warning-only dependency sourcemap noise).
- `bunx @biomejs/biome check plugins/plugin-personal-assistant/src/lifeops/commitments/consumer.ts plugins/plugin-personal-assistant/src/lifeops/commitments/index.ts plugins/plugin-personal-assistant/test/commitment-ledger.test.ts`.
- `git diff --check`.
- `bun run audit:error-policy-ratchet`.
- `bun run --cwd plugins/plugin-personal-assistant build`.

Still not claiming full #14864 closure: live model extraction trajectories, live/source-ingest scenarios, and hand-reviewed rows from a running agent remain required for final acceptance.

## Evidence
<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - backend/runtime LifeOps commitment consumer only; no UI, browser, native, or rendered surface changed.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - backend/runtime LifeOps commitment consumer only; no UI, browser, native, or rendered surface changed.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no user-facing UI flow changed.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no server process was run; focused real-runtime/PGlite test exercises the repository and scheduled-task runner path directly.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend runtime path changed.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no prompt, model, provider, or planner behavior changed; live extraction trajectories remain as #14864 acceptance evidence.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - deterministic domain artifacts are asserted in the PGlite regression: one persisted `life_commitment_ledger` tracked `document` row and one persisted `life_scheduled_tasks` watcher with `standingGuarantee: true`; replay proves no duplicate row or watcher.