### PR TITLE
fix(ci): resolve changed Bun tests from source exports (#15827)

### DIFF
--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -117,7 +117,9 @@ jobs:
             echo "no changed Bun-native test files; skipping coverage run"
             exit 0
           fi
-          bun test "${changed_tests[@]}" --coverage --coverage-reporter=lcov --coverage-dir=coverage/bun
+          # This lane runs before workspace builds, so package defaults point at
+          # absent dist files; source exports keep changed tests self-contained.
+          bun test --conditions=eliza-source "${changed_tests[@]}" --coverage --coverage-reporter=lcov --coverage-dir=coverage/bun
         env:
           # Tests must produce coverage/lcov.info. If a package emits to a
           # different path, surface it here.

--- a/packages/scripts/__tests__/coverage-workflow-source-condition.test.ts
+++ b/packages/scripts/__tests__/coverage-workflow-source-condition.test.ts
@@ -1,0 +1,18 @@
+/**
+ * Pins the clean-checkout coverage lane to source workspace exports so changed
+ * Bun tests do not depend on prebuilt package artifacts.
+ */
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const workflowPath = fileURLToPath(
+  new URL("../../../.github/workflows/coverage-gate.yml", import.meta.url),
+);
+
+test("changed Bun coverage tests use eliza-source workspace exports", () => {
+  const workflow = readFileSync(workflowPath, "utf8");
+  expect(workflow).toMatch(
+    /bun test --conditions=eliza-source "\$\{changed_tests\[@\]\}" --coverage/,
+  );
+});


### PR DESCRIPTION
Fixes #15827.

## Problem

The changed-file coverage job installs the workspace before any package build, then ran Bun-native changed tests under default package export conditions. Workspace imports such as `@elizaos/core` therefore resolved to absent `dist` files. #15810 reproduced this as `Cannot find module '@elizaos/core' from plugins/plugin-sql/src/index.ts` before its first wake-integrity assertion.

## Fix

Run the Bun coverage command with `--conditions=eliza-source`, matching the clean-checkout source-resolution repair already used by the scenario coverage lanes in #15797. A workflow contract test pins the flag so it cannot silently disappear.

## Verification

Fresh worktree from current `develop`, `bun install --frozen-lockfile --ignore-scripts`, no `packages/core/dist`:

- old exact command: exit 1 before tests (`Cannot find module '@elizaos/core'`)
- after the setup action's keyword-generation equivalent, new exact command: 24 passed, 0 failed, 143 assertions
- real LCOV produced: 2,186,025 bytes at `coverage/bun/lcov.info`
- workflow contract test: 1 passed
- focused Biome and `git diff --check`: clean

## Evidence

<!-- evidence-row:before-screenshots -->
Before screenshots: N/A - CI command resolution only; no rendered UI.

<!-- evidence-row:after-screenshots -->
After screenshots: N/A - no visual surface changed.

<!-- evidence-row:walkthrough-video -->
Walkthrough video: N/A - headless CI workflow fix.

<!-- evidence-row:backend-logs -->
Backend logs: [clean-checkout source-condition run](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15829-source-coverage.log) — 24 passed, 0 failed, 143 assertions.

<!-- evidence-row:frontend-logs -->
Frontend logs: N/A - no frontend runtime changed.

<!-- evidence-row:llm-trajectory -->
Real-LLM trajectory: N/A - no agent, prompt, action, provider, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
Domain artifacts: [LCOV output](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15829-lcov.info) from the real 24-case wake-integrity suite (2,186,025 bytes).

