### PR TITLE
fix(discord): retry initial login with backoff on transient boot failure (#15855)

### DIFF
--- a/plugins/plugin-discord/__tests__/login-retry.test.ts
+++ b/plugins/plugin-discord/__tests__/login-retry.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Drives the real initial-login retry loop (`DiscordService.attemptDiscordLogin`)
+ * against a deterministic fake discord.js client whose `login()` rejects N times
+ * then resolves and emits ClientReady. Guards #15855: a transient boot-time
+ * login failure must retry with backoff and eventually reach ready — never
+ * settle terminal, leaving the process connected-but-deaf. Collaborators that
+ * are not under test (event wiring, onReady backfill, legacy aliasing) are
+ * stubbed on the instance; the retry/backoff/heartbeat code runs for real.
+ */
+import { Events } from "discord.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DiscordAccountClientState } from "../account-client-pool.ts";
+import { DiscordService } from "../service.ts";
+
+type FakeClient = {
+	once: (event: string, cb: (...args: unknown[]) => void) => FakeClient;
+	on: () => FakeClient;
+	login: ReturnType<typeof vi.fn>;
+	destroy: ReturnType<typeof vi.fn>;
+	isReady: () => boolean;
+	emit: (event: string, ...args: unknown[]) => void;
+};
+
+function makeFakeClient(shouldSucceed: boolean): FakeClient {
+	const handlers = new Map<string, (...args: unknown[]) => void>();
+	const client: FakeClient = {
+		once(event, cb) {
+			handlers.set(event, cb);
+			return client;
+		},
+		on: () => client,
+		destroy: vi.fn().mockResolvedValue(undefined),
+		isReady: () => true,
+		emit(event, ...args) {
+			handlers.get(event)?.(...args);
+		},
+		login: vi.fn().mockImplementation(async () => {
+			if (!shouldSucceed) {
+				throw new Error("The socket connection was closed unexpectedly.");
+			}
+			// discord.js emits ClientReady asynchronously once the gateway session
+			// is up; mirror that so the ready handler fires after login resolves.
+			queueMicrotask(() => client.emit(Events.ClientReady, client));
+			return "token";
+		}),
+	};
+	return client;
+}
+
+function makeRuntime() {
+	return {
+		agentId: "agent-1",
+		character: { name: "Eliza" },
+		logger: {
+			error: vi.fn(),
+			warn: vi.fn(),
+			info: vi.fn(),
+			debug: vi.fn(),
+		},
+	};
+}
+
+function makeState(accountId: string): DiscordAccountClientState {
+	return {
+		accountId,
+		account: { accountId, token: "bot-token" },
+		client: null,
+		settings: {},
+		dynamicChannelIds: new Set(),
+		clientReadyPromise: null,
+		loginFailed: false,
+	} as unknown as DiscordAccountClientState;
+}
+
+describe("DiscordService initial-login retry (#15855)", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("retries a transient login failure with backoff and eventually reaches ready", async () => {
+		const runtime = makeRuntime();
+		const clients: FakeClient[] = [];
+		const FAIL_TIMES = 2;
+
+		const service = Object.assign(Object.create(DiscordService.prototype), {
+			runtime,
+			defaultAccountId: "default",
+			_loginFailed: false,
+			timeouts: [] as ReturnType<typeof setTimeout>[],
+			createDiscordJsClient: () => {
+				const client = makeFakeClient(clients.length >= FAIL_TIMES);
+				clients.push(client);
+				return client;
+			},
+			// Isolate the retry loop from the heavy gateway/backfill collaborators.
+			setupEventListenersForAccount: vi.fn(),
+			onReadyForAccount: vi.fn().mockResolvedValue(undefined),
+			syncLegacyDefaultAliases: vi.fn(),
+		}) as unknown as DiscordService & {
+			attemptDiscordLogin: (
+				state: DiscordAccountClientState,
+				token: string,
+				attempt: number,
+				resolve: () => void,
+				reject: (error: unknown) => void,
+			) => void;
+			_loginFailed: boolean;
+		};
+
+		const state = makeState("default");
+		let readyResolved = false;
+
+		const ready = new Promise<void>((resolve, reject) => {
+			service.attemptDiscordLogin(state, "bot-token", 0, resolve, reject);
+		}).then(() => {
+			readyResolved = true;
+		});
+
+		// Advance past both backoff windows (1s + 2s) so all three attempts run.
+		await vi.advanceTimersByTimeAsync(5_000);
+		await ready;
+
+		// login was attempted more than once (one client per attempt).
+		const totalLoginCalls = clients.reduce(
+			(sum, c) => sum + c.login.mock.calls.length,
+			0,
+		);
+		expect(clients.length).toBe(FAIL_TIMES + 1);
+		expect(totalLoginCalls).toBeGreaterThan(1);
+
+		// The ready promise resolves once the network recovers.
+		expect(readyResolved).toBe(true);
+		expect(state.loginFailed).toBe(false);
+		expect(service._loginFailed).toBe(false);
+
+		// A Warn heartbeat named the account + failure while it was failing.
+		const warnCalls = runtime.logger.warn.mock.calls;
+		expect(warnCalls.length).toBeGreaterThanOrEqual(1);
+		const heartbeat = warnCalls.find((call) =>
+			String(call[1] ?? call[0]).includes("connected-but-deaf"),
+		);
+		expect(heartbeat).toBeDefined();
+		expect(String(heartbeat?.[1])).toContain("default");
+		expect(heartbeat?.[0]).toMatchObject({
+			accountId: "default",
+			error: "The socket connection was closed unexpectedly.",
+		});
+	});
+
+	it("does not schedule a retry when the first login succeeds", async () => {
+		const runtime = makeRuntime();
+		const clients: FakeClient[] = [];
+
+		const service = Object.assign(Object.create(DiscordService.prototype), {
+			runtime,
+			defaultAccountId: "default",
+			_loginFailed: false,
+			timeouts: [] as ReturnType<typeof setTimeout>[],
+			createDiscordJsClient: () => {
+				const client = makeFakeClient(true);
+				clients.push(client);
+				return client;
+			},
+			setupEventListenersForAccount: vi.fn(),
+			onReadyForAccount: vi.fn().mockResolvedValue(undefined),
+			syncLegacyDefaultAliases: vi.fn(),
+		}) as unknown as DiscordService & {
+			attemptDiscordLogin: (
+				state: DiscordAccountClientState,
+				token: string,
+				attempt: number,
+				resolve: () => void,
+				reject: (error: unknown) => void,
+			) => void;
+			timeouts: ReturnType<typeof setTimeout>[];
+		};
+
+		const state = makeState("default");
+		await new Promise<void>((resolve, reject) => {
+			service.attemptDiscordLogin(state, "bot-token", 0, resolve, reject);
+		});
+
+		expect(clients.length).toBe(1);
+		expect(service.timeouts.length).toBe(0);
+		expect(runtime.logger.warn).not.toHaveBeenCalled();
+	});
+});

--- a/plugins/plugin-discord/__tests__/login-retry.test.ts
+++ b/plugins/plugin-discord/__tests__/login-retry.test.ts
@@ -1,10 +1,12 @@
 /**
  * Drives the real initial-login retry loop (`DiscordService.attemptDiscordLogin`)
  * against a deterministic fake discord.js client whose `login()` rejects N times
- * then resolves and emits ClientReady. Guards #15855: a transient boot-time
- * login failure must retry with backoff and eventually reach ready — never
- * settle terminal, leaving the process connected-but-deaf. Collaborators that
- * are not under test (event wiring, onReady backfill, legacy aliasing) are
+ * then resolves and emits ClientReady, plus focused checks of the real backoff
+ * (`computeLoginBackoffMs`) and throttled failure heartbeat
+ * (`emitLoginFailureHeartbeat`). Guards #15855: a transient boot-time login
+ * failure must retry with capped-exponential backoff and eventually reach ready
+ * — never settle terminal, leaving the process connected-but-deaf. Collaborators
+ * that are not under test (event wiring, onReady backfill, legacy aliasing) are
  * stubbed on the instance; the retry/backoff/heartbeat code runs for real.
  */
 import { Events } from "discord.js";
@@ -144,10 +146,70 @@ describe("DiscordService initial-login retry (#15855)", () => {
 		);
 		expect(heartbeat).toBeDefined();
 		expect(String(heartbeat?.[1])).toContain("default");
+		// The first retry waits the backoff base (1s) and names the attempt.
 		expect(heartbeat?.[0]).toMatchObject({
 			accountId: "default",
+			attempt: 1,
+			retryInMs: 1_000,
 			error: "The socket connection was closed unexpectedly.",
 		});
+
+		// Once connected, the loop stops: discord.js owns reconnection from here,
+		// so no further warn heartbeat fires however long we wait, and no retry
+		// timer stays armed on the account.
+		const warnCountAtReady = runtime.logger.warn.mock.calls.length;
+		await vi.advanceTimersByTimeAsync(120_000);
+		expect(runtime.logger.warn.mock.calls.length).toBe(warnCountAtReady);
+		expect(state.loginRetryTimer).toBeUndefined();
+	});
+
+	it("computes capped exponential backoff per attempt", () => {
+		const service = Object.assign(Object.create(DiscordService.prototype), {
+			runtime: makeRuntime(),
+		}) as unknown as DiscordService & {
+			computeLoginBackoffMs: (attempt: number) => number;
+		};
+
+		// Delay doubles from the 1s base each attempt, then clamps at the 60s cap
+		// so an indefinitely-down network settles into a steady retry cadence.
+		expect(service.computeLoginBackoffMs(0)).toBe(1_000);
+		expect(service.computeLoginBackoffMs(1)).toBe(2_000);
+		expect(service.computeLoginBackoffMs(2)).toBe(4_000);
+		expect(service.computeLoginBackoffMs(5)).toBe(32_000);
+		expect(service.computeLoginBackoffMs(6)).toBe(60_000);
+		expect(service.computeLoginBackoffMs(20)).toBe(60_000);
+	});
+
+	it("throttles the failure heartbeat to at most one per interval", () => {
+		const runtime = makeRuntime();
+		const service = Object.assign(Object.create(DiscordService.prototype), {
+			runtime,
+		}) as unknown as DiscordService & {
+			emitLoginFailureHeartbeat: (
+				state: DiscordAccountClientState,
+				error: unknown,
+				attempt: number,
+				delayMs: number,
+			) => void;
+		};
+		const state = makeState("default");
+		const error = new Error("The socket connection was closed unexpectedly.");
+
+		vi.setSystemTime(0);
+		service.emitLoginFailureHeartbeat(state, error, 0, 1_000);
+		expect(runtime.logger.warn).toHaveBeenCalledTimes(1);
+
+		// Inside the 30s throttle window a fast retry storm is suppressed so it
+		// cannot flood the log.
+		vi.setSystemTime(10_000);
+		service.emitLoginFailureHeartbeat(state, error, 1, 2_000);
+		expect(runtime.logger.warn).toHaveBeenCalledTimes(1);
+
+		// Past the window the heartbeat fires again, keeping a stuck account
+		// observably surfaced.
+		vi.setSystemTime(41_000);
+		service.emitLoginFailureHeartbeat(state, error, 2, 4_000);
+		expect(runtime.logger.warn).toHaveBeenCalledTimes(2);
 	});
 
 	it("does not schedule a retry when the first login succeeds", async () => {

--- a/plugins/plugin-discord/account-client-pool.ts
+++ b/plugins/plugin-discord/account-client-pool.ts
@@ -24,6 +24,12 @@ export interface DiscordAccountClientState {
 	dynamicChannelIds: Set<string>;
 	clientReadyPromise: Promise<void> | null;
 	loginFailed: boolean;
+	// Pending initial-login retry, tracked so `stop()` can cancel an in-flight
+	// backoff and the ClientReady handler can clear a superseded retry.
+	loginRetryTimer?: ReturnType<typeof setTimeout>;
+	// Wall-clock of the last login-failure heartbeat, used to throttle the Warn
+	// heartbeat while the account is stuck retrying.
+	lastLoginHeartbeatAt?: number;
 	messageManager?: MessageManager;
 	voiceManager?: VoiceManager;
 	channelDebouncer?: ChannelDebouncer;

--- a/plugins/plugin-discord/service.ts
+++ b/plugins/plugin-discord/service.ts
@@ -199,6 +199,18 @@ type DiscordAccountServiceFacade = IDiscordService &
 		isVoiceChannelClaimed(guildId: string, channelId: string): boolean;
 	};
 
+// Initial-login retry schedule. discord.js only auto-reconnects once a gateway
+// session exists, so a transient failure of the FIRST `client.login()` is
+// otherwise terminal — the process stays "active" but deaf (#15855). We retry
+// the initial connect with capped exponential backoff (base doubles per
+// attempt, clamped) and keep retrying indefinitely until a session is
+// established; the network coming back is the only success condition.
+const DISCORD_LOGIN_RETRY_BASE_MS = 1_000;
+const DISCORD_LOGIN_RETRY_MAX_MS = 60_000;
+// While an account is stuck in the failed state, warn at most this often so the
+// retry storm surfaces as an observable heartbeat without flooding the log.
+const DISCORD_LOGIN_HEARTBEAT_MIN_INTERVAL_MS = 30_000;
+
 // Forward Content.metadata onto the persisted Memory (e.g. `transient: true`
 // for orchestrator status posts). Plain-object guard so arrays/instances don't leak through.
 function extractContentMetadata(
@@ -1441,49 +1453,12 @@ export class DiscordService extends Service implements IDiscordService {
 		state.voiceManager = new VoiceManager(facade, this.runtime);
 		state.messageManager = new MessageManager(facade, this.runtime);
 
-		const client = state.client;
-		if (!client) {
-			throw new Error(
-				`Discord client is not available for account ${state.accountId}`,
-			);
-		}
-		state.clientReadyPromise = new Promise((resolve, reject) => {
-			client.once(Events.ClientReady, async (readyClient) => {
-				try {
-					await this.onReadyForAccount(state.accountId, readyClient);
-					resolve();
-				} catch (error) {
-					this.runtime.logger.error(
-						`Error in Discord onReady for account ${state.accountId}: ${
-							error instanceof Error ? error.message : String(error)
-						}`,
-					);
-					reject(error);
-				}
-			});
-			client.once(Events.Error, (error) => {
-				this.runtime.logger.error(
-					`Discord client error for account ${state.accountId}: ${
-						error instanceof Error ? error.message : String(error)
-					}`,
-				);
-				state.loginFailed = true;
-				reject(error);
-			});
-			client.login(account.token).catch((error) => {
-				this.runtime.logger.warn(
-					`Failed to login to Discord account ${state.accountId}: ${
-						error instanceof Error ? error.message : String(error)
-					} — check the configured Discord bot token`,
-				);
-				state.loginFailed = true;
-				state.client?.destroy().catch(() => {});
-				state.client = null;
-				if (state.accountId === this.defaultAccountId) {
-					this.syncLegacyDefaultAliases(state);
-				}
-				reject(error);
-			});
+		// Initial login now retries with backoff instead of settling terminal on
+		// a transient transport failure (#15855). The promise resolves on the
+		// first successful ClientReady (any attempt) and only rejects on a
+		// terminal post-ready onReady failure — never on a login rejection.
+		state.clientReadyPromise = new Promise<void>((resolve, reject) => {
+			this.attemptDiscordLogin(state, account.token, 0, resolve, reject);
 		});
 
 		state.clientReadyPromise.catch((error) => {
@@ -1501,8 +1476,149 @@ export class DiscordService extends Service implements IDiscordService {
 				this._loginFailed = true;
 			}
 		});
+	}
 
+	/**
+	 * Drives one initial-login attempt for an account and re-arms the next on
+	 * failure. discord.js destroys the client when `login()` rejects, so each
+	 * attempt binds a fresh client (created here once the prior one was torn
+	 * down), re-attaches the gateway listeners, and races ClientReady against the
+	 * login rejection / gateway Error. Success resolves the ready promise and
+	 * clears the failed state; a transient failure discards the client and
+	 * schedules `attempt + 1` after a capped-exponential backoff, keeping the
+	 * connector self-healing instead of running deaf-but-active (#15855). Once
+	 * ClientReady fires, discord.js owns reconnection — this loop stops.
+	 */
+	private attemptDiscordLogin(
+		state: DiscordAccountClientState,
+		token: string,
+		attempt: number,
+		resolve: () => void,
+		reject: (error: unknown) => void,
+	): void {
+		if (!state.client) {
+			state.client = this.createDiscordJsClient();
+		}
+		const client = state.client;
+		// Rebind message/reaction/guild listeners onto this (possibly fresh)
+		// client; the prior attempt's debouncer is discarded with its client.
+		state.channelDebouncer?.destroy();
 		this.setupEventListenersForAccount(state);
+
+		// ClientReady, gateway Error, and the login() rejection can all fire for
+		// one attempt — settle exactly once so we never both resolve and retry.
+		let settled = false;
+
+		const scheduleRetry = (error: unknown): void => {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			state.loginFailed = true;
+			if (state.accountId === this.defaultAccountId) {
+				this._loginFailed = true;
+				this.syncLegacyDefaultAliases(state);
+			}
+			state.client?.destroy().catch((destroyError) => {
+				// error-policy:J6 best-effort teardown of the client we are replacing
+				this.runtime.logger.debug(
+					`Discord client teardown after failed login for account ${state.accountId}: ${
+						destroyError instanceof Error
+							? destroyError.message
+							: String(destroyError)
+					}`,
+				);
+			});
+			state.client = null;
+			const delayMs = this.computeLoginBackoffMs(attempt);
+			this.emitLoginFailureHeartbeat(state, error, attempt, delayMs);
+			const timer = setTimeout(() => {
+				state.loginRetryTimer = undefined;
+				this.attemptDiscordLogin(state, token, attempt + 1, resolve, reject);
+			}, delayMs);
+			state.loginRetryTimer = timer;
+			this.timeouts.push(timer);
+		};
+
+		client.once(Events.ClientReady, async (readyClient) => {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			if (state.loginRetryTimer) {
+				clearTimeout(state.loginRetryTimer);
+				state.loginRetryTimer = undefined;
+			}
+			state.loginFailed = false;
+			state.lastLoginHeartbeatAt = undefined;
+			if (state.accountId === this.defaultAccountId) {
+				this._loginFailed = false;
+			}
+			try {
+				await this.onReadyForAccount(state.accountId, readyClient);
+				resolve();
+			} catch (error) {
+				// A post-ready onReady failure (backfill/voice scan) is terminal, not
+				// a login-transport problem — surface it rather than looping login.
+				this.runtime.logger.error(
+					`Error in Discord onReady for account ${state.accountId}: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+				);
+				reject(error);
+			}
+		});
+		client.once(Events.Error, (error) => {
+			this.runtime.logger.error(
+				`Discord client error for account ${state.accountId}: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+			scheduleRetry(error);
+		});
+		client.login(token).catch((error) => {
+			scheduleRetry(error);
+		});
+	}
+
+	// Capped exponential backoff for the initial-login retry loop: the delay
+	// doubles per attempt and clamps at DISCORD_LOGIN_RETRY_MAX_MS.
+	private computeLoginBackoffMs(attempt: number): number {
+		const scaled = DISCORD_LOGIN_RETRY_BASE_MS * 2 ** attempt;
+		return Math.min(scaled, DISCORD_LOGIN_RETRY_MAX_MS);
+	}
+
+	/**
+	 * Warn-level heartbeat naming the account and the login failure, throttled to
+	 * at most once per DISCORD_LOGIN_HEARTBEAT_MIN_INTERVAL_MS so a fast retry
+	 * storm surfaces observably (#15855) without flooding the log.
+	 */
+	private emitLoginFailureHeartbeat(
+		state: DiscordAccountClientState,
+		error: unknown,
+		attempt: number,
+		delayMs: number,
+	): void {
+		const now = Date.now();
+		const last = state.lastLoginHeartbeatAt;
+		if (
+			last !== undefined &&
+			now - last < DISCORD_LOGIN_HEARTBEAT_MIN_INTERVAL_MS
+		) {
+			return;
+		}
+		state.lastLoginHeartbeatAt = now;
+		this.runtime.logger.warn(
+			{
+				src: "plugin:discord",
+				agentId: this.runtime.agentId,
+				accountId: state.accountId,
+				attempt: attempt + 1,
+				retryInMs: delayMs,
+				error: error instanceof Error ? error.message : String(error),
+			},
+			`Discord account ${state.accountId} failed to log in and is connected-but-deaf; retrying in ${delayMs}ms (attempt ${attempt + 1})`,
+		);
 	}
 
 	/**

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -156,6 +156,32 @@ export default defineConfig({
         find: /^@elizaos\/vault\/(.+)$/,
         replacement: path.join(root, "packages/vault/src/$1"),
       },
+      {
+        // plugin-commands ships only a built `dist/` entry, so a test run
+        // straight from source (targeted package tests, the changed-files
+        // coverage gate) fails to resolve its `.`/`./*` exports with "Failed to
+        // resolve entry for @elizaos/plugin-commands" whenever a graph pulls in
+        // the Discord connector (service.ts → catalog-commands.ts). Pin barrel
+        // and subpaths to source; mirrors plugin-discord/vitest.config.ts so the
+        // per-package lane and this root lane resolve identically.
+        find: /^@elizaos\/plugin-commands$/,
+        replacement: path.join(root, "plugins/plugin-commands/src/index.ts"),
+      },
+      {
+        find: /^@elizaos\/plugin-commands\/(.+)$/,
+        replacement: path.join(root, "plugins/plugin-commands/src/$1"),
+      },
+      {
+        // Same source-resolution story for @elizaos/plugin-meetings: the Discord
+        // voice-meeting seams import its barrel, and it too ships no dist in the
+        // test lane.
+        find: /^@elizaos\/plugin-meetings$/,
+        replacement: path.join(root, "plugins/plugin-meetings/src/index.ts"),
+      },
+      {
+        find: /^@elizaos\/plugin-meetings\/(.+)$/,
+        replacement: path.join(root, "plugins/plugin-meetings/src/$1"),
+      },
     ],
   },
 });


### PR DESCRIPTION
Closes part 1 of #15855.

## Problem

On a transient socket failure of the **first** `client.login()` at boot, the Discord connector settled terminal: it destroyed the client, nulled `state.client`, and rejected the ready promise permanently. discord.js only auto-reconnects **after** a gateway session exists, so the initial rejection is never retried — the process ran `active` with the task scheduler humming but **fully deaf** (zero inbound processing) until a manual restart. In the live incident this was ~19 minutes of a healthy-looking corpse.

## Fix (scope: part 1 — login retry + failed-state heartbeat)

`initializeAccount` now drives the initial login through a new `attemptDiscordLogin` retry loop that:

- **re-creates the discord.js client per attempt** (the failed one is destroyed, so a retry cannot reuse the corpse) and re-binds the gateway listeners;
- races `ClientReady` against the `login()` rejection / gateway `Error`, settling each attempt exactly once;
- on a transient failure, tears the client down and schedules `attempt + 1` after **capped exponential backoff** (`1s` doubling, clamped at `60s`), keeping the connector self-healing until the network recovers;
- resolves the ready promise on the first successful `ClientReady` (any attempt) and only rejects on a **terminal post-ready `onReady` failure** (backfill/voice scan) — never on a login-transport failure;
- emits a **Warn-level heartbeat** naming the account and the failure while it is stuck retrying, throttled to at most once per 30s so the retry storm surfaces observably without flooding the log.

Pending retries are cancelled on `stop()` (the timers are tracked in the existing `this.timeouts`).

**Part 2** of the issue (a post-`ready` window where a live inbound is silently dropped with zero trace) is investigative/observability and not headlessly provable — left as a follow-up and untouched here (the message-processing path is not modified).

## Test

New deterministic vitest `plugins/plugin-discord/__tests__/login-retry.test.ts` drives the real `attemptDiscordLogin` against a fake discord.js client whose `login()` rejects N times then resolves and emits `ClientReady`, using `vi` fake timers to advance the backoff. It asserts: `login()` called more than once (one client per attempt), the ready promise eventually resolves, `state.loginFailed` clears, and a Warn heartbeat naming the account + failure was logged while failing. A second case asserts a first-try success schedules no retry and logs no warning.

**Fails-before / passes-after:** neutralizing the retry (making `scheduleRetry` reject terminally, i.e. the old behavior) fails the retry test; the shipped loop passes it.

<details><summary>Test output</summary>

```
 RUN  v4.1.5 plugins/plugin-discord
 __tests__/login-retry.test.ts (2 tests) ✓
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Full package suite (unchanged existing tests still green):

```
 Test Files  47 passed (47)
      Tests  288 passed (288)
```

`bun run --cwd plugins/plugin-discord typecheck` — clean.
`biome check` on touched files — clean.
</details>

## Evidence matrix

| Evidence | Status |
| --- | --- |
| Unit test (real code, fake gateway) | ✓ new deterministic vitest, fails-before/passes-after |
| Existing tests | ✓ 288/288 pass |
| Typecheck | ✓ clean |
| Lint | ✓ clean |
| Real-LLM trajectory | N/A — no agent/action/prompt/model behavior changed (connector transport only) |
| UI screenshots/video | N/A — no user-facing UI surface |
| Live Discord repro | N/A — transient boot-time socket failure is not deterministically reproducible against the live gateway; modeled deterministically in the test |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Evidence

<!-- evidence-row:before-screenshots -->
- Before screenshots: `N/A - backend/CI/build change, no UI surface`
<!-- evidence-row:after-screenshots -->
- After screenshots: `N/A - backend/CI/build change, no UI surface`
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: `N/A - no user-facing flow changed`
<!-- evidence-row:backend-logs -->
- Backend logs: `N/A - covered by the deterministic unit test output in the PR body`
<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: `N/A - no frontend surface`
<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model behavior change`
<!-- evidence-row:domain-artifacts -->
- Domain artifacts: `N/A - no DB/memory/scheduled-task/wallet/on-chain output; change is code + tests only`