### PR TITLE
fix(discord): make initial-login retry terminal-aware and stop-safe

### DIFF
--- a/plugins/plugin-discord/__tests__/login-retry.test.ts
+++ b/plugins/plugin-discord/__tests__/login-retry.test.ts
@@ -1,17 +1,24 @@
 /**
  * Drives the real initial-login retry loop (`DiscordService.attemptDiscordLogin`)
- * against a deterministic fake discord.js client whose `login()` rejects N times
- * then resolves and emits ClientReady, plus focused checks of the real backoff
- * (`computeLoginBackoffMs`) and throttled failure heartbeat
- * (`emitLoginFailureHeartbeat`). Guards #15855: a transient boot-time login
- * failure must retry with capped-exponential backoff and eventually reach ready
- * — never settle terminal, leaving the process connected-but-deaf. Collaborators
- * that are not under test (event wiring, onReady backfill, legacy aliasing) are
- * stubbed on the instance; the retry/backoff/heartbeat code runs for real.
+ * against a deterministic fake discord.js client, plus focused checks of the
+ * real backoff (`computeLoginBackoffMs`) and throttled failure heartbeat
+ * (`emitLoginFailureHeartbeat`). Guards #15855 (a transient boot-time login
+ * failure retries with capped-exponential backoff and eventually reaches ready
+ * instead of leaving the process connected-but-deaf) and #15968 (terminal
+ * authentication/configuration failures reject typed and stop retrying; at most
+ * one retry timer per account with no append-only handle history; the real
+ * `stop()` cancels a pending backoff and invalidates in-flight attempts so no
+ * client or timer is ever created after stop). Collaborators that are not under
+ * test (event wiring, onReady backfill, legacy aliasing, voice teardown) are
+ * stubbed on the instance; the retry/backoff/heartbeat/stop code runs for real.
  */
+import { ElizaError } from "@elizaos/core";
 import { Events } from "discord.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { DiscordAccountClientState } from "../account-client-pool.ts";
+import {
+	DiscordAccountClientPool,
+	type DiscordAccountClientState,
+} from "../account-client-pool.ts";
 import { DiscordService } from "../service.ts";
 
 type FakeClient = {
@@ -21,10 +28,24 @@ type FakeClient = {
 	destroy: ReturnType<typeof vi.fn>;
 	isReady: () => boolean;
 	emit: (event: string, ...args: unknown[]) => void;
+	/** Settles a `{ kind: "hang" }` login with a rejection (post-stop races). */
+	rejectPendingLogin: (error: unknown) => void;
 };
 
-function makeFakeClient(shouldSucceed: boolean): FakeClient {
+type LoginBehavior =
+	| { kind: "succeed" }
+	| { kind: "reject"; error: Error }
+	// Login promise stays pending until the test settles it via
+	// rejectPendingLogin (or emits ClientReady), modelling an in-flight attempt.
+	| { kind: "hang" };
+
+function transientSocketError(): Error {
+	return new Error("The socket connection was closed unexpectedly.");
+}
+
+function makeFakeClient(behavior: LoginBehavior): FakeClient {
 	const handlers = new Map<string, (...args: unknown[]) => void>();
+	let rejectPending: ((error: unknown) => void) | undefined;
 	const client: FakeClient = {
 		once(event, cb) {
 			handlers.set(event, cb);
@@ -36,14 +57,22 @@ function makeFakeClient(shouldSucceed: boolean): FakeClient {
 		emit(event, ...args) {
 			handlers.get(event)?.(...args);
 		},
-		login: vi.fn().mockImplementation(async () => {
-			if (!shouldSucceed) {
-				throw new Error("The socket connection was closed unexpectedly.");
+		rejectPendingLogin(error) {
+			rejectPending?.(error);
+		},
+		login: vi.fn().mockImplementation(() => {
+			if (behavior.kind === "reject") {
+				return Promise.reject(behavior.error);
+			}
+			if (behavior.kind === "hang") {
+				return new Promise((_resolve, reject) => {
+					rejectPending = reject;
+				});
 			}
 			// discord.js emits ClientReady asynchronously once the gateway session
 			// is up; mirror that so the ready handler fires after login resolves.
 			queueMicrotask(() => client.emit(Events.ClientReady, client));
-			return "token";
+			return Promise.resolve("token");
 		}),
 	};
 	return client;
@@ -53,6 +82,7 @@ function makeRuntime() {
 	return {
 		agentId: "agent-1",
 		character: { name: "Eliza" },
+		reportError: vi.fn(),
 		logger: {
 			error: vi.fn(),
 			warn: vi.fn(),
@@ -74,7 +104,59 @@ function makeState(accountId: string): DiscordAccountClientState {
 	} as unknown as DiscordAccountClientState;
 }
 
-describe("DiscordService initial-login retry (#15855)", () => {
+// The retry loop's private surface plus the collaborators the real `stop()`
+// touches, exposed for direct driving in tests.
+type TestService = DiscordService & {
+	attemptDiscordLogin: (
+		state: DiscordAccountClientState,
+		token: string,
+		attempt: number,
+		resolve: () => void,
+		reject: (error: unknown) => void,
+		generation: number,
+	) => void;
+	computeLoginBackoffMs: (attempt: number) => number;
+	emitLoginFailureHeartbeat: (
+		state: DiscordAccountClientState,
+		error: unknown,
+		attempt: number,
+		delayMs: number,
+	) => void;
+	timeouts: ReturnType<typeof setTimeout>[];
+	accountPool: DiscordAccountClientPool;
+	onReadyForAccount: ReturnType<typeof vi.fn>;
+	_loginFailed: boolean;
+	lifecycleGeneration: number;
+};
+
+/**
+ * Fabricates a DiscordService around the real prototype: the retry loop,
+ * classification, backoff, heartbeat, and `stop()` run for real; heavy gateway
+ * collaborators are stubbed. `accountPool` is the real pool so `stop()`
+ * exercises genuine state iteration and clearing.
+ */
+function makeService(
+	runtime: ReturnType<typeof makeRuntime>,
+	createClient: () => FakeClient,
+): TestService {
+	return Object.assign(Object.create(DiscordService.prototype), {
+		runtime,
+		defaultAccountId: "default",
+		_loginFailed: false,
+		lifecycleGeneration: 0,
+		timeouts: [] as ReturnType<typeof setTimeout>[],
+		accountPool: new DiscordAccountClientPool(),
+		voiceTargets: { unregisterAccount: vi.fn(), clear: vi.fn() },
+		audioSinks: new Map(),
+		createDiscordJsClient: createClient,
+		// Isolate the retry loop from the heavy gateway/backfill collaborators.
+		setupEventListenersForAccount: vi.fn(),
+		onReadyForAccount: vi.fn().mockResolvedValue(undefined),
+		syncLegacyDefaultAliases: vi.fn(),
+	}) as unknown as TestService;
+}
+
+describe("DiscordService initial-login retry (#15855, #15968)", () => {
 	beforeEach(() => {
 		vi.useFakeTimers();
 	});
@@ -87,36 +169,21 @@ describe("DiscordService initial-login retry (#15855)", () => {
 		const clients: FakeClient[] = [];
 		const FAIL_TIMES = 2;
 
-		const service = Object.assign(Object.create(DiscordService.prototype), {
-			runtime,
-			defaultAccountId: "default",
-			_loginFailed: false,
-			timeouts: [] as ReturnType<typeof setTimeout>[],
-			createDiscordJsClient: () => {
-				const client = makeFakeClient(clients.length >= FAIL_TIMES);
-				clients.push(client);
-				return client;
-			},
-			// Isolate the retry loop from the heavy gateway/backfill collaborators.
-			setupEventListenersForAccount: vi.fn(),
-			onReadyForAccount: vi.fn().mockResolvedValue(undefined),
-			syncLegacyDefaultAliases: vi.fn(),
-		}) as unknown as DiscordService & {
-			attemptDiscordLogin: (
-				state: DiscordAccountClientState,
-				token: string,
-				attempt: number,
-				resolve: () => void,
-				reject: (error: unknown) => void,
-			) => void;
-			_loginFailed: boolean;
-		};
+		const service = makeService(runtime, () => {
+			const client = makeFakeClient(
+				clients.length >= FAIL_TIMES
+					? { kind: "succeed" }
+					: { kind: "reject", error: transientSocketError() },
+			);
+			clients.push(client);
+			return client;
+		});
 
 		const state = makeState("default");
 		let readyResolved = false;
 
 		const ready = new Promise<void>((resolve, reject) => {
-			service.attemptDiscordLogin(state, "bot-token", 0, resolve, reject);
+			service.attemptDiscordLogin(state, "bot-token", 0, resolve, reject, 0);
 		}).then(() => {
 			readyResolved = true;
 		});
@@ -161,6 +228,286 @@ describe("DiscordService initial-login retry (#15855)", () => {
 		await vi.advanceTimersByTimeAsync(120_000);
 		expect(runtime.logger.warn.mock.calls.length).toBe(warnCountAtReady);
 		expect(state.loginRetryTimer).toBeUndefined();
+		expect(state.cancelLoginRetry).toBeUndefined();
+
+		// Timer hygiene (#15968): retry handles are tracked per account, never
+		// appended to the service-wide timeouts array as fired-handle history.
+		expect(service.timeouts.length).toBe(0);
+	});
+
+	it("keeps exactly one tracked retry handle across a long transient outage", async () => {
+		const runtime = makeRuntime();
+		const clients: FakeClient[] = [];
+		const FAIL_TIMES = 8;
+
+		const service = makeService(runtime, () => {
+			const client = makeFakeClient(
+				clients.length >= FAIL_TIMES
+					? { kind: "succeed" }
+					: { kind: "reject", error: transientSocketError() },
+			);
+			clients.push(client);
+			return client;
+		});
+		const state = makeState("default");
+
+		const ready = new Promise<void>((resolve, reject) => {
+			service.attemptDiscordLogin(state, "bot-token", 0, resolve, reject, 0);
+		});
+
+		// Walk the outage attempt by attempt: after each failure exactly one
+		// handle is armed on the state and nothing accumulates service-wide.
+		for (let attempt = 0; attempt < FAIL_TIMES; attempt += 1) {
+			await vi.advanceTimersByTimeAsync(0);
+			expect(state.loginRetryTimer).toBeDefined();
+			expect(typeof state.cancelLoginRetry).toBe("function");
+			expect(service.timeouts.length).toBe(0);
+			await vi.advanceTimersByTimeAsync(service.computeLoginBackoffMs(attempt));
+		}
+		await ready;
+
+		expect(clients.length).toBe(FAIL_TIMES + 1);
+		expect(state.loginRetryTimer).toBeUndefined();
+		expect(state.cancelLoginRetry).toBeUndefined();
+		expect(service.timeouts.length).toBe(0);
+	});
+
+	it("classifies an invalid token as terminal: typed rejection, owner report, no retry", async () => {
+		const runtime = makeRuntime();
+		const clients: FakeClient[] = [];
+		const service = makeService(runtime, () => {
+			const client = makeFakeClient({
+				kind: "reject",
+				error: Object.assign(new Error("An invalid token was provided."), {
+					code: "TokenInvalid",
+				}),
+			});
+			clients.push(client);
+			return client;
+		});
+		const state = makeState("default");
+
+		const ready = new Promise<void>((resolve, reject) => {
+			service.attemptDiscordLogin(state, "bad-token", 0, resolve, reject, 0);
+		});
+		const rejection = await ready.then(
+			() => {
+				throw new Error("ready promise must reject for a terminal failure");
+			},
+			(error: unknown) => error,
+		);
+
+		expect(rejection).toBeInstanceOf(ElizaError);
+		expect(rejection).toMatchObject({
+			code: "DISCORD_LOGIN_TERMINAL",
+			severity: "fatal",
+			context: { accountId: "default", attempt: 1 },
+		});
+		expect((rejection as ElizaError).cause).toMatchObject({
+			code: "TokenInvalid",
+		});
+
+		// The dead account is raised through the diagnostic boundary so the owner
+		// sees it (RECENT_ERRORS / escalation), not just a debug log.
+		expect(runtime.reportError).toHaveBeenCalledTimes(1);
+		expect(runtime.reportError).toHaveBeenCalledWith(
+			"discord:login",
+			rejection,
+			{ accountId: "default" },
+		);
+
+		// Terminal means terminal: no timer armed, and however long we wait no
+		// new client or login attempt appears.
+		expect(state.loginRetryTimer).toBeUndefined();
+		expect(state.cancelLoginRetry).toBeUndefined();
+		await vi.advanceTimersByTimeAsync(600_000);
+		expect(clients.length).toBe(1);
+		expect(clients[0]?.login).toHaveBeenCalledTimes(1);
+		expect(state.loginFailed).toBe(true);
+		expect(service._loginFailed).toBe(true);
+		expect(state.client).toBeNull();
+	});
+
+	it("classifies a privileged-intent gateway rejection as terminal", async () => {
+		const runtime = makeRuntime();
+		const clients: FakeClient[] = [];
+		const service = makeService(runtime, () => {
+			// @discordjs/ws surfaces close code 4014 as a plain Error with exactly
+			// this message via the shard error event / login rejection.
+			const client = makeFakeClient({
+				kind: "reject",
+				error: new Error("Used disallowed intents"),
+			});
+			clients.push(client);
+			return client;
+		});
+		const state = makeState("default");
+
+		const rejection = await new Promise<void>((resolve, reject) => {
+			service.attemptDiscordLogin(state, "bot-token", 0, resolve, reject, 0);
+		}).then(
+			() => {
+				throw new Error("ready promise must reject for a terminal failure");
+			},
+			(error: unknown) => error,
+		);
+
+		expect(rejection).toBeInstanceOf(ElizaError);
+		expect(rejection).toMatchObject({ code: "DISCORD_LOGIN_TERMINAL" });
+		expect(runtime.reportError).toHaveBeenCalledTimes(1);
+
+		await vi.advanceTimersByTimeAsync(600_000);
+		expect(clients.length).toBe(1);
+		expect(state.loginRetryTimer).toBeUndefined();
+	});
+
+	it("treats a terminal gateway Error event as terminal too", async () => {
+		const runtime = makeRuntime();
+		const clients: FakeClient[] = [];
+		const service = makeService(runtime, () => {
+			const client = makeFakeClient({ kind: "hang" });
+			clients.push(client);
+			return client;
+		});
+		const state = makeState("default");
+
+		const readyOutcome = new Promise<void>((resolve, reject) => {
+			service.attemptDiscordLogin(state, "bot-token", 0, resolve, reject, 0);
+		}).then(
+			() => {
+				throw new Error("ready promise must reject for a terminal failure");
+			},
+			(error: unknown) => error,
+		);
+
+		// The gateway Error event (not the login rejection) carries the terminal
+		// close-code failure.
+		clients[0]?.emit(Events.Error, new Error("Authentication failed"));
+		const rejection = await readyOutcome;
+
+		expect(rejection).toBeInstanceOf(ElizaError);
+		expect(rejection).toMatchObject({ code: "DISCORD_LOGIN_TERMINAL" });
+		await vi.advanceTimersByTimeAsync(600_000);
+		expect(clients.length).toBe(1);
+	});
+
+	it("stop() during backoff cancels the pending retry and settles the ready promise", async () => {
+		const runtime = makeRuntime();
+		const clients: FakeClient[] = [];
+		const service = makeService(runtime, () => {
+			const client = makeFakeClient({
+				kind: "reject",
+				error: transientSocketError(),
+			});
+			clients.push(client);
+			return client;
+		});
+		const state = makeState("default");
+		service.accountPool.set(state);
+
+		const readyOutcome = new Promise<void>((resolve, reject) => {
+			service.attemptDiscordLogin(state, "bot-token", 0, resolve, reject, 0);
+		}).then(
+			() => {
+				throw new Error("ready promise must not resolve after stop()");
+			},
+			(error: unknown) => error,
+		);
+
+		// Let the first attempt fail and arm the backoff timer.
+		await vi.advanceTimersByTimeAsync(0);
+		expect(state.loginRetryTimer).toBeDefined();
+
+		await service.stop();
+
+		// The armed timer is cleared and the ready promise settles typed.
+		expect(state.loginRetryTimer).toBeUndefined();
+		expect(state.cancelLoginRetry).toBeUndefined();
+		const rejection = await readyOutcome;
+		expect(rejection).toBeInstanceOf(ElizaError);
+		expect(rejection).toMatchObject({ code: "DISCORD_LOGIN_ABORTED" });
+
+		// No resurrection: however long we wait after stop, no new client is
+		// created and no further login fires.
+		await vi.advanceTimersByTimeAsync(600_000);
+		expect(clients.length).toBe(1);
+		expect(clients[0]?.login).toHaveBeenCalledTimes(1);
+		expect(service.accountPool.list().length).toBe(0);
+	});
+
+	it("a login rejection landing after stop() cannot arm a timer or create a client", async () => {
+		const runtime = makeRuntime();
+		const clients: FakeClient[] = [];
+		const service = makeService(runtime, () => {
+			const client = makeFakeClient({ kind: "hang" });
+			clients.push(client);
+			return client;
+		});
+		const state = makeState("default");
+		service.accountPool.set(state);
+
+		const readyOutcome = new Promise<void>((resolve, reject) => {
+			service.attemptDiscordLogin(state, "bot-token", 0, resolve, reject, 0);
+		}).then(
+			() => {
+				throw new Error("ready promise must not resolve after stop()");
+			},
+			(error: unknown) => error,
+		);
+
+		await service.stop();
+
+		// The in-flight login() settles only now, after teardown.
+		clients[0]?.rejectPendingLogin(transientSocketError());
+		const rejection = await readyOutcome;
+
+		expect(rejection).toBeInstanceOf(ElizaError);
+		expect(rejection).toMatchObject({ code: "DISCORD_LOGIN_ABORTED" });
+		expect((rejection as ElizaError).cause).toMatchObject({
+			message: "The socket connection was closed unexpectedly.",
+		});
+		expect(state.loginRetryTimer).toBeUndefined();
+
+		await vi.advanceTimersByTimeAsync(600_000);
+		expect(clients.length).toBe(1);
+		expect(clients[0]?.login).toHaveBeenCalledTimes(1);
+	});
+
+	it("a ClientReady landing after stop() does not resurrect the connector", async () => {
+		const runtime = makeRuntime();
+		const clients: FakeClient[] = [];
+		const service = makeService(runtime, () => {
+			const client = makeFakeClient({ kind: "hang" });
+			clients.push(client);
+			return client;
+		});
+		const state = makeState("default");
+		service.accountPool.set(state);
+
+		const readyOutcome = new Promise<void>((resolve, reject) => {
+			service.attemptDiscordLogin(state, "bot-token", 0, resolve, reject, 0);
+		}).then(
+			() => {
+				throw new Error("ready promise must not resolve after stop()");
+			},
+			(error: unknown) => error,
+		);
+
+		await service.stop();
+		// stop() already destroyed the pooled client.
+		expect(clients[0]?.destroy).toHaveBeenCalled();
+
+		// A late gateway ready must not run onReady side effects or resolve.
+		clients[0]?.emit(Events.ClientReady, clients[0]);
+		const rejection = await readyOutcome;
+
+		expect(rejection).toBeInstanceOf(ElizaError);
+		expect(rejection).toMatchObject({ code: "DISCORD_LOGIN_ABORTED" });
+		expect(service.onReadyForAccount).not.toHaveBeenCalled();
+		expect(state.client).toBeNull();
+
+		await vi.advanceTimersByTimeAsync(600_000);
+		expect(clients.length).toBe(1);
 	});
 
 	it("computes capped exponential backoff per attempt", () => {
@@ -215,38 +562,21 @@ describe("DiscordService initial-login retry (#15855)", () => {
 	it("does not schedule a retry when the first login succeeds", async () => {
 		const runtime = makeRuntime();
 		const clients: FakeClient[] = [];
-
-		const service = Object.assign(Object.create(DiscordService.prototype), {
-			runtime,
-			defaultAccountId: "default",
-			_loginFailed: false,
-			timeouts: [] as ReturnType<typeof setTimeout>[],
-			createDiscordJsClient: () => {
-				const client = makeFakeClient(true);
-				clients.push(client);
-				return client;
-			},
-			setupEventListenersForAccount: vi.fn(),
-			onReadyForAccount: vi.fn().mockResolvedValue(undefined),
-			syncLegacyDefaultAliases: vi.fn(),
-		}) as unknown as DiscordService & {
-			attemptDiscordLogin: (
-				state: DiscordAccountClientState,
-				token: string,
-				attempt: number,
-				resolve: () => void,
-				reject: (error: unknown) => void,
-			) => void;
-			timeouts: ReturnType<typeof setTimeout>[];
-		};
-
+		const service = makeService(runtime, () => {
+			const client = makeFakeClient({ kind: "succeed" });
+			clients.push(client);
+			return client;
+		});
 		const state = makeState("default");
+
 		await new Promise<void>((resolve, reject) => {
-			service.attemptDiscordLogin(state, "bot-token", 0, resolve, reject);
+			service.attemptDiscordLogin(state, "bot-token", 0, resolve, reject, 0);
 		});
 
 		expect(clients.length).toBe(1);
 		expect(service.timeouts.length).toBe(0);
+		expect(state.loginRetryTimer).toBeUndefined();
 		expect(runtime.logger.warn).not.toHaveBeenCalled();
+		expect(runtime.reportError).not.toHaveBeenCalled();
 	});
 });

--- a/plugins/plugin-discord/account-client-pool.ts
+++ b/plugins/plugin-discord/account-client-pool.ts
@@ -27,6 +27,10 @@ export interface DiscordAccountClientState {
 	// Pending initial-login retry, tracked so `stop()` can cancel an in-flight
 	// backoff and the ClientReady handler can clear a superseded retry.
 	loginRetryTimer?: ReturnType<typeof setTimeout>;
+	// Cancels the armed retry: clears `loginRetryTimer` and settles the
+	// account's ready promise with a typed abort so awaiting callers cannot
+	// hang on a stopped service. Set only while a retry timer is armed.
+	cancelLoginRetry?: () => void;
 	// Wall-clock of the last login-failure heartbeat, used to throttle the Warn
 	// heartbeat while the account is stuck retrying.
 	lastLoginHeartbeatAt?: number;

--- a/plugins/plugin-discord/service.ts
+++ b/plugins/plugin-discord/service.ts
@@ -14,6 +14,7 @@ import {
 	type Character,
 	type Content,
 	createUniqueUuid,
+	ElizaError,
 	type EventPayload,
 	getConnectorAdminWhitelist,
 	type IAgentRuntime,
@@ -201,15 +202,59 @@ type DiscordAccountServiceFacade = IDiscordService &
 
 // Initial-login retry schedule. discord.js only auto-reconnects once a gateway
 // session exists, so a transient failure of the FIRST `client.login()` is
-// otherwise terminal — the process stays "active" but deaf (#15855). We retry
-// the initial connect with capped exponential backoff (base doubles per
-// attempt, clamped) and keep retrying indefinitely until a session is
-// established; the network coming back is the only success condition.
+// otherwise terminal — the process stays "active" but deaf (#15855). Transient
+// transport failures retry the initial connect with capped exponential backoff
+// (base doubles per attempt, clamped) until a session is established;
+// authentication/configuration failures are classified terminal (#15968) and
+// stop the loop — retrying an invalid token or disallowed intent never succeeds.
 const DISCORD_LOGIN_RETRY_BASE_MS = 1_000;
 const DISCORD_LOGIN_RETRY_MAX_MS = 60_000;
 // While an account is stuck in the failed state, warn at most this often so the
 // retry storm surfaces as an observable heartbeat without flooding the log.
 const DISCORD_LOGIN_HEARTBEAT_MIN_INTERVAL_MS = 30_000;
+
+// Terminal initial-login failures a retry can never fix. discord.js surfaces
+// them in two shapes: `DiscordjsError`s carrying a string `code`
+// (`DiscordjsErrorCodes` — a 401 from the gateway-info fetch is coerced to
+// `TokenInvalid` inside discord.js), and plain `Error`s thrown by @discordjs/ws
+// for the unrecoverable gateway close codes (4004 authentication failed,
+// 4010–4014 shard/API-version/intent misconfiguration) which carry only these
+// exact messages — message identity is the only classification handle
+// @discordjs/ws exposes for them (see its WebSocketShard close-code switch).
+const DISCORD_TERMINAL_LOGIN_ERROR_CODES: ReadonlySet<string> = new Set([
+	"TokenInvalid",
+	"TokenMissing",
+	"DisallowedIntents",
+	"InvalidIntents",
+	"ShardingRequired",
+]);
+const DISCORD_TERMINAL_LOGIN_ERROR_MESSAGES: ReadonlySet<string> = new Set([
+	"Authentication failed",
+	"Invalid shard",
+	"Sharding is required",
+	"Used an invalid API version",
+	"Used invalid intents",
+	"Used disallowed intents",
+]);
+
+function isTerminalDiscordLoginError(error: unknown): boolean {
+	if (!(error instanceof Error)) {
+		return false;
+	}
+	const code = (error as { code?: unknown }).code;
+	if (
+		typeof code === "string" &&
+		DISCORD_TERMINAL_LOGIN_ERROR_CODES.has(code)
+	) {
+		return true;
+	}
+	// A REST 401 (DiscordAPIError / HTTPError `status`) that reaches here
+	// uncoerced is still an invalid-credential failure.
+	if ((error as { status?: unknown }).status === 401) {
+		return true;
+	}
+	return DISCORD_TERMINAL_LOGIN_ERROR_MESSAGES.has(error.message);
+}
 
 // Forward Content.metadata onto the persisted Memory (e.g. `transient: true`
 // for orchestrator status posts). Plain-object guard so arrays/instances don't leak through.
@@ -532,6 +577,11 @@ export class DiscordService extends Service implements IDiscordService {
 	voiceManager?: VoiceManager;
 	private channelDebouncer?: ChannelDebouncer;
 	private _loginFailed = false;
+	// Bumped by `stop()` before any teardown. Login attempts capture the value
+	// when the sequence starts and every settle path re-checks it, so a login
+	// rejection, gateway error, or ready event landing after stop cannot create
+	// a client or arm a retry timer on an orphaned account state (#15968).
+	private lifecycleGeneration = 0;
 	private timeouts: ReturnType<typeof setTimeout>[] = [];
 	public clientReadyPromise: Promise<void> | null = null;
 	/**
@@ -1453,12 +1503,20 @@ export class DiscordService extends Service implements IDiscordService {
 		state.voiceManager = new VoiceManager(facade, this.runtime);
 		state.messageManager = new MessageManager(facade, this.runtime);
 
-		// Initial login now retries with backoff instead of settling terminal on
-		// a transient transport failure (#15855). The promise resolves on the
-		// first successful ClientReady (any attempt) and only rejects on a
-		// terminal post-ready onReady failure — never on a login rejection.
+		// Initial login retries transient transport failures with backoff instead
+		// of settling terminal (#15855). The promise resolves on the first
+		// successful ClientReady (any attempt) and rejects on a terminal
+		// authentication/configuration failure, a post-ready onReady failure, or
+		// service stop (#15968) — never on a transient login rejection.
 		state.clientReadyPromise = new Promise<void>((resolve, reject) => {
-			this.attemptDiscordLogin(state, account.token, 0, resolve, reject);
+			this.attemptDiscordLogin(
+				state,
+				account.token,
+				0,
+				resolve,
+				reject,
+				this.lifecycleGeneration,
+			);
 		});
 
 		state.clientReadyPromise.catch((error) => {
@@ -1480,14 +1538,22 @@ export class DiscordService extends Service implements IDiscordService {
 
 	/**
 	 * Drives one initial-login attempt for an account and re-arms the next on
-	 * failure. discord.js destroys the client when `login()` rejects, so each
-	 * attempt binds a fresh client (created here once the prior one was torn
-	 * down), re-attaches the gateway listeners, and races ClientReady against the
-	 * login rejection / gateway Error. Success resolves the ready promise and
-	 * clears the failed state; a transient failure discards the client and
-	 * schedules `attempt + 1` after a capped-exponential backoff, keeping the
-	 * connector self-healing instead of running deaf-but-active (#15855). Once
-	 * ClientReady fires, discord.js owns reconnection — this loop stops.
+	 * transient failure. discord.js destroys the client when `login()` rejects,
+	 * so each attempt binds a fresh client (created here once the prior one was
+	 * torn down), re-attaches the gateway listeners, and races ClientReady
+	 * against the login rejection / gateway Error. Success resolves the ready
+	 * promise and clears the failed state; a transient transport failure
+	 * discards the client and schedules `attempt + 1` after a capped-exponential
+	 * backoff, keeping the connector self-healing instead of running
+	 * deaf-but-active (#15855); a terminal authentication/configuration failure
+	 * rejects with a typed `ElizaError` and reports to the owner instead of
+	 * retrying forever (#15968). Once ClientReady fires, discord.js owns
+	 * reconnection — this loop stops.
+	 *
+	 * `generation` is the service lifecycle generation captured when the login
+	 * sequence started. `stop()` bumps it before tearing anything down, so the
+	 * entry check and every settle path abort on a stale value instead of
+	 * resurrecting the stopped connector.
 	 */
 	private attemptDiscordLogin(
 		state: DiscordAccountClientState,
@@ -1495,7 +1561,12 @@ export class DiscordService extends Service implements IDiscordService {
 		attempt: number,
 		resolve: () => void,
 		reject: (error: unknown) => void,
+		generation: number,
 	): void {
+		if (generation !== this.lifecycleGeneration) {
+			reject(this.loginAbortedError(state, attempt));
+			return;
+		}
 		if (!state.client) {
 			state.client = this.createDiscordJsClient();
 		}
@@ -1509,7 +1580,7 @@ export class DiscordService extends Service implements IDiscordService {
 		// one attempt — settle exactly once so we never both resolve and retry.
 		let settled = false;
 
-		const scheduleRetry = (error: unknown): void => {
+		const failAttempt = (error: unknown): void => {
 			if (settled) {
 				return;
 			}
@@ -1530,14 +1601,58 @@ export class DiscordService extends Service implements IDiscordService {
 				);
 			});
 			state.client = null;
+			if (generation !== this.lifecycleGeneration) {
+				// The failure settled after stop(): the pool is torn down, so settle
+				// the ready promise instead of arming a timer whose callback would
+				// recreate a client on the orphaned state.
+				reject(this.loginAbortedError(state, attempt, error));
+				return;
+			}
+			if (isTerminalDiscordLoginError(error)) {
+				const terminal = new ElizaError(
+					`Discord login for account ${state.accountId} failed terminally: ${
+						error instanceof Error ? error.message : String(error)
+					} — fix the bot token / privileged-intent configuration; retrying cannot recover this`,
+					{
+						code: "DISCORD_LOGIN_TERMINAL",
+						cause: error,
+						severity: "fatal",
+						context: { accountId: state.accountId, attempt: attempt + 1 },
+					},
+				);
+				// Diagnostic boundary (#12263): nothing on the boot path awaits the
+				// ready promise, so surface the dead account to RECENT_ERRORS and
+				// owner escalation instead of failing silently.
+				this.runtime.reportError("discord:login", terminal, {
+					accountId: state.accountId,
+				});
+				reject(terminal);
+				return;
+			}
 			const delayMs = this.computeLoginBackoffMs(attempt);
 			this.emitLoginFailureHeartbeat(state, error, attempt, delayMs);
+			// One tracked handle per account, cleared when it fires and cancelable
+			// by stop() — deliberately NOT appended to the service-wide `timeouts`
+			// array, which would retain every fired handle for the whole outage.
 			const timer = setTimeout(() => {
 				state.loginRetryTimer = undefined;
-				this.attemptDiscordLogin(state, token, attempt + 1, resolve, reject);
+				state.cancelLoginRetry = undefined;
+				this.attemptDiscordLogin(
+					state,
+					token,
+					attempt + 1,
+					resolve,
+					reject,
+					generation,
+				);
 			}, delayMs);
 			state.loginRetryTimer = timer;
-			this.timeouts.push(timer);
+			state.cancelLoginRetry = () => {
+				clearTimeout(timer);
+				state.loginRetryTimer = undefined;
+				state.cancelLoginRetry = undefined;
+				reject(this.loginAbortedError(state, attempt, error));
+			};
 		};
 
 		client.once(Events.ClientReady, async (readyClient) => {
@@ -1548,6 +1663,24 @@ export class DiscordService extends Service implements IDiscordService {
 			if (state.loginRetryTimer) {
 				clearTimeout(state.loginRetryTimer);
 				state.loginRetryTimer = undefined;
+				state.cancelLoginRetry = undefined;
+			}
+			if (generation !== this.lifecycleGeneration) {
+				// Ready raced stop(): tear the client down and settle instead of
+				// running onReady side effects on a stopped service.
+				state.client?.destroy().catch((destroyError) => {
+					// error-policy:J6 best-effort teardown after stop
+					this.runtime.logger.debug(
+						`Discord client teardown after post-stop ready for account ${state.accountId}: ${
+							destroyError instanceof Error
+								? destroyError.message
+								: String(destroyError)
+						}`,
+					);
+				});
+				state.client = null;
+				reject(this.loginAbortedError(state, attempt));
+				return;
 			}
 			state.loginFailed = false;
 			state.lastLoginHeartbeatAt = undefined;
@@ -1574,11 +1707,29 @@ export class DiscordService extends Service implements IDiscordService {
 					error instanceof Error ? error.message : String(error)
 				}`,
 			);
-			scheduleRetry(error);
+			failAttempt(error);
 		});
 		client.login(token).catch((error) => {
-			scheduleRetry(error);
+			failAttempt(error);
 		});
+	}
+
+	// Typed settle for a login sequence interrupted by service stop; `cause`
+	// carries the failure that was in flight when the stop landed, when any.
+	private loginAbortedError(
+		state: DiscordAccountClientState,
+		attempt: number,
+		cause?: unknown,
+	): ElizaError {
+		return new ElizaError(
+			`Discord initial login aborted for account ${state.accountId}: service stopped`,
+			{
+				code: "DISCORD_LOGIN_ABORTED",
+				severity: "ephemeral",
+				context: { accountId: state.accountId, attempt: attempt + 1 },
+				...(cause !== undefined ? { cause } : {}),
+			},
+		);
 	}
 
 	// Capped exponential backoff for the initial-login retry loop: the delay
@@ -3749,11 +3900,19 @@ export class DiscordService extends Service implements IDiscordService {
 	 */
 	public async stop(): Promise<void> {
 		this.runtime.logger.info("Stopping Discord service");
+		// Invalidate every in-flight login attempt BEFORE any teardown: a login
+		// rejection, gateway error, or ready event settling after this line sees
+		// a stale generation and cannot create a client or arm a retry timer on
+		// the orphaned account state (#15968).
+		this.lifecycleGeneration += 1;
 		this.timeouts.forEach(clearTimeout);
 		this.timeouts = [];
 
 		const states = this.accountPool.list();
 		for (const state of states) {
+			// Cancel a pending backoff retry and settle its ready promise so
+			// awaiting callers cannot hang on a stopped service.
+			state.cancelLoginRetry?.();
 			state.channelDebouncer?.destroy();
 			state.channelDebouncer = undefined;
 		}


### PR DESCRIPTION
Fixes #15968. Addresses the part-1 regressions of #15855's fix (#15940), found in post-merge review: the initial-login retry loop retried terminal failures forever, retained every fired timer handle, and had no stop guard.

## What changed

`plugins/plugin-discord/service.ts`, `account-client-pool.ts`:

1. **Terminal-failure classification.** `isTerminalDiscordLoginError` classifies authentication/configuration failures a retry can never fix: `DiscordjsError` codes (`TokenInvalid`, `TokenMissing`, `DisallowedIntents`, `InvalidIntents`, `ShardingRequired`), raw REST 401 `status`, and the exact plain-`Error` messages @discordjs/ws emits for the unrecoverable gateway close codes 4004/4010–4014 ("Authentication failed", "Used disallowed intents", … — verified against the vendored discord.js 14.26.4 / @discordjs/ws sources; message identity is the only handle that layer exposes). Terminal failures reject the account ready promise with a typed `ElizaError` (`DISCORD_LOGIN_TERMINAL`, `severity: "fatal"`, `cause` preserved) and are raised through `runtime.reportError("discord:login", …)` so the dead account reaches RECENT_ERRORS / owner escalation instead of looping backoff forever. Transient transport failures keep the existing capped-exponential retry and throttled connected-but-deaf heartbeat.

2. **Timer hygiene.** Retry timers are no longer appended to the service-wide `timeouts` array (which retained every fired handle for the whole outage — that array stays, it is still used by slash-command interaction timeouts). Each account tracks exactly one armed handle in `state.loginRetryTimer` plus a `state.cancelLoginRetry` closure; both are cleared when the timer fires, when ready lands, or when canceled.

3. **Stop-generation guard.** `stop()` bumps a service `lifecycleGeneration` as its first act and cancels each account's armed retry (settling that account's ready promise with a typed `DISCORD_LOGIN_ABORTED` rejection so `await state.clientReadyPromise` callers cannot hang). Every login attempt captures the generation at sequence start and re-checks it at attempt entry and at every settle path — a login rejection, gateway error, or ClientReady landing after `stop()` settles the promise typed and can no longer create a client or arm a timer on the orphaned account state.

All kept catches are annotated (`error-policy:J6` best-effort teardown); no empty catches, no fabricated defaults; ratchet clean.

## Tests

`plugins/plugin-discord/__tests__/login-retry.test.ts` — 11 tests driving the real `attemptDiscordLogin` / `computeLoginBackoffMs` / `emitLoginFailureHeartbeat` / `stop()` code under vitest fake timers against a deterministic fake discord.js client (only heavy gateway collaborators — event wiring, onReady backfill, legacy aliasing, voice teardown — are stubbed; the unit under test is never mocked). New adversarial coverage: invalid token terminal (typed rejection + `reportError` + zero retries over 10 simulated minutes), privileged-intent terminal via login rejection and via the gateway `Error` event, an 8-failure outage holding exactly one tracked timer handle with the service-wide array untouched, `stop()` during backoff (timer canceled, ready settles typed, pool cleared, no post-stop login), a login rejection landing after `stop()` (no timer, no client, typed abort with the in-flight failure as `cause`), and a late ClientReady after `stop()` (no `onReadyForAccount`, no resurrection). The #15855 transient-recovery path and heartbeat assertions are preserved.

## Evidence

| Row | Status |
| --- | --- |
| Focused tests | 11/11 pass (transcript below) |
| Full plugin suite | 48 files / 304 tests pass |
| Typecheck | `bun run --cwd plugins/plugin-discord typecheck` clean |
| Lint | biome check clean on the three changed files |
| Error-policy ratchet | `bun run audit:error-policy-ratchet` — "no new fallback-slop in touched files" |
| Live Discord trajectory | N/A — exercising a real terminal login (invalid token / disallowed privileged intent) requires a live Discord bot token plus a bot with deliberately broken intent configuration; the repo has no keyless harness for the Discord gateway. The deterministic suite drives the real retry/stop code against the exact error shapes verified in the vendored discord.js 14.26.4 / @discordjs/ws sources. |
| Screenshots / video | N/A — backend connector lifecycle change, no UI surface |

<details>
<summary>Focused test transcript (vitest, fake timers)</summary>

```
✓ DiscordService initial-login retry (#15855, #15968) > retries a transient login failure with backoff and eventually reaches ready 39ms
✓ DiscordService initial-login retry (#15855, #15968) > keeps exactly one tracked retry handle across a long transient outage 7ms
✓ DiscordService initial-login retry (#15855, #15968) > classifies an invalid token as terminal: typed rejection, owner report, no retry 11ms
✓ DiscordService initial-login retry (#15855, #15968) > classifies a privileged-intent gateway rejection as terminal 2ms
✓ DiscordService initial-login retry (#15855, #15968) > treats a terminal gateway Error event as terminal too 9ms
✓ DiscordService initial-login retry (#15855, #15968) > stop() during backoff cancels the pending retry and settles the ready promise 8ms
✓ DiscordService initial-login retry (#15855, #15968) > a login rejection landing after stop() cannot arm a timer or create a client 5ms
✓ DiscordService initial-login retry (#15855, #15968) > a ClientReady landing after stop() does not resurrect the connector 4ms
✓ DiscordService initial-login retry (#15855, #15968) > computes capped exponential backoff per attempt 4ms
✓ DiscordService initial-login retry (#15855, #15968) > throttles the failure heartbeat to at most one per interval 7ms
✓ DiscordService initial-login retry (#15855, #15968) > does not schedule a retry when the first login succeeds 1ms

Test Files  1 passed (1)
     Tests  11 passed (11)
```

Full plugin suite:

```
Test Files  48 passed (48)
     Tests  304 passed (304)
  Duration  25.71s
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Discord login retry runtime path has no user-facing UI surface.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - Discord login retry runtime path has no user-facing UI surface.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - connector retry lifecycle change exercised by automated tests, not a visual workflow.

<!-- evidence-row:backend-logs -->
- [x] [16022](https://github.com/elizaOS/eliza/pull/16022)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - Discord login retry lifecycle does not alter prompt/model behavior.

<!-- evidence-row:domain-artifacts -->
- [x] [16022](https://github.com/elizaOS/eliza/pull/16022)
