### PR TITLE
fix(scripts): exclude PR cards from MVP audit

### DIFF
--- a/packages/scripts/__tests__/mvp-board-readiness.test.ts
+++ b/packages/scripts/__tests__/mvp-board-readiness.test.ts
@@ -171,6 +171,24 @@ describe("MVP board readiness audit", () => {
     expect(report.issueCount).toBe(0);
   });
 
+  test("does not treat pull-request cards as project issues", () => {
+    const report = board.auditMvpBoardReadiness([issue(14490, ["mvp"])], {
+      items: [
+        {
+          ...projectItem(14490, "Done"),
+          content: {
+            ...projectItem(14490, "Done").content,
+            type: "PullRequest",
+          },
+        },
+      ],
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.issueCount).toBe(0);
+    expect(report.rows).toEqual([]);
+  });
+
   test("flags human-review status without a blocker label", () => {
     const report = board.auditMvpBoardReadiness([issue(15748, ["testing"])], {
       items: [projectItem(15748, "Needs human review")],

--- a/packages/scripts/__tests__/mvp-closeout-audit.test.ts
+++ b/packages/scripts/__tests__/mvp-closeout-audit.test.ts
@@ -45,6 +45,21 @@ function issue(number: number, labels: string[]) {
   };
 }
 
+function pullRequestItem(number: number, status = "Done") {
+  return {
+    content: {
+      type: "PullRequest",
+      number,
+      repository: "elizaOS/eliza",
+      title: `Pull request ${number}`,
+      url: `https://github.com/elizaOS/eliza/pull/${number}`,
+    },
+    title: `Pull request ${number}`,
+    status,
+    labels: ["mvp"],
+  };
+}
+
 function snapshot() {
   return {
     fetchedAt: "2026-07-09T20:00:00.000Z",
@@ -78,6 +93,20 @@ describe("atomic MVP closeout audit", () => {
       agentActionable: 1,
     });
     expect(report.readiness.agentActionableCount).toBe(1);
+    expect(report.parity.readiness).toEqual([1, 2]);
+    expect(report.parity.evidence).toEqual([1, 2]);
+  });
+
+  test("excludes Project pull-request cards from issue reconciliation", () => {
+    const withPullRequest = snapshot();
+    withPullRequest.project.items.push(pullRequestItem(14490));
+
+    const report = audit.buildCloseoutReport(withPullRequest);
+
+    expect(report.integrityOk).toBe(true);
+    expect(report.snapshot.projectItemCount).toBe(4);
+    expect(report.snapshot.projectIssueItemCount).toBe(3);
+    expect(report.board.counts.projectIssues).toBe(3);
     expect(report.parity.readiness).toEqual([1, 2]);
     expect(report.parity.evidence).toEqual([1, 2]);
   });

--- a/packages/scripts/check-mvp-board-readiness.mjs
+++ b/packages/scripts/check-mvp-board-readiness.mjs
@@ -183,10 +183,21 @@ export function projectItemMatchesRepo(item, repo = DEFAULT_REPO) {
   return !expectedRepo || !itemRepo || itemRepo === expectedRepo;
 }
 
+/**
+ * Project item-list mixes issues, pull requests, and draft cards. The MVP
+ * contract is issue-scoped, while older offline fixtures omit content.type;
+ * retain those fixtures but reject every explicitly non-Issue card.
+ */
+export function projectItemIsIssue(item) {
+  const type = item?.content?.type;
+  return type === undefined || type === "Issue";
+}
+
 export function normalizeProjectItems(payload, repo = DEFAULT_REPO) {
   const items = Array.isArray(payload) ? payload : (payload.items ?? []);
   const byNumber = new Map();
   for (const item of items) {
+    if (!projectItemIsIssue(item)) continue;
     if (!projectItemMatchesRepo(item, repo)) continue;
     const number = projectItemNumber(item);
     if (typeof number === "number") {

--- a/packages/scripts/run-mvp-closeout-audit.mjs
+++ b/packages/scripts/run-mvp-closeout-audit.mjs
@@ -17,6 +17,7 @@ import {
 import {
   auditMvpBoardReadiness,
   normalizeProjectItems,
+  projectItemIsIssue,
   projectItemMatchesRepo,
 } from "./check-mvp-board-readiness.mjs";
 
@@ -247,8 +248,8 @@ export function buildCloseoutReport(snapshot) {
   // evidence filter internally, so the board summary gets the filtered items
   // here lest a same-numbered cross-repo card donate its status to an eliza
   // issue.
-  const projectItems = snapshot.project.items.filter((item) =>
-    projectItemMatchesRepo(item, repo),
+  const projectItems = snapshot.project.items.filter(
+    (item) => projectItemIsIssue(item) && projectItemMatchesRepo(item, repo),
   );
   const board = summarizeMvpBoard({
     projectItems,
@@ -279,6 +280,7 @@ export function buildCloseoutReport(snapshot) {
       projectNumber: snapshot.projectNumber ?? null,
       repo,
       projectItemCount: snapshot.project.items.length,
+      projectIssueItemCount: projectItems.length,
       openIssueCount: snapshot.openIssues.length,
       closedIssueCount: snapshot.closedIssues.length,
     },


### PR DESCRIPTION
## What changed

- exclude explicitly non-Issue GitHub Project cards before MVP issue reconciliation
- report both total Project cards and issue-card counts in the atomic snapshot
- cover the real failure shape at the board-normalization and closeout-report layers

## Why

`gh project item-list` returns issues and pull requests together. Project 15 contains PR #14490, while the open/closed issue inventory correctly omits it, so the atomic closeout audit failed before it could report the board state. The audit contract is issue-scoped and must filter Project content by type before comparing inventories.

Closes #15758

## Validation

- `bun test packages/scripts/__tests__/mvp-closeout-audit.test.ts packages/scripts/__tests__/mvp-board-readiness.test.ts packages/scripts/__tests__/mvp-evidence-matrix.test.ts packages/scripts/__tests__/audit-mvp-project-board.test.ts` — 44 pass, 0 fail
- live `bun run mvp:closeout-audit -- --json` — integrity OK; parity OK; 205 Project cards; 204 issue cards; 17 current agent-actionable issues
- `bun run verify` — 573/573 Turbo tasks passed and diff-scoped audits found zero regressions; the final dist-path guard is blocked by the pre-existing stale `tsconfig.dist-paths.json` on `origin/develop`

## Evidence applicability

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - CLI audit and unit-test change only; no rendered UI surface changed.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - CLI audit and unit-test change only; no rendered UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - the changed behavior is a non-interactive JSON CLI report.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no backend runtime request, service, database, or worker path changed.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend code or network behavior changed.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, prompt, action, provider, model, or trajectory behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [live red/green Project snapshot and validation record](https://github.com/elizaOS/eliza/issues/15758#issuecomment-4933274520). The current live report distinguishes 205 total Project cards from 204 issue cards while preserving inventory parity.