### PR TITLE
fix(build): parse run-turbo tasks across full argv; drop ignored generate-keywords --target flag

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -189,7 +189,7 @@ jobs:
           # The migrate entry imports @elizaos/core, whose i18n barrel pulls in the
           # gitignored generated keyword data. Source-mode (eliza-source) migrate
           # never builds core, so generate the file first (mirrors core's prebuild).
-          node packages/shared/scripts/generate-keywords.mjs --target ts
+          node packages/shared/scripts/generate-keywords.mjs
           bun run db:cloud:migrate
 
   # ---------------------------------------------------------------------------

--- a/.github/workflows/cloud-deploy-backend.yml
+++ b/.github/workflows/cloud-deploy-backend.yml
@@ -117,7 +117,7 @@ jobs:
           # The migrate entry imports @elizaos/core, whose i18n barrel pulls in the
           # gitignored generated keyword data. Source-mode (eliza-source) migrate
           # never builds core, so generate the file first (mirrors core's prebuild).
-          node packages/shared/scripts/generate-keywords.mjs --target ts
+          node packages/shared/scripts/generate-keywords.mjs
           bun run db:cloud:migrate
 
       - name: Notify Discord (Success)

--- a/.github/workflows/release-electrobun.yml
+++ b/.github/workflows/release-electrobun.yml
@@ -512,7 +512,7 @@ jobs:
 
       - name: Generate i18n keyword data
         run: |
-          node packages/shared/scripts/generate-keywords.mjs --target ts
+          node packages/shared/scripts/generate-keywords.mjs
           test -f packages/shared/src/i18n/generated/validation-keyword-data.js
 
       - name: Stage desktop bundle inputs

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "test:launch-qa:release:dry": "node packages/scripts/launch-qa/run.mjs --suite release --dry-run",
     "test:desktop:packaged": "bun run --cwd packages/app test:desktop:packaged",
     "test:desktop:packaged:windows": "bun run --cwd packages/app test:desktop:packaged:windows",
-    "generate:action-search-keywords": "node packages/scripts/generate-action-search-keywords.mjs && node packages/shared/scripts/generate-keywords.mjs --target ts",
+    "generate:action-search-keywords": "node packages/scripts/generate-action-search-keywords.mjs && node packages/shared/scripts/generate-keywords.mjs",
     "lifeops-bench:manifest": "node --conditions=eliza-source --conditions=development --import tsx scripts/lifeops-bench/export-action-manifest.ts",
     "start": "bun run --cwd packages/agent start",
     "start:eliza": "node packages/app-core/scripts/run-node-tsx.mjs packages/app-core/src/entry.ts start",

--- a/packages/app-core/scripts/ensure-shared-i18n-data.mjs
+++ b/packages/app-core/scripts/ensure-shared-i18n-data.mjs
@@ -30,7 +30,6 @@ const GENERATOR_PATH = join(SHARED_PKG_DIR, "scripts", "generate-keywords.mjs");
 export function runKeywordGenerator({
   generatorPath = GENERATOR_PATH,
   cwd = SHARED_PKG_DIR,
-  target = "ts",
 } = {}) {
   if (!existsSync(generatorPath)) {
     console.warn(
@@ -39,15 +38,11 @@ export function runKeywordGenerator({
     return { skipped: true };
   }
 
-  const result = spawnSync(
-    process.execPath,
-    [generatorPath, "--target", target],
-    {
-      cwd,
-      stdio: "inherit",
-      env: process.env,
-    },
-  );
+  const result = spawnSync(process.execPath, [generatorPath], {
+    cwd,
+    stdio: "inherit",
+    env: process.env,
+  });
 
   if (result.error) {
     throw result.error;

--- a/packages/cloud/shared/package.json
+++ b/packages/cloud/shared/package.json
@@ -25,7 +25,7 @@
     "lint:fix": "bunx @biomejs/biome check --write --unsafe .",
     "format": "bunx @biomejs/biome format --write .",
     "format:check": "bunx @biomejs/biome format .",
-    "typecheck": "node ../../shared/scripts/generate-keywords.mjs --target ts && tsgo --noEmit",
+    "typecheck": "node ../../shared/scripts/generate-keywords.mjs && tsgo --noEmit",
     "check:tenant-scope": "bun scripts/check-tenant-scope.ts",
     "check:tenant-scope:self-test": "bun test scripts/check-tenant-scope.test.ts",
     "verify:tenant-isolation": "bun scripts/verify-tenant-db-isolation.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -108,7 +108,7 @@
 		"dist"
 	],
 	"scripts": {
-		"prebuild": "bun run --cwd ../logger build && bun run --cwd ../contracts build && bun run --cwd ../cloud/routing build && ([ -f src/i18n/generated/validation-keyword-data.ts ] || node ../shared/scripts/generate-keywords.mjs --target ts)",
+		"prebuild": "bun run --cwd ../logger build && bun run --cwd ../contracts build && bun run --cwd ../cloud/routing build && ([ -f src/i18n/generated/validation-keyword-data.ts ] || node ../shared/scripts/generate-keywords.mjs)",
 		"prepublishOnly": "bun run build",
 		"build": "bun run build.ts",
 		"build:node": "bun run build.ts --node-only",
@@ -123,7 +123,7 @@
 		"test:watch": "node ../scripts/run-vitest.mjs",
 		"lint": "bunx @biomejs/biome check --write ./src",
 		"lint:check": "bunx @biomejs/biome check ./src",
-		"typecheck": "node ../shared/scripts/generate-keywords.mjs --target ts && tsgo --noEmit -p ./tsconfig.json",
+		"typecheck": "node ../shared/scripts/generate-keywords.mjs && tsgo --noEmit -p ./tsconfig.json",
 		"format": "bunx @biomejs/biome format --write ./src",
 		"format:check": "bunx @biomejs/biome format ./src"
 	},

--- a/packages/scripts/__tests__/run-turbo-typecheck-prerequisite.test.ts
+++ b/packages/scripts/__tests__/run-turbo-typecheck-prerequisite.test.ts
@@ -1,4 +1,10 @@
-/** Verifies Turbo typecheck invocations materialize generated declarations before scheduling. */
+/**
+ * Verifies Turbo typecheck invocations materialize generated declarations
+ * before scheduling, across every argv shape run-turbo accepts: `run <task>`,
+ * bare `<task>`, and flags in any position (#15847). Real subprocesses, no
+ * mocks — the fixture generator stands in for generate-keywords.mjs only so
+ * tests can observe invocation counts and argv without touching src/.
+ */
 
 import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
@@ -7,18 +13,23 @@ import { join, resolve } from "node:path";
 
 const repoRoot = resolve(import.meta.dir, "../../..");
 const runTurbo = join(repoRoot, "packages/scripts/run-turbo.mjs");
+const keywordGenerator = join(
+  repoRoot,
+  "packages/shared/scripts/generate-keywords.mjs",
+);
 const tempDirs: string[] = [];
 
 async function fixture() {
   const dir = await mkdtemp(join(tmpdir(), "run-turbo-prerequisite-"));
   tempDirs.push(dir);
   const marker = join(dir, "marker.txt");
+  const argvFile = join(dir, "argv.json");
   const generator = join(dir, "generator.mjs");
   await writeFile(
     generator,
-    `import { appendFileSync } from "node:fs";\nappendFileSync(${JSON.stringify(marker)}, "generated\\n");\nprocess.exit(Number(process.env.GENERATOR_EXIT ?? 0));\n`,
+    `import { appendFileSync, writeFileSync } from "node:fs";\nappendFileSync(${JSON.stringify(marker)}, "generated\\n");\nwriteFileSync(${JSON.stringify(argvFile)}, JSON.stringify(process.argv.slice(2)));\nprocess.exit(Number(process.env.GENERATOR_EXIT ?? 0));\n`,
   );
-  return { generator, marker };
+  return { generator, marker, argvFile };
 }
 
 async function invoke(args: string[], generator: string, exitCode = 0) {
@@ -60,6 +71,41 @@ describe("run-turbo typecheck prerequisites", () => {
     expect(await readFile(marker, "utf8")).toBe("generated\n");
   });
 
+  test("runs the generator when flags precede the task list", async () => {
+    const { generator, marker } = await fixture();
+
+    expect(
+      await invoke(["run", "--filter=@elizaos/core", "typecheck"], generator),
+    ).toBe(0);
+    expect(await readFile(marker, "utf8")).toBe("generated\n");
+  });
+
+  test("runs the generator for a bare typecheck invocation without `run`", async () => {
+    const { generator, marker } = await fixture();
+
+    expect(await invoke(["typecheck"], generator)).toBe(0);
+    expect(await readFile(marker, "utf8")).toBe("generated\n");
+  });
+
+  test("runs the generator for a bare invocation with flags on both sides", async () => {
+    const { generator, marker } = await fixture();
+
+    expect(
+      await invoke(
+        ["--filter=@elizaos/core", "typecheck", "--concurrency=4"],
+        generator,
+      ),
+    ).toBe(0);
+    expect(await readFile(marker, "utf8")).toBe("generated\n");
+  });
+
+  test("invokes the generator with an empty argv (it rejects arguments)", async () => {
+    const { generator, argvFile } = await fixture();
+
+    expect(await invoke(["run", "typecheck"], generator)).toBe(0);
+    expect(JSON.parse(await readFile(argvFile, "utf8"))).toEqual([]);
+  });
+
   test("does not generate declarations for unrelated Turbo tasks", async () => {
     const { generator, marker } = await fixture();
 
@@ -69,9 +115,52 @@ describe("run-turbo typecheck prerequisites", () => {
     });
   });
 
+  test("does not generate declarations for bare unrelated tasks with flags", async () => {
+    const { generator, marker } = await fixture();
+
+    expect(await invoke(["lint", "--filter=@elizaos/core"], generator)).toBe(0);
+    await expect(readFile(marker, "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  test("does not treat pass-through args after `--` as tasks", async () => {
+    const { generator, marker } = await fixture();
+
+    expect(await invoke(["run", "lint", "--", "typecheck"], generator)).toBe(0);
+    await expect(readFile(marker, "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
   test("fails before scheduling when generation fails", async () => {
     const { generator } = await fixture();
 
     expect(await invoke(["run", "typecheck"], generator, 7)).toBe(7);
+  });
+
+  test("fails before scheduling when generation fails on a bare invocation", async () => {
+    const { generator } = await fixture();
+
+    expect(await invoke(["typecheck"], generator, 7)).toBe(7);
+  });
+});
+
+describe("generate-keywords argv contract", () => {
+  test("rejects the removed --target flag before writing anything", async () => {
+    const child = Bun.spawn(
+      [process.execPath, keywordGenerator, "--target", "ts"],
+      {
+        cwd: repoRoot,
+        env: process.env,
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+    await child.exited;
+    const stderr = await new Response(child.stderr).text();
+
+    expect(child.exitCode).toBe(1);
+    expect(stderr).toContain("takes no arguments");
   });
 });

--- a/packages/scripts/check-scenario-workflow-coverage.mjs
+++ b/packages/scripts/check-scenario-workflow-coverage.mjs
@@ -48,7 +48,7 @@ function ensureGeneratedKeywordData() {
     return;
   }
 
-  const completed = spawnSync("node", [KEYWORD_GENERATOR, "--target", "ts"], {
+  const completed = spawnSync("node", [KEYWORD_GENERATOR], {
     cwd: REPO_ROOT,
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],

--- a/packages/scripts/run-turbo.mjs
+++ b/packages/scripts/run-turbo.mjs
@@ -62,22 +62,27 @@ if (process.env.RUN_TURBO_LOCKFILE_CHECK_ONLY === "1") {
 }
 
 const rawTurboArgs = process.argv.slice(2);
-const rawRunIndex = rawTurboArgs.indexOf("run");
-const taskAndOptionArgs =
-  rawRunIndex === -1 ? [] : rawTurboArgs.slice(rawRunIndex + 1);
-const firstOptionIndex = taskAndOptionArgs.findIndex((arg) =>
-  arg.startsWith("-"),
-);
+// Turbo accepts tasks as `turbo run <task>` or bare `turbo <task>`, with flags
+// anywhere in between (`run --filter=x typecheck`), and forwards everything
+// after a bare `--` to the tasks themselves. Collect every non-flag argument
+// before the `--` separator, dropping only a leading `run` command word, so
+// keyword pre-generation cannot be skipped by flag placement or the bare form.
+// A space-separated flag value (`--filter core`) may be miscounted as a task;
+// that errs toward running the idempotent generator, never toward skipping it.
+const passThroughIndex = rawTurboArgs.indexOf("--");
+const turboOwnArgs =
+  passThroughIndex === -1
+    ? rawTurboArgs
+    : rawTurboArgs.slice(0, passThroughIndex);
+const positionalArgs = turboOwnArgs.filter((arg) => !arg.startsWith("-"));
 const requestedTasks =
-  firstOptionIndex === -1
-    ? taskAndOptionArgs
-    : taskAndOptionArgs.slice(0, firstOptionIndex);
+  positionalArgs[0] === "run" ? positionalArgs.slice(1) : positionalArgs;
 
 if (requestedTasks.includes("typecheck")) {
   const generator = process.env.RUN_TURBO_KEYWORD_GENERATOR
     ? path.resolve(process.env.RUN_TURBO_KEYWORD_GENERATOR)
     : path.join(repoRoot, "packages/shared/scripts/generate-keywords.mjs");
-  const result = spawnSync(process.execPath, [generator, "--target", "ts"], {
+  const result = spawnSync(process.execPath, [generator], {
     cwd: repoRoot,
     env: process.env,
     stdio: "inherit",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -30,7 +30,7 @@
     "clean": "node ../scripts/rm-path-recursive.mjs dist",
     "prepublishOnly": "bun run build",
     "build": "bun run build:i18n && bun run build:dist",
-    "build:i18n": "node scripts/generate-keywords.mjs --target ts",
+    "build:i18n": "node scripts/generate-keywords.mjs",
     "typecheck": "bun run build:i18n && tsgo --noEmit -p tsconfig.json",
     "test": "node ../scripts/run-vitest.mjs run --config ./vitest.config.ts",
     "lint": "bunx @biomejs/biome check --write src",

--- a/packages/shared/scripts/generate-keywords.mjs
+++ b/packages/shared/scripts/generate-keywords.mjs
@@ -1,15 +1,20 @@
 #!/usr/bin/env node
 /**
- * i18n Keyword Code Generator
- *
- * Reads keyword JSON files from src/i18n/keywords/*.keywords.json and generates
- * the TypeScript keyword module consumed by @elizaos/shared and @elizaos/core.
+ * i18n keyword code generator: reads the hand-authored keyword JSON files from
+ * src/i18n/keywords/*.keywords.json and emits the gitignored keyword modules
+ * consumed by @elizaos/shared and @elizaos/core.
  *
  * Usage:
  *   node scripts/generate-keywords.mjs
  *
  * Output: src/i18n/generated/validation-keyword-data.ts (and .js)
  *         ../core/src/i18n/generated/validation-keyword-data.ts (standalone)
+ *
+ * All three outputs are always emitted together and it takes no arguments:
+ * each caller depends on a different file (core typecheck on the standalone
+ * .ts, Vite/Rolldown bundles and release packaging on the literal .js path),
+ * so partial emission is never safe. Unexpected argv is rejected so a call
+ * site cannot silently imply target selection that does not exist (#15847).
  */
 
 import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
@@ -21,8 +26,13 @@ const keywordsDir = join(__dirname, "..", "src", "i18n", "keywords");
 const generatedDir = join(__dirname, "..", "src", "i18n", "generated");
 
 const args = process.argv.slice(2);
-const targetIdx = args.indexOf("--target");
-const _target = targetIdx !== -1 ? args[targetIdx + 1] : "all";
+if (args.length > 0) {
+  console.error(
+    `generate-keywords.mjs takes no arguments (got: ${args.join(" ")}); ` +
+      "it always emits every output (shared .ts + .js and the standalone core .ts).",
+  );
+  process.exit(1);
+}
 
 // --- Load all keyword JSON files ---
 

--- a/plugins/plugin-computeruse/ci-templates/cua-parity-real.yml
+++ b/plugins/plugin-computeruse/ci-templates/cua-parity-real.yml
@@ -98,7 +98,7 @@ jobs:
       # ---- REQUIRED: codegen before core build (bun does not run prebuild) ----
       - name: Generate core i18n keyword data
         shell: bash
-        run: node packages/shared/scripts/generate-keywords.mjs --target ts
+        run: node packages/shared/scripts/generate-keywords.mjs
 
       # ---- REQUIRED: build core to dist (fixes eliza-source/@opentelemetry ESM) ----
       - name: Build @elizaos/core (Node target)

--- a/scripts/training-harvest/README.md
+++ b/scripts/training-harvest/README.md
@@ -76,5 +76,5 @@ node scripts/training-harvest/harvest-runner.mjs \
 ```
 
 Prereq in a fresh worktree: generate the i18n keyword data once —
-`node packages/shared/scripts/generate-keywords.mjs --target ts` (gitignored
+`node packages/shared/scripts/generate-keywords.mjs` (gitignored
 build artifact; the CLI imports `packages/core/src/i18n/generated/`).


### PR DESCRIPTION
Closes #15847

## Summary

`packages/scripts/run-turbo.mjs` pre-generates the i18n keyword modules before Turbo hashes/schedules the graph, but its `requestedTasks` parser only saw tasks appearing **after `run` and before the first `-`-prefixed arg**. Two accepted Turbo argv shapes therefore silently skipped keyword pre-generation — resurfacing the missing-generated-file race the wrapper exists to close:

- `run-turbo.mjs run --filter=x typecheck` (flag before the task list)
- `run-turbo.mjs typecheck` (bare form, no `run`)

**Fix (run-turbo.mjs):** tasks are now every non-flag argument before the `--` pass-through separator, minus a leading `run` command word. Flag placement and the bare form can no longer skip pre-generation; args after `--` (which Turbo forwards to tasks) are never miscounted as tasks. A space-separated flag value (`--filter core`) can only err toward *running* the idempotent generator, never toward skipping it.

**Fix (generate-keywords.mjs):** the `--target ts` flag was parsed into an unused `const _target` — the generator always emits all three outputs (shared `.ts` + `.js`, standalone core `.ts`). I checked what callers expect before choosing honor-vs-remove: every caller depends on a *different* output — core's `typecheck`/`prebuild` need the standalone core `.ts`, while Vite/Rolldown bundles and the release-electrobun workflow import the shared `.js` by literal path (that workflow even asserts `test -f .../validation-keyword-data.js` right after passing `--target ts`). Honoring `ts`-only emission would break those consumers, so **the flag is removed** and leftover argv is now **rejected loudly** (exit 1 before any write) so a call site can never again imply target selection that does not exist. All call sites drop the flag in the same commit, keeping core's build working throughout:

- `package.json` (`generate:action-search-keywords`), `packages/shared/package.json` (`build:i18n`), `packages/core/package.json` (`prebuild`, `typecheck`), `packages/cloud/shared/package.json` (`typecheck`)
- `packages/scripts/run-turbo.mjs`, `packages/scripts/check-scenario-workflow-coverage.mjs`, `packages/app-core/scripts/ensure-shared-i18n-data.mjs` (also drops the misleading `target` option)
- `.github/workflows/release-electrobun.yml`, `.github/workflows/cloud-cf-deploy.yml`, `.github/workflows/cloud-deploy-backend.yml`, `plugins/plugin-computeruse/ci-templates/cua-parity-real.yml`
- `scripts/training-harvest/README.md`

**Tests:** `packages/scripts/__tests__/run-turbo-typecheck-prerequisite.test.ts` extended from 4 to 12 cases: flag-before-task, bare invocation, bare with flags on both sides, `--` pass-through not treated as tasks, bare unrelated task, empty-argv contract (run-turbo must not pass the removed flag), failure propagation on the bare form, and the generator's argv-rejection contract (real generator subprocess, exits 1 before writing). Note: this test dir has no CI lane today (#15846) — proven green locally with `bun test` below.

## Verification

```
bun test packages/scripts/__tests__/run-turbo-typecheck-prerequisite.test.ts
# 12 pass / 0 fail (bun 1.4.0-canary.1)

node packages/shared/scripts/generate-keywords.mjs                 # exit 0, emits all 3 outputs
node packages/shared/scripts/generate-keywords.mjs --target ts     # exit 1, loud rejection

# before/after through run-turbo itself with the REAL generator (RUN_TURBO_PREPARE_CHECK_ONLY=1):
#   develop's run-turbo: bare 'typecheck' and 'run --filter=@elizaos/core typecheck' -> file NOT generated (the bug)
#   this branch:         both forms -> all 3 generated files materialized; 'run lint' still skips

node packages/app-core/scripts/ensure-shared-i18n-data.mjs         # exit 0 end-to-end
node packages/scripts/error-policy-ratchet.mjs                     # no new fallback-slop
bunx @biomejs/biome check <changed files>                          # clean (6 pre-existing noUndeclaredEnvVars warnings in run-turbo.mjs, untouched rule)
```

<details>
<summary>bun test output (12/12 green)</summary>

```
bun test v1.4.0-canary.1 (55f6c899f)

 12 pass
 0 fail
 22 expect() calls
Ran 12 tests across 1 file. [1402.00ms]
```

</details>

<details>
<summary>Real-generator contract: no-args succeeds (all 3 outputs), stale --target fails loudly</summary>

```
$ node packages/shared/scripts/generate-keywords.mjs
Generating keyword code from JSON...

  Loaded action-search.generated.keywords.json: 114 entries
  Loaded context-search.keywords.json: 38 entries
  Loaded shared.keywords.json: 73 entries
  Loaded typescript.keywords.json: 16 entries
  Loaded validate.keywords.json: 2 entries

Total: 241 entries, 6 locales

  TypeScript (shared): .../packages/shared/src/i18n/generated/validation-keyword-data.ts
  JavaScript (shared): .../packages/shared/src/i18n/generated/validation-keyword-data.js
  TypeScript (core):   .../packages/core/src/i18n/generated/validation-keyword-data.ts

Done!
exit=0

$ node packages/shared/scripts/generate-keywords.mjs --target ts
generate-keywords.mjs takes no arguments (got: --target ts); it always emits every output (shared .ts + .js and the standalone core .ts).
exit=1
```

</details>

<details>
<summary>Before/after: develop's run-turbo vs this branch, real generator, both broken argv shapes</summary>

```
=== BEFORE (develop run-turbo): bare 'typecheck' skips generation ===
exit=0
ls: packages/core/src/i18n/generated/validation-keyword-data.ts: No such file or directory
=== BEFORE (develop run-turbo): 'run --filter=@elizaos/core typecheck' skips generation ===
exit=0
ls: packages/core/src/i18n/generated/validation-keyword-data.ts: No such file or directory
=== AFTER (fixed run-turbo): bare 'typecheck' generates ===
exit=0
packages/core/src/i18n/generated/validation-keyword-data.ts
=== AFTER (fixed run-turbo): 'run --filter=@elizaos/core typecheck' generates ===
exit=0
packages/core/src/i18n/generated/validation-keyword-data.ts
packages/shared/src/i18n/generated/validation-keyword-data.js
packages/shared/src/i18n/generated/validation-keyword-data.ts
=== AFTER: 'run lint' still does not generate ===
exit=0
ls: packages/core/src/i18n/generated/validation-keyword-data.ts: No such file or directory
```

</details>

<details>
<summary>error-policy ratchet + ensure-shared-i18n-data</summary>

```
$ node packages/scripts/error-policy-ratchet.mjs
[error-policy-ratchet] base origin/develop (afb55d4fd5); 0 changed production source file(s)
[error-policy-ratchet] no new fallback-slop in touched files

$ node packages/app-core/scripts/ensure-shared-i18n-data.mjs
  ...
  TypeScript (core):   .../packages/core/src/i18n/generated/validation-keyword-data.ts
Done!
exit=0
```

</details>

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] **Before screenshots:** N/A — build-tooling scripts only; no UI surface. The "before" wrong behavior is captured as terminal output above (develop's run-turbo skipping generation on both argv shapes).

<!-- evidence-row:after-screenshots -->
- [x] **After screenshots:** N/A — build-tooling scripts only; no UI surface. The "after" behavior is the terminal output above (both argv shapes materialize all 3 generated files).

<!-- evidence-row:walkthrough-video -->
- [x] **Walkthrough video:** N/A — no user-exercisable UI flow; the full flow is the CLI transcripts above (before/after run-turbo, generator contract, tests).

<!-- evidence-row:backend-logs -->
- [x] [15867](https://github.com/elizaOS/eliza/pull/15867)

<!-- evidence-row:frontend-logs -->
- [x] **Frontend logs:** N/A — no frontend code path involved.

<!-- evidence-row:llm-trajectory -->
- [x] **LLM trajectory:** N/A — no agent/action/provider/prompt/model behavior change; pure build tooling.

<!-- evidence-row:domain-artifacts -->
- [x] [files](https://github.com/elizaOS/eliza/pull/15867/files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
