### PR TITLE
fix(cloud): log container route cleanup failures

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/container-job-executors.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/container-job-executors.test.ts
@@ -422,6 +422,22 @@ describe("ingress route hooks", () => {
     });
   });
 
+  test("delete still marks the container deleted when route removal fails", async () => {
+    await withBase("apps.elizacloud.ai", async () => {
+      const { events, store } = fakeStore();
+      const { provider } = fakeProvider();
+      await executeContainerDelete(job({ containerId: "container-1", organizationId: "org-1" }), {
+        provider,
+        store,
+        onRouteRemoved: async () => {
+          throw new Error("caddy admin unavailable");
+        },
+      });
+
+      expect(events).toContainEqual({ op: "deleted", id: "container-1" });
+    });
+  });
+
   test("no base domain -> no route call (ingress not configured)", async () => {
     await withBase(undefined, async () => {
       const { store } = fakeStore();

--- a/packages/cloud/shared/src/lib/services/agent-managed-discord.ts
+++ b/packages/cloud/shared/src/lib/services/agent-managed-discord.ts
@@ -235,7 +235,16 @@ export class ManagedAgentDiscordService {
         organizationId: params.organizationId,
         userId: sandbox.user_id,
       });
-      void provisioningJobService.triggerImmediate().catch(() => {});
+      // The restart job is already enqueued; triggerImmediate only nudges the
+      // daemon to pick it up now. A failed nudge delays restart to the next poll.
+      // error-policy:J7 nudge failure only delays an already-enqueued restart; logged, not fatal.
+      void provisioningJobService.triggerImmediate().catch((err) =>
+        logger.warn("[managed-discord] provisioning triggerImmediate nudge failed", {
+          agentId: sandbox.id,
+          organizationId: params.organizationId,
+          error: err instanceof Error ? err.message : String(err),
+        }),
+      );
       restarted = true;
     }
 
@@ -288,7 +297,16 @@ export class ManagedAgentDiscordService {
         organizationId: params.organizationId,
         userId: sandbox.user_id,
       });
-      void provisioningJobService.triggerImmediate().catch(() => {});
+      // The restart job is already enqueued; triggerImmediate only nudges the
+      // daemon to pick it up now. A failed nudge delays restart to the next poll.
+      // error-policy:J7 nudge failure only delays an already-enqueued restart; logged, not fatal.
+      void provisioningJobService.triggerImmediate().catch((err) =>
+        logger.warn("[managed-discord] provisioning triggerImmediate nudge failed", {
+          agentId: sandbox.id,
+          organizationId: params.organizationId,
+          error: err instanceof Error ? err.message : String(err),
+        }),
+      );
       restarted = true;
     }
 

--- a/packages/cloud/shared/src/lib/services/container-job-executors.ts
+++ b/packages/cloud/shared/src/lib/services/container-job-executors.ts
@@ -149,7 +149,15 @@ export async function executeContainerProvision(
     const endpoint = deriveAppPublicUrl(containerId);
     if (endpoint && deps.onRouteAdded) {
       const extraHostnames = deps.listVerifiedAppHostnames
-        ? await deps.listVerifiedAppHostnames(row.appId).catch(() => [] as string[])
+        ? await deps.listVerifiedAppHostnames(row.appId).catch((error) => {
+            // error-policy:J4 custom domains are additive; the primary app route stays explicit.
+            logger.warn("[ContainerExecutor] custom-domain lookup failed during route-add", {
+              containerId,
+              appId: row.appId,
+              error: error instanceof Error ? error.message : String(error),
+            });
+            return [] as string[];
+          })
         : [];
       await deps.onRouteAdded({
         hostname: endpoint.hostname,
@@ -203,7 +211,14 @@ export async function executeContainerDelete(
   // Remove the ingress route (best-effort; a reconciler sweeps any orphan).
   const endpoint = deriveAppPublicUrl(containerId);
   if (endpoint && deps.onRouteRemoved) {
-    await deps.onRouteRemoved({ hostname: endpoint.hostname }).catch(() => undefined);
+    await deps.onRouteRemoved({ hostname: endpoint.hostname }).catch((error) => {
+      // error-policy:J6 route removal is teardown best-effort; reconciler sweeps orphans.
+      logger.warn("[ContainerExecutor] route removal failed during container delete", {
+        containerId,
+        hostname: endpoint.hostname,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
   }
   await deps.store.markDeleted(containerId);
 }


### PR DESCRIPTION
## Summary
- log custom-domain lookup failures while preserving wildcard-route deploy behavior
- log best-effort container route removal failures during delete teardown
- log managed Discord restart trigger nudge failures instead of swallowing them
- cover failed route removal still marking the container deleted

## Verification
- node ../shared/scripts/generate-keywords.mjs --target ts (from packages/core)
- bunx @biomejs/biome check packages/cloud/shared/src/lib/services/container-job-executors.ts packages/cloud/shared/src/lib/services/agent-managed-discord.ts packages/cloud/shared/src/lib/services/__tests__/container-job-executors.test.ts --no-errors-on-unmatched
- bun test src/lib/services/__tests__/container-job-executors.test.ts
- bun run --cwd packages/cloud/shared typecheck 2>&1 | rg "container-job-executors|agent-managed-discord" || true
- git diff --check origin/develop...HEAD
- bun run audit:error-policy-ratchet

Refs #13415