### PR TITLE
docs(hitl): catalog identity slots

### DIFF
--- a/docs/testing/hitl-identity-slots.md
+++ b/docs/testing/hitl-identity-slots.md
@@ -1,0 +1,58 @@
+<!--
+Identity-slot catalog for the LifeOps HITL connector matrix. The table is
+checked by scripts/lifeops/connector-paths.test.mjs so operators can trust that
+OWNER/AGENT slot docs match the registry that drives the dashboard and lane
+preflight.
+-->
+
+# HITL Identity Slot Catalog
+
+The LifeOps HITL matrix needs to know whether a credential represents the
+OWNER, the AGENT, a runtime OAuth role, a separate real account, or a
+slotless/shared credential. This table documents the current `CONNECTOR_PATHS`
+contract for every auth path.
+
+`n/a` means the path does not carry that slot through env vars. It does not mean
+the connector never needs two real identities in a live lane; for OAuth-role and
+separate-account rows the role is carried by the runtime login flow or by
+separate account provisioning instead of by env key names.
+
+| Path ID | Family | Kind | Slot model | OWNER env vars | AGENT env vars | Gate env vars | Notes |
+|---|---|---|---|---|---|---|---|
+| `model.openai-key` | model | api-key | single/slotless | n/a | n/a | OPENAI_API_KEY | n/a |
+| `model.cerebras-key` | model | api-key | single/slotless | n/a | n/a | CEREBRAS_API_KEY | n/a |
+| `model.anthropic-key` | model | api-key | single/slotless | n/a | n/a | ANTHROPIC_API_KEY | n/a |
+| `elizacloud.siwe-session` | elizacloud | cloud-session | single/slotless | n/a | n/a | ELIZA_CLOUD_API_KEY<br>ELIZAOS_CLOUD_API_KEY | The session artifact is the API key, not the browser's steward_session_token JWT (that one only lives in dashboard localStorage). |
+| `elizacloud.api-key` | elizacloud | api-key | single/slotless | n/a | n/a | ELIZA_CLOUD_API_KEY<br>ELIZAOS_CLOUD_API_KEY | n/a |
+| `github.gh-cli` | github | cloud-session | single/slotless | n/a | n/a | GITHUB_TOKEN | n/a |
+| `github.pat` | github | pat | env slots | GITHUB_USER_PAT<br>ELIZA_E2E_GITHUB_USER_PAT | GITHUB_AGENT_PAT<br>ELIZA_E2E_GITHUB_AGENT_PAT | GITHUB_USER_PAT<br>GITHUB_AGENT_PAT<br>GITHUB_TOKEN | OWNER label maps to plugin-github role 'user', AGENT to 'agent' (plugins/plugin-github/src/accounts.ts); GITHUB_ACCOUNTS JSON and character.settings.github.accounts are the multi-account forms; GITHUB_TOKEN stays the ownerless legacy single token. |
+| `github.user-oauth` | github | user-oauth | single/slotless | n/a | n/a | GITHUB_OAUTH_CLIENT_ID<br>GITHUB_OAUTH_CLIENT_SECRET<br>GITHUB_OAUTH_REDIRECT_URI | n/a |
+| `google.oauth-owner` | google | user-oauth | OAuth requestedRole | n/a | n/a | GOOGLE_CLIENT_ID<br>GOOGLE_CLIENT_SECRET<br>GOOGLE_REDIRECT_URI | n/a |
+| `google.oauth-agent` | google | user-oauth | OAuth requestedRole | n/a | n/a | GOOGLE_CLIENT_ID<br>GOOGLE_CLIENT_SECRET<br>GOOGLE_REDIRECT_URI | OWNER and AGENT are separate real Google accounts (owner-agent matrix doc §3); the role rides oauth start metadata (packages/core/src/connectors/oauth-role.ts), not env names. |
+| `telegram.bot` | telegram | bot | single/slotless | n/a | n/a | TELEGRAM_BOT_TOKEN | n/a |
+| `telegram.user-client` | telegram | user-client | single/slotless | n/a | n/a | TELEGRAM_API_ID<br>TELEGRAM_API_HASH<br>TELEGRAM_USER_SESSION | Documented ahead of a gramjs integration; Telegram Desktop's tdata is proprietary/encrypted and is not a credential source. |
+| `discord.bot` | discord | bot | single/slotless | n/a | n/a | DISCORD_API_TOKEN<br>DISCORD_BOT_TOKEN | n/a |
+| `discord.user-token` | discord | user-client | single/slotless | n/a | n/a | DISCORD_USER_TOKEN | n/a |
+| `discord.user-oauth` | discord | user-oauth | single/slotless | n/a | n/a | DISCORD_CLIENT_ID<br>DISCORD_CLIENT_SECRET | n/a |
+| `slack.bot` | slack | bot | single/slotless | n/a | n/a | SLACK_BOT_TOKEN<br>SLACK_APP_TOKEN | n/a |
+| `slack.user-token` | slack | user-client | single/slotless | n/a | n/a | SLACK_USER_TOKEN | n/a |
+| `signal.desktop-bridge` | signal | local-bridge | single/slotless | n/a | n/a | n/a | n/a |
+| `signal.cli` | signal | user-client | single/slotless | n/a | n/a | SIGNAL_ACCOUNT_NUMBER<br>SIGNAL_HTTP_URL<br>SIGNAL_CLI_PATH | A signal-cli binary can be present but unrunnable (e.g. built for a newer JRE); the data-dir requirement keeps an unregistered install skipping instead of red. |
+| `whatsapp.cloud-api` | whatsapp | api-key | single/slotless | n/a | n/a | ELIZA_WHATSAPP_ACCESS_TOKEN<br>ELIZA_WHATSAPP_PHONE_NUMBER_ID | ELIZA_WHATSAPP_* and bare WHATSAPP_* spellings are write-aliased by the dashboard; either satisfies the probe. |
+| `imessage.macos` | imessage | local-bridge | single/slotless | n/a | n/a | n/a | n/a |
+| `imessage.bluebubbles` | imessage | local-bridge | single/slotless | n/a | n/a | BLUEBUBBLES_SERVER_URL<br>BLUEBUBBLES_PASSWORD | An installed-but-stopped server is 'available' (row shows, probe reports connection refused with the start hint); the password lives in the server's config.db. |
+| `x.oauth1-user` | x | user-oauth | single/slotless | n/a | n/a | TWITTER_API_KEY<br>TWITTER_API_SECRET_KEY<br>TWITTER_ACCESS_TOKEN<br>TWITTER_ACCESS_TOKEN_SECRET | n/a |
+| `x.bearer-app` | x | api-key | single/slotless | n/a | n/a | TWITTER_BEARER_TOKEN | n/a |
+| `x.agent-account` | x | user-oauth | separate real account | n/a | n/a | n/a | n/a |
+| `twilio.api` | twilio | api-key | single/slotless | n/a | n/a | TWILIO_ACCOUNT_SID<br>TWILIO_AUTH_TOKEN | n/a |
+| `health.strava` | health | api-key | single/slotless | n/a | n/a | STRAVA_ACCESS_TOKEN | n/a |
+| `health.oura` | health | api-key | single/slotless | n/a | n/a | OURA_ACCESS_TOKEN | n/a |
+| `health.fitbit` | health | api-key | single/slotless | n/a | n/a | FITBIT_ACCESS_TOKEN | n/a |
+| `health.withings` | health | api-key | single/slotless | n/a | n/a | WITHINGS_ACCESS_TOKEN | n/a |
+| `health.healthkit` | health | local-bridge | single/slotless | n/a | n/a | ELIZA_HEALTHKIT_CLI_PATH | n/a |
+| `health.google-fit` | health | api-key | single/slotless | n/a | n/a | ELIZA_GOOGLE_FIT_ACCESS_TOKEN | n/a |
+| `finance.plaid` | finance | api-key | single/slotless | n/a | n/a | PLAID_CLIENT_ID<br>PLAID_SECRET | n/a |
+| `finance.paypal` | finance | api-key | single/slotless | n/a | n/a | PAYPAL_CLIENT_ID<br>PAYPAL_CLIENT_SECRET | LIFEOPS_FINANCE_CSV_FIXTURE remains the keyless finance alternative recognized by CONNECTOR_GROUPS; it is a fixture, not an auth path. |
+| `crypto.evm` | crypto | api-key | single/slotless | n/a | n/a | EVM_PRIVATE_KEY | n/a |
+| `crypto.solana` | crypto | api-key | single/slotless | n/a | n/a | SOLANA_PRIVATE_KEY | n/a |
+

--- a/scripts/lifeops/connector-paths.test.mjs
+++ b/scripts/lifeops/connector-paths.test.mjs
@@ -7,6 +7,7 @@
  */
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import test from "node:test";
 import {
   appBase,
@@ -48,6 +49,45 @@ function markdownCells(row) {
     .split("|")
     .slice(1, -1)
     .map((cell) => cell.replaceAll("__ESCAPED_PIPE__", "|").trim());
+}
+
+const ROOT = resolve(new URL("../..", import.meta.url).pathname);
+const IDENTITY_SLOT_CATALOG = resolve(
+  ROOT,
+  "docs/testing/hitl-identity-slots.md",
+);
+
+function slotModel(path) {
+  if (path.rolesVia === "env-slots") return "env slots";
+  if (path.rolesVia === "oauth-requested-role") return "OAuth requestedRole";
+  if (path.rolesVia === "separate-real-accounts")
+    return "separate real account";
+  return "single/slotless";
+}
+
+function markdownList(values) {
+  return values.length > 0 ? values.join("<br>") : "n/a";
+}
+
+function parseIdentitySlotCatalog() {
+  const rows = new Map();
+  const text = readFileSync(IDENTITY_SLOT_CATALOG, "utf8");
+  for (const line of text.split(/\r?\n/)) {
+    if (!line.startsWith("| `")) continue;
+    const cells = markdownCells(line);
+    const id = cells[0]?.replace(/^`|`$/g, "");
+    assert.equal(cells.length, 8, `${id} row must have 8 columns`);
+    rows.set(id, {
+      family: cells[1],
+      kind: cells[2],
+      slotModel: cells[3],
+      ownerVars: cells[4],
+      agentVars: cells[5],
+      gateVars: cells[6],
+      notes: cells[7],
+    });
+  }
+  return rows;
 }
 
 // --- registry shape ------------------------------------------------------------
@@ -182,6 +222,37 @@ test("kinds are constrained to the declared vocabulary", () => {
       CONNECTOR_PATH_KINDS.includes(path.kind),
       `${path.id} kind ${path.kind}`,
     );
+  }
+});
+
+test("identity-slot catalog is in lockstep with every connector path", () => {
+  const rows = parseIdentitySlotCatalog();
+  assert.deepEqual(
+    [...rows.keys()].sort(),
+    CONNECTOR_PATHS.map((path) => path.id).sort(),
+  );
+  for (const path of CONNECTOR_PATHS) {
+    const row = rows.get(path.id);
+    assert.ok(row, `missing identity-slot catalog row for ${path.id}`);
+    assert.equal(row.family, path.family, `${path.id} family drift`);
+    assert.equal(row.kind, path.kind, `${path.id} kind drift`);
+    assert.equal(row.slotModel, slotModel(path), `${path.id} slot model drift`);
+    assert.equal(
+      row.ownerVars,
+      markdownList(path.ownerVars),
+      `${path.id} owner vars drift`,
+    );
+    assert.equal(
+      row.agentVars,
+      markdownList(path.agentVars),
+      `${path.id} agent vars drift`,
+    );
+    assert.equal(
+      row.gateVars,
+      markdownList([...path.requiredAll, ...path.requiredAny]),
+      `${path.id} gate vars drift`,
+    );
+    assert.ok(row.notes.length > 0, `${path.id} notes cell must not be blank`);
   }
 });
 


### PR DESCRIPTION
## Summary
- add `docs/testing/hitl-identity-slots.md`, a one-row-per-auth-path catalog of OWNER/AGENT slot semantics for the HITL connector matrix
- document whether each path is env-slot based, OAuth requestedRole based, separate-real-account based, or slotless/shared
- add a lockstep test that parses the markdown table and fails if any `CONNECTOR_PATHS` id, family, kind, slot model, owner vars, agent vars, or gate vars drifts

Fixes part of #14795.

## Verification
- `node --test scripts/lifeops/connector-paths.test.mjs` - 16 tests passed
- `node scripts/check-markdown-links.mjs docs/testing/hitl-identity-slots.md` - passed
- `bunx @biomejs/biome check scripts/lifeops/connector-paths.test.mjs` - passed
- `git diff --check` - passed

## Evidence
<!-- evidence-row:before-screenshots -->
Before screenshots: N/A - docs and Node-side HITL registry tests only; no rendered app UI changed.

<!-- evidence-row:after-screenshots -->
After screenshots: N/A - no dashboard CSS/component/view files changed in this slice.

<!-- evidence-row:walkthrough-video -->
Walkthrough video: N/A - no user-facing UI flow changed; the doc-registry contract is verified by the lockstep test.

<!-- evidence-row:backend-logs -->
Backend logs: N/A - no server was started. The relevant backend-adjacent proof is the Node test output above for the connector registry/catalog contract.

<!-- evidence-row:frontend-logs -->
Frontend console/network logs: N/A - no frontend route/component/network behavior changed.

<!-- evidence-row:llm-trajectory -->
Real-LLM trajectory: N/A - identity-slot documentation and registry tests only; no model prompt/action/provider behavior changed.

<!-- evidence-row:domain-artifacts -->
Domain artifacts: [identity-slot catalog](https://github.com/elizaOS/eliza/blob/fix/hitl-identity-slot-catalog-14795/docs/testing/hitl-identity-slots.md) plus the test-enforced [registry/catalog lockstep](https://github.com/elizaOS/eliza/blob/fix/hitl-identity-slot-catalog-14795/scripts/lifeops/connector-paths.test.mjs).

## Notes
- This does not close #14795. Live evidence still needs dashboard screenshots with OWNER/AGENT slots for real connectors, paired account lane logs, and ledger diffs with identifiers/secrets masked.
