### PR TITLE
fix(ci): honor eliza-source condition in ui-smoke Playwright collector (#15759 cluster 2)

### DIFF
--- a/packages/app/scripts/run-ui-playwright.mjs
+++ b/packages/app/scripts/run-ui-playwright.mjs
@@ -342,12 +342,21 @@ async function getDistinctFreePort(excludedPorts = new Set()) {
   throw new Error("Could not allocate a distinct free port for UI smoke.");
 }
 
-if (hasPlaywrightConfig("playwright.electrobun.packaged.config.ts")) {
-  env.NODE_OPTIONS = appendNodeOption(
-    env.NODE_OPTIONS,
-    "--conditions=eliza-source",
-  );
-}
+// Every Playwright lane collects its spec files up front, and those specs pull
+// workspace helpers whose static import graph reaches source-only packages —
+// e.g. app-core `server.ts` → `@elizaos/agent` → `settings-actions.ts` →
+// `@elizaos/plugin-app-control`, and `@elizaos/core` → `@elizaos/cloud-routing`.
+// Those packages publish an `eliza-source` export condition pointing at `src`;
+// on a fresh CI install (`bun install --ignore-scripts`) they have no `dist`, so
+// under default node conditions the collector resolves a missing
+// `dist/index.js` and the whole lane dies before any spec runs. The live-stack
+// web server (`run-node-tsx.mjs`) and the vitest source aliases already resolve
+// via `eliza-source`; the Playwright runner process must match so spec
+// collection reads the same source. No-op for packages without the condition.
+env.NODE_OPTIONS = appendNodeOption(
+  env.NODE_OPTIONS,
+  "--conditions=eliza-source",
+);
 
 if (hasPlaywrightConfig("playwright.ui-smoke.config.ts")) {
   env.ELIZA_UI_SMOKE_RUN_ID =


### PR DESCRIPTION
## Problem — issue #15759 cluster 2 (module-resolution)

Zero-Key browser/Playwright lanes fail at **spec-collection time** with:

```
Error: Cannot find module '/home/runner/work/eliza/eliza/packages/agent/node_modules/@elizaos/plugin-app-control/dist/index.js' imported from /home/runner/work/eliza/eliza/packages/agent/src/actions/settings-actions.ts
```

and the equivalent for `@elizaos/cloud-routing`. Observed in Scenario PR E2E run [29007198774](https://github.com/elizaOS/eliza/actions/runs/29007198774) (`develop@03f8dcdcf9d`), job **Zero-Key app browser auto-discovered specs** (86083959875). Known since #14804 per the #15721 investigation.

## Root cause — the exact resolution mechanism

`packages/app/scripts/run-ui-playwright.mjs` (the `test:e2e` entrypoint for every Zero-Key app-browser lane) appended `--conditions=eliza-source` to `NODE_OPTIONS` **only** when the config was `playwright.electrobun.packaged.config.ts`. For `playwright.ui-smoke.config.ts` the Playwright runner process collected specs under **default node conditions**.

Several ui-smoke specs statically import app-core source helpers (e.g. `auth-pairing-real.spec.ts` → `../../../app-core/src/api/server.ts`, `scheduled-reminder-fire.spec.ts` → `real-runtime.ts`). Those chains reach:

- `@elizaos/agent` → `settings-actions.ts` → **`@elizaos/plugin-app-control`**
- `@elizaos/core` → `cloud-routing.ts` → **`@elizaos/cloud-routing`**

Both packages publish an `eliza-source` export condition pointing at `src`, falling back to `dist/index.js` under default conditions. The Zero-Key install is `bun install --ignore-scripts` (no build), so **there is no dist** — the collector resolves a missing `dist/index.js` and the whole lane dies before any spec runs. The `bun` condition added in #15721 fixed bun-run lanes; the Playwright runner runs under **node**, which honors neither `bun` nor (previously) `eliza-source`.

The live-stack web server (`run-node-tsx.mjs`) and the vitest source aliases already resolve via `eliza-source`; the Playwright runner process was the one place that didn't.

## Fix

Apply `--conditions=eliza-source` to `NODE_OPTIONS` **unconditionally** for every Playwright lane launched by this runner. `appendNodeOption` is idempotent and the condition is a no-op for packages that don't declare it, so this subsumes the electrobun special case with no behavior change there. Follows the established source-alias pattern rather than adding a new mechanism.

## Evidence — red → green (local, exact reproduction)

Reproduced the byte-identical CI error and verified the fix through the real `run-ui-playwright.mjs` entrypoint, mirroring the CI env (`--ignore-scripts` install, shared+core built, `ELIZA_UI_SMOKE_FORCE_STUB=1`, no key).

**RED** (default conditions — pre-fix ui-smoke behavior), Playwright `--list` on the triggering spec:
```
Error: Cannot find module '.../packages/agent/node_modules/@elizaos/plugin-app-control/dist/index.js' imported from .../packages/agent/src/actions/settings-actions.ts
```

**GREEN** (with the fix, through `node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts ... --list`):
```
Listing tests:
  [chromium] › auth-pairing-real.spec.ts:101:1 › remote pairing against real app-core mints a machine session and survives reload
Total: 1 test in 1 file
```

Full auto-discovered lane collects cleanly with the fix:
```
Total: 152 tests in 27 files
```
(all 29 auto-discovered spec files load; 0 resolution errors)

`cloud-routing` resolution mechanism, isolated (same class, covered by the same fix):
```
RED   (default):              .../packages/cloud/routing/dist/index.js   (missing under --ignore-scripts)
GREEN (--conditions=...):     .../packages/cloud/routing/src/index.ts
```

`bunx biome check packages/app/scripts/run-ui-playwright.mjs` — clean.

N/A rows: no UI/pixel change (CI-harness resolver fix only); no runtime/model behavior change (no trajectories).

🤖 Generated with [Claude Code](https://claude.com/claude-code)