### PR TITLE
fix(evidence): enforce real view bundles on the actual audit:app lane (#15791)

### DIFF
--- a/packages/app-core/scripts/playwright-ui-smoke-api-stub.mjs
+++ b/packages/app-core/scripts/playwright-ui-smoke-api-stub.mjs
@@ -27,6 +27,9 @@ const port = Number(process.env.ELIZA_UI_SMOKE_API_PORT || "31337");
 const repoRoot = path.resolve(
   fileURLToPath(new URL("../../..", import.meta.url)),
 );
+const VIEW_BUNDLE_ROOT =
+  process.env.ELIZA_UI_SMOKE_VIEW_BUNDLE_ROOT?.trim() ||
+  path.join(repoRoot, "plugins");
 const SMOKE_GENERATED_AT = "2026-01-01T00:00:00.000Z";
 const DEMO_ORCHESTRATOR = process.env.ELIZA_UI_SMOKE_DEMO_ORCHESTRATOR === "1";
 const HUMAN_CHAT_FIXTURES = process.env.ELIZA_UI_SMOKE_HUMAN_CHAT === "1";
@@ -92,8 +95,7 @@ function smokeViewObject({
   const encodedId = encodeURIComponent(id);
   const query = "?v=ui-smoke";
   const bundlePath = path.join(
-    repoRoot,
-    "plugins",
+    VIEW_BUNDLE_ROOT,
     pluginDirName,
     "dist",
     "views",
@@ -1673,8 +1675,7 @@ function smokeViewBundleSource(view) {
 
 function sendSmokeViewAsset(req, res, url, view, subResource) {
   const bundleDir = path.join(
-    repoRoot,
-    "plugins",
+    VIEW_BUNDLE_ROOT,
     view._smokePluginDirName,
     "dist",
     "views",

--- a/packages/app-core/scripts/smoke-view-bundle-provenance.test.ts
+++ b/packages/app-core/scripts/smoke-view-bundle-provenance.test.ts
@@ -6,11 +6,12 @@
  * as such on the wire (issue #15791).
  */
 import { type ChildProcess, spawn } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:net";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
-import { realViewBundleExists } from "./smoke-view-declarations.mjs";
 
 const repoRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -72,22 +73,41 @@ async function bootStub(env: Record<string, string>): Promise<{
 }
 
 let running: ChildProcess | null = null;
-afterEach(() => {
+const tempRoots: string[] = [];
+afterEach(async () => {
   running?.kill("SIGKILL");
   running = null;
+  await Promise.all(
+    tempRoots
+      .splice(0)
+      .map((root) => rm(root, { recursive: true, force: true })),
+  );
 });
 
-describe("smoke view bundle provenance over HTTP (#15791)", () => {
-  // Whether a real dist bundle exists depends on prior builds; the provenance
-  // contract must hold in either state, so the expectations branch on it.
-  const walletHasRealBundle = realViewBundleExists(
-    repoRoot,
-    "plugin-wallet-ui",
-  );
+async function emptyBundleRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "eliza-view-bundles-"));
+  tempRoots.push(root);
+  return root;
+}
 
+async function bundleRootWithWallet(): Promise<string> {
+  const root = await emptyBundleRoot();
+  const bundleDir = path.join(root, "plugin-wallet-ui", "dist", "views");
+  await mkdir(bundleDir, { recursive: true });
+  await writeFile(
+    path.join(bundleDir, "bundle.js"),
+    "export const InventoryView = () => null;\n",
+    "utf8",
+  );
+  return root;
+}
+
+describe("smoke view bundle provenance over HTTP (#15791)", () => {
   it("audit mode returns an observable failure, never a fabricated bundle", async () => {
+    const bundleRoot = await emptyBundleRoot();
     const { child, port } = await bootStub({
       ELIZA_UI_SMOKE_REQUIRE_REAL_BUNDLES: "1",
+      ELIZA_UI_SMOKE_VIEW_BUNDLE_ROOT: bundleRoot,
     });
     running = child;
     const response = await fetch(
@@ -96,15 +116,6 @@ describe("smoke view bundle provenance over HTTP (#15791)", () => {
     expect(response.headers.get("x-eliza-view-component")).toBe(
       "InventoryView",
     );
-    if (walletHasRealBundle) {
-      // A real bundle is present: audit mode must serve it, marked real-dist.
-      expect(response.status).toBe(200);
-      expect(response.headers.get("x-eliza-view-bundle-provenance")).toBe(
-        "real-dist",
-      );
-      return;
-    }
-    // No real bundle: audit mode refuses to fabricate one and fails observably.
     expect(response.status).toBe(424);
     expect(response.headers.get("x-eliza-view-bundle-provenance")).toBe(
       "missing-real-bundle",
@@ -117,7 +128,10 @@ describe("smoke view bundle provenance over HTTP (#15791)", () => {
   });
 
   it("non-audit marks synthesized placeholders on the wire and in bytes", async () => {
-    const { child, port } = await bootStub({});
+    const bundleRoot = await emptyBundleRoot();
+    const { child, port } = await bootStub({
+      ELIZA_UI_SMOKE_VIEW_BUNDLE_ROOT: bundleRoot,
+    });
     running = child;
     const response = await fetch(
       `http://127.0.0.1:${port}/api/views/wallet/bundle.js`,
@@ -130,12 +144,29 @@ describe("smoke view bundle provenance over HTTP (#15791)", () => {
     );
     const provenance = response.headers.get("x-eliza-view-bundle-provenance");
     const body = await response.text();
-    if (walletHasRealBundle) {
-      expect(provenance).toBe("real-dist");
-      return;
-    }
     expect(provenance).toBe("synthesized-generic");
     expect(body).toContain("eliza-view-bundle-provenance: synthesized-generic");
     expect(body).toContain("InventoryView");
+  });
+
+  it("audit mode serves a present real bundle with exact identity headers", async () => {
+    const bundleRoot = await bundleRootWithWallet();
+    const { child, port } = await bootStub({
+      ELIZA_UI_SMOKE_REQUIRE_REAL_BUNDLES: "1",
+      ELIZA_UI_SMOKE_VIEW_BUNDLE_ROOT: bundleRoot,
+    });
+    running = child;
+    const response = await fetch(
+      `http://127.0.0.1:${port}/api/views/wallet/bundle.js`,
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-eliza-view-bundle-provenance")).toBe(
+      "real-dist",
+    );
+    expect(response.headers.get("x-eliza-view-component")).toBe(
+      "InventoryView",
+    );
+    expect(response.headers.get("x-eliza-view-id")).toBe("wallet");
+    expect(await response.text()).toContain("export const InventoryView");
   });
 });

--- a/packages/app-core/scripts/smoke-view-declarations.mjs
+++ b/packages/app-core/scripts/smoke-view-declarations.mjs
@@ -20,6 +20,7 @@
 
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
+import ts from "typescript";
 
 /**
  * One GUI declaration per shipped plugin view: `[id, label, pluginDirName,
@@ -109,7 +110,13 @@ export const smokeViewDeclarations = [
     "/trajectory-logger",
     "TrajectoryLoggerView",
   ],
-  ["training", "Fine Tuning", "plugin-training", "/training", "FineTuningView"],
+  [
+    "training",
+    "Fine Tuning",
+    "plugin-training",
+    "/apps/fine-tuning",
+    "FineTuningView",
+  ],
 ];
 
 /**
@@ -133,17 +140,73 @@ function readSourceFiles(dir) {
       return;
     }
     for (const entry of entries) {
-      if (entry.name === "node_modules" || entry.name === "dist") continue;
+      if (
+        entry.name === "node_modules" ||
+        entry.name === "dist" ||
+        entry.name === "__tests__" ||
+        /\.(test|spec)\.[cm]?[jt]sx?$/.test(entry.name)
+      ) {
+        continue;
+      }
       const full = path.join(current, entry.name);
       if (entry.isDirectory()) {
         walk(full);
       } else if (/\.(ts|tsx|mjs|js)$/.test(entry.name)) {
-        sources.push(readFileSync(full, "utf8"));
+        sources.push({ filePath: full, source: readFileSync(full, "utf8") });
       }
     }
   };
   walk(dir);
   return sources;
+}
+
+function stringProperty(object, propertyName) {
+  for (const property of object.properties) {
+    if (!ts.isPropertyAssignment(property)) continue;
+    const name = property.name;
+    const key =
+      ts.isIdentifier(name) || ts.isStringLiteralLike(name)
+        ? name.text
+        : undefined;
+    if (key !== propertyName) continue;
+    return ts.isStringLiteralLike(property.initializer)
+      ? property.initializer.text
+      : undefined;
+  }
+  return undefined;
+}
+
+function inspectViewDeclarations(
+  sourceFiles,
+  { id, viewPath, componentExport },
+) {
+  let declaresIdAndPath = false;
+  let declaresExactView = false;
+  for (const { filePath, source } of sourceFiles) {
+    const sourceFile = ts.createSourceFile(
+      filePath,
+      source,
+      ts.ScriptTarget.Latest,
+      true,
+      filePath.endsWith("x") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+    );
+    const visit = (node) => {
+      if (ts.isObjectLiteralExpression(node)) {
+        const objectId = stringProperty(node, "id");
+        const objectPath = stringProperty(node, "path");
+        if (objectId === id && objectPath === viewPath) {
+          declaresIdAndPath = true;
+          if (stringProperty(node, "componentExport") === componentExport) {
+            declaresExactView = true;
+          }
+        }
+      }
+      if (!declaresExactView) ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+    if (declaresExactView) break;
+  }
+  return { declaresExactView, declaresIdAndPath };
 }
 
 /**
@@ -160,7 +223,8 @@ export function checkSmokeViewParity(
   const pluginsDir = path.join(repoRoot, "plugins");
   const missing = [];
   for (const tuple of declarations) {
-    const { id, pluginDirName, componentExport } = toDeclaration(tuple);
+    const { id, pluginDirName, componentExport, viewPath } =
+      toDeclaration(tuple);
     const pluginDir = path.join(pluginsDir, pluginDirName);
     let dirExists = false;
     try {
@@ -177,17 +241,16 @@ export function checkSmokeViewParity(
       });
       continue;
     }
-    const sources = readSourceFiles(path.join(pluginDir, "src"));
-    const declaresId = sources.some((source) => source.includes(`"${id}"`));
-    const exportsComponent = sources.some((source) =>
-      source.includes(componentExport),
+    const declaration = inspectViewDeclarations(
+      readSourceFiles(path.join(pluginDir, "src")),
+      { id, viewPath, componentExport },
     );
-    if (!declaresId || !exportsComponent) {
+    if (!declaration.declaresExactView) {
       missing.push({
         id,
         pluginDirName,
         componentExport,
-        reason: !exportsComponent
+        reason: declaration.declaresIdAndPath
           ? "component-export-missing"
           : "view-id-not-declared",
       });

--- a/packages/app-core/scripts/smoke-view-declarations.mjs
+++ b/packages/app-core/scripts/smoke-view-declarations.mjs
@@ -131,14 +131,7 @@ function toDeclaration(tuple) {
 function readSourceFiles(dir) {
   const sources = [];
   const walk = (current) => {
-    let entries;
-    try {
-      entries = readdirSync(current, { withFileTypes: true });
-    } catch {
-      // error-policy:J3 a plugin dir that vanished mid-scan is reported by the
-      // caller as a parity miss (missing directory), not swallowed as "clean".
-      return;
-    }
+    const entries = readdirSync(current, { withFileTypes: true });
     for (const entry of entries) {
       if (
         entry.name === "node_modules" ||
@@ -226,12 +219,8 @@ export function checkSmokeViewParity(
     const { id, pluginDirName, componentExport, viewPath } =
       toDeclaration(tuple);
     const pluginDir = path.join(pluginsDir, pluginDirName);
-    let dirExists = false;
-    try {
-      dirExists = statSync(pluginDir).isDirectory();
-    } catch {
-      dirExists = false;
-    }
+    const dirExists =
+      existsSync(pluginDir) && statSync(pluginDir).isDirectory();
     if (!dirExists) {
       missing.push({
         id,

--- a/packages/app/scripts/run-ui-playwright.mjs
+++ b/packages/app/scripts/run-ui-playwright.mjs
@@ -385,6 +385,17 @@ if (hasPlaywrightConfig("playwright.ui-smoke.config.ts")) {
   }
 }
 
+// The all-views audit is evidence for production plugin bundles, so its stub
+// server must reject missing dist output instead of exercising the generic
+// placeholder used by lightweight offline smoke lanes. build-views runs below
+// before the server starts, making this a fail-closed provenance contract.
+if (
+  hasPlaywrightConfig("playwright.ui-smoke.config.ts") &&
+  hasPlaywrightProject("audit-app")
+) {
+  env.ELIZA_UI_SMOKE_REQUIRE_REAL_BUNDLES = "1";
+}
+
 if (
   hasPlaywrightConfig("playwright.ui-smoke.config.ts") &&
   env.ELIZA_UI_SMOKE_SKIP_VIEW_BUILD !== "1"

--- a/packages/app/test/audit/mvp-visual-verify.test.ts
+++ b/packages/app/test/audit/mvp-visual-verify.test.ts
@@ -32,6 +32,10 @@ const visualVerify = await import("../../scripts/mvp-visual-verify.mjs");
 const appPackageJson = JSON.parse(
   readFileSync(path.resolve(__dirname, "../../package.json"), "utf8"),
 ) as { scripts: Record<string, string> };
+const uiPlaywrightRunnerSource = readFileSync(
+  path.resolve(__dirname, "../../scripts/run-ui-playwright.mjs"),
+  "utf8",
+);
 
 describe("color-bucket", () => {
   it("parses rgb and rgba", () => {
@@ -670,6 +674,12 @@ describe("audit:app OCR command contract", () => {
     );
     expect(appPackageJson.scripts["audit:app:verify"]).toContain(
       "--require-baseline-states",
+    );
+    expect(uiPlaywrightRunnerSource).toContain(
+      'hasPlaywrightProject("audit-app")',
+    );
+    expect(uiPlaywrightRunnerSource).toContain(
+      'env.ELIZA_UI_SMOKE_REQUIRE_REAL_BUNDLES = "1"',
     );
   });
 });

--- a/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
@@ -914,6 +914,10 @@ interface RemoteBundleAuditProof {
   response: Promise<import("@playwright/test").Response>;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 async function forceRemoteBundleAuditRoute(
   page: Page,
   view: AuditCase,
@@ -921,20 +925,25 @@ async function forceRemoteBundleAuditRoute(
   if (view.kind !== "plugin") return null;
   const registryResponse = await page.request.get("/api/views");
   expect(registryResponse.ok(), "plugin view registry must load").toBe(true);
-  const payload = (await registryResponse.json()) as {
-    views?: Array<{
-      id: string;
-      viewType?: string;
-      path?: string;
-      bundleUrl?: string;
-      componentExport?: string;
-    }>;
-  };
+  const payload: unknown = await registryResponse.json();
+  if (!isRecord(payload) || !Array.isArray(payload.views)) {
+    throw new Error("plugin view registry returned an invalid views payload");
+  }
   const registered = payload.views?.find(
     (entry) =>
-      entry.id === view.id && (entry.viewType ?? "gui") === view.viewType,
+      isRecord(entry) &&
+      entry.id === view.id &&
+      (entry.viewType ?? "gui") === view.viewType,
   );
-  if (!registered?.bundleUrl || !registered.componentExport) return null;
+  if (
+    !isRecord(registered) ||
+    typeof registered.bundleUrl !== "string" ||
+    typeof registered.componentExport !== "string"
+  ) {
+    throw new Error(
+      `${view.slug} is missing its production bundle declaration in /api/views`,
+    );
+  }
 
   const auditPath = `/__audit/plugin-view/${encodeURIComponent(registered.id)}`;
   const bundlePath = new URL(registered.bundleUrl, "http://audit.local")
@@ -949,7 +958,8 @@ async function forceRemoteBundleAuditRoute(
       contentType: "application/json",
       body: JSON.stringify({
         ...payload,
-        views: payload.views?.map((entry) =>
+        views: payload.views.map((entry) =>
+          isRecord(entry) &&
           entry.id === registered.id &&
           (entry.viewType ?? "gui") === view.viewType
             ? { ...entry, path: auditPath }

--- a/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
@@ -156,6 +156,7 @@ const NAV_INDEX_PATH = fileURLToPath(
 );
 
 interface AuditCase {
+  id: string;
   slug: string;
   path: string;
   viewType: "gui" | "tui";
@@ -166,6 +167,7 @@ function buildAuditCases(): AuditCase[] {
   const cases: AuditCase[] = [];
   for (const [id, viewPath] of Object.entries(BUILTIN_TAB_PATHS)) {
     cases.push({
+      id,
       slug: `builtin-${id}`,
       path: viewPath,
       viewType: "gui",
@@ -174,6 +176,7 @@ function buildAuditCases(): AuditCase[] {
   }
   for (const view of VIEW_CASES) {
     cases.push({
+      id: view.id,
       slug: `plugin-${view.id}-${view.viewType}`,
       path: view.path,
       viewType: view.viewType,
@@ -329,6 +332,11 @@ interface ViewFinding {
   overlayPresent: boolean;
   overlayClearanceIssues: string[];
   viewType: "gui" | "tui";
+  /** Dynamic-bundle identity captured from the real stub response. Plugin
+   * routes without a remote registry entry leave these absent. */
+  bundleProvenance?: string;
+  bundleComponent?: string;
+  bundleViewId?: string;
   /** Readable text length in the view root; ~0 means the view never painted. */
   readableChars: number;
   /** documentElement.scrollWidth − innerWidth in px (≥0). >tolerance means the
@@ -862,6 +870,9 @@ function renderManualReviewStub(finding: ViewFinding): string {
     `# ${finding.slug} (${finding.viewport})`,
     "",
     `- **path:** \`${finding.path}\``,
+    `- **bundle provenance:** ${finding.bundleProvenance ?? "n/a (not a remote-bundle route)"}`,
+    `- **bundle component:** ${finding.bundleComponent ?? "n/a"}`,
+    `- **bundle view id:** ${finding.bundleViewId ?? "n/a"}`,
     `- **verdict:** ${finding.verdict}`,
     `- **console errors:** ${finding.consoleErrors.length}`,
     `- **blue colors (banned):** ${finding.blueColors.length ? finding.blueColors.join(", ") : "none"}`,
@@ -895,6 +906,67 @@ function renderManualReviewStub(finding: ViewFinding): string {
 // overlay-clearance + light-surface checks. They still must not crash, log
 // console errors, render fully blank, or use blue.
 const findings: ViewFinding[] = [];
+
+interface RemoteBundleAuditProof {
+  auditPath: string;
+  bundlePath: string;
+  componentExport: string;
+  response: Promise<import("@playwright/test").Response>;
+}
+
+async function forceRemoteBundleAuditRoute(
+  page: Page,
+  view: AuditCase,
+): Promise<RemoteBundleAuditProof | null> {
+  if (view.kind !== "plugin") return null;
+  const registryResponse = await page.request.get("/api/views");
+  expect(registryResponse.ok(), "plugin view registry must load").toBe(true);
+  const payload = (await registryResponse.json()) as {
+    views?: Array<{
+      id: string;
+      viewType?: string;
+      path?: string;
+      bundleUrl?: string;
+      componentExport?: string;
+    }>;
+  };
+  const registered = payload.views?.find(
+    (entry) =>
+      entry.id === view.id && (entry.viewType ?? "gui") === view.viewType,
+  );
+  if (!registered?.bundleUrl || !registered.componentExport) return null;
+
+  const auditPath = `/__audit/plugin-view/${encodeURIComponent(registered.id)}`;
+  const bundlePath = new URL(registered.bundleUrl, "http://audit.local")
+    .pathname;
+  await page.route("**/api/views", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      status: registryResponse.status(),
+      contentType: "application/json",
+      body: JSON.stringify({
+        ...payload,
+        views: payload.views?.map((entry) =>
+          entry.id === registered.id &&
+          (entry.viewType ?? "gui") === view.viewType
+            ? { ...entry, path: auditPath }
+            : entry,
+        ),
+      }),
+    });
+  });
+  return {
+    auditPath,
+    bundlePath,
+    componentExport: registered.componentExport,
+    response: page.waitForResponse(
+      (response) => new URL(response.url()).pathname === bundlePath,
+    ),
+  };
+}
 
 test.describe("all-views aesthetic audit (#8796)", () => {
   const outputDir =
@@ -995,7 +1067,24 @@ test.describe("all-views aesthetic audit (#8796)", () => {
         await page.setViewportSize({ width: vp.width, height: vp.height });
         await seedAppStorage(page);
         await installDefaultAppRoutes(page);
-        await openAppPath(page, view.path);
+        const remoteBundleProof = await forceRemoteBundleAuditRoute(page, view);
+        await openAppPath(page, remoteBundleProof?.auditPath ?? view.path);
+        const bundleResponse = remoteBundleProof
+          ? await remoteBundleProof.response
+          : null;
+        if (bundleResponse && remoteBundleProof) {
+          expect(
+            bundleResponse.status(),
+            `${view.slug} must load its production dynamic bundle`,
+          ).toBe(200);
+          expect(
+            bundleResponse.headers()["x-eliza-view-bundle-provenance"],
+          ).toBe("real-dist");
+          expect(bundleResponse.headers()["x-eliza-view-component"]).toBe(
+            remoteBundleProof.componentExport,
+          );
+          expect(bundleResponse.headers()["x-eliza-view-id"]).toBe(view.id);
+        }
 
         // Robust readiness under sustained sequential load: most views render
         // <main>, but chat/phone/etc. render straight into #root with no <main>.
@@ -1140,6 +1229,10 @@ test.describe("all-views aesthetic audit (#8796)", () => {
           viewport: vp.name,
           path: view.path,
           viewType: view.viewType,
+          bundleProvenance:
+            bundleResponse?.headers()["x-eliza-view-bundle-provenance"],
+          bundleComponent: bundleResponse?.headers()["x-eliza-view-component"],
+          bundleViewId: bundleResponse?.headers()["x-eliza-view-id"],
           consoleErrors,
           blueColors,
           hoverViolations,


### PR DESCRIPTION
Follow-up to #15803 (completes #15791).

## Why a new PR

#15803 merged **before** its NEEDS-FIXES review was addressed. The verify pass found the parity + `build-views` teeth solid but the headline acceptance — *the audit proves the production bundle / a missing bundle fails observably* — **not wired into the real `audit:app` lane**: `ELIZA_UI_SMOKE_REQUIRE_REAL_BUNDLES` was only read by the stub and set by an isolated unit test, so a missing production bundle could still pass the real audit. This PR closes every point on the real path.

## What changed

1. **The real audit lane now requires real bundles.** `packages/app/scripts/run-ui-playwright.mjs` sets `env.ELIZA_UI_SMOKE_REQUIRE_REAL_BUNDLES = "1"` whenever the `playwright.ui-smoke.config.ts` config runs with the `audit-app` project selected — the exact lane `audit:app` → `audit:app:capture` uses. `build-views.mjs` already runs in that script before the web server binds, so healthy views serve `real-dist`; a production-declared view with no emitted bundle now yields an observable **`424 missing-real-bundle`**, never a synthesized `200`. Offline/keyless smoke lanes are untouched.

2. **The actual audit spec asserts provenance + component.** `all-views-aesthetic-audit.spec.ts` (the spec the `audit-app` project runs) requests each plugin view's bundle through the running stack and asserts `x-eliza-view-bundle-provenance === "real-dist"`, `x-eliza-view-component === <declared export>`, and `x-eliza-view-id === <id>`, and writes those into each `manual-review/<slug>.md` stub — the provenance is part of the audit evidence, not just a unit test.

3. **The audited route is forced through the dynamic bundle.** `forceRemoteBundleAuditRoute` rewrites the registry entry's `path` to a synthetic `/__audit/plugin-view/<id>` so the app-shell's in-process `registerAppShellPage` short-circuit can't resolve first; the view must load via `/api/views/<id>/bundle.js`, and the spec `waitForResponse`-asserts that request happened. Closes the `/polymarket`-passes-without-requesting-its-bundle gap from #15791.

4. **Parity parses the authoritative declaration, not substrings.** `checkSmokeViewParity` compiles each plugin source with the TypeScript AST (`inspectViewDeclarations`) and requires an object literal whose `id` **and** `path` **and** `componentExport` all match — a stray comment/import string can no longer satisfy it. (Also corrected the `training` view path to `/apps/fine-tuning`.)

5. **Deterministic HTTP provenance test.** The stub takes an `ELIZA_UI_SMOKE_VIEW_BUNDLE_ROOT` test seam; `smoke-view-bundle-provenance.test.ts` points it at a temp dir it controls — empty → deterministic `424`, seeded → deterministic `200 real-dist` — so neither case branches on ambient `dist` state.

6. **New test proves the REAL audit path fails** (not the guard in isolation): the provenance test boots the actual stub under the **same env the audit lane sets** with an empty bundle root and asserts the production-declared `wallet` view returns `424 / missing-real-bundle / InventoryView`; `mvp-visual-verify.test.ts` asserts `run-ui-playwright.mjs` actually wires that env for `audit-app`. Chain: audit lane sets the flag → stub `424`s on a missing production bundle → the audit spec's `must load its production dynamic bundle` assertion (expects `200`/`real-dist`) fails the run.

## Evidence

Gate results (Node 24):
```
smoke-view-declarations.test.ts (parity, AST teeth)   7 passed
smoke-view-bundle-provenance.test.ts (live stub HTTP) 3 passed
build-views-guard.test.ts (bun:test)                  3 passed
mvp-visual-verify.test.ts (audit-lane wiring guard)  29 passed
biome check (6 changed files)                          clean
tsgo --noEmit (app-core, app)   no new errors from this diff (pre-existing
                                unbuilt-workspace-dist module errors only)
```

Live-stub HTTP provenance (the real server the audit uses), driven by the deterministic seam:
```
AUDIT (REQUIRE_REAL=1), empty bundle root:
  GET /api/views/wallet/bundle.js -> 424  prov=missing-real-bundle  comp=InventoryView  (no fabrication)
AUDIT (REQUIRE_REAL=1), seeded bundle root:
  GET /api/views/wallet/bundle.js -> 200  prov=real-dist            comp=InventoryView
NON-AUDIT, empty bundle root:
  GET /api/views/wallet/bundle.js -> 200  prov=synthesized-generic  comp=InventoryView  (banner in bytes)
```

### Evidence rows

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - this changes audit/evidence infrastructure, not product pixels.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: ![Polymarket real-dist audit](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15854-polymarket-real-dist.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - the affected flow is a headless bundle-provenance contract plus a focused automated browser audit, not a user interaction flow.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: [focused provenance report](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15854-provenance-report.json) plus the live-stub transcript above record deterministic 424 missing-real-bundle, 200 real-dist, and marked non-audit synthesis outcomes.

<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: [focused audit report](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15854-provenance-report.json) records zero console errors while the production Polymarket bundle rendered.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, prompt, provider, action, evaluator, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [focused audit report](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15854-provenance-report.json) records `real-dist`, `PolymarketView`, view id `polymarket`, verdict `good`, and no quality issues.

<!-- evidence-row:ocr-review -->
- [x] OCR visual text review: N/A - no product copy changed; the screenshot was manually inspected for the correct Polymarket surface and absence of developer errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)