### PR TITLE
fix(evidence): scope app-audit OCR to the current capture (#15790)

### DIFF
--- a/packages/app/scripts/ocr-triage.ts
+++ b/packages/app/scripts/ocr-triage.ts
@@ -300,7 +300,7 @@ async function main() {
 // Auto-run only as a CLI entrypoint (`bun scripts/ocr-triage.ts …`). When a test
 // imports this module for `authorizedShots`, `import.meta.main` is false so the
 // triage does not fire and call `process.exit` out from under the test runner.
-if ((import.meta as { main?: boolean }).main) {
+if (import.meta.main) {
   main()
     .catch((e) => {
       // error-policy:J1 CLI boundary — surface the failure and exit non-zero.

--- a/packages/app/scripts/ocr-triage.ts
+++ b/packages/app/scripts/ocr-triage.ts
@@ -11,6 +11,13 @@
  * labels they exist to show, retiring them from the manual "needs-eyeball" pile
  * instead of leaving every soft-signal view for a human to squint at.
  *
+ * Provenance is report-authoritative: the triage evaluates exactly the
+ * screenshots named by the current `report.json` — one per row, all present —
+ * never a directory glob. A screenshot left behind by an earlier capture is
+ * structurally unable to enter the result, so the OCR row count always equals
+ * the DOM report row count and a stale render can never be mis-reported as a
+ * current regression (#15790).
+ *
  * Run: `bun scripts/ocr-triage.ts [--audit-dir <dir>] [--ocr <ndjson>] [--out <json>] [--baseline <json>]`.
  * With no `--ocr`, it uses `scripts/mvp-visual-verify/ocr.mjs`, which prefers the
  * installed `tesseract.js` package so CI and local verification do not depend on
@@ -19,7 +26,7 @@
  * the same ratchet posture as the aesthetic audit's verdict-debt map, so a known
  * bug stays visible without wedging CI while a NEW pixel-broken render fails it.
  */
-import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { OVERLAY_NATIVE_OR_CANVAS_SLUGS } from "../test/ui-smoke/aesthetic-audit-rules";
 import {
@@ -46,7 +53,7 @@ const BLANK_EXEMPT_SLUGS = new Set<string>([
   "plugin-focus-gui",
 ]);
 
-interface ReportEntry {
+export interface ReportEntry {
   slug: string;
   viewport: string;
   viewType?: "gui" | "tui";
@@ -78,16 +85,53 @@ function parseArgs(argv: string[]): Record<string, string> {
   return out;
 }
 
-function listPngs(dir: string): string[] {
-  const out: string[] = [];
-  for (const viewport of readdirSync(dir, { withFileTypes: true })) {
-    if (!viewport.isDirectory()) continue;
-    const vp = join(dir, viewport.name);
-    for (const f of readdirSync(vp)) {
-      if (f.endsWith(".png")) out.push(join(vp, f));
-    }
+/** One authorized screenshot per current report row, with its on-disk path. */
+export interface AuthorizedShot {
+  key: string;
+  slug: string;
+  viewport: string;
+  path: string;
+}
+
+/**
+ * The screenshots the current `report.json` authorizes OCR to evaluate — the
+ * single source of provenance for this triage.
+ *
+ * The prior implementation globbed every PNG under the audit directory, so a
+ * screenshot left behind by an earlier capture (a retired view, a since-fixed
+ * crash) was OCR'd and mis-reported as a CURRENT regression (#15790: 240 report
+ * rows, 379 globbed PNGs). Scoping to report rows makes stale files structurally
+ * unable to enter the result: a shot not named by a row is never read, and every
+ * row's shot must exist. A missing report, a duplicate row, or a row whose
+ * screenshot is absent is a corrupt capture and fails fast rather than silently
+ * narrowing the run.
+ */
+export function authorizedShots(
+  auditDir: string,
+  report: ReportEntry[],
+): AuthorizedShot[] {
+  if (report.length === 0) {
+    throw new Error(
+      `[ocr-triage] ${join(auditDir, "report.json")} lists no views — run \`audit:app:capture\` first. OCR is scoped to the current report, never a directory glob.`,
+    );
   }
-  return out;
+  const seen = new Set<string>();
+  return report.map((r) => {
+    const key = `${r.slug}::${r.viewport}`;
+    if (seen.has(key)) {
+      throw new Error(
+        `[ocr-triage] duplicate report row ${key} — report.json is corrupt; each slug::viewport must appear once.`,
+      );
+    }
+    seen.add(key);
+    const path = join(auditDir, r.viewport, `${r.slug}.png`);
+    if (!existsSync(path)) {
+      throw new Error(
+        `[ocr-triage] report row ${key} has no screenshot at ${path} — the capture is incomplete; re-run \`audit:app:capture\`.`,
+      );
+    }
+    return { key, slug: r.slug, viewport: r.viewport, path };
+  });
 }
 
 async function runPackagedOcr(paths: string[]): Promise<OcrRecord[]> {
@@ -143,13 +187,35 @@ async function main() {
   const reportByKey = new Map<string, ReportEntry>();
   for (const r of report) reportByKey.set(`${r.slug}::${r.viewport}`, r);
 
-  const pngs = listPngs(auditDir);
-  const ocr: OcrRecord[] = args.ocr
-    ? readFileSync(args.ocr, "utf8")
-        .split("\n")
-        .filter((l) => l.trim())
-        .map((l) => JSON.parse(l) as OcrRecord)
-    : await runPackagedOcr(pngs);
+  // Provenance: OCR evaluates exactly the shots the current report authorizes —
+  // one per row, all present — so the OCR row count equals the DOM report row
+  // count by construction and no stale PNG can slip in (#15790).
+  const shots = authorizedShots(auditDir, report);
+
+  let ocr: OcrRecord[];
+  if (args.ocr) {
+    // A precomputed OCR ndjson (CI / deterministic tests) is still filtered to
+    // the report: index its records by slug::viewport, then select exactly one
+    // per report row. A row with no matching record means the OCR input is out
+    // of sync with the report — fail loudly instead of skipping the view.
+    const byKey = new Map<string, OcrRecord>();
+    for (const line of readFileSync(args.ocr, "utf8").split("\n")) {
+      if (!line.trim()) continue;
+      const rec = JSON.parse(line) as OcrRecord;
+      byKey.set(`${slugOf(rec.path)}::${viewportOf(rec.path)}`, rec);
+    }
+    ocr = shots.map((s) => {
+      const rec = byKey.get(s.key);
+      if (!rec) {
+        throw new Error(
+          `[ocr-triage] report row ${s.key} has no OCR record in ${args.ocr} — the OCR input is out of sync with report.json.`,
+        );
+      }
+      return rec;
+    });
+  } else {
+    ocr = await runPackagedOcr(shots.map((s) => s.path));
+  }
 
   const entries: TriageEntry[] = [];
   for (const rec of ocr) {
@@ -231,12 +297,18 @@ async function main() {
   process.exitCode = newRegressions.length > 0 ? 1 : 0;
 }
 
-main()
-  .catch((e) => {
-    console.error("[ocr-triage]", e);
-    process.exitCode = 2;
-  })
-  .finally(async () => {
-    await closeOcrEngines();
-    if (process.exitCode) process.exit(process.exitCode);
-  });
+// Auto-run only as a CLI entrypoint (`bun scripts/ocr-triage.ts …`). When a test
+// imports this module for `authorizedShots`, `import.meta.main` is false so the
+// triage does not fire and call `process.exit` out from under the test runner.
+if ((import.meta as { main?: boolean }).main) {
+  main()
+    .catch((e) => {
+      // error-policy:J1 CLI boundary — surface the failure and exit non-zero.
+      console.error("[ocr-triage]", e);
+      process.exitCode = 2;
+    })
+    .finally(async () => {
+      await closeOcrEngines();
+      if (process.exitCode) process.exit(process.exitCode);
+    });
+}

--- a/packages/app/scripts/ocr-triage.ts
+++ b/packages/app/scripts/ocr-triage.ts
@@ -64,7 +64,7 @@ interface OcrRecord extends OcrResult {
   path: string;
 }
 
-interface TriageEntry {
+export interface TriageEntry {
   slug: string;
   viewport: string;
   path: string;
@@ -74,6 +74,21 @@ interface TriageEntry {
   /** DOM audit passed (good/needs-eyeball) but the pixels are broken — the caught bug. */
   regression: boolean;
   text: string;
+}
+
+export interface TriageSummary {
+  total: number;
+  verified: number;
+  broken: number;
+  needsEyeball: number;
+  regressions: number;
+  knownRegressions: number;
+  newRegressions: number;
+}
+
+export interface TriageResult {
+  summary: TriageSummary;
+  entries: TriageEntry[];
 }
 
 function parseArgs(argv: string[]): Record<string, string> {
@@ -166,8 +181,8 @@ function viewportOf(path: string): string {
   return basename(dirname(path));
 }
 
-async function main() {
-  const args = parseArgs(process.argv.slice(2));
+export async function runOcrTriage(argv: string[]): Promise<TriageResult> {
+  const args = parseArgs(argv);
   const auditDir = args["audit-dir"] ?? "aesthetic-audit-output";
   const outPath = args.out ?? join(auditDir, "ocr-triage.json");
 
@@ -294,14 +309,17 @@ async function main() {
     }
   }
   console.log(`\n[ocr-triage] wrote ${outPath}`);
-  process.exitCode = newRegressions.length > 0 ? 1 : 0;
+  return { summary, entries };
 }
 
 // Auto-run only as a CLI entrypoint (`bun scripts/ocr-triage.ts …`). When a test
 // imports this module for `authorizedShots`, `import.meta.main` is false so the
 // triage does not fire and call `process.exit` out from under the test runner.
 if (import.meta.main) {
-  main()
+  runOcrTriage(process.argv.slice(2))
+    .then(({ summary }) => {
+      process.exitCode = summary.newRegressions > 0 ? 1 : 0;
+    })
     .catch((e) => {
       // error-policy:J1 CLI boundary — surface the failure and exit non-zero.
       console.error("[ocr-triage]", e);

--- a/packages/app/test/audit/ocr-triage-provenance.test.ts
+++ b/packages/app/test/audit/ocr-triage-provenance.test.ts
@@ -9,6 +9,7 @@
  */
 import { execFileSync } from "node:child_process";
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -20,10 +21,13 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { authorizedShots, type ReportEntry } from "../../scripts/ocr-triage";
 
-// Vitest runs from the package root (`vitest run --config vitest.config.ts`),
-// so the CLI under test resolves from cwd — `import.meta.url` is a virtual,
-// non-file URL under the vitest transform pipeline.
-const APP_DIR = process.cwd();
+// Changed-file coverage invokes Vitest from the repository root while the
+// package script invokes it from `packages/app`. Vitest gives `import.meta.url`
+// a virtual scheme, so select between those two documented cwd contracts by
+// probing for the CLI rather than assuming the package-root invocation.
+const APP_DIR = existsSync(join(process.cwd(), "scripts", "ocr-triage.ts"))
+  ? process.cwd()
+  : join(process.cwd(), "packages", "app");
 const CLI = join(APP_DIR, "scripts", "ocr-triage.ts");
 
 /** Minimal valid 1×1 PNG — enough for `existsSync`; the CLI OCR comes from ndjson. */

--- a/packages/app/test/audit/ocr-triage-provenance.test.ts
+++ b/packages/app/test/audit/ocr-triage-provenance.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Provenance regression guard for the app-audit OCR triage (#15790). Proves the
+ * triage is scoped to the current `report.json` and can never fold a screenshot
+ * left behind by an earlier capture into the result. Two layers: pure-function
+ * tests of `authorizedShots` (the selection invariant), and an end-to-end run of
+ * the real `scripts/ocr-triage.ts` CLI over a fixture directory salted with a
+ * stale PNG and a stale OCR record — the exact shape that produced the bug where
+ * 240 report rows were triaged against 379 globbed PNGs.
+ */
+import { execFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { authorizedShots, type ReportEntry } from "../../scripts/ocr-triage";
+
+// Vitest runs from the package root (`vitest run --config vitest.config.ts`),
+// so the CLI under test resolves from cwd — `import.meta.url` is a virtual,
+// non-file URL under the vitest transform pipeline.
+const APP_DIR = process.cwd();
+const CLI = join(APP_DIR, "scripts", "ocr-triage.ts");
+
+/** Minimal valid 1×1 PNG — enough for `existsSync`; the CLI OCR comes from ndjson. */
+const PNG_1x1 = Buffer.from(
+  "89504e470d0a1a0a0000000d494844520000000100000001080600000" +
+    "01f15c4890000000d49444154789c62000100000500010d0a2db40000" +
+    "000049454e44ae426082",
+  "hex",
+);
+
+function shot(dir: string, viewport: string, slug: string): void {
+  const vp = join(dir, viewport);
+  mkdirSync(vp, { recursive: true });
+  writeFileSync(join(vp, `${slug}.png`), PNG_1x1);
+}
+
+function ocrLine(viewport: string, slug: string, text: string): string {
+  return JSON.stringify({
+    path: join(viewport, `${slug}.png`),
+    ok: true,
+    text,
+    lines: text.split("\n").filter(Boolean),
+    words: text.split(/\s+/).filter(Boolean).length,
+    meanConfidence: 1,
+  });
+}
+
+// Slugs with no VIEW_EXPECTATIONS so the OCR verdict cannot confound the gate
+// exit code — this test asserts provenance (which rows are triaged), not verdict.
+const CURRENT_ROWS: ReportEntry[] = [
+  { slug: "builtin-chat", viewport: "desktop-landscape", verdict: "good" },
+  { slug: "builtin-phone", viewport: "desktop-landscape", verdict: "good" },
+];
+const STALE_SLUG = "plugin-social-alpha-gui";
+
+describe("authorizedShots (report-authoritative selection)", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "ocr-authz-"));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("selects exactly one shot per report row", () => {
+    for (const r of CURRENT_ROWS) shot(dir, r.viewport, r.slug);
+    const shots = authorizedShots(dir, CURRENT_ROWS);
+    expect(shots.map((s) => s.key).sort()).toEqual([
+      "builtin-chat::desktop-landscape",
+      "builtin-phone::desktop-landscape",
+    ]);
+  });
+
+  it("ignores a stale PNG that no current row names", () => {
+    for (const r of CURRENT_ROWS) shot(dir, r.viewport, r.slug);
+    // A retired view left behind by an earlier capture (the #15790 symptom).
+    shot(dir, "desktop-landscape", STALE_SLUG);
+    const shots = authorizedShots(dir, CURRENT_ROWS);
+    expect(shots).toHaveLength(CURRENT_ROWS.length);
+    expect(shots.some((s) => s.slug.includes("social-alpha"))).toBe(false);
+  });
+
+  it("fails fast when a report row has no screenshot", () => {
+    shot(dir, "desktop-landscape", "builtin-chat");
+    // builtin-phone.png intentionally absent.
+    expect(() => authorizedShots(dir, CURRENT_ROWS)).toThrow(
+      /builtin-phone::desktop-landscape has no screenshot/,
+    );
+  });
+
+  it("fails fast on a duplicate report row", () => {
+    for (const r of CURRENT_ROWS) shot(dir, r.viewport, r.slug);
+    expect(() =>
+      authorizedShots(dir, [...CURRENT_ROWS, CURRENT_ROWS[0]]),
+    ).toThrow(/duplicate report row builtin-chat::desktop-landscape/);
+  });
+
+  it("fails fast on an empty report", () => {
+    expect(() => authorizedShots(dir, [])).toThrow(/lists no views/);
+  });
+});
+
+describe("ocr-triage CLI (end-to-end provenance)", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "ocr-cli-"));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  function run(): { status: number; stderr: string } {
+    try {
+      execFileSync(
+        "bun",
+        [
+          CLI,
+          "--audit-dir",
+          dir,
+          "--ocr",
+          join(dir, "ocr.ndjson"),
+          "--out",
+          join(dir, "ocr-triage.json"),
+        ],
+        { cwd: APP_DIR, encoding: "utf8", stdio: "pipe" },
+      );
+      return { status: 0, stderr: "" };
+    } catch (e) {
+      const err = e as { status?: number; stderr?: string };
+      return { status: err.status ?? 1, stderr: err.stderr ?? "" };
+    }
+  }
+
+  it("triages exactly the report rows and drops a stale PNG + stale OCR record", () => {
+    for (const r of CURRENT_ROWS) shot(dir, r.viewport, r.slug);
+    writeFileSync(join(dir, "report.json"), JSON.stringify(CURRENT_ROWS));
+    // Salt the directory with a retired-view PNG and its stale OCR record — the
+    // pre-fix glob would have OCR'd this and reported it as a current failure.
+    shot(dir, "desktop-landscape", STALE_SLUG);
+    writeFileSync(
+      join(dir, "ocr.ndjson"),
+      [
+        ocrLine("desktop-landscape", "builtin-chat", "Chat messages composer"),
+        ocrLine("desktop-landscape", "builtin-phone", "Phone dialer keypad"),
+        ocrLine("desktop-landscape", STALE_SLUG, "Social Alpha leaderboard"),
+      ].join("\n"),
+    );
+
+    const { status, stderr } = run();
+    expect(stderr).toBe("");
+    expect(status).toBe(0);
+
+    const out = JSON.parse(
+      readFileSync(join(dir, "ocr-triage.json"), "utf8"),
+    ) as { summary: { total: number }; entries: { slug: string }[] };
+    // OCR row count equals the DOM report row count — provenance holds.
+    expect(out.summary.total).toBe(CURRENT_ROWS.length);
+    expect(out.entries.map((e) => e.slug).sort()).toEqual([
+      "builtin-chat",
+      "builtin-phone",
+    ]);
+    expect(out.entries.some((e) => e.slug.includes("social-alpha"))).toBe(
+      false,
+    );
+  });
+
+  it("exits non-zero when a report row's screenshot is missing", () => {
+    shot(dir, "desktop-landscape", "builtin-chat");
+    // builtin-phone.png absent → incomplete capture.
+    writeFileSync(join(dir, "report.json"), JSON.stringify(CURRENT_ROWS));
+    writeFileSync(
+      join(dir, "ocr.ndjson"),
+      ocrLine("desktop-landscape", "builtin-chat", "Chat messages"),
+    );
+    const { status, stderr } = run();
+    expect(status).not.toBe(0);
+    expect(stderr).toMatch(
+      /builtin-phone::desktop-landscape has no screenshot/,
+    );
+  });
+});

--- a/packages/app/test/audit/ocr-triage-provenance.test.ts
+++ b/packages/app/test/audit/ocr-triage-provenance.test.ts
@@ -19,7 +19,11 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { authorizedShots, type ReportEntry } from "../../scripts/ocr-triage";
+import {
+  authorizedShots,
+  type ReportEntry,
+  runOcrTriage,
+} from "../../scripts/ocr-triage";
 
 // Changed-file coverage invokes Vitest from the repository root while the
 // package script invokes it from `packages/app`. Vitest gives `import.meta.url`
@@ -146,7 +150,7 @@ describe("ocr-triage CLI (end-to-end provenance)", () => {
     }
   }
 
-  it("triages exactly the report rows and drops a stale PNG + stale OCR record", () => {
+  it("triages exactly the report rows and drops a stale PNG + stale OCR record", async () => {
     for (const r of CURRENT_ROWS) shot(dir, r.viewport, r.slug);
     writeFileSync(join(dir, "report.json"), JSON.stringify(CURRENT_ROWS));
     // Salt the directory with a retired-view PNG and its stale OCR record — the
@@ -160,6 +164,20 @@ describe("ocr-triage CLI (end-to-end provenance)", () => {
         ocrLine("desktop-landscape", STALE_SLUG, "Social Alpha leaderboard"),
       ].join("\n"),
     );
+
+    const result = await runOcrTriage([
+      "--audit-dir",
+      dir,
+      "--ocr",
+      join(dir, "ocr.ndjson"),
+      "--out",
+      join(dir, "ocr-triage.json"),
+    ]);
+    expect(result.summary.total).toBe(CURRENT_ROWS.length);
+    expect(result.entries.map((entry) => entry.slug).sort()).toEqual([
+      "builtin-chat",
+      "builtin-phone",
+    ]);
 
     const { status, stderr } = run();
     expect(stderr).toBe("");
@@ -179,7 +197,7 @@ describe("ocr-triage CLI (end-to-end provenance)", () => {
     );
   });
 
-  it("exits non-zero when a report row's screenshot is missing", () => {
+  it("exits non-zero when a report row's screenshot is missing", async () => {
     shot(dir, "desktop-landscape", "builtin-chat");
     // builtin-phone.png absent → incomplete capture.
     writeFileSync(join(dir, "report.json"), JSON.stringify(CURRENT_ROWS));
@@ -187,6 +205,16 @@ describe("ocr-triage CLI (end-to-end provenance)", () => {
       join(dir, "ocr.ndjson"),
       ocrLine("desktop-landscape", "builtin-chat", "Chat messages"),
     );
+    await expect(
+      runOcrTriage([
+        "--audit-dir",
+        dir,
+        "--ocr",
+        join(dir, "ocr.ndjson"),
+        "--out",
+        join(dir, "ocr-triage.json"),
+      ]),
+    ).rejects.toThrow(/builtin-phone::desktop-landscape has no screenshot/);
     const { status, stderr } = run();
     expect(status).not.toBe(0);
     expect(stderr).toMatch(

--- a/packages/app/test/audit/ocr-triage-provenance.test.ts
+++ b/packages/app/test/audit/ocr-triage-provenance.test.ts
@@ -25,9 +25,18 @@ import { authorizedShots, type ReportEntry } from "../../scripts/ocr-triage";
 // package script invokes it from `packages/app`. Vitest gives `import.meta.url`
 // a virtual scheme, so select between those two documented cwd contracts by
 // probing for the CLI rather than assuming the package-root invocation.
-const APP_DIR = existsSync(join(process.cwd(), "scripts", "ocr-triage.ts"))
-  ? process.cwd()
-  : join(process.cwd(), "packages", "app");
+const appDirCandidates = [
+  process.cwd(),
+  join(process.cwd(), "packages", "app"),
+].filter((candidate) =>
+  existsSync(join(candidate, "scripts", "ocr-triage.ts")),
+);
+if (appDirCandidates.length !== 1) {
+  throw new Error(
+    `Expected one app package root from ${process.cwd()}, found ${appDirCandidates.length}`,
+  );
+}
+const [APP_DIR] = appDirCandidates;
 const CLI = join(APP_DIR, "scripts", "ocr-triage.ts");
 
 /** Minimal valid 1×1 PNG — enough for `existsSync`; the CLI OCR comes from ndjson. */

--- a/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
@@ -3,7 +3,7 @@
  * the real renderer fixture.
  */
 import { readFileSync } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { expect, type Page, test } from "@playwright/test";
@@ -900,6 +900,17 @@ test.describe("all-views aesthetic audit (#8796)", () => {
   const outputDir =
     process.env.ELIZA_AUDIT_APP_DIR ??
     path.join(process.cwd(), "aesthetic-audit-output");
+
+  // Provenance guard (#15790): every run starts from an empty, dedicated output
+  // directory. Screenshots and report.json left by an earlier capture would
+  // otherwise linger — the report-authoritative OCR triage never reads them, but
+  // a stale contact-sheet/manual-review file is still misleading evidence. The
+  // walk runs single-worker (workers:1, fullyParallel:false), so a one-shot wipe
+  // here cannot race a sibling worker's already-written shots.
+  test.beforeAll(async () => {
+    await rm(outputDir, { recursive: true, force: true });
+    await mkdir(outputDir, { recursive: true });
+  });
 
   // Coverage guard: the audit must walk EVERY built-in view. Fails on a phantom
   // key, a path drift, or any distinct navigation route the audit doesn't cover —


### PR DESCRIPTION
Fixes #15790.

## The bug (root provenance defect)

`bun run --cwd packages/app audit:app` left screenshots from earlier runs in `aesthetic-audit-output/`, and the OCR stage (`scripts/ocr-triage.ts`) **recursively globbed every PNG under that directory** (`listPngs`) instead of the screenshots named by the current `report.json`. Stale shots — retired views and since-fixed crashes — were OCR'd and mis-reported as **current** failures, destroying evidence provenance.

Reproduced against a **real 240-row capture** (`packages/app/aesthetic-audit-output`):

| | count |
|---|---|
| DOM report rows (`report.json`) | **240** |
| PNG keys the old glob would OCR | **379** |
| Stale keys not backed by any report row | **139** (incl. `plugin-social-alpha-gui`, `plugin-social-alpha-tui`, `plugin-polymarket-tui`, `builtin-help`, `builtin-tutorial`, cross-spec `assistant-home-flow/*`, `view-manager-actual-flow/*`, every `plugin-*-tui`) |

This is exactly the "240 findings / 379 screenshots" split from the issue.

## The fix

1. **OCR is report-authoritative** (`authorizedShots`): selects exactly one screenshot per current `report.json` row, and **fails fast** on a missing report, a duplicate row, or a row whose screenshot is absent. A PNG no row names is never read, so a stale file is *structurally unable* to enter the result and the OCR row count equals the DOM report row count by construction. The `--ocr` ndjson path is filtered to the report the same way.
2. **Capture starts clean**: the all-views audit wipes its dedicated output dir in `beforeAll` (single-worker: `workers:1`, `fullyParallel:false`, so no sibling race), so every run begins from an empty slate.
3. **Regression test** proves a stale PNG + stale OCR record cannot enter the result and that missing/duplicate rows fail loudly — as pure-function unit tests **and** end-to-end through the real CLI.

## Count-match proof (fixed triage over the real 240-row capture)

```
$ ELIZA_MVP_OCR_ENGINE=packaged bun scripts/ocr-triage.ts \
    --audit-dir <real-capture> --baseline test/ui-smoke/ocr-triage-baseline.json
[ocr-triage] 240 views | verified 92 | broken 0 | needs-eyeball 148
[ocr-triage] wrote ocr-triage.json

DOM report rows : 240
OCR triage rows : 240   ← MATCH (was 379 under the glob)
summary         : {total:240, verified:92, broken:0, needsEyeball:148, regressions:0, newRegressions:0}
glob PNG keys (old buggy input): 379
stale social-alpha/polymarket-tui in OCR result: 0
OCR rows not backed by a report row: 0
```

`broken: 0` — the retired Social Alpha shots and the older Polymarket-TUI crash that the glob surfaced as false regressions are gone; every OCR row is backed by a current report row.

## Current vs retired views (ground truth for the route-fix phase)

- **`Social Alpha` is RETIRED** — not registered in `VIEW_CASES` (`plugin-view-cases.ts`) nor `BUILTIN_TAB_PATHS`. It survives only as mock fixtures in unrelated capture specs; its `plugin-social-alpha-{gui,tui}` PNGs were stale carry-over.
- **`Polymarket` is CURRENT** — `["polymarket","gui","/polymarket"]` → `plugin-polymarket-gui` is registered. (The `plugin-polymarket-tui` variant in the OCR baseline is stale — only the gui view exists today.)

## Regression test

```
$ bunx vitest run test/audit/ocr-triage-provenance.test.ts
 ✓ authorizedShots > selects exactly one shot per report row
 ✓ authorizedShots > ignores a stale PNG that no current row names
 ✓ authorizedShots > fails fast when a report row has no screenshot
 ✓ authorizedShots > fails fast on a duplicate report row
 ✓ authorizedShots > fails fast on an empty report
 ✓ ocr-triage CLI > triages exactly the report rows and drops a stale PNG + stale OCR record
 ✓ ocr-triage CLI > exits non-zero when a report row's screenshot is missing
 Test Files  1 passed (1)   Tests  7 passed (7)
```

## Evidence notes

- Count-match run above is the **OCR stage** (the surface this PR changes) executed over a **real** capture (real screenshots + real `report.json` from an actual all-views walk) — DOM rows 240 == OCR rows 240.
- A fresh **full** `audit:app` (re-running the Playwright walk) could not complete in this sandbox: the renderer `build:web` fails resolving `packages/cloud/routing/src/features.js` via the `eliza-source` export condition under the node ESM config loader — a pre-existing workspace-build fragility unrelated to this change. The clean-before-capture `beforeAll` guarantees a fresh walk starts empty; the report-authoritative selection guarantees the count-match regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Current real-capture verification

Applied this PR's report-authoritative OCR stage to a fresh hosted 240-row app audit capture: report rows 240, OCR rows 240, both key sets unique and exactly equal, no null DOM verdicts, no Social Alpha or Polymarket-TUI stale entries, 92 verified, 148 needs-eyeball, 0 OCR-broken, and 0 regressions. I opened the four viewport montages, the complete metrics sheet, and every one of the 17 `needs-eyeball` originals. Several dynamic plugin views visibly remain on `Loading view...`, and mobile-landscape Calendar overlaps; those are honest surviving visual findings and are not misrepresented as fixes by this provenance-only PR.

## Evidence rows

<!-- evidence-row:before-screenshots -->
- [ ] N/A - this changes capture/OCR provenance rather than product pixels; the pre-fix defect was stale files entering a later report.

<!-- evidence-row:after-screenshots -->
- [x] [Four-viewport montage of all 240 current screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15805-real-capture-montage.jpg), opened and manually reviewed together with all 17 `needs-eyeball` originals.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing interaction changed; the affected end-to-end flow is the headless capture-to-report-to-OCR pipeline.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend runtime or route changed.

<!-- evidence-row:frontend-logs -->
- [x] [Both real test-lane transcripts](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15805-verification.log) show the provenance suite passing 7/7 from repo-root changed-file coverage and 7/7 from the app package lane.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, prompt, action, provider, evaluator, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] [Fresh 240-row app audit report](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15805-real-app-audit-report.json) and [report-authoritative OCR result](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15805-real-ocr-triage.json) have exact `slug::viewport` key parity.

<!-- evidence-row:ocr-review -->
- [x] [OCR execution log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15805-real-ocr.log) and [full OCR result](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15805-real-ocr-triage.json): 240 report rows equal 240 OCR rows, with no stale retired-view entries and no regressions.