### PR TITLE
fix(discord): duplicate slash-command menu entries — global commands re-registered per-guild (resubmit w/ test + two-guild evidence)

### DIFF
--- a/plugins/plugin-discord/__tests__/slash-command-registration-scope.test.ts
+++ b/plugins/plugin-discord/__tests__/slash-command-registration-scope.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Exercises the real Discord service registration method against an in-memory
+ * Discord API boundary so global and guild command scopes cannot overlap.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { DiscordService } from "../service";
+import type { DiscordSlashCommand } from "../types";
+
+const AGENT_ID = "11111111-1111-1111-1111-111111111111";
+
+function command(
+	name: string,
+	scope: { guildOnly?: boolean; guildIds?: string[] } = {},
+): DiscordSlashCommand {
+	return {
+		name,
+		description: `${name} command`,
+		...scope,
+		execute: vi.fn(async () => undefined),
+	} as unknown as DiscordSlashCommand;
+}
+
+function makeService() {
+	const globalAndGuildSet = vi.fn(async () => undefined);
+	const targetedCreate = vi.fn(async () => undefined);
+	const targetedFetch = vi.fn(async () => ({ find: () => undefined }));
+	const guild = {
+		id: "guild-a",
+		name: "Guild A",
+		fetch: vi.fn(async () => ({
+			commands: { fetch: targetedFetch, create: targetedCreate },
+		})),
+	};
+	const client = {
+		application: { commands: { set: globalAndGuildSet } },
+		guilds: { cache: new Map([[guild.id, guild]]) },
+	};
+	const state = {
+		accountId: "default",
+		clientReadyPromise: Promise.resolve(),
+		client,
+	};
+	const runtime = {
+		agentId: AGENT_ID,
+		logger: {
+			debug: vi.fn(),
+			error: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+		},
+	} as unknown as IAgentRuntime;
+	const service = Object.assign(Object.create(DiscordService.prototype), {
+		runtime,
+		slashCommands: [],
+		allowAllSlashCommands: new Set<string>(),
+		commandRegistrationQueue: Promise.resolve(),
+		requireAccountState: () => state,
+	}) as DiscordService;
+
+	return { globalAndGuildSet, service, targetedCreate };
+}
+
+describe("Discord slash-command registration scopes", () => {
+	it("keeps global commands out of guild scope while retaining guild-only and targeted commands", async () => {
+		const { globalAndGuildSet, service, targetedCreate } = makeService();
+
+		await service.registerSlashCommands([
+			command("global"),
+			command("guild-only", { guildOnly: true }),
+			command("targeted", { guildIds: ["guild-a"] }),
+		]);
+
+		expect(globalAndGuildSet).toHaveBeenNthCalledWith(
+			1,
+			expect.arrayContaining([expect.objectContaining({ name: "global" })]),
+		);
+		expect(globalAndGuildSet.mock.calls[0]?.[0]).toHaveLength(1);
+		expect(globalAndGuildSet).toHaveBeenNthCalledWith(
+			2,
+			[expect.objectContaining({ name: "guild-only" })],
+			"guild-a",
+		);
+		expect(targetedCreate).toHaveBeenCalledWith(
+			expect.objectContaining({ name: "targeted" }),
+		);
+	});
+
+	it("writes an empty guild scope to clear stale copies of global commands", async () => {
+		const { globalAndGuildSet, service } = makeService();
+
+		await service.registerSlashCommands([command("global")]);
+
+		expect(globalAndGuildSet).toHaveBeenNthCalledWith(1, [
+			expect.objectContaining({ name: "global" }),
+		]);
+		expect(globalAndGuildSet).toHaveBeenNthCalledWith(2, [], "guild-a");
+	});
+});

--- a/plugins/plugin-discord/discord-commands.ts
+++ b/plugins/plugin-discord/discord-commands.ts
@@ -78,8 +78,13 @@ export async function handleGuildCreate(
 	const clientApplication = service.client?.application;
 	if (service.slashCommands.length > 0 && clientApplication) {
 		try {
-			const generalCommands = service.slashCommands.filter(
-				(cmd) => (cmd.guildIds?.length ?? 0) === 0,
+			// Per-guild registration must NOT include general (non-guild-only)
+			// commands — those are registered GLOBALLY elsewhere, and pushing
+			// them into a guild's scope too made Discord merge the two scopes and
+			// show every command TWICE in the slash menu. Only guild-only and
+			// guild-targeted commands belong in a guild's scope.
+			const guildOnlyGeneralCommands = service.slashCommands.filter(
+				(cmd) => (cmd.guildIds?.length ?? 0) === 0 && isGuildOnlyCommand(cmd),
 			);
 
 			const targetedCommandsForThisGuild = service.slashCommands.filter((cmd) =>
@@ -87,32 +92,36 @@ export async function handleGuildCreate(
 			);
 
 			const commandMap = new Map<string, DiscordSlashCommand>();
-			for (const cmd of [...generalCommands, ...targetedCommandsForThisGuild]) {
+			for (const cmd of [
+				...guildOnlyGeneralCommands,
+				...targetedCommandsForThisGuild,
+			]) {
 				if (cmd.name) {
 					commandMap.set(cmd.name, cmd);
 				}
 			}
 			const commandsToRegister = Array.from(commandMap.values());
 
-			if (commandsToRegister.length > 0) {
-				const discordCommands = commandsToRegister.map((cmd) =>
-					transformCommandToDiscordApi(cmd),
-				);
-
-				await clientApplication.commands.set(discordCommands, fullGuild.id);
-				service.runtime.logger.info(
-					{
-						src: "plugin:discord",
-						agentId: service.runtime.agentId,
-						guildId: fullGuild.id,
-						guildName: fullGuild.name,
-						generalCount: generalCommands.length,
-						targetedCount: targetedCommandsForThisGuild.length,
-						totalCount: discordCommands.length,
-					},
-					"Commands registered to newly joined guild",
-				);
-			}
+			// Always set the guild scope (even to an empty array): when there are
+			// no guild-scoped commands, this CLEARS any stale guild-scoped copies
+			// of global commands a previous build registered, which is what
+			// removes the duplicate slash-menu entries.
+			const discordCommands = commandsToRegister.map((cmd) =>
+				transformCommandToDiscordApi(cmd),
+			);
+			await clientApplication.commands.set(discordCommands, fullGuild.id);
+			service.runtime.logger.info(
+				{
+					src: "plugin:discord",
+					agentId: service.runtime.agentId,
+					guildId: fullGuild.id,
+					guildName: fullGuild.name,
+					guildOnlyCount: guildOnlyGeneralCommands.length,
+					targetedCount: targetedCommandsForThisGuild.length,
+					totalCount: discordCommands.length,
+				},
+				"Guild-scoped commands synced (global commands live globally)",
+			);
 		} catch (error) {
 			service.runtime.logger.warn(
 				{

--- a/plugins/plugin-discord/service.ts
+++ b/plugins/plugin-discord/service.ts
@@ -740,10 +740,6 @@ export class DiscordService extends Service implements IDiscordService {
 				const transformedGuildOnlyCommands = guildOnlyCommands.map((cmd) =>
 					transformCommandToDiscordApi(cmd),
 				);
-				const transformedAllGeneralCommands = [
-					...transformedGlobalCommands,
-					...transformedGuildOnlyCommands,
-				];
 
 				const clientApp = client.application;
 				if (!clientApp) {
@@ -764,13 +760,19 @@ export class DiscordService extends Service implements IDiscordService {
 					);
 				}
 
+				// Per-guild registration pushes ONLY the guild-only commands. The
+				// global commands were already registered globally above; a guild
+				// also carrying them made Discord merge the global + guild scopes
+				// and show every command TWICE in the slash menu. Pushing the
+				// guild-only set (often empty) here also CLEARS any stale
+				// guild-scoped duplicates a previous build registered.
 				const guilds = client.guilds.cache;
-				if (guilds && transformedAllGeneralCommands.length > 0) {
+				if (guilds) {
 					await Promise.all(
 						[...guilds].map(async ([guildId, guild]) => {
 							try {
 								await clientApp.commands.set(
-									transformedAllGeneralCommands,
+									transformedGuildOnlyCommands,
 									guildId,
 								);
 							} catch (err) {


### PR DESCRIPTION
## What (resubmit of #15982 with the requested evidence + regression test)

Global slash commands were registered into **both** the global scope and every guild's scope, so Discord merged the two scopes and every command appeared **twice** in the slash menu. Two paths pushed the globals per-guild (`service.ts` `registerSlashCommands` and `discord-commands.ts` `handleGuildCreate`). Fix: register global commands **globally only**; a guild's scope gets **only** its guild-only + guild-targeted commands, and is set to `[]` when there are none so a prior build's stale guild-scoped copies clear.

Rebased on current `develop`. Includes the pinned regression test (`__tests__/slash-command-registration-scope.test.ts`) that drives the real `DiscordService` registration against an in-memory Discord API boundary.

## Regression test coverage (2/2 green)

- **"keeps global commands out of guild scope while retaining guild-only and targeted commands"** — asserts the global `commands.set` is called with the global set only, and the guild scope receives the guild-only + guild-targeted commands (the retention Shaw asked to prove).
- **"writes an empty guild scope to clear stale copies of global commands"** — asserts `set(globals)` globally + `set([], guildId)` per guild when there are no guild-scoped commands.

```
✓ __tests__/slash-command-registration-scope.test.ts (2 passed)
```

## Live evidence — two guilds, before/after

**Before** (production bot, 2 guilds) — every command doubled in the menu:
```
GLOBAL:          clear, help, model, search, settings, setup, status   (7)
GUILD NUBot-test: clear, help, model, search, settings, setup, status   (7)  ← dupes
GUILD Cozy-Devs:  clear, help, model, search, settings, setup, status   (7)  ← dupes
```

**After** (same bot head, restart) — global keeps 7, both guild scopes cleared to 0, survives restart:
```
GLOBAL:          7  (clear, help, model, search, settings, setup, status)
GUILD NUBot-test: 0
GUILD Cozy-Devs:  0
```

Redacted API calls used to verify (bot application-command endpoints):
```
GET  /applications/<APP>/commands                       → 200  [7 names above]
GET  /applications/<APP>/guilds/<guildA>/commands       → 200  [] (0)
GET  /applications/<APP>/guilds/<guildB>/commands       → 200  [] (0)
PUT  /applications/<APP>/guilds/<guild>/commands  body=[] → 200  (clears stale guild scope)
```

Restart log line proving the guild-sync fires and reports the split:
```
[plugin:discord] Guild-scoped commands synced (global commands live globally)
  guildOnlyCount=0 targetedCount=0 totalCount=0
```

Related: the same live debugging surfaced #15984 (/help honesty) — being reworked separately per review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
