### PR TITLE
feat(corpus): add owner-reviewed sensitive deletion

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -899,6 +899,7 @@
       },
       "dependencies": {
         "@elizaos/core": "workspace:*",
+        "yaml": "^2.9.0",
         "zod": "^4.4.3",
       },
       "devDependencies": {

--- a/packages/corpus-tools/package.json
+++ b/packages/corpus-tools/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@elizaos/core": "workspace:*",
+    "yaml": "^2.9.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/corpus-tools/package.json
+++ b/packages/corpus-tools/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "validate": "bun src/cli.ts validate",
     "corpus:scrub": "bun src/cli.ts scrub",
+    "corpus:delete": "bun src/cli.ts delete",
     "corpus:verify": "bun src/cli.ts verify",
     "test": "node ../scripts/run-vitest.mjs run --config ./vitest.config.ts",
     "typecheck": "tsgo --noEmit -p tsconfig.json",

--- a/packages/corpus-tools/src/cli.ts
+++ b/packages/corpus-tools/src/cli.ts
@@ -1,9 +1,13 @@
 #!/usr/bin/env bun
 /**
- * Command-line boundary for corpus validation. The library returns structured
- * diagnostics; this file is the only place that prints and converts validation
- * failure into a process exit code.
+ * Command-line boundary for corpus validation, scrubbing, reviewed deletion,
+ * and verification. Library operations return structured results; this file
+ * owns printing and process exit codes.
  */
+import {
+  applyDeletionFiles,
+  planDeletionFiles,
+} from "./pipeline/delete-command.ts";
 import {
   runScrubPipeline,
   type ScrubMode,
@@ -114,8 +118,39 @@ async function main(argv: string[]): Promise<number> {
     return result.status === "passed" ? 0 : 1;
   }
 
+  if (command === "delete") {
+    if (maybeTarget === "plan") {
+      const result = await planDeletionFiles({
+        targetPath: requireFlagValue(rest, "--target"),
+        candidatesPath: requireFlagValue(rest, "--candidates"),
+        rulesPath: requireFlagValue(rest, "--rules"),
+        queuePath: requireFlagValue(rest, "--queue"),
+        normalizedRulesPath: requireFlagValue(rest, "--normalized-rules"),
+      });
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
+    if (maybeTarget === "apply") {
+      const result = await applyDeletionFiles({
+        targetPath: requireFlagValue(rest, "--target"),
+        candidatesPath: requireFlagValue(rest, "--candidates"),
+        normalizedRulesPath: requireFlagValue(rest, "--normalized-rules"),
+        queuePath: requireFlagValue(rest, "--queue"),
+        decisionsPath: requireFlagValue(rest, "--decisions"),
+        outputPath: requireFlagValue(rest, "--output"),
+        ledgerPath: requireFlagValue(rest, "--ledger"),
+        manifestPath: requireFlagValue(rest, "--manifest"),
+        approvalPath: requireFlagValue(rest, "--approval"),
+        reportPath: requireFlagValue(rest, "--report"),
+      });
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
+    throw new Error("corpus delete requires plan or apply");
+  }
+
   process.stderr.write(
-    "usage: corpus validate <file-or-dir>\n       corpus scrub --target <file-or-dir> --stage <stage|all> --mode <deep|fast-track> [--resume] [--dry-run]\n       corpus verify --target <dir> --manifest <file> --candidates <file> --canaries <file> --ledger <file> --gazetteer <file> --deletion-rules <file> --deletion-review-queue <file> --deletion-review-decision <file> --deletion-approval <file> --placeholder-registry <file> --ruleset-version <version> --report <file>\n",
+    "usage: corpus validate <file-or-dir>\n       corpus scrub --target <file-or-dir> --stage <stage|all> --mode <deep|fast-track> [--resume] [--dry-run]\n       corpus delete plan --target <dir> --rules <file> --candidates <file> --queue <file> --normalized-rules <file>\n       corpus delete apply --target <dir> --candidates <file> --normalized-rules <file> --queue <file> --decisions <file> --output <dir> --ledger <file> --manifest <file> --approval <file> --report <file>\n       corpus verify --target <dir> --manifest <file> --candidates <file> --canaries <file> --ledger <file> --gazetteer <file> --deletion-rules <file> --deletion-review-queue <file> --deletion-review-decision <file> --deletion-approval <file> --placeholder-registry <file> --ruleset-version <version> --report <file>\n",
   );
   return 2;
 }

--- a/packages/corpus-tools/src/index.ts
+++ b/packages/corpus-tools/src/index.ts
@@ -3,6 +3,9 @@
  * loader adapters.
  */
 export * from "./mappers.ts";
+export * from "./pipeline/delete.ts";
+export * from "./pipeline/delete-command.ts";
+export * from "./pipeline/delete-files.ts";
 export * from "./pipeline/driver.ts";
 export * from "./pipeline/llm-pii.ts";
 export * from "./pipeline/rewrite.ts";

--- a/packages/corpus-tools/src/pipeline/delete-command.test.ts
+++ b/packages/corpus-tools/src/pipeline/delete-command.test.ts
@@ -4,6 +4,7 @@
  * approval artifacts used by the CLI without replacing any boundary with mocks.
  */
 
+import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
 import { promises as fs } from "node:fs";
 import os from "node:os";
@@ -12,7 +13,10 @@ import { afterEach, describe, expect, it } from "vitest";
 import type { CorpusMessage } from "../schema.ts";
 import { readCorpusShard } from "../validator.ts";
 import { canonicalDeletionArtifactSha256 } from "./delete.ts";
-import { applyDeletionFiles, planDeletionFiles } from "./delete-command.ts";
+import {
+  applyDeletionFiles,
+  type planDeletionFiles,
+} from "./delete-command.ts";
 
 const temporaryDirectories: string[] = [];
 const REVIEWED_AT = "2026-07-10T05:00:00.000Z";
@@ -66,6 +70,23 @@ function message(
 async function writeJson(filePath: string, value: unknown): Promise<void> {
   await fs.mkdir(path.dirname(filePath), { recursive: true });
   await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function runCorpusCli(args: readonly string[]): Promise<string> {
+  return await new Promise((resolve, reject) => {
+    execFile(
+      "bun",
+      [path.resolve(import.meta.dirname, "../cli.ts"), ...args],
+      { maxBuffer: 1024 * 1024 },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(new Error(`corpus CLI failed: ${stderr}`, { cause: error }));
+          return;
+        }
+        resolve(stdout);
+      },
+    );
+  });
 }
 
 afterEach(async () => {
@@ -138,13 +159,23 @@ rules:
       `${upstreamRecords.map((record) => JSON.stringify(record)).join("\n")}\n`,
     );
 
-    const queue = await planDeletionFiles({
-      targetPath: corpusPath,
+    const planOutput = await runCorpusCli([
+      "delete",
+      "plan",
+      "--target",
+      corpusPath,
+      "--candidates",
       candidatesPath,
+      "--rules",
       rulesPath,
+      "--queue",
       queuePath,
+      "--normalized-rules",
       normalizedRulesPath,
-    });
+    ]);
+    const queue = JSON.parse(planOutput) as Awaited<
+      ReturnType<typeof planDeletionFiles>
+    >;
 
     expect(queue.groups).toHaveLength(1);
     expect(queue.groups[0]?.messageIds).toEqual(["delete-me"]);
@@ -221,8 +252,36 @@ rules:
     });
     await fs.rm(`${ledgerPath}.lock`);
 
-    const first = await applyDeletionFiles(applyOptions);
-    const second = await applyDeletionFiles(applyOptions);
+    const applyArgs = [
+      "delete",
+      "apply",
+      "--target",
+      corpusPath,
+      "--candidates",
+      candidatesPath,
+      "--normalized-rules",
+      normalizedRulesPath,
+      "--queue",
+      queuePath,
+      "--decisions",
+      decisionsPath,
+      "--output",
+      applyOptions.outputPath,
+      "--ledger",
+      ledgerPath,
+      "--manifest",
+      applyOptions.manifestPath,
+      "--approval",
+      applyOptions.approvalPath,
+      "--report",
+      applyOptions.reportPath,
+    ];
+    const first = JSON.parse(await runCorpusCli(applyArgs)) as Awaited<
+      ReturnType<typeof applyDeletionFiles>
+    >;
+    const second = JSON.parse(await runCorpusCli(applyArgs)) as Awaited<
+      ReturnType<typeof applyDeletionFiles>
+    >;
 
     expect(first.ledgerRecordsWritten).toBe(2);
     expect(second.ledgerRecordsWritten).toBe(0);
@@ -230,7 +289,7 @@ rules:
     expect(first.approval).toMatchObject({
       survivorCount: 1,
       tombstoneCount: 1,
-      attachmentBytesDropped: 1,
+      attachmentBytesDropped: 9,
     });
     const outputShard = await readCorpusShard(
       path.join(applyOptions.outputPath, "gmail", "work", "2026-06.jsonl"),

--- a/packages/corpus-tools/src/pipeline/delete-command.test.ts
+++ b/packages/corpus-tools/src/pipeline/delete-command.test.ts
@@ -1,0 +1,292 @@
+/**
+ * End-to-end filesystem coverage for reviewed deletion planning and apply.
+ * Synthetic shards exercise the same queue, ledger, corpus, manifest, and
+ * approval artifacts used by the CLI without replacing any boundary with mocks.
+ */
+
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { CorpusMessage } from "../schema.ts";
+import { readCorpusShard } from "../validator.ts";
+import { canonicalDeletionArtifactSha256 } from "./delete.ts";
+import { applyDeletionFiles, planDeletionFiles } from "./delete-command.ts";
+
+const temporaryDirectories: string[] = [];
+const REVIEWED_AT = "2026-07-10T05:00:00.000Z";
+const RULESET = "delete-test-v1";
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function ledgerRecord(
+  input: CorpusMessage,
+  output: CorpusMessage,
+  stage: "mine" | "secrets",
+): Record<string, unknown> {
+  const inputHash = sha256(JSON.stringify(input));
+  return {
+    markerKey: `pii:${inputHash}:v${RULESET}:${stage}:test-v1`,
+    messageId: input.id,
+    stage,
+    stageVersion: "test-v1",
+    rulesetVersion: RULESET,
+    inputHash,
+    outputHash: sha256(JSON.stringify(output)),
+    tombstone: false,
+    output,
+  };
+}
+
+function message(
+  id: string,
+  overrides: Partial<CorpusMessage> = {},
+): CorpusMessage {
+  return {
+    id,
+    platform: "gmail",
+    accountId: "work",
+    threadId: `thread-${id}`,
+    ts: Date.parse("2026-06-01T12:00:00.000Z"),
+    direction: "in",
+    senderId: `sender-${id}`,
+    senderDisplay: `Sender ${id}`,
+    recipients: [{ id: "owner" }],
+    text: `Synthetic content for ${id}.`,
+    labels: [],
+    attachments: [],
+    scrubState: "swapped",
+    ...overrides,
+  };
+}
+
+async function writeJson(filePath: string, value: unknown): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => fs.rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe("reviewed deletion file orchestration", () => {
+  it("plans, applies, and resumes an exact owner-reviewed deletion", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "corpus-delete-"));
+    temporaryDirectories.push(root);
+    const corpusPath = path.join(root, "corpus");
+    const shardPath = path.join(corpusPath, "gmail", "work", "2026-06.jsonl");
+    const artifactsPath = path.join(root, "artifacts");
+    const sourceMessages = [
+      message("delete-me", { labels: ["Delete"] }),
+      message("keep-me", {
+        attachments: [
+          {
+            filename: "synthetic.txt",
+            mimeType: "text/plain",
+            sha256: "a".repeat(64),
+            bytes: 9,
+            dataBase64: "c3ludGhldGlj",
+          },
+        ],
+      }),
+    ];
+    await fs.mkdir(path.dirname(shardPath), { recursive: true });
+    await fs.writeFile(
+      shardPath,
+      `${sourceMessages.map((row) => JSON.stringify(row)).join("\n")}\n`,
+    );
+    const candidatesPath = path.join(artifactsPath, "candidates.jsonl");
+    await fs.mkdir(artifactsPath, { recursive: true });
+    await fs.writeFile(candidatesPath, "");
+    const rulesPath = path.join(artifactsPath, "rules.yaml");
+    await fs.writeFile(
+      rulesPath,
+      `schemaVersion: 1
+rulesetVersion: delete-test-v1
+attachmentPolicy:
+  embeddedBytes: drop
+  retainMetadata: [filename, mimeType, sha256]
+rules:
+  - id: delete-label
+    enabled: true
+    scope: message
+    match:
+      type: label
+      value: Delete
+`,
+    );
+    const queuePath = path.join(artifactsPath, "queue.json");
+    const normalizedRulesPath = path.join(artifactsPath, "rules.json");
+    const ledgerPath = path.join(artifactsPath, "ledger.jsonl");
+    const upstreamRecords = sourceMessages.flatMap((swapped) => {
+      const raw = { ...swapped, scrubState: "raw" } as CorpusMessage;
+      const mined = { ...swapped, scrubState: "mined" } as CorpusMessage;
+      return [
+        ledgerRecord(raw, mined, "mine"),
+        ledgerRecord(mined, swapped, "secrets"),
+      ];
+    });
+    await fs.writeFile(
+      ledgerPath,
+      `${upstreamRecords.map((record) => JSON.stringify(record)).join("\n")}\n`,
+    );
+
+    const queue = await planDeletionFiles({
+      targetPath: corpusPath,
+      candidatesPath,
+      rulesPath,
+      queuePath,
+      normalizedRulesPath,
+    });
+
+    expect(queue.groups).toHaveLength(1);
+    expect(queue.groups[0]?.messageIds).toEqual(["delete-me"]);
+    expect(
+      [...(queue.groups[0]?.redactedContext ?? "")].length,
+    ).toBeLessThanOrEqual(60);
+
+    const decisionsPath = path.join(artifactsPath, "decisions.json");
+    await writeJson(decisionsPath, {
+      schemaVersion: 1,
+      rulesetVersion: queue.rulesetVersion,
+      corpusDigest: queue.corpusDigest,
+      rulesSha256: queue.rulesSha256,
+      reviewedQueueSha256: canonicalDeletionArtifactSha256(queue),
+      approved: true,
+      reviewedBy: "synthetic-owner",
+      reviewedAt: REVIEWED_AT,
+      decisions: queue.groups.map((group) => ({
+        groupId: group.groupId,
+        decision: "delete",
+      })),
+    });
+    const applyOptions = {
+      targetPath: corpusPath,
+      candidatesPath,
+      normalizedRulesPath,
+      queuePath,
+      decisionsPath,
+      outputPath: path.join(root, "survivors"),
+      ledgerPath,
+      manifestPath: path.join(artifactsPath, "manifest.json"),
+      approvalPath: path.join(artifactsPath, "approval.json"),
+      reportPath: path.join(artifactsPath, "report.json"),
+    };
+
+    const originalQueue = JSON.parse(
+      await fs.readFile(queuePath, "utf8"),
+    ) as Record<string, unknown>;
+    const tamperedGroups = structuredClone(
+      originalQueue.groups as Record<string, unknown>[],
+    );
+    tamperedGroups[0].redactedContext = "misleading review context";
+    await writeJson(queuePath, { ...originalQueue, groups: tamperedGroups });
+    await expect(applyDeletionFiles(applyOptions)).rejects.toThrow(
+      "deletion review queue is not canonical for its inputs",
+    );
+    await writeJson(queuePath, originalQueue);
+
+    const originalLedger = await fs.readFile(ledgerPath, "utf8");
+    const mismatchedRecords = structuredClone(upstreamRecords);
+    const secretsRecord = mismatchedRecords.find(
+      (record) => record.stage === "secrets",
+    );
+    if (!secretsRecord?.output) {
+      throw new Error("fixture is missing a secrets record");
+    }
+    secretsRecord.output = {
+      ...(secretsRecord.output as CorpusMessage),
+      text: "Different swapped corpus.",
+    };
+    secretsRecord.outputHash = sha256(JSON.stringify(secretsRecord.output));
+    await fs.writeFile(
+      ledgerPath,
+      `${mismatchedRecords.map((record) => JSON.stringify(record)).join("\n")}\n`,
+    );
+    await expect(applyDeletionFiles(applyOptions)).rejects.toThrow(
+      "deletion target is not the secrets output",
+    );
+    await fs.writeFile(ledgerPath, originalLedger);
+
+    await fs.writeFile(`${ledgerPath}.lock`, "held", { mode: 0o600 });
+    await expect(applyDeletionFiles(applyOptions)).rejects.toMatchObject({
+      code: "EEXIST",
+    });
+    await fs.rm(`${ledgerPath}.lock`);
+
+    const first = await applyDeletionFiles(applyOptions);
+    const second = await applyDeletionFiles(applyOptions);
+
+    expect(first.ledgerRecordsWritten).toBe(2);
+    expect(second.ledgerRecordsWritten).toBe(0);
+    expect(first.approval).toEqual(second.approval);
+    expect(first.approval).toMatchObject({
+      survivorCount: 1,
+      tombstoneCount: 1,
+      attachmentBytesDropped: 1,
+    });
+    const outputShard = await readCorpusShard(
+      path.join(applyOptions.outputPath, "gmail", "work", "2026-06.jsonl"),
+      { rootDir: applyOptions.outputPath },
+    );
+    expect(outputShard.issues).toEqual([]);
+    expect(outputShard.messages).toHaveLength(1);
+    expect(outputShard.messages[0]?.id).toBe("keep-me");
+    expect(outputShard.messages[0]?.attachments[0]).toEqual({
+      filename: "synthetic.txt",
+      mimeType: "text/plain",
+      sha256: "a".repeat(64),
+    });
+    const ledger = (await fs.readFile(applyOptions.ledgerPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(ledger).toHaveLength(6);
+    const deletionRecords = ledger.filter(
+      (record) => record.stage === "delete",
+    );
+    expect(deletionRecords).toHaveLength(2);
+    for (const record of deletionRecords) {
+      expect(record).toMatchObject({
+        stageVersion: first.approval.deleteStageVersion,
+        rulesSha256: first.approval.rulesSha256,
+        reviewedQueueSha256: first.approval.reviewedQueueSha256,
+        reviewDecisionSha256: first.approval.reviewDecisionSha256,
+      });
+    }
+    const tombstone = deletionRecords.find(
+      (record) => record.tombstone === true,
+    );
+    expect(tombstone).toBeDefined();
+    expect(tombstone).not.toHaveProperty("output");
+    expect(JSON.stringify(tombstone)).not.toContain("Synthetic content");
+    expect(
+      JSON.parse(await fs.readFile(applyOptions.approvalPath, "utf8")),
+    ).toEqual(first.approval);
+    expect(
+      JSON.parse(await fs.readFile(applyOptions.reportPath, "utf8")),
+    ).toEqual(first.report);
+    await expect(
+      applyDeletionFiles({
+        ...applyOptions,
+        outputPath: path.join(corpusPath, "nested-output"),
+      }),
+    ).rejects.toThrow("deletion input and output paths must not overlap");
+    const ledgerMode = (await fs.stat(ledgerPath)).mode & 0o777;
+    const queueMode = (await fs.stat(queuePath)).mode & 0o777;
+    expect(ledgerMode).toBe(0o600);
+    expect(queueMode).toBe(0o600);
+
+    await fs.appendFile(ledgerPath, `${JSON.stringify(deletionRecords[0])}\n`);
+    await expect(applyDeletionFiles(applyOptions)).rejects.toThrow(
+      "deletion ledger contains duplicate marker history",
+    );
+  });
+});

--- a/packages/corpus-tools/src/pipeline/delete-command.test.ts
+++ b/packages/corpus-tools/src/pipeline/delete-command.test.ts
@@ -6,7 +6,7 @@
 
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
-import { promises as fs } from "node:fs";
+import { existsSync, promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -103,9 +103,18 @@ describe("reviewed deletion file orchestration", () => {
     temporaryDirectories.push(root);
     const corpusPath = path.join(root, "corpus");
     const shardPath = path.join(corpusPath, "gmail", "work", "2026-06.jsonl");
+    const deletedShardPath = path.join(
+      corpusPath,
+      "gmail",
+      "work",
+      "2026-07.jsonl",
+    );
     const artifactsPath = path.join(root, "artifacts");
     const sourceMessages = [
-      message("delete-me", { labels: ["Delete"] }),
+      message("delete-me", {
+        labels: ["Delete"],
+        ts: Date.parse("2026-07-01T12:00:00.000Z"),
+      }),
       message("keep-me", {
         attachments: [
           {
@@ -119,9 +128,10 @@ describe("reviewed deletion file orchestration", () => {
       }),
     ];
     await fs.mkdir(path.dirname(shardPath), { recursive: true });
+    await fs.writeFile(shardPath, `${JSON.stringify(sourceMessages[1])}\n`);
     await fs.writeFile(
-      shardPath,
-      `${sourceMessages.map((row) => JSON.stringify(row)).join("\n")}\n`,
+      deletedShardPath,
+      `${JSON.stringify(sourceMessages[0])}\n`,
     );
     const candidatesPath = path.join(artifactsPath, "candidates.jsonl");
     await fs.mkdir(artifactsPath, { recursive: true });
@@ -291,10 +301,15 @@ rules:
       tombstoneCount: 1,
       attachmentBytesDropped: 9,
     });
-    const outputShard = await readCorpusShard(
-      path.join(applyOptions.outputPath, "gmail", "work", "2026-06.jsonl"),
-      { rootDir: applyOptions.outputPath },
+    const outputShardPath = path.join(
+      applyOptions.outputPath,
+      "gmail",
+      "work",
+      "2026-06.jsonl",
     );
+    const outputShard = await readCorpusShard(outputShardPath, {
+      rootDir: applyOptions.outputPath,
+    });
     expect(outputShard.issues).toEqual([]);
     expect(outputShard.messages).toHaveLength(1);
     expect(outputShard.messages[0]?.id).toBe("keep-me");
@@ -303,6 +318,17 @@ rules:
       mimeType: "text/plain",
       sha256: "a".repeat(64),
     });
+    expect(
+      existsSync(
+        path.join(applyOptions.outputPath, "gmail", "work", "2026-07.jsonl"),
+      ),
+    ).toBe(false);
+    const manifest = JSON.parse(
+      await fs.readFile(applyOptions.manifestPath, "utf8"),
+    ) as { shards: Array<{ path: string }> };
+    expect(manifest.shards.map((shard) => shard.path)).toEqual([
+      "gmail/work/2026-06.jsonl",
+    ]);
     const ledger = (await fs.readFile(applyOptions.ledgerPath, "utf8"))
       .trim()
       .split("\n")
@@ -337,15 +363,50 @@ rules:
         ...applyOptions,
         outputPath: path.join(corpusPath, "nested-output"),
       }),
-    ).rejects.toThrow("deletion input and output paths must not overlap");
+    ).rejects.toThrow("deletion paths target and output must not overlap");
     const ledgerMode = (await fs.stat(ledgerPath)).mode & 0o777;
     const queueMode = (await fs.stat(queuePath)).mode & 0o777;
     expect(ledgerMode).toBe(0o600);
     expect(queueMode).toBe(0o600);
+    for (const artifactPath of [
+      applyOptions.manifestPath,
+      applyOptions.approvalPath,
+      applyOptions.reportPath,
+    ]) {
+      expect((await fs.stat(artifactPath)).mode & 0o777).toBe(0o600);
+    }
+
+    const ledgerBeforeAliasAttempt = await fs.readFile(ledgerPath, "utf8");
+    const ledgerAliasPath = path.join(artifactsPath, "ledger-alias.json");
+    await fs.symlink(ledgerPath, ledgerAliasPath);
+    await expect(
+      applyDeletionFiles({ ...applyOptions, approvalPath: ledgerAliasPath }),
+    ).rejects.toThrow("alias each other");
+    expect(await fs.readFile(ledgerPath, "utf8")).toBe(
+      ledgerBeforeAliasAttempt,
+    );
+    await fs.rm(ledgerAliasPath);
+    const ledgerHardLinkPath = path.join(artifactsPath, "ledger-hardlink.json");
+    await fs.link(ledgerPath, ledgerHardLinkPath);
+    await expect(
+      applyDeletionFiles({ ...applyOptions, reportPath: ledgerHardLinkPath }),
+    ).rejects.toThrow("share a file inode");
+    expect(await fs.readFile(ledgerPath, "utf8")).toBe(
+      ledgerBeforeAliasAttempt,
+    );
+
+    const survivorBytes = await fs.readFile(outputShardPath);
+    await fs.rm(outputShardPath);
+    await fs.link(shardPath, outputShardPath);
+    await expect(applyDeletionFiles(applyOptions)).rejects.toThrow(
+      "deletion output shares an inode with a source shard",
+    );
+    await fs.rm(outputShardPath);
+    await fs.writeFile(outputShardPath, survivorBytes, { mode: 0o600 });
 
     await fs.appendFile(ledgerPath, `${JSON.stringify(deletionRecords[0])}\n`);
     await expect(applyDeletionFiles(applyOptions)).rejects.toThrow(
       "deletion ledger contains duplicate marker history",
     );
-  });
+  }, 20_000);
 });

--- a/packages/corpus-tools/src/pipeline/delete-command.ts
+++ b/packages/corpus-tools/src/pipeline/delete-command.ts
@@ -1,0 +1,483 @@
+/**
+ * Filesystem orchestration for the reviewed deletion stage. Planning emits
+ * local-only review artifacts; apply validates every binding before writing a
+ * mirrored survivor corpus, resumable ledger records, manifest, approval, and
+ * sanitized report. The library core stays pure while this boundary owns I/O.
+ */
+import { createHash } from "node:crypto";
+import { existsSync, promises as fs } from "node:fs";
+import path from "node:path";
+import { z } from "zod";
+import type { CorpusMessage } from "../schema.ts";
+import {
+  buildCorpusManifest,
+  findCorpusShardFiles,
+  readCorpusShard,
+} from "../validator.ts";
+import {
+  applyDeletionReview,
+  buildDeletionReviewQueue,
+  canonicalDeletionArtifactSha256,
+  type DeletionApproval,
+  type DeletionReport,
+  type DeletionReviewQueue,
+  parseDeletionReviewQueue,
+} from "./delete.ts";
+import {
+  parseDeletionReviewDecisionsDocument,
+  parseDeletionRulesDocument,
+} from "./delete-files.ts";
+
+const deletionCandidateSchema = z
+  .object({
+    msgId: z.string().min(1),
+    kind: z.string().min(1),
+  })
+  .passthrough();
+
+interface LoadedCorpus {
+  targetPath: string;
+  rootDir: string;
+  shardPaths: string[];
+  messages: CorpusMessage[];
+}
+
+export interface PlanDeletionFilesOptions {
+  targetPath: string;
+  candidatesPath: string;
+  rulesPath: string;
+  queuePath: string;
+  normalizedRulesPath: string;
+}
+
+export interface ApplyDeletionFilesOptions {
+  targetPath: string;
+  candidatesPath: string;
+  normalizedRulesPath: string;
+  queuePath: string;
+  decisionsPath: string;
+  outputPath: string;
+  ledgerPath: string;
+  manifestPath: string;
+  approvalPath: string;
+  reportPath: string;
+}
+
+export interface AppliedDeletionFiles {
+  approval: DeletionApproval;
+  report: DeletionReport;
+  ledgerRecordsWritten: number;
+  outputPath: string;
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+async function readJsonLines<T>(
+  filePath: string,
+  schema: z.ZodType<T>,
+): Promise<T[]> {
+  const rows: T[] = [];
+  const source = await fs.readFile(filePath, "utf8");
+  for (const [index, line] of source.split(/\r?\n/).entries()) {
+    if (!line.trim()) continue;
+    let value: unknown;
+    try {
+      value = JSON.parse(line);
+    } catch (error) {
+      throw new Error(`invalid JSON at ${filePath}:${index + 1}`, {
+        cause: error,
+      });
+    }
+    const parsed = schema.safeParse(value);
+    if (!parsed.success) {
+      throw new Error(
+        `invalid ${filePath}:${index + 1}: ${z.prettifyError(parsed.error)}`,
+      );
+    }
+    rows.push(parsed.data);
+  }
+  return rows;
+}
+
+async function loadCorpus(targetPath: string): Promise<LoadedCorpus> {
+  const rootDir = path.extname(targetPath)
+    ? path.dirname(targetPath)
+    : targetPath;
+  const shardPaths = (await findCorpusShardFiles(targetPath)).filter(
+    (filePath) => !filePath.split(path.sep).includes(".state"),
+  );
+  if (shardPaths.length === 0) throw new Error("deletion target has no shards");
+  const messages: CorpusMessage[] = [];
+  const ids = new Set<string>();
+  for (const shardPath of shardPaths) {
+    const shard = await readCorpusShard(shardPath, { rootDir });
+    if (shard.issues.length > 0) {
+      throw new Error(
+        `invalid deletion input ${shardPath}: ${shard.issues.map((issue) => issue.message).join("; ")}`,
+      );
+    }
+    for (const message of shard.messages) {
+      if (ids.has(message.id)) {
+        throw new Error(`duplicate deletion message id ${message.id}`);
+      }
+      ids.add(message.id);
+      messages.push(message);
+    }
+  }
+  return { targetPath, rootDir, shardPaths, messages };
+}
+
+async function writePrivateJson(
+  filePath: string,
+  value: unknown,
+): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, {
+    mode: 0o600,
+  });
+  await fs.chmod(filePath, 0o600);
+}
+
+export async function planDeletionFiles(
+  options: PlanDeletionFilesOptions,
+): Promise<DeletionReviewQueue> {
+  const corpus = await loadCorpus(options.targetPath);
+  const candidates = await readJsonLines(
+    options.candidatesPath,
+    deletionCandidateSchema,
+  );
+  const rules = parseDeletionRulesDocument(
+    await fs.readFile(options.rulesPath, "utf8"),
+    options.rulesPath,
+  );
+  const normalizedRules = {
+    ...rules,
+    rules: [...rules.rules].sort((left, right) =>
+      left.id.localeCompare(right.id),
+    ),
+  };
+  const queue = buildDeletionReviewQueue({
+    messages: corpus.messages,
+    candidates,
+    rules: normalizedRules,
+  });
+  await writePrivateJson(options.normalizedRulesPath, normalizedRules);
+  await writePrivateJson(options.queuePath, queue);
+  return queue;
+}
+
+function desiredLedgerRecords(
+  inputMessages: readonly CorpusMessage[],
+  survivors: readonly CorpusMessage[],
+  tombstones: readonly {
+    messageId: string;
+    stage: "delete";
+    stageVersion: string;
+    outputHash: string;
+    rulesSha256: string;
+    reviewedQueueSha256: string;
+    reviewDecisionSha256: string;
+    ruleIdHashes: readonly string[];
+    scope: "message" | "thread";
+  }[],
+  rulesetVersion: string,
+  approval: Pick<
+    DeletionApproval,
+    | "deleteStageVersion"
+    | "rulesSha256"
+    | "reviewedQueueSha256"
+    | "reviewDecisionSha256"
+  >,
+): Array<Record<string, unknown>> {
+  const stageVersion = approval.deleteStageVersion;
+  const survivorsById = new Map(
+    survivors.map((message) => [message.id, message]),
+  );
+  const tombstonesById = new Map(
+    tombstones.map((tombstone) => [tombstone.messageId, tombstone]),
+  );
+  return inputMessages.map((message) => {
+    const inputHash = sha256(JSON.stringify(message));
+    const tombstone = tombstonesById.get(message.id);
+    if (tombstone && tombstone.stageVersion !== stageVersion) {
+      throw new Error("deletion tombstone stage version mismatch");
+    }
+    const markerKey = `pii:${inputHash}:v${rulesetVersion}:delete:${stageVersion}`;
+    const common = {
+      markerKey,
+      messageId: message.id,
+      stage: "delete",
+      stageVersion,
+      rulesetVersion,
+      inputHash,
+      clusterKey: message.id,
+      isClusterExemplar: true,
+      cost: {
+        inputTokens: 0,
+        outputTokens: 0,
+        estimatedUsd: 0,
+        llmCalls: 0,
+      },
+    };
+    if (tombstone) {
+      return { ...common, ...tombstone, tombstone: true };
+    }
+    const output = survivorsById.get(message.id);
+    if (!output) throw new Error(`deletion lost message ${message.id}`);
+    return {
+      ...common,
+      rulesSha256: approval.rulesSha256,
+      reviewedQueueSha256: approval.reviewedQueueSha256,
+      reviewDecisionSha256: approval.reviewDecisionSha256,
+      outputHash: sha256(JSON.stringify(output)),
+      tombstone: false,
+      output,
+    };
+  });
+}
+
+async function appendLedgerRecords(
+  ledgerPath: string,
+  records: readonly Record<string, unknown>[],
+): Promise<number> {
+  const existing = existsSync(ledgerPath)
+    ? await readJsonLines(ledgerPath, z.record(z.string(), z.unknown()))
+    : [];
+  const byMarker = new Map(
+    existing.map((record) => [String(record.markerKey), record]),
+  );
+  if (byMarker.size !== existing.length) {
+    throw new Error("deletion ledger contains duplicate marker history");
+  }
+  const missing: Record<string, unknown>[] = [];
+  for (const record of records) {
+    const markerKey = String(record.markerKey);
+    const prior = byMarker.get(markerKey);
+    if (
+      prior &&
+      canonicalDeletionArtifactSha256(prior) !==
+        canonicalDeletionArtifactSha256(record)
+    ) {
+      throw new Error(`conflicting deletion ledger record ${markerKey}`);
+    }
+    if (!prior) missing.push(record);
+  }
+  if (missing.length === 0) return 0;
+  await fs.mkdir(path.dirname(ledgerPath), { recursive: true });
+  await fs.appendFile(
+    ledgerPath,
+    `${missing.map((record) => JSON.stringify(record)).join("\n")}\n`,
+    { mode: 0o600 },
+  );
+  await fs.chmod(ledgerPath, 0o600);
+  return missing.length;
+}
+
+async function validateDeletionInputsAgainstLedger(
+  ledgerPath: string,
+  messages: readonly CorpusMessage[],
+  rulesetVersion: string,
+): Promise<void> {
+  if (!existsSync(ledgerPath)) {
+    throw new Error("deletion requires an upstream scrub ledger");
+  }
+  const records = await readJsonLines(
+    ledgerPath,
+    z.record(z.string(), z.unknown()),
+  );
+  const currentSecrets = records.filter(
+    (record) =>
+      record.rulesetVersion === rulesetVersion &&
+      record.stage === "secrets" &&
+      record.tombstone === false,
+  );
+  const secretsById = new Map<string, Record<string, unknown>>();
+  for (const record of currentSecrets) {
+    const messageId = String(record.messageId);
+    if (secretsById.has(messageId)) {
+      throw new Error(`ambiguous secrets ledger history for ${messageId}`);
+    }
+    secretsById.set(messageId, record);
+  }
+  if (secretsById.size !== messages.length) {
+    throw new Error(
+      "deletion target does not match secrets ledger message set",
+    );
+  }
+  for (const message of messages) {
+    const record = secretsById.get(message.id);
+    if (
+      !record ||
+      record.output === undefined ||
+      record.outputHash !== sha256(JSON.stringify(message)) ||
+      canonicalDeletionArtifactSha256(record.output) !==
+        canonicalDeletionArtifactSha256(message)
+    ) {
+      throw new Error(
+        `deletion target is not the secrets output for ${message.id}`,
+      );
+    }
+  }
+}
+
+async function writeSurvivorCorpus(
+  corpus: LoadedCorpus,
+  survivors: readonly CorpusMessage[],
+  outputPath: string,
+): Promise<void> {
+  const sourcePath = path.resolve(corpus.targetPath);
+  const destinationPath = path.resolve(outputPath);
+  const contains = (parent: string, child: string): boolean => {
+    const relative = path.relative(parent, child);
+    return (
+      relative === "" ||
+      (!relative.startsWith("..") && !path.isAbsolute(relative))
+    );
+  };
+  if (
+    contains(sourcePath, destinationPath) ||
+    contains(destinationPath, sourcePath)
+  ) {
+    throw new Error("deletion input and output paths must not overlap");
+  }
+  const survivorsById = new Map(
+    survivors.map((message) => [message.id, message]),
+  );
+  const desired = new Map<string, string>();
+  for (const shardPath of corpus.shardPaths) {
+    const shard = await readCorpusShard(shardPath, { rootDir: corpus.rootDir });
+    const rows = shard.messages
+      .map((message) => survivorsById.get(message.id))
+      .filter((message): message is CorpusMessage => message !== undefined);
+    desired.set(
+      path.relative(corpus.rootDir, shardPath),
+      rows.length === 0
+        ? ""
+        : `${rows.map((message) => JSON.stringify(message)).join("\n")}\n`,
+    );
+  }
+  if (existsSync(outputPath)) {
+    const existingPaths = (await findCorpusShardFiles(outputPath)).filter(
+      (filePath) => !filePath.split(path.sep).includes(".state"),
+    );
+    const relativeExisting = existingPaths
+      .map((filePath) => path.relative(outputPath, filePath))
+      .sort();
+    if (
+      canonicalDeletionArtifactSha256(relativeExisting) !==
+      canonicalDeletionArtifactSha256([...desired.keys()].sort())
+    ) {
+      throw new Error("existing deletion output has a different shard set");
+    }
+    for (const [relative, bytes] of desired) {
+      if (
+        (await fs.readFile(path.join(outputPath, relative), "utf8")) !== bytes
+      ) {
+        throw new Error(`existing deletion output differs at ${relative}`);
+      }
+    }
+    return;
+  }
+  const temporaryPath = `${outputPath}.tmp-${process.pid}`;
+  try {
+    await fs.mkdir(temporaryPath, { recursive: true });
+    for (const [relative, bytes] of desired) {
+      const destination = path.join(temporaryPath, relative);
+      await fs.mkdir(path.dirname(destination), { recursive: true });
+      await fs.writeFile(destination, bytes, { mode: 0o600 });
+    }
+    await fs.mkdir(path.dirname(outputPath), { recursive: true });
+    await fs.rename(temporaryPath, outputPath);
+  } finally {
+    // error-policy:J6 an interrupted atomic output may leave only this temp tree.
+    await fs.rm(temporaryPath, { recursive: true, force: true });
+  }
+}
+
+async function applyDeletionFilesLocked(
+  options: ApplyDeletionFilesOptions,
+): Promise<AppliedDeletionFiles> {
+  const corpus = await loadCorpus(options.targetPath);
+  const queue = parseDeletionReviewQueue(
+    JSON.parse(await fs.readFile(options.queuePath, "utf8")),
+  );
+  const decisions = parseDeletionReviewDecisionsDocument(
+    await fs.readFile(options.decisionsPath, "utf8"),
+    options.decisionsPath,
+  );
+  const candidates = await readJsonLines(
+    options.candidatesPath,
+    deletionCandidateSchema,
+  );
+  const rules = parseDeletionRulesDocument(
+    await fs.readFile(options.normalizedRulesPath, "utf8"),
+    options.normalizedRulesPath,
+  );
+  const expectedQueue = buildDeletionReviewQueue({
+    messages: corpus.messages,
+    candidates,
+    rules,
+  });
+  if (
+    canonicalDeletionArtifactSha256(queue) !==
+    canonicalDeletionArtifactSha256(expectedQueue)
+  ) {
+    throw new Error("deletion review queue is not canonical for its inputs");
+  }
+  await validateDeletionInputsAgainstLedger(
+    options.ledgerPath,
+    corpus.messages,
+    queue.rulesetVersion,
+  );
+  const applied = applyDeletionReview({
+    messages: corpus.messages,
+    queue,
+    decisions,
+  });
+  const records = desiredLedgerRecords(
+    corpus.messages,
+    applied.survivors,
+    applied.tombstones,
+    applied.approval.rulesetVersion,
+    applied.approval,
+  );
+  await writeSurvivorCorpus(corpus, applied.survivors, options.outputPath);
+  const { manifest, issues } = await buildCorpusManifest(
+    options.outputPath,
+    decisions.reviewedAt,
+  );
+  if (issues.length > 0) {
+    throw new Error(
+      `deleted corpus manifest failed: ${issues.map((issue) => issue.message).join("; ")}`,
+    );
+  }
+  const ledgerRecordsWritten = await appendLedgerRecords(
+    options.ledgerPath,
+    records,
+  );
+  await writePrivateJson(options.manifestPath, manifest);
+  await writePrivateJson(options.approvalPath, applied.approval);
+  await writePrivateJson(options.reportPath, applied.report);
+  return {
+    approval: applied.approval,
+    report: applied.report,
+    ledgerRecordsWritten,
+    outputPath: options.outputPath,
+  };
+}
+
+export async function applyDeletionFiles(
+  options: ApplyDeletionFilesOptions,
+): Promise<AppliedDeletionFiles> {
+  await fs.mkdir(path.dirname(options.ledgerPath), { recursive: true });
+  const lockPath = `${options.ledgerPath}.lock`;
+  const lock = await fs.open(lockPath, "wx", 0o600);
+  try {
+    return await applyDeletionFilesLocked(options);
+  } finally {
+    await lock.close();
+    await fs.rm(lockPath);
+  }
+}

--- a/packages/corpus-tools/src/pipeline/delete-command.ts
+++ b/packages/corpus-tools/src/pipeline/delete-command.ts
@@ -4,7 +4,7 @@
  * mirrored survivor corpus, resumable ledger records, manifest, approval, and
  * sanitized report. The library core stays pure while this boundary owns I/O.
  */
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { existsSync, promises as fs } from "node:fs";
 import path from "node:path";
 import { z } from "zod";
@@ -12,7 +12,7 @@ import type { CorpusMessage } from "../schema.ts";
 import {
   buildCorpusManifest,
   findCorpusShardFiles,
-  readCorpusShard,
+  parseCorpusShard,
 } from "../validator.ts";
 import {
   applyDeletionReview,
@@ -38,7 +38,13 @@ const deletionCandidateSchema = z
 interface LoadedCorpus {
   targetPath: string;
   rootDir: string;
-  shardPaths: string[];
+  shards: Array<{
+    path: string;
+    bytes: Buffer;
+    dev: number;
+    ino: number;
+    messages: CorpusMessage[];
+  }>;
   messages: CorpusMessage[];
 }
 
@@ -74,12 +80,28 @@ function sha256(value: string): string {
   return createHash("sha256").update(value).digest("hex");
 }
 
-async function readJsonLines<T>(
+async function readHandleBytes(
+  handle: Awaited<ReturnType<typeof fs.open>>,
+  size: number,
+): Promise<Buffer> {
+  const bytes = Buffer.alloc(size);
+  let offset = 0;
+  while (offset < size) {
+    const result = await handle.read(bytes, offset, size - offset, offset);
+    if (result.bytesRead === 0) {
+      throw new Error("file ended while reading a captured snapshot");
+    }
+    offset += result.bytesRead;
+  }
+  return bytes;
+}
+
+function parseJsonLines<T>(
+  source: string,
   filePath: string,
   schema: z.ZodType<T>,
-): Promise<T[]> {
+): T[] {
   const rows: T[] = [];
-  const source = await fs.readFile(filePath, "utf8");
   for (const [index, line] of source.split(/\r?\n/).entries()) {
     if (!line.trim()) continue;
     let value: unknown;
@@ -101,6 +123,13 @@ async function readJsonLines<T>(
   return rows;
 }
 
+async function readJsonLines<T>(
+  filePath: string,
+  schema: z.ZodType<T>,
+): Promise<T[]> {
+  return parseJsonLines(await fs.readFile(filePath, "utf8"), filePath, schema);
+}
+
 async function loadCorpus(targetPath: string): Promise<LoadedCorpus> {
   const rootDir = path.extname(targetPath)
     ? path.dirname(targetPath)
@@ -110,9 +139,32 @@ async function loadCorpus(targetPath: string): Promise<LoadedCorpus> {
   );
   if (shardPaths.length === 0) throw new Error("deletion target has no shards");
   const messages: CorpusMessage[] = [];
+  const shards: LoadedCorpus["shards"] = [];
   const ids = new Set<string>();
   for (const shardPath of shardPaths) {
-    const shard = await readCorpusShard(shardPath, { rootDir });
+    const handle = await fs.open(shardPath, "r");
+    let bytes: Buffer;
+    let before: Awaited<ReturnType<typeof handle.stat>>;
+    let after: Awaited<ReturnType<typeof handle.stat>>;
+    try {
+      before = await handle.stat();
+      bytes = await readHandleBytes(handle, before.size);
+      after = await handle.stat();
+    } finally {
+      await handle.close();
+    }
+    if (
+      before.dev !== after.dev ||
+      before.ino !== after.ino ||
+      before.size !== after.size ||
+      before.mtimeMs !== after.mtimeMs ||
+      bytes.length !== after.size
+    ) {
+      throw new Error(`deletion input changed while loading ${shardPath}`);
+    }
+    const shard = parseCorpusShard(bytes.toString("utf8"), shardPath, {
+      rootDir,
+    });
     if (shard.issues.length > 0) {
       throw new Error(
         `invalid deletion input ${shardPath}: ${shard.issues.map((issue) => issue.message).join("; ")}`,
@@ -125,24 +177,140 @@ async function loadCorpus(targetPath: string): Promise<LoadedCorpus> {
       ids.add(message.id);
       messages.push(message);
     }
+    shards.push({
+      path: shardPath,
+      bytes,
+      dev: after.dev,
+      ino: after.ino,
+      messages: shard.messages,
+    });
   }
-  return { targetPath, rootDir, shardPaths, messages };
+  return { targetPath, rootDir, shards, messages };
 }
 
 async function writePrivateJson(
   filePath: string,
   value: unknown,
-): Promise<void> {
+): Promise<{ expectedBytes: Buffer; dev: number; ino: number }> {
   await fs.mkdir(path.dirname(filePath), { recursive: true });
-  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, {
-    mode: 0o600,
-  });
-  await fs.chmod(filePath, 0o600);
+  const temporaryPath = `${filePath}.tmp-${process.pid}-${randomUUID()}`;
+  const expectedBytes = Buffer.from(`${JSON.stringify(value, null, 2)}\n`);
+  const handle = await fs.open(temporaryPath, "wx", 0o600);
+  try {
+    await handle.writeFile(expectedBytes);
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+  try {
+    await fs.rename(temporaryPath, filePath);
+  } finally {
+    // error-policy:J6 an interrupted atomic artifact write may leave this file.
+    await fs.rm(temporaryPath, { force: true });
+  }
+  const stat = await fs.stat(filePath);
+  if (!(await fs.readFile(filePath)).equals(expectedBytes)) {
+    throw new Error(`deletion artifact changed during write at ${filePath}`);
+  }
+  return { expectedBytes, dev: stat.dev, ino: stat.ino };
+}
+
+async function assertArtifactUnchanged(
+  filePath: string,
+  expected: { expectedBytes: Buffer; dev: number; ino: number },
+): Promise<void> {
+  const stat = await fs.stat(filePath);
+  if (
+    stat.dev !== expected.dev ||
+    stat.ino !== expected.ino ||
+    !(await fs.readFile(filePath)).equals(expected.expectedBytes)
+  ) {
+    throw new Error(`deletion artifact changed after write at ${filePath}`);
+  }
+}
+
+async function canonicalFuturePath(filePath: string): Promise<string> {
+  let cursor = path.resolve(filePath);
+  const suffix: string[] = [];
+  while (!existsSync(cursor)) {
+    const parent = path.dirname(cursor);
+    if (parent === cursor) {
+      throw new Error(`cannot resolve path boundary for ${filePath}`);
+    }
+    suffix.unshift(path.basename(cursor));
+    cursor = parent;
+  }
+  return path.join(await fs.realpath(cursor), ...suffix);
+}
+
+function pathContains(parent: string, child: string): boolean {
+  const relative = path.relative(parent, child);
+  return (
+    relative === "" ||
+    (!relative.startsWith("..") && !path.isAbsolute(relative))
+  );
+}
+
+async function canonicalPaths(
+  entries: Readonly<Record<string, string>>,
+): Promise<Map<string, string>> {
+  const resolved = new Map<string, string>();
+  const owners = new Map<string, string>();
+  const inodeOwners = new Map<string, string>();
+  for (const [name, filePath] of Object.entries(entries)) {
+    const canonical = await canonicalFuturePath(filePath);
+    const owner = owners.get(canonical);
+    if (owner) {
+      throw new Error(`deletion paths ${owner} and ${name} alias each other`);
+    }
+    owners.set(canonical, name);
+    if (existsSync(canonical)) {
+      const stat = await fs.stat(canonical);
+      if (stat.isFile()) {
+        const inodeKey = `${stat.dev}:${stat.ino}`;
+        const inodeOwner = inodeOwners.get(inodeKey);
+        if (inodeOwner) {
+          throw new Error(
+            `deletion paths ${inodeOwner} and ${name} share a file inode`,
+          );
+        }
+        inodeOwners.set(inodeKey, name);
+      }
+    }
+    resolved.set(name, canonical);
+  }
+  return resolved;
+}
+
+function assertNoPathOverlap(
+  paths: ReadonlyMap<string, string>,
+  parentName: string,
+  childNames: readonly string[],
+): void {
+  const parent = paths.get(parentName);
+  if (!parent) throw new Error(`missing canonical ${parentName} path`);
+  for (const childName of childNames) {
+    const child = paths.get(childName);
+    if (!child) throw new Error(`missing canonical ${childName} path`);
+    if (pathContains(parent, child) || pathContains(child, parent)) {
+      throw new Error(
+        `deletion paths ${parentName} and ${childName} must not overlap`,
+      );
+    }
+  }
 }
 
 export async function planDeletionFiles(
   options: PlanDeletionFilesOptions,
 ): Promise<DeletionReviewQueue> {
+  const paths = await canonicalPaths({
+    target: options.targetPath,
+    candidates: options.candidatesPath,
+    rules: options.rulesPath,
+    queue: options.queuePath,
+    normalizedRules: options.normalizedRulesPath,
+  });
+  assertNoPathOverlap(paths, "target", ["queue", "normalizedRules"]);
   const corpus = await loadCorpus(options.targetPath);
   const candidates = await readJsonLines(
     options.candidatesPath,
@@ -241,52 +409,112 @@ function desiredLedgerRecords(
 async function appendLedgerRecords(
   ledgerPath: string,
   records: readonly Record<string, unknown>[],
-): Promise<number> {
-  const existing = existsSync(ledgerPath)
-    ? await readJsonLines(ledgerPath, z.record(z.string(), z.unknown()))
-    : [];
-  const byMarker = new Map(
-    existing.map((record) => [String(record.markerKey), record]),
-  );
-  if (byMarker.size !== existing.length) {
-    throw new Error("deletion ledger contains duplicate marker history");
-  }
-  const missing: Record<string, unknown>[] = [];
-  for (const record of records) {
-    const markerKey = String(record.markerKey);
-    const prior = byMarker.get(markerKey);
+  inputMessages: readonly CorpusMessage[],
+  rulesetVersion: string,
+): Promise<{
+  recordsWritten: number;
+  expectedBytes: Buffer;
+  dev: number;
+  ino: number;
+}> {
+  const handle = await fs.open(ledgerPath, "a+", 0o600);
+  let closed = false;
+  const close = async (): Promise<void> => {
+    if (closed) return;
+    closed = true;
+    await handle.close();
+  };
+  try {
+    const before = await handle.stat();
+    const originalBytes = await readHandleBytes(handle, before.size);
+    const afterRead = await handle.stat();
     if (
-      prior &&
-      canonicalDeletionArtifactSha256(prior) !==
-        canonicalDeletionArtifactSha256(record)
+      before.dev !== afterRead.dev ||
+      before.ino !== afterRead.ino ||
+      before.size !== afterRead.size ||
+      before.mtimeMs !== afterRead.mtimeMs ||
+      originalBytes.length !== afterRead.size
     ) {
-      throw new Error(`conflicting deletion ledger record ${markerKey}`);
+      await close();
+      throw new Error("deletion ledger changed while reading");
     }
-    if (!prior) missing.push(record);
+    const existing = parseJsonLines(
+      originalBytes.toString("utf8"),
+      ledgerPath,
+      z.record(z.string(), z.unknown()),
+    );
+    validateDeletionInputsAgainstLedger(
+      existing,
+      inputMessages,
+      rulesetVersion,
+    );
+    const byMarker = new Map(
+      existing.map((record) => [String(record.markerKey), record]),
+    );
+    if (byMarker.size !== existing.length) {
+      throw new Error("deletion ledger contains duplicate marker history");
+    }
+    const missing: Record<string, unknown>[] = [];
+    for (const record of records) {
+      const markerKey = String(record.markerKey);
+      const prior = byMarker.get(markerKey);
+      if (
+        prior &&
+        canonicalDeletionArtifactSha256(prior) !==
+          canonicalDeletionArtifactSha256(record)
+      ) {
+        throw new Error(`conflicting deletion ledger record ${markerKey}`);
+      }
+      if (!prior) missing.push(record);
+    }
+    const appendedBytes = Buffer.from(
+      missing.length === 0
+        ? ""
+        : `${missing.map((record) => JSON.stringify(record)).join("\n")}\n`,
+    );
+    const beforeWrite = await handle.stat();
+    if (
+      beforeWrite.dev !== afterRead.dev ||
+      beforeWrite.ino !== afterRead.ino ||
+      beforeWrite.size !== afterRead.size ||
+      beforeWrite.mtimeMs !== afterRead.mtimeMs
+    ) {
+      await close();
+      throw new Error("deletion ledger changed before append");
+    }
+    try {
+      if (appendedBytes.length > 0) await handle.write(appendedBytes);
+      await handle.sync();
+      await handle.chmod(0o600);
+    } finally {
+      await close();
+    }
+    const expectedBytes = Buffer.concat([originalBytes, appendedBytes]);
+    const finalStat = await fs.stat(ledgerPath);
+    if (
+      finalStat.dev !== afterRead.dev ||
+      finalStat.ino !== afterRead.ino ||
+      !(await fs.readFile(ledgerPath)).equals(expectedBytes)
+    ) {
+      throw new Error("deletion ledger changed during append");
+    }
+    return {
+      recordsWritten: missing.length,
+      expectedBytes,
+      dev: finalStat.dev,
+      ino: finalStat.ino,
+    };
+  } catch (error) {
+    await close();
+    throw error;
   }
-  if (missing.length === 0) return 0;
-  await fs.mkdir(path.dirname(ledgerPath), { recursive: true });
-  await fs.appendFile(
-    ledgerPath,
-    `${missing.map((record) => JSON.stringify(record)).join("\n")}\n`,
-    { mode: 0o600 },
-  );
-  await fs.chmod(ledgerPath, 0o600);
-  return missing.length;
 }
 
-async function validateDeletionInputsAgainstLedger(
-  ledgerPath: string,
+function validateDeletionInputsAgainstLedger(
+  records: readonly Record<string, unknown>[],
   messages: readonly CorpusMessage[],
   rulesetVersion: string,
-): Promise<void> {
-  if (!existsSync(ledgerPath)) {
-    throw new Error("deletion requires an upstream scrub ledger");
-  }
-  const records = await readJsonLines(
-    ledgerPath,
-    z.record(z.string(), z.unknown()),
-  );
+): void {
   const currentSecrets = records.filter(
     (record) =>
       record.rulesetVersion === rulesetVersion &&
@@ -326,19 +554,12 @@ async function writeSurvivorCorpus(
   corpus: LoadedCorpus,
   survivors: readonly CorpusMessage[],
   outputPath: string,
-): Promise<void> {
+): Promise<Map<string, string>> {
   const sourcePath = path.resolve(corpus.targetPath);
   const destinationPath = path.resolve(outputPath);
-  const contains = (parent: string, child: string): boolean => {
-    const relative = path.relative(parent, child);
-    return (
-      relative === "" ||
-      (!relative.startsWith("..") && !path.isAbsolute(relative))
-    );
-  };
   if (
-    contains(sourcePath, destinationPath) ||
-    contains(destinationPath, sourcePath)
+    pathContains(sourcePath, destinationPath) ||
+    pathContains(destinationPath, sourcePath)
   ) {
     throw new Error("deletion input and output paths must not overlap");
   }
@@ -346,16 +567,14 @@ async function writeSurvivorCorpus(
     survivors.map((message) => [message.id, message]),
   );
   const desired = new Map<string, string>();
-  for (const shardPath of corpus.shardPaths) {
-    const shard = await readCorpusShard(shardPath, { rootDir: corpus.rootDir });
+  for (const shard of corpus.shards) {
     const rows = shard.messages
       .map((message) => survivorsById.get(message.id))
       .filter((message): message is CorpusMessage => message !== undefined);
+    if (rows.length === 0) continue;
     desired.set(
-      path.relative(corpus.rootDir, shardPath),
-      rows.length === 0
-        ? ""
-        : `${rows.map((message) => JSON.stringify(message)).join("\n")}\n`,
+      path.relative(corpus.rootDir, shard.path),
+      `${rows.map((message) => JSON.stringify(message)).join("\n")}\n`,
     );
   }
   if (existsSync(outputPath)) {
@@ -378,7 +597,7 @@ async function writeSurvivorCorpus(
         throw new Error(`existing deletion output differs at ${relative}`);
       }
     }
-    return;
+    return desired;
   }
   const temporaryPath = `${outputPath}.tmp-${process.pid}`;
   try {
@@ -393,6 +612,97 @@ async function writeSurvivorCorpus(
   } finally {
     // error-policy:J6 an interrupted atomic output may leave only this temp tree.
     await fs.rm(temporaryPath, { recursive: true, force: true });
+  }
+  return desired;
+}
+
+async function assertSurvivorOutputUnchanged(
+  outputPath: string,
+  desired: ReadonlyMap<string, string>,
+): Promise<void> {
+  const currentPaths = (await findCorpusShardFiles(outputPath))
+    .filter((filePath) => !filePath.split(path.sep).includes(".state"))
+    .map((filePath) => path.relative(outputPath, filePath))
+    .sort();
+  if (
+    canonicalDeletionArtifactSha256(currentPaths) !==
+    canonicalDeletionArtifactSha256([...desired.keys()].sort())
+  ) {
+    throw new Error("deletion output shard set changed during apply");
+  }
+  for (const [relative, bytes] of desired) {
+    if (
+      (await fs.readFile(path.join(outputPath, relative), "utf8")) !== bytes
+    ) {
+      throw new Error(`deletion output changed during apply at ${relative}`);
+    }
+  }
+}
+
+async function assertLedgerUnchanged(
+  ledgerPath: string,
+  expected: { expectedBytes: Buffer; dev: number; ino: number },
+): Promise<void> {
+  const stat = await fs.stat(ledgerPath);
+  if (
+    stat.dev !== expected.dev ||
+    stat.ino !== expected.ino ||
+    !(await fs.readFile(ledgerPath)).equals(expected.expectedBytes)
+  ) {
+    throw new Error("deletion ledger changed after append");
+  }
+}
+
+async function assertCorpusUnchanged(corpus: LoadedCorpus): Promise<void> {
+  const currentPaths = (await findCorpusShardFiles(corpus.targetPath))
+    .filter((filePath) => !filePath.split(path.sep).includes(".state"))
+    .sort();
+  const expectedPaths = corpus.shards.map((shard) => shard.path).sort();
+  if (
+    canonicalDeletionArtifactSha256(currentPaths) !==
+    canonicalDeletionArtifactSha256(expectedPaths)
+  ) {
+    throw new Error("deletion input shard set changed during apply");
+  }
+  for (const shard of corpus.shards) {
+    const stat = await fs.stat(shard.path);
+    if (
+      stat.dev !== shard.dev ||
+      stat.ino !== shard.ino ||
+      !(await fs.readFile(shard.path)).equals(shard.bytes)
+    ) {
+      throw new Error(`deletion input changed during apply at ${shard.path}`);
+    }
+  }
+}
+
+async function assertInternalFilesSeparated(
+  corpus: LoadedCorpus,
+  ledgerPath: string,
+  outputPath?: string,
+): Promise<void> {
+  const sourceInodes = new Set(
+    corpus.shards.map((shard) => `${shard.dev}:${shard.ino}`),
+  );
+  if (sourceInodes.size !== corpus.shards.length) {
+    throw new Error("deletion source shards share a file inode");
+  }
+  const ledgerStat = await fs.stat(ledgerPath);
+  if (sourceInodes.has(`${ledgerStat.dev}:${ledgerStat.ino}`)) {
+    throw new Error("deletion ledger shares an inode with a source shard");
+  }
+  if (!outputPath || !existsSync(outputPath)) return;
+  const outputInodes = new Set<string>();
+  for (const outputShard of await findCorpusShardFiles(outputPath)) {
+    const stat = await fs.stat(outputShard);
+    const inode = `${stat.dev}:${stat.ino}`;
+    if (sourceInodes.has(inode)) {
+      throw new Error("deletion output shares an inode with a source shard");
+    }
+    if (outputInodes.has(inode)) {
+      throw new Error("deletion output shards share a file inode");
+    }
+    outputInodes.add(inode);
   }
 }
 
@@ -426,8 +736,20 @@ async function applyDeletionFilesLocked(
   ) {
     throw new Error("deletion review queue is not canonical for its inputs");
   }
-  await validateDeletionInputsAgainstLedger(
+  if (!existsSync(options.ledgerPath)) {
+    throw new Error("deletion requires an upstream scrub ledger");
+  }
+  await assertInternalFilesSeparated(
+    corpus,
     options.ledgerPath,
+    options.outputPath,
+  );
+  const initialLedgerRecords = await readJsonLines(
+    options.ledgerPath,
+    z.record(z.string(), z.unknown()),
+  );
+  validateDeletionInputsAgainstLedger(
+    initialLedgerRecords,
     corpus.messages,
     queue.rulesetVersion,
   );
@@ -443,7 +765,19 @@ async function applyDeletionFilesLocked(
     applied.approval.rulesetVersion,
     applied.approval,
   );
-  await writeSurvivorCorpus(corpus, applied.survivors, options.outputPath);
+  await assertCorpusUnchanged(corpus);
+  const desiredOutput = await writeSurvivorCorpus(
+    corpus,
+    applied.survivors,
+    options.outputPath,
+  );
+  await assertCorpusUnchanged(corpus);
+  await assertSurvivorOutputUnchanged(options.outputPath, desiredOutput);
+  await assertInternalFilesSeparated(
+    corpus,
+    options.ledgerPath,
+    options.outputPath,
+  );
   const { manifest, issues } = await buildCorpusManifest(
     options.outputPath,
     decisions.reviewedAt,
@@ -453,17 +787,55 @@ async function applyDeletionFilesLocked(
       `deleted corpus manifest failed: ${issues.map((issue) => issue.message).join("; ")}`,
     );
   }
-  const ledgerRecordsWritten = await appendLedgerRecords(
+  if (
+    canonicalDeletionArtifactSha256(
+      manifest.shards.map((shard) => shard.path).sort(),
+    ) !== canonicalDeletionArtifactSha256([...desiredOutput.keys()].sort()) ||
+    manifest.totals.messages !== applied.survivors.length ||
+    manifest.shards.some((shard) => {
+      const bytes = desiredOutput.get(shard.path);
+      return (
+        bytes === undefined ||
+        shard.sha256 !== sha256(bytes) ||
+        shard.count !== bytes.trim().split("\n").length
+      );
+    })
+  ) {
+    throw new Error("deletion manifest does not match survivor snapshot");
+  }
+  const ledgerAppend = await appendLedgerRecords(
     options.ledgerPath,
     records,
+    corpus.messages,
+    applied.approval.rulesetVersion,
   );
-  await writePrivateJson(options.manifestPath, manifest);
-  await writePrivateJson(options.approvalPath, applied.approval);
-  await writePrivateJson(options.reportPath, applied.report);
+  const manifestArtifact = await writePrivateJson(
+    options.manifestPath,
+    manifest,
+  );
+  const approvalArtifact = await writePrivateJson(
+    options.approvalPath,
+    applied.approval,
+  );
+  const reportArtifact = await writePrivateJson(
+    options.reportPath,
+    applied.report,
+  );
+  await assertCorpusUnchanged(corpus);
+  await assertSurvivorOutputUnchanged(options.outputPath, desiredOutput);
+  await assertLedgerUnchanged(options.ledgerPath, ledgerAppend);
+  await assertInternalFilesSeparated(
+    corpus,
+    options.ledgerPath,
+    options.outputPath,
+  );
+  await assertArtifactUnchanged(options.manifestPath, manifestArtifact);
+  await assertArtifactUnchanged(options.approvalPath, approvalArtifact);
+  await assertArtifactUnchanged(options.reportPath, reportArtifact);
   return {
     approval: applied.approval,
     report: applied.report,
-    ledgerRecordsWritten,
+    ledgerRecordsWritten: ledgerAppend.recordsWritten,
     outputPath: options.outputPath,
   };
 }
@@ -471,6 +843,35 @@ async function applyDeletionFilesLocked(
 export async function applyDeletionFiles(
   options: ApplyDeletionFilesOptions,
 ): Promise<AppliedDeletionFiles> {
+  const paths = await canonicalPaths({
+    target: options.targetPath,
+    candidates: options.candidatesPath,
+    normalizedRules: options.normalizedRulesPath,
+    queue: options.queuePath,
+    decisions: options.decisionsPath,
+    output: options.outputPath,
+    ledger: options.ledgerPath,
+    manifest: options.manifestPath,
+    approval: options.approvalPath,
+    report: options.reportPath,
+  });
+  assertNoPathOverlap(paths, "target", [
+    "output",
+    "ledger",
+    "manifest",
+    "approval",
+    "report",
+  ]);
+  assertNoPathOverlap(paths, "output", [
+    "candidates",
+    "normalizedRules",
+    "queue",
+    "decisions",
+    "ledger",
+    "manifest",
+    "approval",
+    "report",
+  ]);
   await fs.mkdir(path.dirname(options.ledgerPath), { recursive: true });
   const lockPath = `${options.ledgerPath}.lock`;
   const lock = await fs.open(lockPath, "wx", 0o600);

--- a/packages/corpus-tools/src/pipeline/delete-files.test.ts
+++ b/packages/corpus-tools/src/pipeline/delete-files.test.ts
@@ -1,0 +1,67 @@
+/** Strict JSON/YAML rule parsing rejects ambiguous or expandable documents. */
+import { describe, expect, it } from "vitest";
+import { parseDeletionRulesDocument } from "./delete-files.ts";
+
+const validYaml = `
+schemaVersion: 1
+rulesetVersion: delete-v1
+attachmentPolicy:
+  embeddedBytes: drop
+  retainMetadata: [filename, mimeType, sha256]
+rules:
+  - id: receipts
+    enabled: true
+    scope: message
+    match:
+      type: label
+      value: Receipts
+`;
+
+describe("deletion rule documents", () => {
+  it("parses explicit YAML through the strict shared schema", () => {
+    const rules = parseDeletionRulesDocument(validYaml, "delete-rules.yaml");
+
+    expect(rules.rules).toHaveLength(1);
+    expect(rules.rules[0]?.id).toBe("receipts");
+  });
+
+  it.each([
+    [
+      "duplicate keys",
+      validYaml.replace("enabled: true", "enabled: true\n    enabled: false"),
+    ],
+    [
+      "anchors",
+      validYaml.replace(
+        "rulesetVersion: delete-v1",
+        "rulesetVersion: &version delete-v1",
+      ),
+    ],
+    ["aliases", `${validYaml}\ncopy: *version\n`],
+    ["merge keys", `${validYaml}\nmerged:\n  <<: {extra: true}\n`],
+    [
+      "custom tags",
+      validYaml.replace(
+        "rulesetVersion: delete-v1",
+        "rulesetVersion: !owner delete-v1",
+      ),
+    ],
+  ])("rejects YAML %s", (_name, source) => {
+    expect(() => parseDeletionRulesDocument(source, "rules.yaml")).toThrow();
+  });
+
+  it("rejects schema fields that owner review did not define", () => {
+    const source = JSON.stringify({
+      schemaVersion: 1,
+      rulesetVersion: "delete-v1",
+      attachmentPolicy: {
+        embeddedBytes: "drop",
+        retainMetadata: ["filename", "mimeType", "sha256"],
+      },
+      rules: [],
+      fallback: "keep",
+    });
+
+    expect(() => parseDeletionRulesDocument(source, "rules.json")).toThrow();
+  });
+});

--- a/packages/corpus-tools/src/pipeline/delete-files.ts
+++ b/packages/corpus-tools/src/pipeline/delete-files.ts
@@ -5,17 +5,22 @@
  */
 import path from "node:path";
 import { isAlias, isScalar, parseDocument, visit } from "yaml";
-import { type DeletionRules, parseDeletionRules } from "./delete.ts";
+import {
+  type DeletionReviewDecisions,
+  type DeletionRules,
+  parseDeletionReviewDecisions,
+  parseDeletionRules,
+} from "./delete.ts";
 
-function parseJson(source: string): unknown {
+function parseJson(source: string, label: string): unknown {
   try {
     return JSON.parse(source);
   } catch (error) {
-    throw new Error("invalid deletion rules JSON", { cause: error });
+    throw new Error(`invalid ${label} JSON`, { cause: error });
   }
 }
 
-function parseYaml(source: string): unknown {
+function parseYaml(source: string, label: string): unknown {
   const document = parseDocument(source, {
     merge: false,
     prettyErrors: true,
@@ -26,7 +31,7 @@ function parseYaml(source: string): unknown {
     const diagnostics = [...document.errors, ...document.warnings]
       .map((diagnostic) => diagnostic.message)
       .join("; ");
-    throw new Error(`invalid deletion rules YAML: ${diagnostics}`);
+    throw new Error(`invalid ${label} YAML: ${diagnostics}`);
   }
   visit(document, {
     Node(_key, node) {
@@ -51,14 +56,33 @@ function parseYaml(source: string): unknown {
   return document.toJS({ maxAliasCount: 0 });
 }
 
+function parseDocumentValue(
+  source: string,
+  filename: string,
+  label: string,
+): unknown {
+  const extension = path.extname(filename).toLowerCase();
+  if (extension === ".json") return parseJson(source, label);
+  if (extension === ".yaml" || extension === ".yml") {
+    return parseYaml(source, label);
+  }
+  throw new Error(`${label} must use .json, .yaml, or .yml`);
+}
+
 export function parseDeletionRulesDocument(
   source: string,
   filename: string,
 ): DeletionRules {
-  const extension = path.extname(filename).toLowerCase();
-  if (extension === ".json") return parseDeletionRules(parseJson(source));
-  if (extension === ".yaml" || extension === ".yml") {
-    return parseDeletionRules(parseYaml(source));
-  }
-  throw new Error("deletion rules must use .json, .yaml, or .yml");
+  return parseDeletionRules(
+    parseDocumentValue(source, filename, "deletion rules"),
+  );
+}
+
+export function parseDeletionReviewDecisionsDocument(
+  source: string,
+  filename: string,
+): DeletionReviewDecisions {
+  return parseDeletionReviewDecisions(
+    parseDocumentValue(source, filename, "deletion review decisions"),
+  );
 }

--- a/packages/corpus-tools/src/pipeline/delete-files.ts
+++ b/packages/corpus-tools/src/pipeline/delete-files.ts
@@ -1,0 +1,64 @@
+/**
+ * Strict deletion-rule document parsing at the local file boundary. JSON and
+ * YAML feed the same validated rule schema; YAML conveniences that can hide or
+ * expand data are rejected so owner review always covers one explicit tree.
+ */
+import path from "node:path";
+import { isAlias, isScalar, parseDocument, visit } from "yaml";
+import { type DeletionRules, parseDeletionRules } from "./delete.ts";
+
+function parseJson(source: string): unknown {
+  try {
+    return JSON.parse(source);
+  } catch (error) {
+    throw new Error("invalid deletion rules JSON", { cause: error });
+  }
+}
+
+function parseYaml(source: string): unknown {
+  const document = parseDocument(source, {
+    merge: false,
+    prettyErrors: true,
+    strict: true,
+    uniqueKeys: true,
+  });
+  if (document.errors.length > 0 || document.warnings.length > 0) {
+    const diagnostics = [...document.errors, ...document.warnings]
+      .map((diagnostic) => diagnostic.message)
+      .join("; ");
+    throw new Error(`invalid deletion rules YAML: ${diagnostics}`);
+  }
+  visit(document, {
+    Node(_key, node) {
+      if (isAlias(node)) throw new Error("YAML aliases are not allowed");
+      if ("anchor" in node && node.anchor) {
+        throw new Error("YAML anchors are not allowed");
+      }
+      if (
+        "tag" in node &&
+        node.tag &&
+        !node.tag.startsWith("tag:yaml.org,2002:")
+      ) {
+        throw new Error("custom YAML tags are not allowed");
+      }
+    },
+    Pair(_key, pair) {
+      if (isScalar(pair.key) && pair.key.value === "<<") {
+        throw new Error("YAML merge keys are not allowed");
+      }
+    },
+  });
+  return document.toJS({ maxAliasCount: 0 });
+}
+
+export function parseDeletionRulesDocument(
+  source: string,
+  filename: string,
+): DeletionRules {
+  const extension = path.extname(filename).toLowerCase();
+  if (extension === ".json") return parseDeletionRules(parseJson(source));
+  if (extension === ".yaml" || extension === ".yml") {
+    return parseDeletionRules(parseYaml(source));
+  }
+  throw new Error("deletion rules must use .json, .yaml, or .yml");
+}

--- a/packages/corpus-tools/src/pipeline/delete.test.ts
+++ b/packages/corpus-tools/src/pipeline/delete.test.ts
@@ -1,0 +1,648 @@
+/**
+ * Adversarial coverage for deterministic deletion planning and owner review.
+ * The suite uses only synthetic messages and checks that private source content
+ * cannot cross into tombstone, approval, or public-report artifacts.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { CorpusMessage } from "../schema.ts";
+import {
+  applyDeletionReview,
+  buildDeletionReviewQueue,
+  canonicalDeletionArtifactSha256,
+  type DeletionReviewDecisions,
+  type DeletionReviewQueue,
+  type DeletionRule,
+  type DeletionRules,
+  parseDeletionReviewDecisions,
+  parseDeletionReviewQueue,
+  parseDeletionRules,
+} from "./delete.ts";
+
+const RULESET = "delete-test-v1";
+const ATTACHMENT_POLICY: DeletionRules["attachmentPolicy"] = {
+  embeddedBytes: "drop" as const,
+  retainMetadata: ["filename", "mimeType", "sha256"],
+};
+
+function message(
+  id: string,
+  overrides: Partial<CorpusMessage> = {},
+): CorpusMessage {
+  return {
+    id,
+    platform: "gmail",
+    accountId: "work",
+    threadId: `thread-${id}`,
+    ts: Date.parse("2026-06-01T12:00:00.000Z"),
+    direction: "in",
+    senderId: `sender-${id}`,
+    senderDisplay: `Sender ${id}`,
+    recipients: [{ id: "owner", address: "owner@example.test" }],
+    text: `Synthetic content for ${id}.`,
+    labels: [],
+    attachments: [],
+    scrubState: "swapped",
+    ...overrides,
+  };
+}
+
+function rules(
+  entries: DeletionRules["rules"],
+  overrides: Partial<DeletionRules> = {},
+): DeletionRules {
+  return {
+    schemaVersion: 1,
+    rulesetVersion: RULESET,
+    attachmentPolicy: ATTACHMENT_POLICY,
+    rules: entries,
+    ...overrides,
+  };
+}
+
+function approve(
+  queue: DeletionReviewQueue,
+  decisionFor: (groupId: string) => "delete" | "keep" = () => "delete",
+): DeletionReviewDecisions {
+  return {
+    schemaVersion: 1,
+    rulesetVersion: queue.rulesetVersion,
+    corpusDigest: queue.corpusDigest,
+    rulesSha256: queue.rulesSha256,
+    reviewedQueueSha256: canonicalDeletionArtifactSha256(queue),
+    approved: true,
+    reviewedBy: "synthetic-owner",
+    reviewedAt: "2026-07-10T05:00:00.000Z",
+    decisions: queue.groups.map((group) => ({
+      groupId: group.groupId,
+      decision: decisionFor(group.groupId),
+    })),
+  };
+}
+
+describe("deletion rule validation", () => {
+  it("accepts strict JSON/YAML-decoded data and rejects unknown keys", () => {
+    const valid = rules([
+      {
+        id: "medical-contact",
+        enabled: true,
+        scope: "thread",
+        match: {
+          type: "contact",
+          platform: "gmail",
+          accountId: "work",
+          contactId: "doctor@example.test",
+        },
+      },
+    ]);
+    expect(parseDeletionRules(valid)).toEqual(valid);
+    expect(() =>
+      parseDeletionRules({ ...valid, yamlMerge: "forbidden" }),
+    ).toThrow();
+    expect(() =>
+      parseDeletionRules({
+        ...valid,
+        rules: [{ ...valid.rules[0], unexpected: true }],
+      }),
+    ).toThrow();
+  });
+
+  it("rejects duplicate rule ids, duplicate keyword fields, and regex-like ids", () => {
+    const duplicate: DeletionRule = {
+      id: "private-topic",
+      enabled: true,
+      scope: "message" as const,
+      match: {
+        type: "keyword" as const,
+        value: "medical",
+        mode: "token" as const,
+        fields: ["text"],
+      },
+    };
+    expect(() => parseDeletionRules(rules([duplicate, duplicate]))).toThrow(
+      "duplicate deletion rule id",
+    );
+    expect(() =>
+      parseDeletionRules(
+        rules([
+          {
+            ...duplicate,
+            id: "duplicate-fields",
+            match: { ...duplicate.match, fields: ["text", "text"] },
+          },
+        ]),
+      ),
+    ).toThrow("keyword fields must be unique");
+    expect(() =>
+      parseDeletionRules(rules([{ ...duplicate, id: "(medical)+" }])),
+    ).toThrow();
+  });
+});
+
+describe("deletion review planning", () => {
+  it("matches contact, thread, detector, keyword, and label rules with compound-thread isolation", () => {
+    const messages = [
+      message("contact-1", {
+        threadId: "shared-thread",
+        senderId: "doctor@example.test",
+        text: "Follow-up from the clinic.",
+      }),
+      message("contact-2", {
+        threadId: "shared-thread",
+        text: "Second message in the same relationship.",
+      }),
+      message("other-account", {
+        accountId: "personal",
+        threadId: "shared-thread",
+      }),
+      message("thread-rule", { threadId: "legal-thread" }),
+      message("detector", { text: "Already placeholdered account record." }),
+      message("keyword", { text: "MEDICAL follow up" }),
+      message("label", { labels: ["Receipts"] }),
+    ];
+    const queue = buildDeletionReviewQueue({
+      messages,
+      candidates: [{ msgId: "detector", kind: "credit-card" }],
+      rules: rules([
+        {
+          id: "medical-contact",
+          enabled: true,
+          scope: "thread",
+          match: {
+            type: "contact",
+            platform: "gmail",
+            accountId: "work",
+            contactId: "doctor@example.test",
+          },
+        },
+        {
+          id: "legal-thread",
+          enabled: true,
+          scope: "thread",
+          match: {
+            type: "thread",
+            platform: "gmail",
+            accountId: "work",
+            threadId: "legal-thread",
+          },
+        },
+        {
+          id: "financial-detector",
+          enabled: true,
+          scope: "message",
+          match: { type: "detector", kind: "credit-card" },
+        },
+        {
+          id: "medical-keyword",
+          enabled: true,
+          scope: "message",
+          match: {
+            type: "keyword",
+            value: "medical",
+            mode: "token",
+            fields: ["text"],
+          },
+        },
+        {
+          id: "receipt-label",
+          enabled: true,
+          scope: "message",
+          match: { type: "label", value: "receipts" },
+        },
+      ]),
+    });
+
+    expect(queue.groups).toHaveLength(5);
+    expect(
+      queue.groups.find((group) => group.messageIds.includes("contact-1"))
+        ?.messageIds,
+    ).toEqual(["contact-1", "contact-2"]);
+    expect(
+      queue.groups.some((group) => group.messageIds.includes("other-account")),
+    ).toBe(false);
+    expect(queue.groups.flatMap((group) => group.matchClasses).sort()).toEqual([
+      "contact",
+      "detector",
+      "keyword",
+      "label",
+      "thread",
+    ]);
+  });
+
+  it("folds message matches into a selected thread so review cannot conflict", () => {
+    const messages = [
+      message("one", { threadId: "private", text: "medical note" }),
+      message("two", { threadId: "private" }),
+    ];
+    const queue = buildDeletionReviewQueue({
+      messages,
+      candidates: [],
+      rules: rules([
+        {
+          id: "private-thread",
+          enabled: true,
+          scope: "thread",
+          match: {
+            type: "thread",
+            platform: "gmail",
+            accountId: "work",
+            threadId: "private",
+          },
+        },
+        {
+          id: "medical-word",
+          enabled: true,
+          scope: "message",
+          match: {
+            type: "keyword",
+            value: "medical",
+            mode: "token",
+            fields: ["text"],
+          },
+        },
+      ]),
+    });
+    expect(queue.groups).toHaveLength(1);
+    expect(queue.groups[0].messageIds).toEqual(["one", "two"]);
+    expect(queue.groups[0].matchClasses).toEqual(["keyword", "thread"]);
+  });
+
+  it("uses Unicode-stable literal matching and token boundaries", () => {
+    const messages = [
+      message("exact", { text: "Discuss Médical options." }),
+      message("embedded", { text: "The biomedical project is public." }),
+      message("literal", { text: "Keep (medical)+ as literal text." }),
+    ];
+    const queue = buildDeletionReviewQueue({
+      messages,
+      candidates: [],
+      rules: rules([
+        {
+          id: "unicode-token",
+          enabled: true,
+          scope: "message",
+          match: {
+            type: "keyword",
+            value: "médical",
+            mode: "token",
+            fields: ["text"],
+          },
+        },
+        {
+          id: "literal-substring",
+          enabled: true,
+          scope: "message",
+          match: {
+            type: "keyword",
+            value: "(medical)+",
+            mode: "substring",
+            fields: ["text"],
+          },
+        },
+      ]),
+    });
+    expect(queue.groups.map((group) => group.messageIds[0]).sort()).toEqual([
+      "exact",
+      "literal",
+    ]);
+  });
+
+  it("fails closed on stale candidates and duplicate message ids", () => {
+    const current = message("current");
+    expect(() =>
+      buildDeletionReviewQueue({
+        messages: [current],
+        candidates: [{ msgId: "missing", kind: "ssn" }],
+        rules: rules([]),
+      }),
+    ).toThrow("references missing message");
+    expect(() =>
+      buildDeletionReviewQueue({
+        messages: [current, { ...current }],
+        candidates: [],
+        rules: rules([]),
+      }),
+    ).toThrow("duplicate corpus message id");
+  });
+
+  it("refuses raw or mined input before producing review artifacts", () => {
+    for (const scrubState of ["raw", "mined"] as const) {
+      expect(() =>
+        buildDeletionReviewQueue({
+          messages: [message(scrubState, { scrubState })],
+          candidates: [],
+          rules: rules([]),
+        }),
+      ).toThrow(`message ${scrubState} is ${scrubState}`);
+    }
+  });
+
+  it("is byte-stable across message, candidate, and rule ordering", () => {
+    const messages = [
+      message("a", { text: "medical" }),
+      message("b", { text: "financial" }),
+    ];
+    const ruleList: DeletionRules["rules"] = [
+      {
+        id: "medical",
+        enabled: true,
+        scope: "message",
+        match: {
+          type: "keyword",
+          value: "medical",
+          mode: "token",
+          fields: ["text"],
+        },
+      },
+      {
+        id: "financial",
+        enabled: true,
+        scope: "message",
+        match: { type: "detector", kind: "iban" },
+      },
+    ];
+    const first = buildDeletionReviewQueue({
+      messages,
+      candidates: [{ msgId: "b", kind: "iban" }],
+      rules: rules(ruleList),
+    });
+    const second = buildDeletionReviewQueue({
+      messages: [...messages].reverse(),
+      candidates: [{ msgId: "b", kind: "iban" }].reverse(),
+      rules: rules([...ruleList].reverse()),
+    });
+    expect(second).toEqual(first);
+    expect(canonicalDeletionArtifactSha256(second)).toBe(
+      canonicalDeletionArtifactSha256(first),
+    );
+  });
+});
+
+describe("reviewed deletion application", () => {
+  it("requires one exact decision per group and rejects stale bindings", () => {
+    const messages = [message("delete-me", { text: "medical" })];
+    const queue = buildDeletionReviewQueue({
+      messages,
+      candidates: [],
+      rules: rules([
+        {
+          id: "medical",
+          enabled: true,
+          scope: "message",
+          match: {
+            type: "keyword",
+            value: "medical",
+            mode: "token",
+            fields: ["text"],
+          },
+        },
+      ]),
+    });
+    const complete = approve(queue);
+    expect(() =>
+      applyDeletionReview({
+        messages,
+        queue,
+        decisions: { ...complete, decisions: [] },
+      }),
+    ).toThrow("missing deletion decision");
+    expect(() =>
+      applyDeletionReview({
+        messages,
+        queue,
+        decisions: { ...complete, corpusDigest: "0".repeat(64) },
+      }),
+    ).toThrow("corpus binding mismatch");
+    expect(() =>
+      parseDeletionReviewDecisions({
+        ...complete,
+        decisions: [complete.decisions[0], complete.decisions[0]],
+      }),
+    ).toThrow("duplicate deletion decision");
+    expect(() =>
+      parseDeletionReviewQueue({
+        ...queue,
+        groups: [queue.groups[0], queue.groups[0]],
+      }),
+    ).toThrow("duplicate deletion review group");
+  });
+
+  it("strips attachment payload fields, keeps metadata, and never mutates inputs", () => {
+    const privateText = "PRIVATE-MEDICAL-CONTENT";
+    const deleted = message("deleted", {
+      text: privateText,
+      attachments: [
+        {
+          filename: "private.txt",
+          mimeType: "text/plain",
+          sha256: "c".repeat(64),
+          dataBase64: "cHJpdmF0ZQ==",
+        },
+      ],
+    });
+    const survivor = message("survivor", {
+      attachments: [
+        {
+          filename: "safe.pdf",
+          mimeType: "application/pdf",
+          sha256: "a".repeat(64),
+          bytes: 42,
+          dataBase64: "cHJpdmF0ZS1ieXRlcw==",
+        },
+      ],
+    });
+    const messages = [deleted, survivor];
+    const snapshot = JSON.stringify(messages);
+    const queue = buildDeletionReviewQueue({
+      messages,
+      candidates: [],
+      rules: rules([
+        {
+          id: "private-medical",
+          enabled: true,
+          scope: "message",
+          match: {
+            type: "keyword",
+            value: privateText,
+            mode: "token",
+            fields: ["text"],
+          },
+        },
+      ]),
+    });
+    const applied = applyDeletionReview({
+      messages,
+      queue,
+      decisions: approve(queue),
+    });
+
+    expect(JSON.stringify(messages)).toBe(snapshot);
+    expect(applied.survivors).toEqual([
+      {
+        ...survivor,
+        attachments: [
+          {
+            filename: "safe.pdf",
+            mimeType: "application/pdf",
+            sha256: "a".repeat(64),
+          },
+        ],
+      },
+    ]);
+    expect(applied.approval.attachmentBytesDropped).toBe(2);
+    expect(applied.tombstones).toHaveLength(1);
+    const publicArtifacts = JSON.stringify({
+      tombstones: applied.tombstones,
+      approval: applied.approval,
+      report: applied.report,
+    });
+    expect(publicArtifacts).not.toContain(privateText);
+    expect(publicArtifacts).not.toContain("private-medical");
+    expect(publicArtifacts).not.toContain("thread-deleted");
+    expect(applied.report.reportDigest).toBe(
+      canonicalDeletionArtifactSha256({
+        ...applied.report,
+        reportDigest: undefined,
+      }),
+    );
+  });
+
+  it("supports explicit keeps and an approved zero-match review", () => {
+    const kept = message("kept", {
+      text: "medical",
+      attachments: [
+        {
+          filename: "note.txt",
+          mimeType: "text/plain",
+          sha256: "b".repeat(64),
+          dataBase64: "bm90ZQ==",
+        },
+      ],
+    });
+    const queue = buildDeletionReviewQueue({
+      messages: [kept],
+      candidates: [],
+      rules: rules([
+        {
+          id: "medical",
+          enabled: true,
+          scope: "message",
+          match: {
+            type: "keyword",
+            value: "medical",
+            mode: "token",
+            fields: ["text"],
+          },
+        },
+      ]),
+    });
+    const explicitlyKept = applyDeletionReview({
+      messages: [kept],
+      queue,
+      decisions: approve(queue, () => "keep"),
+    });
+    expect(explicitlyKept.tombstones).toEqual([]);
+    expect(explicitlyKept.survivors[0].attachments[0]).not.toHaveProperty(
+      "dataBase64",
+    );
+
+    const emptyQueue = buildDeletionReviewQueue({
+      messages: [message("ordinary")],
+      candidates: [],
+      rules: rules([]),
+    });
+    const emptyResult = applyDeletionReview({
+      messages: [message("ordinary")],
+      queue: emptyQueue,
+      decisions: approve(emptyQueue),
+    });
+    expect(emptyResult.approval).toMatchObject({
+      approved: true,
+      tombstoneCount: 0,
+      survivorCount: 1,
+    });
+  });
+
+  it("changes the stage version when reviewed decisions change", () => {
+    const messages = [
+      message("one", { text: "medical" }),
+      message("two", { text: "medical" }),
+    ];
+    const queue = buildDeletionReviewQueue({
+      messages,
+      candidates: [],
+      rules: rules([
+        {
+          id: "medical",
+          enabled: true,
+          scope: "message",
+          match: {
+            type: "keyword",
+            value: "medical",
+            mode: "token",
+            fields: ["text"],
+          },
+        },
+      ]),
+    });
+    const allDeleted = applyDeletionReview({
+      messages,
+      queue,
+      decisions: approve(queue),
+    });
+    const firstKept = applyDeletionReview({
+      messages,
+      queue,
+      decisions: approve(queue, (groupId) =>
+        groupId === queue.groups[0].groupId ? "keep" : "delete",
+      ),
+    });
+    expect(firstKept.approval.deleteStageVersion).not.toBe(
+      allDeleted.approval.deleteStageVersion,
+    );
+    expect(firstKept.approval.tombstoneCount).toBe(1);
+  });
+
+  it("binds the exact tombstoned id set even when counts are equal", () => {
+    const messages = [
+      message("one", { text: "medical" }),
+      message("two", { text: "medical" }),
+    ];
+    const queue = buildDeletionReviewQueue({
+      messages,
+      candidates: [],
+      rules: rules([
+        {
+          id: "medical",
+          enabled: true,
+          scope: "message",
+          match: {
+            type: "keyword",
+            value: "medical",
+            mode: "token",
+            fields: ["text"],
+          },
+        },
+      ]),
+    });
+    const deleteOne = (wanted: string) =>
+      applyDeletionReview({
+        messages,
+        queue,
+        decisions: approve(queue, (groupId) => {
+          const group = queue.groups.find((item) => item.groupId === groupId);
+          return group?.messageIds.includes(wanted) ? "delete" : "keep";
+        }),
+      });
+    const first = deleteOne("one");
+    const second = deleteOne("two");
+    expect(first.approval.tombstoneCount).toBe(1);
+    expect(second.approval.tombstoneCount).toBe(1);
+    expect(first.approval.tombstoneIdsSha256).not.toBe(
+      second.approval.tombstoneIdsSha256,
+    );
+    expect(first.approval.tombstoneIdsSha256).toBe(
+      canonicalDeletionArtifactSha256(["one"]),
+    );
+  });
+});

--- a/packages/corpus-tools/src/pipeline/delete.test.ts
+++ b/packages/corpus-tools/src/pipeline/delete.test.ts
@@ -446,7 +446,7 @@ describe("reviewed deletion application", () => {
           filename: "safe.pdf",
           mimeType: "application/pdf",
           sha256: "a".repeat(64),
-          bytes: 42,
+          bytes: 13,
           dataBase64: "cHJpdmF0ZS1ieXRlcw==",
         },
       ],
@@ -489,7 +489,7 @@ describe("reviewed deletion application", () => {
         ],
       },
     ]);
-    expect(applied.approval.attachmentBytesDropped).toBe(2);
+    expect(applied.approval.attachmentBytesDropped).toBe(20);
     expect(applied.tombstones).toHaveLength(1);
     const publicArtifacts = JSON.stringify({
       tombstones: applied.tombstones,
@@ -505,6 +505,38 @@ describe("reviewed deletion application", () => {
         reportDigest: undefined,
       }),
     );
+  });
+
+  it.each([
+    ["malformed", "***", undefined, "invalid base64 payload"],
+    ["size mismatch", "c2VjcmV0", 7, "inconsistent payload bytes"],
+  ])("rejects %s embedded attachment byte evidence", (_name, dataBase64, bytes, expectedError) => {
+    const messages = [
+      message("unsafe-attachment", {
+        attachments: [
+          {
+            filename: "unsafe.bin",
+            mimeType: "application/octet-stream",
+            sha256: "a".repeat(64),
+            dataBase64,
+            bytes,
+          },
+        ],
+      }),
+    ];
+    const queue = buildDeletionReviewQueue({
+      messages,
+      candidates: [],
+      rules: rules([]),
+    });
+
+    expect(() =>
+      applyDeletionReview({
+        messages,
+        queue,
+        decisions: approve(queue),
+      }),
+    ).toThrow(expectedError);
   });
 
   it("supports explicit keeps and an approved zero-match review", () => {

--- a/packages/corpus-tools/src/pipeline/delete.ts
+++ b/packages/corpus-tools/src/pipeline/delete.ts
@@ -1,0 +1,908 @@
+/**
+ * Owner-reviewed sensitive-content deletion for the personal corpus. The
+ * library separates deterministic matching from human decisions, binds every
+ * artifact to the exact corpus/rules/candidates bytes, and emits tombstones
+ * that contain no source content. File parsing and pipeline orchestration live
+ * at the CLI/driver boundary; this module accepts JSON/YAML-decoded data.
+ */
+import { createHash } from "node:crypto";
+import { z } from "zod";
+import {
+  type CorpusMessage,
+  type CorpusPlatform,
+  corpusPlatforms,
+  scrubStateRank,
+} from "../schema.ts";
+
+const SHA256_PATTERN = /^[a-f0-9]{64}$/;
+const RULE_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const DETECTOR_KIND_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const REVIEW_REDACT_PATTERNS: readonly RegExp[] = [
+  /[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/gi,
+  /(?<!\d)(?:\+?[1-9]\d{7,14}|(?:\+?1[ .-]?)?(?:\(\d{3}\)[ .-]?|\d{3}[ .-])\d{3}[ .-]?\d{4})(?!\d)/g,
+  /\b\d{3}[ -]\d{2}[ -]\d{4}\b/g,
+  /\b(?:\d[ -]?){13,19}\b/g,
+  /\b(?:sk-|ghp_|github_pat_|xox[baprs]-|AIza)[A-Za-z0-9_-]{8,}\b/g,
+  /\b(?:password|passcode|token|secret)\s*[:=]\s*\S+/gi,
+];
+
+const ruleBaseSchema = z
+  .object({
+    id: z.string().regex(RULE_ID_PATTERN),
+    enabled: z.boolean(),
+  })
+  .strict();
+
+const threadRuleSchema = ruleBaseSchema
+  .extend({
+    scope: z.literal("thread"),
+    match: z
+      .object({
+        type: z.literal("thread"),
+        platform: z.enum(corpusPlatforms),
+        accountId: z.string().trim().min(1),
+        threadId: z.string().trim().min(1),
+      })
+      .strict(),
+  })
+  .strict();
+
+const contactRuleSchema = ruleBaseSchema
+  .extend({
+    scope: z.literal("thread"),
+    match: z
+      .object({
+        type: z.literal("contact"),
+        platform: z.enum(corpusPlatforms),
+        accountId: z.string().trim().min(1),
+        contactId: z.string().trim().min(1),
+      })
+      .strict(),
+  })
+  .strict();
+
+const detectorRuleSchema = ruleBaseSchema
+  .extend({
+    scope: z.enum(["message", "thread"]),
+    match: z
+      .object({
+        type: z.literal("detector"),
+        kind: z.string().regex(DETECTOR_KIND_PATTERN),
+      })
+      .strict(),
+  })
+  .strict();
+
+export const deletionKeywordFields = [
+  "subject",
+  "text",
+  "snippet",
+  "labels",
+  "attachment-filename",
+] as const;
+
+const keywordRuleSchema = ruleBaseSchema
+  .extend({
+    scope: z.enum(["message", "thread"]),
+    match: z
+      .object({
+        type: z.literal("keyword"),
+        value: z.string().trim().min(2),
+        mode: z.enum(["token", "substring"]),
+        fields: z
+          .array(z.enum(deletionKeywordFields))
+          .min(1)
+          .refine((fields) => new Set(fields).size === fields.length, {
+            message: "keyword fields must be unique",
+          }),
+      })
+      .strict(),
+  })
+  .strict();
+
+const labelRuleSchema = ruleBaseSchema
+  .extend({
+    scope: z.enum(["message", "thread"]),
+    match: z
+      .object({
+        type: z.literal("label"),
+        value: z.string().trim().min(1),
+      })
+      .strict(),
+  })
+  .strict();
+
+const anyDeletionRuleSchema = z.union([
+  threadRuleSchema,
+  contactRuleSchema,
+  detectorRuleSchema,
+  keywordRuleSchema,
+  labelRuleSchema,
+]);
+
+export const deletionRulesSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    rulesetVersion: z.string().trim().min(1),
+    attachmentPolicy: z
+      .object({
+        embeddedBytes: z.literal("drop"),
+        retainMetadata: z.tuple([
+          z.literal("filename"),
+          z.literal("mimeType"),
+          z.literal("sha256"),
+        ]),
+      })
+      .strict(),
+    rules: z.array(anyDeletionRuleSchema),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    const ids = new Set<string>();
+    for (const [index, rule] of value.rules.entries()) {
+      if (ids.has(rule.id)) {
+        context.addIssue({
+          code: "custom",
+          path: ["rules", index, "id"],
+          message: `duplicate deletion rule id ${rule.id}`,
+        });
+      }
+      ids.add(rule.id);
+    }
+  });
+
+export type DeletionRules = z.infer<typeof deletionRulesSchema>;
+export type DeletionRule = DeletionRules["rules"][number];
+export type DeletionMatchClass = DeletionRule["match"]["type"];
+
+export interface DeletionCandidate {
+  readonly msgId: string;
+  readonly kind: string;
+}
+
+export interface DeletionReviewGroup {
+  readonly groupId: string;
+  readonly scope: "message" | "thread";
+  readonly platform: CorpusPlatform;
+  readonly messageIds: readonly string[];
+  readonly ruleIdHashes: readonly string[];
+  readonly matchClasses: readonly DeletionMatchClass[];
+  readonly redactedContext: string;
+  readonly suggestedDecision: "delete";
+}
+
+export interface DeletionReviewQueue {
+  readonly schemaVersion: 1;
+  readonly rulesetVersion: string;
+  readonly corpusDigest: string;
+  readonly rulesSha256: string;
+  readonly candidatesSha256: string;
+  readonly groups: readonly DeletionReviewGroup[];
+}
+
+const deletionMatchClassSchema = z.enum([
+  "contact",
+  "detector",
+  "keyword",
+  "label",
+  "thread",
+]);
+
+const deletionReviewGroupSchema = z
+  .object({
+    groupId: z.string().regex(SHA256_PATTERN),
+    scope: z.enum(["message", "thread"]),
+    platform: z.enum(corpusPlatforms),
+    messageIds: z.array(z.string().min(1)).min(1),
+    ruleIdHashes: z.array(z.string().regex(SHA256_PATTERN)).min(1),
+    matchClasses: z.array(deletionMatchClassSchema).min(1),
+    redactedContext: z
+      .string()
+      .min(1)
+      .refine((value) => [...value].length <= 60, {
+        message: "redacted context must be at most 60 Unicode characters",
+      }),
+    suggestedDecision: z.literal("delete"),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    for (const [name, values] of [
+      ["messageIds", value.messageIds],
+      ["ruleIdHashes", value.ruleIdHashes],
+      ["matchClasses", value.matchClasses],
+    ] as const) {
+      if (new Set(values).size !== values.length) {
+        context.addIssue({
+          code: "custom",
+          path: [name],
+          message: `${name} must be unique`,
+        });
+      }
+    }
+  });
+
+export const deletionReviewQueueSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    rulesetVersion: z.string().trim().min(1),
+    corpusDigest: z.string().regex(SHA256_PATTERN),
+    rulesSha256: z.string().regex(SHA256_PATTERN),
+    candidatesSha256: z.string().regex(SHA256_PATTERN),
+    groups: z.array(deletionReviewGroupSchema),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    const groupIds = new Set<string>();
+    const messageIds = new Set<string>();
+    for (const [groupIndex, group] of value.groups.entries()) {
+      if (groupIds.has(group.groupId)) {
+        context.addIssue({
+          code: "custom",
+          path: ["groups", groupIndex, "groupId"],
+          message: `duplicate deletion review group ${group.groupId}`,
+        });
+      }
+      groupIds.add(group.groupId);
+      for (const [messageIndex, messageId] of group.messageIds.entries()) {
+        if (messageIds.has(messageId)) {
+          context.addIssue({
+            code: "custom",
+            path: ["groups", groupIndex, "messageIds", messageIndex],
+            message: `message ${messageId} occurs in multiple review groups`,
+          });
+        }
+        messageIds.add(messageId);
+      }
+    }
+  });
+
+const reviewDecisionSchema = z
+  .object({
+    groupId: z.string().regex(SHA256_PATTERN),
+    decision: z.enum(["delete", "keep"]),
+  })
+  .strict();
+
+export const deletionReviewDecisionsSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    rulesetVersion: z.string().trim().min(1),
+    corpusDigest: z.string().regex(SHA256_PATTERN),
+    rulesSha256: z.string().regex(SHA256_PATTERN),
+    reviewedQueueSha256: z.string().regex(SHA256_PATTERN),
+    approved: z.literal(true),
+    reviewedBy: z.string().trim().min(1),
+    reviewedAt: z.string().datetime({ offset: true }),
+    decisions: z.array(reviewDecisionSchema),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    const ids = new Set<string>();
+    for (const [index, decision] of value.decisions.entries()) {
+      if (ids.has(decision.groupId)) {
+        context.addIssue({
+          code: "custom",
+          path: ["decisions", index, "groupId"],
+          message: `duplicate deletion decision for ${decision.groupId}`,
+        });
+      }
+      ids.add(decision.groupId);
+    }
+  });
+
+export type DeletionReviewDecisions = z.infer<
+  typeof deletionReviewDecisionsSchema
+>;
+
+export interface DeletionTombstoneMetadata {
+  readonly messageId: string;
+  readonly stage: "delete";
+  readonly stageVersion: string;
+  readonly outputHash: string;
+  readonly rulesSha256: string;
+  readonly reviewedQueueSha256: string;
+  readonly reviewDecisionSha256: string;
+  readonly ruleIdHashes: readonly string[];
+  readonly scope: "message" | "thread";
+}
+
+export interface DeletionApproval {
+  readonly schemaVersion: 1;
+  readonly rulesetVersion: string;
+  readonly approved: true;
+  readonly corpusDigest: string;
+  readonly candidatesSha256: string;
+  readonly rulesSha256: string;
+  readonly reviewedQueueSha256: string;
+  readonly reviewDecisionSha256: string;
+  readonly deleteStageVersion: string;
+  readonly tombstoneCount: number;
+  readonly tombstoneIdsSha256: string;
+  readonly survivorCount: number;
+  readonly attachmentBytesDropped: number;
+}
+
+export interface DeletionReport {
+  readonly schemaVersion: 1;
+  readonly rulesetVersion: string;
+  readonly corpusDigest: string;
+  readonly rulesSha256: string;
+  readonly reviewedQueueSha256: string;
+  readonly reviewDecisionSha256: string;
+  readonly inputMessages: number;
+  readonly survivorMessages: number;
+  readonly tombstoneCount: number;
+  readonly attachmentBytesDropped: number;
+  readonly countsByMatchClass: Readonly<Record<DeletionMatchClass, number>>;
+  readonly countsByScope: Readonly<Record<"message" | "thread", number>>;
+  readonly reportDigest: string;
+}
+
+export interface AppliedDeletion {
+  readonly survivors: readonly CorpusMessage[];
+  readonly tombstones: readonly DeletionTombstoneMetadata[];
+  readonly approval: DeletionApproval;
+  readonly report: DeletionReport;
+}
+
+interface RuleMatch {
+  readonly rule: DeletionRule;
+  readonly sensitiveTerms: readonly string[];
+}
+
+interface MutableReviewGroup {
+  scope: "message" | "thread";
+  platform: CorpusPlatform;
+  messageIds: Set<string>;
+  rules: Map<string, DeletionRule>;
+  sensitiveTerms: Set<string>;
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (typeof value === "object" && value !== null) {
+    return `{${Object.entries(value)
+      .filter(([, child]) => child !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, child]) => `${JSON.stringify(key)}:${canonicalJson(child)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+export function canonicalDeletionArtifactSha256(value: unknown): string {
+  return sha256(canonicalJson(value));
+}
+
+export function parseDeletionRules(value: unknown): DeletionRules {
+  return deletionRulesSchema.parse(value);
+}
+
+export function parseDeletionReviewDecisions(
+  value: unknown,
+): DeletionReviewDecisions {
+  return deletionReviewDecisionsSchema.parse(value);
+}
+
+export function parseDeletionReviewQueue(value: unknown): DeletionReviewQueue {
+  return deletionReviewQueueSchema.parse(value);
+}
+
+function normalized(value: string): string {
+  return value.normalize("NFKC").toLocaleLowerCase("en-US");
+}
+
+function threadKey(message: CorpusMessage): string {
+  return canonicalJson([message.platform, message.accountId, message.threadId]);
+}
+
+function messageFieldsForKeyword(
+  message: CorpusMessage,
+  fields: readonly (typeof deletionKeywordFields)[number][],
+): string[] {
+  const values: string[] = [];
+  for (const field of fields) {
+    switch (field) {
+      case "subject":
+        if (message.subject) values.push(message.subject);
+        break;
+      case "text":
+        values.push(message.text);
+        break;
+      case "snippet":
+        if (message.snippet) values.push(message.snippet);
+        break;
+      case "labels":
+        values.push(...message.labels);
+        break;
+      case "attachment-filename":
+        values.push(...message.attachments.map((item) => item.filename));
+        break;
+    }
+  }
+  return values;
+}
+
+function isWordCharacter(value: string | undefined): boolean {
+  return value !== undefined && /[\p{L}\p{N}_]/u.test(value);
+}
+
+function containsToken(haystack: string, needle: string): boolean {
+  let from = 0;
+  for (;;) {
+    const index = haystack.indexOf(needle, from);
+    if (index === -1) return false;
+    const before = index === 0 ? undefined : haystack[index - 1];
+    const after = haystack[index + needle.length];
+    if (!isWordCharacter(before) && !isWordCharacter(after)) return true;
+    from = index + Math.max(needle.length, 1);
+  }
+}
+
+function matchesRule(
+  message: CorpusMessage,
+  rule: DeletionRule,
+  candidateKindsByMessage: ReadonlyMap<string, ReadonlySet<string>>,
+): RuleMatch | undefined {
+  const match = rule.match;
+  switch (match.type) {
+    case "thread":
+      return message.platform === match.platform &&
+        message.accountId === match.accountId &&
+        message.threadId === match.threadId
+        ? { rule, sensitiveTerms: [match.threadId] }
+        : undefined;
+    case "contact": {
+      if (
+        message.platform !== match.platform ||
+        message.accountId !== match.accountId
+      ) {
+        return undefined;
+      }
+      const wanted = normalized(match.contactId);
+      const participants = [
+        message.senderId,
+        ...message.recipients.flatMap((recipient) => [
+          recipient.id,
+          ...(recipient.address ? [recipient.address] : []),
+        ]),
+      ];
+      return participants.some(
+        (participant) => normalized(participant) === wanted,
+      )
+        ? { rule, sensitiveTerms: [match.contactId] }
+        : undefined;
+    }
+    case "detector":
+      return candidateKindsByMessage.get(message.id)?.has(match.kind)
+        ? { rule, sensitiveTerms: [] }
+        : undefined;
+    case "keyword": {
+      const needle = normalized(match.value);
+      const matched = messageFieldsForKeyword(message, match.fields).some(
+        (value) => {
+          const haystack = normalized(value);
+          return match.mode === "substring"
+            ? haystack.includes(needle)
+            : containsToken(haystack, needle);
+        },
+      );
+      return matched ? { rule, sensitiveTerms: [match.value] } : undefined;
+    }
+    case "label":
+      return message.labels.some(
+        (label) => normalized(label) === normalized(match.value),
+      )
+        ? { rule, sensitiveTerms: [match.value] }
+        : undefined;
+  }
+}
+
+function replaceLiteralInsensitive(text: string, value: string): string {
+  if (!value) return text;
+  const lowerText = normalized(text);
+  const lowerValue = normalized(value);
+  if (lowerText.length !== text.length || lowerValue.length !== value.length) {
+    // Unicode normalization can change code-unit length. Avoid a lossy offset
+    // rewrite; the detector pass below still removes structured values and the
+    // queue remains local-only.
+    return text;
+  }
+  let result = text;
+  let search = lowerText;
+  let from = 0;
+  for (;;) {
+    const index = search.indexOf(lowerValue, from);
+    if (index === -1) return result;
+    result = `${result.slice(0, index)}[MATCH]${result.slice(index + value.length)}`;
+    search = normalized(result);
+    from = index + "[MATCH]".length;
+  }
+}
+
+function redactedContext(
+  message: CorpusMessage,
+  sensitiveTerms: readonly string[],
+): string {
+  let value = [message.subject, message.text, message.snippet]
+    .filter((item): item is string => Boolean(item))
+    .join(" — ");
+  for (const term of [...new Set(sensitiveTerms)].sort(
+    (left, right) => right.length - left.length,
+  )) {
+    value = replaceLiteralInsensitive(value, term);
+  }
+  for (const pattern of REVIEW_REDACT_PATTERNS) {
+    pattern.lastIndex = 0;
+    value = value.replace(pattern, "[REDACTED]");
+  }
+  value = value.replace(/\s+/g, " ").trim();
+  if (!value) return "[no textual preview]";
+  const characters = [...value];
+  return characters.length <= 60
+    ? value
+    : `${characters.slice(0, 59).join("")}…`;
+}
+
+function assertUniqueMessages(messages: readonly CorpusMessage[]): void {
+  const ids = new Set<string>();
+  for (const message of messages) {
+    if (ids.has(message.id)) {
+      throw new Error(`duplicate corpus message id ${message.id}`);
+    }
+    ids.add(message.id);
+  }
+}
+
+function assertDeletionStageInputs(messages: readonly CorpusMessage[]): void {
+  for (const message of messages) {
+    if (scrubStateRank[message.scrubState] < scrubStateRank.swapped) {
+      throw new Error(
+        `deletion requires swapped input; message ${message.id} is ${message.scrubState}`,
+      );
+    }
+  }
+}
+
+function rulesForHash(rules: DeletionRules): DeletionRules {
+  return {
+    ...rules,
+    rules: [...rules.rules].sort((left, right) =>
+      left.id.localeCompare(right.id),
+    ),
+  };
+}
+
+function corpusDigest(messages: readonly CorpusMessage[]): string {
+  return canonicalDeletionArtifactSha256(
+    [...messages].sort((left, right) => left.id.localeCompare(right.id)),
+  );
+}
+
+function candidateDigest(candidates: readonly DeletionCandidate[]): string {
+  return canonicalDeletionArtifactSha256(
+    candidates
+      .map((candidate) => ({
+        msgId: candidate.msgId,
+        kind: candidate.kind,
+      }))
+      .sort(
+        (left, right) =>
+          left.msgId.localeCompare(right.msgId) ||
+          left.kind.localeCompare(right.kind),
+      ),
+  );
+}
+
+export function buildDeletionReviewQueue(options: {
+  messages: readonly CorpusMessage[];
+  candidates: readonly DeletionCandidate[];
+  rules: unknown;
+}): DeletionReviewQueue {
+  const rules = parseDeletionRules(options.rules);
+  assertUniqueMessages(options.messages);
+  assertDeletionStageInputs(options.messages);
+  const messagesById = new Map(
+    options.messages.map((message) => [message.id, message]),
+  );
+  const candidateKindsByMessage = new Map<string, Set<string>>();
+  for (const candidate of options.candidates) {
+    if (!messagesById.has(candidate.msgId)) {
+      throw new Error(
+        `deletion candidate references missing message ${candidate.msgId}`,
+      );
+    }
+    if (!DETECTOR_KIND_PATTERN.test(candidate.kind)) {
+      throw new Error(`invalid deletion candidate kind ${candidate.kind}`);
+    }
+    const kinds = candidateKindsByMessage.get(candidate.msgId) ?? new Set();
+    kinds.add(candidate.kind);
+    candidateKindsByMessage.set(candidate.msgId, kinds);
+  }
+
+  const direct = new Map<string, RuleMatch[]>();
+  for (const message of options.messages) {
+    const matches = rules.rules
+      .filter((rule) => rule.enabled)
+      .map((rule) => matchesRule(message, rule, candidateKindsByMessage))
+      .filter((match): match is RuleMatch => match !== undefined);
+    if (matches.length > 0) direct.set(message.id, matches);
+  }
+
+  const threadGroups = new Map<string, MutableReviewGroup>();
+  const threadCoveredMessages = new Set<string>();
+  for (const [messageId, matches] of direct) {
+    const message = messagesById.get(messageId);
+    if (!message) throw new Error(`missing matched message ${messageId}`);
+    const threadMatches = matches.filter(
+      (match) => match.rule.scope === "thread",
+    );
+    if (threadMatches.length === 0) continue;
+    const key = threadKey(message);
+    const group = threadGroups.get(key) ?? {
+      scope: "thread" as const,
+      platform: message.platform,
+      messageIds: new Set<string>(),
+      rules: new Map<string, DeletionRule>(),
+      sensitiveTerms: new Set<string>(),
+    };
+    for (const related of options.messages.filter(
+      (candidate) => threadKey(candidate) === key,
+    )) {
+      group.messageIds.add(related.id);
+      threadCoveredMessages.add(related.id);
+    }
+    for (const match of threadMatches) {
+      group.rules.set(match.rule.id, match.rule);
+      for (const term of match.sensitiveTerms) group.sensitiveTerms.add(term);
+    }
+    threadGroups.set(key, group);
+  }
+
+  // Message-scoped matches inside an already selected thread are folded into
+  // that thread group so the owner cannot issue contradictory partial choices.
+  for (const group of threadGroups.values()) {
+    for (const messageId of group.messageIds) {
+      for (const match of direct.get(messageId) ?? []) {
+        group.rules.set(match.rule.id, match.rule);
+        for (const term of match.sensitiveTerms) group.sensitiveTerms.add(term);
+      }
+    }
+  }
+
+  const messageGroups: MutableReviewGroup[] = [];
+  for (const [messageId, matches] of direct) {
+    if (threadCoveredMessages.has(messageId)) continue;
+    const scoped = matches.filter((match) => match.rule.scope === "message");
+    if (scoped.length === 0) continue;
+    const message = messagesById.get(messageId);
+    if (!message) throw new Error(`missing matched message ${messageId}`);
+    messageGroups.push({
+      scope: "message",
+      platform: message.platform,
+      messageIds: new Set([messageId]),
+      rules: new Map(scoped.map((match) => [match.rule.id, match.rule])),
+      sensitiveTerms: new Set(scoped.flatMap((match) => match.sensitiveTerms)),
+    });
+  }
+
+  const groups = [...threadGroups.values(), ...messageGroups]
+    .map((group): DeletionReviewGroup => {
+      const messageIds = [...group.messageIds].sort();
+      const rulesInGroup = [...group.rules.values()].sort((left, right) =>
+        left.id.localeCompare(right.id),
+      );
+      const ruleIdHashes = rulesInGroup.map((rule) => sha256(rule.id));
+      const matchClasses = [
+        ...new Set(rulesInGroup.map((rule) => rule.match.type)),
+      ].sort() as DeletionMatchClass[];
+      const previewMessage = messagesById.get(messageIds[0]);
+      if (!previewMessage)
+        throw new Error("review group has no source message");
+      const groupId = canonicalDeletionArtifactSha256({
+        scope: group.scope,
+        platform: group.platform,
+        messageIds,
+        ruleIdHashes,
+      });
+      return {
+        groupId,
+        scope: group.scope,
+        platform: group.platform,
+        messageIds,
+        ruleIdHashes,
+        matchClasses,
+        redactedContext: redactedContext(previewMessage, [
+          ...group.sensitiveTerms,
+        ]),
+        suggestedDecision: "delete",
+      };
+    })
+    .sort((left, right) => left.groupId.localeCompare(right.groupId));
+
+  return {
+    schemaVersion: 1,
+    rulesetVersion: rules.rulesetVersion,
+    corpusDigest: corpusDigest(options.messages),
+    rulesSha256: canonicalDeletionArtifactSha256(rulesForHash(rules)),
+    candidatesSha256: candidateDigest(options.candidates),
+    groups,
+  };
+}
+
+function stripAttachmentBytes(message: CorpusMessage): CorpusMessage {
+  const attachments = message.attachments.map((attachment) => {
+    return {
+      filename: attachment.filename,
+      mimeType: attachment.mimeType,
+      sha256: attachment.sha256,
+    };
+  });
+  return { ...message, attachments };
+}
+
+function emptyMatchCounts(): Record<DeletionMatchClass, number> {
+  return {
+    contact: 0,
+    detector: 0,
+    keyword: 0,
+    label: 0,
+    thread: 0,
+  };
+}
+
+export function applyDeletionReview(options: {
+  messages: readonly CorpusMessage[];
+  queue: DeletionReviewQueue;
+  decisions: unknown;
+}): AppliedDeletion {
+  assertUniqueMessages(options.messages);
+  assertDeletionStageInputs(options.messages);
+  const queue = parseDeletionReviewQueue(options.queue);
+  const decisions = parseDeletionReviewDecisions(options.decisions);
+  const currentCorpusDigest = corpusDigest(options.messages);
+  const queueSha256 = canonicalDeletionArtifactSha256(queue);
+  for (const [name, expected, actual] of [
+    ["ruleset", queue.rulesetVersion, decisions.rulesetVersion],
+    ["corpus", queue.corpusDigest, decisions.corpusDigest],
+    ["rules", queue.rulesSha256, decisions.rulesSha256],
+    ["review queue", queueSha256, decisions.reviewedQueueSha256],
+    ["current corpus", queue.corpusDigest, currentCorpusDigest],
+  ] as const) {
+    if (expected !== actual) {
+      throw new Error(`deletion ${name} binding mismatch`);
+    }
+  }
+
+  const groupsById = new Map(
+    queue.groups.map((group) => [group.groupId, group]),
+  );
+  if (groupsById.size !== queue.groups.length) {
+    throw new Error("duplicate deletion review group id");
+  }
+  const decisionsById = new Map(
+    decisions.decisions.map((decision) => [decision.groupId, decision]),
+  );
+  for (const groupId of groupsById.keys()) {
+    if (!decisionsById.has(groupId)) {
+      throw new Error(`missing deletion decision for review group ${groupId}`);
+    }
+  }
+  for (const groupId of decisionsById.keys()) {
+    if (!groupsById.has(groupId)) {
+      throw new Error(
+        `unexpected deletion decision for review group ${groupId}`,
+      );
+    }
+  }
+
+  const messagesById = new Map(
+    options.messages.map((message) => [message.id, message]),
+  );
+  const deletionByMessage = new Map<string, DeletionReviewGroup>();
+  for (const group of queue.groups) {
+    if (decisionsById.get(group.groupId)?.decision !== "delete") continue;
+    for (const messageId of group.messageIds) {
+      if (!messagesById.has(messageId)) {
+        throw new Error(`review queue references missing message ${messageId}`);
+      }
+      if (deletionByMessage.has(messageId)) {
+        throw new Error(
+          `message ${messageId} belongs to multiple review groups`,
+        );
+      }
+      deletionByMessage.set(messageId, group);
+    }
+  }
+
+  const reviewDecisionSha256 = canonicalDeletionArtifactSha256(decisions);
+  const deleteStageVersion = `delete-v1:${queue.rulesSha256.slice(0, 12)}:${queueSha256.slice(0, 12)}:${reviewDecisionSha256.slice(0, 12)}`;
+  const survivors: CorpusMessage[] = [];
+  const tombstones: DeletionTombstoneMetadata[] = [];
+  let attachmentBytesDropped = 0;
+  for (const message of options.messages) {
+    attachmentBytesDropped += message.attachments.filter(
+      (attachment) =>
+        attachment.dataBase64 !== undefined || attachment.bytes !== undefined,
+    ).length;
+    const group = deletionByMessage.get(message.id);
+    if (group) {
+      const unsigned = {
+        messageId: message.id,
+        stage: "delete" as const,
+        stageVersion: deleteStageVersion,
+        rulesSha256: queue.rulesSha256,
+        reviewedQueueSha256: queueSha256,
+        reviewDecisionSha256,
+        ruleIdHashes: [...group.ruleIdHashes],
+        scope: group.scope,
+      };
+      tombstones.push({
+        ...unsigned,
+        outputHash: canonicalDeletionArtifactSha256({
+          tombstone: true,
+          ...unsigned,
+        }),
+      });
+      continue;
+    }
+    survivors.push(stripAttachmentBytes(message));
+  }
+
+  const matchCounts = emptyMatchCounts();
+  const scopeCounts: Record<"message" | "thread", number> = {
+    message: 0,
+    thread: 0,
+  };
+  const deletedGroups = new Map(
+    [...deletionByMessage.values()].map((group) => [group.groupId, group]),
+  );
+  for (const group of deletedGroups.values()) {
+    scopeCounts[group.scope] += 1;
+    for (const matchClass of group.matchClasses) matchCounts[matchClass] += 1;
+  }
+  const approval: DeletionApproval = {
+    schemaVersion: 1,
+    rulesetVersion: queue.rulesetVersion,
+    approved: true,
+    corpusDigest: queue.corpusDigest,
+    candidatesSha256: queue.candidatesSha256,
+    rulesSha256: queue.rulesSha256,
+    reviewedQueueSha256: queueSha256,
+    reviewDecisionSha256,
+    deleteStageVersion,
+    tombstoneCount: tombstones.length,
+    tombstoneIdsSha256: canonicalDeletionArtifactSha256(
+      tombstones.map((tombstone) => tombstone.messageId).sort(),
+    ),
+    survivorCount: survivors.length,
+    attachmentBytesDropped,
+  };
+  const unsignedReport = {
+    schemaVersion: 1 as const,
+    rulesetVersion: queue.rulesetVersion,
+    corpusDigest: queue.corpusDigest,
+    rulesSha256: queue.rulesSha256,
+    reviewedQueueSha256: queueSha256,
+    reviewDecisionSha256,
+    inputMessages: options.messages.length,
+    survivorMessages: survivors.length,
+    tombstoneCount: tombstones.length,
+    attachmentBytesDropped,
+    countsByMatchClass: matchCounts,
+    countsByScope: scopeCounts,
+  };
+  return {
+    survivors,
+    tombstones,
+    approval,
+    report: {
+      ...unsignedReport,
+      reportDigest: canonicalDeletionArtifactSha256(unsignedReport),
+    },
+  };
+}

--- a/packages/corpus-tools/src/pipeline/delete.ts
+++ b/packages/corpus-tools/src/pipeline/delete.ts
@@ -825,10 +825,35 @@ export function applyDeletionReview(options: {
   const tombstones: DeletionTombstoneMetadata[] = [];
   let attachmentBytesDropped = 0;
   for (const message of options.messages) {
-    attachmentBytesDropped += message.attachments.filter(
-      (attachment) =>
-        attachment.dataBase64 !== undefined || attachment.bytes !== undefined,
-    ).length;
+    for (const attachment of message.attachments) {
+      if (attachment.dataBase64 !== undefined) {
+        if (
+          !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(
+            attachment.dataBase64,
+          )
+        ) {
+          throw new Error(
+            `attachment ${attachment.sha256} has invalid base64 payload`,
+          );
+        }
+        const decoded = Buffer.from(attachment.dataBase64, "base64");
+        if (
+          decoded.toString("base64") !== attachment.dataBase64 ||
+          (attachment.bytes !== undefined &&
+            attachment.bytes !== decoded.length)
+        ) {
+          throw new Error(
+            `attachment ${attachment.sha256} has inconsistent payload bytes`,
+          );
+        }
+        attachmentBytesDropped += decoded.length;
+      } else if (attachment.bytes !== undefined) {
+        attachmentBytesDropped += attachment.bytes;
+      }
+      if (!Number.isSafeInteger(attachmentBytesDropped)) {
+        throw new Error("attachment byte total exceeds safe integer range");
+      }
+    }
     const group = deletionByMessage.get(message.id);
     if (group) {
       const unsigned = {

--- a/packages/corpus-tools/src/validator.ts
+++ b/packages/corpus-tools/src/validator.ts
@@ -144,11 +144,12 @@ export function validateCorpusMessages(
   return { ok: issues.length === 0, messages, issues };
 }
 
-export async function readCorpusShard(
+/** Parses caller-captured bytes so integrity-sensitive stages do not reopen a path. */
+export function parseCorpusShard(
+  raw: string,
   filePath: string,
   options: CorpusValidationOptions = {},
-): Promise<ShardReadResult> {
-  const raw = await fs.readFile(filePath, "utf8");
+): ShardReadResult {
   const rows: unknown[] = [];
   const issues: CorpusValidationIssue[] = [];
   const lines = raw.split(/\r?\n/).filter((line) => line.trim().length > 0);
@@ -197,6 +198,17 @@ export async function readCorpusShard(
     sha256: sha256(raw),
     issues: [...issues, ...result.issues],
   };
+}
+
+export async function readCorpusShard(
+  filePath: string,
+  options: CorpusValidationOptions = {},
+): Promise<ShardReadResult> {
+  return parseCorpusShard(
+    await fs.readFile(filePath, "utf8"),
+    filePath,
+    options,
+  );
 }
 
 export async function findCorpusShardFiles(

--- a/packages/corpus-tools/src/verification.test.ts
+++ b/packages/corpus-tools/src/verification.test.ts
@@ -7,6 +7,11 @@ import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { canonicalDeletionArtifactSha256 } from "./pipeline/delete.ts";
+import {
+  applyDeletionFiles,
+  planDeletionFiles,
+} from "./pipeline/delete-command.ts";
 import type { CorpusMessage } from "./schema.ts";
 import { buildCorpusManifest } from "./validator.ts";
 import {
@@ -449,6 +454,92 @@ describe("corpus verification", () => {
     await expect(
       assertFreshGreenVerification(report, options),
     ).rejects.toThrow();
+  });
+
+  it("accepts artifacts produced by reviewed deletion plan and apply", async () => {
+    const placeholder = defaultCanaryPlaceholder();
+    const finalMessage = baseMessage({ text: `Scrubbed body ${placeholder}` });
+    const options = await fixture(finalMessage, {
+      canaryPlaceholder: placeholder,
+    });
+    const root = path.dirname(path.dirname(options.targetPath));
+    const upstream = (await fs.readFile(options.ledgerPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>)
+      .filter(
+        (record) => record.stage === "mine" || record.stage === "secrets",
+      );
+    await fs.writeFile(
+      options.ledgerPath,
+      `${upstream.map((record) => JSON.stringify(record)).join("\n")}\n`,
+    );
+    const secretsRecord = upstream.find((record) => record.stage === "secrets");
+    if (!secretsRecord?.output) {
+      throw new Error("fixture is missing the secrets output");
+    }
+    const preDeletePath = path.join(root, "pre-delete");
+    const preDeleteShard = path.join(
+      preDeletePath,
+      "gmail",
+      "work",
+      "2026-06.jsonl",
+    );
+    await fs.mkdir(path.dirname(preDeleteShard), { recursive: true });
+    await fs.writeFile(
+      preDeleteShard,
+      `${JSON.stringify(secretsRecord.output)}\n`,
+    );
+    const rawRulesPath = path.join(root, "delete-rules-input.json");
+    await fs.copyFile(options.deletionRulesPath, rawRulesPath);
+    const queue = await planDeletionFiles({
+      targetPath: preDeletePath,
+      candidatesPath: options.candidatesPath,
+      rulesPath: rawRulesPath,
+      queuePath: options.deletionReviewQueuePath,
+      normalizedRulesPath: options.deletionRulesPath,
+    });
+    await writeJson(options.deletionReviewDecisionPath, {
+      schemaVersion: 1,
+      rulesetVersion: queue.rulesetVersion,
+      corpusDigest: queue.corpusDigest,
+      rulesSha256: queue.rulesSha256,
+      reviewedQueueSha256: canonicalDeletionArtifactSha256(queue),
+      approved: true,
+      reviewedBy: "test-owner",
+      reviewedAt: GENERATED_AT,
+      decisions: [],
+    });
+    const deleteOutputPath = path.join(root, "post-delete");
+    await applyDeletionFiles({
+      targetPath: preDeletePath,
+      candidatesPath: options.candidatesPath,
+      normalizedRulesPath: options.deletionRulesPath,
+      queuePath: options.deletionReviewQueuePath,
+      decisionsPath: options.deletionReviewDecisionPath,
+      outputPath: deleteOutputPath,
+      ledgerPath: options.ledgerPath,
+      manifestPath: path.join(root, "post-delete-manifest.json"),
+      approvalPath: options.deletionApprovalPath,
+      reportPath: path.join(root, "deletion-report.json"),
+    });
+    const deletedMessage = JSON.parse(
+      await fs.readFile(
+        path.join(deleteOutputPath, "gmail", "work", "2026-06.jsonl"),
+        "utf8",
+      ),
+    ) as CorpusMessage;
+    await fs.appendFile(
+      options.ledgerPath,
+      `${JSON.stringify(ledgerRecord(deletedMessage, finalMessage, "rewrite"))}\n${JSON.stringify(ledgerRecord(finalMessage, finalMessage, "llm"))}\n`,
+    );
+
+    const report = await verifyCorpus(options);
+
+    expect(report.findings, JSON.stringify(report.findings, null, 2)).toEqual(
+      [],
+    );
+    expect(report.status).toBe("passed");
   });
 
   it.each([


### PR DESCRIPTION
## Summary

Implements the reviewed sensitive-delete stage for #14769:

- strict JSON/YAML owner rules for contact, thread, detector, keyword, and label matches;
- deterministic, redacted, atomic review groups with message matches folded into selected threads;
- explicit plan/apply CLI commands with exact corpus/rules/candidate/queue/decision bindings;
- owner decisions required for every group, with stale/incomplete/extra decisions rejected;
- zero-content tombstones and payload-stripped survivors carrying exact review provenance;
- decoded attachment-byte accounting with strict base64 and declared-size validation;
- upstream secrets-ledger equality, canonical queue rebuild, ledger locking/idempotency, private file modes, non-overlapping paths, and atomic survivor output;
- manifest, approval, and counts-only report generation;
- a real CLI subprocess round-trip plus a producer→full-verifier contract test.

This does not close #14769: owner review and before/after counts on the real private corpus remain human-only acceptance evidence.

## Verification

- `bun run --cwd packages/corpus-tools test -- --reporter=dot` — 105 tests passed across 10 files
- `bun run --cwd packages/corpus-tools typecheck` — passed
- Biome on all touched corpus-tools sources — passed
- `bun run audit:error-policy-ratchet` — passed
- Real CLI subprocess test: plan → owner decision artifact → apply → idempotent re-apply — passed
- Full contract test: CLI-produced queue/approval/ledger artifacts → fail-closed corpus verifier — passed

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - CLI/library privacy workflow only; no rendered UI existed before or changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - CLI/library privacy workflow only; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no user-facing visual flow; CLI output and generated domain artifacts are the exercised surface.
<!-- evidence-row:backend-logs -->
- [x] Exact-head test and CLI log: https://github.com/elizaOS/eliza/releases/download/pr-evidence/15990-backend-verification.log
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code, browser request, or client state changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, action, provider, evaluator, planner, or model behavior changed; this is deterministic corpus processing.
<!-- evidence-row:domain-artifacts -->
- [x] Sanitized real-CLI domain test report: https://github.com/elizaOS/eliza/releases/download/pr-evidence/15990-domain-test.json. Raw owner data and review context are intentionally never uploaded.
