### PR TITLE
test(app): clarify remote capability smoke contract

### DIFF
--- a/packages/app/test/ui-smoke/remote-capability-view.spec.ts
+++ b/packages/app/test/ui-smoke/remote-capability-view.spec.ts
@@ -29,23 +29,16 @@ type RemoteCapabilityServer = {
 };
 
 const ADVANCED_SETTINGS_STORAGE_KEY = "eliza:settings-advanced";
-// The Capabilities settings section is developerOnly since the MVP settings
-// declutter (788a314a7b9 / 5102e001b41): the hub renders it only when
-// Developer Mode is on. The advanced flag above additionally reveals the
-// remote-endpoint connect form INSIDE the section (CapabilitiesSection).
+// Both flags are required: developer mode exposes the section, while advanced
+// settings exposes its remote-endpoint controls.
 const DEVELOPER_MODE_STORAGE_KEY = "eliza:developerMode";
 const REMOTE_CAPABILITY_BUNDLE_PATH =
   "/api/views/remote-capability-live/bundle.js";
 
-// The production renderer registers /sw.js, whose fetch handler serves
-// /api/views/:id/bundle.js stale-while-revalidate (fd47ef2b275). A
-// service-worker-originated fetch is invisible to page.route, so with the SW
-// controlling the page the mocked bundle below is fetched from the real stub
-// server (404) and the dynamic import fails. Blocking SWs keeps the
-// route-mocked bundle path authoritative — same rationale as the
-// desktop-webkit project in playwright.ui-smoke.config.ts. Playwright's block
-// resolves register() to undefined, which sw-registration.ts already treats
-// as SW-unavailable without logging a console error.
+// The worker owns dynamic-view caching, but Playwright cannot intercept its
+// requests with page.route. Blocking it keeps this spec focused on the real
+// loader against its explicitly routed remote bundle; worker caching and auth
+// behavior are covered independently against public/sw.js.
 test.use({ serviceWorkers: "block" });
 
 test("app shell loads a remote capability view bundle from a running endpoint", async ({
@@ -280,9 +273,8 @@ test("settings provisions a cloud capability sandbox", async ({ page }) => {
   await openAppPath(page, "/settings");
   await openSettingsSection(page, /^Capabilities\b/);
 
-  // The Endpoint/Cloud connection-mode switch is a SettingsSegmentedRow
-  // radiogroup ("Capability router connection mode"), so the Cloud option
-  // exposes role=radio, not role=button.
+  // Select through the control's public accessibility contract so the test
+  // follows the same radiogroup semantics as keyboard and assistive-tech users.
   await page.getByRole("radio", { name: "Cloud", exact: true }).click();
   await page
     .getByLabel("Capability cloud API base URL")


### PR DESCRIPTION
Comment-only follow-up to #15736 under #12181.

The remote capability smoke test had accumulated change-history narration and comments that restated the mechanics. This rewrites the file header and the few durable implementation notes around the actual test boundaries: Playwright cannot intercept service-worker-originated requests, the local endpoint must remain alive for dynamic imports, and the settings flows deliberately opt into developer-only controls.

No executable token changed. The repository's comment-only guard compares the file against `origin/develop` and confirms byte-for-byte-equivalent code tokens.

## Verification

- `bun run check:comment-only` — passed; one source file changed and every code token is identical to `origin/develop`.
- `bun run --cwd packages/app test:remote-capabilities:ui` — 3/3 passed against the rebased head.
- `bun run --cwd packages/app audit:app` — the complete audit performed during #15736 passed 241/241 with zero broken or needs-work computed verdicts; this follow-up changes comments only.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - comments-only test-source cleanup; rendered behavior and pixels are byte-for-byte unaffected.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - comments-only test-source cleanup; rendered behavior and pixels are byte-for-byte unaffected.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - comments-only test-source cleanup; no user-exercisable behavior changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend or production code changed.

<!-- evidence-row:frontend-logs -->
- [x] [Remote capability smoke and full app-audit review log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15736-remote-capability-review.log)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, planner, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - comments-only test-source cleanup creates no persistent domain state.