### PR TITLE
feat(corpus): add fail-closed verification gate (#14772)

### DIFF
--- a/packages/corpus-tools/AGENTS.md
+++ b/packages/corpus-tools/AGENTS.md
@@ -16,5 +16,16 @@ work.
   boundary.
 - Validator failures are data errors; return structured diagnostics from the
   library and let only the CLI translate them to stdout/stderr and exit codes.
+- Verification is corpus-wide, non-mutating, and fail-closed. A row-level stage
+  may not assign `scrubState: "verified"`; publication reruns the complete gate
+  against every bound input, and its declared scope must not imply multimodal
+  coverage.
+- Raw gitleaks output, mine candidates, gazetteers, and other cleartext
+  provenance stay local. Persisted verification findings contain hashes and
+  structural locations only.
+- Verification and publisher freshness checks bind the exact manifest, ledger,
+  mine candidates, gazetteer, deletion rules/review/approval chain, placeholder
+  registry, scanner config, and final corpus bytes. Report self-hashes detect
+  corruption but never substitute for a fresh rerun or owner authorization.
 
 Repo-wide rules and evidence standards are in the root `AGENTS.md`.

--- a/packages/corpus-tools/CLAUDE.md
+++ b/packages/corpus-tools/CLAUDE.md
@@ -16,5 +16,16 @@ work.
   boundary.
 - Validator failures are data errors; return structured diagnostics from the
   library and let only the CLI translate them to stdout/stderr and exit codes.
+- Verification is corpus-wide, non-mutating, and fail-closed. A row-level stage
+  may not assign `scrubState: "verified"`; publication reruns the complete gate
+  against every bound input, and its declared scope must not imply multimodal
+  coverage.
+- Raw gitleaks output, mine candidates, gazetteers, and other cleartext
+  provenance stay local. Persisted verification findings contain hashes and
+  structural locations only.
+- Verification and publisher freshness checks bind the exact manifest, ledger,
+  mine candidates, gazetteer, deletion rules/review/approval chain, placeholder
+  registry, scanner config, and final corpus bytes. Report self-hashes detect
+  corruption but never substitute for a fresh rerun or owner authorization.
 
 Repo-wide rules and evidence standards are in the root `AGENTS.md`.

--- a/packages/corpus-tools/README.md
+++ b/packages/corpus-tools/README.md
@@ -15,6 +15,20 @@ which is ignored by the repo-wide `**/data/` rule. Only synthetic fixtures under
 bun run --cwd packages/corpus-tools validate -- fixtures/synthetic
 bun run --cwd packages/corpus-tools corpus:scrub -- --target data --stage all --mode deep --resume
 bun run --cwd packages/corpus-tools corpus:scrub -- --target data --stage llm --mode fast-track --dry-run
+bun run --cwd packages/corpus-tools corpus:verify -- \
+  --target data/final \
+  --manifest data/final/manifest.json \
+  --candidates data/.state/candidates.jsonl \
+  --canaries data/.state/canaries.json \
+  --ledger data/.state/scrub-ledger.jsonl \
+  --gazetteer data/.state/original-gazetteer.json \
+  --deletion-rules data/delete-rules.yaml \
+  --deletion-review-queue data/.state/deletion-review.json \
+  --deletion-review-decision data/.state/deletion-decisions.json \
+  --deletion-approval data/.state/deletion-approval.json \
+  --placeholder-registry data/.state/placeholder-registry.json \
+  --ruleset-version 1 \
+  --report data/.state/verification-report.json
 ```
 
 The validator accepts either a shard file or a directory of `*.jsonl` shards and
@@ -58,6 +72,29 @@ enforces `privacy-filter-f16.gguf`; q8 model paths are rejected because the
 issue research found token-label mismatches. The committed deterministic engine
 is the test/parity harness until the large f16 GGUF and `pf-cli` sidecar are
 installed locally.
+
+`corpus:scrub --stage all` stops at `rewritten`; verification is deliberately a
+separate whole-corpus boundary. The former per-message `verify` stage is
+disabled because it could label raw rows verified without scanning sibling
+shards or local-only provenance artifacts.
+
+`corpus:verify` is fail-closed and currently declares scope `jsonl-text-v1`. It
+requires an exact shard manifest, hash-chained scrub ledger, raw local mine
+candidates, original-value gazetteer, canary attestation, deletion rules plus
+the owner-reviewed queue/decision/approval chain, and placeholder registry from
+the same ruleset. It snapshots shards before scanning, recomputes the mine
+detector floor, checks deletion rules against the exact review queue and
+tombstone set, scans every string field, rejects embedded attachment bytes, and
+invokes gitleaks over the same snapshot. It writes only hashes and locations for
+findings. A missing scanner/report, malformed or incomplete artifact, concurrent
+input change, stale manifest, or ruleset mismatch is an error. Audio and other
+multimodal bytes are not certified by this report.
+
+Publishers consume `assertFreshGreenVerification()`, which reruns the complete
+gate immediately before upload and requires a byte-identical green report. The
+self-hash detects corruption but is not an authorization signature. Owner sample
+review remains a separate authorization bound to that machine report; the
+machine report alone does not satisfy the final human sign-off.
 
 ## X Mapping
 

--- a/packages/corpus-tools/package.json
+++ b/packages/corpus-tools/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "validate": "bun src/cli.ts validate",
     "corpus:scrub": "bun src/cli.ts scrub",
+    "corpus:verify": "bun src/cli.ts verify",
     "test": "node ../scripts/run-vitest.mjs run --config ./vitest.config.ts",
     "typecheck": "tsgo --noEmit -p tsconfig.json",
     "lint": "bunx @biomejs/biome check src fixtures",

--- a/packages/corpus-tools/src/cli.ts
+++ b/packages/corpus-tools/src/cli.ts
@@ -10,6 +10,7 @@ import {
   type ScrubStageSelector,
 } from "./pipeline/driver.ts";
 import { validateCorpusTarget } from "./validator.ts";
+import { type VerifyCorpusOptions, verifyCorpus } from "./verification.ts";
 
 interface ScrubCliOptions {
   targetPath: string;
@@ -32,6 +33,35 @@ function readFlagValue(args: string[], flag: string): string | undefined {
     throw new Error(`missing value for ${flag}`);
   }
   return value;
+}
+
+function requireFlagValue(args: string[], flag: string): string {
+  const value = readFlagValue(args, flag);
+  if (!value) throw new Error(`${flag} is required`);
+  return value;
+}
+
+function parseVerifyCliOptions(args: string[]): VerifyCorpusOptions {
+  return {
+    targetPath: requireFlagValue(args, "--target"),
+    manifestPath: requireFlagValue(args, "--manifest"),
+    candidatesPath: requireFlagValue(args, "--candidates"),
+    canariesPath: requireFlagValue(args, "--canaries"),
+    ledgerPath: requireFlagValue(args, "--ledger"),
+    gazetteerPath: requireFlagValue(args, "--gazetteer"),
+    deletionRulesPath: requireFlagValue(args, "--deletion-rules"),
+    deletionReviewQueuePath: requireFlagValue(args, "--deletion-review-queue"),
+    deletionReviewDecisionPath: requireFlagValue(
+      args,
+      "--deletion-review-decision",
+    ),
+    deletionApprovalPath: requireFlagValue(args, "--deletion-approval"),
+    placeholderRegistryPath: requireFlagValue(args, "--placeholder-registry"),
+    rulesetVersion: requireFlagValue(args, "--ruleset-version"),
+    reportPath: requireFlagValue(args, "--report"),
+    gitleaksBinaryPath: readFlagValue(args, "--gitleaks-binary"),
+    gitleaksConfigPath: readFlagValue(args, "--gitleaks-config"),
+  };
 }
 
 function parseScrubCliOptions(args: string[]): ScrubCliOptions {
@@ -76,8 +106,16 @@ async function main(argv: string[]): Promise<number> {
     return 0;
   }
 
+  if (command === "verify") {
+    const result = await verifyCorpus(
+      parseVerifyCliOptions([maybeTarget, ...rest]),
+    );
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return result.status === "passed" ? 0 : 1;
+  }
+
   process.stderr.write(
-    "usage: corpus validate <file-or-dir>\n       corpus scrub --target <file-or-dir> --stage <stage|all> --mode <deep|fast-track> [--resume] [--dry-run]\n",
+    "usage: corpus validate <file-or-dir>\n       corpus scrub --target <file-or-dir> --stage <stage|all> --mode <deep|fast-track> [--resume] [--dry-run]\n       corpus verify --target <dir> --manifest <file> --candidates <file> --canaries <file> --ledger <file> --gazetteer <file> --deletion-rules <file> --deletion-review-queue <file> --deletion-review-decision <file> --deletion-approval <file> --placeholder-registry <file> --ruleset-version <version> --report <file>\n",
   );
   return 2;
 }

--- a/packages/corpus-tools/src/index.ts
+++ b/packages/corpus-tools/src/index.ts
@@ -9,3 +9,4 @@ export * from "./pipeline/rewrite.ts";
 export * from "./pipeline/secrets.ts";
 export * from "./schema.ts";
 export * from "./validator.ts";
+export * from "./verification.ts";

--- a/packages/corpus-tools/src/pipeline/driver.test.ts
+++ b/packages/corpus-tools/src/pipeline/driver.test.ts
@@ -116,6 +116,24 @@ function deterministicStages(): ScrubStageDefinition[] {
 }
 
 describe("scrub pipeline driver", () => {
+  it("refuses the former no-op verify stage", async () => {
+    const dir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "corpus-verify-refusal-"),
+    );
+    await writeShard(dir, [message("msg-1", "Raw owner data")]);
+
+    await expect(
+      runScrubPipeline({
+        targetPath: dir,
+        stage: "verify",
+        mode: "deep",
+        resume: true,
+        dryRun: false,
+        rulesetVersion: "verify-refusal-v1",
+      }),
+    ).rejects.toThrow("per-message verify is disabled");
+  });
+
   it("resumes after interruption to the same final output hash", async () => {
     const uninterruptedDir = await fs.mkdtemp(
       path.join(os.tmpdir(), "corpus-scrub-uninterrupted-"),

--- a/packages/corpus-tools/src/pipeline/driver.ts
+++ b/packages/corpus-tools/src/pipeline/driver.ts
@@ -391,6 +391,11 @@ function selectedStages(
   if (selector === "all") return [...stages];
   const found = stages.find((stage) => stage.name === selector);
   if (!found) {
+    if (selector === "verify") {
+      throw new Error(
+        "per-message verify is disabled; use `corpus verify` with all corpus-wide artifacts",
+      );
+    }
     throw new Error(`unknown scrub stage ${selector}`);
   }
   return [found];
@@ -403,6 +408,11 @@ function defaultStage(stage: ScrubStageName): ScrubStageDefinition {
     version: "1",
     targetState,
     async run(message, context) {
+      if (stage === "verify") {
+        throw new Error(
+          "per-message verify cannot establish a corpus-wide privacy verdict",
+        );
+      }
       assertScrubStateTransition(message.scrubState, targetState);
       if (stage === "secrets") {
         const swapped = swapPermanentSecrets(message, {
@@ -482,7 +492,9 @@ function defaultStage(stage: ScrubStageName): ScrubStageDefinition {
 }
 
 export function defaultScrubStages(): ScrubStageDefinition[] {
-  return SCRUB_STAGE_NAMES.map(defaultStage);
+  return SCRUB_STAGE_NAMES.filter((stage) => stage !== "verify").map(
+    defaultStage,
+  );
 }
 
 /**

--- a/packages/corpus-tools/src/verification.test.ts
+++ b/packages/corpus-tools/src/verification.test.ts
@@ -1,0 +1,890 @@
+/**
+ * Adversarial coverage for the corpus-wide privacy gate: exact-byte freshness,
+ * detector failures, canary and placeholder provenance, and report sanitizing.
+ */
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { CorpusMessage } from "./schema.ts";
+import { buildCorpusManifest } from "./validator.ts";
+import {
+  assertFreshGreenVerification,
+  scanShardsWithGitleaks,
+  type VerifyCorpusOptions,
+  verifyCorpus,
+} from "./verification.ts";
+
+const RULESET = "verification-test-v1";
+const GENERATED_AT = "2026-07-09T00:00:00.000Z";
+const temporaryDirectories: string[] = [];
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (typeof value === "object" && value !== null) {
+    return `{${Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, child]) => `${JSON.stringify(key)}:${canonicalJson(child)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function ledgerRecord(
+  input: CorpusMessage,
+  output: CorpusMessage,
+  stage: string,
+  stageVersion = "test-v1",
+): Record<string, unknown> {
+  const inputHash = sha256(JSON.stringify(input));
+  return {
+    markerKey: [`pii:${inputHash}:v${RULESET}`, stage, stageVersion].join(":"),
+    messageId: input.id,
+    stage,
+    stageVersion,
+    rulesetVersion: RULESET,
+    inputHash,
+    outputHash: sha256(JSON.stringify(output)),
+    tombstone: false,
+    output,
+  };
+}
+
+function baseMessage(overrides: Partial<CorpusMessage> = {}): CorpusMessage {
+  return {
+    id: "message-1",
+    platform: "gmail",
+    accountId: "work",
+    threadId: "thread-1",
+    ts: Date.parse("2026-06-01T12:00:00.000Z"),
+    direction: "in",
+    senderId: "sender-1",
+    senderDisplay: "Sender One",
+    recipients: [{ id: "recipient-1", display: "Recipient One" }],
+    text: "Scrubbed body.",
+    labels: [],
+    attachments: [],
+    scrubState: "rewritten",
+    ...overrides,
+  };
+}
+
+async function writeJson(filePath: string, value: unknown): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function fakeGitleaks(
+  root: string,
+  reportMode: "missing" | "empty",
+): Promise<string> {
+  const binaryPath = path.join(root, `gitleaks-${reportMode}`);
+  const reportWrite =
+    reportMode === "empty"
+      ? 'while [ "$#" -gt 0 ]; do if [ "$1" = "--report-path" ]; then shift; printf "[]" > "$1"; fi; shift; done\n'
+      : "";
+  await fs.writeFile(
+    binaryPath,
+    `#!/bin/sh\nif [ "$1" = "version" ]; then echo 8.30.1; exit 0; fi\n${reportWrite}exit 1\n`,
+    { mode: 0o700 },
+  );
+  return binaryPath;
+}
+
+async function fixture(
+  message: CorpusMessage,
+  options: { candidate?: string; canaryPlaceholder?: string } = {},
+): Promise<VerifyCorpusOptions> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "corpus-verify-test-"));
+  temporaryDirectories.push(root);
+  const corpusDir = path.join(root, "corpus");
+  const artifactDir = path.join(root, "artifacts");
+  const shardPath = path.join(corpusDir, "gmail", "work", "2026-06.jsonl");
+  await fs.mkdir(path.dirname(shardPath), { recursive: true });
+  await fs.mkdir(artifactDir, { recursive: true });
+  await fs.writeFile(shardPath, `${JSON.stringify(message)}\n`);
+
+  const { manifest, issues } = await buildCorpusManifest(
+    corpusDir,
+    GENERATED_AT,
+  );
+  expect(issues).toEqual([]);
+  const manifestPath = path.join(artifactDir, "manifest.json");
+  await writeJson(manifestPath, manifest);
+
+  const candidate = options.candidate ?? "original-owner-name";
+  const candidateKind = candidate.includes("@") ? "email" : "original";
+  const candidateHash = sha256(`${RULESET}\0${candidate}`);
+  const mineText = `Source ${candidate}`;
+  const candidateStart = mineText.indexOf(candidate);
+  const candidatesPath = path.join(artifactDir, "candidates.jsonl");
+  await fs.writeFile(
+    candidatesPath,
+    `${JSON.stringify({
+      msgId: message.id,
+      kind: candidateKind,
+      sourceRef: {
+        tableName: "corpus_messages",
+        memoryId: message.id,
+        threadId: message.threadId,
+        platform: message.platform,
+        accountId: message.accountId,
+        field: "text",
+        span: { start: candidateStart, end: candidateStart + candidate.length },
+      },
+      surfaceForm: candidate,
+      valueHash: candidateHash,
+    })}\n`,
+  );
+
+  const canaryPlaceholder =
+    options.canaryPlaceholder ??
+    message.text.match(/\[\[SECRET:[^\]]+\]\]/)?.[0] ??
+    "[[SECRET:openai-key:0123456789ab]]";
+  const canariesPath = path.join(artifactDir, "canaries.json");
+  await writeJson(canariesPath, {
+    schemaVersion: 1,
+    rulesetVersion: RULESET,
+    canaries: [
+      {
+        id: "canary-1",
+        messageId: message.id,
+        expected: { outcome: "placeholder", value: canaryPlaceholder },
+      },
+    ],
+  });
+
+  const raw = {
+    ...message,
+    text: mineText,
+    scrubState: "raw",
+  } as CorpusMessage;
+  const mined = {
+    ...message,
+    text: mineText,
+    scrubState: "mined",
+  } as CorpusMessage;
+  const swapped = { ...message, scrubState: "swapped" } as CorpusMessage;
+  const rewritten = { ...message, scrubState: "rewritten" } as CorpusMessage;
+  const ledgerRecords = [
+    ledgerRecord(raw, mined, "mine"),
+    ledgerRecord(mined, swapped, "secrets"),
+    ledgerRecord(swapped, swapped, "delete", "delete-v1"),
+    ledgerRecord(swapped, rewritten, "rewrite"),
+    ledgerRecord(rewritten, rewritten, "llm"),
+  ];
+  const ledgerPath = path.join(artifactDir, "scrub-ledger.jsonl");
+  await fs.writeFile(
+    ledgerPath,
+    `${ledgerRecords.map((record) => JSON.stringify(record)).join("\n")}\n`,
+  );
+  const gazetteerPath = path.join(artifactDir, "gazetteer.json");
+  await writeJson(gazetteerPath, [
+    { kind: "person", value: "original-owner-name" },
+  ]);
+  const deletionRulesPath = path.join(artifactDir, "delete-rules.json");
+  const deletionReviewQueuePath = path.join(
+    artifactDir,
+    "deletion-review-queue.json",
+  );
+  const deletionReviewDecisionPath = path.join(
+    artifactDir,
+    "deletion-review-decision.json",
+  );
+  const deletionRules = {
+    schemaVersion: 1,
+    rulesetVersion: RULESET,
+    attachmentPolicy: {
+      embeddedBytes: "drop",
+      retainMetadata: ["filename", "mimeType", "sha256"],
+    },
+    rules: [],
+  };
+  const rulesSha256 = sha256(canonicalJson(deletionRules));
+  const deletionCandidatesSha256 = sha256(
+    canonicalJson([{ msgId: message.id, kind: candidateKind }]),
+  );
+  const deletionQueue = {
+    schemaVersion: 1,
+    rulesetVersion: RULESET,
+    corpusDigest: "pending",
+    rulesSha256,
+    candidatesSha256: deletionCandidatesSha256,
+    groups: [],
+  };
+  await writeJson(deletionRulesPath, deletionRules);
+  const shardBytes = await fs.readFile(shardPath);
+  const corpusDigest = createHash("sha256")
+    .update("gmail/work/2026-06.jsonl")
+    .update("\0")
+    .update(shardBytes)
+    .update("\0")
+    .digest("hex");
+  deletionQueue.corpusDigest = corpusDigest;
+  await writeJson(deletionReviewQueuePath, deletionQueue);
+  const reviewedQueueSha256 = sha256(canonicalJson(deletionQueue));
+  const deletionDecision = {
+    schemaVersion: 1,
+    rulesetVersion: RULESET,
+    corpusDigest,
+    rulesSha256,
+    reviewedQueueSha256,
+    approved: true,
+    reviewedBy: "test-owner",
+    reviewedAt: GENERATED_AT,
+    decisions: [],
+  };
+  await writeJson(deletionReviewDecisionPath, deletionDecision);
+  const deletionApprovalPath = path.join(artifactDir, "deletion-approval.json");
+  await writeJson(deletionApprovalPath, {
+    schemaVersion: 1,
+    rulesetVersion: RULESET,
+    corpusDigest,
+    candidatesSha256: deletionCandidatesSha256,
+    deleteStageVersion: "delete-v1",
+    approved: true,
+    rulesSha256,
+    reviewedQueueSha256,
+    reviewDecisionSha256: sha256(canonicalJson(deletionDecision)),
+    tombstoneIdsSha256: sha256(canonicalJson([])),
+    tombstoneCount: 0,
+  });
+  const placeholderRegistryPath = path.join(
+    artifactDir,
+    "placeholder-registry.json",
+  );
+  const registryEntries = [
+    ...message.text.matchAll(
+      /\[\[(?:SECRET|PII):([a-z0-9-]+):([a-f0-9]{12})\]\]/g,
+    ),
+  ].map((match) => ({
+    placeholder: match[0],
+    kind: match[1],
+    valueHash: `${match[2]}${"0".repeat(52)}`,
+    stage: "secrets",
+    messageId: message.id,
+  }));
+  await writeJson(placeholderRegistryPath, {
+    schemaVersion: 1,
+    rulesetVersion: RULESET,
+    entries: registryEntries,
+  });
+  const gitleaksConfigPath = path.join(artifactDir, ".gitleaks.toml");
+  await fs.writeFile(gitleaksConfigPath, 'title = "test"\n');
+
+  return {
+    targetPath: corpusDir,
+    manifestPath,
+    candidatesPath,
+    canariesPath,
+    ledgerPath,
+    gazetteerPath,
+    deletionRulesPath,
+    deletionReviewQueuePath,
+    deletionReviewDecisionPath,
+    deletionApprovalPath,
+    placeholderRegistryPath,
+    rulesetVersion: RULESET,
+    reportPath: path.join(artifactDir, "verification-report.json"),
+    gitleaksConfigPath,
+    gitleaksScanner: async () => ({ version: "test-gitleaks", findings: [] }),
+    now: () => new Date(GENERATED_AT),
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => fs.rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe("corpus verification", () => {
+  it("binds a green report to exact corpus bytes and rejects tampering", async () => {
+    const placeholder = "[[SECRET:openai-key:0123456789ab]]";
+    const options = await fixture(
+      baseMessage({ text: `Scrubbed body ${placeholder}` }),
+      { canaryPlaceholder: placeholder },
+    );
+    const report = await verifyCorpus(options);
+
+    expect(report.findings, JSON.stringify(report.findings, null, 2)).toEqual(
+      [],
+    );
+    expect(report.status).toBe("passed");
+    await expect(
+      assertFreshGreenVerification(report, options),
+    ).resolves.toBeUndefined();
+
+    const tampered = { ...report, messageCount: 99 };
+    await expect(
+      assertFreshGreenVerification(tampered, options),
+    ).rejects.toThrow("does not match a fresh verification");
+
+    const shard = path.join(
+      options.targetPath,
+      "gmail",
+      "work",
+      "2026-06.jsonl",
+    );
+    await fs.appendFile(shard, " \n");
+    await expect(
+      assertFreshGreenVerification(report, options),
+    ).rejects.toThrow();
+  });
+
+  it.each([
+    "manifestPath",
+    "ledgerPath",
+    "candidatesPath",
+    "canariesPath",
+    "gazetteerPath",
+    "deletionRulesPath",
+    "deletionReviewQueuePath",
+    "deletionReviewDecisionPath",
+    "deletionApprovalPath",
+    "placeholderRegistryPath",
+    "gitleaksConfigPath",
+  ] as const)("rejects a report after %s changes", async (pathKey) => {
+    const placeholder = "[[SECRET:openai-key:0123456789ab]]";
+    const options = await fixture(
+      baseMessage({ text: `Scrubbed body ${placeholder}` }),
+      { canaryPlaceholder: placeholder },
+    );
+    const report = await verifyCorpus(options);
+    const artifactPath = options[pathKey];
+    expect(artifactPath).toBeTypeOf("string");
+    await fs.appendFile(artifactPath as string, " ");
+
+    await expect(
+      assertFreshGreenVerification(report, options),
+    ).rejects.toThrow();
+  });
+
+  it("cannot turn a failed report green by recomputing its plain digest", async () => {
+    const leaked = "owner-private@example.com";
+    const options = await fixture(baseMessage({ text: leaked }), {
+      candidate: leaked,
+    });
+    const failed = await verifyCorpus(options);
+    const zeroCounts: typeof failed.counts = {
+      "attachment-policy": 0,
+      canary: 0,
+      entity: 0,
+      gitleaks: 0,
+      ledger: 0,
+      "original-value": 0,
+      placeholder: 0,
+      "redact-pattern": 0,
+      "structured-pii": 0,
+    };
+    const forgedUnsigned = {
+      ...failed,
+      status: "passed" as const,
+      findings: [],
+      scanner: { ...failed.scanner, findingCount: 0 },
+      counts: zeroCounts,
+    };
+    const { reportDigest: _oldDigest, ...unsigned } = forgedUnsigned;
+    const forged = {
+      ...unsigned,
+      reportDigest: sha256(canonicalJson(unsigned)),
+    };
+
+    await expect(assertFreshGreenVerification(forged, options)).rejects.toThrow(
+      "fresh verification is not green",
+    );
+  });
+
+  it("rejects a candidate whose claimed value hash is forged", async () => {
+    const options = await fixture(baseMessage());
+    const line = JSON.parse(
+      (await fs.readFile(options.candidatesPath, "utf8")).trim(),
+    ) as Record<string, unknown>;
+    line.valueHash = "0".repeat(64);
+    await fs.writeFile(options.candidatesPath, `${JSON.stringify(line)}\n`);
+
+    await expect(verifyCorpus(options)).rejects.toThrow(
+      "candidate value hash is invalid",
+    );
+  });
+
+  it("rejects an incomplete mine candidate artifact", async () => {
+    const leaked = "owner-private@example.com";
+    const options = await fixture(baseMessage({ text: leaked }), {
+      candidate: leaked,
+    });
+    const line = JSON.parse(
+      (await fs.readFile(options.candidatesPath, "utf8")).trim(),
+    ) as Record<string, unknown>;
+    line.kind = "original";
+    await fs.writeFile(options.candidatesPath, `${JSON.stringify(line)}\n`);
+
+    await expect(verifyCorpus(options)).rejects.toThrow(
+      "mine candidate artifact is incomplete",
+    );
+  });
+
+  it("rejects an ambiguous mine source instead of last-write-wins", async () => {
+    const options = await fixture(baseMessage());
+    const records = (await fs.readFile(options.ledgerPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    const mine = records.find((record) => record.stage === "mine");
+    if (!mine) throw new Error("fixture ledger has no mine record");
+    await fs.appendFile(options.ledgerPath, `${JSON.stringify(mine)}\n`);
+
+    await expect(verifyCorpus(options)).rejects.toThrow(
+      "ambiguous mine ledger history",
+    );
+  });
+
+  it("rejects deletion provenance that is not bound to the supplied bytes", async () => {
+    const options = await fixture(baseMessage());
+    const rules = JSON.parse(
+      await fs.readFile(options.deletionRulesPath, "utf8"),
+    ) as { rules: unknown[] };
+    rules.rules.push({ id: "unreviewed" });
+    await writeJson(options.deletionRulesPath, rules);
+
+    await expect(verifyCorpus(options)).rejects.toThrow();
+  });
+
+  it("rejects a deletion queue that omits a rule match", async () => {
+    const options = await fixture(baseMessage({ labels: ["Delete"] }));
+    const rules = JSON.parse(
+      await fs.readFile(options.deletionRulesPath, "utf8"),
+    ) as Record<string, unknown>;
+    rules.rules = [
+      {
+        id: "delete-label",
+        enabled: true,
+        scope: "message",
+        match: { type: "label", value: "Delete" },
+      },
+    ];
+    await writeJson(options.deletionRulesPath, rules);
+    const rulesSha256 = sha256(canonicalJson(rules));
+    const queue = JSON.parse(
+      await fs.readFile(options.deletionReviewQueuePath, "utf8"),
+    ) as Record<string, unknown>;
+    queue.rulesSha256 = rulesSha256;
+    await writeJson(options.deletionReviewQueuePath, queue);
+    const reviewedQueueSha256 = sha256(canonicalJson(queue));
+    const decision = JSON.parse(
+      await fs.readFile(options.deletionReviewDecisionPath, "utf8"),
+    ) as Record<string, unknown>;
+    decision.rulesSha256 = rulesSha256;
+    decision.reviewedQueueSha256 = reviewedQueueSha256;
+    await writeJson(options.deletionReviewDecisionPath, decision);
+    const approval = JSON.parse(
+      await fs.readFile(options.deletionApprovalPath, "utf8"),
+    ) as Record<string, unknown>;
+    await writeJson(options.deletionApprovalPath, {
+      ...approval,
+      rulesSha256,
+      reviewedQueueSha256,
+      reviewDecisionSha256: sha256(canonicalJson(decision)),
+    });
+
+    await expect(verifyCorpus(options)).rejects.toThrow(
+      "deletion review queue does not match rules and corpus",
+    );
+  });
+
+  it("fails a ledger whose stage chain does not reach the final output", async () => {
+    const options = await fixture(baseMessage());
+    const records = (await fs.readFile(options.ledgerPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    const terminal = records.at(-1);
+    if (!terminal) throw new Error("fixture ledger has no terminal record");
+    terminal.inputHash = "7".repeat(64);
+    terminal.markerKey = [
+      `pii:${terminal.inputHash}:v${RULESET}`,
+      terminal.stage,
+      terminal.stageVersion,
+    ].join(":");
+    await fs.writeFile(
+      options.ledgerPath,
+      `${records.map((record) => JSON.stringify(record)).join("\n")}\n`,
+    );
+
+    const report = await verifyCorpus(options);
+
+    expect(report.status).toBe("failed");
+    expect(report.findings).toContainEqual(
+      expect.objectContaining({
+        kind: "ledger",
+        detector: "broken-stage-chain",
+      }),
+    );
+  });
+
+  it("rejects a message that has both an approved tombstone and a live branch", async () => {
+    const options = await fixture(baseMessage({ labels: ["Delete"] }));
+    const rules = JSON.parse(
+      await fs.readFile(options.deletionRulesPath, "utf8"),
+    ) as Record<string, unknown>;
+    rules.rules = [
+      {
+        id: "delete-label",
+        enabled: true,
+        scope: "message",
+        match: { type: "label", value: "Delete" },
+      },
+    ];
+    await writeJson(options.deletionRulesPath, rules);
+    const rulesSha256 = sha256(canonicalJson(rules));
+    const queue = JSON.parse(
+      await fs.readFile(options.deletionReviewQueuePath, "utf8"),
+    ) as Record<string, unknown>;
+    const ruleIdHashes = [sha256("delete-label")];
+    const groupId = sha256(
+      canonicalJson({
+        scope: "message",
+        platform: "gmail",
+        messageIds: ["message-1"],
+        ruleIdHashes,
+      }),
+    );
+    queue.rulesSha256 = rulesSha256;
+    queue.groups = [
+      {
+        groupId,
+        scope: "message",
+        platform: "gmail",
+        messageIds: ["message-1"],
+        ruleIdHashes,
+        matchClasses: ["label"],
+        redactedContext: "[MATCH]",
+        suggestedDecision: "delete",
+      },
+    ];
+    await writeJson(options.deletionReviewQueuePath, queue);
+    const reviewedQueueSha256 = sha256(canonicalJson(queue));
+    const decision = {
+      schemaVersion: 1,
+      rulesetVersion: RULESET,
+      corpusDigest: queue.corpusDigest,
+      rulesSha256,
+      reviewedQueueSha256,
+      approved: true,
+      reviewedBy: "test-owner",
+      reviewedAt: GENERATED_AT,
+      decisions: [{ groupId, decision: "delete" }],
+    };
+    await writeJson(options.deletionReviewDecisionPath, decision);
+    const approval = JSON.parse(
+      await fs.readFile(options.deletionApprovalPath, "utf8"),
+    ) as Record<string, unknown>;
+    await writeJson(options.deletionApprovalPath, {
+      ...approval,
+      rulesSha256,
+      reviewedQueueSha256,
+      reviewDecisionSha256: sha256(canonicalJson(decision)),
+      tombstoneIdsSha256: sha256(canonicalJson(["message-1"])),
+      tombstoneCount: 1,
+    });
+    const tombstoneInputHash = "9".repeat(64);
+    const tombstoneMetadata = {
+      messageId: "message-1",
+      stage: "delete",
+      stageVersion: "delete-v1",
+      rulesSha256,
+      reviewedQueueSha256,
+      reviewDecisionSha256: sha256(canonicalJson(decision)),
+      ruleIdHashes,
+      scope: "message",
+    };
+    await fs.appendFile(
+      options.ledgerPath,
+      `${JSON.stringify({
+        markerKey: `pii:${tombstoneInputHash}:v${RULESET}:delete:delete-v1`,
+        ...tombstoneMetadata,
+        rulesetVersion: RULESET,
+        inputHash: tombstoneInputHash,
+        outputHash: sha256(
+          canonicalJson({ tombstone: true, ...tombstoneMetadata }),
+        ),
+        tombstone: true,
+      })}\n`,
+    );
+
+    const report = await verifyCorpus(options);
+
+    expect(report.status).toBe("failed");
+    expect(report.findings).toContainEqual(
+      expect.objectContaining({ detector: "tombstone-live-conflict" }),
+    );
+    expect(report.findings).toContainEqual(
+      expect.objectContaining({ detector: "broken-tombstone-chain" }),
+    );
+  });
+
+  it("fails if live shard bytes change while scanners are running", async () => {
+    const options = await fixture(baseMessage());
+    const shardPath = path.join(
+      options.targetPath,
+      "gmail",
+      "work",
+      "2026-06.jsonl",
+    );
+    options.gitleaksScanner = async () => {
+      await fs.appendFile(shardPath, " ");
+      return { version: "test-gitleaks", findings: [] };
+    };
+
+    await expect(verifyCorpus(options)).rejects.toThrow(
+      "corpus shards changed during verification",
+    );
+  });
+
+  it("fails if an auxiliary artifact changes while scanners are running", async () => {
+    const options = await fixture(baseMessage());
+    options.gitleaksScanner = async () => {
+      await fs.appendFile(options.candidatesPath, " ");
+      return { version: "test-gitleaks", findings: [] };
+    };
+
+    await expect(verifyCorpus(options)).rejects.toThrow(
+      "candidatesSha256 changed during verification",
+    );
+  });
+
+  it("fails if a shard is added while scanners are running", async () => {
+    const options = await fixture(baseMessage());
+    options.gitleaksScanner = async () => {
+      const added = path.join(
+        options.targetPath,
+        "gmail",
+        "work",
+        "2026-07.jsonl",
+      );
+      await fs.writeFile(added, "{}\n");
+      return { version: "test-gitleaks", findings: [] };
+    };
+
+    await expect(verifyCorpus(options)).rejects.toThrow(
+      "corpus shard set changed during verification",
+    );
+  });
+
+  it.each([
+    ["text", (leaked: string) => baseMessage({ text: leaked })],
+    [
+      "subject",
+      (leaked: string) => baseMessage({ subject: leaked.toUpperCase() }),
+    ],
+    ["sender id", (leaked: string) => baseMessage({ senderId: leaked })],
+    [
+      "sender display",
+      (leaked: string) => baseMessage({ senderDisplay: leaked }),
+    ],
+    [
+      "recipient address",
+      (leaked: string) =>
+        baseMessage({ recipients: [{ id: "recipient-1", address: leaked }] }),
+    ],
+    [
+      "recipient display",
+      (leaked: string) =>
+        baseMessage({ recipients: [{ id: "recipient-1", display: leaked }] }),
+    ],
+    ["snippet", (leaked: string) => baseMessage({ snippet: leaked })],
+    ["label", (leaked: string) => baseMessage({ labels: [leaked] })],
+    [
+      "attachment filename",
+      (leaked: string) =>
+        baseMessage({
+          attachments: [
+            {
+              filename: leaked,
+              mimeType: "text/plain",
+              sha256: "a".repeat(64),
+            },
+          ],
+        }),
+    ],
+  ])("fails on a planted email in %s without persisting cleartext", async (_field, build) => {
+    const leaked = "owner-private@example.com";
+    const options = await fixture(build(leaked), {
+      candidate: leaked,
+      canaryPlaceholder: "[[SECRET:openai-key:0123456789ab]]",
+    });
+    const report = await verifyCorpus(options);
+    const serialized = JSON.stringify(report);
+
+    expect(report.status).toBe("failed");
+    expect(report.counts["structured-pii"]).toBeGreaterThan(0);
+    expect(report.counts["original-value"]).toBeGreaterThan(0);
+    expect(serialized.toLowerCase()).not.toContain(leaked);
+  });
+
+  it("fails missing canaries, malformed placeholders, and embedded bytes", async () => {
+    const malformed = "[[SECRET:openai-key:ABC]]";
+    const options = await fixture(
+      baseMessage({
+        text: malformed,
+        attachments: [
+          {
+            filename: "safe.bin",
+            mimeType: "application/octet-stream",
+            sha256: "a".repeat(64),
+            dataBase64: "c2VjcmV0",
+          },
+        ],
+      }),
+      { canaryPlaceholder: "[[SECRET:openai-key:0123456789ab]]" },
+    );
+    const report = await verifyCorpus(options);
+
+    expect(report.status).toBe("failed");
+    expect(report.counts.canary).toBe(1);
+    expect(report.counts.placeholder).toBeGreaterThan(0);
+    expect(report.counts["attachment-policy"]).toBe(1);
+  });
+
+  it("rejects PII hidden in an unknown top-level message field", async () => {
+    const options = await fixture(baseMessage());
+    const shardPath = path.join(
+      options.targetPath,
+      "gmail",
+      "work",
+      "2026-06.jsonl",
+    );
+    const row: unknown = JSON.parse(await fs.readFile(shardPath, "utf8"));
+    if (typeof row !== "object" || row === null) {
+      throw new Error("fixture row is not an object");
+    }
+    Object.assign(row, { metadata: { ownerName: "original-owner-name" } });
+    await fs.writeFile(shardPath, `${JSON.stringify(row)}\n`);
+
+    await expect(verifyCorpus(options)).rejects.toThrow("Unrecognized key");
+  });
+
+  it("rejects PII hidden in an unknown nested attachment field", async () => {
+    const options = await fixture(
+      baseMessage({
+        attachments: [
+          {
+            filename: "safe.txt",
+            mimeType: "text/plain",
+            sha256: "a".repeat(64),
+          },
+        ],
+      }),
+    );
+    const shardPath = path.join(
+      options.targetPath,
+      "gmail",
+      "work",
+      "2026-06.jsonl",
+    );
+    const row: unknown = JSON.parse(await fs.readFile(shardPath, "utf8"));
+    if (typeof row !== "object" || row === null) {
+      throw new Error("fixture row is not an object");
+    }
+    const attachments = Reflect.get(row, "attachments");
+    if (!Array.isArray(attachments) || !attachments[0]) {
+      throw new Error("fixture row has no attachment");
+    }
+    Object.assign(attachments[0], { ownerName: "original-owner-name" });
+    await fs.writeFile(shardPath, `${JSON.stringify(row)}\n`);
+
+    await expect(verifyCorpus(options)).rejects.toThrow("Unrecognized key");
+  });
+
+  it("ignores historical tombstones from a stale delete-stage version", async () => {
+    const placeholder = "[[SECRET:openai-key:0123456789ab]]";
+    const options = await fixture(
+      baseMessage({ text: `Scrubbed body ${placeholder}` }),
+      { canaryPlaceholder: placeholder },
+    );
+    const staleInputHash = "5".repeat(64);
+    await fs.appendFile(
+      options.ledgerPath,
+      `${JSON.stringify({
+        markerKey: `pii:${staleInputHash}:v${RULESET}:delete:delete-v0`,
+        messageId: "historical-message",
+        stage: "delete",
+        stageVersion: "delete-v0",
+        rulesetVersion: RULESET,
+        inputHash: staleInputHash,
+        outputHash: sha256(canonicalJson({ tombstone: true })),
+        tombstone: true,
+      })}\n`,
+    );
+
+    const report = await verifyCorpus(options);
+
+    expect(report.status).toBe("passed");
+  });
+
+  it("rejects a live chain that passed through a stale delete stage", async () => {
+    const options = await fixture(baseMessage());
+    const records = (await fs.readFile(options.ledgerPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    const deletion = records.find((record) => record.stage === "delete");
+    if (!deletion) throw new Error("fixture ledger has no delete record");
+    deletion.stageVersion = "delete-v0";
+    deletion.markerKey = [
+      `pii:${deletion.inputHash}:v${RULESET}`,
+      "delete",
+      deletion.stageVersion,
+    ].join(":");
+    await fs.writeFile(
+      options.ledgerPath,
+      `${records.map((record) => JSON.stringify(record)).join("\n")}\n`,
+    );
+
+    const report = await verifyCorpus(options);
+
+    expect(report.status).toBe("failed");
+    expect(report.findings).toContainEqual(
+      expect.objectContaining({ detector: "broken-stage-chain" }),
+    );
+  });
+
+  it("fails closed when the gitleaks executable is unavailable", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "gitleaks-missing-"));
+    temporaryDirectories.push(root);
+    await expect(
+      scanShardsWithGitleaks([], {
+        binaryPath: path.join(root, "missing-gitleaks"),
+        configPath: path.join(root, "config.toml"),
+        workDir: root,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it.each([
+    "missing",
+    "empty",
+  ] as const)("fails closed when gitleaks exits one with a %s report", async (reportMode) => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "gitleaks-report-"));
+    temporaryDirectories.push(root);
+    const shardPath = path.join(root, "shard.jsonl");
+    const configPath = path.join(root, "config.toml");
+    await fs.writeFile(shardPath, '{"secret":"planted"}\n');
+    await fs.writeFile(configPath, 'title = "test"\n');
+
+    await expect(
+      scanShardsWithGitleaks([shardPath], {
+        binaryPath: await fakeGitleaks(root, reportMode),
+        configPath,
+        workDir: root,
+      }),
+    ).rejects.toThrow(/produced no report|report was empty/);
+  });
+});

--- a/packages/corpus-tools/src/verification.ts
+++ b/packages/corpus-tools/src/verification.ts
@@ -1,0 +1,1904 @@
+/**
+ * Fail-closed verification for a scrubbed personal corpus. The verifier scans
+ * the exact shard bytes with gitleaks and the runtime detector floor, checks
+ * original-value and canary invariants, and emits a sanitized report. Publisher
+ * authorization reruns the full gate; the report's digest detects corruption
+ * but is never treated as an authentication signature.
+ */
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import {
+  detectPii,
+  GazetteerEntityRecognizer,
+  getDefaultRedactPatterns,
+  RegexEntityRecognizer,
+} from "@elizaos/core";
+import { z } from "zod";
+import { minePiiCandidates } from "./pipeline/mine.ts";
+import {
+  type CorpusMessage,
+  corpusAttachmentSchema,
+  corpusManifestSchema,
+  corpusMessageSchema,
+  corpusPlatforms,
+  corpusRecipientSchema,
+} from "./schema.ts";
+import { findCorpusShardFiles } from "./validator.ts";
+
+const verificationMessageSchema = corpusMessageSchema
+  .extend({
+    recipients: z.array(corpusRecipientSchema.strict()),
+    attachments: z.array(corpusAttachmentSchema.strict()),
+  })
+  .strict();
+
+const candidateSchema = z.object({
+  msgId: z.string().min(1),
+  sourceRef: z.object({
+    tableName: z.literal("corpus_messages"),
+    memoryId: z.string().min(1),
+    threadId: z.string().min(1),
+    platform: z.enum(corpusPlatforms),
+    accountId: z.string().min(1),
+    field: z.literal("text"),
+    span: z.object({
+      start: z.number().int().nonnegative(),
+      end: z.number().int().positive(),
+    }),
+  }),
+  kind: z.string().min(1),
+  surfaceForm: z.string().min(1),
+  valueHash: z.string().regex(/^[a-f0-9]{64}$/),
+});
+
+const canaryManifestSchema = z.object({
+  schemaVersion: z.literal(1),
+  rulesetVersion: z.string().min(1),
+  canaries: z
+    .array(
+      z.object({
+        id: z.string().min(1),
+        messageId: z.string().min(1),
+        expected: z.discriminatedUnion("outcome", [
+          z.object({
+            outcome: z.literal("placeholder"),
+            value: z
+              .string()
+              .regex(/^\[\[(?:SECRET|PII):[a-z0-9-]+:[a-f0-9]{12}\]\]$/),
+          }),
+          z.object({
+            outcome: z.literal("tombstone"),
+            stage: z.string().min(1),
+          }),
+        ]),
+      }),
+    )
+    .min(1),
+});
+
+const deletionApprovalSchema = z.object({
+  schemaVersion: z.literal(1),
+  rulesetVersion: z.string().min(1),
+  corpusDigest: z.string().regex(/^[a-f0-9]{64}$/),
+  candidatesSha256: z.string().regex(/^[a-f0-9]{64}$/),
+  deleteStageVersion: z.string().min(1),
+  approved: z.literal(true),
+  rulesSha256: z.string().regex(/^[a-f0-9]{64}$/),
+  reviewedQueueSha256: z.string().regex(/^[a-f0-9]{64}$/),
+  reviewDecisionSha256: z.string().regex(/^[a-f0-9]{64}$/),
+  tombstoneIdsSha256: z.string().regex(/^[a-f0-9]{64}$/),
+  tombstoneCount: z.number().int().nonnegative(),
+});
+
+const deletionRuleBaseSchema = z
+  .object({
+    id: z.string().regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/),
+    enabled: z.boolean(),
+  })
+  .strict();
+
+const deletionRuleSchema = z.union([
+  deletionRuleBaseSchema
+    .extend({
+      scope: z.literal("thread"),
+      match: z
+        .object({
+          type: z.literal("thread"),
+          platform: z.enum(corpusPlatforms),
+          accountId: z.string().min(1),
+          threadId: z.string().min(1),
+        })
+        .strict(),
+    })
+    .strict(),
+  deletionRuleBaseSchema
+    .extend({
+      scope: z.literal("thread"),
+      match: z
+        .object({
+          type: z.literal("contact"),
+          platform: z.enum(corpusPlatforms),
+          accountId: z.string().min(1),
+          contactId: z.string().min(1),
+        })
+        .strict(),
+    })
+    .strict(),
+  deletionRuleBaseSchema
+    .extend({
+      scope: z.enum(["message", "thread"]),
+      match: z
+        .object({
+          type: z.literal("detector"),
+          kind: z.string().regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/),
+        })
+        .strict(),
+    })
+    .strict(),
+  deletionRuleBaseSchema
+    .extend({
+      scope: z.enum(["message", "thread"]),
+      match: z
+        .object({
+          type: z.literal("keyword"),
+          value: z.string().min(2),
+          mode: z.enum(["token", "substring"]),
+          fields: z
+            .array(
+              z.enum([
+                "subject",
+                "text",
+                "snippet",
+                "labels",
+                "attachment-filename",
+              ]),
+            )
+            .min(1),
+        })
+        .strict(),
+    })
+    .strict(),
+  deletionRuleBaseSchema
+    .extend({
+      scope: z.enum(["message", "thread"]),
+      match: z
+        .object({
+          type: z.literal("label"),
+          value: z.string().min(1),
+        })
+        .strict(),
+    })
+    .strict(),
+]);
+
+const deletionRulesArtifactSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    rulesetVersion: z.string().min(1),
+    attachmentPolicy: z
+      .object({
+        embeddedBytes: z.literal("drop"),
+        retainMetadata: z.tuple([
+          z.literal("filename"),
+          z.literal("mimeType"),
+          z.literal("sha256"),
+        ]),
+      })
+      .strict(),
+    rules: z.array(deletionRuleSchema),
+  })
+  .strict();
+
+const deletionReviewQueueSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    rulesetVersion: z.string().min(1),
+    corpusDigest: z.string().regex(/^[a-f0-9]{64}$/),
+    rulesSha256: z.string().regex(/^[a-f0-9]{64}$/),
+    candidatesSha256: z.string().regex(/^[a-f0-9]{64}$/),
+    groups: z.array(
+      z
+        .object({
+          groupId: z.string().regex(/^[a-f0-9]{64}$/),
+          scope: z.enum(["message", "thread"]),
+          platform: z.enum(corpusPlatforms),
+          messageIds: z.array(z.string().min(1)).min(1),
+          ruleIdHashes: z.array(z.string().regex(/^[a-f0-9]{64}$/)).min(1),
+          matchClasses: z
+            .array(
+              z.enum(["contact", "detector", "keyword", "label", "thread"]),
+            )
+            .min(1),
+          redactedContext: z.string().min(1),
+          suggestedDecision: z.literal("delete"),
+        })
+        .strict(),
+    ),
+  })
+  .strict();
+
+const deletionReviewDecisionSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    rulesetVersion: z.string().min(1),
+    corpusDigest: z.string().regex(/^[a-f0-9]{64}$/),
+    rulesSha256: z.string().regex(/^[a-f0-9]{64}$/),
+    reviewedQueueSha256: z.string().regex(/^[a-f0-9]{64}$/),
+    approved: z.literal(true),
+    reviewedBy: z.string().min(1),
+    reviewedAt: z.string().datetime({ offset: true }),
+    decisions: z.array(
+      z
+        .object({
+          groupId: z.string().regex(/^[a-f0-9]{64}$/),
+          decision: z.enum(["delete", "keep"]),
+        })
+        .strict(),
+    ),
+  })
+  .strict();
+
+const placeholderRegistrySchema = z.object({
+  schemaVersion: z.literal(1),
+  rulesetVersion: z.string().min(1),
+  entries: z.array(
+    z.object({
+      placeholder: z
+        .string()
+        .regex(/^\[\[(?:SECRET|PII):[a-z0-9-]+:[a-f0-9]{12}\]\]$/),
+      kind: z.string().regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/),
+      valueHash: z.string().regex(/^[a-f0-9]{64}$/),
+      stage: z.string().min(1),
+      messageId: z.string().min(1),
+    }),
+  ),
+});
+
+const gazetteerSchema = z
+  .array(
+    z.object({
+      kind: z.string().min(1),
+      value: z.string().trim().min(2),
+    }),
+  )
+  .min(1);
+
+const ledgerRecordSchema = z.object({
+  markerKey: z.string().min(1),
+  messageId: z.string().min(1),
+  stage: z.string().min(1),
+  stageVersion: z.string().min(1),
+  rulesetVersion: z.string().min(1),
+  inputHash: z.string().regex(/^[a-f0-9]{64}$/),
+  outputHash: z.string().regex(/^[a-f0-9]{64}$/),
+  tombstone: z.boolean(),
+  output: verificationMessageSchema.optional(),
+  rulesSha256: z
+    .string()
+    .regex(/^[a-f0-9]{64}$/)
+    .optional(),
+  reviewedQueueSha256: z
+    .string()
+    .regex(/^[a-f0-9]{64}$/)
+    .optional(),
+  reviewDecisionSha256: z
+    .string()
+    .regex(/^[a-f0-9]{64}$/)
+    .optional(),
+  ruleIdHashes: z.array(z.string().regex(/^[a-f0-9]{64}$/)).optional(),
+  scope: z.enum(["message", "thread"]).optional(),
+});
+
+const gitleaksFindingSchema = z.object({
+  RuleID: z.string().optional(),
+  File: z.string().optional(),
+  StartLine: z.number().int().nonnegative().optional(),
+  Fingerprint: z.string().optional(),
+});
+
+export type VerificationFindingKind =
+  | "attachment-policy"
+  | "canary"
+  | "entity"
+  | "gitleaks"
+  | "ledger"
+  | "original-value"
+  | "placeholder"
+  | "redact-pattern"
+  | "structured-pii";
+
+export interface VerificationFinding {
+  kind: VerificationFindingKind;
+  detector: string;
+  messageId?: string;
+  field?: string;
+  valueHash: string;
+}
+
+export interface CorpusVerificationReport {
+  schemaVersion: 1;
+  scope: "jsonl-text-v1";
+  generatedAt: string;
+  rulesetVersion: string;
+  status: "passed" | "failed";
+  corpusDigest: string;
+  shardCount: number;
+  messageCount: number;
+  candidateCount: number;
+  canaryCount: number;
+  inputs: {
+    manifestSha256: string;
+    ledgerSha256: string;
+    candidatesSha256: string;
+    canariesSha256: string;
+    gazetteerSha256: string;
+    deletionRulesSha256: string;
+    deletionReviewQueueSha256: string;
+    deletionReviewDecisionSha256: string;
+    deletionApprovalSha256: string;
+    placeholderRegistrySha256: string;
+    gitleaksConfigSha256: string;
+  };
+  scanner: { name: "gitleaks"; version: string; findingCount: number };
+  counts: Record<VerificationFindingKind, number>;
+  findings: VerificationFinding[];
+  reportDigest: string;
+}
+
+export interface GitleaksResult {
+  version: string;
+  findings: VerificationFinding[];
+}
+
+export type GitleaksScanner = (
+  shardPaths: readonly string[],
+  options: { binaryPath: string; configPath: string; workDir: string },
+) => Promise<GitleaksResult>;
+
+export interface VerifyCorpusOptions {
+  targetPath: string;
+  candidatesPath: string;
+  canariesPath: string;
+  manifestPath: string;
+  ledgerPath: string;
+  gazetteerPath: string;
+  deletionRulesPath: string;
+  deletionReviewQueuePath: string;
+  deletionReviewDecisionPath: string;
+  deletionApprovalPath: string;
+  placeholderRegistryPath: string;
+  rulesetVersion: string;
+  reportPath?: string;
+  gitleaksBinaryPath?: string;
+  gitleaksConfigPath?: string;
+  gitleaksScanner?: GitleaksScanner;
+  now?: () => Date;
+}
+
+const verificationInputKeys = [
+  "manifestSha256",
+  "ledgerSha256",
+  "candidatesSha256",
+  "canariesSha256",
+  "gazetteerSha256",
+  "deletionRulesSha256",
+  "deletionReviewQueueSha256",
+  "deletionReviewDecisionSha256",
+  "deletionApprovalSha256",
+  "placeholderRegistrySha256",
+  "gitleaksConfigSha256",
+] as const;
+
+interface StringField {
+  field: string;
+  value: string;
+}
+
+interface ShardSnapshot {
+  path: string;
+  bytes: Buffer;
+}
+
+const VALID_PLACEHOLDER_GLOBAL =
+  /\[\[(?:SECRET|PII):[a-z0-9-]+:[a-f0-9]{12}\]\]/g;
+
+function sha256(value: string | Uint8Array): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+async function verificationInputHashes(
+  options: VerifyCorpusOptions,
+  gitleaksConfigPath: string,
+): Promise<CorpusVerificationReport["inputs"]> {
+  return {
+    manifestSha256: sha256(await fs.readFile(options.manifestPath)),
+    ledgerSha256: sha256(await fs.readFile(options.ledgerPath)),
+    candidatesSha256: sha256(await fs.readFile(options.candidatesPath)),
+    canariesSha256: sha256(await fs.readFile(options.canariesPath)),
+    gazetteerSha256: sha256(await fs.readFile(options.gazetteerPath)),
+    deletionRulesSha256: sha256(await fs.readFile(options.deletionRulesPath)),
+    deletionReviewQueueSha256: sha256(
+      await fs.readFile(options.deletionReviewQueuePath),
+    ),
+    deletionReviewDecisionSha256: sha256(
+      await fs.readFile(options.deletionReviewDecisionPath),
+    ),
+    deletionApprovalSha256: sha256(
+      await fs.readFile(options.deletionApprovalPath),
+    ),
+    placeholderRegistrySha256: sha256(
+      await fs.readFile(options.placeholderRegistryPath),
+    ),
+    gitleaksConfigSha256: sha256(await fs.readFile(gitleaksConfigPath)),
+  };
+}
+
+function findingHash(detector: string, value: string): string {
+  return sha256(`${detector}\0${value}`);
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (typeof value === "object" && value !== null) {
+    return `{${Object.entries(value)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, child]) => `${JSON.stringify(key)}:${canonicalJson(child)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function reportDigest(
+  report: Omit<CorpusVerificationReport, "reportDigest">,
+): string {
+  return sha256(canonicalJson(report));
+}
+
+async function readJsonLines<T>(
+  filePath: string,
+  schema: z.ZodType<T>,
+): Promise<T[]> {
+  const raw = await fs.readFile(filePath, "utf8");
+  const rows: T[] = [];
+  for (const [index, line] of raw.split(/\r?\n/).entries()) {
+    if (!line.trim()) continue;
+    const parsed = schema.safeParse(JSON.parse(line));
+    if (!parsed.success) {
+      throw new Error(
+        `invalid ${filePath} line ${index + 1}: ${z.prettifyError(parsed.error)}`,
+      );
+    }
+    rows.push(parsed.data);
+  }
+  return rows;
+}
+
+async function readMessages(
+  targetPath: string,
+  snapshots: readonly ShardSnapshot[],
+): Promise<{
+  messages: CorpusMessage[];
+  manifestShards: Array<{
+    path: string;
+    platform: (typeof corpusPlatforms)[number];
+    accountId: string;
+    month: string;
+    count: number;
+    firstTs: number;
+    lastTs: number;
+    sha256: string;
+  }>;
+}> {
+  const rootDir = path.extname(targetPath)
+    ? path.dirname(targetPath)
+    : targetPath;
+  const messages: CorpusMessage[] = [];
+  const manifestShards: Array<{
+    path: string;
+    platform: (typeof corpusPlatforms)[number];
+    accountId: string;
+    month: string;
+    count: number;
+    firstTs: number;
+    lastTs: number;
+    sha256: string;
+  }> = [];
+  const messageIds = new Set<string>();
+  for (const snapshot of snapshots) {
+    const relative = path.relative(rootDir, snapshot.path).split(path.sep);
+    const shardMessages: CorpusMessage[] = [];
+    for (const [index, line] of snapshot.bytes
+      .toString("utf8")
+      .split(/\r?\n/)
+      .entries()) {
+      if (!line.trim()) continue;
+      const parsed = verificationMessageSchema.safeParse(JSON.parse(line));
+      if (!parsed.success) {
+        throw new Error(
+          `invalid verification input ${snapshot.path} line ${index + 1}: ${z.prettifyError(parsed.error)}`,
+        );
+      }
+      const message = parsed.data;
+      if (
+        relative.length >= 3 &&
+        (message.platform !== relative[0] || message.accountId !== relative[1])
+      ) {
+        throw new Error(
+          `message ${message.id} does not match its platform/account shard path`,
+        );
+      }
+      if (messageIds.has(message.id)) {
+        throw new Error(`duplicate message id across shards: ${message.id}`);
+      }
+      if (message.scrubState !== "rewritten") {
+        throw new Error(
+          `message ${message.id} must be rewritten before corpus verification`,
+        );
+      }
+      messageIds.add(message.id);
+      messages.push(message);
+      shardMessages.push(message);
+    }
+    const platform = corpusPlatforms.find((value) => value === relative[0]);
+    const accountId = relative[1];
+    const month = relative[2]?.replace(/\.jsonl$/, "");
+    if (!platform || !accountId || !month || shardMessages.length === 0) {
+      throw new Error(
+        `verification shard path must be <platform>/<account>/<yyyy-mm>.jsonl`,
+      );
+    }
+    const timestamps = shardMessages
+      .map((message) => message.ts)
+      .sort((a, b) => a - b);
+    manifestShards.push({
+      path: relative.join("/"),
+      platform,
+      accountId,
+      month,
+      count: shardMessages.length,
+      firstTs: timestamps[0],
+      lastTs: timestamps[timestamps.length - 1],
+      sha256: sha256(snapshot.bytes),
+    });
+  }
+  return { messages, manifestShards };
+}
+
+async function digestShards(
+  targetPath: string,
+  shardPaths: readonly string[],
+): Promise<string> {
+  const rootDir = path.extname(targetPath)
+    ? path.dirname(targetPath)
+    : targetPath;
+  const hash = createHash("sha256");
+  for (const shardPath of [...shardPaths].sort()) {
+    hash.update(path.relative(rootDir, shardPath));
+    hash.update("\0");
+    hash.update(await fs.readFile(shardPath));
+    hash.update("\0");
+  }
+  return hash.digest("hex");
+}
+
+function digestSnapshots(
+  targetPath: string,
+  snapshots: readonly ShardSnapshot[],
+): string {
+  const rootDir = path.extname(targetPath)
+    ? path.dirname(targetPath)
+    : targetPath;
+  const hash = createHash("sha256");
+  for (const snapshot of [...snapshots].sort((left, right) =>
+    left.path.localeCompare(right.path),
+  )) {
+    hash.update(path.relative(rootDir, snapshot.path));
+    hash.update("\0");
+    hash.update(snapshot.bytes);
+    hash.update("\0");
+  }
+  return hash.digest("hex");
+}
+
+function collectStringFields(
+  value: unknown,
+  prefix = "message",
+): StringField[] {
+  if (typeof value === "string") return [{ field: prefix, value }];
+  if (Array.isArray(value)) {
+    return value.flatMap((child, index) =>
+      collectStringFields(child, `${prefix}[${index}]`),
+    );
+  }
+  if (typeof value !== "object" || value === null) return [];
+  return Object.entries(value).flatMap(([key, child]) =>
+    collectStringFields(child, `${prefix}.${key}`),
+  );
+}
+
+function parseRedactPatterns(): RegExp[] {
+  return getDefaultRedactPatterns().map((raw) => {
+    const slash = raw.match(/^\/(.+)\/([gimsuy]*)$/);
+    try {
+      if (slash) {
+        const flags = slash[2].includes("g") ? slash[2] : `${slash[2]}g`;
+        return new RegExp(slash[1], flags);
+      }
+      return new RegExp(raw, "gi");
+    } catch (error) {
+      throw new Error(`invalid core redact pattern ${JSON.stringify(raw)}`, {
+        cause: error,
+      });
+    }
+  });
+}
+
+function patternFindings(
+  messageId: string,
+  field: StringField,
+  patterns: readonly RegExp[],
+): VerificationFinding[] {
+  const findings: VerificationFinding[] = [];
+  const placeholderRanges = [
+    ...field.value.matchAll(VALID_PLACEHOLDER_GLOBAL),
+  ].map((match) => ({
+    start: match.index,
+    end: match.index + match[0].length,
+  }));
+  for (const pattern of patterns) {
+    pattern.lastIndex = 0;
+    for (const match of field.value.matchAll(pattern)) {
+      const value = match[match.length - 1] || match[0];
+      if (!value) continue;
+      const start = match.index ?? 0;
+      const end = start + match[0].length;
+      if (
+        placeholderRanges.some(
+          (range) => start >= range.start && end <= range.end,
+        )
+      ) {
+        continue;
+      }
+      findings.push({
+        kind: "redact-pattern",
+        detector: pattern.source,
+        messageId,
+        field: field.field,
+        valueHash: findingHash(pattern.source, value),
+      });
+    }
+  }
+  return findings;
+}
+
+function placeholderFindings(
+  messageId: string,
+  field: StringField,
+): VerificationFinding[] {
+  const withoutValid = field.value.replace(VALID_PLACEHOLDER_GLOBAL, "");
+  const invalidMarkers = [
+    ...withoutValid.matchAll(/\[\[(?:SECRET|PII):[^\r\n]*/g),
+    ...withoutValid.matchAll(/__ELIZA_SECRET_[A-Za-z0-9_]+__/g),
+    ...withoutValid.matchAll(/\[REDACTED:[^\]\r\n]*\]/g),
+  ].map((match) => match[0]);
+  return invalidMarkers.map((value) => ({
+    kind: "placeholder" as const,
+    detector: "placeholder-integrity",
+    messageId,
+    field: field.field,
+    valueHash: findingHash("placeholder-integrity", value),
+  }));
+}
+
+async function detectorFindings(
+  messages: readonly CorpusMessage[],
+  gazetteerValues: readonly string[],
+): Promise<VerificationFinding[]> {
+  const patterns = parseRedactPatterns();
+  const gazetteer = new GazetteerEntityRecognizer(
+    gazetteerValues.map((value) => ({ kind: "original-value", value })),
+    { name: "verification-gazetteer" },
+  );
+  const regexEntities = new RegexEntityRecognizer({
+    address: true,
+    email: true,
+    phone: true,
+  });
+  const findings: VerificationFinding[] = [];
+  for (const message of messages) {
+    for (const field of collectStringFields(message)) {
+      for (const match of detectPii(field.value)) {
+        findings.push({
+          kind: "structured-pii",
+          detector: match.kind,
+          messageId: message.id,
+          field: field.field,
+          valueHash: findingHash(match.kind, match.value),
+        });
+      }
+      findings.push(...patternFindings(message.id, field, patterns));
+      findings.push(...placeholderFindings(message.id, field));
+      for (const recognizer of [gazetteer, regexEntities]) {
+        const spans = await recognizer.recognize(field.value);
+        for (const span of spans) {
+          findings.push({
+            kind: "entity",
+            detector: recognizer.name,
+            messageId: message.id,
+            field: field.field,
+            valueHash: findingHash(recognizer.name, span.value),
+          });
+        }
+      }
+    }
+  }
+  return findings;
+}
+
+function runCommand(
+  binary: string,
+  args: readonly string[],
+  cwd: string,
+  timeoutMs = 310_000,
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(binary, [...args], {
+      cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    const timeout = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`${binary} timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    child.stdout.on("data", (chunk) => stdout.push(Buffer.from(chunk)));
+    child.stderr.on("data", (chunk) => stderr.push(Buffer.from(chunk)));
+    child.on("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.on("close", (code) => {
+      clearTimeout(timeout);
+      resolve({
+        code: code ?? -1,
+        stdout: Buffer.concat(stdout).toString("utf8"),
+        stderr: Buffer.concat(stderr).toString("utf8"),
+      });
+    });
+  });
+}
+
+export async function scanShardsWithGitleaks(
+  shardPaths: readonly string[],
+  options: { binaryPath: string; configPath: string; workDir: string },
+): Promise<GitleaksResult> {
+  const versionResult = await runCommand(
+    options.binaryPath,
+    ["version", "--no-banner"],
+    options.workDir,
+    30_000,
+  );
+  if (versionResult.code !== 0) {
+    throw new Error(
+      `gitleaks version probe failed with exit ${versionResult.code}`,
+    );
+  }
+  const findings: VerificationFinding[] = [];
+  const reportDir = await fs.mkdtemp(path.join(options.workDir, "gitleaks-"));
+  try {
+    for (const [index, shardPath] of shardPaths.entries()) {
+      const rawReportPath = path.join(reportDir, `${index}.json`);
+      const result = await runCommand(
+        options.binaryPath,
+        [
+          "dir",
+          shardPath,
+          "--config",
+          options.configPath,
+          "--report-format",
+          "json",
+          "--report-path",
+          rawReportPath,
+          "--redact",
+          "--no-banner",
+          "--exit-code",
+          "1",
+          "--timeout",
+          "300",
+        ],
+        options.workDir,
+      );
+      if (result.code !== 0 && result.code !== 1) {
+        throw new Error(
+          `gitleaks failed for shard ${index + 1} with exit ${result.code}: ${result.stderr.trim().slice(0, 500)}`,
+        );
+      }
+      let raw: string;
+      try {
+        await fs.chmod(rawReportPath, 0o600);
+        raw = await fs.readFile(rawReportPath, "utf8");
+      } catch (error) {
+        // error-policy:J4 gitleaks omits its report when a shard has zero findings.
+        if (
+          !(
+            error instanceof Error &&
+            "code" in error &&
+            error.code === "ENOENT"
+          )
+        ) {
+          throw error;
+        }
+        if (result.code === 1) {
+          throw new Error(
+            `gitleaks reported findings for shard ${index + 1} but produced no report`,
+            { cause: error },
+          );
+        }
+        raw = "[]";
+      }
+      const parsed = z.array(gitleaksFindingSchema).safeParse(JSON.parse(raw));
+      if (!parsed.success) {
+        throw new Error(
+          `invalid gitleaks JSON report: ${z.prettifyError(parsed.error)}`,
+        );
+      }
+      if (result.code === 1 && parsed.data.length === 0) {
+        throw new Error(
+          `gitleaks reported findings for shard ${index + 1} but its report was empty`,
+        );
+      }
+      for (const finding of parsed.data) {
+        const detector = finding.RuleID ?? "unknown-rule";
+        const fingerprint =
+          finding.Fingerprint ??
+          `${finding.File ?? path.basename(shardPath)}:${finding.StartLine ?? 0}:${detector}`;
+        findings.push({
+          kind: "gitleaks",
+          detector,
+          field: finding.File
+            ? path.basename(finding.File)
+            : path.basename(shardPath),
+          valueHash: findingHash(detector, fingerprint),
+        });
+      }
+    }
+  } finally {
+    // Raw reports can contain secrets, so deletion failure must fail the gate.
+    await fs.rm(reportDir, { recursive: true, force: true });
+  }
+  return {
+    version: versionResult.stdout.trim() || versionResult.stderr.trim(),
+    findings,
+  };
+}
+
+async function readGazetteerValues(filePath: string): Promise<string[]> {
+  const raw = await fs.readFile(filePath, "utf8");
+  const values = gazetteerSchema.safeParse(JSON.parse(raw));
+  if (!values.success) {
+    throw new Error(`invalid gazetteer: ${z.prettifyError(values.error)}`);
+  }
+  return values.data.map((entry) => entry.value);
+}
+
+function registryFindings(
+  messages: readonly CorpusMessage[],
+  registry: z.infer<typeof placeholderRegistrySchema>,
+): VerificationFinding[] {
+  const byMessageAndPlaceholder = new Map(
+    registry.entries.map((entry) => [
+      `${entry.messageId}\0${entry.placeholder}`,
+      entry,
+    ]),
+  );
+  const used = new Set<string>();
+  const findings: VerificationFinding[] = [];
+  for (const message of messages) {
+    for (const field of collectStringFields(message)) {
+      for (const match of field.value.matchAll(VALID_PLACEHOLDER_GLOBAL)) {
+        const placeholder = match[0];
+        const key = `${message.id}\0${placeholder}`;
+        const entry = byMessageAndPlaceholder.get(key);
+        const encoded = placeholder.match(
+          /^\[\[(?:SECRET|PII):([a-z0-9-]+):([a-f0-9]{12})\]\]$/,
+        );
+        if (
+          !entry ||
+          !encoded ||
+          entry.kind !== encoded[1] ||
+          !entry.valueHash.startsWith(encoded[2])
+        ) {
+          findings.push({
+            kind: "placeholder",
+            detector: "placeholder-registry",
+            messageId: message.id,
+            field: field.field,
+            valueHash: findingHash("placeholder-registry", placeholder),
+          });
+        } else {
+          used.add(key);
+        }
+      }
+    }
+  }
+  for (const entry of registry.entries) {
+    const key = `${entry.messageId}\0${entry.placeholder}`;
+    if (used.has(key)) continue;
+    findings.push({
+      kind: "placeholder",
+      detector: "unused-placeholder-registry-entry",
+      messageId: entry.messageId,
+      valueHash: findingHash(
+        "unused-placeholder-registry-entry",
+        entry.placeholder,
+      ),
+    });
+  }
+  return findings;
+}
+
+function attachmentFindings(
+  messages: readonly CorpusMessage[],
+): VerificationFinding[] {
+  return messages.flatMap((message) =>
+    message.attachments
+      .filter((attachment) => attachment.dataBase64 !== undefined)
+      .map((attachment) => ({
+        kind: "attachment-policy" as const,
+        detector: "embedded-attachment-bytes",
+        messageId: message.id,
+        field: "message.attachments.dataBase64",
+        valueHash: findingHash("embedded-attachment-bytes", attachment.sha256),
+      })),
+  );
+}
+
+async function validateManifestSnapshots(
+  manifestPath: string,
+  manifestShards: ReadonlyArray<
+    z.infer<typeof corpusManifestSchema>["shards"][number]
+  >,
+): Promise<void> {
+  const raw = await fs.readFile(manifestPath, "utf8");
+  const expected = corpusManifestSchema.parse(JSON.parse(raw));
+  const actual = corpusManifestSchema.parse({
+    schemaVersion: 1,
+    generatedAt: expected.generatedAt,
+    cutoffIso: expected.cutoffIso,
+    shards: [...manifestShards],
+    totals: {
+      messages: manifestShards.reduce((sum, shard) => sum + shard.count, 0),
+      contacts: 0,
+      threads: 0,
+    },
+  });
+  for (const entry of actual.shards) {
+    if (
+      path.isAbsolute(entry.path) ||
+      entry.path.split("/").some((segment) => segment === "..")
+    ) {
+      throw new Error(`unsafe manifest shard path ${entry.path}`);
+    }
+  }
+  if (canonicalJson(actual) !== canonicalJson(expected)) {
+    throw new Error("manifest does not match the exact verification target");
+  }
+}
+
+function originalValueFindings(
+  messages: readonly CorpusMessage[],
+  candidates: readonly z.infer<typeof candidateSchema>[],
+): VerificationFinding[] {
+  const canonicalize = (value: string): string =>
+    value.normalize("NFKC").toLocaleLowerCase("en-US");
+  const serialized = messages.map((message) =>
+    canonicalize(JSON.stringify(message).replace(VALID_PLACEHOLDER_GLOBAL, "")),
+  );
+  const unique = new Map(
+    candidates.map((candidate) => [candidate.valueHash, candidate]),
+  );
+  const findings: VerificationFinding[] = [];
+  for (const candidate of unique.values()) {
+    for (const [index, messageJson] of serialized.entries()) {
+      if (!messageJson.includes(canonicalize(candidate.surfaceForm))) continue;
+      findings.push({
+        kind: "original-value",
+        detector: candidate.kind,
+        messageId: messages[index].id,
+        valueHash: candidate.valueHash,
+      });
+    }
+  }
+  return findings;
+}
+
+function canaryFindings(
+  messages: readonly CorpusMessage[],
+  manifest: z.infer<typeof canaryManifestSchema>,
+  ledger: readonly z.infer<typeof ledgerRecordSchema>[],
+): VerificationFinding[] {
+  const byId = new Map(messages.map((message) => [message.id, message]));
+  const findings: VerificationFinding[] = [];
+  for (const canary of manifest.canaries) {
+    let satisfied = false;
+    if (canary.expected.outcome === "placeholder") {
+      const message = byId.get(canary.messageId);
+      satisfied = Boolean(
+        message && JSON.stringify(message).includes(canary.expected.value),
+      );
+    } else {
+      const expectedStage = canary.expected.stage;
+      satisfied = ledger.some(
+        (record) =>
+          record.messageId === canary.messageId &&
+          record.stage === expectedStage &&
+          record.rulesetVersion === manifest.rulesetVersion &&
+          record.tombstone,
+      );
+    }
+    if (!satisfied) {
+      findings.push({
+        kind: "canary",
+        detector: `canary-${canary.expected.outcome}`,
+        messageId: canary.messageId,
+        valueHash: findingHash("canary", canary.id),
+      });
+    }
+  }
+  return findings;
+}
+
+function deletionRuleMatches(
+  message: CorpusMessage,
+  rule: z.infer<typeof deletionRuleSchema>,
+  candidateKinds: ReadonlyMap<string, ReadonlySet<string>>,
+): boolean {
+  const match = rule.match;
+  const normalize = (value: string): string =>
+    value.normalize("NFKC").toLocaleLowerCase("en-US");
+  switch (match.type) {
+    case "thread":
+      return (
+        message.platform === match.platform &&
+        message.accountId === match.accountId &&
+        message.threadId === match.threadId
+      );
+    case "contact": {
+      if (
+        message.platform !== match.platform ||
+        message.accountId !== match.accountId
+      ) {
+        return false;
+      }
+      const contactId = normalize(match.contactId);
+      return [
+        message.senderId,
+        ...message.recipients.flatMap((recipient) => [
+          recipient.id,
+          ...(recipient.address ? [recipient.address] : []),
+        ]),
+      ].some((participant) => normalize(participant) === contactId);
+    }
+    case "detector":
+      return candidateKinds.get(message.id)?.has(match.kind) === true;
+    case "label":
+      return message.labels.some(
+        (label) => normalize(label) === normalize(match.value),
+      );
+    case "keyword": {
+      const values = match.fields.flatMap((field): string[] => {
+        if (field === "text") return [message.text];
+        if (field === "subject")
+          return message.subject ? [message.subject] : [];
+        if (field === "snippet")
+          return message.snippet ? [message.snippet] : [];
+        if (field === "labels") return message.labels;
+        return message.attachments.map((attachment) => attachment.filename);
+      });
+      const needle = normalize(match.value);
+      return values.some((value) => {
+        const haystack = normalize(value);
+        if (match.mode === "substring") return haystack.includes(needle);
+        return haystack
+          .split(/[^\p{L}\p{N}_]+/u)
+          .some((token) => token === needle);
+      });
+    }
+  }
+}
+
+function validateDeletionQueueSemantics(
+  messages: readonly CorpusMessage[],
+  candidates: readonly z.infer<typeof candidateSchema>[],
+  rules: z.infer<typeof deletionRulesArtifactSchema>,
+  queue: z.infer<typeof deletionReviewQueueSchema>,
+): void {
+  const candidateKinds = new Map<string, Set<string>>();
+  for (const candidate of candidates) {
+    const kinds = candidateKinds.get(candidate.msgId) ?? new Set<string>();
+    kinds.add(candidate.kind);
+    candidateKinds.set(candidate.msgId, kinds);
+  }
+  const messagesById = new Map(
+    messages.map((message) => [message.id, message]),
+  );
+  const ruleByHash = new Map(
+    rules.rules.map((rule) => [sha256(rule.id), rule]),
+  );
+  const expectedPairs = new Set<string>();
+  for (const rule of rules.rules.filter((candidate) => candidate.enabled)) {
+    const direct = messages.filter((message) =>
+      deletionRuleMatches(message, rule, candidateKinds),
+    );
+    const selected =
+      rule.scope === "thread"
+        ? messages.filter((message) =>
+            direct.some(
+              (match) =>
+                match.platform === message.platform &&
+                match.accountId === message.accountId &&
+                match.threadId === message.threadId,
+            ),
+          )
+        : direct;
+    const ruleHash = sha256(rule.id);
+    for (const message of selected)
+      expectedPairs.add(`${ruleHash}\0${message.id}`);
+  }
+  const coveredPairs = new Set<string>();
+  for (const group of queue.groups) {
+    const sortedMessageIds = [...group.messageIds].sort();
+    const sortedRuleHashes = [...group.ruleIdHashes].sort();
+    const expectedGroupId = sha256(
+      canonicalJson({
+        scope: group.scope,
+        platform: group.platform,
+        messageIds: sortedMessageIds,
+        ruleIdHashes: sortedRuleHashes,
+      }),
+    );
+    if (group.groupId !== expectedGroupId) {
+      throw new Error(
+        `deletion review group ${group.groupId} has an invalid id`,
+      );
+    }
+    if (group.scope === "message" && group.messageIds.length !== 1) {
+      throw new Error("message-scoped deletion review group is not atomic");
+    }
+    const groupRules = group.ruleIdHashes.map((ruleHash) => {
+      const rule = ruleByHash.get(ruleHash);
+      if (!rule) {
+        throw new Error(
+          `deletion review group ${group.groupId} has an unknown rule`,
+        );
+      }
+      return rule;
+    });
+    const expectedMatchClasses = [
+      ...new Set(groupRules.map((rule) => rule.match.type)),
+    ].sort();
+    if (
+      canonicalJson([...group.matchClasses].sort()) !==
+      canonicalJson(expectedMatchClasses)
+    ) {
+      throw new Error(
+        `deletion review group ${group.groupId} has invalid match classes`,
+      );
+    }
+    if (groupRules.some((rule) => rule.scope === "thread")) {
+      if (group.scope !== "thread") {
+        throw new Error("thread deletion rule is not grouped atomically");
+      }
+      const first = messagesById.get(group.messageIds[0]);
+      const completeThread = messages
+        .filter(
+          (message) =>
+            first &&
+            message.platform === first.platform &&
+            message.accountId === first.accountId &&
+            message.threadId === first.threadId,
+        )
+        .map((message) => message.id)
+        .sort();
+      if (canonicalJson(sortedMessageIds) !== canonicalJson(completeThread)) {
+        throw new Error("thread deletion review group is incomplete");
+      }
+    }
+    for (const messageId of group.messageIds) {
+      const message = messagesById.get(messageId);
+      if (!message || message.platform !== group.platform) {
+        throw new Error(
+          `deletion review group ${group.groupId} has invalid membership`,
+        );
+      }
+      let memberMatched = false;
+      for (const ruleHash of group.ruleIdHashes) {
+        const pair = `${ruleHash}\0${messageId}`;
+        if (expectedPairs.has(pair)) {
+          memberMatched = true;
+          coveredPairs.add(pair);
+        }
+      }
+      if (!memberMatched) {
+        throw new Error(
+          `deletion review group ${group.groupId} contains an unmatched message`,
+        );
+      }
+    }
+  }
+  if (
+    expectedPairs.size !== coveredPairs.size ||
+    [...expectedPairs].some((pair) => !coveredPairs.has(pair))
+  ) {
+    throw new Error("deletion review queue does not match rules and corpus");
+  }
+}
+
+function ledgerFindings(
+  messages: readonly CorpusMessage[],
+  ledger: readonly z.infer<typeof ledgerRecordSchema>[],
+  deletionApproval: z.infer<typeof deletionApprovalSchema>,
+  rulesetVersion: string,
+): VerificationFinding[] {
+  const findings: VerificationFinding[] = [];
+  const current = ledger.filter(
+    (record) => record.rulesetVersion === rulesetVersion,
+  );
+  const byMarker = new Map<string, z.infer<typeof ledgerRecordSchema>>();
+  for (const record of current) {
+    const expectedMarker = [
+      `pii:${record.inputHash}:v${record.rulesetVersion}`,
+      record.stage,
+      record.stageVersion,
+    ].join(":");
+    if (record.markerKey !== expectedMarker) {
+      findings.push({
+        kind: "ledger",
+        detector: "invalid-marker-key",
+        messageId: record.messageId,
+        valueHash: findingHash("invalid-marker-key", record.markerKey),
+      });
+    }
+    const approvedDeletionTombstone =
+      record.tombstone &&
+      record.stage === "delete" &&
+      record.stageVersion === deletionApproval.deleteStageVersion;
+    const hasDeletionMetadata =
+      record.rulesSha256 !== undefined &&
+      record.reviewedQueueSha256 !== undefined &&
+      record.reviewDecisionSha256 !== undefined &&
+      record.ruleIdHashes !== undefined &&
+      record.scope !== undefined;
+    if (approvedDeletionTombstone && !hasDeletionMetadata) {
+      findings.push({
+        kind: "ledger",
+        detector: "missing-deletion-metadata",
+        messageId: record.messageId,
+        valueHash: findingHash("missing-deletion-metadata", record.markerKey),
+      });
+    }
+    if (
+      approvedDeletionTombstone &&
+      hasDeletionMetadata &&
+      (record.rulesSha256 !== deletionApproval.rulesSha256 ||
+        record.reviewedQueueSha256 !== deletionApproval.reviewedQueueSha256 ||
+        record.reviewDecisionSha256 !== deletionApproval.reviewDecisionSha256)
+    ) {
+      findings.push({
+        kind: "ledger",
+        detector: "deletion-metadata-binding",
+        messageId: record.messageId,
+        valueHash: findingHash("deletion-metadata-binding", record.markerKey),
+      });
+    }
+    const expectedOutputHash = record.tombstone
+      ? hasDeletionMetadata
+        ? sha256(
+            canonicalJson({
+              tombstone: true,
+              messageId: record.messageId,
+              stage: record.stage,
+              stageVersion: record.stageVersion,
+              rulesSha256: record.rulesSha256,
+              reviewedQueueSha256: record.reviewedQueueSha256,
+              reviewDecisionSha256: record.reviewDecisionSha256,
+              ruleIdHashes: record.ruleIdHashes,
+              scope: record.scope,
+            }),
+          )
+        : sha256(canonicalJson({ tombstone: true }))
+      : record.output
+        ? sha256(JSON.stringify(record.output))
+        : undefined;
+    if (
+      expectedOutputHash === undefined ||
+      expectedOutputHash !== record.outputHash ||
+      (record.tombstone && record.output !== undefined)
+    ) {
+      findings.push({
+        kind: "ledger",
+        detector: "invalid-output-hash",
+        messageId: record.messageId,
+        valueHash: findingHash("invalid-output-hash", record.markerKey),
+      });
+    }
+    const existing = byMarker.get(record.markerKey);
+    if (existing && canonicalJson(existing) !== canonicalJson(record)) {
+      findings.push({
+        kind: "ledger",
+        detector: "conflicting-marker",
+        messageId: record.messageId,
+        valueHash: findingHash("conflicting-marker", record.markerKey),
+      });
+    }
+    byMarker.set(record.markerKey, record);
+  }
+  const approvedTombstones = current.filter(
+    (record) =>
+      record.stage === "delete" &&
+      record.stageVersion === deletionApproval.deleteStageVersion &&
+      record.tombstone,
+  );
+  const tombstoned = new Set(
+    approvedTombstones.map((record) => record.messageId),
+  );
+  if (approvedTombstones.length !== tombstoned.size) {
+    findings.push({
+      kind: "ledger",
+      detector: "ambiguous-deletion-tombstone",
+      valueHash: findingHash(
+        "ambiguous-deletion-tombstone",
+        deletionApproval.deleteStageVersion,
+      ),
+    });
+  }
+  for (const tombstone of approvedTombstones) {
+    const secretsRecords = current.filter(
+      (record) =>
+        record.messageId === tombstone.messageId &&
+        record.stage === "secrets" &&
+        !record.tombstone &&
+        record.outputHash === tombstone.inputHash,
+    );
+    const mineRecords =
+      secretsRecords.length === 1
+        ? current.filter(
+            (record) =>
+              record.messageId === tombstone.messageId &&
+              record.stage === "mine" &&
+              !record.tombstone &&
+              record.outputHash === secretsRecords[0].inputHash,
+          )
+        : [];
+    if (secretsRecords.length !== 1 || mineRecords.length !== 1) {
+      findings.push({
+        kind: "ledger",
+        detector: "broken-tombstone-chain",
+        messageId: tombstone.messageId,
+        valueHash: findingHash("broken-tombstone-chain", tombstone.markerKey),
+      });
+    }
+  }
+  const tombstoneIds = [...tombstoned].sort();
+  if (
+    sha256(canonicalJson(tombstoneIds)) !== deletionApproval.tombstoneIdsSha256
+  ) {
+    findings.push({
+      kind: "ledger",
+      detector: "deletion-tombstone-set",
+      valueHash: findingHash(
+        "deletion-tombstone-set",
+        canonicalJson(tombstoneIds),
+      ),
+    });
+  }
+  for (const message of messages) {
+    if (tombstoned.has(message.id)) {
+      findings.push({
+        kind: "ledger",
+        detector: "tombstone-live-conflict",
+        messageId: message.id,
+        valueHash: findingHash("tombstone-live-conflict", message.id),
+      });
+    }
+    const messageHash = sha256(JSON.stringify(message));
+    const terminals = current.filter(
+      (record) =>
+        record.messageId === message.id &&
+        record.stage === "llm" &&
+        !record.tombstone &&
+        record.outputHash === messageHash &&
+        record.output !== undefined &&
+        canonicalJson(record.output) === canonicalJson(message),
+    );
+    if (terminals.length !== 1) {
+      findings.push({
+        kind: "ledger",
+        detector:
+          terminals.length === 0
+            ? "missing-terminal-coverage"
+            : "ambiguous-terminal-coverage",
+        messageId: message.id,
+        valueHash: findingHash("terminal-coverage", message.id),
+      });
+      continue;
+    }
+    let downstream = terminals[0];
+    for (const expectedStage of [
+      "rewrite",
+      "delete",
+      "secrets",
+      "mine",
+    ] as const) {
+      const predecessors = current.filter(
+        (record) =>
+          record.messageId === message.id &&
+          record.stage === expectedStage &&
+          !record.tombstone &&
+          record.outputHash === downstream.inputHash &&
+          (expectedStage !== "delete" ||
+            record.stageVersion === deletionApproval.deleteStageVersion),
+      );
+      if (predecessors.length !== 1) {
+        findings.push({
+          kind: "ledger",
+          detector:
+            predecessors.length === 0
+              ? "broken-stage-chain"
+              : "ambiguous-stage-chain",
+          messageId: message.id,
+          valueHash: findingHash("stage-chain", downstream.markerKey),
+        });
+        break;
+      }
+      downstream = predecessors[0];
+    }
+  }
+  if (tombstoned.size !== deletionApproval.tombstoneCount) {
+    findings.push({
+      kind: "ledger",
+      detector: "deletion-tombstone-count",
+      valueHash: findingHash(
+        "deletion-tombstone-count",
+        `${tombstoned.size}:${deletionApproval.tombstoneCount}`,
+      ),
+    });
+  }
+  return findings;
+}
+
+function dedupeFindings(
+  findings: readonly VerificationFinding[],
+): VerificationFinding[] {
+  return [
+    ...new Map(
+      findings.map((finding) => [JSON.stringify(finding), finding]),
+    ).values(),
+  ].sort(
+    (a, b) =>
+      a.kind.localeCompare(b.kind) ||
+      (a.messageId ?? "").localeCompare(b.messageId ?? "") ||
+      a.valueHash.localeCompare(b.valueHash),
+  );
+}
+
+export async function verifyCorpus(
+  options: VerifyCorpusOptions,
+): Promise<CorpusVerificationReport> {
+  const gitleaksConfigPath = path.resolve(
+    options.gitleaksConfigPath ??
+      path.resolve(import.meta.dirname, "../../../.gitleaks.toml"),
+  );
+  const initialInputHashes = await verificationInputHashes(
+    options,
+    gitleaksConfigPath,
+  );
+  const shardPaths = (await findCorpusShardFiles(options.targetPath)).filter(
+    (file) => !file.split(path.sep).includes(".state"),
+  );
+  if (shardPaths.length === 0)
+    throw new Error("verification target has no corpus shards");
+  const snapshots = await Promise.all(
+    shardPaths.map(async (shardPath) => ({
+      path: shardPath,
+      bytes: await fs.readFile(shardPath),
+    })),
+  );
+  const { messages, manifestShards } = await readMessages(
+    options.targetPath,
+    snapshots,
+  );
+  await validateManifestSnapshots(options.manifestPath, manifestShards);
+  const corpusDigest = digestSnapshots(options.targetPath, snapshots);
+  const candidates = await readJsonLines(
+    options.candidatesPath,
+    candidateSchema,
+  );
+  if (candidates.length === 0) {
+    throw new Error(
+      "verification requires the complete mine candidate artifact",
+    );
+  }
+  for (const candidate of candidates) {
+    const expected = sha256(
+      `${options.rulesetVersion}\0${candidate.surfaceForm}`,
+    );
+    if (candidate.valueHash !== expected) {
+      throw new Error(
+        `candidate value hash is invalid for message ${candidate.msgId}`,
+      );
+    }
+  }
+  const deletionCandidatesDigest = sha256(
+    canonicalJson(
+      candidates
+        .map((candidate) => ({ msgId: candidate.msgId, kind: candidate.kind }))
+        .sort(
+          (left, right) =>
+            left.msgId.localeCompare(right.msgId) ||
+            left.kind.localeCompare(right.kind),
+        ),
+    ),
+  );
+  const canaryRaw = JSON.parse(await fs.readFile(options.canariesPath, "utf8"));
+  const canaries = canaryManifestSchema.parse(canaryRaw);
+  if (canaries.rulesetVersion !== options.rulesetVersion) {
+    throw new Error(
+      `canary ruleset ${canaries.rulesetVersion} does not match ${options.rulesetVersion}`,
+    );
+  }
+  const ledger = await readJsonLines(options.ledgerPath, ledgerRecordSchema);
+  const uniqueStageRecords = new Set<string>();
+  for (const record of ledger.filter(
+    (candidate) =>
+      candidate.rulesetVersion === options.rulesetVersion &&
+      candidate.stage !== "delete",
+  )) {
+    const key = `${record.messageId}\0${record.stage}`;
+    if (uniqueStageRecords.has(key)) {
+      throw new Error(
+        `ambiguous ${record.stage} ledger history for message ${record.messageId}`,
+      );
+    }
+    uniqueStageRecords.add(key);
+  }
+  const mineOutputs = new Map(
+    ledger
+      .filter(
+        (record) =>
+          record.rulesetVersion === options.rulesetVersion &&
+          record.stage === "mine" &&
+          !record.tombstone &&
+          record.output,
+      )
+      .map((record) => [record.messageId, record.output]),
+  );
+  for (const candidate of candidates) {
+    const source = mineOutputs.get(candidate.msgId);
+    const { start, end } = candidate.sourceRef.span;
+    if (
+      !source ||
+      candidate.sourceRef.memoryId !== candidate.msgId ||
+      candidate.sourceRef.threadId !== source.threadId ||
+      candidate.sourceRef.platform !== source.platform ||
+      candidate.sourceRef.accountId !== source.accountId ||
+      start >= end ||
+      source.text.slice(start, end) !== candidate.surfaceForm
+    ) {
+      throw new Error(
+        `candidate source reference is invalid for message ${candidate.msgId}`,
+      );
+    }
+  }
+  const mineMessages = [...mineOutputs.values()].filter(
+    (message): message is CorpusMessage => message !== undefined,
+  );
+  const rerunMine = await minePiiCandidates(mineMessages, {
+    hashSalt: options.rulesetVersion,
+  });
+  const suppliedCandidateKeys = new Set(
+    candidates.map(
+      (candidate) =>
+        `${candidate.msgId}\0${candidate.kind}\0${candidate.sourceRef.span.start}\0${candidate.sourceRef.span.end}\0${candidate.valueHash}`,
+    ),
+  );
+  for (const expected of rerunMine.candidates) {
+    const key = `${expected.msgId}\0${expected.kind}\0${expected.sourceRef.span.start}\0${expected.sourceRef.span.end}\0${expected.valueHash}`;
+    if (!suppliedCandidateKeys.has(key)) {
+      throw new Error(
+        `mine candidate artifact is incomplete for message ${expected.msgId}`,
+      );
+    }
+  }
+  const deletionApproval = deletionApprovalSchema.parse(
+    JSON.parse(await fs.readFile(options.deletionApprovalPath, "utf8")),
+  );
+  const deletionRules = deletionRulesArtifactSchema.parse(
+    JSON.parse(await fs.readFile(options.deletionRulesPath, "utf8")),
+  );
+  const deletionReviewQueue = deletionReviewQueueSchema.parse(
+    JSON.parse(await fs.readFile(options.deletionReviewQueuePath, "utf8")),
+  );
+  const deletionReviewDecision = deletionReviewDecisionSchema.parse(
+    JSON.parse(await fs.readFile(options.deletionReviewDecisionPath, "utf8")),
+  );
+  if (
+    new Set(deletionRules.rules.map((rule) => rule.id)).size !==
+    deletionRules.rules.length
+  ) {
+    throw new Error("deletion rules contain duplicate ids");
+  }
+  const rulesDigest = sha256(canonicalJson(deletionRules));
+  const queueDigest = sha256(canonicalJson(deletionReviewQueue));
+  const decisionDigest = sha256(canonicalJson(deletionReviewDecision));
+  const deletionBindings = [
+    ["corpus", deletionApproval.corpusDigest, corpusDigest],
+    ["candidates", deletionApproval.candidatesSha256, deletionCandidatesDigest],
+    ["deletion rules", deletionApproval.rulesSha256, rulesDigest],
+    [
+      "deletion review queue",
+      deletionApproval.reviewedQueueSha256,
+      queueDigest,
+    ],
+    [
+      "deletion review decision",
+      deletionApproval.reviewDecisionSha256,
+      decisionDigest,
+    ],
+    ["queue corpus", deletionReviewQueue.corpusDigest, corpusDigest],
+    ["queue rules", deletionReviewQueue.rulesSha256, rulesDigest],
+    [
+      "queue candidates",
+      deletionReviewQueue.candidatesSha256,
+      deletionCandidatesDigest,
+    ],
+    ["decision corpus", deletionReviewDecision.corpusDigest, corpusDigest],
+    ["decision rules", deletionReviewDecision.rulesSha256, rulesDigest],
+    ["decision queue", deletionReviewDecision.reviewedQueueSha256, queueDigest],
+  ] as const;
+  for (const [name, claimed, actual] of deletionBindings) {
+    if (claimed !== actual) {
+      throw new Error(`${name} digest does not match deletion approval`);
+    }
+  }
+  for (const [name, value] of [
+    ["deletion rules", deletionRules.rulesetVersion],
+    ["deletion queue", deletionReviewQueue.rulesetVersion],
+    ["deletion decision", deletionReviewDecision.rulesetVersion],
+  ] as const) {
+    if (value !== options.rulesetVersion) {
+      throw new Error(`${name} ruleset does not match verification ruleset`);
+    }
+  }
+  const groupsById = new Map(
+    deletionReviewQueue.groups.map((group) => [group.groupId, group]),
+  );
+  if (groupsById.size !== deletionReviewQueue.groups.length) {
+    throw new Error("deletion review queue contains duplicate group ids");
+  }
+  for (const group of deletionReviewQueue.groups) {
+    if (new Set(group.messageIds).size !== group.messageIds.length) {
+      throw new Error(
+        `deletion review group ${group.groupId} repeats a message`,
+      );
+    }
+    for (const messageId of group.messageIds) {
+      if (!mineOutputs.has(messageId)) {
+        throw new Error(
+          `deletion review group ${group.groupId} references an unknown message`,
+        );
+      }
+    }
+  }
+  const deletionInputMessages = ledger
+    .filter(
+      (record) =>
+        record.rulesetVersion === options.rulesetVersion &&
+        record.stage === "secrets" &&
+        !record.tombstone &&
+        record.output,
+    )
+    .map((record) => record.output)
+    .filter((message): message is CorpusMessage => message !== undefined);
+  validateDeletionQueueSemantics(
+    deletionInputMessages,
+    candidates,
+    deletionRules,
+    deletionReviewQueue,
+  );
+  const decisionsById = new Map(
+    deletionReviewDecision.decisions.map((decision) => [
+      decision.groupId,
+      decision.decision,
+    ]),
+  );
+  if (decisionsById.size !== deletionReviewDecision.decisions.length) {
+    throw new Error("deletion review decision contains duplicate group ids");
+  }
+  if (
+    [...groupsById.keys()].some((groupId) => !decisionsById.has(groupId)) ||
+    [...decisionsById.keys()].some((groupId) => !groupsById.has(groupId))
+  ) {
+    throw new Error(
+      "deletion review decisions are incomplete or contain extras",
+    );
+  }
+  const approvedDeletedIds = [
+    ...new Set(
+      deletionReviewQueue.groups.flatMap((group) =>
+        decisionsById.get(group.groupId) === "delete" ? group.messageIds : [],
+      ),
+    ),
+  ].sort();
+  if (
+    approvedDeletedIds.length !== deletionApproval.tombstoneCount ||
+    sha256(canonicalJson(approvedDeletedIds)) !==
+      deletionApproval.tombstoneIdsSha256
+  ) {
+    throw new Error("deletion approval does not match reviewed deleted ids");
+  }
+  const placeholderRegistry = placeholderRegistrySchema.parse(
+    JSON.parse(await fs.readFile(options.placeholderRegistryPath, "utf8")),
+  );
+  const registryKeys = new Set<string>();
+  for (const entry of placeholderRegistry.entries) {
+    const key = `${entry.messageId}\0${entry.placeholder}`;
+    if (registryKeys.has(key)) {
+      throw new Error(
+        `duplicate placeholder registry entry for ${entry.messageId}`,
+      );
+    }
+    registryKeys.add(key);
+  }
+  for (const [name, ruleset] of [
+    ["deletion approval", deletionApproval.rulesetVersion],
+    ["placeholder registry", placeholderRegistry.rulesetVersion],
+  ] as const) {
+    if (ruleset !== options.rulesetVersion) {
+      throw new Error(
+        `${name} ruleset ${ruleset} does not match ${options.rulesetVersion}`,
+      );
+    }
+  }
+  const gazetteerValues = [
+    ...new Set([
+      ...candidates.map((candidate) => candidate.surfaceForm),
+      ...(await readGazetteerValues(options.gazetteerPath)),
+    ]),
+  ];
+  const workDir = await fs.mkdtemp(
+    path.join(
+      path.dirname(options.reportPath ?? options.targetPath),
+      "corpus-verify-",
+    ),
+  );
+  let gitleaks: GitleaksResult;
+  try {
+    const snapshotPaths: string[] = [];
+    for (const [index, snapshot] of snapshots.entries()) {
+      const snapshotPath = path.join(workDir, "shards", `${index}.jsonl`);
+      await fs.mkdir(path.dirname(snapshotPath), { recursive: true });
+      await fs.writeFile(snapshotPath, snapshot.bytes, { mode: 0o600 });
+      snapshotPaths.push(snapshotPath);
+    }
+    gitleaks = await (options.gitleaksScanner ?? scanShardsWithGitleaks)(
+      snapshotPaths,
+      {
+        binaryPath: options.gitleaksBinaryPath ?? "gitleaks",
+        configPath: gitleaksConfigPath,
+        workDir,
+      },
+    );
+  } finally {
+    // Scratch may contain raw scanner reports, so deletion failure is fatal.
+    await fs.rm(workDir, { recursive: true, force: true });
+  }
+  const findings = dedupeFindings([
+    ...gitleaks.findings,
+    ...(await detectorFindings(messages, gazetteerValues)),
+    ...originalValueFindings(messages, candidates),
+    ...canaryFindings(messages, canaries, ledger),
+    ...registryFindings(messages, placeholderRegistry),
+    ...attachmentFindings(messages),
+    ...ledgerFindings(
+      messages,
+      ledger,
+      deletionApproval,
+      options.rulesetVersion,
+    ),
+  ]);
+  const counts: Record<VerificationFindingKind, number> = {
+    "attachment-policy": 0,
+    canary: 0,
+    entity: 0,
+    gitleaks: 0,
+    ledger: 0,
+    "original-value": 0,
+    placeholder: 0,
+    "redact-pattern": 0,
+    "structured-pii": 0,
+  };
+  for (const finding of findings) counts[finding.kind] += 1;
+  const finalShardPaths = (
+    await findCorpusShardFiles(options.targetPath)
+  ).filter((file) => !file.split(path.sep).includes(".state"));
+  if (
+    canonicalJson([...finalShardPaths].sort()) !==
+    canonicalJson([...shardPaths].sort())
+  ) {
+    throw new Error("corpus shard set changed during verification");
+  }
+  const currentCorpusDigest = await digestShards(
+    options.targetPath,
+    finalShardPaths,
+  );
+  if (currentCorpusDigest !== corpusDigest) {
+    throw new Error("corpus shards changed during verification");
+  }
+  const finalInputHashes = await verificationInputHashes(
+    options,
+    gitleaksConfigPath,
+  );
+  for (const key of verificationInputKeys) {
+    if (initialInputHashes[key] !== finalInputHashes[key]) {
+      throw new Error(`${key} changed during verification`);
+    }
+  }
+  const unsigned: Omit<CorpusVerificationReport, "reportDigest"> = {
+    schemaVersion: 1,
+    scope: "jsonl-text-v1",
+    generatedAt: (options.now ?? (() => new Date()))().toISOString(),
+    rulesetVersion: options.rulesetVersion,
+    status: findings.length === 0 ? "passed" : "failed",
+    corpusDigest,
+    shardCount: shardPaths.length,
+    messageCount: messages.length,
+    candidateCount: candidates.length,
+    canaryCount: canaries.canaries.length,
+    inputs: finalInputHashes,
+    scanner: {
+      name: "gitleaks",
+      version: gitleaks.version,
+      findingCount: gitleaks.findings.length,
+    },
+    counts,
+    findings,
+  };
+  const report = { ...unsigned, reportDigest: reportDigest(unsigned) };
+  if (options.reportPath) {
+    await fs.mkdir(path.dirname(options.reportPath), { recursive: true });
+    await fs.writeFile(
+      options.reportPath,
+      `${JSON.stringify(report, null, 2)}\n`,
+    );
+  }
+  return report;
+}
+
+export async function assertFreshGreenVerification(
+  report: CorpusVerificationReport,
+  options: VerifyCorpusOptions,
+): Promise<void> {
+  const generatedAt = new Date(report.generatedAt);
+  if (Number.isNaN(generatedAt.valueOf())) {
+    throw new Error("verification report generatedAt is invalid");
+  }
+  const fresh = await verifyCorpus({
+    ...options,
+    reportPath: undefined,
+    now: () => generatedAt,
+  });
+  if (
+    fresh.status !== "passed" ||
+    fresh.findings.length !== 0 ||
+    fresh.scanner.findingCount !== 0
+  ) {
+    throw new Error("fresh verification is not green");
+  }
+  if (canonicalJson(fresh) !== canonicalJson(report)) {
+    throw new Error("verification report does not match a fresh verification");
+  }
+}


### PR DESCRIPTION
Refs #14772. Part of #14747.

## Problem

The existing `verify` stage performed no verification: it cloned each message and advanced `scrubState` to `verified`. Worse, `corpus scrub --stage verify --target <raw shards>` could read raw input directly and bless it one row at a time, without checking sibling shards, original-value provenance, deletion approval, canaries, attachment bytes, placeholders, or gitleaks.

## Change

- disables the row-level no-op; `corpus:scrub --stage all` now stops at `rewritten`, and direct `--stage verify` fails with a pointer to the corpus-wide command
- adds `corpus:verify`, a non-mutating, fail-closed `jsonl-text-v1` verifier
- snapshots the exact shard set, rejects concurrent shard/artifact changes and unknown JSON fields, and scans the same bytes with structured detectors and gitleaks
- requires an exact manifest plus unambiguous hash-chained ledger, recomputed complete mine candidates, original gazetteer, canary attestation, semantically validated deletion rules/review/approval artifacts, and placeholder registry
- scans every string-bearing message field with core structured PII detectors, regex entities, original-value gazetteer/LHS matching, and production redact patterns
- rejects embedded attachment bytes and malformed, legacy, forged, unregistered, or unused placeholders
- runs gitleaks over each exact shard with the repository config, a timeout, full redaction, mode-0600 transient reports, and fatal cleanup semantics
- emits a canonical self-hashed report containing hashes and structural locations only; no matched text, snippets, raw gitleaks secrets, or gazetteer values
- exports `assertFreshGreenVerification()` so #14773 reruns the complete gate and requires a byte-identical green report immediately before publishing; the self-hash is corruption detection, not authorization

This PR deliberately cannot certify the real corpus yet. #14769 must produce the required deletion approval/attachment disposition, production canary and placeholder-registry artifacts must exist, multimodal/audio verification remains outside the declared scope, and the owner must bind the ≥200-message review to the exact machine report hash.

## Verification

Exact rebased head: `64d3df6c0ecaa0d2d1e5b2d796672b3e3e0520e2`

- `bun run --cwd packages/corpus-tools test` — 7 files / 66 tests pass
- `bun run --cwd packages/corpus-tools typecheck` — pass
- `bun run --cwd packages/corpus-tools lint` — 19 files clean
- `bun run audit:error-policy-ratchet` — four changed production files, zero new empty catches or server console calls
- `bun run check:agents-claude` — 294 package instruction pairs identical
- real gitleaks 8.30.1 scan: clean full synthetic verification report = green/0 findings; planted Sidekiq credential = 1 `sidekiq-secret`; sanitized results contain no source cleartext
- `bun run verify` bootstrap attempt — all 570 Turbo typecheck/lint tasks passed; later `typecheck:dist` failed because mandatory artifact sync materialized the archived package/plugin bundle and made `tsconfig.dist-paths.json` stale. Generated install artifacts were removed; the exact-head focused gates above are green and exact-head repository gates are running in CI.

<details><summary>Real gitleaks sanitized artifact</summary>

```json
{
  "version": "8.30.1",
  "count": 1,
  "ruleIds": ["sidekiq-secret"],
  "rawSecretPersisted": false
}
```

</details>

<details><summary>Adversarial coverage</summary>

The suite plants an email independently in text, subject (case-variant), sender id/display, recipient address/display, snippet, label, and attachment filename. It also covers unknown top-level/nested fields, embedded attachment bytes, missing canaries, malformed placeholders, missing/empty gitleaks reports, forged/incomplete/ambiguous candidates, deletion queue omissions and live+tombstone branches, broken live/tombstone chains, stale delete versions, self-hash forgery, mutation of every auxiliary input, concurrent shard replacement/addition, exact-byte staleness, and the former raw-row verify path.

</details>

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - CLI/library privacy boundary only; no rendered UI existed before or changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - CLI/library privacy boundary only; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no user-facing visual flow; the machine report and CLI exit status are the exercised surface.
<!-- evidence-row:backend-logs -->
- [x] Exact-head package/full-gate log: https://github.com/elizaOS/eliza/releases/download/pr-evidence/15952-backend-verification.log
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code, browser request, or client state changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, action, provider, evaluator, planner, or model behavior changed; this is deterministic privacy verification.
<!-- evidence-row:domain-artifacts -->
- [x] Full green synthetic verification report: https://github.com/elizaOS/eliza/releases/download/pr-evidence/15952-synthetic-verification-report.json and sanitized planted-secret result: https://github.com/elizaOS/eliza/releases/download/pr-evidence/15952-gitleaks-sanitized.json (raw candidate/gazetteer material is intentionally never uploaded).
