### PR TITLE
fix(cloud): skip impossible Worker SSH for sandboxed shared-agent deletes

### DIFF
--- a/packages/cloud/api/__tests__/eliza-agents-delete-async-fallback.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-delete-async-fallback.test.ts
@@ -1,0 +1,396 @@
+/**
+ * DELETE /api/v1/eliza/agents/:agentId — sync-vs-async routing (#15802).
+ *
+ * The Worker can never SSH (ssh2 is stubbed in workerd), so a shared agent
+ * that carries a `sandbox_id` must NOT be deleted synchronously — the sync
+ * attempt could only ever fail (#15275). The contract pinned here:
+ *   - shared agent WITH a sandbox_id → 202 + real agent_delete job enqueued,
+ *     row flipped to deletion_pending, sync deleteAgent never attempted;
+ *   - second DELETE while the job is pending is idempotent (202, same job);
+ *   - the async path itself (what the provisioning daemon runs) completes and
+ *     removes the row;
+ *   - shared agent WITHOUT a sandbox_id keeps the immediate sync delete (200,
+ *     row gone, no job);
+ *   - a genuine sync failure on that sandbox-less path falls back to the
+ *     async job (202) with the underlying error preserved in the [agent-api]
+ *     warn log — never swallowed behind an opaque 500;
+ *   - dedicated agents keep the async 202 contract; provisioning → 409,
+ *     unknown id → 404.
+ *
+ * Real route module + real elizaSandboxService/provisioningJobService against
+ * in-process PGlite; the only mocked seam is `requireUserOrApiKeyWithOrg`
+ * (same pattern as eliza-agents-restore-body-guard).
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+// The daemon-path assertion runs elizaSandboxService.executeDeletion for real;
+// the memory provider treats an unknown sandbox as already-gone, which is the
+// same observable outcome as a successful node-side stop.
+process.env.ELIZA_TEST_SANDBOX_PROVIDER = "memory";
+
+import { Hono } from "hono";
+import * as realWorkersAuth from "@/lib/auth/workers-hono-auth";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+const ORG = "11111111-1111-4111-8111-111111111111";
+const USER = "aaaaaaaa-1111-4111-8111-111111111111";
+const AGENT_SHARED_SANDBOXED = "cccccccc-1111-4111-8111-111111111111";
+const AGENT_SHARED_PLAIN = "cccccccc-2222-4222-8222-222222222222";
+const AGENT_SHARED_PLAIN_2 = "cccccccc-3333-4333-8333-333333333333";
+const AGENT_DEDICATED = "cccccccc-4444-4444-8444-444444444444";
+const AGENT_PROVISIONING = "cccccccc-5555-4555-8555-555555555555";
+const AGENT_UNKNOWN = "cccccccc-9999-4999-8999-999999999999";
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  ...realWorkersAuth,
+  requireUserOrApiKeyWithOrg: mock(async () => ({
+    id: USER,
+    email: "owner@test.test",
+    organization_id: ORG,
+    organization: { id: ORG, name: "Org", is_active: true },
+    is_active: true,
+    role: "owner",
+  })),
+}));
+
+const ENV = { NODE_ENV: "test" } as unknown as AppEnv["Bindings"];
+
+let pgliteReady = true;
+let closeDb: (() => Promise<void>) | undefined;
+let app: Hono<AppEnv>;
+
+beforeAll(async () => {
+  try {
+    const { closeDatabaseConnectionsForTests, dbWrite } = await import(
+      "@/db/client"
+    );
+    closeDb = closeDatabaseConnectionsForTests;
+
+    const { organizations } = await import("@/db/schemas/organizations");
+    const { users } = await import("@/db/schemas/users");
+    const { userCharacters } = await import("@/db/schemas/user-characters");
+    const { agentSandboxes } = await import("@/db/schemas/agent-sandboxes");
+    const { jobs } = await import("@/db/schemas/jobs");
+    const { apiKeys } = await import("@/db/schemas/api-keys");
+    const { generations } = await import("@/db/schemas/generations");
+    const { usageRecords } = await import("@/db/schemas/usage-records");
+    const { sharedRuntimeHistory } = await import(
+      "@/db/schemas/shared-runtime-history"
+    );
+    const { pushSchema } = await import("@/db/push-schema-for-tests");
+    const { apply } = await pushSchema(
+      {
+        organizations,
+        users,
+        userCharacters,
+        agentSandboxes,
+        jobs,
+        apiKeys,
+        generations,
+        usageRecords,
+        sharedRuntimeHistory,
+      } as never,
+      dbWrite as never,
+    );
+    await apply();
+
+    await dbWrite
+      .insert(organizations)
+      .values([{ id: ORG, name: "Org", slug: "org" }]);
+    await dbWrite.insert(users).values([
+      {
+        id: USER,
+        email: "owner@test.test",
+        organization_id: ORG,
+        role: "owner",
+        steward_user_id: `steward-${USER}`,
+      },
+    ]);
+
+    await dbWrite.insert(agentSandboxes).values([
+      // The #15275 shape: shared tier but backed by a real container the
+      // Worker cannot tear down.
+      {
+        id: AGENT_SHARED_SANDBOXED,
+        organization_id: ORG,
+        user_id: USER,
+        agent_name: "Shared with sandbox",
+        execution_tier: "shared",
+        status: "running",
+        sandbox_id: "sandbox-shared-1",
+      },
+      // Pure Tier-0 shared rows (no container) — sync delete must keep working.
+      {
+        id: AGENT_SHARED_PLAIN,
+        organization_id: ORG,
+        user_id: USER,
+        agent_name: "Shared plain",
+        execution_tier: "shared",
+        status: "running",
+      },
+      {
+        id: AGENT_SHARED_PLAIN_2,
+        organization_id: ORG,
+        user_id: USER,
+        agent_name: "Shared plain 2",
+        execution_tier: "shared",
+        status: "running",
+      },
+      {
+        id: AGENT_DEDICATED,
+        organization_id: ORG,
+        user_id: USER,
+        agent_name: "Dedicated",
+        execution_tier: "dedicated-lazy",
+        status: "running",
+        sandbox_id: "sandbox-dedicated-1",
+      },
+      {
+        id: AGENT_PROVISIONING,
+        organization_id: ORG,
+        user_id: USER,
+        agent_name: "Provisioning",
+        execution_tier: "shared",
+        status: "provisioning",
+      },
+    ]);
+
+    const agentRoute = (await import("../v1/eliza/agents/[agentId]/route"))
+      .default;
+    app = new Hono<AppEnv>();
+    app.route("/api/v1/eliza/agents/:agentId", agentRoute);
+  } catch (error) {
+    pgliteReady = false;
+    console.error(
+      "[eliza-agents-delete-async-fallback.test] setup failed — failing.",
+      error,
+    );
+  }
+}, 120_000);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+  mock.restore();
+});
+
+function del(agentId: string) {
+  return app.request(
+    `/api/v1/eliza/agents/${agentId}`,
+    { method: "DELETE" },
+    ENV,
+  );
+}
+
+async function agentRow(agentId: string) {
+  const { dbWrite } = await import("@/db/client");
+  const { agentSandboxes } = await import("@/db/schemas/agent-sandboxes");
+  const { eq } = await import("drizzle-orm");
+  const rows = await dbWrite
+    .select()
+    .from(agentSandboxes)
+    .where(eq(agentSandboxes.id, agentId))
+    .limit(1);
+  return rows[0];
+}
+
+async function deleteJobsFor(agentId: string) {
+  const { dbWrite } = await import("@/db/client");
+  const { jobs } = await import("@/db/schemas/jobs");
+  const { and, eq } = await import("drizzle-orm");
+  return dbWrite
+    .select()
+    .from(jobs)
+    .where(and(eq(jobs.type, "agent_delete"), eq(jobs.agent_id, agentId)));
+}
+
+describe("DELETE /api/v1/eliza/agents/:agentId — async fallback for sandboxed shared agents (#15275)", () => {
+  let firstJobId: string;
+
+  test("shared agent WITH sandbox_id enqueues an agent_delete job and returns 202 (no sync attempt)", async () => {
+    expect(pgliteReady).toBe(true);
+    const { elizaSandboxService } = await import(
+      "@/lib/services/eliza-sandbox"
+    );
+    const deleteSpy = spyOn(elizaSandboxService, "deleteAgent");
+    try {
+      const res = await del(AGENT_SHARED_SANDBOXED);
+      expect(res.status).toBe(202);
+      const body = (await res.json()) as {
+        success: boolean;
+        created: boolean;
+        alreadyInProgress: boolean;
+        data: { jobId: string; agentId: string; status: string };
+      };
+      expect(body.success).toBe(true);
+      expect(body.created).toBe(true);
+      expect(body.alreadyInProgress).toBe(false);
+      expect(body.data.agentId).toBe(AGENT_SHARED_SANDBOXED);
+      firstJobId = body.data.jobId;
+
+      // The Worker never attempted the (impossible) sync teardown.
+      expect(deleteSpy).not.toHaveBeenCalled();
+
+      // Real DB effects: one pending agent_delete job, row marked deleting.
+      const jobRows = await deleteJobsFor(AGENT_SHARED_SANDBOXED);
+      expect(jobRows.length).toBe(1);
+      expect(jobRows[0].status).toBe("pending");
+      expect(jobRows[0].id).toBe(firstJobId);
+      const row = await agentRow(AGENT_SHARED_SANDBOXED);
+      expect(row?.status).toBe("deletion_pending");
+    } finally {
+      deleteSpy.mockRestore();
+    }
+  });
+
+  test("second DELETE while the job is pending is idempotent (202, same job, no duplicate)", async () => {
+    expect(pgliteReady).toBe(true);
+    const res = await del(AGENT_SHARED_SANDBOXED);
+    expect(res.status).toBe(202);
+    const body = (await res.json()) as {
+      success: boolean;
+      created: boolean;
+      alreadyInProgress: boolean;
+      data: { jobId: string };
+    };
+    expect(body.success).toBe(true);
+    expect(body.created).toBe(false);
+    expect(body.alreadyInProgress).toBe(true);
+    expect(body.data.jobId).toBe(firstJobId);
+
+    const jobRows = await deleteJobsFor(AGENT_SHARED_SANDBOXED);
+    expect(jobRows.length).toBe(1);
+  });
+
+  test("the async path (daemon executeDeletion) completes the enqueued delete and removes the row", async () => {
+    expect(pgliteReady).toBe(true);
+    const { elizaSandboxService } = await import(
+      "@/lib/services/eliza-sandbox"
+    );
+    const outcome = await elizaSandboxService.executeDeletion(
+      AGENT_SHARED_SANDBOXED,
+      ORG,
+    );
+    expect(outcome.success).toBe(true);
+    expect(outcome.containerStopped).toBe(true);
+    expect(await agentRow(AGENT_SHARED_SANDBOXED)).toBeUndefined();
+  });
+
+  test("shared agent WITHOUT sandbox_id keeps the immediate sync delete (200, row gone, no job)", async () => {
+    expect(pgliteReady).toBe(true);
+    const res = await del(AGENT_SHARED_PLAIN);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      success: boolean;
+      deleted: boolean;
+      source: string;
+      data: { agentId: string; status: string };
+    };
+    expect(body.success).toBe(true);
+    expect(body.deleted).toBe(true);
+    expect(body.source).toBe("shared_runtime");
+    expect(body.data.status).toBe("deleted");
+
+    expect(await agentRow(AGENT_SHARED_PLAIN)).toBeUndefined();
+    expect((await deleteJobsFor(AGENT_SHARED_PLAIN)).length).toBe(0);
+  });
+
+  test("a genuine sandbox-less sync failure falls back to the async job (202) and logs the underlying error", async () => {
+    expect(pgliteReady).toBe(true);
+    const { elizaSandboxService } = await import(
+      "@/lib/services/eliza-sandbox"
+    );
+    const { logger } = await import("@/lib/utils/logger");
+    const underlying =
+      "Failed to delete sandbox: ssh2 is not available on Cloudflare Workers — proxy to the Node sidecar (cloud/INFRA.md).";
+    const deleteSpy = spyOn(
+      elizaSandboxService,
+      "deleteAgent",
+    ).mockResolvedValueOnce({
+      success: false,
+      error: underlying,
+    });
+    const warnSpy = spyOn(logger, "warn");
+    try {
+      const res = await del(AGENT_SHARED_PLAIN_2);
+      expect(res.status).toBe(202);
+      const body = (await res.json()) as {
+        success: boolean;
+        created: boolean;
+        data: { jobId: string; agentId: string };
+      };
+      expect(body.success).toBe(true);
+      expect(body.created).toBe(true);
+      expect(body.data.agentId).toBe(AGENT_SHARED_PLAIN_2);
+
+      // The sandbox-less path still attempts the sync delete, and its
+      // underlying error surfaces in the fallback warn — never swallowed
+      // behind an opaque 500.
+      expect(deleteSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[agent-api] Shared-runtime agent delete failed synchronously; falling back to async delete job",
+        expect.objectContaining({
+          agentId: AGENT_SHARED_PLAIN_2,
+          orgId: ORG,
+          error: underlying,
+        }),
+      );
+
+      // Real DB effects: the fallback enqueued a genuine agent_delete job and
+      // flipped the row so the failure is observable, not a silent success.
+      const jobRows = await deleteJobsFor(AGENT_SHARED_PLAIN_2);
+      expect(jobRows.length).toBe(1);
+      expect(jobRows[0].status).toBe("pending");
+      expect((await agentRow(AGENT_SHARED_PLAIN_2))?.status).toBe(
+        "deletion_pending",
+      );
+    } finally {
+      deleteSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+  });
+
+  test("dedicated agent keeps the async 202 job contract", async () => {
+    expect(pgliteReady).toBe(true);
+    const res = await del(AGENT_DEDICATED);
+    expect(res.status).toBe(202);
+    const body = (await res.json()) as {
+      success: boolean;
+      created: boolean;
+      data: { jobId: string };
+    };
+    expect(body.success).toBe(true);
+    expect(body.created).toBe(true);
+
+    const jobRows = await deleteJobsFor(AGENT_DEDICATED);
+    expect(jobRows.length).toBe(1);
+    expect((await agentRow(AGENT_DEDICATED))?.status).toBe("deletion_pending");
+  });
+
+  test("provisioning agent → 409; unknown agent → 404", async () => {
+    expect(pgliteReady).toBe(true);
+    const provisioning = await del(AGENT_PROVISIONING);
+    expect(provisioning.status).toBe(409);
+    expect(((await provisioning.json()) as { error: string }).error).toBe(
+      "Agent provisioning is in progress",
+    );
+
+    const missing = await del(AGENT_UNKNOWN);
+    expect(missing.status).toBe(404);
+    expect(((await missing.json()) as { error: string }).error).toBe(
+      "Agent not found",
+    );
+  });
+});

--- a/packages/cloud/api/__tests__/eliza-agents-delete-shared-fallback.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-delete-shared-fallback.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Route-level contract for DELETE /api/v1/eliza/agents/:agentId shared-tier
+ * dispatch, with the sandbox service and job queue mocked: a sandboxed shared
+ * agent skips the impossible Worker-side sync teardown and goes straight to
+ * the async agent_delete job (#15802); a sandbox-less shared agent still
+ * attempts the sync delete and falls back to the async job on a
+ * non-terminal failure (#15286). Real-PGlite coverage of the same contract
+ * lives in eliza-agents-delete-async-fallback.test.ts.
+ */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
 
@@ -96,6 +105,9 @@ const { default: agentRoute } = await import(
 const app = new Hono();
 app.route("/api/v1/eliza/agents/:agentId", agentRoute);
 
+// Default shape is the sandbox-less Tier-0 shared agent — the only shared
+// shape the route still deletes synchronously. Sandboxed cases override
+// `sandbox_id` explicitly.
 function sharedAgent(overrides: Record<string, unknown> = {}) {
   return {
     id: "agent-1",
@@ -103,7 +115,7 @@ function sharedAgent(overrides: Record<string, unknown> = {}) {
     user_id: "user-1",
     status: "running",
     execution_tier: "shared",
-    sandbox_id: "sandbox-agent-1",
+    sandbox_id: null,
     node_id: null,
     container_name: null,
     headscale_ip: null,
@@ -189,5 +201,31 @@ describe("DELETE /api/v1/eliza/agents/:agentId shared-runtime fallback", () => {
       error: "Agent provisioning is in progress",
     });
     expect(enqueueAgentDeleteOnce).not.toHaveBeenCalled();
+  });
+
+  test("sandboxed shared agent skips the impossible sync teardown and goes straight to the async job", async () => {
+    getAgent.mockResolvedValue(sharedAgent({ sandbox_id: "sandbox-agent-1" }));
+
+    const response = await deleteRequest();
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      created: true,
+      data: {
+        jobId: "delete-job-1",
+        agentId: "agent-1",
+        status: "pending",
+      },
+    });
+    // The Worker cannot SSH (ssh2 is stubbed in workerd) — the sync delete
+    // must never even be attempted for a shared agent with a container.
+    expect(deleteAgent).not.toHaveBeenCalled();
+    expect(enqueueAgentDeleteOnce).toHaveBeenCalledWith({
+      agentId: "agent-1",
+      organizationId: "org-1",
+      userId: "user-1",
+    });
+    expect(triggerImmediate).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/route.ts
@@ -388,7 +388,14 @@ app.delete("/", async (c) => {
       );
     }
 
-    if (existing.execution_tier === "shared") {
+    // Synchronous delete is only attempted when there is NO container to tear
+    // down (`sandbox_id` unset — the pure-DB Tier-0 shared case). A shared
+    // agent WITH a sandbox needs `provider.stop()`, which SSHes into the
+    // docker node — impossible from this Worker (ssh2 is stubbed in workerd,
+    // see packages/cloud/api/src/stubs/ssh2.ts) — so those agents skip the
+    // doomed sync attempt and go straight to the async agent_delete job
+    // below, which the provisioning daemon (real ssh2) completes (#15802).
+    if (existing.execution_tier === "shared" && !existing.sandbox_id) {
       const result = await elizaSandboxService.deleteAgent(
         agentId,
         user.organization_id,
@@ -437,12 +444,15 @@ app.delete("/", async (c) => {
       }
     }
 
-    // Async delete via the same job-queue path agent_provision uses. This
-    // moves the SSH stop, Neon deletion, and per-agent key revoke off the
-    // request thread so a slow / unreachable Hetzner core can no longer
-    // make the API hang or silently return 200 while the container lives
-    // on. Idempotent: a second DELETE while a job is in flight reuses
-    // the existing one.
+    // Async delete via the same job-queue path agent_provision uses — for
+    // dedicated agents, any shared agent that carries a sandbox_id (the
+    // Worker cannot SSH; the daemon does the teardown), and sandbox-less
+    // shared deletes whose sync attempt failed. This moves the SSH stop,
+    // Neon deletion, and per-agent key revoke off the request thread so a
+    // slow / unreachable Hetzner core can no longer make the API hang or
+    // silently return 200 while the container lives on. Enqueue flips the
+    // row to `deletion_pending`. Idempotent: a second DELETE while a job is
+    // in flight reuses the existing one.
     const enqueueResult = await provisioningJobService.enqueueAgentDeleteOnce({
       agentId,
       organizationId: user.organization_id,

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -1905,7 +1905,11 @@ describe("ElizaSandboxService.deleteAgent teardown cap (#9066)", () => {
     try {
       const res = (await svc.deleteAgent(AGENT, ORG)) as { success: boolean; error?: string };
       expect(res.success).toBe(false);
-      expect(res.error).toBe("Failed to delete sandbox");
+      // The underlying stop failure must surface in the returned error so the
+      // job result / API envelope stays diagnosable (#15275).
+      expect(res.error).toBe(
+        "Failed to delete sandbox: docker stop -> daemon hung; docker rm -f -> daemon hung",
+      );
       // Critically: the row delete is never attempted when the container may
       // still be running.
       expect(commit).not.toHaveBeenCalled();

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -1288,7 +1288,10 @@ export class ElizaSandboxService {
             status: precheck.status,
             error: errorMessage,
           });
-          return { success: false, error: "Failed to delete sandbox" };
+          // Carry the underlying stop failure so the job result / API envelope
+          // is diagnosable without server logs (#15275 shipped as an opaque
+          // "Failed to delete agent" 500 for weeks because this was generic).
+          return { success: false, error: `Failed to delete sandbox: ${errorMessage}` };
         }
       }
     }


### PR DESCRIPTION
## Summary

`DELETE /api/v1/eliza/agents/:agentId` attempted a synchronous `elizaSandboxService.deleteAgent` for **every** shared agent — but a shared agent with a `sandbox_id` needs `provider.stop()` → `DockerSSHClient` → `ssh2`, and ssh2 is stubbed in the Worker (`packages/cloud/api/src/stubs/ssh2.ts` throws `ssh2 is not available on Cloudflare Workers`). The sync attempt could only ever fail; #15286 papered over that by falling back to the async job **after** the doomed attempt.

This PR adapts the orphaned post-fix branch `fix/agent-delete-async-15275` (commit `87b833f4`, never PR'd) onto the current `develop` shape:

- **Route** (`packages/cloud/api/v1/eliza/agents/[agentId]/route.ts`): the sync delete is only attempted for shared agents **without** a `sandbox_id` (pure-DB Tier-0 case that works in workerd). Shared agents **with** a `sandbox_id` skip the doomed sync attempt entirely and go straight to the async `agent_delete` job — 202 + jobId, row flipped to `deletion_pending`, idempotent re-DELETE — the path the provisioning daemon (real ssh2) completes.
- **Preserved `develop` behavior** (acceptance): 404/409 terminal sync errors return unchanged; the sandbox-less fallback from #15286 is kept — a genuine non-terminal sync failure warns with the underlying error and enqueues the async job.
- **Service** (`packages/cloud/shared/src/lib/services/eliza-sandbox.ts`): `deleteAgent`'s stop-failure result now carries the underlying stop error (`Failed to delete sandbox: <cause>`) so job results / API envelopes are diagnosable without server logs — no more opaque generic failure.
- **Not blindly cherry-picked**: the orphaned commit's "return unswallowed 500" route behavior predated #15286; it was re-resolved against the current fallback-to-async shape so sandbox-less shared deletes behave exactly as on `develop` today.

## Tests

- **New real-PGlite route suite** `packages/cloud/api/__tests__/eliza-agents-delete-async-fallback.test.ts` (7 tests, real route module + real `elizaSandboxService`/`provisioningJobService` against in-process PGlite; only the auth seam is mocked):
  - sandboxed shared delete → 202, real `agent_delete` job row `pending`, agent row `deletion_pending`, **`deleteAgent` never called** (no SSH attempt)
  - second DELETE while pending → idempotent 202, same job, no duplicate
  - daemon path (`executeDeletion`) completes the queued delete and removes the row
  - sandbox-less shared delete → immediate sync 200, row gone, no job
  - genuine sandbox-less sync failure → 202 fallback, underlying error preserved in the `[agent-api]` warn, real job enqueued (failure observable, never a silent success)
  - dedicated agent keeps the async 202 contract; provisioning → 409; unknown → 404
- **Updated mocked route suite** `eliza-agents-delete-shared-fallback.test.ts`: fallback tests now model the sandbox-less agent (the only shape still deleted synchronously); new test pins sandboxed → direct async with `deleteAgent` **not** called.
- **Updated service test** `eliza-sandbox.test.ts`: stop-failure result carries the underlying cause.

## Evidence

- Focused tests (real PGlite / real service singletons, bun test):
  - `eliza-agents-delete-async-fallback.test.ts` — **7 pass / 0 fail** (51 expects)
  - `eliza-agents-delete-shared-fallback.test.ts` — **3 pass / 0 fail**
  - `eliza-sandbox.test.ts` — **96 pass / 0 fail**
- `bunx biome check` on all 5 touched files — clean
- `tsgo --noEmit` typecheck: `packages/cloud/shared` OK, `packages/cloud/api` (incl. worker-bundle dry-run) OK
- `bun run audit:error-policy-ratchet` — no new fallback-slop
- Video walkthrough / screenshots: N/A — backend Worker route + service change with no rendered UI surface; behavior is fully pinned by the route-level suites above (202/200/404/409 envelopes + DB rows inspected in-test).
- Real-LLM trajectories: N/A — no agent/action/provider/prompt/model behavior change; this is cloud control-plane delete routing.

Fixes #15802

🤖 Generated with [Claude Code](https://claude.com/claude-code)