### PR TITLE
fix(ci): require LCOV for every executable changed source

### DIFF
--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -2,8 +2,11 @@ name: coverage-gate
 
 # SOC2 CC4.1 — track unit-test coverage on changed files. ENFORCED (issue #9943):
 # a PR that changes source under packages/plugins/apps must change at least one
-# unit test that can emit coverage, and changed source files that appear in LCOV
-# must clear the line-coverage floor. Docs-only PRs do not spend coverage time.
+# unit test that can emit coverage. Every surviving changed executable source
+# must appear in LCOV and clear the line-coverage floor; an LCOV-present LF:0
+# type-only module is satisfied, while declarations and deleted files are not
+# coverage targets. Source covered only by e2e/live lanes still needs a focused
+# unit test in this gate. Docs-only PRs do not spend coverage time.
 # A test-only PR (changed tests, no changed source) executes its changed tests —
 # gating the run steps on changed *source* let such PRs go vacuously green with
 # the new test never running (#15849); the per-file floor simply has no source

--- a/.github/workflows/develop-pr.yml
+++ b/.github/workflows/develop-pr.yml
@@ -58,6 +58,11 @@ jobs:
       - name: Test-integrity audit self-test
         run: node packages/scripts/lint-test-integrity.self-test.mjs
 
+      - name: Changed-file coverage classifier self-tests
+        run: |
+          node scripts/security/coverage-changed-files.self-test.mjs
+          node scripts/security/coverage-gate.self-test.mjs
+
       # View→action ratchet (#14369): every builtin-view on-screen mutation
       # must map to a registered agent action (chat twin), and the generated
       # action catalog must reflect the real registered surface. Dependency-free

--- a/scripts/security/coverage-changed-files.self-test.mjs
+++ b/scripts/security/coverage-changed-files.self-test.mjs
@@ -1,12 +1,5 @@
 #!/usr/bin/env node
-/**
- * Regression checks for the changed-file enumerator the coverage gate consumes.
- * Each case builds a throwaway git repo whose history reproduces a real gate
- * hazard, runs the actual coverage-changed-files.sh against it, and asserts the
- * emitted GITHUB_OUTPUT sections. The two-dot regression (issue #15845) is
- * pinned by first proving a plain `BASE..HEAD` diff *would* drag a develop-side
- * file in, then asserting the script's three-dot diff does not.
- */
+/** Exercises changed-source/test classification against a real throwaway Git history. */
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
@@ -86,6 +79,7 @@ try {
 
   // Merge-base commit: the point the feature branch forks from.
   write(dir, "packages/demo/src/base.ts", "export const base = 1;\n");
+  write(dir, "packages/demo/src/deleted.ts", "export const removed = 1;\n");
   git(dir, "add", "-A");
   git(dir, "commit", "-q", "-m", "base");
   const mergeBase = git(dir, "rev-parse", "HEAD");
@@ -98,7 +92,13 @@ try {
 
   // Feature branch forks from the merge-base and adds its own source + tests.
   git(dir, "checkout", "-q", "-b", "feature", mergeBase);
+  rmSync(join(dir, "packages/demo/src/deleted.ts"));
   write(dir, "packages/demo/src/feature.ts", "export const f = 1;\n");
+  write(
+    dir,
+    "packages/demo/src/public.d.ts",
+    "export interface PublicType { id: string }\n",
+  );
   write(
     dir,
     "plugins/plugin-demo/vitest.config.ts",
@@ -188,6 +188,14 @@ try {
       `vitest config leaked into changed source: ${out.files.join(",")}`,
     );
   });
+
+  assertCase(
+    "deleted source and declaration files are not LCOV-enforced",
+    () => {
+      assert.ok(!out.files.includes("packages/demo/src/deleted.ts"));
+      assert.ok(!out.files.includes("packages/demo/src/public.d.ts"));
+    },
+  );
 } finally {
   rmSync(dir, { recursive: true, force: true });
 }

--- a/scripts/security/coverage-changed-files.sh
+++ b/scripts/security/coverage-changed-files.sh
@@ -40,8 +40,12 @@ is_excluded_test() {
 }
 
 changed_source() {
-  git diff --name-only "$MERGE_BASE" "$HEAD" -- '*.ts' '*.tsx' '*.js' '*.jsx' \
-    | grep -vE '(^|/)(__tests__|test|tests)/|[.](test|spec)[.](ts|tsx|js|jsx|mjs)$|(^|/)vitest[.]config[.](ts|js|mts|mjs|cts|cjs)$' || true
+  git diff --name-only --diff-filter=ACMRT "$MERGE_BASE" "$HEAD" -- \
+    '*.ts' '*.tsx' '*.js' '*.jsx' \
+    | grep -vE '(^|/)(__tests__|test|tests)/|[.]d[.]ts$|[.](test|spec)[.](ts|tsx|js|jsx|mjs)$|(^|/)vitest[.]config[.](ts|js|mts|mjs|cts|cjs)$' \
+    | while IFS= read -r file; do
+        [ -f "$file" ] && echo "$file"
+      done || true
 }
 
 changed_tests() {

--- a/scripts/security/coverage-gate.awk
+++ b/scripts/security/coverage-gate.awk
@@ -65,6 +65,7 @@ function path_matches_lcov(current_path, changed_path,    current_len, changed_l
       if (path_matches_lcov(current, cf)) { matched = cf; break }
     }
     if (matched != "") {
+      matched_map[matched] = 1
       changed_count++
       changed_sum += pct
       printf "  %6.2f%% %s\n", pct, matched
@@ -75,25 +76,33 @@ function path_matches_lcov(current_path, changed_path,    current_len, changed_l
 }
 
 END {
+  missing_count = 0
+  for (f in changed_map) {
+    if (!(f in matched_map)) {
+      printf "  MISSING: %s\n", f
+      missing_count++
+    }
+  }
+
   if (changed_count == 0) {
     print "no changed files matched the LCOV report"
-    if (changed != "" && ENVIRON["COVERAGE_GATE_ENFORCE"] == "1") {
-      print "coverage gate FAILED (changed source missing from LCOV)"
-      exit 1
-    }
-    exit 0
+  } else {
+    avg = changed_sum / changed_count
+    printf "\nchanged files: %d, mean coverage: %.2f%%, threshold: %d%%\n", \
+      changed_count, avg, threshold
   }
-  avg = changed_sum / changed_count
-  printf "\nchanged files: %d, mean coverage: %.2f%%, threshold: %d%%\n", \
-    changed_count, avg, threshold
 
-  fail = 0
+  fail = missing_count > 0
   for (f in below) {
     printf "  BELOW: %s (%.2f%%)\n", f, below[f]
     fail = 1
   }
   if (fail && ENVIRON["COVERAGE_GATE_ENFORCE"] == "1") {
-    print "coverage gate FAILED (enforcement enabled)"
+    if (missing_count > 0) {
+      print "coverage gate FAILED (changed source missing from LCOV)"
+    } else {
+      print "coverage gate FAILED (enforcement enabled)"
+    }
     exit 1
   }
   if (fail) {

--- a/scripts/security/coverage-gate.awk
+++ b/scripts/security/coverage-gate.awk
@@ -42,11 +42,13 @@ function path_matches_lcov(current_path, changed_path,    current_len, changed_l
   current = $0
   lines_found = 0
   lines_hit = 0
+  saw_lf = 0
 }
 
 /^LF:/ {
   sub(/^LF:/, "", $0)
   lines_found = $0 + 0
+  saw_lf = 1
 }
 
 /^LH:/ {
@@ -55,28 +57,32 @@ function path_matches_lcov(current_path, changed_path,    current_len, changed_l
 }
 
 /^end_of_record/ {
-  if (lines_found > 0) {
-    pct = (lines_hit / lines_found) * 100
-    # Check if this file is in changed list. LCOV paths may be absolute while
-    # the changed list is repo-relative, so accept only exact path-segment
-    # suffixes; raw substring matching lets foo.ts pass via foo.tsx.
-    matched = ""
-    matched_len = 0
-    for (cf in changed_map) {
-      if (path_matches_lcov(current, cf) && length(cf) > matched_len) {
-        matched = cf
-        matched_len = length(cf)
-      }
+  # LCOV paths may be absolute while the changed list is repo-relative. Pick
+  # the longest exact path-segment suffix so overlapping paths are deterministic.
+  matched = ""
+  matched_len = 0
+  for (cf in changed_map) {
+    if (path_matches_lcov(current, cf) && length(cf) > matched_len) {
+      matched = cf
+      matched_len = length(cf)
     }
-    if (matched != "") {
-      matched_map[matched] = 1
+  }
+  if (matched != "" && saw_lf) {
+    matched_map[matched] = 1
+    matched_record_count++
+    if (lines_found > 0) {
+      pct = (lines_hit / lines_found) * 100
       changed_count++
       changed_sum += pct
       printf "  %6.2f%% %s\n", pct, matched
       if (pct + 0 < threshold + 0) below[matched] = pct
+    } else {
+      # A present LF:0 record is a type-only module with no executable lines;
+      # requiring a percentage would make its coverage target impossible.
+      printf "  TYPE-ONLY: %s (LF:0)\n", matched
     }
   }
-  current = ""; lines_found = 0; lines_hit = 0
+  current = ""; lines_found = 0; lines_hit = 0; saw_lf = 0
 }
 
 END {
@@ -88,8 +94,10 @@ END {
     }
   }
 
-  if (changed_count == 0) {
+  if (matched_record_count == 0) {
     print "no changed files matched the LCOV report"
+  } else if (changed_count == 0) {
+    print "changed LCOV records contain no executable lines"
   } else {
     avg = changed_sum / changed_count
     printf "\nchanged files: %d, mean coverage: %.2f%%, threshold: %d%%\n", \

--- a/scripts/security/coverage-gate.awk
+++ b/scripts/security/coverage-gate.awk
@@ -61,8 +61,12 @@ function path_matches_lcov(current_path, changed_path,    current_len, changed_l
     # the changed list is repo-relative, so accept only exact path-segment
     # suffixes; raw substring matching lets foo.ts pass via foo.tsx.
     matched = ""
+    matched_len = 0
     for (cf in changed_map) {
-      if (path_matches_lcov(current, cf)) { matched = cf; break }
+      if (path_matches_lcov(current, cf) && length(cf) > matched_len) {
+        matched = cf
+        matched_len = length(cf)
+      }
     }
     if (matched != "") {
       matched_map[matched] = 1

--- a/scripts/security/coverage-gate.self-test.mjs
+++ b/scripts/security/coverage-gate.self-test.mjs
@@ -84,6 +84,18 @@ try {
     assert.equal(result.status, 1, result.stdout);
     assert.match(result.stdout, /changed source missing from LCOV/);
   });
+
+  assertGate("fails when any changed source is absent from LCOV", () => {
+    const covered = "packages/demo/src/covered.ts";
+    const missing = "packages/demo/src/missing.ts";
+    const lcov = writeLcov(dir, covered);
+    const result = runGate({ changed: `${covered}\n${missing}`, lcov });
+
+    assert.equal(result.status, 1, result.stdout);
+    assert.match(result.stdout, /100\.00% packages\/demo\/src\/covered\.ts/);
+    assert.match(result.stdout, /MISSING: packages\/demo\/src\/missing\.ts/);
+    assert.match(result.stdout, /changed source missing from LCOV/);
+  });
 } finally {
   rmSync(dir, { recursive: true, force: true });
 }

--- a/scripts/security/coverage-gate.self-test.mjs
+++ b/scripts/security/coverage-gate.self-test.mjs
@@ -26,11 +26,12 @@ function writeLcov(dir, sourcePath, found = 2, hit = 2) {
 }
 
 function runGate({ changed, lcov, enforce = true, threshold = 50 }) {
+  const changedArgument = changed.replaceAll("\\", "\\\\").replaceAll("\n", "\\n");
   return spawnSync(
     "awk",
     [
       "-v",
-      `changed=${changed}`,
+      `changed=${changedArgument}`,
       "-v",
       `threshold=${threshold}`,
       "-f",

--- a/scripts/security/coverage-gate.self-test.mjs
+++ b/scripts/security/coverage-gate.self-test.mjs
@@ -1,10 +1,5 @@
 #!/usr/bin/env node
-/**
- * Regression checks for the changed-file LCOV matcher used by the coverage
- * gate. The gate compares repo-relative changed paths with LCOV paths that may
- * be absolute, so these cases pin the exact path-boundary behavior rather than
- * a permissive substring match.
- */
+/** Verifies exact changed-path attribution, missing-source failure, and type-only LCOV handling. */
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
@@ -43,7 +38,9 @@ function writeLcovRecords(dir, sourcePaths) {
 }
 
 function runGate({ changed, lcov, enforce = true, threshold = 50 }) {
-  const changedArgument = changed.replaceAll("\\", "\\\\").replaceAll("\n", "\\n");
+  const changedArgument = changed
+    .replaceAll("\\", "\\\\")
+    .replaceAll("\n", "\\n");
   return spawnSync(
     "awk",
     [
@@ -127,6 +124,19 @@ try {
     assert.equal(result.status, 0, result.stdout);
     assert.match(result.stdout, /100\.00% src\/foo\.ts/);
     assert.match(result.stdout, /100\.00% packages\/demo\/src\/foo\.ts/);
+    assert.doesNotMatch(result.stdout, /MISSING:/);
+  });
+
+  assertGate("accepts an LCOV-present type-only source with LF zero", () => {
+    const source = "packages/demo/src/types.ts";
+    const lcov = writeLcov(dir, source, 0, 0);
+    const result = runGate({ changed: source, lcov });
+
+    assert.equal(result.status, 0, result.stdout);
+    assert.match(
+      result.stdout,
+      /TYPE-ONLY: packages\/demo\/src\/types[.]ts \(LF:0\)/,
+    );
     assert.doesNotMatch(result.stdout, /MISSING:/);
   });
 } finally {

--- a/scripts/security/coverage-gate.self-test.mjs
+++ b/scripts/security/coverage-gate.self-test.mjs
@@ -25,6 +25,23 @@ function writeLcov(dir, sourcePath, found = 2, hit = 2) {
   return file;
 }
 
+function writeLcovRecords(dir, sourcePaths) {
+  const file = join(dir, "lcov.info");
+  writeFileSync(
+    file,
+    sourcePaths
+      .flatMap((sourcePath) => [
+        `SF:${sourcePath}`,
+        "LF:2",
+        "LH:2",
+        "end_of_record",
+      ])
+      .concat("")
+      .join("\n"),
+  );
+  return file;
+}
+
 function runGate({ changed, lcov, enforce = true, threshold = 50 }) {
   const changedArgument = changed.replaceAll("\\", "\\\\").replaceAll("\n", "\\n");
   return spawnSync(
@@ -96,6 +113,21 @@ try {
     assert.match(result.stdout, /100\.00% packages\/demo\/src\/covered\.ts/);
     assert.match(result.stdout, /MISSING: packages\/demo\/src\/missing\.ts/);
     assert.match(result.stdout, /changed source missing from LCOV/);
+  });
+
+  assertGate("prefers the longest matching changed path", () => {
+    const rootPath = "src/foo.ts";
+    const nestedPath = "packages/demo/src/foo.ts";
+    const lcov = writeLcovRecords(dir, [
+      `/workspace/eliza/${rootPath}`,
+      `/workspace/eliza/${nestedPath}`,
+    ]);
+    const result = runGate({ changed: `${rootPath}\n${nestedPath}`, lcov });
+
+    assert.equal(result.status, 0, result.stdout);
+    assert.match(result.stdout, /100\.00% src\/foo\.ts/);
+    assert.match(result.stdout, /100\.00% packages\/demo\/src\/foo\.ts/);
+    assert.doesNotMatch(result.stdout, /MISSING:/);
   });
 } finally {
   rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
Relates to #13620. Supersedes closed #16006 after its adversarial review found LF:0 and deleted-file failure classes.

## Summary

The coverage gate now requires every surviving changed executable source to have an LCOV record and at least 50% line coverage. It handles non-executable targets explicitly:

- a present LCOV record with LF:0 is recognized as type-only and satisfies the gate without an impossible percentage;
- declaration files and deleted paths are excluded from changed-source targets;
- overlapping repo-relative/absolute paths select the longest exact path-segment suffix;
- any other changed source missing from LCOV fails, including source currently exercised only by e2e/live lanes. The workflow documents that policy and requires a focused unit test.

Both the changed-file classifier and LCOV matcher self-tests now run in the Develop PR Test Integrity job, so these rules cannot drift without a required check failing.

## Verification

Exact head: 9b834361e8724cedf3ec0406b611452bcae512a4
Base: 5e1da4085f79fe3899287f34ffb252cb4ee136c0

- coverage-gate self-test: 7/7 passed, including covered+missing, overlapping suffixes, and LF:0.
- changed-file classifier self-test: 5/5 passed, including deleted source and declarations.
- focused coverage workflow/contract suite: 21/21 passed.
- ci-workflow-dedup-contract: passed.
- actionlint: passed for coverage-gate.yml and develop-pr.yml.
- YAML parse, bash -n, Biome, and git diff --check: passed.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI classification only; no rendered surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - CI classification only; no rendered surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - non-interactive CI gate.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend runtime path; the executable self-tests are the verification surface.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or network path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the change produces CI pass/fail status and persists no domain state.