### PR TITLE
fix(discord): remove the post-reply response cooldown — silent 30s drop of conversational follow-ups

### DIFF
--- a/plugins/plugin-discord/__tests__/debouncer-recent-context.test.ts
+++ b/plugins/plugin-discord/__tests__/debouncer-recent-context.test.ts
@@ -153,26 +153,45 @@ describe("Discord channel debouncer — recent unaddressed context buffer", () =
 		}
 	});
 
-	it("still buffers an unaddressed message during the response cooldown (strict mode)", () => {
+	it("still buffers an unaddressed follow-up right after the bot responds (strict mode)", () => {
 		vi.useFakeTimers();
 		try {
 			const { flushed, debouncer } = setup({
 				shouldRespondOnlyToMentions: true,
 				bufferTtlMs: 10_000,
-				responseCooldownMs: 30_000,
 			});
 
-			// Bot just answered an addressed message → cooldown armed, buffer cleared.
+			// Bot just answered an addressed message → buffer cleared.
 			debouncer.markResponded("channel-1");
 
-			// A follow-up question (unaddressed) arrives inside the cooldown window.
-			// In strict mode it never triggers a reply, so it must NOT be dropped —
-			// it should still be ingested and buffered for a following pointer.
+			// A follow-up question (unaddressed) arrives moments later. In strict
+			// mode it never triggers a reply, so it must NOT be dropped — it should
+			// still be ingested and buffered for a following pointer.
 			debouncer.enqueue(mockMessage("1", "a follow-up question"));
 			vi.advanceTimersByTime(3000);
 
 			debouncer.enqueue(mockMessage("2", "<@123> ^^"));
 			expect(flushed[flushed.length - 1]).toEqual(["1", "2"]);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("flushes an unaddressed follow-up right after the bot responds (respond-to-all mode)", () => {
+		vi.useFakeTimers();
+		try {
+			// Regression: a post-reply "response cooldown" used to hard-drop
+			// unaddressed messages for 30s after each bot reply in respond-to-all
+			// mode, so "@bot hi" → reply → "wyd?" lost the follow-up silently.
+			const { flushed, debouncer } = setup({
+				shouldRespondOnlyToMentions: false,
+			});
+
+			debouncer.markResponded("channel-1");
+			debouncer.enqueue(mockMessage("1", "wyd?"));
+			vi.advanceTimersByTime(3000);
+
+			expect(flushed[flushed.length - 1]).toEqual(["1"]);
 		} finally {
 			vi.useRealTimers();
 		}

--- a/plugins/plugin-discord/debouncer.ts
+++ b/plugins/plugin-discord/debouncer.ts
@@ -20,7 +20,6 @@ function runSafely(callback: () => void): void {
 
 export interface ChannelDebouncerOptions {
 	debounceMs?: number;
-	responseCooldownMs?: number;
 	botUserId?: string;
 	getBotUserId?: () => string | undefined;
 	coalesceEnabled?: boolean;
@@ -59,11 +58,9 @@ export function createChannelDebouncer(
 	options: ChannelDebouncerOptions = {},
 ): ChannelDebouncer {
 	const debounceMs = options.debounceMs ?? DEFAULT_CHANNEL_DEBOUNCE_MS;
-	const responseCooldownMs = options.responseCooldownMs ?? 30_000;
 	const coalesceEnabled = options.coalesceEnabled === true;
 	const maxBatch = Math.max(1, options.maxBatch ?? Number.POSITIVE_INFINITY);
 	const pending = new Map<string, ChannelPendingEntry>();
-	const lastResponseTime = new Map<string, number>();
 
 	// Carry recent unaddressed messages forward so a pointer-only addressed
 	// message (e.g. "@bot ^^" pointing at a question typed moments earlier in a
@@ -176,18 +173,6 @@ export function createChannelDebouncer(
 		return !/[\p{L}\p{N}]/u.test(withoutMarkup);
 	};
 
-	const isInCooldown = (channelId: string): boolean => {
-		const lastRespondedAt = lastResponseTime.get(channelId);
-		if (!lastRespondedAt) {
-			return false;
-		}
-		if (Date.now() - lastRespondedAt >= responseCooldownMs) {
-			lastResponseTime.delete(channelId);
-			return false;
-		}
-		return true;
-	};
-
 	const flush = (channelId: string) => {
 		const entry = pending.get(channelId);
 		if (!entry) {
@@ -222,16 +207,11 @@ export function createChannelDebouncer(
 			return;
 		}
 
-		// The response cooldown throttles further REPLIES after the bot answers.
-		// When we buffer unaddressed messages (strict / mention-only mode) those
-		// messages never trigger a reply anyway, so dropping them here would only
-		// discard context the next "@bot ^^" pointer needs. Keep ingesting +
-		// buffering them; the cooldown still gates unaddressed traffic in
-		// respond-to-all mode (bufferUnaddressed is false there).
-		if (isInCooldown(channelId) && !targeted && !bufferUnaddressed) {
-			return;
-		}
-
+		// Every unaddressed message flows through to the message service; whether
+		// the agent actually REPLIES is the shouldRespond model's call, not a
+		// time-based throttle here. (A post-reply "response cooldown" used to
+		// hard-drop unaddressed messages for 30s after each bot reply, which made
+		// natural follow-ups — "@bot hi" → reply → "wyd?" — vanish silently.)
 		if (bufferUnaddressed && !targeted) {
 			rememberRecent(message);
 		}
@@ -262,7 +242,6 @@ export function createChannelDebouncer(
 	return {
 		enqueue,
 		markResponded: (channelId: string) => {
-			lastResponseTime.set(channelId, Date.now());
 			// Buffered chatter has now been answered (or folded into the reply);
 			// drop it so it never re-bundles into a later unrelated response.
 			recentUnaddressed.delete(channelId);
@@ -278,7 +257,6 @@ export function createChannelDebouncer(
 				clearTimeout(entry.timer);
 			}
 			pending.clear();
-			lastResponseTime.clear();
 			recentUnaddressed.clear();
 		},
 	};

--- a/plugins/plugin-discord/discord-events.ts
+++ b/plugins/plugin-discord/discord-events.ts
@@ -100,7 +100,6 @@ export interface DiscordServiceInternals {
 interface EventListenerConfig {
 	listenCids: string[];
 	channelDebounceMs: number;
-	responseCooldownMs: number;
 	recentContextTtlMs: number;
 	shouldRespondOnlyToMentions: boolean;
 }
@@ -136,17 +135,6 @@ function parseEventListenerConfig(
 				? Number.parseInt(channelDebounceMsSetting, 10) || 3000
 				: 3000;
 
-	const responseCooldownMsSetting = service.runtime.getSetting(
-		"DISCORD_RESPONSE_COOLDOWN_MS",
-	) as string | number | undefined;
-	const responseCooldownMs =
-		typeof responseCooldownMsSetting === "number"
-			? responseCooldownMsSetting
-			: typeof responseCooldownMsSetting === "string" &&
-					responseCooldownMsSetting.trim()
-				? Number.parseInt(responseCooldownMsSetting, 10) || 30000
-				: 30000;
-
 	// How long a recent unaddressed message stays eligible to be folded into a
 	// following pointer's "[Recent channel context]". Tunable like its siblings;
 	// the debouncer clamps it up to the channel debounce window. Default 90s:
@@ -173,7 +161,6 @@ function parseEventListenerConfig(
 	return {
 		listenCids,
 		channelDebounceMs,
-		responseCooldownMs,
 		recentContextTtlMs,
 		shouldRespondOnlyToMentions,
 	};
@@ -192,7 +179,6 @@ export function setupDiscordEventListeners(service: DiscordServiceInternals): {
 	const {
 		listenCids,
 		channelDebounceMs,
-		responseCooldownMs,
 		recentContextTtlMs,
 		shouldRespondOnlyToMentions,
 	} = parseEventListenerConfig(service);
@@ -270,18 +256,16 @@ export function setupDiscordEventListeners(service: DiscordServiceInternals): {
 				void service.messageManager.handleMessage(combined as Message);
 			}
 
-			// Arm the response cooldown only when the bot actually engages with
-			// this batch. A purely-unaddressed batch (channel chatter the bot is
-			// not replying to) must not start the cooldown — otherwise the next
-			// unaddressed message is dropped (debouncer cooldown gate), losing
-			// context like a question typed just before an "@bot ^^" pointer.
+			// Clear the answered-context buffer only when the bot actually engages
+			// with this batch — a purely-unaddressed batch (channel chatter the bot
+			// is not replying to) must keep its buffer so a following "@bot ^^"
+			// pointer can still fold that question in.
 			if (botAddressed || !shouldRespondOnlyToMentions) {
 				channelDebouncer?.markResponded(messages[0].channel.id);
 			}
 		},
 		{
 			debounceMs: effectiveChannelDebounceMs,
-			responseCooldownMs,
 			getBotUserId: () => service.client?.user?.id,
 			coalesceEnabled: messageCoalesce.enabled,
 			maxBatch: messageCoalesce.maxBatch,


### PR DESCRIPTION
## What

Removes the debouncer's post-reply "response cooldown" entirely: after the bot replied in a channel, unaddressed messages were **silently hard-dropped for 30s** (`debouncer.ts` cooldown gate) in respond-to-all mode. Whether the agent replies to unaddressed chatter is the shouldRespond model's decision; a time-based throttle in the connector both duplicates that judgment and destroys natural conversation.

`markResponded` stays — its other duty (clearing the answered pointer-context buffer, the #11118 fix) is untouched. The `DISCORD_RESPONSE_COOLDOWN_MS` setting read is removed with the mechanism (note: it also couldn't be disabled — `Number.parseInt(...) || 30000` swallowed `0`).

## Why (observed live)

```
[01:16] user: @bot hi        → bot: "Hi! How can I help you today?"
[01:16] user: Wyd            → dropped, zero log trace
[01:16] user: Nubilio?       → dropped, zero log trace
```

The owner's natural follow-ups vanished with no trace at any log level — the bot looks deaf/broken exactly when a conversation starts (the reply arms the cooldown; every follow-up inside 30s dies). Cross-checked: with the gate removed, the same follow-up shape reaches message processing and the shouldRespond model decides.

## Tests

- New regression test for the exact lost-follow-up shape (respond-to-all mode: `markResponded` → unaddressed follow-up → must flush).
- Strict-mode buffering behavior re-pinned (unaddressed follow-up after a reply still buffers for a later "@bot ^^" pointer).
- `plugin-discord` suite: 34/34 on the touched files, full suite green; typecheck clean.

Related: #15855 (the same session's other silent-drop findings — silent inbound drops are indistinguishable from user error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
