### PR TITLE
fix(ci): format plugin-openrouter after #15777

### DIFF
--- a/plugins/plugin-openrouter/__tests__/anthropic-cache.shape.test.ts
+++ b/plugins/plugin-openrouter/__tests__/anthropic-cache.shape.test.ts
@@ -13,11 +13,15 @@ function createRuntime(settings: Record<string, string> = {}) {
     character: { system: "system prompt" },
     emitEvent: vi.fn(async () => undefined),
     getSetting: vi.fn((key: string) => {
-      return ({
-        OPENROUTER_API_KEY: "test-key",
-        OPENROUTER_LARGE_MODEL: "anthropic/claude-opus-4-8",
-        ...settings,
-      } as Record<string, string>)[key] ?? null;
+      return (
+        (
+          {
+            OPENROUTER_API_KEY: "test-key",
+            OPENROUTER_LARGE_MODEL: "anthropic/claude-opus-4-8",
+            ...settings,
+          } as Record<string, string>
+        )[key] ?? null
+      );
     }),
   } as IAgentRuntime;
 }
@@ -62,15 +66,15 @@ describe("Anthropic cache injection — runtime cacheControl fallback", () => {
     const { generateText } = mockModules();
     const { handleTextLarge } = await import("../models/text");
 
-    await handleTextLarge(
-      createRuntime({ ANTHROPIC_PROMPT_CACHE_TTL: "1h" }),
-      { prompt: "hello" } as never,
-    );
+    await handleTextLarge(createRuntime({ ANTHROPIC_PROMPT_CACHE_TTL: "1h" }), {
+      prompt: "hello",
+    } as never);
 
     const call = generateText.mock.calls[0][0] as Record<string, unknown>;
     const messages = call.messages as Array<Record<string, unknown>>;
-    const anthropicOpts = (messages?.[0]?.providerOptions as Record<string, unknown>)
-      ?.anthropic as Record<string, unknown> | undefined;
+    const anthropicOpts = (messages?.[0]?.providerOptions as Record<string, unknown>)?.anthropic as
+      | Record<string, unknown>
+      | undefined;
     expect(anthropicOpts?.cacheControl).toEqual({ type: "ephemeral", ttl: "1h" });
   });
 
@@ -83,7 +87,7 @@ describe("Anthropic cache injection — runtime cacheControl fallback", () => {
         OPENROUTER_LARGE_MODEL: "google/gemini-2.5-flash",
         ANTHROPIC_PROMPT_CACHE_TTL: "1h",
       }),
-      { prompt: "hello" } as never,
+      { prompt: "hello" } as never
     );
 
     const call = generateText.mock.calls[0][0] as Record<string, unknown>;
@@ -130,18 +134,15 @@ describe("Anthropic cache injection — internal field stripping", () => {
     const { generateText } = mockModules();
     const { handleTextLarge } = await import("../models/text");
 
-    await handleTextLarge(
-      createRuntime({ OPENROUTER_LARGE_MODEL: "anthropic/claude-opus-4-8" }),
-      {
-        messages: [
-          { role: "system", content: "system prompt" },
-          { role: "user", content: "hello" },
-        ],
-        providerOptions: {
-          anthropic: { cacheSystem: true, thinking: { type: "enabled" } },
-        },
-      } as never,
-    );
+    await handleTextLarge(createRuntime({ OPENROUTER_LARGE_MODEL: "anthropic/claude-opus-4-8" }), {
+      messages: [
+        { role: "system", content: "system prompt" },
+        { role: "user", content: "hello" },
+      ],
+      providerOptions: {
+        anthropic: { cacheSystem: true, thinking: { type: "enabled" } },
+      },
+    } as never);
 
     const call = generateText.mock.calls[0][0] as Record<string, unknown>;
     const wireAnthropic = (call.providerOptions as Record<string, unknown> | undefined)
@@ -175,8 +176,9 @@ describe("Anthropic cache injection — segmented user content", () => {
     const content = userMsg?.content as Array<Record<string, unknown>>;
     expect(content).toHaveLength(2);
     expect(content[0]?.text).toBe("seg1");
-    const seg0Opts = (content[0]?.providerOptions as Record<string, unknown>)
-      ?.anthropic as Record<string, unknown> | undefined;
+    const seg0Opts = (content[0]?.providerOptions as Record<string, unknown>)?.anthropic as
+      | Record<string, unknown>
+      | undefined;
     expect(seg0Opts?.cacheControl).toEqual({ type: "ephemeral" });
     expect(content[1]?.text).toBe("seg2");
     expect(content[1]?.providerOptions).toBeUndefined();
@@ -242,8 +244,7 @@ describe("Anthropic cache injection — segmented user content", () => {
     const userMsg = messages?.[1];
     const content = userMsg?.content as Array<Record<string, unknown>>;
     const cachedBlocks = content?.filter(
-      (b) =>
-        (b.providerOptions as Record<string, unknown> | undefined)?.anthropic !== undefined,
+      (b) => (b.providerOptions as Record<string, unknown> | undefined)?.anthropic !== undefined
     );
     // Only segmentIndex 0 survives the cap of 1
     expect(cachedBlocks).toHaveLength(1);

--- a/plugins/plugin-openrouter/models/text.ts
+++ b/plugins/plugin-openrouter/models/text.ts
@@ -317,7 +317,7 @@ function isAnthropicCacheBreakpoint(value: unknown): value is AnthropicCacheBrea
 
 function readAnthropicCacheBreakpoints(
   anthropicOptions: Record<string, unknown> | undefined,
-  maxBreakpoints: number,
+  maxBreakpoints: number
 ): AnthropicCacheBreakpoint[] {
   const raw = anthropicOptions?.cacheBreakpoints;
   if (!Array.isArray(raw)) return [];
@@ -333,13 +333,13 @@ function readAnthropicCacheBreakpoints(
  */
 function buildSegmentedPromptUserContent(
   promptSegments: Array<{ content: string; stable?: boolean }>,
-  cacheBreakpoints: AnthropicCacheBreakpoint[],
+  cacheBreakpoints: AnthropicCacheBreakpoint[]
 ): CacheableTextPart[] {
   if (cacheBreakpoints.length === 0) {
     return promptSegments.map((seg) => ({ type: "text" as const, text: seg.content }));
   }
   const breakpointMap = new Map<number, AnthropicCacheControl>(
-    cacheBreakpoints.map((bp) => [bp.segmentIndex, bp.cacheControl]),
+    cacheBreakpoints.map((bp) => [bp.segmentIndex, bp.cacheControl])
   );
   return promptSegments.map((seg, index) => {
     const cc = breakpointMap.get(index);
@@ -609,9 +609,10 @@ function buildGenerateParams(
       : 3;
   const cacheBreakpoints = readAnthropicCacheBreakpoints(anthropicOptions, maxBreakpoints);
   const promptSegments = Array.isArray(
-    (paramsWithAttachments as { promptSegments?: unknown }).promptSegments,
+    (paramsWithAttachments as { promptSegments?: unknown }).promptSegments
   )
-    ? ((paramsWithAttachments as { promptSegments?: Array<{ content: string; stable?: boolean }> }).promptSegments ?? [])
+    ? ((paramsWithAttachments as { promptSegments?: Array<{ content: string; stable?: boolean }> })
+        .promptSegments ?? [])
     : [];
 
   let finalWireMessages = wireMessages;
@@ -648,7 +649,10 @@ function buildGenerateParams(
                 // additional breakpoints under Anthropic's four-block cap).
                 content:
                   promptSegments.length > 0 && cacheBreakpoints.length > 0 && !userContent
-                    ? (buildSegmentedPromptUserContent(promptSegments, cacheBreakpoints) as UserContent)
+                    ? (buildSegmentedPromptUserContent(
+                        promptSegments,
+                        cacheBreakpoints
+                      ) as UserContent)
                     : (userContent ?? buildUserContent(paramsWithAttachments)),
               },
             ],


### PR DESCRIPTION
Quality (Extended)'s "Format + Type Safety Ratchet" job fails `format:check` on `@elizaos/plugin-openrouter` since the external cache_control fix #15777 merged unformatted (run [29066189508](https://github.com/elizaOS/eliza/actions/runs/29066189508)).

`bunx biome format --write` on the package (2 files); package tests green after. Formatting-only — the ratchet's type-safety counters were already at/below baseline in the failing run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)