### PR TITLE
fix(ui): unbreak app-host apex misclassification and stale restore-concurrency test

### DIFF
--- a/packages/ui/src/App.surface-manifest-wallpaper.test.tsx
+++ b/packages/ui/src/App.surface-manifest-wallpaper.test.tsx
@@ -424,6 +424,16 @@ describe("App wallpaper-grant invariant — manifest gates the wallpaper (#13452
       "requestAnimationFrame",
       vi.fn(() => 1),
     );
+    // No backend serves this suite, yet mounted pages (e.g. AutomationsFeed)
+    // fire real on-mount fetches; their socket errors can settle after vitest
+    // tears down the file's jsdom environment, where the late setState makes
+    // react-dom read the deleted `window` (unhandled teardown rejection on
+    // loaded CI workers). Forever-pending requests keep every page in its
+    // designed loading state with nothing left to settle after teardown.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise<Response>(() => {})),
+    );
     window.history.replaceState(null, "", "/views");
     Reflect.deleteProperty(window, "__ELIZAOS_API_BASE__");
     window.addEventListener("error", swallow);

--- a/packages/ui/src/cloud/shell/apex-host.ts
+++ b/packages/ui/src/cloud/shell/apex-host.ts
@@ -8,10 +8,15 @@
 
 import { ELIZA_CLOUD_CONTROL_PLANE_HOSTS } from "../../utils/cloud-agent-base";
 
-/** Control-plane hosts minus the API origins (api. / api-staging.) — the API
- * origins never serve the UI shell. */
+/** Control-plane hosts minus the API origins (api. / api-staging.), which
+ * never serve the UI shell, and minus the app hosts (app. / app-staging.),
+ * which serve the agent chat app — not the console. The app hosts sit in
+ * ELIZA_CLOUD_CONTROL_PLANE_HOSTS only so per-agent `<id>.elizacloud.ai`
+ * detection doesn't misread them as dedicated agent subdomains; classifying
+ * them as apex here would stop the agent app from ever booting on them (see
+ * AppCatchAllRoute) and send their post-login default to /dashboard. */
 export const APEX_UI_CONTROL_PLANE_HOSTS = new Set(
-  [...ELIZA_CLOUD_CONTROL_PLANE_HOSTS].filter((h) => !/^api[.-]/.test(h)),
+  [...ELIZA_CLOUD_CONTROL_PLANE_HOSTS].filter((h) => !/^(api|app)[.-]/.test(h)),
 );
 
 export function isApexControlPlaneHost(): boolean {

--- a/packages/ui/src/state/startup-phase-restore.concurrency.test.ts
+++ b/packages/ui/src/state/startup-phase-restore.concurrency.test.ts
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
 //
-// Boot parallelization of the restoring-session phase: (1) the cloud restore
-// overlaps the apiBase backfill lookup with the Steward-token refresh (both
-// network round-trips run concurrently; client mutations still land base →
+// Boot parallelization of the restoring-session phase: (1) a cloud restore
+// derives the dedicated per-agent base synchronously from the persisted id —
+// no backfill network lookup — and routes the client while the Steward-token
+// refresh round-trip is still in flight (client mutations still land base →
 // token), and (2) a desktop local restore issues ONE runtime-mode RPC shared
 // by the agent-autostart gate and the embedded-local target reclassification.
 // Real restore module under test; only the network / desktop-bridge
@@ -70,7 +71,7 @@ function makeDeps(): RestoringSessionDeps {
   };
 }
 
-describe("cloud restore overlaps backfill and Steward-token refresh", () => {
+describe("cloud restore routes the client without waiting on the Steward refresh", () => {
   let fetchMock: ReturnType<typeof vi.fn>;
   const realFetch = globalThis.fetch;
   const pendingRequests: Array<{
@@ -104,11 +105,12 @@ describe("cloud restore overlaps backfill and Steward-token refresh", () => {
     vi.restoreAllMocks();
   });
 
-  it("dispatches the Steward refresh while the backfill agent lookup is still in flight", async () => {
+  it("sets the id-derived dedicated base while the Steward refresh is still in flight", async () => {
     // A near-expiry stored JWT forces the refresh POST…
     localStorage.setItem(STEWARD_TOKEN_KEY, makeJwt(30));
     const fresh = makeJwt(3600);
-    // …and a MISSING apiBase forces backfill's network lookup for the agent.
+    // …and a MISSING apiBase forces the backfill, which derives the dedicated
+    // `<agentId>.elizacloud.ai` base purely from the persisted id.
     const restored: PersistedActiveServer = {
       id: "cloud:agent-123",
       kind: "cloud",
@@ -121,44 +123,37 @@ describe("cloud restore overlaps backfill and Steward-token refresh", () => {
       clientRef,
     });
 
-    // BOTH network calls must be observable while NEITHER has resolved —
-    // that is the concurrency this change introduces. (Serial code would
-    // hold the refresh until the agent lookup settles.)
+    // The startup-latency contract: while the refresh POST is observable and
+    // UNRESOLVED, the client base must already be routed — base routing is
+    // never serialized behind the refresh round-trip.
     await vi.waitFor(() => {
       expect(
         pendingRequests.some((r) => r.url.includes("steward-refresh")),
       ).toBe(true);
-      expect(
-        pendingRequests.some(
-          (r) => r.url.includes("agent") && !r.url.includes("steward"),
-        ),
-      ).toBe(true);
+      expect(clientRef.setBaseUrl).toHaveBeenCalledTimes(1);
     });
+    // The backfill is derivation-only: the refresh POST is the sole network
+    // round-trip in the whole cloud restore (no agent lookup to wait behind).
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(clientRef.setBaseUrl).toHaveBeenLastCalledWith(
+      "https://agent-123.elizacloud.ai",
+    );
+    // Token routing DOES wait for the refresh (fresh credential or nothing).
+    expect(clientRef.setToken).not.toHaveBeenCalled();
 
-    // Settle both: the agent lookup fails (backfill then derives the base
-    // from the persisted id) and the refresh succeeds.
+    // Settle the refresh; the restore completes with the fresh token.
     for (const req of pendingRequests) {
-      if (req.url.includes("steward-refresh")) {
-        req.resolve({
-          ok: true,
-          status: 200,
-          json: async () => ({ token: fresh }),
-        } as unknown as Response);
-      } else {
-        req.resolve({
-          ok: false,
-          status: 500,
-          json: async () => ({}),
-        } as unknown as Response);
-      }
+      req.resolve({
+        ok: true,
+        status: 200,
+        json: async () => ({ token: fresh }),
+      } as unknown as Response);
     }
     await done;
 
     // Same terminal state as the serial code: id-derived per-agent base,
     // refreshed Steward token, base set before token.
     expect(clientRef.setBaseUrl).toHaveBeenCalledTimes(1);
-    const base = clientRef.setBaseUrl.mock.calls[0][0] as string;
-    expect(base).toContain("agent-123");
     expect(clientRef.setToken).toHaveBeenLastCalledWith(fresh);
     expect(clientRef.setBaseUrl.mock.invocationCallOrder[0]).toBeLessThan(
       clientRef.setToken.mock.invocationCallOrder.at(-1) as number,

--- a/packages/ui/test/portable-stories.tsx
+++ b/packages/ui/test/portable-stories.tsx
@@ -16,7 +16,15 @@
 import { composeStories } from "@storybook/react";
 import { cleanup, render } from "@testing-library/react";
 import type { ComponentType, ReactElement, ReactNode } from "react";
-import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import { TooltipProvider } from "../src/components/ui/tooltip";
 
 /** Polyfill the jsdom gaps that recharts / embla / Radix touch on mount. */
@@ -81,7 +89,21 @@ export function smokeStoryModules(
     ((node: ReactNode) => <TooltipProvider>{node}</TooltipProvider>);
   const skip = new Set(options.skip ?? []);
 
-  beforeAll(installJsdomUiPolyfills);
+  beforeAll(() => {
+    installJsdomUiPolyfills();
+    // This smoke is offline (no backend behind jsdom), but components still
+    // fire real on-mount fetches whose socket errors settle on the network's
+    // schedule — on a loaded CI worker that can be AFTER vitest tore down the
+    // file's jsdom environment, where the late setState makes react-dom read
+    // the deleted `window` and the file fails with an unhandled
+    // "window is not defined" rejection. Keep every request forever-pending
+    // instead: components render their designed loading state and no
+    // settlement can ever fire after unmount/teardown.
+    vi.stubGlobal("fetch", () => new Promise<Response>(() => {}));
+  });
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
   afterEach(cleanup);
 
   const entries = Object.entries(modules);


### PR DESCRIPTION
Greens the @elizaos/ui vitest portion of the **Tests lane / Client Tests job** red on develop ([run 28999744769](https://github.com/elizaOS/eliza/actions/runs/28999744769)). That job had 5 failing tests + 3 unhandled teardown errors; this PR fixes 2 of the failures and all 3 teardown errors. The remaining 3 failures are the `ContinuousChatOverlay` suites (`src/components/shell/`), owned by a parallel branch and deliberately untouched here.

Both failures were introduced by the same commit, `b3d32d00e3d` ("fix(ui): keep cloud chat on dedicated runtime").

## 1. `login-return-to.test.ts` — real regression, host misclassification (not test leakage)

**Root cause.** `b3d32d00e3d` added `app.elizacloud.ai` / `app-staging.elizacloud.ai` to `ELIZA_CLOUD_CONTROL_PLANE_HOSTS` — correctly, so per-agent `<id>.elizacloud.ai` detection stops misreading the app hosts as dedicated agent subdomains. But that set also feeds `APEX_UI_CONTROL_PLANE_HOSTS` (`src/cloud/shell/apex-host.ts`), whose filter only stripped `api.*` hosts. The app hosts therefore started classifying as the **apex console**: `isApexControlPlaneHost()` returned true on `app.elizacloud.ai`, so the post-login default flipped from `/join` (drop-into-chat, the headline migration outcome) to `/dashboard` — and worse, `AppCatchAllRoute` would **never boot the agent app** on `app.elizacloud.ai` (its own doc comment says "Every non-apex host (per-agent subdomains, app.elizacloud.ai, localhost) is untouched: chat stays home").

The suggested cross-test-leakage hypothesis was disproven: the test fails **in isolation** at develop tip.

**Fix.** The apex UI derivation now strips `app.` / `app-` hosts alongside `api.` / `api-`, restoring the pre-commit apex set (`elizacloud.ai`, `www.`, `dev.`, `staging.`). The assertion was correct and is unchanged; the commented rationale in `apex-host.ts` explains why the app hosts sit in the control-plane set but must not classify as apex.

## 2. `startup-phase-restore.concurrency.test.ts` — stale assertion, not a concurrency regression

**Root cause.** The test asserted that the Steward-refresh POST and the backfill's **agent-lookup fetch** are both in flight concurrently. `b3d32d00e3d` removed the backfill network lookup entirely: `backfillCloudApiBase` now derives `https://<agentId>.elizacloud.ai` synchronously from the persisted id (`buildDedicatedCloudAgentApiBase`). The lookup the test waits for no longer exists — the new code is strictly *better* for startup latency (zero backfill round-trips), so this is a stale observable, not a serialization regression.

**Fix.** Rewrote the test to pin the new, stronger contract:
- the client base is routed (`setBaseUrl` with the id-derived dedicated base) **while the Steward refresh POST is still in flight** — base routing is never serialized behind the refresh round-trip;
- the refresh POST is the **sole** network round-trip in the whole cloud restore (`expect(fetchMock).toHaveBeenCalledTimes(1)`);
- terminal state unchanged: exact dedicated base `https://agent-123.elizacloud.ai`, refreshed token, mutations land base → token.

## 3. Three unhandled `window is not defined` teardown errors (pages-stories-smoke ×2, App.surface-manifest-wallpaper ×1)

**Root cause.** These jsdom suites have no backend, but mounted pages (`AutomationsFeed`) fire real on-mount fetches. The socket error settles on the network's schedule — on a loaded CI worker that can be **after** vitest tears down the file's jsdom environment. The late `finally { setLoading(false) }` then makes react-dom (`resolveUpdatePriority`) read the deleted `window`, failing the file with an unhandled rejection. Timing-dependent: not reproducible locally (fast local ECONNREFUSED settles in time), unambiguous from the CI stacks.

**Fix.** The portable-stories harness (`test/portable-stories.tsx`) and the wallpaper suite now stub `fetch` to a forever-pending promise: pages render their designed loading state and nothing can ever settle after unmount/teardown. Deterministic, offline-true-to-intent, and it removes the whole class for every current and future story smoke.

## Evidence

**Before (develop tip `ba3dad4308e`, matching CI run 28999744769):**

<details><summary>Red: both tests fail at tip (local repro)</summary>

```
 FAIL  src/state/startup-phase-restore.concurrency.test.ts > cloud restore overlaps backfill and Steward-token refresh > dispatches the Steward refresh while the backfill agent lookup is still in flight
AssertionError: expected false to be true // Object.is equality
 ❯ src/state/startup-phase-restore.concurrency.test.ts:135:9
    133|           (r) => r.url.includes("agent") && !r.url.includes("steward"),

 FAIL  src/cloud/public-pages/lib/login-return-to.test.ts > login return-to resolution > defaults to the /join drop-into-chat flow on app hosts
AssertionError: expected '/dashboard' to be '/join' // Object.is equality
 ❯ src/cloud/public-pages/lib/login-return-to.test.ts:41:36
     40|     setHostname("app.elizacloud.ai");
     41|     expect(defaultLoginReturnTo()).toBe("/join");
```

(login-return-to fails in isolation too — disproving the leakage hypothesis.)

</details>

**After (this branch, rebased on `64407c7cec0`):**

<details><summary>Green: targets + full packages/ui suite</summary>

```
$ bunx vitest run src/cloud/public-pages/lib/login-return-to.test.ts src/state/startup-phase-restore.concurrency.test.ts
 Test Files  2 passed (2)
      Tests  7 passed (7)

$ bunx vitest run src/components/pages/__tests__/pages-stories-smoke.test.tsx src/App.surface-manifest-wallpaper.test.tsx
 Test Files  2 passed (2)
      Tests  71 passed (71)     # no unhandled teardown errors

$ bun run --cwd packages/ui test   (full suite)
 Test Files  4 failed | 755 passed (759)
      Tests  4 failed | 7568 passed | 7 skipped (7579)
```

The 4 remaining failures are: the 3 `ContinuousChatOverlay` suites (same 3 as in CI run 28999744769 — owned by the parallel `src/components/shell/` branch, untouched here) and `ConversationsSidebar.test.tsx > selects a conversation when its row is clicked`, an infra-flake under full-suite load — it passes in isolation on this branch and passed in the CI run:

```
$ bunx vitest run src/components/conversations/ConversationsSidebar.test.tsx
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

</details>

`bunx biome check` clean on all touched files; `bun run --cwd packages/ui typecheck` clean.

**Evidence rows N/A:** UI screenshots / video / real-LLM trajectories / audio — N/A: CI test-only change (host-classification one-liner in a pure function, test-contract update, and test-harness network stubs); no rendered surface or agent behavior changes.

## Known residuals (not addressed here)

- The 3 `ContinuousChatOverlay` failures — sibling branch owns `src/components/shell/`.
- `persistence-cloud-active-server.test.ts > logs a warning instead of silently swallowing a failed active-server persist` fails **locally at develop tip in isolation** on Node 24 (the `Storage.prototype.setItem` spy doesn't intercept the runtime's storage under the local `--localstorage-file` webstorage setup) but passes in CI and in the local full-suite run — environment-specific, pre-existing, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)