### PR TITLE
fix(ci): defuse Windows shard regressions from the wave-2 merges + a date time bomb

### DIFF
--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -3861,8 +3861,11 @@ function generatePodfile() {
 
   fs.writeFileSync(
     path.join(podfileDir, "Podfile"),
-    `\
-def node_package_path(package_name)
+    // No backslash-newline continuation here: it is the file's only
+    // line-ending-sensitive token, and a CRLF checkout (Windows runners,
+    // core.autocrlf) turns it into \<CR><LF>, which the Windows test lane
+    // rejects at parse ("Invalid or unexpected token" importing this module).
+    `def node_package_path(package_name)
   package_json = \`node --print "require.resolve('#{package_name}/package.json')"\`.strip
   if package_json.empty?
     raise "Unable to resolve #{package_name}; run bun install before pod install"

--- a/packages/cloud/shared/src/lib/services/__tests__/ad-campaign-performance-report.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/ad-campaign-performance-report.test.ts
@@ -164,18 +164,22 @@ describe("campaign performance reports (#11600)", () => {
       }),
     );
 
+    // Relative to now: the service rejects non-future expirations, so a
+    // hardcoded calendar date is a wall-clock time bomb (this test went red
+    // repo-wide the moment 2026-07-10T00:00Z passed).
+    const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
     const share = await advertisingService.createCampaignReportShare({
       organizationId: ORG_ID,
       userId: "user-1",
       campaignId: CAMPAIGN_ID,
-      expiresAt: new Date("2026-07-10T00:00:00.000Z"),
+      expiresAt,
     });
 
     expect(create).toHaveBeenCalledTimes(1);
     expect(share).toMatchObject({
       id: "share-created",
       campaignId: CAMPAIGN_ID,
-      expiresAt: "2026-07-10T00:00:00.000Z",
+      expiresAt: expiresAt.toISOString(),
     });
     expect(share.token.length).toBeGreaterThan(20);
     expect(share.publicPath).toContain("/api/v1/advertising/reports/");

--- a/plugins/plugin-elizacloud/vitest.config.ts
+++ b/plugins/plugin-elizacloud/vitest.config.ts
@@ -1,7 +1,7 @@
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
@@ -49,6 +49,12 @@ export default defineConfig({
 	},
 	test: {
 		include: ["__tests__/**/*.test.ts", "src/**/*.test.{ts,tsx}"],
+		// dist-packaging drives the real build.ts, which is bun-only
+		// (import.meta.dir); it runs under `bun test` in the cloud sweep and can
+		// never execute under vitest — excluded here (extending the defaults) so
+		// the package's vitest lane (incl. the Windows plugins shard) stays green
+		// without weakening the gate.
+		exclude: [...configDefaults.exclude, "__tests__/dist-packaging.test.ts"],
 		environment: "node",
 		server: {
 			deps: {


### PR DESCRIPTION
## What

Windows CI run [29060044856](https://github.com/elizaOS/eliza/actions/runs/29060044856) (develop@3af48986ec0) flipped red with three distinct causes — two Windows-first executions of freshly merged tests, one repo-wide wall-clock time bomb:

1. **`ad-campaign-performance-report.test.ts` — time bomb (fails everywhere, urgent)**: hardcoded `expiresAt: 2026-07-10T00:00:00Z` hit the service's future-expiration guard the moment midnight UTC passed (~00:45Z runs onward). Now relative (`Date.now() + 24h`), assertion follows the value.
2. **`dist-packaging.test.ts` (from #15801)**: imports `bun:test` and drives the bun-only `build.ts` (`import.meta.dir`), but plugin-elizacloud's `test` script is vitest — the Windows plugins shard failed at import; under vitest it can never run (verified: the build script TypeErrors under node). Kept as `bun:test` and excluded from the vitest lane (extending `configDefaults.exclude` so node_modules exclusion is preserved); the gate remains fully enforced in the bun-based cloud sweep (4/4 there).
3. **`run-mobile-build.mjs` (test from #15788)**: the module's only backslash-newline continuation inside a template literal becomes `\<CR><LF>` on a CRLF checkout, and the app-and-cli shard failed collection with `SyntaxError: Invalid or unexpected token`. Replaced by starting the template on the same line — Podfile output byte-identical.

## Evidence (all local, real runners)

```
ad-campaign (bun):          5 pass / 0 fail
plugin-elizacloud vitest:   42 passed | 1 skipped (dist-packaging excluded)
dist-packaging (bun test):  4 pass / 0 fail  (gate still enforced)
mobile-build (vitest):      1 passed; plain-node import OK
```

CI-lane test/portability fixes only; no product behavior change (the Podfile template emits identical bytes). Follow-on to the wave-2 merges in the 2026-07-09 remediation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)