### PR TITLE
fix(test): sweep all of packages/scripts/__tests__ in CI — give 33 dead suites a lane (#15846)

### DIFF
--- a/.github/workflows/scenario-pr.yml
+++ b/.github/workflows/scenario-pr.yml
@@ -796,66 +796,29 @@ jobs:
       - name: Ensure generated shared i18n data
         run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
 
-      - name: Test-runner pool + shard unit tests
-        run: bun test packages/scripts/__tests__/test-task-pool.test.ts
-
-      # #13620/#12342: spawned real-runner guards for vacuous-green failures.
-      # packages/scripts/__tests__ is outside workspace test discovery, so keep
-      # this explicit or zero-task / no-tests-skip regressions can ship green.
-      - name: Test-runner vacuous-green guard
-        run: bun test packages/scripts/__tests__/run-all-tests-vacuous-green-guard.test.ts
-
-      # Contract-tests the cloud agent image workflow's Turbo build step.
-      # packages/scripts/__tests__ is outside workspace test discovery, so keep
-      # this explicit or the workflow contract can silently stop running in CI.
-      - name: Agent image workflow contract
-        run: bun test packages/scripts/__tests__/build-agent-image-workflow.test.ts
-
-      # Drift guard for the build:core package set + delegation (issue #10200).
-      # packages/scripts/__tests__ is outside workspace test discovery, so keep
-      # this explicit or the guard silently stops running in CI.
-      - name: build:core package-set drift guard
-        run: bun test packages/scripts/__tests__/build-core.test.ts
-
-      # Self-test for the shared plugin build driver (issue #10200): 57 plugin
-      # build.ts files delegate to buildPlugin; this drives it against fixture
-      # packages and asserts the real emitted dist/ tree.
-      - name: Shared plugin-build driver self-test
-        run: bun test packages/scripts/__tests__/plugin-build.test.ts
-
-      # Smoke-tests the packages/app extension of the script inventory tool
-      # (issue #10200, item 2) — the second dense script surface.
-      - name: Script inventory (packages/app) smoke test
-        run: bun test packages/scripts/__tests__/audit-scripts-inventory.test.ts
-
-      # #9310 §E: guarded *.real/*.live suite accounting. Keeps the post-merge
-      # lane's named-skip summary honest: manifest ↔ on-disk drift, phantom
-      # guard credentials, and vitest configs that would silently re-exclude a
-      # guarded suite from every lane. packages/scripts/__tests__ is outside
-      # workspace test discovery, so keep this explicit.
-      - name: Real/live guarded-suite manifest gate
-        run: bun test packages/scripts/__tests__/real-live-suites.test.ts
-
-      # #9310 §3.16: every packages/ui __e2e__ run-*.mjs fixture runner must
-      # have a package script AND a workflow leg (ui-fixture-e2e.yml et al) —
-      # a runner nothing invokes is coverage that does not exist.
-      - name: UI fixture-runner CI-coverage ratchet
-        run: bun test packages/scripts/__tests__/ui-e2e-runner-coverage.test.ts
-
-      # E2E coverage gate (issue #8802). Now REQUIRED: the baseline is green —
-      # commands 38/38, #8791 shortcuts 1/1 (wired into SHORTCUT_COVERAGE),
-      # plugin routes covered/exempt, view ship-gates intact, zero blocking gaps.
-      # The advisory cycle is complete, so the ratchets (route-manifest lockstep,
-      # zero-test plugins, no-blocking-gaps) now fail the build on regression.
-      # `--conditions=eliza-source`: inventory.ts scans plugin SOURCE and reaches
-      # plugin-commands/src → @elizaos/core, which under bun's default `bun`
-      # export condition resolves to unbuilt dist on this --ignore-scripts install.
-      # The source condition resolves those workspace packages to src (same as the
-      # matrix-report step below), so the gate runs before build:core (#15759).
-      - name: E2E coverage ship-gate
+      # packages/scripts has no package.json, so packages/scripts/__tests__ is
+      # outside workspace test discovery (run-all-tests.mjs never sees it). This
+      # job used to enumerate individual files here, which left every unlisted
+      # suite dead on arrival — most of the directory never ran anywhere
+      # (#15846). Sweep the whole directory so a new test file there always has
+      # a lane. The sweep still owns every guard the per-file steps named:
+      # test-task-pool, the vacuous-green runner guard (#13620/#12342), the
+      # agent-image workflow + build:core drift contracts and the plugin-build
+      # driver self-test (#10200), the scripts-inventory smoke, the real/live
+      # guarded-suite manifest gate (#9310 §E), the UI fixture-runner
+      # CI-coverage ratchet (#9310 §3.16), and the ENFORCED e2e-coverage
+      # ship-gate (#8802 — baseline green; route-manifest lockstep, zero-test
+      # plugins, and no-blocking-gaps ratchets fail the build on regression).
+      # `--conditions=eliza-source`: several suites (e2e-coverage among them)
+      # scan workspace SOURCE that reaches @elizaos/core, which under bun's
+      # default `bun` export condition resolves to unbuilt dist on this
+      # --ignore-scripts install. The source condition resolves those workspace
+      # packages to src (same as the matrix-report step below), so the sweep
+      # runs before build:core (#15759).
+      - name: packages/scripts test sweep (all __tests__ suites)
         env:
           E2E_COVERAGE_GATE_ENFORCE: "1"
-        run: bun test --conditions=eliza-source packages/scripts/__tests__/e2e-coverage.test.ts
+        run: bun test --conditions=eliza-source packages/scripts/__tests__/
 
       # Per-plugin keyless-e2e coverage gate (issue #8801). The surface matrix
       # above proves app-facing routes/views; this ratchet proves each plugin

--- a/packages/scripts/__tests__/coverage-gate-playwright-classification.test.ts
+++ b/packages/scripts/__tests__/coverage-gate-playwright-classification.test.ts
@@ -1,20 +1,43 @@
 /**
- * Pins Android Playwright specs outside the unit-coverage runners. Those specs
- * use a package-local fixture, so import-only Playwright detection cannot
- * distinguish them from Bun tests.
+ * Pins Android Playwright specs outside the coverage gate's unit-test lanes.
+ * Those specs use a package-local fixture, so import-only Playwright detection
+ * cannot distinguish them from Bun tests. The classification lives in
+ * scripts/security/coverage-changed-files.sh (invoked by coverage-gate.yml),
+ * whose shared is_excluded_test() must gate BOTH the bun and vitest lanes.
  */
 
 import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
+const repoRoot = resolve(import.meta.dir, "../../..");
+const classifier = readFileSync(
+  resolve(repoRoot, "scripts/security/coverage-changed-files.sh"),
+  "utf8",
+);
 const workflow = readFileSync(
-  resolve(import.meta.dir, "../../../.github/workflows/coverage-gate.yml"),
+  resolve(repoRoot, ".github/workflows/coverage-gate.yml"),
   "utf8",
 );
 
-test("coverage gate excludes Android Playwright specs from both unit runners", () => {
+test("changed-file classifier excludes Android Playwright specs", () => {
+  const excludedCase = classifier.match(
+    /is_excluded_test\(\)\s*\{[\s\S]*?\n\}/,
+  );
+  expect(excludedCase?.[0]).toContain(
+    "packages/app/test/android/*.android.spec.*",
+  );
+});
+
+test("both unit lanes apply the exclusion filter", () => {
+  // One loop per lane (bun_tests, vitest_tests); each must consult
+  // is_excluded_test before emitting a file, or an Android spec slips into
+  // that lane's fast unit runner.
   expect(
-    workflow.match(/packages\/app\/test\/android\/\*\.android\.spec\.\*/g),
+    classifier.match(/is_excluded_test "\$file" && continue/g),
   ).toHaveLength(2);
+});
+
+test("coverage-gate workflow delegates classification to the script", () => {
+  expect(workflow).toContain("scripts/security/coverage-changed-files.sh");
 });

--- a/packages/scripts/__tests__/real-live-suites.test.ts
+++ b/packages/scripts/__tests__/real-live-suites.test.ts
@@ -15,7 +15,8 @@
  *      anyOf groups, the missing-creds line printed even at zero).
  *
  * packages/scripts/__tests__ is outside workspace test discovery — this file
- * runs via an explicit `bun test` leg in .github/workflows/scenario-pr.yml.
+ * runs via the directory-wide `bun test` sweep in
+ * .github/workflows/scenario-pr.yml (#15846).
  */
 
 import { describe, expect, test } from "bun:test";

--- a/packages/scripts/__tests__/ui-e2e-runner-coverage.test.ts
+++ b/packages/scripts/__tests__/ui-e2e-runner-coverage.test.ts
@@ -16,7 +16,8 @@
  * change — or consciously deleting it.
  *
  * packages/scripts/__tests__ is outside workspace test discovery — this file
- * runs via an explicit `bun test` leg in .github/workflows/scenario-pr.yml.
+ * runs via the directory-wide `bun test` sweep in
+ * .github/workflows/scenario-pr.yml (#15846).
  */
 
 import { expect, test } from "bun:test";

--- a/packages/scripts/__tests__/verify-environment-routing.test.ts
+++ b/packages/scripts/__tests__/verify-environment-routing.test.ts
@@ -320,7 +320,11 @@ describe("ENVIRONMENT_ROUTING matrix integrity", () => {
     // Every staging route host EXCEPT the R2 blob host (which serves objects,
     // not /api/health) and wildcard routes (the per-agent *.staging wildcard
     // from #15213 has no fixed hostname to probe) must be represented in the
-    // matrix as a staging domain.
+    // matrix as a staging domain. The wildcard exemption is pinned to the one
+    // known route: a new or broader wildcard (e.g. *.elizacloud.ai claimed by
+    // staging) must fail here for review instead of being silently skipped.
+    const wildcardHosts = routeHosts.filter((h) => h.includes("*"));
+    expect(wildcardHosts).toEqual(["*.staging.elizacloud.ai"]);
     const healthHosts = routeHosts.filter(
       (h) => !h.startsWith("blob-") && !h.includes("*"),
     );

--- a/packages/scripts/__tests__/verify-environment-routing.test.ts
+++ b/packages/scripts/__tests__/verify-environment-routing.test.ts
@@ -318,8 +318,12 @@ describe("ENVIRONMENT_ROUTING matrix integrity", () => {
       ...stagingBlock.matchAll(/pattern\s*=\s*"([^"/]+)\/\*"/g),
     ].map((m) => m[1]);
     // Every staging route host EXCEPT the R2 blob host (which serves objects,
-    // not /api/health) must be represented in the matrix as a staging domain.
-    const healthHosts = routeHosts.filter((h) => !h.startsWith("blob-"));
+    // not /api/health) and wildcard routes (the per-agent *.staging wildcard
+    // from #15213 has no fixed hostname to probe) must be represented in the
+    // matrix as a staging domain.
+    const healthHosts = routeHosts.filter(
+      (h) => !h.startsWith("blob-") && !h.includes("*"),
+    );
     const stagingMatrix = new Set(
       ENVIRONMENT_ROUTING.filter((e) => e.environment === "staging").map(
         (e) => e.domain,

--- a/packages/scripts/__tests__/windows-ci-workflow.test.ts
+++ b/packages/scripts/__tests__/windows-ci-workflow.test.ts
@@ -23,7 +23,11 @@ const EXPECTED_COMMANDS = [
   "bun run --cwd packages/shared test",
   "bun run --cwd packages/app-core test",
   "bun run --cwd packages/elizaos test",
-  "bun run --cwd packages/cloud/shared test",
+  // #15785: the tenant-db placement-claimer suite panics intermittently under
+  // Bun canary/PGlite on Windows, so the whole-package run skips it and a
+  // dedicated retry-isolated step (asserted below) re-runs it with a bounded
+  // retry. The exclusion is only sound while that step exists.
+  'bun run --cwd packages/cloud/shared test --path-ignore-patterns "**/tenant-db-placement-claimer.test.ts"',
   "bun run --cwd packages/scenario-runner test",
   "bun run --cwd packages/vault test",
   "bun run --cwd packages/security test",
@@ -49,9 +53,7 @@ function extractMatrixLanes(): string[] {
 }
 
 function extractMatrixCommands(): string[] {
-  return [...workflowText.matchAll(/^ {14}- (.+)$/gm)].map(
-    (match) => match[1],
-  );
+  return [...workflowText.matchAll(/^ {14}- (.+)$/gm)].map((match) => match[1]);
 }
 
 describe("Windows CI workflow", () => {
@@ -65,5 +67,16 @@ describe("Windows CI workflow", () => {
     expect(commands).toHaveLength(EXPECTED_COMMANDS.length);
     expect(commands).toEqual(EXPECTED_COMMANDS);
     expect(new Set(commands).size).toBe(commands.length);
+  });
+
+  test("still runs the tenant-db suite the whole-package run excludes", () => {
+    // Skipping a suite in the matrix without the isolated retry step would be
+    // silent coverage loss, not flake mitigation.
+    expect(workflowText).toContain(
+      "Retry-isolated tenant-db PGlite suite (Windows canary flake, #15785)",
+    );
+    expect(workflowText).toContain(
+      "bun run --cwd packages/cloud/shared test $suite",
+    );
   });
 });

--- a/packages/scripts/__tests__/windows-ci-workflow.test.ts
+++ b/packages/scripts/__tests__/windows-ci-workflow.test.ts
@@ -71,11 +71,24 @@ describe("Windows CI workflow", () => {
 
   test("still runs the tenant-db suite the whole-package run excludes", () => {
     // Skipping a suite in the matrix without the isolated retry step would be
-    // silent coverage loss, not flake mitigation.
-    expect(workflowText).toContain(
-      "Retry-isolated tenant-db PGlite suite (Windows canary flake, #15785)",
+    // silent coverage loss, not flake mitigation. Pin the step's own block —
+    // not the whole workflow — so repointing $suite at a different suite or
+    // moving the step off the lane that runs packages/cloud/shared cannot
+    // silently drop tenant-db coverage while these substrings survive elsewhere.
+    const stepName =
+      "Retry-isolated tenant-db PGlite suite (Windows canary flake, #15785)";
+    const stepStart = workflowText.indexOf(stepName);
+    expect(stepStart).toBeGreaterThan(-1);
+    const nextStep = workflowText.indexOf("- name:", stepStart);
+    const stepBlock = workflowText.slice(
+      stepStart,
+      nextStep === -1 ? undefined : nextStep,
     );
-    expect(workflowText).toContain(
+    expect(stepBlock).toContain("if: matrix.lane == 'app-and-cli'");
+    expect(stepBlock).toContain(
+      '$suite = "src/lib/services/tenant-db/tenant-db-placement-claimer.test.ts"',
+    );
+    expect(stepBlock).toContain(
       "bun run --cwd packages/cloud/shared test $suite",
     );
   });


### PR DESCRIPTION
## Problem

Closes #15846 (part 2 — `packages/scripts/__tests__` has no executing lane).

`packages/scripts` has no `package.json`, so `packages/scripts/__tests__` sits outside workspace test discovery (`run-all-tests.mjs` never sees it). The only thing that ever executed files there was a hand-maintained list of per-file `bun test` steps in `scenario-pr.yml`'s `scenario-runner-e2e` job — **9 of 52 files**. A full reference audit of the directory (every `*.test.ts`/`*.test.mjs` grepped against workflows, root scripts, and `packages/scripts` itself) found **33 files with no reference anywhere** and 43 that no CI lane executes, including both files named in the issue (`coverage-gate-playwright-classification.test.ts`, `run-turbo-typecheck-prerequisite.test.ts`).

Three of the dead suites had silently drifted red while unexecuted — exactly the failure mode the issue predicts.

Part 1 of #15846 (`plugins/plugin-elizacloud/scripts/verify-built-package.test.mjs` discovery) is covered by the already-open #15880; this PR deliberately does not touch that file to avoid a collision.

## Fix

**Wire the directory into the existing lane, not a new mechanism.** The per-file steps in `scenario-pr.yml#scenario-runner-e2e` become one directory-wide sweep:

```yaml
- name: packages/scripts test sweep (all __tests__ suites)
  env:
    E2E_COVERAGE_GATE_ENFORCE: "1"
  run: bun test --conditions=eliza-source packages/scripts/__tests__/
```

Every current and future test file in the directory now runs on: develop pushes, the nightly heavy lane, the scheduled exhaustive lane (`develop-exhaustive.yml` calls `scenario-pr.yml` via `workflow_call`), and `ci:full`-labeled PRs. This matches the repo's CI design: PRs to develop run lint/typecheck/build + changed tests (`develop-pr.yml` + `coverage-gate.yml`); the full test surface runs post-merge. The enforced e2e-coverage ship-gate env and the `--conditions=eliza-source` resolution (needed on the job's `--ignore-scripts` install) are preserved; `test.yml`'s independent vacuous-green-guard leg is untouched.

**Repair the three suites that drifted while dead** (each verified against its source of truth):

1. `coverage-gate-playwright-classification.test.ts` — the Android-spec exclusion moved from inline `coverage-gate.yml` YAML into `scripts/security/coverage-changed-files.sh`; the test matched the old location and got `null`. Re-anchored to the classifier: asserts the pattern inside `is_excluded_test()`, asserts **both** unit-lane loops call `is_excluded_test`, and asserts `coverage-gate.yml` still delegates to the script.
2. `verify-environment-routing.test.ts` — merged #15213 added the per-agent `*.staging.elizacloud.ai/*` wildcard route to `[env.staging]` in `wrangler.toml`; a wildcard has no fixed hostname to health-probe, so it can never be an `ENVIRONMENT_ROUTING` matrix entry. Wildcard hosts are now excluded from the sync requirement (same rationale as the existing `blob-` exclusion). *(Review follow-up)* the wildcard exemption is pinned to exactly `["*.staging.elizacloud.ai"]`, so a new or broader wildcard (e.g. `*.elizacloud.ai` claimed by staging) fails the test for review instead of being silently skipped.
3. `windows-ci-workflow.test.ts` — merged #15842 (#15785) deliberately added `--path-ignore-patterns "**/tenant-db-placement-claimer.test.ts"` to the cloud/shared shard command and re-runs that suite in a retry-isolated step. `EXPECTED_COMMANDS` now matches, and a new assertion pins the retry-isolated step so the exclusion cannot silently become coverage loss. *(Review follow-up)* the assertion now scopes to the step's own YAML block and additionally pins `if: matrix.lane == 'app-and-cli'` and `$suite = "src/lib/services/tenant-db/tenant-db-placement-claimer.test.ts"`, so repointing `$suite` or moving the step off the lane that runs `packages/cloud/shared` cannot silently drop tenant-db coverage.

Stale headers in `real-live-suites.test.ts` / `ui-e2e-runner-coverage.test.ts` ("runs via an explicit `bun test` leg") updated to name the sweep.

## Verification

All run in this branch's worktree, mirroring the CI job env (`CI=true TEST_LANE=pr ELIZA_LIVE_TEST=0 SCENARIO_USE_LLM_PROXY=1 E2E_COVERAGE_GATE_ENFORCE=1`, empty provider keys):

- **Post-rebase full re-run** (head `c15602bb5e` rebased onto develop `c24888bbe9`): `387 pass, 0 fail. Ran 387 tests across 53 files.` — the sweep now also covers `headscale-api-key-health-workflow.test.ts`, which landed on develop via #15843 after this branch's original merge-base (that suite also run explicitly: `4 pass, 0 fail`). Full teed log (sweep + file inventory + all contract gates + ratchet + biome): [15920-sweep-rerun.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15920-sweep-rerun.log).
- **Fail-before:** `bun test --conditions=eliza-source packages/scripts/__tests__/` on unmodified `origin/develop` → `377 pass, 3 fail` across 52 files (the three drifted suites above).
- **Pass-after:** same command → `383 pass, 0 fail. Ran 383 tests across 52 files. [63.93s]` — the runner output below lists every previously-dead file executing.
- Workflow contract gates over the edited `scenario-pr.yml`: `node packages/scripts/ci-zero-key-command-ownership-contract.mjs` → `passed (112 command(s), 4 workflow(s) scanned)`; `node packages/scripts/ci-workflow-dedup-contract.mjs` → `passed`; `node packages/scripts/ci-merge-gate-contract.mjs --self-test && …` → `17 cases passed` + main check passed.
- `bunx vitest run src/scenario-pr-workflow.test.ts` (packages/scenario-runner) → `11 passed`.
- `python3 -c "yaml.safe_load(...)"` on `scenario-pr.yml` → parses.
- `bun run audit:error-policy-ratchet` → `no new fallback-slop in touched files`.
- `bunx biome check --write` on all changed test files → clean.

<details>
<summary>Directory reference audit (why 33 files are dead) — grep of every test file against workflows/scripts</summary>

```
DEAD: app-aesthetic-audit-workflow.test.ts
DEAD: audit-mvp-project-board.test.ts
OK:   audit-scripts-inventory.test.ts -> .github/workflows/scenario-pr.yml
OK:   build-agent-image-workflow.test.ts -> .github/workflows/scenario-pr.yml
OK:   build-core.test.ts -> packages/scripts/build-core-packages.mjs .github/workflows/scenario-pr.yml
DEAD: build-views-guard.test.ts
DEAD: capacitor-bridge-typecheck-boundary.test.ts
DEAD: ci-bun-version-contract.test.ts
DEAD: ci-capacity-dashboard.test.ts
DEAD: ci-full-matrix-proof.test.ts
DEAD: ci-turbo-cache-contract.test.ts
DEAD: ci-windows-command-coverage-contract.test.ts
DEAD: ci-workflow-dedup-contract.test.ts
DEAD: ci-zero-key-command-ownership-contract.test.ts
DEAD: coverage-gate-playwright-classification.test.ts
DEAD: coverage-gate-test-only-pr.test.ts
DEAD: coverage-workflow-source-condition.test.ts
DEAD: declaration-emit-no-check.test.ts
DEAD: deploy-freshness-guard.test.ts
OK:   e2e-coverage.test.ts -> scenario-pr.yml (+docs)
DEAD: gh-check-run-triage.test.ts
DEAD: lifeops-catalog-coverage.test.ts
DEAD: lint-lane-coverage.test.ts
DEAD: monetized-loop-workflow.test.ts
DEAD: mvp-board-readiness.test.ts
DEAD: mvp-closeout-audit.test.ts
DEAD: mvp-evidence-matrix.test.ts
OK:   plugin-build.test.ts -> .github/workflows/scenario-pr.yml
OK:   plugin-discovery-zero-edit.test.ts -> packages/scripts/lib/script-metadata.mjs (comment only — no executing lane)
OK:   real-live-suites.test.ts -> packages/scripts/lib/real-live-suites.mjs .github/workflows/scenario-pr.yml
DEAD: rewrite-dist-relative-imports-node-esm.test.ts
OK:   run-all-tests-vacuous-green-guard.test.ts -> .github/workflows/test.yml .github/workflows/scenario-pr.yml
DEAD: run-scenarios-isolated.test.ts
DEAD: run-turbo-typecheck-prerequisite.test.ts
DEAD: test-realness-audit.test.ts
OK:   test-task-pool.test.ts -> .github/workflows/scenario-pr.yml
OK:   trajectory-validate.test.ts -> AGENTS.md CLAUDE.md (manual command only — no executing lane)
DEAD: turbo-build-stamp-env-contract.test.ts
DEAD: turbo-cache-key.test.ts
DEAD: turbo-prompts-cache-outputs.test.ts
OK:   ui-e2e-runner-coverage.test.ts -> .github/workflows/mobile-build-smoke.yml .github/workflows/scenario-pr.yml
DEAD: verify-environment-routing.test.ts
DEAD: verify-pages-frontend.test.ts
OK:   view-bundle-single-chunk.test.ts -> packages/agent/src/api/dynamic-view-host-external.mjs (comment only — no executing lane)
DEAD: voice-cloud-bench.test.mjs
DEAD: voice-matrix.test.ts
DEAD: voice-openwakeword-eval.test.ts
DEAD: voice-policy-ratchet.test.ts
DEAD: voice-railway-service-defs.test.ts
DEAD: voice-stage-b-eval.test.ts
DEAD: windows-ci-workflow.test.ts
DEAD: workspaces-lib.test.ts
```
</details>

<details>
<summary>Fail-before: sweep on unmodified origin/develop — the 3 drifted suites</summary>

```
packages/scripts/__tests__/coverage-gate-playwright-classification.test.ts:
error: Received value does not have a length property: null
(fail) coverage gate excludes Android Playwright specs from both unit runners [0.46ms]

packages/scripts/__tests__/verify-environment-routing.test.ts:
error: expect(received).toBe(expected)
Expected: true
Received: false
(fail) ENVIRONMENT_ROUTING matrix integrity > stays in sync with the staging Worker routes in wrangler.toml [0.31ms]

packages/scripts/__tests__/windows-ci-workflow.test.ts:
error: expect(received).toEqual(expected)
@@ -6,3 +6,3 @@
    "bun run --cwd packages/elizaos test",
-   "bun run --cwd packages/cloud/shared test",
+   "bun run --cwd packages/cloud/shared test --path-ignore-patterns "**/tenant-db-placement-claimer.test.ts"",
    "bun run --cwd packages/scenario-runner test",
(fail) Windows CI workflow > keeps every pre-shard command represented exactly once [0.24ms]

 377 pass
 3 fail
Ran 380 tests across 52 files. [46.58s]
```
</details>

<details>
<summary>Pass-after: full sweep under CI-like env — every suite executes and passes</summary>

```
$ CI=true TEST_LANE=pr ELIZA_LIVE_TEST=0 SCENARIO_USE_LLM_PROXY=1 E2E_COVERAGE_GATE_ENFORCE=1 \
  bun test --conditions=eliza-source packages/scripts/__tests__/
bun test v1.4.0-canary.1 (55f6c899f)
...
 383 pass
 0 fail
 3438 expect() calls
Ran 383 tests across 52 files. [63.93s]
exit=0
```
</details>

<details>
<summary>Workflow contract gates over the edited scenario-pr.yml</summary>

```
$ node packages/scripts/ci-zero-key-command-ownership-contract.mjs
ci zero-key command ownership contract passed (112 command(s), 4 workflow(s) scanned)
$ node packages/scripts/ci-workflow-dedup-contract.mjs
ci workflow dedup contract passed
$ node packages/scripts/ci-merge-gate-contract.mjs --self-test
ci-merge-gate-contract self-test: 17 cases passed
$ node packages/scripts/ci-merge-gate-contract.mjs
ci-merge-gate-contract: classifiers have hosted fallback, fleet-drain fallback present, ci-ok enforces the quality gate.
$ bunx vitest run src/scenario-pr-workflow.test.ts   # packages/scenario-runner
 Test Files  1 passed (1)
      Tests  11 passed (11)
$ bun run audit:error-policy-ratchet
[error-policy-ratchet] base origin/develop (ebce0f08ea); 0 changed production source file(s)
[error-policy-ratchet] no new fallback-slop in touched files
```
</details>

## Notes / N/A

- CI-config + test-repair change with no runtime/UI surface; all UI/audio/model evidence rows are N/A below.
- Companion PR for the issue's part 1 (plugin-elizacloud `verify-built-package.test.mjs`): #15880.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-row:before-screenshots -->
- [ ] N/A - CI workflow + test-file change; no UI surface.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - CI workflow + test-file change; no UI surface.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow; behavior is proven by the runner output above.

<!-- evidence-row:backend-logs -->
- [x] Full post-rebase re-run log — sweep (`387 pass, 0 fail` across 53 files), explicit headscale run, zero-key/dedup/merge-gate contract gates, error-policy ratchet, biome: [15920-sweep-rerun.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15920-sweep-rerun.log). Fail-before/pass-after excerpts also inline in the `<details>` blocks above.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic CI/test change; no model path.

<!-- evidence-row:domain-artifacts -->
- [x] The domain artifact is the runner output itself: [15920-sweep-rerun.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15920-sweep-rerun.log) — `Ran 387 tests across 53 files` (vs 9 files with an executing lane before), including the post-branch headscale suite (#15843), with a per-file inventory cross-check; reviewed by hand. Per-file dead/alive audit inline above.

