### PR TITLE
fix(cloud): log docker ssh pool teardown failures

### DIFF
--- a/packages/cloud/shared/src/lib/services/docker-ssh.ts
+++ b/packages/cloud/shared/src/lib/services/docker-ssh.ts
@@ -159,6 +159,13 @@ export class DockerSSHClient {
   /** Max number of concurrent SSH connections in pool to prevent unbounded growth. */
   private static readonly MAX_POOL_SIZE = 50;
 
+  private static warnDisconnectFailure(poolKey: string, err: unknown): void {
+    // error-policy:J6 best-effort teardown; pool eviction continues, but SSH cleanup failure must remain observable.
+    logger.warn(
+      `[docker-ssh] error disconnecting pooled client ${poolKey}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
   /**
    * Get (or create) a pooled client for the given hostname.
    * Uses default SSH port / user / key unless the pool entry was created
@@ -189,7 +196,9 @@ export class DockerSSHClient {
         Date.now() - client.lastActivityMs > DockerSSHClient.IDLE_TIMEOUT_MS
       ) {
         logger.info(`[docker-ssh] Evicting idle connection for ${poolKey}`);
-        client.disconnect().catch(() => {});
+        client.disconnect().catch((err) => {
+          DockerSSHClient.warnDisconnectFailure(poolKey, err);
+        });
         DockerSSHClient.pool.delete(poolKey);
         client = undefined;
       }
@@ -200,7 +209,9 @@ export class DockerSSHClient {
           normalizeSshFingerprint(hostKeyFingerprint ?? "")
       ) {
         logger.info(`[docker-ssh] Evicting pooled connection for ${poolKey} — fingerprint changed`);
-        client.disconnect().catch(() => {});
+        client.disconnect().catch((err) => {
+          DockerSSHClient.warnDisconnectFailure(poolKey, err);
+        });
         DockerSSHClient.pool.delete(poolKey);
         client = undefined;
       }
@@ -222,7 +233,9 @@ export class DockerSSHClient {
           DockerSSHClient.pool
             .get(oldestKey)
             ?.disconnect()
-            .catch(() => {});
+            .catch((err) => {
+              DockerSSHClient.warnDisconnectFailure(oldestKey, err);
+            });
           DockerSSHClient.pool.delete(oldestKey);
         }
       }


### PR DESCRIPTION
## Summary
- replace swallowed pooled SSH disconnect failures with logged best-effort teardown warnings
- keep idle/fingerprint/max-pool eviction behavior unchanged
- add a J6 error-policy annotation for the teardown path

## Evidence
- `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/docker-ssh.ts --no-errors-on-unmatched`
- `bun run --cwd packages/cloud/shared typecheck 2>&1 | rg "docker-ssh" || true`
- `git diff --check origin/develop...HEAD && git diff --check`
- `bun run audit:error-policy-ratchet`

N/A: no UI artifacts; backend SSH pool cleanup observability only.
N/A: no live LLM trajectory; no model/action/prompt behavior changed.

Refs #13415