### PR TITLE
feat(lifeops): process delegated connector turns

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/delegation-contracts/inbound-event.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/delegation-contracts/inbound-event.ts
@@ -6,12 +6,12 @@
  * processor persists state and creates approval-gated reply drafts.
  */
 import type { IAgentRuntime, Memory, MessagePayload } from "@elizaos/core";
-import { createApprovalQueue } from "../approval-queue.js";
-import { LifeOpsRepository } from "../repository.js";
-import {
-  type DelegationChannel,
-  type DelegationInboundTurn,
-  processDelegationInboundTurn,
+import type { ApprovalQueue } from "../approval-queue.types.js";
+import type {
+  DelegationChannel,
+  DelegationContractRepository,
+  DelegationInboundProcessingResult,
+  DelegationInboundTurn,
 } from "./index.js";
 
 type UnknownRecord = Record<string, unknown>;
@@ -191,18 +191,35 @@ export function delegationInboundTurnFromMessage(
   };
 }
 
-/** Process a connector message through the durable delegation policy path. */
-export async function handleDelegationInboundMessage(
-  payload: MessagePayload,
-): Promise<void> {
-  const turn = delegationInboundTurnFromMessage(payload.message);
-  if (!turn) return;
-  const runtime: IAgentRuntime = payload.runtime;
-  await processDelegationInboundTurn({
-    agentId: runtime.agentId,
-    turn,
-    nowIso: new Date().toISOString(),
-    repository: new LifeOpsRepository(runtime),
-    approvalQueue: createApprovalQueue(runtime, { agentId: runtime.agentId }),
-  });
+export interface DelegationInboundMessageDependencies {
+  readonly createRepository: (
+    runtime: IAgentRuntime,
+  ) => DelegationContractRepository;
+  readonly createApprovalQueue: (runtime: IAgentRuntime) => ApprovalQueue;
+  readonly processTurn: (input: {
+    readonly agentId: string;
+    readonly turn: DelegationInboundTurn;
+    readonly nowIso: string;
+    readonly repository: DelegationContractRepository;
+    readonly approvalQueue: ApprovalQueue;
+  }) => Promise<DelegationInboundProcessingResult>;
+  readonly now?: () => Date;
+}
+
+/** Build the connector-event handler with runtime-owned persistence adapters. */
+export function createDelegationInboundMessageHandler(
+  dependencies: DelegationInboundMessageDependencies,
+): (payload: MessagePayload) => Promise<void> {
+  return async (payload: MessagePayload): Promise<void> => {
+    const turn = delegationInboundTurnFromMessage(payload.message);
+    if (!turn) return;
+    const runtime: IAgentRuntime = payload.runtime;
+    await dependencies.processTurn({
+      agentId: runtime.agentId,
+      turn,
+      nowIso: (dependencies.now?.() ?? new Date()).toISOString(),
+      repository: dependencies.createRepository(runtime),
+      approvalQueue: dependencies.createApprovalQueue(runtime),
+    });
+  };
 }

--- a/plugins/plugin-personal-assistant/src/lifeops/delegation-contracts/inbound-event.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/delegation-contracts/inbound-event.ts
@@ -1,0 +1,208 @@
+/**
+ * Normalizes runtime connector messages into LifeOps delegation turns.
+ *
+ * Connectors keep ownership of transport-specific metadata; this boundary
+ * extracts their shared thread and sender fields before the delegation policy
+ * processor persists state and creates approval-gated reply drafts.
+ */
+import type { IAgentRuntime, Memory, MessagePayload } from "@elizaos/core";
+import { createApprovalQueue } from "../approval-queue.js";
+import { LifeOpsRepository } from "../repository.js";
+import {
+  type DelegationChannel,
+  type DelegationInboundTurn,
+  processDelegationInboundTurn,
+} from "./index.js";
+
+type UnknownRecord = Record<string, unknown>;
+
+const CHANNEL_ALIASES: Readonly<Record<string, DelegationChannel>> = {
+  discord: "discord",
+  email: "email",
+  gmail: "email",
+  google: "email",
+  imessage: "imessage",
+  signal: "signal",
+  slack: "slack",
+  telegram: "telegram",
+  whatsapp: "whatsapp",
+  x: "x_dm",
+  x_dm: "x_dm",
+  twitter: "x_dm",
+};
+
+function record(value: unknown): UnknownRecord {
+  return value !== null && typeof value === "object"
+    ? (value as UnknownRecord)
+    : {};
+}
+
+function stringValue(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return String(value);
+    }
+  }
+  return undefined;
+}
+
+function numberValue(...values: unknown[]): number | undefined {
+  for (const value of values) {
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+  }
+  return undefined;
+}
+
+function channelFromMessage(
+  content: UnknownRecord,
+  metadata: UnknownRecord,
+): DelegationChannel | null {
+  const origin = record(metadata.origin);
+  const source = stringValue(
+    content.source,
+    metadata.source,
+    metadata.provider,
+    origin.provider,
+    origin.surface,
+  )?.toLowerCase();
+  return source ? (CHANNEL_ALIASES[source] ?? null) : null;
+}
+
+function threadIdFromMessage(
+  message: Memory,
+  content: UnknownRecord,
+  metadata: UnknownRecord,
+): string {
+  const contentMetadata = record(content.metadata);
+  const thread = record(metadata.thread);
+  const delivery = record(metadata.delivery);
+  const origin = record(metadata.origin);
+  const telegram = record(metadata.telegram);
+  const slack = record(metadata.slack);
+  const whatsapp = record(metadata.whatsapp);
+  const signal = record(metadata.signal);
+  const x = record(metadata.x);
+  return (
+    stringValue(
+      thread.id,
+      delivery.threadId,
+      origin.threadId,
+      slack.threadTs,
+      telegram.threadId,
+      whatsapp.chatId,
+      signal.groupId,
+      x.conversationId,
+      content.threadId,
+      contentMetadata.threadId,
+      message.roomId,
+    ) ?? String(message.roomId)
+  );
+}
+
+function receivedAtFromMessage(
+  message: Memory,
+  metadata: UnknownRecord,
+): string {
+  const timestamp = numberValue(message.createdAt, metadata.timestamp);
+  if (timestamp === undefined) {
+    throw new Error(
+      "[DelegationInboundEvent] connector message has no timestamp.",
+    );
+  }
+  const receivedAt = new Date(timestamp);
+  if (!Number.isFinite(receivedAt.getTime())) {
+    throw new Error(
+      `[DelegationInboundEvent] connector message has invalid timestamp ${timestamp}.`,
+    );
+  }
+  return receivedAt.toISOString();
+}
+
+/** Map one canonical runtime message into the delegation policy vocabulary. */
+export function delegationInboundTurnFromMessage(
+  message: Memory,
+): DelegationInboundTurn | null {
+  const content = record(message.content);
+  const metadata = record(message.metadata);
+  const contentMetadata = record(content.metadata);
+  const sender = record(metadata.sender);
+  const channel = channelFromMessage(content, metadata);
+  if (!channel) return null;
+  const text = stringValue(content.text);
+  if (!text) return null;
+
+  const senderName =
+    stringValue(
+      sender.name,
+      sender.username,
+      sender.id,
+      metadata.entityName,
+      metadata.entityUserName,
+      metadata.from,
+      content.sender,
+      message.entityId,
+    ) ?? String(message.entityId);
+  const senderEmail = stringValue(
+    sender.email,
+    metadata.senderEmail,
+    metadata.fromEmail,
+    content.senderEmail,
+    content.fromEmail,
+    contentMetadata.senderEmail,
+  );
+  const senderClass = stringValue(
+    metadata.senderClass,
+    content.senderClass,
+    contentMetadata.senderClass,
+  );
+  const subject = stringValue(
+    metadata.subject,
+    content.subject,
+    contentMetadata.subject,
+  );
+  const ownerRepliedAt = stringValue(
+    metadata.ownerRepliedAt,
+    contentMetadata.ownerRepliedAt,
+  );
+  const followupCount = numberValue(
+    metadata.followupCount,
+    contentMetadata.followupCount,
+  );
+  const renewalDeltaPercent = numberValue(
+    metadata.renewalDeltaPercent,
+    contentMetadata.renewalDeltaPercent,
+  );
+
+  return {
+    channel,
+    threadId: threadIdFromMessage(message, content, metadata),
+    sender: senderName,
+    ...(senderEmail ? { senderEmail } : {}),
+    ...(senderClass ? { senderClass } : {}),
+    ...(subject ? { subject } : {}),
+    text,
+    receivedAt: receivedAtFromMessage(message, metadata),
+    ...(ownerRepliedAt ? { ownerRepliedAt } : {}),
+    ...(followupCount !== undefined ? { followupCount } : {}),
+    ...(renewalDeltaPercent !== undefined ? { renewalDeltaPercent } : {}),
+  };
+}
+
+/** Process a connector message through the durable delegation policy path. */
+export async function handleDelegationInboundMessage(
+  payload: MessagePayload,
+): Promise<void> {
+  const turn = delegationInboundTurnFromMessage(payload.message);
+  if (!turn) return;
+  const runtime: IAgentRuntime = payload.runtime;
+  await processDelegationInboundTurn({
+    agentId: runtime.agentId,
+    turn,
+    nowIso: new Date().toISOString(),
+    repository: new LifeOpsRepository(runtime),
+    approvalQueue: createApprovalQueue(runtime, { agentId: runtime.agentId }),
+  });
+}

--- a/plugins/plugin-personal-assistant/src/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.ts
@@ -116,6 +116,7 @@ import {
   registerDefaultConnectorPack,
 } from "./lifeops/connectors/index.js";
 import { applyMockoonEnvOverrides } from "./lifeops/connectors/mockoon-redirect.js";
+import { handleDelegationInboundMessage } from "./lifeops/delegation-contracts/inbound-event.js";
 import { handleVoiceTurnObserved } from "./lifeops/entities/voice-observer-bridge.js";
 import { installFirstRunChannelInspector } from "./lifeops/first-run/channel-inspector.js";
 import { setRuntimeChannelInspector } from "./lifeops/first-run/questions.js";
@@ -758,6 +759,10 @@ const rawPersonalAssistantPlugin: Plugin = {
       detachInboundScan(
         "question-followup-cancel",
         handleOwnerMessageForQuestionFollowup,
+      ),
+      detachInboundScan(
+        "delegation-contract-inbound",
+        handleDelegationInboundMessage,
       ),
     ],
     // Agent reply ends with a question the owner never answers → seed a

--- a/plugins/plugin-personal-assistant/src/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.ts
@@ -104,6 +104,7 @@ import {
   registerFollowupTrackerWorker,
 } from "./followup/index.js";
 import { anticipationFeedbackEvaluator } from "./lifeops/anticipation/evaluator.js";
+import { createApprovalQueue } from "./lifeops/approval-queue.js";
 import { registerLifeOpsCalendarGate } from "./lifeops/calendar-gate.js";
 import {
   createChannelRegistry,
@@ -116,7 +117,8 @@ import {
   registerDefaultConnectorPack,
 } from "./lifeops/connectors/index.js";
 import { applyMockoonEnvOverrides } from "./lifeops/connectors/mockoon-redirect.js";
-import { handleDelegationInboundMessage } from "./lifeops/delegation-contracts/inbound-event.js";
+import { createDelegationInboundMessageHandler } from "./lifeops/delegation-contracts/inbound-event.js";
+import { processDelegationInboundTurn } from "./lifeops/delegation-contracts/index.js";
 import { handleVoiceTurnObserved } from "./lifeops/entities/voice-observer-bridge.js";
 import { installFirstRunChannelInspector } from "./lifeops/first-run/channel-inspector.js";
 import { setRuntimeChannelInspector } from "./lifeops/first-run/questions.js";
@@ -211,6 +213,13 @@ import {
   ensureBlockRuleReconcileTask,
   registerBlockRuleReconcilerWorker,
 } from "./website-blocker/chat-integration/index.js";
+
+const handleDelegationInboundMessage = createDelegationInboundMessageHandler({
+  createRepository: (runtime) => new LifeOpsRepository(runtime),
+  createApprovalQueue: (runtime) =>
+    createApprovalQueue(runtime, { agentId: runtime.agentId }),
+  processTurn: processDelegationInboundTurn,
+});
 
 const GOOGLE_CONNECTOR_PLUGIN_PACKAGE = "@elizaos/plugin-google";
 const GOOGLE_CONNECTOR_PLUGIN_NAME = "google";

--- a/plugins/plugin-personal-assistant/test/delegation-contracts-event.test.ts
+++ b/plugins/plugin-personal-assistant/test/delegation-contracts-event.test.ts
@@ -6,26 +6,15 @@
  */
 import type { IAgentRuntime, Memory, MessagePayload } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
-
-const listDelegationContracts = vi.fn(async () => []);
-
-vi.mock("../src/lifeops/repository.js", () => ({
-  LifeOpsRepository: class {
-    listDelegationContracts = listDelegationContracts;
-    upsertDelegationContract = vi.fn(async () => undefined);
-  },
-}));
-
-vi.mock("../src/lifeops/approval-queue.js", () => ({
-  createApprovalQueue: vi.fn(() => ({
-    enqueue: vi.fn(),
-  })),
-}));
-
+import type { ApprovalQueue } from "../src/lifeops/approval-queue.types.js";
 import {
+  createDelegationInboundMessageHandler,
   delegationInboundTurnFromMessage,
-  handleDelegationInboundMessage,
 } from "../src/lifeops/delegation-contracts/inbound-event.js";
+import type {
+  DelegationContractRepository,
+  DelegationInboundProcessingResult,
+} from "../src/lifeops/delegation-contracts/index.js";
 
 const ENTITY_ID = "00000000-0000-0000-0000-000000001856";
 const ROOM_ID = "00000000-0000-0000-0000-000000001857";
@@ -101,18 +90,69 @@ describe("delegation connector event normalization", () => {
     ).toBeNull();
   });
 
-  it("hands connector messages to the durable contract repository", async () => {
-    listDelegationContracts.mockClear();
+  it("hands connector messages to the durable policy processor", async () => {
+    const repository: DelegationContractRepository = {
+      listDelegationContracts: vi.fn(async () => []),
+      upsertDelegationContract: vi.fn(async () => undefined),
+    };
+    const approvalQueue: ApprovalQueue = {
+      enqueue: vi.fn(),
+      list: vi.fn(),
+      byId: vi.fn(),
+      approve: vi.fn(),
+      reject: vi.fn(),
+      markExecuting: vi.fn(),
+      markDone: vi.fn(),
+      markExpired: vi.fn(),
+      purgeExpired: vi.fn(),
+    };
+    const processingResult: DelegationInboundProcessingResult = {
+      evaluations: [],
+      enqueuedApprovals: [],
+    };
+    const processTurn = vi.fn(async () => processingResult);
+    const handler = createDelegationInboundMessageHandler({
+      createRepository: () => repository,
+      createApprovalQueue: () => approvalQueue,
+      processTurn,
+      now: () => new Date("2026-07-09T18:01:00.000Z"),
+    });
     const payload: MessagePayload = {
       runtime: { agentId: ENTITY_ID } as IAgentRuntime,
       message: message(),
       source: "test",
     };
-    await handleDelegationInboundMessage(payload);
-    expect(listDelegationContracts).toHaveBeenCalledWith(ENTITY_ID, {
-      statuses: ["active"],
-      activeAtIso: "2026-07-09T18:00:00.000Z",
+    await handler(payload);
+    expect(processTurn).toHaveBeenCalledWith({
+      agentId: ENTITY_ID,
+      turn: delegationInboundTurnFromMessage(message()),
+      nowIso: "2026-07-09T18:01:00.000Z",
+      repository,
+      approvalQueue,
     });
+  });
+
+  it("does not allocate adapters for non-connector chat", async () => {
+    const createRepository = vi.fn();
+    const createApprovalQueue = vi.fn();
+    const processTurn = vi.fn();
+    const handler = createDelegationInboundMessageHandler({
+      createRepository,
+      createApprovalQueue,
+      processTurn,
+    });
+
+    await handler({
+      runtime: { agentId: ENTITY_ID } as IAgentRuntime,
+      message: message({
+        content: { text: "hello", source: "client_chat" },
+        metadata: { type: "message", source: "client_chat" },
+      }),
+      source: "test",
+    });
+    expect(createRepository).not.toHaveBeenCalled();
+    expect(createApprovalQueue).not.toHaveBeenCalled();
+    expect(processTurn).not.toHaveBeenCalled();
   });
 
   it("fails fast when connector metadata omits message time", () => {

--- a/plugins/plugin-personal-assistant/test/delegation-contracts-event.test.ts
+++ b/plugins/plugin-personal-assistant/test/delegation-contracts-event.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Connector-event coverage for delegation contracts.
+ *
+ * Real connector-shaped memories prove transport metadata reaches the existing
+ * durable delegation processor without teaching connectors LifeOps policy.
+ */
+import type { IAgentRuntime, Memory, MessagePayload } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+
+const listDelegationContracts = vi.fn(async () => []);
+
+vi.mock("../src/lifeops/repository.js", () => ({
+  LifeOpsRepository: class {
+    listDelegationContracts = listDelegationContracts;
+    upsertDelegationContract = vi.fn(async () => undefined);
+  },
+}));
+
+vi.mock("../src/lifeops/approval-queue.js", () => ({
+  createApprovalQueue: vi.fn(() => ({
+    enqueue: vi.fn(),
+  })),
+}));
+
+import {
+  delegationInboundTurnFromMessage,
+  handleDelegationInboundMessage,
+} from "../src/lifeops/delegation-contracts/inbound-event.js";
+
+const ENTITY_ID = "00000000-0000-0000-0000-000000001856";
+const ROOM_ID = "00000000-0000-0000-0000-000000001857";
+
+function message(overrides: Partial<Memory> = {}): Memory {
+  return {
+    entityId: ENTITY_ID,
+    roomId: ROOM_ID,
+    createdAt: Date.parse("2026-07-09T18:00:00.000Z"),
+    content: { text: "The price is too high; procurement needs a discount." },
+    metadata: {
+      type: "message",
+      source: "telegram",
+      sender: { id: "vendor-1", name: "Riley Vendor" },
+      telegram: {
+        userId: "vendor-1",
+        chatId: "vendor-chat",
+        threadId: "renewal-thread",
+      },
+    },
+    ...overrides,
+  } as Memory;
+}
+
+describe("delegation connector event normalization", () => {
+  it("maps a Telegram topic to its contract thread", () => {
+    expect(delegationInboundTurnFromMessage(message())).toEqual({
+      channel: "telegram",
+      threadId: "renewal-thread",
+      sender: "Riley Vendor",
+      text: "The price is too high; procurement needs a discount.",
+      receivedAt: "2026-07-09T18:00:00.000Z",
+    });
+  });
+
+  it("maps Gmail aliases and sender-class metadata for SLA contracts", () => {
+    expect(
+      delegationInboundTurnFromMessage(
+        message({
+          content: {
+            text: "Can you send the latest numbers?",
+            source: "gmail",
+            metadata: {
+              senderEmail: "dana@board.example",
+              senderClass: "board_member",
+              subject: "Quarterly update",
+              threadId: "thread-board-1",
+            },
+          },
+          metadata: { type: "message", source: "gmail" },
+        }),
+      ),
+    ).toEqual({
+      channel: "email",
+      threadId: "thread-board-1",
+      sender: ENTITY_ID,
+      senderEmail: "dana@board.example",
+      senderClass: "board_member",
+      subject: "Quarterly update",
+      text: "Can you send the latest numbers?",
+      receivedAt: "2026-07-09T18:00:00.000Z",
+    });
+  });
+
+  it("ignores in-app messages that cannot match connector contracts", () => {
+    expect(
+      delegationInboundTurnFromMessage(
+        message({
+          content: { text: "hello", source: "client_chat" },
+          metadata: { type: "message", source: "client_chat" },
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("hands connector messages to the durable contract repository", async () => {
+    listDelegationContracts.mockClear();
+    const payload: MessagePayload = {
+      runtime: { agentId: ENTITY_ID } as IAgentRuntime,
+      message: message(),
+      source: "test",
+    };
+    await handleDelegationInboundMessage(payload);
+    expect(listDelegationContracts).toHaveBeenCalledWith(ENTITY_ID, {
+      statuses: ["active"],
+      activeAtIso: "2026-07-09T18:00:00.000Z",
+    });
+  });
+
+  it("fails fast when connector metadata omits message time", () => {
+    expect(() =>
+      delegationInboundTurnFromMessage(
+        message({
+          createdAt: undefined,
+          metadata: { type: "message", source: "signal" },
+        }),
+      ),
+    ).toThrow("connector message has no timestamp");
+  });
+});


### PR DESCRIPTION
## Summary

- attach LifeOps delegation-contract processing to canonical `MESSAGE_RECEIVED`
- normalize email and chat connector thread/sender metadata without moving policy into transports
- pass matching turns to the durable repository and approval queue; skip in-app traffic and reject malformed timestamps
- inject repository, approval-queue, and clock dependencies at the plugin composition root so the actual event seam remains root-testable without prebuilt cloud packages

Fixes part of #14856.

## Verification

- Root Vitest coverage run: 7 tests passed; new module 50/52 covered lines (96%).
- Package delegation suite: 13 tests passed.
- Package build, focused Biome, `git diff --check`, and error-policy ratchet passed.
- Package typecheck remains blocked by existing unresolved workspace declarations and unrelated stale cross-package types; no reported error points to this change.

## Evidence

<!-- evidence-row:before-screenshots -->
Before screenshots: N/A - runtime connector-event wiring only; no rendered UI changed.

<!-- evidence-row:after-screenshots -->
After screenshots: N/A - no visual source changed.

<!-- evidence-row:walkthrough-video -->
Walkthrough video: N/A - no user-facing UI flow changed.

<!-- evidence-row:backend-logs -->
Backend logs: N/A - no live credentialed connector is available here; focused tests prove event normalization and processor handoff, while live evidence remains required on #14856.

<!-- evidence-row:frontend-logs -->
Frontend logs: N/A - no frontend behavior changed.

<!-- evidence-row:ocr-review -->
OCR review: N/A - no rendered surface changed.

<!-- evidence-row:llm-trajectory -->
Real-LLM trajectory: N/A - deterministic normalization and policy handoff only; live threaded-communication trajectories remain part of #14856.

<!-- evidence-row:domain-artifacts -->
Domain artifacts: N/A - existing PGlite coverage proves durable contract and approval rows; live connector and owner-visible artifacts remain required before closing #14856.

## Remaining issue scope

This does not close #14856. Live connector evidence, owner-visible escalation delivery, delegation-map artifacts, and live trajectories remain required.
