### PR TITLE
fix(cloud): log sandbox restore body read failures

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -316,6 +316,56 @@ describe("ElizaSandboxService state restore auth", () => {
     expect(requests).toHaveLength(1);
     expect(requests[0].headers).toEqual({ "Content-Type": "application/json" });
   });
+
+  test("logs restore error body read failures before throwing the restore status", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
+    globalThis.fetch = mock(async () => {
+      return {
+        ok: false,
+        status: 502,
+        text: mock(async () => {
+          throw new Error("restore body stream broke");
+        }),
+      } as Response;
+    });
+
+    try {
+      await expect(
+        (
+          new ElizaSandboxService() as unknown as {
+            pushState: (
+              bridgeUrl: string,
+              state: {
+                memories: unknown[];
+                config: Record<string, unknown>;
+                workspaceFiles: object;
+              },
+              options?: { trusted?: boolean },
+            ) => Promise<void>;
+          }
+        ).pushState(
+          "https://runtime.example",
+          {
+            memories: [],
+            config: {},
+            workspaceFiles: {},
+          },
+          { trusted: true },
+        ),
+      ).rejects.toThrow("State restore failed: HTTP 502");
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[agent-sandbox] Failed to read restore error body",
+        expect.objectContaining({
+          status: 502,
+          error: "restore body stream broke",
+        }),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
 });
 
 describe("ElizaSandboxService bridge status", () => {

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -6251,7 +6251,15 @@ export class ElizaSandboxService {
       signal: AbortSignal.timeout(SNAPSHOT_RESTORE_TIMEOUT_MS),
     });
     if (!res.ok) {
-      const text = await res.text().catch(() => "");
+      // error-policy:J6 best-effort read of the restore error body to enrich
+      // the error we throw next; a failed body read must not mask the status.
+      const text = await res.text().catch((error) => {
+        logger.warn("[agent-sandbox] Failed to read restore error body", {
+          status: res.status,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return "";
+      });
       throw new Error(`State restore failed: HTTP ${res.status} ${text.slice(0, 200)}`);
     }
   }


### PR DESCRIPTION
## Summary
- log failures when sandbox state-restore cannot read the non-OK restore response body
- keep the existing thrown restore status instead of masking it with the body-read failure
- add a regression test for a rejecting restore response body read

Fixes part of #13415.

## Verification
- `bun test packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts -t "logs restore error body read failures"` passed the target test, then hung during coverage/report teardown and was interrupted
- bunx @biomejs/biome check packages/cloud/shared/src/lib/services/eliza-sandbox.ts packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts --no-errors-on-unmatched
- bun run --cwd packages/cloud/shared typecheck 2>&1 | rg "eliza-sandbox" || true
- git diff --check
- bun run audit:error-policy-ratchet