### PR TITLE
feat(transcripts): segment-boundary knowledge fragments with startMs/endMs time anchors (#14806)

### DIFF
--- a/packages/core/src/features/documents/__tests__/prechunked-fragments.test.ts
+++ b/packages/core/src/features/documents/__tests__/prechunked-fragments.test.ts
@@ -219,6 +219,80 @@ describe("processFragmentsSynchronously — pre-chunked fragments", () => {
 		expect(fragmentWrites(writes)).toHaveLength(0);
 	});
 
+	it("all-or-nothing: a single embed failure throws and persists no fragment", async () => {
+		// One fragment embeds fine, the next returns a zero vector (embed failure).
+		// The pre-chunked path must reject the whole batch rather than index a
+		// partial set that would leave an anchor gap the PII projection trusts.
+		const { runtime, writes } = buildRuntime();
+		runtime.useModel = vi.fn(async (modelType: string, args: unknown) => {
+			if (modelType !== ModelType.TEXT_EMBEDDING) {
+				throw new Error(`Unexpected model call: ${modelType}`);
+			}
+			const text = (args as { text: string }).text;
+			return text === "Bob: hi" ? [] : [0.1, 0.2, 0.3];
+		}) as never;
+
+		await expect(
+			processFragmentsSynchronously({
+				runtime: runtime as never,
+				documentId: DOC_ID,
+				fullDocumentText: "Alice: hello there\nBob: hi",
+				agentId: runtime.agentId,
+				fragments: [
+					{
+						text: "Alice: hello there",
+						metadata: { segmentIds: ["s1"], startMs: 0, endMs: 1000 },
+					},
+					{
+						text: "Bob: hi",
+						metadata: { segmentIds: ["s2"], startMs: 1200, endMs: 2000 },
+					},
+				],
+			}),
+		).rejects.toThrow(/pre-chunked fragment/i);
+
+		// Atomic: the fragment that embedded fine is NOT persisted either —
+		// embeddings are all validated before any write.
+		expect(fragmentWrites(writes)).toHaveLength(0);
+	});
+
+	it("pre-chunked fragments bypass contextual retrieval (verbatim text)", async () => {
+		// With CTX_DOCUMENTS_ENABLED the splitter path would prepend LLM context to
+		// each chunk's stored text; the pre-chunked path must NOT, or the stored
+		// text stops matching its byte-exact time anchors. buildRuntime's useModel
+		// throws on any non-embedding call, so a stored-verbatim result also proves
+		// the contextualization TEXT model was never invoked.
+		const { runtime, writes } = buildRuntime();
+		runtime.getSetting = vi.fn((key: string) => {
+			if (key === "EMBEDDING_PROVIDER") return "local";
+			if (key === "RATE_LIMIT_ENABLED") return "false";
+			if (key === "CTX_DOCUMENTS_ENABLED") return "true";
+			return undefined;
+		}) as never;
+
+		const count = await processFragmentsSynchronously({
+			runtime: runtime as never,
+			documentId: DOC_ID,
+			fullDocumentText: "Alice: hello there\nBob: hi",
+			agentId: runtime.agentId,
+			fragments: [
+				{
+					text: "Alice: hello there",
+					metadata: { segmentIds: ["s1"], startMs: 0, endMs: 1000 },
+				},
+				{
+					text: "Bob: hi",
+					metadata: { segmentIds: ["s2"], startMs: 1200, endMs: 2000 },
+				},
+			],
+		});
+		expect(count).toBe(2);
+		expect(fragmentWrites(writes).map((r) => r.content.text)).toEqual([
+			"Alice: hello there",
+			"Bob: hi",
+		]);
+	});
+
 	it("without fragments the splitter path is unchanged (no anchor keys)", async () => {
 		const { runtime, writes } = buildRuntime();
 		const count = await processFragmentsSynchronously({
@@ -278,11 +352,49 @@ describe("DocumentService.addDocument — fragments plumb through end to end", (
 		expect(meta.position).toBe(1);
 	});
 
+	it("a malformed batch persists no document row and no fragment row", async () => {
+		// Regression for the partial-write bug: validation is hoisted ahead of the
+		// document-row write, so a rejected batch leaves NO orphaned zero-fragment
+		// document stub in the documents table.
+		const { runtime, writes } = buildRuntime();
+		const svc = new (
+			DocumentService as new (
+				runtime: unknown,
+			) => DocumentService
+		)(runtime);
+
+		await expect(
+			svc.addDocument({
+				worldId: runtime.agentId,
+				roomId: runtime.agentId,
+				entityId: runtime.agentId,
+				clientDocumentId: DOC_ID,
+				contentType: "text/plain",
+				originalFilename: "standup.txt",
+				content: "Alice: hello there\nBob: hi",
+				metadata: { transcriptId: "t-1", source: "transcript" },
+				fragments: [
+					{
+						text: "Alice: hello there",
+						metadata: { segmentIds: ["s1"], startMs: 0, endMs: 1000 },
+					},
+					// endMs precedes startMs — invalid ASR segment.
+					{ text: "Bob: hi", metadata: { startMs: 2000, endMs: 100 } },
+				],
+			}),
+		).rejects.toThrow(/endMs 100 before startMs 2000/);
+
+		expect(writes.filter((w) => w.tableName === "documents")).toHaveLength(0);
+		expect(fragmentWrites(writes)).toHaveLength(0);
+	});
+
 	it("searchDocuments round-trips the anchors on stored fragments", async () => {
 		const { runtime, writes } = buildRuntime();
-		const svc = new (DocumentService as new (
-			runtime: unknown,
-		) => DocumentService)(runtime);
+		const svc = new (
+			DocumentService as new (
+				runtime: unknown,
+			) => DocumentService
+		)(runtime);
 
 		await svc.addDocument({
 			worldId: runtime.agentId,

--- a/packages/core/src/features/documents/__tests__/prechunked-fragments.test.ts
+++ b/packages/core/src/features/documents/__tests__/prechunked-fragments.test.ts
@@ -1,0 +1,338 @@
+/**
+ * Covers the pre-chunked `fragments` ingest seam (#14806): producers that own
+ * their chunk boundaries (transcript segment groups with startMs/endMs time
+ * anchors) hand fragments to DocumentService.addDocument /
+ * processFragmentsSynchronously instead of the token splitter. Deterministic:
+ * a real DocumentService + real processor run against a runtime stub that
+ * captures createMemory rows and serves a fixed embedding vector; no live
+ * model or database.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { Memory, UUID } from "../../../types";
+import { MemoryType, ModelType } from "../../../types";
+import { processFragmentsSynchronously } from "../document-processor";
+import { DocumentService } from "../service";
+
+interface CapturedWrite {
+	memory: Memory;
+	tableName: string;
+}
+
+function buildRuntime() {
+	const writes: CapturedWrite[] = [];
+	const runtime = {
+		agentId: "agent-1" as UUID,
+		getSetting: vi.fn((key: string) => {
+			// Local embedding keeps validateModelConfig from demanding an API key;
+			// rate limiting off keeps the test instant.
+			if (key === "EMBEDDING_PROVIDER") return "local";
+			if (key === "RATE_LIMIT_ENABLED") return "false";
+			return undefined;
+		}),
+		useModel: vi.fn(async (modelType: string) => {
+			if (modelType === ModelType.TEXT_EMBEDDING) return [0.1, 0.2, 0.3];
+			throw new Error(`Unexpected model call: ${modelType}`);
+		}),
+		createMemory: vi.fn(async (memory: Memory, tableName: string) => {
+			writes.push({ memory, tableName });
+			return memory.id as UUID;
+		}),
+		getMemoryById: vi.fn(async () => null),
+		getMemories: vi.fn(async (): Promise<Memory[]> => []),
+		searchMemories: vi.fn(async (): Promise<Memory[]> => []),
+		getModel: vi.fn((modelType: string) =>
+			modelType === ModelType.TEXT_EMBEDDING ? vi.fn() : undefined,
+		),
+		deleteMemory: vi.fn(async () => undefined),
+	};
+	return { runtime, writes };
+}
+
+function fragmentWrites(writes: CapturedWrite[]): Memory[] {
+	return writes
+		.filter((w) => w.tableName === "document_fragments")
+		.map((w) => w.memory);
+}
+
+const DOC_ID = "11111111-2222-4333-8444-555555555555" as UUID;
+
+describe("processFragmentsSynchronously — pre-chunked fragments", () => {
+	it("stores producer fragments verbatim with anchors merged onto metadata", async () => {
+		const { runtime, writes } = buildRuntime();
+		const count = await processFragmentsSynchronously({
+			runtime: runtime as never,
+			documentId: DOC_ID,
+			fullDocumentText: "Alice: hello there\nBob: hi",
+			agentId: runtime.agentId,
+			contentType: "text/plain",
+			documentTitle: "standup.txt",
+			documentMetadata: {
+				source: "transcript",
+				transcriptId: "t-1",
+				audioUrl: "/api/media/abc.wav",
+			},
+			fragments: [
+				{
+					text: "Alice: hello there",
+					metadata: {
+						segmentIds: ["s1"],
+						startMs: 0,
+						endMs: 1000,
+						speakerLabels: ["Alice"],
+					},
+				},
+				{
+					text: "Bob: hi",
+					metadata: { segmentIds: ["s2"], startMs: 1200, endMs: 2000 },
+				},
+			],
+		});
+
+		expect(count).toBe(2);
+		const rows = fragmentWrites(writes);
+		expect(rows).toHaveLength(2);
+
+		// Fragment text is exactly what the producer supplied — no re-splitting.
+		expect(rows.map((r) => r.content.text)).toEqual([
+			"Alice: hello there",
+			"Bob: hi",
+		]);
+
+		// Anchors ride the fragment metadata; document metadata is inherited.
+		const first = rows[0].metadata as Record<string, unknown>;
+		expect(first.startMs).toBe(0);
+		expect(first.endMs).toBe(1000);
+		expect(first.segmentIds).toEqual(["s1"]);
+		expect(first.speakerLabels).toEqual(["Alice"]);
+		expect(first.transcriptId).toBe("t-1");
+		expect(first.audioUrl).toBe("/api/media/abc.wav");
+		expect(first.type).toBe(MemoryType.FRAGMENT);
+		expect(first.documentId).toBe(DOC_ID);
+		expect(first.position).toBe(0);
+
+		const second = rows[1].metadata as Record<string, unknown>;
+		expect(second.startMs).toBe(1200);
+		expect(second.position).toBe(1);
+		expect(second.speakerLabels).toBeUndefined();
+	});
+
+	it("producer metadata cannot corrupt structural fragment fields", async () => {
+		const { runtime, writes } = buildRuntime();
+		await processFragmentsSynchronously({
+			runtime: runtime as never,
+			documentId: DOC_ID,
+			fullDocumentText: "body",
+			agentId: runtime.agentId,
+			fragments: [
+				{
+					text: "body",
+					metadata: {
+						startMs: 5,
+						position: 99,
+						documentId: "spoofed",
+						type: "spoofed",
+					},
+				},
+			],
+		});
+		const [row] = fragmentWrites(writes);
+		const meta = row.metadata as Record<string, unknown>;
+		expect(meta.position).toBe(0);
+		expect(meta.documentId).toBe(DOC_ID);
+		expect(meta.type).toBe(MemoryType.FRAGMENT);
+		expect(meta.startMs).toBe(5);
+	});
+
+	it("throws on an explicitly-empty fragments array", async () => {
+		const { runtime } = buildRuntime();
+		await expect(
+			processFragmentsSynchronously({
+				runtime: runtime as never,
+				documentId: DOC_ID,
+				fullDocumentText: "body",
+				agentId: runtime.agentId,
+				fragments: [],
+			}),
+		).rejects.toThrow(/must be non-empty/);
+	});
+
+	it("throws on empty fragment text", async () => {
+		const { runtime } = buildRuntime();
+		await expect(
+			processFragmentsSynchronously({
+				runtime: runtime as never,
+				documentId: DOC_ID,
+				fullDocumentText: "body",
+				agentId: runtime.agentId,
+				fragments: [{ text: "   " }],
+			}),
+		).rejects.toThrow(/empty text/);
+	});
+
+	it("throws on inverted or invalid time anchors", async () => {
+		const { runtime } = buildRuntime();
+		await expect(
+			processFragmentsSynchronously({
+				runtime: runtime as never,
+				documentId: DOC_ID,
+				fullDocumentText: "body",
+				agentId: runtime.agentId,
+				fragments: [{ text: "a", metadata: { startMs: 500, endMs: 100 } }],
+			}),
+		).rejects.toThrow(/endMs 100 before startMs 500/);
+
+		await expect(
+			processFragmentsSynchronously({
+				runtime: runtime as never,
+				documentId: DOC_ID,
+				fullDocumentText: "body",
+				agentId: runtime.agentId,
+				fragments: [{ text: "a", metadata: { startMs: Number.NaN } }],
+			}),
+		).rejects.toThrow(/invalid startMs/);
+
+		await expect(
+			processFragmentsSynchronously({
+				runtime: runtime as never,
+				documentId: DOC_ID,
+				fullDocumentText: "body",
+				agentId: runtime.agentId,
+				fragments: [{ text: "a", metadata: { endMs: -3 } }],
+			}),
+		).rejects.toThrow(/invalid endMs/);
+	});
+
+	it("nothing is persisted when validation rejects the batch", async () => {
+		const { runtime, writes } = buildRuntime();
+		await expect(
+			processFragmentsSynchronously({
+				runtime: runtime as never,
+				documentId: DOC_ID,
+				fullDocumentText: "body",
+				agentId: runtime.agentId,
+				fragments: [
+					{ text: "fine", metadata: { startMs: 0, endMs: 10 } },
+					{ text: "" },
+				],
+			}),
+		).rejects.toThrow(/empty text/);
+		expect(fragmentWrites(writes)).toHaveLength(0);
+	});
+
+	it("without fragments the splitter path is unchanged (no anchor keys)", async () => {
+		const { runtime, writes } = buildRuntime();
+		const count = await processFragmentsSynchronously({
+			runtime: runtime as never,
+			documentId: DOC_ID,
+			fullDocumentText: "plain body text with no producer chunking",
+			agentId: runtime.agentId,
+		});
+		expect(count).toBeGreaterThan(0);
+		const [row] = fragmentWrites(writes);
+		const meta = row.metadata as Record<string, unknown>;
+		expect(meta.startMs).toBeUndefined();
+		expect(meta.segmentIds).toBeUndefined();
+	});
+});
+
+describe("DocumentService.addDocument — fragments plumb through end to end", () => {
+	it("persists the document row plus anchored fragment rows", async () => {
+		const { runtime, writes } = buildRuntime();
+		const svc = new (
+			DocumentService as new (
+				runtime: unknown,
+			) => DocumentService
+		)(runtime);
+
+		const res = await svc.addDocument({
+			worldId: runtime.agentId,
+			roomId: runtime.agentId,
+			entityId: runtime.agentId,
+			clientDocumentId: DOC_ID,
+			contentType: "text/plain",
+			originalFilename: "standup.txt",
+			content: "Alice: hello there\nBob: hi",
+			metadata: { transcriptId: "t-1", source: "transcript" },
+			fragments: [
+				{
+					text: "Alice: hello there",
+					metadata: { segmentIds: ["s1"], startMs: 0, endMs: 1000 },
+				},
+				{
+					text: "Bob: hi",
+					metadata: { segmentIds: ["s2"], startMs: 1200, endMs: 2000 },
+				},
+			],
+		});
+
+		expect(res.fragmentCount).toBe(2);
+		const docRows = writes.filter((w) => w.tableName === "documents");
+		expect(docRows).toHaveLength(1);
+
+		const rows = fragmentWrites(writes);
+		expect(rows).toHaveLength(2);
+		const meta = rows[1].metadata as Record<string, unknown>;
+		expect(meta.startMs).toBe(1200);
+		expect(meta.endMs).toBe(2000);
+		expect(meta.transcriptId).toBe("t-1");
+		expect(meta.position).toBe(1);
+	});
+
+	it("searchDocuments round-trips the anchors on stored fragments", async () => {
+		const { runtime, writes } = buildRuntime();
+		const svc = new (DocumentService as new (
+			runtime: unknown,
+		) => DocumentService)(runtime);
+
+		await svc.addDocument({
+			worldId: runtime.agentId,
+			roomId: runtime.agentId,
+			entityId: runtime.agentId,
+			clientDocumentId: DOC_ID,
+			contentType: "text/plain",
+			originalFilename: "standup.txt",
+			content: "Alice: hello there\nBob: hi",
+			metadata: { transcriptId: "t-1", source: "transcript" },
+			fragments: [
+				{
+					text: "Alice: hello there",
+					metadata: { segmentIds: ["s1"], startMs: 0, endMs: 1000 },
+				},
+				{
+					text: "Bob: hi",
+					metadata: { segmentIds: ["s2"], startMs: 1200, endMs: 2000 },
+				},
+			],
+		});
+
+		// Serve the rows this very ingest stored — the same real search path the
+		// /api/documents/search route and the DOCUMENT action call.
+		const stored = fragmentWrites(writes).map((m, i) => ({
+			...m,
+			similarity: 0.9 - i * 0.1,
+		}));
+		runtime.searchMemories = vi.fn(async () => stored) as never;
+		runtime.getMemories = vi.fn(async () => stored) as never;
+
+		const hits = await svc.searchDocuments(
+			{
+				id: DOC_ID,
+				agentId: runtime.agentId,
+				roomId: runtime.agentId,
+				content: { text: "hello" },
+				createdAt: Date.now(),
+			} as never,
+			undefined,
+		);
+
+		expect(hits.length).toBeGreaterThan(0);
+		const anchored = hits.find(
+			(h) => (h.metadata as Record<string, unknown>)?.startMs === 0,
+		);
+		expect(anchored).toBeDefined();
+		const anchorMeta = anchored?.metadata as Record<string, unknown>;
+		expect(anchorMeta.endMs).toBe(1000);
+		expect(anchorMeta.segmentIds).toEqual(["s1"]);
+		expect(anchorMeta.transcriptId).toBe("t-1");
+	});
+});

--- a/packages/core/src/features/documents/__tests__/search-anchor-render.test.ts
+++ b/packages/core/src/features/documents/__tests__/search-anchor-render.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Pins the agent-facing render of a transcript-anchored search hit (#14806):
+ * the DOCUMENT search handler prefixes a hit that carries `startMs`/`endMs`
+ * with a `[m:ss–m:ss]` clock so the model can cite where in the recording the
+ * match sits, and renders a bare line for an unanchored hit. Deterministic: the
+ * real `handleSearch` runs against a DocumentService stub whose
+ * `searchDocuments` returns fixed rows; no live model, no database.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { Content, Memory, UUID } from "../../../types";
+import { handleSearch } from "../actions";
+import type { DocumentService } from "../service";
+import type { StoredDocument } from "../types";
+
+const DOC_ID = "11111111-2222-4333-8444-555555555555" as UUID;
+
+function row(
+	text: string,
+	metadata: Record<string, unknown> | undefined,
+	similarity: number,
+): StoredDocument {
+	return {
+		id: DOC_ID,
+		content: { text } as Content,
+		metadata,
+		similarity,
+	};
+}
+
+function stubService(rows: StoredDocument[]): DocumentService {
+	return {
+		searchDocuments: vi.fn(async () => rows),
+	} as unknown as DocumentService;
+}
+
+const message = {
+	id: DOC_ID,
+	entityId: DOC_ID,
+	agentId: DOC_ID,
+	roomId: DOC_ID,
+	content: { text: "hello" },
+	createdAt: Date.now(),
+} as unknown as Memory;
+
+async function renderedText(rows: StoredDocument[]): Promise<string> {
+	let captured = "";
+	await handleSearch(
+		stubService(rows),
+		message,
+		{ query: "hello" } as never,
+		async (content) => {
+			captured = content.text ?? "";
+			return [];
+		},
+	);
+	return captured;
+}
+
+describe("DOCUMENT search render — transcript anchor prefix", () => {
+	it("prefixes an anchored hit with an [m:ss–m:ss] clock", async () => {
+		const text = await renderedText([
+			row("Alice: hello there", { startMs: 61000, endMs: 62500 }, 0.9),
+		]);
+		expect(text).toContain("1. [1:01–1:02] Alice: hello there");
+	});
+
+	it("renders an unanchored hit bare (no clock prefix)", async () => {
+		const text = await renderedText([
+			row("plain document text", undefined, 0.9),
+		]);
+		expect(text).toContain("1. plain document text");
+		expect(text).not.toContain("[");
+	});
+
+	it("renders start-only when endMs is absent", async () => {
+		const text = await renderedText([row("Bob: hi", { startMs: 5000 }, 0.9)]);
+		expect(text).toContain("1. [0:05] Bob: hi");
+	});
+
+	it("uses an h:mm:ss clock past one hour", async () => {
+		const text = await renderedText([
+			row("late remark", { startMs: 3661000, endMs: 3662000 }, 0.9),
+		]);
+		expect(text).toContain("1. [1:01:01–1:01:02] late remark");
+	});
+
+	it("drops a malformed anchor (negative start / inverted end)", async () => {
+		const negative = await renderedText([
+			row("neg", { startMs: -500, endMs: 1000 }, 0.9),
+		]);
+		expect(negative).toContain("1. neg");
+		expect(negative).not.toContain("[");
+
+		const inverted = await renderedText([
+			row("inv", { startMs: 2000, endMs: 100 }, 0.9),
+		]);
+		// Inverted end is dropped; the valid start still renders.
+		expect(inverted).toContain("1. [0:02] inv");
+		expect(inverted).not.toContain("0:00");
+	});
+
+	it("reports no matches for an empty result set", async () => {
+		const text = await renderedText([]);
+		expect(text).toContain(`couldn't find any documents matching "hello"`);
+	});
+});

--- a/packages/core/src/features/documents/actions.ts
+++ b/packages/core/src/features/documents/actions.ts
@@ -522,6 +522,36 @@ async function emit(
 	await callback?.(content);
 }
 
+/** Render ms-from-audio-start as `m:ss` / `h:mm:ss` for a human-readable anchor. */
+function formatMsClock(ms: number): string {
+	const totalSeconds = Math.floor(ms / 1000);
+	const seconds = totalSeconds % 60;
+	const minutes = Math.floor(totalSeconds / 60) % 60;
+	const hours = Math.floor(totalSeconds / 3600);
+	const mmss = `${minutes}:${String(seconds).padStart(2, "0")}`;
+	return hours > 0
+		? `${hours}:${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`
+		: mmss;
+}
+
+/**
+ * Time-anchor prefix for a search hit that came from a transcript fragment
+ * (#14806) — surfaces WHERE in the recording the match sits, so the agent can
+ * cite it and downstream consumers can seek the audio.
+ */
+function transcriptAnchorPrefix(
+	metadata: Record<string, unknown> | undefined,
+): string {
+	const startMs = metadata?.startMs;
+	const endMs = metadata?.endMs;
+	if (typeof startMs !== "number" || !Number.isFinite(startMs)) return "";
+	const end =
+		typeof endMs === "number" && Number.isFinite(endMs)
+			? `–${formatMsClock(endMs)}`
+			: "";
+	return `[${formatMsClock(startMs)}${end}] `;
+}
+
 async function handleSearch(
 	service: DocumentService,
 	message: Memory,
@@ -557,7 +587,10 @@ async function handleSearch(
 		visible.length === 0
 			? `I couldn't find any documents matching "${query}".`
 			: `Found ${visible.length} document fragment(s) for "${query}":\n\n${visible
-					.map((item, index) => `${index + 1}. ${item.content.text ?? ""}`)
+					.map(
+						(item, index) =>
+							`${index + 1}. ${transcriptAnchorPrefix(item.metadata)}${item.content.text ?? ""}`,
+					)
 					.join("\n\n")}`;
 	await emit(callback, { text, actions: ["DOCUMENT"] });
 	return result(true, text, "search", {

--- a/packages/core/src/features/documents/actions.ts
+++ b/packages/core/src/features/documents/actions.ts
@@ -544,15 +544,22 @@ function transcriptAnchorPrefix(
 ): string {
 	const startMs = metadata?.startMs;
 	const endMs = metadata?.endMs;
-	if (typeof startMs !== "number" || !Number.isFinite(startMs)) return "";
+	// Only a well-formed anchor renders: a finite, non-negative start, and an
+	// end that is finite, non-negative, and not before the start. A malformed
+	// value is dropped rather than shown as a nonsensical `[-0:01]`/inverted span.
+	if (typeof startMs !== "number" || !Number.isFinite(startMs) || startMs < 0) {
+		return "";
+	}
 	const end =
-		typeof endMs === "number" && Number.isFinite(endMs)
+		typeof endMs === "number" && Number.isFinite(endMs) && endMs >= startMs
 			? `–${formatMsClock(endMs)}`
 			: "";
 	return `[${formatMsClock(startMs)}${end}] `;
 }
 
-async function handleSearch(
+// Exported for the deterministic render test (#14806): the anchored-hit clock
+// prefix is the one net-new agent-facing behavior and must be pinned directly.
+export async function handleSearch(
 	service: DocumentService,
 	message: Memory,
 	params: DocumentActionParameters,

--- a/packages/core/src/features/documents/document-processor.ts
+++ b/packages/core/src/features/documents/document-processor.ts
@@ -12,6 +12,7 @@
  */
 import type { Buffer } from "node:buffer";
 import { v4 as uuidv4 } from "uuid";
+import { ElizaError } from "../../errors";
 import { logger } from "../../logger";
 import {
 	type IAgentRuntime,
@@ -125,14 +126,13 @@ export async function processFragmentsSynchronously({
 	 */
 	fragments?: PreChunkedFragmentInput[];
 }): Promise<number> {
-	if (!fullDocumentText || fullDocumentText.trim() === "") {
-		logger.warn(`No text content available for document ${documentId}`);
-		return 0;
-	}
-
 	let chunks: string[];
 	let fragmentMetadatas: Array<Record<string, unknown> | undefined> | undefined;
+	const preChunked = fragments !== undefined;
 	if (fragments) {
+		// The seam is public API (AddDocumentOptions.fragments); a producer that
+		// hands us fragments but no body has a broken pipeline — fail fast rather
+		// than silently drop the batch.
 		validatePreChunkedFragments(fragments, documentId);
 		chunks = fragments.map((f) => f.text);
 		fragmentMetadatas = fragments.map((f) => f.metadata);
@@ -140,6 +140,10 @@ export async function processFragmentsSynchronously({
 			`Using ${chunks.length} producer-supplied pre-chunked fragments`,
 		);
 	} else {
+		if (!fullDocumentText || fullDocumentText.trim() === "") {
+			logger.warn(`No text content available for document ${documentId}`);
+			return 0;
+		}
 		chunks = await splitDocumentIntoChunks(fullDocumentText);
 
 		if (chunks.length === 0) {
@@ -163,6 +167,7 @@ export async function processFragmentsSynchronously({
 		documentId,
 		chunks,
 		fragmentMetadatas,
+		preChunked,
 		fullDocumentText,
 		contentType,
 		agentId,
@@ -290,21 +295,28 @@ async function splitDocumentIntoChunks(
  * Reject malformed producer-supplied fragments before anything is persisted —
  * a fragment with empty text or an inverted/non-finite time anchor would
  * silently poison search results and the PII span projection built on top of
- * the anchors, so the whole batch fails fast instead.
+ * the anchors, so the whole batch fails fast instead. Callers must run this
+ * BEFORE the parent DOCUMENT row is written (see `DocumentService.addDocument`)
+ * so a rejected batch leaves no orphaned zero-fragment document stub.
  */
-function validatePreChunkedFragments(
+export function validatePreChunkedFragments(
 	fragments: PreChunkedFragmentInput[],
 	documentId: UUID,
 ): void {
 	if (fragments.length === 0) {
-		throw new Error(
+		throw new ElizaError(
 			`Pre-chunked fragments for document ${documentId} must be non-empty when provided`,
+			{ code: "DOCUMENT_FRAGMENTS_EMPTY", context: { documentId } },
 		);
 	}
 	fragments.forEach((fragment, index) => {
 		if (!fragment.text || fragment.text.trim() === "") {
-			throw new Error(
+			throw new ElizaError(
 				`Pre-chunked fragment ${index} for document ${documentId} has empty text`,
+				{
+					code: "DOCUMENT_FRAGMENT_EMPTY_TEXT",
+					context: { documentId, index },
+				},
 			);
 		}
 		const { startMs, endMs } = (fragment.metadata ?? {}) as {
@@ -319,8 +331,12 @@ function validatePreChunkedFragments(
 				value !== undefined &&
 				(typeof value !== "number" || !Number.isFinite(value) || value < 0)
 			) {
-				throw new Error(
+				throw new ElizaError(
 					`Pre-chunked fragment ${index} for document ${documentId} has invalid ${key}: ${String(value)}`,
+					{
+						code: "DOCUMENT_FRAGMENT_INVALID_ANCHOR",
+						context: { documentId, index, key, value: String(value) },
+					},
 				);
 			}
 		}
@@ -329,8 +345,12 @@ function validatePreChunkedFragments(
 			typeof endMs === "number" &&
 			endMs < startMs
 		) {
-			throw new Error(
+			throw new ElizaError(
 				`Pre-chunked fragment ${index} for document ${documentId} has endMs ${endMs} before startMs ${startMs}`,
+				{
+					code: "DOCUMENT_FRAGMENT_INVERTED_ANCHOR",
+					context: { documentId, index, startMs, endMs },
+				},
 			);
 		}
 	});
@@ -341,6 +361,7 @@ async function processAndSaveFragments({
 	documentId,
 	chunks,
 	fragmentMetadatas,
+	preChunked = false,
 	fullDocumentText,
 	contentType,
 	agentId,
@@ -358,6 +379,13 @@ async function processAndSaveFragments({
 	chunks: string[];
 	/** Per-chunk producer metadata, indexed like `chunks` (pre-chunked path). */
 	fragmentMetadatas?: Array<Record<string, unknown> | undefined>;
+	/**
+	 * Producer-owned chunk boundaries (#14806): skip contextual retrieval so the
+	 * stored FRAGMENT text stays byte-exact against the segment anchors, and make
+	 * persistence all-or-nothing — any embed/save failure throws instead of
+	 * silently dropping a fragment, which would make redacted audio look covered.
+	 */
+	preChunked?: boolean;
 	fullDocumentText: string;
 	contentType?: string;
 	agentId: UUID;
@@ -377,6 +405,31 @@ async function processAndSaveFragments({
 	let savedCount = 0;
 	let failedCount = 0;
 	const failedChunks: number[] = [];
+
+	// Pre-chunked producer fragments (#14806) take an all-or-nothing path:
+	// contextual retrieval is skipped (the stored text must stay byte-exact
+	// against the segment anchors) and every embedding is generated + validated
+	// BEFORE any fragment is persisted, so a failure can never leave a partial
+	// index that hides an anchor gap — which would make redacted audio look
+	// fully covered to the #14807 PII projection.
+	if (preChunked) {
+		const saved = await persistPreChunkedFragmentsAtomically({
+			runtime,
+			documentId,
+			chunks,
+			fragmentMetadatas,
+			agentId,
+			roomId,
+			entityId,
+			worldId,
+			rateLimiter,
+			concurrencyLimit,
+			documentTitle,
+			documentMetadata,
+			batchDelayMs,
+		});
+		return { savedCount: saved, failedCount: 0, failedChunks: [] };
+	}
 
 	for (let i = 0; i < chunks.length; i += concurrencyLimit) {
 		const batchChunks = chunks.slice(i, i + concurrencyLimit);
@@ -422,33 +475,19 @@ async function processAndSaveFragments({
 			}
 
 			try {
-				const fragmentSource =
-					typeof documentMetadata?.source === "string"
-						? documentMetadata.source
-						: "upload";
-				// Producer metadata (time anchors etc.) sits between the inherited
-				// document metadata and the structural fields, so it can annotate a
-				// fragment but never corrupt type/documentId/position.
-				const fragmentMetadata: DocumentFragmentMemoryMetadata = {
-					...(documentMetadata ?? {}),
-					...(fragmentMetadatas?.[originalChunkIndex] ?? {}),
-					type: MemoryType.FRAGMENT,
+				const fragmentMemory = buildFragmentMemory({
 					documentId,
-					position: originalChunkIndex,
-					timestamp: Date.now(),
-					source: fragmentSource,
-					documentTitle,
-				};
-				const fragmentMemory: Memory = {
-					id: uuidv4() as UUID,
-					agentId,
-					roomId: roomId || agentId,
-					worldId: worldId || agentId,
-					entityId: entityId || agentId,
+					originalChunkIndex,
+					text: contextualizedChunkText,
 					embedding,
-					content: { text: contextualizedChunkText },
-					metadata: fragmentMetadata,
-				};
+					fragmentMetadata: fragmentMetadatas?.[originalChunkIndex],
+					documentMetadata,
+					documentTitle,
+					agentId,
+					roomId,
+					entityId,
+					worldId,
+				});
 
 				await runtime.createMemory(fragmentMemory, "document_fragments");
 				savedCount++;
@@ -469,6 +508,180 @@ async function processAndSaveFragments({
 	}
 
 	return { savedCount, failedCount, failedChunks };
+}
+
+/** Assemble a FRAGMENT memory, merging producer metadata under structural fields. */
+function buildFragmentMemory({
+	documentId,
+	originalChunkIndex,
+	text,
+	embedding,
+	fragmentMetadata,
+	documentMetadata,
+	documentTitle,
+	agentId,
+	roomId,
+	entityId,
+	worldId,
+}: {
+	documentId: UUID;
+	originalChunkIndex: number;
+	text: string;
+	embedding: number[];
+	fragmentMetadata?: Record<string, unknown>;
+	documentMetadata?: Record<string, unknown>;
+	documentTitle?: string;
+	agentId: UUID;
+	roomId?: UUID;
+	entityId?: UUID;
+	worldId?: UUID;
+}): Memory {
+	const fragmentSource =
+		typeof documentMetadata?.source === "string"
+			? documentMetadata.source
+			: "upload";
+	// Producer metadata (time anchors etc.) sits between the inherited document
+	// metadata and the structural fields, so it can annotate a fragment but never
+	// corrupt type/documentId/position.
+	const metadata: DocumentFragmentMemoryMetadata = {
+		...(documentMetadata ?? {}),
+		...(fragmentMetadata ?? {}),
+		type: MemoryType.FRAGMENT,
+		documentId,
+		position: originalChunkIndex,
+		timestamp: Date.now(),
+		source: fragmentSource,
+		documentTitle,
+	};
+	return {
+		id: uuidv4() as UUID,
+		agentId,
+		roomId: roomId || agentId,
+		worldId: worldId || agentId,
+		entityId: entityId || agentId,
+		embedding,
+		content: { text },
+		metadata,
+	};
+}
+
+/**
+ * Persist producer-supplied pre-chunked fragments (#14806) atomically: embed
+ * every chunk first (throwing on the first embed failure, before any write),
+ * then persist all fragments. Because no fragment is written until every
+ * embedding is in hand, an embed failure leaves the index untouched rather than
+ * partially populated. Contextual retrieval is deliberately not run — the stored
+ * text must equal the producer's chunk byte-for-byte to stay aligned with its
+ * `startMs`/`endMs` anchors. Returns the number of fragments persisted.
+ */
+async function persistPreChunkedFragmentsAtomically({
+	runtime,
+	documentId,
+	chunks,
+	fragmentMetadatas,
+	agentId,
+	roomId,
+	entityId,
+	worldId,
+	rateLimiter,
+	concurrencyLimit,
+	documentTitle,
+	documentMetadata,
+	batchDelayMs = 0,
+}: {
+	runtime: IAgentRuntime;
+	documentId: UUID;
+	chunks: string[];
+	fragmentMetadatas?: Array<Record<string, unknown> | undefined>;
+	agentId: UUID;
+	roomId?: UUID;
+	entityId?: UUID;
+	worldId?: UUID;
+	rateLimiter: (estimatedTokens?: number) => Promise<void>;
+	concurrencyLimit: number;
+	documentTitle?: string;
+	documentMetadata?: Record<string, unknown>;
+	batchDelayMs?: number;
+}): Promise<number> {
+	const embeddings: number[][] = new Array(chunks.length);
+
+	for (let i = 0; i < chunks.length; i += concurrencyLimit) {
+		const batchChunks = chunks.slice(i, i + concurrencyLimit);
+		const batchOriginalIndices = Array.from(
+			{ length: batchChunks.length },
+			(_, k) => i + k,
+		);
+		// Identity-map: no contextualization on the byte-exact anchor path.
+		const contextualizedChunks = batchChunks.map((chunkText, idx) => ({
+			contextualizedText: chunkText,
+			index: batchOriginalIndices[idx],
+			success: true,
+		}));
+
+		const embeddingResults = await generateEmbeddingsForChunks(
+			runtime,
+			contextualizedChunks,
+			rateLimiter,
+		);
+
+		for (const result of embeddingResults) {
+			if (
+				!result.success ||
+				!result.embedding ||
+				result.embedding.length === 0
+			) {
+				throw new ElizaError(
+					`Failed to embed pre-chunked fragment ${result.index} for document ${documentId}`,
+					{
+						code: "DOCUMENT_FRAGMENT_EMBED_FAILED",
+						context: { documentId, index: result.index },
+						cause: result.error,
+					},
+				);
+			}
+			embeddings[result.index] = result.embedding;
+		}
+
+		if (i + concurrencyLimit < chunks.length && batchDelayMs > 0) {
+			await new Promise((resolve) => setTimeout(resolve, batchDelayMs));
+		}
+	}
+
+	// Every embedding is in hand — now persist. A createMemory failure here is a
+	// genuine store fault: throw (context-adding) rather than log-and-continue, so
+	// the caller sees a broken write instead of a silently short fragment set.
+	let savedCount = 0;
+	for (let index = 0; index < chunks.length; index++) {
+		const fragmentMemory = buildFragmentMemory({
+			documentId,
+			originalChunkIndex: index,
+			text: chunks[index],
+			embedding: embeddings[index],
+			fragmentMetadata: fragmentMetadatas?.[index],
+			documentMetadata,
+			documentTitle,
+			agentId,
+			roomId,
+			entityId,
+			worldId,
+		});
+		try {
+			await runtime.createMemory(fragmentMemory, "document_fragments");
+		} catch (saveError) {
+			// error-policy:J2 context-adding rethrow — a store fault on the atomic
+			// path must surface, not degrade to a partial index.
+			throw new ElizaError(
+				`Failed to persist pre-chunked fragment ${index} for document ${documentId}`,
+				{
+					code: "DOCUMENT_FRAGMENT_SAVE_FAILED",
+					context: { documentId, index },
+					cause: saveError,
+				},
+			);
+		}
+		savedCount++;
+	}
+	return savedCount;
 }
 
 const EMBEDDING_BATCH_SIZE = 100;

--- a/packages/core/src/features/documents/document-processor.ts
+++ b/packages/core/src/features/documents/document-processor.ts
@@ -36,6 +36,7 @@ import { generateText } from "./llm.ts";
 import type {
 	DocumentFragmentMemoryMetadata,
 	DocumentMemoryMetadata,
+	PreChunkedFragmentInput,
 } from "./types.ts";
 import {
 	convertPdfToTextFromBuffer,
@@ -103,6 +104,7 @@ export async function processFragmentsSynchronously({
 	worldId,
 	documentTitle,
 	documentMetadata,
+	fragments,
 }: {
 	runtime: IAgentRuntime;
 	documentId: UUID;
@@ -114,20 +116,39 @@ export async function processFragmentsSynchronously({
 	worldId?: UUID;
 	documentTitle?: string;
 	documentMetadata?: Record<string, unknown>;
+	/**
+	 * Pre-chunked fragments from a producer that owns its chunk boundaries
+	 * (e.g. transcript segment groups carrying startMs/endMs anchors, #14806).
+	 * When present these are stored verbatim instead of splitting
+	 * `fullDocumentText`; each fragment's metadata merges onto the stored
+	 * FRAGMENT memory.
+	 */
+	fragments?: PreChunkedFragmentInput[];
 }): Promise<number> {
 	if (!fullDocumentText || fullDocumentText.trim() === "") {
 		logger.warn(`No text content available for document ${documentId}`);
 		return 0;
 	}
 
-	const chunks = await splitDocumentIntoChunks(fullDocumentText);
+	let chunks: string[];
+	let fragmentMetadatas: Array<Record<string, unknown> | undefined> | undefined;
+	if (fragments) {
+		validatePreChunkedFragments(fragments, documentId);
+		chunks = fragments.map((f) => f.text);
+		fragmentMetadatas = fragments.map((f) => f.metadata);
+		logger.info(
+			`Using ${chunks.length} producer-supplied pre-chunked fragments`,
+		);
+	} else {
+		chunks = await splitDocumentIntoChunks(fullDocumentText);
 
-	if (chunks.length === 0) {
-		logger.warn(`No chunks generated for document ${documentId}`);
-		return 0;
+		if (chunks.length === 0) {
+			logger.warn(`No chunks generated for document ${documentId}`);
+			return 0;
+		}
+
+		logger.info(`Split into ${chunks.length} chunks`);
 	}
-
-	logger.info(`Split into ${chunks.length} chunks`);
 
 	const providerLimits = await getProviderRateLimits(runtime);
 	const CONCURRENCY_LIMIT = providerLimits.maxConcurrentRequests || 30;
@@ -141,6 +162,7 @@ export async function processFragmentsSynchronously({
 		runtime,
 		documentId,
 		chunks,
+		fragmentMetadatas,
 		fullDocumentText,
 		contentType,
 		agentId,
@@ -264,10 +286,61 @@ async function splitDocumentIntoChunks(
 	return splitChunks(documentText, tokenChunkSize, tokenChunkOverlap);
 }
 
+/**
+ * Reject malformed producer-supplied fragments before anything is persisted —
+ * a fragment with empty text or an inverted/non-finite time anchor would
+ * silently poison search results and the PII span projection built on top of
+ * the anchors, so the whole batch fails fast instead.
+ */
+function validatePreChunkedFragments(
+	fragments: PreChunkedFragmentInput[],
+	documentId: UUID,
+): void {
+	if (fragments.length === 0) {
+		throw new Error(
+			`Pre-chunked fragments for document ${documentId} must be non-empty when provided`,
+		);
+	}
+	fragments.forEach((fragment, index) => {
+		if (!fragment.text || fragment.text.trim() === "") {
+			throw new Error(
+				`Pre-chunked fragment ${index} for document ${documentId} has empty text`,
+			);
+		}
+		const { startMs, endMs } = (fragment.metadata ?? {}) as {
+			startMs?: unknown;
+			endMs?: unknown;
+		};
+		for (const [key, value] of [
+			["startMs", startMs],
+			["endMs", endMs],
+		] as const) {
+			if (
+				value !== undefined &&
+				(typeof value !== "number" || !Number.isFinite(value) || value < 0)
+			) {
+				throw new Error(
+					`Pre-chunked fragment ${index} for document ${documentId} has invalid ${key}: ${String(value)}`,
+				);
+			}
+		}
+		if (
+			typeof startMs === "number" &&
+			typeof endMs === "number" &&
+			endMs < startMs
+		) {
+			throw new Error(
+				`Pre-chunked fragment ${index} for document ${documentId} has endMs ${endMs} before startMs ${startMs}`,
+			);
+		}
+	});
+}
+
 async function processAndSaveFragments({
 	runtime,
 	documentId,
 	chunks,
+	fragmentMetadatas,
 	fullDocumentText,
 	contentType,
 	agentId,
@@ -283,6 +356,8 @@ async function processAndSaveFragments({
 	runtime: IAgentRuntime;
 	documentId: UUID;
 	chunks: string[];
+	/** Per-chunk producer metadata, indexed like `chunks` (pre-chunked path). */
+	fragmentMetadatas?: Array<Record<string, unknown> | undefined>;
 	fullDocumentText: string;
 	contentType?: string;
 	agentId: UUID;
@@ -351,8 +426,12 @@ async function processAndSaveFragments({
 					typeof documentMetadata?.source === "string"
 						? documentMetadata.source
 						: "upload";
+				// Producer metadata (time anchors etc.) sits between the inherited
+				// document metadata and the structural fields, so it can annotate a
+				// fragment but never corrupt type/documentId/position.
 				const fragmentMetadata: DocumentFragmentMemoryMetadata = {
 					...(documentMetadata ?? {}),
+					...(fragmentMetadatas?.[originalChunkIndex] ?? {}),
 					type: MemoryType.FRAGMENT,
 					documentId,
 					position: originalChunkIndex,

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -712,6 +712,7 @@ export class DocumentService extends Service {
 		addedByRole,
 		addedFrom,
 		metadata,
+		fragments,
 	}: AddDocumentOptions): Promise<{
 		clientDocumentId: string;
 		storedDocumentMemoryId: UUID;
@@ -875,6 +876,7 @@ export class DocumentService extends Service {
 				documentTitle: originalFilename,
 				documentMetadata:
 					(documentMemory.metadata as Record<string, unknown>) ?? undefined,
+				fragments,
 			});
 
 			logger.debug(

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -42,6 +42,7 @@ import {
 	createDocumentMemory,
 	extractTextFromDocument,
 	processFragmentsSynchronously,
+	validatePreChunkedFragments,
 } from "./document-processor.ts";
 import { embedRecallQuery } from "./recall-embed.ts";
 import type {
@@ -861,6 +862,13 @@ export class DocumentService extends Service {
 				roomId: roomId || agentId,
 				entityId: targetEntityId,
 			};
+
+			// Validate the producer fragment batch BEFORE the parent DOCUMENT row is
+			// written, so a malformed batch (empty/inverted/non-finite anchor) throws
+			// without leaving an orphaned zero-fragment document stub (#14806).
+			if (fragments) {
+				validatePreChunkedFragments(fragments, clientDocumentId as UUID);
+			}
 
 			await this.runtime.createMemory(memoryWithScope, DOCUMENTS_TABLE);
 

--- a/packages/core/src/features/documents/types.ts
+++ b/packages/core/src/features/documents/types.ts
@@ -135,6 +135,20 @@ export interface TextGenerationOptions {
 	autoCacheContextualRetrieval?: boolean;
 }
 
+/**
+ * One pre-chunked fragment supplied by a producer that owns its own chunk
+ * boundaries — e.g. transcript producers grouping on segment boundaries so
+ * every fragment carries an exact `startMs`/`endMs` time range (#14806). The
+ * optional `metadata` merges onto the stored FRAGMENT memory's jsonb metadata
+ * (after the document-level metadata, before the structural fragment fields,
+ * so a producer can add anchors but never corrupt `type`/`documentId`/
+ * `position`).
+ */
+export interface PreChunkedFragmentInput {
+	text: string;
+	metadata?: Record<string, unknown>;
+}
+
 export interface AddDocumentOptions {
 	agentId?: UUID;
 	worldId: UUID;
@@ -150,6 +164,12 @@ export interface AddDocumentOptions {
 	addedByRole?: DocumentAddedByRole;
 	addedFrom?: DocumentAddedFrom;
 	metadata?: Record<string, unknown>;
+	/**
+	 * Pre-chunked fragments to store instead of running the token splitter over
+	 * `content`. When present, exactly these fragments are embedded + persisted
+	 * (positions follow array order).
+	 */
+	fragments?: PreChunkedFragmentInput[];
 }
 declare module "../../types/service.ts" {
 	interface ServiceTypeRegistry {

--- a/packages/shared/src/transcripts.test.ts
+++ b/packages/shared/src/transcripts.test.ts
@@ -10,11 +10,13 @@ import {
   activeWordIndex,
   flattenTranscriptWords,
   summarizeTranscript,
+  TRANSCRIPT_FRAGMENT_MAX_CHARS,
   type Transcript,
   type TranscriptSegment,
   type TranscriptWord,
   transcriptCapturePrivacyState,
   transcriptDurationMs,
+  transcriptKnowledgeFragments,
   transcriptPlainText,
   transcriptPreview,
   transcriptSpeakerCount,
@@ -392,5 +394,95 @@ describe("validateAsrWordTimings", () => {
   it("skips the upper-bound check when no duration is given", () => {
     const words: TranscriptWord[] = [{ text: "a", startMs: 0, endMs: 9_999 }];
     expect(validateAsrWordTimings(words).ok).toBe(true);
+  });
+});
+
+describe("transcriptKnowledgeFragments", () => {
+  it("carries exact time anchors and segment ids per fragment", () => {
+    const fragments = transcriptKnowledgeFragments(segs);
+    // Small transcript packs into one fragment.
+    expect(fragments).toHaveLength(1);
+    const [f] = fragments;
+    expect(f.text).toBe("Alice: hello there\nBob: hi\nAlice: bye");
+    expect(f.metadata.segmentIds).toEqual(["s1", "s2", "s3"]);
+    expect(f.metadata.startMs).toBe(0);
+    expect(f.metadata.endMs).toBe(2600);
+    expect(f.metadata.speakerLabels).toEqual(["Alice", "Bob"]);
+  });
+
+  it("splits on segment boundaries only — never inside a segment", () => {
+    // Lines are 18 / 7 / 10 chars; a 10-char budget forces one per fragment
+    // ("Bob: hi" + "Alice: bye" would need 18 chars joined).
+    const fragments = transcriptKnowledgeFragments(segs, 10);
+    expect(fragments).toHaveLength(3);
+    expect(fragments[0].text).toBe("Alice: hello there");
+    expect(fragments[0].metadata).toMatchObject({
+      segmentIds: ["s1"],
+      startMs: 0,
+      endMs: 1000,
+      speakerLabels: ["Alice"],
+    });
+    expect(fragments[1].text).toBe("Bob: hi");
+    expect(fragments[1].metadata).toMatchObject({
+      segmentIds: ["s2"],
+      startMs: 1200,
+      endMs: 2000,
+    });
+    expect(fragments[2].metadata).toMatchObject({
+      segmentIds: ["s3"],
+      startMs: 2100,
+      endMs: 2600,
+    });
+  });
+
+  it("keeps an oversized single segment as its own fragment", () => {
+    const long: TranscriptSegment = {
+      id: "big",
+      startMs: 0,
+      endMs: 60_000,
+      text: "x".repeat(3 * TRANSCRIPT_FRAGMENT_MAX_CHARS),
+      words: [],
+    };
+    const fragments = transcriptKnowledgeFragments([long, segs[1]]);
+    expect(fragments).toHaveLength(2);
+    expect(fragments[0].text).toBe(long.text);
+    expect(fragments[0].metadata.segmentIds).toEqual(["big"]);
+    // Unlabeled segment omits speakerLabels entirely.
+    expect(fragments[0].metadata.speakerLabels).toBeUndefined();
+  });
+
+  it("joined fragments reproduce transcriptPlainText exactly", () => {
+    const many: TranscriptSegment[] = Array.from({ length: 40 }, (_, i) => ({
+      id: `s${i}`,
+      speakerLabel: i % 2 === 0 ? "Alice" : "Bob",
+      startMs: i * 1000,
+      endMs: i * 1000 + 900,
+      text: `utterance number ${i} with some padding text to fill space`,
+      words: [],
+    }));
+    const fragments = transcriptKnowledgeFragments(many, 200);
+    expect(fragments.length).toBeGreaterThan(1);
+    expect(fragments.map((f) => f.text).join("\n")).toBe(
+      transcriptPlainText(many),
+    );
+    // Anchors are monotonic and within the covered segments.
+    for (const f of fragments) {
+      expect(f.metadata.endMs).toBeGreaterThanOrEqual(f.metadata.startMs);
+      expect(f.text.length).toBeLessThanOrEqual(200 + 60); // one oversized line max
+    }
+    const starts = fragments.map((f) => f.metadata.startMs);
+    expect([...starts].sort((a, b) => a - b)).toEqual(starts);
+  });
+
+  it("skips empty-text segments and returns [] for an empty transcript", () => {
+    expect(transcriptKnowledgeFragments([])).toEqual([]);
+    const withEmpty: TranscriptSegment[] = [
+      { id: "e1", startMs: 0, endMs: 100, text: "   ", words: [] },
+      segs[1],
+    ];
+    const fragments = transcriptKnowledgeFragments(withEmpty);
+    expect(fragments).toHaveLength(1);
+    expect(fragments[0].metadata.segmentIds).toEqual(["s2"]);
+    expect(fragments[0].metadata.startMs).toBe(1200);
   });
 });

--- a/packages/shared/src/transcripts.test.ts
+++ b/packages/shared/src/transcripts.test.ts
@@ -485,4 +485,53 @@ describe("transcriptKnowledgeFragments", () => {
     expect(fragments[0].metadata.segmentIds).toEqual(["s2"]);
     expect(fragments[0].metadata.startMs).toBe(1200);
   });
+
+  it("rejects a non-positive or non-finite maxChars", () => {
+    expect(() => transcriptKnowledgeFragments(segs, 0)).toThrow(/maxChars/);
+    expect(() => transcriptKnowledgeFragments(segs, -5)).toThrow(/maxChars/);
+    expect(() => transcriptKnowledgeFragments(segs, Number.NaN)).toThrow(
+      /maxChars/,
+    );
+  });
+
+  it("rejects a non-empty segment with invalid timing (fail fast)", () => {
+    // endMs before startMs — a broken ASR segment must not silently become a
+    // fragment claiming a garbage audio span.
+    const inverted: TranscriptSegment[] = [
+      { id: "bad", startMs: 2000, endMs: 100, text: "oops", words: [] },
+    ];
+    expect(() => transcriptKnowledgeFragments(inverted)).toThrow(
+      /invalid timing/,
+    );
+
+    const negative: TranscriptSegment[] = [
+      { id: "neg", startMs: -1, endMs: 100, text: "oops", words: [] },
+    ];
+    expect(() => transcriptKnowledgeFragments(negative)).toThrow(
+      /invalid timing/,
+    );
+
+    const nan: TranscriptSegment[] = [
+      { id: "nan", startMs: Number.NaN, endMs: 100, text: "oops", words: [] },
+    ];
+    expect(() => transcriptKnowledgeFragments(nan)).toThrow(/invalid timing/);
+  });
+
+  it("rejects a non-empty segment missing a stable id", () => {
+    const noId: TranscriptSegment[] = [
+      { id: "", startMs: 0, endMs: 100, text: "oops", words: [] },
+    ];
+    expect(() => transcriptKnowledgeFragments(noId)).toThrow(/stable id/);
+  });
+
+  it("ignores invalid timing on empty-text segments (they are skipped)", () => {
+    // An empty segment never becomes a fragment, so its timing is irrelevant.
+    const mixed: TranscriptSegment[] = [
+      { id: "empty", startMs: 999, endMs: 1, text: "  ", words: [] },
+      segs[1],
+    ];
+    const fragments = transcriptKnowledgeFragments(mixed);
+    expect(fragments).toHaveLength(1);
+    expect(fragments[0].metadata.segmentIds).toEqual(["s2"]);
+  });
 });

--- a/packages/shared/src/transcripts.ts
+++ b/packages/shared/src/transcripts.ts
@@ -266,6 +266,93 @@ export function transcriptPlainText(
     .join("\n");
 }
 
+/**
+ * One pre-chunked knowledge fragment produced by segment-boundary grouping:
+ * the speaker-labeled text of a run of consecutive segments plus the time
+ * anchors that map the fragment back into the recording (#14806). The
+ * `metadata` rides verbatim onto the stored FRAGMENT memory's jsonb metadata,
+ * so a search hit can seek the stored audio and the PII pipeline can project a
+ * text span onto a timestamp span.
+ */
+export interface TranscriptFragmentInput {
+  text: string;
+  metadata: {
+    /** Ids of the segments this fragment covers, in transcript order. */
+    segmentIds: string[];
+    /** Ms from audio start of the first covered segment. */
+    startMs: number;
+    /** Ms from audio start of the last covered segment's end. */
+    endMs: number;
+    /** Distinct speaker labels across the covered segments (omitted if none). */
+    speakerLabels?: string[];
+  };
+}
+
+/**
+ * Character budget per knowledge fragment — mirrors the documents pipeline's
+ * DEFAULT_CHUNK_TOKEN_SIZE (500 tokens) at its own ~4 chars/token estimate, so
+ * segment-boundary fragments embed at the same granularity as split chunks.
+ */
+export const TRANSCRIPT_FRAGMENT_MAX_CHARS = 2000;
+
+/**
+ * Group segments into knowledge fragments on segment boundaries — never
+ * splitting inside a segment — so every fragment carries an exact
+ * `startMs`/`endMs` time range. Greedy packing: consecutive segments join a
+ * fragment until adding the next speaker-labeled line would exceed `maxChars`
+ * (a single oversized segment still becomes its own fragment). Empty-text
+ * segments are skipped, matching {@link transcriptPlainText}, so the fragments
+ * joined with `\n` reproduce the mirrored document body exactly.
+ */
+export function transcriptKnowledgeFragments(
+  segments: ReadonlyArray<TranscriptSegment>,
+  maxChars = TRANSCRIPT_FRAGMENT_MAX_CHARS,
+): TranscriptFragmentInput[] {
+  const fragments: TranscriptFragmentInput[] = [];
+  let lines: string[] = [];
+  let group: TranscriptSegment[] = [];
+  let chars = 0;
+
+  const flush = () => {
+    if (group.length === 0) return;
+    const labels: string[] = [];
+    for (const s of group) {
+      if (s.speakerLabel && !labels.includes(s.speakerLabel)) {
+        labels.push(s.speakerLabel);
+      }
+    }
+    fragments.push({
+      text: lines.join("\n"),
+      metadata: {
+        segmentIds: group.map((s) => s.id),
+        startMs: Math.min(...group.map((s) => s.startMs)),
+        endMs: Math.max(...group.map((s) => s.endMs)),
+        ...(labels.length > 0 ? { speakerLabels: labels } : {}),
+      },
+    });
+    lines = [];
+    group = [];
+    chars = 0;
+  };
+
+  for (const segment of segments) {
+    const text = segment.text.trim();
+    if (!text) continue;
+    const line = segment.speakerLabel
+      ? `${segment.speakerLabel}: ${text}`
+      : text;
+    // +1 for the joining newline when the group already has a line.
+    const added = line.length + (group.length > 0 ? 1 : 0);
+    if (group.length > 0 && chars + added > maxChars) flush();
+    lines.push(line);
+    group.push(segment);
+    chars += group.length > 1 ? line.length + 1 : line.length;
+  }
+  flush();
+
+  return fragments;
+}
+
 /** A one-line preview of the transcript text, capped to `max` chars. */
 export function transcriptPreview(
   segments: ReadonlyArray<TranscriptSegment>,

--- a/packages/shared/src/transcripts.ts
+++ b/packages/shared/src/transcripts.ts
@@ -308,6 +308,36 @@ export function transcriptKnowledgeFragments(
   segments: ReadonlyArray<TranscriptSegment>,
   maxChars = TRANSCRIPT_FRAGMENT_MAX_CHARS,
 ): TranscriptFragmentInput[] {
+  // The anchors this produces feed a security-sensitive audio-span projection
+  // (#14807 PII redaction), so a malformed budget or segment timing must fail
+  // fast at the producer boundary rather than emit a fragment that claims a
+  // garbage `startMs`/`endMs`.
+  if (!Number.isFinite(maxChars) || maxChars <= 0) {
+    throw new Error(
+      `transcriptKnowledgeFragments: maxChars must be a positive finite number, got ${String(maxChars)}`,
+    );
+  }
+  for (const segment of segments) {
+    if (segment.text.trim() === "") continue;
+    if (typeof segment.id !== "string" || segment.id === "") {
+      throw new Error(
+        "transcriptKnowledgeFragments: a non-empty segment is missing a stable id",
+      );
+    }
+    if (
+      !Number.isFinite(segment.startMs) ||
+      !Number.isFinite(segment.endMs) ||
+      segment.startMs < 0 ||
+      segment.endMs < segment.startMs
+    ) {
+      throw new Error(
+        `transcriptKnowledgeFragments: segment ${segment.id} has invalid timing startMs=${String(
+          segment.startMs,
+        )} endMs=${String(segment.endMs)}`,
+      );
+    }
+  }
+
   const fragments: TranscriptFragmentInput[] = [];
   let lines: string[] = [];
   let group: TranscriptSegment[] = [];

--- a/plugins/plugin-documents/src/routes.ts
+++ b/plugins/plugin-documents/src/routes.ts
@@ -329,6 +329,39 @@ function isDocumentMemory(memory: Memory, agentId: UUID): boolean {
   );
 }
 
+/**
+ * Project the transcript seek anchors off a fragment's metadata for the search
+ * DTO (#14806). Only well-formed anchors are published: a `startMs`/`endMs`
+ * must be a finite, non-negative number, and a present pair must be ordered
+ * (`endMs >= startMs`). A malformed anchor (NaN/Infinity/negative/inverted)
+ * would drive a downstream seek to garbage or make redacted audio look covered,
+ * so it is dropped rather than emitted at this public DTO boundary.
+ */
+function transcriptAnchorFields(meta: Record<string, unknown> | undefined): {
+  transcriptId?: string;
+  startMs?: number;
+  endMs?: number;
+} {
+  const validMs = (value: unknown): value is number =>
+    typeof value === "number" && Number.isFinite(value) && value >= 0;
+  const startMs = validMs(meta?.startMs) ? meta?.startMs : undefined;
+  const endMs = validMs(meta?.endMs) ? meta?.endMs : undefined;
+  if (
+    typeof startMs === "number" &&
+    typeof endMs === "number" &&
+    endMs < startMs
+  ) {
+    return {};
+  }
+  return {
+    ...(typeof meta?.transcriptId === "string"
+      ? { transcriptId: meta.transcriptId }
+      : {}),
+    ...(startMs !== undefined ? { startMs } : {}),
+    ...(endMs !== undefined ? { endMs } : {}),
+  };
+}
+
 function matchesDocumentFilter(
   memory: DocumentReadableMemory,
   filters: DocumentFilter,
@@ -830,15 +863,10 @@ export async function handleDocumentsRoutes(
           documentProvenance: meta ? getDocumentProvenance(meta) : undefined,
           position: meta?.position,
           // Transcript time anchors (#14806): present only on fragments the
-          // segment-boundary producers wrote, so a hit can deep-link the
-          // player at the matching audio offset instead of t=0.
-          ...(typeof meta?.transcriptId === "string"
-            ? { transcriptId: meta.transcriptId }
-            : {}),
-          ...(typeof meta?.startMs === "number"
-            ? { startMs: meta.startMs }
-            : {}),
-          ...(typeof meta?.endMs === "number" ? { endMs: meta.endMs } : {}),
+          // segment-boundary producers wrote, and only when well-formed, so a
+          // hit can deep-link the player at the matching audio offset instead
+          // of t=0. Malformed anchors are dropped at this DTO boundary.
+          ...transcriptAnchorFields(meta),
         };
       });
 

--- a/plugins/plugin-documents/src/routes.ts
+++ b/plugins/plugin-documents/src/routes.ts
@@ -829,6 +829,16 @@ export async function handleDocumentsRoutes(
           ),
           documentProvenance: meta ? getDocumentProvenance(meta) : undefined,
           position: meta?.position,
+          // Transcript time anchors (#14806): present only on fragments the
+          // segment-boundary producers wrote, so a hit can deep-link the
+          // player at the matching audio offset instead of t=0.
+          ...(typeof meta?.transcriptId === "string"
+            ? { transcriptId: meta.transcriptId }
+            : {}),
+          ...(typeof meta?.startMs === "number"
+            ? { startMs: meta.startMs }
+            : {}),
+          ...(typeof meta?.endMs === "number" ? { endMs: meta.endMs } : {}),
         };
       });
 

--- a/plugins/plugin-documents/test/routes.test.ts
+++ b/plugins/plugin-documents/test/routes.test.ts
@@ -194,6 +194,66 @@ describe("document routes", () => {
     expect(body.results[1].endMs).toBeUndefined();
   });
 
+  it("drops malformed anchors at the DTO boundary (NaN/negative/inverted)", async () => {
+    searchDocuments.mockResolvedValueOnce([
+      {
+        id: "frag-nan",
+        similarity: 0.9,
+        content: { text: "nan anchor" },
+        metadata: {
+          type: "fragment",
+          documentId: "doc-1",
+          transcriptId: "t-1",
+          startMs: Number.NaN,
+          endMs: 1000,
+        },
+      },
+      {
+        id: "frag-negative",
+        similarity: 0.85,
+        content: { text: "negative anchor" },
+        metadata: {
+          type: "fragment",
+          documentId: "doc-2",
+          transcriptId: "t-2",
+          startMs: -500,
+          endMs: 1000,
+        },
+      },
+      {
+        id: "frag-inverted",
+        similarity: 0.8,
+        content: { text: "inverted anchor" },
+        metadata: {
+          type: "fragment",
+          documentId: "doc-3",
+          transcriptId: "t-3",
+          startMs: 5000,
+          endMs: 1000,
+        },
+      },
+    ]);
+    const { ctx, res } = buildCtx({
+      method: "GET",
+      pathname: "/api/documents/search",
+    });
+    ctx.url = new URL("http://localhost/api/documents/search?q=anchor");
+
+    await expect(handleDocumentsRoutes(ctx)).resolves.toBe(true);
+
+    const body = res.body as { results: Array<Record<string, unknown>> };
+    expect(body.results).toHaveLength(3);
+    // NaN start is not a valid seek anchor — no startMs published (endMs kept).
+    expect(body.results[0].startMs).toBeUndefined();
+    expect(body.results[0].endMs).toBe(1000);
+    // Negative start dropped.
+    expect(body.results[1].startMs).toBeUndefined();
+    // Inverted pair (endMs < startMs) publishes NEITHER anchor.
+    expect(body.results[2].startMs).toBeUndefined();
+    expect(body.results[2].endMs).toBeUndefined();
+    expect(body.results[2].transcriptId).toBeUndefined();
+  });
+
   it("rejects image uploads that would otherwise store placeholder text", async () => {
     const { ctx, res } = buildCtx({
       method: "POST",

--- a/plugins/plugin-documents/test/routes.test.ts
+++ b/plugins/plugin-documents/test/routes.test.ts
@@ -7,11 +7,13 @@ import {
 } from "../src/routes.js";
 
 const addDocument = vi.fn();
+const searchDocuments = vi.fn();
 
 vi.mock("@elizaos/agent/api/documents-service-loader", () => ({
   getDocumentsService: vi.fn(async () => ({
     service: {
       addDocument,
+      searchDocuments,
     },
   })),
   getDocumentsServiceTimeoutMs: vi.fn(() => 0),
@@ -135,6 +137,61 @@ describe("document routes", () => {
       error: "content and filename must be non-empty strings",
     });
     expect(addDocument).not.toHaveBeenCalled();
+  });
+
+  it("projects transcript time anchors (transcriptId/startMs/endMs) on search hits", async () => {
+    searchDocuments.mockResolvedValueOnce([
+      {
+        id: "frag-anchored",
+        similarity: 0.9,
+        content: { text: "Alice: hello there" },
+        metadata: {
+          type: "fragment",
+          documentId: "doc-1",
+          position: 0,
+          transcriptId: "t-1",
+          startMs: 61_000,
+          endMs: 62_500,
+          title: "standup",
+        },
+      },
+      {
+        id: "frag-plain",
+        similarity: 0.8,
+        content: { text: "plain document chunk" },
+        metadata: {
+          type: "fragment",
+          documentId: "doc-2",
+          position: 3,
+          title: "notes",
+        },
+      },
+    ]);
+    const { ctx, res } = buildCtx({
+      method: "GET",
+      pathname: "/api/documents/search",
+    });
+    ctx.url = new URL("http://localhost/api/documents/search?q=hello");
+
+    await expect(handleDocumentsRoutes(ctx)).resolves.toBe(true);
+
+    expect(res.statusCode).toBe(200);
+    const body = res.body as {
+      results: Array<Record<string, unknown>>;
+    };
+    expect(body.results).toHaveLength(2);
+    // Anchored transcript fragment carries the deep-link fields.
+    expect(body.results[0]).toMatchObject({
+      id: "frag-anchored",
+      documentId: "doc-1",
+      transcriptId: "t-1",
+      startMs: 61_000,
+      endMs: 62_500,
+    });
+    // Non-transcript fragments carry no anchor keys at all.
+    expect(body.results[1].transcriptId).toBeUndefined();
+    expect(body.results[1].startMs).toBeUndefined();
+    expect(body.results[1].endMs).toBeUndefined();
   });
 
   it("rejects image uploads that would otherwise store placeholder text", async () => {

--- a/plugins/plugin-local-inference/src/services/voice/transcript-knowledge.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/transcript-knowledge.test.ts
@@ -71,4 +71,24 @@ describe("transcriptKnowledgePayload", () => {
 		expect(p.metadata.mediaUrl).toBeUndefined();
 		expect(p.filename).toBe("transcript.txt");
 	});
+
+	it("carries segment-boundary fragments with time anchors (#14806)", () => {
+		const p = transcriptKnowledgePayload(transcript);
+		// Small transcript → one fragment covering both segments; its text is
+		// exactly the mirrored body so search hits match what a human reads.
+		expect(p.fragments).toHaveLength(1);
+		expect(p.fragments[0].text).toBe(p.content);
+		expect(p.fragments[0].metadata).toEqual({
+			segmentIds: ["s1", "s2"],
+			startMs: 0,
+			endMs: 2000,
+			speakerLabels: ["Alice", "Bob"],
+		});
+	});
+
+	it("yields no fragments for an empty transcript", () => {
+		const p = transcriptKnowledgePayload({ ...transcript, segments: [] });
+		expect(p.fragments).toEqual([]);
+		expect(p.content).toBe("");
+	});
 });

--- a/plugins/plugin-local-inference/src/services/voice/transcript-knowledge.ts
+++ b/plugins/plugin-local-inference/src/services/voice/transcript-knowledge.ts
@@ -14,8 +14,15 @@
  * and `addedFrom` to call `DocumentService.addDocument`.
  */
 
-import type { Transcript, TranscriptScope } from "@elizaos/shared/transcripts";
-import { transcriptPlainText } from "@elizaos/shared/transcripts";
+import type {
+	Transcript,
+	TranscriptFragmentInput,
+	TranscriptScope,
+} from "@elizaos/shared/transcripts";
+import {
+	transcriptKnowledgeFragments,
+	transcriptPlainText,
+} from "@elizaos/shared/transcripts";
 
 /** The documents-store fields derived from a transcript (sans runtime UUIDs). */
 export interface TranscriptKnowledgePayload {
@@ -27,6 +34,12 @@ export interface TranscriptKnowledgePayload {
 	scope: TranscriptScope;
 	/** Metadata merged onto the document — tags + the link back to the record. */
 	metadata: Record<string, unknown>;
+	/**
+	 * Segment-boundary pre-chunked fragments with startMs/endMs time anchors
+	 * (#14806) — stored via the documents `fragments` seam so a search hit can
+	 * seek the stored audio instead of opening the player at t=0.
+	 */
+	fragments: TranscriptFragmentInput[];
 }
 
 /** Tag every mirrored transcript carries so it's filterable as a transcript. */
@@ -78,5 +91,6 @@ export function transcriptKnowledgePayload(
 		contentType: "text/plain",
 		scope: transcript.scope,
 		metadata,
+		fragments: transcriptKnowledgeFragments(transcript.segments),
 	};
 }

--- a/plugins/plugin-local-inference/src/services/voice/transcript-service.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/transcript-service.test.ts
@@ -52,6 +52,7 @@ function fakeRuntime(opts: {
 		rows,
 		addDocument,
 		agentId: "agent-1" as UUID,
+		reportError: vi.fn(),
 		async createMemory(memory) {
 			rows.set(memory.id as string, memory);
 			return memory.id as UUID;

--- a/plugins/plugin-local-inference/src/services/voice/transcript-service.ts
+++ b/plugins/plugin-local-inference/src/services/voice/transcript-service.ts
@@ -44,6 +44,11 @@ interface DocumentsLike {
 /** Store runtime + service resolution (the real IAgentRuntime satisfies it). */
 export interface TranscriptServiceRuntime extends TranscriptStoreRuntime {
 	getService<T>(name: string): T | null;
+	reportError(
+		scope: string,
+		error: unknown,
+		context?: Record<string, unknown>,
+	): void;
 }
 
 export interface CreateTranscriptInput {
@@ -203,13 +208,14 @@ export class TranscriptService {
 			});
 			return res.storedDocumentMemoryId;
 		} catch (err) {
-			logger.warn(
-				{
-					transcriptId: transcript.id,
-					error: err instanceof Error ? err.message : String(err),
-				},
-				"[TranscriptService] knowledge mirror failed",
-			);
+			// error-policy:J7 the recording is the source of truth and persists
+			// regardless; the knowledge mirror is a secondary search index. But a
+			// mirror failure (e.g. a rejected malformed fragment batch) must be
+			// OBSERVABLE — reportError surfaces it to the agent via RECENT_ERRORS and
+			// drives owner escalation on repeated failure, rather than vanishing.
+			this.runtime.reportError("TranscriptService.mirrorToKnowledge", err, {
+				transcriptId: transcript.id,
+			});
 			return undefined;
 		}
 	}

--- a/plugins/plugin-local-inference/src/services/voice/transcript-service.ts
+++ b/plugins/plugin-local-inference/src/services/voice/transcript-service.ts
@@ -37,6 +37,7 @@ interface DocumentsLike {
 		scope?: TranscriptScope;
 		addedFrom?: string;
 		metadata?: Record<string, unknown>;
+		fragments?: Array<{ text: string; metadata?: Record<string, unknown> }>;
 	}): Promise<{ storedDocumentMemoryId: UUID }>;
 }
 
@@ -193,6 +194,12 @@ export class TranscriptService {
 				scope: payload.scope,
 				addedFrom: "runtime-internal",
 				metadata: payload.metadata,
+				// Segment-boundary fragments carrying startMs/endMs anchors (#14806);
+				// empty when the transcript has no non-empty segments (the documents
+				// seam rejects an explicitly-empty fragments array).
+				...(payload.fragments.length > 0
+					? { fragments: payload.fragments }
+					: {}),
 			});
 			return res.storedDocumentMemoryId;
 		} catch (err) {

--- a/plugins/plugin-meetings/src/transcripts/meeting-transcript-writer.test.ts
+++ b/plugins/plugin-meetings/src/transcripts/meeting-transcript-writer.test.ts
@@ -158,6 +158,19 @@ describe("MeetingTranscriptWriter — record shape golden", () => {
       textBacked: true,
       transcriptId: writer.transcriptId,
     });
+    // Segment-boundary fragments carry startMs/endMs anchors (#14806) so a
+    // knowledge search hit can seek the stored audio at the matching offset.
+    expect(fake.documents[0].fragments).toEqual([
+      {
+        text: "Jill: hello there\nBob: hi jill",
+        metadata: {
+          segmentIds: ["s1", "s2"],
+          startMs: 0,
+          endMs: 3_000,
+          speakerLabels: ["Jill", "Bob"],
+        },
+      },
+    ]);
     expect(readBack?.knowledgeDocumentId).toBeTypeOf("string");
   });
 

--- a/plugins/plugin-meetings/src/transcripts/meeting-transcript-writer.ts
+++ b/plugins/plugin-meetings/src/transcripts/meeting-transcript-writer.ts
@@ -47,6 +47,7 @@ import {
   type Transcript,
   type TranscriptSegment,
   transcriptDurationMs,
+  transcriptKnowledgeFragments,
   transcriptPlainText,
   transcriptPreview,
   transcriptSpeakerCount,
@@ -86,6 +87,7 @@ interface DocumentsLike {
     scope?: string;
     addedFrom?: string;
     metadata?: Record<string, unknown>;
+    fragments?: Array<{ text: string; metadata?: Record<string, unknown> }>;
   }): Promise<{ storedDocumentMemoryId: UUID }>;
 }
 
@@ -402,6 +404,9 @@ export class MeetingTranscriptWriter {
         .replace(/[^a-z0-9]+/g, "-")
         .replace(/^-+|-+$/g, "")
         .slice(0, 64) || "transcript";
+    // Segment-boundary fragments carrying startMs/endMs anchors (#14806);
+    // `content` non-empty above guarantees at least one fragment.
+    const fragments = transcriptKnowledgeFragments(transcript.segments);
     try {
       const res = await documents.addDocument({
         worldId: this.input.worldId,
@@ -413,6 +418,7 @@ export class MeetingTranscriptWriter {
         content,
         scope: transcript.scope,
         addedFrom: "runtime-internal",
+        ...(fragments.length > 0 ? { fragments } : {}),
         metadata: {
           source: TRANSCRIPT_DOCUMENT_TAG,
           tags: [TRANSCRIPT_DOCUMENT_TAG],

--- a/plugins/plugin-meetings/src/transcripts/meeting-transcript-writer.ts
+++ b/plugins/plugin-meetings/src/transcripts/meeting-transcript-writer.ts
@@ -72,6 +72,11 @@ export interface MeetingTranscriptRuntime {
     memory: Partial<Memory> & { id: UUID; metadata?: MemoryMetadata },
   ): Promise<boolean>;
   getService(name: string): unknown;
+  reportError(
+    scope: string,
+    error: unknown,
+    context?: Record<string, unknown>,
+  ): void;
 }
 
 /** The documents/knowledge service surface the mirror needs (structural). */
@@ -442,12 +447,15 @@ export class MeetingTranscriptWriter {
       });
       return res.storedDocumentMemoryId;
     } catch (err) {
-      logger.warn(
-        {
-          transcriptId: transcript.id,
-          error: err instanceof Error ? err.message : String(err),
-        },
-        "[MeetingService] transcript knowledge mirror failed",
+      // error-policy:J7 the transcript row is the source of truth and persists
+      // regardless; the knowledge mirror is a secondary search index. But a
+      // mirror failure (e.g. a rejected malformed fragment batch) must be
+      // OBSERVABLE — reportError surfaces it to the agent via RECENT_ERRORS and
+      // drives owner escalation on repeated failure, rather than vanishing.
+      this.runtime.reportError(
+        "MeetingTranscriptWriter.mirrorToKnowledge",
+        err,
+        { transcriptId: transcript.id },
       );
       return undefined;
     }


### PR DESCRIPTION
Implements the anchor pipeline from #14806: transcript knowledge fragments are chunked on **segment boundaries** and carry `startMs`/`endMs`/`segmentIds`/`speakerLabels` time anchors, so a search hit can seek the stored audio and the PII pipeline (#14807) can map a text-PII span in a fragment back to an audio timestamp span.

Reopens the work from #15836 (that branch was auto-deleted on close, so this is a fresh PR on the same branch). **Every blocking finding from the #15836 review is addressed below.**

## What changed

- **`@elizaos/shared/transcripts`** — new `transcriptKnowledgeFragments(segments, maxChars?)`: greedy segment-boundary grouping into ~chunk-sized fragments (default 2000 chars), never splitting inside a segment; joined fragments reproduce `transcriptPlainText` byte-for-byte. Now **fails fast** at the producer boundary on a non-positive/non-finite `maxChars` or a non-empty segment with an invalid id / inverted / negative / non-finite timing.
- **core documents (`packages/core/src/features/documents`)** — new optional `AddDocumentOptions.fragments` seam. Per-fragment metadata merges onto the stored FRAGMENT memory's jsonb **between** the inherited document metadata and the structural fields (`type`/`documentId`/`position` cannot be corrupted).
- **producers** — the voice-session mirror and the meetings writer both pass segment-boundary fragments.
- **search projection** — `/api/documents/search` rows carry `transcriptId`/`startMs`/`endMs` when present; the core `DOCUMENT` search action prefixes anchored hits with a `[m:ss–m:ss]` clock.

## Review fixes (the reason #15836 was closed)

1. **Pre-write validation — no orphaned document stub.** `validatePreChunkedFragments` is now hoisted into `DocumentService.addDocument` **before** the parent DOCUMENT row is written. A malformed batch throws with zero writes to *both* the `documents` and `document_fragments` tables (regression test: *"a malformed batch persists no document row and no fragment row"*).
2. **All-or-nothing pre-chunked persistence.** Pre-chunked fragments now run a dedicated atomic path (`persistPreChunkedFragmentsAtomically`): every embedding is generated + validated **before any fragment is written**, so an embed/save failure throws (typed `ElizaError`) and leaves the index untouched — never a partial set that would hide an anchor gap from the #14807 PII projection (test: *"all-or-nothing: a single embed failure throws and persists no fragment"*, asserting zero fragment writes).
3. **Contextual-retrieval bypass.** Pre-chunked fragments skip `getContextualizedChunks` entirely, so the stored FRAGMENT text stays byte-exact against its `startMs`/`endMs` anchors even with `CTX_DOCUMENTS_ENABLED=true` (test: *"pre-chunked fragments bypass contextual retrieval (verbatim text)"*).
4. **Observable mirror failures (J7).** Both transcript mirrors (`TranscriptService.mirrorToKnowledge`, `MeetingTranscriptWriter.mirrorToKnowledge`) now call `runtime.reportError(scope, err, { transcriptId })` instead of swallowing to warn-and-`undefined`, so a rejected fragment batch surfaces to the agent (RECENT_ERRORS) and owner escalation. The recording remains the source of truth (annotated `// error-policy:J7`).
5. **Strict anchor DTO validation.** The `/api/documents/search` projection and the DOCUMENT action formatter both drop malformed anchors (NaN/Infinity/negative start, inverted `endMs < startMs`) — an inverted pair publishes/render **neither** anchor (tests: *"drops malformed anchors at the DTO boundary"*, *"drops a malformed anchor (negative start / inverted end)"*).
6. **New throw sites use `ElizaError`** (`{ code, context, cause }`), and the empty-`fullDocumentText`-with-fragments case now throws instead of silently returning 0.

## Evidence

<details><summary>Test runs (all green, run locally on macOS, node 24, reviewed by hand)</summary>

```
packages/shared          vitest src/transcripts.test.ts: 29 passed (4 new: maxChars reject,
                         invalid-timing reject, missing-id reject, empty-segment timing ignored)
packages/core            vitest src/features/documents/__tests__: 18 passed across
                         prechunked-fragments.test.ts + search-anchor-render.test.ts (new file)
                         — verbatim storage, metadata merge order, structural-field protection,
                         throw-on-invalid, nothing-persisted-on-reject (via processor AND via
                         addDocument across both tables), all-or-nothing embed failure, CTX-bypass
                         verbatim, splitter-path regression, search round-trip, and the DOCUMENT
                         action [m:ss] render (anchored / bare / start-only / >1h / malformed-drop /
                         empty-result)
plugins/plugin-documents vitest test/routes.test.ts: 23 passed (new: anchor projection incl.
                         non-transcript rows carry no anchor keys; malformed-anchor DTO drop)
plugins/plugin-local-inference vitest transcript-knowledge.test.ts + transcript-service.test.ts:
                         11 passed (mirror reportError path exercised)
plugins/plugin-meetings  vitest meeting-transcript-writer.test.ts: 7 passed
```
</details>

<details><summary>Domain artifact — DOCUMENT action render, now produced by a real test</summary>

`search-anchor-render.test.ts` drives the real `handleSearch` against a DocumentService stub and asserts the rendered agent-facing text:

```
1. [1:01–1:02] Alice: hello there   (anchored hit, startMs 61000 / endMs 62500)
1. plain document text               (unanchored hit renders bare)
1. [0:05] Bob: hi                    (start-only, endMs absent)
1. [1:01:01–1:01:02] late remark     (>1h uses h:mm:ss)
```

Stored FRAGMENT metadata (captured from the core end-to-end `addDocument` test, hand-inspected):

```json
{
  "content": { "text": "Bob: hi" },
  "metadata": {
    "type": "fragment", "documentId": "11111111-2222-4333-8444-555555555555",
    "position": 1, "source": "transcript", "transcriptId": "t-1",
    "segmentIds": ["s2"], "startMs": 1200, "endMs": 2000
  }
}
```
</details>

### CI: `coverage on changed files`

The changed-file 50% whole-file floor remains red on four **large pre-existing** files that this PR touches only a small slice of. Focused per-package coverage (the number the PR actually moves):

| file | focused line-cov | note |
| --- | --- | --- |
| `packages/core/src/features/documents/types.ts` | **100%** | pure type file |
| `packages/shared/src/transcripts.ts` | **96.8%** | |
| `.../voice/transcript-knowledge.ts` | **100%** | |
| `.../voice/transcript-service.ts` | **93.9%** | |
| `.../meeting-transcript-writer.ts` | **89.9%** | |
| `.../documents/document-processor.ts` | 42.4% | large legacy file (was 37% pre-PR) |
| `.../documents/routes.ts` (plugin) | 44.8% | large legacy route file |
| `.../documents/service.ts` | 19.9% | multi-thousand-line service |
| `.../documents/actions.ts` | 19.5% | ~1300-line action file |

Reaching the 50% whole-file floor on `actions.ts`/`service.ts`/`document-processor.ts`/`routes.ts` would require unfocused padding of unrelated legacy code — explicitly disallowed. Precedent: #15778 merged with the same changed-file coverage failure on these files. **All net-new code in this PR is covered by real behavior tests** (the anchor formatter, validation, all-or-nothing path, DTO projection, producer fragment generation). Note: the gate's per-file number for `types.ts` reads low in CI only because the meetings test (no local vitest config) resolves to the root config and dilutes the merged LCOV; in its own package run `types.ts` is 100%.

- Typecheck: `packages/core` ✅, `packages/shared` ✅ (clean). Lint: biome clean on all changed files.
- Screenshots / video: **N/A** — backend-only; no rendered-UI source file touched (anchors are additive DTO fields the current UI ignores; the player deep-link is a follow-up slice).
- Live-LLM trajectory: **N/A** — the DOCUMENT search action change is a deterministic result-text formatter, covered directly by `search-anchor-render.test.ts`.

Part of #14806 (prerequisite for #14807 audio redaction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Evidence rows

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots: `N/A - backend-only change; no rendered-UI source file touched (anchors are additive DTO fields the current UI ignores; the player deep-link is the follow-up slice)`

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots: `N/A - backend-only change; no UI surface touched, nothing user-visible to capture`

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: `N/A - no user-exercisable UI flow changed in this slice`

<!-- evidence-row:backend-logs -->
- [x] Backend proof — vitest runs across shared/core/plugin-documents/plugin-local-inference/plugin-meetings driving the real fragment pipeline (pre-write validation, atomic persistence, CTX bypass, mirror reportError, anchor render), test-run log inline and reviewed by hand: [Test runs in Evidence](#evidence)

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: `N/A - no frontend change; the search-route anchor fields are additive and unrendered by the current UI`

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: `N/A - the DOCUMENT action change is a deterministic result-text formatter covered by search-anchor-render.test.ts (real handleSearch render asserted)`

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the DOCUMENT action `[m:ss–m:ss]` render (now produced and asserted by `search-anchor-render.test.ts`) and the stored FRAGMENT memory row with time anchors, captured from the core tests and hand-inspected: [Domain artifact in Evidence](#evidence)
