### PR TITLE
fix(app-core): register the pendant transcript tab in the dev route catalog

### DIFF
--- a/packages/app-core/src/api/dev-route-catalog.ts
+++ b/packages/app-core/src/api/dev-route-catalog.ts
@@ -382,6 +382,16 @@ const ROUTES: DevRouteEntry[] = [
     platformGate: null,
   },
   {
+    tabId: "pendant-transcript",
+    path: "/pendant/transcript",
+    label: "Pendant Transcript",
+    group: "Pendant",
+    visibility: "all",
+    featureFlag: null,
+    requiresAuth: true,
+    platformGate: null,
+  },
+  {
     tabId: "automations",
     path: "/automations",
     label: "Automations",


### PR DESCRIPTION
#15806 (pendant realtime transcription bridge) added the `pendant-transcript` tab to `TAB_PATHS` without a `dev-route-catalog` entry, so `dev-route-catalog.test.ts > represents every TAB_PATHS key` fails cross-platform since it merged (first surfaced in Windows run [29067171727](https://github.com/elizaOS/eliza/actions/runs/29067171727); reproduced on Linux at tip: `expected [ 'pendant-transcript' ] to deeply equal []`).

Adds the catalog row mirroring the navigation definition (`/pendant/transcript`, Pendant group, auth-gated, no feature flag / platform gate). Test now 9/9; biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)