### PR TITLE
fix(discord): /help lists only commands actually registered with Discord (stop advertising unavailable catalog commands)

### DIFF
--- a/plugins/plugin-discord/slash-commands.ts
+++ b/plugins/plugin-discord/slash-commands.ts
@@ -133,7 +133,36 @@ const helpCommand: SlashCommand = {
 	ephemeral: true,
 	async execute(interaction) {
 		const lines: string[] = ["**Available Commands**\n"];
+		// List ONLY the commands actually registered with Discord (global + this
+		// guild's scope), so /help matches the slash menu exactly. The in-process
+		// registry also holds "catalog" commands that are filtered out of the
+		// Discord push (guild-context classification); listing those made /help
+		// advertise commands a user cannot pick from the / menu. Falls back to the
+		// full registry if the registered set can't be read.
+		let registeredNames: Set<string> | null = null;
+		try {
+			const app = interaction.client.application;
+			if (app) {
+				const names = new Set<string>();
+				const global = app.commands.cache.size
+					? app.commands.cache
+					: await app.commands.fetch();
+				for (const cmd of global.values()) names.add(cmd.name);
+				if (interaction.guildId) {
+					const guildCmds = await app.commands.fetch({
+						guildId: interaction.guildId,
+					});
+					for (const cmd of guildCmds.values()) names.add(cmd.name);
+				}
+				if (names.size > 0) registeredNames = names;
+			}
+		} catch {
+			// error-policy:J4 degrade — an unreadable registered set falls back to
+			// the full in-process registry (the pre-existing behavior).
+			registeredNames = null;
+		}
 		for (const [name, command] of commands) {
+			if (registeredNames && !registeredNames.has(name)) continue;
 			const options = command.options
 				? command.options
 						.map((option) =>


### PR DESCRIPTION
## What

`/help` listed the **entire in-process command registry** — 41 entries, including the "catalog" commands (`think`, `reasoning`, `views`, `knowledge`, `plugins`, `tasks`, `wallet`, `usage`, `logs`, `database`, `allowlist`, `elevated`, …). But only the ~7 built-ins (`clear`, `help`, `model`, `search`, `settings`, `setup`, `status`) are actually registered with Discord as invocable slash commands; the catalog commands are filtered out of the Discord push by their guild-context classification (`isGuildOnlyCommand`). So `/help` advertised 34 commands that never appear in the `/` autocomplete menu.

## Fix

`/help` now lists only the commands **actually registered with Discord** — the application-command set (global + the current guild's scope) — so it matches the slash menu exactly and can't drift again. Falls back to the full in-process registry only if that set can't be read (error-policy:J4). No change to what's registered; help output only.

## Why not expose all 41 as slash commands instead?

That would give users a cluttered 41-item menu including power/admin commands (`database`, `logs`, `allowlist`, `elevated`) most users shouldn't see. The catalog commands are valid (verified: registering `/think` via the API returns 201) but are deliberately kept off the default menu — so the right fix is to make `/help` honest about it, not to flood the menu.

## Evidence

- Discord API before: 7 registered globally, 0 per-guild; `/help` output enumerated all 41 registry entries.
- After: `/help` filters to the registered set (the 7). Verified the registered-command read path against the live bot; typecheck clean, plugin builds.

Related: #15982 (the duplicate-menu-entry fix on the same surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
