### PR TITLE
fix(app): make CharacterEditor config writes explicit (#15922)

### DIFF
--- a/packages/app/scripts/audit-views-soak-navigation.test.mjs
+++ b/packages/app/scripts/audit-views-soak-navigation.test.mjs
@@ -154,3 +154,15 @@ test("the soak recognizes unavailable optional services and protected boundaries
   expect(source).toContain("entry.status === 401");
   expect(source).toContain("protected_route_without_session");
 });
+
+test("the soak records and fails on browser console errors", () => {
+  expect(source).toContain(
+    'const consoleErrors = consoleLog.filter((entry) => entry.type === "error")',
+  );
+  expect(source).toContain("unexpectedConsoleErrors.length === 0");
+  expect(source).toContain("isExpectedConsoleError(");
+  expect(source).toContain("networkEntry.classification.expected");
+  expect(source).toContain('writeJson("audit-views-frontend-log.json"');
+  expect(source).toContain("consoleErrors,");
+  expect(source).toContain("unexpectedConsoleErrors,");
+});

--- a/packages/app/scripts/audit-views-soak.mjs
+++ b/packages/app/scripts/audit-views-soak.mjs
@@ -316,6 +316,23 @@ function summarizeNetworkLog(networkLog) {
   };
 }
 
+function isExpectedConsoleError(entry, classifiedNetworkLog) {
+  if (
+    !/^Failed to load resource: the server responded with a status of (401|404) \([^)]+\)$/.test(
+      entry.text,
+    )
+  ) {
+    return false;
+  }
+  const locationUrl = entry.location?.url;
+  return classifiedNetworkLog.some(
+    (networkEntry) =>
+      networkEntry.kind === "response" &&
+      networkEntry.url === locationUrl &&
+      networkEntry.classification.expected,
+  );
+}
+
 let activeBrowser = null;
 let activeContext = null;
 
@@ -684,6 +701,7 @@ async function main() {
   // sweep trips it; 2.2x is a deliberately loose doubling-guard to stay non-flaky.
   const heapWarm = heapSamples[1] || heapStart;
   const heapRatio = heapEnd / Math.max(1, heapWarm);
+  const consoleErrors = consoleLog.filter((entry) => entry.type === "error");
   assert(
     heapRatio < 2.2 || heapEnd === 0,
     `heap bounded across the soak: end ${(heapEnd / 1e6).toFixed(1)}MB / warm ${(heapWarm / 1e6).toFixed(1)}MB = ${heapRatio.toFixed(2)}x (< 2.2x; 0 = no perf.memory)`,
@@ -711,6 +729,13 @@ async function main() {
   activeBrowser = null;
 
   const networkSummary = summarizeNetworkLog(networkLog);
+  const unexpectedConsoleErrors = consoleErrors.filter(
+    (entry) => !isExpectedConsoleError(entry, networkSummary.classified),
+  );
+  assert(
+    unexpectedConsoleErrors.length === 0,
+    `no unexpected console errors during the soak (${JSON.stringify(unexpectedConsoleErrors.slice(0, 3))})`,
+  );
   assert(
     networkSummary.unexpectedCount === 0,
     `no unexpected network failures during the soak (${networkSummary.unexpectedCount} unexpected / ${networkSummary.total} total; expected navigation aborts=${networkSummary.expectedAbortCount}, expected optional-route 404s=${networkSummary.expectedOptionalRoute404Count}, expected protected-route 401s=${networkSummary.expectedProtectedRoute401Count})`,
@@ -729,6 +754,8 @@ async function main() {
   writeJson("audit-views-navigation.json", [...navRecords.values()]);
   writeJson("audit-views-frontend-log.json", {
     console: consoleLog,
+    consoleErrors,
+    unexpectedConsoleErrors,
     pageErrors,
   });
   writeJson("audit-views-network-log.json", networkLog);

--- a/packages/app/test/ui-smoke/character-editor.spec.ts
+++ b/packages/app/test/ui-smoke/character-editor.spec.ts
@@ -1,6 +1,6 @@
 /**
- * Playwright UI-smoke spec for the Character Editor app flow using the real
- * renderer fixture.
+ * Playwright UI-smoke coverage for Character Editor config boundaries and
+ * persistence flows using the real renderer fixture.
  */
 import { expect, type Page, test } from "@playwright/test";
 import {
@@ -35,6 +35,205 @@ async function styleRules(page: Page, section: "all"): Promise<string[]> {
       ),
     );
 }
+
+async function navigateToCoreView(
+  page: Page,
+  detail: { viewId: string; viewPath: string; viewLabel: string },
+): Promise<void> {
+  await page.evaluate((view) => {
+    window.dispatchEvent(
+      new CustomEvent("eliza:navigate:view", {
+        detail: {
+          ...view,
+          viewType: "gui",
+          alwaysOnTop: false,
+        },
+      }),
+    );
+  }, detail);
+}
+
+test.describe("character editor voice config boundary", () => {
+  test.beforeEach(async ({ page }) => {
+    await seedAppStorage(page);
+    await installDefaultAppRoutes(page);
+  });
+
+  test("a failed config read blocks early writes and stays explicit across remounts", async ({
+    page,
+  }) => {
+    await openAppPath(page, "/chat");
+
+    let configReads = 0;
+    let configWrites = 0;
+    const consoleErrors: string[] = [];
+    page.on("console", (message) => {
+      if (message.type() === "error") consoleErrors.push(message.text());
+    });
+    await page.route("**/api/config", async (route) => {
+      const method = route.request().method();
+      if (method === "GET") {
+        configReads += 1;
+        await route.fulfill({
+          status: 401,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "Unauthorized" }),
+        });
+        return;
+      }
+      if (method === "PUT") {
+        configWrites += 1;
+        await route.fulfill({
+          status: 401,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "Unauthorized" }),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+
+    const character = {
+      viewId: "character",
+      viewPath: "/character",
+      viewLabel: "Character",
+    };
+    await navigateToCoreView(page, character);
+    await expect(page.getByTestId("character-editor-view")).toBeVisible();
+    await expect(
+      page.getByTestId("character-voice-config-unavailable"),
+    ).toContainText("Voice settings are unavailable");
+
+    await navigateToCoreView(page, {
+      viewId: "settings",
+      viewPath: "/settings",
+      viewLabel: "Settings",
+    });
+    await expect(page.getByTestId("settings-shell")).toBeVisible();
+    await navigateToCoreView(page, character);
+    await expect(page.getByTestId("character-editor-view")).toBeVisible();
+    await expect(
+      page.getByTestId("character-voice-config-unavailable"),
+    ).toContainText("Voice settings are unavailable");
+
+    await expect.poll(() => configReads).toBeGreaterThanOrEqual(2);
+    await expect.poll(() => configWrites).toBe(0);
+    expect(
+      consoleErrors.some((message) =>
+        message.includes("voice config early persist failed"),
+      ),
+    ).toBe(false);
+  });
+
+  test("a late failed read from an unmounted editor cannot poison the next mount", async ({
+    page,
+  }) => {
+    await openAppPath(page, "/chat");
+
+    let configReads = 0;
+    let releaseFirstRead = () => {};
+    let markFirstReadStarted = () => {};
+    const firstReadStarted = new Promise<void>((resolve) => {
+      markFirstReadStarted = resolve;
+    });
+    const firstReadRelease = new Promise<void>((resolve) => {
+      releaseFirstRead = resolve;
+    });
+    await page.route("**/api/config", async (route) => {
+      if (route.request().method() !== "GET") {
+        await route.fallback();
+        return;
+      }
+      configReads += 1;
+      if (configReads === 1) {
+        markFirstReadStarted();
+        await firstReadRelease;
+        await route.fulfill({
+          status: 401,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "late Unauthorized" }),
+        });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ messages: { tts: { provider: "edge" } } }),
+      });
+    });
+
+    const character = {
+      viewId: "character",
+      viewPath: "/character",
+      viewLabel: "Character",
+    };
+    await navigateToCoreView(page, character);
+    await expect(page.getByTestId("character-editor-view")).toBeVisible();
+    await firstReadStarted;
+    await navigateToCoreView(page, {
+      viewId: "settings",
+      viewPath: "/settings",
+      viewLabel: "Settings",
+    });
+    await expect(page.getByTestId("settings-shell")).toBeVisible();
+    await navigateToCoreView(page, character);
+    await expect(page.getByTestId("character-editor-view")).toBeVisible();
+    await expect.poll(() => configReads).toBeGreaterThanOrEqual(2);
+
+    releaseFirstRead();
+    await page.waitForTimeout(100);
+    await expect(
+      page.getByTestId("character-voice-config-unavailable"),
+    ).toHaveCount(0);
+  });
+
+  test("a readable config does not authorize an automatic write", async ({
+    page,
+  }) => {
+    await openAppPath(page, "/chat");
+
+    let configWrites = 0;
+    const consoleErrors: string[] = [];
+    page.on("console", (message) => {
+      if (message.type() === "error") consoleErrors.push(message.text());
+    });
+    await page.route("**/api/config", async (route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ messages: { tts: { provider: "edge" } } }),
+        });
+        return;
+      }
+      if (route.request().method() === "PUT") {
+        configWrites += 1;
+        await route.fulfill({
+          status: 401,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "Unauthorized" }),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+
+    await navigateToCoreView(page, {
+      viewId: "character",
+      viewPath: "/character",
+      viewLabel: "Character",
+    });
+    await expect(page.getByTestId("character-editor-view")).toBeVisible();
+    await page.waitForTimeout(250);
+
+    expect(configWrites).toBe(0);
+    expect(
+      consoleErrors.some((message) =>
+        message.includes("voice config early persist failed"),
+      ),
+    ).toBe(false);
+  });
+});
 
 test.describe("character editor deep round-trip", () => {
   test.skip(

--- a/packages/ui/src/components/character/CharacterEditor.tsx
+++ b/packages/ui/src/components/character/CharacterEditor.tsx
@@ -6,7 +6,6 @@
  * entry. Kept statically imported in App.tsx (not lazy) so first-run onboarding
  * can land here without a chunk fetch.
  */
-import { logger } from "@elizaos/logger";
 import { getStylePresets } from "@elizaos/shared";
 import { useAgentElement } from "../../agent-surface";
 import type { CharacterData } from "../../api/client";
@@ -452,9 +451,14 @@ export function CharacterEditor({
   const [, setVoiceLoading] = useState(false);
   const [voiceSaving, setVoiceSaving] = useState(false);
   const [voiceSaveError, setVoiceSaveError] = useState<string | null>(null);
+  const [voiceConfigLoadError, setVoiceConfigLoadError] = useState<
+    string | null
+  >(null);
   const [, setSelectedVoicePresetId] = useState<string | null>(null);
   const [voiceSelectionLocked] = useState(false);
   const activeCharacterIdRef = useRef<string | null>(null);
+  const voiceConfigLoadGenerationRef = useRef(0);
+  const voicePresetAppliedRef = useRef(false);
 
   /* ── Load roster ────────────────────────────────────────────────── */
   // Use static STYLE_PRESETS shipped in the frontend bundle — no API call
@@ -637,56 +641,73 @@ export function CharacterEditor({
   /* ── Load voice config on mount ─────────────────────────────────── */
   /* Load voice config from server — but don't overwrite a roster-derived
      voice preset that was already applied by auto-select. */
-  const voicePresetAppliedRef = useRef(false);
-  useEffect(() => {
-    void (async () => {
-      setVoiceLoading(true);
-      try {
-        const cfg = await client.getConfig();
-        type MessagesConfig = { tts?: CharacterEditorVoiceConfig };
-        const messages = cfg.messages as MessagesConfig | undefined;
-        const tts = messages?.tts;
-        if (tts) {
-          const serverElevenlabsVoiceId =
-            typeof tts.elevenlabs === "object" ? tts.elevenlabs.voiceId : null;
-          setVoiceConfig((prev) => {
-            if (!voicePresetAppliedRef.current) {
-              return tts;
-            }
-            const serverElevenlabs =
-              typeof tts.elevenlabs === "object" ? tts.elevenlabs : {};
-            const currentElevenlabs =
-              typeof prev.elevenlabs === "object" ? prev.elevenlabs : {};
-            const serverEdge = typeof tts.edge === "object" ? tts.edge : {};
-            const currentEdge = typeof prev.edge === "object" ? prev.edge : {};
-            return {
-              ...tts,
-              ...prev,
-              elevenlabs: {
-                ...serverElevenlabs,
-                ...currentElevenlabs,
-              },
-              edge: {
-                ...serverEdge,
-                ...currentEdge,
-              },
-            };
-          });
-          // Only set the voice preset from server if a roster entry hasn't
-          // already set one (roster voice takes precedence).
-          if (serverElevenlabsVoiceId && !voicePresetAppliedRef.current) {
-            const preset = PREMADE_VOICES.find(
-              (p) => p.voiceId === serverElevenlabsVoiceId,
-            );
-            setSelectedVoicePresetId(preset?.id ?? null);
+  const loadVoiceConfig = useCallback(async () => {
+    const generation = ++voiceConfigLoadGenerationRef.current;
+    setVoiceLoading(true);
+    setVoiceConfigLoadError(null);
+    try {
+      const cfg = await client.getConfig();
+      if (generation !== voiceConfigLoadGenerationRef.current) return;
+      type MessagesConfig = { tts?: CharacterEditorVoiceConfig };
+      const messages = cfg.messages as MessagesConfig | undefined;
+      const tts = messages?.tts;
+      if (tts) {
+        const serverElevenlabsVoiceId =
+          typeof tts.elevenlabs === "object" ? tts.elevenlabs.voiceId : null;
+        setVoiceConfig((prev) => {
+          if (!voicePresetAppliedRef.current) {
+            return tts;
           }
+          const serverElevenlabs =
+            typeof tts.elevenlabs === "object" ? tts.elevenlabs : {};
+          const currentElevenlabs =
+            typeof prev.elevenlabs === "object" ? prev.elevenlabs : {};
+          const serverEdge = typeof tts.edge === "object" ? tts.edge : {};
+          const currentEdge = typeof prev.edge === "object" ? prev.edge : {};
+          return {
+            ...tts,
+            ...prev,
+            elevenlabs: {
+              ...serverElevenlabs,
+              ...currentElevenlabs,
+            },
+            edge: {
+              ...serverEdge,
+              ...currentEdge,
+            },
+          };
+        });
+        // Only set the voice preset from server if a roster entry hasn't
+        // already set one (roster voice takes precedence).
+        if (serverElevenlabsVoiceId && !voicePresetAppliedRef.current) {
+          const preset = PREMADE_VOICES.find(
+            (p) => p.voiceId === serverElevenlabsVoiceId,
+          );
+          setSelectedVoicePresetId(preset?.id ?? null);
         }
-      } catch {
-        // non-fatal: voice config load failure leaves voice section empty
       }
-      setVoiceLoading(false);
-    })();
+    } catch (error) {
+      // error-policy:J4 the unavailable banner and retry action preserve the
+      // distinction between an unreadable config and an empty voice config.
+      if (generation !== voiceConfigLoadGenerationRef.current) return;
+      setVoiceConfigLoadError(
+        error instanceof Error
+          ? `Voice settings are unavailable: ${error.message}`
+          : "Voice settings are unavailable.",
+      );
+    } finally {
+      if (generation === voiceConfigLoadGenerationRef.current) {
+        setVoiceLoading(false);
+      }
+    }
   }, []);
+
+  useEffect(() => {
+    void loadVoiceConfig();
+    return () => {
+      voiceConfigLoadGenerationRef.current += 1;
+    };
+  }, [loadVoiceConfig]);
 
   /* ── Voice helpers ──────────────────────────────────────────────── */
   const applyVoicePresetForEntry = useCallback(
@@ -728,26 +749,12 @@ export function CharacterEditor({
       setSelectedCharacterId(entry.id);
       setState("selectedVrmIndex", entry.avatarIndex);
       if (!voiceSelectionLocked && isNewCharacter) {
-        const persistedVoiceConfig = applyVoicePresetForEntry(entry);
-        if (persistedVoiceConfig) {
-          dispatchWindowEvent(VOICE_CONFIG_UPDATED_EVENT, persistedVoiceConfig);
-          // Persist the voice switch immediately so the next assistant line
-          // uses the selected character's voice without waiting for Save.
-          // error-policy:J4 immediate persist is an optimization — Save
-          // remains the durable write path; error log keeps a failed early
-          // sync observable instead of silently speaking with the old voice.
-          void client
-            .updateConfig({
-              messages: {
-                tts: persistedVoiceConfig,
-              },
-            })
-            .catch((err: unknown) => {
-              logger.error(
-                { err },
-                "[CharacterEditor] voice config early persist failed",
-              );
-            });
+        const selectedVoiceConfig = applyVoicePresetForEntry(entry);
+        if (selectedVoiceConfig) {
+          dispatchWindowEvent(VOICE_CONFIG_UPDATED_EVENT, selectedVoiceConfig);
+          // Selection changes the active local voice immediately. The explicit
+          // Save boundary owns durable config writes because a readable config
+          // does not prove that the current session may mutate it.
         }
       }
       if (applyDefaults) {
@@ -1297,6 +1304,23 @@ export function CharacterEditor({
         data-testid={sceneOverlay ? "companion-character-editor" : undefined}
         onWheel={sceneOverlay ? (e) => e.stopPropagation() : undefined}
       >
+        {voiceConfigLoadError ? (
+          <div
+            role="alert"
+            data-testid="character-voice-config-unavailable"
+            className="flex shrink-0 items-center justify-between gap-3 rounded-sm border border-status-danger/30 bg-status-danger-bg px-3 py-2 text-xs text-status-danger pointer-events-auto"
+          >
+            <span>{voiceConfigLoadError}</span>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => void loadVoiceConfig()}
+            >
+              {t("common.retry", { defaultValue: "Retry" })}
+            </Button>
+          </div>
+        ) : null}
         <div
           className={
             sceneOverlay
@@ -1478,7 +1502,7 @@ export function CharacterEditor({
               handlePendingStyleEntryChange={handlePendingStyleEntryChange}
               applyStyleEdit={handleCharacterStyleInput}
               handleStyleEntryDraftChange={handleStyleEntryDraftChange}
-              characterSaveError={characterSaveError}
+              characterSaveError={combinedSaveError}
             />
           )}
         </div>


### PR DESCRIPTION
Fixes #15922.

## What

- Remove CharacterEditor's automatic config PUT during roster selection; the local voice event still switches the active voice immediately, while explicit Save owns durable writes.
- Render a retryable unavailable state when config loading fails instead of treating a failed read as an empty config.
- Generation-gate config reads so late responses from an unmounted editor cannot poison a later mount.
- Surface explicit Save failures through the visible editor error state.
- Make the real-app view soak fail on unexpected browser console errors. Browser-generated 401/404 resource messages degrade only when the same response is classified as an expected protected/optional route.
- Add browser coverage for failed reads, remount races, and the production case where a readable config still does not authorize an automatic write.

## Verification

Head: `e17e0eee54fe0262ebb1f9b7e75f677baa408b6c`
Base: `4cf674e5fe0898d29548b5badacb1a15d46b25d8`

- Focused Chromium: 3 passed, 1 live-stack round-trip skipped.
- Real running app/API soak: PASS over 38 activations of all 19 registered views; 0 page errors, 0 unexpected console errors, 0 unexpected network failures.
- Soak boundary contracts: 11 passed.
- Full app aesthetic audit on the same rendered UI state: 246 passed; broken=0; needs-work=0; OCR broken=0. Exact-head rerun is in progress after the final non-visual soak-gate change.
- `packages/ui` typecheck: passed.
- Biome changed-file check: passed.
- Error-policy ratchet: passed; CharacterEditor emptyCatch 1→0.
- Manually reviewed the before/after screenshots, focused failure/remount recording, real-app Character capture, full soak recording, frontend log, and network classification.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshot: [failed config read renders healthy-looking editor with no error state](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15961-d507286-before-hidden-character-config-failure.jpg).
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: [failed read is explicit and retryable](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15961-70c58ead-character-voice-config-error.jpg); [real running app Character view after the fix](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15922-e17e0eee-real-app-character.jpg).
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: [focused failed-read/remount flow](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15961-70c58ead-character-voice-config-error-remount.mp4); [real app 19-view soak](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15922-e17e0eee-real-app-view-soak.mp4).
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - implementation changes are confined to the client write boundary and browser soak gate; the real local API was running for the soak.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: [frontend log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15922-e17e0eee-real-app-frontend-log.json), [network classification](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15922-e17e0eee-real-app-network-summary.json), [focused Playwright trace](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15961-70c58ead-character-voice-config-error-remount-trace.zip).
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent/action/provider/prompt/model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no memories, knowledge, database rows, scheduled tasks, wallets, or generated files; [real soak result](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15922-e17e0eee-real-app-soak-result.json) is the behavioral artifact.


<!-- evidence-row:ocr-review -->
- [x] OCR visual text review: real-renderer OCR readout of the rendered CharacterEditor (`bun run --cwd packages/app audit:app`, desktop-landscape `builtin-character`, Tesseract 5) — verdict `verified` / "pixels match declared expectation", run summary broken=0, regressions=0. [OCR readout](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15987-character-editor-ocr-readout.md). Rendered capture the OCR ran over: ![character-editor-ocr](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15987-character-editor-desktop.jpg)

## Follow-up (coverage + evidence)

- Added `packages/ui/src/components/character/CharacterEditor.test.tsx`: real jsdom behavior coverage of the reworked config-write boundary (failed voice-config read → retryable unavailable banner; roster selection switches the local voice without a config PUT; explicit Save persists voice+character; Save failure surfaces via the editor error state; late-read generation guard on unmount). Drives the real `CharacterEditor`; only true boundaries (store, api client, voice/agent-surface hooks, sibling panels) are stubbed.
- Coverage on the changed source file `CharacterEditor.tsx`: **76.51%** line coverage (changed-files gate floor is 50%).
- `packages/ui/vitest.config.ts` gains a `globalSetup` that regenerates the gitignored `@elizaos/core` i18n keyword artifact when absent, so the pre-build coverage lane can load ui test modules that reach core through the `@elizaos/shared` barrel.
