### PR TITLE
fix(corpus): bind reviewed deletion to pre-delete corpus

### DIFF
--- a/packages/corpus-tools/src/verification.test.ts
+++ b/packages/corpus-tools/src/verification.test.ts
@@ -18,6 +18,7 @@ import {
 
 const RULESET = "verification-test-v1";
 const GENERATED_AT = "2026-07-09T00:00:00.000Z";
+const DEFAULT_CANDIDATE = "Original Sender";
 const temporaryDirectories: string[] = [];
 
 function sha256(value: string): string {
@@ -33,6 +34,10 @@ function canonicalJson(value: unknown): string {
       .join(",")}}`;
   }
   return JSON.stringify(value);
+}
+
+function defaultCanaryPlaceholder(): string {
+  return `[[PII:person:${sha256(`${RULESET}\0${DEFAULT_CANDIDATE}`).slice(0, 12)}]]`;
 }
 
 function ledgerRecord(
@@ -117,8 +122,8 @@ async function fixture(
   const manifestPath = path.join(artifactDir, "manifest.json");
   await writeJson(manifestPath, manifest);
 
-  const candidate = options.candidate ?? "original-owner-name";
-  const candidateKind = candidate.includes("@") ? "email" : "original";
+  const candidate = options.candidate ?? DEFAULT_CANDIDATE;
+  const candidateKind = candidate.includes("@") ? "email" : "person";
   const candidateHash = sha256(`${RULESET}\0${candidate}`);
   const mineText = `Source ${candidate}`;
   const candidateStart = mineText.indexOf(candidate);
@@ -145,7 +150,7 @@ async function fixture(
   const canaryPlaceholder =
     options.canaryPlaceholder ??
     message.text.match(/\[\[SECRET:[^\]]+\]\]/)?.[0] ??
-    "[[SECRET:openai-key:0123456789ab]]";
+    defaultCanaryPlaceholder();
   const canariesPath = path.join(artifactDir, "canaries.json");
   await writeJson(canariesPath, {
     schemaVersion: 1,
@@ -162,20 +167,32 @@ async function fixture(
   const raw = {
     ...message,
     text: mineText,
+    senderDisplay:
+      options.candidate === undefined ? candidate : message.senderDisplay,
     scrubState: "raw",
   } as CorpusMessage;
   const mined = {
     ...message,
     text: mineText,
+    senderDisplay:
+      options.candidate === undefined ? candidate : message.senderDisplay,
     scrubState: "mined",
   } as CorpusMessage;
   const swapped = { ...message, scrubState: "swapped" } as CorpusMessage;
+  const deleted = {
+    ...swapped,
+    attachments: swapped.attachments.map((attachment) => ({
+      filename: attachment.filename,
+      mimeType: attachment.mimeType,
+      sha256: attachment.sha256,
+    })),
+  } as CorpusMessage;
   const rewritten = { ...message, scrubState: "rewritten" } as CorpusMessage;
   const ledgerRecords = [
     ledgerRecord(raw, mined, "mine"),
     ledgerRecord(mined, swapped, "secrets"),
-    ledgerRecord(swapped, swapped, "delete", "delete-v1"),
-    ledgerRecord(swapped, rewritten, "rewrite"),
+    ledgerRecord(swapped, deleted, "delete", "delete-v1"),
+    ledgerRecord(deleted, rewritten, "rewrite"),
     ledgerRecord(rewritten, rewritten, "llm"),
   ];
   const ledgerPath = path.join(artifactDir, "scrub-ledger.jsonl");
@@ -218,13 +235,7 @@ async function fixture(
     groups: [],
   };
   await writeJson(deletionRulesPath, deletionRules);
-  const shardBytes = await fs.readFile(shardPath);
-  const corpusDigest = createHash("sha256")
-    .update("gmail/work/2026-06.jsonl")
-    .update("\0")
-    .update(shardBytes)
-    .update("\0")
-    .digest("hex");
+  const corpusDigest = sha256(canonicalJson([swapped]));
   deletionQueue.corpusDigest = corpusDigest;
   await writeJson(deletionReviewQueuePath, deletionQueue);
   const reviewedQueueSha256 = sha256(canonicalJson(deletionQueue));
@@ -240,19 +251,45 @@ async function fixture(
     decisions: [],
   };
   await writeJson(deletionReviewDecisionPath, deletionDecision);
+  const reviewDecisionSha256 = sha256(canonicalJson(deletionDecision));
+  const deleteStageVersion = `delete-v1:${rulesSha256.slice(0, 12)}:${reviewedQueueSha256.slice(0, 12)}:${reviewDecisionSha256.slice(0, 12)}`;
+  Object.assign(ledgerRecords[2], {
+    stageVersion: deleteStageVersion,
+    markerKey: [
+      `pii:${ledgerRecords[2].inputHash}:v${RULESET}`,
+      "delete",
+      deleteStageVersion,
+    ].join(":"),
+    rulesSha256,
+    reviewedQueueSha256,
+    reviewDecisionSha256,
+  });
+  await fs.writeFile(
+    ledgerPath,
+    `${ledgerRecords.map((record) => JSON.stringify(record)).join("\n")}\n`,
+  );
   const deletionApprovalPath = path.join(artifactDir, "deletion-approval.json");
   await writeJson(deletionApprovalPath, {
     schemaVersion: 1,
     rulesetVersion: RULESET,
     corpusDigest,
     candidatesSha256: deletionCandidatesSha256,
-    deleteStageVersion: "delete-v1",
+    deleteStageVersion,
     approved: true,
     rulesSha256,
     reviewedQueueSha256,
-    reviewDecisionSha256: sha256(canonicalJson(deletionDecision)),
+    reviewDecisionSha256,
     tombstoneIdsSha256: sha256(canonicalJson([])),
     tombstoneCount: 0,
+    survivorCount: 1,
+    attachmentBytesDropped: swapped.attachments.reduce(
+      (total, attachment) =>
+        total +
+        (attachment.dataBase64 !== undefined
+          ? Buffer.from(attachment.dataBase64, "base64").length
+          : (attachment.bytes ?? 0)),
+      0,
+    ),
   });
   const placeholderRegistryPath = path.join(
     artifactDir,
@@ -265,7 +302,10 @@ async function fixture(
   ].map((match) => ({
     placeholder: match[0],
     kind: match[1],
-    valueHash: `${match[2]}${"0".repeat(52)}`,
+    valueHash:
+      match[2] === candidateHash.slice(0, 12)
+        ? candidateHash
+        : `${match[2]}${"0".repeat(52)}`,
     stage: "secrets",
     messageId: message.id,
   }));
@@ -297,6 +337,74 @@ async function fixture(
   };
 }
 
+async function rebindDeletionArtifacts(
+  options: VerifyCorpusOptions,
+  rules: Record<string, unknown>,
+): Promise<void> {
+  await writeJson(options.deletionRulesPath, rules);
+  const normalizedRules = {
+    ...rules,
+    rules: [...((rules.rules as Record<string, unknown>[]) ?? [])].sort(
+      (left, right) => String(left.id).localeCompare(String(right.id)),
+    ),
+  };
+  const rulesSha256 = sha256(canonicalJson(normalizedRules));
+  const ledger = (await fs.readFile(options.ledgerPath, "utf8"))
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+  const deletionInputs = ledger
+    .filter(
+      (record) =>
+        record.stage === "secrets" && !record.tombstone && record.output,
+    )
+    .map((record) => record.output as CorpusMessage)
+    .sort((left, right) => left.id.localeCompare(right.id));
+  const corpusDigest = sha256(canonicalJson(deletionInputs));
+  const queue = JSON.parse(
+    await fs.readFile(options.deletionReviewQueuePath, "utf8"),
+  ) as Record<string, unknown>;
+  Object.assign(queue, { corpusDigest, rulesSha256 });
+  await writeJson(options.deletionReviewQueuePath, queue);
+  const reviewedQueueSha256 = sha256(canonicalJson(queue));
+  const decision = JSON.parse(
+    await fs.readFile(options.deletionReviewDecisionPath, "utf8"),
+  ) as Record<string, unknown>;
+  Object.assign(decision, { corpusDigest, rulesSha256, reviewedQueueSha256 });
+  await writeJson(options.deletionReviewDecisionPath, decision);
+  const reviewDecisionSha256 = sha256(canonicalJson(decision));
+  const deleteStageVersion = `delete-v1:${rulesSha256.slice(0, 12)}:${reviewedQueueSha256.slice(0, 12)}:${reviewDecisionSha256.slice(0, 12)}`;
+  const approval = JSON.parse(
+    await fs.readFile(options.deletionApprovalPath, "utf8"),
+  ) as Record<string, unknown>;
+  await writeJson(options.deletionApprovalPath, {
+    ...approval,
+    corpusDigest,
+    rulesSha256,
+    reviewedQueueSha256,
+    reviewDecisionSha256,
+    deleteStageVersion,
+  });
+  for (const record of ledger) {
+    if (record.stage !== "delete" || record.tombstone) continue;
+    record.stageVersion = deleteStageVersion;
+    record.markerKey = [
+      `pii:${record.inputHash}:v${RULESET}`,
+      "delete",
+      deleteStageVersion,
+    ].join(":");
+    Object.assign(record, {
+      rulesSha256,
+      reviewedQueueSha256,
+      reviewDecisionSha256,
+    });
+  }
+  await fs.writeFile(
+    options.ledgerPath,
+    `${ledger.map((record) => JSON.stringify(record)).join("\n")}\n`,
+  );
+}
+
 afterEach(async () => {
   await Promise.all(
     temporaryDirectories
@@ -307,7 +415,7 @@ afterEach(async () => {
 
 describe("corpus verification", () => {
   it("binds a green report to exact corpus bytes and rejects tampering", async () => {
-    const placeholder = "[[SECRET:openai-key:0123456789ab]]";
+    const placeholder = defaultCanaryPlaceholder();
     const options = await fixture(
       baseMessage({ text: `Scrubbed body ${placeholder}` }),
       { canaryPlaceholder: placeholder },
@@ -318,6 +426,10 @@ describe("corpus verification", () => {
       [],
     );
     expect(report.status).toBe("passed");
+    const deletionApproval = JSON.parse(
+      await fs.readFile(options.deletionApprovalPath, "utf8"),
+    ) as { corpusDigest: string };
+    expect(deletionApproval.corpusDigest).not.toBe(report.corpusDigest);
     await expect(
       assertFreshGreenVerification(report, options),
     ).resolves.toBeUndefined();
@@ -352,7 +464,7 @@ describe("corpus verification", () => {
     "placeholderRegistryPath",
     "gitleaksConfigPath",
   ] as const)("rejects a report after %s changes", async (pathKey) => {
-    const placeholder = "[[SECRET:openai-key:0123456789ab]]";
+    const placeholder = defaultCanaryPlaceholder();
     const options = await fixture(
       baseMessage({ text: `Scrubbed body ${placeholder}` }),
       { canaryPlaceholder: placeholder },
@@ -427,7 +539,17 @@ describe("corpus verification", () => {
     await fs.writeFile(options.candidatesPath, `${JSON.stringify(line)}\n`);
 
     await expect(verifyCorpus(options)).rejects.toThrow(
-      "mine candidate artifact is incomplete",
+      "mine candidate artifact does not exactly match mining rerun",
+    );
+  });
+
+  it("rejects extra or duplicate mine candidates", async () => {
+    const options = await fixture(baseMessage());
+    const row = (await fs.readFile(options.candidatesPath, "utf8")).trim();
+    await fs.writeFile(options.candidatesPath, `${row}\n${row}\n`);
+
+    await expect(verifyCorpus(options)).rejects.toThrow(
+      "mine candidate artifact does not exactly match mining rerun",
     );
   });
 
@@ -443,6 +565,193 @@ describe("corpus verification", () => {
 
     await expect(verifyCorpus(options)).rejects.toThrow(
       "ambiguous mine ledger history",
+    );
+  });
+
+  it("rejects a mine row without an exact secrets successor", async () => {
+    const options = await fixture(baseMessage());
+    const orphanInput = baseMessage({
+      id: "orphan-mine",
+      threadId: "orphan-thread",
+      scrubState: "raw",
+    });
+    const orphanOutput = {
+      ...orphanInput,
+      scrubState: "mined",
+    } as CorpusMessage;
+    await fs.appendFile(
+      options.ledgerPath,
+      `${JSON.stringify(ledgerRecord(orphanInput, orphanOutput, "mine"))}\n`,
+    );
+
+    await expect(verifyCorpus(options)).rejects.toThrow(
+      "mine and secrets ledger stages do not match exactly",
+    );
+  });
+
+  it("canonicalizes deletion rule order when validating provenance", async () => {
+    const placeholder = defaultCanaryPlaceholder();
+    const options = await fixture(baseMessage({ text: placeholder }), {
+      canaryPlaceholder: placeholder,
+    });
+    const rules = JSON.parse(
+      await fs.readFile(options.deletionRulesPath, "utf8"),
+    ) as Record<string, unknown>;
+    rules.rules = [
+      {
+        id: "z-disabled",
+        enabled: false,
+        scope: "message",
+        match: { type: "label", value: "Z" },
+      },
+      {
+        id: "a-disabled",
+        enabled: false,
+        scope: "message",
+        match: { type: "label", value: "A" },
+      },
+    ];
+    await rebindDeletionArtifacts(options, rules);
+
+    const report = await verifyCorpus(options);
+
+    expect(report.findings, JSON.stringify(report.findings, null, 2)).toEqual(
+      [],
+    );
+    expect(report.status).toBe("passed");
+  });
+
+  it("matches token-mode keyword phrases at word boundaries", async () => {
+    const options = await fixture(baseMessage());
+    const rules = {
+      schemaVersion: 1,
+      rulesetVersion: RULESET,
+      attachmentPolicy: {
+        embeddedBytes: "drop",
+        retainMetadata: ["filename", "mimeType", "sha256"],
+      },
+      rules: [
+        {
+          id: "phrase-match",
+          enabled: true,
+          scope: "message",
+          match: {
+            type: "keyword",
+            value: "scrubbed body",
+            mode: "token",
+            fields: ["text"],
+          },
+        },
+      ],
+    };
+    const ruleIdHashes = [sha256("phrase-match")];
+    const groupId = sha256(
+      canonicalJson({
+        scope: "message",
+        platform: "gmail",
+        messageIds: ["message-1"],
+        ruleIdHashes,
+      }),
+    );
+    const queue = JSON.parse(
+      await fs.readFile(options.deletionReviewQueuePath, "utf8"),
+    ) as Record<string, unknown>;
+    queue.groups = [
+      {
+        groupId,
+        scope: "message",
+        platform: "gmail",
+        messageIds: ["message-1"],
+        ruleIdHashes,
+        matchClasses: ["keyword"],
+        redactedContext: "[MATCH].",
+        suggestedDecision: "delete",
+      },
+    ];
+    await writeJson(options.deletionReviewQueuePath, queue);
+    const decision = JSON.parse(
+      await fs.readFile(options.deletionReviewDecisionPath, "utf8"),
+    ) as Record<string, unknown>;
+    decision.decisions = [{ groupId, decision: "keep" }];
+    await writeJson(options.deletionReviewDecisionPath, decision);
+    await rebindDeletionArtifacts(options, rules);
+
+    const report = await verifyCorpus(options);
+
+    expect(report.status).toBe("failed");
+    expect(report.findings).toEqual([
+      expect.objectContaining({ detector: "canary-placeholder" }),
+    ]);
+  });
+
+  it("rejects a forged delete-stage version", async () => {
+    const options = await fixture(baseMessage());
+    const approval = JSON.parse(
+      await fs.readFile(options.deletionApprovalPath, "utf8"),
+    ) as Record<string, unknown>;
+    approval.deleteStageVersion = "delete-v1:forged";
+    await writeJson(options.deletionApprovalPath, approval);
+
+    await expect(verifyCorpus(options)).rejects.toThrow(
+      "deletion approval delete stage version is invalid",
+    );
+  });
+
+  it("rejects a pre-delete message omitted from both survivors and tombstones", async () => {
+    const options = await fixture(baseMessage());
+    const orphan = baseMessage({
+      id: "message-orphan",
+      threadId: "thread-orphan",
+      scrubState: "swapped",
+    });
+    const orphanInput = { ...orphan, scrubState: "mined" } as CorpusMessage;
+    const orphanRaw = { ...orphan, scrubState: "raw" } as CorpusMessage;
+    await fs.appendFile(
+      options.ledgerPath,
+      `${JSON.stringify(ledgerRecord(orphanRaw, orphanInput, "mine"))}\n${JSON.stringify(ledgerRecord(orphanInput, orphan, "secrets"))}\n`,
+    );
+    const rules = JSON.parse(
+      await fs.readFile(options.deletionRulesPath, "utf8"),
+    ) as Record<string, unknown>;
+    await rebindDeletionArtifacts(options, rules);
+
+    const report = await verifyCorpus(options);
+
+    expect(report.status).toBe("failed");
+    expect(report.findings).toContainEqual(
+      expect.objectContaining({ detector: "deletion-input-partition" }),
+    );
+  });
+
+  it("rejects a deletion approval with the wrong survivor count", async () => {
+    const options = await fixture(baseMessage());
+    const approval = JSON.parse(
+      await fs.readFile(options.deletionApprovalPath, "utf8"),
+    ) as Record<string, unknown>;
+    approval.survivorCount = 2;
+    await writeJson(options.deletionApprovalPath, approval);
+
+    const report = await verifyCorpus(options);
+
+    expect(report.status).toBe("failed");
+    expect(report.findings).toContainEqual(
+      expect.objectContaining({ detector: "deletion-survivor-count" }),
+    );
+  });
+
+  it("rejects a deletion approval with the wrong attachment drop count", async () => {
+    const options = await fixture(baseMessage());
+    const approval = JSON.parse(
+      await fs.readFile(options.deletionApprovalPath, "utf8"),
+    ) as Record<string, unknown>;
+    approval.attachmentBytesDropped = 1;
+    await writeJson(options.deletionApprovalPath, approval);
+
+    const report = await verifyCorpus(options);
+
+    expect(report.status).toBe("failed");
+    expect(report.findings).toContainEqual(
+      expect.objectContaining({ detector: "deletion-attachment-drop-count" }),
     );
   });
 
@@ -487,15 +796,134 @@ describe("corpus verification", () => {
     const approval = JSON.parse(
       await fs.readFile(options.deletionApprovalPath, "utf8"),
     ) as Record<string, unknown>;
+    const reviewDecisionSha256 = sha256(canonicalJson(decision));
+    const deleteStageVersion = `delete-v1:${rulesSha256.slice(0, 12)}:${reviewedQueueSha256.slice(0, 12)}:${reviewDecisionSha256.slice(0, 12)}`;
+    await writeJson(options.deletionApprovalPath, {
+      ...approval,
+      deleteStageVersion,
+      rulesSha256,
+      reviewedQueueSha256,
+      reviewDecisionSha256,
+    });
+
+    await expect(verifyCorpus(options)).rejects.toThrow(
+      "deletion review queue does not match canonical grouping",
+    );
+  });
+
+  it("rejects split groups that permit contradictory thread decisions", async () => {
+    const options = await fixture(
+      baseMessage({ labels: ["Sensitive", "Delete"] }),
+    );
+    const rules = {
+      schemaVersion: 1,
+      rulesetVersion: RULESET,
+      attachmentPolicy: {
+        embeddedBytes: "drop",
+        retainMetadata: ["filename", "mimeType", "sha256"],
+      },
+      rules: [
+        {
+          id: "thread-sensitive",
+          enabled: true,
+          scope: "thread",
+          match: { type: "label", value: "Sensitive" },
+        },
+        {
+          id: "message-delete",
+          enabled: true,
+          scope: "message",
+          match: { type: "label", value: "Delete" },
+        },
+      ],
+    };
+    await writeJson(options.deletionRulesPath, rules);
+    const rulesSha256 = sha256(
+      canonicalJson({
+        ...rules,
+        rules: [...rules.rules].sort((a, b) => a.id.localeCompare(b.id)),
+      }),
+    );
+    const queue = JSON.parse(
+      await fs.readFile(options.deletionReviewQueuePath, "utf8"),
+    ) as Record<string, unknown>;
+    const threadRuleHashes = [sha256("thread-sensitive")];
+    const messageRuleHashes = [sha256("message-delete")];
+    const threadGroupId = sha256(
+      canonicalJson({
+        scope: "thread",
+        platform: "gmail",
+        messageIds: ["message-1"],
+        ruleIdHashes: threadRuleHashes,
+      }),
+    );
+    const messageGroupId = sha256(
+      canonicalJson({
+        scope: "message",
+        platform: "gmail",
+        messageIds: ["message-1"],
+        ruleIdHashes: messageRuleHashes,
+      }),
+    );
+    Object.assign(queue, {
+      rulesSha256,
+      groups: [
+        {
+          groupId: threadGroupId,
+          scope: "thread",
+          platform: "gmail",
+          messageIds: ["message-1"],
+          ruleIdHashes: threadRuleHashes,
+          matchClasses: ["label"],
+          redactedContext: "kept thread",
+          suggestedDecision: "delete",
+        },
+        {
+          groupId: messageGroupId,
+          scope: "message",
+          platform: "gmail",
+          messageIds: ["message-1"],
+          ruleIdHashes: messageRuleHashes,
+          matchClasses: ["label"],
+          redactedContext: "deleted message",
+          suggestedDecision: "delete",
+        },
+      ],
+    });
+    await writeJson(options.deletionReviewQueuePath, queue);
+    const reviewedQueueSha256 = sha256(canonicalJson(queue));
+    const decision = {
+      schemaVersion: 1,
+      rulesetVersion: RULESET,
+      corpusDigest: queue.corpusDigest,
+      rulesSha256,
+      reviewedQueueSha256,
+      approved: true,
+      reviewedBy: "test-owner",
+      reviewedAt: GENERATED_AT,
+      decisions: [
+        { groupId: threadGroupId, decision: "keep" },
+        { groupId: messageGroupId, decision: "delete" },
+      ],
+    };
+    await writeJson(options.deletionReviewDecisionPath, decision);
+    const reviewDecisionSha256 = sha256(canonicalJson(decision));
+    const approval = JSON.parse(
+      await fs.readFile(options.deletionApprovalPath, "utf8"),
+    ) as Record<string, unknown>;
     await writeJson(options.deletionApprovalPath, {
       ...approval,
       rulesSha256,
       reviewedQueueSha256,
-      reviewDecisionSha256: sha256(canonicalJson(decision)),
+      reviewDecisionSha256,
+      deleteStageVersion: `delete-v1:${rulesSha256.slice(0, 12)}:${reviewedQueueSha256.slice(0, 12)}:${reviewDecisionSha256.slice(0, 12)}`,
+      tombstoneCount: 1,
+      tombstoneIdsSha256: sha256(canonicalJson(["message-1"])),
+      survivorCount: 0,
     });
 
     await expect(verifyCorpus(options)).rejects.toThrow(
-      "deletion review queue does not match rules and corpus",
+      "deletion review queue does not match canonical grouping",
     );
   });
 
@@ -525,6 +953,45 @@ describe("corpus verification", () => {
       expect.objectContaining({
         kind: "ledger",
         detector: "broken-stage-chain",
+      }),
+    );
+  });
+
+  it("rejects a survivor delete record that changes content", async () => {
+    const options = await fixture(baseMessage());
+    const records = (await fs.readFile(options.ledgerPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    const deleteRecord = records.find((record) => record.stage === "delete");
+    const rewriteRecord = records.find((record) => record.stage === "rewrite");
+    if (!deleteRecord || !rewriteRecord || !deleteRecord.output) {
+      throw new Error("fixture is missing delete/rewrite records");
+    }
+    const maliciousOutput = {
+      ...(deleteRecord.output as CorpusMessage),
+      text: "Delete stage changed content.",
+    };
+    const maliciousHash = sha256(JSON.stringify(maliciousOutput));
+    deleteRecord.output = maliciousOutput;
+    deleteRecord.outputHash = maliciousHash;
+    rewriteRecord.inputHash = maliciousHash;
+    rewriteRecord.markerKey = [
+      `pii:${maliciousHash}:v${RULESET}`,
+      "rewrite",
+      rewriteRecord.stageVersion,
+    ].join(":");
+    await fs.writeFile(
+      options.ledgerPath,
+      `${records.map((record) => JSON.stringify(record)).join("\n")}\n`,
+    );
+
+    const report = await verifyCorpus(options);
+
+    expect(report.status).toBe("failed");
+    expect(report.findings).toContainEqual(
+      expect.objectContaining({
+        detector: "invalid-deletion-survivor-transform",
       }),
     );
   });
@@ -565,7 +1032,7 @@ describe("corpus verification", () => {
         messageIds: ["message-1"],
         ruleIdHashes,
         matchClasses: ["label"],
-        redactedContext: "[MATCH]",
+        redactedContext: "Scrubbed body.",
         suggestedDecision: "delete",
       },
     ];
@@ -586,11 +1053,14 @@ describe("corpus verification", () => {
     const approval = JSON.parse(
       await fs.readFile(options.deletionApprovalPath, "utf8"),
     ) as Record<string, unknown>;
+    const reviewDecisionSha256 = sha256(canonicalJson(decision));
+    const deleteStageVersion = `delete-v1:${rulesSha256.slice(0, 12)}:${reviewedQueueSha256.slice(0, 12)}:${reviewDecisionSha256.slice(0, 12)}`;
     await writeJson(options.deletionApprovalPath, {
       ...approval,
+      deleteStageVersion,
       rulesSha256,
       reviewedQueueSha256,
-      reviewDecisionSha256: sha256(canonicalJson(decision)),
+      reviewDecisionSha256,
       tombstoneIdsSha256: sha256(canonicalJson(["message-1"])),
       tombstoneCount: 1,
     });
@@ -598,17 +1068,17 @@ describe("corpus verification", () => {
     const tombstoneMetadata = {
       messageId: "message-1",
       stage: "delete",
-      stageVersion: "delete-v1",
+      stageVersion: deleteStageVersion,
       rulesSha256,
       reviewedQueueSha256,
-      reviewDecisionSha256: sha256(canonicalJson(decision)),
-      ruleIdHashes,
+      reviewDecisionSha256,
+      ruleIdHashes: [sha256("forged-deletion-reason")],
       scope: "message",
     };
     await fs.appendFile(
       options.ledgerPath,
       `${JSON.stringify({
-        markerKey: `pii:${tombstoneInputHash}:v${RULESET}:delete:delete-v1`,
+        markerKey: `pii:${tombstoneInputHash}:v${RULESET}:delete:${deleteStageVersion}`,
         ...tombstoneMetadata,
         rulesetVersion: RULESET,
         inputHash: tombstoneInputHash,
@@ -627,6 +1097,11 @@ describe("corpus verification", () => {
     );
     expect(report.findings).toContainEqual(
       expect.objectContaining({ detector: "broken-tombstone-chain" }),
+    );
+    expect(report.findings).toContainEqual(
+      expect.objectContaining({
+        detector: "deletion-tombstone-review-binding",
+      }),
     );
   });
 
@@ -753,6 +1228,66 @@ describe("corpus verification", () => {
     expect(report.counts["attachment-policy"]).toBe(1);
   });
 
+  it("rejects retained attachment byte counts without base64 payloads", async () => {
+    const options = await fixture(
+      baseMessage({
+        attachments: [
+          {
+            filename: "safe.bin",
+            mimeType: "application/octet-stream",
+            sha256: "a".repeat(64),
+            bytes: 8,
+          },
+        ],
+      }),
+    );
+
+    const report = await verifyCorpus(options);
+
+    expect(report.status).toBe("failed");
+    expect(report.counts["attachment-policy"]).toBe(1);
+  });
+
+  it.each([
+    ["malformed", "***", undefined, "invalid base64 payload"],
+    ["size mismatch", "c2VjcmV0", 7, "inconsistent payload bytes"],
+  ])("rejects %s embedded attachment byte evidence", async (_name, dataBase64, bytes, expectedError) => {
+    const options = await fixture(
+      baseMessage({
+        attachments: [
+          {
+            filename: "unsafe.bin",
+            mimeType: "application/octet-stream",
+            sha256: "a".repeat(64),
+            dataBase64,
+            bytes,
+          },
+        ],
+      }),
+    );
+    const rules = JSON.parse(
+      await fs.readFile(options.deletionRulesPath, "utf8"),
+    ) as Record<string, unknown>;
+    await rebindDeletionArtifacts(options, rules);
+
+    await expect(verifyCorpus(options)).rejects.toThrow(expectedError);
+  });
+
+  it("rejects a placeholder without a matching mined candidate", async () => {
+    const forgedPlaceholder = "[[SECRET:openai-key:0123456789ab]]";
+    const options = await fixture(
+      baseMessage({ text: `Scrubbed body ${forgedPlaceholder}` }),
+      { canaryPlaceholder: forgedPlaceholder },
+    );
+
+    const report = await verifyCorpus(options);
+
+    expect(report.status).toBe("failed");
+    expect(report.findings).toContainEqual(
+      expect.objectContaining({ detector: "placeholder-registry" }),
+    );
+  });
+
   it("rejects PII hidden in an unknown top-level message field", async () => {
     const options = await fixture(baseMessage());
     const shardPath = path.join(
@@ -804,7 +1339,7 @@ describe("corpus verification", () => {
   });
 
   it("ignores historical tombstones from a stale delete-stage version", async () => {
-    const placeholder = "[[SECRET:openai-key:0123456789ab]]";
+    const placeholder = defaultCanaryPlaceholder();
     const options = await fixture(
       baseMessage({ text: `Scrubbed body ${placeholder}` }),
       { canaryPlaceholder: placeholder },
@@ -827,6 +1362,42 @@ describe("corpus verification", () => {
     const report = await verifyCorpus(options);
 
     expect(report.status).toBe("passed");
+  });
+
+  it("does not satisfy a delete canary with a stale tombstone", async () => {
+    const options = await fixture(baseMessage());
+    await writeJson(options.canariesPath, {
+      schemaVersion: 1,
+      rulesetVersion: RULESET,
+      canaries: [
+        {
+          id: "delete-canary",
+          messageId: "message-1",
+          expected: { outcome: "tombstone", stage: "delete" },
+        },
+      ],
+    });
+    const staleInputHash = "5".repeat(64);
+    await fs.appendFile(
+      options.ledgerPath,
+      `${JSON.stringify({
+        markerKey: `pii:${staleInputHash}:v${RULESET}:delete:delete-v0`,
+        messageId: "message-1",
+        stage: "delete",
+        stageVersion: "delete-v0",
+        rulesetVersion: RULESET,
+        inputHash: staleInputHash,
+        outputHash: sha256(canonicalJson({ tombstone: true })),
+        tombstone: true,
+      })}\n`,
+    );
+
+    const report = await verifyCorpus(options);
+
+    expect(report.status).toBe("failed");
+    expect(report.findings).toContainEqual(
+      expect.objectContaining({ detector: "canary-tombstone" }),
+    );
   });
 
   it("rejects a live chain that passed through a stale delete stage", async () => {

--- a/packages/corpus-tools/src/verification.ts
+++ b/packages/corpus-tools/src/verification.ts
@@ -90,6 +90,8 @@ const deletionApprovalSchema = z.object({
   reviewDecisionSha256: z.string().regex(/^[a-f0-9]{64}$/),
   tombstoneIdsSha256: z.string().regex(/^[a-f0-9]{64}$/),
   tombstoneCount: z.number().int().nonnegative(),
+  survivorCount: z.number().int().nonnegative(),
+  attachmentBytesDropped: z.number().int().nonnegative(),
 });
 
 const deletionRuleBaseSchema = z
@@ -250,7 +252,7 @@ const placeholderRegistrySchema = z.object({
         .regex(/^\[\[(?:SECRET|PII):[a-z0-9-]+:[a-f0-9]{12}\]\]$/),
       kind: z.string().regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/),
       valueHash: z.string().regex(/^[a-f0-9]{64}$/),
-      stage: z.string().min(1),
+      stage: z.literal("secrets"),
       messageId: z.string().min(1),
     }),
   ),
@@ -887,6 +889,8 @@ async function readGazetteerValues(filePath: string): Promise<string[]> {
 function registryFindings(
   messages: readonly CorpusMessage[],
   registry: z.infer<typeof placeholderRegistrySchema>,
+  candidates: readonly z.infer<typeof candidateSchema>[],
+  ledger: readonly z.infer<typeof ledgerRecordSchema>[],
 ): VerificationFinding[] {
   const byMessageAndPlaceholder = new Map(
     registry.entries.map((entry) => [
@@ -905,11 +909,44 @@ function registryFindings(
         const encoded = placeholder.match(
           /^\[\[(?:SECRET|PII):([a-z0-9-]+):([a-f0-9]{12})\]\]$/,
         );
+        const secretsRecords = ledger.filter(
+          (record) =>
+            record.rulesetVersion === registry.rulesetVersion &&
+            record.messageId === message.id &&
+            record.stage === "secrets" &&
+            !record.tombstone &&
+            record.output,
+        );
+        const secretsRecord = secretsRecords[0];
+        const linkedMineRecord = secretsRecord
+          ? ledger.find(
+              (record) =>
+                record.rulesetVersion === registry.rulesetVersion &&
+                record.messageId === message.id &&
+                record.stage === "mine" &&
+                record.outputHash === secretsRecord.inputHash &&
+                record.output,
+            )
+          : undefined;
+        const transitioned =
+          secretsRecords.length === 1 &&
+          secretsRecord?.output !== undefined &&
+          JSON.stringify(secretsRecord.output).includes(placeholder) &&
+          linkedMineRecord?.output !== undefined &&
+          !JSON.stringify(linkedMineRecord.output).includes(placeholder);
+        const candidateBound = candidates.some(
+          (candidate) =>
+            candidate.msgId === message.id &&
+            candidate.kind === entry?.kind &&
+            candidate.valueHash === entry?.valueHash,
+        );
         if (
           !entry ||
           !encoded ||
           entry.kind !== encoded[1] ||
-          !entry.valueHash.startsWith(encoded[2])
+          !entry.valueHash.startsWith(encoded[2]) ||
+          !candidateBound ||
+          !transitioned
         ) {
           findings.push({
             kind: "placeholder",
@@ -945,15 +982,56 @@ function attachmentFindings(
 ): VerificationFinding[] {
   return messages.flatMap((message) =>
     message.attachments
-      .filter((attachment) => attachment.dataBase64 !== undefined)
+      .filter(
+        (attachment) =>
+          attachment.dataBase64 !== undefined || attachment.bytes !== undefined,
+      )
       .map((attachment) => ({
         kind: "attachment-policy" as const,
         detector: "embedded-attachment-bytes",
         messageId: message.id,
-        field: "message.attachments.dataBase64",
+        field: "message.attachments",
         valueHash: findingHash("embedded-attachment-bytes", attachment.sha256),
       })),
   );
+}
+
+function droppedAttachmentByteCount(
+  messages: readonly CorpusMessage[],
+): number {
+  let total = 0;
+  for (const message of messages) {
+    for (const attachment of message.attachments) {
+      if (attachment.dataBase64 !== undefined) {
+        if (
+          !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(
+            attachment.dataBase64,
+          )
+        ) {
+          throw new Error(
+            `attachment ${attachment.sha256} has invalid base64 payload`,
+          );
+        }
+        const decoded = Buffer.from(attachment.dataBase64, "base64");
+        if (
+          decoded.toString("base64") !== attachment.dataBase64 ||
+          (attachment.bytes !== undefined &&
+            attachment.bytes !== decoded.length)
+        ) {
+          throw new Error(
+            `attachment ${attachment.sha256} has inconsistent payload bytes`,
+          );
+        }
+        total += decoded.length;
+      } else if (attachment.bytes !== undefined) {
+        total += attachment.bytes;
+      }
+      if (!Number.isSafeInteger(total)) {
+        throw new Error("attachment byte total exceeds safe integer range");
+      }
+    }
+  }
+  return total;
 }
 
 async function validateManifestSnapshots(
@@ -1019,6 +1097,8 @@ function canaryFindings(
   messages: readonly CorpusMessage[],
   manifest: z.infer<typeof canaryManifestSchema>,
   ledger: readonly z.infer<typeof ledgerRecordSchema>[],
+  deletionApproval: z.infer<typeof deletionApprovalSchema>,
+  approvedDeletedIds: ReadonlySet<string>,
 ): VerificationFinding[] {
   const byId = new Map(messages.map((message) => [message.id, message]));
   const findings: VerificationFinding[] = [];
@@ -1036,7 +1116,10 @@ function canaryFindings(
           record.messageId === canary.messageId &&
           record.stage === expectedStage &&
           record.rulesetVersion === manifest.rulesetVersion &&
-          record.tombstone,
+          record.tombstone &&
+          (expectedStage !== "delete" ||
+            (record.stageVersion === deletionApproval.deleteStageVersion &&
+              approvedDeletedIds.has(record.messageId))),
       );
     }
     if (!satisfied) {
@@ -1102,12 +1185,86 @@ function deletionRuleMatches(
       return values.some((value) => {
         const haystack = normalize(value);
         if (match.mode === "substring") return haystack.includes(needle);
-        return haystack
-          .split(/[^\p{L}\p{N}_]+/u)
-          .some((token) => token === needle);
+        let from = 0;
+        for (;;) {
+          const index = haystack.indexOf(needle, from);
+          if (index === -1) return false;
+          const before = index === 0 ? undefined : haystack[index - 1];
+          const after = haystack[index + needle.length];
+          const isWord = (character: string | undefined): boolean =>
+            character !== undefined && /[\p{L}\p{N}_]/u.test(character);
+          if (!isWord(before) && !isWord(after)) return true;
+          from = index + Math.max(needle.length, 1);
+        }
       });
     }
   }
+}
+
+const deletionReviewRedactPatterns: readonly RegExp[] = [
+  /[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/gi,
+  /(?<!\d)(?:\+?[1-9]\d{7,14}|(?:\+?1[ .-]?)?(?:\(\d{3}\)[ .-]?|\d{3}[ .-])\d{3}[ .-]?\d{4})(?!\d)/g,
+  /\b\d{3}[ -]\d{2}[ -]\d{4}\b/g,
+  /\b(?:\d[ -]?){13,19}\b/g,
+  /\b(?:sk-|ghp_|github_pat_|xox[baprs]-|AIza)[A-Za-z0-9_-]{8,}\b/g,
+  /\b(?:password|passcode|token|secret)\s*[:=]\s*\S+/gi,
+];
+
+function deletionRuleSensitiveTerms(
+  rule: z.infer<typeof deletionRuleSchema>,
+): string[] {
+  const match = rule.match;
+  if (match.type === "thread") return [match.threadId];
+  if (match.type === "contact") return [match.contactId];
+  if (match.type === "keyword" || match.type === "label") {
+    return [match.value];
+  }
+  return [];
+}
+
+function replaceDeletionReviewTerm(text: string, value: string): string {
+  if (!value) return text;
+  const normalized = (candidate: string): string =>
+    candidate.normalize("NFKC").toLocaleLowerCase("en-US");
+  const lowerText = normalized(text);
+  const lowerValue = normalized(value);
+  if (lowerText.length !== text.length || lowerValue.length !== value.length) {
+    return text;
+  }
+  let result = text;
+  let search = lowerText;
+  let from = 0;
+  for (;;) {
+    const index = search.indexOf(lowerValue, from);
+    if (index === -1) return result;
+    result = `${result.slice(0, index)}[MATCH]${result.slice(index + value.length)}`;
+    search = normalized(result);
+    from = index + "[MATCH]".length;
+  }
+}
+
+function deletionReviewContext(
+  message: CorpusMessage,
+  sensitiveTerms: readonly string[],
+): string {
+  let value = [message.subject, message.text, message.snippet]
+    .filter((item): item is string => Boolean(item))
+    .join(" — ");
+  for (const term of [...new Set(sensitiveTerms)].sort(
+    (left, right) => right.length - left.length,
+  )) {
+    value = replaceDeletionReviewTerm(value, term);
+  }
+  for (const pattern of deletionReviewRedactPatterns) {
+    pattern.lastIndex = 0;
+    value = value.replace(pattern, "[REDACTED]");
+  }
+  value = value.replace(/\s+/g, " ").trim();
+  if (!value) return "[no textual preview]";
+  const characters = [...value];
+  return characters.length <= 60
+    ? value
+    : `${characters.slice(0, 59).join("")}…`;
 }
 
 function validateDeletionQueueSemantics(
@@ -1128,8 +1285,122 @@ function validateDeletionQueueSemantics(
   const ruleByHash = new Map(
     rules.rules.map((rule) => [sha256(rule.id), rule]),
   );
+  const enabledRules = rules.rules.filter((rule) => rule.enabled);
+  const directMatches = new Map<
+    string,
+    Array<{ rule: z.infer<typeof deletionRuleSchema>; terms: string[] }>
+  >();
+  for (const message of messages) {
+    const matches = enabledRules
+      .filter((rule) => deletionRuleMatches(message, rule, candidateKinds))
+      .map((rule) => ({
+        rule,
+        terms: deletionRuleSensitiveTerms(rule),
+      }));
+    if (matches.length > 0) directMatches.set(message.id, matches);
+  }
+  const threadKey = (message: CorpusMessage): string =>
+    canonicalJson([message.platform, message.accountId, message.threadId]);
+  const selectedThreadKeys = new Set<string>();
+  for (const message of messages) {
+    if (
+      directMatches
+        .get(message.id)
+        ?.some((match) => match.rule.scope === "thread")
+    ) {
+      selectedThreadKeys.add(threadKey(message));
+    }
+  }
+  const expectedGroups: Array<
+    z.infer<typeof deletionReviewQueueSchema>["groups"][number]
+  > = [];
+  const threadCoveredMessages = new Set<string>();
+  for (const key of selectedThreadKeys) {
+    const members = messages
+      .filter((message) => threadKey(message) === key)
+      .sort((left, right) => left.id.localeCompare(right.id));
+    for (const member of members) threadCoveredMessages.add(member.id);
+    const matches = members.flatMap(
+      (member) => directMatches.get(member.id) ?? [],
+    );
+    const groupRules = [
+      ...new Map(matches.map((match) => [match.rule.id, match.rule])).values(),
+    ].sort((left, right) => left.id.localeCompare(right.id));
+    const messageIds = members.map((message) => message.id);
+    const ruleIdHashes = groupRules.map((rule) => sha256(rule.id));
+    const matchClasses = [
+      ...new Set(groupRules.map((rule) => rule.match.type)),
+    ].sort();
+    const preview = members[0];
+    if (!preview) throw new Error("deletion review thread group is empty");
+    expectedGroups.push({
+      groupId: sha256(
+        canonicalJson({
+          scope: "thread",
+          platform: preview.platform,
+          messageIds,
+          ruleIdHashes,
+        }),
+      ),
+      scope: "thread",
+      platform: preview.platform,
+      messageIds,
+      ruleIdHashes,
+      matchClasses,
+      redactedContext: deletionReviewContext(
+        preview,
+        matches.flatMap((match) => match.terms),
+      ),
+      suggestedDecision: "delete",
+    });
+  }
+  for (const message of messages) {
+    if (threadCoveredMessages.has(message.id)) continue;
+    const matches = (directMatches.get(message.id) ?? []).filter(
+      (match) => match.rule.scope === "message",
+    );
+    if (matches.length === 0) continue;
+    const groupRules = [
+      ...new Map(matches.map((match) => [match.rule.id, match.rule])).values(),
+    ].sort((left, right) => left.id.localeCompare(right.id));
+    const messageIds = [message.id];
+    const ruleIdHashes = groupRules.map((rule) => sha256(rule.id));
+    const matchClasses = [
+      ...new Set(groupRules.map((rule) => rule.match.type)),
+    ].sort();
+    expectedGroups.push({
+      groupId: sha256(
+        canonicalJson({
+          scope: "message",
+          platform: message.platform,
+          messageIds,
+          ruleIdHashes,
+        }),
+      ),
+      scope: "message",
+      platform: message.platform,
+      messageIds,
+      ruleIdHashes,
+      matchClasses,
+      redactedContext: deletionReviewContext(
+        message,
+        matches.flatMap((match) => match.terms),
+      ),
+      suggestedDecision: "delete",
+    });
+  }
+  if (
+    canonicalJson(
+      [...queue.groups].sort((a, b) => a.groupId.localeCompare(b.groupId)),
+    ) !==
+    canonicalJson(
+      expectedGroups.sort((a, b) => a.groupId.localeCompare(b.groupId)),
+    )
+  ) {
+    throw new Error("deletion review queue does not match canonical grouping");
+  }
   const expectedPairs = new Set<string>();
-  for (const rule of rules.rules.filter((candidate) => candidate.enabled)) {
+  for (const rule of enabledRules) {
     const direct = messages.filter((message) =>
       deletionRuleMatches(message, rule, candidateKinds),
     );
@@ -1239,8 +1510,13 @@ function validateDeletionQueueSemantics(
 
 function ledgerFindings(
   messages: readonly CorpusMessage[],
+  deletionInputMessages: readonly CorpusMessage[],
   ledger: readonly z.infer<typeof ledgerRecordSchema>[],
   deletionApproval: z.infer<typeof deletionApprovalSchema>,
+  approvedDeletionGroups: ReadonlyMap<
+    string,
+    { scope: "message" | "thread"; ruleIdHashes: readonly string[] }
+  >,
   rulesetVersion: string,
 ): VerificationFinding[] {
   const findings: VerificationFinding[] = [];
@@ -1262,17 +1538,21 @@ function ledgerFindings(
         valueHash: findingHash("invalid-marker-key", record.markerKey),
       });
     }
-    const approvedDeletionTombstone =
-      record.tombstone &&
+    const approvedDeletionRecord =
       record.stage === "delete" &&
       record.stageVersion === deletionApproval.deleteStageVersion;
-    const hasDeletionMetadata =
+    const hasDeletionBinding =
       record.rulesSha256 !== undefined &&
       record.reviewedQueueSha256 !== undefined &&
-      record.reviewDecisionSha256 !== undefined &&
+      record.reviewDecisionSha256 !== undefined;
+    const hasTombstoneMetadata =
+      hasDeletionBinding &&
       record.ruleIdHashes !== undefined &&
       record.scope !== undefined;
-    if (approvedDeletionTombstone && !hasDeletionMetadata) {
+    if (
+      approvedDeletionRecord &&
+      (!hasDeletionBinding || (record.tombstone && !hasTombstoneMetadata))
+    ) {
       findings.push({
         kind: "ledger",
         detector: "missing-deletion-metadata",
@@ -1281,8 +1561,8 @@ function ledgerFindings(
       });
     }
     if (
-      approvedDeletionTombstone &&
-      hasDeletionMetadata &&
+      approvedDeletionRecord &&
+      hasDeletionBinding &&
       (record.rulesSha256 !== deletionApproval.rulesSha256 ||
         record.reviewedQueueSha256 !== deletionApproval.reviewedQueueSha256 ||
         record.reviewDecisionSha256 !== deletionApproval.reviewDecisionSha256)
@@ -1295,7 +1575,7 @@ function ledgerFindings(
       });
     }
     const expectedOutputHash = record.tombstone
-      ? hasDeletionMetadata
+      ? hasTombstoneMetadata
         ? sha256(
             canonicalJson({
               tombstone: true,
@@ -1356,6 +1636,23 @@ function ledgerFindings(
     });
   }
   for (const tombstone of approvedTombstones) {
+    const approvedGroup = approvedDeletionGroups.get(tombstone.messageId);
+    if (
+      !approvedGroup ||
+      tombstone.scope !== approvedGroup.scope ||
+      canonicalJson(tombstone.ruleIdHashes) !==
+        canonicalJson(approvedGroup.ruleIdHashes)
+    ) {
+      findings.push({
+        kind: "ledger",
+        detector: "deletion-tombstone-review-binding",
+        messageId: tombstone.messageId,
+        valueHash: findingHash(
+          "deletion-tombstone-review-binding",
+          tombstone.markerKey,
+        ),
+      });
+    }
     const secretsRecords = current.filter(
       (record) =>
         record.messageId === tombstone.messageId &&
@@ -1395,6 +1692,53 @@ function ledgerFindings(
       ),
     });
   }
+  const deletionInputIds = deletionInputMessages.map((message) => message.id);
+  const liveIds = messages.map((message) => message.id);
+  const partitionIds = [...liveIds, ...tombstoneIds].sort();
+  if (
+    new Set(deletionInputIds).size !== deletionInputIds.length ||
+    new Set(liveIds).size !== liveIds.length ||
+    liveIds.some((messageId) => tombstoned.has(messageId)) ||
+    canonicalJson([...deletionInputIds].sort()) !== canonicalJson(partitionIds)
+  ) {
+    findings.push({
+      kind: "ledger",
+      detector: "deletion-input-partition",
+      valueHash: findingHash(
+        "deletion-input-partition",
+        canonicalJson({
+          deletionInputIds: [...deletionInputIds].sort(),
+          partitionIds,
+        }),
+      ),
+    });
+  }
+  if (messages.length !== deletionApproval.survivorCount) {
+    findings.push({
+      kind: "ledger",
+      detector: "deletion-survivor-count",
+      valueHash: findingHash(
+        "deletion-survivor-count",
+        `${messages.length}:${deletionApproval.survivorCount}`,
+      ),
+    });
+  }
+  const attachmentBytesDropped = droppedAttachmentByteCount(
+    deletionInputMessages,
+  );
+  if (attachmentBytesDropped !== deletionApproval.attachmentBytesDropped) {
+    findings.push({
+      kind: "ledger",
+      detector: "deletion-attachment-drop-count",
+      valueHash: findingHash(
+        "deletion-attachment-drop-count",
+        `${attachmentBytesDropped}:${deletionApproval.attachmentBytesDropped}`,
+      ),
+    });
+  }
+  const deletionInputsById = new Map(
+    deletionInputMessages.map((message) => [message.id, message]),
+  );
   for (const message of messages) {
     if (tombstoned.has(message.id)) {
       findings.push({
@@ -1453,6 +1797,38 @@ function ledgerFindings(
           valueHash: findingHash("stage-chain", downstream.markerKey),
         });
         break;
+      }
+      if (expectedStage === "delete") {
+        const source = deletionInputsById.get(message.id);
+        const expectedOutput = source
+          ? {
+              ...source,
+              attachments: source.attachments.map((attachment) => ({
+                filename: attachment.filename,
+                mimeType: attachment.mimeType,
+                sha256: attachment.sha256,
+              })),
+            }
+          : undefined;
+        const deleteRecord = predecessors[0];
+        if (
+          !source ||
+          !expectedOutput ||
+          deleteRecord.inputHash !== sha256(JSON.stringify(source)) ||
+          deleteRecord.outputHash !== sha256(JSON.stringify(expectedOutput)) ||
+          deleteRecord.output === undefined ||
+          canonicalJson(deleteRecord.output) !== canonicalJson(expectedOutput)
+        ) {
+          findings.push({
+            kind: "ledger",
+            detector: "invalid-deletion-survivor-transform",
+            messageId: message.id,
+            valueHash: findingHash(
+              "invalid-deletion-survivor-transform",
+              deleteRecord.markerKey,
+            ),
+          });
+        }
       }
       downstream = predecessors[0];
     }
@@ -1565,16 +1941,45 @@ export async function verifyCorpus(
     }
     uniqueStageRecords.add(key);
   }
+  const currentMineStageRecords = ledger.filter(
+    (record) =>
+      record.rulesetVersion === options.rulesetVersion &&
+      record.stage === "mine",
+  );
+  const currentSecretsStageRecords = ledger.filter(
+    (record) =>
+      record.rulesetVersion === options.rulesetVersion &&
+      record.stage === "secrets",
+  );
+  const mineByMessageId = new Map(
+    currentMineStageRecords.map((record) => [record.messageId, record]),
+  );
+  const secretsByMessageId = new Map(
+    currentSecretsStageRecords.map((record) => [record.messageId, record]),
+  );
+  if (
+    currentSecretsStageRecords.some((secretsRecord) => {
+      const mineRecord = mineByMessageId.get(secretsRecord.messageId);
+      return (
+        !mineRecord ||
+        mineRecord.tombstone ||
+        secretsRecord.inputHash !== mineRecord.outputHash
+      );
+    }) ||
+    currentMineStageRecords.some((mineRecord) => {
+      const secretsRecord = secretsByMessageId.get(mineRecord.messageId);
+      return mineRecord.tombstone
+        ? secretsRecord !== undefined
+        : !secretsRecord || secretsRecord.inputHash !== mineRecord.outputHash;
+    })
+  ) {
+    throw new Error("mine and secrets ledger stages do not match exactly");
+  }
+  const currentMineRecords = currentMineStageRecords.filter(
+    (record) => !record.tombstone && record.output,
+  );
   const mineOutputs = new Map(
-    ledger
-      .filter(
-        (record) =>
-          record.rulesetVersion === options.rulesetVersion &&
-          record.stage === "mine" &&
-          !record.tombstone &&
-          record.output,
-      )
-      .map((record) => [record.messageId, record.output]),
+    currentMineRecords.map((record) => [record.messageId, record.output]),
   );
   for (const candidate of candidates) {
     const source = mineOutputs.get(candidate.msgId);
@@ -1599,19 +2004,17 @@ export async function verifyCorpus(
   const rerunMine = await minePiiCandidates(mineMessages, {
     hashSalt: options.rulesetVersion,
   });
-  const suppliedCandidateKeys = new Set(
-    candidates.map(
-      (candidate) =>
-        `${candidate.msgId}\0${candidate.kind}\0${candidate.sourceRef.span.start}\0${candidate.sourceRef.span.end}\0${candidate.valueHash}`,
-    ),
-  );
-  for (const expected of rerunMine.candidates) {
-    const key = `${expected.msgId}\0${expected.kind}\0${expected.sourceRef.span.start}\0${expected.sourceRef.span.end}\0${expected.valueHash}`;
-    if (!suppliedCandidateKeys.has(key)) {
-      throw new Error(
-        `mine candidate artifact is incomplete for message ${expected.msgId}`,
-      );
-    }
+  const candidateKey = (candidate: (typeof candidates)[number]): string =>
+    `${candidate.msgId}\0${candidate.kind}\0${candidate.sourceRef.span.start}\0${candidate.sourceRef.span.end}\0${candidate.valueHash}`;
+  const suppliedCandidateKeys = candidates.map(candidateKey).sort();
+  const expectedCandidateKeys = rerunMine.candidates.map(candidateKey).sort();
+  if (
+    canonicalJson(suppliedCandidateKeys) !==
+    canonicalJson(expectedCandidateKeys)
+  ) {
+    throw new Error(
+      "mine candidate artifact does not exactly match mining rerun",
+    );
   }
   const deletionApproval = deletionApprovalSchema.parse(
     JSON.parse(await fs.readFile(options.deletionApprovalPath, "utf8")),
@@ -1631,11 +2034,34 @@ export async function verifyCorpus(
   ) {
     throw new Error("deletion rules contain duplicate ids");
   }
-  const rulesDigest = sha256(canonicalJson(deletionRules));
+  const deletionInputMessages = ledger
+    .filter(
+      (record) =>
+        record.rulesetVersion === options.rulesetVersion &&
+        record.stage === "secrets" &&
+        !record.tombstone &&
+        record.output,
+    )
+    .map((record) => record.output)
+    .filter((message): message is CorpusMessage => message !== undefined);
+  const deletionInputDigest = sha256(
+    canonicalJson(
+      [...deletionInputMessages].sort((left, right) =>
+        left.id.localeCompare(right.id),
+      ),
+    ),
+  );
+  const normalizedDeletionRules = {
+    ...deletionRules,
+    rules: [...deletionRules.rules].sort((left, right) =>
+      left.id.localeCompare(right.id),
+    ),
+  };
+  const rulesDigest = sha256(canonicalJson(normalizedDeletionRules));
   const queueDigest = sha256(canonicalJson(deletionReviewQueue));
   const decisionDigest = sha256(canonicalJson(deletionReviewDecision));
   const deletionBindings = [
-    ["corpus", deletionApproval.corpusDigest, corpusDigest],
+    ["corpus", deletionApproval.corpusDigest, deletionInputDigest],
     ["candidates", deletionApproval.candidatesSha256, deletionCandidatesDigest],
     ["deletion rules", deletionApproval.rulesSha256, rulesDigest],
     [
@@ -1648,14 +2074,18 @@ export async function verifyCorpus(
       deletionApproval.reviewDecisionSha256,
       decisionDigest,
     ],
-    ["queue corpus", deletionReviewQueue.corpusDigest, corpusDigest],
+    ["queue corpus", deletionReviewQueue.corpusDigest, deletionInputDigest],
     ["queue rules", deletionReviewQueue.rulesSha256, rulesDigest],
     [
       "queue candidates",
       deletionReviewQueue.candidatesSha256,
       deletionCandidatesDigest,
     ],
-    ["decision corpus", deletionReviewDecision.corpusDigest, corpusDigest],
+    [
+      "decision corpus",
+      deletionReviewDecision.corpusDigest,
+      deletionInputDigest,
+    ],
     ["decision rules", deletionReviewDecision.rulesSha256, rulesDigest],
     ["decision queue", deletionReviewDecision.reviewedQueueSha256, queueDigest],
   ] as const;
@@ -1663,6 +2093,10 @@ export async function verifyCorpus(
     if (claimed !== actual) {
       throw new Error(`${name} digest does not match deletion approval`);
     }
+  }
+  const expectedDeleteStageVersion = `delete-v1:${rulesDigest.slice(0, 12)}:${queueDigest.slice(0, 12)}:${decisionDigest.slice(0, 12)}`;
+  if (deletionApproval.deleteStageVersion !== expectedDeleteStageVersion) {
+    throw new Error("deletion approval delete stage version is invalid");
   }
   for (const [name, value] of [
     ["deletion rules", deletionRules.rulesetVersion],
@@ -1693,16 +2127,6 @@ export async function verifyCorpus(
       }
     }
   }
-  const deletionInputMessages = ledger
-    .filter(
-      (record) =>
-        record.rulesetVersion === options.rulesetVersion &&
-        record.stage === "secrets" &&
-        !record.tombstone &&
-        record.output,
-    )
-    .map((record) => record.output)
-    .filter((message): message is CorpusMessage => message !== undefined);
   validateDeletionQueueSemantics(
     deletionInputMessages,
     candidates,
@@ -1733,6 +2157,24 @@ export async function verifyCorpus(
       ),
     ),
   ].sort();
+  const approvedDeletionGroups = new Map<
+    string,
+    { scope: "message" | "thread"; ruleIdHashes: readonly string[] }
+  >();
+  for (const group of deletionReviewQueue.groups) {
+    if (decisionsById.get(group.groupId) !== "delete") continue;
+    for (const messageId of group.messageIds) {
+      if (approvedDeletionGroups.has(messageId)) {
+        throw new Error(
+          `message ${messageId} belongs to multiple approved deletion groups`,
+        );
+      }
+      approvedDeletionGroups.set(messageId, {
+        scope: group.scope,
+        ruleIdHashes: group.ruleIdHashes,
+      });
+    }
+  }
   if (
     approvedDeletedIds.length !== deletionApproval.tombstoneCount ||
     sha256(canonicalJson(approvedDeletedIds)) !==
@@ -1800,13 +2242,21 @@ export async function verifyCorpus(
     ...gitleaks.findings,
     ...(await detectorFindings(messages, gazetteerValues)),
     ...originalValueFindings(messages, candidates),
-    ...canaryFindings(messages, canaries, ledger),
-    ...registryFindings(messages, placeholderRegistry),
+    ...canaryFindings(
+      messages,
+      canaries,
+      ledger,
+      deletionApproval,
+      new Set(approvedDeletedIds),
+    ),
+    ...registryFindings(messages, placeholderRegistry, candidates, ledger),
     ...attachmentFindings(messages),
     ...ledgerFindings(
       messages,
+      deletionInputMessages,
       ledger,
       deletionApproval,
+      approvedDeletionGroups,
       options.rulesetVersion,
     ),
   ]);

--- a/packages/corpus-tools/vitest.config.ts
+++ b/packages/corpus-tools/vitest.config.ts
@@ -2,12 +2,16 @@
  * Vitest config for @elizaos/corpus-tools: deterministic unit coverage over
  * synthetic JSONL fixtures, schema validation, and mock-shape mappers.
  */
-import { defineConfig } from "vitest/config";
+import { defineConfig, mergeConfig } from "vitest/config";
+import rootConfig from "../../vitest.config.ts";
 
-export default defineConfig({
-  test: {
-    environment: "node",
-    include: ["src/**/*.test.ts"],
-    exclude: ["**/node_modules/**"],
-  },
-});
+export default mergeConfig(
+  rootConfig,
+  defineConfig({
+    test: {
+      environment: "node",
+      include: ["src/**/*.test.ts"],
+      exclude: ["**/node_modules/**"],
+    },
+  }),
+);


### PR DESCRIPTION
## Summary

Follow-up to #15952. The merged verifier bound the reviewed deletion approval to the final post-delete shard digest, but the deletion workflow reviews the pre-delete `swapped` corpus. This change makes those two trust boundaries explicit and closes the remaining provenance gaps:

- binds rules, queue, decision, and approval to the exact pre-delete `secrets` outputs;
- canonicalizes deletion rules by ID, matching the deletion producer;
- recomputes the exact `delete-v1:<rules>:<queue>:<decision>` stage version;
- reconstructs the producer's exact atomic review groups and redacted context;
- requires the mine artifact to equal the deterministic mining rerun, rejecting extras and duplicates;
- proves every mine row reaches exactly one hash-linked secrets row or an explicit stage tombstone;
- binds placeholder canaries and registry entries to a real mined candidate and secrets transition;
- requires rules/queue/decision binding metadata on surviving delete-stage records;
- proves every survivor is the exact pre-delete message with only attachment payload fields removed;
- proves the pre-delete ID set is exactly partitioned into live survivors and approved tombstones;
- binds every tombstone's scope and rule hashes to its approved review group;
- binds delete canaries to the exact approved tombstone set and stage version;
- verifies survivor, tombstone, and embedded-attachment drop counts;
- attests decoded attachment bytes, rejecting malformed base64 or declared-size mismatches;
- adds adversarial regressions for each bypass.

This does not close #14772: the owner-reviewed real corpus, production artifacts, multimodal scope, and ≥200-message human review remain outstanding.

## Verification

- `bun run --cwd packages/corpus-tools test -- --reporter=dot` — 81 tests passed
- `bun run --cwd packages/corpus-tools typecheck` — passed
- `bunx biome check packages/corpus-tools/src/verification.ts packages/corpus-tools/src/verification.test.ts` — passed
- `bun run audit:error-policy-ratchet` — passed
- Changed-test coverage lane (`run-changed-vitest-coverage.mjs`) — 55 tests passed from source aliases
- Real gitleaks 8.30.1 synthetic end-to-end report — passed, 0 findings, report digest `964b5450121847b9bea6845521c53d1f2f80b99c1e84d7b12bfabf7b69ecc6ab`

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - CLI/library privacy boundary only; no rendered UI existed before or changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - CLI/library privacy boundary only; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no user-facing visual flow; the machine report and CLI exit status are the exercised surface.
<!-- evidence-row:backend-logs -->
- [x] Exact-head package/full-gate log: https://github.com/elizaOS/eliza/releases/download/pr-evidence/15977-backend-verification.log
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code, browser request, or client state changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, action, provider, evaluator, planner, or model behavior changed; this is deterministic privacy verification.
<!-- evidence-row:domain-artifacts -->
- [x] Full green synthetic verification report: https://github.com/elizaOS/eliza/releases/download/pr-evidence/15977-synthetic-verification-report.json and sanitized planted-secret result: https://github.com/elizaOS/eliza/releases/download/pr-evidence/15977-gitleaks-sanitized.json (raw candidate/gazetteer material is intentionally never uploaded).

Manual review: report status, every detector count, exact input hashes, gitleaks version, and absence of planted cleartext were inspected directly.
