### PR TITLE
fix(cloud): prove cleanup and delete app containers by immutable ID

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/app-container-provider.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-container-provider.test.ts
@@ -93,19 +93,20 @@ describe("AppContainerProvider.provision", () => {
 
     const rmIdx = calls.indexOf("docker rm -f 'app-nubilio'");
     const createIdx = calls.findIndex((c) => c.startsWith("docker create"));
-    // A best-effort `docker rm -f <name>` is issued, and it precedes the create
+    // The idempotent `docker rm -f <name>` is issued, and it precedes the create
     // so the deterministic `app-<slug>` name is free (no 'name already in use').
     expect(rmIdx).toBeGreaterThanOrEqual(0);
     expect(createIdx).toBeGreaterThanOrEqual(0);
     expect(rmIdx).toBeLessThan(createIdx);
   });
 
-  test("a failing pre-clean rm does not abort the provision (best-effort)", async () => {
+  test("a missing pre-clean target is confirmed absent before provisioning", async () => {
     const calls: string[] = [];
     const ssh: AppContainerSsh = {
       async exec(command) {
         calls.push(command);
-        if (command.startsWith("docker rm -f")) throw new Error("no such container");
+        if (command === "docker rm -f 'app-nubilio'") throw new Error("rm failed");
+        if (command.startsWith("docker inspect")) throw new Error("No such container");
         if (command.startsWith("docker create")) return "cid";
         return "";
       },
@@ -120,9 +121,28 @@ describe("AppContainerProvider.provision", () => {
       containerName: "app-nubilio",
       input: INPUT,
     });
-    // rm threw but the create still ran and the provision succeeded.
+    // rm failed, but inspect proved the name absent before create continued.
     expect(result.containerId).toBe("cid");
     expect(calls.some((c) => c.startsWith("docker create"))).toBe(true);
+  });
+
+  test("an uninspectable pre-clean target blocks provisioning", async () => {
+    const ssh: AppContainerSsh = {
+      async exec(command) {
+        if (command.startsWith("docker rm -f")) throw new Error("ssh write failed");
+        if (command.startsWith("docker inspect")) throw new Error("ssh read failed");
+        return "";
+      },
+    };
+    const provider = new AppContainerProvider({
+      ssh,
+      nodeId: "node-1",
+      allocateHostPort: async () => 49001,
+    });
+
+    await expect(
+      provider.provision({ appId: APP_ID, containerName: "app-nubilio", input: INPUT }),
+    ).rejects.toThrow("Could not prove Docker container app-nubilio is absent");
   });
 
   test("picks a host port not already in use on the node (collision-safe)", async () => {
@@ -150,7 +170,7 @@ describe("AppContainerProvider.provision", () => {
     expect(result.hostPort).toBe(31000);
   });
 
-  test("a start failure removes the created container before propagating", async () => {
+  test("a start failure propagates to the executor cleanup boundary", async () => {
     const calls: string[] = [];
     const ssh: AppContainerSsh = {
       async exec(command) {
@@ -169,7 +189,7 @@ describe("AppContainerProvider.provision", () => {
     await expect(
       provider.provision({ appId: APP_ID, containerName: "app-nubilio", input: INPUT }),
     ).rejects.toThrow("start failed");
-    expect(calls.filter((command) => command === "docker rm -f 'app-nubilio'")).toHaveLength(2);
+    expect(calls.filter((command) => command === "docker rm -f 'app-nubilio'")).toHaveLength(1);
   });
 
   test("provision with DATABASE_URL + POSTGRES_URL stands up the ambassador + rewrites BOTH", async () => {
@@ -218,10 +238,13 @@ describe("AppContainerProvider.provision", () => {
       allocateHostPort: async () => 1,
     });
     await provider.delete("app-x");
+    await provider.deleteById("docker-immutable-1", "app-x");
     await provider.restart("app-x");
     await provider.logs("app-x", 50);
     expect(calls).toEqual([
       "docker rm -f 'app-x'",
+      "docker rm -f 'app-db-x' >/dev/null 2>&1 || true",
+      "docker rm -f 'docker-immutable-1'",
       "docker rm -f 'app-db-x' >/dev/null 2>&1 || true",
       "docker restart 'app-x'",
       "docker logs --tail 50 'app-x'",

--- a/packages/cloud/shared/src/lib/services/__tests__/app-container-store-recovery.integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-container-store-recovery.integration.test.ts
@@ -116,8 +116,11 @@ describe("app-container persistence transactions", () => {
   });
 
   test("claims and rolls back exactly one authoritative node slot", async () => {
-    expect(await store.claimNodeSlot(SLOT_ID, ORG_ONE, "node-1")).toBe(true);
-    expect(await store.claimNodeSlot(SLOT_ID, ORG_ONE, "node-1")).toBe(false);
+    expect(await store.claimNodeSlot(SLOT_ID, ORG_ONE, "node-1")).toBe("claimed");
+    expect(await store.claimNodeSlot(SLOT_ID, ORG_ONE, "node-1")).toBe("already-claimed");
+    await expect(store.claimNodeSlot(SLOT_ID, ORG_ONE, "node-full")).rejects.toMatchObject({
+      name: "APP_CONTAINER_NODE_SLOT_CONFLICT",
+    });
     expect(await store.getById(SLOT_ID)).toMatchObject({ id: SLOT_ID, nodeId: "node-1" });
 
     expect(await countAllocatedWorkloadsOnNodeWithDatabase(database, "node-1")).toBe(1);
@@ -154,6 +157,7 @@ describe("app-container persistence transactions", () => {
   });
 
   test("running, failure, and deletion transitions preserve ownership and placement", async () => {
+    expect(await store.claimNodeSlot(SLOT_ID, ORG_ONE, "node-1")).toBe("claimed");
     await store.markRunning(SLOT_ID, {
       hostContainerId: "docker-1",
       hostPort: 31000,
@@ -161,6 +165,15 @@ describe("app-container persistence transactions", () => {
       nodeHost: "10.0.0.1",
     });
     await store.markError(SLOT_ID, "health check failed");
+    await store.markCleanupRequired(SLOT_ID, "docker absence unproven");
+    expect(await countAllocatedWorkloadsOnNodeWithDatabase(database, "node-1")).toBe(1);
+    expect(
+      (
+        await client.query<{ error_message: string; status: string }>(
+          `SELECT status, error_message FROM containers WHERE id='${SLOT_ID}'`,
+        )
+      ).rows,
+    ).toEqual([{ status: "cleanup_required", error_message: "docker absence unproven" }]);
     await store.markDeleted(SLOT_ID, ORG_ONE, "node-1");
 
     expect(statusUpdates).toContainEqual({ id: SLOT_ID, status: "running" });

--- a/packages/cloud/shared/src/lib/services/__tests__/app-container-store.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-container-store.test.ts
@@ -27,7 +27,9 @@ function row(overrides: Partial<ProjectableContainerRow> = {}): ProjectableConta
 
 describe("mapContainerRowToAppContainerRow", () => {
   test("projects columns and carries the per-tenant DSN through env vars", () => {
-    const r = mapContainerRowToAppContainerRow(row());
+    const r = mapContainerRowToAppContainerRow(
+      row({ metadata: { hostContainerId: "docker-immutable-1" } }),
+    );
     expect(r).toEqual({
       id: "c-1",
       appId: "app-id-123", // from project_name (no metadata.appId)
@@ -37,6 +39,7 @@ describe("mapContainerRowToAppContainerRow", () => {
       organizationId: "org-1",
       userId: "user-1",
       environmentVars: { DATABASE_URL: DSN, PORT: "3000" },
+      hostContainerId: "docker-immutable-1",
     });
   });
 

--- a/packages/cloud/shared/src/lib/services/__tests__/container-job-executors.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/container-job-executors.test.ts
@@ -19,6 +19,7 @@ const ROW: AppContainerRow = {
   organizationId: "org-1",
   userId: "user-1",
   environmentVars: { DATABASE_URL: "postgresql://app_x:pw@cluster1/db_app_x" },
+  hostContainerId: "docker-immutable-1",
 };
 
 function fakeStore(row: AppContainerRow | null = ROW) {
@@ -33,7 +34,7 @@ function fakeStore(row: AppContainerRow | null = ROW) {
     },
     async claimNodeSlot(_id, _organizationId, nodeId) {
       slotEvents.push({ op: "claim", nodeId });
-      return true;
+      return "claimed";
     },
     async rollbackNodeSlotClaim(_id, _organizationId, nodeId) {
       slotEvents.push({ op: "rollback", nodeId });
@@ -47,6 +48,9 @@ function fakeStore(row: AppContainerRow | null = ROW) {
     },
     async markError(id, error) {
       events.push({ op: "error", id, info: error });
+    },
+    async markCleanupRequired(id, error) {
+      events.push({ op: "cleanup-required", id, info: error });
     },
   };
   return { events, slotEvents, store };
@@ -68,6 +72,9 @@ function fakeProvider(over: Partial<Record<keyof AppContainerProvider, unknown>>
     },
     async delete(name: string) {
       calls.push({ op: "delete", arg: name });
+    },
+    async deleteById(hostContainerId: string, name: string) {
+      calls.push({ op: "deleteById", arg: { hostContainerId, name } });
     },
     async restart(name: string) {
       calls.push({ op: "restart", arg: name });
@@ -117,6 +124,20 @@ describe("executeContainerProvision", () => {
       },
     ]);
     expect(slotEvents).toEqual([{ op: "claim", nodeId: "node-1" }]);
+  });
+
+  test("a worker retry may continue only with the same idempotent slot claim", async () => {
+    const { events, store } = fakeStore();
+    store.claimNodeSlot = async () => "already-claimed";
+    const { calls, provider } = fakeProvider();
+
+    await executeContainerProvision(
+      job({ containerId: "container-1", organizationId: "org-1", userId: "user-1" }),
+      { provider, store },
+    );
+
+    expect(calls.some((call) => call.op === "provision")).toBe(true);
+    expect(events.some((event) => event.op === "running")).toBe(true);
   });
 
   test("flips the linked app to deployed on success (#5: deploy reaches READY)", async () => {
@@ -183,6 +204,38 @@ describe("executeContainerProvision", () => {
     ]);
   });
 
+  test("create or start failure with unproven removal retains the claimed slot", async () => {
+    const { events, slotEvents, store } = fakeStore();
+    let containerExists = false;
+    const { provider } = fakeProvider({
+      async provision() {
+        containerExists = true;
+        throw new Error("docker start failed");
+      },
+      async delete() {
+        expect(containerExists).toBe(true);
+        throw new Error("docker rm failed");
+      },
+    } as never);
+
+    await expect(
+      executeContainerProvision(
+        job({ containerId: "container-1", organizationId: "org-1", userId: "user-1" }),
+        { provider, store },
+      ),
+    ).rejects.toThrow("cleanup could not be proven");
+
+    expect(slotEvents).toEqual([{ op: "claim", nodeId: "node-1" }]);
+    expect(containerExists).toBe(true);
+    expect(events).toEqual([
+      {
+        op: "cleanup-required",
+        id: "container-1",
+        info: "docker start failed; Docker absence unproven: docker rm failed",
+      },
+    ]);
+  });
+
   test("capacity refusal never invokes Docker or fabricates a failed container", async () => {
     const { events, store } = fakeStore();
     store.claimNodeSlot = async () => {
@@ -224,7 +277,7 @@ describe("executeContainerProvision", () => {
   });
 
   test("failed Docker rollback keeps the slot claimed for retry reconciliation", async () => {
-    const { slotEvents, store } = fakeStore();
+    const { events, slotEvents, store } = fakeStore();
     store.markRunning = async () => {
       throw new Error("status write failed");
     };
@@ -239,9 +292,16 @@ describe("executeContainerProvision", () => {
         job({ containerId: "container-1", organizationId: "org-1", userId: "user-1" }),
         { provider, store },
       ),
-    ).rejects.toThrow("status write failed");
+    ).rejects.toThrow("cleanup could not be proven");
 
     expect(slotEvents).toEqual([{ op: "claim", nodeId: "node-1" }]);
+    expect(events).toEqual([
+      {
+        op: "cleanup-required",
+        id: "container-1",
+        info: "status write failed; Docker absence unproven: ssh unavailable",
+      },
+    ]);
   });
 
   test("throws when the container row is missing", async () => {
@@ -356,7 +416,10 @@ describe("executeContainerDelete / restart / logs", () => {
       provider,
       store,
     });
-    expect(calls.find((c) => c.op === "delete")?.arg).toBe("app-nubilio");
+    expect(calls.find((c) => c.op === "deleteById")?.arg).toEqual({
+      hostContainerId: "docker-immutable-1",
+      name: "app-nubilio",
+    });
     expect(events).toEqual([{ op: "deleted", id: "container-1" }]);
   });
 
@@ -382,7 +445,24 @@ describe("executeContainerDelete / restart / logs", () => {
       store,
     });
 
-    expect(calls.find((call) => call.op === "delete")?.arg).toBe("app-nubilio");
+    expect(calls.find((call) => call.op === "deleteById")?.arg).toEqual({
+      hostContainerId: "docker-immutable-1",
+      name: "app-nubilio",
+    });
+    expect(events).toEqual([{ op: "deleted", id: "container-1" }]);
+  });
+
+  test("legacy recovery never removes a newer live container through a reused name", async () => {
+    const staleDeletingRow = { ...ROW, hostContainerId: undefined };
+    const { events, store } = fakeStore(staleDeletingRow);
+    const { calls, provider } = fakeProvider();
+
+    await executeContainerDelete(job({ organizationId: "org-1" }), {
+      provider,
+      store,
+    });
+
+    expect(calls.filter((call) => call.op === "delete" || call.op === "deleteById")).toEqual([]);
     expect(events).toEqual([{ op: "deleted", id: "container-1" }]);
   });
 

--- a/packages/cloud/shared/src/lib/services/__tests__/container-job-service.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/container-job-service.test.ts
@@ -25,6 +25,7 @@ const ROW: AppContainerRow = {
   port: 3000,
   organizationId: "org-1",
   userId: "user-1",
+  hostContainerId: "docker-immutable-1",
 };
 
 function fakeDeps() {
@@ -37,7 +38,7 @@ function fakeDeps() {
       return [ROW];
     },
     async claimNodeSlot() {
-      return true;
+      return "claimed";
     },
     async rollbackNodeSlotClaim() {
       return true;
@@ -47,6 +48,7 @@ function fakeDeps() {
       calls.push("markDeleted");
     },
     async markError() {},
+    async markCleanupRequired() {},
   };
   const provider = {
     targetNodeId: "node-1",
@@ -61,6 +63,9 @@ function fakeDeps() {
       };
     },
     async delete() {
+      calls.push("delete");
+    },
+    async deleteById() {
       calls.push("delete");
     },
     async restart() {

--- a/packages/cloud/shared/src/lib/services/app-container-orphan-reconciler.test.ts
+++ b/packages/cloud/shared/src/lib/services/app-container-orphan-reconciler.test.ts
@@ -101,8 +101,8 @@ describe("computeOrphanContainersToReap (app diff)", () => {
     ]);
   });
 
-  test("does NOT reap deploying / building / pending rows", () => {
-    for (const status of ["deploying", "building", "pending"]) {
+  test("does NOT reap deploying, building, pending, or cleanup-required rows", () => {
+    for (const status of ["deploying", "building", "pending", "cleanup_required"]) {
       const orphans = compute([container("app-x", "cx")], [live("app-x", status)]);
       expect(orphans).toEqual([]);
     }

--- a/packages/cloud/shared/src/lib/services/app-container-orphan-reconciler.ts
+++ b/packages/cloud/shared/src/lib/services/app-container-orphan-reconciler.ts
@@ -4,6 +4,8 @@
  * protects them together while a missing or fully terminal row makes each
  * observed Docker ID reapable. Multiple deployment rows may share one name;
  * the generic reconciler therefore keeps the resources when any row is live.
+ * A `cleanup_required` row also remains live until a retry proves Docker
+ * absence, preserving the node-capacity claim across uncertain teardown.
  * Containers outside the `app-` namespace are never listed or touched.
  */
 
@@ -42,6 +44,9 @@ export const APP_CONTAINER_NAME_PREFIX = "app-";
  * `deleted` is the hard-terminal state. `deleting` is NOT included: a delete job
  * is actively in flight and owns the teardown; reaping under it would race the
  * worker (the exact mirror of the agent reconciler excluding `deletion_pending`).
+ * `cleanup_required` is also protected: it deliberately retains node capacity
+ * until a provision retry proves Docker absence or successfully replaces the
+ * deterministic container name.
  */
 const TERMINAL_CONTAINER_STATUSES = new Set<string>(["stopped", "failed", "deleted"]);
 

--- a/packages/cloud/shared/src/lib/services/app-container-provider.ts
+++ b/packages/cloud/shared/src/lib/services/app-container-provider.ts
@@ -11,6 +11,7 @@
  * scaffolding, no shared network, no NET_ADMIN.
  */
 
+import { ElizaError } from "@elizaos/core";
 import { logger } from "../utils/logger";
 import {
   ambassadorName,
@@ -102,6 +103,46 @@ export class AppContainerProvider {
     this.targetNodeId = deps.nodeId;
   }
 
+  private async removeContainerAndConfirmAbsent(containerName: string): Promise<void> {
+    try {
+      await this.deps.ssh.exec(`docker rm -f ${shellQuote(containerName)}`);
+      return;
+    } catch (removalError) {
+      // error-policy:J2 add Docker inspection context before rethrowing cleanup failure.
+      let inspectedId: string;
+      try {
+        inspectedId = await this.deps.ssh.exec(
+          `docker inspect --format '{{.Id}}' ${shellQuote(containerName)}`,
+        );
+      } catch (inspectionError) {
+        // error-policy:J2 preserve both removal and inspection failures as absence-proof context.
+        if (/no such (object|container)/i.test(describeAppContainerError(inspectionError))) {
+          return;
+        }
+        throw new ElizaError(`Could not prove Docker container ${containerName} is absent`, {
+          code: "APP_CONTAINER_ABSENCE_UNPROVEN",
+          context: {
+            containerName,
+            removalError: describeAppContainerError(removalError),
+            inspectionError: describeAppContainerError(inspectionError),
+          },
+          cause: inspectionError,
+          severity: "fatal",
+        });
+      }
+      throw new ElizaError(`Docker container ${containerName} remains after removal failed`, {
+        code: "APP_CONTAINER_REMOVAL_FAILED",
+        context: {
+          containerName,
+          containerId: inspectedId.trim(),
+          removalError: describeAppContainerError(removalError),
+        },
+        cause: removalError,
+        severity: "fatal",
+      });
+    }
+  }
+
   /** Ensure the per-app `--internal` network, create the container, start it. */
   async provision(params: ProvisionAppContainerParams): Promise<ProvisionedAppContainer> {
     const network = appNetworkName(params.appId);
@@ -166,35 +207,16 @@ export class AppContainerProvider {
       pidsLimit: this.deps.pidsLimit,
     });
 
-    // Best-effort pre-clean: a redeploy reuses the deterministic `app-<slug>`
+    // A redeploy reuses the deterministic `app-<slug>`
     // name, so a still-present container from a prior deploy makes `docker
     // create --name` fail with 'name already in use'. Remove it first (no-op when
     // absent). Mirrors `executeContainerUpgrade`/`provider.delete`; self-heals
     // regardless of which deploy route enqueued this provision.
-    await this.deps.ssh.exec(`docker rm -f ${shellQuote(params.containerName)}`).catch((error) => {
-      // error-policy:J6 best-effort teardown; a missing/stale container must not block the replacement create, but failed cleanup stays visible.
-      logger.warn("[AppContainerProvider] Failed to remove stale app container before create", {
-        appId: params.appId,
-        containerName: params.containerName,
-        error: describeAppContainerError(error),
-      });
-    });
+    await this.removeContainerAndConfirmAbsent(params.containerName);
 
     const stdout = await this.deps.ssh.exec(createCmd);
     const containerId = (this.deps.extractContainerId ?? defaultExtractContainerId)(stdout);
-    try {
-      await this.deps.ssh.exec(`docker start ${shellQuote(params.containerName)}`);
-    } catch (error) {
-      await this.delete(params.containerName).catch((cleanupError) => {
-        // error-policy:J6 failed-start cleanup is best-effort; the start failure still propagates to the slot rollback boundary.
-        logger.warn("[AppContainerProvider] Failed to remove container after start failure", {
-          appId: params.appId,
-          containerName: params.containerName,
-          error: describeAppContainerError(cleanupError),
-        });
-      });
-      throw error;
-    }
+    await this.deps.ssh.exec(`docker start ${shellQuote(params.containerName)}`);
 
     return {
       containerId,
@@ -206,8 +228,16 @@ export class AppContainerProvider {
   }
 
   async delete(containerName: string): Promise<void> {
-    await this.deps.ssh.exec(`docker rm -f ${shellQuote(containerName)}`);
+    await this.removeContainerAndConfirmAbsent(containerName);
     // Tear down the per-app DB ambassador too (best-effort; no-op if absent).
+    await this.deps.ssh.exec(buildRemoveAmbassadorCmdForContainer(containerName));
+  }
+
+  /** Remove one persisted Docker object without trusting its reusable app name. */
+  async deleteById(hostContainerId: string, containerName: string): Promise<void> {
+    await this.removeContainerAndConfirmAbsent(hostContainerId);
+    // The ambassador name derives from the stable app-container name, not the
+    // immutable Docker id of the primary container.
     await this.deps.ssh.exec(buildRemoveAmbassadorCmdForContainer(containerName));
   }
 

--- a/packages/cloud/shared/src/lib/services/app-container-store-queries.ts
+++ b/packages/cloud/shared/src/lib/services/app-container-store-queries.ts
@@ -39,6 +39,16 @@ export type AppContainerReadDatabase = Pick<typeof dbWrite, "select">;
 /** Minimum database surface required by atomic slot mutations. */
 export type AppContainerTransactionDatabase = Pick<typeof dbWrite, "transaction">;
 
+/** A slot reservation is either new or an idempotent retry of the same row. */
+export type AppContainerNodeSlotClaim = "claimed" | "already-claimed";
+
+export interface ExistingAppContainerNodeSlotClaim {
+  nodeId: string | null;
+  status: string;
+  slotClaimed: boolean;
+  slotReleased: boolean;
+}
+
 export async function findAppContainerRowById(
   database: AppContainerReadDatabase,
   containerId: string,
@@ -68,7 +78,8 @@ export function claimAppContainerNodeSlot(
   organizationId: string,
   nodeId: string,
   capacityError: () => Error,
-): Promise<boolean> {
+  conflictError: (existing: ExistingAppContainerNodeSlotClaim | null) => Error,
+): Promise<AppContainerNodeSlotClaim> {
   return database.transaction(async (tx) => {
     const [claimed] = await tx
       .update(containers)
@@ -87,7 +98,27 @@ export function claimAppContainerNodeSlot(
       )
       .returning({ id: containers.id });
 
-    if (!claimed) return false;
+    if (!claimed) {
+      const [existing] = await tx
+        .select({
+          nodeId: containers.node_id,
+          status: containers.status,
+          slotClaimed: sql<boolean>`jsonb_exists(coalesce(${containers.metadata}, '{}'::jsonb), 'slotClaimedAt')`,
+          slotReleased: sql<boolean>`jsonb_exists(coalesce(${containers.metadata}, '{}'::jsonb), 'slotReleasedAt')`,
+        })
+        .from(containers)
+        .where(and(eq(containers.id, containerId), eq(containers.organization_id, organizationId)))
+        .limit(1);
+      if (
+        existing?.nodeId === nodeId &&
+        existing.slotClaimed &&
+        !existing.slotReleased &&
+        existing.status !== "deleted"
+      ) {
+        return "already-claimed";
+      }
+      throw conflictError(existing ?? null);
+    }
 
     const [node] = await tx
       .update(dockerNodes)
@@ -107,7 +138,7 @@ export function claimAppContainerNodeSlot(
     // The exception rolls back both attribution and the claim marker. The caller
     // supplies its domain error so this SQL-only module stays runtime-independent.
     if (!node) throw capacityError();
-    return true;
+    return "claimed";
   });
 }
 

--- a/packages/cloud/shared/src/lib/services/app-container-store.ts
+++ b/packages/cloud/shared/src/lib/services/app-container-store.ts
@@ -10,6 +10,7 @@ import type { dbWrite } from "../../db/helpers";
 import type { containersRepository } from "../../db/repositories/containers";
 import { containers } from "../../db/schemas/containers";
 import {
+  type AppContainerNodeSlotClaim,
   type AppContainerReadDatabase,
   type AppContainerTransactionDatabase,
   claimAppContainerNodeSlot,
@@ -56,6 +57,8 @@ export interface ContainerRepoAppContainerStoreDeps {
 export function mapContainerRowToAppContainerRow(row: ProjectableContainerRow): AppContainerRow {
   const metaAppId =
     typeof row.metadata?.appId === "string" ? (row.metadata.appId as string) : undefined;
+  const hostContainerId =
+    typeof row.metadata?.hostContainerId === "string" ? row.metadata.hostContainerId : undefined;
   return {
     id: row.id,
     // project_name is set to the appId by the deploy orchestrator's
@@ -68,6 +71,7 @@ export function mapContainerRowToAppContainerRow(row: ProjectableContainerRow): 
     userId: row.user_id,
     environmentVars: row.environment_vars ?? undefined,
     nodeId: row.node_id ?? undefined,
+    hostContainerId,
   };
 }
 
@@ -116,7 +120,7 @@ export class ContainerRepoAppContainerStore implements AppContainerStore {
     containerId: string,
     organizationId: string,
     nodeId: string,
-  ): Promise<boolean> {
+  ): Promise<AppContainerNodeSlotClaim> {
     return claimAppContainerNodeSlot(
       this.deps.writeDatabase,
       containerId,
@@ -127,6 +131,12 @@ export class ContainerRepoAppContainerStore implements AppContainerStore {
           code: "APP_CONTAINER_NODE_CAPACITY_UNAVAILABLE",
           context: { containerId, organizationId, nodeId },
           severity: "ephemeral",
+        }),
+      (existing) =>
+        this.deps.errorFactory(`App container ${containerId} has a conflicting node-slot claim`, {
+          code: "APP_CONTAINER_NODE_SLOT_CONFLICT",
+          context: { containerId, organizationId, requestedNodeId: nodeId, existing },
+          severity: "fatal",
         }),
     );
   }
@@ -201,5 +211,12 @@ export class ContainerRepoAppContainerStore implements AppContainerStore {
 
   async markError(containerId: string, error: string): Promise<void> {
     await this.deps.repository.updateStatus(containerId, "failed", error);
+  }
+
+  async markCleanupRequired(containerId: string, error: string): Promise<void> {
+    await this.deps.writeDatabase
+      .update(containers)
+      .set({ status: "cleanup_required", error_message: error, updated_at: new Date() })
+      .where(eq(containers.id, containerId));
   }
 }

--- a/packages/cloud/shared/src/lib/services/container-job-executors.ts
+++ b/packages/cloud/shared/src/lib/services/container-job-executors.ts
@@ -13,6 +13,7 @@
 import { ElizaError } from "@elizaos/core";
 import { logger } from "../utils/logger";
 import type { AppContainerProvider } from "./app-container-provider";
+import type { AppContainerNodeSlotClaim } from "./app-container-store-queries";
 import { deriveAppPublicUrl } from "./app-url";
 import {
   isContainerDeleteJobData,
@@ -37,13 +38,19 @@ export interface AppContainerRow {
   /** Caller env incl. the app's per-tenant DATABASE_URL (never the shared one). */
   environmentVars?: Record<string, string>;
   nodeId?: string;
+  /** Immutable Docker id persisted when the row reached running. */
+  hostContainerId?: string;
 }
 
 /** Read/write seam for app container state (over the `containers` table). */
 export interface AppContainerStore {
   getById(containerId: string): Promise<AppContainerRow | null>;
   findDeletingByOrganization(organizationId: string): Promise<AppContainerRow[]>;
-  claimNodeSlot(containerId: string, organizationId: string, nodeId: string): Promise<boolean>;
+  claimNodeSlot(
+    containerId: string,
+    organizationId: string,
+    nodeId: string,
+  ): Promise<AppContainerNodeSlotClaim>;
   rollbackNodeSlotClaim(
     containerId: string,
     organizationId: string,
@@ -55,6 +62,7 @@ export interface AppContainerStore {
   ): Promise<void>;
   markDeleted(containerId: string, organizationId: string, nodeId?: string): Promise<void>;
   markError(containerId: string, error: string): Promise<void>;
+  markCleanupRequired(containerId: string, error: string): Promise<void>;
 }
 
 export interface ContainerExecutorDeps {
@@ -110,6 +118,57 @@ async function requireRow(store: AppContainerStore, containerId: string): Promis
   return row;
 }
 
+async function settleFailedProvision(
+  deps: ContainerExecutorDeps,
+  row: AppContainerRow,
+  containerId: string,
+  failure: unknown,
+): Promise<never> {
+  const nodeId = deps.provider.targetNodeId;
+  const failureMessage = failure instanceof Error ? failure.message : String(failure);
+  try {
+    await deps.provider.delete(row.containerName);
+  } catch (cleanupError) {
+    // error-policy:J2 retain the slot and add cleanup proof context to the provisioning failure.
+    const cleanupMessage =
+      cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
+    await deps.store.markCleanupRequired(
+      containerId,
+      `${failureMessage}; Docker absence unproven: ${cleanupMessage}`,
+    );
+    throw new ElizaError(
+      `App container ${containerId} provisioning failed and Docker cleanup could not be proven`,
+      {
+        code: "APP_CONTAINER_CLEANUP_UNPROVEN",
+        context: { containerId, nodeId, failure: failureMessage, cleanupError: cleanupMessage },
+        cause: cleanupError,
+        severity: "fatal",
+      },
+    );
+  }
+
+  const rolledBack = await deps.store.rollbackNodeSlotClaim(
+    containerId,
+    row.organizationId,
+    nodeId,
+  );
+  if (!rolledBack) {
+    await deps.store.markCleanupRequired(
+      containerId,
+      `${failureMessage}; Docker is absent but the node-slot claim could not be released`,
+    );
+    throw new ElizaError(`App container ${containerId} node-slot rollback was not applied`, {
+      code: "APP_CONTAINER_SLOT_ROLLBACK_UNAPPLIED",
+      context: { containerId, nodeId, failure: failureMessage },
+      cause: failure,
+      severity: "fatal",
+    });
+  }
+
+  await deps.store.markError(containerId, failureMessage);
+  throw failure;
+}
+
 export async function executeContainerProvision(
   job: JobLike,
   deps: ContainerExecutorDeps,
@@ -137,13 +196,8 @@ export async function executeContainerProvision(
       input,
     });
   } catch (error) {
-    await deps.store.rollbackNodeSlotClaim(
-      containerId,
-      row.organizationId,
-      deps.provider.targetNodeId,
-    );
-    await deps.store.markError(containerId, error instanceof Error ? error.message : String(error));
-    throw error;
+    // error-policy:J2 cleanup and slot-accounting context is added by settleFailedProvision.
+    return settleFailedProvision(deps, row, containerId, error);
   }
 
   try {
@@ -154,23 +208,8 @@ export async function executeContainerProvision(
       nodeHost: result.nodeHost,
     });
   } catch (error) {
-    try {
-      await deps.provider.delete(row.containerName);
-      await deps.store.rollbackNodeSlotClaim(
-        containerId,
-        row.organizationId,
-        deps.provider.targetNodeId,
-      );
-    } catch (cleanupError) {
-      // error-policy:J6 failed provision rollback remains visible and keeps its slot claimed until retry/reconciliation.
-      logger.error("[ContainerExecutor] failed to remove container after running-state write", {
-        containerId,
-        nodeId: result.nodeId,
-        error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
-      });
-    }
-    await deps.store.markError(containerId, error instanceof Error ? error.message : String(error));
-    throw error;
+    // error-policy:J2 cleanup and slot-accounting context is added by settleFailedProvision.
+    return settleFailedProvision(deps, row, containerId, error);
   }
 
   // POST-markRunning: the container IS running. Registering the ingress route +
@@ -276,18 +315,29 @@ export async function executeContainerDelete(
   }
 
   for (const { id, organizationId, row } of targets) {
-    if (row) {
+    if (row?.hostContainerId) {
       try {
-        await deps.provider.delete(row.containerName);
+        await deps.provider.deleteById(row.hostContainerId, row.containerName);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        if (!/no such container/i.test(message)) throw error;
-        // error-policy:J6 another teardown worker already removed the target; the terminal DB transition still must complete.
+        if (!/no such (object|container)/i.test(message)) throw error;
+        // error-policy:J6 another teardown worker already removed the immutable target; the terminal DB transition still must complete.
         logger.info("[ContainerExecutor] container already absent during delete", {
           containerId: id,
-          containerName: row.containerName,
+          hostContainerId: row.hostContainerId,
         });
       }
+    } else if (row) {
+      // A deterministic app name is reused by every deploy. An old deleting
+      // row without its immutable Docker id must never remove by name: that
+      // could kill a newer running row for the same app. Mark this stale row
+      // terminal and let the orphan reconciler remove any genuinely unowned
+      // Docker object by the immutable id it gets from `docker ps` (#15826).
+      logger.warn("[ContainerExecutor] skipping unsafe name-only container delete", {
+        containerId: id,
+        containerName: row.containerName,
+        organizationId,
+      });
     }
     // Remove the ingress route (best-effort; a reconciler sweeps any orphan).
     const endpoint = deriveAppPublicUrl(id);


### PR DESCRIPTION
Closes #15839.
Closes #15826.

App-container capacity is released only after Docker absence is proven. Provision retries may reuse the same authoritative claim, different claims conflict, cleanup failures persist cleanup_required and retain the slot, and deterministic pre-clean reconciles the retained claim on retry.

Deletion now targets the immutable Docker container ID persisted in placement metadata. Legacy rows without that ID never delete by a reusable shared name; they are marked stale so the orphan reconciler can remove the actual orphan by immutable Docker ID without risking a newly provisioned live container.

Verification with branch synchronized to develop f865c5d (focused lifecycle proof recorded on service-equivalent e5daa84):
- 79 focused provider, executor, store, recovery, service, and orphan-reconciler tests pass (192 assertions) with the source-export condition used by CI
- real Docker 29.6.1 shared-name proof confirms legacy recovery leaves the newly created live container untouched, then removes the intended target by immutable ID and confirms absence
- real Docker removal proof confirms successful absence and forced transport failure retains the live container with APP_CONTAINER_REMOVAL_FAILED
- cloud/shared typecheck passes
- Biome checks the changed source and tests
- error-policy ratchet and diff checks pass

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend container lifecycle only; no rendered surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend container lifecycle only; no rendered surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing UI flow changes.
<!-- evidence-row:backend-logs -->
- [x] Real Docker immutable-ID/shared-name race proof: https://github.com/elizaOS/eliza/releases/download/pr-evidence/15826-real-docker-delete-proof.log
- [x] Real Docker absence/failure proof: https://github.com/elizaOS/eliza/releases/download/pr-evidence/15869-real-docker-proof.log
- [x] Focused 78-test lifecycle proof: https://github.com/elizaOS/eliza/releases/download/pr-evidence/15869-lifecycle-proof-17a74e8.log
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network behavior changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, planner, action, provider, evaluator, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Immutable container IDs, confirmed absence, and retained live-container state are recorded in https://github.com/elizaOS/eliza/releases/download/pr-evidence/15826-real-docker-delete-proof.log and https://github.com/elizaOS/eliza/releases/download/pr-evidence/15869-real-docker-proof.log


