### PR TITLE
docs(orchestrator): document GitHub credential setup (PAT vs OAuth device flow, vault vs env) (#15796)

### DIFF
--- a/plugins/plugin-agent-orchestrator/AGENTS.md
+++ b/plugins/plugin-agent-orchestrator/AGENTS.md
@@ -247,8 +247,19 @@ bun run --cwd plugins/plugin-agent-orchestrator clean           # Remove dist/.t
 All are optional unless noted. Read by `src/services/config-env.ts` and
 `src/services/acp-service.ts`.
 
+**GitHub credentials** gate every GitHub-writing capability (`TASKS_MANAGE_ISSUES`,
+`TASKS_SUBMIT_WORKSPACE` commit/push/PR). Supply a PAT via `GITHUB_TOKEN` or run the
+OAuth device flow via `GITHUB_OAUTH_CLIENT_ID`. Both are read per-agent through
+`runtime.getSetting` in `src/services/workspace-github.ts`, so store the token in the
+**vault/settings, not process env** — a process-env `GITHUB_TOKEN` leaks to every agent
+on a shared/multi-tenant host, whereas `getSetting` scopes it to one agent. Full setup:
+README → "GitHub credentials".
+
 | Variable | Default | Purpose |
 |---|---|---|
+| `GITHUB_TOKEN` | unset | PAT for GitHub-writing capabilities (issues, push, PR). Read via `runtime.getSetting` — store per-agent in vault/settings, not process env (multi-tenant leak). Wins over device flow when both set. |
+| `GITHUB_OAUTH_CLIENT_ID` | unset | OAuth **device flow** client id (read via `getSetting`); used when no `GITHUB_TOKEN`. Requires a live `authPromptCallback` to surface the device-code prompt. |
+| `GITHUB_OAUTH_CLIENT_SECRET` | unset | Server-side OAuth secret for the device flow. Read directly from **process env** by design — deliberately kept out of the plugin `getSetting` allowlist. |
 | `ELIZA_ACP_TRANSPORT` | `native` | Transport: `native` (embedded JSON-RPC) or `cli`/`acpx` (legacy shell wrapper) |
 | `ELIZA_ACP_CLI` | `acpx` | Path/command for the CLI transport |
 | `ELIZA_ACP_DEFAULT_AGENT` | `elizaos` | Default agent type: `elizaos`, `pi-agent`, `opencode` |

--- a/plugins/plugin-agent-orchestrator/CLAUDE.md
+++ b/plugins/plugin-agent-orchestrator/CLAUDE.md
@@ -247,8 +247,19 @@ bun run --cwd plugins/plugin-agent-orchestrator clean           # Remove dist/.t
 All are optional unless noted. Read by `src/services/config-env.ts` and
 `src/services/acp-service.ts`.
 
+**GitHub credentials** gate every GitHub-writing capability (`TASKS_MANAGE_ISSUES`,
+`TASKS_SUBMIT_WORKSPACE` commit/push/PR). Supply a PAT via `GITHUB_TOKEN` or run the
+OAuth device flow via `GITHUB_OAUTH_CLIENT_ID`. Both are read per-agent through
+`runtime.getSetting` in `src/services/workspace-github.ts`, so store the token in the
+**vault/settings, not process env** — a process-env `GITHUB_TOKEN` leaks to every agent
+on a shared/multi-tenant host, whereas `getSetting` scopes it to one agent. Full setup:
+README → "GitHub credentials".
+
 | Variable | Default | Purpose |
 |---|---|---|
+| `GITHUB_TOKEN` | unset | PAT for GitHub-writing capabilities (issues, push, PR). Read via `runtime.getSetting` — store per-agent in vault/settings, not process env (multi-tenant leak). Wins over device flow when both set. |
+| `GITHUB_OAUTH_CLIENT_ID` | unset | OAuth **device flow** client id (read via `getSetting`); used when no `GITHUB_TOKEN`. Requires a live `authPromptCallback` to surface the device-code prompt. |
+| `GITHUB_OAUTH_CLIENT_SECRET` | unset | Server-side OAuth secret for the device flow. Read directly from **process env** by design — deliberately kept out of the plugin `getSetting` allowlist. |
 | `ELIZA_ACP_TRANSPORT` | `native` | Transport: `native` (embedded JSON-RPC) or `cli`/`acpx` (legacy shell wrapper) |
 | `ELIZA_ACP_CLI` | `acpx` | Path/command for the CLI transport |
 | `ELIZA_ACP_DEFAULT_AGENT` | `elizaos` | Default agent type: `elizaos`, `pi-agent`, `opencode` |

--- a/plugins/plugin-agent-orchestrator/README.md
+++ b/plugins/plugin-agent-orchestrator/README.md
@@ -169,6 +169,28 @@ Native transport is an ACP JSON-RPC client. It currently handles `initialize`, `
 
 Use the CLI transport only when you need the existing `acpx` command wrapper semantics.
 
+## GitHub credentials
+
+Every GitHub-touching capability needs a credential before it can act. Without one, the operation fails with a clean error naming both accepted settings (`ensureGitHubClient` in `src/services/workspace-github.ts`).
+
+**Which capabilities need a token:**
+
+| Capability | What breaks without a token |
+| --- | --- |
+| `TASKS_MANAGE_ISSUES` | create / list / get / update / comment / close / reopen / add-labels on GitHub issues (`src/services/workspace-github.ts`). |
+| `TASKS_SUBMIT_WORKSPACE` | authenticated `commit` / `push` / open-PR against the remote (`src/services/workspace-service.ts` → `workspace-git-ops.ts`). |
+
+Read-only actions (spawn, provision-workspace against a public repo) do not require a token; anything that writes to GitHub does.
+
+**Two ways to supply the credential:**
+
+1. **Personal access token (PAT)** — set `GITHUB_TOKEN`. Read at act-time via `runtime.getSetting("GITHUB_TOKEN")`, so it can be stored per-agent in the vault/settings and rotated without a restart. This is the path a live multi-tenant deployment uses: the agent acts as its own bot account with zero `GITHUB_*` in process env.
+2. **OAuth device flow** — set `GITHUB_OAUTH_CLIENT_ID` (via `getSetting`) and the server-side `GITHUB_OAUTH_CLIENT_SECRET` (read directly from process env, deliberately kept out of the plugin `getSetting` allowlist). On first GitHub access the agent surfaces a device-code prompt (verification URI + user code) through an immediate, user-visible channel and polls until the user completes login. The flow requires an `authPromptCallback` wired to a live chat path — a buffered action callback is unsafe because the flow blocks on user consent.
+
+When both are present, `GITHUB_TOKEN` wins.
+
+**Multi-tenant safety — prefer vault/settings over process env.** A `GITHUB_TOKEN` placed in the host **process environment** is visible to *every* agent sharing that host, so on a shared/cloud deployment one tenant's token would act on behalf of all of them. Store the token **per-agent in the runtime settings/vault** instead, where `runtime.getSetting("GITHUB_TOKEN")` scopes it to the single agent. The service does fall back to `process.env.GITHUB_TOKEN` for the git push/PR path, but that fallback is a single-tenant/local-dev convenience — do not rely on it on a shared host.
+
 ## Persistence
 
 Session state is persisted with a tiered backend:

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/github-credentials-docs.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/github-credentials-docs.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Documentation contract for GitHub credential setup (#15796).
+ *
+ * The orchestrator's GitHub-writing capabilities fail with a bare error until an
+ * operator discovers the right setting by reading source. This test pins the
+ * README/CLAUDE docs to the *actual* credential settings read by
+ * `src/services/workspace-github.ts`, so the docs can never silently drift from
+ * the setting names the code checks: it greps the real source for every
+ * `getSetting("GITHUB_*")` / `process.env.GITHUB_*` name and asserts each one is
+ * documented, plus the multi-tenant vault-vs-env safety point and the two
+ * capabilities that require a token. Reads real files off disk — no mocks.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const pkgRoot = fileURLToPath(new URL("../..", import.meta.url));
+const read = (rel: string) => readFileSync(`${pkgRoot}/${rel}`, "utf8");
+
+const workspaceGithubSrc = read("src/services/workspace-github.ts");
+const readme = read("README.md");
+const claudeMd = read("CLAUDE.md");
+const agentsMd = read("AGENTS.md");
+
+// The credential setting names the code actually consults, extracted from source
+// rather than hard-coded here, so renaming a setting fails this test until docs follow.
+function githubSettingNames(src: string): string[] {
+  const names = new Set<string>();
+  for (const m of src.matchAll(/getSetting\(\s*["'](GITHUB_[A-Z_]+)["']/g)) {
+    names.add(m[1]);
+  }
+  for (const m of src.matchAll(/process\.env\.(GITHUB_[A-Z_]+)/g)) {
+    names.add(m[1]);
+  }
+  return [...names];
+}
+
+describe("GitHub credential documentation (#15796)", () => {
+  const settings = githubSettingNames(workspaceGithubSrc);
+
+  it("extracts the expected credential settings from workspace-github.ts", () => {
+    expect(settings).toEqual(
+      expect.arrayContaining([
+        "GITHUB_TOKEN",
+        "GITHUB_OAUTH_CLIENT_ID",
+        "GITHUB_OAUTH_CLIENT_SECRET",
+      ]),
+    );
+  });
+
+  it("README documents every credential setting the code reads", () => {
+    for (const name of settings) {
+      expect(readme, `README must document ${name}`).toContain(name);
+    }
+  });
+
+  it("README distinguishes PAT from OAuth device flow", () => {
+    expect(readme).toMatch(/PAT|personal access token/i);
+    expect(readme).toMatch(/device flow/i);
+  });
+
+  it("README states the multi-tenant vault-vs-env safety point", () => {
+    expect(readme).toMatch(/vault|settings/i);
+    expect(readme).toMatch(/process env/i);
+    expect(readme).toMatch(/multi-tenant|shared host|every agent/i);
+  });
+
+  it("README names the capabilities that require a token", () => {
+    expect(readme).toContain("TASKS_MANAGE_ISSUES");
+    expect(readme).toContain("TASKS_SUBMIT_WORKSPACE");
+  });
+
+  it("CLAUDE.md and AGENTS.md mirror the key credential point and stay identical", () => {
+    expect(claudeMd).toBe(agentsMd);
+    for (const name of settings) {
+      expect(claudeMd, `CLAUDE.md must document ${name}`).toContain(name);
+    }
+    expect(claudeMd).toMatch(/vault|getSetting/);
+  });
+});


### PR DESCRIPTION
## What & why

Closes #15796 (docs slice). A newly-spun-up agent had no user-facing doc for GitHub credentials, so every GitHub-writing capability failed until the operator discovered the right setting by reading source.

Scope is **only** "What's missing" item #3 (docs). Items #1 (onboarding surface) and #2 (cloud provisioning identity story) are undecided design and explicitly out of scope — they belong in a separate feature PR.

## Changes

- **`plugins/plugin-agent-orchestrator/README.md`** — new **"GitHub credentials"** section documenting:
  - **PAT** via `runtime.getSetting("GITHUB_TOKEN")` **vs OAuth device flow** via `GITHUB_OAUTH_CLIENT_ID` (+ server-side `GITHUB_OAUTH_CLIENT_SECRET`, kept out of the `getSetting` allowlist by design);
  - the **multi-tenant safety** distinction — a process-env `GITHUB_TOKEN` leaks to every agent on a shared host, so store per-agent in vault/settings where `getSetting` scopes it to one agent;
  - **which capabilities require a token** — `TASKS_MANAGE_ISSUES`, `TASKS_SUBMIT_WORKSPACE` (commit/push/PR).
- **`CLAUDE.md` / `AGENTS.md`** (kept identical) — mirror the key point into the config-env table with the three `GITHUB_*` rows and a pointer to the README section.
- **Test** — `__tests__/unit/github-credentials-docs.test.ts`: a docs-contract test that greps the *real* credential setting names out of `src/services/workspace-github.ts` and asserts each is documented, plus the PAT-vs-device-flow, vault-vs-env, and required-capability points. This pins docs to the code so a setting rename fails the test until docs follow.

All documented setting names verified against `getSetting(...)` / `process.env.*` usage in `workspace-github.ts` and `workspace-service.ts`.

## Test evidence

Fail-before / pass-after on the same test (drives real files off disk, no mocks):

**Before** (README at `origin/develop`):
```
❯ github-credentials-docs.test.ts (6 tests | 3 failed) 459ms
 Tests  3 failed | 3 passed (6)
```
**After** (this branch):
```
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

Lint on the touched test file: `bunx biome check` → `Checked 1 file. No fixes applied.`

**Typecheck:** N/A for a green package run in this worktree — `bun run typecheck` fails only on pre-existing environmental gaps from `install:light` (missing built workspace artifacts: `@elizaos/contracts`, `@elizaos/cloud-routing`, generated i18n data). None reference the touched files; the new test imports only node built-ins + vitest.

**Visual/trajectory/domain-artifact evidence:** N/A — docs + a docs-contract test only; no runtime behavior, UI, agent, or model path changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Evidence rows

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - documentation and a docs-contract test only; no rendered UI changes.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - documentation and a docs-contract test only; no rendered UI changes.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no user-facing runtime flow changed.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no backend runtime path changed.

<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend code, console, or network path changed.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, planner, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no persisted domain state is created; the real documentation files and six-case docs-contract test are the changed artifacts.