### PR TITLE
fix(cloud): surface x402 facilitator secret read failures

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/x402-facilitator.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/x402-facilitator.test.ts
@@ -25,6 +25,7 @@ const parseEventLogs = mock(() => [
     },
   },
 ]);
+const getSecret = mock(async () => null as string | null);
 
 mock.module("@solana/kit", () => ({
   createKeyPairSignerFromBytes: mock(() => ({ address: "solana-signer" })),
@@ -85,6 +86,12 @@ mock.module("viem/chains", () => ({
   sepolia: {},
 }));
 
+mock.module("../secrets", () => ({
+  secretsService: {
+    get: getSecret,
+  },
+}));
+
 const { x402FacilitatorService } = await import("../x402-facilitator");
 
 type MutableFacilitator = {
@@ -102,6 +109,27 @@ type MutableFacilitator = {
     }
   >;
 };
+
+function resetFacilitatorInitialization(): MutableFacilitator & {
+  initializing: Promise<void> | null;
+} {
+  const service = x402FacilitatorService as unknown as MutableFacilitator & {
+    initializing: Promise<void> | null;
+    svmScheme: unknown;
+    enabledSolanaNetworks: string[];
+    solanaNetworks: Record<string, unknown>;
+  };
+  service.initialized = false;
+  service.initializing = null;
+  service.account = null;
+  service.enabledNetworks = [];
+  service.clients = new Map();
+  service.networks = {};
+  service.svmScheme = null;
+  service.enabledSolanaNetworks = [];
+  service.solanaNetworks = {};
+  return service;
+}
 
 function paymentPayload(authorizationValue: string) {
   return {
@@ -140,6 +168,70 @@ const requirements = {
 // the platform recipient here so the legitimate settle tests below pass the
 // guard; the attacker test uses a DIFFERENT payTo that is not platform-owned.
 process.env.X402_RECIPIENT_ADDRESS = PAY_TO;
+
+test("initialize fails closed when the EVM facilitator secret read fails", async () => {
+  const previousNetworks = process.env.X402_NETWORKS;
+  const previousFacilitatorKey = process.env.FACILITATOR_PRIVATE_KEY;
+  const previousX402FacilitatorKey = process.env.X402_FACILITATOR_PRIVATE_KEY;
+  resetFacilitatorInitialization();
+  getSecret.mockReset();
+  getSecret.mockRejectedValue(new Error("secrets store unavailable"));
+  process.env.X402_NETWORKS = "base";
+  process.env.FACILITATOR_PRIVATE_KEY =
+    "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+  delete process.env.X402_FACILITATOR_PRIVATE_KEY;
+
+  try {
+    await expect(x402FacilitatorService.initialize()).rejects.toMatchObject({
+      message: "[x402-facilitator] Failed to read FACILITATOR_PRIVATE_KEY from secrets service",
+      cause: expect.objectContaining({ message: "secrets store unavailable" }),
+    });
+    expect(getSecret).toHaveBeenCalledWith("system", "FACILITATOR_PRIVATE_KEY");
+  } finally {
+    resetFacilitatorInitialization();
+    getSecret.mockReset();
+    getSecret.mockResolvedValue(null);
+    if (previousNetworks === undefined) delete process.env.X402_NETWORKS;
+    else process.env.X402_NETWORKS = previousNetworks;
+    if (previousFacilitatorKey === undefined) delete process.env.FACILITATOR_PRIVATE_KEY;
+    else process.env.FACILITATOR_PRIVATE_KEY = previousFacilitatorKey;
+    if (previousX402FacilitatorKey === undefined) delete process.env.X402_FACILITATOR_PRIVATE_KEY;
+    else process.env.X402_FACILITATOR_PRIVATE_KEY = previousX402FacilitatorKey;
+  }
+});
+
+test("initialize fails closed when the Solana facilitator secret read fails", async () => {
+  const previousNetworks = process.env.X402_NETWORKS;
+  const previousSolanaKey = process.env.X402_SOLANA_FACILITATOR_PRIVATE_KEY;
+  resetFacilitatorInitialization();
+  getSecret.mockReset();
+  getSecret.mockImplementation(async (_scope, keyName) => {
+    if (keyName === "FACILITATOR_PRIVATE_KEY") return null;
+    throw new Error("solana secret read failed");
+  });
+  process.env.X402_NETWORKS = "solana-devnet";
+  process.env.X402_SOLANA_FACILITATOR_PRIVATE_KEY = `[${Array.from(
+    { length: 64 },
+    (_, i) => i,
+  ).join(",")}]`;
+
+  try {
+    await expect(x402FacilitatorService.initialize()).rejects.toMatchObject({
+      message:
+        "[x402-facilitator] Failed to read X402_SOLANA_FACILITATOR_PRIVATE_KEY from secrets service",
+      cause: expect.objectContaining({ message: "solana secret read failed" }),
+    });
+    expect(getSecret).toHaveBeenCalledWith("system", "X402_SOLANA_FACILITATOR_PRIVATE_KEY");
+  } finally {
+    resetFacilitatorInitialization();
+    getSecret.mockReset();
+    getSecret.mockResolvedValue(null);
+    if (previousNetworks === undefined) delete process.env.X402_NETWORKS;
+    else process.env.X402_NETWORKS = previousNetworks;
+    if (previousSolanaKey === undefined) delete process.env.X402_SOLANA_FACILITATOR_PRIVATE_KEY;
+    else process.env.X402_SOLANA_FACILITATOR_PRIVATE_KEY = previousSolanaKey;
+  }
+});
 
 function primeEvmFacilitator() {
   process.env.X402_RECIPIENT_ADDRESS = PAY_TO;

--- a/packages/cloud/shared/src/lib/services/x402-facilitator.ts
+++ b/packages/cloud/shared/src/lib/services/x402-facilitator.ts
@@ -1503,23 +1503,34 @@ class X402FacilitatorService {
   }
 
   private async loadSolanaFacilitatorKey(): Promise<string | null> {
+    let secretsService: Awaited<typeof import("./secrets")>["secretsService"] | null | undefined;
     try {
-      const { secretsService } = await import("./secrets");
-      if (secretsService) {
-        for (const keyName of [
-          "X402_SOLANA_FACILITATOR_PRIVATE_KEY",
-          "SOLANA_FACILITATOR_PRIVATE_KEY",
-          "SOLANA_PAYOUT_PRIVATE_KEY",
-        ]) {
-          const key = await secretsService.get("system", keyName).catch(() => null);
-          if (key) {
-            logger.info(`[x402-facilitator] Loaded ${keyName} from secrets service`);
-            return key;
-          }
+      ({ secretsService } = await import("./secrets"));
+    } catch {
+      // error-policy:J4 local/dev degrade; the optional encrypted secrets module is not available in all runtimes.
+      secretsService = null;
+    }
+
+    if (secretsService) {
+      for (const keyName of [
+        "X402_SOLANA_FACILITATOR_PRIVATE_KEY",
+        "SOLANA_FACILITATOR_PRIVATE_KEY",
+        "SOLANA_PAYOUT_PRIVATE_KEY",
+      ]) {
+        let key: string | null;
+        try {
+          key = await secretsService.get("system", keyName);
+        } catch (error) {
+          // error-policy:J2 context-adding rethrow; a secrets read failure must not masquerade as an absent key.
+          throw new Error(`[x402-facilitator] Failed to read ${keyName} from secrets service`, {
+            cause: error,
+          });
+        }
+        if (key) {
+          logger.info(`[x402-facilitator] Loaded ${keyName} from secrets service`);
+          return key;
         }
       }
-    } catch {
-      // Secrets service not available, fall through
     }
 
     const env = getCloudAwareEnv();
@@ -1538,18 +1549,30 @@ class X402FacilitatorService {
    */
   private async loadFacilitatorKey(): Promise<string | null> {
     // Try secrets service first (production)
+    let secretsService: Awaited<typeof import("./secrets")>["secretsService"] | null | undefined;
     try {
-      const { secretsService } = await import("./secrets");
-      if (secretsService) {
-        // Try org-level facilitator key
-        const key = await secretsService.get("system", "FACILITATOR_PRIVATE_KEY").catch(() => null);
-        if (key) {
-          logger.info("[x402-facilitator] Loaded key from secrets service (encrypted)");
-          return key;
-        }
-      }
+      ({ secretsService } = await import("./secrets"));
     } catch {
-      // Secrets service not available, fall through
+      // error-policy:J4 local/dev degrade; the optional encrypted secrets module is not available in all runtimes.
+      secretsService = null;
+    }
+
+    if (secretsService) {
+      // Try org-level facilitator key.
+      let key: string | null;
+      try {
+        key = await secretsService.get("system", "FACILITATOR_PRIVATE_KEY");
+      } catch (error) {
+        // error-policy:J2 context-adding rethrow; a secrets read failure must not masquerade as an absent key.
+        throw new Error(
+          "[x402-facilitator] Failed to read FACILITATOR_PRIVATE_KEY from secrets service",
+          { cause: error },
+        );
+      }
+      if (key) {
+        logger.info("[x402-facilitator] Loaded key from secrets service (encrypted)");
+        return key;
+      }
     }
 
     // Fallback to environment variable (development)


### PR DESCRIPTION
## Summary
- stop swallowing x402 facilitator secrets-service read failures into absent-key fallback
- keep local/dev fallback only for an unavailable secrets module
- preserve EVM and Solana secret-read failures with J2 context and original cause
- add regression coverage for EVM and Solana facilitator secret read failures

## Evidence
- `bun test src/lib/services/__tests__/x402-facilitator.test.ts` from `packages/cloud/shared` with temporary package-local bunfig disabling root coverage: 9 pass, 0 fail, 27 expects
- `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/x402-facilitator.ts packages/cloud/shared/src/lib/services/__tests__/x402-facilitator.test.ts --no-errors-on-unmatched`
- `bun run audit:error-policy-ratchet`
- `bun run --cwd packages/cloud/shared typecheck 2>&1 | rg "x402-facilitator" || true`
- `git diff --check origin/develop...HEAD && git diff --check`

N/A: no UI artifacts; backend payment facilitator secret-loading/error-handling only.
N/A: no live LLM trajectory; no prompt/model/action path changed.

Refs #13415