### PR TITLE
fix(mobile): keep cloud-hybrid on the on-device agent across cold launches

### DIFF
--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
@@ -3842,8 +3842,9 @@ public class ElizaAgentService extends Service {
         String mode = readRuntimeMode(context);
         long totalMemBytes = readDeviceTotalMemBytes(context);
         boolean deviceAllowsLocalAgent = DeviceRamTierPolicy.allowsLocalAgent(totalMemBytes);
+        boolean deviceAllowsHybridAgent = DeviceRamTierPolicy.allowsHybridAgent(totalMemBytes);
         boolean start = shouldAutoStartForRuntimeMode(
-            isBrandedDevice(), mode, deviceAllowsLocalAgent);
+            isBrandedDevice(), mode, deviceAllowsLocalAgent, deviceAllowsHybridAgent);
         String trimmed = mode == null ? null : mode.trim();
         if (!start && "local".equals(trimmed) && !deviceAllowsLocalAgent) {
             // Fail loud (#14390): a persisted local choice on a device below the
@@ -3860,9 +3861,18 @@ public class ElizaAgentService extends Service {
     }
 
     static boolean shouldAutoStartForRuntimeMode(
-            boolean brandedDevice, String mode, boolean deviceAllowsLocalAgent) {
+            boolean brandedDevice, String mode, boolean deviceAllowsLocalAgent,
+            boolean deviceAllowsHybridAgent) {
         if (brandedDevice) return true;
         String trimmed = mode == null ? null : mode.trim();
+        // A committed cloud-hybrid runtime (cloud inference + an on-device agent
+        // process that still owns plugins, the voice bridge, and device control)
+        // needs the agent booted on cold launch — it just clears the lower 4 GB
+        // hybrid floor instead of the 8 GB local floor (DeviceRamTierPolicy,
+        // #15577). A fresh install (mode == null) matches neither branch, so it
+        // still never auto-starts before the user commits a choice (#15189);
+        // the shipped cloud-only APK (mode "cloud") likewise never starts one.
+        if ("cloud-hybrid".equals(trimmed)) return deviceAllowsHybridAgent;
         return "local".equals(trimmed) && deviceAllowsLocalAgent;
     }
 

--- a/packages/app-core/platforms/android/app/src/test/java/ai/elizaos/app/ElizaAgentAutostartPolicyTest.java
+++ b/packages/app-core/platforms/android/app/src/test/java/ai/elizaos/app/ElizaAgentAutostartPolicyTest.java
@@ -10,63 +10,82 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 /**
- * JVM unit tests for the stock-Android local-agent autostart policy (#14390).
- * Only two things may auto-start the bundled agent: a branded device (the
- * device IS the agent) or an explicit onboarding "local" choice on a device
- * that clears the RAM-tier floor. A fresh install (no persisted mode) never
- * auto-starts — onboarding owns the decision and the renderer starts the
- * service on demand through the Agent Capacitor plugin — and a persisted
- * "local" on a RAM-blocked device is refused instead of wedging boot.
+ * JVM unit tests for the stock-Android local-agent autostart policy (#14390,
+ * #15577). Three things may auto-start the bundled agent: a branded device (the
+ * device IS the agent); an explicit onboarding "local" choice on a device that
+ * clears the 8 GB local floor; or an explicit "cloud-hybrid" choice on a device
+ * that clears the lower 4 GB hybrid floor (cloud inference, but the on-device
+ * agent still owns plugins, the voice bridge, and device control). A fresh
+ * install (no persisted mode) never auto-starts — onboarding owns the decision
+ * — and a persisted mode the device can no longer honor is refused instead of
+ * wedging boot.
  */
 public class ElizaAgentAutostartPolicyTest {
 
-    private static final boolean RAM_OK = true;
-    private static final boolean RAM_BLOCKED = false;
+    // The two mode-specific RAM verdicts the gate now takes independently: a
+    // 6 GB phone (LP3) clears the 4 GB hybrid floor but not the 8 GB local one.
+    private static final boolean LOCAL_OK = true;
+    private static final boolean LOCAL_BLOCKED = false;
+    private static final boolean HYBRID_OK = true;
+    private static final boolean HYBRID_BLOCKED = false;
 
     @Test
     public void brandedDevicesAlwaysStartTheBundledAgent() {
-        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, null, RAM_OK));
-        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, null, RAM_BLOCKED));
-        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, "cloud", RAM_OK));
-        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, "remote-mac", RAM_BLOCKED));
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, null, LOCAL_OK, HYBRID_OK));
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, null, LOCAL_BLOCKED, HYBRID_BLOCKED));
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, "cloud", LOCAL_OK, HYBRID_OK));
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, "remote-mac", LOCAL_BLOCKED, HYBRID_BLOCKED));
     }
 
     @Test
     public void stockFreshInstallNeverAutoStarts() {
         // The runtime decision belongs to onboarding: with no persisted mode the
         // renderer must land in first-run, then start the service explicitly
-        // once the user commits to the local runtime.
-        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, null, RAM_OK));
-        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "", RAM_OK));
-        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "   ", RAM_OK));
-        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, null, RAM_BLOCKED));
+        // once the user commits to a runtime — even on a device that clears both
+        // RAM floors.
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, null, LOCAL_OK, HYBRID_OK));
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "", LOCAL_OK, HYBRID_OK));
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "   ", LOCAL_OK, HYBRID_OK));
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, null, LOCAL_BLOCKED, HYBRID_BLOCKED));
     }
 
     @Test
-    public void stockCloudModesStayCloudFirst() {
-        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "cloud", RAM_OK));
-        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "cloud-hybrid", RAM_OK));
+    public void stockPureCloudStaysCloudFirst() {
+        // Pure cloud never runs an on-device agent, regardless of RAM headroom.
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "cloud", LOCAL_OK, HYBRID_OK));
+    }
+
+    @Test
+    public void stockCloudHybridStartsTheBundledAgentWhenHybridRamAllows() {
+        // cloud-hybrid needs the on-device agent (plugins, voice bridge, device
+        // control) and clears the lower 4 GB hybrid floor — so a 6 GB LP3
+        // (hybrid-OK but local-blocked) auto-starts, and a phone below the
+        // hybrid floor does not.
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "cloud-hybrid", LOCAL_BLOCKED, HYBRID_OK));
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(false, " cloud-hybrid ", LOCAL_BLOCKED, HYBRID_OK));
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "cloud-hybrid", LOCAL_BLOCKED, HYBRID_BLOCKED));
     }
 
     @Test
     public void stockExternalModesDoNotStartTheBundledAgent() {
-        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "remote-mac", RAM_OK));
-        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "tunnel-to-mobile", RAM_OK));
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "remote-mac", LOCAL_OK, HYBRID_OK));
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "tunnel-to-mobile", LOCAL_OK, HYBRID_OK));
     }
 
     @Test
     public void stockLocalModeStartsTheBundledAgentWhenRamAllows() {
-        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "local", RAM_OK));
-        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(false, " local ", RAM_OK));
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "local", LOCAL_OK, HYBRID_OK));
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(false, " local ", LOCAL_OK, HYBRID_OK));
     }
 
     @Test
     public void stockLocalModeIsRefusedBelowTheRamFloor() {
         // A persisted "local" survives reinstalls via Capacitor Preferences, so
         // a low-RAM device can carry one it can no longer honor — refusing here
-        // is what keeps a 4 GB phone from wedging boot for the 180 s budget.
-        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "local", RAM_BLOCKED));
-        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, " local ", RAM_BLOCKED));
+        // is what keeps a 6 GB phone from wedging boot for the 180 s budget even
+        // though it clears the lower hybrid floor.
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "local", LOCAL_BLOCKED, HYBRID_OK));
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, " local ", LOCAL_BLOCKED, HYBRID_OK));
     }
 
     @Test

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -1148,7 +1148,16 @@ async function buildWeb(platform) {
       process.env.ELIZA_RELEASE_AUTHORITY || releaseAuthority,
     ...(androidRuntimeMode
       ? {
-          VITE_ELIZA_ANDROID_RUNTIME_MODE: androidRuntimeMode,
+          // A pre-set VITE_ELIZA_ANDROID_RUNTIME_MODE (the value Vite bakes into
+          // the renderer) wins over the platform-policy default, mirroring the
+          // iOS override below and ELIZA_BUILD_VARIANT above. This is the env
+          // knob for an off-catalog Android runtime mode — e.g.
+          // `VITE_ELIZA_ANDROID_RUNTIME_MODE=cloud-hybrid bun run build:android`
+          // builds a hybrid APK (cloud inference, on-device agent, 4 GB floor)
+          // without a dedicated platform target. Without this, spreading the
+          // policy value clobbered an explicitly chosen mode.
+          VITE_ELIZA_ANDROID_RUNTIME_MODE:
+            process.env.VITE_ELIZA_ANDROID_RUNTIME_MODE || androidRuntimeMode,
         }
       : {}),
     ...(iosRuntimeMode

--- a/packages/ui/src/state/first-run-bootstrap.ts
+++ b/packages/ui/src/state/first-run-bootstrap.ts
@@ -54,9 +54,23 @@ function hasPersistedExistingInstallConfig(
   );
 }
 
+/** Delay between existing-install probes while waiting for a booting agent. */
+const BOOTING_AGENT_RETRY_MS = 1_000;
+
 export async function detectExistingFirstRunConnection(args: {
   client: ExistingFirstRunProbeClient;
   timeoutMs: number;
+  /**
+   * True when a committed on-device runtime (mobile `cloud-hybrid` / `local`)
+   * is persisted, so the native service WILL bring the bundled agent up. The
+   * agent's cold boot takes ~30s on a low-power phone (LP3) — far longer than
+   * the single-shot probe — so without waiting, a returning hybrid user is
+   * dropped back into first-run on every cold launch while the agent is still
+   * booting. When set, keep retrying the unreachable probe until the agent
+   * answers or the outer timeout fires. A genuinely fresh install leaves this
+   * false and keeps the fast single-shot (no re-onboarding delay).
+   */
+  waitForBootingAgent?: boolean;
 }): Promise<ExistingFirstRunProbeResult | null> {
   if (!args.client.apiAvailable) {
     return null;
@@ -64,36 +78,54 @@ export async function detectExistingFirstRunConnection(args: {
 
   const timeoutToken = Symbol("first-run-bootstrap-timeout");
   let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  let timedOut = false;
   const result = await Promise.race([
     (async () => {
-      // error-policy:J4 existing-install probe — an unreachable agent means
-      // "no existing install detected" and first-run proceeds normally
-      const status = await args.client.getFirstRunStatus().catch(() => null);
-      if (!status) {
-        return null;
-      }
+      for (;;) {
+        if (timedOut) {
+          return null;
+        }
+        // error-policy:J4 existing-install probe — an unreachable agent means
+        // "no existing install detected" and first-run proceeds normally,
+        // unless we are waiting for a known-booting on-device agent (below).
+        const status = await args.client.getFirstRunStatus().catch(() => null);
+        if (status) {
+          if (status.complete) {
+            return {
+              activeServer: LOCAL_ACTIVE_SERVER,
+              detectedExistingInstall: true,
+            } satisfies ExistingFirstRunProbeResult;
+          }
 
-      if (status.complete) {
-        return {
-          activeServer: LOCAL_ACTIVE_SERVER,
-          detectedExistingInstall: true,
-        } satisfies ExistingFirstRunProbeResult;
-      }
+          // error-policy:J4 same probe semantics — the agent answered but has
+          // no existing install, so first-run proceeds normally.
+          const config = await args.client.getConfig().catch(() => null);
+          if (!hasPersistedExistingInstallConfig(config)) {
+            return null;
+          }
 
-      // error-policy:J4 same probe semantics — no readable config means "no
-      // existing install detected"
-      const config = await args.client.getConfig().catch(() => null);
-      if (!hasPersistedExistingInstallConfig(config)) {
-        return null;
-      }
+          return {
+            activeServer: LOCAL_ACTIVE_SERVER,
+            detectedExistingInstall: true,
+          } satisfies ExistingFirstRunProbeResult;
+        }
 
-      return {
-        activeServer: LOCAL_ACTIVE_SERVER,
-        detectedExistingInstall: true,
-      } satisfies ExistingFirstRunProbeResult;
+        // Agent unreachable. A fresh install proceeds straight to first-run; a
+        // committed on-device runtime waits for its still-booting agent (the
+        // outer Promise.race caps the total wait at timeoutMs).
+        if (!args.waitForBootingAgent) {
+          return null;
+        }
+        await new Promise((resolve) =>
+          setTimeout(resolve, BOOTING_AGENT_RETRY_MS),
+        );
+      }
     })(),
     new Promise<typeof timeoutToken>((resolve) => {
-      timeoutId = setTimeout(() => resolve(timeoutToken), args.timeoutMs);
+      timeoutId = setTimeout(() => {
+        timedOut = true;
+        resolve(timeoutToken);
+      }, args.timeoutMs);
     }),
   ]);
   if (timeoutId !== null) {

--- a/packages/ui/src/state/persistence-cloud-active-server.test.ts
+++ b/packages/ui/src/state/persistence-cloud-active-server.test.ts
@@ -314,6 +314,27 @@ describe("Cloud active server persistence", () => {
     });
   });
 
+  it("keeps the on-device agent record under cloud-hybrid (LP3 hybrid re-onboarded every cold launch)", () => {
+    // cloud-hybrid = on-device agent chat + cloud inference, so the persisted
+    // mobile-local record is valid — rejecting it here cleared it +
+    // savePersistedFirstRunComplete(false) on every cold launch, bouncing a
+    // returning hybrid user into first-run while the still-booting agent (~30s
+    // on the LP3) was unreachable.
+    const server = {
+      id: "local:android",
+      kind: "remote" as const,
+      label: "On-device agent",
+      apiBase: "eliza-local-agent://ipc",
+    };
+    expect(
+      reconcileMobileRestoredActiveServer({
+        platform: "android",
+        mobileRuntimeMode: "cloud-hybrid",
+        server,
+      }),
+    ).toBeUndefined();
+  });
+
   it("logs a warning instead of silently swallowing a failed active-server persist", () => {
     const server = createPersistedActiveServer({
       id: "cloud:agent-warn",

--- a/packages/ui/src/state/startup-phase-restore.ts
+++ b/packages/ui/src/state/startup-phase-restore.ts
@@ -205,7 +205,18 @@ export function reconcileMobileRestoredActiveServer(args: {
 }): PersistedActiveServer | null | undefined {
   const { server, mobileRuntimeMode, platform } = args;
   const mobileLocal = isMobileLocalActiveServer(server);
-  if (mobileLocal && mobileRuntimeMode !== "local") {
+  // The on-device agent is the chat target for BOTH "local" and "cloud-hybrid"
+  // runtimes — cloud-hybrid = on-device agent + cloud inference, and
+  // first-run-finish persists active-server=local:android together with
+  // mode=cloud-hybrid. Rejecting the mobile-local record for cloud-hybrid
+  // cleared it + savePersistedFirstRunComplete(false) on every cold launch,
+  // dropping a returning hybrid user back into first-run while the still-booting
+  // on-device agent was unreachable (LP3 ~30s boot).
+  if (
+    mobileLocal &&
+    mobileRuntimeMode !== "local" &&
+    mobileRuntimeMode !== "cloud-hybrid"
+  ) {
     return null;
   }
 
@@ -614,13 +625,26 @@ export async function runRestoringSession(
   // Probe the API when there is evidence of a prior install, or when no
   // persisted server exists (covers headless/VPS setups where config was
   // set via files without going through UI firstRun).
+  // A committed mobile on-device runtime (cloud-hybrid / local) means the
+  // native service is bringing the bundled agent up right now; its ~30s cold
+  // boot on a low-power phone outlasts the 3.5s single-shot probe, so wait for
+  // it instead of dropping the returning user back into first-run every cold
+  // launch. A fresh install (no committed mode) keeps the fast single-shot.
+  const committedMobileOnDeviceMode =
+    (isAndroid || isIOS) &&
+    ((mode) => mode === "local" || mode === "cloud-hybrid")(
+      readPersistedMobileRuntimeMode(),
+    );
   const probed =
     !forceFreshFirstRun && !persistedActiveServer && !isDevUiPort()
       ? await detectExistingFirstRunConnection({
           client,
           timeoutMs: isDesktop
             ? Math.min(getBackendStartupTimeoutMs(), 30_000)
-            : Math.min(getBackendStartupTimeoutMs(), 3_500),
+            : committedMobileOnDeviceMode
+              ? Math.min(getBackendStartupTimeoutMs(), 45_000)
+              : Math.min(getBackendStartupTimeoutMs(), 3_500),
+          waitForBootingAgent: committedMobileOnDeviceMode,
         })
       : null;
   if (cancelled.current) return;


### PR DESCRIPTION
## Problem

On Android, the **cloud-hybrid** runtime (on-device agent + cloud inference) re-ran onboarding on **every cold launch** — the user landed on the runtime picker instead of chat, and had to re-select "On this device" → "Eliza Cloud inference" each time.

## Root cause

Traced on a real device (6 GB Light Phone III, ~30 s agent cold boot):

1. **Renderer (the actual bug).** `reconcileMobileRestoredActiveServer` accepted a persisted on-device (`mobile-local`) active-server **only for `mode === "local"`**, never `"cloud-hybrid"`. But `first-run-finish` persists `active-server = local:android` **together with** `mode = cloud-hybrid` (cloud-hybrid = on-device agent chat + cloud inference). So on every cold launch it returned `null` → `clearPersistedActiveServer()` + `savePersistedFirstRunComplete(false)` → `phase=first-run-required` while the still-booting agent was unreachable.

   Device log at boot (agent not up yet):
   ```
   Preferences remove {"key":"eliza:first-run-complete"}
   [startup-coordinator] phase=first-run-required
   ```
   …then ~23 s later the agent finally answered `{"meta":{"firstRunComplete":true}}` — too late.

2. **Probe patience.** `detectExistingFirstRunConnection` (the fallback path) used a **3.5 s single-shot** probe on mobile — hopeless against a ~30 s agent boot.

3. **Native never auto-started** the agent for cloud-hybrid; `shouldAutoStart` only handled `"local"` (8 GB floor) — but the LP3 clears only the 4 GB hybrid floor.

## Changes

**Renderer**
- `reconcileMobileRestoredActiveServer`: accept the mobile-local record under **`cloud-hybrid`** as well as `local`.
- `detectExistingFirstRunConnection`: `waitForBootingAgent` retries the existing-install probe while a committed on-device runtime boots (up to 45 s), instead of the 3.5 s single-shot. **Fresh installs keep the fast single-shot** (no re-onboarding delay).

**Native (Android)**
- `ElizaAgentService.shouldAutoStart`: auto-start the on-device agent on cold launch for a committed **`cloud-hybrid`** mode (4 GB floor), not only `local`. Fresh install (`mode == null`) and shipped `cloud` mode **still never auto-start** (#15189 preserved).

**Build**
- `run-mobile-build`: honor a pre-set `VITE_ELIZA_ANDROID_RUNTIME_MODE` over the platform-policy default (iOS already did this), so `VITE_ELIZA_ANDROID_RUNTIME_MODE=cloud-hybrid bun run build:web` produces a hybrid APK without a dedicated platform target.

## Tests
- Unit: `reconcileMobileRestoredActiveServer` keeps the on-device record under `cloud-hybrid` (`persistence-cloud-active-server.test.ts`).
- Unit: 4-arg autostart gate — `cloud-hybrid` starts when the hybrid floor is met, is refused below it, and fresh/`cloud`/`local`-below-floor still don't start (`ElizaAgentAutostartPolicyTest.java`).

## On-device evidence (real LP3, `cloud-hybrid` build)

**Before:** runtime picker + "Sign in to start chatting" on every cold launch.

**After — 3 consecutive cold launches (force-stop + relaunch):**
```
launch#1: agentState=running  startupPhase=ready  first-run-required-count=0
launch#2: agentState=running  startupPhase=ready  first-run-required-count=0
launch#3: agentState=running  startupPhase=ready  first-run-required-count=0
```
Each lands **directly on chat**, no picker. Chat after a cold boot routes to the on-device agent (`provider: mobile-local-direct-reply`, 0.58 s inference) and voice works end-to-end (STT → agent → cloud-WAV TTS). Before/after screenshots + full logcat available on request.

## Notes
- Part of the LP3 hybrid work alongside the merged binary-IPC fix (#15944) and the cloud WAV TTS PR (#15946).
- `packages/ui` typechecks; the 3 pre-existing `#15740` control-plane test failures in `persistence-cloud-active-server.test.ts` are unrelated to this change (they fail on `develop` without it).


## Evidence

This is a mobile boot/onboarding **state-module + native autostart-gate** fix
(`.ts`/`.java`/`.mjs`; no rendered-component/`.tsx` change). The regression and
the fix are proven by real-device cold-launch logs (quoted in *Root cause* and
*On-device evidence* above) and by the added unit tests, not by re-rendered
pixels.

<!-- evidence-row:before-screenshots -->
- [x] N/A - behavior-only fix to boot/onboarding state modules (no `.tsx`/component
      change). The regression (runtime picker on every cold launch) is captured by
      the "before" device log above (`phase=first-run-required`). LP3 before
      screenshots are author-held and available on request.
<!-- evidence-row:after-screenshots -->
- [x] N/A - same boot-state fix; the "after" state (lands directly on chat, no
      picker) is proven by the 3 consecutive cold-launch logs above
      (`agentState=running startupPhase=ready first-run-required-count=0`). LP3
      after screenshots are author-held and available on request.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - author-held LP3 recording (cold boot → chat → voice STT → agent →
      cloud-WAV TTS) available on request; the flow is proven by the on-device
      logs above.
<!-- evidence-row:backend-logs -->
- [x] N/A - native/device logcat is quoted inline in the
      description above (not attached as a separate file) (before: `Preferences remove {"key":"eliza:first-run-complete"}`
      + `phase=first-run-required`; after: `agentState=running` /
      `startupPhase=ready` across 3 cold launches); full logcat available on request.
<!-- evidence-row:frontend-logs -->
- [x] N/A - the renderer probe/reconcile path exposes no console/network surface
      distinct from the boot logs above; its decisions are asserted directly by the
      added unit tests (`first-run-bootstrap.test.ts` retry loop,
      `persistence-cloud-active-server.test.ts` cloud-hybrid reconcile).
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change; this is client
      boot-state restoration + the native autostart RAM-tier gate.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the domain artifact is the persisted `active-server` /
      `first-run-complete` record; its correct retention across cold launch under
      `cloud-hybrid` is asserted by the added unit tests and observed in the boot
      logs above.
