### PR TITLE
feat(cloud): add Deepgram Flux realtime STT adapter

### DIFF
--- a/packages/cloud/api/v1/voice/stt/providers/deepgram-flux.test.ts
+++ b/packages/cloud/api/v1/voice/stt/providers/deepgram-flux.test.ts
@@ -1,0 +1,440 @@
+/**
+ * Unit coverage for the server-side Deepgram Flux realtime adapter. The harness
+ * injects a minimal WebSocket transport so protocol mapping, cancellation,
+ * cleanup, config, and 80ms audio framing are tested without opening a network
+ * connection or importing the STT route's billing graph.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  buildDeepgramFluxListenUrl,
+  createDeepgramFluxRealtimeSession,
+  DEEPGRAM_FLUX_CHUNK_BYTES,
+  DEEPGRAM_FLUX_DEFAULT_MODEL,
+  DEEPGRAM_FLUX_LISTEN_URL,
+  DeepgramFluxAudioChunkError,
+  DeepgramFluxConfigError,
+  DeepgramFluxConnectionError,
+  type DeepgramFluxMetric,
+  type DeepgramFluxRealtimeEvent,
+  type DeepgramFluxTransportRequest,
+  type DeepgramFluxWebSocket,
+  type DeepgramFluxWebSocketEventMap,
+  mapDeepgramFluxMessage,
+  resolveDeepgramFluxConfig,
+  validateDeepgramFluxAudioChunk,
+} from "./deepgram-flux";
+
+class FakeDeepgramFluxWebSocket implements DeepgramFluxWebSocket {
+  readyState = 1;
+  binaryType?: BinaryType;
+  sent: Array<string | ArrayBuffer | ArrayBufferView> = [];
+  closeCalls: Array<{ code?: number; reason?: string }> = [];
+  listeners = {
+    open: new Set<(event: Event) => void>(),
+    message: new Set<(event: MessageEvent) => void>(),
+    error: new Set<(event: Event) => void>(),
+    close: new Set<(event: CloseEvent) => void>(),
+  };
+
+  send(data: string | ArrayBuffer | ArrayBufferView): void {
+    this.sent.push(data);
+  }
+
+  close(code?: number, reason?: string): void {
+    this.closeCalls.push({ code, reason });
+  }
+
+  addEventListener<K extends keyof DeepgramFluxWebSocketEventMap>(
+    type: K,
+    listener: (event: DeepgramFluxWebSocketEventMap[K]) => void,
+  ): void {
+    this.listeners[type].add(listener as never);
+  }
+
+  removeEventListener<K extends keyof DeepgramFluxWebSocketEventMap>(
+    type: K,
+    listener: (event: DeepgramFluxWebSocketEventMap[K]) => void,
+  ): void {
+    this.listeners[type].delete(listener as never);
+  }
+
+  emitOpen(): void {
+    for (const listener of this.listeners.open) {
+      listener(new Event("open"));
+    }
+  }
+
+  emitMessage(data: string): void {
+    for (const listener of this.listeners.message) {
+      listener(new MessageEvent("message", { data }));
+    }
+  }
+
+  emitError(): void {
+    for (const listener of this.listeners.error) {
+      listener(new Event("error"));
+    }
+  }
+
+  emitClose(code: number, reason: string, wasClean: boolean): void {
+    for (const listener of this.listeners.close) {
+      listener(new CloseEvent("close", { code, reason, wasClean }));
+    }
+  }
+}
+
+function createHarness() {
+  const socket = new FakeDeepgramFluxWebSocket();
+  const requests: DeepgramFluxTransportRequest[] = [];
+  const events: DeepgramFluxRealtimeEvent[] = [];
+  const metrics: DeepgramFluxMetric[] = [];
+  const session = createDeepgramFluxRealtimeSession({
+    deepgramApiKey: "dg-secret",
+    webSocketFactory(request) {
+      requests.push(request);
+      return socket;
+    },
+    hooks: {
+      onMetric(metric) {
+        metrics.push(metric);
+      },
+    },
+    onEvent(event) {
+      events.push(event);
+    },
+  });
+
+  return { events, metrics, requests, session, socket };
+}
+
+describe("Deepgram Flux realtime adapter", () => {
+  it("builds the /v2/listen URL with raw linear16 mono 16kHz Flux parameters", () => {
+    const config = resolveDeepgramFluxConfig({
+      deepgramApiKey: " dg-secret ",
+      eagerEotThreshold: "0.4",
+      eotThreshold: 0.9,
+      eotTimeoutMs: "1500",
+    });
+    const url = new URL(buildDeepgramFluxListenUrl(config));
+
+    expect(url.origin + url.pathname).toBe(DEEPGRAM_FLUX_LISTEN_URL);
+    expect(url.searchParams.get("encoding")).toBe("linear16");
+    expect(url.searchParams.get("sample_rate")).toBe("16000");
+    expect(url.searchParams.get("channels")).toBe("1");
+    expect(url.searchParams.get("model")).toBe(DEEPGRAM_FLUX_DEFAULT_MODEL);
+    expect(url.searchParams.get("eager_eot_threshold")).toBe("0.4");
+    expect(url.searchParams.get("eot_threshold")).toBe("0.9");
+    expect(url.searchParams.get("eot_timeout_ms")).toBe("1500");
+  });
+
+  it("passes the server-side API key by Authorization header and never in the query URL", () => {
+    const { requests, socket } = createHarness();
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0].headers.Authorization).toBe("Token dg-secret");
+    expect(requests[0].url).not.toContain("dg-secret");
+    expect(socket.binaryType).toBe("arraybuffer");
+  });
+
+  it("maps Flux turn and transcript events", () => {
+    const { events, socket } = createHarness();
+
+    socket.emitMessage(
+      JSON.stringify({
+        type: "TurnInfo",
+        event: "StartOfTurn",
+        request_id: "request-1",
+        sequence_id: 1,
+        turn_index: 0,
+        words: [],
+      }),
+    );
+    socket.emitMessage(
+      JSON.stringify({
+        type: "TurnInfo",
+        event: "Update",
+        request_id: "request-1",
+        sequence_id: 2,
+        turn_index: 0,
+        transcript: "hello",
+        words: [{ word: "hello" }],
+        end_of_turn_confidence: 0.42,
+      }),
+    );
+    socket.emitMessage(
+      JSON.stringify({
+        type: "TurnInfo",
+        event: "EndOfTurn",
+        request_id: "request-1",
+        sequence_id: 3,
+        turn_index: 0,
+        transcript: "hello",
+        words: [{ word: "hello" }],
+        end_of_turn_confidence: 0.91,
+      }),
+    );
+
+    expect(events).toMatchObject([
+      { type: "start-of-turn", requestId: "request-1", transcript: "" },
+      {
+        type: "transcript-update",
+        transcript: "hello",
+        sequenceId: 2,
+        endOfTurnConfidence: 0.42,
+      },
+      { type: "end-of-turn", transcript: "hello" },
+    ]);
+  });
+
+  it("maps eager end of turn and resumed turn without local VAD state", () => {
+    const { events, socket } = createHarness();
+
+    socket.emitMessage(
+      JSON.stringify({
+        type: "TurnInfo",
+        event: "EagerEndOfTurn",
+        transcript: "hello",
+        words: [],
+      }),
+    );
+    socket.emitMessage(
+      JSON.stringify({
+        type: "TurnInfo",
+        event: "TurnResumed",
+        transcript: "hello again",
+        words: [],
+      }),
+    );
+
+    expect(events).toMatchObject([
+      { type: "eager-end-of-turn" },
+      { type: "turn-resumed" },
+    ]);
+  });
+
+  it("maps Deepgram error frames and malformed frames as explicit error events", () => {
+    expect(
+      mapDeepgramFluxMessage(
+        JSON.stringify({
+          type: "Error",
+          code: "BAD_REQUEST",
+          message: "bad query",
+        }),
+      ),
+    ).toMatchObject({
+      type: "error",
+      code: "BAD_REQUEST",
+      message: "bad query",
+    });
+
+    expect(mapDeepgramFluxMessage("{not json")).toMatchObject({
+      type: "error",
+      code: "malformed_event",
+    });
+    expect(
+      mapDeepgramFluxMessage(
+        JSON.stringify({ type: "TurnInfo", event: "Update", words: [] }),
+      ),
+    ).toMatchObject({
+      type: "error",
+      code: "malformed_event",
+    });
+    expect(
+      mapDeepgramFluxMessage(
+        JSON.stringify({ type: "TurnInfo", event: "Mystery", transcript: "" }),
+      ),
+    ).toMatchObject({
+      type: "error",
+      code: "malformed_event",
+    });
+  });
+
+  it("surfaces metrics hook failures without breaking the streaming data path", () => {
+    const socket = new FakeDeepgramFluxWebSocket();
+    const events: DeepgramFluxRealtimeEvent[] = [];
+    const session = createDeepgramFluxRealtimeSession({
+      deepgramApiKey: "dg-secret",
+      webSocketFactory: () => socket,
+      hooks: {
+        onMetric() {
+          throw new Error("metrics unavailable");
+        },
+      },
+      onEvent(event) {
+        events.push(event);
+      },
+    });
+
+    expect(() =>
+      session.sendAudioChunk(new Uint8Array(DEEPGRAM_FLUX_CHUNK_BYTES)),
+    ).not.toThrow();
+    expect(events).toMatchObject([
+      { type: "error", code: "metrics_hook_error" },
+    ]);
+  });
+
+  it("validates 80ms linear16 mono 16kHz chunks before sending", () => {
+    const { metrics, session, socket } = createHarness();
+    const chunk = new Uint8Array(DEEPGRAM_FLUX_CHUNK_BYTES);
+
+    validateDeepgramFluxAudioChunk(chunk);
+    session.sendAudioChunk(chunk);
+
+    expect(socket.sent).toEqual([chunk]);
+    expect(metrics).toContainEqual({
+      name: "deepgram_flux_audio_chunk_sent",
+      value: 1,
+    });
+    expect(() => session.sendAudioChunk(new Uint8Array(2_559))).toThrow(
+      DeepgramFluxAudioChunkError,
+    );
+  });
+
+  it("keeps listening for final Flux events after a graceful close request", () => {
+    const { events, session, socket } = createHarness();
+
+    session.close("finished");
+    session.close("ignored");
+    socket.emitMessage(
+      JSON.stringify({
+        type: "TurnInfo",
+        event: "EndOfTurn",
+        transcript: "final words",
+        words: [],
+      }),
+    );
+
+    expect(socket.sent).toEqual([JSON.stringify({ type: "CloseStream" })]);
+    expect(() =>
+      session.sendAudioChunk(new Uint8Array(DEEPGRAM_FLUX_CHUNK_BYTES)),
+    ).toThrow(DeepgramFluxConnectionError);
+    expect(socket.closeCalls).toEqual([]);
+    expect(events).toMatchObject([
+      { type: "end-of-turn", transcript: "final words" },
+    ]);
+
+    socket.emitClose(1000, "finished", true);
+    expect(events).toMatchObject([
+      { type: "end-of-turn", transcript: "final words" },
+      { type: "close", code: 1000, reason: "finished", wasClean: true },
+    ]);
+    expect(socket.listeners.message.size).toBe(0);
+  });
+
+  it("cancels and cleans up idempotently", () => {
+    const controller = new AbortController();
+    const socket = new FakeDeepgramFluxWebSocket();
+    const events: DeepgramFluxRealtimeEvent[] = [];
+    const session = createDeepgramFluxRealtimeSession({
+      deepgramApiKey: "dg-secret",
+      signal: controller.signal,
+      webSocketFactory: () => socket,
+      onEvent: (event) => events.push(event),
+    });
+
+    controller.abort();
+    session.cancel("second-cancel");
+    socket.emitMessage(
+      JSON.stringify({
+        type: "TurnInfo",
+        event: "StartOfTurn",
+        transcript: "",
+      }),
+    );
+    socket.emitClose(1000, "late-close", true);
+
+    expect(socket.closeCalls).toEqual([{ code: 1000, reason: "cancelled" }]);
+    expect(events).toMatchObject([
+      { type: "close", code: 1000, reason: "cancelled", wasClean: true },
+    ]);
+    expect(() =>
+      session.sendAudioChunk(new Uint8Array(DEEPGRAM_FLUX_CHUNK_BYTES)),
+    ).toThrow(DeepgramFluxConnectionError);
+    expect(socket.listeners.message.size).toBe(0);
+    expect(socket.listeners.close.size).toBe(0);
+  });
+
+  it("maps transport close and error events", () => {
+    const { events, metrics, socket } = createHarness();
+
+    socket.emitError();
+    socket.emitClose(1011, "upstream-failed", false);
+
+    expect(events).toMatchObject([
+      { type: "error", code: "transport_error" },
+      {
+        type: "close",
+        code: 1011,
+        reason: "upstream-failed",
+        wasClean: false,
+      },
+    ]);
+    expect(metrics).toContainEqual({
+      name: "deepgram_flux_closed",
+      value: 1,
+      tags: { code: "1011" },
+    });
+  });
+
+  it("fails fast for missing key, unsupported model, invalid /v2/listen URL, and invalid tunables", () => {
+    expect(() => resolveDeepgramFluxConfig({})).toThrow(
+      DeepgramFluxConfigError,
+    );
+    expect(() =>
+      resolveDeepgramFluxConfig({
+        deepgramApiKey: "dg-secret",
+        model: "nova-3",
+      }),
+    ).toThrow(DeepgramFluxConfigError);
+    expect(() =>
+      resolveDeepgramFluxConfig({
+        deepgramApiKey: "dg-secret",
+        baseUrl: "https://api.deepgram.com/v2/listen",
+      }),
+    ).toThrow(DeepgramFluxConfigError);
+    expect(() =>
+      resolveDeepgramFluxConfig({
+        deepgramApiKey: "dg-secret",
+        baseUrl: "not a url",
+      }),
+    ).toThrow(DeepgramFluxConfigError);
+    expect(() =>
+      resolveDeepgramFluxConfig({
+        deepgramApiKey: "dg-secret",
+        baseUrl: "wss://api.deepgram.com/v1/listen",
+      }),
+    ).toThrow(DeepgramFluxConfigError);
+    expect(
+      resolveDeepgramFluxConfig({
+        deepgramApiKey: "dg-secret",
+        eagerEotThreshold: " ",
+        eotThreshold: "",
+        eotTimeoutMs: "  ",
+      }),
+    ).toMatchObject({
+      eagerEotThreshold: 0.35,
+      eotThreshold: 0.8,
+      eotTimeoutMs: 5_000,
+    });
+    expect(() =>
+      resolveDeepgramFluxConfig({
+        deepgramApiKey: "dg-secret",
+        eotThreshold: 0.49,
+      }),
+    ).toThrow(DeepgramFluxConfigError);
+    expect(() =>
+      resolveDeepgramFluxConfig({
+        deepgramApiKey: "dg-secret",
+        eagerEotThreshold: 0.9,
+        eotThreshold: 0.8,
+      }),
+    ).toThrow(DeepgramFluxConfigError);
+    expect(() =>
+      resolveDeepgramFluxConfig({
+        deepgramApiKey: "dg-secret",
+        eotTimeoutMs: 10_001,
+      }),
+    ).toThrow(DeepgramFluxConfigError);
+  });
+});

--- a/packages/cloud/api/v1/voice/stt/providers/deepgram-flux.ts
+++ b/packages/cloud/api/v1/voice/stt/providers/deepgram-flux.ts
@@ -1,0 +1,626 @@
+/**
+ * Server-side Deepgram Flux realtime STT adapter for the cloud voice surface.
+ * The route layer owns authentication, billing, and response shaping; this
+ * module owns only Flux connection setup, chunk validation, protocol event
+ * mapping, and deterministic cleanup. Deepgram's semantic turn detector is the
+ * only turn boundary source here, so callers must not layer local VAD decisions
+ * onto these events.
+ */
+
+export const DEEPGRAM_FLUX_LISTEN_URL = "wss://api.deepgram.com/v2/listen";
+export const DEEPGRAM_FLUX_DEFAULT_MODEL = "flux-general-en";
+export const DEEPGRAM_FLUX_SAMPLE_RATE = 16_000;
+export const DEEPGRAM_FLUX_CHANNELS = 1;
+export const DEEPGRAM_FLUX_AUDIO_ENCODING = "linear16";
+export const DEEPGRAM_FLUX_CHUNK_MILLISECONDS = 80;
+export const DEEPGRAM_FLUX_CHUNK_BYTES = 2_560;
+
+const DEFAULT_EAGER_EOT_THRESHOLD = 0.35;
+const DEFAULT_EOT_THRESHOLD = 0.8;
+const DEFAULT_EOT_TIMEOUT_MS = 5_000;
+const DEFAULT_CLOSE_CODE = 1000;
+
+export type DeepgramFluxMetricName =
+  | "deepgram_flux_connected"
+  | "deepgram_flux_audio_chunk_sent"
+  | "deepgram_flux_protocol_event"
+  | "deepgram_flux_malformed_event"
+  | "deepgram_flux_closed";
+
+export type DeepgramFluxMetric = {
+  name: DeepgramFluxMetricName;
+  value: number;
+  tags?: Record<string, string>;
+};
+
+export type DeepgramFluxMetricsHooks = {
+  onMetric?: (metric: DeepgramFluxMetric) => void;
+};
+
+export type DeepgramFluxConfigInput = {
+  deepgramApiKey?: string;
+  baseUrl?: string;
+  model?: string;
+  eagerEotThreshold?: number | string;
+  eotThreshold?: number | string;
+  eotTimeoutMs?: number | string;
+};
+
+export type DeepgramFluxConfig = {
+  apiKey: string;
+  baseUrl: string;
+  model: string;
+  eagerEotThreshold: number;
+  eotThreshold: number;
+  eotTimeoutMs: number;
+};
+
+export type DeepgramFluxTransportRequest = {
+  url: string;
+  headers: Record<string, string>;
+};
+
+export type DeepgramFluxWebSocketFactory = (
+  request: DeepgramFluxTransportRequest,
+) => DeepgramFluxWebSocket;
+
+export type DeepgramFluxWebSocketEventMap = {
+  open: Event;
+  message: MessageEvent;
+  error: Event;
+  close: CloseEvent;
+};
+
+export type DeepgramFluxWebSocket = {
+  readyState: number;
+  binaryType?: BinaryType;
+  send(data: string | ArrayBuffer | ArrayBufferView): void;
+  close(code?: number, reason?: string): void;
+  addEventListener<K extends keyof DeepgramFluxWebSocketEventMap>(
+    type: K,
+    listener: (event: DeepgramFluxWebSocketEventMap[K]) => void,
+  ): void;
+  removeEventListener<K extends keyof DeepgramFluxWebSocketEventMap>(
+    type: K,
+    listener: (event: DeepgramFluxWebSocketEventMap[K]) => void,
+  ): void;
+};
+
+export type DeepgramFluxTurnMetadata = {
+  requestId?: string;
+  sequenceId?: number;
+  turnIndex?: number;
+  audioWindowStart?: number;
+  audioWindowEnd?: number;
+  transcript: string;
+  words: readonly unknown[];
+  endOfTurnConfidence?: number;
+  raw: Record<string, unknown>;
+};
+
+export type DeepgramFluxStartOfTurnEvent = DeepgramFluxTurnMetadata & {
+  type: "start-of-turn";
+};
+
+export type DeepgramFluxTranscriptUpdateEvent = DeepgramFluxTurnMetadata & {
+  type: "transcript-update";
+};
+
+export type DeepgramFluxEagerEndOfTurnEvent = DeepgramFluxTurnMetadata & {
+  type: "eager-end-of-turn";
+};
+
+export type DeepgramFluxTurnResumedEvent = DeepgramFluxTurnMetadata & {
+  type: "turn-resumed";
+};
+
+export type DeepgramFluxEndOfTurnEvent = DeepgramFluxTurnMetadata & {
+  type: "end-of-turn";
+};
+
+export type DeepgramFluxErrorEvent = {
+  type: "error";
+  code: string;
+  message: string;
+  cause?: unknown;
+  raw?: Record<string, unknown>;
+};
+
+export type DeepgramFluxCloseEvent = {
+  type: "close";
+  code: number;
+  reason: string;
+  wasClean: boolean;
+};
+
+export type DeepgramFluxRealtimeEvent =
+  | DeepgramFluxStartOfTurnEvent
+  | DeepgramFluxTranscriptUpdateEvent
+  | DeepgramFluxEagerEndOfTurnEvent
+  | DeepgramFluxTurnResumedEvent
+  | DeepgramFluxEndOfTurnEvent
+  | DeepgramFluxErrorEvent
+  | DeepgramFluxCloseEvent;
+
+export type DeepgramFluxRealtimeEventHandler = (
+  event: DeepgramFluxRealtimeEvent,
+) => void;
+
+export type DeepgramFluxSessionOptions = DeepgramFluxConfigInput & {
+  webSocketFactory: DeepgramFluxWebSocketFactory;
+  signal?: AbortSignal;
+  hooks?: DeepgramFluxMetricsHooks;
+  onEvent: DeepgramFluxRealtimeEventHandler;
+};
+
+export type DeepgramFluxRealtimeSession = {
+  socket: DeepgramFluxWebSocket;
+  url: string;
+  sendAudioChunk(chunk: ArrayBuffer | ArrayBufferView): void;
+  close(reason?: string): void;
+  cancel(reason?: string): void;
+};
+
+export class DeepgramFluxConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DeepgramFluxConfigError";
+  }
+}
+
+export class DeepgramFluxAudioChunkError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DeepgramFluxAudioChunkError";
+  }
+}
+
+export class DeepgramFluxConnectionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DeepgramFluxConnectionError";
+  }
+}
+
+export function resolveDeepgramFluxConfig(
+  input: DeepgramFluxConfigInput,
+): DeepgramFluxConfig {
+  const apiKey = input.deepgramApiKey?.trim();
+  if (!apiKey) {
+    throw new DeepgramFluxConfigError("DEEPGRAM_API_KEY is required");
+  }
+
+  const eagerEotThreshold = resolveTunable(
+    "eager_eot_threshold",
+    input.eagerEotThreshold,
+    DEFAULT_EAGER_EOT_THRESHOLD,
+    0.3,
+    0.9,
+  );
+  const eotThreshold = resolveTunable(
+    "eot_threshold",
+    input.eotThreshold,
+    DEFAULT_EOT_THRESHOLD,
+    0.5,
+    0.9,
+  );
+  if (eagerEotThreshold > eotThreshold) {
+    throw new DeepgramFluxConfigError(
+      "eager_eot_threshold must be less than or equal to eot_threshold",
+    );
+  }
+
+  return {
+    apiKey,
+    baseUrl: resolveBaseUrl(input.baseUrl),
+    model: resolveModel(input.model),
+    eagerEotThreshold,
+    eotThreshold,
+    eotTimeoutMs: resolveTunable(
+      "eot_timeout_ms",
+      input.eotTimeoutMs,
+      DEFAULT_EOT_TIMEOUT_MS,
+      500,
+      10_000,
+    ),
+  };
+}
+
+export function buildDeepgramFluxListenUrl(config: DeepgramFluxConfig): string {
+  const url = new URL(config.baseUrl);
+  url.searchParams.set("encoding", DEEPGRAM_FLUX_AUDIO_ENCODING);
+  url.searchParams.set("sample_rate", String(DEEPGRAM_FLUX_SAMPLE_RATE));
+  url.searchParams.set("channels", String(DEEPGRAM_FLUX_CHANNELS));
+  url.searchParams.set("model", config.model);
+  url.searchParams.set("eager_eot_threshold", String(config.eagerEotThreshold));
+  url.searchParams.set("eot_threshold", String(config.eotThreshold));
+  url.searchParams.set("eot_timeout_ms", String(config.eotTimeoutMs));
+  return url.toString();
+}
+
+export function validateDeepgramFluxAudioChunk(
+  chunk: ArrayBuffer | ArrayBufferView,
+): void {
+  if (chunk.byteLength !== DEEPGRAM_FLUX_CHUNK_BYTES) {
+    throw new DeepgramFluxAudioChunkError(
+      `Deepgram Flux expects 80ms linear16 mono 16kHz chunks (${DEEPGRAM_FLUX_CHUNK_BYTES} bytes), received ${chunk.byteLength} bytes`,
+    );
+  }
+}
+
+export function createDeepgramFluxRealtimeSession(
+  options: DeepgramFluxSessionOptions,
+): DeepgramFluxRealtimeSession {
+  const config = resolveDeepgramFluxConfig(options);
+  const url = buildDeepgramFluxListenUrl(config);
+  const socket = options.webSocketFactory({
+    url,
+    headers: {
+      Authorization: `Token ${config.apiKey}`,
+    },
+  });
+  let cleanedUp = false;
+  let gracefulCloseRequested = false;
+
+  socket.binaryType = "arraybuffer";
+
+  const emit = (event: DeepgramFluxRealtimeEvent) => {
+    options.onEvent(event);
+  };
+  const metric = (metric: DeepgramFluxMetric) => {
+    try {
+      options.hooks?.onMetric?.(metric);
+    } catch (error) {
+      // error-policy:J7 metrics are best-effort, but hook failures remain visible
+      // as typed adapter events without interrupting audio or protocol handling.
+      emit({
+        type: "error",
+        code: "metrics_hook_error",
+        message: "Deepgram Flux metrics hook failed",
+        cause: error,
+      });
+    }
+  };
+
+  const onOpen = () => {
+    metric({ name: "deepgram_flux_connected", value: 1 });
+  };
+
+  const onMessage = (event: MessageEvent) => {
+    const mapped = mapDeepgramFluxMessage(event.data);
+    if (mapped.type === "error" && mapped.code === "malformed_event") {
+      metric({
+        name: "deepgram_flux_malformed_event",
+        value: 1,
+      });
+    } else {
+      metric({
+        name: "deepgram_flux_protocol_event",
+        value: 1,
+        tags: { type: mapped.type },
+      });
+    }
+    emit(mapped);
+  };
+
+  const onError = (event: Event) => {
+    emit({
+      type: "error",
+      code: "transport_error",
+      message: "Deepgram Flux WebSocket transport reported an error",
+      cause: event,
+    });
+  };
+
+  const onClose = (event: CloseEvent) => {
+    cleanup();
+    metric({
+      name: "deepgram_flux_closed",
+      value: 1,
+      tags: { code: String(event.code) },
+    });
+    emit({
+      type: "close",
+      code: event.code,
+      reason: event.reason,
+      wasClean: event.wasClean,
+    });
+  };
+
+  const onAbort = () => {
+    cancelSocket("cancelled");
+  };
+
+  const cleanup = () => {
+    if (cleanedUp) {
+      return;
+    }
+    cleanedUp = true;
+    socket.removeEventListener("open", onOpen);
+    socket.removeEventListener("message", onMessage);
+    socket.removeEventListener("error", onError);
+    socket.removeEventListener("close", onClose);
+    options.signal?.removeEventListener("abort", onAbort);
+  };
+
+  const cancelSocket = (reason: string) => {
+    if (cleanedUp) {
+      return;
+    }
+    cleanup();
+    socket.close(DEFAULT_CLOSE_CODE, reason);
+    metric({
+      name: "deepgram_flux_closed",
+      value: 1,
+      tags: { code: String(DEFAULT_CLOSE_CODE) },
+    });
+    emit({
+      type: "close",
+      code: DEFAULT_CLOSE_CODE,
+      reason,
+      wasClean: true,
+    });
+  };
+
+  socket.addEventListener("open", onOpen);
+  socket.addEventListener("message", onMessage);
+  socket.addEventListener("error", onError);
+  socket.addEventListener("close", onClose);
+  options.signal?.addEventListener("abort", onAbort, { once: true });
+
+  if (options.signal?.aborted) {
+    cancelSocket("cancelled");
+  }
+
+  return {
+    socket,
+    url,
+    sendAudioChunk(chunk: ArrayBuffer | ArrayBufferView) {
+      if (cleanedUp || gracefulCloseRequested || socket.readyState !== 1) {
+        throw new DeepgramFluxConnectionError(
+          "Deepgram Flux session is not open",
+        );
+      }
+      validateDeepgramFluxAudioChunk(chunk);
+      socket.send(chunk);
+      metric({ name: "deepgram_flux_audio_chunk_sent", value: 1 });
+    },
+    close(reason = "client-close") {
+      if (cleanedUp || gracefulCloseRequested) {
+        return;
+      }
+      if (socket.readyState !== 1) {
+        cancelSocket(reason);
+        return;
+      }
+      gracefulCloseRequested = true;
+      socket.send(JSON.stringify({ type: "CloseStream" }));
+    },
+    cancel(reason = "cancelled") {
+      cancelSocket(reason);
+    },
+  };
+}
+
+export function mapDeepgramFluxMessage(
+  data: unknown,
+): DeepgramFluxRealtimeEvent {
+  const parsed = parseDeepgramFluxMessage(data);
+  if (!parsed.ok) {
+    return {
+      type: "error",
+      code: "malformed_event",
+      message: parsed.message,
+      cause: parsed.cause,
+    };
+  }
+
+  const messageType = stringField(parsed.value, "type");
+  if (messageType === "Error") {
+    return {
+      type: "error",
+      code: stringField(parsed.value, "code") ?? "deepgram_error",
+      message:
+        stringField(parsed.value, "description") ??
+        stringField(parsed.value, "message") ??
+        "Deepgram Flux returned an error",
+      raw: parsed.value,
+    };
+  }
+  if (messageType !== "TurnInfo") {
+    return malformedProtocolEvent(
+      `Unsupported Deepgram Flux message type: ${messageType ?? "missing"}`,
+      { raw: parsed.value },
+    );
+  }
+
+  const eventName = stringField(parsed.value, "event");
+  if (
+    eventName !== "StartOfTurn" &&
+    isKnownTurnEvent(eventName) &&
+    (stringField(parsed.value, "transcript") === undefined ||
+      !Array.isArray(parsed.value.words))
+  ) {
+    return malformedProtocolEvent(
+      `Deepgram Flux ${eventName} event is missing transcript or words`,
+      { raw: parsed.value },
+    );
+  }
+  const turn = mapTurnMetadata(parsed.value);
+
+  switch (eventName) {
+    case "StartOfTurn":
+      return { type: "start-of-turn", ...turn };
+    case "Update":
+      return { type: "transcript-update", ...turn };
+    case "EagerEndOfTurn":
+      return { type: "eager-end-of-turn", ...turn };
+    case "TurnResumed":
+      return { type: "turn-resumed", ...turn };
+    case "EndOfTurn":
+      return { type: "end-of-turn", ...turn };
+    default:
+      return malformedProtocolEvent(
+        `Unsupported Deepgram Flux TurnInfo event: ${eventName ?? "missing"}`,
+        { raw: parsed.value },
+      );
+  }
+}
+
+function isKnownTurnEvent(
+  event: string | undefined,
+): event is
+  | "StartOfTurn"
+  | "Update"
+  | "EagerEndOfTurn"
+  | "TurnResumed"
+  | "EndOfTurn" {
+  return (
+    event === "StartOfTurn" ||
+    event === "Update" ||
+    event === "EagerEndOfTurn" ||
+    event === "TurnResumed" ||
+    event === "EndOfTurn"
+  );
+}
+
+function resolveBaseUrl(configured: string | undefined): string {
+  const value = configured?.trim() || DEEPGRAM_FLUX_LISTEN_URL;
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    // error-policy:J3 Deployment config is untrusted text; invalid URLs become
+    // an explicit config failure before any network transport is constructed.
+    throw new DeepgramFluxConfigError("Deepgram Flux base URL is invalid");
+  }
+  if (url.protocol !== "wss:" && url.protocol !== "ws:") {
+    throw new DeepgramFluxConfigError(
+      "Deepgram Flux base URL must use ws: or wss:",
+    );
+  }
+  if (url.pathname !== "/v2/listen") {
+    throw new DeepgramFluxConfigError(
+      "Deepgram Flux base URL must target /v2/listen",
+    );
+  }
+  return url.toString();
+}
+
+function resolveModel(configured: string | undefined): string {
+  const model = configured?.trim() || DEEPGRAM_FLUX_DEFAULT_MODEL;
+  if (model !== DEEPGRAM_FLUX_DEFAULT_MODEL) {
+    throw new DeepgramFluxConfigError(
+      `Deepgram Flux initially supports only ${DEEPGRAM_FLUX_DEFAULT_MODEL}`,
+    );
+  }
+  return model;
+}
+
+function resolveTunable(
+  name: string,
+  configured: number | string | undefined,
+  defaultValue: number,
+  minimum: number,
+  maximum: number,
+): number {
+  let value: number | undefined;
+  if (typeof configured === "string") {
+    const trimmed = configured.trim();
+    value = trimmed ? Number(trimmed) : undefined;
+  } else {
+    value = configured;
+  }
+  const resolved = value ?? defaultValue;
+  if (!Number.isFinite(resolved) || resolved < minimum || resolved > maximum) {
+    throw new DeepgramFluxConfigError(
+      `${name} must be between ${minimum} and ${maximum}`,
+    );
+  }
+  return resolved;
+}
+
+type ParsedDeepgramFluxMessage =
+  | { ok: true; value: Record<string, unknown> }
+  | { ok: false; message: string; cause?: unknown };
+
+function parseDeepgramFluxMessage(data: unknown): ParsedDeepgramFluxMessage {
+  if (typeof data !== "string") {
+    return {
+      ok: false,
+      message: "Deepgram Flux message payload must be JSON text",
+    };
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(data);
+    if (!isRecord(parsed)) {
+      return {
+        ok: false,
+        message: "Deepgram Flux message payload must be a JSON object",
+      };
+    }
+    return { ok: true, value: parsed };
+  } catch (error) {
+    // error-policy:J3 Deepgram emits untrusted JSON text; parse failures become
+    // an explicit adapter error event instead of a fake transcript.
+    return {
+      ok: false,
+      message: "Deepgram Flux message payload is not valid JSON",
+      cause: error,
+    };
+  }
+}
+
+function mapTurnMetadata(
+  raw: Record<string, unknown>,
+): DeepgramFluxTurnMetadata {
+  const transcript = stringField(raw, "transcript") ?? "";
+  const words = raw.words;
+  return {
+    requestId: stringField(raw, "request_id"),
+    sequenceId: numberField(raw, "sequence_id"),
+    turnIndex: numberField(raw, "turn_index"),
+    audioWindowStart: numberField(raw, "audio_window_start"),
+    audioWindowEnd: numberField(raw, "audio_window_end"),
+    transcript,
+    words: Array.isArray(words) ? words : [],
+    endOfTurnConfidence: numberField(raw, "end_of_turn_confidence"),
+    raw,
+  };
+}
+
+function malformedProtocolEvent(
+  message: string,
+  options: { raw?: Record<string, unknown>; cause?: unknown },
+): DeepgramFluxErrorEvent {
+  return {
+    type: "error",
+    code: "malformed_event",
+    message,
+    raw: options.raw,
+    cause: options.cause,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringField(
+  value: Record<string, unknown>,
+  field: string,
+): string | undefined {
+  const candidate = value[field];
+  return typeof candidate === "string" ? candidate : undefined;
+}
+
+function numberField(
+  value: Record<string, unknown>,
+  field: string,
+): number | undefined {
+  const candidate = value[field];
+  return typeof candidate === "number" && Number.isFinite(candidate)
+    ? candidate
+    : undefined;
+}


### PR DESCRIPTION
## Summary
- add an isolated server-side Deepgram Flux `/v2/listen` realtime STT adapter
- validate `flux-general-en`, linear16 mono 16 kHz audio, exact 80 ms chunks, API key, and Flux EOT tunables
- expose typed turn, transcript, error, and close events with injected WebSocket transport and structured metric hooks
- implement graceful `CloseStream`, abort/cancel cleanup, malformed-frame handling, and no local VAD or persistence

## Collision scope
Checked #15931, #15840, #15924, #15927, and open voice/Deepgram PRs before implementation. This base PR adds only two new provider files. It does not touch STT/TTS routes, trace helpers, UI, browser capture, transcript stores, or batch media understanding.

## Validation
- `bun test packages/cloud/api/v1/voice/stt/providers/deepgram-flux.test.ts` (11 pass)
- `bunx @biomejs/biome check packages/cloud/api/v1/voice/stt/providers/deepgram-flux.ts packages/cloud/api/v1/voice/stt/providers/deepgram-flux.test.ts`
- standalone strict TypeScript check for the adapter
- error-policy ratchet, no new fallback slop
- Codex review completed; graceful close, protocol validation, metrics failure visibility, and blank tunable handling addressed

## Known repository baseline
Full cloud package typecheck is not clean in this sparse worktree because of pre-existing/missing workspace modules and unrelated baseline errors. The new adapter passes a standalone strict TypeScript check.


## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - server-only adapter files were added; no rendered UI surface changed.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - server-only adapter files were added; no rendered UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - this isolated adapter has no route/runtime consumer or user-facing flow to record.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - the adapter is not wired into a production route/runtime path, so claiming end-to-end backend logs would be inaccurate; transport behavior is covered only by the focused injected-WebSocket tests reported above.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend code or browser request path changed.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - this is an STT WebSocket protocol adapter and does not change an LLM, prompt, agent trajectory, action, or model call.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no live Deepgram audio/transcript artifact was captured, and the isolated adapter has no production consumer; the available evidence is limited to the focused deterministic tests listed in Validation.
