### PR TITLE
feat(lifeops): process finalized meeting transcripts

### DIFF
--- a/packages/shared/src/meetings.ts
+++ b/packages/shared/src/meetings.ts
@@ -12,7 +12,7 @@
  * integration and post-hoc artifacts remain the OAuth surfaces.
  */
 
-import type { TranscriptSegment } from "./transcripts.js";
+import type { Transcript, TranscriptSegment } from "./transcripts.js";
 
 /** Platforms an agent can attend. Browser-bot: meet/teams/zoom. Native RX: discord. */
 export type MeetingPlatform = "google_meet" | "teams" | "zoom" | "discord";
@@ -67,6 +67,20 @@ export const DEFAULT_MEETING_AUTO_LEAVE: MeetingAutoLeaveConfig = {
 /** Default upper bound for a browser-bot meeting session: 60 minutes. */
 export const DEFAULT_MEETING_MAX_DURATION_MS = 60 * 60 * 1000;
 
+/**
+ * Owner-side context for post-meeting "ghost attendance" processing. Meeting
+ * capture owns the transcript; LifeOps owns what to do with it for the owner.
+ */
+export interface MeetingGhostAttendanceContext {
+  ownerUserId: string;
+  ownerDisplayName: string;
+  requestedBy?: string;
+  careAbouts: string[];
+  calendarId?: string;
+  approvalTtlMs?: number;
+  attendees?: Array<{ name: string; email?: string }>;
+}
+
 /** Input contract to start a bot (the request side of POST /api/meetings). */
 export interface MeetingJoinRequest {
   platform: MeetingPlatform;
@@ -85,6 +99,11 @@ export interface MeetingJoinRequest {
   maxDurationMs?: number;
   /** Calendar event that prompted the join, when auto-joined. */
   calendarEventId?: string;
+  /**
+   * Optional LifeOps post-processing context: when present, a finalized
+   * transcript can be analyzed as a meeting the owner skipped.
+   */
+  ghostAttendance?: MeetingGhostAttendanceContext;
 }
 
 /** Metering state exposed so routes/UI can prove a meeting is spend-bounded. */
@@ -163,6 +182,16 @@ export interface MeetingStatusEvent {
 }
 
 export type MeetingWsEvent = MeetingTranscriptEvent | MeetingStatusEvent;
+
+/** Runtime event emitted when a meeting transcript is finalized and readable. */
+export const MEETING_TRANSCRIPT_FINALIZED_EVENT =
+  "meeting.transcript.finalized";
+
+export interface MeetingTranscriptFinalizedPayload {
+  session: MeetingSession;
+  transcript: Transcript;
+  ghostAttendance?: MeetingGhostAttendanceContext;
+}
 
 /** Result of parsing a user-supplied meeting URL. */
 export interface ParsedMeetingUrl {

--- a/plugins/plugin-meetings/src/service.test.ts
+++ b/plugins/plugin-meetings/src/service.test.ts
@@ -3,7 +3,10 @@
  * single-bot-per-meeting enforcement, roster, transcript persistence, and
  * listing. Deterministic: fake runtime plus scripted adapter/pipeline.
  */
-import { DEFAULT_MEETING_MAX_DURATION_MS } from "@elizaos/shared";
+import {
+  DEFAULT_MEETING_MAX_DURATION_MS,
+  MEETING_TRANSCRIPT_FINALIZED_EVENT,
+} from "@elizaos/shared";
 import { describe, expect, it, vi } from "vitest";
 import { MeetingJoinError, MeetingService } from "./service.js";
 import {
@@ -489,6 +492,65 @@ describe("MeetingService — roster, transcripts, listing", () => {
     expect((fake.documents[0].metadata as { tags: string[] }).tags).toContain(
       "transcript",
     );
+  });
+
+  it("emits the finalized transcript event with ghost-attendance context", async () => {
+    const adapter = new ScriptedAdapter("google_meet");
+    const { fake, service, pipelines } = makeService([adapter]);
+    const dto = await service.requestJoin({
+      platform: "google_meet",
+      meetingUrl: MEET_URL,
+      ghostAttendance: {
+        ownerUserId: "owner-1",
+        ownerDisplayName: "Shaw",
+        requestedBy: "owner-1",
+        careAbouts: ["launch date"],
+        calendarId: "primary",
+        attendees: [{ name: "Ava", email: "ava@example.com" }],
+      },
+    });
+    await adapter.started;
+
+    pipelines[0].finalSegments = [
+      segment(
+        "s1",
+        "Ava",
+        "Ava will send the launch-date rollback plan by Friday.",
+        0,
+        2_000,
+      ),
+    ];
+    pipelines[0].audioWav = null;
+
+    adapter.end("normal_completion");
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(fake.events).toHaveLength(1);
+    expect(fake.events[0].event).toBe(MEETING_TRANSCRIPT_FINALIZED_EVENT);
+    expect(fake.events[0].payload).toMatchObject({
+      source: "plugin-meetings",
+      session: {
+        id: dto.id,
+        status: "ended",
+        transcriptId: dto.transcriptId,
+      },
+      transcript: {
+        id: dto.transcriptId,
+        status: "ready",
+        segments: [
+          expect.objectContaining({
+            speakerLabel: "Ava",
+            text: "Ava will send the launch-date rollback plan by Friday.",
+          }),
+        ],
+      },
+      ghostAttendance: {
+        ownerUserId: "owner-1",
+        careAbouts: ["launch date"],
+        attendees: [{ name: "Ava", email: "ava@example.com" }],
+      },
+    });
+    expect(fake.reportedErrors).toHaveLength(0);
   });
 
   it("fails the session when pipeline finalize throws", async () => {

--- a/plugins/plugin-meetings/src/service.ts
+++ b/plugins/plugin-meetings/src/service.ts
@@ -707,6 +707,7 @@ export class MeetingService extends Service {
   ): Promise<void> {
     if (!transcript || session.status !== "ended") return;
     const payload: EventPayload & MeetingTranscriptFinalizedPayload = {
+      runtime: this.runtime,
       session: dto,
       transcript,
       ...(session.ghostAttendance

--- a/plugins/plugin-meetings/src/service.ts
+++ b/plugins/plugin-meetings/src/service.ts
@@ -22,9 +22,11 @@ import {
   DEFAULT_MEETING_AUTO_LEAVE,
   DEFAULT_MEETING_MAX_DURATION_MS,
   MEETING_PLATFORM_LABELS,
+  MEETING_TRANSCRIPT_FINALIZED_EVENT,
   type MeetingAutoLeaveConfig,
   type MeetingBillingState,
   type MeetingEndReason,
+  type MeetingGhostAttendanceContext,
   type MeetingJoinRequest,
   type MeetingParticipant,
   type MeetingPlatform,
@@ -33,7 +35,10 @@ import {
   parseMeetingUrl,
   parsePositiveInteger,
 } from "@elizaos/shared";
-import type { TranscriptSegment } from "@elizaos/shared/transcripts";
+import type {
+  Transcript,
+  TranscriptSegment,
+} from "@elizaos/shared/transcripts";
 import { MeetingEventEmitter } from "./events.js";
 import { resolveMeetingRuntimeSupport } from "./platform-support.js";
 import { MeetingTranscriptWriter } from "./transcripts/meeting-transcript-writer.js";
@@ -109,6 +114,7 @@ interface InternalSession {
   readonly pipeline: MeetingPipelineInstance;
   readonly writer: MeetingTranscriptWriter;
   readonly billing?: MeetingBillingSession;
+  readonly ghostAttendance?: MeetingGhostAttendanceContext;
   billingFinalized?: Promise<void>;
   /** Confirmed segments accumulated from pipeline updates (live view state). */
   confirmedSegments: TranscriptSegment[];
@@ -292,6 +298,9 @@ export class MeetingService extends Service {
       pipeline,
       writer,
       ...(billing ? { billing } : {}),
+      ...(request.ghostAttendance
+        ? { ghostAttendance: request.ghostAttendance }
+        : {}),
       confirmedSegments: [],
       done: Promise.resolve(),
     };
@@ -619,6 +628,7 @@ export class MeetingService extends Service {
     errorMessage: string | undefined,
   ): Promise<void> {
     let segments: TranscriptSegment[];
+    let finalizedTranscript: Transcript | null = null;
     try {
       segments = await session.pipeline.finalize();
     } catch (err) {
@@ -633,7 +643,7 @@ export class MeetingService extends Service {
     }
 
     try {
-      await session.writer.finalize({
+      finalizedTranscript = await session.writer.finalize({
         segments,
         endReason,
         participants: session.participants,
@@ -678,6 +688,7 @@ export class MeetingService extends Service {
       },
       "[MeetingService] session finished",
     );
+    await this.emitTranscriptFinalized(session, dto, finalizedTranscript);
 
     // Evict the heavy session: dropping the pipeline (retained PCM),
     // writer, and roster arrays lets them be garbage-collected. Only the DTO
@@ -685,6 +696,29 @@ export class MeetingService extends Service {
     // the durable data.
     this.sessions.delete(session.id);
     this.terminated.set(session.id, dto);
+  }
+
+  private async emitTranscriptFinalized(
+    session: InternalSession,
+    dto: MeetingSession,
+    transcript: Transcript | null,
+  ): Promise<void> {
+    if (!transcript || session.status !== "ended") return;
+    try {
+      await this.runtime.emitEvent(MEETING_TRANSCRIPT_FINALIZED_EVENT, {
+        session: dto,
+        transcript,
+        ...(session.ghostAttendance
+          ? { ghostAttendance: session.ghostAttendance }
+          : {}),
+        source: "plugin-meetings",
+      });
+    } catch (err) {
+      this.runtime.reportError("MeetingService.transcriptFinalizedEvent", err, {
+        sessionId: session.id,
+        transcriptId: transcript.id,
+      });
+    }
   }
 
   private async reconcileBillingOnce(

--- a/plugins/plugin-meetings/src/service.ts
+++ b/plugins/plugin-meetings/src/service.ts
@@ -13,6 +13,7 @@
 import {
   ChannelType,
   createUniqueUuid,
+  type EventPayload,
   type IAgentRuntime,
   logger,
   Service,
@@ -32,6 +33,7 @@ import {
   type MeetingPlatform,
   type MeetingSession,
   type MeetingSessionStatus,
+  type MeetingTranscriptFinalizedPayload,
   parseMeetingUrl,
   parsePositiveInteger,
 } from "@elizaos/shared";
@@ -704,15 +706,16 @@ export class MeetingService extends Service {
     transcript: Transcript | null,
   ): Promise<void> {
     if (!transcript || session.status !== "ended") return;
+    const payload: EventPayload & MeetingTranscriptFinalizedPayload = {
+      session: dto,
+      transcript,
+      ...(session.ghostAttendance
+        ? { ghostAttendance: session.ghostAttendance }
+        : {}),
+      source: "plugin-meetings",
+    };
     try {
-      await this.runtime.emitEvent(MEETING_TRANSCRIPT_FINALIZED_EVENT, {
-        session: dto,
-        transcript,
-        ...(session.ghostAttendance
-          ? { ghostAttendance: session.ghostAttendance }
-          : {}),
-        source: "plugin-meetings",
-      });
+      await this.runtime.emitEvent(MEETING_TRANSCRIPT_FINALIZED_EVENT, payload);
     } catch (err) {
       this.runtime.reportError("MeetingService.transcriptFinalizedEvent", err, {
         sessionId: session.id,

--- a/plugins/plugin-meetings/src/test-support.ts
+++ b/plugins/plugin-meetings/src/test-support.ts
@@ -38,6 +38,8 @@ export interface FakeRuntime {
   entities: Array<Record<string, unknown>>;
   broadcasts: object[];
   documents: Array<Record<string, unknown>>;
+  events: Array<{ event: string | string[]; payload: unknown }>;
+  reportedErrors: Array<{ scope: string; error: unknown; context?: unknown }>;
   settings: Record<string, string>;
 }
 
@@ -49,6 +51,12 @@ export function makeFakeRuntime(): FakeRuntime {
   const entities: Array<Record<string, unknown>> = [];
   const broadcasts: object[] = [];
   const documents: Array<Record<string, unknown>> = [];
+  const events: Array<{ event: string | string[]; payload: unknown }> = [];
+  const reportedErrors: Array<{
+    scope: string;
+    error: unknown;
+    context?: unknown;
+  }> = [];
   const settings: Record<string, string> = {};
 
   const connectorSetup = {
@@ -94,6 +102,12 @@ export function makeFakeRuntime(): FakeRuntime {
       memories.set(patch.id, { ...existing, ...patch });
       return true;
     },
+    emitEvent: async (event: string | string[], payload: unknown) => {
+      events.push({ event, payload });
+    },
+    reportError: (scope: string, error: unknown, context?: unknown) => {
+      reportedErrors.push({ scope, error, context });
+    },
   } as unknown as IAgentRuntime;
 
   return {
@@ -105,6 +119,8 @@ export function makeFakeRuntime(): FakeRuntime {
     entities,
     broadcasts,
     documents,
+    events,
+    reportedErrors,
     settings,
   };
 }

--- a/plugins/plugin-personal-assistant/src/lifeops/meeting-ghost/event-handler.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/meeting-ghost/event-handler.ts
@@ -1,0 +1,79 @@
+/**
+ * Runtime event bridge from finalized meeting transcripts into LifeOps
+ * post-meeting ownership.
+ *
+ * The meetings plugin owns capture and transcript persistence; this bridge owns
+ * interpreting an owner-skipped meeting into approvals and ledger rows when the
+ * join request supplied ghost-attendance context.
+ */
+import type { EventPayload, IAgentRuntime } from "@elizaos/core";
+import type {
+  MeetingGhostAttendanceContext,
+  MeetingTranscriptFinalizedPayload,
+} from "@elizaos/shared";
+import {
+  type RunMeetingGhostInput,
+  runMeetingGhostForTranscript,
+} from "./consumer.js";
+import type { MeetingGhostAttendee } from "./index.js";
+
+const DEFAULT_APPROVAL_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+type FinalizedMeetingEvent = EventPayload & MeetingTranscriptFinalizedPayload;
+
+function attendeeList(
+  ghostAttendance: MeetingGhostAttendanceContext,
+  payload: MeetingTranscriptFinalizedPayload,
+): MeetingGhostAttendee[] {
+  if (ghostAttendance.attendees && ghostAttendance.attendees.length > 0) {
+    return ghostAttendance.attendees.map((attendee) => ({
+      name: attendee.name,
+      ...(attendee.email ? { email: attendee.email } : {}),
+    }));
+  }
+  return payload.session.participants.map((participant) => ({
+    name: participant.displayName,
+  }));
+}
+
+export function meetingGhostInputFromFinalizedPayload(
+  runtime: IAgentRuntime,
+  payload: MeetingTranscriptFinalizedPayload,
+): RunMeetingGhostInput | null {
+  const ghostAttendance = payload.ghostAttendance;
+  if (!ghostAttendance) return null;
+
+  const approvalTtlMs =
+    ghostAttendance.approvalTtlMs && ghostAttendance.approvalTtlMs > 0
+      ? ghostAttendance.approvalTtlMs
+      : DEFAULT_APPROVAL_TTL_MS;
+
+  return {
+    agentId: runtime.agentId,
+    owner: {
+      ownerUserId: ghostAttendance.ownerUserId,
+      ownerDisplayName: ghostAttendance.ownerDisplayName,
+      requestedBy: ghostAttendance.requestedBy ?? ghostAttendance.ownerUserId,
+      careAbouts: ghostAttendance.careAbouts,
+      ...(ghostAttendance.calendarId
+        ? { calendarId: ghostAttendance.calendarId }
+        : {}),
+      approvalExpiresAt: new Date(Date.now() + approvalTtlMs),
+    },
+    transcript: {
+      meetingId: payload.session.id,
+      title: payload.transcript.title,
+      startedAt: new Date(payload.transcript.createdAt).toISOString(),
+      attendees: attendeeList(ghostAttendance, payload),
+      segments: payload.transcript.segments,
+    },
+  };
+}
+
+export async function handleMeetingTranscriptFinalized(
+  payload: FinalizedMeetingEvent,
+): Promise<void> {
+  const input = meetingGhostInputFromFinalizedPayload(payload.runtime, payload);
+  if (!input) return;
+  await runMeetingGhostForTranscript(payload.runtime, input);
+}

--- a/plugins/plugin-personal-assistant/src/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.ts
@@ -9,6 +9,7 @@
  * default packs into a runnable Eliza plugin; it owns no domain logic itself.
  */
 import {
+  type EventPayload,
   EventType,
   getDefaultTriageService,
   type IAgentRuntime,
@@ -52,10 +53,12 @@ import { remoteDesktopPlugin } from "@elizaos/plugin-remote-desktop";
 import { XDmAdapter } from "@elizaos/plugin-x/lifeops-message-adapter";
 import type {
   IPermissionsRegistry,
+  MeetingTranscriptFinalizedPayload,
   PermissionState,
   Platform,
   Prober,
 } from "@elizaos/shared";
+import { MEETING_TRANSCRIPT_FINALIZED_EVENT } from "@elizaos/shared";
 import { blockAction } from "./actions/block.js";
 import { briefAction } from "./actions/brief.js";
 import { calendarAction } from "./actions/calendar.js";
@@ -124,6 +127,7 @@ import {
   registerDefaultPromptPack,
   registerMultilingualPromptRegistry,
 } from "./lifeops/i18n/prompt-registry.js";
+import { handleMeetingTranscriptFinalized } from "./lifeops/meeting-ghost/event-handler.js";
 import {
   createOwnerSendPolicy,
   registerOwnerSendApprovalWorker,
@@ -769,6 +773,12 @@ const rawPersonalAssistantPlugin: Plugin = {
     _pluginConfig: Record<string, unknown>,
     runtime: IAgentRuntime,
   ) => {
+    runtime.registerEvent(MEETING_TRANSCRIPT_FINALIZED_EVENT, async (payload) =>
+      handleMeetingTranscriptFinalized(
+        payload as EventPayload & MeetingTranscriptFinalizedPayload,
+      ),
+    );
+
     // When LIFEOPS_USE_MOCKOON=1, redirect every external connector base URL
     // to the matching Mockoon environment on localhost. No-op otherwise.
     const mockoonApplied = applyMockoonEnvOverrides();

--- a/plugins/plugin-personal-assistant/test/meeting-ghost-event-handler.test.ts
+++ b/plugins/plugin-personal-assistant/test/meeting-ghost-event-handler.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Meeting-ghost event bridge tests.
+ *
+ * These keep the runtime event mapper root-Vitest friendly while the
+ * `.integration.test.ts` sibling proves the consumer writes real approval and
+ * ledger rows under PGlite.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import type { MeetingTranscriptFinalizedPayload } from "@elizaos/shared";
+import { describe, expect, it, vi } from "vitest";
+import { runMeetingGhostForTranscript } from "../src/lifeops/meeting-ghost/consumer.js";
+import {
+  handleMeetingTranscriptFinalized,
+  meetingGhostInputFromFinalizedPayload,
+} from "../src/lifeops/meeting-ghost/event-handler.js";
+
+vi.mock("../src/lifeops/meeting-ghost/consumer.js", () => ({
+  runMeetingGhostForTranscript: vi.fn(async () => ({
+    analysis: {
+      meetingId: "meeting-event-session",
+      decisions: [],
+      commitments: [],
+      commitmentLedgerRecords: [],
+      careHits: [],
+      followUpApprovals: [],
+      calendarIntents: [],
+      digestLines: [],
+    },
+    enqueued: [],
+    commitmentLedgerIds: [],
+  })),
+}));
+
+const startedAt = Date.parse("2026-07-06T16:00:00.000Z");
+
+function runtime(): IAgentRuntime {
+  return { agentId: "agent-1" } as IAgentRuntime;
+}
+
+function payload(
+  overrides: Partial<MeetingTranscriptFinalizedPayload> = {},
+): MeetingTranscriptFinalizedPayload {
+  return {
+    session: {
+      id: "meeting-event-session",
+      platform: "google_meet",
+      meetingUrl: "https://meet.google.com/abc-defg-hij",
+      nativeMeetingId: "abc-defg-hij",
+      botName: "Eliza Notetaker",
+      status: "ended",
+      requestedAt: startedAt - 60_000,
+      activeAt: startedAt,
+      endedAt: startedAt + 120_000,
+      transcriptId: "meeting-event-transcript",
+      participants: [{ id: "ava", displayName: "Ava" }],
+    },
+    transcript: {
+      id: "meeting-event-transcript",
+      title: "Ops Sync Event",
+      createdAt: startedAt,
+      durationMs: 120_000,
+      source: "meeting",
+      scope: "owner-private",
+      status: "ready",
+      speakerCount: 1,
+      segments: [
+        {
+          id: "s1",
+          speakerLabel: "Ava",
+          startMs: 60_000,
+          endMs: 68_000,
+          text: "Ava will send the launch-date rollback plan by 2026-07-10.",
+          words: [],
+        },
+      ],
+    },
+    ghostAttendance: {
+      ownerUserId: "owner-mtg-event",
+      ownerDisplayName: "Shaw",
+      requestedBy: "meeting-ghost-event",
+      careAbouts: ["launch date"],
+      calendarId: "primary",
+      approvalTtlMs: 24 * 60 * 60 * 1000,
+      attendees: [{ name: "Ava", email: "ava@example.com" }],
+    },
+    ...overrides,
+  };
+}
+
+describe("meeting ghost finalized transcript event bridge", () => {
+  it("maps finalized meeting payloads to the consumer input", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-06T17:00:00.000Z"));
+    const input = meetingGhostInputFromFinalizedPayload(runtime(), payload());
+
+    expect(input).toMatchObject({
+      agentId: "agent-1",
+      owner: {
+        ownerUserId: "owner-mtg-event",
+        ownerDisplayName: "Shaw",
+        requestedBy: "meeting-ghost-event",
+        careAbouts: ["launch date"],
+        calendarId: "primary",
+        approvalExpiresAt: new Date("2026-07-07T17:00:00.000Z"),
+      },
+      transcript: {
+        meetingId: "meeting-event-session",
+        title: "Ops Sync Event",
+        startedAt: "2026-07-06T16:00:00.000Z",
+        attendees: [{ name: "Ava", email: "ava@example.com" }],
+      },
+    });
+    expect(input?.transcript.segments).toHaveLength(1);
+    vi.useRealTimers();
+  });
+
+  it("falls back to roster names when ghost context has no attendee emails", () => {
+    const input = meetingGhostInputFromFinalizedPayload(
+      runtime(),
+      payload({
+        ghostAttendance: {
+          ownerUserId: "owner-mtg-event",
+          ownerDisplayName: "Shaw",
+          careAbouts: [],
+        },
+      }),
+    );
+
+    expect(input?.owner.requestedBy).toBe("owner-mtg-event");
+    expect(input?.transcript.attendees).toEqual([{ name: "Ava" }]);
+  });
+
+  it("does nothing when a finalized transcript has no ghost-attendance context", async () => {
+    const run = vi.mocked(runMeetingGhostForTranscript);
+    run.mockClear();
+
+    await handleMeetingTranscriptFinalized({
+      runtime: runtime(),
+      source: "test",
+      ...payload({ ghostAttendance: undefined }),
+    });
+
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("passes mapped input to the consumer", async () => {
+    const run = vi.mocked(runMeetingGhostForTranscript);
+    run.mockClear();
+
+    await handleMeetingTranscriptFinalized({
+      runtime: runtime(),
+      source: "test",
+      ...payload(),
+    });
+
+    expect(run).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "agent-1" }),
+      expect.objectContaining({
+        agentId: "agent-1",
+        transcript: expect.objectContaining({
+          meetingId: "meeting-event-session",
+        }),
+      }),
+    );
+  });
+});

--- a/plugins/plugin-personal-assistant/test/meeting-ghost.integration.test.ts
+++ b/plugins/plugin-personal-assistant/test/meeting-ghost.integration.test.ts
@@ -17,10 +17,7 @@ import { join } from "node:path";
 import type { AgentRuntime } from "@elizaos/core";
 import { AgentEventService } from "@elizaos/core";
 import { schedulingPlugin } from "@elizaos/plugin-scheduling";
-import {
-  MEETING_TRANSCRIPT_FINALIZED_EVENT,
-  type TranscriptSegment,
-} from "@elizaos/shared";
+import type { TranscriptSegment } from "@elizaos/shared";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createRealTestRuntime } from "../../../packages/test/helpers/real-runtime.ts";
 import { createApprovalQueue } from "../src/lifeops/approval-queue.js";
@@ -109,87 +106,6 @@ afterAll(async () => {
 });
 
 describe("meeting-ghost consumer (real approval queue)", () => {
-  it("runs from the finalized meeting transcript runtime event", async () => {
-    await runtime.emitEvent(MEETING_TRANSCRIPT_FINALIZED_EVENT, {
-      session: {
-        id: "meeting-event-session",
-        platform: "google_meet",
-        meetingUrl: "https://meet.google.com/abc-defg-hij",
-        nativeMeetingId: "abc-defg-hij",
-        botName: "Eliza Notetaker",
-        status: "ended",
-        requestedAt: Date.parse("2026-07-06T15:59:00.000Z"),
-        activeAt: Date.parse("2026-07-06T16:00:00.000Z"),
-        endedAt: Date.parse("2026-07-06T16:30:00.000Z"),
-        transcriptId: "meeting-event-transcript",
-        participants: [{ id: "ava", displayName: "Ava" }],
-      },
-      transcript: {
-        id: "meeting-event-transcript",
-        title: "Ops Sync Event",
-        createdAt: Date.parse("2026-07-06T16:00:00.000Z"),
-        durationMs: 120_000,
-        source: "meeting",
-        scope: "owner-private",
-        status: "ready",
-        speakerCount: 1,
-        metadata: {
-          sessionId: "meeting-event-session",
-          platform: "google_meet",
-          meetingUrl: "https://meet.google.com/abc-defg-hij",
-          nativeMeetingId: "abc-defg-hij",
-          participants: [],
-        },
-        segments: [
-          seg(
-            "Ava",
-            60_000,
-            "Ava will send the launch-date rollback plan by 2026-07-10.",
-          ),
-        ],
-      },
-      ghostAttendance: {
-        ownerUserId: "owner-mtg-event",
-        ownerDisplayName: "Shaw",
-        requestedBy: "meeting-ghost-event",
-        careAbouts: ["launch date"],
-        calendarId: "primary",
-        approvalTtlMs: 24 * 60 * 60 * 1000,
-        attendees: [{ name: "Ava", email: "ava@example.com" }],
-      },
-    });
-
-    const pending = await queue.list({
-      subjectUserId: "owner-mtg-event",
-      state: "pending",
-      action: null,
-      limit: 20,
-    });
-    expect(pending.map((request) => request.action).sort()).toEqual([
-      "schedule_event",
-      "send_email",
-    ]);
-
-    const repo = new LifeOpsRepository(runtime);
-    const ledgerRows = await repo.listCommitmentLedgerRecords(runtime.agentId, {
-      source: "transcript",
-    });
-    const eventRows = ledgerRows.filter((row) =>
-      row.sourceKey.startsWith("meeting-event-session:"),
-    );
-    expect(eventRows).toHaveLength(1);
-    expect(eventRows[0]).toMatchObject({
-      counterparty: "Ava",
-      dueAt: "2026-07-10T17:00:00.000Z",
-      summary: "send the launch-date rollback plan",
-      metadata: expect.objectContaining({
-        meetingId: "meeting-event-session",
-        meetingTitle: "Ops Sync Event",
-        recipientEmail: "ava@example.com",
-      }),
-    });
-  });
-
   it("enqueues follow-up + calendar approvals from a diarized transcript, resolvable by the owner", async () => {
     const approvalExpiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
     const result = await runMeetingGhostForTranscript(runtime, {

--- a/plugins/plugin-personal-assistant/test/meeting-ghost.integration.test.ts
+++ b/plugins/plugin-personal-assistant/test/meeting-ghost.integration.test.ts
@@ -17,7 +17,10 @@ import { join } from "node:path";
 import type { AgentRuntime } from "@elizaos/core";
 import { AgentEventService } from "@elizaos/core";
 import { schedulingPlugin } from "@elizaos/plugin-scheduling";
-import type { TranscriptSegment } from "@elizaos/shared";
+import {
+  MEETING_TRANSCRIPT_FINALIZED_EVENT,
+  type TranscriptSegment,
+} from "@elizaos/shared";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createRealTestRuntime } from "../../../packages/test/helpers/real-runtime.ts";
 import { createApprovalQueue } from "../src/lifeops/approval-queue.js";
@@ -106,6 +109,87 @@ afterAll(async () => {
 });
 
 describe("meeting-ghost consumer (real approval queue)", () => {
+  it("runs from the finalized meeting transcript runtime event", async () => {
+    await runtime.emitEvent(MEETING_TRANSCRIPT_FINALIZED_EVENT, {
+      session: {
+        id: "meeting-event-session",
+        platform: "google_meet",
+        meetingUrl: "https://meet.google.com/abc-defg-hij",
+        nativeMeetingId: "abc-defg-hij",
+        botName: "Eliza Notetaker",
+        status: "ended",
+        requestedAt: Date.parse("2026-07-06T15:59:00.000Z"),
+        activeAt: Date.parse("2026-07-06T16:00:00.000Z"),
+        endedAt: Date.parse("2026-07-06T16:30:00.000Z"),
+        transcriptId: "meeting-event-transcript",
+        participants: [{ id: "ava", displayName: "Ava" }],
+      },
+      transcript: {
+        id: "meeting-event-transcript",
+        title: "Ops Sync Event",
+        createdAt: Date.parse("2026-07-06T16:00:00.000Z"),
+        durationMs: 120_000,
+        source: "meeting",
+        scope: "owner-private",
+        status: "ready",
+        speakerCount: 1,
+        metadata: {
+          sessionId: "meeting-event-session",
+          platform: "google_meet",
+          meetingUrl: "https://meet.google.com/abc-defg-hij",
+          nativeMeetingId: "abc-defg-hij",
+          participants: [],
+        },
+        segments: [
+          seg(
+            "Ava",
+            60_000,
+            "Ava will send the launch-date rollback plan by 2026-07-10.",
+          ),
+        ],
+      },
+      ghostAttendance: {
+        ownerUserId: "owner-mtg-event",
+        ownerDisplayName: "Shaw",
+        requestedBy: "meeting-ghost-event",
+        careAbouts: ["launch date"],
+        calendarId: "primary",
+        approvalTtlMs: 24 * 60 * 60 * 1000,
+        attendees: [{ name: "Ava", email: "ava@example.com" }],
+      },
+    });
+
+    const pending = await queue.list({
+      subjectUserId: "owner-mtg-event",
+      state: "pending",
+      action: null,
+      limit: 20,
+    });
+    expect(pending.map((request) => request.action).sort()).toEqual([
+      "schedule_event",
+      "send_email",
+    ]);
+
+    const repo = new LifeOpsRepository(runtime);
+    const ledgerRows = await repo.listCommitmentLedgerRecords(runtime.agentId, {
+      source: "transcript",
+    });
+    const eventRows = ledgerRows.filter((row) =>
+      row.sourceKey.startsWith("meeting-event-session:"),
+    );
+    expect(eventRows).toHaveLength(1);
+    expect(eventRows[0]).toMatchObject({
+      counterparty: "Ava",
+      dueAt: "2026-07-10T17:00:00.000Z",
+      summary: "send the launch-date rollback plan",
+      metadata: expect.objectContaining({
+        meetingId: "meeting-event-session",
+        meetingTitle: "Ops Sync Event",
+        recipientEmail: "ava@example.com",
+      }),
+    });
+  });
+
   it("enqueues follow-up + calendar approvals from a diarized transcript, resolvable by the owner", async () => {
     const approvalExpiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
     const result = await runMeetingGhostForTranscript(runtime, {


### PR DESCRIPTION
## Summary
- add a shared `meeting.transcript.finalized` runtime event contract and optional `ghostAttendance` context on meeting join requests
- emit the finalized transcript event after `MeetingService` successfully finalizes a ready meeting transcript
- register a LifeOps event bridge that maps finalized meeting transcripts into the existing meeting-ghost consumer, creating owner approval requests and commitment-ledger rows
- add deterministic service event coverage plus root-compatible LifeOps event-mapper coverage; the existing PGlite meeting-ghost integration test continues to prove approval and ledger persistence

Fixes part of #14870.

## Verification
- `bunx vitest run plugins/plugin-personal-assistant/test/meeting-ghost-event-handler.test.ts --coverage --coverage.reporter=lcov --coverage.reportsDirectory=coverage/vitest` - passed
- `bunx @biomejs/biome check packages/shared/src/meetings.ts plugins/plugin-meetings/src/service.ts plugins/plugin-meetings/src/service.test.ts plugins/plugin-meetings/src/test-support.ts plugins/plugin-personal-assistant/src/lifeops/meeting-ghost/event-handler.ts plugins/plugin-personal-assistant/src/plugin.ts plugins/plugin-personal-assistant/test/meeting-ghost-event-handler.test.ts plugins/plugin-personal-assistant/test/meeting-ghost.integration.test.ts` - passed
- `git diff --check` - passed
- `bun run audit:error-policy-ratchet` - passed
- `node packages/shared/scripts/generate-keywords.mjs --target ts` - generated missing ignored keyword data required by local Vitest imports
- attempted `bun run --cwd plugins/plugin-meetings test -- src/service.test.ts` - blocked locally by incomplete workspace install: missing `uuid` from `@elizaos/core`
- attempted `bunx vitest run plugins/plugin-meetings/src/service.test.ts plugins/plugin-personal-assistant/test/meeting-ghost-event-handler.test.ts --coverage --coverage.reporter=lcov --coverage.reportsDirectory=coverage/vitest` - LifeOps handler test passed; meeting-service import blocked locally by incomplete workspace install: missing `uuid` while loading `@elizaos/core`
- attempted `ELIZA_SKIP_ARTIFACT_SYNC=1 bun install --frozen-lockfile --ignore-scripts` - blocked because current develop manifests and `bun.lock` are out of sync; no source files changed

## Evidence
<!-- evidence-row:before-screenshots -->
Before screenshots: N/A - backend/runtime event wiring and LifeOps persistence path only; no rendered UI changed.

<!-- evidence-row:after-screenshots -->
After screenshots: N/A - no app, web, native, CSS, or visual asset files changed.

<!-- evidence-row:walkthrough-video -->
Walkthrough video: N/A - no user-facing UI flow changed in this slice; runtime behavior is covered by service event and LifeOps event-bridge tests.

<!-- evidence-row:backend-logs -->
Backend logs: N/A - no backend server was started for this non-route slice. Test logs above prove the deterministic LifeOps bridge locally; CI coverage logs cover the clean-install service event test.

<!-- evidence-row:frontend-logs -->
Frontend console/network logs: N/A - no frontend route/component/network behavior changed.

<!-- evidence-row:llm-trajectory -->
Real-LLM trajectory: N/A - deterministic event bridge: no prompt/model/action selection changed. The remaining #14870 live-LLM meeting scenarios still need credentials and live meeting capture evidence before closing the issue.

<!-- evidence-row:domain-artifacts -->
Domain artifacts: N/A - local persistent artifact capture for the event bridge is represented by the existing PGlite meeting-ghost consumer integration test; this PR adds the missing finalized-transcript-to-consumer mapper coverage without adding a second scheduling or persistence path.

## Notes
- This does not close #14870. Remaining acceptance still needs live bot meeting ingestion/transcript screenshots, live WebSocket frames, and hand-reviewed live approval/calendar artifacts.
