### PR TITLE
fix(cloud): keep E2E fixture sandboxes inert

### DIFF
--- a/packages/cloud/api/__tests__/fixture-sandbox.test.ts
+++ b/packages/cloud/api/__tests__/fixture-sandbox.test.ts
@@ -1,0 +1,116 @@
+/** Verifies fixture sandboxes stay inert across first seed and repeated preloads. */
+
+import { describe, expect, mock, test } from "bun:test";
+import type { NewAgentSandbox } from "@elizaos/cloud-shared/db/repositories/agent-sandboxes";
+import {
+  ensureFixtureSandbox,
+  type FixtureSandboxRecord,
+} from "../test/e2e/fixture-sandbox";
+
+const baseSandbox = {
+  id: "11111111-1111-4111-8111-111111111111",
+  sandbox_id: "playwright-e2e-org-sandbox",
+  status: "running",
+  bridge_url: "http://127.0.0.1:65535",
+  health_url: "http://127.0.0.1:65535/health",
+} satisfies FixtureSandboxRecord;
+
+function repository() {
+  const create = mock(async (data: NewAgentSandbox): Promise<unknown> => data);
+  const update = mock(
+    async (
+      id: string,
+      _data: Partial<NewAgentSandbox>,
+    ): Promise<{ id: string } | undefined> => ({ id }),
+  );
+  return { create, update };
+}
+
+const fixtureOptions = {
+  slug: "playwright-e2e-org",
+  organizationId: "22222222-2222-4222-8222-222222222222",
+  userId: "33333333-3333-4333-8333-333333333333",
+};
+
+describe("ensureFixtureSandbox", () => {
+  test("creates an inert row without a fake runtime endpoint", async () => {
+    const repo = repository();
+    await ensureFixtureSandbox({
+      ...fixtureOptions,
+      sandboxes: [],
+      repository: repo,
+    });
+
+    expect(repo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sandbox_id: "playwright-e2e-org-sandbox",
+        status: "stopped",
+        bridge_url: null,
+        health_url: null,
+      }),
+    );
+    expect(repo.update).not.toHaveBeenCalled();
+  });
+
+  test("repairs the old running loopback sentinel on the next preload", async () => {
+    const repo = repository();
+    await ensureFixtureSandbox({
+      ...fixtureOptions,
+      sandboxes: [baseSandbox],
+      repository: repo,
+    });
+
+    expect(repo.create).not.toHaveBeenCalled();
+    expect(repo.update).toHaveBeenCalledWith(baseSandbox.id, {
+      status: "stopped",
+      bridge_url: null,
+      health_url: null,
+    });
+  });
+
+  test("does not write again once the fixture is inert", async () => {
+    const repo = repository();
+    await ensureFixtureSandbox({
+      ...fixtureOptions,
+      sandboxes: [
+        {
+          ...baseSandbox,
+          status: "stopped",
+          bridge_url: null,
+          health_url: null,
+        },
+      ],
+      repository: repo,
+    });
+
+    expect(repo.create).not.toHaveBeenCalled();
+    expect(repo.update).not.toHaveBeenCalled();
+  });
+
+  test("creates the named fixture when an unrelated sandbox already exists", async () => {
+    const repo = repository();
+    await ensureFixtureSandbox({
+      ...fixtureOptions,
+      sandboxes: [{ ...baseSandbox, sandbox_id: "another-sandbox" }],
+      repository: repo,
+    });
+
+    expect(repo.create).toHaveBeenCalledTimes(1);
+    expect(repo.update).not.toHaveBeenCalled();
+  });
+
+  test("fails fast when a raced update cannot repair the fixture", async () => {
+    const repo = repository();
+    repo.update.mockResolvedValue(undefined);
+
+    await expect(
+      ensureFixtureSandbox({
+        ...fixtureOptions,
+        sandboxes: [baseSandbox],
+        repository: repo,
+      }),
+    ).rejects.toThrow(
+      `E2E fixture sandbox disappeared while normalizing it: ${baseSandbox.id}`,
+    );
+  });
+});

--- a/packages/cloud/api/test/e2e/fixture-sandbox-state.test.ts
+++ b/packages/cloud/api/test/e2e/fixture-sandbox-state.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Proves the real E2E preload writes inert fixture sandboxes to Postgres and
+ * the live backup-cron route does not enqueue them as reachable agents.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { agentSandboxesRepository } from "@elizaos/cloud-shared/db/repositories/agent-sandboxes";
+import { Client } from "pg";
+import { api, cronHeaders } from "./_helpers/api";
+import { ensureFixtureSandbox } from "./fixture-sandbox";
+
+const FIXTURE_SANDBOX_IDS = [
+  "playwright-e2e-org-sandbox",
+  "playwright-e2e-member-org-sandbox",
+  "playwright-e2e-affiliate-org-sandbox",
+];
+
+const client = new Client({
+  connectionString: process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL,
+});
+
+beforeAll(async () => {
+  await client.connect();
+});
+
+afterAll(async () => {
+  await client.end();
+});
+
+describe("E2E fixture sandbox lifecycle", () => {
+  test("the preload stores fixtures as stopped with no runtime endpoint", async () => {
+    const result = await client.query<{
+      sandbox_id: string;
+      status: string;
+      bridge_url: string | null;
+      health_url: string | null;
+    }>(
+      `SELECT sandbox_id, status, bridge_url, health_url
+       FROM agent_sandboxes
+       WHERE sandbox_id = ANY($1::text[])
+       ORDER BY sandbox_id`,
+      [FIXTURE_SANDBOX_IDS],
+    );
+
+    expect(result.rows).toHaveLength(FIXTURE_SANDBOX_IDS.length);
+    expect(result.rows).toEqual(
+      result.rows.map((row) => ({
+        sandbox_id: row.sandbox_id,
+        status: "stopped",
+        bridge_url: null,
+        health_url: null,
+      })),
+    );
+  });
+
+  test("a repeated preload repairs an existing running sentinel through the real repository", async () => {
+    const poisoned = await client.query<{
+      organization_id: string;
+      user_id: string;
+    }>(
+      `UPDATE agent_sandboxes
+       SET status = 'running',
+           bridge_url = 'http://127.0.0.1:65535',
+           health_url = 'http://127.0.0.1:65535/health'
+       WHERE sandbox_id = 'playwright-e2e-org-sandbox'
+       RETURNING organization_id, user_id`,
+    );
+    const fixtureOwner = poisoned.rows[0];
+    if (!fixtureOwner) {
+      throw new Error("Expected the owner fixture sandbox to exist");
+    }
+
+    const sandboxes = await agentSandboxesRepository.listByOrganization(
+      fixtureOwner.organization_id,
+    );
+    await ensureFixtureSandbox({
+      slug: "playwright-e2e-org",
+      organizationId: fixtureOwner.organization_id,
+      userId: fixtureOwner.user_id,
+      sandboxes,
+      repository: agentSandboxesRepository,
+    });
+
+    const repaired = await client.query<{
+      status: string;
+      bridge_url: string | null;
+      health_url: string | null;
+    }>(
+      `SELECT status, bridge_url, health_url
+       FROM agent_sandboxes
+       WHERE sandbox_id = 'playwright-e2e-org-sandbox'`,
+    );
+    expect(repaired.rows).toEqual([
+      { status: "stopped", bridge_url: null, health_url: null },
+    ]);
+  });
+
+  test("the real backup cron scans zero fixture agents", async () => {
+    const response = await api.post(
+      "/api/v1/cron/agent-backups?intervalMs=1",
+      {},
+      { headers: cronHeaders() },
+    );
+    expect(response.status).toBe(200);
+    const body: unknown = await response.json();
+    expect(body).toMatchObject({
+      success: true,
+      scanned: 0,
+      enqueued: 0,
+    });
+  });
+});

--- a/packages/cloud/api/test/e2e/fixture-sandbox.ts
+++ b/packages/cloud/api/test/e2e/fixture-sandbox.ts
@@ -1,0 +1,77 @@
+/**
+ * Maintains the inert sandbox rows used to exercise ownership and billing APIs.
+ * These records deliberately have no runtime endpoint: advertising them as
+ * running would make background health and backup scanners treat test fixtures
+ * as live agents.
+ */
+
+import type {
+  AgentSandbox,
+  NewAgentSandbox,
+} from "@elizaos/cloud-shared/db/repositories/agent-sandboxes";
+
+export interface FixtureSandboxRepository {
+  create(data: NewAgentSandbox): Promise<unknown>;
+  update(
+    id: string,
+    data: Partial<NewAgentSandbox>,
+  ): Promise<{ id: string } | undefined>;
+}
+
+export type FixtureSandboxRecord = Pick<
+  AgentSandbox,
+  "id" | "sandbox_id" | "status" | "bridge_url" | "health_url"
+>;
+
+interface EnsureFixtureSandboxOptions {
+  slug: string;
+  organizationId: string;
+  userId: string;
+  sandboxes: FixtureSandboxRecord[];
+  repository: FixtureSandboxRepository;
+}
+
+const INERT_FIXTURE_STATE = {
+  status: "stopped",
+  bridge_url: null,
+  health_url: null,
+} as const;
+
+export async function ensureFixtureSandbox({
+  slug,
+  organizationId,
+  userId,
+  sandboxes,
+  repository,
+}: EnsureFixtureSandboxOptions): Promise<void> {
+  const sandboxId = `${slug}-sandbox`;
+  const fixture = sandboxes.find((sandbox) => sandbox.sandbox_id === sandboxId);
+
+  if (!fixture) {
+    await repository.create({
+      organization_id: organizationId,
+      user_id: userId,
+      sandbox_id: sandboxId,
+      agent_name: `${slug} test agent`,
+      database_status: "ready",
+      environment_vars: {},
+      ...INERT_FIXTURE_STATE,
+    });
+    return;
+  }
+
+  if (
+    fixture.status === INERT_FIXTURE_STATE.status &&
+    fixture.bridge_url === INERT_FIXTURE_STATE.bridge_url &&
+    fixture.health_url === INERT_FIXTURE_STATE.health_url
+  ) {
+    return;
+  }
+
+  const updated = await repository.update(fixture.id, INERT_FIXTURE_STATE);
+  if (!updated) {
+    throw new Error(
+      `E2E fixture sandbox disappeared while normalizing it: ${fixture.id}`,
+    );
+  }
+}

--- a/packages/cloud/api/test/e2e/preload.ts
+++ b/packages/cloud/api/test/e2e/preload.ts
@@ -23,6 +23,7 @@ import { apiKeysService } from "@elizaos/cloud-shared/lib/services/api-keys";
 import { config } from "dotenv";
 import { eq } from "drizzle-orm";
 import { privateKeyToAccount } from "viem/accounts";
+import { ensureFixtureSandbox } from "./fixture-sandbox";
 
 for (const envPath of [
   resolve("../../.env"),
@@ -135,19 +136,13 @@ async function ensureTestUser({
   const sandboxes = await agentSandboxesRepository.listByOrganization(
     organization.id,
   );
-  if (sandboxes.length === 0) {
-    await agentSandboxesRepository.create({
-      organization_id: organization.id,
-      user_id: user.id,
-      sandbox_id: `${slug}-sandbox`,
-      status: "running",
-      agent_name: `${slug} test agent`,
-      bridge_url: "http://127.0.0.1:65535",
-      health_url: "http://127.0.0.1:65535/health",
-      database_status: "ready",
-      environment_vars: {},
-    });
-  }
+  await ensureFixtureSandbox({
+    slug,
+    organizationId: organization.id,
+    userId: user.id,
+    sandboxes,
+    repository: agentSandboxesRepository,
+  });
 
   await apiKeysService.deactivateUserKeysByName(user.id, "playwright-e2e");
   const { plainKey } = await apiKeysService.create({


### PR DESCRIPTION
# Relates to

Part of #15737. This removes the code-level source of the poisoned fixture rows; staging redeploy/database confirmation remains an operational verification step on the issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; unrelated blockers are recorded below.
- [x] A reviewer can confirm the change works without reading the code from the evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` at `05b806cfea4`; zero conflicts.
- [x] `bun run verify` completed all 570 Turbo typecheck/lint tasks and audits before the final unrelated stale generated-config blocker documented below.

# Risks

Low. This affects only E2E preload fixtures. Rows that advertised fake live endpoints become stopped with no bridge or health URL. Re-running preload repairs poisoned fixtures idempotently.

# Background

## What does this PR do?

- Creates the three ownership/billing fixture sandboxes in an inert state.
- Repairs existing `running` fixtures using the `127.0.0.1:65535` sentinel.
- Finds fixtures by deterministic sandbox ID rather than skipping creation when any unrelated sandbox exists.
- Adds focused unit coverage and a real PGlite + Wrangler E2E proving the backup route scans and enqueues zero fixture agents.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. This corrects test-fixture lifecycle behavior and does not change a public contract.

# Testing

## Where should a reviewer start?

```bash
E2E_ONLY=fixture-sandbox-state bun run --cwd packages/cloud/api test:e2e
```

## Detailed testing steps

1. Run the command above from a clean E2E database.
2. Confirm migrations and preload complete against PGlite.
3. Confirm three fixture rows are `stopped` with null runtime URLs.
4. Confirm the test poisons one row, repairs it through the real repository, and reads the repaired row.
5. Confirm real Wrangler `POST /api/v1/cron/agent-backups?intervalMs=1` returns 200 with `scanned: 0`, `enqueued: 0`.

Additional results: cloud API unit lane 166/166 files; helper tests 5/5 with 100% function/line coverage; real E2E 3/3; cloud API typecheck and production Worker dry-run; Biome and all diff ratchets; repository Turbo matrix 570/570 tasks.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only E2E fixture lifecycle change; no UI surface is affected.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only E2E fixture lifecycle change; no UI surface is affected.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no frontend flow; real database and HTTP boundaries are exercised below.
<!-- evidence-row:backend-logs -->
- [x] Real PGlite migration, Wrangler request, and test logs are included in [Backend + frontend logs](#backend--frontend-logs).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request or state is changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Real database-state and cron-result assertions are included in [Domain artifacts](#domain-artifacts).

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changes.

## Backend + frontend logs

Backend, real PGlite TCP server + migrated database + Wrangler Worker:

<details>
<summary>Focused E2E transcript</summary>

```text
[api-e2e] START PGlite TCP server at 127.0.0.1:49541
[pglite] DATABASE_URL=postgresql://postgres@127.0.0.1:49541/postgres
[✓] migrations applied successfully!
[wrangler:info] Ready on http://127.0.0.1:44541
(pass) the preload stores fixtures as stopped with no runtime endpoint
(pass) a repeated preload repairs an existing running sentinel through the real repository
<-- POST /api/v1/cron/agent-backups?intervalMs=1
--> POST /api/v1/cron/agent-backups?intervalMs=1 200 25ms
[wrangler:info] POST /api/v1/cron/agent-backups 200 OK (996ms)
(pass) the real backup cron scans zero fixture agents
3 pass
0 fail
```

</details>

Frontend: N/A - no frontend code or flow is involved.

## Domain artifacts

The E2E queries the migrated database and verifies:

```text
playwright-e2e-org-sandbox           status=stopped bridge_url=null health_url=null
playwright-e2e-member-org-sandbox    status=stopped bridge_url=null health_url=null
playwright-e2e-affiliate-org-sandbox status=stopped bridge_url=null health_url=null
```

It then restores the historical poison state, repairs through `agentSandboxesRepository`, reads `stopped/null/null` from Postgres, and invokes the real cron endpoint, asserting:

```json
{ "success": true, "scanned": 0, "enqueued": 0 }
```

## Screenshots (before / after) + video walkthrough

N/A - backend-only behavior; no rendered surface changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio behavior changed.

## Known gaps / failures

- `bun install --frozen-lockfile` says the checked-in lockfile would change under the pinned Bun canary. A normal install resolved dependencies, but its optional 971 MiB artifact postinstall was interrupted; no tracked changes remain. Installed dependencies supported every check above.
- `bun run verify` passed all policy audits and 570 Turbo tasks, then failed only at final `typecheck:dist`: `[generate-dist-paths-config] tsconfig.dist-paths.json is stale` on rebased `develop`. This PR does not touch exports/dist paths; the worktree remained clean.
- Closing #15737 still requires running updated preload in staging, inspecting its three rows, and confirming the next backup scan emits no fixture failures.

# Deploy Notes

No schema migration. Run normal E2E preload once in staging to normalize existing fixture rows, then inspect the following backup scan.
