### PR TITLE
fix(cloud): restore Kokoro TTS fast path

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -554,7 +554,15 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: bunx wrangler deploy ${{ steps.env.outputs.wrangler_args }} --var ELIZA_DEPLOY_COMMIT:"$GITHUB_SHA"
+          KOKORO_TTS_URL: ${{ vars.ELIZA_VOICE_KOKORO_TTS_URL }}
+        run: |
+          args=(${{ steps.env.outputs.wrangler_args }} --var ELIZA_DEPLOY_COMMIT:"$GITHUB_SHA")
+          if [ -n "${KOKORO_TTS_URL:-}" ]; then
+            args+=(--var KOKORO_TTS_URL:"$KOKORO_TTS_URL")
+          else
+            echo "::notice::ELIZA_VOICE_KOKORO_TTS_URL is not configured; deploying without KOKORO_TTS_URL"
+          fi
+          bunx wrangler deploy "${args[@]}"
 
       - name: Verify deployed API commit
         if: steps.cf.outputs.configured == 'true' && steps.freshness.outputs.should_deploy == 'true'

--- a/packages/cloud/api/v1/voice/tts/__tests__/provider-selection.test.ts
+++ b/packages/cloud/api/v1/voice/tts/__tests__/provider-selection.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Regression coverage for cloud TTS provider selection.
+ *
+ * The helper is intentionally pure so typo handling and free-default routing
+ * can be verified without reaching auth, billing, or either synthesis upstream.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { selectTtsProvider } from "../provider-selection";
+
+describe("selectTtsProvider", () => {
+  test("selects configured Kokoro for omitted voice and known Kokoro ids", () => {
+    expect(
+      selectTtsProvider({ kokoroConfigured: true, voiceId: undefined }),
+    ).toEqual({
+      ok: true,
+      provider: "kokoro",
+      voiceId: "af_heart",
+      fallbackReason: "configured-default",
+    });
+
+    expect(
+      selectTtsProvider({ kokoroConfigured: true, voiceId: "af_bella" }),
+    ).toEqual({
+      ok: true,
+      provider: "kokoro",
+      voiceId: "af_bella",
+      fallbackReason: "explicit-kokoro",
+    });
+  });
+
+  test("rejects unsupported Kokoro-shaped voice ids before any upstream path", () => {
+    const selection = selectTtsProvider({
+      kokoroConfigured: true,
+      voiceId: "af_not_a_voice",
+    });
+
+    expect(selection).toEqual({
+      ok: false,
+      provider: "kokoro",
+      status: 400,
+      code: "unsupported_kokoro_voice",
+      error: "Unsupported Kokoro voice ID: af_not_a_voice",
+      fallbackReason: "unsupported-explicit-kokoro",
+    });
+  });
+
+  test("fails known Kokoro ids clearly when Kokoro is unconfigured", () => {
+    expect(
+      selectTtsProvider({ kokoroConfigured: false, voiceId: "af_heart" }),
+    ).toEqual({
+      ok: false,
+      provider: "kokoro",
+      status: 503,
+      code: "kokoro_unconfigured",
+      error: "Kokoro TTS is not configured for this environment.",
+      fallbackReason: "explicit-kokoro-unconfigured",
+    });
+  });
+
+  test("routes the proxy-injected legacy default to configured Kokoro", () => {
+    expect(
+      selectTtsProvider({
+        kokoroConfigured: true,
+        voiceId: "EXAVITQu4vr4xnSDxMaL",
+      }),
+    ).toEqual({
+      ok: true,
+      provider: "kokoro",
+      voiceId: "af_heart",
+      fallbackReason: "configured-default-compat",
+    });
+  });
+
+  test("returns fallback metadata while preserving ElevenLabs custom voices", () => {
+    expect(
+      selectTtsProvider({ kokoroConfigured: false, voiceId: undefined }),
+    ).toEqual({
+      ok: true,
+      provider: "elevenlabs",
+      fallbackReason: "kokoro-unconfigured-default",
+    });
+
+    expect(
+      selectTtsProvider({
+        kokoroConfigured: true,
+        voiceId: "JBFqnCBsd6RMkjVDRZzb",
+      }),
+    ).toEqual({
+      ok: true,
+      provider: "elevenlabs",
+      voiceId: "JBFqnCBsd6RMkjVDRZzb",
+      fallbackReason: "custom-or-elevenlabs-voice",
+    });
+  });
+});

--- a/packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts
+++ b/packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts
@@ -44,14 +44,17 @@ let cachedVoiceResponse: {
   contentType: string;
   hitCount: number;
 } | null = null;
-const fetchMock = mock<typeof fetch>(async () => {
-  if (allowKokoroFetch) {
-    return new Response(new Uint8Array([82, 73, 70, 70]), {
-      headers: { "Content-Type": "audio/wav" },
-    });
-  }
-  throw new Error("fetch must not be called for selection failures");
-});
+const fetchMock = Object.assign(
+  mock(async (..._args: Parameters<typeof fetch>): Promise<Response> => {
+    if (allowKokoroFetch) {
+      return new Response(new Uint8Array([82, 73, 70, 70]), {
+        headers: { "Content-Type": "audio/wav" },
+      });
+    }
+    throw new Error("fetch must not be called for selection failures");
+  }),
+  { preconnect: () => undefined },
+) satisfies typeof fetch;
 const realFetch = globalThis.fetch;
 
 mock.module("@/lib/api/cloud-worker-errors", () => ({
@@ -223,7 +226,11 @@ describe("POST /api/v1/voice/tts provider selection", () => {
     const serverTiming = response.headers.get("Server-Timing") ?? "";
     expect(serverTiming).toContain("auth;dur=");
     expect(serverTiming).toContain("admission;dur=");
-    expect(await response.json()).toEqual({
+    const body = (await response.json()) as {
+      error: string;
+      code: string;
+    };
+    expect(body).toEqual({
       error: "Unsupported Kokoro voice ID: af_not_a_voice",
       code: "unsupported_kokoro_voice",
     });
@@ -237,7 +244,11 @@ describe("POST /api/v1/voice/tts provider selection", () => {
     expect(response.status).toBe(503);
     expect(response.headers.get("X-Eliza-TTS-Provider")).toBe("kokoro");
     expect(response.headers.get("Server-Timing")).toContain("admission;dur=");
-    expect(await response.json()).toEqual({
+    const body = (await response.json()) as {
+      error: string;
+      code: string;
+    };
+    expect(body).toEqual({
       error: "Kokoro TTS is not configured for this environment.",
       code: "kokoro_unconfigured",
     });

--- a/packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts
+++ b/packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts
@@ -20,7 +20,30 @@ const requireAuthOrApiKeyWithOrg = mock(async () => ({
   apiKey: null,
 }));
 const assertSafeForPublicUse = mock(async () => undefined);
+const reserveCredits = mock(async () => ({
+  reconcile: async () => undefined,
+}));
+const billUsage = mock(async () => ({
+  totalCost: 0.001,
+  baseTotalCost: 0.001,
+  platformMarkup: 0,
+}));
+const elevenLabsTextToSpeech = mock(
+  async () =>
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([73, 68, 51]));
+        controller.close();
+      },
+    }),
+);
 let allowKokoroFetch = false;
+let cachedVoiceResponse: {
+  bytes: Uint8Array;
+  byteSize: number;
+  contentType: string;
+  hitCount: number;
+} | null = null;
 const fetchMock = mock<typeof fetch>(async () => {
   if (allowKokoroFetch) {
     return new Response(new Uint8Array([82, 73, 70, 70]), {
@@ -61,11 +84,7 @@ mock.module("@/lib/services/ai-pricing", () => ({
 }));
 
 mock.module("@/lib/services/ai-billing", () => ({
-  billFlatUsage: async () => ({
-    totalCost: 0.001,
-    baseTotalCost: 0.001,
-    platformMarkup: 0,
-  }),
+  billFlatUsage: billUsage,
 }));
 
 mock.module("@/lib/services/credits", () => {
@@ -74,22 +93,18 @@ mock.module("@/lib/services/credits", () => {
   }
   return {
     InsufficientCreditsError,
-    creditsService: {
-      reserve: async () => ({ reconcile: async () => undefined }),
-    },
+    creditsService: { reserve: reserveCredits },
   };
 });
 
 mock.module("@/lib/services/elevenlabs", () => ({
-  getElevenLabsService: () => ({
-    textToSpeech: async () => new ReadableStream(),
-  }),
+  getElevenLabsService: () => ({ textToSpeech: elevenLabsTextToSpeech }),
 }));
 
 mock.module("@/lib/services/tts-first-line-cache", () => ({
   fingerprintCloudVoiceSettings: () => "fp-test",
   getCloudFirstLineCacheService: () => ({
-    get: async () => null,
+    get: async () => cachedVoiceResponse,
     has: async () => true,
     put: async () => true,
   }),
@@ -129,8 +144,12 @@ beforeAll(async () => {
 
 beforeEach(() => {
   allowKokoroFetch = false;
+  cachedVoiceResponse = null;
   fetchMock.mockClear();
   assertSafeForPublicUse.mockClear();
+  reserveCredits.mockClear();
+  billUsage.mockClear();
+  elevenLabsTextToSpeech.mockClear();
 });
 
 afterAll(() => {
@@ -165,6 +184,34 @@ describe("POST /api/v1/voice/tts provider selection", () => {
     expect(assertSafeForPublicUse).toHaveBeenCalledTimes(1);
   });
 
+  test("serves a configured Kokoro cache hit with provider timing headers", async () => {
+    cachedVoiceResponse = {
+      bytes: new Uint8Array([82, 73, 70, 70]),
+      byteSize: 4,
+      contentType: "audio/wav",
+      hitCount: 2,
+    };
+
+    const response = await postTts(
+      { text: "Hello.", voiceId: "af_heart" },
+      {
+        KOKORO_TTS_URL: "https://kokoro.example.test",
+        KOKORO_FIRST_LINE_CACHE: "1",
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("X-Eliza-TTS-Provider")).toBe("kokoro");
+    expect(response.headers.get("X-TTS-Cache")).toBe(
+      "hit; kokoro; first-sentence",
+    );
+    expect(response.headers.get("Server-Timing")).toContain("synthesis;dur=");
+    expect(await response.arrayBuffer()).toEqual(
+      new Uint8Array([82, 73, 70, 70]).buffer,
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   test("rejects unsupported Kokoro-shaped voice ids with clear 4xx and no upstream call", async () => {
     const response = await postTts(
       { text: "Hello.", voiceId: "af_not_a_voice" },
@@ -182,5 +229,47 @@ describe("POST /api/v1/voice/tts provider selection", () => {
     });
     expect(fetchMock).not.toHaveBeenCalled();
     expect(assertSafeForPublicUse).not.toHaveBeenCalled();
+  });
+
+  test("fails a Kokoro voice fast when the provider is unconfigured", async () => {
+    const response = await postTts({ text: "Hello.", voiceId: "af_heart" });
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("X-Eliza-TTS-Provider")).toBe("kokoro");
+    expect(response.headers.get("Server-Timing")).toContain("admission;dur=");
+    expect(await response.json()).toEqual({
+      error: "Kokoro TTS is not configured for this environment.",
+      code: "kokoro_unconfigured",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(assertSafeForPublicUse).not.toHaveBeenCalled();
+    expect(elevenLabsTextToSpeech).not.toHaveBeenCalled();
+  });
+
+  test("preserves ElevenLabs routing and observability for a custom voice", async () => {
+    const response = await postTts({
+      text: "Hello from a custom voice.",
+      voiceId: "custom-elevenlabs-voice",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("audio/mpeg");
+    expect(response.headers.get("X-Eliza-TTS-Provider")).toBe("elevenlabs");
+    const serverTiming = response.headers.get("Server-Timing") ?? "";
+    expect(serverTiming).toContain("auth;dur=");
+    expect(serverTiming).toContain("admission;dur=");
+    expect(serverTiming).toContain("synthesis;dur=");
+    expect(await response.arrayBuffer()).toEqual(
+      new Uint8Array([73, 68, 51]).buffer,
+    );
+    expect(elevenLabsTextToSpeech).toHaveBeenCalledTimes(1);
+    expect(elevenLabsTextToSpeech).toHaveBeenCalledWith({
+      text: "Hello from a custom voice.",
+      voiceId: "custom-elevenlabs-voice",
+      modelId: undefined,
+    });
+    expect(reserveCredits).toHaveBeenCalledTimes(1);
+    expect(billUsage).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts
+++ b/packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Route-level regression coverage for cloud TTS provider admission.
+ *
+ * These tests stop before synthesis so unsupported Kokoro ids can be proven to
+ * fail without touching either upstream provider.
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+const requireAuthOrApiKeyWithOrg = mock(async () => ({
+  user: { id: "user-1", organization_id: "org-1" },
+  apiKey: null,
+}));
+const assertSafeForPublicUse = mock(async () => undefined);
+let allowKokoroFetch = false;
+const fetchMock = mock<typeof fetch>(async () => {
+  if (allowKokoroFetch) {
+    return new Response(new Uint8Array([82, 73, 70, 70]), {
+      headers: { "Content-Type": "audio/wav" },
+    });
+  }
+  throw new Error("fetch must not be called for selection failures");
+});
+const realFetch = globalThis.fetch;
+
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  ApiError: class ApiError extends Error {
+    statusCode = 500;
+  },
+}));
+
+mock.module("@/lib/auth", () => ({
+  requireAuthOrApiKeyWithOrg,
+}));
+
+mock.module("@/db/repositories/user-voices", () => ({
+  userVoicesRepository: {
+    findByElevenLabsVoiceId: async () => null,
+    incrementUsageCount: async () => undefined,
+  },
+}));
+
+mock.module("@/lib/services/content-safety", () => ({
+  contentSafetyService: { assertSafeForPublicUse },
+}));
+
+mock.module("@/lib/services/ai-pricing", () => ({
+  calculateTTSCostFromCatalog: async () => ({
+    totalCost: 0.001,
+    baseTotalCost: 0.001,
+    platformMarkup: 0,
+  }),
+}));
+
+mock.module("@/lib/services/ai-billing", () => ({
+  billFlatUsage: async () => ({
+    totalCost: 0.001,
+    baseTotalCost: 0.001,
+    platformMarkup: 0,
+  }),
+}));
+
+mock.module("@/lib/services/credits", () => {
+  class InsufficientCreditsError extends Error {
+    required = 0;
+  }
+  return {
+    InsufficientCreditsError,
+    creditsService: {
+      reserve: async () => ({ reconcile: async () => undefined }),
+    },
+  };
+});
+
+mock.module("@/lib/services/elevenlabs", () => ({
+  getElevenLabsService: () => ({
+    textToSpeech: async () => new ReadableStream(),
+  }),
+}));
+
+mock.module("@/lib/services/tts-first-line-cache", () => ({
+  fingerprintCloudVoiceSettings: () => "fp-test",
+  getCloudFirstLineCacheService: () => ({
+    get: async () => null,
+    has: async () => true,
+    put: async () => true,
+  }),
+  shouldBypassCloudFirstLineCache: () => true,
+}));
+
+mock.module("@/lib/services/usage", () => ({
+  usageService: { create: async () => undefined },
+}));
+
+mock.module("@/lib/pricing-constants", () => ({
+  CUSTOM_VOICE_TTS_MARKUP: 1.2,
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+    debug: () => undefined,
+  },
+}));
+
+let route: {
+  default: {
+    fetch: (
+      request: Request,
+      env?: Record<string, unknown>,
+    ) => Promise<Response>;
+  };
+};
+
+beforeAll(async () => {
+  globalThis.fetch = fetchMock;
+  route = (await import("../route")) as typeof route;
+});
+
+beforeEach(() => {
+  allowKokoroFetch = false;
+  fetchMock.mockClear();
+  assertSafeForPublicUse.mockClear();
+});
+
+afterAll(() => {
+  globalThis.fetch = realFetch;
+});
+
+function postTts(body: unknown, env: Record<string, unknown> = {}) {
+  return route.default.fetch(
+    new Request("http://test.local/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    env,
+  );
+}
+
+describe("POST /api/v1/voice/tts provider selection", () => {
+  test("uses Kokoro for the proxy-injected legacy default when configured", async () => {
+    allowKokoroFetch = true;
+    const response = await postTts(
+      { text: "Hello.", voiceId: "EXAVITQu4vr4xnSDxMaL" },
+      { KOKORO_TTS_URL: "https://kokoro.example.test" },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("X-Eliza-TTS-Provider")).toBe("kokoro");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "https://kokoro.example.test/api/tts",
+    );
+    expect(assertSafeForPublicUse).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects unsupported Kokoro-shaped voice ids with clear 4xx and no upstream call", async () => {
+    const response = await postTts(
+      { text: "Hello.", voiceId: "af_not_a_voice" },
+      { KOKORO_TTS_URL: "https://kokoro.example.test" },
+    );
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("X-Eliza-TTS-Provider")).toBe("kokoro");
+    const serverTiming = response.headers.get("Server-Timing") ?? "";
+    expect(serverTiming).toContain("auth;dur=");
+    expect(serverTiming).toContain("admission;dur=");
+    expect(await response.json()).toEqual({
+      error: "Unsupported Kokoro voice ID: af_not_a_voice",
+      code: "unsupported_kokoro_voice",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(assertSafeForPublicUse).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/voice/tts/provider-selection.ts
+++ b/packages/cloud/api/v1/voice/tts/provider-selection.ts
@@ -1,0 +1,139 @@
+/**
+ * Provider selection for the cloud voice TTS route.
+ *
+ * The route keeps Kokoro as the free default when it is configured, while
+ * preserving arbitrary ElevenLabs voice ids for custom voices. Explicit
+ * Kokoro-shaped ids are fail-closed so a typo never waits on, or bills through,
+ * the ElevenLabs upstream.
+ */
+
+const DEFAULT_KOKORO_VOICE_ID = "af_heart";
+/** Default injected by the existing cloud TTS proxy when callers omit voiceId. */
+const LEGACY_DEFAULT_ELEVENLABS_VOICE_ID = "EXAVITQu4vr4xnSDxMaL";
+const KOKORO_VOICE_ID_PATTERN = /^[ab][fm]_[a-z0-9][a-z0-9_-]*$/;
+
+export const KOKORO_VOICE_IDS = new Set([
+  DEFAULT_KOKORO_VOICE_ID,
+  "af_bella",
+  "af_sarah",
+  "af_nicole",
+  "af_sky",
+  "am_michael",
+  "am_adam",
+  "bf_emma",
+  "bf_isabella",
+  "bm_george",
+  "bm_lewis",
+]);
+
+export type TtsProvider = "kokoro" | "elevenlabs";
+
+export type TtsProviderSelection =
+  | {
+      ok: true;
+      provider: "kokoro";
+      voiceId: string;
+      fallbackReason:
+        | "configured-default"
+        | "configured-default-compat"
+        | "explicit-kokoro";
+    }
+  | {
+      ok: true;
+      provider: "elevenlabs";
+      voiceId?: string;
+      fallbackReason:
+        | "kokoro-unconfigured-default"
+        | "custom-or-elevenlabs-voice";
+    }
+  | {
+      ok: false;
+      provider: "kokoro";
+      status: 400 | 503;
+      code: "unsupported_kokoro_voice" | "kokoro_unconfigured";
+      error: string;
+      fallbackReason:
+        | "unsupported-explicit-kokoro"
+        | "explicit-kokoro-unconfigured";
+    };
+
+export function isKokoroVoiceId(voiceId: string): boolean {
+  return KOKORO_VOICE_IDS.has(voiceId);
+}
+
+export function isKokoroShapedVoiceId(voiceId: string): boolean {
+  return KOKORO_VOICE_ID_PATTERN.test(voiceId);
+}
+
+export function selectTtsProvider(args: {
+  voiceId?: string;
+  kokoroConfigured: boolean;
+}): TtsProviderSelection {
+  const voiceId = args.voiceId?.trim();
+
+  if (!voiceId) {
+    if (args.kokoroConfigured) {
+      return {
+        ok: true,
+        provider: "kokoro",
+        voiceId: DEFAULT_KOKORO_VOICE_ID,
+        fallbackReason: "configured-default",
+      };
+    }
+    return {
+      ok: true,
+      provider: "elevenlabs",
+      fallbackReason: "kokoro-unconfigured-default",
+    };
+  }
+
+  // The server cloud proxy normalizes omitted/OpenAI/Edge voice names to this
+  // legacy ElevenLabs default before forwarding. Treat it as the product
+  // default when Kokoro is available, while retaining the legacy fallback when
+  // Kokoro is not configured.
+  if (args.kokoroConfigured && voiceId === LEGACY_DEFAULT_ELEVENLABS_VOICE_ID) {
+    return {
+      ok: true,
+      provider: "kokoro",
+      voiceId: DEFAULT_KOKORO_VOICE_ID,
+      fallbackReason: "configured-default-compat",
+    };
+  }
+
+  if (isKokoroVoiceId(voiceId)) {
+    if (args.kokoroConfigured) {
+      return {
+        ok: true,
+        provider: "kokoro",
+        voiceId,
+        fallbackReason: "explicit-kokoro",
+      };
+    }
+    return {
+      ok: false,
+      provider: "kokoro",
+      status: 503,
+      code: "kokoro_unconfigured",
+      error: "Kokoro TTS is not configured for this environment.",
+      fallbackReason: "explicit-kokoro-unconfigured",
+    };
+  }
+
+  if (isKokoroShapedVoiceId(voiceId)) {
+    return {
+      ok: false,
+      provider: "kokoro",
+      status: 400,
+      code: "unsupported_kokoro_voice",
+      error: `Unsupported Kokoro voice ID: ${voiceId}`,
+      fallbackReason: "unsupported-explicit-kokoro",
+    };
+  }
+
+  return {
+    ok: true,
+    provider: "elevenlabs",
+    voiceId,
+    fallbackReason: "custom-or-elevenlabs-voice",
+  };
+}

--- a/packages/cloud/api/v1/voice/tts/route.ts
+++ b/packages/cloud/api/v1/voice/tts/route.ts
@@ -56,6 +56,7 @@ import {
   buildKokoroCacheKey,
   isKokoroFirstLineCacheEnabled,
 } from "./kokoro-first-line-cache";
+import { selectTtsProvider, type TtsProvider } from "./provider-selection";
 
 /**
  * Default ElevenLabs output format. Must stay in sync with the ElevenLabs
@@ -84,6 +85,34 @@ const TtsBody = z.object({
   modelId: z.string().optional(),
 });
 
+interface TtsTimings {
+  authMs?: number;
+  admissionMs?: number;
+  synthesisMs?: number;
+}
+
+function buildTtsObservabilityHeaders(
+  provider: TtsProvider,
+  timings: TtsTimings,
+): Record<string, string> {
+  const serverTiming = [
+    timings.authMs !== undefined ? `auth;dur=${timings.authMs}` : null,
+    timings.admissionMs !== undefined
+      ? `admission;dur=${timings.admissionMs}`
+      : null,
+    timings.synthesisMs !== undefined
+      ? `synthesis;dur=${timings.synthesisMs}`
+      : null,
+  ].filter((entry): entry is string => entry !== null);
+
+  return {
+    "X-Eliza-TTS-Provider": provider,
+    ...(serverTiming.length > 0
+      ? { "Server-Timing": serverTiming.join(", ") }
+      : {}),
+  };
+}
+
 /**
  * POST /api/v1/voice/tts
  * Converts text to speech using the voice synthesis service.
@@ -93,32 +122,15 @@ const TtsBody = z.object({
  * @param request - Request body with text, voiceId, and optional modelId.
  * @returns Streaming audio response (audio/mpeg).
  */
-/**
- * The Kokoro voice ids the self-hosted service ships. Map an incoming voiceId to
- * a Kokoro voice when it matches; otherwise fall back to the default `af_heart`.
- */
-const KOKORO_VOICE_IDS = new Set([
-  "af_heart",
-  "af_bella",
-  "af_sarah",
-  "af_nicole",
-  "af_sky",
-  "am_michael",
-  "am_adam",
-  "bf_emma",
-  "bf_isabella",
-  "bm_george",
-  "bm_lewis",
-]);
-function resolveKokoroVoice(voiceId?: string): string {
-  return voiceId && KOKORO_VOICE_IDS.has(voiceId) ? voiceId : "af_heart";
-}
-
 async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
   let reservation: CreditReservation | undefined;
+  const requestStart = Date.now();
+  const timings: TtsTimings = {};
 
   try {
     const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
+    timings.authMs = Date.now() - requestStart;
+    const admissionStart = Date.now();
 
     const rawBody = await request.json();
     const parsed = TtsBody.safeParse(rawBody);
@@ -129,6 +141,11 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
       );
     }
     const { text, voiceId, modelId } = parsed.data;
+    const kokoroBaseUrl = env.KOKORO_TTS_URL?.trim();
+    const providerSelection = selectTtsProvider({
+      voiceId,
+      kokoroConfigured: Boolean(kokoroBaseUrl),
+    });
 
     if (!text) {
       return Response.json({ error: "No text provided" }, { status: 400 });
@@ -147,6 +164,28 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
       );
     }
 
+    if (!providerSelection.ok) {
+      timings.admissionMs = Date.now() - admissionStart;
+      logger.warn?.("[Voice TTS API] TTS provider selection failed", {
+        provider: providerSelection.provider,
+        fallbackReason: providerSelection.fallbackReason,
+        code: providerSelection.code,
+      });
+      return Response.json(
+        {
+          error: providerSelection.error,
+          code: providerSelection.code,
+        },
+        {
+          status: providerSelection.status,
+          headers: buildTtsObservabilityHeaders(
+            providerSelection.provider,
+            timings,
+          ),
+        },
+      );
+    }
+
     await contentSafetyService.assertSafeForPublicUse({
       surface: "media_generation_prompt",
       organizationId: user.organization_id,
@@ -158,16 +197,20 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
     logger.info(
       `[Voice TTS API] Generating speech for user ${user.id}: ${text.length} chars`,
     );
+    logger.info("[Voice TTS API] Selected TTS provider", {
+      provider: providerSelection.provider,
+      fallbackReason: providerSelection.fallbackReason,
+      voiceId: providerSelection.voiceId ?? "default",
+    });
 
     // -------------------------------------------------------------------------
     // Free default voice: self-hosted Kokoro TTS. When KOKORO_TTS_URL is set this
-    // is the product default — no credit reservation, no billing. ElevenLabs
-    // (custom voices / opt-in) is the path below. Inert when KOKORO_TTS_URL is
-    // unset, so existing ElevenLabs behavior is unchanged.
+    // is the product default — no credit reservation, no billing. Explicit
+    // custom/ElevenLabs voice ids continue down the paid provider path.
     // -------------------------------------------------------------------------
-    const kokoroBaseUrl = env.KOKORO_TTS_URL?.trim();
-    if (kokoroBaseUrl) {
-      const kokoroVoice = resolveKokoroVoice(voiceId);
+    if (providerSelection.provider === "kokoro") {
+      const kokoroVoice = providerSelection.voiceId;
+      timings.admissionMs = Date.now() - admissionStart;
 
       // First-line cache (#14375), gated on the #14370 TTFB benchmark and off by
       // default. Only WHOLE-input short openers ("Got it.") are cacheable — the
@@ -189,9 +232,11 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
 
       if (kokoroCacheKey) {
         try {
+          const cacheStart = Date.now();
           const cached =
             await getCloudFirstLineCacheService().get(kokoroCacheKey);
           if (cached) {
+            timings.synthesisMs = Date.now() - cacheStart;
             logger.info(
               `[Voice TTS API] Kokoro first-line cache HIT (${cached.byteSize}B, hits=${cached.hitCount}, voice=${kokoroVoice}) — no upstream request`,
             );
@@ -200,6 +245,7 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
               headers: {
                 "Content-Type": cached.contentType,
                 "Cache-Control": "no-cache",
+                ...buildTtsObservabilityHeaders("kokoro", timings),
                 "X-TTS-Cache": "hit; kokoro; first-sentence",
               },
             });
@@ -215,7 +261,7 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
 
       const kokoroStart = Date.now();
       const kokoroResponse = await fetch(
-        `${kokoroBaseUrl.replace(/\/+$/, "")}/api/tts`,
+        `${kokoroBaseUrl!.replace(/\/+$/, "")}/api/tts`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -223,10 +269,10 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
           signal: AbortSignal.timeout(30_000),
         },
       );
+      timings.synthesisMs = Date.now() - kokoroStart;
       if (!kokoroResponse.ok || !kokoroResponse.body) {
-        const detail = await kokoroResponse.text().catch(() => "");
         logger.error(
-          `[Voice TTS API] Kokoro synthesis failed (${kokoroResponse.status}): ${detail.slice(0, 200)}`,
+          `[Voice TTS API] Kokoro synthesis failed (${kokoroResponse.status})`,
         );
         return Response.json(
           { error: "TTS synthesis failed" },
@@ -256,7 +302,7 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
           .then((ok) => {
             if (ok) {
               logger.info(
-                `[Voice TTS API] Kokoro first-line cache POPULATE ok (${bytes.byteLength}B, "${kokoroSnip.normalized}")`,
+                `[Voice TTS API] Kokoro first-line cache POPULATE ok (${bytes.byteLength}B, words=${kokoroSnip.wordCount})`,
               );
             }
           })
@@ -273,6 +319,7 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
           headers: {
             "Content-Type": kokoroContentType,
             "Cache-Control": "no-store",
+            ...buildTtsObservabilityHeaders("kokoro", timings),
             "X-TTS-Cache": "miss; kokoro",
           },
         });
@@ -283,6 +330,7 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
         headers: {
           "Content-Type": kokoroContentType,
           "Cache-Control": "no-store",
+          ...buildTtsObservabilityHeaders("kokoro", timings),
         },
       });
     }
@@ -333,6 +381,7 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
     const voiceSettingsFingerprint = fingerprintCloudVoiceSettings({
       outputFormat: DEFAULT_OUTPUT_FORMAT,
     });
+    timings.admissionMs = Date.now() - admissionStart;
 
     if (
       snipResult &&
@@ -342,6 +391,7 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
       snipResult.endOffset === text.trimEnd().length
     ) {
       try {
+        const cacheStart = Date.now();
         const cacheService = getCloudFirstLineCacheService();
         const cached = await cacheService.get({
           algoVersion: FIRST_SENTENCE_SNIP_VERSION,
@@ -358,6 +408,7 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
           scope: cacheScope,
         });
         if (cached) {
+          timings.synthesisMs = Date.now() - cacheStart;
           logger.info(
             `[Voice TTS API] first-line cache HIT (${cacheScope}, ${cached.byteSize}B, hits=${cached.hitCount})`,
           );
@@ -365,12 +416,14 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
             headers: {
               "Content-Type": cached.contentType,
               "Cache-Control": "no-cache",
+              ...buildTtsObservabilityHeaders("elevenlabs", timings),
               "X-TTS-Cache": "hit; first-sentence",
             },
           });
         }
       } catch (err) {
-        // Cache failure is non-fatal — fall through to normal synthesis.
+        // error-policy:J4 cache lookup failure degrades to fresh synthesis; the
+        // ElevenLabs request below remains the source of truth.
         logger.warn?.(
           `[Voice TTS API] first-line cache lookup failed: ${err instanceof Error ? err.message : String(err)}`,
         );
@@ -405,6 +458,7 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
       }
       throw error;
     }
+    timings.admissionMs = Date.now() - admissionStart;
 
     const elevenlabs = getElevenLabsService(env);
 
@@ -415,8 +469,13 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
       modelId,
     });
     const duration = Date.now() - startTime;
+    timings.synthesisMs = duration;
 
-    logger.info(`[Voice TTS API] Stream started in ${duration}ms`);
+    logger.info("[Voice TTS API] Stream started", {
+      provider: "elevenlabs",
+      fallbackReason: providerSelection.fallbackReason,
+      durationMs: duration,
+    });
 
     const billing = await billFlatUsage(
       {
@@ -539,7 +598,7 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
             wordCount: snipResult.wordCount,
           });
           logger.info(
-            `[Voice TTS API] first-line cache POPULATE ok (${cacheScope}, ${total}B, "${snipResult.normalized}")`,
+            `[Voice TTS API] first-line cache POPULATE ok (${cacheScope}, ${total}B, words=${snipResult.wordCount})`,
           );
         } catch (err) {
           logger.warn?.(
@@ -554,6 +613,7 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
         "Content-Type": "audio/mpeg",
         "Transfer-Encoding": "chunked",
         "Cache-Control": "no-cache",
+        ...buildTtsObservabilityHeaders("elevenlabs", timings),
         "X-TTS-Cache": "miss",
       },
     });


### PR DESCRIPTION
# Relates to

Staging voice latency investigation: default TTS first byte P50 was ~2.7s, and explicit `af_heart` was incorrectly forwarded to ElevenLabs, returning a slow HTTP 400.

- [x] This PR targets `develop` and was created from fresh `origin/develop` with zero conflicts.
- [ ] `bun install` and `bun run verify` were not run. Focused tests and formatting pass; the package typecheck is blocked by pre-existing missing workspace dependencies in this worktree, documented below.
- [x] A reviewer can confirm provider selection and the no-upstream rejection behavior from the focused route tests below.

# Sync with develop

- [x] Branched from `origin/develop` at `238a04d435` with zero conflicts.
- [ ] Full `bun run verify` is blocked as documented in **Known gaps / failures**.

# Risks

Low to medium. The default shared-cloud voice switches from paid ElevenLabs to free Kokoro only when `KOKORO_TTS_URL` is configured. Explicit ordinary ElevenLabs voice IDs continue to use ElevenLabs. Explicit Kokoro IDs now fail fast if the service is unavailable instead of being sent to ElevenLabs.

# Background

## What does this PR do?

- Adds explicit, testable TTS provider selection.
- Routes omitted voice IDs and the legacy default ID injected by the cloud proxy (`EXAVITQu4vr4xnSDxMaL`) to `af_heart` on configured Kokoro environments.
- Preserves explicit custom ElevenLabs voices.
- Rejects unsupported Kokoro-shaped IDs with immediate HTTP 400 and configured Kokoro IDs with immediate HTTP 503 when Kokoro is unavailable, before content safety, credit admission, or upstream synthesis.
- Publishes environment-scoped `vars.ELIZA_VOICE_KOKORO_TTS_URL` into the Worker as `KOKORO_TTS_URL` during deploy, without hardcoding an endpoint.
- Adds `X-Eliza-TTS-Provider` and `Server-Timing` (`auth`, `admission`, `synthesis`) on successful synthesis/cache responses, plus structured provider/fallback logs.

## What kind of change is this?

Bug fix and observability improvement.

# Documentation changes needed?

No user-facing documentation change. Deployment owner action is documented below and the existing Kokoro service README already defines the Railway contract.

# Testing

## Where should a reviewer start?

- `packages/cloud/api/v1/voice/tts/provider-selection.ts`
- `packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts`
- `.github/workflows/cloud-cf-deploy.yml`

## Detailed testing steps

```bash
bun test \
  packages/cloud/api/v1/voice/tts/__tests__/provider-selection.test.ts \
  packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts
# 7 pass, 0 fail, 19 expect() calls

bunx @biomejs/biome check \
  packages/cloud/api/v1/voice/tts/provider-selection.ts \
  packages/cloud/api/v1/voice/tts/route.ts \
  packages/cloud/api/v1/voice/tts/__tests__/provider-selection.test.ts \
  packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts
# Checked 4 files. No fixes applied.

bun run audit:error-policy-ratchet
# no new fallback-slop in touched files
```

Codex review found the first implementation missed the legacy proxy-injected default ID. That was fixed with route-level coverage. A second `codex review --uncommitted` returned: `No discrete correctness issues were found in the changed files.`

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend Worker routing change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend Worker routing change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI flow changed; live Kokoro endpoint is not configured in repository environments yet.
<!-- evidence-row:backend-logs -->
- [x] N/A - live backend path cannot fire until the owner deploys Kokoro and configures the environment variable; deterministic route tests verify URL, provider header, and zero-fetch failures.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no LLM/action/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - audio capture requires the not-yet-configured live Kokoro service.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM path changed.

## Backend + frontend logs

N/A for live logs. Focused route evidence:

- configured Kokoro + proxy-injected legacy default calls `https://kokoro.example.test/api/tts` once and returns `X-Eliza-TTS-Provider: kokoro`;
- unsupported `af_not_a_real_voice` returns 400 with `unsupported_kokoro_voice`, with zero safety/admission/upstream calls;
- explicit `af_heart` without Kokoro returns 503 with `kokoro_unconfigured`, with zero safety/admission/upstream calls.

## Screenshots (before / after) + video walkthrough

N/A - backend-only.

## Audio / voice walkthrough

N/A until the deployment owner provisions the Kokoro service and environment URL.

## Known gaps / failures

- `gh variable list --repo elizaOS/eliza --env staging` and `--env production` show no `ELIZA_VOICE_KOKORO_TTS_URL`. This PR supplies the missing deploy propagation, but does not invent or hardcode a service URL.
- `bun run --cwd packages/cloud/api typecheck` fails in this reused local dependency tree on existing missing modules such as `ai`, `viem`, `stripe`, and generated i18n files. Filtering the output showed no diagnostics in the touched `v1/voice/tts` files.
- Full `bun install`/`bun run verify` was not run to avoid modifying `bun.lock`; focused tests, Biome, diff checks, error-policy ratchet, and two Codex reviews were run.

# Deploy Notes

Owner action after merge:

1. Deploy/verify `packages/cloud/services/voice-kokoro-tts` and confirm `GET /health` returns 200.
2. Set the public base URL, with no `/api/tts` suffix, as the environment-scoped GitHub Actions variable `ELIZA_VOICE_KOKORO_TTS_URL` in **staging**.
3. Run `Cloud CF Deploy` for staging. The workflow publishes it as Worker `KOKORO_TTS_URL`.
4. Call `/api/v1/voice/tts` with the normal shared-runtime request and verify `X-Eliza-TTS-Provider: kokoro` plus `Server-Timing`.
5. Call with `af_not_a_real_voice` and verify a fast 400 with no multi-second upstream wait.
6. Repeat for production only after staging audio quality and latency are accepted.
