### PR TITLE
test(app): unmask remote-capability ui-smoke — block SW bundle interception, align with MVP settings gating

### DIFF
--- a/packages/app/test/ui-smoke/remote-capability-view.spec.ts
+++ b/packages/app/test/ui-smoke/remote-capability-view.spec.ts
@@ -29,8 +29,24 @@ type RemoteCapabilityServer = {
 };
 
 const ADVANCED_SETTINGS_STORAGE_KEY = "eliza:settings-advanced";
+// The Capabilities settings section is developerOnly since the MVP settings
+// declutter (788a314a7b9 / 5102e001b41): the hub renders it only when
+// Developer Mode is on. The advanced flag above additionally reveals the
+// remote-endpoint connect form INSIDE the section (CapabilitiesSection).
+const DEVELOPER_MODE_STORAGE_KEY = "eliza:developerMode";
 const REMOTE_CAPABILITY_BUNDLE_PATH =
   "/api/views/remote-capability-live/bundle.js";
+
+// The production renderer registers /sw.js, whose fetch handler serves
+// /api/views/:id/bundle.js stale-while-revalidate (fd47ef2b275). A
+// service-worker-originated fetch is invisible to page.route, so with the SW
+// controlling the page the mocked bundle below is fetched from the real stub
+// server (404) and the dynamic import fails. Blocking SWs keeps the
+// route-mocked bundle path authoritative — same rationale as the
+// desktop-webkit project in playwright.ui-smoke.config.ts. Playwright's block
+// resolves register() to undefined, which sw-registration.ts already treats
+// as SW-unavailable without logging a console error.
+test.use({ serviceWorkers: "block" });
 
 test("app shell loads a remote capability view bundle from a running endpoint", async ({
   page,
@@ -89,7 +105,10 @@ test("app shell loads a remote capability view bundle from a running endpoint", 
 test("settings connects a remote capability endpoint and opens its view", async ({
   page,
 }) => {
-  await seedAppStorage(page, { [ADVANCED_SETTINGS_STORAGE_KEY]: "1" });
+  await seedAppStorage(page, {
+    [ADVANCED_SETTINGS_STORAGE_KEY]: "1",
+    [DEVELOPER_MODE_STORAGE_KEY]: "1",
+  });
   await installDefaultAppRoutes(page);
 
   const remote = await startRemoteCapabilityServer();
@@ -214,7 +233,10 @@ test("settings connects a remote capability endpoint and opens its view", async 
 });
 
 test("settings provisions a cloud capability sandbox", async ({ page }) => {
-  await seedAppStorage(page, { [ADVANCED_SETTINGS_STORAGE_KEY]: "1" });
+  await seedAppStorage(page, {
+    [ADVANCED_SETTINGS_STORAGE_KEY]: "1",
+    [DEVELOPER_MODE_STORAGE_KEY]: "1",
+  });
   await installDefaultAppRoutes(page);
 
   let connectPayload: unknown = null;
@@ -258,7 +280,10 @@ test("settings provisions a cloud capability sandbox", async ({ page }) => {
   await openAppPath(page, "/settings");
   await openSettingsSection(page, /^Capabilities\b/);
 
-  await page.getByRole("button", { name: "Cloud", exact: true }).click();
+  // The Endpoint/Cloud connection-mode switch is a SettingsSegmentedRow
+  // radiogroup ("Capability router connection mode"), so the Cloud option
+  // exposes role=radio, not role=button.
+  await page.getByRole("radio", { name: "Cloud", exact: true }).click();
   await page
     .getByLabel("Capability cloud API base URL")
     .fill("https://api.elizacloud.ai");


### PR DESCRIPTION
Fixes the `Client Tests` failure in Tests run [29007198905](https://github.com/elizaOS/eliza/actions/runs/29007198905) (develop@03f8dcdcf9d, job 86081848686): all 3 tests in `packages/app/test/ui-smoke/remote-capability-view.spec.ts` red with `[playwright-ui-smoke] remote capability live view: ready checks failed (fail:selector=[data-testid="remote-capability-live-view"])` plus two `#capabilities` scroll timeouts.

## Not a regression in `1550922604d..03f8dcdcf9d` — the step had simply never run

- The "Remote capability UI smoke" step (and the spec, and `/sw.js` view-bundle caching) all landed in the fd47ef2b275 squash (#14459). Since then **every** completed `Tests` run on develop either failed at the preceding `bun run test:client` step (step `skipped`) or never started the Client Tests job — verified via the Actions API across all completed develop runs back to Jul 6. Run 29007198905 is the **first run in which this step ever executed** (`Run client tests: success` → `Remote capability UI smoke: failure`), because #15721/#15731/#15732 greened `test:client` ahead of it.
- Local repro fails **identically at both endpoints of the suspect range** with a freshly rebuilt, commit-stamped renderer: 3/3 red at `03f8dcdcf9d` and 3/3 red at `1550922604d` (`dist/eliza-renderer-build.json` verified `"commit": "1550922604d…"` before the run).
- **#15721's `bun` exports condition and #15731's apex-host change are exonerated** (scrutinized as requested): the failures predate both, and neither commit's diff is on the failing path (`APEX_UI_CONTROL_PLANE_HOSTS` never matches `127.0.0.1`; the smoke's renderer build resolves workspace plugins by Vite alias, not package exports).

## Root causes (three, all product-intent changes the masked spec never caught up with)

1. **Service worker swallows the route-mocked bundle** (test 1, and test 2's view-open step). The production renderer registers `/sw.js`, whose fetch handler serves `/api/views/:id/bundle.js` stale-while-revalidate (landed with the same #14459 squash). A service-worker-originated fetch is invisible to Playwright `page.route`, so the spec's mocked bundle was fetched from the real zero-key stub server and 404'd — the dynamic import failed and the remote view never mounted. Proven with an instrumented run (below): the bundle response reports `fromServiceWorker=true`, status 404, and the spec's route handler **never fires**, while the `/api/views` list fetch — a path the SW has no handler for — **is** intercepted, which is why the view title still rendered around the "Failed to load view" error card.
2. **MVP settings declutter hid the Capabilities section** (tests 2/3). Since 788a314a7b9 / 5102e001b41 the section is `developerOnly` — hidden from the settings hub unless Developer Mode is on. The product contract is pinned by `packages/ui/src/components/settings/settings-sections.mvp-hidden.test.ts` ("hidden when Developer Mode is off, reappears when on"). The spec seeded only `eliza:settings-advanced`, so `openSettingsSection(/^Capabilities\b/)` timed out on `#capabilities`.
3. **Endpoint/Cloud mode switch is a radiogroup** (test 3). The connection-mode control is a `SettingsSegmentedRow` radiogroup (`role=radio`), but the spec clicked `getByRole("button", { name: "Cloud" })`.

## Fix (spec alignment only — no product change)

- `test.use({ serviceWorkers: "block" })` for this spec, mirroring the existing `desktop-webkit` project precedent in `playwright.ui-smoke.config.ts`. Playwright's block patches `register()` to resolve `undefined`, which `sw-registration.ts` already treats as SW-unavailable without logging a console error (so test 1's `pageErrors` assertion stays intact). The spec's contract — DynamicViewLoader's real host-external import path — is untouched; the SW cache layer is orthogonal to what this spec mocks and proves.
- Seed `eliza:developerMode=1` in the two settings flows (the advanced flag still gates the remote-endpoint form *inside* the section).
- Click the Cloud **radio** in the connection-mode radiogroup.

The product is deliberately untouched: SW stale-while-revalidate for view bundles and the MVP declutter are both intended behavior (the latter machine-pinned by its own unit test).

## Evidence

**Red → green on the same tree/build** (only the spec file differs):

<details><summary>BEFORE — pre-fix spec at 03f8dcdcf9d: 3/3 failed (same signature as CI run 29007198905)</summary>

```
✘  1 [chromium] › app shell loads a remote capability view bundle from a running endpoint (34.0s)
✘  2 [chromium] › settings connects a remote capability endpoint and opens its view (21.6s)
✘  3 [chromium] › settings provisions a cloud capability sandbox (21.7s)
Error: [playwright-ui-smoke] remote capability live view: ready checks failed (fail:selector=[data-testid="remote-capability-live-view"])
TimeoutError: locator.scrollIntoViewIfNeeded: Timeout 15000ms exceeded. — waiting for locator('#capabilities')  (x2)
3 failed
```
Also reproduced 3/3 red at the previous run's head `1550922604d` with a fresh renderer build stamped `"commit": "1550922604d…"`.
</details>

<details><summary>Instrumented network trace proving the SW mechanism (pre-fix)</summary>

```
REQ GET http://127.0.0.1:40131/api/views  rtype=fetch
ROUTE-VIEWS(list) fired
RES 200 http://127.0.0.1:40131/api/views  fromSW=false            <-- page.route mock works (no SW handler on this path)

REQ GET http://127.0.0.1:40131/api/views/remote-capability-live/bundle.js?hostExternalRuntime=1&...  rtype=script
RES 404 ...bundle.js?...  fromSW=true                              <-- served BY the service worker; ROUTE-BUNDLE never fired
CONSOLE[error] Failed to load resource: the server responded with a status of 404 (Not Found)
CONSOLE[error] DynamicViewLoader failed to load view "remote-capability-live.view" ... TypeError: Failed to fetch dynamically imported module
SW {"controller":"http://127.0.0.1:40131/sw.js","registrations":["http://127.0.0.1:40131/sw.js"]}
MOUNTED=0 bundleReq=0 manifestReq=2
```
</details>

<details><summary>AFTER — fixed spec, same build: 3/3 passed (two consecutive runs + one recorded run)</summary>

```
✓  1 [chromium] › app shell loads a remote capability view bundle from a running endpoint (3.2s)
✓  2 [chromium] › settings connects a remote capability endpoint and opens its view (6.1s)
✓  3 [chromium] › settings provisions a cloud capability sandbox (3.9s)
3 passed (18.0s)
```
</details>

**Before (red) — remote view never mounts / Capabilities section missing / Cloud button unfindable:**

<img src="https://gist.githubusercontent.com/lalalune/3bff829cce93dfa97973ac549adefcbd/raw/before-test1-fail.jpg" width="420"> <img src="https://gist.githubusercontent.com/lalalune/3bff829cce93dfa97973ac549adefcbd/raw/before-test2-fail.jpg" width="420">
<img src="https://gist.githubusercontent.com/lalalune/3bff829cce93dfa97973ac549adefcbd/raw/before-test3-fail.jpg" width="420">

**After (green) — remote capability view mounted from the routed bundle; cloud sandbox connect confirmation:**

<img src="https://gist.githubusercontent.com/lalalune/3bff829cce93dfa97973ac549adefcbd/raw/after-app-bf0ad-dle-from-a-running-endpoint.jpg" width="420"> <img src="https://gist.githubusercontent.com/lalalune/3bff829cce93dfa97973ac549adefcbd/raw/after-set-28d5c--a-cloud-capability-sandbox.jpg" width="420">

Pass-run video walkthroughs (Playwright recordings): [test 1](https://gist.githubusercontent.com/lalalune/3bff829cce93dfa97973ac549adefcbd/raw/after-test1-pass.mp4) · [test 2](https://gist.githubusercontent.com/lalalune/3bff829cce93dfa97973ac549adefcbd/raw/after-test2-pass.mp4) · [test 3](https://gist.githubusercontent.com/lalalune/3bff829cce93dfa97973ac549adefcbd/raw/after-test3-pass.mp4)

- `bunx biome check packages/app/test/ui-smoke/remote-capability-view.spec.ts` — clean.
- Scope: one spec file; no shared harness, config, or product code touched, so the rest of the ui-smoke lane is unaffected by construction (the `serviceWorkers` override is `test.use` inside this file only).
- Real-LLM trajectories: N/A — zero-key deterministic ui-smoke stub lane; no agent/model behavior changed.
- Mobile/desktop per-platform capture: N/A — desktop-Chromium-only smoke spec; no product UI changed.
- Backend structured logs: N/A — stub API stack; the relevant server-side signal is the instrumented network trace above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://gist.githubusercontent.com/lalalune/3bff829cce93dfa97973ac549adefcbd/raw/before-test1-fail.jpg)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://gist.githubusercontent.com/lalalune/3bff829cce93dfa97973ac549adefcbd/raw/after-app-bf0ad-dle-from-a-running-endpoint.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] https://gist.githubusercontent.com/lalalune/3bff829cce93dfa97973ac549adefcbd/raw/after-test3-pass.mp4

<!-- evidence-row:backend-logs -->
- [ ] N/A - deterministic local UI-smoke stack; no production backend code changed.

<!-- evidence-row:frontend-logs -->
- [x] [15736-remote-capability-review.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15736-remote-capability-review.log)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, planner, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - test-harness alignment only; no persistent domain state changed.