### PR TITLE
fix(agent): resolve the price/weather contradiction in the web-fetch routing hint

### DIFF
--- a/packages/agent/src/runtime/actions/web-fetch.ts
+++ b/packages/agent/src/runtime/actions/web-fetch.ts
@@ -118,7 +118,7 @@ export const webFetch: Action & Record<string, unknown> = {
   contexts: ["web"],
   suppressInitialMessage: true,
   routingHint:
-    "fetch/read the contents of ONE specific URL, JSON API, or data file whose address you already have or can construct exactly (a price/weather endpoint, a page you can name) -> WEB_FETCH; to discover pages or answer an open-ended real-world question with NO known URL (prices, news, recommendations, 'latest on...') -> WEB_SEARCH; to read a link/attachment already in THIS conversation -> ATTACHMENT (action=read); for the user's own notes/memories -> MEMORY (action=search)",
+    "fetch/read the contents of ONE specific URL, JSON API, or data file whose address you already have or can construct exactly (a crypto-price or weather endpoint like api.coingecko.com or wttr.in/<city>?format=j1, a page you can name) -> WEB_FETCH; to discover pages or answer an open-ended real-world question with NO constructable URL (news, recommendations, 'latest on...') -> WEB_SEARCH; to read a link/attachment already in THIS conversation -> ATTACHMENT (action=read); for the user's own notes/memories -> MEMORY (action=search)",
   description:
     "Fetch one specific URL and return its contents — a JSON API, data file, or page whose address you already have or can construct exactly. " +
     "Prefer a JSON API over an HTML page so the value parses cleanly, and fetch it inline THIS turn — " +


### PR DESCRIPTION
## What

One-line fix to `WEB_FETCH`'s `routingHint`: the hint listed **"prices" in BOTH routing directions** — "a price/weather endpoint" → WEB_FETCH, but also "open-ended … (**prices**, news, recommendations…)" → WEB_SEARCH. The new text names the constructable endpoints explicitly (`api.coingecko.com`, `wttr.in/<city>?format=j1`) and keeps WEB_SEARCH for genuinely non-constructable questions (news, recommendations, "latest on…").

## Why

A weaker planner (cerebras `zai-glm-4.7`) coin-flipped weather/price turns to WEB_SEARCH on the contradictory hint, producing vague no-answer replies ("The search didn't return a specific current temperature… I recommend checking JMA") instead of fetching the endpoint the action's own description recommends.

## Evidence (live)

Before: "whats the weather in tokyo right now" → `WEB_SEARCH` → no answer.
After: "hows the weather looking in paris" → `WEB_FETCH` → wttr.in →

> Paris weather right now: **Temperature** 90°F (32°C), feels like 87°F; **Conditions** Sunny, clear skies; **Humidity** 24%; **Wind** 9 mph NE; **Rain chance** 1% …

Prompt-text only — no code-path change; routing stays with the model per the #8123 philosophy (no inline force-routing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
