### PR TITLE
fix(evidence): plugin-view smoke proves current production bundles (#15791)

### DIFF
--- a/packages/app-core/scripts/playwright-ui-smoke-api-stub.mjs
+++ b/packages/app-core/scripts/playwright-ui-smoke-api-stub.mjs
@@ -10,6 +10,18 @@ import {
   parseHostExternalSpecifiers,
   wrapBundleAsHostExternalFactory,
 } from "../../agent/src/api/dynamic-view-host-external.mjs";
+// The declarations + provenance decision live in one place so a removed plugin
+// cannot linger in the stub and a fabricated bundle can never masquerade as the
+// production one. Audit mode (ELIZA_UI_SMOKE_REQUIRE_REAL_BUNDLES=1) turns a
+// missing real bundle into an observable 424 instead of a synthesized surface.
+import {
+  resolveBundleProvenance,
+  smokeViewDeclarations,
+  VIEW_BUNDLE_PROVENANCE_HEADER,
+} from "./smoke-view-declarations.mjs";
+
+const REQUIRE_REAL_VIEW_BUNDLES =
+  process.env.ELIZA_UI_SMOKE_REQUIRE_REAL_BUNDLES === "1";
 
 const port = Number(process.env.ELIZA_UI_SMOKE_API_PORT || "31337");
 const repoRoot = path.resolve(
@@ -64,119 +76,10 @@ const SMOKE_VOICE_TRANSCRIPT = "this is the voice smoke transcript";
 // the overlay's TTS output is non-empty and the assistant bubble is assertable.
 const SMOKE_VOICE_REPLY = "Got it, this is the spoken reply.";
 
-// The smoke stub mirrors shipped plugin views: one GUI declaration per route.
-// The viewType contract still accepts future modalities, but this fixture should
-// not manufacture concrete XR/TUI rows that production no longer ships.
-const smokeViewDeclarations = [
-  ["birdclaw", "Birdclaw", "plugin-birdclaw", "/birdclaw", "BirdclawView"],
-  ["contacts", "Contacts", "plugin-contacts", "/contacts", "ContactsView"],
-  [
-    "hyperliquid",
-    "Hyperliquid",
-    "plugin-hyperliquid",
-    "/hyperliquid",
-    "HyperliquidView",
-  ],
-  // NOTE: the LifeOps overview view was removed (PA no longer registers a
-  // `lifeops` view). Its stub entries are deleted so the smoke launcher matches
-  // production. The decomposed per-domain views below are the real surfaces.
-  // Decomposed personal-assistant domain views — registered so their dynamic
-  // bundles load in keyless ui-smoke and the decomposed-interactions spec can
-  // drive them (closing INTERACTION_DEBT in view-interaction-coverage.test.ts).
-  // NOTE: "documents" is intentionally NOT registered here — its view path
-  // `/documents` collides with the built-in "documents" tab (App.tsx findView
-  // matches `/${tab}`), which would hijack the `/character/documents` route.
-  ["calendar", "Calendar", "plugin-calendar", "/calendar", "CalendarView"],
-  ["finances", "Finances", "plugin-finances", "/finances", "FinancesView"],
-  ["focus", "Focus", "plugin-blocker", "/focus", "FocusView"],
-  ["goals", "Goals", "plugin-goals", "/goals", "GoalsView"],
-  ["health", "Health", "plugin-health", "/health", "HealthView"],
-  ["inbox", "Inbox", "plugin-inbox", "/inbox", "InboxView"],
-  ["todos", "Todos", "plugin-todos", "/todos", "TodosView"],
-  [
-    "relationships",
-    "Relationships",
-    "plugin-relationships",
-    "/relationships",
-    "RelationshipsView",
-  ],
-  ["messages", "Messages", "plugin-messages", "/messages", "MessagesView"],
-  [
-    "model-tester",
-    "Model Tester",
-    "app-model-tester",
-    "/model-tester",
-    "ModelTesterView",
-  ],
-  ["phone", "Phone", "plugin-phone", "/phone", "PhoneView"],
-  [
-    "polymarket",
-    "Polymarket",
-    "plugin-polymarket",
-    "/polymarket",
-    "PolymarketView",
-  ],
-  ["shopify", "Shopify", "plugin-shopify", "/shopify", "ShopifyView"],
-  ["steward", "Steward", "plugin-steward", "/steward", "StewardView"],
-  [
-    "wallet",
-    "Wallet",
-    "plugin-wallet-ui",
-    "/wallet",
-    "InventoryView",
-  ],
-  [
-    "vector-browser",
-    "Vector Browser",
-    "plugin-vector-browser",
-    "/vector-browser",
-    "VectorBrowserView",
-  ],
-  ["feed", "Feed", "plugin-feed", "/feed", "FeedView"],
-  [
-    "views-manager",
-    "Views",
-    "plugin-app-control",
-    "/views",
-    "ViewManagerView",
-  ],
-  [
-    "screenshare",
-    "Screenshare",
-    "plugin-screenshare",
-    "/screenshare",
-    "ScreenshareView",
-  ],
-  [
-    "social-alpha",
-    "Social Alpha",
-    "plugin-social-alpha",
-    "/social-alpha",
-    "SocialAlphaView",
-  ],
-  [
-    "task-coordinator",
-    "Task Coordinator",
-    "plugin-task-coordinator",
-    "/task-coordinator",
-    "TaskCoordinatorView",
-  ],
-  [
-    "orchestrator",
-    "Orchestrator",
-    "plugin-task-coordinator",
-    "/orchestrator",
-    "OrchestratorView",
-  ],
-  [
-    "trajectory-logger",
-    "Trajectory Logger",
-    "plugin-trajectory-logger",
-    "/trajectory-logger",
-    "TrajectoryLoggerView",
-  ],
-  ["training", "Fine Tuning", "plugin-training", "/training", "FineTuningView"],
-];
+// `smokeViewDeclarations` is imported from ./smoke-view-declarations.mjs so it
+// stays pinned to shipping plugins by `checkSmokeViewParity` (removed views such
+// as Shopify/Steward/Social Alpha cannot reappear here). The viewType contract
+// still accepts future modalities; this fixture ships GUI-only rows.
 
 function smokeViewObject({
   id,
@@ -1787,22 +1690,71 @@ function sendSmokeViewAsset(req, res, url, view, subResource) {
     return;
   }
   const hostExternalSpecifiers = parseHostExternalSpecifiers(url);
-  if (!existsSync(assetPath)) {
-    if (subResource === "bundle.js") {
-      const source = smokeViewBundleSource(view);
+  if (subResource === "bundle.js") {
+    // The bundle route is the one an audit trusts to prove the production
+    // surface, so its provenance is always decided explicitly and echoed on the
+    // response header — real built bundle, marked synthesis, or (audit mode)
+    // observable failure — never a silent fabrication.
+    const provenance = resolveBundleProvenance({
+      viewId: view.id,
+      realBundleExists: existsSync(assetPath),
+      requireRealBundle: REQUIRE_REAL_VIEW_BUNDLES,
+    });
+    res.setHeader(VIEW_BUNDLE_PROVENANCE_HEADER, provenance.mode);
+    res.setHeader("X-Eliza-View-Component", view.componentExport);
+    res.setHeader("X-Eliza-View-Id", view.id);
+    if (provenance.mode === "missing-real-bundle") {
+      sendJson(req, res, provenance.status, {
+        error: `Missing production view bundle: ${view.pluginName}`,
+        viewId: view.id,
+        componentExport: view.componentExport,
+        provenance: provenance.mode,
+        expectedBundlePath: `plugins/${view._smokePluginDirName}/dist/views/bundle.js`,
+        hint: "Build the plugin view bundle (bun run build-views) before running the audit; audit mode refuses to fabricate a placeholder.",
+      });
+      return;
+    }
+    if (provenance.mode === "real-dist") {
+      const rawBody = readFileSync(assetPath);
       const body =
         hostExternalSpecifiers.length > 0
-          ? wrapBundleAsHostExternalFactory(source, hostExternalSpecifiers)
-          : source;
+          ? Buffer.from(
+              wrapBundleAsHostExternalFactory(
+                rawBody.toString("utf8"),
+                hostExternalSpecifiers,
+              ),
+              "utf8",
+            )
+          : rawBody;
       sendBinary(
         req,
         res,
-        200,
+        provenance.status,
         "application/javascript; charset=utf-8",
-        Buffer.from(body, "utf8"),
+        body,
       );
       return;
     }
+    // Non-audit synthesized placeholder: prefix a provenance banner so the byte
+    // stream itself, not just the header, marks the bundle as synthesized.
+    const banner =
+      `/* eliza-view-bundle-provenance: ${provenance.mode}; component=${view.componentExport}; view=${view.id} */\n` +
+      `globalThis.__ELIZA_VIEW_BUNDLE_PROVENANCE__ = Object.assign(globalThis.__ELIZA_VIEW_BUNDLE_PROVENANCE__ || {}, { ${JSON.stringify(view.id)}: ${JSON.stringify(provenance.mode)} });\n`;
+    const source = banner + smokeViewBundleSource(view);
+    const body =
+      hostExternalSpecifiers.length > 0
+        ? wrapBundleAsHostExternalFactory(source, hostExternalSpecifiers)
+        : source;
+    sendBinary(
+      req,
+      res,
+      provenance.status,
+      "application/javascript; charset=utf-8",
+      Buffer.from(body, "utf8"),
+    );
+    return;
+  }
+  if (!existsSync(assetPath)) {
     sendJson(req, res, 404, { error: `View asset not found: ${subResource}` });
     return;
   }

--- a/packages/app-core/scripts/smoke-view-bundle-provenance.test.ts
+++ b/packages/app-core/scripts/smoke-view-bundle-provenance.test.ts
@@ -1,0 +1,141 @@
+/**
+ * End-to-end contract for the UI-smoke stub's view-bundle route: boots the real
+ * stub server (no mocks) and asserts the provenance the stub actually emits over
+ * HTTP. Proves that audit mode fails observably instead of fabricating a bundle
+ * for a production-declared view, and that synthesized placeholders are marked
+ * as such on the wire (issue #15791).
+ */
+import { type ChildProcess, spawn } from "node:child_process";
+import { createServer } from "node:net";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { realViewBundleExists } from "./smoke-view-declarations.mjs";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "..",
+);
+const stubPath = path.join(
+  repoRoot,
+  "packages",
+  "app-core",
+  "scripts",
+  "playwright-ui-smoke-api-stub.mjs",
+);
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+async function bootStub(env: Record<string, string>): Promise<{
+  child: ChildProcess;
+  port: number;
+}> {
+  const port = await freePort();
+  const child = spawn("node", [stubPath], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      ELIZA_UI_SMOKE_API_PORT: String(port),
+      ...env,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error("stub did not start in time")),
+      30_000,
+    );
+    child.stdout?.on("data", (chunk) => {
+      if (String(chunk).includes("listening")) {
+        clearTimeout(timer);
+        resolve();
+      }
+    });
+    child.once("exit", (code) => {
+      clearTimeout(timer);
+      reject(new Error(`stub exited before ready (code ${code})`));
+    });
+  });
+  return { child, port };
+}
+
+let running: ChildProcess | null = null;
+afterEach(() => {
+  running?.kill("SIGKILL");
+  running = null;
+});
+
+describe("smoke view bundle provenance over HTTP (#15791)", () => {
+  // Whether a real dist bundle exists depends on prior builds; the provenance
+  // contract must hold in either state, so the expectations branch on it.
+  const walletHasRealBundle = realViewBundleExists(
+    repoRoot,
+    "plugin-wallet-ui",
+  );
+
+  it("audit mode returns an observable failure, never a fabricated bundle", async () => {
+    const { child, port } = await bootStub({
+      ELIZA_UI_SMOKE_REQUIRE_REAL_BUNDLES: "1",
+    });
+    running = child;
+    const response = await fetch(
+      `http://127.0.0.1:${port}/api/views/wallet/bundle.js`,
+    );
+    expect(response.headers.get("x-eliza-view-component")).toBe(
+      "InventoryView",
+    );
+    if (walletHasRealBundle) {
+      // A real bundle is present: audit mode must serve it, marked real-dist.
+      expect(response.status).toBe(200);
+      expect(response.headers.get("x-eliza-view-bundle-provenance")).toBe(
+        "real-dist",
+      );
+      return;
+    }
+    // No real bundle: audit mode refuses to fabricate one and fails observably.
+    expect(response.status).toBe(424);
+    expect(response.headers.get("x-eliza-view-bundle-provenance")).toBe(
+      "missing-real-bundle",
+    );
+    const body = await response.json();
+    expect(body.provenance).toBe("missing-real-bundle");
+    expect(body.expectedBundlePath).toContain(
+      "plugins/plugin-wallet-ui/dist/views/bundle.js",
+    );
+  });
+
+  it("non-audit marks synthesized placeholders on the wire and in bytes", async () => {
+    const { child, port } = await bootStub({});
+    running = child;
+    const response = await fetch(
+      `http://127.0.0.1:${port}/api/views/wallet/bundle.js`,
+    );
+    expect(response.status).toBe(200);
+    // The component name is echoed so an audit asserts the RIGHT component's
+    // surface rendered — a route cannot silently pass against the wrong one.
+    expect(response.headers.get("x-eliza-view-component")).toBe(
+      "InventoryView",
+    );
+    const provenance = response.headers.get("x-eliza-view-bundle-provenance");
+    const body = await response.text();
+    if (walletHasRealBundle) {
+      expect(provenance).toBe("real-dist");
+      return;
+    }
+    expect(provenance).toBe("synthesized-generic");
+    expect(body).toContain("eliza-view-bundle-provenance: synthesized-generic");
+    expect(body).toContain("InventoryView");
+  });
+});

--- a/packages/app-core/scripts/smoke-view-declarations.mjs
+++ b/packages/app-core/scripts/smoke-view-declarations.mjs
@@ -1,0 +1,241 @@
+/**
+ * Authoritative source of the plugin-view declarations the UI-smoke API stub
+ * serves, plus the parity check that pins them to the plugins that actually
+ * ship those views today.
+ *
+ * The smoke stub (`playwright-ui-smoke-api-stub.mjs`) answers `GET /api/views`
+ * with these rows and serves each view's `/api/views/<id>/bundle.js`. If a row
+ * survives here after its plugin is deleted, an audit renders a fabricated
+ * surface for a view production no longer registers — proving nothing. So the
+ * declarations live here next to `checkSmokeViewParity`, which fails the moment
+ * a declared view's plugin directory is gone or no longer exports the named
+ * component. Removed plugin IDs (Shopify, Steward, Social Alpha) are therefore
+ * kept out and cannot silently reappear.
+ *
+ * `resolveBundleProvenance` is the single decision the stub uses when serving a
+ * bundle: serve the real built `dist/views/bundle.js`, or — only outside audit
+ * mode — a clearly-marked synthesized placeholder. In audit mode a missing real
+ * bundle is a hard, observable failure, never a generic fabrication.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * One GUI declaration per shipped plugin view: `[id, label, pluginDirName,
+ * path, componentExport]`. Every entry must pass `checkSmokeViewParity` — its
+ * plugin directory exists and its source both declares the `id` and exports the
+ * `componentExport`. Do NOT add a view here for a plugin that no longer exists.
+ */
+export const smokeViewDeclarations = [
+  ["birdclaw", "Birdclaw", "plugin-birdclaw", "/birdclaw", "BirdclawView"],
+  ["contacts", "Contacts", "plugin-contacts", "/contacts", "ContactsView"],
+  [
+    "hyperliquid",
+    "Hyperliquid",
+    "plugin-hyperliquid",
+    "/hyperliquid",
+    "HyperliquidView",
+  ],
+  // The decomposed personal-assistant domain views are the real surfaces (the
+  // old monolithic `lifeops` overview view was removed). `documents` is
+  // intentionally absent — its `/documents` path collides with the built-in
+  // Knowledge tab (`App.tsx` findView matches `/${tab}`).
+  ["calendar", "Calendar", "plugin-calendar", "/calendar", "CalendarView"],
+  ["finances", "Finances", "plugin-finances", "/finances", "FinancesView"],
+  ["focus", "Focus", "plugin-blocker", "/focus", "FocusView"],
+  ["goals", "Goals", "plugin-goals", "/goals", "GoalsView"],
+  ["health", "Health", "plugin-health", "/health", "HealthView"],
+  ["inbox", "Inbox", "plugin-inbox", "/inbox", "InboxView"],
+  ["todos", "Todos", "plugin-todos", "/todos", "TodosView"],
+  [
+    "relationships",
+    "Relationships",
+    "plugin-relationships",
+    "/relationships",
+    "RelationshipsView",
+  ],
+  ["messages", "Messages", "plugin-messages", "/messages", "MessagesView"],
+  [
+    "model-tester",
+    "Model Tester",
+    "app-model-tester",
+    "/model-tester",
+    "ModelTesterView",
+  ],
+  ["phone", "Phone", "plugin-phone", "/phone", "PhoneView"],
+  [
+    "polymarket",
+    "Polymarket",
+    "plugin-polymarket",
+    "/polymarket",
+    "PolymarketView",
+  ],
+  ["wallet", "Wallet", "plugin-wallet-ui", "/wallet", "InventoryView"],
+  [
+    "vector-browser",
+    "Vector Browser",
+    "plugin-vector-browser",
+    "/vector-browser",
+    "VectorBrowserView",
+  ],
+  ["feed", "Feed", "plugin-feed", "/feed", "FeedView"],
+  ["views-manager", "Views", "plugin-app-control", "/views", "ViewManagerView"],
+  [
+    "screenshare",
+    "Screenshare",
+    "plugin-screenshare",
+    "/screenshare",
+    "ScreenshareView",
+  ],
+  [
+    "task-coordinator",
+    "Task Coordinator",
+    "plugin-task-coordinator",
+    "/task-coordinator",
+    "TaskCoordinatorView",
+  ],
+  [
+    "orchestrator",
+    "Orchestrator",
+    "plugin-task-coordinator",
+    "/orchestrator",
+    "OrchestratorView",
+  ],
+  [
+    "trajectory-logger",
+    "Trajectory Logger",
+    "plugin-trajectory-logger",
+    "/trajectory-logger",
+    "TrajectoryLoggerView",
+  ],
+  ["training", "Fine Tuning", "plugin-training", "/training", "FineTuningView"],
+];
+
+/**
+ * Normalize a declaration tuple to a named record. Kept internal so callers
+ * consume `id` / `pluginDirName` / `componentExport` rather than tuple indices.
+ */
+function toDeclaration(tuple) {
+  const [id, label, pluginDirName, viewPath, componentExport] = tuple;
+  return { id, label, pluginDirName, viewPath, componentExport };
+}
+
+function readSourceFiles(dir) {
+  const sources = [];
+  const walk = (current) => {
+    let entries;
+    try {
+      entries = readdirSync(current, { withFileTypes: true });
+    } catch {
+      // error-policy:J3 a plugin dir that vanished mid-scan is reported by the
+      // caller as a parity miss (missing directory), not swallowed as "clean".
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.name === "node_modules" || entry.name === "dist") continue;
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (/\.(ts|tsx|mjs|js)$/.test(entry.name)) {
+        sources.push(readFileSync(full, "utf8"));
+      }
+    }
+  };
+  walk(dir);
+  return sources;
+}
+
+/**
+ * Check every smoke view declaration against the plugin that must register it.
+ * A declaration is in parity when the plugin directory exists and its source
+ * both declares the view `id` and exports the named component. Returns the full
+ * declaration list plus the misses so a test can assert the shipped set is
+ * clean AND that a removed plugin id would be caught.
+ */
+export function checkSmokeViewParity(
+  repoRoot,
+  declarations = smokeViewDeclarations,
+) {
+  const pluginsDir = path.join(repoRoot, "plugins");
+  const missing = [];
+  for (const tuple of declarations) {
+    const { id, pluginDirName, componentExport } = toDeclaration(tuple);
+    const pluginDir = path.join(pluginsDir, pluginDirName);
+    let dirExists = false;
+    try {
+      dirExists = statSync(pluginDir).isDirectory();
+    } catch {
+      dirExists = false;
+    }
+    if (!dirExists) {
+      missing.push({
+        id,
+        pluginDirName,
+        componentExport,
+        reason: "plugin-directory-missing",
+      });
+      continue;
+    }
+    const sources = readSourceFiles(path.join(pluginDir, "src"));
+    const declaresId = sources.some((source) => source.includes(`"${id}"`));
+    const exportsComponent = sources.some((source) =>
+      source.includes(componentExport),
+    );
+    if (!declaresId || !exportsComponent) {
+      missing.push({
+        id,
+        pluginDirName,
+        componentExport,
+        reason: !exportsComponent
+          ? "component-export-missing"
+          : "view-id-not-declared",
+      });
+    }
+  }
+  return { declarations, missing, ok: missing.length === 0 };
+}
+
+/**
+ * Provenance the smoke stub must attach when serving a plugin-view bundle. The
+ * value flows out on the `X-Eliza-View-Bundle-Provenance` response header so an
+ * audit can assert WHICH bundle rendered — the real built one or a marked
+ * placeholder — and never mistake a fabricated surface for the production one.
+ */
+export const VIEW_BUNDLE_PROVENANCE_HEADER = "X-Eliza-View-Bundle-Provenance";
+
+/**
+ * Decide how the stub serves a view's bundle. In audit mode
+ * (`requireRealBundle`) a missing real `dist/views/bundle.js` is a hard failure
+ * (`status` 424, mode `missing-real-bundle`) — the stub must NOT fabricate a
+ * generic bundle for a production-declared view. Outside audit mode a missing
+ * bundle degrades to a clearly-marked synthesized placeholder so the offline
+ * keyless smoke can still exercise routing, but the provenance says so.
+ */
+export function resolveBundleProvenance({
+  viewId,
+  realBundleExists,
+  requireRealBundle,
+}) {
+  if (realBundleExists) {
+    return { mode: "real-dist", status: 200, synthesized: false };
+  }
+  if (requireRealBundle) {
+    return { mode: "missing-real-bundle", status: 424, synthesized: false };
+  }
+  const dedicated = new Set(["screenshare", "task-coordinator"]);
+  return {
+    mode: dedicated.has(viewId)
+      ? `synthesized-${viewId}`
+      : "synthesized-generic",
+    status: 200,
+    synthesized: true,
+  };
+}
+
+/** True when `plugins/<pluginDirName>/dist/views/bundle.js` exists on disk. */
+export function realViewBundleExists(repoRoot, pluginDirName) {
+  return existsSync(
+    path.join(repoRoot, "plugins", pluginDirName, "dist", "views", "bundle.js"),
+  );
+}

--- a/packages/app-core/scripts/smoke-view-declarations.test.ts
+++ b/packages/app-core/scripts/smoke-view-declarations.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Parity + provenance contract for the UI-smoke plugin-view stub. Runs against
+ * the real repo tree (no mocks): asserts every declared smoke view still maps to
+ * a shipping plugin, that a removed plugin id is caught, and that a
+ * production-declared view can never be served as a fabricated bundle in audit
+ * mode. Guards issue #15791.
+ */
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  checkSmokeViewParity,
+  resolveBundleProvenance,
+  smokeViewDeclarations,
+} from "./smoke-view-declarations.mjs";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "..",
+);
+
+const REMOVED_PLUGIN_IDS = ["shopify", "steward", "social-alpha"];
+
+describe("smoke view declaration parity (#15791)", () => {
+  it("every shipped declaration maps to a plugin that still registers it", () => {
+    const { ok, missing } = checkSmokeViewParity(repoRoot);
+    expect(
+      missing,
+      `smoke views out of parity with production: ${JSON.stringify(missing, null, 2)}`,
+    ).toEqual([]);
+    expect(ok).toBe(true);
+  });
+
+  it("does not declare any removed plugin view", () => {
+    const declaredIds = smokeViewDeclarations.map(([id]) => id);
+    for (const removed of REMOVED_PLUGIN_IDS) {
+      expect(
+        declaredIds,
+        `${removed} was removed from production and must not be declared in the smoke stub`,
+      ).not.toContain(removed);
+    }
+  });
+
+  it("fails parity when a deleted plugin id is (re)introduced", () => {
+    const withRemoved = [
+      ...smokeViewDeclarations,
+      ["shopify", "Shopify", "plugin-shopify", "/shopify", "ShopifyView"],
+    ];
+    const { ok, missing } = checkSmokeViewParity(repoRoot, withRemoved);
+    expect(ok).toBe(false);
+    expect(missing.map((entry) => entry.id)).toContain("shopify");
+    expect(missing.find((entry) => entry.id === "shopify")?.reason).toBe(
+      "plugin-directory-missing",
+    );
+  });
+
+  it("fails parity when a live plugin no longer exports the declared component", () => {
+    // polymarket exists, but a bogus export name must be rejected — this is the
+    // "a route cannot pass against the wrong component" guard.
+    const wrongComponent = [
+      [
+        "polymarket",
+        "Polymarket",
+        "plugin-polymarket",
+        "/polymarket",
+        "NotARealPolymarketExport",
+      ],
+    ];
+    const { ok, missing } = checkSmokeViewParity(repoRoot, wrongComponent);
+    expect(ok).toBe(false);
+    expect(missing[0]?.reason).toBe("component-export-missing");
+  });
+});
+
+describe("view bundle provenance (#15791)", () => {
+  it("serves the real built bundle when present", () => {
+    const provenance = resolveBundleProvenance({
+      viewId: "polymarket",
+      realBundleExists: true,
+      requireRealBundle: false,
+    });
+    expect(provenance).toEqual({
+      mode: "real-dist",
+      status: 200,
+      synthesized: false,
+    });
+  });
+
+  it("audit mode fails observably instead of fabricating a bundle", () => {
+    const provenance = resolveBundleProvenance({
+      viewId: "polymarket",
+      realBundleExists: false,
+      requireRealBundle: true,
+    });
+    expect(provenance.mode).toBe("missing-real-bundle");
+    expect(provenance.status).toBe(424);
+    expect(provenance.synthesized).toBe(false);
+  });
+
+  it("non-audit mode marks a synthesized placeholder as synthesized", () => {
+    const generic = resolveBundleProvenance({
+      viewId: "polymarket",
+      realBundleExists: false,
+      requireRealBundle: false,
+    });
+    expect(generic.mode).toBe("synthesized-generic");
+    expect(generic.synthesized).toBe(true);
+    expect(generic.status).toBe(200);
+
+    const dedicated = resolveBundleProvenance({
+      viewId: "screenshare",
+      realBundleExists: false,
+      requireRealBundle: false,
+    });
+    expect(dedicated.mode).toBe("synthesized-screenshare");
+  });
+});

--- a/packages/app/test/ui-smoke/plugin-views-visual.spec.ts
+++ b/packages/app/test/ui-smoke/plugin-views-visual.spec.ts
@@ -17,7 +17,6 @@ const KNOWN_BROKEN = new Set<string>([]);
 const MIN_VISIBLE_TEXT_LENGTH_BY_VIEW_ID = new Map<string, number>([
   ["feed", 4],
   ["focus", 4],
-  ["social-alpha", 4],
 ]);
 const DEFAULT_MIN_VISIBLE_TEXT_LENGTH = 21;
 
@@ -86,19 +85,6 @@ test.describe("registered plugin views visual coverage", () => {
 
       await seedAppStorage(page);
       await installDefaultAppRoutes(page);
-      if (view.id === "social-alpha") {
-        await page.route("**/api/social-alpha/leaderboard", async (route) => {
-          if (route.request().method() !== "GET") {
-            await route.fallback();
-            return;
-          }
-          await route.fulfill({
-            status: 200,
-            contentType: "application/json",
-            body: JSON.stringify({ data: [] }),
-          });
-        });
-      }
       await openAppPath(page, view.path);
 
       await expectNoFailedView(

--- a/packages/app/test/ui-smoke/views-plugin-audit-capture.spec.ts
+++ b/packages/app/test/ui-smoke/views-plugin-audit-capture.spec.ts
@@ -78,19 +78,6 @@ async function captureViewCase(
   try {
     await seedAppStorage(page);
     await installDefaultAppRoutes(page);
-    if (view.id === "social-alpha") {
-      await page.route("**/api/social-alpha/leaderboard", async (route) => {
-        if (route.request().method() !== "GET") {
-          await route.fallback();
-          return;
-        }
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify({ data: [] }),
-        });
-      });
-    }
 
     await page
       .goto(view.path, {

--- a/packages/scripts/__tests__/build-views-guard.test.ts
+++ b/packages/scripts/__tests__/build-views-guard.test.ts
@@ -1,0 +1,45 @@
+// Guards the build-views failure contract (#15791): a build that emits no
+// bundle for a configured plugin view must fail, and stale outputs are cleared
+// before each build. Imports the real helpers — build-views only runs its
+// orchestration under import.meta.main, so importing it here is side-effect free.
+import { describe, expect, test } from "bun:test";
+import path from "node:path";
+import { expectedBundlePath, missingBundleReport } from "../build-views.mjs";
+
+describe("build-views bundle guard (#15791)", () => {
+  test("expectedBundlePath resolves the required emit target", () => {
+    const configPath = path.join(
+      "/repo",
+      "plugins",
+      "plugin-polymarket",
+      "vite.config.views.ts",
+    );
+    expect(expectedBundlePath(configPath)).toBe(
+      path.join(
+        "/repo",
+        "plugins",
+        "plugin-polymarket",
+        "dist",
+        "views",
+        "bundle.js",
+      ),
+    );
+  });
+
+  test("a build with no missing bundles reports success (null)", () => {
+    expect(missingBundleReport([])).toBeNull();
+  });
+
+  test("a configured view that emitted no bundle fails observably", () => {
+    const report = missingBundleReport([
+      {
+        name: "plugin-polymarket",
+        relativeBundle: "plugins/plugin-polymarket/dist/views/bundle.js",
+        relativeConfig: "plugins/plugin-polymarket/vite.config.views.ts",
+      },
+    ]);
+    expect(report).not.toBeNull();
+    expect(report).toContain("plugin-polymarket");
+    expect(report).toContain("missing after build");
+  });
+});

--- a/packages/scripts/build-views.mjs
+++ b/packages/scripts/build-views.mjs
@@ -1,21 +1,46 @@
 #!/usr/bin/env node
-// Drives repo automation build views with explicit CLI and CI behavior.
+/**
+ * Builds every plugin's dynamic view bundle and refuses to report success on a
+ * build that emitted nothing. Each plugin with a `vite.config.views.ts` must
+ * produce `dist/views/bundle.js`; a downstream audit trusts that artifact to
+ * prove the production view, so a missing or stale bundle here is a hard failure
+ * (issue #15791), never a silent no-op. The orchestration only runs when this
+ * file is executed as a script — the helpers are importable for tests.
+ */
 import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
-import { readdir } from "node:fs/promises";
+import { readdir, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 const repoRoot = path.resolve(import.meta.dirname, "../..");
-const args = process.argv.slice(2);
-const filterArg = args.find(
-  (arg) => arg === "--filter" || arg.startsWith("--filter="),
-);
-const filter =
-  filterArg === "--filter"
-    ? args[args.indexOf(filterArg) + 1]
-    : filterArg?.slice("--filter=".length);
-async function findViewConfigs() {
+
+/** Absolute path to the bundle a plugin's view config is required to emit. */
+export function expectedBundlePath(configPath) {
+  return path.join(path.dirname(configPath), "dist", "views", "bundle.js");
+}
+
+/**
+ * A build that finished with no configured bundle missing is the only success.
+ * Returns a non-empty error message when any expected bundle is absent so the
+ * caller fails loudly instead of validating a stale or never-produced artifact.
+ */
+export function missingBundleReport(missingBundles) {
+  if (missingBundles.length === 0) return null;
+  const lines = missingBundles.map(
+    (bundle) =>
+      `  ✗ ${bundle.name}: expected ${bundle.relativeBundle} (declared by ${bundle.relativeConfig})`,
+  );
+  return (
+    `[build-views] ${missingBundles.length} configured view bundle(s) missing after build:\n` +
+    `${lines.join("\n")}\n` +
+    "[build-views] Each plugin with vite.config.views.ts must emit " +
+    "dist/views/bundle.js; a build that produces none is a failure, not a no-op."
+  );
+}
+
+async function findViewConfigs(filter) {
   const pluginsDir = path.join(repoRoot, "plugins");
   const entries = await readdir(pluginsDir, { withFileTypes: true });
   return entries
@@ -30,15 +55,13 @@ async function findViewConfigs() {
     .sort();
 }
 
-const configs = await findViewConfigs();
-if (configs.length === 0) {
-  console.log("[build-views] no view configs found");
-  process.exit(0);
-}
-
 async function buildView(configPath) {
   const cwd = path.dirname(configPath);
   const label = path.relative(repoRoot, cwd);
+  // Delete the previous bundle first so a build that silently emits nothing
+  // (misconfigured entry, skipped compile) cannot pass on a stale artifact —
+  // the post-build guard would otherwise validate last run's output.
+  await rm(expectedBundlePath(configPath), { force: true });
   const { status, output } = await runBun(["run", "build:views"], cwd);
   return { label, status: status ?? 1, output };
 }
@@ -60,55 +83,92 @@ function runBun(buildArgs, cwd) {
   });
 }
 
-const concurrency = Math.min(configs.length, Math.max(1, os.cpus().length - 1));
+async function main() {
+  const args = process.argv.slice(2);
+  const filterArg = args.find(
+    (arg) => arg === "--filter" || arg.startsWith("--filter="),
+  );
+  const filter =
+    filterArg === "--filter"
+      ? args[args.indexOf(filterArg) + 1]
+      : filterArg?.slice("--filter=".length);
 
-const failures = [];
-let nextIndex = 0;
+  const configs = await findViewConfigs(filter);
+  if (configs.length === 0) {
+    console.log("[build-views] no view configs found");
+    process.exit(0);
+  }
 
-async function worker() {
-  while (true) {
-    const index = nextIndex++;
-    if (index >= configs.length) return;
-    const configPath = configs[index];
-    const result = await buildView(configPath);
-    console.log(`[build-views] ${result.label}`);
-    if (result.output.length > 0) {
-      process.stdout.write(result.output);
+  const concurrency = Math.min(
+    configs.length,
+    Math.max(1, os.cpus().length - 1),
+  );
+  const failures = [];
+  let nextIndex = 0;
+
+  const worker = async () => {
+    while (true) {
+      const index = nextIndex++;
+      if (index >= configs.length) return;
+      const result = await buildView(configs[index]);
+      console.log(`[build-views] ${result.label}`);
+      if (result.output.length > 0) {
+        process.stdout.write(result.output);
+      }
+      if (result.status !== 0) {
+        failures.push(result);
+      }
     }
-    if (result.status !== 0) {
-      failures.push(result);
+  };
+
+  await Promise.all(Array.from({ length: concurrency }, () => worker()));
+
+  if (failures.length > 0) {
+    console.error(
+      `[build-views] ${failures.length} view build(s) failed: ${failures
+        .map((failure) => failure.label)
+        .join(", ")}`,
+    );
+    const exitStatus =
+      failures.find((failure) => failure.status > 0)?.status ?? 1;
+    process.exit(exitStatus);
+  }
+
+  // Every freshly built bundle must (a) exist and (b) import only specifiers
+  // DynamicViewLoader can rewrite at runtime — otherwise the view ships but
+  // fails to load in the browser ("Failed to resolve module specifier").
+  const { validateViewBundles } = await import(
+    "./view-bundle-import-guard.mjs"
+  );
+  const { violations, missingBundles } = await validateViewBundles();
+  // The guard scans every configured plugin; a `--filter` run only built a
+  // subset, so only hold the built subset to the "must emit a bundle" rule.
+  const builtPluginNames = new Set(
+    configs.map((configPath) => path.basename(path.dirname(configPath))),
+  );
+  const missingFromBuilt = missingBundles.filter((bundle) =>
+    builtPluginNames.has(bundle.name),
+  );
+  const missingReport = missingBundleReport(missingFromBuilt);
+  if (missingReport) {
+    console.error(missingReport);
+    process.exit(1);
+  }
+  if (violations.length > 0) {
+    console.error(
+      `[build-views] ${violations.length} view bundle(s) import specifiers the host cannot rewrite:`,
+    );
+    for (const v of violations) {
+      console.error(`  ✗ ${v.plugin}: ${v.specifier}`);
     }
+    console.error(
+      "[build-views] Import these from a host-provided specifier (e.g. the " +
+        "`@elizaos/ui/components` barrel) instead of a deep subpath.",
+    );
+    process.exit(1);
   }
 }
 
-await Promise.all(Array.from({ length: concurrency }, () => worker()));
-
-if (failures.length > 0) {
-  console.error(
-    `[build-views] ${failures.length} view build(s) failed: ${failures
-      .map((failure) => failure.label)
-      .join(", ")}`,
-  );
-  const exitStatus =
-    failures.find((failure) => failure.status > 0)?.status ?? 1;
-  process.exit(exitStatus);
-}
-
-// Every freshly built bundle must import only specifiers DynamicViewLoader can
-// rewrite at runtime — otherwise the view ships but fails to load in the
-// browser ("Failed to resolve module specifier"). Fail the build on drift.
-const { validateViewBundles } = await import("./view-bundle-import-guard.mjs");
-const { violations } = await validateViewBundles();
-if (violations.length > 0) {
-  console.error(
-    `[build-views] ${violations.length} view bundle(s) import specifiers the host cannot rewrite:`,
-  );
-  for (const v of violations) {
-    console.error(`  ✗ ${v.plugin}: ${v.specifier}`);
-  }
-  console.error(
-    "[build-views] Import these from a host-provided specifier (e.g. the " +
-      "`@elizaos/ui/components` barrel) instead of a deep subpath.",
-  );
-  process.exit(1);
+if (import.meta.main || process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main();
 }

--- a/packages/scripts/launch-qa/run-ui-smoke-offline.mjs
+++ b/packages/scripts/launch-qa/run-ui-smoke-offline.mjs
@@ -32,7 +32,6 @@ const defaultTestGreps = [
   "desktop app tool database",
   "desktop app tool logs",
   "desktop app tool companion",
-  "desktop app tool shopify",
   "mobile chat",
   "mobile apps catalog",
   "mobile automations",


### PR DESCRIPTION
Fixes #15791.\n\n## Problem (#15791)

The plugin-view UI-smoke stub still declared **removed** Shopify, Steward, and Social Alpha views and **synthesized a generic JS bundle** whenever a real `dist/views/bundle.js` was absent. Separately, `packages/scripts/build-views.mjs` **discarded** the `missingBundles` returned by the import guard. An audit could therefore render a healthy generic / in-process surface **without proving the production bundle it claims to validate** (e.g. `/polymarket` passing without ever requesting `/api/views/polymarket/bundle.js`).

## What changed

1. **Declarations pinned to production.** Smoke view declarations moved into `packages/app-core/scripts/smoke-view-declarations.mjs` and are checked against shipping plugins by `checkSmokeViewParity` — a declared view whose plugin directory is gone, or which no longer exports the named component, **fails parity**. Shopify / Steward / Social Alpha are removed and cannot reappear.
2. **No fabrication in audit mode.** The bundle route decides provenance explicitly (`resolveBundleProvenance`) and echoes it on `X-Eliza-View-Bundle-Provenance` / `X-Eliza-View-Component` / `X-Eliza-View-Id`. With `ELIZA_UI_SMOKE_REQUIRE_REAL_BUNDLES=1`, a missing real bundle is a hard **`424` observable failure** — never a generic fabrication. Outside audit mode, synthesized placeholders are marked as such on the wire **and** in the byte stream.
3. **build-views fails on missing output.** Each stale `dist/views/bundle.js` is deleted before building, and a built plugin that emits no bundle now **fails the build** (stops discarding `missingBundles`).
4. **Evidence asserts which component/bundle rendered** via the provenance + component headers (network/provenance marker for dynamic bundles).
5. **Focused tests.** Parity teeth (a deleted plugin id fails; a wrong component export fails), provenance decision, an HTTP E2E against the real stub, and a build-guard test.

## Current production view registry (authoritative)

Real / current plugin view IDs (plugin dir exists + declares view + exports component): `birdclaw, contacts, hyperliquid, calendar, finances, focus, goals, health, inbox, todos, relationships, messages, model-tester, phone, polymarket, wallet, vector-browser, feed, views-manager, screenshare, task-coordinator, orchestrator, trajectory-logger, training` (24).

**Removed** (no plugin directory, dropped from the stub, fail parity): **`shopify`, `steward`, `social-alpha`**. **Polymarket is current/real.**

## Evidence

**Parity + provenance unit/E2E (app-core, live stub, no mocks):**
```
 RUN  v4.1.5 packages/app-core
 Test Files  2 passed (2)
      Tests  9 passed (9)
```

**build-views guard (bun:test):**
```
 3 pass  0 fail  5 expect() calls
Ran 3 tests across 1 file.
```

**Real stub HTTP — provenance matrix (`/api/views/<id>/bundle.js`):**
```
NON-AUDIT polymarket : 200 prov=synthesized-generic     comp=PolymarketView  (banner in bytes)
NON-AUDIT screenshare: 200 prov=synthesized-screenshare comp=ScreenshareView
AUDIT     polymarket : 424 prov=missing-real-bundle      comp=PolymarketView  (no fabrication)
AUDIT+built polymarket: 200 prov=real-dist               comp=PolymarketView  (serves real 14726-byte bundle)
AUDIT     wallet     : 424 prov=missing-real-bundle      comp=InventoryView
```

**build-views missing-bundle guard fires (filtered build of polymarket built its bundle; unbuilt configs reported and would fail a full run):**
```
✗ plugin-wallet-ui: expected plugins/plugin-wallet-ui/dist/views/bundle.js ...
[build-views] Each plugin with vite.config.views.ts must emit dist/views/bundle.js; a build that produces none is a failure, not a no-op.
dist/views/bundle.js  14.72 kB │ gzip: 4.25 kB   ✓ built in 737ms
```

_N/A — no user-facing UI pixels change; this is test/evidence-harness infrastructure. Behavior is proven by the live-stub HTTP transcript above and the committed E2E test._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Evidence rows

<!-- evidence-row:before-screenshots -->
- [ ] N/A - evidence-harness infrastructure only; no product pixels changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - evidence-harness infrastructure only; no rendered product surface changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - the affected flow is a headless bundle-provenance HTTP contract, captured in the linked transcript.

<!-- evidence-row:backend-logs -->
- [x] [Real stub HTTP provenance transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15803-http-provenance.log) shows audit mode returning observable 424/missing-real-bundle and non-audit mode marking synthesized bytes and headers.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime code changed; the bundle contract is exercised at the HTTP boundary before rendering.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, prompt, provider, action, evaluator, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] [Focused parity, live-stub E2E, and build-guard verification log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15803-verification.log) records 12 passing assertions.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no product pixels or visual text changed; this PR makes later audits prove their bundle provenance before OCR.