### PR TITLE
fix(cloud): persist container boot diagnostics into error_message on health-timeout

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-probe-transport.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-probe-transport.test.ts
@@ -24,7 +24,7 @@ type PollInternals = {
   pollSshDockerHealth: (
     meta: ContainerMetaShape,
     deadline: number,
-  ) => Promise<{ ready: boolean; verdict: string; detail?: string; diagnostics?: string }>;
+  ) => Promise<{ ready: boolean; verdict: string; detail?: string }>;
   hydrateContainerFromDb: (sandboxId: string) => Promise<ContainerMetaShape | null>;
 };
 
@@ -167,7 +167,7 @@ describe("pollSshDockerHealth transport-vs-not-ready classification (#15310 #6)"
     expect(outcome.verdict).toBe("ready");
   });
 
-  test("not_ready timeout carries the classified reason + boot-log tail (#13406)", async () => {
+  test("not_ready timeout carries only the allowlisted classification (#13406)", async () => {
     const provider = new DockerSandboxProvider();
     const internals = provider as unknown as PollInternals;
     spyOn(internals, "hydrateContainerFromDb").mockResolvedValue(META);
@@ -184,7 +184,7 @@ describe("pollSshDockerHealth transport-vs-not-ready classification (#15310 #6)"
           "--- ports ---",
           "",
           "--- logs ---",
-          "[boot] FATAL: SANDBOX_ROUTE_AGENT_ID missing, cannot start",
+          "[boot] OPENAI_API_KEY=sk-secret Bearer private-token https://signed.example/path",
         ].join("\n");
       }
       if (command.includes("docker inspect")) return "starting"; // probe: reached, unhealthy
@@ -195,30 +195,52 @@ describe("pollSshDockerHealth transport-vs-not-ready classification (#15310 #6)"
 
     expect(outcome.ready).toBe(false);
     expect(outcome.verdict).toBe("not_ready");
-    // The opaque "health check timed out" now carries WHY the container failed.
-    expect(outcome.detail).toBe("container not running (state=exited exit=1) error=OOMKilled");
-    expect(outcome.diagnostics).toContain("FATAL: SANDBOX_ROUTE_AGENT_ID missing");
+    expect(outcome.detail).toBe("container not running (state=exited exit=1)");
+    expect(JSON.stringify(outcome)).not.toContain("sk-secret");
+    expect(JSON.stringify(outcome)).not.toContain("private-token");
+    expect(JSON.stringify(outcome)).not.toContain("signed.example");
+    expect(JSON.stringify(outcome)).not.toContain("OOMKilled");
   });
 });
 
 describe("classifyHealthTimeoutDetail", () => {
-  test("exited container → not-running reason with exit code + docker error", () => {
+  test("exited container → not-running reason with allowlisted fields only", () => {
     expect(
       classifyHealthTimeoutDetail(
         "--- inspect ---\nstate=exited health= exit=137 error=OOMKilled\n--- logs ---\nkilled",
       ),
-    ).toBe("container not running (state=exited exit=137) error=OOMKilled");
+    ).toBe("container not running (state=exited exit=137)");
   });
 
   test("running but unhealthy → surfaces the health status", () => {
-    expect(classifyHealthTimeoutDetail("state=running health=unhealthy exit=0 error=")).toBe(
-      "container running but health=unhealthy",
-    );
+    expect(
+      classifyHealthTimeoutDetail(
+        "--- inspect ---\nstate=running health=unhealthy exit=0 error=",
+      ),
+    ).toBe("container running but health=unhealthy");
   });
 
   test("no inspect line → undefined so the caller keeps the generic message", () => {
     expect(
       classifyHealthTimeoutDetail("--- logs ---\nonly logs, the inspect step failed"),
+    ).toBeUndefined();
+  });
+
+  test("container-controlled lookalikes and invalid inspect fields are not persisted", () => {
+    expect(
+      classifyHealthTimeoutDetail(
+        "--- inspect ---\ninspect failed\n--- logs ---\nstate=exited health= exit=1 error=sk-secret",
+      ),
+    ).toBeUndefined();
+    expect(
+      classifyHealthTimeoutDetail(
+        "--- inspect ---\nstate=compromised health=unhealthy exit=1 error=sk-secret",
+      ),
+    ).toBeUndefined();
+    expect(
+      classifyHealthTimeoutDetail(
+        "--- inspect ---\nstate=exited health= exit=not-a-number error=sk-secret",
+      ),
     ).toBeUndefined();
   });
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-probe-transport.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-probe-transport.test.ts
@@ -17,14 +17,14 @@
  * window runs instantly.
  */
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
-import { DockerSandboxProvider } from "../docker-sandbox-provider";
+import { classifyHealthTimeoutDetail, DockerSandboxProvider } from "../docker-sandbox-provider";
 import { DockerSSHClient } from "../docker-ssh";
 
 type PollInternals = {
   pollSshDockerHealth: (
     meta: ContainerMetaShape,
     deadline: number,
-  ) => Promise<{ ready: boolean; verdict: string }>;
+  ) => Promise<{ ready: boolean; verdict: string; detail?: string; diagnostics?: string }>;
   hydrateContainerFromDb: (sandboxId: string) => Promise<ContainerMetaShape | null>;
 };
 
@@ -165,5 +165,60 @@ describe("pollSshDockerHealth transport-vs-not-ready classification (#15310 #6)"
     const outcome = await internals.pollSshDockerHealth(META, Date.now() + 50);
     expect(outcome.ready).toBe(true);
     expect(outcome.verdict).toBe("ready");
+  });
+
+  test("not_ready timeout carries the classified reason + boot-log tail (#13406)", async () => {
+    const provider = new DockerSandboxProvider();
+    const internals = provider as unknown as PollInternals;
+    spyOn(internals, "hydrateContainerFromDb").mockResolvedValue(META);
+    stubPollWaitsWithClock();
+
+    // Reached-but-unhealthy for the whole budget (→ not_ready), and the FINAL
+    // diagnostics collection (the joined command carrying `--- inspect ---`)
+    // returns a realistic docker inspect + boot-log tail.
+    fakeSsh((command: string) => {
+      if (command.includes("--- inspect ---")) {
+        return [
+          "--- inspect ---",
+          "state=exited health= exit=1 error=OOMKilled",
+          "--- ports ---",
+          "",
+          "--- logs ---",
+          "[boot] FATAL: SANDBOX_ROUTE_AGENT_ID missing, cannot start",
+        ].join("\n");
+      }
+      if (command.includes("docker inspect")) return "starting"; // probe: reached, unhealthy
+      return REMOTE_NOT_READY(); // host probe: reached (exit 1)
+    });
+
+    const outcome = await internals.pollSshDockerHealth(META, Date.now() + 50);
+
+    expect(outcome.ready).toBe(false);
+    expect(outcome.verdict).toBe("not_ready");
+    // The opaque "health check timed out" now carries WHY the container failed.
+    expect(outcome.detail).toBe("container not running (state=exited exit=1) error=OOMKilled");
+    expect(outcome.diagnostics).toContain("FATAL: SANDBOX_ROUTE_AGENT_ID missing");
+  });
+});
+
+describe("classifyHealthTimeoutDetail", () => {
+  test("exited container → not-running reason with exit code + docker error", () => {
+    expect(
+      classifyHealthTimeoutDetail(
+        "--- inspect ---\nstate=exited health= exit=137 error=OOMKilled\n--- logs ---\nkilled",
+      ),
+    ).toBe("container not running (state=exited exit=137) error=OOMKilled");
+  });
+
+  test("running but unhealthy → surfaces the health status", () => {
+    expect(classifyHealthTimeoutDetail("state=running health=unhealthy exit=0 error=")).toBe(
+      "container running but health=unhealthy",
+    );
+  });
+
+  test("no inspect line → undefined so the caller keeps the generic message", () => {
+    expect(
+      classifyHealthTimeoutDetail("--- logs ---\nonly logs, the inspect step failed"),
+    ).toBeUndefined();
   });
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-probe-transport.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-probe-transport.test.ts
@@ -214,9 +214,7 @@ describe("classifyHealthTimeoutDetail", () => {
 
   test("running but unhealthy → surfaces the health status", () => {
     expect(
-      classifyHealthTimeoutDetail(
-        "--- inspect ---\nstate=running health=unhealthy exit=0 error=",
-      ),
+      classifyHealthTimeoutDetail("--- inspect ---\nstate=running health=unhealthy exit=0 error="),
     ).toBe("container running but health=unhealthy");
   });
 

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
@@ -828,32 +828,24 @@ PY`;
 }
 
 /**
- * Cap for the boot-diagnostics tail persisted into `agent_sandboxes.error_message`
- * on a health-check timeout. The full 12 KB tail still goes to the logger; the
- * DB/UI copy is bounded so one wedged provision cannot bloat the row.
- */
-const HEALTH_TIMEOUT_ERROR_DIAGNOSTICS_CHARS = 2_000;
-
-/**
- * Classify a health-check timeout from the `docker inspect` line embedded in the
- * collected diagnostics ("state=<s> health=<h> exit=<n> error=<e>") into a
- * one-line reason for `error_message`. Returns undefined when that line is
- * absent (e.g. the inspect itself failed) so the caller keeps the generic
- * message rather than inventing a state.
+ * Classify a health-check timeout from the allowlisted fields in the dedicated
+ * `docker inspect` section. Container-controlled logs and Docker's free-text
+ * error field remain restricted to backend logs because they may contain
+ * credentials or user data.
  */
 export function classifyHealthTimeoutDetail(diagnostics: string): string | undefined {
-  const match = diagnostics.match(/state=(\S*)\s+health=(\S*)\s+exit=(\S*)\s+error=(.*)$/m);
+  const match = diagnostics.match(
+    /^--- inspect ---\r?\nstate=(created|running|paused|restarting|removing|exited|dead) health=(starting|healthy|unhealthy)? exit=(\d+) error=.*$/m,
+  );
   if (!match) return undefined;
-  const [, state, health, exit, rawError] = match;
-  const error = rawError?.trim();
-  const errorPart = error ? ` error=${error}` : "";
-  if (state && state !== "running") {
-    return `container not running (state=${state} exit=${exit})${errorPart}`;
+  const [, state, health, exit] = match;
+  if (state !== "running") {
+    return `container not running (state=${state} exit=${exit})`;
   }
   if (health && health !== "healthy") {
-    return `container running but health=${health}${errorPart}`;
+    return `container running but health=${health}`;
   }
-  return `container running (state=${state || "unknown"} health=${health || "none"})${errorPart}`;
+  return undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -2148,7 +2140,6 @@ export class DockerSandboxProvider implements SandboxProvider {
       current.sshUser,
     );
     let detail: string | undefined;
-    let diagnosticsTail: string | undefined;
     try {
       const diagnostics = await ssh.exec(
         [
@@ -2167,9 +2158,9 @@ export class DockerSandboxProvider implements SandboxProvider {
         diagnostics: diagnostics.slice(-12_000),
       });
       detail = classifyHealthTimeoutDetail(diagnostics);
-      diagnosticsTail =
-        diagnostics.slice(-HEALTH_TIMEOUT_ERROR_DIAGNOSTICS_CHARS).trim() || undefined;
     } catch (diagnosticsError) {
+      // error-policy:J4 supplemental diagnostics may degrade to the explicit
+      // generic not-ready failure; they never turn the failed probe into success.
       logger.warn("[docker-sandbox] Failed to collect health timeout diagnostics", {
         containerName: current.containerName,
         error:
@@ -2177,10 +2168,8 @@ export class DockerSandboxProvider implements SandboxProvider {
       });
     }
     // We reached the container at least once but it never answered healthy — a
-    // genuine not-ready verdict (terminal), not a transport false-negative. Carry
-    // the classified reason + boot-log tail so the caller persists WHY into
-    // error_message instead of an opaque "Sandbox health check timed out" (#13406).
-    return { ready: false, verdict: "not_ready", detail, diagnostics: diagnosticsTail };
+    // genuine not-ready verdict (terminal), not a transport false-negative.
+    return { ready: false, verdict: "not_ready", detail };
   }
 
   // ------------------------------------------------------------------

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
@@ -827,6 +827,35 @@ PY`;
   return extractStewardToken(rawToken);
 }
 
+/**
+ * Cap for the boot-diagnostics tail persisted into `agent_sandboxes.error_message`
+ * on a health-check timeout. The full 12 KB tail still goes to the logger; the
+ * DB/UI copy is bounded so one wedged provision cannot bloat the row.
+ */
+const HEALTH_TIMEOUT_ERROR_DIAGNOSTICS_CHARS = 2_000;
+
+/**
+ * Classify a health-check timeout from the `docker inspect` line embedded in the
+ * collected diagnostics ("state=<s> health=<h> exit=<n> error=<e>") into a
+ * one-line reason for `error_message`. Returns undefined when that line is
+ * absent (e.g. the inspect itself failed) so the caller keeps the generic
+ * message rather than inventing a state.
+ */
+export function classifyHealthTimeoutDetail(diagnostics: string): string | undefined {
+  const match = diagnostics.match(/state=(\S*)\s+health=(\S*)\s+exit=(\S*)\s+error=(.*)$/m);
+  if (!match) return undefined;
+  const [, state, health, exit, rawError] = match;
+  const error = rawError?.trim();
+  const errorPart = error ? ` error=${error}` : "";
+  if (state && state !== "running") {
+    return `container not running (state=${state} exit=${exit})${errorPart}`;
+  }
+  if (health && health !== "healthy") {
+    return `container running but health=${health}${errorPart}`;
+  }
+  return `container running (state=${state || "unknown"} health=${health || "none"})${errorPart}`;
+}
+
 // ---------------------------------------------------------------------------
 // DockerSandboxProvider
 // ---------------------------------------------------------------------------
@@ -2118,6 +2147,8 @@ export class DockerSandboxProvider implements SandboxProvider {
       current.hostKeyFingerprint,
       current.sshUser,
     );
+    let detail: string | undefined;
+    let diagnosticsTail: string | undefined;
     try {
       const diagnostics = await ssh.exec(
         [
@@ -2135,6 +2166,9 @@ export class DockerSandboxProvider implements SandboxProvider {
         nodeId: current.nodeId,
         diagnostics: diagnostics.slice(-12_000),
       });
+      detail = classifyHealthTimeoutDetail(diagnostics);
+      diagnosticsTail =
+        diagnostics.slice(-HEALTH_TIMEOUT_ERROR_DIAGNOSTICS_CHARS).trim() || undefined;
     } catch (diagnosticsError) {
       logger.warn("[docker-sandbox] Failed to collect health timeout diagnostics", {
         containerName: current.containerName,
@@ -2143,8 +2177,10 @@ export class DockerSandboxProvider implements SandboxProvider {
       });
     }
     // We reached the container at least once but it never answered healthy — a
-    // genuine not-ready verdict (terminal), not a transport false-negative.
-    return { ready: false, verdict: "not_ready" };
+    // genuine not-ready verdict (terminal), not a transport false-negative. Carry
+    // the classified reason + boot-log tail so the caller persists WHY into
+    // error_message instead of an opaque "Sandbox health check timed out" (#13406).
+    return { ready: false, verdict: "not_ready", detail, diagnostics: diagnosticsTail };
   }
 
   // ------------------------------------------------------------------

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -5,6 +5,7 @@
 
 import crypto from "node:crypto";
 import { isIP } from "node:net";
+import { ElizaError } from "@elizaos/core";
 import { and, desc, eq, inArray, sql } from "drizzle-orm";
 import { type Database, dbWrite } from "../../db/helpers";
 import { agentBillingRepository } from "../../db/repositories/agent-billing";
@@ -1700,10 +1701,12 @@ export class ElizaSandboxService {
                 "leaving the container in place for retry/reconciliation",
             );
           }
-          throw new Error(
-            `Sandbox health check timed out${health.detail ? `: ${health.detail}` : ""}${
-              health.diagnostics ? `\n--- container diagnostics ---\n${health.diagnostics}` : ""
-            }`,
+          throw new ElizaError(
+            `Sandbox health check timed out${health.detail ? `: ${health.detail}` : ""}`,
+            {
+              code: "SANDBOX_HEALTH_CHECK_TIMEOUT",
+              context: health.detail ? { detail: health.detail } : {},
+            },
           );
         }
 

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -1700,7 +1700,11 @@ export class ElizaSandboxService {
                 "leaving the container in place for retry/reconciliation",
             );
           }
-          throw new Error("Sandbox health check timed out");
+          throw new Error(
+            `Sandbox health check timed out${health.detail ? `: ${health.detail}` : ""}${
+              health.diagnostics ? `\n--- container diagnostics ---\n${health.diagnostics}` : ""
+            }`,
+          );
         }
 
         // C1b attribution guard (audit §C1b/§C5): a docker-fleet container MUST

--- a/packages/cloud/shared/src/lib/services/sandbox-provider-types.ts
+++ b/packages/cloud/shared/src/lib/services/sandbox-provider-types.ts
@@ -20,22 +20,10 @@ export interface SandboxHealthOutcome {
   ready: boolean;
   verdict: SandboxHealthVerdict;
   /**
-   * One-line classification of a `not_ready` outcome parsed from the container's
-   * docker inspect at timeout — e.g. "container not running (state=exited
-   * exit=1)" vs "container running but health=unhealthy". Undefined when ready,
-   * transport-unresolved, or when the provider cannot classify. Surfaced into
-   * `agent_sandboxes.error_message` so a timed-out provision records WHY instead
-   * of an opaque "Sandbox health check timed out" (#13406 dedicated-error triage).
+   * One-line classification built only from allowlisted Docker state, health,
+   * and numeric exit fields. Free-text diagnostics never cross this boundary.
    */
   detail?: string;
-  /**
-   * Bounded tail of the container boot diagnostics (docker inspect + published
-   * ports + `docker logs`) captured at the timeout. Undefined when ready,
-   * transport-unresolved, or uncollectable. Persisted (truncated) into
-   * `error_message` so the boot-failure reason is visible without SSHing to the
-   * node — the full untruncated tail is still emitted to the logger.
-   */
-  diagnostics?: string;
 }
 
 export interface SandboxProvider {

--- a/packages/cloud/shared/src/lib/services/sandbox-provider-types.ts
+++ b/packages/cloud/shared/src/lib/services/sandbox-provider-types.ts
@@ -19,6 +19,23 @@ export type SandboxHealthVerdict = "ready" | "not_ready" | "transport_unresolved
 export interface SandboxHealthOutcome {
   ready: boolean;
   verdict: SandboxHealthVerdict;
+  /**
+   * One-line classification of a `not_ready` outcome parsed from the container's
+   * docker inspect at timeout — e.g. "container not running (state=exited
+   * exit=1)" vs "container running but health=unhealthy". Undefined when ready,
+   * transport-unresolved, or when the provider cannot classify. Surfaced into
+   * `agent_sandboxes.error_message` so a timed-out provision records WHY instead
+   * of an opaque "Sandbox health check timed out" (#13406 dedicated-error triage).
+   */
+  detail?: string;
+  /**
+   * Bounded tail of the container boot diagnostics (docker inspect + published
+   * ports + `docker logs`) captured at the timeout. Undefined when ready,
+   * transport-unresolved, or uncollectable. Persisted (truncated) into
+   * `error_message` so the boot-failure reason is visible without SSHing to the
+   * node — the full untruncated tail is still emitted to the logger.
+   */
+  diagnostics?: string;
 }
 
 export interface SandboxProvider {


### PR DESCRIPTION
## Why

A dedicated provision that times out at readiness writes only `Sandbox health check timed out` to `agent_sandboxes.error_message`, although the Docker provider already collects state, health, exit status, and restricted boot diagnostics. Persisting raw diagnostics would improve triage but would also copy credentials or user data from container-controlled output into a durable, broadly surfaced DB field.

## What

- `SandboxHealthOutcome.detail` carries only an allowlisted Docker state, health state, and numeric exit code.
- Classification is anchored to the dedicated `--- inspect ---` section. Container-log lookalikes, invalid state/exit values, Docker's free-text error, ports, and boot logs never cross the provider boundary.
- Raw diagnostics remain on the existing structured backend logger path only.
- The provision boundary throws `ElizaError` with code `SANDBOX_HEALTH_CHECK_TIMEOUT`; its message includes the sanitized detail when available and otherwise remains the generic failure.
- `memory` / `local-docker` and `transport_unresolved` behavior is unchanged.

No schema change is required.

## Testing

Exact rebased head `f1c8129af8`:

```text
bun test ./packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-probe-transport.test.ts
9 pass, 0 fail, 21 expect() calls

bun run --cwd packages/cloud/shared typecheck
exit 0

bunx biome check <four touched files>
Checked 4 files. No fixes applied.

bun run audit:error-policy-ratchet
no new fallback-slop in touched files
```

The regression plants an API key, bearer token, signed URL, Docker free-text error, container-log lookalike, invalid state, and nonnumeric exit value. None appears in the returned health outcome; valid state/health/exit classification remains.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only service change; no rendered UI is touched.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only service change; no rendered UI is touched.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing visual flow is changed.
<!-- evidence-row:backend-logs -->
- [x] Focused test output is pasted above and exercises the real health-poll/classification code with only the SSH transport boundary controlled. A live failed-container artifact is still required before merge.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or API-request surface is changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model behavior is changed.
<!-- evidence-row:domain-artifacts -->
- [x] The regression's health outcome is the domain artifact: `detail="container not running (state=exited exit=1)"`; planted free text and secrets are absent. No schema, migration, on-chain, or generated-file artifact applies.

## Remaining merge gate

Run one real failed-container provision and attach the structured backend log plus final stored `agent_sandboxes.error_message`, confirming the durable value contains the useful allowlisted classification and none of the raw Docker error or boot log.
