### PR TITLE
ci: monitor Headscale API key health

### DIFF
--- a/.github/workflows/headscale-api-key-health.yml
+++ b/.github/workflows/headscale-api-key-health.yml
@@ -1,0 +1,111 @@
+name: Headscale API Key Health
+
+# The Headscale admin key expires independently of deploy cadence. Probe the
+# daemon-local API from the control-plane host so an expired or rebuild-lost key
+# turns the nightly red without copying the admin credential into GitHub Actions.
+
+on:
+  schedule:
+    - cron: "23 7 * * *"
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Control-plane environment to probe"
+        type: choice
+        default: staging
+        options: [staging, production]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: headscale-api-key-health-${{ github.event.inputs.environment || 'staging' }}
+  cancel-in-progress: false
+
+jobs:
+  probe:
+    name: Probe ${{ github.event.inputs.environment || 'staging' }} Headscale key
+    runs-on: ubuntu-24.04
+    environment: ${{ github.event.inputs.environment || 'staging' }}
+    timeout-minutes: 5
+    env:
+      DEPLOY_HOST: ${{ secrets.ELIZA_PROVISIONING_HOST }}
+      DEPLOY_SSH_KEY: ${{ secrets.ELIZA_PROVISIONING_SSH_KEY }}
+    steps:
+      - name: Check probe configuration
+        run: |
+          fail=0
+          [ -n "$DEPLOY_HOST" ] || { echo "::error::missing secret ELIZA_PROVISIONING_HOST"; fail=1; }
+          [ -n "$DEPLOY_SSH_KEY" ] || { echo "::error::missing secret ELIZA_PROVISIONING_SSH_KEY"; fail=1; }
+          [ "$fail" = 0 ] || exit 1
+
+      - name: Probe daemon-local Headscale API
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2
+        with:
+          host: ${{ env.DEPLOY_HOST }}
+          username: deploy
+          key: ${{ env.DEPLOY_SSH_KEY }}
+          command_timeout: 2m
+          script: |
+            set -eu
+            ENV_FILE=/opt/eliza/cloud/.env.local
+            RESPONSE_FILE=$(mktemp)
+            trap 'rm -f "$RESPONSE_FILE"' EXIT
+
+            read_env_value() {
+              key="$1"
+              line=$(sudo grep -m1 "^${key}=" "$ENV_FILE" || true)
+              value="${line#*=}"
+              if [ "${value#\"}" != "$value" ] && [ "${value%\"}" != "$value" ]; then
+                value="${value#\"}"
+                value="${value%\"}"
+              fi
+              printf '%s' "$value"
+            }
+
+            sudo test -r "$ENV_FILE" || {
+              echo "::error::Headscale environment file is unreadable on the control-plane host"
+              exit 1
+            }
+
+            HEADSCALE_API_URL=$(read_env_value HEADSCALE_API_URL)
+            HEADSCALE_API_KEY=$(read_env_value HEADSCALE_API_KEY)
+            [ -n "$HEADSCALE_API_URL" ] || {
+              echo "::error::HEADSCALE_API_URL is missing from the control-plane environment"
+              exit 1
+            }
+            [ -n "$HEADSCALE_API_KEY" ] || {
+              echo "::error::HEADSCALE_API_KEY is missing from the control-plane environment"
+              exit 1
+            }
+
+            endpoint="${HEADSCALE_API_URL%/}/api/v1/user"
+            status=$(curl --silent --show-error --connect-timeout 5 --max-time 20 \
+              --output "$RESPONSE_FILE" --write-out '%{http_code}' \
+              --header "Authorization: Bearer $HEADSCALE_API_KEY" \
+              "$endpoint") || {
+                echo "::error::Headscale API probe could not reach the daemon-local endpoint"
+                exit 1
+              }
+
+            case "$status" in
+              200)
+                node -e '
+                  const fs = require("node:fs");
+                  const payload = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+                  if (!payload || !Array.isArray(payload.users)) process.exit(1);
+                ' "$RESPONSE_FILE" || {
+                  echo "::error::Headscale API returned HTTP 200 with an invalid user-list payload"
+                  exit 1
+                }
+                echo "Headscale API key accepted by the daemon-local endpoint."
+                ;;
+              401|403)
+                echo "::error::Headscale rejected the configured API key with HTTP $status; rotate it before provisioning fails"
+                exit 1
+                ;;
+              *)
+                echo "::error::Headscale API key probe returned unexpected HTTP $status"
+                exit 1
+                ;;
+            esac

--- a/packages/cloud/services/headscale/DEPLOY.md
+++ b/packages/cloud/services/headscale/DEPLOY.md
@@ -61,6 +61,13 @@ Worker secret path. Keep host and Worker values identical for
 `HEADSCALE_API_KEY`, `AGENT_TOKEN_PRIVATE_KEY_PEM`, and `ELIZA_LOCAL_ROOT_KEY`;
 otherwise the daemon can mint state that the Worker cannot validate.
 
+`headscale-api-key-health.yml` probes the daemon-local user-list endpoint from
+the staging control-plane host every day and fails on a missing, expired, or
+rejected key. It deliberately reads `HEADSCALE_API_KEY` from the host's
+`/opt/eliza/cloud/.env.local` instead of importing the admin key into the
+Actions runner. Production uses the same workflow through a manual dispatch
+because that GitHub Environment requires deployment approval.
+
 ### Manual equivalent
 
 ```bash

--- a/packages/scripts/__tests__/headscale-api-key-health-workflow.test.ts
+++ b/packages/scripts/__tests__/headscale-api-key-health-workflow.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Static contract for the scheduled Headscale credential probe. The monitor
+ * must fail loud on expired host-local credentials without importing the
+ * Headscale admin key into the GitHub Actions runner.
+ */
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const workflowText = readFileSync(
+  new URL(
+    "../../../.github/workflows/headscale-api-key-health.yml",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+function extractStepBody(stepName: string): string {
+  const escapedName = stepName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = workflowText.match(
+    new RegExp(
+      `^      - name: ${escapedName}\\n(?<body>[\\s\\S]*?)(?=^      - (?:name|uses|id): |$(?![\\s\\S]))`,
+      "m",
+    ),
+  );
+  if (!match?.groups?.body) {
+    throw new Error(`Missing workflow step: ${stepName}`);
+  }
+  return match.groups.body;
+}
+
+function extractRemoteScript(stepName: string): string {
+  const script = extractStepBody(stepName).match(
+    /^ {10}script: \|\n(?<body>(?: {12}.*(?:\n|$))*)/m,
+  )?.groups?.body;
+  if (!script) {
+    throw new Error(`Workflow step has no remote script: ${stepName}`);
+  }
+  return script
+    .split("\n")
+    .map((line) => line.replace(/^ {12}/, ""))
+    .join("\n");
+}
+
+describe("Headscale API key health workflow", () => {
+  test("runs staging on a daily cadence and keeps production manually selectable", () => {
+    expect(workflowText).toContain('cron: "23 7 * * *"');
+    expect(workflowText).toContain("options: [staging, production]");
+    expect(workflowText).toContain(
+      `environment: \${{ github.event.inputs.environment || "staging" }}`.replace(
+        '"staging"',
+        "'staging'",
+      ),
+    );
+  });
+
+  test("keeps the Headscale admin key on the control-plane host", () => {
+    const envBlock = workflowText.match(
+      / {4}env:\n(?<body>(?: {6}.*\n)+) {4}steps:/,
+    )?.groups?.body;
+
+    expect(envBlock).toBeDefined();
+    expect(envBlock).not.toContain("HEADSCALE_API_KEY");
+    expect(workflowText).not.toContain("secrets.HEADSCALE_API_KEY");
+
+    const probe = extractStepBody("Probe daemon-local Headscale API");
+    expect(probe).toContain("ENV_FILE=/opt/eliza/cloud/.env.local");
+    expect(probe).toContain(
+      "HEADSCALE_API_KEY=$(read_env_value HEADSCALE_API_KEY)",
+    );
+  });
+
+  test("fails loud for missing, rejected, unreachable, and malformed credentials", () => {
+    const probe = extractStepBody("Probe daemon-local Headscale API");
+
+    expect(probe).toContain("HEADSCALE_API_KEY is missing");
+    expect(probe).toContain("401|403)");
+    expect(probe).toContain("Headscale API probe could not reach");
+    expect(probe).toContain("HTTP 200 with an invalid user-list payload");
+    expect(probe).toContain("exit 1");
+  });
+
+  test("keeps the remote probe valid Bash", () => {
+    const result = spawnSync("bash", ["-n"], {
+      encoding: "utf8",
+      input: extractRemoteScript("Probe daemon-local Headscale API"),
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+  });
+});


### PR DESCRIPTION
Part of #15401 (Headscale API-key drift entry).

## Summary

- Add a daily staging Headscale API-key health workflow with a manual production path.
- Keep the admin key host-local and retrieve it only inside the remote SSH session.
- Fail loudly on missing configuration, transport errors, 401/403 responses, malformed JSON, and unexpected response shapes.
- Document the operational monitor and cover its security/failure invariants with focused tests.

## Verification

- Real Headscale v0.29.2 with isolated SQLite/state: a freshly minted API key produced HTTP 200 from `/api/v1/user`; an invalid key produced HTTP 401. The manually reviewed server log showed both requests and token validation failure without exposing the key: https://github.com/elizaOS/eliza/issues/15401#issuecomment-4930707484
- `bun test packages/scripts/__tests__/headscale-api-key-health-workflow.test.ts` — 4/4 pass.
- Focused Biome check — pass.
- Workflow YAML parse and extracted remote `bash -n` contract — pass.
- `bun run audit:scripts` — pass after rebase onto current `origin/develop`.
- `bun run audit:error-policy-ratchet` — pass.

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] N/A - server-side CI/operations workflow only; no existing rendered UI is changed.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no pixels, styles, components, or view structure changed.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - the observable behavior is a scheduled authenticated health probe, not a visual user flow.
<!-- evidence-row:backend-logs -->
- [x] Real Headscale v0.29.2 accepted/rejected request and manually reviewed server-log evidence: https://github.com/elizaOS/eliza/issues/15401#issuecomment-4930707484
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend package, browser request, or client state changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, action, provider, evaluator, planner, or inference behavior changed.
<!-- evidence-row:domain-artifacts -->\n- [x] Real minted-key HTTP 200, rejected-key HTTP 401, graceful Headscale shutdown, and workflow artifacts: https://github.com/elizaOS/eliza/issues/15401#issuecomment-4930707484

The first credentialed staging dispatch necessarily occurs after merge because the staging GitHub Environment and SSH credentials are unavailable to local development. Production remains a manual dispatch behind its Environment approval and should move the board card to human verification after merge.
