### PR TITLE
fix(openrouter): scope Anthropic cache validation and reject malformed breakpoint TTLs

### DIFF
--- a/plugins/plugin-openrouter/__tests__/anthropic-cache.shape.test.ts
+++ b/plugins/plugin-openrouter/__tests__/anthropic-cache.shape.test.ts
@@ -4,9 +4,12 @@
  * options (Fix 3a), segmented-user-content breakpoints with validated shapes and capping
  * (Fix 3b/3c), the cacheSystem:false opt-out, verbatim survival of caller-supplied
  * providerOptions (openrouter + arbitrary keys) alongside injected cacheControl and
- * multi-breakpoint stamping (#15825), and the explicit boundary failure when a
- * caller-supplied cacheControl is malformed (#15825, no silent drop). AI SDK and provider
- * are mocked — no network calls, deterministic string fixtures.
+ * multi-breakpoint stamping (#15825), the explicit boundary failure when a
+ * caller-supplied cacheControl or cacheBreakpoint is malformed (#15825/#15966 — typed
+ * ElizaError, no silent drop or normalization, no provider request sent), and the
+ * provider-scoping contract that non-Anthropic routes never parse or reject the unused
+ * anthropic namespace (#15966). AI SDK and provider are mocked — no network calls,
+ * deterministic string fixtures.
  */
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -187,35 +190,31 @@ describe("Anthropic cache injection — segmented user content", () => {
     expect(content[1]?.providerOptions).toBeUndefined();
   });
 
-  it("filters out cacheBreakpoints with invalid shapes without crashing", async () => {
+  it("stamps a validated 5m TTL breakpoint onto its segment", async () => {
     const { generateText } = mockModules();
     const { handleTextLarge } = await import("../models/text");
 
     await handleTextLarge(createRuntime(), {
-      prompt: "text",
-      promptSegments: [{ content: "text", stable: true }],
+      prompt: "s0s1",
+      promptSegments: [
+        { content: "s0", stable: true },
+        { content: "s1", stable: false },
+      ],
       providerOptions: {
         anthropic: {
-          cacheBreakpoints: [
-            { segmentIndex: "not-a-number", cacheControl: { type: "ephemeral" } },
-            { segmentIndex: 0, cacheControl: { type: "invalid" } },
-            null,
-            42,
-          ],
+          cacheBreakpoints: [{ segmentIndex: 0, cacheControl: { type: "ephemeral", ttl: "5m" } }],
         },
       },
     } as never);
 
     const call = generateText.mock.calls[0][0] as Record<string, unknown>;
     const messages = call.messages as Array<Record<string, unknown>>;
-    // No valid breakpoints after filtering → user content blocks carry no cacheControl
-    const userMsg = messages?.[1];
-    if (userMsg) {
-      const content = userMsg.content as Array<Record<string, unknown>>;
-      for (const block of content) {
-        expect(block.providerOptions).toBeUndefined();
-      }
-    }
+    const content = messages?.[1]?.content as Array<Record<string, unknown>>;
+    const cc0 = (content[0]?.providerOptions as Record<string, unknown>)?.anthropic as
+      | Record<string, unknown>
+      | undefined;
+    expect(cc0?.cacheControl).toEqual({ type: "ephemeral", ttl: "5m" });
+    expect(content[1]?.providerOptions).toBeUndefined();
   });
 
   it("caps applied breakpoints at maxBreakpoints", async () => {
@@ -326,8 +325,8 @@ describe("Anthropic cache injection — caller providerOptions survive verbatim"
 });
 
 describe("Anthropic cache injection — malformed cacheControl fails loudly", () => {
-  it("throws when caller-supplied cacheControl has an unsupported type", async () => {
-    mockModules();
+  it("throws a typed error and sends no request when cacheControl has an unsupported type", async () => {
+    const { generateText } = mockModules();
     const { handleTextLarge } = await import("../models/text");
 
     await expect(
@@ -335,11 +334,15 @@ describe("Anthropic cache injection — malformed cacheControl fails loudly", ()
         prompt: "hello",
         providerOptions: { anthropic: { cacheControl: { type: "persistent" } } },
       } as never)
-    ).rejects.toThrow(/cacheControl/);
+    ).rejects.toMatchObject({
+      name: "ElizaError",
+      code: "OPENROUTER_INVALID_CACHE_CONTROL",
+    });
+    expect(generateText).not.toHaveBeenCalled();
   });
 
-  it("throws when cacheControl is present but not an object", async () => {
-    mockModules();
+  it("throws and sends no request when cacheControl is present but not an object", async () => {
+    const { generateText } = mockModules();
     const { handleTextLarge } = await import("../models/text");
 
     await expect(
@@ -348,10 +351,11 @@ describe("Anthropic cache injection — malformed cacheControl fails loudly", ()
         providerOptions: { anthropic: { cacheControl: "ephemeral" } },
       } as never)
     ).rejects.toThrow(/cacheControl/);
+    expect(generateText).not.toHaveBeenCalled();
   });
 
-  it("throws when cacheControl.ttl is an unsupported value", async () => {
-    mockModules();
+  it("throws and sends no request when cacheControl.ttl is an unsupported value", async () => {
+    const { generateText } = mockModules();
     const { handleTextLarge } = await import("../models/text");
 
     await expect(
@@ -360,6 +364,214 @@ describe("Anthropic cache injection — malformed cacheControl fails loudly", ()
         providerOptions: { anthropic: { cacheControl: { type: "ephemeral", ttl: "2h" } } },
       } as never)
     ).rejects.toThrow(/ttl/);
+    expect(generateText).not.toHaveBeenCalled();
+  });
+});
+
+describe("Anthropic cache breakpoints — malformed shapes fail loudly (#15966)", () => {
+  // Shared fixture: an Anthropic-routed prompt-only call with segments, so any
+  // supplied breakpoints are actually consumed by the segmented-content path.
+  function segmentedParams(anthropic: Record<string, unknown>) {
+    return {
+      prompt: "s0s1",
+      promptSegments: [
+        { content: "s0", stable: true },
+        { content: "s1", stable: false },
+      ],
+      providerOptions: { anthropic },
+    } as never;
+  }
+
+  async function expectBreakpointRejection(anthropic: Record<string, unknown>, pattern: RegExp) {
+    // Fresh registry per invocation so tests that assert several shapes in one
+    // body bind the handler to the mock actually being inspected.
+    vi.resetModules();
+    const { generateText } = mockModules();
+    const { handleTextLarge } = await import("../models/text");
+
+    const call = handleTextLarge(createRuntime(), segmentedParams(anthropic));
+    await expect(call).rejects.toMatchObject({
+      name: "ElizaError",
+      code: "OPENROUTER_INVALID_CACHE_BREAKPOINT",
+    });
+    await expect(call).rejects.toThrow(pattern);
+    // No provider request may be sent after a malformed consumed option.
+    expect(generateText).not.toHaveBeenCalled();
+  }
+
+  it("throws when cacheBreakpoints is present but not an array", async () => {
+    await expectBreakpointRejection({ cacheBreakpoints: "not-an-array" }, /expected an array/);
+  });
+
+  it("throws when a breakpoint entry is null", async () => {
+    await expectBreakpointRejection({ cacheBreakpoints: [null] }, /cacheBreakpoints\[0\]/);
+  });
+
+  it("throws when a breakpoint entry is a primitive", async () => {
+    await expectBreakpointRejection({ cacheBreakpoints: [42] }, /cacheBreakpoints\[0\]/);
+  });
+
+  it("throws when segmentIndex is not a number", async () => {
+    await expectBreakpointRejection(
+      { cacheBreakpoints: [{ segmentIndex: "not-a-number", cacheControl: { type: "ephemeral" } }] },
+      /segmentIndex/
+    );
+  });
+
+  it("throws when segmentIndex is negative", async () => {
+    await expectBreakpointRejection(
+      { cacheBreakpoints: [{ segmentIndex: -1, cacheControl: { type: "ephemeral" } }] },
+      /segmentIndex/
+    );
+  });
+
+  it("throws when segmentIndex is a non-integer number", async () => {
+    await expectBreakpointRejection(
+      { cacheBreakpoints: [{ segmentIndex: 0.5, cacheControl: { type: "ephemeral" } }] },
+      /segmentIndex/
+    );
+  });
+
+  it("throws when a breakpoint cacheControl is missing", async () => {
+    await expectBreakpointRejection({ cacheBreakpoints: [{ segmentIndex: 0 }] }, /cacheControl/);
+  });
+
+  it("throws when a breakpoint cacheControl type is not ephemeral", async () => {
+    await expectBreakpointRejection(
+      { cacheBreakpoints: [{ segmentIndex: 0, cacheControl: { type: "invalid" } }] },
+      /cacheControl/
+    );
+  });
+
+  it("throws when a breakpoint TTL is an unsupported duration", async () => {
+    await expectBreakpointRejection(
+      { cacheBreakpoints: [{ segmentIndex: 0, cacheControl: { type: "ephemeral", ttl: "2h" } }] },
+      /ttl/
+    );
+  });
+
+  it("throws when a breakpoint TTL is numeric", async () => {
+    await expectBreakpointRejection(
+      { cacheBreakpoints: [{ segmentIndex: 0, cacheControl: { type: "ephemeral", ttl: 300 } }] },
+      /ttl/
+    );
+  });
+
+  it("throws on a mixed array instead of applying only the valid entries", async () => {
+    await expectBreakpointRejection(
+      {
+        cacheBreakpoints: [
+          { segmentIndex: 0, cacheControl: { type: "ephemeral" } },
+          { segmentIndex: 1, cacheControl: { type: "ephemeral", ttl: "30s" } },
+        ],
+      },
+      /cacheBreakpoints\[1\]/
+    );
+  });
+
+  it("validates entries past the maxBreakpoints cap instead of dropping them unseen", async () => {
+    await expectBreakpointRejection(
+      {
+        maxBreakpoints: 1,
+        cacheBreakpoints: [
+          { segmentIndex: 0, cacheControl: { type: "ephemeral" } },
+          { segmentIndex: 1, cacheControl: { type: "broken" } },
+        ],
+      },
+      /cacheBreakpoints\[1\]/
+    );
+  });
+
+  it("throws when maxBreakpoints is present but malformed", async () => {
+    await expectBreakpointRejection(
+      {
+        maxBreakpoints: -1,
+        cacheBreakpoints: [{ segmentIndex: 0, cacheControl: { type: "ephemeral" } }],
+      },
+      /maxBreakpoints/
+    );
+    await expectBreakpointRejection(
+      {
+        maxBreakpoints: 1.5,
+        cacheBreakpoints: [{ segmentIndex: 0, cacheControl: { type: "ephemeral" } }],
+      },
+      /maxBreakpoints/
+    );
+  });
+
+  it("accepts maxBreakpoints: 0 as an explicit opt-out of segment stamping", async () => {
+    const { generateText } = mockModules();
+    const { handleTextLarge } = await import("../models/text");
+
+    await handleTextLarge(
+      createRuntime(),
+      segmentedParams({
+        maxBreakpoints: 0,
+        cacheBreakpoints: [{ segmentIndex: 0, cacheControl: { type: "ephemeral" } }],
+      })
+    );
+
+    const call = generateText.mock.calls[0][0] as Record<string, unknown>;
+    const messages = call.messages as Array<Record<string, unknown>>;
+    const content = messages?.[1]?.content;
+    // With zero slots the prompt collapses to the unsegmented single text block —
+    // valid breakpoints are validated but none are stamped.
+    if (Array.isArray(content)) {
+      for (const block of content as Array<Record<string, unknown>>) {
+        expect(block.providerOptions).toBeUndefined();
+      }
+    }
+  });
+});
+
+describe("Non-Anthropic routes skip Anthropic cache validation (#15966)", () => {
+  const NON_ANTHROPIC = { OPENROUTER_LARGE_MODEL: "google/gemini-2.5-flash" };
+
+  it("does not reject a malformed anthropic.cacheControl and still sends the request", async () => {
+    const { generateText } = mockModules();
+    const { handleTextLarge } = await import("../models/text");
+
+    await handleTextLarge(createRuntime(NON_ANTHROPIC), {
+      prompt: "hello",
+      providerOptions: { anthropic: { cacheControl: { type: "persistent", ttl: "2h" } } },
+    } as never);
+
+    expect(generateText).toHaveBeenCalledTimes(1);
+    const call = generateText.mock.calls[0][0] as Record<string, unknown>;
+    // No Anthropic message-level injection happens on this route; the unused
+    // namespace passes through unparsed rather than failing the request.
+    expect(call.prompt).toBe("hello");
+    expect((call.providerOptions as Record<string, unknown>).anthropic).toEqual({
+      cacheControl: { type: "persistent", ttl: "2h" },
+    });
+  });
+
+  it("does not reject malformed anthropic.cacheBreakpoints and applies no segment stamping", async () => {
+    const { generateText } = mockModules();
+    const { handleTextLarge } = await import("../models/text");
+
+    await handleTextLarge(createRuntime(NON_ANTHROPIC), {
+      prompt: "s0s1",
+      promptSegments: [
+        { content: "s0", stable: true },
+        { content: "s1", stable: false },
+      ],
+      providerOptions: {
+        anthropic: {
+          maxBreakpoints: "broken",
+          cacheBreakpoints: [null, { segmentIndex: -1, cacheControl: { type: "nope" } }],
+        },
+      },
+    } as never);
+
+    expect(generateText).toHaveBeenCalledTimes(1);
+    const call = generateText.mock.calls[0][0] as Record<string, unknown>;
+    expect(call.prompt).toBe("s0s1");
+    if (Array.isArray(call.messages)) {
+      for (const msg of call.messages as Array<Record<string, unknown>>) {
+        expect(msg?.providerOptions).toBeUndefined();
+      }
+    }
   });
 });
 

--- a/plugins/plugin-openrouter/models/text.ts
+++ b/plugins/plugin-openrouter/models/text.ts
@@ -24,6 +24,9 @@
  * injected on the user content blocks corresponding to the cacheBreakpoints from
  * the provider cache plan. This extends the single system-message breakpoint to
  * up to three more user-content breakpoints under Anthropic's four-block cap.
+ * Anthropic-local cache options are parsed — and strictly validated — only when
+ * the selected model routes to Anthropic; malformed cacheControl or breakpoint
+ * shapes throw a typed ElizaError instead of being silently dropped (#15966).
  */
 import type {
   GenerateTextParams,
@@ -246,10 +249,12 @@ function isAnthropicModel(modelName: string): boolean {
 type WireProviderOptions = NonNullable<SystemModelMessage["providerOptions"]>;
 
 function anthropicCacheProviderOptions(cacheControl: AnthropicCacheControl): WireProviderOptions {
+  // Inputs reach here only through the boundary validators below, so the TTL is
+  // already known-good; this is a key-or-omit materialization, never a coercion.
   return {
     anthropic: {
       cacheControl:
-        cacheControl.ttl === "5m" || cacheControl.ttl === "1h"
+        cacheControl.ttl !== undefined
           ? { type: "ephemeral", ttl: cacheControl.ttl }
           : { type: "ephemeral" },
     },
@@ -331,15 +336,58 @@ function getRuntimeCacheControl(runtime: IAgentRuntime): AnthropicCacheControl {
 
 type AnthropicCacheBreakpoint = { segmentIndex: number; cacheControl: AnthropicCacheControl };
 
-function isAnthropicCacheBreakpoint(value: unknown): value is AnthropicCacheBreakpoint {
-  return (
-    isRecord(value) &&
-    typeof value.segmentIndex === "number" &&
-    Number.isInteger(value.segmentIndex) &&
-    value.segmentIndex >= 0 &&
-    isRecord(value.cacheControl) &&
-    value.cacheControl.type === "ephemeral"
-  );
+// Breakpoints are caller-requested cache placements: silently filtering a
+// malformed entry (the pre-#15966 behavior) emits a request the caller believes
+// is cached when it is not. Every entry is validated and any unsupported shape
+// throws before a provider request can be built.
+function parseAnthropicCacheBreakpoint(value: unknown, index: number): AnthropicCacheBreakpoint {
+  if (!isRecord(value)) {
+    throw new ElizaError(
+      `Invalid anthropic.cacheBreakpoints[${index}]: expected { segmentIndex, cacheControl } object`,
+      {
+        code: "OPENROUTER_INVALID_CACHE_BREAKPOINT",
+        context: { index, breakpoint: value },
+        severity: "fatal",
+      }
+    );
+  }
+  const segmentIndex = value.segmentIndex;
+  if (typeof segmentIndex !== "number" || !Number.isInteger(segmentIndex) || segmentIndex < 0) {
+    throw new ElizaError(
+      `Invalid anthropic.cacheBreakpoints[${index}].segmentIndex: expected a non-negative integer`,
+      {
+        code: "OPENROUTER_INVALID_CACHE_BREAKPOINT",
+        context: { index, segmentIndex },
+        severity: "fatal",
+      }
+    );
+  }
+  const cacheControl = value.cacheControl;
+  if (!isRecord(cacheControl) || cacheControl.type !== "ephemeral") {
+    throw new ElizaError(
+      `Invalid anthropic.cacheBreakpoints[${index}].cacheControl: expected { type: 'ephemeral' }`,
+      {
+        code: "OPENROUTER_INVALID_CACHE_BREAKPOINT",
+        context: { index, cacheControl },
+        severity: "fatal",
+      }
+    );
+  }
+  const ttl = cacheControl.ttl;
+  if (ttl !== undefined && ttl !== "5m" && ttl !== "1h") {
+    throw new ElizaError(
+      `Invalid anthropic.cacheBreakpoints[${index}].cacheControl.ttl: expected '5m' or '1h'`,
+      {
+        code: "OPENROUTER_INVALID_CACHE_BREAKPOINT",
+        context: { index, ttl },
+        severity: "fatal",
+      }
+    );
+  }
+  return {
+    segmentIndex,
+    cacheControl: { type: "ephemeral", ...(ttl === "5m" || ttl === "1h" ? { ttl } : {}) },
+  };
 }
 
 function readAnthropicCacheBreakpoints(
@@ -347,8 +395,37 @@ function readAnthropicCacheBreakpoints(
   maxBreakpoints: number
 ): AnthropicCacheBreakpoint[] {
   const raw = anthropicOptions?.cacheBreakpoints;
-  if (!Array.isArray(raw)) return [];
-  return raw.filter(isAnthropicCacheBreakpoint).slice(0, maxBreakpoints);
+  if (raw === undefined) return [];
+  if (!Array.isArray(raw)) {
+    throw new ElizaError("Invalid anthropic.cacheBreakpoints: expected an array", {
+      code: "OPENROUTER_INVALID_CACHE_BREAKPOINT",
+      context: { cacheBreakpoints: raw },
+      severity: "fatal",
+    });
+  }
+  // Validate every supplied entry before applying the slot cap so a malformed
+  // entry past the cap still fails loudly instead of being dropped unseen.
+  const breakpoints = raw.map((entry, index) => parseAnthropicCacheBreakpoint(entry, index));
+  return breakpoints.slice(0, maxBreakpoints);
+}
+
+// The slot cap defaults to Anthropic's three user-content breakpoints (the
+// fourth block is the system message). Absent means "use the default"; a
+// present-but-malformed value is a broken cache plan and must not be silently
+// replaced by the default.
+function readAnthropicMaxBreakpoints(
+  anthropicOptions: Record<string, unknown> | undefined
+): number {
+  const raw = anthropicOptions?.maxBreakpoints;
+  if (raw === undefined) return 3;
+  if (typeof raw !== "number" || !Number.isInteger(raw) || raw < 0) {
+    throw new ElizaError("Invalid anthropic.maxBreakpoints: expected a non-negative integer", {
+      code: "OPENROUTER_INVALID_CACHE_BREAKPOINT",
+      context: { maxBreakpoints: raw },
+      severity: "fatal",
+    });
+  }
+  return raw;
 }
 
 /**
@@ -615,9 +692,13 @@ function buildGenerateParams(
   const anthropicOptions = isRecord(rawProviderOptions?.anthropic)
     ? rawProviderOptions.anthropic
     : undefined;
-  const anthropicCacheControl =
-    readAnthropicCacheControl(anthropicOptions) ??
-    (isAnthropic ? getRuntimeCacheControl(runtime) : undefined);
+  // Anthropic-local cache options are parsed — and therefore rejected — only
+  // when the selected model actually routes to Anthropic. A non-Anthropic route
+  // neither injects nor consumes this namespace, so its contents pass through
+  // unparsed rather than failing an unrelated request (#15966).
+  const anthropicCacheControl = isAnthropic
+    ? (readAnthropicCacheControl(anthropicOptions) ?? getRuntimeCacheControl(runtime))
+    : undefined;
   const anthropicCacheSystem = anthropicOptions?.cacheSystem !== false;
   const cacheSystemMessage =
     isAnthropic && anthropicCacheSystem
@@ -626,15 +707,11 @@ function buildGenerateParams(
   const shouldInjectMessageLevelCache = Boolean(cacheSystemMessage);
 
   // Collect cacheBreakpoints for per-segment user-content injection.
-  // Only used on the prompt-only path (no messages) together with promptSegments.
-  // maxBreakpoints caps the number of slots used (Anthropic allows up to 3 user-content).
-  const maxBreakpoints =
-    typeof anthropicOptions?.maxBreakpoints === "number" &&
-    Number.isInteger(anthropicOptions.maxBreakpoints) &&
-    anthropicOptions.maxBreakpoints >= 0
-      ? anthropicOptions.maxBreakpoints
-      : 3;
-  const cacheBreakpoints = readAnthropicCacheBreakpoints(anthropicOptions, maxBreakpoints);
+  // Only used on the prompt-only path (no messages) together with promptSegments,
+  // and only parsed on Anthropic routes (same scoping as cacheControl above).
+  const cacheBreakpoints = isAnthropic
+    ? readAnthropicCacheBreakpoints(anthropicOptions, readAnthropicMaxBreakpoints(anthropicOptions))
+    : [];
   const promptSegments = Array.isArray(
     (paramsWithAttachments as { promptSegments?: unknown }).promptSegments
   )


### PR DESCRIPTION
Fixes #15966

## What

Two fail-fast boundary gaps left on `develop` after #15937:

1. **Provider-scoped validation.** `readAnthropicCacheControl` ran before the `isAnthropic` routing guard, so a non-Anthropic OpenRouter model threw `OPENROUTER_INVALID_CACHE_CONTROL` for a malformed option in the unrelated `anthropic` namespace. Anthropic-local cache options (`cacheControl`, `cacheBreakpoints`, `maxBreakpoints`) are now parsed — and therefore rejected — only when the selected model routes to Anthropic. On non-Anthropic routes the unused namespace passes through unparsed (existing passthrough behavior, now covered by tests).
2. **Strict breakpoint validation.** `isAnthropicCacheBreakpoint` accepted unsupported TTLs (e.g. `"2h"`) which `anthropicCacheProviderOptions` then silently stripped to a bare ephemeral marker, and malformed entries were silently removed by `.filter(...)`. Every caller-supplied breakpoint is now runtime-validated (integer non-negative `segmentIndex`, `type: "ephemeral"`, TTL absent/`5m`/`1h`); any unsupported shape throws a typed `ElizaError` (`OPENROUTER_INVALID_CACHE_BREAKPOINT`, with `context`) **before any provider request is built**. Entries past the `maxBreakpoints` cap are still validated before the slice. `maxBreakpoints` gets the same treatment: absent → documented default 3; present-but-malformed → throw, no silent replacement.

Files:
- `plugins/plugin-openrouter/models/text.ts`
- `plugins/plugin-openrouter/__tests__/anthropic-cache.shape.test.ts`

## Fails-before / passes-after

New suite run against `origin/develop`'s `models/text.ts` (pre-fix): **14 failed | 16 passed** — every new case fails, covering non-Anthropic scoping, unsupported breakpoint TTLs, malformed breakpoint objects, mixed valid/invalid arrays, non-array `cacheBreakpoints`, malformed `maxBreakpoints`, and past-the-cap validation. Against this branch: **30/30 pass**; full plugin unit suite **72/72**; `tsgo --noEmit` clean; `biome check` clean; `bun run audit:error-policy-ratchet` clean.

<details>
<summary>Fails-before transcript (new tests vs develop text.ts)</summary>

```
× throws when cacheBreakpoints is present but not an array
× throws when a breakpoint entry is null
× throws when a breakpoint entry is a primitive
× throws when segmentIndex is not a number
× throws when segmentIndex is negative
× throws when segmentIndex is a non-integer number
× throws when a breakpoint cacheControl is missing
× throws when a breakpoint cacheControl type is not ephemeral
× throws when a breakpoint TTL is an unsupported duration
× throws when a breakpoint TTL is numeric
× throws on a mixed array instead of applying only the valid entries
× validates entries past the maxBreakpoints cap instead of dropping them unseen
× throws when maxBreakpoints is present but malformed
× does not reject a malformed anthropic.cacheControl and still sends the request
Test Files  1 failed (1)
Tests  14 failed | 16 passed (30)
```
</details>

<details>
<summary>Passes-after transcript (full plugin suite)</summary>

```
bun run --cwd plugins/plugin-openrouter test
 Test Files  7 passed (7)
      Tests  72 passed (72)

bun run --cwd plugins/plugin-openrouter typecheck
$ tsgo --noEmit -p tsconfig.json   (clean)

bunx biome check plugins/plugin-openrouter/models/text.ts \
  plugins/plugin-openrouter/__tests__/anthropic-cache.shape.test.ts
Checked 2 files. No fixes applied.

bun run audit:error-policy-ratchet
[error-policy-ratchet] no new fallback-slop in touched files
```
</details>

## Wire-level proof — real AI SDK + real `@openrouter/ai-sdk-provider` over real HTTP

No mocked `ai` SDK: the real plugin path serialized real HTTP requests to a local capture sink via the documented `OPENROUTER_BASE_URL` override. This proves the actual wire body and that **no provider request is sent after a malformed consumed option**:

<details>
<summary>Capture transcript (request bodies + typed failures)</summary>

```
=== CASE A: anthropic route, valid TTLs (5m top-level, 1h breakpoint) ===
[wire] request body:
{
  "model": "anthropic/claude-sonnet-4.5",
  "max_tokens": 8192,
  "messages": [
    { "role": "system", "content": [
      { "type": "text", "text": "You are a terse assistant.",
        "cache_control": { "type": "ephemeral", "ttl": "5m" } } ] },
    { "role": "user", "content": [
      { "type": "text", "text": "stable-context ",
        "cache_control": { "type": "ephemeral", "ttl": "1h" } },
      { "type": "text", "text": "dynamic-question" } ] }
  ],
  "promptCacheKey": "evidence-15966"
}

=== CASE B: anthropic route, malformed breakpoint ttl '2h' ===
[throw] ElizaError OPENROUTER_INVALID_CACHE_BREAKPOINT -
  Invalid anthropic.cacheBreakpoints[0].cacheControl.ttl: expected '5m' or '1h'
  context: {"index":0,"ttl":"2h"}
[wire] requests after malformed option: 1 (was 1) -> NO request sent

=== CASE B2: anthropic route, malformed top-level cacheControl type ===
[throw] ElizaError OPENROUTER_INVALID_CACHE_CONTROL -
  Invalid anthropic.cacheControl: expected { type: 'ephemeral' }
[wire] requests: 1 -> NO request sent

=== CASE C: non-anthropic route (gemini), same malformed anthropic namespace ===
[result] text: ok (local sink)
[wire] requests: 2 (request WAS sent for non-anthropic route)
[wire] cache_control present in body? false
```
</details>

## Evidence

| Evidence | Status |
| --- | --- |
| Real-LLM trajectory (live OpenRouter/Anthropic cache round-trip with cache read/write usage + finish reason) | N/A — no `OPENROUTER_API_KEY` exists in this environment (searched env, `.env` files, eliza state dir, vault artifacts; only the `sk-or-v1-test` placeholder). The plugin's live lane (`vitest.live.config.ts`) is key-gated and not run in CI. In its place: the wire-level capture above drives the **real** `ai` SDK + `@openrouter/ai-sdk-provider` over real HTTP, proving the exact `cache_control` bodies OpenRouter receives, the typed malformed-option failures, and that zero requests are emitted after a rejected option. |
| Backend structured logs | N/A — model-handler library code; failures surface as thrown `ElizaError` (code + context shown in the capture transcript), not log lines. |
| Frontend console/network logs, screenshots, video | N/A — no UI surface; provider plugin internals only. |
| Domain artifacts | Wire request bodies + typed error objects in the transcripts above, reviewed by hand. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-row:before-screenshots -->
- [ ] N/A - OpenRouter provider cache validation has no user-facing UI surface.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - OpenRouter provider cache validation has no user-facing UI surface.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - provider request validation change exercised by automated tests, not a visual workflow.

<!-- evidence-row:backend-logs -->
- [x] [backend-logs](https://github.com/elizaOS/eliza/pull/16025)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - request-shape validation does not alter prompt/model trajectory behavior.

<!-- evidence-row:domain-artifacts -->
- [x] [domain-artifacts](https://github.com/elizaOS/eliza/pull/16025)
