### PR TITLE
fix(cloud): monitor Headscale API key health (#15401)

### DIFF
--- a/packages/cloud/services/headscale/DEPLOY.md
+++ b/packages/cloud/services/headscale/DEPLOY.md
@@ -56,6 +56,16 @@ The workflow:
 5. restarts `headscale` and `eliza-provisioning-worker.service`;
 6. fails if local `/health` is not green.
 
+The provisioning worker adds the credential-level check that `/health` cannot:
+it calls authenticated `GET /api/v1/user` before publishing its first heartbeat
+and repeats the probe on every infra-maintenance sweep. A 401/403 pages the
+configured `PROVISIONING_ALERT_*` channels under the stable
+`headscale-api-key-unhealthy` incident key, stops heartbeat publication, and
+causes provisioning to fail closed. After rotating a key, rerun the arm workflow
+to reconcile the control-plane daemon, update the matching Cloudflare Worker
+secret through the normal Worker secret path, then confirm the worker startup log contains
+`headscaleApiKeyAuthenticated: true`.
+
 The matching Cloudflare Worker secrets still need to be set through the normal
 Worker secret path. Keep host and Worker values identical for
 `HEADSCALE_API_KEY`, `AGENT_TOKEN_PRIVATE_KEY_PEM`, and `ELIZA_LOCAL_ROOT_KEY`;

--- a/packages/cloud/services/headscale/README.md
+++ b/packages/cloud/services/headscale/README.md
@@ -42,6 +42,13 @@ values are in [`DEPLOY.md`](./DEPLOY.md). The `HEADSCALE_API_KEY` is generated o
 the host and stored as a GitHub/Worker secret — never pasted into issues or
 workflow inputs.
 
+The provisioning daemon authenticates `GET /api/v1/user` at startup and on each
+infra-maintenance sweep. A missing, expired, revoked, or wrong-server key pages
+through the provisioning alert channels and withholds the daemon heartbeat, so
+the Cloud API fails provisioning closed instead of reporting a healthy but
+unusable control plane. The unauthenticated Headscale `/health` endpoint is not
+sufficient evidence that the key works.
+
 ## Local dev
 
 A `docker-compose.yml` for headscale is intentionally NOT included in `cloud/docker-compose.yml` — local dev uses the `tag:agent` flow only and doesn't touch customer-tunnel pricing. To exercise customer tunnels locally, point `HEADSCALE_API_URL` at a development instance you stand up by hand.

--- a/packages/cloud/shared/src/lib/services/headscale-api-key-health.test.ts
+++ b/packages/cloud/shared/src/lib/services/headscale-api-key-health.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Authenticated Headscale health checks use deterministic HTTP responses while
+ * preserving the production request shape and alert/throw boundary.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import {
+  assertHeadscaleApiKeyHealthy,
+  checkHeadscaleApiKeyHealth,
+  HeadscaleApiKeyHealthError,
+} from "./headscale-api-key-health";
+
+const ENV = {
+  HEADSCALE_API_URL: "http://127.0.0.1:8081/",
+  HEADSCALE_API_KEY: "live-key",
+} as NodeJS.ProcessEnv;
+
+describe("checkHeadscaleApiKeyHealth", () => {
+  test("proves the configured bearer key against the read-only users endpoint", async () => {
+    const fetchImpl = mock(async () => new Response('{"users":[]}', { status: 200 }));
+
+    const result = await checkHeadscaleApiKeyHealth({ env: ENV, fetchImpl });
+
+    expect(result).toEqual({
+      healthy: true,
+      endpoint: "http://127.0.0.1:8081/api/v1/user",
+      status: 200,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(url).toBe("http://127.0.0.1:8081/api/v1/user");
+    expect(init?.method).toBe("GET");
+    expect(init?.headers).toEqual({ Authorization: "Bearer live-key" });
+  });
+
+  test("fails explicitly without sending a request when the key is missing", async () => {
+    const fetchImpl = mock(async () => new Response(null, { status: 200 }));
+
+    const result = await checkHeadscaleApiKeyHealth({
+      env: { HEADSCALE_API_URL: "http://headscale.internal" } as NodeJS.ProcessEnv,
+      fetchImpl,
+    });
+
+    expect(result.healthy).toBe(false);
+    if (result.healthy) throw new Error("expected unhealthy result");
+    expect(result.code).toBe("HEADSCALE_API_KEY_MISSING");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  test.each([401, 403])("classifies HTTP %i as a rejected key", async (status) => {
+    const result = await checkHeadscaleApiKeyHealth({
+      env: ENV,
+      fetchImpl: async () => new Response(null, { status }),
+    });
+
+    expect(result.healthy).toBe(false);
+    if (result.healthy) throw new Error("expected unhealthy result");
+    expect(result.code).toBe("HEADSCALE_API_KEY_REJECTED");
+    expect(result.status).toBe(status);
+  });
+
+  test("classifies non-auth HTTP failures without reading or logging a response body", async () => {
+    const result = await checkHeadscaleApiKeyHealth({
+      env: ENV,
+      fetchImpl: async () => new Response("secret diagnostic", { status: 503 }),
+    });
+
+    expect(result.healthy).toBe(false);
+    if (result.healthy) throw new Error("expected unhealthy result");
+    expect(result.code).toBe("HEADSCALE_API_UNHEALTHY");
+    expect(result.message).not.toContain("secret diagnostic");
+  });
+
+  test("classifies transport failures as unhealthy", async () => {
+    const result = await checkHeadscaleApiKeyHealth({
+      env: ENV,
+      fetchImpl: async () => {
+        throw new Error("connection refused");
+      },
+    });
+
+    expect(result.healthy).toBe(false);
+    if (result.healthy) throw new Error("expected unhealthy result");
+    expect(result.code).toBe("HEADSCALE_API_UNHEALTHY");
+    expect(result.message).toContain("connection refused");
+  });
+});
+
+describe("assertHeadscaleApiKeyHealthy", () => {
+  test("is silent when the authenticated probe succeeds", async () => {
+    const alert = mock(async () => {});
+    const health = {
+      healthy: true as const,
+      endpoint: "http://headscale/api/v1/user",
+      status: 200,
+    };
+
+    await expect(
+      assertHeadscaleApiKeyHealthy({ check: async () => health, alert }),
+    ).resolves.toEqual(health);
+    expect(alert).not.toHaveBeenCalled();
+  });
+
+  test("pages with a stable dedup key and throws a typed failure", async () => {
+    const alert = mock(async () => {});
+    const health = {
+      healthy: false as const,
+      endpoint: "http://headscale/api/v1/user",
+      status: 401,
+      code: "HEADSCALE_API_KEY_REJECTED" as const,
+      message: "Headscale rejected the key",
+    };
+
+    const promise = assertHeadscaleApiKeyHealthy({
+      check: async () => health,
+      alert,
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(HeadscaleApiKeyHealthError);
+    await expect(promise).rejects.toMatchObject({
+      code: "HEADSCALE_API_KEY_REJECTED",
+      severity: "fatal",
+      context: {
+        endpoint: "http://headscale/api/v1/user",
+        status: 401,
+      },
+    });
+    expect(alert).toHaveBeenCalledWith({
+      title: "Headscale API key is unhealthy",
+      message: "Headscale rejected the key",
+      dedupKey: "headscale-api-key-unhealthy",
+      details: {
+        code: "HEADSCALE_API_KEY_REJECTED",
+        endpoint: "http://headscale/api/v1/user",
+        status: 401,
+      },
+    });
+  });
+});

--- a/packages/cloud/shared/src/lib/services/headscale-api-key-health.ts
+++ b/packages/cloud/shared/src/lib/services/headscale-api-key-health.ts
@@ -1,0 +1,148 @@
+/**
+ * Authenticated Headscale API-key health gate for the provisioning control plane.
+ *
+ * The local `/health` endpoint proves only that Headscale is running; an expired
+ * or lost admin key still makes every dedicated-agent enrollment fail with 401.
+ * This probe exercises the read-only `/api/v1/user` endpoint, alerts through the
+ * provisioning ops channels, and throws a typed error so startup fails before a
+ * worker can advertise healthy with unusable VPN credentials.
+ */
+
+import { ElizaError } from "@elizaos/core";
+import type { DaemonHealthAlert } from "./provisioning-worker-health-monitor";
+import { sendProvisioningWorkerAlert } from "./provisioning-worker-health-monitor";
+
+const DEFAULT_HEADSCALE_API_URL = "http://localhost:8081";
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+export type HeadscaleApiKeyHealthCode =
+  | "HEADSCALE_API_KEY_MISSING"
+  | "HEADSCALE_API_KEY_REJECTED"
+  | "HEADSCALE_API_UNHEALTHY";
+
+export type HeadscaleApiKeyHealth =
+  | {
+      healthy: true;
+      endpoint: string;
+      status: number;
+    }
+  | {
+      healthy: false;
+      endpoint: string;
+      code: HeadscaleApiKeyHealthCode;
+      message: string;
+      status?: number;
+    };
+
+export class HeadscaleApiKeyHealthError extends ElizaError {
+  override readonly name = "HeadscaleApiKeyHealthError";
+
+  constructor(health: Extract<HeadscaleApiKeyHealth, { healthy: false }>) {
+    super(health.message, {
+      code: health.code,
+      severity: "fatal",
+      context: {
+        endpoint: health.endpoint,
+        status: health.status,
+      },
+    });
+  }
+}
+
+function apiUsersEndpoint(env: NodeJS.ProcessEnv): string {
+  const baseUrl = (env.HEADSCALE_API_URL || DEFAULT_HEADSCALE_API_URL).replace(/\/+$/, "");
+  return `${baseUrl}/api/v1/user`;
+}
+
+/**
+ * Probe the authenticated read-only endpoint used by provisioning operations.
+ * Expected auth and availability failures become explicit unhealthy states so
+ * the monitor can alert with a stable code without exposing the bearer token.
+ */
+export async function checkHeadscaleApiKeyHealth(
+  deps: { env?: NodeJS.ProcessEnv; fetchImpl?: typeof fetch; timeoutMs?: number } = {},
+): Promise<HeadscaleApiKeyHealth> {
+  const env = deps.env ?? process.env;
+  const endpoint = apiUsersEndpoint(env);
+  const apiKey = env.HEADSCALE_API_KEY?.trim();
+
+  if (!apiKey) {
+    return {
+      healthy: false,
+      endpoint,
+      code: "HEADSCALE_API_KEY_MISSING",
+      message:
+        "HEADSCALE_API_KEY is missing; dedicated-agent VPN enrollment cannot authenticate. " +
+        "Rotate a key on the control-plane host and re-arm the provisioning worker.",
+    };
+  }
+
+  let response: Response;
+  try {
+    response = await (deps.fetchImpl ?? fetch)(endpoint, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${apiKey}` },
+      signal: AbortSignal.timeout(deps.timeoutMs ?? DEFAULT_TIMEOUT_MS),
+    });
+  } catch (error) {
+    // error-policy:J7 this diagnostic failure is converted to a paged unhealthy state below.
+    const reason = error instanceof Error ? error.message : String(error);
+    return {
+      healthy: false,
+      endpoint,
+      code: "HEADSCALE_API_UNHEALTHY",
+      message: `Authenticated Headscale health probe failed: ${reason}`,
+    };
+  }
+
+  if (response.ok) {
+    return { healthy: true, endpoint, status: response.status };
+  }
+
+  if (response.status === 401 || response.status === 403) {
+    return {
+      healthy: false,
+      endpoint,
+      status: response.status,
+      code: "HEADSCALE_API_KEY_REJECTED",
+      message:
+        `Headscale rejected HEADSCALE_API_KEY with HTTP ${response.status}; the key is expired, revoked, or belongs to a different server. ` +
+        "Rotate it on the control-plane host and re-arm the provisioning worker.",
+    };
+  }
+
+  return {
+    healthy: false,
+    endpoint,
+    status: response.status,
+    code: "HEADSCALE_API_UNHEALTHY",
+    message: `Authenticated Headscale health probe returned HTTP ${response.status}.`,
+  };
+}
+
+/**
+ * Alert and fail fast when the authenticated Headscale probe is unhealthy.
+ * PagerDuty deduplicates this failure domain independently from daemon-heartbeat
+ * and backup-restorability incidents.
+ */
+export async function assertHeadscaleApiKeyHealthy(
+  deps: {
+    check?: () => Promise<HeadscaleApiKeyHealth>;
+    alert?: (alert: DaemonHealthAlert) => void | Promise<void>;
+  } = {},
+): Promise<HeadscaleApiKeyHealth> {
+  const health = await (deps.check ?? checkHeadscaleApiKeyHealth)();
+  if (health.healthy) return health;
+
+  await (deps.alert ?? sendProvisioningWorkerAlert)({
+    title: "Headscale API key is unhealthy",
+    message: health.message,
+    dedupKey: "headscale-api-key-unhealthy",
+    details: {
+      code: health.code,
+      endpoint: health.endpoint,
+      status: health.status,
+    },
+  });
+  throw new HeadscaleApiKeyHealthError(health);
+}

--- a/packages/scripts/cloud/admin/daemons/provisioning-worker.headscale-health.test.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker.headscale-health.test.ts
@@ -1,0 +1,44 @@
+/**
+ * The provisioning daemon delegates authenticated Headscale health checks to
+ * the shared alerting gate and propagates failures to its bounded phase.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import {
+  __setDepsForTests,
+  processHeadscaleApiKeyHealthCycle,
+} from "./provisioning-worker";
+
+afterEach(() => {
+  __setDepsForTests(null);
+});
+
+describe("processHeadscaleApiKeyHealthCycle", () => {
+  test("returns the authenticated probe result unchanged", async () => {
+    const health = {
+      healthy: true as const,
+      endpoint: "http://127.0.0.1:8081/api/v1/user",
+      status: 200,
+    };
+    const assertHeadscaleApiKeyHealthy = mock(async () => health);
+    __setDepsForTests({ assertHeadscaleApiKeyHealthy } as unknown as Parameters<
+      typeof __setDepsForTests
+    >[0]);
+
+    await expect(processHeadscaleApiKeyHealthCycle()).resolves.toEqual(health);
+    expect(assertHeadscaleApiKeyHealthy).toHaveBeenCalledTimes(1);
+  });
+
+  test("propagates a rejected key so startup fails and the bounded cycle fails closed", async () => {
+    const assertHeadscaleApiKeyHealthy = mock(async () => {
+      throw new Error("Headscale rejected HEADSCALE_API_KEY with HTTP 401");
+    });
+    __setDepsForTests({ assertHeadscaleApiKeyHealthy } as unknown as Parameters<
+      typeof __setDepsForTests
+    >[0]);
+
+    await expect(processHeadscaleApiKeyHealthCycle()).rejects.toThrow(
+      "HTTP 401",
+    );
+  });
+});

--- a/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
@@ -59,6 +59,8 @@ type WorkerProcessNodeDiskCleanup =
   typeof import("@elizaos/cloud-shared/lib/services/node-disk-manager").processNodeDiskCleanup;
 type WorkerRunBackupVerificationCycle =
   typeof import("@elizaos/cloud-shared/lib/services/agent-backup-verifier").runBackupVerificationCycle;
+type WorkerAssertHeadscaleApiKeyHealthy =
+  typeof import("@elizaos/cloud-shared/lib/services/headscale-api-key-health").assertHeadscaleApiKeyHealthy;
 
 interface PreflightKmsClient {
   getOrCreateKey(keyId: string): Promise<unknown>;
@@ -89,6 +91,7 @@ interface WorkerDeps {
   withTimeout: WorkerWithTimeout;
   processNodeDiskCleanup: WorkerProcessNodeDiskCleanup;
   runBackupVerificationCycle: WorkerRunBackupVerificationCycle;
+  assertHeadscaleApiKeyHealthy: WorkerAssertHeadscaleApiKeyHealthy;
 }
 
 export interface ProvisioningWorkerConfig {
@@ -248,6 +251,7 @@ async function loadDeps(): Promise<WorkerDeps> {
       import("@elizaos/cloud-shared/lib/utils/with-timeout"),
       import("@elizaos/cloud-shared/lib/services/node-disk-manager"),
       import("@elizaos/cloud-shared/lib/services/agent-backup-verifier"),
+      import("@elizaos/cloud-shared/lib/services/headscale-api-key-health"),
     ]).then(
       ([
         jobsModule,
@@ -265,6 +269,7 @@ async function loadDeps(): Promise<WorkerDeps> {
         withTimeoutModule,
         nodeDiskManagerModule,
         backupVerifierModule,
+        headscaleApiKeyHealthModule,
       ]) => ({
         provisioningJobService: jobsModule.provisioningJobService,
         logger: loggerModule.logger,
@@ -286,6 +291,8 @@ async function loadDeps(): Promise<WorkerDeps> {
         processNodeDiskCleanup: nodeDiskManagerModule.processNodeDiskCleanup,
         runBackupVerificationCycle:
           backupVerifierModule.runBackupVerificationCycle,
+        assertHeadscaleApiKeyHealthy:
+          headscaleApiKeyHealthModule.assertHeadscaleApiKeyHealthy,
       }),
     );
   }
@@ -689,6 +696,19 @@ async function processNodeDiskCleanupCycle(): Promise<NodeDiskCleanupSummary> {
 }
 
 /**
+ * Exercise the real authenticated Headscale API boundary used by dedicated
+ * provisioning. The unauthenticated `/health` endpoint stays green when an API
+ * key expires, so only this read-only `/api/v1/user` probe can detect the drift
+ * before every new agent fails enrollment. Exported for the daemon wiring test.
+ */
+export async function processHeadscaleApiKeyHealthCycle(): Promise<
+  Awaited<ReturnType<WorkerAssertHeadscaleApiKeyHealthy>>
+> {
+  const { assertHeadscaleApiKeyHealthy } = await loadDeps();
+  return assertHeadscaleApiKeyHealthy();
+}
+
+/**
  * Verify a bounded sample of stored agent backups is actually RESTORABLE with
  * the current KMS keys (#15603 B5): decrypt the newest backup per agent,
  * replay incremental chains, validate content/manifest hashes, stamp the
@@ -1077,6 +1097,14 @@ assertWatchdogInvariant();
  */
 let preflightOk = false;
 
+/**
+ * Authenticated Headscale health is independent from the KMS preflight. A
+ * running Headscale process with an expired admin key cannot enroll agents, so
+ * the heartbeat gate requires both signals and fails closed after a periodic
+ * probe detects key drift.
+ */
+let headscaleApiKeyOk = false;
+
 /** Wall-clock of the last `pollCycle` that returned. Drives the watchdog. */
 let lastCycleCompletedAt = Date.now();
 
@@ -1226,7 +1254,7 @@ function startHeartbeatInterval(
     if (heartbeatPublishInFlight) return;
     heartbeatPublishInFlight = true;
     void maybePublishHeartbeat(logger, {
-      preflightOk,
+      preflightOk: preflightOk && headscaleApiKeyOk,
       lastCycleCompletedAt,
     })
       .then(({ watchdogTripped }) => {
@@ -1477,6 +1505,31 @@ async function runInfraMaintenanceCycle(
     "db liveness check cycle",
     () => processDbLivenessCheckCycle(config),
     (assessment) => logJobsTableLiveness(logger, assessment),
+  );
+
+  await runBoundedPhase(
+    logger,
+    "Headscale API key health cycle",
+    async () => {
+      try {
+        const health = await processHeadscaleApiKeyHealthCycle();
+        headscaleApiKeyOk = true;
+        return health;
+      } catch (error) {
+        // error-policy:J7 the shared monitor already pages; keep the maintenance loop alive but fail the heartbeat gate closed.
+        headscaleApiKeyOk = false;
+        throw error;
+      }
+    },
+    (health) => {
+      logger.info(
+        "[provisioning-worker] Headscale API key health check passed",
+        {
+          endpoint: health.endpoint,
+          status: health.status,
+        },
+      );
+    },
   );
 
   await runBoundedPhase(
@@ -1741,8 +1794,12 @@ async function main(): Promise<void> {
     throw error;
   }
 
+  await processHeadscaleApiKeyHealthCycle();
+  headscaleApiKeyOk = true;
   preflightOk = true;
-  logger.info("[provisioning-worker] startup preflight passed");
+  logger.info("[provisioning-worker] startup preflight passed", {
+    headscaleApiKeyAuthenticated: true,
+  });
 
   // #15160 guard, startup half: right after the preflight, check that the
   // jobs table this DATABASE_URL points at has been written to recently.


### PR DESCRIPTION
Part of #15401 (Headscale API-key drift entry).

## Summary

- Authenticate the real read-only Headscale `GET /api/v1/user` endpoint before the provisioning worker publishes its first heartbeat.
- Repeat the authenticated probe on every infra-maintenance sweep and withdraw later heartbeat publication when the key becomes unhealthy.
- Classify missing keys, 401/403 rejection, other HTTP failures, and transport failures without logging the key or reading an upstream error body.
- Page through the existing provisioning Slack/PagerDuty channels with an independent `headscale-api-key-unhealthy` dedup key, then throw a typed `ElizaError` so startup fails fast.
- Document the monitor and rotation/recovery procedure in the Headscale runbook.

## Verification

- Real Headscale v0.29.2 with isolated SQLite/state: a freshly minted API key produced HTTP 200 from `/api/v1/user`; an invalid key produced HTTP 401 and the expected `HEADSCALE_API_KEY_REJECTED` result. The manually reviewed server log showed both requests and token validation failure without exposing the key. Full record: https://github.com/elizaOS/eliza/issues/15401#issuecomment-4930707484
- `bun test packages/scripts/cloud/admin/daemons/provisioning-worker*.test.ts packages/cloud/shared/src/lib/services/headscale-api-key-health.test.ts packages/cloud/shared/src/lib/services/headscale-client.test.ts` — passed; 5 pre-existing environment-dependent reconcile cases skipped by contract.
- New health service reached 100% function and line coverage in the focused run.
- `bun run --cwd packages/cloud/shared typecheck` — passed.
- Focused Biome, `git diff --check`, and `bun run audit:error-policy-ratchet` — passed.
- Synced with current `origin/develop` before push.

Repository-wide `bun run verify` stops before affected typecheck on an unrelated develop baseline: untouched core/agent/app-core contain 377 `?? {}` sites against a baseline of 375. This PR does not touch those packages or add that pattern.

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] N/A - server-side control-plane health policy only; no rendered UI or native visual changes.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no pixels, styles, components, or view structure changed.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - the observable behavior is an authenticated daemon health boundary and structured ops alert, not a visual user flow.
<!-- evidence-row:backend-logs -->
- [x] Real Headscale v0.29.2 request/result and server-log evidence: https://github.com/elizaOS/eliza/issues/15401#issuecomment-4930707484
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend package, browser request, or client state changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model prompt, action, provider, evaluator, planner, or inference behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Real API key mint, authenticated 200, rejected-key 401, typed health result, and graceful server shutdown record: https://github.com/elizaOS/eliza/issues/15401#issuecomment-4930707484
