### PR TITLE
fix(app): consume navigation-preload response on the SW /login + OAuth-callback bypass branch

### DIFF
--- a/packages/app/public/sw.js
+++ b/packages/app/public/sw.js
@@ -190,17 +190,28 @@ self.addEventListener("fetch", (event) => {
     return;
   }
 
-  // Auth navigations are NEVER intercepted: the sign-in page and the OAuth
-  // callback must always load the freshest shell from the network. A stale
-  // cached shell can carry an outdated build — e.g. one baked with the wrong
-  // Steward tenant — which makes the code exchange fail with 401, and caching a
-  // one-time `?code=` callback URL risks replaying a consumed code. Bypassing
-  // (no respondWith) lets the browser fetch directly, uncached.
+  // Auth requests are NEVER cached: the sign-in page and the OAuth callback
+  // must always load the freshest shell from the network. A stale cached
+  // shell can carry an outdated build — e.g. one baked with the wrong
+  // Steward tenant — which makes the code exchange fail with 401, and caching
+  // a one-time `?code=` callback URL risks replaying a consumed code. But a
+  // bare bypass (no respondWith) leaves the navigation-preload response —
+  // already in flight once `activate` enabled preload — unconsumed, so the
+  // browser cancels it, logs a "navigation preload request was cancelled"
+  // warning, and wastes the round trip on the sign-in golden path. Take over
+  // auth navigations as a pure network passthrough instead: consume the
+  // preload when present, else fetch the original request untouched (same
+  // credentials/redirect semantics), touching no cache in either direction.
+  // Non-navigation requests (the browser never preloads those) stay fully
+  // bypassed, which is behavior-identical to a direct browser fetch.
   if (
     pathname === "/login" ||
     url.searchParams.has("code") ||
     url.searchParams.has("token")
   ) {
+    if (request.mode === "navigate") {
+      event.respondWith(networkPassthrough(request, event.preloadResponse));
+    }
     return;
   }
 
@@ -369,6 +380,31 @@ async function networkFirst(request, cacheName, preloadResponsePromise) {
     const cached = await cache.match(request);
     return cached ?? new Response("Offline", { status: 503 });
   }
+}
+
+/**
+ * Pure network passthrough (no cache reads, no cache writes) for auth
+ * navigations (/login and the OAuth callback). Consumes the browser's
+ * navigation-preload response when one was started — leaving it unconsumed
+ * cancels the parallel fetch and logs a "navigation preload request was
+ * cancelled" warning — else fetches the original request untouched, so the
+ * served response is byte-for-byte what the network returns.
+ * `preloadResponse` resolves undefined when preload wasn't started (preload
+ * disabled/unsupported), and older engines don't expose the property at all;
+ * both fall through to the plain fetch.
+ */
+async function networkPassthrough(request, preloadResponsePromise) {
+  try {
+    const preloaded = preloadResponsePromise
+      ? await preloadResponsePromise
+      : undefined;
+    if (preloaded) return preloaded;
+  } catch {
+    // Preload failed or was aborted — fall through to a direct fetch so the
+    // auth navigation is never more fragile than the browser fetch that the
+    // old bypass delegated to.
+  }
+  return fetch(request);
 }
 
 /**

--- a/packages/app/test/service-worker-auth-bypass.test.ts
+++ b/packages/app/test/service-worker-auth-bypass.test.ts
@@ -1,30 +1,82 @@
 /**
- * Service-worker auth navigation guard. The test evaluates the real `sw.js`
- * file inside a minimal worker-like VM so the fetch handler can be exercised
- * without a browser install.
+ * Service-worker auth navigation guard (#15741). The tests evaluate the real
+ * `sw.js` file inside a minimal worker-like VM so the fetch handler can be
+ * exercised without a browser install.
+ *
+ * Contract for /login + OAuth-callback (?code= / ?token=) requests:
+ *  - navigations ARE responded to (respondWith called synchronously), but as
+ *    a pure network passthrough that consumes `event.preloadResponse` —
+ *    leaving the preload unconsumed cancels the browser's parallel fetch and
+ *    logs a "navigation preload request was cancelled" warning on the
+ *    sign-in golden path;
+ *  - when no preload was started (resolves undefined, or the property is
+ *    absent on older engines) the ORIGINAL request goes straight to fetch(),
+ *    preserving credentials/redirect semantics;
+ *  - nothing is ever read from or written to any cache on this path;
+ *  - non-navigation auth-param requests stay fully bypassed (no respondWith).
  */
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import vm from "node:vm";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 
-type FetchEventLike = {
-  request: {
-    method: string;
-    mode: string;
-    url: string;
-    clone: () => FetchEventLike["request"];
-  };
-  respondWith: ReturnType<typeof vi.fn>;
+type RequestLike = {
+  method: string;
+  mode: string;
+  url: string;
+  clone: () => RequestLike;
 };
 
-function loadServiceWorker() {
+type FetchEventLike = {
+  request: RequestLike;
+  preloadResponse?: Promise<Response | undefined>;
+  respondWith: (value: Promise<Response> | Response) => void;
+  _responded?: Promise<Response> | Response;
+  _respondWithCalls: number;
+};
+
+type Harness = {
+  dispatchFetch: (event: FetchEventLike) => void;
+  /** Names of caches the worker opened/created (auth path must open none). */
+  cacheNames: () => string[];
+  /** URLs cached across every cache the worker opened. */
+  cachedUrls: () => string[];
+  /** Requests the worker passed to fetch(). */
+  fetchedRequests: () => RequestLike[];
+};
+
+function loadServiceWorker(): Harness {
   const listeners = new Map<string, ((event: unknown) => void)[]>();
+
+  /** In-memory Cache — enough surface for the strategies sw.js uses. */
+  class FakeCache {
+    entries = new Map<string, Response>();
+    async match(request: RequestLike | string) {
+      const key = typeof request === "string" ? request : request.url;
+      return this.entries.get(key) ?? null;
+    }
+    async put(request: RequestLike | string, response: Response) {
+      const key = typeof request === "string" ? request : request.url;
+      this.entries.set(key, response);
+    }
+    async keys() {
+      return [...this.entries.keys()].map((url) => ({ url }));
+    }
+    async delete(request: RequestLike | string) {
+      const key = typeof request === "string" ? request : request.url;
+      return this.entries.delete(key);
+    }
+  }
+
+  const cacheStore = new Map<string, FakeCache>();
+  const fetchedRequests: RequestLike[] = [];
+
   const self = {
     location: { origin: "https://app.example.test" },
+    registration: {},
     addEventListener(type: string, listener: (event: unknown) => void) {
       listeners.set(type, [...(listeners.get(type) ?? []), listener]);
     },
@@ -34,64 +86,171 @@ function loadServiceWorker() {
       matchAll: () => Promise.resolve([]),
     },
   };
-  const cache = {
-    match: () => Promise.resolve(null),
-    put: () => Promise.resolve(),
-    keys: () => Promise.resolve([]),
-    delete: () => Promise.resolve(true),
-  };
+
   const context = vm.createContext({
     self,
     URL,
     Response,
-    caches: {
-      keys: () => Promise.resolve([]),
-      open: () => Promise.resolve(cache),
-      delete: () => Promise.resolve(true),
-    },
-    fetch: () =>
-      Promise.resolve(new Response("<html></html>", { status: 200 })),
     Promise,
+    caches: {
+      keys: async () => [...cacheStore.keys()],
+      open: async (name: string) => {
+        let cache = cacheStore.get(name);
+        if (!cache) {
+          cache = new FakeCache();
+          cacheStore.set(name, cache);
+        }
+        return cache;
+      },
+      delete: async (name: string) => cacheStore.delete(name),
+    },
+    fetch: async (request: RequestLike) => {
+      fetchedRequests.push(request);
+      return new Response("network-body", { status: 200 });
+    },
   });
+
   const script = readFileSync(path.resolve(here, "../public/sw.js"), "utf8");
   vm.runInContext(script, context, { filename: "sw.js" });
+
   return {
-    dispatchFetch(event: FetchEventLike) {
+    dispatchFetch(event) {
       for (const listener of listeners.get("fetch") ?? []) listener(event);
     },
+    cacheNames: () => [...cacheStore.keys()],
+    cachedUrls: () =>
+      [...cacheStore.values()].flatMap((cache) => [...cache.entries.keys()]),
+    fetchedRequests: () => fetchedRequests,
   };
 }
 
-function navigation(pathname: string): FetchEventLike {
-  const request = {
+function makeFetchEvent(
+  pathname: string,
+  opts?: { mode?: string; preloadResponse?: Promise<Response | undefined> },
+): FetchEventLike {
+  const request: RequestLike = {
     method: "GET",
-    mode: "navigate",
+    mode: opts?.mode ?? "navigate",
     url: `https://app.example.test${pathname}`,
     clone: () => request,
   };
-  return { request, respondWith: vi.fn() };
+  const event: FetchEventLike = {
+    request,
+    respondWith(value) {
+      event._responded = value;
+      event._respondWithCalls += 1;
+    },
+    _respondWithCalls: 0,
+  };
+  if (opts && "preloadResponse" in opts) {
+    event.preloadResponse = opts.preloadResponse;
+  }
+  return event;
 }
 
-describe("service worker auth navigation bypass", () => {
-  it.each([
-    "/login",
-    "/login?code=one-time",
-    "/chat?token=handoff",
-  ])("does not intercept %s", (pathname) => {
+const AUTH_PATHS = ["/login", "/login?code=one-time", "/chat?token=handoff"];
+
+describe("service worker auth navigation passthrough", () => {
+  it.each(
+    AUTH_PATHS,
+  )("consumes the navigation preload response for %s (no second fetch, no cache)", async (pathname) => {
     const worker = loadServiceWorker();
-    const event = navigation(pathname);
+    const preloaded = new Response("preloaded-auth-shell", { status: 200 });
+    const event = makeFetchEvent(pathname, {
+      preloadResponse: Promise.resolve(preloaded),
+    });
 
     worker.dispatchFetch(event);
 
-    expect(event.respondWith).not.toHaveBeenCalled();
+    // respondWith must have been called synchronously inside the handler —
+    // the spec rejects an async respondWith after the dispatch turn ends.
+    expect(event._respondWithCalls).toBe(1);
+
+    const response = await event._responded;
+    // The served response is the preload itself, not a copy or a re-fetch.
+    expect(response).toBe(preloaded);
+    expect(worker.fetchedRequests()).toHaveLength(0);
+    // Pure passthrough: the auth path never opens or writes any cache.
+    expect(worker.cacheNames()).toEqual([]);
+    expect(worker.cachedUrls()).toEqual([]);
   });
 
-  it("still intercepts ordinary app-shell navigations", () => {
+  it.each(
+    AUTH_PATHS,
+  )("falls back to fetching the ORIGINAL request for %s when preload resolves undefined", async (pathname) => {
     const worker = loadServiceWorker();
-    const event = navigation("/chat");
+    // Preload not started (disabled/unsupported): resolves undefined.
+    const event = makeFetchEvent(pathname, {
+      preloadResponse: Promise.resolve(undefined),
+    });
+
+    worker.dispatchFetch(event);
+    expect(event._respondWithCalls).toBe(1);
+
+    const response = await event._responded;
+    expect(await response?.text()).toBe("network-body");
+    // Exactly one network fetch, and it received the original request
+    // object (not a clone/rewrite) so credentials/redirect are preserved.
+    expect(worker.fetchedRequests()).toHaveLength(1);
+    expect(worker.fetchedRequests()[0]).toBe(event.request);
+    expect(worker.cacheNames()).toEqual([]);
+  });
+
+  it("falls back to fetch when the preloadResponse property is absent (older engines)", async () => {
+    const worker = loadServiceWorker();
+    const event = makeFetchEvent("/login"); // no preloadResponse at all
+
+    worker.dispatchFetch(event);
+    expect(event._respondWithCalls).toBe(1);
+
+    const response = await event._responded;
+    expect(await response?.text()).toBe("network-body");
+    expect(worker.fetchedRequests()).toHaveLength(1);
+    expect(worker.fetchedRequests()[0]).toBe(event.request);
+  });
+
+  it("falls back to a direct fetch when the preload rejects", async () => {
+    const worker = loadServiceWorker();
+    const event = makeFetchEvent("/login?code=one-time", {
+      preloadResponse: Promise.reject(new Error("preload aborted")),
+    });
+
+    worker.dispatchFetch(event);
+    expect(event._respondWithCalls).toBe(1);
+
+    const response = await event._responded;
+    expect(await response?.text()).toBe("network-body");
+    expect(worker.fetchedRequests()).toHaveLength(1);
+    expect(worker.fetchedRequests()[0]).toBe(event.request);
+  });
+
+  it.each([
+    ["/api/session?token=handoff", "cors"],
+    ["/api/oauth/exchange?code=one-time", "cors"],
+    ["/login-banner.png?token=x", "no-cors"],
+  ])("still fully bypasses non-navigation auth-param request %s (no respondWith)", (pathname, mode) => {
+    const worker = loadServiceWorker();
+    const event = makeFetchEvent(pathname, { mode });
 
     worker.dispatchFetch(event);
 
-    expect(event.respondWith).toHaveBeenCalledTimes(1);
+    // The browser never starts a preload for non-navigations, so a bare
+    // bypass is behavior-identical to a direct browser fetch here.
+    expect(event._respondWithCalls).toBe(0);
+    expect(event._responded).toBeUndefined();
+    expect(worker.fetchedRequests()).toHaveLength(0);
+  });
+
+  it("still intercepts ordinary app-shell navigations with the caching strategy", async () => {
+    const worker = loadServiceWorker();
+    const event = makeFetchEvent("/chat");
+
+    worker.dispatchFetch(event);
+
+    expect(event._respondWithCalls).toBe(1);
+    const response = await event._responded;
+    expect(await response?.clone().text()).toBe("network-body");
+    // Unlike the auth path, the shell navigation IS cached (network-first).
+    expect(worker.cachedUrls()).toContain("https://app.example.test/chat");
   });
 });


### PR DESCRIPTION
## Summary

Closes #15741.

`packages/app/public/sw.js` enables **navigation preload** in `activate`, but the fetch handler's auth branch (`/login`, `?code=`, `?token=`) returned **without** `respondWith`. On every SW-controlled sign-in / OAuth-callback navigation the browser had already fired the preload fetch; the bare bypass left `event.preloadResponse` unconsumed, so Chromium/WebKit cancel it, log **"The service worker navigation preload request was cancelled before 'preloadResponse' settled…"** on the SW console, and re-issue the same request — a wasted round trip on the most latency-sensitive navigation.

### Fix

Take over **auth navigations** as a pure network passthrough (`networkPassthrough` helper, called synchronously via `respondWith` inside the handler):

- serve `await event.preloadResponse` when the browser started one;
- else `fetch(request)` with the **original request object** (credentials/redirect semantics preserved);
- if the preload rejects, fall back to a direct fetch so the auth path is never more fragile than the browser fetch the old bypass delegated to;
- **no cache is read or written in either direction** — the auth path still always gets byte-for-byte what the network returns (fresh shell; one-time `?code=` never replayed from cache).

Non-navigation auth-param requests (the browser never preloads those) keep the bare bypass — behavior-identical to a direct browser fetch. I audited every other early-`return` in the fetch handler for the same defect class: non-GET, unparseable-URL, and cross-origin returns can never carry a preload (preload fires only for GET navigations matched to this SW's scope), and the plain same-origin-subresource fall-through likewise never preloads — the auth branch was the only navigation-reachable bypass.

No cache-name bump needed: cached content/keys are unchanged, and the SW itself updates by byte-diff with `skipWaiting()` + `clients.claim()` taking over immediately.

## Evidence

### Real-browser before/after — console warning + wasted fetch (real Chromium 1228 via playwright-core, real `sw.js`)

Harness: a local HTTP server serves the **real** `sw.js` (+ real `sw-push.js`) and a minimal shell page (the app build is not required to exercise the SW path); real headless Chromium registers the SW, waits for `activate` (`navigationPreload.getState().enabled === true`, page controlled), then performs the golden-path navigation to `/login?code=one-time`. SW-console captured over a raw CDP WebSocket to the `service_worker` target; every server-side request logged with its `Service-Worker-Navigation-Preload` header.

**BEFORE (develop `sw.js`)** — warning fires, duplicate fetch wasted:

```json
{
  "label": "BEFORE",
  "swControlledBeforeNav": true,
  "navigationPreloadState": { "enabled": true, "headerValue": "true" },
  "servedPage": "/login?code=one-time",
  "loginNavRequestsSeenByServer": [
    { "url": "/login?code=one-time", "preloadHeader": "true" },
    { "url": "/login?code=one-time", "preloadHeader": null }
  ],
  "loginNavRequestCount": 2,
  "cancelledPreloadWarnings": [
    "[sw-log.worker.error] The service worker navigation preload request was cancelled before 'preloadResponse' settled. If you intend to use 'preloadResponse', use waitUntil() or respondWith() to wait for the promise to settle."
  ]
}
```

**AFTER (this PR)** — warning gone, exactly one network request (the consumed preload) serves the page:

```json
{
  "label": "AFTER",
  "swControlledBeforeNav": true,
  "navigationPreloadState": { "enabled": true, "headerValue": "true" },
  "servedPage": "/login?code=one-time",
  "loginNavRequestsSeenByServer": [
    { "url": "/login?code=one-time", "preloadHeader": "true" }
  ],
  "loginNavRequestCount": 1,
  "cancelledPreloadWarnings": []
}
```

The server-side trace doubles as the network-log row: before = 2 hits for the same auth navigation (one preload, cancelled + one direct), after = 1 hit carrying `Service-Worker-Navigation-Preload: true`, consumed and rendered (`servedPage` confirms the navigation landed).

### Regression tests (real `sw.js` evaluated in a worker-like VM — existing harness pattern)

`packages/app/test/service-worker-auth-bypass.test.ts` rewritten to the new contract (11 tests):

- auth navigations (`/login`, `/login?code=`, `/chat?token=`) respond with the **preload response itself** when one was started — `respondWith` called synchronously, zero `fetch()` calls, **zero caches opened or written**;
- fall back to fetching the **original request object** when preload resolves `undefined` (preload disabled), when the `preloadResponse` property is absent (older engines), and when the preload **rejects**;
- non-navigation auth-param requests (`?token=`/`?code=` subresources) stay fully bypassed (no `respondWith`, no fetch);
- ordinary app-shell navigations still go through the caching `networkFirst` strategy.

```
Test Files  4 passed (4)
     Tests  64 passed (64)   # service-worker-auth-bypass (11) + service-worker-cache-strategies (9) + pages-middleware-serving + sw-push
```

- Lint: `bunx @biomejs/biome@2.5.3 check` clean on both touched files.
- Typecheck: new test file compiles clean under `tsc --strict` in isolation; `bun run --cwd packages/app typecheck` carries 407 pre-existing errors in *other* packages (stale shared install in this worktree — missing `@elizaos/auth` build artifacts / `@types/pg`), none referencing the touched files.

### Evidence matrix

| Row | Status |
| --- | --- |
| Before/after browser console | ✅ above — real Chromium SW-console via CDP: warning present before, gone after |
| Frontend network logs | ✅ above — server-side request trace w/ `Service-Worker-Navigation-Preload` header (2 hits → 1 hit) |
| Regression tests | ✅ 11-test rewrite of `service-worker-auth-bypass.test.ts` against the real `sw.js`; adjacent SW suites green |
| Backend structured logs | N/A - no server-side code changed; the SW is client-side and the request trace above is the server-visible behavior |
| Before/after full-page screenshots (desktop + mobile) | N/A - zero rendered-pixel change; the fix is console/network-level SW behavior, and the harness asserts the identical page (`servedPage`) is served on both variants |
| Video walkthrough | N/A - same reason; the user-visible flow (/login renders) is unchanged and proven by the harness `servedPage` assertion |
| Real-LLM trajectories | N/A - no agent/action/provider/prompt/model behavior touched |
| Per-platform capture | N/A - the SW registers only in production **web** builds (`sw-registration.ts` excludes Capacitor/Electrobun); web behavior proven in real Chromium above |
| Audio walkthrough | N/A - no voice/TTS/STT changes |
| Domain artifacts | ✅ the served auth page + request trace above; no DB/memory/on-chain artifacts involved |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Evidence rows

<!-- evidence-row:before-screenshots -->
Before screenshots: N/A - service-worker network behavior only; `public/sw.js` is not a rendered-UI surface file and no pixels change. The BEFORE state is the captured SW-console warning + duplicate server fetch in the JSON evidence above.

<!-- evidence-row:after-screenshots -->
After screenshots: N/A - same as above; the AFTER state is the warning-free SW console + single preload-served fetch in the JSON evidence above.

<!-- evidence-row:walkthrough-video -->
Walkthrough video: N/A - headless CDP harness against real Chromium; the observable behavior is console/network traffic (captured inline above), not a visual flow.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: the harness server request log with `Service-Worker-Navigation-Preload` headers is inline above ([BEFORE/AFTER JSON](#real-browser-beforeafter--console-warning--wasted-fetch-real-chromium-1228-via-playwright-core-real-swjs)) — BEFORE shows the duplicate `/login?code=` fetch, AFTER shows the single preload-served request.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: [raw SW-console capture (inline above)](#real-browser-beforeafter--console-warning--wasted-fetch-real-chromium-1228-via-playwright-core-real-swjs) over the CDP `service_worker` target — BEFORE contains the "navigation preload request was cancelled" warning, AFTER is warning-free.

<!-- evidence-row:llm-trajectory -->
Real-LLM trajectory: N/A - no model, prompt, action, provider, or planner behavior changes.

<!-- evidence-row:domain-artifacts -->
Domain artifacts: N/A - no persisted domain state; the SW cache is intentionally untouched in both directions (byte-equality asserted in `service-worker-auth-bypass.test.ts`).