### PR TITLE
fix(evidence): reject stale imported OCR manifests (#15790)

### DIFF
--- a/packages/app/scripts/ocr-triage.ts
+++ b/packages/app/scripts/ocr-triage.ts
@@ -27,7 +27,7 @@
  * bug stays visible without wedging CI while a NEW pixel-broken render fails it.
  */
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { basename, dirname, join } from "node:path";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import { OVERLAY_NATIVE_OR_CANVAS_SLUGS } from "../test/ui-smoke/aesthetic-audit-rules";
 import {
   evaluateOcrContent,
@@ -181,6 +181,63 @@ function viewportOf(path: string): string {
   return basename(dirname(path));
 }
 
+function recordMatchesShotPath(
+  auditDir: string,
+  recordPath: string,
+  shotPath: string,
+): boolean {
+  const expected = resolve(shotPath);
+  if (resolve(recordPath) === expected) return true;
+  return !isAbsolute(recordPath) && resolve(auditDir, recordPath) === expected;
+}
+
+/**
+ * Bind imported OCR evidence one-to-one to the screenshots authorized by the
+ * current report. Filtering an over-broad NDJSON file would make a combined or
+ * stale evidence bundle look healthy after the bad records disappeared, so
+ * every missing, duplicate, unexpected, or path-mismatched record fails.
+ */
+export function validateImportedOcrRecords(
+  auditDir: string,
+  sourcePath: string,
+  shots: AuthorizedShot[],
+  records: OcrRecord[],
+): OcrRecord[] {
+  const expected = new Map(shots.map((shot) => [shot.key, shot]));
+  const byKey = new Map<string, OcrRecord>();
+
+  for (const record of records) {
+    const key = `${slugOf(record.path)}::${viewportOf(record.path)}`;
+    if (byKey.has(key)) {
+      throw new Error(
+        `[ocr-triage] duplicate OCR record ${key} in ${sourcePath} — each report row must have exactly one record.`,
+      );
+    }
+    const shot = expected.get(key);
+    if (!shot) {
+      throw new Error(
+        `[ocr-triage] unexpected OCR record ${key} in ${sourcePath} — imported OCR must exactly match the current report.`,
+      );
+    }
+    if (!recordMatchesShotPath(auditDir, record.path, shot.path)) {
+      throw new Error(
+        `[ocr-triage] OCR record ${key} points to ${record.path}, expected ${shot.path}.`,
+      );
+    }
+    byKey.set(key, record);
+  }
+
+  return shots.map((shot) => {
+    const record = byKey.get(shot.key);
+    if (!record) {
+      throw new Error(
+        `[ocr-triage] report row ${shot.key} has no OCR record in ${sourcePath} — the OCR input is out of sync with report.json.`,
+      );
+    }
+    return record;
+  });
+}
+
 export async function runOcrTriage(argv: string[]): Promise<TriageResult> {
   const args = parseArgs(argv);
   const auditDir = args["audit-dir"] ?? "aesthetic-audit-output";
@@ -209,25 +266,11 @@ export async function runOcrTriage(argv: string[]): Promise<TriageResult> {
 
   let ocr: OcrRecord[];
   if (args.ocr) {
-    // A precomputed OCR ndjson (CI / deterministic tests) is still filtered to
-    // the report: index its records by slug::viewport, then select exactly one
-    // per report row. A row with no matching record means the OCR input is out
-    // of sync with the report — fail loudly instead of skipping the view.
-    const byKey = new Map<string, OcrRecord>();
-    for (const line of readFileSync(args.ocr, "utf8").split("\n")) {
-      if (!line.trim()) continue;
-      const rec = JSON.parse(line) as OcrRecord;
-      byKey.set(`${slugOf(rec.path)}::${viewportOf(rec.path)}`, rec);
-    }
-    ocr = shots.map((s) => {
-      const rec = byKey.get(s.key);
-      if (!rec) {
-        throw new Error(
-          `[ocr-triage] report row ${s.key} has no OCR record in ${args.ocr} — the OCR input is out of sync with report.json.`,
-        );
-      }
-      return rec;
-    });
+    const records = readFileSync(args.ocr, "utf8")
+      .split("\n")
+      .filter((line) => line.trim())
+      .map((line) => JSON.parse(line) as OcrRecord);
+    ocr = validateImportedOcrRecords(auditDir, args.ocr, shots, records);
   } else {
     ocr = await runPackagedOcr(shots.map((s) => s.path));
   }

--- a/packages/app/test/audit/ocr-triage-provenance.test.ts
+++ b/packages/app/test/audit/ocr-triage-provenance.test.ts
@@ -23,6 +23,7 @@ import {
   authorizedShots,
   type ReportEntry,
   runOcrTriage,
+  validateImportedOcrRecords,
 } from "../../scripts/ocr-triage";
 
 // Changed-file coverage invokes Vitest from the repository root while the
@@ -150,18 +151,16 @@ describe("ocr-triage CLI (end-to-end provenance)", () => {
     }
   }
 
-  it("triages exactly the report rows and drops a stale PNG + stale OCR record", async () => {
+  it("triages exactly the report rows while ignoring an unreported stale PNG", async () => {
     for (const r of CURRENT_ROWS) shot(dir, r.viewport, r.slug);
     writeFileSync(join(dir, "report.json"), JSON.stringify(CURRENT_ROWS));
-    // Salt the directory with a retired-view PNG and its stale OCR record — the
-    // pre-fix glob would have OCR'd this and reported it as a current failure.
+    // A retired-view PNG can remain on disk, but it is not authorized evidence.
     shot(dir, "desktop-landscape", STALE_SLUG);
     writeFileSync(
       join(dir, "ocr.ndjson"),
       [
         ocrLine("desktop-landscape", "builtin-chat", "Chat messages composer"),
         ocrLine("desktop-landscape", "builtin-phone", "Phone dialer keypad"),
-        ocrLine("desktop-landscape", STALE_SLUG, "Social Alpha leaderboard"),
       ].join("\n"),
     );
 
@@ -195,6 +194,79 @@ describe("ocr-triage CLI (end-to-end provenance)", () => {
     expect(out.entries.some((e) => e.slug.includes("social-alpha"))).toBe(
       false,
     );
+  });
+
+  it("rejects imported OCR with missing, duplicate, unexpected, or mismatched records", () => {
+    for (const r of CURRENT_ROWS) shot(dir, r.viewport, r.slug);
+    const shots = authorizedShots(dir, CURRENT_ROWS);
+    const chat = JSON.parse(
+      ocrLine("desktop-landscape", "builtin-chat", "Chat messages composer"),
+    );
+    const phone = JSON.parse(
+      ocrLine("desktop-landscape", "builtin-phone", "Phone dialer keypad"),
+    );
+    const stale = JSON.parse(
+      ocrLine("desktop-landscape", STALE_SLUG, "Social Alpha leaderboard"),
+    );
+
+    expect(() =>
+      validateImportedOcrRecords(dir, "ocr.ndjson", shots, [chat]),
+    ).toThrow(/builtin-phone::desktop-landscape has no OCR record/);
+    expect(() =>
+      validateImportedOcrRecords(dir, "ocr.ndjson", shots, [
+        chat,
+        phone,
+        phone,
+      ]),
+    ).toThrow(/duplicate OCR record builtin-phone::desktop-landscape/);
+    expect(() =>
+      validateImportedOcrRecords(dir, "ocr.ndjson", shots, [
+        chat,
+        phone,
+        stale,
+      ]),
+    ).toThrow(/unexpected OCR record plugin-social-alpha-gui/);
+    expect(() =>
+      validateImportedOcrRecords(dir, "ocr.ndjson", shots, [
+        {
+          ...chat,
+          path: join(
+            tmpdir(),
+            "elsewhere",
+            "desktop-landscape",
+            "builtin-chat.png",
+          ),
+        },
+        phone,
+      ]),
+    ).toThrow(/builtin-chat::desktop-landscape points to/);
+  });
+
+  it("exits non-zero when imported OCR contains a stale record", async () => {
+    for (const r of CURRENT_ROWS) shot(dir, r.viewport, r.slug);
+    writeFileSync(join(dir, "report.json"), JSON.stringify(CURRENT_ROWS));
+    writeFileSync(
+      join(dir, "ocr.ndjson"),
+      [
+        ocrLine("desktop-landscape", "builtin-chat", "Chat messages composer"),
+        ocrLine("desktop-landscape", "builtin-phone", "Phone dialer keypad"),
+        ocrLine("desktop-landscape", STALE_SLUG, "Social Alpha leaderboard"),
+      ].join("\n"),
+    );
+
+    await expect(
+      runOcrTriage([
+        "--audit-dir",
+        dir,
+        "--ocr",
+        join(dir, "ocr.ndjson"),
+        "--out",
+        join(dir, "ocr-triage.json"),
+      ]),
+    ).rejects.toThrow(/unexpected OCR record plugin-social-alpha-gui/);
+    const { status, stderr } = run();
+    expect(status).not.toBe(0);
+    expect(stderr).toMatch(/unexpected OCR record plugin-social-alpha-gui/);
   });
 
   it("exits non-zero when a report row's screenshot is missing", async () => {


### PR DESCRIPTION
Closes #15790. Follow-up to merged #15805.

## Problem

#15805 correctly made screenshots report-authoritative, but imported `--ocr` NDJSON was narrowed through a `Map`: duplicate keys silently overwrote earlier records and unexpected/path-mismatched records disappeared when the code selected only report keys. A combined or stale evidence file could therefore look healthy after invalid records were filtered away.

## Change

- Bind imported OCR records one-to-one to the current report's authorized screenshots.
- Reject missing, duplicate, unexpected, and path-mismatched records with observable errors.
- Preserve the intended distinction: a stale PNG on disk is harmless because the report does not authorize it; a stale OCR record is malformed evidence and fails.
- Keep both in-process contract tests and the real CLI exit-code boundary.

## Verification

- `bunx biome check` on both touched files: clean.
- `bunx vitest run packages/app/test/audit/ocr-triage-provenance.test.ts`: 9 passed.
- Real CLI boundary exits nonzero for a stale imported OCR record.
- `git diff --check origin/develop...HEAD`: clean.
- App typecheck was attempted in the sparse shared checkout and stopped on pre-existing missing workspace dependencies; no touched-file diagnostic appeared. CI performs the required clean-install typecheck.

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] N/A - this tightens evidence validation and does not change product pixels.

<!-- evidence-row:after-screenshots -->
- [x] [Fresh 240-view audit montage](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15805-real-capture-montage.jpg) remains the pixel baseline; this PR changes only rejection of malformed imported OCR manifests.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - the affected flow is a headless OCR evidence boundary exercised by the real CLI test.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend runtime, route, service, or database behavior changed.

<!-- evidence-row:frontend-logs -->
- [x] [Verification transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15790-exact-ocr-verification.log) records Biome clean and the complete 9/9 provenance suite.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, prompt, provider, evaluator, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] [Verification transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15790-exact-ocr-verification.log) records exact-manifest contracts for missing, duplicate, unexpected, and path-mismatched OCR records plus the real stale-record CLI failure.

<!-- evidence-row:ocr-review -->
- [x] The linked verification transcript proves malformed imported OCR fails before a triage artifact can be reported healthy; the unchanged fresh 240-row OCR baseline is [here](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15805-real-ocr-triage.json).