### PR TITLE
test(agent): compile-time parity between capacitor-bridge shims and real agent exports

### DIFF
--- a/packages/agent/src/capacitor-bridge-shim-parity.test.ts
+++ b/packages/agent/src/capacitor-bridge-shim-parity.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Compile-time parity between the Capacitor bridge's type-only agent shims and
+ * the real agent export surfaces (#15850). The bridge package typechecks
+ * against `plugins/plugin-capacitor-bridge/src/type-shims/*` (tsconfig paths)
+ * and its declaration build runs `--noCheck`, so without this file no compiler
+ * verifies that the real `@elizaos/agent{,/api,/runtime}` modules still satisfy
+ * what the bridge expects — drift keeps the bridge typecheck green and
+ * surfaces only on-device. Every assertion here typechecks in THIS package,
+ * against real sources, so drift fails `bun run --cwd packages/agent
+ * typecheck` (and this suite) instead.
+ *
+ * Direction of the checks: at runtime the bridge holds values typed by its
+ * shims and the real implementations are slotted in, so each REAL export must
+ * be assignable to its SHIM (bridge-expected) type.
+ */
+
+import type { AgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import type {
+  AndroidCoreRouteDeps,
+  AndroidDispatchRoute,
+} from "../../../plugins/plugin-capacitor-bridge/src/android/dispatch.ts";
+
+type ShimAgentRoot =
+  typeof import("../../../plugins/plugin-capacitor-bridge/src/type-shims/agent-root.ts");
+type ShimAgentApi =
+  typeof import("../../../plugins/plugin-capacitor-bridge/src/type-shims/agent-api.ts");
+type ShimAgentRuntime =
+  typeof import("../../../plugins/plugin-capacitor-bridge/src/type-shims/agent-runtime.ts");
+
+type RealAgentRoot = typeof import("./index.ts");
+type RealAgentApi = typeof import("./api/index.ts");
+type RealAgentRuntime = typeof import("./runtime/index.ts");
+type RealLocalInferenceRuntime =
+  typeof import("../../../plugins/plugin-local-inference/src/runtime/index.ts");
+
+/**
+ * Compile-time-only assignability probe: instantiating it with a `_From` that
+ * does not extend `To` is a type error. The exported aliases below are the
+ * actual assertions; they carry no runtime cost.
+ */
+type AssertAssignable<To, _From extends To> = never;
+
+// ── @elizaos/agent (root) — Android bridge contract ─────────────────────────
+// `loadAgentModule` in android/bridge.ts casts the dynamic root import to the
+// same member types the agent-root shim declares.
+export type StartElizaParity = AssertAssignable<
+  ShimAgentRoot["startEliza"],
+  RealAgentRoot["startEliza"]
+>;
+export type RootDispatchRouteParity = AssertAssignable<
+  ShimAgentRoot["dispatchRoute"],
+  RealAgentRoot["dispatchRoute"]
+>;
+export type ConfigFileExistsParity = AssertAssignable<
+  ShimAgentRoot["configFileExists"],
+  RealAgentRoot["configFileExists"]
+>;
+export type LoadElizaConfigParity = AssertAssignable<
+  ShimAgentRoot["loadElizaConfig"],
+  RealAgentRoot["loadElizaConfig"]
+>;
+export type SaveElizaConfigParity = AssertAssignable<
+  ShimAgentRoot["saveElizaConfig"],
+  RealAgentRoot["saveElizaConfig"]
+>;
+export type HasPersistedFirstRunStateParity = AssertAssignable<
+  ShimAgentRoot["hasPersistedFirstRunState"],
+  RealAgentRoot["hasPersistedFirstRunState"]
+>;
+
+// The Android dispatch/core-route types are the bridge's own vocabulary for
+// the same members; pin the real exports against them directly too so a drift
+// in either the shim or the bridge contract is caught.
+export type AndroidDispatchParity = AssertAssignable<
+  AndroidDispatchRoute,
+  RealAgentApi["dispatchRoute"]
+>;
+export type AndroidCoreRouteDepsParity = AssertAssignable<
+  AndroidCoreRouteDeps,
+  Pick<
+    RealAgentRoot,
+    | "configFileExists"
+    | "loadElizaConfig"
+    | "saveElizaConfig"
+    | "hasPersistedFirstRunState"
+  >
+>;
+
+// ── @elizaos/agent/api — shared dispatchRoute contract ───────────────────────
+export type ApiDispatchRouteParity = AssertAssignable<
+  ShimAgentApi["dispatchRoute"],
+  RealAgentApi["dispatchRoute"]
+>;
+
+// ── @elizaos/agent/runtime — iOS bridge contract ────────────────────────────
+export type BootElizaRuntimeParity = AssertAssignable<
+  ShimAgentRuntime["bootElizaRuntime"],
+  RealAgentRuntime["bootElizaRuntime"]
+>;
+
+// ── @elizaos/plugin-local-inference/runtime — router install contract ───────
+// The android bridge invokes `installRouterHandler(runtime, {})` with the
+// booted AgentRuntime; the real export must keep accepting exactly that call.
+export type InstallRouterHandlerParity = AssertAssignable<
+  (runtime: AgentRuntime, options: Record<string, never>) => void,
+  RealLocalInferenceRuntime["installRouterHandler"]
+>;
+
+describe("capacitor-bridge shim parity (#15850)", () => {
+  it("is enforced at compile time — this file failing to typecheck IS the signal", () => {
+    // The type aliases above are the assertions; tsgo/tsc rejects this file
+    // (and the agent typecheck lane fails) the moment a real export drifts
+    // from the bridge's shim contract.
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #15850.

## Summary

The capacitor-bridge package typechecks against type-only shims (`plugins/plugin-capacitor-bridge/src/type-shims/*` via tsconfig paths) and its declaration build runs `--noCheck`, so no compiler verified that the real `@elizaos/agent{,/api,/runtime}` and `@elizaos/plugin-local-inference/runtime` surfaces still satisfy the bridge's expectations — drift kept the bridge green and surfaced only on-device.

`packages/agent/src/capacitor-bridge-shim-parity.test.ts` asserts, inside `packages/agent` (where the real sources typecheck), that every real export is assignable to its bridge-expected type:

- `startEliza`, root `dispatchRoute`, `configFileExists`, `loadElizaConfig`, `saveElizaConfig`, `hasPersistedFirstRunState` vs the `agent-root` shim (the Android `loadAgentModule` cast contract)
- `dispatchRoute` vs both the `agent-api` shim and the bridge's own `AndroidDispatchRoute` / `AndroidCoreRouteDeps` vocabulary
- `bootElizaRuntime` vs the `agent-runtime` shim (iOS bridge)
- `installRouterHandler` vs the Android bridge's actual `(runtime, {})` invocation

Zero runtime cost — the assertions are exported type aliases; the suite's single runtime test documents that the typecheck IS the enforcement.

## Verification — mutation proof

Adding a required field to the real `DispatchRouteArgs` (`requiredNewField: string`) fails `bun run --cwd packages/agent typecheck` with three parity errors:

```
src/capacitor-bridge-shim-parity.test.ts(53,2): error TS2344: Type '(args: DispatchRouteArgs) => Promise<RouteHandlerResult | null>' does not satisfy the constraint 'AndroidDispatchRoute'.
src/capacitor-bridge-shim-parity.test.ts(77,2): error TS2344: ...
src/capacitor-bridge-shim-parity.test.ts(93,2): error TS2344: ...
```

Restoring the field returns the typecheck to green. `bunx vitest run src/capacitor-bridge-shim-parity.test.ts`: 1 passed. Biome: clean.

## Evidence rows

<!-- evidence-row:before-screenshots -->
Before screenshots: N/A - compile-time type assertion only; no product UI changed.

<!-- evidence-row:after-screenshots -->
After screenshots: N/A - compile-time type assertion only; no product UI changed.

<!-- evidence-row:walkthrough-video -->
Walkthrough video: N/A - compile-time type assertion; the observable behavior is the typecheck failure shown in the mutation proof above.

<!-- evidence-row:backend-logs -->
Backend logs: N/A - no runtime behavior changed; zero runtime cost (type aliases only).

<!-- evidence-row:frontend-logs -->
Frontend logs: N/A - no frontend code changed.

<!-- evidence-row:llm-trajectory -->
Real-LLM trajectory: N/A - no model or agent behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the mutation-proof typecheck output above (three TS2344 parity errors on injected drift, green on restore) is the artifact this change produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)