### PR TITLE
fix(agent): scope NOTIFY off ordinary chat turns (split 1/4 of #15957)

### DIFF
--- a/packages/agent/src/actions/notify.test.ts
+++ b/packages/agent/src/actions/notify.test.ts
@@ -124,4 +124,21 @@ describe("notifyAction", () => {
     );
     expect((result as { success: boolean }).success).toBe(false);
   });
+
+  it("is scoped to automation/agent-internal turns, not ordinary chat", () => {
+    // Without explicit contexts NOTIFY fell back to ["general"] and landed on
+    // the action surface of every chat turn; a weak planner then picked it to
+    // "answer" a question (observed live: NOTIFY chosen for "who are the top 3
+    // contributors", posting a self-notification instead of the answer).
+    expect(notifyAction.contexts).toEqual(["automation", "agent_internal"]);
+    expect(notifyAction.contexts).not.toContain("general");
+  });
+
+  it("drops answer-flavored similes that read as 'tell the user'", () => {
+    // NOTIFY_USER / ALERT_USER made a planner treat NOTIFY as the reply path.
+    expect(notifyAction.similes ?? []).not.toContain("NOTIFY_USER");
+    expect(notifyAction.similes ?? []).not.toContain("ALERT_USER");
+    // Genuinely notification-flavored similes are kept.
+    expect(notifyAction.similes ?? []).toContain("SEND_NOTIFICATION");
+  });
 });

--- a/packages/agent/src/actions/notify.ts
+++ b/packages/agent/src/actions/notify.ts
@@ -51,11 +51,19 @@ function getService(runtime: {
 
 export const notifyAction: Action = {
   name: "NOTIFY",
+  // Deliberately NOT the chat-answer path: without explicit contexts this
+  // action fell back to ["general"], landing on the action surface of every
+  // ordinary chat turn — and similes like NOTIFY_USER read to a weak planner
+  // as "tell the user the answer" (observed live: NOTIFY chosen for "who are
+  // the top 3 contributors", posting a self-notification instead of the
+  // answer). Scope it to automation/agent-internal turns where proactive
+  // alerts actually originate.
+  contexts: ["automation", "agent_internal"],
+  routingHint:
+    "push a proactive OS/notification-center alert (completed job, reminder, approval needed) -> NOTIFY; to answer the user's question in chat -> REPLY (never NOTIFY)",
   similes: [
     "SEND_NOTIFICATION",
-    "NOTIFY_USER",
     "PUSH_NOTIFICATION",
-    "ALERT_USER",
     "SEND_ALERT",
   ],
   description:


### PR DESCRIPTION
## What (focused split #1 of #15957 — one causal change)

`NOTIFY` declared no `contexts`, so it fell back to `["general"]` and landed on the action surface of **every ordinary chat turn**. Its answer-flavored similes (`NOTIFY_USER`, `ALERT_USER`) read to a weak planner as "tell the user the answer", so it was picked for informational questions.

**Observed live** (cerebras `zai-glm-4.7` planner): asked "who are the top 3 contributors to the eliza repo", the planner chose `NOTIFY` and posted a self-notification ("Notification sent: Fetching eliza repo contributors") into the channel instead of answering.

## Fix

- `contexts: ["automation", "agent_internal"]` — where proactive alerts actually originate; keeps NOTIFY off ordinary chat turns.
- `routingHint` pointing chat answers at `REPLY` (never `NOTIFY`).
- Drop the answer-flavored similes `NOTIFY_USER` / `ALERT_USER`; keep the genuinely notification-flavored `SEND_NOTIFICATION` / `PUSH_NOTIFICATION` / `SEND_ALERT`.

One causal change, no behavioral coupling to other files.

## Tests

Extends `notify.test.ts`:
- asserts `contexts` is `["automation","agent_internal"]` and excludes `"general"`
- asserts the answer-flavored similes are gone and `SEND_NOTIFICATION` is retained

```
Test Files  1 passed (1)
     Tests  7 passed (7)
```

This is the first of the focused splits requested on #15957; the answer-clobber rescue, evaluator drift guards, and guarded-fetch redirect work follow as their own PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
