### PR TITLE
fix(app): align ios mixed content smoke origin contract

### DIFF
--- a/packages/app/scripts/ios-onboarding-smoke.mjs
+++ b/packages/app/scripts/ios-onboarding-smoke.mjs
@@ -20,6 +20,7 @@ import {
   DEFAULT_HOST_AGENT_PORT,
   startDeviceE2eHostAgent,
 } from "./lib/host-agent.mjs";
+import { assertIosMixedContentSmokeResult } from "./lib/ios-mixed-content-smoke-contract.mjs";
 import {
   assertCandidateIosAppRendererFresh,
   assertInstalledIosAppRendererFresh,
@@ -580,41 +581,7 @@ async function main() {
       log(`liveness reply OK: ${JSON.stringify(result.livenessReply)}`);
     }
     const mixedContentResult = await pollMixedContentResult(udid, appId);
-    if (
-      !String(mixedContentResult.webViewOrigin).startsWith("https://localhost")
-    ) {
-      throw new Error(
-        `iOS mixed-content smoke did not run from https://localhost: ${JSON.stringify(mixedContentResult)}`,
-      );
-    }
-    if (mixedContentResult.mixedContentWouldBlockWebSocket !== true) {
-      throw new Error(
-        `iOS mixed-content smoke did not prove an insecure ws:// would be mixed content: ${JSON.stringify(mixedContentResult)}`,
-      );
-    }
-    if (
-      !Array.isArray(mixedContentResult.webSocketConstructorCalls) ||
-      mixedContentResult.webSocketConstructorCalls.length !== 0
-    ) {
-      throw new Error(
-        `iOS mixed-content smoke attempted a WebSocket: ${JSON.stringify(mixedContentResult.webSocketConstructorCalls)}`,
-      );
-    }
-    if (mixedContentResult.connectionState?.state !== "connected") {
-      throw new Error(
-        `iOS mixed-content smoke was not connected-over-REST: ${JSON.stringify(mixedContentResult.connectionState)}`,
-      );
-    }
-    if (mixedContentResult.lostBackendOverlayAbsent !== true) {
-      throw new Error(
-        `iOS mixed-content smoke found the lost backend overlay: ${JSON.stringify(mixedContentResult)}`,
-      );
-    }
-    if (mixedContentResult.restHealth?.ok !== true) {
-      throw new Error(
-        `iOS mixed-content smoke REST health failed: ${JSON.stringify(mixedContentResult.restHealth)}`,
-      );
-    }
+    assertIosMixedContentSmokeResult(mixedContentResult);
     defaultsWriteString(
       udid,
       appId,

--- a/packages/app/scripts/lib/ios-mixed-content-smoke-contract.mjs
+++ b/packages/app/scripts/lib/ios-mixed-content-smoke-contract.mjs
@@ -1,0 +1,78 @@
+/**
+ * iOS onboarding mixed-content smoke contract.
+ *
+ * WKWebView currently serves the bundled app from capacitor://localhost while
+ * some historical harness text expected https://localhost. The important
+ * invariant is transport behavior: the remote-connect path must be healthy over
+ * REST and must not require a WebSocket from the WebView.
+ */
+
+const SUPPORTED_ORIGINS = new Set(["capacitor://localhost"]);
+
+function resultJson(result) {
+  return JSON.stringify(result);
+}
+
+export function isSupportedIosWebViewOrigin(origin) {
+  const value = String(origin ?? "");
+  return value.startsWith("https://localhost") || SUPPORTED_ORIGINS.has(value);
+}
+
+export function assertIosMixedContentSmokeResult(result) {
+  if (!result || typeof result !== "object") {
+    throw new Error(
+      `iOS mixed-content smoke returned no result: ${resultJson(result)}`,
+    );
+  }
+
+  if (!isSupportedIosWebViewOrigin(result.webViewOrigin)) {
+    throw new Error(
+      `iOS mixed-content smoke ran from an unsupported WebView origin: ${resultJson(result)}`,
+    );
+  }
+
+  if (
+    String(result.webViewOrigin).startsWith("https://localhost") &&
+    result.mixedContentWouldBlockWebSocket !== true
+  ) {
+    throw new Error(
+      `iOS mixed-content smoke did not prove an insecure ws:// would be mixed content: ${resultJson(result)}`,
+    );
+  }
+
+  if (
+    result.webViewOrigin === "capacitor://localhost" &&
+    result.mixedContentWouldBlockWebSocket !== false
+  ) {
+    throw new Error(
+      `iOS mixed-content smoke reported an impossible mixed-content result for capacitor://localhost: ${resultJson(result)}`,
+    );
+  }
+
+  if (
+    !Array.isArray(result.webSocketConstructorCalls) ||
+    result.webSocketConstructorCalls.length !== 0
+  ) {
+    throw new Error(
+      `iOS mixed-content smoke attempted a WebSocket: ${resultJson(result.webSocketConstructorCalls)}`,
+    );
+  }
+
+  if (result.connectionState?.state !== "connected") {
+    throw new Error(
+      `iOS mixed-content smoke was not connected-over-REST: ${resultJson(result.connectionState)}`,
+    );
+  }
+
+  if (result.lostBackendOverlayAbsent !== true) {
+    throw new Error(
+      `iOS mixed-content smoke found the lost backend overlay: ${resultJson(result)}`,
+    );
+  }
+
+  if (result.restHealth?.ok !== true) {
+    throw new Error(
+      `iOS mixed-content smoke REST health failed: ${resultJson(result.restHealth)}`,
+    );
+  }
+}

--- a/packages/app/scripts/lib/ios-mixed-content-smoke-contract.test.mjs
+++ b/packages/app/scripts/lib/ios-mixed-content-smoke-contract.test.mjs
@@ -1,0 +1,93 @@
+/**
+ * Regression coverage for the iOS onboarding mixed-content simulator contract.
+ */
+import { describe, expect, it } from "vitest";
+import { assertIosMixedContentSmokeResult } from "./ios-mixed-content-smoke-contract.mjs";
+
+function validResult(overrides = {}) {
+  return {
+    webViewOrigin: "capacitor://localhost",
+    mixedContentWouldBlockWebSocket: false,
+    webSocketConstructorCalls: [],
+    connectionState: { state: "connected" },
+    lostBackendOverlayAbsent: true,
+    restHealth: { ok: true },
+    ...overrides,
+  };
+}
+
+describe("assertIosMixedContentSmokeResult", () => {
+  it("accepts the current iOS Capacitor WebView origin when REST is connected and no WebSocket is attempted", () => {
+    expect(() => assertIosMixedContentSmokeResult(validResult())).not.toThrow();
+  });
+
+  it("keeps the historical https://localhost contract when a build actually runs from that origin", () => {
+    expect(() =>
+      assertIosMixedContentSmokeResult(
+        validResult({
+          webViewOrigin: "https://localhost",
+          mixedContentWouldBlockWebSocket: true,
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  it("rejects unsupported origins", () => {
+    expect(() =>
+      assertIosMixedContentSmokeResult(
+        validResult({ webViewOrigin: "http://localhost" }),
+      ),
+    ).toThrow(/unsupported WebView origin/);
+  });
+
+  it("rejects WebSocket construction even on capacitor://localhost", () => {
+    expect(() =>
+      assertIosMixedContentSmokeResult(
+        validResult({
+          webSocketConstructorCalls: ["ws://127.0.0.1:31338/ws"],
+        }),
+      ),
+    ).toThrow(/attempted a WebSocket/);
+  });
+
+  it("rejects disconnected REST state", () => {
+    expect(() =>
+      assertIosMixedContentSmokeResult(
+        validResult({
+          connectionState: { state: "disconnected" },
+        }),
+      ),
+    ).toThrow(/not connected-over-REST/);
+  });
+
+  it("rejects lost-backend overlay visibility", () => {
+    expect(() =>
+      assertIosMixedContentSmokeResult(
+        validResult({
+          lostBackendOverlayAbsent: false,
+        }),
+      ),
+    ).toThrow(/lost backend overlay/);
+  });
+
+  it("rejects impossible mixed-content state for capacitor://localhost", () => {
+    expect(() =>
+      assertIosMixedContentSmokeResult(
+        validResult({
+          mixedContentWouldBlockWebSocket: true,
+        }),
+      ),
+    ).toThrow(/impossible mixed-content result/);
+  });
+
+  it("rejects https://localhost without the mixed-content proof", () => {
+    expect(() =>
+      assertIosMixedContentSmokeResult(
+        validResult({
+          webViewOrigin: "https://localhost",
+          mixedContentWouldBlockWebSocket: false,
+        }),
+      ),
+    ).toThrow(/did not prove an insecure ws/);
+  });
+});


### PR DESCRIPTION
## Summary
- update the iOS onboarding mixed-content smoke contract to accept the documented `capacitor://localhost` WKWebView origin
- keep the real transport assertions: no WebSocket constructor calls, REST connected, no lost-backend overlay, REST health ok
- preserve the old `https://localhost` mixed-content proof when a build actually reports that origin

Fixes #15725.

## Verification
- bun test packages/app/scripts/lib/ios-mixed-content-smoke-contract.test.mjs
- bunx @biomejs/biome check packages/app/scripts/ios-onboarding-smoke.mjs packages/app/scripts/lib/ios-mixed-content-smoke-contract.mjs packages/app/scripts/lib/ios-mixed-content-smoke-contract.test.mjs --no-errors-on-unmatched
- bun run --cwd packages/app typecheck 2>&1 | rg "ios-(mixed-content|onboarding-smoke)|ios-mixed-content" || true
- git diff --check
- bun run audit:error-policy-ratchet