### PR TITLE
fix(cloud): serialize shared agent tier upgrades

### DIFF
--- a/packages/cloud/api/__tests__/eliza-agents-upgrade-tier.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-upgrade-tier.test.ts
@@ -33,6 +33,10 @@ const CHARACTER_A = "eeeeeeee-1111-4111-8111-111111111111";
 const SHARED_A = "cccccccc-1111-4111-8111-111111111111";
 const SHARED_A_STOPPED = "cccccccc-3333-4333-8333-333333333333";
 const DEDICATED_A = "cccccccc-4444-4444-8444-444444444444";
+const SHARED_RESUME = "cccccccc-7777-4777-8777-777777777777";
+const STOPPED_TARGET = "cccccccc-8888-4888-8888-888888888888";
+const SLEEPING_TARGET = "cccccccc-9999-4999-8999-999999999999";
+const SHARED_CONCURRENT = "cccccccc-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
 const SHARED_B = "cccccccc-2222-4222-8222-222222222222";
 const MISSING = "dddddddd-9999-4999-8999-999999999999";
 
@@ -280,6 +284,52 @@ describe("POST /api/v1/eliza/agents/:agentId/upgrade-tier", () => {
     );
   });
 
+  test("stopped and sleeping targets cannot restart below the hosting runway", async () => {
+    expect(pgliteReady).toBe(true);
+    const { dbWrite } = await import("@/db/client");
+    const { agentSandboxes } = await import("@/db/schemas/agent-sandboxes");
+    const { jobs } = await import("@/db/schemas/jobs");
+    await dbWrite.insert(agentSandboxes).values({
+      id: SHARED_RESUME,
+      organization_id: ORG_A,
+      user_id: USER_A,
+      agent_name: "Resume Source",
+      execution_tier: "shared",
+      status: "running",
+      database_status: "none",
+    });
+
+    for (const [targetId, status] of [
+      [STOPPED_TARGET, "stopped"],
+      [SLEEPING_TARGET, "sleeping"],
+    ] as const) {
+      await dbWrite.insert(agentSandboxes).values({
+        id: targetId,
+        organization_id: ORG_A,
+        user_id: USER_A,
+        agent_name: `Resume ${status}`,
+        agent_config: { __agentUpgradedFrom: SHARED_RESUME },
+        execution_tier: "dedicated-always",
+        status,
+        database_status: "none",
+      });
+
+      const res = await upgrade(SHARED_RESUME);
+      expect(res.status).toBe(402);
+      const body = (await res.json()) as { code: string };
+      expect(body.code).toBe("insufficient_credits");
+      const targetJobs = await dbWrite
+        .select()
+        .from(jobs)
+        .where(eq(jobs.agent_id, targetId));
+      expect(targetJobs).toHaveLength(0);
+
+      await dbWrite
+        .delete(agentSandboxes)
+        .where(eq(agentSandboxes.id, targetId));
+    }
+  });
+
   test("funded upgrade mints a dedicated-always target with the identity copied server-side", async () => {
     expect(pgliteReady).toBe(true);
     await setOrgBalance(ORG_A, "10");
@@ -399,6 +449,47 @@ describe("POST /api/v1/eliza/agents/:agentId/upgrade-tier", () => {
       .where(eq(jobs.agent_id, target.id));
     expect(jobRows.length).toBe(1);
     expect(body.data.jobId).toBe(jobRows[0]?.id ?? "");
+  });
+
+  test("concurrent upgrades atomically converge on one target and one job", async () => {
+    expect(pgliteReady).toBe(true);
+    const { dbWrite } = await import("@/db/client");
+    const { agentSandboxes } = await import("@/db/schemas/agent-sandboxes");
+    const { jobs } = await import("@/db/schemas/jobs");
+    await dbWrite.insert(agentSandboxes).values({
+      id: SHARED_CONCURRENT,
+      organization_id: ORG_A,
+      user_id: USER_A,
+      agent_name: "Concurrent Source",
+      execution_tier: "shared",
+      status: "running",
+      database_status: "none",
+    });
+
+    const responses = await Promise.all(
+      Array.from({ length: 8 }, () => upgrade(SHARED_CONCURRENT)),
+    );
+    expect(responses.every((response) => response.status === 202)).toBe(true);
+    const bodies = (await Promise.all(
+      responses.map((response) => response.json()),
+    )) as Array<{ data: { dedicatedAgentId: string; jobId: string } }>;
+    const targetIds = new Set(bodies.map((body) => body.data.dedicatedAgentId));
+    const jobIds = new Set(bodies.map((body) => body.data.jobId));
+    expect(targetIds.size).toBe(1);
+    expect(jobIds.size).toBe(1);
+
+    const targets = (await dbWrite.select().from(agentSandboxes)).filter(
+      (agent) =>
+        (agent.agent_config as Record<string, unknown> | null)
+          ?.__agentUpgradedFrom === SHARED_CONCURRENT,
+    );
+    expect(targets).toHaveLength(1);
+    const targetJobs = await dbWrite
+      .select()
+      .from(jobs)
+      .where(eq(jobs.agent_id, targets[0]!.id));
+    expect(targetJobs).toHaveLength(1);
+    expect(targetJobs[0]?.id).toBe([...jobIds][0]);
   });
 
   test("a RUNNING in-flight target reattaches without a job (client goes straight to handoff)", async () => {

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/upgrade-tier/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/upgrade-tier/route.ts
@@ -25,8 +25,8 @@
  *    reconstruct identity from DTOs (onboarding-created shared agents keep
  *    name/bio only in agent_config).
  *  - 2xx `alreadyInProgress:true` reattach when this shared agent already has a
- *    live migration target (the `__agentUpgradedFrom` marker): a retry or a
- *    second tab must resume the SAME upgrade, never mint a second container.
+ *    live migration target (the `__agentUpgradedFrom` marker): a per-source
+ *    database lock makes retries and concurrent tabs resume the SAME upgrade.
  */
 
 import { Hono } from "hono";
@@ -38,9 +38,10 @@ import { getMaxNonTerminalAgentsForOrg } from "@/lib/constants/agent-sandbox-quo
 import { checkAgentTierUpgradeCreditGate } from "@/lib/services/agent-billing-gate";
 import { insufficientCredits402 } from "@/lib/services/agent-billing-gate-402";
 import {
-  AGENT_UPGRADED_FROM_KEY,
-  readUpgradedFromAgentId,
-} from "@/lib/services/eliza-agent-config";
+  createTierUpgradeTarget,
+  findActiveTierUpgradeProvisionJob,
+} from "@/lib/services/agent-tier-upgrade-target";
+import { readUpgradedFromAgentId } from "@/lib/services/eliza-agent-config";
 import { prepareManagedElizaEnvironment } from "@/lib/services/eliza-managed-launch";
 import {
   AgentQuotaExceededError,
@@ -83,6 +84,21 @@ function pollingBody(jobId: string) {
   };
 }
 
+async function waitForConcurrentProvisionJob(
+  agentId: string,
+  organizationId: string,
+) {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    const job = await findActiveTierUpgradeProvisionJob(
+      agentId,
+      organizationId,
+    );
+    if (job) return job;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return undefined;
+}
+
 function asConfigRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -100,9 +116,8 @@ function asEnvRecord(value: unknown): Record<string, string> {
 
 /**
  * The org's live migration target for this shared agent, if one exists.
- * Best-effort dedup for the realistic retry cases (double-click, client retry,
- * reload mid-provision); a sub-second concurrent race can still double-mint,
- * bounded by the per-org agent quota the create enforces.
+ * The atomic find-or-create service repeats this lookup under its per-source
+ * database lock before inserting, closing the concurrent double-mint window.
  */
 async function findLiveUpgradeTarget(
   organizationId: string,
@@ -208,10 +223,10 @@ async function __hono_POST(
     }
 
     // ── Reattach: an upgrade for this shared agent is already under way. ──
-    // No credit gate here — nothing new is minted, and blocking the reattach
-    // would strand a user whose balance dipped AFTER the (gated) mint while
-    // the container is already provisioned/billing. Ongoing solvency is owned
-    // by the billing cron + low-credit shutdown, not this route.
+    // Running and already-provisioning targets reattach without a second gate:
+    // nothing new starts billing. Resuming a stopped/sleeping target does start
+    // compute again, so that path must prove the same dedicated runway as a
+    // fresh upgrade before it may enqueue work.
     const existingTarget = await findLiveUpgradeTarget(
       user.organization_id,
       agentId,
@@ -238,6 +253,29 @@ async function __hono_POST(
             executionTier: existingTarget.execution_tier,
           },
         });
+      }
+      if (
+        existingTarget.status === "stopped" ||
+        existingTarget.status === "sleeping"
+      ) {
+        const resumeCreditCheck = await checkAgentTierUpgradeCreditGate(
+          user.organization_id,
+        );
+        if (!resumeCreditCheck.allowed) {
+          return json(
+            insufficientCredits402(
+              resumeCreditCheck,
+              "[agent-upgrade-tier] Resume blocked: insufficient hosting runway",
+              {
+                sharedAgentId: agentId,
+                dedicatedAgentId: existingTarget.id,
+                orgId: user.organization_id,
+              },
+              { requiredBalance: AGENT_PRICING.UPGRADE_MINIMUM_BALANCE },
+            ),
+            402,
+          );
+        }
       }
       // pending/provisioning (or stopped/sleeping after an interrupted boot):
       // hand back the active provision job — enqueue reuses an in-flight job
@@ -304,20 +342,16 @@ async function __hono_POST(
     const sourceEnv = stripReservedEnvKeys(
       asEnvRecord(shared.environment_vars),
     );
-    let created: Awaited<ReturnType<typeof elizaSandboxService.createAgent>>;
+    let created: Awaited<ReturnType<typeof createTierUpgradeTarget>>;
     try {
-      created = await elizaSandboxService.createAgent({
+      created = await createTierUpgradeTarget({
+        sourceAgentId: agentId,
         organizationId: user.organization_id,
         userId: user.id,
         agentName: shared.agent_name ?? agentId,
         ...(shared.character_id ? { characterId: shared.character_id } : {}),
         agentConfig: sourceConfig,
         environmentVars: sourceEnv,
-        executionTier: "dedicated-always",
-        // The shared source is itself a live non-terminal agent — the reuse
-        // guard would hand it straight back, so the migration target must be a
-        // forced fresh record, bounded by the balance-tiered org quota.
-        reuseExistingNonTerminal: false,
         maxNonTerminalAgents: getMaxNonTerminalAgentsForOrg(
           creditCheck.balance,
         ),
@@ -345,21 +379,107 @@ async function __hono_POST(
     }
     const dedicated = created.agent;
 
+    if (created.idempotent) {
+      if (dedicated.status === "running") {
+        return json({
+          success: true,
+          created: false,
+          alreadyInProgress: true,
+          data: {
+            id: dedicated.id,
+            agentId: dedicated.id,
+            dedicatedAgentId: dedicated.id,
+            sharedAgentId: agentId,
+            agentName: dedicated.agent_name,
+            status: dedicated.status,
+            executionTier: dedicated.execution_tier,
+          },
+        });
+      }
+      const concurrentJob = await waitForConcurrentProvisionJob(
+        dedicated.id,
+        user.organization_id,
+      );
+      if (concurrentJob) {
+        return json(
+          {
+            success: true,
+            created: false,
+            alreadyInProgress: true,
+            data: {
+              id: dedicated.id,
+              agentId: dedicated.id,
+              dedicatedAgentId: dedicated.id,
+              sharedAgentId: agentId,
+              agentName: dedicated.agent_name,
+              status: concurrentJob.status,
+              jobId: concurrentJob.id,
+              estimatedCompletionAt: concurrentJob.estimated_completion_at,
+              executionTier: dedicated.execution_tier,
+            },
+            polling: pollingBody(concurrentJob.id),
+          },
+          202,
+        );
+      }
+      const workerHealth = await checkProvisioningWorkerHealth();
+      if (!workerHealth.ok) {
+        return json(
+          provisioningWorkerFailureBody(workerHealth),
+          workerHealth.status,
+        );
+      }
+      const managedEnvironment = await prepareManagedElizaEnvironment({
+        existingEnv: sourceEnv,
+        organizationId: user.organization_id,
+        userId: user.id,
+        agentSandboxId: dedicated.id,
+      });
+      if (managedEnvironment.changed) {
+        await elizaSandboxService.updateAgentEnvironment(
+          dedicated.id,
+          user.organization_id,
+          managedEnvironment.environmentVars,
+        );
+      }
+      const reattach = await provisioningJobService.enqueueAgentProvisionOnce({
+        agentId: dedicated.id,
+        organizationId: user.organization_id,
+        userId: user.id,
+        agentName: dedicated.agent_name ?? dedicated.id,
+      });
+      if (reattach.created) {
+        void provisioningJobService.triggerImmediate(env).catch(() => {
+          // error-policy:J5 fire-and-forget nudge; the job is persisted and the
+          // provisioning cron is the safety net (failure logged in the service).
+        });
+      }
+      return json(
+        {
+          success: true,
+          created: false,
+          alreadyInProgress: true,
+          data: {
+            id: dedicated.id,
+            agentId: dedicated.id,
+            dedicatedAgentId: dedicated.id,
+            sharedAgentId: agentId,
+            agentName: dedicated.agent_name,
+            status: reattach.job.status,
+            jobId: reattach.job.id,
+            estimatedCompletionAt: reattach.job.estimated_completion_at,
+            executionTier: dedicated.execution_tier,
+          },
+          polling: pollingBody(reattach.job.id),
+        },
+        202,
+      );
+    }
+
     return await withUpgradeOrphanCleanup(
       dedicated.id,
       user.organization_id,
       async () => {
-        // Persist the upgrade marker FIRST so a crash after this point still
-        // leaves a reattachable target (the marker is what retries key on).
-        // buildAgentInsertData strips the reserved `__agent` namespace from
-        // caller config, so the marker must be written post-create.
-        await agentSandboxesRepository.update(dedicated.id, {
-          agent_config: {
-            ...asConfigRecord(dedicated.agent_config),
-            [AGENT_UPGRADED_FROM_KEY]: agentId,
-          },
-        });
-
         const managedEnvironment = await prepareManagedElizaEnvironment({
           existingEnv: sourceEnv,
           organizationId: user.organization_id,
@@ -401,7 +521,7 @@ async function __hono_POST(
           );
         }
 
-        const job = await provisioningJobService.enqueueAgentProvision({
+        const { job } = await provisioningJobService.enqueueAgentProvisionOnce({
           agentId: dedicated.id,
           organizationId: user.organization_id,
           userId: user.id,

--- a/packages/cloud/shared/src/lib/services/agent-tier-upgrade-target.ts
+++ b/packages/cloud/shared/src/lib/services/agent-tier-upgrade-target.ts
@@ -1,0 +1,119 @@
+/**
+ * Atomically creates or rejoins the dedicated target for a shared-agent tier
+ * upgrade. The route consumes this narrow persistence boundary so target
+ * identity, quota enforcement, and concurrent request convergence share one
+ * transaction without broadening the general sandbox lifecycle service.
+ */
+
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
+import { dbWrite } from "../../db/helpers";
+import { type AgentSandbox, type AgentSandboxStatus } from "../../db/repositories/agent-sandboxes";
+import { jobsRepository } from "../../db/repositories/jobs";
+import { agentSandboxes } from "../../db/schemas/agent-sandboxes";
+import { encryptAgentEnvVarsForStorage } from "./agent-env-crypto";
+import {
+  AGENT_UPGRADED_FROM_KEY,
+  stripReservedElizaConfigKeys,
+  withReusedElizaCharacterOwnership,
+} from "./eliza-agent-config";
+import { elizaAgentTierUpgradeAdvisoryLockSql } from "./eliza-provision-lock";
+import { AgentQuotaExceededError } from "./eliza-sandbox";
+import { JOB_TYPES } from "./provisioning-job-types";
+
+const LIVE_TARGET_STATUSES: AgentSandboxStatus[] = [
+  "pending",
+  "provisioning",
+  "running",
+  "stopped",
+  "sleeping",
+];
+
+export interface CreateTierUpgradeTargetParams {
+  sourceAgentId: string;
+  organizationId: string;
+  userId: string;
+  agentName: string;
+  agentConfig?: Record<string, unknown>;
+  environmentVars?: Record<string, string>;
+  characterId?: string;
+  maxNonTerminalAgents: number;
+}
+
+export async function createTierUpgradeTarget(
+  params: CreateTierUpgradeTargetParams,
+): Promise<{ agent: AgentSandbox; idempotent: boolean }> {
+  const environmentVars = params.environmentVars
+    ? await encryptAgentEnvVarsForStorage(params.organizationId, params.environmentVars)
+    : {};
+  const sanitizedConfig = stripReservedElizaConfigKeys(params.agentConfig);
+  const agentConfig = params.characterId
+    ? withReusedElizaCharacterOwnership(sanitizedConfig)
+    : sanitizedConfig;
+
+  return dbWrite.transaction(async (tx) => {
+    await tx.execute(
+      elizaAgentTierUpgradeAdvisoryLockSql(params.organizationId, params.sourceAgentId),
+    );
+
+    const [existing] = await tx
+      .select()
+      .from(agentSandboxes)
+      .where(
+        and(
+          eq(agentSandboxes.organization_id, params.organizationId),
+          eq(agentSandboxes.execution_tier, "dedicated-always"),
+          inArray(agentSandboxes.status, LIVE_TARGET_STATUSES),
+          sql`${agentSandboxes.agent_config} ->> ${AGENT_UPGRADED_FROM_KEY} = ${params.sourceAgentId}`,
+        ),
+      )
+      .orderBy(desc(agentSandboxes.created_at))
+      .limit(1);
+    if (existing) return { agent: existing, idempotent: true };
+
+    const [{ count } = { count: 0 }] = await tx
+      .select({ count: sql<number>`count(*)::int` })
+      .from(agentSandboxes)
+      .where(
+        and(
+          eq(agentSandboxes.organization_id, params.organizationId),
+          sql`${agentSandboxes.pool_status} IS NULL`,
+          inArray(agentSandboxes.status, LIVE_TARGET_STATUSES),
+        ),
+      );
+    if (count >= params.maxNonTerminalAgents) {
+      throw new AgentQuotaExceededError(count, params.maxNonTerminalAgents);
+    }
+
+    const [created] = await tx
+      .insert(agentSandboxes)
+      .values({
+        organization_id: params.organizationId,
+        user_id: params.userId,
+        agent_name: params.agentName,
+        agent_config: {
+          ...agentConfig,
+          [AGENT_UPGRADED_FROM_KEY]: params.sourceAgentId,
+        },
+        environment_vars: environmentVars,
+        execution_tier: "dedicated-always",
+        status: "pending",
+        database_status: "none",
+        ...(params.characterId ? { character_id: params.characterId } : {}),
+      })
+      .returning();
+    if (!created) throw new Error("Failed to create tier-upgrade target");
+    return { agent: created, idempotent: false };
+  });
+}
+
+/** Returns the active provision job created by a winning concurrent request. */
+export async function findActiveTierUpgradeProvisionJob(agentId: string, organizationId: string) {
+  const jobs = await jobsRepository.findByDataFieldForWrite({
+    type: JOB_TYPES.AGENT_PROVISION,
+    organizationId,
+    dataField: "agentId",
+    dataValue: agentId,
+    orderBy: "desc",
+  });
+  return jobs.find((job) => job.status === "pending" || job.status === "in_progress");
+}

--- a/packages/cloud/shared/src/lib/services/eliza-provision-lock.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-provision-lock.ts
@@ -31,3 +31,15 @@ export function elizaCodingContainerImageAdvisoryLockSql(organizationId: string,
 export function elizaAgentCreateAdvisoryLockSql(organizationId: string) {
   return sql`SELECT pg_advisory_xact_lock(hashtext(${organizationId}), hashtext(${"agent-create"}))`;
 }
+
+/**
+ * Per-source-agent tier-upgrade lock. The target service holds this across its
+ * durable re-check and initial insert so concurrent requests can only observe
+ * and reattach to the first request's target.
+ */
+export function elizaAgentTierUpgradeAdvisoryLockSql(
+  organizationId: string,
+  sharedAgentId: string,
+) {
+  return sql`SELECT pg_advisory_xact_lock(hashtext(${organizationId}), hashtext(${`tier-upgrade:${sharedAgentId}`}))`;
+}


### PR DESCRIPTION
Closes #15925. Corrects the concurrency and runway-gating defects found after #15861 merged.

## What changed

- Adds a per-source PostgreSQL advisory lock and moves the reserved upgrade marker into the atomic target insert.
- Makes all concurrent callers converge on the same durable target and active provision job. Losing callers wait for the winner's initialized job, avoiding concurrent managed-token/environment setup.
- Applies the dedicated-hosting runway gate before stopped or sleeping migration targets can restart.
- Uses the idempotent provision-job path for the fresh target too.

## Verification

- `bun test packages/cloud/api/__tests__/eliza-agents-upgrade-tier.test.ts` — 11 passed, 0 failed, 83 assertions. This is the real Hono route + sandbox/billing/provisioning services + repositories against in-process PGlite; auth is the only mocked seam.
- `bun run --cwd packages/cloud/shared typecheck` — passed.
- `bunx biome check <five changed files>` — passed.

The PGlite route lane sends eight simultaneous POSTs and inspects durable rows: exactly one dedicated target, one active job, and identical target/job IDs in all eight responses. Stopped and sleeping targets at $0.50 versus the required $0.72 both return the canonical 402 and create zero jobs.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only concurrency and billing-gate correction; no rendered surface changed.

<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only concurrency and billing-gate correction; no rendered surface changed.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing visual flow changed.

<!-- evidence-row:backend-logs -->
- [x] [Real route logs and exact-head verification](https://github.com/elizaOS/eliza/pull/15929#issuecomment-4931804481)

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser request path changed.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, provider, evaluator, or planner behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] [Inspected PGlite agent/job rows and eight-request convergence result](https://github.com/elizaOS/eliza/pull/15929#issuecomment-4931804481)
