### PR TITLE
fix(test): route walkthrough first-run-complete seed through the guard-permitted window (#15759 cluster 3)

### DIFF
--- a/packages/app/test/ui-smoke/helpers.ts
+++ b/packages/app/test/ui-smoke/helpers.ts
@@ -272,6 +272,38 @@ export async function seedAppStorage(
   );
 }
 
+const firstRunSeededPages = new WeakSet<Page>();
+
+/**
+ * Seed the shell-reserved `eliza:first-run-complete` flag for the NEXT full page
+ * load. That key sits in the shell's reserved `eliza:` namespace, which the
+ * surface-realm guard (#15247) lets only privileged shell code write: a raw
+ * `localStorage.setItem` on the live page throws {@link SurfaceRealmDeniedError}
+ * the moment a view owns the host realm. An `addInitScript` runs at
+ * document-start of the reload a caller performs next — before the shell mounts
+ * any view and publishes a surface-realm scope — which is the same
+ * guard-permitted window `seedAppStorage` seeds through, so the synchronous boot
+ * readers route straight to chat without a view-forbidden write. Callers that
+ * only flip the mock `/api/first-run/status` still need this so the flag is
+ * present on the SYNCHRONOUS boot read, before the API resolves. Install-once
+ * per page: the seed then re-runs on every later navigation, which is correct
+ * because every load after first-run completes wants the flag set.
+ */
+export async function seedFirstRunCompleteBeforeLoad(
+  page: Page,
+): Promise<void> {
+  if (firstRunSeededPages.has(page)) return;
+  firstRunSeededPages.add(page);
+  await page.addInitScript(() => {
+    try {
+      localStorage.setItem("eliza:first-run-complete", "1");
+    } catch {
+      // Opaque-origin / storage-hostile frames deny Web Storage; the mutable
+      // /api/first-run/status the caller sets stays the authority there.
+    }
+  });
+}
+
 export async function hideContinuousChatOverlay(page: Page): Promise<void> {
   await page.addInitScript(() => {
     const install = () => {

--- a/packages/app/test/ui-smoke/walkthrough/journey.ts
+++ b/packages/app/test/ui-smoke/walkthrough/journey.ts
@@ -38,6 +38,7 @@ import {
   openAppPath,
   openSettingsSection,
   seedAppStorage,
+  seedFirstRunCompleteBeforeLoad,
 } from "../helpers";
 
 export type Lane = "mock" | "live";
@@ -678,9 +679,7 @@ async function navigateViaAgentEvent(
 
 async function reachChatReady(ctx: StepContext): Promise<void> {
   ctx.routes.firstRun.setComplete(true);
-  await ctx.page.evaluate(() => {
-    localStorage.setItem("eliza:first-run-complete", "1");
-  });
+  await seedFirstRunCompleteBeforeLoad(ctx.page);
   await openAppPath(ctx.page, "/chat");
   await expect(ctx.page.getByTestId("continuous-chat-overlay")).toBeVisible({
     timeout: 60_000,

--- a/packages/app/test/ui-smoke/walkthrough/walkthrough-capture-smoke.spec.ts
+++ b/packages/app/test/ui-smoke/walkthrough/walkthrough-capture-smoke.spec.ts
@@ -15,6 +15,7 @@ import {
   installPageDiagnosticsGuard,
   openAppPath,
   seedAppStorage,
+  seedFirstRunCompleteBeforeLoad,
 } from "../helpers";
 
 const CHAT_COMPOSER_SELECTOR =
@@ -247,9 +248,7 @@ test.describe("walkthrough capture smoke", () => {
     await captureState(page, testInfo, "walkthrough-01-onboarding.png");
 
     firstRun.setComplete(true);
-    await page.evaluate(() => {
-      localStorage.setItem("eliza:first-run-complete", "1");
-    });
+    await seedFirstRunCompleteBeforeLoad(page);
     await openAppPath(page, "/chat");
     const overlay = page.getByTestId("continuous-chat-overlay");
     await expect(overlay).toBeVisible({ timeout: 60_000 });


### PR DESCRIPTION
## Issue #15759 cluster 3 — Zero-Key full-walkthrough (mock lane) `SurfaceRealmDeniedError`

The `Zero-Key full-walkthrough (mock lane)` job in `scenario-pr.yml` failed with
`SurfaceRealmDeniedError` on the reserved shell key `eliza:first-run-complete`
(Scenario PR E2E run 29007198774, develop@03f8dcdcf9d).

### Which side was wrong: the harness

I checked all three candidates the storage-guard contract distinguishes:

- **Product code — correct.** Every product write of `eliza:first-run-complete`
  already routes through the privileged channel
  (`persistence.ts` → `shellLocalStorage.setItem`, `first-run-reset.ts` →
  `runAsPrivilegedShell`). Product never hits the denial at runtime, so this is
  **not** a user-facing first-run bug.
- **Realm map — correct.** `eliza:first-run-complete` is legitimately in the
  shell's reserved `eliza:` namespace. The map (`surface-realm-broker.ts`)
  rightly forbids a view from writing it; `surface-realm-reserved-writers.guard.test.ts`
  mechanically enforces the same contract over `packages/ui` + `packages/app`
  **product source**. Weakening it was never an option.
- **Harness — the violator.** `reachChatReady` (`walkthrough/journey.ts`) and the
  capture-smoke spec forced first-run completion with a mid-run
  `page.evaluate(() => localStorage.setItem("eliza:first-run-complete", "1"))`.
  Once #15247 installed the realm-wide raw-`localStorage` guard, that raw write on
  a reserved key is denied the moment a view owns the host realm — exactly the
  bypass class the guard exists to catch. The reserved-writers static scan skips
  `.test.`/`.spec.` files, so the harness bypass slipped the static gate but
  tripped the **runtime** guard when Playwright drove the real app.

### Fix

Seed the flag via `page.addInitScript` (new shared helper
`seedFirstRunCompleteBeforeLoad` in `test/ui-smoke/helpers.ts`) so it lands at
**document-start of the reload `openAppPath` performs** — before the shell
publishes any surface-realm scope, which is the same guard-permitted window
`seedAppStorage` already uses — instead of forging a write a view is forbidden to
make. **Guard enforcement is unchanged.** Applied to both `reachChatReady` and
`walkthrough-capture-smoke.spec.ts` (identical latent bug).

### Evidence — red → green (full-walkthrough desktop, mock lane, reused stub server)

Reproduced the failing lane locally with the workflow command
(`test:e2e:walkthrough` harness → `full-walkthrough.spec.ts`, `ELIZA_UI_SMOKE_FORCE_STUB=1`),
built the app-dependency tree, booted the ui-smoke stub stack, and ran the same
spec before/after the fix against the same server.

| | `SurfaceRealmDeniedError` failures | step 03 `provisioning-ready` |
|---|---|---|
| **RED** (unmodified baseline) | **3** — steps 03, 08, 12, all on `eliza:first-run-complete` | `page.evaluate: SurfaceRealmDeniedError: View "chat" denied storage: raw localStorage setItem on reserved shell key "eliza:first-run-complete"` |
| **GREEN** (this PR) | **0** | `✓ 03-provisioning-ready (3009ms)` |

Every other failing step (01/02 onboarding greeting, 04/05 tutorial, 06/24
settings-scroll, 08/10/16 chat-streaming) is **byte-identical between the RED and
GREEN runs** — they are environmental artifacts of the manually-reused local stub
server (the first-run greeting SSE / chat-streaming / tutorial do not render in
this harness), present on the unmodified baseline too, and are **not** the
cluster-3 realm denial. This change touches only the first-run seed and
introduces no regressions.

<details><summary>RED step 03 error (gate.json)</summary>

```
page.evaluate: SurfaceRealmDeniedError: View "chat" denied storage: raw localStorage
setItem on reserved shell key "eliza:first-run-complete" — views use the surface
storage facade (scope.storage); shell code uses shellLocalStorage
    at assertRawStorageWriteAllowed (…/assets/index-*.js)
    at Proxy.guardedSetItem (…/assets/index-*.js)
```
</details>

N/A rows: rendered UI screenshots/video — the change is test-harness only (no
product pixels change); real-LLM trajectories — keyless mock lane, no model
behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
