### PR TITLE
fix(ci): refresh voice RTT dist alias

### DIFF
--- a/tsconfig.dist-paths.json
+++ b/tsconfig.dist-paths.json
@@ -555,6 +555,9 @@
       "@elizaos/vault": [
         "./packages/vault/dist/index.d.ts"
       ],
+      "@elizaos/voice-rtt-bench": [
+        "./packages/benchmarks/voice-rtt/src/index.ts"
+      ],
       "@feed/a2a": [
         "./packages/feed/packages/a2a/src/index.ts"
       ],


### PR DESCRIPTION
Closes #15978.

## What

Regenerates the canonical `tsconfig.dist-paths.json` after `@elizaos/voice-rtt-bench` became a workspace package. The generated config now maps it to `./packages/benchmarks/voice-rtt/src/index.ts`.

This is split from #15981 so the independent dist-path repair can restore `bun run verify` without coupling it to the blocked local-inference downloader change.

## Verification

Exact base: `origin/develop@4cf674e5fe0898d29548b5badacb1a15d46b25d8`.

- `node packages/scripts/generate-dist-paths-config.mjs --check` — 199 aliases current.
- `bun run install:light` — completed; unrelated Bun-canary lockfile rewrite discarded.
- `bun run build:core` — 70/70 build tasks passed.
- `bun run typecheck:dist` — the generated-config check passes and the original stale-alias failure is gone; a standalone partial build then reaches the next consumer and stops on an unbuilt `@elizaos/plugin-openrouter` dist. The fresh PR build/typecheck checks are the exact-head full-workspace proof.
- `git diff --check` — passed.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - generated TypeScript path metadata only; no rendered UI changed.

<!-- evidence-row:after-screenshots -->
- [x] N/A - generated TypeScript path metadata only; no rendered UI changed.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing interaction changed.

<!-- evidence-row:backend-logs -->
- [x] N/A - no server runtime path changed.

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime path changed.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, provider, or planner behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] N/A - the generated `tsconfig.dist-paths.json` diff is the domain artifact and contains exactly the new voice RTT alias.

