### PR TITLE
test(anthropic-proxy): deterministic PROXY_STATUS action coverage; drain allowlist entry (#15856)

### DIFF
--- a/packages/scripts/lint-lane-coverage.allowlist.json
+++ b/packages/scripts/lint-lane-coverage.allowlist.json
@@ -20,11 +20,6 @@
       "reason": "Legacy deterministic lane coverage debt tracked in #15856; ratchet by removing entries as tests/scenarios land."
     },
     {
-      "plugin": "plugin-anthropic-proxy",
-      "issues": ["missing-action-tests"],
-      "reason": "Legacy deterministic lane coverage debt tracked in #15856; ratchet by removing entries as tests/scenarios land."
-    },
-    {
       "plugin": "plugin-aosp-local-inference",
       "issues": ["missing-deterministic-e2e"],
       "reason": "Legacy deterministic lane coverage debt tracked in #15856; ratchet by removing entries as tests/scenarios land."

--- a/plugins/plugin-anthropic-proxy/__tests__/proxy-status.action.test.ts
+++ b/plugins/plugin-anthropic-proxy/__tests__/proxy-status.action.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Action-surface tests for PROXY_STATUS: they drive the real
+ * `proxyStatusAction.handler` against a stubbed AnthropicProxyService so the
+ * status-formatting production logic (line assembly, optional fields, the
+ * service-missing degrade) is exercised deterministically without a live proxy
+ * or network. The service is a legitimate runtime boundary here — the handler's
+ * own DTO shaping is the code under test.
+ */
+
+import type { IAgentRuntime, Memory } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { proxyStatusAction } from "../src/actions/proxy-status.action.js";
+import { ANTHROPIC_PROXY_SERVICE_NAME } from "../src/services/proxy-service.js";
+
+// PROXY_STATUS reads only `runtime`, but the Handler/Validator signatures still
+// require a message; a placeholder satisfies the type without affecting output.
+const message = {} as unknown as Memory;
+
+async function runHandler(runtime: IAgentRuntime) {
+  const result = await proxyStatusAction.handler(runtime, message);
+  if (!result) {
+    throw new Error("PROXY_STATUS handler returned no ActionResult");
+  }
+  return result;
+}
+
+type ProxyStatus = Awaited<
+  ReturnType<import("../src/services/proxy-service.js").AnthropicProxyService["getStatus"]>
+>;
+
+function runtimeWithStatus(status: ProxyStatus | null): IAgentRuntime {
+  return {
+    getService(name: string) {
+      if (name !== ANTHROPIC_PROXY_SERVICE_NAME || status === null) {
+        return null;
+      }
+      return { getStatus: async () => status };
+    },
+  } as unknown as IAgentRuntime;
+}
+
+describe("PROXY_STATUS action", () => {
+  it("validates unconditionally so operators can always query status", async () => {
+    await expect(proxyStatusAction.validate(runtimeWithStatus(null), message)).resolves.toBe(true);
+  });
+
+  it("reports an explicit unavailable result when the service is not loaded", async () => {
+    const result = await runHandler(runtimeWithStatus(null));
+    expect(result.success).toBe(false);
+    expect(result.text).toContain("not loaded");
+    expect(result.values?.available).toBe(false);
+  });
+
+  it("formats a full shared-mode status, including upstream reachability", async () => {
+    const status: ProxyStatus = {
+      mode: "shared",
+      url: "http://127.0.0.1:8787",
+      listening: true,
+      startError: null,
+      stats: {
+        requestsServed: 42,
+        uptimeSec: 1234,
+        tokenExpiresInHours: 5.25,
+        subscriptionType: "max",
+      } as ProxyStatus["stats"],
+      upstream: { reachable: true, status: 200 },
+    };
+    const result = await runHandler(runtimeWithStatus(status));
+
+    expect(result.success).toBe(true);
+    expect(result.text).toContain("mode: shared");
+    expect(result.text).toContain("url: http://127.0.0.1:8787");
+    expect(result.text).toContain("listening: true");
+    expect(result.text).toContain("requests: 42");
+    expect(result.text).toContain("uptime: 1234s");
+    // toFixed(1) rounding is the production contract for the expiry line.
+    expect(result.text).toContain("tokenExpiresInHours: 5.3");
+    expect(result.text).toContain("subscription: max");
+    expect(result.text).toContain("upstream: reachable=true status=200");
+    expect(result.values?.available).toBe(true);
+    expect(result.values?.mode).toBe("shared");
+  });
+
+  it("degrades optional fields: null url, startError, null token expiry, unreachable upstream", async () => {
+    const status: ProxyStatus = {
+      mode: "off",
+      url: null,
+      listening: false,
+      startError: "boom",
+      stats: {
+        requestsServed: 0,
+        uptimeSec: 0,
+        tokenExpiresInHours: null,
+        subscriptionType: null,
+      } as ProxyStatus["stats"],
+      upstream: { reachable: false, error: "timeout" },
+    };
+    const result = await runHandler(runtimeWithStatus(status));
+
+    expect(result.success).toBe(true);
+    expect(result.text).toContain("url: (none)");
+    expect(result.text).toContain("startError: boom");
+    expect(result.text).not.toContain("tokenExpiresInHours:");
+    expect(result.text).toContain("subscription: unknown");
+    expect(result.text).toContain("upstream: reachable=false status=n/a error=timeout");
+  });
+});


### PR DESCRIPTION
## What

First slice of #15856 (drain the deterministic lane-coverage allowlist, one plugin per PR).

- Adds a **real** action-surface test that drives the production `proxyStatusAction.handler` (`plugins/plugin-anthropic-proxy/src/actions/proxy-status.action.ts`) against a stubbed `AnthropicProxyService` — the service is a legitimate runtime boundary; the handler's own status-line assembly and DTO shaping are the code under test. No mock of the thing under test, no filename-only/marker-only stub.
  - Covers: unconditional `validate`, the service-not-loaded **explicit unavailable** result (`success:false`, `available:false`), a full shared-mode status (mode/url/listening/requests/uptime/`toFixed(1)` token-expiry/subscription/upstream reachability), and optional-field degrade (null url → `(none)`, `startError`, omitted expiry line, unreachable upstream).
- Removes the now-satisfied `plugin-anthropic-proxy: missing-action-tests` entry from `packages/scripts/lint-lane-coverage.allowlist.json` in the **same PR**, keeping the enforced (non `--dry-run`) ratchet green.

## Why this is real coverage

Fails-before / passes-after: the test asserts the exact production text contract line-by-line; if the handler regresses (missing line, wrong rounding, wrong degrade), the test fails. It is deterministic — no live model, no network.

## Evidence

Focused plugin test (`bun run --cwd plugins/plugin-anthropic-proxy test`):
```
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Ratchet before removal (test present, entry stale):
```
allowlistErrorCount: 1
  allowlist: unused entry plugin-anthropic-proxy:missing-action-tests
```

Ratchet after removing the entry — `node packages/scripts/lint-lane-coverage.mjs` exit 0:
```
[lint-lane-coverage] 142 plugins scanned; 0 missing tests; 100 missing deterministic E2E/scenario coverage; 0 blocking issue(s); 149 suppressed issue(s).
```
`--json` summary: `unsuppressedIssueCount: 0`, `allowlistErrorCount: 0` (was 150 suppressed → 149; this action-tests finding is gone, not re-suppressed).

Gates: biome clean on the new test; plugin `typecheck` clean. The allowlist file's pre-existing whole-file array formatting is generator output identical to `develop` (not reformatted here).

## Scope

This is one slice; the allowlist still tracks the remaining 149 findings for future slices per the issue's per-plugin plan. Enforcement is unchanged — not weakened, deferred, or disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Evidence matrix

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only change; no rendered UI behavior changed

<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only change; no rendered UI behavior changed

<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic action-contract test only; no user flow changed

<!-- evidence-row:backend-logs -->
- [x] N/A - no production backend path changed

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changed

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or runtime behavior changed

<!-- evidence-row:domain-artifacts -->
- [x] [Reproduced handler-test and lane-ratchet proof](https://github.com/elizaOS/eliza/pull/15934#issuecomment-4931909459)