### PR TITLE
fix(discord): duplicate slash-command menu entries (global commands re-registered per-guild)

### DIFF
--- a/plugins/plugin-discord/__tests__/slash-command-registration-scope.test.ts
+++ b/plugins/plugin-discord/__tests__/slash-command-registration-scope.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Exercises the real Discord service registration method against an in-memory
+ * Discord API boundary so global and guild command scopes cannot overlap.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { DiscordService } from "../service";
+import type { DiscordSlashCommand } from "../types";
+
+const AGENT_ID = "11111111-1111-1111-1111-111111111111";
+
+function command(
+	name: string,
+	scope: { guildOnly?: boolean; guildIds?: string[] } = {},
+): DiscordSlashCommand {
+	return {
+		name,
+		description: `${name} command`,
+		...scope,
+		execute: vi.fn(async () => undefined),
+	} as unknown as DiscordSlashCommand;
+}
+
+function makeService() {
+	const globalAndGuildSet = vi.fn(async () => undefined);
+	const targetedCreate = vi.fn(async () => undefined);
+	const targetedFetch = vi.fn(async () => ({ find: () => undefined }));
+	const guild = {
+		id: "guild-a",
+		name: "Guild A",
+		fetch: vi.fn(async () => ({
+			commands: { fetch: targetedFetch, create: targetedCreate },
+		})),
+	};
+	const client = {
+		application: { commands: { set: globalAndGuildSet } },
+		guilds: { cache: new Map([[guild.id, guild]]) },
+	};
+	const state = {
+		accountId: "default",
+		clientReadyPromise: Promise.resolve(),
+		client,
+	};
+	const runtime = {
+		agentId: AGENT_ID,
+		logger: {
+			debug: vi.fn(),
+			error: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+		},
+	} as unknown as IAgentRuntime;
+	const service = Object.assign(Object.create(DiscordService.prototype), {
+		runtime,
+		slashCommands: [],
+		allowAllSlashCommands: new Set<string>(),
+		commandRegistrationQueue: Promise.resolve(),
+		requireAccountState: () => state,
+	}) as DiscordService;
+
+	return { globalAndGuildSet, service, targetedCreate };
+}
+
+describe("Discord slash-command registration scopes", () => {
+	it("keeps global commands out of guild scope while retaining guild-only and targeted commands", async () => {
+		const { globalAndGuildSet, service, targetedCreate } = makeService();
+
+		await service.registerSlashCommands([
+			command("global"),
+			command("guild-only", { guildOnly: true }),
+			command("targeted", { guildIds: ["guild-a"] }),
+		]);
+
+		expect(globalAndGuildSet).toHaveBeenNthCalledWith(
+			1,
+			expect.arrayContaining([expect.objectContaining({ name: "global" })]),
+		);
+		expect(globalAndGuildSet.mock.calls[0]?.[0]).toHaveLength(1);
+		expect(globalAndGuildSet).toHaveBeenNthCalledWith(
+			2,
+			[expect.objectContaining({ name: "guild-only" })],
+			"guild-a",
+		);
+		expect(targetedCreate).toHaveBeenCalledWith(
+			expect.objectContaining({ name: "targeted" }),
+		);
+	});
+
+	it("writes an empty guild scope to clear stale copies of global commands", async () => {
+		const { globalAndGuildSet, service } = makeService();
+
+		await service.registerSlashCommands([command("global")]);
+
+		expect(globalAndGuildSet).toHaveBeenNthCalledWith(1, [
+			expect.objectContaining({ name: "global" }),
+		]);
+		expect(globalAndGuildSet).toHaveBeenNthCalledWith(2, [], "guild-a");
+	});
+});

--- a/plugins/plugin-discord/discord-commands.ts
+++ b/plugins/plugin-discord/discord-commands.ts
@@ -78,8 +78,13 @@ export async function handleGuildCreate(
 	const clientApplication = service.client?.application;
 	if (service.slashCommands.length > 0 && clientApplication) {
 		try {
-			const generalCommands = service.slashCommands.filter(
-				(cmd) => (cmd.guildIds?.length ?? 0) === 0,
+			// Per-guild registration must NOT include general (non-guild-only)
+			// commands — those are registered GLOBALLY elsewhere, and pushing
+			// them into a guild's scope too made Discord merge the two scopes and
+			// show every command TWICE in the slash menu. Only guild-only and
+			// guild-targeted commands belong in a guild's scope.
+			const guildOnlyGeneralCommands = service.slashCommands.filter(
+				(cmd) => (cmd.guildIds?.length ?? 0) === 0 && isGuildOnlyCommand(cmd),
 			);
 
 			const targetedCommandsForThisGuild = service.slashCommands.filter((cmd) =>
@@ -87,32 +92,36 @@ export async function handleGuildCreate(
 			);
 
 			const commandMap = new Map<string, DiscordSlashCommand>();
-			for (const cmd of [...generalCommands, ...targetedCommandsForThisGuild]) {
+			for (const cmd of [
+				...guildOnlyGeneralCommands,
+				...targetedCommandsForThisGuild,
+			]) {
 				if (cmd.name) {
 					commandMap.set(cmd.name, cmd);
 				}
 			}
 			const commandsToRegister = Array.from(commandMap.values());
 
-			if (commandsToRegister.length > 0) {
-				const discordCommands = commandsToRegister.map((cmd) =>
-					transformCommandToDiscordApi(cmd),
-				);
-
-				await clientApplication.commands.set(discordCommands, fullGuild.id);
-				service.runtime.logger.info(
-					{
-						src: "plugin:discord",
-						agentId: service.runtime.agentId,
-						guildId: fullGuild.id,
-						guildName: fullGuild.name,
-						generalCount: generalCommands.length,
-						targetedCount: targetedCommandsForThisGuild.length,
-						totalCount: discordCommands.length,
-					},
-					"Commands registered to newly joined guild",
-				);
-			}
+			// Always set the guild scope (even to an empty array): when there are
+			// no guild-scoped commands, this CLEARS any stale guild-scoped copies
+			// of global commands a previous build registered, which is what
+			// removes the duplicate slash-menu entries.
+			const discordCommands = commandsToRegister.map((cmd) =>
+				transformCommandToDiscordApi(cmd),
+			);
+			await clientApplication.commands.set(discordCommands, fullGuild.id);
+			service.runtime.logger.info(
+				{
+					src: "plugin:discord",
+					agentId: service.runtime.agentId,
+					guildId: fullGuild.id,
+					guildName: fullGuild.name,
+					guildOnlyCount: guildOnlyGeneralCommands.length,
+					targetedCount: targetedCommandsForThisGuild.length,
+					totalCount: discordCommands.length,
+				},
+				"Guild-scoped commands synced (global commands live globally)",
+			);
 		} catch (error) {
 			service.runtime.logger.warn(
 				{

--- a/plugins/plugin-discord/service.ts
+++ b/plugins/plugin-discord/service.ts
@@ -740,10 +740,6 @@ export class DiscordService extends Service implements IDiscordService {
 				const transformedGuildOnlyCommands = guildOnlyCommands.map((cmd) =>
 					transformCommandToDiscordApi(cmd),
 				);
-				const transformedAllGeneralCommands = [
-					...transformedGlobalCommands,
-					...transformedGuildOnlyCommands,
-				];
 
 				const clientApp = client.application;
 				if (!clientApp) {
@@ -764,13 +760,19 @@ export class DiscordService extends Service implements IDiscordService {
 					);
 				}
 
+				// Per-guild registration pushes ONLY the guild-only commands. The
+				// global commands were already registered globally above; a guild
+				// also carrying them made Discord merge the global + guild scopes
+				// and show every command TWICE in the slash menu. Pushing the
+				// guild-only set (often empty) here also CLEARS any stale
+				// guild-scoped duplicates a previous build registered.
 				const guilds = client.guilds.cache;
-				if (guilds && transformedAllGeneralCommands.length > 0) {
+				if (guilds) {
 					await Promise.all(
 						[...guilds].map(async ([guildId, guild]) => {
 							try {
 								await clientApp.commands.set(
-									transformedAllGeneralCommands,
+									transformedGuildOnlyCommands,
 									guildId,
 								);
 							} catch (err) {


### PR DESCRIPTION
## What

Global slash commands were being registered into **both** the global scope and every guild's scope, so Discord's slash menu showed **every command twice**.

Two paths pushed the globals per-guild:
- `service.ts` `registerSlashCommands` pushed `global + guildOnly` to each guild (the globals were already registered globally just above).
- `discord-commands.ts` `handleGuildCreate` pushed `general + targeted` to each joined guild (`general` = every non-guild-scoped command, i.e. the globals).

Discord merges the global and guild command scopes for display, so a command present in both appears twice.

## Fix

Register global commands **globally only**; a guild's scope gets **only** its guild-only and guild-targeted commands. `handleGuildCreate` now also sets the guild scope to `[]` when there are none, which clears any stale guild-scoped duplicates a previous build left behind. Removes a now-unused `transformedAllGeneralCommands`.

## Evidence (live, production bot in 2 guilds)

Before — Discord API: GLOBAL 7 + GUILD 7 + GUILD 7 (every command doubled in the menu):
```
GLOBAL:  clear, help, model, search, settings, setup, status
GUILD A: clear, help, model, search, settings, setup, status   ← dupes
GUILD B: clear, help, model, search, settings, setup, status   ← dupes
```

After — GLOBAL 7, every guild scope 0, and it **survives a restart** (the sync no longer re-adds them):
```
GLOBAL:  7 (clear, help, model, search, settings, setup, status)
GUILD A: 0
GUILD B: 0
```
typecheck clean; plugin-discord command tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
