### PR TITLE
fix(ci): tolerate YAML comments in the windows command-coverage contract

### DIFF
--- a/.github/ci-windows-command-inventory.json
+++ b/.github/ci-windows-command-inventory.json
@@ -6,7 +6,7 @@
     "bun run --cwd packages/shared test",
     "bun run --cwd packages/app-core test",
     "bun run --cwd packages/elizaos test",
-    "bun run --cwd packages/cloud/shared test",
+    "bun run --cwd packages/cloud/shared test --path-ignore-patterns \"**/tenant-db-placement-claimer.test.ts\"",
     "bun run --cwd packages/scenario-runner test",
     "bun run --cwd packages/vault test",
     "bun run --cwd packages/security test",

--- a/packages/scripts/ci-windows-command-coverage-contract.mjs
+++ b/packages/scripts/ci-windows-command-coverage-contract.mjs
@@ -95,6 +95,9 @@ export function parseWindowsCommands(repoRoot = DEFAULT_REPO_ROOT) {
       listIndent = null;
       continue;
     }
+    // YAML comments are legitimate inside the list (e.g. rationale above a
+    // split-out suite) and are not command items.
+    if (line.slice(itemIndent).startsWith("#")) continue;
     const item = line.slice(itemIndent).match(/^-\s+(.+?)\s*$/);
     assert(
       item !== null,


### PR DESCRIPTION
## Problem

Every Tests run on develop since ~01:22Z fails at **"Classify changed paths"** (cascading `ci-ok` red), e.g. run [29062158081](https://github.com/elizaOS/eliza/actions/runs/29062158081):

```
[ci-windows-command-coverage-contract] FAIL .github/workflows/windows-ci.yml: malformed command list under "windows" matrix (got: "  # The tenant-db durable-placement-claimer suite is split out into")
```

#15842 (the tenant-db PGlite isolation for #15785) documented its suite split with a YAML comment inside the matrix `commands:` list; the contract parser asserted every line is a `- item`.

## Fix

1. Parser skips comment lines — comments are legitimate YAML and not command items (red→green proven against the live yml).
2. With parsing fixed, the contract then correctly flagged that #15842 morphed the inventoried `bun run --cwd packages/cloud/shared test` into its `--path-ignore-patterns` variant (the claimer suite runs in a separate retried step — coverage split, not shrunk). Per the contract's own prescription, the inventory entry follows the matrix in the same PR.

## Evidence

```
without parser fix: FAIL malformed command list (the #15842 comment)
with fix:           ci windows command coverage contract passed (22 lane command(s); 22 inventoried command(s) all present)
```

Unblocks the Tests lane classifier; CI-infra only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)