### PR TITLE
feat(ui): teach first-session launcher swipe

### DIFF
--- a/packages/ui/src/components/shell/FirstSessionSwipeHint.test.tsx
+++ b/packages/ui/src/components/shell/FirstSessionSwipeHint.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * Exercises the swipe hint's once-only lifecycle against the real home
+ * dismissal store, including completed, interrupted, and acted-on sessions.
+ */
+// @vitest-environment jsdom
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetHomeDismissalsForTests,
+  __simulateNewSessionForTests,
+} from "../../widgets/home-dismissal-store";
+import {
+  FirstSessionSwipeHint,
+  SWIPE_HINT_DISPLAY_MS,
+  SWIPE_HINT_FADE_MS,
+  SWIPE_HINT_SHOW_DELAY_MS,
+  SWIPE_HINT_WIDGET_KEY,
+} from "./FirstSessionSwipeHint";
+
+const HINT_TESTID = "first-session-swipe-hint";
+const STORAGE_KEY = "eliza:home-dismissed:v1";
+
+// jsdom has no matchMedia; FirstSessionSwipeHint treats that as a non-fine
+// pointer (the touch case the hint exists for). Fine-pointer suppression gets
+// an explicit matchMedia stub in its own test.
+const originalMatchMedia = window.matchMedia;
+
+function stubFinePointerMedia(): void {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches:
+      query.includes("(hover: hover)") && query.includes("(pointer: fine)"),
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })) as unknown as typeof window.matchMedia;
+}
+
+function persistedLifecycle(): {
+  seen?: number;
+  acted?: boolean;
+  dismissed?: boolean;
+} {
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  if (!raw) return {};
+  return (JSON.parse(raw) as Record<string, Record<string, unknown>>)[
+    SWIPE_HINT_WIDGET_KEY
+  ] as { seen?: number; acted?: boolean; dismissed?: boolean };
+}
+
+function advance(ms: number): void {
+  act(() => {
+    vi.advanceTimersByTime(ms);
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  __resetHomeDismissalsForTests();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  __resetHomeDismissalsForTests();
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: originalMatchMedia,
+  });
+});
+
+describe("FirstSessionSwipeHint", () => {
+  it("reveals once after the settle delay, fades, and dismisses permanently", () => {
+    render(<FirstSessionSwipeHint page="home" />);
+
+    // Nothing paints before the settle delay.
+    expect(screen.queryByTestId(HINT_TESTID)).toBeNull();
+    advance(SWIPE_HINT_SHOW_DELAY_MS - 1);
+    expect(screen.queryByTestId(HINT_TESTID)).toBeNull();
+
+    // Reveal: pill up, session counted, purely decorative chrome.
+    advance(1);
+    const hint = screen.getByTestId(HINT_TESTID);
+    expect(hint.className).toContain("pointer-events-none");
+    expect(hint.getAttribute("aria-hidden")).toBe("true");
+    expect(hint.className).toContain("opacity-100");
+    expect(persistedLifecycle().seen).toBe(1);
+
+    // Display cycle ends: fade, then permanent dismissal.
+    advance(SWIPE_HINT_DISPLAY_MS);
+    expect(screen.getByTestId(HINT_TESTID).className).toContain("opacity-0");
+    advance(SWIPE_HINT_FADE_MS);
+    expect(screen.queryByTestId(HINT_TESTID)).toBeNull();
+    expect(persistedLifecycle().dismissed).toBe(true);
+  });
+
+  it("never re-reveals after a completed display cycle, even on remount", () => {
+    const first = render(<FirstSessionSwipeHint page="home" />);
+    // Sequential advances: each timer in the reveal → display → fade chain is
+    // armed by an effect that only flushes when its act() block ends.
+    advance(SWIPE_HINT_SHOW_DELAY_MS);
+    advance(SWIPE_HINT_DISPLAY_MS);
+    advance(SWIPE_HINT_FADE_MS);
+    expect(screen.queryByTestId(HINT_TESTID)).toBeNull();
+    first.unmount();
+
+    render(<FirstSessionSwipeHint page="home" />);
+    advance(SWIPE_HINT_SHOW_DELAY_MS * 2);
+    expect(screen.queryByTestId(HINT_TESTID)).toBeNull();
+  });
+
+  it("retires on a home → launcher flip before it ever paints", () => {
+    const view = render(<FirstSessionSwipeHint page="home" />);
+    advance(SWIPE_HINT_SHOW_DELAY_MS / 2);
+    view.rerender(<FirstSessionSwipeHint page="launcher" />);
+    expect(persistedLifecycle().acted).toBe(true);
+
+    // Back on home, the lesson stays retired.
+    view.rerender(<FirstSessionSwipeHint page="home" />);
+    advance(SWIPE_HINT_SHOW_DELAY_MS * 2);
+    expect(screen.queryByTestId(HINT_TESTID)).toBeNull();
+  });
+
+  it("hides mid-display the moment the user performs the swipe", () => {
+    const view = render(<FirstSessionSwipeHint page="home" />);
+    advance(SWIPE_HINT_SHOW_DELAY_MS);
+    expect(screen.getByTestId(HINT_TESTID)).toBeTruthy();
+
+    view.rerender(<FirstSessionSwipeHint page="launcher" />);
+    expect(screen.queryByTestId(HINT_TESTID)).toBeNull();
+    expect(persistedLifecycle().acted).toBe(true);
+
+    view.rerender(<FirstSessionSwipeHint page="home" />);
+    advance(SWIPE_HINT_SHOW_DELAY_MS * 2);
+    expect(screen.queryByTestId(HINT_TESTID)).toBeNull();
+  });
+
+  it("does not count a route-driven launcher start as acting", () => {
+    render(<FirstSessionSwipeHint page="launcher" />);
+    advance(SWIPE_HINT_SHOW_DELAY_MS * 2);
+    expect(persistedLifecycle().acted).not.toBe(true);
+  });
+
+  it("a session spent on the launcher half does not consume the showing", () => {
+    const view = render(<FirstSessionSwipeHint page="launcher" />);
+    advance(SWIPE_HINT_SHOW_DELAY_MS * 2);
+    expect(persistedLifecycle().seen ?? 0).toBe(0);
+    view.unmount();
+
+    __simulateNewSessionForTests();
+    render(<FirstSessionSwipeHint page="home" />);
+    advance(SWIPE_HINT_SHOW_DELAY_MS);
+    expect(screen.getByTestId(HINT_TESTID)).toBeTruthy();
+  });
+
+  it("never shows again in the next session, even after an interrupted first showing", () => {
+    // Session 1: reveal, then the "tab closes" mid-display (unmount without
+    // the display cycle completing — no dismissal recorded).
+    const first = render(<FirstSessionSwipeHint page="home" />);
+    advance(SWIPE_HINT_SHOW_DELAY_MS + 100);
+    expect(screen.getByTestId(HINT_TESTID)).toBeTruthy();
+    first.unmount();
+    expect(persistedLifecycle().dismissed).not.toBe(true);
+
+    // Session 2: the afterSeen: 1 sunset holds — no reveal at any point.
+    __simulateNewSessionForTests();
+    render(<FirstSessionSwipeHint page="home" />);
+    advance(
+      SWIPE_HINT_SHOW_DELAY_MS + SWIPE_HINT_DISPLAY_MS + SWIPE_HINT_FADE_MS,
+    );
+    expect(screen.queryByTestId(HINT_TESTID)).toBeNull();
+  });
+
+  it("never renders on fine-pointer devices (PagerEdgeButtons' complement)", () => {
+    stubFinePointerMedia();
+    render(<FirstSessionSwipeHint page="home" />);
+    advance(SWIPE_HINT_SHOW_DELAY_MS * 2);
+    expect(screen.queryByTestId(HINT_TESTID)).toBeNull();
+    // The showing is not consumed either — a later touch session still teaches.
+    expect(persistedLifecycle().seen ?? 0).toBe(0);
+  });
+});

--- a/packages/ui/src/components/shell/FirstSessionSwipeHint.tsx
+++ b/packages/ui/src/components/shell/FirstSessionSwipeHint.tsx
@@ -1,0 +1,195 @@
+/**
+ * One-time first-session hint that teaches the home ↔ launcher swipe (#13453
+ * design-verdict debt #5). The rail's page dots were removed (they collided
+ * with the floating composer) and on touch devices the horizontal swipe is the
+ * sole rail navigation, so a brand-new user has no signal the launcher exists.
+ * This floating pill surfaces once — after a short settle delay in the user's
+ * first session on the home half — then retires forever through the
+ * home-dismissal sunset lifecycle: it counts one `seen` session when it
+ * actually paints (`afterSeen: 1` retires it from the next session on),
+ * retires on `acted` the moment the user first flips the rail to the launcher
+ * (they demonstrably know the gesture — including before the hint ever shows),
+ * and dismisses itself permanently after one full display cycle.
+ *
+ * Deliberately NOT persistent chrome: `pointer-events-none` + `aria-hidden`,
+ * so it can never intercept the gesture it teaches, and it never renders on
+ * fine-pointer/hover devices — {@link PagerEdgeButtons} is their resting
+ * affordance (exact media-query complement, no gap and no overlap).
+ */
+import { ChevronLeft } from "lucide-react";
+import * as React from "react";
+import { useMediaQuery } from "../../hooks/useMediaQuery";
+import { cn } from "../../lib/utils";
+import type { HomeLauncherPage } from "../../state/shell-surface-store";
+import {
+  dismissHomeWidget,
+  type HomeWidgetLifecycle,
+  isHomeWidgetSunset,
+  markHomeWidgetActed,
+  recordHomeWidgetSeen,
+  useHomeDismissals,
+} from "../../widgets/home-dismissal-store";
+import type { HomeWidgetSunset } from "../../widgets/types";
+import { FINE_POINTER_EDGE_BUTTON_QUERY } from "./PagerEdgeButtons";
+import {
+  WALLPAPER_FLOAT_SHADOW,
+  WALLPAPER_GLASS,
+  WALLPAPER_TEXT,
+} from "./wallpaper-idiom";
+
+export const SWIPE_HINT_WIDGET_KEY = "shell:first-session-swipe-hint";
+
+/**
+ * Retire after the one session it painted in, immediately once the user
+ * performs any rail navigation, or permanently after its own display cycle
+ * completes (self-dismissed below). Whichever fires first wins.
+ */
+const SWIPE_HINT_SUNSET: HomeWidgetSunset = {
+  afterSeen: 1,
+  afterAction: true,
+  dismissible: true,
+};
+
+/** Settle delay before the hint paints, so it never competes with home load. */
+export const SWIPE_HINT_SHOW_DELAY_MS = 1600;
+/** How long the hint stays up before fading itself out. */
+export const SWIPE_HINT_DISPLAY_MS = 7000;
+/** Fade-out duration; the permanent dismissal is recorded when it completes. */
+export const SWIPE_HINT_FADE_MS = 600;
+
+// Entrance slide-in plus a repeating leftward nudge on the chevron cluster —
+// the nudge mimes the finger motion being taught. Fully stilled under
+// prefers-reduced-motion (the pill still shows; only the motion stops).
+const SWIPE_HINT_CSS = `
+@keyframes swipe-hint-in {
+  from { opacity: 0; transform: translateX(10px); }
+  to   { opacity: 1; transform: none; }
+}
+@keyframes swipe-hint-nudge {
+  0%, 55%, 100% { transform: translateX(0); }
+  25% { transform: translateX(-6px); }
+}
+.swipe-hint-pill { animation: swipe-hint-in 420ms cubic-bezier(0.22,1,0.36,1) both; }
+.swipe-hint-chevrons { animation: swipe-hint-nudge 1.8s ease-in-out 600ms 3; }
+@media (prefers-reduced-motion: reduce) {
+  .swipe-hint-pill, .swipe-hint-chevrons { animation: none; }
+}
+`;
+
+/**
+ * Whether the hint may still start its one showing. The sunset policy is
+ * evaluated against the lifecycle as it will be AFTER this session's `seen`
+ * is counted, so a first showing interrupted mid-display (reload, closed tab)
+ * can never earn a second one — "one-time" is one reveal ever, not one
+ * completed display.
+ */
+function canStartShowing(life: HomeWidgetLifecycle): boolean {
+  const predicted: HomeWidgetLifecycle = { ...life, seen: life.seen + 1 };
+  return !isHomeWidgetSunset(SWIPE_HINT_WIDGET_KEY, SWIPE_HINT_SUNSET, {
+    [SWIPE_HINT_WIDGET_KEY]: predicted,
+  });
+}
+
+export function FirstSessionSwipeHint({
+  page,
+}: {
+  page: HomeLauncherPage;
+}): React.JSX.Element | null {
+  const finePointer = useMediaQuery(FINE_POINTER_EDGE_BUTTON_QUERY);
+  const dismissals = useHomeDismissals();
+  const lifecycle = dismissals[SWIPE_HINT_WIDGET_KEY];
+  const seen = lifecycle?.seen ?? 0;
+  // The user has proven (or ended) the lesson. The reveal-time `seen` bump can
+  // retire the hint under its afterSeen policy mid-display — that must not
+  // yank a pill that is already up, so only acted/dismissed hide it live.
+  const acted = lifecycle?.acted === true || lifecycle?.dismissed === true;
+
+  const [shown, setShown] = React.useState(false);
+  const [fading, setFading] = React.useState(false);
+  const [done, setDone] = React.useState(false);
+
+  // Any home → launcher flip (swipe, edge button, tutorial) demonstrates the
+  // rail; retire the hint permanently even if it never painted. Route-driven
+  // initial pages don't count: only an observed home → launcher transition.
+  const prevPageRef = React.useRef<HomeLauncherPage | null>(null);
+  React.useEffect(() => {
+    const prev = prevPageRef.current;
+    prevPageRef.current = page;
+    if (prev === "home" && page === "launcher") {
+      markHomeWidgetActed(SWIPE_HINT_WIDGET_KEY);
+    }
+  }, [page]);
+
+  // Reveal: eligibility is evaluated when the settle delay elapses, and the
+  // `seen` session is only counted when the hint actually paints — a session
+  // spent entirely on the launcher half never consumes the one showing.
+  // Primitive deps keep unrelated dismissal-store churn (other widgets
+  // recording their own lifecycles) from restarting the delay.
+  React.useEffect(() => {
+    if (shown || done || acted || finePointer || page !== "home") return;
+    if (!canStartShowing({ seen, acted: false, dismissed: false })) return;
+    const timer = window.setTimeout(() => {
+      setShown(true);
+      recordHomeWidgetSeen(SWIPE_HINT_WIDGET_KEY);
+    }, SWIPE_HINT_SHOW_DELAY_MS);
+    return () => window.clearTimeout(timer);
+  }, [shown, done, acted, seen, finePointer, page]);
+
+  React.useEffect(() => {
+    if (!shown || fading || done) return;
+    const timer = window.setTimeout(
+      () => setFading(true),
+      SWIPE_HINT_DISPLAY_MS,
+    );
+    return () => window.clearTimeout(timer);
+  }, [shown, fading, done]);
+
+  // The display cycle completing IS the permanent dismissal — "one-time" is
+  // literal: one full showing, then never again, even across remounts within
+  // the same session.
+  React.useEffect(() => {
+    if (!fading || done) return;
+    const timer = window.setTimeout(() => {
+      setDone(true);
+      dismissHomeWidget(SWIPE_HINT_WIDGET_KEY);
+    }, SWIPE_HINT_FADE_MS);
+    return () => window.clearTimeout(timer);
+  }, [fading, done]);
+
+  if (!shown || done || acted || page !== "home") return null;
+
+  return (
+    <div
+      data-testid="first-session-swipe-hint"
+      aria-hidden
+      className={cn(
+        "pointer-events-none absolute right-4 top-1/2 z-10 -translate-y-1/2 transition-opacity",
+        fading ? "opacity-0" : "opacity-100",
+      )}
+      style={{ transitionDuration: `${SWIPE_HINT_FADE_MS}ms` }}
+    >
+      <style>{SWIPE_HINT_CSS}</style>
+      <div
+        className={cn(
+          "swipe-hint-pill flex items-center gap-2 rounded-full py-2 pr-3.5 pl-2.5",
+          WALLPAPER_GLASS.floatingControl,
+        )}
+      >
+        <span className="swipe-hint-chevrons flex items-center">
+          <ChevronLeft className="-mr-2 h-4 w-4 opacity-40" aria-hidden />
+          <ChevronLeft className="-mr-2 h-4 w-4 opacity-70" aria-hidden />
+          <ChevronLeft className="h-4 w-4" aria-hidden />
+        </span>
+        <span
+          className={cn(
+            "text-xs font-medium",
+            WALLPAPER_TEXT.strong,
+            WALLPAPER_FLOAT_SHADOW,
+          )}
+        >
+          Swipe for apps
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/shell/HomeLauncherSurface.tsx
+++ b/packages/ui/src/components/shell/HomeLauncherSurface.tsx
@@ -11,6 +11,7 @@ import {
   setShellSurfacePage,
   useShellSurface,
 } from "../../state/shell-surface-store";
+import { FirstSessionSwipeHint } from "./FirstSessionSwipeHint";
 import { PagerEdgeButtons } from "./PagerEdgeButtons";
 
 export interface HomeLauncherSurfaceProps {
@@ -171,6 +172,11 @@ export function HomeLauncherSurface({
         prevLabel="Home"
         nextLabel="Launcher"
       />
+      {/* Touch complement of the edge buttons: a one-time first-session pill
+          teaching the swipe, retired forever through the home-dismissal sunset
+          lifecycle. Floats over the rail (pointer-events-none) so it can never
+          steal the gesture it teaches. */}
+      <FirstSessionSwipeHint page={page} />
     </section>
   );
 }

--- a/packages/ui/src/components/shell/PagerEdgeButtons.test.tsx
+++ b/packages/ui/src/components/shell/PagerEdgeButtons.test.tsx
@@ -6,7 +6,10 @@
 
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { PagerEdgeButtons } from "./PagerEdgeButtons";
+import {
+  FINE_POINTER_EDGE_BUTTON_QUERY,
+  PagerEdgeButtons,
+} from "./PagerEdgeButtons";
 
 function mockPointerCapability({ finePointer }: { finePointer: boolean }) {
   window.matchMedia = vi.fn().mockImplementation((query: string) => ({
@@ -102,5 +105,27 @@ describe("PagerEdgeButtons (#10717)", () => {
     expect(cls).toContain("text-white/55");
     expect(cls).toContain("hover:text-white");
     expect(cls).not.toMatch(/border|rounded-|bg-(black|white|blue)/);
+  });
+});
+
+// The first-session swipe hint (#13453 debt 5) renders exactly where these
+// buttons do not: both surfaces evaluate this ONE exported query, so the
+// complement cannot drift into showing both teaching affordances (or neither)
+// on a single device.
+describe("FINE_POINTER_EDGE_BUTTON_QUERY complement contract", () => {
+  it("is the exact fine-pointer query FirstSessionSwipeHint inverts", () => {
+    expect(FINE_POINTER_EDGE_BUTTON_QUERY).toBe(
+      "(hover: hover) and (pointer: fine)",
+    );
+  });
+
+  it("gates the buttons on exactly this query, nothing else", () => {
+    mockPointerCapability({ finePointer: true });
+    render(
+      <PagerEdgeButtons canPrev canNext goPrev={vi.fn()} goNext={vi.fn()} />,
+    );
+    expect(window.matchMedia).toHaveBeenCalledWith(
+      FINE_POINTER_EDGE_BUTTON_QUERY,
+    );
   });
 });

--- a/packages/ui/src/components/shell/PagerEdgeButtons.tsx
+++ b/packages/ui/src/components/shell/PagerEdgeButtons.tsx
@@ -21,7 +21,13 @@ import { Button } from "../ui/button";
  * no blue), positioned on the vertical center of the left/right edges. Each
  * arrow is hidden when there is no page to move to in that direction.
  */
-const FINE_POINTER_EDGE_BUTTON_QUERY = "(hover: hover) and (pointer: fine)";
+/**
+ * Devices that get the resting `<` `>` affordance. FirstSessionSwipeHint keys
+ * off the exact same query (inverted) so the two teaching surfaces are perfect
+ * complements — every device gets exactly one of them, never both.
+ */
+export const FINE_POINTER_EDGE_BUTTON_QUERY =
+  "(hover: hover) and (pointer: fine)";
 
 export function PagerEdgeButtons({
   canPrev,

--- a/packages/ui/src/widgets/home-dismissal-store.ts
+++ b/packages/ui/src/widgets/home-dismissal-store.ts
@@ -159,6 +159,18 @@ export function isHomeWidgetSunset(
   return false;
 }
 
+/**
+ * Test-only session boundary: clears the per-session `seen` guard and re-reads
+ * persisted state, exactly what a page reload does. Lets a test exercise
+ * cross-session sunset behavior (afterSeen retirement) without resetting the
+ * module registry.
+ */
+export function __simulateNewSessionForTests(): void {
+  seenThisSession.clear();
+  state = readPersisted();
+  emit();
+}
+
 /** Test-only reset (state + session guard + listeners). */
 export function __resetHomeDismissalsForTests(): void {
   state = {};


### PR DESCRIPTION
Closes a remaining #13453 launcher discoverability gap — design-verdict debt #5 from the [verdict pass](https://github.com/elizaOS/eliza/issues/13453#issuecomment-4889349540): *"Gesture discoverability — one-time first-session hint via the existing `home-dismissal-store` sunset lifecycle; never persistent chrome."* The home↔launcher rail's page dots were removed (they collided with the floating composer), so on touch devices the horizontal swipe is the sole rail navigation with no resting signal that the launcher exists.

The hint:

- appears only on coarse/touch pointers — the exact media-query complement of the desktop `PagerEdgeButtons` `<` `>` affordance (every device gets exactly one teaching surface, never both);
- never intercepts the gesture it teaches (`pointer-events: none`, `aria-hidden`);
- is **not persistent chrome** (the verdict-doc requirement): it surfaces once after a 1.6 s settle delay in the user's first home session, holds 7 s, fades, and permanently dismisses itself;
- retires early the moment the user demonstrates the gesture (any observed home→launcher flip marks `acted`, even before the hint ever paints) and can never earn a second reveal after an interrupted first showing (`afterSeen: 1` is evaluated against the post-reveal lifecycle);
- persists retirement through the existing `home-dismissal-store` sunset lifecycle (`seen`/`acted`/`dismissed` in `eliza:home-dismissed:v1`) — no new store, no new persistence namespace.

## Verification

- `bun run --cwd packages/ui test -- FirstSessionSwipeHint.test.tsx` — 8/8 pass (once-only lifecycle: reveal→fade→permanent dismissal, no re-reveal on remount, acted-before-shown retirement, mid-display acted hide, route-driven launcher start not counted, launcher-only session does not consume the showing, interrupted first showing never re-reveals next session, fine-pointer suppression)
- `PagerEdgeButtons.test.tsx` (incl. 2 new complement-query contract tests, 7/7) + all `src/widgets/` suites — 116/116 pass; `HomeLauncherSurface(.composed)` — 26/26 pass; `PagerEdgeButtons.tsx` at 100% line coverage in the changed-files lane
- `bun run --cwd packages/ui typecheck` — pass
- Biome on all five changed files — pass
- `bun run audit:error-policy-ratchet` — pass (no new fallback-slop in touched files)
- `bun run --cwd packages/app audit:app` **on this build** — exit 0: 241/241 Playwright cases passed; 240 findings — **broken=0, needs-work=0, good=227, needs-eyeball=13**; minimalism budget/ratchet 0 failures; OCR triage broken=0, gate green. The touched surfaces (`builtin-chat` home rail + `builtin-apps` launcher) are **`good` on all four viewports with zero console errors**. (The audit browser is fine-pointer, so the touch-only hint deterministically never enters audit captures — by construction, the same media query that hides it on desktop.)

## Evidence

Captured against the real built renderer (`[renderer-build] 9749cfba8801 built 2026-07-10T00:55Z`) served by the ui-smoke live stack, Pixel 7 emulation (coarse pointer) + 1440×900 desktop. Full assets: [evidence gist](https://gist.github.com/lalalune/dacd063b9472e54f1fda44a1938df8d3).

**Video walkthrough (MP4, 19 s): [swipe-hint-once-then-never.mp4](https://gist.github.com/lalalune/dacd063b9472e54f1fda44a1938df8d3/raw/swipe-hint-once-then-never.mp4)** — home loads → hint reveals after the settle delay → holds → fades and permanently dismisses → reload → never returns → the taught swipe flips to the launcher.

| First session (hint up) | After display cycle | Reload — never again | Swipe still works |
|---|---|---|---|
| ![hint visible](https://gist.github.com/lalalune/dacd063b9472e54f1fda44a1938df8d3/raw/mobile-hint-visible.jpg) | ![hint gone](https://gist.github.com/lalalune/dacd063b9472e54f1fda44a1938df8d3/raw/mobile-hint-gone.jpg) | ![second session](https://gist.github.com/lalalune/dacd063b9472e54f1fda44a1938df8d3/raw/mobile-second-session.jpg) | ![launcher](https://gist.github.com/lalalune/dacd063b9472e54f1fda44a1938df8d3/raw/mobile-launcher-after-swipe.jpg) |

Desktop (fine pointer): no hint ever renders; the `>` edge chevron is the resting affordance —
![desktop](https://gist.github.com/lalalune/dacd063b9472e54f1fda44a1938df8d3/raw/desktop-no-hint.jpg)

<details>
<summary>Frontend console probes — the persisted lifecycle records (domain artifact)</summary>

```
[probe] lifecycle after reveal:        {"shell:first-session-swipe-hint":{"seen":1,"acted":false,"dismissed":false}}
[probe] lifecycle after display cycle: {"shell:first-session-swipe-hint":{"seen":1,"acted":false,"dismissed":true}}
[probe] hint present after reload:     false
[probe] rail page after swipe:         launcher
[probe] acted-path lifecycle:          {"shell:first-session-swipe-hint":{"seen":0,"acted":true,"dismissed":false}}   (fresh session: swiped before the hint painted -> retired without ever showing)
[probe] hint present after acted:      false
[probe] desktop hint present:          false
[probe] desktop edge-next present:     true
```

Full console + network logs: [console.log](https://gist.github.com/lalalune/dacd063b9472e54f1fda44a1938df8d3/raw/console.log), [network.log](https://gist.github.com/lalalune/dacd063b9472e54f1fda44a1938df8d3/raw/network.log). The 404/501 resource errors visible during boot are the ui-smoke stub stack's unimplemented endpoints, identical on develop.
</details>

- Backend logs: N/A — purely client-side shell chrome; no server code path changes (the network log shows only static/renderer serving).
- Live-LLM trajectories: N/A — no agent/action/provider/prompt/model behavior change.
- Domain artifacts: the persisted `eliza:home-dismissed:v1` lifecycle records (`seen→dismissed`, `acted`) are shown in the console probes above — that localStorage record is this change's only domain artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15858-before-mobile-home-develop.jpg)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15858-mobile-hint-visible.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence/15858-swipe-hint-once-then-never.mp4

<!-- evidence-row:backend-logs -->
- [ ] N/A - purely client-side shell chrome (pointer-events-none decorative pill); no server code path changes

<!-- evidence-row:frontend-logs -->
- [x] [15858-frontend-console-network.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15858-frontend-console-network.log)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model behavior change

<!-- evidence-row:domain-artifacts -->
- [x] [15858-lifecycle-records.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15858-lifecycle-records.txt)

<!-- evidence-row:ocr-review -->
- [x] [15858-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15858-ocr-review.txt)