### PR TITLE
test(lifeops): cover delegated inbound processor

### DIFF
--- a/plugins/plugin-personal-assistant/test/delegation-contracts-inbound.test.ts
+++ b/plugins/plugin-personal-assistant/test/delegation-contracts-inbound.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Regression coverage for the runtime-facing delegated-inbound processor.
+ * The repository and approval queue are small fakes so root-level coverage
+ * jobs can load this test without the package-local Vitest aliases, while the
+ * assertions still cover the processor contract that connector hooks call.
+ */
+import { describe, expect, it } from "vitest";
+import type {
+  ApprovalEnqueueInput,
+  ApprovalListFilter,
+  ApprovalQueue,
+  ApprovalRequest,
+  ApprovalResolution,
+} from "../src/lifeops/approval-queue.types.js";
+import {
+  createLifeOpsDelegationContractRecord,
+  type DelegationContractRepository,
+  type LifeOpsDelegationContractRecord,
+  processDelegationInboundTurn,
+} from "../src/lifeops/delegation-contracts/index.js";
+
+class TestDelegationRepository implements DelegationContractRepository {
+  private readonly records = new Map<string, LifeOpsDelegationContractRecord>();
+
+  constructor(seed: readonly LifeOpsDelegationContractRecord[]) {
+    for (const record of seed) {
+      this.records.set(record.contractId, record);
+    }
+  }
+
+  async listDelegationContracts(
+    _agentId: string,
+    _filter: {
+      statuses?: LifeOpsDelegationContractRecord["status"][];
+      activeAtIso?: string;
+    },
+  ): Promise<LifeOpsDelegationContractRecord[]> {
+    return Array.from(this.records.values());
+  }
+
+  async upsertDelegationContract(
+    record: LifeOpsDelegationContractRecord,
+  ): Promise<void> {
+    this.records.set(record.contractId, record);
+  }
+
+  get(contractId: string): LifeOpsDelegationContractRecord | undefined {
+    return this.records.get(contractId);
+  }
+}
+
+class TestApprovalQueue implements ApprovalQueue {
+  private readonly requests: ApprovalRequest[] = [];
+
+  async enqueue(input: ApprovalEnqueueInput): Promise<ApprovalRequest> {
+    const now = new Date("2026-07-06T18:05:00.000Z");
+    const request: ApprovalRequest = {
+      id: `approval-${this.requests.length + 1}`,
+      createdAt: now,
+      updatedAt: now,
+      state: "pending",
+      requestedBy: input.requestedBy,
+      subjectUserId: input.subjectUserId,
+      action: input.action,
+      payload: input.payload,
+      channel: input.channel,
+      reason: input.reason,
+      expiresAt: input.expiresAt,
+      resolvedAt: null,
+      resolvedBy: null,
+      resolutionReason: null,
+    };
+    this.requests.push(request);
+    return request;
+  }
+
+  async list(
+    filter: ApprovalListFilter,
+  ): Promise<ReadonlyArray<ApprovalRequest>> {
+    return this.requests.filter(
+      (request) =>
+        (filter.subjectUserId === null ||
+          request.subjectUserId === filter.subjectUserId) &&
+        (filter.state === null || request.state === filter.state) &&
+        (filter.action === null || request.action === filter.action),
+    );
+  }
+
+  async byId(id: string): Promise<ApprovalRequest | null> {
+    return this.requests.find((request) => request.id === id) ?? null;
+  }
+
+  async approve(
+    _id: string,
+    _resolution: ApprovalResolution,
+  ): Promise<ApprovalRequest> {
+    throw new Error("TestApprovalQueue.approve is not used by this test.");
+  }
+
+  async reject(
+    _id: string,
+    _resolution: ApprovalResolution,
+  ): Promise<ApprovalRequest> {
+    throw new Error("TestApprovalQueue.reject is not used by this test.");
+  }
+
+  async markExecuting(_id: string): Promise<ApprovalRequest> {
+    throw new Error(
+      "TestApprovalQueue.markExecuting is not used by this test.",
+    );
+  }
+
+  async markDone(_id: string): Promise<ApprovalRequest> {
+    throw new Error("TestApprovalQueue.markDone is not used by this test.");
+  }
+
+  async markExpired(_id: string): Promise<ApprovalRequest> {
+    throw new Error("TestApprovalQueue.markExpired is not used by this test.");
+  }
+
+  async purgeExpired(_now: Date): Promise<ReadonlyArray<string>> {
+    return [];
+  }
+}
+
+describe("processDelegationInboundTurn", () => {
+  it("turns a delegated sender-class SLA into one pending approval", async () => {
+    const agentId = "00000000-0000-0000-0000-000000001856";
+    const repository = new TestDelegationRepository([
+      createLifeOpsDelegationContractRecord({
+        contractId: "delegation:board-sla",
+        objective: "Board member holding reply",
+        scope: {
+          kind: "sender_class",
+          channel: "email",
+          senderClass: "board_member",
+        },
+        autonomyLevel: "approval_gated",
+        tripwires: [],
+        sla: {
+          holdingReplyAfterMinutes: 60,
+          subjectPrefix: "Re:",
+          holdingReplyBody:
+            "Thanks, I have this and will come back with a proper answer shortly.",
+        },
+        createdAt: "2026-07-06T16:00:00.000Z",
+        expiresAt: "2026-07-13T16:00:00.000Z",
+        ownerUserId: "owner-1",
+        requestedBy: "delegation-contracts",
+        agentId,
+        metadata: { policy: "board-member-one-hour-hold" },
+      }),
+    ]);
+    const approvalQueue = new TestApprovalQueue();
+
+    const processed = await processDelegationInboundTurn({
+      agentId,
+      repository,
+      approvalQueue,
+      nowIso: "2026-07-06T18:05:00.000Z",
+      turn: {
+        channel: "email",
+        threadId: "thread-board-1",
+        sender: "Dana Board",
+        senderClass: "board_member",
+        senderEmail: "dana@board.example",
+        subject: "Quarterly update",
+        text: "Can you send the latest numbers?",
+        receivedAt: "2026-07-06T17:00:00.000Z",
+      },
+    });
+
+    expect(processed.evaluations.map((entry) => entry.outcome)).toEqual([
+      "holding_reply_due",
+    ]);
+    expect(processed.enqueuedApprovals).toHaveLength(1);
+    expect(processed.enqueuedApprovals[0]).toMatchObject({
+      state: "pending",
+      requestedBy: "delegation-contracts",
+      subjectUserId: "owner-1",
+      action: "send_email",
+      channel: "email",
+      reason: "SLA holding reply for delegated Board member holding reply",
+      payload: {
+        action: "send_email",
+        to: ["dana@board.example"],
+        subject: "Re: Quarterly update",
+        body: "Thanks, I have this and will come back with a proper answer shortly.",
+        threadId: "thread-board-1",
+      },
+    });
+    expect(
+      repository.get("delegation:board-sla")?.state?.holdingReplyQueuedAt,
+    ).toBe("2026-07-06T18:05:00.000Z");
+
+    const replayed = await processDelegationInboundTurn({
+      agentId,
+      repository,
+      approvalQueue,
+      nowIso: "2026-07-06T18:10:00.000Z",
+      turn: {
+        channel: "email",
+        threadId: "thread-board-1",
+        sender: "Dana Board",
+        senderClass: "board_member",
+        senderEmail: "dana@board.example",
+        subject: "Quarterly update",
+        text: "Can you send the latest numbers?",
+        receivedAt: "2026-07-06T17:00:00.000Z",
+      },
+    });
+
+    expect(replayed.evaluations).toHaveLength(1);
+    expect(replayed.evaluations[0]?.outcome).toBe("in_bounds");
+    expect(replayed.enqueuedApprovals).toHaveLength(0);
+    await expect(
+      approvalQueue.list({
+        subjectUserId: "owner-1",
+        state: "pending",
+        action: "send_email",
+        limit: 10,
+      }),
+    ).resolves.toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Refs #14856. Follow-up to #15696.

## Summary
- Add a root-Vitest-compatible regression for `processDelegationInboundTurn()`.
- The test uses typed fake repository and approval queue dependencies so CI's changed-file coverage lane can load it without package-local aliases.
- Keeps the existing package-level repository/provider tests untouched.

## Verification
- `bunx vitest run plugins/plugin-personal-assistant/test/delegation-contracts-inbound.test.ts --coverage --coverage.reporter=lcov --coverage.reportsDirectory=coverage/vitest`.
- `bun run --cwd plugins/plugin-personal-assistant test -- test/delegation-contracts.test.ts test/delegation-contracts-inbound.test.ts`.
- `bunx @biomejs/biome check plugins/plugin-personal-assistant/src/lifeops/delegation-contracts/index.ts plugins/plugin-personal-assistant/test/delegation-contracts-inbound.test.ts`.
- `git diff --check`.
- `bun run audit:error-policy-ratchet`.
- `bun run --cwd plugins/plugin-personal-assistant build`.

## Evidence
<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - test-only backend/runtime coverage change; no UI, browser, native, or rendered surface changed.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - test-only backend/runtime coverage change; no UI, browser, native, or rendered surface changed.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no user-facing flow changed.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no server process was run; verification is Vitest coverage over the delegated inbound processor.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend runtime path changed.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no prompt, model, provider, or planner behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - deterministic test artifact asserts one pending `send_email` approval, persisted `holdingReplyQueuedAt`, and replay with no duplicate approval.
