### PR TITLE
fix(core): validate anthropic cache-control shape at the boundary, drop unsafe casts (#15825)

### DIFF
--- a/plugins/plugin-openrouter/__tests__/anthropic-cache.shape.test.ts
+++ b/plugins/plugin-openrouter/__tests__/anthropic-cache.shape.test.ts
@@ -2,8 +2,11 @@
  * Shape tests for Anthropic prompt-cache injection in the OpenRouter text handler.
  * Covers the runtime-fallback cacheControl (Fix 2), internal-field stripping from wire
  * options (Fix 3a), segmented-user-content breakpoints with validated shapes and capping
- * (Fix 3b/3c), and the cacheSystem:false opt-out. AI SDK and provider are mocked —
- * no network calls, deterministic string fixtures.
+ * (Fix 3b/3c), the cacheSystem:false opt-out, verbatim survival of caller-supplied
+ * providerOptions (openrouter + arbitrary keys) alongside injected cacheControl and
+ * multi-breakpoint stamping (#15825), and the explicit boundary failure when a
+ * caller-supplied cacheControl is malformed (#15825, no silent drop). AI SDK and provider
+ * are mocked — no network calls, deterministic string fixtures.
  */
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -249,6 +252,114 @@ describe("Anthropic cache injection — segmented user content", () => {
     // Only segmentIndex 0 survives the cap of 1
     expect(cachedBlocks).toHaveLength(1);
     expect(cachedBlocks?.[0]?.text).toBe("s0");
+  });
+});
+
+describe("Anthropic cache injection — caller providerOptions survive verbatim", () => {
+  it("preserves openrouter.promptCacheKey and arbitrary provider keys alongside injected cacheControl", async () => {
+    const { generateText } = mockModules();
+    const { handleTextLarge } = await import("../models/text");
+
+    await handleTextLarge(createRuntime(), {
+      prompt: "hello",
+      providerOptions: {
+        openrouter: { promptCacheKey: "caller-key-123" },
+        gateway: { caching: "auto" },
+        customProvider: { nested: { flag: true }, count: 7 },
+      },
+    } as never);
+
+    const call = generateText.mock.calls[0][0] as Record<string, unknown>;
+    const providerOpts = call.providerOptions as Record<string, unknown>;
+    // Caller keys survive unchanged into the serialized request.
+    expect(providerOpts.openrouter).toEqual({ promptCacheKey: "caller-key-123" });
+    expect(providerOpts.gateway).toEqual({ caching: "auto" });
+    expect(providerOpts.customProvider).toEqual({ nested: { flag: true }, count: 7 });
+    // And the injected message-level cacheControl is still applied on the system message.
+    const messages = call.messages as Array<Record<string, unknown>>;
+    const anthropicOpts = (messages?.[0]?.providerOptions as Record<string, unknown>)?.anthropic as
+      | Record<string, unknown>
+      | undefined;
+    expect(anthropicOpts?.cacheControl).toEqual(expect.objectContaining({ type: "ephemeral" }));
+  });
+
+  it("stamps cacheControl on multiple segment breakpoints while caller providerOptions survive", async () => {
+    const { generateText } = mockModules();
+    const { handleTextLarge } = await import("../models/text");
+
+    await handleTextLarge(createRuntime(), {
+      prompt: "s0s1s2",
+      promptSegments: [
+        { content: "s0", stable: true },
+        { content: "s1", stable: true },
+        { content: "s2", stable: false },
+      ],
+      providerOptions: {
+        openrouter: { promptCacheKey: "multi-bp" },
+        anthropic: {
+          cacheBreakpoints: [
+            { segmentIndex: 0, cacheControl: { type: "ephemeral" } },
+            { segmentIndex: 1, cacheControl: { type: "ephemeral", ttl: "1h" } },
+          ],
+        },
+      },
+    } as never);
+
+    const call = generateText.mock.calls[0][0] as Record<string, unknown>;
+    const messages = call.messages as Array<Record<string, unknown>>;
+    const content = messages?.[1]?.content as Array<Record<string, unknown>>;
+    expect(content).toHaveLength(3);
+    const cc0 = (content[0]?.providerOptions as Record<string, unknown>)?.anthropic as
+      | Record<string, unknown>
+      | undefined;
+    const cc1 = (content[1]?.providerOptions as Record<string, unknown>)?.anthropic as
+      | Record<string, unknown>
+      | undefined;
+    expect(cc0?.cacheControl).toEqual({ type: "ephemeral" });
+    expect(cc1?.cacheControl).toEqual({ type: "ephemeral", ttl: "1h" });
+    expect(content[2]?.providerOptions).toBeUndefined();
+    // Caller-supplied openrouter option survives.
+    expect((call.providerOptions as Record<string, unknown>).openrouter).toEqual({
+      promptCacheKey: "multi-bp",
+    });
+  });
+});
+
+describe("Anthropic cache injection — malformed cacheControl fails loudly", () => {
+  it("throws when caller-supplied cacheControl has an unsupported type", async () => {
+    mockModules();
+    const { handleTextLarge } = await import("../models/text");
+
+    await expect(
+      handleTextLarge(createRuntime(), {
+        prompt: "hello",
+        providerOptions: { anthropic: { cacheControl: { type: "persistent" } } },
+      } as never)
+    ).rejects.toThrow(/cacheControl/);
+  });
+
+  it("throws when cacheControl is present but not an object", async () => {
+    mockModules();
+    const { handleTextLarge } = await import("../models/text");
+
+    await expect(
+      handleTextLarge(createRuntime(), {
+        prompt: "hello",
+        providerOptions: { anthropic: { cacheControl: "ephemeral" } },
+      } as never)
+    ).rejects.toThrow(/cacheControl/);
+  });
+
+  it("throws when cacheControl.ttl is an unsupported value", async () => {
+    mockModules();
+    const { handleTextLarge } = await import("../models/text");
+
+    await expect(
+      handleTextLarge(createRuntime(), {
+        prompt: "hello",
+        providerOptions: { anthropic: { cacheControl: { type: "ephemeral", ttl: "2h" } } },
+      } as never)
+    ).rejects.toThrow(/ttl/);
   });
 });
 

--- a/plugins/plugin-openrouter/models/text.ts
+++ b/plugins/plugin-openrouter/models/text.ts
@@ -34,6 +34,7 @@ import type {
 import {
   buildCanonicalSystemPrompt,
   dropDuplicateLeadingSystemMessage,
+  ElizaError,
   ModelType,
   resolveEffectiveSystemPrompt,
 } from "@elizaos/core";
@@ -43,7 +44,9 @@ import {
   jsonSchema,
   type LanguageModel,
   type ModelMessage,
+  type SystemModelMessage,
   streamText,
+  type TextPart,
   type ToolChoice,
   type ToolSet,
   type UserContent,
@@ -235,10 +238,28 @@ function isAnthropicModel(modelName: string): boolean {
   return modelName.toLowerCase().startsWith("anthropic/");
 }
 
+// AI SDK `providerOptions` is typed `Record<string, JSONObject>`, so the
+// optional `ttl` on AnthropicCacheControl (which widens to `... | undefined`,
+// not a JSON value) is materialized here as a concrete key-or-omit shape. This
+// lets the segment/system builders return real `SystemModelMessage` / `TextPart`
+// values that the SDK accepts without an `as unknown` escape hatch.
+type WireProviderOptions = NonNullable<SystemModelMessage["providerOptions"]>;
+
+function anthropicCacheProviderOptions(cacheControl: AnthropicCacheControl): WireProviderOptions {
+  return {
+    anthropic: {
+      cacheControl:
+        cacheControl.ttl === "5m" || cacheControl.ttl === "1h"
+          ? { type: "ephemeral", ttl: cacheControl.ttl }
+          : { type: "ephemeral" },
+    },
+  };
+}
+
 function buildCacheableSystemMessage(
   systemPrompt: string | undefined,
   cacheControl: AnthropicCacheControl | undefined
-): ModelMessage | undefined {
+): SystemModelMessage | undefined {
   if (!systemPrompt) {
     return undefined;
   }
@@ -248,10 +269,8 @@ function buildCacheableSystemMessage(
   return {
     role: "system",
     content: systemPrompt,
-    providerOptions: {
-      anthropic: { cacheControl },
-    },
-  } as unknown as ModelMessage;
+    providerOptions: anthropicCacheProviderOptions(cacheControl),
+  };
 }
 
 function readAnthropicCacheControl(
@@ -261,11 +280,27 @@ function readAnthropicCacheControl(
     return undefined;
   }
   const cacheControl = anthropicOptions.cacheControl;
-  if (isRecord(cacheControl) && cacheControl.type === "ephemeral") {
-    return {
-      type: "ephemeral",
-      ...(cacheControl.ttl === "5m" || cacheControl.ttl === "1h" ? { ttl: cacheControl.ttl } : {}),
-    };
+  // A caller that supplies `cacheControl` is explicitly opting into prompt
+  // caching. A malformed shape must fail loudly: silently dropping it would emit
+  // an uncached request while the caller believes caching is active, and the
+  // wire would still report the option as accepted. Fail fast at the boundary.
+  if (cacheControl !== undefined) {
+    if (!isRecord(cacheControl) || cacheControl.type !== "ephemeral") {
+      throw new ElizaError("Invalid anthropic.cacheControl: expected { type: 'ephemeral' }", {
+        code: "OPENROUTER_INVALID_CACHE_CONTROL",
+        context: { cacheControl },
+        severity: "fatal",
+      });
+    }
+    const ttl = cacheControl.ttl;
+    if (ttl !== undefined && ttl !== "5m" && ttl !== "1h") {
+      throw new ElizaError("Invalid anthropic.cacheControl.ttl: expected '5m' or '1h'", {
+        code: "OPENROUTER_INVALID_CACHE_CONTROL",
+        context: { ttl },
+        severity: "fatal",
+      });
+    }
+    return { type: "ephemeral", ...(ttl === "5m" || ttl === "1h" ? { ttl } : {}) };
   }
   return anthropicOptions.cacheSystem === true ? { type: "ephemeral" } : undefined;
 }
@@ -295,14 +330,6 @@ function getRuntimeCacheControl(runtime: IAgentRuntime): AnthropicCacheControl {
 }
 
 type AnthropicCacheBreakpoint = { segmentIndex: number; cacheControl: AnthropicCacheControl };
-
-// Extends the AI SDK TextPart shape with provider-metadata so the AI SDK can forward
-// cache_control directives to the wire without losing the type guarantee on type/text.
-type CacheableTextPart = {
-  type: "text";
-  text: string;
-  providerOptions?: Record<string, unknown>;
-};
 
 function isAnthropicCacheBreakpoint(value: unknown): value is AnthropicCacheBreakpoint {
   return (
@@ -334,7 +361,7 @@ function readAnthropicCacheBreakpoints(
 function buildSegmentedPromptUserContent(
   promptSegments: Array<{ content: string; stable?: boolean }>,
   cacheBreakpoints: AnthropicCacheBreakpoint[]
-): CacheableTextPart[] {
+): TextPart[] {
   if (cacheBreakpoints.length === 0) {
     return promptSegments.map((seg) => ({ type: "text" as const, text: seg.content }));
   }
@@ -347,7 +374,7 @@ function buildSegmentedPromptUserContent(
       return {
         type: "text" as const,
         text: seg.content,
-        providerOptions: { anthropic: { cacheControl: cc } },
+        providerOptions: anthropicCacheProviderOptions(cc),
       };
     }
     return { type: "text" as const, text: seg.content };
@@ -649,10 +676,7 @@ function buildGenerateParams(
                 // additional breakpoints under Anthropic's four-block cap).
                 content:
                   promptSegments.length > 0 && cacheBreakpoints.length > 0 && !userContent
-                    ? (buildSegmentedPromptUserContent(
-                        promptSegments,
-                        cacheBreakpoints
-                      ) as UserContent)
+                    ? buildSegmentedPromptUserContent(promptSegments, cacheBreakpoints)
                     : (userContent ?? buildUserContent(paramsWithAttachments)),
               },
             ],


### PR DESCRIPTION
Closes #15825. Follow-up to #15777.

## Problem

The OpenRouter Anthropic prompt-cache path (`plugins/plugin-openrouter/models/text.ts`) injected message-level `cache_control` through two unsafe escape-hatch casts, and silently dropped a caller-supplied `cacheControl` when its shape was malformed:

- `buildCacheableSystemMessage` returned `... as unknown as ModelMessage`.
- `buildSegmentedPromptUserContent` output was cast `as UserContent`.
- `readAnthropicCacheControl` fell through to `undefined` for a present-but-malformed `cacheControl` — emitting an **uncached** request while the wire still reported the option as accepted (broken pipeline looks healthy).

## Fix

- **Remove both casts.** The casts existed only because `AnthropicCacheControl.ttl?` widens to `... | undefined`, which is not a `JSONValue` and so not assignable to the SDK's `providerOptions: Record<string, JSONObject>`. A new `anthropicCacheProviderOptions` helper materializes `ttl` into a concrete key-or-omit shape, so `buildCacheableSystemMessage` returns a real `SystemModelMessage` and `buildSegmentedPromptUserContent` returns real `TextPart[]` — both accepted by the AI SDK with **no casts**. (`CacheableTextPart` deleted.)
- **Fail fast at the boundary.** `readAnthropicCacheControl` now throws a typed `ElizaError` (`code: OPENROUTER_INVALID_CACHE_CONTROL`, `severity: fatal`) when a present `cacheControl` is not a valid `{ type: "ephemeral" }` shape or carries an unsupported `ttl`, instead of silently dropping the option.
- **Caller providerOptions survive verbatim.** The pre-existing additive merge (`restProviderOptions` spread) is unchanged; `openrouter.promptCacheKey` and arbitrary provider keys reach the serialized `generateText` params untouched.

## Acceptance mapping

| Acceptance | Status |
| --- | --- |
| No `as unknown as ModelMessage` / `as UserContent` on cache path | Done — `grep` returns none; enforced by typecheck |
| Malformed anthropic shape → explicit typed error, no silent drop | Done — `ElizaError` throw |
| Caller providerOptions (openrouter + arbitrary keys) survive verbatim | Done — asserted in tests |
| Multiple cache breakpoints stamped | Done — asserted in tests |
| Live OpenRouter/Anthropic trajectory | N/A here — owner-run evidence (requires live `OPENROUTER_API_KEY` + Anthropic model); code correctness is fully unit-verifiable via the deterministic AI-SDK-mock harness |

## Test evidence

Extended `plugins/plugin-openrouter/__tests__/anthropic-cache.shape.test.ts` (existing harness mocks the AI SDK and inspects the wire shape). New cases: caller keys survive alongside injected cacheControl, >1 segment breakpoint stamped, and malformed cacheControl throws.

**Fails-before / passes-after** — reverting only the validation logic makes the three throw-cases red:

```
 ❯ __tests__/anthropic-cache.shape.test.ts (14 tests | 3 failed)
     × throws when caller-supplied cacheControl has an unsupported type
     × throws when cacheControl is present but not an object
     × throws when cacheControl.ttl is an unsupported value
```

**Passes-after** (`bun run --cwd plugins/plugin-openrouter test:unit`):

```
 Test Files  7 passed (7)
      Tests  56 passed (56)
```

**Typecheck** (`bun run --cwd plugins/plugin-openrouter typecheck`) — clean (proves the casts are gone, not merely suppressed). Biome check clean on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Evidence

<!-- evidence-row:before-screenshots -->
- Before screenshots: `N/A - backend/CI/build change, no UI surface`
<!-- evidence-row:after-screenshots -->
- After screenshots: `N/A - backend/CI/build change, no UI surface`
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: `N/A - no user-facing flow changed`
<!-- evidence-row:backend-logs -->
- Backend logs: `N/A - covered by the deterministic unit test output in the PR body`
<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: `N/A - no frontend surface`
<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model behavior change`
<!-- evidence-row:domain-artifacts -->
- Domain artifacts: `N/A - no DB/memory/scheduled-task/wallet/on-chain output; change is code + tests only`