### PR TITLE
fix(ui): distinguish unavailable wallet balances from empty holdings

### DIFF
--- a/packages/ui/src/components/chat/widgets/__e2e__/run-wallet-widget-e2e.mjs
+++ b/packages/ui/src/components/chat/widgets/__e2e__/run-wallet-widget-e2e.mjs
@@ -2,11 +2,12 @@
  * Real-browser screenshot + assertion harness for the WALLET home widget
  * (#14344) — no app server. Bundles wallet-widget-fixture.tsx (the REAL
  * `WalletBalanceWidget`) with esbuild, stubs only the `../../../api` client,
- * auth, and nav modules, loads it in headless chromium, and proves both states:
+ * auth, and nav modules, loads it in headless chromium, and proves three states:
  *
  *   - DEFAULT (no holdings): the tracked BTC/SOL/ETH price rows are shown
  *     (previously the widget rendered nothing here — the bug this fixes).
  *   - HELD (≥1 priced holding): the top-3 held by holding value, price-only.
+ *   - UNAVAILABLE: a failed balances request never masquerades as no holdings.
  *
  * Captures a screenshot of each state for inline PR evidence.
  *
@@ -17,6 +18,11 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { build } from "esbuild";
 import { chromium } from "playwright";
+import {
+  closeOcrEngines,
+  dominantColorsFromPng,
+  ocrImage,
+} from "../../../../../../evidence/src/visual-primitives.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const stylesDir = join(here, "../../../../styles");
@@ -45,7 +51,9 @@ const TOKEN_SHIM = `
 const apiStub = join(outDir, "api-stub.ts");
 await writeFile(
   apiStub,
-  `const held = new URLSearchParams(location.search).get("state") === "held";
+  `const state = new URLSearchParams(location.search).get("state");
+const held = state === "held";
+const unavailable = state === "unavailable";
 const overview = {
   generatedAt: "", cacheTtlSeconds: 120, stale: false,
   sources: {}, predictions: [], movers: [],
@@ -64,7 +72,10 @@ const heldBalances = {
   solana: { address: "sol1", solBalance: "0", solValueUsd: "2000", tokens: [] },
 };
 export const client = {
-  getWalletBalances: async () => (held ? heldBalances : { evm: null, solana: null }),
+  getWalletBalances: async () => {
+    if (unavailable) throw new Error("balances 503");
+    return held ? heldBalances : { evm: null, solana: null };
+  },
   getWalletMarketOverview: async () => overview,
 };
 `,
@@ -137,6 +148,9 @@ try {
     `DEFAULT state shows BTC/SOL/ETH rows (got ${JSON.stringify(defaultRows)})`,
   );
   await page.screenshot({ path: join(outDir, "wallet-default.png") });
+  await page
+    .locator('[data-testid="chat-widget-wallet-prices"]')
+    .screenshot({ path: join(outDir, "wallet-default-card.png") });
   console.log("  📸 wallet-default.png");
 
   // HELD state — top-3 priced holdings by holding value: ETH $5000, SOL $2000, USDC $800.
@@ -165,7 +179,26 @@ try {
     "HELD state leaks no holding values (price-only #10706)",
   );
   await page.screenshot({ path: join(outDir, "wallet-held.png") });
+  await page
+    .locator('[data-testid="chat-widget-wallet-prices"]')
+    .screenshot({ path: join(outDir, "wallet-held-card.png") });
   console.log("  📸 wallet-held.png");
+
+  // Market prices alone cannot prove whether the wallet has holdings.
+  await page.goto(`file://${htmlPath}?state=unavailable`);
+  await page.waitForSelector('[data-testid="wallet-state-label"]', {
+    timeout: 8000,
+  });
+  await page.waitForTimeout(100);
+  const unavailableRows = await page
+    .locator('[data-testid^="wallet-price-row-"]')
+    .count();
+  assert(
+    unavailableRows === 0,
+    `UNAVAILABLE state shows no fabricated default rows (got ${unavailableRows})`,
+  );
+  await page.screenshot({ path: join(outDir, "wallet-unavailable.png") });
+  console.log("  📸 wallet-unavailable.png");
 
   assert(errors.length === 0, `no page errors (${errors.length})`);
   for (const e of errors) console.log("  ERR:", e);
@@ -173,6 +206,102 @@ try {
 } finally {
   await browser.close();
 }
+
+const visualStates = [
+  {
+    state: "default",
+    image: "wallet-default.png",
+    ocrImages: ["wallet-default.png", "wallet-default-card.png"],
+    present: ["DEFAULT", "Wallet", "BTC", "SOL", "ETH"],
+    absent: ["UNAVAILABLE"],
+  },
+  {
+    state: "held",
+    image: "wallet-held.png",
+    ocrImages: ["wallet-held.png", "wallet-held-card.png"],
+    present: ["HELD", "Wallet", "ETH", "SOL", "USDC"],
+    absent: ["UNAVAILABLE"],
+  },
+  {
+    state: "unavailable",
+    image: "wallet-unavailable.png",
+    ocrImages: ["wallet-unavailable.png"],
+    present: ["UNAVAILABLE", "holdings unknown"],
+    absent: ["Wallet", "BTC", "SOL", "ETH", "USDC"],
+  },
+];
+const visualAnalysis = [];
+try {
+  for (const spec of visualStates) {
+    const imagePath = join(outDir, spec.image);
+    const [ocrParts, palette] = await Promise.all([
+      Promise.all(
+        spec.ocrImages.map((image) =>
+          ocrImage(join(outDir, image), { timeoutMs: 60_000 }),
+        ),
+      ),
+      dominantColorsFromPng(imagePath),
+    ]);
+    const ocr = {
+      available: ocrParts.every((part) => part.available),
+      parts: ocrParts,
+      text: ocrParts
+        .filter((part) => part.available)
+        .map((part) => part.text)
+        .join("\n"),
+    };
+    const normalizedText = ocr.text.toLowerCase();
+    const missing = spec.present.filter(
+      (value) => !normalizedText.includes(value.toLowerCase()),
+    );
+    const unexpected = spec.absent.filter((value) =>
+      normalizedText.includes(value.toLowerCase()),
+    );
+    const orangeCoverage = palette.buckets.orange ?? 0;
+    const blueCoverage = palette.buckets.blue ?? 0;
+    assert(ocr.available, `${spec.state} OCR is available`);
+    assert(
+      missing.length === 0,
+      `${spec.state} OCR contains expected text (missing ${JSON.stringify(missing)})`,
+    );
+    assert(
+      unexpected.length === 0,
+      `${spec.state} OCR excludes other-state text (found ${JSON.stringify(unexpected)})`,
+    );
+    assert(
+      orangeCoverage >= 0.65,
+      `${spec.state} keeps the orange home field (${(orangeCoverage * 100).toFixed(1)}%)`,
+    );
+    assert(
+      blueCoverage <= 0.01,
+      `${spec.state} contains no blue palette bleed (${(blueCoverage * 100).toFixed(1)}%)`,
+    );
+    visualAnalysis.push({
+      ...spec,
+      ocr,
+      palette,
+      verdict: {
+        missing,
+        unexpected,
+        orangeCoverage,
+        blueCoverage,
+        pass:
+          ocr.available &&
+          missing.length === 0 &&
+          unexpected.length === 0 &&
+          orangeCoverage >= 0.65 &&
+          blueCoverage <= 0.01,
+      },
+    });
+  }
+} finally {
+  await closeOcrEngines();
+}
+await writeFile(
+  join(outDir, "wallet-visual-analysis.json"),
+  `${JSON.stringify(visualAnalysis, null, 2)}\n`,
+);
+console.log("  📊 wallet-visual-analysis.json");
 
 if (failures > 0) {
   console.error(`\n${failures} assertion(s) FAILED`);

--- a/packages/ui/src/components/chat/widgets/__e2e__/run-wallet-widget-e2e.mjs
+++ b/packages/ui/src/components/chat/widgets/__e2e__/run-wallet-widget-e2e.mjs
@@ -186,7 +186,7 @@ try {
 
   // Market prices alone cannot prove whether the wallet has holdings.
   await page.goto(`file://${htmlPath}?state=unavailable`);
-  await page.waitForSelector('[data-testid="wallet-state-label"]', {
+  await page.waitForSelector('[data-testid="chat-widget-wallet-unavailable"]', {
     timeout: 8000,
   });
   await page.waitForTimeout(100);
@@ -198,6 +198,9 @@ try {
     `UNAVAILABLE state shows no fabricated default rows (got ${unavailableRows})`,
   );
   await page.screenshot({ path: join(outDir, "wallet-unavailable.png") });
+  await page
+    .locator('[data-testid="chat-widget-wallet-unavailable"]')
+    .screenshot({ path: join(outDir, "wallet-unavailable-card.png") });
   console.log("  📸 wallet-unavailable.png");
 
   assert(errors.length === 0, `no page errors (${errors.length})`);
@@ -225,9 +228,9 @@ const visualStates = [
   {
     state: "unavailable",
     image: "wallet-unavailable.png",
-    ocrImages: ["wallet-unavailable.png"],
-    present: ["UNAVAILABLE", "holdings unknown"],
-    absent: ["Wallet", "BTC", "SOL", "ETH", "USDC"],
+    ocrImages: ["wallet-unavailable.png", "wallet-unavailable-card.png"],
+    present: ["UNAVAILABLE", "holdings unknown", "Wallet"],
+    absent: ["BTC", "SOL", "ETH", "USDC"],
   },
 ];
 const visualAnalysis = [];

--- a/packages/ui/src/components/chat/widgets/__e2e__/wallet-widget-fixture.tsx
+++ b/packages/ui/src/components/chat/widgets/__e2e__/wallet-widget-fixture.tsx
@@ -2,15 +2,15 @@
  * Render fixture for the WALLET home widget (#14344). Mounts the REAL
  * `WalletBalanceWidget` on an orange home-like field so the screenshot harness
  * can capture both states in a real browser without an app server: the
- * no-holdings DEFAULT state (BTC/SOL/ETH price rows) and the HELD state (top-3
- * held by holding value, price-only). The state is chosen by `?state=held` in
- * the URL; the `../../../api` client is stubbed by the runner to return the
- * matching balances/overview.
+ * no-holdings DEFAULT state (BTC/SOL/ETH price rows), the HELD state (top-3
+ * held by holding value, price-only), and the UNAVAILABLE state where a failed
+ * balance request must not look like an empty wallet. The state is chosen by
+ * the URL; the runner stubs `../../../api` with the matching response.
  */
 import { createRoot } from "react-dom/client";
 import { WalletBalanceWidget } from "../wallet-balance";
 
-const held = new URLSearchParams(location.search).get("state") === "held";
+const state = new URLSearchParams(location.search).get("state");
 
 const root = createRoot(document.getElementById("root") as HTMLElement);
 root.render(
@@ -35,7 +35,11 @@ root.render(
           textAlign: "center",
         }}
       >
-        {held ? "HELD — top-3 by holding value" : "DEFAULT — no holdings"}
+        {state === "held"
+          ? "HELD — top-3 by holding value"
+          : state === "unavailable"
+            ? "UNAVAILABLE — holdings unknown"
+            : "DEFAULT — no holdings"}
       </div>
       <div className="grid grid-cols-2 gap-2">
         <WalletBalanceWidget spanClassName="col-span-2 row-span-1" />

--- a/packages/ui/src/components/chat/widgets/wallet-balance.test.tsx
+++ b/packages/ui/src/components/chat/widgets/wallet-balance.test.tsx
@@ -350,4 +350,18 @@ describe("WalletBalanceWidget (price-only, #10706)", () => {
     await waitFor(() => expect(getWalletMarketOverview).toHaveBeenCalled());
     await waitFor(() => expect(container.firstChild).toBeNull());
   });
+
+  it("does not render no-holdings defaults when balances are unavailable", async () => {
+    getWalletBalances.mockRejectedValue(new Error("balances 503"));
+    getWalletMarketOverview.mockResolvedValue(
+      overview([
+        { symbol: "BTC", priceUsd: 64000 },
+        { symbol: "SOL", priceUsd: 150 },
+        { symbol: "ETH", priceUsd: 3000 },
+      ]),
+    );
+    const { container } = render(<WalletBalanceWidget />);
+    await waitFor(() => expect(getWalletBalances).toHaveBeenCalled());
+    await waitFor(() => expect(container.firstChild).toBeNull());
+  });
 });

--- a/packages/ui/src/components/chat/widgets/wallet-balance.test.tsx
+++ b/packages/ui/src/components/chat/widgets/wallet-balance.test.tsx
@@ -242,8 +242,11 @@ describe("WalletBalanceWidget (price-only, #10706)", () => {
     expect(text).toContain("$3,000.00");
   });
 
-  it("shows BTC/SOL/ETH default rows when balances fail but prices load", async () => {
-    getWalletBalances.mockRejectedValue(new Error("balances 503"));
+  it("keeps the last-good rows when a later balance refresh fails", async () => {
+    vi.useFakeTimers();
+    getWalletBalances
+      .mockResolvedValueOnce({ evm: null, solana: null })
+      .mockRejectedValue(new Error("balances 503"));
     getWalletMarketOverview.mockResolvedValue(
       overview([
         { symbol: "BTC", priceUsd: 64000, change24hPct: 1.2 },
@@ -253,10 +256,14 @@ describe("WalletBalanceWidget (price-only, #10706)", () => {
     );
 
     render(<WalletBalanceWidget />);
-
-    await waitFor(() =>
-      expect(screen.getByTestId("chat-widget-wallet-prices")).toBeTruthy(),
-    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(screen.getByTestId("chat-widget-wallet-prices")).toBeTruthy();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    expect(getWalletBalances).toHaveBeenCalledTimes(2);
     expect(
       screen.getAllByTestId(/^wallet-price-row-/).map((r) => r.dataset.testid),
     ).toEqual([
@@ -264,6 +271,20 @@ describe("WalletBalanceWidget (price-only, #10706)", () => {
       "wallet-price-row-SOL",
       "wallet-price-row-ETH",
     ]);
+  });
+
+  it("does not render no-holdings defaults when balances are unavailable", async () => {
+    getWalletBalances.mockRejectedValue(new Error("balances 503"));
+    getWalletMarketOverview.mockResolvedValue(
+      overview([
+        { symbol: "BTC", priceUsd: 64000, change24hPct: 1.2 },
+        { symbol: "ETH", priceUsd: 3000, change24hPct: -0.5 },
+        { symbol: "SOL", priceUsd: 150, change24hPct: 2.1 },
+      ]),
+    );
+    const { container } = render(<WalletBalanceWidget />);
+    await waitFor(() => expect(getWalletBalances).toHaveBeenCalled());
+    await waitFor(() => expect(container.firstChild).toBeNull());
   });
 
   it("refreshes prices on the 60s visibility-gated interval (#14344)", async () => {
@@ -348,20 +369,6 @@ describe("WalletBalanceWidget (price-only, #10706)", () => {
     getWalletMarketOverview.mockRejectedValue(new Error("overview 503"));
     const { container } = render(<WalletBalanceWidget />);
     await waitFor(() => expect(getWalletMarketOverview).toHaveBeenCalled());
-    await waitFor(() => expect(container.firstChild).toBeNull());
-  });
-
-  it("does not render no-holdings defaults when balances are unavailable", async () => {
-    getWalletBalances.mockRejectedValue(new Error("balances 503"));
-    getWalletMarketOverview.mockResolvedValue(
-      overview([
-        { symbol: "BTC", priceUsd: 64000 },
-        { symbol: "SOL", priceUsd: 150 },
-        { symbol: "ETH", priceUsd: 3000 },
-      ]),
-    );
-    const { container } = render(<WalletBalanceWidget />);
-    await waitFor(() => expect(getWalletBalances).toHaveBeenCalled());
     await waitFor(() => expect(container.firstChild).toBeNull());
   });
 });

--- a/packages/ui/src/components/chat/widgets/wallet-balance.test.tsx
+++ b/packages/ui/src/components/chat/widgets/wallet-balance.test.tsx
@@ -282,9 +282,14 @@ describe("WalletBalanceWidget (price-only, #10706)", () => {
         { symbol: "SOL", priceUsd: 150, change24hPct: 2.1 },
       ]),
     );
-    const { container } = render(<WalletBalanceWidget />);
+    render(<WalletBalanceWidget />);
     await waitFor(() => expect(getWalletBalances).toHaveBeenCalled());
-    await waitFor(() => expect(container.firstChild).toBeNull());
+    const unavailable = await screen.findByTestId(
+      "chat-widget-wallet-unavailable",
+    );
+    expect(unavailable.textContent).toContain("Wallet");
+    expect(unavailable.textContent).toContain("Unavailable");
+    expect(screen.queryAllByTestId(/^wallet-price-row-/)).toHaveLength(0);
   });
 
   it("refreshes prices on the 60s visibility-gated interval (#14344)", async () => {
@@ -363,12 +368,13 @@ describe("WalletBalanceWidget (price-only, #10706)", () => {
     ).toContain("$70,000.00");
   });
 
-  it("hides (no error chrome) when the overview is unavailable", async () => {
-    // Overview down → no prices at all → the widget self-hides on the home.
+  it("renders unavailable when the overview cannot load", async () => {
     getWalletBalances.mockResolvedValue({ evm: null, solana: null });
     getWalletMarketOverview.mockRejectedValue(new Error("overview 503"));
-    const { container } = render(<WalletBalanceWidget />);
+    render(<WalletBalanceWidget />);
     await waitFor(() => expect(getWalletMarketOverview).toHaveBeenCalled());
-    await waitFor(() => expect(container.firstChild).toBeNull());
+    expect(
+      await screen.findByTestId("chat-widget-wallet-unavailable"),
+    ).toBeTruthy();
   });
 });

--- a/packages/ui/src/components/chat/widgets/wallet-balance.tsx
+++ b/packages/ui/src/components/chat/widgets/wallet-balance.tsx
@@ -3,13 +3,11 @@
  * showing crypto **unit prices only** - never the amount held or the holding
  * value (#10706). Tapping opens the wallet view.
  *
- * Two states once both wallet balances and prices load (#14344): when the user
- * holds ≥1 priced token worth ≥ $1, the top-3 held by holding value; otherwise
- * the tracked BTC/SOL/ETH default rows (back-filled from trending movers if the
- * overview is partial). Prices refresh on a 60s document-visibility-gated
- * interval - no polling while the app is backgrounded. It self-hides when
- * either response is unavailable because unknown holdings are not an empty
- * wallet; the wallet view owns the explicit error state (J4).
+ * Three states keep loading, unavailable data, and confirmed holdings distinct.
+ * Once balances and prices load, the widget shows either the top-3 held tokens
+ * worth ≥ $1 or tracked BTC/SOL/ETH defaults for a confirmed-empty wallet.
+ * Prices refresh on a 60s document-visibility-gated interval; an unavailable
+ * first load renders a compact route to the wallet's detailed error state.
  */
 
 import type { WalletBalancesResponse } from "@elizaos/shared";
@@ -36,6 +34,11 @@ const REFRESH_INTERVAL_MS = 60_000;
 const DEFAULT_SPAN = "col-span-2 row-span-1";
 
 type RefreshResult<T> = { ok: true; value: T } | { ok: false };
+
+type WalletDisplayState =
+  | { status: "loading" }
+  | { status: "unavailable" }
+  | { status: "ready"; holdings: PricedHolding[] };
 
 /** Format a unit price: more decimals for sub-dollar assets, 2 for the rest. */
 function formatPrice(priceUsd: number): string {
@@ -65,8 +68,9 @@ export function WalletBalanceWidget(
   props: Partial<WidgetProps>,
 ): React.JSX.Element | null {
   const spanClassName = props.spanClassName ?? DEFAULT_SPAN;
-  const [holdings, setHoldings] = useState<PricedHolding[] | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [displayState, setDisplayState] = useState<WalletDisplayState>({
+    status: "loading",
+  });
   const nav = useWidgetNavigation();
   // Auth gate (#11084): the widget mounts before the auth probe resolves, so
   // fetching stays dormant until the session is authenticated.
@@ -84,8 +88,7 @@ export function WalletBalanceWidget(
   useEffect(() => {
     if (authenticated) return;
     refreshSeqRef.current += 1;
-    setHoldings(null);
-    setLoading(true);
+    setDisplayState({ status: "loading" });
   }, [authenticated]);
 
   // Prices (BTC/SOL/ETH + trending) come from the market-overview endpoint;
@@ -123,23 +126,24 @@ export function WalletBalanceWidget(
         })),
     ]);
     if (!activeRef.current || seq !== refreshSeqRef.current) return;
-    const next =
-      overviewResult.ok && balancesResult.ok
-        ? (() => {
-            const held = selectPricedHoldings(
-              balancesResult.value,
-              overviewResult.value.prices,
-            );
-            return held.length > 0
-              ? held
-              : selectDefaultPriceRows(overviewResult.value);
-          })()
-        : [];
-    // A failed refresh (next empty) keeps the last-good rows so a transient
-    // outage does not flicker the tile out; only a first load with no prices
-    // resolves to empty (→ hidden).
-    setHoldings((prev) => (next.length > 0 ? next : (prev ?? [])));
-    setLoading(false);
+    if (!overviewResult.ok || !balancesResult.ok) {
+      // A transient failure keeps a prior ready state. On first load, J4
+      // requires a visible unavailable state rather than loading forever or
+      // fabricating an empty wallet.
+      setDisplayState((previous) =>
+        previous.status === "ready" ? previous : { status: "unavailable" },
+      );
+      return;
+    }
+    const held = selectPricedHoldings(
+      balancesResult.value,
+      overviewResult.value.prices,
+    );
+    setDisplayState({
+      status: "ready",
+      holdings:
+        held.length > 0 ? held : selectDefaultPriceRows(overviewResult.value),
+    });
   }, []);
 
   useEffect(() => {
@@ -159,7 +163,7 @@ export function WalletBalanceWidget(
   if (!authenticated) return null;
 
   // First load pending: a quiet placeholder keeps the grid cell stable.
-  if (loading && holdings == null) {
+  if (displayState.status === "loading") {
     return (
       <div
         data-testid="chat-widget-wallet-balance-loading"
@@ -169,9 +173,26 @@ export function WalletBalanceWidget(
     );
   }
 
-  // Prices unavailable (overview never loaded / both endpoints down) → render
-  // nothing rather than error chrome on the home surface (J4).
-  if (!holdings || holdings.length === 0) return null;
+  if (displayState.status === "unavailable") {
+    return (
+      <Button
+        data-testid="chat-widget-wallet-unavailable"
+        aria-label="Wallet data unavailable. Open wallet."
+        onClick={() => nav.openView("/wallet", "wallet")}
+        variant="ghost"
+        className={`${spanClassName} ${HOME_WIDGET_SOLID_TILE_CLASS} items-center justify-between gap-3 px-3 py-2.5 font-normal transition-[background-color,border-color,opacity] hover:border-[color:color-mix(in_srgb,var(--brand-white)_34%,var(--brand-black))] hover:bg-[var(--brand-black)] hover:opacity-90`}
+      >
+        <span className="flex items-center gap-2 text-xs text-[color:color-mix(in_srgb,var(--brand-white)_68%,transparent)] [&>svg]:h-3.5 [&>svg]:w-3.5">
+          <Wallet />
+          Wallet
+        </span>
+        <span className="text-xs text-[var(--brand-white)]">Unavailable</span>
+      </Button>
+    );
+  }
+
+  const { holdings } = displayState;
+  if (holdings.length === 0) return null;
 
   return (
     <Button

--- a/packages/ui/src/components/chat/widgets/wallet-balance.tsx
+++ b/packages/ui/src/components/chat/widgets/wallet-balance.tsx
@@ -35,6 +35,8 @@ const REFRESH_INTERVAL_MS = 60_000;
 
 const DEFAULT_SPAN = "col-span-2 row-span-1";
 
+type RefreshResult<T> = { ok: true; value: T } | { ok: false; error: unknown };
+
 /** Format a unit price: more decimals for sub-dollar assets, 2 for the rest. */
 function formatPrice(priceUsd: number): string {
   const digits = priceUsd > 0 && priceUsd < 1 ? 6 : 2;
@@ -88,22 +90,53 @@ export function WalletBalanceWidget(
 
   // Prices (BTC/SOL/ETH + trending) come from the market-overview endpoint;
   // balances decide the held-vs-default branch. Both are fetched together and
-  // best-effort (J4): a null overview means prices are unavailable → hide; a
-  // null balances alone still shows the default rows.
+  // best-effort (J4): either unavailable response hides the initial tile rather
+  // than presenting an unknown wallet as an empty wallet.
   const refresh = useCallback(async () => {
     refreshSeqRef.current += 1;
     const seq = refreshSeqRef.current;
-    const [balances, overview] = await Promise.all([
-      // error-policy:J4 balances failure ⇒ no held rows; default rows still show
-      (client.getWalletBalances() as Promise<WalletBalancesResponse>).catch(
-        () => null,
-      ),
-      // error-policy:J4 overview failure ⇒ no prices at all ⇒ widget hides
-      client.getWalletMarketOverview().catch(() => null),
+    const [balancesResult, overviewResult] = await Promise.all([
+      (client.getWalletBalances() as Promise<WalletBalancesResponse>)
+        .then<RefreshResult<WalletBalancesResponse>>((value) => ({
+          ok: true,
+          value,
+        }))
+        .catch<RefreshResult<WalletBalancesResponse>>((error) => ({
+          // error-policy:J4 balances unavailable means holdings are unknown; do
+          // not fabricate "empty wallet" default rows.
+          ok: false,
+          error,
+        })),
+      client
+        .getWalletMarketOverview()
+        .then<
+          RefreshResult<
+            Awaited<ReturnType<typeof client.getWalletMarketOverview>>
+          >
+        >((value) => ({ ok: true, value }))
+        .catch<
+          RefreshResult<
+            Awaited<ReturnType<typeof client.getWalletMarketOverview>>
+          >
+        >((error) => ({
+          // error-policy:J4 overview failure ⇒ no prices at all ⇒ widget hides
+          ok: false,
+          error,
+        })),
     ]);
     if (!activeRef.current || seq !== refreshSeqRef.current) return;
-    const held = selectPricedHoldings(balances, overview?.prices);
-    const next = held.length > 0 ? held : selectDefaultPriceRows(overview);
+    const next =
+      overviewResult.ok && balancesResult.ok
+        ? (() => {
+            const held = selectPricedHoldings(
+              balancesResult.value,
+              overviewResult.value.prices,
+            );
+            return held.length > 0
+              ? held
+              : selectDefaultPriceRows(overviewResult.value);
+          })()
+        : [];
     // A failed refresh (next empty) keeps the last-good rows so a transient
     // outage does not flicker the tile out; only a first load with no prices
     // resolves to empty (→ hidden).

--- a/packages/ui/src/components/chat/widgets/wallet-balance.tsx
+++ b/packages/ui/src/components/chat/widgets/wallet-balance.tsx
@@ -3,13 +3,13 @@
  * showing crypto **unit prices only** - never the amount held or the holding
  * value (#10706). Tapping opens the wallet view.
  *
- * Two states, always visible once prices load (#14344): when the user holds ≥1
- * priced token worth ≥ $1, the top-3 held by holding value; otherwise the
- * tracked BTC/SOL/ETH default rows (back-filled from trending movers if the
+ * Two states once both wallet balances and prices load (#14344): when the user
+ * holds ≥1 priced token worth ≥ $1, the top-3 held by holding value; otherwise
+ * the tracked BTC/SOL/ETH default rows (back-filled from trending movers if the
  * overview is partial). Prices refresh on a 60s document-visibility-gated
- * interval - no polling while the app is backgrounded. It self-hides only when
- * prices are unavailable (both endpoints down / never loaded): the home surface
- * shows no error chrome; the wallet view owns error state (J4).
+ * interval - no polling while the app is backgrounded. It self-hides when
+ * either response is unavailable because unknown holdings are not an empty
+ * wallet; the wallet view owns the explicit error state (J4).
  */
 
 import type { WalletBalancesResponse } from "@elizaos/shared";
@@ -35,7 +35,7 @@ const REFRESH_INTERVAL_MS = 60_000;
 
 const DEFAULT_SPAN = "col-span-2 row-span-1";
 
-type RefreshResult<T> = { ok: true; value: T } | { ok: false; error: unknown };
+type RefreshResult<T> = { ok: true; value: T } | { ok: false };
 
 /** Format a unit price: more decimals for sub-dollar assets, 2 for the rest. */
 function formatPrice(priceUsd: number): string {
@@ -101,11 +101,10 @@ export function WalletBalanceWidget(
           ok: true,
           value,
         }))
-        .catch<RefreshResult<WalletBalancesResponse>>((error) => ({
+        .catch<RefreshResult<WalletBalancesResponse>>(() => ({
           // error-policy:J4 balances unavailable means holdings are unknown; do
           // not fabricate "empty wallet" default rows.
           ok: false,
-          error,
         })),
       client
         .getWalletMarketOverview()
@@ -118,10 +117,9 @@ export function WalletBalanceWidget(
           RefreshResult<
             Awaited<ReturnType<typeof client.getWalletMarketOverview>>
           >
-        >((error) => ({
+        >(() => ({
           // error-policy:J4 overview failure ⇒ no prices at all ⇒ widget hides
           ok: false,
-          error,
         })),
     ]);
     if (!activeRef.current || seq !== refreshSeqRef.current) return;


### PR DESCRIPTION
Closes #15771. Follow-up to #14344.

## Summary

- represent wallet balance and market refreshes as explicit success/failure results
- render a compact unavailable home tile when holdings are unknown instead of fabricating the confirmed-empty BTC/SOL/ETH state
- preserve last-good rows across transient refresh failures
- certify confirmed-empty, held, and unavailable rendered states in Chromium
- emit OCR and dominant-color analysis for every captured state

## Verification

- 25 focused wallet tests pass
- real-browser three-state fixture passes with zero page errors
- OCR expectations pass for all three states
- orange coverage is 83.4%, 83.4%, and 94.4%; blue bleed is 0%
- UI package typecheck passes
- UI lint check completes with pre-existing warnings only
- error-policy ratchet passes

## Manual visual review

I opened every screenshot and reviewed it. Before the fix, an actual balance 503 on `develop` renders the healthy `DEFAULT — no holdings` card. After the fix, confirmed-empty and held wallets retain their intended compact cards, while the balance-unavailable state renders a distinct compact Wallet / Unavailable tile with no fabricated token data. All three after states use the orange home field with no blue accents or clipping.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshot — actual `develop` balance-503 path: ![before unavailable](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15774-wallet-before-unavailable.jpg)

<!-- evidence-row:after-screenshots -->
- [x] After screenshots — confirmed empty: ![confirmed empty](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15774-wallet-default.jpg)
- [x] After screenshots — held: ![held](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15774-wallet-held.jpg)
- [x] After screenshots — unavailable: ![unavailable](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15774-wallet-unavailable.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] [Six-second rendered-state walkthrough (MP4)](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15774-wallet-states.mp4)

<!-- evidence-row:backend-logs -->
- [ ] N/A - client-only display policy; no backend path changed.

<!-- evidence-row:frontend-logs -->
- [x] [Real-browser console and verification log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15774-wallet-e2e.log) records all state assertions and zero page errors.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, prompt, provider, model, or action behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] [Machine-readable OCR and palette analysis](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15774-wallet-visual-analysis.json)

<!-- evidence-row:ocr-review -->
- [x] [OCR report](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15774-wallet-visual-analysis.json) reads the expected state labels and token rows; the unavailable tile reads Wallet/UNAVAILABLE/holdings unknown and excludes BTC/SOL/ETH/USDC.

