### PR TITLE
test(app): align retired-view OCR assertions

### DIFF
--- a/packages/app/test/audit/ocr-triage-provenance.test.ts
+++ b/packages/app/test/audit/ocr-triage-provenance.test.ts
@@ -226,7 +226,7 @@ describe("ocr-triage CLI (end-to-end provenance)", () => {
         phone,
         stale,
       ]),
-    ).toThrow(/unexpected OCR record plugin-social-alpha-gui/);
+    ).toThrow(/unexpected OCR record plugin-retired-gui/);
     expect(() =>
       validateImportedOcrRecords(dir, "ocr.ndjson", shots, [
         {
@@ -264,10 +264,10 @@ describe("ocr-triage CLI (end-to-end provenance)", () => {
         "--out",
         join(dir, "ocr-triage.json"),
       ]),
-    ).rejects.toThrow(/unexpected OCR record plugin-social-alpha-gui/);
+    ).rejects.toThrow(/unexpected OCR record plugin-retired-gui/);
     const { status, stderr } = run();
     expect(status).not.toBe(0);
-    expect(stderr).toMatch(/unexpected OCR record plugin-social-alpha-gui/);
+    expect(stderr).toMatch(/unexpected OCR record plugin-retired-gui/);
   });
 
   it("exits non-zero when a report row's screenshot is missing", async () => {


### PR DESCRIPTION
## Summary

- align the stale imported-OCR error assertions with the generic `plugin-retired-gui` fixture introduced by #15795
- preserve the report-authoritative stale-artifact regression coverage from #15790

## Verification

- `bun test packages/app/test/audit/ocr-triage-provenance.test.ts` — 11 passed
- `bunx biome check packages/app/test/audit/ocr-triage-provenance.test.ts` — clean
- `git diff --check` — clean

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots/visual baseline: N/A - test assertion text only; no renderer, CSS, component, or production behavior changed.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots/visual check: N/A - test assertion text only; no rendered pixels changed.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - there is no user-exercisable behavior change to demonstrate.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no backend, API, database, worker, or service behavior changed.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs/checks: N/A - no frontend runtime behavior changed; the exact OCR provenance suite passed 11/11 locally.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, prompt, model, action, or provider behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - this test-only repair produces no domain data or user artifact.

Related: #15790
Follow-up to: #15795