### PR TITLE
test(scenarios): accept reminder create child

### DIFF
--- a/.github/workflows/live-scenarios.yml
+++ b/.github/workflows/live-scenarios.yml
@@ -193,8 +193,9 @@ jobs:
           fi
 
           package_dirs=(
-            plugins/plugin-local-inference
             plugins/plugin-sql
+            plugins/plugin-blocker
+            plugins/plugin-local-inference
             plugins/plugin-app-control
             plugins/plugin-agent-skills
             plugins/plugin-health

--- a/packages/scripts/__tests__/live-scenarios-workflow.test.ts
+++ b/packages/scripts/__tests__/live-scenarios-workflow.test.ts
@@ -16,3 +16,10 @@ test("builds the local-inference voice-workbench export before the scenario CLI 
     /package_dirs=\([\s\S]*plugins\/plugin-local-inference[\s\S]*\)[\s\S]*for package_dir in "\$\{package_dirs\[@\]\}"/,
   );
 });
+
+test("builds the blocker engine imported by personal-assistant scenarios", () => {
+  const workflow = readFileSync(workflowPath, "utf8");
+  expect(workflow).toMatch(
+    /package_dirs=\([\s\S]*plugins\/plugin-blocker[\s\S]*\)[\s\S]*for package_dir in "\$\{package_dirs\[@\]\}"/,
+  );
+});

--- a/packages/test/scenarios/cross-cutting/planner.missing-input-terminal-relay.assertion.ts
+++ b/packages/test/scenarios/cross-cutting/planner.missing-input-terminal-relay.assertion.ts
@@ -1,0 +1,70 @@
+/**
+ * Validates the action provenance and owner-facing result captured by the
+ * credentialed missing-input scenario without depending on model routing.
+ */
+import type { ScenarioTurnExecution } from "@elizaos/scenario-runner/schema";
+
+const FAILURE_RE =
+  /sorry, something went wrong|trajectory limit|try again|failed on my end/i;
+const FORM_RE = /^\[FORM\]\s*([\s\S]*)\s*\[\/FORM\]$/;
+const REMINDER_CREATE_ACTIONS = new Set([
+  "OWNER_REMINDERS",
+  "OWNER_REMINDERS_CREATE",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function validSchedulingForm(text: string): boolean {
+  const match = FORM_RE.exec(text);
+  if (!match?.[1]) return false;
+  try {
+    const payload: unknown = JSON.parse(match[1]);
+    if (!isRecord(payload) || !Array.isArray(payload.fields)) return false;
+    const names = payload.fields.flatMap((field) =>
+      isRecord(field) && typeof field.name === "string" ? [field.name] : [],
+    );
+    return names.includes("date") && names.includes("time");
+  } catch {
+    // error-policy:J3 invalid model-authored form JSON is an explicit failed match
+    return false;
+  }
+}
+
+export function expectMissingInputTerminalRelay(
+  execution: ScenarioTurnExecution,
+): string | undefined {
+  const response = execution.responseText?.trim() ?? "";
+  if (!response) return "missing-input turn returned an empty reply";
+  if (FAILURE_RE.test(response)) {
+    return `missing-input turn returned a synthetic failure: ${JSON.stringify(response)}`;
+  }
+  const reminder = execution.actionsCalled.find((action) =>
+    REMINDER_CREATE_ACTIONS.has(action.actionName),
+  );
+  if (!reminder?.result) {
+    const seen = execution.actionsCalled.map((action) => action.actionName);
+    return `no reminder-create action executed (saw: ${seen.join(", ")})`;
+  }
+  if (reminder.result.success !== true) {
+    return `reminder-create action did not succeed: ${JSON.stringify(reminder.result)}`;
+  }
+  if (
+    !isRecord(reminder.result.data) ||
+    reminder.result.data.awaitingUserInput !== true
+  ) {
+    return `reminder-create action lacked awaitingUserInput: ${JSON.stringify(reminder.result.data)}`;
+  }
+  if (!isRecord(reminder.result.raw)) {
+    return "reminder-create action lacked a raw action result";
+  }
+  const actionText = reminder.result.raw.userFacingText;
+  if (typeof actionText !== "string" || !actionText.trim()) {
+    return "reminder-create clarification lacked userFacingText";
+  }
+  if (!validSchedulingForm(response) && response !== actionText.trim()) {
+    return `reply was neither a scheduling form nor the action clarification: ${JSON.stringify(response)}`;
+  }
+  return undefined;
+}

--- a/packages/test/scenarios/cross-cutting/planner.missing-input-terminal-relay.scenario.ts
+++ b/packages/test/scenarios/cross-cutting/planner.missing-input-terminal-relay.scenario.ts
@@ -3,30 +3,7 @@
  * authorize a clarification or grammar-valid scheduling form.
  */
 import { scenario } from "@elizaos/scenario-runner/schema";
-
-const FAILURE_RE =
-  /sorry, something went wrong|trajectory limit|try again|failed on my end/i;
-const FORM_RE = /^\[FORM\]\s*([\s\S]*)\s*\[\/FORM\]$/;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
-function validSchedulingForm(text: string): boolean {
-  const match = FORM_RE.exec(text);
-  if (!match?.[1]) return false;
-  try {
-    const payload: unknown = JSON.parse(match[1]);
-    if (!isRecord(payload) || !Array.isArray(payload.fields)) return false;
-    const names = payload.fields.flatMap((field) =>
-      isRecord(field) && typeof field.name === "string" ? [field.name] : [],
-    );
-    return names.includes("date") && names.includes("time");
-  } catch {
-    // error-policy:J3 invalid model-authored form JSON is an explicit failed match
-    return false;
-  }
-}
+import { expectMissingInputTerminalRelay } from "./planner.missing-input-terminal-relay.assertion";
 
 export default scenario({
   id: "live-missing-input-terminal-relay",
@@ -48,34 +25,7 @@ export default scenario({
       name: "missing reminder fields finish as a user-visible interaction",
       room: "main",
       text: "I need a reminder for an upcoming report deadline — ask me for the report name, day, and time before creating anything.",
-      assertTurn: (execution) => {
-        const response = execution.responseText?.trim() ?? "";
-        if (!response) return "missing-input turn returned an empty reply";
-        if (FAILURE_RE.test(response)) {
-          return `missing-input turn returned a synthetic failure: ${JSON.stringify(response)}`;
-        }
-        const reminder = execution.actionsCalled.find(
-          (action) => action.actionName === "OWNER_REMINDERS",
-        );
-        if (!reminder?.result) return "OWNER_REMINDERS did not execute";
-        if (
-          !isRecord(reminder.result.data) ||
-          reminder.result.data.awaitingUserInput !== true
-        ) {
-          return `OWNER_REMINDERS lacked awaitingUserInput: ${JSON.stringify(reminder.result.data)}`;
-        }
-        if (!isRecord(reminder.result.raw)) {
-          return "OWNER_REMINDERS lacked a raw action result";
-        }
-        const actionText = reminder.result.raw.userFacingText;
-        if (typeof actionText !== "string" || !actionText.trim()) {
-          return "OWNER_REMINDERS clarification lacked userFacingText";
-        }
-        if (!validSchedulingForm(response) && response !== actionText.trim()) {
-          return `reply was neither a scheduling form nor the action clarification: ${JSON.stringify(response)}`;
-        }
-        return undefined;
-      },
+      assertTurn: expectMissingInputTerminalRelay,
     },
   ],
 });

--- a/packages/test/scenarios/cross-cutting/planner.missing-input-terminal-relay.test.ts
+++ b/packages/test/scenarios/cross-cutting/planner.missing-input-terminal-relay.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Pins the missing-input live scenario's action provenance before credentialed
+ * execution so parent and generated child routes share the same strict result bar.
+ */
+import { describe, expect, test } from "bun:test";
+import type { CapturedAction } from "@elizaos/scenario-runner/schema";
+import { expectMissingInputTerminalRelay } from "./planner.missing-input-terminal-relay.assertion";
+
+const CLARIFICATION =
+  "What’s the report name, what day is it due, and what time should I use?";
+
+function action(
+  actionName: string,
+  overrides: Partial<NonNullable<CapturedAction["result"]>> = {},
+): CapturedAction {
+  return {
+    actionName,
+    result: {
+      success: true,
+      data: { awaitingUserInput: true },
+      raw: { userFacingText: CLARIFICATION },
+      ...overrides,
+    },
+  };
+}
+
+function evaluate(candidate: CapturedAction, responseText = CLARIFICATION) {
+  return expectMissingInputTerminalRelay({
+    actionsCalled: [candidate],
+    responseText,
+  });
+}
+
+describe("missing-input terminal relay scenario", () => {
+  test("accepts the parent reminder action", () => {
+    expect(evaluate(action("OWNER_REMINDERS"))).toBeUndefined();
+  });
+
+  test("accepts the generated reminder-create child", () => {
+    expect(evaluate(action("OWNER_REMINDERS_CREATE"))).toBeUndefined();
+  });
+
+  test("rejects an unrelated action even when its payload copies the markers", () => {
+    expect(evaluate(action("OWNER_ROUTINES_CREATE"))).toMatch(
+      /no reminder-create action executed/,
+    );
+  });
+
+  test("requires successful execution and explicit missing-input authority", () => {
+    expect(
+      evaluate(action("OWNER_REMINDERS_CREATE", { success: false })),
+    ).toMatch(/did not succeed/);
+    expect(
+      evaluate(
+        action("OWNER_REMINDERS_CREATE", {
+          data: { awaitingUserInput: false },
+        }),
+      ),
+    ).toMatch(/lacked awaitingUserInput/);
+  });
+
+  test("rejects model paraphrase that is not a valid scheduling form", () => {
+    expect(evaluate(action("OWNER_REMINDERS_CREATE"), "Tell me more.")).toMatch(
+      /neither a scheduling form nor the action clarification/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- accepts both `OWNER_REMINDERS` and the generated `OWNER_REMINDERS_CREATE` child in the credentialed missing-input proof
- keeps the assertion fail-closed: the selected action must succeed, carry `awaitingUserInput: true`, and own the exact clarification (or a grammar-valid scheduling form)
- builds `plugin-blocker` before the live scenario CLI because personal-assistant imports its dist-only engine during runtime creation
- adds deterministic parent/child/adversarial assertion coverage and a workflow prerequisite regression

Closes #15995

## Verification

- `bun test packages/test/scenarios/cross-cutting/planner.missing-input-terminal-relay.test.ts packages/scripts/__tests__/live-scenarios-workflow.test.ts` — 7 passed
- scenario imports under `eliza-source` and is discovered as `live-missing-input-terminal-relay` after the workflow-equivalent core build
- Biome, diff check, error-policy ratchet, and test-realness audit pass
- exact-head credentialed live run: pending

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - the changed surface is a credentialed scenario assertion and workflow prerequisite.
<!-- evidence-row:backend-logs -->
- [ ] Exact-head live workflow log pending.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime or network path changed.
<!-- evidence-row:llm-trajectory -->
- [ ] Exact-head live trajectory pending.
<!-- evidence-row:domain-artifacts -->
- [ ] Exact-head scenario report/native export pending.