### PR TITLE
fix(ci): enforce lane coverage on main gate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -163,11 +163,10 @@ jobs:
       - name: Test realness ratchet
         run: bun run audit:test-realness
 
-      # Per-plugin mock-LLM e2e coverage. Warn-first (--dry-run exits 0) while
-      # the backlog is burned down; flip to enforcing (drop --dry-run, allowlist
-      # justified N/A) once plugins carry a withMockLlmRuntime e2e. (#8801)
-      - name: Per-plugin e2e coverage (warn-only)
-        run: node packages/scripts/lint-lane-coverage.mjs --dry-run
+      # Per-plugin mock-LLM e2e coverage. The seeded allowlist carries
+      # historical debt; new unsuppressed gaps fail the main gate (#13620).
+      - name: Per-plugin e2e coverage
+        run: node packages/scripts/lint-lane-coverage.mjs
 
   # Build job
   build:

--- a/packages/scripts/__tests__/ci-workflow-dedup-contract.test.ts
+++ b/packages/scripts/__tests__/ci-workflow-dedup-contract.test.ts
@@ -30,6 +30,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: ./.github/actions/setup-bun-workspace
+      - run: node packages/scripts/lint-lane-coverage.mjs
 `;
 
 // Post-#14194: test.yml is the develop POST-MERGE orchestrator. Develop `push`
@@ -55,6 +56,10 @@ on:
   pull_request:
     branches: [develop]
 jobs:
+  lane-coverage:
+    runs-on: ubuntu-24.04
+    steps:
+      - run: node packages/scripts/lint-lane-coverage.mjs
   lint:
     runs-on: ubuntu-24.04
     steps:
@@ -185,14 +190,29 @@ describe("ci-workflow-dedup-contract", () => {
     });
   });
 
+  test("downgrading lane coverage to dry-run fails the contract", () => {
+    const workflows = baseWorkflows();
+    workflows["ci.yaml"] = CI_YAML.replace(
+      "node packages/scripts/lint-lane-coverage.mjs",
+      "node packages/scripts/lint-lane-coverage.mjs --dry-run",
+    );
+    withRepo(workflows, (root) => {
+      expect(() => runContract(root)).toThrow(
+        /ci\.yaml lane coverage must be enforced/,
+      );
+    });
+  });
+
   test("re-adding the SaaS remote cache to any workflow fails the contract", () => {
     const workflows = baseWorkflows();
     workflows["scenario-pr.yml"] = SCENARIO_PR_YML.replace(
       "  x:",
-      "  x:\n    env:\n      TURBO_TOKEN: \${{ secrets.TURBO_TOKEN }}",
+      "  x:\n    env:\n      TURBO_TOKEN: $" + "{{ secrets.TURBO_TOKEN }}",
     );
     withRepo(workflows, (root) => {
-      expect(() => runContract(root)).toThrow(/SaaS Turbo remote cache is banned/);
+      expect(() => runContract(root)).toThrow(
+        /SaaS Turbo remote cache is banned/,
+      );
     });
   });
 
@@ -216,7 +236,10 @@ describe("ci-workflow-dedup-contract", () => {
     withRepo(workflows, (root) => {
       const hits = findSaasRemoteCache(root);
       expect(hits).toEqual([
-        { file: ".github/workflows/release.yaml", label: "TURBO_CACHE: remote" },
+        {
+          file: ".github/workflows/release.yaml",
+          label: "TURBO_CACHE: remote",
+        },
       ]);
     });
   });

--- a/packages/scripts/ci-workflow-dedup-contract.mjs
+++ b/packages/scripts/ci-workflow-dedup-contract.mjs
@@ -159,6 +159,15 @@ export function runContract(repoRoot = DEFAULT_REPO_ROOT) {
     ["main"],
     "ci.yaml PR branches",
   );
+  assertIncludes(
+    ci,
+    "node packages/scripts/lint-lane-coverage.mjs",
+    "ci.yaml enforces lane coverage",
+  );
+  assert(
+    !ci.includes("lint-lane-coverage.mjs --dry-run"),
+    "ci.yaml lane coverage must be enforced, not warn-only (#13620)",
+  );
 
   // test.yml is the develop POST-MERGE orchestrator (#14194): develop `push`
   // only, and it must NOT carry a `pull_request` or `merge_group` trigger, or
@@ -196,6 +205,15 @@ export function runContract(repoRoot = DEFAULT_REPO_ROOT) {
     ),
     ["develop"],
     "develop-pr.yml PR branches",
+  );
+  assertIncludes(
+    developPr,
+    "node packages/scripts/lint-lane-coverage.mjs",
+    "develop-pr.yml enforces lane coverage",
+  );
+  assert(
+    !developPr.includes("lint-lane-coverage.mjs --dry-run"),
+    "develop-pr.yml lane coverage must be enforced, not warn-only (#13620)",
   );
 
   // scenario-pr.yml follows the same pre/post-merge split as test.yml: the


### PR DESCRIPTION
## Summary
- remove `--dry-run` from `ci.yaml` per-plugin lane coverage so main PR/push CI enforces the seeded allowlist
- update the workflow contract to require enforced lane coverage in both `ci.yaml` and `develop-pr.yml`
- add a regression proving a dry-run downgrade fails the contract

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yaml"); puts "ci.yaml parsed"'\n- actionlint .github/workflows/ci.yaml\n- bun test packages/scripts/__tests__/ci-workflow-dedup-contract.test.ts\n- node packages/scripts/ci-workflow-dedup-contract.mjs\n- node packages/scripts/lint-lane-coverage.mjs\n- bunx @biomejs/biome check .github/workflows/ci.yaml packages/scripts/ci-workflow-dedup-contract.mjs packages/scripts/__tests__/ci-workflow-dedup-contract.test.ts --no-errors-on-unmatched\n- git diff --check\n\nRefs #13620