### PR TITLE
fix(ci): drain React scheduler before jsdom teardown in useAuthStatus prime suite

### DIFF
--- a/packages/ui/src/hooks/useAuthStatus.prime.test.tsx
+++ b/packages/ui/src/hooks/useAuthStatus.prime.test.tsx
@@ -7,7 +7,7 @@
 // test; only global fetch (the network boundary) is stubbed. The shared
 // module snapshot is reset per test via the __resetAuthStatusForTests seam.
 
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   __resetAuthStatusForTests,
@@ -40,7 +40,17 @@ describe("primeAuthStatusProbe + activation reuse", () => {
     globalThis.fetch = fetchMock as unknown as typeof fetch;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    // React 19 schedules render work as a macrotask (setImmediate /
+    // MessageChannel): any work still queued when vitest tears down this
+    // file's jsdom environment makes react-dom's performWorkUntilDeadline
+    // dereference the deleted `window` and fail the lane as an unhandled
+    // exception. Unmount every rendered hook and drain the scheduler while
+    // the window is still live, before the network stub is removed.
+    cleanup();
+    await act(async () => {
+      await new Promise((resolve) => setImmediate(resolve));
+    });
     globalThis.fetch = realFetch;
     vi.restoreAllMocks();
     __resetAuthStatusForTests();


### PR DESCRIPTION
## Problem

Tests run [29011595240](https://github.com/elizaOS/eliza/actions/runs/29011595240) (develop@03f8dcdcf9d) failed the Client job with a single unhandled exception — `ReferenceError: window is not defined` in react-dom's `performWorkUntilDeadline` — originating in `useAuthStatus.prime.test.tsx`, despite 7,575 passing tests.

Mechanism (verified via log + source during the 2026-07-09 lane audit): React 19 posts render work as a macrotask (`setImmediate`/MessageChannel). The suite renders six hooks and never unmounts them; when a queued scheduler macrotask fires after Vitest tears down this file's jsdom environment, react-dom dereferences the deleted `window`, and Vitest surfaces it as a lane-failing uncaught exception. Timing-flaky: the identical file passed in adjacent runs. Adversarially verified as distinct from #15732 (Event.timeStamp shim, different file/mechanism) and #15731's teardown stubs (apex-host scoped).

## Fix

`afterEach` now runs `cleanup()` (unmounting every rendered hook) and drains one macrotask turn inside `act()` **while the window is still live**, before the fetch stub is restored — so late scheduler work flushes safely and any in-flight poll still hits the mock. No assertion changes.

## Evidence

- 10/10 consecutive clean runs of the file with the fix (no unhandled errors).
- Full hooks directory: **40 files, 271 tests, all pass**.
- Biome clean. (The failure is CI-timing-dependent and did not reproduce locally pre-fix; the mechanism proof is the run-log stack + the missing unmount/drain, and the fix makes the teardown deterministic rather than racing the scheduler.)

Test-hygiene only; no product code touched. Part of the develop CI remediation (#15713…#15784); closes out the last confirmed-new finding from today's 12-lane audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)