### PR TITLE
feat(auth): auto-adopt Codex CLI login into the account pool (+ shared-grant guard for Claude)

### DIFF
--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -3881,6 +3881,31 @@ export async function startEliza(
   // bridge (see ./host-bridge.ts) — no app-core import, no boot-time cycle.
   if (readAliasedEnv("ELIZA_CLOUD_PROVISIONED") !== "1")
     try {
+      // Auto-adopt an existing Codex / Claude Code CLI login into the account
+      // pool BEFORE the pool loads, so a self-hosted operator who ran
+      // `codex login` / `claude login` gets a first-class, pool-owned account
+      // with no manual step — the pool then owns the single refresh chain
+      // (mutex + 5-min keep-alive sweep + per-account CODEX_HOME), which is
+      // what stops the one-time-use refresh-token race that revokes an
+      // uncoordinated shared login. Idempotent (skips when the store already
+      // holds the current token) and non-destructive (the CLI files stay in
+      // place); opt out with ELIZA_AUTO_IMPORT_CLI_LOGINS=0.
+      if (readAliasedEnv("ELIZA_AUTO_IMPORT_CLI_LOGINS") !== "0") {
+        try {
+          const { importAllCliLogins } = await import("@elizaos/auth");
+          for (const r of importAllCliLogins()) {
+            if (r.imported) {
+              logger.info(
+                `[eliza] Adopted ${r.provider} CLI login into the account pool (account "${r.accountId}")`,
+              );
+            }
+          }
+        } catch (err) {
+          logger.debug(
+            `[eliza] CLI-login auto-import skipped: ${formatError(err)}`,
+          );
+        }
+      }
       const accountPool = await importAppCoreRuntime();
       accountPool.getDefaultAccountPool();
       await accountPool.applyAccountPoolApiCredentials({

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -3881,19 +3881,35 @@ export async function startEliza(
   // bridge (see ./host-bridge.ts) — no app-core import, no boot-time cycle.
   if (readAliasedEnv("ELIZA_CLOUD_PROVISIONED") !== "1")
     try {
-      // Auto-adopt an existing Codex / Claude Code CLI login into the account
-      // pool BEFORE the pool loads, so a self-hosted operator who ran
-      // `codex login` / `claude login` gets a first-class, pool-owned account
-      // with no manual step — the pool then owns the single refresh chain
-      // (mutex + 5-min keep-alive sweep + per-account CODEX_HOME), which is
-      // what stops the one-time-use refresh-token race that revokes an
-      // uncoordinated shared login. Idempotent (skips when the store already
-      // holds the current token) and non-destructive (the CLI files stay in
-      // place); opt out with ELIZA_AUTO_IMPORT_CLI_LOGINS=0.
+      // Auto-adopt an existing Codex CLI login (`codex login`) into the account
+      // pool BEFORE the pool loads, so a self-hosted operator gets a
+      // first-class, pool-owned account with no manual step — the pool then
+      // owns the single refresh chain (mutex + 5-min keep-alive sweep +
+      // per-account CODEX_HOME), which is what stops the one-time-use
+      // refresh-token race that revokes an uncoordinated shared login.
+      // Idempotent + non-destructive; opt out with ELIZA_AUTO_IMPORT_CLI_LOGINS=0.
+      //
+      // Codex is safe to auto-pool: the spawned codex-acp runs against an
+      // ISOLATED per-account CODEX_HOME, so the pool and any interactive
+      // `codex` use never share a token in memory. The Claude Code login is
+      // NOT auto-imported: a Claude Max login is almost always the SAME account
+      // the operator uses interactively in Claude Code, and both share ONE
+      // one-time-use refresh chain — the moment the pool's keep-alive sweep
+      // refreshes it, the interactive Claude Code session's copy is revoked and
+      // the operator is silently logged out (observed live). Pooling Claude is
+      // therefore explicit opt-in via ELIZA_POOL_CLAUDE_CLI_LOGIN=1 and is
+      // only safe for a Claude Max account DEDICATED to the bot (not shared
+      // with interactive Claude Code). See importClaudeCliLogin.
       if (readAliasedEnv("ELIZA_AUTO_IMPORT_CLI_LOGINS") !== "0") {
         try {
-          const { importAllCliLogins } = await import("@elizaos/auth");
-          for (const r of importAllCliLogins()) {
+          const { importCodexCliLogin, importClaudeCliLogin } = await import(
+            "@elizaos/auth"
+          );
+          const results = [importCodexCliLogin()];
+          if (readAliasedEnv("ELIZA_POOL_CLAUDE_CLI_LOGIN") === "1") {
+            results.push(importClaudeCliLogin());
+          }
+          for (const r of results) {
             if (r.imported) {
               logger.info(
                 `[eliza] Adopted ${r.provider} CLI login into the account pool (account "${r.accountId}")`,

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -4,4 +4,5 @@ export * from "./claude-code-stealth.ts";
 export * from "./credentials.ts";
 export * from "./oauth-flow.ts";
 export * from "./openai-codex.ts";
+export * from "./subscription-auth/import-cli-logins.ts";
 export * from "./types.ts";

--- a/packages/auth/src/subscription-auth/import-cli-logins.test.ts
+++ b/packages/auth/src/subscription-auth/import-cli-logins.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for the CLI-login importer: mapping the Codex/Claude CLI blob
+ * shapes into canonical account records, idempotency, and non-destructiveness.
+ * Uses a temp ELIZA_HOME so the real store is never touched.
+ */
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadAccount } from "../account-storage.ts";
+import { importCodexCliLogin, importClaudeCliLogin } from "./import-cli-logins.ts";
+
+let home: string;
+let prevHome: string | undefined;
+let prevElizaHome: string | undefined;
+
+function makeJwt(expSeconds: number): string {
+  const b = (o: unknown) =>
+    Buffer.from(JSON.stringify(o)).toString("base64url");
+  return `${b({ alg: "RS256" })}.${b({ exp: expSeconds })}.sig`;
+}
+
+beforeEach(() => {
+  home = mkdtempSync(path.join(tmpdir(), "auth-import-"));
+  prevHome = process.env.HOME;
+  prevElizaHome = process.env.ELIZA_HOME;
+  process.env.HOME = home;
+  process.env.ELIZA_HOME = home; // authRoot() → <ELIZA_HOME>/auth
+  delete process.env.CODEX_HOME;
+});
+afterEach(() => {
+  if (prevHome === undefined) delete process.env.HOME;
+  else process.env.HOME = prevHome;
+  if (prevElizaHome === undefined) delete process.env.ELIZA_HOME;
+  else process.env.ELIZA_HOME = prevElizaHome;
+});
+
+describe("importCodexCliLogin", () => {
+  it("maps ~/.codex/auth.json (chatgpt mode) into an openai-codex account", () => {
+    mkdirSync(path.join(home, ".codex"), { recursive: true });
+    const exp = Math.floor(Date.now() / 1000) + 3600;
+    writeFileSync(
+      path.join(home, ".codex", "auth.json"),
+      JSON.stringify({
+        auth_mode: "chatgpt",
+        tokens: {
+          access_token: makeJwt(exp),
+          refresh_token: "rt.1.CODEX",
+          id_token: "id.token.codex",
+          account_id: "acct-123",
+        },
+        last_refresh: new Date().toISOString(),
+      }),
+    );
+    const r = importCodexCliLogin();
+    expect(r.imported).toBe(true);
+    const rec = loadAccount("openai-codex", "default");
+    expect(rec?.credentials.refresh).toBe("rt.1.CODEX");
+    expect(rec?.credentials.idToken).toBe("id.token.codex"); // required for CODEX_HOME
+    expect(rec?.organizationId).toBe("acct-123");
+    expect(rec?.credentials.expires).toBe(exp * 1000);
+  });
+
+  it("is idempotent when the store already holds the same refresh token", () => {
+    mkdirSync(path.join(home, ".codex"), { recursive: true });
+    const auth = JSON.stringify({
+      tokens: { access_token: makeJwt(9e9), refresh_token: "rt.same", id_token: "x" },
+      last_refresh: new Date().toISOString(),
+    });
+    writeFileSync(path.join(home, ".codex", "auth.json"), auth);
+    expect(importCodexCliLogin().imported).toBe(true);
+    expect(importCodexCliLogin().imported).toBe(false); // already current
+  });
+
+  it("returns imported=false with a reason when no login file exists", () => {
+    expect(importCodexCliLogin().imported).toBe(false);
+  });
+});
+
+describe("importClaudeCliLogin", () => {
+  it("maps a FLAT ~/.claude/.credentials.json into an anthropic-subscription account", () => {
+    mkdirSync(path.join(home, ".claude"), { recursive: true });
+    writeFileSync(
+      path.join(home, ".claude", ".credentials.json"),
+      JSON.stringify({
+        accessToken: "acc.flat",
+        refreshToken: "rt.flat",
+        expiresAt: Date.now() + 3600_000,
+        subscriptionType: "max",
+      }),
+    );
+    const r = importClaudeCliLogin();
+    expect(r.imported).toBe(true);
+    const rec = loadAccount("anthropic-subscription", "default");
+    expect(rec?.credentials.access).toBe("acc.flat");
+    expect(rec?.credentials.refresh).toBe("rt.flat");
+    // Non-destructive: source file survives.
+    expect(existsSync(path.join(home, ".claude", ".credentials.json"))).toBe(true);
+  });
+
+  it("also maps the NESTED claudeAiOauth wrapper shape", () => {
+    mkdirSync(path.join(home, ".claude"), { recursive: true });
+    writeFileSync(
+      path.join(home, ".claude", ".credentials.json"),
+      JSON.stringify({
+        claudeAiOauth: { accessToken: "acc.nested", refreshToken: "rt.nested", expiresAt: 1 },
+      }),
+    );
+    expect(importClaudeCliLogin().imported).toBe(true);
+    expect(loadAccount("anthropic-subscription", "default")?.credentials.access).toBe(
+      "acc.nested",
+    );
+  });
+});

--- a/packages/auth/src/subscription-auth/import-cli-logins.ts
+++ b/packages/auth/src/subscription-auth/import-cli-logins.ts
@@ -1,0 +1,204 @@
+/**
+ * One-shot importer that lifts an existing Codex CLI (`~/.codex/auth.json`) or
+ * Claude Code CLI (`~/.claude/.credentials.json`) subscription login into the
+ * canonical eliza account store, so the AccountPool owns the refresh chain.
+ *
+ * Why this exists: without a linked account, every coding spawn rides the raw
+ * machine-global CLI login. Those files have ONE-TIME-USE refresh tokens
+ * (OpenAI and Anthropic both rotate-and-revoke on reuse), and multiple
+ * uncoordinated refreshers — the planner backend, each spawned CLI, an
+ * interactive session — race the same token; a stale replay revokes the whole
+ * grant family ("refresh token was revoked, please log out and sign in again").
+ * Once the login is a first-class account, the per-account refresh mutex, the
+ * 5-minute keep-alive sweep, per-account CODEX_HOME materialization, and
+ * rotated-token adoption keep exactly one owner of the chain — the de-auth
+ * cadence goes away and multi-account/cycling become reachable.
+ *
+ * Non-destructive by default: the source CLI files are left in place (the CLIs
+ * keep working); pass `retireSource` to rename them once the pool is proven, so
+ * there is a single refresher.
+ */
+
+import { existsSync, readFileSync, renameSync } from "node:fs";
+import path from "node:path";
+import type { AccountCredentialProvider } from "../types.js";
+import { loadAccount, saveAccount } from "../account-storage.js";
+
+function codexHomePath(): string {
+  return path.join(
+    process.env.CODEX_HOME || path.join(process.env.HOME || "", ".codex"),
+    "auth.json",
+  );
+}
+
+function claudeCredentialsPath(): string {
+  return path.join(process.env.HOME || "", ".claude", ".credentials.json");
+}
+
+/** Decode a JWT's `exp` (seconds) into ms, or undefined when undecodable. */
+function jwtExpiryMs(token: string): number | undefined {
+  const parts = token.split(".");
+  if (parts.length < 2) return undefined;
+  try {
+    const payload = JSON.parse(
+      Buffer.from(
+        parts[1].replace(/-/g, "+").replace(/_/g, "/"),
+        "base64",
+      ).toString("utf-8"),
+    ) as { exp?: unknown };
+    return typeof payload.exp === "number" ? payload.exp * 1000 : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export interface ImportResult {
+  provider: AccountCredentialProvider;
+  accountId: string;
+  imported: boolean;
+  reason: string;
+}
+
+/**
+ * Import the Codex CLI's chatgpt-mode login. The CLI store shape is
+ * `{ tokens: { access_token, refresh_token, id_token, account_id }, last_refresh }`.
+ * `id_token` is REQUIRED so the materialized per-account CODEX_HOME can
+ * authenticate in chatgpt mode.
+ */
+export function importCodexCliLogin(
+  opts: { accountId?: string; retireSource?: boolean } = {},
+): ImportResult {
+  const provider: AccountCredentialProvider = "openai-codex";
+  const accountId = opts.accountId ?? "default";
+  const authPath = codexHomePath();
+  if (!existsSync(authPath)) {
+    return { provider, accountId, imported: false, reason: "no ~/.codex/auth.json" };
+  }
+  let parsed: {
+    tokens?: {
+      access_token?: string;
+      refresh_token?: string;
+      id_token?: string;
+      account_id?: string;
+    };
+    last_refresh?: string;
+  };
+  try {
+    parsed = JSON.parse(readFileSync(authPath, "utf-8"));
+  } catch {
+    return { provider, accountId, imported: false, reason: "unparseable auth.json" };
+  }
+  const tokens = parsed.tokens;
+  if (!tokens?.access_token || !tokens.refresh_token) {
+    return { provider, accountId, imported: false, reason: "missing tokens" };
+  }
+  const materializedAt =
+    typeof parsed.last_refresh === "string"
+      ? Date.parse(parsed.last_refresh)
+      : Number.NaN;
+  const existing = loadAccount(provider, accountId);
+  // Idempotent: skip when the store already holds this exact refresh token
+  // (nothing changed) or a strictly newer record (the pool refreshed since).
+  if (existing) {
+    if (existing.credentials.refresh === tokens.refresh_token) {
+      return { provider, accountId, imported: false, reason: "already current" };
+    }
+    if (Number.isFinite(materializedAt) && materializedAt <= existing.updatedAt) {
+      return { provider, accountId, imported: false, reason: "store is newer" };
+    }
+  }
+  const now = Date.now();
+  saveAccount({
+    id: accountId,
+    providerId: provider,
+    label: "Imported Codex CLI login",
+    source: "oauth",
+    credentials: {
+      access: tokens.access_token,
+      refresh: tokens.refresh_token,
+      // Undecodable exp ⇒ already-expired so the first getAccessToken refreshes
+      // immediately with the (still valid) refresh token.
+      expires: jwtExpiryMs(tokens.access_token) ?? now,
+      ...(tokens.id_token ? { idToken: tokens.id_token } : {}),
+    },
+    createdAt: existing?.createdAt ?? now,
+    updatedAt: now,
+    ...(tokens.account_id ? { organizationId: tokens.account_id } : {}),
+  });
+  if (opts.retireSource) {
+    try {
+      renameSync(authPath, `${authPath}.imported-${now}`);
+    } catch {
+      // best-effort — the record is written regardless.
+    }
+  }
+  return { provider, accountId, imported: true, reason: "imported" };
+}
+
+/**
+ * Import the Claude Code CLI's Max login. The blob is either flat
+ * (`{ accessToken, refreshToken, expiresAt, subscriptionType }`) or wrapped in
+ * `{ claudeAiOauth: { ... } }`; both are accepted.
+ */
+export function importClaudeCliLogin(
+  opts: { accountId?: string; retireSource?: boolean } = {},
+): ImportResult {
+  const provider: AccountCredentialProvider = "anthropic-subscription";
+  const accountId = opts.accountId ?? "default";
+  const credPath = claudeCredentialsPath();
+  if (!existsSync(credPath)) {
+    return { provider, accountId, imported: false, reason: "no ~/.claude/.credentials.json" };
+  }
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(readFileSync(credPath, "utf-8"));
+  } catch {
+    return { provider, accountId, imported: false, reason: "unparseable credentials" };
+  }
+  const oauth = (
+    parsed.claudeAiOauth && typeof parsed.claudeAiOauth === "object"
+      ? parsed.claudeAiOauth
+      : parsed
+  ) as {
+    accessToken?: string;
+    refreshToken?: string;
+    expiresAt?: number;
+    subscriptionType?: string;
+  };
+  if (!oauth.accessToken || !oauth.refreshToken) {
+    return { provider, accountId, imported: false, reason: "missing tokens" };
+  }
+  const existing = loadAccount(provider, accountId);
+  if (existing && existing.credentials.refresh === oauth.refreshToken) {
+    return { provider, accountId, imported: false, reason: "already current" };
+  }
+  const now = Date.now();
+  saveAccount({
+    id: accountId,
+    providerId: provider,
+    label: `Imported Claude ${oauth.subscriptionType ?? "Max"} login`,
+    source: "oauth",
+    credentials: {
+      access: oauth.accessToken,
+      refresh: oauth.refreshToken,
+      expires: typeof oauth.expiresAt === "number" ? oauth.expiresAt : now,
+    },
+    createdAt: existing?.createdAt ?? now,
+    updatedAt: now,
+  });
+  if (opts.retireSource) {
+    try {
+      renameSync(credPath, `${credPath}.imported-${now}`);
+    } catch {
+      // best-effort.
+    }
+  }
+  return { provider, accountId, imported: true, reason: "imported" };
+}
+
+/** Import whichever CLI logins are present. */
+export function importAllCliLogins(
+  opts: { retireSource?: boolean } = {},
+): ImportResult[] {
+  return [importCodexCliLogin(opts), importClaudeCliLogin(opts)];
+}

--- a/packages/auth/src/subscription-auth/import-cli-logins.ts
+++ b/packages/auth/src/subscription-auth/import-cli-logins.ts
@@ -52,7 +52,7 @@ function jwtExpiryMs(token: string): number | undefined {
   }
 }
 
-export interface ImportResult {
+export interface CliLoginImportResult {
   provider: AccountCredentialProvider;
   accountId: string;
   imported: boolean;
@@ -67,7 +67,7 @@ export interface ImportResult {
  */
 export function importCodexCliLogin(
   opts: { accountId?: string; retireSource?: boolean } = {},
-): ImportResult {
+): CliLoginImportResult {
   const provider: AccountCredentialProvider = "openai-codex";
   const accountId = opts.accountId ?? "default";
   const authPath = codexHomePath();
@@ -139,10 +139,22 @@ export function importCodexCliLogin(
  * Import the Claude Code CLI's Max login. The blob is either flat
  * (`{ accessToken, refreshToken, expiresAt, subscriptionType }`) or wrapped in
  * `{ claudeAiOauth: { ... } }`; both are accepted.
+ *
+ * ⚠ SHARED-GRANT HAZARD — read before calling from an auto-import path. Unlike
+ * Codex (whose per-account CODEX_HOME isolates the pool from any interactive
+ * `codex` use), a Claude Max login is almost always the SAME account the
+ * operator runs Claude Code with. The pool and interactive Claude Code then
+ * share ONE one-time-use refresh chain: when the pool's keep-alive sweep
+ * refreshes the token, Anthropic rotates-and-revokes it and the interactive
+ * Claude Code session's now-stale copy is kicked — the operator is silently
+ * logged out (reproduced live). Only pool a Claude Max account DEDICATED to the
+ * bot; the boot auto-import gates this behind ELIZA_POOL_CLAUDE_CLI_LOGIN=1 for
+ * exactly this reason. This function itself is a safe library primitive — the
+ * hazard is in WHERE it is called, not the mapping.
  */
 export function importClaudeCliLogin(
   opts: { accountId?: string; retireSource?: boolean } = {},
-): ImportResult {
+): CliLoginImportResult {
   const provider: AccountCredentialProvider = "anthropic-subscription";
   const accountId = opts.accountId ?? "default";
   const credPath = claudeCredentialsPath();
@@ -199,6 +211,6 @@ export function importClaudeCliLogin(
 /** Import whichever CLI logins are present. */
 export function importAllCliLogins(
   opts: { retireSource?: boolean } = {},
-): ImportResult[] {
+): CliLoginImportResult[] {
   return [importCodexCliLogin(opts), importClaudeCliLogin(opts)];
 }


### PR DESCRIPTION
## What

Auto-adopt an existing **Codex CLI** login (`codex login`) into the account pool at boot, so a self-hosted operator gets a first-class, pool-owned account with no manual step. Once pooled, the existing machinery (per-account refresh mutex, 5-min keep-alive refresh sweep, per-account `CODEX_HOME` materialization, rotated-token adoption) owns the **single** refresh chain.

## Why

The whole multi-account pool (storage, `AccountPool` with priority/round-robin/least-used/quota-aware strategies, per-account `CODEX_HOME`, auth-failure failover) was fully built and tested but **inert** on a fresh box: with zero linked accounts, every coding spawn rode the raw machine-global `~/.codex/auth.json` / `~/.claude/.credentials.json`, which bypass all of it. Those files hold **one-time-use** refresh tokens (OpenAI and Anthropic both rotate-and-revoke on reuse), and multiple uncoordinated refreshers — the planner backend, each spawned CLI, an interactive session — race the same token; a stale replay revokes the whole grant family (*"refresh token was revoked, please log out and sign in again"*). Adopting the login into the pool makes exactly one owner of the chain, which removes that de-auth cadence.

## Shared-grant guard (the important safety bit)

A **Claude Max** login is almost always the *same* account the operator uses interactively in Claude Code, sharing **one** one-time-use refresh chain. If the pool refreshes it, Anthropic rotates+revokes and the interactive Claude Code session is silently logged out (**reproduced live**). So:
- **Codex is auto-imported** at boot (its spawned CLI runs against an isolated per-account `CODEX_HOME`, so it never shares a token in memory with interactive `codex`).
- **Claude is opt-in only** via `ELIZA_POOL_CLAUDE_CLI_LOGIN=1`, and documented as safe *only* for a Claude Max account **dedicated** to the bot.

`importCodexCliLogin` / `importClaudeCliLogin` are safe library primitives (handle the codex chatgpt-mode blob incl. the required `id_token`, and both flat + `claudeAiOauth`-wrapped Claude blobs); idempotent + non-destructive. Auto-import is opt-out via `ELIZA_AUTO_IMPORT_CLI_LOGINS=0`, and skipped on cloud-provisioned runtimes.

## Evidence (live)

- Boot: `[eliza] Adopted openai-codex CLI login into the account pool (account "default")`; deleting the record and restarting re-adopts it idempotently.
- Codex spawn selects `codex → openai-codex account (default) via least-used` + `Dropped OPENAI_API_KEY … per-account CODEX_HOME`, 0 auth errors.
- Force-expire → pool `Refreshing openai-codex token` → new access token, refresh rotated + persisted, **zero re-login**.
- Multi-account cycling proven end-to-end: with a 2nd codex account added (device-auth) and `round-robin`, two coding tasks landed on two different accounts.

5 unit tests (`import-cli-logins.test.ts`): codex/claude blob mapping (both shapes), idempotency, non-destructiveness. auth + agent typecheck clean.

## Follow-up finding (separate)

Codex's built-in OAuth account-connect uses a `localhost:1455` loopback redirect that only works when the browser is co-located with the agent (desktop app). On a **remote/headless** host it can't complete — the correct path there is the codex CLI's `--device-auth` device-code flow. The account-connect API should offer a device-code option for headless; noted for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
