### PR TITLE
fix(ui): make the chat-sheet press latch pointer-identity safe

### DIFF
--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -134,6 +134,7 @@ import {
   resolveChatPanelLayout,
 } from "./chat-panel-layout";
 import { LIQUID_GLASS_EDGE_SHADOW, LIQUID_GLASS_SHEEN } from "./liquid-glass";
+import { withPressLatch } from "./press-latch";
 import { SlashCommandMenu, useSlashMenu } from "./SlashCommandMenu";
 import {
   filterRenderableShellMessages,
@@ -149,41 +150,6 @@ import {
 import { type PullGestureBinding, usePullGesture } from "./use-pull-gesture";
 import type { ConversationNav, ShellController } from "./useShellController";
 import { WALLPAPER_FLOAT_SHADOW, WALLPAPER_TEXT } from "./wallpaper-idiom";
-
-/**
- * Wraps a pull-gesture binding so `pressed` tracks whether a pointer is held on
- * the bound element — set on pointerdown, cleared on every terminal (up, cancel,
- * lost-capture). A drag handle that unmounts under a captured pointer drops the
- * capture (Chromium fires pointercancel/lostpointercapture on the dead node and
- * the gesture's settle never runs); the consumer reads this ref in the element's
- * MOUNT gate so the handle stays alive across the whole press, closing the
- * window between pointerdown and the integrator's first frame where a stray
- * re-render would otherwise unmount it.
- */
-function withPressLatch(
-  binding: PullGestureBinding,
-  pressed: React.MutableRefObject<boolean>,
-): PullGestureBinding {
-  return {
-    onPointerDown: (event) => {
-      pressed.current = true;
-      binding.onPointerDown(event);
-    },
-    onPointerMove: binding.onPointerMove,
-    onPointerUp: (event) => {
-      pressed.current = false;
-      binding.onPointerUp(event);
-    },
-    onPointerCancel: (event) => {
-      pressed.current = false;
-      binding.onPointerCancel(event);
-    },
-    onLostPointerCapture: (event) => {
-      pressed.current = false;
-      binding.onLostPointerCapture(event);
-    },
-  };
-}
 
 /** No-op slash controller so the overlay renders without a provider (stories). */
 const EMPTY_SLASH_CONTROLLER: SlashCommandController = {
@@ -1501,10 +1467,13 @@ export function ContinuousChatOverlay({
   // sheet's settle springs — the desktop-held FULL→bottom drain then reads the
   // corrupted sheet and never engages, stuck at scale 1.00). Held deliberately
   // OUT of the settle-suppression guards (unlike `draggingRef`): they only keep
-  // the element mounted, and the browser guarantees a pointerup/cancel/lostcapture
-  // terminal for every press, so they clear without a fragile per-callback web.
-  const grabberPressRef = React.useRef(false);
-  const restorePressRef = React.useRef(false);
+  // the element mounted. Each ref holds the ACCEPTED pointer's id (#15824), not
+  // a boolean: only an eligible primary press latches (the browser guarantees a
+  // terminal for a captured press — an ineligible one gets no capture and no
+  // such guarantee), and only that pointer's own terminal clears it, so a
+  // secondary finger's up can never unlatch a still-held primary drag.
+  const grabberPressRef = React.useRef<number | null>(null);
+  const restorePressRef = React.useRef<number | null>(null);
   // Peak RAW (pre-clamp) pull height reached during the current upward drag
   // (#13531). The visible `threadHeight` is rubber-band-clamped at `openH`, so a
   // deliberate over-pull past FULL is invisible to a `threadHeight.get()` read on
@@ -4887,7 +4856,7 @@ export function ContinuousChatOverlay({
         {!firstRunOpen &&
         ((!fullBleed && !restoreDragging) ||
           draggingRef.current ||
-          grabberPressRef.current) ? (
+          grabberPressRef.current != null) ? (
           // Suppressed while full-bleed (the restore strip owns the top) and
           // while a restore drag is in flight (so the strip keeps the pointer
           // capture through the un-maximize) — EXCEPT while a grabber drag is
@@ -5132,7 +5101,9 @@ export function ContinuousChatOverlay({
                 over the top bar fall THROUGH to this strip. Keyboard-operable
                 (Enter/Space/ArrowDown restore) so the gesture-only affordance
                 stays WCAG 2.1.1 operable. */}
-            {(fullBleed || restoreDragging || restorePressRef.current) &&
+            {(fullBleed ||
+              restoreDragging ||
+              restorePressRef.current != null) &&
             !pinnedOpen ? (
               <button
                 {...restoreZoneBinding}

--- a/packages/ui/src/components/shell/press-latch.test.ts
+++ b/packages/ui/src/components/shell/press-latch.test.ts
@@ -1,0 +1,134 @@
+// Deterministic contract tests for the drag-handle press latch (#15824):
+// pointer-identity latching against a spied gesture binding — no DOM, no
+// timers; events are hand-built React.PointerEvent shapes.
+import { describe, expect, it, vi } from "vitest";
+import { withPressLatch } from "./press-latch";
+import type { PullGestureBinding } from "./use-pull-gesture";
+
+type LatchRef = { current: number | null };
+
+function makeBinding() {
+  const handler = () => vi.fn<(event: React.PointerEvent) => void>();
+  return {
+    onPointerDown: handler(),
+    onPointerMove: handler(),
+    onPointerUp: handler(),
+    onPointerCancel: handler(),
+    onLostPointerCapture: handler(),
+  } satisfies PullGestureBinding;
+}
+
+function ev(overrides: {
+  pointerId: number;
+  pointerType?: string;
+  isPrimary?: boolean;
+  button?: number;
+}): React.PointerEvent {
+  return {
+    pointerId: overrides.pointerId,
+    pointerType: overrides.pointerType ?? "touch",
+    isPrimary: overrides.isPrimary ?? true,
+    button: overrides.button ?? 0,
+  } as unknown as React.PointerEvent;
+}
+
+describe("withPressLatch pointer identity (#15824)", () => {
+  it("latches an eligible primary touch and clears on ITS terminal", () => {
+    const pressed: LatchRef = { current: null };
+    const binding = makeBinding();
+    const latched = withPressLatch(binding, pressed);
+
+    latched.onPointerDown(ev({ pointerId: 7 }));
+    expect(pressed.current).toBe(7);
+    expect(binding.onPointerDown).toHaveBeenCalledTimes(1);
+
+    latched.onPointerUp(ev({ pointerId: 7 }));
+    expect(pressed.current).toBeNull();
+    expect(binding.onPointerUp).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats pointerId 0 as a real held press (id-null check, not truthiness)", () => {
+    const pressed: LatchRef = { current: null };
+    const latched = withPressLatch(makeBinding(), pressed);
+    latched.onPointerDown(ev({ pointerId: 0 }));
+    expect(pressed.current).toBe(0);
+    latched.onPointerUp(ev({ pointerId: 0 }));
+    expect(pressed.current).toBeNull();
+  });
+
+  it("never latches a rejected secondary touch finger (no capture → no guaranteed terminal)", () => {
+    const pressed: LatchRef = { current: null };
+    const binding = makeBinding();
+    const latched = withPressLatch(binding, pressed);
+
+    latched.onPointerDown(ev({ pointerId: 9, isPrimary: false }));
+    expect(pressed.current).toBeNull();
+    // The gesture still sees the event (it applies its own rejection).
+    expect(binding.onPointerDown).toHaveBeenCalledTimes(1);
+  });
+
+  it("never latches a non-primary mouse button (right/middle-click drags nothing)", () => {
+    const pressed: LatchRef = { current: null };
+    const latched = withPressLatch(makeBinding(), pressed);
+
+    latched.onPointerDown(
+      ev({ pointerId: 1, pointerType: "mouse", button: 2 }),
+    );
+    expect(pressed.current).toBeNull();
+    latched.onPointerDown(
+      ev({ pointerId: 1, pointerType: "mouse", button: 1 }),
+    );
+    expect(pressed.current).toBeNull();
+    // The primary button still latches on the same mouse pointer id.
+    latched.onPointerDown(
+      ev({ pointerId: 1, pointerType: "mouse", button: 0 }),
+    );
+    expect(pressed.current).toBe(1);
+  });
+
+  it("a secondary pointer's terminal cannot clear the active primary latch", () => {
+    const pressed: LatchRef = { current: null };
+    const binding = makeBinding();
+    const latched = withPressLatch(binding, pressed);
+
+    latched.onPointerDown(ev({ pointerId: 7 }));
+    expect(pressed.current).toBe(7);
+
+    // A second finger lands (rejected — never latches) and lifts: its up,
+    // cancel, and lost-capture must all leave the primary latch alone.
+    latched.onPointerDown(ev({ pointerId: 8, isPrimary: false }));
+    latched.onPointerUp(ev({ pointerId: 8, isPrimary: false }));
+    latched.onPointerCancel(ev({ pointerId: 8, isPrimary: false }));
+    latched.onLostPointerCapture(ev({ pointerId: 8, isPrimary: false }));
+    expect(pressed.current).toBe(7);
+
+    // The primary's own terminal still clears it.
+    latched.onPointerCancel(ev({ pointerId: 7 }));
+    expect(pressed.current).toBeNull();
+  });
+
+  it("clears on lostpointercapture for the active pointer (mid-press unmount path)", () => {
+    const pressed: LatchRef = { current: null };
+    const latched = withPressLatch(makeBinding(), pressed);
+    latched.onPointerDown(ev({ pointerId: 3 }));
+    latched.onLostPointerCapture(ev({ pointerId: 3 }));
+    expect(pressed.current).toBeNull();
+  });
+
+  it("forwards every callback to the wrapped binding regardless of latch outcome", () => {
+    const pressed: LatchRef = { current: null };
+    const binding = makeBinding();
+    const latched = withPressLatch(binding, pressed);
+
+    latched.onPointerDown(ev({ pointerId: 2, isPrimary: false }));
+    latched.onPointerMove(ev({ pointerId: 2 }));
+    latched.onPointerUp(ev({ pointerId: 2 }));
+    latched.onPointerCancel(ev({ pointerId: 2 }));
+    latched.onLostPointerCapture(ev({ pointerId: 2 }));
+    expect(binding.onPointerDown).toHaveBeenCalledTimes(1);
+    expect(binding.onPointerMove).toHaveBeenCalledTimes(1);
+    expect(binding.onPointerUp).toHaveBeenCalledTimes(1);
+    expect(binding.onPointerCancel).toHaveBeenCalledTimes(1);
+    expect(binding.onLostPointerCapture).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/components/shell/press-latch.test.ts
+++ b/packages/ui/src/components/shell/press-latch.test.ts
@@ -1,6 +1,7 @@
-// Deterministic contract tests for the drag-handle press latch (#15824):
-// pointer-identity latching against a spied gesture binding — no DOM, no
-// timers; events are hand-built React.PointerEvent shapes.
+/**
+ * Deterministic contract tests for the drag-handle press latch (#15824):
+ * pointer-identity latching against a spied gesture binding — no DOM, no timers.
+ */
 import { describe, expect, it, vi } from "vitest";
 import { withPressLatch } from "./press-latch";
 import type { PullGestureBinding } from "./use-pull-gesture";

--- a/packages/ui/src/components/shell/press-latch.ts
+++ b/packages/ui/src/components/shell/press-latch.ts
@@ -1,0 +1,70 @@
+/**
+ * Press latch for chat-sheet drag handles: keeps a handle MOUNTED for the whole
+ * lifetime of the press that owns it, closing the pointerdown-to-first-frame
+ * window where a stray re-render (a settle spring landing under a loaded main
+ * thread) would unmount the element under a captured pointer — Chromium then
+ * fires pointercancel/lostpointercapture on the dead node and the gesture's
+ * settle never runs (#15807). Consumed by ContinuousChatOverlay's grabber and
+ * maximize-restore strip mount gates.
+ */
+import type * as React from "react";
+import type { PullGestureBinding } from "./use-pull-gesture";
+
+/**
+ * Wraps a pull-gesture binding so `pressed` tracks WHICH pointer is held on
+ * the bound element — the accepted pointer's id, latched on an eligible
+ * primary pointerdown and cleared only by that pointer's terminals (up,
+ * cancel, lost-capture). A drag handle that unmounts under a captured pointer
+ * drops the capture (Chromium fires pointercancel/lostpointercapture on the
+ * dead node and the gesture's settle never runs); the consumer reads this ref
+ * in the element's MOUNT gate so the handle stays alive across the whole
+ * press, closing the window between pointerdown and the integrator's first
+ * frame where a stray re-render would otherwise unmount it.
+ *
+ * Pointer identity matters twice (#15824): an INELIGIBLE press (a secondary
+ * touch finger the gesture rejects, or a non-primary mouse button) never
+ * receives pointer capture, so the browser guarantees no terminal on this
+ * node for it — latching it would hold the handle mounted forever. And a
+ * secondary pointer's terminal must not clear a latch the still-held primary
+ * owns, or the original mid-press unmount race reopens.
+ */
+export function withPressLatch(
+  binding: PullGestureBinding,
+  pressed: React.MutableRefObject<number | null>,
+): PullGestureBinding {
+  // Mirrors the gesture's own acceptance rule (use-pull-gesture onPointerDown
+  // rejects secondary touch/pen pointers) plus the primary-button rule for
+  // mouse: a right/middle-click drags nothing and captures nothing.
+  const eligible = (event: React.PointerEvent): boolean => {
+    if (
+      event.isPrimary === false &&
+      event.pointerType &&
+      event.pointerType !== "mouse"
+    ) {
+      return false;
+    }
+    return event.pointerType !== "mouse" || event.button === 0;
+  };
+  const clear = (event: React.PointerEvent) => {
+    if (pressed.current === event.pointerId) pressed.current = null;
+  };
+  return {
+    onPointerDown: (event) => {
+      if (eligible(event)) pressed.current = event.pointerId;
+      binding.onPointerDown(event);
+    },
+    onPointerMove: binding.onPointerMove,
+    onPointerUp: (event) => {
+      clear(event);
+      binding.onPointerUp(event);
+    },
+    onPointerCancel: (event) => {
+      clear(event);
+      binding.onPointerCancel(event);
+    },
+    onLostPointerCapture: (event) => {
+      clear(event);
+      binding.onLostPointerCapture(event);
+    },
+  };
+}


### PR DESCRIPTION
# Relates to

Fixes #15824 (follow-up to #15807).

- [x] Targets `develop`, based on latest `origin/develop`; zero conflicts.
- [x] `packages/ui` typecheck + biome green; suites below.
- [x] A reviewer can confirm the change works without reading the code, from the evidence below.

# Sync with develop

- [x] Branched from `origin/develop` tip today; will rebase before merge if it moves.
- [x] Verify green post-sync.

# Risks

Low. The latch keeps its exact #15807 role (mount-gate widening across the press) — only its identity model changes. Gates now compare `!= null` (pointerId 0 is a valid id). The full real-browser gesture suite passed under deliberate CPU contention.

# Background

## What does this PR do?

The #15807 mount latch was a shared boolean set before the gesture rejected ineligible input and cleared by ANY terminal event. Two holes (#15824): a rejected right-click / secondary touch could set it with **no pointer capture** (no guaranteed terminal on the node → a leaked latch holds the handle mounted forever), and a secondary pointer's terminal could clear the latch while the valid primary was still held — reopening the original mid-press unmount race.

The latch now stores the **accepted pointer's id**: only an eligible primary press latches (the gesture's own primary-pointer rule + the primary mouse button), and only that pointer's own up/cancel/lost-capture clears it. Extracted to `press-latch.ts` with deterministic contract tests for both holes.

## What kind of change is this?

Bug fix (correctness of the gesture mount latch).

# Documentation changes needed?

None — module + ref comments carry the invariant.

# Testing

## Where should a reviewer start?

`packages/ui/src/components/shell/press-latch.ts` (the whole change is legible there), then `press-latch.test.ts`.

## Detailed testing steps

1. `bun run --cwd packages/ui test src/components/shell/press-latch.test.ts` → 7/7.
2. `bun run --cwd packages/ui test:chat-sheet-e2e` → full gesture suite.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Rest state before/after is pixel-identical by design (the latch only controls mount lifetime during a press): rest ![rest](https://gist.githubusercontent.com/lalalune/6ca2c4fa8343ed45a024c7ea5d3e94b9/raw/c7ab65dd490d85627c384f6e6acd2fd3c06ee89a/latch-rest.jpg)
<!-- evidence-row:after-screenshots -->
- [x] Held mid-drag (handle mounted under the press — the state the latch protects) ![held](https://gist.githubusercontent.com/lalalune/6ca2c4fa8343ed45a024c7ea5d3e94b9/raw/c7ab65dd490d85627c384f6e6acd2fd3c06ee89a/latch-held.jpg) · released/settled ![release](https://gist.githubusercontent.com/lalalune/6ca2c4fa8343ed45a024c7ea5d3e94b9/raw/c7ab65dd490d85627c384f6e6acd2fd3c06ee89a/latch-release.jpg) — from the real-Chromium gesture suite on this branch.
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence/15900-latch-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [x] N/A - client-only gesture code; no server path.
<!-- evidence-row:frontend-logs -->
- [x] Full gesture-suite log (296 ✓, 0 ✗, run under deliberate CPU contention — the same load profile that exposed #15807): [latch-gesture-suite.log](https://gist.githubusercontent.com/lalalune/6ca2c4fa8343ed45a024c7ea5d3e94b9/raw/c7ab65dd490d85627c384f6e6acd2fd3c06ee89a/latch-gesture-suite.log)
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/model behavior.
<!-- evidence-row:domain-artifacts -->
- [x] Deterministic contract tests (7/7): rejected right-click/middle-click/secondary-touch never latch; a secondary pointer's up/cancel/lost-capture cannot clear an active primary latch; pointerId 0 handled; every callback still forwards. Plus the 296/296 real-browser suite: [latch-gesture-suite.log](https://gist.githubusercontent.com/lalalune/6ca2c4fa8343ed45a024c7ea5d3e94b9/raw/c7ab65dd490d85627c384f6e6acd2fd3c06ee89a/latch-gesture-suite.log)
<!-- evidence-row:ocr-review -->
- [x] [15900-ocr-15900-ci.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15900-ocr-15900-ci.json)

# Evidence Details

## Real LLM-call trajectory

N/A - see row above.

## Backend + frontend logs

[latch-gesture-suite.log](https://gist.githubusercontent.com/lalalune/6ca2c4fa8343ed45a024c7ea5d3e94b9/raw/c7ab65dd490d85627c384f6e6acd2fd3c06ee89a/latch-gesture-suite.log) — includes the clean-console assertions (0 page errors, 0 error-level console messages).

## Screenshots (before / after) + video walkthrough

Rest / held / release frames above, captured by the gesture suite on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

