### PR TITLE
fix(cloud): make prior-container retirement atomic

### DIFF
--- a/packages/cloud/shared/src/db/container-retirement-migration.test.ts
+++ b/packages/cloud/shared/src/db/container-retirement-migration.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Applies the historical container-retirement repair to real PGlite tables and
+ * proves it creates exactly one durable job without duplicating owned rows.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+const TIMEOUT = 60_000;
+const ORG_ID = "00000000-0000-4000-8000-000000015951";
+const ORPHAN_ID = "00000000-0000-4000-8000-000000215951";
+const OWNED_ID = "00000000-0000-4000-8000-000000315951";
+const OWNED_JOB_ID = "00000000-0000-4000-8000-000000415951";
+const migrationUrl = new URL("./migrations/0176_container_retirement_outbox.sql", import.meta.url);
+
+let dbWrite: typeof import("./client").dbWrite;
+let closeDb: typeof import("./client").closeDatabaseConnectionsForTests | undefined;
+let databaseReady = true;
+
+beforeAll(async () => {
+  try {
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("./client"));
+    await dbWrite.execute(`
+      CREATE TABLE containers (
+        id uuid PRIMARY KEY,
+        organization_id uuid NOT NULL,
+        status text NOT NULL,
+        metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+        updated_at timestamp NOT NULL DEFAULT now()
+      );
+    `);
+    await dbWrite.execute(`
+      CREATE TABLE jobs (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        type text NOT NULL,
+        status text NOT NULL DEFAULT 'pending',
+        data jsonb NOT NULL,
+        data_storage text NOT NULL DEFAULT 'inline',
+        organization_id uuid NOT NULL,
+        created_at timestamp NOT NULL DEFAULT now(),
+        updated_at timestamp NOT NULL DEFAULT now()
+      );
+    `);
+  } catch (error) {
+    databaseReady = false;
+    console.warn("[container-retirement-migration] PGlite setup failed", error);
+  }
+}, TIMEOUT);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+async function applyMigration(): Promise<void> {
+  const sql = readFileSync(fileURLToPath(migrationUrl), "utf8");
+  await dbWrite.execute(sql);
+}
+
+async function deleteJobs(containerId: string): Promise<Array<{ id: string; status: string }>> {
+  const result = await dbWrite.execute(
+    `SELECT id, status FROM jobs
+     WHERE type = 'container_delete' AND data->>'containerId' = '${containerId}'
+     ORDER BY created_at;`,
+  );
+  return result.rows as Array<{ id: string; status: string }>;
+}
+
+describe("0176 container retirement outbox repair", () => {
+  test("is registered in the migration journal", () => {
+    const journal = JSON.parse(
+      readFileSync(
+        fileURLToPath(new URL("./migrations/meta/_journal.json", import.meta.url)),
+        "utf8",
+      ),
+    ) as { entries: Array<{ tag: string }> };
+    expect(journal.entries.some((entry) => entry.tag === "0176_container_retirement_outbox")).toBe(
+      true,
+    );
+  });
+
+  test("repairs only the unowned row and is idempotent", async () => {
+    expect(databaseReady).toBe(true);
+    await dbWrite.execute(
+      `INSERT INTO containers (id, organization_id, status)
+       VALUES
+         ('${ORPHAN_ID}', '${ORG_ID}', 'deleting'),
+         ('${OWNED_ID}', '${ORG_ID}', 'deleting');`,
+    );
+    await dbWrite.execute(
+      `INSERT INTO jobs (id, type, data, organization_id)
+       VALUES (
+         '${OWNED_JOB_ID}',
+         'container_delete',
+         '{"containerId":"${OWNED_ID}","organizationId":"${ORG_ID}"}'::jsonb,
+         '${ORG_ID}'
+       );`,
+    );
+
+    await applyMigration();
+    await applyMigration();
+
+    const orphanJobs = await deleteJobs(ORPHAN_ID);
+    expect(orphanJobs).toHaveLength(1);
+    expect(orphanJobs[0]?.status).toBe("pending");
+    expect(await deleteJobs(OWNED_ID)).toEqual([{ id: OWNED_JOB_ID, status: "pending" }]);
+
+    const container = await dbWrite.execute(
+      `SELECT status, metadata #>> '{retirement,deleteJobId}' AS delete_job_id
+       FROM containers WHERE id = '${ORPHAN_ID}';`,
+    );
+    expect(container.rows).toEqual([
+      {
+        status: "deleting",
+        delete_job_id: orphanJobs[0]?.id,
+      },
+    ]);
+  });
+});
+
+test("PGlite schema applied — migration proofs never silently skip", () => {
+  expect(databaseReady).toBe(true);
+});

--- a/packages/cloud/shared/src/db/migrations/0176_container_retirement_outbox.sql
+++ b/packages/cloud/shared/src/db/migrations/0176_container_retirement_outbox.sql
@@ -1,0 +1,47 @@
+-- Repair pre-atomic-retirement rows by giving every unowned `deleting`
+-- container a pending delete job and recording that ownership in the same
+-- statement. Re-running is a no-op because the live job excludes its row.
+WITH orphaned AS (
+  SELECT c.id, c.organization_id, c.metadata
+  FROM containers c
+  WHERE c.status = 'deleting'
+    AND NOT EXISTS (
+      SELECT 1
+      FROM jobs j
+      WHERE j.type = 'container_delete'
+        AND j.organization_id = c.organization_id
+        AND j.status IN ('pending', 'in_progress')
+        AND j.data->>'containerId' = c.id::text
+    )
+  FOR UPDATE
+), inserted AS (
+  INSERT INTO jobs (id, type, status, data, data_storage, organization_id)
+  SELECT
+    gen_random_uuid(),
+    'container_delete',
+    'pending',
+    jsonb_build_object(
+      'containerId', orphaned.id::text,
+      'organizationId', orphaned.organization_id::text
+    ),
+    'inline',
+    orphaned.organization_id
+  FROM orphaned
+  RETURNING id, organization_id, data
+)
+UPDATE containers c
+SET
+  metadata = jsonb_set(
+    coalesce(c.metadata, '{}'::jsonb),
+    '{retirement}',
+    jsonb_build_object(
+      'deleteJobId', inserted.id::text,
+      'retiredAt', now()::text,
+      'recoveredBy', '0176_container_retirement_outbox'
+    ),
+    true
+  ),
+  updated_at = now()
+FROM inserted
+WHERE c.id = (inserted.data->>'containerId')::uuid
+  AND c.organization_id = inserted.organization_id;

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1226,6 +1226,13 @@
       "when": 1783640127133,
       "tag": "0175_pii_scrub_markers",
       "breakpoints": true
+    },
+    {
+      "idx": 175,
+      "version": "7",
+      "when": 1783726527133,
+      "tag": "0176_container_retirement_outbox",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/lib/services/__tests__/app-deploy-runner-retire.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-deploy-runner-retire.test.ts
@@ -1,21 +1,6 @@
 /**
- * Bug 1 (apps deploy/redeploy lifecycle) — a redeploy must RETIRE the app's
- * pre-existing container row(s) so stale rows from prior deploys stop counting
- * against the per-org container quota.
- *
- * Root cause: every deploy creates a NEW `containers` row under the same project
- * key (project_name = appId) and never retired the prior row. The quota readers
- * (`checkQuota` / `createWithQuotaCheck`) count every row EXCEPT `deleting`/
- * `deleted`, so a prior `running`/`stopped`/`failed` row kept consuming a quota
- * slot forever. The fix flips each prior row to `deleting` (a non-counting state)
- * before the new row is created, and enqueues a CONTAINER_DELETE so the daemon
- * removes the old container + releases its node slot. Net effect: at most one
- * active (quota-counting) row per app.
- *
- * This test wires the real `DefaultAppDeployRunner.run()` against an in-memory
- * `containers` store, simulates a prior `running` deploy, redeploys, and asserts
- * the prior row was flipped to `deleting`, a CONTAINER_DELETE was enqueued for
- * it, and the count of quota-counting rows for the app stays ≤ 1.
+ * Exercises redeploy retirement through an atomic persistence seam, including
+ * ambiguous post-commit failures and a worker transition racing the response.
  */
 
 import { describe, expect, mock, test } from "bun:test";
@@ -24,52 +9,31 @@ const APP_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
 const ORG_ID = "org-retire";
 const USER_ID = "user-retire";
 
-// A minimal in-memory `containers` store keyed by id. Only the columns the
-// runner's retire step + the default createContainerRow touch are modeled.
 interface Row {
   id: string;
   organization_id: string;
   project_name: string;
   status: string;
 }
+
 const rows = new Map<string, Row>();
-
-// Status values whose updateStatus write should throw — lets a test fail a
-// SPECIFIC write (e.g. only the revert back to `running`) to drive the runner's
-// escalation branches. Cleared per test.
-const updateStatusFailures = new Set<string>();
-
-// The set of statuses the quota readers EXCLUDE — a row in any other status
-// counts toward the org cap. Mirrors `notInArray(status, ["deleting","deleted"])`.
 const NON_COUNTING = new Set(["deleting", "deleted"]);
+
 function quotaCountForApp(appId: string): number {
-  let n = 0;
-  for (const row of rows.values()) {
-    if (row.project_name === appId && !NON_COUNTING.has(row.status)) n += 1;
-  }
-  return n;
+  return [...rows.values()].filter(
+    (row) => row.project_name === appId && !NON_COUNTING.has(row.status),
+  ).length;
 }
 
 mock.module("../../../db/repositories/containers", () => ({
   containersRepository: {
-    // Mirrors the real reader: every row for (org, project_name) NOT already
-    // terminal (deleting/deleted).
     findUndeletedByProjectName: async (organizationId: string, projectName: string) =>
       [...rows.values()].filter(
-        (r) =>
-          r.organization_id === organizationId &&
-          r.project_name === projectName &&
-          !NON_COUNTING.has(r.status),
+        (row) =>
+          row.organization_id === organizationId &&
+          row.project_name === projectName &&
+          !NON_COUNTING.has(row.status),
       ),
-    updateStatus: async (id: string, status: string) => {
-      if (updateStatusFailures.has(status)) {
-        throw new Error(`status write rejected: ${status}`);
-      }
-      const row = rows.get(id);
-      if (row) row.status = status;
-      return row ?? null;
-    },
-    // The default createContainerRow path; inserts a fresh `pending` row.
     createWithQuotaCheck: async () => {
       const id = `container-new-${rows.size + 1}`;
       rows.set(id, {
@@ -93,7 +57,6 @@ mock.module("../apps", () => ({
             organization_id: ORG_ID,
             created_by_user_id: USER_ID,
             github_repo: null,
-            // "none" => stateless app, so ensureTenantDb is never called.
             metadata: { databaseMode: "none" },
           }
         : undefined,
@@ -102,178 +65,107 @@ mock.module("../apps", () => ({
 }));
 
 import { DefaultAppDeployRunner } from "../app-deploy-runner";
-import type { ContainerJobInsert, ContainerJobsWriter } from "../container-job-service";
+import type { ContainerJobsWriter } from "../container-job-service";
+import type { ContainerRetirementResult } from "../container-retirement";
 import { JOB_TYPES } from "../provisioning-job-types";
 
-describe("DefaultAppDeployRunner — redeploy retires the prior container row (Bug 1)", () => {
-  test("a redeploy flips the prior row to deleting, enqueues its delete, and keeps quota ≤1", async () => {
-    rows.clear();
-    updateStatusFailures.clear();
-    // Simulate a prior deploy: one live `running` row for this app.
-    rows.set("container-prior", {
-      id: "container-prior",
-      organization_id: ORG_ID,
-      project_name: APP_ID,
-      status: "running",
-    });
-    expect(quotaCountForApp(APP_ID)).toBe(1); // baseline: prior deploy counts
+function seedPrior(status = "running"): void {
+  rows.clear();
+  rows.set("container-prior", {
+    id: "container-prior",
+    organization_id: ORG_ID,
+    project_name: APP_ID,
+    status,
+  });
+}
 
-    const enqueued: ContainerJobInsert[] = [];
-    const jobsWriter: ContainerJobsWriter = {
-      async insertJob(job) {
-        enqueued.push(job);
-        return { id: `job-${enqueued.length}` };
-      },
-    };
+function setRowStatus(containerId: string, status: string): void {
+  const row = rows.get(containerId);
+  if (!row) throw new Error(`Missing test container ${containerId}`);
+  row.status = status;
+}
 
-    const runner = new DefaultAppDeployRunner({
+function makeRunner(
+  retireContainer: (
+    containerId: string,
+    organizationId: string,
+  ) => Promise<ContainerRetirementResult>,
+): { runner: DefaultAppDeployRunner; provisionJobs: string[] } {
+  const provisionJobs: string[] = [];
+  const jobsWriter: ContainerJobsWriter = {
+    async insertJob(job) {
+      if (job.type === JOB_TYPES.CONTAINER_PROVISION) provisionJobs.push(job.type);
+      return { id: `job-${provisionJobs.length}` };
+    },
+  };
+  return {
+    runner: new DefaultAppDeployRunner({
       ensureTenantDb: async () => {
-        throw new Error("ensureTenantDb must NOT be called for a stateless app");
+        throw new Error("ensureTenantDb must not run for a stateless app");
       },
       jobsWriter,
+      retireContainer,
       resolveImage: () => "ghcr.io/elizaos/app:test",
+    }),
+    provisionJobs,
+  };
+}
+
+describe("DefaultAppDeployRunner prior-container retirement", () => {
+  test("retires the prior row before creating the replacement", async () => {
+    seedPrior();
+    const deleteJobs: string[] = [];
+    const { runner } = makeRunner(async (containerId) => {
+      setRowStatus(containerId, "deleting");
+      deleteJobs.push(containerId);
+      return { containerId, jobId: "delete-1", outcome: "retired" };
     });
 
     await runner.run(APP_ID);
 
-    // The prior row was retired to `deleting` (a non-quota-counting state).
     expect(rows.get("container-prior")?.status).toBe("deleting");
-
-    // A CONTAINER_DELETE was enqueued for the prior container so the daemon
-    // removes it + releases its node slot.
-    const deleteJob = enqueued.find(
-      (j) =>
-        j.type === JOB_TYPES.CONTAINER_DELETE &&
-        (j.data as { containerId?: string }).containerId === "container-prior",
-    );
-    expect(deleteJob).toBeDefined();
-    expect(deleteJob?.organizationId).toBe(ORG_ID);
-
-    // A fresh row exists for the new deploy, AND the quota-counting rows for the
-    // app stay ≤ 1 (the retired row no longer counts) — no leak across redeploys.
-    expect([...rows.values()].some((r) => r.status === "pending")).toBe(true);
+    expect(deleteJobs).toEqual(["container-prior"]);
+    expect([...rows.values()].some((row) => row.status === "pending")).toBe(true);
     expect(quotaCountForApp(APP_ID)).toBeLessThanOrEqual(1);
   });
 
-  test("#15826: a failed delete-enqueue reverts the row instead of stranding it in deleting", async () => {
-    rows.clear();
-    updateStatusFailures.clear();
-    rows.set("container-prior", {
-      id: "container-prior",
-      organization_id: ORG_ID,
-      project_name: APP_ID,
-      status: "running",
-    });
-
-    // The delete-enqueue write fails (e.g. the jobs table is unreachable, or the
-    // enqueue-side payload validation throws); the provision enqueue still works
-    // so the new deploy itself proceeds.
-    const enqueued: ContainerJobInsert[] = [];
-    const jobsWriter: ContainerJobsWriter = {
-      async insertJob(job) {
-        if (job.type === JOB_TYPES.CONTAINER_DELETE) {
-          throw new Error("jobs table unavailable");
-        }
-        enqueued.push(job);
-        return { id: `job-${enqueued.length}` };
-      },
-    };
-
-    const runner = new DefaultAppDeployRunner({
-      ensureTenantDb: async () => {
-        throw new Error("ensureTenantDb must NOT be called for a stateless app");
-      },
-      jobsWriter,
-      resolveImage: () => "ghcr.io/elizaos/app:test",
+  test("a pre-commit retirement failure leaves the prior row untouched", async () => {
+    seedPrior();
+    const { runner, provisionJobs } = makeRunner(async () => {
+      throw new Error("transaction rolled back");
     });
 
     await runner.run(APP_ID);
 
-    // The prior row was flipped BACK to its pre-retire status: a `deleting` row
-    // with no CONTAINER_DELETE job is permanently stuck (recovery only fans out
-    // from a claimed legacy job, and `deleting` is excluded from the retire
-    // query), whereas a reverted `running` row is retried by the next deploy.
     expect(rows.get("container-prior")?.status).toBe("running");
-    // The new deploy still went through — retirement stays best-effort.
-    expect([...rows.values()].some((r) => r.status === "pending")).toBe(true);
-    expect(enqueued.some((j) => j.type === JOB_TYPES.CONTAINER_PROVISION)).toBe(true);
+    expect(provisionJobs).toEqual([JOB_TYPES.CONTAINER_PROVISION]);
   });
 
-  test("#15826: a failed revert write escalates loudly and still never blocks the deploy", async () => {
-    rows.clear();
-    updateStatusFailures.clear();
-    rows.set("container-prior", {
-      id: "container-prior",
-      organization_id: ORG_ID,
-      project_name: APP_ID,
-      status: "running",
-    });
-    // Worst case: the enqueue fails AND the revert write back to `running` also
-    // fails (jobs table and containers write path both broken).
-    updateStatusFailures.add("running");
-
-    const enqueued: ContainerJobInsert[] = [];
-    const jobsWriter: ContainerJobsWriter = {
-      async insertJob(job) {
-        if (job.type === JOB_TYPES.CONTAINER_DELETE) {
-          throw new Error("jobs table unavailable");
-        }
-        enqueued.push(job);
-        return { id: `job-${enqueued.length}` };
-      },
-    };
-
-    const runner = new DefaultAppDeployRunner({
-      ensureTenantDb: async () => {
-        throw new Error("ensureTenantDb must NOT be called for a stateless app");
-      },
-      jobsWriter,
-      resolveImage: () => "ghcr.io/elizaos/app:test",
+  test("a commit-then-throw response never compensates a durable retirement", async () => {
+    seedPrior();
+    const durableDeleteJobs: string[] = [];
+    const { runner } = makeRunner(async (containerId) => {
+      setRowStatus(containerId, "deleting");
+      durableDeleteJobs.push(containerId);
+      throw new Error("connection lost after commit");
     });
 
     await runner.run(APP_ID);
 
-    // Both writes failed, so the row IS stuck in `deleting` — the runner's job
-    // is to say so at error level (asserted by the log line in the run output),
-    // not to crash the deploy: the new deploy still proceeds.
     expect(rows.get("container-prior")?.status).toBe("deleting");
-    expect([...rows.values()].some((r) => r.status === "pending")).toBe(true);
-    expect(enqueued.some((j) => j.type === JOB_TYPES.CONTAINER_PROVISION)).toBe(true);
+    expect(durableDeleteJobs).toEqual(["container-prior"]);
   });
 
-  test("#15826: an out-of-vocabulary pre-retire status is never written back", async () => {
-    rows.clear();
-    updateStatusFailures.clear();
-    // `containers.status` is free text at the column level; a corrupted value
-    // must not round-trip through the typed status writer during the revert.
-    rows.set("container-prior", {
-      id: "container-prior",
-      organization_id: ORG_ID,
-      project_name: APP_ID,
-      status: "zombie",
-    });
-
-    const jobsWriter: ContainerJobsWriter = {
-      async insertJob(job) {
-        if (job.type === JOB_TYPES.CONTAINER_DELETE) {
-          throw new Error("jobs table unavailable");
-        }
-        return { id: "job-1" };
-      },
-    };
-
-    const runner = new DefaultAppDeployRunner({
-      ensureTenantDb: async () => {
-        throw new Error("ensureTenantDb must NOT be called for a stateless app");
-      },
-      jobsWriter,
-      resolveImage: () => "ghcr.io/elizaos/app:test",
+  test("an ambiguous response cannot overwrite a terminal worker transition", async () => {
+    seedPrior();
+    const { runner } = makeRunner(async (containerId) => {
+      setRowStatus(containerId, "deleting");
+      setRowStatus(containerId, "deleted");
+      throw new Error("response lost after worker completion");
     });
 
     await runner.run(APP_ID);
 
-    // The guard refused the garbage value, so the row keeps the `deleting` flip
-    // (escalated loudly) rather than having "zombie" written back as a status.
-    expect(rows.get("container-prior")?.status).toBe("deleting");
+    expect(rows.get("container-prior")?.status).toBe("deleted");
   });
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/container-retirement.integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/container-retirement.integration.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Runs atomic container retirement and historical-row reconciliation against
+ * real in-process Postgres semantics, including ambiguous post-commit failure.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+const TIMEOUT = 60_000;
+const ORG_ID = "00000000-0000-4000-8000-000000015951";
+const RUNNING_ID = "00000000-0000-4000-8000-000000115951";
+const TERMINAL_ID = "00000000-0000-4000-8000-000000315951";
+const REJECTED_ID = "00000000-0000-4000-8000-000000515951";
+
+let dbWrite: typeof import("../../../db/client").dbWrite;
+let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
+let retireContainerWithDeleteJob: typeof import("../container-retirement").retireContainerWithDeleteJob;
+let databaseReady = true;
+
+beforeAll(async () => {
+  try {
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
+    ({ retireContainerWithDeleteJob } = await import("../container-retirement"));
+    await dbWrite.execute(`
+      CREATE TABLE IF NOT EXISTS containers (
+        id uuid PRIMARY KEY,
+        organization_id uuid NOT NULL,
+        status text NOT NULL,
+        metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+        updated_at timestamp NOT NULL DEFAULT now()
+      );
+    `);
+    await dbWrite.execute(`
+      CREATE TABLE IF NOT EXISTS jobs (
+        id uuid PRIMARY KEY,
+        type text NOT NULL,
+        status text NOT NULL DEFAULT 'pending',
+        data jsonb NOT NULL,
+        data_storage text NOT NULL DEFAULT 'inline',
+        data_key text,
+        agent_id text,
+        character_id text,
+        result jsonb,
+        result_storage text NOT NULL DEFAULT 'inline',
+        result_key text,
+        error text,
+        error_storage text NOT NULL DEFAULT 'inline',
+        error_key text,
+        attempts integer NOT NULL DEFAULT 0,
+        max_attempts integer NOT NULL DEFAULT 3,
+        organization_id uuid NOT NULL,
+        user_id uuid,
+        api_key_id uuid,
+        generation_id uuid,
+        webhook_url text,
+        webhook_status text,
+        estimated_completion_at timestamp,
+        scheduled_for timestamp NOT NULL DEFAULT now(),
+        started_at timestamp,
+        completed_at timestamp,
+        created_at timestamp NOT NULL DEFAULT now(),
+        updated_at timestamp NOT NULL DEFAULT now(),
+        CONSTRAINT reject_test_delete CHECK (
+          type <> 'container_delete'
+          OR data->>'containerId' <> '${REJECTED_ID}'
+        )
+      );
+    `);
+  } catch (error) {
+    databaseReady = false;
+    console.warn("[container-retirement-test] PGlite setup failed", error);
+  }
+}, TIMEOUT);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+beforeEach(async () => {
+  expect(databaseReady).toBe(true);
+  await dbWrite.execute("DELETE FROM jobs;");
+  await dbWrite.execute("DELETE FROM containers;");
+});
+
+async function seedContainer(id: string, status: string): Promise<void> {
+  await dbWrite.execute(
+    `INSERT INTO containers (id, organization_id, status)
+     VALUES ('${id}', '${ORG_ID}', '${status}');`,
+  );
+}
+
+async function databaseState(containerId: string): Promise<{
+  status: string;
+  deleteJobIds: string[];
+  metadataJobId?: string;
+}> {
+  const containerResult = await dbWrite.execute(
+    `SELECT status, metadata #>> '{retirement,deleteJobId}' AS delete_job_id
+     FROM containers WHERE id = '${containerId}';`,
+  );
+  const jobResult = await dbWrite.execute(
+    `SELECT id FROM jobs
+     WHERE type = 'container_delete'
+       AND data->>'containerId' = '${containerId}'
+     ORDER BY created_at;`,
+  );
+  const container = containerResult.rows[0] as
+    | { status: string; delete_job_id: string | null }
+    | undefined;
+  if (!container) throw new Error(`Missing container ${containerId}`);
+  return {
+    status: container.status,
+    deleteJobIds: jobResult.rows.map((row) => String((row as { id: string }).id)),
+    ...(container.delete_job_id ? { metadataJobId: container.delete_job_id } : {}),
+  };
+}
+
+describe("atomic prior-container retirement", () => {
+  test("a rejected job insert rolls back the deleting transition", async () => {
+    await seedContainer(REJECTED_ID, "running");
+
+    await expect(retireContainerWithDeleteJob(REJECTED_ID, ORG_ID)).rejects.toThrow();
+
+    const state = await databaseState(REJECTED_ID);
+    expect(state.status).toBe("running");
+    expect(state.deleteJobIds).toEqual([]);
+  });
+
+  test("a commit-then-throw boundary leaves deleting paired with one durable job", async () => {
+    await seedContainer(RUNNING_ID, "running");
+
+    await expect(
+      (async () => {
+        await retireContainerWithDeleteJob(RUNNING_ID, ORG_ID);
+        throw new Error("transport failed after database commit");
+      })(),
+    ).rejects.toThrow("after database commit");
+
+    const state = await databaseState(RUNNING_ID);
+    expect(state.status).toBe("deleting");
+    expect(state.deleteJobIds).toHaveLength(1);
+    expect(state.metadataJobId).toBe(state.deleteJobIds[0]);
+
+    const retry = await retireContainerWithDeleteJob(RUNNING_ID, ORG_ID);
+    expect(retry.outcome).toBe("already_owned");
+    expect((await databaseState(RUNNING_ID)).deleteJobIds).toEqual(state.deleteJobIds);
+  });
+
+  test("a worker terminal transition cannot be overwritten by retry compensation", async () => {
+    await seedContainer(TERMINAL_ID, "running");
+    await retireContainerWithDeleteJob(TERMINAL_ID, ORG_ID);
+    await dbWrite.execute(`UPDATE containers SET status = 'deleted' WHERE id = '${TERMINAL_ID}';`);
+
+    const retry = await retireContainerWithDeleteJob(TERMINAL_ID, ORG_ID);
+
+    expect(retry.outcome).toBe("worker_owned");
+    expect((await databaseState(TERMINAL_ID)).status).toBe("deleted");
+  });
+
+  test("cleanup_required remains worker-owned and never receives a delete job", async () => {
+    await seedContainer(TERMINAL_ID, "cleanup_required");
+
+    const result = await retireContainerWithDeleteJob(TERMINAL_ID, ORG_ID);
+
+    expect(result.outcome).toBe("worker_owned");
+    const state = await databaseState(TERMINAL_ID);
+    expect(state.status).toBe("cleanup_required");
+    expect(state.deleteJobIds).toEqual([]);
+  });
+});
+
+test("PGlite schema applied — database proofs never silently skip", () => {
+  expect(databaseReady).toBe(true);
+});

--- a/packages/cloud/shared/src/lib/services/app-deploy-runner.ts
+++ b/packages/cloud/shared/src/lib/services/app-deploy-runner.ts
@@ -42,9 +42,7 @@
  * per-tenant DSN, never the shared agent URL — is asserted directly.
  */
 
-import { ElizaError } from "@elizaos/core";
 import { appDatabasesRepository } from "../../db/repositories/app-databases";
-import { isContainerStatus } from "../../db/repositories/container-status";
 import { containersRepository } from "../../db/repositories/containers";
 import { containersEnv } from "../config/containers-env";
 import { logger } from "../utils/logger";
@@ -61,6 +59,10 @@ import { deriveAppPublicUrl } from "./app-url";
 import { appsService } from "./apps";
 import { imageRequiresDigestPin, isCodingContainerImageAllowed } from "./coding-containers";
 import { ContainerJobEnqueuer, type ContainerJobsWriter } from "./container-job-service";
+import {
+  type ContainerRetirementResult,
+  retireContainerWithDeleteJob,
+} from "./container-retirement";
 import { getOrgImageNamespaces } from "./org-image-namespaces";
 import type { TenantDbProvisioning } from "./tenant-db/tenant-db-provisioning";
 import type { UserDatabaseService } from "./user-database";
@@ -81,6 +83,11 @@ export interface AppDeployRunnerDeps {
   createContainerRow?: (row: NewAppContainerRow) => Promise<{ containerId: string }>;
   /** Enqueues the provision job. Defaults to a `ContainerJobEnqueuer` over the writer. */
   jobsWriter: ContainerJobsWriter;
+  /** Atomically marks a prior row deleting and gives a durable delete job ownership. */
+  retireContainer?: (
+    containerId: string,
+    organizationId: string,
+  ) => Promise<ContainerRetirementResult>;
   /**
    * Resolve the full image reference (`ghcr.io/owner/app:tag`) to deploy. When
    * omitted, falls back to `app.metadata.imageTag` then `APP_DEFAULT_IMAGE`.
@@ -231,12 +238,11 @@ export class DefaultAppDeployRunner implements AppDeployRunner {
     // Every deploy creates a fresh `containers` row under the same project key
     // (project_name = appId); without retiring the old ones, their stale
     // `stopped`/`failed` rows keep counting against the per-org container quota
-    // forever (the quota readers exclude only `deleting`/`deleted`). We flip each
-    // prior row to `deleting` immediately (so it stops counting before the new
-    // row's quota check runs) and enqueue a CONTAINER_DELETE so the daemon
-    // removes the old container + releases its node slot. Net effect: at most one
-    // active row per app.
-    await this.retirePriorContainers(app.organization_id, appId, enqueuer);
+    // forever (the quota readers exclude only `deleting`/`deleted`). The atomic
+    // retirement transaction pairs each non-counting transition with the
+    // CONTAINER_DELETE job that owns teardown. Net effect: at most one active
+    // row per app without an unowned intermediate state.
+    await this.retirePriorContainers(app.organization_id, appId);
 
     const createContainerRow =
       this.deps.createContainerRow ??
@@ -296,80 +302,32 @@ export class DefaultAppDeployRunner implements AppDeployRunner {
   /**
    * Retire every pre-existing container row for an app so stale rows from prior
    * deploys stop counting against the per-org container quota (and the old
-   * containers get torn down on the node). Each prior row is flipped to
-   * `deleting` immediately — a non-quota-counting state — so the quota count
-   * drops BEFORE the new row's createWithQuotaCheck runs (the enqueued
-   * CONTAINER_DELETE is async and would otherwise race the new row's check). The
-   * daemon's CONTAINER_DELETE then does the real `docker rm -f` + node-slot
-   * release and flips the row to terminal `deleted`. Best-effort per row: a
-   * failure to retire one row is logged but never blocks the new deploy. An
-   * enqueue failure AFTER the status flip additionally reverts the row to its
-   * pre-retire status: a `deleting` row with no job is permanently stuck
-   * (recovery only fans out from a claimed legacy job, and `deleting` is
-   * excluded from this retire query), whereas a reverted row is simply retried
-   * by the next deploy's retire pass (#15826).
+   * containers get torn down on the node). Retirement commits `deleting` and
+   * its CONTAINER_DELETE job in one transaction before the new row's quota
+   * check. The daemon owns every later transition; an ambiguous response cannot
+   * trigger compensation that overwrites `deleted` or another worker state.
+   * Best-effort remains at the deploy boundary: a failed transaction leaves
+   * both records untouched and is reported without blocking the new deploy.
    */
-  private async retirePriorContainers(
-    organizationId: string,
-    appId: string,
-    enqueuer: ContainerJobEnqueuer,
-  ): Promise<void> {
+  private async retirePriorContainers(organizationId: string, appId: string): Promise<void> {
     const prior = await containersRepository.findUndeletedByProjectName(organizationId, appId);
+    const retireContainer = this.deps.retireContainer ?? retireContainerWithDeleteJob;
     for (const row of prior) {
-      // Captured before the flip: the revert below must restore the PRE-retire
-      // status even if the row object aliases live state mutated by updateStatus.
-      const preRetireStatus = row.status;
       try {
-        // Mark `deleting` up front so it stops counting toward quota before the
-        // new row's quota check; the daemon's CONTAINER_DELETE finishes the job.
-        await containersRepository.updateStatus(row.id, "deleting");
+        const retirement = await retireContainer(row.id, organizationId);
+        logger.info("[AppDeployRunner] retired prior container row", {
+          appId,
+          containerId: row.id,
+          deleteJobId: retirement.jobId,
+          outcome: retirement.outcome,
+        });
       } catch (error) {
-        // error-policy:J6 retire is best-effort teardown on the deploy path; the untouched row is retried by the next deploy's retire pass.
+        // error-policy:J6 retirement is best-effort for this deploy; the atomic transaction leaves no partial state, and the periodic reconciler repairs historical rows.
         logger.warn("[AppDeployRunner] failed to retire prior container row", {
           appId,
           containerId: row.id,
           error: error instanceof Error ? error.message : String(error),
         });
-        continue;
-      }
-      try {
-        await enqueuer.enqueueDelete({ containerId: row.id, organizationId });
-        logger.info("[AppDeployRunner] retired prior container row", {
-          appId,
-          containerId: row.id,
-        });
-      } catch (error) {
-        // error-policy:J6 teardown stays best-effort for the deploy, but the stuck-`deleting` hazard is reverted and surfaced at error level (an enqueue failure means the jobs write path is broken — systemic, not a per-row blip).
-        const enqueueMessage = error instanceof Error ? error.message : String(error);
-        try {
-          // `containers.status` is free text at the column level; validate the
-          // read-back value before handing it to the typed writer.
-          if (!isContainerStatus(preRetireStatus)) {
-            throw new ElizaError(
-              `Container ${row.id} pre-retire status '${preRetireStatus}' is outside the containers status vocabulary`,
-              {
-                code: "CONTAINER_PRE_RETIRE_STATUS_INVALID",
-                context: { appId, containerId: row.id, preRetireStatus },
-              },
-            );
-          }
-          await containersRepository.updateStatus(row.id, preRetireStatus);
-          logger.error(
-            "[AppDeployRunner] failed to enqueue prior-container delete; reverted the row to its pre-retire status",
-            { appId, containerId: row.id, revertedTo: preRetireStatus, error: enqueueMessage },
-          );
-        } catch (revertError) {
-          // error-policy:J6 last-resort escalation: both writes failed and the row IS stuck in `deleting` with no job — surfaced at error level, never a quiet warn.
-          logger.error(
-            "[AppDeployRunner] failed to enqueue prior-container delete AND failed to revert the row — container row is stuck in deleting with no job",
-            {
-              appId,
-              containerId: row.id,
-              error: enqueueMessage,
-              revertError: revertError instanceof Error ? revertError.message : String(revertError),
-            },
-          );
-        }
       }
     }
   }

--- a/packages/cloud/shared/src/lib/services/container-retirement.ts
+++ b/packages/cloud/shared/src/lib/services/container-retirement.ts
@@ -1,0 +1,179 @@
+/**
+ * Atomically retires app-container rows with their durable delete jobs. The
+ * container row is the serialization point, while migration 0175 repairs rows
+ * created before this invariant existed.
+ */
+
+import { randomUUID } from "node:crypto";
+import { ElizaError } from "@elizaos/core";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import type { DbTransaction } from "../../db/client";
+import { dbWrite } from "../../db/helpers";
+import { containers } from "../../db/schemas/containers";
+import { jobs } from "../../db/schemas/jobs";
+import { logger } from "../utils/logger";
+import { JOB_TYPES } from "./provisioning-job-types";
+
+const LIVE_JOB_STATUSES = ["pending", "in_progress"] as const;
+const WORKER_OWNED_CONTAINER_STATUSES = new Set(["deleted", "cleanup_required"]);
+
+export interface ContainerRetirementResult {
+  containerId: string;
+  jobId?: string;
+  outcome: "retired" | "already_owned" | "missing" | "worker_owned";
+}
+
+interface LockedContainer {
+  id: string;
+  organizationId: string;
+  status: string;
+  metadata: Record<string, unknown>;
+}
+
+async function findLiveDeleteJob(
+  tx: DbTransaction,
+  containerId: string,
+  organizationId: string,
+): Promise<{ id: string } | undefined> {
+  const [job] = await tx
+    .select({ id: jobs.id })
+    .from(jobs)
+    .where(
+      and(
+        eq(jobs.type, JOB_TYPES.CONTAINER_DELETE),
+        eq(jobs.organization_id, organizationId),
+        inArray(jobs.status, LIVE_JOB_STATUSES),
+        sql`${jobs.data}->>'containerId' = ${containerId}`,
+      ),
+    )
+    .orderBy(jobs.created_at)
+    .limit(1);
+  return job;
+}
+
+function retirementMetadata(
+  metadata: Record<string, unknown>,
+  jobId: string,
+): Record<string, unknown> {
+  return {
+    ...metadata,
+    retirement: {
+      deleteJobId: jobId,
+      retiredAt: new Date().toISOString(),
+    },
+  };
+}
+
+function ownedDeleteJobId(metadata: Record<string, unknown>): string | undefined {
+  const retirement = metadata.retirement;
+  if (typeof retirement !== "object" || retirement === null) return undefined;
+  const deleteJobId = Reflect.get(retirement, "deleteJobId");
+  return typeof deleteJobId === "string" ? deleteJobId : undefined;
+}
+
+async function retireLockedContainer(
+  tx: DbTransaction,
+  row: LockedContainer,
+): Promise<ContainerRetirementResult> {
+  if (WORKER_OWNED_CONTAINER_STATUSES.has(row.status)) {
+    return { containerId: row.id, outcome: "worker_owned" };
+  }
+
+  const existingJob = await findLiveDeleteJob(tx, row.id, row.organizationId);
+  if (
+    existingJob &&
+    row.status === "deleting" &&
+    ownedDeleteJobId(row.metadata) === existingJob.id
+  ) {
+    return {
+      containerId: row.id,
+      jobId: existingJob.id,
+      outcome: "already_owned",
+    };
+  }
+  const jobId = existingJob?.id ?? randomUUID();
+
+  if (!existingJob) {
+    await tx.insert(jobs).values({
+      id: jobId,
+      type: JOB_TYPES.CONTAINER_DELETE,
+      organization_id: row.organizationId,
+      data: { containerId: row.id, organizationId: row.organizationId },
+      data_storage: "inline",
+    });
+  }
+
+  const [updated] = await tx
+    .update(containers)
+    .set({
+      status: "deleting",
+      metadata: retirementMetadata(row.metadata, jobId),
+      updated_at: new Date(),
+    })
+    .where(
+      and(
+        eq(containers.id, row.id),
+        eq(containers.organization_id, row.organizationId),
+        eq(containers.status, row.status),
+      ),
+    )
+    .returning({ id: containers.id });
+
+  if (!updated) {
+    throw new ElizaError(
+      `Container ${row.id} changed while its retirement transaction held the row`,
+      {
+        code: "CONTAINER_RETIREMENT_CAS_MISSED",
+        context: {
+          containerId: row.id,
+          organizationId: row.organizationId,
+          expectedStatus: row.status,
+        },
+      },
+    );
+  }
+
+  return {
+    containerId: row.id,
+    jobId,
+    outcome: existingJob ? "already_owned" : "retired",
+  };
+}
+
+async function lockContainer(
+  tx: DbTransaction,
+  containerId: string,
+  organizationId: string,
+): Promise<LockedContainer | undefined> {
+  const [row] = await tx
+    .select({
+      id: containers.id,
+      organizationId: containers.organization_id,
+      status: containers.status,
+      metadata: containers.metadata,
+    })
+    .from(containers)
+    .where(and(eq(containers.id, containerId), eq(containers.organization_id, organizationId)))
+    .for("update")
+    .limit(1);
+  return row;
+}
+
+/** Commit the non-quota-counting state and durable teardown ownership together. */
+export async function retireContainerWithDeleteJob(
+  containerId: string,
+  organizationId: string,
+): Promise<ContainerRetirementResult> {
+  const result = await dbWrite.transaction(async (tx) => {
+    const row = await lockContainer(tx, containerId, organizationId);
+    if (!row) return { containerId, outcome: "missing" as const };
+    return retireLockedContainer(tx, row);
+  });
+  logger.info("[ContainerRetirement] retirement transaction committed", {
+    containerId,
+    organizationId,
+    deleteJobId: result.jobId,
+    outcome: result.outcome,
+  });
+  return result;
+}

--- a/packages/cloud/shared/src/lib/services/container-retirement.ts
+++ b/packages/cloud/shared/src/lib/services/container-retirement.ts
@@ -1,6 +1,6 @@
 /**
  * Atomically retires app-container rows with their durable delete jobs. The
- * container row is the serialization point, while migration 0175 repairs rows
+ * container row is the serialization point, while migration 0176 repairs rows
  * created before this invariant existed.
  */
 


### PR DESCRIPTION
Fixes #15951

## Summary

- retires each prior container and creates its durable `container_delete` job in one organization-scoped database transaction
- locks the container row, preserves worker-owned terminal states, reuses an existing live delete job, and records the job ID in retirement metadata so retries are idempotent
- removes deploy-runner compensation that could overwrite a worker's `deleted` or `cleanup_required` transition after an ambiguous commit response
- adds migration `0176_container_retirement_outbox` to atomically recover historical `deleting` rows that have no live delete job
- proves rollback, commit-then-throw, retry, terminal-worker ownership, migration recovery, and migration idempotency against real PGlite tables

## Verification

- focused retirement and migration suites — 12 pass across 3 files, 36 assertions
- `bun run --cwd packages/cloud/shared typecheck` — pass
- `bun run --cwd packages/cloud/shared db:check-migrations` — pass
- Biome on all 5 touched TypeScript/test files — pass
- exact changed-file coverage lane — pass: `app-deploy-runner.ts` 71.78%, `container-retirement.ts` 92.14%, mean 81.96% (50% floor)
- `bun run audit:error-policy-ratchet` — pass, 0 new fallback slop
- `bun run audit:type-safety-ratchet` — pass
- `bun run audit:test-realness` — 0 diff-scoped regressions
- `git diff origin/develop...HEAD --check` — pass

The full cloud-shared package suite was also attempted after rebuilding all workspace dependencies. It remained CPU-active without a failure summary for more than 32 minutes and reached roughly 18 GB RSS, so I stopped that pathological local run. The exact affected lane above completes cleanly; the PR checks provide the clean CI-wide result.

## Manual evidence review

I ran the production retirement service and recovery migration against real PGlite tables, then opened and reviewed the structured logs and queried rows. After a simulated response loss following commit, the container is `deleting`, its metadata job ID exactly matches one durable pending delete job, and retry after a worker transition returns `worker_owned` while preserving `deleted`. Applying the historical repair creates exactly one linked pending job for the orphaned row and remains idempotent.

## Evidence matrix

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI source changed

<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI source changed

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI source changed

<!-- evidence-row:backend-logs -->
- [x] [production service and PGlite transaction log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15951-database-evidence.log)

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend source or browser path changed

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt, provider, or model behavior changed

<!-- evidence-row:domain-artifacts -->
- [x] [queried container and delete-job rows](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15951-database-evidence.log)

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered UI source changed
