### PR TITLE
fix(ui): distinct Polymarket loading/empty/error states + enforce OCR gate (#15781)

### DIFF
--- a/packages/app/test/audit/ocr-content-rules.test.ts
+++ b/packages/app/test/audit/ocr-content-rules.test.ts
@@ -192,4 +192,47 @@ describe("evaluateOcrContent", () => {
   it("does not use stale positive text expectations for sparse builtin chat", () => {
     expect(VIEW_EXPECTATIONS["builtin-chat"]).toBeUndefined();
   });
+
+  // #15781: the Polymarket view once painted its caught `.ready` TypeError into
+  // the market-detail render. The expectation positively verifies the healthy
+  // chrome across every viewport's layout, and the universal developer-string
+  // rules reject the crash residue. The three OCR strings below are the exact
+  // packaged-Tesseract reads off the committed audit capture per layout.
+  it.each([
+    // Desktop/tablet market-detail: "< Markets" back control renders.
+    [
+      "detail (desktop/tablet)",
+      "< Wallet\nWallet Perps Predictions\n<Markets\nWill the Ul smoke suite stay green?\nYes 87% No 13%",
+    ],
+    // Mobile compact detail: no back control, but the Vol/Liq/Last metric row does.
+    [
+      "compact detail (mobile)",
+      "< Wallet\nWallet Perps Predictions\nWill the Ul smoke suite stay green?\nYes 87% No 13%\nVol $45.7K - Liq $12.3K - Last 87%",
+    ],
+    // List state: readiness chips + the "markets" label.
+    ["list", "reads ready trading off\n2 markets\nmarkets\n01 Will BTC..."],
+  ])("verifies a healthy Polymarket render — %s", (_layout, text) => {
+    const f = evaluateOcrContent({
+      ocr: ocr(text),
+      expectation: VIEW_EXPECTATIONS["plugin-polymarket-gui"],
+    });
+    expect(f.verdict).toBe("verified");
+    expect(f.missingRequired).toHaveLength(0);
+  });
+
+  it("breaks the Polymarket view when the `.ready` crash string reaches the pixels", () => {
+    const f = evaluateOcrContent({
+      ocr: ocr(
+        "markets\nCannot read properties of undefined (reading 'ready')",
+      ),
+      expectation: VIEW_EXPECTATIONS["plugin-polymarket-gui"],
+    });
+    expect(f.errorLeaks).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/undefined/),
+        expect.stringMatching(/Cannot read propert/i),
+      ]),
+    );
+    expect(f.verdict).toBe("broken");
+  });
 });

--- a/packages/app/test/ui-smoke/ocr-triage-baseline.json
+++ b/packages/app/test/ui-smoke/ocr-triage-baseline.json
@@ -1,14 +1,5 @@
 {
   "note": "slug::viewport of pixel-broken renders the DOM audit passed, already tracked by an issue. Remove an entry once the underlying render is fixed; the gate then fails if it regresses. New keys must NOT be added here without an accompanying issue — a new pixel-broken render should fail the gate, not be baselined away.",
-  "known": [
-    "plugin-polymarket-gui::desktop-landscape",
-    "plugin-polymarket-gui::ipad-portrait",
-    "plugin-polymarket-gui::mobile-portrait",
-    "plugin-polymarket-tui::desktop-landscape",
-    "plugin-polymarket-tui::ipad-portrait",
-    "plugin-polymarket-tui::mobile-portrait"
-  ],
-  "tracking": {
-    "plugin-polymarket": "PolymarketSpatialView paints 'Cannot read properties of undefined (reading ready)' — see the filed issue"
-  }
+  "known": [],
+  "tracking": {}
 }

--- a/packages/app/test/ui-smoke/ocr-view-expectations.ts
+++ b/packages/app/test/ui-smoke/ocr-view-expectations.ts
@@ -195,6 +195,18 @@ export const VIEW_EXPECTATIONS: Record<string, OcrExpectation> = {
       "Electrobun desktop runtim",
     ],
   },
+  // First-party MVP plugin view (#15781). Unlike third-party plugin surfaces it
+  // ships stable, OCR-legible chrome we positively verify. The audit auto-selects
+  // the first market, so the capture is the market-detail state: the "< Markets"
+  // back control (desktop/tablet) or the compact "Vol/Liq/Last" metric row
+  // (mobile, where the chat composer forces compact layout). The list state adds
+  // the "markets" label and the "reads"/"trading" readiness chips. requireAny
+  // over the union covers every viewport's layout; the universal developer-string
+  // rules independently reject the `undefined` / `Cannot read properties` crash
+  // this view once leaked, so a regressed render breaks instead of verifying.
+  "plugin-polymarket-gui": {
+    requireAny: ["markets", "reads", "trading", "vol", "liq", "last"],
+  },
 };
 
 // Native/permission-gated views (camera, contacts, phone, rolodex, messages) are

--- a/plugins/plugin-polymarket/src/PolymarketView.test.tsx
+++ b/plugins/plugin-polymarket/src/PolymarketView.test.tsx
@@ -378,14 +378,33 @@ describe("PolymarketView — refresh + error path", () => {
     expect(polymarketClient.polymarketStatus).toHaveBeenCalledTimes(2);
   });
 
-  it("surfaces a markets fetch failure as the error text", async () => {
+  it("renders a distinct error state — not the empty placeholder — when the load fails with no cached markets", async () => {
     polymarketClient.polymarketStatus.mockResolvedValue(sampleStatus);
     polymarketClient.polymarketMarkets.mockRejectedValue(
       new Error("network down"),
     );
     render(React.createElement(PolymarketView));
     await screen.findByText("network down");
-    expect(screen.getByText("no markets loaded")).toBeTruthy();
+    // The three-state rule (#15781): a failed load is its own designed state, so
+    // the empty ("no markets loaded") and loading placeholders must NOT co-render.
+    expect(screen.getByText("Couldn't load markets")).toBeTruthy();
+    expect(screen.queryByText("no markets loaded")).toBeNull();
+    expect(screen.queryByText("loading markets")).toBeNull();
+  });
+
+  it("renders the empty state — not an error — when the load succeeds with zero markets", async () => {
+    polymarketClient.polymarketStatus.mockResolvedValue(sampleStatus);
+    polymarketClient.polymarketMarkets.mockResolvedValue({
+      markets: [],
+      source: { api: "gamma", endpoint: "/markets" },
+    });
+    render(React.createElement(PolymarketView));
+    await screen.findByText("no markets loaded");
+    expect(screen.queryByText("Couldn't load markets")).toBeNull();
+    // A legitimately-empty response never leaks a developer crash string.
+    const text = document.body.textContent ?? "";
+    expect(text).not.toContain("Cannot read properties");
+    expect(text).not.toContain("undefined");
   });
 });
 

--- a/plugins/plugin-polymarket/src/components/PolymarketSpatialView.tsx
+++ b/plugins/plugin-polymarket/src/components/PolymarketSpatialView.tsx
@@ -276,6 +276,37 @@ function PositionRow({ position }: { position: PolymarketPosition }) {
   );
 }
 
+function MarketsEmptyState({
+  loading,
+  error,
+}: {
+  loading: boolean;
+  error: string | null;
+}) {
+  // Three distinguishable no-data renders (#15781): a failed load is a
+  // danger-toned error block, an in-flight load a neutral "loading" line, and a
+  // resolved-but-empty response a muted "empty" line. `refresh` clears `error`
+  // before it sets `loading`, so the two are mutually exclusive and the error
+  // branch can take precedence without masking an in-flight retry.
+  if (error) {
+    return (
+      <VStack gap={0} align="center" tone="danger" border padding={1}>
+        <Text tone="danger" style="caption" bold>
+          Couldn't load markets
+        </Text>
+        <Text tone="danger" style="caption" align="center" wrap>
+          {error}
+        </Text>
+      </VStack>
+    );
+  }
+  return (
+    <Text tone="muted" align="center" style="caption">
+      {loading ? "loading markets" : "no markets loaded"}
+    </Text>
+  );
+}
+
 function PositionsSection({
   positions,
   summary,
@@ -363,8 +394,12 @@ export function PolymarketSpatialView({
         </HStack>
       ) : null}
 
-      {error ? (
-        <Text tone="danger" style="caption">
+      {/* Stale-while-error banner: keep the failure visible over cached content
+          (detail overlay or a populated list) instead of blanking it. When there
+          is no content to preserve, the empty region below owns the error state
+          so the message never double-renders (#15781). */}
+      {error && (selectedMarket || markets.length > 0) ? (
+        <Text tone="danger" style="caption" wrap>
           {error}
         </Text>
       ) : null}
@@ -386,11 +421,7 @@ export function PolymarketSpatialView({
           <Text style="caption" tone="muted">
             markets
           </Text>
-          {markets.length === 0 ? (
-            <Text tone="muted" align="center" style="caption">
-              {loading ? "loading markets" : "no markets loaded"}
-            </Text>
-          ) : (
+          {markets.length > 0 ? (
             <List gap={1}>
               {markets.slice(0, MAX_LIST).map((market, index) => (
                 <MarketRow
@@ -402,6 +433,11 @@ export function PolymarketSpatialView({
                 />
               ))}
             </List>
+          ) : (
+            <MarketsEmptyState
+              loading={loading ?? false}
+              error={error ?? null}
+            />
           )}
         </>
       )}


### PR DESCRIPTION
Closes #15781.

## Problem

The fresh full-app visual audit classified the Polymarket market-detail state as broken, with the tracking note "PolymarketSpatialView paints `Cannot read properties of undefined (reading ready)`". The readiness reads had already been fully optional-chained (#14448) and a well-formed status fixture added, so the crash string no longer reaches the pixels — but the residual debt was still open: the OCR gate baselined polymarket away, no positive expectation verified the view, and the empty/error/loading states were not distinct.

## What changed

1. **Three distinct designed states** in `PolymarketSpatialView`. Previously an error prepended an inline danger banner while the empty "no markets loaded" placeholder still rendered below (the old test even asserted both co-render). Now, with no cached markets, the view renders exactly one of: a danger-toned **"Couldn't load markets"** error block, a neutral **"loading markets"** line, or a muted **"no markets loaded"** empty line. `refresh` clears `error` before setting `loading`, so the two are mutually exclusive. When cached markets or the detail overlay exist, a refresh failure keeps a stale-while-error banner rather than blanking the content (J4 degrade).

2. **Positive OCR expectation** for `plugin-polymarket-gui` (`ocr-view-expectations.ts`). `requireAny: ["markets","reads","trading","vol","liq","last"]` covers every viewport's captured layout — desktop/tablet `< Markets` detail, mobile compact `Vol/Liq/Last` metric row, and the list readiness chips. The universal `DEVELOPER_LEAK_PATTERNS` already reject `undefined` and `Cannot read properties`, so a regressed render breaks instead of verifying.

3. **Emptied the OCR triage baseline** (`ocr-triage-baseline.json`) — removed the stale `plugin-polymarket-{gui,tui}::*` known entries and the tracking note. The gate now enforces polymarket: a future crash regression fails CI instead of being baselined away. (The `-tui` entries were already orphaned — the audit only captures the gui view.)

## Evidence

### Real audit capture + packaged OCR triage (ground truth)

`bun run --cwd packages/app audit:app` capture for `plugin-polymarket-gui` across all four viewports, then `ocr-triage.ts` with the emptied baseline:

```
[aesthetic-audit] 4 findings — broken=0 needs-work=0 needs-eyeball=0 good=4 ...
  4 passed (2.8m)

[ocr-triage] 4 views | verified 4 | broken 0 | needs-eyeball 0
=== EXIT 0 ===
```

<details><summary>Exact packaged-Tesseract OCR text per viewport (no crash string on any)</summary>

```
plugin-polymarket-gui [desktop-landscape] verified
"< Wallet\nWallet Perps Predictions\n<Markets\nWill the Ul smoke suite stay green?\nYes 87% No 13%\n4 AskEliza 9"

plugin-polymarket-gui [ipad-portrait] verified
"< Wallet\nWallet Perps Predictions\n<Markets\nWill the Ul smoke suite stay green?\nYes 87% No 13%\n4 AskEliza 9"

plugin-polymarket-gui [mobile-landscape] verified
"< Wallet\nWallet Perps Predictions\nWill the Ul smoke suite stay green?\nYes 87% No 13%\nVol $45.7K - Liq $12.3K - Last 87%\nAsk\nEliza\nar ["

plugin-polymarket-gui [mobile-portrait] verified
"< Wallet\nWallet Perps Predictions\nWill the Ul smoke suite stay green?\nYes 87% No 13%\nVol $45.7K - Liq $12.3K - Last 87%\n+ AskEliza [UE"
```

Before this PR the same triage reported the polymarket gui/tui slugs as baselined-known regressions; the emptied baseline + healthy render now yields `verified 4 / broken 0`.
</details>

Desktop capture (reviewed by hand — clean `< Markets` detail, `Yes 87% / No 13%`, orange accent, no developer string):

`packages/app/aesthetic-audit-output/desktop-landscape/plugin-polymarket-gui.png`

### Unit tests (red→green)

- `plugins/plugin-polymarket/src/PolymarketView.test.tsx` — the old test asserted the error banner and the "no markets loaded" placeholder co-rendered; it now asserts the **distinct** error state ("Couldn't load markets", no empty/loading placeholder) and a new empty-state test (zero markets → "no markets loaded", no error, no crash string). `#14448` account-missing regression guard still green.

```
plugins/plugin-polymarket  Test Files 7 passed | 1 skipped   Tests 46 passed | 3 skipped
```

- `packages/app/test/audit/ocr-content-rules.test.ts` — adds three healthy-render cases (per-layout, seeded from the exact packaged-Tesseract OCR above) that verify, and one that breaks when the `.ready` crash string reaches the pixels.

```
packages/app ocr-content-rules  Test Files 1 passed   Tests 28 passed
```

### Checks

- `bunx biome check` on all five touched files — clean.
- `bun run --cwd plugins/plugin-polymarket typecheck` — clean.

N/A: real-LLM trajectories (no agent/action/prompt/model behavior changed — this is a view render + audit-gate fix). Video walkthrough N/A — the change is state-render logic proven by the per-viewport captures + DOM render tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Release evidence

Manually reviewed on 2026-07-09 at head `1c7ca12c`. The four audit viewports render the seeded market without developer text; the recorded interaction shows boot → Predictions → populated list → market detail → return to list. The Playwright trace records repeated HTTP 200 responses for `/api/polymarket/status` and `/api/polymarket/markets?limit=25`. The scoped Node-24 lane passed: `1 passed (35.4s)`.

<!-- evidence-row:before-screenshots -->
- [x] [Before — raw undefined.ready exception](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15781-polymarket-before.jpg)

<!-- evidence-row:after-screenshots -->
- [x] [Desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15818-polymarket-after-desktop.jpg), [iPad portrait](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15818-polymarket-after-ipad.jpg), [mobile landscape](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15818-polymarket-after-mobile-landscape.jpg), and [mobile portrait](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15818-polymarket-after-mobile-portrait.jpg) — all manually reviewed; no raw exception.

<!-- evidence-row:walkthrough-video -->
- [x] [MP4 walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15818-polymarket-walkthrough.mp4) — manually reviewed through list/detail/back states.

<!-- evidence-row:backend-logs -->
- [ ] N/A - the changed surface is client render-state logic and OCR rules; the keyless API fixture contract is attached in the trace/domain artifacts below.

<!-- evidence-row:frontend-logs -->
- [x] [Playwright trace with console and network](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15818-polymarket-playwright-trace.zip) — manually inspected; Polymarket status/markets requests return 200 and the issue-specific `undefined.ready` exception is absent.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, prompt, provider, evaluator, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] [Full 240-row app-audit report](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15818-app-audit-report.json) and [packaged OCR result](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15818-ocr-triage.json): Polymarket is `good` + `verified` in all four viewports, with 0 broken and 0 regressions overall.

<!-- evidence-row:ocr-review -->
- [x] The linked OCR artifact contains four `plugin-polymarket-gui` rows, each `ocrVerdict: verified`, with the exact desktop/tablet and compact-mobile market text manually checked against the screenshots.