### PR TITLE
fix(app): fail audit on broken mobile-landscape renders

### DIFF
--- a/packages/app/test/audit/aesthetic-audit-rules.test.ts
+++ b/packages/app/test/audit/aesthetic-audit-rules.test.ts
@@ -13,6 +13,7 @@ import {
   evaluateMinimalismRatchet,
   evaluateStrictGate,
   exceedsMinimalismBudget,
+  findRemoteBundleDeclaration,
   type GateFinding,
   MINIMALISM_DENSITY_CEILING,
   MINIMALISM_RATCHET_TOLERANCE,
@@ -25,6 +26,35 @@ import {
   resolveAuditStrictFlags,
   type VerdictFinding,
 } from "../ui-smoke/aesthetic-audit-rules";
+
+describe("findRemoteBundleDeclaration", () => {
+  it("distinguishes in-process app-shell pages from production bundles", () => {
+    const payload = {
+      views: [
+        { id: "documents", viewType: "gui", path: "/documents" },
+        {
+          id: "calendar",
+          viewType: "gui",
+          bundleUrl: "/api/views/calendar/bundle.js",
+        },
+      ],
+    };
+
+    expect(findRemoteBundleDeclaration(payload, "documents", "gui")).toBeNull();
+    expect(findRemoteBundleDeclaration(payload, "missing", "gui")).toBeNull();
+    expect(findRemoteBundleDeclaration(payload, "calendar", "gui")).toEqual({
+      id: "calendar",
+      bundleUrl: "/api/views/calendar/bundle.js",
+      componentExport: "default",
+    });
+  });
+
+  it("rejects a malformed registry boundary", () => {
+    expect(() => findRemoteBundleDeclaration({}, "calendar", "gui")).toThrow(
+      /invalid views payload/,
+    );
+  });
+});
 
 describe("parseRgb (#8796)", () => {
   it("parses rgb() and rgba(), defaulting alpha to 1", () => {

--- a/packages/app/test/audit/aesthetic-audit-rules.test.ts
+++ b/packages/app/test/audit/aesthetic-audit-rules.test.ts
@@ -153,6 +153,11 @@ describe("computeVerdict (#8796 verdict precedence)", () => {
       "broken",
     );
     expect(computeVerdict(finding({ readableChars: 0 }))).toBe("broken");
+    expect(
+      computeVerdict(
+        finding({ renderStateIssues: ["dynamic view remained loading"] }),
+      ),
+    ).toBe("broken");
   });
 
   it("TUI and overlay surfaces are exempt from the quality/content floors", () => {

--- a/packages/app/test/ui-smoke/aesthetic-audit-rules.ts
+++ b/packages/app/test/ui-smoke/aesthetic-audit-rules.ts
@@ -24,6 +24,48 @@ export type AestheticVerdict =
   | "needs-eyeball"
   | "broken";
 
+export interface RemoteBundleDeclaration {
+  id: string;
+  bundleUrl: string;
+  componentExport: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Selects production JS-bundle metadata for a plugin route. App-shell pages
+ * legitimately share the registry without a bundle URL, so they return null
+ * and continue through their in-process registration path.
+ */
+export function findRemoteBundleDeclaration(
+  payload: unknown,
+  id: string,
+  viewType: "gui" | "tui",
+): RemoteBundleDeclaration | null {
+  if (!isRecord(payload) || !Array.isArray(payload.views)) {
+    throw new Error("plugin view registry returned an invalid views payload");
+  }
+  const registered = payload.views.find(
+    (entry) =>
+      isRecord(entry) &&
+      entry.id === id &&
+      (entry.viewType ?? "gui") === viewType,
+  );
+  if (!isRecord(registered) || typeof registered.bundleUrl !== "string") {
+    return null;
+  }
+  return {
+    id,
+    bundleUrl: registered.bundleUrl,
+    componentExport:
+      typeof registered.componentExport === "string"
+        ? registered.componentExport
+        : "default",
+  };
+}
+
 /** The subset of a view audit finding the verdict policy reads. The spec's
  * fuller `ViewFinding` is structurally assignable to this. */
 export interface VerdictFinding {

--- a/packages/app/test/ui-smoke/aesthetic-audit-rules.ts
+++ b/packages/app/test/ui-smoke/aesthetic-audit-rules.ts
@@ -31,6 +31,8 @@ export interface VerdictFinding {
   viewType: "gui" | "tui";
   consoleErrors: string[];
   qualityIssues: string[];
+  /** User-visible state/layout failures detected from the live DOM. */
+  renderStateIssues?: string[];
   /** Readable text length in the view root; ~0 means the view never painted. */
   readableChars: number;
   /** Border/divider edges per 1M viewport pixels. */
@@ -458,6 +460,7 @@ export function computeVerdict(finding: VerdictFinding): AestheticVerdict {
   // floors are waived for them.
   if (
     finding.consoleErrors.length > 0 ||
+    (finding.renderStateIssues?.length ?? 0) > 0 ||
     (!exempt &&
       (finding.qualityIssues.length > 0 || finding.readableChars < 10))
   ) {

--- a/packages/app/test/ui-smoke/aesthetic-minimalism-baseline.json
+++ b/packages/app/test/ui-smoke/aesthetic-minimalism-baseline.json
@@ -69,7 +69,7 @@
     "plugin-calendar-gui@mobile-landscape": {
       "borderDividerDensity": 127.5975,
       "textDensity": 4.1925,
-      "whitespaceRatio": 0.749
+      "whitespaceRatio": 0.6833
     },
     "plugin-calendar-gui@mobile-portrait": {
       "borderDividerDensity": 139.7497,
@@ -107,9 +107,9 @@
       "whitespaceRatio": 0.7934
     },
     "plugin-relationships-gui@mobile-landscape": {
-      "borderDividerDensity": 60.7607,
-      "textDensity": 7.3217,
-      "whitespaceRatio": 0.8633
+      "borderDividerDensity": 48.6086,
+      "textDensity": 5.9849,
+      "whitespaceRatio": 0.778
     },
     "plugin-relationships-gui@mobile-portrait": {
       "borderDividerDensity": 60.7607,

--- a/packages/app/test/ui-smoke/aesthetic-minimalism-baseline.json
+++ b/packages/app/test/ui-smoke/aesthetic-minimalism-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-07T13:40:29.175Z",
+  "generatedAt": "2026-07-10T02:06:43Z",
   "views": {
     "builtin-background@ipad-portrait": {
       "borderDividerDensity": 45.4733,
@@ -67,9 +67,9 @@
       "whitespaceRatio": 0.8595
     },
     "plugin-calendar-gui@mobile-landscape": {
-      "borderDividerDensity": 139.7497,
-      "textDensity": 5.9242,
-      "whitespaceRatio": 0.876
+      "borderDividerDensity": 127.5975,
+      "textDensity": 4.1925,
+      "whitespaceRatio": 0.749
     },
     "plugin-calendar-gui@mobile-portrait": {
       "borderDividerDensity": 139.7497,
@@ -77,9 +77,9 @@
       "whitespaceRatio": 0.7231
     },
     "plugin-goals-gui@mobile-landscape": {
-      "borderDividerDensity": 60.7607,
-      "textDensity": 8.2635,
-      "whitespaceRatio": 0.8618
+      "borderDividerDensity": 48.6086,
+      "textDensity": 6.5318,
+      "whitespaceRatio": 0.8169
     },
     "plugin-goals-gui@mobile-portrait": {
       "borderDividerDensity": 60.7607,

--- a/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
@@ -14,6 +14,7 @@ import {
   evaluateAestheticMetricBudget,
   evaluateMinimalismRatchet,
   evaluateStrictGate,
+  findRemoteBundleDeclaration,
   minimalismBaselineKey,
   OVERLAY_NATIVE_OR_CANVAS_SLUGS,
   parseMinimalismBaseline,
@@ -994,10 +995,6 @@ interface RemoteBundleAuditProof {
   response: Promise<import("@playwright/test").Response>;
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
 async function forceRemoteBundleAuditRoute(
   page: Page,
   view: AuditCase,
@@ -1006,24 +1003,12 @@ async function forceRemoteBundleAuditRoute(
   const registryResponse = await page.request.get("/api/views");
   expect(registryResponse.ok(), "plugin view registry must load").toBe(true);
   const payload: unknown = await registryResponse.json();
-  if (!isRecord(payload) || !Array.isArray(payload.views)) {
-    throw new Error("plugin view registry returned an invalid views payload");
-  }
-  const registered = payload.views?.find(
-    (entry) =>
-      isRecord(entry) &&
-      entry.id === view.id &&
-      (entry.viewType ?? "gui") === view.viewType,
+  const registered = findRemoteBundleDeclaration(
+    payload,
+    view.id,
+    view.viewType,
   );
-  if (
-    !isRecord(registered) ||
-    typeof registered.bundleUrl !== "string" ||
-    typeof registered.componentExport !== "string"
-  ) {
-    throw new Error(
-      `${view.slug} is missing its production bundle declaration in /api/views`,
-    );
-  }
+  if (!registered) return null;
 
   const auditPath = `/__audit/plugin-view/${encodeURIComponent(registered.id)}`;
   const bundlePath = new URL(registered.bundleUrl, "http://audit.local")
@@ -1038,10 +1023,13 @@ async function forceRemoteBundleAuditRoute(
       contentType: "application/json",
       body: JSON.stringify({
         ...payload,
-        views: payload.views.map((entry) =>
-          isRecord(entry) &&
+        views: (payload as { views: unknown[] }).views.map((entry) =>
+          typeof entry === "object" &&
+          entry !== null &&
+          !Array.isArray(entry) &&
+          "id" in entry &&
           entry.id === registered.id &&
-          (entry.viewType ?? "gui") === view.viewType
+          ("viewType" in entry ? entry.viewType : "gui") === view.viewType
             ? { ...entry, path: auditPath }
             : entry,
         ),

--- a/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
@@ -324,6 +324,8 @@ interface ViewFinding {
   viewport: string;
   path: string;
   consoleErrors: string[];
+  /** User-visible loading persistence, overlap, or composer legibility failures. */
+  renderStateIssues: string[];
   blueColors: string[];
   hoverViolations: string[];
   /** Buttons the hover probe could not drive (hover timeout / detach) — a
@@ -866,6 +868,82 @@ async function collectOverlayClearanceIssues(
   }, overlaySelector);
 }
 
+/** Spatial column siblings must flow rather than paint through each other. */
+async function collectSpatialOverlapIssues(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const issues: string[] = [];
+    const label = (element: HTMLElement): string =>
+      (
+        element.getAttribute("data-agent-id") ||
+        element.textContent?.trim().replace(/\s+/g, " ") ||
+        element.getAttribute("data-spatial-kind") ||
+        element.tagName.toLowerCase()
+      ).slice(0, 48);
+    for (const box of document.querySelectorAll<HTMLElement>(
+      '[data-spatial-kind="box"]',
+    )) {
+      const style = getComputedStyle(box);
+      if (style.display !== "flex" || style.flexDirection !== "column") {
+        continue;
+      }
+      const children = Array.from(box.children).filter(
+        (child): child is HTMLElement => {
+          if (!(child instanceof HTMLElement)) return false;
+          const childStyle = getComputedStyle(child);
+          const rect = child.getBoundingClientRect();
+          return (
+            childStyle.display !== "none" &&
+            childStyle.visibility !== "hidden" &&
+            childStyle.position !== "absolute" &&
+            childStyle.position !== "fixed" &&
+            rect.width > 0 &&
+            rect.height > 0
+          );
+        },
+      );
+      for (let index = 1; index < children.length; index += 1) {
+        const previous = children[index - 1];
+        const current = children[index];
+        const previousRect = previous.getBoundingClientRect();
+        const currentRect = current.getBoundingClientRect();
+        const horizontalIntersection =
+          Math.min(previousRect.right, currentRect.right) -
+          Math.max(previousRect.left, currentRect.left);
+        const verticalOverlap = previousRect.bottom - currentRect.top;
+        if (horizontalIntersection > 1 && verticalOverlap > 1) {
+          issues.push(
+            `spatial column overlaps "${label(previous)}" with "${label(current)}" by ${Math.round(verticalOverlap)}px`,
+          );
+          if (issues.length >= 5) return issues;
+        }
+      }
+    }
+    return issues;
+  });
+}
+
+/** A resting empty composer must not grow just to wrap its placeholder. */
+async function collectComposerLegibilityIssues(page: Page): Promise<string[]> {
+  return page
+    .locator('[data-testid="chat-composer-textarea"]')
+    .evaluateAll((nodes) =>
+      nodes.flatMap((node) => {
+        if (!(node instanceof HTMLTextAreaElement) || node.value) return [];
+        const placeholder = node.placeholder.trim();
+        const lineHeight = Number.parseFloat(getComputedStyle(node).lineHeight);
+        const height = node.getBoundingClientRect().height;
+        if (!placeholder || !Number.isFinite(lineHeight) || lineHeight <= 0) {
+          return [];
+        }
+        return height > lineHeight * 2.25
+          ? [
+              `composer placeholder wraps beyond two lines (${Math.round(height / lineHeight)} lines): "${placeholder.slice(0, 48)}"`,
+            ]
+          : [];
+      }),
+    );
+}
+
 function renderManualReviewStub(finding: ViewFinding): string {
   const lines = [
     `# ${finding.slug} (${finding.viewport})`,
@@ -876,6 +954,7 @@ function renderManualReviewStub(finding: ViewFinding): string {
     `- **bundle view id:** ${finding.bundleViewId ?? "n/a"}`,
     `- **verdict:** ${finding.verdict}`,
     `- **console errors:** ${finding.consoleErrors.length}`,
+    `- **render-state issues:** ${finding.renderStateIssues.length ? finding.renderStateIssues.join("; ") : "none"}`,
     `- **blue colors (banned):** ${finding.blueColors.length ? finding.blueColors.join(", ") : "none"}`,
     `- **border-radius violations (off-token):** ${finding.borderRadiusViolations.length ? finding.borderRadiusViolations.join(", ") : "none"}`,
     `- **orange↔black hover violations:** ${finding.hoverViolations.length ? finding.hoverViolations.join("; ") : "none"}`,
@@ -1120,6 +1199,7 @@ test.describe("all-views aesthetic audit (#8796)", () => {
         const readPaint = async (): Promise<{
           readableChars: number;
           overlayPresent: boolean;
+          loadingViewPresent: boolean;
         }> => {
           const readableChars = await viewRoot
             .evaluate(
@@ -1145,20 +1225,32 @@ test.describe("all-views aesthetic audit (#8796)", () => {
               }),
             )
             .catch(() => false);
-          return { readableChars, overlayPresent };
+          const loadingViewPresent = await page
+            .locator('[data-view-status="loading"]')
+            .isVisible()
+            .catch(() => false);
+          return { readableChars, overlayPresent, loadingViewPresent };
         };
         let paint = await readPaint();
         for (
           let attempt = 0;
           attempt < 12 &&
           (paint.readableChars < 10 ||
-            (overlayRequired && !paint.overlayPresent));
+            (overlayRequired && !paint.overlayPresent) ||
+            paint.loadingViewPresent);
           attempt += 1
         ) {
           await page.waitForTimeout(1000);
           paint = await readPaint();
         }
         const { readableChars, overlayPresent } = paint;
+        const renderStateIssues = [
+          ...(paint.loadingViewPresent
+            ? ["dynamic view remained in its loading state after 12 seconds"]
+            : []),
+          ...(await collectSpatialOverlapIssues(page)),
+          ...(await collectComposerLegibilityIssues(page)),
+        ];
 
         // Document-level horizontal-overflow invariant (WS5). Measured, not
         // swallowed: a genuine measurement failure throws and fails the view
@@ -1245,6 +1337,7 @@ test.describe("all-views aesthetic audit (#8796)", () => {
           bundleComponent: bundleResponse?.headers()["x-eliza-view-component"],
           bundleViewId: bundleResponse?.headers()["x-eliza-view-id"],
           consoleErrors,
+          renderStateIssues,
           blueColors,
           hoverViolations,
           hoverFailures,

--- a/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
@@ -932,6 +932,37 @@ async function collectSpatialOverlapIssues(page: Page): Promise<string[]> {
       rect: DOMRect;
       text: string;
     }> = [];
+    const clipToVisibleAncestors = (
+      source: DOMRect,
+      element: HTMLElement,
+    ): DOMRect => {
+      let left = Math.max(0, source.left);
+      let top = Math.max(0, source.top);
+      let right = Math.min(window.innerWidth, source.right);
+      let bottom = Math.min(window.innerHeight, source.bottom);
+      for (
+        let ancestor: HTMLElement | null = element;
+        ancestor;
+        ancestor = ancestor.parentElement
+      ) {
+        const style = getComputedStyle(ancestor);
+        const rect = ancestor.getBoundingClientRect();
+        if (/hidden|clip|auto|scroll/.test(style.overflowX)) {
+          left = Math.max(left, rect.left);
+          right = Math.min(right, rect.right);
+        }
+        if (/hidden|clip|auto|scroll/.test(style.overflowY)) {
+          top = Math.max(top, rect.top);
+          bottom = Math.min(bottom, rect.bottom);
+        }
+      }
+      return new DOMRect(
+        left,
+        top,
+        Math.max(0, right - left),
+        Math.max(0, bottom - top),
+      );
+    };
     const walker = document.createTreeWalker(
       document.body,
       NodeFilter.SHOW_TEXT,
@@ -944,9 +975,16 @@ async function collectSpatialOverlapIssues(page: Page): Promise<string[]> {
       const text = node.textContent?.trim().replace(/\s+/g, " ") ?? "";
       const element = node.parentElement;
       if (!text || !element) continue;
+      const closedDetails = element.closest("details:not([open])");
+      if (
+        closedDetails &&
+        !closedDetails.querySelector(":scope > summary")?.contains(element)
+      ) {
+        continue;
+      }
       if (
         element.closest(
-          "[data-continuous-chat-overlay], [data-testid='continuous-chat-overlay'], [data-aesthetic-overlap-ignore='true']",
+          ".sr-only, [aria-hidden='true'], [hidden], [data-continuous-chat-overlay], [data-testid='continuous-chat-overlay'], [data-aesthetic-overlap-ignore='true']",
         )
       ) {
         continue;
@@ -961,7 +999,8 @@ async function collectSpatialOverlapIssues(page: Page): Promise<string[]> {
       }
       const range = document.createRange();
       range.selectNodeContents(node);
-      for (const rect of range.getClientRects()) {
+      for (const rawRect of range.getClientRects()) {
+        const rect = clipToVisibleAncestors(rawRect, element);
         if (
           rect.width > 0 &&
           rect.height > 0 &&
@@ -993,8 +1032,8 @@ async function collectSpatialOverlapIssues(page: Page): Promise<string[]> {
           Math.max(first.rect.top, second.rect.top);
         if (
           overlapWidth > 2 &&
-          overlapHeight > 2 &&
-          overlapWidth * overlapHeight >= 16
+          overlapHeight > 4 &&
+          overlapWidth * overlapHeight >= 32
         ) {
           issues.push(
             `text overlaps "${first.text}" with "${second.text}" (${Math.round(overlapWidth)}×${Math.round(overlapHeight)}px)`,

--- a/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
@@ -927,6 +927,8 @@ async function collectSpatialOverlapIssues(page: Page): Promise<string[]> {
       }
     }
 
+    if (window.innerHeight > 520) return issues;
+
     const textRects: Array<{
       element: HTMLElement;
       rect: DOMRect;
@@ -1014,10 +1016,12 @@ async function collectSpatialOverlapIssues(page: Page): Promise<string[]> {
       }
       range.detach();
     }
+    textRects.sort((left, right) => left.rect.top - right.rect.top);
     for (let left = 0; left < textRects.length; left += 1) {
       const first = textRects[left];
       for (let right = left + 1; right < textRects.length; right += 1) {
         const second = textRects[right];
+        if (second.rect.top >= first.rect.bottom - 4) break;
         if (
           first.element.contains(second.element) ||
           second.element.contains(first.element)

--- a/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
@@ -869,7 +869,7 @@ async function collectOverlayClearanceIssues(
   }, overlaySelector);
 }
 
-/** Spatial column siblings must flow rather than paint through each other. */
+/** Flex-column siblings must flow rather than paint through each other. */
 async function collectSpatialOverlapIssues(page: Page): Promise<string[]> {
   return page.evaluate(() => {
     const issues: string[] = [];
@@ -880,9 +880,16 @@ async function collectSpatialOverlapIssues(page: Page): Promise<string[]> {
         element.getAttribute("data-spatial-kind") ||
         element.tagName.toLowerCase()
       ).slice(0, 48);
-    for (const box of document.querySelectorAll<HTMLElement>(
-      '[data-spatial-kind="box"]',
-    )) {
+    for (const box of Array.from(
+      document.querySelectorAll<HTMLElement>("*"),
+    ).slice(0, 4000)) {
+      if (
+        box.closest(
+          "[data-continuous-chat-overlay], [data-testid='continuous-chat-overlay'], [data-aesthetic-overlap-ignore='true']",
+        )
+      ) {
+        continue;
+      }
       const style = getComputedStyle(box);
       if (style.display !== "flex" || style.flexDirection !== "column") {
         continue;
@@ -919,8 +926,109 @@ async function collectSpatialOverlapIssues(page: Page): Promise<string[]> {
         }
       }
     }
+
+    const textRects: Array<{
+      element: HTMLElement;
+      rect: DOMRect;
+      text: string;
+    }> = [];
+    const walker = document.createTreeWalker(
+      document.body,
+      NodeFilter.SHOW_TEXT,
+    );
+    for (
+      let node = walker.nextNode();
+      node && textRects.length < 600;
+      node = walker.nextNode()
+    ) {
+      const text = node.textContent?.trim().replace(/\s+/g, " ") ?? "";
+      const element = node.parentElement;
+      if (!text || !element) continue;
+      if (
+        element.closest(
+          "[data-continuous-chat-overlay], [data-testid='continuous-chat-overlay'], [data-aesthetic-overlap-ignore='true']",
+        )
+      ) {
+        continue;
+      }
+      const style = getComputedStyle(element);
+      if (
+        style.display === "none" ||
+        style.visibility === "hidden" ||
+        Number(style.opacity || "1") <= 0.02
+      ) {
+        continue;
+      }
+      const range = document.createRange();
+      range.selectNodeContents(node);
+      for (const rect of range.getClientRects()) {
+        if (
+          rect.width > 0 &&
+          rect.height > 0 &&
+          rect.right > 0 &&
+          rect.bottom > 0 &&
+          rect.left < window.innerWidth &&
+          rect.top < window.innerHeight
+        ) {
+          textRects.push({ element, rect, text: text.slice(0, 32) });
+        }
+      }
+      range.detach();
+    }
+    for (let left = 0; left < textRects.length; left += 1) {
+      const first = textRects[left];
+      for (let right = left + 1; right < textRects.length; right += 1) {
+        const second = textRects[right];
+        if (
+          first.element.contains(second.element) ||
+          second.element.contains(first.element)
+        ) {
+          continue;
+        }
+        const overlapWidth =
+          Math.min(first.rect.right, second.rect.right) -
+          Math.max(first.rect.left, second.rect.left);
+        const overlapHeight =
+          Math.min(first.rect.bottom, second.rect.bottom) -
+          Math.max(first.rect.top, second.rect.top);
+        if (
+          overlapWidth > 2 &&
+          overlapHeight > 2 &&
+          overlapWidth * overlapHeight >= 16
+        ) {
+          issues.push(
+            `text overlaps "${first.text}" with "${second.text}" (${Math.round(overlapWidth)}×${Math.round(overlapHeight)}px)`,
+          );
+          if (issues.length >= 5) return issues;
+        }
+      }
+    }
     return issues;
   });
+}
+
+/** A hosted spatial view must fill the shell content width. */
+async function collectSpatialSizingIssues(page: Page): Promise<string[]> {
+  return page.locator("[data-spatial-surface]").evaluateAll((surfaces) =>
+    surfaces.flatMap((surface) => {
+      if (!(surface instanceof HTMLElement)) return [];
+      const rect = surface.getBoundingClientRect();
+      const rootStyle = getComputedStyle(document.documentElement);
+      const sideClearance =
+        Number.parseFloat(
+          rootStyle.getPropertyValue("--eliza-continuous-chat-side-clearance"),
+        ) || 0;
+      const surfaceStyle = getComputedStyle(surface);
+      const duplicatePadding =
+        Number.parseFloat(surfaceStyle.paddingInlineEnd) || 0;
+      const usableWidth = rect.width - duplicatePadding;
+      const expectedWidth = window.innerWidth - sideClearance;
+      if (usableWidth >= expectedWidth * 0.8) return [];
+      return [
+        `spatial surface underfills shell content (${Math.round(usableWidth)}/${Math.round(expectedWidth)}px usable; ${Math.round(duplicatePadding)}px nested clearance)`,
+      ];
+    }),
+  );
 }
 
 /** A resting empty composer must not grow just to wrap its placeholder. */
@@ -1237,6 +1345,7 @@ test.describe("all-views aesthetic audit (#8796)", () => {
             ? ["dynamic view remained in its loading state after 12 seconds"]
             : []),
           ...(await collectSpatialOverlapIssues(page)),
+          ...(await collectSpatialSizingIssues(page)),
           ...(await collectComposerLegibilityIssues(page)),
         ];
 

--- a/packages/ui/src/App.navigate-view-wiring.test.tsx
+++ b/packages/ui/src/App.navigate-view-wiring.test.tsx
@@ -566,6 +566,7 @@ describe("App navigate-view event wiring", () => {
       expect(dynamicViewLoaderMock.render).toHaveBeenCalledWith(
         expect.objectContaining({
           bundleUrl: "/api/views/remote-ledger/bundle.js",
+          reserveChatClearance: false,
           viewId: "remote-ledger",
           viewType: "gui",
         }),

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1160,6 +1160,7 @@ function renderRemoteView(view: ViewRegistryEntry, nav?: ReactNode): ReactNode {
           componentExport={view.componentExport}
           viewId={view.id}
           viewType={view.viewType}
+          reserveChatClearance={false}
           surface={view.surface}
         />
       </div>

--- a/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
@@ -2444,7 +2444,7 @@ export function BrowserWorkspaceView(): React.JSX.Element {
             {workspace.mode === "web" &&
             browserBridgeSupported &&
             !browserBridgeUnsupportedInNativeLocalMode ? (
-              <div className="grid w-full max-w-xl grid-cols-1 items-stretch gap-1.5 px-6 [@media(orientation:landscape)_and_(max-height:520px)]:-mt-10 [@media(orientation:landscape)_and_(max-height:520px)]:pb-[var(--eliza-continuous-chat-clearance,5.25rem)] [@media(orientation:landscape)_and_(max-height:520px)]:pe-[var(--eliza-continuous-chat-side-clearance,0px)] sm:grid-cols-3">
+              <div className="grid w-full max-w-xl grid-cols-1 items-stretch gap-1.5 px-6 [@media(orientation:landscape)_and_(max-height:520px)]:pb-[var(--eliza-continuous-chat-clearance,5.25rem)] [@media(orientation:landscape)_and_(max-height:520px)]:pe-[var(--eliza-continuous-chat-side-clearance,0px)] sm:grid-cols-3">
                 <div className="text-center text-[11px] text-muted/70 sm:col-span-3">
                   {browserBridgeConnected
                     ? t("browserworkspace.BrowserBridgeConnected", {

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -534,7 +534,16 @@ describe("ContinuousChatOverlay", () => {
         "--eliza-continuous-chat-side-clearance",
       );
 
-      render(<ContinuousChatOverlay controller={makeController()} />);
+      render(
+        <ContinuousChatOverlay
+          controller={makeController()}
+          agentName="Playwright Smoke"
+        />,
+      );
+
+      expect(screen.getByLabelText("message").getAttribute("placeholder")).toBe(
+        "Ask",
+      );
 
       expect(
         document.documentElement.style.getPropertyValue(
@@ -543,6 +552,10 @@ describe("ContinuousChatOverlay", () => {
       ).toBe("232px");
 
       fireEvent.focus(screen.getByLabelText("message"));
+
+      expect(screen.getByLabelText("message").getAttribute("placeholder")).toBe(
+        "Ask Playwright Smoke",
+      );
 
       expect(
         document.documentElement.style.getPropertyValue(

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -2530,6 +2530,9 @@ export function ContinuousChatOverlay({
     !hasImages &&
     !recording &&
     !responding &&
+    !noProviderConfigured &&
+    !modelBlocksSend &&
+    !booting &&
     !pinnedOpen;
 
   // In short landscape the resting composer moves to the bottom inline-end
@@ -5753,17 +5756,20 @@ export function ContinuousChatOverlay({
                 // (This surface's strings are plain literals by design — see
                 // the imageError note above.)
                 placeholder={
-                  firstRunOpen
-                    ? "Sign in to start chatting"
-                    : noProviderConfigured
-                      ? "Connect a model provider in Settings to chat"
-                      : modelBlocksSend
-                        ? modelStatus?.kind === "downloading"
-                          ? `Downloading ${modelStatus.modelName ?? "your model"} — you can keep typing`
-                          : `Getting ${modelStatus?.modelName ?? "your model"} ready — you can keep typing`
-                        : booting
-                          ? `Ask ${agentName} — waking up…`
-                          : (viewChatBinding?.placeholder ?? `Ask ${agentName}`)
+                  compactLanding
+                    ? "Ask"
+                    : firstRunOpen
+                      ? "Sign in to start chatting"
+                      : noProviderConfigured
+                        ? "Connect a model provider in Settings to chat"
+                        : modelBlocksSend
+                          ? modelStatus?.kind === "downloading"
+                            ? `Downloading ${modelStatus.modelName ?? "your model"} — you can keep typing`
+                            : `Getting ${modelStatus?.modelName ?? "your model"} ready — you can keep typing`
+                          : booting
+                            ? `Ask ${agentName} — waking up…`
+                            : (viewChatBinding?.placeholder ??
+                              `Ask ${agentName}`)
                 }
                 aria-label="message"
                 data-testid="chat-composer-textarea"

--- a/packages/ui/src/components/views/DynamicViewLoader.test.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.test.tsx
@@ -1044,7 +1044,9 @@ describe("DynamicViewLoader", () => {
     const rendered = render(
       <DynamicViewLoader bundleUrl={bundleUrl} viewId="late.cleanup.view" />,
     );
-    expect(screen.getByText("Loading view…")).toBeTruthy();
+    expect(
+      screen.getByText("Loading view…").closest('[data-view-status="loading"]'),
+    ).toBeTruthy();
 
     rendered.unmount();
     expect(resolveImport).toBeTruthy();

--- a/packages/ui/src/components/views/DynamicViewLoader.test.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.test.tsx
@@ -162,6 +162,29 @@ describe("DynamicViewLoader", () => {
     );
   });
 
+  it("does not reserve chat clearance owned by an enclosing shell", async () => {
+    window.__ELIZA_DYNAMIC_VIEW_BUNDLE_IMPORT__ = vi.fn(async () => ({
+      default: function ShellHostedPanel() {
+        return <div>Shell-hosted panel</div>;
+      },
+    }));
+
+    render(
+      <DynamicViewLoader
+        bundleUrl="/api/views/shell-hosted/bundle.js"
+        viewId="shell-hosted"
+        reserveChatClearance={false}
+      />,
+    );
+
+    await screen.findByText("Shell-hosted panel");
+    const surface = document.querySelector(
+      '[data-spatial-surface="gui"]',
+    ) as HTMLElement | null;
+    expect(surface?.style.paddingBottom).toBe("");
+    expect(surface?.style.paddingInlineEnd).toBe("");
+  });
+
   it("renders sandboxed iframe views from frameUrl and does not import bundleUrl", () => {
     const importBundle = vi.fn(async () => ({
       default: function ShouldNotLoad() {

--- a/packages/ui/src/components/views/DynamicViewLoader.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.tsx
@@ -1247,6 +1247,8 @@ interface DynamicViewLoaderProps {
   viewProps?: Record<string, unknown>;
   /** Presentation/runtime family for this view. Defaults to GUI. */
   viewType?: "gui" | "tui" | "xr";
+  /** Reserve floating-chat space when no enclosing shell already owns it. */
+  reserveChatClearance?: boolean;
   /**
    * The view's declared surface manifest (#13452). Resolved to a
    * {@link ResolvedSurfaceManifest} and used to broker the interact channel: a
@@ -1275,6 +1277,7 @@ export const DynamicViewLoader = memo(function DynamicViewLoader({
   viewId,
   viewProps: forwardedViewProps,
   viewType = "gui",
+  reserveChatClearance = true,
   surface,
 }: DynamicViewLoaderProps) {
   // Resolve the declared manifest once per surface declaration so the interact
@@ -1552,7 +1555,7 @@ export const DynamicViewLoader = memo(function DynamicViewLoader({
               keeps the exact auto-detect behaviour the per-view wrappers had.
               The host also reserves the floating composer clearance once so
               spatial plugin content scrolls above the chat affordance. */}
-          <SpatialSurface reserveChatClearance>
+          <SpatialSurface reserveChatClearance={reserveChatClearance}>
             <View {...viewProps} />
           </SpatialSurface>
         </ErrorBoundary>

--- a/packages/ui/src/components/views/ViewStatusStates.tsx
+++ b/packages/ui/src/components/views/ViewStatusStates.tsx
@@ -55,7 +55,10 @@ export function ViewStatusFrame({
         : "border-primary/20 bg-primary/5 text-primary";
 
   return (
-    <div className="flex flex-1 min-h-0 min-w-0 items-center justify-center p-6">
+    <div
+      className="flex flex-1 min-h-0 min-w-0 items-center justify-center p-6"
+      data-view-status={tone}
+    >
       <div
         className={`flex w-full max-w-sm flex-col gap-3 rounded-lg border p-4 ${toneClass}`}
       >

--- a/plugins/app-model-tester/src/ModelTesterView.test.tsx
+++ b/plugins/app-model-tester/src/ModelTesterView.test.tsx
@@ -91,8 +91,13 @@ describe("ModelTesterView — unified GUI wrapper", () => {
   });
 
   it("renders inside a spatial surface and shows the probe rows after the status fetch", async () => {
-    render(React.createElement(ModelTesterView));
+    const { container } = render(React.createElement(ModelTesterView));
     await screen.findByText("6 ready");
+    const root = container.querySelector(
+      '[data-spatial-kind="box"]',
+    ) as HTMLElement;
+    expect(root.style.flexShrink).toBe("0");
+    expect(root.style.width).toBe("100%");
     // Each probe row renders its label.
     expect(screen.getByText("Text")).toBeTruthy();
     expect(screen.getByText("Activity")).toBeTruthy();

--- a/plugins/app-model-tester/src/components/ModelTesterSpatialView.tsx
+++ b/plugins/app-model-tester/src/components/ModelTesterSpatialView.tsx
@@ -101,7 +101,7 @@ export function ModelTesterSpatialView({
 }: ModelTesterSpatialViewProps) {
   const dispatch = (action: string) => () => onAction?.(action);
   return (
-    <Card gap={1} padding={1}>
+    <Card gap={1} padding={1} shrink={0} width="100%">
       <HStack gap={1} align="center" wrap>
         <Text style="caption" tone="success">
           {snapshot.readyCount} ready
@@ -119,7 +119,7 @@ export function ModelTesterSpatialView({
           Refresh
         </Button>
         <Button
-          variant="outline"
+          variant="ghost"
           tone="default"
           agent="back"
           onPress={dispatch("back")}
@@ -142,7 +142,7 @@ export function ModelTesterSpatialView({
         {PROMPT_PRESETS.map((preset) => (
           <Button
             key={preset}
-            variant="outline"
+            variant="ghost"
             tone="default"
             grow={1}
             agent={`preset-${preset.toLowerCase()}`}
@@ -154,7 +154,7 @@ export function ModelTesterSpatialView({
       </HStack>
       <HStack gap={1} wrap>
         <Button
-          variant="outline"
+          variant="ghost"
           tone={snapshot.imageDataUrl ? "success" : "default"}
           grow={1}
           agent="pick-image"
@@ -163,7 +163,7 @@ export function ModelTesterSpatialView({
           {snapshot.imageDataUrl ? "Image ok" : "Image"}
         </Button>
         <Button
-          variant="outline"
+          variant="ghost"
           tone={snapshot.audioLoaded ? "success" : "default"}
           grow={1}
           agent="pick-audio"
@@ -202,7 +202,7 @@ export function ModelTesterSpatialView({
                   {resultLabel(probe)}
                 </Text>
                 <Button
-                  variant="outline"
+                  variant="ghost"
                   tone="default"
                   disabled={probe.running}
                   agent={`run-${probe.id}`}

--- a/plugins/plugin-calendar/src/components/calendar/CalendarSpatialView.tsx
+++ b/plugins/plugin-calendar/src/components/calendar/CalendarSpatialView.tsx
@@ -84,7 +84,7 @@ export function CalendarSpatialView({
   const eventCount = snapshot.events.length;
 
   return (
-    <Card gap={1} padding={1}>
+    <Card gap={1} padding={1} shrink={0}>
       <HStack gap={1} align="center">
         <Text style="subheading" bold grow={1} wrap={false}>
           {snapshot.periodLabel}

--- a/plugins/plugin-calendar/src/components/calendar/CalendarView.test.tsx
+++ b/plugins/plugin-calendar/src/components/calendar/CalendarView.test.tsx
@@ -122,6 +122,10 @@ describe("CalendarView (unified spatial wrapper)", () => {
       </SpatialSurface>,
     );
     expect(container.querySelector("[data-spatial-surface]")).toBeTruthy();
+    expect(
+      (container.querySelector('[data-spatial-kind="box"]') as HTMLElement)
+        .style.flexShrink,
+    ).toBe("0");
     expect(agent("prev")).toBeTruthy();
     expect(agent("today")).toBeTruthy();
     expect(agent("next")).toBeTruthy();

--- a/plugins/plugin-relationships/src/components/relationships/RelationshipsSpatialView.tsx
+++ b/plugins/plugin-relationships/src/components/relationships/RelationshipsSpatialView.tsx
@@ -96,7 +96,7 @@ export function RelationshipsSpatialView({
   const dispatch = (action: string) => () => onAction?.(action);
 
   return (
-    <Card gap={1} padding={1}>
+    <Card gap={1} padding={1} shrink={0} width="100%">
       {snapshot.state === "loading" ? (
         <Text tone="muted" align="center" style="caption">
           Loading relationships

--- a/plugins/plugin-relationships/src/components/relationships/RelationshipsView.test.tsx
+++ b/plugins/plugin-relationships/src/components/relationships/RelationshipsView.test.tsx
@@ -129,7 +129,7 @@ describe("RelationshipsView — states", () => {
   });
 
   it("renders the populated graph with entity nodes and their edges", async () => {
-    render(
+    const { container } = render(
       <RelationshipsView
         fetchers={makeFetchers({
           fetchEntities: async () => ({
@@ -171,6 +171,11 @@ describe("RelationshipsView — states", () => {
     );
 
     await screen.findByText("Owner");
+    const root = container.querySelector(
+      '[data-spatial-kind="box"]',
+    ) as HTMLElement;
+    expect(root.style.flexShrink).toBe("0");
+    expect(root.style.width).toBe("100%");
     // The self node carries the colleague edge to Pat with cadence + last contact.
     expect(agent("rel-self")).toBeTruthy();
     expect(screen.getByText(/colleague_of · every 14d · last/)).toBeTruthy();


### PR DESCRIPTION
Closes #15871.

The app audit now waits through the dynamic-view loading boundary instead of accepting the ambient chat overlay as proof that the routed view painted. Persistent loading, overlapping spatial column siblings, and an empty composer whose placeholder grows beyond two lines are explicit render-state failures and produce a `broken` verdict.

The product fixes are structural:
- the calendar spatial root cannot flex-shrink its rows through each other in the short landscape scrollport;
- the resting short-landscape composer keeps its compact gesture affordance but uses the readable cue `Ask`; focus restores the full view/agent-specific prompt;
- model setup/download/boot status never enters compact mode, so important status text remains complete;
- loading/error/restricted view status surfaces expose a stable semantic state marker for the audit.

Focused verification on `3a051c9a56`:
- 4/4 exact mobile-landscape audit cases passed after real bundle builds
- all four former failure screenshots reached populated/designed states
- 0 broken, 0 needs-work, 0 render-state issues, 0 overlap issues, 0 overlay-clearance issues
- packaged OCR: 4 rows, 0 broken, 0 new regressions
- audit verdict policy 56/56; compact composer 1/1; dynamic loader state marker 1/1; calendar wrapper 8/8
- Biome and `git diff --check` pass
- UI typecheck passes; app/calendar standalone typechecks are blocked only by unbuilt workspace declarations outside the touched files
- five complete post-sync audit iterations and final video/log capture are in progress

<!-- evidence-row:before-screenshots -->
- [x] Before, manually reviewed: [calendar](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15871-before-calendar-mobile-landscape.jpg), [goals](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15871-before-goals-mobile-landscape.jpg), [inbox](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15871-before-inbox-mobile-landscape.jpg), [screenshare](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15871-before-screenshare-mobile-landscape.jpg)
<!-- evidence-row:after-screenshots -->
- [x] After, manually reviewed: [calendar](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15871-after-calendar-mobile-landscape.jpg), [goals](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15871-after-goals-mobile-landscape.jpg), [inbox](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15871-after-inbox-mobile-landscape.jpg), [screenshare](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15871-after-screenshare-mobile-landscape.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] N/A for draft - the required final post-sync walkthrough is still being captured before readiness; this PR remains draft.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend route, service, data, or model behavior changes.
<!-- evidence-row:frontend-logs -->
- [x] Focused browser diagnostics are embedded per row in the [audit report](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15871-focused-report.json): all four have zero console errors and zero render-state issues.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, planner, action, provider, evaluator, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] [Focused DOM/aesthetic report](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15871-focused-report.json)
- [x] [Matching packaged OCR result](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15871-focused-ocr.json)
