### PR TITLE
fix(ui): unify shell and composer voice mute state

### DIFF
--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -367,6 +367,8 @@ const selectShellController = (s: AppContextValue) => ({
   setTab: s.setTab,
   handleChatStop: s.handleChatStop,
   setActionNotice: s.setActionNotice,
+  chatAgentVoiceMuted: s.chatAgentVoiceMuted,
+  setState: s.setState,
 });
 
 export function useShellController(): ShellController {
@@ -385,6 +387,8 @@ export function useShellController(): ShellController {
     setTab,
     handleChatStop,
     setActionNotice,
+    chatAgentVoiceMuted,
+    setState,
   } = useAppSelectorShallow(selectShellController);
   // The wake phrase for transcript-mode inline replies follows the character
   // name (issue #9880); falls back to the running agent name, then "eliza".
@@ -1344,6 +1348,10 @@ export function useShellController(): ShellController {
     if (captureRef.current) stopCapture();
   }, [stopCapture]);
 
+  const toggleAgentVoiceMute = React.useCallback(() => {
+    setState("chatAgentVoiceMuted", !chatAgentVoiceMuted);
+  }, [chatAgentVoiceMuted, setState]);
+
   const voiceOutput = useShellVoiceOutput({
     conversationMessages: Array.isArray(conversationMessages)
       ? conversationMessages
@@ -1351,6 +1359,8 @@ export function useShellController(): ShellController {
     chatSending,
     recording,
     lastTurnVoice,
+    agentVoiceMuted: chatAgentVoiceMuted,
+    toggleAgentVoiceMute,
     uiLanguage,
     cloudConnected: elizaCloudVoiceProxyAvailable,
   });

--- a/packages/ui/src/components/shell/useShellVoiceOutput.test.tsx
+++ b/packages/ui/src/components/shell/useShellVoiceOutput.test.tsx
@@ -74,6 +74,8 @@ const BASE: ShellVoiceOutputOptions = {
   chatSending: false,
   recording: false,
   lastTurnVoice: false,
+  agentVoiceMuted: false,
+  toggleAgentVoiceMute: vi.fn(),
   uiLanguage: "en",
   cloudConnected: false,
 };
@@ -266,16 +268,30 @@ describe("useShellVoiceOutput", () => {
     expect(hoisted.stopSpeaking).toHaveBeenCalled();
   });
 
-  it("mutes: stops in-flight speech and silences later replies", () => {
+  it("uses the shared mute state, stops speech, and silences later replies", () => {
+    const toggleAgentVoiceMute = vi.fn();
+    const firstMessages = [userMsg("u1", "hi"), assistantMsg("a1", "First.")];
     const { result, rerender } = render({
       ...BASE,
       lastTurnVoice: true,
-      conversationMessages: [userMsg("u1", "hi"), assistantMsg("a1", "First.")],
+      toggleAgentVoiceMute,
+      conversationMessages: firstMessages,
     });
     expect(hoisted.queueAssistantSpeech).toHaveBeenCalledTimes(1);
 
     act(() => {
       result.current.toggleAgentVoiceMute();
+    });
+    expect(toggleAgentVoiceMute).toHaveBeenCalledTimes(1);
+
+    // AppContext commits the shared mute state. The shell immediately stops the
+    // same playback and reads muted everywhere the composer does.
+    rerender({
+      ...BASE,
+      lastTurnVoice: true,
+      agentVoiceMuted: true,
+      toggleAgentVoiceMute,
+      conversationMessages: firstMessages,
     });
     expect(result.current.agentVoiceMuted).toBe(true);
     expect(hoisted.stopSpeaking).toHaveBeenCalled();
@@ -284,9 +300,10 @@ describe("useShellVoiceOutput", () => {
     rerender({
       ...BASE,
       lastTurnVoice: true,
+      agentVoiceMuted: true,
+      toggleAgentVoiceMute,
       conversationMessages: [
-        userMsg("u1", "hi"),
-        assistantMsg("a1", "First."),
+        ...firstMessages,
         userMsg("u2", "again"),
         assistantMsg("a2", "Second."),
       ],

--- a/packages/ui/src/components/shell/useShellVoiceOutput.ts
+++ b/packages/ui/src/components/shell/useShellVoiceOutput.ts
@@ -60,6 +60,10 @@ export interface ShellVoiceOutputOptions {
   recording: boolean;
   /** True when the latest user turn was voice-originated (`VOICE_DM`). */
   lastTurnVoice: boolean;
+  /** Shared composer/shell mute state from AppContext. */
+  agentVoiceMuted: boolean;
+  /** Toggle the shared composer/shell mute state. */
+  toggleAgentVoiceMute: () => void;
   uiLanguage: string;
   cloudConnected: boolean;
 }
@@ -83,12 +87,13 @@ export function useShellVoiceOutput(
     chatSending,
     recording,
     lastTurnVoice,
+    agentVoiceMuted,
+    toggleAgentVoiceMute,
     uiLanguage,
     cloudConnected,
   } = options;
 
   const { voiceConfig, voiceBootstrapTick } = useVoiceConfig(uiLanguage);
-  const [agentVoiceMuted, setAgentVoiceMuted] = React.useState(false);
 
   const {
     queueAssistantSpeech,
@@ -175,10 +180,6 @@ export function useShellVoiceOutput(
   React.useEffect(() => {
     if (agentVoiceMuted) stopSpeaking();
   }, [agentVoiceMuted, stopSpeaking]);
-
-  const toggleAgentVoiceMute = React.useCallback(() => {
-    setAgentVoiceMuted((muted) => !muted);
-  }, []);
 
   return {
     speaking: isSpeaking,


### PR DESCRIPTION
[sol-cloud]

## Summary

- remove the shell-local assistant voice mute boolean
- make `useShellVoiceOutput` consume the same `AppContext.chatAgentVoiceMuted` state used by ChatView/composer
- keep the existing stop-in-flight and suppress-future-speech behavior, now synchronized across both voice surfaces
- add a focused controlled-state regression test

## Why this slice

The composer and shell still have separate input state machines, so a full consolidation is too risky for one PR. Mute was a proven, isolated duplicate truth source: ChatView used shared AppContext state while the shell initialized its own `useState(false)`. This is the smallest safe first step toward removing voice behavior drift.

No capture transitions, streaming, auto-send policy, provider selection, defaults, native bridges, or barge-in behavior changed.

## Test plan

Passed:

- `bunx @biomejs/biome check packages/ui/src/components/shell/useShellVoiceOutput.ts packages/ui/src/components/shell/useShellVoiceOutput.test.tsx packages/ui/src/components/shell/useShellController.ts`
- `bun run --cwd packages/ui test src/components/shell/useShellVoiceOutput.test.tsx` (13/13)
- `git diff --check`
- `codex review --uncommitted` (no findings)

Environment-limited in the fresh worktree:

- `useShellController.test.tsx` cannot import ungenerated `packages/core/src/i18n/generated/validation-keyword-data.ts`
- full UI typecheck cannot resolve numerous optional/workspace dependencies from the borrowed install and reports broad unrelated setup failures

A full state inventory and exact follow-up PR sequence are recorded in `~/.moltbot/projects/eliza-fleet/VOICE-STATE-UNIFICATION-PLAN.md`.

Co-authored-by: wakesync <shadow@shad0w.xyz>


## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: https://github.com/elizaOS/eliza/releases/download/pr-evidence/before-voice-mute.png

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: https://github.com/elizaOS/eliza/releases/download/pr-evidence/after-voice-mute.png

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: https://github.com/elizaOS/eliza/releases/download/pr-evidence/walkthrough-voice-mute.mp4

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - client-side voice state owner unification; no backend code path changed`.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: https://github.com/elizaOS/eliza/releases/download/pr-evidence/frontend-test-log.txt

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no LLM behavior or prompt/runtime path changed`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no domain artifacts produced; targeted regression test covers the state-owner behavior`.
