### PR TITLE
fix(core): deliver grammar-valid [FORM]/clarify replies on missing-input turns — terminal-continuation relay + FINISH precedence (#15918)

### DIFF
--- a/packages/core/src/runtime/__tests__/planner-loop-terminal-continuation-form-relay.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-terminal-continuation-form-relay.test.ts
@@ -1,9 +1,11 @@
 /**
- * Covers terminal-continuation recovery for missing-input turns whose real
- * reply is the PLANNER's own terminal output — a grammar-valid [FORM] or a
- * user-directed prose ask — rather than a structurally-marked tool result
- * (#15918). Deterministic: vitest-mocked `useModel` + injected evaluator
- * replaying the live gpt-oss-120b rule-19 CONTINUE-loop shapes; no live model.
+ * Covers missing-input turns whose real reply is the MODEL's own output — a
+ * grammar-valid [FORM] or a user-directed prose ask — rather than a
+ * structurally-marked tool result (#15918): terminal-continuation-limit
+ * recovery when the evaluator CONTINUE-loops past rule 19, and final-message
+ * precedence when it FINISHes with a widget reply the confirmation-question
+ * relay used to drop. Deterministic: vitest-mocked `useModel` + injected
+ * evaluator replaying the live gpt-oss-120b trajectory shapes; no live model.
  */
 import { describe, expect, it, vi } from "vitest";
 import type { TrajectoryLimitExceeded } from "../limits";
@@ -196,6 +198,75 @@ describe("planner-loop - terminal continuation [FORM]/ask relay (#15918)", () =>
 		).rejects.toMatchObject({
 			kind: "terminal_only_continuations",
 		} satisfies Partial<TrajectoryLimitExceeded>);
+	});
+
+	it("delivers a FINISH [FORM] reply over the tool's missing-input confirmation question", async () => {
+		// Live 5-run shape on current develop: the evaluator honors rule 19 and
+		// FINISHes with a grammar-valid [FORM] in messageToUser, but the final-
+		// message precedence used to drop it for the tool's requiresConfirmation
+		// prose question.
+		const formFinish = `I can set that up — details below:\n${FORM_REPLY}`;
+		const runtime = plannerEmitsToolCallThenTerminalTexts([]);
+		const executeToolCall = vi.fn(async () => ({
+			success: false,
+			text: "Sure! Please tell me the report name, the day, and the time you'd like the reminder.",
+			data: {
+				error: "MISSING_DEFINITION_FIELD",
+				missingField: "schedule",
+				requiresConfirmation: true,
+			},
+		}));
+		const evaluate = vi.fn(async () => ({
+			success: false,
+			decision: "FINISH" as const,
+			thought: "Missing input; surface the collection form.",
+			messageToUser: formFinish,
+		}));
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			executeToolCall,
+			evaluate,
+		});
+
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBe(formFinish);
+	});
+
+	it("keeps a lifeDraft confirm preview ahead of a widget FINISH reply", async () => {
+		// Action-owned draft-confirm copy must reach the user verbatim so they
+		// approve the exact draft — a FORM must not displace it into a re-ask.
+		const preview =
+			"I can save this as a goal. Success looks like walking three times a week. Confirm and I'll save it.";
+		const runtime = plannerEmitsToolCallThenTerminalTexts([]);
+		const executeToolCall = vi.fn(async () => ({
+			success: false,
+			text: preview,
+			data: {
+				requiresConfirmation: true,
+				lifeDraft: {
+					operation: "create_goal",
+					request: { title: "Leave the apartment more" },
+				},
+			},
+		}));
+		const evaluate = vi.fn(async () => ({
+			success: false,
+			decision: "FINISH" as const,
+			thought: "Draft ready; asking for confirmation.",
+			messageToUser: `Fill this in to confirm:\n${FORM_REPLY}`,
+		}));
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			executeToolCall,
+			evaluate,
+		});
+
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBe(preview);
 	});
 
 	it("keeps the structured tool-result relays ahead of the prose ask", async () => {

--- a/packages/core/src/runtime/__tests__/planner-loop-terminal-continuation-form-relay.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-terminal-continuation-form-relay.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Covers terminal-continuation recovery for missing-input turns whose real
+ * reply is the PLANNER's own terminal output — a grammar-valid [FORM] or a
+ * user-directed prose ask — rather than a structurally-marked tool result
+ * (#15918). Deterministic: vitest-mocked `useModel` + injected evaluator
+ * replaying the live gpt-oss-120b rule-19 CONTINUE-loop shapes; no live model.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { TrajectoryLimitExceeded } from "../limits";
+import { runPlannerLoop } from "../planner-loop";
+
+// Grammar-valid [FORM] mirroring the live run-4 planner terminal output: the
+// form that collects exactly the fields the clarify tool asked for.
+const FORM_REPLY = [
+	"Happy to set that reminder — fill this in:",
+	"[FORM]",
+	'{"title":"Create Reminder","submitLabel":"Create","fields":[{"name":"title","type":"text","label":"Report Name","required":true},{"name":"date","type":"date","label":"Date","required":true},{"name":"time","type":"time","label":"Time","required":true}]}',
+	"[/FORM]",
+].join("\n");
+
+const PROSE_ASK =
+	"I'm ready to set the reminder. Please provide the report name, the date, and the time you'd like to be reminded.";
+
+// Success-shaped, marker-less clarify result — the live OWNER_REMINDERS
+// empty-args shape: user-directed question in `.text`, no `userFacingText`,
+// no requiresConfirmation/awaitingUserInput/noop marker.
+const MARKERLESS_CLARIFY_RESULT = {
+	success: true,
+	text: "Sure! Please tell me the report name, the date, and the time you'd like to be reminded.",
+	data: { actionName: "OWNER_REMINDERS" },
+};
+
+function plannerEmitsToolCallThenTerminalTexts(terminalTexts: string[]) {
+	let useModel = vi.fn().mockResolvedValueOnce({
+		text: "",
+		toolCalls: [
+			{
+				id: "call-1",
+				name: "OWNER_REMINDERS",
+				arguments: { action: "create" },
+			},
+		],
+		usage: { promptTokens: 100, completionTokens: 10, totalTokens: 110 },
+	});
+	for (const text of terminalTexts) {
+		useModel = useModel.mockResolvedValueOnce({
+			text,
+			usage: { promptTokens: 100, completionTokens: 10, totalTokens: 110 },
+		});
+	}
+	return { useModel };
+}
+
+// The live failure shape: the evaluator ignores its own missing-input=>FINISH
+// rule and keeps burning terminal-only continuations.
+function evaluatorContinueLoops() {
+	return vi.fn(async () => ({
+		success: false,
+		decision: "CONTINUE" as const,
+		thought:
+			"Awaiting user to provide report name, date, and time to create the reminder.",
+	}));
+}
+
+describe("planner-loop - terminal continuation [FORM]/ask relay (#15918)", () => {
+	it("relays the planner's grammar-valid [FORM] when the evaluator CONTINUE-loops past it (live run-4 shape)", async () => {
+		// Trajectory: marker-less clarify tool result → planner [FORM] → CONTINUE
+		// → planner prose → CONTINUE → limit. The FORM emitted two iterations
+		// before the limit must be found by the reverse scan.
+		const runtime = plannerEmitsToolCallThenTerminalTexts([
+			FORM_REPLY,
+			PROSE_ASK,
+		]);
+		const executeToolCall = vi.fn(async () => MARKERLESS_CLARIFY_RESULT);
+		const evaluate = evaluatorContinueLoops();
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			config: { maxTerminalOnlyContinuations: 1 },
+			executeToolCall,
+			evaluate,
+		});
+
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBe(FORM_REPLY);
+		expect(executeToolCall).toHaveBeenCalledTimes(1);
+		expect(evaluate).toHaveBeenCalledTimes(3);
+		expect(runtime.useModel).toHaveBeenCalledTimes(3);
+	});
+
+	it("prefers the planner's [FORM] over a confirmation-required tool question (live run-1 shape)", async () => {
+		// The tool's requiresConfirmation prose question is what the FORM
+		// refines — relaying the question instead of the form discards the
+		// model's actual reply.
+		const runtime = plannerEmitsToolCallThenTerminalTexts([FORM_REPLY]);
+		const executeToolCall = vi.fn(async () => ({
+			success: false,
+			text: "Sure! Could you tell me the report name, the day, and the time you'd like the reminder?",
+			data: {
+				error: "MISSING_DEFINITION_FIELD",
+				requiresConfirmation: true,
+			},
+		}));
+		const evaluate = evaluatorContinueLoops();
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			config: { maxTerminalOnlyContinuations: 0 },
+			executeToolCall,
+			evaluate,
+		});
+
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBe(FORM_REPLY);
+	});
+
+	it("relays the planner's user-directed prose ask when the clarify result carries no structured marker (live run-5 shape)", async () => {
+		const runtime = plannerEmitsToolCallThenTerminalTexts([PROSE_ASK]);
+		const executeToolCall = vi.fn(async () => MARKERLESS_CLARIFY_RESULT);
+		const evaluate = evaluatorContinueLoops();
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			config: { maxTerminalOnlyContinuations: 0 },
+			executeToolCall,
+			evaluate,
+		});
+
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBe(PROSE_ASK);
+	});
+
+	it("relays a trailing-question ask only when it addresses the user", async () => {
+		const runtime = plannerEmitsToolCallThenTerminalTexts([
+			"What time would you like the reminder?",
+		]);
+		const executeToolCall = vi.fn(async () => MARKERLESS_CLARIFY_RESULT);
+		const evaluate = evaluatorContinueLoops();
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			config: { maxTerminalOnlyContinuations: 0 },
+			executeToolCall,
+			evaluate,
+		});
+
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBe("What time would you like the reminder?");
+	});
+
+	it("still throws when the terminal text is deliberation, not a user-directed ask", async () => {
+		for (const deliberation of [
+			"We should wait for the sub-agent result before replying.",
+			"Which tool should I use for reminders?",
+		]) {
+			const runtime = plannerEmitsToolCallThenTerminalTexts([deliberation]);
+			const executeToolCall = vi.fn(async () => MARKERLESS_CLARIFY_RESULT);
+			const evaluate = evaluatorContinueLoops();
+
+			await expect(
+				runPlannerLoop({
+					runtime,
+					context: { id: "ctx" },
+					config: { maxTerminalOnlyContinuations: 0 },
+					executeToolCall,
+					evaluate,
+				}),
+			).rejects.toMatchObject({
+				kind: "terminal_only_continuations",
+			} satisfies Partial<TrajectoryLimitExceeded>);
+		}
+	});
+
+	it("does not relay a malformed widget block through the prose-ask side door", async () => {
+		// The strict parse yields zero blocks for this text, so it is not a
+		// widget candidate; the ask gate must not ship the broken markup as
+		// prose either, despite the ask marker.
+		const runtime = plannerEmitsToolCallThenTerminalTexts([
+			"Please provide a time below.\n[FORM]\nnot-json\n[/FORM]",
+		]);
+		const executeToolCall = vi.fn(async () => MARKERLESS_CLARIFY_RESULT);
+		const evaluate = evaluatorContinueLoops();
+
+		await expect(
+			runPlannerLoop({
+				runtime,
+				context: { id: "ctx" },
+				config: { maxTerminalOnlyContinuations: 0 },
+				executeToolCall,
+				evaluate,
+			}),
+		).rejects.toMatchObject({
+			kind: "terminal_only_continuations",
+		} satisfies Partial<TrajectoryLimitExceeded>);
+	});
+
+	it("keeps the structured tool-result relays ahead of the prose ask", async () => {
+		// A noop-marked clarification is a designed shape; the weaker prose-ask
+		// heuristic must not preempt it.
+		const clarification =
+			"Which deadline should I use before I create that reminder?";
+		const runtime = plannerEmitsToolCallThenTerminalTexts([PROSE_ASK]);
+		const executeToolCall = vi.fn(async () => ({
+			success: true,
+			text: clarification,
+			data: { noop: true },
+		}));
+		const evaluate = evaluatorContinueLoops();
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			config: { maxTerminalOnlyContinuations: 0 },
+			executeToolCall,
+			evaluate,
+		});
+
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBe(clarification);
+	});
+});

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -548,7 +548,7 @@ export async function runPlannerLoop(
 									maxTerminalOnlyContinuations:
 										config.maxTerminalOnlyContinuations,
 								},
-								"[planner-loop] terminal-only continuation limit reached; relaying the completed tool result instead of discarding the turn",
+								"[planner-loop] terminal-only continuation limit reached; relaying the turn's best user-safe reply instead of discarding it",
 							);
 							return {
 								status: "finished",
@@ -3022,14 +3022,57 @@ function deterministicSuccessfulToolRelay(
 	return undefined;
 }
 
+/**
+ * Deterministic (no model call) recovery at the terminal-only-continuation
+ * limit: the evaluator kept answering CONTINUE while the planner produced only
+ * terminal text, so the loop is about to throw and the caller would surface a
+ * synthetic apology. Before that, surface the best reply the turn ALREADY
+ * produced. Precedence (#15918):
+ *
+ *   1. The latest grammar-valid widget reply ([FORM]/[CHOICE]/…) the planner
+ *      emitted as terminal output. A parse-valid widget that collects the
+ *      missing input is the model's actual reply — strictly better than the
+ *      tool question it refines — and the strict block parser authenticates
+ *      it (a pre-tool thought never contains a parse-valid block).
+ *   2. Tool-result relays (opt-in `userFacingText`, confirmation-required
+ *      preview, noop clarification) — structurally-marked, designed shapes.
+ *   3. The latest user-DIRECTED terminal ask ("Please provide…", "…would you
+ *      like?") — last resort for marker-less clarify turns where neither the
+ *      tool result nor the planner produced a structured shape (live
+ *      gpt-oss-120b runs crashed exactly here, discarding the model's ask).
+ */
 function deterministicTerminalContinuationLimitRelay(
 	trajectory: PlannerTrajectory,
 ): string | undefined {
 	return (
+		deterministicTerminalWidgetReplyRelay(trajectory) ??
 		deterministicSuccessfulToolRelay(trajectory) ??
 		deterministicRequiresConfirmationRelay(trajectory) ??
-		deterministicNoopClarificationRelay(trajectory)
+		deterministicNoopClarificationRelay(trajectory) ??
+		deterministicTerminalMissingInputAskRelay(trajectory)
 	);
+}
+
+function deterministicTerminalWidgetReplyRelay(
+	trajectory: PlannerTrajectory,
+): string | undefined {
+	for (const step of [...trajectory.steps].reverse()) {
+		if (!step.terminalOnly) continue;
+		const candidate = userSafeWidgetReplyCandidate(step.terminalMessage);
+		if (candidate) return candidate;
+	}
+	return undefined;
+}
+
+function deterministicTerminalMissingInputAskRelay(
+	trajectory: PlannerTrajectory,
+): string | undefined {
+	for (const step of [...trajectory.steps].reverse()) {
+		if (!step.terminalOnly) continue;
+		const candidate = userSafeMissingInputAskCandidate(step.terminalMessage);
+		if (candidate) return candidate;
+	}
+	return undefined;
 }
 
 function deterministicRequiresConfirmationRelay(
@@ -3765,6 +3808,59 @@ function userSafeWidgetReplyCandidate(
 	const candidate = sanitizePlannerMessage(message);
 	if (!candidate) return undefined;
 	if (parseInteractionBlocks(candidate).blocks.length === 0) return undefined;
+	if (isUnsafeUserVisibleText(candidate)) return undefined;
+	if (looksLikePreToolThought(candidate)) return undefined;
+	if (WIDGET_REPLY_IN_FLIGHT_CLAIM.some((pattern) => pattern.test(candidate))) {
+		return undefined;
+	}
+	return candidate;
+}
+
+// Positive markers that a terminal text is a user-DIRECTED request for input —
+// the only prose shape the terminal-continuation limit may relay. An allowlist
+// in the REFUSAL_MARKERS mold: deliberation narration ("We should wait for the
+// sub-agent result before replying.") carries none of these, and a trailing
+// "?" only qualifies when the sentence addresses the user ("What time would
+// you like…?"), so a self-directed planning question ("Which tool should I
+// use?") never ships.
+const USER_DIRECTED_ASK_MARKERS = [
+	/\bplease\s+(?:provide|share|tell|give|send|specify|confirm|enter|choose|pick|select|reply|clarify|include|upload|attach)\b/i,
+	/\b(?:could|can|would)\s+you\b/i,
+	/\btell me\b/i,
+	/\blet me know\b/i,
+];
+
+function isUserDirectedAsk(text: string): boolean {
+	if (USER_DIRECTED_ASK_MARKERS.some((pattern) => pattern.test(text))) {
+		return true;
+	}
+	return /\?\s*$/.test(text) && /\byour?\b/i.test(text);
+}
+
+// Any widget wire-marker token, open or close, valid or not. Used to keep
+// widget-bearing text out of the prose-ask relay below.
+const WIDGET_MARKER_TOKEN =
+	/\[\/?(?:FORM\]|CHOICE[:\]]|FOLLOWUPS[\s\]]|TASK[:\]])/;
+
+// Missing-input ask gate for the terminal-continuation limit (#15918). When a
+// missing-input turn produces neither a structured tool shape (userFacingText /
+// requiresConfirmation / noop) nor a widget block, the planner's own prose ask
+// ("Please provide the report name, the date, and the time…") is the turn's
+// real reply — discarding it throws TrajectoryLimitExceeded and ships a
+// synthetic apology. Requires a POSITIVE user-directed-ask marker, then applies
+// the same safety rejects as the widget gate. Uses the widget variant of the
+// in-flight reject deliberately: an ask legitimately says "let me know" or
+// promises follow-through conditioned on the user's input, and the ask marker
+// itself proves the turn ends by asking the user. Widget-marker text is
+// rejected wholesale — a block that failed the strict parse (or the widget
+// gate's rejects) must not ship as prose through this side door.
+function userSafeMissingInputAskCandidate(
+	message: string | undefined,
+): string | undefined {
+	const candidate = sanitizePlannerMessage(message);
+	if (!candidate) return undefined;
+	if (WIDGET_MARKER_TOKEN.test(candidate)) return undefined;
+	if (!isUserDirectedAsk(candidate)) return undefined;
 	if (isUnsafeUserVisibleText(candidate)) return undefined;
 	if (looksLikePreToolThought(candidate)) return undefined;
 	if (WIDGET_REPLY_IN_FLIGHT_CLAIM.some((pattern) => pattern.test(candidate))) {

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -3287,13 +3287,28 @@ function preferredFinalMessageFromToolOrModel(
 	const modelText = getNonEmptyString(modelMessage);
 	const usableModelText =
 		modelText && !isToolMetaNarration(modelText) ? modelText : undefined;
+	// A parse-valid, user-safe widget reply ([FORM]/[CHOICE]/…) from the
+	// model/evaluator supersedes a missing-input confirmation QUESTION: the
+	// widget is the model's designed collection UI for exactly the fields the
+	// tool asked about, authenticated by the strict block parser — not the
+	// paraphrase risk precedence 2 guards against (#15918; live gpt-oss-120b
+	// FINISHed with a grammar-valid [FORM] that this precedence then dropped
+	// for the tool's prose question). A lifeDraft draft-confirm preview keeps
+	// its priority: action-owned "confirm and I'll save it" copy must never
+	// be displaced into a re-ask.
+	const widgetReply = userSafeWidgetReplyCandidate(usableModelText);
+	const widgetBeatsConfirmation =
+		widgetReply !== undefined &&
+		!latestConfirmationMarkedResultHasLifeDraft(trajectory);
 	// Precedence:
 	//   1. A single successful tool whose result was explicitly marked
 	//      `verifiedUserFacing: true` — used for structured outputs
 	//      (paths, ids, counts) where evaluator paraphrase risks
 	//      hallucinating a value.
 	//   2. A confirmation-required tool preview — action-owned copy must not be
-	//      paraphrased into a vague extra question or a false save.
+	//      paraphrased into a vague extra question or a false save. A widget
+	//      reply outranks it ONLY when the marked result is a missing-input
+	//      question rather than a lifeDraft preview (see above).
 	//   3. The model/evaluator's explicit `messageToUser` — authoritative
 	//      by default; the evaluator has seen the full trajectory and
 	//      chose what the user should read.
@@ -3308,13 +3323,34 @@ function preferredFinalMessageFromToolOrModel(
 	//   - `planner-happy-path.test.ts` → "prefers a single tool's verified
 	//     user-facing text over evaluator paraphrase" — tool wins when it
 	//     opts in via `verifiedUserFacing: true`.
+	//   - `planner-loop-terminal-continuation-form-relay.test.ts` → widget
+	//     vs confirmation-question and lifeDraft-keeps-priority cases.
 	return (
 		singleVerifiedUserFacingToolResultText(trajectory) ??
+		(widgetBeatsConfirmation ? widgetReply : undefined) ??
 		deterministicRequiresConfirmationRelay(trajectory) ??
 		usableModelText ??
 		latestToolResultText(trajectory) ??
 		getNonEmptyString(fallback)
 	);
+}
+
+// True when the most recent confirmation-marked tool result is a lifeDraft
+// draft-confirm preview (as opposed to a missing-input question). The lifeDraft
+// marker is what distinguishes "confirm and I'll save it" copy — which must
+// reach the user verbatim so the user can approve the exact draft — from a
+// clarify question a widget reply may legitimately supersede.
+function latestConfirmationMarkedResultHasLifeDraft(
+	trajectory: PlannerTrajectory,
+): boolean {
+	for (const step of [...trajectory.steps].reverse()) {
+		if (!step.toolCall || isTerminalToolCall(step.toolCall)) continue;
+		const result = step.result;
+		if (!result) continue;
+		if (!hasRequiresConfirmationMarker(result)) continue;
+		return result.data?.lifeDraft !== undefined;
+	}
+	return false;
 }
 
 function isToolMetaNarration(text: string): boolean {


### PR DESCRIPTION
# Relates to

Closes #15918

**Relation to #15947 (opened mid-flight from a parallel lane):** overlapping but not equivalent. #15947 addresses the issue's three original mechanisms via marker-conditioned relays plus the OWNER_REMINDERS marker fix (issue direction 3). This PR additionally fixes a **fourth mechanism #15947 does not touch**: on current develop the evaluator now usually *honors* rule 19 and FINISHes with the grammar-valid `[FORM]` in `messageToUser` — and `preferredFinalMessageFromToolOrModel` precedence 2 drops it for the tool's confirmation question (**5/5 fresh live runs**; see before-runs artifact). Without that FINISH-path fix, the live `live-chat-widgets-form-roundtrip` scenario still delivers the prose question instead of the form. This PR's relays are also marker-independent (text-shape gated), so any tool's marker-less clarify result is survivable, not only OWNER_REMINDERS'. Live proof here: 0/5 → **4/5** full form round trips (judge 1.0) on the issue's exact lane. Happy to reconcile: #15947's plugin-side markers compose cleanly with this PR's core precedence fixes.

# Risks

**Low–medium.** Two precedence changes inside `packages/core` planner-loop final-message selection, both gated behind the existing `userSafeWidgetReplyCandidate` / `isUnsafeUserVisibleText` safety machinery:

- The terminal-only-continuation **limit relay** (only reached when the loop is otherwise about to throw `TrajectoryLimitExceeded` and ship a synthetic apology) gains two new candidates.
- The FINISH-path `preferredFinalMessageFromToolOrModel` lets a **parse-valid widget reply** outrank a missing-input confirmation *question* — never a `lifeDraft` draft-confirm preview, whose verbatim-copy priority is pinned by a new regression test.

Blast radius is the v5 message loop's reply selection on missing-input turns; all 3951 packages/core tests pass, including the pre-existing confirmation-precedence and noop-relay suites.

# Background

## What does this PR do?

Live #14488 re-proof runs (#15918, Cerebras `gpt-oss-120b`, scenario `live-chat-widgets-form-roundtrip`) showed the v5 loop discarding grammar-valid `[FORM]` replies on missing-input turns — and in 2/5 runs crashing the turn to a synthetic *"Sorry, something went wrong."* Four cooperating mechanisms, two fixes:

**Fix 1 — terminal-continuation limit relay reads the planner's own terminal output** (issue mechanisms a+b+c). When the evaluator CONTINUE-loops past its missing-input⇒FINISH rule (rule 19 adherence is model-dependent) and the limit trips, `deterministicTerminalContinuationLimitRelay` previously considered only structured tool results (`userFacingText` / `requiresConfirmation` / `noop`). A grammar-valid `[FORM]` the planner emitted as terminal output was never a candidate, and OWNER_REMINDERS' success-shaped **marker-less** clarify result left nothing to relay → `TrajectoryLimitExceeded` → apology. The relay now tries, in order:

1. the latest **parse-valid widget reply** (`[FORM]`/`[CHOICE]`/…) from a terminal planner step — via the existing #15230 `userSafeWidgetReplyCandidate` gate (strict block parse authenticates it; a pre-tool thought never contains a parse-valid block);
2. the existing structured tool-result relays (unchanged);
3. last resort, the latest **user-directed prose ask** — behind a positive ask-marker allowlist (`please provide…`, `could you…`, trailing `?` only when the sentence addresses the user) plus the same unsafe-text / pre-tool-thought / in-flight rejects, so deliberation narration (`"We should wait for the sub-agent result…"`, `"Which tool should I use?"`) and malformed widget blocks still never ship.

**Fix 2 — a parse-valid widget FINISH reply supersedes a missing-input confirmation question.** Fresh live runs on current develop surfaced a fourth mechanism: the evaluator now often *does* FINISH with a grammar-valid `[FORM]` in `messageToUser`, but `preferredFinalMessageFromToolOrModel` precedence 2 (confirmation-required tool preview) dropped it for the tool's prose question in **5/5 runs**. A user-safe parse-valid widget reply now outranks the confirmation relay — **only** when the confirmation-marked result is a missing-input question. A `lifeDraft` draft-confirm preview keeps its priority (action-owned "confirm and I'll save it" copy must reach the user verbatim), pinned by a regression test.

Issue fix-direction 2 (deterministic evaluator CONTINUE→FINISH override) was deliberately **not** taken: overriding the evaluator risks shipping a form that re-asks for information the user already gave in legitimate CONTINUE cases, while the relay/precedence fixes only fire where the alternative is provably worse (a dropped reply or a synthetic apology). Direction 3 (OWNER_REMINDERS marker) becomes unnecessary for delivery: the marker-less clarify shape is now survivable for every tool.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No — behavior change is internal to the v5 loop's reply selection; in-code comments document the new precedence and its rationale.

# Testing

## Where should a reviewer start?

- `packages/core/src/runtime/__tests__/planner-loop-terminal-continuation-form-relay.test.ts` — 9 deterministic tests replaying the live run-1/4/5 trajectory shapes from the issue plus the FINISH-precedence shape from the fresh runs. **5 of 9 fail on unpatched develop** (proof in the linked red/green log).
- `packages/core/src/runtime/planner-loop.ts` — `deterministicTerminalContinuationLimitRelay` (new precedence + two new relays), `userSafeMissingInputAskCandidate` (new gate), `preferredFinalMessageFromToolOrModel` (widget vs confirmation-question precedence), `latestConfirmationMarkedResultHasLifeDraft`.

## Detailed testing steps

```bash
# deterministic regressions (red on develop, green here)
bun run --cwd packages/core test -- src/runtime/__tests__/planner-loop-terminal-continuation-form-relay.test.ts

# full touched-package lane
bun run --cwd packages/core test        # 3951 passed | 1 skipped
bun run --cwd packages/core typecheck   # pass
bun run audit:error-policy-ratchet      # no new fallback-slop

# live confirmation (issue's exact repro lane)
cd packages/scenario-runner
CEREBRAS_API_KEY=... OPENAI_SMALL_MODEL=gpt-oss-120b OPENAI_LARGE_MODEL=gpt-oss-120b \
bun --conditions eliza-source --tsconfig-override ../../tsconfig.json src/cli.ts run test/scenarios \
  --scenario live-chat-widgets-form-roundtrip --report /tmp/report.json --run-dir /tmp/run
```

**Live 5-run before/after on the same lane (Cerebras `gpt-oss-120b`):**

| | form delivered turn 1 | full round trip passed (judge 1.0) | crash/apology |
|---|---|---|---|
| before (develop FINISH path) | 0/5 — tool question relayed, FORM dropped | 0/5 | 0 (evaluator happened to FINISH; issue evidence had 2/5 apologies via the CONTINUE-loop path) |
| **after (this PR)** | **4/5** | **4/5** | **0** |

The 1/5 miss is the allowed model-chose-prose shape (issue run 2 equivalent): no form emitted anywhere in the turn, graceful prose ask, no crash.

Known gap: repo-wide `bun run verify` currently fails on develop itself — `@elizaos/plugin-starter#lint` has 3 pre-existing `noExplicitAny` errors in `packages/examples/_plugin/env.d.ts` (untouched by this branch), and several package lint scripts run `biome check --write`, rewriting ~554 unrelated files. Scoped verification (core tests + typecheck, biome lint on changed files, error-policy ratchet) is fully green.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots: `N/A - no UI surface changed; this is a packages/core agent-loop reply-selection fix. The before behavior (grammar-valid [FORM] discarded for the tool's prose question in 5/5 live runs) is captured in the linked before-run reports/trajectories: https://github.com/elizaOS/eliza/releases/download/pr-evidence/15918-live-before-finish-fix-5runs.tar.gz`
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots: `N/A - no UI surface changed; [FORM] rendering in the dashboard is pre-existing (#14322) and untouched. The after behavior (form delivered, submitted, consumed; judge 1.0 in 4/5 runs) is captured in the linked after-run reports/trajectories: https://github.com/elizaOS/eliza/releases/download/pr-evidence/15918-live-after-fix-5runs.tar.gz`
<!-- evidence-row:walkthrough-video -->
- [ ] Video walkthrough: `N/A - no UI/flow change to record; the fixed flow is a headless agent-loop path, proven end to end by the live scenario round trip (form emission → [form:submit] re-entry → domain write) in the linked reports.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: full structured server log of a passing after-fix run (AgentRuntime boot → planner/tool/evaluator stages → scenario pass): https://github.com/elizaOS/eliza/releases/download/pr-evidence/15918-backend-run1.log
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs: `N/A - no frontend code executed; the scenario harness plays the dashboard user over the message API and its full request/response record is in the linked run reports.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: 5 live runs on the issue's exact lane (Cerebras gpt-oss-120b, real AgentRuntime, scenario `live-chat-widgets-form-roundtrip`), JSON reports + native per-turn trajectories: https://github.com/elizaOS/eliza/releases/download/pr-evidence/15918-live-after-fix-5runs.tar.gz — single passing-run report for quick reading: https://github.com/elizaOS/eliza/releases/download/pr-evidence/15918-live-report-run1.json — before-fix comparison runs: https://github.com/elizaOS/eliza/releases/download/pr-evidence/15918-live-before-finish-fix-5runs.tar.gz
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the passing runs' turn-2 domain writes (OWNER_REMINDERS create with the submitted Q3/budget/Dana values and July 14 9:30 AM schedule) are recorded in `actionsCalled` of each report: https://github.com/elizaOS/eliza/releases/download/pr-evidence/15918-live-report-run1.json — deterministic red/green test log + typecheck + ratchet: https://github.com/elizaOS/eliza/releases/download/pr-evidence/15918-deterministic-tests.txt

# Evidence Details

## Real LLM-call trajectory

After-fix turn-1 reply (run 1, verbatim from the report):

> "I can certainly set that up for you. Please provide the details below:\n\n[FORM]\n{\"title\":\"Report Deadline Reminder\",\"submitLabel\":\"Set Reminder\",\"fields\":[…date/time fields…]}\n[/FORM]"

After-fix turn-2 reply (submitted values consumed, real domain write):

> "Saved. I've set a reminder to send the Q3 budget report to Dana on July 14 at 9:30 AM."

Before-fix turn-1 reply (same lane, 5/5 runs — evaluator FINISHed **with a grammar-valid [FORM] in messageToUser**, dropped by the confirmation-question precedence):

> "Sure! Please tell me the report name, the day, and the time you'd like the reminder."

## Backend + frontend logs

Backend: linked `15918-backend-run1.log` (structured `[ClassName]` lines; AgentRuntime boot, planner/tool/evaluation stages, scenario pass). Frontend: N/A — see evidence rows.

## Deterministic red/green proof

Linked `15918-deterministic-tests.txt`: the new 9-test suite run against develop's `planner-loop.ts` (5 fail: run-4 FORM relay, run-1 FORM-over-question, run-5 prose ask, trailing-question ask, FINISH-widget precedence) and against this branch (9 pass), plus core typecheck and the error-policy ratchet output.
