### PR TITLE
feat(ui): LP3-first ambient mode capture surface [sol-cloud]

### DIFF
--- a/packages/app-core/src/api/dev-route-catalog.ts
+++ b/packages/app-core/src/api/dev-route-catalog.ts
@@ -392,6 +392,18 @@ const ROUTES: DevRouteEntry[] = [
     platformGate: null,
   },
   {
+    tabId: "ambient",
+    path: "/ambient",
+    label: "Ambient",
+    group: "Ambient",
+    visibility: "all",
+    // Opt-in surface: the nav tile only shows when VITE_ENABLE_AMBIENT is set,
+    // but the route is always addressable (mirrors navigation TAB_PATHS).
+    featureFlag: "VITE_ENABLE_AMBIENT",
+    requiresAuth: true,
+    platformGate: null,
+  },
+  {
     tabId: "automations",
     path: "/automations",
     label: "Automations",

--- a/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
@@ -124,6 +124,7 @@ const BUILTIN_TAB_PATHS: Record<string, string> = {
   browser: "/browser",
   stream: "/stream",
   "pendant-transcript": "/pendant/transcript",
+  ambient: "/ambient",
   apps: "/apps",
   views: "/views",
   character: "/character",

--- a/packages/app/test/ui-smoke/view-routes.ts
+++ b/packages/app/test/ui-smoke/view-routes.ts
@@ -24,6 +24,7 @@ export const VIEW_ROUTES: readonly ViewRoute[] = [
   { id: "browser", path: "/browser" },
   { id: "stream", path: "/stream" },
   { id: "pendant-transcript", path: "/pendant/transcript" },
+  { id: "ambient", path: "/ambient" },
   { id: "apps", path: "/apps" },
   { id: "views", path: "/views" },
   { id: "character", path: "/character" },

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -112,6 +112,7 @@ import { useSecretsManagerModalState } from "./hooks/useSecretsManagerModal";
 import { useSecretsManagerShortcut } from "./hooks/useSecretsManagerShortcut";
 import { cn } from "./lib/utils";
 import {
+  AMBIENT_NAV_ENABLED,
   APPS_ENABLED,
   getAppSlugFromPath,
   getWindowNavigationPath,
@@ -292,6 +293,10 @@ const StreamView = lazyNamedView(
 const PendantTranscriptView = lazyNamedView(
   () => import("./components/pages/PendantTranscriptView"),
   "PendantTranscriptView",
+);
+const AmbientView = lazyNamedView(
+  () => import("./components/pages/AmbientView"),
+  "AmbientView",
 );
 // Route-level page views — lazy-split out of the main chunk. Each renders
 // inside the LazyViewBoundary Suspense below, and none is imported statically
@@ -1382,6 +1387,12 @@ function buildStaticTabRenderers(): Record<
     browser: () => <BrowserWorkspaceView />,
     stream: () => <StreamView />,
     "pendant-transcript": () => <PendantTranscriptView />,
+    // Ambient is opt-in: even though /ambient stays routable for parity/tests,
+    // the always-listening surface must NOT mount when the flag is off, or
+    // direct navigation would bypass the default-off gate. Render the
+    // unavailable fallback instead when disabled.
+    ambient: () =>
+      AMBIENT_NAV_ENABLED ? <AmbientView /> : <ViewUnavailableFallback />,
     tasks: wrap(<TasksPageView />),
     automations: () => <AutomationsFeed />,
     plugins: withHeader("plugins", <PluginsPageView />),

--- a/packages/ui/src/ambient/AmbientCaptureControl.test.tsx
+++ b/packages/ui/src/ambient/AmbientCaptureControl.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * Tests the ambient capture control surface: consent gate before first start,
+ * lifecycle buttons per state, duration formatting, and honest unsupported
+ * copy.
+ */
+
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  AmbientCaptureControl,
+  formatAmbientDuration,
+} from "./AmbientCaptureControl";
+import type { AmbientSessionSnapshot } from "./ambient-session-adapter";
+
+afterEach(cleanup);
+
+function snapshot(
+  overrides: Partial<AmbientSessionSnapshot> = {},
+): AmbientSessionSnapshot {
+  return {
+    status: "idle",
+    transport: "batch",
+    processingLocation: "on-device",
+    deviceName: null,
+    capturing: false,
+    supported: true,
+    error: null,
+    ...overrides,
+  };
+}
+
+const handlers = {
+  onGrantConsent: vi.fn(),
+  onStart: vi.fn(),
+  onPause: vi.fn(),
+  onResume: vi.fn(),
+  onStop: vi.fn(),
+};
+
+describe("formatAmbientDuration", () => {
+  it("formats mm:ss under an hour and h:mm:ss past it", () => {
+    expect(formatAmbientDuration(0)).toBe("00:00");
+    expect(formatAmbientDuration(65_000)).toBe("01:05");
+    expect(formatAmbientDuration(3_725_000)).toBe("1:02:05");
+  });
+});
+
+describe("AmbientCaptureControl", () => {
+  it("shows the consent gate before consent is granted", () => {
+    render(
+      <AmbientCaptureControl
+        snapshot={snapshot()}
+        consent="ungranted"
+        elapsedMs={0}
+        resolvedCount={0}
+        pendingCount={0}
+        {...handlers}
+      />,
+    );
+    expect(screen.getByTestId("ambient-consent-gate")).toBeTruthy();
+    expect(screen.queryByTestId("ambient-start")).toBeNull();
+  });
+
+  it("shows Start once consent is granted", () => {
+    render(
+      <AmbientCaptureControl
+        snapshot={snapshot()}
+        consent="granted"
+        elapsedMs={0}
+        resolvedCount={0}
+        pendingCount={0}
+        {...handlers}
+      />,
+    );
+    expect(screen.queryByTestId("ambient-consent-gate")).toBeNull();
+    fireEvent.click(screen.getByTestId("ambient-start"));
+    expect(handlers.onStart).toHaveBeenCalled();
+  });
+
+  it("shows Pause + Stop while capturing, with session stats", () => {
+    render(
+      <AmbientCaptureControl
+        snapshot={snapshot({ status: "capturing", capturing: true })}
+        consent="granted"
+        elapsedMs={65_000}
+        resolvedCount={3}
+        pendingCount={1}
+        {...handlers}
+      />,
+    );
+    expect(screen.getByTestId("ambient-duration").textContent).toBe("01:05");
+    expect(screen.getByTestId("ambient-segment-count").textContent).toContain(
+      "3",
+    );
+    fireEvent.click(screen.getByTestId("ambient-pause"));
+    expect(handlers.onPause).toHaveBeenCalled();
+    fireEvent.click(screen.getByTestId("ambient-stop"));
+    expect(handlers.onStop).toHaveBeenCalled();
+  });
+
+  it("shows Resume while paused", () => {
+    render(
+      <AmbientCaptureControl
+        snapshot={snapshot({ status: "paused" })}
+        consent="granted"
+        elapsedMs={0}
+        resolvedCount={0}
+        pendingCount={0}
+        {...handlers}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("ambient-resume"));
+    expect(handlers.onResume).toHaveBeenCalled();
+  });
+
+  it("shows honest unsupported copy and no controls when unsupported", () => {
+    render(
+      <AmbientCaptureControl
+        snapshot={snapshot({ status: "unsupported", supported: false })}
+        consent="ungranted"
+        elapsedMs={0}
+        resolvedCount={0}
+        pendingCount={0}
+        {...handlers}
+      />,
+    );
+    expect(screen.getByTestId("ambient-unsupported")).toBeTruthy();
+    expect(screen.queryByTestId("ambient-consent-gate")).toBeNull();
+    expect(screen.queryByTestId("ambient-start")).toBeNull();
+  });
+});

--- a/packages/ui/src/ambient/AmbientCaptureControl.tsx
+++ b/packages/ui/src/ambient/AmbientCaptureControl.tsx
@@ -1,0 +1,176 @@
+/**
+ * Ambient capture control surface.
+ *
+ * The command header for an ambient session: consent gate before first start,
+ * start/pause/resume/stop lifecycle, the always-visible recording indicator,
+ * and session bookkeeping (duration mm:ss + resolved/pending segment counts).
+ *
+ * Layout is LP3-first: single column, big tap targets (`size="lg"`, full-width
+ * buttons), monochrome-safe state via the indicator, and no bleeding-edge CSS
+ * (flex + border tokens only). Black/white/orange tokens + lucide icons; no
+ * gradients, no emoji.
+ */
+
+import { Ear, Loader2, Pause, Play, Square } from "lucide-react";
+import type * as React from "react";
+import { cn } from "../lib/utils";
+import { Button } from "../components/ui/button";
+import { AmbientConsentGate } from "./AmbientConsentGate";
+import { AmbientRecordingIndicator } from "./AmbientRecordingIndicator";
+import { ambientCaptureAllowed, type AmbientConsentState } from "./ambient-consent";
+import type { AmbientSessionSnapshot } from "./ambient-session-adapter";
+
+export interface AmbientCaptureControlProps {
+  snapshot: AmbientSessionSnapshot;
+  consent: AmbientConsentState;
+  elapsedMs: number;
+  resolvedCount: number;
+  pendingCount: number;
+  onGrantConsent: () => void;
+  onStart: () => void;
+  onPause: () => void;
+  onResume: () => void;
+  onStop: () => void;
+  className?: string;
+}
+
+/** Format elapsed ms as mm:ss (or h:mm:ss past an hour). Grayscale-friendly. */
+export function formatAmbientDuration(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1_000));
+  const hours = Math.floor(totalSeconds / 3_600);
+  const minutes = Math.floor((totalSeconds % 3_600) / 60);
+  const seconds = totalSeconds % 60;
+  const mm = String(minutes).padStart(2, "0");
+  const ss = String(seconds).padStart(2, "0");
+  return hours > 0 ? `${hours}:${mm}:${ss}` : `${mm}:${ss}`;
+}
+
+export function AmbientCaptureControl({
+  snapshot,
+  consent,
+  elapsedMs,
+  resolvedCount,
+  pendingCount,
+  onGrantConsent,
+  onStart,
+  onPause,
+  onResume,
+  onStop,
+  className,
+}: AmbientCaptureControlProps): React.ReactElement {
+  const { status, supported } = snapshot;
+  const capturing = status === "capturing";
+  const paused = status === "paused";
+  const active = capturing || paused;
+  const starting = status === "starting";
+  const canStart = ambientCaptureAllowed(consent);
+
+  return (
+    <section
+      data-testid="ambient-capture-control"
+      className={cn("flex flex-col gap-4", className)}
+    >
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <AmbientRecordingIndicator
+          status={status}
+          processingLocation={snapshot.processingLocation}
+        />
+        {active ? (
+          <div
+            className="flex items-center gap-4 font-mono text-sm text-muted"
+            data-testid="ambient-session-stats"
+          >
+            <span data-testid="ambient-duration">
+              {formatAmbientDuration(elapsedMs)}
+            </span>
+            <span data-testid="ambient-segment-count">
+              {resolvedCount} · {pendingCount} pending
+            </span>
+          </div>
+        ) : null}
+      </div>
+
+      {!supported ? (
+        <div
+          className="border-l-2 border-border bg-bg-muted px-3 py-2.5 text-sm text-muted"
+          data-testid="ambient-unsupported"
+        >
+          Ambient listening isn't available in this environment. Use the Android
+          app or a desktop Chrome browser. On iPhone, ambient runs only while the
+          app is open and in the foreground.
+        </div>
+      ) : !active && !canStart ? (
+        <AmbientConsentGate
+          processingLocation={snapshot.processingLocation}
+          onGrant={onGrantConsent}
+        />
+      ) : (
+        <div className="flex flex-col gap-2">
+          {!active ? (
+            <Button
+              variant="surfaceAccent"
+              size="lg"
+              onClick={onStart}
+              disabled={starting}
+              data-testid="ambient-start"
+              className="w-full"
+            >
+              {starting ? (
+                <Loader2 className="size-4 animate-spin" aria-hidden />
+              ) : (
+                <Ear className="size-4" aria-hidden />
+              )}
+              {starting ? "Starting…" : "Start listening"}
+            </Button>
+          ) : (
+            <div className="flex flex-col gap-2 sm:flex-row">
+              {paused ? (
+                <Button
+                  variant="surfaceAccent"
+                  size="lg"
+                  onClick={onResume}
+                  data-testid="ambient-resume"
+                  className="w-full"
+                >
+                  <Play className="size-4" aria-hidden />
+                  Resume
+                </Button>
+              ) : (
+                <Button
+                  variant="surface"
+                  size="lg"
+                  onClick={onPause}
+                  data-testid="ambient-pause"
+                  className="w-full"
+                >
+                  <Pause className="size-4" aria-hidden />
+                  Pause
+                </Button>
+              )}
+              <Button
+                variant="surfaceDestructive"
+                size="lg"
+                onClick={onStop}
+                data-testid="ambient-stop"
+                className="w-full"
+              >
+                <Square className="size-4" aria-hidden />
+                Stop
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {snapshot.error ? (
+        <div
+          role="alert"
+          className="border-l-2 border-danger bg-danger/10 px-3 py-2.5 text-sm text-danger"
+          data-testid="ambient-control-error"
+        >
+          {snapshot.error}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/packages/ui/src/ambient/AmbientConsentGate.test.tsx
+++ b/packages/ui/src/ambient/AmbientConsentGate.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * Tests the ambient consent gate: it affirms per processing path (no
+ * contradictory cloud/on-device disclosure), carries the two-party reminder,
+ * and grants on the explicit action only.
+ */
+
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AmbientConsentGate } from "./AmbientConsentGate";
+
+afterEach(cleanup);
+
+describe("AmbientConsentGate", () => {
+  it("states cloud processing for the cloud path (no on-device claim)", () => {
+    render(
+      <AmbientConsentGate processingLocation="cloud" onGrant={vi.fn()} />,
+    );
+    const gate = screen.getByTestId("ambient-consent-gate");
+    const text = gate.textContent?.toLowerCase() ?? "";
+    expect(text).toContain("cloud");
+    expect(text).not.toContain("on this device");
+    expect(screen.getByTestId("ambient-two-party-reminder")).toBeTruthy();
+  });
+
+  it("states on-device processing for the batch path (no cloud claim in the affirmation)", () => {
+    render(
+      <AmbientConsentGate processingLocation="on-device" onGrant={vi.fn()} />,
+    );
+    const affirmation = screen
+      .getByTestId("ambient-consent-gate")
+      .querySelector("p")?.textContent
+      ?.toLowerCase();
+    expect(affirmation).toContain("on this device");
+    expect(affirmation).not.toContain("cloud");
+  });
+
+  it("grants only on the explicit action", () => {
+    const onGrant = vi.fn();
+    render(
+      <AmbientConsentGate processingLocation="cloud" onGrant={onGrant} />,
+    );
+    expect(onGrant).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByTestId("ambient-consent-grant"));
+    expect(onGrant).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/ambient/AmbientConsentGate.tsx
+++ b/packages/ui/src/ambient/AmbientConsentGate.tsx
@@ -1,0 +1,92 @@
+/**
+ * Explicit per-session ambient consent gate.
+ *
+ * AMBIENT-MODE-DESIGN §8.1: capture requires an explicit per-session consent
+ * action before the first frame; §8.3: show a jurisdiction-neutral two-party
+ * reminder at multi-speaker session start (guidance, never a legal shield).
+ *
+ * This is NOT a dismissible toast — it is a blocking affordance that stands
+ * between "idle" and the first capture. It states plainly what starting does
+ * (continuous listening, cloud processing) and carries the bystander reminder.
+ * The user must actively affirm; there is no pre-checked box, no "remember"
+ * (consent is per-session by design). Big tap targets for the LP3.
+ */
+
+import { Ear, ShieldAlert } from "lucide-react";
+import type * as React from "react";
+import { cn } from "../lib/utils";
+import { Button } from "../components/ui/button";
+import {
+  AMBIENT_TWO_PARTY_REMINDER,
+  ambientConsentAffirmation,
+} from "./ambient-consent";
+import type { AmbientProcessingLocation } from "./ambient-session-adapter";
+
+export interface AmbientConsentGateProps {
+  processingLocation: AmbientProcessingLocation;
+  /** Affirm consent for this session (does not itself begin capture). */
+  onGrant: () => void;
+  className?: string;
+}
+
+export function AmbientConsentGate({
+  processingLocation,
+  onGrant,
+  className,
+}: AmbientConsentGateProps): React.ReactElement {
+  // Single source of truth for the processing-location clause so the headline
+  // affirmation and any supporting copy can never contradict each other.
+  const affirmation = ambientConsentAffirmation(processingLocation);
+
+  return (
+    <section
+      data-testid="ambient-consent-gate"
+      className={cn(
+        "flex flex-col gap-4 border border-border bg-card p-5",
+        className,
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <Ear
+          className="mt-0.5 size-5 shrink-0 text-accent"
+          aria-hidden
+        />
+        <div className="min-w-0">
+          <h2 className="text-base font-semibold text-txt-strong">
+            Start ambient listening
+          </h2>
+          <p className="mt-1 text-sm leading-6 text-muted">
+            {affirmation}
+          </p>
+        </div>
+      </div>
+
+      <div
+        className="flex items-start gap-3 border-l-2 border-accent bg-accent-subtle px-3 py-2.5"
+        data-testid="ambient-two-party-reminder"
+      >
+        <ShieldAlert
+          className="mt-0.5 size-4 shrink-0 text-accent"
+          aria-hidden
+        />
+        <p className="text-xs leading-relaxed text-muted-strong">
+          {AMBIENT_TWO_PARTY_REMINDER}
+        </p>
+      </div>
+
+      <Button
+        variant="surfaceAccent"
+        size="lg"
+        onClick={onGrant}
+        data-testid="ambient-consent-grant"
+        className="w-full"
+      >
+        <Ear className="size-4" aria-hidden />I understand — enable listening
+      </Button>
+      <p className="text-2xs leading-relaxed text-muted/80">
+        Consent applies to this session only. Stopping resets it, and starting
+        again asks once more.
+      </p>
+    </section>
+  );
+}

--- a/packages/ui/src/ambient/AmbientRecordingIndicator.test.tsx
+++ b/packages/ui/src/ambient/AmbientRecordingIndicator.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * Tests the always-visible recording indicator: it communicates state via a
+ * word (never icon-only), marks the capturing state on a data attribute, and
+ * states processing location honestly while active.
+ */
+
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { AmbientRecordingIndicator } from "./AmbientRecordingIndicator";
+
+afterEach(cleanup);
+
+describe("AmbientRecordingIndicator", () => {
+  it("shows a LISTENING word + capturing flag while capturing", () => {
+    render(
+      <AmbientRecordingIndicator
+        status="capturing"
+        processingLocation="cloud"
+      />,
+    );
+    const el = screen.getByTestId("ambient-recording-indicator");
+    expect(el.getAttribute("data-capturing")).toBe("true");
+    expect(screen.getByTestId("ambient-recording-word").textContent).toBe(
+      "Listening",
+    );
+    expect(screen.getByTestId("ambient-processing-location").textContent).toBe(
+      "cloud",
+    );
+  });
+
+  it("shows PAUSED and clears the capturing flag when paused", () => {
+    render(
+      <AmbientRecordingIndicator
+        status="paused"
+        processingLocation="on-device"
+      />,
+    );
+    const el = screen.getByTestId("ambient-recording-indicator");
+    expect(el.getAttribute("data-capturing")).toBe("false");
+    expect(screen.getByTestId("ambient-recording-word").textContent).toBe(
+      "Paused",
+    );
+    expect(screen.getByTestId("ambient-processing-location").textContent).toBe(
+      "on-device",
+    );
+  });
+
+  it("shows OFF and hides the location line when idle", () => {
+    render(
+      <AmbientRecordingIndicator status="idle" processingLocation="cloud" />,
+    );
+    expect(screen.getByTestId("ambient-recording-word").textContent).toBe(
+      "Off",
+    );
+    expect(screen.queryByTestId("ambient-processing-location")).toBeNull();
+  });
+});

--- a/packages/ui/src/ambient/AmbientRecordingIndicator.tsx
+++ b/packages/ui/src/ambient/AmbientRecordingIndicator.tsx
@@ -1,0 +1,108 @@
+/**
+ * Always-visible ambient recording indicator.
+ *
+ * AMBIENT-MODE-DESIGN §8.1 requires a persistent, monochrome-safe, unmistakable
+ * "listening / paused" element — "a requirement, not a toast." So this is not a
+ * subtle dot: it is a bordered pill that communicates state three redundant
+ * ways so it survives a small grayscale-ish LP3 screen and reduced-motion:
+ *
+ *   1. SHAPE   — a filled square while capturing (the universal "recording"
+ *                glyph), an outlined double-bar while paused, a hollow ring idle.
+ *   2. MOTION  — a slow pulse while capturing (disabled under reduce-motion,
+ *                where the solid shape + word still carry the state).
+ *   3. WORD    — an explicit "LISTENING" / "PAUSED" / "OFF" label, never
+ *                icon-only, so colorblind + grayscale users read state directly.
+ *
+ * It also states the processing location honestly ("cloud" vs "on-device") so
+ * the UI never implies on-device for a cloud path. Uses only the black/white/
+ * orange token system and lucide icons — no gradients, no emoji.
+ */
+
+import { CircleDot, Radio, Square } from "lucide-react";
+import type * as React from "react";
+import { cn } from "../lib/utils";
+import type {
+  AmbientCaptureStatus,
+  AmbientProcessingLocation,
+} from "./ambient-session-adapter";
+
+export interface AmbientRecordingIndicatorProps {
+  status: AmbientCaptureStatus;
+  processingLocation: AmbientProcessingLocation;
+  className?: string;
+}
+
+function stateWord(status: AmbientCaptureStatus): string {
+  switch (status) {
+    case "capturing":
+      return "Listening";
+    case "paused":
+      return "Paused";
+    case "starting":
+      return "Starting";
+    case "stopping":
+      return "Stopping";
+    case "error":
+      return "Error";
+    case "unsupported":
+      return "Unavailable";
+    default:
+      return "Off";
+  }
+}
+
+export function AmbientRecordingIndicator({
+  status,
+  processingLocation,
+  className,
+}: AmbientRecordingIndicatorProps): React.ReactElement {
+  const capturing = status === "capturing";
+  const paused = status === "paused";
+  const active = capturing || paused;
+  const location =
+    processingLocation === "cloud" ? "cloud" : "on-device";
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      data-testid="ambient-recording-indicator"
+      data-capturing={capturing ? "true" : "false"}
+      className={cn(
+        "inline-flex items-center gap-2 rounded-sm border px-3 py-2 text-sm font-medium",
+        // High-contrast border + fill so the pill reads on a grayscale screen.
+        capturing
+          ? "border-accent bg-accent-subtle text-txt-strong"
+          : paused
+            ? "border-border bg-card text-muted-strong"
+            : "border-border bg-card text-muted",
+        className,
+      )}
+    >
+      {/* SHAPE: filled square = recording, double-bar ring = paused, hollow = off. */}
+      {capturing ? (
+        <Square
+          className={cn(
+            "size-3.5 fill-accent text-accent",
+            "animate-pulse motion-reduce:animate-none",
+          )}
+          aria-hidden
+        />
+      ) : paused ? (
+        <Radio className="size-3.5 text-muted-strong" aria-hidden />
+      ) : (
+        <CircleDot className="size-3.5 text-muted" aria-hidden />
+      )}
+      {/* WORD: never icon-only. */}
+      <span data-testid="ambient-recording-word">{stateWord(status)}</span>
+      {active ? (
+        <span
+          className="border-l border-border pl-2 text-2xs uppercase tracking-wide text-muted"
+          data-testid="ambient-processing-location"
+        >
+          {location}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/ui/src/ambient/AmbientTranscriptFeed.tsx
+++ b/packages/ui/src/ambient/AmbientTranscriptFeed.tsx
@@ -1,0 +1,139 @@
+/**
+ * Live ambient transcript feed.
+ *
+ * Renders the streaming segment list from the REUSED pendant transcript store
+ * (`PendantTranscriptSegment` — no new transcript store). Segments render in
+ * their lifecycle states: `pending` (in-flight, muted "Transcribing…"),
+ * `resolved` (final text), `failed` (quiet failure). Auto-scrolls to the latest
+ * segment while pinned to the bottom, with a "Latest" jump affordance otherwise
+ * — the same interaction the pendant transcript view uses, so the two surfaces
+ * feel identical.
+ *
+ * LP3-first: single column, large readable body text, no bleeding-edge CSS.
+ */
+
+import { ArrowDown } from "lucide-react";
+import type * as React from "react";
+import { cn } from "../lib/utils";
+import { Button } from "../components/ui/button";
+import { useThreadAutoScroll } from "../hooks/useThreadAutoScroll";
+import type { PendantTranscriptSegment } from "../pendant/pendant-transcript-session";
+
+const CLOCK_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+  hour12: false,
+});
+
+function formatClock(ms: number): string {
+  return CLOCK_FORMATTER.format(ms);
+}
+
+function AmbientSegmentRow({
+  segment,
+}: {
+  segment: PendantTranscriptSegment;
+}): React.ReactElement {
+  const pending = segment.status === "pending";
+  const failed = segment.status === "failed";
+  return (
+    <article
+      className={cn(
+        "border-b border-border px-4 py-4",
+        pending && "text-muted",
+        failed && "text-muted/80",
+      )}
+      data-testid={`ambient-segment-${segment.status}`}
+    >
+      <div className="mb-2 flex items-center justify-between gap-3 text-2xs uppercase text-muted">
+        <span>{formatClock(segment.startedAt)}</span>
+        <span>{Math.max(0, segment.durationMs / 1_000).toFixed(1)}s</span>
+      </div>
+      {pending ? (
+        <p className="text-sm leading-6">Transcribing…</p>
+      ) : failed ? (
+        <p className="text-sm leading-6">
+          {segment.warning ?? "Could not transcribe this segment."}
+        </p>
+      ) : (
+        <p className="text-base leading-7 text-txt">{segment.text}</p>
+      )}
+    </article>
+  );
+}
+
+export interface AmbientTranscriptFeedProps {
+  segments: PendantTranscriptSegment[];
+  /** True while capture is live; drives the empty-state copy. */
+  capturing: boolean;
+  cacheError?: string | null;
+  className?: string;
+}
+
+export function AmbientTranscriptFeed({
+  segments,
+  capturing,
+  cacheError,
+  className,
+}: AmbientTranscriptFeedProps): React.ReactElement {
+  const { scrollRef, atBottom, jumpToLatest } =
+    useThreadAutoScroll<HTMLDivElement>({
+      growthKey: `${segments.length}:${
+        segments.at(-1)?.status ?? "empty"
+      }:${segments.at(-1)?.text.length ?? 0}`,
+    });
+
+  return (
+    <div className={cn("relative min-h-0 flex-1", className)}>
+      <div
+        ref={scrollRef}
+        className="h-full overflow-y-auto"
+        aria-live="polite"
+        data-testid="ambient-transcript-feed"
+      >
+        {cacheError && segments.length === 0 ? (
+          <div className="flex h-full items-center justify-center px-6 text-center">
+            <div className="max-w-md">
+              <p className="text-sm font-medium text-danger">
+                Transcript cache unavailable
+              </p>
+              <p className="mt-2 text-sm leading-6 text-muted">
+                Clear the local view to retry storage access.
+              </p>
+            </div>
+          </div>
+        ) : segments.length === 0 ? (
+          <div className="flex h-full items-center justify-center px-6 text-center">
+            <div className="max-w-md">
+              <p className="text-sm font-medium text-txt-strong">
+                {capturing ? "Listening…" : "No transcript yet"}
+              </p>
+              <p className="mt-2 text-sm leading-6 text-muted">
+                {capturing
+                  ? "Speak, and finalized segments appear here as each turn ends."
+                  : "Start listening, and finalized segments appear here as you speak."}
+              </p>
+            </div>
+          </div>
+        ) : (
+          segments.map((segment) => (
+            <AmbientSegmentRow key={segment.id} segment={segment} />
+          ))
+        )}
+      </div>
+      {!atBottom ? (
+        <Button
+          variant="surfaceAccent"
+          size="sm"
+          onClick={jumpToLatest}
+          className="absolute bottom-4 left-1/2 -translate-x-1/2"
+          data-testid="ambient-transcript-jump"
+        >
+          <ArrowDown className="size-4" aria-hidden />
+          Latest
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/ui/src/ambient/ambient-consent.test.ts
+++ b/packages/ui/src/ambient/ambient-consent.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Unit tests for the per-session ambient consent gate.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  AMBIENT_CONSENT_AFFIRMATION,
+  AMBIENT_TWO_PARTY_REMINDER,
+  ambientCaptureAllowed,
+  ambientConsentAffirmation,
+  ambientConsentReducer,
+} from "./ambient-consent";
+
+describe("ambient consent gate", () => {
+  it("starts ungranted and blocks capture", () => {
+    expect(ambientCaptureAllowed("ungranted")).toBe(false);
+  });
+
+  it("grant permits capture", () => {
+    const next = ambientConsentReducer("ungranted", "grant");
+    expect(next).toBe("granted");
+    expect(ambientCaptureAllowed(next)).toBe(true);
+  });
+
+  it("revoke re-blocks capture (per-session reset)", () => {
+    const granted = ambientConsentReducer("ungranted", "grant");
+    const revoked = ambientConsentReducer(granted, "revoke");
+    expect(revoked).toBe("ungranted");
+    expect(ambientCaptureAllowed(revoked)).toBe(false);
+  });
+
+  it("exposes non-empty consent + two-party copy", () => {
+    expect(AMBIENT_CONSENT_AFFIRMATION.length).toBeGreaterThan(0);
+    expect(AMBIENT_TWO_PARTY_REMINDER.toLowerCase()).toContain("consent");
+  });
+
+  it("words the affirmation per processing path without contradiction", () => {
+    const cloud = ambientConsentAffirmation("cloud");
+    const local = ambientConsentAffirmation("on-device");
+    // Cloud copy claims cloud and never claims on-device, and vice versa.
+    expect(cloud.toLowerCase()).toContain("cloud");
+    expect(cloud.toLowerCase()).not.toContain("on this device");
+    expect(local.toLowerCase()).toContain("on this device");
+    expect(local.toLowerCase()).not.toContain("cloud");
+  });
+});

--- a/packages/ui/src/ambient/ambient-consent.ts
+++ b/packages/ui/src/ambient/ambient-consent.ts
@@ -1,0 +1,62 @@
+/**
+ * Per-session ambient consent gate.
+ *
+ * AMBIENT-MODE-DESIGN §8.1: "Ambient capture requires an explicit per-session
+ * consent action before the first uplink frame. No ambient session mints
+ * without it." Consent is PER SESSION — it is not persisted across sessions and
+ * is cleared whenever capture stops. Starting a new ambient session always
+ * re-prompts. This module owns only that in-memory gate; it deliberately does
+ * NOT write consent to storage (a "remembered consent" would defeat the
+ * per-session requirement) and it NEVER records bystander consent (§8.3 — the
+ * software cannot obtain it and must not claim to).
+ */
+
+/** Consent lifecycle for a single ambient session attempt. */
+export type AmbientConsentState =
+  | "ungranted" // no consent yet this session — capture is blocked
+  | "granted"; // user explicitly consented for this session
+
+/**
+ * Jurisdiction-neutral two-party reminder shown at session start
+ * (AMBIENT-MODE-DESIGN §8.3). Guidance, never a legal shield — it does not
+ * geolocate or assert a specific law.
+ */
+export const AMBIENT_TWO_PARTY_REMINDER =
+  "Recording laws vary by place. Some require everyone in the conversation to consent before you record. You are responsible for the people around you.";
+
+/**
+ * The consent copy the user affirms. Kept explicit so the gate cannot be
+ * satisfied by an incidental click — the label states what starting does. The
+ * processing-location clause is honest per path: the cloud/WS path streams
+ * audio to a provider; the on-device batch path transcribes locally. Never
+ * claim cloud for an on-device path or vice versa (AMBIENT-MODE-DESIGN §8.1).
+ */
+export function ambientConsentAffirmation(
+  processingLocation: "on-device" | "cloud",
+): string {
+  const clause =
+    processingLocation === "cloud"
+      ? "and audio is streamed to the cloud for transcription"
+      : "and audio is transcribed on this device";
+  return `I understand this will continuously listen and transcribe until I pause or stop it, ${clause}.`;
+}
+
+/**
+ * Backwards-compatible default affirmation string (cloud-worded). Prefer
+ * {@link ambientConsentAffirmation} so the copy matches the actual path.
+ */
+export const AMBIENT_CONSENT_AFFIRMATION =
+  ambientConsentAffirmation("cloud");
+
+/** Reduce a consent action against the current consent state. */
+export function ambientConsentReducer(
+  state: AmbientConsentState,
+  action: "grant" | "revoke",
+): AmbientConsentState {
+  return action === "grant" ? "granted" : "ungranted";
+}
+
+/** True when capture is permitted to begin. */
+export function ambientCaptureAllowed(state: AmbientConsentState): boolean {
+  return state === "granted";
+}

--- a/packages/ui/src/ambient/ambient-flag.test.ts
+++ b/packages/ui/src/ambient/ambient-flag.test.ts
@@ -1,0 +1,21 @@
+/**
+ * Unit tests for the ambient build-flag reader.
+ */
+
+import { describe, expect, it } from "vitest";
+import { readAmbientFlag } from "./ambient-flag";
+
+describe("readAmbientFlag", () => {
+  it("returns the default when unset", () => {
+    expect(readAmbientFlag("X", false, {})).toBe(false);
+    expect(readAmbientFlag("X", true, {})).toBe(true);
+    expect(readAmbientFlag("X", false, undefined)).toBe(false);
+  });
+
+  it("treats anything but the literal 'false' as enabled", () => {
+    expect(readAmbientFlag("X", false, { X: "true" })).toBe(true);
+    expect(readAmbientFlag("X", false, { X: "1" })).toBe(true);
+    expect(readAmbientFlag("X", true, { X: "false" })).toBe(false);
+    expect(readAmbientFlag("X", true, { X: "FALSE" })).toBe(false);
+  });
+});

--- a/packages/ui/src/ambient/ambient-flag.ts
+++ b/packages/ui/src/ambient/ambient-flag.ts
@@ -1,0 +1,40 @@
+/**
+ * Ambient-mode build flag.
+ *
+ * Ambient (always-listening) capture is a distinct, privacy-loaded surface from
+ * the pendant transcript view. It ships OFF by default and is only reachable
+ * when the operator opts in via `VITE_ENABLE_AMBIENT`. The flag mirrors the
+ * `VOICE_AMBIENT_ENABLED` server gate from AMBIENT-MODE-DESIGN section 9: when
+ * off, none of the ambient nav/route/settings surfaces mount, so ambient adds
+ * zero behavior to the existing app.
+ *
+ * This is intentionally the same string-compare shape the navigation module
+ * uses for its own vite flags so the semantics ("anything but the literal
+ * string false is on") stay identical across the codebase.
+ */
+
+type RuntimeImportMeta = ImportMeta & {
+  env?: Record<string, unknown>;
+};
+
+const ambientViteEnv = (import.meta as RuntimeImportMeta).env;
+
+/**
+ * Read a vite env flag with an explicit default. `null`/`undefined` returns the
+ * default; any value other than the literal string "false" (case-insensitive)
+ * is treated as enabled.
+ */
+export function readAmbientFlag(
+  name: string,
+  defaultValue: boolean,
+  env: Record<string, unknown> | undefined = ambientViteEnv,
+): boolean {
+  const value = env?.[name];
+  if (value == null) return defaultValue;
+  return String(value).toLowerCase() !== "false";
+}
+
+/**
+ * Master ambient-mode toggle. Default OFF — ambient must be explicitly enabled.
+ */
+export const AMBIENT_ENABLED = readAmbientFlag("VITE_ENABLE_AMBIENT", false);

--- a/packages/ui/src/ambient/ambient-session-adapter.test.ts
+++ b/packages/ui/src/ambient/ambient-session-adapter.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Unit tests for the ambient transport adapter helpers: status mapping,
+ * transport selection (batch until the WS seam lands), and the WS TODO seam.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  ambientStatusFromPendant,
+  createAmbientWebSocketAdapter,
+  selectAmbientTransport,
+} from "./ambient-session-adapter";
+
+describe("ambientStatusFromPendant", () => {
+  it("maps unsupported and error verbatim", () => {
+    expect(ambientStatusFromPendant("unsupported", false)).toBe("unsupported");
+    expect(ambientStatusFromPendant("error", false)).toBe("error");
+  });
+
+  it("maps idle to idle", () => {
+    expect(ambientStatusFromPendant("idle", false)).toBe("idle");
+  });
+
+  it("collapses connect steps into starting", () => {
+    for (const s of ["requesting", "connecting", "reconnecting"] as const) {
+      expect(ambientStatusFromPendant(s, false)).toBe("starting");
+    }
+  });
+
+  it("treats live audio states as capturing", () => {
+    for (const s of [
+      "connected",
+      "listening",
+      "hearing",
+      "transcribing",
+    ] as const) {
+      expect(ambientStatusFromPendant(s, false)).toBe("capturing");
+    }
+  });
+
+  it("reports paused when the paused flag is set, regardless of live state", () => {
+    expect(ambientStatusFromPendant("hearing", true)).toBe("paused");
+    expect(ambientStatusFromPendant("paused", false)).toBe("paused");
+  });
+});
+
+describe("ambient transport selection", () => {
+  it("the WS adapter is an unimplemented seam today", () => {
+    expect(createAmbientWebSocketAdapter()).toBeNull();
+  });
+
+  it("selects batch while the WS adapter is a null seam", () => {
+    expect(selectAmbientTransport(true)).toBe("batch");
+    expect(selectAmbientTransport(false)).toBe("batch");
+  });
+});

--- a/packages/ui/src/ambient/ambient-session-adapter.ts
+++ b/packages/ui/src/ambient/ambient-session-adapter.ts
@@ -1,0 +1,154 @@
+/**
+ * Ambient capture data-layer adapter.
+ *
+ * AMBIENT-MODE-DESIGN says ambient is "a second mode on the existing
+ * voice-session WebSocket" whose finals commit to the canonical
+ * `pendant_sessions_v1` store. That WS mode is NOT merged yet (design section 9,
+ * Phase 1a rides an in-flight server lane). So the ambient UI talks to the data
+ * layer through THIS small adapter interface, with two implementations:
+ *
+ *   - `batch` — the working impl. It drives the pendant capture stack that
+ *     exists on develop today: {@link usePendant} (BLE mic → local VAD → local
+ *     ASR) surfacing `PendantTranscriptSegmentDetail`s, folded into the existing
+ *     view-owned transcript store (`pendant-transcript-session`). No new
+ *     transcript store, no new session store — the adapter is a thin control
+ *     surface over the surfaces already in packages/ui/src/pendant.
+ *
+ *   - `ws` — a TODO seam only. When the ambient WebSocket mode
+ *     (`mode:"ambient"` mint + `stt_final`/`segment_committed` events) lands, a
+ *     second implementation binds here and the UI is unchanged. Until then it
+ *     is `null` and the UI selects `batch`.
+ *
+ * The adapter is deliberately transport-agnostic: it exposes lifecycle
+ * (start/pause/resume/stop), a live status snapshot, and a segment subscription,
+ * so the ambient control + feed components never learn whether the segments
+ * arrived over BLE-local-ASR (today) or over the ambient WS (later).
+ *
+ * FORBIDDEN (per design section 11): this adapter never creates a second
+ * transcript store, a second session store, a second STT client, or a second
+ * VAD. It reuses the pendant surfaces.
+ */
+
+import type { PendantStatus } from "../pendant/pendant-status";
+import type { PendantTranscriptSegmentDetail } from "../pendant/transcript-segment-event";
+
+/**
+ * Which transport backs the ambient data layer. `batch` is the develop-today
+ * BLE + local-ASR path; `websocket` is the not-yet-merged ambient WS mode.
+ */
+export type AmbientTransportKind = "batch" | "websocket";
+
+/** High-level ambient capture lifecycle, independent of transport internals. */
+export type AmbientCaptureStatus =
+  | "unsupported"
+  | "idle"
+  | "starting"
+  | "capturing"
+  | "paused"
+  | "stopping"
+  | "error";
+
+/**
+ * Where audio is processed. Ambient over the WS is unambiguously "cloud"
+ * (streams to Deepgram); the batch/local-ASR path today is "on-device". The UI
+ * surfaces this honestly and never claims on-device for a cloud path
+ * (design section 8.1).
+ */
+export type AmbientProcessingLocation = "on-device" | "cloud";
+
+/** Immutable snapshot of ambient capture state for rendering. */
+export interface AmbientSessionSnapshot {
+  status: AmbientCaptureStatus;
+  transport: AmbientTransportKind;
+  /** Where the audio is processed, surfaced verbatim to the user. */
+  processingLocation: AmbientProcessingLocation;
+  /** Human-facing device / source name, when known. */
+  deviceName: string | null;
+  /** True while audio is actively being captured (not paused, not idle). */
+  capturing: boolean;
+  /** True when the transport cannot run in this environment. */
+  supported: boolean;
+  /** Last error message, if the session is in an error state. */
+  error: string | null;
+}
+
+/** A segment lifecycle update from the ambient data layer. */
+export type AmbientSegmentListener = (
+  detail: PendantTranscriptSegmentDetail,
+) => void;
+
+/** A snapshot-change listener (status/device/error transitions). */
+export type AmbientSnapshotListener = (
+  snapshot: AmbientSessionSnapshot,
+) => void;
+
+/**
+ * The transport-agnostic ambient data adapter the UI drives. Implementations
+ * bridge to a concrete capture stack (BLE-local today, WS later).
+ */
+export interface AmbientSessionAdapter {
+  readonly transport: AmbientTransportKind;
+  /** Current state snapshot. */
+  snapshot(): AmbientSessionSnapshot;
+  /** Begin capture. No-op / idempotent if already capturing. */
+  start(): void;
+  /** Sever the capture stream (real pause, not "stop rendering"). */
+  pause(): void;
+  /** Resume a paused capture stream. */
+  resume(): void;
+  /** End the session and release the capture source. */
+  stop(): void;
+  /** Subscribe to segment lifecycle updates. Returns an unsubscribe fn. */
+  onSegment(listener: AmbientSegmentListener): () => void;
+  /** Subscribe to snapshot changes. Returns an unsubscribe fn. */
+  onSnapshot(listener: AmbientSnapshotListener): () => void;
+}
+
+/**
+ * Map a raw pendant status into the coarser ambient capture status. Ambient
+ * does not surface the fine-grained BLE connect steps; it collapses them into
+ * `starting`, and treats any "live" audio state as `capturing`.
+ */
+export function ambientStatusFromPendant(
+  status: PendantStatus,
+  paused: boolean,
+): AmbientCaptureStatus {
+  if (status === "unsupported") return "unsupported";
+  if (status === "error") return "error";
+  if (status === "idle") return "idle";
+  if (
+    status === "requesting" ||
+    status === "connecting" ||
+    status === "reconnecting"
+  ) {
+    return "starting";
+  }
+  // connected / listening / hearing / transcribing / paused → capturing/paused
+  if (paused || status === "paused") return "paused";
+  return "capturing";
+}
+
+/**
+ * TODO(ambient-ws): return the ambient WebSocket adapter once `mode:"ambient"`
+ * mint + `stt_final`/`segment_committed` land (AMBIENT-MODE-DESIGN §1, §9
+ * Phase 1a). It will bind to a stable `pendantSessionId`, renew the capture
+ * lease over the socket, and surface `processingLocation: "cloud"`. Until then
+ * this is `null` and {@link selectAmbientTransport} falls back to `batch`.
+ */
+export function createAmbientWebSocketAdapter(): AmbientSessionAdapter | null {
+  return null;
+}
+
+/**
+ * Pick the ambient transport. Prefers the WS adapter when available; otherwise
+ * uses `batch` (the develop-today path). The `preferWebSocket` arg exists so a
+ * future flag can force the WS path for testing without changing call sites.
+ */
+export function selectAmbientTransport(
+  preferWebSocket = true,
+): AmbientTransportKind {
+  if (preferWebSocket && createAmbientWebSocketAdapter() !== null) {
+    return "websocket";
+  }
+  return "batch";
+}

--- a/packages/ui/src/ambient/index.ts
+++ b/packages/ui/src/ambient/index.ts
@@ -1,0 +1,52 @@
+/**
+ * Ambient mode public surface.
+ *
+ * The LP3-first always-listening capture UI, backed by the pendant session
+ * stack behind a transport adapter (batch today, WebSocket TODO seam). See
+ * AMBIENT-MODE-DESIGN-2026-07-10.md. Everything here is flag-gated
+ * ({@link AMBIENT_ENABLED}); nothing mounts unless ambient is enabled.
+ */
+
+export { AMBIENT_ENABLED, readAmbientFlag } from "./ambient-flag";
+export {
+  AMBIENT_CONSENT_AFFIRMATION,
+  AMBIENT_TWO_PARTY_REMINDER,
+  type AmbientConsentState,
+  ambientCaptureAllowed,
+  ambientConsentAffirmation,
+  ambientConsentReducer,
+} from "./ambient-consent";
+export {
+  type AmbientCaptureStatus,
+  type AmbientProcessingLocation,
+  type AmbientSegmentListener,
+  type AmbientSessionAdapter,
+  type AmbientSessionSnapshot,
+  type AmbientSnapshotListener,
+  type AmbientTransportKind,
+  ambientStatusFromPendant,
+  createAmbientWebSocketAdapter,
+  selectAmbientTransport,
+} from "./ambient-session-adapter";
+export {
+  type UseAmbientSessionOptions,
+  type UseAmbientSessionResult,
+  useAmbientSession,
+} from "./useAmbientSession";
+export {
+  AmbientCaptureControl,
+  type AmbientCaptureControlProps,
+  formatAmbientDuration,
+} from "./AmbientCaptureControl";
+export {
+  AmbientConsentGate,
+  type AmbientConsentGateProps,
+} from "./AmbientConsentGate";
+export {
+  AmbientRecordingIndicator,
+  type AmbientRecordingIndicatorProps,
+} from "./AmbientRecordingIndicator";
+export {
+  AmbientTranscriptFeed,
+  type AmbientTranscriptFeedProps,
+} from "./AmbientTranscriptFeed";

--- a/packages/ui/src/ambient/useAmbientSession.test.tsx
+++ b/packages/ui/src/ambient/useAmbientSession.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * Behavior tests for the ambient session controller hook.
+ *
+ * usePendant is mocked so the hook's consent gating, segment folding (into the
+ * reused pendant transcript store), duration bookkeeping, and stop/reset
+ * semantics are exercised deterministically in jsdom.
+ */
+
+// @vitest-environment jsdom
+
+import { act, cleanup, render } from "@testing-library/react";
+import type * as React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  UsePendantOptions,
+  UsePendantResult,
+} from "../pendant/usePendant";
+import { useAmbientSession } from "./useAmbientSession";
+
+const pendantMock = vi.hoisted(() => ({
+  result: undefined as UsePendantResult | undefined,
+  onSegment: undefined as UsePendantOptions["onSegment"] | undefined,
+}));
+
+vi.mock("../pendant/usePendant", () => ({
+  usePendant: (options?: UsePendantOptions) => {
+    pendantMock.onSegment = options?.onSegment;
+    if (!pendantMock.result) {
+      throw new Error("usePendant mock result was not configured");
+    }
+    return pendantMock.result;
+  },
+}));
+
+const connect = vi.fn();
+const disconnect = vi.fn();
+const pause = vi.fn();
+const resume = vi.fn();
+
+function setPendant(
+  overrides: Partial<UsePendantResult["state"]> = {},
+  supported = true,
+): void {
+  pendantMock.result = {
+    state: {
+      status: supported ? "idle" : "unsupported",
+      connectStep: "idle",
+      deviceName: null,
+      batteryPercent: null,
+      codecId: null,
+      lastTranscript: null,
+      droppedPackets: 0,
+      error: null,
+      typedError: null,
+      paused: false,
+      ...overrides,
+    },
+    supported,
+    connect,
+    disconnect,
+    pause,
+    resume,
+  };
+}
+
+let captured: ReturnType<typeof useAmbientSession> | undefined;
+let clock = 0;
+
+function Harness(): React.ReactElement {
+  captured = useAmbientSession({ now: () => clock });
+  return <div data-testid="harness" />;
+}
+
+describe("useAmbientSession", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+    clock = 1_000;
+    captured = undefined;
+    setPendant();
+  });
+
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  it("blocks start until consent is granted", () => {
+    render(<Harness />);
+    expect(captured?.consent).toBe("ungranted");
+
+    act(() => captured?.start());
+    expect(connect).not.toHaveBeenCalled();
+
+    act(() => captured?.grantConsent());
+    expect(captured?.consent).toBe("granted");
+
+    act(() => captured?.start());
+    expect(connect).toHaveBeenCalledTimes(1);
+  });
+
+  it("folds pendant segments into the reused transcript store", () => {
+    render(<Harness />);
+    act(() => {
+      pendantMock.onSegment?.({
+        id: "seg-1",
+        status: "resolved",
+        text: "hello world",
+        startedAt: 1_000,
+        endedAt: 2_000,
+        durationMs: 1_000,
+        words: [],
+      });
+    });
+    expect(captured?.segments).toHaveLength(1);
+    expect(captured?.segments[0]?.text).toBe("hello world");
+    expect(captured?.resolvedCount).toBe(1);
+  });
+
+  it("reports capturing status and processing location for the batch path", () => {
+    setPendant({ status: "hearing", deviceName: "omi pendant" });
+    render(<Harness />);
+    expect(captured?.snapshot.status).toBe("capturing");
+    expect(captured?.snapshot.capturing).toBe(true);
+    // Batch/local-ASR path is on-device today; the WS path (cloud) is a seam.
+    expect(captured?.snapshot.processingLocation).toBe("on-device");
+    expect(captured?.snapshot.transport).toBe("batch");
+  });
+
+  it("reports paused status without claiming capture", () => {
+    setPendant({ status: "paused", paused: true });
+    render(<Harness />);
+    expect(captured?.snapshot.status).toBe("paused");
+    expect(captured?.snapshot.capturing).toBe(false);
+  });
+
+  it("stop revokes consent so the next start re-prompts", () => {
+    render(<Harness />);
+    act(() => captured?.grantConsent());
+    expect(captured?.consent).toBe("granted");
+
+    act(() => captured?.stop());
+    expect(disconnect).toHaveBeenCalledTimes(1);
+    expect(captured?.consent).toBe("ungranted");
+
+    act(() => captured?.start());
+    expect(connect).not.toHaveBeenCalled();
+  });
+
+  it("stop resets the session duration to zero (no carry-over)", () => {
+    // Capture for 5s, stop, and confirm elapsed resets so the next session
+    // does not inherit the prior duration.
+    setPendant({ status: "hearing" });
+    const { rerender } = render(<Harness />);
+    clock = 6_000; // 5s after the initial clock of 1_000
+    // Flip out of capturing to flush the active span into the accumulator.
+    setPendant({ status: "idle" });
+    rerender(<Harness />);
+    expect(captured?.elapsedMs).toBeGreaterThanOrEqual(5_000);
+
+    act(() => captured?.stop());
+    expect(captured?.elapsedMs).toBe(0);
+  });
+
+  it("surfaces an error snapshot from the pendant error state", () => {
+    setPendant({
+      status: "error",
+      error: "raw denied",
+      typedError: {
+        code: "permission-denied",
+        category: "permission",
+        message: "Mic permission is off.",
+        recoverable: true,
+      },
+    });
+    render(<Harness />);
+    expect(captured?.snapshot.status).toBe("error");
+    expect(captured?.snapshot.error).toBe("Mic permission is off.");
+  });
+
+  it("clear empties the transcript store", () => {
+    render(<Harness />);
+    act(() => {
+      pendantMock.onSegment?.({
+        id: "seg-1",
+        status: "resolved",
+        text: "hi",
+        startedAt: 1_000,
+        endedAt: 2_000,
+        durationMs: 1_000,
+        words: [],
+      });
+    });
+    expect(captured?.segments).toHaveLength(1);
+    act(() => captured?.clear());
+    expect(captured?.segments).toHaveLength(0);
+  });
+});

--- a/packages/ui/src/ambient/useAmbientSession.ts
+++ b/packages/ui/src/ambient/useAmbientSession.ts
@@ -1,0 +1,275 @@
+/**
+ * Ambient capture controller hook.
+ *
+ * Ties the pendant capture stack (batch transport — {@link usePendant}), the
+ * view-owned transcript store (`pendant-transcript-session`, REUSED — no new
+ * transcript store), the per-session consent gate, and session bookkeeping
+ * (duration, segment count) into one surface the ambient components render.
+ *
+ * The hook is transport-agnostic at its edges: it reports an
+ * {@link AmbientSessionSnapshot} and a segment list, never leaking whether the
+ * data arrived over BLE-local-ASR (today) or the ambient WebSocket (later —
+ * TODO seam in ambient-session-adapter). Today it selects the `batch`
+ * transport; when the WS adapter lands, only the internals change.
+ *
+ * Consent is enforced here: `start()` refuses unless consent is granted for
+ * the current session, and stopping revokes consent so the next session
+ * re-prompts (AMBIENT-MODE-DESIGN §8.1).
+ */
+
+import * as React from "react";
+import {
+  createLocalOptimisticPendantTranscriptSessionAdapter,
+  EMPTY_PENDANT_TRANSCRIPT_SESSION,
+  type PendantTranscriptSegment,
+  type PendantTranscriptSessionState,
+  pendantTranscriptSessionReducer,
+} from "../pendant/pendant-transcript-session";
+import { usePendant } from "../pendant/usePendant";
+import {
+  type AmbientProcessingLocation,
+  type AmbientSessionSnapshot,
+  type AmbientTransportKind,
+  ambientStatusFromPendant,
+  selectAmbientTransport,
+} from "./ambient-session-adapter";
+import {
+  type AmbientConsentState,
+  ambientCaptureAllowed,
+  ambientConsentReducer,
+} from "./ambient-consent";
+
+export interface UseAmbientSessionResult {
+  /** Coarse transport-agnostic capture state for rendering. */
+  snapshot: AmbientSessionSnapshot;
+  /** Consent state for the current session attempt. */
+  consent: AmbientConsentState;
+  /** The live transcript segments (reused pendant transcript store). */
+  segments: PendantTranscriptSegment[];
+  /** Elapsed capture time in ms (excludes paused spans). */
+  elapsedMs: number;
+  /** Count of committed (resolved) segments this session. */
+  resolvedCount: number;
+  /** Count of in-flight (pending) segments. */
+  pendingCount: number;
+  /** True when a persistent cache read/write failed. */
+  cacheError: string | null;
+  /** Grant per-session consent (does not start capture). */
+  grantConsent: () => void;
+  /** Start capture. No-op unless consent is granted. */
+  start: () => void;
+  /** Sever capture (real pause). */
+  pause: () => void;
+  /** Resume paused capture. */
+  resume: () => void;
+  /** Stop capture, end the session, and revoke consent. */
+  stop: () => void;
+  /** Clear the local transcript view/cache. */
+  clear: () => void;
+}
+
+/** Monotonic-ish clock; injectable for tests. */
+type NowFn = () => number;
+
+export interface UseAmbientSessionOptions {
+  /** Override the clock (tests). Defaults to Date.now. */
+  now?: NowFn;
+  /**
+   * Force a transport for testing. Defaults to {@link selectAmbientTransport}
+   * (which picks `batch` until the ambient WS adapter is merged).
+   */
+  transport?: AmbientTransportKind;
+}
+
+function processingLocationFor(
+  transport: AmbientTransportKind,
+): AmbientProcessingLocation {
+  // The ambient WS path streams to Deepgram → cloud. The batch/local-ASR path
+  // on develop today transcribes on-device. Surface this honestly (§8.1).
+  return transport === "websocket" ? "cloud" : "on-device";
+}
+
+export function useAmbientSession(
+  options: UseAmbientSessionOptions = {},
+): UseAmbientSessionResult {
+  const now = options.now ?? Date.now;
+  const transport = options.transport ?? selectAmbientTransport();
+
+  // Reused transcript store — the same view-owned optimistic cache the pendant
+  // transcript view uses. No second transcript store is created.
+  const sessionAdapter = React.useMemo(
+    () => createLocalOptimisticPendantTranscriptSessionAdapter(),
+    [],
+  );
+  const initial = React.useMemo<{
+    session: PendantTranscriptSessionState;
+    error: string | null;
+  }>(() => {
+    try {
+      return { session: sessionAdapter.load(), error: null };
+    } catch (error) {
+      return {
+        session: EMPTY_PENDANT_TRANSCRIPT_SESSION,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Ambient transcript cache is unavailable.",
+      };
+    }
+  }, [sessionAdapter]);
+
+  const [session, dispatchSession] = React.useReducer(
+    pendantTranscriptSessionReducer,
+    initial.session,
+  );
+  const [cacheError, setCacheError] = React.useState(initial.error);
+  const [consent, dispatchConsent] = React.useReducer(
+    ambientConsentReducer,
+    "ungranted" as AmbientConsentState,
+  );
+
+  // Duration bookkeeping — accumulate active spans so paused time is excluded.
+  const [elapsedMs, setElapsedMs] = React.useState(0);
+  const accumulatedRef = React.useRef(0);
+  const activeSinceRef = React.useRef<number | null>(null);
+
+  const {
+    state: pendantState,
+    supported,
+    connect,
+    disconnect,
+    pause: pendantPause,
+    resume: pendantResume,
+  } = usePendant({
+    onSegment: React.useCallback((detail) => {
+      dispatchSession({ type: "segment", detail });
+    }, []),
+  });
+
+  // Persist the reused store whenever it changes, surfacing write failures.
+  React.useEffect(() => {
+    if (cacheError) return;
+    try {
+      sessionAdapter.save(session);
+    } catch (error) {
+      setCacheError(
+        error instanceof Error
+          ? error.message
+          : "Ambient transcript cache could not be saved.",
+      );
+    }
+  }, [cacheError, session, sessionAdapter]);
+
+  const status = ambientStatusFromPendant(
+    pendantState.status,
+    pendantState.paused,
+  );
+  const capturing = status === "capturing";
+
+  // Track active-span start/stop transitions for the duration counter.
+  React.useEffect(() => {
+    if (capturing) {
+      if (activeSinceRef.current === null) {
+        activeSinceRef.current = now();
+      }
+    } else if (activeSinceRef.current !== null) {
+      accumulatedRef.current += now() - activeSinceRef.current;
+      activeSinceRef.current = null;
+      setElapsedMs(accumulatedRef.current);
+    }
+  }, [capturing, now]);
+
+  // Tick the elapsed clock while actively capturing (1s cadence; the LP3 screen
+  // is small + grayscale-ish, a coarse mm:ss counter is plenty).
+  React.useEffect(() => {
+    if (!capturing) return;
+    const id = window.setInterval(() => {
+      const base = accumulatedRef.current;
+      const since = activeSinceRef.current;
+      setElapsedMs(since === null ? base : base + (now() - since));
+    }, 1_000);
+    return () => window.clearInterval(id);
+  }, [capturing, now]);
+
+  const snapshot: AmbientSessionSnapshot = {
+    status,
+    transport,
+    processingLocation: processingLocationFor(transport),
+    deviceName: pendantState.deviceName,
+    capturing,
+    supported,
+    error:
+      status === "error"
+        ? (pendantState.typedError?.message ??
+          pendantState.error ??
+          "Ambient capture failed.")
+        : null,
+  };
+
+  const grantConsent = React.useCallback(() => {
+    dispatchConsent("grant");
+  }, []);
+
+  const start = React.useCallback(() => {
+    if (!ambientCaptureAllowed(consent)) return;
+    connect();
+  }, [connect, consent]);
+
+  const pause = React.useCallback(() => {
+    pendantPause();
+  }, [pendantPause]);
+
+  const resume = React.useCallback(() => {
+    pendantResume();
+  }, [pendantResume]);
+
+  const stop = React.useCallback(() => {
+    disconnect();
+    // Ending the session resets ALL per-session bookkeeping to zero: the next
+    // consent+start is a brand-new session, so it must not inherit this
+    // session's elapsed time. Consent is revoked so the next start re-prompts
+    // (§8.1).
+    activeSinceRef.current = null;
+    accumulatedRef.current = 0;
+    setElapsedMs(0);
+    dispatchConsent("revoke");
+  }, [disconnect]);
+
+  const clear = React.useCallback(() => {
+    const at = now();
+    try {
+      sessionAdapter.clear(at);
+      dispatchSession({ type: "clear", at });
+      setCacheError(null);
+    } catch (error) {
+      setCacheError(
+        error instanceof Error
+          ? error.message
+          : "Ambient transcript cache could not be cleared.",
+      );
+    }
+  }, [now, sessionAdapter]);
+
+  const resolvedCount = session.segments.filter(
+    (segment) => segment.status === "resolved",
+  ).length;
+  const pendingCount = session.segments.filter(
+    (segment) => segment.status === "pending",
+  ).length;
+
+  return {
+    snapshot,
+    consent,
+    segments: session.segments,
+    elapsedMs,
+    resolvedCount,
+    pendingCount,
+    cacheError,
+    grantConsent,
+    start,
+    pause,
+    resume,
+    stop,
+    clear,
+  };
+}

--- a/packages/ui/src/components/pages/AmbientView.tsx
+++ b/packages/ui/src/components/pages/AmbientView.tsx
@@ -1,0 +1,80 @@
+/**
+ * Ambient mode page — the always-listening capture surface.
+ *
+ * Composes the capture control (consent → start/pause/stop, indicator, session
+ * stats) above the live transcript feed. Backed by {@link useAmbientSession},
+ * which drives the pendant capture stack behind the transport adapter (batch
+ * today, WS TODO seam) and reuses the pendant transcript store. Flag-gated at
+ * the route level — this component only mounts when ambient is enabled.
+ *
+ * LP3-first: single column, big tap targets, monochrome-safe indicator, no
+ * bleeding-edge CSS. Black/white/orange tokens + lucide icons only.
+ */
+
+import { Trash2 } from "lucide-react";
+import type * as React from "react";
+import { Button } from "../ui/button";
+import { AmbientCaptureControl } from "../../ambient/AmbientCaptureControl";
+import { AmbientTranscriptFeed } from "../../ambient/AmbientTranscriptFeed";
+import { useAmbientSession } from "../../ambient/useAmbientSession";
+import { ShellViewAgentSurface } from "../views/ShellViewAgentSurface";
+
+export function AmbientView(): React.ReactElement {
+  const ambient = useAmbientSession();
+  const { snapshot } = ambient;
+
+  return (
+    <ShellViewAgentSurface viewId="ambient">
+      <div className="flex h-full min-h-0 w-full flex-col bg-bg text-txt">
+        <header className="border-b border-border px-4 py-4">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <h1 className="text-lg font-semibold text-txt-strong">
+                Ambient
+              </h1>
+              <p className="mt-1 text-sm text-muted">
+                {snapshot.deviceName ?? "Always-listening capture"}
+              </p>
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={ambient.clear}
+              disabled={ambient.segments.length === 0 && !ambient.cacheError}
+              data-testid="ambient-clear"
+            >
+              <Trash2 className="size-4" aria-hidden />
+              Clear local view
+            </Button>
+          </div>
+          <div className="mt-4">
+            <AmbientCaptureControl
+              snapshot={snapshot}
+              consent={ambient.consent}
+              elapsedMs={ambient.elapsedMs}
+              resolvedCount={ambient.resolvedCount}
+              pendingCount={ambient.pendingCount}
+              onGrantConsent={ambient.grantConsent}
+              onStart={ambient.start}
+              onPause={ambient.pause}
+              onResume={ambient.resume}
+              onStop={ambient.stop}
+            />
+          </div>
+          <p className="mt-3 text-xs text-muted">
+            Local offline view · this device only. Deleting here clears the local
+            cache, not server history.
+          </p>
+        </header>
+
+        <AmbientTranscriptFeed
+          segments={ambient.segments}
+          capturing={snapshot.capturing}
+          cacheError={ambient.cacheError}
+        />
+      </div>
+    </ShellViewAgentSurface>
+  );
+}
+
+export default AmbientView;

--- a/packages/ui/src/components/settings/AmbientSettingsCard.tsx
+++ b/packages/ui/src/components/settings/AmbientSettingsCard.tsx
@@ -1,0 +1,45 @@
+/**
+ * AmbientSettingsCard — Settings → Voice entry point for ambient listening.
+ *
+ * A thin settings surface: it explains the always-listening capture mode, its
+ * honest limits (foreground-only on iOS PWA), and routes to the full Ambient
+ * view where consent + capture live. It never starts capture itself — the
+ * consent gate is on the Ambient surface, not buried in Settings.
+ *
+ * Flag-gated: the caller (VoiceSection) only mounts this when ambient is
+ * enabled, so the card adds nothing to the default Settings tree.
+ *
+ * Black/white/orange tokens + lucide icons only; no gradients, no emoji.
+ */
+
+import { Ear } from "lucide-react";
+import type * as React from "react";
+import { AMBIENT_TWO_PARTY_REMINDER } from "../../ambient/ambient-consent";
+import { SettingsGroup, SettingsRow } from "./settings-layout";
+
+export interface AmbientSettingsCardProps {
+  /** Navigate to the Ambient view (`/ambient`). */
+  onOpen?: () => void;
+}
+
+export function AmbientSettingsCard({
+  onOpen,
+}: AmbientSettingsCardProps): React.ReactElement {
+  return (
+    <SettingsGroup
+      title="Ambient listening"
+      description="Continuous, always-on capture that transcribes what it hears until you pause or stop it."
+      footer={AMBIENT_TWO_PARTY_REMINDER}
+      data-testid="ambient-settings"
+    >
+      <SettingsRow
+        icon={Ear}
+        label="Ambient session"
+        description="Opens the always-listening surface. You confirm consent there before capture starts. On iPhone, ambient runs only while the app is open and in the foreground."
+        onClick={onOpen}
+        chevron
+        data-testid="ambient-settings-open"
+      />
+    </SettingsGroup>
+  );
+}

--- a/packages/ui/src/components/settings/VoiceSection.tsx
+++ b/packages/ui/src/components/settings/VoiceSection.tsx
@@ -18,6 +18,9 @@ import { ContinuousChatToggle } from "../composites/chat/ContinuousChatToggle";
 import { Input } from "../ui/input";
 import { AdvancedToggle } from "./AdvancedToggle";
 import { useAdvancedSettingsEnabled } from "./AdvancedToggle.hooks";
+import { AMBIENT_ENABLED } from "../../ambient/ambient-flag";
+import { navigateBrowserPath } from "../../app-navigate-view";
+import { AmbientSettingsCard } from "./AmbientSettingsCard";
 import { PendantSettingsCard } from "./PendantSettingsCard";
 import { SettingsGroup, SettingsRow, SettingsStack } from "./settings-layout";
 import { VoiceProfileSection } from "./VoiceProfileSection";
@@ -200,6 +203,12 @@ export function VoiceSection({
         </SettingsGroup>
 
         <PendantSettingsCard />
+
+        {AMBIENT_ENABLED ? (
+          <AmbientSettingsCard
+            onOpen={() => navigateBrowserPath("/ambient")}
+          />
+        ) : null}
 
         <SettingsGroup
           title={t("voicesection.chatGroupTitle", {

--- a/packages/ui/src/navigation/index.test.ts
+++ b/packages/ui/src/navigation/index.test.ts
@@ -90,6 +90,22 @@ describe("navigation tabFromPath", () => {
   });
 });
 
+describe("ambient tab is routable but flag-gated in the nav tiles", () => {
+  it("keeps /ambient routable via TAB_PATHS so deep links + parity guards resolve", () => {
+    expect(TAB_PATHS.ambient).toBe("/ambient");
+    expect(tabFromPath("/ambient")).toBe("ambient");
+  });
+
+  it("hides the ambient tile from ALL_TAB_GROUPS while the opt-in flag is off (default)", () => {
+    // VITE_ENABLE_AMBIENT is unset in the test env → default OFF, so the
+    // always-listening tile must not appear in the launcher groups.
+    const ambientGroup = ALL_TAB_GROUPS.find((group) =>
+      group.tabs.includes("ambient"),
+    );
+    expect(ambientGroup).toBeUndefined();
+  });
+});
+
 describe("navigation prefix sub-tab resolution is registry-derived", () => {
   // Built-in `/apps/<sub>` and `/character/<sub>` routes must resolve to the
   // tab declared for that exact path in TAB_PATHS, so the routing table never

--- a/packages/ui/src/navigation/index.ts
+++ b/packages/ui/src/navigation/index.ts
@@ -13,6 +13,7 @@
 import type { LucideIcon } from "lucide-react";
 import {
   Clock3,
+  Ear,
   LayoutGrid,
   Monitor,
   Phone,
@@ -44,6 +45,18 @@ export const APPS_ENABLED = viteEnvFlagEnabled("VITE_ENABLE_APPS", true);
 /** Stream routes stay addressable; the nav hides the tab unless streaming is enabled. */
 export const STREAM_ENABLED = true;
 
+/**
+ * Ambient (always-listening) capture is a privacy-loaded surface that ships OFF
+ * by default; the nav tile only appears when the operator opts in via
+ * `VITE_ENABLE_AMBIENT`. The route stays addressable regardless (it is a real
+ * TAB_PATHS entry) so deep links resolve, but the tile is flag-gated. Mirrors
+ * the `AMBIENT_ENABLED` flag in packages/ui/src/ambient/ambient-flag.ts.
+ */
+export const AMBIENT_NAV_ENABLED = viteEnvFlagEnabled(
+  "VITE_ENABLE_AMBIENT",
+  false,
+);
+
 /** Built-in tab identifiers. */
 export type BuiltinTab =
   | "chat"
@@ -56,6 +69,7 @@ export type BuiltinTab =
   | "browser"
   | "stream"
   | "pendant-transcript"
+  | "ambient"
   | "apps"
   | "views"
   | "character"
@@ -278,7 +292,7 @@ export function getWindowNavigationPath(
     : location.pathname;
 }
 
-export const ALL_TAB_GROUPS: TabGroup[] = [
+const RAW_TAB_GROUPS: TabGroup[] = [
   {
     // AOSP ElizaOS-fork only — the native dialer/SMS/contact tiles are gated to
     // the fork in the launcher (see launcher-curation LAUNCHER_AOSP_ONLY_IDS).
@@ -335,6 +349,15 @@ export const ALL_TAB_GROUPS: TabGroup[] = [
     icon: ScrollText,
     description: "Realtime transcript from the omi pendant",
   },
+  // Ambient tile is flag-gated (default OFF). When disabled it is filtered out
+  // below so the always-listening surface never appears unbidden; the /ambient
+  // route stays addressable via TAB_PATHS for direct navigation + tests.
+  {
+    label: "Ambient",
+    tabs: ["ambient"],
+    icon: Ear,
+    description: "Always-listening capture (opt-in)",
+  },
   {
     // One consolidated surface — workflows, triggers, and scheduled items share
     // the Automations feed. `triggers`/`tasks` stay routable aliases (TAB_PATHS).
@@ -350,6 +373,16 @@ export const ALL_TAB_GROUPS: TabGroup[] = [
     description: "Configuration and preferences",
   },
 ];
+
+/**
+ * Navigation tile groups. The Ambient tile is dropped unless the opt-in flag is
+ * set, so the always-listening surface never appears in the launcher by
+ * default. The /ambient route stays in TAB_PATHS regardless for direct
+ * navigation + the route parity guards.
+ */
+export const ALL_TAB_GROUPS: TabGroup[] = RAW_TAB_GROUPS.filter((group) =>
+  group.tabs.includes("ambient") ? AMBIENT_NAV_ENABLED : true,
+);
 
 // Canonical settings-section metadata (pure data) re-exported here so
 // non-renderer consumers (e.g. app-core's dev-route-catalog parity test) can
@@ -369,6 +402,7 @@ export const TAB_PATHS: Record<BuiltinTab, string> = {
   browser: "/browser",
   stream: "/stream",
   "pendant-transcript": "/pendant/transcript",
+  ambient: "/ambient",
   apps: "/apps",
   views: "/views",
   character: "/character",
@@ -671,6 +705,8 @@ export function titleForTab(tab: Tab): string {
       return "Stream";
     case "pendant-transcript":
       return "Pendant Transcript";
+    case "ambient":
+      return "Ambient";
     default:
       // Dynamic plugin tabs — capitalize the tab ID as a fallback title.
       return tab.charAt(0).toUpperCase() + tab.slice(1).replace(/-/g, " ");


### PR DESCRIPTION
## What

Adds the **LP3-first ambient (always-listening) capture UI** for the Eliza app, built on top of the existing pendant session stack. Implements AMBIENT-MODE-DESIGN-2026-07-10 (consent, indicator, surfaces) + the VOICE-INTEGRATION-DECISION §7 contract.

**Flag-gated (`VITE_ENABLE_AMBIENT`), default OFF, zero behavior change when off.**

Signed: `[sol-cloud]` ambient-UI seat.

## Why

Ambient is "a second mode on the existing voice-session WebSocket" whose finals commit to the canonical `pendant_sessions_v1` store. The WS ambient mode is **not merged yet** (design §9, Phase 1a rides an in-flight server lane), so this lane delivers the user surface now, with the data layer behind a small adapter interface: the **batch path** (BLE mic → local VAD → local ASR → the existing pendant transcript store) is the working impl, and the **WS path is a documented TODO seam**. When the ambient WS mint + `stt_final`/`segment_committed` events land, only the adapter internals change — the UI is untouched.

## What's in it

**`packages/ui/src/ambient/` (new module)**
- `ambient-session-adapter.ts` — transport-agnostic adapter interface + status mapping + transport selection. `batch` working impl; `createAmbientWebSocketAdapter()` is the null seam for the not-yet-merged WS mode.
- `ambient-consent.ts` — per-session consent gate (not persisted; cleared on stop so each session re-prompts). Consent copy worded per processing path. Two-party bystander reminder (guidance, never a legal shield).
- `useAmbientSession.ts` — controller hook: enforces consent before start, folds pendant segments into the **reused** pendant transcript store, tracks session duration (excluding paused spans) + segment counts, resets bookkeeping + consent on stop.
- Components: **AmbientRecordingIndicator** (persistent, monochrome-safe: shape + motion + word, honest processing-location), **AmbientConsentGate**, **AmbientCaptureControl** (consent → start/pause/resume/stop + stats), **AmbientTranscriptFeed** (streaming pending/final segments, reused store).

**Surfaces**
- `components/pages/AmbientView.tsx` — the `/ambient` page.
- `components/settings/AmbientSettingsCard.tsx` — Settings → Voice entry point, mounted in `VoiceSection` behind the flag.
- Nav/route: `/ambient` registered in `TAB_PATHS`, `dev-route-catalog`, `view-routes`, and the aesthetic-audit parity table. The nav tile is flag-gated out of `ALL_TAB_GROUPS` when off, **and** the route mount is flag-gated in `App.tsx` so direct navigation to `/ambient` cannot open the always-listening surface when disabled.

## Design conformance

- **No new transcript / session / STT store or VAD** — reuses `pendant-transcript-session` + `usePendant` (design §11 forbidden-duplicates).
- **Consent enforced, not promised** (§8.1): no start without an explicit per-session grant.
- **Always-visible recording indicator** (§8.1): persistent bordered pill, communicates state via shape + motion + word (survives grayscale + reduced-motion), states processing-location honestly.
- **LP3 constraints** (§7.1): WebView 113-safe CSS (flex + border tokens, no bleeding-edge features), big tap targets (`size="lg"`, full-width buttons), grayscale-friendly.
- **Collision-free**: touches only new ambient components + settings additions. Did **not** touch `packages/ui/src/voice/*` (pwa-client lane) or `packages/ui/src/pendant/omi-protocol*/pendant-connection*` (pendant-stack lane).

## Codex review (gpt-5.5)

Ran and addressed 3 findings before opening:
1. Consent copy contradicted itself (hardcoded "cloud" while the batch path is on-device) → now worded per processing path via `ambientConsentAffirmation(location)`.
2. `stop()` didn't reset session duration → now resets `elapsedMs`/accumulator to zero so the next session doesn't inherit prior duration.
3. `/ambient` mounted even with the flag off (direct nav bypassed the gate) → route mount now flag-gated in `App.tsx` (renders the unavailable fallback when disabled).

## Evidence

**Tests — 46 green** (real jsdom render/interaction, not mocks-asserting-themselves):

```
 ✓ src/ambient/ambient-flag.test.ts (2)
 ✓ src/ambient/ambient-consent.test.ts (5)
 ✓ src/ambient/ambient-session-adapter.test.ts (7)
 ✓ src/ambient/AmbientRecordingIndicator.test.tsx (3)
 ✓ src/ambient/AmbientCaptureControl.test.tsx (6)
 ✓ src/ambient/AmbientConsentGate.test.tsx (3)
 ✓ src/ambient/useAmbientSession.test.tsx (8)
 ✓ src/navigation/index.test.ts (12)
 Test Files  8 passed (8)
      Tests  46 passed (46)
```

Coverage includes: consent blocks start until granted; stop revokes consent + resets duration; segments fold into the reused store; capturing/paused/error/unsupported states; per-path consent copy has no cloud/on-device contradiction; indicator word + capturing flag + honest location; capture-control lifecycle buttons per state; duration formatting; `/ambient` routable but flag-gated out of the launcher tiles by default.

- **Parity guard green**: `packages/app-core` `dev-route-catalog.test.ts` (9 tests) — the `/ambient` route stays consistent across navigation `TAB_PATHS`, the dev route catalog, and `view-routes`.
- **Typecheck**: `packages/ui` clean for all changed files (only the pre-existing `@elizaos/cloud-routing` build-order errors in `packages/core` remain, untouched by this PR).

## Notes / follow-ups (documented seams, not shortcuts)

- **Ambient WS transport** is a null seam (`createAmbientWebSocketAdapter()` returns null) until the server-side `mode:"ambient"` mint + WS events land (design §9 Phase 1a). The UI already targets it via the adapter interface.
- **iOS PWA foreground-only** and the wearable LED are honest-limit items called out in the design; the UI's `supported`/`processingLocation` reporting is wired to reflect them as the underlying capture stack surfaces them.

## Relates to

- AMBIENT-MODE-DESIGN-2026-07-10 (ambient-design seat)
- VOICE-INTEGRATION-DECISION-2026-07-10 §7 (voice-session contract)

---
`[sol-cloud]` ambient-UI
