### PR TITLE
fix(voice): stop the 'yes, local Eliza-1' always-on-mic loop

### DIFF
--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -446,9 +446,14 @@ function buildAndroidLocalDirectChatPrompt(args: {
   userText: string;
 }): string {
   const systemText = [
-    "Eliza-1 on device.",
-    "One natural sentence under 10 words. Stop after it.",
-    "If asked local/on-device: yes, local Eliza-1.",
+    "You are Eliza, running on device.",
+    "Reply to the user's message in one natural sentence under 10 words. Stop after it.",
+    // NOTE: do NOT hardcode a canned identity answer here. A prior
+    // "If asked local/on-device: yes, local Eliza-1." line made the small
+    // temperature-0 model default to emitting that exact sentence for garbled /
+    // ambiguous voice transcripts, so an always-on mic kept replying
+    // "yes, local Eliza-1." to real speech and room noise. Let the model just
+    // answer the actual message.
     "No markdown, labels, tools, logs, or hidden reasoning.",
   ].join("\n");
   return [

--- a/packages/shared/src/voice/respond-gate.ts
+++ b/packages/shared/src/voice/respond-gate.ts
@@ -51,6 +51,24 @@ function words(text: string): string[] {
     .filter(Boolean);
 }
 
+/**
+ * Strip Whisper's non-speech sound-event annotations — parenthesised or
+ * bracketed tokens like "(music)", "(bubbling sound)", "[laughter]",
+ * "(Perro jadea)", "(clicking)". An always-on mic transcribes room noise and the
+ * agent's own audio bleeding back, and Whisper wraps those as `(...)`/`[...]`
+ * events. Returns the residual SPOKEN text; when a turn is entirely such
+ * annotations the residue is empty. This is the #1 source of the agent replying
+ * to ambient noise ("yes, local Eliza-1" on repeat), which the word/disfluency
+ * and echo guards below do not catch (the annotation words don't overlap the
+ * reply and aren't in the disfluency set).
+ */
+function stripNonSpeechAnnotations(text: string): string {
+  return text
+    .replace(/[([{][^)\]}]*[)\]}]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
 export interface ShouldRespondContext {
   /** The agent's most recent spoken reply, for the echo guard. */
   recentAgentReply?: string;
@@ -74,7 +92,11 @@ export function shouldRespondToVoiceTurn(
   transcript: string,
   context: ShouldRespondContext = {},
 ): boolean {
-  const w = words(transcript);
+  // Drop turns that are ENTIRELY non-speech sound-event annotations
+  // ("(bubbling sound)", "(techno music)", "(Perro jadea)") — ambient noise or
+  // the agent's own audio bled back into the open mic, never a spoken turn.
+  const spoken = stripNonSpeechAnnotations(transcript);
+  const w = words(spoken);
   if (w.length === 0) return false;
 
   // Pure disfluency ("um", "uh huh"… with nothing substantive) → ignore.


### PR DESCRIPTION
## Problem (from real on-device voice trajectories)
In always-on voice, the agent kept replying **"yes, local Eliza-1."** to *everything* — real speech and room noise alike:
```
u: "The command should work."          → a: "yes, local Eliza-1."
u: (bubbling sound)                     → a: "yes, local Eliza-1."
u: (techno music)                       → a: "yes, local Eliza-1."
```

Two independent causes:

1. **Canned-reply prompt.** The Android local direct-chat fast-path system prompt hardcoded `"If asked local/on-device: yes, local Eliza-1."`. The small `temperature:0` model (20-token cap) latched onto that exact sentence for garbled/ambiguous voice transcripts instead of answering the message. Removed it — verified live the model now answers ("which command are you referring to?", "the capital of france is paris.").

2. **Non-speech turns weren't gated.** `shouldRespondToVoiceTurn` filtered disfluencies + echo but not Whisper's non-speech sound-event annotations (`(bubbling sound)`, `(techno music)`, `(Perro jadea)`, `[laughter]`) — what an open mic transcribes from room noise / TTS echo. A turn that is entirely such annotations now returns false (no reply).

## Evidence
Verified on device after the fix: real varied replies to real input; the canned loop is gone.
