### PR TITLE
feat(ui): first-run greeting opens with "Hi, I'm Eliza! Seems like you're new here"

### DIFF
--- a/packages/app/test/ui-smoke/onboarding-to-home.shared.ts
+++ b/packages/app/test/ui-smoke/onboarding-to-home.shared.ts
@@ -1018,12 +1018,13 @@ export async function expectCloudOnlySignInOnboarding(
   const chatOverlay = page.getByTestId("continuous-chat-overlay");
   await expect(chatOverlay).toBeVisible({ timeout: 30_000 });
   // Cloud-only greeting (#13377): the conductor seeds CLOUD_SIGN_IN_GREETING
-  // ("Hi — I'm Eliza.") with the single "Sign in to Eliza Cloud" CTA
+  // ("Hi, I'm Eliza! Seems like you're new here — let's get started.")
+  // with the single "Sign in to Eliza Cloud" CTA
   // (`runtime:cloud`); the same-text fallback (ContinuousChatOverlay's
   // FIRST_RUN_SIGN_IN_FALLBACK_MESSAGE) covers the pre-seed race. There is no
   // "First, where should your agent run?" chooser question in this mode.
   await expect(
-    page.getByText("Hi — I'm Eliza.", { exact: false }).first(),
+    page.getByText("Hi, I'm Eliza!", { exact: false }).first(),
   ).toBeVisible({ timeout: 20_000 });
   await expect(page.getByTestId(RUNTIME_CHOICE("cloud"))).toBeVisible({
     timeout: 15_000,

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.firstrun.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.firstrun.test.tsx
@@ -32,6 +32,7 @@ vi.mock("../../utils/clipboard", () => ({
 }));
 
 import { CHAT_PREFILL_EVENT } from "../../events";
+import { FIRST_RUN_GREETING } from "../../first-run/first-run-greeting";
 import { __setAppValueForTests } from "../../state/app-store";
 import type { AppContextValue } from "../../state/internal";
 import { resetShellSurfaceForTests } from "../../state/shell-surface-store";
@@ -353,13 +354,13 @@ describe("ContinuousChatOverlay first-run gating", () => {
         <ContinuousChatOverlay controller={makeController()} firstRunOpen />,
       );
 
-      expect(screen.queryByText("Hi — I'm Eliza.")).toBeNull();
+      expect(screen.queryByText(FIRST_RUN_GREETING)).toBeNull();
 
       act(() => {
         vi.advanceTimersByTime(600);
       });
 
-      expect(screen.getByText("Hi — I'm Eliza.")).toBeTruthy();
+      expect(screen.getByText(FIRST_RUN_GREETING)).toBeTruthy();
       expect(screen.getAllByText("Sign in to Eliza Cloud")).toHaveLength(1);
       expect(
         screen.getByTestId("choice-__first_run__:runtime:cloud"),
@@ -376,7 +377,7 @@ describe("ContinuousChatOverlay first-run gating", () => {
       id: "first-run:greeting",
       role: "assistant",
       content: [
-        "Hi — I'm Eliza.",
+        FIRST_RUN_GREETING,
         "",
         "[CHOICE:first-run id=runtime]",
         "__first_run__:runtime:cloud=Sign in to Eliza Cloud",
@@ -407,7 +408,7 @@ describe("ContinuousChatOverlay first-run gating", () => {
         vi.advanceTimersByTime(600);
       });
 
-      expect(screen.getByText("Hi — I'm Eliza.")).toBeTruthy();
+      expect(screen.getByText(FIRST_RUN_GREETING)).toBeTruthy();
       expect(screen.getAllByText("Sign in to Eliza Cloud")).toHaveLength(1);
     } finally {
       vi.useRealTimers();
@@ -422,7 +423,7 @@ describe("ContinuousChatOverlay first-run gating", () => {
           id: "first-run:greeting",
           role: "assistant",
           content: [
-            "Hi — I'm Eliza.",
+            FIRST_RUN_GREETING,
             "",
             "[CHOICE:first-run id=runtime]",
             "__first_run__:runtime:cloud=Sign in to Eliza Cloud",
@@ -434,7 +435,7 @@ describe("ContinuousChatOverlay first-run gating", () => {
           id: "first-run:cloud-oauth",
           role: "assistant",
           content: [
-            "Hi — I'm Eliza.",
+            FIRST_RUN_GREETING,
             "",
             "[CHOICE:first-run id=runtime]",
             "__first_run__:runtime:cloud=Sign in to Eliza Cloud",
@@ -448,7 +449,7 @@ describe("ContinuousChatOverlay first-run gating", () => {
     render(<ContinuousChatOverlay controller={controller} firstRunOpen />);
 
     expect(screen.getAllByText("Sign in to Eliza Cloud")).toHaveLength(1);
-    expect(screen.queryAllByText("Hi — I'm Eliza.").length).toBe(1);
+    expect(screen.queryAllByText(FIRST_RUN_GREETING).length).toBe(1);
   });
 
   it("exposes the sr-only onboarding-state probe with the current step + choice ids while onboarding is open", () => {

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.slash.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.slash.test.tsx
@@ -145,6 +145,9 @@ function renderOverlay(
   controller = makeController(),
 ) {
   render(<ContinuousChatOverlay controller={controller} slash={slash} />);
+  expect(
+    (screen.getByLabelText("message") as HTMLTextAreaElement).placeholder,
+  ).toBe("Ask Eliza");
   return {
     controller,
     input: screen.getByLabelText("message") as HTMLInputElement,

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -55,6 +55,7 @@ import {
   type ChatPrefillEventDetail,
   ELIZA_BACK_INTENT_EVENT,
 } from "../../events";
+import { FIRST_RUN_GREETING } from "../../first-run/first-run-greeting";
 import {
   TOUCH_TAP_MOVE_SLOP as OUTSIDE_SHEET_TAP_SLOP,
   useRafCoalescer,
@@ -959,8 +960,10 @@ const FIRST_RUN_SIGN_IN_FALLBACK_MESSAGE: ShellMessage = {
   role: "assistant",
   source: "first_run",
   createdAt: 0,
+  // Byte-identical to the conductor's seeded greeting so the latest-turn
+  // dedupe collapses fallback + real greeting into one message.
   content: [
-    "Hi — I'm Eliza.",
+    FIRST_RUN_GREETING,
     "",
     "[CHOICE:first-run id=runtime]",
     "__first_run__:runtime:cloud=Sign in to Eliza Cloud",

--- a/packages/ui/src/first-run/first-run-greeting.ts
+++ b/packages/ui/src/first-run/first-run-greeting.ts
@@ -1,0 +1,9 @@
+/**
+ * The canonical first-run opener Eliza speaks to a brand-new user. The
+ * first-run conductor seeds it as the first chat turn and the continuous-chat
+ * overlay reuses the same text for its pre-conductor fallback turn, so the two
+ * can never drift apart — byte-identical text is what lets the overlay's
+ * latest-first-run-turn dedupe collapse them into a single greeting.
+ */
+export const FIRST_RUN_GREETING =
+  "Hi, I'm Eliza! Seems like you're new here — let's get started.";

--- a/packages/ui/src/first-run/use-first-run-conductor.test.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.test.ts
@@ -12,6 +12,7 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import * as React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FIRST_RUN_GREETING } from "./first-run-greeting";
 
 const mocks = vi.hoisted(() => ({
   client: {
@@ -1277,7 +1278,7 @@ describe("surfaceCloudLoginRetryTurn", () => {
 
     expect(messages[0]?.id).toBe("first-run:cloud-oauth");
     expect(messages[0]?.secretRequest).toBeUndefined();
-    expect(messages[0]?.text).toContain("Hi — I'm Eliza.");
+    expect(messages[0]?.text).toContain(FIRST_RUN_GREETING);
     expect(messages[0]?.text).toContain("__first_run__:runtime:cloud=");
     expect(messages[0]?.text).not.toContain("__first_run__:runtime:local=");
     expect(messages[0]?.text).not.toContain("__first_run__:runtime:remote=");
@@ -1708,7 +1709,7 @@ describe("cloud-only onboarding (runtime chooser off — the production default)
     expect(tryHandleFirstRunAction("__first_run__:runtime:cloud")).toBe(true);
     const retry = await waitForTurn(turn, "first-run:cloud-oauth");
     expect(retry.secretRequest).toBeUndefined();
-    expect(retry.text).toContain("Hi — I'm Eliza.");
+    expect(retry.text).toContain(FIRST_RUN_GREETING);
     expect(retry.text).toContain("__first_run__:runtime:cloud=");
     expect(retry.text).not.toContain("__first_run__:runtime:local=");
     unmount();

--- a/packages/ui/src/first-run/use-first-run-conductor.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.ts
@@ -108,11 +108,11 @@ import {
   resetFirstRunPersistGuard,
   runFirstRunFinish,
 } from "./first-run-finish";
+import { FIRST_RUN_GREETING } from "./first-run-greeting";
 import { isRuntimeChooserEnabled } from "./first-run-runtime-flag";
 import { revertLocalRuntimeCommitment } from "./revert-local-runtime-commitment";
 
-const GREETING =
-  "Hi — I'm Eliza. Let's get you set up. First, where should your agent run?";
+const GREETING = `${FIRST_RUN_GREETING} First, where should your agent run?`;
 
 // Cloud-only greetings (#13377). The sign-in button reuses the runtime:cloud
 // action value on purpose: the tap IS the user gesture that launches the real
@@ -120,7 +120,7 @@ const GREETING =
 // open, same-tab /login navigation where popups are blocked or hostile,
 // #15143). Keep this as one obvious CTA; the Cloud flow itself owns OAuth and
 // provisioning, so there is no second in-chat "Connect" step.
-const CLOUD_SIGN_IN_GREETING = "Hi — I'm Eliza.";
+const CLOUD_SIGN_IN_GREETING = FIRST_RUN_GREETING;
 const CLOUD_SIGN_IN_CHOICE = [
   "[CHOICE:first-run id=runtime]",
   `${FIRST_RUN_ACTION_PREFIX}runtime:cloud=Sign in to Eliza Cloud`,


### PR DESCRIPTION
# Relates to

#13377 (chat-native onboarding) — the greeting slice.

- [x] Targets `develop`, based on `origin/develop`; zero conflicts.
- [x] `bun install` + `packages/ui`/`packages/app` typecheck green.
- [x] A reviewer can confirm the change works without reading the code, from the evidence below.

# Sync with develop

- [x] Based on latest `origin/develop` at branch time; will rebase before merge if develop moves.
- [x] Verify green post-sync.

# Risks

Low. One canonical greeting string module; the conductor, the overlay fallback, and all tests import it, making the byte-identical-text dedupe invariant structural instead of hand-synced. Onboarding flow logic is untouched.

# Background

## What does this PR do?

Onboarding now opens chat-native with one canonical agent-spoken opener — **"Hi, I'm Eliza! Seems like you're new here — let's get started."** — for both the cloud sign-in path (default) and the runtime-chooser path (+ "First, where should your agent run?"). The string lives in `packages/ui/src/first-run/first-run-greeting.ts`, imported by the conductor and the overlay's pre-conductor fallback turn, so the two can never drift (the overlay's latest-first-run-turn dedupe depends on byte-identical text). The ui-smoke golden-path assertion matches the new opener.

## What kind of change is this?

Improvement (product copy + single-sourcing an invariant).

# Documentation changes needed?

None.

# Testing

## Where should a reviewer start?

`first-run-greeting.ts`, then `use-first-run-conductor.ts` greeting constants, then the video below.

## Detailed testing steps

1. `bun run --cwd packages/ui test src/first-run src/App.chat-overlay-first-run.test.tsx src/components/shell/__tests__/ChatSurface.test.tsx` → 328/328.
2. Real-browser: chat-sheet fixture `?firstrun&empty` — the 600ms fallback renders the new greeting + sign-in CTA.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before (base sources, same fixture): mobile ![greeting-before-mobile](https://gist.githubusercontent.com/lalalune/6ca2c4fa8343ed45a024c7ea5d3e94b9/raw/12a9589cb15324def8af9cc120a27d91e157c2c5/greeting-before-mobile.jpg) · desktop ![greeting-before-desktop](https://gist.githubusercontent.com/lalalune/6ca2c4fa8343ed45a024c7ea5d3e94b9/raw/12a9589cb15324def8af9cc120a27d91e157c2c5/greeting-before-desktop.jpg) — old terse "Hi — I'm Eliza."
<!-- evidence-row:after-screenshots -->
- [x] After (this branch): mobile ![greeting-after-mobile](https://gist.githubusercontent.com/lalalune/6ca2c4fa8343ed45a024c7ea5d3e94b9/raw/12a9589cb15324def8af9cc120a27d91e157c2c5/greeting-first-run-greeting-mobile.jpg) · desktop ![greeting-after-desktop](https://gist.githubusercontent.com/lalalune/6ca2c4fa8343ed45a024c7ea5d3e94b9/raw/12a9589cb15324def8af9cc120a27d91e157c2c5/greeting-first-run-greeting-desktop.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] First-run flow video (empty first-run → fallback greeting fires → tap "Sign in to Eliza Cloud" → locked CTA; real Chromium, 390×844): [greeting-walkthrough.mp4](https://gist.githubusercontent.com/lalalune/6ca2c4fa8343ed45a024c7ea5d3e94b9/raw/12a9589cb15324def8af9cc120a27d91e157c2c5/greeting-walkthrough.mp4)
<!-- evidence-row:backend-logs -->
- [x] N/A - the first-run greeting is a client-seeded conductor turn (`source: "first_run"`); no server code path changes.
<!-- evidence-row:frontend-logs -->
- [x] Text-presence probes + suite totals: [greeting-frontend-logs.txt](https://gist.githubusercontent.com/lalalune/6ca2c4fa8343ed45a024c7ea5d3e94b9/raw/12a9589cb15324def8af9cc120a27d91e157c2c5/greeting-frontend-logs.txt)
<!-- evidence-row:llm-trajectory -->
- [x] N/A - conductor-seeded turn, not model output; no prompt/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] 328/328 first-run + overlay tests green — including the fallback/seeded race dedupe (exactly one greeting) and stale-greeting collapse ([greeting-frontend-logs.txt](https://gist.githubusercontent.com/lalalune/6ca2c4fa8343ed45a024c7ea5d3e94b9/raw/12a9589cb15324def8af9cc120a27d91e157c2c5/greeting-frontend-logs.txt)); before/after pixels above reviewed by hand.
<!-- evidence-row:ocr-review -->
- [x] [15889-ocr-15889-ci.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15889-ocr-15889-ci.json)

# Evidence Details

## Real LLM-call trajectory

N/A - see row above.

## Backend + frontend logs

[greeting-frontend-logs.txt](https://gist.githubusercontent.com/lalalune/6ca2c4fa8343ed45a024c7ea5d3e94b9/raw/12a9589cb15324def8af9cc120a27d91e157c2c5/greeting-frontend-logs.txt)

## Screenshots (before / after) + video walkthrough

Above — same deterministic first-run fixture, base sources vs branch, mobile + desktop, plus the interaction video.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
