### PR TITLE
fix(cloud): account app containers against node capacity

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/app-container-provider.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-container-provider.test.ts
@@ -49,6 +49,7 @@ describe("AppContainerProvider.provision", () => {
     const { calls, ssh } = recordingSsh();
     const provider = new AppContainerProvider({
       ssh,
+      nodeId: "node-1",
       allocateHostPort: async () => 49001,
       egressProxyUrl: "http://egress-gw:3128",
     });
@@ -78,7 +79,11 @@ describe("AppContainerProvider.provision", () => {
 
   test("removes any stale container by name BEFORE docker create (redeploy self-heal)", async () => {
     const { calls, ssh } = recordingSsh();
-    const provider = new AppContainerProvider({ ssh, allocateHostPort: async () => 49001 });
+    const provider = new AppContainerProvider({
+      ssh,
+      nodeId: "node-1",
+      allocateHostPort: async () => 49001,
+    });
 
     await provider.provision({
       appId: APP_ID,
@@ -105,7 +110,11 @@ describe("AppContainerProvider.provision", () => {
         return "";
       },
     };
-    const provider = new AppContainerProvider({ ssh, allocateHostPort: async () => 49001 });
+    const provider = new AppContainerProvider({
+      ssh,
+      nodeId: "node-1",
+      allocateHostPort: async () => 49001,
+    });
     const result = await provider.provision({
       appId: APP_ID,
       containerName: "app-nubilio",
@@ -129,6 +138,7 @@ describe("AppContainerProvider.provision", () => {
     };
     const provider = new AppContainerProvider({
       ssh,
+      nodeId: "node-1",
       allocateHostPort: async () => ports[i++] ?? 39999,
     });
     const result = await provider.provision({
@@ -140,9 +150,35 @@ describe("AppContainerProvider.provision", () => {
     expect(result.hostPort).toBe(31000);
   });
 
+  test("a start failure removes the created container before propagating", async () => {
+    const calls: string[] = [];
+    const ssh: AppContainerSsh = {
+      async exec(command) {
+        calls.push(command);
+        if (command.startsWith("docker create")) return "cid";
+        if (command.startsWith("docker start")) throw new Error("start failed");
+        return "";
+      },
+    };
+    const provider = new AppContainerProvider({
+      ssh,
+      nodeId: "node-1",
+      allocateHostPort: async () => 49001,
+    });
+
+    await expect(
+      provider.provision({ appId: APP_ID, containerName: "app-nubilio", input: INPUT }),
+    ).rejects.toThrow("start failed");
+    expect(calls.filter((command) => command === "docker rm -f 'app-nubilio'")).toHaveLength(2);
+  });
+
   test("provision with DATABASE_URL + POSTGRES_URL stands up the ambassador + rewrites BOTH", async () => {
     const { calls, ssh } = recordingSsh();
-    const provider = new AppContainerProvider({ ssh, allocateHostPort: async () => 49002 });
+    const provider = new AppContainerProvider({
+      ssh,
+      nodeId: "node-1",
+      allocateHostPort: async () => 49002,
+    });
 
     await provider.provision({
       appId: APP_ID,
@@ -176,7 +212,11 @@ describe("AppContainerProvider.provision", () => {
 
   test("lifecycle verbs issue the expected docker commands", async () => {
     const { calls, ssh } = recordingSsh();
-    const provider = new AppContainerProvider({ ssh, allocateHostPort: async () => 1 });
+    const provider = new AppContainerProvider({
+      ssh,
+      nodeId: "node-1",
+      allocateHostPort: async () => 1,
+    });
     await provider.delete("app-x");
     await provider.restart("app-x");
     await provider.logs("app-x", 50);

--- a/packages/cloud/shared/src/lib/services/__tests__/app-container-store-recovery.integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-container-store-recovery.integration.test.ts
@@ -1,21 +1,62 @@
-/** Proves malformed-delete recovery selects only deleting rows owned by the queued organization in real Postgres SQL. */
+/**
+ * Exercises app-container recovery reads and slot transactions against real
+ * Postgres semantics using an isolated PGlite database.
+ */
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { PGlite } from "@electric-sql/pglite";
 import { drizzle } from "drizzle-orm/pglite";
-import { findDeletingAppContainerRows } from "../app-container-store-queries";
+import {
+  type AppContainerStoreRepository,
+  ContainerRepoAppContainerStore,
+} from "../app-container-store";
+import { countAllocatedWorkloadsOnNodeWithDatabase } from "../docker-node-workload-queries";
 
 const ORG_ONE = "00000000-0000-0000-0000-0000000000a1";
 const ORG_TWO = "00000000-0000-0000-0000-0000000000a2";
 const USER_ID = "00000000-0000-0000-0000-0000000000b1";
 const DELETING_ID = "00000000-0000-0000-0000-0000000000c1";
+const SLOT_ID = "00000000-0000-0000-0000-0000000000c4";
+const CAPACITY_ID = "00000000-0000-0000-0000-0000000000c5";
 
 let client: PGlite;
 let database: ReturnType<typeof drizzle>;
+let store: ContainerRepoAppContainerStore;
+const statusUpdates: Array<{ id: string; status: string; error?: string }> = [];
+const containerUpdates: Array<{
+  id: string;
+  organizationId: string;
+  data: Parameters<AppContainerStoreRepository["update"]>[2];
+}> = [];
+const releasedSlots: Array<{ id: string; organizationId: string; nodeId: string }> = [];
 
 beforeAll(async () => {
   client = new PGlite();
   database = drizzle(client);
+  const repository: AppContainerStoreRepository = {
+    updateStatus: async (id, status, error) => {
+      statusUpdates.push({ id, status, ...(error ? { error } : {}) });
+      return null;
+    },
+    update: async (id, organizationId, data) => {
+      containerUpdates.push({ id, organizationId, data });
+      return null;
+    },
+    tryReleaseNodeSlot: async (id, organizationId, nodeId) => {
+      releasedSlots.push({ id, organizationId, nodeId });
+      return true;
+    },
+  };
+  store = new ContainerRepoAppContainerStore({
+    readDatabase: database,
+    writeDatabase: database,
+    repository,
+    errorFactory: (message, options) => {
+      const error = new Error(message);
+      error.name = options.code;
+      return error;
+    },
+  });
 
   await client.exec(`
     CREATE TABLE containers (
@@ -28,16 +69,33 @@ beforeAll(async () => {
       user_id uuid NOT NULL,
       environment_vars jsonb NOT NULL DEFAULT '{}',
       metadata jsonb NOT NULL DEFAULT '{}',
+      node_id text,
+      status text NOT NULL,
+      error_message text,
+      updated_at timestamp NOT NULL DEFAULT now()
+    );
+    CREATE TABLE docker_nodes (
+      node_id text PRIMARY KEY,
+      allocated_count integer NOT NULL DEFAULT 0,
+      capacity integer NOT NULL,
+      enabled boolean NOT NULL DEFAULT true,
+      updated_at timestamp NOT NULL DEFAULT now()
+    );
+    CREATE TABLE agent_sandboxes (
+      id uuid PRIMARY KEY,
+      node_id text,
       status text NOT NULL
-    )
-  `);
-  await client.exec(`
+    );
+    INSERT INTO docker_nodes (node_id, allocated_count, capacity, enabled)
+    VALUES ('node-1', 0, 2, true), ('node-full', 1, 1, true);
     INSERT INTO containers
       (id, name, project_name, image_tag, port, organization_id, user_id, status)
     VALUES
       ('${DELETING_ID}', 'delete-me', 'app-1', 'image:1', 3000, '${ORG_ONE}', '${USER_ID}', 'deleting'),
       ('00000000-0000-0000-0000-0000000000c2', 'keep-running', 'app-2', 'image:2', 3000, '${ORG_ONE}', '${USER_ID}', 'running'),
-      ('00000000-0000-0000-0000-0000000000c3', 'other-org', 'app-3', 'image:3', 3000, '${ORG_TWO}', '${USER_ID}', 'deleting')
+      ('00000000-0000-0000-0000-0000000000c3', 'other-org', 'app-3', 'image:3', 3000, '${ORG_TWO}', '${USER_ID}', 'deleting'),
+      ('${SLOT_ID}', 'slot-lifecycle', 'app-4', 'image:4', 3000, '${ORG_ONE}', '${USER_ID}', 'pending'),
+      ('${CAPACITY_ID}', 'capacity-refusal', 'app-5', 'image:5', 3000, '${ORG_ONE}', '${USER_ID}', 'pending');
   `);
 });
 
@@ -45,15 +103,100 @@ afterAll(async () => {
   await client.close();
 });
 
-describe("ContainerRepoAppContainerStore malformed-delete recovery", () => {
-  test("filters by both organization ownership and deleting status", async () => {
-    const rows = await findDeletingAppContainerRows(database, ORG_ONE);
+describe("app-container persistence transactions", () => {
+  test("recovery filters by both organization ownership and deleting status", async () => {
+    const rows = await store.findDeletingByOrganization(ORG_ONE);
 
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({
       id: DELETING_ID,
-      organization_id: ORG_ONE,
-      name: "delete-me",
+      organizationId: ORG_ONE,
+      containerName: "delete-me",
     });
+  });
+
+  test("claims and rolls back exactly one authoritative node slot", async () => {
+    expect(await store.claimNodeSlot(SLOT_ID, ORG_ONE, "node-1")).toBe(true);
+    expect(await store.claimNodeSlot(SLOT_ID, ORG_ONE, "node-1")).toBe(false);
+    expect(await store.getById(SLOT_ID)).toMatchObject({ id: SLOT_ID, nodeId: "node-1" });
+
+    expect(await countAllocatedWorkloadsOnNodeWithDatabase(database, "node-1")).toBe(1);
+
+    expect(await store.rollbackNodeSlotClaim(SLOT_ID, ORG_ONE, "node-1")).toBe(true);
+    expect(await store.rollbackNodeSlotClaim(SLOT_ID, ORG_ONE, "node-1")).toBe(false);
+    expect(await countAllocatedWorkloadsOnNodeWithDatabase(database, "node-1")).toBe(0);
+
+    const [rolledBack] = (
+      await client.query<{ allocated_count: number; node_id: string | null; claimed: boolean }>(`
+        SELECT docker_nodes.allocated_count, containers.node_id,
+               jsonb_exists(containers.metadata, 'slotClaimedAt') AS claimed
+        FROM containers CROSS JOIN docker_nodes
+        WHERE containers.id = '${SLOT_ID}' AND docker_nodes.node_id = 'node-1'
+      `)
+    ).rows;
+    expect(rolledBack).toEqual({ allocated_count: 0, node_id: null, claimed: false });
+  });
+
+  test("capacity refusal atomically rolls back attribution and claim metadata", async () => {
+    await expect(store.claimNodeSlot(CAPACITY_ID, ORG_ONE, "node-full")).rejects.toMatchObject({
+      name: "APP_CONTAINER_NODE_CAPACITY_UNAVAILABLE",
+    });
+
+    const [state] = (
+      await client.query<{ allocated_count: number; node_id: string | null; claimed: boolean }>(`
+        SELECT docker_nodes.allocated_count, containers.node_id,
+               jsonb_exists(containers.metadata, 'slotClaimedAt') AS claimed
+        FROM containers CROSS JOIN docker_nodes
+        WHERE containers.id = '${CAPACITY_ID}' AND docker_nodes.node_id = 'node-full'
+      `)
+    ).rows;
+    expect(state).toEqual({ allocated_count: 1, node_id: null, claimed: false });
+  });
+
+  test("running, failure, and deletion transitions preserve ownership and placement", async () => {
+    await store.markRunning(SLOT_ID, {
+      hostContainerId: "docker-1",
+      hostPort: 31000,
+      network: "app-network",
+      nodeHost: "10.0.0.1",
+    });
+    await store.markError(SLOT_ID, "health check failed");
+    await store.markDeleted(SLOT_ID, ORG_ONE, "node-1");
+
+    expect(statusUpdates).toContainEqual({ id: SLOT_ID, status: "running" });
+    expect(statusUpdates).toContainEqual({
+      id: SLOT_ID,
+      status: "failed",
+      error: "health check failed",
+    });
+    expect(containerUpdates).toHaveLength(1);
+    expect(containerUpdates[0]).toMatchObject({
+      id: SLOT_ID,
+      organizationId: ORG_ONE,
+      data: {
+        metadata: {
+          hostContainerId: "docker-1",
+          hostPort: 31000,
+          network: "app-network",
+          hostname: "10.0.0.1",
+        },
+      },
+    });
+    expect(releasedSlots).toEqual([{ id: SLOT_ID, organizationId: ORG_ONE, nodeId: "node-1" }]);
+    expect(
+      (
+        await client.query<{ status: string }>(
+          `SELECT status FROM containers WHERE id='${SLOT_ID}'`,
+        )
+      ).rows,
+    ).toEqual([{ status: "deleted" }]);
+
+    await expect(
+      store.markRunning("00000000-0000-0000-0000-000000000099", {
+        hostContainerId: "missing",
+        hostPort: 31001,
+        network: "app-network",
+      }),
+    ).rejects.toMatchObject({ name: "APP_CONTAINER_ROW_MISSING" });
   });
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/app-container-store.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-container-store.test.ts
@@ -1,11 +1,11 @@
 // Exercises app container store behavior with deterministic cloud-shared lib fixtures.
 import { describe, expect, test } from "bun:test";
+import { toNewContainer } from "../app-container-record";
 import {
   mapContainerRowToAppContainerRow,
   mergeHostPlacementMetadata,
   type ProjectableContainerRow,
 } from "../app-container-store";
-import { toNewContainer } from "../app-deploy-runner";
 
 const DSN = "postgresql://app_x:pw@cluster:5432/db_app_x?sslmode=require";
 
@@ -20,6 +20,7 @@ function row(overrides: Partial<ProjectableContainerRow> = {}): ProjectableConta
     user_id: "user-1",
     environment_vars: { DATABASE_URL: DSN, PORT: "3000" },
     metadata: {},
+    node_id: null,
     ...overrides,
   };
 }

--- a/packages/cloud/shared/src/lib/services/__tests__/container-job-executors.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/container-job-executors.test.ts
@@ -23,12 +23,21 @@ const ROW: AppContainerRow = {
 
 function fakeStore(row: AppContainerRow | null = ROW) {
   const events: Array<{ op: string; id: string; info?: unknown }> = [];
+  const slotEvents: Array<{ op: "claim" | "rollback"; nodeId: string }> = [];
   const store: AppContainerStore = {
     async getById() {
       return row;
     },
     async findDeletingByOrganization() {
       return row ? [row] : [];
+    },
+    async claimNodeSlot(_id, _organizationId, nodeId) {
+      slotEvents.push({ op: "claim", nodeId });
+      return true;
+    },
+    async rollbackNodeSlotClaim(_id, _organizationId, nodeId) {
+      slotEvents.push({ op: "rollback", nodeId });
+      return true;
     },
     async markRunning(id, info) {
       events.push({ op: "running", id, info });
@@ -40,15 +49,22 @@ function fakeStore(row: AppContainerRow | null = ROW) {
       events.push({ op: "error", id, info: error });
     },
   };
-  return { events, store };
+  return { events, slotEvents, store };
 }
 
 function fakeProvider(over: Partial<Record<keyof AppContainerProvider, unknown>> = {}) {
   const calls: Array<{ op: string; arg: unknown }> = [];
   const provider = {
+    targetNodeId: "node-1",
     async provision(params: unknown): Promise<ProvisionedAppContainer> {
       calls.push({ op: "provision", arg: params });
-      return { containerId: "docker-abc", hostPort: 49001, network: "app-net-x" };
+      return {
+        containerId: "docker-abc",
+        hostPort: 49001,
+        network: "app-net-x",
+        nodeId: "node-1",
+        nodeHost: "node.example.test",
+      };
     },
     async delete(name: string) {
       calls.push({ op: "delete", arg: name });
@@ -69,7 +85,7 @@ const job = (data: unknown) => ({ id: "job-1", data });
 
 describe("executeContainerProvision", () => {
   test("builds input from the row, provisions, and marks running", async () => {
-    const { events, store } = fakeStore();
+    const { events, slotEvents, store } = fakeStore();
     const { calls, provider } = fakeProvider();
     await executeContainerProvision(
       job({ containerId: "container-1", organizationId: "org-1", userId: "user-1" }),
@@ -92,9 +108,15 @@ describe("executeContainerProvision", () => {
       {
         op: "running",
         id: "container-1",
-        info: { hostContainerId: "docker-abc", hostPort: 49001, network: "app-net-x" },
+        info: {
+          hostContainerId: "docker-abc",
+          hostPort: 49001,
+          network: "app-net-x",
+          nodeHost: "node.example.test",
+        },
       },
     ]);
+    expect(slotEvents).toEqual([{ op: "claim", nodeId: "node-1" }]);
   });
 
   test("flips the linked app to deployed on success (#5: deploy reaches READY)", async () => {
@@ -139,7 +161,7 @@ describe("executeContainerProvision", () => {
   });
 
   test("marks error and rethrows when provisioning fails", async () => {
-    const { events, store } = fakeStore();
+    const { events, slotEvents, store } = fakeStore();
     const { provider } = fakeProvider({
       async provision() {
         throw new Error("docker create failed");
@@ -155,6 +177,71 @@ describe("executeContainerProvision", () => {
       ),
     ).rejects.toThrow("docker create failed");
     expect(events[0]).toMatchObject({ op: "error", id: "container-1" });
+    expect(slotEvents).toEqual([
+      { op: "claim", nodeId: "node-1" },
+      { op: "rollback", nodeId: "node-1" },
+    ]);
+  });
+
+  test("capacity refusal never invokes Docker or fabricates a failed container", async () => {
+    const { events, store } = fakeStore();
+    store.claimNodeSlot = async () => {
+      throw new Error("node capacity unavailable");
+    };
+    const { calls, provider } = fakeProvider();
+
+    await expect(
+      executeContainerProvision(
+        job({ containerId: "container-1", organizationId: "org-1", userId: "user-1" }),
+        { provider, store },
+      ),
+    ).rejects.toThrow("node capacity unavailable");
+
+    expect(calls).toEqual([]);
+    expect(events).toEqual([]);
+  });
+
+  test("a running-state write failure removes Docker before releasing the slot", async () => {
+    const { events, slotEvents, store } = fakeStore();
+    store.markRunning = async () => {
+      throw new Error("status write failed");
+    };
+    const { calls, provider } = fakeProvider();
+
+    await expect(
+      executeContainerProvision(
+        job({ containerId: "container-1", organizationId: "org-1", userId: "user-1" }),
+        { provider, store },
+      ),
+    ).rejects.toThrow("status write failed");
+
+    expect(calls.map((call) => call.op)).toEqual(["provision", "delete"]);
+    expect(slotEvents).toEqual([
+      { op: "claim", nodeId: "node-1" },
+      { op: "rollback", nodeId: "node-1" },
+    ]);
+    expect(events).toEqual([{ op: "error", id: "container-1", info: "status write failed" }]);
+  });
+
+  test("failed Docker rollback keeps the slot claimed for retry reconciliation", async () => {
+    const { slotEvents, store } = fakeStore();
+    store.markRunning = async () => {
+      throw new Error("status write failed");
+    };
+    const { provider } = fakeProvider({
+      async delete() {
+        throw new Error("ssh unavailable");
+      },
+    });
+
+    await expect(
+      executeContainerProvision(
+        job({ containerId: "container-1", organizationId: "org-1", userId: "user-1" }),
+        { provider, store },
+      ),
+    ).rejects.toThrow("status write failed");
+
+    expect(slotEvents).toEqual([{ op: "claim", nodeId: "node-1" }]);
   });
 
   test("throws when the container row is missing", async () => {

--- a/packages/cloud/shared/src/lib/services/__tests__/container-job-service.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/container-job-service.test.ts
@@ -36,6 +36,12 @@ function fakeDeps() {
     async findDeletingByOrganization() {
       return [ROW];
     },
+    async claimNodeSlot() {
+      return true;
+    },
+    async rollbackNodeSlotClaim() {
+      return true;
+    },
     async markRunning() {},
     async markDeleted() {
       calls.push("markDeleted");
@@ -43,9 +49,16 @@ function fakeDeps() {
     async markError() {},
   };
   const provider = {
+    targetNodeId: "node-1",
     async provision() {
       calls.push("provision");
-      return { containerId: "c", hostPort: 1, network: "n" };
+      return {
+        containerId: "c",
+        hostPort: 1,
+        network: "n",
+        nodeId: "node-1",
+        nodeHost: "node.example.test",
+      };
     },
     async delete() {
       calls.push("delete");

--- a/packages/cloud/shared/src/lib/services/app-container-provider.ts
+++ b/packages/cloud/shared/src/lib/services/app-container-provider.ts
@@ -31,6 +31,8 @@ export interface AppContainerSsh {
 
 export interface AppContainerProviderDeps {
   ssh: AppContainerSsh;
+  /** Durable scheduler identity for the SSH target. */
+  nodeId: string;
   /** Allocate an external host port to map to the container's app port. */
   allocateHostPort: () => Promise<number>;
   /** Optional egress proxy URL routed into the container. */
@@ -63,6 +65,7 @@ export interface ProvisionedAppContainer {
   containerId: string;
   hostPort: number;
   network: string;
+  nodeId: string;
   /** The node the container runs on (for ingress routing + placement). */
   nodeHost: string;
 }
@@ -92,9 +95,11 @@ export function parseUsedHostPorts(dockerPsPortsOutput: string): Set<number> {
 
 export class AppContainerProvider {
   private readonly deps: AppContainerProviderDeps;
+  readonly targetNodeId: string;
 
   constructor(deps: AppContainerProviderDeps) {
     this.deps = deps;
+    this.targetNodeId = deps.nodeId;
   }
 
   /** Ensure the per-app `--internal` network, create the container, start it. */
@@ -177,9 +182,27 @@ export class AppContainerProvider {
 
     const stdout = await this.deps.ssh.exec(createCmd);
     const containerId = (this.deps.extractContainerId ?? defaultExtractContainerId)(stdout);
-    await this.deps.ssh.exec(`docker start ${shellQuote(params.containerName)}`);
+    try {
+      await this.deps.ssh.exec(`docker start ${shellQuote(params.containerName)}`);
+    } catch (error) {
+      await this.delete(params.containerName).catch((cleanupError) => {
+        // error-policy:J6 failed-start cleanup is best-effort; the start failure still propagates to the slot rollback boundary.
+        logger.warn("[AppContainerProvider] Failed to remove container after start failure", {
+          appId: params.appId,
+          containerName: params.containerName,
+          error: describeAppContainerError(cleanupError),
+        });
+      });
+      throw error;
+    }
 
-    return { containerId, hostPort, network, nodeHost: this.deps.nodeHost ?? "" };
+    return {
+      containerId,
+      hostPort,
+      network,
+      nodeId: this.targetNodeId,
+      nodeHost: this.deps.nodeHost ?? "",
+    };
   }
 
   async delete(containerName: string): Promise<void> {

--- a/packages/cloud/shared/src/lib/services/app-container-record.ts
+++ b/packages/cloud/shared/src/lib/services/app-container-record.ts
@@ -1,0 +1,22 @@
+/** Maps app deployment requests onto persistent container rows without loading runtime services. */
+
+import type { NewContainer } from "../../db/schemas/containers";
+import type { NewAppContainerRow } from "./app-deploy-orchestrator";
+
+/** Preserves app ownership, image, port, and tenant database environment at persistence. */
+export function toNewContainer(row: NewAppContainerRow): NewContainer {
+  return {
+    name: row.containerName,
+    // project_name is the durable app identity consumed by delete recovery and
+    // the partial per-project uniqueness constraint.
+    project_name: row.appId,
+    organization_id: row.organizationId,
+    user_id: row.userId,
+    image_tag: row.image,
+    port: row.port,
+    // Database credentials belong to the app tenant, never the shared agent DB.
+    environment_vars: row.environmentVars,
+    metadata: { appId: row.appId },
+    status: "pending",
+  };
+}

--- a/packages/cloud/shared/src/lib/services/app-container-store-queries.ts
+++ b/packages/cloud/shared/src/lib/services/app-container-store-queries.ts
@@ -1,11 +1,12 @@
 /**
- * Defines the app-container row projection and ownership-scoped reads independently
- * of the process database singleton so real Postgres tests can inject an isolated DB.
+ * Defines app-container reads and slot-accounting transactions independently of
+ * the process database singleton so real Postgres tests can inject an isolated DB.
  */
 
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import type { dbWrite } from "../../db/helpers";
 import { containers } from "../../db/schemas/containers";
+import { dockerNodes } from "../../db/schemas/docker-nodes";
 
 export interface ProjectableContainerRow {
   id: string;
@@ -17,6 +18,7 @@ export interface ProjectableContainerRow {
   user_id: string;
   environment_vars: Record<string, string> | null;
   metadata: Record<string, unknown> | null;
+  node_id: string | null;
 }
 
 const appContainerSelection = {
@@ -29,9 +31,13 @@ const appContainerSelection = {
   user_id: containers.user_id,
   environment_vars: containers.environment_vars,
   metadata: containers.metadata,
+  node_id: containers.node_id,
 };
 
-type AppContainerReadDatabase = Pick<typeof dbWrite, "select">;
+/** Minimum database surface required by app-container ownership reads. */
+export type AppContainerReadDatabase = Pick<typeof dbWrite, "select">;
+/** Minimum database surface required by atomic slot mutations. */
+export type AppContainerTransactionDatabase = Pick<typeof dbWrite, "transaction">;
 
 export async function findAppContainerRowById(
   database: AppContainerReadDatabase,
@@ -53,4 +59,92 @@ export function findDeletingAppContainerRows(
     .select(appContainerSelection)
     .from(containers)
     .where(and(eq(containers.organization_id, organizationId), eq(containers.status, "deleting")));
+}
+
+/** Atomically attributes a container to a node and reserves one available slot. */
+export function claimAppContainerNodeSlot(
+  database: AppContainerTransactionDatabase,
+  containerId: string,
+  organizationId: string,
+  nodeId: string,
+  capacityError: () => Error,
+): Promise<boolean> {
+  return database.transaction(async (tx) => {
+    const [claimed] = await tx
+      .update(containers)
+      .set({
+        node_id: nodeId,
+        metadata: sql`jsonb_set(coalesce(${containers.metadata}, '{}'::jsonb), '{slotClaimedAt}', to_jsonb(now()::text))`,
+        updated_at: new Date(),
+      })
+      .where(
+        and(
+          eq(containers.id, containerId),
+          eq(containers.organization_id, organizationId),
+          sql`NOT jsonb_exists(coalesce(${containers.metadata}, '{}'::jsonb), 'slotClaimedAt')`,
+          sql`NOT jsonb_exists(coalesce(${containers.metadata}, '{}'::jsonb), 'slotReleasedAt')`,
+        ),
+      )
+      .returning({ id: containers.id });
+
+    if (!claimed) return false;
+
+    const [node] = await tx
+      .update(dockerNodes)
+      .set({
+        allocated_count: sql`${dockerNodes.allocated_count} + 1`,
+        updated_at: new Date(),
+      })
+      .where(
+        and(
+          eq(dockerNodes.node_id, nodeId),
+          eq(dockerNodes.enabled, true),
+          sql`${dockerNodes.allocated_count} < ${dockerNodes.capacity}`,
+        ),
+      )
+      .returning({ nodeId: dockerNodes.node_id });
+
+    // The exception rolls back both attribution and the claim marker. The caller
+    // supplies its domain error so this SQL-only module stays runtime-independent.
+    if (!node) throw capacityError();
+    return true;
+  });
+}
+
+/** Reverses an unstarted container's slot claim without allowing a double decrement. */
+export function rollbackAppContainerNodeSlotClaim(
+  database: AppContainerTransactionDatabase,
+  containerId: string,
+  organizationId: string,
+  nodeId: string,
+): Promise<boolean> {
+  return database.transaction(async (tx) => {
+    const [rolledBack] = await tx
+      .update(containers)
+      .set({
+        node_id: null,
+        metadata: sql`coalesce(${containers.metadata}, '{}'::jsonb) - 'slotClaimedAt'`,
+        updated_at: new Date(),
+      })
+      .where(
+        and(
+          eq(containers.id, containerId),
+          eq(containers.organization_id, organizationId),
+          eq(containers.node_id, nodeId),
+          sql`jsonb_exists(coalesce(${containers.metadata}, '{}'::jsonb), 'slotClaimedAt')`,
+          sql`NOT jsonb_exists(coalesce(${containers.metadata}, '{}'::jsonb), 'slotReleasedAt')`,
+        ),
+      )
+      .returning({ id: containers.id });
+
+    if (!rolledBack) return false;
+    await tx
+      .update(dockerNodes)
+      .set({
+        allocated_count: sql`GREATEST(${dockerNodes.allocated_count} - 1, 0)`,
+        updated_at: new Date(),
+      })
+      .where(eq(dockerNodes.node_id, nodeId));
+    return true;
+  });
 }

--- a/packages/cloud/shared/src/lib/services/app-container-store.ts
+++ b/packages/cloud/shared/src/lib/services/app-container-store.ts
@@ -5,20 +5,48 @@
  * while terminal `deleted` status is required to release organization quota.
  */
 
-import { eq } from "drizzle-orm";
-import { dbRead, dbWrite } from "../../db/helpers";
-import { containersRepository } from "../../db/repositories/containers";
+import { and, eq } from "drizzle-orm";
+import type { dbWrite } from "../../db/helpers";
+import type { containersRepository } from "../../db/repositories/containers";
 import { containers } from "../../db/schemas/containers";
-import { logger } from "../utils/logger";
 import {
+  type AppContainerReadDatabase,
+  type AppContainerTransactionDatabase,
+  claimAppContainerNodeSlot,
   findAppContainerRowById,
   findDeletingAppContainerRows,
   type ProjectableContainerRow,
+  rollbackAppContainerNodeSlotClaim,
 } from "./app-container-store-queries";
 import { deriveAppPublicUrl } from "./app-url";
 import type { AppContainerRow, AppContainerStore } from "./container-job-executors";
 
 export type { ProjectableContainerRow } from "./app-container-store-queries";
+
+type AppContainerWriteDatabase = AppContainerReadDatabase &
+  AppContainerTransactionDatabase &
+  Pick<typeof dbWrite, "update">;
+
+/** Existing container-repository operations used for lifecycle side effects. */
+export type AppContainerStoreRepository = Pick<
+  typeof containersRepository,
+  "tryReleaseNodeSlot" | "update" | "updateStatus"
+>;
+
+/** Structural error metadata translated to ElizaError by runtime composition. */
+export interface AppContainerStoreErrorOptions {
+  code: string;
+  context: Record<string, unknown>;
+  severity: "ephemeral" | "fatal";
+}
+
+/** Injectable persistence and error boundaries for the app-container store. */
+export interface ContainerRepoAppContainerStoreDeps {
+  readDatabase: AppContainerReadDatabase;
+  writeDatabase: AppContainerWriteDatabase;
+  repository: AppContainerStoreRepository;
+  errorFactory: (message: string, options: AppContainerStoreErrorOptions) => Error;
+}
 
 /**
  * Project a `containers` row onto the executor's {@link AppContainerRow}. Pure,
@@ -39,6 +67,7 @@ export function mapContainerRowToAppContainerRow(row: ProjectableContainerRow): 
     organizationId: row.organization_id,
     userId: row.user_id,
     environmentVars: row.environment_vars ?? undefined,
+    nodeId: row.node_id ?? undefined,
   };
 }
 
@@ -65,11 +94,13 @@ export function mergeHostPlacementMetadata(
 
 /** Read/write seam impl over `containersRepository` + a direct id-scoped read. */
 export class ContainerRepoAppContainerStore implements AppContainerStore {
+  constructor(private readonly deps: ContainerRepoAppContainerStoreDeps) {}
+
   async getById(containerId: string): Promise<AppContainerRow | null> {
     // The executor only has the container id (from the job payload), but the
     // repo's findById is org-scoped. Read by primary key directly to recover the
     // full row (incl. organization_id), then project onto AppContainerRow.
-    const row = await findAppContainerRowById(dbRead, containerId);
+    const row = await findAppContainerRowById(this.deps.readDatabase, containerId);
     if (!row) return null;
     return mapContainerRowToAppContainerRow(row);
   }
@@ -77,22 +108,60 @@ export class ContainerRepoAppContainerStore implements AppContainerStore {
   async findDeletingByOrganization(organizationId: string): Promise<AppContainerRow[]> {
     // A recovered legacy job is consumed once, so replica lag must not turn a
     // real deleting row into a terminal no-op.
-    const rows = await findDeletingAppContainerRows(dbWrite, organizationId);
+    const rows = await findDeletingAppContainerRows(this.deps.writeDatabase, organizationId);
     return rows.map(mapContainerRowToAppContainerRow);
+  }
+
+  async claimNodeSlot(
+    containerId: string,
+    organizationId: string,
+    nodeId: string,
+  ): Promise<boolean> {
+    return claimAppContainerNodeSlot(
+      this.deps.writeDatabase,
+      containerId,
+      organizationId,
+      nodeId,
+      () =>
+        this.deps.errorFactory(`Docker node ${nodeId} has no available app-container slot`, {
+          code: "APP_CONTAINER_NODE_CAPACITY_UNAVAILABLE",
+          context: { containerId, organizationId, nodeId },
+          severity: "ephemeral",
+        }),
+    );
+  }
+
+  async rollbackNodeSlotClaim(
+    containerId: string,
+    organizationId: string,
+    nodeId: string,
+  ): Promise<boolean> {
+    return rollbackAppContainerNodeSlotClaim(
+      this.deps.writeDatabase,
+      containerId,
+      organizationId,
+      nodeId,
+    );
   }
 
   async markRunning(
     containerId: string,
     info: { hostContainerId: string; hostPort: number; network: string; nodeHost?: string },
   ): Promise<void> {
-    const [row] = await dbRead
+    const [row] = await this.deps.readDatabase
       .select({ organization_id: containers.organization_id, metadata: containers.metadata })
       .from(containers)
       .where(eq(containers.id, containerId))
       .limit(1);
     if (!row) {
-      logger.warn("[AppContainerStore] markRunning: container not found", { containerId });
-      return;
+      throw this.deps.errorFactory(
+        `App container ${containerId} disappeared before it became running`,
+        {
+          code: "APP_CONTAINER_ROW_MISSING",
+          context: { containerId, transition: "running" },
+          severity: "fatal",
+        },
+      );
     }
 
     // Merge host placement into metadata (no dedicated columns on the 2AM
@@ -106,28 +175,31 @@ export class ContainerRepoAppContainerStore implements AppContainerStore {
 
     // Two writes: status (id-scoped) + metadata/url/last_deployed_at (org-scoped
     // update, which is the only metadata-writing surface the repo exposes).
-    await containersRepository.updateStatus(containerId, "running");
-    await containersRepository.update(containerId, row.organization_id, {
+    await this.deps.repository.updateStatus(containerId, "running");
+    await this.deps.repository.update(containerId, row.organization_id, {
       metadata: nextMetadata,
       last_deployed_at: new Date(),
       ...(endpoint ? { public_hostname: endpoint.hostname, load_balancer_url: endpoint.url } : {}),
     });
   }
 
-  async markDeleted(containerId: string): Promise<void> {
+  async markDeleted(containerId: string, organizationId: string, nodeId?: string): Promise<void> {
     // Terminal "deleted" — the daemon has actually removed the container, so the
     // row must reach a state that does NOT count toward the per-org container
     // quota. `checkQuota`/`createWithQuotaCheck` exclude only `deleting`/`deleted`;
     // a `stopped` row would keep leaking quota across redeploys (the daemon never
     // reuses this row — each deploy creates a fresh one). App containers carry no
     // `volume_path`, so the active_project_volume_unique index never applies here.
-    await containersRepository.updateStatus(containerId, "deleted");
+    if (nodeId) {
+      await this.deps.repository.tryReleaseNodeSlot(containerId, organizationId, nodeId);
+    }
+    await this.deps.writeDatabase
+      .update(containers)
+      .set({ status: "deleted", error_message: null, updated_at: new Date() })
+      .where(and(eq(containers.id, containerId), eq(containers.organization_id, organizationId)));
   }
 
   async markError(containerId: string, error: string): Promise<void> {
-    await containersRepository.updateStatus(containerId, "failed", error);
+    await this.deps.repository.updateStatus(containerId, "failed", error);
   }
 }
-
-/** Singleton — wired into the daemon's container-executor deps. */
-export const appContainerStore: AppContainerStore = new ContainerRepoAppContainerStore();

--- a/packages/cloud/shared/src/lib/services/app-deploy-runner.ts
+++ b/packages/cloud/shared/src/lib/services/app-deploy-runner.ts
@@ -44,9 +44,9 @@
 
 import { appDatabasesRepository } from "../../db/repositories/app-databases";
 import { containersRepository } from "../../db/repositories/containers";
-import type { NewContainer } from "../../db/schemas/containers";
 import { containersEnv } from "../config/containers-env";
 import { logger } from "../utils/logger";
+import { toNewContainer } from "./app-container-record";
 import { resolveAppDatabaseMode } from "./app-database-mode";
 import {
   type AppDeployDeps,
@@ -98,25 +98,6 @@ export interface AppDeployRunnerDeps {
   orgImageNamespaces?: (organizationId: string) => Promise<string[]>;
   /** App listen port. Default 3000. */
   port?: number;
-}
-
-/** Map the orchestrator's NewAppContainerRow onto a `containers` insert. */
-export function toNewContainer(row: NewAppContainerRow): NewContainer {
-  return {
-    name: row.containerName,
-    // project_name = appId so the executor's AppContainerStore can recover the
-    // appId from the row, and so the partial unique index keys per-app.
-    project_name: row.appId,
-    organization_id: row.organizationId,
-    user_id: row.userId,
-    image_tag: row.image,
-    port: row.port,
-    // The app's OWN isolated DSN rides here — never the shared agent DATABASE_URL.
-    environment_vars: row.environmentVars,
-    // Stash appId in metadata too (belt-and-suspenders for the store's getById).
-    metadata: { appId: row.appId },
-    status: "pending",
-  };
 }
 
 export async function resolveImageRef(

--- a/packages/cloud/shared/src/lib/services/container-executor-deps.ts
+++ b/packages/cloud/shared/src/lib/services/container-executor-deps.ts
@@ -17,12 +17,15 @@
  */
 
 import { Buffer } from "node:buffer";
+import { ElizaError } from "@elizaos/core";
+import { dbRead, dbWrite } from "../../db/helpers";
+import { containersRepository } from "../../db/repositories/containers";
 import { containersEnv } from "../config/containers-env";
 import { logger } from "../utils/logger";
 import { isValidUUID } from "../utils/validation";
 import { decideBuilderArming, selectBuilderHost } from "./app-builder-host";
 import { AppContainerProvider, type AppContainerSsh } from "./app-container-provider";
-import { appContainerStore } from "./app-container-store";
+import { ContainerRepoAppContainerStore } from "./app-container-store";
 import type { BuildExec } from "./app-image-builder";
 import { waitForUrlReachable } from "./app-reachability";
 import { appsService } from "./apps";
@@ -178,17 +181,32 @@ export function buildContainerExecutorDeps(): ContainerExecutorDeps {
   }
   const ssh = makeNodeSsh();
   const nodeHost = selectNodeHost();
+  const nodeId = parseSeedNodeIdOrNull();
+  if (!nodeId) {
+    throw new ElizaError("CONTAINERS_DOCKER_NODES has no durable node id", {
+      code: "APP_CONTAINER_NODE_ID_MISSING",
+      context: { seedNodesConfigured: Boolean(containersEnv.seedNodes()) },
+      severity: "fatal",
+    });
+  }
   const egressProxyUrl = process.env.CONTAINERS_EGRESS_PROXY_URL || undefined;
   // The DB ambassador's egress network (it reaches the tenant DB) + socat image.
   const dbEgressNetwork = process.env.APPS_DB_EGRESS_NETWORK || undefined;
   const ambassadorImage = process.env.APPS_DB_AMBASSADOR_IMAGE || undefined;
   const provider = new AppContainerProvider({
     ssh,
+    nodeId,
     allocateHostPort,
     egressProxyUrl,
     dbEgressNetwork,
     ambassadorImage,
     nodeHost,
+  });
+  const store = new ContainerRepoAppContainerStore({
+    readDatabase: dbRead,
+    writeDatabase: dbWrite,
+    repository: containersRepository,
+    errorFactory: (message, options) => new ElizaError(message, options),
   });
 
   // Ingress route hooks — wired only when a Caddy admin URL is configured.
@@ -210,14 +228,15 @@ export function buildContainerExecutorDeps(): ContainerExecutorDeps {
     : {};
 
   logger.info("[container-executor-deps] built apps container backend", {
-    node: nodeHost,
+    nodeId,
+    nodeHost,
     egressProxy: Boolean(egressProxyUrl),
     dbEgressNetwork: dbEgressNetwork ?? "bridge",
     ingress: Boolean(caddyAdminUrl),
   });
   return {
     provider,
-    store: appContainerStore,
+    store,
     // Verified custom domains for the app -> bare hostnames, folded into the
     // ingress route's host-match. Reuses the existing CORS verified-origin query
     // (status='active' AND verified=true); only invoked when ingress is wired.

--- a/packages/cloud/shared/src/lib/services/container-job-executors.ts
+++ b/packages/cloud/shared/src/lib/services/container-job-executors.ts
@@ -36,17 +36,24 @@ export interface AppContainerRow {
   userId: string;
   /** Caller env incl. the app's per-tenant DATABASE_URL (never the shared one). */
   environmentVars?: Record<string, string>;
+  nodeId?: string;
 }
 
 /** Read/write seam for app container state (over the `containers` table). */
 export interface AppContainerStore {
   getById(containerId: string): Promise<AppContainerRow | null>;
   findDeletingByOrganization(organizationId: string): Promise<AppContainerRow[]>;
+  claimNodeSlot(containerId: string, organizationId: string, nodeId: string): Promise<boolean>;
+  rollbackNodeSlotClaim(
+    containerId: string,
+    organizationId: string,
+    nodeId: string,
+  ): Promise<boolean>;
   markRunning(
     containerId: string,
     info: { hostContainerId: string; hostPort: number; network: string; nodeHost?: string },
   ): Promise<void>;
-  markDeleted(containerId: string): Promise<void>;
+  markDeleted(containerId: string, organizationId: string, nodeId?: string): Promise<void>;
   markError(containerId: string, error: string): Promise<void>;
 }
 
@@ -118,6 +125,7 @@ export async function executeContainerProvision(
     port: row.port,
     environmentVars: row.environmentVars,
   });
+  await deps.store.claimNodeSlot(containerId, row.organizationId, deps.provider.targetNodeId);
   // PROVISION + markRunning: a failure HERE means no container is running, so the
   // row is a true provision failure -> markError (reapable/retryable). Only this
   // span is allowed to flip the row to `failed`.
@@ -128,6 +136,17 @@ export async function executeContainerProvision(
       containerName: row.containerName,
       input,
     });
+  } catch (error) {
+    await deps.store.rollbackNodeSlotClaim(
+      containerId,
+      row.organizationId,
+      deps.provider.targetNodeId,
+    );
+    await deps.store.markError(containerId, error instanceof Error ? error.message : String(error));
+    throw error;
+  }
+
+  try {
     await deps.store.markRunning(containerId, {
       hostContainerId: result.containerId,
       hostPort: result.hostPort,
@@ -135,6 +154,21 @@ export async function executeContainerProvision(
       nodeHost: result.nodeHost,
     });
   } catch (error) {
+    try {
+      await deps.provider.delete(row.containerName);
+      await deps.store.rollbackNodeSlotClaim(
+        containerId,
+        row.organizationId,
+        deps.provider.targetNodeId,
+      );
+    } catch (cleanupError) {
+      // error-policy:J6 failed provision rollback remains visible and keeps its slot claimed until retry/reconciliation.
+      logger.error("[ContainerExecutor] failed to remove container after running-state write", {
+        containerId,
+        nodeId: result.nodeId,
+        error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+      });
+    }
     await deps.store.markError(containerId, error instanceof Error ? error.message : String(error));
     throw error;
   }
@@ -207,7 +241,11 @@ export async function executeContainerDelete(
   job: JobLike,
   deps: ContainerExecutorDeps,
 ): Promise<void> {
-  let targets: Array<{ id: string; row: AppContainerRow | null }>;
+  let targets: Array<{
+    id: string;
+    organizationId: string;
+    row: AppContainerRow | null;
+  }>;
   if (isContainerDeleteJobData(job.data)) {
     const row = await deps.store.getById(job.data.containerId);
     if (row && row.organizationId !== job.data.organizationId) {
@@ -225,11 +263,11 @@ export async function executeContainerDelete(
         },
       );
     }
-    targets = [{ id: job.data.containerId, row }];
+    targets = [{ id: job.data.containerId, organizationId: job.data.organizationId, row }];
   } else {
     const organizationId = recoverableDeleteOrganizationId(job);
     const rows = await deps.store.findDeletingByOrganization(organizationId);
-    targets = rows.map((row) => ({ id: row.id, row }));
+    targets = rows.map((row) => ({ id: row.id, organizationId, row }));
     logger.warn("[ContainerExecutor] recovering malformed container delete job", {
       jobId: job.id,
       organizationId,
@@ -237,7 +275,7 @@ export async function executeContainerDelete(
     });
   }
 
-  for (const { id, row } of targets) {
+  for (const { id, organizationId, row } of targets) {
     if (row) {
       try {
         await deps.provider.delete(row.containerName);
@@ -263,7 +301,7 @@ export async function executeContainerDelete(
         });
       });
     }
-    await deps.store.markDeleted(id);
+    await deps.store.markDeleted(id, organizationId, row?.nodeId);
   }
 }
 

--- a/packages/cloud/shared/src/lib/services/docker-node-workload-queries.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workload-queries.ts
@@ -1,0 +1,51 @@
+/**
+ * Counts active Docker-node workloads through an injected database so runtime
+ * reconciliation and isolated Postgres integration tests execute the same query.
+ */
+
+import { and, eq, sql } from "drizzle-orm";
+import type { dbRead } from "../../db/helpers";
+import { agentSandboxes } from "../../db/schemas/agent-sandboxes";
+import { containers } from "../../db/schemas/containers";
+
+/** Sandbox states that no longer consume a live Docker slot. */
+export const TERMINAL_SANDBOX_STATUSES = [
+  "stopped",
+  "error",
+  "sleeping",
+  "deletion_failed",
+] as const;
+
+type WorkloadCountDatabase = Pick<typeof dbRead, "select">;
+
+/** Counts live app and agent rows assigned to one Docker node. */
+export async function countAllocatedWorkloadsOnNodeWithDatabase(
+  database: WorkloadCountDatabase,
+  nodeId: string,
+): Promise<number> {
+  const [[containerRow], [agentRow]] = await Promise.all([
+    database
+      .select({ count: sql<number>`count(*)::int` })
+      .from(containers)
+      .where(
+        and(
+          eq(containers.node_id, nodeId),
+          sql`${containers.status} not in ('failed','stopped','deleted')`,
+        ),
+      ),
+    database
+      .select({ count: sql<number>`count(*)::int` })
+      .from(agentSandboxes)
+      .where(
+        and(
+          eq(agentSandboxes.node_id, nodeId),
+          sql`${agentSandboxes.status} not in (${sql.join(
+            TERMINAL_SANDBOX_STATUSES.map((status) => sql`${status}`),
+            sql`, `,
+          )})`,
+        ),
+      ),
+  ]);
+
+  return containerRow.count + agentRow.count;
+}

--- a/packages/cloud/shared/src/lib/services/docker-node-workloads.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workloads.ts
@@ -3,6 +3,10 @@ import { and, eq, inArray, sql } from "drizzle-orm";
 import { dbRead } from "../../db/helpers";
 import { agentSandboxes } from "../../db/schemas/agent-sandboxes";
 import { containers } from "../../db/schemas/containers";
+import {
+  countAllocatedWorkloadsOnNodeWithDatabase,
+  TERMINAL_SANDBOX_STATUSES,
+} from "./docker-node-workload-queries";
 import { AGENT_CONTAINER_NAME_PREFIX } from "./docker-sandbox-utils";
 import {
   type LiveContainerRef,
@@ -32,12 +36,7 @@ async function countRows(query: Promise<Array<{ count: number }>>): Promise<numb
  * agent_delete job is actively in flight and owns the teardown; reaping under
  * it would race the worker.
  */
-const TERMINAL_SANDBOX_STATUSES = new Set<string>([
-  "stopped",
-  "error",
-  "sleeping",
-  "deletion_failed",
-]);
+const TERMINAL_SANDBOX_STATUS_SET = new Set<string>(TERMINAL_SANDBOX_STATUSES);
 
 /**
  * Active compute slots on a Docker node.
@@ -56,35 +55,7 @@ const TERMINAL_SANDBOX_STATUSES = new Set<string>([
  * container is up but unreachable) and still occupies the slot.
  */
 export async function countAllocatedWorkloadsOnNode(nodeId: string): Promise<number> {
-  const [containerCount, agentCount] = await Promise.all([
-    countRows(
-      dbRead
-        .select({ count: sql<number>`count(*)::int` })
-        .from(containers)
-        .where(
-          and(
-            eq(containers.node_id, nodeId),
-            sql`${containers.status} not in ('failed','stopped','deleted')`,
-          ),
-        ),
-    ),
-    countRows(
-      dbRead
-        .select({ count: sql<number>`count(*)::int` })
-        .from(agentSandboxes)
-        .where(
-          and(
-            eq(agentSandboxes.node_id, nodeId),
-            sql`${agentSandboxes.status} not in (${sql.join(
-              [...TERMINAL_SANDBOX_STATUSES].map((status) => sql`${status}`),
-              sql`, `,
-            )})`,
-          ),
-        ),
-    ),
-  ]);
-
-  return containerCount + agentCount;
+  return countAllocatedWorkloadsOnNodeWithDatabase(dbRead, nodeId);
 }
 
 // ---------------------------------------------------------------------------
@@ -156,7 +127,7 @@ async function loadSandboxStatusesByIds(agentIds: readonly string[]): Promise<Li
 const AGENT_ORPHAN_RECONCILER_CONFIG: OrphanReconcilerConfig = {
   prefix: AGENT_CONTAINER_NAME_PREFIX,
   keyOf: agentIdFromContainerName,
-  terminalStatuses: TERMINAL_SANDBOX_STATUSES,
+  terminalStatuses: TERMINAL_SANDBOX_STATUS_SET,
   loadStatuses: loadSandboxStatusesByIds,
   logScope: "orphan-reconciler",
   nodeAware: true,


### PR DESCRIPTION
# Relates to

Relates to #15793. The issue remains open for staging deploy/delete proof.

# Sync with develop

- [x] Rebased onto current `origin/develop` (`28ae6126ec7`).
- [x] `bun install --frozen-lockfile --ignore-scripts` completed with no lock changes.
- [x] Package typecheck, diff-scoped error-policy audit, and test-realness audit pass.

# What changed

- Carries the configured Docker node ID through app-container provisioning and persists it on `containers.node_id`.
- Atomically claims one enabled node slot before Docker creation, rejecting missing/full nodes without leaving attribution or claim metadata behind.
- Rolls a claim back exactly once when provisioning fails; after a running-state write failure, Docker cleanup must succeed before the slot is released.
- Releases the slot through the existing one-way `metadata.slotReleasedAt` transaction when deletion succeeds.
- Makes Docker start failure remove the created container before propagating.
- Extracts the authoritative live-workload count behind an injected database seam so production reconciliation and real PGlite tests execute the same query.
- Makes the persistence store injectable and fail-fast when its row disappears, while runtime composition still produces structured `ElizaError` failures.

# Invariants

- Node attribution and `allocated_count` commit in one transaction.
- Duplicate claim/rollback/release calls cannot double-increment or double-decrement.
- A failed Docker cleanup preserves the slot claim for retry/reconciliation rather than making occupied capacity look free.
- App rows now participate in the same authoritative node workload count as agent sandboxes.

# Testing

- Post-rebase focused store/provider/executor/reconciliation suite: 59 passed, 0 failed, 153 assertions across 7 files.
- Enforced changed-file coverage: 97.39% mean; app-container persistence/query and workload query modules are 100%.
- Clean-core-dist PGlite import/run: 4 passed, proving the coverage path does not depend on prebuilt core artifacts.
- Complete cloud-shared suite: 4,313 passed, 61 explicitly live-gated skips, one unrelated `pricing-fallback.test.ts` setup timeout across 533 files; isolated rerun passed 3/3.
- `bun run --cwd packages/cloud/shared typecheck`: pass.
- Error-policy ratchet: no new fallback slop.
- Test-realness audit: 0 regressions.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - daemon/database behavior only; no UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - daemon/database behavior only; no UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no frontend flow.
<!-- evidence-row:backend-logs -->
- [x] https://github.com/elizaOS/eliza/issues/15793#issuecomment-4930355839 - focused, coverage, clean-workspace, and full-suite logs.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend behavior.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, provider, or LLM behavior.
<!-- evidence-row:domain-artifacts -->
- [x] https://github.com/elizaOS/eliza/issues/15793#issuecomment-4930355839 - reviewed PGlite node attribution, claim, rollback, capacity refusal, workload count, and exactly-once release artifacts.

# Known gap

Staging deployment authority and credentials are outside this code lane. After deployment, the issue still requires a real app deploy/delete capture showing the Docker runtime, `containers.node_id`/slot markers, and `docker_nodes.allocated_count` before and after. This PR therefore relates to rather than closes #15793.