### PR TITLE
fix(app): exempt builtin-rolodex from the OCR blank floor

### DIFF
--- a/packages/app/scripts/ocr-triage.ts
+++ b/packages/app/scripts/ocr-triage.ts
@@ -51,6 +51,12 @@ const BLANK_EXEMPT_SLUGS = new Set<string>([
   ...OVERLAY_NATIVE_OR_CANVAS_SLUGS,
   "builtin-background",
   "plugin-focus-gui",
+  // Legacy alias route that resolves to the launcher-grid fallback (see
+  // launcher-curation.ts and the ocr-view-expectations.ts trailer). The grid's
+  // white-on-gradient icon labels sit right at the engine's blank word floor
+  // (1–2 garbled words across runs), so without the exemption the same healthy
+  // render flaps between needs-eyeball and blank-broken run to run.
+  "builtin-rolodex",
 ]);
 
 export interface ReportEntry {


### PR DESCRIPTION
## What

Adds `builtin-rolodex` to `BLANK_EXEMPT_SLUGS` in `packages/app/scripts/ocr-triage.ts` so the OCR triage stops hard-failing the audit gate on a healthy, by-design render.

## Why

`/rolodex` is a legacy alias route that resolves to the **launcher-grid fallback** (`launcher-curation.ts` aliases `rolodex -> relationships`; `all-pages-clicksafe.spec.ts` anchors the route on the launcher testid). The grid's white-on-gradient icon labels OCR to 1–2 garbled words, straddling `BLANK_PIXEL_WORD_FLOOR = 2`, so the *same healthy render* flaps between `needs-eyeball` and `blank-broken` run to run:

- previous full sweep: tesseract read `"CG\nCo"` (2 words) → `needs-eyeball`
- #13560 close-out sweep (origin/develop `f981862c45c`): tesseract read `"oY)"` (1 word) → `broken` → `1 NEW REGRESSION(S)` → `audit:ocr` exit 1

The capture is manifestly not blank — it is the standard launcher grid:

![builtin-rolodex mobile-portrait — launcher-grid fallback, not blank](https://github.com/elizaOS/eliza/releases/download/pr-evidence/13560-closeout-builtin-rolodex.jpg)

The expectations file already documents this class of view (`ocr-view-expectations.ts` trailer): launcher-fallback captures are intentionally unexpectationed and should stay `needs-eyeball` for a human to judge — not hard-fail on an OCR word-count coin flip. `BLANK_EXEMPT_SLUGS` exists for exactly this ("builtin-background", "plugin-focus-gui"); this adds the one launcher-fallback slug that was missing. Not baselined in `ocr-triage-baseline.json` because the render is not pixel-broken — a baseline entry would misclassify a triage false positive as a tracked rendering bug.

## Validation

Full `bun run --cwd packages/app audit:app` sweep on origin/develop (this branch's merge base):

- Playwright: **245 passed** (19.2m)
- Aesthetic report: **broken=0, needs-work=0, needs-eyeball=18, good=226** (244 findings)
- OCR triage before this fix: `broken 1` / `1 NEW REGRESSION` (builtin-rolodex@mobile-portrait) → exit 1
- OCR triage after this fix (re-run over the same captures): **`244 views | verified 96 | broken 0 | needs-eyeball 148`**, `newRegressions=0` → exit 0; `builtin-rolodex` reports `needs-eyeball` on all four viewports, matching the documented launcher-fallback posture

Unit suite covering the rules: `bun x vitest run test/audit/ocr-content-rules.test.ts` → 28 passed.

Evidence rows N/A: video walkthrough / trajectories / frontend logs — N/A, audit-tooling-only change (one Set entry in a triage script); no runtime, UI, or agent surface is touched. The rendered proof above is the actual capture the gate misjudged.

Part of the #13560 close-out sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)