### PR TITLE
fix(build): verify plugin-elizacloud dist exports

### DIFF
--- a/plugins/plugin-elizacloud/package.json
+++ b/plugins/plugin-elizacloud/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "main": "dist/node/index.node.js",
   "module": "dist/node/index.node.js",
-  "types": "dist/node/index.d.ts",
+  "types": "dist/index.node.d.ts",
   "browser": "dist/browser/index.browser.js",
   "sideEffects": false,
   "repository": {
@@ -14,19 +14,19 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "types": "./dist/node/index.d.ts",
+      "types": "./dist/index.node.d.ts",
       "eliza-source": {
         "types": "./src/index.node.ts",
         "import": "./src/index.node.ts",
         "default": "./src/index.node.ts"
       },
       "browser": {
-        "types": "./dist/browser/index.d.ts",
+        "types": "./dist/index.browser.d.ts",
         "import": "./dist/browser/index.browser.js",
         "default": "./dist/browser/index.browser.js"
       },
       "node": {
-        "types": "./dist/node/index.d.ts",
+        "types": "./dist/index.node.d.ts",
         "import": "./dist/node/index.node.js",
         "default": "./dist/node/index.node.js"
       },
@@ -131,7 +131,7 @@
     "test:unit": "vitest run __tests__/unit/",
     "test:integration": "vitest run __tests__/integration/",
     "lint:check": "bunx @biomejs/biome check .",
-    "build": "bun run build.ts && bun run build:views",
+    "build": "bun run build.ts && bun run build:views && node scripts/verify-built-package.mjs",
     "build:ts": "bun run build.ts",
     "build:views": "bunx --bun vite build --config vite.config.views.ts",
     "test:e2e": "node ../../packages/app-core/scripts/run-local-plugin-live-smoke.mjs",

--- a/plugins/plugin-elizacloud/scripts/verify-built-package.mjs
+++ b/plugins/plugin-elizacloud/scripts/verify-built-package.mjs
@@ -1,0 +1,52 @@
+/**
+ * Verifies the published Node entry under default package conditions after a
+ * build. Clearing NODE_OPTIONS prevents source-resolution flags from hiding a
+ * missing or internally broken dist artifact.
+ */
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const probe = `
+  const module = await import("@elizaos/plugin-elizacloud");
+  if (module.default !== module.elizaOSCloudPlugin) {
+    throw new Error("default and named plugin exports differ");
+  }
+  if (module.default?.name !== "elizaOSCloud") {
+    throw new Error("built plugin export is missing or malformed");
+  }
+`;
+
+export function verifyBuiltPackage({
+  spawn = spawnSync,
+  environment = process.env,
+  executable = process.execPath,
+} = {}) {
+  const env = { ...environment };
+  delete env.NODE_OPTIONS;
+  const result = spawn(executable, ["--input-type=module", "--eval", probe], {
+    cwd: packageDir,
+    env,
+    encoding: "utf8",
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `Default-condition built-package import failed:\n${result.stderr || result.stdout}`,
+    );
+  }
+}
+
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  verifyBuiltPackage();
+  process.stdout.write(
+    "[plugin-elizacloud] default-condition dist import passed\n",
+  );
+}

--- a/plugins/plugin-elizacloud/scripts/verify-built-package.test.mjs
+++ b/plugins/plugin-elizacloud/scripts/verify-built-package.test.mjs
@@ -1,0 +1,35 @@
+/**
+ * Proves the dist probe cannot inherit source conditions or hide child failures.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { verifyBuiltPackage } from "./verify-built-package.mjs";
+
+describe("verifyBuiltPackage", () => {
+  it("imports with default conditions in an isolated child", () => {
+    const spawn = vi.fn(() => ({ status: 0, stdout: "", stderr: "" }));
+
+    verifyBuiltPackage({
+      spawn,
+      environment: {
+        NODE_OPTIONS: "--conditions=eliza-source --trace-warnings",
+        PATH: "/bin",
+      },
+      executable: "/node",
+    });
+
+    expect(spawn).toHaveBeenCalledOnce();
+    const [command, args, options] = spawn.mock.calls[0];
+    expect(command).toBe("/node");
+    expect(args).toContain("--input-type=module");
+    expect(args.join(" ")).toContain("@elizaos/plugin-elizacloud");
+    expect(options.env).toEqual({ PATH: "/bin" });
+  });
+
+  it("fails when the built public import fails", () => {
+    expect(() =>
+      verifyBuiltPackage({
+        spawn: () => ({ status: 1, stdout: "", stderr: "missing dist entry" }),
+      }),
+    ).toThrow("missing dist entry");
+  });
+});


### PR DESCRIPTION
Fixes #15779.

## Summary

- point the public Node and browser type conditions directly at declarations emitted by `tsc`, instead of routing consumers through alias shims
- keep the compatibility shims NodeNext-safe with explicit `.js` specifiers
- make every plugin build spawn a clean default-condition Node process with `NODE_OPTIONS` removed and import the package by its public name
- assert the default and named plugin exports are the same valid `elizaOSCloud` plugin

This closes the source-condition blind spot: `eliza-source` can no longer make the package build green while the published Node entry is missing or internally unresolved.

## Verification

- clean `bun run --cwd plugins/plugin-elizacloud build` — pass; Node, browser, CJS, declarations, views, and default-condition import all completed
- clean public import transcript: `[plugin-elizacloud] default-condition dist import passed`
- `bun run --cwd plugins/plugin-elizacloud typecheck` — pass after generating the repository keyword declarations required by a fresh worktree
- focused Biome and `git diff --check` — pass
- `bun run audit:error-policy-ratchet` — pass
- `bun run audit:test-integrity` — pass; 5,888 files scanned, zero blockers

## Evidence

<!-- evidence-row:before-screenshots -->
Before screenshots: N/A - package build/export behavior only; no rendered UI changed.

<!-- evidence-row:after-screenshots -->
After screenshots: N/A - no visual surface changed.

<!-- evidence-row:walkthrough-video -->
Walkthrough video: N/A - the affected user flow is a headless package import, proven by the build transcript.

<!-- evidence-row:backend-logs -->
Backend logs: N/A - no running backend service changed.

<!-- evidence-row:frontend-logs -->
Frontend logs: N/A - no frontend code changed.

<!-- evidence-row:llm-trajectory -->
Real-LLM trajectory: N/A - no agent, prompt, action, provider, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
Domain artifacts: [emitted Node declaration artifact](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15801-index.node.d.ts), produced by the clean build and manually inspected; the default-condition child import also passed.
