### PR TITLE
fix(cloud): log native bridge json parse failures

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-failurekind.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-failurekind.test.ts
@@ -13,8 +13,9 @@
  * fabricated generic fallback. Real ladder methods; only the sandbox-side HTTP
  * boundary (fetch) is stubbed.
  */
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import type { AgentSandbox } from "../../db/repositories/agent-sandboxes";
+import { logger } from "../utils/logger";
 import { ElizaSandboxService } from "./eliza-sandbox";
 import type { BridgeRequest, BridgeResponse } from "./eliza-sandbox-bridge";
 import { ElizaSandboxBridgeService } from "./eliza-sandbox-bridge";
@@ -136,6 +137,43 @@ describe("ElizaSandboxService native bridge failureKind propagation", () => {
     expect(response.result?.transport).toBe("native-jsonrpc");
     expect(response.result?.fallback).toBeUndefined();
     expect(paths).toEqual(["/bridge"]);
+  });
+
+  test("malformed native JSON-RPC body is logged before the ladder falls through", async () => {
+    const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
+    const paths: string[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      const path = new URL(url).pathname;
+      paths.push(path);
+      if (path === "/bridge") {
+        return {
+          status: 502,
+          json: async () => {
+            throw new Error("invalid json");
+          },
+        } as Response;
+      }
+      return new Response("not found", { status: 404 });
+    }) as typeof fetch;
+
+    try {
+      const response = await makeHostServiceSender().bridgeMessageSend(rec, rpc);
+
+      expect(response.result?.fallback).toBe(true);
+      expect(response.result?.transport).toBe("fallback");
+      expect(paths).toContain("/bridge");
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[agent-sandbox] Failed to parse native bridge JSON-RPC body",
+        expect.objectContaining({
+          agentId: "sandbox-1",
+          status: 502,
+          error: "invalid json",
+        }),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -2804,7 +2804,14 @@ export class ElizaSandboxService {
       );
     }
     // Parse envelope; cloud-agent returns valid JSON-RPC on both 200 and 500.
-    const body = (await res.json().catch(() => null)) as {
+    const body = (await res.json().catch((error) => {
+      logger.warn("[agent-sandbox] Failed to parse native bridge JSON-RPC body", {
+        agentId: rec.id,
+        status: res.status,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    })) as {
       jsonrpc?: string;
       id?: unknown;
       result?: { text?: string };


### PR DESCRIPTION
## Summary
- log failures when the cloud-agent native `/bridge` JSON-RPC body cannot be parsed
- preserve existing bridge ladder behavior: malformed native bridge responses still fall through to legacy/fallback routes
- add a focused regression test that asserts the warning and fallback behavior

Fixes part of #13415.

## Verification
- `bun test packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-failurekind.test.ts` passed all 8 tests, then hung during coverage/report teardown and was interrupted
- bunx @biomejs/biome check packages/cloud/shared/src/lib/services/eliza-sandbox.ts packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-failurekind.test.ts --no-errors-on-unmatched
- bun run --cwd packages/cloud/shared typecheck 2>&1 | rg "eliza-sandbox(-bridge-failurekind)?" || true
- git diff --check
- bun run audit:error-policy-ratchet