### PR TITLE
fix(ci): green Zero-Key PR E2E lanes (renderer-build eliza-source leak + coverage/accounts source resolution)

### DIFF
--- a/.github/workflows/scenario-pr.yml
+++ b/.github/workflows/scenario-pr.yml
@@ -847,17 +847,24 @@ jobs:
       # plugin routes covered/exempt, view ship-gates intact, zero blocking gaps.
       # The advisory cycle is complete, so the ratchets (route-manifest lockstep,
       # zero-test plugins, no-blocking-gaps) now fail the build on regression.
+      # `--conditions=eliza-source`: inventory.ts scans plugin SOURCE and reaches
+      # plugin-commands/src → @elizaos/core, which under bun's default `bun`
+      # export condition resolves to unbuilt dist on this --ignore-scripts install.
+      # The source condition resolves those workspace packages to src (same as the
+      # matrix-report step below), so the gate runs before build:core (#15759).
       - name: E2E coverage ship-gate
         env:
           E2E_COVERAGE_GATE_ENFORCE: "1"
-        run: bun test packages/scripts/__tests__/e2e-coverage.test.ts
+        run: bun test --conditions=eliza-source packages/scripts/__tests__/e2e-coverage.test.ts
 
       # Per-plugin keyless-e2e coverage gate (issue #8801). The surface matrix
       # above proves app-facing routes/views; this ratchet proves each plugin
       # with user-facing capabilities has a deterministic, credential-free
       # scenario or an explicit baseline entry.
+      # Source condition for the same reason as the ship-gate step: this test
+      # imports inventory.ts, which resolves plugin source → @elizaos/core (#15759).
       - name: Per-plugin keyless e2e coverage self-test
-        run: bun test packages/scripts/e2e-coverage/check-e2e-coverage.test.ts
+        run: bun test --conditions=eliza-source packages/scripts/e2e-coverage/check-e2e-coverage.test.ts
 
       # #15616: pass/fail classifier for the live cloud chat smokes
       # (hetzner-e2e-chat, live-cloud-provision-smoke). packages/scripts is

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ensure-plugin-test-conventions": "bun packages/scripts/ensure-plugin-test-conventions.mjs",
     "ensure-plugin-test-conventions:check": "bun packages/scripts/ensure-plugin-test-conventions.mjs --check",
     "trajectory:inspect": "bun packages/scripts/trajectory.ts",
-    "audit:e2e-coverage": "bun packages/scripts/e2e-coverage/check-e2e-coverage.ts",
+    "audit:e2e-coverage": "bun --conditions=eliza-source packages/scripts/e2e-coverage/check-e2e-coverage.ts",
     "soc2:verify": "bun run packages/security/soc2-verify/src/cli.ts",
     "audit:even-research": "node scripts/check-even-research-audit.mjs",
     "audit:even-research:self-test": "node scripts/check-even-research-audit.mjs --self-test",

--- a/packages/app-core/scripts/playwright-ui-live-stack.ts
+++ b/packages/app-core/scripts/playwright-ui-live-stack.ts
@@ -244,6 +244,38 @@ function resolveBunCommand(): string {
   return process.platform === "win32" ? "bun.exe" : "bun";
 }
 
+/**
+ * NODE_OPTIONS with the `--conditions=eliza-source` token removed, for build
+ * subprocesses that must resolve workspace packages through their normal
+ * (dist/browser) exports rather than source.
+ *
+ * The Playwright runner exports `NODE_OPTIONS=--conditions=eliza-source` so its
+ * spec collector resolves app-core/agent source on a fresh `--ignore-scripts`
+ * install (run-ui-playwright.mjs, #15764). That condition must NOT reach the
+ * Vite renderer build: `node vite.js build` loads `vite.config.ts` under node's
+ * native ESM/type-stripping loader, which — unlike tsx — does not rewrite
+ * `.js`→`.ts` import specifiers. Under `eliza-source` a package like
+ * `@elizaos/cloud-routing` resolves to `src/index.ts`, whose internal
+ * `import "./features.js"` has no on-disk match, and the whole build dies at
+ * config load (#15759). The renderer build resolves those packages via Vite's
+ * own bundler/aliases and their built dist, so it never needs the condition.
+ */
+function nodeOptionsWithoutElizaSource(): string {
+  const tokens = (process.env.NODE_OPTIONS ?? "").split(/\s+/).filter(Boolean);
+  const kept = tokens.filter((token, index) => {
+    if (token === "--conditions=eliza-source") return false;
+    // Also handle the space-separated `--conditions eliza-source` form.
+    if (token === "--conditions" && tokens[index + 1] === "eliza-source") {
+      return false;
+    }
+    if (token === "eliza-source" && tokens[index - 1] === "--conditions") {
+      return false;
+    }
+    return true;
+  });
+  return kept.join(" ");
+}
+
 function resolveExecutableFromPath(command: string): string | null {
   const pathValue = process.env.PATH ?? process.env.Path ?? "";
   if (!pathValue) return null;
@@ -819,6 +851,10 @@ async function ensureUiDistReady(): Promise<void> {
     cwd: APP_DIR,
     env: {
       ...process.env,
+      // The renderer build resolves workspace packages via Vite/dist, not the
+      // Playwright collector's `eliza-source` condition; leaving it in leaks
+      // into `node vite.js build`'s config load and kills it (#15759).
+      NODE_OPTIONS: nodeOptionsWithoutElizaSource(),
       FORCE_COLOR: "0",
       VITE_ELIZA_RENDER_TELEMETRY: "1",
       // ui-smoke serves the dist locally and never ships it, so skip the
@@ -966,6 +1002,10 @@ async function ensureLiveStackOptionalViewPluginsReady(): Promise<void> {
       cwd: pluginDir,
       env: {
         ...process.env,
+        // Same reason as the renderer build: a plugin's own build must resolve
+        // through dist/Vite, not the collector's `eliza-source` condition
+        // (#15759).
+        NODE_OPTIONS: nodeOptionsWithoutElizaSource(),
         FORCE_COLOR: "0",
       },
       stdio: ["ignore", "pipe", "pipe"],

--- a/packages/app/e2e/accounts-ui/tsconfig.e2e-paths.json
+++ b/packages/app/e2e/accounts-ui/tsconfig.e2e-paths.json
@@ -4,7 +4,11 @@
     "packages/app-core has no `bun`/`eliza-source` export condition, so the accounts",
     "routes' dynamic import of @elizaos/app-core/account-pool would resolve to a",
     "possibly-stale dist build. This paths mapping pins app-core and its workspace",
-    "dependencies to current source so the e2e always tests the tree it runs from."
+    "dependencies to current source so the e2e always tests the tree it runs from.",
+    "@elizaos/core/src pins force every transitive workspace dep core's source",
+    "reaches to be pinned too (e.g. cloud-routing, imported by core/src/cloud-routing.ts",
+    "since #14459): otherwise it resolves to the package's `dist/index.js`, which does",
+    "not exist on the CI --ignore-scripts install, and the API server crashes at boot."
   ],
   "compilerOptions": {
     "baseUrl": "../../../..",
@@ -13,6 +17,8 @@
         "packages/app-core/src/services/account-pool.ts"
       ],
       "@elizaos/core": ["packages/core/src/index.ts"],
+      "@elizaos/cloud-routing": ["packages/cloud/routing/src/index.ts"],
+      "@elizaos/cloud-routing/*": ["packages/cloud/routing/src/*"],
       "@elizaos/shared": ["packages/shared/src/index.ts"],
       "@elizaos/shared/*": ["packages/shared/src/*"]
     }


### PR DESCRIPTION
## What

Drives the **Zero-Key Scenario PR E2E** lanes green. Run
[29051672668](https://github.com/elizaOS/eliza/actions/runs/29051672668)
(develop@`30469f6511e`, which already includes today's #15736 / #15757 / #15764 /
#15778 / #15784) still failed **14 Zero-Key jobs**. Those source-condition fixes
took effect and uncovered three new walls (plus one aggregator). This PR walks
all of them in one pass.

Refs run 29051672668, issue #15759.

## The walls

### Wall A — 11 ui-smoke browser lanes + the walkthrough died at the renderer build

**Red signature** (every browser lane, run 29051672668):

```
[ui-smoke] failed to start live stack: Error: app renderer build failed (exit 1).
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../packages/cloud/routing/src/features.js'
  imported from '.../packages/cloud/routing/src/index.ts'
```

**Root cause.** #15764 made `run-ui-playwright.mjs` append
`--conditions=eliza-source` to `NODE_OPTIONS` for **all** ui-smoke lanes so the
Playwright spec collector resolves app-core/agent source on a fresh
`--ignore-scripts` install. `NODE_OPTIONS` propagates into child processes, so
the renderer build (`playwright-ui-live-stack.ts` → `ensureUiDistReady` →
`bun run build:web` → `node vite.js build`) inherited it too. Node's native
TypeScript loader — unlike `tsx` — does **not** rewrite `.js`→`.ts` import
specifiers, so under `eliza-source` `@elizaos/cloud-routing` resolves to
`src/index.ts`, whose `import "./features.js"` has no on-disk match, and the
whole build dies **at vite config load**, before any spec runs.

**Fix.** Strip `--conditions=eliza-source` from the `NODE_OPTIONS` handed to the
renderer-build subprocess (and the optional-plugin build) in
`playwright-ui-live-stack.ts`. The renderer build resolves workspace packages via
Vite/dist and never needs the condition — this is exactly the pre-#15764
renderer-build behavior, so the produced bundle is unchanged. #15764's
spec-collection fix stays intact.

**Green proof** — full `onboarding-to-home` ui-smoke lane through the fixed
renderer build:

```
@elizaos/core:build: ✓ Built 4 file(s) ...        # coreBuild also builds cloud-routing dist
  ✓  1 …onboarding-to-home.spec.ts:70  Local onboarding lands on the home … (15.8s)
  ✓  2 …Cloud onboarding connects, binds an agent, and lands on the home (6.2s)
  ✓  3 …Local cloud-inference onboarding completes in chat (8.0s)
  ✓  4 …Other provider completes in chat and hands off to Settings … (7.1s)
  ✓  5 …Remote connect adopts a host and replaces onboarding … (5.1s)
  ✓  6 …tutorial CHOICE 'Take the tutorial' completes onboarding … (10.1s)
  6 passed (3.3m)
```

Directly confirmed at the build level too: `bun run build:web` with
`NODE_OPTIONS=--conditions=eliza-source` fails with the exact `features.js`
`ERR_MODULE_NOT_FOUND`; without it, exit 0.

### Wall B — Zero-Key scenario runner E2E: E2E coverage ship-gate

**Red signature** (run 29051672668, `E2E coverage ship-gate` step):

```
# Unhandled error between tests
error: Cannot find module '@elizaos/core' from
  '.../plugins/plugin-commands/src/actions/handlers.ts'
```

**Root cause.** `e2e-coverage/inventory.ts` imports `plugin-commands/src`
(added in #14459 as "dependency-light"), but `shortcuts.ts` → `handlers.ts`
carries a **runtime** `@elizaos/core` import. Under `bun test`, core's default
`bun` export condition resolves to unbuilt `dist/node/index.node.js`, and this
step runs **before** `build:core`.

**Fix.** Run the three coverage steps that scan plugin source with
`--conditions=eliza-source` (the same pattern the `E2E coverage matrix report`
step in this very job already uses) so those workspace packages resolve to src:
the two `bun test` steps in `scenario-pr.yml`, and the root `audit:e2e-coverage`
script (which inherently scans plugin source).

**Green proof** — core `dist/` moved aside to mirror the CI `--ignore-scripts`
install:

| command | without flag | with `--conditions=eliza-source` |
| --- | --- | --- |
| `e2e-coverage.test.ts` | `Cannot find module '@elizaos/core'` — 0 pass / 1 fail | **9 pass / 0 fail** |
| `check-e2e-coverage.test.ts` | `Cannot find module '@elizaos/core'` — 0 pass / 1 fail | **10 pass / 0 fail** |
| `audit:e2e-coverage` | (would fail) | **`[e2e-coverage] OK — 38 surface plugin(s) have keyless e2e`** |

### Wall C — Zero-Key accounts UI e2e: real API server crashed at boot

**Red signature** (run 29051672668):

```
[api] Internal error: directory mismatch for directory ".../tsconfig.e2e-paths.json", fd 4. …
[api] error: Cannot find module '@elizaos/cloud-routing' from '.../packages/core/src/cloud-routing.ts'
Error: API server exited early (code 1)
```

**Root cause.** The accounts-ui API server runs `bun --tsconfig-override
tsconfig.e2e-paths.json`, which pins `@elizaos/core`→src. `core/src/cloud-routing.ts`
(added #14459) imports `@elizaos/cloud-routing`, which the override never pinned →
it resolved to the package's missing `dist/index.js` on the `--ignore-scripts`
install.

**Fix.** Pin `@elizaos/cloud-routing` (a pure leaf package — no `@elizaos`
imports, no deps) to src in the paths override, exactly as `@elizaos/core` and
`@elizaos/shared` already are.

**Green proof** — reproduced **byte-for-byte under bun canary `fc865b398`** (the
exact CI build) with `cloud-routing/dist` removed:

```
# BEFORE fix (current paths):
Internal error: directory mismatch for directory ".../tsconfig.e2e-paths.json", fd 4. …
error: Cannot find module '@elizaos/cloud-routing' from '.../packages/core/src/cloud-routing.ts'
Bun v1.4.0-canary.1+fc865b398 (Linux x64)

# AFTER fix (cloud-routing pinned to src), same canary, no dist:
{"ready":true,"port":34114}          # server boots and stays up
```

Full lane (`test:e2e:accounts-ui`): **`ALL ASSERTIONS PASSED — 13 screenshots`**.

### Wall D — Zero-Key Deterministic E2E

Pure aggregator over the lanes above (`needs:` + a result check); goes green once
its dependency lanes do. No independent fix.

## The 14 lanes

| Lane | Wall | Status |
| --- | --- | --- |
| app browser core | A | fixed (onboarding lane 6/6 green through fixed build) |
| app browser view lifecycle | A | fixed (renderer build + spec collection green; specs = CI baseline 56 pass) |
| app browser all-pages | A | fixed (shared Wall A gate) |
| app browser feature interactions | A | fixed (shared Wall A gate) |
| app browser cloud keyless | A | fixed (shared Wall A gate) |
| app browser ratcheted | A | fixed (shared Wall A gate) |
| app browser auto-discovered specs | A | fixed (shared Wall A gate) |
| app browser dashboard device matrix | A | fixed (shared Wall A gate) |
| app browser Pixel-7 real-touch lane | A | fixed (shared Wall A gate) |
| app browser WebKit lane | A | fixed (shared Wall A gate) |
| full-walkthrough (mock lane) | A | fixed (same live-stack renderer build) |
| accounts UI e2e | C | fixed (canary-authentic repro; full lane ALL ASSERTIONS PASSED) |
| scenario runner E2E | B | fixed (all 3 coverage commands fail-without/pass-with, dist aside) |
| Deterministic E2E | D | auto-greens once deps pass |

## Residuals (documented, not chased — per #15759)

- **Single-spec flakes (#15759).** The pre-#15764 develop run
  [29047871132](https://github.com/elizaOS/eliza/actions/runs/29047871132) ran
  `plugin-views-lifecycle.spec.ts` to **`56 passed (9.6m)`** on a dedicated
  runner, with `1 failed` elsewhere in the job — the known #15759 per-spec
  locator flake class. Those are not touched here; if a spec fails identically on
  baseline it is a #15759 residual.
- **Local sandbox load.** This shared fleet VPS ran at load-avg ~21 (multiple
  concurrent worktree playwright lanes), so a full 56-spec local lane compounds
  into uniform ~24s environmental timeouts. The short 6-spec onboarding lane
  still completed 6/6, and the CI baseline above shows the 56-spec lane green on a
  dedicated runner. No code cause — the renderer build my fix produces is
  byte-equivalent to the pre-#15764 build that logged `56 passed`.
- **Pixel-7 real-touch** runs as the `mobile-chromium` Playwright project (not
  physical hardware) and shares the Wall A gate; no hardware dependency here.

## Verification discipline

- No assertions weakened; the fixes are export-condition/resolution plumbing only.
- `bunx biome check` clean on touched files. `bun.lock` untouched. YAML/JSON valid.
- bun canary (`fc865b398`, CI's exact build) installed to a scratch dir to
  reproduce Wall C authentically without clobbering the workspace bun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)