### PR TITLE
test(voice): benchmark transcript-to-first-phrase latency

### DIFF
--- a/packages/app-core/src/services/phrase-chunked-tts.test.ts
+++ b/packages/app-core/src/services/phrase-chunked-tts.test.ts
@@ -310,6 +310,43 @@ describe("PhraseChunkedTts", () => {
 });
 
 describe("PhraseChunkedTts — latency benchmark assertions", () => {
+  it("deterministically measures transcript commit → first token → first speakable phrase", async () => {
+    let now = 10_000;
+    const transcriptCommittedAt = now;
+    let firstTokenAt: number | null = null;
+    let firstPhraseAt: number | null = null;
+    const phrases: string[] = [];
+    const pipe = new PhraseChunkedTts(
+      async (text: string) => {
+        firstPhraseAt ??= now;
+        phrases.push(text);
+        return text;
+      },
+      { clock: () => now },
+    );
+
+    // Virtual time only: 35 ms chat admission + 45 ms provider TTFT, followed
+    // by three 8 ms token intervals before punctuation makes phrase one
+    // speakable. No live provider or wall-clock scheduler participates in CI.
+    now += 35 + 45;
+    firstTokenAt = now;
+    pipe.push("Hello");
+    now += 8;
+    pipe.push(" there");
+    now += 8;
+    pipe.push("!");
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(firstTokenAt - transcriptCommittedAt).toBe(80);
+    expect(firstPhraseAt).not.toBeNull();
+    expect((firstPhraseAt as number) - transcriptCommittedAt).toBe(96);
+    expect((firstPhraseAt as number) - firstTokenAt).toBe(16);
+    expect(phrases[0]).toBe("Hello there!");
+
+    await pipe.finish();
+  });
+
   it("for a realistic streaming response, first TTS call lands within 50 ms of stream start", async () => {
     const dispatchAt: number[] = [];
     const start = performance.now();


### PR DESCRIPTION
## Summary

- add deterministic benchmark coverage for transcript commit to first model token to first speakable phrase
- use a virtual clock, with no live provider call or wall-clock threshold
- keep the existing phrase chunker and TTS pipeline unchanged

## Context

This is the benchmark-only output of the Gemma 4 / Cerebras voice hot-path audit. No low-risk production route change cleared review. In particular, overlapping JSON body parsing with auth was rejected because it weakens the unauthenticated resource boundary.

The implementation continues to use the existing `/api/v1/chat/completions` Cerebras pass-through stream and cancellation contract. No provider or parallel chat API is introduced.

## Test plan

- `cd packages/app-core && bun run test -- src/services/phrase-chunked-tts.test.ts` (15 passed)
- `bunx prettier --check packages/app-core/src/services/phrase-chunked-tts.test.ts`
- `codex review --uncommitted` (no findings on final diff)

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only change; the diff touches a single .test.ts, no rendered UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only change; no rendered UI surface touched

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only change; nothing user-visible to walk through

<!-- evidence-row:backend-logs -->
- [x] [15948-vitest-coverage-run.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15948-vitest-coverage-run.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface exercised; the change is a server-side vitest unit test

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic virtual-clock benchmark test; no agent/action/prompt/model behavior changed

<!-- evidence-row:domain-artifacts -->
- [x] [15948-coverage-lcov.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15948-coverage-lcov.txt)
