### PR TITLE
test(scenarios): accept reminder create child routing

### DIFF
--- a/.github/workflows/live-scenarios.yml
+++ b/.github/workflows/live-scenarios.yml
@@ -193,8 +193,9 @@ jobs:
           fi
 
           package_dirs=(
-            plugins/plugin-local-inference
             plugins/plugin-sql
+            plugins/plugin-blocker
+            plugins/plugin-local-inference
             plugins/plugin-app-control
             plugins/plugin-agent-skills
             plugins/plugin-health

--- a/packages/scripts/__tests__/live-scenarios-workflow.test.ts
+++ b/packages/scripts/__tests__/live-scenarios-workflow.test.ts
@@ -16,3 +16,10 @@ test("builds the local-inference voice-workbench export before the scenario CLI 
     /package_dirs=\([\s\S]*plugins\/plugin-local-inference[\s\S]*\)[\s\S]*for package_dir in "\$\{package_dirs\[@\]\}"/,
   );
 });
+
+test("builds the blocker engine imported by personal-assistant scenarios", () => {
+  const workflow = readFileSync(workflowPath, "utf8");
+  expect(workflow).toMatch(
+    /package_dirs=\([\s\S]*plugins\/plugin-blocker[\s\S]*\)[\s\S]*for package_dir in "\$\{package_dirs\[@\]\}"/,
+  );
+});

--- a/packages/test/scenarios/cross-cutting/planner.missing-input-terminal-relay.assertion.ts
+++ b/packages/test/scenarios/cross-cutting/planner.missing-input-terminal-relay.assertion.ts
@@ -1,0 +1,70 @@
+/**
+ * Validates the action provenance and owner-facing result captured by the
+ * credentialed missing-input scenario without depending on model routing.
+ */
+import type { ScenarioTurnExecution } from "@elizaos/scenario-runner/schema";
+
+const FAILURE_RE =
+  /sorry, something went wrong|trajectory limit|try again|failed on my end/i;
+const FORM_RE = /^\[FORM\]\s*([\s\S]*)\s*\[\/FORM\]$/;
+const REMINDER_CREATE_ACTIONS = new Set([
+  "OWNER_REMINDERS",
+  "OWNER_REMINDERS_CREATE",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function validSchedulingForm(text: string): boolean {
+  const match = FORM_RE.exec(text);
+  if (!match?.[1]) return false;
+  try {
+    const payload: unknown = JSON.parse(match[1]);
+    if (!isRecord(payload) || !Array.isArray(payload.fields)) return false;
+    const names = payload.fields.flatMap((field) =>
+      isRecord(field) && typeof field.name === "string" ? [field.name] : [],
+    );
+    return names.includes("date") && names.includes("time");
+  } catch {
+    // error-policy:J3 invalid model-authored form JSON is an explicit failed match
+    return false;
+  }
+}
+
+export function expectMissingInputTerminalRelay(
+  execution: ScenarioTurnExecution,
+): string | undefined {
+  const response = execution.responseText?.trim() ?? "";
+  if (!response) return "missing-input turn returned an empty reply";
+  if (FAILURE_RE.test(response)) {
+    return `missing-input turn returned a synthetic failure: ${JSON.stringify(response)}`;
+  }
+  const reminder = execution.actionsCalled.find((action) =>
+    REMINDER_CREATE_ACTIONS.has(action.actionName),
+  );
+  if (!reminder?.result) {
+    const seen = execution.actionsCalled.map((action) => action.actionName);
+    return `no reminder-create action executed (saw: ${seen.join(", ")})`;
+  }
+  if (reminder.result.success !== true) {
+    return `reminder-create action did not succeed: ${JSON.stringify(reminder.result)}`;
+  }
+  if (
+    !isRecord(reminder.result.data) ||
+    reminder.result.data.awaitingUserInput !== true
+  ) {
+    return `reminder-create action lacked awaitingUserInput: ${JSON.stringify(reminder.result.data)}`;
+  }
+  if (!isRecord(reminder.result.raw)) {
+    return "reminder-create action lacked a raw action result";
+  }
+  const actionText = reminder.result.raw.userFacingText;
+  if (typeof actionText !== "string" || !actionText.trim()) {
+    return "reminder-create clarification lacked userFacingText";
+  }
+  if (!validSchedulingForm(response) && response !== actionText.trim()) {
+    return `reply was neither a scheduling form nor the action clarification: ${JSON.stringify(response)}`;
+  }
+  return undefined;
+}

--- a/packages/test/scenarios/cross-cutting/planner.missing-input-terminal-relay.scenario.ts
+++ b/packages/test/scenarios/cross-cutting/planner.missing-input-terminal-relay.scenario.ts
@@ -3,30 +3,7 @@
  * authorize a clarification or grammar-valid scheduling form.
  */
 import { scenario } from "@elizaos/scenario-runner/schema";
-
-const FAILURE_RE =
-  /sorry, something went wrong|trajectory limit|try again|failed on my end/i;
-const FORM_RE = /^\[FORM\]\s*([\s\S]*)\s*\[\/FORM\]$/;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
-function validSchedulingForm(text: string): boolean {
-  const match = FORM_RE.exec(text);
-  if (!match?.[1]) return false;
-  try {
-    const payload: unknown = JSON.parse(match[1]);
-    if (!isRecord(payload) || !Array.isArray(payload.fields)) return false;
-    const names = payload.fields.flatMap((field) =>
-      isRecord(field) && typeof field.name === "string" ? [field.name] : [],
-    );
-    return names.includes("date") && names.includes("time");
-  } catch {
-    // error-policy:J3 invalid model-authored form JSON is an explicit failed match
-    return false;
-  }
-}
+import { expectMissingInputTerminalRelay } from "./planner.missing-input-terminal-relay.assertion";
 
 export default scenario({
   id: "live-missing-input-terminal-relay",
@@ -48,34 +25,7 @@ export default scenario({
       name: "missing reminder fields finish as a user-visible interaction",
       room: "main",
       text: "I need a reminder for an upcoming report deadline — ask me for the report name, day, and time before creating anything.",
-      assertTurn: (execution) => {
-        const response = execution.responseText?.trim() ?? "";
-        if (!response) return "missing-input turn returned an empty reply";
-        if (FAILURE_RE.test(response)) {
-          return `missing-input turn returned a synthetic failure: ${JSON.stringify(response)}`;
-        }
-        const reminder = execution.actionsCalled.find(
-          (action) => action.actionName === "OWNER_REMINDERS",
-        );
-        if (!reminder?.result) return "OWNER_REMINDERS did not execute";
-        if (
-          !isRecord(reminder.result.data) ||
-          reminder.result.data.awaitingUserInput !== true
-        ) {
-          return `OWNER_REMINDERS lacked awaitingUserInput: ${JSON.stringify(reminder.result.data)}`;
-        }
-        if (!isRecord(reminder.result.raw)) {
-          return "OWNER_REMINDERS lacked a raw action result";
-        }
-        const actionText = reminder.result.raw.userFacingText;
-        if (typeof actionText !== "string" || !actionText.trim()) {
-          return "OWNER_REMINDERS clarification lacked userFacingText";
-        }
-        if (!validSchedulingForm(response) && response !== actionText.trim()) {
-          return `reply was neither a scheduling form nor the action clarification: ${JSON.stringify(response)}`;
-        }
-        return undefined;
-      },
+      assertTurn: expectMissingInputTerminalRelay,
     },
   ],
 });

--- a/packages/test/scenarios/cross-cutting/planner.missing-input-terminal-relay.test.ts
+++ b/packages/test/scenarios/cross-cutting/planner.missing-input-terminal-relay.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Pins the missing-input live scenario's action provenance before credentialed
+ * execution so parent and generated child routes share the same strict result bar.
+ */
+import { describe, expect, test } from "bun:test";
+import type { CapturedAction } from "@elizaos/scenario-runner/schema";
+import { expectMissingInputTerminalRelay } from "./planner.missing-input-terminal-relay.assertion";
+
+const CLARIFICATION =
+  "What’s the report name, what day is it due, and what time should I use?";
+
+function action(
+  actionName: string,
+  overrides: Partial<NonNullable<CapturedAction["result"]>> = {},
+): CapturedAction {
+  return {
+    actionName,
+    result: {
+      success: true,
+      data: { awaitingUserInput: true },
+      raw: { userFacingText: CLARIFICATION },
+      ...overrides,
+    },
+  };
+}
+
+function evaluate(candidate: CapturedAction, responseText = CLARIFICATION) {
+  return expectMissingInputTerminalRelay({
+    actionsCalled: [candidate],
+    responseText,
+  });
+}
+
+describe("missing-input terminal relay scenario", () => {
+  test("accepts the parent reminder action", () => {
+    expect(evaluate(action("OWNER_REMINDERS"))).toBeUndefined();
+  });
+
+  test("accepts the generated reminder-create child", () => {
+    expect(evaluate(action("OWNER_REMINDERS_CREATE"))).toBeUndefined();
+  });
+
+  test("rejects an unrelated action even when its payload copies the markers", () => {
+    expect(evaluate(action("OWNER_ROUTINES_CREATE"))).toMatch(
+      /no reminder-create action executed/,
+    );
+  });
+
+  test("requires successful execution and explicit missing-input authority", () => {
+    expect(
+      evaluate(action("OWNER_REMINDERS_CREATE", { success: false })),
+    ).toMatch(/did not succeed/);
+    expect(
+      evaluate(
+        action("OWNER_REMINDERS_CREATE", {
+          data: { awaitingUserInput: false },
+        }),
+      ),
+    ).toMatch(/lacked awaitingUserInput/);
+  });
+
+  test("rejects model paraphrase that is not a valid scheduling form", () => {
+    expect(evaluate(action("OWNER_REMINDERS_CREATE"), "Tell me more.")).toMatch(
+      /neither a scheduling form nor the action clarification/,
+    );
+  });
+});


### PR DESCRIPTION
# Relates to

Fixes #15995
Follow-up to #15988

# Summary

The live missing-input scenario now accepts either the parent `OWNER_REMINDERS` action or its valid `OWNER_REMINDERS_CREATE` child route. Both surfaces execute the same handler and return the canonical parent result; the assertion continues to require `awaitingUserInput: true` plus the exact action-owned clarification or a valid scheduling form.

# Testing

- `bun run --cwd packages/scenario-runner test -- src/action-effect-ratchet.test.ts src/__tests__/deterministic-action-coverage.test.ts` — 19 passed.
- Full `@elizaos/scenario-runner` suite — 273 passed.
- Live Codex `gpt-5.4` scenario after the assertion fix — passed with 3/3 native calls and zero privacy residuals.
- Live pre-fix reproduction selected `OWNER_REMINDERS_CREATE`, returned the correct `awaitingUserInput` result and exact question, then failed only the parent-name assertion.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this is a live scenario assertion, not a visual interaction flow.
<!-- evidence-row:backend-logs -->
- [x] [pre-fix child-route log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15997-before-child-console.log) and [post-fix passing log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15997-after-pass-console.log).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser request path changed.
<!-- evidence-row:llm-trajectory -->
- [x] [pre-fix child-route Codex trajectory](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15997-before-child-trajectory.json) and [post-fix passing Codex trajectory](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15997-after-pass-trajectory.json).
<!-- evidence-row:domain-artifacts -->
- [x] Pre-fix child route: [report](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15997-before-child-report.json), [native JSONL](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15997-before-child-native.jsonl), [manifest](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15997-before-child-native-manifest.json), [privacy attestation](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15997-before-child-privacy-attestation.json). Post-fix pass: [report](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15997-after-pass-report.json), [native JSONL](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15997-after-pass-native.jsonl), [manifest](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15997-after-pass-native-manifest.json), [privacy attestation](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15997-after-pass-privacy-attestation.json).

# Manual review

- Pre-fix child route: opened the report and trajectory; `OWNER_REMINDERS_CREATE` succeeded, returned `noop + awaitingUserInput`, and the exact action-owned question reached the user. The sole failure was `OWNER_REMINDERS did not execute`.
- Post-fix run: opened the report, trajectory, and native export; scenario passed, `OWNER_REMINDERS` returned explicit missing-input authority, and the exact action-owned question reached the user.
- Both strict native exports reported zero residual privacy findings.