### PR TITLE
feat(corpus): add resumable Gmail collector

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -899,10 +899,12 @@
       },
       "dependencies": {
         "@elizaos/core": "workspace:*",
+        "@elizaos/plugin-google": "workspace:*",
         "zod": "^4.4.3",
       },
       "devDependencies": {
         "@types/node": "^24.0.0",
+        "googleapis": "^169.0.0",
       },
     },
     "packages/docs": {

--- a/packages/corpus-tools/AGENTS.md
+++ b/packages/corpus-tools/AGENTS.md
@@ -9,6 +9,10 @@ work.
 
 - Raw, owner, or intermediate corpus data never enters git. Use ignored
   `data/`; commit only synthetic fixtures under `fixtures/`.
+- Gmail collection consumes the account-scoped `@elizaos/plugin-google`
+  service. OAuth/token resolution stays in that plugin; this package owns only
+  local monthly shards, `.state/gmail-<account>.json` checkpoints, and the
+  canonical manifest.
 - `src/schema.ts` is the boundary contract for collectors and scrub stages.
   Widen additively and update validators/tests with every schema change.
 - Mappers are compatibility adapters, not schema owners. Keep platform-specific

--- a/packages/corpus-tools/CLAUDE.md
+++ b/packages/corpus-tools/CLAUDE.md
@@ -9,6 +9,10 @@ work.
 
 - Raw, owner, or intermediate corpus data never enters git. Use ignored
   `data/`; commit only synthetic fixtures under `fixtures/`.
+- Gmail collection consumes the account-scoped `@elizaos/plugin-google`
+  service. OAuth/token resolution stays in that plugin; this package owns only
+  local monthly shards, `.state/gmail-<account>.json` checkpoints, and the
+  canonical manifest.
 - `src/schema.ts` is the boundary contract for collectors and scrub stages.
   Widen additively and update validators/tests with every schema change.
 - Mappers are compatibility adapters, not schema owners. Keep platform-specific

--- a/packages/corpus-tools/README.md
+++ b/packages/corpus-tools/README.md
@@ -9,6 +9,31 @@ Raw and intermediate owner data belongs under `packages/corpus-tools/data/`,
 which is ignored by the repo-wide `**/data/` rule. Only synthetic fixtures under
 `fixtures/` are committed.
 
+## Gmail collection
+
+`collectGmailCorpusFromRuntime()` consumes the existing account-scoped
+`GoogleWorkspaceService`; it never reads OAuth tokens or introduces a second
+credential path. Call it from a running agent that already loaded
+`@elizaos/plugin-google`:
+
+```ts
+import { collectGmailCorpusFromRuntime } from "@elizaos/corpus-tools";
+
+const result = await collectGmailCorpusFromRuntime(runtime, {
+  accounts: [{ accountId: "work" }, { accountId: "home" }],
+  outputDir: "packages/corpus-tools/data/raw",
+});
+```
+
+The default query is the frozen corpus window from `CORPUS_CUTOFF_ISO` through
+`CORPUS_ANCHOR_ISO`. Each account is paginated to exhaustion with Gmail read
+retries, full bodies, and attachment hashes. Bytes remain optional. Monthly
+shards are rewritten atomically and de-duplicated by Gmail message id before the
+page checkpoint advances, so a crash between shard and checkpoint writes is
+safe to resume. Completed checkpoints make reruns no-ops; changing the query or
+account identity fails fast instead of silently mixing collections. Delete the
+local checkpoint only when intentionally starting a new full collection.
+
 ## CLI
 
 ```bash

--- a/packages/corpus-tools/package.json
+++ b/packages/corpus-tools/package.json
@@ -24,10 +24,12 @@
   },
   "dependencies": {
     "@elizaos/core": "workspace:*",
+    "@elizaos/plugin-google": "workspace:*",
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@types/node": "^24.0.0"
+    "@types/node": "^24.0.0",
+    "googleapis": "^169.0.0"
   },
   "elizaos": {
     "scripts": {

--- a/packages/corpus-tools/src/collectors/gmail.integration.test.ts
+++ b/packages/corpus-tools/src/collectors/gmail.integration.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Drives the production googleapis client and corpus collector through a local
+ * HTTP Gmail seam. Live OAuth/account proof remains a separate owner-gated run.
+ */
+
+import { mkdtemp } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  type GoogleAuthResolutionRequest,
+  GoogleWorkspaceService,
+} from "@elizaos/plugin-google";
+import { Auth } from "googleapis";
+import { afterEach, describe, expect, it } from "vitest";
+import { collectGmailCorpus } from "./gmail.ts";
+
+const NOW = new Date("2026-07-05T00:00:00.000Z");
+const originalMockBase = process.env.ELIZA_MOCK_GOOGLE_BASE;
+let server: Server | undefined;
+
+afterEach(async () => {
+  if (originalMockBase === undefined) {
+    delete process.env.ELIZA_MOCK_GOOGLE_BASE;
+  } else {
+    process.env.ELIZA_MOCK_GOOGLE_BASE = originalMockBase;
+  }
+  if (server) {
+    await new Promise<void>((resolve, reject) => {
+      server?.close((error) => (error ? reject(error) : resolve()));
+    });
+    server = undefined;
+  }
+});
+
+describe("Gmail corpus collector HTTP integration", () => {
+  it("uses account OAuth, Gmail pagination, full MIME fetch, and attachment fetch", async () => {
+    const requests: Array<{
+      accountId: string;
+      path: string;
+      query: string;
+    }> = [];
+    let workListAttempts = 0;
+    const attachment = Buffer.from("integration attachment", "utf8");
+    server = createServer((request, response) => {
+      const url = new URL(request.url ?? "/", "http://localhost");
+      const authorization = request.headers.authorization ?? "";
+      const accountId = authorization.replace(/^Bearer\s+/i, "");
+      requests.push({ accountId, path: url.pathname, query: url.search });
+      response.setHeader("content-type", "application/json");
+
+      if (url.pathname.endsWith("/users/me/profile")) {
+        response.end(
+          JSON.stringify({
+            emailAddress: `${accountId}@example.test`,
+            historyId: `profile-${accountId}`,
+          }),
+        );
+        return;
+      }
+      if (url.pathname.endsWith("/users/me/messages")) {
+        if (accountId === "work") {
+          workListAttempts += 1;
+          if (workListAttempts === 1) {
+            response.statusCode = 429;
+            response.end(
+              JSON.stringify({
+                error: { code: 429, message: "quota retry fixture" },
+              }),
+            );
+            return;
+          }
+        }
+        response.end(
+          JSON.stringify({
+            messages: [{ id: `${accountId}-message` }],
+            resultSizeEstimate: 1,
+          }),
+        );
+        return;
+      }
+      const attachmentMatch = url.pathname.match(
+        /\/users\/me\/messages\/([^/]+)\/attachments\/([^/]+)$/,
+      );
+      if (attachmentMatch) {
+        response.end(
+          JSON.stringify({ data: attachment.toString("base64url") }),
+        );
+        return;
+      }
+      const messageMatch = url.pathname.match(
+        /\/users\/me\/messages\/([^/]+)$/,
+      );
+      if (messageMatch) {
+        const messageId = decodeURIComponent(messageMatch[1]);
+        response.end(
+          JSON.stringify({
+            id: messageId,
+            threadId: `${accountId}-thread`,
+            historyId: `${accountId}-history`,
+            internalDate: String(NOW.getTime() - 60_000),
+            labelIds: ["INBOX"],
+            snippet: `Snippet for ${accountId}`,
+            payload: {
+              mimeType: "multipart/mixed",
+              headers: [
+                { name: "Subject", value: `Subject for ${accountId}` },
+                {
+                  name: "From",
+                  value: `Sender <sender-${accountId}@example.test>`,
+                },
+                {
+                  name: "To",
+                  value: `Owner <${accountId}@example.test>`,
+                },
+                { name: "Date", value: "Sun, 05 Jul 2026 00:00:00 GMT" },
+              ],
+              parts: [
+                {
+                  mimeType: "text/plain",
+                  body: {
+                    data: Buffer.from(`Body for ${accountId}`).toString(
+                      "base64url",
+                    ),
+                  },
+                },
+                {
+                  filename: `${accountId}.txt`,
+                  mimeType: "text/plain",
+                  body: {
+                    attachmentId: `${accountId}-attachment`,
+                    size: attachment.byteLength,
+                  },
+                },
+              ],
+            },
+          }),
+        );
+        return;
+      }
+
+      response.statusCode = 404;
+      response.end(JSON.stringify({ error: "not found" }));
+    });
+    await new Promise<void>((resolve, reject) => {
+      server?.listen(0, "127.0.0.1", () => resolve());
+      server?.once("error", reject);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Gmail integration server did not bind a TCP port.");
+    }
+    process.env.ELIZA_MOCK_GOOGLE_BASE = `http://127.0.0.1:${address.port}/`;
+
+    const service = new GoogleWorkspaceService(undefined, {
+      credentialResolver: {
+        getAuthClient: async (request: GoogleAuthResolutionRequest) => {
+          const client = new Auth.OAuth2Client();
+          client.setCredentials({ access_token: request.accountId });
+          return client;
+        },
+      },
+    });
+    const outputDir = await mkdtemp(path.join(tmpdir(), "gmail-http-"));
+    const result = await collectGmailCorpus({
+      source: service,
+      accounts: [{ accountId: "work" }, { accountId: "home" }],
+      outputDir,
+      now: () => NOW,
+    });
+
+    expect(result.manifest.totals.messages).toBe(2);
+    expect(result.accounts).toEqual([
+      expect.objectContaining({ accountId: "work", writtenMessages: 1 }),
+      expect.objectContaining({ accountId: "home", writtenMessages: 1 }),
+    ]);
+    expect(new Set(requests.map((request) => request.accountId))).toEqual(
+      new Set(["work", "home"]),
+    );
+    expect(
+      requests.filter((request) => request.path.endsWith("/users/me/messages")),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          accountId: "work",
+          query: expect.stringContaining("includeSpamTrash=true"),
+        }),
+        expect.objectContaining({
+          accountId: "home",
+          query: expect.stringContaining("includeSpamTrash=true"),
+        }),
+      ]),
+    );
+    expect(workListAttempts).toBe(2);
+    expect(
+      requests.filter((request) => request.path.includes("/attachments/")),
+    ).toHaveLength(2);
+  });
+});

--- a/packages/corpus-tools/src/collectors/gmail.test.ts
+++ b/packages/corpus-tools/src/collectors/gmail.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Exercises Gmail pagination, crash-resume idempotency, multi-account shard
+ * layout, and manifest validation through the collector's source boundary.
+ */
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { ElizaError } from "@elizaos/core";
+import type {
+  GoogleAccountRef,
+  GoogleGmailExportMessage,
+  GoogleGmailMessagePage,
+  GoogleGmailProfile,
+} from "@elizaos/plugin-google";
+import { describe, expect, it, vi } from "vitest";
+import {
+  collectGmailCorpus,
+  collectGmailCorpusFromRuntime,
+  type GmailCorpusSource,
+} from "./gmail.ts";
+
+const NOW = new Date("2026-07-05T00:00:00.000Z");
+
+function message(
+  id: string,
+  account: "work" | "home",
+  offsetMs: number,
+  overrides: Partial<GoogleGmailExportMessage> = {},
+): GoogleGmailExportMessage {
+  const owner = `${account}@example.test`;
+  return {
+    id,
+    threadId: `thread-${id}`,
+    internalDateMs: NOW.getTime() - offsetMs,
+    historyId: `history-${id}`,
+    subject: `Subject ${id}`,
+    from: { email: "sender@example.test", name: "Sender" },
+    to: [{ email: owner, name: "Owner" }],
+    cc: [],
+    snippet: `Snippet ${id}`,
+    bodyText: `Body ${id}`,
+    labelIds: ["INBOX"],
+    headers: {},
+    attachments: [],
+    ...overrides,
+  };
+}
+
+class Source implements GmailCorpusSource {
+  readonly profileCalls = vi.fn();
+  readonly pageCalls = vi.fn();
+  readonly messageCalls = vi.fn();
+  failToken?: string;
+
+  constructor(
+    private readonly pages: Record<
+      string,
+      Record<string, GoogleGmailMessagePage>
+    >,
+    private readonly messages: Record<string, GoogleGmailExportMessage>,
+  ) {}
+
+  async getGmailProfile(params: GoogleAccountRef): Promise<GoogleGmailProfile> {
+    this.profileCalls(params);
+    return {
+      emailAddress: `${params.accountId}@example.test`,
+      historyId: `profile-${params.accountId}`,
+    };
+  }
+
+  async listGmailMessagePage(
+    params: GoogleAccountRef & { pageToken?: string },
+  ): Promise<GoogleGmailMessagePage> {
+    this.pageCalls(params);
+    const token = params.pageToken ?? "first";
+    if (token === this.failToken) {
+      throw new Error(`planned failure at ${token}`);
+    }
+    const page = this.pages[params.accountId]?.[token];
+    if (!page) throw new Error(`missing page ${params.accountId}:${token}`);
+    return page;
+  }
+
+  async getGmailExportMessage(
+    params: GoogleAccountRef & { messageId: string },
+  ): Promise<GoogleGmailExportMessage> {
+    this.messageCalls(params);
+    const found = this.messages[params.messageId];
+    if (!found) throw new Error(`missing message ${params.messageId}`);
+    return found;
+  }
+}
+
+describe("Gmail corpus collector", () => {
+  it("requires the account-scoped Google service on runtime entry", async () => {
+    const collection = collectGmailCorpusFromRuntime(
+      { getService: () => null } as never,
+      {
+        accounts: [{ accountId: "work" }],
+        outputDir: path.join(tmpdir(), "missing-google-service"),
+      },
+    );
+
+    await expect(collection).rejects.toBeInstanceOf(ElizaError);
+    await expect(collection).rejects.toMatchObject({
+      code: "GMAIL_CORPUS_SERVICE_UNAVAILABLE",
+      severity: "fatal",
+    });
+  });
+
+  it("writes two account histories into validated monthly shards", async () => {
+    const outputDir = await mkdtemp(path.join(tmpdir(), "gmail-corpus-"));
+    const source = new Source(
+      {
+        work: {
+          first: { messageIds: ["work-in", "work-out"] },
+        },
+        home: {
+          first: { messageIds: ["home-html", "home-attachment"] },
+        },
+      },
+      {
+        "work-in": message("work-in", "work", 60_000),
+        "work-out": message("work-out", "work", 120_000, {
+          from: { email: "work@example.test", name: "Owner" },
+          to: [{ email: "client@example.test", name: "Client" }],
+          headers: { "In-Reply-To": "work-in" },
+        }),
+        "home-html": message("home-html", "home", 180_000, {
+          bodyText: undefined,
+          bodyHtml: "<p>Hello <strong>home</strong></p>",
+        }),
+        "home-attachment": message("home-attachment", "home", 240_000, {
+          bodyText: "",
+          attachments: [
+            {
+              filename: "receipt.pdf",
+              mimeType: "application/pdf",
+              sha256: "a".repeat(64),
+              bytes: 12,
+            },
+          ],
+        }),
+      },
+    );
+
+    const result = await collectGmailCorpus({
+      source,
+      accounts: [{ accountId: "work" }, { accountId: "home" }],
+      outputDir,
+      now: () => NOW,
+    });
+
+    expect(result.manifest.totals.messages).toBe(4);
+    expect(result.manifest.shards).toHaveLength(2);
+    expect(result.accounts).toEqual([
+      expect.objectContaining({
+        accountId: "work",
+        writtenMessages: 2,
+        completed: true,
+      }),
+      expect.objectContaining({
+        accountId: "home",
+        writtenMessages: 2,
+        completed: true,
+      }),
+    ]);
+    const homeRows = (
+      await readFile(
+        path.join(outputDir, "gmail", "home", "2026-07.jsonl"),
+        "utf8",
+      )
+    )
+      .trim()
+      .split("\n")
+      .map((row) => JSON.parse(row));
+    expect(homeRows).toEqual([
+      expect.objectContaining({ id: "home-attachment", text: "" }),
+      expect.objectContaining({ id: "home-html", text: "Hello home" }),
+    ]);
+    expect(
+      JSON.parse(await readFile(path.join(outputDir, "manifest.json"), "utf8")),
+    ).toEqual(result.manifest);
+  });
+
+  it("resumes at the durable page token without duplicating committed rows", async () => {
+    const outputDir = await mkdtemp(path.join(tmpdir(), "gmail-resume-"));
+    const pages = {
+      work: {
+        first: { messageIds: ["page-one"], nextPageToken: "second" },
+        second: { messageIds: ["page-two"] },
+      },
+    };
+    const messages = {
+      "page-one": message("page-one", "work", 60_000),
+      "page-two": message("page-two", "work", 120_000),
+    };
+    const interrupted = new Source(pages, messages);
+    interrupted.failToken = "second";
+
+    await expect(
+      collectGmailCorpus({
+        source: interrupted,
+        accounts: [{ accountId: "work" }],
+        outputDir,
+        now: () => NOW,
+      }),
+    ).rejects.toThrow("planned failure at second");
+
+    const resumed = new Source(pages, messages);
+    const result = await collectGmailCorpus({
+      source: resumed,
+      accounts: [{ accountId: "work" }],
+      outputDir,
+      now: () => NOW,
+    });
+
+    expect(resumed.pageCalls).toHaveBeenCalledTimes(1);
+    expect(resumed.pageCalls).toHaveBeenCalledWith(
+      expect.objectContaining({ pageToken: "second" }),
+    );
+    expect(resumed.messageCalls).toHaveBeenCalledTimes(1);
+    expect(result.manifest.totals.messages).toBe(2);
+    expect(result.accounts[0]).toMatchObject({
+      processedMessages: 2,
+      writtenMessages: 1,
+      duplicateMessages: 0,
+      completed: true,
+    });
+
+    const completedRerun = new Source({}, {});
+    const rerun = await collectGmailCorpus({
+      source: completedRerun,
+      accounts: [{ accountId: "work" }],
+      outputDir,
+      now: () => NOW,
+    });
+    expect(completedRerun.profileCalls).not.toHaveBeenCalled();
+    expect(completedRerun.pageCalls).not.toHaveBeenCalled();
+    expect(rerun.manifest.totals.messages).toBe(2);
+  });
+
+  it("fails fast when a checkpoint is reused for a different query", async () => {
+    const outputDir = await mkdtemp(path.join(tmpdir(), "gmail-query-"));
+    const source = new Source({ work: { first: { messageIds: [] } } }, {});
+    await collectGmailCorpus({
+      source,
+      accounts: [{ accountId: "work" }],
+      outputDir,
+      query: "after:2025/01/01 before:2026/01/01",
+      now: () => NOW,
+    });
+
+    await expect(
+      collectGmailCorpus({
+        source,
+        accounts: [{ accountId: "work" }],
+        outputDir,
+        query: "after:2024/01/01 before:2026/01/01",
+        now: () => NOW,
+      }),
+    ).rejects.toThrow("different account or query");
+  });
+
+  it("rejects a repeated page token before advancing its checkpoint", async () => {
+    const outputDir = await mkdtemp(path.join(tmpdir(), "gmail-token-"));
+    const source = new Source(
+      {
+        work: {
+          first: { messageIds: ["page-one"], nextPageToken: "repeat" },
+          repeat: { messageIds: ["page-two"], nextPageToken: "repeat" },
+        },
+      },
+      {
+        "page-one": message("page-one", "work", 60_000),
+        "page-two": message("page-two", "work", 120_000),
+      },
+    );
+
+    await expect(
+      collectGmailCorpus({
+        source,
+        accounts: [{ accountId: "work" }],
+        outputDir,
+        now: () => NOW,
+      }),
+    ).rejects.toThrow("repeated page token");
+
+    const checkpoint = JSON.parse(
+      await readFile(path.join(outputDir, ".state", "gmail-work.json"), "utf8"),
+    );
+    expect(checkpoint).toMatchObject({
+      pageToken: "repeat",
+      processedMessages: 1,
+      completed: false,
+    });
+  });
+
+  it("rejects API rows outside the frozen corpus window", async () => {
+    const outputDir = await mkdtemp(path.join(tmpdir(), "gmail-window-"));
+    const source = new Source(
+      { work: { first: { messageIds: ["future"] } } },
+      {
+        future: message("future", "work", -1),
+      },
+    );
+
+    await expect(
+      collectGmailCorpus({
+        source,
+        accounts: [{ accountId: "work" }],
+        outputDir,
+        now: () => NOW,
+      }),
+    ).rejects.toMatchObject({
+      code: "GMAIL_CORPUS_MESSAGE_OUTSIDE_WINDOW",
+      context: { messageId: "future", timestamp: NOW.getTime() + 1 },
+      severity: "fatal",
+    });
+  });
+});

--- a/packages/corpus-tools/src/collectors/gmail.ts
+++ b/packages/corpus-tools/src/collectors/gmail.ts
@@ -1,0 +1,625 @@
+/**
+ * Account-scoped Gmail backfill into canonical monthly corpus shards. The
+ * Google plugin owns OAuth and API DTOs; this module owns resumable pagination,
+ * idempotent local persistence, corpus normalization, and manifest production.
+ * Raw owner mail remains below the caller-provided ignored data directory.
+ */
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { ElizaError, type IAgentRuntime } from "@elizaos/core";
+import type {
+  GoogleAccountRef,
+  GoogleGmailExportMessage,
+  GoogleGmailMessagePage,
+  GoogleGmailProfile,
+} from "@elizaos/plugin-google";
+import { z } from "zod";
+import {
+  CORPUS_ANCHOR_MS,
+  CORPUS_CUTOFF_MS,
+  type CorpusManifest,
+  type CorpusMessage,
+  corpusMessageSchema,
+} from "../schema.ts";
+import {
+  buildCorpusManifest,
+  findCorpusShardFiles,
+  readCorpusShard,
+} from "../validator.ts";
+
+// Gmail interprets yyyy/mm/dd searches in Pacific time. Epoch seconds keep the
+// frozen UTC corpus window exact across owner and runner timezones.
+const DEFAULT_QUERY = `after:${Math.floor(CORPUS_CUTOFF_MS / 1000) - 1} before:${Math.floor(CORPUS_ANCHOR_MS / 1000) + 1}`;
+const DEFAULT_PAGE_SIZE = 500;
+const DEFAULT_FETCH_CONCURRENCY = 8;
+
+const checkpointSchema = z.object({
+  schemaVersion: z.literal(1),
+  accountId: z.string().min(1),
+  ownerEmail: z.string().email(),
+  query: z.string().min(1),
+  pageToken: z.string().min(1).optional(),
+  startHistoryId: z.string().min(1).optional(),
+  completedHistoryId: z.string().min(1).optional(),
+  processedMessages: z.number().int().nonnegative(),
+  completed: z.boolean(),
+  updatedAt: z.string().datetime(),
+});
+
+type GmailCollectorCheckpoint = z.infer<typeof checkpointSchema>;
+
+export interface GmailCorpusSource {
+  getGmailProfile(params: GoogleAccountRef): Promise<GoogleGmailProfile>;
+  listGmailMessagePage(
+    params: GoogleAccountRef & {
+      query: string;
+      pageToken?: string;
+      maxResults?: number;
+      includeSpamTrash?: boolean;
+    },
+  ): Promise<GoogleGmailMessagePage>;
+  getGmailExportMessage(
+    params: GoogleAccountRef & {
+      messageId: string;
+      includeAttachmentData?: boolean;
+    },
+  ): Promise<GoogleGmailExportMessage>;
+}
+
+export interface GmailCorpusAccount {
+  accountId: string;
+  ownerEmail?: string;
+}
+
+export interface CollectGmailCorpusOptions {
+  source: GmailCorpusSource;
+  accounts: GmailCorpusAccount[];
+  outputDir: string;
+  stateDir?: string;
+  query?: string;
+  pageSize?: number;
+  fetchConcurrency?: number;
+  includeAttachmentData?: boolean;
+  now?: () => Date;
+}
+
+export interface GmailCorpusAccountResult {
+  accountId: string;
+  ownerEmail: string;
+  processedMessages: number;
+  writtenMessages: number;
+  duplicateMessages: number;
+  completed: boolean;
+  monthCounts: Record<string, number>;
+}
+
+export interface GmailCorpusCollectionResult {
+  query: string;
+  accounts: GmailCorpusAccountResult[];
+  manifest: CorpusManifest;
+}
+
+export async function collectGmailCorpusFromRuntime(
+  runtime: IAgentRuntime,
+  options: Omit<CollectGmailCorpusOptions, "source">,
+): Promise<GmailCorpusCollectionResult> {
+  const service = runtime.getService("google");
+  if (!isGmailCorpusSource(service)) {
+    throw new ElizaError(
+      "Google Workspace service with Gmail export methods is not loaded.",
+      { code: "GMAIL_CORPUS_SERVICE_UNAVAILABLE", severity: "fatal" },
+    );
+  }
+  return collectGmailCorpus({ ...options, source: service });
+}
+
+export async function collectGmailCorpus(
+  options: CollectGmailCorpusOptions,
+): Promise<GmailCorpusCollectionResult> {
+  if (options.accounts.length < 1) {
+    throw new ElizaError("At least one Gmail account is required.", {
+      code: "GMAIL_CORPUS_ACCOUNTS_REQUIRED",
+      severity: "fatal",
+    });
+  }
+  const accountIds = new Set<string>();
+  for (const account of options.accounts) {
+    assertAccountPathSegment(account.accountId);
+    if (accountIds.has(account.accountId)) {
+      throw new ElizaError(`Duplicate Gmail account ${account.accountId}.`, {
+        code: "GMAIL_CORPUS_DUPLICATE_ACCOUNT",
+        context: { accountId: account.accountId },
+        severity: "fatal",
+      });
+    }
+    accountIds.add(account.accountId);
+  }
+
+  const query = options.query?.trim() || DEFAULT_QUERY;
+  const stateDir = options.stateDir ?? path.join(options.outputDir, ".state");
+  const now = options.now ?? (() => new Date());
+  await fs.mkdir(options.outputDir, { recursive: true });
+  await fs.mkdir(stateDir, { recursive: true });
+  const accountResults: GmailCorpusAccountResult[] = [];
+
+  for (const account of options.accounts) {
+    accountResults.push(
+      await collectAccount({
+        ...options,
+        account,
+        query,
+        stateDir,
+        now,
+      }),
+    );
+  }
+
+  const generatedAt = now().toISOString();
+  const { manifest, issues } = await buildCorpusManifest(
+    options.outputDir,
+    generatedAt,
+  );
+  if (issues.length > 0) {
+    throw new ElizaError(
+      `Gmail collection produced an invalid corpus: ${issues
+        .map((issue) => issue.message)
+        .join("; ")}`,
+      {
+        code: "GMAIL_CORPUS_VALIDATION_FAILED",
+        context: { issueCount: issues.length },
+        severity: "fatal",
+      },
+    );
+  }
+  await writeJsonAtomic(
+    path.join(options.outputDir, "manifest.json"),
+    manifest,
+  );
+  return { query, accounts: accountResults, manifest };
+}
+
+async function collectAccount(
+  options: CollectGmailCorpusOptions & {
+    account: GmailCorpusAccount;
+    query: string;
+    stateDir: string;
+    now: () => Date;
+  },
+): Promise<GmailCorpusAccountResult> {
+  const checkpointPath = path.join(
+    options.stateDir,
+    `gmail-${options.account.accountId}.json`,
+  );
+  const existingCheckpoint = await readCheckpoint(checkpointPath);
+  if (
+    existingCheckpoint &&
+    (existingCheckpoint.accountId !== options.account.accountId ||
+      existingCheckpoint.query !== options.query)
+  ) {
+    throw new ElizaError(
+      `Gmail checkpoint ${checkpointPath} belongs to a different account or query.`,
+      {
+        code: "GMAIL_CORPUS_CHECKPOINT_MISMATCH",
+        context: {
+          accountId: options.account.accountId,
+          checkpointPath,
+        },
+        severity: "fatal",
+      },
+    );
+  }
+
+  const existing = await loadExistingAccountMessages(
+    options.outputDir,
+    options.account.accountId,
+  );
+  if (existingCheckpoint?.completed) {
+    return accountResult(existingCheckpoint, existing, 0, 0);
+  }
+
+  const profile = await options.source.getGmailProfile({
+    accountId: options.account.accountId,
+  });
+  const ownerEmail = normalizeEmail(
+    options.account.ownerEmail ?? profile.emailAddress,
+  );
+  const checkpoint: GmailCollectorCheckpoint = existingCheckpoint ?? {
+    schemaVersion: 1,
+    accountId: options.account.accountId,
+    ownerEmail,
+    query: options.query,
+    startHistoryId: profile.historyId,
+    processedMessages: 0,
+    completed: false,
+    updatedAt: options.now().toISOString(),
+  };
+  if (checkpoint.ownerEmail !== ownerEmail) {
+    throw new ElizaError(
+      `Gmail checkpoint owner ${checkpoint.ownerEmail} does not match ${ownerEmail}.`,
+      {
+        code: "GMAIL_CORPUS_OWNER_MISMATCH",
+        context: {
+          accountId: options.account.accountId,
+          checkpointOwnerEmail: checkpoint.ownerEmail,
+          ownerEmail,
+        },
+        severity: "fatal",
+      },
+    );
+  }
+
+  let writtenMessages = 0;
+  let duplicateMessages = 0;
+  let pageToken = checkpoint.pageToken;
+  while (true) {
+    const page = await options.source.listGmailMessagePage({
+      accountId: options.account.accountId,
+      query: options.query,
+      pageToken,
+      maxResults: normalizedPositiveInteger(
+        options.pageSize,
+        DEFAULT_PAGE_SIZE,
+        DEFAULT_PAGE_SIZE,
+      ),
+      includeSpamTrash: true,
+    });
+    const messages = await mapWithConcurrency(
+      page.messageIds,
+      normalizedPositiveInteger(
+        options.fetchConcurrency,
+        DEFAULT_FETCH_CONCURRENCY,
+        32,
+      ),
+      async (messageId) =>
+        options.source.getGmailExportMessage({
+          accountId: options.account.accountId,
+          messageId,
+          includeAttachmentData: options.includeAttachmentData,
+        }),
+    );
+    const changedMonths = new Set<string>();
+    for (const exported of messages) {
+      const normalized = normalizeGmailMessage(
+        exported,
+        options.account.accountId,
+        ownerEmail,
+      );
+      const current = existing.byId.get(normalized.id);
+      if (current) {
+        if (JSON.stringify(current) !== JSON.stringify(normalized)) {
+          throw new ElizaError(
+            `Gmail message ${normalized.id} changed after it was persisted.`,
+            {
+              code: "GMAIL_CORPUS_MESSAGE_CHANGED",
+              context: {
+                accountId: options.account.accountId,
+                messageId: normalized.id,
+              },
+              severity: "fatal",
+            },
+          );
+        }
+        duplicateMessages += 1;
+        continue;
+      }
+      const month = monthFor(normalized.ts);
+      const shard = existing.byMonth.get(month) ?? [];
+      shard.push(normalized);
+      existing.byMonth.set(month, shard);
+      existing.byId.set(normalized.id, normalized);
+      changedMonths.add(month);
+      writtenMessages += 1;
+    }
+    for (const month of changedMonths) {
+      await writeShard(
+        options.outputDir,
+        options.account.accountId,
+        month,
+        existing.byMonth.get(month) ?? [],
+      );
+    }
+
+    if (page.nextPageToken && page.nextPageToken === pageToken) {
+      throw new ElizaError(
+        `Gmail account ${options.account.accountId} returned a repeated page token.`,
+        {
+          code: "GMAIL_CORPUS_REPEATED_PAGE_TOKEN",
+          context: {
+            accountId: options.account.accountId,
+            pageToken,
+          },
+          severity: "fatal",
+        },
+      );
+    }
+
+    checkpoint.processedMessages += page.messageIds.length;
+    checkpoint.pageToken = page.nextPageToken;
+    checkpoint.completed = !page.nextPageToken;
+    checkpoint.completedHistoryId = checkpoint.completed
+      ? profile.historyId
+      : undefined;
+    checkpoint.updatedAt = options.now().toISOString();
+    await writeJsonAtomic(checkpointPath, checkpoint);
+    if (!page.nextPageToken) break;
+    pageToken = page.nextPageToken;
+  }
+
+  return accountResult(
+    checkpoint,
+    existing,
+    writtenMessages,
+    duplicateMessages,
+  );
+}
+
+function isGmailCorpusSource(value: unknown): value is GmailCorpusSource {
+  if (value === null || typeof value !== "object") return false;
+  return (
+    "getGmailProfile" in value &&
+    typeof value.getGmailProfile === "function" &&
+    "listGmailMessagePage" in value &&
+    typeof value.listGmailMessagePage === "function" &&
+    "getGmailExportMessage" in value &&
+    typeof value.getGmailExportMessage === "function"
+  );
+}
+
+function normalizeGmailMessage(
+  message: GoogleGmailExportMessage,
+  accountId: string,
+  ownerEmail: string,
+): CorpusMessage {
+  if (
+    message.internalDateMs < CORPUS_CUTOFF_MS ||
+    message.internalDateMs > CORPUS_ANCHOR_MS
+  ) {
+    throw new ElizaError(
+      `Gmail message ${message.id} is outside the corpus window.`,
+      {
+        code: "GMAIL_CORPUS_MESSAGE_OUTSIDE_WINDOW",
+        context: { messageId: message.id, timestamp: message.internalDateMs },
+        severity: "fatal",
+      },
+    );
+  }
+  const senderEmail = message.from?.email
+    ? normalizeEmail(message.from.email)
+    : undefined;
+  if (!senderEmail) {
+    throw new ElizaError(`Gmail message ${message.id} has no From address.`, {
+      code: "GMAIL_CORPUS_MESSAGE_SENDER_MISSING",
+      context: { messageId: message.id },
+      severity: "fatal",
+    });
+  }
+  const direction = senderEmail === ownerEmail ? "out" : "in";
+  const recipients = [...(message.to ?? []), ...(message.cc ?? [])].map(
+    (recipient) => ({
+      id: normalizeEmail(recipient.email),
+      display: recipient.name?.trim() || undefined,
+      address: normalizeEmail(recipient.email),
+    }),
+  );
+  const text = message.bodyText ?? htmlToText(message.bodyHtml ?? "");
+  return corpusMessageSchema.parse({
+    id: message.id,
+    platform: "gmail",
+    accountId,
+    threadId: message.threadId,
+    ts: message.internalDateMs,
+    direction,
+    senderId: senderEmail,
+    senderDisplay: message.from?.name?.trim() || senderEmail,
+    recipients,
+    subject: message.subject?.trim() || undefined,
+    text,
+    snippet: message.snippet?.trim() || undefined,
+    labels: message.labelIds ?? [],
+    attachments: message.attachments,
+    scrubState: "raw",
+  });
+}
+
+async function loadExistingAccountMessages(
+  outputDir: string,
+  accountId: string,
+): Promise<{
+  byId: Map<string, CorpusMessage>;
+  byMonth: Map<string, CorpusMessage[]>;
+}> {
+  const accountDir = path.join(outputDir, "gmail", accountId);
+  const byId = new Map<string, CorpusMessage>();
+  const byMonth = new Map<string, CorpusMessage[]>();
+  if (!(await pathExists(accountDir))) return { byId, byMonth };
+  for (const file of await findCorpusShardFiles(accountDir)) {
+    const shard = await readCorpusShard(file, { rootDir: outputDir });
+    if (shard.issues.length > 0) {
+      throw new ElizaError(
+        `Existing Gmail shard ${file} is invalid: ${shard.issues
+          .map((issue) => issue.message)
+          .join("; ")}`,
+        {
+          code: "GMAIL_CORPUS_EXISTING_SHARD_INVALID",
+          context: { file, issueCount: shard.issues.length },
+          severity: "fatal",
+        },
+      );
+    }
+    const month = path.basename(file, ".jsonl");
+    byMonth.set(month, shard.messages);
+    for (const message of shard.messages) {
+      if (byId.has(message.id)) {
+        throw new ElizaError(
+          `Existing Gmail corpus duplicates ${message.id}.`,
+          {
+            code: "GMAIL_CORPUS_EXISTING_DUPLICATE",
+            context: { messageId: message.id },
+            severity: "fatal",
+          },
+        );
+      }
+      byId.set(message.id, message);
+    }
+  }
+  return { byId, byMonth };
+}
+
+async function readCheckpoint(
+  checkpointPath: string,
+): Promise<GmailCollectorCheckpoint | undefined> {
+  if (!(await pathExists(checkpointPath))) return undefined;
+  return checkpointSchema.parse(
+    JSON.parse(await fs.readFile(checkpointPath, "utf8")),
+  );
+}
+
+async function writeShard(
+  outputDir: string,
+  accountId: string,
+  month: string,
+  messages: CorpusMessage[],
+): Promise<void> {
+  const shardPath = path.join(outputDir, "gmail", accountId, `${month}.jsonl`);
+  await fs.mkdir(path.dirname(shardPath), { recursive: true });
+  const ordered = [...messages].sort(
+    (left, right) => left.ts - right.ts || left.id.localeCompare(right.id),
+  );
+  await writeTextAtomic(
+    shardPath,
+    `${ordered.map((message) => JSON.stringify(message)).join("\n")}\n`,
+  );
+}
+
+async function writeJsonAtomic(
+  filePath: string,
+  value: unknown,
+): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await writeTextAtomic(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function writeTextAtomic(filePath: string, value: string): Promise<void> {
+  const temporaryPath = `${filePath}.tmp`;
+  await fs.writeFile(temporaryPath, value, { encoding: "utf8", mode: 0o600 });
+  await fs.rename(temporaryPath, filePath);
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch (error) {
+    // error-policy:J3 filesystem existence is an explicit valid/absent probe.
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function accountResult(
+  checkpoint: GmailCollectorCheckpoint,
+  existing: { byMonth: Map<string, CorpusMessage[]> },
+  writtenMessages: number,
+  duplicateMessages: number,
+): GmailCorpusAccountResult {
+  return {
+    accountId: checkpoint.accountId,
+    ownerEmail: checkpoint.ownerEmail,
+    processedMessages: checkpoint.processedMessages,
+    writtenMessages,
+    duplicateMessages,
+    completed: checkpoint.completed,
+    monthCounts: Object.fromEntries(
+      [...existing.byMonth.entries()]
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([month, messages]) => [month, messages.length]),
+    ),
+  };
+}
+
+function assertAccountPathSegment(accountId: string): void {
+  if (!/^[A-Za-z0-9._-]+$/.test(accountId)) {
+    throw new ElizaError(
+      `Gmail account id ${JSON.stringify(accountId)} is not a safe shard path segment.`,
+      {
+        code: "GMAIL_CORPUS_ACCOUNT_ID_INVALID",
+        context: { accountId },
+        severity: "fatal",
+      },
+    );
+  }
+}
+
+function normalizeEmail(value: string): string {
+  const normalized = value.trim().toLowerCase();
+  if (!z.string().email().safeParse(normalized).success) {
+    throw new ElizaError(`Invalid Gmail address ${JSON.stringify(value)}.`, {
+      code: "GMAIL_CORPUS_EMAIL_INVALID",
+      context: { value },
+      severity: "fatal",
+    });
+  }
+  return normalized;
+}
+
+function monthFor(timestamp: number): string {
+  return new Date(timestamp).toISOString().slice(0, 7);
+}
+
+function htmlToText(html: string): string {
+  return html
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, " ")
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, " ")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/p\s*>/gi, "\n")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/[ \t]+/g, " ")
+    .replace(/\n\s+/g, "\n")
+    .trim();
+}
+
+function normalizedPositiveInteger(
+  value: number | undefined,
+  fallback: number,
+  max: number,
+): number {
+  if (value === undefined) return fallback;
+  if (!Number.isInteger(value) || value < 1 || value > max) {
+    throw new ElizaError(
+      `Expected an integer from 1 through ${max}; received ${value}.`,
+      {
+        code: "GMAIL_CORPUS_LIMIT_INVALID",
+        context: { max, value },
+        severity: "fatal",
+      },
+    );
+  }
+  return value;
+}
+
+async function mapWithConcurrency<T, TResult>(
+  values: readonly T[],
+  concurrency: number,
+  mapper: (value: T) => Promise<TResult>,
+): Promise<TResult[]> {
+  const results = new Array<TResult>(values.length);
+  let cursor = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, values.length) }, async () => {
+      while (cursor < values.length) {
+        const index = cursor;
+        cursor += 1;
+        results[index] = await mapper(values[index]);
+      }
+    }),
+  );
+  return results;
+}

--- a/packages/corpus-tools/src/index.ts
+++ b/packages/corpus-tools/src/index.ts
@@ -2,6 +2,8 @@
  * Public entry for corpus schema consumers, scrub stages, validators, and mock
  * loader adapters.
  */
+
+export * from "./collectors/gmail.ts";
 export * from "./mappers.ts";
 export * from "./pipeline/driver.ts";
 export * from "./pipeline/llm-pii.ts";

--- a/packages/corpus-tools/src/schema.ts
+++ b/packages/corpus-tools/src/schema.ts
@@ -62,7 +62,9 @@ export const corpusMessageSchema = z.object({
   senderDisplay: nonEmptyString,
   recipients: z.array(corpusRecipientSchema),
   subject: optionalNonEmptyString,
-  text: nonEmptyString,
+  // Attachment-only mail is a legitimate source record; collectors must not
+  // invent body text merely to satisfy the interchange boundary.
+  text: z.string(),
   snippet: optionalNonEmptyString,
   labels: z.array(nonEmptyString).default([]),
   attachments: z.array(corpusAttachmentSchema).default([]),

--- a/plugins/plugin-google/AGENTS.md
+++ b/plugins/plugin-google/AGENTS.md
@@ -21,6 +21,7 @@ The plugin object (`googlePlugin`, service name `"google"`) registers:
 ### `GoogleWorkspaceService` methods
 
 Gmail (`src/gmail.ts` via `GoogleGmailClient`):
+- `getGmailProfile` / `listGmailMessagePage` / `getGmailExportMessage` — quota-retried, account-scoped full-history export primitives; exported attachments are always hashed and include bytes only when requested.
 - `searchMessages` / `getMessage` / `sendEmail` — basic message read/send.
 - `listGmailTriageMessages` / `searchGmailMessages` / `getGmailMessage` / `getGmailMessageDetail` — enriched message fetch with triage scoring.
 - `listGmailUnrespondedThreads` — threads needing a reply.

--- a/plugins/plugin-google/CLAUDE.md
+++ b/plugins/plugin-google/CLAUDE.md
@@ -21,6 +21,7 @@ The plugin object (`googlePlugin`, service name `"google"`) registers:
 ### `GoogleWorkspaceService` methods
 
 Gmail (`src/gmail.ts` via `GoogleGmailClient`):
+- `getGmailProfile` / `listGmailMessagePage` / `getGmailExportMessage` — quota-retried, account-scoped full-history export primitives; exported attachments are always hashed and include bytes only when requested.
 - `searchMessages` / `getMessage` / `sendEmail` — basic message read/send.
 - `listGmailTriageMessages` / `searchGmailMessages` / `getGmailMessage` / `getGmailMessageDetail` — enriched message fetch with triage scoring.
 - `listGmailUnrespondedThreads` — threads needing a reply.

--- a/plugins/plugin-google/src/gmail.ts
+++ b/plugins/plugin-google/src/gmail.ts
@@ -6,15 +6,21 @@
  * helpers. Maps Gmail API payloads into the plugin's `GoogleGmail*` DTOs. Each
  * method acquires a scoped googleapis client from `GoogleApiClientFactory`.
  */
+import { createHash } from "node:crypto";
+import { ElizaError } from "@elizaos/core";
 import type { gmail_v1 } from "googleapis";
 import type { GoogleApiClientFactory } from "./client-factory.js";
 import type {
   GoogleAccountRef,
   GoogleEmailAddress,
   GoogleGmailBulkOperation,
+  GoogleGmailExportAttachment,
+  GoogleGmailExportMessage,
   GoogleGmailFilterCreateResult,
   GoogleGmailMessageDetail,
+  GoogleGmailMessagePage,
   GoogleGmailMessageSummary,
+  GoogleGmailProfile,
   GoogleGmailSendResult,
   GoogleGmailSubscriptionMessageHeaders,
   GoogleGmailUnrespondedThread,
@@ -44,9 +50,115 @@ const SUBSCRIPTION_SCAN_QUERY_DEFAULT =
 const GMAIL_LIST_PAGE_SIZE = 500;
 const GMAIL_METADATA_CONCURRENCY = 25;
 const MAX_GMAIL_RESULTS = 1000;
+const GMAIL_READ_RETRY = {
+  retry: true,
+  retryConfig: {
+    retry: 5,
+    retryDelay: 500,
+    retryDelayMultiplier: 2,
+    maxRetryDelay: 30_000,
+    totalTimeout: 120_000,
+  },
+} as const;
 
 export class GoogleGmailClient {
   constructor(private readonly clientFactory: GoogleApiClientFactory) {}
+
+  async getGmailProfile(params: GoogleAccountRef): Promise<GoogleGmailProfile> {
+    const gmail = await this.clientFactory.gmail(params, ["gmail.read"], "gmail.getGmailProfile");
+    const response = await gmail.users.getProfile({ userId: "me" }, GMAIL_READ_RETRY);
+    const emailAddress = response.data.emailAddress?.trim();
+    if (!emailAddress) {
+      throw new ElizaError(`Gmail profile for account ${params.accountId} has no email address.`, {
+        code: "GOOGLE_GMAIL_PROFILE_INVALID",
+        context: { accountId: params.accountId },
+        severity: "fatal",
+      });
+    }
+    return {
+      emailAddress,
+      historyId: response.data.historyId?.trim() || undefined,
+      messagesTotal: response.data.messagesTotal ?? undefined,
+      threadsTotal: response.data.threadsTotal ?? undefined,
+    };
+  }
+
+  async listGmailMessagePage(
+    params: GoogleAccountRef & {
+      query: string;
+      pageToken?: string;
+      maxResults?: number;
+      includeSpamTrash?: boolean;
+    }
+  ): Promise<GoogleGmailMessagePage> {
+    const gmail = await this.clientFactory.gmail(
+      params,
+      ["gmail.read"],
+      "gmail.listGmailMessagePage"
+    );
+    const response = await gmail.users.messages.list(
+      {
+        userId: "me",
+        q: params.query,
+        pageToken: params.pageToken,
+        maxResults: normalizedLimit(params.maxResults, GMAIL_LIST_PAGE_SIZE, GMAIL_LIST_PAGE_SIZE),
+        includeSpamTrash: params.includeSpamTrash === true,
+      },
+      GMAIL_READ_RETRY
+    );
+    return {
+      messageIds: (response.data.messages ?? []).flatMap((message) =>
+        message.id?.trim() ? [message.id.trim()] : []
+      ),
+      nextPageToken: response.data.nextPageToken?.trim() || undefined,
+      resultSizeEstimate: response.data.resultSizeEstimate ?? undefined,
+    };
+  }
+
+  async getGmailExportMessage(
+    params: GoogleAccountRef & {
+      messageId: string;
+      includeAttachmentData?: boolean;
+    }
+  ): Promise<GoogleGmailExportMessage> {
+    const gmail = await this.clientFactory.gmail(
+      params,
+      ["gmail.read"],
+      "gmail.getGmailExportMessage"
+    );
+    const response = await gmail.users.messages.get(
+      {
+        userId: "me",
+        id: params.messageId,
+        format: "full",
+      },
+      GMAIL_READ_RETRY
+    );
+    await hydrateDetachedMessageParts(gmail, params.messageId, response.data.payload);
+    const summary = mapMessage(response.data, true);
+    const threadId = response.data.threadId?.trim();
+    const internalDateMs = Number(response.data.internalDate);
+    if (!summary.id || !threadId || !Number.isSafeInteger(internalDateMs)) {
+      throw new ElizaError(`Gmail message ${params.messageId} lacks required export metadata.`, {
+        code: "GOOGLE_GMAIL_EXPORT_METADATA_MISSING",
+        context: { accountId: params.accountId, messageId: params.messageId },
+        severity: "fatal",
+      });
+    }
+    const attachments = await collectExportAttachments(
+      gmail,
+      summary.id,
+      response.data.payload,
+      params.includeAttachmentData === true
+    );
+    return {
+      ...summary,
+      threadId,
+      internalDateMs,
+      historyId: response.data.historyId?.trim() || undefined,
+      attachments,
+    };
+  }
 
   async searchMessages(
     params: GoogleAccountRef & { query: string; limit?: number }
@@ -666,6 +778,116 @@ function collectMessageBody(
   const body: Pick<GoogleMessageSummary, "bodyHtml" | "bodyText"> = {};
   collectMessagePart(part, body);
   return body;
+}
+
+async function collectExportAttachments(
+  gmail: gmail_v1.Gmail,
+  messageId: string,
+  root: gmail_v1.Schema$MessagePart | undefined,
+  includeData: boolean
+): Promise<GoogleGmailExportAttachment[]> {
+  const parts: gmail_v1.Schema$MessagePart[] = [];
+  collectAttachmentParts(root, parts);
+  return mapWithConcurrency(parts, 8, async (part) => {
+    const attachmentId = part.body?.attachmentId?.trim();
+    const inlineData = part.body?.data?.trim();
+    const encoded = inlineData
+      ? inlineData
+      : attachmentId
+        ? (
+            await gmail.users.messages.attachments.get(
+              {
+                userId: "me",
+                messageId,
+                id: attachmentId,
+              },
+              GMAIL_READ_RETRY
+            )
+          ).data.data?.trim()
+        : undefined;
+    if (!encoded) {
+      throw new ElizaError(
+        `Gmail attachment ${part.filename || attachmentId || "unknown"} on ${messageId} has no bytes.`,
+        {
+          code: "GOOGLE_GMAIL_ATTACHMENT_BYTES_MISSING",
+          context: { attachmentId, filename: part.filename, messageId },
+          severity: "fatal",
+        }
+      );
+    }
+    const bytes = Buffer.from(encoded, "base64url");
+    return {
+      filename: part.filename?.trim() || `attachment-${attachmentId ?? parts.indexOf(part) + 1}`,
+      mimeType: part.mimeType?.trim() || "application/octet-stream",
+      sha256: createHash("sha256").update(bytes).digest("hex"),
+      bytes: bytes.byteLength,
+      ...(includeData ? { dataBase64: bytes.toString("base64") } : {}),
+    };
+  });
+}
+
+async function hydrateDetachedMessageParts(
+  gmail: gmail_v1.Gmail,
+  messageId: string,
+  root: gmail_v1.Schema$MessagePart | undefined
+): Promise<void> {
+  const detached: gmail_v1.Schema$MessagePart[] = [];
+  collectDetachedParts(root, detached);
+  await mapWithConcurrency(detached, 8, async (part) => {
+    const attachmentId = part.body?.attachmentId?.trim();
+    if (!attachmentId) return;
+    const response = await gmail.users.messages.attachments.get(
+      {
+        userId: "me",
+        messageId,
+        id: attachmentId,
+      },
+      GMAIL_READ_RETRY
+    );
+    const data = response.data.data?.trim();
+    if (!data) {
+      throw new ElizaError(
+        `Gmail MIME part ${part.filename || attachmentId} on ${messageId} has no bytes.`,
+        {
+          code: "GOOGLE_GMAIL_MIME_PART_BYTES_MISSING",
+          context: { attachmentId, filename: part.filename, messageId },
+          severity: "fatal",
+        }
+      );
+    }
+    if (!part.body) part.body = {};
+    part.body.data = data;
+  });
+}
+
+function collectDetachedParts(
+  part: gmail_v1.Schema$MessagePart | undefined,
+  output: gmail_v1.Schema$MessagePart[]
+): void {
+  if (!part) return;
+  if (part.body?.attachmentId?.trim() && !part.body.data?.trim()) {
+    output.push(part);
+  }
+  for (const child of part.parts ?? []) {
+    collectDetachedParts(child, output);
+  }
+}
+
+function collectAttachmentParts(
+  part: gmail_v1.Schema$MessagePart | undefined,
+  output: gmail_v1.Schema$MessagePart[]
+): void {
+  if (!part) return;
+  const mimeType = part.mimeType?.trim().toLowerCase();
+  if (
+    part.filename?.trim() ||
+    (part.body?.attachmentId?.trim() && mimeType !== "text/plain" && mimeType !== "text/html")
+  ) {
+    output.push(part);
+  }
+  for (const child of part.parts ?? []) {
+    collectAttachmentParts(child, output);
+  }
 }
 
 function collectMessagePart(

--- a/plugins/plugin-google/src/index.test.ts
+++ b/plugins/plugin-google/src/index.test.ts
@@ -5,6 +5,8 @@
  * are stubbed via fake client factories and a stubbed `fetch`; no live Google
  * API is contacted.
  */
+
+import { createHash } from "node:crypto";
 import type {
   ConnectorAccount,
   ConnectorAccountPatch,
@@ -507,6 +509,133 @@ describe("google plugin", () => {
     });
     expect(results[0]?.from).toEqual({ name: "Ada", email: "ada@example.com" });
     expect(sent).toEqual({ id: "sent_1", threadId: "thread_2" });
+  });
+
+  it("paginates and exports full Gmail messages with hashed attachments", async () => {
+    const attachment = Buffer.from("owner attachment", "utf8");
+    const body = Buffer.from("Full message body", "utf8").toString("base64url");
+    const fakeGmail = {
+      users: {
+        getProfile: vi.fn(async () => ({
+          data: {
+            emailAddress: "owner@example.com",
+            historyId: "history-profile",
+            messagesTotal: 42,
+            threadsTotal: 20,
+          },
+        })),
+        messages: {
+          list: vi.fn(async () => ({
+            data: {
+              messages: [{ id: "msg_export" }],
+              nextPageToken: "next-page",
+              resultSizeEstimate: 42,
+            },
+          })),
+          get: vi.fn(async () => ({
+            data: {
+              id: "msg_export",
+              threadId: "thread_export",
+              historyId: "history-message",
+              internalDate: String(Date.parse("2026-05-07T12:00:00.000Z")),
+              labelIds: ["INBOX"],
+              snippet: "Full message",
+              payload: {
+                mimeType: "multipart/mixed",
+                headers: [
+                  { name: "Subject", value: "Export" },
+                  { name: "From", value: "Ada <ada@example.com>" },
+                  { name: "To", value: "Owner <owner@example.com>" },
+                  { name: "Date", value: "Thu, 07 May 2026 12:00:00 GMT" },
+                ],
+                parts: [
+                  {
+                    mimeType: "text/plain",
+                    body: { attachmentId: "body-1", size: body.length },
+                  },
+                  {
+                    filename: "notes.txt",
+                    mimeType: "text/plain",
+                    body: {
+                      attachmentId: "attachment-1",
+                      size: attachment.byteLength,
+                    },
+                  },
+                ],
+              },
+            },
+          })),
+          attachments: {
+            get: vi.fn(async (params: { id: string }) => ({
+              data: {
+                data: params.id === "body-1" ? body : attachment.toString("base64url"),
+              },
+            })),
+          },
+        },
+      },
+    };
+    const factory = {
+      gmail: vi.fn(async () => fakeGmail),
+    } as GoogleApiClientFactory;
+    const client = new GoogleGmailClient(factory);
+
+    await expect(client.getGmailProfile({ accountId: "acct_google_1" })).resolves.toEqual({
+      emailAddress: "owner@example.com",
+      historyId: "history-profile",
+      messagesTotal: 42,
+      threadsTotal: 20,
+    });
+    await expect(
+      client.listGmailMessagePage({
+        accountId: "acct_google_1",
+        query: "after:2024/07/05",
+        pageToken: "page-1",
+        maxResults: 500,
+        includeSpamTrash: true,
+      })
+    ).resolves.toEqual({
+      messageIds: ["msg_export"],
+      nextPageToken: "next-page",
+      resultSizeEstimate: 42,
+    });
+    await expect(
+      client.getGmailExportMessage({
+        accountId: "acct_google_1",
+        messageId: "msg_export",
+        includeAttachmentData: true,
+      })
+    ).resolves.toMatchObject({
+      id: "msg_export",
+      threadId: "thread_export",
+      historyId: "history-message",
+      bodyText: "Full message body",
+      attachments: [
+        {
+          filename: "notes.txt",
+          mimeType: "text/plain",
+          sha256: createHash("sha256").update(attachment).digest("hex"),
+          bytes: attachment.byteLength,
+          dataBase64: attachment.toString("base64"),
+        },
+      ],
+    });
+    expect(fakeGmail.users.messages.list).toHaveBeenCalledWith(
+      expect.objectContaining({
+        q: "after:2024/07/05",
+        pageToken: "page-1",
+        maxResults: 500,
+      }),
+      expect.objectContaining({ retry: true })
+    );
+    expect(fakeGmail.users.messages.attachments.get).toHaveBeenCalledWith(
+      {
+        userId: "me",
+        messageId: "msg_export",
+        id: "attachment-1",
+      },
+      expect.objectContaining({ retry: true })
+    );
   });
 
   it("exposes rich Gmail management methods for LifeOps delegation", async () => {

--- a/plugins/plugin-google/src/service.ts
+++ b/plugins/plugin-google/src/service.ts
@@ -29,9 +29,12 @@ import {
   type GoogleDriveFile,
   type GoogleDriveFileList,
   type GoogleGmailBulkOperation,
+  type GoogleGmailExportMessage,
   type GoogleGmailFilterCreateResult,
   type GoogleGmailMessageDetail,
+  type GoogleGmailMessagePage,
   type GoogleGmailMessageSummary,
+  type GoogleGmailProfile,
   type GoogleGmailSendResult,
   type GoogleGmailSubscriptionMessageHeaders,
   type GoogleGmailUnrespondedThread,
@@ -108,6 +111,30 @@ export class GoogleWorkspaceService extends Service implements IGoogleWorkspaceS
 
   getOAuthProviderConfig(capabilities: readonly GoogleCapability[]): GoogleOAuthProviderConfig {
     return getGoogleOAuthProviderConfig(capabilities);
+  }
+
+  getGmailProfile(params: GoogleAccountRef): Promise<GoogleGmailProfile> {
+    return this.gmailClient.getGmailProfile(params);
+  }
+
+  listGmailMessagePage(
+    params: GoogleAccountRef & {
+      query: string;
+      pageToken?: string;
+      maxResults?: number;
+      includeSpamTrash?: boolean;
+    }
+  ): Promise<GoogleGmailMessagePage> {
+    return this.gmailClient.listGmailMessagePage(params);
+  }
+
+  getGmailExportMessage(
+    params: GoogleAccountRef & {
+      messageId: string;
+      includeAttachmentData?: boolean;
+    }
+  ): Promise<GoogleGmailExportMessage> {
+    return this.gmailClient.getGmailExportMessage(params);
   }
 
   searchMessages(

--- a/plugins/plugin-google/src/types.ts
+++ b/plugins/plugin-google/src/types.ts
@@ -85,6 +85,34 @@ export interface GoogleMessageSummary {
   headers?: Record<string, string>;
 }
 
+export interface GoogleGmailMessagePage {
+  messageIds: string[];
+  nextPageToken?: string;
+  resultSizeEstimate?: number;
+}
+
+export interface GoogleGmailExportAttachment {
+  filename: string;
+  mimeType: string;
+  sha256: string;
+  bytes: number;
+  dataBase64?: string;
+}
+
+export interface GoogleGmailExportMessage extends GoogleMessageSummary {
+  threadId: string;
+  internalDateMs: number;
+  historyId?: string;
+  attachments: GoogleGmailExportAttachment[];
+}
+
+export interface GoogleGmailProfile {
+  emailAddress: string;
+  historyId?: string;
+  messagesTotal?: number;
+  threadsTotal?: number;
+}
+
 export interface GoogleSendEmailInput extends GoogleAccountRef {
   to: GoogleEmailAddress[];
   cc?: GoogleEmailAddress[];
@@ -572,6 +600,21 @@ export interface GoogleMeetGenerateReportInput extends GoogleAccountRef {
 }
 
 export interface IGoogleGmailService extends Service {
+  getGmailProfile(params: GoogleAccountRef): Promise<GoogleGmailProfile>;
+  listGmailMessagePage(
+    params: GoogleAccountRef & {
+      query: string;
+      pageToken?: string;
+      maxResults?: number;
+      includeSpamTrash?: boolean;
+    }
+  ): Promise<GoogleGmailMessagePage>;
+  getGmailExportMessage(
+    params: GoogleAccountRef & {
+      messageId: string;
+      includeAttachmentData?: boolean;
+    }
+  ): Promise<GoogleGmailExportMessage>;
   searchMessages(
     params: GoogleAccountRef & { query: string; limit?: number }
   ): Promise<GoogleMessageSummary[]>;


### PR DESCRIPTION
# Relates to

Implements the automated collector portion of #14758. The issue remains open for the owner-only two-account OAuth run and redacted real-mail evidence.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; exact unrelated shared-base and host-capacity failures are recorded below.
- [x] A reviewer can confirm the automated path from the attached HTTP integration artifact and commands below.

# Sync with develop

- [x] Rebased onto `origin/develop` at `5e1da4085f79fe3899287f34ffb252cb4ee136c0`; zero conflicts.
- [x] The affected packages pass. Full `verify` is blocked by an identical `origin/develop` type-ratchet failure and later by host `ENOSPC`, documented below; CI runs on clean capacity.

# Risks

Medium. This adds read-only Gmail export methods and widens corpus body text to permit legitimate attachment-only records. OAuth ownership stays in plugin-google, raw data stays under the caller's ignored data directory, writes are atomic/mode 0600, and malformed or changing data fails with typed `ElizaError`s.

# Background

## What does this PR do?

- Adds account-scoped Gmail profile, paginated list, full MIME export, detached-part hydration, attachment SHA-256/byte metadata, and bounded 429/5xx retry support to the existing Google service.
- Adds a multi-account, two-year Gmail corpus collector with exact UTC query bounds, configurable fetch concurrency, monthly JSONL shards, account/query-pinned checkpoints, deterministic deduplication, crash-safe resume, and validated manifest output.
- Supports attachment-only mail without fabricating body text.
- Documents the runtime entry point and the owner OAuth/evidence handoff.

## What kind of change is this?

Feature (non-breaking connector and corpus tooling addition).

# Documentation changes needed?

Documentation is updated in the corpus README and both affected package guides (`CLAUDE.md`/`AGENTS.md` remain byte-identical).

# Testing

## Where should a reviewer start?

`packages/corpus-tools/src/collectors/gmail.integration.test.ts` drives the production `googleapis` client and OAuth resolver against a local HTTP Gmail seam. It covers two account credentials, profile/list/full-message/attachment endpoints, pagination, normalized shards/manifest, and a first-request 429 that must retry successfully.

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-google build
bun run --cwd plugins/plugin-google typecheck
bun run --cwd plugins/plugin-google test       # 30 passed
bun run --cwd plugins/plugin-google lint
bun run --cwd packages/corpus-tools typecheck
bun run --cwd packages/corpus-tools test       # 88 passed
bun run --cwd packages/corpus-tools lint
bun run audit:error-policy-ratchet
bun run audit:turbo-build-deps
bun run check:agents-claude
```

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI files or rendered surfaces change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI files or rendered surfaces change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this is a headless library/service collector with no user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - the collector is a library entry point and does not add a server route; the machine-readable HTTP integration artifact records the executed real client path.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or request path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, provider, or planner behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] [Machine-readable HTTP integration report](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16026-14758-gmail-http-integration.json) (1/1 test passed; SHA-256 `b4faa294f3fd67c0b2a0b39c3ed4afe6a05e20f3ec9bd411ec4409edc058f92c`).

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM path changes.

## Backend + frontend logs

N/A - no server route or frontend path changes. The attached domain artifact is produced by the production Google client integration seam.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT change.

## Known gaps / failures

- `bun run verify` stops at `audit:type-safety-ratchet`: untouched `packages/core`/`packages/agent` currently contain 584 `?? ""` matches against a baseline of 581. The identical command on pristine `origin/develop` produced the same 584/581 result; this diff touches neither package and adds none of the counted construct.
- Running all remaining verify stages explicitly reached 242 successful Turbo tasks before this shared host exhausted disk while unrelated `@elizaos/cloud-sdk#build` wrote `dist/types.cloud-api.js` (`ENOSPC`). The affected package build/typecheck/test/lint lanes and diff-scoped policy/dependency guards pass on the exact rebased commit.
- Final acceptance requires owner action that cannot be fabricated in automation: connect at least two real Google accounts through existing OAuth, run the collector over the full window, and attach manifest counts per account/month plus three redacted header-only rows. Raw mail must remain local. The issue should move to Needs human review after code/CI review, not close from this PR alone.
