### PR TITLE
[sol-cloud] security-hardening

### DIFF
--- a/packages/cloud/api/v1/voice/stt/providers/deepgram-flux.test.ts
+++ b/packages/cloud/api/v1/voice/stt/providers/deepgram-flux.test.ts
@@ -126,6 +126,20 @@ describe("Deepgram Flux realtime adapter", () => {
     expect(url.searchParams.get("eager_eot_threshold")).toBe("0.4");
     expect(url.searchParams.get("eot_threshold")).toBe("0.9");
     expect(url.searchParams.get("eot_timeout_ms")).toBe("1500");
+    expect(url.searchParams.get("mip_opt_out")).toBe("true");
+  });
+
+  it("allows an explicit operator override of the Deepgram training opt-out", () => {
+    const config = resolveDeepgramFluxConfig({
+      deepgramApiKey: "dg-secret",
+      mipOptOut: "false",
+    });
+
+    expect(
+      new URL(buildDeepgramFluxListenUrl(config)).searchParams.get(
+        "mip_opt_out",
+      ),
+    ).toBe("false");
   });
 
   it("passes the server-side API key by Authorization header and never in the query URL", () => {
@@ -434,6 +448,12 @@ describe("Deepgram Flux realtime adapter", () => {
       resolveDeepgramFluxConfig({
         deepgramApiKey: "dg-secret",
         eotTimeoutMs: 10_001,
+      }),
+    ).toThrow(DeepgramFluxConfigError);
+    expect(() =>
+      resolveDeepgramFluxConfig({
+        deepgramApiKey: "dg-secret",
+        mipOptOut: "sometimes",
       }),
     ).toThrow(DeepgramFluxConfigError);
   });

--- a/packages/cloud/api/v1/voice/stt/providers/deepgram-flux.ts
+++ b/packages/cloud/api/v1/voice/stt/providers/deepgram-flux.ts
@@ -19,6 +19,7 @@ const DEFAULT_EAGER_EOT_THRESHOLD = 0.35;
 const DEFAULT_EOT_THRESHOLD = 0.8;
 const DEFAULT_EOT_TIMEOUT_MS = 5_000;
 const DEFAULT_CLOSE_CODE = 1000;
+const DEFAULT_MIP_OPT_OUT = true;
 
 export type DeepgramFluxMetricName =
   | "deepgram_flux_connected"
@@ -44,6 +45,7 @@ export type DeepgramFluxConfigInput = {
   eagerEotThreshold?: number | string;
   eotThreshold?: number | string;
   eotTimeoutMs?: number | string;
+  mipOptOut?: boolean | string;
 };
 
 export type DeepgramFluxConfig = {
@@ -53,6 +55,7 @@ export type DeepgramFluxConfig = {
   eagerEotThreshold: number;
   eotThreshold: number;
   eotTimeoutMs: number;
+  mipOptOut: boolean;
 };
 
 export type DeepgramFluxTransportRequest = {
@@ -223,6 +226,11 @@ export function resolveDeepgramFluxConfig(
       500,
       10_000,
     ),
+    mipOptOut: resolveBoolean(
+      "mip_opt_out",
+      input.mipOptOut,
+      DEFAULT_MIP_OPT_OUT,
+    ),
   };
 }
 
@@ -235,6 +243,7 @@ export function buildDeepgramFluxListenUrl(config: DeepgramFluxConfig): string {
   url.searchParams.set("eager_eot_threshold", String(config.eagerEotThreshold));
   url.searchParams.set("eot_threshold", String(config.eotThreshold));
   url.searchParams.set("eot_timeout_ms", String(config.eotTimeoutMs));
+  url.searchParams.set("mip_opt_out", String(config.mipOptOut));
   return url.toString();
 }
 
@@ -538,6 +547,20 @@ function resolveTunable(
     );
   }
   return resolved;
+}
+
+function resolveBoolean(
+  name: string,
+  configured: boolean | string | undefined,
+  defaultValue: boolean,
+): boolean {
+  if (configured === undefined) return defaultValue;
+  if (typeof configured === "boolean") return configured;
+  const normalized = configured.trim().toLowerCase();
+  if (normalized === "") return defaultValue;
+  if (["1", "true", "yes", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "off"].includes(normalized)) return false;
+  throw new DeepgramFluxConfigError(`${name} must be a boolean`);
 }
 
 type ParsedDeepgramFluxMessage =

--- a/packages/cloud/api/v1/voice/stt/route.test.ts
+++ b/packages/cloud/api/v1/voice/stt/route.test.ts
@@ -17,6 +17,12 @@ const requireAuthOrApiKeyWithOrg = mock<() => Promise<unknown>>();
 mock.module("@/lib/auth", () => ({
   requireAuthOrApiKeyWithOrg,
 }));
+const logError = mock(() => {});
+const logInfo = mock(() => {});
+const logWarn = mock(() => {});
+mock.module("@/lib/utils/logger", () => ({
+  logger: { error: logError, info: logInfo, warn: logWarn },
+}));
 // Billing and provider modules are mocked so importing the route does not
 // initialize DB-backed services in a unit-test process; their behavior is
 // mutable per test so both lanes (free whisper, billed ElevenLabs) and the
@@ -54,7 +60,8 @@ mock.module("@/lib/services/usage", () => ({
   usageService: { create: mock(async () => ({})) },
 }));
 
-const sttRoute = (await import("./route")).default;
+const sttRouteModule = await import("./route");
+const sttRoute = sttRouteModule.default;
 const app = new Hono().route("/api/v1/voice/stt", sttRoute);
 
 /** A real RIFF/WAVE mono PCM16 file so the route's magic-number check passes. */
@@ -213,6 +220,10 @@ const LIVE_SHAPE = {
 };
 
 beforeEach(() => {
+  sttRouteModule.__resetVoiceUsageMeterForTests();
+  logError.mockClear();
+  logInfo.mockClear();
+  logWarn.mockClear();
   requireAuthOrApiKeyWithOrg.mockReset();
   requireAuthOrApiKeyWithOrg.mockResolvedValue({
     user: { id: "user-1", organization_id: "org-1" },
@@ -225,6 +236,9 @@ beforeEach(() => {
   speechToText.mockReset();
   speechToText.mockResolvedValue("elevenlabs transcript");
   upstreamReply = () => Response.json({ text: "" });
+  captured.fields = {};
+  captured.fileName = null;
+  captured.fileType = null;
 });
 
 describe("POST /api/v1/voice/stt — shared upload validation gates", () => {
@@ -264,9 +278,47 @@ describe("POST /api/v1/voice/stt — shared upload validation gates", () => {
       undefined,
       whisperEnv,
     );
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(413);
     expect(await readJson(res)).toEqual({
-      error: "File too large. Maximum size is 25MB",
+      error: "Audio request exceeds the configured size limit",
+      type: "request_too_large",
+    });
+  });
+
+  test("a configured request-size ceiling rejects audio before provider work", async () => {
+    const res = await app.request(sttRequest(), undefined, {
+      WHISPER_STT_URL: `http://localhost:${upstream.port}`,
+      VOICE_STT_MAX_REQUEST_BYTES: "100",
+    } as never);
+    expect(res.status).toBe(413);
+    expect(speechToText).not.toHaveBeenCalled();
+  });
+
+  test("server-derived audio duration enforces the per-user daily cap", async () => {
+    const res = await app.request(sttRequest(), undefined, {
+      WHISPER_STT_URL: `http://localhost:${upstream.port}`,
+      VOICE_STT_USAGE_METERING_ENABLED: "true",
+      VOICE_STT_USER_DAILY_MINUTES: "0.003",
+    } as never);
+    expect(res.status).toBe(429);
+    expect(await readJson(res)).toEqual({
+      error: "Daily speech-to-text quota exhausted",
+      type: "quota_exhausted",
+      scope: "user",
+    });
+    expect(captured.fileName).toBeNull();
+  });
+
+  test("production metering fails closed without a durable Redis binding", async () => {
+    const res = await app.request(sttRequest(), undefined, {
+      ENVIRONMENT: "production",
+      WHISPER_STT_URL: `http://localhost:${upstream.port}`,
+      VOICE_STT_USAGE_METERING_ENABLED: "true",
+    } as never);
+    expect(res.status).toBe(503);
+    expect(await readJson(res)).toEqual({
+      error: "Speech-to-text usage metering is unavailable",
+      type: "service_unavailable",
     });
   });
 
@@ -413,12 +465,17 @@ describe("POST /api/v1/voice/stt — whisper lane (#14806)", () => {
     expect(await readJson(res)).toEqual({ error: "Speech-to-text failed" });
   });
 
-  test("an upstream 5xx stays a structured 502", async () => {
-    upstreamReply = () => new Response("boom", { status: 500 });
+  test("an upstream 5xx stays a structured 502 without logging its body", async () => {
+    upstreamReply = () =>
+      new Response("secret transcript and provider token", { status: 500 });
     const res = await app.request(sttRequest(), undefined, whisperEnv);
 
     expect(res.status).toBe(502);
     expect(await readJson(res)).toEqual({ error: "Speech-to-text failed" });
+    expect(JSON.stringify(logError.mock.calls)).not.toContain(
+      "secret transcript",
+    );
+    expect(JSON.stringify(logError.mock.calls)).not.toContain("provider token");
   });
 });
 
@@ -443,6 +500,13 @@ describe("POST /api/v1/voice/stt — billed ElevenLabs lane", () => {
     const call = speechToText.mock.calls[0][0];
     expect(call.audioFile.name).toBe("probe.wav");
     expect(call.languageCode).toBe("fr");
+    const logs = JSON.stringify([
+      ...logError.mock.calls,
+      ...logInfo.mock.calls,
+      ...logWarn.mock.calls,
+    ]);
+    expect(logs).not.toContain("elevenlabs transcript");
+    expect(logs).not.toContain("probe.wav");
   });
 
   test("insufficient credits is a 402 carrying the required amount", async () => {

--- a/packages/cloud/api/v1/voice/stt/route.ts
+++ b/packages/cloud/api/v1/voice/stt/route.ts
@@ -27,6 +27,12 @@ import type { AppEnv } from "@/types/cloud-worker-env";
  * - Credit reservation before processing ensures payment
  */
 
+import {
+  createDurableVoiceUsageStore,
+  InMemoryVoiceUsageStore,
+  type VoiceUsageIdentity,
+  type VoiceUsageStore,
+} from "@elizaos/cloud-shared/lib/services/voice-usage-meter";
 import { fileTypeFromBuffer } from "file-type";
 import { parseBuffer } from "music-metadata";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
@@ -44,6 +50,13 @@ import { resolveWhisperSttModel } from "./whisper-model";
 import { parseWhisperTimestamps } from "./whisper-timestamps";
 
 const MAX_FILE_SIZE = 25 * 1024 * 1024; // 25MB
+const DEFAULT_ORG_DAILY_MINUTES = 1_440;
+const DEFAULT_USER_DAILY_MINUTES = 720;
+const voiceUsageStore = new InMemoryVoiceUsageStore();
+
+export function __resetVoiceUsageMeterForTests(): void {
+  voiceUsageStore.clear();
+}
 
 const SUPPORTED_MIME_TYPES = [
   "audio/mp3",
@@ -91,6 +104,12 @@ function estimateAudioDurationMinutes(
   return Math.max(0.1, estimatedMinutes);
 }
 
+function positiveEnvNumber(value: unknown, fallback: number): number {
+  if (typeof value !== "string" || value.trim() === "") return fallback;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
 /**
  * POST /api/v1/voice/stt
  * Converts speech to text using the voice transcription service.
@@ -102,6 +121,14 @@ function estimateAudioDurationMinutes(
  */
 async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
   let reservation: CreditReservation | undefined;
+  let meteringCompleted = false;
+  let meteringReservation:
+    | {
+        store: VoiceUsageStore;
+        identity: VoiceUsageIdentity;
+        minutes: number;
+      }
+    | undefined;
 
   try {
     const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
@@ -125,12 +152,17 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
       );
     }
 
-    if (audioFile.size > MAX_FILE_SIZE) {
+    const maxFileSize = positiveEnvNumber(
+      env.VOICE_STT_MAX_REQUEST_BYTES,
+      MAX_FILE_SIZE,
+    );
+    if (audioFile.size > maxFileSize) {
       return Response.json(
         {
-          error: `File too large. Maximum size is ${MAX_FILE_SIZE / 1024 / 1024}MB`,
+          error: "Audio request exceeds the configured size limit",
+          type: "request_too_large",
         },
-        { status: 400 },
+        { status: 413 },
       );
     }
 
@@ -148,9 +180,9 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
     const fileTypeResult = await fileTypeFromBuffer(buffer);
 
     if (!fileTypeResult) {
-      logger.warn(
-        `[Voice STT API] Unable to detect file type for ${audioFile.name} - rejecting`,
-      );
+      logger.warn("[Voice STT API] Unable to detect audio file type", {
+        audioSizeBytes: audioFile.size,
+      });
       return Response.json(
         {
           error:
@@ -161,9 +193,10 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
     }
 
     if (!ALLOWED_AUDIO_SIGNATURES.has(fileTypeResult.mime)) {
-      logger.warn(
-        `[Voice STT API] File signature mismatch for ${audioFile.name}: claimed=${baseMimeType}, actual=${fileTypeResult.mime}`,
-      );
+      logger.warn("[Voice STT API] Audio file signature mismatch", {
+        actualMimeType: fileTypeResult.mime,
+        claimedMimeType: baseMimeType,
+      });
       return Response.json(
         {
           error: `File content does not match the declared format. Detected: ${fileTypeResult.mime}, Expected audio format.`,
@@ -180,9 +213,83 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
       finalMimeType = "audio/webm";
     }
 
-    logger.info(
-      `[Voice STT API] Processing for user ${user.id}: ${audioFile.name} (${audioFile.size} bytes, verified: ${fileTypeResult.mime}, final: ${finalMimeType})`,
-    );
+    const whisperBaseUrl = env.WHISPER_STT_URL?.trim();
+    const meteringEnabled = env.VOICE_STT_USAGE_METERING_ENABLED === "true";
+    let durationSeconds = 1;
+    let estimatedDurationMinutes = 1 / 60;
+    if (meteringEnabled || !whisperBaseUrl) {
+      let parsedDurationSeconds: number | undefined;
+      try {
+        const metadata = await parseBuffer(buffer, { mimeType: finalMimeType });
+        if (Number.isFinite(metadata.format?.duration)) {
+          parsedDurationSeconds = metadata.format.duration;
+        }
+      } catch {
+        return Response.json(
+          { error: "Unable to parse audio metadata", type: "invalid_audio" },
+          { status: 400 },
+        );
+      }
+      durationSeconds = Math.max(
+        parsedDurationSeconds ??
+          estimateAudioDurationMinutes(audioFile.size, finalMimeType) * 60,
+        1,
+      );
+      estimatedDurationMinutes = durationSeconds / 60;
+    }
+    if (meteringEnabled) {
+      const durableStore = createDurableVoiceUsageStore(env);
+      if (env.ENVIRONMENT === "production" && !durableStore) {
+        return Response.json(
+          {
+            error: "Speech-to-text usage metering is unavailable",
+            type: "service_unavailable",
+          },
+          { status: 503 },
+        );
+      }
+      const store = durableStore ?? voiceUsageStore;
+      const identity = {
+        organizationId: user.organization_id,
+        userId: user.id,
+      };
+      const meteringDecision = await store.checkAndRecord(
+        identity,
+        estimatedDurationMinutes,
+        {
+          organizationDailyMinutes: positiveEnvNumber(
+            env.VOICE_STT_ORG_DAILY_MINUTES,
+            DEFAULT_ORG_DAILY_MINUTES,
+          ),
+          userDailyMinutes: positiveEnvNumber(
+            env.VOICE_STT_USER_DAILY_MINUTES,
+            DEFAULT_USER_DAILY_MINUTES,
+          ),
+        },
+      );
+      if (!meteringDecision.allowed) {
+        return Response.json(
+          {
+            error: "Daily speech-to-text quota exhausted",
+            type: "quota_exhausted",
+            scope: meteringDecision.scope,
+          },
+          { status: 429 },
+        );
+      }
+      meteringReservation = {
+        store,
+        identity,
+        minutes: estimatedDurationMinutes,
+      };
+    }
+
+    logger.info("[Voice STT API] Processing verified audio", {
+      audioSizeBytes: audioFile.size,
+      finalMimeType,
+      userId: user.id,
+      verifiedMimeType: fileTypeResult.mime,
+    });
 
     // -------------------------------------------------------------------------
     // Free default STT: self-hosted Whisper (OpenAI-compatible
@@ -190,7 +297,6 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
     // default — no credit reservation, no billing. ElevenLabs STT is the path
     // below. Inert when WHISPER_STT_URL is unset.
     // -------------------------------------------------------------------------
-    const whisperBaseUrl = env.WHISPER_STT_URL?.trim();
     if (whisperBaseUrl) {
       const whisperStart = Date.now();
       const form = new FormData();
@@ -213,10 +319,10 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
         { method: "POST", body: form },
       );
       if (!whisperResponse.ok) {
-        const detail = await whisperResponse.text().catch(() => "");
-        logger.error(
-          `[Voice STT API] Whisper failed (${whisperResponse.status}): ${detail.slice(0, 200)}`,
-        );
+        await whisperResponse.body?.cancel().catch(() => undefined);
+        logger.error("[Voice STT API] Whisper request failed", {
+          status: whisperResponse.status,
+        });
         return Response.json(
           { error: "Speech-to-text failed" },
           { status: 502 },
@@ -228,10 +334,8 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
       let whisperPayload: unknown;
       try {
         whisperPayload = await whisperResponse.json();
-      } catch (parseError) {
-        logger.error(
-          `[Voice STT API] Whisper returned unparseable JSON: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
-        );
+      } catch {
+        logger.error("[Voice STT API] Whisper returned unparseable JSON");
         return Response.json(
           { error: "Speech-to-text failed" },
           { status: 502 },
@@ -276,6 +380,7 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
         transcriptLength: transcript.length,
         wordCount: words?.length,
       });
+      meteringCompleted = true;
       return Response.json({
         transcript,
         duration_ms: whisperDuration,
@@ -284,15 +389,6 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
       });
     }
 
-    const metadata = await parseBuffer(buffer, { mimeType: finalMimeType });
-    const parsedDurationSeconds = metadata.format?.duration;
-    const durationSeconds = Number.isFinite(parsedDurationSeconds)
-      ? Math.max(parsedDurationSeconds ?? 0, 1)
-      : Math.max(
-          estimateAudioDurationMinutes(audioFile.size, finalMimeType) * 60,
-          1,
-        );
-    const estimatedDurationMinutes = durationSeconds / 60;
     const sttCost = await calculateSTTCostFromCatalog({
       model: "elevenlabs/scribe_v1",
       durationSeconds,
@@ -346,9 +442,10 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
       reservation,
     );
 
-    logger.info(
-      `[Voice STT API] Completed in ${duration}ms: "${transcript.substring(0, 100)}..."`,
-    );
+    logger.info("[Voice STT API] Completed", {
+      durationMs: duration,
+      transcriptLength: transcript.length,
+    });
 
     (async () => {
       try {
@@ -367,11 +464,9 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
           duration_ms: duration,
           is_successful: true,
           metadata: {
-            audioFileName: audioFile.name,
             audioSizeBytes: audioFile.size,
             estimatedDurationMinutes,
             durationSeconds,
-            languageCode,
             transcriptLength: transcript.length,
             baseTotalCost: billing.baseTotalCost,
             billingSource: "elevenlabs",
@@ -379,17 +474,20 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
         });
       } catch (error) {
         logger.error("[Voice STT API] Failed to create usage record", {
-          error: error instanceof Error ? error.message : String(error),
+          errorType: error instanceof Error ? error.name : "unknown",
         });
       }
     })();
 
+    meteringCompleted = true;
     return Response.json({
       transcript,
       duration_ms: duration,
     });
   } catch (error) {
-    logger.error("[Voice STT API] Error:", error);
+    logger.error("[Voice STT API] Request failed", {
+      errorType: error instanceof Error ? error.name : "unknown",
+    });
 
     if (reservation) {
       await reservation.reconcile(0);
@@ -459,6 +557,19 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
       { error: "Failed to transcribe audio. Please try again." },
       { status: 500 },
     );
+  } finally {
+    if (meteringReservation && !meteringCompleted) {
+      try {
+        await meteringReservation.store.release(
+          meteringReservation.identity,
+          meteringReservation.minutes,
+        );
+      } catch (error) {
+        logger.error("[Voice STT API] Failed to release usage reservation", {
+          errorType: error instanceof Error ? error.name : "unknown",
+        });
+      }
+    }
   }
 }
 

--- a/packages/cloud/api/v1/voice/tts/route.ts
+++ b/packages/cloud/api/v1/voice/tts/route.ts
@@ -267,7 +267,10 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
           // error-policy:J4 cache lookup failure degrades to fresh synthesis;
           // the upstream Railway request below is the source of truth.
           logger.warn?.(
-            `[Voice TTS API] Kokoro first-line cache lookup failed: ${err instanceof Error ? err.message : String(err)}`,
+            "[Voice TTS API] Kokoro first-line cache lookup failed",
+            {
+              errorType: err instanceof Error ? err.name : "unknown",
+            },
           );
         }
       }
@@ -323,7 +326,10 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
             // error-policy:J7 populate is a background write; a failure must not
             // affect the response the user already receives below.
             logger.warn?.(
-              `[Voice TTS API] Kokoro first-line cache populate failed: ${err instanceof Error ? err.message : String(err)}`,
+              "[Voice TTS API] Kokoro first-line cache populate failed",
+              {
+                errorType: err instanceof Error ? err.name : "unknown",
+              },
             );
           });
 
@@ -363,8 +369,7 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
         userVoicesRepository.incrementUsageCount(voice.id).catch((err) =>
           logger.error("[Voice TTS API] Failed to increment voice usage", {
             voiceId: voice.id,
-            voiceName: voice.name,
-            error: err instanceof Error ? err.message : String(err),
+            errorType: err instanceof Error ? err.name : "unknown",
           }),
         );
 
@@ -438,9 +443,9 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
       } catch (err) {
         // error-policy:J4 cache lookup failure degrades to fresh synthesis; the
         // ElevenLabs request below remains the source of truth.
-        logger.warn?.(
-          `[Voice TTS API] first-line cache lookup failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
+        logger.warn?.("[Voice TTS API] first-line cache lookup failed", {
+          errorType: err instanceof Error ? err.name : "unknown",
+        });
       }
     }
 
@@ -557,7 +562,7 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
         });
       } catch (error) {
         logger.error("[Voice TTS API] Failed to create usage record", {
-          error: error instanceof Error ? error.message : String(error),
+          errorType: error instanceof Error ? error.name : "unknown",
           userVoiceId,
         });
       }
@@ -624,9 +629,9 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
             `[Voice TTS API] first-line cache POPULATE ok (${cacheScope}, ${total}B, words=${snipResult.wordCount})`,
           );
         } catch (err) {
-          logger.warn?.(
-            `[Voice TTS API] first-line cache populate failed: ${err instanceof Error ? err.message : String(err)}`,
-          );
+          logger.warn?.("[Voice TTS API] first-line cache populate failed", {
+            errorType: err instanceof Error ? err.name : "unknown",
+          });
         }
       })();
     }
@@ -654,7 +659,9 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
       },
     });
   } catch (error) {
-    logger.error("[Voice TTS API] Error:", error);
+    logger.error("[Voice TTS API] Request failed", {
+      errorType: error instanceof Error ? error.name : "unknown",
+    });
 
     if (reservation) {
       await reservation.reconcile(0);

--- a/packages/cloud/shared/src/lib/cache/socket-redis.ts
+++ b/packages/cloud/shared/src/lib/cache/socket-redis.ts
@@ -630,6 +630,11 @@ export class SocketRedis {
     return asString(v) ?? "PONG";
   }
 
+  async eval(script: string, keys: string[], args: Array<string | number>): Promise<unknown> {
+    const [value] = await this.conn.send([["EVAL", script, keys.length, ...keys, ...args]]);
+    return unwrap(value);
+  }
+
   pipeline(): Pipeline {
     return new Pipeline(this.conn);
   }

--- a/packages/cloud/shared/src/lib/services/voice-usage-meter.test.ts
+++ b/packages/cloud/shared/src/lib/services/voice-usage-meter.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type AtomicVoiceUsageRedis,
+  checkVoiceByteRate,
+  createDurableVoiceUsageStore,
+  InMemoryVoiceUsageStore,
+  pcmDurationMinutes,
+  RedisVoiceUsageStore,
+} from "./voice-usage-meter";
+
+describe("InMemoryVoiceUsageStore", () => {
+  test("isolates organization and user daily counters", async () => {
+    const store = new InMemoryVoiceUsageStore(() => Date.UTC(2026, 6, 10));
+    const limits = { organizationDailyMinutes: 10, userDailyMinutes: 6 };
+
+    expect(
+      (await store.checkAndRecord({ organizationId: "a", userId: "u1" }, 4, limits)).allowed,
+    ).toBe(true);
+    expect(
+      await store.checkAndRecord({ organizationId: "a", userId: "u1" }, 3, limits),
+    ).toMatchObject({ allowed: false, scope: "user" });
+    expect(
+      (await store.checkAndRecord({ organizationId: "a", userId: "u2" }, 6, limits)).allowed,
+    ).toBe(true);
+    expect(
+      await store.checkAndRecord({ organizationId: "a", userId: "u3" }, 1, limits),
+    ).toMatchObject({ allowed: false, scope: "organization" });
+    expect(
+      (await store.checkAndRecord({ organizationId: "b", userId: "u1" }, 6, limits)).allowed,
+    ).toBe(true);
+  });
+
+  test("releases a failed-operation reservation", async () => {
+    const store = new InMemoryVoiceUsageStore(() => Date.UTC(2026, 6, 10));
+    const identity = { organizationId: "a", userId: "u" };
+    const limits = { organizationDailyMinutes: 5, userDailyMinutes: 5 };
+    expect((await store.checkAndRecord(identity, 5, limits)).allowed).toBe(true);
+    await store.release(identity, 3);
+    expect((await store.checkAndRecord(identity, 3, limits)).allowed).toBe(true);
+  });
+
+  test("resets counters at the UTC day boundary", async () => {
+    let now = Date.UTC(2026, 6, 10, 23, 59);
+    const store = new InMemoryVoiceUsageStore(() => now);
+    const identity = { organizationId: "a", userId: "u" };
+    const limits = { organizationDailyMinutes: 2, userDailyMinutes: 2 };
+    expect((await store.checkAndRecord(identity, 2, limits)).allowed).toBe(true);
+    expect((await store.checkAndRecord(identity, 0.1, limits)).allowed).toBe(false);
+    now = Date.UTC(2026, 6, 11);
+    expect(await store.checkAndRecord(identity, 2, limits)).toMatchObject({
+      allowed: true,
+      day: "2026-07-11",
+    });
+  });
+});
+
+describe("RedisVoiceUsageStore", () => {
+  test("does not misclassify the non-Lua mock client as durable", () => {
+    expect(createDurableVoiceUsageStore({ MOCK_REDIS: "1" })).toBeNull();
+  });
+
+  test("uses one atomic script with day-scoped org and user keys", async () => {
+    const calls: Array<{ keys: string[]; args: Array<string | number> }> = [];
+    const redis: AtomicVoiceUsageRedis = {
+      async eval(_script, keys, args) {
+        calls.push({ keys, args });
+        return [1, 0, 2_000_000, 1_000_000];
+      },
+    };
+    const store = new RedisVoiceUsageStore(redis, () => Date.UTC(2026, 6, 10, 12));
+    const decision = await store.checkAndRecord({ organizationId: "org", userId: "user" }, 1, {
+      organizationDailyMinutes: 10,
+      userDailyMinutes: 5,
+    });
+
+    expect(decision).toMatchObject({
+      allowed: true,
+      organizationUsedMinutes: 2,
+      userUsedMinutes: 1,
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].keys).toEqual([
+      "voice-usage:2026-07-10:org:org",
+      "voice-usage:2026-07-10:user:org:user",
+    ]);
+    expect(calls[0].args.slice(0, 3)).toEqual([1_000_000, 10_000_000, 5_000_000]);
+
+    await store.release({ organizationId: "org", userId: "user" }, 1);
+    expect(calls).toHaveLength(2);
+    expect(calls[1].keys).toEqual(calls[0].keys);
+    expect(calls[1].args[0]).toBe(1_000_000);
+  });
+
+  test("maps an atomic user denial without recording partial usage", async () => {
+    const redis: AtomicVoiceUsageRedis = {
+      async eval() {
+        return [0, 2, 4_000_000, 4_500_000];
+      },
+    };
+    const decision = await new RedisVoiceUsageStore(redis, () =>
+      Date.UTC(2026, 6, 10),
+    ).checkAndRecord({ organizationId: "org", userId: "user" }, 1, {
+      organizationDailyMinutes: 10,
+      userDailyMinutes: 5,
+    });
+    expect(decision).toMatchObject({ allowed: false, scope: "user", usedMinutes: 4.5 });
+  });
+});
+
+describe("voice byte and duration accounting", () => {
+  test("enforces a server-observed byte-rate ceiling with jitter grace", () => {
+    expect(
+      checkVoiceByteRate({ observedBytes: 48_000, elapsedMs: 1_000, maxBytesPerSecond: 32_000 }),
+    ).toMatchObject({ allowed: true, allowedBytes: 64_000 });
+    expect(
+      checkVoiceByteRate({ observedBytes: 64_001, elapsedMs: 1_000, maxBytesPerSecond: 32_000 })
+        .allowed,
+    ).toBe(false);
+  });
+
+  test("derives PCM minutes from server-observed bytes and format", () => {
+    expect(
+      pcmDurationMinutes({
+        byteLength: 1_920_000,
+        sampleRate: 16_000,
+        channels: 1,
+        bytesPerSample: 2,
+      }),
+    ).toBe(1);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/voice-usage-meter.ts
+++ b/packages/cloud/shared/src/lib/services/voice-usage-meter.ts
@@ -1,0 +1,316 @@
+import { buildRedisClient, type RedisFactoryEnv } from "../cache/redis-factory";
+
+const DAY_MS = 86_400_000;
+const COUNTER_SCALE = 1_000_000;
+
+export type VoiceUsageIdentity = {
+  organizationId: string;
+  userId: string;
+};
+
+export type VoiceUsageLimits = {
+  organizationDailyMinutes: number;
+  userDailyMinutes: number;
+};
+
+export type VoiceUsageDecision =
+  | {
+      allowed: true;
+      organizationUsedMinutes: number;
+      userUsedMinutes: number;
+      day: string;
+    }
+  | {
+      allowed: false;
+      scope: "organization" | "user";
+      limitMinutes: number;
+      usedMinutes: number;
+      requestedMinutes: number;
+      day: string;
+    };
+
+export interface VoiceUsageStore {
+  checkAndRecord(
+    identity: VoiceUsageIdentity,
+    requestedMinutes: number,
+    limits: VoiceUsageLimits,
+  ): Promise<VoiceUsageDecision>;
+  release(identity: VoiceUsageIdentity, minutes: number): Promise<void>;
+}
+
+type Counter = { dayNumber: number; minutes: number };
+
+/** Atomic within one JS isolate, intended for tests and local development. */
+export class InMemoryVoiceUsageStore implements VoiceUsageStore {
+  private readonly counters = new Map<string, Counter>();
+  private operations = 0;
+
+  constructor(private readonly now: () => number = Date.now) {}
+
+  async checkAndRecord(
+    identity: VoiceUsageIdentity,
+    requestedMinutes: number,
+    limits: VoiceUsageLimits,
+  ): Promise<VoiceUsageDecision> {
+    validateUsageInput(identity, requestedMinutes, limits);
+    const { dayNumber, day } = resolveDay(this.now());
+    const orgKey = `org:${identity.organizationId}`;
+    const userKey = `user:${identity.organizationId}:${identity.userId}`;
+    const orgUsed = this.current(orgKey, dayNumber);
+    const userUsed = this.current(userKey, dayNumber);
+
+    const denied = quotaDenial(orgUsed, userUsed, requestedMinutes, limits, day);
+    if (denied) return denied;
+
+    const organizationUsedMinutes = orgUsed + requestedMinutes;
+    const userUsedMinutes = userUsed + requestedMinutes;
+    this.counters.set(orgKey, { dayNumber, minutes: organizationUsedMinutes });
+    this.counters.set(userKey, { dayNumber, minutes: userUsedMinutes });
+    if (++this.operations % 256 === 0) this.prune(dayNumber);
+    return { allowed: true, organizationUsedMinutes, userUsedMinutes, day };
+  }
+
+  async release(identity: VoiceUsageIdentity, minutes: number): Promise<void> {
+    assertPositiveFinite("minutes", minutes);
+    const { dayNumber } = resolveDay(this.now());
+    for (const key of [
+      `org:${identity.organizationId}`,
+      `user:${identity.organizationId}:${identity.userId}`,
+    ]) {
+      const counter = this.counters.get(key);
+      if (counter?.dayNumber === dayNumber) {
+        counter.minutes = Math.max(0, counter.minutes - minutes);
+      }
+    }
+  }
+
+  clear(): void {
+    this.counters.clear();
+    this.operations = 0;
+  }
+
+  private current(key: string, dayNumber: number): number {
+    const counter = this.counters.get(key);
+    return counter?.dayNumber === dayNumber ? counter.minutes : 0;
+  }
+
+  private prune(dayNumber: number): void {
+    for (const [key, counter] of this.counters) {
+      if (counter.dayNumber !== dayNumber) this.counters.delete(key);
+    }
+  }
+}
+
+export interface AtomicVoiceUsageRedis {
+  eval(script: string, keys: string[], args: Array<string | number>): Promise<unknown>;
+}
+
+const RELEASE_LUA = `
+for _, key in ipairs(KEYS) do
+  local current = tonumber(redis.call('GET', key) or '0')
+  redis.call('SET', key, math.max(0, current - tonumber(ARGV[1])), 'EX', ARGV[2])
+end
+return 1
+`;
+
+const CHECK_AND_RECORD_LUA = `
+local org = tonumber(redis.call('GET', KEYS[1]) or '0')
+local usr = tonumber(redis.call('GET', KEYS[2]) or '0')
+local requested = tonumber(ARGV[1])
+local org_limit = tonumber(ARGV[2])
+local user_limit = tonumber(ARGV[3])
+if org + requested > org_limit then return {0, 1, org, usr} end
+if usr + requested > user_limit then return {0, 2, org, usr} end
+org = redis.call('INCRBY', KEYS[1], requested)
+usr = redis.call('INCRBY', KEYS[2], requested)
+redis.call('EXPIRE', KEYS[1], ARGV[4])
+redis.call('EXPIRE', KEYS[2], ARGV[4])
+return {1, 0, org, usr}
+`;
+
+/** Durable, cross-isolate quota accounting through one atomic Redis script. */
+export class RedisVoiceUsageStore implements VoiceUsageStore {
+  constructor(
+    private readonly redis: AtomicVoiceUsageRedis,
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  async checkAndRecord(
+    identity: VoiceUsageIdentity,
+    requestedMinutes: number,
+    limits: VoiceUsageLimits,
+  ): Promise<VoiceUsageDecision> {
+    validateUsageInput(identity, requestedMinutes, limits);
+    const now = this.now();
+    const { dayNumber, day } = resolveDay(now);
+    const requested = Math.max(1, Math.ceil(requestedMinutes * COUNTER_SCALE));
+    const orgLimit = Math.floor(limits.organizationDailyMinutes * COUNTER_SCALE);
+    const userLimit = Math.floor(limits.userDailyMinutes * COUNTER_SCALE);
+    const ttlSeconds = Math.ceil((dayNumber * DAY_MS + DAY_MS - now) / 1_000) + 86_400;
+    const prefix = `voice-usage:${day}`;
+    const raw = await this.redis.eval(
+      CHECK_AND_RECORD_LUA,
+      [
+        `${prefix}:org:${identity.organizationId}`,
+        `${prefix}:user:${identity.organizationId}:${identity.userId}`,
+      ],
+      [requested, orgLimit, userLimit, ttlSeconds],
+    );
+    if (!Array.isArray(raw) || raw.length < 4) {
+      throw new Error("Voice usage store returned an invalid response");
+    }
+    const [allowed, deniedScope, orgRaw, userRaw] = raw.map(Number);
+    const orgUsed = orgRaw / COUNTER_SCALE;
+    const userUsed = userRaw / COUNTER_SCALE;
+    if (allowed === 1) {
+      return {
+        allowed: true,
+        organizationUsedMinutes: orgUsed,
+        userUsedMinutes: userUsed,
+        day,
+      };
+    }
+    const scope = deniedScope === 1 ? "organization" : "user";
+    return {
+      allowed: false,
+      scope,
+      limitMinutes:
+        scope === "organization" ? limits.organizationDailyMinutes : limits.userDailyMinutes,
+      usedMinutes: scope === "organization" ? orgUsed : userUsed,
+      requestedMinutes,
+      day,
+    };
+  }
+
+  async release(identity: VoiceUsageIdentity, minutes: number): Promise<void> {
+    assertPositiveFinite("minutes", minutes);
+    const now = this.now();
+    const { dayNumber, day } = resolveDay(now);
+    const ttlSeconds = Math.ceil((dayNumber * DAY_MS + DAY_MS - now) / 1_000) + 86_400;
+    const prefix = `voice-usage:${day}`;
+    await this.redis.eval(
+      RELEASE_LUA,
+      [
+        `${prefix}:org:${identity.organizationId}`,
+        `${prefix}:user:${identity.organizationId}:${identity.userId}`,
+      ],
+      [Math.max(1, Math.ceil(minutes * COUNTER_SCALE)), ttlSeconds],
+    );
+  }
+}
+
+export function createDurableVoiceUsageStore(
+  env: RedisFactoryEnv,
+  now?: () => number,
+): RedisVoiceUsageStore | null {
+  // The repository mock intentionally implements only common Redis commands,
+  // not Lua. Local/tests use the isolate-safe in-memory store instead.
+  if (env.MOCK_REDIS === "1") return null;
+  const redis = buildRedisClient(env);
+  return redis ? new RedisVoiceUsageStore(redis as AtomicVoiceUsageRedis, now) : null;
+}
+
+export type ByteRateDecision = {
+  allowed: boolean;
+  observedBytes: number;
+  allowedBytes: number;
+  byteRate: number;
+};
+
+/** Server-observed byte ceiling. The grace window permits normal frame jitter. */
+export function checkVoiceByteRate(input: {
+  observedBytes: number;
+  elapsedMs: number;
+  maxBytesPerSecond: number;
+  graceMs?: number;
+}): ByteRateDecision {
+  const { observedBytes, elapsedMs, maxBytesPerSecond } = input;
+  const graceMs = input.graceMs ?? 1_000;
+  if (![observedBytes, elapsedMs, maxBytesPerSecond, graceMs].every(Number.isFinite)) {
+    throw new TypeError("byte-rate values must be finite");
+  }
+  if (observedBytes < 0 || elapsedMs < 0 || maxBytesPerSecond <= 0 || graceMs < 0) {
+    throw new RangeError("byte-rate values are out of range");
+  }
+  const allowedBytes = Math.floor(maxBytesPerSecond * ((elapsedMs + graceMs) / 1_000));
+  return {
+    allowed: observedBytes <= allowedBytes,
+    observedBytes,
+    allowedBytes,
+    byteRate: elapsedMs > 0 ? observedBytes / (elapsedMs / 1_000) : observedBytes,
+  };
+}
+
+/** Derives PCM duration from bytes observed by the server, never client claims. */
+export function pcmDurationMinutes(input: {
+  byteLength: number;
+  sampleRate: number;
+  channels: number;
+  bytesPerSample: number;
+}): number {
+  const { byteLength, sampleRate, channels, bytesPerSample } = input;
+  if (![byteLength, sampleRate, channels, bytesPerSample].every(Number.isFinite)) {
+    throw new TypeError("audio format values must be finite");
+  }
+  if (byteLength < 0 || sampleRate <= 0 || channels <= 0 || bytesPerSample <= 0) {
+    throw new RangeError("audio format values are out of range");
+  }
+  return byteLength / (sampleRate * channels * bytesPerSample * 60);
+}
+
+function resolveDay(now: number): { dayNumber: number; day: string } {
+  const dayNumber = Math.floor(now / DAY_MS);
+  return {
+    dayNumber,
+    day: new Date(dayNumber * DAY_MS).toISOString().slice(0, 10),
+  };
+}
+
+function quotaDenial(
+  orgUsed: number,
+  userUsed: number,
+  requestedMinutes: number,
+  limits: VoiceUsageLimits,
+  day: string,
+): VoiceUsageDecision | null {
+  if (orgUsed + requestedMinutes > limits.organizationDailyMinutes) {
+    return {
+      allowed: false,
+      scope: "organization",
+      limitMinutes: limits.organizationDailyMinutes,
+      usedMinutes: orgUsed,
+      requestedMinutes,
+      day,
+    };
+  }
+  if (userUsed + requestedMinutes > limits.userDailyMinutes) {
+    return {
+      allowed: false,
+      scope: "user",
+      limitMinutes: limits.userDailyMinutes,
+      usedMinutes: userUsed,
+      requestedMinutes,
+      day,
+    };
+  }
+  return null;
+}
+
+function validateUsageInput(
+  identity: VoiceUsageIdentity,
+  requestedMinutes: number,
+  limits: VoiceUsageLimits,
+): void {
+  assertPositiveFinite("requestedMinutes", requestedMinutes);
+  assertPositiveFinite("organizationDailyMinutes", limits.organizationDailyMinutes);
+  assertPositiveFinite("userDailyMinutes", limits.userDailyMinutes);
+  if (!identity.organizationId || !identity.userId) {
+    throw new TypeError("organizationId and userId are required");
+  }
+}
+
+function assertPositiveFinite(name: string, value: number): void {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new RangeError(`${name} must be positive and finite`);
+  }
+}

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -80,6 +80,14 @@ export interface Bindings {
    * different hosted model for a deployment.
    */
   WHISPER_STT_MODEL?: string;
+  /** Enables durable daily org/user STT minute caps. Default false. */
+  VOICE_STT_USAGE_METERING_ENABLED?: string;
+  /** Maximum server-observed multipart audio bytes accepted by batch STT. */
+  VOICE_STT_MAX_REQUEST_BYTES?: string;
+  /** Daily server-metered STT audio-minute ceiling shared by an organization. */
+  VOICE_STT_ORG_DAILY_MINUTES?: string;
+  /** Daily server-metered STT audio-minute ceiling for one user. */
+  VOICE_STT_USER_DAILY_MINUTES?: string;
 
   // ---- AI providers ----
   CEREBRAS_API_KEY?: string;


### PR DESCRIPTION
## Summary

Security hardening for the merged voice adapters and batch routes, based on `VOICE-SECURITY-THREAT-MODEL-2026-07-10.md`.

- **SEC-11:** Deepgram Flux now sends `mip_opt_out=true` by default, with a strict explicit operator override.
- **SEC-15:** adds durable atomic Redis org/user daily audio-minute reservations, failed-request release, server-observed PCM duration and byte-rate helpers, and configurable batch STT request/quota enforcement.
- **SEC-13 / SEC-14:** removes transcript, filename, provider response body, raw error object/message, and content-bearing metadata from touched STT/TTS logs and usage events.
- The merged batch STT path uses Whisper or ElevenLabs, not Deepgram, so there was no second Deepgram batch request to patch.
- No WS handler, mint route, consent service, or pendant session file was created or imported. Those remain phase-1 owned.

## Configuration

- `VOICE_STT_MAX_REQUEST_BYTES`, default 25 MiB
- `VOICE_STT_USAGE_METERING_ENABLED=true` enables daily metering
- `VOICE_STT_ORG_DAILY_MINUTES`, default 1440
- `VOICE_STT_USER_DAILY_MINUTES`, default 720
- Production metering fails closed unless the existing Redis factory resolves `REDIS_URL` or Upstash REST credentials.

## Testing

- [x] Unit tests added/updated
- [x] Integration-style route tests updated
- [x] Typecheck passes
- [x] Formatting and `git diff --check` pass

Captured after rebasing onto current `origin/develop`:

```text
Batch STT isolated route: 24 passed, 1 live external test skipped, 0 failed
Deepgram Flux + voice usage meter: 20 passed, 0 failed
tsgo --noEmit -p packages/cloud/api/tsconfig.json: passed
tsgo --noEmit -p packages/cloud/shared/tsconfig.json: passed
Biome touched files: passed
git diff --check: passed
```

Security cases proven include default/override training opt-out, org/user isolation, UTC reset, atomic Redis keying, failed-reservation release, byte-rate ceiling, request-size 413, quota 429, production fail-closed 503, and absence of transcript/filename/provider-body content from logger calls.

## Evidence

### Cloud backend / security

- Real route execution: the Hono batch STT route is exercised through isolated request/response tests against a real local HTTP Whisper stub, including upstream 200/malformed/5xx paths.
- Auth/tenant isolation: route auth remains server-derived; usage-meter tests prove separate org/user counters and org-scoped user keys.
- Structured log hygiene: behavioral tests inspect logger calls and prove transcript, upload filename, and provider error body content is absent.
- Durable accounting: Redis behavior is injected at the atomic Lua boundary; production fail-closed behavior is route-tested.

### N/A

- DB state and migration up/down: N/A, no schema or migration changed.
- UI screenshots/video: N/A, no UI changed.
- Agent trajectory: N/A, no model-backed agent flow changed.
- External production Redis/provider trace: N/A, no production secrets were used. Atomic backend behavior and failure policy are covered by tests.

## Security review notes

Multiple `codex review` passes were run before push. Findings addressed included cross-worker durability, one-second duration floor, TCP Redis support, mock Redis handling, metadata parse placement, and release of quota reservations on failed transcription/billing.

Human-blocked and intentionally not claimed:

- Deepgram DPA is still required to contractually prohibit model improvement/benchmarking.
- Cartesia ZDR/training opt-out remains ops work, per SEC-12.
- Consent nonce and revoke-to-silence remain phase-1/ambient PR requirements.

## Checklist

- [x] Branch rebased on current `origin/develop`
- [x] Threat-model IDs cited
- [x] No unrelated issue/PR hygiene changes
- [x] No phase-1 WS/session files touched
- [x] Commit authored by Sol and co-authored by wakesync
- [x] Requires human security review, no self-merge

[sol-cloud]
