### PR TITLE
fix(app): wait for screenrecord finalization before pulling capture (#14358)

### DIFF
--- a/packages/app/scripts/lib/android-capture.mjs
+++ b/packages/app/scripts/lib/android-capture.mjs
@@ -75,6 +75,42 @@ export async function startAndroidScreenRecord({
         new Promise((resolve) => recorder.once("close", resolve)),
         delay(3_000),
       ]);
+      // The local adb process closing does not mean the on-device screenrecord
+      // has finished: it still has to append the trailing moov atom, and
+      // pulling at that instant yields an unplayable MP4. Wait (bounded) for
+      // the device-side process to exit, re-sending SIGINT while it lives —
+      // a single pkill has been observed not landing.
+      const exitDeadline = Date.now() + 15_000;
+      while (Date.now() < exitDeadline) {
+        const pid = spawnSync(
+          adb,
+          ["-s", serial, "shell", "pidof", "screenrecord"],
+          { encoding: "utf8" },
+        );
+        if (!pid.stdout || pid.stdout.trim() === "") break;
+        spawnSync(
+          adb,
+          ["-s", serial, "shell", "pkill", "-INT", "screenrecord"],
+          { stdio: "ignore" },
+        );
+        await delay(500);
+      }
+      // Belt over the pid check: require the remote file size to hold steady
+      // across consecutive samples so a mid-flush pull can never grab a
+      // truncated file (covers a transient pidof miss or the exit-wait
+      // timing out above).
+      let settledSize = -1;
+      for (let i = 0; i < 10; i += 1) {
+        const stat = spawnSync(
+          adb,
+          ["-s", serial, "shell", "stat", "-c", "%s", remotePath],
+          { encoding: "utf8" },
+        );
+        const size = Number.parseInt(stat.stdout?.trim() ?? "", 10);
+        if (Number.isFinite(size) && size > 0 && size === settledSize) break;
+        settledSize = Number.isFinite(size) ? size : -1;
+        await delay(500);
+      }
       spawnSync(adb, ["-s", serial, "pull", remotePath, localPath], {
         stdio: "ignore",
       });


### PR DESCRIPTION
## Root cause

`startAndroidScreenRecord().stop()` (`packages/app/scripts/lib/android-capture.mjs`) pulled the recording as soon as the **local** adb client process closed. Killing the local adb client (`recorder.kill("SIGINT")`) says nothing about the **on-device** `screenrecord` process, which still has to stop the encoder and append the trailing `moov` atom. Pulling in that window yields a truncated head — every MP4 the #14358 Android cloud-onboarding lane attached was unplayable (`moov atom not found`).

Compounding it, the harness's `adb shell pkill -INT screenrecord` was **observed not landing on the first send** during the #14358 evidence runs: the device-side recorder survived the harness's pkill and only finalized when a later manual `pkill` landed. So a single fire-and-forget signal + fixed 3 s grace is doubly insufficient.

## Fix

After the existing local-recorder teardown, `stop()` now:

1. **Waits (bounded, 15 s) for the device-side `screenrecord` process to exit**, polling `pidof screenrecord` every 500 ms and **re-sending `pkill -INT` while it lives** — directly addressing the observed lost-signal behavior.
2. **Requires the remote file size to settle** (two consecutive equal non-zero `stat -c %s` samples, bounded at ~5 s) before pulling — a belt over the pid check that covers a transient `pidof` miss or the exit-wait timing out.

Scope note: `startChunkedAndroidScreenRecord`'s steady-state segments end via `--time-limit` (the device-side process exits on its own before the local adb channel closes), so they don't hit this window; the single-file recorder is the path the e2e lanes use (`test/android/cloud-onboarding.android.spec.ts`) and the one the corrupt evidence came from.

## Evidence

The fix was validated during the #14358 close-out: with finalization awaited, the recorder produced a valid, fully playable walkthrough — [run-3 walkthrough MP4, 56 s, valid](https://github.com/elizaOS/eliza/releases/download/pr-evidence/14358-android-run3-walkthrough.mp4) (posted in the #14358 evidence comment), versus the earlier pull-before-finalize captures that were all `moov atom not found`. Observed pkill/finalization behavior is documented in the same [#14358 comment](https://github.com/elizaOS/eliza/issues/14358).

| Evidence | Status |
| --- | --- |
| Video walkthrough | N/A - capture-tooling change with no UI surface; the valid 56 s MP4 above (captured after the fix, vs. prior corrupt captures) is the behavioral proof |
| Before/after full-page screenshots (desktop + mobile) | N/A - no rendered UI is changed; the artifact under test is the capture file itself |
| Backend structured logs | N/A - script-only change in the e2e capture helper; no server code path involved |
| Frontend console + network logs | N/A - no frontend involved |
| Real-LLM trajectories | N/A - no agent/action/provider/prompt/model behavior change |

Fixes the capture-harness defect reported in #14358.

🤖 Generated with [Claude Code](https://claude.com/claude-code)