### PR TITLE
fix(ci): ignore empty action placeholders

### DIFF
--- a/packages/scripts/__tests__/lint-lane-coverage.test.ts
+++ b/packages/scripts/__tests__/lint-lane-coverage.test.ts
@@ -1,8 +1,9 @@
 /** Exercises the plugin lane analyzer against deterministic temporary repositories. */
-import { afterEach, describe, expect, test } from "bun:test";
+
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
 
 const laneCoverage = await import(
   new URL("../lint-lane-coverage.mjs", import.meta.url).href

--- a/packages/scripts/__tests__/lint-lane-coverage.test.ts
+++ b/packages/scripts/__tests__/lint-lane-coverage.test.ts
@@ -1,4 +1,4 @@
-// Exercises tests lint lane coverage.test automation behavior with deterministic script fixtures.
+/** Exercises the plugin lane analyzer against deterministic temporary repositories. */
 import { afterEach, describe, expect, test } from "bun:test";
 import fs from "node:fs";
 import os from "node:os";
@@ -111,6 +111,74 @@ describe("lint-lane-coverage analyzer", () => {
     expect(codes).toContain(laneCoverage.ISSUE_CODES.MISSING_ACTION_E2E);
     expect(codes).toContain(laneCoverage.ISSUE_CODES.MISSING_VIEW_TESTS);
     expect(codes).toContain(laneCoverage.ISSUE_CODES.MISSING_VIEW_E2E);
+  });
+
+  test("does not invent action coverage gaps from empty action placeholders", () => {
+    const root = makeRepo();
+    writePlugin(root, "plugin-empty-actions");
+    write(
+      root,
+      "plugins/plugin-empty-actions/src/index.ts",
+      "export default { providers: [] };",
+    );
+    write(
+      root,
+      "plugins/plugin-empty-actions/src/actions/index.ts",
+      "/** Messaging uses connector hooks instead of standalone actions. */\nexport {};",
+    );
+    write(
+      root,
+      "plugins/plugin-empty-actions/src/actions/connector-note.ts",
+      "// The connector owns outbound messaging; no standalone action is registered.",
+    );
+    write(
+      root,
+      "plugins/plugin-empty-actions/src/plugin.test.ts",
+      "import { test, expect } from 'vitest'; test('plugin', () => expect(true).toBe(true));",
+    );
+
+    const result = laneCoverage.analyzeLaneCoverage({
+      repoRoot: root,
+      allowlistPath: null,
+    });
+    const codes = result.unsuppressedIssues.map(
+      (entry: { code: string }) => entry.code,
+    );
+
+    expect(codes).toContain(laneCoverage.ISSUE_CODES.MISSING_DETERMINISTIC_E2E);
+    expect(codes).not.toContain(laneCoverage.ISSUE_CODES.MISSING_ACTION_TESTS);
+    expect(codes).not.toContain(laneCoverage.ISSUE_CODES.MISSING_ACTION_E2E);
+  });
+
+  test("keeps executable action modules in the action-surface inventory", () => {
+    const root = makeRepo();
+    writePlugin(root, "plugin-handler-action");
+    write(
+      root,
+      "plugins/plugin-handler-action/src/index.ts",
+      "export default { providers: [] };",
+    );
+    write(
+      root,
+      "plugins/plugin-handler-action/src/actions/handler.ts",
+      "export async function runAction() { return { success: true }; }",
+    );
+    write(
+      root,
+      "plugins/plugin-handler-action/src/plugin.test.ts",
+      "import { test, expect } from 'vitest'; test('plugin', () => expect(true).toBe(true));",
+    );
+
+    const result = laneCoverage.analyzeLaneCoverage({
+      repoRoot: root,
+      allowlistPath: null,
+    });
+    const codes = result.unsuppressedIssues.map(
+      (entry: { code: string }) => entry.code,
+    );
+
+    expect(codes).toContain(laneCoverage.ISSUE_CODES.MISSING_ACTION_TESTS);
+    expect(codes).toContain(laneCoverage.ISSUE_CODES.MISSING_ACTION_E2E);
   });
 
   test("requires explicit allowlist reasons and treats stale entries as errors", () => {

--- a/packages/scripts/lint-lane-coverage.allowlist.json
+++ b/packages/scripts/lint-lane-coverage.allowlist.json
@@ -41,7 +41,7 @@
     },
     {
       "plugin": "plugin-bluebubbles",
-      "issues": ["missing-action-e2e", "missing-deterministic-e2e"],
+      "issues": ["missing-deterministic-e2e"],
       "reason": "Legacy deterministic lane coverage debt tracked in #15856; ratchet by removing entries as tests/scenarios land."
     },
     {
@@ -149,11 +149,7 @@
     },
     {
       "plugin": "plugin-feishu",
-      "issues": [
-        "missing-action-e2e",
-        "missing-action-tests",
-        "missing-deterministic-e2e"
-      ],
+      "issues": ["missing-deterministic-e2e"],
       "reason": "Legacy deterministic lane coverage debt tracked in #15856; ratchet by removing entries as tests/scenarios land."
     },
     {
@@ -178,11 +174,7 @@
     },
     {
       "plugin": "plugin-google-chat",
-      "issues": [
-        "missing-action-e2e",
-        "missing-action-tests",
-        "missing-deterministic-e2e"
-      ],
+      "issues": ["missing-deterministic-e2e"],
       "reason": "Legacy deterministic lane coverage debt tracked in #15856; ratchet by removing entries as tests/scenarios land."
     },
     {
@@ -202,16 +194,7 @@
     },
     {
       "plugin": "plugin-instagram",
-      "issues": [
-        "missing-action-e2e",
-        "missing-action-tests",
-        "missing-deterministic-e2e"
-      ],
-      "reason": "Legacy deterministic lane coverage debt tracked in #15856; ratchet by removing entries as tests/scenarios land."
-    },
-    {
-      "plugin": "plugin-line",
-      "issues": ["missing-action-tests"],
+      "issues": ["missing-deterministic-e2e"],
       "reason": "Legacy deterministic lane coverage debt tracked in #15856; ratchet by removing entries as tests/scenarios land."
     },
     {

--- a/packages/scripts/lint-lane-coverage.mjs
+++ b/packages/scripts/lint-lane-coverage.mjs
@@ -1,11 +1,8 @@
 #!/usr/bin/env node
 /**
- * lint-lane-coverage.mjs
- *
- * Static coverage gate for the deterministic PR lanes. It inventories plugins,
- * action surfaces, view/app surfaces, deterministic E2E/scenario coverage, and
- * real/live E2E env documentation. Default mode is a CI gate: unsuppressed
- * coverage gaps exit 1. Use --dry-run for local inventory without failing.
+ * Static coverage gate for deterministic plugin PR lanes. It inventories
+ * actions, views, tests, scenarios, and live-test environment documentation;
+ * unsuppressed gaps fail CI while `--dry-run` reports the same inventory.
  */
 
 import fs from "node:fs";
@@ -63,6 +60,17 @@ function readTextIfExists(filePath) {
   } catch {
     return "";
   }
+}
+
+function containsModuleCode(sourceText) {
+  const withoutComments = sourceText
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^\s*\/\/.*$/gm, "")
+    .trim();
+  return (
+    withoutComments.length > 0 &&
+    !/^export\s*\{\s*\}\s*;?$/.test(withoutComments)
+  );
 }
 
 function walkFiles(dir, visitor) {
@@ -207,7 +215,10 @@ function collectPluginFiles(pluginDir) {
 
     if (isSource && !testLike && rel.startsWith("src/")) {
       files.sourceFiles.push(filePath);
-      if (/(?:^|\/)actions?\//.test(rel)) {
+      if (
+        /(?:^|\/)actions?\//.test(rel) &&
+        containsModuleCode(readTextIfExists(filePath))
+      ) {
         files.actionSourceFiles.push(filePath);
       }
       if (
@@ -287,7 +298,7 @@ function sourceDeclaresNonEmptyArray(sourceText, propertyName) {
   return !emptyPattern.test(sourceText);
 }
 
-function detectSurfaces(pluginDir, packageJson, files) {
+function detectSurfaces(packageJson, files) {
   const sourceText = files.sourceFiles
     .map((filePath) => readTextIfExists(filePath))
     .join("\n");
@@ -440,7 +451,7 @@ function analyzePlugin({ repoRoot, envTestKeys, plugin, scenarioFiles }) {
     }
   }
 
-  const surfaces = detectSurfaces(plugin.dir, plugin.packageJson, files);
+  const surfaces = detectSurfaces(plugin.packageJson, files);
   const issues = [];
 
   if (files.allTests.length === 0) {


### PR DESCRIPTION
## What

Continues #15856 by removing false action-surface debt from the deterministic lane auditor.

- Treats comment-only and `export {}` files under `src/actions/` as intentional placeholders rather than executable action surfaces.
- Keeps executable handler modules and non-empty plugin `actions` arrays in the inventory.
- Adds deterministic temporary-repository regressions for both sides of that boundary.
- Removes eight now-invalid `missing-action-tests` / `missing-action-e2e` suppressions across BlueBubbles, Feishu, Google Chat, Instagram, and LINE. No connector production code changes.

## Verification

- `bun test packages/scripts/__tests__/lint-lane-coverage.test.ts` — 5 passed.
- Biome check — passed on all three touched files.
- Full 142-plugin enforced inventory — passed with 0 blocking issues and 140 suppressions.
- `node packages/scripts/error-policy-ratchet.mjs` — passed.
- `git diff --check` — passed.

## Evidence matrix

<!-- evidence-row:before-screenshots -->
- [x] N/A - analyzer/test-only change; no rendered UI behavior changed

<!-- evidence-row:after-screenshots -->
- [x] N/A - analyzer/test-only change; no rendered UI behavior changed

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow changed

<!-- evidence-row:backend-logs -->
- [x] N/A - no production backend path changed

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changed

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, action, or runtime behavior changed

<!-- evidence-row:domain-artifacts -->
- [x] [Reproduced analyzer unit and full-inventory proof](https://github.com/elizaOS/eliza/issues/15856#issuecomment-4932477413)

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered UI source changed
