### PR TITLE
fix(app): diagnose ios full bun smoke stalls

### DIFF
--- a/packages/app/scripts/mobile-local-chat-smoke.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke.mjs
@@ -455,6 +455,58 @@ function readIosDefaultsString(udid, domain, key) {
   return null;
 }
 
+function readIosFullBunSmokeDiagnostics(udid, domain) {
+  const dataContainer = tryExec(
+    "xcrun",
+    ["simctl", "get_app_container", udid, domain, "data"],
+    { allowFailure: true },
+  );
+  const plist = dataContainer
+    ? path.join(dataContainer, "Library", "Preferences", `${domain}.plist`)
+    : null;
+  let plistData = null;
+  if (plist && fs.existsSync(plist)) {
+    const json = tryExec("plutil", ["-convert", "json", "-o", "-", plist], {
+      allowFailure: true,
+    });
+    if (json) {
+      try {
+        plistData = JSON.parse(json);
+      } catch {
+        plistData = null;
+      }
+    }
+  }
+  const keys = [
+    IOS_FULL_BUN_SMOKE_REQUEST_KEY,
+    IOS_FULL_BUN_SMOKE_RESULT_KEY,
+    IOS_FULL_BUN_PREWARM_RESULT_KEY,
+  ].map((key) => {
+    const nativeKey = `CapacitorStorage.${key}`;
+    const plistValue = plistData?.[nativeKey];
+    return [
+      key,
+      {
+        nativeKey,
+        plistValue: typeof plistValue === "string" ? plistValue : null,
+        defaultsValue: tryExec(
+          "xcrun",
+          ["simctl", "spawn", udid, "defaults", "read", domain, nativeKey],
+          { allowFailure: true },
+        ),
+      },
+    ];
+  });
+  return {
+    udid,
+    domain,
+    dataContainer: dataContainer || null,
+    plist,
+    plistExists: Boolean(plist && fs.existsSync(plist)),
+    keys: Object.fromEntries(keys),
+  };
+}
+
 function deleteIosDefaultsKey(udid, domain, key) {
   const dataContainer = tryExec(
     "xcrun",
@@ -640,8 +692,20 @@ function preseedIosFullBunSmoke(udid, id) {
   );
   writeIosDefaultsString(udid, id, IOS_FULL_BUN_SMOKE_REQUEST_KEY, "1");
   flushIosPreferencesCache(udid);
+  const diagnostics = readIosFullBunSmokeDiagnostics(udid, id);
+  const requestReadback =
+    diagnostics.keys[IOS_FULL_BUN_SMOKE_REQUEST_KEY]?.defaultsValue ??
+    diagnostics.keys[IOS_FULL_BUN_SMOKE_REQUEST_KEY]?.plistValue;
+  const resultReadback =
+    diagnostics.keys[IOS_FULL_BUN_SMOKE_RESULT_KEY]?.defaultsValue ??
+    diagnostics.keys[IOS_FULL_BUN_SMOKE_RESULT_KEY]?.plistValue;
+  if (requestReadback !== "1" || !resultReadback) {
+    throw new Error(
+      `iOS full Bun smoke preseed was not readable from native defaults: ${JSON.stringify(diagnostics)}`,
+    );
+  }
   console.log(
-    `[local-chat-smoke] Requested in-app iOS full Bun backend smoke for ${id}.`,
+    `[local-chat-smoke] Requested in-app iOS full Bun backend smoke for ${id}; native defaults readback succeeded.`,
   );
 }
 
@@ -1533,8 +1597,9 @@ async function verifyIosFullBunSmoke(context) {
   }
 
   const screenshot = takeIosScreenshot(context.udid, "ios-full-bun-timeout");
+  const diagnostics = readIosFullBunSmokeDiagnostics(context.udid, id);
   throw new Error(
-    `iOS full Bun smoke did not complete in time. Last result: ${lastRaw || "<none>"}${screenshot ? ` Screenshot: ${screenshot}` : ""}`,
+    `iOS full Bun smoke did not complete in time. Last result: ${lastRaw || "<none>"} Diagnostics: ${JSON.stringify(diagnostics)}${screenshot ? ` Screenshot: ${screenshot}` : ""}`,
   );
 }
 

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -1704,9 +1704,13 @@ async function withIosFullBunSmokeTimeout<T>(
 async function runIosFullBunSmokeIfRequested(): Promise<boolean> {
   if (iosFullBunSmokeStarted) return true;
   let requested = false;
+  let requestSource: "localStorage" | "preferences" | null = null;
   try {
     requested =
       window.localStorage.getItem(IOS_FULL_BUN_SMOKE_REQUEST_KEY) === "1";
+    if (requested) {
+      requestSource = "localStorage";
+    }
   } catch {
     // error-policy:J3 unavailable storage reads as "not requested"; the
     // Preferences read below still serves the simulator harness
@@ -1716,6 +1720,9 @@ async function runIosFullBunSmokeIfRequested(): Promise<boolean> {
     if (!requested) {
       requested =
         (await boundedPreferenceGet(IOS_FULL_BUN_SMOKE_REQUEST_KEY)) === "1";
+      if (requested) {
+        requestSource = "preferences";
+      }
     }
   } catch {
     // error-policy:J4 Preferences unavailable — keep the localStorage
@@ -1741,6 +1748,11 @@ async function runIosFullBunSmokeIfRequested(): Promise<boolean> {
   await writeIosFullBunSmokeResult({
     ok: false,
     phase: "running",
+    step: "request-observed",
+    requestSource,
+    location: window.location.href,
+    hasNativeRequest:
+      typeof window.__ELIZA_BRIDGE__?.iosLocalAgentRequest === "function",
     startedAt: new Date().toISOString(),
   });
 


### PR DESCRIPTION
## Summary
- fail the iOS full-Bun smoke immediately when the seeded native defaults request/result cannot be read back
- include native defaults/plist diagnostics in full-Bun timeout errors instead of reporting only `<none>`
- write an in-app `request-observed` result with the storage source before Bun runtime startup work begins

Fixes #15726.

## Verification
- `bunx @biomejs/biome check packages/app/scripts/mobile-local-chat-smoke.mjs packages/app/src/main.tsx --no-errors-on-unmatched`
- `bun run --cwd packages/app typecheck 2>&1 | rg "mobile-local-chat-smoke|main.tsx|ios-full-bun|full Bun" || true`
- `bun test packages/app/test/mobile-smoke-scripts.test.ts packages/app/scripts/android-smoke-model-contract.test.mjs packages/app/scripts/walkthrough-device-matrix.test.mjs`
- `git diff --check`
- `bun run audit:error-policy-ratchet`