### PR TITLE
fix(ci): green Windows CI + Tests lane persistent test failures

### DIFF
--- a/packages/cloud/services/coding-remote-runner/src/index.ts
+++ b/packages/cloud/services/coding-remote-runner/src/index.ts
@@ -535,10 +535,17 @@ async function resolveExistingPath(
     config,
     rawPath ?? config.containerWorkspaceRoot,
   );
+  // Containment is decided lexically before the filesystem is probed: an
+  // out-of-workspace request must 403 whether or not its target exists, so
+  // the 403/404 split never becomes an existence oracle for host paths
+  // (and the answer stops depending on the runner host's filesystem layout).
+  ensureInsideRoot(nodePath.resolve(config.workspaceRoot), resolved.fsPath);
   const real = await realpath(resolved.fsPath).catch(() => {
     throw new HttpError(404, "Path not found");
   });
   const root = await realpath(config.workspaceRoot);
+  // Re-check after symlink resolution: a link inside the workspace must not
+  // escape it.
   ensureInsideRoot(root, real);
   return { fsPath: real, containerPath: resolved.containerPath };
 }

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-shared-billing.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-shared-billing.test.ts
@@ -222,6 +222,7 @@ describe("ElizaSandboxService shared runtime billing", () => {
           model: "gpt-oss-120b",
           degraded: false,
           runtime: "shared",
+          transport: "shared-runtime",
         },
       });
       expect(reserveCredits).toHaveBeenCalledWith(

--- a/packages/evidence/src/analyzers/keyframes.test.ts
+++ b/packages/evidence/src/analyzers/keyframes.test.ts
@@ -7,6 +7,7 @@ import { existsSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { afterAll, describe, expect, it } from "vitest";
+import { resolveFfmpegBinary } from "../ffmpeg-binaries.ts";
 import {
   extractKeyframes,
   ffmpegAvailable,
@@ -21,13 +22,18 @@ const dir = makeTmpDir();
 afterAll(() => rmSync(dir, { recursive: true, force: true }));
 
 const hasFfmpeg = await ffmpegAvailable();
+// The availability gate above resolves env → PATH → bundled ffmpeg-static, so
+// the fixture must spawn the same resolved binary — a bare "ffmpeg" fails on
+// runners where only the bundled static binary exists.
+const ffmpeg = await resolveFfmpegBinary();
+const ffmpegBin = ffmpeg.available ? ffmpeg.bin : "ffmpeg";
 
 /**
  * Build a 2-scene .mp4: 1s of solid red then 1s of solid blue, concatenated so
  * ffmpeg's scene detector sees exactly one hard cut between two colour blocks.
  */
 async function makeTwoSceneVideo(out: string): Promise<void> {
-  await execFileAsync("ffmpeg", [
+  await execFileAsync(ffmpegBin, [
     "-hide_banner",
     "-loglevel",
     "error",

--- a/packages/scenario-runner/src/__tests__/deterministic-action-coverage.test.ts
+++ b/packages/scenario-runner/src/__tests__/deterministic-action-coverage.test.ts
@@ -111,6 +111,8 @@ const CORE_ACTION_SURFACE: Record<string, readonly string[]> = {
     "GENERATE_MEDIA",
     "IDENTIFY_SPEAKER",
     "LOCAL_INFERENCE",
+    "REDACT_TRANSCRIPT",
+    "SHARE_TRANSCRIPT",
     "START_TRANSCRIPTION",
     "STOP_TRANSCRIPTION",
   ],
@@ -206,6 +208,10 @@ const KNOWN_UNCOVERED: readonly string[] = [
   // New on-device transcription actions; no deterministic keyless scenario yet.
   "START_TRANSCRIPTION",
   "STOP_TRANSCRIPTION",
+  // Transcript permissioning actions (#15606); no deterministic keyless
+  // scenario yet.
+  "REDACT_TRANSCRIPT",
+  "SHARE_TRANSCRIPT",
   // New workflow code-eval action (#8914); no deterministic keyless scenario yet.
   "EVAL_CODE",
   // App-control agent/model switchers + settings surface; dispatched through

--- a/packages/scripts/cloud/admin/prune-runner-workspaces.ts
+++ b/packages/scripts/cloud/admin/prune-runner-workspaces.ts
@@ -71,9 +71,14 @@ export function parseRunnerWorkspacePruneArgs(
     }
   }
 
-  const root = path.resolve(
-    flags.get("root") ?? env.RUNNER_WORKSPACE_ROOT ?? DEFAULT_ROOT,
-  );
+  const rawRoot =
+    flags.get("root") ?? env.RUNNER_WORKSPACE_ROOT ?? DEFAULT_ROOT;
+  // Runner hosts are Linux; keep POSIX-absolute roots verbatim so parsing
+  // behaves identically when this suite runs on win32 CI, where path.resolve
+  // would drive-qualify "/opt/..." into "D:\opt\...".
+  const root = rawRoot.startsWith("/")
+    ? path.posix.normalize(rawRoot)
+    : path.resolve(rawRoot);
   const minAgeRaw =
     flags.get("min-age-hours") ??
     env.RUNNER_WORKSPACE_MIN_AGE_HOURS ??

--- a/plugins/plugin-app-control/package.json
+++ b/plugins/plugin-app-control/package.json
@@ -13,6 +13,11 @@
 				"import": "./src/index.ts",
 				"default": "./src/index.ts"
 			},
+			"bun": {
+				"types": "./src/index.ts",
+				"import": "./src/index.ts",
+				"default": "./src/index.ts"
+			},
 			"import": "./dist/index.js",
 			"default": "./dist/index.js"
 		},
@@ -20,6 +25,11 @@
 		"./*": {
 			"types": "./dist/*.d.ts",
 			"eliza-source": {
+				"types": "./src/*.ts",
+				"import": "./src/*.ts",
+				"default": "./src/*.ts"
+			},
+			"bun": {
 				"types": "./src/*.ts",
 				"import": "./src/*.ts",
 				"default": "./src/*.ts"


### PR DESCRIPTION
## What

Five root-caused fixes for persistent red on develop's **Windows CI** (run [28999744788](https://github.com/elizaOS/eliza/actions/runs/28999744788), shards `build-and-helper-smokes`, `framework-packages`, `app-and-cli`) and **Tests** (run [28999744769](https://github.com/elizaOS/eliza/actions/runs/28999744769)) lanes. Each failure was traced to its regressing commit; none were fixed at tip and no PR was in flight.

| Failure | Regressor | Fix |
|---|---|---|
| `eliza-sandbox-shared-billing.test.ts` — result has extra `transport: "shared-runtime"` (fails cross-platform; also in the Cloud Tests unit lane) | #15616 updated `eliza-sandbox.test.ts` but missed this expectation | add the field to the expected result |
| `prune-runner-workspaces.test.ts` ×3 — `root` comes back `D:\opt\actions-runners` | #15504 written Linux-only; first Windows execution via `fb96f81b4ff` | keep POSIX-absolute roots verbatim (`path.posix.normalize`); relative inputs still `path.resolve` |
| `coding-remote-runner server.test.ts` — `/etc/passwd` read expects 403, got 404 on win32 | old Linux-only assumption exposed by `fb96f81b4ff` | check lexical containment **before** probing existence; also stops the 403/404 split leaking out-of-root file existence. Symlink escape still re-checked post-`realpath` |
| `deterministic-action-coverage.test.ts` — plugin-local-inference real actions ≠ manifest (fails cross-platform; also the Tests-lane server failure) | #15606 added `REDACT_TRANSCRIPT`/`SHARE_TRANSCRIPT` without classifying them | add to `CORE_ACTION_SURFACE`, baseline in `KNOWN_UNCOVERED` (shrink-only list; no deterministic keyless scenario yet) |
| `managed-eliza-lean-chat-boot.integration.test.ts` D10 — `Cannot find module '@elizaos/plugin-app-control'` (persistent since Jul 6) | #14804 added a hard value import from agent src; bun resolves agent via its `bun` export condition to src, but plugin-app-control had no `bun` condition and the Windows lane never builds its dist | add the `bun` exports condition, mirroring `@elizaos/agent` |
| `keyframes.test.ts` ×2 — `spawn ffmpeg ENOENT` (Tests lane) | availability gate resolves env → PATH → bundled `ffmpeg-static`, fixture spawned bare `ffmpeg` | spawn the resolved binary (same pattern as `runner.test.ts`) |

## Evidence (all run locally in a clean worktree at develop tip)

- `bun test packages/cloud/shared/src/lib/services/eliza-sandbox-shared-billing.test.ts` → **0 fail**
- `bun test packages/scripts/cloud/admin/prune-runner-workspaces.test.ts` → **5 pass / 0 fail**
- `bun run --cwd packages/cloud/services/coding-remote-runner test` → **13 pass / 0 fail**
- `bun run --cwd packages/scenario-runner test` → **273 passed (34 files)**
- `bun run --cwd packages/evidence test` → **427 passed | 2 skipped**
- plugin-app-control fix proven red→green: with `dist/` removed and the exports change stashed, D10 fails `Cannot find module '@elizaos/plugin-app-control' from .../settings-actions.ts`; restoring the exports condition → **4 pass / 0 fail** (dist still absent)

The two win32-only fixes can't be executed on this Linux box; their failure modes are deterministic path-semantics differences confirmed from the run logs (`D:\opt\actions-runners`, 404-vs-403 on `D:\etc\passwd`), and the changed code paths are covered by the green Linux suites above.

CI-lane test/infra remediation — no UI surface (screenshots/video N/A); no model/agent behavior change (trajectories N/A). Part of the develop CI remediation alongside #15713.

🤖 Generated with [Claude Code](https://claude.com/claude-code)