### PR TITLE
fix(hitl): Signal availability leaf reuses probeSignal account parsing and reports listAccounts run failures

### DIFF
--- a/scripts/lifeops/connector-paths.mjs
+++ b/scripts/lifeops/connector-paths.mjs
@@ -34,7 +34,10 @@ import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { delimiter, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { PROBE_FAMILIES } from "./credential-probes.mjs";
+import {
+  PROBE_FAMILIES,
+  parseSignalAccountLines,
+} from "./credential-probes.mjs";
 
 /** Path kinds — how the credential is obtained/held, not which provider. */
 export const CONNECTOR_PATH_KINDS = [
@@ -500,6 +503,7 @@ export const CONNECTOR_PATHS = [
               type: "command-output-nonempty",
               command: "signal-cli",
               args: ["listAccounts"],
+              outputFilter: "signal-accounts",
               reason: "no linked Signal account",
             },
           ],
@@ -507,7 +511,7 @@ export const CONNECTOR_PATHS = [
       ],
     },
     notes:
-      "Availability executes the read-only listAccounts command: an installed-but-unrunnable binary and a runnable client with no linked account remain distinct skip states.",
+      "Availability executes the read-only listAccounts command: an installed-but-unrunnable binary, a listAccounts run failure, and a runnable client with no linked account (warning-only output included) remain distinct skip states.",
   }),
 
   // --- WhatsApp -----------------------------------------------------------------------
@@ -871,16 +875,45 @@ export function defaultAvailabilityCtx() {
       return {
         ok: !result.error && result.status === 0,
         stdout: result.stdout ?? "",
+        stderr: result.stderr ?? "",
+        // null on spawn failure (ENOENT, timeout kill) — the reason renders
+        // it as "spawn-error" so a crash never masquerades as empty output.
+        status: result.status,
       };
     },
   };
 }
 
+// Declarative specs are data, so a spec cannot carry a filter function;
+// `outputFilter` names one of these instead. The signal filter is the exact
+// parser probeSignal uses, keeping the coarse availability leaf and the deep
+// probe in agreement on what counts as a linked account (#15848).
+const COMMAND_OUTPUT_FILTERS = {
+  "signal-accounts": parseSignalAccountLines,
+};
+
+// A command that failed to run is a distinct skip state from one that ran and
+// printed nothing; surfacing exit code + first stderr line keeps the
+// dashboard from misdiagnosing e.g. locked signal-cli account storage as "no
+// linked Signal account".
+function commandRunFailureReason(spec, result) {
+  const stderrLine =
+    typeof result.stderr === "string"
+      ? (result.stderr.trim().split(/\r?\n/)[0] ?? "").slice(0, 160)
+      : "";
+  return `${spec.command} ${spec.args.join(" ")} failed (status=${
+    result.status ?? "spawn-error"
+  })${stderrLine ? `: ${stderrLine}` : ""}`;
+}
+
 /**
  * Evaluate a declarative availability spec to { available, reason }. Leaf
- * failures surface their spec's reason; any-of joins all branch reasons,
- * all-of reports the first failing requirement. Unknown spec types throw —
- * a malformed registry entry is a bug, not a skip.
+ * failures surface their spec's reason — except a command that fails to run
+ * under command-output-nonempty, which reports the run failure (exit code +
+ * stderr snippet) so a crash is never labeled with the empty-output reason.
+ * any-of joins all branch reasons, all-of reports the first failing
+ * requirement. Unknown spec types and unknown outputFilter names throw — a
+ * malformed registry entry is a bug, not a skip.
  */
 export function checkAvailability(spec, ctx = defaultAvailabilityCtx()) {
   const ok = { available: true, reason: null };
@@ -927,10 +960,25 @@ export function checkAvailability(spec, ctx = defaultAvailabilityCtx()) {
               spec.reason ?? `${spec.command} ${spec.args.join(" ")} failed`,
           };
     case "command-output-nonempty": {
+      const filter =
+        spec.outputFilter === undefined
+          ? null
+          : COMMAND_OUTPUT_FILTERS[spec.outputFilter];
+      if (spec.outputFilter !== undefined && !filter) {
+        throw new Error(
+          `Unknown command-output filter: ${JSON.stringify(spec.outputFilter)}`,
+        );
+      }
       const result = ctx.runCommand(spec.command, spec.args);
-      return result.ok &&
-        typeof result.stdout === "string" &&
-        result.stdout.trim().length > 0
+      if (!result.ok) {
+        return {
+          available: false,
+          reason: commandRunFailureReason(spec, result),
+        };
+      }
+      const stdout = typeof result.stdout === "string" ? result.stdout : "";
+      const meaningful = filter ? filter(stdout).join("\n") : stdout;
+      return meaningful.trim().length > 0
         ? ok
         : {
             available: false,
@@ -1039,6 +1087,12 @@ function validateAvailabilitySpec(spec, id, problems) {
   }
   if (spec.type === "never" && !spec.reason) {
     problems.push(`${id}: never spec must carry a reason`);
+  }
+  if (
+    spec.outputFilter !== undefined &&
+    !Object.hasOwn(COMMAND_OUTPUT_FILTERS, spec.outputFilter)
+  ) {
+    problems.push(`${id}: unknown command-output filter ${spec.outputFilter}`);
   }
 }
 

--- a/scripts/lifeops/connector-paths.test.mjs
+++ b/scripts/lifeops/connector-paths.test.mjs
@@ -168,7 +168,7 @@ test("validateConnectorPaths flags duplicates, bad kinds, bad probe ids, missing
       probeId: "nope",
       probeEndpoint: "",
       oneClick: { type: "telepathy" },
-      availability: { type: "mystery" },
+      availability: { type: "mystery", outputFilter: "telepathy" },
     },
   ]);
   for (const needle of [
@@ -182,6 +182,7 @@ test("validateConnectorPaths flags duplicates, bad kinds, bad probe ids, missing
     "ownerVars/agentVars imply rolesVia env-slots",
     "malformed env name lower_case",
     "unknown availability type mystery",
+    "unknown command-output filter telepathy",
   ]) {
     assert.ok(
       problems.some((problem) => problem.includes(needle)),
@@ -531,6 +532,98 @@ test("command-output-nonempty requires both success and actual stdout", () => {
     ),
     { available: true, reason: null },
   );
+  // A command that fails to run reports the run failure, never the spec's
+  // empty-output reason — even when the injected ctx omits status/stderr.
+  assert.deepEqual(
+    checkAvailability(spec, fakeCtx({ runCommand: () => ({ ok: false }) })),
+    {
+      available: false,
+      reason: "signal-cli listAccounts failed (status=spawn-error)",
+    },
+  );
+  assert.deepEqual(
+    checkAvailability(
+      spec,
+      fakeCtx({
+        runCommand: () => ({
+          ok: false,
+          status: 3,
+          stdout: "",
+          stderr: "Config file is in use by another instance\nsecond line",
+        }),
+      }),
+    ),
+    {
+      available: false,
+      reason:
+        "signal-cli listAccounts failed (status=3): Config file is in use by another instance",
+    },
+  );
+  // An unknown filter name is a malformed spec — a bug, not a skip.
+  assert.throws(
+    () =>
+      checkAvailability(
+        { ...spec, outputFilter: "telepathy" },
+        fakeCtx({ runCommand: () => ({ ok: true, stdout: "x\n" }) }),
+      ),
+    /Unknown command-output filter: "telepathy"/,
+  );
+});
+
+test("signal.cli scenario: warning-only listAccounts stdout reads as no linked account", () => {
+  const spec = byId("signal.cli").availability;
+  const signalCtx = (listAccountsStdout) =>
+    fakeCtx({
+      commandInPath: (command) => command === "signal-cli",
+      runCommand: (_command, args) => ({
+        ok: true,
+        stdout:
+          args[0] === "listAccounts" ? listAccountsStdout : "signal-cli 0.13\n",
+      }),
+    });
+  // signal-cli builds that emit warnings to stdout with zero linked accounts
+  // must skip exactly like an empty listing — probeSignal already rejects
+  // this shape, and the coarse availability leaf shares its parser.
+  const warningOnly = checkAvailability(
+    spec,
+    signalCtx("WARN no account configured\n"),
+  );
+  assert.equal(warningOnly.available, false);
+  assert.match(warningOnly.reason, /no linked Signal account/);
+  // Warnings interleaved with a real account line still count as linked.
+  const mixed = checkAvailability(
+    spec,
+    signalCtx("WARN storage version is newer\nNumber: +15551234567\n"),
+  );
+  assert.deepEqual(mixed, { available: true, reason: null });
+  // A u:username account handle counts the same as an E.164 number.
+  const username = checkAvailability(spec, signalCtx("u:agent.01\n"));
+  assert.deepEqual(username, { available: true, reason: null });
+});
+
+test("signal.cli scenario: listAccounts crash after --version reports the run failure", () => {
+  const spec = byId("signal.cli").availability;
+  const crashed = checkAvailability(
+    spec,
+    fakeCtx({
+      commandInPath: (command) => command === "signal-cli",
+      runCommand: (_command, args) =>
+        args[0] === "listAccounts"
+          ? {
+              ok: false,
+              status: 1,
+              stdout: "",
+              stderr: "Config file is in use by another instance",
+            }
+          : { ok: true, stdout: "signal-cli 0.13\n" },
+    }),
+  );
+  assert.equal(crashed.available, false);
+  // Locked account storage is a run failure, not evidence of a missing
+  // account — the dashboard reason must carry the exit code and stderr.
+  assert.match(crashed.reason, /signal-cli listAccounts failed \(status=1\)/);
+  assert.match(crashed.reason, /Config file is in use/);
+  assert.doesNotMatch(crashed.reason, /no linked Signal account/);
 });
 
 test("oauth-app-dependent rows skip with an explanatory reason until an app is configured", () => {

--- a/scripts/lifeops/credential-probes.mjs
+++ b/scripts/lifeops/credential-probes.mjs
@@ -390,6 +390,23 @@ async function probeTwilio(e) {
     : fail("twilio", `account HTTP ${r.status}: ${errorSnippet(r)}`);
 }
 
+/**
+ * Linked-account identifiers in `signal-cli listAccounts` stdout. signal-cli
+ * mixes warning lines into stdout on some builds, so non-empty output is not
+ * evidence of a linked account: keep only trimmed lines that — after
+ * stripping the `Number: ` prefix case-insensitively — are an E.164 number or
+ * a `u:username` handle. Shared with the connector-path availability leaf
+ * (connector-paths.mjs) so the coarse dashboard row and this probe cannot
+ * drift on what counts as an account (#15848).
+ */
+export function parseSignalAccountLines(stdout) {
+  return String(stdout ?? "")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .map((line) => line.replace(/^Number:\s*/i, ""))
+    .filter((line) => /^\+\d{6,}$|^u:[A-Za-z0-9_.-]+$/.test(line));
+}
+
 export async function probeSignal(
   e,
   { fetchJsonFn = fetchJson, spawnSyncFn = spawnSync } = {},
@@ -453,11 +470,7 @@ export async function probeSignal(
       `${command} listAccounts failed (status=${listed.status ?? "spawn-error"}${listed.error ? `, ${listed.error.code ?? listed.error.message}` : ""})`,
     );
   }
-  const accounts = String(listed.stdout ?? "")
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .map((line) => line.replace(/^Number:\s*/i, ""))
-    .filter((line) => /^\+\d{6,}$|^u:[A-Za-z0-9_.-]+$/.test(line));
+  const accounts = parseSignalAccountLines(listed.stdout);
   if (accounts.length === 0) return fail("signal", "no linked Signal account");
   const selected = e("SIGNAL_ACCOUNT_NUMBER");
   if (selected && !accounts.includes(selected)) {


### PR DESCRIPTION
Closes #15848

## Summary

Two confined imprecisions in the Signal availability heuristic in `scripts/lifeops/connector-paths.mjs` (from the #15768 review):

1. **Warning-only stdout no longer reads as a linked account.** The `command-output-nonempty` leaf treated ANY non-empty `signal-cli listAccounts` stdout as "linked account present", so a build emitting a warning line with zero accounts showed the dashboard row as available. The probe's line discipline is now extracted from `probeSignal` into an exported `parseSignalAccountLines` (`scripts/lifeops/credential-probes.mjs`): trim each line, strip the `Number: ` prefix case-insensitively, keep only `+<E.164>` / `u:<username>` lines. The leaf references it declaratively via `outputFilter: "signal-accounts"` (specs are data, so the registry names a filter instead of carrying a function), and `probeSignal` now calls the same function — the coarse leaf and the deep probe cannot drift.
2. **A `listAccounts` crash after `--version` succeeded is a run failure, not "no linked Signal account".** The leaf now reports `signal-cli listAccounts failed (status=<code|spawn-error>): <first stderr line>` instead of the spec's empty-output reason. `defaultAvailabilityCtx().runCommand` additionally returns `status`/`stderr` to make that possible (backwards-compatible: injected test ctxs that omit them render `status=spawn-error` with no snippet).

Guard rails: an unknown `outputFilter` name throws at evaluation (same doctrine as unknown spec types — a malformed registry entry is a bug, not a skip) and is flagged by `validateConnectorPaths`, which runs at import time for the shipped registry.

## Tests

Extended `scripts/lifeops/connector-paths.test.mjs` (fully injected machine ctx, no mocks of the module under test):

- `signal.cli scenario: warning-only listAccounts stdout reads as no linked account` — warning-only stdout skips with `no linked Signal account`; warnings interleaved with a real `Number: +…` line stay available; `u:username` handles count.
- `signal.cli scenario: listAccounts crash after --version reports the run failure` — status 1 + locked-storage stderr yields the run-failure reason (asserts it does NOT read `no linked Signal account`).
- `command-output-nonempty requires both success and actual stdout` — extended with spawn-error (ctx omits status/stderr), status+stderr snippet truncation to the first line, and unknown-filter throw.
- `validateConnectorPaths flags …` — extended with the `unknown command-output filter` problem.

## Verification

```
$ bun run test:lifeops-hitl        # node --test scripts/lifeops/*.test.mjs
ℹ tests 60  ℹ pass 60  ℹ fail 0

$ bunx biome check scripts/lifeops/connector-paths.mjs scripts/lifeops/connector-paths.test.mjs scripts/lifeops/credential-probes.mjs
Checked 3 files in 25ms. No fixes applied.
```

<details>
<summary>Suite output (node:test, Node 24)</summary>

```
✔ registry rows validate and every row resolves a probe id or documents its check
✔ leaf spec types evaluate against the injected ctx
✔ any-of aggregates all branch reasons; all-of reports the first failure
✔ signal.cli scenario: installed-but-unrunnable CLI skips distinctly
✔ Signal Desktop and signal-cli unavailability shapes stay distinct
✔ command-output-nonempty requires both success and actual stdout
✔ signal.cli scenario: warning-only listAccounts stdout reads as no linked account
✔ signal.cli scenario: listAccounts crash after --version reports the run failure
✔ Signal REST probe requires at least one linked account
✔ Signal REST probe verifies the selected account without exposing it
✔ Signal CLI probe runs version and listAccounts before passing
✔ Signal CLI probe rejects warning-only account output
ℹ tests 60
ℹ pass 60
ℹ fail 0
```
</details>

<details>
<summary>Real-machine smoke — evaluator driven through real spawnSync (no injected ctx)</summary>

```
$ node --input-type=module -e '…checkAvailability(spec, defaultAvailabilityCtx())…'
# real command exits 1 with stderr -> run-failure reason (was: "no linked Signal account")
{"available":false,"reason":"sh -c echo boom-stderr >&2; exit 1 failed (status=1): boom-stderr"}
# warning-only stdout, exit 0 -> no-account skip (was: available:true)
{"available":false,"reason":"no linked Signal account"}
# "Number: +15551234567" survives the shared filter -> available
{"available":true,"reason":null}
# missing binary -> spawn-error, never the empty-output reason
{"available":false,"reason":"definitely-not-a-binary-xyz listAccounts failed (status=spawn-error)"}
```

This machine has real signal-cli 0.14.3 in PATH with no linked account (`signal-cli listAccounts` prints nothing, exit 0); the shipped registry row evaluates to:

```
{"id":"signal.cli","available":false,"reason":"no signal-cli-rest-api URL; no linked Signal account",…}
```
</details>

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A — headless dashboard-script heuristic; no rendered UI surface changed (the HITL dashboard consumes the reason strings verbatim).
<!-- evidence-row:after-screenshots -->
- [x] N/A — same reason.
<!-- evidence-row:walkthrough-video -->
- [x] N/A — no user-exercisable UI flow; behavior is fully shown by the suite + real-machine smoke above.
<!-- evidence-row:backend-logs -->
- [x] [15865](https://github.com/elizaOS/eliza/pull/15865)
<!-- evidence-row:frontend-logs -->
- [x] N/A — no frontend code path involved.
<!-- evidence-row:llm-trajectory -->
- [x] N/A — no agent/action/provider/prompt/model behavior changed; pure deterministic script logic.
<!-- evidence-row:domain-artifacts -->
- [x] [files](https://github.com/elizaOS/eliza/pull/15865/files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
