### PR TITLE
fix(mobile): make hybrid RAM floor mode-aware

### DIFF
--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/DeviceRamTierPolicy.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/DeviceRamTierPolicy.java
@@ -3,13 +3,10 @@ package ai.elizaos.app;
 /**
  * Device RAM-tier policy for the bundled on-device agent (elizaOS/eliza#14390).
  *
- * <p>Low-RAM phones cannot sustain the Bun agent runtime: a 4 GB Moto G Play
- * (2024) wedges boot for the full 180 s startup budget before surfacing a
- * "Backend Timeout" card. The product policy is RAM-driven, not build-driven —
- * a device below the 8 GB marketed-RAM floor is cloud-only and must never spawn
- * the local agent, no matter which APK variant is installed or what runtime
- * mode an older install persisted (the mode survives reinstalls via Capacitor
- * Preferences).
+ * <p>The Bun runtime and local model loading have separate memory costs. A
+ * hybrid runtime that keeps inference in the cloud may run from 4 GB; an
+ * unconfigured/full local runtime retains the 8 GB floor. The renderer owns
+ * the additional 12/16 GB local-model tiers.
  *
  * <p>{@code ActivityManager.MemoryInfo.totalMem} under-reports the marketed
  * capacity because the kernel/carveout reserve a slice (a marketed "4 GB"
@@ -27,7 +24,10 @@ final class DeviceRamTierPolicy {
     private DeviceRamTierPolicy() {
     }
 
-    /** Marketed-RAM floor (GB) below which the on-device agent is disabled. */
+    /** Marketed-RAM floor (GB) for the runtime-only hybrid path. */
+    static final int HYBRID_AGENT_MIN_MARKETED_RAM_GB = 4;
+
+    /** Marketed-RAM floor (GB) for an unconfigured/full local runtime. */
     static final int LOCAL_AGENT_MIN_MARKETED_RAM_GB = 8;
 
     private static final long ONE_GIB = 1L << 30;
@@ -54,5 +54,12 @@ final class DeviceRamTierPolicy {
         int marketed = marketedRamGb(totalMemBytes);
         if (marketed < 0) return true;
         return marketed >= LOCAL_AGENT_MIN_MARKETED_RAM_GB;
+    }
+
+    /** Whether this device may run the agent while inference stays in cloud. */
+    static boolean allowsHybridAgent(long totalMemBytes) {
+        int marketed = marketedRamGb(totalMemBytes);
+        if (marketed < 0) return true;
+        return marketed >= HYBRID_AGENT_MIN_MARKETED_RAM_GB;
     }
 }

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
@@ -3902,30 +3902,15 @@ public class ElizaAgentService extends Service {
     }
 
     /**
-     * Curated stock-Android devices proven to sustain the on-device agent
-     * below the generic {@link DeviceRamTierPolicy} marketed-RAM floor.
-     *
-     * <p>This is deliberately NARROWER than {@link #isBrandedDevice}: it lifts
-     * the RAM floor for {@link #start} only, and does NOT imply the device "is
-     * the agent". A floor-exempt device still honours the user's runtime choice
-     * — a cloud-only pick is respected and the agent does not auto-start (see
-     * {@link #shouldAutoStartForRuntimeMode}, which gates on branding, not this).
-     *
-     * <p>The Light Phone III (manufacturer {@code "Light"}) is a curated,
-     * single-purpose minimalist phone where Eliza is the intended agent. Its
-     * stock LightOS ROM leaves {@code ro.elizaos.product} unset and it ships
-     * ~6 GB RAM. The 8 GB floor exists to stop a 4 GB device wedging boot AND to
-     * keep local MODELS from OOMing; hybrid (cloud-inference) mode mmaps no
-     * local model, and 6 GB is verified sufficient for the agent runtime, so the
-     * LP3 is exempted here rather than forced cloud-only (elizaOS/eliza#14390).
-     *
-     * <p>Package-visible so {@link ElizaNativeBridge} can mirror it to the
-     * renderer's sync RAM gate ({@code device-ram-tier.ts}) — one allowlist,
-     * read on both sides.
+     * Whether the selected persisted mode clears its matching RAM floor. The
+     * cloud-hybrid mode loads no local model, so it uses the 4 GB runtime-only
+     * floor; every other local start retains the 8 GB floor.
      */
-    static boolean isLocalAgentRamFloorExemptDevice() {
-        String manufacturer = android.os.Build.MANUFACTURER;
-        return manufacturer != null && manufacturer.equalsIgnoreCase("Light");
+    static boolean allowsAgentStartForRuntimeMode(String mode, long totalMemBytes) {
+        String trimmed = mode == null ? null : mode.trim();
+        return "cloud-hybrid".equals(trimmed)
+            ? DeviceRamTierPolicy.allowsHybridAgent(totalMemBytes)
+            : DeviceRamTierPolicy.allowsLocalAgent(totalMemBytes);
     }
 
     private static String readRuntimeMode(Context context) {
@@ -3954,24 +3939,25 @@ public class ElizaAgentService extends Service {
      * Start the foreground service (safe to call repeatedly).
      *
      * <p>Throws {@link IllegalStateException} on a stock device below the
-     * {@link DeviceRamTierPolicy} RAM floor (#14390): every start affordance
+     * matching {@link DeviceRamTierPolicy} RAM floor (#14390): every start affordance
      * — the onboarding finish via the Agent Capacitor plugin, the startup
      * poll's revive request, the boot receiver — funnels here, so this is the
      * one fail-loud backstop against a disallowed mode wedging boot. The
      * renderer surfaces the rejection as the onboarding/startup error it
-     * already renders; branded devices ARE the agent and are exempt, as are
-     * curated floor-exempt devices (the LP3 — see
-     * {@link #isLocalAgentRamFloorExemptDevice}).
+     * already renders; branded devices ARE the agent and remain exempt.
      */
     public static void start(Context context) {
         long totalMemBytes = readDeviceTotalMemBytes(context);
+        String mode = readRuntimeMode(context);
         if (!isBrandedDevice()
-                && !isLocalAgentRamFloorExemptDevice()
-                && !DeviceRamTierPolicy.allowsLocalAgent(totalMemBytes)) {
+                && !allowsAgentStartForRuntimeMode(mode, totalMemBytes)) {
+            int requiredRamGb = "cloud-hybrid".equals(mode == null ? null : mode.trim())
+                ? DeviceRamTierPolicy.HYBRID_AGENT_MIN_MARKETED_RAM_GB
+                : DeviceRamTierPolicy.LOCAL_AGENT_MIN_MARKETED_RAM_GB;
             throw new IllegalStateException(
                 "This device (~" + DeviceRamTierPolicy.marketedRamGb(totalMemBytes)
                 + " GB RAM) is below the "
-                + DeviceRamTierPolicy.LOCAL_AGENT_MIN_MARKETED_RAM_GB
+                + requiredRamGb
                 + " GB floor for the on-device agent; use cloud mode");
         }
         Intent intent = new Intent(context, ElizaAgentService.class);

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaNativeBridge.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaNativeBridge.java
@@ -25,6 +25,10 @@ import android.webkit.JavascriptInterface;
  * Surface area is intentionally narrow — only the local agent bearer is
  * exposed, and only the same-origin WebView (which is the same APK uid
  * that owns the token file) can call it.
+ *
+ * RAM policy crosses this bridge as a measured device total only. Eligibility
+ * depends on the selected runtime mode, so the shared renderer/native policy
+ * applies thresholds without exposing manufacturer-specific capability flags.
  */
 public final class ElizaNativeBridge {
 
@@ -65,20 +69,6 @@ public final class ElizaNativeBridge {
         ActivityManager.MemoryInfo info = new ActivityManager.MemoryInfo();
         am.getMemoryInfo(info);
         return info.totalMem > 0 ? info.totalMem / 1_048_576L : -1L;
-    }
-
-    /**
-     * Whether this device is exempt from the on-device-agent RAM floor (#14390)
-     * as a curated agent target (the Light Phone III). Mirrors
-     * {@link ElizaAgentService#isLocalAgentRamFloorExemptDevice} so the
-     * renderer's boot-time RAM-tier gate ({@code device-ram-tier.ts}) can offer
-     * the hybrid runtime on a device that clears the floor by allowlist rather
-     * than by raw RAM. Synchronous like {@link #getDeviceTotalRamMb} — the gate
-     * runs before the Capacitor plugin executor is trustworthy.
-     */
-    @JavascriptInterface
-    public boolean isLocalAgentRamFloorExempt() {
-        return ElizaAgentService.isLocalAgentRamFloorExemptDevice();
     }
 
     @JavascriptInterface

--- a/packages/app-core/platforms/android/app/src/test/java/ai/elizaos/app/DeviceRamTierPolicyTest.java
+++ b/packages/app-core/platforms/android/app/src/test/java/ai/elizaos/app/DeviceRamTierPolicyTest.java
@@ -1,6 +1,6 @@
 /**
  * JVM unit tests for the device RAM-tier policy (#14390): marketed-GB recovery
- * from raw totalMem readings and the 8 GB on-device-agent floor, pinned against
+ * from raw totalMem readings and the 4/8 GB agent floors, pinned against
  * real observed device readings.
  */
 package ai.elizaos.app;
@@ -53,10 +53,19 @@ public class DeviceRamTierPolicyTest {
     }
 
     @Test
+    public void hybridAgentFloorIsFourMarketedGb() {
+        assertFalse(DeviceRamTierPolicy.allowsHybridAgent(gib(2.8)));
+        assertTrue(DeviceRamTierPolicy.allowsHybridAgent(kb(3_747_844)));
+        assertTrue(DeviceRamTierPolicy.allowsHybridAgent(gib(5.7)));
+    }
+
+    @Test
     public void unreadableTotalMemFailsOpenForAnExplicitLocalChoice() {
         // The only mode that consults this gate is an explicit user "local"
         // choice; a probe failure must not brick it.
         assertTrue(DeviceRamTierPolicy.allowsLocalAgent(0L));
         assertTrue(DeviceRamTierPolicy.allowsLocalAgent(-1L));
+        assertTrue(DeviceRamTierPolicy.allowsHybridAgent(0L));
+        assertTrue(DeviceRamTierPolicy.allowsHybridAgent(-1L));
     }
 }

--- a/packages/app-core/platforms/android/app/src/test/java/ai/elizaos/app/ElizaAgentAutostartPolicyTest.java
+++ b/packages/app-core/platforms/android/app/src/test/java/ai/elizaos/app/ElizaAgentAutostartPolicyTest.java
@@ -69,6 +69,19 @@ public class ElizaAgentAutostartPolicyTest {
         assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, " local ", RAM_BLOCKED));
     }
 
+    @Test
+    public void explicitStartUsesTheModeSpecificRamFloor() {
+        long marketedFourGb = (long) (3.6 * (1L << 30));
+        long belowHybridFloor = (long) (2.8 * (1L << 30));
+
+        assertTrue(ElizaAgentService.allowsAgentStartForRuntimeMode(
+            "cloud-hybrid", marketedFourGb));
+        assertFalse(ElizaAgentService.allowsAgentStartForRuntimeMode(
+            "local", marketedFourGb));
+        assertFalse(ElizaAgentService.allowsAgentStartForRuntimeMode(
+            "cloud-hybrid", belowHybridFloor));
+    }
+
     /**
      * Cold-boot-guard stamp trust: the stamp is only as alive as the child it
      * describes. No journaled start yet = launcher's first second, trust it; a

--- a/packages/ui/src/first-run/device-ram-gate.test.ts
+++ b/packages/ui/src/first-run/device-ram-gate.test.ts
@@ -118,11 +118,12 @@ afterEach(() => {
 
 describe("peekDeviceRamTierAssessment", () => {
   it("classifies synchronously from the Android native bridge", () => {
-    // The #14390 Moto G Play: totalMem ~3660 MB → marketed 4 GB → cloud-only.
+    // The #14390 Moto G Play: totalMem ~3660 MB → marketed 4 GB → hybrid-only.
     installSyncBridge(3660);
     const a = peekDeviceRamTierAssessment();
-    expect(a?.tier).toBe("cloud-only");
+    expect(a?.tier).toBe("no-local-models");
     expect(a?.marketedRamGb).toBe(4);
+    expect(a?.allowsHybridAgent).toBe(true);
     expect(a?.allowsLocalAgent).toBe(false);
   });
 
@@ -140,6 +141,7 @@ describe("peekDeviceRamTierAssessment", () => {
     mocks.isIOS = false;
     const a = peekDeviceRamTierAssessment();
     expect(a?.tier).toBe("unknown");
+    expect(a?.allowsHybridAgent).toBe(true);
     expect(a?.allowsLocalAgent).toBe(true);
   });
 });
@@ -160,18 +162,32 @@ describe("resolveDeviceRamTierAssessment", () => {
     mocks.resourceSnapshot = null;
     const a = await resolveDeviceRamTierAssessment();
     expect(a.tier).toBe("unknown");
+    expect(a.allowsHybridAgent).toBe(true);
     expect(a.allowsLocalAgent).toBe(true);
   });
 });
 
 describe("assertDeviceRamTierAllowsLocalRuntime", () => {
-  it("throws for ANY local runtime on a sub-8 GB device", async () => {
+  it("allows hybrid but rejects local/provider modes on a 4 GB device", async () => {
     installSyncBridge(3660);
+    await expect(
+      assertDeviceRamTierAllowsLocalRuntime("cloud-inference"),
+    ).resolves.toBeUndefined();
     await expect(
       assertDeviceRamTierAllowsLocalRuntime("all-local"),
     ).rejects.toThrow(/on-device agent/);
     await expect(
+      assertDeviceRamTierAllowsLocalRuntime("configure-later"),
+    ).rejects.toThrow(/on-device agent/);
+  });
+
+  it("rejects every local runtime below the 4 GB hybrid floor", async () => {
+    installSyncBridge(2.5 * 1024);
+    await expect(
       assertDeviceRamTierAllowsLocalRuntime("cloud-inference"),
+    ).rejects.toThrow(/on-device agent/);
+    await expect(
+      assertDeviceRamTierAllowsLocalRuntime("all-local"),
     ).rejects.toThrow(/on-device agent/);
   });
 
@@ -204,8 +220,8 @@ describe("assertDeviceRamTierAllowsLocalRuntime", () => {
 });
 
 describe("enforceDeviceRamPolicyOnPersistedRuntimeModeAtBoot", () => {
-  function seedLocalCommitment(): void {
-    persistMobileRuntimeMode("local");
+  function seedLocalCommitment(mode: "local" | "cloud-hybrid" = "local"): void {
+    persistMobileRuntimeMode(mode);
     savePersistedActiveServer({
       id: ANDROID_LOCAL_AGENT_SERVER_ID,
       kind: "remote",
@@ -221,6 +237,15 @@ describe("enforceDeviceRamPolicyOnPersistedRuntimeModeAtBoot", () => {
     expect(enforceDeviceRamPolicyOnPersistedRuntimeModeAtBoot()).toBe(true);
     expect(readPersistedMobileRuntimeMode()).toBeNull();
     expect(loadPersistedActiveServer()).toBeNull();
+  });
+
+  it("keeps persisted hybrid mode at the 4 GB runtime-only floor", () => {
+    installSyncBridge(3660);
+    seedLocalCommitment("cloud-hybrid");
+
+    expect(enforceDeviceRamPolicyOnPersistedRuntimeModeAtBoot()).toBe(false);
+    expect(readPersistedMobileRuntimeMode()).toBe("cloud-hybrid");
+    expect(loadPersistedActiveServer()?.id).toBe(ANDROID_LOCAL_AGENT_SERVER_ID);
   });
 
   it("keeps a persisted local mode on a capable device", () => {

--- a/packages/ui/src/first-run/device-ram-gate.ts
+++ b/packages/ui/src/first-run/device-ram-gate.ts
@@ -33,7 +33,6 @@ import { clearPersistedLocalRuntimeCommitment } from "./revert-local-runtime-com
 
 interface ElizaNativeRamBridge {
   getDeviceTotalRamMb?: () => number;
-  isLocalAgentRamFloorExempt?: () => boolean;
 }
 
 /** The synchronous Android bridge read, or null off-Android / unavailable. */
@@ -51,25 +50,6 @@ function readSyncDeviceTotalRamMb(): number | null {
     // error-policy:J4 native-bridge probe — no sync bridge means this shell
     // doesn't expose it; the async snapshot probe still runs.
     return null;
-  }
-}
-
-/**
- * Whether native flags this as a curated on-device-agent floor-exempt device
- * (the LP3). Synchronous, same JavascriptInterface as the RAM read so the tier
- * gate resolves the same on the sync peek and the async resolve. Absent bridge
- * (older shell / iOS / web) → false, i.e. the generic RAM floor applies.
- */
-function readSyncLocalAgentRamFloorExempt(): boolean {
-  try {
-    const bridge = (
-      globalThis as typeof globalThis & { ElizaNative?: ElizaNativeRamBridge }
-    ).ElizaNative;
-    return bridge?.isLocalAgentRamFloorExempt?.() === true;
-  } catch {
-    // error-policy:J4 native-bridge probe — no bridge means no exemption; the
-    // generic RAM floor governs.
-    return false;
   }
 }
 
@@ -98,7 +78,6 @@ export function peekDeviceRamTierAssessment(): DeviceRamTierAssessment | null {
   if (syncMb !== null) {
     cachedAssessment = classifyDeviceRamTier(
       marketedRamGbFromTotalRamMb(syncMb),
-      readSyncLocalAgentRamFloorExempt(),
     );
     return cachedAssessment;
   }
@@ -117,7 +96,6 @@ export async function resolveDeviceRamTierAssessment(): Promise<DeviceRamTierAss
       const snapshot = await getDeviceResourceSnapshot();
       const assessment = classifyDeviceRamTier(
         marketedRamGbFromTotalRamMb(snapshot?.totalRamMb ?? null),
-        readSyncLocalAgentRamFloorExempt(),
       );
       cachedAssessment = assessment;
       return assessment;
@@ -139,7 +117,11 @@ export async function assertDeviceRamTierAllowsLocalRuntime(
   localInference: string,
 ): Promise<void> {
   const assessment = await resolveDeviceRamTierAssessment();
-  if (!assessment.allowsLocalAgent) {
+  const allowsSelectedRuntime =
+    localInference === "cloud-inference"
+      ? assessment.allowsHybridAgent
+      : assessment.allowsLocalAgent;
+  if (!allowsSelectedRuntime) {
     throw new Error(
       `This device can't run the on-device agent: ${assessment.reason}. Pick "Eliza Cloud (managed)" instead.`,
     );
@@ -166,7 +148,11 @@ export function enforceDeviceRamPolicyOnPersistedRuntimeModeAtBoot(): boolean {
   const mode = readPersistedMobileRuntimeMode();
   if (mode !== "local" && mode !== "cloud-hybrid") return false;
   const assessment = peekDeviceRamTierAssessment();
-  if (!assessment || assessment.allowsLocalAgent) return false;
+  const allowed =
+    mode === "cloud-hybrid"
+      ? assessment?.allowsHybridAgent
+      : assessment?.allowsLocalAgent;
+  if (!assessment || allowed) return false;
   const cleared = clearPersistedLocalRuntimeCommitment();
   logger.warn(
     { mode, marketedRamGb: assessment.marketedRamGb, ...cleared },

--- a/packages/ui/src/first-run/device-ram-tier.test.ts
+++ b/packages/ui/src/first-run/device-ram-tier.test.ts
@@ -1,6 +1,6 @@
 /**
  * Unit coverage for the pure RAM-tier policy (#14390): marketed-GB recovery
- * from raw device totals and the 8/12/16 GB tier boundaries, pinned against
+ * from raw device totals and the 4/8/12/16 GB boundaries, pinned against
  * real observed device readings. Pure functions, no device.
  */
 
@@ -42,10 +42,11 @@ describe("marketedRamGbFromTotalRamMb", () => {
 });
 
 describe("classifyDeviceRamTier", () => {
-  it("blocks the local agent entirely under 8 GB (cloud-only)", () => {
-    for (const gb of [1, 4, 6, 7]) {
+  it("blocks every local agent mode under the 4 GB hybrid floor", () => {
+    for (const gb of [1, 2, 3]) {
       const a = classifyDeviceRamTier(gb);
       expect(a.tier).toBe("cloud-only");
+      expect(a.allowsHybridAgent).toBe(false);
       expect(a.allowsLocalAgent).toBe(false);
       expect(a.allowsLocalModels).toBe(false);
       expect(a.localModelsWarning).toBe(false);
@@ -54,28 +55,22 @@ describe("classifyDeviceRamTier", () => {
     }
   });
 
-  it("lifts the agent floor for a floor-exempt device (LP3) but keeps the local-models floor", () => {
-    // A curated exempt device below 8 GB (the LP3 at ~6 GB) may run the
-    // on-device agent (hybrid/cloud-inference — no local model mmap) but still
-    // may not run local MODELS, which are gated by the unchanged 12 GB floor.
+  it("allows hybrid cloud inference from 4 GB without a device allowlist", () => {
     for (const gb of [4, 6, 7]) {
-      const a = classifyDeviceRamTier(gb, true);
+      const a = classifyDeviceRamTier(gb);
       expect(a.tier).toBe("no-local-models");
-      expect(a.allowsLocalAgent).toBe(true);
+      expect(a.allowsHybridAgent).toBe(true);
+      expect(a.allowsLocalAgent).toBe(false);
       expect(a.allowsLocalModels).toBe(false);
       expect(a.marketedRamGb).toBe(gb);
     }
-    // The exemption never downgrades a device that already clears a floor:
-    // a 16 GB exempt device is still fully unrestricted.
-    expect(classifyDeviceRamTier(16, true).tier).toBe("full-local");
-    // And it does not fabricate capability from an unreadable total.
-    expect(classifyDeviceRamTier(null, true).tier).toBe("unknown");
   });
 
   it("allows the agent but blocks on-device models on 8-11 GB", () => {
     for (const gb of [8, 10, 11]) {
       const a = classifyDeviceRamTier(gb);
       expect(a.tier).toBe("no-local-models");
+      expect(a.allowsHybridAgent).toBe(true);
       expect(a.allowsLocalAgent).toBe(true);
       expect(a.allowsLocalModels).toBe(false);
       expect(a.localModelsWarning).toBe(false);
@@ -86,6 +81,7 @@ describe("classifyDeviceRamTier", () => {
     for (const gb of [12, 15]) {
       const a = classifyDeviceRamTier(gb);
       expect(a.tier).toBe("local-models-warn");
+      expect(a.allowsHybridAgent).toBe(true);
       expect(a.allowsLocalAgent).toBe(true);
       expect(a.allowsLocalModels).toBe(true);
       expect(a.localModelsWarning).toBe(true);
@@ -96,6 +92,7 @@ describe("classifyDeviceRamTier", () => {
     for (const gb of [16, 24, 64]) {
       const a = classifyDeviceRamTier(gb);
       expect(a.tier).toBe("full-local");
+      expect(a.allowsHybridAgent).toBe(true);
       expect(a.allowsLocalAgent).toBe(true);
       expect(a.allowsLocalModels).toBe(true);
       expect(a.localModelsWarning).toBe(false);
@@ -106,6 +103,7 @@ describe("classifyDeviceRamTier", () => {
     const a = classifyDeviceRamTier(null);
     expect(a.tier).toBe("unknown");
     expect(a.marketedRamGb).toBeNull();
+    expect(a.allowsHybridAgent).toBe(true);
     expect(a.allowsLocalAgent).toBe(true);
     expect(a.allowsLocalModels).toBe(true);
     expect(a.localModelsWarning).toBe(false);

--- a/packages/ui/src/first-run/device-ram-tier.ts
+++ b/packages/ui/src/first-run/device-ram-tier.ts
@@ -2,12 +2,10 @@
  * Pure RAM-tier classification for the mobile runtime policy (#14390): which
  * runtime options a phone may be offered, keyed on marketed RAM size.
  *
- * Low-RAM phones cannot sustain the on-device agent — a 4 GB Moto G Play
- * wedges boot for the full 180 s startup budget — so the policy is RAM-driven,
- * not build-driven: under 8 GB the local agent is disabled outright (cloud
- * only); under 12 GB the agent may run but on-device models are disabled
- * (cloud-inference only); under 16 GB on-device models are allowed with a
- * performance/thermal warning; 16 GB and up is unrestricted.
+ * The policy separates the Bun runtime from model loading: hybrid mode may run
+ * from 4 GB because inference stays in the cloud, an unconfigured/full local
+ * runtime needs 8 GB, and on-device models need 12 GB. Under 16 GB local
+ * models carry a performance/thermal warning; 16 GB and up is unrestricted.
  *
  * The OS under-reports marketed capacity (kernel/carveout reserve a slice: a
  * "4 GB" device reads ~3.6 GiB, an "8 GB" one ~7.2-7.6 GiB), so raw readings
@@ -30,6 +28,8 @@ export interface DeviceRamTierAssessment {
   tier: DeviceRamTier;
   /** Marketed RAM size in GB, or null when the device total is unreadable. */
   marketedRamGb: number | null;
+  /** May this device run the on-device agent with cloud inference (>= 4 GB)? */
+  allowsHybridAgent: boolean;
   /** May this device run the on-device agent at all (>= 8 GB)? */
   allowsLocalAgent: boolean;
   /** May this device download/run on-device models (>= 12 GB)? */
@@ -40,6 +40,7 @@ export interface DeviceRamTierAssessment {
   reason: string;
 }
 
+export const HYBRID_AGENT_MIN_MARKETED_RAM_GB = 4;
 export const LOCAL_AGENT_MIN_MARKETED_RAM_GB = 8;
 export const LOCAL_MODELS_MIN_MARKETED_RAM_GB = 12;
 export const LOCAL_MODELS_WARN_BELOW_MARKETED_RAM_GB = 16;
@@ -72,47 +73,48 @@ export function marketedRamGbFromTotalRamMb(
  */
 export function classifyDeviceRamTier(
   marketedRamGb: number | null,
-  // Curated devices (the LP3) that clear the on-device-agent floor by allowlist
-  // rather than by raw RAM — mirrors the native
-  // ElizaAgentService.isLocalAgentRamFloorExemptDevice via the ElizaNative
-  // bridge. Lifts ONLY the local-agent floor (hybrid/cloud-inference runs with
-  // no local model mmap); the 12 GB local-MODELS floor still applies normally.
-  ramFloorExempt = false,
 ): DeviceRamTierAssessment {
   if (marketedRamGb === null || !Number.isFinite(marketedRamGb)) {
     return {
       tier: "unknown",
       marketedRamGb: null,
+      allowsHybridAgent: true,
       allowsLocalAgent: true,
       allowsLocalModels: true,
       localModelsWarning: false,
       reason: "device memory could not be determined",
     };
   }
-  if (marketedRamGb < LOCAL_AGENT_MIN_MARKETED_RAM_GB && !ramFloorExempt) {
+  if (marketedRamGb < HYBRID_AGENT_MIN_MARKETED_RAM_GB) {
     return {
       tier: "cloud-only",
       marketedRamGb,
+      allowsHybridAgent: false,
       allowsLocalAgent: false,
       allowsLocalModels: false,
       localModelsWarning: false,
-      reason: `this device has ~${marketedRamGb} GB RAM and the on-device agent needs ${LOCAL_AGENT_MIN_MARKETED_RAM_GB} GB or more`,
+      reason: `this device has ~${marketedRamGb} GB RAM and the hybrid on-device agent needs ${HYBRID_AGENT_MIN_MARKETED_RAM_GB} GB or more`,
     };
   }
   if (marketedRamGb < LOCAL_MODELS_MIN_MARKETED_RAM_GB) {
     return {
       tier: "no-local-models",
       marketedRamGb,
-      allowsLocalAgent: true,
+      allowsHybridAgent: true,
+      allowsLocalAgent: marketedRamGb >= LOCAL_AGENT_MIN_MARKETED_RAM_GB,
       allowsLocalModels: false,
       localModelsWarning: false,
-      reason: `this device has ~${marketedRamGb} GB RAM and on-device models need ${LOCAL_MODELS_MIN_MARKETED_RAM_GB} GB or more`,
+      reason:
+        marketedRamGb < LOCAL_AGENT_MIN_MARKETED_RAM_GB
+          ? `this device has ~${marketedRamGb} GB RAM; hybrid cloud inference is supported, while a local runtime needs ${LOCAL_AGENT_MIN_MARKETED_RAM_GB} GB or more`
+          : `this device has ~${marketedRamGb} GB RAM and on-device models need ${LOCAL_MODELS_MIN_MARKETED_RAM_GB} GB or more`,
     };
   }
   if (marketedRamGb < LOCAL_MODELS_WARN_BELOW_MARKETED_RAM_GB) {
     return {
       tier: "local-models-warn",
       marketedRamGb,
+      allowsHybridAgent: true,
       allowsLocalAgent: true,
       allowsLocalModels: true,
       localModelsWarning: true,
@@ -122,6 +124,7 @@ export function classifyDeviceRamTier(
   return {
     tier: "full-local",
     marketedRamGb,
+    allowsHybridAgent: true,
     allowsLocalAgent: true,
     allowsLocalModels: true,
     localModelsWarning: false,

--- a/packages/ui/src/first-run/first-run-finish.ts
+++ b/packages/ui/src/first-run/first-run-finish.ts
@@ -392,12 +392,11 @@ async function finishLocal(
   sourceDraft: FirstRunProfileDraft,
   ports: FirstRunFinishPorts,
 ): Promise<FirstRunFinishOutcome> {
-  // RAM-tier gate (#14390), enforced BEFORE any side effect: a device below
-  // the 8 GB floor may not run the on-device agent at all, and one below the
-  // 12 GB floor may not download/run on-device models. The onboarding UI
-  // already blocks these picks, but this is the fail-loud backstop for every
-  // caller — the throw surfaces as the onboarding error turn with the
-  // runtime-recovery choice.
+  // RAM-tier gate (#14390), enforced BEFORE any side effect: hybrid mode uses
+  // the 4 GB runtime-only floor, an unconfigured/full local runtime uses 8 GB,
+  // and on-device models use 12 GB. The onboarding UI already blocks these
+  // picks, but this is the fail-loud backstop for every caller — the throw
+  // surfaces as the onboarding error turn with the runtime-recovery choice.
   await assertDeviceRamTierAllowsLocalRuntime(sourceDraft.localInference);
   syncIdentity(sourceDraft, ports);
   // Local + cloud-inference (hybrid) routes inference through Eliza Cloud, so

--- a/packages/ui/src/first-run/use-first-run-conductor.test.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.test.ts
@@ -95,7 +95,11 @@ vi.mock("./device-ram-gate", async (importOriginal) => {
     assertDeviceRamTierAllowsLocalRuntime: async (localInference: string) => {
       const tier = mocks.deviceRamTier;
       if (!tier) return;
-      if (!tier.allowsLocalAgent) {
+      const allowsSelectedRuntime =
+        localInference === "cloud-inference"
+          ? tier.allowsHybridAgent
+          : tier.allowsLocalAgent;
+      if (!allowsSelectedRuntime) {
         throw new Error(
           `This device can't run the on-device agent: ${tier.reason}.`,
         );
@@ -1956,16 +1960,16 @@ describe("useFirstRunConductor — free-text replies (#12178 composer unlock)", 
 });
 
 describe("device RAM-tier gating + reversible onboarding (#14390)", () => {
-  it("labels the local option unavailable on a sub-8 GB device and refuses the pick with the reason", async () => {
-    mocks.deviceRamTier = classifyDeviceRamTier(4);
+  it("labels the local option unavailable below the 4 GB hybrid floor and refuses the pick", async () => {
+    mocks.deviceRamTier = classifyDeviceRamTier(3);
     seedAppStore();
     const { transcript, turn, unmount } = renderConductor();
 
     // The greeting's local option is visibly gated — never silently hidden.
     const greeting = await waitForTurn(turn, "first-run:greeting");
     expect(greeting.text).toContain("__first_run__:runtime:local=");
-    expect(greeting.text).toContain("unavailable — needs 8 GB+ RAM");
-    expect(greeting.text).toContain("~4 GB detected");
+    expect(greeting.text).toContain("unavailable — needs 4 GB+ RAM");
+    expect(greeting.text).toContain("~3 GB detected");
 
     // The tap is refused at the decision point: a refusal turn with the
     // reason and a FRESH runtime choice — no provider step, no finish.
@@ -1980,7 +1984,7 @@ describe("device RAM-tier gating + reversible onboarding (#14390)", () => {
     const blocked = transcript.current.find((m) =>
       m.id.startsWith("first-run:runtime-blocked:"),
     );
-    expect(blocked?.text).toContain("~4 GB RAM");
+    expect(blocked?.text).toContain("~3 GB RAM");
     expect(blocked?.text).toContain("[CHOICE:first-run id=runtime]");
     expect(turn("first-run:provider")).toBeUndefined();
     expect(mocks.client.submitFirstRun).not.toHaveBeenCalled();
@@ -1991,8 +1995,8 @@ describe("device RAM-tier gating + reversible onboarding (#14390)", () => {
     unmount();
   });
 
-  it("blocks on-device models on a sub-12 GB device but finishes the hybrid local runtime", async () => {
-    mocks.deviceRamTier = classifyDeviceRamTier(8);
+  it("blocks local configuration and models at 4 GB but finishes the hybrid runtime", async () => {
+    mocks.deviceRamTier = classifyDeviceRamTier(4);
     seedAppStore();
     const { transcript, turn, unmount } = renderConductor();
     await waitForTurn(turn, "first-run:greeting");
@@ -2003,6 +2007,9 @@ describe("device RAM-tier gating + reversible onboarding (#14390)", () => {
     expect(provider.text).toContain("unavailable — needs 12 GB+ RAM");
     expect(provider.text).toContain(
       "__first_run__:provider:elizacloud=Eliza Cloud inference (recommended)",
+    );
+    expect(provider.text).toContain(
+      "Other / configure in Settings (unavailable — needs 8 GB+ RAM)",
     );
     expect(provider.text).toContain("__first_run__:back:runtime=");
 
@@ -2021,6 +2028,18 @@ describe("device RAM-tier gating + reversible onboarding (#14390)", () => {
     expect(
       mocks.autoDownloadRecommendedLocalModelInBackground,
     ).not.toHaveBeenCalled();
+
+    // Configure-later is a full local runtime mode, so it retains the 8 GB
+    // floor even though it does not download a model immediately.
+    expect(tryHandleFirstRunAction("__first_run__:provider:other")).toBe(true);
+    await waitFor(() => {
+      expect(
+        transcript.current.some((m) =>
+          m.text.includes("An unconfigured local runtime won't work here"),
+        ),
+      ).toBe(true);
+    });
+    expect(mocks.client.submitFirstRun).not.toHaveBeenCalled();
 
     // Eliza Cloud inference (hybrid) is the allowed local path here and
     // completes the REAL finish: exactly one POST, no model download, and the

--- a/packages/ui/src/first-run/use-first-run-conductor.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.ts
@@ -35,9 +35,10 @@
  *
  * Device RAM-tier gating + reversibility (#14390): the runtime and provider
  * CHOICE blocks are built per-seed against the device's RAM-tier assessment
- * (`device-ram-gate.ts`) — a sub-8 GB phone sees "On this device" labeled
- * unavailable and its tap refused with the reason; a sub-12 GB phone gets
- * on-device models blocked the same way (never silently hidden). Every
+ * (`device-ram-gate.ts`) — a sub-4 GB phone sees "On this device" labeled
+ * unavailable and its tap refused with the reason; 4–7 GB phones may choose
+ * hybrid cloud inference but not an unconfigured local runtime, and a sub-12
+ * GB phone gets on-device models blocked (never silently hidden). Every
  * sub-step CHOICE carries a "← Back" option whose handler unwinds any
  * partially-committed local runtime (persisted mode, local active server,
  * started service) before re-offering a fresh runtime choice, so onboarding
@@ -82,7 +83,11 @@ import {
   peekDeviceRamTierAssessment,
   resolveDeviceRamTierAssessment,
 } from "./device-ram-gate";
-import type { DeviceRamTierAssessment } from "./device-ram-tier";
+import {
+  type DeviceRamTierAssessment,
+  HYBRID_AGENT_MIN_MARKETED_RAM_GB,
+  LOCAL_AGENT_MIN_MARKETED_RAM_GB,
+} from "./device-ram-tier";
 import { normalizeFirstRunName } from "./first-run";
 import {
   FIRST_RUN_ACTION_PREFIX,
@@ -222,15 +227,15 @@ const BACK_TO_RUNTIME_OPTION = `${FIRST_RUN_ACTION_PREFIX}back:runtime=← Back 
 // token; it owns its own provider, so it skips the provider sub-step.
 //
 // Built per-render because the local option is RAM-tier-gated (#14390): on a
-// device below the 8 GB floor it stays VISIBLE but labeled unavailable (never
+// device below the hybrid runtime floor it stays VISIBLE but labeled unavailable (never
 // silently hidden), and its tap is refused with the reason. The tier probe is
 // synchronous on Android; when it has not resolved yet (iOS first frames) the
 // plain label renders and the pick handler + finish backstop still enforce.
 function runtimeChoiceBlock(): string {
   const tier = peekDeviceRamTierAssessment();
   const localLabel =
-    tier && !tier.allowsLocalAgent
-      ? `On this device (unavailable — needs 8 GB+ RAM, ~${tier.marketedRamGb} GB detected)`
+    tier && !tier.allowsHybridAgent
+      ? `On this device (unavailable — needs ${HYBRID_AGENT_MIN_MARKETED_RAM_GB} GB+ RAM, ~${tier.marketedRamGb} GB detected)`
       : "On this device";
   return [
     "[CHOICE:first-run id=runtime]",
@@ -264,11 +269,15 @@ function providerChoice(opts: {
     ? `${FIRST_RUN_ACTION_PREFIX}provider:elizacloud=Eliza Cloud inference (recommended)`
     : `${FIRST_RUN_ACTION_PREFIX}provider:elizacloud=Eliza Cloud inference`;
   const other = `${FIRST_RUN_ACTION_PREFIX}provider:other=Other / configure in Settings`;
+  const configuredOther =
+    opts.tier != null && !opts.tier.allowsLocalAgent
+      ? `${FIRST_RUN_ACTION_PREFIX}provider:other=Other / configure in Settings (unavailable — needs ${LOCAL_AGENT_MIN_MARKETED_RAM_GB} GB+ RAM)`
+      : other;
   const ordered = modelsBlocked
-    ? [cloud, onDevice, other]
+    ? [cloud, onDevice, configuredOther]
     : opts.defaultId === "on-device"
-      ? [onDevice, cloud, other]
-      : [other, onDevice, cloud];
+      ? [onDevice, cloud, configuredOther]
+      : [configuredOther, onDevice, cloud];
   return [
     "[CHOICE:first-run id=provider]",
     ...ordered,
@@ -1013,10 +1022,10 @@ export function useFirstRunConductor(): void {
           return true;
         }
         // On this device: RAM-tier gate first (#14390). A device below the
-        // 8 GB floor is refused with the reason and re-offered a fresh
+        // hybrid runtime floor is refused with the reason and re-offered a fresh
         // runtime choice — enforced at the decision point, not just labeled.
         const tier = peekDeviceRamTierAssessment();
-        if (tier && !tier.allowsLocalAgent) {
+        if (tier && !tier.allowsHybridAgent) {
           seedTurn(
             makeTurn(
               `first-run:runtime-blocked:${Date.now()}`,
@@ -1110,6 +1119,14 @@ export function useFirstRunConductor(): void {
           }
         }
         if (id === "other") {
+          const tier = peekDeviceRamTierAssessment();
+          if (tier && !tier.allowsLocalAgent) {
+            seedFreshChoiceTurn(
+              "first-run:provider",
+              `An unconfigured local runtime won't work here — ${tier.reason}. Eliza Cloud inference keeps the agent on this device without loading a local model.\n\n${providerChoice({ defaultId: "other", tier })}`,
+            );
+            return true;
+          }
           // "Other / configure in Settings" (bring your own keys): finish the
           // LOCAL runtime with no provider wired and no model download.
           // `configure-later` keeps `needsProviderSetup` true, so the finish


### PR DESCRIPTION
Resolves #15577.

## What changed

- Split the mobile RAM policy into three explicit thresholds:
  - 4 GB marketed RAM for the HYBRID runtime-only path (local Bun agent, cloud inference).
  - 8 GB for an unconfigured/full local runtime.
  - 12 GB for loading local models, with the existing warning below 16 GB.
- Removed the Light Phone manufacturer exemption from the Android service, JavaScript bridge, and renderer policy.
- Made first-run choices, finish-time validation, persisted-mode boot cleanup, and the Android service start boundary use the selected mode threshold.
- Kept fail-open behavior for an unreadable RAM probe and fail-loud behavior for known undersized devices.

## Why

NubsCarson decision on #15577 is to make the floor mode-aware. HYBRID does not mmap a local model, and the 6 GB Light Phone III has already booted the real runtime with 17 plugins, database ready, and no OOM. A device allowlist encoded the symptom; the general policy should encode the resource distinction.

## Verification

- `bunx vitest run --config vitest.config.ts src/first-run/device-ram-tier.test.ts src/first-run/device-ram-gate.test.ts src/first-run/use-first-run-conductor.test.ts` — 3 files, 83 tests passed on the synchronized branch.
- Android app compilation + JVM tests with JDK 21 / Android SDK 36: `./gradlew :app:testDebugUnitTest -x :app:copyForkLlamaLib --tests ai.elizaos.app.DeviceRamTierPolicyTest --tests ai.elizaos.app.ElizaAgentAutostartPolicyTest` — BUILD SUCCESSFUL. The excluded task only stages the fused native inference library for APK packaging and is unrelated to Java unit tests.
- `bunx @biomejs/biome check` on touched TypeScript files — passed.
- `bun run audit:error-policy-ratchet` — passed.
- `git diff --check` — passed.
- Rebased onto current `origin/develop` immediately before opening this PR.
- Clean-host GitHub checks passed for build, typecheck, lint, fixture E2E, coverage, evidence, stale-base, environment audit, secrets, and the full app aesthetic audit.

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] N/A - this changes RAM eligibility policy and native/runtime start guards; it does not change component layout or styling. The affected choice copy is asserted in the 83-test renderer suite.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no pixels, styles, or component structure changed; device-mode eligibility is the observable behavior.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - browser impersonation is not valid evidence because injecting Capacitor Android activates native transports. Real-device proof is linked below.
<!-- evidence-row:backend-logs -->
- [x] Existing real LP3 boot evidence: https://github.com/NubsCarson/lp3-eliza-research/blob/main/docs/ON_DEVICE_AGENT_RAM_GATE.md (6 GB device; 17 plugins loaded, database ready, no OOM). Android compile/JVM gate results are summarized above.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - the changed boundary is native RAM probing/start authorization, not a frontend network request.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent prompt, action, provider, evaluator, planner, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Policy artifact: https://github.com/NubsCarson/lp3-eliza-research/blob/main/docs/ON_DEVICE_AGENT_RAM_GATE.md plus the Android JVM and renderer test matrices covering 3 GB rejection, 4 GB HYBRID admission, 8 GB local admission, 12 GB model admission, unknown-probe behavior, and persisted-mode cleanup.

## Review state

The PR is ready for review and Project 12 is at Needs-agent-verify. The OCR follow-on to the successful full app aesthetic audit is advisory.
