### PR TITLE
fix(cloud): revert retire flip when the delete enqueue fails (#15826 secondary)

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/container-status.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/container-status.test.ts
@@ -23,7 +23,11 @@ const EVERY_STATUS: Record<ContainerStatus, true> = {
 
 describe("CONTAINER_STATUSES / isContainerStatus", () => {
   test("the vocabulary const covers the ContainerStatus union exactly", () => {
-    expect([...CONTAINER_STATUSES].sort()).toEqual(Object.keys(EVERY_STATUS).sort());
+    // expect() is anchored on the wider string[] side so the literal-union
+    // array widens into it — cloud-api's project-reference typecheck compiles
+    // this file and rejects the reverse direction (string[] into a
+    // ContainerStatus[] expectation).
+    expect(Object.keys(EVERY_STATUS).sort()).toEqual([...CONTAINER_STATUSES].sort());
   });
 
   test("accepts every member of the vocabulary", () => {

--- a/packages/cloud/shared/src/db/repositories/__tests__/container-status.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/container-status.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Pins the containers status vocabulary and its runtime guard (#15826) — pure
+ * module, no DB. The Record below is the compile-time exhaustiveness check:
+ * adding a member to `ContainerStatus` without listing it here fails typecheck.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { CONTAINER_STATUSES, isContainerStatus } from "../container-status";
+import type { ContainerStatus } from "../containers";
+
+// Typechecking forces one key per union member, so the vocabulary const can
+// never silently trail the `ContainerStatus` type.
+const EVERY_STATUS: Record<ContainerStatus, true> = {
+  pending: true,
+  building: true,
+  deploying: true,
+  running: true,
+  stopped: true,
+  failed: true,
+  deleting: true,
+  deleted: true,
+};
+
+describe("CONTAINER_STATUSES / isContainerStatus", () => {
+  test("the vocabulary const covers the ContainerStatus union exactly", () => {
+    expect([...CONTAINER_STATUSES].sort()).toEqual(Object.keys(EVERY_STATUS).sort());
+  });
+
+  test("accepts every member of the vocabulary", () => {
+    for (const status of Object.keys(EVERY_STATUS)) {
+      expect(isContainerStatus(status)).toBe(true);
+    }
+  });
+
+  test("rejects values outside the vocabulary", () => {
+    for (const garbage of [
+      "",
+      " ",
+      "zombie",
+      "RUNNING", // case-sensitive: the column stores lowercase vocabulary values
+      "running ", // no trimming — a padded value is not a valid status
+      "delete",
+      "deleteing",
+      "null",
+      "undefined",
+    ]) {
+      expect(isContainerStatus(garbage)).toBe(false);
+    }
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/container-status.ts
+++ b/packages/cloud/shared/src/db/repositories/container-status.ts
@@ -1,0 +1,31 @@
+/**
+ * Runtime vocabulary for `containers.status`. The column is free text at the
+ * schema level, so any status read back from a row must be validated here
+ * before being handed to a `ContainerStatus`-typed writer (e.g. the deploy
+ * runner reverting a retire flip, #15826). Kept separate from the repository
+ * module so DB-free consumers and tests can use the guard without loading the
+ * process database singletons.
+ */
+
+import type { ContainerStatus } from "./containers";
+
+/**
+ * Every value `ContainerStatus` admits. `satisfies` rejects entries outside
+ * the union; the exhaustiveness of the list (no union member missing) is
+ * pinned by the vocabulary test alongside this module.
+ */
+export const CONTAINER_STATUSES = [
+  "pending",
+  "building",
+  "deploying",
+  "running",
+  "stopped",
+  "failed",
+  "deleting",
+  "deleted",
+] as const satisfies readonly ContainerStatus[];
+
+/** True when a free-text status value is inside the containers vocabulary. */
+export function isContainerStatus(value: string): value is ContainerStatus {
+  return (CONTAINER_STATUSES as readonly string[]).includes(value);
+}

--- a/packages/cloud/shared/src/db/repositories/containers.ts
+++ b/packages/cloud/shared/src/db/repositories/containers.ts
@@ -24,27 +24,15 @@ import { parseOrganizationCreditBalance } from "./organizations-credit-balance-n
 export type Container = InferSelectModel<typeof containers>;
 export type NewContainer = InferInsertModel<typeof containers>;
 
-export const CONTAINER_STATUSES = [
-  "pending",
-  "building",
-  "deploying",
-  "running",
-  "stopped",
-  "failed",
-  "deleting",
-  "deleted",
-] as const;
-
-export type ContainerStatus = (typeof CONTAINER_STATUSES)[number];
-
-/**
- * Runtime guard for the status vocabulary — the `containers.status` column is
- * free text, so a status read back from a row must be validated before being
- * handed to a `ContainerStatus`-typed writer (e.g. reverting a retire flip).
- */
-export function isContainerStatus(value: string): value is ContainerStatus {
-  return (CONTAINER_STATUSES as readonly string[]).includes(value);
-}
+export type ContainerStatus =
+  | "pending"
+  | "building"
+  | "deploying"
+  | "running"
+  | "stopped"
+  | "failed"
+  | "deleting"
+  | "deleted";
 
 export interface QuotaCheckResult {
   allowed: boolean;

--- a/packages/cloud/shared/src/db/repositories/containers.ts
+++ b/packages/cloud/shared/src/db/repositories/containers.ts
@@ -24,15 +24,27 @@ import { parseOrganizationCreditBalance } from "./organizations-credit-balance-n
 export type Container = InferSelectModel<typeof containers>;
 export type NewContainer = InferInsertModel<typeof containers>;
 
-export type ContainerStatus =
-  | "pending"
-  | "building"
-  | "deploying"
-  | "running"
-  | "stopped"
-  | "failed"
-  | "deleting"
-  | "deleted";
+export const CONTAINER_STATUSES = [
+  "pending",
+  "building",
+  "deploying",
+  "running",
+  "stopped",
+  "failed",
+  "deleting",
+  "deleted",
+] as const;
+
+export type ContainerStatus = (typeof CONTAINER_STATUSES)[number];
+
+/**
+ * Runtime guard for the status vocabulary — the `containers.status` column is
+ * free text, so a status read back from a row must be validated before being
+ * handed to a `ContainerStatus`-typed writer (e.g. reverting a retire flip).
+ */
+export function isContainerStatus(value: string): value is ContainerStatus {
+  return (CONTAINER_STATUSES as readonly string[]).includes(value);
+}
 
 export interface QuotaCheckResult {
   allowed: boolean;

--- a/packages/cloud/shared/src/lib/services/__tests__/app-deploy-runner-retire.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-deploy-runner-retire.test.ts
@@ -73,6 +73,19 @@ mock.module("../../../db/repositories/containers", () => ({
       return { id };
     },
   },
+  // The runner's enqueue-failure revert validates the read-back status before
+  // handing it to the typed writer; mirror the real vocabulary here.
+  isContainerStatus: (value: string) =>
+    [
+      "pending",
+      "building",
+      "deploying",
+      "running",
+      "stopped",
+      "failed",
+      "deleting",
+      "deleted",
+    ].includes(value),
 }));
 
 mock.module("../apps", () => ({
@@ -144,5 +157,48 @@ describe("DefaultAppDeployRunner — redeploy retires the prior container row (B
     // app stay ≤ 1 (the retired row no longer counts) — no leak across redeploys.
     expect([...rows.values()].some((r) => r.status === "pending")).toBe(true);
     expect(quotaCountForApp(APP_ID)).toBeLessThanOrEqual(1);
+  });
+
+  test("#15826: a failed delete-enqueue reverts the row instead of stranding it in deleting", async () => {
+    rows.clear();
+    rows.set("container-prior", {
+      id: "container-prior",
+      organization_id: ORG_ID,
+      project_name: APP_ID,
+      status: "running",
+    });
+
+    // The delete-enqueue write fails (e.g. the jobs table is unreachable, or the
+    // enqueue-side payload validation throws); the provision enqueue still works
+    // so the new deploy itself proceeds.
+    const enqueued: ContainerJobInsert[] = [];
+    const jobsWriter: ContainerJobsWriter = {
+      async insertJob(job) {
+        if (job.type === JOB_TYPES.CONTAINER_DELETE) {
+          throw new Error("jobs table unavailable");
+        }
+        enqueued.push(job);
+        return { id: `job-${enqueued.length}` };
+      },
+    };
+
+    const runner = new DefaultAppDeployRunner({
+      ensureTenantDb: async () => {
+        throw new Error("ensureTenantDb must NOT be called for a stateless app");
+      },
+      jobsWriter,
+      resolveImage: () => "ghcr.io/elizaos/app:test",
+    });
+
+    await runner.run(APP_ID);
+
+    // The prior row was flipped BACK to its pre-retire status: a `deleting` row
+    // with no CONTAINER_DELETE job is permanently stuck (recovery only fans out
+    // from a claimed legacy job, and `deleting` is excluded from the retire
+    // query), whereas a reverted `running` row is retried by the next deploy.
+    expect(rows.get("container-prior")?.status).toBe("running");
+    // The new deploy still went through — retirement stays best-effort.
+    expect([...rows.values()].some((r) => r.status === "pending")).toBe(true);
+    expect(enqueued.some((j) => j.type === JOB_TYPES.CONTAINER_PROVISION)).toBe(true);
   });
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/app-deploy-runner-retire.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-deploy-runner-retire.test.ts
@@ -34,6 +34,11 @@ interface Row {
 }
 const rows = new Map<string, Row>();
 
+// Status values whose updateStatus write should throw — lets a test fail a
+// SPECIFIC write (e.g. only the revert back to `running`) to drive the runner's
+// escalation branches. Cleared per test.
+const updateStatusFailures = new Set<string>();
+
 // The set of statuses the quota readers EXCLUDE — a row in any other status
 // counts toward the org cap. Mirrors `notInArray(status, ["deleting","deleted"])`.
 const NON_COUNTING = new Set(["deleting", "deleted"]);
@@ -57,6 +62,9 @@ mock.module("../../../db/repositories/containers", () => ({
           !NON_COUNTING.has(r.status),
       ),
     updateStatus: async (id: string, status: string) => {
+      if (updateStatusFailures.has(status)) {
+        throw new Error(`status write rejected: ${status}`);
+      }
       const row = rows.get(id);
       if (row) row.status = status;
       return row ?? null;
@@ -73,19 +81,6 @@ mock.module("../../../db/repositories/containers", () => ({
       return { id };
     },
   },
-  // The runner's enqueue-failure revert validates the read-back status before
-  // handing it to the typed writer; mirror the real vocabulary here.
-  isContainerStatus: (value: string) =>
-    [
-      "pending",
-      "building",
-      "deploying",
-      "running",
-      "stopped",
-      "failed",
-      "deleting",
-      "deleted",
-    ].includes(value),
 }));
 
 mock.module("../apps", () => ({
@@ -113,6 +108,7 @@ import { JOB_TYPES } from "../provisioning-job-types";
 describe("DefaultAppDeployRunner — redeploy retires the prior container row (Bug 1)", () => {
   test("a redeploy flips the prior row to deleting, enqueues its delete, and keeps quota ≤1", async () => {
     rows.clear();
+    updateStatusFailures.clear();
     // Simulate a prior deploy: one live `running` row for this app.
     rows.set("container-prior", {
       id: "container-prior",
@@ -161,6 +157,7 @@ describe("DefaultAppDeployRunner — redeploy retires the prior container row (B
 
   test("#15826: a failed delete-enqueue reverts the row instead of stranding it in deleting", async () => {
     rows.clear();
+    updateStatusFailures.clear();
     rows.set("container-prior", {
       id: "container-prior",
       organization_id: ORG_ID,
@@ -200,5 +197,83 @@ describe("DefaultAppDeployRunner — redeploy retires the prior container row (B
     // The new deploy still went through — retirement stays best-effort.
     expect([...rows.values()].some((r) => r.status === "pending")).toBe(true);
     expect(enqueued.some((j) => j.type === JOB_TYPES.CONTAINER_PROVISION)).toBe(true);
+  });
+
+  test("#15826: a failed revert write escalates loudly and still never blocks the deploy", async () => {
+    rows.clear();
+    updateStatusFailures.clear();
+    rows.set("container-prior", {
+      id: "container-prior",
+      organization_id: ORG_ID,
+      project_name: APP_ID,
+      status: "running",
+    });
+    // Worst case: the enqueue fails AND the revert write back to `running` also
+    // fails (jobs table and containers write path both broken).
+    updateStatusFailures.add("running");
+
+    const enqueued: ContainerJobInsert[] = [];
+    const jobsWriter: ContainerJobsWriter = {
+      async insertJob(job) {
+        if (job.type === JOB_TYPES.CONTAINER_DELETE) {
+          throw new Error("jobs table unavailable");
+        }
+        enqueued.push(job);
+        return { id: `job-${enqueued.length}` };
+      },
+    };
+
+    const runner = new DefaultAppDeployRunner({
+      ensureTenantDb: async () => {
+        throw new Error("ensureTenantDb must NOT be called for a stateless app");
+      },
+      jobsWriter,
+      resolveImage: () => "ghcr.io/elizaos/app:test",
+    });
+
+    await runner.run(APP_ID);
+
+    // Both writes failed, so the row IS stuck in `deleting` — the runner's job
+    // is to say so at error level (asserted by the log line in the run output),
+    // not to crash the deploy: the new deploy still proceeds.
+    expect(rows.get("container-prior")?.status).toBe("deleting");
+    expect([...rows.values()].some((r) => r.status === "pending")).toBe(true);
+    expect(enqueued.some((j) => j.type === JOB_TYPES.CONTAINER_PROVISION)).toBe(true);
+  });
+
+  test("#15826: an out-of-vocabulary pre-retire status is never written back", async () => {
+    rows.clear();
+    updateStatusFailures.clear();
+    // `containers.status` is free text at the column level; a corrupted value
+    // must not round-trip through the typed status writer during the revert.
+    rows.set("container-prior", {
+      id: "container-prior",
+      organization_id: ORG_ID,
+      project_name: APP_ID,
+      status: "zombie",
+    });
+
+    const jobsWriter: ContainerJobsWriter = {
+      async insertJob(job) {
+        if (job.type === JOB_TYPES.CONTAINER_DELETE) {
+          throw new Error("jobs table unavailable");
+        }
+        return { id: "job-1" };
+      },
+    };
+
+    const runner = new DefaultAppDeployRunner({
+      ensureTenantDb: async () => {
+        throw new Error("ensureTenantDb must NOT be called for a stateless app");
+      },
+      jobsWriter,
+      resolveImage: () => "ghcr.io/elizaos/app:test",
+    });
+
+    await runner.run(APP_ID);
+
+    // The guard refused the garbage value, so the row keeps the `deleting` flip
+    // (escalated loudly) rather than having "zombie" written back as a status.
+    expect(rows.get("container-prior")?.status).toBe("deleting");
   });
 });

--- a/packages/cloud/shared/src/lib/services/app-deploy-runner.ts
+++ b/packages/cloud/shared/src/lib/services/app-deploy-runner.ts
@@ -44,7 +44,8 @@
 
 import { ElizaError } from "@elizaos/core";
 import { appDatabasesRepository } from "../../db/repositories/app-databases";
-import { containersRepository, isContainerStatus } from "../../db/repositories/containers";
+import { isContainerStatus } from "../../db/repositories/container-status";
+import { containersRepository } from "../../db/repositories/containers";
 import { containersEnv } from "../config/containers-env";
 import { logger } from "../utils/logger";
 import { toNewContainer } from "./app-container-record";

--- a/packages/cloud/shared/src/lib/services/app-deploy-runner.ts
+++ b/packages/cloud/shared/src/lib/services/app-deploy-runner.ts
@@ -42,8 +42,9 @@
  * per-tenant DSN, never the shared agent URL — is asserted directly.
  */
 
+import { ElizaError } from "@elizaos/core";
 import { appDatabasesRepository } from "../../db/repositories/app-databases";
-import { containersRepository } from "../../db/repositories/containers";
+import { containersRepository, isContainerStatus } from "../../db/repositories/containers";
 import { containersEnv } from "../config/containers-env";
 import { logger } from "../utils/logger";
 import { toNewContainer } from "./app-container-record";
@@ -300,7 +301,12 @@ export class DefaultAppDeployRunner implements AppDeployRunner {
    * CONTAINER_DELETE is async and would otherwise race the new row's check). The
    * daemon's CONTAINER_DELETE then does the real `docker rm -f` + node-slot
    * release and flips the row to terminal `deleted`. Best-effort per row: a
-   * failure to retire one row is logged but never blocks the new deploy.
+   * failure to retire one row is logged but never blocks the new deploy. An
+   * enqueue failure AFTER the status flip additionally reverts the row to its
+   * pre-retire status: a `deleting` row with no job is permanently stuck
+   * (recovery only fans out from a claimed legacy job, and `deleting` is
+   * excluded from this retire query), whereas a reverted row is simply retried
+   * by the next deploy's retire pass (#15826).
    */
   private async retirePriorContainers(
     organizationId: string,
@@ -309,21 +315,60 @@ export class DefaultAppDeployRunner implements AppDeployRunner {
   ): Promise<void> {
     const prior = await containersRepository.findUndeletedByProjectName(organizationId, appId);
     for (const row of prior) {
+      // Captured before the flip: the revert below must restore the PRE-retire
+      // status even if the row object aliases live state mutated by updateStatus.
+      const preRetireStatus = row.status;
       try {
         // Mark `deleting` up front so it stops counting toward quota before the
         // new row's quota check; the daemon's CONTAINER_DELETE finishes the job.
         await containersRepository.updateStatus(row.id, "deleting");
+      } catch (error) {
+        // error-policy:J6 retire is best-effort teardown on the deploy path; the untouched row is retried by the next deploy's retire pass.
+        logger.warn("[AppDeployRunner] failed to retire prior container row", {
+          appId,
+          containerId: row.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        continue;
+      }
+      try {
         await enqueuer.enqueueDelete({ containerId: row.id, organizationId });
         logger.info("[AppDeployRunner] retired prior container row", {
           appId,
           containerId: row.id,
         });
       } catch (error) {
-        logger.warn("[AppDeployRunner] failed to retire prior container row", {
-          appId,
-          containerId: row.id,
-          error: error instanceof Error ? error.message : String(error),
-        });
+        // error-policy:J6 teardown stays best-effort for the deploy, but the stuck-`deleting` hazard is reverted and surfaced at error level (an enqueue failure means the jobs write path is broken — systemic, not a per-row blip).
+        const enqueueMessage = error instanceof Error ? error.message : String(error);
+        try {
+          // `containers.status` is free text at the column level; validate the
+          // read-back value before handing it to the typed writer.
+          if (!isContainerStatus(preRetireStatus)) {
+            throw new ElizaError(
+              `Container ${row.id} pre-retire status '${preRetireStatus}' is outside the containers status vocabulary`,
+              {
+                code: "CONTAINER_PRE_RETIRE_STATUS_INVALID",
+                context: { appId, containerId: row.id, preRetireStatus },
+              },
+            );
+          }
+          await containersRepository.updateStatus(row.id, preRetireStatus);
+          logger.error(
+            "[AppDeployRunner] failed to enqueue prior-container delete; reverted the row to its pre-retire status",
+            { appId, containerId: row.id, revertedTo: preRetireStatus, error: enqueueMessage },
+          );
+        } catch (revertError) {
+          // error-policy:J6 last-resort escalation: both writes failed and the row IS stuck in `deleting` with no job — surfaced at error level, never a quiet warn.
+          logger.error(
+            "[AppDeployRunner] failed to enqueue prior-container delete AND failed to revert the row — container row is stuck in deleting with no job",
+            {
+              appId,
+              containerId: row.id,
+              error: enqueueMessage,
+              revertError: revertError instanceof Error ? revertError.message : String(revertError),
+            },
+          );
+        }
       }
     }
   }


### PR DESCRIPTION
# Relates to

Fixes the secondary finding of #15826 (post-merge review of #15792). The primary finding — rm-by-shared-name in the delete executor — is deliberately **not** touched here; it belongs to the open PRs #15890 / #15869. This PR is scoped so it cannot conflict with either: it changes only `retirePriorContainers` in `app-deploy-runner.ts` plus a new DB-free status-vocabulary module (`container-status.ts`), and the retire/vocabulary tests. The containers repository file itself is byte-identical to `develop`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on the latest `origin/develop` (919d8fab6b) with zero conflicts.
- [x] Scoped verification was run after sync (package typecheck + biome + error-policy ratchet + scoped test suite + a local replication of the coverage-gate lane — exact commands and results below, full transcript linked in the evidence rows). Full workspace `bun run verify` is not runnable in this environment (unbuilt sibling-package dist artifacts unrelated to this diff); recorded in **Known gaps**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Branched from the latest `origin/develop` (919d8fab6b); zero conflicts.
- [x] Scoped verify passes post-sync (see Verification); the full-workspace blocker is documented in **Known gaps / failures**.

# Risks

**Low.** The retire loop keeps its contract — retirement stays best-effort and never blocks a deploy. The only behavior change is on the *failure* path: a failed delete-enqueue now restores the row's pre-retire status (previously: permanently stuck `deleting` row with no job) and logs at error level instead of warn. The vocabulary module is additive; `ContainerStatus` in the repository file is untouched, and `CONTAINER_STATUSES` is compile-time pinned to it (`satisfies` + an exhaustiveness `Record` in the test).

# Background

## What does this PR do?

`retirePriorContainers` (redeploy path) flips each prior container row to `deleting` and then enqueues the `CONTAINER_DELETE` job that finishes the teardown. The pre-existing best-effort catch swallowed an enqueue failure **after** the flip, which strands a `deleting` row with no job:

- recovery only fans out from a *claimed* legacy job — a row with no job is never visited;
- `deleting` rows are excluded from the next deploy's retire query (`findUndeletedByProjectName`), so no later redeploy revisits them either;
- the only signal was a single warn line.

This is exactly how the stuck staging rows in #15826 stay stuck. The fix:

1. **Split the two writes.** A failure flipping the status leaves the row untouched (warn, next deploy retries — unchanged semantics).
2. **Revert on enqueue failure.** If the delete-enqueue throws after the flip, the row is restored to its captured pre-retire status so the next deploy's retire pass picks it up again, and the failure is escalated at `error` level (an enqueue failure means the jobs write path is broken — systemic, not a per-row blip). If the revert itself also fails, the stuck state is reported loudly (`error`) instead of a quiet warn.
3. **Type-safe revert.** `containers.status` is a free-text column, so the read-back value is validated with the new `isContainerStatus` guard before being handed to the `ContainerStatus`-typed `updateStatus` writer; an out-of-vocabulary value raises an `ElizaError` (`CONTAINER_PRE_RETIRE_STATUS_INVALID`) into the loud path rather than being written blindly. The guard + `CONTAINER_STATUSES` vocabulary live in a dedicated DB-free module, `src/db/repositories/container-status.ts`, importable (and directly unit-covered) without loading the process database singletons; the repository file stays byte-identical to `develop`.

All kept catches carry `// error-policy:J<N>` annotations per the error-handling doctrine.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/services/__tests__/app-deploy-runner-retire.test.ts` — three failure-branch tests drive the real `DefaultAppDeployRunner.run()`:

- `#15826: a failed delete-enqueue reverts the row instead of stranding it in deleting` — row ends `running` (reverted, retryable), deploy proceeds;
- `#15826: a failed revert write escalates loudly and still never blocks the deploy` — both writes fail, row is stuck `deleting` but reported at error level, deploy proceeds;
- `#15826: an out-of-vocabulary pre-retire status is never written back` — a corrupted `zombie` status is refused by the guard (`CONTAINER_PRE_RETIRE_STATUS_INVALID`), never round-tripped through the typed writer.

Plus `packages/cloud/shared/src/db/repositories/__tests__/container-status.test.ts` — vocabulary exhaustiveness (compile-time `Record<ContainerStatus, true>` + runtime equality) and garbage rejection (case, padding, empty, near-misses).

## Detailed testing steps

```bash
cd packages/cloud/shared
bun test --isolate --conditions=eliza-source \
  src/lib/services/__tests__/app-deploy-runner-retire.test.ts \
  src/db/repositories/__tests__/container-status.test.ts \
  src/lib/services/__tests__/app-deploy-runner.test.ts \
  src/lib/services/__tests__/app-deploy-runner-env-dsn-teardown.test.ts \
  src/lib/services/__tests__/containers-slot-release-idempotency.test.ts \
  src/lib/services/containers/hetzner-client/metadata.error-policy.test.ts \
  src/lib/services/containers/hetzner-client/client.error-policy.test.ts
# -> 59 pass / 0 fail (129 expect() calls)

# Coverage-gate lane replicated locally (same command as .github/workflows/coverage-gate.yml):
bun test --conditions=eliza-source \
  packages/cloud/shared/src/lib/services/__tests__/app-deploy-runner-retire.test.ts \
  packages/cloud/shared/src/db/repositories/__tests__/container-status.test.ts \
  --coverage --coverage-reporter=lcov --coverage-dir=coverage/bun
COVERAGE_GATE_ENFORCE=1 awk -v changed='packages/cloud/shared/src/db/repositories/container-status.ts\npackages/cloud/shared/src/lib/services/app-deploy-runner.ts' \
  -v threshold=50 -f scripts/security/coverage-gate.awk coverage/bun/lcov.info
# -> 100.00% container-status.ts, 75.74% app-deploy-runner.ts, mean 87.87%, coverage gate OK

bun run --cwd packages/cloud/shared typecheck   # 0 TS errors
bun run --cwd packages/cloud/shared lint        # biome: no fixes applied
bun run audit:error-policy-ratchet              # no new fallback-slop in touched files
```

Full captured transcript: <https://github.com/elizaOS/eliza/releases/download/pr-evidence/15921-verification-transcript.txt>

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only change in `packages/cloud/shared` (deploy-runner retire loop + status-vocabulary module); no UI surface is affected.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only change; no UI surface is affected.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow to walk through; the behavior is a server-side failure-path state transition, proven by the linked structured logs + test assertions.
<!-- evidence-row:backend-logs -->
- [x] Backend logs — full verification transcript (scoped 59-test suite with the structured `[AppDeployRunner]` error lines for every failure branch, coverage-gate replication, typecheck, biome, error-policy ratchet): <https://github.com/elizaOS/eliza/releases/download/pr-evidence/15921-verification-transcript.txt>

  <details>
  <summary>Key excerpt — the real code path firing (revert + both loud escalation branches)</summary>

  ```
  src/lib/services/__tests__/app-deploy-runner-retire.test.ts:
  [AppDeployRunner] failed to enqueue prior-container delete; reverted the row to its pre-retire status {
    appId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
    containerId: "container-prior",
    revertedTo: "running",
    error: "jobs table unavailable",
  }
  [AppDeployRunner] failed to enqueue prior-container delete AND failed to revert the row — container row is stuck in deleting with no job {
    appId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
    containerId: "container-prior",
    error: "jobs table unavailable",
    revertError: "status write rejected: running",
  }
  [AppDeployRunner] failed to enqueue prior-container delete AND failed to revert the row — container row is stuck in deleting with no job {
    appId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
    containerId: "container-prior",
    error: "jobs table unavailable",
    revertError: "Container container-prior pre-retire status 'zombie' is outside the containers status vocabulary",
  }

   59 pass
   0 fail
   129 expect() calls
  Ran 59 tests across 7 files.
  ```

  </details>
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend involved; the change has no client-reachable surface.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model behavior changes; pure cloud-backend control flow.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact — the container-row status timeline per scenario (`running → deleting → running` reverted; `running → deleting` stuck-but-loud; `zombie` never written back), captured from the real runner: <https://github.com/elizaOS/eliza/releases/download/pr-evidence/15921-domain-artifact-container-row-states.txt>

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/model behavior changes.

## Backend + frontend logs

Backend: linked + excerpted above in the backend-logs evidence row. Frontend: N/A - no frontend surface.

## Screenshots (before / after) + video walkthrough

N/A - backend-only change; no rendered UI to capture (no files under `packages/app`, `packages/ui`, or any rendered surface are touched).

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT changes.

## Known gaps / failures

- Full-workspace `bun run verify` is not runnable in this checkout: sibling packages resolve `@elizaos/core` through built `dist/` artifacts that are absent in this worktree (pre-existing environment constraint, unrelated to this diff — reproducible on a clean `develop` checkout without a prior full build). Verification was therefore scoped to the touched package: `bun run --cwd packages/cloud/shared typecheck` (0 errors), `bun run --cwd packages/cloud/shared lint` (clean), `bun run audit:error-policy-ratchet` (clean), the 59-test touched-area suite (0 fail), and a local replication of the CI coverage-gate lane (gate OK: 100% / 75.74%, mean 87.87% vs the 50% floor). Tests use `--conditions=eliza-source` (the same source-export condition CI uses) and `--isolate` (matching the package's `test` script).
- The **primary** #15826 finding (delete executor rm-by-shared-name) is intentionally out of scope here — it is owned by the open PRs #15890 / #15869; this PR touches none of those files, so it can land before or after either.
- The producer of the original id-less `container_delete` payloads (noted in #15826) remains unidentified; this PR removes the stranding failure mode regardless of producer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
