### PR TITLE
fix(evidence): scope app audit OCR + artifacts to the current capture (#15790)

### DIFF
--- a/packages/app/scripts/ocr-triage-lib.ts
+++ b/packages/app/scripts/ocr-triage-lib.ts
@@ -1,0 +1,94 @@
+/**
+ * Provenance-scoping for the OCR triage: derives the exact screenshot set an OCR
+ * run may consume from THIS capture's `report.json`, so a stale PNG left by an
+ * earlier run — a since-removed view, an older crash — can never enter the
+ * result (#15790). The aesthetic audit records one report row per view×viewport
+ * and writes its screenshot to `<auditDir>/<viewport>/<slug>.png`; these pure
+ * functions make that mapping total and injective: every row resolves to exactly
+ * one existing file, a duplicate row key or a missing file is a hard error (a
+ * report that pixels cannot back one-to-one is a broken capture, not a
+ * degradable state), and extra files on disk are ignored rather than silently
+ * OCR'd. Kept engine-free and dependency-injectable so the guarantees are unit
+ * tested without an OCR engine or real screenshots.
+ */
+import { existsSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+
+export interface AuditReportRow {
+  slug: string;
+  viewport: string;
+  viewType?: "gui" | "tui";
+  verdict?: string;
+}
+
+export interface ResolvedShot {
+  key: string;
+  row: AuditReportRow;
+  path: string;
+}
+
+export function reportRowKey(slug: string, viewport: string): string {
+  return `${slug}::${viewport}`;
+}
+
+/** `<viewport>/<slug>.png` back to the `slug::viewport` key that names its report row. */
+export function shotKeyOfPath(path: string): string {
+  return reportRowKey(
+    basename(path).replace(/\.png$/, ""),
+    basename(dirname(path)),
+  );
+}
+
+/**
+ * One resolved screenshot per report row, in report order. Throws on a duplicate
+ * row key or a row whose screenshot file is absent — the OCR set is defined by
+ * the report, so a report that cannot be backed one-to-one by real pixels fails
+ * loudly instead of being quietly padded with, or short of, screenshots.
+ */
+export function resolveAuditScreenshots(
+  report: AuditReportRow[],
+  auditDir: string,
+  fileExists: (p: string) => boolean = existsSync,
+): ResolvedShot[] {
+  const seen = new Set<string>();
+  const resolved: ResolvedShot[] = [];
+  for (const row of report) {
+    const key = reportRowKey(row.slug, row.viewport);
+    if (seen.has(key)) {
+      throw new Error(`[ocr-triage] duplicate report row ${key}`);
+    }
+    seen.add(key);
+    const path = join(auditDir, row.viewport, `${row.slug}.png`);
+    if (!fileExists(path)) {
+      throw new Error(
+        `[ocr-triage] report row ${key} has no screenshot at ${path} — the capture is incomplete or the report is stale`,
+      );
+    }
+    resolved.push({ key, row, path });
+  }
+  return resolved;
+}
+
+/**
+ * Selects the precomputed OCR record for each resolved shot from an `--ocr`
+ * ndjson dump, in report order. Records whose path matches no report row (stale
+ * PNGs) are dropped; a report row with no matching record is a hard error, so a
+ * precomputed run is held to the same one-row-one-screenshot contract as a live
+ * packaged run.
+ */
+export function selectOcrRecordsForShots<T extends { path: string }>(
+  shots: ResolvedShot[],
+  records: T[],
+): T[] {
+  const byKey = new Map<string, T>();
+  for (const rec of records) byKey.set(shotKeyOfPath(rec.path), rec);
+  return shots.map((shot) => {
+    const rec = byKey.get(shot.key);
+    if (!rec) {
+      throw new Error(
+        `[ocr-triage] --ocr input has no record for report row ${shot.key}`,
+      );
+    }
+    return rec;
+  });
+}

--- a/packages/app/scripts/ocr-triage.ts
+++ b/packages/app/scripts/ocr-triage.ts
@@ -18,8 +18,14 @@
  * an issue; the gate exits non-zero only on a regression NOT in that baseline —
  * the same ratchet posture as the aesthetic audit's verdict-debt map, so a known
  * bug stays visible without wedging CI while a NEW pixel-broken render fails it.
+ *
+ * Provenance (#15790): the OCR set is defined by THIS run's `report.json`, not by
+ * whatever PNGs happen to sit in the audit dir. `resolveAuditScreenshots` maps
+ * every report row to exactly one existing screenshot; a stale PNG for a
+ * since-removed view is ignored, and a missing/duplicate row fails loudly — so
+ * OCR and DOM-report row counts are identical by construction.
  */
-import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { OVERLAY_NATIVE_OR_CANVAS_SLUGS } from "../test/ui-smoke/aesthetic-audit-rules";
 import {
@@ -33,6 +39,11 @@ import {
   ocrImage,
   resolveOcrEngine,
 } from "./mvp-visual-verify/ocr.mjs";
+import {
+  type AuditReportRow,
+  resolveAuditScreenshots,
+  selectOcrRecordsForShots,
+} from "./ocr-triage-lib";
 
 /**
  * Slugs whose healthy render legitimately OCRs to little or no text: wallpaper
@@ -45,13 +56,6 @@ const BLANK_EXEMPT_SLUGS = new Set<string>([
   "builtin-background",
   "plugin-focus-gui",
 ]);
-
-interface ReportEntry {
-  slug: string;
-  viewport: string;
-  viewType?: "gui" | "tui";
-  verdict?: string;
-}
 
 interface OcrRecord extends OcrResult {
   path: string;
@@ -74,18 +78,6 @@ function parseArgs(argv: string[]): Record<string, string> {
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a.startsWith("--")) out[a.slice(2)] = argv[++i] ?? "";
-  }
-  return out;
-}
-
-function listPngs(dir: string): string[] {
-  const out: string[] = [];
-  for (const viewport of readdirSync(dir, { withFileTypes: true })) {
-    if (!viewport.isDirectory()) continue;
-    const vp = join(dir, viewport.name);
-    for (const f of readdirSync(vp)) {
-      if (f.endsWith(".png")) out.push(join(vp, f));
-    }
   }
   return out;
 }
@@ -137,19 +129,26 @@ async function main() {
   );
 
   const reportPath = join(auditDir, "report.json");
-  const report: ReportEntry[] = existsSync(reportPath)
+  const report: AuditReportRow[] = existsSync(reportPath)
     ? JSON.parse(readFileSync(reportPath, "utf8"))
     : [];
-  const reportByKey = new Map<string, ReportEntry>();
+  const reportByKey = new Map<string, AuditReportRow>();
   for (const r of report) reportByKey.set(`${r.slug}::${r.viewport}`, r);
 
-  const pngs = listPngs(auditDir);
+  // Provenance (#15790): OCR exactly the screenshots this run's report names —
+  // one per row, no stale extras. `resolveAuditScreenshots` throws on a missing
+  // or duplicate row, so a broken capture fails here rather than laundering old
+  // pixels into a "current" verdict.
+  const shots = resolveAuditScreenshots(report, auditDir);
   const ocr: OcrRecord[] = args.ocr
-    ? readFileSync(args.ocr, "utf8")
-        .split("\n")
-        .filter((l) => l.trim())
-        .map((l) => JSON.parse(l) as OcrRecord)
-    : await runPackagedOcr(pngs);
+    ? selectOcrRecordsForShots(
+        shots,
+        readFileSync(args.ocr, "utf8")
+          .split("\n")
+          .filter((l) => l.trim())
+          .map((l) => JSON.parse(l) as OcrRecord),
+      )
+    : await runPackagedOcr(shots.map((s) => s.path));
 
   const entries: TriageEntry[] = [];
   for (const rec of ocr) {

--- a/packages/app/test/audit/ocr-triage-lib.test.ts
+++ b/packages/app/test/audit/ocr-triage-lib.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Regression lock for the OCR-triage provenance scoping (#15790): proves the
+ * screenshot set an OCR run consumes is derived from `report.json` and can never
+ * absorb a stale PNG left by an earlier capture. Pure functions over injected
+ * file-existence and hand-authored records — no OCR engine, no real screenshots.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  type AuditReportRow,
+  resolveAuditScreenshots,
+  selectOcrRecordsForShots,
+  shotKeyOfPath,
+} from "../../scripts/ocr-triage-lib";
+
+const AUDIT_DIR = "/audit-out";
+
+function report(...rows: [string, string][]): AuditReportRow[] {
+  return rows.map(([slug, viewport]) => ({
+    slug,
+    viewport,
+    viewType: "gui" as const,
+    verdict: "good",
+  }));
+}
+
+describe("resolveAuditScreenshots (#15790)", () => {
+  it("resolves exactly one screenshot per report row and ignores stale PNGs on disk", () => {
+    const rows = report(
+      ["builtin-chat", "mobile-portrait"],
+      ["builtin-settings", "desktop-landscape"],
+    );
+    const currentPaths = new Set([
+      `${AUDIT_DIR}/mobile-portrait/builtin-chat.png`,
+      `${AUDIT_DIR}/desktop-landscape/builtin-settings.png`,
+    ]);
+    // A since-removed view (Social Alpha) and an older crash still sit in the
+    // dir; `existsSync` would report them, but they are not report rows.
+    const stalePaths = new Set([
+      `${AUDIT_DIR}/mobile-portrait/plugin-social-alpha-gui.png`,
+      `${AUDIT_DIR}/desktop-landscape/plugin-polymarket-gui.png`,
+    ]);
+    const fileExists = (p: string) => currentPaths.has(p) || stalePaths.has(p);
+
+    const shots = resolveAuditScreenshots(rows, AUDIT_DIR, fileExists);
+
+    expect(shots).toHaveLength(rows.length);
+    expect(shots.map((s) => s.path)).toEqual([...currentPaths]);
+    // No resolved shot points at a stale PNG.
+    for (const shot of shots) expect(stalePaths.has(shot.path)).toBe(false);
+  });
+
+  it("throws on a duplicate report row", () => {
+    const rows = report(
+      ["builtin-chat", "mobile-portrait"],
+      ["builtin-chat", "mobile-portrait"],
+    );
+    expect(() => resolveAuditScreenshots(rows, AUDIT_DIR, () => true)).toThrow(
+      /duplicate report row builtin-chat::mobile-portrait/,
+    );
+  });
+
+  it("throws when a report row has no backing screenshot", () => {
+    const rows = report(["builtin-chat", "mobile-portrait"]);
+    expect(() => resolveAuditScreenshots(rows, AUDIT_DIR, () => false)).toThrow(
+      /no screenshot at .*builtin-chat\.png/,
+    );
+  });
+});
+
+describe("selectOcrRecordsForShots (#15790)", () => {
+  const rows = report(
+    ["builtin-chat", "mobile-portrait"],
+    ["builtin-settings", "desktop-landscape"],
+  );
+  const shots = resolveAuditScreenshots(rows, AUDIT_DIR, () => true);
+
+  it("picks records in report order and drops stale precomputed records", () => {
+    const records = [
+      // deliberately out of order + one stale record for a removed view
+      {
+        path: `${AUDIT_DIR}/desktop-landscape/builtin-settings.png`,
+        id: "settings",
+      },
+      {
+        path: `${AUDIT_DIR}/mobile-portrait/plugin-social-alpha-gui.png`,
+        id: "stale",
+      },
+      { path: `${AUDIT_DIR}/mobile-portrait/builtin-chat.png`, id: "chat" },
+    ];
+    const picked = selectOcrRecordsForShots(shots, records);
+    expect(picked.map((r) => r.id)).toEqual(["chat", "settings"]);
+  });
+
+  it("throws when a report row has no precomputed record", () => {
+    const records = [
+      { path: `${AUDIT_DIR}/mobile-portrait/builtin-chat.png`, id: "chat" },
+    ];
+    expect(() => selectOcrRecordsForShots(shots, records)).toThrow(
+      /no record for report row builtin-settings::desktop-landscape/,
+    );
+  });
+});
+
+describe("shotKeyOfPath", () => {
+  it("maps <viewport>/<slug>.png to slug::viewport", () => {
+    expect(shotKeyOfPath(`${AUDIT_DIR}/mobile-portrait/builtin-chat.png`)).toBe(
+      "builtin-chat::mobile-portrait",
+    );
+  });
+});

--- a/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
@@ -3,7 +3,7 @@
  * the real renderer fixture.
  */
 import { readFileSync } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { expect, type Page, test } from "@playwright/test";
@@ -900,6 +900,17 @@ test.describe("all-views aesthetic audit (#8796)", () => {
   const outputDir =
     process.env.ELIZA_AUDIT_APP_DIR ??
     path.join(process.cwd(), "aesthetic-audit-output");
+
+  // Provenance (#15790): each run starts from an empty dedicated output dir, so
+  // a screenshot for a since-removed view can never survive into the next
+  // capture and be re-read as a current failure by the OCR triage (which scopes
+  // its screenshot set to this run's report.json). The suite runs workers:1 /
+  // fullyParallel:false, so this fires exactly once before any view writes a
+  // screenshot — no worker can wipe another worker's output mid-run.
+  test.beforeAll(async () => {
+    await rm(outputDir, { recursive: true, force: true });
+    await mkdir(outputDir, { recursive: true });
+  });
 
   // Coverage guard: the audit must walk EVERY built-in view. Fails on a phantom
   // key, a path drift, or any distinct navigation route the audit doesn't cover —


### PR DESCRIPTION
Closes #15790.

## Problem

`bun run --cwd packages/app audit:app` captured the current all-views matrix but left screenshots and `report.json` from earlier runs in `aesthetic-audit-output/`. The OCR triage (`scripts/ocr-triage.ts`) then recursively OCR'd **every** PNG under that directory instead of the screenshots named by the current `report.json`. A fresh capture (240 current rows) OCR'd 379 screenshots, so retired **Social Alpha** views and an older **Polymarket** crash surfaced as *current* false regressions — invalidating visual-evidence provenance.

## Fix

- **Capture side** (`all-views-aesthetic-audit.spec.ts`): each run starts from an empty, dedicated output dir (`rm` + `mkdir` in a `workers:1` / `fullyParallel:false` `beforeAll`, before any view writes a screenshot — no worker can wipe another's output mid-run).
- **OCR side** (new `scripts/ocr-triage-lib.ts`): the OCR screenshot set is derived from `report.json`. `resolveAuditScreenshots` maps every report row to exactly one **existing** screenshot (`<auditDir>/<viewport>/<slug>.png`); a **missing** or **duplicate** row is a hard error, and extra PNGs on disk are ignored. `selectOcrRecordsForShots` holds the precomputed `--ocr` path to the same one-row-one-screenshot contract. OCR and DOM-report row counts are now **identical by construction**.
- **Regression test** (`test/audit/ocr-triage-lib.test.ts`): proves stale extra PNGs cannot enter the OCR result, and that a missing/duplicate row throws.

## Acceptance criteria

- [x] The audit capture starts with an empty, dedicated output directory.
- [x] OCR consumes exactly one screenshot per current `report.json` row, rejects missing/duplicate rows, and does not silently include stale screenshots.
- [x] A regression test proves stale extra PNGs cannot enter the OCR result.
- [x] Fresh `audit:app` DOM-report and OCR row counts are identical (guaranteed by construction).
- [ ] Fresh full `audit:app` run manually reviewed with OCR/palette/screenshots attached — see reviewer note below (headless full-matrix run requires a ~15 min renderer build + Chromium live stack; the mechanism is proven deterministically below).
- [ ] #15780 / #15781 re-evaluated against a fresh capture — reviewer step once the fresh capture is produced.

## Evidence — red→green

Reproduced the exact stale-PNG mismatch on the committed `aesthetic-audit-output`: **7** report rows vs **379** PNGs on disk (**372 stale**), including `plugin-social-alpha-*` and `plugin-polymarket-*`.

Deterministic red→green on a synthetic audit dir (1 report row, 2 PNGs on disk — one current `builtin-chat`, one stale `plugin-social-alpha-gui` carrying a crash string), driven through the `--ocr` path (no engine needed):

<details><summary>before (develop <code>ocr-triage.ts</code>)</summary>

```
report rows: 1  |  PNGs on disk: 2
[ocr-triage] 2 views | verified 0 | broken 1 | needs-eyeball 1
total: 2 broken: 1
slugs: [ 'plugin-social-alpha-gui', 'builtin-chat' ]   # stale crash reported as CURRENT
```
</details>

<details><summary>after (this branch)</summary>

```
report rows: 1  |  PNGs on disk: 2
[ocr-triage] 1 views | verified 0 | broken 0 | needs-eyeball 1
total: 1
slugs: [ 'builtin-chat' ]                               # stale PNG excluded; total == report rows
```
</details>

## Evidence — tests / gates

```
$ bunx vitest run --config vitest.config.ts test/audit/ocr-triage-lib.test.ts test/audit/ocr-content-rules.test.ts
 Test Files  2 passed (2)
      Tests  30 passed (30)

$ bun run typecheck        # tsgo --noEmit -p tsconfig.typecheck.json
TYPECHECK EXIT: 0   (0 error TS)

$ bunx @biomejs/biome check <touched files>   # clean after --write
```

## Reviewer verification (full audit)

A full `bun run --cwd packages/app audit:app` on a fresh renderer build will now (a) begin from an empty `aesthetic-audit-output/` and (b) report `[ocr-triage] N views` where `N` equals the `report.json` row count, with no Social Alpha / stale-Polymarket rows. That headless run needs the ~15 min renderer build + Chromium live stack and is the recommended manual step to attach the fresh OCR/palette/screenshots and re-evaluate #15780 / #15781.

N/A rows: no UI pixels changed (audit tooling only), so before/after app screenshots and model trajectories are N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)