### PR TITLE
fix(ui): bridge jsdom event.timeStamp to the performance.now clock — green ContinuousChatOverlay suites

### DIFF
--- a/packages/ui/src/testing/event-clock.test.ts
+++ b/packages/ui/src/testing/event-clock.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+/**
+ * Contract test for the vitest.setup.ts event-clock bridge: under jsdom,
+ * `event.timeStamp` must ride the `performance.now()` clock (as it does in
+ * real browsers, where both are DOMHighResTimeStamps against timeOrigin)
+ * so gesture suites can slow a drag down by mocking `performance.now`.
+ * Without the bridge, jsdom stamps events with epoch wall-clock milliseconds,
+ * and velocity code that trusts `event.timeStamp` (use-pull-gesture's
+ * eventTime) misreads every mock-clocked deliberate drag as a flick.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("jsdom event timeStamp ↔ performance.now bridge", () => {
+  it("stamps a dispatched event from the mocked performance.now clock", () => {
+    const now = vi.spyOn(performance, "now");
+    now.mockReturnValue(1234);
+    let seen = -1;
+    const el = document.createElement("div");
+    el.addEventListener("pointerdown", (event) => {
+      seen = event.timeStamp;
+    });
+    el.dispatchEvent(new Event("pointerdown"));
+    expect(seen).toBe(1234);
+  });
+
+  it("memoizes the first-read stamp so one event keeps one timestamp", () => {
+    const now = vi.spyOn(performance, "now");
+    now.mockReturnValue(100);
+    const event = new Event("pointermove");
+    expect(event.timeStamp).toBe(100);
+    now.mockReturnValue(900); // clock advances; the event must not drift
+    expect(event.timeStamp).toBe(100);
+  });
+
+  it("maps a clock mocked to exactly 0 to a truthy near-zero stamp", () => {
+    // react-dom's synthetic events substitute `Date.now()` for a FALSY native
+    // timeStamp (`event.timeStamp || Date.now()`) — epoch time would poison
+    // the bridged clock, so 0 must surface as the smallest positive double.
+    const now = vi.spyOn(performance, "now");
+    now.mockReturnValue(0);
+    const event = new Event("pointerdown");
+    expect(event.timeStamp).toBe(Number.MIN_VALUE);
+    expect(event.timeStamp).toBeGreaterThan(0);
+    // Arithmetically identical to zero for velocity math: (t1 - t0) is exact.
+    expect(800 - event.timeStamp).toBe(800);
+  });
+});

--- a/packages/ui/vitest.setup.ts
+++ b/packages/ui/vitest.setup.ts
@@ -44,6 +44,36 @@ if (typeof Element !== "undefined") {
   }
 }
 
+// Real browsers stamp events on the same monotonic clock `performance.now()`
+// reads (a DOMHighResTimeStamp relative to timeOrigin); jsdom stamps them with
+// epoch wall-clock milliseconds from its own internal clock instead. Gesture
+// code measures velocity from `event.timeStamp` (use-pull-gesture's eventTime
+// prefers it over a handler-dispatch `performance.now()`, which real devices
+// can delay), so under unbridged jsdom a test cannot slow a drag down by
+// mocking `performance.now` — the epoch stamps make every synchronous pointer
+// sequence read as a millisecond-long flick. Bridge the clocks: an Event's
+// timeStamp is captured from `performance.now()` (mocked or real) on first
+// read — which for dispatched events is inside the handler, i.e. dispatch
+// time — then memoized so one event keeps one stable timestamp. A clock
+// mocked to exactly 0 maps to the smallest positive double: react-dom's
+// synthetic-event layer replaces a falsy native timeStamp with the epoch
+// `Date.now()` (`event.timeStamp || Date.now()`), which would re-poison the
+// bridged clock; the subnormal is truthy yet arithmetically identical to 0.
+if (typeof Event !== "undefined") {
+  const eventTimeStamps = new WeakMap<Event, number>();
+  Object.defineProperty(Event.prototype, "timeStamp", {
+    configurable: true,
+    get(this: Event): number {
+      let stamp = eventTimeStamps.get(this);
+      if (stamp === undefined) {
+        stamp = performance.now() || Number.MIN_VALUE;
+        eventTimeStamps.set(this, stamp);
+      }
+      return stamp;
+    },
+  });
+}
+
 // Node ≥25 ships a Web Storage `localStorage`/`sessionStorage` global that is
 // non-functional without `--localstorage-file` (its methods are missing) and
 // SHADOWS jsdom's Storage — even `window.localStorage` resolves to it here, so


### PR DESCRIPTION
## Summary

Greens the three `@elizaos/ui` ContinuousChatOverlay suites failing in the develop Tests lane, Client Tests job ([run 28999744769](https://github.com/elizaOS/eliza/actions/runs/28999744769)):

- `src/components/shell/ContinuousChatOverlay.test.tsx` — `expected 'pill' to be 'collapsed'`
- `src/components/shell/ContinuousChatOverlay.fuzz.test.tsx` — `expected 'full' to be 'half'`
- `src/components/shell/ContinuousChatOverlay.morph.test.tsx` — `expected 'full' to be 'half'`

**No settle assertion was changed.** The suites' expected settle targets were already correct; the test harness's clock injection broke.

## Root cause — #15666, not #15497

#15497 (`39c72afff51`) rewrote the settle semantics but left these suites passing (its own validation ran two of them). The break came with **#15666 (`1ffe36aa4cc`)**, which taught `use-pull-gesture`'s `eventTime` to prefer `event.timeStamp` over handler-dispatch `performance.now()` for gesture velocity — correct on real devices, where the event stamp reflects input timing while a busy main thread delays the handler.

Real browsers put `event.timeStamp` on the **same timeOrigin-relative clock** `performance.now()` reads. jsdom does not: it stamps events with **epoch wall-clock milliseconds**. The suites simulate deliberate slow drags by mocking `performance.now` (the fuzz suite's `slowDrag` comment says exactly this: *"In jsdom performance.now barely advances, so any move reads as a high-velocity FLICK … `slowDrag` mocks the clock to exercise the deliberate-drag / free-rest path"*). After #15666 the hook read the unmockable epoch stamps instead, so every "slow" drag became a 1–3 ms flick:

- slow 30 px downward drift from the input → misread as **flick down** → collapsed to the **pill** instead of springing back to the input;
- slow free-rest drag from half (+150 px) → misread as **flick up** → stepped a detent to **full** instead of resting where released;
- slow reversal after an over-pull → release misread as **flick up** → stepped to **full** instead of free-resting at 436 px (labelled half).

**Bisect proof the clock is the only break:** at develop tip with *only* `use-pull-gesture.ts` reverted to its pre-#15666 version (no harness change), all 299 tests in the three suites pass.

## Fix

`packages/ui/vitest.setup.ts` (the shared jsdom-fidelity shims: scrollTo, Storage, …) now bridges the two clocks: under jsdom, `Event.prototype.timeStamp` captures `performance.now()` (mocked or real) on first read — which for dispatched events is inside the handler, i.e. dispatch time — and memoizes per event. A clock mocked to exactly `0` maps to `Number.MIN_VALUE` because react-dom substitutes `Date.now()` for falsy native stamps (`event.timeStamp || Date.now()`), which would re-poison the bridge.

`packages/ui/src/testing/event-clock.test.ts` pins the bridge contract (mocked stamp visible to handlers, per-event memoization, truthy near-zero mapping) so a future regression fails there with a precise message instead of as three obscure overlay settle failures.

## The settle contract the suites encode (unchanged, and non-tautological)

- A **flick** (high whole-press or intentional recent-segment velocity) steps **one detent** in the flick direction.
- A **deliberate slow drag rests where released**: within `SHEET_DETENT_MAGNET` (64 px) of a detent it snaps; in the open gap it free-rests and labels `half`.
- From the collapsed input, a downward drift **under half the input→pill morph** (`PILL_OPEN_DISTANCE / 2`) springs back to the input; past it, the sheet commits to the pill.
- A slow over-pull that reverses back below the inset FULL height gives up its maximize intent (peak void) — the release must not re-maximize.

Any future change that makes slow drags step detents, flicks free-rest, or a reversed over-pull re-maximize will fail these suites again — the clock bridge only restores the tests' ability to say "this gesture was slow".

## Before (develop tip `ba3dad4308e`)

<details><summary>Exact failure output</summary>

```
FAIL  src/components/shell/ContinuousChatOverlay.test.tsx > ContinuousChatOverlay > springs back to the input when a slow downward drift stays above the pill threshold
AssertionError: expected 'pill' to be 'collapsed' // Object.is equality
 ❯ src/components/shell/ContinuousChatOverlay.test.tsx:1033:49
 Tests  1 failed | 166 passed (167)

FAIL  src/components/shell/ContinuousChatOverlay.fuzz.test.tsx > ContinuousChatOverlay — reachable states > reaches every named state and each satisfies the invariants
AssertionError: expected 'full' to be 'half' // Object.is equality
 ❯ src/components/shell/ContinuousChatOverlay.fuzz.test.tsx:324:24
 Tests  1 failed | 123 passed (124)

FAIL  src/components/shell/ContinuousChatOverlay.morph.test.tsx > follow-the-finger after an over-pull past the top (overshoot rebase) > tracks the pointer 1:1 back down after pulling beyond the screen top
AssertionError: expected 'full' to be 'half' // Object.is equality
 ❯ src/components/shell/ContinuousChatOverlay.morph.test.tsx:205:49
 Tests  1 failed | 7 passed (8)
```

</details>

## After

<details><summary>Passing output</summary>

```
bun run --cwd packages/ui test src/components/shell/ContinuousChatOverlay.test.tsx src/components/shell/ContinuousChatOverlay.fuzz.test.tsx src/components/shell/ContinuousChatOverlay.morph.test.tsx
 Test Files  3 passed (3)
      Tests  299 passed (299)

bun run --cwd packages/ui test src/components/shell/           # entire shell directory incl. use-pull-gesture.test.ts (#15497/#15666 unit tests)
 Test Files  49 passed (49)
      Tests  834 passed | 7 skipped (841)

bun run --cwd packages/ui test src/testing/event-clock.test.ts
 Tests  3 passed (3)

bun run --cwd packages/ui test                                  # full package
 Test Files  2 failed | 758 passed (760)
      Tests  2 failed | 7573 passed | 7 skipped (7582)
```

The two residual full-package failures are **pre-existing on develop tip and unrelated** (verified failing identically with this change reverted in the working tree):
- `src/cloud/public-pages/lib/login-return-to.test.ts` — `expected '/dashboard' to be '/join'`
- `src/state/startup-phase-restore.concurrency.test.ts` — Steward refresh dispatch ordering

Also verified unaffected: the other `performance.now`-mocking suites (`use-pull-gesture.test.ts` — drives the hook with plain objects, untouched by the prototype bridge; `ContinuousChatOverlay.mouse-drag.test.tsx`; `ProgrammableShaderBackground.gesture-throttle`; `useActivityEvents`; `useHorizontalPager`) — all pass. `use-pull-gesture.ts` is the **only** production reader of `event.timeStamp` in the package, bounding the bridge's blast radius to exactly the broken clock path.

## Evidence

- [x] Before/after test output above (this PR greens part of the Tests lane Client job from run 28999744769)
- [x] `bunx biome check packages/ui/vitest.setup.ts packages/ui/src/testing/event-clock.test.ts` — clean
- [x] Scoped strict typecheck of both changed files — clean
- N/A - screenshots/video: test-harness-only change; no product code or rendered UI changed
- N/A - backend logs: no backend code path changed
- N/A - LLM trajectories: no agent, model, prompt, or provider behavior changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)