### PR TITLE
test(cloud): make Caddy ingress proof fail closed

### DIFF
--- a/packages/cloud/shared/scripts/verify-apps-ingress-routing.sh
+++ b/packages/cloud/shared/scripts/verify-apps-ingress-routing.sh
@@ -5,7 +5,7 @@
 # ingress provisioner, and that removing the route stops routing. Plain HTTP
 # (no domain/TLS; on-demand TLS is validated on real infra). No mocks.
 #   bash packages/cloud/shared/scripts/verify-apps-ingress-routing.sh
-set -uo pipefail
+set -euo pipefail
 cd "$(dirname "$0")/.." || exit 1 # -> packages/cloud/shared
 NET=apps-ing-net
 APP=apps-ing-app
@@ -35,6 +35,15 @@ for _ in $(seq 1 25); do
   curl -fsS -H "Origin: http://localhost:$ADMIN_PORT" "http://localhost:$ADMIN_PORT/config/" >/dev/null 2>&1 && break
   sleep 1
 done
+curl -fsS -H "Origin: http://localhost:$ADMIN_PORT" "http://localhost:$ADMIN_PORT/config/" >/dev/null
+
+echo "=== origin-less admin request is rejected ==="
+ADMIN_STATUS=$(curl -sS -o /dev/null -w '%{http_code}' "http://localhost:$ADMIN_PORT/config/")
+if [ "$ADMIN_STATUS" = 403 ]; then
+  check ok "Caddy admin origin enforcement rejects an origin-less request"
+else
+  check fail "Caddy admin origin enforcement" "expected 403, got $ADMIN_STATUS"
+fi
 
 echo "=== sample app (http-echo) co-located in Caddy's netns (mirrors loopback-only publish) ==="
 # In prod the container publishes to 127.0.0.1:hostPort and the node-local Caddy
@@ -48,7 +57,12 @@ bun -e "import{addAppRoute}from'./src/lib/services/apps-ingress-provisioner';awa
 echo "route posted"
 
 echo "=== request with the app's Host header -> reaches the app ==="
-RESP=$(curl -s -H "Host: $HOST" "http://localhost:$PROXY_PORT/")
+RESP=""
+for _ in $(seq 1 20); do
+  RESP=$(curl -sS -H "Host: $HOST" "http://localhost:$PROXY_PORT/")
+  echo "$RESP" | grep -q "ROUTED-TO-APP" && break
+  sleep 0.25
+done
 echo "response: $RESP"
 echo "$RESP" | grep -q "ROUTED-TO-APP" &&
   check ok "Host: $HOST reverse-proxied to the app container (real Caddy admin-API route)" ||

--- a/packages/cloud/shared/src/lib/services/__tests__/apps-ingress-provisioner.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/apps-ingress-provisioner.test.ts
@@ -92,6 +92,40 @@ describe("addAppRoute", () => {
     ).rejects.toThrow("add-route failed (500) for abc12345.apps.elizacloud.ai via 127.0.0.1:2019");
   });
 
+  test("preserves a route POST transport failure as the typed error cause", async () => {
+    const transportError = new Error("caddy post timeout");
+    const fetchImpl: IngressFetch = async (_url, init) => {
+      if (init.method === "POST") throw transportError;
+      return { ok: true, status: 200, text: async () => "" };
+    };
+
+    await expect(
+      addAppRoute({ hostname: HOST, hostPort: 28123, adminBase: ADMIN, fetchImpl }),
+    ).rejects.toMatchObject({
+      code: "CADDY_ADMIN_MUTATION_FAILED",
+      cause: transportError,
+      context: { operation: "add-route" },
+    });
+  });
+
+  test("surfaces an unreadable Caddy rejection body with its original cause", async () => {
+    const bodyError = new Error("response stream aborted");
+    const fetchImpl: IngressFetch = async (_url, init) => ({
+      ok: init.method === "DELETE",
+      status: init.method === "DELETE" ? 200 : 500,
+      text: async () => {
+        throw bodyError;
+      },
+    });
+
+    await expect(
+      addAppRoute({ hostname: HOST, hostPort: 28123, adminBase: ADMIN, fetchImpl }),
+    ).rejects.toMatchObject({
+      code: "CADDY_ADMIN_RESPONSE_READ_FAILED",
+      cause: bodyError,
+    });
+  });
+
   test("fails before POST when stale-route deletion has a transport failure", async () => {
     const calls: Array<{ url: string; method: string }> = [];
     const fetchImpl: IngressFetch = async (url, init) => {
@@ -178,5 +212,20 @@ describe("removeAppRoute", () => {
     await expect(removeAppRoute({ hostname: HOST, adminBase: ADMIN, fetchImpl })).rejects.toThrow(
       "remove-route failed (500) for abc12345.apps.elizacloud.ai via 127.0.0.1:2019",
     );
+  });
+
+  test("preserves a removal transport failure as the typed error cause", async () => {
+    const transportError = new Error("caddy delete timeout");
+    const fetchImpl: IngressFetch = async () => {
+      throw transportError;
+    };
+
+    await expect(
+      removeAppRoute({ hostname: HOST, adminBase: ADMIN, fetchImpl }),
+    ).rejects.toMatchObject({
+      code: "CADDY_ADMIN_MUTATION_FAILED",
+      cause: transportError,
+      context: { operation: "remove-route" },
+    });
   });
 });


### PR DESCRIPTION
Follow-up to #15747 for #15739.

Reviewing the merged Caddy origin-routing fix exposed a defect in its proof script: because the script enabled `nounset` and `pipefail` but not `errexit`, a failed Bun provisioner command could be followed by the false claims `route posted` and `route deleted`. A real reproduction with an unavailable generated i18n module produced exactly that misleading partial success.

This makes the proof fail closed with `set -euo pipefail`, waits explicitly for the Caddy admin API, verifies that an origin-less request is rejected, and retries the routed request across the app-container startup boundary. It also extends the provisioner tests across POST transport failure, unreadable response bodies, and route-removal transport failure while preserving each typed error's cause.

## Verification

- Targeted provisioner suite: 13/13 passed; 99.19% line coverage.
- Real unmodified `caddy:2` lifecycle: 4/4 checks passed (origin enforcement, known-host routing, unknown-host isolation, removal).
- Deliberate failing-Bun regression: exited 42 immediately and never printed the false `route posted` claim.
- `bun run verify`: all 570 Turbo typecheck/lint tasks passed, along with build/audit/test-realness checks; the final dist-path freshness check reported the existing `tsconfig.dist-paths.json` drift on `develop`.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend verification-script and service-test change; no rendered UI changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend verification-script and service-test change; no rendered UI changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - command-line infrastructure proof with no user-facing visual flow.

<!-- evidence-row:backend-logs -->
- [x] [Real Caddy lifecycle, fail-closed regression, coverage, and repository verification log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15752-caddy-proof-review.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, planner, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] [Caddy route lifecycle artifact: rejected origin-less request, routed known host, isolated unknown host, removed route](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15752-caddy-proof-review.log)