### PR TITLE
fix(cloud): log inference sweep lock release failures

### DIFF
--- a/packages/cloud/shared/src/lib/services/inference-billing-fast-path.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-fast-path.test.ts
@@ -9,7 +9,7 @@
 process.env.MOCK_REDIS = "1";
 process.env.CACHE_ENABLED = "true";
 
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 
 // --- Controllable credits + api-keys seams ----------------------------------
 interface DeductCall {
@@ -69,6 +69,7 @@ const {
 } = await import("./inference-billing-fast-path");
 const { cache } = await import("../cache/client");
 const { CacheKeys } = await import("../cache/keys");
+const { logger } = await import("../utils/logger");
 const { readOrgBalanceHint, writeOrgBalanceHint } = await import("./inference-auth-cache");
 
 // Mirror of the module-private sweep-lock key (kept as a literal so a rename is
@@ -355,6 +356,29 @@ describe("sweepStalePendingInferenceCharges", () => {
     // Entry is untouched, so the next (unlocked) sweep still settles it.
     expect(await cache.get(CacheKeys.inference.pendingCharge(input.requestId))).not.toBeNull();
     await cache.del(SWEEP_LOCK_KEY);
+  });
+
+  test("logs sweep-lock release failure without failing the completed sweep", async () => {
+    const originalDel = cache.del.bind(cache);
+    const warn = spyOn(logger, "warn").mockImplementation(() => undefined as never);
+    const del = spyOn(cache, "del").mockImplementation(async (key: string) => {
+      if (key === SWEEP_LOCK_KEY) {
+        throw new Error("kv delete unavailable");
+      }
+      return originalDel(key);
+    });
+
+    try {
+      const stats = await sweepStalePendingInferenceCharges({ now: 10_000_000 });
+      expect(stats.locked).toBe(false);
+      expect(
+        warn.mock.calls.some(([message]) => String(message).includes("failed to release")),
+      ).toBe(true);
+    } finally {
+      del.mockRestore();
+      warn.mockRestore();
+      await cache.del(SWEEP_LOCK_KEY);
+    }
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/inference-billing-fast-path.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-fast-path.ts
@@ -393,6 +393,12 @@ export async function sweepStalePendingInferenceCharges(opts?: {
     }
     return stats;
   } finally {
-    await cache.del(SWEEP_LOCK_KEY).catch(() => {});
+    await cache.del(SWEEP_LOCK_KEY).catch((error) => {
+      // error-policy:J6 lock release is teardown; failure delays the next sweep until TTL expiry.
+      logger.warn("[InferenceBilling] failed to release pending-charge sweep lock", {
+        lockKey: SWEEP_LOCK_KEY,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
   }
 }


### PR DESCRIPTION
## Summary
- log pending-charge sweep lock release failures instead of swallowing them
- preserve completed sweep stats when lock cleanup fails; the next sweep waits for TTL
- add regression coverage that a lock-release failure is observable and non-fatal

## Verification
- node ../shared/scripts/generate-keywords.mjs --target ts
- bunx @biomejs/biome check packages/cloud/shared/src/lib/services/inference-billing-fast-path.ts packages/cloud/shared/src/lib/services/inference-billing-fast-path.test.ts --no-errors-on-unmatched
- bun test src/lib/services/inference-billing-fast-path.test.ts
- bun run --cwd packages/cloud/shared typecheck 2>&1 | rg "inference-billing-fast-path" || true
- git diff --check
- bun run audit:error-policy-ratchet

Refs #13415