### PR TITLE
fix(core): detect bare Hugging Face tokens in redaction patterns

### DIFF
--- a/packages/core/src/security/redact.test.ts
+++ b/packages/core/src/security/redact.test.ts
@@ -69,6 +69,27 @@ describe("redactSensitiveText (pattern detection)", () => {
 		expect(redactSensitiveText(bearer)).not.toContain("a".repeat(40));
 	});
 
+	it("masks a bare Hugging Face token (hf_) in text and log-object paths", () => {
+		// HF tokens gate the private LifeOps corpus dataset repo (#14773); corpus
+		// publish/pull tooling echoes the bare value in URLs and CLI output where
+		// no credential-named key protects it, so the value shape must be caught.
+		const hf = `hf_${"A".repeat(20)}0123456789abcd`;
+		const text = redactSensitiveText(`pulling with ${hf} from hub`);
+		expect(text).not.toContain(hf);
+		expect(text).toContain("…");
+
+		// Log-sink path: the token hides under a NON-credential key name, so only
+		// value-shape detection can mask it.
+		const [ctx] = redactLogArgs([
+			{ note: `curl -H "Authorization: X" https://hf.co?x=${hf}` },
+		]) as [{ note: string }];
+		expect(ctx.note).not.toContain(hf);
+
+		// Object path: redactObjectSecrets applies pattern detection to nested strings.
+		const obj = redactObjectSecrets({ nested: [`token ${hf}`] }, {});
+		expect(obj.nested[0]).not.toContain(hf);
+	});
+
 	it("masks Stripe secret + restricted keys (underscore form)", () => {
 		// Stripe is the payment processor — a leaked sk_live_ is catastrophic, and these
 		// often appear as bare values (not under a *_SECRET name) in logged request bodies.

--- a/packages/core/src/security/redact.ts
+++ b/packages/core/src/security/redact.ts
@@ -53,6 +53,12 @@ const DEFAULT_REDACT_PATTERNS: string[] = [
 	String.raw`\b((?:sk|rk)_(?:live|test)_[A-Za-z0-9]{10,})\b`,
 	String.raw`\b(ghp_[A-Za-z0-9]{20,})\b`,
 	String.raw`\b(github_pat_[A-Za-z0-9_]{20,})\b`,
+	// Hugging Face access tokens (hf_…) — gate the private LifeOps corpus dataset
+	// repo (#14773). The ENV-name pattern above catches `HF_TOKEN=…`, but corpus
+	// publish/pull tooling also echoes the bare value in URLs and CLI output, so
+	// the value shape needs its own detector. This set also feeds the Stage-1
+	// secret swap (secret-swap.ts) and the corpus scrub/verify gates (corpus-tools).
+	String.raw`\b(hf_[A-Za-z0-9]{15,})\b`,
 	String.raw`\b(xox[baprs]-[A-Za-z0-9-]{10,})\b`,
 	String.raw`\b(xapp-[A-Za-z0-9-]{10,})\b`,
 	String.raw`\b(gsk_[A-Za-z0-9_-]{10,})\b`,
@@ -160,7 +166,7 @@ function parsePattern(raw: string): RegExp | null {
 // Compiled once at module load. The default patterns never change, and
 // String.prototype.replace resets a global regex's lastIndex before each call,
 // so the same compiled array is safe to reuse across every redaction — no need
-// to allocate 16 fresh RegExp objects per call.
+// to allocate fresh RegExp objects per call.
 const DEFAULT_REDACT_REGEXPS: readonly RegExp[] = DEFAULT_REDACT_PATTERNS.map(
 	parsePattern,
 ).filter((re): re is RegExp => Boolean(re));

--- a/packages/core/src/security/secret-swap.test.ts
+++ b/packages/core/src/security/secret-swap.test.ts
@@ -45,6 +45,22 @@ describe("SecretSwapSession", () => {
 		expect(swapped.prompt).not.toContain("sk-known");
 	});
 
+	it("swaps a bare Hugging Face token via the shared redact pattern set", () => {
+		// Ingress draws value-shape detectors from ./redact, so the hf_ pattern
+		// added for the private corpus repo (#14773) must swap here with no
+		// secret-swap-side change — proving the shared set actually propagates.
+		const session = new SecretSwapSession();
+		const hf = `hf_${"B".repeat(20)}0123456789abcd`;
+		const original = `corpus pull auth ${hf} done`;
+		const swapped = session.substituteText(original);
+
+		expect(swapped).not.toContain(hf);
+		expect(swapped).toMatch(PLACEHOLDER);
+		expect(session.restoreText(swapped, { failOnUnresolved: true })).toBe(
+			original,
+		);
+	});
+
 	it("fails loud on a fabricated this-session placeholder, ignores foreign ones", () => {
 		const session = new SecretSwapSession();
 		const swapped = session.substituteText("key sk-test_1234567890abcdef");


### PR DESCRIPTION
# Summary

Part of #14773 (private HF corpus distribution channel).

Adds the missing `hf_` **value-shape token detector** to `DEFAULT_REDACT_PATTERNS` in `packages/core/src/security/redact.ts` — the detector half of the issue's "token never logged" acceptance criterion. Hugging Face tokens (`hf_` + 15+ alphanumerics) were the one credential shape the corpus publish/pull channel depends on that the shared pattern set did not cover (`ghp_`/`npm_`/`gsk_`/`sk-`/`csk-` all exist).

Because the pattern set is shared, one addition propagates to every enforcement point:

- **text redaction** (`redactSensitiveText`) and the **log sink** (`redactLogArgs`) — a bare token in CLI output/URLs is masked even under a non-credential key name,
- **object redaction** (`redactObjectSecrets`),
- the **Stage-1 secret swap** (`secret-swap.ts` draws `SECRET_PATTERNS` from `getDefaultRedactPatterns()`), so a bare `hf_` token never reaches the model and round-trips through the placeholder restore,
- the **corpus-tools scrub/verify gates** (`pipeline/mine.ts`, `verification.ts` both consume the same set), so an `hf_` token in corpus content is now a verification finding.

Tests: new `redact.test.ts` case covering text + log-sink + object paths, and a new `secret-swap.test.ts` case proving the Stage-1 swap picks the token up via the shared set with an exact restore round-trip. Red/green proven: both new tests fail on the pre-change pattern set (red log attached), pass with it.

## Scope note (lane coordination)

The rest of #14773 (corpus:publish / corpus:pull scripts in `packages/corpus-tools`) is claimed by lane `wf_f4da59d0` (issue comment, 2026-07-10T08:53Z); this PR deliberately does not touch `packages/corpus-tools` code. Remaining units for the issue: fail-closed `corpus:publish`, `corpus:pull` + stub round-trip (that lane), and the owner-gated live round-trip evidence (needs-shaw: private repo + token + first authorized upload).

## Verification

All commands run on this branch rebased onto `origin/develop` (`e00bc24446`), Node 24 / Bun:

- `bunx vitest run src/security` (packages/core) — **21 files, 281 tests passed** ([green log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr14773-hf-redact-green.log))
- Red proof: with `redact.ts` reverted to HEAD, the two new tests fail exactly ([red log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr14773-hf-redact-red.log))
- `bunx vitest run src/runtime/__tests__/secret-swap-egress.test.ts src/runtime/__tests__/secret-swap-use-model.test.ts` — 7 passed
- `bun run --cwd packages/corpus-tools test` — **7 files, 81 tests passed** with the widened pattern set ([log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr14773-corpus-tools-tests.log))
- `bun run --cwd packages/core typecheck` — exit 0; `bun run --cwd packages/corpus-tools typecheck` — exit 0 ([log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr14773-typecheck.log))
- `bunx @biomejs/biome check` on the three changed files — no lint diagnostics; the only reports are pre-existing whole-file tab-vs-space `format` diagnostics that reproduce identically on the unmodified HEAD versions of the same files (root `biome.json` says spaces, these committed files use tabs), so nothing new is introduced.
- Error-policy ratchet: no catch blocks or error handling touched (pattern-array append + tests only).

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots `N/A - no UI surface; core security library pattern addition only (no packages/app or packages/ui files touched)`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots `N/A - no UI surface; core security library pattern addition only`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no user-facing flow; deterministic library change exercised by the attached test logs`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: the redaction/secret-swap code paths firing end to end are shown by the in-process suite run — [pr14773-hf-redact-green.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr14773-hf-redact-green.log) (281 security tests incl. the new hf_ text/log-sink/object and Stage-1 swap round-trip cases).
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent/action/provider/prompt/model behavior change; redaction pattern set is deterministic and model-independent (the secret swap keeps tokens FROM reaching the model)`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [red run proving the tests bite](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr14773-hf-redact-red.log), [corpus-tools suite consuming the widened set](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr14773-corpus-tools-tests.log), [core + corpus-tools typecheck](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr14773-typecheck.log).

## Risks

Low. `\b(hf_[A-Za-z0-9]{15,})\b` mirrors the existing prefix-token detectors (`ghp_{20,}`, `npm_{10,}`); the 15-char floor plus the no-underscore character class keeps ordinary `hf_*` snake_case identifiers unmasked. Repo-wide grep found no `hf_`-shaped fixture strings that the corpus verify gate would newly flag.
