### PR TITLE
fix(build): generate keywords before Turbo typechecks

### DIFF
--- a/packages/scripts/__tests__/run-turbo-typecheck-prerequisite.test.ts
+++ b/packages/scripts/__tests__/run-turbo-typecheck-prerequisite.test.ts
@@ -1,0 +1,77 @@
+/** Verifies Turbo typecheck invocations materialize generated declarations before scheduling. */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const repoRoot = resolve(import.meta.dir, "../../..");
+const runTurbo = join(repoRoot, "packages/scripts/run-turbo.mjs");
+const tempDirs: string[] = [];
+
+async function fixture() {
+  const dir = await mkdtemp(join(tmpdir(), "run-turbo-prerequisite-"));
+  tempDirs.push(dir);
+  const marker = join(dir, "marker.txt");
+  const generator = join(dir, "generator.mjs");
+  await writeFile(
+    generator,
+    `import { appendFileSync } from "node:fs";\nappendFileSync(${JSON.stringify(marker)}, "generated\\n");\nprocess.exit(Number(process.env.GENERATOR_EXIT ?? 0));\n`,
+  );
+  return { generator, marker };
+}
+
+async function invoke(args: string[], generator: string, exitCode = 0) {
+  const child = Bun.spawn([process.execPath, runTurbo, ...args], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      RUN_TURBO_KEYWORD_GENERATOR: generator,
+      RUN_TURBO_PREPARE_CHECK_ONLY: "1",
+      GENERATOR_EXIT: String(exitCode),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  await child.exited;
+  return child.exitCode;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+});
+
+describe("run-turbo typecheck prerequisites", () => {
+  test("runs the generator once before a typecheck task", async () => {
+    const { generator, marker } = await fixture();
+
+    expect(
+      await invoke(["run", "typecheck", "--concurrency=8"], generator),
+    ).toBe(0);
+    expect(await readFile(marker, "utf8")).toBe("generated\n");
+  });
+
+  test("runs the generator once for a mixed typecheck and lint graph", async () => {
+    const { generator, marker } = await fixture();
+
+    expect(await invoke(["run", "typecheck", "lint"], generator)).toBe(0);
+    expect(await readFile(marker, "utf8")).toBe("generated\n");
+  });
+
+  test("does not generate declarations for unrelated Turbo tasks", async () => {
+    const { generator, marker } = await fixture();
+
+    expect(await invoke(["run", "lint"], generator)).toBe(0);
+    await expect(readFile(marker, "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  test("fails before scheduling when generation fails", async () => {
+    const { generator } = await fixture();
+
+    expect(await invoke(["run", "typecheck"], generator, 7)).toBe(7);
+  });
+});

--- a/packages/scripts/run-turbo.mjs
+++ b/packages/scripts/run-turbo.mjs
@@ -1,7 +1,11 @@
 #!/usr/bin/env node
-// Drives repo automation run turbo with explicit CLI and CI behavior.
+/**
+ * Runs Turbo with repository-wide safeguards shared by local and CI commands.
+ * Typecheck prerequisites are materialized before Turbo hashes or schedules the
+ * graph so package-specific task overrides cannot race generated declarations.
+ */
 
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -57,6 +61,42 @@ if (process.env.RUN_TURBO_LOCKFILE_CHECK_ONLY === "1") {
   process.exit(0);
 }
 
+const rawTurboArgs = process.argv.slice(2);
+const rawRunIndex = rawTurboArgs.indexOf("run");
+const taskAndOptionArgs =
+  rawRunIndex === -1 ? [] : rawTurboArgs.slice(rawRunIndex + 1);
+const firstOptionIndex = taskAndOptionArgs.findIndex((arg) =>
+  arg.startsWith("-"),
+);
+const requestedTasks =
+  firstOptionIndex === -1
+    ? taskAndOptionArgs
+    : taskAndOptionArgs.slice(0, firstOptionIndex);
+
+if (requestedTasks.includes("typecheck")) {
+  const generator = process.env.RUN_TURBO_KEYWORD_GENERATOR
+    ? path.resolve(process.env.RUN_TURBO_KEYWORD_GENERATOR)
+    : path.join(repoRoot, "packages/shared/scripts/generate-keywords.mjs");
+  const result = spawnSync(process.execPath, [generator, "--target", "ts"], {
+    cwd: repoRoot,
+    env: process.env,
+    stdio: "inherit",
+  });
+  if (result.error) {
+    console.error(
+      `[run-turbo] Failed to generate typecheck prerequisites: ${result.error.message}`,
+    );
+    process.exit(1);
+  }
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+if (process.env.RUN_TURBO_PREPARE_CHECK_ONLY === "1") {
+  process.exit(0);
+}
+
 // Every `node_modules` from repoRoot up to the filesystem root. A git worktree
 // (e.g. `.claude/worktrees/<name>`) has no `node_modules` of its own and shares
 // the parent checkout's via node's ancestor resolution — so turbo lives several
@@ -88,7 +128,7 @@ const turboPackageBin =
     .map((nm) => path.join(nm, "turbo/bin/turbo"))
     .find((candidate) => fs.existsSync(candidate)) ??
   path.join(repoRoot, "node_modules/turbo/bin/turbo");
-const turboArgs = process.argv.slice(2);
+const turboArgs = rawTurboArgs;
 
 if (!turboArgs.some((arg) => arg === "--ui" || arg.startsWith("--ui="))) {
   turboArgs.unshift("--ui=stream");


### PR DESCRIPTION
# Relates to

Fixes #15761.

- [x] Targets `develop` and is rebased onto latest `origin/develop` with zero conflicts.
- [x] Focused regression and a forced first-attempt cloud API typecheck were run after a clean generation state.
- [x] A reviewer can verify ordering and failure behavior from the evidence below.

# Sync with develop

- [x] Rebased onto current `origin/develop`; zero conflicts.
- [x] Diff-scoped test-realness audit passes.

# Risks

Low. The central Turbo wrapper adds one deterministic prerequisite process only when `typecheck` is among the requested tasks. Non-typecheck tasks are unchanged. Generator startup and nonzero exits fail closed before Turbo starts.

# Background

## What does this PR do?

Materializes core/shared keyword declarations before Turbo constructs and hashes a typecheck graph. Package-specific `#typecheck` definitions replace the generic Turbo dependencies; without this wrapper boundary, cloud API and calendar typechecks can start while core build is still generating declarations.

The wrapper is used by local `typecheck`/`verify`, cloud verification, affected PR typechecks, and Windows CI, so future task overrides inherit the ordering guarantee automatically.

## What kind of change is this?

Bug fix for build/CI determinism.

# Documentation changes needed?

No. The wrapper header documents the invariant at its implementation boundary.

# Testing

## Where should a reviewer start?

```bash
bun test packages/scripts/__tests__/run-turbo-typecheck-prerequisite.test.ts
```

## Detailed testing steps

1. In a clean worktree with all three keyword outputs absent, invoke a filtered typecheck through `run-turbo.mjs`.
2. Confirm the generator writes shared TS, shared JS, and core TS outputs before Turbo prints its banner.
3. Run the focused regression test and confirm typecheck, mixed typecheck+lint, unrelated lint, and generator-failure cases pass.
4. Run `bun run audit:test-realness`.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - build orchestration only; no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - build orchestration only; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - command-line ordering fix; no frontend flow.
<!-- evidence-row:backend-logs -->
- [x] Real clean-generation and test logs are included in [Backend + frontend logs](#backend--frontend-logs).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend behavior.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model/agent behavior.
<!-- evidence-row:domain-artifacts -->
- [x] Generated declaration artifacts are listed in [Domain artifacts](#domain-artifacts).

# Evidence Details

## Real LLM-call trajectory

N/A - no model behavior.

## Backend + frontend logs

Clean worktree, before Turbo starts:

```text
$ ls packages/{core,shared}/src/i18n/generated/validation-keyword-data.*
No such file or directory

$ node packages/scripts/run-turbo.mjs run typecheck --filter=@elizaos/cloud-api --concurrency=8 --force
Generating keyword code from JSON...
Total: 241 entries, 6 locales
TypeScript (shared): packages/shared/src/i18n/generated/validation-keyword-data.ts
JavaScript (shared): packages/shared/src/i18n/generated/validation-keyword-data.js
TypeScript (core): packages/core/src/i18n/generated/validation-keyword-data.ts
Done!\n• turbo 2.10.0\n@elizaos/cloud-api:typecheck: $ tsgo --noEmit && bun run check:worker-bundle\n@elizaos/cloud-api:typecheck: --dry-run: exiting now.\nTasks: 1 successful, 1 total\n```

Regression suite:

```text
4 pass
0 fail
7 expect() calls
[test-realness-audit] diffScoped=checked base=origin/develop changedTestFiles=1 regressions=0
```

Frontend: N/A.

## Domain artifacts

The real generator created the three previously missing declaration/code artifacts before Turbo scheduling. They remain ignored generated outputs and are not committed.

## Screenshots (before / after) + video walkthrough

N/A - no rendered surface.

## Audio / voice walkthrough

N/A - no audio behavior.

## Known gaps / failures

- The focused suite covers success, mixed-task, non-typecheck, and fail-closed behavior.\n- A clean-state forced cloud API typecheck completed on its first attempt, including the real Wrangler production dry-run.\n- No UI/model/audio/deployment evidence applies.

# Deploy Notes

No deployment or migration. The fix applies automatically to every typecheck invocation through the repository wrapper.
