### PR TITLE
fix(ui): keep chat-sheet drag handles mounted across the whole press

### DIFF
--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -150,6 +150,41 @@ import { type PullGestureBinding, usePullGesture } from "./use-pull-gesture";
 import type { ConversationNav, ShellController } from "./useShellController";
 import { WALLPAPER_FLOAT_SHADOW, WALLPAPER_TEXT } from "./wallpaper-idiom";
 
+/**
+ * Wraps a pull-gesture binding so `pressed` tracks whether a pointer is held on
+ * the bound element — set on pointerdown, cleared on every terminal (up, cancel,
+ * lost-capture). A drag handle that unmounts under a captured pointer drops the
+ * capture (Chromium fires pointercancel/lostpointercapture on the dead node and
+ * the gesture's settle never runs); the consumer reads this ref in the element's
+ * MOUNT gate so the handle stays alive across the whole press, closing the
+ * window between pointerdown and the integrator's first frame where a stray
+ * re-render would otherwise unmount it.
+ */
+function withPressLatch(
+  binding: PullGestureBinding,
+  pressed: React.MutableRefObject<boolean>,
+): PullGestureBinding {
+  return {
+    onPointerDown: (event) => {
+      pressed.current = true;
+      binding.onPointerDown(event);
+    },
+    onPointerMove: binding.onPointerMove,
+    onPointerUp: (event) => {
+      pressed.current = false;
+      binding.onPointerUp(event);
+    },
+    onPointerCancel: (event) => {
+      pressed.current = false;
+      binding.onPointerCancel(event);
+    },
+    onLostPointerCapture: (event) => {
+      pressed.current = false;
+      binding.onLostPointerCapture(event);
+    },
+  };
+}
+
 /** No-op slash controller so the overlay renders without a provider (stories). */
 const EMPTY_SLASH_CONTROLLER: SlashCommandController = {
   commands: [],
@@ -1453,6 +1488,23 @@ export function ContinuousChatOverlay({
   // the morph keeps the pill↔input crossfade from stranding both bars visible.
   const settleDragRef = React.useRef<(() => void) | null>(null);
   const draggingRef = React.useRef(false);
+  // A pointer is pressed on the open-sheet grabber / the maximize-restore strip
+  // RIGHT NOW. Each gates ITS element's mount (below) so the handle survives any
+  // re-render between the pointerdown and the gesture's first integrated frame.
+  // The mount gates otherwise keep an element alive only once `draggingRef` /
+  // `restoreDragging` go live — which happens on that first frame, not the press
+  // — leaving a window where a re-render (a late settle landing under a loaded
+  // main thread) unmounts the element UNDER the captured pointer. Chromium then
+  // fires pointercancel + lostpointercapture on the dead node and the gesture's
+  // release never runs its settle: the grabber drag dies mid-morph, and worse,
+  // the restore strip strands `restoreDragging`/`draggingRef` true (freezing the
+  // sheet's settle springs — the desktop-held FULL→bottom drain then reads the
+  // corrupted sheet and never engages, stuck at scale 1.00). Held deliberately
+  // OUT of the settle-suppression guards (unlike `draggingRef`): they only keep
+  // the element mounted, and the browser guarantees a pointerup/cancel/lostcapture
+  // terminal for every press, so they clear without a fragile per-callback web.
+  const grabberPressRef = React.useRef(false);
+  const restorePressRef = React.useRef(false);
   // Peak RAW (pre-clamp) pull height reached during the current upward drag
   // (#13531). The visible `threadHeight` is rubber-band-clamped at `openH`, so a
   // deliberate over-pull past FULL is invisible to a `threadHeight.get()` read on
@@ -4477,6 +4529,12 @@ export function ContinuousChatOverlay({
       }
     },
   });
+  // Latch a press on the open-sheet grabber so its mount gate can't drop the
+  // captured pointer between pointerdown and the integrator's first frame.
+  const grabberBinding = React.useMemo(
+    () => withPressLatch(pullBinding, grabberPressRef),
+    [pullBinding],
+  );
 
   // Top-20% pull-down-to-restore (#13531). While maximized (full-bleed) there is
   // no SheetGrabber; this binding drives an invisible grab strip over the top
@@ -4604,6 +4662,15 @@ export function ContinuousChatOverlay({
     // and break the next open. Settle it like any other release.
     onCancel: settleRestore,
   });
+  // Latch a press on the restore strip. Without this the strip can unmount under
+  // its own captured pointer the instant the drag drops full-bleed (before
+  // `restoreDragging` has re-mounted it), stranding the release: `settleRestore`
+  // never runs, so `restoreDragging`/`draggingRef` stay true and freeze the
+  // sheet — the corrupted state the desktop-held drain leg then trips over.
+  const restoreZoneBinding = React.useMemo(
+    () => withPressLatch(maximizeRestoreBinding, restorePressRef),
+    [maximizeRestoreBinding],
+  );
 
   // NOTE: outside pointerdown only drops the keyboard. Outside TAP collapse is
   // handled by the document-level tap detector above so drag gestures can still
@@ -4818,19 +4885,23 @@ export function ContinuousChatOverlay({
         className="pointer-events-none relative flex w-full flex-col items-center"
       >
         {!firstRunOpen &&
-        ((!fullBleed && !restoreDragging) || draggingRef.current) ? (
+        ((!fullBleed && !restoreDragging) ||
+          draggingRef.current ||
+          grabberPressRef.current) ? (
           // Suppressed while full-bleed (the restore strip owns the top) and
           // while a restore drag is in flight (so the strip keeps the pointer
           // capture through the un-maximize) — EXCEPT while a grabber drag is
-          // live: a MID-DRAG commit (pill or maximize) must not unmount or
-          // disable the element holding the pointer capture, or the gesture dies
-          // at the exact moment it commits. Onboarding hides the grabber
-          // entirely: it is pinned, undismissable, and sign-in-first.
+          // live OR merely pressed: a MID-DRAG commit (pill or maximize) must not
+          // unmount or disable the element holding the pointer capture, or the
+          // gesture dies at the exact moment it commits. `grabberPressRef` widens
+          // that window back to the pointerdown, before the integrator's first
+          // frame flips `draggingRef`. Onboarding hides the grabber entirely: it
+          // is pinned, undismissable, and sign-in-first.
           <SheetGrabber
             open={sheetOpen}
             onOpen={openFromGrabber}
             onClose={collapse}
-            binding={pullBinding}
+            binding={grabberBinding}
             // The handle stays QUIET while the mic is recording — the composer
             // mic/voice glyphs already carry the "capture is hot" pulse right
             // next to the user's attention; a second pulsing bar above them
@@ -5061,9 +5132,10 @@ export function ContinuousChatOverlay({
                 over the top bar fall THROUGH to this strip. Keyboard-operable
                 (Enter/Space/ArrowDown restore) so the gesture-only affordance
                 stays WCAG 2.1.1 operable. */}
-            {(fullBleed || restoreDragging) && !pinnedOpen ? (
+            {(fullBleed || restoreDragging || restorePressRef.current) &&
+            !pinnedOpen ? (
               <button
-                {...maximizeRestoreBinding}
+                {...restoreZoneBinding}
                 type="button"
                 data-testid="chat-maximize-restore-zone"
                 aria-label="drag down to exit full screen"

--- a/packages/ui/src/components/shell/use-pull-gesture.test.ts
+++ b/packages/ui/src/components/shell/use-pull-gesture.test.ts
@@ -618,6 +618,54 @@ describe("usePullGesture rAF coalescing (#9141)", () => {
     expect(onPullUp).toHaveBeenCalledTimes(1);
   });
 
+  it("re-seeds a fresh MOUSE gesture stranded on the SAME pointerId (constant id=1)", () => {
+    // A mouse/pen keeps a CONSTANT pointerId (1) across every press, so the
+    // different-id re-seed above does not cover it: when a prior mouse gesture's
+    // element unmounts mid-drag (pill/grabber morph, restore strip), `start`
+    // strands with id 1 and the NEXT mouse press reuses id 1. A same-id early
+    // return then rejects that press outright — the gesture never seeds, never
+    // captures, and drives NOTHING. The fresh press must adopt from its OWN
+    // origin.
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((cb: FrameRequestCallback) => {
+        cb(0);
+        return 1;
+      }),
+    );
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+
+    const onStart = vi.fn();
+    const onDrag = vi.fn();
+    const onPullUp = vi.fn();
+    const onPullDown = vi.fn();
+    const { result } = renderHook(() =>
+      usePullGesture({ onStart, onDrag, onPullUp, onPullDown }),
+    );
+    const b = result.current;
+
+    // Gesture 1 (mouse, pid=1): press at y=300 + drag up, element unmounts —
+    // the pointerup NEVER arrives, so `start` stays seeded at pid=1 / y=300.
+    b.onPointerDown(pointer(100, 300, 1));
+    b.onPointerMove(pointer(100, 200, 1));
+    expect(onDrag).toHaveBeenLastCalledWith(100);
+
+    onStart.mockClear();
+    onDrag.mockClear();
+
+    // Gesture 2 (mouse, pid=1 AGAIN) on the remounted handle at a DIFFERENT
+    // origin (y=520): it must re-seed HERE and drive an upward pull from 520,
+    // not inherit the stranded y=300 seed (which would read the drag as DOWN).
+    b.onPointerDown(pointer(100, 520, 1));
+    b.onPointerMove(pointer(100, 420, 1));
+    b.onPointerUp(pointer(100, 420, 1));
+
+    expect(onStart).toHaveBeenCalledTimes(1);
+    expect(onDrag).toHaveBeenLastCalledWith(100); // up 100 from the fresh y=520
+    expect(onPullUp).toHaveBeenCalledTimes(1);
+    expect(onPullDown).not.toHaveBeenCalled();
+  });
+
   it("calls onStart once for the accepted pointer and ignores secondary starts", () => {
     vi.stubGlobal(
       "requestAnimationFrame",

--- a/packages/ui/src/components/shell/use-pull-gesture.ts
+++ b/packages/ui/src/components/shell/use-pull-gesture.ts
@@ -181,15 +181,19 @@ export function usePullGesture(
       )
         return;
       // A press that reaches here is the primary pointer (a secondary touch
-      // finger returned above), so it is the ONLY pointer down. Any `start` still
-      // held with a different id is therefore stale — the previous gesture's
-      // element unmounted before delivering the pointerup/cancel that clears it
-      // (the maximize restore strip unmounts the instant a restore un-maximizes,
-      // so its captured release never lands and `start` is stranded with the old
-      // id). Re-seed from this press instead of letting the dead id reject every
-      // future gesture on the remounted element; only a duplicate down for the
-      // pointer we already track is ignored.
-      if (start.current?.pointerId === event.pointerId) return;
+      // finger returned above), so it is the ONLY pointer down and it begins a
+      // fresh gesture. Any `start` still held is therefore stale and must be
+      // replaced: the browser never delivers a second pointerdown for a pointer
+      // it still considers down (a pointerup/cancel must land first), so a
+      // lingering `start` means the previous gesture's element unmounted before
+      // its captured release arrived (the maximize restore strip unmounts the
+      // instant a restore un-maximizes; the pill/grabber unmount as the sheet
+      // morphs under a held drag). Re-seed unconditionally — INCLUDING when the
+      // id matches, which is the norm for mouse/pen where `pointerId` is a
+      // constant (1). A same-id early return here (the prior form) stranded
+      // every subsequent MOUSE gesture on a remounted handle: mouse reuses
+      // pointerId 1, so it matched the dead `start` and the fresh press was
+      // rejected outright — no seed, no capture, drives nothing.
       start.current = {
         x: event.clientX,
         y: event.clientY,


### PR DESCRIPTION
## What

Greens the last failing step in the **Chat shell gestures** workflow — step **Chat-sheet gesture e2e** (`packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs`), which failed on `develop@960bef879ab` in the `[desktop-held]` leg:

```
✗ [desktop-held] FULL→bottom hold drains the whole thread height under the finger
✗ [desktop-held] the input→pill morph engages under the held finger (scale 1.00 ≤ 0.7)
✗ [desktop-held] releasing the drained drag lands on the PILL
```

`scale 1.00` = the held drag never drove the surface at all.

## Root cause (load-raced, not deterministic)

A **mid-gesture unmount that drops an active pointer capture.** A chat-sheet drag handle (the open-sheet grabber and the maximize-restore strip) is kept mounted *during* a drag only once the integrator flips `draggingRef` / `restoreDragging` on its **first rAF-coalesced frame**. Between the `pointerdown` and that first frame there is a window: a stray re-render — a late settle spring landing while the main thread is contended (the CI runners are 2-core and busy) — re-evaluates the element's mount gate with those flags still `false` and **unmounts the element under the captured pointer**. Chromium then fires `pointercancel` + `lostpointercapture` on the dead node and the gesture's release never runs.

For the **restore strip** this is the worse of the two: the stranded release never runs `settleRestore`, so `restoreDragging` / `draggingRef` stay **stuck true**, freezing the sheet's settle springs. The subsequent grabber drain drag then reads that corrupted sheet and never engages (`scale 1.00`). Captured live under CPU load with `MutationObserver` + gate-state probes:

```
[GB] down press=true
[GB] cancel  ← Chromium cancels the mouse pointer
[RAF] cancel rafId 513 pending? true  ← the pending drag frame is killed
[MO] grabber REMOVED
[GATE] fullBleed false restoreDragging TRUE dragging false → grabberMounted false
```

## Fix

`withPressLatch` wraps each handle's gesture binding with a boolean ref set on `pointerdown` and cleared on **every** terminal (`pointerup` / `pointercancel` / `lostpointercapture` — all browser-guaranteed), and that ref is read in the element's **mount gate**. This widens "keep the handle mounted" back to the press itself, closing the pointerdown→first-frame window. The refs are kept deliberately **out** of the settle-suppression guards (unlike `draggingRef`) — they only keep the element alive, so they can never freeze a spring.

Also hardens the shared pull-gesture pointerdown re-seed for **mouse**: a constant `pointerId` (1) meant a gesture stranded on a mid-drag unmount rejected every later same-id press outright (no seed, no capture). A fresh `pointerdown` for a pointer the browser still holds down is impossible, so any lingering `start` is by definition stale → re-seed unconditionally. Covered by a new deterministic unit test.

## Evidence

- **Red → green under load:** reproduced the exact CI failure locally under sustained CPU contention (~25% failure rate on `develop`), then **22/22 consecutive clean** `[desktop-held]` drain runs with the fix. No `[mouse]`-suite regressions.
- **Full runner:** `bun run --cwd packages/ui test:chat-sheet-e2e` → **296 passed / 0 failed** (on the rebased `develop` base).
- **Unit:** new `use-pull-gesture` test for the same-pointerId mouse re-seed (fails on the old guard, passes with the fix); `use-pull-gesture.test.ts` green. The 6 remaining jsdom unit failures in the `ContinuousChatOverlay` morph/fuzz/draft suites are **pre-existing on `develop`** (verified identical before/after) and are not part of the real-browser `Chat-sheet gesture e2e` step.
- `bunx biome check` clean on all touched files.

Files: `ContinuousChatOverlay.tsx`, `use-pull-gesture.ts` (+ test). No product-code fabrication, no weakened assertions, `bun.lock` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)