### PR TITLE
fix(cloud): preserve live app database ambassadors

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/app-db-ambassador.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-db-ambassador.test.ts
@@ -1,8 +1,9 @@
-// Exercises app db ambassador behavior with deterministic cloud-shared lib fixtures.
+/** Exercises app DB ambassador behavior with deterministic cloud-shared fixtures. */
 import { describe, expect, test } from "bun:test";
 import {
   ambassadorName,
   ambassadorNameForContainer,
+  appContainerNameForAmbassador,
   buildEnsureAmbassadorCmds,
   buildRemoveAmbassadorCmdForContainer,
   parseDsnEndpoint,
@@ -20,6 +21,12 @@ describe("ambassador naming", () => {
     expect(ambassadorNameForContainer("app-111111112222")).toBe("app-db-111111112222");
     // round-trips with ambassadorName for the same app
     expect(ambassadorNameForContainer("app-111111112222")).toBe(ambassadorName(APP_ID));
+  });
+
+  test("appContainerNameForAmbassador recovers only complete managed names", () => {
+    expect(appContainerNameForAmbassador("app-db-111111112222")).toBe("app-111111112222");
+    expect(appContainerNameForAmbassador("app-db-")).toBeNull();
+    expect(appContainerNameForAmbassador("app-111111112222")).toBeNull();
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/app-container-orphan-reconciler.test.ts
+++ b/packages/cloud/shared/src/lib/services/app-container-orphan-reconciler.test.ts
@@ -39,6 +39,11 @@ describe("appContainerKeyOf", () => {
 
   test("rejects a bare prefix with no slug", () => {
     expect(appContainerKeyOf("app-")).toBeNull();
+    expect(appContainerKeyOf("app-db-")).toBeNull();
+  });
+
+  test("maps a DB ambassador to its owning app container row", () => {
+    expect(appContainerKeyOf("app-db-abc123def456")).toBe("app-abc123def456");
   });
 });
 
@@ -65,6 +70,35 @@ describe("computeOrphanContainersToReap (app diff)", () => {
   test("does NOT reap a container with a live (running) db row", () => {
     const orphans = compute([container("app-live", "c3")], [live("app-live", "running")]);
     expect(orphans).toEqual([]);
+  });
+
+  test("keeps a running app and its DB ambassador from the same live row", () => {
+    const orphans = compute(
+      [container("app-live", "app-id"), container("app-db-live", "ambassador-id")],
+      [live("app-live", "running")],
+    );
+    expect(orphans).toEqual([]);
+  });
+
+  test("reaps a terminal app and its DB ambassador", () => {
+    const orphans = compute(
+      [container("app-dead", "app-id"), container("app-db-dead", "ambassador-id")],
+      [live("app-dead", "deleted")],
+    );
+    expect(orphans).toEqual([
+      {
+        name: "app-dead",
+        id: "app-id",
+        key: "app-dead",
+        reason: "terminal_db_row",
+      },
+      {
+        name: "app-db-dead",
+        id: "ambassador-id",
+        key: "app-dead",
+        reason: "terminal_db_row",
+      },
+    ]);
   });
 
   test("does NOT reap deploying / building / pending rows", () => {

--- a/packages/cloud/shared/src/lib/services/app-container-orphan-reconciler.ts
+++ b/packages/cloud/shared/src/lib/services/app-container-orphan-reconciler.ts
@@ -1,53 +1,16 @@
 /**
- * Orphan APP-container reconciler (Apps / Product 2).
- *
- * The sibling of the AGENT orphan reconciler in `docker-node-workloads.ts`, for
- * the OTHER kind of workload on the shared Hetzner-Docker pool: user-deployed
- * APP containers (the `containers` table, NOT `agent_sandboxes`).
- *
- * Both share ONE implementation — the orchestration loop, the SSH wiring, the
- * hard timeouts, the reap-by-immutable-id rm, and the fail-safe group-by-key
- * diff all live in `orphan-container-reconciler.ts`. This module injects only
- * the three app-specific deltas: the `app-` prefix, the `keyOf` that uses the
- * container NAME as the diff key, and the app terminal-status vocab (plus the
- * `containers` status query and a log tag).
- *
- * THE GAP THIS CLOSES
- * App-container teardown (`appCleanupService` / the CONTAINER_DELETE executor)
- * only runs on an EXPLICIT app delete. A mid-deploy crash or a partial failure
- * can leave an `app-<slug>` container running on a node with no live DB row (or
- * a DB row left in a dead terminal state) — it holds a compute slot and host
- * volume forever because nothing in the deploy lifecycle will ever reap it
- * again. Agents already get a periodic sweep for exactly this; apps did not.
- *
- * HOW APP CONTAINERS DIFFER FROM AGENTS
- *   - App containers are named `app-<first 12 of app id>` (see
- *     `containerNameForApp` in `app-deploy-runner.ts`); the name is written
- *     verbatim to `containers.name`. The diff key is therefore the container
- *     NAME itself, not an id parsed out of the name (agents key on the agent id
- *     embedded in `agent-<id>`).
- *   - The backing row lives in `containers`, with the status vocab
- *     pending | building | deploying | running | stopped | failed | deleting |
- *     deleted. A container is LIVE (do NOT reap) when its row is in
- *     pending/building/deploying/running/deleting (`deleting` = a delete job is
- *     in flight and owns teardown). It is an ORPHAN (reap) when its row is
- *     MISSING (`no_db_row`) or in a dead terminal state stopped/failed/deleted
- *     (`terminal_db_row`).
- *   - `containers.name` has NO unique constraint, so one `app-<slug>` name maps
- *     to MANY rows (one per deploy) — the shared diff's group-by-key
- *     `every-terminal` fail-safe (#9307) is what protects a live app sharing a
- *     name with stale stopped/failed rows. (For agents the key is a PRIMARY KEY
- *     so each key has at most one row and the same fail-safe reduces to a plain
- *     single-status check — identical decisions.)
- *
- * Non-`app-`-prefixed containers on a shared node (agents `agent-…`, the older
- * direct `cloud-container-…` provider path, infra containers like postgres) are
- * never matched by the `--filter name=app-` listing and never touched here.
+ * Reconciles app workloads and their DB ambassadors on the shared Docker pool.
+ * Both resources map to the workload name stored in `containers`, so a live row
+ * protects them together while a missing or fully terminal row makes each
+ * observed Docker ID reapable. Multiple deployment rows may share one name;
+ * the generic reconciler therefore keeps the resources when any row is live.
+ * Containers outside the `app-` namespace are never listed or touched.
  */
 
 import { inArray } from "drizzle-orm";
 import { dbRead } from "../../db/helpers";
 import { containers } from "../../db/schemas/containers";
+import { APP_DB_AMBASSADOR_NAME_PREFIX, appContainerNameForAmbassador } from "./app-db-ambassador";
 import {
   type LiveContainerRef,
   type OrphanReconcileResult,
@@ -83,13 +46,15 @@ export const APP_CONTAINER_NAME_PREFIX = "app-";
 const TERMINAL_CONTAINER_STATUSES = new Set<string>(["stopped", "failed", "deleted"]);
 
 /**
- * The app reconciler's `keyOf`: the diff key is the container NAME itself (apps
- * write the deterministic `app-<slug>` verbatim to `containers.name`). Returns
- * null for names outside the managed-app pattern so unrelated containers on a
- * shared node are never considered. A bare `app-` with no slug is rejected
- * (mirrors the agent reconciler rejecting a bare `agent-`).
+ * Map an app workload or its DB ambassador to the workload name stored in
+ * `containers.name`. Ambassadors deliberately have no row of their own, so
+ * sharing the owner's key makes them live, terminal, or missing as one unit.
+ * Names outside the managed namespace and incomplete names are rejected.
  */
 export function appContainerKeyOf(name: string): string | null {
+  if (name.startsWith(APP_DB_AMBASSADOR_NAME_PREFIX)) {
+    return appContainerNameForAmbassador(name);
+  }
   return name.startsWith(APP_CONTAINER_NAME_PREFIX) &&
     name.length > APP_CONTAINER_NAME_PREFIX.length
     ? name

--- a/packages/cloud/shared/src/lib/services/app-db-ambassador.ts
+++ b/packages/cloud/shared/src/lib/services/app-db-ambassador.ts
@@ -29,6 +29,9 @@ export const DEFAULT_AMBASSADOR_IMAGE = "alpine/socat";
 /** The port the ambassador listens on (and that the rewritten DSN points at). */
 export const AMBASSADOR_LISTEN_PORT = 5432;
 
+/** Docker-name prefix reserved for per-app DB ambassadors. */
+export const APP_DB_AMBASSADOR_NAME_PREFIX = "app-db-";
+
 /**
  * Per-app ambassador container name — stable + DNS-safe. Uses the SAME 12-char
  * slug as `containerNameForApp` (`app-<slug>`), so the ambassador is
@@ -39,7 +42,7 @@ export function ambassadorName(appId: string): string {
     .toLowerCase()
     .replace(/[^a-z0-9]/g, "")
     .slice(0, 12);
-  return `app-db-${short}`;
+  return `${APP_DB_AMBASSADOR_NAME_PREFIX}${short}`;
 }
 
 /**
@@ -51,7 +54,18 @@ export function ambassadorNameForContainer(containerName: string): string {
   const slug = containerName.startsWith("app-")
     ? containerName.slice("app-".length)
     : containerName;
-  return `app-db-${slug}`;
+  return `${APP_DB_AMBASSADOR_NAME_PREFIX}${slug}`;
+}
+
+/**
+ * Recover the owning app container name from a managed ambassador name. This
+ * lets lifecycle services key both Docker resources to the same `containers`
+ * row without creating a second database record for the infrastructure sidecar.
+ */
+export function appContainerNameForAmbassador(ambassadorContainerName: string): string | null {
+  if (!ambassadorContainerName.startsWith(APP_DB_AMBASSADOR_NAME_PREFIX)) return null;
+  const slug = ambassadorContainerName.slice(APP_DB_AMBASSADOR_NAME_PREFIX.length);
+  return slug ? `app-${slug}` : null;
 }
 
 export interface DbEndpoint {


### PR DESCRIPTION
Closes #15919

## What changed

- maps `app-db-<slug>` ambassador containers to the owning `app-<slug>` database lifecycle key
- keeps both workload and ambassador when any matching container row is live
- reaps both by their independently observed immutable Docker IDs when the owner is terminal or missing
- centralizes the reversible ambassador naming contract and adds malformed-name coverage

## Verification

- `bun run install:light`
- `bun run --cwd packages/core build`
- `bun test --isolate packages/cloud/shared/src/lib/services/app-container-orphan-reconciler.test.ts packages/cloud/shared/src/lib/services/__tests__/app-db-ambassador.test.ts` — 34 pass, 0 fail
- `bun run --cwd packages/cloud/shared typecheck`
- Biome check on all four touched files
- `bun run audit:error-policy-ratchet` — no new fallback slop
- full `bun run --cwd packages/cloud/shared test` — 4,420 pass, 61 environment/credential skips, one unrelated `ai-billing-anon-affiliate` timeout under full-lane load; isolated rerun of that file: 8 pass, 0 fail

## Human-verifiable evidence

- UI screenshots/video: N/A — provisioning-daemon reconciliation has no UI surface
- real-LLM trajectory: N/A — no agent/prompt/model behavior changed
- live staging Docker lifecycle: pending post-merge daemon deployment; deterministic orchestration coverage proves the lifecycle decision and immutable-ID reaping contract without touching customer containers
