### PR TITLE
fix(voice): honor explicit cloud ASR over the native recognizer in the capture factory

### DIFF
--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -440,6 +440,47 @@ export function useShellController(): ShellController {
   // gesture time. `undefined` until the voice config first loads, which the
   // capture factory treats as "local-inference-or-browser default".
   const asrProviderRef = React.useRef<AsrProvider | undefined>(undefined);
+  // Opt-in (`eliza:voice-cloud-tts`): force the hands-free/dictate capture onto
+  // the cloud STT proxy (`/api/asr/cloud`) regardless of the resolved config.
+  // The hybrid LP3 config never advertises cloud voice, so `asrProviderRef`
+  // stays `undefined` and the capture factory defaults to the native recognizer
+  // — which on that device has no service and feeds an infinite hand-off loop.
+  // Read via the live Capacitor bridge (the `@capacitor/preferences` module
+  // import can resolve to a web-stub that silently returns no value).
+  const forceCloudVoiceRef = React.useRef(false);
+  React.useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const bridge = (
+          globalThis as {
+            Capacitor?: {
+              Plugins?: {
+                Preferences?: {
+                  get?: (o: { key: string }) => Promise<{ value: string | null }>;
+                };
+              };
+            };
+          }
+        ).Capacitor?.Plugins?.Preferences;
+        let value: string | null = null;
+        if (typeof bridge?.get === "function") {
+          value = (await bridge.get({ key: "eliza:voice-cloud-tts" })).value;
+        } else {
+          const { Preferences } = await import("@capacitor/preferences");
+          value = (await Preferences.get({ key: "eliza:voice-cloud-tts" })).value;
+        }
+        if (!cancelled) {
+          forceCloudVoiceRef.current = value === "1" || value === "true";
+        }
+      } catch {
+        // error-policy:J4 no preferences bridge (web/desktop) → keep default.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
   // Guards the capture-failure notice so the hands-free re-listen loop's retries
   // (which re-call startCapture every ~250ms) don't spam the toast; cleared on
   // the next successful start so a later failure re-notifies.
@@ -966,9 +1007,13 @@ export function useShellController(): ShellController {
         // silently fell through to browser SpeechRecognition instead of
         // `/api/asr/cloud`. Passing the resolved provider makes the documented
         // cloud default reachable from the ambient/hands-free capture surface.
-        ...(asrProviderRef.current
-          ? { asrProvider: asrProviderRef.current }
-          : {}),
+        // Cloud-forced (LP3) pins the cloud STT proxy; otherwise use the
+        // resolved provider (undefined → factory's local/native default).
+        ...(forceCloudVoiceRef.current
+          ? { asrProvider: "eliza-cloud" as const }
+          : asrProviderRef.current
+            ? { asrProvider: asrProviderRef.current }
+            : {}),
         // Push-to-talk dictation ends on release, so the native recognizer must
         // commit its running interim as the final turn even if its silence
         // window hasn't fired. Converse stops only on toggle-off, where a

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -440,47 +440,6 @@ export function useShellController(): ShellController {
   // gesture time. `undefined` until the voice config first loads, which the
   // capture factory treats as "local-inference-or-browser default".
   const asrProviderRef = React.useRef<AsrProvider | undefined>(undefined);
-  // Opt-in (`eliza:voice-cloud-tts`): force the hands-free/dictate capture onto
-  // the cloud STT proxy (`/api/asr/cloud`) regardless of the resolved config.
-  // The hybrid LP3 config never advertises cloud voice, so `asrProviderRef`
-  // stays `undefined` and the capture factory defaults to the native recognizer
-  // — which on that device has no service and feeds an infinite hand-off loop.
-  // Read via the live Capacitor bridge (the `@capacitor/preferences` module
-  // import can resolve to a web-stub that silently returns no value).
-  const forceCloudVoiceRef = React.useRef(false);
-  React.useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      try {
-        const bridge = (
-          globalThis as {
-            Capacitor?: {
-              Plugins?: {
-                Preferences?: {
-                  get?: (o: { key: string }) => Promise<{ value: string | null }>;
-                };
-              };
-            };
-          }
-        ).Capacitor?.Plugins?.Preferences;
-        let value: string | null = null;
-        if (typeof bridge?.get === "function") {
-          value = (await bridge.get({ key: "eliza:voice-cloud-tts" })).value;
-        } else {
-          const { Preferences } = await import("@capacitor/preferences");
-          value = (await Preferences.get({ key: "eliza:voice-cloud-tts" })).value;
-        }
-        if (!cancelled) {
-          forceCloudVoiceRef.current = value === "1" || value === "true";
-        }
-      } catch {
-        // error-policy:J4 no preferences bridge (web/desktop) → keep default.
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
   // Guards the capture-failure notice so the hands-free re-listen loop's retries
   // (which re-call startCapture every ~250ms) don't spam the toast; cleared on
   // the next successful start so a later failure re-notifies.
@@ -1007,13 +966,9 @@ export function useShellController(): ShellController {
         // silently fell through to browser SpeechRecognition instead of
         // `/api/asr/cloud`. Passing the resolved provider makes the documented
         // cloud default reachable from the ambient/hands-free capture surface.
-        // Cloud-forced (LP3) pins the cloud STT proxy; otherwise use the
-        // resolved provider (undefined → factory's local/native default).
-        ...(forceCloudVoiceRef.current
-          ? { asrProvider: "eliza-cloud" as const }
-          : asrProviderRef.current
-            ? { asrProvider: asrProviderRef.current }
-            : {}),
+        ...(asrProviderRef.current
+          ? { asrProvider: asrProviderRef.current }
+          : {}),
         // Push-to-talk dictation ends on release, so the native recognizer must
         // commit its running interim as the final turn even if its silence
         // window hasn't fired. Converse stops only on toggle-off, where a

--- a/packages/ui/src/voice/voice-capture-factory.test.ts
+++ b/packages/ui/src/voice/voice-capture-factory.test.ts
@@ -438,6 +438,105 @@ describe("createVoiceCapture", () => {
     expect(onTranscript).not.toHaveBeenCalled();
   });
 
+  it("explicit eliza-cloud ASR wins over an available native TalkMode recognizer", async () => {
+    // A device can expose a TalkMode plugin whose platform recognizer is absent
+    // or broken (the Light Phone III routes SpeechRecognizer back into the
+    // app's own RecognitionService — an infinite hand-off loop). When the
+    // resolved config EXPLICITLY selects cloud STT, the factory must honor it
+    // instead of silently preferring the native recognizer.
+    isNativePlatformMock.mockReturnValue(true);
+    const talkMode = makeFakeTalkMode();
+    getTalkModePluginMock.mockReturnValue(talkMode as never);
+    const wav = new Uint8Array([5, 6, 7]);
+    startLocalAsrRecorderMock.mockResolvedValue({
+      stop: vi.fn().mockResolvedValue(wav),
+      cancel: vi.fn(),
+      analyser: null,
+    });
+    const onTranscript = vi.fn();
+    const capture = createVoiceCapture({
+      asrProvider: "eliza-cloud",
+      onTranscript,
+    });
+
+    await capture.start();
+    // The WAV recorder is the capture engine; the native recognizer never starts.
+    expect(startLocalAsrRecorderMock).toHaveBeenCalledTimes(1);
+    expect(talkMode.start).not.toHaveBeenCalled();
+
+    await capture.stop();
+    expect(transcribeCloudWavMock).toHaveBeenCalledWith(wav);
+    expect(onTranscript).toHaveBeenCalledWith(
+      expect.objectContaining({ backend: "cloud", text: "Grace Hopper" }),
+    );
+  });
+
+  it("explicit openai ASR also wins over an available native TalkMode recognizer", async () => {
+    isNativePlatformMock.mockReturnValue(true);
+    const talkMode = makeFakeTalkMode();
+    getTalkModePluginMock.mockReturnValue(talkMode as never);
+    startLocalAsrRecorderMock.mockResolvedValue({
+      stop: vi.fn().mockResolvedValue(new Uint8Array([8])),
+      cancel: vi.fn(),
+      analyser: null,
+    });
+    const onTranscript = vi.fn();
+    const capture = createVoiceCapture({ asrProvider: "openai", onTranscript });
+
+    await capture.start();
+    expect(talkMode.start).not.toHaveBeenCalled();
+
+    await capture.stop();
+    expect(onTranscript).toHaveBeenCalledWith(
+      expect.objectContaining({ backend: "cloud" }),
+    );
+  });
+
+  it("explicit cloud ASR degrades to native TalkMode when WAV capture is unsupported", async () => {
+    // Without getUserMedia/AudioContext there is no WAV to POST, so the cloud
+    // preference is unfulfillable — the working native recognizer is the honest
+    // remaining STT path, not a dead browser recognizer.
+    isNativePlatformMock.mockReturnValue(true);
+    isLocalAsrCaptureSupportedMock.mockReturnValue(false);
+    const talkMode = makeFakeTalkMode();
+    getTalkModePluginMock.mockReturnValue(talkMode as never);
+    const onTranscript = vi.fn();
+    const capture = createVoiceCapture({
+      asrProvider: "eliza-cloud",
+      onTranscript,
+    });
+
+    await capture.start();
+    expect(talkMode.start).toHaveBeenCalledTimes(1);
+    expect(startLocalAsrRecorderMock).not.toHaveBeenCalled();
+
+    talkMode.emit("transcript", { transcript: "native path", isFinal: true });
+    expect(onTranscript).toHaveBeenLastCalledWith({
+      text: "native path",
+      final: true,
+      backend: "talkmode",
+    });
+  });
+
+  it("browser preference is a passthrough even when native TalkMode is available", async () => {
+    // `asrProvider: "browser"` is the caller's forced test/dev escape hatch —
+    // it must short-circuit every probe, including the native recognizer.
+    // jsdom has no SpeechRecognition, so start() rejects; the point is that
+    // neither TalkMode nor the WAV recorder was consulted.
+    isNativePlatformMock.mockReturnValue(true);
+    const talkMode = makeFakeTalkMode();
+    getTalkModePluginMock.mockReturnValue(talkMode as never);
+    const capture = createVoiceCapture({
+      asrProvider: "browser",
+      onTranscript: vi.fn(),
+    });
+
+    await expect(capture.start()).rejects.toThrow(/SpeechRecognition/);
+    expect(talkMode.start).not.toHaveBeenCalled();
+    expect(startLocalAsrRecorderMock).not.toHaveBeenCalled();
+    expect(isLocalInferenceAsrReadyMock).not.toHaveBeenCalled();
+  });
+
   it("falls back to browser ONLY when WAV capture is unsupported for eliza-cloud", async () => {
     // No getUserMedia/AudioContext → no WAV path exists, so the honest fallback
     // is the browser recognizer. jsdom has no SpeechRecognition, so start()

--- a/packages/ui/src/voice/voice-capture-factory.ts
+++ b/packages/ui/src/voice/voice-capture-factory.ts
@@ -188,6 +188,19 @@ async function resolveBackendKind(
   if (preferred === "browser") {
     return "browser";
   }
+  // An EXPLICIT cloud ASR preference wins over the native recognizer. The caller
+  // deliberately selected the cloud transcriber (e.g. a device whose platform
+  // speech-recognition service is absent or broken — the Light Phone III has no
+  // usable recognizer and routes SpeechRecognizer back into the app's own
+  // RecognitionService, an infinite hand-off loop), so honor it whenever WAV
+  // capture primitives exist rather than silently using the platform recognizer.
+  // A `local-inference`/undefined preference still prefers native talk-mode below.
+  if (
+    (preferred === "eliza-cloud" || preferred === "openai") &&
+    isLocalAsrCaptureSupported()
+  ) {
+    return "cloud";
+  }
   // Native mobile: the platform speech recognizer (TalkMode) is the working STT
   // path and the only one that streams interim transcripts. Prefer it ahead of
   // the local-inference probe — on mobile that probe can report ready while the

--- a/packages/ui/src/voice/voice-capture-factory.ts
+++ b/packages/ui/src/voice/voice-capture-factory.ts
@@ -188,13 +188,17 @@ async function resolveBackendKind(
   if (preferred === "browser") {
     return "browser";
   }
-  // An EXPLICIT cloud ASR preference wins over the native recognizer. The caller
-  // deliberately selected the cloud transcriber (e.g. a device whose platform
-  // speech-recognition service is absent or broken — the Light Phone III has no
-  // usable recognizer and routes SpeechRecognizer back into the app's own
-  // RecognitionService, an infinite hand-off loop), so honor it whenever WAV
-  // capture primitives exist rather than silently using the platform recognizer.
-  // A `local-inference`/undefined preference still prefers native talk-mode below.
+  // Eliza-cloud / OpenAI ASR: capture the same WAV as the local path and POST
+  // it to the cloud STT proxy (`/api/asr/cloud`) — the real transcriber for the
+  // documented web/cloud `eliza-cloud` default (the browser recognizer is
+  // engine-dependent, or absent, and is NOT the cloud path). An EXPLICIT cloud
+  // preference wins over the native recognizer: the caller deliberately selected
+  // the cloud transcriber (e.g. a device whose platform speech-recognition
+  // service is absent or broken — the Light Phone III has no usable recognizer
+  // and routes SpeechRecognizer back into the app's own RecognitionService, an
+  // infinite hand-off loop), so honor it whenever WAV capture primitives exist
+  // rather than silently using the platform recognizer. A `local-inference`/
+  // undefined preference still prefers native talk-mode below.
   if (
     (preferred === "eliza-cloud" || preferred === "openai") &&
     isLocalAsrCaptureSupported()
@@ -219,16 +223,6 @@ async function resolveBackendKind(
     (await isLocalInferenceAsrReady())
   ) {
     return "local-inference";
-  }
-  // Eliza-cloud / OpenAI ASR: capture the same WAV as the local path and POST
-  // it to the cloud STT proxy (`/api/asr/cloud`). This is the real transcriber
-  // for the documented web/cloud `eliza-cloud` default — the browser recognizer
-  // is engine-dependent (or absent) and is NOT the cloud path.
-  if (
-    (preferred === "eliza-cloud" || preferred === "openai") &&
-    isLocalAsrCaptureSupported()
-  ) {
-    return "cloud";
   }
   // Browser SpeechRecognition is the fallback ONLY where no WAV path exists —
   // a renderer without `getUserMedia`/`AudioContext` can't record a WAV to POST,


### PR DESCRIPTION
## Problem
`resolveBackendKind` in the voice capture factory returned `"talkmode"` (the native platform speech recognizer) for **any** native platform *before* it ever checked an explicit `eliza-cloud`/`openai` ASR preference. So the ambient/hands-free capture (`createVoiceCapture`) always used the native recognizer and silently ignored a configured cloud-STT preference.

On devices whose platform recognizer is absent or broken — e.g. the Light Phone III, which has no recognition service and is its own `RecognitionService`, so a native attempt loops through an `elizaos://voice` hand-off — this made hands-free voice unusable.

## Fix
An **explicit** `eliza-cloud`/`openai` ASR preference now wins over native talk-mode whenever WAV capture primitives exist. `undefined`/`local-inference` still prefer native, so devices with a working recognizer are unchanged. The two previously-duplicated cloud blocks in `resolveBackendKind` are folded into the single early check, so the change is a true reorder with no dead code.

The original revision also read a hidden Capacitor preference key (`eliza:voice-cloud-tts`) in `useShellController.ts` to force the cloud backend. That half is **dropped**: nothing in the repo ever writes that key (verified by repo-wide search), it was named TTS while gating STT, it pinned `eliza-cloud` over an explicitly configured `openai` provider, and its empty catch tripped the error-policy ratchet. `useShellController.ts` is reverted to `develop`.

## Tests
`packages/ui/src/voice/voice-capture-factory.test.ts` gains four backend-selection tests driven through `createVoiceCapture` (jsdom + fake TalkMode plugin, real factory code):

- explicit `eliza-cloud` routes to the cloud STT proxy even when a native TalkMode recognizer is available (recorder started, `talkMode.start` never called, WAV POSTed to `/api/asr/cloud`);
- explicit `openai` does the same;
- explicit cloud **degrades to TalkMode** when WAV capture primitives are absent (no dead browser recognizer);
- the `browser` escape hatch short-circuits every probe, including the native recognizer.

Full suite: 18/18 passing; `voice-capture-factory.ts` per-file line coverage 63.9% (115/180), above the 50% changed-file floor and 55% target.

## Evidence

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - no rendered UI change; the diff touches only the non-visual voice capture factory (`.ts`) and its Vitest suite. Backend selection has no pixels to photograph.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - same as above; no `.tsx`/CSS/HTML surface file is touched.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - the affected hardware (Light Phone III, a device with no platform speech-recognition service) is not available in this environment; the backend-selection behavior is exercised end-to-end by the deterministic Vitest suite linked below (fake TalkMode plugin + real factory), including the interim/final transcript flow.
<!-- evidence-row:backend-logs -->
- Backend logs: N/A - the change is entirely in the client renderer (`packages/ui`); no server code path changes. The cloud proxy endpoint `/api/asr/cloud` is unchanged.
<!-- evidence-row:frontend-logs -->
- Frontend logs: [vitest-voice-capture-factory.log](https://gist.githubusercontent.com/lalalune/a4aa612efc187925ba1575deae71dfba/raw/32559daa0ee6a790c76d9635d544853d5f6d45f8/vitest-voice-capture-factory.log) — full run of the renderer-module suite (18/18 passing) covering the reordered `resolveBackendKind` paths.
<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: N/A - no agent/action/provider/prompt/model behavior changes; this selects the STT capture backend before any transcript reaches the agent. No LLM is in the changed path.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts: [coverage-voice-capture-factory.txt](https://gist.githubusercontent.com/lalalune/a4aa612efc187925ba1575deae71dfba/raw/3f1df3bba834dd7b15d0dd42d06d65b354e94079/coverage-voice-capture-factory.txt) — per-file LCOV line coverage for the changed source file (63.9%, 115/180 lines), reproduced with the coverage-gate workflow's `run-changed-vitest-coverage.mjs`.