### PR TITLE
feat(cloud): opt-in WAV output for voice TTS (codec-less clients)

### DIFF
--- a/packages/cloud/api/v1/voice/tts/route.ts
+++ b/packages/cloud/api/v1/voice/tts/route.ts
@@ -678,7 +678,10 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
     // so codec-less clients can decode it. (Buffered, not streamed — fine for
     // short TTS replies; the MP3 path keeps its chunked streaming below.)
     if (wantWav) {
-      const wav = pcm16ToWav(await drainStream(audioStream), WAV_PCM_SAMPLE_RATE);
+      const wav = pcm16ToWav(
+        await drainStream(audioStream),
+        WAV_PCM_SAMPLE_RATE,
+      );
       return new Response(wav as unknown as BodyInit, {
         headers: {
           "Content-Type": "audio/wav",

--- a/packages/cloud/api/v1/voice/tts/route.ts
+++ b/packages/cloud/api/v1/voice/tts/route.ts
@@ -83,6 +83,11 @@ const TtsBody = z.object({
   text: z.string(),
   voiceId: z.string().optional(),
   modelId: z.string().optional(),
+  // Optional container format. Default (unset) = MP3, unchanged for every
+  // existing caller. `"wav"` returns PCM16 WAV for clients whose audio stack has
+  // no MP3 decoder (e.g. the Light Phone III / LightOS WebView), which need an
+  // uncompressed container that decodes without a codec.
+  format: z.enum(["mp3", "wav"]).optional(),
 });
 
 interface TtsTimings {
@@ -111,6 +116,60 @@ function buildTtsObservabilityHeaders(
       ? { "Server-Timing": serverTiming.join(", ") }
       : {}),
   };
+}
+
+/** ElevenLabs PCM sample rate we request for the WAV path (Hz). */
+const WAV_PCM_SAMPLE_RATE = 24_000;
+
+/** Prepend a canonical 44-byte PCM16 mono WAV header to raw little-endian
+ *  16-bit PCM samples (what ElevenLabs `pcm_24000` streams). */
+function pcm16ToWav(pcm: Uint8Array, sampleRate: number): Uint8Array {
+  const header = new ArrayBuffer(44);
+  const view = new DataView(header);
+  const writeStr = (off: number, s: string) => {
+    for (let i = 0; i < s.length; i++) view.setUint8(off + i, s.charCodeAt(i));
+  };
+  const dataLen = pcm.byteLength;
+  writeStr(0, "RIFF");
+  view.setUint32(4, 36 + dataLen, true);
+  writeStr(8, "WAVE");
+  writeStr(12, "fmt ");
+  view.setUint32(16, 16, true); // PCM fmt chunk size
+  view.setUint16(20, 1, true); // audio format = PCM
+  view.setUint16(22, 1, true); // channels = mono
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * 2, true); // byte rate (mono * 16-bit)
+  view.setUint16(32, 2, true); // block align
+  view.setUint16(34, 16, true); // bits per sample
+  writeStr(36, "data");
+  view.setUint32(40, dataLen, true);
+  const out = new Uint8Array(44 + dataLen);
+  out.set(new Uint8Array(header), 0);
+  out.set(pcm, 44);
+  return out;
+}
+
+/** Drain a ReadableStream of PCM chunks into one buffer. */
+async function drainStream(
+  stream: ReadableStream<Uint8Array>,
+): Promise<Uint8Array> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const r = await reader.read();
+    if (r.done) break;
+    const c = r.value as Uint8Array;
+    chunks.push(c);
+    total += c.byteLength;
+  }
+  const merged = new Uint8Array(total);
+  let off = 0;
+  for (const c of chunks) {
+    merged.set(c, off);
+    off += c.byteLength;
+  }
+  return merged;
 }
 
 /**
@@ -146,6 +205,9 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
       voiceId,
       kokoroConfigured: Boolean(kokoroBaseUrl),
     });
+    // WAV output is opt-in and bypasses the MP3-shaped first-line cache (a
+    // different codec); billing/usage are identical to the MP3 path.
+    const wantWav = parsed.data.format === "wav";
 
     if (!text) {
       return Response.json({ error: "No text provided" }, { status: 400 });
@@ -384,6 +446,7 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
     timings.admissionMs = Date.now() - admissionStart;
 
     if (
+      !wantWav &&
       snipResult &&
       !cacheBypass &&
       // Cache currently only serves WHOLE-input hits to avoid mp3 stream
@@ -467,6 +530,9 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
       text,
       voiceId,
       modelId,
+      // WAV path requests raw PCM (wrapped in a WAV header below); default
+      // callers get the service's MP3 default.
+      ...(wantWav ? { outputFormat: `pcm_${WAV_PCM_SAMPLE_RATE}` } : {}),
     });
     const duration = Date.now() - startTime;
     timings.synthesisMs = duration;
@@ -548,7 +614,7 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
     // boundaries — mp3 frames aren't aligned). The fan-out is bounded by
     // the ≤ 10-word snip cap and skipped entirely on bypass / no-snip.
     // ---------------------------------------------------------------------
-    if (snipResult && !cacheBypass) {
+    if (!wantWav && snipResult && !cacheBypass) {
       void (async () => {
         try {
           const cacheService = getCloudFirstLineCacheService();
@@ -606,6 +672,20 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
           );
         }
       })();
+    }
+
+    // WAV path: ElevenLabs streamed raw PCM; buffer it and wrap in a WAV header
+    // so codec-less clients can decode it. (Buffered, not streamed — fine for
+    // short TTS replies; the MP3 path keeps its chunked streaming below.)
+    if (wantWav) {
+      const wav = pcm16ToWav(await drainStream(audioStream), WAV_PCM_SAMPLE_RATE);
+      return new Response(wav as unknown as BodyInit, {
+        headers: {
+          "Content-Type": "audio/wav",
+          "Cache-Control": "no-cache",
+          "X-TTS-Cache": "miss",
+        },
+      });
     }
 
     return new Response(audioStream, {

--- a/packages/cloud/api/v1/voice/tts/route.ts
+++ b/packages/cloud/api/v1/voice/tts/route.ts
@@ -45,6 +45,7 @@ import {
   InsufficientCreditsError,
 } from "@/lib/services/credits";
 import { getElevenLabsService } from "@/lib/services/elevenlabs";
+import { drainPcm16Stream, pcm16ToWav } from "@/lib/services/pcm16-wav";
 import {
   fingerprintCloudVoiceSettings,
   getCloudFirstLineCacheService,
@@ -120,57 +121,7 @@ function buildTtsObservabilityHeaders(
 
 /** ElevenLabs PCM sample rate we request for the WAV path (Hz). */
 const WAV_PCM_SAMPLE_RATE = 24_000;
-
-/** Prepend a canonical 44-byte PCM16 mono WAV header to raw little-endian
- *  16-bit PCM samples (what ElevenLabs `pcm_24000` streams). */
-function pcm16ToWav(pcm: Uint8Array, sampleRate: number): Uint8Array {
-  const header = new ArrayBuffer(44);
-  const view = new DataView(header);
-  const writeStr = (off: number, s: string) => {
-    for (let i = 0; i < s.length; i++) view.setUint8(off + i, s.charCodeAt(i));
-  };
-  const dataLen = pcm.byteLength;
-  writeStr(0, "RIFF");
-  view.setUint32(4, 36 + dataLen, true);
-  writeStr(8, "WAVE");
-  writeStr(12, "fmt ");
-  view.setUint32(16, 16, true); // PCM fmt chunk size
-  view.setUint16(20, 1, true); // audio format = PCM
-  view.setUint16(22, 1, true); // channels = mono
-  view.setUint32(24, sampleRate, true);
-  view.setUint32(28, sampleRate * 2, true); // byte rate (mono * 16-bit)
-  view.setUint16(32, 2, true); // block align
-  view.setUint16(34, 16, true); // bits per sample
-  writeStr(36, "data");
-  view.setUint32(40, dataLen, true);
-  const out = new Uint8Array(44 + dataLen);
-  out.set(new Uint8Array(header), 0);
-  out.set(pcm, 44);
-  return out;
-}
-
-/** Drain a ReadableStream of PCM chunks into one buffer. */
-async function drainStream(
-  stream: ReadableStream<Uint8Array>,
-): Promise<Uint8Array> {
-  const reader = stream.getReader();
-  const chunks: Uint8Array[] = [];
-  let total = 0;
-  for (;;) {
-    const r = await reader.read();
-    if (r.done) break;
-    const c = r.value as Uint8Array;
-    chunks.push(c);
-    total += c.byteLength;
-  }
-  const merged = new Uint8Array(total);
-  let off = 0;
-  for (const c of chunks) {
-    merged.set(c, off);
-    off += c.byteLength;
-  }
-  return merged;
-}
+const MAX_WAV_PCM_BYTES = 64 * 1024 * 1024;
 
 /**
  * POST /api/v1/voice/tts
@@ -534,6 +485,12 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
       // callers get the service's MP3 default.
       ...(wantWav ? { outputFormat: `pcm_${WAV_PCM_SAMPLE_RATE}` } : {}),
     });
+    const wav = wantWav
+      ? pcm16ToWav(
+          await drainPcm16Stream(audioStream, MAX_WAV_PCM_BYTES),
+          WAV_PCM_SAMPLE_RATE,
+        )
+      : undefined;
     const duration = Date.now() - startTime;
     timings.synthesisMs = duration;
 
@@ -677,11 +634,7 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
     // WAV path: ElevenLabs streamed raw PCM; buffer it and wrap in a WAV header
     // so codec-less clients can decode it. (Buffered, not streamed — fine for
     // short TTS replies; the MP3 path keeps its chunked streaming below.)
-    if (wantWav) {
-      const wav = pcm16ToWav(
-        await drainStream(audioStream),
-        WAV_PCM_SAMPLE_RATE,
-      );
+    if (wav !== undefined) {
       return new Response(wav as unknown as BodyInit, {
         headers: {
           "Content-Type": "audio/wav",

--- a/packages/cloud/shared/src/lib/services/__tests__/elevenlabs.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/elevenlabs.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Exercises the real ElevenLabsService bodies with the ElevenLabs SDK client
+ * stubbed at the network boundary, covering the per-request output-format
+ * override and the env-driven format validation added for the WAV TTS path.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { ElevenLabsService, getElevenLabsService } from "../elevenlabs";
+
+/**
+ * Minimal stand-in for the ElevenLabs SDK client. Only the network boundary is
+ * faked; every assertion drives the real service method body. `ttsCalls`
+ * records the request options so tests can assert the resolved output format.
+ */
+function fakeClient() {
+  const ttsCalls: Array<{ voiceId: string; options: Record<string, unknown> }> = [];
+  const client = {
+    textToSpeech: {
+      stream(voiceId: string, options: Record<string, unknown>) {
+        ttsCalls.push({ voiceId, options });
+        return new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(Uint8Array.of(1, 2, 3, 4));
+            controller.close();
+          },
+        });
+      },
+    },
+    speechToText: {
+      convert: async (_req: unknown) => sttResponse,
+    },
+    voices: {
+      search: async () => ({ voices: [{ voiceId: "v1" }] }),
+      get: async (id: string) => ({ voiceId: id, name: "got" }),
+      delete: async (_id: string) => undefined,
+      update: async (_id: string, settings: Record<string, unknown>) => settings,
+      ivc: { create: async (_req: unknown) => ({ voiceId: "ivc-1" }) },
+      pvc: { create: async (_req: unknown) => ({ voiceId: "pvc-1" }) },
+    },
+  };
+  let sttResponse: unknown = { text: "hello" };
+  return {
+    client,
+    ttsCalls,
+    setSttResponse(next: unknown) {
+      sttResponse = next;
+    },
+  };
+}
+
+function withStubbedClient(config: ConstructorParameters<typeof ElevenLabsService>[0]) {
+  const service = new ElevenLabsService(config);
+  const stub = fakeClient();
+  (service as unknown as { client: unknown }).client = stub.client;
+  return { service, stub };
+}
+
+describe("ElevenLabsService.fromEnv output-format validation", () => {
+  test("defaults to mp3_44100_128 when ELEVENLABS_OUTPUT_FORMAT is unset", () => {
+    const service = ElevenLabsService.fromEnv({ ELEVENLABS_API_KEY: "k" });
+    expect((service as unknown as { config: { outputFormat: string } }).config.outputFormat).toBe(
+      "mp3_44100_128",
+    );
+  });
+
+  test("accepts a valid PCM format used by the WAV path", () => {
+    const service = ElevenLabsService.fromEnv({
+      ELEVENLABS_API_KEY: "k",
+      ELEVENLABS_OUTPUT_FORMAT: "pcm_24000",
+    });
+    expect((service as unknown as { config: { outputFormat: string } }).config.outputFormat).toBe(
+      "pcm_24000",
+    );
+  });
+
+  test("throws a typed error for an unsupported format", () => {
+    expect(() =>
+      ElevenLabsService.fromEnv({
+        ELEVENLABS_API_KEY: "k",
+        ELEVENLABS_OUTPUT_FORMAT: "flac_96000",
+      }),
+    ).toThrow(/Unsupported output format/);
+    try {
+      ElevenLabsService.fromEnv({
+        ELEVENLABS_API_KEY: "k",
+        ELEVENLABS_OUTPUT_FORMAT: "flac_96000",
+      });
+    } catch (err) {
+      expect((err as { code?: string }).code).toBe("ELEVENLABS_OUTPUT_FORMAT_INVALID");
+    }
+  });
+
+  test("requires an API key", () => {
+    expect(() => ElevenLabsService.fromEnv({})).toThrow(/ELEVENLABS_API_KEY/);
+  });
+
+  test("carries the configured voice/model/tuning env values into config", () => {
+    const service = ElevenLabsService.fromEnv({
+      ELEVENLABS_API_KEY: "k",
+      ELEVENLABS_VOICE_ID: "voice-x",
+      ELEVENLABS_MODEL_ID: "model-x",
+      ELEVENLABS_VOICE_STABILITY: "0.9",
+      ELEVENLABS_VOICE_SIMILARITY_BOOST: "0.1",
+      ELEVENLABS_VOICE_STYLE: "0.2",
+      ELEVENLABS_VOICE_USE_SPEAKER_BOOST: "false",
+      ELEVENLABS_OPTIMIZE_STREAMING_LATENCY: "2",
+    });
+    const config = (
+      service as unknown as {
+        config: {
+          voiceId: string;
+          modelId: string;
+          voiceStability: number;
+          voiceUseSpeakerBoost: boolean;
+          optimizeStreamingLatency: number;
+        };
+      }
+    ).config;
+    expect(config.voiceId).toBe("voice-x");
+    expect(config.modelId).toBe("model-x");
+    expect(config.voiceStability).toBeCloseTo(0.9);
+    expect(config.voiceUseSpeakerBoost).toBe(false);
+    expect(config.optimizeStreamingLatency).toBe(2);
+  });
+});
+
+describe("ElevenLabsService.textToSpeech output format", () => {
+  test("forwards a per-request outputFormat override to the client", async () => {
+    const { service, stub } = withStubbedClient({
+      apiKey: "k",
+      outputFormat: "mp3_44100_128",
+    });
+    await service.textToSpeech({ text: "hi", outputFormat: "pcm_24000" });
+    expect(stub.ttsCalls).toHaveLength(1);
+    expect(stub.ttsCalls[0].options.outputFormat).toBe("pcm_24000");
+    expect(stub.ttsCalls[0].voiceId).toBe("EXAVITQu4vr4xnSDxMaL");
+  });
+
+  test("falls back to the configured default output format", async () => {
+    const { service, stub } = withStubbedClient({
+      apiKey: "k",
+      voiceId: "cfg-voice",
+      outputFormat: "mp3_44100_128",
+    });
+    const stream = await service.textToSpeech({ text: "hi", modelId: "m" });
+    expect(stub.ttsCalls[0].options.outputFormat).toBe("mp3_44100_128");
+    expect(stub.ttsCalls[0].voiceId).toBe("cfg-voice");
+    expect(stub.ttsCalls[0].options.modelId).toBe("m");
+    // Streamed bytes flow through unchanged.
+    const chunk = await stream.getReader().read();
+    expect(Array.from(chunk.value ?? [])).toEqual([1, 2, 3, 4]);
+  });
+});
+
+describe("ElevenLabsService speech-to-text and voice management", () => {
+  test("returns the single-channel transcript and wraps a Blob in a File", async () => {
+    const { service, stub } = withStubbedClient({ apiKey: "k" });
+    stub.setSttResponse({ text: "spoken words" });
+    const transcript = await service.speechToText({
+      audioFile: new Blob(["bytes"]),
+      modelId: "scribe_v2",
+    });
+    expect(transcript).toBe("spoken words");
+  });
+
+  test("combines multi-channel transcripts", async () => {
+    const { service, stub } = withStubbedClient({ apiKey: "k" });
+    stub.setSttResponse({
+      transcripts: { ch0: { text: "left" }, ch1: { text: "right" } },
+    });
+    const transcript = await service.speechToText({
+      audioFile: new File(["b"], "a.wav"),
+    });
+    expect(transcript).toBe("left right");
+  });
+
+  test("lists voices, fetches, updates, clones, and deletes", async () => {
+    const { service } = withStubbedClient({ apiKey: "k" });
+    expect(await service.getVoices()).toEqual([{ voiceId: "v1" }]);
+    expect((await service.getVoiceById("v9")).voiceId).toBe("v9");
+    expect(await service.updateVoiceSettings("v9", { name: "n", stability: 0.3 })).toMatchObject({
+      stability: 0.3,
+    });
+    const ivc = await service.createInstantVoiceClone({ name: "clone", files: [] });
+    expect(ivc.voiceId).toBe("ivc-1");
+    const pvc = await service.createProfessionalVoiceClone({ name: "clone2", files: [] });
+    expect(pvc.voiceId).toBe("pvc-1");
+    await expect(service.deleteVoice("v9")).resolves.toBeUndefined();
+  });
+});
+
+describe("getElevenLabsService", () => {
+  test("constructs a fresh service from an explicit env override", () => {
+    const service = getElevenLabsService({ ELEVENLABS_API_KEY: "k" });
+    expect(service).toBeInstanceOf(ElevenLabsService);
+  });
+
+  test("caches the process-env singleton across calls", () => {
+    const prior = process.env.ELEVENLABS_API_KEY;
+    process.env.ELEVENLABS_API_KEY = "process-key";
+    try {
+      const first = getElevenLabsService();
+      const second = getElevenLabsService();
+      expect(first).toBe(second);
+    } finally {
+      if (prior === undefined) delete process.env.ELEVENLABS_API_KEY;
+      else process.env.ELEVENLABS_API_KEY = prior;
+    }
+  });
+});

--- a/packages/cloud/shared/src/lib/services/__tests__/pcm16-wav.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/pcm16-wav.test.ts
@@ -1,0 +1,50 @@
+/** Verifies PCM16 stream validation and the exact RIFF/WAV bytes consumed by codec-less clients. */
+
+import { describe, expect, it } from "vitest";
+import { drainPcm16Stream, pcm16ToWav } from "../pcm16-wav";
+
+function stream(...chunks: number[][]): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(Uint8Array.from(chunk));
+      controller.close();
+    },
+  });
+}
+
+describe("PCM16 WAV encoding", () => {
+  it("preserves streamed samples and writes a canonical mono header", async () => {
+    const pcm = await drainPcm16Stream(stream([0x01], [0x02, 0x03, 0x04]), 1024);
+    const wav = pcm16ToWav(pcm, 24_000);
+    const view = new DataView(wav.buffer);
+
+    expect(new TextDecoder().decode(wav.subarray(0, 4))).toBe("RIFF");
+    expect(view.getUint32(4, true)).toBe(40);
+    expect(new TextDecoder().decode(wav.subarray(8, 12))).toBe("WAVE");
+    expect(view.getUint16(20, true)).toBe(1);
+    expect(view.getUint16(22, true)).toBe(1);
+    expect(view.getUint32(24, true)).toBe(24_000);
+    expect(view.getUint32(28, true)).toBe(48_000);
+    expect(view.getUint16(32, true)).toBe(2);
+    expect(view.getUint16(34, true)).toBe(16);
+    expect(view.getUint32(40, true)).toBe(4);
+    expect([...wav.subarray(44)]).toEqual([0x01, 0x02, 0x03, 0x04]);
+  });
+
+  it("rejects empty and partial samples", async () => {
+    await expect(drainPcm16Stream(stream(), 1024)).rejects.toMatchObject({
+      code: "TTS_PCM_INVALID",
+    });
+    await expect(drainPcm16Stream(stream([0x01, 0x02, 0x03]), 1024)).rejects.toMatchObject({
+      code: "TTS_PCM_INVALID",
+    });
+    expect(() => pcm16ToWav(Uint8Array.of(1), 24_000)).toThrow("complete 16-bit samples");
+  });
+
+  it("cancels and rejects a response beyond the memory limit", async () => {
+    await expect(drainPcm16Stream(stream([0, 1], [2, 3]), 2)).rejects.toMatchObject({
+      code: "TTS_PCM_INVALID",
+      context: { maxBytes: 2, receivedBytes: 4 },
+    });
+  });
+});

--- a/packages/cloud/shared/src/lib/services/__tests__/pcm16-wav.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/pcm16-wav.test.ts
@@ -1,6 +1,6 @@
 /** Verifies PCM16 stream validation and the exact RIFF/WAV bytes consumed by codec-less clients. */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, test } from "bun:test";
 import { drainPcm16Stream, pcm16ToWav } from "../pcm16-wav";
 
 function stream(...chunks: number[][]): ReadableStream<Uint8Array> {
@@ -13,7 +13,7 @@ function stream(...chunks: number[][]): ReadableStream<Uint8Array> {
 }
 
 describe("PCM16 WAV encoding", () => {
-  it("preserves streamed samples and writes a canonical mono header", async () => {
+  test("preserves streamed samples and writes a canonical mono header", async () => {
     const pcm = await drainPcm16Stream(stream([0x01], [0x02, 0x03, 0x04]), 1024);
     const wav = pcm16ToWav(pcm, 24_000);
     const view = new DataView(wav.buffer);
@@ -31,7 +31,7 @@ describe("PCM16 WAV encoding", () => {
     expect([...wav.subarray(44)]).toEqual([0x01, 0x02, 0x03, 0x04]);
   });
 
-  it("rejects empty and partial samples", async () => {
+  test("rejects empty and partial samples", async () => {
     await expect(drainPcm16Stream(stream(), 1024)).rejects.toMatchObject({
       code: "TTS_PCM_INVALID",
     });
@@ -41,7 +41,7 @@ describe("PCM16 WAV encoding", () => {
     expect(() => pcm16ToWav(Uint8Array.of(1), 24_000)).toThrow("complete 16-bit samples");
   });
 
-  it("cancels and rejects a response beyond the memory limit", async () => {
+  test("cancels and rejects a response beyond the memory limit", async () => {
     await expect(drainPcm16Stream(stream([0, 1], [2, 3]), 2)).rejects.toMatchObject({
       code: "TTS_PCM_INVALID",
       context: { maxBytes: 2, receivedBytes: 4 },

--- a/packages/cloud/shared/src/lib/services/elevenlabs.ts
+++ b/packages/cloud/shared/src/lib/services/elevenlabs.ts
@@ -53,6 +53,9 @@ export interface TTSOptions {
   text: string;
   voiceId?: string;
   modelId?: string;
+  /** Per-request container/codec override (e.g. `pcm_24000` for the WAV path);
+   *  falls back to the service default when unset. */
+  outputFormat?: string;
 }
 
 /**
@@ -119,7 +122,13 @@ export class ElevenLabsService {
     const audioStream = await this.client.textToSpeech.stream(voiceId, {
       text: options.text,
       modelId,
-      outputFormat: this.config.outputFormat as "mp3_44100_128" | "pcm_16000",
+      // Honor a per-request outputFormat (e.g. `pcm_24000` for the WAV path);
+      // fall back to the service default. Previously this only ever read the
+      // config default, so callers could not request PCM/WAV.
+      outputFormat: (options.outputFormat ?? this.config.outputFormat) as
+        | "mp3_44100_128"
+        | "pcm_16000"
+        | "pcm_24000",
       optimizeStreamingLatency: this.config.optimizeStreamingLatency,
       voiceSettings: {
         stability: this.config.voiceStability,

--- a/packages/cloud/shared/src/lib/services/elevenlabs.ts
+++ b/packages/cloud/shared/src/lib/services/elevenlabs.ts
@@ -10,6 +10,7 @@
 
 import type { ElevenLabs } from "@elevenlabs/elevenlabs-js";
 import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js";
+import { ElizaError } from "@elizaos/core";
 import { logger } from "../utils/logger";
 
 /**
@@ -24,7 +25,7 @@ export interface ElevenLabsConfig {
   voiceStyle?: number;
   voiceUseSpeakerBoost?: boolean;
   optimizeStreamingLatency?: number;
-  outputFormat?: string;
+  outputFormat?: ElevenLabs.TextToSpeechStreamRequestOutputFormat;
 }
 
 type ElevenLabsEnv = Partial<
@@ -53,9 +54,50 @@ export interface TTSOptions {
   text: string;
   voiceId?: string;
   modelId?: string;
-  /** Per-request container/codec override (e.g. `pcm_24000` for the WAV path);
-   *  falls back to the service default when unset. */
-  outputFormat?: string;
+  /** Per-request codec override; falls back to the configured service default. */
+  outputFormat?: ElevenLabs.TextToSpeechStreamRequestOutputFormat;
+}
+
+const TTS_OUTPUT_FORMATS: ReadonlySet<string> = new Set([
+  "mp3_22050_32",
+  "mp3_24000_48",
+  "mp3_44100_32",
+  "mp3_44100_64",
+  "mp3_44100_96",
+  "mp3_44100_128",
+  "mp3_44100_192",
+  "pcm_8000",
+  "pcm_16000",
+  "pcm_22050",
+  "pcm_24000",
+  "pcm_32000",
+  "pcm_44100",
+  "pcm_48000",
+  "ulaw_8000",
+  "alaw_8000",
+  "opus_48000_32",
+  "opus_48000_64",
+  "opus_48000_96",
+  "opus_48000_128",
+  "opus_48000_192",
+]);
+
+function isTtsOutputFormat(
+  value: string,
+): value is ElevenLabs.TextToSpeechStreamRequestOutputFormat {
+  return TTS_OUTPUT_FORMATS.has(value);
+}
+
+function parseTtsOutputFormat(
+  value: string | undefined,
+): ElevenLabs.TextToSpeechStreamRequestOutputFormat {
+  const resolved = value ?? "mp3_44100_128";
+  if (isTtsOutputFormat(resolved)) return resolved;
+  throw new ElizaError(`[ElevenLabs TTS] Unsupported output format: ${resolved}`, {
+    code: "ELEVENLABS_OUTPUT_FORMAT_INVALID",
+    context: { outputFormat: resolved },
+    severity: "fatal",
+  });
 }
 
 /**
@@ -102,7 +144,7 @@ export class ElevenLabsService {
       optimizeStreamingLatency: Number.parseInt(
         envValue(env, "ELEVENLABS_OPTIMIZE_STREAMING_LATENCY") || "4",
       ),
-      outputFormat: envValue(env, "ELEVENLABS_OUTPUT_FORMAT") || "mp3_44100_128",
+      outputFormat: parseTtsOutputFormat(envValue(env, "ELEVENLABS_OUTPUT_FORMAT")),
     };
 
     return new ElevenLabsService(config);
@@ -122,13 +164,7 @@ export class ElevenLabsService {
     const audioStream = await this.client.textToSpeech.stream(voiceId, {
       text: options.text,
       modelId,
-      // Honor a per-request outputFormat (e.g. `pcm_24000` for the WAV path);
-      // fall back to the service default. Previously this only ever read the
-      // config default, so callers could not request PCM/WAV.
-      outputFormat: (options.outputFormat ?? this.config.outputFormat) as
-        | "mp3_44100_128"
-        | "pcm_16000"
-        | "pcm_24000",
+      outputFormat: options.outputFormat ?? this.config.outputFormat,
       optimizeStreamingLatency: this.config.optimizeStreamingLatency,
       voiceSettings: {
         stability: this.config.voiceStability,

--- a/packages/cloud/shared/src/lib/services/pcm16-wav.ts
+++ b/packages/cloud/shared/src/lib/services/pcm16-wav.ts
@@ -1,0 +1,105 @@
+/**
+ * Validates streamed mono PCM16 audio and wraps it in a canonical WAV container.
+ * The bounded drain protects Worker memory while preserving the complete byte
+ * count required by the RIFF header.
+ */
+
+import { ElizaError } from "@elizaos/core";
+
+const WAV_HEADER_BYTES = 44;
+const MAX_RIFF_DATA_BYTES = 0xffff_ffff - 36;
+
+function invalidPcm(message: string, context: Record<string, unknown>): ElizaError {
+  return new ElizaError(message, {
+    code: "TTS_PCM_INVALID",
+    context,
+    severity: "ephemeral",
+  });
+}
+
+/** Drains a PCM16 stream without allowing an upstream response to exhaust memory. */
+export async function drainPcm16Stream(
+  stream: ReadableStream<Uint8Array>,
+  maxBytes: number,
+): Promise<Uint8Array> {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes <= 0 || maxBytes > MAX_RIFF_DATA_BYTES) {
+    throw invalidPcm("PCM16 byte limit is outside the WAV container range", { maxBytes });
+  }
+
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  try {
+    for (;;) {
+      const result = await reader.read();
+      if (result.done) break;
+      total += result.value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel("PCM16 response exceeded the configured byte limit");
+        throw invalidPcm("PCM16 response exceeded the configured byte limit", {
+          maxBytes,
+          receivedBytes: total,
+        });
+      }
+      chunks.push(result.value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  if (total === 0 || total % 2 !== 0) {
+    throw invalidPcm("PCM16 response must contain complete 16-bit samples", {
+      receivedBytes: total,
+    });
+  }
+
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return merged;
+}
+
+/** Wraps little-endian mono PCM16 samples in a 44-byte RIFF/WAV header. */
+export function pcm16ToWav(pcm: Uint8Array, sampleRate: number): Uint8Array {
+  if (pcm.byteLength === 0 || pcm.byteLength % 2 !== 0) {
+    throw invalidPcm("PCM16 input must contain complete 16-bit samples", {
+      receivedBytes: pcm.byteLength,
+    });
+  }
+  if (!Number.isSafeInteger(sampleRate) || sampleRate <= 0) {
+    throw invalidPcm("PCM16 sample rate must be a positive integer", { sampleRate });
+  }
+  if (pcm.byteLength > MAX_RIFF_DATA_BYTES) {
+    throw invalidPcm("PCM16 input exceeds the WAV container range", {
+      receivedBytes: pcm.byteLength,
+    });
+  }
+
+  const output = new Uint8Array(WAV_HEADER_BYTES + pcm.byteLength);
+  const view = new DataView(output.buffer);
+  const writeAscii = (offset: number, value: string) => {
+    for (let index = 0; index < value.length; index += 1) {
+      view.setUint8(offset + index, value.charCodeAt(index));
+    }
+  };
+
+  writeAscii(0, "RIFF");
+  view.setUint32(4, 36 + pcm.byteLength, true);
+  writeAscii(8, "WAVE");
+  writeAscii(12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, 1, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * 2, true);
+  view.setUint16(32, 2, true);
+  view.setUint16(34, 16, true);
+  writeAscii(36, "data");
+  view.setUint32(40, pcm.byteLength, true);
+  output.set(pcm, WAV_HEADER_BYTES);
+  return output;
+}


### PR DESCRIPTION
## Summary
Adds an **opt-in `format: "wav"`** to `POST /api/v1/voice/tts`. When requested, the route asks ElevenLabs for raw PCM (`pcm_24000`) and wraps it in a PCM16 WAV header, returning `audio/wav`. Default (unset) is **unchanged** — every existing caller keeps the streaming MP3 response.

Also: the shared ElevenLabs service now honors a per-request `outputFormat` (it previously read only the service config default, so callers could never request PCM/WAV).

## Why
Some clients' audio stacks have **no MP3 decoder** — notably the LightOS WebView on the Light Phone III, where neither `AudioContext.decodeAudioData` nor an `<audio>` element can play `audio/mpeg`. WAV is uncompressed PCM and decodes with no codec, so a WAV option makes cloud TTS playable on any codec-limited client. (The self-hosted Kokoro path already returns WAV when `KOKORO_TTS_URL` is set; this covers the ElevenLabs default.)

## Behavior / safety
- **Backward compatible:** no `format` → MP3, byte-for-byte as before.
- WAV path bypasses the MP3-shaped first-line cache (different codec); **billing/usage are identical** to the MP3 path.
- Opt-in per request, so it doesn't change bandwidth/latency for existing users.

## Evidence
- `format:"wav"` → `HTTP 200`, `content-type: audio/wav`, valid RIFF/WAVE header, decodes on a codec-less WebView (`decodeAudioData → 1.81s @ 48000Hz`).
- default (no format) → `content-type: audio/mpeg`, MP3 (`ID3`) — unchanged.

> Note: this change is already running in production (deployed as an urgent unblock for on-device voice); landing it here keeps the repo/main in sync so a subsequent deploy doesn't revert it.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only cloud API change; no UI surface touched

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only cloud API change; no UI surface touched

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing UI flow; HTTP API returns audio bytes (header/byte-level proof attached in domain artifacts)

<!-- evidence-row:backend-logs -->
- [x] [15946-wav-format-test-run.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15946-wav-format-test-run.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend change; endpoint consumed by codec-less native clients

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model change; cloud HTTP TTS route only

<!-- evidence-row:domain-artifacts -->
- [x] [15946-wav-response-hexdump.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15946-wav-response-hexdump.txt)
