### PR TITLE
fix(agent): preserve binary response bodies over the local-agent IPC bridge

### DIFF
--- a/packages/agent/src/api/dispatch-route-binary-response.test.ts
+++ b/packages/agent/src/api/dispatch-route-binary-response.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Verifies lossless response finalization across the legacy route and native IPC boundary.
+ */
+
+import { Buffer } from "node:buffer";
+import type { IAgentRuntime, Route } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { dispatchBufferedRequest } from "../../../../plugins/plugin-capacitor-bridge/src/android/dispatch.ts";
+import { dispatchRoute } from "./dispatch-route.ts";
+
+function runtimeWithHandler(
+  handler: (response: {
+    setHeader(name: string, value: string): void;
+    end(body?: unknown): void;
+  }) => void,
+): IAgentRuntime {
+  const route = {
+    type: "GET",
+    path: "/api/response",
+    public: true,
+    publicReason: "Test-only response finalization fixture.",
+    handler: async (_request: unknown, response: unknown) => {
+      handler(
+        response as {
+          setHeader(name: string, value: string): void;
+          end(body?: unknown): void;
+        },
+      );
+    },
+  } as unknown as Route;
+  return { routes: [route] } as unknown as IAgentRuntime;
+}
+
+async function dispatch(runtime: IAgentRuntime, inProcess = true) {
+  return dispatchRoute({
+    runtime,
+    method: "GET",
+    path: "/api/response",
+    headers: {},
+    inProcess,
+    isAuthorized: () => true,
+  });
+}
+
+describe("dispatchRoute captured response finalization", () => {
+  it("preserves invalid UTF-8 bytes through the Android buffered IPC envelope", async () => {
+    const bytes = Buffer.from([0x52, 0x49, 0x46, 0x46, 0xff, 0x00, 0x80]);
+    const runtime = runtimeWithHandler((response) => {
+      response.setHeader("content-type", "audio/wav");
+      response.end(bytes);
+    });
+
+    const result = await dispatchBufferedRequest(runtime, dispatchRoute, {
+      method: "GET",
+      path: "/api/response",
+    });
+
+    expect(result.bodyEncoding).toBe("base64");
+    expect(Buffer.from(result.bodyBase64, "base64")).toEqual(bytes);
+  });
+
+  it.each([
+    true,
+    false,
+  ])("keeps binary bodies as buffers when inProcess=%s", async (inProcess) => {
+    const bytes = Buffer.from([0xff, 0xfe, 0x00, 0x41]);
+    const runtime = runtimeWithHandler((response) => {
+      response.setHeader("content-type", "application/octet-stream");
+      response.end(bytes);
+    });
+
+    const result = await dispatch(runtime, inProcess);
+
+    expect(Buffer.isBuffer(result?.body)).toBe(true);
+    expect(result?.body).toEqual(bytes);
+  });
+
+  it("does not decode content-encoded text before the client handles it", async () => {
+    const encoded = Buffer.from([0x1f, 0x8b, 0x08, 0x00, 0xff, 0x00]);
+    const runtime = runtimeWithHandler((response) => {
+      response.setHeader("content-type", "text/plain; charset=utf-8");
+      response.setHeader("content-encoding", "gzip");
+      response.end(encoded);
+    });
+
+    const result = await dispatch(runtime);
+
+    expect(Buffer.isBuffer(result?.body)).toBe(true);
+    expect(result?.body).toEqual(encoded);
+  });
+
+  it("preserves textual and JSON response compatibility", async () => {
+    const jsonRuntime = runtimeWithHandler((response) => {
+      response.setHeader("content-type", "application/problem+json");
+      response.end('{"error":"bad request"}');
+    });
+    const textRuntime = runtimeWithHandler((response) => {
+      response.setHeader("content-type", "text/plain");
+      response.end("plain text");
+    });
+
+    await expect(dispatch(jsonRuntime)).resolves.toMatchObject({
+      body: { error: "bad request" },
+    });
+    await expect(dispatch(textRuntime)).resolves.toMatchObject({
+      body: "plain text",
+    });
+  });
+
+  it("returns malformed JSON as raw text and empty responses as undefined", async () => {
+    const invalidJsonRuntime = runtimeWithHandler((response) => {
+      response.setHeader("content-type", "application/json");
+      response.end("{not-json");
+    });
+    const emptyRuntime = runtimeWithHandler((response) => {
+      response.setHeader("content-type", "audio/wav");
+      response.end();
+    });
+
+    await expect(dispatch(invalidJsonRuntime)).resolves.toMatchObject({
+      body: "{not-json",
+    });
+    await expect(dispatch(emptyRuntime)).resolves.toMatchObject({
+      status: 200,
+      body: undefined,
+    });
+  });
+});

--- a/packages/agent/src/api/dispatch-route.ts
+++ b/packages/agent/src/api/dispatch-route.ts
@@ -423,15 +423,39 @@ function buildLegacyShim(args: {
 
 function capturedToResult(captured: CapturedResponse): RouteHandlerResult {
   const buffer = Buffer.concat(captured.chunks);
-  const contentType = captured.headers["content-type"] ?? "";
-  let body: unknown = buffer.length > 0 ? buffer.toString("utf8") : undefined;
-  if (
-    body != null &&
-    typeof body === "string" &&
-    contentType.toLowerCase().includes("application/json")
-  ) {
+  const contentType = (captured.headers["content-type"] ?? "").toLowerCase();
+  if (buffer.length === 0) {
+    return {
+      status: captured.statusCode || 200,
+      headers: captured.headers,
+      body: undefined,
+    };
+  }
+  // Binary responses (audio/*, image/*, octet-stream, …) MUST stay a Buffer.
+  // `buffer.toString("utf8")` replaces every non-ASCII byte with U+FFFD
+  // (ef bf bd) and PERMANENTLY corrupts the payload — this silently mangled all
+  // on-device TTS/audio over the local-agent IPC bridge (the resultBodyBytes /
+  // bodyBase64 stage downstream is lossless only if it receives the raw bytes).
+  // Only decode to a string for known-textual types.
+  const isTextual =
+    contentType === "" ||
+    contentType.startsWith("text/") ||
+    contentType.includes("json") ||
+    contentType.includes("xml") ||
+    contentType.includes("javascript") ||
+    contentType.includes("x-www-form-urlencoded") ||
+    contentType.includes("charset");
+  if (!isTextual) {
+    return {
+      status: captured.statusCode || 200,
+      headers: captured.headers,
+      body: buffer,
+    };
+  }
+  let body: unknown = buffer.toString("utf8");
+  if (contentType.includes("application/json")) {
     try {
-      body = JSON.parse(body);
+      body = JSON.parse(body as string);
     } catch {
       // keep as string
     }

--- a/packages/agent/src/api/dispatch-route.ts
+++ b/packages/agent/src/api/dispatch-route.ts
@@ -424,6 +424,9 @@ function buildLegacyShim(args: {
 function capturedToResult(captured: CapturedResponse): RouteHandlerResult {
   const buffer = Buffer.concat(captured.chunks);
   const contentType = (captured.headers["content-type"] ?? "").toLowerCase();
+  const contentEncoding = (captured.headers["content-encoding"] ?? "")
+    .trim()
+    .toLowerCase();
   if (buffer.length === 0) {
     return {
       status: captured.statusCode || 200,
@@ -431,20 +434,20 @@ function capturedToResult(captured: CapturedResponse): RouteHandlerResult {
       body: undefined,
     };
   }
-  // Binary responses (audio/*, image/*, octet-stream, …) MUST stay a Buffer.
-  // `buffer.toString("utf8")` replaces every non-ASCII byte with U+FFFD
-  // (ef bf bd) and PERMANENTLY corrupts the payload — this silently mangled all
-  // on-device TTS/audio over the local-agent IPC bridge (the resultBodyBytes /
-  // bodyBase64 stage downstream is lossless only if it receives the raw bytes).
-  // Only decode to a string for known-textual types.
+  // Content encodings describe bytes that the client must decode even when the
+  // underlying media type is textual; interpreting either encoded or binary
+  // bytes as UTF-8 would make the downstream IPC base64 envelope lossy.
+  const hasTransferEncoding =
+    contentEncoding !== "" && contentEncoding !== "identity";
   const isTextual =
-    contentType === "" ||
-    contentType.startsWith("text/") ||
-    contentType.includes("json") ||
-    contentType.includes("xml") ||
-    contentType.includes("javascript") ||
-    contentType.includes("x-www-form-urlencoded") ||
-    contentType.includes("charset");
+    !hasTransferEncoding &&
+    (contentType === "" ||
+      contentType.startsWith("text/") ||
+      contentType.includes("json") ||
+      contentType.includes("xml") ||
+      contentType.includes("javascript") ||
+      contentType.includes("x-www-form-urlencoded") ||
+      contentType.includes("charset"));
   if (!isTextual) {
     return {
       status: captured.statusCode || 200,
@@ -452,12 +455,13 @@ function capturedToResult(captured: CapturedResponse): RouteHandlerResult {
       body: buffer,
     };
   }
-  let body: unknown = buffer.toString("utf8");
-  if (contentType.includes("application/json")) {
+  const text = buffer.toString("utf8");
+  let body: unknown = text;
+  if (contentType.includes("json")) {
     try {
-      body = JSON.parse(body as string);
+      body = JSON.parse(text);
     } catch {
-      // keep as string
+      // error-policy:J3 malformed JSON stays explicit raw text at this transport boundary
     }
   }
   return {


### PR DESCRIPTION
## Problem
`capturedToResult` in the local-agent IPC dispatch (`packages/agent/src/api/dispatch-route.ts`) ran `Buffer.concat(chunks).toString("utf8")` on **every** response body before handing it to the bridge. Any non-text payload — `audio/*` (TTS), `image/*`, `application/octet-stream` — had every non-ASCII byte replaced with U+FFFD (`ef bf bd`) and was **permanently corrupted**.

Because both the raw `body` string *and* the derived `bodyBase64` are computed from that already-mangled buffer, even the client's binary-safe `nativeResponseBody` (which prefers `bodyBase64`) received garbage. Result: **all on-device TTS/audio served through the Android/iOS local-agent IPC bridge came back unplayable** — no decoder could read it.

## Fix
Keep the raw `Buffer` for non-textual content types; only decode to a string for `text/*`, `json`, `xml`, `javascript`, form-encoded, or `charset`-tagged responses. Downstream `resultBodyBytes` + `bodyBase64` are lossless when they receive the real bytes. Covers both dispatch paths (plugin `dispatchRoute` and the full-server `dispatchViaInProcessServer`), which both finalize through `capturedToResult`.

## Evidence (real device — Light Phone III)
Before: `/api/tts/cloud` WAV over the bridge → header mangled (`RIFF` then `ef bf bd`, `WAVE` → `\0\0WA`), `decodeAudioData` → `EncodingError`.
After: `content-type: audio/wav`, `WAVE` header intact, **`decodeAudioData` → DECODED 1.81s @ 48000 Hz** — audio plays.

General bug (Android + iOS, any binary response), not device-specific.
## Evidence

<!-- evidence-row:before-screenshots -->
- Before screenshots: `N/A - backend/API change, no UI surface`
<!-- evidence-row:after-screenshots -->
- After screenshots: `N/A - backend/API change, no UI surface`
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: `N/A - no user-facing flow changed`
<!-- evidence-row:backend-logs -->
- Backend logs: `N/A - covered by the deterministic unit tests in this PR`
<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: `N/A - no frontend surface`
<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model behavior change`
<!-- evidence-row:domain-artifacts -->
- Domain artifacts: `N/A - change is code + tests only`