### PR TITLE
fix(cloud): send Caddy admin origin

### DIFF
--- a/packages/cloud/shared/scripts/verify-apps-ingress-routing.sh
+++ b/packages/cloud/shared/scripts/verify-apps-ingress-routing.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 # Local-docker proof (Apps / Product 2): the apps INGRESS routing mechanism.
-# Proves, against a REAL stock Caddy, that a per-app Host header reverse-proxies
-# to that app's container via a route added to Caddy's admin API — built by the
-# REAL `apps-ingress-routes` builders — and that deleting the route by @id stops
-# routing, while an unknown host is never routed. Plain HTTP (no domain/TLS;
-# on-demand TLS is validated on real infra). No mocks.
+# Proves, against a REAL stock Caddy with admin-origin enforcement, that a
+# per-app Host header reverse-proxies to that app's container through the real
+# ingress provisioner, and that removing the route stops routing. Plain HTTP
+# (no domain/TLS; on-demand TLS is validated on real infra). No mocks.
 #   bash packages/cloud/shared/scripts/verify-apps-ingress-routing.sh
 set -uo pipefail
 cd "$(dirname "$0")/.." || exit 1 # -> packages/cloud/shared
@@ -27,12 +26,15 @@ trap cleanup EXIT
 docker network create "$NET" >/dev/null 2>&1 || true
 
 echo "=== stock Caddy: admin API + empty srv0 on :80 ==="
-cat >/tmp/apps-ing-init.json <<'JSON'
-{"admin":{"listen":"0.0.0.0:2019"},"apps":{"http":{"servers":{"srv0":{"listen":[":80"],"routes":[]}}}}}
+cat >/tmp/apps-ing-init.json <<JSON
+{"admin":{"listen":"0.0.0.0:2019","origins":["http://localhost:$ADMIN_PORT"],"enforce_origin":true},"apps":{"http":{"servers":{"srv0":{"listen":[":80"],"routes":[]}}}}}
 JSON
 docker run -d --name "$CADDY" --network "$NET" -p "$PROXY_PORT:80" -p "$ADMIN_PORT:2019" \
   -v /tmp/apps-ing-init.json:/init.json caddy:2 caddy run --config /init.json >/dev/null
-for _ in $(seq 1 25); do curl -fsS "http://localhost:$ADMIN_PORT/config/" >/dev/null 2>&1 && break; sleep 1; done
+for _ in $(seq 1 25); do
+  curl -fsS -H "Origin: http://localhost:$ADMIN_PORT" "http://localhost:$ADMIN_PORT/config/" >/dev/null 2>&1 && break
+  sleep 1
+done
 
 echo "=== sample app (http-echo) co-located in Caddy's netns (mirrors loopback-only publish) ==="
 # In prod the container publishes to 127.0.0.1:hostPort and the node-local Caddy
@@ -41,12 +43,9 @@ echo "=== sample app (http-echo) co-located in Caddy's netns (mirrors loopback-o
 docker run -d --name "$APP" --network "container:$CADDY" \
   hashicorp/http-echo -text="ROUTED-TO-APP" -listen=:5678 >/dev/null
 
-echo "=== build the route via the REAL builder + POST to Caddy admin API ==="
-# upstream = the loopback-published app port (the REAL builder always dials 127.0.0.1)
-ROUTE=$(bun -e "import{buildCaddyRoute}from'./src/lib/services/apps-ingress-routes';process.stdout.write(JSON.stringify(buildCaddyRoute({hostname:'$HOST',hostPort:5678})))")
-echo "route: $ROUTE"
-ADD_URL=$(bun -e "import{buildCaddyAddRouteUrl}from'./src/lib/services/apps-ingress-routes';process.stdout.write(buildCaddyAddRouteUrl('http://localhost:$ADMIN_PORT'))")
-curl -fsS -X POST -H 'Content-Type: application/json' -d "$ROUTE" "$ADD_URL" >/dev/null && echo "route posted"
+echo "=== add the route through the REAL origin-aware ingress provisioner ==="
+bun -e "import{addAppRoute}from'./src/lib/services/apps-ingress-provisioner';await addAppRoute({hostname:'$HOST',hostPort:5678,adminBase:'http://localhost:$ADMIN_PORT'})"
+echo "route posted"
 
 echo "=== request with the app's Host header -> reaches the app ==="
 RESP=$(curl -s -H "Host: $HOST" "http://localhost:$PROXY_PORT/")
@@ -62,9 +61,8 @@ echo "$RESP_X" | grep -q "ROUTED-TO-APP" &&
   check ok "unknown host is NOT routed to the app"
 
 echo "=== DELETE the route by @id -> host no longer routes ==="
-RID=$(bun -e "import{buildCaddyRouteId}from'./src/lib/services/apps-ingress-routes';process.stdout.write(buildCaddyRouteId('$HOST'))")
-DEL_URL=$(bun -e "import{buildCaddyRouteByIdUrl}from'./src/lib/services/apps-ingress-routes';process.stdout.write(buildCaddyRouteByIdUrl('http://localhost:$ADMIN_PORT','$RID'))")
-curl -fsS -X DELETE "$DEL_URL" >/dev/null && echo "route $RID deleted"
+bun -e "import{removeAppRoute}from'./src/lib/services/apps-ingress-provisioner';await removeAppRoute({hostname:'$HOST',adminBase:'http://localhost:$ADMIN_PORT'})"
+echo "route deleted"
 RESP2=$(curl -s -H "Host: $HOST" "http://localhost:$PROXY_PORT/")
 echo "$RESP2" | grep -q "ROUTED-TO-APP" &&
   check fail "route removal" "still routed: $RESP2" ||

--- a/packages/cloud/shared/src/lib/services/__tests__/apps-ingress-provisioner.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/apps-ingress-provisioner.test.ts
@@ -92,7 +92,7 @@ describe("addAppRoute", () => {
     ).rejects.toThrow("add-route failed (500) for abc12345.apps.elizacloud.ai via 127.0.0.1:2019");
   });
 
-  test("logs stale-route delete failure but still POSTs the replacement route", async () => {
+  test("fails before POST when stale-route deletion has a transport failure", async () => {
     const calls: Array<{ url: string; method: string }> = [];
     const fetchImpl: IngressFetch = async (url, init) => {
       calls.push({ url, method: init.method });
@@ -102,14 +102,53 @@ describe("addAppRoute", () => {
       return { ok: true, status: 201, text: async () => "" };
     };
 
-    await addAppRoute({
-      hostname: HOST,
-      hostPort: 28123,
-      adminBase: ADMIN,
-      fetchImpl,
+    await expect(
+      addAppRoute({
+        hostname: HOST,
+        hostPort: 28123,
+        adminBase: ADMIN,
+        fetchImpl,
+      }),
+    ).rejects.toMatchObject({
+      code: "CADDY_ADMIN_MUTATION_FAILED",
+      context: { operation: "replace-route-delete" },
     });
 
+    expect(calls.map((call) => call.method)).toEqual(["DELETE"]);
+  });
+
+  test("fails before POST when Caddy rejects stale-route deletion", async () => {
+    const { calls, fetchImpl } = recordingFetch((_url, method) => ({
+      ok: method !== "DELETE",
+      status: method === "DELETE" ? 403 : 201,
+    }));
+
+    await expect(
+      addAppRoute({ hostname: HOST, hostPort: 28123, adminBase: ADMIN, fetchImpl }),
+    ).rejects.toThrow(
+      "replace-route-delete failed (403) for abc12345.apps.elizacloud.ai via 127.0.0.1:2019",
+    );
+
+    expect(calls.map((call) => call.method)).toEqual(["DELETE"]);
+  });
+
+  test("continues to POST when the stale route is already absent", async () => {
+    const { calls, fetchImpl } = recordingFetch((_url, method) => ({
+      ok: method === "POST",
+      status: method === "DELETE" ? 404 : 201,
+    }));
+
+    await addAppRoute({ hostname: HOST, hostPort: 28123, adminBase: ADMIN, fetchImpl });
+
     expect(calls.map((call) => call.method)).toEqual(["DELETE", "POST"]);
+  });
+
+  test("rejects a malformed admin base before making a request", async () => {
+    const { calls, fetchImpl } = recordingFetch(() => ({ ok: true, status: 200 }));
+    await expect(
+      addAppRoute({ hostname: HOST, hostPort: 28123, adminBase: "not a URL", fetchImpl }),
+    ).rejects.toBeInstanceOf(TypeError);
+    expect(calls).toHaveLength(0);
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/__tests__/apps-ingress-provisioner.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/apps-ingress-provisioner.test.ts
@@ -1,4 +1,4 @@
-// Exercises apps ingress provisioner behavior with deterministic cloud-shared lib fixtures.
+/** Exercises Caddy ingress mutations, origin enforcement, and failure handling. */
 import { describe, expect, test } from "bun:test";
 import { addAppRoute, type IngressFetch, removeAppRoute } from "../apps-ingress-provisioner";
 
@@ -8,9 +8,19 @@ const ADMIN = "http://127.0.0.1:2019";
 function recordingFetch(
   responder: (url: string, method: string) => { ok: boolean; status: number },
 ) {
-  const calls: Array<{ url: string; method: string; body?: string }> = [];
+  const calls: Array<{
+    url: string;
+    method: string;
+    headers?: Record<string, string>;
+    body?: string;
+  }> = [];
   const fetchImpl: IngressFetch = async (url, init) => {
-    calls.push({ url, method: init.method, body: init.body });
+    calls.push({
+      url,
+      method: init.method,
+      headers: init.headers,
+      body: init.body,
+    });
     const { ok, status } = responder(url, init.method);
     return { ok, status, text: async () => "" };
   };
@@ -35,15 +45,41 @@ describe("addAppRoute", () => {
     expect(calls[0]).toMatchObject({
       method: "DELETE",
       url: "http://127.0.0.1:2019/id/app-abc12345",
+      headers: { Origin: ADMIN },
     });
     // 2) POST the route to srv0
     expect(calls[1].method).toBe("POST");
     expect(calls[1].url).toBe("http://127.0.0.1:2019/config/apps/http/servers/srv0/routes");
+    expect(calls[1].headers).toEqual({
+      Origin: ADMIN,
+      "Content-Type": "application/json",
+    });
     const posted = JSON.parse(calls[1].body ?? "{}");
     expect(posted["@id"]).toBe("app-abc12345");
     expect(posted.match[0].host).toEqual([HOST]);
     // dial is node-local loopback (Caddy co-located on the app node)
     expect(posted.handle[0].upstreams[0].dial).toBe("127.0.0.1:28123");
+  });
+
+  test("passes a Caddy origin-enforcement boundary on every mutation", async () => {
+    const fetchImpl: IngressFetch = async (_url, init) => {
+      const accepted = init.headers?.Origin === ADMIN;
+      return {
+        ok: accepted,
+        status: accepted ? 201 : 403,
+        text: async () =>
+          accepted ? "" : '{"error":"client is not allowed to access from origin \'\'"}',
+      };
+    };
+
+    await expect(
+      addAppRoute({
+        hostname: HOST,
+        hostPort: 28123,
+        adminBase: `${ADMIN}/`,
+        fetchImpl,
+      }),
+    ).resolves.toBeUndefined();
   });
 
   test("throws when Caddy rejects the POST (so the deploy fails fast, not a silent 502)", async () => {
@@ -53,7 +89,7 @@ describe("addAppRoute", () => {
     }));
     await expect(
       addAppRoute({ hostname: HOST, nodeHost: "n", hostPort: 1, adminBase: ADMIN, fetchImpl }),
-    ).rejects.toThrow(/add-route failed \(500\)/);
+    ).rejects.toThrow("add-route failed (500) for abc12345.apps.elizacloud.ai via 127.0.0.1:2019");
   });
 
   test("logs stale-route delete failure but still POSTs the replacement route", async () => {
@@ -82,7 +118,12 @@ describe("removeAppRoute", () => {
     const { calls, fetchImpl } = recordingFetch(() => ({ ok: true, status: 200 }));
     await removeAppRoute({ hostname: HOST, adminBase: ADMIN, fetchImpl });
     expect(calls).toEqual([
-      { url: "http://127.0.0.1:2019/id/app-abc12345", method: "DELETE", body: undefined },
+      {
+        url: "http://127.0.0.1:2019/id/app-abc12345",
+        method: "DELETE",
+        headers: { Origin: ADMIN },
+        body: undefined,
+      },
     ]);
   });
 
@@ -96,7 +137,7 @@ describe("removeAppRoute", () => {
   test("throws on a non-404 failure", async () => {
     const { fetchImpl } = recordingFetch(() => ({ ok: false, status: 500 }));
     await expect(removeAppRoute({ hostname: HOST, adminBase: ADMIN, fetchImpl })).rejects.toThrow(
-      /remove-route failed \(500\)/,
+      "remove-route failed (500) for abc12345.apps.elizacloud.ai via 127.0.0.1:2019",
     );
   });
 });

--- a/packages/cloud/shared/src/lib/services/apps-ingress-provisioner.ts
+++ b/packages/cloud/shared/src/lib/services/apps-ingress-provisioner.ts
@@ -42,11 +42,18 @@ function resolveFetch(f?: IngressFetch): IngressFetch {
 }
 
 async function safeText(res: IngressResponse): Promise<string> {
-  try {
-    return (await res.text()).slice(0, 200);
-  } catch {
-    return "";
-  }
+  return (await res.text()).slice(0, 200);
+}
+
+function caddyAdminRequest(adminBase: string): {
+  adminHost: string;
+  headers: Record<string, string>;
+} {
+  const adminUrl = new URL(adminBase);
+  return {
+    adminHost: adminUrl.host,
+    headers: { Origin: adminUrl.origin },
+  };
 }
 
 export interface AddRouteOpts extends AppRouteInput {
@@ -69,29 +76,35 @@ export async function addAppRoute(opts: AddRouteOpts): Promise<void> {
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const route = buildCaddyRoute(opts);
   const routeId = route["@id"];
+  const adminRequest = caddyAdminRequest(opts.adminBase);
 
   // best-effort delete of a stale same-id route (idempotent re-deploy)
   await fetchImpl(buildCaddyRouteByIdUrl(opts.adminBase, routeId), {
     method: "DELETE",
+    headers: adminRequest.headers,
     signal: AbortSignal.timeout(timeoutMs),
   }).catch((error) => {
     // error-policy:J4 stale-route cleanup failure must not block the replacement route.
     logger.warn("[apps-ingress] stale route delete failed before add-route", {
       routeId,
       hostname: opts.hostname,
+      adminHost: adminRequest.adminHost,
       error: error instanceof Error ? error.message : String(error),
     });
   });
 
   const res = await fetchImpl(buildCaddyAddRouteUrl(opts.adminBase, opts.server), {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      ...adminRequest.headers,
+      "Content-Type": "application/json",
+    },
     body: JSON.stringify(route),
     signal: AbortSignal.timeout(timeoutMs),
   });
   if (!res.ok) {
     throw new Error(
-      `[apps-ingress] add-route failed (${res.status}) for ${opts.hostname}: ${await safeText(res)}`,
+      `[apps-ingress] add-route failed (${res.status}) for ${opts.hostname} via ${adminRequest.adminHost}: ${await safeText(res)}`,
     );
   }
 }
@@ -108,12 +121,16 @@ export async function removeAppRoute(opts: RemoveRouteOpts): Promise<void> {
   const fetchImpl = resolveFetch(opts.fetchImpl);
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const routeId = buildCaddyRouteId(opts.hostname);
+  const adminRequest = caddyAdminRequest(opts.adminBase);
   const res = await fetchImpl(buildCaddyRouteByIdUrl(opts.adminBase, routeId), {
     method: "DELETE",
+    headers: adminRequest.headers,
     signal: AbortSignal.timeout(timeoutMs),
   });
   // 200 = removed, 404 = already absent; both are success for teardown.
   if (!res.ok && res.status !== 404) {
-    throw new Error(`[apps-ingress] remove-route failed (${res.status}) for ${opts.hostname}`);
+    throw new Error(
+      `[apps-ingress] remove-route failed (${res.status}) for ${opts.hostname} via ${adminRequest.adminHost}`,
+    );
   }
 }

--- a/packages/cloud/shared/src/lib/services/apps-ingress-provisioner.ts
+++ b/packages/cloud/shared/src/lib/services/apps-ingress-provisioner.ts
@@ -1,21 +1,19 @@
 /**
- * Apps ingress provisioner (Apps / Product 2) — the thin IO layer that applies
- * the pure ingress routes ({@link ./apps-ingress-routes}) to a LIVE Caddy via its
- * admin API. Add a per-app reverse-proxy route after the container is running;
- * remove it (by `@id`) on teardown.
+ * Applies per-app reverse-proxy routes to a live Caddy admin API after a
+ * container starts and removes them during teardown.
  *
  * Mutations go through Caddy's admin API (atomic per route) rather than a
  * Caddyfile reload, so adding/removing one app never blips the others. Each call
- * is best-effort with a short timeout; callers decide failure handling — fail
- * fast on add (so the user retries rather than getting a silent 502), log + carry
- * on for remove (a reconciler sweeps orphaned routes).
+ * has a short timeout and fails fast unless a DELETE confirms the route is
+ * already absent. This prevents a failed replacement from leaving duplicate
+ * route identifiers or an unreachable deployment that appears healthy.
  *
  * `fetchImpl` is injectable so the client is unit-testable without a live Caddy;
  * the real wire format is proven against stock Caddy in
  * `scripts/verify-apps-ingress-routing.sh`.
  */
 
-import { logger } from "../utils/logger";
+import { ElizaError } from "@elizaos/core";
 import {
   type AppRouteInput,
   buildCaddyAddRouteUrl,
@@ -41,10 +39,6 @@ function resolveFetch(f?: IngressFetch): IngressFetch {
   return globalThis.fetch as IngressFetch;
 }
 
-async function safeText(res: IngressResponse): Promise<string> {
-  return (await res.text()).slice(0, 200);
-}
-
 function caddyAdminRequest(adminBase: string): {
   adminHost: string;
   headers: Record<string, string>;
@@ -54,6 +48,45 @@ function caddyAdminRequest(adminBase: string): {
     adminHost: adminUrl.host,
     headers: { Origin: adminUrl.origin },
   };
+}
+
+function mutationError(input: {
+  operation: "add-route" | "remove-route" | "replace-route-delete";
+  status?: number;
+  hostname: string;
+  adminHost: string;
+  detail?: string;
+  cause?: unknown;
+}): ElizaError {
+  const status = input.status === undefined ? "request" : String(input.status);
+  const detail = input.detail ? `: ${input.detail}` : "";
+  return new ElizaError(
+    `[apps-ingress] ${input.operation} failed (${status}) for ${input.hostname} via ${input.adminHost}${detail}`,
+    {
+      code: "CADDY_ADMIN_MUTATION_FAILED",
+      context: {
+        operation: input.operation,
+        status: input.status,
+        hostname: input.hostname,
+        adminHost: input.adminHost,
+      },
+      cause: input.cause,
+      severity: "ephemeral",
+    },
+  );
+}
+
+async function responseDetail(res: IngressResponse): Promise<string> {
+  try {
+    return (await res.text()).slice(0, 200);
+  } catch (cause) {
+    // error-policy:J2 Preserve the body-read failure at the Caddy boundary.
+    throw new ElizaError("[apps-ingress] failed to read Caddy admin error response", {
+      code: "CADDY_ADMIN_RESPONSE_READ_FAILED",
+      cause,
+      severity: "ephemeral",
+    });
+  }
 }
 
 export interface AddRouteOpts extends AppRouteInput {
@@ -78,34 +111,60 @@ export async function addAppRoute(opts: AddRouteOpts): Promise<void> {
   const routeId = route["@id"];
   const adminRequest = caddyAdminRequest(opts.adminBase);
 
-  // best-effort delete of a stale same-id route (idempotent re-deploy)
-  await fetchImpl(buildCaddyRouteByIdUrl(opts.adminBase, routeId), {
-    method: "DELETE",
-    headers: adminRequest.headers,
-    signal: AbortSignal.timeout(timeoutMs),
-  }).catch((error) => {
-    // error-policy:J4 stale-route cleanup failure must not block the replacement route.
-    logger.warn("[apps-ingress] stale route delete failed before add-route", {
-      routeId,
+  let deleteRes: IngressResponse;
+  try {
+    deleteRes = await fetchImpl(buildCaddyRouteByIdUrl(opts.adminBase, routeId), {
+      method: "DELETE",
+      headers: adminRequest.headers,
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (cause) {
+    // error-policy:J2 Classify transport failures at the Caddy mutation boundary.
+    throw mutationError({
+      operation: "replace-route-delete",
       hostname: opts.hostname,
       adminHost: adminRequest.adminHost,
-      error: error instanceof Error ? error.message : String(error),
+      cause,
     });
-  });
+  }
+  if (!deleteRes.ok && deleteRes.status !== 404) {
+    throw mutationError({
+      operation: "replace-route-delete",
+      status: deleteRes.status,
+      hostname: opts.hostname,
+      adminHost: adminRequest.adminHost,
+      detail: await responseDetail(deleteRes),
+    });
+  }
 
-  const res = await fetchImpl(buildCaddyAddRouteUrl(opts.adminBase, opts.server), {
-    method: "POST",
-    headers: {
-      ...adminRequest.headers,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(route),
-    signal: AbortSignal.timeout(timeoutMs),
-  });
+  let res: IngressResponse;
+  try {
+    res = await fetchImpl(buildCaddyAddRouteUrl(opts.adminBase, opts.server), {
+      method: "POST",
+      headers: {
+        ...adminRequest.headers,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(route),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (cause) {
+    // error-policy:J2 Classify transport failures at the Caddy mutation boundary.
+    throw mutationError({
+      operation: "add-route",
+      hostname: opts.hostname,
+      adminHost: adminRequest.adminHost,
+      cause,
+    });
+  }
   if (!res.ok) {
-    throw new Error(
-      `[apps-ingress] add-route failed (${res.status}) for ${opts.hostname} via ${adminRequest.adminHost}: ${await safeText(res)}`,
-    );
+    throw mutationError({
+      operation: "add-route",
+      status: res.status,
+      hostname: opts.hostname,
+      adminHost: adminRequest.adminHost,
+      detail: await responseDetail(res),
+    });
   }
 }
 
@@ -116,21 +175,35 @@ export interface RemoveRouteOpts {
   timeoutMs?: number;
 }
 
-/** Remove a per-app route by `@id` (best-effort; a 404 means it's already gone). */
+/** Remove a per-app route by `@id`; a 404 confirms it is already gone. */
 export async function removeAppRoute(opts: RemoveRouteOpts): Promise<void> {
   const fetchImpl = resolveFetch(opts.fetchImpl);
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const routeId = buildCaddyRouteId(opts.hostname);
   const adminRequest = caddyAdminRequest(opts.adminBase);
-  const res = await fetchImpl(buildCaddyRouteByIdUrl(opts.adminBase, routeId), {
-    method: "DELETE",
-    headers: adminRequest.headers,
-    signal: AbortSignal.timeout(timeoutMs),
-  });
+  let res: IngressResponse;
+  try {
+    res = await fetchImpl(buildCaddyRouteByIdUrl(opts.adminBase, routeId), {
+      method: "DELETE",
+      headers: adminRequest.headers,
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (cause) {
+    // error-policy:J2 Classify transport failures at the Caddy mutation boundary.
+    throw mutationError({
+      operation: "remove-route",
+      hostname: opts.hostname,
+      adminHost: adminRequest.adminHost,
+      cause,
+    });
+  }
   // 200 = removed, 404 = already absent; both are success for teardown.
   if (!res.ok && res.status !== 404) {
-    throw new Error(
-      `[apps-ingress] remove-route failed (${res.status}) for ${opts.hostname} via ${adminRequest.adminHost}`,
-    );
+    throw mutationError({
+      operation: "remove-route",
+      status: res.status,
+      hostname: opts.hostname,
+      adminHost: adminRequest.adminHost,
+    });
   }
 }


### PR DESCRIPTION
# Relates to

Part of #15739. This fixes the rejected Caddy admin mutation path; the issue should remain open until a staging app is reprovisioned and its public route is verified.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated root-verification blocker is recorded below.
- [x] A reviewer can confirm the change from the real stock-Caddy transcript and package results below.

# Sync with develop

- [x] `origin/develop...HEAD` was `0 1` at `cbb60cabb06`; zero conflicts.
- [x] The root typecheck/lint phase completed all 570 tasks successfully. The later test-realness audit was blocked only by an unrelated pre-existing dirty vendor submodule, documented below.

# Risks

Low. The change adds the admin endpoint's own URL origin to Caddy mutation requests. A malformed admin base now fails before a network request. Credentials and full URLs are not added to diagnostics.

# Background

## What does this PR do?

- Sends `Origin` on stale-route DELETE, route POST, and route removal so Caddy accepts mutations when `enforce_origin` is enabled.
- Normalizes the admin base once, including trailing-slash inputs, and includes only the sanitized admin host in failures.
- Exercises the production ingress provisioner against stock `caddy:2` configured with admin-origin enforcement.
- Lets response-body read failures propagate rather than fabricating an empty diagnostic.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

N/A - request behavior is internal and is covered by the executable verification script and tests.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/services/apps-ingress-provisioner.ts` and `packages/cloud/shared/scripts/verify-apps-ingress-routing.sh`.

## Detailed testing steps

1. Run `bun test packages/cloud/shared/src/lib/services/__tests__/apps-ingress-provisioner.test.ts` (7 pass, 0 fail; changed source 98.39% line coverage).
2. Run `bash packages/cloud/shared/scripts/verify-apps-ingress-routing.sh` with Docker (3 pass, 0 fail).
3. Run `bun run --cwd packages/cloud/shared test` (4,294 pass, 61 credential-gated live skips, 0 fail across 532 files).
4. Run `bun run --cwd packages/cloud/shared typecheck`, focused Biome, ShellCheck, `git diff --check`, and `bun run audit:error-policy-ratchet` (all pass).

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - backend-only Caddy admin HTTP behavior; no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - backend-only Caddy admin HTTP behavior; no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - the complete affected flow is a headless Caddy admin mutation and is captured in the real-service transcript below.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: [real stock-Caddy add, route, isolation, and removal transcript](#backend--frontend-logs).
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend request or state path changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, planner, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [real Caddy route lifecycle and HTTP responses](#backend--frontend-logs).

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM-facing behavior changed.

## Backend + frontend logs

Manually reviewed output from the production provisioner against stock `caddy:2`, with `admin.origins=["http://localhost:<port>"]` and `enforce_origin=true`:

<details>
<summary>Real Caddy route lifecycle</summary>

```text
=== stock Caddy: admin API + empty srv0 on :80 ===
=== sample app (http-echo) co-located in Caddy's netns (mirrors loopback-only publish) ===
=== add the route through the REAL origin-aware ingress provisioner ===
route posted
=== request with the app's Host header -> reaches the app ===
PASS: known host routed to the app
=== unknown Host header -> never reaches the app (tenant isolation) ===
PASS: unknown host is NOT routed to the app
=== DELETE the route by @id -> host no longer routes ===
route deleted
PASS: route removal stops routing

3 passed, 0 failed
```

</details>

Frontend logs: N/A - no frontend code path changed.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

- Root `bun run verify`: all 570 Turbo typecheck/lint tasks passed in 3m41s, then `audit:test-realness` found one `test.todo` inside the unrelated, pre-existing dirty submodule `plugins/plugin-agent-orchestrator/vendor/opencode`. The changed test-file diff reported `regressions=0`. The cloud-shared package test, typecheck, lint, Docker proof, and policy ratchet all pass.
- Live staging evidence still requires the staging deployment/runtime lever: reprovision an affected app, capture the structured control-plane route-add log, and verify its public URL. This PR does not claim that operational check has occurred.

# Deploy Notes

After deployment, retry one affected staging app provision and attach the resulting control-plane log and reachable public URL to #15739 before closing the issue.
