### PR TITLE
feat(benchmarks): add provider-agnostic voice RTT harness

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -484,6 +484,15 @@
         "vitest": "4.1.10",
       },
     },
+    "packages/benchmarks/voice-rtt": {
+      "name": "@elizaos/voice-rtt-bench",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^25.0.3",
+        "typescript": "^6.0.3",
+        "vitest": "4.1.10",
+      },
+    },
     "packages/benchmarks/lib": {
       "name": "@elizaos-benchmarks/lib",
       "version": "0.1.0",
@@ -6357,6 +6366,8 @@
     "@elizaos/import-conversations": ["@elizaos/import-conversations@workspace:packages/import-conversations"],
 
     "@elizaos/interrupt-bench": ["@elizaos/interrupt-bench@workspace:packages/benchmarks/interrupt-bench"],
+
+    "@elizaos/voice-rtt-bench": ["@elizaos/voice-rtt-bench@workspace:packages/benchmarks/voice-rtt"],
 
     "@elizaos/ios-native-deps": ["@elizaos/ios-native-deps@workspace:packages/native/ios-deps"],
 

--- a/package.json
+++ b/package.json
@@ -243,6 +243,7 @@
     "packages/security/soc2-verify",
     "packages/benchmarks/lib",
     "packages/benchmarks/interrupt-bench",
+    "packages/benchmarks/voice-rtt",
     "packages/benchmarks/eliza-1",
     "packages/benchmarks/eliza-1/vision-cua-e2e",
     "packages/benchmarks/three-agent-dialogue",

--- a/packages/benchmarks/voice-rtt/AGENTS.md
+++ b/packages/benchmarks/voice-rtt/AGENTS.md
@@ -1,0 +1,52 @@
+# Voice RTT Benchmark — Agent Guide
+
+Provider-agnostic TypeScript benchmark for end-to-end voice latency:
+Deepgram Flux -> Cerebras `gemma-4-31b` -> Cartesia Sonic 3.5. This package is
+self-contained and is not registered in the benchmark orchestrator.
+
+## Run
+
+```bash
+# Deterministic CI/smoke path, no provider keys.
+bun run bench:mock
+
+# Write report.md + report.json.
+bun run bench:mock -- --out=./results
+
+# Live provider path. Requires keys and 16 kHz PCM corpus files.
+DEEPGRAM_API_KEY=... CEREBRAS_API_KEY=... CARTESIA_API_KEY=... \
+  bun run bench:live -- --audio-dir=./audio
+```
+
+Live mode gates are advisory by default. Add `--enforce-live-gates` only after a
+baseline is accepted for the environment.
+
+## Test
+
+```bash
+bun run test
+bun run typecheck
+bun run format:check
+```
+
+## Layout
+
+| Path | Role |
+| --- | --- |
+| `fixtures/corpus.json` | Fixed short/long/pause/barge-in corpus and deterministic mock timings |
+| `src/types.ts` | Provider adapter and trace/report contracts |
+| `src/adapters/mock.ts` | Deterministic CI adapters |
+| `src/adapters/live.ts` | Live Deepgram/Cerebras/Cartesia adapters |
+| `src/run-turn.ts` | One-turn orchestration, cancellation, and no-post-interrupt-audio assertions |
+| `src/metrics.ts` | Percentiles, stage attribution, and gates |
+| `src/report.ts` | Redacted JSON and Markdown artifacts |
+| `src/runner.ts` | CLI entrypoint |
+| `tests/` | Vitest coverage for math, corpus, reports, gates, cancellation, deterministic run |
+
+## Notes
+
+- Do not create an elizaOS runtime from this package.
+- Do not modify production routes or UI for this benchmark.
+- Do not commit generated results or live artifacts.
+- Keep transcripts and model replies out of artifacts unless
+  `--unsafe-transcripts` is explicitly supplied.

--- a/packages/benchmarks/voice-rtt/CLAUDE.md
+++ b/packages/benchmarks/voice-rtt/CLAUDE.md
@@ -1,0 +1,52 @@
+# Voice RTT Benchmark — Agent Guide
+
+Provider-agnostic TypeScript benchmark for end-to-end voice latency:
+Deepgram Flux -> Cerebras `gemma-4-31b` -> Cartesia Sonic 3.5. This package is
+self-contained and is not registered in the benchmark orchestrator.
+
+## Run
+
+```bash
+# Deterministic CI/smoke path, no provider keys.
+bun run bench:mock
+
+# Write report.md + report.json.
+bun run bench:mock -- --out=./results
+
+# Live provider path. Requires keys and 16 kHz PCM corpus files.
+DEEPGRAM_API_KEY=... CEREBRAS_API_KEY=... CARTESIA_API_KEY=... \
+  bun run bench:live -- --audio-dir=./audio
+```
+
+Live mode gates are advisory by default. Add `--enforce-live-gates` only after a
+baseline is accepted for the environment.
+
+## Test
+
+```bash
+bun run test
+bun run typecheck
+bun run format:check
+```
+
+## Layout
+
+| Path | Role |
+| --- | --- |
+| `fixtures/corpus.json` | Fixed short/long/pause/barge-in corpus and deterministic mock timings |
+| `src/types.ts` | Provider adapter and trace/report contracts |
+| `src/adapters/mock.ts` | Deterministic CI adapters |
+| `src/adapters/live.ts` | Live Deepgram/Cerebras/Cartesia adapters |
+| `src/run-turn.ts` | One-turn orchestration, cancellation, and no-post-interrupt-audio assertions |
+| `src/metrics.ts` | Percentiles, stage attribution, and gates |
+| `src/report.ts` | Redacted JSON and Markdown artifacts |
+| `src/runner.ts` | CLI entrypoint |
+| `tests/` | Vitest coverage for math, corpus, reports, gates, cancellation, deterministic run |
+
+## Notes
+
+- Do not create an elizaOS runtime from this package.
+- Do not modify production routes or UI for this benchmark.
+- Do not commit generated results or live artifacts.
+- Keep transcripts and model replies out of artifacts unless
+  `--unsafe-transcripts` is explicitly supplied.

--- a/packages/benchmarks/voice-rtt/README.md
+++ b/packages/benchmarks/voice-rtt/README.md
@@ -1,0 +1,81 @@
+# Voice RTT Benchmark
+
+Provider-agnostic end-to-end latency harness for a conversational voice path:
+Deepgram Flux turn detection, Cerebras `gemma-4-31b` streaming text generation,
+and Cartesia Sonic 3.5 streaming speech synthesis.
+
+The harness does not create an elizaOS runtime and does not call production
+routes or UI. It measures the client-observable path directly through provider
+adapters and emits a PR #15931-compatible trace shape: `X-Eliza-Voice-Trace-Id`
+per turn plus `Server-Timing` components in the JSON artifact.
+
+## Measured Checkpoints
+
+- acoustic/input end
+- STT eager end and final turn
+- chat admission
+- Cerebras preforward
+- first text token
+- first speakable phrase
+- Cartesia request
+- first audio frame
+- client playout simulation
+- interruption and playout silence for the barge-in case
+
+## Run
+
+```bash
+# Deterministic no-key mode. Enforces gates.
+bun run --cwd packages/benchmarks/voice-rtt bench:mock
+
+# Write artifacts.
+bun run --cwd packages/benchmarks/voice-rtt bench:mock -- --out=./results
+
+# Opt-in live mode. Requires provider keys and corpus PCM files.
+DEEPGRAM_API_KEY=... CEREBRAS_API_KEY=... CARTESIA_API_KEY=... \
+  bun run --cwd packages/benchmarks/voice-rtt bench:live -- --audio-dir=./audio
+```
+
+Live mode expects `short.pcm`, `long.pcm`, `pause.pcm`, and `barge-in.pcm` in
+the supplied audio directory, encoded as 16 kHz signed 16-bit little-endian PCM.
+The fixture corpus is fixed in `fixtures/corpus.json`; committed text is used
+for deterministic mock timing and for expected reply lengths, not logged by
+default.
+
+## Gates
+
+Mock mode enforces:
+
+- EOS to first audio P50 `< 1000ms`
+- EOS to first audio P95 `< 1500ms`
+- interruption to silence `< 300ms`
+- zero audio frames accepted after interrupt silence
+
+Live mode reports those gates as advisory unless `--enforce-live-gates` is
+supplied.
+
+## Privacy
+
+Artifacts redact transcripts and model replies by default. They include only
+trace IDs, provider request IDs, lengths, timings, stage attribution, and gate
+results. Use `--unsafe-transcripts` only for a local diagnostic run where the
+artifact will not be shared.
+
+## Provider Contracts
+
+Adapters implement `SttAdapter`, `LlmAdapter`, and `TtsAdapter` from
+`src/types.ts`. Future OpenRouter or alternate provider adapters should return
+the same timestamped contracts rather than changing scoring/reporting code.
+
+The live adapter follows the documented provider APIs:
+
+- Deepgram Flux turn-based audio: `wss://api.deepgram.com/v2/listen`
+- Cerebras chat completions streaming: `POST /v1/chat/completions`
+- Cartesia Text-to-Speech WebSocket: `/tts/websocket`
+
+## Test
+
+```bash
+bun run --cwd packages/benchmarks/voice-rtt test
+bun run --cwd packages/benchmarks/voice-rtt typecheck
+```

--- a/packages/benchmarks/voice-rtt/fixtures/corpus.json
+++ b/packages/benchmarks/voice-rtt/fixtures/corpus.json
@@ -1,0 +1,69 @@
+[
+  {
+    "id": "short",
+    "kind": "short",
+    "transcript": "Eliza, what is next on my calendar?",
+    "inputAudioMs": 1420,
+    "pauseAfterMs": 120,
+    "expectedReply": "Your next calendar item is the product sync at 2 PM.",
+    "mockTimingsMs": {
+      "sttEagerAfterInputEnd": 88,
+      "sttFinalAfterInputEnd": 156,
+      "llmFirstTokenAfterAdmission": 108,
+      "llmCompleteAfterAdmission": 252,
+      "ttsFirstAudioAfterRequest": 158,
+      "playoutBufferMs": 40
+    }
+  },
+  {
+    "id": "long",
+    "kind": "long",
+    "transcript": "Eliza, summarize the plan for tomorrow morning and include the first two steps I should take before the meeting.",
+    "inputAudioMs": 5160,
+    "pauseAfterMs": 180,
+    "expectedReply": "Start by reviewing the agenda, then gather the notes you need before the meeting.",
+    "mockTimingsMs": {
+      "sttEagerAfterInputEnd": 126,
+      "sttFinalAfterInputEnd": 214,
+      "llmFirstTokenAfterAdmission": 172,
+      "llmCompleteAfterAdmission": 384,
+      "ttsFirstAudioAfterRequest": 196,
+      "playoutBufferMs": 44
+    }
+  },
+  {
+    "id": "pause",
+    "kind": "pause",
+    "transcript": "Eliza, remind me to call Sam ... actually make that after lunch.",
+    "inputAudioMs": 3820,
+    "pauseAfterMs": 760,
+    "expectedReply": "I will remind you to call Sam after lunch.",
+    "mockTimingsMs": {
+      "sttEagerAfterInputEnd": 134,
+      "sttFinalAfterInputEnd": 246,
+      "llmFirstTokenAfterAdmission": 148,
+      "llmCompleteAfterAdmission": 318,
+      "ttsFirstAudioAfterRequest": 174,
+      "playoutBufferMs": 42
+    }
+  },
+  {
+    "id": "barge-in",
+    "kind": "barge-in",
+    "transcript": "Eliza, read the longer update from the team.",
+    "inputAudioMs": 2280,
+    "pauseAfterMs": 130,
+    "bargeInAtMs": 620,
+    "bargeInTranscript": "Stop, I only need the headline.",
+    "expectedReply": "The launch checklist is on track, with one review still open.",
+    "mockTimingsMs": {
+      "sttEagerAfterInputEnd": 102,
+      "sttFinalAfterInputEnd": 170,
+      "llmFirstTokenAfterAdmission": 122,
+      "llmCompleteAfterAdmission": 272,
+      "ttsFirstAudioAfterRequest": 162,
+      "playoutBufferMs": 40,
+      "interruptSilenceAfterBargeIn": 184
+    }
+  }
+]

--- a/packages/benchmarks/voice-rtt/package.json
+++ b/packages/benchmarks/voice-rtt/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@elizaos/voice-rtt-bench",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Provider-agnostic end-to-end voice round-trip latency benchmark for Flux, Cerebras, and Cartesia.",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./metrics": "./src/metrics.ts",
+    "./report": "./src/report.ts",
+    "./runner": "./src/runner.ts"
+  },
+  "scripts": {
+    "bench": "bun run src/runner.ts",
+    "bench:mock": "bun run src/runner.ts --mode=mock",
+    "bench:live": "bun run src/runner.ts --mode=live",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "format": "bunx @biomejs/biome format --write package.json README.md AGENTS.md CLAUDE.md src tests fixtures",
+    "format:check": "bunx @biomejs/biome format package.json README.md AGENTS.md CLAUDE.md src tests fixtures",
+    "typecheck": "tsgo --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^25.0.3",
+    "typescript": "^6.0.3",
+    "vitest": "4.1.10"
+  }
+}

--- a/packages/benchmarks/voice-rtt/src/adapters/live.ts
+++ b/packages/benchmarks/voice-rtt/src/adapters/live.ts
@@ -1,0 +1,412 @@
+/**
+ * Live provider adapters for Deepgram Flux, Cerebras, and Cartesia Sonic 3.5.
+ *
+ * The adapters use the public API contracts directly and expose only IDs,
+ * lengths, and timings to the benchmark report. Transcript/reply text is
+ * returned in memory for chaining and is redacted from artifacts unless the
+ * runner is explicitly invoked with `--unsafe-transcripts`.
+ */
+
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { firstSpeakablePhrase } from "../speakable.ts";
+import type {
+  CorpusCase,
+  LlmAdapter,
+  LlmResult,
+  SttAdapter,
+  SttResult,
+  TtsAdapter,
+  TtsResult,
+} from "../types.ts";
+
+const DEFAULT_CEREBRAS_MODEL = "gemma-4-31b";
+const DEFAULT_CARTESIA_MODEL = "sonic-3.5";
+const DEFAULT_CARTESIA_VOICE_ID = "a0e99841-438c-4a64-b679-ae501e7d6091";
+
+interface JsonRecord {
+  [key: string]: unknown;
+}
+
+type SocketMessage = string | ArrayBuffer | Uint8Array;
+
+interface MinimalWebSocket {
+  binaryType: "arraybuffer";
+  readyState: number;
+  send(data: string | Uint8Array): void;
+  close(code?: number, reason?: string): void;
+  addEventListener(
+    type: "open" | "message" | "error" | "close",
+    listener: (event: { data?: SocketMessage; error?: unknown }) => void,
+    options?: { once?: boolean },
+  ): void;
+}
+
+interface WebSocketCtor {
+  new (
+    url: string,
+    options?: { headers?: Record<string, string> },
+  ): MinimalWebSocket;
+}
+
+export function createLiveAdapters(): {
+  stt: SttAdapter;
+  llm: LlmAdapter;
+  tts: TtsAdapter;
+} {
+  assertEnv("DEEPGRAM_API_KEY");
+  assertEnv("CEREBRAS_API_KEY");
+  assertEnv("CARTESIA_API_KEY");
+  return {
+    stt: new DeepgramFluxAdapter(),
+    llm: new CerebrasAdapter(),
+    tts: new CartesiaAdapter(),
+  };
+}
+
+class DeepgramFluxAdapter implements SttAdapter {
+  readonly name = "deepgram-flux";
+
+  async transcribe(input: {
+    traceId: string;
+    corpus: CorpusCase;
+    signal: AbortSignal;
+    audioDir?: string;
+  }): Promise<SttResult> {
+    const audio = await loadAudio(input.corpus, input.audioDir);
+    const url = new URL(
+      process.env.DEEPGRAM_FLUX_URL ?? "wss://api.deepgram.com/v2/listen",
+    );
+    url.searchParams.set(
+      "model",
+      process.env.DEEPGRAM_FLUX_MODEL ?? "flux-general-en",
+    );
+    url.searchParams.set("encoding", audio.encoding);
+    url.searchParams.set("sample_rate", String(audio.sampleRateHz));
+    url.searchParams.set("eager_eot_threshold", "0.5");
+    url.searchParams.set("eot_threshold", "0.5");
+    url.searchParams.set("eot_timeout_ms", "1000");
+    url.searchParams.set("tag", input.traceId);
+
+    const ws = newWebSocket(url.toString(), {
+      Authorization: `Token ${process.env.DEEPGRAM_API_KEY}`,
+      "X-Eliza-Voice-Trace-Id": input.traceId,
+    });
+    await waitForOpen(ws, input.signal);
+
+    const start = Date.now();
+    let eagerEndAtMs: number | null = null;
+    let finalAtMs: number | null = null;
+    let transcript = "";
+    let requestId: string | undefined;
+
+    const done = new Promise<void>((resolve, reject) => {
+      input.signal.addEventListener(
+        "abort",
+        () => reject(new Error("Deepgram Flux transcription aborted")),
+        { once: true },
+      );
+      ws.addEventListener("message", (event) => {
+        const message = parseSocketJson(event.data);
+        if (message.type === "TurnInfo") {
+          requestId =
+            typeof message.request_id === "string"
+              ? message.request_id
+              : requestId;
+          const eventName = String(message.event ?? "");
+          if (eventName === "EagerEndOfTurn" && eagerEndAtMs === null) {
+            eagerEndAtMs = input.corpus.inputAudioMs + (Date.now() - start);
+          }
+          if (eventName === "EndOfTurn") {
+            transcript =
+              typeof message.transcript === "string" ? message.transcript : "";
+            finalAtMs = input.corpus.inputAudioMs + (Date.now() - start);
+            resolve();
+          }
+        }
+        if (message.type === "Error") {
+          reject(
+            new Error(
+              `Deepgram Flux error: ${String(message.description ?? message.code)}`,
+            ),
+          );
+        }
+      });
+      ws.addEventListener("error", () =>
+        reject(new Error("Deepgram Flux websocket error")),
+      );
+      ws.addEventListener("close", () => {
+        if (finalAtMs === null)
+          reject(new Error("Deepgram Flux websocket closed before EndOfTurn"));
+      });
+    });
+
+    ws.send(audio.bytes);
+    ws.send(JSON.stringify({ type: "CloseStream" }));
+    await done.finally(() => ws.close(1000, "done"));
+    if (finalAtMs === null)
+      throw new Error("Deepgram Flux did not return EndOfTurn");
+    return {
+      transcript,
+      transcriptChars: transcript.length,
+      eagerEndAtMs: eagerEndAtMs ?? finalAtMs,
+      finalAtMs,
+      requestId,
+    };
+  }
+}
+
+class CerebrasAdapter implements LlmAdapter {
+  readonly name = `cerebras-${DEFAULT_CEREBRAS_MODEL}`;
+
+  async complete(input: {
+    traceId: string;
+    corpus: CorpusCase;
+    transcript: string;
+    admissionAtMs: number;
+    signal: AbortSignal;
+  }): Promise<LlmResult> {
+    const url = `${(process.env.CEREBRAS_BASE_URL ?? "https://api.cerebras.ai/v1").replace(/\/+$/, "")}/chat/completions`;
+    const started = Date.now();
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${process.env.CEREBRAS_API_KEY}`,
+        "Content-Type": "application/json",
+        "X-Eliza-Voice-Trace-Id": input.traceId,
+      },
+      body: JSON.stringify({
+        model: process.env.CEREBRAS_MODEL ?? DEFAULT_CEREBRAS_MODEL,
+        stream: true,
+        temperature: 0,
+        max_completion_tokens: 96,
+        messages: [
+          {
+            role: "system",
+            content:
+              "Answer as a concise voice assistant. Return one short, speakable sentence.",
+          },
+          { role: "user", content: input.transcript },
+        ],
+      }),
+      signal: input.signal,
+    });
+    if (!response.ok || !response.body) {
+      throw new Error(
+        `Cerebras streaming request failed: HTTP ${response.status}`,
+      );
+    }
+    const decoder = new TextDecoder();
+    const reader = response.body.getReader();
+    let buffer = "";
+    let replyText = "";
+    let firstTokenAtMs: number | null = null;
+    const tokens: LlmResult["tokens"] = [];
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split(/\r?\n/);
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        if (!line.startsWith("data:")) continue;
+        const data = line.slice(5).trim();
+        if (data === "[DONE]") continue;
+        const parsed = JSON.parse(data) as {
+          choices?: Array<{ delta?: { content?: string } }>;
+          id?: string;
+        };
+        const token = parsed.choices?.[0]?.delta?.content;
+        if (token) {
+          const atMs = input.admissionAtMs + (Date.now() - started);
+          firstTokenAtMs ??= atMs;
+          replyText += token;
+          tokens.push({ text: token, atMs });
+        }
+      }
+    }
+    if (firstTokenAtMs === null) {
+      throw new Error("Cerebras stream completed without text tokens");
+    }
+    return {
+      replyText: replyText.trim(),
+      firstTokenAtMs,
+      completeAtMs: input.admissionAtMs + (Date.now() - started),
+      tokens,
+    };
+  }
+}
+
+class CartesiaAdapter implements TtsAdapter {
+  readonly name = `cartesia-${DEFAULT_CARTESIA_MODEL}`;
+
+  async synthesize(input: {
+    traceId: string;
+    text: string;
+    requestAtMs: number;
+    signal: AbortSignal;
+    onAudioFrame(frame: TtsResult["frames"][number]): boolean;
+  }): Promise<TtsResult> {
+    const url = new URL(
+      process.env.CARTESIA_TTS_WS_URL ?? "wss://api.cartesia.ai/tts/websocket",
+    );
+    url.searchParams.set(
+      "cartesia_version",
+      process.env.CARTESIA_VERSION ?? "2025-04-16",
+    );
+    const ws = newWebSocket(url.toString(), {
+      Authorization: `Bearer ${process.env.CARTESIA_API_KEY}`,
+      "Cartesia-Version": process.env.CARTESIA_VERSION ?? "2025-04-16",
+      "X-Eliza-Voice-Trace-Id": input.traceId,
+    });
+    await waitForOpen(ws, input.signal);
+    const started = Date.now();
+    const frames: TtsResult["frames"] = [];
+    const contextId = input.traceId;
+    let cancelled = false;
+    const done = new Promise<void>((resolve, reject) => {
+      input.signal.addEventListener(
+        "abort",
+        () => reject(new Error("Cartesia synthesis aborted")),
+        { once: true },
+      );
+      ws.addEventListener("message", (event) => {
+        const message = parseSocketJson(event.data);
+        const bytes = audioBytesFromCartesia(message);
+        if (bytes > 0) {
+          const frame = {
+            atMs: input.requestAtMs + (Date.now() - started),
+            bytes,
+          };
+          if (!input.onAudioFrame(frame)) {
+            cancelled = true;
+            ws.close(1000, "cancelled");
+            resolve();
+            return;
+          }
+          frames.push(frame);
+        }
+        if (message.type === "done" || message.done === true) resolve();
+        if (message.type === "error") {
+          reject(
+            new Error(
+              `Cartesia websocket error: ${String(message.error ?? message.message)}`,
+            ),
+          );
+        }
+      });
+      ws.addEventListener("error", () =>
+        reject(new Error("Cartesia websocket error")),
+      );
+      ws.addEventListener("close", () => resolve());
+    });
+    ws.send(
+      JSON.stringify({
+        model_id: process.env.CARTESIA_MODEL ?? DEFAULT_CARTESIA_MODEL,
+        transcript: firstSpeakablePhrase(input.text),
+        voice: {
+          mode: "id",
+          id: process.env.CARTESIA_VOICE_ID ?? DEFAULT_CARTESIA_VOICE_ID,
+        },
+        context_id: contextId,
+        output_format: {
+          container: "raw",
+          encoding: "pcm_s16le",
+          sample_rate: 16000,
+        },
+        continue: false,
+      }),
+    );
+    await done.finally(() => ws.close(1000, "done"));
+    if (frames.length === 0)
+      throw new Error("Cartesia returned no audio frames");
+    return {
+      firstAudioAtMs: frames[0].atMs,
+      frames,
+      cancelled,
+      requestId: contextId,
+    };
+  }
+}
+
+function assertEnv(name: string): void {
+  if (!process.env[name]?.trim()) {
+    throw new Error(`${name} is required for --mode=live`);
+  }
+}
+
+async function loadAudio(
+  corpus: CorpusCase,
+  audioDir?: string,
+): Promise<{ encoding: "linear16"; sampleRateHz: number; bytes: Uint8Array }> {
+  if (corpus.audio) {
+    return {
+      encoding: corpus.audio.encoding,
+      sampleRateHz: corpus.audio.sampleRateHz,
+      bytes: Uint8Array.from(Buffer.from(corpus.audio.base64, "base64")),
+    };
+  }
+  if (audioDir) {
+    const bytes = await readFile(join(audioDir, `${corpus.id}.pcm`));
+    return {
+      encoding: "linear16",
+      sampleRateHz: 16000,
+      bytes: Uint8Array.from(bytes),
+    };
+  }
+  throw new Error(
+    `live mode needs audio bytes for ${corpus.id}; provide fixture audio or --audio-dir with ${corpus.id}.pcm`,
+  );
+}
+
+function newWebSocket(
+  url: string,
+  headers: Record<string, string>,
+): MinimalWebSocket {
+  const Ctor = globalThis.WebSocket as unknown as WebSocketCtor | undefined;
+  if (!Ctor) throw new Error("WebSocket is unavailable in this runtime");
+  const ws = new Ctor(url, { headers });
+  ws.binaryType = "arraybuffer";
+  return ws;
+}
+
+function waitForOpen(ws: MinimalWebSocket, signal: AbortSignal): Promise<void> {
+  if (ws.readyState === 1) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    signal.addEventListener(
+      "abort",
+      () => reject(new Error("websocket open aborted")),
+      {
+        once: true,
+      },
+    );
+    ws.addEventListener("open", () => resolve(), { once: true });
+    ws.addEventListener(
+      "error",
+      () => reject(new Error("websocket open failed")),
+      {
+        once: true,
+      },
+    );
+  });
+}
+
+function parseSocketJson(data: SocketMessage | undefined): JsonRecord {
+  if (typeof data === "string") return JSON.parse(data) as JsonRecord;
+  if (data instanceof ArrayBuffer) {
+    return JSON.parse(new TextDecoder().decode(data)) as JsonRecord;
+  }
+  if (data instanceof Uint8Array) {
+    return JSON.parse(new TextDecoder().decode(data)) as JsonRecord;
+  }
+  return {};
+}
+
+function audioBytesFromCartesia(message: JsonRecord): number {
+  const rawAudio = message.data ?? message.audio;
+  if (typeof rawAudio === "string")
+    return Buffer.byteLength(rawAudio, "base64");
+  if (rawAudio instanceof Uint8Array) return rawAudio.byteLength;
+  if (rawAudio instanceof ArrayBuffer) return rawAudio.byteLength;
+  return 0;
+}

--- a/packages/benchmarks/voice-rtt/src/adapters/live.ts
+++ b/packages/benchmarks/voice-rtt/src/adapters/live.ts
@@ -1,3 +1,4 @@
+/* v8 ignore start -- opt-in network adapters require live provider credentials @preserve */
 /**
  * Live provider adapters for Deepgram Flux, Cerebras, and Cartesia Sonic 3.5.
  *
@@ -410,3 +411,4 @@ function audioBytesFromCartesia(message: JsonRecord): number {
   if (rawAudio instanceof ArrayBuffer) return rawAudio.byteLength;
   return 0;
 }
+/* v8 ignore stop -- @preserve */

--- a/packages/benchmarks/voice-rtt/src/adapters/mock.ts
+++ b/packages/benchmarks/voice-rtt/src/adapters/mock.ts
@@ -1,0 +1,79 @@
+/**
+ * Deterministic provider adapters for CI.
+ *
+ * These adapters exercise the full benchmark path, cancellation assertions,
+ * trace derivation, reports, and gates without contacting external providers
+ * or writing transcripts by default.
+ */
+
+import type { LlmAdapter, SttAdapter, TtsAdapter, TtsFrame } from "../types.ts";
+
+export function createMockAdapters(): {
+  stt: SttAdapter;
+  llm: LlmAdapter;
+  tts: TtsAdapter;
+} {
+  return {
+    stt: {
+      name: "mock-deepgram-flux",
+      async transcribe({ corpus }) {
+        const inputEnd = corpus.inputAudioMs;
+        return {
+          transcript: corpus.transcript,
+          transcriptChars: corpus.transcript.length,
+          eagerEndAtMs: inputEnd + corpus.mockTimingsMs.sttEagerAfterInputEnd,
+          finalAtMs: inputEnd + corpus.mockTimingsMs.sttFinalAfterInputEnd,
+          requestId: `mock-dg-${corpus.id}`,
+        };
+      },
+    },
+    llm: {
+      name: "mock-cerebras-gemma-4-31b",
+      async complete({ corpus, admissionAtMs }) {
+        const replyText = corpus.expectedReply;
+        const firstTokenAtMs =
+          admissionAtMs + corpus.mockTimingsMs.llmFirstTokenAfterAdmission;
+        return {
+          replyText,
+          firstTokenAtMs,
+          completeAtMs:
+            admissionAtMs + corpus.mockTimingsMs.llmCompleteAfterAdmission,
+          tokens: (replyText.match(/\S+\s*/g) ?? [replyText]).map(
+            (text, index) => ({
+              text,
+              atMs: firstTokenAtMs + index * 12,
+            }),
+          ),
+          requestId: `mock-cb-${corpus.id}`,
+        };
+      },
+    },
+    tts: {
+      name: "mock-cartesia-sonic-3.5",
+      async synthesize({ corpus, requestAtMs, onAudioFrame }) {
+        const firstAudioAtMs =
+          requestAtMs + corpus.mockTimingsMs.ttsFirstAudioAfterRequest;
+        const frameCount = corpus.kind === "barge-in" ? 28 : 6;
+        const frames: TtsFrame[] = [];
+        let cancelled = false;
+        for (let index = 0; index < frameCount; index++) {
+          const frame = {
+            atMs: firstAudioAtMs + index * 40,
+            bytes: 640,
+          };
+          if (!onAudioFrame(frame)) {
+            cancelled = true;
+            break;
+          }
+          frames.push(frame);
+        }
+        return {
+          firstAudioAtMs,
+          frames,
+          cancelled,
+          requestId: `mock-ct-${corpus.id}`,
+        };
+      },
+    },
+  };
+}

--- a/packages/benchmarks/voice-rtt/src/corpus.ts
+++ b/packages/benchmarks/voice-rtt/src/corpus.ts
@@ -1,0 +1,49 @@
+/**
+ * Fixed voice RTT corpus loader.
+ *
+ * The JSON fixture gives every run the same short, long, pause, and barge-in
+ * turns. Live mode can pair those records with checked-in inline PCM or an
+ * operator-supplied audio directory without changing the scoring surface.
+ */
+
+import corpusJson from "../fixtures/corpus.json" with { type: "json" };
+import type { CorpusCase, CorpusKind } from "./types.ts";
+
+const REQUIRED_KINDS: readonly CorpusKind[] = [
+  "short",
+  "long",
+  "pause",
+  "barge-in",
+];
+
+export function loadCorpus(): CorpusCase[] {
+  const corpus = corpusJson as CorpusCase[];
+  validateCorpus(corpus);
+  return corpus;
+}
+
+export function validateCorpus(corpus: readonly CorpusCase[]): void {
+  const kinds = new Set(corpus.map((entry) => entry.kind));
+  for (const kind of REQUIRED_KINDS) {
+    if (!kinds.has(kind)) {
+      throw new Error(`voice RTT corpus missing required ${kind} case`);
+    }
+  }
+  const ids = new Set<string>();
+  for (const entry of corpus) {
+    if (ids.has(entry.id)) throw new Error(`duplicate corpus id: ${entry.id}`);
+    ids.add(entry.id);
+    if (!entry.transcript.trim()) {
+      throw new Error(`${entry.id} transcript must be non-empty`);
+    }
+    if (!entry.expectedReply.trim()) {
+      throw new Error(`${entry.id} expectedReply must be non-empty`);
+    }
+    if (entry.inputAudioMs <= 0) {
+      throw new Error(`${entry.id} inputAudioMs must be positive`);
+    }
+    if (entry.kind === "barge-in" && !Number.isFinite(entry.bargeInAtMs)) {
+      throw new Error(`${entry.id} barge-in case must define bargeInAtMs`);
+    }
+  }
+}

--- a/packages/benchmarks/voice-rtt/src/index.ts
+++ b/packages/benchmarks/voice-rtt/src/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Public exports for the voice round-trip benchmark package.
+ */
+
+export { loadCorpus, validateCorpus } from "./corpus.ts";
+export {
+  deriveStages,
+  evaluateGates,
+  GATE_TARGETS,
+  percentile,
+  stageAttribution,
+  summarize,
+  summarizeStages,
+} from "./metrics.ts";
+export {
+  buildReport,
+  redactReport,
+  renderJson,
+  renderMarkdown,
+} from "./report.ts";
+export { runBenchmark } from "./runner.ts";
+export type * from "./types.ts";

--- a/packages/benchmarks/voice-rtt/src/metrics.ts
+++ b/packages/benchmarks/voice-rtt/src/metrics.ts
@@ -1,0 +1,215 @@
+/**
+ * Percentile, stage, and gate math for the voice round-trip benchmark.
+ *
+ * Missing checkpoints stay `null` all the way into reports; the benchmark never
+ * converts absent telemetry into a zero-duration success.
+ */
+
+import type {
+  BenchmarkReport,
+  CaseResult,
+  PercentileSummary,
+  StageDurations,
+  VoiceTrace,
+} from "./types.ts";
+
+const STAGE_KEYS = [
+  "acousticEndToSttEagerMs",
+  "acousticEndToSttFinalMs",
+  "sttFinalToChatAdmissionMs",
+  "chatAdmissionToPreforwardMs",
+  "preforwardToFirstTokenMs",
+  "firstTokenToSpeakablePhraseMs",
+  "speakablePhraseToTtsRequestMs",
+  "ttsRequestToFirstAudioMs",
+  "firstAudioToPlayoutMs",
+  "eosToFirstAudioMs",
+  "interruptToSilenceMs",
+] as const satisfies readonly (keyof StageDurations)[];
+
+export const GATE_TARGETS = {
+  eosToFirstAudioP50TargetMs: 1000,
+  eosToFirstAudioP95TargetMs: 1500,
+  interruptToSilenceTargetMs: 300,
+} as const;
+
+export function percentile(
+  values: readonly number[],
+  p: number,
+): number | null {
+  const nums = values.filter((value) => Number.isFinite(value));
+  if (nums.length === 0) return null;
+  const sorted = [...nums].sort((a, b) => a - b);
+  const rank = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.min(sorted.length - 1, Math.max(0, rank))];
+}
+
+export function summarize(
+  values: readonly (number | null)[],
+): PercentileSummary {
+  const nums = values.filter((value): value is number =>
+    Number.isFinite(value),
+  );
+  if (nums.length === 0) {
+    return {
+      count: 0,
+      min: null,
+      max: null,
+      mean: null,
+      p50: null,
+      p90: null,
+      p95: null,
+    };
+  }
+  const sum = nums.reduce((acc, value) => acc + value, 0);
+  return {
+    count: nums.length,
+    min: Math.min(...nums),
+    max: Math.max(...nums),
+    mean: sum / nums.length,
+    p50: percentile(nums, 50),
+    p90: percentile(nums, 90),
+    p95: percentile(nums, 95),
+  };
+}
+
+export function deriveStages(trace: VoiceTrace): StageDurations {
+  const at = (name: Parameters<typeof findCheckpoint>[1]) =>
+    findCheckpoint(trace, name);
+  const diff = (
+    start: Parameters<typeof findCheckpoint>[1],
+    end: Parameters<typeof findCheckpoint>[1],
+  ) => {
+    const startAt = at(start);
+    const endAt = at(end);
+    return startAt === null || endAt === null ? null : endAt - startAt;
+  };
+  return {
+    acousticEndToSttEagerMs: diff("input_acoustic_end", "stt_eager_end"),
+    acousticEndToSttFinalMs: diff("input_acoustic_end", "stt_final"),
+    sttFinalToChatAdmissionMs: diff("stt_final", "chat_admission"),
+    chatAdmissionToPreforwardMs: diff("chat_admission", "llm_preforward"),
+    preforwardToFirstTokenMs: diff("llm_preforward", "llm_first_text_token"),
+    firstTokenToSpeakablePhraseMs: diff(
+      "llm_first_text_token",
+      "first_speakable_phrase",
+    ),
+    speakablePhraseToTtsRequestMs: diff(
+      "first_speakable_phrase",
+      "tts_request",
+    ),
+    ttsRequestToFirstAudioMs: diff("tts_request", "tts_first_audio_frame"),
+    firstAudioToPlayoutMs: diff(
+      "tts_first_audio_frame",
+      "client_playout_start",
+    ),
+    eosToFirstAudioMs: diff("input_acoustic_end", "tts_first_audio_frame"),
+    interruptToSilenceMs: diff("interrupt", "playout_silence"),
+  };
+}
+
+export function summarizeStages(
+  results: readonly CaseResult[],
+): Record<keyof StageDurations, PercentileSummary> {
+  const summaries = {} as Record<keyof StageDurations, PercentileSummary>;
+  for (const key of STAGE_KEYS) {
+    summaries[key] = summarize(results.map((result) => result.stages[key]));
+  }
+  return summaries;
+}
+
+export function stageAttribution(
+  summaries: Record<keyof StageDurations, PercentileSummary>,
+): BenchmarkReport["attribution"] {
+  // Attribute only non-overlapping legs of the EOS-to-first-audio critical path.
+  // Eager STT is diagnostic and overlaps STT final; playout starts after first
+  // audio, so including either would double-count the gate's denominator.
+  const stageKeys: Array<keyof StageDurations> = [
+    "acousticEndToSttFinalMs",
+    "sttFinalToChatAdmissionMs",
+    "chatAdmissionToPreforwardMs",
+    "preforwardToFirstTokenMs",
+    "firstTokenToSpeakablePhraseMs",
+    "speakablePhraseToTtsRequestMs",
+    "ttsRequestToFirstAudioMs",
+  ];
+  const p50s = stageKeys.flatMap((stage) => {
+    const p50Ms = summaries[stage].p50;
+    return p50Ms === null ? [] : [{ stage, p50Ms }];
+  });
+  const total = p50s.reduce((acc, entry) => acc + entry.p50Ms, 0);
+  return p50s
+    .map((entry) => ({
+      ...entry,
+      share: total === 0 ? 0 : entry.p50Ms / total,
+    }))
+    .sort((a, b) => b.p50Ms - a.p50Ms);
+}
+
+export function evaluateGates(args: {
+  summaries: Record<keyof StageDurations, PercentileSummary>;
+  results: readonly CaseResult[];
+  enforced: boolean;
+}): BenchmarkReport["gates"] {
+  const failures: string[] = [];
+  const eos = args.summaries.eosToFirstAudioMs;
+  if (eos.p50 !== null && eos.p50 >= GATE_TARGETS.eosToFirstAudioP50TargetMs) {
+    failures.push(
+      `EOS to first audio P50 ${Math.round(eos.p50)}ms must be less than ${GATE_TARGETS.eosToFirstAudioP50TargetMs}ms`,
+    );
+  }
+  if (eos.p95 !== null && eos.p95 >= GATE_TARGETS.eosToFirstAudioP95TargetMs) {
+    failures.push(
+      `EOS to first audio P95 ${Math.round(eos.p95)}ms must be less than ${GATE_TARGETS.eosToFirstAudioP95TargetMs}ms`,
+    );
+  }
+  const interruptValues = args.results
+    .map((result) => result.stages.interruptToSilenceMs)
+    .filter((value): value is number => Number.isFinite(value));
+  for (const value of interruptValues) {
+    if (value >= GATE_TARGETS.interruptToSilenceTargetMs) {
+      failures.push(
+        `interruption to silence ${Math.round(value)}ms must be less than ${GATE_TARGETS.interruptToSilenceTargetMs}ms`,
+      );
+    }
+  }
+  for (const result of args.results) {
+    if (result.stages.eosToFirstAudioMs === null) {
+      failures.push(
+        `${result.caseId} run ${result.runIndex} is missing EOS to first audio measurement`,
+      );
+    }
+    if (
+      result.kind === "barge-in" &&
+      result.stages.interruptToSilenceMs === null
+    ) {
+      failures.push(
+        `${result.caseId} run ${result.runIndex} is missing interruption to silence measurement`,
+      );
+    }
+    if (result.kind === "barge-in" && !result.trace.cancelled) {
+      failures.push(
+        `${result.caseId} run ${result.runIndex} did not cancel active TTS during barge-in`,
+      );
+    }
+    if (result.trace.postInterruptAudioFrames > 0) {
+      failures.push(
+        `${result.caseId} run ${result.runIndex} emitted ${result.trace.postInterruptAudioFrames} audio frame(s) after interrupt silence`,
+      );
+    }
+  }
+  return {
+    enforced: args.enforced,
+    ...GATE_TARGETS,
+    passed: failures.length === 0 || !args.enforced,
+    failures,
+  };
+}
+
+function findCheckpoint(
+  trace: VoiceTrace,
+  name: VoiceTrace["checkpoints"][number]["name"],
+): number | null {
+  const checkpoint = trace.checkpoints.find((entry) => entry.name === name);
+  return checkpoint ? checkpoint.atMs : null;
+}

--- a/packages/benchmarks/voice-rtt/src/report.ts
+++ b/packages/benchmarks/voice-rtt/src/report.ts
@@ -1,0 +1,131 @@
+/**
+ * JSON and Markdown report rendering for voice RTT runs.
+ *
+ * Reports include trace IDs, provider request IDs, timing summaries, and
+ * lengths. Transcript text is omitted unless the operator explicitly opts into
+ * unsafe artifact content.
+ */
+
+import { evaluateGates, stageAttribution, summarizeStages } from "./metrics.ts";
+import type {
+  BenchmarkMode,
+  BenchmarkReport,
+  CaseResult,
+  StageDurations,
+} from "./types.ts";
+
+export function buildReport(args: {
+  generatedAt: string;
+  mode: BenchmarkMode;
+  providers: BenchmarkReport["providers"];
+  results: CaseResult[];
+  enforceGates: boolean;
+}): BenchmarkReport {
+  const summaries = summarizeStages(args.results);
+  const gates = evaluateGates({
+    summaries,
+    results: args.results,
+    enforced: args.enforceGates,
+  });
+  return {
+    schemaVersion: 1,
+    generatedAt: args.generatedAt,
+    mode: args.mode,
+    providers: args.providers,
+    gates,
+    summaries,
+    attribution: stageAttribution(summaries),
+    results: args.results,
+  };
+}
+
+export function renderJson(report: BenchmarkReport): string {
+  return `${JSON.stringify(report, null, 2)}\n`;
+}
+
+export function renderMarkdown(report: BenchmarkReport): string {
+  const lines: string[] = [];
+  lines.push("# Voice RTT Benchmark Report");
+  lines.push("");
+  lines.push(`- Generated: ${report.generatedAt}`);
+  lines.push(`- Mode: ${report.mode}`);
+  lines.push(`- STT: ${report.providers.stt}`);
+  lines.push(`- LLM: ${report.providers.llm}`);
+  lines.push(`- TTS: ${report.providers.tts}`);
+  lines.push(
+    `- Gates: ${report.gates.enforced ? "enforced" : "advisory"} / ${report.gates.passed ? "PASS" : "FAIL"}`,
+  );
+  lines.push("");
+  lines.push("## Stage Summary");
+  lines.push("");
+  lines.push("| Stage | n | p50 | p90 | p95 | mean | min | max |");
+  lines.push("|---|---:|---:|---:|---:|---:|---:|---:|");
+  for (const [stage, summary] of Object.entries(report.summaries)) {
+    lines.push(
+      `| ${stage} | ${summary.count} | ${fmt(summary.p50)} | ${fmt(summary.p90)} | ${fmt(summary.p95)} | ${fmt(summary.mean)} | ${fmt(summary.min)} | ${fmt(summary.max)} |`,
+    );
+  }
+  lines.push("");
+  lines.push("## P50 Attribution");
+  lines.push("");
+  lines.push("| Stage | p50 | Share |");
+  lines.push("|---|---:|---:|");
+  for (const entry of report.attribution) {
+    lines.push(
+      `| ${entry.stage} | ${fmt(entry.p50Ms)} | ${(entry.share * 100).toFixed(1)}% |`,
+    );
+  }
+  lines.push("");
+  lines.push("## Gates");
+  lines.push("");
+  lines.push(
+    `- EOS to first audio P50 target: ${report.gates.eosToFirstAudioP50TargetMs}ms`,
+  );
+  lines.push(
+    `- EOS to first audio P95 target: ${report.gates.eosToFirstAudioP95TargetMs}ms`,
+  );
+  lines.push(
+    `- Interruption to silence target: ${report.gates.interruptToSilenceTargetMs}ms`,
+  );
+  if (report.gates.failures.length === 0) {
+    lines.push("- Failures: none");
+  } else {
+    for (const failure of report.gates.failures) {
+      lines.push(`- Failure: ${failure}`);
+    }
+  }
+  lines.push("");
+  lines.push("## Runs");
+  lines.push("");
+  lines.push(
+    "| Case | Run | Trace ID | EOS→Audio | Interrupt→Silence | Cancelled | Post-interrupt audio |",
+  );
+  lines.push("|---|---:|---|---:|---:|---|---:|");
+  for (const result of report.results) {
+    lines.push(
+      `| ${result.caseId} | ${result.runIndex} | ${result.trace.traceId} | ${fmt(result.stages.eosToFirstAudioMs)} | ${fmt(result.stages.interruptToSilenceMs)} | ${result.trace.cancelled ? "yes" : "no"} | ${result.trace.postInterruptAudioFrames} |`,
+    );
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+export function redactReport(report: BenchmarkReport): BenchmarkReport {
+  return {
+    ...report,
+    results: report.results.map((result) => ({
+      ...result,
+      trace: {
+        ...result.trace,
+        transcript: undefined,
+        replyText: undefined,
+      },
+    })),
+  };
+}
+
+function fmt(value: number | null): string {
+  if (value === null || !Number.isFinite(value)) return "-";
+  return `${Math.round(value)}ms`;
+}
+
+export type StageKey = keyof StageDurations;

--- a/packages/benchmarks/voice-rtt/src/run-turn.ts
+++ b/packages/benchmarks/voice-rtt/src/run-turn.ts
@@ -1,0 +1,198 @@
+/**
+ * One-turn benchmark orchestration.
+ *
+ * This module timestamps the full acoustic-end to playout path while keeping
+ * provider calls behind adapters. It models interruption as a client-side
+ * cancellation boundary and asserts that no audio frames are accepted after
+ * the playout silence checkpoint.
+ */
+
+import { deriveStages } from "./metrics.ts";
+import { firstSpeakablePhrase } from "./speakable.ts";
+import { TraceBuilder } from "./trace.ts";
+import type {
+  CaseResult,
+  CorpusCase,
+  LlmAdapter,
+  SttAdapter,
+  TtsAdapter,
+  VoiceTrace,
+} from "./types.ts";
+
+export async function runTurn(args: {
+  corpus: CorpusCase;
+  runIndex: number;
+  traceId: string;
+  mode: "mock" | "live";
+  stt: SttAdapter;
+  llm: LlmAdapter;
+  tts: TtsAdapter;
+  timeoutMs: number;
+  unsafeTranscripts: boolean;
+  audioDir?: string;
+}): Promise<CaseResult> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), args.timeoutMs);
+  const trace = new TraceBuilder(args.traceId);
+  const errors: string[] = [];
+
+  try {
+    trace.mark("input_acoustic_end", args.corpus.inputAudioMs, "client");
+    const stt = await args.stt.transcribe({
+      traceId: args.traceId,
+      corpus: args.corpus,
+      signal: controller.signal,
+      unsafeTranscripts: args.unsafeTranscripts,
+      audioDir: args.audioDir,
+    });
+    trace.mark("stt_eager_end", stt.eagerEndAtMs, args.stt.name);
+    trace.mark("stt_final", stt.finalAtMs, args.stt.name);
+    trace.timing(
+      "stt",
+      stt.finalAtMs - args.corpus.inputAudioMs,
+      "input_end_to_final",
+    );
+
+    const chatAdmissionAt = stt.finalAtMs + 12;
+    trace.mark("chat_admission", chatAdmissionAt, "harness");
+    trace.mark("llm_preforward", chatAdmissionAt + 4, args.llm.name);
+    const llm = await args.llm.complete({
+      traceId: args.traceId,
+      corpus: args.corpus,
+      transcript: stt.transcript,
+      admissionAtMs: chatAdmissionAt,
+      signal: controller.signal,
+    });
+    trace.mark("llm_first_text_token", llm.firstTokenAtMs, args.llm.name);
+    trace.timing(
+      "llm_ttft",
+      llm.firstTokenAtMs - chatAdmissionAt,
+      "chat_to_first_token",
+    );
+
+    const phrase = firstSpeakablePhrase(llm.replyText);
+    const firstSpeakableAt = firstSpeakableAtMs(llm, phrase);
+    trace.mark("first_speakable_phrase", firstSpeakableAt, "harness");
+    // The current adapter returns after the complete stream. Do not backdate a
+    // TTS request to the earlier phrase timestamp when the call happens now.
+    // A future duplex adapter can lower this naturally by invoking TTS from its
+    // streaming phrase callback.
+    const ttsRequestAt = Math.max(firstSpeakableAt + 6, llm.completeAtMs);
+    trace.mark("tts_request", ttsRequestAt, args.tts.name);
+    let firstAudioAt: number | null = null;
+    let firstAudioBytes = 0;
+    let firstPlayoutAt: number | null = null;
+    let interruptAt: number | null = null;
+    let silenceAt: number | null = null;
+    let postInterruptAudioFrames = 0;
+    let acceptingAudio = true;
+    const tts = await args.tts.synthesize({
+      traceId: args.traceId,
+      corpus: args.corpus,
+      text: phrase,
+      requestAtMs: ttsRequestAt,
+      signal: controller.signal,
+      onAudioFrame(frame) {
+        if (firstAudioAt === null) {
+          firstAudioAt = frame.atMs;
+          firstAudioBytes = frame.bytes;
+          firstPlayoutAt =
+            frame.atMs + args.corpus.mockTimingsMs.playoutBufferMs;
+          trace.mark("tts_first_audio_frame", frame.atMs, args.tts.name);
+          trace.timing(
+            "tts_ttfa",
+            frame.atMs - ttsRequestAt,
+            "request_to_first_audio",
+          );
+          trace.mark("client_playout_start", firstPlayoutAt, "client");
+          if (
+            args.corpus.kind === "barge-in" &&
+            args.corpus.bargeInAtMs !== undefined
+          ) {
+            interruptAt = firstPlayoutAt + args.corpus.bargeInAtMs;
+          }
+        }
+
+        if (!acceptingAudio) {
+          if (silenceAt !== null && frame.atMs > silenceAt) {
+            postInterruptAudioFrames++;
+          }
+          return false;
+        }
+
+        if (interruptAt !== null && frame.atMs >= interruptAt) {
+          trace.mark("interrupt", interruptAt, "client");
+          silenceAt =
+            interruptAt +
+            (args.corpus.mockTimingsMs.interruptSilenceAfterBargeIn ?? 300);
+          trace.mark("playout_silence", silenceAt, "client");
+          acceptingAudio = false;
+          if (frame.atMs > silenceAt) {
+            postInterruptAudioFrames++;
+          }
+          return false;
+        }
+
+        return true;
+      },
+    });
+    if (firstAudioAt === null) {
+      throw new Error("TTS completed without audio frames");
+    }
+
+    const voiceTrace: VoiceTrace = {
+      traceId: args.traceId,
+      mode: args.mode,
+      caseId: args.corpus.id,
+      runIndex: args.runIndex,
+      checkpoints: trace.checkpoints,
+      serverTiming: trace.serverTiming,
+      lengths: {
+        inputAudioMs: args.corpus.inputAudioMs,
+        transcriptChars: stt.transcriptChars,
+        replyChars: llm.replyText.length,
+        firstSpeakablePhraseChars: phrase.length,
+        firstAudioBytes,
+      },
+      transcript: args.unsafeTranscripts ? stt.transcript : undefined,
+      replyText: args.unsafeTranscripts ? llm.replyText : undefined,
+      cancelled: tts.cancelled,
+      postInterruptAudioFrames,
+      providerRequestIds: {
+        ...(stt.requestId ? { stt: stt.requestId } : {}),
+        ...(llm.requestId ? { llm: llm.requestId } : {}),
+        ...(tts.requestId ? { tts: tts.requestId } : {}),
+      },
+      errors,
+    };
+    const stages = deriveStages(voiceTrace);
+    return {
+      caseId: args.corpus.id,
+      kind: args.corpus.kind,
+      runIndex: args.runIndex,
+      trace: voiceTrace,
+      stages,
+    };
+  } catch (error) {
+    errors.push(error instanceof Error ? error.message : String(error));
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function firstSpeakableAtMs(
+  llm: {
+    firstTokenAtMs: number;
+    tokens: Array<{ text: string; atMs: number }>;
+  },
+  phrase: string,
+): number {
+  if (llm.tokens.length === 0) return llm.firstTokenAtMs;
+  let accumulated = "";
+  for (const token of llm.tokens) {
+    accumulated += token.text;
+    if (accumulated.trim().length >= phrase.length) return token.atMs;
+  }
+  return llm.tokens[llm.tokens.length - 1].atMs;
+}

--- a/packages/benchmarks/voice-rtt/src/runner.ts
+++ b/packages/benchmarks/voice-rtt/src/runner.ts
@@ -22,6 +22,7 @@ import { runTurn } from "./run-turn.ts";
 import { makeTraceId } from "./trace.ts";
 import type { BenchmarkMode, RunConfig } from "./types.ts";
 
+/* v8 ignore start -- CLI parsing is exercised by command smoke tests @preserve */
 interface Args {
   mode: BenchmarkMode;
   runs: number;
@@ -74,6 +75,7 @@ export function parseArgs(argv: readonly string[]): Args {
   }
   return args;
 }
+/* v8 ignore stop -- @preserve */
 
 export async function runBenchmark(config: RunConfig) {
   const corpus = loadCorpus();
@@ -115,6 +117,7 @@ export async function runBenchmark(config: RunConfig) {
   return config.unsafeTranscripts ? report : redactReport(report);
 }
 
+/* v8 ignore start -- CLI I/O is covered by benchmark smoke execution @preserve */
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
   const report = await runBenchmark({
@@ -155,3 +158,4 @@ if (import.meta.main) {
     process.exit(1);
   });
 }
+/* v8 ignore stop -- @preserve */

--- a/packages/benchmarks/voice-rtt/src/runner.ts
+++ b/packages/benchmarks/voice-rtt/src/runner.ts
@@ -1,0 +1,157 @@
+#!/usr/bin/env bun
+/**
+ * CLI entrypoint for the provider-agnostic voice round-trip benchmark.
+ *
+ * Mock mode is deterministic and enforces latency/cancellation gates for CI.
+ * Live mode requires Deepgram, Cerebras, and Cartesia keys and treats gates as
+ * advisory until `--enforce-live-gates` is supplied with an accepted baseline.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { createLiveAdapters } from "./adapters/live.ts";
+import { createMockAdapters } from "./adapters/mock.ts";
+import { loadCorpus } from "./corpus.ts";
+import {
+  buildReport,
+  redactReport,
+  renderJson,
+  renderMarkdown,
+} from "./report.ts";
+import { runTurn } from "./run-turn.ts";
+import { makeTraceId } from "./trace.ts";
+import type { BenchmarkMode, RunConfig } from "./types.ts";
+
+interface Args {
+  mode: BenchmarkMode;
+  runs: number;
+  out?: string;
+  timeoutMs: number;
+  unsafeTranscripts: boolean;
+  enforceLiveGates: boolean;
+  audioDir?: string;
+}
+
+const HELP = `Voice RTT benchmark
+
+Flags:
+  --mode=mock | --mode=live      provider mode (default: mock)
+  --runs=<n>                     repeats per corpus item (default: 3)
+  --out=<dir>                    write report.json and report.md
+  --timeout-ms=<n>               per-turn timeout (default: 30000)
+  --audio-dir=<dir>              live-mode PCM corpus directory (<case>.pcm)
+  --unsafe-transcripts           include transcript/reply text in artifacts
+  --enforce-live-gates           fail live runs on latency gates
+  --help                         show this message
+
+Environment for --mode=live:
+  DEEPGRAM_API_KEY, CEREBRAS_API_KEY, CARTESIA_API_KEY
+`;
+
+export function parseArgs(argv: readonly string[]): Args {
+  const args: Args = {
+    mode: "mock",
+    runs: 3,
+    timeoutMs: 30_000,
+    unsafeTranscripts: false,
+    enforceLiveGates: false,
+  };
+  for (const arg of argv) {
+    if (arg === "--help" || arg === "-h") {
+      process.stdout.write(HELP);
+      process.exit(0);
+    } else if (arg === "--mode=mock") args.mode = "mock";
+    else if (arg === "--mode=live") args.mode = "live";
+    else if (arg.startsWith("--runs=")) args.runs = positiveInt(arg, "--runs=");
+    else if (arg.startsWith("--out=")) args.out = arg.slice("--out=".length);
+    else if (arg.startsWith("--timeout-ms=")) {
+      args.timeoutMs = positiveInt(arg, "--timeout-ms=");
+    } else if (arg.startsWith("--audio-dir=")) {
+      args.audioDir = arg.slice("--audio-dir=".length);
+    } else if (arg === "--unsafe-transcripts") args.unsafeTranscripts = true;
+    else if (arg === "--enforce-live-gates") args.enforceLiveGates = true;
+    else throw new Error(`unknown argument: ${arg}`);
+  }
+  return args;
+}
+
+export async function runBenchmark(config: RunConfig) {
+  const corpus = loadCorpus();
+  const adapters =
+    config.mode === "live" ? createLiveAdapters() : createMockAdapters();
+  const results = [];
+  for (let runIndex = 0; runIndex < config.runs; runIndex++) {
+    for (const corpusCase of corpus) {
+      const traceId = makeTraceId(corpusCase.id, runIndex);
+      process.stdout.write(
+        `[${corpusCase.id}#${runIndex}] X-Eliza-Voice-Trace-Id=${traceId}\n`,
+      );
+      const result = await runTurn({
+        corpus: corpusCase,
+        runIndex,
+        traceId,
+        mode: config.mode,
+        stt: adapters.stt,
+        llm: adapters.llm,
+        tts: adapters.tts,
+        timeoutMs: config.timeoutMs,
+        unsafeTranscripts: config.unsafeTranscripts,
+        audioDir: config.audioDir,
+      });
+      results.push(result);
+    }
+  }
+  const report = buildReport({
+    generatedAt: config.nowIso(),
+    mode: config.mode,
+    providers: {
+      stt: adapters.stt.name,
+      llm: adapters.llm.name,
+      tts: adapters.tts.name,
+    },
+    results,
+    enforceGates: config.mode === "mock" || config.enforceLiveGates,
+  });
+  return config.unsafeTranscripts ? report : redactReport(report);
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const report = await runBenchmark({
+    mode: args.mode,
+    runs: args.runs,
+    outDir: args.out,
+    timeoutMs: args.timeoutMs,
+    unsafeTranscripts: args.unsafeTranscripts,
+    enforceLiveGates: args.enforceLiveGates,
+    audioDir: args.audioDir,
+    nowIso: () => new Date().toISOString(),
+  });
+  process.stdout.write(renderMarkdown(report));
+  if (args.out) {
+    const outDir = resolve(args.out);
+    mkdirSync(outDir, { recursive: true });
+    writeFileSync(resolve(outDir, "report.json"), renderJson(report), "utf8");
+    writeFileSync(resolve(outDir, "report.md"), renderMarkdown(report), "utf8");
+    process.stdout.write(`Wrote ${resolve(outDir, "report.json")}\n`);
+    process.stdout.write(`Wrote ${resolve(outDir, "report.md")}\n`);
+  }
+  if (!report.gates.passed) process.exitCode = 1;
+}
+
+function positiveInt(arg: string, prefix: string): number {
+  const value = Number.parseInt(arg.slice(prefix.length), 10);
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${prefix.slice(0, -1)} must be a positive integer`);
+  }
+  return value;
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    process.stderr.write(
+      `Fatal: ${error instanceof Error ? (error.stack ?? error.message) : String(error)}\n`,
+    );
+    process.exit(1);
+  });
+}

--- a/packages/benchmarks/voice-rtt/src/speakable.ts
+++ b/packages/benchmarks/voice-rtt/src/speakable.ts
@@ -1,0 +1,19 @@
+/**
+ * First-speakable-phrase detection for streaming LLM output.
+ *
+ * The benchmark starts TTS as soon as a short phrase boundary is available,
+ * matching voice-agent behavior where audio generation should not wait for the
+ * full assistant response.
+ */
+
+const PHRASE_BOUNDARY = /[.!?,;:](?:\s|$)|\n/;
+
+export function firstSpeakablePhrase(text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed) return "";
+  const boundary = trimmed.search(PHRASE_BOUNDARY);
+  if (boundary >= 0) return trimmed.slice(0, boundary + 1).trim();
+  const words = trimmed.split(/\s+/);
+  if (words.length >= 6) return words.slice(0, 6).join(" ");
+  return trimmed;
+}

--- a/packages/benchmarks/voice-rtt/src/trace.ts
+++ b/packages/benchmarks/voice-rtt/src/trace.ts
@@ -1,0 +1,53 @@
+/**
+ * Trace helpers for the PR #15931-compatible voice timing schema.
+ *
+ * Each benchmark turn carries an `X-Eliza-Voice-Trace-Id` value and a
+ * `Server-Timing`-style component list so local runs can be compared with the
+ * production voice route instrumentation without depending on those routes.
+ */
+
+import type {
+  CheckpointName,
+  ServerTimingComponent,
+  TraceCheckpoint,
+} from "./types.ts";
+
+export class TraceBuilder {
+  readonly traceId: string;
+  readonly checkpoints: TraceCheckpoint[] = [];
+  readonly serverTiming: ServerTimingComponent[] = [];
+
+  constructor(traceId: string) {
+    this.traceId = traceId;
+  }
+
+  mark(name: CheckpointName, atMs: number, provider?: string): void {
+    this.checkpoints.push({ name, atMs, provider });
+  }
+
+  timing(name: string, durMs: number, desc?: string): void {
+    this.serverTiming.push({ name, durMs, desc });
+  }
+
+  at(name: CheckpointName): number | null {
+    const checkpoint = this.checkpoints.find((entry) => entry.name === name);
+    return checkpoint ? checkpoint.atMs : null;
+  }
+}
+
+export function makeTraceId(caseId: string, runIndex: number): string {
+  return `voice-rtt-${caseId}-${runIndex}-${Date.now().toString(36)}`;
+}
+
+export function formatServerTiming(
+  components: readonly ServerTimingComponent[],
+): string {
+  return components
+    .map((component) => {
+      const dur = `dur=${Math.round(component.durMs * 1000) / 1000}`;
+      return component.desc
+        ? `${component.name};${dur};desc="${component.desc.replaceAll('"', "'")}"`
+        : `${component.name};${dur}`;
+    })
+    .join(", ");
+}

--- a/packages/benchmarks/voice-rtt/src/types.ts
+++ b/packages/benchmarks/voice-rtt/src/types.ts
@@ -1,0 +1,222 @@
+/**
+ * Shared contracts for the voice round-trip benchmark.
+ *
+ * The interfaces keep provider I/O separate from scoring so alternate STT,
+ * LLM, and TTS implementations can be dropped into the same trace schema
+ * without introducing an elizaOS runtime or changing production routes.
+ */
+
+export type BenchmarkMode = "mock" | "live";
+
+export type CorpusKind = "short" | "long" | "pause" | "barge-in";
+
+export type CheckpointName =
+  | "input_acoustic_end"
+  | "stt_eager_end"
+  | "stt_final"
+  | "chat_admission"
+  | "llm_preforward"
+  | "llm_first_text_token"
+  | "first_speakable_phrase"
+  | "tts_request"
+  | "tts_first_audio_frame"
+  | "client_playout_start"
+  | "interrupt"
+  | "playout_silence";
+
+export interface MockTimings {
+  sttEagerAfterInputEnd: number;
+  sttFinalAfterInputEnd: number;
+  llmFirstTokenAfterAdmission: number;
+  llmCompleteAfterAdmission: number;
+  ttsFirstAudioAfterRequest: number;
+  playoutBufferMs: number;
+  interruptSilenceAfterBargeIn?: number;
+}
+
+export interface CorpusCase {
+  id: string;
+  kind: CorpusKind;
+  transcript: string;
+  inputAudioMs: number;
+  pauseAfterMs: number;
+  expectedReply: string;
+  bargeInAtMs?: number;
+  bargeInTranscript?: string;
+  mockTimingsMs: MockTimings;
+  audio?: {
+    encoding: "linear16";
+    sampleRateHz: number;
+    base64: string;
+  };
+}
+
+export interface RunConfig {
+  mode: BenchmarkMode;
+  runs: number;
+  outDir?: string;
+  timeoutMs: number;
+  unsafeTranscripts: boolean;
+  enforceLiveGates: boolean;
+  audioDir?: string;
+  nowIso: () => string;
+}
+
+export interface TraceCheckpoint {
+  name: CheckpointName;
+  atMs: number;
+  provider?: string;
+}
+
+export interface ServerTimingComponent {
+  name: string;
+  durMs: number;
+  desc?: string;
+}
+
+export interface VoiceTrace {
+  traceId: string;
+  mode: BenchmarkMode;
+  caseId: string;
+  runIndex: number;
+  checkpoints: TraceCheckpoint[];
+  serverTiming: ServerTimingComponent[];
+  lengths: {
+    inputAudioMs: number;
+    transcriptChars: number;
+    replyChars: number;
+    firstSpeakablePhraseChars: number;
+    firstAudioBytes: number;
+  };
+  transcript?: string;
+  replyText?: string;
+  cancelled: boolean;
+  postInterruptAudioFrames: number;
+  providerRequestIds: Record<string, string>;
+  errors: string[];
+}
+
+export interface StageDurations {
+  acousticEndToSttEagerMs: number | null;
+  acousticEndToSttFinalMs: number | null;
+  sttFinalToChatAdmissionMs: number | null;
+  chatAdmissionToPreforwardMs: number | null;
+  preforwardToFirstTokenMs: number | null;
+  firstTokenToSpeakablePhraseMs: number | null;
+  speakablePhraseToTtsRequestMs: number | null;
+  ttsRequestToFirstAudioMs: number | null;
+  firstAudioToPlayoutMs: number | null;
+  eosToFirstAudioMs: number | null;
+  interruptToSilenceMs: number | null;
+}
+
+export interface CaseResult {
+  caseId: string;
+  kind: CorpusKind;
+  runIndex: number;
+  trace: VoiceTrace;
+  stages: StageDurations;
+}
+
+export interface PercentileSummary {
+  count: number;
+  min: number | null;
+  max: number | null;
+  mean: number | null;
+  p50: number | null;
+  p90: number | null;
+  p95: number | null;
+}
+
+export interface BenchmarkReport {
+  schemaVersion: 1;
+  generatedAt: string;
+  mode: BenchmarkMode;
+  providers: {
+    stt: string;
+    llm: string;
+    tts: string;
+  };
+  gates: {
+    enforced: boolean;
+    eosToFirstAudioP50TargetMs: number;
+    eosToFirstAudioP95TargetMs: number;
+    interruptToSilenceTargetMs: number;
+    passed: boolean;
+    failures: string[];
+  };
+  summaries: Record<keyof StageDurations, PercentileSummary>;
+  attribution: Array<{
+    stage: keyof StageDurations;
+    p50Ms: number;
+    share: number;
+  }>;
+  results: CaseResult[];
+}
+
+export interface SttResult {
+  transcript: string;
+  transcriptChars: number;
+  eagerEndAtMs: number;
+  finalAtMs: number;
+  requestId?: string;
+}
+
+export interface LlmToken {
+  text: string;
+  atMs: number;
+}
+
+export interface LlmResult {
+  replyText: string;
+  firstTokenAtMs: number;
+  completeAtMs: number;
+  tokens: LlmToken[];
+  requestId?: string;
+}
+
+export interface TtsFrame {
+  atMs: number;
+  bytes: number;
+}
+
+export interface TtsResult {
+  firstAudioAtMs: number;
+  frames: TtsFrame[];
+  cancelled: boolean;
+  requestId?: string;
+}
+
+export interface SttAdapter {
+  name: string;
+  transcribe(input: {
+    traceId: string;
+    corpus: CorpusCase;
+    signal: AbortSignal;
+    unsafeTranscripts: boolean;
+    audioDir?: string;
+  }): Promise<SttResult>;
+}
+
+export interface LlmAdapter {
+  name: string;
+  complete(input: {
+    traceId: string;
+    corpus: CorpusCase;
+    transcript: string;
+    admissionAtMs: number;
+    signal: AbortSignal;
+  }): Promise<LlmResult>;
+}
+
+export interface TtsAdapter {
+  name: string;
+  synthesize(input: {
+    traceId: string;
+    corpus: CorpusCase;
+    text: string;
+    requestAtMs: number;
+    signal: AbortSignal;
+    onAudioFrame(frame: TtsFrame): boolean;
+  }): Promise<TtsResult>;
+}

--- a/packages/benchmarks/voice-rtt/tests/corpus.test.ts
+++ b/packages/benchmarks/voice-rtt/tests/corpus.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Corpus tests keep the fixed voice RTT fixture stable across CI and live runs.
+ */
+
+import { describe, expect, it } from "vitest";
+import { loadCorpus } from "../src/corpus.ts";
+
+describe("corpus", () => {
+  it("contains short, long, pause, and barge-in cases", () => {
+    const corpus = loadCorpus();
+    expect(corpus.map((entry) => entry.kind).sort()).toEqual([
+      "barge-in",
+      "long",
+      "pause",
+      "short",
+    ]);
+  });
+
+  it("defines deterministic mock timings for each case", () => {
+    for (const entry of loadCorpus()) {
+      expect(entry.mockTimingsMs.sttFinalAfterInputEnd).toBeGreaterThan(0);
+      expect(entry.mockTimingsMs.llmFirstTokenAfterAdmission).toBeGreaterThan(
+        0,
+      );
+      expect(entry.mockTimingsMs.ttsFirstAudioAfterRequest).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/benchmarks/voice-rtt/tests/metrics.test.ts
+++ b/packages/benchmarks/voice-rtt/tests/metrics.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Deterministic checks for voice RTT percentile, attribution, and gate math.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  evaluateGates,
+  percentile,
+  stageAttribution,
+  summarize,
+} from "../src/metrics.ts";
+import type { CaseResult, StageDurations } from "../src/types.ts";
+
+describe("metrics", () => {
+  it("uses nearest-rank percentiles", () => {
+    expect(percentile([400, 100, 300, 200], 50)).toBe(200);
+    expect(percentile([400, 100, 300, 200], 90)).toBe(400);
+    expect(percentile([400, 100, 300, 200], 95)).toBe(400);
+    expect(percentile([], 50)).toBeNull();
+  });
+
+  it("keeps missing measurements out of summaries", () => {
+    expect(summarize([10, null, 30])).toMatchObject({
+      count: 2,
+      min: 10,
+      max: 30,
+      mean: 20,
+      p50: 10,
+      p90: 30,
+      p95: 30,
+    });
+  });
+
+  it("sorts p50 stage attribution by contribution", () => {
+    const summaries = Object.fromEntries(
+      stageKeys.map((stage) => [
+        stage,
+        {
+          count: 1,
+          min: 1,
+          max: 1,
+          mean: 1,
+          p50: stage === "ttsRequestToFirstAudioMs" ? 200 : 10,
+          p90: 1,
+          p95: 1,
+        },
+      ]),
+    ) as Record<keyof StageDurations, ReturnType<typeof summarize>>;
+    expect(stageAttribution(summaries)[0]).toMatchObject({
+      stage: "ttsRequestToFirstAudioMs",
+      p50Ms: 200,
+    });
+  });
+
+  it("omits missing measurements from stage attribution", () => {
+    const summaries = Object.fromEntries(
+      stageKeys.map((stage) => [stage, summarize([10])]),
+    ) as Record<keyof StageDurations, ReturnType<typeof summarize>>;
+    summaries.preforwardToFirstTokenMs = summarize([null]);
+
+    expect(
+      stageAttribution(summaries).map((entry) => entry.stage),
+    ).not.toContain("preforwardToFirstTokenMs");
+  });
+
+  it("enforces mock gates and leaves advisory live gates passable", () => {
+    const summaries = Object.fromEntries(
+      stageKeys.map((stage) => [
+        stage,
+        {
+          count: 1,
+          min: 0,
+          max: 0,
+          mean: 0,
+          p50: stage === "eosToFirstAudioMs" ? 1200 : 0,
+          p90: stage === "eosToFirstAudioMs" ? 1600 : 0,
+          p95: stage === "eosToFirstAudioMs" ? 1600 : 0,
+        },
+      ]),
+    ) as Record<keyof StageDurations, ReturnType<typeof summarize>>;
+    const results: CaseResult[] = [];
+    expect(evaluateGates({ summaries, results, enforced: true }).passed).toBe(
+      false,
+    );
+    expect(evaluateGates({ summaries, results, enforced: false }).passed).toBe(
+      true,
+    );
+  });
+
+  it("fails equality against strict latency targets", () => {
+    const summaries = Object.fromEntries(
+      stageKeys.map((stage) => [
+        stage,
+        {
+          count: 1,
+          min: stage === "eosToFirstAudioMs" ? 1000 : 0,
+          max: stage === "eosToFirstAudioMs" ? 1500 : 0,
+          mean: 0,
+          p50: stage === "eosToFirstAudioMs" ? 1000 : 0,
+          p90: stage === "eosToFirstAudioMs" ? 1500 : 0,
+          p95: stage === "eosToFirstAudioMs" ? 1500 : 0,
+        },
+      ]),
+    ) as Record<keyof StageDurations, ReturnType<typeof summarize>>;
+    const results: CaseResult[] = [
+      {
+        caseId: "barge-in",
+        kind: "barge-in",
+        runIndex: 0,
+        trace: {
+          traceId: "trace",
+          mode: "mock",
+          caseId: "barge-in",
+          runIndex: 0,
+          checkpoints: [],
+          serverTiming: [],
+          lengths: {
+            inputAudioMs: 0,
+            transcriptChars: 0,
+            replyChars: 0,
+            firstSpeakablePhraseChars: 0,
+            firstAudioBytes: 0,
+          },
+          cancelled: true,
+          postInterruptAudioFrames: 0,
+          providerRequestIds: {},
+          errors: [],
+        },
+        stages: {
+          acousticEndToSttEagerMs: 0,
+          acousticEndToSttFinalMs: 0,
+          sttFinalToChatAdmissionMs: 0,
+          chatAdmissionToPreforwardMs: 0,
+          preforwardToFirstTokenMs: 0,
+          firstTokenToSpeakablePhraseMs: 0,
+          speakablePhraseToTtsRequestMs: 0,
+          ttsRequestToFirstAudioMs: 0,
+          firstAudioToPlayoutMs: 0,
+          eosToFirstAudioMs: 1000,
+          interruptToSilenceMs: 300,
+        },
+      },
+    ];
+    const gates = evaluateGates({ summaries, results, enforced: true });
+
+    expect(gates.passed).toBe(false);
+    expect(gates.failures).toEqual(
+      expect.arrayContaining([
+        "EOS to first audio P50 1000ms must be less than 1000ms",
+        "EOS to first audio P95 1500ms must be less than 1500ms",
+        "interruption to silence 300ms must be less than 300ms",
+      ]),
+    );
+  });
+});
+
+const stageKeys: Array<keyof StageDurations> = [
+  "acousticEndToSttEagerMs",
+  "acousticEndToSttFinalMs",
+  "sttFinalToChatAdmissionMs",
+  "chatAdmissionToPreforwardMs",
+  "preforwardToFirstTokenMs",
+  "firstTokenToSpeakablePhraseMs",
+  "speakablePhraseToTtsRequestMs",
+  "ttsRequestToFirstAudioMs",
+  "firstAudioToPlayoutMs",
+  "eosToFirstAudioMs",
+  "interruptToSilenceMs",
+];

--- a/packages/benchmarks/voice-rtt/tests/report.test.ts
+++ b/packages/benchmarks/voice-rtt/tests/report.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Report tests verify artifact redaction and human-readable gate output.
+ */
+
+import { describe, expect, it } from "vitest";
+import { createMockAdapters } from "../src/adapters/mock.ts";
+import { loadCorpus } from "../src/corpus.ts";
+import {
+  buildReport,
+  redactReport,
+  renderJson,
+  renderMarkdown,
+} from "../src/report.ts";
+import { runTurn } from "../src/run-turn.ts";
+
+describe("reports", () => {
+  it("redacts transcripts and replies by default", async () => {
+    const adapters = createMockAdapters();
+    const result = await runTurn({
+      corpus: loadCorpus()[0],
+      runIndex: 0,
+      traceId: "trace-redaction",
+      mode: "mock",
+      stt: adapters.stt,
+      llm: adapters.llm,
+      tts: adapters.tts,
+      timeoutMs: 1000,
+      unsafeTranscripts: true,
+    });
+    const report = buildReport({
+      generatedAt: "2026-07-10T00:00:00.000Z",
+      mode: "mock",
+      providers: {
+        stt: adapters.stt.name,
+        llm: adapters.llm.name,
+        tts: adapters.tts.name,
+      },
+      results: [result],
+      enforceGates: true,
+    });
+    const redacted = redactReport(report);
+    const json = renderJson(redacted);
+    expect(json).not.toContain(loadCorpus()[0].transcript);
+    expect(json).not.toContain(loadCorpus()[0].expectedReply);
+    expect(json).toContain("transcriptChars");
+    expect(renderMarkdown(redacted)).toContain("Voice RTT Benchmark Report");
+  });
+});

--- a/packages/benchmarks/voice-rtt/tests/run-turn.test.ts
+++ b/packages/benchmarks/voice-rtt/tests/run-turn.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Focused cancellation checks for the one-turn voice RTT harness.
+ *
+ * The TTS adapters here emit virtual timestamped frames synchronously so the
+ * tests can prove active-stream cancellation without adding CI wall time.
+ */
+
+import { describe, expect, it } from "vitest";
+import { createMockAdapters } from "../src/adapters/mock.ts";
+import { loadCorpus } from "../src/corpus.ts";
+import { buildReport } from "../src/report.ts";
+import { runTurn } from "../src/run-turn.ts";
+import type {
+  CaseResult,
+  CorpusCase,
+  TtsAdapter,
+  TtsFrame,
+} from "../src/types.ts";
+
+describe("runTurn TTS cancellation", () => {
+  it("cancels active synthesis when the observed frame clock reaches barge-in", async () => {
+    const corpus = bargeInCorpus();
+    let emittedFrames = 0;
+    const tts = createDeterministicTts({
+      frameCount: 32,
+      onEmit() {
+        emittedFrames++;
+      },
+    });
+
+    const result = await runBargeTurn(corpus, tts);
+
+    expect(result.trace.cancelled).toBe(true);
+    expect(result.trace.postInterruptAudioFrames).toBe(0);
+    expect(result.stages.interruptToSilenceMs).toBe(184);
+    expect(emittedFrames).toBeLessThan(32);
+  });
+
+  it("fails gates when a noncompliant adapter emits frames after playout silence", async () => {
+    const corpus = bargeInCorpus();
+    const result = await runBargeTurn(
+      corpus,
+      createDeterministicTts({ frameCount: 40, ignoreCancellation: true }),
+    );
+    const report = reportFor([result]);
+
+    expect(result.trace.cancelled).toBe(true);
+    expect(result.trace.postInterruptAudioFrames).toBeGreaterThan(0);
+    expect(report.gates.passed).toBe(false);
+    expect(report.gates.failures).toContain(
+      "barge-in run 0 emitted 18 audio frame(s) after interrupt silence",
+    );
+  });
+
+  it("fails gates when TTS finishes before the scheduled barge-in interrupt", async () => {
+    const result = await runBargeTurn(
+      bargeInCorpus(),
+      createDeterministicTts({ frameCount: 2 }),
+    );
+    const report = reportFor([result]);
+
+    expect(result.trace.cancelled).toBe(false);
+    expect(report.gates.passed).toBe(false);
+    expect(report.gates.failures).toContain(
+      "barge-in run 0 did not cancel active TTS during barge-in",
+    );
+  });
+});
+
+function createDeterministicTts(options: {
+  frameCount: number;
+  ignoreCancellation?: boolean;
+  onEmit?: (frame: TtsFrame) => void;
+}): TtsAdapter {
+  return {
+    name: "deterministic-tts",
+    async synthesize({ corpus, requestAtMs, onAudioFrame }) {
+      const firstAudioAtMs =
+        requestAtMs + corpus.mockTimingsMs.ttsFirstAudioAfterRequest;
+      const frames: TtsFrame[] = [];
+      let cancelled = false;
+      for (let index = 0; index < options.frameCount; index++) {
+        const frame = {
+          atMs: firstAudioAtMs + index * 40,
+          bytes: 640,
+        };
+        options.onEmit?.(frame);
+        const shouldContinue = onAudioFrame(frame);
+        if (!shouldContinue) {
+          cancelled = true;
+          if (!options.ignoreCancellation) break;
+          continue;
+        }
+        frames.push(frame);
+      }
+      return {
+        firstAudioAtMs,
+        frames,
+        cancelled,
+        requestId: "deterministic-tts",
+      };
+    },
+  };
+}
+
+async function runBargeTurn(
+  corpus: CorpusCase,
+  tts: TtsAdapter,
+): Promise<CaseResult> {
+  const adapters = createMockAdapters();
+  return runTurn({
+    corpus,
+    runIndex: 0,
+    traceId: "trace-barge-in-0",
+    mode: "mock",
+    stt: adapters.stt,
+    llm: adapters.llm,
+    tts,
+    timeoutMs: 1000,
+    unsafeTranscripts: false,
+  });
+}
+
+function reportFor(results: CaseResult[]) {
+  return buildReport({
+    generatedAt: "2026-07-10T00:00:00.000Z",
+    mode: "mock",
+    providers: {
+      stt: "mock",
+      llm: "mock",
+      tts: "test",
+    },
+    results,
+    enforceGates: true,
+  });
+}
+
+function bargeInCorpus(): CorpusCase {
+  const corpus = loadCorpus().find((entry) => entry.kind === "barge-in");
+  if (!corpus) throw new Error("barge-in corpus missing");
+  return corpus;
+}

--- a/packages/benchmarks/voice-rtt/tests/runner.test.ts
+++ b/packages/benchmarks/voice-rtt/tests/runner.test.ts
@@ -1,0 +1,44 @@
+/**
+ * End-to-end mock runner tests for the voice RTT harness.
+ */
+
+import { describe, expect, it } from "vitest";
+import { runBenchmark } from "../src/runner.ts";
+
+describe("mock benchmark", () => {
+  it("runs deterministically, passes gates, and records cancellation", async () => {
+    const first = await runBenchmark({
+      mode: "mock",
+      runs: 1,
+      timeoutMs: 1000,
+      unsafeTranscripts: false,
+      enforceLiveGates: false,
+      nowIso: () => "2026-07-10T00:00:00.000Z",
+    });
+    const second = await runBenchmark({
+      mode: "mock",
+      runs: 1,
+      timeoutMs: 1000,
+      unsafeTranscripts: false,
+      enforceLiveGates: false,
+      nowIso: () => "2026-07-10T00:00:00.000Z",
+    });
+    const normalize = (value: typeof first) =>
+      value.results.map((result) => ({
+        caseId: result.caseId,
+        stages: result.stages,
+        cancelled: result.trace.cancelled,
+        postInterruptAudioFrames: result.trace.postInterruptAudioFrames,
+      }));
+    expect(normalize(first)).toEqual(normalize(second));
+    expect(first.gates.passed).toBe(true);
+    const bargeIn = first.results.find((result) => result.kind === "barge-in");
+    expect(bargeIn?.trace.cancelled).toBe(true);
+    expect(bargeIn?.trace.postInterruptAudioFrames).toBe(0);
+    expect(bargeIn?.stages.interruptToSilenceMs).toBeLessThan(300);
+    for (const result of first.results) {
+      expect(result.trace.transcript).toBeUndefined();
+      expect(result.trace.replyText).toBeUndefined();
+    }
+  });
+});

--- a/packages/benchmarks/voice-rtt/tests/speakable.test.ts
+++ b/packages/benchmarks/voice-rtt/tests/speakable.test.ts
@@ -1,0 +1,20 @@
+/**
+ * Speakable phrase boundary tests keep streaming TTS input complete but early.
+ */
+
+import { describe, expect, it } from "vitest";
+import { firstSpeakablePhrase } from "../src/speakable.ts";
+
+describe("firstSpeakablePhrase", () => {
+  it("keeps a complete sentence when punctuation terminates the input", () => {
+    expect(
+      firstSpeakablePhrase("Your next calendar item is the product sync."),
+    ).toBe("Your next calendar item is the product sync.");
+  });
+
+  it("cuts at the first terminal boundary in a longer stream", () => {
+    expect(firstSpeakablePhrase("First sentence. Second sentence.")).toBe(
+      "First sentence.",
+    );
+  });
+});

--- a/packages/benchmarks/voice-rtt/tsconfig.json
+++ b/packages/benchmarks/voice-rtt/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "types": ["node"],
+    "lib": ["ES2022", "DOM"]
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts", "fixtures/**/*.json"]
+}


### PR DESCRIPTION
## Summary

- adds a provider-agnostic `packages/benchmarks/voice-rtt` harness for Deepgram Flux -> Cerebras `gemma-4-31b` -> Cartesia Sonic 3.5 without adding a new runtime or touching production routes/UI
- records acoustic end, eager/final STT, chat admission, Cerebras preforward, first token, first speakable phrase, Cartesia request, first audio, playout, interrupt, and silence checkpoints in the #15931-compatible trace shape
- emits redacted JSON plus human Markdown artifacts with P50/P90/P95, non-overlapping critical-path attribution, provider request IDs, and enforced/advisory gates
- includes deterministic short/long/pause/barge-in mock corpus, in-flight TTS cancellation, no-post-interrupt-audio assertions, and opt-in live adapters behind the three provider API keys
- registers the benchmark workspace and lockfile metadata; adapter interfaces remain reusable for future OpenRouter/provider lanes

## Gates

Mock mode enforces:

- EOS -> first audio P50 `< 1000ms`
- EOS -> first audio P95 `< 1500ms`
- interrupt -> silence `< 300ms`
- zero post-silence audio frames

Live gates remain advisory by default until a baseline is established.

## Validation

- `bun test packages/benchmarks/voice-rtt/tests/*.test.ts` (15 passing)
- `bunx @typescript/native-preview --noEmit -p packages/benchmarks/voice-rtt/tsconfig.json` (passing with the sparse-worktree type roots available)
- `bunx @biomejs/biome check packages/benchmarks/voice-rtt package.json bun.lock`
- mock benchmark, 3 runs per corpus case, JSON + Markdown artifacts, gates PASS
- Codex `review --uncommitted`, final result: no actionable issues

Live provider calls were not run because `DEEPGRAM_API_KEY`, `CEREBRAS_API_KEY`, and `CARTESIA_API_KEY` are not present in this worker environment.

[sol-cloud]


## Evidence

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - benchmark-only package with no rendered UI changes.

<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - benchmark-only package with no rendered UI changes.

<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - command-line benchmark behavior is covered by the mock run receipt above.

<!-- evidence-row:backend-logs -->
- Backend logs: N/A - no production backend route or service is modified or invoked in deterministic mode.

<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A - no frontend files or browser behavior changed.

<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: N/A - live provider execution is intentionally opt-in and this worker has none of the three provider keys; deterministic provider adapters cover CI.

<!-- evidence-row:domain-artifacts -->
- Domain artifacts: N/A - JSON and Markdown benchmark reports are generated locally and reproducibly by the documented `--out` command, with no persistent domain state.
