### PR TITLE
ci(windows): isolate + retry tenant-db PGlite suite on Bun-canary shard (#15785)

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -105,7 +105,13 @@ jobs:
             commands:
               - bun run --cwd packages/app-core test
               - bun run --cwd packages/elizaos test
-              - bun run --cwd packages/cloud/shared test
+              # The tenant-db durable-placement-claimer suite is split out into
+              # its own bounded-retry step below (#15785): under Bun canary on
+              # Windows it intermittently trips a native `Illegal instruction`
+              # panic while driving PGlite (WASM). Ignore it in the whole-package
+              # run so that upstream-runtime flake cannot fail the shard; the rest
+              # of packages/cloud/shared still runs here unchanged.
+              - bun run --cwd packages/cloud/shared test --path-ignore-patterns "**/tenant-db-placement-claimer.test.ts"
           - lane: framework-packages
             commands:
               - bun run --cwd packages/scenario-runner test
@@ -203,3 +209,32 @@ jobs:
               exit $code
             }
           }
+
+      # #15785: The tenant-db durable-placement-claimer suite drives PGlite
+      # (WASM) and intermittently trips a native `Illegal instruction` panic
+      # under Bun canary on Windows. That is an upstream runtime flake, not a
+      # product regression (the test blob is byte-identical to a run that passed
+      # in 49ms hours earlier — do not bisect). It is ignored by the whole-package
+      # run above and re-run here in isolation with a small bounded retry so a
+      # single native panic is retried instead of failing the whole shard.
+      # Each attempt is logged; the suite still has to pass for the shard to pass.
+      - name: Retry-isolated tenant-db PGlite suite (Windows canary flake, #15785)
+        if: matrix.lane == 'app-and-cli'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Continue"
+          $suite = "src/lib/services/tenant-db/tenant-db-placement-claimer.test.ts"
+          $maxAttempts = 3
+          for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+            Write-Host "::group::tenant-db placement-claimer suite (attempt $attempt/$maxAttempts)"
+            bun run --cwd packages/cloud/shared test $suite
+            $code = $LASTEXITCODE
+            Write-Host "::endgroup::"
+            if ($code -eq 0) {
+              Write-Host "tenant-db placement-claimer suite passed on attempt $attempt/$maxAttempts."
+              exit 0
+            }
+            Write-Warning "tenant-db placement-claimer suite failed on attempt $attempt/$maxAttempts with exit code $code (Bun canary/PGlite native flake, #15785)."
+          }
+          Write-Error "tenant-db placement-claimer suite still failing after $maxAttempts attempts; not the expected transient flake."
+          exit 1


### PR DESCRIPTION
## What

Closes #15785. Isolates the tenant-db durable-placement-claimer PGlite suite into its own bounded-retry step on the Windows Bun-canary shard, so a single intermittent native panic no longer fails the whole `app-and-cli` shard.

## Why

The Windows `app-and-cli` shard intermittently fails when `tenant DB durable placement claimer` (PGlite/WASM) trips a native `Illegal instruction` panic under **Bun canary** (the lane pins `bun-version: canary`). Per the issue, this is verified as an upstream runtime flake, **not** a product regression — do not bisect. Mitigation, not a deterministic fix.

## Change (`.github/workflows/windows-ci.yml` only — no product code)

1. The `app-and-cli` lane's whole-package `packages/cloud/shared` run now passes `--path-ignore-patterns "**/tenant-db-placement-claimer.test.ts"`, so the flaky suite is excluded there and cannot fail the shard. Every other cloud/shared suite still runs unchanged.
2. A new `app-and-cli`-only step (`if: matrix.lane == 'app-and-cli'`) re-runs just that one suite in a bounded 3-attempt retry loop, logging each attempt (`::group::`, per-attempt warning). It still has to pass for the shard to pass — a genuine failure after 3 attempts fails, so this only absorbs transient native panics.

## Verification

- **`actionlint .github/workflows/windows-ci.yml` → exit 0** (v1.7.12, no findings).
- **YAML parses** (`yaml.safe_load` → OK).
- **Filtering proven for real against Bun canary v1.4.0-canary.1** (the exact version CI pins):

  Positional selection + `bun run` arg forwarding — the isolated command runs exactly the one file:
  ```
  $ bun test --isolate src/lib/services/tenant-db/tenant-db-placement-claimer.test.ts
  src/lib/services/tenant-db/tenant-db-placement-claimer.test.ts:
  Ran 1 test across 1 file.
  ```

  `--path-ignore-patterns` excludes exactly that suite and nothing else:
  ```
  WITHOUT ignore:  Ran 49 tests across 7 files  (placement-claimer + provisioning present)
  WITH    ignore:  Ran 48 tests across 6 files  (placement-claimer removed; provisioning still runs)
  ```
  Delta is exactly the 1 placement-claimer file / 1 test; the sibling `tenant-db-provisioning.integration.test.ts` is untouched.

- **Logic review**: only the `app-and-cli` cloud/shared command gained the ignore glob, and only a new `app-and-cli`-gated step gained the retry loop. `core-runtime`, `framework-packages`, `plugins`, and `build-and-helper-smokes` lanes and the generic "Run shard" loop are byte-for-byte unchanged in semantics.

### Verification caveat (disclosed)

The crash is intermittent WASM/Bun-canary native fragility, so it **cannot be deterministically reproduced or proven fixed headlessly** — this is a mitigation to keep one native panic from failing the shard, exactly as the issue's "Suggested handling" proposes. If it recurs, the per-attempt logs capture the panic for an upstream Bun report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Evidence rows

<!-- evidence-row:before-screenshots -->
Before screenshots: N/A - GitHub Actions workflow-only change; no rendered UI.

<!-- evidence-row:after-screenshots -->
After screenshots: N/A - GitHub Actions workflow-only change; no rendered UI.

<!-- evidence-row:walkthrough-video -->
Walkthrough video: N/A - no user-facing application flow changed.

<!-- evidence-row:backend-logs -->
Backend logs: N/A - no backend runtime changed; the exact Bun-canary selection and exclusion transcripts are included in the verification section above.

<!-- evidence-row:frontend-logs -->
Frontend logs: N/A - no frontend code or network path changed.

<!-- evidence-row:llm-trajectory -->
Real-LLM trajectory: N/A - no agent, action, provider, prompt, planner, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
Domain artifacts: N/A - no persisted product artifact is created; the workflow and its per-attempt CI logs are the changed operational artifact.