### PR TITLE
test(core): restore v5 widget-marker delivery coverage

### DIFF
--- a/packages/core/src/__tests__/message-v5-widget-markers.test.ts
+++ b/packages/core/src/__tests__/message-v5-widget-markers.test.ts
@@ -1,13 +1,5 @@
 /**
- * Integration coverage for interactive widget markers on the v5 reply path
- * (#14658, #14659), driven through `runV5MessageRuntimeStage1` with real
- * action handlers and a queued canned-model runtime (no live model, no DB).
- * Pins the three delivery channels end to end against the shared interaction
- * grammar that every render boundary (dashboard, Discord, Telegram) parses:
- * an action's callback-emitted [CHOICE] block reaches the connector callback
- * verbatim, an action's `verifiedUserFacing` [CHOICE] payload beats evaluator
- * paraphrase as the turn's final message, and a model-authored [FORM]
- * messageToUser survives the evaluator boundary and reply sanitizers intact.
+ * Exercises callback, verified-payload, and evaluator widget-marker delivery through stage 1 with deterministic fixtures (#14658, #14659).
  */
 import { describe, expect, it, vi } from "vitest";
 import { parseInteractionBlocks } from "../messaging/interactions/parse";

--- a/packages/core/src/__tests__/message-v5-widget-markers.test.ts
+++ b/packages/core/src/__tests__/message-v5-widget-markers.test.ts
@@ -1,0 +1,353 @@
+/**
+ * Integration coverage for interactive widget markers on the v5 reply path
+ * (#14658, #14659), driven through `runV5MessageRuntimeStage1` with real
+ * action handlers and a queued canned-model runtime (no live model, no DB).
+ * Pins the three delivery channels end to end against the shared interaction
+ * grammar that every render boundary (dashboard, Discord, Telegram) parses:
+ * an action's callback-emitted [CHOICE] block reaches the connector callback
+ * verbatim, an action's `verifiedUserFacing` [CHOICE] payload beats evaluator
+ * paraphrase as the turn's final message, and a model-authored [FORM]
+ * messageToUser survives the evaluator boundary and reply sanitizers intact.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { parseInteractionBlocks } from "../messaging/interactions/parse";
+import { BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS } from "../runtime/builtin-field-evaluators";
+import { ResponseHandlerFieldRegistry } from "../runtime/response-handler-field-registry";
+import { runV5MessageRuntimeStage1 } from "../services/message";
+import type {
+	Action,
+	ActionResult,
+	HandlerCallback,
+	HandlerOptions,
+} from "../types/components";
+import type { ChoiceInteraction, FormInteraction } from "../types/interactions";
+import type { Memory } from "../types/memory";
+import type { UUID } from "../types/primitives";
+import type { IAgentRuntime } from "../types/runtime";
+import type { State } from "../types/state";
+
+const MSG_ID = "00000000-0000-0000-0000-000000000001" as UUID;
+const SENDER_ID = "00000000-0000-0000-0000-000000000002" as UUID;
+const AGENT_ID = "00000000-0000-0000-0000-000000000003" as UUID;
+const ROOM_ID = "00000000-0000-0000-0000-000000000004" as UUID;
+const RESPONSE_ID = "00000000-0000-0000-0000-000000000005" as UUID;
+
+const CHOICE_BLOCK = [
+	"I found an installed app named Notes. What would you like to do?",
+	"[CHOICE:app-create id=intent-1]",
+	"new=Create a new app",
+	"edit-1=Edit existing: Notes",
+	"cancel=Cancel",
+	"[/CHOICE]",
+].join("\n");
+
+const FORM_BLOCK = [
+	"Here are the details I need:",
+	"[FORM]",
+	JSON.stringify({
+		id: "reminder-form",
+		title: "Reminder details",
+		fields: [
+			{ name: "report", type: "text", label: "Report name", required: true },
+			{ name: "day", type: "date", label: "Deadline day", required: true },
+			{ name: "time", type: "time", label: "Reminder time", required: true },
+		],
+	}),
+	"[/FORM]",
+].join("\n");
+
+function makeMessage(text: string): Memory {
+	return {
+		id: MSG_ID,
+		entityId: SENDER_ID,
+		agentId: AGENT_ID,
+		roomId: ROOM_ID,
+		content: { text, source: "test" },
+		createdAt: 1,
+	};
+}
+
+function makeState(): State {
+	return {
+		values: { availableContexts: "general, apps" },
+		data: {},
+		text: "Recent conversation summary",
+	};
+}
+
+function stage1Response(fields: {
+	contexts: string[];
+	thought: string;
+	candidateActionNames?: string[];
+}) {
+	return {
+		text: "",
+		toolCalls: [
+			{
+				id: "handle-response-1",
+				name: "HANDLE_RESPONSE",
+				arguments: {
+					shouldRespond: "RESPOND",
+					thought: fields.thought,
+					contexts: fields.contexts,
+					intents: [],
+					candidateActionNames: fields.candidateActionNames ?? [],
+					replyText: "",
+					facts: [],
+					relationships: [],
+					addressedTo: [],
+				},
+			},
+		],
+	};
+}
+
+function evaluatorFinish(messageToUser: string) {
+	return JSON.stringify({
+		success: true,
+		decision: "FINISH",
+		thought: "Turn complete.",
+		messageToUser,
+	});
+}
+
+function makeRuntime(opts: {
+	actions: Action[];
+	responses: unknown[];
+}): IAgentRuntime {
+	const queue = [...opts.responses];
+	const responseHandlerFieldRegistry = new ResponseHandlerFieldRegistry();
+	for (const evaluator of BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS) {
+		responseHandlerFieldRegistry.register(evaluator);
+	}
+	return {
+		agentId: AGENT_ID,
+		character: {
+			name: "Test Agent",
+			system: "You are concise.",
+			bio: "I help with practical tasks.",
+		},
+		actions: opts.actions,
+		providers: [],
+		responseHandlerFieldRegistry,
+		responseHandlerFieldEvaluators: [
+			...BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS,
+		],
+		emitEvent: vi.fn(async () => undefined),
+		runActionsByMode: vi.fn(async () => undefined),
+		useModel: vi.fn(async (modelType: unknown) => {
+			if (queue.length === 0) {
+				throw new Error(
+					`Unexpected useModel call (modelType=${String(modelType)}); queue empty`,
+				);
+			}
+			return queue.shift();
+		}),
+		logger: {
+			debug: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+			trace: vi.fn(),
+		},
+	} as IAgentRuntime;
+}
+
+function makeAction(opts: {
+	name: string;
+	handler: (
+		runtime: IAgentRuntime,
+		message: Memory,
+		state: State | undefined,
+		options: HandlerOptions,
+		callback?: HandlerCallback,
+	) => Promise<ActionResult>;
+}): Action {
+	return {
+		name: opts.name,
+		description: `${opts.name} test action`,
+		similes: [],
+		examples: [],
+		parameters: [],
+		validate: async () => true,
+		handler: opts.handler,
+	} as Action;
+}
+
+describe("v5 widget markers — action callback and verified payload channels", () => {
+	it("delivers an action's callback-emitted [CHOICE] block to the connector callback verbatim", async () => {
+		const connectorDeliveries: Array<{ text: string; actionName?: string }> =
+			[];
+		const connectorCallback: HandlerCallback = vi.fn(
+			async (response, actionName) => {
+				connectorDeliveries.push({
+					text: String(response.text ?? ""),
+					...(actionName !== undefined ? { actionName } : {}),
+				});
+				return [];
+			},
+		);
+		const picker = makeAction({
+			name: "APP_PICKER",
+			handler: async (_runtime, _message, _state, _options, callback) => {
+				await callback?.({ text: CHOICE_BLOCK });
+				return { success: true, text: "choice presented; awaiting pick" };
+			},
+		});
+		const runtime = makeRuntime({
+			actions: [picker],
+			responses: [
+				stage1Response({
+					contexts: ["general"],
+					thought: "App creation needs the picker action.",
+					candidateActionNames: ["APP_PICKER"],
+				}),
+				{
+					text: "",
+					toolCalls: [{ id: "call-1", name: "APP_PICKER", args: {} }],
+				},
+				evaluatorFinish("On it."),
+			],
+		});
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage("Create a notes app for me."),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+			callback: connectorCallback,
+		});
+
+		// The deterministic code-authored channel: the handler's widget text
+		// reached the connector callback verbatim, attributed to the action.
+		expect(connectorCallback).toHaveBeenCalledTimes(1);
+		expect(connectorDeliveries).toEqual([
+			{ text: CHOICE_BLOCK, actionName: "APP_PICKER" },
+		]);
+
+		// The delivered text parses at the render boundary with the shared
+		// grammar — exactly what the dashboard/Discord/Telegram renderers do.
+		const { blocks, cleanedText } = parseInteractionBlocks(
+			connectorDeliveries[0].text,
+		);
+		expect(blocks).toHaveLength(1);
+		const choice = blocks[0] as ChoiceInteraction;
+		expect(choice.kind).toBe("choice");
+		expect(choice.scope).toBe("app-create");
+		expect(choice.id).toBe("intent-1");
+		expect(choice.options.map((option) => option.value)).toEqual([
+			"new",
+			"edit-1",
+			"cancel",
+		]);
+		expect(cleanedText).toBe(
+			"I found an installed app named Notes. What would you like to do?",
+		);
+
+		// The evaluator's paraphrase stays the turn's final message; connectors
+		// dedup identical text per turn, so both channels may deliver safely.
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind === "planned_reply") {
+			expect(result.result.responseContent?.text).toBe("On it.");
+		}
+	});
+
+	it("prefers an action's verified [CHOICE] payload over the evaluator paraphrase", async () => {
+		const picker = makeAction({
+			name: "APP_PICKER",
+			handler: async () => ({
+				success: true,
+				text: "choice presented; awaiting pick",
+				userFacingText: CHOICE_BLOCK,
+				verifiedUserFacing: true,
+			}),
+		});
+		const runtime = makeRuntime({
+			actions: [picker],
+			responses: [
+				stage1Response({
+					contexts: ["general"],
+					thought: "App creation needs the picker action.",
+					candidateActionNames: ["APP_PICKER"],
+				}),
+				{
+					text: "",
+					toolCalls: [{ id: "call-1", name: "APP_PICKER", args: {} }],
+				},
+				evaluatorFinish("On it."),
+			],
+		});
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage("Create a notes app for me."),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+		});
+
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind !== "planned_reply") return;
+		// Verified user-facing payloads are priority 1 for the final message:
+		// the verbatim marker block wins over "On it.".
+		expect(result.result.responseContent?.text).toBe(CHOICE_BLOCK);
+		const { blocks } = parseInteractionBlocks(
+			String(result.result.responseContent?.text ?? ""),
+		);
+		expect(blocks).toHaveLength(1);
+		expect((blocks[0] as ChoiceInteraction).scope).toBe("app-create");
+	});
+
+	it("keeps a model-authored [FORM] messageToUser intact through the evaluator boundary", async () => {
+		const lookup = makeAction({
+			name: "REMINDER_LOOKUP",
+			handler: async () => ({
+				success: true,
+				text: "no matching reminder found; details required",
+			}),
+		});
+		const runtime = makeRuntime({
+			actions: [lookup],
+			responses: [
+				stage1Response({
+					contexts: ["general"],
+					thought: "Reminder request needs a lookup, then details.",
+					candidateActionNames: ["REMINDER_LOOKUP"],
+				}),
+				{
+					text: "",
+					toolCalls: [{ id: "call-1", name: "REMINDER_LOOKUP", args: {} }],
+				},
+				evaluatorFinish(FORM_BLOCK),
+			],
+		});
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage(
+				"I need a reminder — you'll need the report name, the day, and the time from me.",
+			),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+		});
+
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind !== "planned_reply") return;
+		// The [FORM] body is a JSON object on its own line — the reply
+		// sanitizers must treat it as user-visible interaction payload, not a
+		// JSON/tool attempt to strip (#14659).
+		expect(result.result.responseContent?.text).toBe(FORM_BLOCK);
+		const { blocks, cleanedText } = parseInteractionBlocks(
+			String(result.result.responseContent?.text ?? ""),
+		);
+		expect(blocks).toHaveLength(1);
+		const form = blocks[0] as FormInteraction;
+		expect(form.kind).toBe("form");
+		expect(form.id).toBe("reminder-form");
+		expect(form.fields.map((field) => field.name)).toEqual([
+			"report",
+			"day",
+			"time",
+		]);
+		expect(cleanedText).toBe("Here are the details I need:");
+	});
+});


### PR DESCRIPTION
Fixes #15799. Refs #14658 and #14659.

## Summary

The production fixes landed through #14666 and #14670, but forensic branch analysis found their later message-path regression test stranded on `fix/14658-14659-v5-marker-path`. This restores that test unchanged against current `develop`.

The three assertions cover callback-emitted `[CHOICE]`, verified action payload precedence over evaluator paraphrase, and model-authored `[FORM]` preservation through the evaluator boundary.

## Verification

- generated required i18n test data via the package prebuild
- focused Bun test: 3/3 pass, 21 assertions
- Biome: pass
- diff check: pass

## Evidence

<!-- evidence-row:before-screenshots -->
Before screenshots: N/A - test-only change; no product pixels change.

<!-- evidence-row:after-screenshots -->
After screenshots: N/A - test-only change; no product pixels change.

<!-- evidence-row:walkthrough-video -->
Walkthrough video: N/A - test-only restoration.

<!-- evidence-row:backend-logs -->
Backend logs: N/A - test-only restoration; the CI check output is the verification surface and no server process behavior changed.

<!-- evidence-row:frontend-logs -->
Frontend logs: N/A - no frontend code changed.

<!-- evidence-row:llm-trajectory -->
Real-LLM trajectory: N/A - no model/runtime behavior changed; this PR only restores deterministic regression coverage for behavior already live on `develop`.

<!-- evidence-row:domain-artifacts -->
Domain artifacts: N/A - the test uses isolated in-memory message-path fixtures and writes no persistent state.
