### PR TITLE
fix(ci): green two Plugin Tests failures — cli-inference binary pin + evidence-bundle deterministic wait

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/completion-evidence-bundle.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/completion-evidence-bundle.test.ts
@@ -240,9 +240,8 @@ describe("completion-evidence bundle assembly + trajectory persistence", () => {
     acp.emit(sessionId, "task_complete", {
       response: "Added caching and verified it works.",
     });
-    // The verify chain is fire-and-forget off the event bridge and includes a
-    // real thread-pool fs op (the child-trajectory readdir), so a fixed flush
-    // count races it on loaded machines — wait for the verifier call instead.
+    // Verification crosses the event bridge and a thread-pool filesystem read,
+    // so the verifier call is the stable synchronization point under runner load.
     await waitFor(() => prompts.length > 0, { label: "verifier prompted" });
 
     expect(prompts).toHaveLength(1);
@@ -286,10 +285,8 @@ describe("completion-evidence bundle assembly + trajectory persistence", () => {
       response:
         "Done — deployed to https://claimed-but-not-probed.example.com/",
     });
-    // Deterministic wait (not a fixed flush count): with no mirrored change set
-    // this path also runs the synchronous git capture fallback before the
-    // readdir, and on oversubscribed CI runners two timer ticks lose that race
-    // (develop run 28999744769 failed exactly here with prompts = []).
+    // This path also captures the git change set before reading child trajectories;
+    // synchronize on the resulting verifier call instead of scheduler timing.
     await waitFor(() => prompts.length > 0, { label: "verifier prompted" });
 
     expect(prompts).toHaveLength(1);

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/completion-evidence-bundle.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/completion-evidence-bundle.test.ts
@@ -240,8 +240,10 @@ describe("completion-evidence bundle assembly + trajectory persistence", () => {
     acp.emit(sessionId, "task_complete", {
       response: "Added caching and verified it works.",
     });
-    await flush();
-    await flush();
+    // The verify chain is fire-and-forget off the event bridge and includes a
+    // real thread-pool fs op (the child-trajectory readdir), so a fixed flush
+    // count races it on loaded machines — wait for the verifier call instead.
+    await waitFor(() => prompts.length > 0, { label: "verifier prompted" });
 
     expect(prompts).toHaveLength(1);
     const [prompt] = prompts;
@@ -284,8 +286,11 @@ describe("completion-evidence bundle assembly + trajectory persistence", () => {
       response:
         "Done — deployed to https://claimed-but-not-probed.example.com/",
     });
-    await flush();
-    await flush();
+    // Deterministic wait (not a fixed flush count): with no mirrored change set
+    // this path also runs the synchronous git capture fallback before the
+    // readdir, and on oversubscribed CI runners two timer ticks lose that race
+    // (develop run 28999744769 failed exactly here with prompts = []).
+    await waitFor(() => prompts.length > 0, { label: "verifier prompted" });
 
     expect(prompts).toHaveLength(1);
     const [prompt] = prompts;

--- a/plugins/plugin-cli-inference/AGENTS.md
+++ b/plugins/plugin-cli-inference/AGENTS.md
@@ -151,12 +151,12 @@ plugins/plugin-cli-inference/
 | `ELIZA_CHAT_VIA_CLI` | — | (unset = inert) | `claude`, `claude-sdk`, or `codex` — the single enable gate |
 | `ELIZA_CLI_CLAUDE_MODEL` | No | `claude-opus-4-8` | claude large-tier model (`--model` / SDK large tier) |
 | `ELIZA_CLI_CLAUDE_PLANNER_MODEL` | No | (falls back to large) | `claude-sdk` small/planner tier model (e.g. sonnet) |
-| `ELIZA_CLI_CLAUDE_BIN` | No | (SDK default) | `claude-sdk`: path to the Claude Code executable the SDK drives |
+| `ELIZA_CLI_CLAUDE_BIN` | No | (SDK default / allowlist lookup) | path to the claude executable: drives the `claude-sdk` session AND pins the cold `claude` spawn (deploys outside the SOC2 launcher allowlist) |
 | `ELIZA_CLI_SDK_RESTART_AFTER_TURNS` | No | `20` | `claude-sdk`: restart a warm session after N turns (bounds context) |
 | `ELIZA_CLI_CODEX_MODEL` | No | `gpt-5.5` | codex large-tier model (`codex exec -m` / SDK large tier) |
 | `ELIZA_CLI_CODEX_PLANNER_MODEL` | No | (falls back to large) | `codex-sdk` small/planner tier model |
 | `ELIZA_CLI_CODEX_REASONING_EFFORT` | No | (sdk default) | `codex-sdk`: `modelReasoningEffort` (minimal..xhigh) |
-| `ELIZA_CLI_CODEX_BIN` | No | (sdk bundled) | `codex-sdk`: path to the system codex binary (REQUIRED — bundled 0.80.0 rejects current models) |
+| `ELIZA_CLI_CODEX_BIN` | No | (sdk bundled / allowlist lookup) | path to the system codex binary: REQUIRED for `codex-sdk` (bundled 0.80.0 rejects current models); also pins the cold `codex` spawn |
 | `ELIZA_CLI_TIMEOUT_MS` | No | `120000` | per-call spawn timeout (SIGTERM on expiry; CLI backends) |
 
 ## Errors

--- a/plugins/plugin-cli-inference/CLAUDE.md
+++ b/plugins/plugin-cli-inference/CLAUDE.md
@@ -151,12 +151,12 @@ plugins/plugin-cli-inference/
 | `ELIZA_CHAT_VIA_CLI` | — | (unset = inert) | `claude`, `claude-sdk`, or `codex` — the single enable gate |
 | `ELIZA_CLI_CLAUDE_MODEL` | No | `claude-opus-4-8` | claude large-tier model (`--model` / SDK large tier) |
 | `ELIZA_CLI_CLAUDE_PLANNER_MODEL` | No | (falls back to large) | `claude-sdk` small/planner tier model (e.g. sonnet) |
-| `ELIZA_CLI_CLAUDE_BIN` | No | (SDK default) | `claude-sdk`: path to the Claude Code executable the SDK drives |
+| `ELIZA_CLI_CLAUDE_BIN` | No | (SDK default / allowlist lookup) | path to the claude executable: drives the `claude-sdk` session AND pins the cold `claude` spawn (deploys outside the SOC2 launcher allowlist) |
 | `ELIZA_CLI_SDK_RESTART_AFTER_TURNS` | No | `20` | `claude-sdk`: restart a warm session after N turns (bounds context) |
 | `ELIZA_CLI_CODEX_MODEL` | No | `gpt-5.5` | codex large-tier model (`codex exec -m` / SDK large tier) |
 | `ELIZA_CLI_CODEX_PLANNER_MODEL` | No | (falls back to large) | `codex-sdk` small/planner tier model |
 | `ELIZA_CLI_CODEX_REASONING_EFFORT` | No | (sdk default) | `codex-sdk`: `modelReasoningEffort` (minimal..xhigh) |
-| `ELIZA_CLI_CODEX_BIN` | No | (sdk bundled) | `codex-sdk`: path to the system codex binary (REQUIRED — bundled 0.80.0 rejects current models) |
+| `ELIZA_CLI_CODEX_BIN` | No | (sdk bundled / allowlist lookup) | path to the system codex binary: REQUIRED for `codex-sdk` (bundled 0.80.0 rejects current models); also pins the cold `codex` spawn |
 | `ELIZA_CLI_TIMEOUT_MS` | No | `120000` | per-call spawn timeout (SIGTERM on expiry; CLI backends) |
 
 ## Errors

--- a/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
@@ -444,8 +444,16 @@ describe("models map gating (large-tier only)", () => {
           params: unknown
         ) => Promise<string>
       >;
+      // ELIZA_CLI_CLAUDE_BIN pins the binary so `resolveSafeBinary` never probes
+      // the real filesystem (CI runners have no allowlisted claude install); the
+      // spawn itself goes through the mocked seam.
       const runtime = {
-        getSetting: (key: string) => (key === "ELIZA_CHAT_VIA_CLI" ? "claude" : undefined),
+        getSetting: (key: string) =>
+          key === "ELIZA_CHAT_VIA_CLI"
+            ? "claude"
+            : key === "ELIZA_CLI_CLAUDE_BIN"
+              ? FAKE_CLAUDE
+              : undefined,
       };
 
       await expect(models.TEXT_LARGE(runtime, { prompt: "hello" })).resolves.toBe("from claude");
@@ -503,8 +511,15 @@ describe("models map gating (large-tier only)", () => {
           params: unknown
         ) => Promise<string>
       >;
+      // Same binary pin as the cold-handler test above: keeps the test hermetic
+      // on boxes without an allowlisted claude install.
       const runtime = {
-        getSetting: (key: string) => (key === "ELIZA_CHAT_VIA_CLI" ? "claude" : undefined),
+        getSetting: (key: string) =>
+          key === "ELIZA_CHAT_VIA_CLI"
+            ? "claude"
+            : key === "ELIZA_CLI_CLAUDE_BIN"
+              ? FAKE_CLAUDE
+              : undefined,
       };
 
       expect(models.ACTION_PLANNER).toBeTypeOf("function");

--- a/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
@@ -444,9 +444,7 @@ describe("models map gating (large-tier only)", () => {
           params: unknown
         ) => Promise<string>
       >;
-      // ELIZA_CLI_CLAUDE_BIN pins the binary so `resolveSafeBinary` never probes
-      // the real filesystem (CI runners have no allowlisted claude install); the
-      // spawn itself goes through the mocked seam.
+      // A configured pin keeps model routing independent of the host's CLI layout.
       const runtime = {
         getSetting: (key: string) =>
           key === "ELIZA_CHAT_VIA_CLI"
@@ -459,6 +457,7 @@ describe("models map gating (large-tier only)", () => {
       await expect(models.TEXT_LARGE(runtime, { prompt: "hello" })).resolves.toBe("from claude");
 
       const argv = calls[0].argv;
+      expect(argv[0]).toBe(FAKE_CLAUDE);
       expect(argv[argv.indexOf("--model") + 1]).toBe("claude-opus-4-8");
     } finally {
       restore();
@@ -511,8 +510,7 @@ describe("models map gating (large-tier only)", () => {
           params: unknown
         ) => Promise<string>
       >;
-      // Same binary pin as the cold-handler test above: keeps the test hermetic
-      // on boxes without an allowlisted claude install.
+      // The planner and response handlers share the same operator-pinned executable.
       const runtime = {
         getSetting: (key: string) =>
           key === "ELIZA_CHAT_VIA_CLI"
@@ -527,6 +525,37 @@ describe("models map gating (large-tier only)", () => {
         "NONE"
       );
       expect(calls).toHaveLength(1);
+    } finally {
+      restore();
+    }
+  });
+
+  it("routes cold Codex model handlers through the configured binary", async () => {
+    const { calls, fn } = recordingSpawn({
+      stdout: '{"type":"agent_message","message":"from codex"}',
+    });
+    const restore = __setCodexSpawn(fn);
+    try {
+      const models = buildModels({ ELIZA_CHAT_VIA_CLI: "codex" }) as Record<
+        string,
+        (
+          runtime: { getSetting: (key: string) => string | undefined },
+          params: unknown
+        ) => Promise<string>
+      >;
+      const runtime = {
+        getSetting: (key: string) =>
+          key === "ELIZA_CHAT_VIA_CLI"
+            ? "codex"
+            : key === "ELIZA_CLI_CODEX_BIN"
+              ? FAKE_CODEX
+              : undefined,
+      };
+
+      await expect(models.TEXT_LARGE(runtime, { prompt: "hello" })).resolves.toBe("from codex");
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0].argv[0]).toBe(FAKE_CODEX);
     } finally {
       restore();
     }

--- a/plugins/plugin-cli-inference/index.ts
+++ b/plugins/plugin-cli-inference/index.ts
@@ -267,13 +267,9 @@ function parseTimeout(value: string | undefined): number | undefined {
   return Number.isFinite(n) && n > 0 ? n : undefined;
 }
 
-/**
- * Optional operator-pinned binary path for the cold CLI backends. The warm SDK
- * sessions already honor `ELIZA_CLI_CLAUDE_BIN` / `ELIZA_CLI_CODEX_BIN`; the
- * cold `claude`/`codex` spawn paths must honor the same pin so a deploy whose
- * CLI lives outside the SOC2 launcher allowlist (e.g. a container image) can
- * still use them. Empty/whitespace reads as unset → allowlisted PATH lookup.
- */
+// One binary setting covers both warm and cold backends so container images can
+// pin executables outside the launcher allowlist. Blank settings retain the
+// allowlisted PATH lookup used by unmanaged installations.
 function resolveBinaryPin(runtime: IAgentRuntime, key: string): string | undefined {
   const value = getSetting(runtime, key)?.trim();
   return value ? value : undefined;

--- a/plugins/plugin-cli-inference/index.ts
+++ b/plugins/plugin-cli-inference/index.ts
@@ -267,10 +267,23 @@ function parseTimeout(value: string | undefined): number | undefined {
   return Number.isFinite(n) && n > 0 ? n : undefined;
 }
 
+/**
+ * Optional operator-pinned binary path for the cold CLI backends. The warm SDK
+ * sessions already honor `ELIZA_CLI_CLAUDE_BIN` / `ELIZA_CLI_CODEX_BIN`; the
+ * cold `claude`/`codex` spawn paths must honor the same pin so a deploy whose
+ * CLI lives outside the SOC2 launcher allowlist (e.g. a container image) can
+ * still use them. Empty/whitespace reads as unset → allowlisted PATH lookup.
+ */
+function resolveBinaryPin(runtime: IAgentRuntime, key: string): string | undefined {
+  const value = getSetting(runtime, key)?.trim();
+  return value ? value : undefined;
+}
+
 function buildClaude(runtime: IAgentRuntime): ClaudeCli {
   return new ClaudeCli({
     model: getSetting(runtime, "ELIZA_CLI_CLAUDE_MODEL"),
     timeoutMs: parseTimeout(getSetting(runtime, "ELIZA_CLI_TIMEOUT_MS")),
+    binaryPath: resolveBinaryPin(runtime, "ELIZA_CLI_CLAUDE_BIN"),
   });
 }
 
@@ -278,6 +291,7 @@ function buildCodex(runtime: IAgentRuntime): CodexCli {
   return new CodexCli({
     model: getSetting(runtime, "ELIZA_CLI_CODEX_MODEL"),
     timeoutMs: parseTimeout(getSetting(runtime, "ELIZA_CLI_TIMEOUT_MS")),
+    binaryPath: resolveBinaryPin(runtime, "ELIZA_CLI_CODEX_BIN"),
   });
 }
 
@@ -455,6 +469,7 @@ export const cliInferencePlugin: Plugin = {
     ELIZA_CLI_SDK_RESTART_AFTER_TURNS: readEnv("ELIZA_CLI_SDK_RESTART_AFTER_TURNS") ?? null,
     ELIZA_CLI_SDK_TURN_TIMEOUT_MS: readEnv("ELIZA_CLI_SDK_TURN_TIMEOUT_MS") ?? null,
     ELIZA_CLI_CODEX_MODEL: readEnv("ELIZA_CLI_CODEX_MODEL") ?? null,
+    ELIZA_CLI_CODEX_BIN: readEnv("ELIZA_CLI_CODEX_BIN") ?? null,
     ELIZA_CLI_TIMEOUT_MS: readEnv("ELIZA_CLI_TIMEOUT_MS") ?? null,
     ELIZA_CLI_INFERENCE_ACCOUNT_ROTATION: readEnv("ELIZA_CLI_INFERENCE_ACCOUNT_ROTATION") ?? null,
   },


### PR DESCRIPTION
Greens two failures in the **Plugin Tests** job of the develop Tests lane (run [28999744769](https://github.com/elizaOS/eliza/actions/runs/28999744769), shard 4/4).

## Fix 1 — `plugin-cli-inference`: 2 tests reject with `SubAgentBinaryError` on runners without claude

**Root cause:** the two model-handler routing tests added new in `f9b9fd644be` (`routes cold Claude model handlers through the configured backend`, `registers and routes ACTION_PLANNER only in text-planner mode`) drive `buildModels → generateViaCli → buildClaude → ClaudeCli.generate`, which resolves the `claude` binary through the SOC2 allowlist (`resolveSafeBinary`) **before** reaching the mocked spawn seam. Binary resolution has always been at `generate()` call time (verified: placement unchanged since before `3815a6590ba` / `f9b9fd644be` — not an eager-resolution regression); the tests were simply born non-hermetic and only pass on boxes with an allowlisted claude install (e.g. `~/.local/bin/claude`). CI runners have none → `SubAgentBinaryError: Could not resolve claude under any whitelisted dir`.

**Fix (product gap + hermetic test):** `ELIZA_CLI_CLAUDE_BIN` / `ELIZA_CLI_CODEX_BIN` are documented pins already honored by the warm SDK sessions, and `ClaudeCliConfig.binaryPath` exists precisely for "container deploys that pin the CLI outside the default allowlist" — but the cold `claude`/`codex` spawn paths never read them, so such a deploy could not use the cold backends at all. Wired the pins into `buildClaude`/`buildCodex` (empty/whitespace = unset → allowlisted PATH lookup, unchanged default), added `ELIZA_CLI_CODEX_BIN` to the plugin config block, updated the env table in `AGENTS.md`/`CLAUDE.md` (kept identical). The two tests now pin the same `FAKE_CLAUDE` path every sibling test uses — via a real config path, so the full routing path (`buildModels → generateViaCli → ClaudeCli.generate` argv assembly → spawn seam) stays under test with zero filesystem dependence. Nothing under test is mocked.

**Red → green** (CI simulated with a fake `$HOME` so the allowlist has no claude):

Before:
```
FAIL … routes cold Claude model handlers through the configured backend
FAIL … registers and routes ACTION_PLANNER only in text-planner mode
AssertionError: promise rejected "SubAgentBinaryError: Could not resolve cl…" instead of resolving
Tests  2 failed | 29 passed | 2 skipped (33)
```

After (same fake-HOME env):
```
Tests  31 passed | 2 skipped (33)
```

Full plugin suite (real env): `Test Files 7 passed (7) / Tests 99 passed | 1 skipped (100)`. `bun run typecheck` clean.

## Fix 2 — `plugin-agent-orchestrator` `completion-evidence-bundle.test.ts:290`: `expected [] to have a length of 1`

**Root cause (fragile wait, not a product bug):** the failing test (`does NOT label a URL merely mentioned in prose as verified`) fires `task_complete` and waits a **fixed two `setTimeout(0)` flushes** before asserting the verifier `useModel` prompt landed. The auto-verify chain is fire-and-forget off the event bridge and contains a real thread-pool fs op (`readdir` ENOENT in `ingestChildTrajectories`) — and on this test's specific path (no mirrored `lastChangeSet`) additionally runs the synchronous `git` capture fallback (`captureChangeSet` → `spawnSync` ×2 under bun), which blocks the loop while both flush timers expire. On an oversubscribed runner the readdir completion loses the race against the two timer ticks → `prompts` is still `[]`. The Plugin Tests job runs on the self-hosted `hetzner-robot` fleet with 4 concurrent shards, which is exactly that environment. Product behavior is correct (the verifier is always called); no source commit changed behavior — the test file's own test 3 already uses a `waitFor` helper with a comment warning against "guessing a flush count" for this same chain.

**Reproduced deterministically** (CPU starvation: 8 busy loops + test pinned to the same core, `UV_THREADPOOL_SIZE=1`): **2/6 runs failed with the exact CI assertion**:
```
FAIL  __tests__/unit/completion-evidence-bundle.test.ts > … > does NOT label a URL merely mentioned in prose as verified
AssertionError: expected [] to have a length of 1 but got +0
 ❯ __tests__/unit/completion-evidence-bundle.test.ts:290:21
```

**Fix:** replace the fixed flush count in both prompt-asserting tests with the file's existing `waitFor(() => prompts.length > 0)` deterministic wait (test 3's established pattern). All assertions on the prompt content are unchanged.

**After, under the same starvation:** 7/7 runs green (was 2/6 red). Full suite: `Test Files 183 passed | 4 skipped (187) / Tests 1882 passed | 8 skipped (1890)`. `bun run typecheck` clean. The `vendor/opencode` submodule is untouched.

## Verification
- `bun run --cwd plugins/plugin-cli-inference test` → 7 files, 99 passed / 1 skipped
- `bun run --cwd plugins/plugin-agent-orchestrator test` → 183 files passed / 4 skipped, 1882 passed / 8 skipped
- Both re-run green after rebase onto latest `origin/develop`
- `bunx biome check` on all touched files: clean
- No `bun.lock` or submodule changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Coordination and evidence

Contributes to #13620.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots: N/A - this changes Node-only plugin launch configuration and test synchronization, with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots: N/A - this changes Node-only plugin launch configuration and test synchronization, with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: N/A - there is no interactive user flow; the observable behavior is a CLI model invocation and plugin test execution.
<!-- evidence-row:backend-logs -->
- [x] Backend logs and full deterministic test summaries: https://github.com/elizaOS/eliza/releases/download/pr-evidence/15734-live-cli-and-tests.txt
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: N/A - neither plugin exposes or changes a frontend request path.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: https://github.com/elizaOS/eliza/releases/download/pr-evidence/15734-live-cli-and-tests.txt (live authenticated Claude CLI call through `ClaudeCli.generate()` using the configured absolute pin; request, raw response, elapsed time, and manual review included).
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: N/A - this repair produces no DB rows, memories, scheduled tasks, files, audio, wallet, or chain state.

### Post-sync verification

- `plugin-cli-inference`: 7 files passed; 100 passed, 1 skipped; typecheck passed.
- `plugin-agent-orchestrator`: 183 files passed, 4 skipped; 1,882 passed, 8 skipped; typecheck passed.
- Focused Biome and `git diff --check` passed.
- Full `bun run verify`: all 570 Turbo lint/typecheck/build dependency tasks passed. The final `typecheck:dist` step failed because current `origin/develop` has a stale checked-in `tsconfig.dist-paths.json`; this PR does not touch that generated config.
- `bun install` also regenerated unrelated lock/artifact content from current package manifests; those command side effects were removed from this clean branch and are not included in the PR.
