### PR TITLE
fix(app): consume navigation preload on SW auth bypass branch (#15741)

### DIFF
--- a/packages/app/public/sw.js
+++ b/packages/app/public/sw.js
@@ -206,7 +206,17 @@ self.addEventListener("fetch", (event) => {
     url.searchParams.has("token")
   ) {
     event.respondWith(
-      (async () => (await event.preloadResponse) || fetch(request))(),
+      (async () => {
+        try {
+          const preloaded = await event.preloadResponse;
+          if (preloaded) return preloaded;
+        } catch (_err) {
+          // error-policy:J4 a failed/aborted preload must not fail the sign-in
+          // navigation — fall through to the same direct network fetch the
+          // pre-takeover bypass delegated to the browser.
+        }
+        return fetch(request);
+      })(),
     );
     return;
   }

--- a/packages/app/public/sw.js
+++ b/packages/app/public/sw.js
@@ -194,13 +194,20 @@ self.addEventListener("fetch", (event) => {
   // callback must always load the freshest shell from the network. A stale
   // cached shell can carry an outdated build — e.g. one baked with the wrong
   // Steward tenant — which makes the code exchange fail with 401, and caching a
-  // one-time `?code=` callback URL risks replaying a consumed code. Bypassing
-  // (no respondWith) lets the browser fetch directly, uncached.
+  // one-time `?code=` callback URL risks replaying a consumed code. We take
+  // over the response only to drain the already-issued navigation-preload fetch
+  // (`event.preloadResponse`) — otherwise the browser logs "navigation preload
+  // request was cancelled" and wastes that round-trip on the sign-in golden
+  // path. The invariant above is preserved: both the preload and the fallback
+  // are uncached network fetches, so no cached shell is ever served here.
   if (
     pathname === "/login" ||
     url.searchParams.has("code") ||
     url.searchParams.has("token")
   ) {
+    event.respondWith(
+      (async () => (await event.preloadResponse) || fetch(request))(),
+    );
     return;
   }
 

--- a/packages/app/src/sw-fetch.test.ts
+++ b/packages/app/src/sw-fetch.test.ts
@@ -166,6 +166,27 @@ describe("sw.js fetch handler — auth navigation branch", () => {
     expect(cacheCalls).toEqual([]);
   });
 
+  it("falls back to a live fetch when the preload REJECTS (flaky-network sign-in must not fail)", async () => {
+    const handler = loadFetchListener(caches, fetchImpl);
+    const event: FetchEventStub = {
+      request: { url: `${ORIGIN}/login`, method: "GET", mode: "navigate" },
+      preloadResponse: Promise.reject(new Error("preload aborted")),
+      respondWith: vi.fn((p: unknown) => {
+        event.responsePromise = p;
+      }),
+    };
+
+    handler(event);
+
+    // The pre-takeover bypass let the browser fetch directly after a dead
+    // preload; the takeover must be no more fragile than that.
+    expect(event.respondWith).toHaveBeenCalledTimes(1);
+    const resolved = await event.responsePromise;
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(resolved).toEqual({ __from: "fetch" });
+    expect(cacheCalls).toEqual([]);
+  });
+
   it("still routes a normal shell navigation through the cache (control)", () => {
     const handler = loadFetchListener(caches, fetchImpl);
     const event = makeNavEvent(`${ORIGIN}/dashboard`, undefined);

--- a/packages/app/src/sw-fetch.test.ts
+++ b/packages/app/src/sw-fetch.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Contract tests for the service-worker `fetch` handler (`public/sw.js`),
+ * focused on the auth/OAuth navigation branch (`/login`, `?code=`, `?token=`).
+ *
+ * `sw.js` is plain event-listener JS: it registers `self.addEventListener`
+ * handlers at load time. We evaluate it against a stubbed `self` (capturing the
+ * registered `fetch` listener) and stubbed `caches`/`fetch`, then dispatch
+ * synthetic `FetchEvent`s — driving the real handler, not a re-implementation.
+ *
+ * The invariant under test: auth navigations must consume the browser's
+ * navigation-preload fetch (so no "navigation preload request was cancelled"
+ * warning / wasted round-trip) while still serving only uncached network
+ * responses — the `caches` API must never be touched on this path.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const ORIGIN = "https://app.example.com";
+
+interface CapturedListeners {
+  fetch?: (event: unknown) => void;
+}
+
+interface FetchEventStub {
+  request: { url: string; method: string; mode: string };
+  preloadResponse: Promise<unknown>;
+  respondWith: ReturnType<typeof vi.fn>;
+  responsePromise?: unknown;
+}
+
+// A `caches` stub whose every access records a hit, so a test can assert the
+// auth branch never reaches the Cache Storage API (would mean a cached shell
+// could be served on the sign-in golden path — the forbidden regression).
+function makeCachesSpy() {
+  const calls: string[] = [];
+  const record = (name: string) => {
+    calls.push(name);
+  };
+  // open() resolves to a functional Cache stub so a control (non-auth)
+  // navigation can flow through networkFirst without an unhandled rejection;
+  // every access still lands in `calls` for the "was Cache Storage touched?"
+  // assertions the auth-branch tests rely on.
+  const cache = {
+    match: () => {
+      record("cache.match");
+      return Promise.resolve(undefined);
+    },
+    put: () => {
+      record("cache.put");
+      return Promise.resolve();
+    },
+  };
+  const caches = {
+    open: (...a: unknown[]) => {
+      record(`open:${String(a[0])}`);
+      return Promise.resolve(cache);
+    },
+    match: () => {
+      record("match");
+      return Promise.resolve(undefined);
+    },
+    keys: () => {
+      record("keys");
+      return Promise.resolve([]);
+    },
+    delete: () => {
+      record("delete");
+      return Promise.resolve(true);
+    },
+  };
+  return { caches, calls };
+}
+
+function loadFetchListener(caches: unknown, fetchImpl: unknown) {
+  const listeners: CapturedListeners = {};
+  const self = {
+    addEventListener: (type: string, handler: (event: unknown) => void) => {
+      if (type === "fetch") listeners.fetch = handler;
+    },
+    location: { origin: ORIGIN },
+    registration: { navigationPreload: undefined, showNotification: vi.fn() },
+    clients: { matchAll: () => Promise.resolve([]), claim: () => {} },
+    navigator: {},
+    skipWaiting: () => Promise.resolve(),
+    __elizaPush: undefined,
+  };
+  const src = readFileSync(join(__dirname, "..", "public", "sw.js"), "utf8");
+  // importScripts is a no-op here: the push module is exercised separately in
+  // sw-push.test.ts and is irrelevant to the fetch-routing logic under test.
+  const importScripts = () => {};
+  const console = { warn: () => {}, error: () => {}, log: () => {} };
+  // eslint-disable-next-line no-new-func
+  new Function("self", "caches", "fetch", "importScripts", "console", src)(
+    self,
+    caches,
+    fetchImpl,
+    importScripts,
+    console,
+  );
+  if (!listeners.fetch)
+    throw new Error("sw.js did not register a fetch listener");
+  return listeners.fetch;
+}
+
+function makeNavEvent(url: string, preload: unknown): FetchEventStub {
+  const event: FetchEventStub = {
+    request: { url, method: "GET", mode: "navigate" },
+    preloadResponse: Promise.resolve(preload),
+    respondWith: vi.fn((p: unknown) => {
+      event.responsePromise = p;
+    }),
+  };
+  return event;
+}
+
+const AUTH_URLS = [
+  `${ORIGIN}/login`,
+  `${ORIGIN}/?code=abc123`,
+  `${ORIGIN}/auth/callback?token=xyz`,
+];
+
+describe("sw.js fetch handler — auth navigation branch", () => {
+  let caches: unknown;
+  let cacheCalls: string[];
+  let fetchImpl: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    const spy = makeCachesSpy();
+    caches = spy.caches;
+    cacheCalls = spy.calls;
+    fetchImpl = vi.fn(() => Promise.resolve({ __from: "fetch" }));
+  });
+
+  it.each(
+    AUTH_URLS,
+  )("takes over the response to consume the preload for %s", async (url) => {
+    const handler = loadFetchListener(caches, fetchImpl);
+    const preload = { __from: "preload" };
+    const event = makeNavEvent(url, preload);
+
+    handler(event);
+
+    // Regression guard: before the fix this branch returned without
+    // respondWith, leaving event.preloadResponse unconsumed.
+    expect(event.respondWith).toHaveBeenCalledTimes(1);
+    await expect(event.responsePromise).resolves.toBe(preload);
+    // The preload already carried the network response, so no direct fetch.
+    expect(fetchImpl).not.toHaveBeenCalled();
+    // Never touch Cache Storage on the auth path — no cached shell served.
+    expect(cacheCalls).toEqual([]);
+  });
+
+  it("falls back to a live fetch when no preload was issued", async () => {
+    const handler = loadFetchListener(caches, fetchImpl);
+    const event = makeNavEvent(`${ORIGIN}/login`, undefined);
+
+    handler(event);
+
+    expect(event.respondWith).toHaveBeenCalledTimes(1);
+    const resolved = await event.responsePromise;
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(resolved).toEqual({ __from: "fetch" });
+    // Fallback is still an uncached network fetch — no Cache Storage access.
+    expect(cacheCalls).toEqual([]);
+  });
+
+  it("still routes a normal shell navigation through the cache (control)", () => {
+    const handler = loadFetchListener(caches, fetchImpl);
+    const event = makeNavEvent(`${ORIGIN}/dashboard`, undefined);
+
+    handler(event);
+
+    // A non-auth navigation is intercepted by networkFirst, which does consult
+    // the shell cache — proving the auth carve-out above is branch-specific.
+    expect(event.respondWith).toHaveBeenCalledTimes(1);
+    expect(cacheCalls.some((c) => c.startsWith("open:"))).toBe(true);
+  });
+});

--- a/packages/app/test/service-worker-runtime.test.ts
+++ b/packages/app/test/service-worker-runtime.test.ts
@@ -1,0 +1,546 @@
+/**
+ * In-process runtime coverage for the real `public/sw.js`: the module is
+ * imported directly (not vm-evaluated) under stubbed service-worker globals, so
+ * the coverage gate observes the production file while the tests drive every
+ * registered handler — lifecycle cache cleanup + navigation-preload enable, all
+ * four fetch strategies, the auth-navigation network passthrough (#15741), the
+ * page message commands, and the push/notificationclick adapters.
+ *
+ * The companion `service-worker-auth-bypass.test.ts` proves the same contract
+ * inside real Chromium; this harness pins the handler logic branch-by-branch.
+ */
+
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+type Handler = (event: unknown) => void;
+
+const handlers = new Map<string, Handler>();
+
+/** Insertion-ordered Cache Storage double; order matters for trimCache. */
+class FakeCache {
+  store = new Map<string, Response>();
+
+  async match(
+    request: { url: string } | string,
+  ): Promise<Response | undefined> {
+    const url = typeof request === "string" ? request : request.url;
+    const hit = this.store.get(url);
+    return hit?.clone();
+  }
+
+  async put(
+    request: { url: string } | string,
+    response: Response,
+  ): Promise<void> {
+    const url = typeof request === "string" ? request : request.url;
+    // Re-put refreshes insertion order, matching Cache Storage semantics.
+    this.store.delete(url);
+    this.store.set(url, response);
+  }
+
+  async keys(): Promise<Array<{ url: string }>> {
+    return [...this.store.keys()].map((url) => ({ url }));
+  }
+
+  async delete(request: { url: string } | string): Promise<boolean> {
+    const url = typeof request === "string" ? request : request.url;
+    return this.store.delete(url);
+  }
+}
+
+class FakeCacheStorage {
+  caches = new Map<string, FakeCache>();
+
+  async open(name: string): Promise<FakeCache> {
+    let cache = this.caches.get(name);
+    if (!cache) {
+      cache = new FakeCache();
+      this.caches.set(name, cache);
+    }
+    return cache;
+  }
+
+  async keys(): Promise<string[]> {
+    return [...this.caches.keys()];
+  }
+
+  async delete(name: string): Promise<boolean> {
+    return this.caches.delete(name);
+  }
+}
+
+interface FakeRequestInit {
+  method?: string;
+  mode?: string;
+}
+
+class FakeRequest {
+  method: string;
+  mode: string;
+  url: string;
+
+  constructor(url: string, init: FakeRequestInit = {}) {
+    this.url = url;
+    this.method = init.method ?? "GET";
+    this.mode = init.mode ?? "no-cors";
+  }
+
+  clone(): FakeRequest {
+    return new FakeRequest(this.url, { method: this.method, mode: this.mode });
+  }
+}
+
+interface FetchEventLike {
+  request: FakeRequest;
+  preloadResponse?: Promise<Response | undefined>;
+  respondWith: (value: Promise<Response> | Response) => void;
+  waitUntil: (value: Promise<unknown>) => void;
+  responded: Promise<Response> | Response | null;
+  respondWithCalls: number;
+  pending: Promise<unknown>[];
+}
+
+function makeFetchEvent(
+  request: FakeRequest,
+  preloadResponse?: Promise<Response | undefined>,
+): FetchEventLike {
+  const event: FetchEventLike = {
+    request,
+    respondWith(value) {
+      this.respondWithCalls += 1;
+      this.responded = value;
+    },
+    waitUntil(value) {
+      this.pending.push(value);
+    },
+    responded: null,
+    respondWithCalls: 0,
+    pending: [],
+  };
+  if (preloadResponse) event.preloadResponse = preloadResponse;
+  return event;
+}
+
+async function dispatchFetch(
+  request: FakeRequest,
+  preloadResponse?: Promise<Response | undefined>,
+): Promise<FetchEventLike> {
+  const handler = handlers.get("fetch");
+  if (!handler) throw new Error("fetch handler not registered");
+  const event = makeFetchEvent(request, preloadResponse);
+  handler(event);
+  return event;
+}
+
+const ORIGIN = "https://app.test";
+const cacheStorage = new FakeCacheStorage();
+const fetchMock = vi.fn();
+const skipWaiting = vi.fn(async () => {});
+const preloadEnable = vi.fn(async () => {});
+const clientsClaim = vi.fn(async () => {});
+const showNotification = vi.fn(async () => {});
+const postedMessages: unknown[] = [];
+const matchAll = vi.fn(async () => [
+  { postMessage: (m: unknown) => postedMessages.push(m) },
+]);
+
+const fakePush = {
+  parsePushData: vi.fn(() => ({ kind: "chat" })),
+  buildNotification: vi.fn(() => ({ title: "Eliza", options: { body: "hi" } })),
+  badgeCountFromPayload: vi.fn(() => 3),
+  dispatchToVisibleClients: vi.fn(async () => false),
+  applyBadge: vi.fn(async () => {}),
+  resolveClickTarget: vi.fn(() => "/chat/c1"),
+  focusOrOpen: vi.fn(async () => {}),
+  clearBadge: vi.fn(async () => {}),
+};
+
+const savedGlobals = new Map<string, PropertyDescriptor | undefined>();
+
+// Some runtime globals (navigator under Node) are getter-only, so plain
+// assignment throws; define/restore via property descriptors instead.
+function setGlobal(key: string, value: unknown): void {
+  if (!savedGlobals.has(key)) {
+    savedGlobals.set(key, Object.getOwnPropertyDescriptor(globalThis, key));
+  }
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    writable: true,
+    value,
+  });
+}
+
+beforeAll(async () => {
+  setGlobal("self", globalThis);
+  setGlobal("location", { origin: ORIGIN });
+  setGlobal("caches", cacheStorage);
+  setGlobal("fetch", fetchMock);
+  setGlobal("skipWaiting", skipWaiting);
+  setGlobal("registration", {
+    navigationPreload: { enable: preloadEnable },
+    showNotification,
+  });
+  setGlobal("clients", { claim: clientsClaim, matchAll });
+  setGlobal("navigator", {});
+  // The real /sw-push.js attaches self.__elizaPush; the stub wires the same
+  // contract so the push/notificationclick adapters can be driven.
+  setGlobal("importScripts", () => {
+    setGlobal("__elizaPush", fakePush);
+  });
+  setGlobal("addEventListener", (type: string, handler: Handler) => {
+    handlers.set(type, handler);
+  });
+
+  await import("../public/sw.js");
+});
+
+afterAll(() => {
+  for (const [key, descriptor] of savedGlobals) {
+    if (descriptor === undefined) {
+      delete (globalThis as unknown as Record<string, unknown>)[key];
+    } else {
+      Object.defineProperty(globalThis, key, descriptor);
+    }
+  }
+});
+
+describe("lifecycle", () => {
+  it("install skips waiting immediately", () => {
+    const pending: Promise<unknown>[] = [];
+    handlers.get("install")?.({
+      waitUntil: (p: Promise<unknown>) => pending.push(p),
+    });
+    expect(skipWaiting).toHaveBeenCalledTimes(1);
+    expect(pending).toHaveLength(1);
+  });
+
+  it("activate drops unknown caches, enables navigation preload, claims clients", async () => {
+    await (await cacheStorage.open("elizaos-views-v0")).put(
+      new FakeRequest(`${ORIGIN}/stale`),
+      new Response("old"),
+    );
+    await cacheStorage.open("elizaos-views-v1");
+
+    const pending: Promise<unknown>[] = [];
+    handlers.get("activate")?.({
+      waitUntil: (p: Promise<unknown>) => pending.push(p),
+    });
+    await Promise.all(pending);
+
+    expect(await cacheStorage.keys()).not.toContain("elizaos-views-v0");
+    expect(await cacheStorage.keys()).toContain("elizaos-views-v1");
+    expect(preloadEnable).toHaveBeenCalledTimes(1);
+    expect(clientsClaim).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("fetch routing guards", () => {
+  it("ignores non-GET, unparseable, and cross-origin requests", async () => {
+    const post = await dispatchFetch(
+      new FakeRequest(`${ORIGIN}/login`, { method: "POST" }),
+    );
+    expect(post.respondWithCalls).toBe(0);
+
+    const bad = await dispatchFetch(new FakeRequest("::not-a-url::"));
+    expect(bad.respondWithCalls).toBe(0);
+
+    const cross = await dispatchFetch(
+      new FakeRequest("https://other.test/login"),
+    );
+    expect(cross.respondWithCalls).toBe(0);
+  });
+});
+
+describe("auth navigation passthrough (#15741)", () => {
+  it("serves the consumed preload response for /login navigations, touching no cache", async () => {
+    const preloaded = new Response("login shell", { status: 200 });
+    fetchMock.mockClear();
+    const event = await dispatchFetch(
+      new FakeRequest(`${ORIGIN}/login`, { mode: "navigate" }),
+      Promise.resolve(preloaded),
+    );
+    expect(event.respondWithCalls).toBe(1);
+    await expect(event.responded).resolves.toBe(preloaded);
+    expect(fetchMock).not.toHaveBeenCalled();
+    // No cache gained a /login entry in either direction.
+    for (const cache of cacheStorage.caches.values()) {
+      expect(cache.store.has(`${ORIGIN}/login`)).toBe(false);
+    }
+  });
+
+  it("fetches the ORIGINAL request when no preload was started (resolves undefined)", async () => {
+    const network = new Response("net", { status: 200 });
+    fetchMock.mockResolvedValueOnce(network);
+    const request = new FakeRequest(`${ORIGIN}/chat?code=one-time`, {
+      mode: "navigate",
+    });
+    const event = await dispatchFetch(request, Promise.resolve(undefined));
+    await expect(event.responded).resolves.toBe(network);
+    // Passthrough must hand fetch the original object, not a clone.
+    expect(fetchMock).toHaveBeenCalledWith(request);
+  });
+
+  it("falls back to a direct fetch when the preload rejects", async () => {
+    const network = new Response("net", { status: 200 });
+    fetchMock.mockResolvedValueOnce(network);
+    const event = await dispatchFetch(
+      new FakeRequest(`${ORIGIN}/cb?token=t1`, { mode: "navigate" }),
+      Promise.reject(new Error("preload aborted")),
+    );
+    await expect(event.responded).resolves.toBe(network);
+  });
+
+  it("handles engines that expose no preloadResponse property at all", async () => {
+    const network = new Response("net", { status: 200 });
+    fetchMock.mockResolvedValueOnce(network);
+    const event = await dispatchFetch(
+      new FakeRequest(`${ORIGIN}/login`, { mode: "navigate" }),
+    );
+    await expect(event.responded).resolves.toBe(network);
+  });
+
+  it("passes non-navigation auth-param requests straight to the network, untouched by caches", async () => {
+    const network = new Response("api", { status: 200 });
+    fetchMock.mockClear();
+    fetchMock.mockResolvedValueOnce(network);
+    const request = new FakeRequest(`${ORIGIN}/api/session?token=abc`);
+    const event = await dispatchFetch(request);
+    expect(event.respondWithCalls).toBe(1);
+    await expect(event.responded).resolves.toBe(network);
+    expect(fetchMock).toHaveBeenCalledWith(request);
+  });
+});
+
+describe("view bundle stale-while-revalidate", () => {
+  const bundleUrl = `${ORIGIN}/api/views/v1/bundle.js`;
+
+  it("cold cache: serves the network response and caches it", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response("bundle-1", { status: 200, headers: { etag: '"e1"' } }),
+    );
+    const event = await dispatchFetch(new FakeRequest(bundleUrl));
+    const response = await event.responded;
+    expect(await response?.text()).toBe("bundle-1");
+    const cache = await cacheStorage.open("elizaos-views-v1");
+    expect(cache.store.has(bundleUrl)).toBe(true);
+  });
+
+  it("warm cache: serves stale immediately and notifies clients on an etag change", async () => {
+    postedMessages.length = 0;
+    fetchMock.mockResolvedValueOnce(
+      new Response("bundle-2", { status: 200, headers: { etag: '"e2"' } }),
+    );
+    const event = await dispatchFetch(new FakeRequest(bundleUrl));
+    const response = await event.responded;
+    expect(await response?.text()).toBe("bundle-1");
+    await Promise.all(event.pending);
+    await vi.waitFor(() => {
+      expect(postedMessages).toContainEqual({
+        type: "sw:view-updated",
+        viewId: "v1",
+      });
+    });
+  });
+
+  it("offline with a cached copy serves the cache; without one serves 503", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("offline"));
+    const warm = await dispatchFetch(new FakeRequest(bundleUrl));
+    expect(await (await warm.responded)?.text()).toBe("bundle-2");
+
+    fetchMock.mockRejectedValueOnce(new Error("offline"));
+    const cold = await dispatchFetch(
+      new FakeRequest(`${ORIGIN}/api/views/v-none/bundle.js`),
+    );
+    expect((await cold.responded)?.status).toBe(503);
+  });
+});
+
+describe("hero cache-first with max-age", () => {
+  const heroUrl = `${ORIGIN}/api/views/v1/hero`;
+
+  it("caches the first fetch and serves fresh hits from cache", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response("hero", {
+        status: 200,
+        headers: { date: new Date().toUTCString() },
+      }),
+    );
+    const miss = await dispatchFetch(new FakeRequest(heroUrl));
+    expect(await (await miss.responded)?.text()).toBe("hero");
+
+    fetchMock.mockClear();
+    const hit = await dispatchFetch(new FakeRequest(heroUrl));
+    expect(await (await hit.responded)?.text()).toBe("hero");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("refetches an expired hero", async () => {
+    const cache = await cacheStorage.open("elizaos-views-v1");
+    await cache.put(
+      new FakeRequest(heroUrl),
+      new Response("stale-hero", {
+        status: 200,
+        headers: {
+          date: new Date(Date.now() - 25 * 60 * 60 * 1000).toUTCString(),
+        },
+      }),
+    );
+    fetchMock.mockResolvedValueOnce(
+      new Response("fresh-hero", { status: 200 }),
+    );
+    const event = await dispatchFetch(new FakeRequest(heroUrl));
+    expect(await (await event.responded)?.text()).toBe("fresh-hero");
+  });
+});
+
+describe("immutable assets", () => {
+  it("serves cache-first, caches misses, and bounds the cache to its MRU window", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("chunk", { status: 200 }));
+    const miss = await dispatchFetch(
+      new FakeRequest(`${ORIGIN}/assets/entry-abc123.js`),
+    );
+    expect(await (await miss.responded)?.text()).toBe("chunk");
+
+    fetchMock.mockClear();
+    const hit = await dispatchFetch(
+      new FakeRequest(`${ORIGIN}/assets/entry-abc123.js`),
+    );
+    expect(await (await hit.responded)?.text()).toBe("chunk");
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    // Overfill past the 220-entry cap; the oldest keys must be evicted.
+    const assets = await cacheStorage.open("elizaos-assets-v1");
+    for (let i = 0; i < 224; i += 1) {
+      await assets.put(
+        new FakeRequest(`${ORIGIN}/assets/seed-${i}.js`),
+        new Response("s"),
+      );
+    }
+    fetchMock.mockResolvedValueOnce(new Response("tip", { status: 200 }));
+    const tip = await dispatchFetch(
+      new FakeRequest(`${ORIGIN}/assets/tip-fff.js`),
+    );
+    await tip.responded;
+    expect(assets.store.size).toBe(220);
+    expect(assets.store.has(`${ORIGIN}/assets/tip-fff.js`)).toBe(true);
+    expect(assets.store.has(`${ORIGIN}/assets/entry-abc123.js`)).toBe(false);
+  });
+
+  it("degrades to 503 when the network is down and nothing is cached", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("offline"));
+    const event = await dispatchFetch(
+      new FakeRequest(`${ORIGIN}/assets/missing-000.css`),
+    );
+    expect((await event.responded)?.status).toBe(503);
+  });
+});
+
+describe("app shell network-first", () => {
+  it("consumes the preload, caches OK responses, and falls back to cache offline", async () => {
+    const preloaded = new Response("shell", { status: 200 });
+    fetchMock.mockClear();
+    const preload = await dispatchFetch(
+      new FakeRequest(`${ORIGIN}/chat`, { mode: "navigate" }),
+      Promise.resolve(preloaded),
+    );
+    expect(await preload.responded).toBe(preloaded);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    fetchMock.mockRejectedValueOnce(new Error("offline"));
+    const offline = await dispatchFetch(
+      new FakeRequest(`${ORIGIN}/chat`, { mode: "navigate" }),
+    );
+    expect(await (await offline.responded)?.text()).toBe("shell");
+
+    fetchMock.mockRejectedValueOnce(new Error("offline"));
+    const cold = await dispatchFetch(
+      new FakeRequest(`${ORIGIN}/never-seen`, { mode: "navigate" }),
+    );
+    expect((await cold.responded)?.status).toBe(503);
+  });
+});
+
+describe("page message commands", () => {
+  async function dispatchMessage(data: unknown): Promise<Promise<unknown>[]> {
+    const pending: Promise<unknown>[] = [];
+    handlers.get("message")?.({
+      data,
+      waitUntil: (p: Promise<unknown>) => pending.push(p),
+    });
+    await Promise.all(pending);
+    return pending;
+  }
+
+  it("evicts one view's bundle + hero and leaves other views intact", async () => {
+    const cache = await cacheStorage.open("elizaos-views-v1");
+    await cache.put(
+      new FakeRequest(`${ORIGIN}/api/views/v9/bundle.js`),
+      new Response("b"),
+    );
+    await cache.put(
+      new FakeRequest(`${ORIGIN}/api/views/v9/hero`),
+      new Response("h"),
+    );
+
+    await dispatchMessage({ type: "sw:evict-view", viewId: "v9" });
+    expect(cache.store.has(`${ORIGIN}/api/views/v9/bundle.js`)).toBe(false);
+    expect(cache.store.has(`${ORIGIN}/api/views/v9/hero`)).toBe(false);
+    expect(cache.store.has(`${ORIGIN}/api/views/v1/bundle.js`)).toBe(true);
+  });
+
+  it("evicts the whole views cache, ignores malformed commands, and clears the badge", async () => {
+    await dispatchMessage({ type: "sw:evict-all-views" });
+    expect(await cacheStorage.keys()).not.toContain("elizaos-views-v1");
+
+    await dispatchMessage(null);
+    await dispatchMessage({ type: "sw:evict-view", viewId: 42 });
+
+    fakePush.clearBadge.mockClear();
+    await dispatchMessage({ type: "sw:clear-badge" });
+    expect(fakePush.clearBadge).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("push adapters", () => {
+  it("shows an OS notification when no visible client took the payload", async () => {
+    fakePush.dispatchToVisibleClients.mockResolvedValueOnce(false);
+    const pending: Promise<unknown>[] = [];
+    handlers.get("push")?.({
+      data: "raw",
+      waitUntil: (p: Promise<unknown>) => pending.push(p),
+    });
+    await Promise.all(pending);
+    expect(showNotification).toHaveBeenCalledWith("Eliza", { body: "hi" });
+    expect(fakePush.applyBadge).toHaveBeenCalled();
+  });
+
+  it("suppresses the OS notification when a visible client rendered it in-app", async () => {
+    showNotification.mockClear();
+    fakePush.dispatchToVisibleClients.mockResolvedValueOnce(true);
+    const pending: Promise<unknown>[] = [];
+    handlers.get("push")?.({
+      data: "raw",
+      waitUntil: (p: Promise<unknown>) => pending.push(p),
+    });
+    await Promise.all(pending);
+    expect(showNotification).not.toHaveBeenCalled();
+  });
+
+  it("notificationclick closes, routes via focusOrOpen, and clears the badge", async () => {
+    const close = vi.fn();
+    fakePush.clearBadge.mockClear();
+    const pending: Promise<unknown>[] = [];
+    handlers.get("notificationclick")?.({
+      notification: { close, data: { conversationId: "c1" } },
+      waitUntil: (p: Promise<unknown>) => pending.push(p),
+    });
+    await Promise.all(pending);
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(fakePush.focusOrOpen).toHaveBeenCalledWith(
+      expect.anything(),
+      "/chat/c1",
+      ORIGIN,
+    );
+    expect(fakePush.clearBadge).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #15741.

The service worker enables navigation preload in `activate`, but the `fetch` handler **bypassed** the auth navigations — `/login`, `?code=`, `?token=` (the sign-in / OAuth-callback golden path) — with a bare `return`, so `event.preloadResponse` was never consumed. WebKit/Chromium then log `navigation preload request was cancelled` and the parallel preload round-trip is wasted on the most latency-sensitive navigation.

The auth branch now takes over the response **only to drain the preload**, falling back to a live `fetch` when no preload was issued:

```js
event.respondWith(
  (async () => (await event.preloadResponse) || fetch(request))(),
);
return;
```

The documented freshest-from-network invariant is **preserved**: both `event.preloadResponse` and the `fetch` fallback are uncached network fetches, so no cached shell is ever served on the auth path (the reason the branch exists — stale shells break the code exchange, and a cached one-time `?code=` risks code replay).

Scope is `packages/app/public/sw.js` only. The generated Android copy (`android/app/src/main/assets/public/sw.js`) is intentionally untouched — it re-syncs from `public/` at build time.

## Acceptance

- [x] Auth-path navigations (`/login`, `?code=`, `?token=`) consume `event.preloadResponse` (or fall back to `fetch`), still uncached; no cached shell served.
- [x] `bun run --cwd packages/app build` passes; built `dist/sw.js` carries the `respondWith(preloadResponse || fetch)` shape.

## Test evidence

Added `packages/app/src/sw-fetch.test.ts` — it loads the **real** `public/sw.js` into a stubbed scope (capturing the registered `fetch` listener) and dispatches synthetic `FetchEvent`s, driving the actual handler rather than a re-implementation. It asserts the auth branch calls `respondWith`, resolves to the preload (or fetch fallback), and **never touches Cache Storage**; a control non-auth navigation still routes through the cache.

Fail-before / pass-after (real regression guard — reverting the fix to a bare `return` fails 4/5):

```
# with fix
 Test Files  1 passed (1)
      Tests  5 passed (5)

# fix reverted to bare `return;`
 Test Files  1 failed (1)
      Tests  4 failed | 1 passed (5)
```

Built-artifact confirmation:

```
$ grep -n "preloadResponse) || fetch(request)" packages/app/dist/sw.js
209:      (async () => (await event.preloadResponse) || fetch(request))(),
```

Build: `bun run --cwd packages/app build` → `✓ built in 2m 6s` (784 assets; warnings are pre-existing `INEFFECTIVE_DYNAMIC_IMPORT` noise, unrelated).

Lint: Biome clean on the touched test file (`public/*` is biome-ignored, plain SW JS).

## Not proven (headless limitation)

The runtime disappearance of the `navigation preload request was cancelled` warning is **browser-only** and cannot be observed in a headless harness — **N/A (headless)**. The code path and its consequence (respondWith consumes the preload) are verified by the unit test and the built-artifact grep above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Evidence rows

<!-- evidence-row:before-screenshots -->
Before screenshots: N/A - service-worker network behavior only; `public/sw.js` is not a rendered-UI surface file and no pixels change. The BEFORE state is the "navigation preload request was cancelled" SW-console warning described in #15741.

<!-- evidence-row:after-screenshots -->
After screenshots: N/A - same as above; the AFTER state is the warning-free auth navigation asserted by the contract tests.

<!-- evidence-row:walkthrough-video -->
Walkthrough video: N/A - no visual flow; the observable behavior is SW fetch-handler routing, pinned branch-by-branch by `sw-fetch.test.ts` + `service-worker-runtime.test.ts`.

<!-- evidence-row:backend-logs -->
Backend logs: N/A - no backend route changed; the SW serves the same uncached network responses on the auth path (Cache Storage untouched, asserted in [sw-fetch.test.ts](https://github.com/elizaOS/eliza/blob/fix/15741-fix/packages/app/src/sw-fetch.test.ts)).

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: the preload-consumption contract (respondWith called, preload drained, rejected-preload fallback, no cache access) is executed against the real `sw.js` in [sw-fetch.test.ts](https://github.com/elizaOS/eliza/blob/fix/15741-fix/packages/app/src/sw-fetch.test.ts) and [service-worker-runtime.test.ts](https://github.com/elizaOS/eliza/blob/fix/15741-fix/packages/app/test/service-worker-runtime.test.ts) (27 tests, sw.js at 96% line coverage in the changed-files gate).

<!-- evidence-row:llm-trajectory -->
Real-LLM trajectory: N/A - no model, prompt, action, provider, or planner behavior changes.

<!-- evidence-row:domain-artifacts -->
Domain artifacts: N/A - no persisted domain state; the SW cache is intentionally untouched on the auth path (asserted by the cache-spy in both suites).