### PR TITLE
docs: add Removed Root Command Migrations rows for mvp:closeout-audit replacements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,9 @@ locking and linear probing so active lanes do not collide. See
 | `bun run personality:bench:calibrate` | `bun run bench:personality:calibrate` |
 | `bun run lint:all` | `bun run verify` |
 | `bun run build:typescript` | `node packages/scripts/run-turbo.mjs run build` |
+| `bun run audit:mvp-board` | `bun run mvp:closeout-audit` |
+| `bun run mvp:board-readiness` | `bun run mvp:closeout-audit` |
+| `bun run mvp:evidence-matrix` | `bun run mvp:closeout-audit` |
 
 ## Repo map — where to find what
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,9 @@ locking and linear probing so active lanes do not collide. See
 | `bun run personality:bench:calibrate` | `bun run bench:personality:calibrate` |
 | `bun run lint:all` | `bun run verify` |
 | `bun run build:typescript` | `node packages/scripts/run-turbo.mjs run build` |
+| `bun run audit:mvp-board` | `bun run mvp:closeout-audit` |
+| `bun run mvp:board-readiness` | `bun run mvp:closeout-audit` |
+| `bun run mvp:evidence-matrix` | `bun run mvp:closeout-audit` |
 
 ## Repo map — where to find what
 


### PR DESCRIPTION
Closes #15851

## Summary

PR #15763 removed three root commands — `audit:mvp-board`, `mvp:board-readiness`, `mvp:evidence-matrix` — replaced by `bun run mvp:closeout-audit`, but did not add rows to the root `CLAUDE.md` "Removed Root Command Migrations" table as every prior removal did. This PR adds the three migration rows and syncs the byte-identical `AGENTS.md`.

Replacement verified against root `package.json` (line 201): `"mvp:closeout-audit": "node packages/scripts/run-mvp-closeout-audit.mjs"` exists; none of the three removed script names remain anywhere in the repo (grep over `*.md`/`*.json` excluding `node_modules` hits only the new table rows).

## Verification

Docs-only change (two Markdown files); no install, build, or test lane applies.

```
$ grep -nE '"(audit:mvp-board|mvp:board-readiness|mvp:evidence-matrix|mvp:closeout-audit)"' package.json
201:    "mvp:closeout-audit": "node packages/scripts/run-mvp-closeout-audit.mjs",

$ cmp CLAUDE.md AGENTS.md && echo "IDENTICAL after edit"
IDENTICAL after edit
```

<details>
<summary>git diff (both files, identical hunks)</summary>

```diff
diff --git a/AGENTS.md b/AGENTS.md
index 03dbfa88cc..bd570c9177 100644
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,9 @@ locking and linear probing so active lanes do not collide. See
 | `bun run personality:bench:calibrate` | `bun run bench:personality:calibrate` |
 | `bun run lint:all` | `bun run verify` |
 | `bun run build:typescript` | `node packages/scripts/run-turbo.mjs run build` |
+| `bun run audit:mvp-board` | `bun run mvp:closeout-audit` |
+| `bun run mvp:board-readiness` | `bun run mvp:closeout-audit` |
+| `bun run mvp:evidence-matrix` | `bun run mvp:closeout-audit` |
 
 ## Repo map — where to find what
 
diff --git a/CLAUDE.md b/CLAUDE.md
index 03dbfa88cc..bd570c9177 100644
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,9 @@ locking and linear probing so active lanes do not collide. See
 | `bun run personality:bench:calibrate` | `bun run bench:personality:calibrate` |
 | `bun run lint:all` | `bun run verify` |
 | `bun run build:typescript` | `node packages/scripts/run-turbo.mjs run build` |
+| `bun run audit:mvp-board` | `bun run mvp:closeout-audit` |
+| `bun run mvp:board-readiness` | `bun run mvp:closeout-audit` |
+| `bun run mvp:evidence-matrix` | `bun run mvp:closeout-audit` |
 
 ## Repo map — where to find what
 
```

</details>

<details>
<summary>Repo-wide grep: no stale references to the removed commands remain</summary>

```
$ grep -rn --include='*.md' --include='*.json' -E 'audit:mvp-board|mvp:board-readiness|mvp:evidence-matrix' . \
    --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=.turbo
AGENTS.md:114:| `bun run audit:mvp-board` | `bun run mvp:closeout-audit` |
AGENTS.md:115:| `bun run mvp:board-readiness` | `bun run mvp:closeout-audit` |
AGENTS.md:116:| `bun run mvp:evidence-matrix` | `bun run mvp:closeout-audit` |
CLAUDE.md:114:| `bun run audit:mvp-board` | `bun run mvp:closeout-audit` |
CLAUDE.md:115:| `bun run mvp:board-readiness` | `bun run mvp:closeout-audit` |
CLAUDE.md:116:| `bun run mvp:evidence-matrix` | `bun run mvp:closeout-audit` |
```

</details>

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A — docs-only change, no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A — docs-only change, no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A — docs-only change, no user-exercisable flow.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A — no server code path touched; verification output (`cmp`, `grep`, `git diff`) is inline above.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A — no frontend code touched.
<!-- evidence-row:llm-trajectory -->
- [x] LLM trajectories: N/A — no agent/action/provider/prompt/model behavior change.
<!-- evidence-row:domain-artifacts -->
- [x] [files](https://github.com/elizaOS/eliza/pull/15870/files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
