### PR TITLE
fix(hitl): use telegram owner session key

### DIFF
--- a/scripts/lifeops/connector-paths.mjs
+++ b/scripts/lifeops/connector-paths.mjs
@@ -298,11 +298,8 @@ export const CONNECTOR_PATHS = [
     group: "telegram",
     kind: "user-client",
     label: "Telegram user client (future gramjs)",
-    requiredAll: [
-      "TELEGRAM_API_ID",
-      "TELEGRAM_API_HASH",
-      "TELEGRAM_USER_SESSION",
-    ],
+    requiredAll: ["TELEGRAM_API_ID", "TELEGRAM_API_HASH"],
+    requiredAny: ["TELEGRAM_OWNER_SESSION", "TELEGRAM_USER_SESSION"],
     probeId: null,
     probeEndpoint:
       "gramjs getMe over the string session (not yet wired in-repo)",
@@ -311,8 +308,9 @@ export const CONNECTOR_PATHS = [
       specs: [
         {
           type: "env-present",
-          names: ["TELEGRAM_USER_SESSION"],
-          reason: "no gramjs string session in env",
+          names: ["TELEGRAM_OWNER_SESSION", "TELEGRAM_USER_SESSION"],
+          reason:
+            "no owner gramjs string session in env (TELEGRAM_OWNER_SESSION)",
         },
         {
           type: "file-exists",
@@ -322,7 +320,7 @@ export const CONNECTOR_PATHS = [
       ],
     },
     notes:
-      "Documented ahead of a gramjs integration; Telegram Desktop's tdata is proprietary/encrypted and is not a credential source.",
+      "Documented ahead of a gramjs integration; TELEGRAM_OWNER_SESSION is the owner-scoped key required by the HITL issue, while TELEGRAM_USER_SESSION remains a temporary read alias. Telegram Desktop's tdata is proprietary/encrypted and is not a credential source.",
   }),
 
   // --- Discord --------------------------------------------------------------------

--- a/scripts/lifeops/connector-paths.test.mjs
+++ b/scripts/lifeops/connector-paths.test.mjs
@@ -209,6 +209,32 @@ test("google owner/agent rows use oauth requestedRole, never invented env slots"
   }
 });
 
+test("telegram user-client gates on the owner session key with a legacy alias", () => {
+  const path = byId("telegram.user-client");
+  assert.deepEqual(path.requiredAll, ["TELEGRAM_API_ID", "TELEGRAM_API_HASH"]);
+  assert.deepEqual(path.requiredAny, [
+    "TELEGRAM_OWNER_SESSION",
+    "TELEGRAM_USER_SESSION",
+  ]);
+  assert.match(path.notes, /TELEGRAM_OWNER_SESSION/);
+
+  const missing = checkAvailability(path.availability, fakeCtx());
+  assert.equal(missing.available, false);
+  assert.match(missing.reason, /TELEGRAM_OWNER_SESSION/);
+
+  const ownerSession = checkAvailability(
+    path.availability,
+    fakeCtx({ env: { TELEGRAM_OWNER_SESSION: "session" } }),
+  );
+  assert.equal(ownerSession.available, true);
+
+  const legacySession = checkAvailability(
+    path.availability,
+    fakeCtx({ env: { TELEGRAM_USER_SESSION: "session" } }),
+  );
+  assert.equal(legacySession.available, true);
+});
+
 test("x agent slot is a separate real account, permanently skipped with the matrix reason", () => {
   const path = byId("x.agent-account");
   assert.equal(path.rolesVia, "separate-real-accounts");


### PR DESCRIPTION
## Summary
- align the Telegram user-client HITL path with the issue-owned credential name: `TELEGRAM_OWNER_SESSION`
- keep `TELEGRAM_USER_SESSION` as a temporary compatibility alias so existing local setups do not break abruptly
- add registry coverage proving the owner key is primary, the legacy alias still gates cleanly, and missing sessions skip with an owner-scoped reason

Fixes part of #14796.

## Verification
- `node --test scripts/lifeops/connector-paths.test.mjs` - 16 tests passed
- `bunx @biomejs/biome check scripts/lifeops/connector-paths.mjs scripts/lifeops/connector-paths.test.mjs` - passed
- `git diff --check` - passed

## Evidence
<!-- evidence-row:before-screenshots -->
Before screenshots: N/A - Node-side HITL registry metadata only; no rendered app UI changed.

<!-- evidence-row:after-screenshots -->
After screenshots: N/A - no dashboard CSS/component/view files changed in this slice.

<!-- evidence-row:walkthrough-video -->
Walkthrough video: N/A - no user-facing login flow was added here; this slice corrects the credential contract the future/login flow will use.

<!-- evidence-row:backend-logs -->
Backend logs: N/A - no server was started. The relevant backend-adjacent proof is the Node registry test output above.

<!-- evidence-row:frontend-logs -->
Frontend console/network logs: N/A - no frontend route/component/network behavior changed.

<!-- evidence-row:llm-trajectory -->
Real-LLM trajectory: N/A - credential registry plumbing only; no model prompt/action/provider behavior changed.

<!-- evidence-row:domain-artifacts -->
Domain artifacts: [Telegram user-client registry entry](https://github.com/elizaOS/eliza/blob/fix/hitl-telegram-owner-session-14796/scripts/lifeops/connector-paths.mjs) plus [owner-session registry test](https://github.com/elizaOS/eliza/blob/fix/hitl-telegram-owner-session-14796/scripts/lifeops/connector-paths.test.mjs).

## Notes
- This does not close #14796. The actual one-time MTProto login/session creation flow, real-account lane, and masked live evidence still need owner credentials and implementation.
