### PR TITLE
fix(cloud): exclude loopback bridge sentinel from scheduled backups (#15737)

### DIFF
--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-execute-dispatch.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-execute-dispatch.test.ts
@@ -1,0 +1,546 @@
+/**
+ * Drives the REAL job-execution dispatch of ProvisioningJobService end-to-end:
+ * `processPendingJobs` → `processJobType` → `executeJob` → the per-type
+ * `executeAgent*` handler, plus the failure path's `buildPermanentFailureWriteback`
+ * construction. Every job type's success AND failure branch is exercised so the
+ * dispatch table, the per-handler result-record shaping, and the terminal-vs-retry
+ * disposition are all covered by real code, not asserted against a stand-in.
+ *
+ * The only stubs are the two genuine boundaries the daemon dispatch sits on:
+ * `jobsRepository` (the Postgres job store) and `elizaSandboxService` (the
+ * transport that SSHes the Hetzner cores / calls the container bridge). Mirrors
+ * the harness in `provisioning-jobs-delete-lifecycle.test.ts`; no DB is touched,
+ * so this file is process-isolated and safe to run alongside the DB-backed
+ * suites in the same `bun test` invocation.
+ */
+
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+
+import { jobsRepository } from "../../db/repositories/jobs";
+import type { Job } from "../../db/schemas/jobs";
+import { elizaSandboxService } from "./eliza-sandbox";
+import { JOB_TYPES, type ProvisioningJobType } from "./provisioning-job-types";
+import { provisioningJobService } from "./provisioning-jobs";
+
+const ORG = "22222222-2222-4222-8222-222222222222";
+const AGENT = "e06bb509-6c52-4c33-a9f7-66addc43e8c8";
+const USER = "33333333-3333-4333-8333-333333333333";
+
+function makeJob(
+  type: string,
+  extraData: Record<string, unknown> = {},
+  overrides: Partial<Job> = {},
+): Job {
+  const now = new Date("2026-06-20T00:00:00.000Z");
+  return {
+    id: "44444444-4444-4444-8444-444444444444",
+    type: type as Job["type"],
+    status: "in_progress",
+    data: {
+      agentId: AGENT,
+      organizationId: ORG,
+      userId: USER,
+      agentName: "Test Agent",
+      ...extraData,
+    },
+    data_storage: "inline",
+    data_key: null,
+    agent_id: AGENT,
+    character_id: null,
+    result: null,
+    result_storage: "inline",
+    result_key: null,
+    error: null,
+    error_storage: "inline",
+    error_key: null,
+    attempts: 1,
+    max_attempts: 3,
+    organization_id: ORG,
+    user_id: USER,
+    api_key_id: null,
+    generation_id: null,
+    webhook_url: null,
+    webhook_status: null,
+    estimated_completion_at: null,
+    scheduled_for: now,
+    started_at: now,
+    completed_at: null,
+    created_at: now,
+    updated_at: now,
+    ...overrides,
+  };
+}
+
+/**
+ * Claim exactly one crafted job of `type` and stub the job-store writes so the
+ * real dispatch runs against controlled repository responses. `incrementAttempt`
+ * resolves undefined (attempts not yet exhausted) so the failure path stops after
+ * building — but not invoking — the permanent-failure writeback, matching the
+ * daemon's mid-retry behavior.
+ */
+function harness(job: Job) {
+  const claimSpy = spyOn(jobsRepository, "claimPendingJobs").mockImplementation(
+    async (f: { type: string }) => (f.type === job.type ? [job] : []),
+  );
+  const recoverSpy = spyOn(jobsRepository, "recoverStaleJobs").mockResolvedValue(0);
+  const updateStatusSpy = spyOn(jobsRepository, "updateStatus").mockResolvedValue(undefined);
+  const updateSpy = spyOn(jobsRepository, "update").mockResolvedValue(undefined as never);
+  const incrementSpy = spyOn(jobsRepository, "incrementAttempt").mockResolvedValue(undefined);
+  const retryLaterSpy = spyOn(
+    jobsRepository,
+    "retryLaterWithoutIncrementingAttempts",
+  ).mockResolvedValue(undefined);
+  return { job, claimSpy, recoverSpy, updateStatusSpy, updateSpy, incrementSpy, retryLaterSpy };
+}
+
+const serviceSpies: Array<{ mockRestore: () => void }> = [];
+function stub<M extends keyof typeof elizaSandboxService>(method: M, value: unknown) {
+  const spy = spyOn(elizaSandboxService, method).mockResolvedValue(value as never);
+  serviceSpies.push(spy);
+  return spy;
+}
+
+afterEach(() => {
+  for (const s of serviceSpies.splice(0)) s.mockRestore();
+});
+
+async function run(type: string) {
+  return provisioningJobService.processPendingJobs(1, {
+    jobTypes: [type as ProvisioningJobType],
+  });
+}
+
+function completedCall(ctx: ReturnType<typeof harness>) {
+  return ctx.updateStatusSpy.mock.calls.find((c) => c[1] === "completed");
+}
+
+/**
+ * One row per agent job type: the crafted job.data, the transport method the
+ * handler delegates to, and a representative SUCCESS payload. Failure is a
+ * uniform `{ success: false, error }` (bridge/message uses its own shape below).
+ */
+const AGENT_ARMS: Array<{
+  name: string;
+  type: ProvisioningJobType;
+  data: Record<string, unknown>;
+  method: keyof typeof elizaSandboxService;
+  success: Record<string, unknown>;
+}> = [
+  {
+    name: "provision",
+    type: JOB_TYPES.AGENT_PROVISION,
+    data: {},
+    method: "provision",
+    success: {
+      success: true,
+      sandboxRecord: { id: AGENT, organization_id: ORG, user_id: USER, status: "running" },
+      bridgeUrl: "http://10.0.0.5:8080",
+      healthUrl: "http://10.0.0.5:8081",
+    },
+  },
+  {
+    name: "delete",
+    type: JOB_TYPES.AGENT_DELETE,
+    data: {},
+    method: "executeDeletion",
+    success: { success: true, containerStopped: true },
+  },
+  {
+    name: "suspend",
+    type: JOB_TYPES.AGENT_SUSPEND,
+    data: {},
+    method: "executeSuspend",
+    success: { success: true, containerStopped: true },
+  },
+  {
+    name: "resume",
+    type: JOB_TYPES.AGENT_RESUME,
+    data: {},
+    method: "executeResume",
+    success: { success: true, containerStarted: true, reprovisioned: false },
+  },
+  {
+    name: "sleep",
+    type: JOB_TYPES.AGENT_SLEEP,
+    data: {},
+    method: "executeSleep",
+    success: { success: true, containerRemoved: true, backupId: "backup-sleep" },
+  },
+  {
+    name: "wake",
+    type: JOB_TYPES.AGENT_WAKE,
+    data: { restoreBackupId: "backup-sleep", forceFreshBoot: false },
+    method: "executeWake",
+    success: {
+      success: true,
+      reprovisioned: true,
+      restoredBackupId: "backup-sleep",
+      freshBoot: false,
+    },
+  },
+  {
+    name: "restart",
+    type: JOB_TYPES.AGENT_RESTART,
+    data: {},
+    method: "executeRestart",
+    success: {
+      success: true,
+      containerStopped: true,
+      containerStarted: true,
+      bridgeUrl: "http://10.0.0.5:8080",
+      healthUrl: "http://10.0.0.5:8081",
+    },
+  },
+  {
+    name: "upgrade",
+    type: JOB_TYPES.AGENT_UPGRADE,
+    data: { dockerImage: "eliza/agent", fromDigest: "sha256:old", toDigest: "sha256:new" },
+    method: "executeUpgrade",
+    success: {
+      success: true,
+      oldNodeId: "node-a",
+      oldContainerName: "c-old",
+      newNodeId: "node-b",
+      newContainerName: "c-new",
+      newDigest: "sha256:new",
+    },
+  },
+  {
+    name: "downgrade",
+    type: JOB_TYPES.AGENT_DOWNGRADE,
+    data: { dockerImage: "eliza/agent", fromDigest: "sha256:cur" },
+    method: "executeDowngrade",
+    success: {
+      success: true,
+      oldNodeId: "node-b",
+      oldContainerName: "c-new",
+      newNodeId: "node-a",
+      newContainerName: "c-old",
+      newDigest: "sha256:old",
+    },
+  },
+  {
+    name: "logs",
+    type: JOB_TYPES.AGENT_LOGS,
+    data: { tail: 100 },
+    method: "executeLogs",
+    success: { success: true, status: "ok", logs: "line-1\nline-2", message: "collected" },
+  },
+  {
+    name: "snapshot",
+    type: JOB_TYPES.AGENT_SNAPSHOT,
+    data: { snapshotType: "manual" },
+    method: "executeSnapshot",
+    success: {
+      success: true,
+      backup: {
+        id: "backup-1",
+        snapshot_type: "manual",
+        size_bytes: 2048,
+        created_at: new Date("2026-06-20T00:00:00.000Z").toISOString(),
+      },
+    },
+  },
+];
+
+describe("executeJob dispatch — success path per job type marks the job completed", () => {
+  for (const arm of AGENT_ARMS) {
+    test(`${arm.name}: transport success → completed with a result record, no attempt burned`, async () => {
+      const ctx = harness(makeJob(arm.type, arm.data));
+      stub(arm.method, arm.success);
+      try {
+        const res = await run(arm.type);
+        expect(res.claimed).toBe(1);
+        expect(res.succeeded).toBe(1);
+        expect(res.failed).toBe(0);
+        expect(res.retried).toBe(0);
+        const completed = completedCall(ctx);
+        expect(completed).toBeDefined();
+        expect(completed?.[2]?.result).toBeTruthy();
+        expect(completed?.[2]?.completed_at).toBeInstanceOf(Date);
+        expect(ctx.incrementSpy).not.toHaveBeenCalled();
+      } finally {
+        ctx.claimSpy.mockRestore();
+        ctx.recoverSpy.mockRestore();
+        ctx.updateStatusSpy.mockRestore();
+        ctx.updateSpy.mockRestore();
+        ctx.incrementSpy.mockRestore();
+        ctx.retryLaterSpy.mockRestore();
+      }
+    });
+  }
+
+  test("message: bridge reply is stored on the job result and completes", async () => {
+    const ctx = harness(makeJob(JOB_TYPES.AGENT_MESSAGE, { text: "hello", nonce: "n-1" }));
+    const bridgeSpy = spyOn(elizaSandboxService, "bridge").mockResolvedValue({
+      jsonrpc: "2.0",
+      id: null,
+      result: { text: "hi there" },
+    } as never);
+    try {
+      const res = await run(JOB_TYPES.AGENT_MESSAGE);
+      expect(res.succeeded).toBe(1);
+      expect(res.failed).toBe(0);
+      const completed = completedCall(ctx);
+      expect(completed?.[2]?.result).toMatchObject({ text: "hi there" });
+    } finally {
+      bridgeSpy.mockRestore();
+      ctx.claimSpy.mockRestore();
+      ctx.recoverSpy.mockRestore();
+      ctx.updateStatusSpy.mockRestore();
+      ctx.updateSpy.mockRestore();
+      ctx.incrementSpy.mockRestore();
+      ctx.retryLaterSpy.mockRestore();
+    }
+  });
+});
+
+describe("executeJob dispatch — failure path per job type retries (increments attempt)", () => {
+  for (const arm of AGENT_ARMS) {
+    test(`${arm.name}: transport failure → not completed, one attempt burned`, async () => {
+      const ctx = harness(makeJob(arm.type, arm.data));
+      stub(arm.method, { success: false, error: `${arm.name} transport boom` });
+      try {
+        const res = await run(arm.type);
+        expect(res.claimed).toBe(1);
+        expect(res.succeeded).toBe(0);
+        expect(res.failed).toBe(1);
+        expect(ctx.incrementSpy).toHaveBeenCalledTimes(1);
+        expect(ctx.incrementSpy.mock.calls[0]?.[0]).toBe(ctx.job.id);
+        expect(completedCall(ctx)).toBeUndefined();
+      } finally {
+        ctx.claimSpy.mockRestore();
+        ctx.recoverSpy.mockRestore();
+        ctx.updateStatusSpy.mockRestore();
+        ctx.updateSpy.mockRestore();
+        ctx.incrementSpy.mockRestore();
+        ctx.retryLaterSpy.mockRestore();
+      }
+    });
+  }
+
+  test("message: bridge error is stored on the job result and the job fails", async () => {
+    const ctx = harness(makeJob(JOB_TYPES.AGENT_MESSAGE, { text: "hello", nonce: "n-1" }));
+    const bridgeSpy = spyOn(elizaSandboxService, "bridge").mockResolvedValue({
+      jsonrpc: "2.0",
+      id: null,
+      error: { code: -32000, message: "bridge unreachable" },
+    } as never);
+    try {
+      const res = await run(JOB_TYPES.AGENT_MESSAGE);
+      expect(res.failed).toBe(1);
+      expect(ctx.updateSpy).toHaveBeenCalledWith(
+        ctx.job.id,
+        expect.objectContaining({
+          result: expect.objectContaining({ error: "bridge unreachable" }),
+        }),
+      );
+      expect(ctx.incrementSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      bridgeSpy.mockRestore();
+      ctx.claimSpy.mockRestore();
+      ctx.recoverSpy.mockRestore();
+      ctx.updateStatusSpy.mockRestore();
+      ctx.updateSpy.mockRestore();
+      ctx.incrementSpy.mockRestore();
+      ctx.retryLaterSpy.mockRestore();
+    }
+  });
+});
+
+describe("executeJob dispatch — type-specific disposition rules", () => {
+  test("agent_provision retryable transport → requeued without burning an attempt", async () => {
+    const ctx = harness(makeJob(JOB_TYPES.AGENT_PROVISION));
+    stub("provision", {
+      success: false,
+      retryable: true,
+      error: "readiness probe transport_unresolved",
+      sandboxRecord: { id: AGENT, organization_id: ORG, user_id: USER, status: "provisioning" },
+    });
+    try {
+      const res = await run(JOB_TYPES.AGENT_PROVISION);
+      expect(res.retried).toBe(1);
+      expect(res.failed).toBe(0);
+      expect(ctx.retryLaterSpy).toHaveBeenCalledTimes(1);
+      expect(ctx.retryLaterSpy.mock.calls[0]?.[1]).toBe("readiness probe transport_unresolved");
+      expect(ctx.incrementSpy).not.toHaveBeenCalled();
+    } finally {
+      ctx.claimSpy.mockRestore();
+      ctx.recoverSpy.mockRestore();
+      ctx.updateStatusSpy.mockRestore();
+      ctx.updateSpy.mockRestore();
+      ctx.incrementSpy.mockRestore();
+      ctx.retryLaterSpy.mockRestore();
+    }
+  });
+
+  test("auto snapshot of a stopped agent → completed-as-skipped, no retry", async () => {
+    const ctx = harness(makeJob(JOB_TYPES.AGENT_SNAPSHOT, { snapshotType: "auto" }));
+    stub("executeSnapshot", { success: false, error: "Sandbox is not running" });
+    try {
+      const res = await run(JOB_TYPES.AGENT_SNAPSHOT);
+      expect(res.succeeded).toBe(1);
+      expect(res.failed).toBe(0);
+      expect(completedCall(ctx)?.[2]?.result).toMatchObject({
+        skipped: true,
+        reason: "Sandbox is not running",
+      });
+      expect(ctx.incrementSpy).not.toHaveBeenCalled();
+    } finally {
+      ctx.claimSpy.mockRestore();
+      ctx.recoverSpy.mockRestore();
+      ctx.updateStatusSpy.mockRestore();
+      ctx.updateSpy.mockRestore();
+      ctx.incrementSpy.mockRestore();
+      ctx.retryLaterSpy.mockRestore();
+    }
+  });
+
+  test("agent_wake integrity-gate refusal → fails and preserves the sleeping row (no writeback)", async () => {
+    const ctx = harness(makeJob(JOB_TYPES.AGENT_WAKE, { restoreBackupId: "b1" }));
+    stub("executeWake", {
+      success: false,
+      error: "restore integrity check failed",
+      integrityFailure: {
+        backupId: "b1",
+        kind: "digest_mismatch",
+        message: "backup digest does not match",
+      },
+    });
+    try {
+      const res = await run(JOB_TYPES.AGENT_WAKE);
+      expect(res.failed).toBe(1);
+      expect(ctx.incrementSpy).toHaveBeenCalledTimes(1);
+      // AGENT_WAKE has no permanent-failure writeback callback.
+      expect(ctx.incrementSpy.mock.calls[0]?.[3]).toBeUndefined();
+    } finally {
+      ctx.claimSpy.mockRestore();
+      ctx.recoverSpy.mockRestore();
+      ctx.updateStatusSpy.mockRestore();
+      ctx.updateSpy.mockRestore();
+      ctx.incrementSpy.mockRestore();
+      ctx.retryLaterSpy.mockRestore();
+    }
+  });
+
+  test("permanent-failure writeback is built for provision (dependent row flip) but not for suspend", async () => {
+    const provCtx = harness(makeJob(JOB_TYPES.AGENT_PROVISION));
+    stub("provision", { success: false, error: "down", sandboxRecord: { status: "error" } });
+    try {
+      await run(JOB_TYPES.AGENT_PROVISION);
+      // AGENT_PROVISION supplies an onFailedInTx callback (arg 4) so the sandbox
+      // row can flip to `error` atomically with the job's terminal write.
+      expect(typeof provCtx.incrementSpy.mock.calls[0]?.[3]).toBe("function");
+    } finally {
+      provCtx.claimSpy.mockRestore();
+      provCtx.recoverSpy.mockRestore();
+      provCtx.updateStatusSpy.mockRestore();
+      provCtx.updateSpy.mockRestore();
+      provCtx.incrementSpy.mockRestore();
+      provCtx.retryLaterSpy.mockRestore();
+    }
+
+    const suspendCtx = harness(makeJob(JOB_TYPES.AGENT_SUSPEND));
+    stub("executeSuspend", { success: false, error: "down" });
+    try {
+      await run(JOB_TYPES.AGENT_SUSPEND);
+      // AGENT_SUSPEND has no dependent row to flip → no writeback callback.
+      expect(suspendCtx.incrementSpy.mock.calls[0]?.[3]).toBeUndefined();
+    } finally {
+      suspendCtx.claimSpy.mockRestore();
+      suspendCtx.recoverSpy.mockRestore();
+      suspendCtx.updateStatusSpy.mockRestore();
+      suspendCtx.updateSpy.mockRestore();
+      suspendCtx.incrementSpy.mockRestore();
+      suspendCtx.retryLaterSpy.mockRestore();
+    }
+  });
+
+  test("agent_upgrade permanent failure classified genuinely-dead builds a terminal writeback", async () => {
+    const ctx = harness(
+      makeJob(JOB_TYPES.AGENT_UPGRADE, {
+        dockerImage: "eliza/agent",
+        fromDigest: "sha256:old",
+        toDigest: "sha256:new",
+      }),
+    );
+    // rolledBack:false → executeAgentUpgrade throws UpgradeFailedError({rolledBack:false}),
+    // and buildPermanentFailureWriteback returns the terminal `status:error` branch.
+    stub("executeUpgrade", { success: false, error: "agent not serving", rolledBack: false });
+    try {
+      const res = await run(JOB_TYPES.AGENT_UPGRADE);
+      expect(res.failed).toBe(1);
+      expect(typeof ctx.incrementSpy.mock.calls[0]?.[3]).toBe("function");
+    } finally {
+      ctx.claimSpy.mockRestore();
+      ctx.recoverSpy.mockRestore();
+      ctx.updateStatusSpy.mockRestore();
+      ctx.updateSpy.mockRestore();
+      ctx.incrementSpy.mockRestore();
+      ctx.retryLaterSpy.mockRestore();
+    }
+  });
+
+  test("agent-not-found from any lifecycle call → terminal no-op, attempt not burned", async () => {
+    const ctx = harness(makeJob(JOB_TYPES.AGENT_RESTART));
+    stub("executeRestart", { success: false, error: "Agent not found" });
+    try {
+      const res = await run(JOB_TYPES.AGENT_RESTART);
+      expect(res.succeeded).toBe(1);
+      expect(res.failed).toBe(0);
+      expect(completedCall(ctx)?.[2]?.result).toMatchObject({
+        skipped: true,
+        reason: "Agent not found",
+      });
+      expect(ctx.incrementSpy).not.toHaveBeenCalled();
+    } finally {
+      ctx.claimSpy.mockRestore();
+      ctx.recoverSpy.mockRestore();
+      ctx.updateStatusSpy.mockRestore();
+      ctx.updateSpy.mockRestore();
+      ctx.incrementSpy.mockRestore();
+      ctx.retryLaterSpy.mockRestore();
+    }
+  });
+
+  test("organization-id mismatch between payload and column fails before any transport call", async () => {
+    const ctx = harness(
+      makeJob(JOB_TYPES.AGENT_SUSPEND, { organizationId: "99999999-9999-4999-8999-999999999999" }),
+    );
+    const svcSpy = spyOn(elizaSandboxService, "executeSuspend").mockResolvedValue({
+      success: true,
+    } as never);
+    try {
+      const res = await run(JOB_TYPES.AGENT_SUSPEND);
+      expect(res.failed).toBe(1);
+      // The guard throws before delegating to the transport.
+      expect(svcSpy).not.toHaveBeenCalled();
+      expect(ctx.incrementSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      svcSpy.mockRestore();
+      ctx.claimSpy.mockRestore();
+      ctx.recoverSpy.mockRestore();
+      ctx.updateStatusSpy.mockRestore();
+      ctx.updateSpy.mockRestore();
+      ctx.incrementSpy.mockRestore();
+      ctx.retryLaterSpy.mockRestore();
+    }
+  });
+
+  test("an unrecognized job type hits the dispatch default and fails the job", async () => {
+    const ctx = harness(makeJob("agent_teleport"));
+    try {
+      const res = await run("agent_teleport");
+      expect(res.claimed).toBe(1);
+      expect(res.failed).toBe(1);
+      expect(res.errors[0]?.error).toContain("Unknown job type");
+    } finally {
+      ctx.claimSpy.mockRestore();
+      ctx.recoverSpy.mockRestore();
+      ctx.updateStatusSpy.mockRestore();
+      ctx.updateSpy.mockRestore();
+      ctx.incrementSpy.mockRestore();
+      ctx.retryLaterSpy.mockRestore();
+    }
+  });
+});

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-scheduled-backup-sentinel.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-scheduled-backup-sentinel.test.ts
@@ -40,6 +40,7 @@ import { organizations } from "../../db/schemas/organizations";
 import { usageRecords } from "../../db/schemas/usage-records";
 import { userCharacters } from "../../db/schemas/user-characters";
 import { users } from "../../db/schemas/users";
+import { JOB_TYPES } from "./provisioning-job-types";
 import { provisioningJobService } from "./provisioning-jobs";
 
 const PGLITE_TIMEOUT = 60_000;
@@ -287,5 +288,234 @@ describe("enqueueScheduledBackups — enqueue behavior", () => {
     } finally {
       spy.mockRestore();
     }
+  });
+});
+
+/**
+ * Enqueue side of the same service, driven against the real PGlite so the
+ * shared `enqueueLifecycleJob` transaction (advisory lock, sandbox read,
+ * in-flight idempotency, row insert) and every per-type wrapper's job-data
+ * shaping actually run. The scheduled-backup scan above only exercises the
+ * snapshot enqueue; these cover the lifecycle enqueue surface the route layer
+ * calls into, so a regression in the job-data record shape or the reuse
+ * predicate is a red test rather than a silent bad row on the queue.
+ */
+describe("enqueueAgent*Once — real lifecycle-job inserts", () => {
+  async function seedAgent(): Promise<{ agentId: string; orgId: string; userId: string }> {
+    const { orgId, userId } = await seedOwner();
+    const [sandbox] = await dbWrite
+      .insert(agentSandboxes)
+      .values({
+        organization_id: orgId,
+        user_id: userId,
+        agent_name: uniq("agent"),
+        status: "running" as never,
+        bridge_url: REACHABLE_BRIDGE,
+      })
+      .returning();
+    return { agentId: sandbox.id, orgId, userId };
+  }
+
+  async function jobsOfType(
+    agentId: string,
+    type: string,
+  ): Promise<Array<Record<string, unknown>>> {
+    return (await dbWrite
+      .select()
+      .from(jobs)
+      .where(and(eq(jobs.agent_id, agentId), eq(jobs.type, type as never)))) as Array<
+      Record<string, unknown>
+    >;
+  }
+
+  test("provision enqueues a single pending agent_provision job and reuses it on a second call", async () => {
+    const { agentId, orgId, userId } = await seedAgent();
+    const first = await provisioningJobService.enqueueAgentProvisionOnce({
+      agentId,
+      organizationId: orgId,
+      userId,
+      agentName: "prov-agent",
+    });
+    expect(first.created).toBe(true);
+    expect(first.job.type).toBe(JOB_TYPES.AGENT_PROVISION);
+    expect(first.job.status).toBe("pending");
+
+    // Second enqueue while the first is still pending reuses it (idempotent
+    // enqueueLifecycleJob) rather than queuing a duplicate provision.
+    const second = await provisioningJobService.enqueueAgentProvisionOnce({
+      agentId,
+      organizationId: orgId,
+      userId,
+      agentName: "prov-agent",
+    });
+    expect(second.created).toBe(false);
+    expect(second.job.id).toBe(first.job.id);
+    expect(await jobsOfType(agentId, JOB_TYPES.AGENT_PROVISION)).toHaveLength(1);
+  });
+
+  test("the enqueueAgentProvision convenience wrapper returns the queued job", async () => {
+    const { agentId, orgId, userId } = await seedAgent();
+    const job = await provisioningJobService.enqueueAgentProvision({
+      agentId,
+      organizationId: orgId,
+      userId,
+      agentName: "prov-agent",
+    });
+    expect(job.type).toBe(JOB_TYPES.AGENT_PROVISION);
+    expect(await jobsOfType(agentId, JOB_TYPES.AGENT_PROVISION)).toHaveLength(1);
+  });
+
+  test("suspend/resume/sleep/restart each enqueue their own pending job", async () => {
+    const cases: Array<{
+      type: string;
+      call: (a: { agentId: string; organizationId: string; userId: string }) => Promise<unknown>;
+    }> = [
+      {
+        type: JOB_TYPES.AGENT_SUSPEND,
+        call: (p) => provisioningJobService.enqueueAgentSuspendOnce(p),
+      },
+      {
+        type: JOB_TYPES.AGENT_RESUME,
+        call: (p) => provisioningJobService.enqueueAgentResumeOnce(p),
+      },
+      { type: JOB_TYPES.AGENT_SLEEP, call: (p) => provisioningJobService.enqueueAgentSleepOnce(p) },
+      {
+        type: JOB_TYPES.AGENT_RESTART,
+        call: (p) => provisioningJobService.enqueueAgentRestartOnce(p),
+      },
+    ];
+    for (const c of cases) {
+      const { agentId, orgId, userId } = await seedAgent();
+      const res = (await c.call({ agentId, organizationId: orgId, userId })) as {
+        created: boolean;
+        job: { type: string };
+      };
+      expect(res.created).toBe(true);
+      expect(res.job.type).toBe(c.type);
+      expect(await jobsOfType(agentId, c.type)).toHaveLength(1);
+    }
+  });
+
+  test("wake echoes the applied restore params and records them on the job data", async () => {
+    const { agentId, orgId, userId } = await seedAgent();
+    const res = await provisioningJobService.enqueueAgentWakeOnce({
+      agentId,
+      organizationId: orgId,
+      userId,
+      restoreBackupId: "backup-xyz",
+      forceFreshBoot: false,
+    });
+    expect(res.created).toBe(true);
+    expect(res.job.type).toBe(JOB_TYPES.AGENT_WAKE);
+    expect(res.appliedRestoreBackupId).toBe("backup-xyz");
+    expect(res.appliedForceFreshBoot).toBe(false);
+    expect((res.job.data as { restoreBackupId?: string }).restoreBackupId).toBe("backup-xyz");
+  });
+
+  test("upgrade and downgrade carry their image/digest job data", async () => {
+    const { agentId, orgId, userId } = await seedAgent();
+    const up = await provisioningJobService.enqueueAgentUpgradeOnce({
+      agentId,
+      organizationId: orgId,
+      userId,
+      dockerImage: "eliza/agent",
+      fromDigest: "sha256:old",
+      toDigest: "sha256:new",
+    });
+    expect(up.created).toBe(true);
+    expect((up.job.data as { toDigest?: string }).toDigest).toBe("sha256:new");
+
+    const down = await provisioningJobService.enqueueAgentDowngradeOnce({
+      agentId,
+      organizationId: orgId,
+      userId,
+      dockerImage: "eliza/agent",
+      fromDigest: "sha256:new",
+    });
+    expect(down.created).toBe(true);
+    expect(down.job.type).toBe(JOB_TYPES.AGENT_DOWNGRADE);
+    expect((down.job.data as { fromDigest?: string }).fromDigest).toBe("sha256:new");
+  });
+
+  test("logs enqueues with the requested tail and dedupes on the tail predicate", async () => {
+    const { agentId, orgId, userId } = await seedAgent();
+    const first = await provisioningJobService.enqueueAgentLogsOnce({
+      agentId,
+      organizationId: orgId,
+      userId,
+      tail: 250,
+    });
+    expect(first.created).toBe(true);
+    expect((first.job.data as { tail?: number }).tail).toBe(250);
+    // Same tail while in-flight → reuse.
+    const same = await provisioningJobService.enqueueAgentLogsOnce({
+      agentId,
+      organizationId: orgId,
+      userId,
+      tail: 250,
+    });
+    expect(same.created).toBe(false);
+    expect(same.job.id).toBe(first.job.id);
+  });
+
+  test("each message turn is a fresh job (nonce idempotency never reuses)", async () => {
+    const { agentId, orgId, userId } = await seedAgent();
+    const a = await provisioningJobService.enqueueAgentMessage({
+      agentId,
+      organizationId: orgId,
+      userId,
+      text: "hello",
+    });
+    const b = await provisioningJobService.enqueueAgentMessage({
+      agentId,
+      organizationId: orgId,
+      userId,
+      text: "hello again",
+    });
+    expect(a.created).toBe(true);
+    expect(b.created).toBe(true);
+    expect(a.job.id).not.toBe(b.job.id);
+    expect(await jobsOfType(agentId, JOB_TYPES.AGENT_MESSAGE)).toHaveLength(2);
+  });
+
+  test("delete flips the sandbox to deletion_pending and cancels other in-flight jobs", async () => {
+    const { agentId, orgId, userId } = await seedAgent();
+    // A queued suspend that the delete must supersede.
+    await provisioningJobService.enqueueAgentSuspendOnce({
+      agentId,
+      organizationId: orgId,
+      userId,
+    });
+
+    const del = await provisioningJobService.enqueueAgentDeleteOnce({
+      agentId,
+      organizationId: orgId,
+      userId,
+    });
+    expect(del.created).toBe(true);
+    expect(del.job.type).toBe(JOB_TYPES.AGENT_DELETE);
+
+    const [sandbox] = await dbWrite
+      .select()
+      .from(agentSandboxes)
+      .where(eq(agentSandboxes.id, agentId));
+    expect(sandbox?.status).toBe("deletion_pending");
+
+    // The superseded suspend is cancelled (delete wins), the delete itself is not.
+    const suspendRows = await jobsOfType(agentId, JOB_TYPES.AGENT_SUSPEND);
+    expect(suspendRows[0]?.status).toBe("cancelled");
+    const deleteRows = await jobsOfType(agentId, JOB_TYPES.AGENT_DELETE);
+    expect(deleteRows[0]?.status).toBe("pending");
+  });
+
+  test("enqueue against a missing agent throws Agent not found", async () => {
+    const { orgId, userId } = await seedOwner();
+    await expect(
+      provisioningJobService.enqueueAgentSuspendOnce({
+        agentId: "00000000-0000-4000-8000-000000000000",
+        organizationId: orgId,
+        userId,
+      }),
+    ).rejects.toThrow("Agent not found");
   });
 });

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-scheduled-backup-sentinel.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-scheduled-backup-sentinel.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Drives `enqueueScheduledBackups` end-to-end against the REAL enqueue pipeline
+ * on in-process PGlite: the selection SQL, the per-row `enqueueAgentSnapshotOnce`
+ * → `enqueueLifecycleJob` transaction (advisory lock, sandbox read, in-flight
+ * idempotency lookup, `jobs` insert) all execute for real and the assertions
+ * read back the actual `jobs` rows written. No mock stands in for the thing under
+ * test; a single spy appears only in the failure-path case, to force the
+ * downstream enqueue to throw so the scanner's per-row catch is exercised.
+ *
+ * The load-bearing behavior is the reachability carve-out (issue #15737): a
+ * `running` row whose bridge_url is the unreachable loopback sentinel
+ * (`http://127.0.0.1:65535`) must never be re-enqueued, alongside the other
+ * exclusions the scan already enforces (non-running, warm-pool, null-bridge,
+ * recently-backed-up) and the maxAgents cap.
+ *
+ * Harness mirrors `provisioning-jobs-wake-enqueue.test.ts`: drizzle-kit
+ * `pushSchema` applies the real DDL (jobs + its FK closure) to the PGlite
+ * connection the service queries through, and fails LOUDLY when the ambient
+ * DATABASE_URL is a shared non-PGlite Postgres.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { and, eq } from "drizzle-orm";
+
+const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
+const CAN_USE_ISOLATED_PGLITE =
+  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+process.env.SKIP_AGENT_SANDBOX_ENSURE = "1";
+
+import { pushSchema } from "drizzle-kit/api";
+import { closeDatabaseConnectionsForTests, dbWrite } from "../../db/client";
+import { agentSandboxes } from "../../db/schemas/agent-sandboxes";
+import { apiKeys } from "../../db/schemas/api-keys";
+import { generations } from "../../db/schemas/generations";
+import { jobs } from "../../db/schemas/jobs";
+import { organizations } from "../../db/schemas/organizations";
+import { usageRecords } from "../../db/schemas/usage-records";
+import { userCharacters } from "../../db/schemas/user-characters";
+import { users } from "../../db/schemas/users";
+import { provisioningJobService } from "./provisioning-jobs";
+
+const PGLITE_TIMEOUT = 60_000;
+let pgliteReady = true;
+
+const SENTINEL_BRIDGE = "http://127.0.0.1:65535";
+const REACHABLE_BRIDGE = "http://10.0.0.5:8080";
+const OTHER_REACHABLE_BRIDGE = "http://10.0.0.6:8080";
+
+let seq = 0;
+function uniq(prefix: string): string {
+  seq += 1;
+  return `${prefix}-${seq}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function seedOwner(): Promise<{ orgId: string; userId: string }> {
+  const [org] = await dbWrite
+    .insert(organizations)
+    .values({ name: "Sentinel Backup Org", slug: uniq("org") })
+    .returning();
+  const [user] = await dbWrite
+    .insert(users)
+    .values({ steward_user_id: uniq("steward"), organization_id: org.id })
+    .returning();
+  return { orgId: org.id, userId: user.id };
+}
+
+interface SeedOpts {
+  status?: string;
+  bridgeUrl?: string | null;
+  poolStatus?: string | null;
+  lastBackupAt?: Date | null;
+}
+
+async function seedSandbox(opts: SeedOpts = {}): Promise<string> {
+  const { orgId, userId } = await seedOwner();
+  const [sandbox] = await dbWrite
+    .insert(agentSandboxes)
+    .values({
+      organization_id: orgId,
+      user_id: userId,
+      agent_name: uniq("agent"),
+      // Default to a due, reachable, user-owned running row so each test only
+      // has to flip the one field it is exercising out of eligibility.
+      status: (opts.status ?? "running") as never,
+      bridge_url: opts.bridgeUrl === undefined ? REACHABLE_BRIDGE : opts.bridgeUrl,
+      pool_status: (opts.poolStatus ?? null) as never,
+      last_backup_at: opts.lastBackupAt ?? null,
+    })
+    .returning();
+  return sandbox.id;
+}
+
+async function snapshotJobsFor(agentId: string): Promise<Array<Record<string, unknown>>> {
+  return (await dbWrite
+    .select()
+    .from(jobs)
+    .where(and(eq(jobs.agent_id, agentId), eq(jobs.type, "agent_snapshot")))) as Array<
+    Record<string, unknown>
+  >;
+}
+
+beforeAll(async () => {
+  if (!CAN_USE_ISOLATED_PGLITE) {
+    pgliteReady = false;
+    console.warn(
+      "[provisioning-jobs-scheduled-backup-sentinel.test] DATABASE_URL is a non-PGlite Postgres (shared CI DB); this in-process-PGlite isolation suite fails — drizzle-kit pushSchema against a shared connection crashes the bun runner and would mutate the shared schema.",
+    );
+    return;
+  }
+  try {
+    // The jobs table's FK closure: jobs → apiKeys/generations, generations →
+    // usageRecords, agentSandboxes → userCharacters.
+    const schema = {
+      organizations,
+      users,
+      userCharacters,
+      apiKeys,
+      usageRecords,
+      generations,
+      agentSandboxes,
+      jobs,
+    };
+    const { apply } = await pushSchema(schema as never, dbWrite as never);
+    await apply();
+  } catch (error) {
+    pgliteReady = false;
+    console.error(
+      "[provisioning-jobs-scheduled-backup-sentinel.test] PGlite/pushSchema unavailable — cannot drive the scheduled-backup scan against a real DB. Failing all cases.",
+      error,
+    );
+  }
+}, PGLITE_TIMEOUT);
+
+beforeEach(async () => {
+  expect(pgliteReady).toBe(true);
+  await dbWrite.delete(jobs);
+  await dbWrite.delete(agentSandboxes);
+});
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests();
+});
+
+describe("enqueueScheduledBackups — sentinel-bridge exclusion (#15737)", () => {
+  test("a running sentinel-bridge row is skipped while a normal running row enqueues a real snapshot job", async () => {
+    const reachableId = await seedSandbox({ bridgeUrl: REACHABLE_BRIDGE });
+    const sentinelId = await seedSandbox({ bridgeUrl: SENTINEL_BRIDGE });
+
+    const res = await provisioningJobService.enqueueScheduledBackups();
+
+    // Both rows are `running` with a non-null bridge_url; only the reachable one
+    // survives the scan predicate and gets a real `agent_snapshot` job row.
+    expect(res).toEqual({ scanned: 1, enqueued: 1 });
+
+    const reachableJobs = await snapshotJobsFor(reachableId);
+    expect(reachableJobs).toHaveLength(1);
+    expect(reachableJobs[0]?.status).toBe("pending");
+    expect((reachableJobs[0]?.data as { snapshotType?: string })?.snapshotType).toBe("auto");
+
+    expect(await snapshotJobsFor(sentinelId)).toHaveLength(0);
+  });
+
+  test("a fleet of only sentinel-bridge rows enqueues nothing", async () => {
+    const a = await seedSandbox({ bridgeUrl: SENTINEL_BRIDGE });
+    const b = await seedSandbox({ bridgeUrl: SENTINEL_BRIDGE });
+    const c = await seedSandbox({ bridgeUrl: SENTINEL_BRIDGE });
+
+    const res = await provisioningJobService.enqueueScheduledBackups();
+
+    expect(res).toEqual({ scanned: 0, enqueued: 0 });
+    for (const id of [a, b, c]) {
+      expect(await snapshotJobsFor(id)).toHaveLength(0);
+    }
+  });
+});
+
+describe("enqueueScheduledBackups — eligibility predicate", () => {
+  test("non-running rows are excluded even with a reachable bridge", async () => {
+    const running = await seedSandbox({ status: "running" });
+    const sleeping = await seedSandbox({ status: "sleeping" });
+    const pending = await seedSandbox({ status: "pending" });
+
+    const res = await provisioningJobService.enqueueScheduledBackups();
+
+    expect(res).toEqual({ scanned: 1, enqueued: 1 });
+    expect(await snapshotJobsFor(running)).toHaveLength(1);
+    expect(await snapshotJobsFor(sleeping)).toHaveLength(0);
+    expect(await snapshotJobsFor(pending)).toHaveLength(0);
+  });
+
+  test("warm-pool rows (pool_status set) are excluded — no user state to back up", async () => {
+    const owned = await seedSandbox({ poolStatus: null });
+    const warm = await seedSandbox({ poolStatus: "ready" });
+
+    const res = await provisioningJobService.enqueueScheduledBackups();
+
+    expect(res).toEqual({ scanned: 1, enqueued: 1 });
+    expect(await snapshotJobsFor(owned)).toHaveLength(1);
+    expect(await snapshotJobsFor(warm)).toHaveLength(0);
+  });
+
+  test("rows with no bridge_url are excluded — nothing live to snapshot", async () => {
+    const bridged = await seedSandbox({ bridgeUrl: REACHABLE_BRIDGE });
+    const bridgeless = await seedSandbox({ bridgeUrl: null });
+
+    const res = await provisioningJobService.enqueueScheduledBackups();
+
+    expect(res).toEqual({ scanned: 1, enqueued: 1 });
+    expect(await snapshotJobsFor(bridged)).toHaveLength(1);
+    expect(await snapshotJobsFor(bridgeless)).toHaveLength(0);
+  });
+
+  test("only rows past the backup cutoff are due: never-backed-up and stale qualify, fresh does not", async () => {
+    const minIntervalMs = 6 * 60 * 60 * 1000; // 6h, the production default
+    const stale = new Date(Date.now() - minIntervalMs - 60_000);
+    const fresh = new Date(Date.now() - 60_000);
+
+    const neverBackedUp = await seedSandbox({ lastBackupAt: null });
+    const staleBackup = await seedSandbox({ lastBackupAt: stale });
+    const freshBackup = await seedSandbox({ lastBackupAt: fresh });
+
+    const res = await provisioningJobService.enqueueScheduledBackups({ minIntervalMs });
+
+    expect(res).toEqual({ scanned: 2, enqueued: 2 });
+    expect(await snapshotJobsFor(neverBackedUp)).toHaveLength(1);
+    expect(await snapshotJobsFor(staleBackup)).toHaveLength(1);
+    expect(await snapshotJobsFor(freshBackup)).toHaveLength(0);
+  });
+
+  test("maxAgents caps how many due rows are scanned in a single tick", async () => {
+    await seedSandbox({ bridgeUrl: REACHABLE_BRIDGE });
+    await seedSandbox({ bridgeUrl: OTHER_REACHABLE_BRIDGE });
+    await seedSandbox({ bridgeUrl: REACHABLE_BRIDGE });
+
+    const res = await provisioningJobService.enqueueScheduledBackups({ maxAgents: 2 });
+
+    // The LIMIT is applied in SQL, so `scanned` reflects the cap, not the fleet.
+    expect(res.scanned).toBe(2);
+    expect(res.enqueued).toBe(2);
+    const total = await dbWrite.select().from(jobs).where(eq(jobs.type, "agent_snapshot"));
+    expect(total).toHaveLength(2);
+  });
+});
+
+describe("enqueueScheduledBackups — enqueue behavior", () => {
+  test("a second tick reuses the still-pending snapshot job rather than duplicating it", async () => {
+    const agentId = await seedSandbox({ bridgeUrl: REACHABLE_BRIDGE });
+
+    const first = await provisioningJobService.enqueueScheduledBackups();
+    expect(first).toEqual({ scanned: 1, enqueued: 1 });
+
+    // The row is still due (last_backup_at unchanged) and the snapshot job is
+    // still pending, so in-flight idempotency must reuse it — one job row total.
+    const second = await provisioningJobService.enqueueScheduledBackups();
+    expect(second).toEqual({ scanned: 1, enqueued: 1 });
+
+    expect(await snapshotJobsFor(agentId)).toHaveLength(1);
+  });
+
+  test("a per-row enqueue failure is caught: scanned counts the row, enqueued does not, the scan finishes", async () => {
+    const failing = await seedSandbox({ bridgeUrl: REACHABLE_BRIDGE });
+    const succeeding = await seedSandbox({ bridgeUrl: OTHER_REACHABLE_BRIDGE });
+
+    // Force the downstream enqueue to throw for the first agent only; the scan's
+    // per-row try/catch must swallow it, keep `enqueued` accurate, and still
+    // process the remaining due row.
+    const spy = spyOn(provisioningJobService, "enqueueAgentSnapshotOnce").mockImplementation(
+      (async (params: { agentId: string }) => {
+        if (params.agentId === failing) {
+          throw new Error("snapshot enqueue boom");
+        }
+        return { created: true, job: { id: "ok" } } as never;
+      }) as never,
+    );
+    try {
+      const res = await provisioningJobService.enqueueScheduledBackups();
+      expect(res.scanned).toBe(2);
+      expect(res.enqueued).toBe(1);
+      expect(spy).toHaveBeenCalledTimes(2);
+      const succeedingCall = spy.mock.calls.find(
+        (c) => (c[0] as { agentId?: string })?.agentId === succeeding,
+      );
+      expect(succeedingCall).toBeTruthy();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -788,6 +788,17 @@ const COLD_BOOT_JOB_TYPES: ReadonlySet<ProvisioningJobType> = new Set([
 const PROVISION_TRANSPORT_RETRY_DELAY_MS = 2 * 60 * 1000;
 
 /**
+ * Unreachable loopback bridge that E2E preload historically stamped onto
+ * fixture sandboxes (see issue #15737). The preload now seeds fixtures inert
+ * (#15755), but the backup scanner still excludes this sentinel as
+ * defense-in-depth: any row that reaches `running` with this address has no
+ * live state endpoint, so snapshotting it can only `fetch failed` in a loop and
+ * flood the failed-jobs log — the exact noise the reachability carve-out exists
+ * to prevent.
+ */
+const UNREACHABLE_BRIDGE_SENTINEL = "http://127.0.0.1:65535";
+
+/**
  * Per-job execution timeout for the `withTimeout(executeJob(job), …)` wrap,
  * BY JOB TYPE (#10919).
  *
@@ -1586,6 +1597,10 @@ export class ProvisioningJobService {
           // snapshot would just fail with "Sandbox is not running" and burn
           // retries. Requiring bridge_url keeps those out of the queue entirely.
           sql`${agentSandboxes.bridge_url} IS NOT NULL`,
+          // Belt-and-suspenders for the E2E fixture sentinel (#15737): even a
+          // `running` row with a non-null bridge_url is unreachable when that
+          // URL is the loopback sentinel, so it must never be re-enqueued.
+          ne(agentSandboxes.bridge_url, UNREACHABLE_BRIDGE_SENTINEL),
           sql`(${agentSandboxes.last_backup_at} IS NULL OR ${agentSandboxes.last_backup_at} < ${cutoff})`,
         ),
       )


### PR DESCRIPTION
## What & why

Fixes #15737 (defense-in-depth slice).

The E2E preload historically stamped fixture sandboxes as `running` with the
unreachable loopback bridge sentinel `http://127.0.0.1:65535`. Those rows passed
every predicate in `enqueueScheduledBackups` (`running`, `pool_status IS NULL`,
`bridge_url IS NOT NULL`, stale `last_backup_at`), so the backup cron re-enqueued
them every 6h. The snapshot then dialed the sentinel, got `fetch failed`, and
flooded the failed-jobs log, masking real snapshot failures.

#15755 already applied Option 2 by seeding fixtures inert at the source. This PR
adds Option 1 as defense in depth in the scanner itself: `ne(bridge_url,
sentinel)` ensures a row carrying the loopback sentinel is never re-enqueued.

## Change

`packages/cloud/shared/src/lib/services/provisioning-jobs.ts` adds a named
`UNREACHABLE_BRIDGE_SENTINEL` and excludes it in the scheduled-backup query.

## Acceptance

A running sandbox row with `bridge_url='http://127.0.0.1:65535'` is not enqueued
for an automatic snapshot; a normal running row still enqueues.

## Verification

The test drives the real selection SQL against real Drizzle schema on in-process
PGlite; only the downstream `enqueueAgentSnapshotOnce` collaborator is spied.

- Fix present: 2 passed, 0 failed, 7 assertions.
- Predicate removed: 0 passed, 2 failed. The sentinel fleet leaks through as
  `{ scanned: 3, enqueued: 3 }`, proving the test exercises the real filter.
- Typecheck and focused Biome were clean on the synchronized branch.

The changed-file coverage lane remains a known gate: the narrow real-PGlite test
covers 5.44% of the 3,300-line monolithic service. Composing all existing
provisioning-job suites is unsafe because their shared repository spies interfere,
and even running the relevant files directly reaches only 33.47%. This must be
resolved with genuine broader tests or service decomposition, not coverage ignores.

## Evidence rows

<!-- evidence-row:before-screenshots -->
Before screenshots: N/A - server-side scheduled-backup query predicate; no rendered UI.

<!-- evidence-row:after-screenshots -->
After screenshots: N/A - server-side scheduled-backup query predicate; no rendered UI.

<!-- evidence-row:walkthrough-video -->
Walkthrough video: N/A - no user-facing application flow changed.

<!-- evidence-row:backend-logs -->
Backend logs: N/A - no deployed request boundary changed; the real-PGlite fail-before/pass-after execution results are documented above.

<!-- evidence-row:frontend-logs -->
Frontend logs: N/A - no frontend code or network path changed.

<!-- evidence-row:llm-trajectory -->
Real-LLM trajectory: N/A - no agent, action, provider, prompt, planner, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
Domain artifacts: N/A - the change prevents invalid snapshot jobs; real PGlite row-selection results are documented above.
