### PR TITLE
fix(test): exclude the bun-only soak tripwire from the app vitest lane

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -12,7 +12,7 @@
     "format:check": "bunx @biomejs/biome format src scripts",
     "clean": "node ../scripts/rm-path-recursive.mjs dist .turbo",
     "typecheck": "tsgo --noEmit -p tsconfig.typecheck.json",
-    "test": "vitest run --config vitest.config.ts",
+    "test": "bun test scripts/audit-views-soak-navigation.test.mjs && vitest run --config vitest.config.ts",
     "trace:startup": "node scripts/capture-startup-trace.mjs",
     "perf:startup-budget": "node scripts/check-startup-budget.mjs",
     "test:dev-smoke": "node scripts/run-ui-playwright.mjs --config playwright.dev-smoke.config.ts",

--- a/packages/app/scripts/audit-views-soak-navigation.test.mjs
+++ b/packages/app/scripts/audit-views-soak-navigation.test.mjs
@@ -3,7 +3,7 @@
  * while releasing its final active view.
  */
 
-import { expect, test } from "vitest";
+import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 
 const source = readFileSync(

--- a/packages/app/scripts/audit-views-soak-navigation.test.mjs
+++ b/packages/app/scripts/audit-views-soak-navigation.test.mjs
@@ -3,7 +3,7 @@
  * while releasing its final active view.
  */
 
-import { expect, test } from "bun:test";
+import { expect, test } from "vitest";
 import { readFileSync } from "node:fs";
 
 const source = readFileSync(

--- a/packages/app/vitest.config.ts
+++ b/packages/app/vitest.config.ts
@@ -20,6 +20,9 @@ const unitExcludes = [
   "**/*.spec.{ts,tsx}",
   "test/ui-smoke/**",
   "test/electrobun-packaged/**",
+  // Uses bun:test and reads sibling source via a file: URL, which vitest's
+  // jsdom transform cannot provide; coverage-gate routes it to `bun test`.
+  "scripts/audit-views-soak-navigation.test.mjs",
 ];
 
 export default defineConfig({


### PR DESCRIPTION
Follow-up to #15896 (merged): its new tripwire test `packages/app/scripts/audit-views-soak-navigation.test.mjs` is a bun-only test sitting inside `packages/app`'s vitest include glob (`scripts/**/*.test.{ts,tsx,mjs}`), so `bun run --cwd packages/app test` (the test:client lane) fails at collection on current develop — vitest cannot bundle the `bun:test` builtin.

An import swap to `vitest` is **not** sufficient: the file reads its sibling source via `readFileSync(new URL("./audit-views-soak.mjs", import.meta.url))`, and under vitest's jsdom transform `import.meta.url` is not a `file:` URL (`TypeError: The URL must be of scheme file`, reproduced in the evidence log). The right fix is the repo's established pattern — `packages/app-core/vitest.config.ts` documents excluding bun-only tests — so this PR excludes the file from the app vitest lane with a why-comment. `bun test` still owns and runs it (4/4 pass), which is how coverage-gate routes it.

## Verification
All runs performed in an isolated worktree at the #15896 merge commit (919d8fab), full transcript in the evidence asset:
1. BEFORE: `bunx vitest run scripts/audit-views-soak-navigation.test.mjs` → collection failure `Cannot bundle built-in module "bun:test"` (the broken develop lane).
2. Import-swap counter-proof: with `from "vitest"` the file still fails — `TypeError: The URL must be of scheme file` at the `readFileSync(new URL(...))` source read.
3. AFTER: same invocation with this PR's exclusion → `No test files found, exiting with code 0`; printed exclude list shows the entry.
4. `bun test scripts/audit-views-soak-navigation.test.mjs` → 4 pass / 0 fail (20 expects).

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-lane config fix; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-lane config fix; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow.
<!-- evidence-row:backend-logs -->
- [x] [Full before/insufficient-swap/after/bun-test transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15917-lane-repro.log)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no browser path changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistent state produced.
