### PR TITLE
fix(discord): strip native model tool-call syntax from outbound text

### DIFF
--- a/plugins/plugin-discord/__tests__/reasoning-tags.test.ts
+++ b/plugins/plugin-discord/__tests__/reasoning-tags.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Unit tests for stripReasoningTags — the pre-send sanitizer that removes
+ * model reasoning tags, end-of-turn sentinels, and native tool-call syntax
+ * from generated text while preserving fenced code blocks.
+ */
+import { describe, expect, it } from "vitest";
+import { stripReasoningTags } from "../reasoning-tags";
+
+describe("stripReasoningTags", () => {
+	it("strips paired reasoning tags with their contents", () => {
+		expect(
+			stripReasoningTags("<thinking>internal notes</thinking>The answer is 4."),
+		).toBe("The answer is 4.");
+	});
+
+	it("strips an unclosed reasoning tag to end of text", () => {
+		expect(stripReasoningTags("The answer is 4.<reasoning>and then I")).toBe(
+			"The answer is 4.",
+		);
+	});
+
+	it("strips an unclosed native tool_call leak (observed live)", () => {
+		// glm-4.7 drifted out of the response grammar mid-turn and this exact
+		// shape reached Discord verbatim.
+		expect(
+			stripReasoningTags(
+				"Let me try the weather action for current conditions.<tool_call>get_weather",
+			),
+		).toBe("Let me try the weather action for current conditions.");
+	});
+
+	it("strips paired tool_call and function_call blocks with contents", () => {
+		expect(
+			stripReasoningTags(
+				'Done.<tool_call>{"name":"get_weather","args":{}}</tool_call>',
+			),
+		).toBe("Done.");
+		expect(
+			stripReasoningTags("Sure.<function_call>lookup(x)</function_call> Next."),
+		).toBe("Sure. Next.");
+	});
+
+	it("preserves tool_call syntax inside fenced code blocks", () => {
+		const text =
+			"Example:\n```xml\n<tool_call>get_weather</tool_call>\n```\nThat is the format.";
+		expect(stripReasoningTags(text)).toBe(text);
+	});
+
+	it("leaves plain text untouched", () => {
+		expect(stripReasoningTags("Bitcoin is at $63,217.")).toBe(
+			"Bitcoin is at $63,217.",
+		);
+	});
+});

--- a/plugins/plugin-discord/reasoning-tags.ts
+++ b/plugins/plugin-discord/reasoning-tags.ts
@@ -9,12 +9,19 @@ const REASONING_TAGS = [
 	"reflection",
 	"thought",
 	"antthinking",
+	// Native model tool-call syntax (glm/qwen-family `<tool_call>`, gemini-style
+	// `<function_call>`): a model that drifts out of the eliza response grammar
+	// mid-turn emits these as visible text (observed live: "…Let me try the
+	// weather action.<tool_call>get_weather" delivered verbatim). They are
+	// machine syntax, never user-facing prose — strip them like reasoning tags.
+	"tool_call",
+	"function_call",
 ] as const;
 
 const SELF_CLOSING_ARTIFACTS_RE =
 	/<(?:STOP|END|end_turn|eot_id)\s*\/?>|<\|(?:end|stop|im_end|eot_id)\|>/gi;
 const QUICK_TAG_RE =
-	/<\/?(?:thinking|reasoning|reflection|thought|antthinking|final|STOP|END|end_turn)\b|<\|(?:end|stop|im_end)/i;
+	/<\/?(?:thinking|reasoning|reflection|thought|antthinking|tool_call|function_call|final|STOP|END|end_turn)\b|<\|(?:end|stop|im_end)/i;
 const CODE_BLOCK_RE = /```[\s\S]*?```/g;
 const CODE_BLOCK_SENTINEL_PREFIX = "\x00CB";
 


### PR DESCRIPTION
## What

Extends the Discord pre-send sanitizer (`reasoning-tags.ts`) to strip native model tool-call syntax — `<tool_call>` (glm/qwen family) and `<function_call>` (gemini style) — from outbound text, both paired-with-contents and unclosed-to-end-of-text. Fenced code blocks remain protected (a doc example of the syntax inside ``` fences survives untouched).

## Why

A model that drifts out of the eliza response grammar mid-turn emits its native tool syntax as visible text. Observed live (cerebras `zai-glm-4.7` planner, weather turn):

> The NOAA result in the search shows data from July 6, which is 3 days old. Let me try the weather action for current conditions.**<tool_call>get_weather**

— delivered to the Discord user verbatim. This is machine syntax, never user-facing prose; it belongs to the same class the sanitizer already handles for `<thinking>`/`<reasoning>` tags and end-of-turn sentinels, and uses the exact same machinery.

## Tests

New `__tests__/reasoning-tags.test.ts` — 6 cases: paired + unclosed reasoning tags (pre-existing contract), the exact live leak shape, paired `tool_call`/`function_call` with contents, code-block preservation, plain-text passthrough. Full `plugin-discord` suite: 292/292 (47 files) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
