### PR TITLE
fix(ci): retire covered Birdclaw lane debt

### DIFF
--- a/packages/scripts/lint-lane-coverage.allowlist.json
+++ b/packages/scripts/lint-lane-coverage.allowlist.json
@@ -58,15 +58,6 @@
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
-      "plugin": "plugin-birdclaw",
-      "issues": [
-        "missing-action-e2e",
-        "missing-deterministic-e2e",
-        "missing-view-e2e"
-      ],
-      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
-    },
-    {
       "plugin": "plugin-blocker",
       "issues": [
         "missing-deterministic-e2e",


### PR DESCRIPTION
## Summary

- remove the three Birdclaw lane-coverage debt suppressions made obsolete by #15778
- restore the fail-closed lane inventory on `develop`, where stale allowlist entries currently block every PR

## Verification

- `bun run audit:test-integrity:lane-coverage` — passed; 142 plugins scanned, 0 blocking issues, 150 valid suppressions
- `bun test packages/scripts/__tests__/lint-lane-coverage.test.ts` — 3/3 passed
- `git diff --check` — passed

## Evidence

<!-- evidence-row:before-screenshots -->
Before screenshots: N/A - CI inventory metadata has no rendered UI.

<!-- evidence-row:after-screenshots -->
After screenshots: N/A - CI inventory metadata has no rendered UI.

<!-- evidence-row:walkthrough-video -->
Walkthrough video: N/A - there is no user-facing flow; the lane audit output is the proof surface.

<!-- evidence-row:backend-logs -->
Backend logs: N/A - no server runtime changed; the successful lane-audit command is recorded in Verification.

<!-- evidence-row:frontend-logs -->
Frontend console/network logs: N/A - no frontend runtime changed.

<!-- evidence-row:llm-trajectory -->
Real-LLM trajectory: N/A - no model or agent behavior changed.

<!-- evidence-row:domain-artifacts -->
Domain artifacts: N/A - the only artifact is the validated CI allowlist itself.