### PR TITLE
fix(core): rescue a complete answer clobbered by a progress-ack promotion

### DIFF
--- a/packages/core/src/__tests__/message-answer-clobber-rescue.test.ts
+++ b/packages/core/src/__tests__/message-answer-clobber-rescue.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Regression coverage for the answer-clobber rescue in runV5MessageRuntimeStage1:
+ * when a response-handler evaluator promotes a simple turn to planning and
+ * overwrites a COMPLETE stage-0 answer with a bare progress ack ("On it."), the
+ * turn must not end answerless — the preserved pre-patch answer is delivered as
+ * the final message. Drives the real message→planner→evaluator pipeline with a
+ * queued canned-response model mock (no live model) and a real clobbering
+ * evaluator, exactly reproducing the live failure: eliza-code finished the
+ * "top contributors" answer, the promotion flailed through NOTIFY, and the turn
+ * ended with only the ack visible.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS } from "../runtime/builtin-field-evaluators";
+import type { ResponseHandlerEvaluator } from "../runtime/response-handler-evaluators";
+import { ResponseHandlerFieldRegistry } from "../runtime/response-handler-field-registry";
+import { runV5MessageRuntimeStage1 } from "../services/message";
+import type { Memory } from "../types/memory";
+import { ModelType } from "../types/model";
+import type { UUID } from "../types/primitives";
+import type { IAgentRuntime } from "../types/runtime";
+import type { State } from "../types/state";
+
+const AGENT_ID = "00000000-0000-0000-0000-000000000003" as UUID;
+const RESPONSE_ID = "00000000-0000-0000-0000-000000000005" as UUID;
+
+const SUBSTANTIVE_ANSWER =
+	"The top 3 contributors to elizaOS/eliza are lalalune, shakkernerd, and odilitime.";
+const PROGRESS_ACK = "On it, working on that now.";
+
+function makeMessage(): Memory {
+	return {
+		id: "00000000-0000-0000-0000-000000000001" as UUID,
+		entityId: "00000000-0000-0000-0000-000000000002" as UUID,
+		agentId: AGENT_ID,
+		roomId: "00000000-0000-0000-0000-000000000004" as UUID,
+		content: { text: "who are the top 3 contributors to the eliza repo", source: "test" },
+		createdAt: 1,
+	};
+}
+
+function makeState(): State {
+	return {
+		values: { availableContexts: "general, web" },
+		data: {},
+		text: "Recent conversation summary",
+	};
+}
+
+function stage1Response(fields: {
+	contexts?: string[];
+	replyText?: string;
+	extra?: Record<string, unknown>;
+}) {
+	return {
+		text: "",
+		toolCalls: [
+			{
+				id: "handle-response-1",
+				name: "HANDLE_RESPONSE",
+				arguments: {
+					shouldRespond: "RESPOND",
+					thought: "",
+					contexts: fields.contexts ?? [],
+					intents: [],
+					candidateActionNames: [],
+					replyText: fields.replyText ?? "",
+					facts: [],
+					relationships: [],
+					addressedTo: [],
+					...(fields.extra ?? {}),
+				},
+			},
+		],
+	};
+}
+
+// A response-handler evaluator that reproduces the live promotion-that-clobbers:
+// it forces the turn into planning (requiresTool) and overwrites the substantive
+// stage-0 answer with a bare progress ack.
+const CLOBBER_EVALUATOR: ResponseHandlerEvaluator = {
+	name: "test-clobber-to-ack",
+	priority: 100,
+	shouldRun: () => true,
+	evaluate: () => ({ reply: PROGRESS_ACK, requiresTool: true }),
+};
+
+function makeRuntime(responses: unknown[]): IAgentRuntime {
+	const queue = [...responses];
+	const responseHandlerFieldRegistry = new ResponseHandlerFieldRegistry();
+	for (const evaluator of BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS) {
+		responseHandlerFieldRegistry.register(evaluator);
+	}
+	return {
+		agentId: AGENT_ID,
+		character: { name: "Test Agent", system: "You are concise.", bio: "I help." },
+		actions: [],
+		providers: [],
+		composeState: vi.fn(async () => makeState()),
+		runActionsByMode: vi.fn(async () => undefined),
+		emitEvent: vi.fn(async () => undefined),
+		useModel: vi.fn(async () => {
+			if (queue.length === 0) throw new Error("Unexpected useModel call");
+			return queue.shift();
+		}),
+		getSetting: vi.fn(() => undefined),
+		logger: {
+			debug: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+			trace: vi.fn(),
+		},
+		responseHandlerFieldRegistry,
+		responseHandlerFieldEvaluators: [...BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS],
+		responseHandlerEvaluators: [CLOBBER_EVALUATOR],
+	} as unknown as IAgentRuntime;
+}
+
+describe("answer-clobber rescue", () => {
+	it("delivers the preserved stage-0 answer when a promotion clobbers it with a progress ack", async () => {
+		const earlyReplies: string[] = [];
+		const runtime = makeRuntime([
+			stage1Response({
+				contexts: ["web"],
+				replyText: SUBSTANTIVE_ANSWER,
+			}),
+			// Planner finishes without producing any new final text (answerless).
+			{
+				expectModelType: ModelType.ACTION_PLANNER,
+				body: { text: "", toolCalls: [] },
+			},
+			// Evaluator FINISHes with no messageToUser — nothing new to say.
+			{
+				expectModelType: ModelType.RESPONSE_HANDLER,
+				body: JSON.stringify({
+					success: true,
+					decision: "FINISH",
+					thought: "Nothing further.",
+					messageToUser: "",
+				}),
+			},
+		]);
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage(),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+			onResponseHandlerEarlyReply: async ({ text }) => {
+				earlyReplies.push(text);
+			},
+		});
+
+		// The ack was the early reply the user saw first.
+		expect(earlyReplies).toContain(PROGRESS_ACK);
+		// The turn does NOT end answerless: the preserved substantive answer is the
+		// final delivered text, not a second copy of the progress ack.
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind === "planned_reply") {
+			expect(result.result.responseContent?.text).toBe(SUBSTANTIVE_ANSWER);
+		}
+	});
+});

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -6791,6 +6791,17 @@ export async function runV5MessageRuntimeStage1(args: {
 				});
 		}
 
+		// Response-handler evaluators may promote a simple turn to planning and
+		// clobber a COMPLETE stage-0 answer with an "On it." ack (observed live:
+		// stage-0 held the full contributors answer; the promotion flailed through
+		// NOTIFY and the turn ended answerless). Preserve the pre-patch reply so
+		// the planner loop's answer rescue and the answerless-final fallback can
+		// still deliver it.
+		const prePatchStageOneReply =
+			typeof messageHandler.plan.reply === "string" &&
+			messageHandler.plan.reply.trim().length > 0
+				? messageHandler.plan.reply
+				: undefined;
 		const responseHandlerEvaluation = fieldRunResult?.preempt
 			? {
 					activeEvaluators: [],
@@ -7227,10 +7238,24 @@ export async function runV5MessageRuntimeStage1(args: {
 				// replyText (when answer-shaped) is surfaced instead of the
 				// generic transient-failure apology. Duplicate delivery is safe —
 				// early-reply turns dedup via plannedTextRepeatsEarlyReply.
-				stageOneReplyText:
-					typeof messageHandler.plan.reply === "string"
-						? messageHandler.plan.reply
-						: undefined,
+				stageOneReplyText: (() => {
+					const postPatch =
+						typeof messageHandler.plan.reply === "string"
+							? messageHandler.plan.reply
+							: undefined;
+					// A promotion patch that replaced a substantive stage-0 answer
+					// with a bare progress ack must not also disarm the loop's
+					// answer rescue — feed the preserved pre-patch answer instead.
+					if (
+						prePatchStageOneReply &&
+						postPatch &&
+						postPatch !== prePatchStageOneReply &&
+						PROGRESS_ONLY_ANSWER_REJECT.test(postPatch.trim())
+					) {
+						return prePatchStageOneReply;
+					}
+					return postPatch;
+				})(),
 				// Per-turn miss-budget cap for answered turns escalated only by a
 				// view-surface token overlap (see viewOverlapRequiredToolMissBudget);
 				// the loop honors it only when stageOneReplyText is answer-shaped.
@@ -7338,11 +7363,25 @@ export async function runV5MessageRuntimeStage1(args: {
 			typeof messageHandler.plan.reply === "string"
 				? messageHandler.plan.reply.trim()
 				: "";
+		// Answerless-final fallback: when the planner loop finished with NO final
+		// text and the only thing the user saw was a progress ack ("On it."), a
+		// preserved substantive stage-0 answer is strictly better than silence —
+		// deliver it. The earlyReply/action dedup guards below still apply.
+		const preservedAnswerFallback =
+			!plannedText &&
+			earlyReplySent &&
+			!suppressesPlannerReply &&
+			prePatchStageOneReply &&
+			!PROGRESS_ONLY_ANSWER_REJECT.test(prePatchStageOneReply.trim()) &&
+			normalizeVisibleTextForDuplicateCheck(prePatchStageOneReply) !==
+				normalizeVisibleTextForDuplicateCheck(earlyReplyText)
+				? prePatchStageOneReply
+				: "";
 		const ackFallback =
 			!plannedText && !earlyReplySent && !suppressesPlannerReply
 				? stageOneAck ||
 					(ranNonSilentAction ? "on it, working on that now." : "")
-				: "";
+				: preservedAnswerFallback;
 		const effectiveReplyText = plannedText || ackFallback;
 		const plannedTextRepeatsEarlyReply =
 			earlyReplySent &&


### PR DESCRIPTION
Split 3/4 of #15957 (one causal change per PR, per review).

## The bug
A response-handler evaluator can **promote a simple turn to planning** and, in the same patch, **overwrite a COMPLETE stage-0 answer with a bare progress ack** (`"On it."`). When the ensuing planner loop then finishes without producing new final text, the turn ends with **only the ack visible** — the real answer is silently lost.

Observed live (cerebras + eliza-code): the sub-agent finished the "top 3 contributors" answer, the promotion flailed through `NOTIFY`, and the user saw `"On it."` and nothing else.

## The fix
One causal change — **answer preservation across an evaluator promotion** in `runV5MessageRuntimeStage1`:

1. **Capture** `prePatchStageOneReply` *before* the response-handler evaluators run.
2. **Don't disarm the loop's answer rescue.** When the post-patch reply is a bare progress ack (`PROGRESS_ONLY_ANSWER_REJECT`) but the pre-patch reply was substantive, feed the **preserved** answer to the planner loop's required-tool answer-rescue instead of the ack.
3. **Answerless-final fallback.** If the loop finishes with no final text and the user has seen only the progress ack, deliver the **preserved substantive answer** rather than silence. The existing `earlyReply` / action-echo dedup guards still apply (the ack that was already sent is never duplicated).

No behavior change when the stage-0 answer is *not* clobbered, or when the planner produces its own final text.

## Test — real pipeline, no mock-under-test
`packages/core/src/__tests__/message-answer-clobber-rescue.test.ts` drives the **actual** message→planner→evaluator path through `runV5MessageRuntimeStage1` with a queued canned-response model (no live model) and a **real** clobbering `ResponseHandlerEvaluator` that reproduces the promotion. It asserts the user receives the preserved answer, not the ack.

Proven to catch the regression:
- **Without the fix** (develop's `message.ts`): `result.result.responseContent?.text` is `undefined` — the turn ends answerless. ❌
- **With the fix**: the substantive answer is delivered. ✅

`packages/core` builds clean (`build:node`).
