### PR TITLE
fix(core): preserve missing-input planner replies

### DIFF
--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -104,7 +104,7 @@ jobs:
             echo "no changed Vitest test files; skipping coverage run"
             exit 0
           fi
-          bunx vitest run "${changed_tests[@]}" --coverage --coverage.reporter=lcov --coverage.reportsDirectory=coverage/vitest
+          node packages/scripts/run-changed-vitest-coverage.mjs "${changed_tests[@]}"
 
       - name: Apply coverage gate (enforced)
         # Runs whenever changed tests ran, including test-only PRs (files == '').

--- a/packages/core/src/runtime/__tests__/planner-loop-terminal-continuation-noop-relay.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-terminal-continuation-noop-relay.test.ts
@@ -49,6 +49,22 @@ function evaluatorRequestsAnotherIteration() {
 	}));
 }
 
+function evaluatorContinuesThenFinishes(messageToUser: string) {
+	return vi
+		.fn()
+		.mockResolvedValueOnce({
+			success: true,
+			decision: "CONTINUE" as const,
+			thought: "The owner still needs an interaction.",
+		})
+		.mockResolvedValueOnce({
+			success: true,
+			decision: "FINISH" as const,
+			thought: "The form collects the missing fields.",
+			messageToUser,
+		});
+}
+
 describe("planner-loop - terminal continuation missing-input relay", () => {
 	it("finishes with a grammar-valid planner form when the evaluator continues past missing input", async () => {
 		const toolQuestion =
@@ -273,6 +289,64 @@ describe("planner-loop - terminal continuation missing-input relay", () => {
 			runtime,
 			context: { id: "ctx" },
 			config: { maxTerminalOnlyContinuations: 0 },
+			executeToolCall,
+			evaluate,
+		});
+
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBe(preview);
+	});
+
+	it("keeps a grammar-valid FINISH form ahead of the missing-input prose question", async () => {
+		const question =
+			"Please tell me the report name, date, and time before I create the reminder.";
+		const runtime = plannerEmitsNoopThenTerminalText(REMINDER_FORM);
+		const executeToolCall = vi.fn(async () => ({
+			success: false,
+			text: question,
+			userFacingText: question,
+			data: {
+				missingField: "schedule",
+				requiresConfirmation: true,
+				awaitingUserInput: true,
+			},
+		}));
+		const evaluate = evaluatorContinuesThenFinishes(REMINDER_FORM);
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			executeToolCall,
+			evaluate,
+		});
+
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBe(REMINDER_FORM);
+		expect(evaluate).toHaveBeenCalledTimes(2);
+	});
+
+	it("keeps a lifeDraft confirmation preview ahead of a FINISH form", async () => {
+		const preview =
+			"I can save this reminder for Friday at 9 AM. Confirm and I'll create it.";
+		const runtime = plannerEmitsNoopThenTerminalText(REMINDER_FORM);
+		const executeToolCall = vi.fn(async () => ({
+			success: false,
+			text: preview,
+			userFacingText: preview,
+			data: {
+				requiresConfirmation: true,
+				awaitingUserInput: true,
+				lifeDraft: {
+					operation: "create_definition",
+					request: { title: "Report deadline" },
+				},
+			},
+		}));
+		const evaluate = evaluatorContinuesThenFinishes(REMINDER_FORM);
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
 			executeToolCall,
 			evaluate,
 		});

--- a/packages/core/src/runtime/__tests__/planner-loop-terminal-continuation-noop-relay.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-terminal-continuation-noop-relay.test.ts
@@ -1,14 +1,23 @@
 /**
- * Covers terminal-continuation recovery for no-op clarification actions. When a
- * successful tool structurally marks its result as `noop: true`, its clarification
- * question is the real user-facing outcome, so a stuck evaluator/planner loop must
- * relay that question instead of replacing it with a generic trajectory-limit
- * failure. Deterministic - vitest-mocked `useModel` + injected evaluator; no live
- * model.
+ * Covers safe terminal-continuation recovery for tools waiting on owner input,
+ * using deterministic model and evaluator doubles.
  */
 import { describe, expect, it, vi } from "vitest";
 import type { TrajectoryLimitExceeded } from "../limits";
 import { runPlannerLoop } from "../planner-loop";
+
+const REMINDER_FORM = [
+	"[FORM]",
+	JSON.stringify({
+		title: "Create reminder",
+		fields: [
+			{ name: "title", type: "text", label: "Report name" },
+			{ name: "date", type: "date", label: "Date" },
+			{ name: "time", type: "time", label: "Time" },
+		],
+	}),
+	"[/FORM]",
+].join("\n");
 
 function plannerEmitsNoopThenTerminalText(terminalText: string) {
 	return {
@@ -40,7 +49,87 @@ function evaluatorRequestsAnotherIteration() {
 	}));
 }
 
-describe("planner-loop - terminal continuation noop clarification relay", () => {
+describe("planner-loop - terminal continuation missing-input relay", () => {
+	it("finishes with a grammar-valid planner form when the evaluator continues past missing input", async () => {
+		const toolQuestion =
+			"Please tell me the report name, date, and time before I create the reminder.";
+		const runtime = plannerEmitsNoopThenTerminalText(REMINDER_FORM);
+		const executeToolCall = vi.fn(async () => ({
+			success: false,
+			text: toolQuestion,
+			userFacingText: toolQuestion,
+			data: {
+				missingField: "title",
+				requiresConfirmation: true,
+			},
+		}));
+		const evaluate = evaluatorRequestsAnotherIteration();
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			executeToolCall,
+			evaluate,
+		});
+
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBe(REMINDER_FORM);
+		expect(executeToolCall).toHaveBeenCalledTimes(1);
+		expect(evaluate).toHaveBeenCalledTimes(2);
+		expect(runtime.useModel).toHaveBeenCalledTimes(2);
+	});
+
+	it("relays a safe planner clarification when missingField is the only awaiting-input marker", async () => {
+		const clarification =
+			"Please provide the report name, date, and time before I create the reminder.";
+		const runtime = plannerEmitsNoopThenTerminalText(clarification);
+		const executeToolCall = vi.fn(async () => ({
+			success: true,
+			text: "clarification required",
+			data: {
+				missingField: "title",
+			},
+		}));
+		const evaluate = evaluatorRequestsAnotherIteration();
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			config: { maxTerminalOnlyContinuations: 0 },
+			executeToolCall,
+			evaluate,
+		});
+
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBe(clarification);
+	});
+
+	it("rejects unsafe planner text even when the tool marks a missing field", async () => {
+		const runtime = plannerEmitsNoopThenTerminalText(
+			"I need to call OWNER_REMINDERS again with guessed title and schedule before answering.",
+		);
+		const executeToolCall = vi.fn(async () => ({
+			success: true,
+			text: "internal clarification state",
+			data: {
+				missingField: "title",
+			},
+		}));
+		const evaluate = evaluatorRequestsAnotherIteration();
+
+		await expect(
+			runPlannerLoop({
+				runtime,
+				context: { id: "ctx" },
+				config: { maxTerminalOnlyContinuations: 0 },
+				executeToolCall,
+				evaluate,
+			}),
+		).rejects.toMatchObject({
+			kind: "terminal_only_continuations",
+		} satisfies Partial<TrajectoryLimitExceeded>);
+	});
+
 	it("relays a successful noop action's clarification when terminal-only continuation exhaustion would otherwise discard it", async () => {
 		const clarification =
 			"What would success look like for you: completing the 5K in a target time, distance, or consistency goal?";
@@ -160,5 +249,35 @@ describe("planner-loop - terminal continuation noop clarification relay", () => 
 		expect(result.finalMessage).toBe(preview);
 		expect(executeToolCall).toHaveBeenCalledTimes(1);
 		expect(evaluate).toHaveBeenCalledTimes(2);
+	});
+
+	it("keeps an action-owned confirmation preview ahead of an unrelated planner form", async () => {
+		const preview =
+			"I can save this reminder for Friday at 9 AM. Confirm and I'll create it.";
+		const runtime = plannerEmitsNoopThenTerminalText(REMINDER_FORM);
+		const executeToolCall = vi.fn(async () => ({
+			success: false,
+			text: preview,
+			userFacingText: preview,
+			data: {
+				requiresConfirmation: true,
+				lifeDraft: {
+					operation: "create_definition",
+					request: { title: "Report deadline" },
+				},
+			},
+		}));
+		const evaluate = evaluatorRequestsAnotherIteration();
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			config: { maxTerminalOnlyContinuations: 0 },
+			executeToolCall,
+			evaluate,
+		});
+
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBe(preview);
 	});
 });

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -928,6 +928,56 @@ describe("v5 planner loop skeleton", () => {
 		);
 	});
 
+	it("preserves a planner form when the action explicitly awaits owner input", async () => {
+		const form = [
+			"[FORM]",
+			JSON.stringify({
+				title: "Create reminder",
+				fields: [{ name: "schedule", type: "text", label: "When?" }],
+			}),
+			"[/FORM]",
+		].join("\n");
+		const runtime = {
+			useModel: vi
+				.fn()
+				.mockResolvedValueOnce({
+					text: "",
+					toolCalls: [
+						{
+							id: "call-1",
+							name: "OWNER_REMINDERS",
+							arguments: { action: "create" },
+						},
+					],
+				})
+				.mockResolvedValueOnce({ text: form }),
+		};
+		const executeToolCall = vi.fn(async () => ({
+			success: false,
+			text: "When should the reminder happen?",
+			data: { awaitingUserInput: true },
+		}));
+		const evaluate = vi.fn(async () => ({
+			success: true,
+			decision: "CONTINUE" as const,
+			thought: "The owner still needs an interaction.",
+		}));
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			tools: [
+				{ name: "OWNER_REMINDERS", description: "Manage owner reminders." },
+			],
+			executeToolCall,
+			evaluate,
+		});
+
+		expect(result.finalMessage).toBe(form);
+		expect(runtime.useModel).toHaveBeenCalledTimes(2);
+		expect(executeToolCall).toHaveBeenCalledTimes(1);
+	});
+
 	it("falls back to tool text when evaluator names an action execution", async () => {
 		const runtime = {
 			useModel: vi.fn(async () => ({

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -3327,19 +3327,25 @@ function preferredFinalMessageFromToolOrModel(
 	const modelText = getNonEmptyString(modelMessage);
 	const usableModelText =
 		modelText && !isToolMetaNarration(modelText) ? modelText : undefined;
+	const widgetReply = userSafeWidgetReplyCandidate(usableModelText);
+	const widgetCollectsLatestMissingInput =
+		widgetReply !== undefined && latestToolResultAwaitsUserInput(trajectory);
 	// Precedence:
 	//   1. A single successful tool whose result was explicitly marked
 	//      `verifiedUserFacing: true` — used for structured outputs
 	//      (paths, ids, counts) where evaluator paraphrase risks
 	//      hallucinating a value.
-	//   2. A confirmation-required tool preview — action-owned copy must not be
+	//   2. A grammar-valid widget emitted for a structurally-marked missing-input
+	//      result. The widget preserves the planner's field types and supersedes
+	//      the tool's prose question, but never a lifeDraft confirmation preview.
+	//   3. A confirmation-required tool preview — action-owned copy must not be
 	//      paraphrased into a vague extra question or a false save.
-	//   3. The model/evaluator's explicit `messageToUser` — authoritative
+	//   4. The model/evaluator's explicit `messageToUser` — authoritative
 	//      by default; the evaluator has seen the full trajectory and
 	//      chose what the user should read.
-	//   4. The most recent tool's `userFacingText` — fallback when neither
+	//   5. The most recent tool's `userFacingText` — fallback when neither
 	//      the model nor any verified tool provided a clean reply.
-	//   5. An explicit caller-provided fallback (e.g. failed-tool message).
+	//   6. An explicit caller-provided fallback (e.g. failed-tool message).
 	//
 	// Regression coverage:
 	//   - `planner-loop-user-facing-text.test.ts` → "does not regress
@@ -3350,11 +3356,25 @@ function preferredFinalMessageFromToolOrModel(
 	//     opts in via `verifiedUserFacing: true`.
 	return (
 		singleVerifiedUserFacingToolResultText(trajectory) ??
+		(widgetCollectsLatestMissingInput ? widgetReply : undefined) ??
 		deterministicRequiresConfirmationRelay(trajectory) ??
 		usableModelText ??
 		latestToolResultText(trajectory) ??
 		getNonEmptyString(fallback)
 	);
+}
+
+function latestToolResultAwaitsUserInput(
+	trajectory: PlannerTrajectory,
+): boolean {
+	for (const step of [...trajectory.steps].reverse()) {
+		if (!step.toolCall || isTerminalToolCall(step.toolCall) || !step.result) {
+			continue;
+		}
+		if (step.result.data?.lifeDraft !== undefined) return false;
+		return hasAwaitingUserInputMarker(step.result);
+	}
+	return false;
 }
 
 function isToolMetaNarration(text: string): boolean {

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -536,6 +536,24 @@ export async function runPlannerLoop(
 						continue;
 					}
 
+					const missingInputWidgetRelay =
+						deterministicMissingInputPlannerWidgetRelay(trajectory);
+					if (missingInputWidgetRelay) {
+						params.runtime.logger?.warn?.(
+							{ iteration },
+							"[planner-loop] evaluator continued after a missing-input widget; finishing with the user interaction",
+						);
+						return {
+							status: "finished",
+							trajectory,
+							evaluator,
+							finalMessage: userSafeFinalMessage(
+								missingInputWidgetRelay,
+								trajectory,
+							),
+						};
+					}
+
 					terminalOnlyContinuations++;
 					if (terminalOnlyContinuations > config.maxTerminalOnlyContinuations) {
 						const relay =
@@ -3026,10 +3044,57 @@ function deterministicTerminalContinuationLimitRelay(
 	trajectory: PlannerTrajectory,
 ): string | undefined {
 	return (
+		deterministicMissingInputPlannerWidgetRelay(trajectory) ??
 		deterministicSuccessfulToolRelay(trajectory) ??
 		deterministicRequiresConfirmationRelay(trajectory) ??
-		deterministicNoopClarificationRelay(trajectory)
+		deterministicNoopClarificationRelay(trajectory) ??
+		deterministicMissingInputPlannerClarificationRelay(trajectory)
 	);
+}
+
+/**
+ * A planner reply may finish a missing-input turn only when the latest executed
+ * tool structurally declares that it is waiting for the owner. This keeps the
+ * relay from treating arbitrary terminal prose after successful work as safe.
+ * Widgets take precedence over prose because they preserve the fields and input
+ * types the planner selected instead of degrading the turn to another question.
+ */
+function deterministicMissingInputPlannerWidgetRelay(
+	trajectory: PlannerTrajectory,
+): string | undefined {
+	return missingInputPlannerTerminalCandidates(trajectory)
+		.map(userSafeWidgetReplyCandidate)
+		.find((candidate): candidate is string => candidate !== undefined);
+}
+
+function deterministicMissingInputPlannerClarificationRelay(
+	trajectory: PlannerTrajectory,
+): string | undefined {
+	return missingInputPlannerTerminalCandidates(trajectory)
+		.map(userSafeClarificationReplyCandidate)
+		.find((candidate): candidate is string => candidate !== undefined);
+}
+
+function missingInputPlannerTerminalCandidates(
+	trajectory: PlannerTrajectory,
+): Array<string | undefined> {
+	let latestToolResultIndex = -1;
+	for (let index = trajectory.steps.length - 1; index >= 0; index--) {
+		const step = trajectory.steps[index];
+		if (!step?.toolCall || isTerminalToolCall(step.toolCall) || !step.result) {
+			continue;
+		}
+		latestToolResultIndex = index;
+		if (!hasAwaitingUserInputMarker(step.result)) return [];
+		break;
+	}
+	if (latestToolResultIndex < 0) return [];
+
+	return trajectory.steps
+		.slice(latestToolResultIndex + 1)
+		.filter((step) => step.terminalOnly === true)
+		.map((step) => step.terminalMessage)
+		.reverse();
 }
 
 function deterministicRequiresConfirmationRelay(
@@ -3075,6 +3140,24 @@ function hasNoopMarker(result: PlannerToolResult): boolean {
 		typeof values === "object" &&
 		!Array.isArray(values) &&
 		(values as Record<string, unknown>).noop === true
+	);
+}
+
+function hasAwaitingUserInputMarker(result: PlannerToolResult): boolean {
+	if (hasNoopMarker(result)) return true;
+	const data = result.data;
+	if (!data) return false;
+	if (data.awaitingUserInput === true || getNonEmptyString(data.missingField)) {
+		return true;
+	}
+	const values = data.values;
+	return (
+		values !== null &&
+		typeof values === "object" &&
+		!Array.isArray(values) &&
+		((values as Record<string, unknown>).awaitingUserInput === true ||
+			getNonEmptyString((values as Record<string, unknown>).missingField) !==
+				undefined)
 	);
 }
 
@@ -3734,6 +3817,17 @@ function userSafeCapturedAnswerCandidate(
 		return undefined;
 	}
 	if (PROGRESS_ONLY_ANSWER_REJECT.test(candidate)) return undefined;
+	return candidate;
+}
+
+const CLARIFICATION_REQUEST =
+	/(?:\?\s*(?:$|\n)|\bplease\s+(?:choose|confirm|enter|provide|select|share|specify|tell)\b|^(?:can|could|do|does|how|is|are|what|when|where|which|who|would)\b)/i;
+
+function userSafeClarificationReplyCandidate(
+	message: string | undefined,
+): string | undefined {
+	const candidate = userSafeCapturedAnswerCandidate(message);
+	if (!candidate || !CLARIFICATION_REQUEST.test(candidate)) return undefined;
 	return candidate;
 }
 

--- a/packages/scenario-runner/src/__tests__/deterministic-action-coverage.test.ts
+++ b/packages/scenario-runner/src/__tests__/deterministic-action-coverage.test.ts
@@ -792,6 +792,8 @@ const PROSE_ONLY_LLM_SCENARIOS: Record<string, string> = {
     "live-only real-LLM help-knowledge lane (#14360); the model answers from bundled help documents in prose, routing no action.",
   "live-lifeops-task-filter-due-window":
     "live-only real-LLM counterpart of the deterministic lifeops scheduled-task lanes; the live model routes SCHEDULED_TASKS with no deterministic ACTION_PLANNER fixture. The deterministic twins gate the keyless lane.",
+  "live-missing-input-terminal-relay":
+    "live-only real-LLM missing-input planner-loop regression; the live model routes OWNER_REMINDERS without a deterministic ACTION_PLANNER fixture, while the keyless planner-loop suite forces the erroneous evaluator-CONTINUE branch.",
   "live-plugin-enable-toggle-verb":
     "live-only real-LLM plugin enable/toggle verb routing; no deterministic ACTION_PLANNER fixture. Keyless gating proof: plugin-manager action unit suites in core.",
   "live-workflow-action-executions":

--- a/packages/scenario-runner/test/scenarios/live-missing-input-terminal-relay.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/live-missing-input-terminal-relay.scenario.ts
@@ -1,0 +1,69 @@
+/**
+ * Live-model proof that a missing-input owner action ends in its explicit
+ * clarification or a grammar-valid widget, never a trajectory-limit apology.
+ */
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { validateSchedulingFormReply } from "./_helpers/chat-widgets";
+
+const SYNTHETIC_FAILURE_RE =
+  /sorry, something went wrong|trajectory limit|try again|failed on my end/i;
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+export default scenario({
+  id: "live-missing-input-terminal-relay",
+  lane: "live-only",
+  title: "Missing-input reminder clarification reaches the owner",
+  domain: "chat-widgets",
+  tags: ["live", "real-llm", "planner-loop", "lifeops", "regression"],
+  isolation: "per-scenario",
+  rooms: [
+    {
+      id: "main",
+      source: "eliza-app",
+      title: "Missing Input Relay",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "missing reminder fields finish as a user-visible interaction",
+      room: "main",
+      text: "I need a reminder for an upcoming report deadline — you'll need the report name, the day, and the time from me.",
+      assertTurn: (execution) => {
+        const response = execution.responseText?.trim() ?? "";
+        if (!response) return "missing-input turn returned an empty reply";
+        if (SYNTHETIC_FAILURE_RE.test(response)) {
+          return `missing-input turn returned a synthetic failure: ${JSON.stringify(response)}`;
+        }
+
+        const reminder = execution.actionsCalled.find(
+          (action) => action.actionName === "OWNER_REMINDERS",
+        );
+        if (!reminder?.result) {
+          return "OWNER_REMINDERS did not execute on the missing-input turn";
+        }
+        const data = record(reminder.result.data);
+        if (data?.awaitingUserInput !== true) {
+          return `OWNER_REMINDERS did not mark awaitingUserInput: ${JSON.stringify(data)}`;
+        }
+        const raw = record(reminder.result.raw);
+        const userFacingText = raw?.userFacingText;
+        if (typeof userFacingText !== "string" || !userFacingText.trim()) {
+          return "OWNER_REMINDERS clarification did not declare userFacingText";
+        }
+
+        const parsedForm = validateSchedulingFormReply(response);
+        if (typeof parsedForm !== "string") return undefined;
+        if (response !== userFacingText.trim()) {
+          return `reply was neither a valid scheduling form nor the action-owned clarification: ${JSON.stringify(response)}`;
+        }
+        return undefined;
+      },
+    },
+  ],
+});

--- a/packages/scripts/__tests__/coverage-workflow-source-condition.test.ts
+++ b/packages/scripts/__tests__/coverage-workflow-source-condition.test.ts
@@ -1,6 +1,6 @@
 /**
  * Pins the clean-checkout coverage lane to source workspace exports so changed
- * Bun tests do not depend on prebuilt package artifacts.
+ * Bun and Vitest tests do not depend on prebuilt package artifacts.
  */
 import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
@@ -14,5 +14,12 @@ test("changed Bun coverage tests use eliza-source workspace exports", () => {
   const workflow = readFileSync(workflowPath, "utf8");
   expect(workflow).toMatch(
     /bun test --conditions=eliza-source "\$\{changed_tests\[@\]\}" --coverage/,
+  );
+});
+
+test("changed Vitest coverage tests use package-aware source configuration", () => {
+  const workflow = readFileSync(workflowPath, "utf8");
+  expect(workflow).toMatch(
+    /node packages\/scripts\/run-changed-vitest-coverage[.]mjs "\$\{changed_tests\[@\]\}"/,
   );
 });

--- a/packages/scripts/__tests__/run-changed-vitest-coverage.test.ts
+++ b/packages/scripts/__tests__/run-changed-vitest-coverage.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Verifies changed Vitest files are grouped by their real package config while
+ * root-level tests retain the root config and report namespace.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  findNearestVitestConfig,
+  groupChangedVitestTests,
+  normalizeLcovReport,
+} from "../run-changed-vitest-coverage.mjs";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true });
+});
+
+function fixture(): string {
+  const root = mkdtempSync(path.join(tmpdir(), "changed-vitest-"));
+  roots.push(root);
+  const packageDir = path.join(root, "packages", "feature");
+  const nestedDir = path.join(packageDir, "src", "nested");
+  mkdirSync(nestedDir, { recursive: true });
+  writeFileSync(path.join(root, "vitest.config.ts"), "export default {};");
+  writeFileSync(
+    path.join(packageDir, "vitest.config.ts"),
+    "export default {};",
+  );
+  writeFileSync(path.join(root, "root.test.ts"), "");
+  writeFileSync(path.join(nestedDir, "feature.test.ts"), "");
+  return root;
+}
+
+describe("changed Vitest coverage grouping", () => {
+  test("uses the nearest package config and an isolated report directory", () => {
+    const root = fixture();
+    const config = findNearestVitestConfig(
+      root,
+      "packages/feature/src/nested/feature.test.ts",
+    );
+    expect(config).toBe(path.join(root, "packages/feature/vitest.config.ts"));
+
+    const groups = groupChangedVitestTests(root, [
+      "packages/feature/src/nested/feature.test.ts",
+      "root.test.ts",
+    ]);
+    expect(groups).toHaveLength(2);
+    expect(
+      groups.map((group) => path.relative(root, group.reportDir)).sort(),
+    ).toEqual(["coverage/vitest/packages-feature", "coverage/vitest/root"]);
+    expect(groups.flatMap((group) => group.tests)).toEqual(
+      expect.arrayContaining([
+        path.join(root, "root.test.ts"),
+        path.join(root, "packages/feature/src/nested/feature.test.ts"),
+      ]),
+    );
+  });
+
+  test("rejects a changed test outside the repository", () => {
+    const root = fixture();
+    expect(() => findNearestVitestConfig(root, "../outside.test.ts")).toThrow(
+      "escapes the repository",
+    );
+  });
+
+  test("normalizes package-relative LCOV source paths to repository paths", () => {
+    const root = fixture();
+    const packageDir = path.join(root, "packages", "feature");
+    const reportDir = path.join(root, "coverage", "vitest", "feature");
+    mkdirSync(reportDir, { recursive: true });
+    writeFileSync(path.join(packageDir, "src", "covered.ts"), "export {};\n");
+    writeFileSync(
+      path.join(reportDir, "lcov.info"),
+      "TN:\nSF:src/covered.ts\nLF:1\nLH:1\nend_of_record\n",
+    );
+
+    normalizeLcovReport(root, packageDir, reportDir);
+
+    expect(readFileSync(path.join(reportDir, "lcov.info"), "utf8")).toContain(
+      "SF:packages/feature/src/covered.ts",
+    );
+  });
+});

--- a/packages/scripts/run-changed-vitest-coverage.mjs
+++ b/packages/scripts/run-changed-vitest-coverage.mjs
@@ -1,0 +1,163 @@
+/**
+ * Runs changed Vitest files through their nearest package configuration.
+ *
+ * The coverage gate executes before workspace builds, so combining unrelated
+ * package tests under the root config can resolve absent dist entrypoints and
+ * bypass package-specific aliases or setup. Each group writes an independent
+ * LCOV report; the existing coverage gate merges every discovered report.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const CONFIG_NAMES = [
+  "vitest.config.ts",
+  "vitest.config.mts",
+  "vitest.config.js",
+  "vitest.config.mjs",
+  "vitest.config.cts",
+  "vitest.config.cjs",
+];
+
+const normalize = (value) => value.split(path.sep).join("/");
+
+export function findNearestVitestConfig(repoRoot, testFile) {
+  const absoluteRoot = path.resolve(repoRoot);
+  const absoluteTest = path.resolve(absoluteRoot, testFile);
+  const relativeTest = path.relative(absoluteRoot, absoluteTest);
+  if (
+    relativeTest === ".." ||
+    relativeTest.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relativeTest)
+  ) {
+    throw new Error(`Changed test escapes the repository: ${testFile}`);
+  }
+
+  let directory = path.dirname(absoluteTest);
+  while (true) {
+    for (const name of CONFIG_NAMES) {
+      const candidate = path.join(directory, name);
+      if (existsSync(candidate)) return candidate;
+    }
+    if (directory === absoluteRoot) break;
+    const parent = path.dirname(directory);
+    if (parent === directory) break;
+    directory = parent;
+  }
+
+  throw new Error(`No Vitest config found for changed test: ${testFile}`);
+}
+
+export function groupChangedVitestTests(repoRoot, testFiles) {
+  const absoluteRoot = path.resolve(repoRoot);
+  const groups = new Map();
+
+  for (const testFile of testFiles) {
+    const configPath = findNearestVitestConfig(absoluteRoot, testFile);
+    const absoluteTest = path.resolve(absoluteRoot, testFile);
+    const tests = groups.get(configPath) ?? [];
+    tests.push(absoluteTest);
+    groups.set(configPath, tests);
+  }
+
+  return [...groups.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([configPath, tests]) => {
+      const configDir = path.dirname(configPath);
+      const relativeDir = normalize(path.relative(absoluteRoot, configDir));
+      const reportSlug = (relativeDir || "root").replaceAll(
+        /[^a-zA-Z0-9._-]+/g,
+        "-",
+      );
+      return {
+        configDir,
+        configPath,
+        reportDir: path.join(absoluteRoot, "coverage", "vitest", reportSlug),
+        tests: tests.sort(),
+      };
+    });
+}
+
+export function normalizeLcovReport(repoRoot, configDir, reportDir) {
+  const lcovPath = path.join(reportDir, "lcov.info");
+  if (!existsSync(lcovPath)) return;
+
+  const absoluteRoot = path.resolve(repoRoot);
+  const normalized = readFileSync(lcovPath, "utf8")
+    .split("\n")
+    .map((line) => {
+      if (!line.startsWith("SF:")) return line;
+      const sourcePath = line.slice("SF:".length);
+      const candidates = path.isAbsolute(sourcePath)
+        ? [sourcePath]
+        : [
+            path.resolve(configDir, sourcePath),
+            path.resolve(absoluteRoot, sourcePath),
+          ];
+      const existing = candidates.find((candidate) => existsSync(candidate));
+      if (!existing) return line;
+      const relative = path.relative(absoluteRoot, existing);
+      if (relative.startsWith("..") || path.isAbsolute(relative)) return line;
+      return `SF:${normalize(relative)}`;
+    })
+    .join("\n");
+  writeFileSync(lcovPath, normalized);
+}
+
+export function runChangedVitestCoverage(repoRoot, testFiles) {
+  const groups = groupChangedVitestTests(repoRoot, testFiles);
+  for (const group of groups) {
+    const result = spawnSync(
+      "bunx",
+      [
+        "vitest",
+        "run",
+        ...group.tests,
+        "--config",
+        group.configPath,
+        "--coverage",
+        "--coverage.reporter=lcov",
+        // Package configs carry whole-suite global thresholds. This lane runs
+        // only changed files and applies its stricter changed-source floor in
+        // coverage-gate.awk after merging the per-package LCOV reports.
+        "--coverage.thresholds.lines=0",
+        "--coverage.thresholds.functions=0",
+        "--coverage.thresholds.statements=0",
+        "--coverage.thresholds.branches=0",
+        `--coverage.reportsDirectory=${group.reportDir}`,
+      ],
+      {
+        cwd: group.configDir,
+        env: process.env,
+        stdio: "inherit",
+      },
+    );
+
+    if (result.error) throw result.error;
+    if (result.status !== 0) {
+      throw new Error(
+        `Vitest coverage failed for ${normalize(path.relative(repoRoot, group.configDir)) || "root"} (exit ${result.status ?? "signal"})`,
+      );
+    }
+    normalizeLcovReport(repoRoot, group.configDir, group.reportDir);
+  }
+}
+
+const isMain = process.argv[1]
+  ? path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+  : false;
+
+if (isMain) {
+  const testFiles = process.argv.slice(2).filter(Boolean);
+  if (testFiles.length === 0) {
+    throw new Error("At least one changed Vitest file is required.");
+  }
+  const repoRoot = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+    "..",
+  );
+  runChangedVitestCoverage(repoRoot, testFiles);
+}

--- a/plugins/plugin-personal-assistant/src/actions/life-reminder-datetime.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life-reminder-datetime.test.ts
@@ -30,7 +30,9 @@ import type { ExtractedTaskParams } from "./lib/extract-task-plan.js";
 import {
   buildCadenceFromLlmParams,
   buildCadenceFromUpdateFields,
+  resolveDefinitionFromIntent,
   resolveOnceDueAt,
+  runLifeConnectedQuery,
   runLifeOperationHandler,
 } from "./life.js";
 
@@ -584,6 +586,177 @@ describe("runLifeOperationHandler clarification contract", () => {
       },
     });
     expect(serviceState.createCalls).toHaveLength(0);
+  });
+});
+
+describe("runLifeConnectedQuery capability boundaries", () => {
+  const service = (
+    overrides: Record<string, unknown>,
+  ): Parameters<typeof runLifeConnectedQuery>[0]["service"] =>
+    ({
+      getGoogleConnectorStatus: vi.fn(async () => ({
+        connected: false,
+        grantedCapabilities: [],
+      })),
+      listCalendars: vi.fn(async () => []),
+      ...overrides,
+    }) as unknown as Parameters<typeof runLifeConnectedQuery>[0]["service"];
+
+  const query = async (
+    queryOperation: Parameters<
+      typeof runLifeConnectedQuery
+    >[0]["queryOperation"],
+    serviceOverrides: Record<string, unknown>,
+  ) =>
+    runLifeConnectedQuery({
+      runtime: makeRuntime(() => ""),
+      message: makeMessage("show me the connected data"),
+      state: undefined,
+      intent: "show me the connected data",
+      service: service(serviceOverrides),
+      queryOperation,
+      actionName: "OWNER_LIFE",
+    });
+
+  it("reports Gmail unavailable without calling the triage endpoint", async () => {
+    const getGmailTriage = vi.fn();
+    const result = await query("query_email", { getGmailTriage });
+
+    expect(result.success).toBe(false);
+    expect(result.text).toContain("Gmail is not connected");
+    expect(getGmailTriage).not.toHaveBeenCalled();
+  });
+
+  it("returns the designed empty Gmail state when triage access is granted", async () => {
+    const result = await query("query_email", {
+      getGoogleConnectorStatus: vi.fn(async () => ({
+        connected: true,
+        grantedCapabilities: ["google.gmail.triage"],
+      })),
+      getGmailTriage: vi.fn(async () => ({
+        messages: [],
+        source: "synced",
+        syncedAt: "2026-07-10T00:00:00.000Z",
+        summary: {
+          unreadCount: 0,
+          importantNewCount: 0,
+          likelyReplyNeededCount: 0,
+        },
+      })),
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.text).toBe("No important emails right now.");
+  });
+
+  it("uses an Apple calendar grant when Google calendar access is absent", async () => {
+    const result = await query("query_calendar_next", {
+      listCalendars: vi.fn(async () => [{ id: "apple-calendar" }]),
+      getNextCalendarEventContext: vi.fn(async () => ({
+        event: null,
+        startsAt: null,
+        startsInMinutes: null,
+        location: null,
+        attendeeNames: [],
+      })),
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.text).toBe("No upcoming events on your calendar.");
+  });
+
+  it("reports calendar unavailable when neither connector grants read access", async () => {
+    const result = await query("query_calendar_today", {});
+
+    expect(result.success).toBe(false);
+    expect(result.text).toContain("Google Calendar is not connected");
+    expect(result.data).toEqual({
+      actionName: "OWNER_LIFE",
+      operation: "query_calendar_today",
+    });
+  });
+
+  it("returns the designed empty state for an accessible clear calendar", async () => {
+    const getCalendarFeed = vi.fn(async () => ({ events: [] }));
+    const result = await query("query_calendar_today", {
+      getGoogleConnectorStatus: vi.fn(async () => ({
+        connected: true,
+        grantedCapabilities: ["google.calendar.read"],
+      })),
+      getCalendarFeed,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.text).toBe("Your calendar is clear today.");
+    expect(getCalendarFeed).toHaveBeenCalledOnce();
+  });
+
+  it("summarizes populated accessible calendar feeds", async () => {
+    const result = await query("query_calendar_today", {
+      getGoogleConnectorStatus: vi.fn(async () => ({
+        connected: true,
+        grantedCapabilities: ["google.calendar.read"],
+      })),
+      getCalendarFeed: vi.fn(async () => ({
+        events: [
+          {
+            title: "Report review",
+            startAt: "2026-07-10T15:00:00.000Z",
+            timezone: "UTC",
+          },
+        ],
+      })),
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.text).toContain("You have 1 event today:");
+    expect(result.text).toContain("Report review");
+  });
+
+  it("translates a connected-service rate limit at the action boundary", async () => {
+    const { LifeOpsServiceError } = await import("../lifeops/service.js");
+    const result = await query("query_calendar_today", {
+      getGoogleConnectorStatus: vi.fn(async () => ({
+        connected: true,
+        grantedCapabilities: ["google.calendar.read"],
+      })),
+      getCalendarFeed: vi.fn(async () => {
+        throw new LifeOpsServiceError("rate limit", 429);
+      }),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.text).toBe(
+      "LifeOps is rate-limited right now. Try again in a bit.",
+    );
+    expect(result.data).toEqual({
+      actionName: "OWNER_LIFE",
+      operation: "query_calendar_today",
+    });
+  });
+});
+
+describe("resolveDefinitionFromIntent", () => {
+  it("resolves a uniquely named definition from natural-language intent", async () => {
+    const service = {
+      listDefinitions: vi.fn(async () => [
+        {
+          definition: {
+            id: "def-1",
+            title: "workout",
+            domain: "user_lifeops",
+          },
+        },
+      ]),
+    } as unknown as Parameters<typeof resolveDefinitionFromIntent>[0];
+    const result = await resolveDefinitionFromIntent(
+      service,
+      undefined,
+      "Please update my workout routine",
+      "user_lifeops",
+    );
+
+    expect(result?.definition.id).toBe("def-1");
   });
 });
 

--- a/plugins/plugin-personal-assistant/src/actions/life-reminder-datetime.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life-reminder-datetime.test.ts
@@ -480,6 +480,113 @@ function taskPlanJson(overrides: Record<string, unknown>): string {
   });
 }
 
+describe("runLifeOperationHandler clarification contract", () => {
+  it("marks a reminder-plan response as user-facing and awaiting owner input", async () => {
+    const clarification =
+      "Please tell me the report name, date, and time before I create the reminder.";
+    const runtime = makeRuntime((prompt) => {
+      if (
+        prompt.includes(
+          "Plan the next step for a LifeOps create_definition request.",
+        )
+      ) {
+        return taskPlanJson({
+          mode: "respond",
+          response: clarification,
+        });
+      }
+      return clarification;
+    });
+
+    const result = await runLifeOperationHandler(
+      runtime,
+      makeMessage(
+        "I need a reminder for an upcoming report deadline, but I still need to provide its name, date, and time.",
+      ),
+      undefined,
+      {
+        parameters: {
+          action: "create",
+          intent:
+            "Create a reminder after asking me for its report name, date, and time.",
+          ownerSurface: "OWNER_REMINDERS",
+        },
+      } as HandlerOptions,
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      text: clarification,
+      userFacingText: clarification,
+      values: {
+        success: true,
+        noop: true,
+        awaitingUserInput: true,
+        suggestedOperation: "create",
+      },
+      data: {
+        actionName: "OWNER_REMINDERS",
+        noop: true,
+        awaitingUserInput: true,
+        suggestedOperation: "create",
+      },
+    });
+    expect(serviceState.createCalls).toHaveLength(0);
+  });
+
+  it("marks a missing reminder schedule as user-facing and awaiting owner input", async () => {
+    const clarification = "What day and time should I use?";
+    const runtime = makeRuntime((prompt) => {
+      if (
+        prompt.includes(
+          "Plan the next step for a LifeOps create_definition request.",
+        )
+      ) {
+        return taskPlanJson({
+          mode: "respond",
+          response: clarification,
+          title: "Report deadline",
+        });
+      }
+      return clarification;
+    });
+
+    const result = await runLifeOperationHandler(
+      runtime,
+      makeMessage("Remind me about my report deadline."),
+      undefined,
+      {
+        parameters: {
+          action: "create",
+          intent: "Create a report deadline reminder.",
+          title: "Report deadline",
+          ownerSurface: "OWNER_REMINDERS",
+        },
+      } as HandlerOptions,
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      text: "When should it happen?",
+      userFacingText: "When should it happen?",
+      values: {
+        success: false,
+        error: "MISSING_DEFINITION_FIELD",
+        missingField: "schedule",
+        requiresConfirmation: true,
+        awaitingUserInput: true,
+      },
+      data: {
+        actionName: "OWNER_REMINDERS",
+        missingField: "schedule",
+        requiresConfirmation: true,
+        awaitingUserInput: true,
+      },
+    });
+    expect(serviceState.createCalls).toHaveLength(0);
+  });
+});
+
 describe("runLifeOperationHandler snooze durations", () => {
   beforeEach(() => {
     serviceState.snoozeCalls.length = 0;

--- a/plugins/plugin-personal-assistant/src/actions/life.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life.ts
@@ -2912,26 +2912,35 @@ export async function runLifeOperationHandler(
       operation: operationPlan.operation,
       kind: resolvedKind,
     });
+    const text = await renderLifeActionReply({
+      runtime,
+      message,
+      state,
+      intent,
+      scenario:
+        operationPlan.operation === "create" && resolvedKind === "goal"
+          ? "clarify_create_goal"
+          : "clarify_create_definition",
+      fallback,
+      context: {
+        missing: operationPlan.missing,
+        operation: operationPlan.operation,
+      },
+    });
     return {
       success: true,
-      text: await renderLifeActionReply({
-        runtime,
-        message,
-        state,
-        intent,
-        scenario:
-          operationPlan.operation === "create" && resolvedKind === "goal"
-            ? "clarify_create_goal"
-            : "clarify_create_definition",
-        fallback,
-        context: {
-          missing: operationPlan.missing,
-          operation: operationPlan.operation,
-        },
-      }),
+      text,
+      userFacingText: text,
+      values: {
+        success: true,
+        noop: true,
+        awaitingUserInput: true,
+        suggestedOperation: operationPlan.operation,
+      },
       data: {
         actionName: ownerSurfaceActionName,
         noop: true,
+        awaitingUserInput: true,
         suggestedOperation: operationPlan.operation,
       },
     };
@@ -3140,9 +3149,23 @@ export async function runLifeOperationHandler(
           !detailString(details, "goalTitle") &&
           !detailString(details, "kind");
         if (shouldHonorPlannerResponse && llmPlan.response) {
+          const text = llmPlan.response;
           return {
             success: true as const,
-            text: llmPlan.response,
+            text,
+            userFacingText: text,
+            values: {
+              success: true,
+              noop: true,
+              awaitingUserInput: true,
+              suggestedOperation: "create",
+            },
+            data: {
+              actionName: ownerSurfaceActionName,
+              noop: true,
+              awaitingUserInput: true,
+              suggestedOperation: "create",
+            },
           };
         }
         if (llmPlan) {
@@ -3215,20 +3238,22 @@ export async function runLifeOperationHandler(
 
       if (!title) {
         const fallback = "What should I call it?";
+        const text = await renderLifeActionReply({
+          runtime,
+          message,
+          state,
+          intent,
+          scenario: "clarify_create_definition",
+          fallback,
+          context: {
+            missing: ["title"],
+            operation: "create_definition",
+          },
+        });
         return {
           success: false as const,
-          text: await renderLifeActionReply({
-            runtime,
-            message,
-            state,
-            intent,
-            scenario: "clarify_create_definition",
-            fallback,
-            context: {
-              missing: ["title"],
-              operation: "create_definition",
-            },
-          }),
+          text,
+          userFacingText: text,
           // Asking the owner to fill in a missing field — selection +
           // execution were both correct, terminal state is "needs human
           // input". Flag so the native planner chain breaks and the spy
@@ -3238,40 +3263,46 @@ export async function runLifeOperationHandler(
             error: "MISSING_DEFINITION_FIELD",
             missingField: "title",
             requiresConfirmation: true,
+            awaitingUserInput: true,
           },
           data: {
             actionName: ownerSurfaceActionName,
             missingField: "title",
             requiresConfirmation: true,
+            awaitingUserInput: true,
           },
         };
       }
       if (!cadence) {
         const fallback = "When should it happen?";
+        const text = await renderLifeActionReply({
+          runtime,
+          message,
+          state,
+          intent,
+          scenario: "clarify_create_definition",
+          fallback,
+          context: {
+            missing: ["schedule"],
+            operation: "create_definition",
+          },
+        });
         return {
           success: false as const,
-          text: await renderLifeActionReply({
-            runtime,
-            message,
-            state,
-            intent,
-            scenario: "clarify_create_definition",
-            fallback,
-            context: {
-              missing: ["schedule"],
-              operation: "create_definition",
-            },
-          }),
+          text,
+          userFacingText: text,
           values: {
             success: false,
             error: "MISSING_DEFINITION_FIELD",
             missingField: "schedule",
             requiresConfirmation: true,
+            awaitingUserInput: true,
           },
           data: {
             actionName: ownerSurfaceActionName,
             missingField: "schedule",
             requiresConfirmation: true,
+            awaitingUserInput: true,
           },
         };
       }


### PR DESCRIPTION
Fixes #15918

## Summary

- preserves a grammar-valid `[FORM]` planner reply when a tool result structurally says it is waiting for missing user input, even if the evaluator incorrectly asks the planner to continue
- gives missing-input planner interactions the correct terminal relay priority on both continuation-limit and evaluator-`FINISH` paths without allowing unrelated forms to override action-owned confirmation previews
- makes `OWNER_REMINDERS` clarification results explicit through `userFacingText`, `noop`, and `awaitingUserInput` markers instead of relying on success-shaped prose
- adds deterministic regression coverage for safe forms, safe clarification prose, unsafe planning narration, and confirmation precedence, plus a live-model scenario for the real reminder path

## Verification

- `bun test packages/core/src/runtime/__tests__/planner-loop-terminal-continuation-noop-relay.test.ts` — 10 pass
- focused core planner suites — 94 pass
- full `@elizaos/core` suite — 3,945 pass, 1 skip
- `bun test plugins/plugin-personal-assistant/src/actions/life-reminder-datetime.test.ts` — 47 pass
- full `@elizaos/plugin-personal-assistant` suite — 1,436 pass, 8 skip
- full `@elizaos/scenario-runner` suite — 273 pass
- filtered workspace typecheck — 76/76 tasks pass
- `bun run audit:error-policy-ratchet` — pass
- `bun run audit:type-safety-ratchet` — pass
- `bun run audit:test-realness` — 0 diff-scoped regressions
- exact changed-file coverage lane in a clean-checkout state with the relevant plugin `dist` directories absent — pass: `planner-loop.ts` 82.61%, `life.ts` 51.30%, enforced floor 50%
- coverage workflow regressions — 5 pass; changed Vitest files now run through their nearest package config and emit normalized, mergeable LCOV paths
- `bun run verify` — all 570 workspace compiler/lint tasks and subsequent audits pass; final `typecheck:dist --check` reports the pre-existing one-line stale `@elizaos/plugin-elizacloud` alias on `origin/develop`
- live Cerebras-backed scenario `live-missing-input-terminal-relay` — 1/1 pass, 3.7 seconds, `OWNER_REMINDERS` called, explicit `awaitingUserInput`, exact action-owned clarification delivered
- live Cerebras-backed strict `live-chat-widgets-form-roundtrip` scenario — 1/1 pass, 8.1 seconds: exact grammar-valid GUI `[FORM]`, raw `[form:submit]` re-entry, real `OWNER_REMINDERS` write, and persisted reminder plan

## Manual evidence review

I opened and reviewed both live reports, native JSONL exports, privacy manifests, complete model trajectories, action results, evaluator outputs, and final responses. The targeted run contains the real `OWNER_REMINDERS` call, does not create a reminder with missing fields, and returns the action-owned clarification instead of a trajectory-limit apology.

The strict roundtrip run emitted the GUI form, consumed the raw submission, and persisted “Send the Q3 budget report to Dana” for July 14, 2026 at 9:30 AM America/New_York (`2026-07-14T13:30:00.000Z`) with a real reminder plan. I checked both turn trajectories and the six-row native export (`passed=6`, `failed=0`, `redactions=40`, `residuals=0`). This also verifies the evaluator-`FINISH` precedence branch discovered during duplicate-PR consolidation.

## Evidence matrix

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI source changed

<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI source changed

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI source changed

<!-- evidence-row:backend-logs -->
- [x] [live runtime log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15947-console.log)

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend source or browser path changed

<!-- evidence-row:llm-trajectory -->
- [x] [targeted live trajectory](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15947-tj-4b2303dbb7c003.json) · [strict form turn](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15947-tj-823d5dab78598b.json) · [strict submission turn](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15947-tj-8244cced05da57.json)

<!-- evidence-row:domain-artifacts -->
- [x] [targeted report](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15947-report.json) · [strict roundtrip report](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15947-consolidated-live-report.json) · [strict native JSONL](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15947-consolidated-native.jsonl) · [manifest](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15947-consolidated-native.manifest.json) · [privacy attestation](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15947-consolidated-native.privacy-attestation.json)

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered UI source changed
