### PR TITLE
chore(voice): prepare staging realtime ops rig

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -26,6 +26,7 @@ name: Cloud CF Deploy
 #   OPENROUTER_API_KEY, CEREBRAS_API_KEY, OPENAI_API_KEY, ANTHROPIC_API_KEY,
 #   GROQ_API_KEY, AI_GATEWAY_API_KEY, FAL_KEY, ELEVENLABS_API_KEY, VAST_API_KEY, VAST_BASE_URL.
 # Media/voice secrets, likewise published when configured (#13406):
+#   DEEPGRAM_API_KEY, CARTESIA_API_KEY
 #   FAL_API_KEY (the video provider registry reads FAL_KEY ?? FAL_API_KEY),
 #   ELIZA_VOICE_CATALOG_SIGNING_KEY_BASE64 + ELIZA_VOICE_CATALOG_PUBLIC_KEY_BASE64
 #   (Ed25519 keypair for the signed voice-model catalog; the catalog route 503s
@@ -467,6 +468,8 @@ jobs:
           # FAL_KEY ?? FAL_API_KEY, and prod carries it as FAL_API_KEY (#13406).
           FAL_API_KEY: ${{ secrets.FAL_API_KEY }}
           ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
+          DEEPGRAM_API_KEY: ${{ secrets.DEEPGRAM_API_KEY }}
+          CARTESIA_API_KEY: ${{ secrets.CARTESIA_API_KEY }}
           # Ed25519 keypair for the signed voice-model catalog —
           # /v1/voice-models/catalog 503s while the signing key is unset
           # (#13406). publish_secret no-ops with a notice while these are
@@ -522,6 +525,8 @@ jobs:
             FAL_KEY \
             FAL_API_KEY \
             ELEVENLABS_API_KEY \
+            DEEPGRAM_API_KEY \
+            CARTESIA_API_KEY \
             ELIZA_VOICE_CATALOG_SIGNING_KEY_BASE64 \
             ELIZA_VOICE_CATALOG_PUBLIC_KEY_BASE64 \
             VAST_API_KEY \
@@ -555,8 +560,15 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           KOKORO_TTS_URL: ${{ vars.ELIZA_VOICE_KOKORO_TTS_URL }}
+          DEPLOY_ENVIRONMENT: ${{ steps.env.outputs.deploy_environment }}
+          VOICE_REALTIME_WS_ENABLED_INPUT: ${{ vars.VOICE_REALTIME_WS_ENABLED || 'false' }}
         run: |
           args=(${{ steps.env.outputs.wrangler_args }} --var ELIZA_DEPLOY_COMMIT:"$GITHUB_SHA")
+          voice_realtime_ws_enabled="${VOICE_REALTIME_WS_ENABLED_INPUT:-false}"
+          if [ "$DEPLOY_ENVIRONMENT" = "production" ]; then
+            voice_realtime_ws_enabled="false"
+          fi
+          args+=(--var VOICE_REALTIME_WS_ENABLED:"$voice_realtime_ws_enabled")
           if [ -n "${KOKORO_TTS_URL:-}" ]; then
             args+=(--var KOKORO_TTS_URL:"$KOKORO_TTS_URL")
           else

--- a/packages/benchmarks/voice-rtt/README.md
+++ b/packages/benchmarks/voice-rtt/README.md
@@ -34,6 +34,15 @@ bun run --cwd packages/benchmarks/voice-rtt bench:mock -- --out=./results
 # Opt-in live mode. Requires provider keys and corpus PCM files.
 DEEPGRAM_API_KEY=... CEREBRAS_API_KEY=... CARTESIA_API_KEY=... \
   bun run --cwd packages/benchmarks/voice-rtt bench:live -- --audio-dir=./audio
+
+# Staging cloud WebSocket session benchmark. Requires 16 kHz PCM files.
+VOICE_STAGING_BEARER_TOKEN=... VOICE_STAGING_AGENT_ID=... \
+VOICE_STAGING_CONVERSATION_ID=... VOICE_STAGING_AUDIO_DIR=./audio \
+  packages/benchmarks/voice-rtt/scripts/staging-session.sh --runs=3 --out=./results/session
+
+# Current staging batch route baseline through /api/v1/voice/tts and /stt.
+VOICE_STAGING_BEARER_TOKEN=... \
+  packages/benchmarks/voice-rtt/scripts/staging-batch.sh --runs=5 --out=./results/batch
 ```
 
 Live mode expects `short.pcm`, `long.pcm`, `pause.pcm`, and `barge-in.pcm` in
@@ -61,6 +70,40 @@ trace IDs, provider request IDs, lengths, timings, stage attribution, and gate
 results. Use `--unsafe-transcripts` only for a local diagnostic run where the
 artifact will not be shared.
 
+The staging tools never print bearer tokens or response text. The WebSocket
+session report records redacted session IDs, WebSocket hosts, event names, and
+latency metrics. The batch baseline stores generated probe audio under the
+local work directory so the exact TTS output is fed into STT, but its JSON and
+Markdown reports include only timings, byte counts, route paths, and errors.
+
+## Staging Voice Ops
+
+`configs/staging-session.json` describes the public staging URL, mint route,
+WebSocket event names, hello and barge-in message names, chunk size, and
+timeouts. The phase-1 route may not exist in an environment yet, so the runner
+fails with a clear mint or event-mapping error instead of falling back to
+provider-direct adapters.
+
+Session benchmark contract:
+
+- `POST /api/v1/voice/session` with `Authorization: Bearer ...` and JSON body
+  `agentId`, `conversationId`, `transport: "websocket"`.
+- Expect `wsUrl`, `token`, and `sessionId`.
+- Send hello JSON with token, protocol `1`, and `pcm16` at 16 kHz.
+- Stream `<case>.pcm` in real-time 80 ms, 2560-byte chunks.
+- Observe configured `ready`, `stt_final`, `llm_first_text`, and first binary
+  TTS frame.
+- For `barge-in.pcm`, send configured `barge_in` after the first binary frame,
+  measure interrupt acknowledgement, wait the guard interval, and count
+  post-interrupt binary frames.
+
+`configs/staging-batch.json` describes the current batch TTS/STT endpoints and
+curl response handling. Defaults target `https://staging.elizacloud.ai` and
+route paths `/api/v1/voice/tts` and `/api/v1/voice/stt`. The runner generates
+deterministic short and long speech probes through staging TTS, feeds those
+exact audio files into staging STT, captures curl DNS/connect/TLS/TTFB/total
+timings, extracts STT `duration_ms`, and reports p50/p90/p95.
+
 ## Provider Contracts
 
 Adapters implement `SttAdapter`, `LlmAdapter`, and `TtsAdapter` from
@@ -78,4 +121,5 @@ The live adapter follows the documented provider APIs:
 ```bash
 bun run --cwd packages/benchmarks/voice-rtt test
 bun run --cwd packages/benchmarks/voice-rtt typecheck
+bun run --cwd packages/benchmarks/voice-rtt format:check
 ```

--- a/packages/benchmarks/voice-rtt/configs/staging-batch.json
+++ b/packages/benchmarks/voice-rtt/configs/staging-batch.json
@@ -1,0 +1,16 @@
+{
+  "baseUrl": "https://staging.elizacloud.ai",
+  "ttsPath": "/api/v1/voice/tts",
+  "sttPath": "/api/v1/voice/stt",
+  "ttsRequest": {
+    "textField": "text",
+    "responseFormat": "binary",
+    "contentType": "application/json"
+  },
+  "sttRequest": {
+    "fieldName": "audio",
+    "responseFormat": "json",
+    "durationField": "duration_ms"
+  },
+  "curlTimeoutSeconds": 60
+}

--- a/packages/benchmarks/voice-rtt/configs/staging-session.json
+++ b/packages/benchmarks/voice-rtt/configs/staging-session.json
@@ -1,0 +1,32 @@
+{
+  "baseUrl": "https://staging.elizacloud.ai",
+  "mintPath": "/api/v1/voice/session",
+  "transport": "websocket",
+  "protocol": 1,
+  "audio": {
+    "encoding": "pcm16",
+    "sampleRateHz": 16000,
+    "chunkBytes": 2560,
+    "chunkMs": 80
+  },
+  "events": {
+    "ready": "ready",
+    "sttFinal": "stt_final",
+    "llmFirstText": "llm_first_text",
+    "interrupted": "interrupted",
+    "error": "error"
+  },
+  "messages": {
+    "helloType": "hello",
+    "bargeInType": "barge_in",
+    "endOfInputType": "input_audio_done"
+  },
+  "cases": ["short", "long", "barge-in"],
+  "guardMs": 250,
+  "timeouts": {
+    "mintMs": 10000,
+    "readyMs": 10000,
+    "turnMs": 60000,
+    "interruptMs": 5000
+  }
+}

--- a/packages/benchmarks/voice-rtt/package.json
+++ b/packages/benchmarks/voice-rtt/package.json
@@ -16,10 +16,12 @@
     "bench": "bun run src/runner.ts",
     "bench:mock": "bun run src/runner.ts --mode=mock",
     "bench:live": "bun run src/runner.ts --mode=live",
+    "bench:staging-session": "bun run src/staging-session.ts",
+    "bench:staging-batch": "bun run src/staging-batch.ts",
     "test": "vitest run",
     "test:watch": "vitest",
-    "format": "bunx @biomejs/biome format --write package.json README.md AGENTS.md CLAUDE.md src tests fixtures",
-    "format:check": "bunx @biomejs/biome format package.json README.md AGENTS.md CLAUDE.md src tests fixtures",
+    "format": "bunx @biomejs/biome format --write package.json README.md AGENTS.md CLAUDE.md src tests fixtures configs scripts",
+    "format:check": "bunx @biomejs/biome format package.json README.md AGENTS.md CLAUDE.md src tests fixtures configs scripts",
     "typecheck": "tsgo --noEmit"
   },
   "devDependencies": {

--- a/packages/benchmarks/voice-rtt/scripts/staging-batch.sh
+++ b/packages/benchmarks/voice-rtt/scripts/staging-batch.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+exec bun run src/staging-batch.ts --config=configs/staging-batch.json "$@"

--- a/packages/benchmarks/voice-rtt/scripts/staging-session.sh
+++ b/packages/benchmarks/voice-rtt/scripts/staging-session.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+exec bun run src/staging-session.ts --config=configs/staging-session.json "$@"

--- a/packages/benchmarks/voice-rtt/src/staging-batch.ts
+++ b/packages/benchmarks/voice-rtt/src/staging-batch.ts
@@ -1,0 +1,421 @@
+#!/usr/bin/env bun
+/**
+ * Repeatable staging batch baseline for current voice TTS and STT routes.
+ *
+ * The runner shells out to curl for DNS/connect/TLS/TTFB/total timings, stores
+ * generated probe audio locally, and keeps response bodies out of stdout and
+ * reports by default.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  joinUrl,
+  metricSummaries,
+  parsePositiveInt,
+  readJsonConfig,
+  renderStagingJson,
+  renderStagingMarkdown,
+  requiredEnv,
+  type StagingReport,
+  writeReportFiles,
+} from "./staging-common.ts";
+
+type BatchMetric =
+  | "ttsDnsMs"
+  | "ttsConnectMs"
+  | "ttsTlsMs"
+  | "ttsTtfbMs"
+  | "ttsTotalMs"
+  | "sttDnsMs"
+  | "sttConnectMs"
+  | "sttTlsMs"
+  | "sttTtfbMs"
+  | "sttTotalMs"
+  | "sttDurationMs";
+
+const BATCH_METRICS = [
+  "ttsDnsMs",
+  "ttsConnectMs",
+  "ttsTlsMs",
+  "ttsTtfbMs",
+  "ttsTotalMs",
+  "sttDnsMs",
+  "sttConnectMs",
+  "sttTlsMs",
+  "sttTtfbMs",
+  "sttTotalMs",
+  "sttDurationMs",
+] as const satisfies readonly BatchMetric[];
+
+const DEFAULT_PROBES = [
+  {
+    id: "short",
+    text: "Staging voice probe short one two three.",
+  },
+  {
+    id: "long",
+    text: "Staging voice probe long. The benchmark uses deterministic text so current batch latency can be compared across runs without storing transcripts in the output artifacts.",
+  },
+] as const;
+
+interface BatchConfig {
+  baseUrl: string;
+  ttsPath: string;
+  sttPath: string;
+  probes?: Array<{ id: string; text: string }>;
+  ttsRequest: {
+    textField: string;
+    responseFormat: "binary" | "jsonAudioBase64";
+    contentType: string;
+    audioBase64Field?: string;
+  };
+  sttRequest: {
+    fieldName: string;
+    responseFormat: "json";
+    durationField: string;
+  };
+  curlTimeoutSeconds: number;
+}
+
+interface CurlTiming {
+  httpCode: number;
+  dnsMs: number;
+  connectMs: number;
+  tlsMs: number;
+  ttfbMs: number;
+  totalMs: number;
+}
+
+interface BatchRun {
+  probeId: string;
+  runIndex: number;
+  audioBytes: number;
+  metrics: Record<BatchMetric, number | null>;
+  error?: string;
+}
+
+interface Args {
+  config: string;
+  runs: number;
+  out?: string;
+  workDir: string;
+}
+
+const HELP = `Staging voice current batch baseline
+
+Flags:
+  --config=<path>       config JSON (default: configs/staging-batch.json)
+  --runs=<n>            repeats per probe (default: 3)
+  --out=<dir>           write staging-batch.json and staging-batch.md
+  --work-dir=<dir>      generated audio/temp directory (default: .staging-batch)
+  --help                show this message
+
+Environment:
+  VOICE_STAGING_BEARER_TOKEN
+`;
+
+export function parseBatchArgs(argv: readonly string[]): Args {
+  const args: Args = {
+    config: "configs/staging-batch.json",
+    runs: 3,
+    workDir: ".staging-batch",
+  };
+  for (const arg of argv) {
+    if (arg === "--help" || arg === "-h") {
+      process.stdout.write(HELP);
+      process.exit(0);
+    } else if (arg.startsWith("--config=")) args.config = arg.slice(9);
+    else if (arg.startsWith("--runs="))
+      args.runs = parsePositiveInt(arg.slice(7), 3);
+    else if (arg.startsWith("--out=")) args.out = arg.slice(6);
+    else if (arg.startsWith("--work-dir=")) args.workDir = arg.slice(11);
+    else throw new Error(`unknown argument: ${arg}`);
+  }
+  return args;
+}
+
+export async function runStagingBatchBaseline(args: {
+  config: BatchConfig;
+  runs: number;
+  workDir: string;
+  bearerToken: string;
+  nowIso: () => string;
+}): Promise<StagingReport<BatchMetric, BatchRun>> {
+  mkdirSync(args.workDir, { recursive: true });
+  const runs: BatchRun[] = [];
+  const probes = args.config.probes ?? DEFAULT_PROBES;
+  for (let runIndex = 0; runIndex < args.runs; runIndex++) {
+    for (const probe of probes) {
+      process.stdout.write(`[staging-batch ${probe.id}#${runIndex}]\n`);
+      runs.push(
+        await runProbe({
+          config: args.config,
+          probe,
+          runIndex,
+          workDir: args.workDir,
+          bearerToken: args.bearerToken,
+        }),
+      );
+    }
+  }
+  return {
+    schemaVersion: 1,
+    generatedAt: args.nowIso(),
+    tool: "Staging Voice Batch Baseline",
+    target: {
+      baseUrl: args.config.baseUrl,
+      paths: { tts: args.config.ttsPath, stt: args.config.sttPath },
+    },
+    summaries: metricSummaries(
+      runs,
+      BATCH_METRICS,
+      (run, metric) => run.metrics[metric],
+    ),
+    runs,
+  };
+}
+
+async function runProbe(args: {
+  config: BatchConfig;
+  probe: { id: string; text: string };
+  runIndex: number;
+  workDir: string;
+  bearerToken: string;
+}): Promise<BatchRun> {
+  const metrics = emptyMetrics();
+  const audioPath = resolve(
+    args.workDir,
+    `${args.probe.id}-${args.runIndex}.audio`,
+  );
+  const ttsBodyPath = resolve(
+    args.workDir,
+    `${args.probe.id}-${args.runIndex}.tts-body`,
+  );
+  const sttBodyPath = resolve(
+    args.workDir,
+    `${args.probe.id}-${args.runIndex}.stt-body.json`,
+  );
+  try {
+    const requestPath = resolve(
+      args.workDir,
+      `${args.probe.id}-${args.runIndex}.tts-request.json`,
+    );
+    writeFileSync(
+      requestPath,
+      JSON.stringify({ [args.config.ttsRequest.textField]: args.probe.text }),
+      "utf8",
+    );
+    const tts = await curlPost({
+      url: joinUrl(args.config.baseUrl, args.config.ttsPath),
+      bearerToken: args.bearerToken,
+      outputPath: ttsBodyPath,
+      timeoutSeconds: args.config.curlTimeoutSeconds,
+      args: [
+        "-H",
+        `Content-Type: ${args.config.ttsRequest.contentType}`,
+        "--data-binary",
+        `@${requestPath}`,
+      ],
+    });
+    assignCurl(metrics, "tts", tts);
+    if (tts.httpCode < 200 || tts.httpCode >= 300) {
+      throw new Error(`TTS failed with HTTP ${tts.httpCode}`);
+    }
+    if (args.config.ttsRequest.responseFormat === "binary") {
+      await Bun.write(audioPath, readFileSync(ttsBodyPath));
+    } else {
+      const json = JSON.parse(readFileSync(ttsBodyPath, "utf8")) as Record<
+        string,
+        unknown
+      >;
+      const field = args.config.ttsRequest.audioBase64Field ?? "audioBase64";
+      const audioBase64 = json[field];
+      if (typeof audioBase64 !== "string") {
+        throw new Error(`TTS JSON response missing ${field}`);
+      }
+      await Bun.write(audioPath, Buffer.from(audioBase64, "base64"));
+    }
+    const audioBytes = existsSync(audioPath)
+      ? readFileSync(audioPath).byteLength
+      : 0;
+    const stt = await curlPost({
+      url: joinUrl(args.config.baseUrl, args.config.sttPath),
+      bearerToken: args.bearerToken,
+      outputPath: sttBodyPath,
+      timeoutSeconds: args.config.curlTimeoutSeconds,
+      // curl cannot infer a useful MIME type from the neutral `.audio`
+      // extension. The route validates both the multipart MIME and the file
+      // signature, so provide an accepted container MIME explicitly.
+      args: [
+        "-F",
+        `${args.config.sttRequest.fieldName}=@${audioPath};type=audio/mpeg`,
+      ],
+    });
+    assignCurl(metrics, "stt", stt);
+    if (stt.httpCode < 200 || stt.httpCode >= 300) {
+      throw new Error(`STT failed with HTTP ${stt.httpCode}`);
+    }
+    const sttJson = JSON.parse(readFileSync(sttBodyPath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+    const durationValue = sttJson[args.config.sttRequest.durationField];
+    metrics.sttDurationMs =
+      typeof durationValue === "number" && Number.isFinite(durationValue)
+        ? durationValue
+        : null;
+    return {
+      probeId: args.probe.id,
+      runIndex: args.runIndex,
+      audioBytes,
+      metrics,
+    };
+  } catch (error) {
+    return {
+      probeId: args.probe.id,
+      runIndex: args.runIndex,
+      audioBytes: existsSync(audioPath)
+        ? readFileSync(audioPath).byteLength
+        : 0,
+      metrics,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function curlPost(args: {
+  url: string;
+  bearerToken: string;
+  outputPath: string;
+  timeoutSeconds: number;
+  args: string[];
+}): Promise<CurlTiming> {
+  const timingFormat = JSON.stringify({
+    httpCode: "%{http_code}",
+    dns: "%{time_namelookup}",
+    connect: "%{time_connect}",
+    tls: "%{time_appconnect}",
+    ttfb: "%{time_starttransfer}",
+    total: "%{time_total}",
+  });
+  const proc = Bun.spawn(
+    [
+      "curl",
+      "-sS",
+      "--max-time",
+      String(args.timeoutSeconds),
+      "-X",
+      "POST",
+      "-H",
+      "@-",
+      "-o",
+      args.outputPath,
+      "-w",
+      timingFormat,
+      ...args.args,
+      args.url,
+    ],
+    { stdin: "pipe", stdout: "pipe", stderr: "pipe" },
+  );
+  proc.stdin.write(`Authorization: Bearer ${args.bearerToken}\n`);
+  proc.stdin.end();
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  const timing = parseCurlTiming(stdout);
+  if (exitCode !== 0) {
+    throw new Error(
+      `curl failed with exit ${exitCode}, http ${timing.httpCode || "000"}: ${stderr.trim()}`,
+    );
+  }
+  return timing;
+}
+
+export function parseCurlTiming(stdout: string): CurlTiming {
+  const parsed = JSON.parse(stdout) as Record<string, string>;
+  const seconds = (key: string) => Number.parseFloat(parsed[key] ?? "0") * 1000;
+  return {
+    httpCode: Number.parseInt(parsed.httpCode ?? "0", 10),
+    dnsMs: seconds("dns"),
+    connectMs: seconds("connect"),
+    tlsMs: seconds("tls"),
+    ttfbMs: seconds("ttfb"),
+    totalMs: seconds("total"),
+  };
+}
+
+function assignCurl(
+  metrics: Record<BatchMetric, number | null>,
+  prefix: "tts" | "stt",
+  timing: CurlTiming,
+): void {
+  metrics[`${prefix}DnsMs`] = timing.dnsMs;
+  metrics[`${prefix}ConnectMs`] = timing.connectMs;
+  metrics[`${prefix}TlsMs`] = timing.tlsMs;
+  metrics[`${prefix}TtfbMs`] = timing.ttfbMs;
+  metrics[`${prefix}TotalMs`] = timing.totalMs;
+}
+
+function emptyMetrics(): Record<BatchMetric, number | null> {
+  return Object.fromEntries(
+    BATCH_METRICS.map((metric) => [metric, null]),
+  ) as Record<BatchMetric, number | null>;
+}
+
+export function renderBatchRunTable(
+  report: StagingReport<BatchMetric, BatchRun>,
+): string[] {
+  const lines = [
+    "| Probe | Run | Audio bytes | TTS TTFB | TTS total | STT TTFB | STT total | STT duration | Error |",
+    "|---|---:|---:|---:|---:|---:|---:|---:|---|",
+  ];
+  for (const run of report.runs) {
+    const m = run.metrics;
+    lines.push(
+      `| ${run.probeId} | ${run.runIndex} | ${run.audioBytes} | ${fmt(m.ttsTtfbMs)} | ${fmt(m.ttsTotalMs)} | ${fmt(m.sttTtfbMs)} | ${fmt(m.sttTotalMs)} | ${fmt(m.sttDurationMs)} | ${run.error ?? ""} |`,
+    );
+  }
+  return lines;
+}
+
+function fmt(value: number | null): string {
+  if (value === null || !Number.isFinite(value)) return "-";
+  return `${Math.round(value)}ms`;
+}
+
+async function main(): Promise<void> {
+  const args = parseBatchArgs(process.argv.slice(2));
+  const config = readJsonConfig<BatchConfig>(args.config);
+  const report = await runStagingBatchBaseline({
+    config,
+    runs: args.runs,
+    workDir: args.workDir,
+    bearerToken: requiredEnv("VOICE_STAGING_BEARER_TOKEN"),
+    nowIso: () => new Date().toISOString(),
+  });
+  const json = renderStagingJson(report);
+  const markdown = renderStagingMarkdown(report, renderBatchRunTable(report));
+  process.stdout.write(markdown);
+  if (args.out) {
+    writeReportFiles({
+      outDir: args.out,
+      json,
+      markdown,
+      jsonName: "staging-batch.json",
+      markdownName: "staging-batch.md",
+    });
+  }
+  if (report.runs.some((run) => run.error)) process.exitCode = 1;
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    process.stderr.write(
+      `Fatal: ${error instanceof Error ? (error.stack ?? error.message) : String(error)}\n`,
+    );
+    process.exit(1);
+  });
+}

--- a/packages/benchmarks/voice-rtt/src/staging-common.ts
+++ b/packages/benchmarks/voice-rtt/src/staging-common.ts
@@ -1,0 +1,143 @@
+/**
+ * Shared config, timing summary, and report rendering for staging voice ops.
+ *
+ * The staging tools intentionally use a separate artifact schema from the
+ * direct-provider RTT harness because they exercise cloud routes and redacted
+ * operational timings rather than provider-specific traces.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { summarize } from "./metrics.ts";
+import type { PercentileSummary } from "./types.ts";
+
+export interface StagingReport<TMetric extends string, TRun> {
+  schemaVersion: 1;
+  generatedAt: string;
+  tool: string;
+  target: {
+    baseUrl: string;
+    paths: Record<string, string>;
+  };
+  summaries: Record<TMetric, PercentileSummary>;
+  runs: TRun[];
+}
+
+export function readJsonConfig<T>(path: string): T {
+  if (!existsSync(path)) {
+    throw new Error(`config file not found: ${path}`);
+  }
+  return JSON.parse(readFileSync(path, "utf8")) as T;
+}
+
+export function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+export function optionalEnv(name: string): string | undefined {
+  const value = process.env[name];
+  return value && value.length > 0 ? value : undefined;
+}
+
+export function parsePositiveInt(value: string | undefined, fallback: number) {
+  if (value === undefined) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`expected a positive integer, received ${value}`);
+  }
+  return parsed;
+}
+
+export function metricSummaries<TMetric extends string, TRun>(
+  runs: readonly TRun[],
+  metricNames: readonly TMetric[],
+  readMetric: (run: TRun, metric: TMetric) => number | null,
+): Record<TMetric, PercentileSummary> {
+  const output = {} as Record<TMetric, PercentileSummary>;
+  for (const metric of metricNames) {
+    output[metric] = summarize(runs.map((run) => readMetric(run, metric)));
+  }
+  return output;
+}
+
+export function renderStagingJson<TMetric extends string, TRun>(
+  report: StagingReport<TMetric, TRun>,
+): string {
+  return `${JSON.stringify(report, null, 2)}\n`;
+}
+
+export function renderStagingMarkdown<TMetric extends string, TRun>(
+  report: StagingReport<TMetric, TRun>,
+  runTable: string[],
+): string {
+  const lines: string[] = [];
+  lines.push(`# ${report.tool} Report`);
+  lines.push("");
+  lines.push(`- Generated: ${report.generatedAt}`);
+  lines.push(`- Target: ${report.target.baseUrl}`);
+  for (const [name, path] of Object.entries(report.target.paths)) {
+    lines.push(`- ${name}: ${path}`);
+  }
+  lines.push("");
+  lines.push("## Summary");
+  lines.push("");
+  lines.push("| Metric | n | p50 | p90 | p95 | mean | min | max |");
+  lines.push("|---|---:|---:|---:|---:|---:|---:|---:|");
+  for (const [metric, summary] of Object.entries(report.summaries) as Array<
+    [TMetric, PercentileSummary]
+  >) {
+    lines.push(
+      `| ${metric} | ${summary.count} | ${fmt(summary.p50)} | ${fmt(summary.p90)} | ${fmt(summary.p95)} | ${fmt(summary.mean)} | ${fmt(summary.min)} | ${fmt(summary.max)} |`,
+    );
+  }
+  lines.push("");
+  lines.push("## Runs");
+  lines.push("");
+  lines.push(...runTable);
+  return `${lines.join("\n")}\n`;
+}
+
+export function writeReportFiles(args: {
+  outDir: string;
+  json: string;
+  markdown: string;
+  jsonName?: string;
+  markdownName?: string;
+}): void {
+  const outDir = resolve(args.outDir);
+  mkdirSync(outDir, { recursive: true });
+  const jsonPath = resolve(outDir, args.jsonName ?? "report.json");
+  const markdownPath = resolve(outDir, args.markdownName ?? "report.md");
+  mkdirSync(dirname(jsonPath), { recursive: true });
+  writeFileSync(jsonPath, args.json, "utf8");
+  writeFileSync(markdownPath, args.markdown, "utf8");
+  process.stdout.write(`Wrote ${jsonPath}\n`);
+  process.stdout.write(`Wrote ${markdownPath}\n`);
+}
+
+export function joinUrl(baseUrl: string, path: string): string {
+  return `${baseUrl.replace(/\/+$/, "")}/${path.replace(/^\/+/, "")}`;
+}
+
+export function nowMs(): number {
+  return performance.now();
+}
+
+export function duration(startMs: number, endMs: number | null): number | null {
+  return endMs === null ? null : endMs - startMs;
+}
+
+export function redactIdentifier(
+  value: string | undefined,
+): string | undefined {
+  if (!value) return undefined;
+  if (value.length <= 8) return "<redacted>";
+  return `${value.slice(0, 4)}...${value.slice(-4)}`;
+}
+
+function fmt(value: number | null): string {
+  if (value === null || !Number.isFinite(value)) return "-";
+  return `${Math.round(value)}ms`;
+}

--- a/packages/benchmarks/voice-rtt/src/staging-session.ts
+++ b/packages/benchmarks/voice-rtt/src/staging-session.ts
@@ -1,0 +1,529 @@
+#!/usr/bin/env bun
+/**
+ * Staging cloud voice-session WebSocket benchmark.
+ *
+ * This runner exercises the phase-1 session route through public staging URLs,
+ * keeps endpoint/event names configurable, and emits only redacted timing
+ * artifacts so provider credentials and transcripts never leave the operator.
+ */
+
+import { readFileSync } from "node:fs";
+import { basename, resolve } from "node:path";
+import {
+  duration,
+  joinUrl,
+  metricSummaries,
+  nowMs,
+  parsePositiveInt,
+  readJsonConfig,
+  redactIdentifier,
+  renderStagingJson,
+  renderStagingMarkdown,
+  requiredEnv,
+  type StagingReport,
+  writeReportFiles,
+} from "./staging-common.ts";
+
+type SessionMetric =
+  | "mintLatencyMs"
+  | "helloToReadyMs"
+  | "uplinkEndToSttFinalMs"
+  | "sttFinalToLlmFirstTextMs"
+  | "llmFirstTextToFirstTtsFrameMs"
+  | "endOfUplinkToFirstAudioMs"
+  | "interruptToSilenceMs";
+
+const SESSION_METRICS = [
+  "mintLatencyMs",
+  "helloToReadyMs",
+  "uplinkEndToSttFinalMs",
+  "sttFinalToLlmFirstTextMs",
+  "llmFirstTextToFirstTtsFrameMs",
+  "endOfUplinkToFirstAudioMs",
+  "interruptToSilenceMs",
+] as const satisfies readonly SessionMetric[];
+
+interface SessionConfig {
+  baseUrl: string;
+  mintPath: string;
+  transport: "websocket";
+  protocol: number;
+  audio: {
+    encoding: "pcm16";
+    sampleRateHz: number;
+    chunkBytes: number;
+    chunkMs: number;
+  };
+  events: {
+    ready: string;
+    sttFinal: string;
+    llmFirstText: string;
+    interrupted: string;
+    error: string;
+  };
+  messages: {
+    helloType: string;
+    bargeInType: string;
+    endOfInputType: string;
+  };
+  cases: string[];
+  guardMs: number;
+  timeouts: {
+    mintMs: number;
+    readyMs: number;
+    turnMs: number;
+    interruptMs: number;
+  };
+}
+
+interface SessionRun {
+  caseId: string;
+  runIndex: number;
+  sessionId?: string;
+  wsUrlHost?: string;
+  metrics: Record<SessionMetric, number | null>;
+  postInterruptBinaryFrames: number;
+  observedEvents: string[];
+  error?: string;
+}
+
+interface Args {
+  config: string;
+  runs: number;
+  out?: string;
+  audioDir?: string;
+}
+
+const HELP = `Staging voice-session WebSocket benchmark
+
+Flags:
+  --config=<path>      config JSON (default: configs/staging-session.json)
+  --runs=<n>           repeats per case (default: 1)
+  --out=<dir>          write staging-session.json and staging-session.md
+  --audio-dir=<dir>    PCM corpus directory (default: VOICE_STAGING_AUDIO_DIR)
+  --help               show this message
+
+Environment:
+  VOICE_STAGING_BEARER_TOKEN, VOICE_STAGING_AGENT_ID,
+  VOICE_STAGING_CONVERSATION_ID, VOICE_STAGING_AUDIO_DIR
+`;
+
+export function parseSessionArgs(argv: readonly string[]): Args {
+  const args: Args = { config: "configs/staging-session.json", runs: 1 };
+  for (const arg of argv) {
+    if (arg === "--help" || arg === "-h") {
+      process.stdout.write(HELP);
+      process.exit(0);
+    } else if (arg.startsWith("--config=")) args.config = arg.slice(9);
+    else if (arg.startsWith("--runs=")) {
+      args.runs = parsePositiveInt(arg.slice(7), 1);
+    } else if (arg.startsWith("--out=")) args.out = arg.slice(6);
+    else if (arg.startsWith("--audio-dir=")) args.audioDir = arg.slice(12);
+    else throw new Error(`unknown argument: ${arg}`);
+  }
+  return args;
+}
+
+export async function runStagingSessionBenchmark(args: {
+  config: SessionConfig;
+  runs: number;
+  audioDir: string;
+  bearerToken: string;
+  agentId: string;
+  conversationId: string;
+  nowIso: () => string;
+}): Promise<StagingReport<SessionMetric, SessionRun>> {
+  const runs: SessionRun[] = [];
+  for (let runIndex = 0; runIndex < args.runs; runIndex++) {
+    for (const caseId of args.config.cases) {
+      process.stdout.write(`[staging-session ${caseId}#${runIndex}]\n`);
+      runs.push(
+        await runSessionCase({
+          config: args.config,
+          runIndex,
+          caseId,
+          audioPath: resolve(args.audioDir, `${caseId}.pcm`),
+          bearerToken: args.bearerToken,
+          agentId: args.agentId,
+          conversationId: args.conversationId,
+        }),
+      );
+    }
+  }
+  return {
+    schemaVersion: 1,
+    generatedAt: args.nowIso(),
+    tool: "Staging Voice Session",
+    target: {
+      baseUrl: args.config.baseUrl,
+      paths: { mint: args.config.mintPath },
+    },
+    summaries: metricSummaries(
+      runs,
+      SESSION_METRICS,
+      (run, metric) => run.metrics[metric],
+    ),
+    runs,
+  };
+}
+
+async function runSessionCase(args: {
+  config: SessionConfig;
+  runIndex: number;
+  caseId: string;
+  audioPath: string;
+  bearerToken: string;
+  agentId: string;
+  conversationId: string;
+}): Promise<SessionRun> {
+  const observedEvents: string[] = [];
+  const metrics = emptyMetrics();
+  let sessionId: string | undefined;
+  let wsUrlHost: string | undefined;
+  let postInterruptBinaryFrames = 0;
+  let firstBinarySeen = false;
+  let interruptAt: number | null = null;
+  let lastBinaryAfterInterruptAt: number | null = null;
+  const caseStartedAt = nowMs();
+  try {
+    const mintStart = nowMs();
+    const mint = await mintSession(args);
+    const mintEnd = nowMs();
+    metrics.mintLatencyMs = mintEnd - mintStart;
+    sessionId = mint.sessionId;
+    wsUrlHost = new URL(mint.wsUrl).host;
+
+    const audio = readFileSync(args.audioPath);
+    const ws = await connectWebSocket(mint.wsUrl, args.config.timeouts.readyMs);
+    const helloAt = nowMs();
+    ws.send(
+      JSON.stringify({
+        type: args.config.messages.helloType,
+        token: mint.token,
+        protocol: args.config.protocol,
+        audio: {
+          encoding: args.config.audio.encoding,
+          sampleRateHz: args.config.audio.sampleRateHz,
+        },
+      }),
+    );
+
+    let uplinkEndAt: number | null = null;
+    let sttFinalAt: number | null = null;
+    let llmFirstTextAt: number | null = null;
+    let firstTtsFrameAt: number | null = null;
+    let interruptedAt: number | null = null;
+
+    await new Promise<void>((resolvePromise, reject) => {
+      let finished = false;
+      let interruptTimer: ReturnType<typeof setTimeout> | undefined;
+      const closeSocket = () => {
+        clearTimeout(turnTimer);
+        if (interruptTimer) clearTimeout(interruptTimer);
+        ws.close();
+      };
+      const finish = () => {
+        if (finished) return;
+        finished = true;
+        closeSocket();
+        resolvePromise();
+      };
+      const fail = (error: unknown) => {
+        if (finished) return;
+        finished = true;
+        closeSocket();
+        reject(error);
+      };
+      const turnTimer = setTimeout(() => {
+        fail(
+          new Error(
+            `timed out waiting for configured events after ${args.config.timeouts.turnMs}ms`,
+          ),
+        );
+      }, args.config.timeouts.turnMs);
+
+      ws.binaryType = "arraybuffer";
+      ws.onmessage = (event) => {
+        try {
+          if (typeof event.data !== "string") {
+            if (interruptAt !== null) {
+              postInterruptBinaryFrames++;
+              lastBinaryAfterInterruptAt = nowMs();
+            }
+            if (!firstBinarySeen) {
+              firstBinarySeen = true;
+              firstTtsFrameAt = nowMs();
+              if (args.caseId === "barge-in") {
+                interruptAt = nowMs();
+                ws.send(
+                  JSON.stringify({ type: args.config.messages.bargeInType }),
+                );
+                interruptTimer = setTimeout(() => {
+                  fail(
+                    new Error(
+                      `timed out waiting for ${args.config.events.interrupted} after ${args.config.timeouts.interruptMs}ms`,
+                    ),
+                  );
+                }, args.config.timeouts.interruptMs);
+              } else {
+                finish();
+              }
+            }
+            return;
+          }
+          const message = parseEvent(event.data);
+          observedEvents.push(message.type);
+          if (message.type === args.config.events.error) {
+            fail(new Error(`server emitted ${args.config.events.error}`));
+            return;
+          }
+          if (message.type === args.config.events.ready) {
+            const readyAt = nowMs();
+            metrics.helloToReadyMs = readyAt - helloAt;
+            void streamAudio(ws, audio, args.config).then((endedAt) => {
+              uplinkEndAt = endedAt;
+            }, fail);
+            return;
+          }
+          if (message.type === args.config.events.sttFinal) {
+            sttFinalAt = nowMs();
+            metrics.uplinkEndToSttFinalMs =
+              uplinkEndAt === null ? null : duration(uplinkEndAt, sttFinalAt);
+            return;
+          }
+          if (message.type === args.config.events.llmFirstText) {
+            llmFirstTextAt = nowMs();
+            metrics.sttFinalToLlmFirstTextMs =
+              sttFinalAt === null ? null : duration(sttFinalAt, llmFirstTextAt);
+            return;
+          }
+          if (message.type === args.config.events.interrupted) {
+            interruptedAt = nowMs();
+            if (interruptTimer) clearTimeout(interruptTimer);
+            setTimeout(() => {
+              metrics.interruptToSilenceMs =
+                interruptAt === null
+                  ? null
+                  : duration(
+                      interruptAt,
+                      lastBinaryAfterInterruptAt ?? interruptedAt,
+                    );
+              finish();
+            }, args.config.guardMs);
+          }
+        } catch (error) {
+          fail(error);
+        }
+      };
+      ws.onerror = () => fail(new Error("websocket error"));
+      ws.onclose = () => {
+        if (args.caseId !== "barge-in" && firstTtsFrameAt !== null) {
+          finish();
+        }
+      };
+    });
+
+    metrics.llmFirstTextToFirstTtsFrameMs =
+      llmFirstTextAt === null
+        ? null
+        : duration(llmFirstTextAt, firstTtsFrameAt);
+    metrics.endOfUplinkToFirstAudioMs =
+      uplinkEndAt === null ? null : duration(uplinkEndAt, firstTtsFrameAt);
+    if (sttFinalAt === null) {
+      throw new Error(
+        `did not observe ${args.config.events.sttFinal}; observed ${observedEvents.join(", ")}`,
+      );
+    }
+    if (llmFirstTextAt === null) {
+      throw new Error(
+        `did not observe ${args.config.events.llmFirstText}; observed ${observedEvents.join(", ")}`,
+      );
+    }
+    if (firstTtsFrameAt === null) {
+      throw new Error("did not observe first binary TTS frame");
+    }
+    if (args.caseId === "barge-in" && interruptedAt === null) {
+      throw new Error(
+        `barge-in did not observe ${args.config.events.interrupted}; observed ${observedEvents.join(", ")}`,
+      );
+    }
+    if (postInterruptBinaryFrames > 0) {
+      process.stderr.write(
+        `warning: ${basename(args.audioPath)} emitted binary frames after barge_in\n`,
+      );
+    }
+  } catch (error) {
+    return {
+      caseId: args.caseId,
+      runIndex: args.runIndex,
+      sessionId: redactIdentifier(sessionId),
+      wsUrlHost,
+      metrics,
+      postInterruptBinaryFrames,
+      observedEvents,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+  if (nowMs() - caseStartedAt > args.config.timeouts.turnMs) {
+    throw new Error(`${args.caseId} exceeded configured turn timeout`);
+  }
+  return {
+    caseId: args.caseId,
+    runIndex: args.runIndex,
+    sessionId: redactIdentifier(sessionId),
+    wsUrlHost,
+    metrics,
+    postInterruptBinaryFrames,
+    observedEvents,
+  };
+}
+
+async function mintSession(args: {
+  config: SessionConfig;
+  bearerToken: string;
+  agentId: string;
+  conversationId: string;
+}): Promise<{ wsUrl: string; token: string; sessionId: string }> {
+  const response = await fetch(
+    joinUrl(args.config.baseUrl, args.config.mintPath),
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${args.bearerToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        agentId: args.agentId,
+        conversationId: args.conversationId,
+        transport: args.config.transport,
+      }),
+      signal: AbortSignal.timeout(args.config.timeouts.mintMs),
+    },
+  );
+  if (!response.ok) {
+    throw new Error(
+      `mint ${args.config.mintPath} failed with ${response.status}; verify endpoint mapping and auth`,
+    );
+  }
+  const body = (await response.json()) as Partial<{
+    wsUrl: string;
+    token: string;
+    sessionId: string;
+  }>;
+  if (!body.wsUrl || !body.token || !body.sessionId) {
+    throw new Error("mint response must include wsUrl, token, and sessionId");
+  }
+  return body as { wsUrl: string; token: string; sessionId: string };
+}
+
+async function connectWebSocket(
+  wsUrl: string,
+  timeoutMs: number,
+): Promise<WebSocket> {
+  return new Promise((resolvePromise, reject) => {
+    const ws = new WebSocket(wsUrl);
+    const timer = setTimeout(() => {
+      ws.close();
+      reject(new Error(`websocket open timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    ws.onopen = () => {
+      clearTimeout(timer);
+      resolvePromise(ws);
+    };
+    ws.onerror = () => {
+      clearTimeout(timer);
+      reject(new Error("websocket open failed"));
+    };
+  });
+}
+
+async function streamAudio(
+  ws: WebSocket,
+  audio: Buffer,
+  config: SessionConfig,
+): Promise<number> {
+  for (
+    let offset = 0;
+    offset < audio.length;
+    offset += config.audio.chunkBytes
+  ) {
+    ws.send(
+      Uint8Array.from(audio.subarray(offset, offset + config.audio.chunkBytes)),
+    );
+    await Bun.sleep(config.audio.chunkMs);
+  }
+  ws.send(JSON.stringify({ type: config.messages.endOfInputType }));
+  return nowMs();
+}
+
+function parseEvent(data: string): { type: string } {
+  const parsed = JSON.parse(data) as { type?: unknown; event?: unknown };
+  const type = typeof parsed.type === "string" ? parsed.type : parsed.event;
+  if (typeof type !== "string") {
+    throw new Error("websocket JSON event is missing type/event");
+  }
+  return { ...parsed, type } as { type: string };
+}
+
+function emptyMetrics(): Record<SessionMetric, number | null> {
+  return Object.fromEntries(
+    SESSION_METRICS.map((metric) => [metric, null]),
+  ) as Record<SessionMetric, number | null>;
+}
+
+export function renderSessionRunTable(
+  report: StagingReport<SessionMetric, SessionRun>,
+): string[] {
+  const lines = [
+    "| Case | Run | Mint | Ready | EOS to STT | STT to LLM | LLM to audio | EOS to audio | Interrupt to silence | Post-interrupt binary | Error |",
+    "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|",
+  ];
+  for (const run of report.runs) {
+    const m = run.metrics;
+    lines.push(
+      `| ${run.caseId} | ${run.runIndex} | ${fmt(m.mintLatencyMs)} | ${fmt(m.helloToReadyMs)} | ${fmt(m.uplinkEndToSttFinalMs)} | ${fmt(m.sttFinalToLlmFirstTextMs)} | ${fmt(m.llmFirstTextToFirstTtsFrameMs)} | ${fmt(m.endOfUplinkToFirstAudioMs)} | ${fmt(m.interruptToSilenceMs)} | ${run.postInterruptBinaryFrames} | ${run.error ?? ""} |`,
+    );
+  }
+  return lines;
+}
+
+function fmt(value: number | null): string {
+  if (value === null || !Number.isFinite(value)) return "-";
+  return `${Math.round(value)}ms`;
+}
+
+async function main(): Promise<void> {
+  const args = parseSessionArgs(process.argv.slice(2));
+  const config = readJsonConfig<SessionConfig>(args.config);
+  const report = await runStagingSessionBenchmark({
+    config,
+    runs: args.runs,
+    audioDir: args.audioDir ?? requiredEnv("VOICE_STAGING_AUDIO_DIR"),
+    bearerToken: requiredEnv("VOICE_STAGING_BEARER_TOKEN"),
+    agentId: requiredEnv("VOICE_STAGING_AGENT_ID"),
+    conversationId: requiredEnv("VOICE_STAGING_CONVERSATION_ID"),
+    nowIso: () => new Date().toISOString(),
+  });
+  const json = renderStagingJson(report);
+  const markdown = renderStagingMarkdown(report, renderSessionRunTable(report));
+  process.stdout.write(markdown);
+  if (args.out) {
+    writeReportFiles({
+      outDir: args.out,
+      json,
+      markdown,
+      jsonName: "staging-session.json",
+      markdownName: "staging-session.md",
+    });
+  }
+  if (report.runs.some((run) => run.error)) process.exitCode = 1;
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    process.stderr.write(
+      `Fatal: ${error instanceof Error ? (error.stack ?? error.message) : String(error)}\n`,
+    );
+    process.exit(1);
+  });
+}

--- a/packages/benchmarks/voice-rtt/tests/staging-common.test.ts
+++ b/packages/benchmarks/voice-rtt/tests/staging-common.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Offline coverage for staging voice ops report helpers.
+ *
+ * These tests keep the redacted artifact math deterministic without requiring
+ * staging credentials or live cloud endpoints.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  joinUrl,
+  metricSummaries,
+  redactIdentifier,
+  renderStagingMarkdown,
+  type StagingReport,
+} from "../src/staging-common.ts";
+import { parseCurlTiming } from "../src/staging-batch.ts";
+
+describe("staging helpers", () => {
+  it("summarizes nullable metrics", () => {
+    const runs = [{ ms: 10 }, { ms: 30 }, { ms: null }, { ms: 20 }];
+    const summaries = metricSummaries(runs, ["ms"], (run) => run.ms);
+    expect(summaries.ms.count).toBe(3);
+    expect(summaries.ms.p50).toBe(20);
+    expect(summaries.ms.p90).toBe(30);
+    expect(summaries.ms.p95).toBe(30);
+  });
+
+  it("renders markdown without secret-like identifiers", () => {
+    const report: StagingReport<
+      "latencyMs",
+      { metrics: { latencyMs: number } }
+    > = {
+      schemaVersion: 1,
+      generatedAt: "2026-07-10T00:00:00.000Z",
+      tool: "Staging Voice Test",
+      target: {
+        baseUrl: "https://staging.elizacloud.ai",
+        paths: { tts: "/x" },
+      },
+      summaries: metricSummaries(
+        [{ metrics: { latencyMs: 12 } }],
+        ["latencyMs"],
+        (run) => run.metrics.latencyMs,
+      ),
+      runs: [{ metrics: { latencyMs: 12 } }],
+    };
+    const markdown = renderStagingMarkdown(report, ["| Run |", "|---|"]);
+    expect(markdown).toContain("latencyMs");
+    expect(markdown).not.toContain("Bearer");
+  });
+
+  it("joins URLs and redacts long identifiers", () => {
+    expect(joinUrl("https://staging.elizacloud.ai/", "/api/v1/voice/stt")).toBe(
+      "https://staging.elizacloud.ai/api/v1/voice/stt",
+    );
+    expect(redactIdentifier("session_123456789")).toBe("sess...6789");
+  });
+
+  it("parses curl timing JSON into milliseconds", () => {
+    expect(
+      parseCurlTiming(
+        '{"httpCode":"200","dns":"0.001","connect":"0.002","tls":"0.003","ttfb":"0.040","total":"0.050"}',
+      ),
+    ).toEqual({
+      httpCode: 200,
+      dnsMs: 1,
+      connectMs: 2,
+      tlsMs: 3,
+      ttfbMs: 40,
+      totalMs: 50,
+    });
+  });
+});

--- a/packages/benchmarks/voice-rtt/tsconfig.json
+++ b/packages/benchmarks/voice-rtt/tsconfig.json
@@ -9,7 +9,7 @@
     "noEmit": true,
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
-    "types": ["node"],
+    "types": ["node", "bun"],
     "lib": ["ES2022", "DOM"]
   },
   "include": ["src/**/*.ts", "tests/**/*.ts", "fixtures/**/*.json"]

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -229,6 +229,8 @@ TUNNEL_AUTH_KEY_COST_USD = "0.01"
 #   AI_GATEWAY_API_KEY
 #   GROQ_API_KEY                       Groq
 #   CEREBRAS_API_KEY                   Cerebras — ultra-fast inference for provisioning chat agent
+#   DEEPGRAM_API_KEY                   Deepgram STT for staging voice-session soak
+#   CARTESIA_API_KEY                   Cartesia TTS for staging voice-session soak
 #   FAL_KEY                            Fal.ai video gen
 #   FAL_API_KEY                        Alias for FAL_KEY used by image/video/music generation
 #   ATLASCLOUD_API_KEY                 AtlasCloud image generation billing key
@@ -406,6 +408,7 @@ INFERENCE_PASSTHROUGH_STREAMING = "true"
 # the upstream JSON untouched; usage parses from the same buffer and bills
 # through the identical settle chain. Default off; rollback = flip off.
 INFERENCE_PASSTHROUGH_EMBEDDINGS = "true"
+VOICE_REALTIME_WS_ENABLED = "false"
 FORCE_REDIS_EVENTS = "false"
 R2_PUBLIC_HOST = "blob-staging.elizacloud.ai"
 SQL_HEAVY_PAYLOAD_STORAGE = "r2"
@@ -572,6 +575,7 @@ INFERENCE_PASSTHROUGH_STREAMING = "true"
 # the upstream JSON untouched; usage parses from the same buffer and bills
 # through the identical settle chain. Default off; rollback = flip off.
 INFERENCE_PASSTHROUGH_EMBEDDINGS = "true"
+VOICE_REALTIME_WS_ENABLED = "false"
 FORCE_REDIS_EVENTS = "false"
 R2_PUBLIC_HOST = "blob.elizacloud.ai"
 SQL_HEAVY_PAYLOAD_STORAGE = "r2"


### PR DESCRIPTION
## Summary

- add a configurable staging voice-session WebSocket RTT runner for mint, ready, STT, LLM, first audio, and interruption timing
- add a repeatable current batch TTS to STT staging baseline with curl DNS/connect/TLS/TTFB/total measurements
- publish Deepgram and Cartesia staging environment secrets during Worker deploys
- wire `VOICE_REALTIME_WS_ENABLED` as a fail-closed staging variable and hard-force it off in production

## Safety

- no deployment performed
- no flag enabled
- no provider calls or credentials used
- bearer tokens are not placed in curl argv or output artifacts
- current batch endpoints remain the fallback and production cannot enable the flag through the workflow

## Validation

- `bun run format:check`
- `bun run test` (7 files, 19 tests)
- `bun run typecheck`
- both staging wrapper `--help` smoke checks
- Codex review completed, timeout socket cleanup and bearer argv exposure findings fixed

## Deploy-day order

1. Merge the phase-1 server route and this ops wiring.
2. Run the batch baseline.
3. Set the GitHub staging environment variable and dispatch Cloud CF Deploy.
4. Verify `/api/health.commit` exactly matches the workflow `headSha` before testing.
5. Run the session rig.

[sol-cloud]
