### PR TITLE
fix(cloud): recover malformed container delete jobs

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/app-container-store-recovery.integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-container-store-recovery.integration.test.ts
@@ -1,0 +1,59 @@
+/** Proves malformed-delete recovery selects only deleting rows owned by the queued organization in real Postgres SQL. */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { PGlite } from "@electric-sql/pglite";
+import { drizzle } from "drizzle-orm/pglite";
+import { findDeletingAppContainerRows } from "../app-container-store-queries";
+
+const ORG_ONE = "00000000-0000-0000-0000-0000000000a1";
+const ORG_TWO = "00000000-0000-0000-0000-0000000000a2";
+const USER_ID = "00000000-0000-0000-0000-0000000000b1";
+const DELETING_ID = "00000000-0000-0000-0000-0000000000c1";
+
+let client: PGlite;
+let database: ReturnType<typeof drizzle>;
+
+beforeAll(async () => {
+  client = new PGlite();
+  database = drizzle(client);
+
+  await client.exec(`
+    CREATE TABLE containers (
+      id uuid PRIMARY KEY,
+      name text NOT NULL,
+      project_name text NOT NULL,
+      image_tag text,
+      port integer NOT NULL,
+      organization_id uuid NOT NULL,
+      user_id uuid NOT NULL,
+      environment_vars jsonb NOT NULL DEFAULT '{}',
+      metadata jsonb NOT NULL DEFAULT '{}',
+      status text NOT NULL
+    )
+  `);
+  await client.exec(`
+    INSERT INTO containers
+      (id, name, project_name, image_tag, port, organization_id, user_id, status)
+    VALUES
+      ('${DELETING_ID}', 'delete-me', 'app-1', 'image:1', 3000, '${ORG_ONE}', '${USER_ID}', 'deleting'),
+      ('00000000-0000-0000-0000-0000000000c2', 'keep-running', 'app-2', 'image:2', 3000, '${ORG_ONE}', '${USER_ID}', 'running'),
+      ('00000000-0000-0000-0000-0000000000c3', 'other-org', 'app-3', 'image:3', 3000, '${ORG_TWO}', '${USER_ID}', 'deleting')
+  `);
+});
+
+afterAll(async () => {
+  await client.close();
+});
+
+describe("ContainerRepoAppContainerStore malformed-delete recovery", () => {
+  test("filters by both organization ownership and deleting status", async () => {
+    const rows = await findDeletingAppContainerRows(database, ORG_ONE);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: DELETING_ID,
+      organization_id: ORG_ONE,
+      name: "delete-me",
+    });
+  });
+});

--- a/packages/cloud/shared/src/lib/services/__tests__/container-job-executors.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/container-job-executors.test.ts
@@ -1,4 +1,4 @@
-// Exercises container job executors behavior with deterministic cloud-shared lib fixtures.
+/** Exercises container lifecycle transitions through deterministic provider and store seams. */
 import { describe, expect, test } from "bun:test";
 import type { AppContainerProvider, ProvisionedAppContainer } from "../app-container-provider";
 import {
@@ -26,6 +26,9 @@ function fakeStore(row: AppContainerRow | null = ROW) {
   const store: AppContainerStore = {
     async getById() {
       return row;
+    },
+    async findDeletingByOrganization() {
+      return row ? [row] : [];
     },
     async markRunning(id, info) {
       events.push({ op: "running", id, info });
@@ -268,6 +271,74 @@ describe("executeContainerDelete / restart / logs", () => {
     });
     expect(calls.find((c) => c.op === "delete")?.arg).toBe("app-nubilio");
     expect(events).toEqual([{ op: "deleted", id: "container-1" }]);
+  });
+
+  test("delete completes the terminal transition when its row is already absent", async () => {
+    const { events, store } = fakeStore(null);
+    const { calls, provider } = fakeProvider();
+
+    await executeContainerDelete(job({ containerId: "container-1", organizationId: "org-1" }), {
+      provider,
+      store,
+    });
+
+    expect(calls).toEqual([]);
+    expect(events).toEqual([{ op: "deleted", id: "container-1" }]);
+  });
+
+  test("an org-only legacy job recovers rows already marked for deletion", async () => {
+    const { events, store } = fakeStore();
+    const { calls, provider } = fakeProvider();
+
+    await executeContainerDelete(job({ organizationId: "org-1" }), {
+      provider,
+      store,
+    });
+
+    expect(calls.find((call) => call.op === "delete")?.arg).toBe("app-nubilio");
+    expect(events).toEqual([{ op: "deleted", id: "container-1" }]);
+  });
+
+  test("a repeated legacy job is an idempotent no-op after recovery", async () => {
+    const { events, store } = fakeStore(null);
+    const { calls, provider } = fakeProvider();
+
+    await executeContainerDelete(job({ organizationId: "org-1" }), {
+      provider,
+      store,
+    });
+
+    expect(calls).toEqual([]);
+    expect(events).toEqual([]);
+  });
+
+  test("recovery completes the DB transition when another worker removed Docker first", async () => {
+    const { events, store } = fakeStore();
+    const { provider } = fakeProvider({
+      async delete() {
+        throw new Error("No such container: app-nubilio");
+      },
+    });
+
+    await executeContainerDelete(job({ organizationId: "org-1" }), {
+      provider,
+      store,
+    });
+
+    expect(events).toEqual([{ op: "deleted", id: "container-1" }]);
+  });
+
+  test("a valid delete job cannot target another organization's row", async () => {
+    const { store } = fakeStore({ ...ROW, organizationId: "org-2" });
+    const { calls, provider } = fakeProvider();
+
+    await expect(
+      executeContainerDelete(job({ containerId: "container-1", organizationId: "org-1" }), {
+        provider,
+        store,
+      }),
+    ).rejects.toThrow("does not own");
+    expect(calls).toEqual([]);
   });
 
   test("restart restarts by container name", async () => {

--- a/packages/cloud/shared/src/lib/services/__tests__/container-job-service.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/container-job-service.test.ts
@@ -1,4 +1,4 @@
-// Exercises container job service behavior with deterministic cloud-shared lib fixtures.
+/** Exercises container-job dispatch and persistence through deterministic queue seams. */
 import { describe, expect, test } from "bun:test";
 import type { AppContainerProvider } from "../app-container-provider";
 import type {
@@ -32,6 +32,9 @@ function fakeDeps() {
   const store: AppContainerStore = {
     async getById() {
       return ROW;
+    },
+    async findDeletingByOrganization() {
+      return [ROW];
     },
     async markRunning() {},
     async markDeleted() {
@@ -133,5 +136,15 @@ describe("ContainerJobEnqueuer", () => {
     ]);
     expect(inserts[0].data).toMatchObject({ containerId: "c1", userId: "u1" });
     expect(inserts[2].data).toMatchObject({ image: "ghcr.io/x:2" });
+  });
+
+  test("rejects an undefined runtime container id before writing a delete job", async () => {
+    const { inserts, writer } = fakeWriter();
+    const enqueuer = new ContainerJobEnqueuer(writer);
+    const malformed = { containerId: "placeholder", organizationId: "o1" };
+    Object.defineProperty(malformed, "containerId", { value: undefined });
+
+    expect(() => enqueuer.enqueueDelete(malformed)).toThrow("persistence");
+    expect(inserts).toHaveLength(0);
   });
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/container-jobs-data.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/container-jobs-data.test.ts
@@ -1,8 +1,10 @@
-// Exercises container jobs data behavior with deterministic cloud-shared lib fixtures.
+/** Exercises container-job runtime validation at its read and persistence boundaries. */
 import { describe, expect, test } from "bun:test";
 import {
+  containerDeleteJobDataToRecord,
   containerLogsJobDataToRecord,
   containerProvisionJobDataToRecord,
+  containerRestartJobDataToRecord,
   containerUpgradeJobDataToRecord,
   isContainerLogsJobData,
   isContainerProvisionJobData,
@@ -26,7 +28,7 @@ describe("container-jobs-data codecs", () => {
 
   test("delete + restart accept the minimal {containerId, organizationId}", () => {
     const data = { containerId: "c1", organizationId: "o1" };
-    expect(readContainerDeleteJobData(job(data))).toEqual(data);
+    expect(readContainerDeleteJobData(job(containerDeleteJobDataToRecord(data)))).toEqual(data);
     expect(readContainerRestartJobData(job(data))).toEqual(data);
   });
 
@@ -43,6 +45,9 @@ describe("container-jobs-data codecs", () => {
   test("guards reject malformed data", () => {
     expect(isContainerProvisionJobData({ containerId: "c1", organizationId: "o1" })).toBe(false); // missing userId
     expect(isContainerProvisionJobData(null)).toBe(false);
+    expect(
+      isContainerProvisionJobData({ containerId: " ", organizationId: "o1", userId: "u1" }),
+    ).toBe(false);
     expect(isContainerUpgradeJobData({ containerId: "c1", organizationId: "o1", image: 5 })).toBe(
       false,
     );
@@ -54,5 +59,27 @@ describe("container-jobs-data codecs", () => {
   test("read* throws (with the job id) on invalid data", () => {
     expect(() => readContainerProvisionJobData(job({ containerId: "c1" }))).toThrow("job-1");
     expect(() => readContainerLogsJobData(job("nope"))).toThrow();
+  });
+
+  test("persistence codecs reject missing runtime identifiers", () => {
+    const deleteData = { containerId: "c1", organizationId: "o1" };
+    Object.defineProperty(deleteData, "containerId", { value: undefined });
+    expect(() => containerDeleteJobDataToRecord(deleteData)).toThrow("persistence");
+
+    const provisionData = { containerId: "c1", organizationId: "o1", userId: "u1" };
+    Object.defineProperty(provisionData, "userId", { value: undefined });
+    expect(() => containerProvisionJobDataToRecord(provisionData)).toThrow("persistence");
+
+    const restartData = { containerId: "c1", organizationId: "o1" };
+    Object.defineProperty(restartData, "organizationId", { value: undefined });
+    expect(() => containerRestartJobDataToRecord(restartData)).toThrow("persistence");
+
+    const upgradeData = { containerId: "c1", organizationId: "o1", image: "image:2" };
+    Object.defineProperty(upgradeData, "containerId", { value: undefined });
+    expect(() => containerUpgradeJobDataToRecord(upgradeData)).toThrow("persistence");
+
+    const logsData = { containerId: "c1", organizationId: "o1", tail: 100 };
+    Object.defineProperty(logsData, "containerId", { value: undefined });
+    expect(() => containerLogsJobDataToRecord(logsData)).toThrow("persistence");
   });
 });

--- a/packages/cloud/shared/src/lib/services/app-container-store-queries.ts
+++ b/packages/cloud/shared/src/lib/services/app-container-store-queries.ts
@@ -1,0 +1,56 @@
+/**
+ * Defines the app-container row projection and ownership-scoped reads independently
+ * of the process database singleton so real Postgres tests can inject an isolated DB.
+ */
+
+import { and, eq } from "drizzle-orm";
+import type { dbWrite } from "../../db/helpers";
+import { containers } from "../../db/schemas/containers";
+
+export interface ProjectableContainerRow {
+  id: string;
+  name: string;
+  project_name: string;
+  image_tag: string | null;
+  port: number;
+  organization_id: string;
+  user_id: string;
+  environment_vars: Record<string, string> | null;
+  metadata: Record<string, unknown> | null;
+}
+
+const appContainerSelection = {
+  id: containers.id,
+  name: containers.name,
+  project_name: containers.project_name,
+  image_tag: containers.image_tag,
+  port: containers.port,
+  organization_id: containers.organization_id,
+  user_id: containers.user_id,
+  environment_vars: containers.environment_vars,
+  metadata: containers.metadata,
+};
+
+type AppContainerReadDatabase = Pick<typeof dbWrite, "select">;
+
+export async function findAppContainerRowById(
+  database: AppContainerReadDatabase,
+  containerId: string,
+): Promise<ProjectableContainerRow | null> {
+  const [row] = await database
+    .select(appContainerSelection)
+    .from(containers)
+    .where(eq(containers.id, containerId))
+    .limit(1);
+  return row ?? null;
+}
+
+export function findDeletingAppContainerRows(
+  database: AppContainerReadDatabase,
+  organizationId: string,
+): Promise<ProjectableContainerRow[]> {
+  return database
+    .select(appContainerSelection)
+    .from(containers)
+    .where(and(eq(containers.organization_id, organizationId), eq(containers.status, "deleting")));
+}

--- a/packages/cloud/shared/src/lib/services/app-container-store.ts
+++ b/packages/cloud/shared/src/lib/services/app-container-store.ts
@@ -1,64 +1,24 @@
 /**
- * AppContainerStore (Apps / Product 2) — the integration backing for the
- * {@link AppContainerStore} read/write seam declared in
- * `container-job-executors.ts`. It adapts the apps-lane executor's container
- * view onto 2AM's `containers` table via `containersRepository`, so the executor
- * itself never imports that schema/repo (decoupled per the seam's intent).
- *
- * IMPEDANCE MAP — the executor's AppContainerRow vs the `containers` columns:
- *   AppContainerRow.id              -> containers.id
- *   AppContainerRow.appId           -> containers.project_name  (the deploy
- *                                       orchestrator sets project_name = appId)
- *   AppContainerRow.containerName   -> containers.name
- *   AppContainerRow.image           -> containers.image_tag
- *   AppContainerRow.port            -> containers.port
- *   AppContainerRow.organizationId  -> containers.organization_id
- *   AppContainerRow.userId          -> containers.user_id
- *   AppContainerRow.environmentVars -> containers.environment_vars (jsonb;
- *                                       carries the per-tenant DATABASE_URL)
- *
- * markRunning persists {hostContainerId, hostPort, network}. The `containers`
- * table has NO dedicated columns for these (2AM's 2026-05-17 schema), so they
- * are merged into `containers.metadata` (the only free-form jsonb sink). When
- * 2AM's #8273 lands and ALTERs the schema, prefer real columns if it adds them;
- * until then `metadata` is canonical for host placement. We also stamp
- * `last_deployed_at` on success for the deploy-status poll.
- *
- * STATUS VOCAB (containers.ContainerStatus): pending | building | deploying |
- *   running | stopped | failed | deleting | deleted. We use:
- *     markRunning -> "running", markError -> "failed", markDeleted -> "deleted".
- *   ("deleted" is the terminal, non-quota-counting state — the quota readers
- *   exclude only `deleting`/`deleted`, so a retired row stops counting against
- *   the org's container cap. App containers carry no `volume_path`, so the
- *   active_project_volume_unique index never applies to them.)
- *
- * SERVER + NODE: this is a plain DB adapter (no `pg`), but it is wired into the
- * node daemon's container-executor deps (the daemon runs the provision against a
- * real worker node). `getById` uses a non-org-scoped read (the executor only has
- * the container id from the job payload; the repo's findById/update are
- * org-scoped, so we read the org from the row first, then call org-scoped update).
+ * Adapts app-container executor state transitions onto the shared `containers` table.
+ * The executor consumes this boundary without importing database concerns. Host
+ * placement stays in metadata because the schema has no dedicated host columns,
+ * while terminal `deleted` status is required to release organization quota.
  */
 
 import { eq } from "drizzle-orm";
-import { dbRead } from "../../db/helpers";
+import { dbRead, dbWrite } from "../../db/helpers";
 import { containersRepository } from "../../db/repositories/containers";
 import { containers } from "../../db/schemas/containers";
 import { logger } from "../utils/logger";
+import {
+  findAppContainerRowById,
+  findDeletingAppContainerRows,
+  type ProjectableContainerRow,
+} from "./app-container-store-queries";
 import { deriveAppPublicUrl } from "./app-url";
 import type { AppContainerRow, AppContainerStore } from "./container-job-executors";
 
-/** The `containers` columns the executor's view projects from (structural). */
-export interface ProjectableContainerRow {
-  id: string;
-  name: string;
-  project_name: string;
-  image_tag: string | null;
-  port: number;
-  organization_id: string;
-  user_id: string;
-  environment_vars: Record<string, string> | null;
-  metadata: Record<string, unknown> | null;
-}
+export type { ProjectableContainerRow } from "./app-container-store-queries";
 
 /**
  * Project a `containers` row onto the executor's {@link AppContainerRow}. Pure,
@@ -109,13 +69,16 @@ export class ContainerRepoAppContainerStore implements AppContainerStore {
     // The executor only has the container id (from the job payload), but the
     // repo's findById is org-scoped. Read by primary key directly to recover the
     // full row (incl. organization_id), then project onto AppContainerRow.
-    const [row] = await dbRead
-      .select()
-      .from(containers)
-      .where(eq(containers.id, containerId))
-      .limit(1);
+    const row = await findAppContainerRowById(dbRead, containerId);
     if (!row) return null;
     return mapContainerRowToAppContainerRow(row);
+  }
+
+  async findDeletingByOrganization(organizationId: string): Promise<AppContainerRow[]> {
+    // A recovered legacy job is consumed once, so replica lag must not turn a
+    // real deleting row into a terminal no-op.
+    const rows = await findDeletingAppContainerRows(dbWrite, organizationId);
+    return rows.map(mapContainerRowToAppContainerRow);
   }
 
   async markRunning(

--- a/packages/cloud/shared/src/lib/services/container-job-executors.ts
+++ b/packages/cloud/shared/src/lib/services/container-job-executors.ts
@@ -3,18 +3,19 @@
  * provisioning daemon runs for app containers. Kept as a standalone, fully
  * dependency-injected module so the dispatch + state transitions are
  * unit-testable with fakes; the integration into `provisioning-jobs.ts` is a
- * thin set of `case JOB_TYPES.CONTAINER_*` arms that delegate here (appended,
- * never replacing the AGENT_* arms).
+ * thin set of `case JOB_TYPES.CONTAINER_*` arms that delegate here.
  *
  * Decoupled from 2AM's `containers` table: it reads/writes app container rows
  * through an injected {@link AppContainerStore}, so it never imports that schema
  * or repo directly.
  */
 
+import { ElizaError } from "@elizaos/core";
 import { logger } from "../utils/logger";
 import type { AppContainerProvider } from "./app-container-provider";
 import { deriveAppPublicUrl } from "./app-url";
 import {
+  isContainerDeleteJobData,
   type JobLike,
   readContainerDeleteJobData,
   readContainerLogsJobData,
@@ -40,6 +41,7 @@ export interface AppContainerRow {
 /** Read/write seam for app container state (over the `containers` table). */
 export interface AppContainerStore {
   getById(containerId: string): Promise<AppContainerRow | null>;
+  findDeletingByOrganization(organizationId: string): Promise<AppContainerRow[]>;
   markRunning(
     containerId: string,
     info: { hostContainerId: string; hostPort: number; network: string; nodeHost?: string },
@@ -205,22 +207,75 @@ export async function executeContainerDelete(
   job: JobLike,
   deps: ContainerExecutorDeps,
 ): Promise<void> {
-  const { containerId } = readContainerDeleteJobData(job);
-  const row = await deps.store.getById(containerId);
-  if (row) await deps.provider.delete(row.containerName);
-  // Remove the ingress route (best-effort; a reconciler sweeps any orphan).
-  const endpoint = deriveAppPublicUrl(containerId);
-  if (endpoint && deps.onRouteRemoved) {
-    await deps.onRouteRemoved({ hostname: endpoint.hostname }).catch((error) => {
-      // error-policy:J6 route removal is teardown best-effort; reconciler sweeps orphans.
-      logger.warn("[ContainerExecutor] route removal failed during container delete", {
-        containerId,
-        hostname: endpoint.hostname,
-        error: error instanceof Error ? error.message : String(error),
-      });
+  let targets: Array<{ id: string; row: AppContainerRow | null }>;
+  if (isContainerDeleteJobData(job.data)) {
+    const row = await deps.store.getById(job.data.containerId);
+    if (row && row.organizationId !== job.data.organizationId) {
+      throw new ElizaError(
+        `Container delete job ${job.id} organization does not own ${job.data.containerId}`,
+        {
+          code: "CONTAINER_DELETE_ORGANIZATION_MISMATCH",
+          context: {
+            jobId: job.id,
+            containerId: job.data.containerId,
+            jobOrganizationId: job.data.organizationId,
+            containerOrganizationId: row.organizationId,
+          },
+          severity: "fatal",
+        },
+      );
+    }
+    targets = [{ id: job.data.containerId, row }];
+  } else {
+    const organizationId = recoverableDeleteOrganizationId(job);
+    const rows = await deps.store.findDeletingByOrganization(organizationId);
+    targets = rows.map((row) => ({ id: row.id, row }));
+    logger.warn("[ContainerExecutor] recovering malformed container delete job", {
+      jobId: job.id,
+      organizationId,
+      recoveredContainers: rows.map((row) => row.id),
     });
   }
-  await deps.store.markDeleted(containerId);
+
+  for (const { id, row } of targets) {
+    if (row) {
+      try {
+        await deps.provider.delete(row.containerName);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (!/no such container/i.test(message)) throw error;
+        // error-policy:J6 another teardown worker already removed the target; the terminal DB transition still must complete.
+        logger.info("[ContainerExecutor] container already absent during delete", {
+          containerId: id,
+          containerName: row.containerName,
+        });
+      }
+    }
+    // Remove the ingress route (best-effort; a reconciler sweeps any orphan).
+    const endpoint = deriveAppPublicUrl(id);
+    if (endpoint && deps.onRouteRemoved) {
+      await deps.onRouteRemoved({ hostname: endpoint.hostname }).catch((error) => {
+        // error-policy:J6 route removal is teardown best-effort; reconciler sweeps orphans.
+        logger.warn("[ContainerExecutor] route removal failed during container delete", {
+          containerId: id,
+          hostname: endpoint.hostname,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+    }
+    await deps.store.markDeleted(id);
+  }
+}
+
+function recoverableDeleteOrganizationId(job: JobLike): string {
+  if (typeof job.data !== "object" || job.data === null) {
+    return readContainerDeleteJobData(job).organizationId;
+  }
+  const organizationId = Reflect.get(job.data, "organizationId");
+  if (typeof organizationId !== "string" || organizationId.trim().length === 0) {
+    return readContainerDeleteJobData(job).organizationId;
+  }
+  return organizationId;
 }
 
 export async function executeContainerRestart(

--- a/packages/cloud/shared/src/lib/services/container-jobs-data.ts
+++ b/packages/cloud/shared/src/lib/services/container-jobs-data.ts
@@ -52,7 +52,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function hasStrings(value: unknown, keys: readonly string[]): boolean {
   if (!isRecord(value)) return false;
-  return keys.every((k) => typeof value[k] === "string");
+  return keys.every((key) => typeof value[key] === "string" && value[key].trim().length > 0);
 }
 
 export function isContainerProvisionJobData(value: unknown): value is ContainerProvisionJobData {
@@ -119,27 +119,27 @@ export function readContainerLogsJobData(job: JobLike): ContainerLogsJobData {
 export function containerProvisionJobDataToRecord(
   data: ContainerProvisionJobData,
 ): Record<string, unknown> {
-  return { ...data };
+  return { ...readContainerProvisionJobData({ id: "persistence", data }) };
 }
 
 export function containerDeleteJobDataToRecord(
   data: ContainerDeleteJobData,
 ): Record<string, unknown> {
-  return { ...data };
+  return { ...readContainerDeleteJobData({ id: "persistence", data }) };
 }
 
 export function containerRestartJobDataToRecord(
   data: ContainerRestartJobData,
 ): Record<string, unknown> {
-  return { ...data };
+  return { ...readContainerRestartJobData({ id: "persistence", data }) };
 }
 
 export function containerUpgradeJobDataToRecord(
   data: ContainerUpgradeJobData,
 ): Record<string, unknown> {
-  return { ...data };
+  return { ...readContainerUpgradeJobData({ id: "persistence", data }) };
 }
 
 export function containerLogsJobDataToRecord(data: ContainerLogsJobData): Record<string, unknown> {
-  return { ...data };
+  return { ...readContainerLogsJobData({ id: "persistence", data }) };
 }


### PR DESCRIPTION
# Relates to

Fixes #15738.

# Sync with develop

- [x] Rebased onto current `origin/develop` (`199ba069ca7`) with zero conflicts.
- [x] `bun install --frozen-lockfile --ignore-scripts` completed with no lock changes.
- [x] Diff-scoped error-policy and test-realness audits pass.

# What changed

- Validates every `CONTAINER_*` payload at the persistence boundary, so runtime-undefined identifiers throw before JSON can erase them.
- Recovers legacy organization-only delete jobs by selecting only that organization owned rows already in `deleting` state from the primary database.
- Preserves idempotency when another worker already removed Docker, while generic provider failures still propagate.
- Rejects a valid-looking delete job if its organization does not own the selected container.
- Keeps route removal and terminal DB transition behavior when the row is already absent.

The current schema makes the original suspected id-less row impossible: `containers.id` is a non-null primary key and both callers select complete rows. The durable fault was the unchecked serialization boundary, which allowed runtime shape drift to become a persisted org-only JSON payload.

# Risks

Recovery is deliberately narrow. It never guesses among running or stopped containers; only rows already marked `deleting` are safe to re-derive from organization ownership. Repeated legacy jobs are idempotent no-ops after those rows reach `deleted`.

# Testing

- `bun run --cwd packages/cloud/shared typecheck`
- Focused lifecycle, codec, service, and real PGlite recovery suites: 39 passed, 0 failed.
- Codec boundary suite: 100% functions and lines.
- Full cloud-shared suite with `bun test --isolate --timeout 30000`: 4,305 passed, 61 explicitly gated live tests skipped, 0 failed across 533 files.
- `node packages/scripts/error-policy-ratchet.mjs`: no new fallback slop.
- `bun run audit:test-realness`: 4 changed test files, 0 regressions.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - daemon and database behavior only; no UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - daemon and database behavior only; no UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no frontend flow.
<!-- evidence-row:backend-logs -->
- [x] https://github.com/elizaOS/eliza/pull/15792#issuecomment-4930022336 - focused and full-suite backend logs.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend behavior.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, or provider behavior.
<!-- evidence-row:domain-artifacts -->
- [x] https://github.com/elizaOS/eliza/pull/15792#issuecomment-4930022336 - reviewed PGlite row artifacts proving organization and status filtering.

# Evidence Details

## Backend logs

```text
ContainerRepoAppContainerStore malformed-delete recovery
  filters by both organization ownership and deleting status: pass

container-jobs-data codecs
  persistence codecs reject missing runtime identifiers: pass
  6 pass, 0 fail, 18 assertions
  100% functions, 100% lines

cloud-shared full suite
  4305 pass
  61 skip (explicit live credential/device gates)
  0 fail
  12242 assertions
  533 files
```

## Domain artifacts

The PGlite integration inserts three real rows: org A/deleting, org A/running, and org B/deleting. The production store query returns exactly org A/deleting, proving both ownership and lifecycle-state constraints in real Postgres SQL.

## Known gaps

- Existing staging org-only jobs still require retry/requeue after deployment. This PR makes those retries recoverable; deployment authority and staging credentials are outside this code PR.
- An org-only legacy job for a row already marked `stopped` remains intentionally unrecoverable because choosing among stopped rows without a container ID could delete the wrong workload.
- UI, screenshots, video, audio, and live-LLM evidence are N/A for this daemon/database change.