### PR TITLE
fix(ci): green Zero-Key scenario-runner-e2e deterministic coverage gates

### DIFF
--- a/.github/workflows/mobile-build-smoke.yml
+++ b/.github/workflows/mobile-build-smoke.yml
@@ -245,6 +245,29 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
+      - name: Run Mobile Safari chat-sheet visual smoke (#15666)
+        # run-chat-sheet-mobile-safari-smoke.mjs builds the WebKit chat-sheet
+        # fixture via the Playwright smoke, serves it over loopback HTTP, opens
+        # it in real Mobile Safari on the booted simulator, and asserts a
+        # non-blank screen capture. Wired here because this is the only
+        # PR-path lane with an iOS Simulator available, and the ui-e2e
+        # runner-coverage ratchet (packages/scripts/__tests__/
+        # ui-e2e-runner-coverage.test.ts) requires every packages/ui __e2e__
+        # runner to be invoked by a workflow leg.
+        run: |
+          set -euo pipefail
+          bunx playwright install webkit
+          bun run --cwd packages/ui test:chat-sheet-mobile-safari-smoke
+
+      - name: Upload Mobile Safari chat-sheet evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: ios-mobile-safari-chat-sheet
+          path: packages/ui/src/components/shell/__e2e__/output-mobile-safari/**
+          if-no-files-found: warn
+          retention-days: 7
+
       - name: Verify required Info.plist keys for background HealthKit
         # Background HealthKit + BGTaskScheduler integration is in
         # progress: no plist generator is configured yet (no

--- a/packages/scripts/e2e-coverage/manifest.ts
+++ b/packages/scripts/e2e-coverage/manifest.ts
@@ -120,15 +120,6 @@ function covered(artifact: string, extraSignals: string[] = []): CoverageEntry {
   };
 }
 
-/** A keyless route e2e that drives routeHandler/Hono production dispatch. */
-function coveredByHono(artifact: string): CoverageEntry {
-  return {
-    status: "covered",
-    artifacts: [artifact],
-    signals: ["buildHonoAppForRuntime"],
-  };
-}
-
 /** A pre-existing route test is trusted to exist; deletion is the regression. */
 function existing(artifact: string): CoverageEntry {
   return { status: "covered", artifacts: [artifact], signals: [] };
@@ -143,6 +134,9 @@ export const PLUGIN_ROUTE_COVERAGE: Record<string, ManifestEntry> = {
   // ── Pre-existing dedicated route tests (trusted; ratcheted against deletion) ─
   "plugin-agent-orchestrator": existing(
     "plugins/plugin-agent-orchestrator/__tests__/unit/agent-routes-goal-wrapper.test.ts",
+  ),
+  "plugin-birdclaw": existing(
+    "plugins/plugin-birdclaw/src/routes/birdclaw-routes.test.ts",
   ),
   "plugin-bluebubbles": existing(
     "plugins/plugin-bluebubbles/__tests__/data-routes.test.ts",
@@ -160,19 +154,17 @@ export const PLUGIN_ROUTE_COVERAGE: Record<string, ManifestEntry> = {
   "plugin-hyperliquid": existing(
     "plugins/plugin-hyperliquid/src/routes.real.test.ts",
   ),
+  "plugin-inbox": existing("plugins/plugin-inbox/test/inbox-routes.test.ts"),
   "plugin-local-inference": existing(
     "plugins/plugin-local-inference/__tests__/voice-models-routes.test.ts",
+  ),
+  "plugin-meetings": existing(
+    "plugins/plugin-meetings/src/routes/meetings-routes.test.ts",
   ),
   "plugin-polymarket": existing(
     "plugins/plugin-polymarket/src/routes.real.test.ts",
   ),
-  "plugin-shopify": existing(
-    "plugins/plugin-shopify/src/routes.contract.test.ts",
-  ),
   "plugin-signal": existing("plugins/plugin-signal/src/setup-routes.test.ts"),
-  "plugin-social-alpha": existing(
-    "plugins/plugin-social-alpha/src/routes.test.ts",
-  ),
   "plugin-scheduling": existing(
     "plugins/plugin-scheduling/src/routes/scheduled-tasks.test.ts",
   ),
@@ -202,9 +194,6 @@ export const PLUGIN_ROUTE_COVERAGE: Record<string, ManifestEntry> = {
   "plugin-telegram": covered("plugins/plugin-telegram/src/routes-e2e.test.ts"),
   "plugin-workflow": covered(
     "plugins/plugin-workflow/__tests__/integration/routes-e2e.test.ts",
-  ),
-  "plugin-xr": coveredByHono(
-    "plugins/plugin-xr/src/__tests__/routes-e2e.test.ts",
   ),
 
   // ── Exempt with written justification (genuinely covered elsewhere, or need a

--- a/plugins/plugin-facewear/src/__tests__/routes-e2e.test.ts
+++ b/plugins/plugin-facewear/src/__tests__/routes-e2e.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Route-level e2e for plugin-facewear (issue #8802).
+ *
+ * Boots the plugin's declared `Route[]` through the real production dispatcher
+ * (`tryHandleRuntimePluginRoute`) over a loopback `http.createServer` —
+ * exercising the real auth gate, route matching, `:id` param parsing, and
+ * handler dispatch — with a faked `FacewearService` standing
+ * in for the only external dependency. Every assertion is on a real
+ * HTTP response; no `json`/`error` functions are mocked, no shapes are faked.
+ *
+ * Facewear routes use the canonical return-shape `routeHandler(ctx)->{status,
+ * headers, body}` contract. `tryHandleRuntimePluginRoute` reads the legacy
+ * `handler` field, so each route is bridged to a legacy `handler` with the same
+ * adapter the runtime uses in production (`dispatch-route.ts`): build a
+ * `RouteHandlerContext` from the dispatcher-augmented request, call
+ * `routeHandler`, and write the structured result to the Node response.
+ */
+
+import type { IncomingMessage, ServerResponse } from "node:http";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import type { AgentRuntime, Route, RouteHandlerContext } from "@elizaos/core";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { tryHandleRuntimePluginRoute } from "../../../../packages/agent/src/api/runtime-plugin-routes.ts";
+import { facewearPlugin } from "../index.ts";
+import { FACEWEAR_SERVICE_TYPE } from "../services/facewear-service.ts";
+
+const FACEWEAR_ROUTES = facewearPlugin.routes as Route[];
+
+const servers: http.Server[] = [];
+
+afterEach(async () => {
+	await Promise.all(
+		servers.map(
+			(server) =>
+				new Promise<void>((resolve) => {
+					server.closeAllConnections?.();
+					server.close(() => resolve());
+				}),
+		),
+	);
+	servers.length = 0;
+});
+
+// ── routeHandler → legacy handler adapter ──────────────────────────────────
+// Mirrors the production `routeHandler` invocation in
+// packages/agent/src/api/dispatch-route.ts: build the canonical
+// RouteHandlerContext from the request the dispatcher already augmented
+// (.params/.query/.body), run routeHandler, and flush {status, headers, body}.
+
+type AugmentedRequest = IncomingMessage & {
+	params?: Record<string, string>;
+	query?: Record<string, string | string[]>;
+	body?: unknown;
+	rawBody?: string;
+	path?: string;
+};
+
+function headersToRecord(req: IncomingMessage): Record<string, string> {
+	const out: Record<string, string> = {};
+	for (const [key, value] of Object.entries(req.headers)) {
+		out[key] = Array.isArray(value) ? value.join(",") : (value ?? "");
+	}
+	return out;
+}
+
+function bridgeToLegacyHandler(route: Route): Route {
+	const routeHandler = route.routeHandler;
+	if (!routeHandler) return route;
+	return {
+		...route,
+		routeHandler: undefined,
+		handler: async (req, res, runtime) => {
+			const augmented = req as unknown as AugmentedRequest;
+			const ctx: RouteHandlerContext = {
+				body: augmented.body,
+				rawBody: augmented.rawBody,
+				params: augmented.params ?? {},
+				query: augmented.query ?? {},
+				headers: headersToRecord(req as unknown as IncomingMessage),
+				method: (req as unknown as IncomingMessage).method ?? "GET",
+				path: augmented.path ?? "",
+				runtime,
+				inProcess: false,
+			};
+			const result = await routeHandler(ctx);
+			const response = res as unknown as ServerResponse;
+			response.statusCode = result.status;
+			for (const [key, value] of Object.entries(result.headers ?? {})) {
+				response.setHeader(key, value);
+			}
+			if (result.body === undefined) {
+				response.end();
+				return;
+			}
+			if (typeof result.body === "string" || Buffer.isBuffer(result.body)) {
+				if (!response.getHeader("Content-Type")) {
+					response.setHeader("Content-Type", "text/plain; charset=utf-8");
+				}
+				response.end(result.body);
+				return;
+			}
+			if (!response.getHeader("Content-Type")) {
+				response.setHeader("Content-Type", "application/json; charset=utf-8");
+			}
+			response.end(JSON.stringify(result.body));
+		},
+	};
+}
+
+const BRIDGED_ROUTES = FACEWEAR_ROUTES.map(bridgeToLegacyHandler);
+
+// ── Fake services ───────────────────────────────────────────────────────────
+
+function makeFacewearService(
+	devices: Array<{
+		id: string;
+		kind: "smartglasses";
+		deviceType?: string;
+	}>,
+) {
+	return {
+		getConnectedDevices: () => devices,
+	};
+}
+
+interface RuntimeServices {
+	facewear?: ReturnType<typeof makeFacewearService> | null;
+}
+
+function makeRuntime(services: RuntimeServices = {}): AgentRuntime {
+	return {
+		routes: BRIDGED_ROUTES,
+		getService: (key: string) => {
+			if (key === FACEWEAR_SERVICE_TYPE) return services.facewear ?? null;
+			return null;
+		},
+	} as unknown as AgentRuntime;
+}
+
+async function startServer(
+	runtime: AgentRuntime,
+	isAuthorized: () => boolean = () => true,
+): Promise<string> {
+	const server = http.createServer(async (req, res) => {
+		const url = new URL(req.url ?? "/", "http://127.0.0.1");
+		const handled = await tryHandleRuntimePluginRoute({
+			req,
+			res,
+			method: req.method ?? "GET",
+			pathname: url.pathname,
+			url,
+			runtime,
+			isAuthorized,
+		});
+		if (!handled && !res.headersSent) {
+			res.statusCode = 404;
+			res.end("not found");
+		}
+	});
+	servers.push(server);
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+	const { port } = server.address() as AddressInfo;
+	return `http://127.0.0.1:${port}`;
+}
+
+describe("plugin-facewear routes (real dispatch)", () => {
+	it("GET /api/facewear/devices lists the full device registry", async () => {
+		const base = await startServer(makeRuntime());
+		const res = await fetch(`${base}/api/facewear/devices`);
+		expect(res.status).toBe(200);
+		expect(res.headers.get("content-type")).toContain("application/json");
+		const body = (await res.json()) as {
+			devices: Array<{ id: string }>;
+		};
+		expect(Array.isArray(body.devices)).toBe(true);
+		expect(body.devices.length).toBeGreaterThan(0);
+		expect(body.devices.map((d) => d.id)).toContain("even-realities");
+	});
+
+	it("GET /api/facewear/devices/:id resolves a known profile via the :id param", async () => {
+		const base = await startServer(makeRuntime());
+
+		const known = await fetch(`${base}/api/facewear/devices/even-realities`);
+		expect(known.status).toBe(200);
+		expect(((await known.json()) as { id: string }).id).toBe("even-realities");
+
+		// An unknown id is validated against the registry at the route boundary
+		// (`isFacewearDeviceType`) and rejected with a real 404 instead of serving
+		// an empty 200 body.
+		const unknown = await fetch(`${base}/api/facewear/devices/does-not-exist`);
+		expect(unknown.status).toBe(404);
+		expect(unknown.headers.get("content-type")).toContain("application/json");
+		expect(((await unknown.json()) as { error: string }).error).toBe(
+			"Device not found",
+		);
+	});
+
+	it("GET /api/facewear/status reports connected devices from FacewearService", async () => {
+		const base = await startServer(
+			makeRuntime({
+				facewear: makeFacewearService([
+					{ id: "smartglasses", kind: "smartglasses" },
+				]),
+			}),
+		);
+		const res = await fetch(`${base}/api/facewear/status`);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			connected: boolean;
+			devices: Array<{ id: string; kind: string }>;
+		};
+		expect(body.connected).toBe(true);
+		expect(body.devices).toHaveLength(1);
+		expect(body.devices[0]).toMatchObject({
+			id: "smartglasses",
+			kind: "smartglasses",
+		});
+	});
+
+	it("GET /api/facewear/status returns an empty list when FacewearService is absent", async () => {
+		const base = await startServer(makeRuntime({ facewear: null }));
+		const res = await fetch(`${base}/api/facewear/status`);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			connected: boolean;
+			devices: unknown[];
+		};
+		expect(body.connected).toBe(false);
+		expect(body.devices).toEqual([]);
+	});
+
+	it("enforces the auth gate on the non-public facewear routes (401)", async () => {
+		// None of the facewear routes are declared `public: true`, so the auth gate
+		// applies to all of them. With auth denied every route must 401 before the
+		// handler runs.
+		const base = await startServer(
+			makeRuntime({ facewear: makeFacewearService([]) }),
+			() => false,
+		);
+
+		for (const path of [
+			"/api/facewear/devices",
+			"/api/facewear/devices/even-realities",
+			"/api/facewear/status",
+		]) {
+			const res = await fetch(`${base}${path}`);
+			expect(res.status, `expected 401 for ${path}`).toBe(401);
+			expect(((await res.json()) as { error: string }).error).toBe(
+				"Unauthorized",
+			);
+		}
+	});
+});


### PR DESCRIPTION
## What

Fixes the two **deterministic** ship-gate failures in the **Zero-Key scenario runner E2E** job of `Scenario PR E2E` (the gate that failed as job `86083959940` in develop run [29007198774](https://github.com/elizaOS/eliza/actions/runs/29007198774), and is still red on the newest develop run).

These are the hard-fail steps in that job (the job stops at the first, then the coverage-matrix report step confirms the second):

1. **`ui-e2e-runner-coverage.test.ts`** — #15666 added the `packages/ui/src/components/shell/__e2e__/run-chat-sheet-mobile-safari-smoke.mjs` runner + `test:chat-sheet-mobile-safari-smoke` package script but wired **no workflow leg**, so the runner-coverage ratchet flagged it CI-orphaned:
   > `run-chat-sheet-mobile-safari-smoke.mjs: script "test:chat-sheet-mobile-safari-smoke" is not invoked by any .github/workflows/*.yml`

2. **`e2e-coverage.test.ts`** (run with `E2E_COVERAGE_GATE_ENFORCE=1`, so the advisory ratchets are hard) — the route-plugin coverage manifest drifted from discovered route wiring:
   - `plugin-facewear`'s `covered()` entry claimed a `routes-e2e.test.ts` that **did not exist** → hard ship-gate *"manifested coverage is broken"*.
   - `plugin-birdclaw` / `plugin-inbox` / `plugin-meetings` wire routes with **no manifest entry** → `missingFromManifest` ratchet.
   - `plugin-shopify` / `plugin-social-alpha` / `plugin-xr` keep entries for route tests/plugins that **no longer exist** → `staleInManifest` ratchet.

## Fix

- **New real route e2e** `plugins/plugin-facewear/src/__tests__/routes-e2e.test.ts`: boots the plugin's declared `Route[]` through the production dispatcher (`tryHandleRuntimePluginRoute`) over a loopback `http.createServer` — real auth gate, route matching, `:id` parsing, structured `{status,headers,body}` — with only the external `FacewearService` faked. No mocked `json`/`error` shapes (satisfies the `covered()` anti-larp signal).
- Add `existing()` manifest entries for `plugin-birdclaw`, `plugin-inbox`, `plugin-meetings` pointing at their pre-existing dedicated route tests (birdclaw-routes / inbox-routes / meetings-routes — all passing).
- Remove the stale `plugin-shopify` / `plugin-social-alpha` / `plugin-xr` entries and the now-unused `coveredByHono()` helper.
- Wire `test:chat-sheet-mobile-safari-smoke` into the iOS-simulator `mobile-build-smoke.yml` lane (the WebKit Mobile Safari smoke), satisfying the runner-coverage ratchet.

Never weakened a gate: the manifest additions cite real, passing tests; the removals are for genuinely-deleted files; the ratchet's forbidden escape hatch (baselining) was **not** used.

## Evidence (local red → green)

```
E2E_COVERAGE_GATE_ENFORCE=1 bun test .../e2e-coverage.test.ts     → 9 pass, 0 fail (was: missingFromManifest birdclaw/inbox/meetings + facewear "coverage broken")
bun test .../ui-e2e-runner-coverage.test.ts                       → 1 pass, 0 fail (was: chat-sheet-mobile-safari-smoke unwired)
bun .../write-coverage-matrix-report.ts  → "commands 38/38; routes 25/29 (+4 exempt); blocking gaps 0; advisory 0"  (was: blocking gaps 4)
bunx vitest run plugins/plugin-facewear/.../routes-e2e.test.ts    → 5 pass
bunx vitest run birdclaw-routes / inbox-routes / meetings-routes  → all pass
bunx biome check <touched files>                                 → clean
```

## Scope / not-in-this-PR

Triage of develop run 29007198774 shows the 12 Zero-Key jobs fail for **several independent** root causes, most of them **unmasked never-green lanes** rather than a single 07-07→07-09 regression (matching the #15736 "Tests Client job was red for days" finding). This PR lands the deterministic, verifiable coverage-gate fixes only. Remaining, separately-tracked blockers:

- **`scenario-runner-e2e` also** hits `check-e2e-coverage.test.ts`'s keyless-scenario baseline: `plugin-birdclaw`, `plugin-elizacloud`, `plugin-meetings` expose action surfaces with **no `pr-deterministic` keyless scenario**. This is pre-existing (`plugin-elizacloud` is untouched by this branch) and the baseline is a strict ratchet whose `$comment` forbids baselining to silence it — it needs real keyless scenarios (separate, larger change).
- **auto-discovered / cloud-keyless / feature-interactions** API boot: `Cannot find module '@elizaos/plugin-app-control/dist/index.js'` — the plugin ships only `src` (bun/eliza-source export conditions) and its `dist` is never built; this predates the branch (#15721 notes it "since #14804").
- **accounts-ui**: `Cannot find module '@elizaos/cloud-routing'` + `tsconfig.e2e-paths` directory mismatch.
- The **browser Playwright lanes** (view-lifecycle, core, dashboard matrix, WebKit, Pixel-7, walkthrough mock) have many independent per-spec failures (incl. the `SurfaceRealmDeniedError` on `eliza:first-run-complete` in the walkthrough harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)