### PR TITLE
fix(calendar): agenda no longer overprints the view switcher at mobile-landscape (#15911)

### DIFF
--- a/packages/app/test/ui-smoke/aesthetic-minimalism-baseline.json
+++ b/packages/app/test/ui-smoke/aesthetic-minimalism-baseline.json
@@ -67,9 +67,9 @@
       "whitespaceRatio": 0.8595
     },
     "plugin-calendar-gui@mobile-landscape": {
-      "borderDividerDensity": 139.7497,
-      "textDensity": 5.9242,
-      "whitespaceRatio": 0.876
+      "borderDividerDensity": 91.1411,
+      "textDensity": 3.7064,
+      "whitespaceRatio": 0.806
     },
     "plugin-calendar-gui@mobile-portrait": {
       "borderDividerDensity": 139.7497,

--- a/plugins/plugin-calendar/src/components/calendar/CalendarSpatialView.tsx
+++ b/plugins/plugin-calendar/src/components/calendar/CalendarSpatialView.tsx
@@ -84,7 +84,12 @@ export function CalendarSpatialView({
   const eventCount = snapshot.events.length;
 
   return (
-    <Card gap={1} padding={1}>
+    // shrink={0}: the host SpatialSurface is a height-constrained scrollport
+    // (overflow-y auto). Left shrinkable, a short viewport (mobile landscape,
+    // ~390px tall) compresses every toolbar/agenda row below its content
+    // height — the 44px-min buttons and two-line rows then overprint each
+    // other instead of the surface scrolling (#15911).
+    <Card gap={1} padding={1} shrink={0}>
       <HStack gap={1} align="center">
         <Text style="subheading" bold grow={1} wrap={false}>
           {snapshot.periodLabel}

--- a/plugins/plugin-calendar/src/components/calendar/CalendarView.test.tsx
+++ b/plugins/plugin-calendar/src/components/calendar/CalendarView.test.tsx
@@ -129,6 +129,22 @@ describe("CalendarView (unified spatial wrapper)", () => {
     expect(agent("mode")).toBeTruthy();
   });
 
+  it("keeps the spatial root at content height so short viewports scroll instead of overprinting rows (#15911)", () => {
+    // The host SpatialSurface is a height-constrained scrollport. If the root
+    // card is allowed to flex-shrink, a short landscape viewport compresses
+    // the toolbar/agenda rows through each other instead of scrolling.
+    const { container } = render(
+      <SpatialSurface modality="gui">
+        <CalendarView />
+      </SpatialSurface>,
+    );
+    const root = container.querySelector(
+      '[data-spatial-surface] > [data-spatial-kind="box"]',
+    ) as HTMLElement | null;
+    expect(root).toBeTruthy();
+    expect(root?.style.flexShrink).toBe("0");
+  });
+
   it("renders populated agenda events from the feed", () => {
     calendarState.current = makeResult({
       events: [


### PR DESCRIPTION
Closes #15911.

## Root cause

`DynamicViewLoader` hosts every plugin view inside a `SpatialSurface` that is a height-constrained scrollport (`overflow-y: auto`, `height: 100%`). The calendar's root `Card` compiles to a flex child with `min-height: 0` and the default `flex-shrink: 1`, so at short viewports (mobile-landscape, 844×390) the card **compressed to the scrollport height instead of overflowing into it**. Every toolbar/agenda row inside squeezed below its content height (~22px measured), and the 44px-min buttons plus two-line agenda rows overprinted the Day/Week/Month switcher and each other — while the surface never became scrollable. Mechanism proven in isolated Chromium: at constrained height the rows compress to 22–23px with `scrollable: false`; with `flex-shrink: 0` on the card they hold 44px and the surface reports `scrollable: true`.

## Fix

- `CalendarSpatialView`: pin the root card at content height (`shrink={0}`) so the host surface scrolls instead of crushing rows. Calendar-scoped and idempotent with the global `Card` default proposed in draft PR #15907 (`shrink={props.shrink ?? 0}`).
- `CalendarView.test.tsx`: render test proving the spatial root is not shrinkable (fails RED on the pre-fix code, verified).
- `aesthetic-minimalism-baseline.json`: rebaseline `plugin-calendar-gui@mobile-landscape` — the committed entry was measured against the broken, mostly-blank render (whitespace 0.876); the fixed view improves density (border/divider 139.7 → 91.1, text 5.9 → 3.7) and reports the real content's whitespace 0.806, which the ratchet otherwise read as a regression against the broken baseline.

## Verification

Scoped `audit:app` run (`--project=audit-app --grep plugin-calendar-gui`, real `dist/views/bundle.js` with `real-dist` provenance enforced), all four audit viewports:

| | before | after |
|---|---|---|
| result | `needs-eyeball` + **"New" hover probe timeout** (the same signal from the #13560 audit) | 4/4 passed, `broken=0 needs-work=0`, ratchet clean, **hover probes 0 failures** |

- `bun run --cwd plugins/plugin-calendar test` — 217 passed / 2 skipped (includes the new render test; proven RED without the fix)
- `bun run --cwd plugins/plugin-calendar typecheck` — clean
- Biome clean on touched files

<!-- evidence-row:before-screenshots -->
- [x] Before, manually reviewed — mobile-landscape shows the double-struck agenda rows over the view switcher: [mobile-landscape (broken)](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15911-before-mobile-landscape.jpg), [mobile-portrait](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15911-before-mobile-portrait.jpg), [desktop-landscape](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15911-before-desktop-landscape.jpg), [ipad-portrait](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15911-before-ipad-portrait.jpg)

![before mobile-landscape](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15911-before-mobile-landscape.jpg)

<!-- evidence-row:after-screenshots -->
- [x] After, manually reviewed — header, month nav, View+New, and Day/Week/Month chips separate; agenda rows reachable by scroll (`scrollHeight 435 > clientHeight 168`): [mobile-landscape](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15911-after-mobile-landscape.jpg), [mobile-landscape scrolled to agenda](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15911-after-mobile-landscape-scrolled.jpg), [mobile-portrait](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15911-after-mobile-portrait.jpg), [desktop-landscape](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15911-after-desktop-landscape.jpg), [ipad-portrait](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15911-after-ipad-portrait.jpg)

![after mobile-landscape](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15911-after-mobile-landscape.jpg)
![after mobile-landscape scrolled](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15911-after-mobile-landscape-scrolled.jpg)

No regression at the other three viewports: the before/after mobile-portrait and desktop-landscape captures are pixel-identical; ipad-portrait is unchanged.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - single-view CSS flex layout fix; the before/after captures at all four audit viewports plus the scrolled-agenda capture show the full extent of the change (no flow or interaction changed).
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend route, service, data, or model behavior changes; frontend-only flex layout.
<!-- evidence-row:frontend-logs -->
- [x] Audit harness console-error capture: 0 non-network console errors for plugin-calendar-gui at all four viewports (enforced by the audit spec's `must not throw an uncaught page error` assertion, 4/4 green).
<!-- evidence-row:trajectories -->
- [x] N/A - no agent/action/provider/prompt/model behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
