### PR TITLE
feat(github): add guided device-flow onboarding

### DIFF
--- a/plugins/plugin-github/src/index.ts
+++ b/plugins/plugin-github/src/index.ts
@@ -26,7 +26,10 @@ import {
 } from "@elizaos/core";
 import { githubAction } from "./actions/github.js";
 import { createGitHubConnectorAccountProvider } from "./connector-account-provider.js";
-import { handleGitHubRoutes } from "./routes/github-routes.js";
+import {
+  type GitHubRouteRuntime,
+  handleGitHubRoutes,
+} from "./routes/github-routes.js";
 import { registerGitHubSearchCategory } from "./search-category.js";
 import { GitHubService } from "./services/github-service.js";
 
@@ -39,12 +42,12 @@ function createGitHubRouteHandler(method: "GET" | "POST" | "DELETE") {
     const httpReq = req as http.IncomingMessage;
     const httpRes = res as http.ServerResponse;
     const url = new URL(httpReq.url ?? "/api/github/token", "http://localhost");
-    void runtime;
     await handleGitHubRoutes({
       req: httpReq,
       res: httpRes,
       method,
       pathname: url.pathname,
+      runtime: runtime as GitHubRouteRuntime,
     });
   };
 }
@@ -80,6 +83,18 @@ const githubRoutes: Route[] = [
     path: "/api/github/token",
     rawPath: true,
     handler: createGitHubRouteHandler("DELETE"),
+  },
+  {
+    type: "POST",
+    path: "/api/github/device-login/start",
+    rawPath: true,
+    handler: createGitHubRouteHandler("POST"),
+  },
+  {
+    type: "GET",
+    path: "/api/github/device-login/:flowId/status",
+    rawPath: true,
+    handler: createGitHubRouteHandler("GET"),
   },
 ];
 

--- a/plugins/plugin-github/src/routes/github-device-flow.test.ts
+++ b/plugins/plugin-github/src/routes/github-device-flow.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Protocol-level tests for the GitHub device-flow state machine. GitHub is
+ * stubbed at the module's HTTP boundary (the injectable `fetch`, answering
+ * with real `Response` objects) and time is injected, so every GitHub protocol
+ * answer — pending, slow_down, denied, expired, token — and the local
+ * rate-limit/expiry bookkeeping is driven for real without contacting
+ * github.com. The full route/dispatcher path is covered separately in
+ * `../device-login-e2e.test.ts`.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  clearDeviceFlowsForTest,
+  DeviceFlowError,
+  pollDeviceFlow,
+  startDeviceFlow,
+} from "./github-device-flow.js";
+
+const DEVICE_CODE_URL = "https://github.com/login/device/code";
+const ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token";
+
+interface RecordedRequest {
+  url: string;
+  form: URLSearchParams;
+}
+
+/**
+ * A scripted GitHub double: each element of `tokenResponses` answers one
+ * access-token poll in order. Requests are recorded (URL + decoded form body)
+ * so tests can assert exactly what left the module.
+ */
+function makeGitHub(options: {
+  deviceCodeBody?: Record<string, unknown>;
+  deviceCodeStatus?: number;
+  tokenResponses?: Array<
+    { body: Record<string, unknown>; status?: number } | Error
+  >;
+}) {
+  const requests: RecordedRequest[] = [];
+  let tokenCall = 0;
+  const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : String(input);
+    requests.push({ url, form: new URLSearchParams(String(init?.body)) });
+    if (url === DEVICE_CODE_URL) {
+      return new Response(
+        JSON.stringify(
+          options.deviceCodeBody ?? {
+            device_code: "dc_secret",
+            user_code: "ABCD-1234",
+            verification_uri: "https://github.com/login/device",
+            interval: 5,
+            expires_in: 900,
+          },
+        ),
+        {
+          status: options.deviceCodeStatus ?? 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    }
+    if (url === ACCESS_TOKEN_URL) {
+      const scripted = options.tokenResponses?.[tokenCall];
+      tokenCall += 1;
+      if (!scripted) throw new Error(`unscripted token poll #${tokenCall}`);
+      if (scripted instanceof Error) throw scripted;
+      return new Response(JSON.stringify(scripted.body), {
+        status: scripted.status ?? 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    throw new Error(`unexpected URL ${url}`);
+  }) as typeof fetch;
+  return {
+    fetchImpl,
+    requests,
+    tokenPolls: () => requests.filter((r) => r.url === ACCESS_TOKEN_URL).length,
+  };
+}
+
+/** Mutable injected clock. */
+function makeClock(startMs = 1_000_000) {
+  let nowMs = startMs;
+  return {
+    now: () => nowMs,
+    advance: (ms: number) => {
+      nowMs += ms;
+    },
+  };
+}
+
+afterEach(() => {
+  clearDeviceFlowsForTest();
+});
+
+describe("startDeviceFlow", () => {
+  it("registers a flow and returns only user-facing fields", async () => {
+    const github = makeGitHub({});
+    const clock = makeClock();
+    const started = await startDeviceFlow("client-123", {
+      fetchImpl: github.fetchImpl,
+      now: clock.now,
+    });
+    expect(started.userCode).toBe("ABCD-1234");
+    expect(started.verificationUri).toBe("https://github.com/login/device");
+    expect(started.intervalSeconds).toBe(5);
+    expect(started.expiresInSeconds).toBe(900);
+    // The opaque local handle must never be GitHub's device_code.
+    expect(started.flowId).not.toBe("dc_secret");
+    expect(JSON.stringify(started)).not.toContain("dc_secret");
+    // The request GitHub saw carried the client id and scope.
+    expect(github.requests[0]?.form.get("client_id")).toBe("client-123");
+    expect(github.requests[0]?.form.get("scope")).toBe("repo read:user");
+  });
+
+  it("maps a GitHub 5xx to a 502 upstream error", async () => {
+    const github = makeGitHub({
+      deviceCodeStatus: 503,
+      deviceCodeBody: { error: "boom" },
+    });
+    await expect(
+      startDeviceFlow("client-123", { fetchImpl: github.fetchImpl }),
+    ).rejects.toMatchObject({ code: "upstream_error", httpStatus: 502 });
+  });
+
+  it("maps a 200-with-error body to a 502 upstream error", async () => {
+    const github = makeGitHub({
+      deviceCodeBody: { error: "unauthorized_client" },
+    });
+    await expect(
+      startDeviceFlow("client-123", { fetchImpl: github.fetchImpl }),
+    ).rejects.toMatchObject({ code: "upstream_error", httpStatus: 502 });
+  });
+
+  it("rejects a device-code response missing required fields", async () => {
+    const github = makeGitHub({ deviceCodeBody: { user_code: "X" } });
+    await expect(
+      startDeviceFlow("client-123", { fetchImpl: github.fetchImpl }),
+    ).rejects.toMatchObject({ code: "upstream_error" });
+  });
+
+  it("treats an unreachable GitHub as a 502 with the cause attached", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as typeof fetch;
+    const err = await startDeviceFlow("client-123", { fetchImpl }).catch(
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(DeviceFlowError);
+    expect((err as DeviceFlowError).httpStatus).toBe(502);
+    expect(((err as DeviceFlowError).cause as Error).message).toBe(
+      "ECONNREFUSED",
+    );
+  });
+});
+
+describe("pollDeviceFlow", () => {
+  it("rejects an unknown flow id with 404", async () => {
+    const github = makeGitHub({});
+    await expect(
+      pollDeviceFlow("no-such-flow", { fetchImpl: github.fetchImpl }),
+    ).rejects.toMatchObject({ code: "unknown_flow", httpStatus: 404 });
+  });
+
+  it("returns pending on authorization_pending and rate-limits the next poll locally", async () => {
+    const github = makeGitHub({
+      tokenResponses: [{ body: { error: "authorization_pending" } }],
+    });
+    const clock = makeClock();
+    const io = { fetchImpl: github.fetchImpl, now: clock.now };
+    const { flowId } = await startDeviceFlow("client-123", io);
+
+    const first = await pollDeviceFlow(flowId, io);
+    expect(first).toEqual({ status: "pending", retryAfterSeconds: 5 });
+    expect(github.tokenPolls()).toBe(1);
+
+    // Within the interval the module answers locally — GitHub is not hit.
+    clock.advance(1_000);
+    const second = await pollDeviceFlow(flowId, io);
+    expect(second).toEqual({ status: "pending", retryAfterSeconds: 4 });
+    expect(github.tokenPolls()).toBe(1);
+  });
+
+  it("backs off by 5s on slow_down, per GitHub's protocol", async () => {
+    const github = makeGitHub({
+      tokenResponses: [{ body: { error: "slow_down" } }],
+    });
+    const clock = makeClock();
+    const io = { fetchImpl: github.fetchImpl, now: clock.now };
+    const { flowId } = await startDeviceFlow("client-123", io);
+
+    const result = await pollDeviceFlow(flowId, io);
+    expect(result).toEqual({ status: "pending", retryAfterSeconds: 10 });
+
+    // The grown interval governs the local gate too.
+    clock.advance(6_000);
+    const gated = await pollDeviceFlow(flowId, io);
+    expect(gated).toEqual({ status: "pending", retryAfterSeconds: 4 });
+    expect(github.tokenPolls()).toBe(1);
+  });
+
+  it("completes exactly once and consumes the flow", async () => {
+    const github = makeGitHub({
+      tokenResponses: [
+        {
+          body: {
+            access_token: "gho_token",
+            token_type: "bearer",
+            scope: "repo,read:user",
+          },
+        },
+      ],
+    });
+    const clock = makeClock();
+    const io = { fetchImpl: github.fetchImpl, now: clock.now };
+    const { flowId } = await startDeviceFlow("client-123", io);
+
+    const result = await pollDeviceFlow(flowId, io);
+    expect(result).toEqual({
+      status: "complete",
+      token: "gho_token",
+      tokenType: "bearer",
+      scope: "repo,read:user",
+    });
+    // The token request GitHub saw used the device_code grant.
+    const tokenReq = github.requests.find((r) => r.url === ACCESS_TOKEN_URL);
+    expect(tokenReq?.form.get("device_code")).toBe("dc_secret");
+    expect(tokenReq?.form.get("grant_type")).toBe(
+      "urn:ietf:params:oauth:grant-type:device_code",
+    );
+
+    await expect(pollDeviceFlow(flowId, io)).rejects.toMatchObject({
+      code: "unknown_flow",
+    });
+  });
+
+  it("ends the flow with 403 when the user declines on github.com", async () => {
+    const github = makeGitHub({
+      tokenResponses: [{ body: { error: "access_denied" } }],
+    });
+    const clock = makeClock();
+    const io = { fetchImpl: github.fetchImpl, now: clock.now };
+    const { flowId } = await startDeviceFlow("client-123", io);
+
+    await expect(pollDeviceFlow(flowId, io)).rejects.toMatchObject({
+      code: "authorization_declined",
+      httpStatus: 403,
+    });
+    await expect(pollDeviceFlow(flowId, io)).rejects.toMatchObject({
+      code: "unknown_flow",
+    });
+  });
+
+  it("ends the flow with 410 when GitHub reports the code expired", async () => {
+    const github = makeGitHub({
+      tokenResponses: [{ body: { error: "expired_token" } }],
+    });
+    const clock = makeClock();
+    const io = { fetchImpl: github.fetchImpl, now: clock.now };
+    const { flowId } = await startDeviceFlow("client-123", io);
+
+    await expect(pollDeviceFlow(flowId, io)).rejects.toMatchObject({
+      code: "flow_expired",
+      httpStatus: 410,
+    });
+  });
+
+  it("keeps the flow alive across a transient upstream failure", async () => {
+    const github = makeGitHub({
+      tokenResponses: [
+        new Error("ECONNRESET"),
+        {
+          body: { access_token: "gho_after_retry", token_type: "bearer" },
+        },
+      ],
+    });
+    const clock = makeClock();
+    const io = { fetchImpl: github.fetchImpl, now: clock.now };
+    const { flowId } = await startDeviceFlow("client-123", io);
+
+    await expect(pollDeviceFlow(flowId, io)).rejects.toMatchObject({
+      code: "upstream_error",
+      httpStatus: 502,
+    });
+    clock.advance(5_000);
+    const result = await pollDeviceFlow(flowId, io);
+    expect(result).toMatchObject({
+      status: "complete",
+      token: "gho_after_retry",
+    });
+  });
+
+  it("drops a flow whose device code passed its expiry", async () => {
+    const github = makeGitHub({
+      deviceCodeBody: {
+        device_code: "dc_secret",
+        user_code: "ABCD-1234",
+        verification_uri: "https://github.com/login/device",
+        interval: 5,
+        expires_in: 10,
+      },
+    });
+    const clock = makeClock();
+    const io = { fetchImpl: github.fetchImpl, now: clock.now };
+    const { flowId } = await startDeviceFlow("client-123", io);
+
+    clock.advance(11_000);
+    await expect(pollDeviceFlow(flowId, io)).rejects.toMatchObject({
+      code: "unknown_flow",
+      httpStatus: 404,
+    });
+  });
+});

--- a/plugins/plugin-github/src/routes/github-device-flow.ts
+++ b/plugins/plugin-github/src/routes/github-device-flow.ts
@@ -1,0 +1,311 @@
+/**
+ * Server-side GitHub OAuth device-flow state for the guided credential
+ * onboarding routes (#15796). Same custody model as the LifeOps HITL
+ * credential dashboard's device-login primitive (#15749,
+ * `scripts/lifeops/github-device-login.mjs`): the browser only ever sees the
+ * short `user_code` and an opaque local `flowId`; the GitHub `device_code`
+ * (and later the access token, until the route layer persists it) stays in
+ * server memory until GitHub issues a token or the flow expires.
+ *
+ * GitHub is polled lazily — only when a client asks for the flow's status —
+ * so there is no background scheduler to leak; `nextPollAtMs` enforces
+ * GitHub's minimum poll interval (including `slow_down` back-off) no matter
+ * how aggressively a client polls. Network access is injectable so protocol
+ * behavior is covered by tests that stub GitHub at the HTTP boundary without
+ * touching github.com.
+ */
+
+import { randomBytes } from "node:crypto";
+
+const DEVICE_CODE_URL = "https://github.com/login/device/code";
+const ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token";
+/** Matches the PAT card's guidance and the #15749 primitive. */
+const DEVICE_FLOW_SCOPE = "repo read:user";
+
+/** Failure classes a device flow can end in — drives the route's HTTP status. */
+export type DeviceFlowErrorCode =
+  | "unknown_flow"
+  | "authorization_declined"
+  | "flow_expired"
+  | "upstream_error";
+
+/**
+ * Typed terminal failure for a device flow. `httpStatus` is the status the
+ * route boundary should respond with; the route must not collapse
+ * user-caused ends (declined / expired) into upstream faults.
+ */
+export class DeviceFlowError extends Error {
+  constructor(
+    message: string,
+    readonly code: DeviceFlowErrorCode,
+    readonly httpStatus: number,
+    options?: { cause?: unknown },
+  ) {
+    super(message, options);
+    this.name = "DeviceFlowError";
+  }
+}
+
+export interface DeviceFlowStart {
+  /** Opaque local handle the client polls with. Never GitHub's device_code. */
+  flowId: string;
+  /** Short code the user types at the verification URI. */
+  userCode: string;
+  verificationUri: string;
+  intervalSeconds: number;
+  expiresInSeconds: number;
+}
+
+export type DeviceFlowPoll =
+  | { status: "pending"; retryAfterSeconds: number }
+  | { status: "complete"; token: string; tokenType: string; scope: string };
+
+interface PendingFlow {
+  clientId: string;
+  deviceCode: string;
+  intervalSeconds: number;
+  nextPollAtMs: number;
+  expiresAtMs: number;
+}
+
+interface FlowIo {
+  fetchImpl?: typeof fetch;
+  now?: () => number;
+  randomBytesImpl?: typeof randomBytes;
+}
+
+const pendingFlows = new Map<string, PendingFlow>();
+
+function sweepExpired(nowMs: number): void {
+  for (const [flowId, flow] of pendingFlows) {
+    if (nowMs >= flow.expiresAtMs) pendingFlows.delete(flowId);
+  }
+}
+
+function upstreamError(label: string, cause?: unknown): DeviceFlowError {
+  return new DeviceFlowError(
+    `${label}. Try again.`,
+    "upstream_error",
+    502,
+    cause === undefined ? undefined : { cause },
+  );
+}
+
+async function postForm(
+  url: string,
+  form: Record<string, string>,
+  label: string,
+  fetchImpl: typeof fetch,
+): Promise<Record<string, unknown>> {
+  let response: Response;
+  try {
+    response = await fetchImpl(url, {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams(form).toString(),
+    });
+  } catch (err) {
+    // error-policy:J2 context-adding rethrow — a thrown fetch is GitHub being
+    // unreachable, an upstream fault the route reports as 502 with the cause.
+    throw upstreamError(`Could not reach GitHub (${label})`, err);
+  }
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (err) {
+    // error-policy:J2 context-adding rethrow — an unparseable body from GitHub
+    // is the same upstream fault class as an unreachable host.
+    throw upstreamError(`GitHub returned a non-JSON ${label} response`, err);
+  }
+  const record =
+    payload && typeof payload === "object" && !Array.isArray(payload)
+      ? (payload as Record<string, unknown>)
+      : {};
+  // GitHub's OAuth endpoints report protocol errors either as a non-2xx or as
+  // a 200 with an `error` field; a non-2xx is always terminal here (the 200 +
+  // `error` case is interpreted per-endpoint by the callers).
+  if (!response.ok) {
+    const providerError =
+      typeof record.error === "string" ? ` (${record.error})` : "";
+    throw upstreamError(
+      `GitHub ${label} request failed: HTTP ${response.status}${providerError}`,
+    );
+  }
+  return record;
+}
+
+function requireString(
+  payload: Record<string, unknown>,
+  key: string,
+  label: string,
+): string {
+  const value = payload[key];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw upstreamError(`GitHub ${label} response is missing ${key}`);
+  }
+  return value.trim();
+}
+
+function positiveNumber(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : fallback;
+}
+
+/**
+ * Ask GitHub for a device code and register a pending flow. Returns only the
+ * user-facing fields; the `device_code` never leaves this module.
+ */
+export async function startDeviceFlow(
+  clientId: string,
+  io: FlowIo = {},
+): Promise<DeviceFlowStart> {
+  const fetchImpl = io.fetchImpl ?? fetch;
+  const now = io.now ?? Date.now;
+  const randomBytesImpl = io.randomBytesImpl ?? randomBytes;
+
+  const payload = await postForm(
+    DEVICE_CODE_URL,
+    { client_id: clientId, scope: DEVICE_FLOW_SCOPE },
+    "device-code",
+    fetchImpl,
+  );
+  if (typeof payload.error === "string") {
+    throw upstreamError(`GitHub device-code request failed (${payload.error})`);
+  }
+  const deviceCode = requireString(payload, "device_code", "device-code");
+  const userCode = requireString(payload, "user_code", "device-code");
+  const verificationUri = requireString(
+    payload,
+    "verification_uri",
+    "device-code",
+  );
+  const intervalSeconds = positiveNumber(payload.interval, 5);
+  const expiresInSeconds = positiveNumber(payload.expires_in, 900);
+
+  const nowMs = now();
+  sweepExpired(nowMs);
+  const flowId = randomBytesImpl(24).toString("base64url");
+  pendingFlows.set(flowId, {
+    clientId,
+    deviceCode,
+    intervalSeconds,
+    nextPollAtMs: nowMs,
+    expiresAtMs: nowMs + expiresInSeconds * 1_000,
+  });
+  return {
+    flowId,
+    userCode,
+    verificationUri,
+    intervalSeconds,
+    expiresInSeconds,
+  };
+}
+
+/**
+ * Poll GitHub for the flow's token, respecting the poll interval GitHub set
+ * (a too-early call returns `pending` locally without contacting GitHub).
+ * Terminal outcomes — declined, expired, upstream fault — throw a
+ * {@link DeviceFlowError} and drop the flow; `complete` also drops it and
+ * hands the token to the caller exactly once.
+ */
+export async function pollDeviceFlow(
+  flowId: string,
+  io: FlowIo = {},
+): Promise<DeviceFlowPoll> {
+  const fetchImpl = io.fetchImpl ?? fetch;
+  const now = io.now ?? Date.now;
+
+  const nowMs = now();
+  sweepExpired(nowMs);
+  const flow = pendingFlows.get(flowId);
+  if (!flow) {
+    throw new DeviceFlowError(
+      "This sign-in attempt is unknown or has expired. Start again.",
+      "unknown_flow",
+      404,
+    );
+  }
+  if (nowMs < flow.nextPollAtMs) {
+    return {
+      status: "pending",
+      retryAfterSeconds: Math.max(
+        1,
+        Math.ceil((flow.nextPollAtMs - nowMs) / 1_000),
+      ),
+    };
+  }
+  flow.nextPollAtMs = nowMs + flow.intervalSeconds * 1_000;
+
+  let payload: Record<string, unknown>;
+  try {
+    payload = await postForm(
+      ACCESS_TOKEN_URL,
+      {
+        client_id: flow.clientId,
+        device_code: flow.deviceCode,
+        grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+      },
+      "device-token",
+      fetchImpl,
+    );
+  } catch (err) {
+    // error-policy:J2 context-adding rethrow — an upstream fault is
+    // retryable: keep the flow alive so the next poll can succeed once
+    // GitHub recovers, but still surface this poll's failure to the caller.
+    if (err instanceof DeviceFlowError && err.code === "upstream_error") {
+      throw err;
+    }
+    throw upstreamError("GitHub device-token request failed", err);
+  }
+
+  if (
+    typeof payload.access_token === "string" &&
+    payload.access_token.length > 0
+  ) {
+    pendingFlows.delete(flowId);
+    return {
+      status: "complete",
+      token: payload.access_token,
+      tokenType:
+        typeof payload.token_type === "string" ? payload.token_type : "bearer",
+      scope: typeof payload.scope === "string" ? payload.scope : "",
+    };
+  }
+  if (payload.error === "authorization_pending") {
+    return { status: "pending", retryAfterSeconds: flow.intervalSeconds };
+  }
+  if (payload.error === "slow_down") {
+    // GitHub's protocol: add 5 seconds to the interval for the rest of the flow.
+    flow.intervalSeconds += 5;
+    flow.nextPollAtMs = nowMs + flow.intervalSeconds * 1_000;
+    return { status: "pending", retryAfterSeconds: flow.intervalSeconds };
+  }
+
+  pendingFlows.delete(flowId);
+  if (payload.error === "access_denied") {
+    throw new DeviceFlowError(
+      "GitHub sign-in was declined on github.com.",
+      "authorization_declined",
+      403,
+    );
+  }
+  if (payload.error === "expired_token") {
+    throw new DeviceFlowError(
+      "The sign-in code expired before it was entered on github.com. Start again.",
+      "flow_expired",
+      410,
+    );
+  }
+  const code =
+    typeof payload.error === "string" ? payload.error : "unknown_error";
+  throw upstreamError(`GitHub device login failed (${code})`);
+}
+
+/** Test-only: drop all pending flows so suites do not leak state. */
+export function clearDeviceFlowsForTest(): void {
+  pendingFlows.clear();
+}

--- a/plugins/plugin-github/src/routes/github-routes.ts
+++ b/plugins/plugin-github/src/routes/github-routes.ts
@@ -1,21 +1,42 @@
 /**
- * GitHub PAT routes — power the "GitHub" connection card in Settings →
+ * GitHub credential routes — power the "GitHub" connection card in Settings →
  * Coding Agents and surface the same token to the orchestrator's
  * sub-agent spawn env.
  *
  * Exposes:
- *   GET    /api/github/token   — `{ connected: bool, username?, scopes?, savedAt? }`.
- *                                 Token itself is never returned.
+ *   GET    /api/github/token   — `{ connected, deviceFlowAvailable, username?,
+ *                                 scopes?, savedAt? }`. Token never returned.
  *   POST   /api/github/token   — body `{ token }`. Validates by calling
  *                                 GitHub's `/user` endpoint, then persists
- *                                 the credential record to disk.
+ *                                 the credential record.
  *   DELETE /api/github/token   — clears the saved credential and returns
  *                                 `{ connected: false }`.
+ *   POST   /api/github/device-login/start
+ *                              — begins a GitHub OAuth device flow (#15796):
+ *                                 returns `{ flowId, userCode, verificationUri,
+ *                                 intervalSeconds, expiresInSeconds }`. Requires
+ *                                 the GITHUB_OAUTH_CLIENT_ID setting; GitHub's
+ *                                 device_code stays server-side.
+ *   GET    /api/github/device-login/:flowId/status
+ *                              — polls the flow: `{ status: "pending",
+ *                                 retryAfterSeconds }` until the user approves
+ *                                 on github.com, then validates + persists the
+ *                                 token and returns `{ status: "complete",
+ *                                 ...connection metadata }`.
  *
- * `handleGitHubRoutes` is the pure dispatcher — no auth, no runtime deps.
- * The runtime adapter (`createGitHubRouteHandler`) lives in index.ts where
- * it can import the heavier app-core auth surface without polluting this
- * module's import graph (and breaking tests that only need the pure handler).
+ * A validated token is persisted twice, deliberately: the on-disk credential
+ * store (`github-credentials.ts`, feeds `gh`/`git` subprocess env at boot) and
+ * the per-agent character secrets via `runtime.setSetting` + `updateAgent` —
+ * the multi-tenant-safe path the orchestrator's
+ * `runtime.getSetting("GITHUB_TOKEN")` resolution reads live, with no
+ * process-env write (env is shared by every agent in the host; settings are
+ * per-agent).
+ *
+ * `handleGitHubRoutes` is the pure dispatcher — no auth, no transitive
+ * app-core deps. The runtime adapter (`createGitHubRouteHandler`) lives in
+ * index.ts where it can import the heavier app-core auth surface without
+ * polluting this module's import graph (and breaking tests that only need the
+ * pure handler).
  */
 
 import type http from "node:http";
@@ -24,9 +45,15 @@ import {
   buildCredentialsFromUserResponse,
   clearCredentials,
   type GitHubCredentialMetadata,
+  type GitHubCredentials,
   loadMetadata,
   saveCredentials,
 } from "../github-credentials.js";
+import {
+  DeviceFlowError,
+  pollDeviceFlow,
+  startDeviceFlow,
+} from "./github-device-flow.js";
 
 const GITHUB_USER_URL = "https://api.github.com/user";
 const VALIDATION_TIMEOUT_MS = 10_000;
@@ -59,11 +86,37 @@ interface GitHubUserResponse {
   login: string;
 }
 
+/**
+ * The slice of `IAgentRuntime` these routes consume. Structural on purpose:
+ * the real runtime satisfies it with no cast, and tests can provide an honest
+ * in-memory implementation instead of stubbing the whole runtime surface.
+ */
+export interface GitHubRouteRuntime {
+  agentId: string;
+  character: { secrets?: Record<string, string | boolean | number> };
+  getSetting(key: string): string | boolean | number | null;
+  setSetting(
+    key: string,
+    value: string | boolean | null,
+    secret?: boolean,
+  ): void;
+  updateAgent(
+    agentId: string,
+    agent: { secrets?: Record<string, string | boolean | number> },
+  ): Promise<boolean>;
+}
+
 export interface GitHubRouteContext {
   req: http.IncomingMessage;
   res: http.ServerResponse;
   method: string;
   pathname: string;
+  /**
+   * Per-agent settings surface. Reads GITHUB_OAUTH_CLIENT_ID for the device
+   * flow and receives the validated token as a character secret so a running
+   * agent picks it up without a restart or a process-env write.
+   */
+  runtime: GitHubRouteRuntime;
   /** Inject for tests. Defaults to the global `fetch`. */
   fetch?: typeof fetch;
   json?: (status: number, body: unknown) => void;
@@ -71,6 +124,8 @@ export interface GitHubRouteContext {
 
 interface TokenStatusResponse {
   connected: boolean;
+  /** True when GITHUB_OAUTH_CLIENT_ID is configured so device sign-in can run. */
+  deviceFlowAvailable: boolean;
   username?: string;
   scopes?: string[];
   savedAt?: number;
@@ -99,16 +154,42 @@ function sendJson(
   ctx.res.end(JSON.stringify(body));
 }
 
+function deviceFlowClientId(runtime: GitHubRouteRuntime): string | null {
+  const value = runtime.getSetting("GITHUB_OAUTH_CLIENT_ID");
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
 function metadataToStatus(
   metadata: GitHubCredentialMetadata | null,
+  deviceFlowAvailable: boolean,
 ): TokenStatusResponse {
-  if (!metadata) return { connected: false };
+  if (!metadata) return { connected: false, deviceFlowAvailable };
   return {
     connected: true,
+    deviceFlowAvailable,
     username: metadata.username,
     scopes: metadata.scopes,
     savedAt: metadata.savedAt,
   };
+}
+
+/**
+ * Persist a validated credential to both stores: the on-disk record (feeds
+ * the boot-time `gh`/`git` env bridge) and the per-agent character secrets
+ * (read live by `runtime.getSetting("GITHUB_TOKEN")` — the orchestrator's
+ * resolution path — and persisted to the agent DB row via `updateAgent`).
+ */
+async function persistCredentials(
+  runtime: GitHubRouteRuntime,
+  credentials: GitHubCredentials,
+): Promise<void> {
+  await saveCredentials(credentials);
+  runtime.setSetting("GITHUB_TOKEN", credentials.token, true);
+  await runtime.updateAgent(runtime.agentId, {
+    secrets: { ...(runtime.character.secrets ?? {}) },
+  });
 }
 
 /**
@@ -208,7 +289,11 @@ async function validateToken(
 
 async function handleGetToken(ctx: GitHubRouteContext): Promise<boolean> {
   const metadata = await loadMetadata();
-  sendJson(ctx, 200, metadataToStatus(metadata));
+  sendJson(
+    ctx,
+    200,
+    metadataToStatus(metadata, deviceFlowClientId(ctx.runtime) !== null),
+  );
   return true;
 }
 
@@ -243,20 +328,150 @@ async function handlePostToken(ctx: GitHubRouteContext): Promise<boolean> {
     validated.user,
     validated.scopes,
   );
-  await saveCredentials(credentials);
+  await persistCredentials(ctx.runtime, credentials);
   logger.info(
     `[github-routes] saved github token for @${validated.user.login} (scopes=${validated.scopes.join(",") || "(none)"})`,
   );
-  sendJson(ctx, 200, metadataToStatus(credentials));
+  sendJson(
+    ctx,
+    200,
+    metadataToStatus(credentials, deviceFlowClientId(ctx.runtime) !== null),
+  );
   return true;
 }
 
 async function handleDeleteToken(ctx: GitHubRouteContext): Promise<boolean> {
   await clearCredentials();
+  // Also drop the per-agent secret so disconnect really disconnects the
+  // running agent; env-provided tokens (developer shell export) are
+  // deliberately untouched — explicit env always wins elsewhere too.
+  const secrets = ctx.runtime.character.secrets;
+  if (secrets && "GITHUB_TOKEN" in secrets) {
+    delete secrets.GITHUB_TOKEN;
+    await ctx.runtime.updateAgent(ctx.runtime.agentId, {
+      secrets: { ...secrets },
+    });
+  }
   logger.info("[github-routes] cleared saved github token");
-  sendJson(ctx, 200, { connected: false });
+  sendJson(ctx, 200, {
+    connected: false,
+    deviceFlowAvailable: deviceFlowClientId(ctx.runtime) !== null,
+  });
   return true;
 }
+
+async function handleDeviceLoginStart(
+  ctx: GitHubRouteContext,
+): Promise<boolean> {
+  const clientId = deviceFlowClientId(ctx.runtime);
+  if (!clientId) {
+    // Designed unavailable state, not a transport error: device sign-in needs
+    // owner setup (a GitHub OAuth app client id) before it can run at all.
+    sendJson(ctx, 409, {
+      error:
+        "GitHub device sign-in needs owner setup: set GITHUB_OAUTH_CLIENT_ID to a GitHub OAuth app client ID with device flow enabled.",
+      code: "client_id_missing",
+    });
+    return true;
+  }
+  const fetchImpl = ctx.fetch ?? fetch;
+  let started: Awaited<ReturnType<typeof startDeviceFlow>>;
+  try {
+    started = await startDeviceFlow(clientId, { fetchImpl });
+  } catch (err) {
+    // error-policy:J1 boundary translation — DeviceFlowError carries the HTTP
+    // status for the failure class (upstream faults are 502); anything else is
+    // a real 500.
+    const status = err instanceof DeviceFlowError ? err.httpStatus : 500;
+    const message = err instanceof Error ? err.message : String(err);
+    logger.warn(
+      `[github-routes] device-login start failed (${status}): ${message}`,
+    );
+    sendJson(ctx, status, { error: message });
+    return true;
+  }
+  logger.info(
+    `[github-routes] device-login flow started (verify at ${started.verificationUri}, expires in ${started.expiresInSeconds}s)`,
+  );
+  sendJson(ctx, 200, started);
+  return true;
+}
+
+async function handleDeviceLoginStatus(
+  ctx: GitHubRouteContext,
+  flowId: string,
+): Promise<boolean> {
+  const fetchImpl = ctx.fetch ?? fetch;
+  let poll: Awaited<ReturnType<typeof pollDeviceFlow>>;
+  try {
+    poll = await pollDeviceFlow(flowId, { fetchImpl });
+  } catch (err) {
+    // error-policy:J1 boundary translation — terminal flow outcomes map to
+    // the status DeviceFlowError carries (404 unknown, 403 declined, 410
+    // expired, 502 upstream); the body keeps the machine-readable code so the
+    // card can render each as a distinct designed error state.
+    if (err instanceof DeviceFlowError) {
+      logger.warn(
+        `[github-routes] device-login flow ended (${err.code}): ${err.message}`,
+      );
+      sendJson(ctx, err.httpStatus, {
+        status: "error",
+        code: err.code,
+        error: err.message,
+      });
+      return true;
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    logger.warn(`[github-routes] device-login status failed: ${message}`);
+    sendJson(ctx, 500, { status: "error", code: "internal", error: message });
+    return true;
+  }
+
+  if (poll.status === "pending") {
+    sendJson(ctx, 200, poll);
+    return true;
+  }
+
+  // GitHub issued a token: validate it against /user exactly like the PAT
+  // path (yielding username + effective scopes), then persist to both stores.
+  let validated: Awaited<ReturnType<typeof validateToken>>;
+  try {
+    validated = await validateToken(poll.token, fetchImpl);
+  } catch (err) {
+    // error-policy:J1 boundary translation — the flow is already consumed, so
+    // a validation failure ends it; a freshly-issued token failing /user is an
+    // upstream fault, surfaced with the status TokenValidationError carries.
+    const status = err instanceof TokenValidationError ? err.status : 500;
+    const message = err instanceof Error ? err.message : String(err);
+    logger.warn(
+      `[github-routes] device-login token validation failed (${status}): ${message}`,
+    );
+    sendJson(ctx, status, {
+      status: "error",
+      code: "validation_failed",
+      error: message,
+    });
+    return true;
+  }
+
+  const credentials = buildCredentialsFromUserResponse(
+    poll.token,
+    validated.user,
+    validated.scopes,
+  );
+  await persistCredentials(ctx.runtime, credentials);
+  logger.info(
+    `[github-routes] device-login connected @${validated.user.login} (scopes=${validated.scopes.join(",") || "(none)"})`,
+  );
+  sendJson(ctx, 200, {
+    status: "complete",
+    ...metadataToStatus(credentials, true),
+  });
+  return true;
+}
+
+const DEVICE_LOGIN_STATUS_RE =
+  /^\/api\/github\/device-login\/([A-Za-z0-9_-]+)\/status$/;
 
 /**
  * Dispatch entry point. Returns `true` when this module owned the request.
@@ -265,16 +480,33 @@ async function handleDeleteToken(ctx: GitHubRouteContext): Promise<boolean> {
 export async function handleGitHubRoutes(
   ctx: GitHubRouteContext,
 ): Promise<boolean> {
-  if (ctx.pathname !== "/api/github/token") return false;
-  switch (ctx.method) {
-    case "GET":
-      return handleGetToken(ctx);
-    case "POST":
-      return handlePostToken(ctx);
-    case "DELETE":
-      return handleDeleteToken(ctx);
-    default:
+  if (ctx.pathname === "/api/github/token") {
+    switch (ctx.method) {
+      case "GET":
+        return handleGetToken(ctx);
+      case "POST":
+        return handlePostToken(ctx);
+      case "DELETE":
+        return handleDeleteToken(ctx);
+      default:
+        sendJson(ctx, 405, { error: "Method not allowed" });
+        return true;
+    }
+  }
+  if (ctx.pathname === "/api/github/device-login/start") {
+    if (ctx.method !== "POST") {
       sendJson(ctx, 405, { error: "Method not allowed" });
       return true;
+    }
+    return handleDeviceLoginStart(ctx);
   }
+  const statusMatch = DEVICE_LOGIN_STATUS_RE.exec(ctx.pathname);
+  if (statusMatch) {
+    if (ctx.method !== "GET") {
+      sendJson(ctx, 405, { error: "Method not allowed" });
+      return true;
+    }
+    return handleDeviceLoginStatus(ctx, statusMatch[1]);
+  }
+  return false;
 }

--- a/plugins/plugin-task-coordinator/src/GitHubConnectionCard.tsx
+++ b/plugins/plugin-task-coordinator/src/GitHubConnectionCard.tsx
@@ -2,33 +2,56 @@
 import { Button, client, openExternalUrl, SettingsControls } from "@elizaos/ui";
 import {
   CheckCircle2,
+  Copy,
   ExternalLink,
   GitPullRequest,
+  Loader2,
   Unplug,
 } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 /**
- * GitHub PAT connection card for the Coding Agents settings page.
+ * GitHub connection card for the Coding Agents settings page.
  *
- * Persists a single per-user token to `<state-dir>/credentials/github.json`
- * via `/api/github/token`. The same token is exposed to spawned coding
- * sub-agents (orchestrator's existing `runtime.getSetting("GITHUB_TOKEN")`
- * resolution + `process.env.GITHUB_TOKEN` inheritance into ACP sessions),
- * so once it's set here `git clone` of private repos / `gh auth status`
- * / push + PR flows all work without the user having to wire env vars.
+ * Two guided paths to a credential (#15796):
+ *   1. **Sign in with GitHub** — the OAuth device flow. The card starts a
+ *      server-side flow (`POST /api/github/device-login/start`), shows the
+ *      short user code + verification link, and polls
+ *      `GET /api/github/device-login/:flowId/status` at the server-directed
+ *      cadence until GitHub reports approval. GitHub's `device_code` and the
+ *      issued token never reach the browser. Shown only when the server
+ *      reports `deviceFlowAvailable` (a GITHUB_OAUTH_CLIENT_ID is configured).
+ *   2. **Paste a PAT** — the always-available fallback, validated server-side
+ *      against GitHub `/user` before being persisted.
  *
- * The token itself is write-only from the UI side: the API never returns
- * it after save. State here is just the metadata (username, scopes,
- * savedAt) plus an in-memory draft input while the user types a new PAT.
+ * Either way the server persists the token to the on-disk credential store
+ * AND the per-agent character secrets, so spawned coding sub-agents (the
+ * orchestrator's `runtime.getSetting("GITHUB_TOKEN")` resolution) see it
+ * without a restart. The token is write-only from the UI side: the API never
+ * returns it after save. State here is the connection metadata (username,
+ * scopes, savedAt), the device-flow state machine, and an in-memory draft
+ * input while the user types a new PAT.
  */
 
 interface TokenStatus {
   connected: boolean;
+  deviceFlowAvailable?: boolean;
   username?: string;
   scopes?: string[];
   savedAt?: number;
 }
+
+interface DeviceLoginStart {
+  flowId: string;
+  userCode: string;
+  verificationUri: string;
+  intervalSeconds: number;
+  expiresInSeconds: number;
+}
+
+type DeviceLoginStatus =
+  | { status: "pending"; retryAfterSeconds: number }
+  | ({ status: "complete" } & TokenStatus);
 
 const TOKEN_GENERATE_URL =
   "https://github.com/settings/tokens/new?description=eliza-coding-agents&scopes=repo,read:user";
@@ -38,19 +61,131 @@ type SubmitState =
   | { kind: "submitting" }
   | { kind: "error"; message: string };
 
+type DeviceFlowState =
+  | { kind: "idle" }
+  | { kind: "starting" }
+  | {
+      kind: "waiting";
+      flowId: string;
+      userCode: string;
+      verificationUri: string;
+    }
+  | { kind: "error"; message: string };
+
 export function GitHubConnectionCard() {
   const [status, setStatus] = useState<TokenStatus | null>(null);
+  const [statusError, setStatusError] = useState<string | null>(null);
   const [draft, setDraft] = useState("");
   const [submitState, setSubmitState] = useState<SubmitState>({ kind: "idle" });
+  const [deviceFlow, setDeviceFlow] = useState<DeviceFlowState>({
+    kind: "idle",
+  });
+  const [codeCopied, setCodeCopied] = useState(false);
+  // The active flow's poll timer + a generation counter so a cancelled or
+  // superseded flow's in-flight response can never clobber newer state.
+  const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const flowGenerationRef = useRef(0);
 
   const refreshStatus = useCallback(async () => {
-    const next = await client.fetch<TokenStatus>("/api/github/token");
-    setStatus(next);
+    try {
+      const next = await client.fetch<TokenStatus>("/api/github/token");
+      setStatus(next);
+      setStatusError(null);
+    } catch (err) {
+      // error-policy:J4 designed error state — the card renders a visible
+      // load-failure row instead of a healthy-looking "not connected".
+      setStatusError(err instanceof Error ? err.message : String(err));
+    }
   }, []);
 
   useEffect(() => {
     void refreshStatus();
   }, [refreshStatus]);
+
+  const stopPolling = useCallback(() => {
+    flowGenerationRef.current += 1;
+    if (pollTimerRef.current !== null) {
+      clearTimeout(pollTimerRef.current);
+      pollTimerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => stopPolling, [stopPolling]);
+
+  const pollDeviceFlow = useCallback(
+    (flowId: string, delaySeconds: number, generation: number) => {
+      pollTimerRef.current = setTimeout(async () => {
+        if (generation !== flowGenerationRef.current) return;
+        try {
+          const result = await client.fetch<DeviceLoginStatus>(
+            `/api/github/device-login/${encodeURIComponent(flowId)}/status`,
+          );
+          if (generation !== flowGenerationRef.current) return;
+          if (result.status === "pending") {
+            pollDeviceFlow(flowId, result.retryAfterSeconds, generation);
+            return;
+          }
+          const { status: _status, ...connection } = result;
+          setStatus(connection);
+          setDeviceFlow({ kind: "idle" });
+        } catch (err) {
+          if (generation !== flowGenerationRef.current) return;
+          // error-policy:J4 designed error state — declined / expired /
+          // upstream failures all end the flow visibly with the server's
+          // human-readable reason and a retry affordance.
+          setDeviceFlow({
+            kind: "error",
+            message: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }, delaySeconds * 1000);
+    },
+    [],
+  );
+
+  const handleDeviceSignIn = useCallback(async () => {
+    stopPolling();
+    const generation = flowGenerationRef.current;
+    setDeviceFlow({ kind: "starting" });
+    setCodeCopied(false);
+    try {
+      const started = await client.fetch<DeviceLoginStart>(
+        "/api/github/device-login/start",
+        { method: "POST" },
+      );
+      if (generation !== flowGenerationRef.current) return;
+      setDeviceFlow({
+        kind: "waiting",
+        flowId: started.flowId,
+        userCode: started.userCode,
+        verificationUri: started.verificationUri,
+      });
+      pollDeviceFlow(started.flowId, started.intervalSeconds, generation);
+    } catch (err) {
+      if (generation !== flowGenerationRef.current) return;
+      setDeviceFlow({
+        kind: "error",
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }, [pollDeviceFlow, stopPolling]);
+
+  const handleDeviceCancel = useCallback(() => {
+    stopPolling();
+    setDeviceFlow({ kind: "idle" });
+  }, [stopPolling]);
+
+  const handleCopyCode = useCallback(async (code: string) => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCodeCopied(true);
+    } catch {
+      // error-policy:J4 designed degrade — clipboard access can be denied by
+      // the browser; the code stays visible on screen to type by hand, so the
+      // copy affordance simply not confirming is the designed fallback.
+      setCodeCopied(false);
+    }
+  }, []);
 
   const handleConnect = useCallback(async () => {
     const token = draft.trim();
@@ -81,8 +216,10 @@ export function GitHubConnectionCard() {
   const handleDisconnect = useCallback(async () => {
     setSubmitState({ kind: "submitting" });
     try {
-      await client.fetch("/api/github/token", { method: "DELETE" });
-      setStatus({ connected: false });
+      const next = await client.fetch<TokenStatus>("/api/github/token", {
+        method: "DELETE",
+      });
+      setStatus(next);
       setSubmitState({ kind: "idle" });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -93,6 +230,8 @@ export function GitHubConnectionCard() {
   const submitting = submitState.kind === "submitting";
   const errorMessage =
     submitState.kind === "error" ? submitState.message : null;
+  const deviceBusy =
+    deviceFlow.kind === "starting" || deviceFlow.kind === "waiting";
 
   return (
     <div className="space-y-3 px-1 py-1">
@@ -118,7 +257,16 @@ export function GitHubConnectionCard() {
         </div>
       </div>
 
-      {status?.connected ? (
+      {statusError ? (
+        <div className="rounded-md border border-rose-500/40 bg-rose-500/10 px-2 py-1.5 text-xs text-rose-500">
+          Could not load GitHub connection status: {statusError}
+        </div>
+      ) : status === null ? (
+        <div className="flex items-center gap-2 text-xs text-muted">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+          <span>Loading connection status…</span>
+        </div>
+      ) : status.connected ? (
         <div className="flex flex-col gap-2 text-xs">
           <div className="flex items-center gap-2 text-muted">
             <CheckCircle2
@@ -159,41 +307,126 @@ export function GitHubConnectionCard() {
         </div>
       ) : (
         <div className="flex flex-col gap-2 text-xs">
-          <p className="sr-only">
-            Paste a personal access token so coding sub-agents can clone private
-            repos, push commits, and open pull requests.
-          </p>
-          <Button
-            unstyled
-            type="button"
-            className="inline-flex w-fit items-center gap-1 text-xs text-accent hover:underline"
-            onClick={() => openExternalUrl(TOKEN_GENERATE_URL)}
-          >
-            <ExternalLink className="h-3 w-3" aria-hidden />
-            Generate a token on github.com (scopes: repo, read:user)
-          </Button>
-          <div className="flex items-center gap-2">
-            <SettingsControls.Input
-              className="w-full"
-              variant="compact"
-              type="password"
-              placeholder="ghp_…"
-              value={draft}
-              onChange={(e) => setDraft(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") void handleConnect();
-              }}
-              autoComplete="off"
-            />
-            <Button
-              variant="default"
-              size="sm"
-              onClick={() => void handleConnect()}
-              disabled={submitting || draft.trim().length === 0}
-            >
-              {submitting ? "Connecting…" : "Connect"}
-            </Button>
-          </div>
+          {status.deviceFlowAvailable ? (
+            deviceFlow.kind === "waiting" ? (
+              <div
+                className="flex flex-col gap-2 rounded-md border border-border bg-muted/10 p-2.5"
+                data-testid="github-device-waiting"
+              >
+                <span className="text-muted">
+                  Enter this code on github.com to sign in:
+                </span>
+                <div className="flex items-center gap-2">
+                  <span className="rounded bg-muted/20 px-2 py-1 font-mono text-base font-semibold tracking-widest text-txt">
+                    {deviceFlow.userCode}
+                  </span>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => void handleCopyCode(deviceFlow.userCode)}
+                    aria-label="Copy code"
+                  >
+                    <Copy className="mr-1 h-3 w-3" aria-hidden />
+                    {codeCopied ? "Copied" : "Copy"}
+                  </Button>
+                </div>
+                <Button
+                  unstyled
+                  type="button"
+                  className="inline-flex w-fit items-center gap-1 text-xs text-accent hover:underline"
+                  onClick={() => openExternalUrl(deviceFlow.verificationUri)}
+                >
+                  <ExternalLink className="h-3 w-3" aria-hidden />
+                  Open {deviceFlow.verificationUri}
+                </Button>
+                <div className="flex items-center gap-2 text-muted">
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+                  <span>Waiting for approval on github.com…</span>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={handleDeviceCancel}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <div className="flex flex-col gap-2">
+                <Button
+                  variant="default"
+                  size="sm"
+                  className="w-fit"
+                  onClick={() => void handleDeviceSignIn()}
+                  disabled={deviceFlow.kind === "starting"}
+                >
+                  {deviceFlow.kind === "starting" ? (
+                    <>
+                      <Loader2
+                        className="mr-1.5 h-3.5 w-3.5 animate-spin"
+                        aria-hidden
+                      />
+                      Contacting GitHub…
+                    </>
+                  ) : (
+                    "Sign in with GitHub"
+                  )}
+                </Button>
+                {deviceFlow.kind === "error" ? (
+                  <div
+                    className="rounded-md border border-rose-500/40 bg-rose-500/10 px-2 py-1.5 text-rose-500"
+                    data-testid="github-device-error"
+                  >
+                    {deviceFlow.message}
+                  </div>
+                ) : null}
+                <span className="text-muted">
+                  Or paste a personal access token:
+                </span>
+              </div>
+            )
+          ) : null}
+          {deviceFlow.kind !== "waiting" ? (
+            <>
+              <p className="sr-only">
+                Paste a personal access token so coding sub-agents can clone
+                private repos, push commits, and open pull requests.
+              </p>
+              <Button
+                unstyled
+                type="button"
+                className="inline-flex w-fit items-center gap-1 text-xs text-accent hover:underline"
+                onClick={() => openExternalUrl(TOKEN_GENERATE_URL)}
+              >
+                <ExternalLink className="h-3 w-3" aria-hidden />
+                Generate a token on github.com (scopes: repo, read:user)
+              </Button>
+              <div className="flex items-center gap-2">
+                <SettingsControls.Input
+                  className="w-full"
+                  variant="compact"
+                  type="password"
+                  placeholder="ghp_…"
+                  value={draft}
+                  onChange={(e) => setDraft(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") void handleConnect();
+                  }}
+                  autoComplete="off"
+                />
+                <Button
+                  variant="default"
+                  size="sm"
+                  onClick={() => void handleConnect()}
+                  disabled={
+                    submitting || deviceBusy || draft.trim().length === 0
+                  }
+                >
+                  {submitting ? "Connecting…" : "Connect"}
+                </Button>
+              </div>
+            </>
+          ) : null}
         </div>
       )}
 


### PR DESCRIPTION
Implements the guided OAuth device-flow path requested by #15796, complementing the credential documentation in #15844.

The recovered implementation:
- keeps GitHub's device code and access token server-side;
- exposes only the short user code and an opaque local flow ID to the browser;
- enforces GitHub's polling interval and `slow_down` backoff;
- distinguishes pending, declined, expired, unknown, and upstream-failure states;
- validates the issued token against GitHub `/user` before persisting it;
- persists to both the credential file and per-agent secrets so coding sub-agents can use it without restart;
- retains PAT paste as the always-available fallback and renders loading/error/empty states distinctly.

Verification:
- device-flow protocol tests: 13/13 pass
- `plugins/plugin-github` typecheck: pass
- Biome on all five changed files: pass after formatting
- `bun run audit:error-policy-ratchet`: pass
- `plugins/plugin-task-coordinator` typecheck reaches an unrelated pre-existing missing `@xterm/addon-fit` declaration in `PtyTerminalPane.tsx`; no changed-file diagnostic

The PR remains draft pending:
- component tests for the connection-card state machine;
- a real GitHub OAuth app/device-flow run, credential persistence inspection, and spawned sub-agent `gh auth status` proof;
- app visual audit iterations, desktop/mobile screenshots, video, and frontend/backend logs.

Live-model trajectory: N/A — credential onboarding is not model-backed.
