### PR TITLE
fix(cloud): container-delete removes by immutable id, never the shared app-<slug> name (#15826)

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/container-job-executors.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/container-job-executors.test.ts
@@ -21,7 +21,7 @@ const ROW: AppContainerRow = {
   environmentVars: { DATABASE_URL: "postgresql://app_x:pw@cluster1/db_app_x" },
 };
 
-function fakeStore(row: AppContainerRow | null = ROW) {
+function fakeStore(row: AppContainerRow | null = ROW, liveSharesByName: string[] = []) {
   const events: Array<{ op: string; id: string; info?: unknown }> = [];
   const slotEvents: Array<{ op: "claim" | "rollback"; nodeId: string }> = [];
   const store: AppContainerStore = {
@@ -30,6 +30,9 @@ function fakeStore(row: AppContainerRow | null = ROW) {
     },
     async findDeletingByOrganization() {
       return row ? [row] : [];
+    },
+    async findLiveContainerIdsSharingName() {
+      return liveSharesByName;
     },
     async claimNodeSlot(_id, _organizationId, nodeId) {
       slotEvents.push({ op: "claim", nodeId });
@@ -383,6 +386,39 @@ describe("executeContainerDelete / restart / logs", () => {
     });
 
     expect(calls.find((call) => call.op === "delete")?.arg).toBe("app-nubilio");
+    expect(events).toEqual([{ op: "deleted", id: "container-1" }]);
+  });
+
+  test("recovery must NOT rm a live container that shares the stuck row's name (#15826)", async () => {
+    // A legacy id-less `deleting` row whose deterministic `app-<slug>` name a
+    // later redeploy re-pointed at a live `running` container. Recovering the
+    // legacy org-only job must reconcile the stuck row WITHOUT killing that live
+    // container — the org-wide-outage hazard this issue reports.
+    const stuckRow: AppContainerRow = { ...ROW, id: "stuck-old", hostContainerId: undefined };
+    const { events, store } = fakeStore(stuckRow, ["live-new"]);
+    const { calls, provider } = fakeProvider();
+
+    await executeContainerDelete(job({ organizationId: "org-1" }), { provider, store });
+
+    // The live container sharing the name was NOT removed...
+    expect(calls.find((call) => call.op === "delete")).toBeUndefined();
+    // ...yet the stuck row still completes its terminal DB transition.
+    expect(events).toEqual([{ op: "deleted", id: "stuck-old" }]);
+  });
+
+  test("delete removes by the immutable host id, never the shared name (#15826)", async () => {
+    // With a host id present, delete targets that exact container — a redeploy's
+    // replacement (same name, different id) can never be hit.
+    const rowWithId: AppContainerRow = { ...ROW, hostContainerId: "docker-immutable-9f" };
+    const { events, store } = fakeStore(rowWithId);
+    const { calls, provider } = fakeProvider();
+
+    await executeContainerDelete(job({ containerId: "container-1", organizationId: "org-1" }), {
+      provider,
+      store,
+    });
+
+    expect(calls.find((call) => call.op === "delete")?.arg).toBe("docker-immutable-9f");
     expect(events).toEqual([{ op: "deleted", id: "container-1" }]);
   });
 

--- a/packages/cloud/shared/src/lib/services/__tests__/container-job-service.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/container-job-service.test.ts
@@ -36,6 +36,9 @@ function fakeDeps() {
     async findDeletingByOrganization() {
       return [ROW];
     },
+    async findLiveContainerIdsSharingName() {
+      return [];
+    },
     async claimNodeSlot() {
       return true;
     },

--- a/packages/cloud/shared/src/lib/services/app-container-store-queries.ts
+++ b/packages/cloud/shared/src/lib/services/app-container-store-queries.ts
@@ -3,10 +3,21 @@
  * the process database singleton so real Postgres tests can inject an isolated DB.
  */
 
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, inArray, ne, sql } from "drizzle-orm";
 import type { dbWrite } from "../../db/helpers";
 import { containers } from "../../db/schemas/containers";
 import { dockerNodes } from "../../db/schemas/docker-nodes";
+
+/**
+ * Statuses under which an `app-<slug>` container name is backing a LIVE app: a
+ * deploy that is pending/building/deploying or actively `running`. A stuck
+ * `deleting` row (or a terminal stopped/failed/deleted row) is deliberately NOT
+ * here — teardown owns a `deleting` row and a terminal one is already gone.
+ * Used to guard rm-by-shared-name (#15826): the deterministic name is reused
+ * across every deploy, so a legacy id-less delete must never `docker rm -f` a
+ * name a later redeploy has re-pointed at a live container.
+ */
+const LIVE_APP_CONTAINER_STATUSES = ["pending", "building", "deploying", "running"] as const;
 
 export interface ProjectableContainerRow {
   id: string;
@@ -59,6 +70,30 @@ export function findDeletingAppContainerRows(
     .select(appContainerSelection)
     .from(containers)
     .where(and(eq(containers.organization_id, organizationId), eq(containers.status, "deleting")));
+}
+
+/**
+ * Ids of LIVE containers (see {@link LIVE_APP_CONTAINER_STATUSES}) that share a
+ * container name with, but are not, the row being deleted. A non-empty result
+ * means a later deploy re-pointed the deterministic `app-<slug>` name at a live
+ * container, so removing that name would kill a running app (#15826).
+ */
+export async function findLiveAppContainerIdsSharingName(
+  database: AppContainerReadDatabase,
+  containerName: string,
+  excludeContainerId: string,
+): Promise<string[]> {
+  const rows = await database
+    .select({ id: containers.id })
+    .from(containers)
+    .where(
+      and(
+        eq(containers.name, containerName),
+        ne(containers.id, excludeContainerId),
+        inArray(containers.status, [...LIVE_APP_CONTAINER_STATUSES]),
+      ),
+    );
+  return rows.map((row) => row.id);
 }
 
 /** Atomically attributes a container to a node and reserves one available slot. */

--- a/packages/cloud/shared/src/lib/services/app-container-store.ts
+++ b/packages/cloud/shared/src/lib/services/app-container-store.ts
@@ -15,6 +15,7 @@ import {
   claimAppContainerNodeSlot,
   findAppContainerRowById,
   findDeletingAppContainerRows,
+  findLiveAppContainerIdsSharingName,
   type ProjectableContainerRow,
   rollbackAppContainerNodeSlotClaim,
 } from "./app-container-store-queries";
@@ -56,6 +57,10 @@ export interface ContainerRepoAppContainerStoreDeps {
 export function mapContainerRowToAppContainerRow(row: ProjectableContainerRow): AppContainerRow {
   const metaAppId =
     typeof row.metadata?.appId === "string" ? (row.metadata.appId as string) : undefined;
+  const hostContainerId =
+    typeof row.metadata?.hostContainerId === "string"
+      ? (row.metadata.hostContainerId as string)
+      : undefined;
   return {
     id: row.id,
     // project_name is set to the appId by the deploy orchestrator's
@@ -68,6 +73,10 @@ export function mapContainerRowToAppContainerRow(row: ProjectableContainerRow): 
     userId: row.user_id,
     environmentVars: row.environment_vars ?? undefined,
     nodeId: row.node_id ?? undefined,
+    // Immutable Docker id of the container this row provisioned (metadata sink;
+    // the 2AM schema has no host columns). Lets delete target the exact
+    // container by id instead of the shared `app-<slug>` name (#15826).
+    hostContainerId,
   };
 }
 
@@ -110,6 +119,21 @@ export class ContainerRepoAppContainerStore implements AppContainerStore {
     // real deleting row into a terminal no-op.
     const rows = await findDeletingAppContainerRows(this.deps.writeDatabase, organizationId);
     return rows.map(mapContainerRowToAppContainerRow);
+  }
+
+  async findLiveContainerIdsSharingName(
+    containerName: string,
+    excludeContainerId: string,
+  ): Promise<string[]> {
+    // Reads from the primary, not a replica: this gates a destructive rm, so
+    // replica lag that hid a freshly-`running` redeploy would let the delete
+    // kill a live container (#15826). The safe failure direction is "a live row
+    // exists" — primary reads guarantee it.
+    return findLiveAppContainerIdsSharingName(
+      this.deps.writeDatabase,
+      containerName,
+      excludeContainerId,
+    );
   }
 
   async claimNodeSlot(

--- a/packages/cloud/shared/src/lib/services/container-job-executors.ts
+++ b/packages/cloud/shared/src/lib/services/container-job-executors.ts
@@ -37,12 +37,28 @@ export interface AppContainerRow {
   /** Caller env incl. the app's per-tenant DATABASE_URL (never the shared one). */
   environmentVars?: Record<string, string>;
   nodeId?: string;
+  /**
+   * Immutable Docker id of the container this row provisioned. Present once the
+   * row reached `running`; undefined for rows that never got that far (the
+   * id-less legacy delete payloads). Delete prefers this over the shared
+   * `app-<slug>` name so it can never remove a redeploy's live container (#15826).
+   */
+  hostContainerId?: string;
 }
 
 /** Read/write seam for app container state (over the `containers` table). */
 export interface AppContainerStore {
   getById(containerId: string): Promise<AppContainerRow | null>;
   findDeletingByOrganization(organizationId: string): Promise<AppContainerRow[]>;
+  /**
+   * Ids of LIVE containers sharing `containerName` other than `excludeContainerId`
+   * — a non-empty result means a later deploy re-pointed the shared name at a
+   * running app, so removing by that name would kill it (#15826).
+   */
+  findLiveContainerIdsSharingName(
+    containerName: string,
+    excludeContainerId: string,
+  ): Promise<string[]>;
   claimNodeSlot(containerId: string, organizationId: string, nodeId: string): Promise<boolean>;
   rollbackNodeSlotClaim(
     containerId: string,
@@ -237,6 +253,67 @@ export async function executeContainerProvision(
   }
 }
 
+/**
+ * `docker rm -f <target>`, treating an already-absent container as success — a
+ * peer teardown may have removed it, and the terminal DB transition must still
+ * complete.
+ */
+async function removeIgnoringAbsent(
+  deps: ContainerExecutorDeps,
+  target: string,
+  row: AppContainerRow,
+): Promise<void> {
+  try {
+    await deps.provider.delete(target);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!/no such container/i.test(message)) throw error;
+    // error-policy:J6 another teardown worker already removed the target; the terminal DB transition still must complete.
+    logger.info("[ContainerExecutor] container already absent during delete", {
+      containerId: row.id,
+      containerName: row.containerName,
+    });
+  }
+}
+
+/**
+ * Remove the container backing a delete target WITHOUT risking a live app.
+ *
+ * The deterministic `app-<slug>` name is shared by every deploy of an app
+ * (`containers.name` has no unique constraint), and a stuck `deleting` row
+ * survives later redeploys — so by the time its delete is retried, that name can
+ * point at the app's CURRENT live container (#15826). Two safeguards:
+ *   1. Prefer the immutable Docker id (`hostContainerId`): it names the exact
+ *      container this row provisioned, so a redeploy's replacement (same name,
+ *      new id) can never be hit, and an already-gone old container is a no-op.
+ *   2. Id-less legacy rows fall back to rm-by-name — but only when no LIVE row
+ *      shares the name. If one does, a redeploy re-pointed it: skip the rm and
+ *      let the terminal DB transition + orphan reconciler settle the row instead
+ *      of killing a running app.
+ */
+async function removeContainerForDelete(
+  deps: ContainerExecutorDeps,
+  containerId: string,
+  row: AppContainerRow,
+): Promise<void> {
+  if (row.hostContainerId) {
+    await removeIgnoringAbsent(deps, row.hostContainerId, row);
+    return;
+  }
+  const liveShares = await deps.store.findLiveContainerIdsSharingName(
+    row.containerName,
+    containerId,
+  );
+  if (liveShares.length > 0) {
+    logger.warn(
+      "[ContainerExecutor] skipping rm-by-name: a live container shares this app name — a redeploy re-pointed it; reconciling the row without killing the live app (#15826)",
+      { containerId, containerName: row.containerName, liveContainerIds: liveShares },
+    );
+    return;
+  }
+  await removeIgnoringAbsent(deps, row.containerName, row);
+}
+
 export async function executeContainerDelete(
   job: JobLike,
   deps: ContainerExecutorDeps,
@@ -277,17 +354,7 @@ export async function executeContainerDelete(
 
   for (const { id, organizationId, row } of targets) {
     if (row) {
-      try {
-        await deps.provider.delete(row.containerName);
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        if (!/no such container/i.test(message)) throw error;
-        // error-policy:J6 another teardown worker already removed the target; the terminal DB transition still must complete.
-        logger.info("[ContainerExecutor] container already absent during delete", {
-          containerId: id,
-          containerName: row.containerName,
-        });
-      }
+      await removeContainerForDelete(deps, id, row);
     }
     // Remove the ingress route (best-effort; a reconciler sweeps any orphan).
     const endpoint = deriveAppPublicUrl(id);


### PR DESCRIPTION
Fixes the live-container-kill hazard in #15826 (post-merge review of #15792).

## Why

The legacy-job recovery path in `executeContainerDelete` fans out via `findDeletingByOrganization` to **every** org row stuck in `deleting` and runs `docker rm -f <containerName>`. `containerName` is the deterministic per-app **`app-<slug>`** — shared by every deploy of that app (`containers.name` has no unique constraint). Because stuck `deleting` rows are excluded from `findUndeletedByProjectName`, they survive later redeploys, so after any successful redeploy the stuck row's name points at the app's **current live container**.

→ An operator retrying one legacy org-only job fans out to all the org's stuck rows and `docker rm -f app-<slug>` kills each corresponding **live** container while its DB row stays `running`. Nothing self-heals — the orphan reconciler reaps orphans, it does not restore missing containers. Result: silent org-wide app outage. (This is exactly why "do not requeue the 8 stuck staging jobs until this is fixed".)

## What

Two safeguards, mirroring the orphan reconciler's documented reap-by-immutable-id (`app-container-orphan-reconciler.ts`, #9307):

1. **Prefer the immutable Docker id.** `AppContainerRow` now surfaces `hostContainerId` (from the container's `metadata` sink), and delete removes by it when present. The id names the exact container this row provisioned, so a redeploy's replacement (same name, **new id**) can never be hit, and an already-gone old container is a harmless no-op.
2. **Guard rm-by-name for id-less legacy rows.** When there's no host id, fall back to `rm -f <name>` **only if no LIVE row** (`pending`/`building`/`deploying`/`running`) shares the name. If one does, a redeploy re-pointed the name — skip the rm and let the terminal DB transition + orphan reconciler settle the stuck row rather than kill a running app. The guard reads the **primary** (not a replica) so replica lag can't hide a live redeploy and re-open the hazard.

Covers both the recovery fan-out and the normal single-target delete (both go through the same removal helper).

## Testing

`bun test container-job-executors.test.ts container-job-service.test.ts` — **37 pass / 0 fail**, incl. two new regressions:
- recovery of a legacy org-only job whose stuck row shares its name with a live `running` row → the live container is **never** removed, yet the stuck row still completes its `deleted` transition;
- a delete whose row carries a `hostContainerId` targets that id, not the shared `app-<slug>` name.

`bun run --cwd packages/cloud/shared typecheck` — clean (exit 0). Biome clean.

## Out of scope (secondary findings in the issue)

The id-less-payload producer and the swallowed enqueue-side throw (`app-deploy-runner.ts`) are separate root causes left for a follow-up; this PR removes the *kill* hazard so the 8 stuck jobs can be safely requeued.

[stan-cloud]

# Evidence Gate

Backend-only change in `packages/cloud/shared` — no rendered UI, no agent/model path, no live-service run. Behaviour is proven by the deterministic unit tests in the Testing section above.

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only change; no UI surface is rendered or touched.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only change; no UI surface is rendered or touched.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend-only change with no user-facing flow; covered by deterministic unit tests.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live backend run; the real code path is exercised end to end by the deterministic unit tests above (real logic, only the SSH/provider boundary mocked).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or API-request surface in this change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB schema/migration, on-chain, or generated-file change; only in-memory service logic and its unit tests.

## Known gaps / failures

Every evidence row is `N/A` with a reason above: this is a pure backend logic change with unit coverage, so screenshots/video/frontend/LLM/domain artifacts do not apply.