### PR TITLE
fix(ci): source-alias @elizaos/cloud-routing in plugin-local-inference vitest config

### DIFF
--- a/plugins/plugin-local-inference/vitest.config.ts
+++ b/plugins/plugin-local-inference/vitest.config.ts
@@ -14,6 +14,14 @@ export default defineConfig({
 			"@elizaos/core": fileURLToPath(
 				new URL("../../packages/core/src/index.node.ts", import.meta.url),
 			),
+			// Core's src re-exports the cloud routing surface from
+			// `@elizaos/cloud-routing`, which ships no dist. With @elizaos/core
+			// pinned to source above, that re-export only resolves when
+			// cloud-routing is source-aliased too — otherwise vite falls through
+			// to its missing `dist/index.js` and fails to resolve the entry.
+			"@elizaos/cloud-routing": fileURLToPath(
+				new URL("../../packages/cloud/routing/src/index.ts", import.meta.url),
+			),
 			"@elizaos/logger": fileURLToPath(
 				new URL("../../packages/logger/src/index.ts", import.meta.url),
 			),

--- a/plugins/plugin-local-inference/vitest.config.ts
+++ b/plugins/plugin-local-inference/vitest.config.ts
@@ -14,11 +14,9 @@ export default defineConfig({
 			"@elizaos/core": fileURLToPath(
 				new URL("../../packages/core/src/index.node.ts", import.meta.url),
 			),
-			// Core's src re-exports the cloud routing surface from
-			// `@elizaos/cloud-routing`, which ships no dist. With @elizaos/core
-			// pinned to source above, that re-export only resolves when
-			// cloud-routing is source-aliased too — otherwise vite falls through
-			// to its missing `dist/index.js` and fails to resolve the entry.
+			// Core's source entry re-exports the cloud-routing package. A clean
+			// workspace has not built that package's dist entry yet, so source-mode
+			// tests must keep this transitive dependency on the source graph too.
 			"@elizaos/cloud-routing": fileURLToPath(
 				new URL("../../packages/cloud/routing/src/index.ts", import.meta.url),
 			),


### PR DESCRIPTION
## Problem

The changed-files coverage lane (`coverage-gate.yml` → `packages/scripts/run-changed-vitest-coverage.mjs`) runs package Vitest suites **before** workspace builds. `plugins/plugin-local-inference/vitest.config.ts` source-aliases `@elizaos/core`, but core's src re-exports `@elizaos/cloud-routing` (`packages/core/src/cloud-routing.ts`), a package that ships no dist on a clean checkout. Changed plugin tests therefore failed before collection:

```
Error: Failed to resolve entry for package "@elizaos/cloud-routing". The package may have incorrect main/module/exports specified in its package.json.
  File: packages/core/src/cloud-routing.ts:19:7
```

Observed in PR #15981: https://github.com/elizaOS/eliza/actions/runs/29076770982

## Fix

Add the `@elizaos/cloud-routing` → `packages/cloud/routing/src/index.ts` source alias to the plugin's vitest config, matching the established pattern (and comment) already used by `plugins/plugin-computeruse/vitest.config.ts` and `plugins/plugin-app-control/vitest.config.ts`. One config file changed, 8 lines added.

Fixes #15985

## Proof (clean checkout, no prebuilt dist)

Fresh worktree from `origin/develop` (`d7acb37ff32`), `ELIZA_SKIP_ARTIFACT_SYNC=1 bun install`, plus `node packages/app-core/scripts/ensure-shared-i18n-data.mjs` (the same step CI's `setup-bun-workspace` action runs). Verified `packages/cloud/routing/dist` did **not** exist for both runs below.

<details>
<summary>Repro BEFORE fix — exact CI invocation fails with the reported error</summary>

```
$ node packages/scripts/run-changed-vitest-coverage.mjs \
    plugins/plugin-local-inference/src/services/downloader.test.ts \
    plugins/plugin-local-inference/src/services/manifest/manifest.test.ts

⎯⎯⎯⎯⎯⎯ Failed Suites 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/services/downloader.test.ts [ src/services/downloader.test.ts ]
Error: Failed to resolve entry for package "@elizaos/cloud-routing". The package may have incorrect main/module/exports specified in its package.json.
  Plugin: vite:import-analysis
  File: /home/shaw/eliza-worktrees/fix-15985/packages/core/src/cloud-routing.ts:19:7
  4  |    resolveCloudRoute,
  5  |    toRuntimeSettings
  6  |  } from "@elizaos/cloud-routing";
     |          ^

 Test Files  1 failed | 1 passed (2)
      Tests  53 passed (53)

Error: Vitest coverage failed for plugins/plugin-local-inference (exit 1)
```

</details>

<details>
<summary>AFTER fix — same invocation passes with coverage; LCOV produced and path-normalized</summary>

```
$ node packages/scripts/run-changed-vitest-coverage.mjs \
    plugins/plugin-local-inference/src/services/downloader.test.ts \
    plugins/plugin-local-inference/src/services/manifest/manifest.test.ts

 RUN  v4.1.5 /home/shaw/eliza-worktrees/fix-15985/plugins/plugin-local-inference
      Coverage enabled with v8

 Test Files  2 passed (2)
      Tests  79 passed (79)
   Duration  14.54s

$ grep "^SF:" coverage/vitest/plugins-plugin-local-inference/lcov.info | grep -E "downloader|manifest"
SF:plugins/plugin-local-inference/src/services/downloader.ts
SF:plugins/plugin-local-inference/src/services/manifest/index.ts
SF:plugins/plugin-local-inference/src/services/manifest/schema.ts
SF:plugins/plugin-local-inference/src/services/manifest/validator.ts
```

</details>

<details>
<summary>Full plugin suite + typecheck + biome remain green</summary>

```
$ cd plugins/plugin-local-inference && bun run test
 Test Files  253 passed (253)
      Tests  2602 passed | 2 skipped (2604)
   Duration  46.60s

$ bun run typecheck   # after building logger/contracts/cloud-routing deps, as core's prebuild does
$ tsgo --noEmit -p tsconfig.json
(exit 0)

$ bunx biome check plugins/plugin-local-inference/vitest.config.ts
Checked 1 file in 17ms. No fixes applied.
```

</details>

## Evidence

| Evidence | Status |
| --- | --- |
| Real-LLM trajectories | N/A - CI test-lane config only; no agent/action/prompt/model behavior change |
| Backend logs | N/A - no server runtime path touched; Vitest transcripts above are the real code path |
| Frontend console/network logs | N/A - no UI change |
| Before/after screenshots (desktop + mobile) | N/A - no rendered surface |
| Video walkthrough | N/A - no user-exercisable flow; before/after terminal transcripts attached above |
| Domain artifacts | LCOV report `coverage/vitest/plugins-plugin-local-inference/lcov.info` produced and hand-inspected (SF paths above) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI config-only change; no rendered UI surface.

<!-- evidence-row:after-screenshots -->
- [x] N/A - CI config-only change; no rendered UI surface.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing interaction flow changed.

<!-- evidence-row:backend-logs -->
- [x] [16015](https://github.com/elizaOS/eliza/pull/16015)

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend/browser path changed.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] [16015](https://github.com/elizaOS/eliza/pull/16015)
