### PR TITLE
fix(cloud): log pooled probe body read failures

### DIFF
--- a/packages/cloud/shared/src/lib/services/team-credential-pool/probe.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/team-credential-pool/probe.error-policy.test.ts
@@ -6,7 +6,8 @@
  * `probePooledApiKey` against a stubbed global `fetch` (no network, no DB).
  */
 
-import { afterEach, describe, expect, it, mock } from "bun:test";
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { logger } from "../../utils/logger";
 import { probePooledApiKey } from "./probe";
 
 function okResponse(status: number): Response {
@@ -72,6 +73,7 @@ describe("probePooledApiKey error policy", () => {
   });
 
   it("does not let a failed error-body read clobber the load-bearing HTTP status", async () => {
+    const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
     const bodyReadFails = {
       ok: false,
       status: 403,
@@ -81,12 +83,24 @@ describe("probePooledApiKey error policy", () => {
     } as unknown as Response;
     globalThis.fetch = mock(async () => bodyReadFails) as unknown as typeof fetch;
 
-    const result = await probePooledApiKey("openai-api", "sk-forbidden-key");
+    try {
+      const result = await probePooledApiKey("openai-api", "sk-forbidden-key");
 
-    expect(result.ok).toBe(false);
-    // The inner `.catch(() => "")` on response.text() must preserve status 403,
-    // not fall through to the outer catch (which would report status:0).
-    expect(result.status).toBe(403);
+      expect(result.ok).toBe(false);
+      // The inner body-read handler must preserve status 403, not fall through
+      // to the outer catch (which would report status:0).
+      expect(result.status).toBe(403);
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[team-credential-pool] Failed to read pooled API probe error body",
+        expect.objectContaining({
+          providerId: "openai-api",
+          status: 403,
+          error: "stream already consumed",
+        }),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it("distinguishes all three outcomes from one another", async () => {

--- a/packages/cloud/shared/src/lib/services/team-credential-pool/probe.ts
+++ b/packages/cloud/shared/src/lib/services/team-credential-pool/probe.ts
@@ -13,6 +13,7 @@
  */
 
 import { getCloudAwareEnv } from "../../runtime/cloud-bindings";
+import { logger } from "../../utils/logger";
 import type { PooledDirectProvider } from "./provider-map";
 
 export function pooledProviderBaseUrl(providerId: PooledDirectProvider): string {
@@ -76,7 +77,14 @@ export async function probePooledApiKey(
       // signal (drives fail-closed rejection at contribution and needs-reauth at
       // keep-alive); reading the optional provider error body is best-effort and
       // must not clobber that status by throwing out of this branch.
-      const text = await response.text().catch(() => "");
+      const text = await response.text().catch((error) => {
+        logger.warn("[team-credential-pool] Failed to read pooled API probe error body", {
+          providerId,
+          status: response.status,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return "";
+      });
       return {
         ok: false,
         status: response.status,


### PR DESCRIPTION
## Summary
- log failures when pooled API-key probe error bodies cannot be read
- preserve the existing structured `ok:false` result with the provider HTTP status
- extend the error-policy test to assert the warning and the status-preservation behavior

Fixes part of #13415.

## Verification
- bun test packages/cloud/shared/src/lib/services/team-credential-pool/probe.error-policy.test.ts
- bunx @biomejs/biome check packages/cloud/shared/src/lib/services/team-credential-pool/probe.ts packages/cloud/shared/src/lib/services/team-credential-pool/probe.error-policy.test.ts --no-errors-on-unmatched
- bun run --cwd packages/cloud/shared typecheck 2>&1 | rg "team-credential-pool/probe" || true
- git diff --check
- bun run audit:error-policy-ratchet