### PR TITLE
fix(ci): restore develop green — ratchet fallbacks and pendant route coverage

### DIFF
--- a/packages/agent/src/api/dispatch-route-binary-response.test.ts
+++ b/packages/agent/src/api/dispatch-route-binary-response.test.ts
@@ -107,6 +107,35 @@ describe("dispatchRoute captured response finalization", () => {
     });
   });
 
+  it("treats absent content-type as textual UTF-8", async () => {
+    const runtime = runtimeWithHandler((response) => {
+      response.end("undeclared text");
+    });
+
+    await expect(dispatch(runtime)).resolves.toMatchObject({
+      body: "undeclared text",
+    });
+  });
+
+  it("keeps identity-encoded and empty content-type responses textual", async () => {
+    const identityRuntime = runtimeWithHandler((response) => {
+      response.setHeader("content-type", "text/plain");
+      response.setHeader("content-encoding", "identity");
+      response.end("identity text");
+    });
+    const emptyTypeRuntime = runtimeWithHandler((response) => {
+      response.setHeader("content-type", "");
+      response.end("empty type text");
+    });
+
+    await expect(dispatch(identityRuntime)).resolves.toMatchObject({
+      body: "identity text",
+    });
+    await expect(dispatch(emptyTypeRuntime)).resolves.toMatchObject({
+      body: "empty type text",
+    });
+  });
+
   it("returns malformed JSON as raw text and empty responses as undefined", async () => {
     const invalidJsonRuntime = runtimeWithHandler((response) => {
       response.setHeader("content-type", "application/json");

--- a/packages/agent/src/api/dispatch-route-onchunk.test.ts
+++ b/packages/agent/src/api/dispatch-route-onchunk.test.ts
@@ -52,6 +52,7 @@ describe("dispatchRoute onChunk sink (#12352)", () => {
     expect(chunks).toEqual(["data: one\n\n", "data: two\n\n"]);
     // The buffered result still carries the full concatenated body.
     expect(result?.status).toBe(200);
+    expect(result?.headers?.["content-type"]).toBe("text/event-stream");
     expect(String(result?.body)).toBe("data: one\n\ndata: two\n\n");
   });
 

--- a/packages/agent/src/api/dispatch-route.ts
+++ b/packages/agent/src/api/dispatch-route.ts
@@ -423,10 +423,18 @@ function buildLegacyShim(args: {
 
 function capturedToResult(captured: CapturedResponse): RouteHandlerResult {
   const buffer = Buffer.concat(captured.chunks);
-  const contentType = (captured.headers["content-type"] ?? "").toLowerCase();
-  const contentEncoding = (captured.headers["content-encoding"] ?? "")
-    .trim()
-    .toLowerCase();
+  // Missing headers are meaningful here because undeclared bodies retain the
+  // bridge's historical UTF-8 behavior.
+  const contentTypeHeader = captured.headers["content-type"];
+  const contentType =
+    typeof contentTypeHeader === "string"
+      ? contentTypeHeader.toLowerCase()
+      : undefined;
+  const contentEncodingHeader = captured.headers["content-encoding"];
+  const contentEncoding =
+    typeof contentEncodingHeader === "string"
+      ? contentEncodingHeader.trim().toLowerCase()
+      : undefined;
   if (buffer.length === 0) {
     return {
       status: captured.statusCode || 200,
@@ -438,10 +446,13 @@ function capturedToResult(captured: CapturedResponse): RouteHandlerResult {
   // underlying media type is textual; interpreting either encoded or binary
   // bytes as UTF-8 would make the downstream IPC base64 envelope lossy.
   const hasTransferEncoding =
-    contentEncoding !== "" && contentEncoding !== "identity";
+    contentEncoding !== undefined &&
+    contentEncoding !== "" &&
+    contentEncoding !== "identity";
   const isTextual =
     !hasTransferEncoding &&
-    (contentType === "" ||
+    (contentType === undefined ||
+      contentType === "" ||
       contentType.startsWith("text/") ||
       contentType.includes("json") ||
       contentType.includes("xml") ||
@@ -457,7 +468,7 @@ function capturedToResult(captured: CapturedResponse): RouteHandlerResult {
   }
   const text = buffer.toString("utf8");
   let body: unknown = text;
-  if (contentType.includes("json")) {
+  if (contentType?.includes("json")) {
     try {
       body = JSON.parse(text);
     } catch {

--- a/packages/app/test/ui-smoke/all-pages-clicksafe.spec.ts
+++ b/packages/app/test/ui-smoke/all-pages-clicksafe.spec.ts
@@ -347,6 +347,16 @@ const CORE_ROUTE_PROBES: readonly RouteProbe[] = [
     readyChecks: [{ selector: "#root" }],
     timeoutMs: 60_000,
   },
+  {
+    // /pendant/transcript renders the realtime pendant transcription view
+    // (#15806). Without a paired pendant the view shows its designed
+    // disconnected state; like the device deep links above, the sweep proves
+    // the shell renders it without crashing.
+    name: "pendant transcript deep link",
+    path: "/pendant/transcript",
+    readyChecks: [{ selector: "#root" }],
+    timeoutMs: 60_000,
+  },
 ];
 
 function coreRouteProbe(name: string): RouteProbe {

--- a/packages/scripts/type-safety-ratchet-baseline.json
+++ b/packages/scripts/type-safety-ratchet-baseline.json
@@ -49,11 +49,11 @@
     "asAny": 0,
     "explicitAny": 124,
     "tsSuppress": 0,
-    "nonNullAssertion": 496,
-    "nullishEmptyString": 581,
-    "nullishEmptyArray": 581,
+    "nonNullAssertion": 488,
+    "nullishEmptyString": 579,
+    "nullishEmptyArray": 580,
     "nullishEmptyObject": 375,
-    "nullishZero": 374
+    "nullishZero": 369
   },
-  "filesScanned": 10432
+  "filesScanned": 10419
 }


### PR DESCRIPTION
Two develop push lanes went red on `1f834bfce2` ([Quality ratchet](https://github.com/elizaOS/eliza/actions/runs/29079182684/job/86317820326), [Zero-Key coverage](https://github.com/elizaOS/eliza/actions/runs/29079182729/job/86318071572)). This restores both.

**Rebased onto develop `5e1da4085f7` (post-#15989 revert).** Both modify/delete conflicts on `packages/agent/src/api/audio-redaction.ts` / `audio-redaction.test.ts` were resolved by keeping the #15989 deletion — this branch no longer touches either file. The WAV `as unknown as BodyInit` cast from `cfd5176b0d` is intentionally out of scope (tracked in the #16003/#16017 lane).

## Summary
- **Type-safety ratchet**: the IPC bridge (`packages/agent/src/api/dispatch-route.ts`) now models absent `content-type` / `content-encoding` headers explicitly (`undefined`) instead of adding two `?? ""` fallbacks; absent headers keep the bridge's historical UTF-8 textual behavior. The substring MIME classifier is untouched (no overlap with the closed #15992). Ratchet baselines are regenerated from the exact post-revert tree: 10,419 scanned source files; `?? ""` 579, `?? []` 580, `?? {}` 375, `?? 0` 369, non-null assertions 488 (as-unknown-as 74, `: any` 124 unchanged).
- **Route coverage** (`Missing app all-pages route smoke coverage for: /pendant/transcript`): #15806 registered the route with no smoke entry; `packages/app/test/ui-smoke/all-pages-clicksafe.spec.ts` now deep-links it like the sibling device views (designed disconnected state, shell must render without crashing).

## Files
- `packages/agent/src/api/dispatch-route.ts` — explicit header-absence handling in `capturedToResult` (no behavior change; classifier untouched)
- `packages/agent/src/api/dispatch-route-binary-response.test.ts` — 2 new cases: absent content-type, identity-encoded + empty content-type
- `packages/agent/src/api/dispatch-route-onchunk.test.ts` — asserts the buffered SSE result keeps its `content-type` header
- `packages/app/test/ui-smoke/all-pages-clicksafe.spec.ts` — `/pendant/transcript` route probe
- `packages/scripts/type-safety-ratchet-baseline.json` — regenerated post-revert baseline (exact counts)

## Verification (current head, isolated worktree with full workspace deps)
- `node packages/scripts/type-safety-ratchet.mjs` → exit 0, every metric exactly at baseline (transcript below).
- Focused dispatcher suites (`dispatch-route-binary-response`, `dispatch-route-onchunk`, `dispatch-route.x402`) → 18/18 pass on this head (transcript below; the earlier fs-extra resolution failure was an isolated-worktree dependency-graph artifact, resolved by running against the fully installed workspace).
- `bunx vitest run test/route-coverage.test.ts` (packages/app) → 9/9 pass. Reproduction confirmed: with develop's spec (probe removed) the gate fails `Missing app all-pages route smoke coverage for: /pendant/transcript` (transcript below).
- `bunx biome check` on all 5 changed files: clean.
- Changed-file CI on this head: typecheck / lint / build / coverage-on-changed-files all green.

<details>
<summary>type-safety-ratchet run (current head, exit 0)</summary>

```
[type-safety-ratchet] scanned 10419 tracked production source files
[type-safety-ratchet] as unknown as: 74 / 74
[type-safety-ratchet] as any: 0 / 0
[type-safety-ratchet] explicit `: any` annotation: 124 / 124
[type-safety-ratchet] @ts-expect-error / @ts-ignore: 0 / 0
[type-safety-ratchet] non-null assertion (!): 488 / 488
[type-safety-ratchet] `?? ""` (core/agent/app-core): 579 / 579
[type-safety-ratchet] `?? []` (core/agent/app-core): 580 / 580
[type-safety-ratchet] `?? {}` (core/agent/app-core): 375 / 375
[type-safety-ratchet] `?? 0` (core/agent/app-core): 369 / 369
EXIT=0
```
</details>

<details>
<summary>Focused dispatcher suites (current head, 18/18)</summary>

```
 ✓ src/api/dispatch-route-binary-response.test.ts > dispatchRoute captured response finalization > preserves invalid UTF-8 bytes through the Android buffered IPC envelope 4ms
 ✓ src/api/dispatch-route-binary-response.test.ts > dispatchRoute captured response finalization > keeps binary bodies as buffers when inProcess=true 1ms
 ✓ src/api/dispatch-route-binary-response.test.ts > dispatchRoute captured response finalization > keeps binary bodies as buffers when inProcess=false 0ms
 ✓ src/api/dispatch-route-binary-response.test.ts > dispatchRoute captured response finalization > does not decode content-encoded text before the client handles it 0ms
 ✓ src/api/dispatch-route-binary-response.test.ts > dispatchRoute captured response finalization > preserves textual and JSON response compatibility 2ms
 ✓ src/api/dispatch-route-binary-response.test.ts > dispatchRoute captured response finalization > treats absent content-type as textual UTF-8 0ms
 ✓ src/api/dispatch-route-binary-response.test.ts > dispatchRoute captured response finalization > keeps identity-encoded and empty content-type responses textual 1ms
 ✓ src/api/dispatch-route-binary-response.test.ts > dispatchRoute captured response finalization > returns malformed JSON as raw text and empty responses as undefined 1ms
 ✓ src/api/dispatch-route.x402.test.ts > dispatch-route x402 guard (item 10) > vetX402Module > rejects a missing plugin (null) 1ms
 ✓ src/api/dispatch-route.x402.test.ts > dispatch-route x402 guard (item 10) > vetX402Module > rejects the real mobile null stub via __mobileStub 1ms
 ✓ src/api/dispatch-route.x402.test.ts > dispatch-route x402 guard (item 10) > vetX402Module > rejects a module missing the payment helpers 0ms
 ✓ src/api/dispatch-route.x402.test.ts > dispatch-route x402 guard (item 10) > vetX402Module > accepts a module exposing both payment helpers 0ms
 ✓ src/api/dispatch-route.x402.test.ts > dispatch-route x402 guard (item 10) > selectX402Handler > falls through to the unwrapped handler when x402 is unavailable 0ms
 ✓ src/api/dispatch-route.x402.test.ts > dispatch-route x402 guard (item 10) > selectX402Handler > wraps the handler when x402 is present and route is not yet wrapped 0ms
 ✓ src/api/dispatch-route.x402.test.ts > dispatch-route x402 guard (item 10) > selectX402Handler > does not double-wrap an already payment-wrapped route 0ms
 ✓ src/api/dispatch-route-onchunk.test.ts > dispatchRoute onChunk sink (#12352) > forwards each SSE fragment live and returns the buffered body 1ms
 ✓ src/api/dispatch-route-onchunk.test.ts > dispatchRoute onChunk sink (#12352) > does not invoke the sink when a handler only sends a buffered JSON body 1ms
 ✓ src/api/dispatch-route-onchunk.test.ts > dispatchRoute onChunk sink (#12352) > omitting onChunk is byte-for-byte identical to today (HTTP path) 0ms
 Test Files  3 passed (3)
      Tests  18 passed (18)
```
</details>

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI-lane and non-rendered code fix; no UI pixels changed (the pendant view itself shipped in #15806; this adds only its smoke-matrix entry).
<!-- evidence-row:after-screenshots -->
- [x] N/A - CI-lane and non-rendered code fix; no UI pixels changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow changed.
<!-- evidence-row:backend-logs -->
- [x] Ratchet + focused dispatcher transcripts inline above (current head); combined earlier log: [develop-red-fix-evidence.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/develop-red-fix-evidence.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - CI red-lane and test coverage repair does not change frontend runtime behavior.

  ```
   ✓ test/route-coverage.test.ts > app route coverage gate > route smoke matrix covers catalog and app-window routes 7ms
   ✓ test/route-coverage.test.ts > app route coverage gate > manager-visible view tile matrix tracks every manager-visible gui view 6ms
   ✓ test/route-coverage.test.ts > app route coverage gate > discovers every production plugin view manifest in the manifest ratchet 194ms
   ✓ test/route-coverage.test.ts > app route coverage gate > plugin views visual matrix covers every bundled gui view 2ms
   ✓ test/route-coverage.test.ts > app route coverage gate > operator plugin view manifests keep the shipped gui contract 1ms
   ✓ test/route-coverage.test.ts > app route coverage gate > tracked plugin view visual review report covers every visual matrix case 1ms
   ✓ test/route-coverage.test.ts > app route coverage gate > plugin view manifest ratchet tracks compiled app plugin loaders 20ms
   ✓ test/route-coverage.test.ts > app route coverage gate > compiled app plugin loaders have packaged workspace dependencies 6ms
   ✓ test/route-coverage.test.ts > app route coverage gate > every plugin view manifest is app-boot mapped or explicitly classified 0ms
   Test Files  1 passed (1)
        Tests  9 passed (9)

  # Reproduction with develop's spec (probe removed):
   × route smoke matrix covers catalog and app-window routes 17ms
  AssertionError: Missing app all-pages route smoke coverage for: /pendant/transcript: expected [ '/pendant/transcript' ] to deeply equal []
  ```
  </details>
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Regenerated type-safety ratchet baseline committed in this diff ([packages/scripts/type-safety-ratchet-baseline.json](https://github.com/elizaOS/eliza/blob/c5fc63b5dc79389f8ee3b9571503e0ebd7e2bfbe/packages/scripts/type-safety-ratchet-baseline.json)) — exact post-revert counts locked at 579/580/375/369/488; ratchet run transcript inline in the backend-logs details block above (exit 0, every metric at baseline).