### PR TITLE
fix(cloud): log managed launch onboarding body read failures

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-managed-launch.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-managed-launch.ts
@@ -138,7 +138,15 @@ async function ensureManagedOnboarding(
   });
 
   if (!onboardingResponse.ok) {
-    const text = await onboardingResponse.text().catch(() => "");
+    const text = await onboardingResponse.text().catch((error) => {
+      // error-policy:J6 best-effort error-body read; HTTP status remains the load-bearing failure.
+      logger.warn("[agent-managed-launch] Failed to read onboarding error body", {
+        agentId: sandbox.id,
+        status: onboardingResponse.status,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return "";
+    });
     throw new ManagedElizaLaunchError(
       `Failed to bootstrap managed onboarding (HTTP ${onboardingResponse.status})${text ? `: ${text.slice(0, 200)}` : ""}`,
       502,


### PR DESCRIPTION
## Summary
- log failed best-effort onboarding error-body reads in managed Eliza launch
- preserve the existing HTTP-status-based `ManagedElizaLaunchError` behavior
- annotate the retained handler with an error-policy J6 justification

## Verification
- node ../shared/scripts/generate-keywords.mjs --target ts
- bunx @biomejs/biome check packages/cloud/shared/src/lib/services/eliza-managed-launch.ts --no-errors-on-unmatched
- bun run --cwd packages/cloud/shared typecheck 2>&1 | rg "eliza-managed-launch" || true
- git diff --check
- bun run audit:error-policy-ratchet

Refs #13415