### PR TITLE
fix(ci): fail monetized nightly on rejected cloud credentials

### DIFF
--- a/.github/workflows/monetized-loop-nightly.yml
+++ b/.github/workflows/monetized-loop-nightly.yml
@@ -131,7 +131,20 @@ jobs:
           )"
           rc=$?
           set -e
-          if [ "$rc" -ne 0 ] || [ "$status_code" = "401" ] || [ "$status_code" = "403" ] || [ -z "$status_code" ]; then
+          if [ "$status_code" = "401" ] || [ "$status_code" = "403" ]; then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "::error::Cloud API rejected CLOUD_E2E_API_KEY with HTTP $status_code; refresh the ci-hetzner-e2e environment secret."
+            {
+              echo "### Monetized loop nightly blocked by rejected Cloud API credential"
+              echo ""
+              echo "Cloud API rejected \`CLOUD_E2E_API_KEY\` with HTTP \`$status_code\` before the real-Hetzner monetized loop."
+              echo ""
+              echo "Refresh \`CLOUD_E2E_API_KEY\` / \`ELIZACLOUD_API_KEY\` in the \`ci-hetzner-e2e\` environment, or check the staging API-key lookup path."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          if [ "$rc" -ne 0 ] || [ -z "$status_code" ]; then
             echo "ready=false" >> "$GITHUB_OUTPUT"
             echo "::warning::Cloud API auth preflight failed (rc=$rc status=$status_code); skipping monetized-loop nightly."
             {
@@ -146,7 +159,30 @@ jobs:
             fi
             exit 0
           fi
-          echo "ready=true" >> "$GITHUB_OUTPUT"
+
+          if [ "${status_code#5}" != "$status_code" ]; then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Cloud API auth preflight returned HTTP $status_code; skipping monetized-loop nightly before provisioning."
+            {
+              echo "### Monetized loop nightly skipped"
+              echo ""
+              echo "Cloud API auth preflight against \`$MONETIZED_LOOP_BASE_URL\` returned HTTP \`$status_code\` before provisioning Hetzner capacity."
+              echo ""
+              echo "Check staging Cloud API availability before re-running."
+            } >> "$GITHUB_STEP_SUMMARY"
+            if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+              exit 1
+            fi
+            exit 0
+          fi
+
+          if [ "${status_code#2}" != "$status_code" ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "::error::Unexpected Cloud API auth preflight response: status=$status_code"
+          exit 1
 
       - name: Run monetized full loop + example-apps showcase (real Hetzner)
         if: steps.secret_config.outputs.configured == 'true' && steps.cloud_auth.outputs.ready == 'true'

--- a/packages/scripts/__tests__/monetized-loop-workflow.test.ts
+++ b/packages/scripts/__tests__/monetized-loop-workflow.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Static contract for the real-Hetzner monetized loop workflow: missing
+ * credentials may be an honest scheduled skip, but rejected configured
+ * credentials must fail closed so nightly green cannot hide a dead secret.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const workflowText = readFileSync(
+  new URL(
+    "../../../.github/workflows/monetized-loop-nightly.yml",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function extractStepRunBlock(stepName: string): string {
+  const stepPattern = new RegExp(
+    `^      - name: ${escapeRegExp(stepName)}\\n(?<body>[\\s\\S]*?)(?=^      - (?:name|uses|id): |$(?![\\s\\S]))`,
+    "m",
+  );
+  const stepMatch = workflowText.match(stepPattern);
+  if (!stepMatch?.groups?.body) {
+    throw new Error(`Missing workflow step: ${stepName}`);
+  }
+
+  const runMatch = stepMatch.groups.body.match(
+    /^ {8}run: \|\n(?<run>(?: {10}.*(?:\n|$))*)/m,
+  );
+  if (!runMatch?.groups?.run) {
+    throw new Error(`Workflow step has no shell run block: ${stepName}`);
+  }
+
+  return runMatch.groups.run
+    .split("\n")
+    .map((line) => line.replace(/^ {10}/, ""))
+    .join("\n")
+    .trim();
+}
+
+describe("monetized-loop nightly workflow credential gates", () => {
+  test("keeps missing secrets as an honest scheduled skip", () => {
+    const runBlock = extractStepRunBlock("Check secret configuration");
+
+    expect(runBlock).toContain("Missing secrets:");
+    expect(runBlock).toContain(
+      'if [ "$' + '{{ github.event_name }}" = "workflow_dispatch" ]; then',
+    );
+    expect(runBlock).toContain(
+      "Manual dispatch requires HCLOUD_TOKEN_CI + CLOUD_E2E_API_KEY.",
+    );
+  });
+
+  test("fails closed when the configured Cloud credential is rejected", () => {
+    const runBlock = extractStepRunBlock("Cloud API auth preflight");
+
+    expect(runBlock).toContain(
+      'if [ "$status_code" = "401" ] || [ "$status_code" = "403" ]; then',
+    );
+    expect(runBlock).toContain(
+      "::error::Cloud API rejected CLOUD_E2E_API_KEY with HTTP $status_code",
+    );
+    expect(runBlock).toContain("exit 1");
+    expect(runBlock).not.toMatch(
+      /status_code" = "401"[\s\S]*skipping monetized-loop nightly/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- make `monetized-loop-nightly.yml` fail closed when a configured Cloud credential is rejected with HTTP 401/403
- keep missing secrets and transient/unreachable staging responses as explicit scheduled skips
- add a static workflow contract test so this does not regress into green-by-dead-credential again

Refs #15616.

## Verification
- `bun test packages/scripts/__tests__/monetized-loop-workflow.test.ts`
- `bunx @biomejs/biome check packages/scripts/__tests__/monetized-loop-workflow.test.ts --no-errors-on-unmatched`
- `actionlint .github/workflows/monetized-loop-nightly.yml`
- `git diff --check`
- `bun run audit:error-policy-ratchet`

## Evidence Rows
- Before screenshots: N/A - workflow-only CI credential-gate change
- After screenshots: N/A - workflow-only CI credential-gate change
- Walkthrough video: N/A - workflow-only CI credential-gate change
- Backend logs: N/A - no backend runtime path changed
- Frontend console/network logs: N/A - no frontend path changed
- Real-LLM trajectory: N/A - no agent/model/prompt/provider path changed
- Domain artifacts: N/A - static CI workflow guard plus contract test only
- OCR visual text review: N/A - no UI or rendered artifact changed