### PR TITLE
fix(cloud): bound merged WAV route memory

### DIFF
--- a/packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts
+++ b/packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts
@@ -20,24 +20,27 @@ const requireAuthOrApiKeyWithOrg = mock(async () => ({
   apiKey: null,
 }));
 const assertSafeForPublicUse = mock(async () => undefined);
+const reconcileReservation = mock(async () => undefined);
 const reserveCredits = mock(async () => ({
-  reconcile: async () => undefined,
+  reconcile: reconcileReservation,
 }));
 const billUsage = mock(async () => ({
   totalCost: 0.001,
   baseTotalCost: 0.001,
   platformMarkup: 0,
 }));
-const elevenLabsTextToSpeech = mock(
-  async () =>
-    new ReadableStream<Uint8Array>({
-      start(controller) {
-        controller.enqueue(new Uint8Array([73, 68, 51]));
-        controller.close();
-      },
-    }),
-);
+let elevenLabsBytes = new Uint8Array([73, 68, 51]);
+const elevenLabsTextToSpeech = mock(async () => {
+  const bytes = elevenLabsBytes;
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+});
 let allowKokoroFetch = false;
+let cacheBypass = true;
 let cachedVoiceResponse: {
   bytes: Uint8Array;
   byteSize: number;
@@ -56,6 +59,8 @@ const fetchMock = Object.assign(
   { preconnect: () => undefined },
 ) satisfies typeof fetch;
 const realFetch = globalThis.fetch;
+const cacheGet = mock(async () => cachedVoiceResponse);
+const cacheHas = mock(async () => true);
 
 mock.module("@/lib/api/cloud-worker-errors", () => ({
   ApiError: class ApiError extends Error {
@@ -107,11 +112,11 @@ mock.module("@/lib/services/elevenlabs", () => ({
 mock.module("@/lib/services/tts-first-line-cache", () => ({
   fingerprintCloudVoiceSettings: () => "fp-test",
   getCloudFirstLineCacheService: () => ({
-    get: async () => cachedVoiceResponse,
-    has: async () => true,
+    get: cacheGet,
+    has: cacheHas,
     put: async () => true,
   }),
-  shouldBypassCloudFirstLineCache: () => true,
+  shouldBypassCloudFirstLineCache: () => cacheBypass,
 }));
 
 mock.module("@/lib/services/usage", () => ({
@@ -147,12 +152,17 @@ beforeAll(async () => {
 
 beforeEach(() => {
   allowKokoroFetch = false;
+  cacheBypass = true;
   cachedVoiceResponse = null;
+  elevenLabsBytes = new Uint8Array([73, 68, 51]);
   fetchMock.mockClear();
   assertSafeForPublicUse.mockClear();
   reserveCredits.mockClear();
+  reconcileReservation.mockClear();
   billUsage.mockClear();
   elevenLabsTextToSpeech.mockClear();
+  cacheGet.mockClear();
+  cacheHas.mockClear();
 });
 
 afterAll(() => {
@@ -282,5 +292,48 @@ describe("POST /api/v1/voice/tts provider selection", () => {
     expect(reserveCredits).toHaveBeenCalledTimes(1);
     expect(billUsage).toHaveBeenCalledTimes(1);
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("returns bounded PCM as WAV and bypasses the MP3 first-line cache", async () => {
+    cacheBypass = false;
+    elevenLabsBytes = new Uint8Array([1, 2, 3, 4]);
+
+    const response = await postTts({
+      text: "A complete WAV response.",
+      voiceId: "custom-elevenlabs-voice",
+      format: "wav",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("audio/wav");
+    expect(response.headers.get("X-Eliza-TTS-Provider")).toBe("elevenlabs");
+    expect(response.headers.get("Server-Timing")).toContain("synthesis;dur=");
+    expect(response.headers.get("X-TTS-Cache")).toBe("miss");
+    const wav = new Uint8Array(await response.arrayBuffer());
+    expect(new TextDecoder().decode(wav.subarray(0, 4))).toBe("RIFF");
+    expect([...wav.subarray(44)]).toEqual([1, 2, 3, 4]);
+    expect(elevenLabsTextToSpeech).toHaveBeenCalledWith({
+      text: "A complete WAV response.",
+      voiceId: "custom-elevenlabs-voice",
+      modelId: undefined,
+      outputFormat: "pcm_24000",
+    });
+    expect(cacheGet).not.toHaveBeenCalled();
+    expect(cacheHas).not.toHaveBeenCalled();
+    expect(billUsage).toHaveBeenCalledTimes(1);
+    expect(reconcileReservation).not.toHaveBeenCalled();
+  });
+
+  test("rejects malformed PCM before billing and refunds the reservation", async () => {
+    elevenLabsBytes = new Uint8Array([1, 2, 3]);
+
+    const response = await postTts({
+      text: "This upstream response is malformed.",
+      format: "wav",
+    });
+
+    expect(response.status).toBe(500);
+    expect(billUsage).not.toHaveBeenCalled();
+    expect(reconcileReservation).toHaveBeenCalledWith(0);
   });
 });

--- a/packages/cloud/api/v1/voice/tts/route.ts
+++ b/packages/cloud/api/v1/voice/tts/route.ts
@@ -45,7 +45,7 @@ import {
   InsufficientCreditsError,
 } from "@/lib/services/credits";
 import { getElevenLabsService } from "@/lib/services/elevenlabs";
-import { drainPcm16Stream, pcm16ToWav } from "@/lib/services/pcm16-wav";
+import { drainPcm16ToWav } from "@/lib/services/pcm16-wav";
 import {
   fingerprintCloudVoiceSettings,
   getCloudFirstLineCacheService,
@@ -121,7 +121,9 @@ function buildTtsObservabilityHeaders(
 
 /** ElevenLabs PCM sample rate we request for the WAV path (Hz). */
 const WAV_PCM_SAMPLE_RATE = 24_000;
-const MAX_WAV_PCM_BYTES = 64 * 1024 * 1024;
+// Mono PCM16 at 24 kHz consumes 48,000 bytes/second, so this permits roughly
+// 175 seconds of audio while bounding the two-copy drain/container peak.
+const MAX_WAV_PCM_BYTES = 8 * 1024 * 1024;
 
 /**
  * POST /api/v1/voice/tts
@@ -486,8 +488,9 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
       ...(wantWav ? { outputFormat: `pcm_${WAV_PCM_SAMPLE_RATE}` } : {}),
     });
     const wav = wantWav
-      ? pcm16ToWav(
-          await drainPcm16Stream(audioStream, MAX_WAV_PCM_BYTES),
+      ? await drainPcm16ToWav(
+          audioStream,
+          MAX_WAV_PCM_BYTES,
           WAV_PCM_SAMPLE_RATE,
         )
       : undefined;
@@ -635,10 +638,11 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
     // so codec-less clients can decode it. (Buffered, not streamed — fine for
     // short TTS replies; the MP3 path keeps its chunked streaming below.)
     if (wav !== undefined) {
-      return new Response(wav as unknown as BodyInit, {
+      return new Response(wav, {
         headers: {
           "Content-Type": "audio/wav",
           "Cache-Control": "no-cache",
+          ...buildTtsObservabilityHeaders("elevenlabs", timings),
           "X-TTS-Cache": "miss",
         },
       });

--- a/packages/cloud/shared/src/lib/services/__tests__/pcm16-wav.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/pcm16-wav.test.ts
@@ -1,7 +1,7 @@
 /** Verifies PCM16 stream validation and the exact RIFF/WAV bytes consumed by codec-less clients. */
 
 import { describe, expect, test } from "bun:test";
-import { drainPcm16Stream, pcm16ToWav } from "../pcm16-wav";
+import { drainPcm16ToWav, pcm16ToWav } from "../pcm16-wav";
 
 function stream(...chunks: number[][]): ReadableStream<Uint8Array> {
   return new ReadableStream({
@@ -14,8 +14,7 @@ function stream(...chunks: number[][]): ReadableStream<Uint8Array> {
 
 describe("PCM16 WAV encoding", () => {
   test("preserves streamed samples and writes a canonical mono header", async () => {
-    const pcm = await drainPcm16Stream(stream([0x01], [0x02, 0x03, 0x04]), 1024);
-    const wav = pcm16ToWav(pcm, 24_000);
+    const wav = await drainPcm16ToWav(stream([0x01], [0x02, 0x03, 0x04]), 1024, 24_000);
     const view = new DataView(wav.buffer);
 
     expect(new TextDecoder().decode(wav.subarray(0, 4))).toBe("RIFF");
@@ -32,17 +31,31 @@ describe("PCM16 WAV encoding", () => {
   });
 
   test("rejects empty and partial samples", async () => {
-    await expect(drainPcm16Stream(stream(), 1024)).rejects.toMatchObject({
+    await expect(drainPcm16ToWav(stream(), 1024, 24_000)).rejects.toMatchObject({
       code: "TTS_PCM_INVALID",
     });
-    await expect(drainPcm16Stream(stream([0x01, 0x02, 0x03]), 1024)).rejects.toMatchObject({
+    await expect(drainPcm16ToWav(stream([0x01, 0x02, 0x03]), 1024, 24_000)).rejects.toMatchObject({
       code: "TTS_PCM_INVALID",
     });
     expect(() => pcm16ToWav(Uint8Array.of(1), 24_000)).toThrow("complete 16-bit samples");
   });
 
+  test("rejects invalid drain limits and sample rates before reading", async () => {
+    await expect(drainPcm16ToWav(stream([0, 1]), 0, 24_000)).rejects.toMatchObject({
+      code: "TTS_PCM_INVALID",
+      context: { maxBytes: 0 },
+    });
+    await expect(drainPcm16ToWav(stream([0, 1]), 1024, 0)).rejects.toMatchObject({
+      code: "TTS_PCM_INVALID",
+      context: { sampleRate: 0 },
+    });
+    expect(() => pcm16ToWav(Uint8Array.of(0, 1), Number.NaN)).toThrow(
+      "sample rate must be a positive integer",
+    );
+  });
+
   test("cancels and rejects a response beyond the memory limit", async () => {
-    await expect(drainPcm16Stream(stream([0, 1], [2, 3]), 2)).rejects.toMatchObject({
+    await expect(drainPcm16ToWav(stream([0, 1], [2, 3]), 2, 24_000)).rejects.toMatchObject({
       code: "TTS_PCM_INVALID",
       context: { maxBytes: 2, receivedBytes: 4 },
     });

--- a/packages/cloud/shared/src/lib/services/pcm16-wav.ts
+++ b/packages/cloud/shared/src/lib/services/pcm16-wav.ts
@@ -17,19 +17,58 @@ function invalidPcm(message: string, context: Record<string, unknown>): ElizaErr
   });
 }
 
-/** Drains a PCM16 stream without allowing an upstream response to exhaust memory. */
-export async function drainPcm16Stream(
+function validateSampleRate(sampleRate: number): void {
+  if (!Number.isSafeInteger(sampleRate) || sampleRate <= 0) {
+    throw invalidPcm("PCM16 sample rate must be a positive integer", { sampleRate });
+  }
+}
+
+function writeWavHeader(
+  output: Uint8Array<ArrayBuffer>,
+  pcmBytes: number,
+  sampleRate: number,
+): void {
+  const view = new DataView(output.buffer);
+  const writeAscii = (offset: number, value: string) => {
+    for (let index = 0; index < value.length; index += 1) {
+      view.setUint8(offset + index, value.charCodeAt(index));
+    }
+  };
+
+  writeAscii(0, "RIFF");
+  view.setUint32(4, 36 + pcmBytes, true);
+  writeAscii(8, "WAVE");
+  writeAscii(12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, 1, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * 2, true);
+  view.setUint16(32, 2, true);
+  view.setUint16(34, 16, true);
+  writeAscii(36, "data");
+  view.setUint32(40, pcmBytes, true);
+}
+
+/**
+ * Drains bounded PCM16 into a WAV container without first allocating a merged
+ * PCM copy. Peak audio retention is the upstream chunks plus one final output.
+ */
+export async function drainPcm16ToWav(
   stream: ReadableStream<Uint8Array>,
   maxBytes: number,
-): Promise<Uint8Array> {
+  sampleRate: number,
+): Promise<Uint8Array<ArrayBuffer>> {
   if (!Number.isSafeInteger(maxBytes) || maxBytes <= 0 || maxBytes > MAX_RIFF_DATA_BYTES) {
-    throw invalidPcm("PCM16 byte limit is outside the WAV container range", { maxBytes });
+    throw invalidPcm("PCM16 byte limit is outside the WAV container range", {
+      maxBytes,
+    });
   }
+  validateSampleRate(sampleRate);
 
   const reader = stream.getReader();
-  const chunks: Uint8Array[] = [];
+  const chunks: Uint8Array<ArrayBuffer>[] = [];
   let total = 0;
-
   try {
     for (;;) {
       const result = await reader.read();
@@ -42,7 +81,9 @@ export async function drainPcm16Stream(
           receivedBytes: total,
         });
       }
-      chunks.push(result.value);
+      // A narrow view can otherwise retain an arbitrarily large upstream
+      // ArrayBuffer and defeat the byte limit while the stream is drained.
+      chunks.push(result.value.slice());
     }
   } finally {
     reader.releaseLock();
@@ -54,25 +95,24 @@ export async function drainPcm16Stream(
     });
   }
 
-  const merged = new Uint8Array(total);
-  let offset = 0;
+  const output = new Uint8Array(WAV_HEADER_BYTES + total);
+  writeWavHeader(output, total, sampleRate);
+  let offset = WAV_HEADER_BYTES;
   for (const chunk of chunks) {
-    merged.set(chunk, offset);
+    output.set(chunk, offset);
     offset += chunk.byteLength;
   }
-  return merged;
+  return output;
 }
 
 /** Wraps little-endian mono PCM16 samples in a 44-byte RIFF/WAV header. */
-export function pcm16ToWav(pcm: Uint8Array, sampleRate: number): Uint8Array {
+export function pcm16ToWav(pcm: Uint8Array, sampleRate: number): Uint8Array<ArrayBuffer> {
   if (pcm.byteLength === 0 || pcm.byteLength % 2 !== 0) {
     throw invalidPcm("PCM16 input must contain complete 16-bit samples", {
       receivedBytes: pcm.byteLength,
     });
   }
-  if (!Number.isSafeInteger(sampleRate) || sampleRate <= 0) {
-    throw invalidPcm("PCM16 sample rate must be a positive integer", { sampleRate });
-  }
+  validateSampleRate(sampleRate);
   if (pcm.byteLength > MAX_RIFF_DATA_BYTES) {
     throw invalidPcm("PCM16 input exceeds the WAV container range", {
       receivedBytes: pcm.byteLength,
@@ -80,26 +120,7 @@ export function pcm16ToWav(pcm: Uint8Array, sampleRate: number): Uint8Array {
   }
 
   const output = new Uint8Array(WAV_HEADER_BYTES + pcm.byteLength);
-  const view = new DataView(output.buffer);
-  const writeAscii = (offset: number, value: string) => {
-    for (let index = 0; index < value.length; index += 1) {
-      view.setUint8(offset + index, value.charCodeAt(index));
-    }
-  };
-
-  writeAscii(0, "RIFF");
-  view.setUint32(4, 36 + pcm.byteLength, true);
-  writeAscii(8, "WAVE");
-  writeAscii(12, "fmt ");
-  view.setUint32(16, 16, true);
-  view.setUint16(20, 1, true);
-  view.setUint16(22, 1, true);
-  view.setUint32(24, sampleRate, true);
-  view.setUint32(28, sampleRate * 2, true);
-  view.setUint16(32, 2, true);
-  view.setUint16(34, 16, true);
-  writeAscii(36, "data");
-  view.setUint32(40, pcm.byteLength, true);
+  writeWavHeader(output, pcm.byteLength, sampleRate);
   output.set(pcm, WAV_HEADER_BYTES);
   return output;
 }


### PR DESCRIPTION
# Relates to

Fixes #16003

# Summary

Bounds PCM16 stream accumulation before constructing the merged WAV response, uses a typed byte body without the unsafe cast, and expands route coverage across WAV success, MP3/cache behavior, malformed PCM, billing refund, and over-limit cancellation.

# Testing

- `bun test packages/cloud/shared/src/lib/services/__tests__/pcm16-wav.test.ts packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts` — 11 passed.
- `git diff --check origin/develop...HEAD` — passed.
- `git merge-tree --write-tree origin/develop HEAD` — clean.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - server response and allocation repair; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - server response and allocation repair; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [ ] Device playback proof remains required before ready-for-review.
<!-- evidence-row:backend-logs -->
- [ ] Attach exact-head route logs before ready-for-review.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend implementation changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/model path changed.
<!-- evidence-row:domain-artifacts -->
- [ ] Attach exact-head WAV response/playback artifact before ready-for-review.

Draft until the issue's device playback and exact-head evidence bar is attached.