### PR TITLE
fix(orchestrator): elizaos coding backend finishes cleanly — ack agent-initiated session/close, best-effort teardown, cede-gate observability

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/acp-native-transport.session-close.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/acp-native-transport.session-close.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Agent-initiated session-lifecycle notifications over native ACP: an agent
+ * server (e.g. the elizaos eliza-code ACP server) sends `session/close` /
+ * `session/cancel` to the client once its work is done. The client's
+ * `handleClientRequest` must acknowledge them like `session/update` — before
+ * this was handled, they fell through to the default case and answered
+ * JSON-RPC "Method not found", which surfaced to the user as a spurious
+ * "Couldn't finish … session/close" AFTER an otherwise-complete task.
+ */
+
+import { describe, expect, it } from "vitest";
+import { NativeAcpClient } from "../services/acp-native-transport";
+
+type ClientRequestHandler = {
+  handleClientRequest: (method: string, params: unknown) => Promise<unknown>;
+};
+
+function makeClient(): ClientRequestHandler {
+  return new NativeAcpClient({
+    command: "true",
+    cwd: "/tmp",
+  }) as unknown as ClientRequestHandler;
+}
+
+describe("NativeAcpClient handleClientRequest session lifecycle", () => {
+  it("acknowledges agent-initiated session/close instead of Method not found", async () => {
+    const client = makeClient();
+    await expect(
+      client.handleClientRequest("session/close", { sessionId: "s-1" }),
+    ).resolves.toEqual({});
+  });
+
+  it("acknowledges agent-initiated session/cancel", async () => {
+    const client = makeClient();
+    await expect(
+      client.handleClientRequest("session/cancel", { sessionId: "s-1" }),
+    ).resolves.toEqual({});
+  });
+
+  it("acknowledges session/update (pre-existing contract preserved)", async () => {
+    const client = makeClient();
+    await expect(
+      client.handleClientRequest("session/update", {}),
+    ).resolves.toEqual({});
+  });
+
+  it("still rejects genuinely unknown client methods", async () => {
+    const client = makeClient();
+    await expect(
+      client.handleClientRequest("session/definitely_not_a_method", {}),
+    ).rejects.toThrow(/Unsupported ACP client method/);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
@@ -406,6 +406,16 @@ export class NativeAcpClient {
     switch (method) {
       case "session/update":
         return {};
+      // Agent-initiated session-lifecycle notifications. An ACP agent (e.g. the
+      // elizaos code server) tells the client the session is closing/cancelling
+      // once its work is done; the client's own subprocess teardown is separate,
+      // so the only correct response is to acknowledge. Without these cases the
+      // request fell through to `default` and answered "Method not found", which
+      // surfaced to the user as a spurious "Couldn't finish … session/close"
+      // AFTER an otherwise-complete task.
+      case "session/close":
+      case "session/cancel":
+        return {};
       case "session/request_permission":
         return this.resolvePermission(asRecord(params));
       case "fs/read_text_file":

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -2019,12 +2019,31 @@ export class AcpService extends Service {
         session.name ?? session.id,
       ]),
     ];
-    await this.runAcpx({
-      sessionId,
-      agentType: session.agentType,
-      workdir: session.workdir,
-      args,
-    });
+    try {
+      await this.runAcpx({
+        sessionId,
+        agentType: session.agentType,
+        workdir: session.workdir,
+        args,
+      });
+    } catch (err: unknown) {
+      // error-policy:J6 best-effort teardown — `sessions close` is cleanup that
+      // runs AFTER the task's real work is done. An agent server that does not
+      // implement `session/close` (e.g. an older elizaos ACP build) answers
+      // "Method not found"; letting that throw here marks a fully-successful
+      // task (files written, app deployed, link returned) as "Couldn't finish".
+      // Log and continue to the stopped-status update so the close never masks
+      // a completed turn.
+      this.runtime.logger.debug(
+        {
+          src: "acp-service",
+          sessionId,
+          agentType: session.agentType,
+          error: errorMessage(err),
+        },
+        "Session close failed (best-effort) — marking stopped anyway",
+      );
+    }
     await this.store.updateStatus(sessionId, "stopped");
     this.emitSessionEvent(sessionId, "stopped", {
       sessionId,

--- a/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
@@ -949,11 +949,25 @@ export class SwarmCoordinatorService
     // the verdict ("App verification passed."). Ceding it to the router would
     // drop it entirely, so synthesis must stay its poster even on a
     // router-owned session.
+    // Observability for the cede decision: when synthesis double-posts next to
+    // the router relay, the answer is always one of these four gates — log them
+    // so a live incident is diagnosable from the log instead of a code dive.
+    const cedeGates = {
+      routerOwnedEvent: ROUTER_OWNED_TERMINAL_EVENTS.has(event),
+      customValidator: isCustomValidatorResult(record),
+      hasRouterOrigin: sessionHasRouterOrigin(meta),
+      routerActive: this.isRouterActive(),
+    };
+    logger.debug(
+      `[SwarmCoordinatorService] cede decision (sessionId=${sessionId}, event=${event}, ` +
+        `routerOwnedEvent=${cedeGates.routerOwnedEvent}, customValidator=${cedeGates.customValidator}, ` +
+        `hasRouterOrigin=${cedeGates.hasRouterOrigin}, routerActive=${cedeGates.routerActive})`,
+    );
     if (
-      ROUTER_OWNED_TERMINAL_EVENTS.has(event) &&
-      !isCustomValidatorResult(record) &&
-      sessionHasRouterOrigin(meta) &&
-      this.isRouterActive()
+      cedeGates.routerOwnedEvent &&
+      !cedeGates.customValidator &&
+      cedeGates.hasRouterOrigin &&
+      cedeGates.routerActive
     ) {
       this.routerCededTerminalSessions.add(sessionId);
       return;


### PR DESCRIPTION
## What

Four commits making the `elizaos` (eliza-code) native-ACP coding backend finish cleanly end-to-end:

1. **Ack agent-initiated `session/close` / `session/cancel`** in `NativeAcpClient.handleClientRequest`. An ACP agent server (e.g. the published `@elizaos/example-code` eliza-code server) notifies the client of session close once its work is done; the client had no case for these methods, so they fell through to `default` → JSON-RPC "Method not found" → surfaced to the user as a spurious **"Couldn't finish … session/close. Want me to retry?" AFTER an otherwise fully successful task** (files written, app deployed, link returned).
2. **Best-effort session close on teardown** (`AcpService.closeSession`, error-policy:J6): `sessions close` is cleanup that runs after the task's real work; a close failure must not mark a completed task as failed.
3. **Log the swarm-synthesis cede decision gates**: when synthesis double-posts next to the router relay the cause is always one of four gates (router-owned event / custom-validator / router origin / router liveness) — log them per terminal event so the next live incident is diagnosable from the log alone instead of a code dive.
4. **Regression test** for the ack (4 cases, including pinning the unknown-method rejection so the guard cannot silently widen).

## Evidence (live deployment, Discord connector, cerebras gemma-4-31b/zai-glm-4.7 + eliza-code backend)

Before: every eliza-code deploy task ended `ready → task_complete → error → stopped` with `"Method not found": session/close` and the user saw "Couldn't finish … retry?" after the successful reply.

After: `ready → message → task_complete → stopped` (no error event), 7/7 coding tasks clean — real files verified on disk, deployed pages live (HTTP 200), links delivered.

<details><summary>Sample lifecycle + delivered reply (after)</summary>

```
[backend-routing] coding → elizaos (pin)
session event (sessionId=…, ev=ready) → ev=message → ev=task_complete → ev=stopped
Message sent (text=Done. Your tip calculator is live at https://nubilio.org/apps/tip-calculator/ …)
```
</details>

Unit suite: `plugin-agent-orchestrator` 1468/1468 (135 files) green including the new tests.

## Notes

- The `eliza-code-acp` default command in `acp-service.ts` references `@elizaos/example-code` (npm `2.0.0-beta.0`); that published build has a separate raw-stream capture bug — filed with a patch in the linked issue.
- Related: #15796 (GitHub credential onboarding gap, found while exercising this surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
