### PR TITLE
fix(test): load tsx for source-mode app audits

### DIFF
--- a/packages/app/scripts/lib/playwright-node-options.mjs
+++ b/packages/app/scripts/lib/playwright-node-options.mjs
@@ -1,0 +1,30 @@
+/**
+ * Normalizes Node options inherited by Playwright and its child build processes.
+ * Source-conditioned workspace exports point at TypeScript, so the export
+ * condition and tsx resolver must travel together through every child process.
+ */
+
+const SOURCE_CONDITION = "--conditions=eliza-source";
+const TSX_IMPORT = "tsx";
+
+export function withElizaSourceNodeOptions(value) {
+  const options =
+    typeof value === "string" && value.trim().length > 0
+      ? value.trim().split(/\s+/)
+      : [];
+
+  if (!options.includes(SOURCE_CONDITION)) {
+    options.push(SOURCE_CONDITION);
+  }
+
+  const hasTsxImport = options.some(
+    (option, index) =>
+      option === `--import=${TSX_IMPORT}` ||
+      (option === "--import" && options[index + 1] === TSX_IMPORT),
+  );
+  if (!hasTsxImport) {
+    options.push("--import", TSX_IMPORT);
+  }
+
+  return options.join(" ");
+}

--- a/packages/app/scripts/lib/playwright-node-options.test.mjs
+++ b/packages/app/scripts/lib/playwright-node-options.test.mjs
@@ -1,0 +1,31 @@
+/**
+ * Verifies that Playwright source-mode child processes inherit a stable,
+ * idempotent Node option set while preserving caller-supplied options.
+ */
+
+import { describe, expect, it } from "vitest";
+import { withElizaSourceNodeOptions } from "./playwright-node-options.mjs";
+
+describe("withElizaSourceNodeOptions", () => {
+  it("adds the source condition and TypeScript resolver", () => {
+    expect(withElizaSourceNodeOptions(undefined)).toBe(
+      "--conditions=eliza-source --import tsx",
+    );
+  });
+
+  it("preserves existing options and adds each requirement once", () => {
+    expect(withElizaSourceNodeOptions("--max-old-space-size=4096")).toBe(
+      "--max-old-space-size=4096 --conditions=eliza-source --import tsx",
+    );
+  });
+
+  it("is idempotent for the split import syntax", () => {
+    const options = "--trace-warnings --conditions=eliza-source --import tsx";
+    expect(withElizaSourceNodeOptions(options)).toBe(options);
+  });
+
+  it("recognizes the equals import syntax without adding a second loader", () => {
+    const options = "--import=tsx --conditions=eliza-source";
+    expect(withElizaSourceNodeOptions(options)).toBe(options);
+  });
+});

--- a/packages/app/scripts/run-ui-playwright.mjs
+++ b/packages/app/scripts/run-ui-playwright.mjs
@@ -8,6 +8,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { getFreePort } from "../test/utils/get-free-port.mjs";
+import { withElizaSourceNodeOptions } from "./lib/playwright-node-options.mjs";
 
 const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const repoRoot = path.resolve(appDir, "..", "..");
@@ -180,17 +181,6 @@ function hasPlaywrightProject(projectName) {
   });
 }
 
-function appendNodeOption(value, option) {
-  const options =
-    typeof value === "string" && value.trim().length > 0
-      ? value.trim().split(/\s+/)
-      : [];
-  if (!options.includes(option)) {
-    options.push(option);
-  }
-  return options.join(" ");
-}
-
 function sleepSync(ms) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
@@ -349,14 +339,10 @@ async function getDistinctFreePort(excludedPorts = new Set()) {
 // Those packages publish an `eliza-source` export condition pointing at `src`;
 // on a fresh CI install (`bun install --ignore-scripts`) they have no `dist`, so
 // under default node conditions the collector resolves a missing
-// `dist/index.js` and the whole lane dies before any spec runs. The live-stack
-// web server (`run-node-tsx.mjs`) and the vitest source aliases already resolve
-// via `eliza-source`; the Playwright runner process must match so spec
-// collection reads the same source. No-op for packages without the condition.
-env.NODE_OPTIONS = appendNodeOption(
-  env.NODE_OPTIONS,
-  "--conditions=eliza-source",
-);
+// `dist/index.js` and the whole lane dies before any spec runs. The tsx import
+// is also required by child Node/Vite processes because source packages retain
+// NodeNext `.js` specifiers while their worktree files are TypeScript.
+env.NODE_OPTIONS = withElizaSourceNodeOptions(env.NODE_OPTIONS);
 
 if (hasPlaywrightConfig("playwright.ui-smoke.config.ts")) {
   env.ELIZA_UI_SMOKE_RUN_ID =


### PR DESCRIPTION
Fixes #15782. Parent #13631.

## Summary

- keep the Playwright runner's `eliza-source` export condition paired with the `tsx` resolver inherited by every child Node/Vite process
- preserve caller-supplied `NODE_OPTIONS` and make both required options idempotent
- add focused coverage for empty, existing, split-import, and equals-import option forms

A clean current-develop worktree previously failed before capture because Vite loaded `@elizaos/cloud-routing/src/index.ts` and plain Node could not resolve its NodeNext `./features.js` specifier to `features.ts`. The unmodified audit command now builds the renderer and completes the entire matrix; no caller-side `NODE_OPTIONS` workaround is needed.

## Verification

- clean `bun install --frozen-lockfile --ignore-scripts` — pass
- focused Vitest — 4/4 pass
- `bun run audit:test-integrity` — pass; 5,883 files scanned, zero blocking issues
- `bun run audit:error-policy-ratchet` — pass
- Biome check on all three touched files — pass
- `bun run --cwd packages/app audit:app` with no environment override — 241/241 Playwright views pass; broken=0, needs-work=0, minimalism failures=0, undebted regressions=0; OCR broken=0
- manual review — mobile and desktop home/chat captures render correctly; this change does not alter product pixels

The six unrelated hover-probe timeouts are the existing transcript, Birdclaw, and calendar probes; they do not affect computed page verdicts or this runner fix.

## Evidence

<!-- evidence-row:before-screenshots -->
Before screenshots: N/A - test-runner process bootstrap only; no product UI changed. The pre-fix failure is the `ERR_MODULE_NOT_FOUND` trace recorded in #15782.

<!-- evidence-row:after-screenshots -->
After screenshots: N/A - no visual delta. The full app audit generated and manually reviewed all current captures.

<!-- evidence-row:walkthrough-video -->
Walkthrough video: N/A - no user-facing flow changed.

<!-- evidence-row:backend-logs -->
Backend logs: N/A - no backend runtime changed.

<!-- evidence-row:frontend-logs -->
Frontend logs: N/A - no frontend runtime changed; the app capture report is the proof surface.

<!-- evidence-row:llm-trajectory -->
Real-LLM trajectory: N/A - no agent, prompt, action, provider, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
Domain artifacts: [full app audit report](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15794-app-audit-report.json) and [OCR triage report](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15794-ocr-triage.json), produced by the unmodified command and manually reviewed.

### Review artifacts

- [Full app audit report](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15794-app-audit-report.json)
- [OCR triage report](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15794-ocr-triage.json)