### PR TITLE
fix(hitl): lock layered secrets precedence

### DIFF
--- a/scripts/lifeops/collect-11632-live-validation-status.mjs
+++ b/scripts/lifeops/collect-11632-live-validation-status.mjs
@@ -10,8 +10,8 @@
  * derives its model gate from the model group), so the CLI body only runs when
  * this file is the entrypoint (import.meta.main). As an entrypoint it hydrates
  * process.env from the layered load shared with the HITL dashboard and lane
- * driver (env-layers.mjs: process.env > repo .env > main-checkout .env >
- * ~/.eliza/.env), so all three surfaces report the same readiness. The HITL
+ * driver (env-layers.mjs: process.env > repo .env > ~/.eliza/.env), so all
+ * three surfaces report the same readiness. The HITL
  * dashboard renders per-auth-path rows from connector-paths.mjs instead.
  */
 import { spawnSync } from "node:child_process";

--- a/scripts/lifeops/env-layers.mjs
+++ b/scripts/lifeops/env-layers.mjs
@@ -1,10 +1,9 @@
 #!/usr/bin/env node
 /**
  * Layered .env resolution for the LifeOps HITL credential tooling (#11632).
- * Credentials can live in four places on an operator machine, and this module
- * is the single arbiter of which one wins: process.env > the checkout's own
- * .env > the main checkout's .env (only when running inside a linked git
- * worktree — discovered via `git rev-parse --git-common-dir`) > ~/.eliza/.env.
+ * Credentials can live in three places on an operator machine, and this module
+ * is the single arbiter of which one wins: process.env > the current repo's
+ * .env > ~/.eliza/.env.
  * The HITL dashboard and lane drivers consume loadLayeredEnv()/listPresent()
  * so a probe sees the same value a paste-and-save produced, no matter which
  * worktree the operator happens to be in.
@@ -18,7 +17,6 @@
  * display-safe surface is listPresent(), which only reports presence and the
  * winning source layer.
  */
-import { spawnSync } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
@@ -36,7 +34,7 @@ const ROOT = resolve(new URL("../..", import.meta.url).pathname);
 export const HOME_ENV_PATH = join(homedir(), ".eliza", ".env");
 
 /** Precedence order, highest first; the values of the `sources` map. */
-export const ENV_LAYER_SOURCES = ["process", "repo", "main", "home"];
+export const ENV_LAYER_SOURCES = ["process", "repo", "home"];
 
 const ENV_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
@@ -117,62 +115,18 @@ export function upsertEnvContent(existingText, entries) {
 }
 
 /**
- * Decide whether a checkout is a linked git worktree from the raw
- * `git rev-parse --git-dir --git-common-dir` outputs. In a linked worktree the
- * git dir is `<main>/.git/worktrees/<name>` while the common dir is
- * `<main>/.git`, so when the two resolve differently the main checkout root is
- * the parent of the common dir. In the main checkout both resolve to the same
- * `.git`, and this returns null (the "main" layer is simply absent).
- */
-export function resolveMainCheckoutRoot({
-  gitDir,
-  gitCommonDir,
-  worktreeRoot,
-}) {
-  if (!gitDir || !gitCommonDir) return null;
-  const resolvedGitDir = resolve(worktreeRoot, gitDir);
-  const resolvedCommonDir = resolve(worktreeRoot, gitCommonDir);
-  if (resolvedGitDir === resolvedCommonDir) return null;
-  return dirname(resolvedCommonDir);
-}
-
-// --- filesystem/git boundary ---------------------------------------------------
-
-/**
- * Discover the main checkout root for a linked worktree, or null when the
- * directory is the main checkout itself or not a git checkout at all. rev-parse
- * failures (git missing, not a repo) intentionally read as "no main layer"
- * rather than an error: the layered load degrades to repo + home.
- */
-export function discoverMainCheckoutRoot(worktreeRoot = ROOT) {
-  const result = spawnSync(
-    "git",
-    ["rev-parse", "--git-dir", "--git-common-dir"],
-    {
-      cwd: worktreeRoot,
-      encoding: "utf8",
-      timeout: 10_000,
-    },
-  );
-  if (result.error || result.status !== 0) return null;
-  const [gitDir, gitCommonDir] = result.stdout.trim().split(/\r?\n/);
-  return resolveMainCheckoutRoot({ gitDir, gitCommonDir, worktreeRoot });
-}
-
-/**
  * Load and merge every env layer. Returns:
  *   values  — merged KEY -> value (real secrets; never render these),
- *   sources — KEY -> 'process' | 'repo' | 'main' | 'home' (winning layer),
+ *   sources — KEY -> 'process' | 'repo' | 'home' (winning layer),
  *   layers  — [{ source, path, exists }] for display ("loaded from ...").
  * All roots/paths are injectable for tests; by default the repo root is this
- * checkout and the main root is git-discovered.
+ * checkout.
  */
 export function loadLayeredEnv(options = {}) {
   const {
     processEnv = process.env,
     repoRoot = ROOT,
     homeEnvPath = HOME_ENV_PATH,
-    mainRoot = discoverMainCheckoutRoot(options.repoRoot ?? ROOT),
   } = options;
   const filePaths = [];
   const pushUnique = (source, path) => {
@@ -181,9 +135,6 @@ export function loadLayeredEnv(options = {}) {
     }
   };
   pushUnique("repo", join(repoRoot, ".env"));
-  if (mainRoot && resolve(mainRoot) !== resolve(repoRoot)) {
-    pushUnique("main", join(mainRoot, ".env"));
-  }
   pushUnique("home", homeEnvPath);
   const layers = [
     { source: "process", path: null, exists: true, values: processEnv },
@@ -255,35 +206,41 @@ function atomicWriteEnvFile(path, content) {
 }
 
 /**
- * Upsert one KEY=value into the chosen layer file — 'home' (~/.eliza/.env,
- * created on first save; the default because it survives worktree churn) or
- * 'repo' (this checkout's .env). Atomic tmp+rename write, mode 600. Also sets
- * the key on processEnv so probes running in the same process observe the save
- * immediately. Values must be single-line; multi-line values would corrupt the
- * dotenv format and are rejected.
+ * Upsert one KEY=value into the chosen layer file — scope 'home'
+ * (~/.eliza/.env, created on first save; the default because it survives
+ * worktree churn) or 'repo' (this checkout's .env). Atomic tmp+rename write,
+ * mode 600. Also sets the key on processEnv so probes running in the same
+ * process observe the save immediately. Values must be single-line; multi-line
+ * values would corrupt the dotenv format and are rejected.
  */
-export function saveEnvVar(key, value, target = "home", options = {}) {
+export function writeSecret(key, value, options = {}) {
   const {
+    scope = "home",
     repoRoot = ROOT,
     homeEnvPath = HOME_ENV_PATH,
     processEnv = process.env,
   } = options;
   if (typeof key !== "string" || !ENV_KEY_PATTERN.test(key)) {
-    throw new Error(`saveEnvVar: invalid env key ${JSON.stringify(key)}`);
+    throw new Error(`writeSecret: invalid env key ${JSON.stringify(key)}`);
   }
   if (typeof value !== "string" || /[\r\n]/.test(value)) {
-    throw new Error(`saveEnvVar(${key}): value must be a single-line string`);
+    throw new Error(`writeSecret(${key}): value must be a single-line string`);
   }
-  if (target !== "home" && target !== "repo") {
+  if (scope !== "home" && scope !== "repo") {
     throw new Error(
-      `saveEnvVar(${key}): target must be "home" or "repo", got ${JSON.stringify(target)}`,
+      `writeSecret(${key}): scope must be "home" or "repo", got ${JSON.stringify(scope)}`,
     );
   }
-  const path = target === "home" ? homeEnvPath : join(repoRoot, ".env");
+  const path = scope === "home" ? homeEnvPath : join(repoRoot, ".env");
   const existing = existsSync(path) ? readFileSync(path, "utf8") : "";
   atomicWriteEnvFile(path, upsertEnvContent(existing, { [key]: value }));
   processEnv[key] = value;
-  return { key, target, path };
+  return { key, scope, path };
+}
+
+export function saveEnvVar(key, value, target = "home", options = {}) {
+  const saved = writeSecret(key, value, { ...options, scope: target });
+  return { key: saved.key, target: saved.scope, path: saved.path };
 }
 
 // --- CLI: presence/source inspection (never prints values) -------------------

--- a/scripts/lifeops/env-layers.test.mjs
+++ b/scripts/lifeops/env-layers.test.mjs
@@ -1,8 +1,8 @@
 /**
  * Unit tests for layered .env resolution: pure parse/merge/upsert primitives,
- * real-filesystem load/save against temp dirs (mode 600 asserted), and real
- * git worktree discovery against a throwaway repo + linked worktree created in
- * a temp dir — no mocks of git or fs.
+ * real-filesystem load/save against temp dirs (mode 600 asserted), and a real
+ * linked-worktree fixture proving an empty worktree .env falls through to the
+ * home-scoped layer.
  */
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
@@ -16,19 +16,20 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import test from "node:test";
 import {
   applyLayeredEnvToProcess,
-  discoverMainCheckoutRoot,
   listPresent,
   loadLayeredEnv,
   mergeEnvLayers,
   parseDotenv,
-  resolveMainCheckoutRoot,
   saveEnvVar,
   upsertEnvContent,
+  writeSecret,
 } from "./env-layers.mjs";
+
+const ROOT = resolve(new URL("../..", import.meta.url).pathname);
 
 // realpath so git-canonicalized paths (macOS /var -> /private/var) compare equal.
 function tempDir(prefix) {
@@ -77,20 +78,19 @@ test("mergeEnvLayers: first (highest-precedence) definition wins, sources attrib
   const { values, sources } = mergeEnvLayers([
     { source: "process", values: { A: "proc", EMPTYWIN: "" } },
     { source: "repo", values: { A: "repo", B: "repo", EMPTYWIN: "file" } },
-    { source: "main", values: { B: "main", C: "main" } },
     { source: "home", values: { C: "home", D: "home", SKIPPED: undefined } },
   ]);
   assert.deepEqual(values, {
     A: "proc",
     B: "repo",
-    C: "main",
+    C: "home",
     D: "home",
     EMPTYWIN: "",
   });
   assert.deepEqual(sources, {
     A: "process",
     B: "repo",
-    C: "main",
+    C: "home",
     D: "home",
     EMPTYWIN: "process",
   });
@@ -129,93 +129,36 @@ test("upsertEnvContent on empty text emits just the entries", () => {
   assert.equal(upsertEnvContent("", { A: "1" }), "A=1\n");
 });
 
-// --- worktree discovery -----------------------------------------------------------
-
-test("resolveMainCheckoutRoot: same git dir means no main layer", () => {
-  assert.equal(
-    resolveMainCheckoutRoot({
-      gitDir: ".git",
-      gitCommonDir: ".git",
-      worktreeRoot: "/repo",
-    }),
-    null,
-  );
-});
-
-test("resolveMainCheckoutRoot: linked worktree resolves to common dir parent", () => {
-  assert.equal(
-    resolveMainCheckoutRoot({
-      gitDir: "/main/.git/worktrees/wt",
-      gitCommonDir: "/main/.git",
-      worktreeRoot: "/main/.claude/worktrees/wt",
-    }),
-    "/main",
-  );
-});
-
-test("discoverMainCheckoutRoot against a real repo + linked worktree", () => {
-  const base = tempDir("env-layers-git-");
-  try {
-    const mainRoot = join(base, "main");
-    const wtRoot = join(base, "wt");
-    git(base, ["init", "-b", "main", "main"]);
-    writeFileSync(join(mainRoot, "seed.txt"), "seed\n");
-    git(mainRoot, ["add", "seed.txt"]);
-    git(mainRoot, [
-      "-c",
-      "user.email=test@example.com",
-      "-c",
-      "user.name=Test",
-      "commit",
-      "-m",
-      "seed",
-    ]);
-    git(mainRoot, ["worktree", "add", wtRoot]);
-
-    assert.equal(discoverMainCheckoutRoot(wtRoot), mainRoot);
-    assert.equal(discoverMainCheckoutRoot(mainRoot), null);
-    assert.equal(discoverMainCheckoutRoot(base), null);
-  } finally {
-    rmSync(base, { recursive: true, force: true });
-  }
-});
-
 // --- loadLayeredEnv / listPresent ---------------------------------------------------
 
-test("loadLayeredEnv merges process > repo > main > home and reports layers", () => {
+test("loadLayeredEnv merges process > repo > home and reports layers", () => {
   const base = tempDir("env-layers-load-");
   try {
     const repoRoot = join(base, "repo");
-    const mainRoot = join(base, "main");
     const homeEnvPath = join(base, "home", ".eliza", ".env");
-    for (const dir of [repoRoot, mainRoot, join(base, "home", ".eliza")]) {
+    for (const dir of [repoRoot, join(base, "home", ".eliza")]) {
       mkdirSync(dir, { recursive: true });
     }
     writeFileSync(join(repoRoot, ".env"), "A=repo\nB=repo\n");
-    writeFileSync(join(mainRoot, ".env"), "B=main\nC=main\n");
-    writeFileSync(homeEnvPath, "C=home\nD=home\n");
+    writeFileSync(homeEnvPath, "B=home\nC=home\n");
     const { values, sources, layers } = loadLayeredEnv({
       processEnv: { A: "proc" },
       repoRoot,
-      mainRoot,
       homeEnvPath,
     });
     assert.equal(values.A, "proc");
     assert.equal(values.B, "repo");
-    assert.equal(values.C, "main");
-    assert.equal(values.D, "home");
+    assert.equal(values.C, "home");
     assert.deepEqual(sources, {
       A: "process",
       B: "repo",
-      C: "main",
-      D: "home",
+      C: "home",
     });
     assert.deepEqual(
       layers.map((layer) => [layer.source, layer.exists]),
       [
         ["process", true],
         ["repo", true],
-        ["main", true],
         ["home", true],
       ],
     );
@@ -224,7 +167,7 @@ test("loadLayeredEnv merges process > repo > main > home and reports layers", ()
   }
 });
 
-test("loadLayeredEnv: absent main layer and missing files are graceful", () => {
+test("loadLayeredEnv: missing files are graceful", () => {
   const base = tempDir("env-layers-absent-");
   try {
     const repoRoot = join(base, "repo");
@@ -232,7 +175,6 @@ test("loadLayeredEnv: absent main layer and missing files are graceful", () => {
     const { values, sources, layers } = loadLayeredEnv({
       processEnv: {},
       repoRoot,
-      mainRoot: null,
       homeEnvPath: join(base, "nonexistent", ".env"),
     });
     assert.deepEqual(values, {});
@@ -244,25 +186,6 @@ test("loadLayeredEnv: absent main layer and missing files are graceful", () => {
     assert.equal(
       layers.every((layer) => layer.source === "process" || !layer.exists),
       true,
-    );
-  } finally {
-    rmSync(base, { recursive: true, force: true });
-  }
-});
-
-test("loadLayeredEnv skips the main layer when it equals the repo root", () => {
-  const base = tempDir("env-layers-samepath-");
-  try {
-    writeFileSync(join(base, ".env"), "A=here\n");
-    const { layers } = loadLayeredEnv({
-      processEnv: {},
-      repoRoot: base,
-      mainRoot: base,
-      homeEnvPath: join(base, "no-home.env"),
-    });
-    assert.deepEqual(
-      layers.map((layer) => layer.source),
-      ["process", "repo", "home"],
     );
   } finally {
     rmSync(base, { recursive: true, force: true });
@@ -281,7 +204,6 @@ test("applyLayeredEnvToProcess hydrates only keys the process does not define", 
     const loaded = applyLayeredEnvToProcess({
       processEnv,
       repoRoot,
-      mainRoot: null,
       homeEnvPath,
     });
     assert.equal(processEnv.FROM_REPO, "repo");
@@ -295,37 +217,64 @@ test("applyLayeredEnvToProcess hydrates only keys the process does not define", 
   }
 });
 
-test("listPresent attributes each of the four sources and never returns values", () => {
+test("fresh linked worktree with empty repo .env uses home-scoped secrets, not main checkout .env", () => {
+  const base = tempDir("env-layers-worktree-home-");
+  try {
+    const mainRoot = join(base, "main");
+    const wtRoot = join(base, "wt");
+    const homeEnvPath = join(base, "home", ".eliza", ".env");
+    git(base, ["init", "-b", "main", "main"]);
+    writeFileSync(join(mainRoot, "seed.txt"), "seed\n");
+    writeFileSync(join(mainRoot, ".env"), "TOKEN=stale-main\n");
+    git(mainRoot, ["add", "seed.txt"]);
+    git(mainRoot, [
+      "-c",
+      "user.email=test@example.com",
+      "-c",
+      "user.name=Test",
+      "commit",
+      "-m",
+      "seed",
+    ]);
+    git(mainRoot, ["worktree", "add", wtRoot]);
+    mkdirSync(dirname(homeEnvPath), { recursive: true });
+    writeFileSync(homeEnvPath, "TOKEN=home-secret\n");
+
+    const loaded = loadLayeredEnv({
+      processEnv: {},
+      repoRoot: wtRoot,
+      homeEnvPath,
+    });
+    assert.equal(loaded.values.TOKEN, "home-secret");
+    assert.equal(loaded.sources.TOKEN, "home");
+    assert.deepEqual(
+      loaded.layers.map((layer) => layer.source),
+      ["process", "repo", "home"],
+    );
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("listPresent attributes each source and never returns values", () => {
   const base = tempDir("env-layers-present-");
   try {
     const repoRoot = join(base, "repo");
-    const mainRoot = join(base, "main");
     const homeEnvPath = join(base, "home.env");
     mkdirSync(repoRoot, { recursive: true });
-    mkdirSync(mainRoot, { recursive: true });
     writeFileSync(join(repoRoot, ".env"), "FROM_REPO=secret-repo\nEMPTYVAL=\n");
-    writeFileSync(join(mainRoot, ".env"), "FROM_MAIN=secret-main\n");
     writeFileSync(homeEnvPath, "FROM_HOME=secret-home\n");
     const rows = listPresent(
-      [
-        "FROM_PROC",
-        "FROM_REPO",
-        "FROM_MAIN",
-        "FROM_HOME",
-        "EMPTYVAL",
-        "ABSENT",
-      ],
+      ["FROM_PROC", "FROM_REPO", "FROM_HOME", "EMPTYVAL", "ABSENT"],
       {
         processEnv: { FROM_PROC: "secret-proc" },
         repoRoot,
-        mainRoot,
         homeEnvPath,
       },
     );
     assert.deepEqual(rows, [
       { name: "FROM_PROC", present: true, source: "process" },
       { name: "FROM_REPO", present: true, source: "repo" },
-      { name: "FROM_MAIN", present: true, source: "main" },
       { name: "FROM_HOME", present: true, source: "home" },
       { name: "EMPTYVAL", present: false, source: "repo" },
       { name: "ABSENT", present: false, source: null },
@@ -338,18 +287,19 @@ test("listPresent attributes each of the four sources and never returns values",
 
 // --- saveEnvVar -----------------------------------------------------------------------
 
-test("saveEnvVar creates the home file with mode 600 and upserts on re-save", () => {
+test("writeSecret creates the home file with mode 600 and upserts on re-save", () => {
   const base = tempDir("env-layers-save-");
   try {
     const homeEnvPath = join(base, ".eliza", ".env");
     const processEnv = {};
-    const first = saveEnvVar("NEW_TOKEN", "tok-1", "home", {
+    const first = writeSecret("NEW_TOKEN", "tok-1", {
+      scope: "home",
       homeEnvPath,
       processEnv,
     });
     assert.deepEqual(first, {
       key: "NEW_TOKEN",
-      target: "home",
+      scope: "home",
       path: homeEnvPath,
     });
     assert.equal(readFileSync(homeEnvPath, "utf8"), "NEW_TOKEN=tok-1\n");
@@ -357,7 +307,11 @@ test("saveEnvVar creates the home file with mode 600 and upserts on re-save", ()
     assert.equal(processEnv.NEW_TOKEN, "tok-1");
 
     writeFileSync(homeEnvPath, "# note\nNEW_TOKEN=tok-1\nOTHER=keep\n");
-    saveEnvVar("NEW_TOKEN", "tok-2", "home", { homeEnvPath, processEnv });
+    writeSecret("NEW_TOKEN", "tok-2", {
+      scope: "home",
+      homeEnvPath,
+      processEnv,
+    });
     assert.equal(
       readFileSync(homeEnvPath, "utf8"),
       "# note\nNEW_TOKEN=tok-2\nOTHER=keep\n",
@@ -368,11 +322,12 @@ test("saveEnvVar creates the home file with mode 600 and upserts on re-save", ()
   }
 });
 
-test("saveEnvVar writes the repo layer when targeted", () => {
+test("writeSecret writes the repo layer when scoped", () => {
   const base = tempDir("env-layers-save-repo-");
   try {
     const processEnv = {};
-    const result = saveEnvVar("REPO_ONLY", "x", "repo", {
+    const result = writeSecret("REPO_ONLY", "x", {
+      scope: "repo",
       repoRoot: base,
       processEnv,
     });
@@ -383,23 +338,58 @@ test("saveEnvVar writes the repo layer when targeted", () => {
   }
 });
 
-test("saveEnvVar rejects invalid keys, multi-line values, and bad targets", () => {
+test("saveEnvVar remains a compatibility wrapper for existing dashboard callers", () => {
+  const base = tempDir("env-layers-save-wrapper-");
+  try {
+    const processEnv = {};
+    const result = saveEnvVar("WRAPPED", "x", "repo", {
+      repoRoot: base,
+      processEnv,
+    });
+    assert.deepEqual(result, {
+      key: "WRAPPED",
+      target: "repo",
+      path: join(base, ".env"),
+    });
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("writeSecret rejects invalid keys, multi-line values, and bad scopes", () => {
   const base = tempDir("env-layers-save-bad-");
   try {
     const options = { homeEnvPath: join(base, ".env"), processEnv: {} };
     assert.throws(
-      () => saveEnvVar("bad key", "v", "home", options),
+      () => writeSecret("bad key", "v", options),
       /invalid env key/,
     );
     assert.throws(
-      () => saveEnvVar("GOOD_KEY", "a\nb", "home", options),
+      () => writeSecret("GOOD_KEY", "a\nb", options),
       /single-line/,
     );
     assert.throws(
-      () => saveEnvVar("GOOD_KEY", "v", "elsewhere", options),
-      /target/,
+      () => writeSecret("GOOD_KEY", "v", { ...options, scope: "elsewhere" }),
+      /scope/,
     );
   } finally {
     rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("HITL dashboard, lane driver, collector, and tests import the shared layered env module", () => {
+  const importers = [
+    "scripts/lifeops/hitl-credential-dashboard.mjs",
+    "scripts/lifeops/run-11632-live-lanes.mjs",
+    "scripts/lifeops/collect-11632-live-validation-status.mjs",
+    "scripts/lifeops/env-layers.test.mjs",
+  ];
+  for (const relativePath of importers) {
+    const text = readFileSync(join(ROOT, relativePath), "utf8");
+    assert.match(
+      text,
+      /from "\.\/env-layers\.mjs"/,
+      `${relativePath} must import scripts/lifeops/env-layers.mjs`,
+    );
   }
 });

--- a/scripts/lifeops/hitl-credential-dashboard.mjs
+++ b/scripts/lifeops/hitl-credential-dashboard.mjs
@@ -9,8 +9,8 @@
  * Google/X roles ride OAuth metadata or separate real accounts per the
  * owner-agent matrix doc) — those slots feed matrix states 2/3/6.
  *
- * Presence is resolved through the layered env (process.env > worktree .env >
- * main-checkout .env > ~/.eliza/.env, env-layers.mjs); every field shows its
+ * Presence is resolved through the layered env (process.env > repo .env >
+ * ~/.eliza/.env, env-layers.mjs); every field shows its
  * winning source layer and the page header prints the resolved layer file
  * paths. Saves default to ~/.eliza/.env (survives worktree churn; atomic
  * tmp+rename, mode 600) with a per-save toggle for the repo .env, and never
@@ -60,7 +60,7 @@ import {
   redactSecrets,
   registerRedactionEnv,
 } from "./credential-probes.mjs";
-import { HOME_ENV_PATH, loadLayeredEnv, saveEnvVar } from "./env-layers.mjs";
+import { HOME_ENV_PATH, loadLayeredEnv, writeSecret } from "./env-layers.mjs";
 import {
   freshness,
   LEDGER_PATH,
@@ -224,7 +224,7 @@ function rememberProbes(results) {
 
 // --- env saves (layered, never via process.env) ---------------------------------
 
-// saveEnvVar mirrors writes into the processEnv it is handed; giving it a
+// writeSecret mirrors writes into the processEnv it is handed; giving it a
 // scratch object keeps the real process.env pristine so the per-layer source
 // badges stay truthful — probes read the merged layered env instead.
 const SAVE_SCRATCH_ENV = {};
@@ -259,7 +259,8 @@ function persistEnvVar(key, value, target) {
   const aliases = WRITE_ALIASES[key] ?? [];
   const paths = new Set();
   for (const name of [key, ...aliases]) {
-    const saved = saveEnvVar(name, trimmed, target, {
+    const saved = writeSecret(name, trimmed, {
+      scope: target,
       processEnv: SAVE_SCRATCH_ENV,
     });
     paths.add(saved.path);

--- a/scripts/lifeops/run-11632-live-lanes.mjs
+++ b/scripts/lifeops/run-11632-live-lanes.mjs
@@ -3,8 +3,8 @@
  * Per-auth-path live-lane driver for the LifeOps HITL validation run (#11632).
  *
  * Env resolution is the layered load shared with the HITL dashboard
- * (env-layers.mjs: process.env > repo .env > main-checkout .env >
- * ~/.eliza/.env), hydrated into process.env once at startup so readiness
+ * (env-layers.mjs: process.env > repo .env > ~/.eliza/.env), hydrated into
+ * process.env once at startup so readiness
  * checks here and the spawned suites see exactly what the dashboard rows show.
  * Env var NAMES are printed for readiness; env var VALUES are never logged.
  *


### PR DESCRIPTION
## Summary
- lock the HITL layered secrets loader to the owner-specified precedence: `process.env > repo .env > ~/.eliza/.env`
- add the requested `writeSecret(key, value, { scope: "home" | "repo" })` API while preserving the old `saveEnvVar` wrapper for existing callers
- switch the HITL credential dashboard to `writeSecret`, and update dashboard/driver/collector docs plus tests so a fresh linked worktree with no repo `.env` resolves home-scoped credentials instead of a stale main-checkout `.env`

Fixes the code contract for #14793. I am not closing the issue until owner-scoped live credential evidence is captured with real secrets masked.

## Verification
- `node --test scripts/lifeops/env-layers.test.mjs scripts/lifeops/hitl-credential-dashboard.test.mjs scripts/lifeops/hitl-ledger.test.mjs scripts/lifeops/connector-paths.test.mjs` - 44 tests passed
- `bunx @biomejs/biome check scripts/lifeops/env-layers.mjs scripts/lifeops/env-layers.test.mjs scripts/lifeops/hitl-credential-dashboard.mjs scripts/lifeops/run-11632-live-lanes.mjs scripts/lifeops/collect-11632-live-validation-status.mjs` - passed
- `node scripts/lifeops/run-11632-live-lanes.mjs --dry-run` - passed; printed only `process`, `repo`, and `home` env layers and readiness reasons by env var name
- `node scripts/lifeops/env-layers.mjs TELEGRAM_BOT_TOKEN OPENAI_API_KEY CEREBRAS_API_KEY --json` - passed; reported only layer metadata and presence/source, no values
- `git diff --check` - passed

## Evidence
<!-- evidence-row:before-screenshots -->
Before screenshots: N/A - Node-side HITL credential loading/persistence code only; no rendered app UI files changed.

<!-- evidence-row:after-screenshots -->
After screenshots: N/A - no dashboard CSS/component/view files changed. The loopback dashboard write path is covered by `scripts/lifeops/hitl-credential-dashboard.test.mjs`.

<!-- evidence-row:walkthrough-video -->
Walkthrough video: N/A - no user-facing app flow changed; the dashboard POST/save boundary is exercised by the integration test.

<!-- evidence-row:backend-logs -->
Backend logs: N/A - no long-lived server was started. The relevant runtime proof is the Node test output above, including the real loopback dashboard process and the dry-run lane readiness output.

<!-- evidence-row:frontend-logs -->
Frontend console/network logs: N/A - no browser frontend route/component/network behavior changed.

<!-- evidence-row:llm-trajectory -->
Real-LLM trajectory: N/A - secret resolution and HITL preflight plumbing only; no model prompt/action/provider behavior changed.

<!-- evidence-row:domain-artifacts -->
Domain artifacts: [shared layered loader](https://github.com/elizaOS/eliza/blob/fix/hitl-layered-secrets-14793/scripts/lifeops/env-layers.mjs), [precedence/write/dashboard tests](https://github.com/elizaOS/eliza/blob/fix/hitl-layered-secrets-14793/scripts/lifeops/env-layers.test.mjs), and [loopback dashboard write-boundary test](https://github.com/elizaOS/eliza/blob/fix/hitl-layered-secrets-14793/scripts/lifeops/hitl-credential-dashboard.test.mjs).

## Notes
- The tests prove home file creation/upsert mode `0600`, unrelated-line preservation, repo-scope writes, and the fresh linked-worktree fallback to `~/.eliza/.env`.
- Live owner evidence still needs a real credential save/ls/probe capture with values masked per #14793.
