### PR TITLE
fix(cloud): guard exact_permit facilitator init on the topup quote path

### DIFF
--- a/packages/cloud/shared/src/lib/services/topup-handler.test.ts
+++ b/packages/cloud/shared/src/lib/services/topup-handler.test.ts
@@ -103,3 +103,38 @@ test("topup quote returns x402_not_configured when facilitator setup fails", asy
   expect(initialize).toHaveBeenCalledTimes(1);
   expect(getSignerAddress).not.toHaveBeenCalled();
 });
+
+test("exact_permit quote fails closed when facilitator setup fails despite a configured recipient", async () => {
+  initialize.mockClear();
+  getSignerAddress.mockClear();
+
+  const handler = createTopupHandler({
+    amount: 10,
+    getSourceId: (walletAddress, paymentId) => `${walletAddress}:${paymentId}`,
+  });
+
+  // A configured recipient skips facilitator init during recipient resolution,
+  // so a bsc (exact_permit) quote reaches the signer-init call — the second,
+  // separately guarded initialize() on the quote path.
+  const response = await handler(
+    new Request("https://api.example.test/api/v1/topup/10", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        walletAddress: "0x1111111111111111111111111111111111111111",
+      }),
+    }),
+    {
+      X402_RECIPIENT_ADDRESS: "0x2222222222222222222222222222222222222222",
+      X402_NETWORK: "bsc",
+    },
+  );
+
+  expect(response.status).toBe(503);
+  expect(await response.json()).toMatchObject({
+    success: false,
+    code: "x402_not_configured",
+  });
+  expect(initialize).toHaveBeenCalledTimes(1);
+  expect(getSignerAddress).not.toHaveBeenCalled();
+});

--- a/packages/cloud/shared/src/lib/services/topup-handler.ts
+++ b/packages/cloud/shared/src/lib/services/topup-handler.ts
@@ -231,7 +231,19 @@ async function createPaymentRequirements(
   const now = Math.floor(Date.now() / 1000);
   let facilitatorCaller: string | null = null;
   if (scheme === "exact_permit") {
-    await x402FacilitatorService.initialize();
+    // Reached with a configured X402_RECIPIENT_ADDRESS (recipient resolution
+    // then skips facilitator init), so this initialize() needs its own guard.
+    try {
+      await x402FacilitatorService.initialize();
+    } catch (error) {
+      // error-policy:J1 boundary translation; topup quotes report unavailable
+      // x402 configuration instead of letting setup failures become Worker 500s.
+      logger.error("[x402] Failed to initialize facilitator for exact_permit signer", error);
+      return {
+        error: "x402 facilitator signer is not configured",
+        status: 503,
+      };
+    }
     facilitatorCaller = x402FacilitatorService.getSignerAddress();
     if (!facilitatorCaller) {
       return {


### PR DESCRIPTION
## Problem

#15700 made `x402FacilitatorService` fail fast when a secrets-store read fails, and `2b0f3332e05` translated that failure into the designed 503 `x402_not_configured` on the topup quote path — but only inside `resolvePaymentRecipient()`, which is skipped entirely when `X402_RECIPIENT_ADDRESS` is configured (the production shape).

With a configured recipient and `X402_NETWORK=bsc`/`bsc-testnet` (the `exact_permit` scheme), `createPaymentRequirements()` reaches a **second, unguarded** `x402FacilitatorService.initialize()` for the facilitator signer. A secrets-store outage there still escapes the route as an opaque Worker 500 instead of the designed fail-closed 503.

## Fix

Same `error-policy:J1` boundary translation on the `exact_permit` signer-init call: log the failure, return the existing `"x402 facilitator signer is not configured"` 503 shape. No quote is issued; retries re-attempt initialization (a failed `initialize()` clears its memoized in-flight promise).

## Evidence

Extended `topup-handler.test.ts` with the configured-recipient + bsc case, driving the real handler:

- **Red without the fix** (unguarded init escapes):
```
(fail) exact_permit quote fails closed when facilitator setup fails despite a configured recipient [0.70ms]
 1 pass
 1 fail
```
- **Green with the fix**:
```
 2 pass
 0 fail
 8 expect() calls
Ran 2 tests across 1 file. [389.00ms]
```

Biome clean; `cloud/shared` typecheck has no errors in touched files. Backend-only route-boundary change — no UI surface (screenshots/video N/A); no model/agent behavior touched (trajectories N/A).

Follow-up to the Cloud Tests develop-lane remediation (topup 500s first seen in run 28999744770 on `1550922604d`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)