### PR TITLE
fix(ci): gate streaming dropped-frame ratio on an in-run ambient baseline

### DIFF
--- a/packages/ui/src/components/shell/__e2e__/run-chat-perf-gate.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-perf-gate.mjs
@@ -53,26 +53,15 @@ const FRAME_BUDGET_OPTIONS = {
   droppedFrameRatio: 0.25, // >25% frames over budget = visible jank
   reportOnLongTask: false, // long tasks are noisy on shared CI runners
 };
-// The streaming windows re-render the tail turn once per animation frame by
-// design (a token batch per rAF), so their dropped-frame ratio tracks MACHINE
-// LOAD, not code health: the same build measured ~20% median dropped on an
-// idle box, 26.8–27.8% on loaded ubuntu CI runners, and ~40% on a saturated
-// dev box — while the p95 stayed pinned at the one-dropped-frame vsync floor
-// (33.4ms, far under the 2.5× budget) in every observation: busy, not janky.
-// No static ratio threshold separates those healthy states from a regression,
-// so the ratio is judged as a DELTA over an in-run ambient baseline (an
-// identical rAF window driving ZERO tokens, sampled on the same machine
-// seconds earlier). Healthy streaming adds ≤ ~22pp over ambient in the worst
-// measured case; a genuine regression — an unmemoized widget re-rendering the
-// thread on every token — doubles nearly every frame (delta far past 50pp)
-// and also trips the untouched p95-factor, widget-remount, CLS, and
-// zero-outside-chat-reflow gates. droppedFrameRatio here is that ALLOWED
-// DELTA, not an absolute ratio.
+// Streaming intentionally updates once per animation frame, making its dropped
+// ratio sensitive to runner contention. Pair each streaming window with an
+// immediately preceding zero-token window so the gate measures incremental work.
 const FRAME_GATE_STREAMING = {
   p95BudgetFactor: 2.5,
-  droppedFrameRatio: 0.3,
   reportOnLongTask: false,
 };
+const STREAMING_DROP_DELTA_BUDGET = 0.3;
+const STREAMING_DROP_ABSOLUTE_CEILING = 0.7;
 const STABILITY_BUDGET = { maxCls: 0.1, flashMinDelta: 0.2 };
 
 // Install the shared layout-shift observer + a rAF frame sampler BEFORE the app
@@ -412,53 +401,45 @@ await runBrowserFixtureE2E(
     // per animation frame — a sustained stream, not a burst) entirely in the page
     // so the rAF cadence is real, then harvests the SAME real frame + shift +
     // reflow entries and feeds them to the SAME shared detector.
-    // Ambient-load baseline: the SAME 120-tick rAF pump with ZERO tokens
-    // driven, harvested with the SAME sampler. Frames dropped here are pure
-    // machine load (co-tenant CI processes, GC), so the streaming ratio is
-    // gated on its delta over this, not on an absolute number.
-    await page.evaluate(() => {
-      window.__ELIZA_PERF_FRAMES__ = [];
-    });
-    await page.evaluate(
-      () =>
-        new Promise((resolve) => {
-          let ticks = 0;
-          const pump = () => {
-            ticks += 1;
-            if (ticks >= 120) {
-              resolve(undefined);
-              return;
-            }
-            requestAnimationFrame(pump);
-          };
-          requestAnimationFrame(pump);
-        }),
-    );
-    await page.waitForTimeout(120);
-    const baselineSummary = summarizeFrameSamples(
-      await page.evaluate(() => window.__ELIZA_PERF_FRAMES__ ?? []),
-    );
-    const baselineRatio = baselineSummary.sampleCount
-      ? baselineSummary.droppedFrames / baselineSummary.sampleCount
-      : 0;
-    check(
-      baselineSummary.sampleCount > 20,
-      `ambient baseline window captured a meaningful frame window (${baselineSummary.sampleCount} frames)`,
-    );
-    // Absolute ceiling so a fully saturated machine can never mask a
-    // pathological regression behind an equally pathological baseline.
-    const streamingDropBudget = Math.min(
-      0.85,
-      baselineRatio + FRAME_GATE_STREAMING.droppedFrameRatio,
-    );
-    console.log(
-      `stream ambient baseline: dropped ${(baselineRatio * 100).toFixed(1)}% of ${baselineSummary.sampleCount} frames | ` +
-        `streaming drop budget ${(streamingDropBudget * 100).toFixed(1)}%`,
-    );
-
     const streamWindows = [];
     const reflowAll = [];
     for (let w = 0; w < STREAM_WINDOWS; w += 1) {
+      // Interleaving controls for load changes during the run; one early sample
+      // cannot represent a later window on a shared runner.
+      await page.evaluate(() => {
+        window.__ELIZA_PERF_FRAMES__ = [];
+      });
+      await page.evaluate(
+        () =>
+          new Promise((resolve) => {
+            let ticks = 0;
+            const pump = () => {
+              ticks += 1;
+              if (ticks >= 120) {
+                resolve(undefined);
+                return;
+              }
+              requestAnimationFrame(pump);
+            };
+            requestAnimationFrame(pump);
+          }),
+      );
+      await page.waitForTimeout(120);
+      const baselineSummary = summarizeFrameSamples(
+        await page.evaluate(() => window.__ELIZA_PERF_FRAMES__ ?? []),
+      );
+      const baselineRatio = baselineSummary.sampleCount
+        ? baselineSummary.droppedFrames / baselineSummary.sampleCount
+        : 0;
+      check(
+        baselineSummary.sampleCount > 20,
+        `ambient window ${w + 1} captured a meaningful frame window (${baselineSummary.sampleCount} frames)`,
+      );
+      const streamingDropBudget = Math.min(
+        STREAMING_DROP_ABSOLUTE_CEILING,
+        baselineRatio + STREAMING_DROP_DELTA_BUDGET,
+      );
+
       await page.evaluate(() => {
         window.__ELIZA_PERF_FRAMES__ = [];
         window.__ELIZA_LAYOUT_SHIFTS__ = [];
@@ -495,11 +476,21 @@ await runBrowserFixtureE2E(
         droppedFrameRatio: streamingDropBudget,
       });
       const stability = summarizeStability(shifts, [], STABILITY_BUDGET);
-      streamWindows.push({ summary, droppedRatio, flagged, cls: stability.cls });
+      streamWindows.push({
+        summary,
+        baselineRatio,
+        droppedRatio,
+        droppedDelta: droppedRatio - baselineRatio,
+        flagged,
+        cls: stability.cls,
+      });
       reflowAll.push(...reflow);
       console.log(
-        `stream window ${w + 1}/${STREAM_WINDOWS}: frames ${summary.sampleCount} | fps ${summary.fps.toFixed(1)} | ` +
-          `p95 ${summary.p95FrameMs.toFixed(1)}ms | dropped ${summary.droppedFrames}/${summary.sampleCount} | flagged ${flagged}`,
+        `stream window ${w + 1}/${STREAM_WINDOWS}: ambient ${(baselineRatio * 100).toFixed(1)}% | ` +
+          `frames ${summary.sampleCount} | fps ${summary.fps.toFixed(1)} | p95 ${summary.p95FrameMs.toFixed(1)}ms | ` +
+          `dropped ${summary.droppedFrames}/${summary.sampleCount} (${(droppedRatio * 100).toFixed(1)}%, ` +
+          `delta ${((droppedRatio - baselineRatio) * 100).toFixed(1)}pp) | ` +
+          `budget ${(streamingDropBudget * 100).toFixed(1)}% | flagged ${flagged}`,
       );
       // Each window must carry a meaningful sample or the median is noise.
       check(
@@ -511,12 +502,15 @@ await runBrowserFixtureE2E(
     const outsideChatShifts = reflowAll.filter((s) => s.outsideChat);
     const budgetMs = streamWindows[0].summary.budgetMs;
     const medianP95 = medianNumber(streamWindows.map((s) => s.summary.p95FrameMs));
+    const medianBaselineRatio = medianNumber(streamWindows.map((s) => s.baselineRatio));
     const medianDroppedRatio = medianNumber(streamWindows.map((s) => s.droppedRatio));
+    const medianDroppedDelta = medianNumber(streamWindows.map((s) => s.droppedDelta));
     const medianCls = medianNumber(streamWindows.map((s) => s.cls));
     const flaggedCount = streamWindows.filter((s) => s.flagged).length;
     console.log(
       `\nstream median: p95 ${medianP95.toFixed(1)}ms (budget ${(budgetMs * FRAME_GATE_STREAMING.p95BudgetFactor).toFixed(1)}ms) | ` +
-        `dropped ${(medianDroppedRatio * 100).toFixed(1)}% | cls ${medianCls.toFixed(4)} | ` +
+        `ambient ${(medianBaselineRatio * 100).toFixed(1)}% | dropped ${(medianDroppedRatio * 100).toFixed(1)}% | ` +
+        `delta ${(medianDroppedDelta * 100).toFixed(1)}pp | cls ${medianCls.toFixed(4)} | ` +
         `flagged ${flaggedCount}/${STREAM_WINDOWS} windows | reflow ${reflowAll.length} outside-chat ${outsideChatShifts.length}\n`,
     );
 
@@ -531,10 +525,14 @@ await runBrowserFixtureE2E(
     );
 
     check(
-      medianDroppedRatio <= streamingDropBudget,
+      medianDroppedDelta <= STREAMING_DROP_DELTA_BUDGET,
+      `median streaming dropped-frame delta ${(medianDroppedDelta * 100).toFixed(1)}pp within ` +
+        `${(STREAMING_DROP_DELTA_BUDGET * 100).toFixed(0)}pp allowance`,
+    );
+    check(
+      medianDroppedRatio <= STREAMING_DROP_ABSOLUTE_CEILING,
       `median streaming dropped-frame ratio ${(medianDroppedRatio * 100).toFixed(1)}% within ` +
-        `${(streamingDropBudget * 100).toFixed(1)}% (ambient ${(baselineRatio * 100).toFixed(1)}% + ` +
-        `${(FRAME_GATE_STREAMING.droppedFrameRatio * 100).toFixed(0)}pp allowance)`,
+        `${(STREAMING_DROP_ABSOLUTE_CEILING * 100).toFixed(0)}% absolute ceiling`,
     );
     check(
       medianP95 <= budgetMs * FRAME_GATE_STREAMING.p95BudgetFactor,

--- a/packages/ui/src/components/shell/__e2e__/run-chat-perf-gate.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-perf-gate.mjs
@@ -53,6 +53,26 @@ const FRAME_BUDGET_OPTIONS = {
   droppedFrameRatio: 0.25, // >25% frames over budget = visible jank
   reportOnLongTask: false, // long tasks are noisy on shared CI runners
 };
+// The streaming windows re-render the tail turn once per animation frame by
+// design (a token batch per rAF), so their dropped-frame ratio tracks MACHINE
+// LOAD, not code health: the same build measured ~20% median dropped on an
+// idle box, 26.8–27.8% on loaded ubuntu CI runners, and ~40% on a saturated
+// dev box — while the p95 stayed pinned at the one-dropped-frame vsync floor
+// (33.4ms, far under the 2.5× budget) in every observation: busy, not janky.
+// No static ratio threshold separates those healthy states from a regression,
+// so the ratio is judged as a DELTA over an in-run ambient baseline (an
+// identical rAF window driving ZERO tokens, sampled on the same machine
+// seconds earlier). Healthy streaming adds ≤ ~22pp over ambient in the worst
+// measured case; a genuine regression — an unmemoized widget re-rendering the
+// thread on every token — doubles nearly every frame (delta far past 50pp)
+// and also trips the untouched p95-factor, widget-remount, CLS, and
+// zero-outside-chat-reflow gates. droppedFrameRatio here is that ALLOWED
+// DELTA, not an absolute ratio.
+const FRAME_GATE_STREAMING = {
+  p95BudgetFactor: 2.5,
+  droppedFrameRatio: 0.3,
+  reportOnLongTask: false,
+};
 const STABILITY_BUDGET = { maxCls: 0.1, flashMinDelta: 0.2 };
 
 // Install the shared layout-shift observer + a rAF frame sampler BEFORE the app
@@ -392,6 +412,50 @@ await runBrowserFixtureE2E(
     // per animation frame — a sustained stream, not a burst) entirely in the page
     // so the rAF cadence is real, then harvests the SAME real frame + shift +
     // reflow entries and feeds them to the SAME shared detector.
+    // Ambient-load baseline: the SAME 120-tick rAF pump with ZERO tokens
+    // driven, harvested with the SAME sampler. Frames dropped here are pure
+    // machine load (co-tenant CI processes, GC), so the streaming ratio is
+    // gated on its delta over this, not on an absolute number.
+    await page.evaluate(() => {
+      window.__ELIZA_PERF_FRAMES__ = [];
+    });
+    await page.evaluate(
+      () =>
+        new Promise((resolve) => {
+          let ticks = 0;
+          const pump = () => {
+            ticks += 1;
+            if (ticks >= 120) {
+              resolve(undefined);
+              return;
+            }
+            requestAnimationFrame(pump);
+          };
+          requestAnimationFrame(pump);
+        }),
+    );
+    await page.waitForTimeout(120);
+    const baselineSummary = summarizeFrameSamples(
+      await page.evaluate(() => window.__ELIZA_PERF_FRAMES__ ?? []),
+    );
+    const baselineRatio = baselineSummary.sampleCount
+      ? baselineSummary.droppedFrames / baselineSummary.sampleCount
+      : 0;
+    check(
+      baselineSummary.sampleCount > 20,
+      `ambient baseline window captured a meaningful frame window (${baselineSummary.sampleCount} frames)`,
+    );
+    // Absolute ceiling so a fully saturated machine can never mask a
+    // pathological regression behind an equally pathological baseline.
+    const streamingDropBudget = Math.min(
+      0.85,
+      baselineRatio + FRAME_GATE_STREAMING.droppedFrameRatio,
+    );
+    console.log(
+      `stream ambient baseline: dropped ${(baselineRatio * 100).toFixed(1)}% of ${baselineSummary.sampleCount} frames | ` +
+        `streaming drop budget ${(streamingDropBudget * 100).toFixed(1)}%`,
+    );
+
     const streamWindows = [];
     const reflowAll = [];
     for (let w = 0; w < STREAM_WINDOWS; w += 1) {
@@ -426,7 +490,10 @@ await runBrowserFixtureE2E(
       const droppedRatio = summary.sampleCount
         ? summary.droppedFrames / summary.sampleCount
         : 1;
-      const flagged = shouldReportFrameBudget(summary, FRAME_BUDGET_OPTIONS);
+      const flagged = shouldReportFrameBudget(summary, {
+        ...FRAME_GATE_STREAMING,
+        droppedFrameRatio: streamingDropBudget,
+      });
       const stability = summarizeStability(shifts, [], STABILITY_BUDGET);
       streamWindows.push({ summary, droppedRatio, flagged, cls: stability.cls });
       reflowAll.push(...reflow);
@@ -448,7 +515,7 @@ await runBrowserFixtureE2E(
     const medianCls = medianNumber(streamWindows.map((s) => s.cls));
     const flaggedCount = streamWindows.filter((s) => s.flagged).length;
     console.log(
-      `\nstream median: p95 ${medianP95.toFixed(1)}ms (budget ${(budgetMs * FRAME_BUDGET_OPTIONS.p95BudgetFactor).toFixed(1)}ms) | ` +
+      `\nstream median: p95 ${medianP95.toFixed(1)}ms (budget ${(budgetMs * FRAME_GATE_STREAMING.p95BudgetFactor).toFixed(1)}ms) | ` +
         `dropped ${(medianDroppedRatio * 100).toFixed(1)}% | cls ${medianCls.toFixed(4)} | ` +
         `flagged ${flaggedCount}/${STREAM_WINDOWS} windows | reflow ${reflowAll.length} outside-chat ${outsideChatShifts.length}\n`,
     );
@@ -464,12 +531,14 @@ await runBrowserFixtureE2E(
     );
 
     check(
-      medianDroppedRatio <= FRAME_BUDGET_OPTIONS.droppedFrameRatio,
-      `median streaming dropped-frame ratio ${(medianDroppedRatio * 100).toFixed(1)}% within ${(FRAME_BUDGET_OPTIONS.droppedFrameRatio * 100).toFixed(0)}%`,
+      medianDroppedRatio <= streamingDropBudget,
+      `median streaming dropped-frame ratio ${(medianDroppedRatio * 100).toFixed(1)}% within ` +
+        `${(streamingDropBudget * 100).toFixed(1)}% (ambient ${(baselineRatio * 100).toFixed(1)}% + ` +
+        `${(FRAME_GATE_STREAMING.droppedFrameRatio * 100).toFixed(0)}pp allowance)`,
     );
     check(
-      medianP95 <= budgetMs * FRAME_BUDGET_OPTIONS.p95BudgetFactor,
-      `median streaming p95 ${medianP95.toFixed(1)}ms within ${(budgetMs * FRAME_BUDGET_OPTIONS.p95BudgetFactor).toFixed(1)}ms`,
+      medianP95 <= budgetMs * FRAME_GATE_STREAMING.p95BudgetFactor,
+      `median streaming p95 ${medianP95.toFixed(1)}ms within ${(budgetMs * FRAME_GATE_STREAMING.p95BudgetFactor).toFixed(1)}ms`,
     );
     // The SAME shared detector the dev HUD uses must clear the MEDIAN streaming
     // window (≤ half the windows flagged). A regression that janks every window


### PR DESCRIPTION
## Problem

With #15722 restoring the chat perf gate past the thread mount, the **Chat shell gestures** lane now fails on the next assertion in line: `✗ median streaming dropped-frame ratio 27.8% within 25%` (develop@`b7514a057b8`) — the same knife-edge that flapped before the mount breakage masked it (26.8% on Jul 8, later "fixed" by the median-of-3 windows in `cd4f94f8bdb`, which moved the flap but didn't remove it).

Measurement across environments shows the streaming dropped-frame ratio tracks **machine load, not code health** — the identical build measured:

| environment | median dropped | median p95 |
|---|---|---|
| idle dev box | ~20%, later 13.5% | 33.3ms |
| loaded ubuntu CI runners | 26.8% / 27.8% | 33.4ms |
| saturated dev box (6 parallel agents) | 39.7% | 33.4ms |

The p95 is pinned at the one-dropped-frame vsync floor in *every* observation — busy, never janky. No static ratio threshold separates these healthy states from a real regression.

## Fix

Judge the ratio as a **delta over an in-run ambient baseline**: an identical 120-tick rAF window driving **zero tokens**, sampled with the same harvester seconds before the streaming windows. Frames dropped there are pure machine load (co-tenant CI processes, GC). Streaming may add **30pp** over ambient — healthy worst-case measured delta is ~22pp, while the regression this gate exists to catch (an unmemoized widget re-rendering the thread on every token) doubles nearly every frame, a delta far past 50pp. An **0.85 absolute ceiling** prevents a pathological baseline from masking a pathological regression.

Untouched and still tight: the p95 factor (2.5×), widget-remount-exactly-once, CLS, zero-outside-chat-reflow, and the injected-CLS teeth self-check. This extends the operating-point doctrine established for the sibling runner's relayout gate in `8fa72907d3a` to a load-dominated metric where a static point-budget cannot work.

## Evidence

Local end-to-end run with the change (`bun run --cwd packages/ui test:chat-perf-gate`):
```
stream ambient baseline: dropped 9.5% of 126 frames | streaming drop budget 39.5%
stream median: p95 33.3ms (budget 41.7ms) | dropped 13.5% | cls 0.0000 | flagged 0/3 windows | reflow 12 outside-chat 0
✓ median streaming dropped-frame ratio 13.5% within 39.5% (ambient 9.5% + 30pp allowance)
✓ frame-budget detector does not flag the streaming window (0/3 windows flagged)
PERF GATE PASSED
```

Adaptivity was demonstrated organically during development: the same assertions measured 39.7% streaming on this box while six parallel build agents saturated it — under the new gate that state passes only because ambient is proportionally elevated; a genuine regression (streaming high while ambient is low) still fails.

Test-fixture-only change; no product code touched. Greens the remaining failure in the Chat shell gestures lane (run on `b7514a057b8`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review follow-up and evidence

Contributes to #13562.

The review replaced the single ambient sample with three interleaved ambient/stream pairs. This prevents a load sample taken early in the run from masking or falsely failing later windows. The gate now evaluates the median paired delta, retains the p95 budget, and uses a 70% independent absolute ceiling.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots: N/A - this changes only a browser performance test runner; product rendering and styling are unchanged.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots: N/A - this changes only a browser performance test runner; product rendering and styling are unchanged.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: https://github.com/elizaOS/eliza/releases/download/pr-evidence/15735-chat-perf-gate.mp4 (post-rebase run of the real ContinuousChatOverlay fixture).
<!-- evidence-row:backend-logs -->
- [ ] Backend logs: N/A - the gate is a local browser fixture and does not invoke a server route.
<!-- evidence-row:frontend-logs -->
- [x] Frontend browser measurements, pass output, and reversion-proof failure: https://github.com/elizaOS/eliza/releases/download/pr-evidence/15735-perf-gate-review.txt
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: N/A - the test creates no DB rows, memories, scheduled tasks, files, audio, wallet, or chain state.

### Manual review

- Post-rebase real browser run passed with median ambient 20.8%, streaming 20.6%, paired delta +0.5pp, p95 33.4ms, zero outside-chat shifts, and zero page errors.
- Reversion proof temporarily injected 25ms synchronous work per streamed batch: median delta rose to 72.4pp, p95 to 50.0ms, all 3 windows were flagged, and the gate exited 1. The mutation was removed before commit.
- `node --check` and `git diff --check origin/develop...HEAD` passed.
