### PR TITLE
fix(mvp): audit every active project card

### DIFF
--- a/packages/scripts/__tests__/audit-mvp-project-board.test.ts
+++ b/packages/scripts/__tests__/audit-mvp-project-board.test.ts
@@ -114,7 +114,7 @@ describe("audit-mvp-project-board", () => {
 
     expect(summary.counts).toEqual({
       projectIssues: 4,
-      mvpIssues: 4,
+      labeledMvpIssues: 4,
       closedNotDone: 1,
       openNotDone: 2,
       humanGated: 1,
@@ -136,10 +136,35 @@ describe("audit-mvp-project-board", () => {
       }),
     );
 
-    expect(text).toContain("Closed MVP issues not marked Done");
-    expect(text).toContain("Open MVP issues not Done and not human-gated");
+    expect(text).toContain("Closed Project 15 issues not marked Done");
+    expect(text).toContain(
+      "Open Project 15 issues not Done and not human-gated",
+    );
     expect(text).toContain("#3 In progress — Agent tractable");
     expect(text).toContain("open-but-Done: 1");
+  });
+
+  test("includes an unlabeled Ready project issue in the actionable set", () => {
+    const unlabeledReady = {
+      content: {
+        type: "Issue",
+        number: 6,
+        title: "Unlabeled ready work",
+        url: "https://github.com/elizaOS/eliza/issues/6",
+      },
+      title: "Unlabeled ready work",
+      status: "Ready",
+      labels: ["testing"],
+    };
+    const summary = board.summarizeMvpBoard({
+      projectItems: [...projectItems, unlabeledReady],
+      openIssues: [{ number: 2 }, { number: 3 }, { number: 4 }, { number: 6 }],
+      closedIssues: [{ number: 1 }],
+    });
+
+    expect(summary.agentActionable.map((issue) => issue.number)).toContain(6);
+    expect(summary.counts.projectIssues).toBe(5);
+    expect(summary.counts.labeledMvpIssues).toBe(4);
   });
 
   test("strictViolations returns the stale buckets that should fail closeout", () => {

--- a/packages/scripts/__tests__/mvp-board-readiness.test.ts
+++ b/packages/scripts/__tests__/mvp-board-readiness.test.ts
@@ -57,18 +57,23 @@ describe("MVP board readiness audit", () => {
     expect(report.violations).toEqual([]);
   });
 
-  test("flags open MVP issues without a blocker label", () => {
+  test("fails and classifies Ready issues without blocker labels as actionable", () => {
     const report = board.auditMvpBoardReadiness([issue(14749, ["mvp"])], {
       items: [projectItem(14749, "Ready")],
     });
 
     expect(report.ok).toBe(false);
+    expect(report.agentActionableCount).toBe(1);
     expect(report.violations).toContainEqual(
-      expect.objectContaining({
-        type: "missing-blocker-label",
-        number: 14749,
-      }),
+      expect.objectContaining({ type: "agent-actionable", number: 14749 }),
     );
+    expect(report.rows).toEqual([
+      expect.objectContaining({
+        number: 14749,
+        projectStatus: "Ready",
+        blockerLabels: [],
+      }),
+    ]);
   });
 
   test("flags blocker-labeled issues outside Needs human review", () => {
@@ -87,19 +92,15 @@ describe("MVP board readiness audit", () => {
     );
   });
 
-  test("flags open MVP issues missing from the project", () => {
+  test("ignores repository issues outside the project", () => {
     const report = board.auditMvpBoardReadiness(
       [issue(14351, ["mvp", "needs-shaw"])],
       { items: [] },
     );
 
-    expect(report.ok).toBe(false);
-    expect(report.violations).toContainEqual(
-      expect.objectContaining({
-        type: "missing-project-item",
-        number: 14351,
-      }),
-    );
+    expect(report.ok).toBe(true);
+    expect(report.issueCount).toBe(0);
+    expect(report.rows).toEqual([]);
   });
 
   test("issues-only mode skips project violations but keeps blocker violations", () => {
@@ -158,7 +159,7 @@ describe("MVP board readiness audit", () => {
     ]);
   });
 
-  test("does not match project items from a different repository by number", () => {
+  test("does not scope project items from a different repository by number", () => {
     const report = board.auditMvpBoardReadiness(
       [issue(14747, ["mvp", "needs-shaw"])],
       {
@@ -166,11 +167,20 @@ describe("MVP board readiness audit", () => {
       },
     );
 
+    expect(report.ok).toBe(true);
+    expect(report.issueCount).toBe(0);
+  });
+
+  test("flags human-review status without a blocker label", () => {
+    const report = board.auditMvpBoardReadiness([issue(15748, ["testing"])], {
+      items: [projectItem(15748, "Needs human review")],
+    });
+
     expect(report.ok).toBe(false);
     expect(report.violations).toContainEqual(
       expect.objectContaining({
-        type: "missing-project-item",
-        number: 14747,
+        type: "human-status-missing-blocker",
+        number: 15748,
       }),
     );
   });

--- a/packages/scripts/__tests__/mvp-evidence-matrix.test.ts
+++ b/packages/scripts/__tests__/mvp-evidence-matrix.test.ts
@@ -13,6 +13,9 @@ import { join } from "node:path";
 const matrix = await import(
   new URL("../audit-mvp-evidence-matrix.mjs", import.meta.url).href
 );
+const readiness = await import(
+  new URL("../check-mvp-board-readiness.mjs", import.meta.url).href
+);
 const scriptPath = new URL("../audit-mvp-evidence-matrix.mjs", import.meta.url)
   .pathname;
 
@@ -63,7 +66,7 @@ describe("MVP evidence matrix", () => {
     );
 
     expect(report.counts).toEqual({
-      openMvpIssues: 1,
+      activeProjectIssues: 1,
       humanGated: 1,
       agentActionable: 0,
     });
@@ -156,7 +159,7 @@ describe("MVP evidence matrix", () => {
       },
     );
 
-    expect(report.rows[0].projectStatus).toBeNull();
+    expect(report.rows).toEqual([]);
   });
 
   test("renders a GitHub-ready markdown checklist for issue evidence", () => {
@@ -174,7 +177,7 @@ describe("MVP evidence matrix", () => {
     const markdown = matrix.formatMarkdown(report);
 
     expect(markdown).toContain("# LifeOps MVP Evidence Checklist");
-    expect(markdown).toContain("| Open MVP issues | 1 |");
+    expect(markdown).toContain("| Active Project 15 issues | 1 |");
     expect(markdown).toContain(
       "### #14358 [onboarding] Device e2e for iOS sim + Android emu",
     );
@@ -196,6 +199,44 @@ describe("MVP evidence matrix", () => {
     );
     expect(markdown).toContain(
       "    - Attach the generated DB rows, memories, scheduled tasks, files, or connector artifacts inline in the issue.",
+    );
+  });
+
+  test("includes an unlabeled Ready project issue", () => {
+    const report = matrix.buildEvidenceMatrix(
+      [issue(15748, "Readiness audit completeness", ["testing"])],
+      { items: [projectItem(15748, "Ready")] },
+    );
+
+    expect(report.counts.activeProjectIssues).toBe(1);
+    expect(
+      report.agentActionable.map((row: { number: number }) => row.number),
+    ).toEqual([15748]);
+  });
+
+  test("uses the same active issue set as board readiness", () => {
+    const issues = [
+      issue(15748, "Unlabeled ready work", ["testing"]),
+      issue(14754, "Human device proof", ["needs-human"]),
+      issue(15000, "Already done", ["mvp"]),
+    ];
+    const project = {
+      items: [
+        projectItem(15748, "Ready"),
+        projectItem(14754, "Needs human review"),
+        projectItem(15000, "Done"),
+      ],
+    };
+
+    const matrixReport = matrix.buildEvidenceMatrix(issues, project);
+    const readinessReport = readiness.auditMvpBoardReadiness(issues, project);
+
+    expect(
+      matrixReport.rows.map((row: { number: number }) => row.number),
+    ).toEqual(
+      readinessReport.rows
+        .map((row: { number: number }) => row.number)
+        .sort((a, b) => a - b),
     );
   });
 

--- a/packages/scripts/audit-mvp-evidence-matrix.mjs
+++ b/packages/scripts/audit-mvp-evidence-matrix.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
- * Evidence expectation matrix for open LifeOps MVP issues. The board can show
- * that a row is human-gated, but closeout still needs a concrete proof contract
+ * Evidence expectation matrix for active LifeOps MVP project issues. The board
+ * can show that a row is human-gated, but closeout still needs a concrete proof contract
  * per issue so screenshots, videos, logs, trajectories, and domain artifacts do
  * not collapse into a vague "needs review" bucket.
  */
@@ -317,18 +317,21 @@ export function normalizeRestIssue(issue) {
   };
 }
 
-function fetchOpenMvpIssuesRest(repo, limit) {
-  const pages = ghJson([
-    "api",
-    "--paginate",
-    "--slurp",
-    `repos/${repo}/issues?state=open&labels=mvp&per_page=100`,
+function fetchOpenProjectIssues(repo, projectOwner, projectNumber, limit) {
+  return ghJson([
+    "issue",
+    "list",
+    "--repo",
+    repo,
+    "--state",
+    "open",
+    "--search",
+    `project:${projectOwner}/${projectNumber}`,
+    "--limit",
+    limit,
+    "--json",
+    "number,title,body,url,labels",
   ]);
-  return pages
-    .flat()
-    .filter((issue) => !issue.pull_request)
-    .slice(0, Number(limit))
-    .map(normalizeRestIssue);
 }
 
 function labelNames(issue) {
@@ -419,6 +422,12 @@ export function buildEvidenceMatrix(issues, projectPayload = {}, options = {}) {
   );
   const projectStatusSource = options.projectStatusSource ?? "project";
   const rows = issues
+    .filter(
+      (issue) =>
+        projectStatusSource === "omitted" ||
+        (statusByNumber.has(issue.number) &&
+          statusByNumber.get(issue.number) !== "Done"),
+    )
     .map((issue) => ({
       ...issue,
       projectStatus: statusByNumber.get(issue.number) ?? null,
@@ -430,7 +439,7 @@ export function buildEvidenceMatrix(issues, projectPayload = {}, options = {}) {
   return {
     projectStatusSource,
     counts: {
-      openMvpIssues: rows.length,
+      activeProjectIssues: rows.length,
       humanGated: humanGated.length,
       agentActionable: agentActionable.length,
     },
@@ -443,7 +452,7 @@ export function buildEvidenceMatrix(issues, projectPayload = {}, options = {}) {
 function formatText(report) {
   const lines = [
     "LifeOps MVP evidence matrix",
-    `open MVP issues: ${report.counts.openMvpIssues}`,
+    `active Project 15 issues: ${report.counts.activeProjectIssues}`,
     `human-gated: ${report.counts.humanGated}; agent-actionable: ${report.counts.agentActionable}`,
     `project-status source: ${report.projectStatusSource}`,
     "",
@@ -496,7 +505,7 @@ export function formatMarkdown(report) {
     "",
     "| Metric | Count |",
     "| --- | ---: |",
-    `| Open MVP issues | ${report.counts.openMvpIssues} |`,
+    `| Active Project 15 issues | ${report.counts.activeProjectIssues} |`,
     `| Human/owner-gated | ${report.counts.humanGated} |`,
     `| Agent-actionable | ${report.counts.agentActionable} |`,
     `| Project status source | ${report.projectStatusSource} |`,
@@ -567,7 +576,12 @@ async function main() {
 
   const issues = args.issuesJson
     ? readJson(args.issuesJson)
-    : fetchOpenMvpIssuesRest(args.repo, args.limit);
+    : fetchOpenProjectIssues(
+        args.repo,
+        args.projectOwner,
+        args.projectNumber,
+        args.limit,
+      );
   const projectPayload = args.projectJson
     ? readJson(args.projectJson)
     : args.noProject

--- a/packages/scripts/audit-mvp-project-board.mjs
+++ b/packages/scripts/audit-mvp-project-board.mjs
@@ -2,7 +2,7 @@
 /**
  * Read-only audit for the LifeOps MVP project board. The GitHub Project is the
  * live kanban, but closeout work needs a compact stale-state report instead of
- * a raw 195-item dump: closed issues that are not Done, open MVP issues still
+ * a raw project dump: closed issues that are not Done, open issues still
  * active, and the subset that is explicitly human-gated.
  */
 
@@ -153,12 +153,14 @@ export function summarizeMvpBoard({ projectItems, openIssues, closedIssues }) {
   const openByNumber = byNumber(openIssues);
   const closedNumbers = new Set(closedIssues.map((issue) => issue.number));
   const issues = projectItems.map(normalizeProjectIssue).filter(Boolean);
-  const mvpIssues = issues.filter((issue) => issue.labels.includes("mvp"));
+  const labeledMvpIssues = issues.filter((issue) =>
+    issue.labels.includes("mvp"),
+  );
 
-  const closedNotDone = mvpIssues.filter(
+  const closedNotDone = issues.filter(
     (issue) => closedNumbers.has(issue.number) && issue.status !== DONE_STATUS,
   );
-  const openOnBoard = mvpIssues.filter(
+  const openOnBoard = issues.filter(
     (issue) => openByNumber.has(issue.number) && issue.status !== DONE_STATUS,
   );
   const humanGated = openOnBoard.filter((issue) =>
@@ -172,14 +174,14 @@ export function summarizeMvpBoard({ projectItems, openIssues, closedIssues }) {
         (label) => label === "needs-human" || label === "needs-shaw",
       ),
   );
-  const openDone = mvpIssues.filter(
+  const openDone = issues.filter(
     (issue) => openByNumber.has(issue.number) && issue.status === DONE_STATUS,
   );
 
   return {
     counts: {
       projectIssues: issues.length,
-      mvpIssues: mvpIssues.length,
+      labeledMvpIssues: labeledMvpIssues.length,
       closedNotDone: closedNotDone.length,
       openNotDone: openOnBoard.length,
       humanGated: humanGated.length,
@@ -234,7 +236,7 @@ export function strictViolations(summary) {
     violations.push({
       type: "closed-not-done",
       count: summary.closedNotDone.length,
-      message: `${summary.closedNotDone.length} closed MVP issue(s) are not marked Done`,
+      message: `${summary.closedNotDone.length} closed Project 15 issue(s) are not marked Done`,
     });
   }
   if (summary.agentActionable.length > 0) {
@@ -243,14 +245,14 @@ export function strictViolations(summary) {
       count: summary.agentActionable.length,
       message: summary.projectCheckSkipped
         ? `${summary.agentActionable.length} open MVP issue(s) are not human-gated`
-        : `${summary.agentActionable.length} open MVP issue(s) are neither Done nor human-gated`,
+        : `${summary.agentActionable.length} open Project 15 issue(s) are neither Done nor human-gated`,
     });
   }
   if (summary.openDone?.length > 0) {
     violations.push({
       type: "open-done",
       count: summary.openDone.length,
-      message: `${summary.openDone.length} open MVP issue(s) are already marked Done`,
+      message: `${summary.openDone.length} open Project 15 issue(s) are already marked Done`,
     });
   }
   return violations;
@@ -273,7 +275,7 @@ export function formatSummary(summary) {
 
   const lines = [
     "LifeOps MVP project-board audit",
-    `project issues: ${summary.counts.projectIssues}; mvp issues: ${summary.counts.mvpIssues}`,
+    `project issues: ${summary.counts.projectIssues}; carrying mvp label: ${summary.counts.labeledMvpIssues}`,
     `closed-not-Done: ${summary.counts.closedNotDone}`,
     `open-not-Done: ${summary.counts.openNotDone} (${summary.counts.humanGated} human-gated, ${summary.counts.agentActionable} agent-actionable)`,
     `open-but-Done: ${summary.counts.openDone}`,
@@ -288,13 +290,16 @@ export function formatSummary(summary) {
     for (const row of rows) lines.push(`  ${formatIssue(row)}`);
   };
 
-  section("Closed MVP issues not marked Done", summary.closedNotDone);
+  section("Closed Project 15 issues not marked Done", summary.closedNotDone);
   section(
-    "Open MVP issues not Done and not human-gated",
+    "Open Project 15 issues not Done and not human-gated",
     summary.agentActionable,
   );
-  section("Open MVP issues not Done and human-gated", summary.humanGated);
-  section("Open MVP issues already marked Done", summary.openDone);
+  section(
+    "Open Project 15 issues not Done and human-gated",
+    summary.humanGated,
+  );
+  section("Open Project 15 issues already marked Done", summary.openDone);
   return lines.join("\n");
 }
 
@@ -400,8 +405,8 @@ async function main() {
         args.repo,
         "--state",
         "open",
-        "--label",
-        "mvp",
+        "--search",
+        `project:${args.owner}/${args.project}`,
         "--limit",
         args.limit,
         "--json",
@@ -416,8 +421,8 @@ async function main() {
         args.repo,
         "--state",
         "closed",
-        "--label",
-        "mvp",
+        "--search",
+        `project:${args.owner}/${args.project}`,
         "--limit",
         args.limit,
         "--json",

--- a/packages/scripts/check-mvp-board-readiness.mjs
+++ b/packages/scripts/check-mvp-board-readiness.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Board-readiness audit for the LifeOps MVP project. Open MVP issues are only
+ * Board-readiness audit for the LifeOps MVP project. Open project issues are
  * actionable for agents when they are either actively being implemented or
  * clearly blocked on owner/hardware/live-evidence work; this script keeps the
  * blocker labels and Project 15 status aligned so evidence gaps do not look
@@ -115,17 +115,21 @@ export function normalizeRestIssue(issue) {
   };
 }
 
-function fetchOpenMvpIssues(repo) {
+function fetchOpenProjectIssues(repo, projectOwner, projectNumber) {
   return ghJson([
-    "api",
-    "--paginate",
-    "--slurp",
-    `repos/${repo}/issues?state=open&labels=mvp&per_page=100`,
-  ])
-    .flat()
-    .filter((issue) => !issue.pull_request)
-    .slice(0, 300)
-    .map(normalizeRestIssue);
+    "issue",
+    "list",
+    "--repo",
+    repo,
+    "--state",
+    "open",
+    "--search",
+    `project:${projectOwner}/${projectNumber}`,
+    "--limit",
+    "500",
+    "--json",
+    "number,title,url,labels",
+  ]).map(normalizeRestIssue);
 }
 
 function fetchProjectItems(projectOwner, projectNumber) {
@@ -192,16 +196,23 @@ export function auditMvpBoardReadiness(issues, projectPayload, options = {}) {
   const violations = [];
   const rows = [];
 
-  if (issues.length < minIssues) {
+  const scopedIssues = projectCheckSkipped
+    ? issues
+    : issues.filter((issue) => {
+        const item = projectItems.get(issue.number);
+        return item && item.status !== "Done";
+      });
+
+  if (scopedIssues.length < minIssues) {
     violations.push({
       type: "too-few-issues",
       minimum: minIssues,
-      actual: issues.length,
-      message: `Loaded ${issues.length} open MVP issue(s), below required minimum ${minIssues}`,
+      actual: scopedIssues.length,
+      message: `Loaded ${scopedIssues.length} active Project 15 issue(s), below required minimum ${minIssues}`,
     });
   }
 
-  for (const issue of issues) {
+  for (const issue of scopedIssues) {
     const labels = labelNames(issue);
     const blockerLabels = labels.filter((label) => BLOCKER_LABELS.has(label));
     const projectItem = projectItems.get(issue.number);
@@ -217,7 +228,7 @@ export function auditMvpBoardReadiness(issues, projectPayload, options = {}) {
     };
     rows.push(row);
 
-    if (blockerLabels.length === 0) {
+    if (projectCheckSkipped && blockerLabels.length === 0) {
       violations.push({
         type: "missing-blocker-label",
         number: issue.number,
@@ -230,14 +241,14 @@ export function auditMvpBoardReadiness(issues, projectPayload, options = {}) {
       continue;
     }
 
-    if (!projectItem) {
+    if (blockerLabels.length === 0) {
       violations.push({
-        type: "missing-project-item",
+        type: "agent-actionable",
         number: issue.number,
         title: issue.title,
-        message: `#${issue.number} is open+mvp but is not present on Project 15`,
+        projectStatus: status,
+        message: `#${issue.number} is active in Project 15 without a human blocker`,
       });
-      continue;
     }
 
     if (blockerLabels.length > 0 && status !== REQUIRED_BLOCKED_STATUS) {
@@ -251,12 +262,23 @@ export function auditMvpBoardReadiness(issues, projectPayload, options = {}) {
         )} but Project 15 status is ${status ?? "unset"}`,
       });
     }
+    if (status === REQUIRED_BLOCKED_STATUS && blockerLabels.length === 0) {
+      violations.push({
+        type: "human-status-missing-blocker",
+        number: issue.number,
+        title: issue.title,
+        projectStatus: status,
+        message: `#${issue.number} is in ${REQUIRED_BLOCKED_STATUS} but has neither needs-human nor needs-shaw`,
+      });
+    }
   }
 
   return {
     ok: violations.length === 0,
-    issueCount: issues.length,
+    issueCount: scopedIssues.length,
     blockerCount: rows.filter((row) => row.blockerLabels.length > 0).length,
+    agentActionableCount: rows.filter((row) => row.blockerLabels.length === 0)
+      .length,
     projectCheckSkipped,
     minIssues,
     requiredBlockedStatus: REQUIRED_BLOCKED_STATUS,
@@ -268,8 +290,9 @@ export function auditMvpBoardReadiness(issues, projectPayload, options = {}) {
 function formatText(report) {
   const lines = [
     `MVP board readiness: ${report.ok ? "PASS" : "FAIL"}`,
-    `Open MVP issues: ${report.issueCount}`,
+    `Active Project 15 issues: ${report.issueCount}`,
     `Blocked issues: ${report.blockerCount}`,
+    `Agent-actionable issues: ${report.agentActionableCount}`,
     `Project status check: ${report.projectCheckSkipped ? "SKIPPED" : "checked"}`,
   ];
   if (report.minIssues > 0) {
@@ -304,7 +327,7 @@ async function main() {
 
   const issues = args.issuesJson
     ? readJson(args.issuesJson)
-    : fetchOpenMvpIssues(args.repo);
+    : fetchOpenProjectIssues(args.repo, args.projectOwner, args.projectNumber);
   const minIssues = parseNonNegativeInteger(args.minIssues, "--min-issues");
   const projectPayload = args.projectJson
     ? readJson(args.projectJson)


### PR DESCRIPTION
Closes #15748. Parent #13631.

## Summary

- make Project 15 membership, not the optional `mvp` label, authoritative for closeout audits
- query every Project 15 issue so unlabeled Ready/In-progress cards cannot disappear
- fail readiness for active unblocked cards and blocker/status contradictions
- filter the evidence matrix to the same active non-Done issue set
- add unlabeled-Ready, Done-exclusion, inverse-mismatch, and cross-tool parity regressions

## Verification

- focused audit/readiness/evidence tests: 35 passed, 0 failed, 122 assertions
- current independent Project 15 query, readiness output, and evidence matrix each returned the same 35 active issue numbers: zero missing, zero extra
- repaired readiness fails closed with 3 agent-actionable rows and 3 blocker/status mismatches after #14792 moved to Done
- Biome, changed-file coverage, security review, error-policy ratchet, and diff checks pass

## Evidence

<!-- evidence-row:before-screenshots -->
Before screenshots: N/A - command-line audit only; no rendered UI source changed.

<!-- evidence-row:after-screenshots -->
After screenshots: N/A - command-line audit only; no rendered UI source changed.

<!-- evidence-row:walkthrough-video -->
Walkthrough video: N/A - no interactive or rendered user flow changed.

<!-- evidence-row:backend-logs -->
Backend/audit summary: https://github.com/elizaOS/eliza/releases/download/pr-evidence/15750-summary.log

<!-- evidence-row:frontend-logs -->
Frontend console/network logs: N/A - no frontend path changed.

<!-- evidence-row:ocr-review -->
OCR review: N/A - no screenshots or rendered surface changed.

<!-- evidence-row:llm-trajectory -->
Real-LLM trajectory: N/A - no agent, model, prompt, provider, evaluator, or action behavior changed.

<!-- evidence-row:domain-artifacts -->
Domain artifacts: [board audit](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15750-audit.json), [readiness report](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15750-readiness.json), [evidence matrix](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15750-matrix.json), and [independent GitHub query](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15750-independent.json). Manually reconciled: all three active sets contain 35 issues, with zero missing and zero extra.

## Current live readiness result

- 195 Project issues total
- 162 carrying the optional `mvp` label
- 35 open non-Done
- 4 closed non-Done drift rows
- 3 unblocked active rows: #15748, #13631, #13406
- 3 blocker/status mismatches: #14864, #14797, #14793
