### PR TITLE
fix(cloud): log social api error body read failures

### DIFF
--- a/packages/cloud/shared/src/lib/services/social-media/rate-limit.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/rate-limit.error-policy.test.ts
@@ -12,16 +12,22 @@
  * it deterministic `Response` objects.
  */
 
-import { afterEach, describe, expect, it, mock } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+const warn = mock(() => undefined);
 
 mock.module("../../utils/logger", () => ({
-  logger: { warn: () => {}, info: () => {}, error: () => {}, debug: () => {} },
+  logger: { warn, info: () => {}, error: () => {}, debug: () => {} },
 }));
 
 const { withRetry, isRateLimitResponse, createRateLimitError } = await import("./rate-limit");
 
 afterEach(() => {
   mock.restore();
+});
+
+beforeEach(() => {
+  warn.mockClear();
 });
 
 const NO_WAIT = { platform: "twitter" as const, maxRetries: 0, baseDelayMs: 0 };
@@ -31,6 +37,23 @@ describe("withRetry — internal failure propagates vs designed-empty passes thr
     const fn = async () => new Response("boom", { status: 500 });
     const parser = async (r: Response) => r.json();
     await expect(withRetry(fn, parser, NO_WAIT)).rejects.toThrow("twitter API error 500: boom");
+  });
+
+  it("logs failed error-body reads without clobbering the HTTP status failure", async () => {
+    const fn = async () =>
+      ({
+        ok: false,
+        status: 503,
+        text: async () => {
+          throw new Error("body stream locked");
+        },
+      }) as Response;
+    const parser = async (r: Response) => r.json();
+
+    await expect(withRetry(fn, parser, NO_WAIT)).rejects.toThrow("twitter API error 503:");
+    expect(warn.mock.calls.some(([message]) => String(message).includes("Failed to read"))).toBe(
+      true,
+    );
   });
 
   it("throws a typed RateLimitError after 429 exhaustion (fail-closed, not empty)", async () => {

--- a/packages/cloud/shared/src/lib/services/social-media/rate-limit.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/rate-limit.ts
@@ -89,7 +89,12 @@ export async function withRetry<T>(
 
       if (!response.ok) {
         // error-policy:J6 best-effort error-body read; the HTTP failure still surfaces via the thrown status error below
-        const errorBody = await response.text().catch(() => "");
+        const errorBody = await response.text().catch((error) => {
+          logger.warn(
+            `[${platform}] Failed to read non-ok response body: ${error instanceof Error ? error.message : String(error)}`,
+          );
+          return "";
+        });
         throw new Error(`${platform} API error ${response.status}: ${errorBody}`);
       }
 


### PR DESCRIPTION
## Summary
- log failed best-effort social API error-body reads instead of silently dropping them
- preserve the existing thrown HTTP status failure when body reading fails
- add regression coverage that the warning fires and the status remains load-bearing

## Verification
- bunx @biomejs/biome check packages/cloud/shared/src/lib/services/social-media/rate-limit.ts packages/cloud/shared/src/lib/services/social-media/rate-limit.error-policy.test.ts --no-errors-on-unmatched
- bun test src/lib/services/social-media/rate-limit.error-policy.test.ts
- bun run --cwd packages/cloud/shared typecheck 2>&1 | rg "social-media/rate-limit" || true
- git diff --check
- bun run audit:error-policy-ratchet

Refs #13415