### PR TITLE
fix(hitl): recognize real Signal account listings

### DIFF
--- a/scripts/lifeops/connector-paths.mjs
+++ b/scripts/lifeops/connector-paths.mjs
@@ -497,7 +497,7 @@ export const CONNECTOR_PATHS = [
               reason: "signal-cli is installed but not runnable",
             },
             {
-              type: "command-ok",
+              type: "command-output-nonempty",
               command: "signal-cli",
               args: ["listAccounts"],
               reason: "no linked Signal account",
@@ -868,7 +868,10 @@ export function defaultAvailabilityCtx() {
         encoding: "utf8",
         timeout: 10_000,
       });
-      return { ok: !result.error && result.status === 0 };
+      return {
+        ok: !result.error && result.status === 0,
+        stdout: result.stdout ?? "",
+      };
     },
   };
 }
@@ -923,6 +926,19 @@ export function checkAvailability(spec, ctx = defaultAvailabilityCtx()) {
             reason:
               spec.reason ?? `${spec.command} ${spec.args.join(" ")} failed`,
           };
+    case "command-output-nonempty": {
+      const result = ctx.runCommand(spec.command, spec.args);
+      return result.ok &&
+        typeof result.stdout === "string" &&
+        result.stdout.trim().length > 0
+        ? ok
+        : {
+            available: false,
+            reason:
+              spec.reason ??
+              `${spec.command} ${spec.args.join(" ")} returned no output`,
+          };
+    }
     case "platform":
       return ctx.platform === spec.platform
         ? ok
@@ -1015,6 +1031,7 @@ function validateAvailabilitySpec(spec, id, problems) {
     "file-exists",
     "command-in-path",
     "command-ok",
+    "command-output-nonempty",
     "platform",
   ];
   if (!known.includes(spec.type)) {

--- a/scripts/lifeops/connector-paths.test.mjs
+++ b/scripts/lifeops/connector-paths.test.mjs
@@ -470,6 +470,10 @@ test("signal.cli scenario: installed-but-unrunnable CLI skips distinctly", () =>
       commandInPath: (command) => command === "signal-cli",
       runCommand: (_command, args) => ({
         ok: args[0] === "--version" || args[0] === "listAccounts",
+        stdout:
+          args[0] === "listAccounts"
+            ? "Number: +15551234567\n"
+            : "signal-cli 0.13\n",
       }),
     }),
   );
@@ -495,10 +499,38 @@ test("Signal Desktop and signal-cli unavailability shapes stay distinct", () => 
     cli,
     fakeCtx({
       commandInPath: () => true,
-      runCommand: (_command, args) => ({ ok: args[0] === "--version" }),
+      runCommand: (_command, args) => ({
+        ok: args[0] === "--version" || args[0] === "listAccounts",
+        stdout: args[0] === "listAccounts" ? "" : "signal-cli 0.13\n",
+      }),
     }),
   );
   assert.match(noAccount.reason, /no linked Signal account/);
+});
+
+test("command-output-nonempty requires both success and actual stdout", () => {
+  const spec = {
+    type: "command-output-nonempty",
+    command: "signal-cli",
+    args: ["listAccounts"],
+    reason: "no linked account",
+  };
+  assert.deepEqual(
+    checkAvailability(
+      spec,
+      fakeCtx({ runCommand: () => ({ ok: true, stdout: "" }) }),
+    ),
+    { available: false, reason: "no linked account" },
+  );
+  assert.deepEqual(
+    checkAvailability(
+      spec,
+      fakeCtx({
+        runCommand: () => ({ ok: true, stdout: "Number: +15551234567\n" }),
+      }),
+    ),
+    { available: true, reason: null },
+  );
 });
 
 test("oauth-app-dependent rows skip with an explanatory reason until an app is configured", () => {

--- a/scripts/lifeops/credential-probes.mjs
+++ b/scripts/lifeops/credential-probes.mjs
@@ -456,6 +456,7 @@ export async function probeSignal(
   const accounts = String(listed.stdout ?? "")
     .split(/\r?\n/)
     .map((line) => line.trim())
+    .map((line) => line.replace(/^Number:\s*/i, ""))
     .filter((line) => /^\+\d{6,}$|^u:[A-Za-z0-9_.-]+$/.test(line));
   if (accounts.length === 0) return fail("signal", "no linked Signal account");
   const selected = e("SIGNAL_ACCOUNT_NUMBER");

--- a/scripts/lifeops/credential-probes.test.mjs
+++ b/scripts/lifeops/credential-probes.test.mjs
@@ -61,7 +61,7 @@ test("Signal CLI probe runs version and listAccounts before passing", async () =
         calls.push([command, ...args]);
         return args[0] === "--version"
           ? { status: 0, stdout: "signal-cli 0.13.20\n" }
-          : { status: 0, stdout: "+15551234567\n" };
+          : { status: 0, stdout: "Number: +15551234567\n" };
       },
     },
   );


### PR DESCRIPTION
Follow-up to merged #15760 for #14797.

Reviewing the Signal linked-account change against the current upstream CLI exposed two contract mismatches:

- dashboard availability used only `listAccounts` exit status, but the upstream command returns normally for an empty account collection, so an unlinked CLI could be reported ready;
- the live probe accepted only bare `+number`/`u:username` lines, while current signal-cli plaintext output is `Number: <account>`, so a linked account could be reported absent.

The upstream implementation is visible in [ListAccountsCommand.java](https://github.com/AsamK/signal-cli/blob/98d9960e66707fc88a2812b5a85685a83c003063/src/main/java/org/asamk/signal/commands/ListAccountsCommand.java).

This adds a declarative `command-output-nonempty` availability leaf, carries stdout through the real-machine evaluator, requires actual account-list output, and normalizes the upstream `Number:` prefix before validating and masking account identifiers.

## Verification

- focused registry/probe suite: 26/26 passed;
- complete `test:lifeops-hitl` lane: 58/58 passed;
- Biome passed on all four changed scripts;
- `git diff --check` passed;
- tests cover a zero-exit empty listing, current-format non-empty output, live-probe parsing, and last-four-only masking.

<!-- evidence-row:before-screenshots -->
- [x] [Original pre-change Signal dashboard screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/14797-before-desktop-signal.jpg)

<!-- evidence-row:after-screenshots -->
- [x] [Current Signal dashboard screenshots from the parent change](https://github.com/elizaOS/eliza/releases/download/pr-evidence/14797-after-desktop-signal.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] [Parent Signal desktop/mobile dashboard walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence/14797-walkthrough.mp4)

<!-- evidence-row:backend-logs -->
- [x] [Upstream contract review and 58-test verification](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15768-signal-review.log)

<!-- evidence-row:frontend-logs -->
- [x] [Parent current-branch desktop console log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/14797-after-desktop-console.log)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent action, prompt, provider, model, or trajectory behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - read-only account enumeration sends no Signal messages and writes no LifeOps domain records.

<!-- evidence-row:ocr-review -->
- [x] [Parent current-branch OCR review manifest](https://github.com/elizaOS/eliza/releases/download/pr-evidence/14797-ocr-manifest.json)