### PR TITLE
fix(cloud): log stale ingress route cleanup failures

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/apps-ingress-provisioner.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/apps-ingress-provisioner.test.ts
@@ -55,6 +55,26 @@ describe("addAppRoute", () => {
       addAppRoute({ hostname: HOST, nodeHost: "n", hostPort: 1, adminBase: ADMIN, fetchImpl }),
     ).rejects.toThrow(/add-route failed \(500\)/);
   });
+
+  test("logs stale-route delete failure but still POSTs the replacement route", async () => {
+    const calls: Array<{ url: string; method: string }> = [];
+    const fetchImpl: IngressFetch = async (url, init) => {
+      calls.push({ url, method: init.method });
+      if (init.method === "DELETE") {
+        throw new Error("caddy delete timeout");
+      }
+      return { ok: true, status: 201, text: async () => "" };
+    };
+
+    await addAppRoute({
+      hostname: HOST,
+      hostPort: 28123,
+      adminBase: ADMIN,
+      fetchImpl,
+    });
+
+    expect(calls.map((call) => call.method)).toEqual(["DELETE", "POST"]);
+  });
 });
 
 describe("removeAppRoute", () => {

--- a/packages/cloud/shared/src/lib/services/apps-ingress-provisioner.ts
+++ b/packages/cloud/shared/src/lib/services/apps-ingress-provisioner.ts
@@ -15,6 +15,7 @@
  * `scripts/verify-apps-ingress-routing.sh`.
  */
 
+import { logger } from "../utils/logger";
 import {
   type AppRouteInput,
   buildCaddyAddRouteUrl,
@@ -73,7 +74,14 @@ export async function addAppRoute(opts: AddRouteOpts): Promise<void> {
   await fetchImpl(buildCaddyRouteByIdUrl(opts.adminBase, routeId), {
     method: "DELETE",
     signal: AbortSignal.timeout(timeoutMs),
-  }).catch(() => undefined);
+  }).catch((error) => {
+    // error-policy:J4 stale-route cleanup failure must not block the replacement route.
+    logger.warn("[apps-ingress] stale route delete failed before add-route", {
+      routeId,
+      hostname: opts.hostname,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
 
   const res = await fetchImpl(buildCaddyAddRouteUrl(opts.adminBase, opts.server), {
     method: "POST",


### PR DESCRIPTION
## Summary
- log stale same-id Caddy route delete failures before add-route instead of silently ignoring them
- keep replacement route creation best-effort/idempotent behavior intact
- add regression coverage that a stale-delete failure still posts the replacement route

## Verification
- bunx @biomejs/biome check packages/cloud/shared/src/lib/services/apps-ingress-provisioner.ts packages/cloud/shared/src/lib/services/__tests__/apps-ingress-provisioner.test.ts --no-errors-on-unmatched
- bun test src/lib/services/__tests__/apps-ingress-provisioner.test.ts
- bun run --cwd packages/cloud/shared typecheck 2>&1 | rg "apps-ingress-provisioner" || true
- git diff --check
- bun run audit:error-policy-ratchet

Refs #13415