### PR TITLE
fix(ui): de-slop chat widgets — chat-native, no card chrome

### DIFF
--- a/packages/ui/src/components/chat/MessageContent.tsx
+++ b/packages/ui/src/components/chat/MessageContent.tsx
@@ -171,7 +171,7 @@ function MessageTextBody({
 export function FormSubmitReceipt({ label }: { label: string }) {
   return (
     <div
-      className="inline-flex max-w-full items-center rounded-full border border-border/70 bg-bg px-2.5 py-1 text-xs font-medium text-muted-strong"
+      className="inline-flex max-w-full items-center py-1 text-xs font-medium text-muted-strong"
       data-testid="form-submit-receipt"
     >
       Submitted {label}
@@ -476,7 +476,7 @@ export const InlinePluginConfig = memo(function InlinePluginConfig({
 
   if (loading) {
     return (
-      <div className="my-2 px-3 py-2 border border-border bg-card text-xs text-muted italic">
+      <div className="my-2 py-2 text-xs text-muted italic">
         {t("messagecontent.LoadingConfiguration", {
           defaultValue: "Loading {{pluginId}} configuration...",
           pluginId,
@@ -487,7 +487,7 @@ export const InlinePluginConfig = memo(function InlinePluginConfig({
 
   if (!plugin) {
     return (
-      <div className="my-2 px-3 py-2 border border-border bg-card text-xs text-muted italic">
+      <div className="my-2 py-2 text-xs text-muted italic">
         {t("messagecontent.PluginNotFound", {
           defaultValue: 'Plugin "{{pluginId}}" not found.',
           pluginId,
@@ -585,7 +585,7 @@ export const InlinePluginConfig = memo(function InlinePluginConfig({
       {/* OAuth sign-in — shown for a cloud/OAuth-shaped mode instead of the env
           form. The API-key / local fallback is always one click away below. */}
       {selectedMode?.kind === "oauth" && (
-        <div className="p-3" data-testid="inline-plugin-config-oauth">
+        <div className="py-1.5" data-testid="inline-plugin-config-oauth">
           <Button
             variant="default"
             size="sm"
@@ -624,7 +624,7 @@ export const InlinePluginConfig = memo(function InlinePluginConfig({
       {/* Local desktop pairing (Discord IPC): one-click authorize instead of an
           env form, plus the mode's guidance text. */}
       {selectedMode?.kind === "local" && localSignIn && (
-        <div className="p-3" data-testid="inline-plugin-config-local">
+        <div className="py-1.5" data-testid="inline-plugin-config-local">
           {selectedMode.description && (
             <p className="mb-2 text-2xs text-muted">
               {selectedMode.description}
@@ -653,7 +653,7 @@ export const InlinePluginConfig = memo(function InlinePluginConfig({
           modes (and connectors with no declared modes at all). Hidden while an
           OAuth or one-click-local mode owns the body. */}
       {showConfigForm ? (
-        <div className="p-3">
+        <div className="py-1.5">
           {selectedMode?.description &&
             selectedMode.kind === "local" &&
             !localSignIn && (
@@ -673,7 +673,7 @@ export const InlinePluginConfig = memo(function InlinePluginConfig({
         </div>
       ) : selectedMode?.kind === "oauth" ||
         (selectedMode?.kind === "local" && localSignIn) ? null : (
-        <div className="px-3 py-2 text-xs text-muted italic">
+        <div className="py-1.5 text-xs text-muted italic">
           {t("messagecontent.NoConfigurablePara")}
         </div>
       )}
@@ -819,8 +819,8 @@ export function MessageUiSpecBlock({
   );
 
   return (
-    <div className="my-2 border border-border overflow-hidden">
-      <div className="flex items-center justify-between px-3 py-1.5 bg-bg-hover">
+    <div className="my-2 overflow-hidden">
+      <div className="flex items-center justify-between py-1">
         <span className="text-2xs font-semibold text-muted uppercase tracking-wider">
           {t("messagecontent.InteractiveUI")}
         </span>
@@ -840,13 +840,15 @@ export function MessageUiSpecBlock({
         </Button>
       </div>
       {showRaw && (
+        // The raw JSON pane keeps a code-block fill: it is code, and the fill
+        // separates it from the rendered widget below.
         <div className="px-3 py-2 bg-card overflow-x-auto overscroll-x-contain">
           <pre className="text-2xs text-muted font-mono whitespace-pre-wrap break-words m-0">
             {raw}
           </pre>
         </div>
       )}
-      <div className="p-3">
+      <div className="py-1.5">
         {/*
           A model-emitted UiSpec can be malformed in ways the renderer can't
           fully normalize (wrong-typed array props, unknown shapes). Without a
@@ -1002,7 +1004,7 @@ export function SensitiveRequestBlock({
   return (
     <div
       data-testid="sensitive-request"
-      className="my-2 border border-border bg-card p-3 text-sm space-y-3"
+      className="my-2 py-1.5 text-sm space-y-3"
     >
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0 break-words font-medium">{requestLabel}</div>

--- a/packages/ui/src/components/chat/widgets/ChoiceWidget.tsx
+++ b/packages/ui/src/components/chat/widgets/ChoiceWidget.tsx
@@ -134,9 +134,10 @@ export const ChoiceWidget = memo(function ChoiceWidget({
     <ChatWidgetShell
       title={firstRun ? "Choose next step" : "Choose"}
       status={
-        // bg-surface, not bg-bg: on the dark cloud/os themes bg-bg is a
-        // near-transparent alpha that left this chip unreadable (#15144).
-        <span className="rounded-sm bg-surface px-2 py-0.5 text-[11px] font-medium text-muted">
+        // Plain muted text, no pill chrome: the theme text token stays
+        // readable on every surface (chat-native de-slop, supersedes the
+        // #15144 pill-background fix by removing the pill).
+        <span className="text-[11px] font-medium text-muted">
           {selected ? "Selected" : `${options.length} options`}
         </span>
       }
@@ -151,8 +152,8 @@ export const ChoiceWidget = memo(function ChoiceWidget({
       <fieldset
         className={
           firstRun
-            ? "flex min-w-0 flex-col items-stretch gap-2 border-0 p-3"
-            : "flex min-w-0 flex-wrap items-center gap-2 border-0 p-3"
+            ? "flex min-w-0 flex-col items-stretch gap-2 border-0 py-1.5"
+            : "flex min-w-0 flex-wrap items-center gap-2 border-0 py-1.5"
         }
         aria-label={`Choose ${scope}`}
         data-choice-id={id}

--- a/packages/ui/src/components/chat/widgets/__e2e__/deslop-walkthrough-fixture.tsx
+++ b/packages/ui/src/components/chat/widgets/__e2e__/deslop-walkthrough-fixture.tsx
@@ -1,0 +1,67 @@
+// Walkthrough fixture for the chat-native widget de-slop: mounts the real
+// interactive widgets (choice → lock/collapse, form → submit/collapse,
+// checklist, workflow) so a recorded run demonstrates the chrome-free
+// rendering AND the intact collapse-on-complete contract end to end.
+import { createRoot } from "react-dom/client";
+import { ChoiceWidget } from "../ChoiceWidget";
+import { FormRequest } from "../form-request";
+import { ChecklistWidget } from "../task-pipeline";
+import { WorkflowSteps } from "../workflow-steps";
+
+const form = {
+  id: "walkthrough-form",
+  title: "Schedule a reminder",
+  description: "Pick what to call it and when it should fire.",
+  submitLabel: "Create reminder",
+  fields: [
+    { name: "title", label: "Title", type: "text" as const, required: true },
+    { name: "when", label: "When", type: "time" as const },
+    { name: "repeat", label: "Repeat daily", type: "checkbox" as const },
+  ],
+};
+
+const workflow = {
+  id: "walkthrough-workflow",
+  title: "Deploy",
+  steps: [
+    { label: "Build image", status: "done" as const },
+    { label: "Push to registry", status: "running" as const },
+    { label: "Roll out", status: "pending" as const },
+  ],
+};
+
+const checklist = [
+  { content: "Draft the migration runbook", status: "completed" },
+  { content: "Review with the on-call", status: "in_progress" },
+  { content: "Schedule the maintenance window", status: "pending" },
+];
+
+function log(kind: string, value: string) {
+  // The recorder asserts on these console lines.
+  console.log(`[walkthrough] ${kind}: ${value}`);
+}
+
+const root = createRoot(document.getElementById("root") as HTMLElement);
+root.render(
+  <div
+    className="mx-auto flex max-w-xl flex-col gap-6 p-5 text-txt"
+    data-testid="deslop-walkthrough"
+  >
+    <div className="text-[15px] leading-[1.7]">
+      Sure — I can set that up. A couple of quick questions:
+    </div>
+    <ChoiceWidget
+      id="walkthrough-choice"
+      scope="scheduling"
+      options={[
+        { value: "morning", label: "Morning (9am)" },
+        { value: "evening", label: "Evening (7pm)" },
+        { value: "cancel", label: "Cancel" },
+      ]}
+      onChoose={(v) => log("choice", v)}
+    />
+    <FormRequest form={form} onSubmit={(id) => log("form", id)} />
+    <WorkflowSteps workflow={workflow} />
+    <ChecklistWidget entries={checklist} title="Migration" />
+  </div>,
+);

--- a/packages/ui/src/components/chat/widgets/__e2e__/deslop-walkthrough-fixture.tsx
+++ b/packages/ui/src/components/chat/widgets/__e2e__/deslop-walkthrough-fixture.tsx
@@ -1,7 +1,9 @@
-// Walkthrough fixture for the chat-native widget de-slop: mounts the real
-// interactive widgets (choice → lock/collapse, form → submit/collapse,
-// checklist, workflow) so a recorded run demonstrates the chrome-free
-// rendering AND the intact collapse-on-complete contract end to end.
+/**
+ * Walkthrough fixture for the chat-native widget de-slop: mounts the real
+ * interactive widgets (choice → lock/collapse, form → submit/collapse,
+ * checklist, workflow) so a recorded run demonstrates the chrome-free
+ * rendering and the intact collapse-on-complete contract end to end.
+ */
 import { createRoot } from "react-dom/client";
 import { ChoiceWidget } from "../ChoiceWidget";
 import { FormRequest } from "../form-request";

--- a/packages/ui/src/components/chat/widgets/__e2e__/task-pipeline-fixture.tsx
+++ b/packages/ui/src/components/chat/widgets/__e2e__/task-pipeline-fixture.tsx
@@ -101,9 +101,9 @@ function TaskCard() {
       data-task-id="b1a7c0de"
       data-task-status="active"
       data-expanded="true"
-      className="my-2 overflow-hidden rounded-sm border border-border bg-card"
+      className="my-2 overflow-hidden"
     >
-      <div className="flex items-start gap-2 px-3 py-2">
+      <div className="flex items-start gap-2 py-1.5">
         <span className="mt-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center text-ok">
           <CirclePlay className="h-3.5 w-3.5 animate-pulse" />
         </span>
@@ -123,7 +123,7 @@ function TaskCard() {
       </div>
       <div
         data-testid="task-widget-pipeline"
-        className="flex flex-col gap-3 border-t border-border px-3 py-3"
+        className="flex flex-col gap-3 py-2"
       >
         <SubagentBlock agent={builder} />
         <SubagentBlock agent={reviewer} />
@@ -155,7 +155,7 @@ root.render(
       <div className="mb-1 text-xs uppercase tracking-wide text-muted">
         [CHECKLIST] todo list
       </div>
-      <div className="my-2 rounded-sm border border-border bg-card px-3 py-2">
+      <div className="my-2 py-1.5">
         <PlanChecklist entries={checklist} title="Migration" />
       </div>
     </div>

--- a/packages/ui/src/components/chat/widgets/background-widget.tsx
+++ b/packages/ui/src/components/chat/widgets/background-widget.tsx
@@ -28,7 +28,7 @@ export function BackgroundWidget() {
         defaultValue: "Background",
       })}
     >
-      <div className="p-3">
+      <div className="py-1.5">
         <BackgroundSettingsControls variant="filmstrip" />
       </div>
     </ChatWidgetShell>

--- a/packages/ui/src/components/chat/widgets/browser-launch-widget.tsx
+++ b/packages/ui/src/components/chat/widgets/browser-launch-widget.tsx
@@ -65,7 +65,7 @@ export function BrowserLaunchWidget({
     <div
       data-testid="browser-launch"
       data-browser-status={status}
-      className="my-2 border border-border bg-card p-3 text-sm space-y-3"
+      className="my-2 text-sm space-y-3"
     >
       <div className="flex items-center gap-2">
         <Globe className="h-4 w-4 shrink-0 text-muted" aria-hidden />
@@ -99,7 +99,7 @@ export function BrowserLaunchWidget({
           src={screenshotUrl}
           alt={target ? `Screenshot of ${target}` : "Browser screenshot"}
           data-testid="browser-launch-screenshot"
-          className="max-h-48 w-full border border-border object-cover"
+          className="max-h-48 w-full object-cover"
         />
       ) : null}
 

--- a/packages/ui/src/components/chat/widgets/chat-widget-shell.tsx
+++ b/packages/ui/src/components/chat/widgets/chat-widget-shell.tsx
@@ -69,12 +69,15 @@ export function ChatWidgetShell({
   }
 
   return (
+    // Chat-native: no card box around the widget — it reads as part of the
+    // message flow (header row + body), with the collapse contract carrying
+    // the "done" state instead of a border doing visual work (#13560).
     <div
-      className="my-2 border border-border bg-card overflow-hidden [contain:content]"
+      className="my-2 overflow-hidden [contain:content]"
       data-testid={testId}
       data-expanded={expanded}
     >
-      <div className="flex items-center justify-between gap-2 px-3 py-2 bg-bg-hover">
+      <div className="flex items-center justify-between gap-2 py-1">
         <div className="flex min-w-0 items-center gap-2 text-xs font-bold text-txt">
           {icon}
           <span className="truncate">{title}</span>
@@ -102,7 +105,7 @@ export function ChatWidgetShell({
       </div>
       {!expanded && summary != null && (
         <div
-          className="truncate px-3 py-2 text-xs text-muted"
+          className="truncate py-1 text-xs text-muted"
           data-testid={testId ? `${testId}-summary` : undefined}
         >
           {summary}

--- a/packages/ui/src/components/chat/widgets/form-request.tsx
+++ b/packages/ui/src/components/chat/widgets/form-request.tsx
@@ -177,7 +177,7 @@ export const FormRequest = memo(function FormRequest({
     <ChatWidgetShell
       title={form.title ?? "Form"}
       status={
-        <span className="rounded-sm bg-bg px-2 py-0.5 text-[11px] font-medium text-muted">
+        <span className="text-[11px] font-medium text-muted">
           {submitted ? "Submitted" : `${form.fields.length} fields`}
         </span>
       }
@@ -188,7 +188,7 @@ export const FormRequest = memo(function FormRequest({
       <form
         data-testid="form-request"
         data-form-id={form.id}
-        className="space-y-3 p-3 text-sm"
+        className="space-y-3 py-1.5 text-sm"
         onSubmit={handleSubmit}
       >
         {form.description ? (

--- a/packages/ui/src/components/chat/widgets/interaction-widgets.behavior.test.tsx
+++ b/packages/ui/src/components/chat/widgets/interaction-widgets.behavior.test.tsx
@@ -326,11 +326,14 @@ describe("ChoiceWidget — pick an option", () => {
       />,
     );
 
-    // Multi-option keeps the shell (title + count chip), chip on a readable
-    // surface token rather than the near-transparent bg-bg.
+    // Multi-option keeps the shell (title + count label). The count is plain
+    // theme-token text — no pill background, no border (chat-native de-slop;
+    // the theme text token stays readable on every surface).
     expect(screen.getByText("Choose next step")).toBeTruthy();
     const chip = screen.getByText("2 options");
-    expect(chip.className).toContain("bg-surface");
+    expect(chip.className).toContain("text-muted");
+    expect(chip.className).not.toContain("bg-surface");
+    expect(chip.className).not.toContain("bg-bg");
 
     const cloudBeforePick = screen.getByTestId("choice-cloud");
     const localBeforePick = screen.getByTestId("choice-local");

--- a/packages/ui/src/components/chat/widgets/task-pipeline.tsx
+++ b/packages/ui/src/components/chat/widgets/task-pipeline.tsx
@@ -115,20 +115,28 @@ export function toNativeToolEvent(step: TaskActivityStep): NativeToolCallEvent {
 export const PlanChecklist = memo(function PlanChecklist({
   entries,
   title,
+  headerless = false,
 }: {
   entries: SwarmActivityPlanEntry[];
   title?: string;
+  /**
+   * Suppress the title + count row when a wrapping surface (the collapsible
+   * ChecklistWidget shell) already renders both — otherwise they appear twice.
+   */
+  headerless?: boolean;
 }) {
   if (entries.length === 0) return null;
   const done = entries.filter((e) => e.status === "completed").length;
   return (
     <div data-testid="plan-checklist" className="flex flex-col gap-1">
-      <div className="flex items-center justify-between text-xs text-muted">
-        <span>{title ?? "Checklist"}</span>
-        <span className="tabular-nums">
-          {done}/{entries.length}
-        </span>
-      </div>
+      {!headerless && (
+        <div className="flex items-center justify-between text-xs text-muted">
+          <span>{title ?? "Checklist"}</span>
+          <span className="tabular-nums">
+            {done}/{entries.length}
+          </span>
+        </div>
+      )}
       <ul className="flex flex-col gap-0.5">
         {entries.map((entry, i) => {
           const isDone = entry.status === "completed";
@@ -191,7 +199,7 @@ export const ChecklistWidget = memo(function ChecklistWidget({
       testId="checklist-widget-shell"
     >
       <div className="py-1.5">
-        <PlanChecklist entries={entries} title={resolvedTitle} />
+        <PlanChecklist entries={entries} title={resolvedTitle} headerless />
       </div>
     </ChatWidgetShell>
   );

--- a/packages/ui/src/components/chat/widgets/task-pipeline.tsx
+++ b/packages/ui/src/components/chat/widgets/task-pipeline.tsx
@@ -182,7 +182,7 @@ export const ChecklistWidget = memo(function ChecklistWidget({
     <ChatWidgetShell
       title={resolvedTitle}
       status={
-        <span className="rounded-sm bg-bg px-2 py-0.5 text-[11px] font-medium tabular-nums text-muted">
+        <span className="text-[11px] font-medium tabular-nums text-muted">
           {done}/{entries.length}
         </span>
       }
@@ -190,7 +190,7 @@ export const ChecklistWidget = memo(function ChecklistWidget({
       complete={complete}
       testId="checklist-widget-shell"
     >
-      <div className="px-3 py-2">
+      <div className="py-1.5">
         <PlanChecklist entries={entries} title={resolvedTitle} />
       </div>
     </ChatWidgetShell>

--- a/packages/ui/src/components/chat/widgets/task-widget.tsx
+++ b/packages/ui/src/components/chat/widgets/task-widget.tsx
@@ -156,7 +156,7 @@ export const TaskWidget = memo(function TaskWidget({
         data-testid="task-widget"
         data-task-id={threadId}
         data-removed="true"
-        className="my-2 rounded-sm border border-border bg-card px-3 py-2 text-xs text-muted"
+        className="my-2 py-1 text-xs text-muted"
       >
         Task removed.
       </div>
@@ -191,14 +191,14 @@ export const TaskWidget = memo(function TaskWidget({
       data-task-id={threadId}
       data-task-status={status}
       data-expanded={expanded ? "true" : "false"}
-      className="my-2 overflow-hidden rounded-sm border border-border bg-card"
+      className="my-2 overflow-hidden"
     >
       <Button
         type="button"
         onClick={() => setExpanded((v) => !v)}
         variant="ghost"
         aria-expanded={expanded}
-        className="flex h-auto w-full items-start justify-start gap-2 whitespace-normal rounded-none px-3 py-2 text-left font-normal transition-colors hover:bg-bg-hover"
+        className="flex h-auto w-full items-start justify-start gap-2 whitespace-normal rounded-sm -mx-2 px-2 py-1.5 text-left font-normal transition-colors hover:bg-bg-hover"
       >
         <span
           className={`mt-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center ${STATUS_TONE[status]}`}
@@ -253,7 +253,7 @@ export const TaskWidget = memo(function TaskWidget({
       {expanded ? (
         <div
           data-testid="task-widget-pipeline"
-          className="flex flex-col gap-3 border-t border-border px-3 py-3"
+          className="flex flex-col gap-3 py-2"
         >
           {activity.plan.length > 0 && activity.subagents.length <= 1 ? (
             <PlanChecklist entries={activity.plan} title="Plan" />

--- a/packages/ui/src/components/chat/widgets/todo.tsx
+++ b/packages/ui/src/components/chat/widgets/todo.tsx
@@ -124,11 +124,13 @@ function TodoRow({
 
   return (
     <div
-      className={`rounded-sm border p-3 ${
+      // Home tone keeps its glass plate (wallpaper surface); the chat tone is
+      // a flat row — the status dot + text carry the structure, no box.
+      className={
         isHome
-          ? "border-white/15 bg-white/10 text-white"
-          : "border-border/50 bg-bg/70"
-      }`}
+          ? "rounded-sm border border-white/15 bg-white/10 p-3 text-white"
+          : "py-1.5"
+      }
     >
       <div className="flex items-start gap-2">
         <span
@@ -258,8 +260,8 @@ function GoalAttentionRow({
       data-testid="todo-goal-attention-row"
       aria-label={`Goal "${goal.title}" ${status}. Open Goals.`}
       onClick={onOpen}
-      className={`flex min-h-11 w-full items-start gap-2 rounded-sm border p-3 text-left ${
-        isHome ? "border-white/15 text-white" : "border-border/50 bg-bg/70"
+      className={`flex min-h-11 w-full items-start gap-2 text-left ${
+        isHome ? "rounded-sm border border-white/15 p-3 text-white" : "py-1.5"
       }`}
     >
       <Target

--- a/packages/ui/src/components/chat/widgets/widget-equality.test.ts
+++ b/packages/ui/src/components/chat/widgets/widget-equality.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Value comparators for streamed inline widgets must bail on equivalent fresh
+ * payloads and invalidate for every user-visible or callback change.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  choicePropsEqual,
+  followupsPropsEqual,
+  formRequestPropsEqual,
+  planChecklistPropsEqual,
+  workflowPropsEqual,
+} from "./widget-equality";
+
+describe("inline widget structural equality", () => {
+  it("compares choice payloads by value and callbacks by identity", () => {
+    const onChoose = () => {};
+    const base = {
+      id: "choice-1",
+      scope: "fruit",
+      allowCustom: false,
+      options: [{ value: "apple", label: "Apple" }],
+      onChoose,
+    };
+
+    expect(choicePropsEqual(base, base)).toBe(true);
+    expect(
+      choicePropsEqual(base, { ...base, options: [...base.options] }),
+    ).toBe(true);
+    expect(choicePropsEqual(base, { ...base, id: "choice-2" })).toBe(false);
+    expect(choicePropsEqual(base, { ...base, scope: "vegetable" })).toBe(false);
+    expect(choicePropsEqual(base, { ...base, allowCustom: true })).toBe(false);
+    expect(choicePropsEqual(base, { ...base, onChoose: () => {} })).toBe(false);
+    expect(choicePropsEqual(base, { ...base, options: [] })).toBe(false);
+    expect(
+      choicePropsEqual(base, {
+        ...base,
+        options: [{ value: "apple", label: "Green apple" }],
+      }),
+    ).toBe(false);
+  });
+
+  it("compares followup actions and optional handlers", () => {
+    const onChoose = () => {};
+    const onNavigate = () => {};
+    const onPrompt = () => {};
+    const base = {
+      id: "followups-1",
+      options: [{ kind: "reply" as const, payload: "yes", label: "Yes" }],
+      onChoose,
+      onNavigate,
+      onPrompt,
+    };
+
+    expect(
+      followupsPropsEqual(base, {
+        ...base,
+        options: base.options.map((option) => ({ ...option })),
+      }),
+    ).toBe(true);
+    expect(followupsPropsEqual(base, { ...base, onNavigate: undefined })).toBe(
+      false,
+    );
+    expect(followupsPropsEqual(base, { ...base, onPrompt: undefined })).toBe(
+      false,
+    );
+    expect(
+      followupsPropsEqual(base, {
+        ...base,
+        options: [{ ...base.options[0], payload: "no" }],
+      }),
+    ).toBe(false);
+  });
+
+  it("compares complete form fields without erasing in-progress input", () => {
+    const onSubmit = () => {};
+    const base = {
+      form: {
+        id: "profile",
+        title: "Profile",
+        description: "Tell us about yourself",
+        submitLabel: "Save",
+        fields: [
+          {
+            name: "role",
+            type: "select" as const,
+            label: "Role",
+            placeholder: "Choose",
+            required: true,
+            options: [{ value: "engineer", label: "Engineer" }],
+          },
+        ],
+      },
+      onSubmit,
+    };
+    const clone = {
+      form: {
+        ...base.form,
+        fields: base.form.fields.map((field) => ({
+          ...field,
+          options: field.options.map((option) => ({ ...option })),
+        })),
+      },
+      onSubmit,
+    };
+
+    expect(formRequestPropsEqual(base, clone)).toBe(true);
+    expect(formRequestPropsEqual(base, { ...clone, onSubmit: () => {} })).toBe(
+      false,
+    );
+    expect(
+      formRequestPropsEqual(base, {
+        ...clone,
+        form: {
+          ...clone.form,
+          fields: [
+            {
+              ...clone.form.fields[0],
+              options: [{ value: "designer", label: "Designer" }],
+            },
+          ],
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("invalidates workflows when a step changes", () => {
+    const base = {
+      workflow: {
+        id: "deploy",
+        title: "Deploy",
+        steps: [{ label: "Build", status: "pending" as const }],
+      },
+    };
+
+    expect(workflowPropsEqual(base, structuredClone(base))).toBe(true);
+    expect(
+      workflowPropsEqual(base, {
+        workflow: {
+          ...base.workflow,
+          steps: [{ label: "Build", status: "running" }],
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("compares checklist title, presentation, content, and status", () => {
+    const base = {
+      title: "Launch",
+      headerless: false,
+      entries: [{ content: "Verify", status: "pending" }],
+    };
+
+    expect(planChecklistPropsEqual(base, structuredClone(base))).toBe(true);
+    expect(planChecklistPropsEqual(base, { ...base, headerless: true })).toBe(
+      false,
+    );
+    expect(
+      planChecklistPropsEqual(base, {
+        ...base,
+        entries: [{ content: "Verify", status: "completed" }],
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/ui/src/components/chat/widgets/widget-equality.ts
+++ b/packages/ui/src/components/chat/widgets/widget-equality.ts
@@ -177,11 +177,20 @@ function planEntryEqual(
  * identical re-parse is not.
  */
 export function planChecklistPropsEqual(
-  prev: { entries: SwarmActivityPlanEntry[]; title?: string },
-  next: { entries: SwarmActivityPlanEntry[]; title?: string },
+  prev: {
+    entries: SwarmActivityPlanEntry[];
+    title?: string;
+    headerless?: boolean;
+  },
+  next: {
+    entries: SwarmActivityPlanEntry[];
+    title?: string;
+    headerless?: boolean;
+  },
 ): boolean {
   return (
     prev.title === next.title &&
+    prev.headerless === next.headerless &&
     listEqual(prev.entries, next.entries, planEntryEqual)
   );
 }

--- a/packages/ui/src/components/chat/widgets/workflow-steps.tsx
+++ b/packages/ui/src/components/chat/widgets/workflow-steps.tsx
@@ -47,7 +47,7 @@ export const WorkflowSteps = memo(function WorkflowSteps({
       title={title}
       status={
         <span
-          className={`rounded-sm bg-bg px-2 py-0.5 text-[11px] font-medium tabular-nums ${
+          className={`text-[11px] font-medium tabular-nums ${
             failed ? "text-danger" : "text-muted"
           }`}
         >
@@ -61,7 +61,7 @@ export const WorkflowSteps = memo(function WorkflowSteps({
       <div
         data-testid="workflow-steps"
         data-workflow-id={workflow.id}
-        className="flex flex-col gap-2 px-3 py-2"
+        className="flex flex-col gap-2 py-1.5"
       >
         <ol className="flex flex-col gap-1">
           {workflow.steps.map((step, i) => (

--- a/packages/ui/src/components/composites/chat/chat-bubble.tsx
+++ b/packages/ui/src/components/composites/chat/chat-bubble.tsx
@@ -1,11 +1,12 @@
 /**
- * Message bubble surface for a single chat line, toned for assistant vs user.
- * Two chromes: `panel` (theme-token fill, ChatView / detached windows /
- * ChatSurface) and `glass` (the continuous overlay's floating dark-glass row —
- * fixed light text + hairline edge + text shadow, never theme `--txt`, so it
- * stays legible over any wallpaper). When a connector `source` is set the panel
- * chrome draws a source-colored outline so cross-channel messages stay
- * visually distinct without a repeated text badge.
+ * Message surface for a single chat line, toned for assistant vs user and kept
+ * chat-native: assistant turns render as plain text (no card fill, no box) and
+ * only the user turn carries a subtle accent tint. Two variants: `panel`
+ * (theme tokens, ChatView / detached windows / ChatSurface) and `glass` (the
+ * continuous overlay's floating row — fixed light text + text shadow, never
+ * theme `--txt`, so it stays legible over any wallpaper). When a connector
+ * `source` is set the panel chrome draws a source-colored outline so
+ * cross-channel messages stay visually distinct without a repeated text badge.
  */
 import type * as React from "react";
 
@@ -72,10 +73,10 @@ export function ChatBubble({
               // box edge or padding.
               "text-white"
             : cn(
-                "rounded-2xl px-3.5 py-2",
-                tone === "user" ? "rounded-br-md" : "rounded-bl-md",
-                // No per-message fill — text floats on the overlay's one shared
-                // panel glass; the hairline edge defines the item boundary (#10698).
+                // Chat-native: no per-message box — text floats on the
+                // overlay's one shared panel glass; row alignment carries the
+                // user/assistant distinction (#13560 de-slop).
+                "py-1",
                 WALLPAPER_GLASS.messageBubble,
               ),
           WALLPAPER_FLOAT_SHADOW,
@@ -87,18 +88,23 @@ export function ChatBubble({
     );
   }
 
-  const sourceBorderClassName = normalizedSource
-    ? getChatSourceMeta(normalizedSource).borderClassName
-    : "border-transparent";
-
   return (
     <div
       className={cn(
-        "relative inline-block max-w-full whitespace-pre-wrap break-words rounded-sm border px-3 py-2",
+        "relative inline-block max-w-full whitespace-pre-wrap break-words",
+        // Chat-native: assistant turns are plain text on the page — no card
+        // fill, no box (#13560 de-slop). The user turn keeps its subtle accent
+        // tint so the reader can scan who said what at a glance.
         tone === "user"
-          ? "bg-[color:color-mix(in_srgb,var(--accent-subtle)_70%,var(--bg)_30%)] text-txt-strong"
-          : "bg-[color:color-mix(in_srgb,var(--card)_82%,var(--text)_12%)] text-txt",
-        sourceBorderClassName,
+          ? "rounded-sm bg-[color:color-mix(in_srgb,var(--accent-subtle)_70%,var(--bg)_30%)] px-3 py-2 text-txt-strong"
+          : "text-txt",
+        // Cross-channel messages keep their connector-colored outline — the
+        // border exists only when it carries information.
+        normalizedSource &&
+          cn(
+            "rounded-sm border px-3 py-2",
+            getChatSourceMeta(normalizedSource).borderClassName,
+          ),
         className,
       )}
       data-chat-source={normalizedSource ?? undefined}

--- a/packages/ui/src/components/shell/wallpaper-idiom.ts
+++ b/packages/ui/src/components/shell/wallpaper-idiom.ts
@@ -31,7 +31,10 @@ export const WALLPAPER_GLASS = {
   menuPanel: "border border-white/14 bg-black/85",
   menuStatus: "border border-white/12 bg-black/85",
   menuWarning: "border border-amber-400/25 bg-black/85",
-  messageBubble: "border border-white/15 text-white",
+  // Chat-native: message text floats directly on the overlay's shared panel
+  // glass — no per-message fill and no hairline box; row alignment + the float
+  // shadow carry the user/assistant distinction (#13560 de-slop).
+  messageBubble: "text-white",
   iconPlate: "bg-white/10 text-white hover:bg-white/20",
   floatingControl: "bg-black/55 text-white hover:bg-black/70",
 } as const;

--- a/packages/ui/src/components/tool-events/ToolCallEventLog.tsx
+++ b/packages/ui/src/components/tool-events/ToolCallEventLog.tsx
@@ -47,10 +47,12 @@ function formatJson(value: unknown): string {
 }
 
 function StatePill({ state }: { state: ToolCallEventDisplayState }) {
+  // Plain colored text, no pill chrome: the state color alone carries the
+  // signal inside the chat flow (chat-native de-slop).
   const styles = {
-    running: "border-primary/30 bg-primary/5 text-primary",
-    success: "border-success/30 bg-success/5 text-success",
-    failure: "border-danger/30 bg-danger/5 text-danger",
+    running: "text-primary",
+    success: "text-success",
+    failure: "text-danger",
   };
   const labels = {
     running: "Running",
@@ -59,7 +61,7 @@ function StatePill({ state }: { state: ToolCallEventDisplayState }) {
   };
   return (
     <span
-      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-semibold uppercase tracking-[0.12em] ${styles[state]}`}
+      className={`inline-flex items-center text-[11px] font-semibold uppercase tracking-[0.12em] ${styles[state]}`}
     >
       {labels[state]}
     </span>
@@ -95,10 +97,7 @@ export function ToolCallEventLog({
   const result = event.result ?? event.output ?? event.error;
 
   return (
-    <div
-      className={`rounded-sm border border-border/50 bg-bg/40 px-4 py-3 ${className}`}
-      data-testid="tool-call-event-log"
-    >
+    <div className={`py-1 ${className}`} data-testid="tool-call-event-log">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0">
           <div className="flex items-center gap-2">
@@ -137,7 +136,8 @@ export function ToolCallEventLog({
           <ChevronDown className="h-3.5 w-3.5 transition-transform group-open:rotate-180" />
           JSON details
         </summary>
-        <pre className="mt-2 max-h-[24rem] overflow-x-auto overflow-y-auto whitespace-pre-wrap break-words rounded-sm border border-border/40 bg-bg/60 px-3 py-3 text-xs leading-6 text-txt">
+        {/* Keeps the code-block fill (it is code), border dropped. */}
+        <pre className="mt-2 max-h-[24rem] overflow-x-auto overflow-y-auto whitespace-pre-wrap break-words rounded-sm bg-bg/60 px-3 py-3 text-xs leading-6 text-txt">
           {formatJson(event)}
         </pre>
       </details>


### PR DESCRIPTION
# Relates to

#13560 (views-redesign doctrine: "minimal, no card chrome") and #13453 (cohesive design pass) — this executes the chat-widget slice.

- [x] Targets `develop`, based on `origin/develop`; zero conflicts.
- [x] `bun install` + repo typecheck (338/338 turbo tasks) green.
- [x] A reviewer can confirm the change works without reading the code, from the evidence below.

# Sync with develop

- [x] Based on latest `origin/develop` at branch time; will rebase before merge if develop moves.
- [x] Verify green post-sync (typecheck repo-wide; biome clean on touched files).

# Risks

Medium (visual): every in-transcript widget and the message bubbles change appearance. No behavior changes — the collapse-on-complete contract, marker protocol, and callbacks are byte-identical and covered by 234 widget tests + real-browser interaction recordings below. Home-tone (wallpaper) widget plates and button/form affordances are deliberately untouched.

# Background

## What does this PR do?

Removes borders, card fills, header fills, and pill backgrounds from the in-transcript chat widgets and message bubbles so chat reads chat-native (flat rows, hierarchy from color/indentation — the Claude-Code/Codex idiom) instead of boxes-inside-boxes:

- `ChatWidgetShell`: no card box / header fill; the collapse contract carries "done".
- Count chips (Choice/Form/Workflow/Checklist): plain muted text, no pill (supersedes #15144's pill fix by removing the pill).
- `ToolCallEventLog`: bordered card + ALL-CAPS pill → flat state-colored row.
- `TaskWidget`/`BrowserLaunchWidget`/sensitive-request/`InlinePluginConfig`/`FormSubmitReceipt`/chat-tone `Todo` rows: chrome removed, padding re-based to align with message text.
- `ChatBubble`: assistant turns are plain text; user turn keeps its accent tint; connector-source outline draws only when a source exists; glass overlay drops the per-message hairline box.
- Checklist duplicate title+count header (shell + body both rendered it) fixed via `PlanChecklist headerless`.

## What kind of change is this?

Improvement (visual simplification, no functional change).

# Documentation changes needed?

None — design doctrine already lives in #13560; widget behavior contracts unchanged.

# Testing

## Where should a reviewer start?

`chat-widget-shell.tsx` (the one shared chrome point), then the walkthrough videos below.

## Detailed testing steps

1. `bun run --cwd packages/ui test src/components/chat src/components/composites/chat src/components/tool-events`
2. `bun run --cwd packages/ui test:task-pipeline-e2e` (real-Chromium pixels, deterministic fixture)
3. `bun run --cwd packages/app audit:app` (5 iterations run for this PR; results below)

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before (develop@afb55d4fd5c, same deterministic fixture): desktop ![before-desktop](https://gist.githubusercontent.com/lalalune/6ca2c4fa8343ed45a024c7ea5d3e94b9/raw/12a9589cb15324def8af9cc120a27d91e157c2c5/deslop-before-desktop.jpg) · mobile ![before-mobile](https://gist.githubusercontent.com/lalalune/6ca2c4fa8343ed45a024c7ea5d3e94b9/raw/12a9589cb15324def8af9cc120a27d91e157c2c5/deslop-before-mobile.jpg)
<!-- evidence-row:after-screenshots -->
- [x] After (this branch): desktop ![after-desktop](https://gist.githubusercontent.com/lalalune/6ca2c4fa8343ed45a024c7ea5d3e94b9/raw/12a9589cb15324def8af9cc120a27d91e157c2c5/deslop-after-desktop.jpg) · mobile ![after-mobile](https://gist.githubusercontent.com/lalalune/6ca2c4fa8343ed45a024c7ea5d3e94b9/raw/12a9589cb15324def8af9cc120a27d91e157c2c5/deslop-after-mobile.jpg) · interactive end-state desktop ![final-desktop](https://gist.githubusercontent.com/lalalune/6ca2c4fa8343ed45a024c7ea5d3e94b9/raw/12a9589cb15324def8af9cc120a27d91e157c2c5/deslop-final-desktop.jpg) · mobile ![final-mobile](https://gist.githubusercontent.com/lalalune/6ca2c4fa8343ed45a024c7ea5d3e94b9/raw/12a9589cb15324def8af9cc120a27d91e157c2c5/deslop-final-mobile.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough videos (choice tap → lock+collapse → chevron re-expand → form fill → submit → collapse; real Chromium): mobile [deslop-walkthrough-1.mp4](https://gist.githubusercontent.com/lalalune/6ca2c4fa8343ed45a024c7ea5d3e94b9/raw/12a9589cb15324def8af9cc120a27d91e157c2c5/deslop-walkthrough-1.mp4) · desktop [deslop-walkthrough-2.mp4](https://gist.githubusercontent.com/lalalune/6ca2c4fa8343ed45a024c7ea5d3e94b9/raw/12a9589cb15324def8af9cc120a27d91e157c2c5/deslop-walkthrough-2.mp4)
<!-- evidence-row:backend-logs -->
- [x] N/A - pure client-side styling change; no server code path is touched (widget markers, callbacks, and transport are byte-identical).
<!-- evidence-row:frontend-logs -->
- [x] Console + interaction probes (incl. the computed-style proof that no shell renders border/card chrome): [deslop-frontend-logs.txt](https://gist.githubusercontent.com/lalalune/6ca2c4fa8343ed45a024c7ea5d3e94b9/raw/12a9589cb15324def8af9cc120a27d91e157c2c5/deslop-frontend-logs.txt)
<!-- evidence-row:llm-trajectory -->
- [x] N/A - styling-only; no agent/action/provider/prompt/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Rendered-pixel artifacts reviewed by hand: the before/after pairs above + [deslop-frontend-logs.txt](https://gist.githubusercontent.com/lalalune/6ca2c4fa8343ed45a024c7ea5d3e94b9/raw/12a9589cb15324def8af9cc120a27d91e157c2c5/deslop-frontend-logs.txt) (234/234 widget tests, 12/12 tool-events, 945-test chat sweep with only pre-existing failures, audit:app iteration-1: 241 captures passed, 0 broken, 0 regressions).
<!-- evidence-row:ocr-review -->
- [x] [15886-ocr-15886-ci.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15886-ocr-15886-ci.json)

# Evidence Details

## Real LLM-call trajectory

N/A - styling-only change.

## Backend + frontend logs

See [deslop-frontend-logs.txt](https://gist.githubusercontent.com/lalalune/6ca2c4fa8343ed45a024c7ea5d3e94b9/raw/12a9589cb15324def8af9cc120a27d91e157c2c5/deslop-frontend-logs.txt) — recorder probes, e2e output, suite totals, audit summary.

## Screenshots (before / after) + video walkthrough

Above; before/after captured from the SAME deterministic fixture at both widths, base vs branch. The audit:app loop (`bun run --cwd packages/app audit:app`) is being run ≥5× per the redesign bar; per-iteration OCR summaries land in a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
