### PR TITLE
fix(app): fail view-soak evidence finalization

### DIFF
--- a/packages/app/scripts/audit-views-soak-boundary.mjs
+++ b/packages/app/scripts/audit-views-soak-boundary.mjs
@@ -54,6 +54,7 @@ export async function finalizeSoakEvidence({
   page,
   context,
   video,
+  videoRequired = true,
   outDir,
   convertRecording = convertSoakRecordingToMp4,
   onContextClosed = () => {},
@@ -61,7 +62,12 @@ export async function finalizeSoakEvidence({
   await page.screenshot({ path: join(outDir, "soak-final.png") });
   await context.close();
   onContextClosed();
-  if (!video) return null;
+  if (!video) {
+    if (videoRequired) {
+      throw new Error("view-soak recording is required but was not initialized");
+    }
+    return null;
+  }
 
   const source = await video.path();
   const artifact = "audit-views-soak.mp4";

--- a/packages/app/scripts/audit-views-soak-boundary.mjs
+++ b/packages/app/scripts/audit-views-soak-boundary.mjs
@@ -1,0 +1,73 @@
+/**
+ * Failure boundary for the unattended real-app view soak.
+ *
+ * Required evidence and onboarding checks reject so the process cannot publish
+ * a healthy scorecard after losing its screenshot, recording, or browser state.
+ * The caller owns best-effort cleanup after a rejection.
+ */
+
+import { spawnSync } from "node:child_process";
+import { rmSync } from "node:fs";
+import { join } from "node:path";
+
+export function convertSoakRecordingToMp4(
+  source,
+  target,
+  { spawn = spawnSync } = {},
+) {
+  const result = spawn(
+    "ffmpeg",
+    [
+      "-y",
+      "-i",
+      source,
+      "-c:v",
+      "libx264",
+      "-pix_fmt",
+      "yuv420p",
+      "-movflags",
+      "+faststart",
+      "-an",
+      target,
+    ],
+    { encoding: "utf8" },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(
+      `ffmpeg failed to finalize the view-soak MP4: ${result.stderr || result.stdout}`,
+    );
+  }
+}
+
+export async function waitForOnboardingClearance(page, timeout = 45_000) {
+  const backdrop = page.getByTestId("chat-first-run-backdrop");
+  await backdrop.waitFor({ state: "detached", timeout });
+  if (await backdrop.isVisible({ timeout: 500 })) {
+    throw new Error(
+      "first-run onboarding still blocks the rendered app surface",
+    );
+  }
+}
+
+export async function finalizeSoakEvidence({
+  page,
+  context,
+  video,
+  outDir,
+  convertRecording = convertSoakRecordingToMp4,
+  onContextClosed = () => {},
+}) {
+  await page.screenshot({ path: join(outDir, "soak-final.png") });
+  await context.close();
+  onContextClosed();
+  if (!video) return null;
+
+  const source = await video.path();
+  const artifact = "audit-views-soak.mp4";
+  const target = join(outDir, artifact);
+  rmSync(target, { force: true });
+  convertRecording(source, target);
+  rmSync(source, { force: true });
+  return artifact;
+}

--- a/packages/app/scripts/audit-views-soak-navigation.test.mjs
+++ b/packages/app/scripts/audit-views-soak-navigation.test.mjs
@@ -1,10 +1,16 @@
 /**
- * The real-app view soak must never bypass the surface-realm navigation gate
- * while releasing its final active view.
+ * Behavioral contracts for the real-app soak's navigation, onboarding, and
+ * required-evidence failure boundary.
  */
 
 import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  convertSoakRecordingToMp4,
+  finalizeSoakEvidence,
+  waitForOnboardingClearance,
+} from "./audit-views-soak-boundary.mjs";
 
 const source = readFileSync(
   new URL("./audit-views-soak.mjs", import.meta.url),
@@ -19,9 +25,92 @@ test("cleanup navigates through the shell event instead of raw History", () => {
   expect(source).not.toContain("window.history.replaceState");
 });
 
-test("context teardown owns video finalization without a redundant page close", () => {
-  expect(source).toContain("await ctx.close().catch(() => {});");
+test("context teardown owns video finalization without swallowed failures", () => {
+  expect(source).not.toContain("ctx.close().catch");
   expect(source).not.toContain("await page.close()");
+});
+
+test("required screenshot, context close, and video lookup failures reject", async () => {
+  const base = {
+    page: { screenshot: async () => {} },
+    context: { close: async () => {} },
+    video: { path: async () => "/tmp/soak.webm" },
+    outDir: "/tmp/out",
+    convertRecording: () => {},
+  };
+  await expect(
+    finalizeSoakEvidence({
+      ...base,
+      page: { screenshot: async () => Promise.reject(new Error("shot")) },
+    }),
+  ).rejects.toThrow("shot");
+  await expect(
+    finalizeSoakEvidence({
+      ...base,
+      context: { close: async () => Promise.reject(new Error("close")) },
+    }),
+  ).rejects.toThrow("close");
+  await expect(
+    finalizeSoakEvidence({
+      ...base,
+      video: { path: async () => Promise.reject(new Error("video")) },
+    }),
+  ).rejects.toThrow("video");
+});
+
+test("successful evidence finalization produces the required MP4", async () => {
+  const calls = [];
+  const artifact = await finalizeSoakEvidence({
+    page: { screenshot: async (options) => calls.push(["shot", options.path]) },
+    context: { close: async () => calls.push(["close"]) },
+    video: { path: async () => "/tmp/recording.webm" },
+    outDir: "/tmp/out",
+    convertRecording: (sourcePath, targetPath) =>
+      calls.push(["convert", sourcePath, targetPath]),
+  });
+  expect(artifact).toBe("audit-views-soak.mp4");
+  expect(calls).toEqual([
+    ["shot", join("/tmp/out", "soak-final.png")],
+    ["close"],
+    ["convert", "/tmp/recording.webm", join("/tmp/out", artifact)],
+  ]);
+});
+
+test("MP4 conversion surfaces ffmpeg launch and encoding failures", () => {
+  expect(() =>
+    convertSoakRecordingToMp4("input.webm", "output.mp4", {
+      spawn: () => ({ error: new Error("ffmpeg missing") }),
+    }),
+  ).toThrow("ffmpeg missing");
+  expect(() =>
+    convertSoakRecordingToMp4("input.webm", "output.mp4", {
+      spawn: () => ({ status: 1, stderr: "encoder failed", stdout: "" }),
+    }),
+  ).toThrow("encoder failed");
+});
+
+test("onboarding clearance failures reject instead of being ignored", async () => {
+  const page = {
+    getByTestId: () => ({
+      waitFor: async () => Promise.reject(new Error("still attached")),
+      isVisible: async () => true,
+    }),
+  };
+  await expect(waitForOnboardingClearance(page, 1)).rejects.toThrow(
+    "still attached",
+  );
+});
+
+test("onboarding clearance rejects a rendered blocker that remains visible", async () => {
+  const page = {
+    getByTestId: () => ({
+      waitFor: async () => {},
+      isVisible: async () => true,
+    }),
+  };
+  await expect(waitForOnboardingClearance(page, 1)).rejects.toThrow(
+    "onboarding still blocks",
+  );
 });
 
 test("the soak completes current in-chat onboarding before view churn", () => {
@@ -39,7 +128,7 @@ test("the soak completes current in-chat onboarding before view churn", () => {
   );
   expect(source).toContain("/api/first-run/status");
   expect(source).toContain("/api/first-run");
-  expect(source).toContain('getByTestId("chat-first-run-backdrop")');
+  expect(source).toContain("await waitForOnboardingClearance(page)");
   expect(source).not.toContain("first-run-runtime-chooser");
 });
 

--- a/packages/app/scripts/audit-views-soak-navigation.test.mjs
+++ b/packages/app/scripts/audit-views-soak-navigation.test.mjs
@@ -76,6 +76,21 @@ test("successful evidence finalization produces the required MP4", async () => {
   ]);
 });
 
+test("missing required video rejects while an intentional VIDEO=0 run succeeds", async () => {
+  const base = {
+    page: { screenshot: async () => {} },
+    context: { close: async () => {} },
+    video: null,
+    outDir: "/tmp/out",
+  };
+  await expect(finalizeSoakEvidence(base)).rejects.toThrow(
+    "recording is required",
+  );
+  await expect(
+    finalizeSoakEvidence({ ...base, videoRequired: false }),
+  ).resolves.toBeNull();
+});
+
 test("MP4 conversion surfaces ffmpeg launch and encoding failures", () => {
   expect(() =>
     convertSoakRecordingToMp4("input.webm", "output.mp4", {

--- a/packages/app/scripts/audit-views-soak.mjs
+++ b/packages/app/scripts/audit-views-soak.mjs
@@ -16,9 +16,13 @@
  *
  * Run under Node on Windows (Playwright's CDP pipe is dead under Bun there).
  */
-import { mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { chromium } from "playwright";
+import {
+  finalizeSoakEvidence,
+  waitForOnboardingClearance,
+} from "./audit-views-soak-boundary.mjs";
 
 const UI = process.env.UI || "http://127.0.0.1:2138";
 const API = process.env.API || "http://127.0.0.1:31337";
@@ -238,6 +242,8 @@ function classifyNetworkEntry(entry) {
     try {
       return new URL(entry.url).pathname;
     } catch {
+      // error-policy:J3 an invalid URL remains unclassified and therefore
+      // becomes an explicit unexpected-network failure below.
       return "";
     }
   })();
@@ -310,11 +316,40 @@ function summarizeNetworkLog(networkLog) {
   };
 }
 
+let activeBrowser = null;
+let activeContext = null;
+
+async function cleanupAfterFailure() {
+  if (activeContext) {
+    try {
+      await activeContext.close();
+    } catch (error) {
+      // error-policy:J6 the original soak failure remains authoritative; this
+      // retry only prevents its browser child from surviving the process.
+      console.warn(
+        `[soak] context cleanup after failure also failed: ${error}`,
+      );
+    }
+    activeContext = null;
+  }
+  if (activeBrowser) {
+    try {
+      await activeBrowser.close();
+    } catch (error) {
+      // error-policy:J6 the process is already failing and browser shutdown is
+      // retried only to avoid leaking the Playwright child.
+      console.warn(
+        `[soak] browser cleanup after failure also failed: ${error}`,
+      );
+    }
+    activeBrowser = null;
+  }
+}
+
 async function isFirstRunBlocking(page) {
   return page
     .getByTestId("chat-first-run-backdrop")
-    .isVisible({ timeout: 500 })
-    .catch(() => false);
+    .isVisible({ timeout: 500 });
 }
 
 async function waitForRuntimeReady(timeoutMs = 180_000) {
@@ -381,140 +416,141 @@ async function completeFirstRunIfNeeded() {
   return result;
 }
 
-// 1) Enumerate the real registered views.
-const viewsRes = await fetch(`${API}/api/views`).then((r) => r.json());
-const views = (viewsRes.views || []).filter((v) => v.path);
-assert(
-  views.length >= 10,
-  `enumerated ${views.length} registered views via /api/views`,
-);
-const byKind = {};
-for (const v of views) byKind[viewKind(v)] = (byKind[viewKind(v)] || 0) + 1;
-console.log(`[soak] view kinds: ${JSON.stringify(byKind)}`);
-await waitForRuntimeReady();
-const firstRunSetup = await completeFirstRunIfNeeded();
+async function main() {
+  // 1) Enumerate the real registered views.
+  const viewsRes = await fetch(`${API}/api/views`).then((r) => r.json());
+  const views = (viewsRes.views || []).filter((v) => v.path);
+  assert(
+    views.length >= 10,
+    `enumerated ${views.length} registered views via /api/views`,
+  );
+  const byKind = {};
+  for (const v of views) byKind[viewKind(v)] = (byKind[viewKind(v)] || 0) + 1;
+  console.log(`[soak] view kinds: ${JSON.stringify(byKind)}`);
+  await waitForRuntimeReady();
+  const firstRunSetup = await completeFirstRunIfNeeded();
 
-// `--enable-precise-memory-info` makes `performance.memory.usedJSHeapSize`
-// report real byte counts instead of the privacy-bucketed (quantized) value, and
-// `--expose-gc` makes the `window.gc()` we call after each sweep actually run a
-// collection — without both, the heap-growth assertion below is decorative.
-const browser = await chromium.launch({
-  timeout: 300000,
-  args: ["--enable-precise-memory-info", "--js-flags=--expose-gc"],
-});
-const contextOptions = {
-  viewport: { width: 1440, height: 900 },
-};
-if (VIDEO) {
-  contextOptions.recordVideo = {
-    dir: OUT,
-    size: { width: 1440, height: 900 },
+  // `--enable-precise-memory-info` makes `performance.memory.usedJSHeapSize`
+  // report real byte counts instead of the privacy-bucketed (quantized) value, and
+  // `--expose-gc` makes the `window.gc()` we call after each sweep actually run a
+  // collection — without both, the heap-growth assertion below is decorative.
+  const browser = await chromium.launch({
+    timeout: 300000,
+    args: ["--enable-precise-memory-info", "--js-flags=--expose-gc"],
+  });
+  activeBrowser = browser;
+  const contextOptions = {
+    viewport: { width: 1440, height: 900 },
   };
-}
-const ctx = await browser.newContext(contextOptions);
-const page = await ctx.newPage();
-const video = page.video();
-// Pre-create the telemetry rings BEFORE the app boots, so its real
-// ViewTelemetryProfiler / module caches push into them (cache-telemetry only
-// records when the ring array already exists).
-await page.addInitScript(() => {
-  // The browser-side startup snapshot is the second half of first-run
-  // completion. API persistence alone leaves a fresh CI profile in the
-  // onboarding transition even though the server reports complete.
-  localStorage.setItem("eliza:first-run-complete", "1");
-  localStorage.setItem("eliza:setup:step", "activate");
-  localStorage.setItem("eliza:ui-shell-mode", "native");
-  localStorage.setItem("eliza:chat:voiceMuted", "true");
-  // The module-cache ring only records when its array already exists; the
-  // view-runtime + render rings self-create, but pre-seed all three so nothing
-  // emitted during early boot is lost.
-  window.__ELIZA_RENDER_TELEMETRY__ = [];
-  window.__ELIZA_MODULE_CACHE_TELEMETRY__ = [];
-  window.__ELIZA_VIEW_RUNTIME_TELEMETRY__ = [];
-});
-const pageErrors = [];
-const consoleLog = [];
-const networkLog = [];
-page.on("pageerror", (e) => pageErrors.push(String(e.message)));
-page.on("console", (msg) => {
-  consoleLog.push({
-    type: msg.type(),
-    text: msg.text(),
-    location: msg.location(),
-  });
-});
-page.on("requestfailed", (request) => {
-  networkLog.push({
-    kind: "requestfailed",
-    method: request.method(),
-    url: request.url(),
-    failure: request.failure()?.errorText ?? null,
-  });
-});
-page.on("response", (response) => {
-  if (response.status() < 400) return;
-  networkLog.push({
-    kind: "response",
-    status: response.status(),
-    url: response.url(),
-  });
-});
-
-await page.goto(UI, { waitUntil: "domcontentloaded", timeout: 60000 });
-await page.waitForTimeout(3000);
-await page
-  .getByTestId("chat-first-run-backdrop")
-  .waitFor({ state: "detached", timeout: 45000 })
-  .catch(() => {});
-await page.waitForTimeout(3000);
-
-const heap = async () =>
-  page.evaluate(() =>
-    performance?.memory ? performance.memory.usedJSHeapSize : 0,
-  );
-const snapshotTelemetry = async () =>
-  page.evaluate(() => {
-    const render = window.__ELIZA_RENDER_TELEMETRY__ || [];
-    const viewRuntime = window.__ELIZA_VIEW_RUNTIME_TELEMETRY__ || [];
-    const module = window.__ELIZA_MODULE_CACHE_TELEMETRY__ || [];
-    const maxRender = viewRuntime.reduce(
-      (m, e) => Math.max(m, e.renderCount || 0),
-      0,
-    );
-    return {
-      raw: { render, viewRuntime, module },
-      summary: {
-        render: render.length,
-        renderErrors: render.filter((e) => e.severity === "error").length,
-        viewRuntime: viewRuntime.length,
-        shows: viewRuntime.filter((e) => e.reason === "show").length,
-        viewEvicts: viewRuntime.filter((e) => e.reason === "evict").length,
-        maxRenderCount: maxRender,
-        module: module.length,
-        moduleEvicts: module.filter((e) => e.action === "evict").length,
-        moduleCleanups: module.filter((e) => e.action === "cleanup").length,
-      },
+  if (VIDEO) {
+    contextOptions.recordVideo = {
+      dir: OUT,
+      size: { width: 1440, height: 900 },
     };
+  }
+  const ctx = await browser.newContext(contextOptions);
+  activeContext = ctx;
+  const page = await ctx.newPage();
+  const video = page.video();
+  // Pre-create the telemetry rings BEFORE the app boots, so its real
+  // ViewTelemetryProfiler / module caches push into them (cache-telemetry only
+  // records when the ring array already exists).
+  await page.addInitScript(() => {
+    // The browser-side startup snapshot is the second half of first-run
+    // completion. API persistence alone leaves a fresh CI profile in the
+    // onboarding transition even though the server reports complete.
+    localStorage.setItem("eliza:first-run-complete", "1");
+    localStorage.setItem("eliza:setup:step", "activate");
+    localStorage.setItem("eliza:ui-shell-mode", "native");
+    localStorage.setItem("eliza:chat:voiceMuted", "true");
+    // The module-cache ring only records when its array already exists; the
+    // view-runtime + render rings self-create, but pre-seed all three so nothing
+    // emitted during early boot is lost.
+    window.__ELIZA_RENDER_TELEMETRY__ = [];
+    window.__ELIZA_MODULE_CACHE_TELEMETRY__ = [];
+    window.__ELIZA_VIEW_RUNTIME_TELEMETRY__ = [];
+  });
+  const pageErrors = [];
+  const consoleLog = [];
+  const networkLog = [];
+  page.on("pageerror", (e) => pageErrors.push(String(e.message)));
+  page.on("console", (msg) => {
+    consoleLog.push({
+      type: msg.type(),
+      text: msg.text(),
+      location: msg.location(),
+    });
+  });
+  page.on("requestfailed", (request) => {
+    networkLog.push({
+      kind: "requestfailed",
+      method: request.method(),
+      url: request.url(),
+      failure: request.failure()?.errorText ?? null,
+    });
+  });
+  page.on("response", (response) => {
+    if (response.status() < 400) return;
+    networkLog.push({
+      kind: "response",
+      status: response.status(),
+      url: response.url(),
+    });
   });
 
-// Navigate to a view through the REAL app navigation channel — the same
-// `eliza:navigate:view` CustomEvent the shell's WS handler + launcher dispatch
-// (App.tsx handleNavigateView). Switches builtin tabs via setTab and plugin/
-// remote views via DynamicViewLoader, driving the real ViewRouter mount/unmount.
-async function dispatchShellNavigation(view) {
-  await page.evaluate(
-    (detail) =>
-      window.dispatchEvent(new CustomEvent("eliza:navigate:view", { detail })),
-    { viewId: view.id, viewPath: view.path },
-  );
-}
+  await page.goto(UI, { waitUntil: "domcontentloaded", timeout: 60000 });
+  await page.waitForTimeout(3000);
+  await waitForOnboardingClearance(page);
+  await page.waitForTimeout(3000);
 
-async function navTo(view) {
-  const targetPath = normalizePath(view.path);
-  const beforePath = await page.evaluate(() => window.location.pathname);
-  await dispatchShellNavigation(view);
-  await page
-    .waitForFunction(
+  const heap = async () =>
+    page.evaluate(() =>
+      performance?.memory ? performance.memory.usedJSHeapSize : 0,
+    );
+  const snapshotTelemetry = async () =>
+    page.evaluate(() => {
+      const render = window.__ELIZA_RENDER_TELEMETRY__ || [];
+      const viewRuntime = window.__ELIZA_VIEW_RUNTIME_TELEMETRY__ || [];
+      const module = window.__ELIZA_MODULE_CACHE_TELEMETRY__ || [];
+      const maxRender = viewRuntime.reduce(
+        (m, e) => Math.max(m, e.renderCount || 0),
+        0,
+      );
+      return {
+        raw: { render, viewRuntime, module },
+        summary: {
+          render: render.length,
+          renderErrors: render.filter((e) => e.severity === "error").length,
+          viewRuntime: viewRuntime.length,
+          shows: viewRuntime.filter((e) => e.reason === "show").length,
+          viewEvicts: viewRuntime.filter((e) => e.reason === "evict").length,
+          maxRenderCount: maxRender,
+          module: module.length,
+          moduleEvicts: module.filter((e) => e.action === "evict").length,
+          moduleCleanups: module.filter((e) => e.action === "cleanup").length,
+        },
+      };
+    });
+
+  // Navigate to a view through the REAL app navigation channel — the same
+  // `eliza:navigate:view` CustomEvent the shell's WS handler + launcher dispatch
+  // (App.tsx handleNavigateView). Switches builtin tabs via setTab and plugin/
+  // remote views via DynamicViewLoader, driving the real ViewRouter mount/unmount.
+  async function dispatchShellNavigation(view) {
+    await page.evaluate(
+      (detail) =>
+        window.dispatchEvent(
+          new CustomEvent("eliza:navigate:view", { detail }),
+        ),
+      { viewId: view.id, viewPath: view.path },
+    );
+  }
+
+  async function navTo(view) {
+    const targetPath = normalizePath(view.path);
+    const beforePath = await page.evaluate(() => window.location.pathname);
+    await dispatchShellNavigation(view);
+    await page.waitForFunction(
       (target) => {
         const path = window.location.pathname;
         const normalized = path.length > 1 ? path.replace(/\/+$/, "") : path;
@@ -522,233 +558,248 @@ async function navTo(view) {
       },
       targetPath,
       { timeout: Math.max(1000, NAV_WAIT_MS * 3) },
-    )
-    .catch(() => {});
-  await page.waitForTimeout(NAV_WAIT_MS);
-  const afterPath = await page.evaluate(() => window.location.pathname);
-  const firstRunBlocking = await isFirstRunBlocking(page);
-  return {
-    id: view.id,
-    label: view.label ?? view.name ?? view.id,
-    targetPath,
-    beforePath: normalizePath(beforePath),
-    afterPath: normalizePath(afterPath),
-    reached: normalizePath(afterPath) === targetPath,
-    firstRunBlocking,
-  };
-}
+    );
+    await page.waitForTimeout(NAV_WAIT_MS);
+    const afterPath = await page.evaluate(() => window.location.pathname);
+    const firstRunBlocking = await isFirstRunBlocking(page);
+    return {
+      id: view.id,
+      label: view.label ?? view.name ?? view.id,
+      targetPath,
+      beforePath: normalizePath(beforePath),
+      afterPath: normalizePath(afterPath),
+      reached: normalizePath(afterPath) === targetPath,
+      firstRunBlocking,
+    };
+  }
 
-const heapStart = await heap();
-const beforeSnapshot = await snapshotTelemetry();
-const beforeChurn = beforeSnapshot.summary;
-console.log(
-  `[soak] start heap=${(heapStart / 1e6).toFixed(1)}MB telemetry=${JSON.stringify(beforeChurn)}`,
-);
+  const heapStart = await heap();
+  const beforeSnapshot = await snapshotTelemetry();
+  const beforeChurn = beforeSnapshot.summary;
+  console.log(
+    `[soak] start heap=${(heapStart / 1e6).toFixed(1)}MB telemetry=${JSON.stringify(beforeChurn)}`,
+  );
 
-// 2) Churn: cycle every view, ROUNDS times, forcing real mount/unmount + eviction.
-const heapSamples = [heapStart];
-const navRecords = new Map(
-  views.map((view) => [view.id, { view, activations: [] }]),
-);
-let shots = 0;
-for (let r = 0; r < ROUNDS; r++) {
-  for (const v of views) {
-    const navRecord = await navTo(v);
-    navRecords.get(v.id)?.activations.push({
-      round: r + 1,
-      ...navRecord,
-    });
-    // capture a few representative views once for evidence
-    if (r === 0 && shots < 6 && ["system", "developer"].includes(viewKind(v))) {
-      await page
-        .screenshot({
+  // 2) Churn: cycle every view, ROUNDS times, forcing real mount/unmount + eviction.
+  const heapSamples = [heapStart];
+  const navRecords = new Map(
+    views.map((view) => [view.id, { view, activations: [] }]),
+  );
+  let shots = 0;
+  for (let r = 0; r < ROUNDS; r++) {
+    for (const v of views) {
+      const navRecord = await navTo(v);
+      navRecords.get(v.id)?.activations.push({
+        round: r + 1,
+        ...navRecord,
+      });
+      // capture a few representative views once for evidence
+      if (
+        r === 0 &&
+        shots < 6 &&
+        ["system", "developer"].includes(viewKind(v))
+      ) {
+        await page.screenshot({
           path: join(
             OUT,
             `view-${String(++shots).padStart(2, "0")}-${v.id}.png`,
           ),
-        })
-        .catch(() => {});
+        });
+      }
     }
+    // force GC if exposed, then sample heap after each full sweep
+    await page.evaluate(() => window.gc?.());
+    heapSamples.push(await heap());
   }
-  // force GC if exposed, then sample heap after each full sweep
-  await page.evaluate(() => window.gc?.()).catch(() => {});
-  heapSamples.push(await heap());
-}
 
-const afterChurnSnapshot = await snapshotTelemetry();
-const afterChurn = afterChurnSnapshot.summary;
-const heapEnd = heapSamples[heapSamples.length - 1];
-const cycles = ROUNDS * views.length;
-console.log(
-  `[soak] after ${cycles} view activations telemetry=${JSON.stringify(afterChurn)} heapEnd=${(heapEnd / 1e6).toFixed(1)}MB`,
-);
+  const afterChurnSnapshot = await snapshotTelemetry();
+  const afterChurn = afterChurnSnapshot.summary;
+  const heapEnd = heapSamples[heapSamples.length - 1];
+  const cycles = ROUNDS * views.length;
+  console.log(
+    `[soak] after ${cycles} view activations telemetry=${JSON.stringify(afterChurn)} heapEnd=${(heapEnd / 1e6).toFixed(1)}MB`,
+  );
 
-// Leave the final active view through the same shell-owned navigation channel
-// used by the churn. Raw History calls execute under that view's realm and are
-// intentionally denied by the surface-realm broker.
-await dispatchShellNavigation({ id: "chat", path: "/chat" });
-await page.waitForTimeout(NAV_WAIT_MS);
-await page.evaluate(() => {
-  document.dispatchEvent(new CustomEvent("eliza:heap-pressure"));
-  document.dispatchEvent(new Event("eliza:app-pause"));
-  window.dispatchEvent(new Event("eliza:app-pause"));
-});
-await page.waitForTimeout(Math.max(1000, NAV_WAIT_MS));
+  // Leave the final active view through the same shell-owned navigation channel
+  // used by the churn. Raw History calls execute under that view's realm and are
+  // intentionally denied by the surface-realm broker.
+  await dispatchShellNavigation({ id: "chat", path: "/chat" });
+  await page.waitForTimeout(NAV_WAIT_MS);
+  await page.evaluate(() => {
+    document.dispatchEvent(new CustomEvent("eliza:heap-pressure"));
+    document.dispatchEvent(new Event("eliza:app-pause"));
+    window.dispatchEvent(new Event("eliza:app-pause"));
+  });
+  await page.waitForTimeout(Math.max(1000, NAV_WAIT_MS));
 
-const afterReleaseSnapshot = await snapshotTelemetry();
-const afterRelease = afterReleaseSnapshot.summary;
+  const afterReleaseSnapshot = await snapshotTelemetry();
+  const afterRelease = afterReleaseSnapshot.summary;
 
-// 3) Assertions — the real view lifecycle behaved under churn.
-const reachedViews = [...navRecords.values()].filter((record) =>
-  record.activations.some((activation) => activation.reached),
-).length;
-const firstRunBlockedActivations = [...navRecords.values()].reduce(
-  (sum, record) =>
-    sum +
-    record.activations.filter((activation) => activation.firstRunBlocking)
-      .length,
-  0,
-);
-assert(
-  reachedViews === views.length,
-  `navigation reached every registered view path (${reachedViews}/${views.length})`,
-);
-assert(
-  firstRunSetup.completed && firstRunBlockedActivations === 0,
-  `first-run overlay did not block captured views (setup=${JSON.stringify(firstRunSetup)}, blocked activations=${firstRunBlockedActivations})`,
-);
-assert(
-  afterChurn.shows > beforeChurn.shows,
-  `view-runtime telemetry recorded real view mounts under churn (${beforeChurn.shows} -> ${afterChurn.shows} 'show' events)`,
-);
-// No per-view re-render storm: the worst view's committed render count stays
-// well under a pathological bound across its whole soak lifetime.
-assert(
-  afterChurn.maxRenderCount > 0 && afterChurn.maxRenderCount < 400,
-  `no per-view render storm: worst view renderCount = ${afterChurn.maxRenderCount} (0 < n < 400)`,
-);
-// Eviction happened: a backgrounded view's instance and/or its module is pruned
-// under churn — proves the bounded caches prune rather than grow unbounded.
-assert(
-  afterRelease.viewEvicts > 0 || afterRelease.moduleEvicts > 0,
-  `bounded caches evicted under churn/release (view-instance evicts=${afterRelease.viewEvicts}, module-cache evicts=${afterRelease.moduleEvicts}, cleanups=${afterRelease.moduleCleanups}) — the LRU prunes`,
-);
-assert(
-  afterRelease.moduleCleanups > 0 || afterRelease.moduleEvicts > 0,
-  `eviction telemetry includes release cleanup or evict events after APP_PAUSE/heap-pressure (${afterChurn.moduleEvicts}/${afterChurn.moduleCleanups} -> ${afterRelease.moduleEvicts}/${afterRelease.moduleCleanups})`,
-);
-assert(
-  afterRelease.renderErrors === beforeChurn.renderErrors,
-  `no new render-loop guard errors during view churn (${beforeChurn.renderErrors} -> ${afterRelease.renderErrors})`,
-);
-// heap must not grow unboundedly: end within 2.2x of the post-warm baseline.
-// With precise-memory-info + real GC (see launch args) this ratio is measured on
-// actual collected heap, so a leaking view that retains instances across the
-// sweep trips it; 2.2x is a deliberately loose doubling-guard to stay non-flaky.
-const heapWarm = heapSamples[1] || heapStart;
-const heapRatio = heapEnd / Math.max(1, heapWarm);
-assert(
-  heapRatio < 2.2 || heapEnd === 0,
-  `heap bounded across the soak: end ${(heapEnd / 1e6).toFixed(1)}MB / warm ${(heapWarm / 1e6).toFixed(1)}MB = ${heapRatio.toFixed(2)}x (< 2.2x; 0 = no perf.memory)`,
-);
-assert(
-  pageErrors.length === 0,
-  `no uncaught page errors during the soak (${JSON.stringify(pageErrors.slice(0, 3))})`,
-);
+  // 3) Assertions — the real view lifecycle behaved under churn.
+  const reachedViews = [...navRecords.values()].filter((record) =>
+    record.activations.some((activation) => activation.reached),
+  ).length;
+  const firstRunBlockedActivations = [...navRecords.values()].reduce(
+    (sum, record) =>
+      sum +
+      record.activations.filter((activation) => activation.firstRunBlocking)
+        .length,
+    0,
+  );
+  assert(
+    reachedViews === views.length,
+    `navigation reached every registered view path (${reachedViews}/${views.length})`,
+  );
+  assert(
+    firstRunSetup.completed && firstRunBlockedActivations === 0,
+    `first-run overlay did not block captured views (setup=${JSON.stringify(firstRunSetup)}, blocked activations=${firstRunBlockedActivations})`,
+  );
+  assert(
+    afterChurn.shows > beforeChurn.shows,
+    `view-runtime telemetry recorded real view mounts under churn (${beforeChurn.shows} -> ${afterChurn.shows} 'show' events)`,
+  );
+  // No per-view re-render storm: the worst view's committed render count stays
+  // well under a pathological bound across its whole soak lifetime.
+  assert(
+    afterChurn.maxRenderCount > 0 && afterChurn.maxRenderCount < 400,
+    `no per-view render storm: worst view renderCount = ${afterChurn.maxRenderCount} (0 < n < 400)`,
+  );
+  // Eviction happened: a backgrounded view's instance and/or its module is pruned
+  // under churn — proves the bounded caches prune rather than grow unbounded.
+  assert(
+    afterRelease.viewEvicts > 0 || afterRelease.moduleEvicts > 0,
+    `bounded caches evicted under churn/release (view-instance evicts=${afterRelease.viewEvicts}, module-cache evicts=${afterRelease.moduleEvicts}, cleanups=${afterRelease.moduleCleanups}) — the LRU prunes`,
+  );
+  assert(
+    afterRelease.moduleCleanups > 0 || afterRelease.moduleEvicts > 0,
+    `eviction telemetry includes release cleanup or evict events after APP_PAUSE/heap-pressure (${afterChurn.moduleEvicts}/${afterChurn.moduleCleanups} -> ${afterRelease.moduleEvicts}/${afterRelease.moduleCleanups})`,
+  );
+  assert(
+    afterRelease.renderErrors === beforeChurn.renderErrors,
+    `no new render-loop guard errors during view churn (${beforeChurn.renderErrors} -> ${afterRelease.renderErrors})`,
+  );
+  // heap must not grow unboundedly: end within 2.2x of the post-warm baseline.
+  // With precise-memory-info + real GC (see launch args) this ratio is measured on
+  // actual collected heap, so a leaking view that retains instances across the
+  // sweep trips it; 2.2x is a deliberately loose doubling-guard to stay non-flaky.
+  const heapWarm = heapSamples[1] || heapStart;
+  const heapRatio = heapEnd / Math.max(1, heapWarm);
+  assert(
+    heapRatio < 2.2 || heapEnd === 0,
+    `heap bounded across the soak: end ${(heapEnd / 1e6).toFixed(1)}MB / warm ${(heapWarm / 1e6).toFixed(1)}MB = ${heapRatio.toFixed(2)}x (< 2.2x; 0 = no perf.memory)`,
+  );
+  assert(
+    pageErrors.length === 0,
+    `no uncaught page errors during the soak (${JSON.stringify(pageErrors.slice(0, 3))})`,
+  );
 
-await page.screenshot({ path: join(OUT, "soak-final.png") }).catch(() => {});
-let videoArtifact = null;
-// Closing the context owns page teardown and video finalization as one
-// operation. Closing the page first can deadlock Playwright's ffmpeg recorder
-// after a long capture, leaving an unattended nightly green-but-running until
-// the workflow timeout kills it.
-await ctx.close().catch(() => {});
-if (video) {
-  const source = await video.path().catch(() => null);
-  if (source) {
-    videoArtifact = "audit-views-soak.webm";
-    const target = join(OUT, videoArtifact);
-    rmSync(target, { force: true });
-    renameSync(source, target);
-  }
-}
-await browser.close();
+  // Closing the context owns page teardown and video finalization as one
+  // operation. Closing the page first can deadlock Playwright's ffmpeg recorder
+  // after a long capture, leaving an unattended nightly green-but-running until
+  // the workflow timeout kills it.
+  const videoArtifact = await finalizeSoakEvidence({
+    page,
+    context: ctx,
+    video,
+    outDir: OUT,
+    onContextClosed: () => {
+      activeContext = null;
+    },
+  });
+  await browser.close();
+  activeBrowser = null;
 
-const networkSummary = summarizeNetworkLog(networkLog);
-assert(
-  networkSummary.unexpectedCount === 0,
-  `no unexpected network failures during the soak (${networkSummary.unexpectedCount} unexpected / ${networkSummary.total} total; expected navigation aborts=${networkSummary.expectedAbortCount}, expected optional-route 404s=${networkSummary.expectedOptionalRoute404Count}, expected protected-route 401s=${networkSummary.expectedProtectedRoute401Count})`,
-);
+  const networkSummary = summarizeNetworkLog(networkLog);
+  assert(
+    networkSummary.unexpectedCount === 0,
+    `no unexpected network failures during the soak (${networkSummary.unexpectedCount} unexpected / ${networkSummary.total} total; expected navigation aborts=${networkSummary.expectedAbortCount}, expected optional-route 404s=${networkSummary.expectedOptionalRoute404Count}, expected protected-route 401s=${networkSummary.expectedProtectedRoute401Count})`,
+  );
 
-const finalRaw = afterReleaseSnapshot.raw;
-writeJson("audit-views-render-telemetry.json", finalRaw.render);
-writeJson("audit-views-runtime-telemetry.json", finalRaw.viewRuntime);
-writeJson("audit-views-module-cache-telemetry.json", finalRaw.module);
-writeJson("audit-views-heap-series.json", {
-  samples: heapSamples,
-  startBytes: heapStart,
-  endBytes: heapEnd,
-  boundedRatio: heapEnd / Math.max(1, heapSamples[1] || heapStart),
-});
-writeJson("audit-views-navigation.json", [...navRecords.values()]);
-writeJson("audit-views-frontend-log.json", {
-  console: consoleLog,
-  pageErrors,
-});
-writeJson("audit-views-network-log.json", networkLog);
-writeJson("audit-views-network-summary.json", networkSummary);
-const scorecard = buildScorecard({
-  views,
-  raw: finalRaw,
-  navRecords,
-  heapSamples,
-  videoArtifact,
-  networkSummary,
-});
-writeJson("audit-views-scorecard.json", scorecard.rows);
-writeFileSync(join(OUT, "audit-views-scorecard.md"), scorecard.markdown);
-
-const report = {
-  benchmark: "audit:views real-app soak",
-  ui: UI,
-  api: API,
-  views: views.length,
-  viewKinds: byKind,
-  rounds: ROUNDS,
-  activations: cycles,
-  firstRunSetup,
-  telemetry: {
-    before: beforeChurn,
-    afterChurn,
-    afterRelease,
-    scorecard: scorecard.summary,
-  },
-  heap: {
+  const finalRaw = afterReleaseSnapshot.raw;
+  writeJson("audit-views-render-telemetry.json", finalRaw.render);
+  writeJson("audit-views-runtime-telemetry.json", finalRaw.viewRuntime);
+  writeJson("audit-views-module-cache-telemetry.json", finalRaw.module);
+  writeJson("audit-views-heap-series.json", {
+    samples: heapSamples,
     startBytes: heapStart,
     endBytes: heapEnd,
-    samples: heapSamples,
     boundedRatio: heapEnd / Math.max(1, heapSamples[1] || heapStart),
-  },
-  artifacts: {
-    scorecard: join(OUT, "audit-views-scorecard.md"),
-    renderTelemetry: join(OUT, "audit-views-render-telemetry.json"),
-    runtimeTelemetry: join(OUT, "audit-views-runtime-telemetry.json"),
-    moduleCacheTelemetry: join(OUT, "audit-views-module-cache-telemetry.json"),
-    heapSeries: join(OUT, "audit-views-heap-series.json"),
-    navigation: join(OUT, "audit-views-navigation.json"),
-    frontendLog: join(OUT, "audit-views-frontend-log.json"),
-    networkLog: join(OUT, "audit-views-network-log.json"),
-    networkSummary: join(OUT, "audit-views-network-summary.json"),
-    video: videoArtifact ? join(OUT, videoArtifact) : null,
-  },
-  checks,
-  pass: fails === 0,
-};
-writeFileSync(
-  join(OUT, "audit-views-soak.json"),
-  `${JSON.stringify(report, null, 2)}\n`,
-);
-console.log(
-  `\n${fails === 0 ? "PASS" : `FAIL (${fails})`} — audit:views soak over ${cycles} activations of ${views.length} real views → ${OUT}`,
-);
-process.exit(fails === 0 ? 0 : 1);
+  });
+  writeJson("audit-views-navigation.json", [...navRecords.values()]);
+  writeJson("audit-views-frontend-log.json", {
+    console: consoleLog,
+    pageErrors,
+  });
+  writeJson("audit-views-network-log.json", networkLog);
+  writeJson("audit-views-network-summary.json", networkSummary);
+  const scorecard = buildScorecard({
+    views,
+    raw: finalRaw,
+    navRecords,
+    heapSamples,
+    videoArtifact,
+    networkSummary,
+  });
+  writeJson("audit-views-scorecard.json", scorecard.rows);
+  writeFileSync(join(OUT, "audit-views-scorecard.md"), scorecard.markdown);
+
+  const report = {
+    benchmark: "audit:views real-app soak",
+    ui: UI,
+    api: API,
+    views: views.length,
+    viewKinds: byKind,
+    rounds: ROUNDS,
+    activations: cycles,
+    firstRunSetup,
+    telemetry: {
+      before: beforeChurn,
+      afterChurn,
+      afterRelease,
+      scorecard: scorecard.summary,
+    },
+    heap: {
+      startBytes: heapStart,
+      endBytes: heapEnd,
+      samples: heapSamples,
+      boundedRatio: heapEnd / Math.max(1, heapSamples[1] || heapStart),
+    },
+    artifacts: {
+      scorecard: join(OUT, "audit-views-scorecard.md"),
+      renderTelemetry: join(OUT, "audit-views-render-telemetry.json"),
+      runtimeTelemetry: join(OUT, "audit-views-runtime-telemetry.json"),
+      moduleCacheTelemetry: join(
+        OUT,
+        "audit-views-module-cache-telemetry.json",
+      ),
+      heapSeries: join(OUT, "audit-views-heap-series.json"),
+      navigation: join(OUT, "audit-views-navigation.json"),
+      frontendLog: join(OUT, "audit-views-frontend-log.json"),
+      networkLog: join(OUT, "audit-views-network-log.json"),
+      networkSummary: join(OUT, "audit-views-network-summary.json"),
+      video: videoArtifact ? join(OUT, videoArtifact) : null,
+    },
+    checks,
+    pass: fails === 0,
+  };
+  writeFileSync(
+    join(OUT, "audit-views-soak.json"),
+    `${JSON.stringify(report, null, 2)}\n`,
+  );
+  console.log(
+    `\n${fails === 0 ? "PASS" : `FAIL (${fails})`} — audit:views soak over ${cycles} activations of ${views.length} real views → ${OUT}`,
+  );
+  if (fails > 0) {
+    throw new Error(`audit:views soak failed ${fails} required checks`);
+  }
+}
+
+// error-policy:J1 the process boundary translates any required-check or
+// evidence-finalization failure into cleanup, diagnostics, and a non-zero exit.
+await main().catch(async (error) => {
+  await cleanupAfterFailure();
+  console.error(
+    `[soak] fatal: ${error instanceof Error ? error.stack : error}`,
+  );
+  process.exitCode = 1;
+});

--- a/packages/app/scripts/audit-views-soak.mjs
+++ b/packages/app/scripts/audit-views-soak.mjs
@@ -701,6 +701,7 @@ async function main() {
     page,
     context: ctx,
     video,
+    videoRequired: VIDEO,
     outDir: OUT,
     onContextClosed: () => {
       activeContext = null;


### PR DESCRIPTION
Closes #15915

## Summary

- moves required screenshot, context teardown, Playwright video lookup, and MP4 conversion into a rejecting evidence boundary
- makes onboarding clearance an assertion against the rendered backdrop instead of swallowing its timeout
- keeps only retry cleanup as annotated `error-policy:J6` best-effort teardown; the outer process boundary is annotated `J1`
- replaces source-shape checks for swallowed finalization with behavioral rejection and success tests

## Verification

- `bun test packages/app/scripts/audit-views-soak-navigation.test.mjs` — 9 pass, boundary module 100% functions and lines
- `bun run audit:error-policy-ratchet` — pass
- real production build — pass
- real unattended view soak — pass: 19 views, 114 activations, 0 onboarding blocks, 0 page errors, 0 unexpected network failures, 1.01x heap ratio
- real MP4 — H.264/yuv420p, 1440x900, 96.84 seconds; source WebM removed after conversion
- non-cloud workspace verification — 568/568 typecheck and lint tasks pass; all remaining verification audits and 27 dist consumers pass

## Evidence review

I manually opened the final screenshot, representative view screenshots, and a frame extracted from the final MP4. The video traverses the populated real app and the rendered onboarding backdrop does not block any activation.

`bun run --cwd packages/app audit:app` completed 229/245 cases. The 16 baseline failures are four viewport variants each for cloud, documents, LifeOps live-test, and cockpit; each lacks a production bundle declaration in `/api/views` and none is touched by this PR.

Full `bun run verify` is blocked only by the existing `@elizaos/cloud-api` Wrangler production dry-run sleeping indefinitely with no CPU or child work. It reproduced on Node 23 and required Node 24. Excluding that one wedged package, all 568 workspace tasks passed. `typecheck:dist --check` also identifies a pre-existing one-line stale alias for `@elizaos/plugin-elizacloud`; generating the current alias temporarily allowed all 27 dist consumers to pass, and the baseline manifest was restored unchanged.

## Evidence matrix

- MP4 walkthrough: attaching in PR comment
- screenshots: attaching in PR comment
- frontend/network logs: attaching summary and artifacts in PR comment
- backend structured logs: N/A — change is an audit process boundary; the real dev stack logs were reviewed during the soak
- real-LLM trajectory: N/A — no agent, action, provider, prompt, or model behavior changed
- native/platform capture: N/A — no native renderer or bridge behavior changed
- domain artifacts: soak JSON, scorecard, navigation, heap, runtime, and network artifacts attached in PR comment

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI source changed; this PR repairs the audit process boundary

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr-15930-view-soak-final.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr-15930-view-soak.mp4

<!-- evidence-row:backend-logs -->
- [x] N/A - no backend code path changed; the audit drives an existing real dev server

<!-- evidence-row:frontend-logs -->
- [x] [pr-15930-view-soak-network-summary.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr-15930-view-soak-network-summary.json)

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, model, prompt, provider, or action behavior changed

<!-- evidence-row:domain-artifacts -->
- [x] [pr-15930-view-soak.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr-15930-view-soak.json)

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered UI source changed; screenshots were manually inspected for audit clearance

