### PR TITLE
fix(cloud): log onboarding remember body read failures

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
@@ -10,6 +10,7 @@ const findOrCreateByPhone = mock();
 const linkPhoneToUser = mock();
 const generateText = mock();
 const launchManagedElizaAgent = mock();
+const loggerWarn = mock();
 let cloudEnv: Record<string, string | undefined> = {};
 const REAL_CLOUD_BINDINGS = { ...realCloudBindings };
 
@@ -41,6 +42,12 @@ mock.module("../../cache/client", () => ({
 mock.module("../../runtime/cloud-bindings", () => ({
   ...REAL_CLOUD_BINDINGS,
   getCloudAwareEnv: mock(() => cloudEnv),
+}));
+
+mock.module("../../utils/logger", () => ({
+  logger: {
+    warn: loggerWarn,
+  },
 }));
 
 mock.module("@ai-sdk/openai", () => ({
@@ -101,6 +108,7 @@ describe("runOnboardingChat", () => {
     linkPhoneToUser.mockResolvedValue({ success: true });
     generateText.mockReset();
     launchManagedElizaAgent.mockReset();
+    loggerWarn.mockReset();
     cloudEnv = {};
   });
 
@@ -950,6 +958,54 @@ describe("runOnboardingChat", () => {
         });
         expect(third.handoffComplete).toBe(true);
         expect(rememberCalls).toBe(2);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    test("a failed remember error body read is logged without fabricating handoff success", async () => {
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = mock(async (_input: RequestInfo | URL, _init?: RequestInit) => {
+        return {
+          ok: false,
+          status: 502,
+          text: mock(async () => {
+            throw new Error("body stream broke");
+          }),
+        } as Response;
+      }) as typeof fetch;
+
+      try {
+        ensureElizaAppProvisioning.mockResolvedValue({
+          status: "running",
+          agentId: "agent-1",
+          bridgeUrl: "https://agent-1.example",
+          sandbox: { id: "agent-1", status: "running", bridge_url: "https://agent-1.example" },
+        });
+        launchManagedElizaAgent.mockResolvedValue({
+          appUrl: "https://app.elizacloud.ai/dashboard/agents/agent-1",
+          connection: { apiBase: "https://agent-1.example", token: "agent-token" },
+        });
+
+        const result = await runOnboardingChat({
+          message: "My name is Sam",
+          platform: "blooio",
+          platformUserId: PHONE,
+          sessionId: PLATFORM_SESSION,
+          trustedPlatformIdentity: true,
+          authenticatedUser: { userId: "user-1", organizationId: "org-1" },
+        });
+
+        expect(result.handoffComplete).toBe(false);
+        expect(result.session.handoffCopiedAt).toBeUndefined();
+        expect(loggerWarn).toHaveBeenCalledWith(
+          "[eliza-app onboarding] failed to read remember error body",
+          expect.objectContaining({
+            agentId: "agent-1",
+            status: 502,
+            error: "body stream broke",
+          }),
+        );
       } finally {
         globalThis.fetch = originalFetch;
       }

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
@@ -551,7 +551,14 @@ async function copyTranscriptToManagedAgent(session: OnboardingSession): Promise
     if (!rememberResponse.ok) {
       // error-policy:J6 best-effort read of the error body to enrich the error
       // we throw next; a failed body read must not mask the non-ok status.
-      const body = await rememberResponse.text().catch(() => "");
+      const body = await rememberResponse.text().catch((error) => {
+        logger.warn("[eliza-app onboarding] failed to read remember error body", {
+          agentId: session.agentId,
+          status: rememberResponse.status,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return "";
+      });
       throw new Error(`memory copy failed (${rememberResponse.status}) ${body.slice(0, 200)}`);
     }
 


### PR DESCRIPTION
## Summary
- log failures when onboarding handoff cannot read the managed-agent remember error body
- keep the existing fail-open handoff retry behavior while making the diagnostic failure observable
- add a regression test for a rejecting remember response body read

Fixes part of #13415.

## Verification
- bun test packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
- node ../shared/scripts/generate-keywords.mjs --target ts (from packages/core)
- bunx @biomejs/biome check packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts --no-errors-on-unmatched
- bun run --cwd packages/cloud/shared typecheck 2>&1 | rg "onboarding-chat" || true
- git diff --check
- bun run audit:error-policy-ratchet