### PR TITLE
fix(ci): coverage-gate three-dot diff from merge-base (#15845)

### DIFF
--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -44,50 +44,13 @@ jobs:
 
       - name: Determine changed files
         id: changed
+        # Three-dot diff (merge-base..HEAD) so a branch trailing develop does not
+        # count develop-side files it never touched. Logic lives in the script so
+        # its path/diff boundary rules are regression-tested (issue #15845).
         run: |
-          BASE=${{ github.event.pull_request.base.sha }}
-          HEAD=${{ github.event.pull_request.head.sha }}
-          {
-            echo 'files<<EOF'
-            git diff --name-only "$BASE" "$HEAD" -- '*.ts' '*.tsx' '*.js' '*.jsx' \
-              | grep -vE '(^|/)(__tests__|test|tests)/|[.](test|spec)[.](ts|tsx|js|jsx|mjs)$' || true
-            echo 'EOF'
-            echo 'bun_tests<<EOF'
-            git diff --name-only "$BASE" "$HEAD" -- \
-              '*.test.ts' '*.test.tsx' '*.test.js' '*.test.jsx' '*.test.mjs' \
-              '*.spec.ts' '*.spec.tsx' '*.spec.js' '*.spec.jsx' '*.spec.mjs' \
-              | while IFS= read -r file; do
-                  [ -f "$file" ] || continue
-                  case "$file" in
-                    *.e2e.test.*|*.live.test.*|packages/app/test/android/*.android.spec.*) continue ;;
-                  esac
-                  if grep -Eq "from ['\"]vitest['\"]|require\\(['\"]vitest['\"]\\)" "$file"; then
-                    continue
-                  fi
-                  if grep -Eq "from ['\"]@playwright/test['\"]|require\\(['\"]@playwright/test['\"]\\)" "$file"; then
-                    continue
-                  fi
-                  echo "$file"
-                done
-            echo 'EOF'
-            echo 'vitest_tests<<EOF'
-            git diff --name-only "$BASE" "$HEAD" -- \
-              '*.test.ts' '*.test.tsx' '*.test.js' '*.test.jsx' '*.test.mjs' \
-              '*.spec.ts' '*.spec.tsx' '*.spec.js' '*.spec.jsx' '*.spec.mjs' \
-              | while IFS= read -r file; do
-                  [ -f "$file" ] || continue
-                  case "$file" in
-                    *.e2e.test.*|*.live.test.*|packages/app/test/android/*.android.spec.*) continue ;;
-                  esac
-                  if grep -Eq "from ['\"]@playwright/test['\"]|require\\(['\"]@playwright/test['\"]\\)" "$file"; then
-                    continue
-                  fi
-                  if grep -Eq "from ['\"]vitest['\"]|require\\(['\"]vitest['\"]\\)" "$file"; then
-                    echo "$file"
-                  fi
-                done
-            echo 'EOF'
-          } >> "$GITHUB_OUTPUT"
+          bash scripts/security/coverage-changed-files.sh \
+            "${{ github.event.pull_request.base.sha }}" \
+            "${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
 
       - name: Require changed tests for changed source
         if: steps.changed.outputs.files != '' && steps.changed.outputs.bun_tests == '' && steps.changed.outputs.vitest_tests == ''

--- a/scripts/security/coverage-changed-files.self-test.mjs
+++ b/scripts/security/coverage-changed-files.self-test.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+/**
+ * Regression checks for the changed-file enumerator the coverage gate consumes.
+ * Each case builds a throwaway git repo whose history reproduces a real gate
+ * hazard, runs the actual coverage-changed-files.sh against it, and asserts the
+ * emitted GITHUB_OUTPUT sections. The two-dot regression (issue #15845) is
+ * pinned by first proving a plain `BASE..HEAD` diff *would* drag a develop-side
+ * file in, then asserting the script's three-dot diff does not.
+ */
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+const root = new URL("../..", import.meta.url).pathname;
+const script = join(root, "scripts/security/coverage-changed-files.sh");
+
+function git(cwd, ...args) {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8" });
+  assert.equal(
+    result.status,
+    0,
+    `git ${args.join(" ")} failed: ${result.stderr}`,
+  );
+  return result.stdout.trim();
+}
+
+function write(cwd, relPath, contents) {
+  const full = join(cwd, relPath);
+  mkdirSync(dirname(full), { recursive: true });
+  writeFileSync(full, contents);
+}
+
+// Parse the `name<<EOF\n...\nEOF` heredoc blocks the script emits so assertions
+// read against the same shape GitHub Actions stores into step outputs.
+function parseOutput(stdout) {
+  const sections = {};
+  const lines = stdout.split("\n");
+  let key = null;
+  let buf = [];
+  for (const line of lines) {
+    if (key === null) {
+      const m = line.match(/^(\w+)<<EOF$/);
+      if (m) {
+        key = m[1];
+        buf = [];
+      }
+      continue;
+    }
+    if (line === "EOF") {
+      sections[key] = buf.filter((l) => l !== "");
+      key = null;
+      continue;
+    }
+    buf.push(line);
+  }
+  return sections;
+}
+
+function runScript(cwd, base, head) {
+  const result = spawnSync("bash", [script, base, head], {
+    cwd,
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  return parseOutput(result.stdout);
+}
+
+function assertCase(name, fn) {
+  try {
+    fn();
+    console.log(`ok - ${name}`);
+  } catch (error) {
+    console.error(`not ok - ${name}`);
+    throw error;
+  }
+}
+
+const dir = mkdtempSync(join(tmpdir(), "coverage-changed-"));
+try {
+  git(dir, "init", "-q");
+  git(dir, "config", "user.email", "test@example.com");
+  git(dir, "config", "user.name", "test");
+  git(dir, "checkout", "-q", "-b", "develop");
+
+  // Merge-base commit: the point the feature branch forks from.
+  write(dir, "packages/demo/src/base.ts", "export const base = 1;\n");
+  git(dir, "add", "-A");
+  git(dir, "commit", "-q", "-m", "base");
+  const mergeBase = git(dir, "rev-parse", "HEAD");
+
+  // develop advances with a file the feature branch never touches.
+  write(dir, "packages/demo/src/develop-only.ts", "export const d = 1;\n");
+  git(dir, "add", "-A");
+  git(dir, "commit", "-q", "-m", "develop advances");
+  const developTip = git(dir, "rev-parse", "HEAD"); // BASE (event-time develop tip)
+
+  // Feature branch forks from the merge-base and adds its own source + tests.
+  git(dir, "checkout", "-q", "-b", "feature", mergeBase);
+  write(dir, "packages/demo/src/feature.ts", "export const f = 1;\n");
+  write(
+    dir,
+    "packages/demo/src/feature.test.ts",
+    "import { test } from 'vitest';\ntest('f', () => {});\n",
+  );
+  write(
+    dir,
+    "packages/demo/src/native.test.ts",
+    "import { test } from 'bun:test';\ntest('n', () => {});\n",
+  );
+  write(
+    dir,
+    "packages/demo/test/e2e/flow.test.ts",
+    "import { test } from 'bun:test';\ntest('e2e', () => {});\n",
+  );
+  git(dir, "add", "-A");
+  git(dir, "commit", "-q", "-m", "feature work");
+  const featureTip = git(dir, "rev-parse", "HEAD"); // HEAD
+
+  const out = runScript(dir, developTip, featureTip);
+
+  assertCase(
+    "three-dot diff excludes develop-side files (issue #15845)",
+    () => {
+      // Prove the hazard is real: a plain two-dot diff would drag the develop-only
+      // file into the changed set.
+      const twoDot = git(
+        dir,
+        "diff",
+        "--name-only",
+        developTip,
+        featureTip,
+      ).split("\n");
+      assert.ok(
+        twoDot.includes("packages/demo/src/develop-only.ts"),
+        "expected two-dot diff to include the develop-side file",
+      );
+      // The script uses three-dot, so it must not.
+      assert.ok(
+        !out.files.includes("packages/demo/src/develop-only.ts"),
+        `develop-side file leaked into changed source: ${out.files.join(",")}`,
+      );
+      assert.ok(
+        out.files.includes("packages/demo/src/feature.ts"),
+        `feature source missing from changed set: ${out.files.join(",")}`,
+      );
+    },
+  );
+
+  assertCase(
+    "e2e directory tests excluded from unit lanes (issue #15845)",
+    () => {
+      assert.ok(
+        !out.bun_tests.includes("packages/demo/test/e2e/flow.test.ts"),
+        `e2e-dir test leaked into bun lane: ${out.bun_tests.join(",")}`,
+      );
+      assert.ok(
+        !out.vitest_tests.includes("packages/demo/test/e2e/flow.test.ts"),
+        `e2e-dir test leaked into vitest lane: ${out.vitest_tests.join(",")}`,
+      );
+    },
+  );
+
+  assertCase("unit tests bucket by imported runner", () => {
+    assert.ok(
+      out.bun_tests.includes("packages/demo/src/native.test.ts"),
+      `bun-native test missing: ${out.bun_tests.join(",")}`,
+    );
+    assert.ok(
+      !out.bun_tests.includes("packages/demo/src/feature.test.ts"),
+      "vitest test wrongly in bun lane",
+    );
+    assert.ok(
+      out.vitest_tests.includes("packages/demo/src/feature.test.ts"),
+      `vitest test missing: ${out.vitest_tests.join(",")}`,
+    );
+  });
+} finally {
+  rmSync(dir, { recursive: true, force: true });
+}

--- a/scripts/security/coverage-changed-files.sh
+++ b/scripts/security/coverage-changed-files.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Enumerates the source and unit-test files a pull request actually changed, in
+# the GITHUB_OUTPUT heredoc format the coverage-gate workflow consumes. It is
+# invoked by .github/workflows/coverage-gate.yml as
+# `coverage-changed-files.sh "$BASE" "$HEAD" >> "$GITHUB_OUTPUT"`, and lives as a
+# standalone script (rather than inline YAML) so its path/diff boundary rules are
+# regression-tested by coverage-changed-files.self-test.mjs against a real git
+# repo.
+#
+# The diff is three-dot: it walks from `git merge-base BASE HEAD` to HEAD, so
+# only files the branch itself touched enter the lane. A plain two-dot
+# `BASE..HEAD` diff would count develop-side files the branch never touched as
+# "changed" whenever the branch trails develop, dragging unrelated tests into the
+# gate (issue #15845). Test files are bucketed into a Bun-native lane and a
+# Vitest lane by which runner they import; e2e/live suites and Android specs are
+# excluded by both filename and directory so a `test/e2e/` path cannot slip into
+# the fast unit lane.
+set -euo pipefail
+
+BASE=$1
+HEAD=$2
+
+# Fail fast: an empty merge-base means the two commits share no history (bad
+# fetch depth / wrong refs), which would otherwise silently diff the entire tree.
+MERGE_BASE=$(git merge-base "$BASE" "$HEAD")
+if [ -z "$MERGE_BASE" ]; then
+  echo "coverage-changed-files: no merge-base between $BASE and $HEAD" >&2
+  exit 1
+fi
+
+# Excluded from both unit lanes: e2e/live suites (by filename *and* by a
+# `test/e2e/` directory segment) and Android specs. These run in dedicated lanes
+# and pull in heavy harnesses that the changed-file coverage gate must not.
+is_excluded_test() {
+  case "$1" in
+    *.e2e.test.*|*.live.test.*|packages/app/test/android/*.android.spec.*) return 0 ;;
+    */test/e2e/*|test/e2e/*|*/e2e/*.test.*|e2e/*.test.*) return 0 ;;
+  esac
+  return 1
+}
+
+changed_source() {
+  git diff --name-only "$MERGE_BASE" "$HEAD" -- '*.ts' '*.tsx' '*.js' '*.jsx' \
+    | grep -vE '(^|/)(__tests__|test|tests)/|[.](test|spec)[.](ts|tsx|js|jsx|mjs)$' || true
+}
+
+changed_tests() {
+  git diff --name-only "$MERGE_BASE" "$HEAD" -- \
+    '*.test.ts' '*.test.tsx' '*.test.js' '*.test.jsx' '*.test.mjs' \
+    '*.spec.ts' '*.spec.tsx' '*.spec.js' '*.spec.jsx' '*.spec.mjs'
+}
+
+echo 'files<<EOF'
+changed_source
+echo 'EOF'
+
+echo 'bun_tests<<EOF'
+changed_tests | while IFS= read -r file; do
+  [ -f "$file" ] || continue
+  is_excluded_test "$file" && continue
+  if grep -Eq "from ['\"]vitest['\"]|require\\(['\"]vitest['\"]\\)" "$file"; then
+    continue
+  fi
+  if grep -Eq "from ['\"]@playwright/test['\"]|require\\(['\"]@playwright/test['\"]\\)" "$file"; then
+    continue
+  fi
+  echo "$file"
+done
+echo 'EOF'
+
+echo 'vitest_tests<<EOF'
+changed_tests | while IFS= read -r file; do
+  [ -f "$file" ] || continue
+  is_excluded_test "$file" && continue
+  if grep -Eq "from ['\"]@playwright/test['\"]|require\\(['\"]@playwright/test['\"]\\)" "$file"; then
+    continue
+  fi
+  if grep -Eq "from ['\"]vitest['\"]|require\\(['\"]vitest['\"]\\)" "$file"; then
+    echo "$file"
+  fi
+done
+echo 'EOF'


### PR DESCRIPTION
Fixes #15845.

## What
The coverage-gate "Determine changed files" step computed changed files with a **two-dot** `git diff $BASE $HEAD`, where `BASE` is the event-time develop tip. A branch trailing develop therefore counted develop-side files it never touched as "changed", dragging unrelated tests into the gate — the false red on #15743. The e2e filter also matched by **filename only** (`*.e2e.test.*`), so a `packages/.../test/e2e/…test.ts` directory test slipped into the fast Bun unit lane.

(Defect #3 from the issue — bun-native tests running without a workspace build — was already resolved on develop by #15829's `--conditions=eliza-source`.)

## Fix
- Extract the enumeration into `scripts/security/coverage-changed-files.sh` (mirrors the existing `coverage-gate.awk` + `.self-test.mjs` pattern) so its diff/path rules are regression-tested against a real git repo instead of buried in inline YAML.
- Use a **three-dot** diff from `git merge-base "$BASE" "$HEAD"` — only files the branch itself changed enter the lane. Fail-fast if no merge-base exists.
- Exclude e2e/live suites by **directory** (`*/test/e2e/*`, `*/e2e/*.test.*`) as well as filename.
- Workflow step now just calls the script.

## Test evidence
`scripts/security/coverage-changed-files.self-test.mjs` builds a throwaway git repo (merge-base → develop advances with `develop-only.ts` → feature branch forks and adds source + tests), runs the **real script**, and asserts behavior. It first proves a plain two-dot diff *would* leak the develop-side file, then asserts the script does not.

Pass-after (fix in place):
```
ok - three-dot diff excludes develop-side files (issue #15845)
ok - e2e directory tests excluded from unit lanes (issue #15845)
ok - unit tests bucket by imported runner
```

Fail-before (reverting the script to two-dot + no e2e-dir exclusion):
```
not ok - three-dot diff excludes develop-side files (issue #15845)
AssertionError: develop-side file leaked into changed source:
  packages/demo/src/develop-only.ts,packages/demo/src/feature.ts
```

Gates: `shellcheck` clean on the script, `bash -n` OK, YAML parses, biome check clean on the `.mjs`. No TS touched → no typecheck. UI/LLM/native evidence: N/A — CI workflow + shell/node script only, no runtime UI or model surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-row:before-screenshots -->
- [ ] N/A - CI coverage-gate workflow/script fix; no UI surface changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - CI coverage-gate workflow/script fix; no UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - CI-only change; no user walkthrough path.

<!-- evidence-row:backend-logs -->
- [ ] N/A - GitHub Actions coverage-gate logic only; self-test output is included in the PR body.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic CI script; no model path.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persisted domain artifact; regression proof is the self-test output in the PR body.
