### PR TITLE
fix(cloud): codify Cloudflare public-domain edge

### DIFF
--- a/.github/workflows/terraform-pages-domains.yml
+++ b/.github/workflows/terraform-pages-domains.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
-          bun-version: "1.4.0"
+          bun-version: "canary"
       - name: Install test dependencies
         run: bun install --frozen-lockfile --ignore-scripts
       - uses: hashicorp/setup-terraform@v4

--- a/.github/workflows/terraform-pages-domains.yml
+++ b/.github/workflows/terraform-pages-domains.yml
@@ -37,6 +37,12 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: "1.4.0"
+      - name: Install test dependencies
+        run: bun install --frozen-lockfile --ignore-scripts
       - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ env.TF_VERSION }}

--- a/.github/workflows/terraform-pages-domains.yml
+++ b/.github/workflows/terraform-pages-domains.yml
@@ -1,0 +1,107 @@
+name: Terraform — Cloudflare Pages Domains
+
+on:
+  pull_request:
+    branches: [develop, main]
+    paths:
+      - "packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/**"
+      - "packages/cloud/infra/tests/terraform-static.test.ts"
+      - ".github/workflows/terraform-pages-domains.yml"
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Pages domains environment to target
+        type: choice
+        default: staging
+        options: [staging, production]
+      action:
+        description: Terraform action
+        type: choice
+        default: plan
+        options: [plan, apply]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: terraform-pages-domains-${{ github.event.inputs.environment || format('pr-{0}', github.ref) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  TF_DIR: packages/cloud/infra/cloud/terraform/cloudflare/pages-domains
+  TF_VERSION: "1.10.5"
+
+jobs:
+  validate:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+      - name: Terraform format
+        working-directory: ${{ env.TF_DIR }}
+        run: terraform fmt -check -recursive
+      - name: Terraform validate
+        working-directory: ${{ env.TF_DIR }}
+        run: |
+          terraform init -backend=false -input=false
+          terraform validate -no-color
+      - name: Static ownership contract
+        run: bun test packages/cloud/infra/tests/terraform-static.test.ts
+
+  plan-apply:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-24.04
+    environment: ${{ github.event.inputs.environment }}
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.R2_STATE_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_STATE_SECRET_ACCESS_KEY }}
+      TF_VAR_environment: ${{ github.event.inputs.environment }}
+      TF_VAR_cloudflare_account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      TF_VAR_cloudflare_zone_id: ${{ secrets.APPS_CLOUDFLARE_ZONE_ID || vars.APPS_CLOUDFLARE_ZONE_ID }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+      - name: Preflight required credentials
+        run: |
+          fail=0
+          [ -n "$CLOUDFLARE_API_TOKEN" ] || { echo "::error::missing CLOUDFLARE_API_TOKEN"; fail=1; }
+          [ -n "$AWS_ACCESS_KEY_ID" ] || { echo "::error::missing R2_STATE_ACCESS_KEY_ID"; fail=1; }
+          [ -n "$AWS_SECRET_ACCESS_KEY" ] || { echo "::error::missing R2_STATE_SECRET_ACCESS_KEY"; fail=1; }
+          [ -n "$TF_VAR_cloudflare_account_id" ] || { echo "::error::missing CLOUDFLARE_ACCOUNT_ID"; fail=1; }
+          [ -n "$TF_VAR_cloudflare_zone_id" ] || { echo "::error::missing APPS_CLOUDFLARE_ZONE_ID"; fail=1; }
+          exit "$fail"
+      - name: Terraform format
+        working-directory: ${{ env.TF_DIR }}
+        run: terraform fmt -check -recursive
+      - name: Terraform init
+        working-directory: ${{ env.TF_DIR }}
+        run: terraform init -input=false -backend-config="backend-${{ github.event.inputs.environment }}.hcl"
+      - name: Terraform plan
+        working-directory: ${{ env.TF_DIR }}
+        run: terraform plan -no-color -input=false -out=pages-domains.tfplan
+      - name: Terraform apply
+        if: github.event.inputs.action == 'apply'
+        working-directory: ${{ env.TF_DIR }}
+        run: terraform apply -no-color -input=false pages-domains.tfplan
+      - name: Verify domain and certificate state
+        if: github.event.inputs.action == 'apply'
+        working-directory: ${{ env.TF_DIR }}
+        run: |
+          terraform output -json pages_domains > "$RUNNER_TEMP/pages-domains.json"
+          node -e '
+            const fs = require("node:fs");
+            const domains = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+            for (const [key, entry] of Object.entries(domains)) {
+              if (entry.status !== "active") throw new Error(`${key} domain is ${entry.status}, expected active`);
+              if (!entry.certificate_authority) throw new Error(`${key} has no issued certificate authority`);
+            }
+          ' "$RUNNER_TEMP/pages-domains.json"
+      - name: Verify live environment routing
+        if: github.event.inputs.action == 'apply'
+        run: node packages/scripts/cloud/verify-environment-routing-cli.mjs --environment "${{ github.event.inputs.environment }}" --require-beacon

--- a/.github/workflows/terraform-pages-domains.yml
+++ b/.github/workflows/terraform-pages-domains.yml
@@ -68,6 +68,9 @@ jobs:
       TF_VAR_environment: ${{ github.event.inputs.environment }}
       TF_VAR_cloudflare_account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       TF_VAR_cloudflare_zone_id: ${{ secrets.APPS_CLOUDFLARE_ZONE_ID || vars.APPS_CLOUDFLARE_ZONE_ID }}
+      TF_VAR_staging_agent_wildcard_origins: ${{ vars.STAGING_AGENT_WILDCARD_ORIGINS_JSON || '[]' }}
+      TF_VAR_staging_agent_certificate_pack_id: ${{ vars.STAGING_AGENT_CERTIFICATE_PACK_ID }}
+      TF_VAR_staging_agent_certificate_hosts: ${{ vars.STAGING_AGENT_CERTIFICATE_HOSTS_JSON || '[]' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: hashicorp/setup-terraform@v4
@@ -81,6 +84,11 @@ jobs:
           [ -n "$AWS_SECRET_ACCESS_KEY" ] || { echo "::error::missing R2_STATE_SECRET_ACCESS_KEY"; fail=1; }
           [ -n "$TF_VAR_cloudflare_account_id" ] || { echo "::error::missing CLOUDFLARE_ACCOUNT_ID"; fail=1; }
           [ -n "$TF_VAR_cloudflare_zone_id" ] || { echo "::error::missing APPS_CLOUDFLARE_ZONE_ID"; fail=1; }
+          if [ "$TF_VAR_environment" = "staging" ]; then
+            [ "$TF_VAR_staging_agent_wildcard_origins" != "[]" ] || { echo "::error::missing STAGING_AGENT_WILDCARD_ORIGINS_JSON"; fail=1; }
+            [ -n "$TF_VAR_staging_agent_certificate_pack_id" ] || { echo "::error::missing STAGING_AGENT_CERTIFICATE_PACK_ID"; fail=1; }
+            [ "$TF_VAR_staging_agent_certificate_hosts" != "[]" ] || { echo "::error::missing STAGING_AGENT_CERTIFICATE_HOSTS_JSON"; fail=1; }
+          fi
           exit "$fail"
       - name: Terraform format
         working-directory: ${{ env.TF_DIR }}
@@ -100,6 +108,7 @@ jobs:
         working-directory: ${{ env.TF_DIR }}
         run: |
           terraform output -json pages_domains > "$RUNNER_TEMP/pages-domains.json"
+          terraform output -json staging_agent_edge > "$RUNNER_TEMP/staging-agent-edge.json"
           node -e '
             const fs = require("node:fs");
             const domains = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
@@ -107,7 +116,15 @@ jobs:
               if (entry.status !== "active") throw new Error(`${key} domain is ${entry.status}, expected active`);
               if (!entry.certificate_authority) throw new Error(`${key} has no issued certificate authority`);
             }
-          ' "$RUNNER_TEMP/pages-domains.json"
+            const agentEdge = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+            if (process.env.TF_VAR_environment === "staging") {
+              if (Object.keys(agentEdge.dns_records).length !== 2) throw new Error("staging agent wildcard does not have two DNS records");
+              if (agentEdge.certificate_pack.status !== "active") throw new Error(`staging agent certificate is ${agentEdge.certificate_pack.status}, expected active`);
+            }
+          ' "$RUNNER_TEMP/pages-domains.json" "$RUNNER_TEMP/staging-agent-edge.json"
+      - name: Verify staging agent wildcard TLS
+        if: github.event.inputs.action == 'apply' && github.event.inputs.environment == 'staging'
+        run: curl --silent --show-error --output /dev/null https://terraform-probe.staging.elizacloud.ai/api/health
       - name: Verify live environment routing
         if: github.event.inputs.action == 'apply'
         run: node packages/scripts/cloud/verify-environment-routing-cli.mjs --environment "${{ github.event.inputs.environment }}" --require-beacon

--- a/packages/cloud/infra/AGENTS.md
+++ b/packages/cloud/infra/AGENTS.md
@@ -69,6 +69,8 @@ packages/cloud/infra/
           providers.tf
           backend.hcl
           cloud-init/
+      cloudflare/
+        pages-domains/             # Active: Pages custom-domain + DNS/certificate bindings
       gcp/
         01-foundation/             # GCP foundation (VPC, IAM, GKE module) — experimental, not CI-wired
         02-k8s/                    # GKE cluster resources — experimental, not CI-wired
@@ -107,6 +109,11 @@ Three Terraform roots:
 - **`control-plane/`** — manages the control-plane VMs only (one per env: `eliza-staging-1`, `eliza-production-1`).
 - **`apps-data-plane/`** — manages Hetzner data-plane app server resources.
 - **`apps-shared/`** — manages shared Hetzner infrastructure.
+
+The separate **`cloudflare/pages-domains/`** root adopts and manages the
+environment-specific Pages custom domains and CNAMEs for `eliza-cloud` and
+`eliza-app`. Wrangler continues to own deployments and Worker routes; this root
+prevents dashboard-only domain/certificate drift.
 
 The **data plane** is not in Terraform: dedicated robot nodes (`eliza-core-{env}-N`) are registered in the `docker_nodes` table (authoritative; `CONTAINERS_DOCKER_NODES` env only seeds when empty) and extra burst capacity (`eliza-core-<hex>`) is minted at runtime by `packages/cloud/shared/src/lib/services/containers/node-autoscaler.ts` via the Hetzner Cloud API.
 

--- a/packages/cloud/infra/CLAUDE.md
+++ b/packages/cloud/infra/CLAUDE.md
@@ -69,6 +69,8 @@ packages/cloud/infra/
           providers.tf
           backend.hcl
           cloud-init/
+      cloudflare/
+        pages-domains/             # Active: Pages custom-domain + DNS/certificate bindings
       gcp/
         01-foundation/             # GCP foundation (VPC, IAM, GKE module) — experimental, not CI-wired
         02-k8s/                    # GKE cluster resources — experimental, not CI-wired
@@ -107,6 +109,11 @@ Three Terraform roots:
 - **`control-plane/`** — manages the control-plane VMs only (one per env: `eliza-staging-1`, `eliza-production-1`).
 - **`apps-data-plane/`** — manages Hetzner data-plane app server resources.
 - **`apps-shared/`** — manages shared Hetzner infrastructure.
+
+The separate **`cloudflare/pages-domains/`** root adopts and manages the
+environment-specific Pages custom domains and CNAMEs for `eliza-cloud` and
+`eliza-app`. Wrangler continues to own deployments and Worker routes; this root
+prevents dashboard-only domain/certificate drift.
 
 The **data plane** is not in Terraform: dedicated robot nodes (`eliza-core-{env}-N`) are registered in the `docker_nodes` table (authoritative; `CONTAINERS_DOCKER_NODES` env only seeds when empty) and extra burst capacity (`eliza-core-<hex>`) is minted at runtime by `packages/cloud/shared/src/lib/services/containers/node-autoscaler.ts` via the Hetzner Cloud API.
 

--- a/packages/cloud/infra/README.md
+++ b/packages/cloud/infra/README.md
@@ -9,6 +9,7 @@ Infrastructure-as-code for the elizaOS Cloud stack. Contains Kubernetes manifest
 | `cloud/local/` | kind cluster setup for local development (scripts, Helm values, K8s manifests) |
 | `cloud/docker-compose.yml` | Self-hosted Supabase Storage for offline object-storage testing |
 | `cloud/terraform/hetzner/control-plane/` | Terraform for the elizaOS Cloud Hetzner control-plane VMs |
+| `cloud/terraform/cloudflare/pages-domains/` | Terraform for Pages custom domains, DNS, and certificate bindings |
 | `cloud/terraform/gcp/` | Experimental GCP/GKE roots (not active, not CI-wired) |
 | `tests/` | Bun smoke tests validating YAML structure (no cluster required) |
 

--- a/packages/cloud/infra/cloud/terraform/README.md
+++ b/packages/cloud/infra/cloud/terraform/README.md
@@ -39,5 +39,9 @@ service runs today. Short version:
 
 - `gcp/` — partial GKE / foundation modules, not currently wired to CI. Keep
   for future GCP experimentation.
+- `hetzner/` — active control-plane, shared-app, and data-plane roots.
+- `cloudflare/pages-domains/` — active environment-scoped Pages custom-domain,
+  DNS, and certificate bindings for the console and app projects.
 
-That is it.
+Wrangler still owns Cloudflare Worker routes and Pages deployments; the
+Cloudflare Terraform root owns only the stable public edge bindings.

--- a/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/.terraform.lock.hcl
+++ b/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/.terraform.lock.hcl
@@ -1,0 +1,19 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/cloudflare/cloudflare" {
+  version     = "5.21.1"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:gNF1Sro3G9nXhtdkitXwDVKxI1jpBAf8KPv+Y4kAJwk=",
+    "zh:049719425b8be43d9d4f0c208217aca0baa22374f061d7ff92f02563490f649c",
+    "zh:0a8a3c1b26680b437fe9e7910ca81e532d36f8efacfb14f45690b6a779856993",
+    "zh:32b61f80892243f7ab8e453fa038c1f3e2aac733ccb98307c2cfe798b2793b32",
+    "zh:42c27f3cd62979e70716c51f682a3d131d51ad76d86dff83d8cdbfffcebac841",
+    "zh:4c8cd464f9b6ecde5cd4430bbba4be3b810826105e51ef6328b6a2b69f821443",
+    "zh:586ea42ef74d6c5bc4c9b89da6b1f8618a19f4e80272fe8d615e7d5b11c491af",
+    "zh:b09b86c7cac7085e01c9b7a828f09d13c44589d3e3cd42f0b694ca3e4cd3ed0a",
+    "zh:eac80665e60c701b37a6318f4e405d67f1720f8da5f93135c6256049282d3367",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}

--- a/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/README.md
+++ b/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/README.md
@@ -1,0 +1,39 @@
+# Cloudflare Pages public domains
+
+This Terraform root owns the four stable Pages custom-domain bindings and
+their proxied CNAME records:
+
+| Environment | Project | Public domain | CNAME target |
+| --- | --- | --- | --- |
+| staging | `eliza-cloud` | `staging.elizacloud.ai` | `develop.eliza-cloud.pages.dev` |
+| staging | `eliza-app` | `app-staging.elizacloud.ai` | `develop.eliza-app.pages.dev` |
+| production | `eliza-cloud` | `elizacloud.ai` | `eliza-cloud.pages.dev` |
+| production | `eliza-app` | `app.elizacloud.ai` | `eliza-app.pages.dev` |
+
+Wrangler remains responsible for project deployments and Worker routes. This
+root owns only the durable edge attachment and DNS/certificate relationship.
+In particular, staging CNAMEs include the `develop.` branch alias; pointing
+them at the project-level `*.pages.dev` name serves the production branch.
+
+## Adoption
+
+The live bindings predate this root. `import.tf` adopts Pages domains by their
+deterministic import ID and discovers the existing CNAME record ID by exact
+name. A missing or duplicate record makes the first plan fail before any write.
+
+Run the `Terraform — Cloudflare Pages Domains` workflow with `action=plan` for
+staging first. Review that the plan contains imports and no destroy/replace.
+Then apply staging, verify the routing probe and TLS certificate, and repeat
+through the production Environment approval. The workflow never runs apply on
+push or pull request.
+
+Required GitHub Environment configuration:
+
+- `CLOUDFLARE_API_TOKEN` secret with Pages Read/Write and DNS Read/Write.
+- `CLOUDFLARE_ACCOUNT_ID` secret.
+- `APPS_CLOUDFLARE_ZONE_ID` secret or variable.
+- `R2_STATE_ACCESS_KEY_ID` and `R2_STATE_SECRET_ACCESS_KEY` secrets.
+
+The same `cloudflare_pages_domain` resource exposes domain and certificate
+status in `terraform output pages_domains`; the post-apply workflow also probes
+the public HTTPS endpoints and requires the environment-routing beacon.

--- a/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/README.md
+++ b/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/README.md
@@ -1,7 +1,7 @@
 # Cloudflare Pages public domains
 
-This Terraform root owns the four stable Pages custom-domain bindings and
-their proxied CNAME records:
+This Terraform root owns the four stable Pages custom-domain bindings, their
+proxied CNAME records, and the staging dedicated-agent wildcard edge assets:
 
 | Environment | Project | Public domain | CNAME target |
 | --- | --- | --- | --- |
@@ -9,6 +9,12 @@ their proxied CNAME records:
 | staging | `eliza-app` | `app-staging.elizacloud.ai` | `develop.eliza-app.pages.dev` |
 | production | `eliza-cloud` | `elizacloud.ai` | `eliza-cloud.pages.dev` |
 | production | `eliza-app` | `app.elizacloud.ai` | `eliza-app.pages.dev` |
+
+For staging agents it also adopts both proxied A records at
+`*.staging.elizacloud.ai` and advanced certificate pack `02490878…`. Universal
+SSL covers only `*.elizacloud.ai`; the paid advanced pack is what makes the
+two-label agent hosts terminate TLS. The matching Worker route remains owned by
+`packages/cloud/api/wrangler.toml`.
 
 Wrangler remains responsible for project deployments and Worker routes. This
 root owns only the durable edge attachment and DNS/certificate relationship.
@@ -33,7 +39,13 @@ Required GitHub Environment configuration:
 - `CLOUDFLARE_ACCOUNT_ID` secret.
 - `APPS_CLOUDFLARE_ZONE_ID` secret or variable.
 - `R2_STATE_ACCESS_KEY_ID` and `R2_STATE_SECRET_ACCESS_KEY` secrets.
+- On `staging`, `STAGING_AGENT_WILDCARD_ORIGINS_JSON` with the exact two live
+  origin IPv4 addresses, `STAGING_AGENT_CERTIFICATE_PACK_ID` with the full live
+  pack id, and `STAGING_AGENT_CERTIFICATE_HOSTS_JSON` with the exact pack host
+  inventory. Keeping these as protected Environment variables avoids guessing
+  or committing live edge inventory while still making every plan reproducible.
 
-The same `cloudflare_pages_domain` resource exposes domain and certificate
-status in `terraform output pages_domains`; the post-apply workflow also probes
-the public HTTPS endpoints and requires the environment-routing beacon.
+The outputs expose Pages domain state plus wildcard DNS and advanced-certificate
+status; the post-apply workflow verifies both, completes a real wildcard TLS
+handshake, probes the public Pages endpoints, and requires the environment
+routing beacon.

--- a/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/backend-production.hcl
+++ b/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/backend-production.hcl
@@ -1,0 +1,10 @@
+bucket                      = "eliza-terraform-state"
+key                         = "cloudflare/pages-domains/production.tfstate"
+region                      = "auto"
+endpoints                   = { s3 = "https://23cf6feaeaa541f6a0675053c33da768.r2.cloudflarestorage.com" }
+skip_credentials_validation = true
+skip_metadata_api_check     = true
+skip_region_validation      = true
+skip_requesting_account_id  = true
+use_path_style              = true
+use_lockfile                = true

--- a/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/backend-staging.hcl
+++ b/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/backend-staging.hcl
@@ -1,0 +1,10 @@
+bucket                      = "eliza-terraform-state"
+key                         = "cloudflare/pages-domains/staging.tfstate"
+region                      = "auto"
+endpoints                   = { s3 = "https://23cf6feaeaa541f6a0675053c33da768.r2.cloudflarestorage.com" }
+skip_credentials_validation = true
+skip_metadata_api_check     = true
+skip_region_validation      = true
+skip_requesting_account_id  = true
+use_path_style              = true
+use_lockfile                = true

--- a/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/import.tf
+++ b/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/import.tf
@@ -20,6 +20,32 @@ import {
   id       = "${var.cloudflare_account_id}/${each.value.project_name}/${each.value.domain}"
 }
 
+data "cloudflare_dns_records" "existing_staging_agent_wildcard" {
+  count = var.environment == "staging" ? 1 : 0
+
+  zone_id   = var.cloudflare_zone_id
+  type      = "A"
+  max_items = 10
+  name = {
+    exact = "*.staging.elizacloud.ai"
+  }
+}
+
+import {
+  for_each = local.staging_agent_wildcard_records
+  to       = cloudflare_dns_record.staging_agent_wildcard[each.key]
+  id = "${var.cloudflare_zone_id}/${one([
+    for record in data.cloudflare_dns_records.existing_staging_agent_wildcard[0].result : record.id
+    if record.content == each.value
+  ])}"
+}
+
+import {
+  for_each = var.environment == "staging" ? toset(["staging"]) : toset([])
+  to       = cloudflare_certificate_pack.staging_agent[0]
+  id       = "${var.cloudflare_zone_id}/${var.staging_agent_certificate_pack_id}"
+}
+
 import {
   for_each = local.pages_domains
   to       = cloudflare_dns_record.pages[each.key]

--- a/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/import.tf
+++ b/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/import.tf
@@ -1,0 +1,27 @@
+# Adopt the live Pages bindings and their auto-created DNS records. Domain IDs
+# are deterministic; DNS record IDs are resolved read-only by exact name so no
+# opaque production identifier is committed. The live zone already contains
+# exactly one CNAME for each name. A missing/duplicate result fails the first
+# plan instead of creating or choosing a record ambiguously.
+data "cloudflare_dns_records" "existing_pages" {
+  for_each = local.pages_domains
+
+  zone_id   = var.cloudflare_zone_id
+  type      = "CNAME"
+  max_items = 2
+  name = {
+    exact = each.value.domain
+  }
+}
+
+import {
+  for_each = local.pages_domains
+  to       = cloudflare_pages_domain.public[each.key]
+  id       = "${var.cloudflare_account_id}/${each.value.project_name}/${each.value.domain}"
+}
+
+import {
+  for_each = local.pages_domains
+  to       = cloudflare_dns_record.pages[each.key]
+  id       = "${var.cloudflare_zone_id}/${one(data.cloudflare_dns_records.existing_pages[each.key].result).id}"
+}

--- a/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/main.tf
+++ b/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/main.tf
@@ -1,0 +1,53 @@
+locals {
+  pages_domains = var.environment == "production" ? {
+    console = {
+      project_name = "eliza-cloud"
+      domain       = "elizacloud.ai"
+      cname_target = "eliza-cloud.pages.dev"
+    }
+    app = {
+      project_name = "eliza-app"
+      domain       = "app.elizacloud.ai"
+      cname_target = "eliza-app.pages.dev"
+    }
+    } : {
+    console = {
+      project_name = "eliza-cloud"
+      domain       = "staging.elizacloud.ai"
+      cname_target = "develop.eliza-cloud.pages.dev"
+    }
+    app = {
+      project_name = "eliza-app"
+      domain       = "app-staging.elizacloud.ai"
+      cname_target = "develop.eliza-app.pages.dev"
+    }
+  }
+}
+
+# Wrangler owns Pages deployments and branch selection. Terraform owns the
+# stable public-domain attachment so a dashboard edit or account rebuild shows
+# up as plan drift instead of silently routing staging to production.
+resource "cloudflare_pages_domain" "public" {
+  for_each = local.pages_domains
+
+  account_id   = var.cloudflare_account_id
+  project_name = each.value.project_name
+  name         = each.value.domain
+}
+
+# Pages' domain API does not guarantee creation of a Terraform-managed DNS
+# record. Keep the CNAME explicit, including the `develop.` branch alias that
+# prevents staging custom domains from falling through to the production branch.
+resource "cloudflare_dns_record" "pages" {
+  for_each = local.pages_domains
+
+  zone_id = var.cloudflare_zone_id
+  name    = each.value.domain
+  type    = "CNAME"
+  content = each.value.cname_target
+  ttl     = 1
+  proxied = true
+  comment = "${each.value.project_name} Pages ${var.environment} domain (managed by terraform/cloudflare/pages-domains)"
+
+  depends_on = [cloudflare_pages_domain.public]
+}

--- a/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/main.tf
+++ b/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/main.tf
@@ -22,6 +22,10 @@ locals {
       cname_target = "develop.eliza-app.pages.dev"
     }
   }
+
+  staging_agent_wildcard_records = var.environment == "staging" ? {
+    for origin in var.staging_agent_wildcard_origins : origin => origin
+  } : {}
 }
 
 # Wrangler owns Pages deployments and branch selection. Terraform owns the
@@ -50,4 +54,38 @@ resource "cloudflare_dns_record" "pages" {
   comment = "${each.value.project_name} Pages ${var.environment} domain (managed by terraform/cloudflare/pages-domains)"
 
   depends_on = [cloudflare_pages_domain.public]
+}
+
+# The Worker route is durable in wrangler.toml, but proxied DNS must exist for
+# Cloudflare to accept TLS and route an arbitrary dedicated-agent subdomain.
+# Two records preserve the live origin redundancy recorded during launch QA.
+resource "cloudflare_dns_record" "staging_agent_wildcard" {
+  for_each = local.staging_agent_wildcard_records
+
+  zone_id = var.cloudflare_zone_id
+  name    = "*.staging.elizacloud.ai"
+  type    = "A"
+  content = each.value
+  ttl     = 1
+  proxied = true
+  comment = "Staging dedicated-agent wildcard (managed by terraform/cloudflare/pages-domains)"
+}
+
+# Universal SSL covers only one label below the zone. Dedicated staging agents
+# are two labels deep, so this paid advanced pack is a required routing asset.
+resource "cloudflare_certificate_pack" "staging_agent" {
+  count = var.environment == "staging" ? 1 : 0
+
+  zone_id               = var.cloudflare_zone_id
+  certificate_authority = "google"
+  hosts                 = var.staging_agent_certificate_hosts
+  type                  = "advanced"
+  validation_method     = "txt"
+  validity_days         = 90
+  cloudflare_branding   = false
+
+  lifecycle {
+    create_before_destroy = true
+    prevent_destroy       = true
+  }
 }

--- a/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/outputs.tf
+++ b/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/outputs.tf
@@ -1,0 +1,12 @@
+output "pages_domains" {
+  description = "Pages project/domain bindings and certificate state observed after apply."
+  value = {
+    for key, binding in cloudflare_pages_domain.public : key => {
+      project_name          = local.pages_domains[key].project_name
+      domain                = binding.name
+      status                = binding.status
+      certificate_authority = binding.certificate_authority
+      cname_target          = cloudflare_dns_record.pages[key].content
+    }
+  }
+}

--- a/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/outputs.tf
+++ b/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/outputs.tf
@@ -10,3 +10,21 @@ output "pages_domains" {
     }
   }
 }
+
+output "staging_agent_edge" {
+  description = "Staging-only dedicated-agent wildcard DNS and advanced-certificate state."
+  value = var.environment == "staging" ? {
+    dns_records = {
+      for origin, record in cloudflare_dns_record.staging_agent_wildcard : origin => {
+        id      = record.id
+        content = record.content
+        proxied = record.proxied
+      }
+    }
+    certificate_pack = {
+      id     = cloudflare_certificate_pack.staging_agent[0].id
+      hosts  = cloudflare_certificate_pack.staging_agent[0].hosts
+      status = cloudflare_certificate_pack.staging_agent[0].status
+    }
+  } : null
+}

--- a/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/providers.tf
+++ b/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/providers.tf
@@ -1,0 +1,4 @@
+provider "cloudflare" {
+  # CLOUDFLARE_API_TOKEN supplies the credential. It needs Pages Read/Write and
+  # DNS Read/Write for the elizacloud.ai zone; no token enters Terraform state.
+}

--- a/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/tfvars/production.tfvars.example
+++ b/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/tfvars/production.tfvars.example
@@ -1,0 +1,3 @@
+environment           = "production"
+cloudflare_account_id = "<cloudflare-account-id>"
+cloudflare_zone_id    = "<zone-id-for-elizacloud.ai>"

--- a/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/tfvars/staging.tfvars.example
+++ b/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/tfvars/staging.tfvars.example
@@ -1,3 +1,12 @@
 environment           = "staging"
 cloudflare_account_id = "<cloudflare-account-id>"
 cloudflare_zone_id    = "<zone-id-for-elizacloud.ai>"
+staging_agent_wildcard_origins = [
+  "<first-current-origin-ipv4>",
+  "<second-current-origin-ipv4>",
+]
+staging_agent_certificate_pack_id = "<full-existing-pack-id-prefix-02490878>"
+staging_agent_certificate_hosts = [
+  "elizacloud.ai",
+  "*.staging.elizacloud.ai",
+]

--- a/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/tfvars/staging.tfvars.example
+++ b/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/tfvars/staging.tfvars.example
@@ -1,0 +1,3 @@
+environment           = "staging"
+cloudflare_account_id = "<cloudflare-account-id>"
+cloudflare_zone_id    = "<zone-id-for-elizacloud.ai>"

--- a/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/variables.tf
+++ b/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/variables.tf
@@ -27,3 +27,45 @@ variable "cloudflare_zone_id" {
     error_message = "cloudflare_zone_id must be a 32-character hexadecimal Cloudflare zone id"
   }
 }
+
+variable "staging_agent_wildcard_origins" {
+  description = "The two existing IPv4 origins behind the proxied *.staging.elizacloud.ai records. Set from the staging GitHub Environment inventory."
+  type        = set(string)
+  default     = []
+
+  validation {
+    condition = var.environment != "staging" || (
+      length(var.staging_agent_wildcard_origins) == 2 &&
+      alltrue([for address in var.staging_agent_wildcard_origins : can(cidrhost("${address}/32", 0)) && !strcontains(address, ":")])
+    )
+    error_message = "staging_agent_wildcard_origins must contain exactly two IPv4 addresses for staging"
+  }
+}
+
+variable "staging_agent_certificate_pack_id" {
+  description = "Full id of the live advanced certificate pack covering *.staging.elizacloud.ai."
+  type        = string
+  default     = ""
+
+  validation {
+    condition = var.environment != "staging" || can(regex(
+      "^[0-9a-f-]{8,}$",
+      var.staging_agent_certificate_pack_id,
+    ))
+    error_message = "staging_agent_certificate_pack_id is required for staging so the live paid pack is imported instead of duplicated"
+  }
+}
+
+variable "staging_agent_certificate_hosts" {
+  description = "Exact host inventory on the live staging agent advanced certificate pack."
+  type        = set(string)
+  default     = []
+
+  validation {
+    condition = var.environment != "staging" || contains(
+      var.staging_agent_certificate_hosts,
+      "*.staging.elizacloud.ai",
+    )
+    error_message = "staging_agent_certificate_hosts must include *.staging.elizacloud.ai for staging"
+  }
+}

--- a/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/variables.tf
+++ b/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/variables.tf
@@ -1,0 +1,29 @@
+variable "environment" {
+  description = "Cloudflare Pages environment whose domain bindings this state owns."
+  type        = string
+
+  validation {
+    condition     = contains(["staging", "production"], var.environment)
+    error_message = "environment must be staging or production"
+  }
+}
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account that owns the eliza-cloud and eliza-app Pages projects."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[0-9a-f]{32}$", var.cloudflare_account_id))
+    error_message = "cloudflare_account_id must be a 32-character hexadecimal Cloudflare account id"
+  }
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone id for elizacloud.ai."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[0-9a-f]{32}$", var.cloudflare_zone_id))
+    error_message = "cloudflare_zone_id must be a 32-character hexadecimal Cloudflare zone id"
+  }
+}

--- a/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/versions.tf
+++ b/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "s3" {}
+}

--- a/packages/cloud/infra/tests/terraform-static.test.ts
+++ b/packages/cloud/infra/tests/terraform-static.test.ts
@@ -168,6 +168,10 @@ describe("Cloudflare Pages domain durability", () => {
   });
 
   test("keeps real writes manual and verifies certificate plus routing after apply", () => {
+    expect(workflow).toContain("oven-sh/setup-bun@");
+    expect(workflow).toContain(
+      "bun install --frozen-lockfile --ignore-scripts",
+    );
     expect(workflow).toContain("workflow_dispatch:");
     expect(workflow).toContain("options: [plan, apply]");
     expect(workflow).toContain("terraform apply -no-color -input=false");

--- a/packages/cloud/infra/tests/terraform-static.test.ts
+++ b/packages/cloud/infra/tests/terraform-static.test.ts
@@ -17,6 +17,14 @@ const K8S_TERRAFORM_DIR = join(
   "gcp",
   "02-k8s",
 );
+const CLOUDFLARE_PAGES_DOMAINS_DIR = join(
+  import.meta.dir,
+  "..",
+  "cloud",
+  "terraform",
+  "cloudflare",
+  "pages-domains",
+);
 
 function readK8sTerraform(file: string): string {
   return readFileSync(join(K8S_TERRAFORM_DIR, file), "utf-8");
@@ -118,5 +126,53 @@ describe("Terraform namespace contracts", () => {
     expect(variables).toContain(
       'description = "CNPG PostgreSQL clusters to deploy (key = namespace/org UUID)"',
     );
+  });
+});
+
+describe("Cloudflare Pages domain durability", () => {
+  const main = readFileSync(
+    join(CLOUDFLARE_PAGES_DOMAINS_DIR, "main.tf"),
+    "utf-8",
+  );
+  const imports = readFileSync(
+    join(CLOUDFLARE_PAGES_DOMAINS_DIR, "import.tf"),
+    "utf-8",
+  );
+  const workflow = readFileSync(
+    join(
+      import.meta.dir,
+      "../../../../.github/workflows/terraform-pages-domains.yml",
+    ),
+    "utf-8",
+  );
+
+  test("binds production and staging to distinct Pages branch aliases", () => {
+    expect(main).toContain('domain       = "elizacloud.ai"');
+    expect(main).toContain('domain       = "app.elizacloud.ai"');
+    expect(main).toContain('domain       = "staging.elizacloud.ai"');
+    expect(main).toContain('domain       = "app-staging.elizacloud.ai"');
+    expect(main).toContain('cname_target = "develop.eliza-cloud.pages.dev"');
+    expect(main).toContain('cname_target = "develop.eliza-app.pages.dev"');
+    expect(main).toContain('resource "cloudflare_pages_domain" "public"');
+    expect(main).toContain('resource "cloudflare_dns_record" "pages"');
+  });
+
+  test("adopts live bindings and exact-name DNS records before managing them", () => {
+    expect(imports).toContain('data "cloudflare_dns_records" "existing_pages"');
+    expect(imports).toContain("exact = each.value.domain");
+    expect(imports).toContain("cloudflare_pages_domain.public[each.key]");
+    expect(imports).toContain("cloudflare_dns_record.pages[each.key]");
+    expect(imports).toContain(
+      "one(data.cloudflare_dns_records.existing_pages[each.key].result).id",
+    );
+  });
+
+  test("keeps real writes manual and verifies certificate plus routing after apply", () => {
+    expect(workflow).toContain("workflow_dispatch:");
+    expect(workflow).toContain("options: [plan, apply]");
+    expect(workflow).toContain("terraform apply -no-color -input=false");
+    expect(workflow).toContain('entry.status !== "active"');
+    expect(workflow).toContain("--require-beacon");
+    expect(workflow).not.toContain("push:");
   });
 });

--- a/packages/cloud/infra/tests/terraform-static.test.ts
+++ b/packages/cloud/infra/tests/terraform-static.test.ts
@@ -138,6 +138,10 @@ describe("Cloudflare Pages domain durability", () => {
     join(CLOUDFLARE_PAGES_DOMAINS_DIR, "import.tf"),
     "utf-8",
   );
+  const variables = readFileSync(
+    join(CLOUDFLARE_PAGES_DOMAINS_DIR, "variables.tf"),
+    "utf-8",
+  );
   const workflow = readFileSync(
     join(
       import.meta.dir,
@@ -165,6 +169,27 @@ describe("Cloudflare Pages domain durability", () => {
     expect(imports).toContain(
       "one(data.cloudflare_dns_records.existing_pages[each.key].result).id",
     );
+  });
+
+  test("owns the staging dedicated-agent wildcard and paid certificate pack", () => {
+    expect(main).toContain(
+      'resource "cloudflare_dns_record" "staging_agent_wildcard"',
+    );
+    expect(main).toContain('name    = "*.staging.elizacloud.ai"');
+    expect(main).toContain(
+      'resource "cloudflare_certificate_pack" "staging_agent"',
+    );
+    expect(main).toContain('type                  = "advanced"');
+    expect(main).toContain("prevent_destroy       = true");
+    expect(imports).toContain(
+      'data "cloudflare_dns_records" "existing_staging_agent_wildcard"',
+    );
+    expect(imports).toContain("cloudflare_certificate_pack.staging_agent[0]");
+    expect(variables).toContain('variable "staging_agent_wildcard_origins"');
+    expect(variables).toContain('variable "staging_agent_certificate_pack_id"');
+    expect(workflow).toContain("STAGING_AGENT_WILDCARD_ORIGINS_JSON");
+    expect(workflow).toContain("STAGING_AGENT_CERTIFICATE_PACK_ID");
+    expect(workflow).toContain("terraform-probe.staging.elizacloud.ai");
   });
 
   test("keeps real writes manual and verifies certificate plus routing after apply", () => {


### PR DESCRIPTION
Closes the remaining Cloudflare DNS/custom-domain durability work in #15401.

## Summary

- manage all four production/staging Pages custom domains and proxied CNAMEs in a dedicated Terraform root
- adopt the two proxied `*.staging.elizacloud.ai` A records and paid advanced certificate pack, with protected Environment inventory for exact live values
- adopt the existing live Pages bindings and exact-name DNS records into environment-scoped state
- provide a manual, Environment-gated plan/apply workflow with post-apply certificate and live-routing verification
- document the operator contract and protect it with static tests

## Verification

- `bun run --cwd packages/cloud/infra test` — 46 passed
- Terraform 1.10.5 `fmt -check`, `init -backend=false`, and `validate` — passed
- `bunx biome check` — passed with one unrelated pre-existing warning
- `bun run audit:error-policy-ratchet` — passed
- live read-only routing verifier — all production and staging domains passed

<!-- evidence-row:before-screenshots -->
- [ ] N/A - infrastructure-only change; no rendered UI surface changes.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - infrastructure-only change; no rendered UI surface changes.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - infrastructure-only change; no user-facing interaction changed.

<!-- evidence-row:backend-logs -->
- [x] Live routing and certificate observations are recorded in #15401: https://github.com/elizaOS/eliza/issues/15401#issuecomment-4931290585

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser behavior changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, action, provider, evaluator, or planner behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Terraform validation, 46-test output, four live HTTP 200 responses, valid TLS certificates, and environment routing proof are summarized in #15401: https://github.com/elizaOS/eliza/issues/15401#issuecomment-4931290585

The first credentialed plan/apply uses protected GitHub Environment secrets and therefore remains a human/operator verification step after review.