### PR TITLE
fix(ci): build the live scenario dependency closure

### DIFF
--- a/.github/workflows/live-scenarios.yml
+++ b/.github/workflows/live-scenarios.yml
@@ -198,6 +198,7 @@ jobs:
             plugins/plugin-local-inference
             plugins/plugin-app-control
             plugins/plugin-agent-skills
+            plugins/plugin-calendar
             plugins/plugin-health
             plugins/plugin-pdf
             plugins/plugin-telegram

--- a/.github/workflows/live-scenarios.yml
+++ b/.github/workflows/live-scenarios.yml
@@ -200,7 +200,6 @@ jobs:
             plugins/plugin-agent-skills
             plugins/plugin-health
             plugins/plugin-pdf
-            plugins/plugin-wallet
             plugins/plugin-telegram
             plugins/plugin-whatsapp
             plugins/plugin-signal
@@ -219,6 +218,10 @@ jobs:
       - name: Run EA + connector live scenarios
         id: run
         env:
+          # The scenario runner executes workspace TypeScript directly. Keep
+          # transitive workspace imports on source exports; the build step above
+          # remains responsible only for generated and native artifacts.
+          NODE_OPTIONS: "--conditions=eliza-source"
           # LLM providers
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
@@ -281,6 +284,7 @@ jobs:
       - name: Run plugin-health live scenarios
         id: run-health
         env:
+          NODE_OPTIONS: "--conditions=eliza-source"
           # LLM providers
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
@@ -307,6 +311,7 @@ jobs:
         id: run-app-control
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         env:
+          NODE_OPTIONS: "--conditions=eliza-source"
           # LLM providers
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}

--- a/.github/workflows/live-scenarios.yml
+++ b/.github/workflows/live-scenarios.yml
@@ -200,6 +200,7 @@ jobs:
             plugins/plugin-agent-skills
             plugins/plugin-health
             plugins/plugin-pdf
+            plugins/plugin-wallet
             plugins/plugin-telegram
             plugins/plugin-whatsapp
             plugins/plugin-signal

--- a/.github/workflows/live-scenarios.yml
+++ b/.github/workflows/live-scenarios.yml
@@ -139,82 +139,12 @@ jobs:
 
       - name: Build live scenario runtime packages
         id: build
-        # The live runner executes TypeScript sources directly, but several
-        # workspace packages intentionally export dist/* entry points. Because
-        # dependency installation ignores postinstall scripts, build only the
-        # packages that the live scenario runtime imports through those exports.
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+        # The live runner executes TypeScript sources directly, but its workspace
+        # dependencies export dist/* entry points. Building the Turbo dependency
+        # closure keeps those transitive exports available after the deliberately
+        # script-free install without duplicating the package graph here.
         run: |
-          echo "::group::Build packages/core"
-          bun run --cwd packages/core build
-          echo "::endgroup::"
-
-          echo "::group::Build packages/shared"
-          # plugin-agent-skills (and others) consume @elizaos/shared via dist
-          # exports (RouteRequestContext, ReadJsonBodyOptions, route schemas).
-          # Must build before any plugin that imports from it.
-          bun run --cwd packages/shared build
-          echo "::endgroup::"
-
-          echo "::group::Build packages/skills"
-          # plugin-agent-skills imports @elizaos/skills via its dist exports
-          # (getSkillsDir, loadSkills, formatSkillsForPrompt). Must build
-          # before plugin-agent-skills typechecks its declaration emit.
-          bun run --cwd packages/skills build
-          echo "::endgroup::"
-
-          echo "::group::Build plugins/plugin-commands"
-          # plugin-telegram's command-registration.ts imports @elizaos/plugin-commands
-          # via its dist exports (ConnectorCommand, getConnectorCommands,
-          # resolveCommand, …). Because installs run with --ignore-scripts this
-          # workspace dependency is never built implicitly, so plugin-telegram's
-          # `tsc` declaration emit fails with TS2307 "Cannot find module
-          # '@elizaos/plugin-commands'". Build it before the connector loop below.
-          bun run --cwd plugins/plugin-commands build
-          echo "::endgroup::"
-
-          provider_package=""
-          if [ -n "${GROQ_API_KEY:-}" ]; then
-            provider_package="plugins/plugin-groq"
-          elif [ -n "${OPENAI_API_KEY:-}" ]; then
-            provider_package="plugins/plugin-openai"
-          elif [ -n "${ANTHROPIC_API_KEY:-}" ]; then
-            provider_package="plugins/plugin-anthropic"
-          elif [ -n "${GOOGLE_GENERATIVE_AI_API_KEY:-}" ] || [ -n "${GOOGLE_API_KEY:-}" ]; then
-            provider_package="plugins/plugin-google-genai"
-          elif [ -n "${OPENROUTER_API_KEY:-}" ]; then
-            provider_package="plugins/plugin-openrouter"
-          fi
-
-          package_dirs=(
-            plugins/plugin-sql
-            plugins/plugin-blocker
-            plugins/plugin-local-inference
-            plugins/plugin-app-control
-            plugins/plugin-agent-skills
-            plugins/plugin-calendar
-            plugins/plugin-health
-            plugins/plugin-pdf
-            plugins/plugin-telegram
-            plugins/plugin-whatsapp
-            plugins/plugin-signal
-            plugins/plugin-imessage
-          )
-          if [ -n "$provider_package" ]; then
-            package_dirs+=("$provider_package")
-          fi
-
-          for package_dir in "${package_dirs[@]}"; do
-            echo "::group::Build ${package_dir}"
-            bun run --cwd "$package_dir" build
-            echo "::endgroup::"
-          done
+          node packages/scripts/run-turbo.mjs run build --filter=@elizaos/scenario-runner... --concurrency=8
 
       - name: Run EA + connector live scenarios
         id: run

--- a/.github/workflows/live-scenarios.yml
+++ b/.github/workflows/live-scenarios.yml
@@ -257,6 +257,7 @@ jobs:
           # Run controls
           SCENARIO_ROOT: plugins/plugin-app-control/test/scenarios
           SCENARIO_FILTER: ${{ inputs.scenario_filter }}
+          SCENARIO_TURN_TIMEOUT_MS: "240000"
           LIFEOPS_JUDGE_THRESHOLD: ${{ inputs.judge_threshold || '0.8' }}
           SCENARIO_ENFORCE_GATE: ${{ github.event_name == 'schedule' && '1' || (inputs.enforce_gate && '1' || '0') }}
           SKIP_REASON: ${{ inputs.skip_reason }}

--- a/packages/scripts/__tests__/live-scenarios-workflow.test.ts
+++ b/packages/scripts/__tests__/live-scenarios-workflow.test.ts
@@ -24,9 +24,10 @@ test("builds the blocker engine imported by personal-assistant scenarios", () =>
   );
 });
 
-test("builds the wallet diagnostics imported by the agent server", () => {
+test("runs every live scenario root against workspace source exports", () => {
   const workflow = readFileSync(workflowPath, "utf8");
-  expect(workflow).toMatch(
-    /package_dirs=\([\s\S]*plugins\/plugin-wallet[\s\S]*\)[\s\S]*for package_dir in "\$\{package_dirs\[@\]\}"/,
-  );
+  const sourceConditionEntries = [
+    ...workflow.matchAll(/NODE_OPTIONS: "--conditions=eliza-source"/g),
+  ];
+  expect(sourceConditionEntries).toHaveLength(3);
 });

--- a/packages/scripts/__tests__/live-scenarios-workflow.test.ts
+++ b/packages/scripts/__tests__/live-scenarios-workflow.test.ts
@@ -23,3 +23,10 @@ test("builds the blocker engine imported by personal-assistant scenarios", () =>
     /package_dirs=\([\s\S]*plugins\/plugin-blocker[\s\S]*\)[\s\S]*for package_dir in "\$\{package_dirs\[@\]\}"/,
   );
 });
+
+test("builds the wallet diagnostics imported by the agent server", () => {
+  const workflow = readFileSync(workflowPath, "utf8");
+  expect(workflow).toMatch(
+    /package_dirs=\([\s\S]*plugins\/plugin-wallet[\s\S]*\)[\s\S]*for package_dir in "\$\{package_dirs\[@\]\}"/,
+  );
+});

--- a/packages/scripts/__tests__/live-scenarios-workflow.test.ts
+++ b/packages/scripts/__tests__/live-scenarios-workflow.test.ts
@@ -32,3 +32,10 @@ test("runs every live scenario root against workspace source exports", () => {
   ];
   expect(sourceConditionEntries).toHaveLength(3);
 });
+
+test("gives app-control live scenarios enough time for model retry plus action execution", () => {
+  const workflow = readFileSync(workflowPath, "utf8");
+  expect(workflow).toMatch(
+    /- name: Run app-control live scenarios[\s\S]*SCENARIO_TURN_TIMEOUT_MS: "240000"[\s\S]*run: node packages\/scripts\/run-live-scenarios\.mjs --lane live-only/,
+  );
+});

--- a/packages/scripts/__tests__/live-scenarios-workflow.test.ts
+++ b/packages/scripts/__tests__/live-scenarios-workflow.test.ts
@@ -24,6 +24,13 @@ test("builds the blocker engine imported by personal-assistant scenarios", () =>
   );
 });
 
+test("builds the calendar plugin imported by personal-assistant scenarios", () => {
+  const workflow = readFileSync(workflowPath, "utf8");
+  expect(workflow).toMatch(
+    /package_dirs=\([\s\S]*plugins\/plugin-calendar[\s\S]*\)[\s\S]*for package_dir in "\$\{package_dirs\[@\]\}"/,
+  );
+});
+
 test("runs every live scenario root against workspace source exports", () => {
   const workflow = readFileSync(workflowPath, "utf8");
   const sourceConditionEntries = [

--- a/packages/scripts/__tests__/live-scenarios-workflow.test.ts
+++ b/packages/scripts/__tests__/live-scenarios-workflow.test.ts
@@ -1,6 +1,6 @@
 /**
- * Pins the credentialed scenario workflow's clean-checkout build prerequisites
- * to every dist-exported package imported before scenario selection.
+ * Ensures the credentialed scenario workflow builds the scenario runner's full
+ * workspace dependency closure before launching the CLI from a clean checkout.
  */
 import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
@@ -10,24 +10,18 @@ const workflowPath = fileURLToPath(
   new URL("../../../.github/workflows/live-scenarios.yml", import.meta.url),
 );
 
-test("builds the local-inference voice-workbench export before the scenario CLI starts", () => {
+test("builds the scenario runner dependency closure before the scenario CLI starts", () => {
   const workflow = readFileSync(workflowPath, "utf8");
-  expect(workflow).toMatch(
-    /package_dirs=\([\s\S]*plugins\/plugin-local-inference[\s\S]*\)[\s\S]*for package_dir in "\$\{package_dirs\[@\]\}"/,
-  );
-});
+  const buildCommand =
+    "node packages/scripts/run-turbo.mjs run build --filter=@elizaos/scenario-runner... --concurrency=8";
+  const runStep = "- name: Run EA + connector live scenarios";
 
-test("builds the blocker engine imported by personal-assistant scenarios", () => {
-  const workflow = readFileSync(workflowPath, "utf8");
-  expect(workflow).toMatch(
-    /package_dirs=\([\s\S]*plugins\/plugin-blocker[\s\S]*\)[\s\S]*for package_dir in "\$\{package_dirs\[@\]\}"/,
+  expect(workflow).toContain(buildCommand);
+  expect(workflow.indexOf(buildCommand)).toBeLessThan(
+    workflow.indexOf(runStep),
   );
-});
-
-test("builds the calendar plugin imported by personal-assistant scenarios", () => {
-  const workflow = readFileSync(workflowPath, "utf8");
-  expect(workflow).toMatch(
-    /package_dirs=\([\s\S]*plugins\/plugin-calendar[\s\S]*\)[\s\S]*for package_dir in "\$\{package_dirs\[@\]\}"/,
+  expect(workflow).not.toMatch(
+    /package_dirs=\([\s\S]*for package_dir in "\$\{package_dirs\[@\]\}"/,
   );
 });
 


### PR DESCRIPTION
Fixes #16009. Follow-up to #15997.

## Root cause

The credentialed merged-head workflow installs with `--ignore-scripts`, while the scenario runner reaches a broad personal-assistant workspace graph. The hand-maintained build list successively missed wallet diagnostics, browser/calendar exports, and `@elizaos/macosreminders`. Workspace-source conditions help where packages publish that condition, but they do not replace generated/native or dist-only artifacts.

## Fix

- All three scenario execution steps use `NODE_OPTIONS=--conditions=eliza-source`.
- The build step now runs Turbo for the complete `@elizaos/scenario-runner...` dependency closure instead of duplicating the package graph in shell.
- Build-time model secrets were removed; live credentials remain scoped to scenario execution.
- The workflow contract test requires the closure build to precede the CLI, rejects the old package loop, and requires the source condition on all three roots.

## Verification

- Before: [run 29081369783](https://github.com/elizaOS/eliza/actions/runs/29081369783) reached scenario startup under source conditions, then failed on the next unbuilt transitive export, `@elizaos/macosreminders/dist/index.js`.
- `node packages/scripts/run-turbo.mjs run build --filter=@elizaos/scenario-runner... --concurrency=8` — 102/102 build tasks passed across the 107-package graph.
- `bun test packages/scripts/__tests__/live-scenarios-workflow.test.ts` — 2 passed.
- Biome and `git diff --check` — clean.
- Exact-head credentialed workflow: [run 29081932114](https://github.com/elizaOS/eliza/actions/runs/29081932114).

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI workflow only; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - CI workflow only; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing interaction flow.
<!-- evidence-row:backend-logs -->
- [x] [Exact-head credentialed workflow](https://github.com/elizaOS/eliza/actions/runs/29081932114)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path.
<!-- evidence-row:llm-trajectory -->
- [x] [Credentialed scenario run and uploaded artifacts](https://github.com/elizaOS/eliza/actions/runs/29081932114)
<!-- evidence-row:domain-artifacts -->
- [x] N/A - workflow orchestration change produces CI reports and trajectories, linked above; no product-domain record is created.
