### PR TITLE
fix(lifeops): report activity telemetry mirror failures to the agent

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/repository.activity-signal-mirror.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/repository.activity-signal-mirror.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Regression coverage for the telemetry-mirror failure boundary inside
+ * `LifeOpsRepository.createActivitySignal` (#15820): a failing mirror write
+ * must never reject the already-committed signal insert, but it must surface
+ * through `runtime.reportError` as a typed ElizaError with the original cause,
+ * throttled to the first and every 100th consecutive failure. Deterministic:
+ * drives the real repository, registry, and telemetry mapper against a fake
+ * runtime DB that fails only the `life_telemetry_events` insert.
+ */
+
+import { ElizaError, type IAgentRuntime } from "@elizaos/core";
+import type { LifeOpsActivitySignal } from "@elizaos/shared";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createSignalSourceRegistry,
+  registerSignalSourceRegistry,
+} from "./registries/signal-source-registry.js";
+import { LifeOpsRepository } from "./repository.js";
+import type { RawSqlQuery } from "./sql.js";
+import { registerBuiltinSignalSources } from "./telemetry-mapping.js";
+
+function rawSqlTextOf(query: RawSqlQuery): string {
+  return query.queryChunks
+    .map((chunk) =>
+      Array.isArray(chunk.value)
+        ? chunk.value.join("")
+        : typeof chunk.value === "string"
+          ? chunk.value
+          : "",
+    )
+    .join("");
+}
+
+interface MirrorHarness {
+  runtime: IAgentRuntime;
+  repository: LifeOpsRepository;
+  reportError: ReturnType<typeof vi.fn>;
+  mirrorError: Error;
+  setTelemetryDown: (down: boolean) => void;
+  executedSignalInserts: () => number;
+}
+
+/**
+ * Real `LifeOpsRepository` over a fake runtime DB: signal inserts always
+ * succeed; telemetry inserts throw while `telemetryDown` is set. The signal
+ * source registry is the real built-in registration, so the mirror path runs
+ * the production mapper before hitting the failing write.
+ */
+function createMirrorHarness(): MirrorHarness {
+  let telemetryDown = false;
+  let signalInserts = 0;
+  const mirrorError = new Error("telemetry store offline");
+  const reportError = vi.fn();
+  const runtime = {
+    adapter: {
+      db: {
+        execute: async (query: RawSqlQuery) => {
+          const sqlText = rawSqlTextOf(query);
+          if (sqlText.includes("app_lifeops.life_telemetry_events")) {
+            if (telemetryDown) throw mirrorError;
+            return { rows: [{ id: "telemetry-row" }] };
+          }
+          if (sqlText.includes("app_lifeops.life_activity_signals")) {
+            signalInserts += 1;
+          }
+          return { rows: [] };
+        },
+      },
+    },
+    reportError,
+  } as unknown as IAgentRuntime;
+
+  const registry = createSignalSourceRegistry();
+  registerBuiltinSignalSources(registry);
+  registerSignalSourceRegistry(runtime, registry);
+
+  return {
+    runtime,
+    repository: new LifeOpsRepository(runtime),
+    reportError,
+    mirrorError,
+    setTelemetryDown: (down: boolean) => {
+      telemetryDown = down;
+    },
+    executedSignalInserts: () => signalInserts,
+  };
+}
+
+// Unique agent per test: the mirror-failure counter is a per-agent static on
+// LifeOpsRepository and would otherwise leak counts across cases.
+function signal(
+  agentId: string,
+  overrides: Partial<LifeOpsActivitySignal> = {},
+): LifeOpsActivitySignal {
+  return {
+    id: crypto.randomUUID(),
+    agentId,
+    source: "desktop_interaction",
+    platform: "macos_desktop",
+    state: "active",
+    observedAt: "2026-07-06T04:00:00.000Z",
+    idleState: null,
+    idleTimeSeconds: 3,
+    onBattery: null,
+    health: null,
+    metadata: {},
+    createdAt: "2026-07-06T04:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("LifeOpsRepository.createActivitySignal telemetry mirror", () => {
+  it("commits the signal row and reports a typed failure when the mirror write fails", async () => {
+    const harness = createMirrorHarness();
+    const agentId = crypto.randomUUID();
+    harness.setTelemetryDown(true);
+
+    await expect(
+      harness.repository.createActivitySignal(signal(agentId)),
+    ).resolves.toBeUndefined();
+
+    expect(harness.executedSignalInserts()).toBe(1);
+    expect(harness.reportError).toHaveBeenCalledTimes(1);
+    const [scope, error] = harness.reportError.mock.calls[0] as [
+      string,
+      unknown,
+    ];
+    expect(scope).toBe("lifeops.repository");
+    expect(error).toBeInstanceOf(ElizaError);
+    const typed = error as ElizaError;
+    expect(typed.code).toBe("LIFEOPS_ACTIVITY_TELEMETRY_MIRROR_FAILED");
+    expect(typed.cause).toBe(harness.mirrorError);
+    expect(typed.context).toEqual({
+      agentId,
+      source: "desktop_interaction",
+      platform: "macos_desktop",
+      consecutiveFailures: 1,
+    });
+  });
+
+  it("does not report when the mirror write succeeds", async () => {
+    const harness = createMirrorHarness();
+    const agentId = crypto.randomUUID();
+
+    await harness.repository.createActivitySignal(signal(agentId));
+
+    expect(harness.executedSignalInserts()).toBe(1);
+    expect(harness.reportError).not.toHaveBeenCalled();
+  });
+
+  it("throttles reporting to the first and every 100th consecutive failure", async () => {
+    const harness = createMirrorHarness();
+    const agentId = crypto.randomUUID();
+    harness.setTelemetryDown(true);
+
+    for (let i = 0; i < 100; i++) {
+      await harness.repository.createActivitySignal(signal(agentId));
+    }
+
+    // Every signal row still committed despite the broken mirror.
+    expect(harness.executedSignalInserts()).toBe(100);
+    expect(harness.reportError).toHaveBeenCalledTimes(2);
+    const second = harness.reportError.mock.calls[1]?.[1] as ElizaError;
+    expect(second.context).toMatchObject({ consecutiveFailures: 100 });
+  });
+
+  it("resets the failure counter after a successful mirror so the next failure reports again", async () => {
+    const harness = createMirrorHarness();
+    const agentId = crypto.randomUUID();
+
+    harness.setTelemetryDown(true);
+    await harness.repository.createActivitySignal(signal(agentId));
+    harness.setTelemetryDown(false);
+    await harness.repository.createActivitySignal(signal(agentId));
+    harness.setTelemetryDown(true);
+    await harness.repository.createActivitySignal(signal(agentId));
+
+    expect(harness.reportError).toHaveBeenCalledTimes(2);
+    const calls = harness.reportError.mock.calls.map(
+      (call) => (call[1] as ElizaError).context,
+    );
+    expect(calls[0]).toMatchObject({ consecutiveFailures: 1 });
+    expect(calls[1]).toMatchObject({ consecutiveFailures: 1 });
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/repository.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/repository.ts
@@ -3907,9 +3907,9 @@ export class LifeOpsRepository {
 
     // Mirror into the canonical telemetry store. Dedupes on
     // (agent_id, dedupe_key) so re-persists and migrator replays are safe.
-    // Failures here must not block signal persistence, but they are counted
-    // and logged (first + every 100th) so broken mirrors surface in
-    // observability.
+    // Failures here must not block signal persistence, but they are counted,
+    // logged, and reported to the agent (first + every 100th) so broken
+    // mirrors surface in observability.
     try {
       const telemetry = buildTelemetryEventFromSignal(
         signal,
@@ -3922,6 +3922,13 @@ export class LifeOpsRepository {
       }
       LifeOpsRepository.telemetryMirrorFailures.delete(signal.agentId);
     } catch (error) {
+      // error-policy:J7 diagnostics-must-not-kill-the-loop — the telemetry
+      // mirror is a derived copy of the signal row that already committed
+      // above, so a mirror failure must not undo or re-error the primary
+      // insert. It must still surface observably: reportError (throttled with
+      // the warn to the first and every 100th consecutive failure, because
+      // passive signals arrive at sampling frequency) puts the typed failure
+      // in front of the agent and drives owner escalation when systemic.
       const nextCount =
         (LifeOpsRepository.telemetryMirrorFailures.get(signal.agentId) ?? 0) +
         1;
@@ -3936,6 +3943,22 @@ export class LifeOpsRepository {
             error: error instanceof Error ? error.message : String(error),
           },
           "[lifeops] Telemetry mirror failed for activity signal.",
+        );
+        this.runtime.reportError(
+          "lifeops.repository",
+          new ElizaError(
+            "Activity-signal telemetry mirror failed; the signal row committed without a telemetry copy",
+            {
+              code: "LIFEOPS_ACTIVITY_TELEMETRY_MIRROR_FAILED",
+              context: {
+                agentId: signal.agentId,
+                source: signal.source,
+                platform: signal.platform,
+                consecutiveFailures: nextCount,
+              },
+              cause: error,
+            },
+          ),
         );
       }
     }


### PR DESCRIPTION
Fixes #15820

## What

`LifeOpsRepository.createActivitySignal` catches telemetry-mirror failures, counts them, and logs a throttled warn — but never called `runtime.reportError`, so a broken mirror was invisible to the agent (RECENT_ERRORS) and the owner-escalation path. That is a J7 error-policy violation: diagnostics must not kill the loop, but the failure must still surface observably.

## How

- Annotated the mirror catch `// error-policy:J7 diagnostics-must-not-kill-the-loop` in `plugins/plugin-personal-assistant/src/lifeops/repository.ts`.
- The catch now calls `this.runtime.reportError("lifeops.repository", new ElizaError(...))` with code `LIFEOPS_ACTIVITY_TELEMETRY_MIRROR_FAILED`, context `{ agentId, source, platform, consecutiveFailures }`, and the original error preserved on `cause` — matching the registry-missing report site directly above in the same method.
- Reporting shares the existing throttle with the warn (first + every 100th consecutive failure) because passive signals arrive at sampling frequency; the count context conveys sustained breakage.
- Behavior retained: the primary `life_activity_signals` insert stays non-fatal to mirror failures, and a successful mirror still resets the per-agent counter.

## Tests

New focused suite `plugins/plugin-personal-assistant/src/lifeops/repository.activity-signal-mirror.test.ts` drives the **real** repository, real built-in `SignalSourceRegistry` registration, and real telemetry mapper against a runtime DB stub that fails only the `life_telemetry_events` insert:

1. mirror failure is non-fatal, the signal row still commits, and `reportError` receives the typed `ElizaError` with exact scope/code/context/cause;
2. no report when the mirror succeeds;
3. throttle: 100 consecutive failures produce exactly 2 reports (counts 1 and 100);
4. a successful mirror resets the counter so the next failure reports again as count 1.

Verified the 3 reportError assertions **fail against the unfixed code** (only the non-fatal-insert case passed), then pass with the fix.

`bunx biome check` clean on both files; plugin `tsc --noEmit -p tsconfig.build.json` clean; `bun run audit:error-policy-ratchet` passes (`repository.ts: emptyCatch 0->0, serverConsole 0->0; no new fallback-slop`).

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - backend-only change inside a repository catch block; no UI surface affected.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - backend-only change; no UI surface affected.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - backend-only change; no user-facing flow to record.`
<!-- evidence-row:backend-logs -->
- [x] [16019](https://github.com/elizaOS/eliza/pull/16019)

<details>
<summary>Focused vitest run (4/4 pass with fix; 3/4 fail without it)</summary>

```
 RUN  v4.1.5 /home/shaw/eliza-worktrees/fix-15820

 ✓ plugins/plugin-personal-assistant/src/lifeops/repository.activity-signal-mirror.test.ts > LifeOpsRepository.createActivitySignal telemetry mirror > commits the signal row and reports a typed failure when the mirror write fails 18ms
 ✓ plugins/plugin-personal-assistant/src/lifeops/repository.activity-signal-mirror.test.ts > LifeOpsRepository.createActivitySignal telemetry mirror > does not report when the mirror write succeeds 2ms
 ✓ plugins/plugin-personal-assistant/src/lifeops/repository.activity-signal-mirror.test.ts > LifeOpsRepository.createActivitySignal telemetry mirror > throttles reporting to the first and every 100th consecutive failure 13ms
 ✓ plugins/plugin-personal-assistant/src/lifeops/repository.activity-signal-mirror.test.ts > LifeOpsRepository.createActivitySignal telemetry mirror > resets the failure counter after a successful mirror so the next failure reports again 4ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  01:52:30
   Duration  25.96s (transform 19.89s, setup 320ms, import 25.27s, tests 45ms, environment 0ms)

Against the unfixed catch (git checkout of repository.ts):
 Test Files  1 failed (1)
      Tests  3 failed | 1 passed (4)

Neighboring suites (signal-source-registry, telemetry-mapping):
 Test Files  2 passed (2)
      Tests  11 passed (11)

error-policy ratchet:
[error-policy-ratchet] base origin/develop (d7acb37ff3); 1 changed production source file(s)
[error-policy-ratchet]   plugins/plugin-personal-assistant/src/lifeops/repository.ts: emptyCatch 0->0, serverConsole 0->0
[error-policy-ratchet] no new fallback-slop in touched files
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - backend-only change; no frontend request/response involved.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model behavior change; this is a diagnostic reporting boundary inside a repository write path.`
<!-- evidence-row:domain-artifacts -->
- [x] [16019](https://github.com/elizaOS/eliza/pull/16019)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
