### PR TITLE
fix(plugin-openrouter): restore Anthropic cache_control on all call paths

### DIFF
--- a/packages/core/src/__tests__/dynamic-cache-plan-merge.test.ts
+++ b/packages/core/src/__tests__/dynamic-cache-plan-merge.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Unit tests for the providerOptions deep-merge semantics embedded in
+ * AgentRuntime.dynamicPromptExecFromState (runtime.ts). The merge logic is exercised
+ * directly here so the behavioral invariant — "caller options survive alongside cache
+ * plan additions, with one-level-deep provider-namespace merging" — is verifiable
+ * without a full runtime setup. The helper below mirrors the exact merge code in
+ * dynamicPromptExecFromState; if that code changes shape, update here to match.
+ */
+import { describe, expect, it } from "vitest";
+
+// Mirrors the providerOptions merge logic in AgentRuntime.dynamicPromptExecFromState.
+function mergeWithCachePlan(
+  base: Record<string, unknown>,
+  callerOptions: Record<string, unknown> | undefined,
+  planOptions: Record<string, unknown>,
+): Record<string, unknown> {
+  const merged: Record<string, unknown> = { ...base, ...(callerOptions ?? {}) };
+  for (const [key, planValue] of Object.entries(planOptions)) {
+    const existing = merged[key];
+    merged[key] =
+      existing != null &&
+      typeof existing === "object" &&
+      !Array.isArray(existing) &&
+      planValue != null &&
+      typeof planValue === "object" &&
+      !Array.isArray(planValue)
+        ? {
+            ...(existing as Record<string, unknown>),
+            ...(planValue as Record<string, unknown>),
+          }
+        : planValue;
+  }
+  return merged;
+}
+
+describe("dynamicPromptExecFromState — providerOptions deep-merge", () => {
+  it("caller nested provider fields survive alongside cache-plan additions", () => {
+    const result = mergeWithCachePlan(
+      { agentName: "Bot" },
+      { anthropic: { thinking: { type: "enabled", budgetTokens: 1024 } } },
+      { anthropic: { cacheControl: { type: "ephemeral" } } },
+    );
+
+    expect(result.agentName).toBe("Bot");
+    const anthropic = result.anthropic as Record<string, unknown>;
+    expect(anthropic.thinking).toEqual({ type: "enabled", budgetTokens: 1024 });
+    expect(anthropic.cacheControl).toEqual({ type: "ephemeral" });
+  });
+
+  it("cache-plan nested field overwrites caller on key collision within a provider namespace", () => {
+    const result = mergeWithCachePlan(
+      { agentName: "Bot" },
+      { anthropic: { cacheControl: { type: "ephemeral", ttl: "5m" } } },
+      { anthropic: { cacheControl: { type: "ephemeral", ttl: "1h" } } },
+    );
+
+    const anthropic = result.anthropic as Record<string, unknown>;
+    expect((anthropic.cacheControl as Record<string, unknown>).ttl).toBe("1h");
+  });
+
+  it("top-level non-object plan values replace caller values", () => {
+    const result = mergeWithCachePlan(
+      { agentName: "Bot" },
+      { openrouter: { promptCacheKey: "old" } },
+      { openrouter: { promptCacheKey: "new", prompt_cache_key: "new" } },
+    );
+
+    const openrouter = result.openrouter as Record<string, unknown>;
+    expect(openrouter.promptCacheKey).toBe("new");
+    expect(openrouter.prompt_cache_key).toBe("new");
+  });
+
+  it("caller top-level provider namespaces not in the plan survive untouched", () => {
+    const result = mergeWithCachePlan(
+      { agentName: "Bot" },
+      { gateway: { caching: "auto" }, openai: { promptCacheKey: "abc" } },
+      { anthropic: { cacheControl: { type: "ephemeral" } } },
+    );
+
+    expect(result.gateway).toEqual({ caching: "auto" });
+    expect(result.openai).toEqual({ promptCacheKey: "abc" });
+    expect((result.anthropic as Record<string, unknown>).cacheControl).toEqual({
+      type: "ephemeral",
+    });
+  });
+
+  it("empty caller options still receive the full cache plan", () => {
+    const result = mergeWithCachePlan(
+      { agentName: "Bot" },
+      undefined,
+      {
+        anthropic: { cacheControl: { type: "ephemeral" } },
+        openrouter: { promptCacheKey: "x" },
+      },
+    );
+
+    expect(result.agentName).toBe("Bot");
+    expect(result.anthropic).toBeDefined();
+    expect(result.openrouter).toBeDefined();
+  });
+
+  it("agentName from base is not overwritten by caller or plan values", () => {
+    const result = mergeWithCachePlan(
+      { agentName: "RealBot" },
+      { agentName: "CallerOverride" },
+      { agentName: "PlanOverride" },
+    );
+
+    // Caller spreads over base, plan overwrites caller at top-level for scalars.
+    // Plan's agentName wins when it conflicts.
+    expect(result.agentName).toBe("PlanOverride");
+  });
+
+  it("array values in plan replace (not merge) the corresponding caller value", () => {
+    const result = mergeWithCachePlan(
+      { agentName: "Bot" },
+      { tags: ["a", "b"] },
+      { tags: ["c"] },
+    );
+
+    // Arrays are not object-merged — plan replaces
+    expect(result.tags).toEqual(["c"]);
+  });
+});

--- a/packages/core/src/__tests__/dynamic-cache-plan-merge.test.ts
+++ b/packages/core/src/__tests__/dynamic-cache-plan-merge.test.ts
@@ -1,124 +1,94 @@
 /**
- * Unit tests for the providerOptions deep-merge semantics embedded in
- * AgentRuntime.dynamicPromptExecFromState (runtime.ts). The merge logic is exercised
- * directly here so the behavioral invariant — "caller options survive alongside cache
- * plan additions, with one-level-deep provider-namespace merging" — is verifiable
- * without a full runtime setup. The helper below mirrors the exact merge code in
- * dynamicPromptExecFromState; if that code changes shape, update here to match.
+ * Tests for mergeProviderOptionsWithCachePlan — the exported helper used by
+ * dynamicPromptExecFromState to merge per-call providerOptions with the PromptBatcher
+ * cache plan. Imports the real function so regressions in runtime.ts are caught here.
  */
 import { describe, expect, it } from "vitest";
+import { mergeProviderOptionsWithCachePlan } from "../runtime";
 
-// Mirrors the providerOptions merge logic in AgentRuntime.dynamicPromptExecFromState.
-function mergeWithCachePlan(
-  base: Record<string, unknown>,
-  callerOptions: Record<string, unknown> | undefined,
-  planOptions: Record<string, unknown>,
-): Record<string, unknown> {
-  const merged: Record<string, unknown> = { ...base, ...(callerOptions ?? {}) };
-  for (const [key, planValue] of Object.entries(planOptions)) {
-    const existing = merged[key];
-    merged[key] =
-      existing != null &&
-      typeof existing === "object" &&
-      !Array.isArray(existing) &&
-      planValue != null &&
-      typeof planValue === "object" &&
-      !Array.isArray(planValue)
-        ? {
-            ...(existing as Record<string, unknown>),
-            ...(planValue as Record<string, unknown>),
-          }
-        : planValue;
-  }
-  return merged;
-}
+describe("mergeProviderOptionsWithCachePlan", () => {
+	it("caller nested provider fields survive alongside cache-plan additions", () => {
+		const result = mergeProviderOptionsWithCachePlan(
+			{ agentName: "Bot" },
+			{ anthropic: { thinking: { type: "enabled", budgetTokens: 1024 } } },
+			{ anthropic: { cacheControl: { type: "ephemeral" } } },
+		);
 
-describe("dynamicPromptExecFromState — providerOptions deep-merge", () => {
-  it("caller nested provider fields survive alongside cache-plan additions", () => {
-    const result = mergeWithCachePlan(
-      { agentName: "Bot" },
-      { anthropic: { thinking: { type: "enabled", budgetTokens: 1024 } } },
-      { anthropic: { cacheControl: { type: "ephemeral" } } },
-    );
+		expect(result.agentName).toBe("Bot");
+		const anthropic = result.anthropic as Record<string, unknown>;
+		expect(anthropic.thinking).toEqual({ type: "enabled", budgetTokens: 1024 });
+		expect(anthropic.cacheControl).toEqual({ type: "ephemeral" });
+	});
 
-    expect(result.agentName).toBe("Bot");
-    const anthropic = result.anthropic as Record<string, unknown>;
-    expect(anthropic.thinking).toEqual({ type: "enabled", budgetTokens: 1024 });
-    expect(anthropic.cacheControl).toEqual({ type: "ephemeral" });
-  });
+	it("cache-plan nested field overwrites caller on key collision within a provider namespace", () => {
+		const result = mergeProviderOptionsWithCachePlan(
+			{ agentName: "Bot" },
+			{ anthropic: { cacheControl: { type: "ephemeral", ttl: "5m" } } },
+			{ anthropic: { cacheControl: { type: "ephemeral", ttl: "1h" } } },
+		);
 
-  it("cache-plan nested field overwrites caller on key collision within a provider namespace", () => {
-    const result = mergeWithCachePlan(
-      { agentName: "Bot" },
-      { anthropic: { cacheControl: { type: "ephemeral", ttl: "5m" } } },
-      { anthropic: { cacheControl: { type: "ephemeral", ttl: "1h" } } },
-    );
+		const anthropic = result.anthropic as Record<string, unknown>;
+		expect((anthropic.cacheControl as Record<string, unknown>).ttl).toBe("1h");
+	});
 
-    const anthropic = result.anthropic as Record<string, unknown>;
-    expect((anthropic.cacheControl as Record<string, unknown>).ttl).toBe("1h");
-  });
+	it("top-level non-object plan values replace caller values", () => {
+		const result = mergeProviderOptionsWithCachePlan(
+			{ agentName: "Bot" },
+			{ openrouter: { promptCacheKey: "old" } },
+			{ openrouter: { promptCacheKey: "new", prompt_cache_key: "new" } },
+		);
 
-  it("top-level non-object plan values replace caller values", () => {
-    const result = mergeWithCachePlan(
-      { agentName: "Bot" },
-      { openrouter: { promptCacheKey: "old" } },
-      { openrouter: { promptCacheKey: "new", prompt_cache_key: "new" } },
-    );
+		const openrouter = result.openrouter as Record<string, unknown>;
+		expect(openrouter.promptCacheKey).toBe("new");
+		expect(openrouter.prompt_cache_key).toBe("new");
+	});
 
-    const openrouter = result.openrouter as Record<string, unknown>;
-    expect(openrouter.promptCacheKey).toBe("new");
-    expect(openrouter.prompt_cache_key).toBe("new");
-  });
+	it("caller top-level provider namespaces not in the plan survive untouched", () => {
+		const result = mergeProviderOptionsWithCachePlan(
+			{ agentName: "Bot" },
+			{ gateway: { caching: "auto" }, openai: { promptCacheKey: "abc" } },
+			{ anthropic: { cacheControl: { type: "ephemeral" } } },
+		);
 
-  it("caller top-level provider namespaces not in the plan survive untouched", () => {
-    const result = mergeWithCachePlan(
-      { agentName: "Bot" },
-      { gateway: { caching: "auto" }, openai: { promptCacheKey: "abc" } },
-      { anthropic: { cacheControl: { type: "ephemeral" } } },
-    );
+		expect(result.gateway).toEqual({ caching: "auto" });
+		expect(result.openai).toEqual({ promptCacheKey: "abc" });
+		expect((result.anthropic as Record<string, unknown>).cacheControl).toEqual({
+			type: "ephemeral",
+		});
+	});
 
-    expect(result.gateway).toEqual({ caching: "auto" });
-    expect(result.openai).toEqual({ promptCacheKey: "abc" });
-    expect((result.anthropic as Record<string, unknown>).cacheControl).toEqual({
-      type: "ephemeral",
-    });
-  });
+	it("undefined caller options still receive the full cache plan", () => {
+		const result = mergeProviderOptionsWithCachePlan(
+			{ agentName: "Bot" },
+			undefined,
+			{
+				anthropic: { cacheControl: { type: "ephemeral" } },
+				openrouter: { promptCacheKey: "x" },
+			},
+		);
 
-  it("empty caller options still receive the full cache plan", () => {
-    const result = mergeWithCachePlan(
-      { agentName: "Bot" },
-      undefined,
-      {
-        anthropic: { cacheControl: { type: "ephemeral" } },
-        openrouter: { promptCacheKey: "x" },
-      },
-    );
+		expect(result.agentName).toBe("Bot");
+		expect(result.anthropic).toBeDefined();
+		expect(result.openrouter).toBeDefined();
+	});
 
-    expect(result.agentName).toBe("Bot");
-    expect(result.anthropic).toBeDefined();
-    expect(result.openrouter).toBeDefined();
-  });
+	it("plan scalar value wins over caller and base on key collision", () => {
+		const result = mergeProviderOptionsWithCachePlan(
+			{ agentName: "RealBot" },
+			{ agentName: "CallerOverride" },
+			{ agentName: "PlanOverride" },
+		);
 
-  it("agentName from base is not overwritten by caller or plan values", () => {
-    const result = mergeWithCachePlan(
-      { agentName: "RealBot" },
-      { agentName: "CallerOverride" },
-      { agentName: "PlanOverride" },
-    );
+		expect(result.agentName).toBe("PlanOverride");
+	});
 
-    // Caller spreads over base, plan overwrites caller at top-level for scalars.
-    // Plan's agentName wins when it conflicts.
-    expect(result.agentName).toBe("PlanOverride");
-  });
+	it("array values in plan replace (not merge) the corresponding caller value", () => {
+		const result = mergeProviderOptionsWithCachePlan(
+			{ agentName: "Bot" },
+			{ tags: ["a", "b"] },
+			{ tags: ["c"] },
+		);
 
-  it("array values in plan replace (not merge) the corresponding caller value", () => {
-    const result = mergeWithCachePlan(
-      { agentName: "Bot" },
-      { tags: ["a", "b"] },
-      { tags: ["c"] },
-    );
-
-    // Arrays are not object-merged — plan replaces
-    expect(result.tags).toEqual(["c"]);
-  });
+		expect(result.tags).toEqual(["c"]);
+	});
 });

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -306,6 +306,9 @@ import {
 	StructuredFieldStreamExtractor,
 } from "./utils/streaming";
 import { isPlainObject } from "./utils/type-guards";
+import { computePrefixHashes } from "./runtime/context-hash";
+import { cachePrefixSegments } from "./runtime/context-renderer";
+import { buildProviderCachePlan } from "./runtime/provider-cache-plan";
 
 const environmentSettings: RuntimeSettings = {};
 // Whether debug-level logs are emitted, captured once at load (mirrors the
@@ -6880,6 +6883,17 @@ ${section_end}`;
 			);
 
 			// Pass promptSegments so providers can use cache hints when supported (Anthropic block cache, OpenAI/Gemini prefix).
+			// Build the full provider cache plan from the stable-prefix hash so providers like plugin-anthropic and
+			// plugin-openrouter can inject cache_control breakpoints without needing a separate planner call.
+			const _dynamicPrefixHashes = computePrefixHashes(segments);
+			const _dynamicCacheHash =
+				computePrefixHashes(cachePrefixSegments(segments)).at(-1)?.hash ??
+				"no-context-segments";
+			const _dynamicCachePlan = buildProviderCachePlan({
+				prefixHash: _dynamicCacheHash,
+				segmentHashes: _dynamicPrefixHashes.map((e) => e.segmentHash),
+				promptSegments: segments,
+			});
 			const modelParams = {
 				...params,
 				prompt,
@@ -6887,6 +6901,7 @@ ${section_end}`;
 				promptSegments: segments,
 				providerOptions: {
 					agentName: this.character.name,
+					..._dynamicCachePlan.providerOptions,
 				},
 				...(extractor
 					? {

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -523,6 +523,44 @@ export function resolveDynamicPromptStreamFields(
 		.map((row) => row.field);
 }
 
+/**
+ * Merges provider options from three sources: a base object (e.g. `{ agentName }`),
+ * optional caller-supplied options, and a cache-plan's options. Caller fields take
+ * precedence over base; plan fields take precedence over caller on key collision, but
+ * named provider sub-objects (e.g. `anthropic`, `openai`) are merged one level deep so
+ * caller-specific fields like `anthropic.thinking` survive alongside plan additions like
+ * `anthropic.cacheControl`.
+ *
+ * Exported so tests can import and exercise the real function rather than maintaining a
+ * hand-copied mirror that cannot catch regressions in this code path.
+ */
+export function mergeProviderOptionsWithCachePlan(
+	base: Record<string, JsonValue | object | undefined>,
+	callerOptions: Record<string, JsonValue | object | undefined> | undefined,
+	planOptions: Record<string, JsonValue | object | undefined>,
+): Record<string, JsonValue | object | undefined> {
+	const merged: Record<string, JsonValue | object | undefined> = {
+		...base,
+		...(callerOptions ?? {}),
+	};
+	for (const [key, planValue] of Object.entries(planOptions)) {
+		const existing = merged[key];
+		merged[key] =
+			existing != null &&
+			typeof existing === "object" &&
+			!Array.isArray(existing) &&
+			planValue != null &&
+			typeof planValue === "object" &&
+			!Array.isArray(planValue)
+				? {
+						...(existing as Record<string, unknown>),
+						...(planValue as Record<string, unknown>),
+					}
+				: planValue;
+	}
+	return merged;
+}
+
 function resolveResponseSkeletonStreamFields(
 	skeleton: ResponseSkeleton | undefined,
 ): string[] {
@@ -6894,40 +6932,24 @@ ${section_end}`;
 				segmentHashes: _dynamicPrefixHashes.map((e) => e.segmentHash),
 				promptSegments: segments,
 			});
-			// Deep-merge caller-supplied providerOptions with the cache plan so neither
-			// set of fields is overwritten. One-level merge for named provider sub-objects
-			// (e.g. anthropic, openai) preserves caller fields like anthropic.thinking
-			// alongside plan-added fields like cacheControl.
+			// Deep-merge caller-supplied providerOptions with the cache plan. See
+			// mergeProviderOptionsWithCachePlan for the full merging semantics.
 			const _rawCallerProviderOptions = (params as { providerOptions?: unknown }).providerOptions;
-			const _callerProviderOptions: Record<string, unknown> =
+			const _callerProviderOptions =
 				_rawCallerProviderOptions != null &&
 				typeof _rawCallerProviderOptions === "object" &&
 				!Array.isArray(_rawCallerProviderOptions)
-					? (_rawCallerProviderOptions as Record<string, unknown>)
-					: {};
+					? (_rawCallerProviderOptions as Record<string, JsonValue | object | undefined>)
+					: undefined;
 			const _planProviderOptions = (_dynamicCachePlan.providerOptions ?? {}) as Record<
 				string,
-				unknown
+				JsonValue | object | undefined
 			>;
-			const _mergedProviderOptions: Record<string, unknown> = {
-				agentName: this.character.name,
-				..._callerProviderOptions,
-			};
-			for (const [_pKey, _pValue] of Object.entries(_planProviderOptions)) {
-				const _pExisting = _mergedProviderOptions[_pKey];
-				_mergedProviderOptions[_pKey] =
-					_pExisting != null &&
-					typeof _pExisting === "object" &&
-					!Array.isArray(_pExisting) &&
-					_pValue != null &&
-					typeof _pValue === "object" &&
-					!Array.isArray(_pValue)
-						? {
-								...(_pExisting as Record<string, unknown>),
-								...(_pValue as Record<string, unknown>),
-							}
-						: _pValue;
-			}
+			const _mergedProviderOptions = mergeProviderOptionsWithCachePlan(
+				{ agentName: this.character.name },
+				_callerProviderOptions,
+				_planProviderOptions,
+			);
 			const modelParams = {
 				...params,
 				prompt,

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -6894,15 +6894,46 @@ ${section_end}`;
 				segmentHashes: _dynamicPrefixHashes.map((e) => e.segmentHash),
 				promptSegments: segments,
 			});
+			// Deep-merge caller-supplied providerOptions with the cache plan so neither
+			// set of fields is overwritten. One-level merge for named provider sub-objects
+			// (e.g. anthropic, openai) preserves caller fields like anthropic.thinking
+			// alongside plan-added fields like cacheControl.
+			const _rawCallerProviderOptions = (params as { providerOptions?: unknown }).providerOptions;
+			const _callerProviderOptions: Record<string, unknown> =
+				_rawCallerProviderOptions != null &&
+				typeof _rawCallerProviderOptions === "object" &&
+				!Array.isArray(_rawCallerProviderOptions)
+					? (_rawCallerProviderOptions as Record<string, unknown>)
+					: {};
+			const _planProviderOptions = (_dynamicCachePlan.providerOptions ?? {}) as Record<
+				string,
+				unknown
+			>;
+			const _mergedProviderOptions: Record<string, unknown> = {
+				agentName: this.character.name,
+				..._callerProviderOptions,
+			};
+			for (const [_pKey, _pValue] of Object.entries(_planProviderOptions)) {
+				const _pExisting = _mergedProviderOptions[_pKey];
+				_mergedProviderOptions[_pKey] =
+					_pExisting != null &&
+					typeof _pExisting === "object" &&
+					!Array.isArray(_pExisting) &&
+					_pValue != null &&
+					typeof _pValue === "object" &&
+					!Array.isArray(_pValue)
+						? {
+								...(_pExisting as Record<string, unknown>),
+								...(_pValue as Record<string, unknown>),
+							}
+						: _pValue;
+			}
 			const modelParams = {
 				...params,
 				prompt,
 				responseFormat: params.responseFormat ?? { type: "json_object" },
 				promptSegments: segments,
-				providerOptions: {
-					agentName: this.character.name,
-					..._dynamicCachePlan.providerOptions,
-				},
+				providerOptions: _mergedProviderOptions,
 				...(extractor
 					? {
 							onStreamChunk: (chunk: string) => {

--- a/plugins/plugin-openrouter/__tests__/anthropic-cache.shape.test.ts
+++ b/plugins/plugin-openrouter/__tests__/anthropic-cache.shape.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Shape tests for Anthropic prompt-cache injection in the OpenRouter text handler.
+ * Covers the runtime-fallback cacheControl (Fix 2), internal-field stripping from wire
+ * options (Fix 3a), segmented-user-content breakpoints with validated shapes and capping
+ * (Fix 3b/3c), and the cacheSystem:false opt-out. AI SDK and provider are mocked —
+ * no network calls, deterministic string fixtures.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+function createRuntime(settings: Record<string, string> = {}) {
+  return {
+    character: { system: "system prompt" },
+    emitEvent: vi.fn(async () => undefined),
+    getSetting: vi.fn((key: string) => {
+      return ({
+        OPENROUTER_API_KEY: "test-key",
+        OPENROUTER_LARGE_MODEL: "anthropic/claude-opus-4-8",
+        ...settings,
+      } as Record<string, string>)[key] ?? null;
+    }),
+  } as IAgentRuntime;
+}
+
+function mockModules() {
+  const generateText = vi.fn(async () => ({
+    text: "ok",
+    finishReason: "stop",
+    usage: { inputTokens: 5, outputTokens: 2, totalTokens: 7 },
+  }));
+  vi.doMock("ai", () => ({ generateText, streamText: vi.fn() }));
+  vi.doMock("../providers", () => ({
+    createOpenRouterProvider: () => ({ chat: (m: string) => ({ modelName: m }) }),
+  }));
+  return { generateText };
+}
+
+afterEach(() => {
+  vi.doUnmock("ai");
+  vi.doUnmock("../providers");
+  vi.clearAllMocks();
+  vi.resetModules();
+});
+
+describe("Anthropic cache injection — runtime cacheControl fallback", () => {
+  it("injects ephemeral cacheControl on system message for Anthropic models even without explicit providerOptions", async () => {
+    const { generateText } = mockModules();
+    const { handleTextLarge } = await import("../models/text");
+
+    await handleTextLarge(createRuntime(), { prompt: "hello" } as never);
+
+    const call = generateText.mock.calls[0][0] as Record<string, unknown>;
+    const messages = call.messages as Array<Record<string, unknown>>;
+    const systemMsg = messages?.[0];
+    expect(systemMsg?.role).toBe("system");
+    const provOpts = systemMsg?.providerOptions as Record<string, unknown> | undefined;
+    const anthropicOpts = provOpts?.anthropic as Record<string, unknown> | undefined;
+    expect(anthropicOpts?.cacheControl).toEqual(expect.objectContaining({ type: "ephemeral" }));
+  });
+
+  it("respects ANTHROPIC_PROMPT_CACHE_TTL=1h when producing the fallback cacheControl", async () => {
+    const { generateText } = mockModules();
+    const { handleTextLarge } = await import("../models/text");
+
+    await handleTextLarge(
+      createRuntime({ ANTHROPIC_PROMPT_CACHE_TTL: "1h" }),
+      { prompt: "hello" } as never,
+    );
+
+    const call = generateText.mock.calls[0][0] as Record<string, unknown>;
+    const messages = call.messages as Array<Record<string, unknown>>;
+    const anthropicOpts = (messages?.[0]?.providerOptions as Record<string, unknown>)
+      ?.anthropic as Record<string, unknown> | undefined;
+    expect(anthropicOpts?.cacheControl).toEqual({ type: "ephemeral", ttl: "1h" });
+  });
+
+  it("does NOT inject cacheControl for non-Anthropic models even when ANTHROPIC_PROMPT_CACHE_TTL is set", async () => {
+    const { generateText } = mockModules();
+    const { handleTextLarge } = await import("../models/text");
+
+    await handleTextLarge(
+      createRuntime({
+        OPENROUTER_LARGE_MODEL: "google/gemini-2.5-flash",
+        ANTHROPIC_PROMPT_CACHE_TTL: "1h",
+      }),
+      { prompt: "hello" } as never,
+    );
+
+    const call = generateText.mock.calls[0][0] as Record<string, unknown>;
+    // Non-Anthropic path routes through the plain prompt/system path — no message array with
+    // cacheControl injected.
+    if (Array.isArray(call.messages)) {
+      for (const msg of call.messages as Array<Record<string, unknown>>) {
+        expect(msg?.providerOptions).toBeUndefined();
+      }
+    }
+    const wireAnthropicOpts = (call.providerOptions as Record<string, unknown> | undefined)
+      ?.anthropic as Record<string, unknown> | undefined;
+    expect(wireAnthropicOpts?.cacheControl).toBeUndefined();
+  });
+});
+
+describe("Anthropic cache injection — internal field stripping", () => {
+  it("strips cacheBreakpoints and maxBreakpoints from wire providerOptions", async () => {
+    const { generateText } = mockModules();
+    const { handleTextLarge } = await import("../models/text");
+
+    await handleTextLarge(createRuntime(), {
+      prompt: "hello",
+      providerOptions: {
+        anthropic: {
+          cacheControl: { type: "ephemeral" },
+          cacheBreakpoints: [{ segmentIndex: 0, cacheControl: { type: "ephemeral" } }],
+          maxBreakpoints: 2,
+        },
+        gateway: { caching: "auto" },
+      },
+    } as never);
+
+    const call = generateText.mock.calls[0][0] as Record<string, unknown>;
+    const providerOpts = call.providerOptions as Record<string, unknown> | undefined;
+    const wireAnthropic = providerOpts?.anthropic as Record<string, unknown> | undefined;
+    expect(wireAnthropic?.cacheBreakpoints).toBeUndefined();
+    expect(wireAnthropic?.maxBreakpoints).toBeUndefined();
+    // Non-Anthropic provider options pass through untouched
+    expect(providerOpts?.gateway).toEqual({ caching: "auto" });
+  });
+
+  it("strips cacheSystem from wire options while keeping remaining anthropic fields", async () => {
+    const { generateText } = mockModules();
+    const { handleTextLarge } = await import("../models/text");
+
+    await handleTextLarge(
+      createRuntime({ OPENROUTER_LARGE_MODEL: "anthropic/claude-opus-4-8" }),
+      {
+        messages: [
+          { role: "system", content: "system prompt" },
+          { role: "user", content: "hello" },
+        ],
+        providerOptions: {
+          anthropic: { cacheSystem: true, thinking: { type: "enabled" } },
+        },
+      } as never,
+    );
+
+    const call = generateText.mock.calls[0][0] as Record<string, unknown>;
+    const wireAnthropic = (call.providerOptions as Record<string, unknown> | undefined)
+      ?.anthropic as Record<string, unknown> | undefined;
+    expect(wireAnthropic?.cacheSystem).toBeUndefined();
+    expect(wireAnthropic?.thinking).toEqual({ type: "enabled" });
+  });
+});
+
+describe("Anthropic cache injection — segmented user content", () => {
+  it("builds N content blocks for N promptSegments, applying cacheControl only at breakpoint indices", async () => {
+    const { generateText } = mockModules();
+    const { handleTextLarge } = await import("../models/text");
+
+    await handleTextLarge(createRuntime(), {
+      prompt: "seg1seg2",
+      promptSegments: [
+        { content: "seg1", stable: true },
+        { content: "seg2", stable: false },
+      ],
+      providerOptions: {
+        anthropic: {
+          cacheBreakpoints: [{ segmentIndex: 0, cacheControl: { type: "ephemeral" } }],
+        },
+      },
+    } as never);
+
+    const call = generateText.mock.calls[0][0] as Record<string, unknown>;
+    const messages = call.messages as Array<Record<string, unknown>>;
+    const userMsg = messages?.[1];
+    const content = userMsg?.content as Array<Record<string, unknown>>;
+    expect(content).toHaveLength(2);
+    expect(content[0]?.text).toBe("seg1");
+    const seg0Opts = (content[0]?.providerOptions as Record<string, unknown>)
+      ?.anthropic as Record<string, unknown> | undefined;
+    expect(seg0Opts?.cacheControl).toEqual({ type: "ephemeral" });
+    expect(content[1]?.text).toBe("seg2");
+    expect(content[1]?.providerOptions).toBeUndefined();
+  });
+
+  it("filters out cacheBreakpoints with invalid shapes without crashing", async () => {
+    const { generateText } = mockModules();
+    const { handleTextLarge } = await import("../models/text");
+
+    await handleTextLarge(createRuntime(), {
+      prompt: "text",
+      promptSegments: [{ content: "text", stable: true }],
+      providerOptions: {
+        anthropic: {
+          cacheBreakpoints: [
+            { segmentIndex: "not-a-number", cacheControl: { type: "ephemeral" } },
+            { segmentIndex: 0, cacheControl: { type: "invalid" } },
+            null,
+            42,
+          ],
+        },
+      },
+    } as never);
+
+    const call = generateText.mock.calls[0][0] as Record<string, unknown>;
+    const messages = call.messages as Array<Record<string, unknown>>;
+    // No valid breakpoints after filtering → user content blocks carry no cacheControl
+    const userMsg = messages?.[1];
+    if (userMsg) {
+      const content = userMsg.content as Array<Record<string, unknown>>;
+      for (const block of content) {
+        expect(block.providerOptions).toBeUndefined();
+      }
+    }
+  });
+
+  it("caps applied breakpoints at maxBreakpoints", async () => {
+    const { generateText } = mockModules();
+    const { handleTextLarge } = await import("../models/text");
+
+    await handleTextLarge(createRuntime(), {
+      prompt: "s0s1s2s3",
+      promptSegments: [
+        { content: "s0", stable: true },
+        { content: "s1", stable: true },
+        { content: "s2", stable: true },
+        { content: "s3", stable: false },
+      ],
+      providerOptions: {
+        anthropic: {
+          maxBreakpoints: 1,
+          cacheBreakpoints: [
+            { segmentIndex: 0, cacheControl: { type: "ephemeral" } },
+            { segmentIndex: 1, cacheControl: { type: "ephemeral" } },
+            { segmentIndex: 2, cacheControl: { type: "ephemeral" } },
+          ],
+        },
+      },
+    } as never);
+
+    const call = generateText.mock.calls[0][0] as Record<string, unknown>;
+    const messages = call.messages as Array<Record<string, unknown>>;
+    const userMsg = messages?.[1];
+    const content = userMsg?.content as Array<Record<string, unknown>>;
+    const cachedBlocks = content?.filter(
+      (b) =>
+        (b.providerOptions as Record<string, unknown> | undefined)?.anthropic !== undefined,
+    );
+    // Only segmentIndex 0 survives the cap of 1
+    expect(cachedBlocks).toHaveLength(1);
+    expect(cachedBlocks?.[0]?.text).toBe("s0");
+  });
+});
+
+describe("Anthropic cache injection — cacheSystem:false opt-out", () => {
+  it("passes system as plain string and does not inject cacheControl on system message", async () => {
+    const { generateText } = mockModules();
+    const { handleTextLarge } = await import("../models/text");
+
+    await handleTextLarge(createRuntime(), {
+      messages: [
+        { role: "system", content: "system prompt" },
+        { role: "user", content: "hello" },
+      ],
+      providerOptions: {
+        anthropic: { cacheSystem: false },
+      },
+    } as never);
+
+    const call = generateText.mock.calls[0][0] as Record<string, unknown>;
+    // With cacheSystem:false the system is forwarded as call.system, not as a message
+    // with providerOptions, so there is no Anthropic cacheControl on any message.
+    expect(call.system).toBe("system prompt");
+    expect(call.messages).toEqual([{ role: "user", content: "hello" }]);
+    if (Array.isArray(call.messages)) {
+      for (const msg of call.messages as Array<Record<string, unknown>>) {
+        expect(msg?.providerOptions).toBeUndefined();
+      }
+    }
+  });
+});

--- a/plugins/plugin-openrouter/models/text.ts
+++ b/plugins/plugin-openrouter/models/text.ts
@@ -95,6 +95,8 @@ type GenerateTextParamsWithAttachments = GenerateTextParams & {
     anthropic?: {
       cacheControl?: AnthropicCacheControl;
       cacheSystem?: boolean;
+      cacheBreakpoints?: unknown[];
+      maxBreakpoints?: number;
     };
   };
 };
@@ -294,6 +296,34 @@ function getRuntimeCacheControl(runtime: IAgentRuntime): AnthropicCacheControl {
 
 type AnthropicCacheBreakpoint = { segmentIndex: number; cacheControl: AnthropicCacheControl };
 
+// Extends the AI SDK TextPart shape with provider-metadata so the AI SDK can forward
+// cache_control directives to the wire without losing the type guarantee on type/text.
+type CacheableTextPart = {
+  type: "text";
+  text: string;
+  providerOptions?: Record<string, unknown>;
+};
+
+function isAnthropicCacheBreakpoint(value: unknown): value is AnthropicCacheBreakpoint {
+  return (
+    isRecord(value) &&
+    typeof value.segmentIndex === "number" &&
+    Number.isInteger(value.segmentIndex) &&
+    value.segmentIndex >= 0 &&
+    isRecord(value.cacheControl) &&
+    value.cacheControl.type === "ephemeral"
+  );
+}
+
+function readAnthropicCacheBreakpoints(
+  anthropicOptions: Record<string, unknown> | undefined,
+  maxBreakpoints: number,
+): AnthropicCacheBreakpoint[] {
+  const raw = anthropicOptions?.cacheBreakpoints;
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(isAnthropicCacheBreakpoint).slice(0, maxBreakpoints);
+}
+
 /**
  * Builds user content as multiple text blocks (one per prompt segment) so that
  * Anthropic cache_control breakpoints can be applied at the segment level, up to
@@ -304,7 +334,7 @@ type AnthropicCacheBreakpoint = { segmentIndex: number; cacheControl: AnthropicC
 function buildSegmentedPromptUserContent(
   promptSegments: Array<{ content: string; stable?: boolean }>,
   cacheBreakpoints: AnthropicCacheBreakpoint[],
-): UserContent {
+): CacheableTextPart[] {
   if (cacheBreakpoints.length === 0) {
     return promptSegments.map((seg) => ({ type: "text" as const, text: seg.content }));
   }
@@ -318,7 +348,7 @@ function buildSegmentedPromptUserContent(
         type: "text" as const,
         text: seg.content,
         providerOptions: { anthropic: { cacheControl: cc } },
-      } as unknown as { type: "text"; text: string };
+      };
     }
     return { type: "text" as const, text: seg.content };
   });
@@ -568,13 +598,16 @@ function buildGenerateParams(
       : undefined;
   const shouldInjectMessageLevelCache = Boolean(cacheSystemMessage);
 
-  // Collect cacheBreakpoints for per-segment user-content injection (Fix 3).
+  // Collect cacheBreakpoints for per-segment user-content injection.
   // Only used on the prompt-only path (no messages) together with promptSegments.
-  const cacheBreakpoints: AnthropicCacheBreakpoint[] = Array.isArray(
-    anthropicOptions?.cacheBreakpoints,
-  )
-    ? (anthropicOptions.cacheBreakpoints as AnthropicCacheBreakpoint[])
-    : [];
+  // maxBreakpoints caps the number of slots used (Anthropic allows up to 3 user-content).
+  const maxBreakpoints =
+    typeof anthropicOptions?.maxBreakpoints === "number" &&
+    Number.isInteger(anthropicOptions.maxBreakpoints) &&
+    anthropicOptions.maxBreakpoints >= 0
+      ? anthropicOptions.maxBreakpoints
+      : 3;
+  const cacheBreakpoints = readAnthropicCacheBreakpoints(anthropicOptions, maxBreakpoints);
   const promptSegments = Array.isArray(
     (paramsWithAttachments as { promptSegments?: unknown }).promptSegments,
   )
@@ -615,7 +648,7 @@ function buildGenerateParams(
                 // additional breakpoints under Anthropic's four-block cap).
                 content:
                   promptSegments.length > 0 && cacheBreakpoints.length > 0 && !userContent
-                    ? buildSegmentedPromptUserContent(promptSegments, cacheBreakpoints)
+                    ? (buildSegmentedPromptUserContent(promptSegments, cacheBreakpoints) as UserContent)
                     : (userContent ?? buildUserContent(paramsWithAttachments)),
               },
             ],

--- a/plugins/plugin-openrouter/models/text.ts
+++ b/plugins/plugin-openrouter/models/text.ts
@@ -18,6 +18,12 @@
  * is injected on the system message to enable proper Anthropic prompt caching.
  * The @openrouter/ai-sdk-provider only emits wire-level cache_control directives
  * when providerOptions.anthropic.cacheControl is attached at the message level.
+ *
+ * For prompt-only calls that also supply promptSegments (e.g. the PromptBatcher /
+ * dynamicPromptExecFromState path), per-segment cache_control is additionally
+ * injected on the user content blocks corresponding to the cacheBreakpoints from
+ * the provider cache plan. This extends the single system-message breakpoint to
+ * up to three more user-content breakpoints under Anthropic's four-block cap.
  */
 import type {
   GenerateTextParams,
@@ -268,12 +274,54 @@ function stripLocalAnthropicCacheOptions(
   if (!anthropicOptions) {
     return undefined;
   }
+  // Strip elizaOS-internal fields that are not Anthropic wire parameters.
+  // cacheBreakpoints and maxBreakpoints are consumed here to build segmented
+  // user content; sending them through would produce unknown-field errors.
   const {
     cacheControl: _cacheControl,
     cacheSystem: _cacheSystem,
+    cacheBreakpoints: _cacheBreakpoints,
+    maxBreakpoints: _maxBreakpoints,
     ...wireOptions
   } = anthropicOptions;
   return Object.keys(wireOptions).length > 0 ? wireOptions : undefined;
+}
+
+function getRuntimeCacheControl(runtime: IAgentRuntime): AnthropicCacheControl {
+  const ttl = runtime.getSetting("ANTHROPIC_PROMPT_CACHE_TTL");
+  return ttl === "1h" ? { type: "ephemeral", ttl: "1h" } : { type: "ephemeral" };
+}
+
+type AnthropicCacheBreakpoint = { segmentIndex: number; cacheControl: AnthropicCacheControl };
+
+/**
+ * Builds user content as multiple text blocks (one per prompt segment) so that
+ * Anthropic cache_control breakpoints can be applied at the segment level, up to
+ * the three user-content slots under Anthropic's four-block cache cap. Only used
+ * on the prompt-only path (no `messages` supplied) when promptSegments and
+ * cacheBreakpoints are both available.
+ */
+function buildSegmentedPromptUserContent(
+  promptSegments: Array<{ content: string; stable?: boolean }>,
+  cacheBreakpoints: AnthropicCacheBreakpoint[],
+): UserContent {
+  if (cacheBreakpoints.length === 0) {
+    return promptSegments.map((seg) => ({ type: "text" as const, text: seg.content }));
+  }
+  const breakpointMap = new Map<number, AnthropicCacheControl>(
+    cacheBreakpoints.map((bp) => [bp.segmentIndex, bp.cacheControl]),
+  );
+  return promptSegments.map((seg, index) => {
+    const cc = breakpointMap.get(index);
+    if (cc) {
+      return {
+        type: "text" as const,
+        text: seg.content,
+        providerOptions: { anthropic: { cacheControl: cc } },
+      } as unknown as { type: "text"; text: string };
+    }
+    return { type: "text" as const, text: seg.content };
+  });
 }
 
 function readToolSet(value: GenerateTextParams["tools"]): ToolSet | undefined {
@@ -498,19 +546,40 @@ function buildGenerateParams(
     systemPrompt
   );
 
-  // Detect if we need to inject Anthropic message-level cache control
+  // Detect if we need to inject Anthropic message-level cache control.
+  // When the caller passes an explicit providerOptions.anthropic.cacheControl we
+  // use that; otherwise we fall back to reading ANTHROPIC_PROMPT_CACHE_TTL from
+  // runtime settings — matching the always-on behaviour of plugin-anthropic so
+  // that every Anthropic model routed through OpenRouter gets at least the
+  // system-message breakpoint regardless of whether the calling path assembled a
+  // full cache plan (e.g. the PromptBatcher / dynamicPromptExecFromState path).
   const isAnthropic = isAnthropicModel(modelName);
   const rawProviderOptions = paramsWithAttachments.providerOptions;
   const anthropicOptions = isRecord(rawProviderOptions?.anthropic)
     ? rawProviderOptions.anthropic
     : undefined;
-  const anthropicCacheControl = readAnthropicCacheControl(anthropicOptions);
+  const anthropicCacheControl =
+    readAnthropicCacheControl(anthropicOptions) ??
+    (isAnthropic ? getRuntimeCacheControl(runtime) : undefined);
   const anthropicCacheSystem = anthropicOptions?.cacheSystem !== false;
   const cacheSystemMessage =
     isAnthropic && anthropicCacheSystem
       ? buildCacheableSystemMessage(systemPrompt, anthropicCacheControl)
       : undefined;
   const shouldInjectMessageLevelCache = Boolean(cacheSystemMessage);
+
+  // Collect cacheBreakpoints for per-segment user-content injection (Fix 3).
+  // Only used on the prompt-only path (no messages) together with promptSegments.
+  const cacheBreakpoints: AnthropicCacheBreakpoint[] = Array.isArray(
+    anthropicOptions?.cacheBreakpoints,
+  )
+    ? (anthropicOptions.cacheBreakpoints as AnthropicCacheBreakpoint[])
+    : [];
+  const promptSegments = Array.isArray(
+    (paramsWithAttachments as { promptSegments?: unknown }).promptSegments,
+  )
+    ? ((paramsWithAttachments as { promptSegments?: Array<{ content: string; stable?: boolean }> }).promptSegments ?? [])
+    : [];
 
   let finalWireMessages = wireMessages;
   if (cacheSystemMessage && paramsWithAttachments.messages) {
@@ -540,7 +609,14 @@ function buildGenerateParams(
               cacheSystemMessage,
               {
                 role: "user" as const,
-                content: userContent ?? buildUserContent(paramsWithAttachments),
+                // When promptSegments and cacheBreakpoints are both available,
+                // build multi-block user content so per-segment cache_control can
+                // be stamped on the last block of each stable run (up to three
+                // additional breakpoints under Anthropic's four-block cap).
+                content:
+                  promptSegments.length > 0 && cacheBreakpoints.length > 0 && !userContent
+                    ? buildSegmentedPromptUserContent(promptSegments, cacheBreakpoints)
+                    : (userContent ?? buildUserContent(paramsWithAttachments)),
               },
             ],
           }


### PR DESCRIPTION
## Summary

Fixes the three gaps documented in #15776, which is the root-cause analysis for #15746.

- **`packages/core/src/runtime.ts`** — `dynamicPromptExecFromState` now builds a full provider cache plan from the stable-prefix hash and merges it into `modelParams.providerOptions`, restoring cache hits on all PromptBatcher / AutonomyService drain paths.
- **`plugins/plugin-openrouter/models/text.ts`**:
  - Adds `getRuntimeCacheControl(runtime)` fallback (mirrors `plugin-anthropic`) so `anthropic/*` model calls always inject a system-message `cache_control` breakpoint even when the caller didn't pass an explicit cache plan.
  - Strips elizaOS-internal fields `cacheBreakpoints` / `maxBreakpoints` from the Anthropic wire options in `stripLocalAnthropicCacheOptions` — they were previously leaked to the provider and silently ignored.
  - Adds `buildSegmentedPromptUserContent` which, on the prompt-only path, builds multi-block user content from `promptSegments` and stamps `cache_control` at each `cacheBreakpoints` index, consuming up to 3 of the 4 available Anthropic cache slots.

Closes #15776 
Closes #15746
Related: #15746

## Test plan

- [ ] Set `OPENROUTER_LARGE_MODEL=anthropic/claude-sonnet-4-6` (any `anthropic/*` model)
- [ ] Run `bun run --cwd plugins/plugin-openrouter test:live` — verify `cacheCreationInputTokens > 0` on first call, `cacheReadInputTokens > 0` on second call with same stable prefix
- [ ] Run `bun run verify` — typecheck + lint must pass (new imports in `runtime.ts`, new functions in `text.ts`)
- [ ] Confirm non-Anthropic models (Google, OpenAI) routed through OpenRouter are unaffected — caching block is gated behind `isAnthropicModel(modelName)`