### PR TITLE
fix(ci): format packages/app

### DIFF
--- a/packages/app/scripts/audit-views-soak-boundary.mjs
+++ b/packages/app/scripts/audit-views-soak-boundary.mjs
@@ -64,7 +64,9 @@ export async function finalizeSoakEvidence({
   onContextClosed();
   if (!video) {
     if (videoRequired) {
-      throw new Error("view-soak recording is required but was not initialized");
+      throw new Error(
+        "view-soak recording is required but was not initialized",
+      );
     }
     return null;
   }

--- a/packages/app/test/android/glass-bridge.android.spec.ts
+++ b/packages/app/test/android/glass-bridge.android.spec.ts
@@ -183,10 +183,8 @@ test("GlassBridge native-view lifecycle, boundary validation, and rendered pixel
   expect(afterMove.exists).toBe(true);
   expect(afterMove.rect?.width).toBeCloseTo(MOVED_RECT.width * dpr, -1);
   expect(afterMove.rect?.height).toBeCloseTo(MOVED_RECT.height * dpr, -1);
-  const containerOffsetX =
-    (boot.afterAttach.rect?.x ?? 0) - CSS_RECT.x * dpr;
-  const containerOffsetY =
-    (boot.afterAttach.rect?.y ?? 0) - CSS_RECT.y * dpr;
+  const containerOffsetX = (boot.afterAttach.rect?.x ?? 0) - CSS_RECT.x * dpr;
+  const containerOffsetY = (boot.afterAttach.rect?.y ?? 0) - CSS_RECT.y * dpr;
   expect(afterMove.rect?.x).toBeCloseTo(
     MOVED_RECT.x * dpr + containerOffsetX,
     -1,

--- a/packages/app/test/e2e-live-coverage-doc-paths.test.ts
+++ b/packages/app/test/e2e-live-coverage-doc-paths.test.ts
@@ -43,7 +43,10 @@ describe("E2E_LIVE_COVERAGE.md path integrity", () => {
     // Sanity: a broken extraction regex must not silently empty the roster.
     expect(paths.length).toBeGreaterThan(10);
     const missing = paths.filter((p) => !existsSync(path.join(REPO_ROOT, p)));
-    expect(missing, `E2E_LIVE_COVERAGE.md references missing paths:\n${missing.join("\n")}`).toEqual([]);
+    expect(
+      missing,
+      `E2E_LIVE_COVERAGE.md references missing paths:\n${missing.join("\n")}`,
+    ).toEqual([]);
   });
 
   it("does not reference the removed whisper.cpp voice path (#14420)", () => {
@@ -54,7 +57,10 @@ describe("E2E_LIVE_COVERAGE.md path integrity", () => {
       "ELIZA_WHISPER_MODEL",
       "build-omnivoice.mjs",
     ]) {
-      expect(doc, `stale reference to removed voice path: ${banned}`).not.toContain(banned);
+      expect(
+        doc,
+        `stale reference to removed voice path: ${banned}`,
+      ).not.toContain(banned);
     }
   });
 });

--- a/packages/app/test/ios-app-intents-registration.test.ts
+++ b/packages/app/test/ios-app-intents-registration.test.ts
@@ -351,12 +351,8 @@ describe("native assistant entry contracts", () => {
     expect(deviceExtensionSurfaceUITestsSwift).toContain(
       "testHomeScreenWidgetTapForegroundsApp",
     );
-    expect(deviceExtensionSurfaceUITestsSwift).toContain(
-      "Ask Eliza",
-    );
-    expect(deviceExtensionSurfaceUITestsSwift).toContain(
-      "Eliza Voice",
-    );
+    expect(deviceExtensionSurfaceUITestsSwift).toContain("Ask Eliza");
+    expect(deviceExtensionSurfaceUITestsSwift).toContain("Eliza Voice");
     expect(deviceExtensionSurfaceUITestsSwift).toContain(
       "elizaos://assistant?source=ios-widget&action=ask",
     );

--- a/packages/app/test/ui-smoke/apps-personal-assistant-feed-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/apps-personal-assistant-feed-interactions.spec.ts
@@ -20,9 +20,7 @@ test.beforeEach(async ({ page }) => {
   await installDefaultAppRoutes(page);
 });
 
-test("Feed route exposes reachable GUI state", async ({
-  page,
-}) => {
+test("Feed route exposes reachable GUI state", async ({ page }) => {
   await openAppPath(page, "/feed");
   await assertReadyChecks(
     page,

--- a/packages/app/test/ui-smoke/assistant-home-flow.spec.ts
+++ b/packages/app/test/ui-smoke/assistant-home-flow.spec.ts
@@ -316,9 +316,9 @@ async function installAssistantFlowRoutes(page: Page): Promise<{
       // A `before` cursor asks for older history; this fixture conversation has
       // none, so return an empty page with `hasMore:false` to stop the scroll
       // from refetching the same cursor.
-      const hasBeforeCursor = new URL(
-        route.request().url(),
-      ).searchParams.has("before");
+      const hasBeforeCursor = new URL(route.request().url()).searchParams.has(
+        "before",
+      );
       await fulfillJson(route, {
         messages: hasBeforeCursor ? [] : messages,
         hasMore: false,

--- a/packages/app/test/ui-smoke/helpers/view-header.ts
+++ b/packages/app/test/ui-smoke/helpers/view-header.ts
@@ -38,9 +38,7 @@ export async function assertSharedViewHeaderContract(
   const scoped = within
     ? page.locator(within).getByTestId(VIEW_HEADER_TESTID)
     : page.getByTestId(VIEW_HEADER_TESTID);
-  const header = (
-    title ? scoped.filter({ hasText: title }) : scoped
-  ).first();
+  const header = (title ? scoped.filter({ hasText: title }) : scoped).first();
   await expect(
     header,
     "a normal view must render the shared ViewHeader ([data-testid=view-header])",

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -119,7 +119,9 @@
       "@elizaos/ui/*": ["../ui/src/*"],
       "@elizaos/import-conversations": ["../import-conversations/src/index.ts"],
       "@elizaos/import-conversations/*": ["../import-conversations/src/*"],
-      "@elizaos/import-conversations/browser": ["../import-conversations/src/browser.ts"],
+      "@elizaos/import-conversations/browser": [
+        "../import-conversations/src/browser.ts"
+      ],
       "@elizaos/cloud-ui": ["../cloud-ui/src/index.ts"],
       "@elizaos/cloud-ui/*": ["../cloud-ui/src/*"],
       "react": ["../../node_modules/@types/react/index.d.ts"],

--- a/packages/app/tsconfig.typecheck.json
+++ b/packages/app/tsconfig.typecheck.json
@@ -150,7 +150,9 @@
       "@elizaos/ui/*": ["../ui/src/*"],
       "@elizaos/import-conversations": ["../import-conversations/src/index.ts"],
       "@elizaos/import-conversations/*": ["../import-conversations/src/*"],
-      "@elizaos/import-conversations/browser": ["../import-conversations/src/browser.ts"],
+      "@elizaos/import-conversations/browser": [
+        "../import-conversations/src/browser.ts"
+      ],
       "@elizaos/cloud-ui": ["../cloud-ui/src/index.ts"],
       "@elizaos/cloud-ui/*": ["../cloud-ui/src/*"],
       "@elizaos/cloud-shared": ["../cloud/shared/src/index.ts"],


### PR DESCRIPTION
Quality (Extended)'s "Format + Type Safety Ratchet" fails `format:check` on `@elizaos/app` (develop@a5002a05414): nine files landed unformatted across recent merges (test specs, audit script, tsconfigs). `biome format --write` only — `bunx biome format packages/app` is clean after (508 files checked, no fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)