### PR TITLE
fix(ci): retire wedged cloud-cf-deploy concurrency group (v2 suffix)

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -92,7 +92,14 @@ concurrency:
   # commit always lands next. This also removes the need for the manual out-of-band
   # deploy-serialization escort. PRs keep a per-PR dedupe group + cancel-in-progress
   # to avoid preview-deploy churn. Refs #11108.
-  group: cloud-cf-deploy-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('branch-{0}', github.ref) }}
+  #
+  # The "-v2" suffix retires a wedged predecessor group: REJECTING a waiting
+  # migrate-db reviewer gate completes the holder run without releasing its
+  # concurrency group, and GitHub never re-evaluates the queue afterward — every
+  # later run in the group sits in "pending" forever (rerun+cancel of the holder
+  # does not unwedge it; renaming the group is the only recovery). If a stale
+  # waiting deploy must be cleared, CANCEL the run; never reject its gate. (#15892)
+  group: cloud-cf-deploy-v2-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('branch-{0}', github.ref) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Default to least privilege. Override per-job where needed.


### PR DESCRIPTION
Mirrors main commit `1ddff6f3eb4` onto develop so the next develop→main promote keeps the v2 group (by policy, `cloud-cf-deploy.yml` promote conflicts resolve to develop's version — without this PR the next promote would resurrect the wedged group name).

## Why the group had to be renamed

- Prod deploys had been dead since 2026-07-08 22:02Z: cf-deploy run 28978844777 sat `waiting` at the production migrate-db reviewer gate, holding `cloud-cf-deploy-branch-refs/heads/main`; every later main push/dispatch got supersede-cancelled behind it (6 runs).
- **Rejecting** that gate (REST `pending_deployments` `state:"rejected"`) completed the holder run **without releasing its concurrency group**, and GitHub never re-evaluates the queue afterward: fresh dispatches, a rerun of the cancelled push run, and rerun+cancel of the holder itself all wedged in `pending` with zero jobs.
- Renaming the group is the only recovery. Operational lesson (now codified in the workflow comment): to clear a stale waiting deploy, **CANCEL the run — never reject its gate** (cancel released the sibling `cloud-deploy-backend`/provisioning groups instantly).

Diff is comment + group-name only; no job logic changes. Refs #15892, promote PR #15905.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Evidence

<!-- evidence-row:before-screenshots -->
Before screenshots: N/A - GitHub Actions workflow-only change; no rendered UI.

<!-- evidence-row:after-screenshots -->
After screenshots: N/A - GitHub Actions workflow-only change; no rendered UI.

<!-- evidence-row:walkthrough-video -->
Walkthrough video: N/A - operational concurrency-group recovery with no user-facing application flow.

<!-- evidence-row:backend-logs -->
Operational logs: [wedged production deploy holder and reviewer gate](https://github.com/elizaOS/eliza/actions/runs/28978844777); no backend runtime code changed.

<!-- evidence-row:frontend-logs -->
Frontend logs: N/A - no frontend code, console, or network behavior changed.

<!-- evidence-row:llm-trajectory -->
Real-LLM trajectory: N/A - no agent, action, provider, prompt, planner, evaluator, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
Domain artifacts: N/A - no product data is created; the changed artifact is the GitHub Actions concurrency key itself.