### PR TITLE
fix(cloud): route sandboxed shared deletes to daemon

### DIFF
--- a/packages/cloud/api/__tests__/eliza-agents-delete-async-fallback.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-delete-async-fallback.test.ts
@@ -1,0 +1,378 @@
+/**
+ * Exercises shared-agent deletion routing through the real route, sandbox
+ * service, provisioning-job service, and in-process PGlite. Workerd cannot
+ * load ssh2, so sandbox-backed rows must reach the daemon queue without a
+ * synchronous teardown attempt; pure-DB rows retain their immediate path.
+ * Authentication and the best-effort worker wake signal are the only mocked
+ * boundaries; enqueue and daemon execution remain real.
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+// The daemon-path assertion runs elizaSandboxService.executeDeletion for real;
+// the memory provider treats an unknown sandbox as already-gone, which is the
+// same observable outcome as a successful node-side stop.
+process.env.ELIZA_TEST_SANDBOX_PROVIDER = "memory";
+
+import { Hono } from "hono";
+import * as realWorkersAuth from "@/lib/auth/workers-hono-auth";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+const ORG = "11111111-1111-4111-8111-111111111111";
+const USER = "aaaaaaaa-1111-4111-8111-111111111111";
+const AGENT_SHARED_SANDBOXED = "cccccccc-1111-4111-8111-111111111111";
+const AGENT_SHARED_PLAIN = "cccccccc-2222-4222-8222-222222222222";
+const AGENT_SHARED_PLAIN_2 = "cccccccc-3333-4333-8333-333333333333";
+const AGENT_DEDICATED = "cccccccc-4444-4444-8444-444444444444";
+const AGENT_PROVISIONING = "cccccccc-5555-4555-8555-555555555555";
+const AGENT_UNKNOWN = "cccccccc-9999-4999-8999-999999999999";
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  ...realWorkersAuth,
+  requireUserOrApiKeyWithOrg: mock(async () => ({
+    id: USER,
+    email: "owner@test.test",
+    organization_id: ORG,
+    organization: { id: ORG, name: "Org", is_active: true },
+    is_active: true,
+    role: "owner",
+  })),
+}));
+
+const ENV = { NODE_ENV: "test" } as unknown as AppEnv["Bindings"];
+
+let pgliteReady = true;
+let closeDb: (() => Promise<void>) | undefined;
+let restoreImmediateWake: (() => void) | undefined;
+let app: Hono<AppEnv>;
+
+beforeAll(async () => {
+  try {
+    const { closeDatabaseConnectionsForTests, dbWrite } = await import(
+      "@/db/client"
+    );
+    closeDb = closeDatabaseConnectionsForTests;
+    const { provisioningJobService } = await import(
+      "@/lib/services/provisioning-jobs"
+    );
+    const immediateWakeSpy = spyOn(
+      provisioningJobService,
+      "triggerImmediate",
+    ).mockResolvedValue(undefined);
+    restoreImmediateWake = () => immediateWakeSpy.mockRestore();
+
+    const { organizations } = await import("@/db/schemas/organizations");
+    const { users } = await import("@/db/schemas/users");
+    const { userCharacters } = await import("@/db/schemas/user-characters");
+    const { agentSandboxes } = await import("@/db/schemas/agent-sandboxes");
+    const { jobs } = await import("@/db/schemas/jobs");
+    const { apiKeys } = await import("@/db/schemas/api-keys");
+    const { generations } = await import("@/db/schemas/generations");
+    const { usageRecords } = await import("@/db/schemas/usage-records");
+    const { sharedRuntimeHistory } = await import(
+      "@/db/schemas/shared-runtime-history"
+    );
+    const { pushSchema } = await import("@/db/push-schema-for-tests");
+    const { apply } = await pushSchema(
+      {
+        organizations,
+        users,
+        userCharacters,
+        agentSandboxes,
+        jobs,
+        apiKeys,
+        generations,
+        usageRecords,
+        sharedRuntimeHistory,
+      } as never,
+      dbWrite as never,
+    );
+    await apply();
+
+    await dbWrite
+      .insert(organizations)
+      .values([{ id: ORG, name: "Org", slug: "org" }]);
+    await dbWrite.insert(users).values([
+      {
+        id: USER,
+        email: "owner@test.test",
+        organization_id: ORG,
+        role: "owner",
+        steward_user_id: `steward-${USER}`,
+      },
+    ]);
+
+    await dbWrite.insert(agentSandboxes).values([
+      // The #15275 shape: shared tier but backed by a real container the
+      // Worker cannot tear down.
+      {
+        id: AGENT_SHARED_SANDBOXED,
+        organization_id: ORG,
+        user_id: USER,
+        agent_name: "Shared with sandbox",
+        execution_tier: "shared",
+        status: "running",
+        sandbox_id: "sandbox-shared-1",
+      },
+      // Pure Tier-0 shared rows (no container) — sync delete must keep working.
+      {
+        id: AGENT_SHARED_PLAIN,
+        organization_id: ORG,
+        user_id: USER,
+        agent_name: "Shared plain",
+        execution_tier: "shared",
+        status: "running",
+      },
+      {
+        id: AGENT_SHARED_PLAIN_2,
+        organization_id: ORG,
+        user_id: USER,
+        agent_name: "Shared plain 2",
+        execution_tier: "shared",
+        status: "running",
+      },
+      {
+        id: AGENT_DEDICATED,
+        organization_id: ORG,
+        user_id: USER,
+        agent_name: "Dedicated",
+        execution_tier: "dedicated-lazy",
+        status: "running",
+        sandbox_id: "sandbox-dedicated-1",
+      },
+      {
+        id: AGENT_PROVISIONING,
+        organization_id: ORG,
+        user_id: USER,
+        agent_name: "Provisioning",
+        execution_tier: "shared",
+        status: "provisioning",
+      },
+    ]);
+
+    const agentRoute = (await import("../v1/eliza/agents/[agentId]/route"))
+      .default;
+    app = new Hono<AppEnv>();
+    app.route("/api/v1/eliza/agents/:agentId", agentRoute);
+  } catch (error) {
+    pgliteReady = false;
+    console.error(
+      "[eliza-agents-delete-async-fallback.test] setup failed — failing.",
+      error,
+    );
+  }
+}, 120_000);
+
+afterAll(async () => {
+  restoreImmediateWake?.();
+  if (closeDb) await closeDb();
+  mock.restore();
+});
+
+function del(agentId: string) {
+  return app.request(
+    `/api/v1/eliza/agents/${agentId}`,
+    { method: "DELETE" },
+    ENV,
+  );
+}
+
+async function agentRow(agentId: string) {
+  const { dbWrite } = await import("@/db/client");
+  const { agentSandboxes } = await import("@/db/schemas/agent-sandboxes");
+  const { eq } = await import("drizzle-orm");
+  const rows = await dbWrite
+    .select()
+    .from(agentSandboxes)
+    .where(eq(agentSandboxes.id, agentId))
+    .limit(1);
+  return rows[0];
+}
+
+async function deleteJobsFor(agentId: string) {
+  const { dbWrite } = await import("@/db/client");
+  const { jobs } = await import("@/db/schemas/jobs");
+  const { and, eq } = await import("drizzle-orm");
+  return dbWrite
+    .select()
+    .from(jobs)
+    .where(and(eq(jobs.type, "agent_delete"), eq(jobs.agent_id, agentId)));
+}
+
+describe("DELETE /api/v1/eliza/agents/:agentId — async fallback for sandboxed shared agents (#15275)", () => {
+  let firstJobId: string;
+
+  test("shared agent WITH sandbox_id enqueues an agent_delete job and returns 202 (no sync attempt)", async () => {
+    expect(pgliteReady).toBe(true);
+    const { elizaSandboxService } = await import(
+      "@/lib/services/eliza-sandbox"
+    );
+    const deleteSpy = spyOn(elizaSandboxService, "deleteAgent");
+    try {
+      const res = await del(AGENT_SHARED_SANDBOXED);
+      expect(res.status).toBe(202);
+      const body = (await res.json()) as {
+        success: boolean;
+        created: boolean;
+        alreadyInProgress: boolean;
+        data: { jobId: string; agentId: string; status: string };
+      };
+      expect(body.success).toBe(true);
+      expect(body.created).toBe(true);
+      expect(body.alreadyInProgress).toBe(false);
+      expect(body.data.agentId).toBe(AGENT_SHARED_SANDBOXED);
+      firstJobId = body.data.jobId;
+
+      // The Worker never attempted the (impossible) sync teardown.
+      expect(deleteSpy).not.toHaveBeenCalled();
+
+      // Real DB effects: one pending agent_delete job, row marked deleting.
+      const jobRows = await deleteJobsFor(AGENT_SHARED_SANDBOXED);
+      expect(jobRows.length).toBe(1);
+      expect(jobRows[0].status).toBe("pending");
+      expect(jobRows[0].id).toBe(firstJobId);
+      const row = await agentRow(AGENT_SHARED_SANDBOXED);
+      expect(row?.status).toBe("deletion_pending");
+    } finally {
+      deleteSpy.mockRestore();
+    }
+  });
+
+  test("second DELETE while the job is pending is idempotent (202, same job, no duplicate)", async () => {
+    expect(pgliteReady).toBe(true);
+    const res = await del(AGENT_SHARED_SANDBOXED);
+    expect(res.status).toBe(202);
+    const body = (await res.json()) as {
+      success: boolean;
+      created: boolean;
+      alreadyInProgress: boolean;
+      data: { jobId: string };
+    };
+    expect(body.success).toBe(true);
+    expect(body.created).toBe(false);
+    expect(body.alreadyInProgress).toBe(true);
+    expect(body.data.jobId).toBe(firstJobId);
+
+    const jobRows = await deleteJobsFor(AGENT_SHARED_SANDBOXED);
+    expect(jobRows.length).toBe(1);
+  });
+
+  test("the async path (daemon executeDeletion) completes the enqueued delete and removes the row", async () => {
+    expect(pgliteReady).toBe(true);
+    const { elizaSandboxService } = await import(
+      "@/lib/services/eliza-sandbox"
+    );
+    const outcome = await elizaSandboxService.executeDeletion(
+      AGENT_SHARED_SANDBOXED,
+      ORG,
+    );
+    expect(outcome.success).toBe(true);
+    expect(outcome.containerStopped).toBe(true);
+    expect(await agentRow(AGENT_SHARED_SANDBOXED)).toBeUndefined();
+  });
+
+  test("shared agent WITHOUT sandbox_id keeps the immediate sync delete (200, row gone, no job)", async () => {
+    expect(pgliteReady).toBe(true);
+    const res = await del(AGENT_SHARED_PLAIN);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      success: boolean;
+      deleted: boolean;
+      source: string;
+      data: { agentId: string; status: string };
+    };
+    expect(body.success).toBe(true);
+    expect(body.deleted).toBe(true);
+    expect(body.source).toBe("shared_runtime");
+    expect(body.data.status).toBe("deleted");
+
+    expect(await agentRow(AGENT_SHARED_PLAIN)).toBeUndefined();
+    expect((await deleteJobsFor(AGENT_SHARED_PLAIN)).length).toBe(0);
+  });
+
+  test("a genuine sync failure preserves its cause while falling back to the async job", async () => {
+    expect(pgliteReady).toBe(true);
+    const { elizaSandboxService } = await import(
+      "@/lib/services/eliza-sandbox"
+    );
+    const { logger } = await import("@/lib/utils/logger");
+    const underlying =
+      "Failed to delete sandbox: ssh2 is not available on Cloudflare Workers — proxy to the Node sidecar (cloud/INFRA.md).";
+    const deleteSpy = spyOn(
+      elizaSandboxService,
+      "deleteAgent",
+    ).mockResolvedValueOnce({
+      success: false,
+      error: underlying,
+    });
+    const warnSpy = spyOn(logger, "warn");
+    try {
+      const res = await del(AGENT_SHARED_PLAIN_2);
+      expect(res.status).toBe(202);
+      const body = (await res.json()) as {
+        success: boolean;
+        created: boolean;
+        data: { agentId: string };
+      };
+      expect(body.success).toBe(true);
+      expect(body.created).toBe(true);
+      expect(body.data.agentId).toBe(AGENT_SHARED_PLAIN_2);
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[agent-api] Shared-runtime agent delete failed synchronously; falling back to async delete job",
+        expect.objectContaining({
+          agentId: AGENT_SHARED_PLAIN_2,
+          orgId: ORG,
+          error: underlying,
+        }),
+      );
+      expect((await deleteJobsFor(AGENT_SHARED_PLAIN_2)).length).toBe(1);
+    } finally {
+      deleteSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+  });
+
+  test("dedicated agent keeps the async 202 job contract", async () => {
+    expect(pgliteReady).toBe(true);
+    const res = await del(AGENT_DEDICATED);
+    expect(res.status).toBe(202);
+    const body = (await res.json()) as {
+      success: boolean;
+      created: boolean;
+      data: { jobId: string };
+    };
+    expect(body.success).toBe(true);
+    expect(body.created).toBe(true);
+
+    const jobRows = await deleteJobsFor(AGENT_DEDICATED);
+    expect(jobRows.length).toBe(1);
+    expect((await agentRow(AGENT_DEDICATED))?.status).toBe("deletion_pending");
+  });
+
+  test("provisioning agent → 409; unknown agent → 404", async () => {
+    expect(pgliteReady).toBe(true);
+    const provisioning = await del(AGENT_PROVISIONING);
+    expect(provisioning.status).toBe(409);
+    expect(((await provisioning.json()) as { error: string }).error).toBe(
+      "Agent provisioning is in progress",
+    );
+
+    const missing = await del(AGENT_UNKNOWN);
+    expect(missing.status).toBe(404);
+    expect(((await missing.json()) as { error: string }).error).toBe(
+      "Agent not found",
+    );
+  });
+});

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/route.ts
@@ -388,7 +388,11 @@ app.delete("/", async (c) => {
       );
     }
 
-    if (existing.execution_tier === "shared") {
+    // A sandbox-backed delete needs provider.stop(), which reaches the Docker
+    // node through ssh2. Workerd deliberately stubs ssh2, so only the
+    // provisioning daemon can perform that teardown; the synchronous path is
+    // reserved for pure-DB shared agents without a sandbox (#15275).
+    if (existing.execution_tier === "shared" && !existing.sandbox_id) {
       const result = await elizaSandboxService.deleteAgent(
         agentId,
         user.organization_id,
@@ -437,12 +441,10 @@ app.delete("/", async (c) => {
       }
     }
 
-    // Async delete via the same job-queue path agent_provision uses. This
-    // moves the SSH stop, Neon deletion, and per-agent key revoke off the
-    // request thread so a slow / unreachable Hetzner core can no longer
-    // make the API hang or silently return 200 while the container lives
-    // on. Idempotent: a second DELETE while a job is in flight reuses
-    // the existing one.
+    // Dedicated agents and sandbox-backed shared agents use the same daemon
+    // job because SSH teardown, Neon deletion, and per-agent key revocation
+    // must run outside the Worker request boundary. Enqueue marks the row
+    // `deletion_pending`; a repeated DELETE reuses the in-flight job.
     const enqueueResult = await provisioningJobService.enqueueAgentDeleteOnce({
       agentId,
       organizationId: user.organization_id,

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -1684,7 +1684,11 @@ describe("ElizaSandboxService.deleteAgent teardown cap (#9066)", () => {
     try {
       const res = (await svc.deleteAgent(AGENT, ORG)) as { success: boolean; error?: string };
       expect(res.success).toBe(false);
-      expect(res.error).toBe("Failed to delete sandbox");
+      // The underlying stop failure must surface in the returned error so the
+      // job result / API envelope stays diagnosable (#15275).
+      expect(res.error).toBe(
+        "Failed to delete sandbox: docker stop -> daemon hung; docker rm -f -> daemon hung",
+      );
       // Critically: the row delete is never attempted when the container may
       // still be running.
       expect(commit).not.toHaveBeenCalled();

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -1271,7 +1271,9 @@ export class ElizaSandboxService {
             status: precheck.status,
             error: errorMessage,
           });
-          return { success: false, error: "Failed to delete sandbox" };
+          // Job results and API boundaries need the teardown cause because a
+          // generic delete failure cannot distinguish Docker stop/rm faults.
+          return { success: false, error: `Failed to delete sandbox: ${errorMessage}` };
         }
       }
     }


### PR DESCRIPTION
Fixes #15802. Refs #15275.

## Summary

Forensic analysis found a stronger #15275 fix stranded on `fix/agent-delete-async-15275` after #15286 merged the generic fallback.

A shared agent with `sandbox_id` necessarily needs `provider.stop()`/Docker SSH. The Cloudflare Worker stubs `ssh2`, so attempting that synchronously is guaranteed to fail before the route falls back to the daemon job. This PR routes that structural case directly to the existing idempotent `agent_delete` queue while preserving:

- immediate synchronous deletion for pure-DB shared rows without a sandbox
- generic synchronous-failure fallback to the async queue
- dedicated-agent async deletion
- 404/409 terminal behavior
- underlying Docker stop/rm failure context in service results

## Verification

- real route + real sandbox/provisioning services + in-process PGlite: 7/7 pass, 48 assertions
- the suite proves enqueue, idempotent repeat DELETE, real `executeDeletion`, immediate pure-DB delete, generic fallback, dedicated delete, 404, and 409
- focused sandbox teardown-cap suite: 7/7 pass, 21 assertions
- Biome on all four touched files: pass
- error-policy ratchet: pass
- diff check: pass

## Draft status

The recovered PGlite suite is substantially stronger than the merged mock-based fallback test, but the repository definition of done also asks for a real local cloud-stack request/response trace and inspected DB rows. This remains draft until that external-stack evidence is attached.

## Evidence

<!-- evidence-row:before-screenshots -->
Before screenshots: N/A - backend Worker routing only; no UI changed.

<!-- evidence-row:after-screenshots -->
After screenshots: N/A - backend Worker routing only; no UI changed.

<!-- evidence-row:walkthrough-video -->
Walkthrough video: N/A - no user-facing visual flow changed.

<!-- evidence-row:backend-logs -->
Backend logs: N/A - the real route/PGlite integration suite ran in-process; a long-running local cloud stack was not started, so this PR remains draft.

<!-- evidence-row:frontend-logs -->
Frontend logs: N/A - no frontend code changed.

<!-- evidence-row:llm-trajectory -->
Real-LLM trajectory: N/A - no model, prompt, provider, action, or planner behavior changed.

<!-- evidence-row:domain-artifacts -->
Domain artifacts: N/A - the PGlite suite inspects transient real job and agent rows directly but does not retain the ephemeral database after the run; live-stack artifacts remain the draft blocker.