### PR TITLE
fix(ci): mark perf-gate synthetic touch drags as primary pointers

### DIFF
--- a/packages/ui/src/components/shell/__e2e__/run-chat-perf-gate.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-perf-gate.mjs
@@ -121,6 +121,7 @@ async function drag(p, selector, dx, dy, { steps = 14, stepMs = 16 } = {}) {
         new PointerEvent("pointerdown", {
           pointerId: 1,
           pointerType: "touch",
+          isPrimary: true,
           clientX: cx,
           clientY: cy,
           bubbles: true,
@@ -138,6 +139,7 @@ async function drag(p, selector, dx, dy, { steps = 14, stepMs = 16 } = {}) {
           new PointerEvent("pointermove", {
             pointerId: 1,
             pointerType: "touch",
+            isPrimary: true,
             clientX: x,
             clientY: y,
             bubbles: true,
@@ -153,6 +155,7 @@ async function drag(p, selector, dx, dy, { steps = 14, stepMs = 16 } = {}) {
         new PointerEvent("pointerup", {
           pointerId: 1,
           pointerType: "touch",
+          isPrimary: true,
           clientX: x,
           clientY: y,
           bubbles: true,

--- a/packages/ui/src/components/shell/__e2e__/run-perf-gate-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-perf-gate-e2e.mjs
@@ -110,6 +110,7 @@ async function drag(p, selector, dx, dy, { steps = 12, stepMs = 16 } = {}) {
         new PointerEvent("pointerdown", {
           pointerId: 1,
           pointerType: "touch",
+          isPrimary: true,
           clientX: cx,
           clientY: cy,
           bubbles: true,
@@ -127,6 +128,7 @@ async function drag(p, selector, dx, dy, { steps = 12, stepMs = 16 } = {}) {
           new PointerEvent("pointermove", {
             pointerId: 1,
             pointerType: "touch",
+            isPrimary: true,
             clientX: x,
             clientY: y,
             bubbles: true,
@@ -142,6 +144,7 @@ async function drag(p, selector, dx, dy, { steps = 12, stepMs = 16 } = {}) {
         new PointerEvent("pointerup", {
           pointerId: 1,
           pointerType: "touch",
+          isPrimary: true,
           clientX: x,
           clientY: y,
           bubbles: true,


### PR DESCRIPTION
## Problem

The **Chat shell gestures** workflow has failed on every run that reached the "Chat overlay perf gate" step since Jul 8 20:36 UTC, with a deterministic signature: `✗ thread (perf surface) mounted`, then a 30s `TimeoutError` waiting for `locator('#continuous-thread')` in `drag()` (`run-chat-perf-gate.mjs:113`).

`39c72afff515` (#15497) added a guard in `usePullGesture`'s `onPointerDown` that ignores non-primary touch pointers:

```ts
if (event.isPrimary === false && event.pointerType && event.pointerType !== "mouse") return;
```

That commit updated `run-chat-sheet-e2e.mjs`'s synthetic dispatch to pass `isPrimary: true` — but the two perf-gate runners carry their own private copies of `drag()`, and `PointerEventInit.isPrimary` defaults to **false** per spec. Every synthetic grabber drag was silently rejected at `pointerdown`: the sheet never opened, `threadPresented` stayed false, and `#continuous-thread` (mounted only while the thread is presented, by design) never appeared. The page is otherwise healthy — no console errors precede the failure, which is why this looked like a mount regression rather than an input one. Last pass of this step: `26276ba4a1` (Jul 8 16:14, pre-guard).

## Fix

`isPrimary: true` on all six synthetic `pointerdown`/`pointermove`/`pointerup` constructions across `run-chat-perf-gate.mjs` and `run-perf-gate-e2e.mjs` — matching what a real first touch reports and what `run-chat-sheet-e2e.mjs` already does. (The second runner is currently masked by the first one failing; without this it would fail identically the moment the first gate greens, so both are fixed together.)

## Evidence — both gates run locally end-to-end with the fix

`bun run --cwd packages/ui test:chat-perf-gate`:
```
✓ thread (perf surface) mounted
✓ over-pull commits full-bleed (4/4 committed)
✓ top-20% pull-down restores the inset overlay (4/4 restored)
✓ dropped-frame ratio 4.9% within 25%
✓ median streaming dropped-frame ratio 19.8% within 25%
✓ no page errors (saw 0)
PERF GATE PASSED
```

`bun run --cwd packages/ui test:perf-gate-e2e`:
```
✓ an over-pull past the 80% threshold committed full-bleed at least once (12/4)
✓ final over-pull commits full-bleed (data-maximized=true)
✓ layout stable during the maximize/restore transition (CLS 0.0096 ≤ 0.1, 4 shifts)
✓ no page errors (saw 0)
PERF GATE PASSED
```

Test-fixture-only change (no product code touched); the gate output above is the rendered-behavior proof — the drags demonstrably drive the real overlay. Known residual on this lane (separate root cause, not addressed here): the "Chat-sheet gesture e2e" `[desktop-held]` drain-leg flake from the Jul-7 drag rewrite.

Follow-up worth filing: hoist the thrice-duplicated `drag()` into `packages/ui/src/testing/` so the pointer-event contract can't drift per-runner again — this is the second time a gesture change greened one runner and stranded the copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)