### PR TITLE
test(lifeops): Pack H2 kg-capture scenarios assert real store rows (#14786)

### DIFF
--- a/packages/scenario-runner/src/corpus-assertion-guard.test.ts
+++ b/packages/scenario-runner/src/corpus-assertion-guard.test.ts
@@ -338,6 +338,16 @@ const EXPECTED_PR_DETERMINISTIC_SCENARIO_IDS = [
   // structural proof for relationship-cadence follow-up creation.
   "g2-cadence-watcher-due",
   "goals.owner-goals-create",
+  // LifeOps knowledge-graph capture pack H2 (#14786). Keyless direct-action
+  // scenarios that drive the REAL ENTITY set_relationship / merge subactions and
+  // read the captured primitive back off the per-agent RelationshipStore /
+  // EntityStore (`eliza_knowledge_graph` service), asserting persisted rows
+  // rather than the scripted action arguments. Registered here in the same
+  // commit that flips their lane to pr-deterministic.
+  "h2-audit-trail-survives-restart",
+  "h2-conflicting-fact-resolution",
+  "h2-identity-merge-uses-engine",
+  "h2-relationship-update-live",
   "health.owner-health-status",
   "hyperliquid.perpetual-market-status",
   "inbox.summarize-inboxes",

--- a/plugins/plugin-personal-assistant/test/scenarios/_helpers/kg-live-capture.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/_helpers/kg-live-capture.ts
@@ -1,0 +1,194 @@
+/**
+ * Live read-back predicates for the Pack H2 knowledge-graph capture scenarios.
+ *
+ * Pack H2's whole point is to prove that a conversational capture lands as a
+ * real persisted primitive, not that the ENTITY action was called with the
+ * arguments the scenario itself supplied (that is tautological — the runner
+ * records the scripted `options` verbatim, so a `selectedActionArguments` check
+ * passes even when the action no-ops). These predicates instead resolve the
+ * runtime-owned {@link KnowledgeGraphService} (`eliza_knowledge_graph`,
+ * `packages/agent/src/services/knowledge-graph/service.ts`) off `ctx.runtime`
+ * and read the row back through the SAME per-agent store the ENTITY action
+ * wrote to (`RelationshipStore` / `EntityStore`, `app_lifeops.*` tables) — no
+ * mock, no route stub. A predicate returns `undefined` to pass and a diagnostic
+ * string to fail, per the scenario-runner `custom` final-check contract.
+ */
+
+import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
+
+/** Registered service type; mirrors `KNOWLEDGE_GRAPH_SERVICE` in @elizaos/agent. */
+const KNOWLEDGE_GRAPH_SERVICE = "eliza_knowledge_graph";
+
+interface RelationshipRowLike {
+  fromEntityId: string;
+  toEntityId: string;
+  type: string;
+  evidence: string[];
+  confidence: number;
+  status: string;
+}
+
+interface RelationshipStoreLike {
+  list(filter?: {
+    fromEntityId?: string;
+    toEntityId?: string;
+    type?: string | string[];
+    includeRetired?: boolean;
+  }): Promise<RelationshipRowLike[]>;
+}
+
+interface EntityIdentityLike {
+  platform: string;
+  handle: string;
+}
+
+interface EntityRowLike {
+  entityId: string;
+  preferredName: string;
+  identities: EntityIdentityLike[];
+}
+
+interface EntityStoreLike {
+  get(entityId: string): Promise<EntityRowLike | null>;
+  upsert(input: {
+    entityId?: string;
+    type: string;
+    preferredName: string;
+    fullName?: string;
+    identities: EntityIdentityLike[];
+    state: Record<string, unknown>;
+    tags: string[];
+    visibility: string;
+  }): Promise<EntityRowLike>;
+}
+
+interface KnowledgeGraphServiceLike {
+  getRelationshipStore(agentId?: string): RelationshipStoreLike;
+  getEntityStore(agentId?: string): EntityStoreLike;
+}
+
+interface RuntimeLike {
+  agentId: string;
+  getService(type: string): KnowledgeGraphServiceLike | null;
+}
+
+type Resolved = { runtime: RuntimeLike; kg: KnowledgeGraphServiceLike };
+
+function resolveGraph(ctx: ScenarioContext): Resolved | string {
+  const runtime = ctx.runtime as RuntimeLike | undefined;
+  if (!runtime || typeof runtime.getService !== "function") {
+    return "scenario runtime is missing getService — cannot read the knowledge graph";
+  }
+  const kg = runtime.getService(KNOWLEDGE_GRAPH_SERVICE);
+  if (!kg || typeof kg.getRelationshipStore !== "function") {
+    return "KnowledgeGraphService is not registered on the scenario runtime";
+  }
+  return { runtime, kg };
+}
+
+/**
+ * Assert an active typed edge `from -[type]-> to` is persisted, optionally
+ * carrying each of `evidenceIncludes` as a substring of some evidence entry.
+ * Reads the real `RelationshipStore.list` (active-only by default).
+ */
+export function relationshipEdgePersisted(opts: {
+  fromEntityId?: string;
+  toEntityId: string;
+  type: string;
+  evidenceIncludes?: string[];
+}) {
+  return async (ctx: ScenarioContext): Promise<string | undefined> => {
+    const resolved = resolveGraph(ctx);
+    if (typeof resolved === "string") return resolved;
+    const store = resolved.kg.getRelationshipStore(resolved.runtime.agentId);
+    const from = opts.fromEntityId ?? "self";
+    const edges = await store.list({
+      fromEntityId: from,
+      toEntityId: opts.toEntityId,
+      type: opts.type,
+    });
+    if (edges.length < 1) {
+      const anyToTarget = await store.list({ toEntityId: opts.toEntityId });
+      return `expected a persisted ${opts.type} edge ${from} -> ${opts.toEntityId}, but RelationshipStore returned none. Edges to ${opts.toEntityId}: ${JSON.stringify(anyToTarget.map((e) => `${e.type}(${e.status})`))}`;
+    }
+    if (opts.evidenceIncludes && opts.evidenceIncludes.length > 0) {
+      const allEvidence = edges.flatMap((e) => e.evidence ?? []);
+      for (const needle of opts.evidenceIncludes) {
+        if (!allEvidence.some((entry) => entry.includes(needle))) {
+          return `persisted ${opts.type} edge to ${opts.toEntityId} is missing evidence "${needle}"; stored evidence: ${JSON.stringify(allEvidence)}`;
+        }
+      }
+    }
+    return undefined;
+  };
+}
+
+/**
+ * Assert an entity id resolves in the store and preferred name matches. Used to
+ * prove a merge kept the surviving (target) node.
+ */
+export function entityPersisted(opts: {
+  entityId: string;
+  preferredNameIncludes?: string;
+}) {
+  return async (ctx: ScenarioContext): Promise<string | undefined> => {
+    const resolved = resolveGraph(ctx);
+    if (typeof resolved === "string") return resolved;
+    const store = resolved.kg.getEntityStore(resolved.runtime.agentId);
+    const entity = await store.get(opts.entityId);
+    if (!entity)
+      return `expected entity ${opts.entityId} to be persisted, store returned null`;
+    if (
+      opts.preferredNameIncludes &&
+      !entity.preferredName
+        .toLowerCase()
+        .includes(opts.preferredNameIncludes.toLowerCase())
+    ) {
+      return `entity ${opts.entityId} preferredName "${entity.preferredName}" does not include "${opts.preferredNameIncludes}"`;
+    }
+    return undefined;
+  };
+}
+
+/** Assert an entity id no longer resolves — proves a merge collapsed the source. */
+export function entityAbsent(entityId: string) {
+  return async (ctx: ScenarioContext): Promise<string | undefined> => {
+    const resolved = resolveGraph(ctx);
+    if (typeof resolved === "string") return resolved;
+    const store = resolved.kg.getEntityStore(resolved.runtime.agentId);
+    const entity = await store.get(entityId);
+    if (entity) {
+      return `expected entity ${entityId} to be gone after merge, but it is still persisted as "${entity.preferredName}"`;
+    }
+    return undefined;
+  };
+}
+
+/**
+ * Seed a bare entity node directly through the real EntityStore. Used by the
+ * merge scenario to stand up the duplicate rows the ENTITY merge subaction then
+ * collapses — the merge engine requires the target + sources to pre-exist
+ * (`EntityStore.merge` throws on a missing target).
+ */
+export function seedEntity(input: {
+  entityId: string;
+  type: string;
+  preferredName: string;
+  identities?: EntityIdentityLike[];
+}) {
+  return async (ctx: ScenarioContext): Promise<string | undefined> => {
+    const resolved = resolveGraph(ctx);
+    if (typeof resolved === "string") return resolved;
+    const store = resolved.kg.getEntityStore(resolved.runtime.agentId);
+    await store.upsert({
+      entityId: input.entityId,
+      type: input.type,
+      preferredName: input.preferredName,
+      identities: input.identities ?? [],
+      state: {},
+      tags: [],
+      visibility: "owner_agent_admin",
+    });
+    return undefined;
+  };
+}

--- a/plugins/plugin-personal-assistant/test/scenarios/h2-audit-trail-survives-restart.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/h2-audit-trail-survives-restart.scenario.ts
@@ -1,12 +1,19 @@
 /**
- * H2 provenance/audit trail scenario. A relationship write includes a stable
- * source utterance id so later route/read-back evidence can prove where the
- * edge came from.
+ * H2 provenance / audit-trail scenario. A relationship write carries a stable
+ * `source-utterance:` evidence tag; the final check reads the edge back off the
+ * real RelationshipStore and confirms that tag persisted on the stored
+ * `evidence[]` — proving the captured edge is traceable to the utterance it came
+ * from, not merely that the reply mentioned it.
+ *
+ * Fail-without-fix anchor: drop the `source-utterance:` prefix from the seeded
+ * evidence (or un-nest `options`) and the read-back reports the persisted edge
+ * is missing that evidence string.
  */
 import { scenario } from "@elizaos/scenario-runner/schema";
+import { relationshipEdgePersisted } from "./_helpers/kg-live-capture.ts";
 
 export default scenario({
-  lane: "live-only",
+  lane: "pr-deterministic",
   id: "h2-audit-trail-survives-restart",
   title: "H2 captured relationship carries stable source evidence",
   domain: "lifeops.kg",
@@ -21,11 +28,13 @@ export default scenario({
       actionName: "ENTITY",
       text: "Remember that Priya is my colleague and preserve this utterance as the evidence.",
       options: {
-        action: "set_relationship",
-        fromEntityId: "self",
-        toEntityId: "person-h2-priya",
-        relationshipType: "colleague_of",
-        evidence: "source-utterance:h2-audit-001",
+        parameters: {
+          action: "set_relationship",
+          fromEntityId: "self",
+          toEntityId: "person-h2-priya",
+          relationshipType: "colleague_of",
+          evidence: "source-utterance:h2-audit-001",
+        },
       },
     },
   ],
@@ -37,9 +46,13 @@ export default scenario({
       minCount: 1,
     },
     {
-      type: "selectedActionArguments",
-      actionName: "ENTITY",
-      includesAll: ["colleague_of", "source-utterance:h2-audit-001"],
+      type: "custom",
+      name: "colleague_of edge persisted carrying the source-utterance evidence id",
+      predicate: relationshipEdgePersisted({
+        toEntityId: "person-h2-priya",
+        type: "colleague_of",
+        evidenceIncludes: ["source-utterance:h2-audit-001"],
+      }),
     },
   ],
 });

--- a/plugins/plugin-personal-assistant/test/scenarios/h2-conflicting-fact-resolution.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/h2-conflicting-fact-resolution.scenario.ts
@@ -1,12 +1,21 @@
 /**
- * H2 conflicting fact resolution: the owner correction supersedes the earlier
- * captured label, and both writes go through ENTITY so the merge/reconcile path
- * stays observable.
+ * H2 conflicting fact resolution: the owner first records a relationship label,
+ * then corrects it. Both writes go through the ENTITY set_relationship subaction
+ * and land as distinct typed edges (the store keys on from+to+type), so the
+ * final checks read BOTH edges back off the real RelationshipStore and confirm
+ * the correction (co_parent_of) is persisted with its own evidence alongside the
+ * superseded label (partner_of) — the reconcile path is observable in the store,
+ * not just in the reply text.
+ *
+ * Fail-without-fix anchor: revert either turn to the un-nested `options` shape
+ * and that write no-ops via PLANNER_SHOULDACT_FALSE, so the corresponding
+ * store read-back returns "RelationshipStore returned none".
  */
 import { scenario } from "@elizaos/scenario-runner/schema";
+import { relationshipEdgePersisted } from "./_helpers/kg-live-capture.ts";
 
 export default scenario({
-  lane: "live-only",
+  lane: "pr-deterministic",
   id: "h2-conflicting-fact-resolution",
   title: "H2 owner correction supersedes captured relationship fact",
   domain: "lifeops.kg",
@@ -21,11 +30,13 @@ export default scenario({
       actionName: "ENTITY",
       text: "Record Jordan as partner_of from the old context.",
       options: {
-        action: "set_relationship",
-        fromEntityId: "self",
-        toEntityId: "person-h2-jordan",
-        relationshipType: "partner_of",
-        evidence: "older imported context h2-correct-001",
+        parameters: {
+          action: "set_relationship",
+          fromEntityId: "self",
+          toEntityId: "person-h2-jordan",
+          relationshipType: "partner_of",
+          evidence: "older imported context h2-correct-001",
+        },
       },
     },
     {
@@ -35,11 +46,13 @@ export default scenario({
       actionName: "ENTITY",
       text: "Correction: Jordan is my co-parent, not my partner.",
       options: {
-        action: "set_relationship",
-        fromEntityId: "self",
-        toEntityId: "person-h2-jordan",
-        relationshipType: "co_parent_of",
-        evidence: "owner correction h2-correct-002",
+        parameters: {
+          action: "set_relationship",
+          fromEntityId: "self",
+          toEntityId: "person-h2-jordan",
+          relationshipType: "co_parent_of",
+          evidence: "owner correction h2-correct-002",
+        },
       },
     },
   ],
@@ -51,9 +64,22 @@ export default scenario({
       minCount: 2,
     },
     {
-      type: "selectedActionArguments",
-      actionName: "ENTITY",
-      includesAll: ["partner_of", "co_parent_of", "h2-correct-002"],
+      type: "custom",
+      name: "corrected co_parent_of edge persisted with the correction evidence",
+      predicate: relationshipEdgePersisted({
+        toEntityId: "person-h2-jordan",
+        type: "co_parent_of",
+        evidenceIncludes: ["h2-correct-002"],
+      }),
+    },
+    {
+      type: "custom",
+      name: "superseded partner_of edge is also persisted (reconcile is auditable)",
+      predicate: relationshipEdgePersisted({
+        toEntityId: "person-h2-jordan",
+        type: "partner_of",
+        evidenceIncludes: ["h2-correct-001"],
+      }),
     },
   ],
 });

--- a/plugins/plugin-personal-assistant/test/scenarios/h2-identity-merge-uses-engine.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/h2-identity-merge-uses-engine.scenario.ts
@@ -1,18 +1,59 @@
 /**
- * H2 duplicate identity capture must use ENTITY merge, never a side-channel
- * write. The action arguments are the evidence that the merge engine path was
- * requested.
+ * H2 duplicate-identity capture must collapse through the ENTITY merge engine,
+ * never a side-channel write. Two duplicate Sarah nodes (Gmail + Telegram) are
+ * seeded into the real EntityStore, the owner asks to merge them, and the final
+ * checks read the store back: the surviving target persists and BOTH source
+ * nodes are gone — the merge-engine outcome (frozen contract: never bypass it),
+ * asserted against persisted rows rather than the scripted action arguments.
+ *
+ * Fail-without-fix anchor: un-nest `options` and the merge no-ops via
+ * PLANNER_SHOULDACT_FALSE, so the seeded source nodes remain and `entityAbsent`
+ * reports they are still persisted.
  */
 import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+  entityAbsent,
+  entityPersisted,
+  seedEntity,
+} from "./_helpers/kg-live-capture.ts";
 
 export default scenario({
-  lane: "live-only",
+  lane: "pr-deterministic",
   id: "h2-identity-merge-uses-engine",
-  title: "H2 duplicate identity capture uses ENTITY merge",
+  title: "H2 duplicate identity capture uses the ENTITY merge engine",
   domain: "lifeops.kg",
   tags: ["lifeops", "H2", "entity", "merge", "identity"],
   isolation: "per-scenario",
   rooms: [{ id: "main", source: "dashboard", channelType: "DM" }],
+  seed: [
+    {
+      type: "custom",
+      name: "seed surviving Sarah node",
+      apply: seedEntity({
+        entityId: "person-h2-sarah",
+        type: "person",
+        preferredName: "Sarah",
+      }),
+    },
+    {
+      type: "custom",
+      name: "seed duplicate Sarah (Gmail)",
+      apply: seedEntity({
+        entityId: "person-h2-sarah-gmail",
+        type: "person",
+        preferredName: "Sarah (Gmail)",
+      }),
+    },
+    {
+      type: "custom",
+      name: "seed duplicate Sarah (Telegram)",
+      apply: seedEntity({
+        entityId: "person-h2-sarah-telegram",
+        type: "person",
+        preferredName: "Sarah (Telegram)",
+      }),
+    },
+  ],
   turns: [
     {
       kind: "action",
@@ -21,10 +62,15 @@ export default scenario({
       actionName: "ENTITY",
       text: "Merge Sarah from Gmail and Sarah from Telegram; they are the same person.",
       options: {
-        action: "merge",
-        entityId: "person-h2-sarah",
-        sourceEntityIds: ["person-h2-sarah-gmail", "person-h2-sarah-telegram"],
-        evidence: "owner confirmed cross-platform duplicate h2-merge-001",
+        parameters: {
+          action: "merge",
+          entityId: "person-h2-sarah",
+          sourceEntityIds: [
+            "person-h2-sarah-gmail",
+            "person-h2-sarah-telegram",
+          ],
+          evidence: "owner confirmed cross-platform duplicate h2-merge-001",
+        },
       },
     },
   ],
@@ -36,13 +82,22 @@ export default scenario({
       minCount: 1,
     },
     {
-      type: "selectedActionArguments",
-      actionName: "ENTITY",
-      includesAll: [
-        "merge",
-        "person-h2-sarah-gmail",
-        "person-h2-sarah-telegram",
-      ],
+      type: "custom",
+      name: "surviving target entity persists after merge",
+      predicate: entityPersisted({
+        entityId: "person-h2-sarah",
+        preferredNameIncludes: "Sarah",
+      }),
+    },
+    {
+      type: "custom",
+      name: "Gmail duplicate collapsed by the merge engine",
+      predicate: entityAbsent("person-h2-sarah-gmail"),
+    },
+    {
+      type: "custom",
+      name: "Telegram duplicate collapsed by the merge engine",
+      predicate: entityAbsent("person-h2-sarah-telegram"),
     },
   ],
 });

--- a/plugins/plugin-personal-assistant/test/scenarios/h2-relationship-update-live.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/h2-relationship-update-live.scenario.ts
@@ -1,14 +1,22 @@
 /**
- * H2 live relationship capture through ENTITY. The scenario writes a typed edge
- * with evidence so the final assertion targets the captured primitive, not a
- * paraphrase in chat.
+ * H2 live relationship capture through ENTITY. The owner names a typed edge
+ * with a source-utterance evidence tag; the final check reads the edge back off
+ * the real per-agent RelationshipStore (`eliza_knowledge_graph` service) and
+ * asserts the persisted primitive — not the scripted action arguments, which
+ * the runner records verbatim whether or not the write actually happened.
+ *
+ * Fail-without-fix anchor: nest the ENTITY subaction under `options` instead of
+ * `options.parameters` (the shape `getParams` reads) and the action falls into
+ * the planner-clarification branch (`PLANNER_SHOULDACT_FALSE`), persists
+ * nothing, and the store read-back returns "RelationshipStore returned none".
  */
 import { scenario } from "@elizaos/scenario-runner/schema";
+import { relationshipEdgePersisted } from "./_helpers/kg-live-capture.ts";
 
 export default scenario({
-  lane: "live-only",
+  lane: "pr-deterministic",
   id: "h2-relationship-update-live",
-  title: "H2 relationship update lands in ENTITY with evidence",
+  title: "H2 relationship update lands in the RelationshipStore with evidence",
   domain: "lifeops.kg",
   tags: ["lifeops", "H2", "entity", "relationship", "evidence"],
   isolation: "per-scenario",
@@ -21,11 +29,13 @@ export default scenario({
       actionName: "ENTITY",
       text: "Remember that Mira is a friend I coordinate neighborhood logistics with.",
       options: {
-        action: "set_relationship",
-        fromEntityId: "self",
-        toEntityId: "person-h2-mira",
-        relationshipType: "friend_of",
-        evidence: "owner chat h2-rel-001",
+        parameters: {
+          action: "set_relationship",
+          fromEntityId: "self",
+          toEntityId: "person-h2-mira",
+          relationshipType: "friend_of",
+          evidence: "owner chat h2-rel-001",
+        },
       },
     },
   ],
@@ -37,9 +47,13 @@ export default scenario({
       minCount: 1,
     },
     {
-      type: "selectedActionArguments",
-      actionName: "ENTITY",
-      includesAll: ["friend_of", "person-h2-mira", "h2-rel-001"],
+      type: "custom",
+      name: "friend_of edge persisted to person-h2-mira with source evidence",
+      predicate: relationshipEdgePersisted({
+        toEntityId: "person-h2-mira",
+        type: "friend_of",
+        evidenceIncludes: ["h2-rel-001"],
+      }),
     },
   ],
 });


### PR DESCRIPTION
## What & why

Part of #14786 (Pack H2 — on-the-fly memory/fact/relationship capture into runtime primitives, live assertions).

The four H2 scenario-runner scenarios merged in #15065 did **not** live-assert anything. They passed the ENTITY subaction under `options.{action,…}`, but the handler reads `options.parameters` (`getParams`, `plugins/plugin-personal-assistant/src/actions/entity.ts`). So every write fell into the planner-clarification branch (`PLANNER_SHOULDACT_FALSE`) and **persisted zero rows**. Their only real assertion was `selectedActionArguments`, which just re-checks the scripted arguments the runner records verbatim — a tautology that "passes" while nothing is written. And being `live-only`, they ran in **no CI lane**, so this was invisible.

This is exactly the gap the issue calls out: *"NO scenario in either corpus asserts actual EntityStore/RelationshipStore rows created from chat."*

## Change

- Fix the option nesting (`options.parameters.…`) so the ENTITY `set_relationship` / `merge` subactions actually execute.
- Replace the tautological `selectedActionArguments` checks with `custom` final-checks that read the captured row back off the **same per-agent RelationshipStore / EntityStore** the action wrote to, resolved via the runtime `eliza_knowledge_graph` service (`packages/agent/src/services/knowledge-graph/service.ts`). No mock, no route stub. Shared helper: `plugins/plugin-personal-assistant/test/scenarios/_helpers/kg-live-capture.ts`.
- The merge scenario seeds the duplicate nodes through the real EntityStore and asserts the surviving target persists while both sources are collapsed — the frozen merge-engine contract.
- Flip all four to the keyless, merge-blocking **`pr-deterministic`** lane (direct-action turns need no live model) and register them in the corpus-assertion guard allowlist.

## Evidence

Command (keyless, zero credentials):
```
SCENARIO_USE_LLM_PROXY=1 SCENARIO_LLM_PROXY_STRICT=1 \
  bun --conditions=eliza-source packages/scenario-runner/src/cli.ts \
  run plugins/plugin-personal-assistant/test/scenarios \
  --scenario h2-relationship-update-live,h2-conflicting-fact-resolution,h2-audit-trail-survives-restart,h2-identity-merge-uses-engine \
  --lane pr-deterministic
```

**Before (as merged on develop)** — the ENTITY write no-ops, store stays empty:
```
| h2-relationship-update-live | failed | 128ms | actionCalled: expected 1 successful ENTITY call(s) with result.success=true, saw 0 |
  result: { success:false, error:"PLANNER_SHOULDACT_FALSE", noop:true }
```

**After (this branch)** — action persists, store read-back confirms the rows:
```
| h2-audit-trail-survives-restart | passed | 115ms |  |
| h2-conflicting-fact-resolution  | passed |  59ms |  |
| h2-identity-merge-uses-engine   | passed |  85ms |  |
| h2-relationship-update-live     | passed |  64ms |  |
Totals: 4 passed, 0 failed, 0 skipped of 4
```

**Load-bearing proof (red→green):** temporarily un-nesting one scenario's `options` re-reds it — the store read-back reports the edge is missing (`RelationshipStore returned none`), confirming the assertion catches a real no-op rather than passing vacuously.

Guard tests:
```
bun vitest run packages/scenario-runner/src/corpus-assertion-guard.test.ts \
  packages/scenario-runner/src/echo-assertion-ratchet.test.ts \
  packages/scenario-runner/src/skippable-check-ratchet.test.ts
→ Test Files 3 passed (3) | Tests 12 passed (12)
```
`bunx biome check` clean on all touched files.

`plugins/plugin-personal-assistant/test/executive-assistant-scenarios.test.ts` fails identically on `origin/develop` in this worktree (vite cannot resolve the un-built `@elizaos/plugin-personal-assistant` package entry — a pre-existing build-dependency issue, unrelated to this change; CI builds packages first).

## Remaining (not in this PR)

- `h2-profile-extraction-evaluator-live` (first live assertion of the post-response `owner.profile_extraction` evaluator) requires a live model to trigger the evaluator and is best authored on the live lane; enumerated here as follow-up.
- The 4 lifeops-bench H2 mirrors (`packages/benchmarks/lifeops-bench/.../kg_live_capture.py`) added in #15065 are untouched (live bench surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
