### PR TITLE
fix(cloud): log docker provision rollback removal failures

### DIFF
--- a/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
@@ -1437,7 +1437,12 @@ export class DockerSandboxProvider implements SandboxProvider {
 
       await ssh
         .exec(`docker rm -f ${shellQuote(containerName)}`, DOCKER_CMD_TIMEOUT_MS)
-        .catch(() => {});
+        .catch((cleanupErr) => {
+          // error-policy:J6 provision rollback cleanup is best-effort; the original failure still rethrows.
+          logger.warn(
+            `[docker-sandbox] Failed to remove container ${containerName} after provision failure: ${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}`,
+          );
+        });
 
       // Rollback allocated_count on failure. This is the only place the slot
       // reserved by incrementAllocated() is released after a failed provision,


### PR DESCRIPTION
## Summary
- log failed `docker rm -f` rollback cleanup during Docker sandbox provision failure
- preserve the existing best-effort cleanup behavior and original provision failure rethrow
- annotate the retained handler with an error-policy J6 teardown justification

## Verification
- node ../shared/scripts/generate-keywords.mjs --target ts
- bunx @biomejs/biome check packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts --no-errors-on-unmatched
- bun run --cwd packages/cloud/shared typecheck 2>&1 | rg "docker-sandbox-provider" || true
- git diff --check
- bun run audit:error-policy-ratchet

Refs #13415