### PR TITLE
test(scenarios): keyless pr-deterministic e2e for birdclaw, elizacloud, meetings (#15759 cluster 1)

### DIFF
--- a/packages/scenario-runner/src/corpus-assertion-guard.test.ts
+++ b/packages/scenario-runner/src/corpus-assertion-guard.test.ts
@@ -309,6 +309,12 @@ const EXPECTED_PR_DETERMINISTIC_SCENARIO_IDS = [
   "persona.night-owl-quiet-hours-sleep-protection",
   "anthropic-proxy.proxy-status",
   "benchmarks.osworld-action",
+  // Per-plugin keyless coverage (#8801, cluster 1 of #15759): keyless scenarios
+  // that spawn a fake birdclaw CLI, mock the Eliza Cloud HTTP API, and drive a
+  // scripted MeetingService so BIRDCLAW / CLOUD_ACCOUNT_STATUS /
+  // GET_MEETING_TRANSCRIPT each get a credential-free e2e. Added here in the same
+  // commit so this toEqual stays green.
+  "birdclaw.search-archive",
   "commands.help-command",
   // LifeOps persona pack D1 (comms-flood-triage, #12774). Convention (G1):
   // pr-deterministic persona scenarios live in
@@ -320,6 +326,7 @@ const EXPECTED_PR_DETERMINISTIC_SCENARIO_IDS = [
   "computeruse.get-cursor-position",
   "convo.echo-self-test",
   "convo.greeting-dynamic",
+  "elizacloud.account-status",
   "facewear.smartglasses-status",
   "finances.owner-finances-dashboard",
   "form.restore-stashed",
@@ -336,6 +343,7 @@ const EXPECTED_PR_DETERMINISTIC_SCENARIO_IDS = [
   "inbox.summarize-inboxes",
   "linear.search-issues",
   "local-inference.start-transcription",
+  "meetings.get-transcript",
   "music.routing-status",
   "nostr.search-posts",
   // Registered here retroactively: the scenario landed (#13778) without the

--- a/packages/test/scenarios/birdclaw/search-archive.scenario.ts
+++ b/packages/test/scenarios/birdclaw/search-archive.scenario.ts
@@ -1,0 +1,255 @@
+/**
+ * Keyless per-plugin e2e for `@elizaos/plugin-birdclaw` (issue #8801, cluster 1
+ * of #15759).
+ *
+ * Drives the `BIRDCLAW` umbrella action's `search` op end-to-end against a fake
+ * birdclaw CLI binary written to a temp dir and pointed at via `BIRDCLAW_BIN`.
+ * The real BirdclawService spawns it (execFile) exactly as it would the real
+ * `birdclaw` binary — `--version` for the availability probe, `db stats --json`
+ * at service start, and `search tweets <query> … --json` for the search — so
+ * this exercises the real action → service → subprocess → JSON-parse path with
+ * zero credentials and no live archive. The fake binary appends every argv it
+ * receives to an invocation log the final check reads, proving the search
+ * actually reached the CLI seam with the planned query.
+ */
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentRuntime } from "@elizaos/core";
+import { ModelType } from "@elizaos/core";
+import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+  describeCalls,
+  successfulActionData,
+} from "../_helpers/effect-assertions.ts";
+
+const BIRDCLAW = "BIRDCLAW";
+const SEARCH_QUERY = "local-first";
+
+type R = AgentRuntime & {
+  setSetting?: (k: string, v: string, secret?: boolean) => void;
+  scenarioLlmFixtures?: {
+    register: (...f: Array<Record<string, unknown>>) => void;
+  };
+};
+
+let birdclawTmpDir: string | undefined;
+/** Path the fake CLI appends its argv to — read by the effect check. */
+let birdclawInvocationLog: string | undefined;
+
+/**
+ * A `/bin/sh` stand-in for the birdclaw CLI. Answers the three commands the
+ * service issues on the search path with the CLI's `--json` envelope shapes,
+ * and logs every invocation so the effect check can prove the real spawn
+ * happened with the planned query. The log path is baked in (not passed via
+ * env) because BirdclawService.spawnEnv only forwards a PATH/HOME allowlist.
+ */
+function fakeBirdclawScript(logPath: string): string {
+  return [
+    "#!/bin/sh",
+    `echo "$@" >> "${logPath}"`,
+    'if [ "$1" = "--version" ]; then printf "birdclaw 0.7.0-scenario\\n"; exit 0; fi',
+    'if [ "$1" = "db" ] && [ "$2" = "stats" ]; then',
+    '  printf \'%s\' \'{"paths":{"rootDir":"/scenario/birdclaw"},"stats":{"home":2,"mentions":1,"dms":0,"needsReply":1,"inbox":1},"transport":{"installed":true,"availableTransport":"xurl","statusText":"connected"}}\'',
+    "  exit 0",
+    "fi",
+    'if [ "$1" = "search" ] && [ "$2" = "tweets" ]; then',
+    '  q="$3"',
+    '  case "$q" in --*) q="" ;; esac',
+    '  printf \'[{"id":"t1","text":"archived thread about %s and sync engines","createdAt":"2026-01-02T00:00:00.000Z","author":{"handle":"birdwatcher","displayName":"Bird Watcher"},"likeCount":5,"liked":true,"bookmarked":false,"isReplied":false,"kind":"tweet"},{"id":"t2","text":"a second %s note","createdAt":"2026-01-01T00:00:00.000Z","author":{"handle":"birdwatcher","displayName":"Bird Watcher"},"likeCount":2,"liked":false,"bookmarked":true,"isReplied":false,"kind":"tweet"}]\' "$q" "$q"',
+    "  exit 0",
+    "fi",
+    "printf '{}'",
+    "exit 0",
+    "",
+  ].join("\n");
+}
+
+export default scenario({
+  lane: "pr-deterministic",
+  id: "birdclaw.search-archive",
+  title: "Birdclaw: search the local Twitter/X archive via a fake CLI",
+  domain: "birdclaw",
+  tags: ["smoke", "birdclaw", "archive"],
+  description:
+    "Searches the birdclaw local Twitter/X archive through the BIRDCLAW action against a fake birdclaw CLI binary the real service spawns — keyless, no live archive.",
+
+  requires: { plugins: ["@elizaos/plugin-birdclaw"] },
+  isolation: "per-scenario",
+
+  seed: [
+    {
+      type: "custom",
+      name: "birdclaw-fake-cli-and-fixtures",
+      apply: async (ctx) => {
+        const runtime = ctx.runtime as R;
+        birdclawTmpDir = mkdtempSync(join(tmpdir(), "birdclaw-scenario-"));
+        birdclawInvocationLog = join(birdclawTmpDir, "invocations.log");
+        const binPath = join(birdclawTmpDir, "birdclaw");
+        writeFileSync(binPath, fakeBirdclawScript(birdclawInvocationLog), {
+          mode: 0o755,
+        });
+
+        // Point the service at the fake binary BEFORE the plugin registers, so
+        // its start-time availability probe (`--version`) resolves installed
+        // and the action's validate() offers BIRDCLAW to the planner.
+        runtime.setSetting?.("BIRDCLAW_BIN", binPath);
+
+        runtime.scenarioLlmFixtures?.register(
+          {
+            name: "birdclaw-stage1",
+            match: {
+              modelType: ModelType.RESPONSE_HANDLER,
+              input: (v: string) =>
+                v.includes("archive") || v.includes("twitter"),
+              toolName: "HANDLE_RESPONSE",
+            },
+            response: {
+              contexts: ["archive", "social"],
+              intents: ["search my twitter archive"],
+              replyText: "",
+              threadOps: [],
+              candidateActionNames: [BIRDCLAW],
+            },
+            times: 1,
+          },
+          {
+            name: "birdclaw-planner",
+            match: (call: { modelType: string; toolNames: string[] }) =>
+              call.modelType === ModelType.ACTION_PLANNER &&
+              call.toolNames.includes(BIRDCLAW),
+            response: {
+              text: "",
+              thought: "Search the birdclaw archive.",
+              messageToUser: "",
+              completed: true,
+              finishReason: "tool-calls",
+              toolCalls: [
+                {
+                  id: "call-birdclaw",
+                  name: BIRDCLAW,
+                  type: "function",
+                  arguments: {
+                    action: "search",
+                    query: SEARCH_QUERY,
+                    resource: "home",
+                  },
+                },
+              ],
+            },
+            times: 1,
+          },
+          {
+            name: "birdclaw-decision",
+            match: (call: { modelType: string; toolNames: string[] }) =>
+              call.modelType === ModelType.RESPONSE_HANDLER &&
+              !call.toolNames.includes("HANDLE_RESPONSE"),
+            response: {
+              success: true,
+              decision: "FINISH",
+              thought:
+                "Reported the archive search results; nothing more to do.",
+              messageToUser: "Here's what I found in your birdclaw archive.",
+            },
+            times: 1,
+          },
+        );
+        return undefined;
+      },
+    },
+  ],
+  cleanup: [
+    {
+      type: "custom",
+      name: "birdclaw-cleanup-tmp",
+      apply: () => {
+        if (birdclawTmpDir && existsSync(birdclawTmpDir)) {
+          rmSync(birdclawTmpDir, { recursive: true, force: true });
+        }
+        birdclawTmpDir = undefined;
+        birdclawInvocationLog = undefined;
+        return undefined;
+      },
+    },
+  ],
+
+  rooms: [
+    { id: "main", source: "dashboard", channelType: "DM", title: "Birdclaw" },
+  ],
+
+  turns: [
+    {
+      kind: "message",
+      name: "search",
+      text: "Search my twitter archive for that local-first sync engines thread.",
+      timeoutMs: 120_000,
+      assertTurn: (turn) => {
+        const call = turn.actionsCalled.find((a) => a.actionName === BIRDCLAW);
+        if (!call) {
+          return `Expected ${BIRDCLAW} but got: ${turn.actionsCalled
+            .map((a) => a.actionName)
+            .join(", ")}`;
+        }
+        if (!call.result?.success) {
+          return `${BIRDCLAW} did not succeed: ${
+            call.error?.message ?? call.result?.text ?? "unknown error"
+          }`;
+        }
+      },
+    },
+  ],
+
+  finalChecks: [
+    {
+      type: "actionCalled",
+      actionName: BIRDCLAW,
+      status: "success",
+      minCount: 1,
+    },
+    {
+      // Effect proof (#11381): the search really spawned the birdclaw CLI with
+      // the planned query and surfaced the parsed archive rows — not just "the
+      // handler returned success". The invocation log proves the subprocess
+      // received `search tweets local-first …`, and result.data carries the
+      // parsed tweets whose text echoes the searched query.
+      type: "custom",
+      name: "birdclaw-search-effect",
+      predicate: (ctx) => {
+        if (!birdclawInvocationLog || !existsSync(birdclawInvocationLog)) {
+          return "fake birdclaw CLI was never spawned (no invocation log written)";
+        }
+        const log = readFileSync(birdclawInvocationLog, "utf8");
+        if (!/search tweets/.test(log)) {
+          return `the birdclaw CLI never received a 'search tweets' command; log:\n${log}`;
+        }
+        if (!log.includes(SEARCH_QUERY)) {
+          return `the search never reached the CLI with the planned query "${SEARCH_QUERY}"; log:\n${log}`;
+        }
+        const data = successfulActionData(ctx, BIRDCLAW);
+        if (!data) {
+          return `no successful ${BIRDCLAW} result data; calls: ${describeCalls(ctx)}`;
+        }
+        if (data.subaction !== "search") {
+          return `expected result.data.subaction "search", saw ${String(data.subaction ?? "(missing)")}`;
+        }
+        const tweets = data.tweets;
+        if (!Array.isArray(tweets) || tweets.length !== 2) {
+          return `expected the 2 parsed archive rows in result.data.tweets, saw ${JSON.stringify(tweets ?? null).slice(0, 200)}`;
+        }
+        const firstText =
+          tweets[0] && typeof tweets[0] === "object"
+            ? String((tweets[0] as { text?: unknown }).text ?? "")
+            : "";
+        if (!firstText.includes(SEARCH_QUERY)) {
+          return `expected the parsed tweet text to carry the searched query "${SEARCH_QUERY}", saw ${JSON.stringify(firstText).slice(0, 200)}`;
+        }
+      },
+    },
+  ],
+});

--- a/packages/test/scenarios/elizacloud/account-status.scenario.ts
+++ b/packages/test/scenarios/elizacloud/account-status.scenario.ts
@@ -1,0 +1,241 @@
+/**
+ * Keyless per-plugin e2e for `@elizaos/plugin-elizacloud` (issue #8801, cluster
+ * 1 of #15759).
+ *
+ * Drives the `CLOUD_ACCOUNT_STATUS` action end-to-end against a scoped mock of
+ * the Eliza Cloud HTTP API, installed via a fetch interceptor in the seed. The
+ * real CloudAuthService authenticates from a seeded `ELIZAOS_CLOUD_API_KEY`
+ * (isAuthenticated → true, so the action's validate offers it to the planner),
+ * and the handler reads `GET /credits/balance` through the typed SDK — a public
+ * account read that needs no live cloud. `ELIZAOS_CLOUD_USE_INFERENCE` /
+ * `_USE_EMBEDDINGS` are pinned off so the cloud plugin never steals the
+ * deterministic proxy's text/embedding slots, and every other cloud service's
+ * startup read (containers, model registry, gateway relay, key re-validation)
+ * is answered by the same mock so the plugin boots fully offline.
+ */
+import type { AgentRuntime } from "@elizaos/core";
+import { ModelType } from "@elizaos/core";
+import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+  describeCalls,
+  successfulActionData,
+} from "../_helpers/effect-assertions.ts";
+
+const CLOUD_ACCOUNT_STATUS = "CLOUD_ACCOUNT_STATUS";
+const CLOUD_BASE_URL = "https://cloud.test.invalid/api/v1";
+const MOCK_BALANCE = 12.5;
+
+type R = AgentRuntime & {
+  setSetting?: (k: string, v: string, secret?: boolean) => void;
+  scenarioLlmFixtures?: {
+    register: (...f: Array<Record<string, unknown>>) => void;
+  };
+};
+
+let restoreFetch: (() => void) | undefined;
+/** True once the balance endpoint was actually served by the mock. */
+let balanceMockHit = false;
+
+export default scenario({
+  lane: "pr-deterministic",
+  id: "elizacloud.account-status",
+  title: "Eliza Cloud: read credit balance against a mocked cloud API",
+  domain: "elizacloud",
+  tags: ["smoke", "elizacloud", "cloud"],
+  description:
+    "Reads the Eliza Cloud credit balance through the CLOUD_ACCOUNT_STATUS action against a scoped mock of the cloud HTTP API — keyless, no live cloud account.",
+
+  requires: { plugins: ["@elizaos/plugin-elizacloud"] },
+  isolation: "per-scenario",
+
+  seed: [
+    {
+      type: "custom",
+      name: "elizacloud-mock-and-config",
+      apply: async (ctx) => {
+        const runtime = ctx.runtime as R;
+        balanceMockHit = false;
+
+        const realFetch = globalThis.fetch;
+        restoreFetch = () => {
+          if (globalThis.fetch === cloudMockFetch) {
+            globalThis.fetch = realFetch;
+          }
+          restoreFetch = undefined;
+        };
+        const cloudMockFetch = (async (
+          input: RequestInfo | URL,
+          init?: RequestInit,
+        ) => {
+          const url =
+            typeof input === "string"
+              ? input
+              : input instanceof Request
+                ? input.url
+                : input.toString();
+          if (url.includes("cloud.test.invalid")) {
+            if (/\/credits\/balance/.test(url)) {
+              balanceMockHit = true;
+              return new Response(JSON.stringify({ balance: MOCK_BALANCE }), {
+                headers: { "Content-Type": "application/json" },
+              });
+            }
+            // Every other cloud read at plugin start (model registry + auth
+            // probe /models, container list, gateway-relay register) gets a
+            // benign empty payload so the plugin boots fully offline.
+            return new Response(JSON.stringify({ data: [] }), {
+              headers: { "Content-Type": "application/json" },
+            });
+          }
+          return realFetch(input, init);
+        }) as typeof fetch;
+        globalThis.fetch = cloudMockFetch;
+
+        // Authenticate CloudAuth from a saved key, pin the base URL at the
+        // mock host, and keep the cloud plugin from claiming the chat-brain /
+        // embedding model slots the deterministic proxy owns.
+        runtime.setSetting?.(
+          "ELIZAOS_CLOUD_API_KEY",
+          "cloud_scenario_key",
+          true,
+        );
+        runtime.setSetting?.("ELIZAOS_CLOUD_BASE_URL", CLOUD_BASE_URL);
+        runtime.setSetting?.("ELIZAOS_CLOUD_USE_INFERENCE", "false");
+        runtime.setSetting?.("ELIZAOS_CLOUD_USE_EMBEDDINGS", "false");
+        process.env.ELIZAOS_CLOUD_API_KEY = "cloud_scenario_key";
+        process.env.ELIZAOS_CLOUD_BASE_URL = CLOUD_BASE_URL;
+        process.env.ELIZAOS_CLOUD_USE_INFERENCE = "false";
+        process.env.ELIZAOS_CLOUD_USE_EMBEDDINGS = "false";
+
+        runtime.scenarioLlmFixtures?.register(
+          {
+            name: "elizacloud-stage1",
+            match: {
+              modelType: ModelType.RESPONSE_HANDLER,
+              input: (v: string) => v.includes("credit") || v.includes("cloud"),
+              toolName: "HANDLE_RESPONSE",
+            },
+            response: {
+              contexts: ["cloud", "finance"],
+              intents: ["check my cloud credits"],
+              replyText: "",
+              threadOps: [],
+              candidateActionNames: [CLOUD_ACCOUNT_STATUS],
+            },
+            times: 1,
+          },
+          {
+            name: "elizacloud-planner",
+            match: (call: { modelType: string; toolNames: string[] }) =>
+              call.modelType === ModelType.ACTION_PLANNER &&
+              call.toolNames.includes(CLOUD_ACCOUNT_STATUS),
+            response: {
+              text: "",
+              thought: "Check the Eliza Cloud credit balance.",
+              messageToUser: "",
+              completed: true,
+              finishReason: "tool-calls",
+              toolCalls: [
+                {
+                  id: "call-cloud",
+                  name: CLOUD_ACCOUNT_STATUS,
+                  type: "function",
+                  arguments: {},
+                },
+              ],
+            },
+            times: 1,
+          },
+          {
+            name: "elizacloud-decision",
+            match: (call: { modelType: string; toolNames: string[] }) =>
+              call.modelType === ModelType.RESPONSE_HANDLER &&
+              !call.toolNames.includes("HANDLE_RESPONSE"),
+            response: {
+              success: true,
+              decision: "FINISH",
+              thought: "Reported the cloud balance; nothing more to do.",
+              messageToUser: "Here's your Eliza Cloud balance.",
+            },
+            times: 1,
+          },
+        );
+        return undefined;
+      },
+    },
+  ],
+  cleanup: [
+    {
+      type: "custom",
+      name: "restore-elizacloud-fetch",
+      apply: () => {
+        restoreFetch?.();
+        return undefined;
+      },
+    },
+  ],
+
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      channelType: "DM",
+      title: "Eliza Cloud",
+    },
+  ],
+
+  turns: [
+    {
+      kind: "message",
+      name: "balance",
+      text: "How many Eliza Cloud credits do I have left?",
+      timeoutMs: 120_000,
+      assertTurn: (turn) => {
+        const call = turn.actionsCalled.find(
+          (a) => a.actionName === CLOUD_ACCOUNT_STATUS,
+        );
+        if (!call) {
+          return `Expected ${CLOUD_ACCOUNT_STATUS} but got: ${turn.actionsCalled
+            .map((a) => a.actionName)
+            .join(", ")}`;
+        }
+        if (!call.result?.success) {
+          return `${CLOUD_ACCOUNT_STATUS} did not succeed: ${
+            call.error?.message ?? call.result?.text ?? "unknown error"
+          }`;
+        }
+      },
+    },
+  ],
+
+  finalChecks: [
+    {
+      type: "actionCalled",
+      actionName: CLOUD_ACCOUNT_STATUS,
+      status: "success",
+      minCount: 1,
+    },
+    {
+      // Effect proof (#11381): the read really hit the cloud balance endpoint
+      // and surfaced the mock's balance in the action result — not just "the
+      // handler returned success".
+      type: "custom",
+      name: "elizacloud-balance-effect",
+      predicate: (ctx) => {
+        if (!balanceMockHit) {
+          return "cloud mock never served /credits/balance — the balance read never touched the HTTP path";
+        }
+        const data = successfulActionData(ctx, CLOUD_ACCOUNT_STATUS);
+        if (!data) {
+          return `no successful ${CLOUD_ACCOUNT_STATUS} result data; calls: ${describeCalls(ctx)}`;
+        }
+        if (data.balance !== MOCK_BALANCE) {
+          return `expected result.data.balance ${MOCK_BALANCE} from the mock, saw ${String(data.balance ?? "(missing)")}`;
+        }
+        if (typeof data.topUpUrl !== "string" || data.topUpUrl.length === 0) {
+          return `expected a top-up URL in result.data.topUpUrl, saw ${JSON.stringify(data.topUpUrl ?? null)}`;
+        }
+      },
+    },
+  ],
+});

--- a/packages/test/scenarios/meetings/get-transcript.scenario.ts
+++ b/packages/test/scenarios/meetings/get-transcript.scenario.ts
@@ -1,0 +1,297 @@
+/**
+ * Keyless per-plugin e2e for `@elizaos/plugin-meetings` (issue #8801, cluster 1
+ * of #15759).
+ *
+ * Drives the `GET_MEETING_TRANSCRIPT` action end-to-end against a real
+ * MeetingService whose browser adapters + ASR pipeline are replaced by scripted
+ * mocks (via `MeetingService.dependencyFactory`, overridden in the seed after
+ * the plugin module is imported so the override survives registration). The
+ * seed registers the plugin itself, drives a real `requestJoin` on a Google
+ * Meet URL, lets the mock adapter/pipeline run the full lifecycle to a
+ * finalized transcript record, and waits for the session to reach a terminal
+ * state — so the persisted transcript the action reads is produced by the real
+ * session state machine + transcript writer (#15704 finalization path), with no
+ * browser, no live meeting, and no credentials.
+ */
+import type { AgentRuntime, UUID } from "@elizaos/core";
+import { ModelType } from "@elizaos/core";
+import type {
+  MeetingBotSession,
+  MeetingPipelineInstance,
+  MeetingPlatformAdapter,
+  MeetingService,
+  MeetingServiceDependencies,
+} from "@elizaos/plugin-meetings";
+import { scenario } from "@elizaos/scenario-runner/schema";
+import type {
+  MeetingPlatform,
+  MeetingSession,
+  TranscriptSegment,
+} from "@elizaos/shared";
+import {
+  callPayloadBlob,
+  describeCalls,
+  successfulActionData,
+} from "../_helpers/effect-assertions.ts";
+
+const GET_MEETING_TRANSCRIPT = "GET_MEETING_TRANSCRIPT";
+const MEET_URL = "https://meet.google.com/abc-defg-hij";
+const SEGMENT_TEXT = "the quarterly roadmap review is on track for friday";
+const SPEAKER = "Alex";
+
+type R = AgentRuntime & {
+  registerPlugin: (plugin: unknown) => Promise<unknown>;
+  getService: (name: string) => unknown;
+  scenarioLlmFixtures?: {
+    register: (...f: Array<Record<string, unknown>>) => void;
+  };
+};
+
+let joinedTranscriptId: string | undefined;
+
+/**
+ * A scripted ASR pipeline: emits exactly one confirmed segment when the adapter
+ * pushes audio, and returns the accumulated segments on finalize — the same
+ * confirmed/pending update flow the real pipeline drives, minus the model.
+ */
+function createMockPipeline(): MeetingPipelineInstance {
+  let listener:
+    | ((update: {
+        confirmed: TranscriptSegment[];
+        pending: TranscriptSegment[];
+      }) => void)
+    | null = null;
+  const segments: TranscriptSegment[] = [];
+  const makeSegment = (): TranscriptSegment => ({
+    id: `seg-${segments.length + 1}`,
+    speakerLabel: SPEAKER,
+    startMs: segments.length * 1000,
+    endMs: segments.length * 1000 + 900,
+    text: SEGMENT_TEXT,
+    words: [],
+  });
+  return {
+    onUpdate(l) {
+      listener = l;
+      return () => {
+        listener = null;
+      };
+    },
+    pushSpeakerAudio() {
+      const segment = makeSegment();
+      segments.push(segment);
+      listener?.({ confirmed: [segment], pending: [] });
+    },
+    setSpeakerName() {},
+    flushSpeaker() {},
+    participantJoined() {},
+    participantLeft() {},
+    async finalize() {
+      return segments;
+    },
+    speakerNames() {
+      return [SPEAKER];
+    },
+  };
+}
+
+/** A scripted Google Meet adapter: join → one speaker turn → normal completion. */
+const mockAdapter: MeetingPlatformAdapter = {
+  platform: "google_meet",
+  async run(session: MeetingBotSession) {
+    session.reportStatus("joining");
+    session.reportStatus("active");
+    session.sink.participantJoined({
+      id: "p-alex",
+      displayName: SPEAKER,
+      joinedAtMs: 0,
+    });
+    session.sink.setSpeakerName("spk-alex", SPEAKER);
+    session.sink.pushSpeakerAudio("spk-alex", new Float32Array(320));
+    session.sink.flushSpeaker("spk-alex");
+    return "normal_completion";
+  },
+};
+
+export default scenario({
+  lane: "pr-deterministic",
+  id: "meetings.get-transcript",
+  title:
+    "Meetings: read a finalized meeting transcript via GET_MEETING_TRANSCRIPT",
+  domain: "meetings",
+  tags: ["smoke", "meetings", "transcripts"],
+  description:
+    "Reads a finalized meeting transcript through the GET_MEETING_TRANSCRIPT action, backed by a real MeetingService driven with scripted browser/ASR mocks — keyless, no browser or live meeting.",
+
+  requires: { plugins: ["@elizaos/plugin-meetings"] },
+  isolation: "per-scenario",
+
+  seed: [
+    {
+      type: "custom",
+      name: "meetings-mock-join-and-fixtures",
+      apply: async (ctx) => {
+        const runtime = ctx.runtime as R;
+
+        // Import the plugin FIRST (evaluates its module, which sets the real
+        // dependencyFactory), then override with scripted mocks. The module is
+        // cached, so the executor's later auto-load will not re-run it and reset
+        // the factory back to the browser adapters.
+        const meetings = (await import("@elizaos/plugin-meetings")) as {
+          MeetingService: typeof MeetingService;
+          meetingsPlugin: unknown;
+        };
+        const dependencies: MeetingServiceDependencies = {
+          adapters: new Map<MeetingPlatform, MeetingPlatformAdapter>([
+            ["google_meet", mockAdapter],
+          ]),
+          createPipeline: () => createMockPipeline(),
+        };
+        meetings.MeetingService.dependencyFactory = () => dependencies;
+
+        await runtime.registerPlugin(meetings.meetingsPlugin);
+
+        const svc = runtime.getService("meetings") as MeetingService;
+        const session = await svc.requestJoin({
+          platform: "google_meet",
+          meetingUrl: MEET_URL,
+        });
+        joinedTranscriptId = session.transcriptId;
+
+        // The mock adapter completes synchronously; wait for the session state
+        // machine + transcript writer to reach a terminal state so the persisted
+        // transcript is finalized ("ready") before the turn reads it.
+        const deadline = Date.now() + 5_000;
+        while (Date.now() < deadline) {
+          const current = svc.getSession(
+            session.id as UUID,
+          ) as MeetingSession | null;
+          if (
+            current &&
+            (current.status === "ended" || current.status === "failed")
+          ) {
+            break;
+          }
+          await new Promise((resolve) => setTimeout(resolve, 25));
+        }
+
+        runtime.scenarioLlmFixtures?.register(
+          {
+            name: "meetings-stage1",
+            match: {
+              modelType: ModelType.RESPONSE_HANDLER,
+              input: (v: string) =>
+                v.includes("transcript") || v.includes("meeting"),
+              toolName: "HANDLE_RESPONSE",
+            },
+            response: {
+              contexts: ["meetings"],
+              intents: ["show me the meeting transcript"],
+              replyText: "",
+              threadOps: [],
+              candidateActionNames: [GET_MEETING_TRANSCRIPT],
+            },
+            times: 1,
+          },
+          {
+            name: "meetings-planner",
+            match: (call: { modelType: string; toolNames: string[] }) =>
+              call.modelType === ModelType.ACTION_PLANNER &&
+              call.toolNames.includes(GET_MEETING_TRANSCRIPT),
+            response: {
+              text: "",
+              thought: "Read the most recent meeting transcript.",
+              messageToUser: "",
+              completed: true,
+              finishReason: "tool-calls",
+              toolCalls: [
+                {
+                  id: "call-transcript",
+                  name: GET_MEETING_TRANSCRIPT,
+                  type: "function",
+                  arguments: {},
+                },
+              ],
+            },
+            times: 1,
+          },
+          {
+            name: "meetings-decision",
+            match: (call: { modelType: string; toolNames: string[] }) =>
+              call.modelType === ModelType.RESPONSE_HANDLER &&
+              !call.toolNames.includes("HANDLE_RESPONSE"),
+            response: {
+              success: true,
+              decision: "FINISH",
+              thought: "Returned the meeting transcript; nothing more to do.",
+              messageToUser: "Here's the transcript from your last meeting.",
+            },
+            times: 1,
+          },
+        );
+        return undefined;
+      },
+    },
+  ],
+
+  rooms: [
+    { id: "main", source: "dashboard", channelType: "DM", title: "Meetings" },
+  ],
+
+  turns: [
+    {
+      kind: "message",
+      name: "get-transcript",
+      text: "Show me the transcript from my last meeting — what was said?",
+      timeoutMs: 120_000,
+      assertTurn: (turn) => {
+        const call = turn.actionsCalled.find(
+          (a) => a.actionName === GET_MEETING_TRANSCRIPT,
+        );
+        if (!call) {
+          return `Expected ${GET_MEETING_TRANSCRIPT} but got: ${turn.actionsCalled
+            .map((a) => a.actionName)
+            .join(", ")}`;
+        }
+        if (!call.result?.success) {
+          return `${GET_MEETING_TRANSCRIPT} did not succeed: ${
+            call.error?.message ?? call.result?.text ?? "unknown error"
+          }`;
+        }
+      },
+    },
+  ],
+
+  finalChecks: [
+    {
+      type: "actionCalled",
+      actionName: GET_MEETING_TRANSCRIPT,
+      status: "success",
+      minCount: 1,
+    },
+    {
+      // Effect proof (#11381): the action returned the transcript that the real
+      // session lifecycle finalized — the id matches the joined session's
+      // transcript, and the reply carries the transcribed speech — not just
+      // "the handler returned success".
+      type: "custom",
+      name: "meetings-transcript-effect",
+      predicate: (ctx) => {
+        if (!joinedTranscriptId) {
+          return "the mock meeting never produced a transcript id in the seed";
+        }
+        const data = successfulActionData(ctx, GET_MEETING_TRANSCRIPT);
+        if (!data) {
+          return `no successful ${GET_MEETING_TRANSCRIPT} result data; calls: ${describeCalls(ctx)}`;
+        }
+        if (data.transcriptId !== joinedTranscriptId) {
+          return `expected result.data.transcriptId ${joinedTranscriptId} (the finalized session's transcript), saw ${String(data.transcriptId ?? "(missing)")}`;
+        }
+        const blob = callPayloadBlob(ctx, GET_MEETING_TRANSCRIPT);
+        if (!blob.includes(SEGMENT_TEXT)) {
+          return `expected the transcribed speech "${SEGMENT_TEXT}" in the ${GET_MEETING_TRANSCRIPT} reply, saw ${blob.slice(0, 300)}`;
+        }
+      },
+    },
+  ],
+});


### PR DESCRIPTION
## What / why

Closes **cluster 1 of #15759**. The per-plugin keyless-e2e coverage gate (#8801,
`packages/scripts/e2e-coverage/check-e2e-coverage.test.ts`) fails in the Zero-Key
scenario-runner lane because `plugin-birdclaw`, `plugin-elizacloud`, and
`plugin-meetings` each expose an agent action surface with **no** `pr-deterministic`
scenario naming them. The baseline is a shrink-only ratchet whose `$comment`
forbids adding entries to silence it — so the required fix is **real scenarios**,
not baseline edits.

This adds one keyless (`lane: "pr-deterministic"`) scenario per plugin. Each drives
a real action handler (validate + handler firing through the real runtime) under
the deterministic LLM proxy (`SCENARIO_USE_LLM_PROXY`) with **zero credentials** —
no live model, no network, no browser — and each carries an effect-proving
`custom` final check (not an echo assertion).

## What each scenario exercises

| Scenario | Action | Real path exercised | Effect proof |
| --- | --- | --- | --- |
| `birdclaw.search-archive` | `BIRDCLAW` (`search`) | Writes a fake `birdclaw` CLI to a temp dir, points `BIRDCLAW_BIN` at it; the **real** `BirdclawService` spawns it (`--version` probe, `db stats`, `search tweets`) via `execFile` → JSON-parse | Fake CLI logs every argv; check asserts `search tweets local-first …` reached the seam and the parsed tweets carry the searched query |
| `elizacloud.account-status` | `CLOUD_ACCOUNT_STATUS` | `CloudAuthService` authenticates from a seeded key (`isAuthenticated → true`), handler reads `GET /credits/balance` through the typed SDK against a scoped fetch mock; cloud inference/embedding slots pinned off so the plugin never steals the proxy's model handlers | Check asserts the balance endpoint was served and `result.data.balance === 12.5` (the mock) with a top-up URL |
| `meetings.get-transcript` | `GET_MEETING_TRANSCRIPT` | Overrides `MeetingService.dependencyFactory` with a scripted browser adapter + ASR pipeline, drives a **real** `requestJoin` → session state machine → transcript writer to a finalized `"ready"` record (the #15704 finalization path), then reads it back | Check asserts `result.data.transcriptId` matches the finalized session's transcript and the reply carries the transcribed speech |

The `plugin-meetings` scenario is timely given #15704 just added transcript-finalization processing — it exercises that finalize path end-to-end.

## Gate red → green

Before (my scenarios removed), the gate flags exactly these three:

```
ok: false
newlyUncovered: ["plugin-birdclaw","plugin-elizacloud","plugin-meetings"]
```

After (scenarios present):

```
ok: true  newlyUncovered: []  staleCovered: []  staleMissing: []
plugin-birdclaw    hasKeylessE2e: true  ids: ["birdclaw.search-archive"]
plugin-elizacloud  hasKeylessE2e: true  ids: ["elizacloud.account-status"]
plugin-meetings    hasKeylessE2e: true  ids: ["meetings.get-transcript"]
```

`bun test packages/scripts/e2e-coverage/check-e2e-coverage.test.ts` → **10 pass, 0 fail**.

## Real scenario runs (exact CI lane: `--conditions eliza-source`, `SCENARIO_LLM_PROXY_STRICT=1`, `--lane pr-deterministic`)

```
| id                          | status | duration | failures |
| birdclaw.search-archive     | passed | 1575ms   |          |
| elizacloud.account-status   | passed | 1941ms   |          |
| meetings.get-transcript     | passed | 2828ms   |          |
```

Captured action results (from the report bundles):

```
BIRDCLAW               success=true  data={"subaction":"search","tweets":[{"id":"t1","text":"archived thread about local-first and sync engines",…}]}
CLOUD_ACCOUNT_STATUS   success=true  data={"balance":12.5,"low":false,"critical":false,"topUpUrl":"https://www.elizacloud.ai/dashboard/settings?tab=billing"}
GET_MEETING_TRANSCRIPT success=true  data={"sessionId":"…","transcriptId":"95c1dffa-54fe-4064-85ec-9d0340f1458d"}
```

Backend log excerpt confirming the real paths fired:

```
[BirdclawService] started (bin=/tmp/birdclaw-scenario-xxxx/birdclaw, installed=true, version=birdclaw 0.7.0-scenario)
[CloudAuth] Authenticated with saved API key
[MeetingService] meeting transcript finalized (ready) (segments=1, durationMs=900, speakerCount=1, endReason=normal_completion)
[MeetingService] session finished (status=ended, endReason=normal_completion, segments=1, participants=1)
```

## Guards / checks

- `packages/scenario-runner/src/corpus-assertion-guard.test.ts` — the three ids registered in the `EXPECTED_PR_DETERMINISTIC_SCENARIO_IDS` allowlist (same-commit convention).
- Scenario quality ratchets green: `corpus-assertion-guard`, `echo-assertion-ratchet`, `action-effect-ratchet`, `skippable-check-ratchet`, `deterministic-action-coverage` → **31 pass**.
- `bunx biome check` clean on all touched files.

**N/A rows:** UI screenshots / video / audio — N/A (deterministic backend scenarios, no UI surface). Live-LLM trajectories — N/A (keyless lane runs the deterministic proxy by design; real trajectories captured are the proxy's, per the pr-deterministic contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)