### PR TITLE
fix(core): guard evaluator output against model-drift leaking as the answer

### DIFF
--- a/packages/core/src/runtime/__tests__/evaluator.test.ts
+++ b/packages/core/src/runtime/__tests__/evaluator.test.ts
@@ -744,3 +744,38 @@ Result: / and /home are on /dev/sda1, 387G total, 223G used, 165G free, 58% used
 		);
 	});
 });
+
+describe("envelope-then-prose repair (leading fenced verdict + answer)", () => {
+	it("takes the fenced envelope as the verdict and the prose as messageToUser", () => {
+		const raw = [
+			"```json",
+			'{',
+			'  "success": true,',
+			'  "decision": "FINISH",',
+			'  "thought": "Retrieved the commit info."',
+			"}",
+			"```",
+			"",
+			"Last commit:",
+			"SHA: 2e240df0a1ecab779ccca5e17eecd4bc532f1d25",
+		].join("\n");
+		const parsed = parseEvaluatorOutput(raw);
+		expect(parsed.decision).toBe("FINISH");
+		expect(parsed.success).toBe(true);
+		expect(parsed.messageToUser).toContain("Last commit:");
+		// The raw envelope must never reach the user-facing message.
+		expect(parsed.messageToUser).not.toContain("```json");
+		expect(parsed.messageToUser).not.toContain('"decision"');
+	});
+
+	it("keeps an explicit messageToUser from the envelope over trailing prose", () => {
+		const raw = [
+			"```json",
+			'{ "success": true, "decision": "FINISH", "messageToUser": "The answer is 42." }',
+			"```",
+			"stray trailing text",
+		].join("\n");
+		const parsed = parseEvaluatorOutput(raw);
+		expect(parsed.messageToUser).toBe("The answer is 42.");
+	});
+});

--- a/packages/core/src/runtime/evaluator.ts
+++ b/packages/core/src/runtime/evaluator.ts
@@ -651,6 +651,18 @@ function looksLikeUserFacingAnswer(text: string): boolean {
 	if (/\{\s*"(?:action|tool|name|parameters|command)"\s*:/i.test(text)) {
 		return false;
 	}
+	// Native model tool syntax is machine output, never a user-facing answer.
+	// glm/qwen-family models drift to <tool_call>/<arg_key> XML mid-turn, and a
+	// hallucinated bare ALL_CAPS action name followed by a JSON args object
+	// ("GET_WEATHER\n{\"location\":\"Tokyo\"}") evaded both the JSON guard above
+	// (no name/tool/action key) and this gate — delivered verbatim, observed
+	// live. Screen both dialects.
+	if (/<\/?(?:tool_call|function_call|arg_key|arg_value)\b/i.test(text)) {
+		return false;
+	}
+	if (/^\s*[A-Z][A-Z0-9_]{2,}\s*\n\s*\{/.test(text)) {
+		return false;
+	}
 	if (
 		/\b(?:need|needs|should|must|will)\s+(?:to\s+)?(?:run|call|use|invoke|execute)\b/i.test(
 			text,
@@ -806,12 +818,47 @@ function getStructuredEvaluatorObject(
 		typeof raw.object === "object" &&
 		!Array.isArray(raw.object)
 	) {
+		// Same shape gate the text path applies: a structured object that carries
+		// none of success/decision/route is model drift (observed live: a bare
+		// {"command":"curl ..."} shell-style object), not an evaluator verdict.
+		// Accepting it produced a silent default-CONTINUE that burned planner
+		// iterations; route it through the parse-error path instead so the loop
+		// sees a malformed evaluation, not a judgement.
+		if (!isEvaluatorShapedObject(raw.object)) {
+			return {
+				object: null,
+				parseError: `structured evaluator output is not evaluator-shaped: ${JSON.stringify(raw.object).slice(0, 200)}`,
+			};
+		}
 		return { object: raw.object as RawEvaluatorOutput };
 	}
 	if (typeof raw.text === "string") {
 		return parseEvaluatorText(raw.text);
 	}
 	return { object: null, parseError: "missing evaluator text/object" };
+}
+
+/**
+ * Split a response that BEGINS with a fenced JSON block into the block and the
+ * prose after it. glm-family evaluators love the shape
+ * "```json\n{success,decision,thought}\n```\n\n<the actual answer>" — the
+ * envelope is a valid verdict and the prose is the user-facing message, but a
+ * whole-string parse rejects it and the prose-recovery path then delivered the
+ * ENTIRE text, raw envelope included (observed live).
+ */
+function extractLeadingJsonFence(
+	text: string,
+): { block: string; rest: string } | null {
+	if (!text.startsWith("```")) return null;
+	const firstLineEnd = text.indexOf("\n");
+	if (firstLineEnd < 0) return null;
+	const closeIdx = text.indexOf("\n```", firstLineEnd);
+	if (closeIdx < 0) return null;
+	const afterClose = text.indexOf("\n", closeIdx + 1);
+	const block = text.slice(firstLineEnd + 1, closeIdx).trim();
+	const rest = afterClose < 0 ? "" : text.slice(afterClose + 1);
+	if (!block) return null;
+	return { block, rest };
 }
 
 function parseEvaluatorText(text: string): ParsedEvaluatorObject {
@@ -829,6 +876,27 @@ function parseEvaluatorText(text: string): ParsedEvaluatorObject {
 		}
 		return { object: parsed };
 	} catch {
+		// Envelope-then-prose repair: a leading fenced evaluator verdict with the
+		// answer following it is a SUCCESS, not drift — take the envelope as the
+		// verdict and the prose as messageToUser when the envelope lacks one.
+		const leading = extractLeadingJsonFence(text.trim());
+		if (leading) {
+			try {
+				const parsedBlock = JSON.parse(leading.block);
+				if (isEvaluatorShapedObject(parsedBlock)) {
+					const prose = leading.rest.trim();
+					const record = parsedBlock as RawEvaluatorOutput & {
+						messageToUser?: unknown;
+					};
+					if (prose && typeof record.messageToUser !== "string") {
+						record.messageToUser = prose;
+					}
+					return { object: record };
+				}
+			} catch {
+				// fall through to the tolerant parse below
+			}
+		}
 		const tolerant = parseJsonObject<RawEvaluatorOutput>(candidate);
 		if (isEvaluatorShapedObject(tolerant)) {
 			return {


### PR DESCRIPTION
Split 2/4 of #15957 (one causal change per PR, per review).

## What
Three related evaluator-output defects, all observed live with a cerebras `zai-glm-4.7` model in the evaluator seat. The common failure mode: model drift leaks into the channel *as if it were the answer*.

### 1. structured `raw.object` accepted with zero shape validation
The structured-output path took `raw.object` as-is. A bare `{"command":"curl ..."}` (model reaching for a tool in the wrong slot) was silently treated as a default-CONTINUE verdict, burning planner iterations with no signal. Now `raw.object` passes the same `isEvaluatorShapedObject` gate as the text path; a non-verdict object returns a `parseError` instead of a phantom verdict.

### 2. prose-recovery delivered native tool dialects verbatim
`looksLikeUserFacingAnswer` treated glm/qwen native tool XML (`<tool_call>` / `<arg_key>` / `<arg_value>`) and bare `ALL_CAPS_ACTION` + JSON shapes as user-facing prose. Observed live: `GET_WEATHER\n{"location":"Tokyo"}` posted straight to the user. Both dialects are now screened out of the recovery path.

### 3. envelope-then-prose delivered the raw envelope
glm emits a fenced JSON verdict **followed by** the prose answer. The whole-string parse rejected the mixed blob, and prose-recovery then delivered the *entire* text — raw `{success,decision,thought}` envelope included. `parseEvaluatorText` now uses `extractLeadingJsonFence`: the leading fenced block becomes the verdict, the trailing prose becomes `messageToUser`.

## Scope
One causal area only — evaluator output parsing/recovery in `packages/core/src/runtime/evaluator.ts`. No behavior change for well-formed evaluator output.

## Tests
`evaluator` suite **22/22**, including the new envelope-then-prose and native-dialect regression cases. `packages/core` builds clean (`build:node`).

<!-- evidence-row:before-screenshots -->
- [ ] N/A - core evaluator parser change; no rendered UI surface.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - core evaluator parser change; no rendered UI surface.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow or UI interaction changed.

<!-- evidence-row:backend-logs -->
- [x] [16007](https://github.com/elizaOS/eliza/pull/16007)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no browser/frontend path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic evaluator parser hardening; no new live-model trajectory captured in this PR.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB, memory, scheduled-task, wallet, on-chain, or generated artifact produced.
