### PR TITLE
test(cloud): cover native bridge failure kind propagation

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-failurekind.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-failurekind.test.ts
@@ -63,6 +63,13 @@ const senders: Array<[string, () => MessageSender]> = [
   ],
 ];
 
+function makeHostServiceSender(): MessageSender {
+  const hostService = new ElizaSandboxService() as unknown as MessageSender &
+    Record<string, unknown>;
+  Object.assign(hostService, endpointStubs);
+  return hostService;
+}
+
 /**
  * Stub the sandbox HTTP surface: the native /bridge and every REST rung except
  * the conversation route 404 (legacy-image shape), the conversation route
@@ -85,9 +92,51 @@ function installFetchStub(messageBody: Record<string, unknown>): string[] {
   return paths;
 }
 
+/**
+ * Stub the production host-service first rung: the cloud-agent image's native
+ * JSON-RPC `/bridge` endpoint. This is the path the Hetzner nightly hits on
+ * current cloud-agent images, so failure discriminators must not rely on the
+ * later conversation REST rung to be observable.
+ */
+function installNativeBridgeFetchStub(result: Record<string, unknown>): string[] {
+  const paths: string[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    const path = new URL(url).pathname;
+    paths.push(path);
+    if (path === "/bridge") {
+      return Response.json({
+        jsonrpc: "2.0",
+        id: rpc.id,
+        result,
+      });
+    }
+    return new Response("not found", { status: 404 });
+  }) as typeof fetch;
+  return paths;
+}
+
 const realFetch = globalThis.fetch;
 afterEach(() => {
   globalThis.fetch = realFetch;
+});
+
+describe("ElizaSandboxService native bridge failureKind propagation", () => {
+  test("native JSON-RPC canned failure reply carries failureKind and ends the ladder", async () => {
+    const paths = installNativeBridgeFetchStub({
+      text: "Sorry, I'm having a provider issue",
+      failureKind: "provider_issue",
+    });
+
+    const response = await makeHostServiceSender().bridgeMessageSend(rec, rpc);
+
+    expect(response.error).toBeUndefined();
+    expect(response.result?.text).toBe("Sorry, I'm having a provider issue");
+    expect(response.result?.failureKind).toBe("provider_issue");
+    expect(response.result?.transport).toBe("native-jsonrpc");
+    expect(response.result?.fallback).toBeUndefined();
+    expect(paths).toEqual(["/bridge"]);
+  });
 });
 
 for (const [label, make] of senders) {


### PR DESCRIPTION
## Summary
- add regression coverage for the production host-service native `/bridge` JSON-RPC rung
- assert native canned failure replies preserve `failureKind`, gain `transport: native-jsonrpc`, and stop before REST fallback rungs
- keep existing dual-ladder conversation REST assertions intact

## Evidence
- `node ../shared/scripts/generate-keywords.mjs --target ts` from `packages/core`
- `bun test src/lib/services/eliza-sandbox-bridge-failurekind.test.ts` from `packages/cloud/shared`: 7 pass, 0 fail, 36 expects
- `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-failurekind.test.ts --no-errors-on-unmatched`
- `bun run audit:error-policy-ratchet`
- `git diff --check origin/develop...HEAD && git diff --check`

N/A: no UI artifacts; backend bridge regression coverage only.
N/A: no live LLM trajectory; this adds transport-level test coverage for #15616 rather than changing model behavior.

Refs #15616