### PR TITLE
fix(lifeops): report telemetry mirror failures

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/repository-telemetry-mirror.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/repository-telemetry-mirror.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Exercises the activity-signal telemetry mirror against a real repository
+ * boundary with a deterministic failing SQL adapter.
+ */
+
+import { ElizaError, type IAgentRuntime } from "@elizaos/core";
+import type { LifeOpsActivitySignal } from "@elizaos/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetSignalSourceRegistryForTests,
+  createSignalSourceRegistry,
+  registerSignalSourceRegistry,
+} from "./registries/signal-source-registry.js";
+import { LifeOpsRepository } from "./repository.js";
+import { registerBuiltinSignalSources } from "./telemetry-mapping.js";
+
+function activitySignal(): LifeOpsActivitySignal {
+  return {
+    id: "signal-telemetry-mirror-failure",
+    agentId: "agent-telemetry-mirror-failure",
+    source: "desktop_interaction",
+    platform: "macos_desktop",
+    state: "active",
+    observedAt: "2026-07-09T20:00:00.000Z",
+    idleState: null,
+    idleTimeSeconds: 3,
+    onBattery: null,
+    health: null,
+    metadata: {},
+    createdAt: "2026-07-09T20:00:00.000Z",
+  };
+}
+
+describe("LifeOpsRepository activity telemetry mirror", () => {
+  let runtime: IAgentRuntime | undefined;
+
+  afterEach(() => {
+    if (runtime) __resetSignalSourceRegistryForTests(runtime);
+  });
+
+  it("reports a typed mirror failure after preserving the primary signal insert", async () => {
+    const mirrorFailure = new Error("telemetry database unavailable");
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: [] })
+      .mockRejectedValueOnce(mirrorFailure);
+    const reportError = vi.fn();
+    runtime = {
+      adapter: { db: { execute } },
+      reportError,
+    } as unknown as IAgentRuntime;
+    const registry = createSignalSourceRegistry();
+    registerBuiltinSignalSources(registry);
+    registerSignalSourceRegistry(runtime, registry);
+
+    await expect(
+      new LifeOpsRepository(runtime).createActivitySignal(activitySignal()),
+    ).resolves.toBeUndefined();
+
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(reportError).toHaveBeenCalledTimes(1);
+    const [scope, reported] = reportError.mock.calls[0] as [string, ElizaError];
+    expect(scope).toBe("lifeops.repository.telemetry-mirror");
+    expect(reported).toBeInstanceOf(ElizaError);
+    expect(reported.code).toBe(
+      "LIFEOPS_ACTIVITY_SIGNAL_TELEMETRY_MIRROR_FAILED",
+    );
+    expect(reported.cause).toBe(mirrorFailure);
+    expect(reported.context).toMatchObject({
+      agentId: "agent-telemetry-mirror-failure",
+      source: "desktop_interaction",
+      platform: "macos_desktop",
+      consecutiveFailures: 1,
+    });
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/repository-telemetry-mirror.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/repository-telemetry-mirror.test.ts
@@ -4,7 +4,10 @@
  */
 
 import { ElizaError, type IAgentRuntime } from "@elizaos/core";
-import type { LifeOpsActivitySignal } from "@elizaos/shared";
+import type {
+  LifeOpsActivitySignal,
+  LifeOpsTelemetryPayload,
+} from "@elizaos/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   __resetSignalSourceRegistryForTests,
@@ -12,7 +15,6 @@ import {
   registerSignalSourceRegistry,
 } from "./registries/signal-source-registry.js";
 import { LifeOpsRepository } from "./repository.js";
-import { registerBuiltinSignalSources } from "./telemetry-mapping.js";
 
 function activitySignal(): LifeOpsActivitySignal {
   return {
@@ -50,7 +52,19 @@ describe("LifeOpsRepository activity telemetry mirror", () => {
       reportError,
     } as unknown as IAgentRuntime;
     const registry = createSignalSourceRegistry();
-    registerBuiltinSignalSources(registry);
+    registry.register({
+      source: "desktop_interaction",
+      description: "Deterministic repository telemetry fixture.",
+      contributor: "test",
+      telemetryMapper: (signal): LifeOpsTelemetryPayload => ({
+        family: "desktop_idle_sample",
+        platform: "macos_desktop",
+        idleSeconds: signal.idleTimeSeconds ?? 0,
+        source: "iokit_hid",
+        isThresholdCrossing: false,
+      }),
+      reliability: () => 1,
+    });
     registerSignalSourceRegistry(runtime, registry);
 
     await expect(

--- a/plugins/plugin-personal-assistant/src/lifeops/repository.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/repository.ts
@@ -3922,6 +3922,7 @@ export class LifeOpsRepository {
       }
       LifeOpsRepository.telemetryMirrorFailures.delete(signal.agentId);
     } catch (error) {
+      // error-policy:J7 telemetry mirror diagnostics must not block the durable signal row
       const nextCount =
         (LifeOpsRepository.telemetryMirrorFailures.get(signal.agentId) ?? 0) +
         1;
@@ -3938,6 +3939,20 @@ export class LifeOpsRepository {
           "[lifeops] Telemetry mirror failed for activity signal.",
         );
       }
+      this.runtime.reportError(
+        "lifeops.repository.telemetry-mirror",
+        new ElizaError("Telemetry mirror failed for activity signal.", {
+          code: "LIFEOPS_ACTIVITY_SIGNAL_TELEMETRY_MIRROR_FAILED",
+          context: {
+            agentId: signal.agentId,
+            source: signal.source,
+            platform: signal.platform,
+            consecutiveFailures: nextCount,
+          },
+          cause: error,
+          severity: "ephemeral",
+        }),
+      );
     }
   }
 


### PR DESCRIPTION
Fixes #15820. Refs #14690.

## Summary

Forensic analysis found one semantically important hunk stranded after the passive-signal registry merge. The primary activity-signal insert intentionally survives a telemetry-mirror failure, but current `develop` only warns and continues; the failure never reaches `runtime.reportError`, the agent `RECENT_ERRORS` provider, or repeated-failure escalation.

This restores the J7 diagnostic boundary with a typed `ElizaError` carrying the agent, source, platform, consecutive-failure count, severity, and original cause. The durable signal insert and throttled warning behavior remain unchanged.

## Verification

- new repository-boundary regression: 1/1 pass
- regression uses the real `LifeOpsRepository` and registry with a deterministic SQL adapter: primary insert succeeds, mirror insert fails, method resolves, and `reportError` receives the typed cause/context
- package typecheck: pass
- Biome: pass
- error-policy ratchet: pass
- diff check: pass

## Evidence

<!-- evidence-row:before-screenshots -->
Before screenshots: N/A - server diagnostic path only; no UI changed.

<!-- evidence-row:after-screenshots -->
After screenshots: N/A - server diagnostic path only; no UI changed.

<!-- evidence-row:walkthrough-video -->
Walkthrough video: N/A - no user-facing visual flow changed.

<!-- evidence-row:backend-logs -->
Backend logs: N/A - deterministic repository failure-path test; no long-running backend process was required.

<!-- evidence-row:frontend-logs -->
Frontend logs: N/A - no frontend code changed.

<!-- evidence-row:llm-trajectory -->
Real-LLM trajectory: N/A - no prompt/model/action/provider decision behavior changed; this restores diagnostic reporting for a storage failure.

<!-- evidence-row:domain-artifacts -->
Domain artifacts: N/A - the test uses a deterministic SQL adapter and retains no persistent rows; it proves the primary insert precedes the failed mirror and remains non-fatal.