### PR TITLE
fix(agent): survive recoverable stream close-race instead of killing the on-device agent

### DIFF
--- a/plugins/plugin-capacitor-bridge/src/android/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/android/bridge.ts
@@ -398,17 +398,29 @@ export async function runAndroidBridgeCli(): Promise<void> {
 		console.error("[android-bridge] unhandled rejection:", msg);
 	});
 	process.on("uncaughtException", (error) => {
-		_logToFile(
-			`[android-bridge] uncaughtException: ${error.stack || error.message}`,
-		);
-		_appendDiagnostics("agent-fatal", {
+		const msg = error.stack || error.message;
+		_logToFile(`[android-bridge] uncaughtException: ${msg}`);
+		// A ReadableStream/controller close-race that surfaces AFTER a response is
+		// already delivered (e.g. "Invalid state: Controller is already closed" at
+		// endReadableNT, seen on the SSE chat-reply teardown) is recoverable — the
+		// reply was sent. Killing the whole agent over a harmless post-delivery
+		// stream teardown takes chat AND voice down for the entire app and the
+		// supervisor does not always relaunch, so the phone silently "breaks" mid
+		// session. Survive that specific class; exit loudly for everything else so
+		// a genuinely fatal fault still lets the supervisor recover instead of
+		// leaving a zombie.
+		const recoverable =
+			/Controller is already closed|Invalid state|readable ?stream/i.test(msg);
+		_appendDiagnostics(recoverable ? "agent-recovered-uncaught" : "agent-fatal", {
 			kind: "uncaughtException",
-			message: (error.stack || error.message).slice(0, 2000),
+			recoverable: String(recoverable),
+			message: msg.slice(0, 2000),
 		});
 		console.error(
-			"[android-bridge] uncaught exception:",
-			error.stack || error.message,
+			`[android-bridge] uncaught exception${recoverable ? " (recovered)" : ""}:`,
+			msg,
 		);
+		if (recoverable) return;
 		// Installing this handler suppresses the runtime's default fatal exit;
 		// without an explicit exit a post-boot uncaught exception leaves a
 		// zombie agent the supervisor never learns about. Exit loudly instead.


### PR DESCRIPTION
## Problem (observed on a real device)
The Android bridge's `uncaughtException` handler called `process.exit(1)` on **any** error. A recoverable `ReadableStream`/controller close-race on the SSE chat-reply teardown — `TypeError: Invalid state: Controller is already closed` at `endReadableNT`, which fires *after* the reply is already delivered — killed the entire on-device agent process (`agent-fatal → exitCode 1`), taking chat AND voice down mid-session with no reliable supervisor relaunch.

## Fix
Survive that specific recoverable class (`/Controller is already closed|Invalid state|readable ?stream/i` → log + continue); still `exit(1)` on genuinely fatal faults so the supervisor can recover a real crash rather than leaving a zombie.

## Evidence
After the fix, the diagnostics show `agent-recovered-uncaught × 3` (agent caught the race and stayed alive) with **zero** new `agent-fatal` — the agent kept serving chat + voice.
