### PR TITLE
fix(ci): require LCOV for every changed source

### DIFF
--- a/scripts/security/coverage-gate.awk
+++ b/scripts/security/coverage-gate.awk
@@ -65,6 +65,7 @@ function path_matches_lcov(current_path, changed_path,    current_len, changed_l
       if (path_matches_lcov(current, cf)) { matched = cf; break }
     }
     if (matched != "") {
+      matched_map[matched] = 1
       changed_count++
       changed_sum += pct
       printf "  %6.2f%% %s\n", pct, matched
@@ -75,25 +76,33 @@ function path_matches_lcov(current_path, changed_path,    current_len, changed_l
 }
 
 END {
+  missing_count = 0
+  for (f in changed_map) {
+    if (!(f in matched_map)) {
+      printf "  MISSING: %s\n", f
+      missing_count++
+    }
+  }
+
   if (changed_count == 0) {
     print "no changed files matched the LCOV report"
-    if (changed != "" && ENVIRON["COVERAGE_GATE_ENFORCE"] == "1") {
-      print "coverage gate FAILED (changed source missing from LCOV)"
-      exit 1
-    }
-    exit 0
+  } else {
+    avg = changed_sum / changed_count
+    printf "\nchanged files: %d, mean coverage: %.2f%%, threshold: %d%%\n", \
+      changed_count, avg, threshold
   }
-  avg = changed_sum / changed_count
-  printf "\nchanged files: %d, mean coverage: %.2f%%, threshold: %d%%\n", \
-    changed_count, avg, threshold
 
-  fail = 0
+  fail = missing_count > 0
   for (f in below) {
     printf "  BELOW: %s (%.2f%%)\n", f, below[f]
     fail = 1
   }
   if (fail && ENVIRON["COVERAGE_GATE_ENFORCE"] == "1") {
-    print "coverage gate FAILED (enforcement enabled)"
+    if (missing_count > 0) {
+      print "coverage gate FAILED (changed source missing from LCOV)"
+    } else {
+      print "coverage gate FAILED (enforcement enabled)"
+    }
     exit 1
   }
   if (fail) {

--- a/scripts/security/coverage-gate.awk
+++ b/scripts/security/coverage-gate.awk
@@ -61,8 +61,12 @@ function path_matches_lcov(current_path, changed_path,    current_len, changed_l
     # the changed list is repo-relative, so accept only exact path-segment
     # suffixes; raw substring matching lets foo.ts pass via foo.tsx.
     matched = ""
+    matched_len = 0
     for (cf in changed_map) {
-      if (path_matches_lcov(current, cf)) { matched = cf; break }
+      if (path_matches_lcov(current, cf) && length(cf) > matched_len) {
+        matched = cf
+        matched_len = length(cf)
+      }
     }
     if (matched != "") {
       matched_map[matched] = 1

--- a/scripts/security/coverage-gate.self-test.mjs
+++ b/scripts/security/coverage-gate.self-test.mjs
@@ -84,6 +84,18 @@ try {
     assert.equal(result.status, 1, result.stdout);
     assert.match(result.stdout, /changed source missing from LCOV/);
   });
+
+  assertGate("fails when any changed source is absent from LCOV", () => {
+    const covered = "packages/demo/src/covered.ts";
+    const missing = "packages/demo/src/missing.ts";
+    const lcov = writeLcov(dir, covered);
+    const result = runGate({ changed: `${covered}\n${missing}`, lcov });
+
+    assert.equal(result.status, 1, result.stdout);
+    assert.match(result.stdout, /100\.00% packages\/demo\/src\/covered\.ts/);
+    assert.match(result.stdout, /MISSING: packages\/demo\/src\/missing\.ts/);
+    assert.match(result.stdout, /changed source missing from LCOV/);
+  });
 } finally {
   rmSync(dir, { recursive: true, force: true });
 }

--- a/scripts/security/coverage-gate.self-test.mjs
+++ b/scripts/security/coverage-gate.self-test.mjs
@@ -26,11 +26,12 @@ function writeLcov(dir, sourcePath, found = 2, hit = 2) {
 }
 
 function runGate({ changed, lcov, enforce = true, threshold = 50 }) {
+  const changedArgument = changed.replaceAll("\\", "\\\\").replaceAll("\n", "\\n");
   return spawnSync(
     "awk",
     [
       "-v",
-      `changed=${changed}`,
+      `changed=${changedArgument}`,
       "-v",
       `threshold=${threshold}`,
       "-f",

--- a/scripts/security/coverage-gate.self-test.mjs
+++ b/scripts/security/coverage-gate.self-test.mjs
@@ -25,6 +25,23 @@ function writeLcov(dir, sourcePath, found = 2, hit = 2) {
   return file;
 }
 
+function writeLcovRecords(dir, sourcePaths) {
+  const file = join(dir, "lcov.info");
+  writeFileSync(
+    file,
+    sourcePaths
+      .flatMap((sourcePath) => [
+        `SF:${sourcePath}`,
+        "LF:2",
+        "LH:2",
+        "end_of_record",
+      ])
+      .concat("")
+      .join("\n"),
+  );
+  return file;
+}
+
 function runGate({ changed, lcov, enforce = true, threshold = 50 }) {
   const changedArgument = changed.replaceAll("\\", "\\\\").replaceAll("\n", "\\n");
   return spawnSync(
@@ -96,6 +113,21 @@ try {
     assert.match(result.stdout, /100\.00% packages\/demo\/src\/covered\.ts/);
     assert.match(result.stdout, /MISSING: packages\/demo\/src\/missing\.ts/);
     assert.match(result.stdout, /changed source missing from LCOV/);
+  });
+
+  assertGate("prefers the longest matching changed path", () => {
+    const rootPath = "src/foo.ts";
+    const nestedPath = "packages/demo/src/foo.ts";
+    const lcov = writeLcovRecords(dir, [
+      `/workspace/eliza/${rootPath}`,
+      `/workspace/eliza/${nestedPath}`,
+    ]);
+    const result = runGate({ changed: `${rootPath}\n${nestedPath}`, lcov });
+
+    assert.equal(result.status, 0, result.stdout);
+    assert.match(result.stdout, /100\.00% src\/foo\.ts/);
+    assert.match(result.stdout, /100\.00% packages\/demo\/src\/foo\.ts/);
+    assert.doesNotMatch(result.stdout, /MISSING:/);
   });
 } finally {
   rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

The changed-file coverage gate previously ignored changed source files missing from LCOV whenever at least one other changed file was present. This records every matched source and fails enforcement if any changed source is absent.

The self-test adds the mixed covered/missing case. Its multi-file argument is escaped before passing through `awk -v`, preserving the embedded newline on both BSD awk and GNU/mawk.

## Validation

- `node scripts/security/coverage-gate.self-test.mjs`  5 checks passed locally, including the mixed covered/missing case.
- `bunx biome check scripts/security/coverage-gate.self-test.mjs scripts/security/coverage-gate.awk`  passed.

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - CI enforcement script only; no rendered surface.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - CI enforcement script only; no rendered surface.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - non-interactive CI gate.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no backend runtime path; the executable self-test is the verification surface.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend code or network path.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, prompt, action, provider, or model behavior.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - the change produces CI pass/fail status only and persists no domain state.