### PR TITLE
fix(scripts): repo-scope mvp closeout project cards (#15852)

### DIFF
--- a/packages/scripts/__tests__/mvp-closeout-audit.test.ts
+++ b/packages/scripts/__tests__/mvp-closeout-audit.test.ts
@@ -120,6 +120,39 @@ describe("atomic MVP closeout audit", () => {
     );
   });
 
+  test("ignores a foreign-repo card absent from the eliza rows", () => {
+    // A Project-15 card from another repository has no eliza open/closed row,
+    // so keying by bare number made validateSnapshot hard-fail with
+    // "Project issue #999 is missing from open/closed snapshot rows". Repo
+    // scoping drops the foreign card instead of demanding an eliza row for it.
+    const crossRepo = snapshot();
+    crossRepo.project.items.push({
+      content: {
+        type: "Issue",
+        number: 999,
+        repository: "other-org/other-repo",
+        title: "Foreign issue 999",
+        url: "https://github.com/other-org/other-repo/issues/999",
+      },
+      title: "Foreign issue 999",
+      status: "Ready",
+      labels: ["mvp"],
+    });
+
+    expect(() => audit.validateSnapshot(crossRepo)).not.toThrow();
+    const report = audit.buildCloseoutReport(crossRepo);
+    expect(report.integrityOk).toBe(true);
+    expect(report.parity.readiness).toEqual([1, 2]);
+    expect(report.parity.evidence).toEqual([1, 2]);
+  });
+
+  test("labels a source-less snapshot unknown, not fixture", () => {
+    const anonymous = snapshot();
+    delete (anonymous as { source?: string }).source;
+    const report = audit.buildCloseoutReport(anonymous);
+    expect(report.snapshot.source).toBe("unknown");
+  });
+
   test("CLI emits one complete fixture report", () => {
     const dir = mkdtempSync(join(tmpdir(), "mvp-closeout-fixture-"));
     const fixture = join(dir, "snapshot.json");

--- a/packages/scripts/check-mvp-board-readiness.mjs
+++ b/packages/scripts/check-mvp-board-readiness.mjs
@@ -171,7 +171,7 @@ function projectItemRepository(item) {
   );
 }
 
-function normalizeProjectItems(payload, repo = DEFAULT_REPO) {
+export function normalizeProjectItems(payload, repo = DEFAULT_REPO) {
   const items = Array.isArray(payload) ? payload : (payload.items ?? []);
   const byNumber = new Map();
   const expectedRepo = normalizeRepository(repo);

--- a/packages/scripts/run-mvp-closeout-audit.mjs
+++ b/packages/scripts/run-mvp-closeout-audit.mjs
@@ -14,7 +14,10 @@ import {
   strictViolations,
   summarizeMvpBoard,
 } from "./audit-mvp-project-board.mjs";
-import { auditMvpBoardReadiness } from "./check-mvp-board-readiness.mjs";
+import {
+  auditMvpBoardReadiness,
+  normalizeProjectItems,
+} from "./check-mvp-board-readiness.mjs";
 
 const DEFAULT_OWNER = "elizaOS";
 const DEFAULT_PROJECT = "15";
@@ -174,10 +177,15 @@ export function validateSnapshot(snapshot) {
     }
   }
 
+  // Scope cards to the audited repository the same way normalizeProjectItems
+  // does for readiness, so a foreign-repo card that happens to share an issue
+  // number can neither mask a divergence nor hard-fail the open/closed check
+  // ("Project issue #N is missing from open/closed snapshot rows").
   const projectNumbers = new Set(
-    snapshot.project.items
-      .filter((item) => item?.content?.type === "Issue")
-      .map((item) => item.content.number),
+    normalizeProjectItems(
+      snapshot.project,
+      snapshot.repo ?? DEFAULT_REPO,
+    ).keys(),
   );
   if (projectNumbers.size === 0) {
     throw new Error("snapshot contains no Project issue cards");
@@ -247,7 +255,9 @@ export function buildCloseoutReport(snapshot) {
     generatedAt: new Date().toISOString(),
     snapshot: {
       fetchedAt: snapshot.fetchedAt ?? null,
-      source: snapshot.source ?? "fixture",
+      // A source-less snapshot is of unknown provenance, not a fixture:
+      // label it distinctly rather than asserting a false origin.
+      source: snapshot.source ?? "unknown",
       owner: snapshot.owner ?? null,
       projectNumber: snapshot.projectNumber ?? null,
       repo: snapshot.repo ?? DEFAULT_REPO,


### PR DESCRIPTION
## Summary

Closes #15852.

`validateSnapshot` in `packages/scripts/run-mvp-closeout-audit.mjs` keyed Project-15 cards by **bare issue number** with no repository check, unlike `normalizeProjectItems` in `check-mvp-board-readiness.mjs`. Consequences:

- A card from another repository has no eliza open/closed row, so the audit hard-fails: `Project issue #N is missing from open/closed snapshot rows` (fails closed — safe, but a false negative).
- A number collision with an eliza issue could theoretically mask a divergence.
- `source: snapshot.source ?? "fixture"` mislabeled a source-less snapshot as a `fixture`.

## Fix

1. Scope the project card numbers to the audited repository by **reusing** `normalizeProjectItems` (now exported from `check-mvp-board-readiness.mjs`) — the same repo-filtering readiness already uses. Foreign-repo cards are dropped instead of demanding an eliza row.
2. Replace the `?? "fixture"` default with a distinct `"unknown"` label, so a source-less snapshot is honestly labeled rather than asserting a false origin.

## Tests

Two real regression cases added to the existing suite (drive the real `validateSnapshot` / `buildCloseoutReport`, no mocks):

- `ignores a foreign-repo card absent from the eliza rows` — an `other-org/other-repo` card #999 with no eliza row.
- `labels a source-less snapshot unknown, not fixture`.

Fail-before / pass-after (source reverted vs. applied):

```
=== FAIL-BEFORE (source reverted) ===
(fail) ... > ignores a foreign-repo card absent from the eliza rows
(fail) ... > labels a source-less snapshot unknown, not fixture
 5 pass
 2 fail
=== PASS-AFTER (fix applied) ===
 7 pass
 0 fail
Ran 7 tests across 1 file.
```

Readiness suite (verifies the new export didn't regress its owner): `15 pass, 0 fail`.
Biome check on all three touched files: exit 0. `packages/scripts` has no tsconfig/typecheck lane (plain tooling; bun runs the `.ts` test directly).

- Frontend/UI evidence: N/A — build-tooling script, no user-facing surface.
- Real-LLM trajectories: N/A — deterministic snapshot audit, no model in the path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-row:before-screenshots -->
- [ ] N/A - script-only project audit fix; no UI surface changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - script-only project audit fix; no UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - script-only project audit fix; no user-facing walkthrough path.

<!-- evidence-row:backend-logs -->
- [ ] N/A - local repository script change; no server/runtime path.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic project snapshot audit; no model path.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persisted domain artifact; regression proof is the test output in the PR body.
