### PR TITLE
fix(ci): force LF checkout for source files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,21 @@
 # so they must stay byte-identical across platforms — never let a Windows
 # checkout (autocrlf) rewrite them to CRLF.
 patches/CHECKSUMS.sha256 -text
+
+# Source files must check out with LF everywhere: Windows runners default to
+# core.autocrlf=true, and a CRLF checkout makes vitest's transform pipeline
+# reject otherwise-valid modules ("SyntaxError: Invalid or unexpected token"
+# at collection — reproduced by CRLF-converting run-mobile-build.mjs on
+# Linux). Biome also formats LF-only, so CRLF working copies churn
+# format:check.
+*.mjs text eol=lf
+*.cjs text eol=lf
+*.js text eol=lf
+*.jsx text eol=lf
+*.ts text eol=lf
+*.tsx text eol=lf
+*.mts text eol=lf
+*.cts text eol=lf
+*.json text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf


### PR DESCRIPTION
## Problem

The Windows `app-and-cli` shard keeps failing collection of `run-mobile-build-cloud-main-activity.test.mjs` with `SyntaxError: Invalid or unexpected token` (runs [29060044856](https://github.com/elizaOS/eliza/actions/runs/29060044856), [29067171727](https://github.com/elizaOS/eliza/actions/runs/29067171727)) — even after #15893 removed the one backslash-newline continuation.

## Root cause, reproduced on Linux

CRLF-converting `packages/app-core/scripts/run-mobile-build.mjs` (what a Windows runner's `core.autocrlf=true` checkout does) reproduces the exact failure signature under vitest. Isolation of the layers:

| layer | CRLF file |
|---|---|
| `node --check` | accepts |
| bare esbuild transform | accepts |
| native ESM `import()` | accepts |
| **vitest transform pipeline** | **SyntaxError: Invalid or unexpected token** |

So any Windows checkout can fail collection of an otherwise-valid module, depending only on its content meeting vitest's transform — this is almost certainly the chronic Windows "SyntaxError-at-collection on Linux-valid syntax" anomaly class that's been written off as runner weirdness.

## Fix

`.gitattributes` already pins patch bytes against autocrlf for exactly this reason; this extends `text eol=lf` to source extensions (`.mjs/.cjs/.js/.jsx/.ts/.tsx/.mts/.cts/.json/.yml/.yaml`). Verified:

- `git check-attr` shows the rules applying to the affected files
- `git ls-files --eol` shows **zero** CRLF-in-index files for these patterns — nothing renormalizes; the change only affects what Windows materializes at checkout
- Biome formats LF-only, so this also prevents CRLF working-copy churn in `format:check`

CI-infra only; no file contents change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)