### PR TITLE
feat(github): guided GitHub credential setup — device sign-in on the connection card

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ packages/ui/src/components/pages/__e2e__/output-connectors/
 packages/ui/src/components/pages/__e2e__/output-infinite-scroll/
 # Resize-handles e2e output (screenshots + html bundle — regenerate via the composites __e2e__ runner)
 packages/ui/src/components/composites/__e2e__/output-resize-handles/
+# GitHub connection card e2e output (screenshots + html bundle — regenerate via run-github-card-shot.mjs)
+plugins/plugin-task-coordinator/src/__e2e__/github-card-shots/
 # Divider-drag perf-gate output (webm + screenshots + html bundle — regenerate via test:divider-drag-perf-gate)
 packages/ui/src/components/composites/__e2e__/output-divider-perf/
 # Launcher gesture-loop e2e output (webm videos + html bundle + traces — regenerate via test:launcher-loop-e2e)

--- a/packages/docs/connectors/github.md
+++ b/packages/docs/connectors/github.md
@@ -22,6 +22,59 @@ The GitHub plugin is an elizaOS feature plugin that bridges your agent to the Gi
 
 - GitHub API token (personal access token, fine-grained token, or GitHub App credentials)
 
+## Guided credential setup (dashboard)
+
+The fastest path is the dashboard: **Settings → Coding Agents → GitHub**. The
+connection card offers two ways to connect, and either one makes every
+GitHub-touching capability (issue management, workspace push/PR, repo
+provisioning) work immediately — no restart, no manual env editing:
+
+1. **Sign in with GitHub (device flow)** — shown when the agent has a
+   `GITHUB_OAUTH_CLIENT_ID` setting. The card displays a short code, opens
+   `github.com/login/device`, and waits while you approve. The device code and
+   the granted token never pass through the browser.
+2. **Paste a personal access token** — always available. The card links to a
+   pre-filled token-generation page (`repo`, `read:user` scopes).
+
+Both paths validate the token against GitHub, persist it to the agent's local
+credential store (`<state-dir>/credentials/github.json`, mode 600), and apply
+it to the running agent's per-agent settings so `runtime.getSetting("GITHUB_TOKEN")`
+resolves right away.
+
+### PAT vs device sign-in
+
+| | Personal access token | Device sign-in (OAuth device flow) |
+|---|---|---|
+| Owner setup | none | register a GitHub OAuth app with **device flow enabled**, set `GITHUB_OAUTH_CLIENT_ID` |
+| User steps | create token on github.com, paste it | type a short code on github.com, click approve |
+| Scoping | you choose scopes/repos when creating the token (fine-grained tokens can be repo-allowlisted) | fixed `repo read:user` scope requested by the app |
+| Expiry | you set it at creation | GitHub OAuth app token policy |
+| Best for | single operator, precise scoping | fleets/kiosks where users shouldn't hand-build tokens |
+
+If a GitHub action fails with a credentials error mid-task, the error message
+points back at this card — connect there and retry the task.
+
+### Vault/settings vs environment variables
+
+Prefer per-agent settings (the dashboard card, the agent's vault/secrets, or
+`character.settings`) over process environment variables:
+
+- **Env leaks across agents.** On a multi-tenant host, `GITHUB_TOKEN` in the
+  process environment is visible to *every* agent in that process — one
+  agent's identity silently becomes everyone's.
+- **Settings are per-agent.** A token stored via the dashboard card or the
+  vault resolves through `runtime.getSetting("GITHUB_TOKEN")` for that agent
+  only, and survives restarts through the agent's own credential store.
+- Env still works for single-agent, single-operator installs and always wins
+  over the stored credential at boot (an explicit shell export overrides the
+  saved value).
+
+> **Cloud note:** which GitHub identity a cloud-provisioned agent should get
+> (per-agent bot account vs the owner's PAT vs a GitHub App installation) is a
+> policy decision that is still open — see issue #15796. Until then, cloud
+> agents use whatever token the operator connects via the card or the agent's
+> settings.
+
 ## Minimal Configuration
 
 ```json

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-github.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-github.ts
@@ -89,8 +89,10 @@ export async function ensureGitHubClient(
     | undefined;
   if (!clientId) {
     throw new Error(
-      "GitHub access required but no credentials available. " +
-        "Set GITHUB_TOKEN (PAT) or GITHUB_OAUTH_CLIENT_ID (for OAuth device flow).",
+      "GitHub access required but no credentials are configured. " +
+        "Connect GitHub in Settings → Coding Agents (paste a personal access token, " +
+        'or "Sign in with GitHub" when a GITHUB_OAUTH_CLIENT_ID is configured). ' +
+        "Alternatively set the GITHUB_TOKEN setting for this agent.",
     );
   }
 
@@ -141,7 +143,8 @@ export async function performOAuthFlow(
   if (!delivered) {
     throw new Error(
       "GitHub OAuth device flow requires an immediate chat delivery path before polling. " +
-        "Wire an authPromptCallback or set GITHUB_TOKEN.",
+        "Wire an authPromptCallback, connect GitHub in Settings → Coding Agents, " +
+        "or set the GITHUB_TOKEN setting.",
     );
   }
 

--- a/plugins/plugin-github/AGENTS.md
+++ b/plugins/plugin-github/AGENTS.md
@@ -4,7 +4,7 @@ GitHub integration for Eliza agents: pull request listing and review, issue life
 
 ## Purpose / role
 
-Adds GitHub capabilities to any Eliza agent. The plugin is opt-in — add `"@elizaos/plugin-github"` to the agent's plugin list. It registers a `GitHubService` (Octokit REST client pool), three exposed action handlers promoted under one umbrella `GITHUB` action, three API routes for PAT management, and a search category for PR lookup.
+Adds GitHub capabilities to any Eliza agent. The plugin is opt-in — add `"@elizaos/plugin-github"` to the agent's plugin list. It registers a `GitHubService` (Octokit REST client pool), three exposed action handlers promoted under one umbrella `GITHUB` action, five API routes for credential management (PAT paste + OAuth device sign-in — the guided setup step behind the Settings → Coding Agents GitHub card, #15796), and a search category for PR lookup.
 
 ## Plugin surface
 
@@ -33,9 +33,11 @@ Registered at plugin init on the agent's HTTP server:
 
 | Method | Path | Purpose |
 |---|---|---|
-| `GET` | `/api/github/token` | Returns `{ connected, username?, scopes?, savedAt? }` — token never returned |
-| `POST` | `/api/github/token` | Body `{ token }`. Validates against GitHub `/user`, persists to `<state-dir>/credentials/github.json` |
-| `DELETE` | `/api/github/token` | Clears saved credential |
+| `GET` | `/api/github/token` | Returns `{ connected, deviceFlowAvailable, username?, scopes?, savedAt? }` — token never returned |
+| `POST` | `/api/github/token` | Body `{ token }`. Validates against GitHub `/user`, persists to `<state-dir>/credentials/github.json`, applies to the live runtime's per-agent settings (`setSetting("GITHUB_TOKEN", …, true)`) |
+| `DELETE` | `/api/github/token` | Clears saved credential (disk + live runtime settings) |
+| `POST` | `/api/github/device/start` | Starts a GitHub OAuth device flow (needs the `GITHUB_OAUTH_CLIENT_ID` setting; 409 with an owner-setup message otherwise). Returns `{ flowId, userCode, verificationUri, intervalSeconds, expiresInSeconds }` — the GitHub `device_code` never leaves the server |
+| `POST` | `/api/github/device/poll` | Body `{ flowId }`. One poll: 200 `{ status: "pending" \| "denied" \| "expired" }` or, on grant, validates + persists like the PAT route and returns `{ status: "complete", …connected status }`. Flows are scoped to the agent that started them |
 
 ### Search category
 
@@ -56,6 +58,7 @@ src/
   action-helpers.ts            Shared: service lookup, client resolution, param helpers
   rate-limit.ts                Rate-limit detection and formatting
   github-credentials.ts        Local PAT store: load/save/clear at <state-dir>/credentials/github.json
+  device-flow.ts               GitHub OAuth device-flow state machine (start/poll; per-agent scoped; device_code stays server-side)
   search-category.ts           github_pull_requests search category registration
   connector-account-provider.ts  ConnectorAccountManager bridge (PAT + OAuth flows)
   connector-credential-refs.ts   Credential ref persistence helpers
@@ -91,7 +94,7 @@ bun run --cwd plugins/plugin-github clean       # rm dist .turbo
 | `GITHUB_AGENT_ACCOUNT_ID` | No | Override account ID for the legacy `agent` slot (default: `"agent"`) |
 | `ELIZA_E2E_GITHUB_USER_PAT` | No | E2E fallback for `GITHUB_USER_PAT` |
 | `ELIZA_E2E_GITHUB_AGENT_PAT` | No | E2E fallback for `GITHUB_AGENT_PAT` |
-| `GITHUB_OAUTH_CLIENT_ID` | OAuth only | GitHub OAuth app client ID |
+| `GITHUB_OAUTH_CLIENT_ID` | OAuth only | GitHub OAuth app client ID — also enables the device sign-in path on the settings card (`/api/github/device/*`) |
 | `GITHUB_OAUTH_CLIENT_SECRET` | OAuth only | GitHub OAuth app client secret |
 | `GITHUB_OAUTH_REDIRECT_URI` | OAuth only | OAuth redirect URI registered on the GitHub app |
 

--- a/plugins/plugin-github/CLAUDE.md
+++ b/plugins/plugin-github/CLAUDE.md
@@ -4,7 +4,7 @@ GitHub integration for Eliza agents: pull request listing and review, issue life
 
 ## Purpose / role
 
-Adds GitHub capabilities to any Eliza agent. The plugin is opt-in — add `"@elizaos/plugin-github"` to the agent's plugin list. It registers a `GitHubService` (Octokit REST client pool), three exposed action handlers promoted under one umbrella `GITHUB` action, three API routes for PAT management, and a search category for PR lookup.
+Adds GitHub capabilities to any Eliza agent. The plugin is opt-in — add `"@elizaos/plugin-github"` to the agent's plugin list. It registers a `GitHubService` (Octokit REST client pool), three exposed action handlers promoted under one umbrella `GITHUB` action, five API routes for credential management (PAT paste + OAuth device sign-in — the guided setup step behind the Settings → Coding Agents GitHub card, #15796), and a search category for PR lookup.
 
 ## Plugin surface
 
@@ -33,9 +33,11 @@ Registered at plugin init on the agent's HTTP server:
 
 | Method | Path | Purpose |
 |---|---|---|
-| `GET` | `/api/github/token` | Returns `{ connected, username?, scopes?, savedAt? }` — token never returned |
-| `POST` | `/api/github/token` | Body `{ token }`. Validates against GitHub `/user`, persists to `<state-dir>/credentials/github.json` |
-| `DELETE` | `/api/github/token` | Clears saved credential |
+| `GET` | `/api/github/token` | Returns `{ connected, deviceFlowAvailable, username?, scopes?, savedAt? }` — token never returned |
+| `POST` | `/api/github/token` | Body `{ token }`. Validates against GitHub `/user`, persists to `<state-dir>/credentials/github.json`, applies to the live runtime's per-agent settings (`setSetting("GITHUB_TOKEN", …, true)`) |
+| `DELETE` | `/api/github/token` | Clears saved credential (disk + live runtime settings) |
+| `POST` | `/api/github/device/start` | Starts a GitHub OAuth device flow (needs the `GITHUB_OAUTH_CLIENT_ID` setting; 409 with an owner-setup message otherwise). Returns `{ flowId, userCode, verificationUri, intervalSeconds, expiresInSeconds }` — the GitHub `device_code` never leaves the server |
+| `POST` | `/api/github/device/poll` | Body `{ flowId }`. One poll: 200 `{ status: "pending" \| "denied" \| "expired" }` or, on grant, validates + persists like the PAT route and returns `{ status: "complete", …connected status }`. Flows are scoped to the agent that started them |
 
 ### Search category
 
@@ -56,6 +58,7 @@ src/
   action-helpers.ts            Shared: service lookup, client resolution, param helpers
   rate-limit.ts                Rate-limit detection and formatting
   github-credentials.ts        Local PAT store: load/save/clear at <state-dir>/credentials/github.json
+  device-flow.ts               GitHub OAuth device-flow state machine (start/poll; per-agent scoped; device_code stays server-side)
   search-category.ts           github_pull_requests search category registration
   connector-account-provider.ts  ConnectorAccountManager bridge (PAT + OAuth flows)
   connector-credential-refs.ts   Credential ref persistence helpers
@@ -91,7 +94,7 @@ bun run --cwd plugins/plugin-github clean       # rm dist .turbo
 | `GITHUB_AGENT_ACCOUNT_ID` | No | Override account ID for the legacy `agent` slot (default: `"agent"`) |
 | `ELIZA_E2E_GITHUB_USER_PAT` | No | E2E fallback for `GITHUB_USER_PAT` |
 | `ELIZA_E2E_GITHUB_AGENT_PAT` | No | E2E fallback for `GITHUB_AGENT_PAT` |
-| `GITHUB_OAUTH_CLIENT_ID` | OAuth only | GitHub OAuth app client ID |
+| `GITHUB_OAUTH_CLIENT_ID` | OAuth only | GitHub OAuth app client ID — also enables the device sign-in path on the settings card (`/api/github/device/*`) |
 | `GITHUB_OAUTH_CLIENT_SECRET` | OAuth only | GitHub OAuth app client secret |
 | `GITHUB_OAUTH_REDIRECT_URI` | OAuth only | OAuth redirect URI registered on the GitHub app |
 

--- a/plugins/plugin-github/README.md
+++ b/plugins/plugin-github/README.md
@@ -67,13 +67,17 @@ All write operations require confirmation before they execute.
 
 ## HTTP routes
 
-The plugin registers three routes on the agent's server for PAT management:
+The plugin registers five routes on the agent's server for credential
+management — they power the guided GitHub connection card in Settings →
+Coding Agents (PAT paste or OAuth device sign-in):
 
 | Method | Path | Description |
 |---|---|---|
-| `GET` | `/api/github/token` | Returns connection status (token never exposed) |
-| `POST` | `/api/github/token` | Save a PAT (validated against GitHub `/user` before save) |
-| `DELETE` | `/api/github/token` | Remove the saved PAT |
+| `GET` | `/api/github/token` | Returns connection status incl. `deviceFlowAvailable` (token never exposed) |
+| `POST` | `/api/github/token` | Save a PAT (validated against GitHub `/user` before save; applied to the live runtime's per-agent settings) |
+| `DELETE` | `/api/github/token` | Remove the saved PAT (disk + live runtime) |
+| `POST` | `/api/github/device/start` | Start a GitHub OAuth device sign-in (needs `GITHUB_OAUTH_CLIENT_ID`); the device code never leaves the server |
+| `POST` | `/api/github/device/poll` | Poll a pending sign-in: `pending` / `denied` / `expired`, or validate + save the granted token |
 
 ## Development
 

--- a/plugins/plugin-github/src/action-helpers.ts
+++ b/plugins/plugin-github/src/action-helpers.ts
@@ -127,7 +127,7 @@ export function needsClientError(selection: GitHubAccountSelection): string {
   const accountSuffix = selection.accountId
     ? ` accountId "${selection.accountId}"`
     : ` ${selection.role} account`;
-  return `GitHub${accountSuffix} token not configured (set GITHUB_ACCOUNTS or ${
+  return `GitHub${accountSuffix} token not configured (connect GitHub in Settings → Coding Agents, or set GITHUB_ACCOUNTS or ${
     selection.role === "user" ? "GITHUB_USER_PAT" : "GITHUB_AGENT_PAT"
   })`;
 }

--- a/plugins/plugin-github/src/device-flow.test.ts
+++ b/plugins/plugin-github/src/device-flow.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Device-flow protocol unit tests (#15796). GitHub's two OAuth endpoints are
+ * the only thing stubbed — the flow logic under test (state machine, interval
+ * ownership, agent scoping, secret hygiene) is the real module.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  clearDeviceFlowsForTest,
+  DeviceFlowError,
+  pollDeviceFlow,
+  startDeviceFlow,
+} from "./device-flow.js";
+
+const DEVICE_CODE_URL = "https://github.com/login/device/code";
+const ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token";
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+interface RecordedRequest {
+  url: string;
+  body: string;
+}
+
+/** Scripted GitHub: first call answers device/code, later calls answer token polls. */
+function scriptedGitHub(tokenResponses: (() => Response)[]): {
+  fetchImpl: typeof fetch;
+  requests: RecordedRequest[];
+} {
+  const requests: RecordedRequest[] = [];
+  let tokenCall = 0;
+  const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : String(input);
+    requests.push({ url, body: String(init?.body ?? "") });
+    if (url === DEVICE_CODE_URL) {
+      return jsonResponse({
+        device_code: "secret-device-code",
+        user_code: "ABCD-EFGH",
+        verification_uri: "https://github.com/login/device",
+        expires_in: 900,
+        interval: 5,
+      });
+    }
+    if (url === ACCESS_TOKEN_URL) {
+      const next =
+        tokenResponses[Math.min(tokenCall, tokenResponses.length - 1)];
+      tokenCall += 1;
+      return next();
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  }) as typeof fetch;
+  return { fetchImpl, requests };
+}
+
+afterEach(() => clearDeviceFlowsForTest());
+
+describe("startDeviceFlow", () => {
+  it("keeps the device code server-side and returns only the user-visible half", async () => {
+    const { fetchImpl, requests } = scriptedGitHub([]);
+    const started = await startDeviceFlow({
+      clientId: "client-1",
+      agentKey: "agent-a",
+      deps: {
+        fetchImpl,
+        now: () => 1_000,
+        randomBytesImpl: (() => Buffer.from("opaque-flow-id")) as never,
+      },
+    });
+    expect(started).toEqual({
+      flowId: Buffer.from("opaque-flow-id").toString("base64url"),
+      userCode: "ABCD-EFGH",
+      verificationUri: "https://github.com/login/device",
+      intervalSeconds: 5,
+      expiresInSeconds: 900,
+    });
+    expect(JSON.stringify(started)).not.toContain("secret-device-code");
+    expect(requests[0].body).toContain("client_id=client-1");
+  });
+
+  it("maps a client-registration rejection to an owner-setup error (409)", async () => {
+    const fetchImpl = (async () =>
+      // GitHub answers 200 with an error body for an unknown client id.
+      jsonResponse({ error: "device_flow_disabled" })) as typeof fetch;
+    const err = await startDeviceFlow({
+      clientId: "bad-client",
+      agentKey: "agent-a",
+      deps: { fetchImpl },
+    }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(DeviceFlowError);
+    expect((err as DeviceFlowError).code).toBe("owner_setup");
+    expect((err as DeviceFlowError).status).toBe(409);
+  });
+
+  it("maps an unreachable GitHub to an upstream error (502)", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as typeof fetch;
+    const err = await startDeviceFlow({
+      clientId: "client-1",
+      agentKey: "agent-a",
+      deps: { fetchImpl },
+    }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(DeviceFlowError);
+    expect((err as DeviceFlowError).code).toBe("upstream");
+    expect((err as DeviceFlowError).status).toBe(502);
+  });
+
+  it("maps a malformed device-code response to an upstream error", async () => {
+    const fetchImpl = (async () =>
+      jsonResponse({
+        user_code: "ABCD",
+        verification_uri: "x",
+      })) as typeof fetch;
+    const err = await startDeviceFlow({
+      clientId: "client-1",
+      agentKey: "agent-a",
+      deps: { fetchImpl },
+    }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(DeviceFlowError);
+    expect((err as DeviceFlowError).code).toBe("upstream");
+  });
+});
+
+describe("pollDeviceFlow", () => {
+  it("walks pending → complete, sends the device code only to GitHub, and consumes the flow", async () => {
+    let nowMs = 1_000;
+    const { fetchImpl, requests } = scriptedGitHub([
+      () => jsonResponse({ error: "authorization_pending" }),
+      () =>
+        jsonResponse({
+          access_token: "gho_live_token_value",
+          token_type: "bearer",
+          scope: "repo,read:user",
+        }),
+    ]);
+    const started = await startDeviceFlow({
+      clientId: "client-1",
+      agentKey: "agent-a",
+      deps: { fetchImpl, now: () => nowMs },
+    });
+
+    const pending = await pollDeviceFlow({
+      flowId: started.flowId,
+      agentKey: "agent-a",
+      deps: { fetchImpl, now: () => nowMs },
+    });
+    expect(pending).toEqual({ status: "pending", retryAfterSeconds: 5 });
+
+    // Re-polling before the interval elapses never hits GitHub.
+    const early = await pollDeviceFlow({
+      flowId: started.flowId,
+      agentKey: "agent-a",
+      deps: { fetchImpl, now: () => nowMs + 1_000 },
+    });
+    expect(early.status).toBe("pending");
+    expect(requests.filter((r) => r.url === ACCESS_TOKEN_URL)).toHaveLength(1);
+
+    nowMs += 5_000;
+    const completed = await pollDeviceFlow({
+      flowId: started.flowId,
+      agentKey: "agent-a",
+      deps: { fetchImpl, now: () => nowMs },
+    });
+    expect(completed).toEqual({
+      status: "complete",
+      token: "gho_live_token_value",
+      scope: "repo,read:user",
+    });
+    const tokenPolls = requests.filter((r) => r.url === ACCESS_TOKEN_URL);
+    expect(tokenPolls[0].body).toContain("device_code=secret-device-code");
+
+    // The flow is consumed — a replayed poll cannot mint the token twice.
+    await expect(
+      pollDeviceFlow({
+        flowId: started.flowId,
+        agentKey: "agent-a",
+        deps: { fetchImpl, now: () => nowMs },
+      }),
+    ).rejects.toMatchObject({ code: "unknown_flow", status: 404 });
+  });
+
+  it("slow_down raises the server-owned polling interval", async () => {
+    let nowMs = 10_000;
+    const { fetchImpl, requests } = scriptedGitHub([
+      () => jsonResponse({ error: "slow_down" }),
+    ]);
+    const started = await startDeviceFlow({
+      clientId: "client-1",
+      agentKey: "agent-a",
+      deps: { fetchImpl, now: () => nowMs },
+    });
+    const slowed = await pollDeviceFlow({
+      flowId: started.flowId,
+      agentKey: "agent-a",
+      deps: { fetchImpl, now: () => nowMs },
+    });
+    expect(slowed).toEqual({ status: "pending", retryAfterSeconds: 10 });
+
+    // The raised interval is enforced server-side: an eager client re-polling
+    // 1s later is throttled locally without a GitHub request.
+    nowMs += 1_000;
+    const throttled = await pollDeviceFlow({
+      flowId: started.flowId,
+      agentKey: "agent-a",
+      deps: { fetchImpl, now: () => nowMs },
+    });
+    expect(throttled).toEqual({ status: "pending", retryAfterSeconds: 9 });
+    expect(requests.filter((r) => r.url === ACCESS_TOKEN_URL)).toHaveLength(1);
+  });
+
+  it("access_denied resolves as a terminal denied outcome", async () => {
+    const { fetchImpl } = scriptedGitHub([
+      () => jsonResponse({ error: "access_denied" }),
+    ]);
+    const started = await startDeviceFlow({
+      clientId: "client-1",
+      agentKey: "agent-a",
+      deps: { fetchImpl, now: () => 0 },
+    });
+    const denied = await pollDeviceFlow({
+      flowId: started.flowId,
+      agentKey: "agent-a",
+      deps: { fetchImpl, now: () => 0 },
+    });
+    expect(denied).toEqual({ status: "denied" });
+    await expect(
+      pollDeviceFlow({
+        flowId: started.flowId,
+        agentKey: "agent-a",
+        deps: { fetchImpl, now: () => 0 },
+      }),
+    ).rejects.toMatchObject({ code: "unknown_flow" });
+  });
+
+  it("expired_token resolves as a terminal expired outcome", async () => {
+    const { fetchImpl } = scriptedGitHub([
+      () => jsonResponse({ error: "expired_token" }),
+    ]);
+    const started = await startDeviceFlow({
+      clientId: "client-1",
+      agentKey: "agent-a",
+      deps: { fetchImpl, now: () => 0 },
+    });
+    const expired = await pollDeviceFlow({
+      flowId: started.flowId,
+      agentKey: "agent-a",
+      deps: { fetchImpl, now: () => 0 },
+    });
+    expect(expired).toEqual({ status: "expired" });
+  });
+
+  it("sweeps a flow whose ten-minute window lapsed before any grant", async () => {
+    const { fetchImpl } = scriptedGitHub([]);
+    const started = await startDeviceFlow({
+      clientId: "client-1",
+      agentKey: "agent-a",
+      deps: { fetchImpl, now: () => 0 },
+    });
+    // 900s window from the stubbed device-code response.
+    await expect(
+      pollDeviceFlow({
+        flowId: started.flowId,
+        agentKey: "agent-a",
+        deps: { fetchImpl, now: () => 900_001 },
+      }),
+    ).rejects.toMatchObject({ code: "unknown_flow", status: 404 });
+  });
+
+  it("scopes flows per agent: another agent's key cannot poll the flow", async () => {
+    const { fetchImpl, requests } = scriptedGitHub([
+      () => jsonResponse({ access_token: "gho_stolen", scope: "" }),
+    ]);
+    const started = await startDeviceFlow({
+      clientId: "client-1",
+      agentKey: "agent-a",
+      deps: { fetchImpl, now: () => 0 },
+    });
+    await expect(
+      pollDeviceFlow({
+        flowId: started.flowId,
+        agentKey: "agent-b",
+        deps: { fetchImpl, now: () => 0 },
+      }),
+    ).rejects.toMatchObject({ code: "unknown_flow", status: 404 });
+    // The cross-agent probe never reached GitHub.
+    expect(requests.filter((r) => r.url === ACCESS_TOKEN_URL)).toHaveLength(0);
+
+    // The rightful owner still completes.
+    const completed = await pollDeviceFlow({
+      flowId: started.flowId,
+      agentKey: "agent-a",
+      deps: { fetchImpl, now: () => 0 },
+    });
+    expect(completed.status).toBe("complete");
+  });
+
+  it("maps an unrecognized GitHub error code to a terminal upstream error", async () => {
+    const { fetchImpl } = scriptedGitHub([
+      () => jsonResponse({ error: "mystery_failure" }),
+    ]);
+    const started = await startDeviceFlow({
+      clientId: "client-1",
+      agentKey: "agent-a",
+      deps: { fetchImpl, now: () => 0 },
+    });
+    await expect(
+      pollDeviceFlow({
+        flowId: started.flowId,
+        agentKey: "agent-a",
+        deps: { fetchImpl, now: () => 0 },
+      }),
+    ).rejects.toMatchObject({ code: "upstream", status: 502 });
+  });
+});

--- a/plugins/plugin-github/src/device-flow.ts
+++ b/plugins/plugin-github/src/device-flow.ts
@@ -1,0 +1,334 @@
+/**
+ * GitHub OAuth device-flow state for the guided GitHub connection step
+ * (Settings → Coding Agents → GitHub).
+ *
+ * Port of the #15749 lifeops-dashboard primitive
+ * (`scripts/lifeops/github-device-login.mjs`) into the plugin route surface,
+ * with one addition: every flow is bound to the agent that started it
+ * (`agentKey`), so on a multi-agent host one agent's runtime can never poll —
+ * and therefore never receive the token of — a flow another agent started.
+ *
+ * Security posture (same as #15749):
+ *   - The browser receives only the short `user_code` and an opaque local
+ *     `flowId`; the `device_code` GitHub polls against stays in server memory
+ *     until the flow completes or expires.
+ *   - Network access is injectable so protocol behavior (pending, slow_down,
+ *     denied, expired) is covered deterministically without contacting GitHub.
+ */
+
+import { randomBytes } from "node:crypto";
+
+const DEVICE_CODE_URL = "https://github.com/login/device/code";
+const ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token";
+/** Matches the scopes the PAT card asks the user to grant a generated token. */
+const DEFAULT_SCOPE = "repo read:user";
+
+/** Error taxonomy for the routes: each code maps to one HTTP status. */
+export type DeviceFlowErrorCode =
+  /** flowId is not pending for this agent (never started, expired + swept, or another agent's). */
+  | "unknown_flow"
+  /** The OAuth app registration itself is wrong or device flow is disabled — owner setup. */
+  | "owner_setup"
+  /** GitHub was unreachable or returned a malformed/unexpected response. */
+  | "upstream";
+
+export class DeviceFlowError extends Error {
+  constructor(
+    message: string,
+    readonly code: DeviceFlowErrorCode,
+    /** HTTP status the route surfaces for this failure class. */
+    readonly status: number,
+    options?: { cause?: unknown },
+  ) {
+    super(message, options);
+    this.name = "DeviceFlowError";
+  }
+}
+
+export interface DeviceFlowStart {
+  /** Opaque server-local flow handle — NOT the GitHub device_code. */
+  flowId: string;
+  /** Short code the user types at the verification URI. */
+  userCode: string;
+  verificationUri: string;
+  intervalSeconds: number;
+  expiresInSeconds: number;
+}
+
+export type DeviceFlowPollResult =
+  /** User has not approved yet (or the server-owned interval hasn't elapsed). */
+  | { status: "pending"; retryAfterSeconds: number }
+  /** User approved; token granted. Flow is consumed. */
+  | { status: "complete"; token: string; scope: string }
+  /** User explicitly denied the request. Flow is consumed. */
+  | { status: "denied" }
+  /** The device code expired before the user approved. Flow is consumed. */
+  | { status: "expired" };
+
+interface PendingFlow {
+  agentKey: string;
+  clientId: string;
+  deviceCode: string;
+  intervalSeconds: number;
+  nextPollAtMs: number;
+  expiresAtMs: number;
+}
+
+const pendingFlows = new Map<string, PendingFlow>();
+
+interface FlowDeps {
+  fetchImpl?: typeof fetch;
+  now?: () => number;
+  randomBytesImpl?: typeof randomBytes;
+}
+
+function positiveNumber(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : fallback;
+}
+
+function requireString(
+  payload: Record<string, unknown>,
+  key: string,
+  label: string,
+): string {
+  const value = payload[key];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new DeviceFlowError(
+      `${label} response is missing ${key}`,
+      "upstream",
+      502,
+    );
+  }
+  return value.trim();
+}
+
+async function postForm(
+  url: string,
+  form: Record<string, string>,
+  label: string,
+  fetchImpl: typeof fetch,
+): Promise<Record<string, unknown>> {
+  let response: Response;
+  try {
+    response = await fetchImpl(url, {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams(form).toString(),
+    });
+  } catch (err) {
+    // error-policy:J2 context-adding rethrow — a network failure reaching
+    // GitHub is an upstream-reachability problem, typed 502 with the cause.
+    throw new DeviceFlowError(
+      `${label} failed: could not reach GitHub`,
+      "upstream",
+      502,
+      { cause: err },
+    );
+  }
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (err) {
+    throw new DeviceFlowError(
+      `${label} returned invalid JSON (HTTP ${response.status})`,
+      "upstream",
+      502,
+      { cause: err },
+    );
+  }
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new DeviceFlowError(
+      `${label} returned a non-object body (HTTP ${response.status})`,
+      "upstream",
+      502,
+    );
+  }
+  const record = payload as Record<string, unknown>;
+  if (!response.ok) {
+    const providerError =
+      typeof record.error === "string" ? ` (${record.error})` : "";
+    throw new DeviceFlowError(
+      `${label} failed: HTTP ${response.status}${providerError}`,
+      "upstream",
+      502,
+    );
+  }
+  return record;
+}
+
+function sweepExpired(nowMs: number): void {
+  for (const [flowId, flow] of pendingFlows) {
+    if (nowMs >= flow.expiresAtMs) pendingFlows.delete(flowId);
+  }
+}
+
+/**
+ * Start a device flow: ask GitHub for a device+user code pair, keep the
+ * device code server-side, and hand back the user-visible half.
+ */
+export async function startDeviceFlow(options: {
+  clientId: string;
+  /** Identity of the agent runtime that owns this flow (agentId). */
+  agentKey: string;
+  deps?: FlowDeps;
+}): Promise<DeviceFlowStart> {
+  const { clientId, agentKey, deps } = options;
+  const fetchImpl = deps?.fetchImpl ?? fetch;
+  const now = deps?.now ?? Date.now;
+  const randomBytesImpl = deps?.randomBytesImpl ?? randomBytes;
+
+  const payload = await postForm(
+    DEVICE_CODE_URL,
+    { client_id: clientId.trim(), scope: DEFAULT_SCOPE },
+    "GitHub device-code request",
+    fetchImpl,
+  );
+  // GitHub returns 200 for a bad/unregistered client id with an error body.
+  if (typeof payload.error === "string") {
+    throw new DeviceFlowError(
+      `GitHub rejected the device-flow client registration (${payload.error}). ` +
+        "Check GITHUB_OAUTH_CLIENT_ID and that the OAuth app has device flow enabled.",
+      "owner_setup",
+      409,
+    );
+  }
+  const deviceCode = requireString(
+    payload,
+    "device_code",
+    "GitHub device-code",
+  );
+  const userCode = requireString(payload, "user_code", "GitHub device-code");
+  const verificationUri = requireString(
+    payload,
+    "verification_uri",
+    "GitHub device-code",
+  );
+  const intervalSeconds = positiveNumber(payload.interval, 5);
+  const expiresInSeconds = positiveNumber(payload.expires_in, 900);
+
+  const nowMs = now();
+  sweepExpired(nowMs);
+  const flowId = randomBytesImpl(24).toString("base64url");
+  pendingFlows.set(flowId, {
+    agentKey,
+    clientId: clientId.trim(),
+    deviceCode,
+    intervalSeconds,
+    nextPollAtMs: nowMs,
+    expiresAtMs: nowMs + expiresInSeconds * 1_000,
+  });
+  return {
+    flowId,
+    userCode,
+    verificationUri,
+    intervalSeconds,
+    expiresInSeconds,
+  };
+}
+
+/**
+ * Poll a pending flow once. Honors GitHub's server-owned polling interval
+ * (early polls return `pending` without touching the network) and the
+ * `slow_down` back-off. Terminal outcomes (`complete`, `denied`, `expired`)
+ * consume the flow.
+ */
+export async function pollDeviceFlow(options: {
+  flowId: string;
+  /** Must match the agentKey the flow was started with. */
+  agentKey: string;
+  deps?: FlowDeps;
+}): Promise<DeviceFlowPollResult> {
+  const { flowId, agentKey, deps } = options;
+  const fetchImpl = deps?.fetchImpl ?? fetch;
+  const now = deps?.now ?? Date.now;
+
+  const nowMs = now();
+  sweepExpired(nowMs);
+  const flow = pendingFlows.get(flowId);
+  // A flow owned by a different agent is reported exactly like a flow that
+  // never existed — no oracle for other agents' pending flows.
+  if (!flow || flow.agentKey !== agentKey) {
+    throw new DeviceFlowError(
+      "GitHub sign-in flow is unknown or expired. Start a new sign-in.",
+      "unknown_flow",
+      404,
+    );
+  }
+  if (nowMs < flow.nextPollAtMs) {
+    return {
+      status: "pending",
+      retryAfterSeconds: Math.max(
+        1,
+        Math.ceil((flow.nextPollAtMs - nowMs) / 1_000),
+      ),
+    };
+  }
+  flow.nextPollAtMs = nowMs + flow.intervalSeconds * 1_000;
+
+  const payload = await postForm(
+    ACCESS_TOKEN_URL,
+    {
+      client_id: flow.clientId,
+      device_code: flow.deviceCode,
+      grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+    },
+    "GitHub device-token request",
+    fetchImpl,
+  );
+
+  if (
+    typeof payload.access_token === "string" &&
+    payload.access_token.length > 0
+  ) {
+    pendingFlows.delete(flowId);
+    return {
+      status: "complete",
+      token: payload.access_token,
+      scope: typeof payload.scope === "string" ? payload.scope : "",
+    };
+  }
+  const errorCode = typeof payload.error === "string" ? payload.error : "";
+  if (errorCode === "authorization_pending") {
+    return { status: "pending", retryAfterSeconds: flow.intervalSeconds };
+  }
+  if (errorCode === "slow_down") {
+    flow.intervalSeconds += 5;
+    flow.nextPollAtMs = nowMs + flow.intervalSeconds * 1_000;
+    return { status: "pending", retryAfterSeconds: flow.intervalSeconds };
+  }
+  // Every remaining GitHub error is terminal for this flow.
+  pendingFlows.delete(flowId);
+  if (errorCode === "access_denied") {
+    return { status: "denied" };
+  }
+  if (errorCode === "expired_token") {
+    return { status: "expired" };
+  }
+  if (
+    errorCode === "incorrect_client_credentials" ||
+    errorCode === "device_flow_disabled" ||
+    errorCode === "unsupported_grant_type"
+  ) {
+    throw new DeviceFlowError(
+      `GitHub rejected the device-flow client registration (${errorCode}). ` +
+        "Check GITHUB_OAUTH_CLIENT_ID and that the OAuth app has device flow enabled.",
+      "owner_setup",
+      409,
+    );
+  }
+  throw new DeviceFlowError(
+    `GitHub device sign-in failed: ${errorCode || "unknown_error"}`,
+    "upstream",
+    502,
+  );
+}
+
+/** Test hook: drop all pending flows so suites are order-independent. */
+export function clearDeviceFlowsForTest(): void {
+  pendingFlows.clear();
+}

--- a/plugins/plugin-github/src/device-routes-e2e.test.ts
+++ b/plugins/plugin-github/src/device-routes-e2e.test.ts
@@ -1,0 +1,544 @@
+/**
+ * Route-level e2e for the GitHub device sign-in setup step (#15796).
+ *
+ * Boots the plugin's declared device-flow routes (`POST
+ * /api/github/device/start|poll`) plus the token status route through the real
+ * production dispatcher (`tryHandleRuntimePluginRoute`) over a loopback
+ * `http.createServer` — exercising the real auth gate, the dispatcher's JSON
+ * body pre-parse, and handler dispatch. Only GitHub's two OAuth endpoints and
+ * `/user` are stubbed (the thing under test is our flow logic, not GitHub's
+ * server); everything else — flow state, credential persistence, per-agent
+ * runtime settings — is real.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import type http from "node:http";
+import http_ from "node:http";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { IAgentRuntime, Route } from "@elizaos/core";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
+
+// Pin the credential store to an isolated temp dir BEFORE importing any module
+// that resolves the state dir, so the real `loadMetadata`/`saveCredentials`/
+// `clearCredentials` operate on throwaway disk state.
+const stateDir = mkdtempSync(path.join(tmpdir(), "gh-device-e2e-"));
+const priorStateDir = process.env.ELIZA_STATE_DIR;
+process.env.ELIZA_STATE_DIR = stateDir;
+
+const { tryHandleRuntimePluginRoute } = await import(
+  "../../../packages/agent/src/api/runtime-plugin-routes.ts"
+);
+const { handleGitHubRoutes } = await import("./routes/github-routes.ts");
+const { clearDeviceFlowsForTest } = await import("./device-flow.ts");
+const { clearCredentials, loadMetadata } = await import(
+  "./github-credentials.ts"
+);
+
+/**
+ * Mirror the plugin's route wiring from src/index.ts exactly — including the
+ * runtime-derived context (agent scoping, per-agent oauth client id
+ * resolution, and live-runtime token apply/clear). Importing the full plugin
+ * object instead would drag in the entire (unrelated) action graph; the route
+ * declaration + adapter is what we exercise.
+ */
+function createGitHubRouteHandler(method: "GET" | "POST" | "DELETE") {
+  return async (
+    req: unknown,
+    res: unknown,
+    runtime: unknown,
+  ): Promise<void> => {
+    const httpReq = req as http.IncomingMessage;
+    const httpRes = res as http.ServerResponse;
+    const url = new URL(httpReq.url ?? "/api/github/token", "http://localhost");
+    const agentRuntime = runtime as IAgentRuntime;
+    await handleGitHubRoutes({
+      req: httpReq,
+      res: httpRes,
+      method,
+      pathname: url.pathname,
+      agentKey: String(agentRuntime.agentId),
+      getOauthClientId: () => {
+        const clientId = agentRuntime.getSetting("GITHUB_OAUTH_CLIENT_ID");
+        return typeof clientId === "string" ? clientId : undefined;
+      },
+      applyRuntimeToken: (token) =>
+        agentRuntime.setSetting("GITHUB_TOKEN", token, true),
+      clearRuntimeToken: () => {
+        const secrets = agentRuntime.character.secrets;
+        if (secrets && "GITHUB_TOKEN" in secrets) delete secrets.GITHUB_TOKEN;
+      },
+    });
+  };
+}
+
+const githubRoutes: Route[] = [
+  {
+    type: "GET",
+    path: "/api/github/token",
+    rawPath: true,
+    handler: createGitHubRouteHandler("GET"),
+  },
+  {
+    type: "POST",
+    path: "/api/github/token",
+    rawPath: true,
+    handler: createGitHubRouteHandler("POST"),
+  },
+  {
+    type: "DELETE",
+    path: "/api/github/token",
+    rawPath: true,
+    handler: createGitHubRouteHandler("DELETE"),
+  },
+  {
+    type: "POST",
+    path: "/api/github/device/start",
+    rawPath: true,
+    handler: createGitHubRouteHandler("POST"),
+  },
+  {
+    type: "POST",
+    path: "/api/github/device/poll",
+    rawPath: true,
+    handler: createGitHubRouteHandler("POST"),
+  },
+];
+
+/** Per-test runtime stub: a real settings map per agent, nothing shared. */
+function makeRuntime(options: {
+  agentId: string;
+  oauthClientId?: string;
+}): IAgentRuntime & { secrets: Record<string, string> } {
+  const secrets: Record<string, string> = {};
+  return {
+    agentId: options.agentId,
+    routes: githubRoutes,
+    character: { name: "test", secrets },
+    secrets,
+    getSetting: (key: string) => {
+      if (key === "GITHUB_OAUTH_CLIENT_ID")
+        return options.oauthClientId ?? null;
+      return secrets[key] ?? null;
+    },
+    setSetting: (
+      key: string,
+      value: string | boolean | null,
+      _secret?: boolean,
+    ) => {
+      if (value !== null && value !== undefined) secrets[key] = String(value);
+    },
+    getService: () => null,
+  } as unknown as IAgentRuntime & { secrets: Record<string, string> };
+}
+
+const servers: http.Server[] = [];
+const realFetch = globalThis.fetch;
+
+async function startServer(
+  runtime: IAgentRuntime,
+  isAuthorized: () => boolean = () => true,
+): Promise<string> {
+  const server = http_.createServer(async (req, res) => {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    const handled = await tryHandleRuntimePluginRoute({
+      req,
+      res,
+      method: req.method ?? "GET",
+      pathname: url.pathname,
+      url,
+      runtime,
+      isAuthorized,
+    });
+    if (!handled && !res.headersSent) {
+      res.statusCode = 404;
+      res.end("not found");
+    }
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  return `http://127.0.0.1:${port}`;
+}
+
+const DEVICE_CODE_URL = "https://github.com/login/device/code";
+const ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token";
+const USER_URL = "https://api.github.com/user";
+
+interface GitHubStubScript {
+  deviceCode?: () => Response;
+  token?: () => Response;
+  user?: () => Response;
+}
+
+/**
+ * Stub ONLY GitHub's endpoints on the global fetch; every other request
+ * (including the test client's own loopback calls) uses the real fetch.
+ */
+function stubGitHub(script: GitHubStubScript): { calls: string[] } {
+  const calls: string[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const target = typeof input === "string" ? input : String(input);
+    if (target === DEVICE_CODE_URL && script.deviceCode) {
+      calls.push(target);
+      return script.deviceCode();
+    }
+    if (target === ACCESS_TOKEN_URL && script.token) {
+      calls.push(target);
+      return script.token();
+    }
+    if (target === USER_URL && script.user) {
+      calls.push(target);
+      return script.user();
+    }
+    return realFetch(input, init);
+  }) as typeof fetch;
+  return { calls };
+}
+
+function jsonResponse(
+  payload: unknown,
+  status = 200,
+  headers?: Record<string, string>,
+): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json", ...headers },
+  });
+}
+
+function deviceCodeOk(): Response {
+  return jsonResponse({
+    device_code: "secret-device-code",
+    user_code: "ABCD-EFGH",
+    verification_uri: "https://github.com/login/device",
+    expires_in: 900,
+    interval: 5,
+  });
+}
+
+/**
+ * JSON POST via real fetch. The dispatcher pre-reads `application/json`
+ * bodies and hands the parsed object to the handler — this is the exact
+ * request shape the dashboard card sends.
+ */
+async function postJson(
+  base: string,
+  pathName: string,
+  body: unknown,
+): Promise<{ status: number; json: Record<string, unknown> }> {
+  const res = await realFetch(`${base}${pathName}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return {
+    status: res.status,
+    json: (await res.json()) as Record<string, unknown>,
+  };
+}
+
+afterEach(async () => {
+  globalThis.fetch = realFetch;
+  clearDeviceFlowsForTest();
+  await clearCredentials();
+  await Promise.all(
+    servers.map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.closeAllConnections?.();
+          server.close(() => resolve());
+        }),
+    ),
+  );
+  servers.length = 0;
+});
+
+afterAll(() => {
+  if (priorStateDir === undefined) delete process.env.ELIZA_STATE_DIR;
+  else process.env.ELIZA_STATE_DIR = priorStateDir;
+  rmSync(stateDir, { recursive: true, force: true });
+});
+
+describe("github device sign-in routes (real dispatch)", () => {
+  it("enforces the auth gate on both device routes", async () => {
+    const base = await startServer(
+      makeRuntime({ agentId: "agent-a", oauthClientId: "client-1" }),
+      () => false,
+    );
+    const start = await postJson(base, "/api/github/device/start", {});
+    expect(start.status).toBe(401);
+    const poll = await postJson(base, "/api/github/device/poll", {
+      flowId: "x",
+    });
+    expect(poll.status).toBe(401);
+  });
+
+  it("reports deviceFlowAvailable on the status route from the per-agent setting", async () => {
+    const withClient = await startServer(
+      makeRuntime({ agentId: "agent-a", oauthClientId: "client-1" }),
+    );
+    const withRes = (await (
+      await realFetch(`${withClient}/api/github/token`)
+    ).json()) as {
+      connected: boolean;
+      deviceFlowAvailable: boolean;
+    };
+    expect(withRes).toMatchObject({
+      connected: false,
+      deviceFlowAvailable: true,
+    });
+
+    const withoutClient = await startServer(
+      makeRuntime({ agentId: "agent-b" }),
+    );
+    const withoutRes = (await (
+      await realFetch(`${withoutClient}/api/github/token`)
+    ).json()) as { deviceFlowAvailable: boolean };
+    expect(withoutRes.deviceFlowAvailable).toBe(false);
+  });
+
+  it("start without an oauth client id is an explicit owner-setup 409 that names the fix", async () => {
+    const base = await startServer(makeRuntime({ agentId: "agent-a" }));
+    const res = await postJson(base, "/api/github/device/start", {});
+    expect(res.status).toBe(409);
+    const error = res.json.error as string;
+    expect(error).toContain("GITHUB_OAUTH_CLIENT_ID");
+    expect(error.toLowerCase()).toContain("personal access token");
+  });
+
+  it("runs the guided flow end to end: start → pending → grant → validated, persisted, applied per-agent", async () => {
+    const runtime = makeRuntime({
+      agentId: "agent-a",
+      oauthClientId: "client-1",
+    });
+    const base = await startServer(runtime);
+
+    let tokenPolls = 0;
+    stubGitHub({
+      deviceCode: deviceCodeOk,
+      token: () => {
+        tokenPolls += 1;
+        return tokenPolls === 1
+          ? jsonResponse({ error: "authorization_pending" })
+          : jsonResponse({
+              access_token: "gho_device_grant",
+              token_type: "bearer",
+              scope: "repo,read:user",
+            });
+      },
+      user: () =>
+        jsonResponse({ login: "octocat" }, 200, {
+          "x-oauth-scopes": "repo, read:user",
+        }),
+    });
+
+    const started = await postJson(base, "/api/github/device/start", {});
+    expect(started.status).toBe(200);
+    expect(started.json).toMatchObject({
+      status: "started",
+      userCode: "ABCD-EFGH",
+      verificationUri: "https://github.com/login/device",
+      intervalSeconds: 5,
+    });
+    const flowId = started.json.flowId as string;
+    expect(flowId.length).toBeGreaterThan(10);
+    // The GitHub-side device code never crosses to the browser.
+    expect(JSON.stringify(started.json)).not.toContain("secret-device-code");
+
+    const pending = await postJson(base, "/api/github/device/poll", { flowId });
+    expect(pending.status).toBe(200);
+    expect(pending.json).toMatchObject({ status: "pending" });
+    expect(typeof pending.json.retryAfterSeconds).toBe("number");
+
+    // GitHub's polling interval is owned server-side; jump past it by waiting
+    // out the recorded nextPollAt via repeated polls with real time is slow,
+    // so poll again after the interval the server reported — the flow store
+    // uses wall-clock time. Interval is 5s; instead of sleeping, poll through
+    // the throttle: an early poll stays pending and never contacts GitHub.
+    const early = await postJson(base, "/api/github/device/poll", { flowId });
+    expect(early.json.status).toBe("pending");
+    expect(tokenPolls).toBe(1);
+
+    // Now legitimately elapse the interval (short real wait is unavoidable
+    // without poking module internals; 5s is the GitHub-mandated minimum).
+    await new Promise((resolve) => setTimeout(resolve, 5_100));
+
+    const completed = await postJson(base, "/api/github/device/poll", {
+      flowId,
+    });
+    expect(completed.status).toBe(200);
+    expect(completed.json).toMatchObject({
+      status: "complete",
+      connected: true,
+      deviceFlowAvailable: true,
+      username: "octocat",
+      scopes: ["repo", "read:user"],
+    });
+    // The granted token is never returned to the browser…
+    expect(JSON.stringify(completed.json)).not.toContain("gho_device_grant");
+    // …but it really landed on disk through the real save path…
+    expect(await loadMetadata()).toMatchObject({ username: "octocat" });
+    // …and in THIS runtime's per-agent settings (not process.env).
+    expect(runtime.secrets.GITHUB_TOKEN).toBe("gho_device_grant");
+    expect(process.env.GITHUB_TOKEN ?? "").not.toBe("gho_device_grant");
+
+    // Status route now reports connected.
+    const status = (await (
+      await realFetch(`${base}/api/github/token`)
+    ).json()) as {
+      connected: boolean;
+      username: string;
+    };
+    expect(status.connected).toBe(true);
+    expect(status.username).toBe("octocat");
+  }, 30_000);
+
+  it("a denied grant resolves to a terminal denied outcome and persists nothing", async () => {
+    const runtime = makeRuntime({
+      agentId: "agent-a",
+      oauthClientId: "client-1",
+    });
+    const base = await startServer(runtime);
+    stubGitHub({
+      deviceCode: deviceCodeOk,
+      token: () => jsonResponse({ error: "access_denied" }),
+    });
+    const started = await postJson(base, "/api/github/device/start", {});
+    const denied = await postJson(base, "/api/github/device/poll", {
+      flowId: started.json.flowId,
+    });
+    expect(denied.status).toBe(200);
+    expect(denied.json).toEqual({ status: "denied" });
+    expect(await loadMetadata()).toBeNull();
+    expect(runtime.secrets.GITHUB_TOKEN).toBeUndefined();
+  });
+
+  it("an expired grant resolves to a terminal expired outcome", async () => {
+    const base = await startServer(
+      makeRuntime({ agentId: "agent-a", oauthClientId: "client-1" }),
+    );
+    stubGitHub({
+      deviceCode: deviceCodeOk,
+      token: () => jsonResponse({ error: "expired_token" }),
+    });
+    const started = await postJson(base, "/api/github/device/start", {});
+    const expired = await postJson(base, "/api/github/device/poll", {
+      flowId: started.json.flowId,
+    });
+    expect(expired.status).toBe(200);
+    expect(expired.json).toEqual({ status: "expired" });
+  });
+
+  it("rejects a poll with a missing flowId (400) and an unknown flowId (404)", async () => {
+    const base = await startServer(
+      makeRuntime({ agentId: "agent-a", oauthClientId: "client-1" }),
+    );
+    const missing = await postJson(base, "/api/github/device/poll", {});
+    expect(missing.status).toBe(400);
+    expect(missing.json.error).toContain("flowId");
+
+    const unknown = await postJson(base, "/api/github/device/poll", {
+      flowId: "never-started",
+    });
+    expect(unknown.status).toBe(404);
+  });
+
+  it("scopes flows per agent: agent B's runtime cannot poll agent A's flow", async () => {
+    const runtimeA = makeRuntime({
+      agentId: "agent-a",
+      oauthClientId: "client-1",
+    });
+    const runtimeB = makeRuntime({
+      agentId: "agent-b",
+      oauthClientId: "client-1",
+    });
+    const baseA = await startServer(runtimeA);
+    const baseB = await startServer(runtimeB);
+    stubGitHub({
+      deviceCode: deviceCodeOk,
+      token: () => jsonResponse({ access_token: "gho_cross", scope: "" }),
+    });
+
+    const started = await postJson(baseA, "/api/github/device/start", {});
+    const hijack = await postJson(baseB, "/api/github/device/poll", {
+      flowId: started.json.flowId,
+    });
+    expect(hijack.status).toBe(404);
+    expect(runtimeB.secrets.GITHUB_TOKEN).toBeUndefined();
+  });
+
+  it("a GitHub-side registration failure at start surfaces as owner-setup 409", async () => {
+    const base = await startServer(
+      makeRuntime({ agentId: "agent-a", oauthClientId: "client-1" }),
+    );
+    stubGitHub({
+      deviceCode: () => jsonResponse({ error: "device_flow_disabled" }),
+    });
+    const res = await postJson(base, "/api/github/device/start", {});
+    expect(res.status).toBe(409);
+    expect(res.json.error).toContain("device_flow_disabled");
+  });
+
+  it("an unreachable GitHub at start surfaces as upstream 502", async () => {
+    const base = await startServer(
+      makeRuntime({ agentId: "agent-a", oauthClientId: "client-1" }),
+    );
+    globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      const target = typeof input === "string" ? input : String(input);
+      if (target === DEVICE_CODE_URL) throw new Error("ECONNREFUSED");
+      return realFetch(input, init);
+    }) as typeof fetch;
+    const res = await postJson(base, "/api/github/device/start", {});
+    expect(res.status).toBe(502);
+  });
+
+  it("a grant whose token GitHub then rejects at /user is surfaced, and nothing persists", async () => {
+    const runtime = makeRuntime({
+      agentId: "agent-a",
+      oauthClientId: "client-1",
+    });
+    const base = await startServer(runtime);
+    stubGitHub({
+      deviceCode: deviceCodeOk,
+      token: () => jsonResponse({ access_token: "gho_revoked", scope: "" }),
+      user: () => jsonResponse({ message: "Bad credentials" }, 401),
+    });
+    const started = await postJson(base, "/api/github/device/start", {});
+    const res = await postJson(base, "/api/github/device/poll", {
+      flowId: started.json.flowId,
+    });
+    expect(res.status).toBe(400);
+    expect(await loadMetadata()).toBeNull();
+    expect(runtime.secrets.GITHUB_TOKEN).toBeUndefined();
+  });
+
+  it("PAT paste (application/json, the dashboard card's shape) validates, persists, and applies per-agent", async () => {
+    const runtime = makeRuntime({ agentId: "agent-a" });
+    const base = await startServer(runtime);
+    stubGitHub({
+      user: () =>
+        jsonResponse({ login: "octocat" }, 200, {
+          "x-oauth-scopes": "repo, read:user",
+        }),
+    });
+    const res = await postJson(base, "/api/github/token", {
+      token: "ghp_pasted",
+    });
+    expect(res.status).toBe(200);
+    expect(res.json).toMatchObject({ connected: true, username: "octocat" });
+    expect(runtime.secrets.GITHUB_TOKEN).toBe("ghp_pasted");
+
+    // DELETE disconnects the live runtime too, not just the disk record.
+    const del = await realFetch(`${base}/api/github/token`, {
+      method: "DELETE",
+    });
+    expect(del.status).toBe(200);
+    expect(await loadMetadata()).toBeNull();
+    expect(runtime.secrets.GITHUB_TOKEN).toBeUndefined();
+  });
+});

--- a/plugins/plugin-github/src/index.ts
+++ b/plugins/plugin-github/src/index.ts
@@ -30,6 +30,31 @@ import { handleGitHubRoutes } from "./routes/github-routes.js";
 import { registerGitHubSearchCategory } from "./search-category.js";
 import { GitHubService } from "./services/github-service.js";
 
+/**
+ * Remove the GitHub token from the live runtime's per-agent settings.
+ * `runtime.setSetting` has no delete form (null values are ignored by
+ * design), so disconnect clears the two per-agent records `getSetting`
+ * consults: `character.secrets` and `character.settings.secrets`.
+ */
+function clearRuntimeGitHubToken(runtime: IAgentRuntime): void {
+  const secrets = runtime.character.secrets;
+  if (secrets && "GITHUB_TOKEN" in secrets) {
+    delete secrets.GITHUB_TOKEN;
+  }
+  const settings = runtime.character.settings;
+  const nestedSecrets =
+    settings &&
+    typeof settings === "object" &&
+    "secrets" in settings &&
+    typeof settings.secrets === "object" &&
+    settings.secrets !== null
+      ? (settings.secrets as Record<string, unknown>)
+      : undefined;
+  if (nestedSecrets && "GITHUB_TOKEN" in nestedSecrets) {
+    delete nestedSecrets.GITHUB_TOKEN;
+  }
+}
+
 function createGitHubRouteHandler(method: "GET" | "POST" | "DELETE") {
   return async (
     req: unknown,
@@ -39,12 +64,25 @@ function createGitHubRouteHandler(method: "GET" | "POST" | "DELETE") {
     const httpReq = req as http.IncomingMessage;
     const httpRes = res as http.ServerResponse;
     const url = new URL(httpReq.url ?? "/api/github/token", "http://localhost");
-    void runtime;
+    const agentRuntime = runtime as IAgentRuntime;
     await handleGitHubRoutes({
       req: httpReq,
       res: httpRes,
       method,
       pathname: url.pathname,
+      // Device flows are scoped to the agent that started them.
+      agentKey: String(agentRuntime.agentId),
+      getOauthClientId: () => {
+        const clientId = agentRuntime.getSetting("GITHUB_OAUTH_CLIENT_ID");
+        return typeof clientId === "string" ? clientId : undefined;
+      },
+      // Per-agent settings (character.secrets), NOT process.env — env would
+      // leak the token to every agent on a multi-tenant host. The on-disk
+      // credential record still re-applies at next boot via
+      // `applySavedTokenToEnv` for gh/git subprocess inheritance.
+      applyRuntimeToken: (token) =>
+        agentRuntime.setSetting("GITHUB_TOKEN", token, true),
+      clearRuntimeToken: () => clearRuntimeGitHubToken(agentRuntime),
     });
   };
 }
@@ -80,6 +118,18 @@ const githubRoutes: Route[] = [
     path: "/api/github/token",
     rawPath: true,
     handler: createGitHubRouteHandler("DELETE"),
+  },
+  {
+    type: "POST",
+    path: "/api/github/device/start",
+    rawPath: true,
+    handler: createGitHubRouteHandler("POST"),
+  },
+  {
+    type: "POST",
+    path: "/api/github/device/poll",
+    rawPath: true,
+    handler: createGitHubRouteHandler("POST"),
   },
 ];
 

--- a/plugins/plugin-github/src/routes/github-routes.ts
+++ b/plugins/plugin-github/src/routes/github-routes.ts
@@ -1,25 +1,42 @@
 /**
- * GitHub PAT routes — power the "GitHub" connection card in Settings →
- * Coding Agents and surface the same token to the orchestrator's
- * sub-agent spawn env.
+ * GitHub credential routes — power the "GitHub" connection card in Settings →
+ * Coding Agents (the guided credential setup step, #15796) and surface the
+ * same token to the orchestrator's sub-agent spawn env.
  *
  * Exposes:
- *   GET    /api/github/token   — `{ connected: bool, username?, scopes?, savedAt? }`.
- *                                 Token itself is never returned.
+ *   GET    /api/github/token   — `{ connected: bool, deviceFlowAvailable: bool,
+ *                                 username?, scopes?, savedAt? }`. Token itself
+ *                                 is never returned.
  *   POST   /api/github/token   — body `{ token }`. Validates by calling
  *                                 GitHub's `/user` endpoint, then persists
- *                                 the credential record to disk.
- *   DELETE /api/github/token   — clears the saved credential and returns
- *                                 `{ connected: false }`.
+ *                                 the credential record to disk and applies it
+ *                                 to the live runtime's per-agent settings.
+ *   DELETE /api/github/token   — clears the saved credential (disk + live
+ *                                 runtime) and returns `{ connected: false }`.
+ *   POST   /api/github/device/start — starts a GitHub OAuth device flow
+ *                                 (requires the `GITHUB_OAUTH_CLIENT_ID`
+ *                                 setting). Returns the user code + opaque
+ *                                 flow id; the device code stays server-side.
+ *   POST   /api/github/device/poll  — body `{ flowId }`. Polls the flow once:
+ *                                 `pending` / `denied` / `expired`, or on
+ *                                 approval validates + persists the token the
+ *                                 same way the PAT route does and returns the
+ *                                 connected status.
  *
- * `handleGitHubRoutes` is the pure dispatcher — no auth, no runtime deps.
- * The runtime adapter (`createGitHubRouteHandler`) lives in index.ts where
- * it can import the heavier app-core auth surface without polluting this
- * module's import graph (and breaking tests that only need the pure handler).
+ * `handleGitHubRoutes` is the pure dispatcher — no auth, no runtime deps
+ * beyond the injectable `GitHubRouteContext` callbacks. The runtime adapter
+ * (`createGitHubRouteHandler`) lives in index.ts where it can import the
+ * heavier app-core auth surface without polluting this module's import graph
+ * (and breaking tests that only need the pure handler).
  */
 
 import type http from "node:http";
 import { logger } from "@elizaos/core";
+import {
+  DeviceFlowError,
+  pollDeviceFlow,
+  startDeviceFlow,
+} from "../device-flow.js";
 import {
   buildCredentialsFromUserResponse,
   clearCredentials,
@@ -35,6 +52,14 @@ const MAX_BODY_BYTES = 8 * 1024;
 async function readJsonBody(
   req: http.IncomingMessage,
 ): Promise<Record<string, unknown> | null> {
+  // The canonical runtime-plugin dispatcher pre-reads `application/json`
+  // bodies and attaches the parsed object as `req.body` (the raw stream is
+  // already consumed by then). Prefer it when present; fall back to reading
+  // the stream for dispatch paths that leave the body untouched.
+  const preParsed = (req as http.IncomingMessage & { body?: unknown }).body;
+  if (preParsed && typeof preParsed === "object" && !Array.isArray(preParsed)) {
+    return preParsed as Record<string, unknown>;
+  }
   const chunks: Buffer[] = [];
   let total = 0;
   for await (const chunk of req) {
@@ -67,10 +92,33 @@ export interface GitHubRouteContext {
   /** Inject for tests. Defaults to the global `fetch`. */
   fetch?: typeof fetch;
   json?: (status: number, body: unknown) => void;
+  /**
+   * Identity of the agent runtime serving this request. Device flows are
+   * bound to it so one agent can never poll (and receive the token of) a
+   * flow another agent started on the same host.
+   */
+  agentKey?: string;
+  /**
+   * Resolve the `GITHUB_OAUTH_CLIENT_ID` setting for this agent
+   * (`runtime.getSetting` in production). Absent/empty means the owner has
+   * not registered a device-flow-enabled OAuth app — the PAT path still works.
+   */
+  getOauthClientId?: () => string | undefined;
+  /**
+   * Apply a freshly validated token to the live runtime's per-agent settings
+   * (`runtime.setSetting("GITHUB_TOKEN", token, true)` in production) so
+   * GitHub capabilities work immediately, without a restart and without
+   * writing process env (which would leak to every agent on the host).
+   */
+  applyRuntimeToken?: (token: string) => void;
+  /** Remove the token from the live runtime's per-agent settings. */
+  clearRuntimeToken?: () => void;
 }
 
 interface TokenStatusResponse {
   connected: boolean;
+  /** True when `GITHUB_OAUTH_CLIENT_ID` is configured for this agent. */
+  deviceFlowAvailable: boolean;
   username?: string;
   scopes?: string[];
   savedAt?: number;
@@ -99,12 +147,19 @@ function sendJson(
   ctx.res.end(JSON.stringify(body));
 }
 
+function resolveOauthClientId(ctx: GitHubRouteContext): string {
+  const clientId = ctx.getOauthClientId?.();
+  return typeof clientId === "string" ? clientId.trim() : "";
+}
+
 function metadataToStatus(
   metadata: GitHubCredentialMetadata | null,
+  deviceFlowAvailable: boolean,
 ): TokenStatusResponse {
-  if (!metadata) return { connected: false };
+  if (!metadata) return { connected: false, deviceFlowAvailable };
   return {
     connected: true,
+    deviceFlowAvailable,
     username: metadata.username,
     scopes: metadata.scopes,
     savedAt: metadata.savedAt,
@@ -208,18 +263,25 @@ async function validateToken(
 
 async function handleGetToken(ctx: GitHubRouteContext): Promise<boolean> {
   const metadata = await loadMetadata();
-  sendJson(ctx, 200, metadataToStatus(metadata));
+  sendJson(
+    ctx,
+    200,
+    metadataToStatus(metadata, resolveOauthClientId(ctx).length > 0),
+  );
   return true;
 }
 
-async function handlePostToken(ctx: GitHubRouteContext): Promise<boolean> {
-  const body = await readJsonBody(ctx.req);
-  const token = body && typeof body.token === "string" ? body.token.trim() : "";
-  if (token.length === 0) {
-    sendJson(ctx, 400, { error: "Missing `token` in request body." });
-    return true;
-  }
-
+/**
+ * Shared tail of both credential intake paths (PAT paste and device-flow
+ * grant): validate against GitHub `/user`, persist the record, and apply the
+ * token to the live runtime's per-agent settings. Sends the error response
+ * itself and returns `null` when validation fails.
+ */
+async function validatePersistAndApply(
+  ctx: GitHubRouteContext,
+  token: string,
+  source: "pat" | "device-flow",
+): Promise<TokenStatusResponse | null> {
   const fetchImpl = ctx.fetch ?? fetch;
   let validated: Awaited<ReturnType<typeof validateToken>>;
   try {
@@ -232,10 +294,10 @@ async function handlePostToken(ctx: GitHubRouteContext): Promise<boolean> {
     const status = err instanceof TokenValidationError ? err.status : 500;
     const message = err instanceof Error ? err.message : String(err);
     logger.warn(
-      `[github-routes] token validation failed (${status}): ${message}`,
+      `[github-routes] token validation failed (${status}, source=${source}): ${message}`,
     );
     sendJson(ctx, status, { error: message });
-    return true;
+    return null;
   }
 
   const credentials = buildCredentialsFromUserResponse(
@@ -244,17 +306,109 @@ async function handlePostToken(ctx: GitHubRouteContext): Promise<boolean> {
     validated.scopes,
   );
   await saveCredentials(credentials);
+  ctx.applyRuntimeToken?.(token);
   logger.info(
-    `[github-routes] saved github token for @${validated.user.login} (scopes=${validated.scopes.join(",") || "(none)"})`,
+    `[github-routes] saved github token for @${validated.user.login} (source=${source}, scopes=${validated.scopes.join(",") || "(none)"})`,
   );
-  sendJson(ctx, 200, metadataToStatus(credentials));
+  return metadataToStatus(credentials, resolveOauthClientId(ctx).length > 0);
+}
+
+async function handlePostToken(ctx: GitHubRouteContext): Promise<boolean> {
+  const body = await readJsonBody(ctx.req);
+  const token = body && typeof body.token === "string" ? body.token.trim() : "";
+  if (token.length === 0) {
+    sendJson(ctx, 400, { error: "Missing `token` in request body." });
+    return true;
+  }
+  const status = await validatePersistAndApply(ctx, token, "pat");
+  if (status) sendJson(ctx, 200, status);
   return true;
 }
 
 async function handleDeleteToken(ctx: GitHubRouteContext): Promise<boolean> {
   await clearCredentials();
+  ctx.clearRuntimeToken?.();
   logger.info("[github-routes] cleared saved github token");
-  sendJson(ctx, 200, { connected: false });
+  sendJson(ctx, 200, {
+    connected: false,
+    deviceFlowAvailable: resolveOauthClientId(ctx).length > 0,
+  });
+  return true;
+}
+
+async function handleDeviceStart(ctx: GitHubRouteContext): Promise<boolean> {
+  const clientId = resolveOauthClientId(ctx);
+  if (clientId.length === 0) {
+    sendJson(ctx, 409, {
+      error:
+        "GitHub device sign-in needs owner setup: no GITHUB_OAUTH_CLIENT_ID setting " +
+        "is configured (register a GitHub OAuth app with device flow enabled). " +
+        "You can still connect by pasting a personal access token.",
+    });
+    return true;
+  }
+  try {
+    const started = await startDeviceFlow({
+      clientId,
+      agentKey: ctx.agentKey ?? "",
+      deps: ctx.fetch ? { fetchImpl: ctx.fetch } : undefined,
+    });
+    logger.info(
+      `[github-routes] started github device sign-in (interval=${started.intervalSeconds}s, expires=${started.expiresInSeconds}s)`,
+    );
+    sendJson(ctx, 200, { status: "started", ...started });
+  } catch (err) {
+    const status = err instanceof DeviceFlowError ? err.status : 500;
+    const message = err instanceof Error ? err.message : String(err);
+    logger.warn(
+      `[github-routes] github device sign-in start failed (${status}): ${message}`,
+    );
+    sendJson(ctx, status, { error: message });
+  }
+  return true;
+}
+
+async function handleDevicePoll(ctx: GitHubRouteContext): Promise<boolean> {
+  const body = await readJsonBody(ctx.req);
+  const flowId =
+    body && typeof body.flowId === "string" ? body.flowId.trim() : "";
+  if (flowId.length === 0) {
+    sendJson(ctx, 400, { error: "Missing `flowId` in request body." });
+    return true;
+  }
+  let result: Awaited<ReturnType<typeof pollDeviceFlow>>;
+  try {
+    result = await pollDeviceFlow({
+      flowId,
+      agentKey: ctx.agentKey ?? "",
+      deps: ctx.fetch ? { fetchImpl: ctx.fetch } : undefined,
+    });
+  } catch (err) {
+    const status = err instanceof DeviceFlowError ? err.status : 500;
+    const message = err instanceof Error ? err.message : String(err);
+    logger.warn(
+      `[github-routes] github device sign-in poll failed (${status}): ${message}`,
+    );
+    sendJson(ctx, status, { error: message });
+    return true;
+  }
+  if (result.status !== "complete") {
+    // pending / denied / expired are protocol outcomes, not transport errors —
+    // the polling client switches on `status`.
+    if (result.status !== "pending") {
+      logger.info(
+        `[github-routes] github device sign-in ended without a grant (${result.status})`,
+      );
+    }
+    sendJson(ctx, 200, result);
+    return true;
+  }
+  const status = await validatePersistAndApply(
+    ctx,
+    result.token,
+    "device-flow",
+  );
+  if (status) sendJson(ctx, 200, { status: "complete", ...status });
   return true;
 }
 
@@ -265,6 +419,20 @@ async function handleDeleteToken(ctx: GitHubRouteContext): Promise<boolean> {
 export async function handleGitHubRoutes(
   ctx: GitHubRouteContext,
 ): Promise<boolean> {
+  if (ctx.pathname === "/api/github/device/start") {
+    if (ctx.method !== "POST") {
+      sendJson(ctx, 405, { error: "Method not allowed" });
+      return true;
+    }
+    return handleDeviceStart(ctx);
+  }
+  if (ctx.pathname === "/api/github/device/poll") {
+    if (ctx.method !== "POST") {
+      sendJson(ctx, 405, { error: "Method not allowed" });
+      return true;
+    }
+    return handleDevicePoll(ctx);
+  }
   if (ctx.pathname !== "/api/github/token") return false;
   switch (ctx.method) {
     case "GET":

--- a/plugins/plugin-task-coordinator/AGENTS.md
+++ b/plugins/plugin-task-coordinator/AGENTS.md
@@ -78,7 +78,7 @@ src/
   GlobalPrefsSection.tsx           Global preference controls
   LlmProviderSection.tsx           LLM provider selector
   ModelConfigSection.tsx           Model config controls
-  GitHubConnectionCard.tsx         GitHub connection status card
+  GitHubConnectionCard.tsx         GitHub connection card — guided credential setup (PAT paste + OAuth device sign-in via /api/github/device/*)
   PtyConsoleBase.tsx               PTY output streamer (drawer/side-panel/full variants)
   PtyConsoleDrawer.tsx             Drawer variant wrapper
   PtyConsoleSidePanel.tsx          Side-panel variant wrapper

--- a/plugins/plugin-task-coordinator/CLAUDE.md
+++ b/plugins/plugin-task-coordinator/CLAUDE.md
@@ -78,7 +78,7 @@ src/
   GlobalPrefsSection.tsx           Global preference controls
   LlmProviderSection.tsx           LLM provider selector
   ModelConfigSection.tsx           Model config controls
-  GitHubConnectionCard.tsx         GitHub connection status card
+  GitHubConnectionCard.tsx         GitHub connection card — guided credential setup (PAT paste + OAuth device sign-in via /api/github/device/*)
   PtyConsoleBase.tsx               PTY output streamer (drawer/side-panel/full variants)
   PtyConsoleDrawer.tsx             Drawer variant wrapper
   PtyConsoleSidePanel.tsx          Side-panel variant wrapper

--- a/plugins/plugin-task-coordinator/src/GitHubConnectionCard.test.tsx
+++ b/plugins/plugin-task-coordinator/src/GitHubConnectionCard.test.tsx
@@ -1,0 +1,278 @@
+// @vitest-environment jsdom
+//
+// The GitHub connection card is the guided credential setup step (#15796):
+// PAT paste plus — when the agent has a GITHUB_OAUTH_CLIENT_ID — a device
+// sign-in path (start → show user code → poll → connected). These tests pin
+// the card's wiring against the plugin-github route contract: what it sends,
+// how it renders each protocol outcome (pending/complete/denied/expired), and
+// that cancelling really stops the poll loop.
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchMock = vi.fn();
+const openExternalUrlMock = vi.fn();
+
+vi.mock("@elizaos/ui", () => ({
+  client: {
+    fetch: (path: string, init?: RequestInit) => fetchMock(path, init),
+  },
+  openExternalUrl: (url: string) => openExternalUrlMock(url),
+  Button: ({
+    children,
+    unstyled: _unstyled,
+    variant: _variant,
+    size: _size,
+    ...rest
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    unstyled?: boolean;
+    variant?: string;
+    size?: string;
+  }) => (
+    <button type="button" {...rest}>
+      {children}
+    </button>
+  ),
+  SettingsControls: {
+    Input: ({
+      variant: _variant,
+      ...rest
+    }: React.InputHTMLAttributes<HTMLInputElement> & { variant?: string }) => (
+      <input {...rest} />
+    ),
+  },
+}));
+
+import { GitHubConnectionCard } from "./GitHubConnectionCard";
+
+interface RouteScript {
+  status?: unknown;
+  deviceStart?: () => unknown;
+  devicePoll?: () => unknown;
+  tokenPost?: () => unknown;
+}
+
+function scriptRoutes(script: RouteScript) {
+  fetchMock.mockImplementation((path: string, init?: RequestInit) => {
+    const method = init?.method ?? "GET";
+    if (path === "/api/github/token" && method === "GET") {
+      return Promise.resolve(
+        script.status ?? { connected: false, deviceFlowAvailable: false },
+      );
+    }
+    if (path === "/api/github/device/start" && method === "POST") {
+      if (!script.deviceStart) throw new Error("unexpected device start");
+      return Promise.resolve(script.deviceStart());
+    }
+    if (path === "/api/github/device/poll" && method === "POST") {
+      if (!script.devicePoll) throw new Error("unexpected device poll");
+      return Promise.resolve(script.devicePoll());
+    }
+    if (path === "/api/github/token" && method === "POST") {
+      if (!script.tokenPost) throw new Error("unexpected token post");
+      return Promise.resolve(script.tokenPost());
+    }
+    throw new Error(`unexpected request: ${method} ${path}`);
+  });
+}
+
+function startedFlow(overrides?: Partial<Record<string, unknown>>) {
+  return {
+    status: "started",
+    flowId: "flow-1",
+    userCode: "ABCD-EFGH",
+    verificationUri: "https://github.com/login/device",
+    intervalSeconds: 1,
+    expiresInSeconds: 900,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  openExternalUrlMock.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("GitHubConnectionCard", () => {
+  it("offers only the PAT path when the agent has no device-flow client id", async () => {
+    scriptRoutes({ status: { connected: false, deviceFlowAvailable: false } });
+    render(<GitHubConnectionCard />);
+    await waitFor(() =>
+      expect(screen.getByText(/Generate a token on github.com/)).toBeTruthy(),
+    );
+    expect(screen.queryByText("Sign in with GitHub")).toBeNull();
+  });
+
+  it("runs the guided sign-in: shows the user code, opens GitHub, polls to connected", async () => {
+    let polls = 0;
+    scriptRoutes({
+      status: { connected: false, deviceFlowAvailable: true },
+      deviceStart: () => startedFlow(),
+      devicePoll: () => {
+        polls += 1;
+        return polls === 1
+          ? { status: "pending", retryAfterSeconds: 1 }
+          : {
+              status: "complete",
+              connected: true,
+              deviceFlowAvailable: true,
+              username: "octocat",
+              scopes: ["repo", "read:user"],
+            };
+      },
+    });
+    render(<GitHubConnectionCard />);
+
+    const signIn = await screen.findByText("Sign in with GitHub");
+    fireEvent.click(signIn);
+
+    // The short code renders and GitHub's verification page opens.
+    expect(await screen.findByTestId("github-device-user-code")).toBeTruthy();
+    expect(screen.getByTestId("github-device-user-code").textContent).toBe(
+      "ABCD-EFGH",
+    );
+    expect(openExternalUrlMock).toHaveBeenCalledWith(
+      "https://github.com/login/device",
+    );
+
+    // Pending → complete over the server-provided cadence.
+    await waitFor(() => expect(screen.getByText("@octocat")).toBeTruthy(), {
+      timeout: 5_000,
+    });
+    expect(polls).toBe(2);
+    // The poll body carried the opaque flow id.
+    const pollCall = fetchMock.mock.calls.find(
+      ([path]) => path === "/api/github/device/poll",
+    );
+    expect(JSON.parse(String(pollCall?.[1]?.body))).toEqual({
+      flowId: "flow-1",
+    });
+  }, 15_000);
+
+  it("surfaces a denied grant as an actionable error and returns to the sign-in button", async () => {
+    scriptRoutes({
+      status: { connected: false, deviceFlowAvailable: true },
+      deviceStart: () => startedFlow(),
+      devicePoll: () => ({ status: "denied" }),
+    });
+    render(<GitHubConnectionCard />);
+
+    fireEvent.click(await screen.findByText("Sign in with GitHub"));
+    await waitFor(
+      () => expect(screen.getByText(/sign-in was denied/)).toBeTruthy(),
+      { timeout: 5_000 },
+    );
+    // The card recovers: the guided button is available again.
+    expect(screen.getByText("Sign in with GitHub")).toBeTruthy();
+  }, 15_000);
+
+  it("surfaces an expired code as an actionable error", async () => {
+    scriptRoutes({
+      status: { connected: false, deviceFlowAvailable: true },
+      deviceStart: () => startedFlow(),
+      devicePoll: () => ({ status: "expired" }),
+    });
+    render(<GitHubConnectionCard />);
+
+    fireEvent.click(await screen.findByText("Sign in with GitHub"));
+    await waitFor(() => expect(screen.getByText(/code expired/)).toBeTruthy(), {
+      timeout: 5_000,
+    });
+  }, 15_000);
+
+  it("shows the server's owner-setup message when starting the flow fails", async () => {
+    scriptRoutes({
+      status: { connected: false, deviceFlowAvailable: true },
+      deviceStart: () => {
+        throw new Error(
+          "GitHub device sign-in needs owner setup: no GITHUB_OAUTH_CLIENT_ID setting is configured",
+        );
+      },
+    });
+    // client.fetch throws ApiError (an Error) for non-2xx responses.
+    fetchMock.mockImplementation((path: string, init?: RequestInit) => {
+      const method = init?.method ?? "GET";
+      if (path === "/api/github/token" && method === "GET") {
+        return Promise.resolve({ connected: false, deviceFlowAvailable: true });
+      }
+      if (path === "/api/github/device/start") {
+        return Promise.reject(
+          new Error(
+            "GitHub device sign-in needs owner setup: no GITHUB_OAUTH_CLIENT_ID setting is configured",
+          ),
+        );
+      }
+      throw new Error(`unexpected request: ${method} ${path}`);
+    });
+    render(<GitHubConnectionCard />);
+
+    fireEvent.click(await screen.findByText("Sign in with GitHub"));
+    await waitFor(() =>
+      expect(screen.getByText(/needs owner setup/)).toBeTruthy(),
+    );
+  });
+
+  it("cancelling the sign-in stops the poll loop", async () => {
+    scriptRoutes({
+      status: { connected: false, deviceFlowAvailable: true },
+      deviceStart: () => startedFlow({ intervalSeconds: 1 }),
+      devicePoll: () => ({ status: "pending", retryAfterSeconds: 1 }),
+    });
+    render(<GitHubConnectionCard />);
+
+    fireEvent.click(await screen.findByText("Sign in with GitHub"));
+    expect(await screen.findByTestId("github-device-user-code")).toBeTruthy();
+
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(screen.queryByTestId("github-device-user-code")).toBeNull();
+
+    const pollsAtCancel = fetchMock.mock.calls.filter(
+      ([path]) => path === "/api/github/device/poll",
+    ).length;
+    // Give any (buggy) surviving timer a chance to fire, then re-count.
+    await new Promise((resolve) => setTimeout(resolve, 1_500));
+    const pollsAfterWait = fetchMock.mock.calls.filter(
+      ([path]) => path === "/api/github/device/poll",
+    ).length;
+    expect(pollsAfterWait).toBe(pollsAtCancel);
+  }, 15_000);
+
+  it("keeps the PAT paste path working (connect posts the token)", async () => {
+    scriptRoutes({
+      status: { connected: false, deviceFlowAvailable: true },
+      tokenPost: () => ({
+        connected: true,
+        deviceFlowAvailable: true,
+        username: "octocat",
+        scopes: ["repo"],
+      }),
+    });
+    render(<GitHubConnectionCard />);
+
+    const input = (await screen.findByPlaceholderText(
+      "ghp_…",
+    )) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "ghp_pasted" } });
+    fireEvent.click(screen.getByText("Connect"));
+
+    await waitFor(() => expect(screen.getByText("@octocat")).toBeTruthy());
+    const postCall = fetchMock.mock.calls.find(
+      ([path, init]) => path === "/api/github/token" && init?.method === "POST",
+    );
+    expect(JSON.parse(String(postCall?.[1]?.body))).toEqual({
+      token: "ghp_pasted",
+    });
+  });
+});

--- a/plugins/plugin-task-coordinator/src/GitHubConnectionCard.tsx
+++ b/plugins/plugin-task-coordinator/src/GitHubConnectionCard.tsx
@@ -4,27 +4,38 @@ import {
   CheckCircle2,
   ExternalLink,
   GitPullRequest,
+  LogIn,
   Unplug,
 } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 /**
- * GitHub PAT connection card for the Coding Agents settings page.
+ * GitHub connection card for the Coding Agents settings page — the guided
+ * credential setup step for every GitHub-touching capability (#15796).
  *
- * Persists a single per-user token to `<state-dir>/credentials/github.json`
- * via `/api/github/token`. The same token is exposed to spawned coding
- * sub-agents (orchestrator's existing `runtime.getSetting("GITHUB_TOKEN")`
- * resolution + `process.env.GITHUB_TOKEN` inheritance into ACP sessions),
- * so once it's set here `git clone` of private repos / `gh auth status`
- * / push + PR flows all work without the user having to wire env vars.
+ * Two paths to connect, matching the server routes in
+ * `@elizaos/plugin-github`:
  *
- * The token itself is write-only from the UI side: the API never returns
- * it after save. State here is just the metadata (username, scopes,
- * savedAt) plus an in-memory draft input while the user types a new PAT.
+ * 1. **Device sign-in** (`POST /api/github/device/start|poll`) — shown when
+ *    the agent has a `GITHUB_OAUTH_CLIENT_ID` setting. The card shows the
+ *    short user code, opens github.com/login/device, and polls until the
+ *    user approves. The device code and the granted token never reach the
+ *    browser.
+ * 2. **PAT paste** (`POST /api/github/token`) — always available.
+ *
+ * Either way the server validates the token against GitHub `/user`, persists
+ * it to `<state-dir>/credentials/github.json`, and applies it to the live
+ * runtime's per-agent settings (`runtime.getSetting("GITHUB_TOKEN")`) so
+ * GitHub capabilities work immediately — no restart, no process-env write.
+ *
+ * The token itself is write-only from the UI side: the API never returns it
+ * after save. State here is just the metadata (username, scopes, savedAt)
+ * plus the in-flight sign-in / draft-PAT state.
  */
 
 interface TokenStatus {
   connected: boolean;
+  deviceFlowAvailable?: boolean;
   username?: string;
   scopes?: string[];
   savedAt?: number;
@@ -38,10 +49,53 @@ type SubmitState =
   | { kind: "submitting" }
   | { kind: "error"; message: string };
 
+type DeviceFlowState =
+  | { kind: "idle" }
+  | { kind: "starting" }
+  | {
+      kind: "waiting";
+      flowId: string;
+      userCode: string;
+      verificationUri: string;
+    };
+
+interface DeviceStartResponse {
+  status: "started";
+  flowId: string;
+  userCode: string;
+  verificationUri: string;
+  intervalSeconds: number;
+  expiresInSeconds: number;
+}
+
+type DevicePollResponse =
+  | { status: "pending"; retryAfterSeconds: number }
+  | ({ status: "complete" } & TokenStatus)
+  | { status: "denied" }
+  | { status: "expired" };
+
 export function GitHubConnectionCard() {
   const [status, setStatus] = useState<TokenStatus | null>(null);
   const [draft, setDraft] = useState("");
   const [submitState, setSubmitState] = useState<SubmitState>({ kind: "idle" });
+  const [deviceFlow, setDeviceFlow] = useState<DeviceFlowState>({
+    kind: "idle",
+  });
+
+  // In-flight poll timer + a generation counter so a cancelled sign-in's
+  // late responses are ignored instead of resurrecting the waiting state.
+  const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const flowGenRef = useRef(0);
+
+  const stopPolling = useCallback(() => {
+    flowGenRef.current += 1;
+    if (pollTimerRef.current !== null) {
+      clearTimeout(pollTimerRef.current);
+      pollTimerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => stopPolling, [stopPolling]);
 
   const refreshStatus = useCallback(async () => {
     const next = await client.fetch<TokenStatus>("/api/github/token");
@@ -51,6 +105,94 @@ export function GitHubConnectionCard() {
   useEffect(() => {
     void refreshStatus();
   }, [refreshStatus]);
+
+  const pollDeviceFlow = useCallback((flowId: string, generation: number) => {
+    void (async () => {
+      if (generation !== flowGenRef.current) return;
+      try {
+        const res = await client.fetch<DevicePollResponse>(
+          "/api/github/device/poll",
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ flowId }),
+          },
+        );
+        if (generation !== flowGenRef.current) return;
+        if (res.status === "pending") {
+          const delaySeconds = Math.max(1, res.retryAfterSeconds);
+          pollTimerRef.current = setTimeout(
+            () => pollDeviceFlow(flowId, generation),
+            delaySeconds * 1000,
+          );
+          return;
+        }
+        if (res.status === "complete") {
+          setDeviceFlow({ kind: "idle" });
+          setSubmitState({ kind: "idle" });
+          setStatus(res);
+          return;
+        }
+        setDeviceFlow({ kind: "idle" });
+        setSubmitState({
+          kind: "error",
+          message:
+            res.status === "denied"
+              ? "GitHub sign-in was denied on github.com. Start again, or paste a personal access token instead."
+              : "The sign-in code expired before it was approved. Start again to get a new code.",
+        });
+      } catch (err) {
+        if (generation !== flowGenRef.current) return;
+        setDeviceFlow({ kind: "idle" });
+        setSubmitState({
+          kind: "error",
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    })();
+  }, []);
+
+  const handleDeviceSignIn = useCallback(async () => {
+    stopPolling();
+    const generation = flowGenRef.current;
+    setSubmitState({ kind: "idle" });
+    setDeviceFlow({ kind: "starting" });
+    try {
+      const res = await client.fetch<DeviceStartResponse>(
+        "/api/github/device/start",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({}),
+        },
+      );
+      if (generation !== flowGenRef.current) return;
+      setDeviceFlow({
+        kind: "waiting",
+        flowId: res.flowId,
+        userCode: res.userCode,
+        verificationUri: res.verificationUri,
+      });
+      openExternalUrl(res.verificationUri);
+      pollTimerRef.current = setTimeout(
+        () => pollDeviceFlow(res.flowId, generation),
+        Math.max(1, res.intervalSeconds) * 1000,
+      );
+    } catch (err) {
+      if (generation !== flowGenRef.current) return;
+      setDeviceFlow({ kind: "idle" });
+      setSubmitState({
+        kind: "error",
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }, [pollDeviceFlow, stopPolling]);
+
+  const handleCancelDeviceSignIn = useCallback(() => {
+    stopPolling();
+    setDeviceFlow({ kind: "idle" });
+    setSubmitState({ kind: "idle" });
+  }, [stopPolling]);
 
   const handleConnect = useCallback(async () => {
     const token = draft.trim();
@@ -79,20 +221,26 @@ export function GitHubConnectionCard() {
   }, [draft]);
 
   const handleDisconnect = useCallback(async () => {
+    stopPolling();
+    setDeviceFlow({ kind: "idle" });
     setSubmitState({ kind: "submitting" });
     try {
-      await client.fetch("/api/github/token", { method: "DELETE" });
-      setStatus({ connected: false });
+      const next = await client.fetch<TokenStatus>("/api/github/token", {
+        method: "DELETE",
+      });
+      setStatus(next);
       setSubmitState({ kind: "idle" });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       setSubmitState({ kind: "error", message });
     }
-  }, []);
+  }, [stopPolling]);
 
   const submitting = submitState.kind === "submitting";
   const errorMessage =
     submitState.kind === "error" ? submitState.message : null;
+  const deviceFlowAvailable = status?.deviceFlowAvailable === true;
+  const deviceBusy = deviceFlow.kind !== "idle";
 
   return (
     <div className="space-y-3 px-1 py-1">
@@ -160,9 +308,58 @@ export function GitHubConnectionCard() {
       ) : (
         <div className="flex flex-col gap-2 text-xs">
           <p className="sr-only">
-            Paste a personal access token so coding sub-agents can clone private
-            repos, push commits, and open pull requests.
+            Connect GitHub so coding sub-agents can clone private repos, push
+            commits, and open pull requests.
           </p>
+
+          {deviceFlowAvailable && deviceFlow.kind !== "waiting" ? (
+            <Button
+              variant="default"
+              size="sm"
+              className="w-fit"
+              onClick={() => void handleDeviceSignIn()}
+              disabled={submitting || deviceFlow.kind === "starting"}
+            >
+              <LogIn className="mr-1.5 h-3.5 w-3.5" aria-hidden />
+              {deviceFlow.kind === "starting"
+                ? "Starting sign-in…"
+                : "Sign in with GitHub"}
+            </Button>
+          ) : null}
+
+          {deviceFlow.kind === "waiting" ? (
+            <div className="flex flex-col gap-2 rounded-md border border-border bg-bg-accent/40 p-2.5">
+              <div className="text-muted">
+                Enter this code on{" "}
+                <Button
+                  unstyled
+                  type="button"
+                  className="inline-flex items-center gap-1 text-accent hover:underline"
+                  onClick={() => openExternalUrl(deviceFlow.verificationUri)}
+                >
+                  {deviceFlow.verificationUri.replace(/^https:\/\//, "")}
+                  <ExternalLink className="h-3 w-3" aria-hidden />
+                </Button>
+              </div>
+              <div
+                className="select-all font-mono text-base font-semibold tracking-widest text-txt"
+                data-testid="github-device-user-code"
+              >
+                {deviceFlow.userCode}
+              </div>
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-muted">Waiting for approval…</span>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={handleCancelDeviceSignIn}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          ) : null}
+
           <Button
             unstyled
             type="button"
@@ -170,7 +367,9 @@ export function GitHubConnectionCard() {
             onClick={() => openExternalUrl(TOKEN_GENERATE_URL)}
           >
             <ExternalLink className="h-3 w-3" aria-hidden />
-            Generate a token on github.com (scopes: repo, read:user)
+            {deviceFlowAvailable
+              ? "Or generate a token on github.com (scopes: repo, read:user)"
+              : "Generate a token on github.com (scopes: repo, read:user)"}
           </Button>
           <div className="flex items-center gap-2">
             <SettingsControls.Input
@@ -189,7 +388,7 @@ export function GitHubConnectionCard() {
               variant="default"
               size="sm"
               onClick={() => void handleConnect()}
-              disabled={submitting || draft.trim().length === 0}
+              disabled={submitting || deviceBusy || draft.trim().length === 0}
             >
               {submitting ? "Connecting…" : "Connect"}
             </Button>

--- a/plugins/plugin-task-coordinator/src/__e2e__/build-github-card-fixture.mjs
+++ b/plugins/plugin-task-coordinator/src/__e2e__/build-github-card-fixture.mjs
@@ -1,0 +1,111 @@
+/**
+ * Build step for the GitHub connection card screenshot harness (#15796).
+ * Bundles github-card-fixture.tsx with esbuild (stubbing `@elizaos/ui` with
+ * brand-faithful primitives whose classes are copied from packages/ui
+ * button.tsx) and writes the self-contained HTML page the playwright runner
+ * loads. Split from run-github-card-shot.mjs because esbuild resolves from
+ * bun's isolated store (run this under bun) while playwright's launcher needs
+ * node on Windows.
+ *
+ * Run: bun run plugins/plugin-task-coordinator/src/__e2e__/build-github-card-fixture.mjs
+ */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { build } from "esbuild";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const outDir = join(here, "github-card-shots");
+await mkdir(outDir, { recursive: true });
+
+// Stub `@elizaos/ui` (a virtual module, nothing written to src): the card only
+// uses Button, SettingsControls.Input, client.fetch, and openExternalUrl. The
+// Button/Input classes mirror packages/ui/src/components/ui/button.tsx so the
+// pixels match the shipped kit (accent-orange resting → darker-orange hover).
+const uiStub = {
+  name: "elizaos-ui-stub",
+  setup(b) {
+    b.onResolve({ filter: /^@elizaos\/ui$/ }, () => ({
+      path: "elizaos-ui-stub",
+      namespace: "ui-stub",
+    }));
+    b.onLoad({ filter: /.*/, namespace: "ui-stub" }, () => ({
+      loader: "tsx",
+      resolveDir: here,
+      contents: `
+import * as React from "react";
+const VARIANTS = {
+  default: "bg-accent text-accent-fg hover:bg-accent-hover",
+  secondary: "bg-bg-accent text-txt hover:bg-surface",
+};
+export function Button({ children, unstyled, variant = "default", size, className = "", ...rest }) {
+  const base = unstyled
+    ? className
+    : "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-sm text-sm font-medium transition-colors h-9 px-3 py-1.5 cursor-pointer " +
+      (VARIANTS[variant] ?? VARIANTS.default) + " " + className;
+  return <button type="button" className={base} {...rest}>{children}</button>;
+}
+export const SettingsControls = {
+  Input: ({ variant, className = "", ...rest }) => (
+    <input className={"h-8 rounded-sm border border-border bg-bg px-2 text-xs text-txt placeholder:text-muted " + className} {...rest} />
+  ),
+};
+export const client = { fetch: (path, init) => window.__ghFetch(path, init) };
+export function openExternalUrl(url) { window.__openedExternal = url; }
+`,
+    }));
+  },
+};
+
+const result = await build({
+  entryPoints: [join(here, "github-card-fixture.tsx")],
+  bundle: true,
+  format: "iife",
+  platform: "browser",
+  jsx: "automatic",
+  loader: { ".tsx": "tsx", ".ts": "ts" },
+  define: { "process.env.NODE_ENV": '"production"' },
+  plugins: [uiStub],
+  write: false,
+});
+const js = result.outputFiles[0].text;
+
+// Brand palette (dark theme) wired so Tailwind opacity modifiers resolve
+// against real values. Mirrors run-dashboard-shot.mjs.
+const html = `<!doctype html><html><head><meta charset="utf-8"><title>github connection card</title>
+<script>
+window.tailwind = window.tailwind || {};
+window.tailwind.config = {
+  theme: { extend: { colors: {
+    bg: "#07090e", "bg-accent": "#10131b", "bg-hover": "#1a1e28",
+    surface: "#161a23", card: "#0c0f16",
+    txt: "#f4f5f7", "txt-strong": "#ffffff",
+    muted: "#9aa0ad", "muted-strong": "#c3c8d2", border: "#272b36",
+    accent: "#ff5800", "accent-hover": "#e04d00", "accent-fg": "#ffffff",
+    "accent-subtle": "rgba(255,88,0,0.14)",
+    ok: "#4ade80", warn: "#ff8a3d", danger: "#f87171",
+  } } },
+};
+</script>
+<script src="https://cdn.tailwindcss.com"></script>
+<style>html,body{margin:0;height:100%;background:#07090e}
+/* Brand palette injected explicitly so it survives whichever Tailwind the CDN
+   serves (v4 ignores the JS color config). Source order wins. */
+.text-txt{color:#f4f5f7}.text-muted{color:#9aa0ad}
+.text-accent{color:#ff5800}.text-amber-500{color:#f59e0b}
+.text-rose-500{color:#f43f5e}.text-emerald-500{color:#10b981}
+.bg-bg{background-color:#07090e}.bg-card{background-color:#0c0f16}
+.bg-bg-accent{background-color:#10131b}.bg-bg-accent\\/40{background-color:rgba(16,19,27,.4)}
+.bg-surface{background-color:#161a23}
+.bg-accent{background-color:#ff5800}.hover\\:bg-accent-hover:hover{background-color:#e04d00}
+.text-accent-fg{color:#ffffff}
+.bg-emerald-500{background-color:#10b981}.bg-muted\\/40{background-color:rgba(154,160,173,.4)}
+.bg-rose-500\\/10{background-color:rgba(244,63,94,.1)}
+.border-border{border-color:#272b36}.border-rose-500\\/40{border-color:rgba(244,63,94,.4)}
+</style>
+</head><body><div id="root"></div><script>${js}</script></body></html>`;
+const htmlPath = join(outDir, "github-card.html");
+await writeFile(htmlPath, html);
+
+console.log(`Fixture page → ${htmlPath}`);

--- a/plugins/plugin-task-coordinator/src/__e2e__/github-card-fixture.tsx
+++ b/plugins/plugin-task-coordinator/src/__e2e__/github-card-fixture.tsx
@@ -1,0 +1,72 @@
+/**
+ * Render-only fixture for the GitHub connection card (#15796). Mounts the real
+ * `GitHubConnectionCard` with a scripted `/api/github/*` backend (selected via
+ * the `?state=` query param) so the esbuild + playwright harness can
+ * screenshot the actual component in each guided-setup state — no app server.
+ * The `@elizaos/ui` module is stubbed by the runner's esbuild resolver with
+ * brand-faithful Button/Input primitives and a `client.fetch` that delegates
+ * to `window.__ghFetch` (defined here).
+ */
+
+import { createRoot } from "react-dom/client";
+import { GitHubConnectionCard } from "../GitHubConnectionCard";
+
+type Responder = (path: string, init?: RequestInit) => unknown;
+
+declare global {
+  interface Window {
+    __ghFetch: (path: string, init?: RequestInit) => Promise<unknown>;
+  }
+}
+
+function scriptedBackend(state: string): Responder {
+  const disconnected = { connected: false, deviceFlowAvailable: true };
+  const connected = {
+    connected: true,
+    deviceFlowAvailable: true,
+    username: "eliza-agent-bot",
+    scopes: ["repo", "read:user"],
+    savedAt: 1_720_000_000_000,
+  };
+  const started = {
+    status: "started",
+    flowId: "fixture-flow",
+    userCode: "ELIZ-A123",
+    verificationUri: "https://github.com/login/device",
+    intervalSeconds: 1,
+    expiresInSeconds: 900,
+  };
+  return (path, init) => {
+    const method = init?.method ?? "GET";
+    if (path === "/api/github/token" && method === "GET") {
+      if (state === "pat-only")
+        return { connected: false, deviceFlowAvailable: false };
+      if (state === "connected") return connected;
+      return disconnected;
+    }
+    if (path === "/api/github/device/start") return started;
+    if (path === "/api/github/device/poll") {
+      if (state === "denied") return { status: "denied" };
+      return { status: "pending", retryAfterSeconds: 5 };
+    }
+    if (path === "/api/github/token" && method === "POST") return connected;
+    throw new Error(`fixture: unexpected request ${method} ${path}`);
+  };
+}
+
+const params = new URLSearchParams(window.location.search);
+const state = params.get("state") ?? "device";
+const respond = scriptedBackend(state);
+window.__ghFetch = (path, init) => Promise.resolve(respond(path, init));
+
+const root = createRoot(document.getElementById("root") as HTMLElement);
+root.render(
+  <div
+    data-testid="github-card-fixture"
+    className="min-h-screen bg-bg p-6 text-txt"
+  >
+    <div className="mx-auto w-full max-w-md rounded-lg border border-border bg-card p-3">
+      <GitHubConnectionCard />
+    </div>
+  </div>,
+);

--- a/plugins/plugin-task-coordinator/src/__e2e__/run-github-card-shot.mjs
+++ b/plugins/plugin-task-coordinator/src/__e2e__/run-github-card-shot.mjs
@@ -1,0 +1,171 @@
+/**
+ * Real-browser screenshots of the GitHub connection card's guided-setup
+ * states (#15796). Runs the esbuild bundle step under bun (see
+ * build-github-card-fixture.mjs), loads the resulting page in headless
+ * chromium with the brand palette wired into Tailwind, drives the real
+ * component (clicks the sign-in button, waits for the device code / error),
+ * and captures desktop + mobile.
+ *
+ * Run under node (playwright's launcher wedges under bun on Windows):
+ *   node plugins/plugin-task-coordinator/src/__e2e__/run-github-card-shot.mjs
+ */
+
+import { execFileSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const outDir = join(here, "github-card-shots");
+
+execFileSync("bun", ["run", join(here, "build-github-card-fixture.mjs")], {
+  stdio: "inherit",
+  shell: process.platform === "win32",
+});
+const url = `file://${join(outDir, "github-card.html")}`;
+
+let failures = 0;
+const assert = (cond, msg) => {
+  console.log(`${cond ? "✓" : "✗"} ${msg}`);
+  if (!cond) failures += 1;
+};
+
+const browser = await chromium.launch();
+const errors = [];
+try {
+  const shoot = async (page, state, actions, checks, file) => {
+    await page.goto(`${url}?state=${state}`);
+    await page.waitForSelector('[data-testid="github-card-fixture"]');
+    await page.waitForTimeout(400);
+    if (actions) await actions(page);
+    if (checks) await checks(page);
+    await page.screenshot({ path: join(outDir, file), fullPage: true });
+    console.log(`  \u{1F4F8} ${file}`);
+  };
+
+  const desktop = await browser.newPage({
+    viewport: { width: 1100, height: 700 },
+    deviceScaleFactor: 2,
+  });
+  desktop.on("pageerror", (e) => errors.push(String(e)));
+
+  // BEFORE-equivalent: no oauth client id configured — PAT paste only (this is
+  // the entire card as it existed before this change).
+  await shoot(
+    desktop,
+    "pat-only",
+    null,
+    async (page) => {
+      assert(
+        (await page.getByText("Sign in with GitHub").count()) === 0,
+        "pat-only state hides the device sign-in button",
+      );
+      assert(
+        (await page.getByText(/Generate a token/).count()) > 0,
+        "pat-only state keeps the PAT link",
+      );
+    },
+    "01-before-pat-only-desktop.png",
+  );
+
+  // AFTER: device flow available — guided sign-in button offered.
+  await shoot(
+    desktop,
+    "device",
+    null,
+    async (page) => {
+      assert(
+        (await page.getByText("Sign in with GitHub").count()) === 1,
+        "device state offers the guided sign-in button",
+      );
+    },
+    "02-after-signin-offered-desktop.png",
+  );
+
+  // AFTER: sign-in clicked — user code shown, waiting for approval.
+  await shoot(
+    desktop,
+    "device",
+    async (page) => {
+      await page.getByText("Sign in with GitHub").click();
+      await page.waitForSelector('[data-testid="github-device-user-code"]');
+      await page.waitForTimeout(300);
+    },
+    async (page) => {
+      assert(
+        (await page.getByTestId("github-device-user-code").textContent()) ===
+          "ELIZ-A123",
+        "waiting state shows the short user code",
+      );
+      assert(
+        (await page.evaluate(() => window.__openedExternal)) ===
+          "https://github.com/login/device",
+        "sign-in opens github.com/login/device externally",
+      );
+    },
+    "03-after-device-code-waiting-desktop.png",
+  );
+
+  // AFTER: user denied on github.com — actionable error, button recovers.
+  await shoot(
+    desktop,
+    "denied",
+    async (page) => {
+      await page.getByText("Sign in with GitHub").click();
+      await page.waitForSelector("text=/sign-in was denied/");
+      await page.waitForTimeout(200);
+    },
+    async (page) => {
+      assert(
+        (await page
+          .getByText(/paste a personal access token instead/)
+          .count()) > 0,
+        "denied state suggests the PAT fallback",
+      );
+    },
+    "04-after-denied-error-desktop.png",
+  );
+
+  // AFTER: connected state.
+  await shoot(
+    desktop,
+    "connected",
+    null,
+    async (page) => {
+      assert(
+        (await page.getByText("@eliza-agent-bot").count()) > 0,
+        "connected state shows the GitHub login",
+      );
+    },
+    "05-after-connected-desktop.png",
+  );
+  await desktop.close();
+
+  const mobile = await browser.newPage({
+    viewport: { width: 402, height: 800 },
+    deviceScaleFactor: 2,
+  });
+  mobile.on("pageerror", (e) => errors.push(String(e)));
+  await shoot(mobile, "pat-only", null, null, "06-before-pat-only-mobile.png");
+  await shoot(
+    mobile,
+    "device",
+    async (page) => {
+      await page.getByText("Sign in with GitHub").click();
+      await page.waitForSelector('[data-testid="github-device-user-code"]');
+      await page.waitForTimeout(300);
+    },
+    null,
+    "07-after-device-code-waiting-mobile.png",
+  );
+  await mobile.close();
+} finally {
+  await browser.close();
+}
+
+assert(errors.length === 0, `no page errors (${errors.length})`);
+for (const e of errors) console.error(`  ⚠ ${e}`);
+console.log(`\nScreenshots → ${outDir}`);
+if (failures > 0) {
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## What & why

Closes #15796 — a newly spun-up agent (cloud container, fresh desktop install, new user) had no guided path to GitHub credentials, so every GitHub-touching capability (`TASKS_MANAGE_ISSUES`, `TASKS_SUBMIT_WORKSPACE`, repo provisioning) failed until the operator discovered the right setting by reading source.

This makes GitHub credentials a **first-class guided setup step**, reusing the #15749 device-flow primitive as promised in the claim: the Settings → Coding Agents **GitHub connection card** now offers *Sign in with GitHub* (OAuth device flow) alongside the existing PAT paste, stores the obtained token **per-agent via runtime settings + the existing credential store (not process env)**, and mid-task credential failures now point at the setup step.

**Complementary PR:** #15844 (same issue, docs slice for `plugin-agent-orchestrator` README) is open from a parallel lane — zero file overlap with this PR (this PR touches `workspace-github.ts` source + `packages/docs/connectors/github.md`; that one touches the orchestrator README/CLAUDE/AGENTS).

**Out of scope (owner decision pending, per the claim):** the cloud per-agent identity policy — bot account vs user PAT vs GitHub App installation for cloud-provisioned agents. Noted as an open question in the docs; not decided here.

**`elizaos` CLI:** intentionally **not** added. Per `packages/elizaos/CLAUDE.md` the CLI is a standalone, dependency-light scaffolding tool that does not import the runtime; the device flow needs the running agent's HTTP surface and per-agent settings, so a CLI login step would bloat it with runtime/server concerns for no benefit. The dashboard card is the guided surface.

## Changes

**`@elizaos/plugin-github`**
- New `src/device-flow.ts` — TypeScript port of the #15749 primitive (`scripts/lifeops/github-device-login.mjs`): `device_code` never leaves the server, server-owned polling interval (honors `slow_down`, throttles eager clients locally), 409 owner-setup vs 502 upstream error taxonomy, expiry sweep — plus one addition: **flows are bound to the agent that started them** (`agentKey`), so on a multi-agent host one agent's runtime can never poll another agent's flow.
- Two new routes: `POST /api/github/device/start` (409 with an actionable owner-setup message when `GITHUB_OAUTH_CLIENT_ID` is absent) and `POST /api/github/device/poll` (`pending`/`denied`/`expired`, or on grant: validate against GitHub `/user` → persist via the existing `github-credentials` store → apply to the live runtime per-agent via `setSetting("GITHUB_TOKEN", …, true)`). No second storage mechanism; no process-env write (env leaks to every agent on a multi-tenant host — the existing boot-time `applySavedTokenToEnv` behavior for `gh`/`git` subprocess inheritance is unchanged).
- `GET /api/github/token` now reports `deviceFlowAvailable`; the PAT `POST` also applies the live runtime setting (connect → retry works without a restart); `DELETE` disconnects the live runtime too.
- **Latent bug fixed:** `readJsonBody` now prefers the canonical dispatcher's pre-parsed `req.body` — an `application/json` POST (the exact shape the dashboard card sends) previously read an already-consumed stream and returned 400 through `tryHandleRuntimePluginRoute` (the existing e2e dodged it by posting `text/plain`, with a comment acknowledging the behavior). Covered by a new test that posts real `application/json` through the real dispatcher.
- `action-helpers.needsClientError` now points at the setup card, not just env var names.

**`@elizaos/plugin-task-coordinator`**
- `GitHubConnectionCard` grows the guided path: *Sign in with GitHub* → prominent short code + `github.com/login/device` link (opened externally) → poll at the server-provided cadence → connected; denied/expired resolve to actionable errors with the PAT fallback suggested; Cancel really stops the poll loop (generation-guarded timers, cleaned on unmount). Orange accent only, no blue, accent → darker-accent hover (kit `Button` variants).
- New real-browser screenshot harness `src/__e2e__/{github-card-fixture.tsx, build-github-card-fixture.mjs, run-github-card-shot.mjs}` (modeled on the existing `run-dashboard-shot.mjs`; build under bun, drive under node).

**`@elizaos/plugin-agent-orchestrator`**
- `workspace-github.ts` missing-credential errors now point at Settings → Coding Agents (the mid-task failure → setup-step UX from the issue).

**Docs**
- `packages/docs/connectors/github.md`: new *Guided credential setup (dashboard)* section — PAT vs device sign-in comparison, **vault/settings vs env** (multi-tenant leak warning), and the open cloud identity-policy note.
- plugin-github + plugin-task-coordinator `CLAUDE.md`/`AGENTS.md` (kept identical) + plugin-github README updated for the new routes/card.

## Tests (all deterministic; GitHub's HTTP endpoints are the only thing stubbed — the thing under test is our flow/route/card logic)

- `plugins/plugin-github/src/device-flow.test.ts` — **11 tests**: pending→complete walk (device code sent only to GitHub, flow consumed, replay rejected), `slow_down` raising the server-owned interval + local throttling, denied, expired, expiry sweep, **cross-agent flow isolation (no network touch)**, owner-setup 409 mapping, unreachable-GitHub 502, malformed-response 502, unknown-error terminal.
- `plugins/plugin-github/src/device-routes-e2e.test.ts` — **12 tests** through the real production dispatcher (`tryHandleRuntimePluginRoute`) over loopback `http.createServer`: auth gate 401 on both routes, `deviceFlowAvailable` from the per-agent setting, owner-setup 409 naming the fix + PAT alternative, **full guided flow end-to-end** (start → pending → interval throttle → grant → `/user` validation → disk persistence via `loadMetadata` → per-agent runtime secret applied, token absent from every response body and from `process.env`), denied/expired terminal outcomes persisting nothing, missing flowId 400 / unknown 404, **agent B cannot poll agent A's flow (404, no token)**, GitHub-side registration failure 409, unreachable GitHub 502, granted-token-rejected-at-`/user` 400 persisting nothing, and the PAT paste + DELETE round-trip over real `application/json`.
- `plugins/plugin-task-coordinator/src/GitHubConnectionCard.test.tsx` — **7 jsdom tests**: PAT-only when no client id, guided sign-in (code shown, external URL opened, poll body carries the opaque flow id, pending→complete → connected), denied recovery, expired, owner-setup start failure, **cancel stops the poll loop (verified by waiting out the timer)**, PAT paste path.
- Pre-existing `routes-e2e.test.ts` (11) and the full plugin-github suite still green.

```
plugin-github           7 files, 52 tests passed (incl. 23 new)
plugin-task-coordinator GitHubConnectionCard.test.tsx: 7 passed
```

## Evidence

### Before/after screenshots (desktop + mobile, real chromium, real component driven by real clicks)

Captured via `node plugins/plugin-task-coordinator/src/__e2e__/run-github-card-shot.mjs` (all 8 in-page assertions passed, 0 page errors) and **reviewed by hand**. "Before" = the card without an OAuth client id, which is pixel-equivalent to the pre-change card (PAT paste only).

| Before (PAT-only) | After: sign-in offered | After: code + waiting |
|---|---|---|
| ![before](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15873-01-before-pat-only-desktop.png) | ![offered](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15873-02-after-signin-offered-desktop.png) | ![waiting](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15873-03-after-device-code-waiting-desktop.png) |

| After: denied → actionable error | After: connected | Mobile: before / waiting |
|---|---|---|
| ![denied](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15873-04-after-denied-error-desktop.png) | ![connected](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15873-05-after-connected-desktop.png) | ![mobile-before](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15873-06-before-pat-only-mobile.png) ![mobile-waiting](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15873-07-after-device-code-waiting-mobile.png) |

(Screenshots live on scratch ref `evidence/15796-github-card-shots` — not part of this PR's diff; committed evidence payloads are retired per #14891. Delete the ref after review.)

### Backend structured logs + domain artifacts (real route handlers over loopback HTTP)

<details><summary>Full guided flow: server logs, wire responses, credential file, per-agent secret</summary>

```
[server INFO] [github-routes] started github device sign-in (interval=1s, expires=900s)
[client] POST /api/github/device/start → {"status":"started","flowId":"Ca0u5xz3U0s7_mf15CHrNKWzDr7kMQXT","userCode":"ABCD-EFGH","verificationUri":"https://github.com/login/device","intervalSeconds":1,"expiresInSeconds":900}
[client] POST /api/github/device/poll → {"status":"pending","retryAfterSeconds":1}
[server INFO] [github-routes] saved github token for @octocat (source=device-flow, scopes=repo,read:user)
[client] POST /api/github/device/poll → {"status":"complete","connected":true,"deviceFlowAvailable":true,"username":"octocat","scopes":["repo","read:user"],"savedAt":1783642235134}
[domain] runtime per-agent secret applied (not process.env): true
[domain] credential file: %TEMP%\gh-evidence-FMFGGi\credentials\github.json → {"username":"octocat","scopes":["repo","read:user"],"savedAt":1783642235134}
[client] GET /api/github/token → {"connected":true,"deviceFlowAvailable":true,"username":"octocat","scopes":["repo","read:user"],"savedAt":1783642235134}
```

Note the granted token (`gho_demo_grant`) and the device code (`secret-device-code`) appear in **no** client-visible payload — pinned by tests too.
</details>

### Frontend console/network evidence
The screenshot harness drives the real component in real chromium and asserts **0 page errors** across all states; the jsdom suite pins the exact network calls the card makes (paths, methods, JSON bodies). `N/A - no separate devtools capture`: the card is a settings-section slot fill, exercised headlessly above; running the full dashboard stack was not feasible on this box (9 concurrent sibling agents) — see *Verification* for exactly what was run.

### Video walkthrough
`N/A - full app walkthrough infeasible on this loaded box (9 sibling agents share it)`; in its place: the driven real-browser state sequence above (offered → clicked → code shown → denied/connected), which covers every user-visible state of the touched view. `bun run --cwd packages/app audit:app` was **not** run for the same reason — the touched UI lives in `plugins/plugin-task-coordinator` (settings slot fill), not `packages/app`.

### Real-LLM trajectories
`N/A - no agent/action/prompt/model behavior change`: routes, UI, docs, and two error-message strings; no prompts, providers, or model paths were touched.

### Per-platform / audio capture
`N/A - web dashboard settings card only`; no native bridge, no voice surface.

## Verification

- `bun run --cwd plugins/plugin-github typecheck` — **green**.
- `bunx @biomejs/biome@2.5.3 check` (repo-pinned version) on all touched files — **clean**.
- `bunx vitest run` full plugin-github suite — **52/52**; `GitHubConnectionCard.test.tsx` — **7/7** (re-run after rebase onto `afb55d4fd5`).
- `bun run --cwd plugins/plugin-task-coordinator typecheck`: pre-existing failures on this box only — 55 errors on the **baseline** (stale `@elizaos/ui` dist d.ts in the shared install missing `unstyled`, which exists in `packages/ui/src/components/ui/button.tsx:63`; verified by stashing my change), 56 with this PR (the one delta is the same `unstyled` prop class on my second button — a stale-dist artifact, clean where `@elizaos/ui` is built).
- `bun run --cwd plugins/plugin-agent-orchestrator typecheck`: pre-existing failure in untouched `packages/core/src/cloud-routing.ts` (unbuilt `@elizaos/cloud-routing` dist on this box) — **identical on the baseline without my one-string edit** (verified by stash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

