### PR TITLE
test(transcripts): e2e scenario for SHARE_TRANSCRIPT redaction (#14779)

### DIFF
--- a/packages/scenario-runner/src/corpus-assertion-guard.test.ts
+++ b/packages/scenario-runner/src/corpus-assertion-guard.test.ts
@@ -343,6 +343,11 @@ const EXPECTED_PR_DETERMINISTIC_SCENARIO_IDS = [
   "inbox.summarize-inboxes",
   "linear.search-issues",
   "local-inference.start-transcription",
+  // Transcript permissioning (#14779): keyless proof that SHARE_TRANSCRIPT
+  // routes message -> planner -> TranscriptStore and that the disclosure
+  // predicate serves the redacted variant to a non-privileged colleague while
+  // an admin keeps the untouched original. Added here in the same commit.
+  "local-inference.transcript-permissioning",
   "meetings.get-transcript",
   "music.routing-status",
   "nostr.search-posts",

--- a/packages/test/scenarios/local-inference/transcript-permissioning.scenario.ts
+++ b/packages/test/scenarios/local-inference/transcript-permissioning.scenario.ts
@@ -1,0 +1,286 @@
+/**
+ * Deterministic per-plugin e2e for the transcript permissioning actions of
+ * `@elizaos/plugin-local-inference` (issue #14779): the message -> planner ->
+ * `SHARE_TRANSCRIPT` -> `TranscriptStore` path proven end to end, not at the
+ * unit boundary.
+ *
+ * The seed writes one meeting transcript containing PII (email + phone) into
+ * the transcripts partition, owned by the scenario's ADMIN requester. The turn
+ * asks the agent to share it with a non-privileged colleague, redacted. The
+ * planner fixture routes to `SHARE_TRANSCRIPT` with `mode: "redacted"`, which
+ * mints the deterministic redacted variant and writes a per-entity grant on the
+ * original row.
+ *
+ * The effect proof reads the store back the way the API route does — through
+ * the ONE role-aware disclosure predicate (#14781): the colleague (USER, with
+ * the redacted grant) gets the variant served under the original id with audio
+ * withheld and PII scrubbed, while an ADMIN viewer gets the untouched original
+ * with audio and raw PII intact. Handler success without those two disclosures
+ * differing is not proof, so the check fails on either leak or missing redaction.
+ */
+import {
+  type AgentRuntime,
+  ModelType,
+  stringToUuid,
+  type UUID,
+} from "@elizaos/core";
+import {
+  TranscriptStore,
+  type TranscriptStoreRuntime,
+} from "@elizaos/plugin-local-inference/services/voice/transcript-store";
+import { scenario } from "@elizaos/scenario-runner/schema";
+import type { Transcript } from "@elizaos/shared";
+
+const SHARE_TRANSCRIPT = "SHARE_TRANSCRIPT";
+
+/** Stable ids so the planner fixture can name the transcript + grantee. */
+const TRANSCRIPT_ID = stringToUuid(
+  "scenario:transcript-permissioning:meeting-1",
+) as UUID;
+const COLLEAGUE_ID = "a11ce000-0000-4000-8000-000000000001" as UUID;
+const ADMIN_VIEWER_ID = "ad311000-0000-4000-8000-000000000002" as UUID;
+
+const ALICE_EMAIL = "alice@example.com";
+const ALICE_PHONE = "415-555-0199";
+const BOB_EMAIL = "bob@example.com";
+
+type R = AgentRuntime & {
+  scenarioLlmFixtures?: {
+    register: (...f: Array<Record<string, unknown>>) => void;
+  };
+};
+
+function buildTranscript(ownerHint: string): Transcript {
+  return {
+    id: TRANSCRIPT_ID,
+    title: `Q3 Payroll Sync (${ownerHint})`,
+    createdAt: 1_700_000_000_000,
+    endedAt: 1_700_000_600_000,
+    durationMs: 600_000,
+    audioUrl: "/api/media/deadbeef.wav",
+    audioContentType: "audio/wav",
+    segments: [
+      {
+        id: "seg-1",
+        speakerLabel: "Alice",
+        startMs: 0,
+        endMs: 8_000,
+        text: `You can reach me at ${ALICE_EMAIL} or on ${ALICE_PHONE} after the call.`,
+        words: [],
+      },
+      {
+        id: "seg-2",
+        speakerLabel: "Bob",
+        startMs: 8_000,
+        endMs: 15_000,
+        text: `Thanks Alice, I will forward the deck to ${BOB_EMAIL} tonight.`,
+        words: [],
+      },
+    ],
+    source: "meeting",
+    scope: "owner-private",
+    status: "ready",
+    speakerCount: 2,
+  };
+}
+
+export default scenario({
+  lane: "pr-deterministic",
+  id: "local-inference.transcript-permissioning",
+  title: "Local inference: share a meeting transcript redacted to a colleague",
+  domain: "local-inference",
+  tags: ["local-inference", "voice", "security", "permissioning", "memory"],
+  description:
+    "Exercises SHARE_TRANSCRIPT end to end: an admin asks the agent to share a PII-bearing meeting transcript with a non-privileged colleague; the colleague gets the redacted variant (audio withheld, PII scrubbed) while an admin viewer keeps the full original. Keyless deterministic proxy.",
+
+  requires: { plugins: ["@elizaos/plugin-local-inference"] },
+  isolation: "per-scenario",
+
+  seed: [
+    {
+      type: "custom",
+      name: "seed-meeting-transcript-with-pii",
+      apply: async (ctx) => {
+        const runtime = ctx.runtime as R;
+        const owner = (ctx.primaryUserId ?? runtime.agentId) as UUID;
+        const roomId = (ctx.primaryRoomId ?? runtime.agentId) as UUID;
+
+        const store = new TranscriptStore(
+          runtime as unknown as TranscriptStoreRuntime,
+        );
+        await store.create({
+          roomId,
+          entityId: owner,
+          transcript: buildTranscript(owner),
+        });
+
+        runtime.scenarioLlmFixtures?.register(
+          {
+            name: "transcript-permissioning-stage1",
+            match: {
+              modelType: ModelType.RESPONSE_HANDLER,
+              input: (v: string) => v.toLowerCase().includes("share"),
+              toolName: "HANDLE_RESPONSE",
+            },
+            response: {
+              contexts: ["voice"],
+              intents: ["share a meeting transcript, redacted"],
+              replyText: "",
+              threadOps: [],
+              candidateActionNames: [SHARE_TRANSCRIPT],
+            },
+            times: 1,
+          },
+          {
+            name: "transcript-permissioning-planner",
+            match: {
+              modelType: ModelType.ACTION_PLANNER,
+              input: (v: string) => v.toLowerCase().includes("share"),
+              toolName: SHARE_TRANSCRIPT,
+            },
+            response: {
+              text: "",
+              thought:
+                "Alice is not an admin, so share the transcript with her as a redacted variant.",
+              messageToUser: "",
+              completed: true,
+              finishReason: "tool-calls",
+              toolCalls: [
+                {
+                  id: "call-share-transcript",
+                  name: SHARE_TRANSCRIPT,
+                  type: "function",
+                  arguments: {
+                    transcriptId: TRANSCRIPT_ID,
+                    entityId: COLLEAGUE_ID,
+                    mode: "redacted",
+                  },
+                },
+              ],
+            },
+            times: 1,
+          },
+          {
+            name: "transcript-permissioning-decision",
+            match: (call: { modelType: string; toolNames: string[] }) =>
+              call.modelType === ModelType.RESPONSE_HANDLER &&
+              !call.toolNames.includes("HANDLE_RESPONSE"),
+            response: {
+              success: true,
+              decision: "FINISH",
+              thought: "Redacted transcript shared; nothing more to do.",
+              messageToUser: "Shared the redacted transcript with Alice.",
+            },
+            times: 1,
+          },
+        );
+        return undefined;
+      },
+    },
+  ],
+
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      channelType: "DM",
+      title: "Meeting transcript",
+    },
+  ],
+
+  turns: [
+    {
+      kind: "message",
+      name: "share-redacted",
+      text: `Share the meeting transcript ${TRANSCRIPT_ID} with Alice (${COLLEAGUE_ID}). She is not an admin, so send her the redacted version.`,
+      timeoutMs: 120_000,
+      assertTurn: (turn) => {
+        const call = turn.actionsCalled.find(
+          (a) => a.actionName === SHARE_TRANSCRIPT,
+        );
+        if (!call) {
+          return `Expected ${SHARE_TRANSCRIPT} but got: ${turn.actionsCalled
+            .map((a) => a.actionName)
+            .join(", ")}`;
+        }
+        if (!call.result?.success) {
+          return `${SHARE_TRANSCRIPT} did not succeed: ${
+            call.error?.message ?? call.result?.text ?? "unknown error"
+          }`;
+        }
+      },
+    },
+  ],
+
+  finalChecks: [
+    {
+      type: "actionCalled",
+      actionName: SHARE_TRANSCRIPT,
+      status: "success",
+      minCount: 1,
+    },
+    {
+      // Effect proof: read the store the way the disclosure route does. A
+      // non-privileged colleague with the redacted grant must get the variant
+      // (audio withheld, PII scrubbed), and an admin viewer must still get the
+      // untouched original — handler success is not enough on its own.
+      type: "custom",
+      name: "redacted-to-colleague-full-to-admin",
+      predicate: async (ctx) => {
+        const runtime = ctx.runtime as R;
+        const store = new TranscriptStore(
+          runtime as unknown as TranscriptStoreRuntime,
+        );
+
+        const colleagueView = await store.get(TRANSCRIPT_ID, {
+          requesterEntityId: COLLEAGUE_ID,
+          role: "USER",
+        });
+        if (!colleagueView) {
+          return "colleague with a redacted grant saw nothing (expected the redacted variant)";
+        }
+        if (colleagueView.redacted !== true) {
+          return "colleague view was not flagged redacted";
+        }
+        if (colleagueView.audioUrl !== undefined) {
+          return "redacted colleague view leaked audioUrl (audio is never redacted in v1 and must be withheld)";
+        }
+        const colleagueText = colleagueView.segments
+          .map((s) => s.text)
+          .join(" ");
+        if (
+          colleagueText.includes(ALICE_EMAIL) ||
+          colleagueText.includes(ALICE_PHONE) ||
+          colleagueText.includes(BOB_EMAIL)
+        ) {
+          return `redacted colleague view leaked PII: ${colleagueText}`;
+        }
+        if (!colleagueText.includes("[EMAIL]")) {
+          return `redacted colleague view did not scrub email to a surrogate: ${colleagueText}`;
+        }
+
+        const adminView = await store.get(TRANSCRIPT_ID, {
+          requesterEntityId: ADMIN_VIEWER_ID,
+          role: "ADMIN",
+        });
+        if (!adminView) {
+          return "admin viewer saw nothing (expected the full original)";
+        }
+        if (adminView.redacted) {
+          return "admin viewer got a redacted view (admins retain full disclosure)";
+        }
+        if (adminView.audioUrl !== "/api/media/deadbeef.wav") {
+          return "admin viewer lost the original audioUrl (the original must be untouched)";
+        }
+        const adminText = adminView.segments.map((s) => s.text).join(" ");
+        if (
+          !adminText.includes(ALICE_EMAIL) ||
+          !adminText.includes(ALICE_PHONE)
+        ) {
+          return `admin viewer lost original PII, so the original was mutated by redaction: ${adminText}`;
+        }
+        return undefined;
+      },
+    },
+  ],
+});


### PR DESCRIPTION
## What & why

Closes the top acceptance gap of #14779. The transcript permissioning **actions** (`REDACT_TRANSCRIPT` / `SHARE_TRANSCRIPT`), the deterministic **redacted-variant write primitives**, and the **role-aware disclosure predicate** all already landed on develop via #15597, #15602, #15606, and #14781. What was never delivered is issue #14779's **first acceptance criterion** — an end-to-end scenario proving:

> meeting transcript captured → participant asks agent to share → agent shares **redacted to USER, full to ADMIN**

Everything below the message boundary was unit-tested only; the `message → planner → action → store` path had no coverage.

## Change

A keyless **pr-deterministic** scenario, `local-inference.transcript-permissioning`, that drives the real path end to end through the deterministic LLM proxy:

1. **Seed** writes one meeting transcript containing PII (email + phone) into the `transcripts` partition, owned by the scenario's ADMIN requester.
2. **Turn** — the admin asks the agent to share it with a non-privileged colleague, redacted. The planner fixture routes to `SHARE_TRANSCRIPT` with `mode: "redacted"`, which mints the deterministic redacted variant and writes a per-entity grant on the original row.
3. **Effect proof** reads the store back through the *same* disclosure predicate the API route uses (#14781) and asserts the two disclosures actually diverge:
   - colleague (USER + redacted grant) → variant served under the original id, `redacted: true`, **audio withheld**, email/phone scrubbed to `[EMAIL]`/`[PHONE]` surrogates;
   - ADMIN viewer → **untouched original** with `audioUrl` and raw PII intact (proves the original is never mutated by redaction).

Handler success alone is explicitly not accepted — the check fails on any PII leak, a missing redaction flag, a leaked `audioUrl`, or a mutated original.

The new scenario id is registered in the `corpus-assertion-guard` allowlist in the same commit per that guard's convention.

## Evidence

**Green (deterministic proxy, keyless):**
```
$ TZ=UTC SCENARIO_USE_LLM_PROXY=1 SCENARIO_LLM_PROXY_STRICT=1 bun src/cli.ts run \
    ../test/scenarios/local-inference/transcript-permissioning.scenario.ts --lane pr-deterministic
[eliza-scenarios] provider: deterministic-llm-proxy
[eliza-scenarios] ▶ local-inference.transcript-permissioning
[eliza-scenarios] ✓ local-inference.transcript-permissioning passed (3301ms)
| id | status | duration | failures |
| local-inference.transcript-permissioning | passed | 3301ms |  |
Totals: 1 passed, 0 failed, 0 skipped of 1
```

Report confirms the real action fired with the redacted grant:
```json
"actionsCalled": [{
  "actionName": "SHARE_TRANSCRIPT",
  "parameters": { "parameters": { "transcriptId": "…", "entityId": "a11ce000-…", "mode": "redacted" } },
  "result": { "success": true, "text": "Shared the redacted transcript." }
}]
```

**Red → green proof the effect check bites** — flipping the shared mode to `full` (colleague gets a full grant instead of the redacted variant):
```
[eliza-scenarios] ✗ local-inference.transcript-permissioning-RED failed (2797ms)
| local-inference.transcript-permissioning-RED | failed | 2797ms | colleague view was not flagged redacted |
Totals: 0 passed, 1 failed, 0 skipped of 1
```

**Guard + lint:**
```
$ bun test src/corpus-assertion-guard.test.ts   →  Test Files 1 passed (1) | Tests 9 passed (9)
$ bunx biome check packages/test/scenarios/local-inference/transcript-permissioning.scenario.ts  →  No errors
```
Scoped typecheck: no `error TS` lines reference the new file (pre-existing project-reference graph noise only).

Real-LLM trajectory: N/A — this lane is the keyless deterministic-proxy PR gate; no live model key is available in this environment. The scenario is authored so the same file runs live once a key is present (it declares real fixtures, real assertions, and reads real domain artifacts).

## Scope

This PR ships the missing end-to-end proof for the already-merged actions. Remaining #14779 sub-items tracked separately (not regressions, explicitly out of this slice): room-snapshot share grants, a first-class admin "redact-for-all" default-disclosure flag (vs. per-entity grants), consent-state persistence at capture, and the `TRANSCRIPT_MARKER` retirement/Files unification (#8876 follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)