### PR TITLE
[stack] feat(voice): trace shared-runtime STT and TTS (re-land with boundary validation + per-session marks)

### DIFF
--- a/packages/cloud/api/v1/voice/stt/route.ts
+++ b/packages/cloud/api/v1/voice/stt/route.ts
@@ -40,6 +40,12 @@ import {
 import { getElevenLabsService } from "@/lib/services/elevenlabs";
 import { usageService } from "@/lib/services/usage";
 import { logger } from "@/lib/utils/logger";
+import {
+  elapsedMs,
+  readVoiceTraceId,
+  type VoiceTimingComponent,
+  voiceJsonResponse,
+} from "../trace";
 import { resolveWhisperSttModel } from "./whisper-model";
 import { parseWhisperTimestamps } from "./whisper-timestamps";
 
@@ -101,16 +107,23 @@ function estimateAudioDurationMinutes(
  * @returns Transcript and processing duration.
  */
 async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
+  const routeStartMs = Date.now();
+  const traceId = readVoiceTraceId(request);
   let reservation: CreditReservation | undefined;
+  const timings = (): VoiceTimingComponent[] => [
+    { name: "admission", durationMs: elapsedMs(routeStartMs) },
+  ];
+  const json = (body: unknown, status = 200, extra = timings()) =>
+    voiceJsonResponse(body, { status, traceId, timings: extra });
 
   try {
     const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
 
     const contentType = request.headers.get("content-type") ?? "";
     if (!contentType.includes("multipart/form-data")) {
-      return Response.json(
+      return json(
         { error: "Expected multipart form data with audio field" },
-        { status: 400 },
+        400,
       );
     }
 
@@ -119,28 +132,25 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
     const languageCode = formData.get("languageCode") as string | undefined;
 
     if (!audioFile) {
-      return Response.json(
-        { error: "No audio file provided" },
-        { status: 400 },
-      );
+      return json({ error: "No audio file provided" }, 400);
     }
 
     if (audioFile.size > MAX_FILE_SIZE) {
-      return Response.json(
+      return json(
         {
           error: `File too large. Maximum size is ${MAX_FILE_SIZE / 1024 / 1024}MB`,
         },
-        { status: 400 },
+        400,
       );
     }
 
     const baseMimeType = audioFile.type.split(";")[0].trim();
     if (!SUPPORTED_MIME_TYPES.includes(baseMimeType)) {
-      return Response.json(
+      return json(
         {
           error: `Unsupported audio format: ${audioFile.type}. Supported: mp3, mp4, m4a, wav, webm, ogg`,
         },
-        { status: 400 },
+        400,
       );
     }
 
@@ -148,41 +158,54 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
     const fileTypeResult = await fileTypeFromBuffer(buffer);
 
     if (!fileTypeResult) {
-      logger.warn(
-        `[Voice STT API] Unable to detect file type for ${audioFile.name} - rejecting`,
-      );
-      return Response.json(
+      logger.warn("[Voice STT API] Unable to detect file type - rejecting", {
+        traceId,
+        audioFileName: audioFile.name,
+        audioSizeBytes: audioFile.size,
+      });
+      return json(
         {
           error:
             "Unable to verify file type. The file may be corrupted or of an unsupported format.",
         },
-        { status: 400 },
+        400,
       );
     }
 
     if (!ALLOWED_AUDIO_SIGNATURES.has(fileTypeResult.mime)) {
-      logger.warn(
-        `[Voice STT API] File signature mismatch for ${audioFile.name}: claimed=${baseMimeType}, actual=${fileTypeResult.mime}`,
-      );
-      return Response.json(
+      logger.warn("[Voice STT API] File signature mismatch", {
+        traceId,
+        audioFileName: audioFile.name,
+        claimedMimeType: baseMimeType,
+        actualMimeType: fileTypeResult.mime,
+      });
+      return json(
         {
           error: `File content does not match the declared format. Detected: ${fileTypeResult.mime}, Expected audio format.`,
         },
-        { status: 400 },
+        400,
       );
     }
 
     let finalMimeType = fileTypeResult.mime;
     if (fileTypeResult.mime === "video/webm") {
       logger.info(
-        "[Voice STT API] Converting video/webm container to audio/webm (Safari/macOS audio recording)",
+        "[Voice STT API] Converting video/webm container to audio/webm",
+        {
+          traceId,
+        },
       );
       finalMimeType = "audio/webm";
     }
 
-    logger.info(
-      `[Voice STT API] Processing for user ${user.id}: ${audioFile.name} (${audioFile.size} bytes, verified: ${fileTypeResult.mime}, final: ${finalMimeType})`,
-    );
+    logger.info("[Voice STT API] Processing audio", {
+      traceId,
+      userId: user.id,
+      audioFileName: audioFile.name,
+      audioSizeBytes: audioFile.size,
+      verifiedMimeType: fileTypeResult.mime,
+      finalMimeType,
+    });
 
     // -------------------------------------------------------------------------
     // Free default STT: self-hosted Whisper (OpenAI-compatible
@@ -193,6 +216,7 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
     const whisperBaseUrl = env.WHISPER_STT_URL?.trim();
     if (whisperBaseUrl) {
       const whisperStart = Date.now();
+      const admissionMs = elapsedMs(routeStartMs);
       const form = new FormData();
       form.append(
         "file",
@@ -213,14 +237,18 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
         { method: "POST", body: form },
       );
       if (!whisperResponse.ok) {
-        const detail = await whisperResponse.text().catch(() => "");
-        logger.error(
-          `[Voice STT API] Whisper failed (${whisperResponse.status}): ${detail.slice(0, 200)}`,
-        );
-        return Response.json(
-          { error: "Speech-to-text failed" },
-          { status: 502 },
-        );
+        const transcribeMs = elapsedMs(whisperStart);
+        logger.error("[Voice STT API] Whisper failed", {
+          traceId,
+          status: whisperResponse.status,
+          transcribeMs,
+        });
+        return json({ error: "Speech-to-text failed" }, 502, [
+          { name: "admission", durationMs: admissionMs },
+          { name: "transcribe", durationMs: transcribeMs },
+          { name: "provider", durationMs: transcribeMs },
+          { name: "error", durationMs: transcribeMs },
+        ]);
       }
       // Boundary validation (J3): a 200 whose body is not JSON, not an object,
       // or lacks the required `text` string is an upstream failure — translate
@@ -273,15 +301,24 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
         durationMs: whisperDuration,
         model: whisperModel,
         segmentCount: segments?.length,
+        traceId,
         transcriptLength: transcript.length,
         wordCount: words?.length,
       });
-      return Response.json({
-        transcript,
-        duration_ms: whisperDuration,
-        ...(segments ? { segments } : {}),
-        ...(words ? { words } : {}),
-      });
+      return json(
+        {
+          transcript,
+          duration_ms: whisperDuration,
+          ...(segments ? { segments } : {}),
+          ...(words ? { words } : {}),
+        },
+        200,
+        [
+          { name: "admission", durationMs: admissionMs },
+          { name: "transcribe", durationMs: whisperDuration },
+          { name: "provider", durationMs: whisperDuration },
+        ],
+      );
     }
 
     const metadata = await parseBuffer(buffer, { mimeType: finalMimeType });
@@ -307,12 +344,12 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
       });
     } catch (error) {
       if (error instanceof InsufficientCreditsError) {
-        return Response.json(
+        return json(
           {
             error: "Insufficient credits for speech-to-text",
             required: error.required,
           },
-          { status: 402 },
+          402,
         );
       }
       throw error;
@@ -321,6 +358,7 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
     const elevenlabs = getElevenLabsService(env);
 
     const startTime = Date.now();
+    const admissionMs = elapsedMs(routeStartMs);
     const validatedFile = new File([buffer], audioFile.name, {
       type: finalMimeType,
     });
@@ -346,9 +384,11 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
       reservation,
     );
 
-    logger.info(
-      `[Voice STT API] Completed in ${duration}ms: "${transcript.substring(0, 100)}..."`,
-    );
+    logger.info("[Voice STT API] Completed", {
+      traceId,
+      durationMs: duration,
+      transcriptLength: transcript.length,
+    });
 
     (async () => {
       try {
@@ -384,16 +424,20 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
       }
     })();
 
-    return Response.json({
-      transcript,
-      duration_ms: duration,
-    });
+    return json({ transcript, duration_ms: duration }, 200, [
+      { name: "admission", durationMs: admissionMs },
+      { name: "transcribe", durationMs: duration },
+      { name: "provider", durationMs: duration },
+    ]);
   } catch (error) {
-    logger.error("[Voice STT API] Error:", error);
+    logger.error("[Voice STT API] Error", {
+      traceId,
+      error: error instanceof Error ? error.message : String(error),
+    });
 
     if (reservation) {
       await reservation.reconcile(0);
-      logger.info("[Voice STT API] Refunded credits after error");
+      logger.info("[Voice STT API] Refunded credits after error", { traceId });
     }
 
     if (error instanceof Error) {
@@ -412,13 +456,13 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
         errorMessage.includes("authentication required") ||
         errorMessage.includes("forbidden")
       ) {
-        return Response.json({ error: "Unauthorized" }, { status: 401 });
+        return json({ error: "Unauthorized" }, 401);
       }
 
       if (errorMessage.includes("rate limit")) {
-        return Response.json(
+        return json(
           { error: "Rate limit exceeded. Please try again in a moment." },
-          { status: 429 },
+          429,
         );
       }
 
@@ -428,36 +472,33 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
           errorBody.includes("trial tier") ||
           errorBody.includes("ZRM mode")
         ) {
-          return Response.json(
+          return json(
             {
               error:
                 "Speech-to-Text requires a paid plan. Please upgrade to continue.",
             },
-            { status: 402 },
+            402,
           );
         }
-        return Response.json(
+        return json(
           {
             error:
               "Speech-to-text service is temporarily unavailable due to high demand. Please try again shortly.",
             type: "service_unavailable",
             retryAfter: "5 minutes",
           },
-          { status: 503 },
+          503,
         );
       }
 
       if (errorMessage.includes("elevenlabs_api_key")) {
-        return Response.json(
-          { error: "Service not configured" },
-          { status: 500 },
-        );
+        return json({ error: "Service not configured" }, 500);
       }
     }
 
-    return Response.json(
+    return json(
       { error: "Failed to transcribe audio. Please try again." },
-      { status: 500 },
+      500,
     );
   }
 }

--- a/packages/cloud/api/v1/voice/trace.test.ts
+++ b/packages/cloud/api/v1/voice/trace.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Unit coverage for cloud voice trace response headers.
+ *
+ * The v1 STT and TTS routes call these helpers for every practical response
+ * path, so the route-level contract for trace echo and Server-Timing presence
+ * is locked here without mocking provider, auth, billing, or cache services.
+ */
+
+import { describe, expect, it } from "bun:test";
+
+import {
+  MAX_VOICE_TRACE_ID_LENGTH,
+  parseVoiceTraceId,
+  readVoiceTraceId,
+  VOICE_TRACE_HEADER,
+  voiceJsonResponse,
+  voiceTraceHeaders,
+} from "./trace";
+
+describe("parseVoiceTraceId (boundary validation, #15931)", () => {
+  it("accepts a client-minted UUID (randomUUID shape)", () => {
+    const uuid = "018f9f3a-7c2e-7b41-9a2d-6f0e1c2b3a4d";
+    expect(parseVoiceTraceId(uuid)).toEqual({ traceId: uuid, invalid: false });
+  });
+
+  it("accepts the deterministic `voice-<t>-<r>` fallback shape", () => {
+    const fallback = "voice-lz3k9q-847162";
+    expect(parseVoiceTraceId(fallback)).toEqual({
+      traceId: fallback,
+      invalid: false,
+    });
+  });
+
+  it("treats an absent header as absent, not invalid", () => {
+    expect(parseVoiceTraceId(null)).toEqual({ traceId: null, invalid: false });
+    expect(parseVoiceTraceId(undefined)).toEqual({
+      traceId: null,
+      invalid: false,
+    });
+    expect(parseVoiceTraceId("")).toEqual({ traceId: null, invalid: false });
+  });
+
+  it("rejects an oversized id (length bound)", () => {
+    const oversized = "a".repeat(MAX_VOICE_TRACE_ID_LENGTH + 1);
+    expect(parseVoiceTraceId(oversized)).toEqual({
+      traceId: null,
+      invalid: true,
+    });
+    // Exactly at the bound is still valid.
+    const atBound = "a".repeat(MAX_VOICE_TRACE_ID_LENGTH);
+    expect(parseVoiceTraceId(atBound)).toEqual({
+      traceId: atBound,
+      invalid: false,
+    });
+  });
+
+  it("rejects CR/LF and header-injection shapes", () => {
+    for (const hostile of [
+      "abc\r\nX-Injected: 1",
+      "abc\nSet-Cookie: x",
+      "abc\rZ",
+      "trace\u0000id", // NUL
+      "trace\u0007id", // BEL / control char
+      "trace id", // embedded space
+      "trace\tid", // tab
+    ]) {
+      expect(parseVoiceTraceId(hostile)).toEqual({
+        traceId: null,
+        invalid: true,
+      });
+    }
+  });
+
+  it("rejects uppercase, unicode, and log-separator punctuation", () => {
+    for (const bad of [
+      "UPPER-case",
+      "trace_id", // underscore not in charset
+      "trace.id", // dot
+      "trace=id", // key/value separator
+      "trace;id", // Server-Timing separator
+      "trace,id", // list separator
+      'trace"id', // quote
+      "tráce", // accented unicode
+      "trace\u{1f600}", // emoji
+    ]) {
+      expect(parseVoiceTraceId(bad)).toEqual({ traceId: null, invalid: true });
+    }
+  });
+
+  it("rejects leading/trailing/doubled hyphens (empty segments)", () => {
+    for (const bad of ["-abc", "abc-", "a--b", "-", "--"]) {
+      expect(parseVoiceTraceId(bad)).toEqual({ traceId: null, invalid: true });
+    }
+  });
+});
+
+describe("readVoiceTraceId (untrusted request boundary)", () => {
+  it("returns the canonical id for a valid header", () => {
+    const req = new Request("https://api.test/api/v1/voice/stt", {
+      headers: { [VOICE_TRACE_HEADER]: "voice-lz3k9q-847162" },
+    });
+    expect(readVoiceTraceId(req)).toBe("voice-lz3k9q-847162");
+  });
+
+  it("observably ignores a malformed id (returns null, route proceeds)", () => {
+    // A hostile header value must NOT reach logs or the echo path.
+    const req = new Request("https://api.test/api/v1/voice/stt", {
+      headers: { [VOICE_TRACE_HEADER]: "a".repeat(500) },
+    });
+    expect(readVoiceTraceId(req)).toBeNull();
+  });
+});
+
+describe("voiceTraceHeaders echo boundary (defense in depth)", () => {
+  it("never echoes a non-canonical id even if one is passed directly", () => {
+    // Simulate a caller that skipped validation and handed a hostile id.
+    const headers = voiceTraceHeaders("bad id\r\nInjected: 1", [
+      { name: "admission", durationMs: 1 },
+    ]);
+    expect(headers.has(VOICE_TRACE_HEADER)).toBe(false);
+    // Server-Timing is still present so timing observability is unaffected.
+    expect(headers.get("Server-Timing")).toBe("admission;dur=1");
+  });
+
+  it("echoes a canonical id", () => {
+    const headers = voiceTraceHeaders("voice-abc-123", [
+      { name: "admission", durationMs: 1 },
+    ]);
+    expect(headers.get(VOICE_TRACE_HEADER)).toBe("voice-abc-123");
+  });
+});
+
+describe("cloud voice trace headers", () => {
+  it("reads and echoes X-Eliza-Voice-Trace-Id with Server-Timing", async () => {
+    const request = new Request("https://api.test/api/v1/voice/stt", {
+      headers: { [VOICE_TRACE_HEADER]: "trace-turn-1" },
+    });
+    const traceId = readVoiceTraceId(request);
+    const response = voiceJsonResponse(
+      { transcript: "ok" },
+      {
+        traceId,
+        timings: [
+          { name: "admission", durationMs: 3.4 },
+          { name: "transcribe", durationMs: 12.6 },
+          { name: "provider", durationMs: 12.6 },
+        ],
+      },
+    );
+
+    expect(response.headers.get(VOICE_TRACE_HEADER)).toBe("trace-turn-1");
+    expect(response.headers.get("Server-Timing")).toBe(
+      "admission;dur=3, transcribe;dur=13, provider;dur=13",
+    );
+    const payload = (await response.json()) as { transcript: string };
+    expect(payload).toEqual({ transcript: "ok" });
+  });
+
+  it("keeps Server-Timing on untraced error responses", () => {
+    const headers = voiceTraceHeaders(null, [
+      { name: "admission", durationMs: 0 },
+      { name: "error", durationMs: 1 },
+    ]);
+
+    expect(headers.has(VOICE_TRACE_HEADER)).toBe(false);
+    expect(headers.get("Server-Timing")).toBe("admission;dur=0, error;dur=1");
+  });
+});

--- a/packages/cloud/api/v1/voice/trace.ts
+++ b/packages/cloud/api/v1/voice/trace.ts
@@ -1,0 +1,128 @@
+/**
+ * Shared response-header helpers for cloud voice tracing.
+ *
+ * The PWA shared-runtime voice path sends a per-turn trace id to the v1 voice
+ * routes. These helpers keep trace echo and Server-Timing formatting identical
+ * across STT and TTS without coupling either route to the other's provider
+ * branches.
+ */
+
+export const VOICE_TRACE_HEADER = "X-Eliza-Voice-Trace-Id";
+
+export interface VoiceTimingComponent {
+  name: "admission" | "provider" | "transcribe" | "synth" | "cache" | "error";
+  durationMs: number;
+}
+
+/**
+ * Canonical voice trace-id format (boundary validation, #15931 re-land).
+ *
+ * The client mints ids with `createSharedRuntimeVoiceTraceId()`, which returns
+ * either a `crypto.randomUUID()` (RFC-4122, lowercase hex + hyphens, 36 chars)
+ * or the deterministic fallback `voice-<base36-time>-<base36-random>`. Both
+ * shapes are lowercase, hyphen-delimited, ASCII, and comfortably under 200
+ * chars. Rather than couple this parser to one minting scheme, we accept the
+ * union of "looks like a client-minted id" as a bounded, charset-restricted,
+ * length-capped token:
+ *
+ *   - charset: ASCII lowercase letters, digits, and hyphen only
+ *   - length:  1..MAX (rejects oversized ids that could bloat logs/headers)
+ *   - shape:   no leading/trailing/doubled hyphen (rejects `--`, `-x`, `x-`),
+ *              which also rules out header-injection filler and empty segments
+ *
+ * This is deliberately STRICTER than "any non-empty string": control characters
+ * (CR/LF for header injection), whitespace, uppercase, unicode, and separators
+ * used by log parsers (spaces, quotes, `=`, `;`, `,`) are all rejected. An
+ * invalid id is treated as ABSENT (see {@link readVoiceTraceId}) so the route
+ * still runs and still emits Server-Timing, but never logs or echoes attacker
+ * controlled bytes. "Observably ignored", per the reviewer's framing: the
+ * request is served, the trace id simply does not appear in logs or the
+ * response header.
+ */
+export const MAX_VOICE_TRACE_ID_LENGTH = 200;
+
+// Single line, ASCII lowercase alphanumerics grouped by single hyphens.
+// Anchored; no `s` flag, so any CR/LF/other control char fails to match.
+const VOICE_TRACE_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export interface VoiceTraceIdParse {
+  /** The canonical id when the raw header is valid; otherwise `null`. */
+  traceId: string | null;
+  /** True only when a header was present AND rejected as malformed. */
+  invalid: boolean;
+}
+
+/**
+ * Explicit valid/invalid parse of a raw trace-id header value.
+ *
+ * @param raw - the raw `X-Eliza-Voice-Trace-Id` value (or null when absent).
+ * @returns `{ traceId, invalid }`. Absent header -> `{ null, false }`.
+ *          Present + valid -> `{ <id>, false }`. Present + malformed ->
+ *          `{ null, true }` so callers can count/observe rejections.
+ */
+export function parseVoiceTraceId(
+  raw: string | null | undefined,
+): VoiceTraceIdParse {
+  if (raw == null) return { traceId: null, invalid: false };
+  // Do NOT trim: a value that is only valid after trimming (e.g. embedded
+  // whitespace, leading tab) is not canonical and must be rejected, not
+  // silently normalized. An all-whitespace or empty header is "absent".
+  if (raw.length === 0) return { traceId: null, invalid: false };
+  if (
+    raw.length > MAX_VOICE_TRACE_ID_LENGTH ||
+    !VOICE_TRACE_ID_PATTERN.test(raw)
+  ) {
+    return { traceId: null, invalid: true };
+  }
+  return { traceId: raw, invalid: false };
+}
+
+/**
+ * Read the canonical voice trace id from a request, or `null` when absent OR
+ * malformed. Invalid ids are observably ignored (the route proceeds untraced);
+ * the raw attacker-controlled bytes never reach logs or the response header.
+ */
+export function readVoiceTraceId(request: Request): string | null {
+  return parseVoiceTraceId(request.headers.get(VOICE_TRACE_HEADER)).traceId;
+}
+
+export function elapsedMs(startMs: number): number {
+  return Math.max(0, Date.now() - startMs);
+}
+
+export function voiceTraceHeaders(
+  traceId: string | null,
+  timings: ReadonlyArray<VoiceTimingComponent>,
+  extra?: HeadersInit,
+): Headers {
+  const headers = new Headers(extra);
+  // Defense in depth: only echo a canonical id. Every route path derives
+  // `traceId` from `readVoiceTraceId` (already validated), but re-validating
+  // here guarantees the echo boundary can never emit an un-parsed value even
+  // if a future caller forgets to validate.
+  if (traceId && parseVoiceTraceId(traceId).traceId === traceId) {
+    headers.set(VOICE_TRACE_HEADER, traceId);
+  }
+  const serverTiming = timings
+    .map(
+      ({ name, durationMs }) =>
+        `${name};dur=${Math.max(0, Math.round(durationMs))}`,
+    )
+    .join(", ");
+  if (serverTiming) headers.set("Server-Timing", serverTiming);
+  return headers;
+}
+
+export function voiceJsonResponse(
+  body: unknown,
+  init: {
+    status?: number;
+    traceId: string | null;
+    timings: ReadonlyArray<VoiceTimingComponent>;
+  },
+): Response {
+  return Response.json(body, {
+    status: init.status,
+    headers: voiceTraceHeaders(init.traceId, init.timings),
+  });
+}

--- a/packages/cloud/api/v1/voice/tts/route.ts
+++ b/packages/cloud/api/v1/voice/tts/route.ts
@@ -54,6 +54,11 @@ import {
 import { usageService } from "@/lib/services/usage";
 import { logger } from "@/lib/utils/logger";
 import {
+  parseVoiceTraceId,
+  readVoiceTraceId,
+  VOICE_TRACE_HEADER,
+} from "../trace";
+import {
   buildKokoroCacheKey,
   isKokoroFirstLineCacheEnabled,
 } from "./kokoro-first-line-cache";
@@ -100,6 +105,7 @@ interface TtsTimings {
 function buildTtsObservabilityHeaders(
   provider: TtsProvider,
   timings: TtsTimings,
+  traceId: string | null,
 ): Record<string, string> {
   const serverTiming = [
     timings.authMs !== undefined ? `auth;dur=${timings.authMs}` : null,
@@ -111,8 +117,18 @@ function buildTtsObservabilityHeaders(
       : null,
   ].filter((entry): entry is string => entry !== null);
 
+  // Defense in depth: `traceId` already came from `readVoiceTraceId` (canonical
+  // or null), but re-validate at the echo boundary so a malformed value can
+  // never be reflected into a response header even if a future caller skips
+  // validation.
+  const echoTraceId =
+    traceId && parseVoiceTraceId(traceId).traceId === traceId ? traceId : null;
   return {
     "X-Eliza-TTS-Provider": provider,
+    // Echo the shared-runtime voice trace id (#15931) so a single request can be
+    // correlated end to end across STT -> chat -> TTS. Only emitted when the
+    // caller supplied a canonical one; never fabricated here.
+    ...(echoTraceId ? { [VOICE_TRACE_HEADER]: echoTraceId } : {}),
     ...(serverTiming.length > 0
       ? { "Server-Timing": serverTiming.join(", ") }
       : {}),
@@ -136,6 +152,9 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
   let reservation: CreditReservation | undefined;
   const requestStart = Date.now();
   const timings: TtsTimings = {};
+  // #15931: read (and later echo) the shared voice trace id so STT/chat/TTS for
+  // one utterance share a correlation id. Absent header => no trace echo.
+  const traceId = readVoiceTraceId(request);
 
   try {
     const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
@@ -194,6 +213,7 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
           headers: buildTtsObservabilityHeaders(
             providerSelection.provider,
             timings,
+            traceId,
           ),
         },
       );
@@ -211,6 +231,7 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
       `[Voice TTS API] Generating speech for user ${user.id}: ${text.length} chars`,
     );
     logger.info("[Voice TTS API] Selected TTS provider", {
+      traceId,
       provider: providerSelection.provider,
       fallbackReason: providerSelection.fallbackReason,
       voiceId: providerSelection.voiceId ?? "default",
@@ -258,7 +279,7 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
               headers: {
                 "Content-Type": cached.contentType,
                 "Cache-Control": "no-cache",
-                ...buildTtsObservabilityHeaders("kokoro", timings),
+                ...buildTtsObservabilityHeaders("kokoro", timings, traceId),
                 "X-TTS-Cache": "hit; kokoro; first-sentence",
               },
             });
@@ -332,7 +353,7 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
           headers: {
             "Content-Type": kokoroContentType,
             "Cache-Control": "no-store",
-            ...buildTtsObservabilityHeaders("kokoro", timings),
+            ...buildTtsObservabilityHeaders("kokoro", timings, traceId),
             "X-TTS-Cache": "miss; kokoro",
           },
         });
@@ -343,7 +364,7 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
         headers: {
           "Content-Type": kokoroContentType,
           "Cache-Control": "no-store",
-          ...buildTtsObservabilityHeaders("kokoro", timings),
+          ...buildTtsObservabilityHeaders("kokoro", timings, traceId),
         },
       });
     }
@@ -430,7 +451,7 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
             headers: {
               "Content-Type": cached.contentType,
               "Cache-Control": "no-cache",
-              ...buildTtsObservabilityHeaders("elevenlabs", timings),
+              ...buildTtsObservabilityHeaders("elevenlabs", timings, traceId),
               "X-TTS-Cache": "hit; first-sentence",
             },
           });
@@ -495,6 +516,7 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
     timings.synthesisMs = duration;
 
     logger.info("[Voice TTS API] Stream started", {
+      traceId,
       provider: "elevenlabs",
       fallbackReason: providerSelection.fallbackReason,
       durationMs: duration,
@@ -649,7 +671,7 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
         "Content-Type": "audio/mpeg",
         "Transfer-Encoding": "chunked",
         "Cache-Control": "no-cache",
-        ...buildTtsObservabilityHeaders("elevenlabs", timings),
+        ...buildTtsObservabilityHeaders("elevenlabs", timings, traceId),
         "X-TTS-Cache": "miss",
       },
     });

--- a/packages/cloud/shared/src/lib/cors-constants.ts
+++ b/packages/cloud/shared/src/lib/cors-constants.ts
@@ -46,6 +46,9 @@ export const CORS_ALLOW_HEADER_NAMES = [
   "X-Eliza-Client-Id",
   "X-ElizaOS-UI-Language",
   "X-Eliza-UI-Language",
+  // Correlates one shared-runtime PWA voice turn across cloud STT and TTS.
+  // The browser sends this to /api/v1/voice/*, so CORS preflight must allow it.
+  "X-Eliza-Voice-Trace-Id",
 ] as const;
 
 export const CORS_ALLOW_HEADERS = CORS_ALLOW_HEADER_NAMES.join(", ");

--- a/packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.test.ts
+++ b/packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.test.ts
@@ -21,6 +21,7 @@ function appWithCors() {
   app.post("/api/auth/pair", (c) => c.json({ ok: true }));
   app.get("/api/v1/models", (c) => c.json({ ok: true }));
   app.post("/api/v1/chat/completions", (c) => c.json({ ok: true }));
+  app.post("/api/v1/voice/tts", (c) => c.json({ ok: true }));
   return app;
 }
 
@@ -128,6 +129,22 @@ describe("corsMiddleware — Eliza app WebView origin (credentialed SSE)", () =>
     expect(allowHeaders).toContain("x-elizaos-client-id");
     expect(allowHeaders).toContain("x-elizaos-ui-language");
     expect(allowHeaders).toContain("x-eliza-client-id");
+  });
+
+  test("allows the shared-runtime voice trace header", async () => {
+    const app = appWithCors();
+    const res = await app.request("/api/v1/voice/tts", {
+      method: "OPTIONS",
+      headers: {
+        Origin: "https://app.elizacloud.ai",
+        "Access-Control-Request-Method": "POST",
+        "Access-Control-Request-Headers": "content-type,x-eliza-voice-trace-id",
+      },
+    });
+    expect(res.headers.get("access-control-allow-origin")).toBe("https://app.elizacloud.ai");
+    expect((res.headers.get("access-control-allow-headers") || "").toLowerCase()).toContain(
+      "x-eliza-voice-trace-id",
+    );
   });
 });
 

--- a/packages/ui/src/components/pages/chat-view-hooks.tsx
+++ b/packages/ui/src/components/pages/chat-view-hooks.tsx
@@ -107,6 +107,7 @@ type PendingVoiceTurnState = {
   assistantFirstTextAtMs?: number;
   speechEndedAtMs: number;
   voiceStartedAtMs?: number;
+  voiceTraceId?: string;
 };
 
 function makeVoiceTurnId(speechEndedAtMs: number): string {
@@ -332,6 +333,11 @@ export function useChatVoiceController(options: {
       if (!composedText) return;
       const speechEndedAtMs = nowMs();
       const voiceTurnId = event?.turn.id ?? makeVoiceTurnId(speechEndedAtMs);
+      const rawVoiceTraceId = event?.turn.metadata?.voiceTraceId;
+      const voiceTraceId =
+        typeof rawVoiceTraceId === "string" && rawVoiceTraceId.trim()
+          ? rawVoiceTraceId.trim()
+          : undefined;
       // Prefer the signal the native VAD/turn engine computed (it folds in
       // diarization + audio-frame end-of-turn); fall back to the transcript
       // gate so transcript-only backends still reach the server ambient gate.
@@ -346,6 +352,7 @@ export function useChatVoiceController(options: {
         expiresAtMs: speechEndedAtMs + VOICE_TURN_OUTPUT_WINDOW_MS,
         latencyExpiresAtMs: speechEndedAtMs + VOICE_TURN_LATENCY_WINDOW_MS,
         speechEndedAtMs,
+        voiceTraceId,
       };
       setVoiceLatency(null);
       setState("chatInput", composedText);
@@ -718,6 +725,7 @@ export function useChatVoiceController(options: {
         assistantFirstTextAtMs:
           pendingVoiceTurn.assistantFirstTextAtMs ?? textUpdatedAtMs,
         assistantTextUpdatedAtMs: textUpdatedAtMs,
+        voiceTraceId: pendingVoiceTurn.voiceTraceId,
       };
     }
 

--- a/packages/ui/src/hooks/useVoiceChat.ts
+++ b/packages/ui/src/hooks/useVoiceChat.ts
@@ -60,8 +60,12 @@ import {
   type PlaybackFrameTap,
 } from "../voice/playback-frame-pump";
 import {
+  createSharedRuntimeVoiceTraceId,
   currentSharedRuntimeVoiceOrigin,
+  markSharedRuntimeVoiceTrace,
+  measureSharedRuntimeVoiceTrace,
   sharedRuntimeTtsUrl,
+  sharedRuntimeVoiceTraceHeaders,
 } from "../voice/shared-runtime-voice";
 import {
   collapseWhitespace,
@@ -361,6 +365,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
   const captureStartedAtRef = useRef<number>(0);
   const transcriptBufferRef = useRef("");
   const latestTranscriptTurnRef = useRef<VoiceTurn | null>(null);
+  const lastSharedRuntimeVoiceTraceIdRef = useRef<string | null>(null);
   const emitTranscript = useEffectEvent(
     (text: string, event: VoiceTranscriptEvent) => {
       options.onTranscript(text, event);
@@ -993,8 +998,14 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
   );
 
   const transcribeCloudAudio = useCallback(
-    async (audio: Uint8Array, signal?: AbortSignal): Promise<string> => {
-      return transcribeCloudWav(audio, { signal });
+    async (
+      audio: Uint8Array,
+      options?: { signal?: AbortSignal; traceId?: string },
+    ): Promise<string> => {
+      return transcribeCloudWav(audio, {
+        signal: options?.signal,
+        traceId: options?.traceId,
+      });
     },
     [],
   );
@@ -1401,10 +1412,18 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
               url: cloudAsrPostUrl(),
               bytes: audio.byteLength,
             });
-            const transcript = await transcribeCloudAudio(audio);
+            const sharedVoiceTraceId = currentSharedRuntimeVoiceOrigin()
+              ? createSharedRuntimeVoiceTraceId()
+              : undefined;
+            lastSharedRuntimeVoiceTraceIdRef.current =
+              sharedVoiceTraceId ?? null;
+            const transcript = await transcribeCloudAudio(audio, {
+              traceId: sharedVoiceTraceId,
+            });
             voiceCaptureDebug("post:200", {
               status: "200",
               chars: transcript.length,
+              traceId: sharedVoiceTraceId,
             });
             voiceCaptureDebug("txt", { chars: transcript.length });
             applyTranscriptUpdate(transcript, true, {
@@ -1413,7 +1432,12 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
                 normalizeActiveVoiceSessionMode(listeningModeRef.current) ??
                 "compose",
               source: "cloud",
-              metadata: { source: "cloud" },
+              metadata: {
+                source: "cloud",
+                ...(sharedVoiceTraceId
+                  ? { voiceTraceId: sharedVoiceTraceId }
+                  : {}),
+              },
             });
           } catch (error) {
             // Distinguish the failing leg for the HUD: a `post:<status>` when the
@@ -1421,7 +1445,10 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
             // failure (e.g. "No microphone audio was captured" = empty WAV).
             const status = cloudSttErrorStatus(error);
             if (status != null) {
-              voiceCaptureDebug("post:err", { status: String(status) });
+              voiceCaptureDebug("post:err", {
+                status: String(status),
+                traceId: lastSharedRuntimeVoiceTraceIdRef.current ?? undefined,
+              });
             } else {
               voiceCaptureDebug("rec:stop-err", {
                 backend: "cloud",
@@ -1430,6 +1457,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
                   error instanceof Error
                     ? error.message.slice(0, 80)
                     : String(error).slice(0, 80),
+                traceId: lastSharedRuntimeVoiceTraceIdRef.current ?? undefined,
               });
             }
             ttsDebug("asr:cloud:error", {
@@ -1913,9 +1941,13 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
           const ttsTarget = sharedTtsOrigin
             ? sharedRuntimeTtsUrl(sharedTtsOrigin)
             : resolveApiUrl("/api/tts/cloud");
+          const voiceTraceId = sharedTtsOrigin
+            ? task.telemetry?.voiceTraceId
+            : undefined;
+          markSharedRuntimeVoiceTrace("tts_request_start", voiceTraceId);
           res = await fetchWithCsrf(ttsTarget, {
             method: "POST",
-            headers: {
+            headers: sharedRuntimeVoiceTraceHeaders(voiceTraceId, {
               "Content-Type": "application/json",
               Accept: "audio/wav, audio/mpeg, audio/*;q=0.9",
               ...(apiToken ? { Authorization: `Bearer ${apiToken}` } : {}),
@@ -1932,10 +1964,17 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
                     ),
                   }
                 : {}),
-            },
+            }),
             body: JSON.stringify({ text }),
             signal: controller.signal,
           });
+          markSharedRuntimeVoiceTrace("tts_first_byte", voiceTraceId);
+          measureSharedRuntimeVoiceTrace(
+            "tts_first_byte",
+            "tts_request_start",
+            "tts_first_byte",
+            voiceTraceId,
+          );
         } finally {
           clearTimeout(timeoutId);
           if (activeFetchAbortRef.current === controller) {
@@ -1957,13 +1996,34 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
         }
 
         audioBytes = new Uint8Array(await res.arrayBuffer());
+        markSharedRuntimeVoiceTrace("tts_end", task.telemetry?.voiceTraceId);
+        measureSharedRuntimeVoiceTrace(
+          "tts_end",
+          "tts_request_start",
+          "tts_end",
+          task.telemetry?.voiceTraceId,
+        );
         if (cacheKey) {
           rememberCachedSegment(cacheKey, audioBytes.slice());
         }
       }
 
       if (generation !== generationRef.current) return;
+      markSharedRuntimeVoiceTrace(
+        "audio_decode_start",
+        task.telemetry?.voiceTraceId,
+      );
       const audioBuffer = await ctx.decodeAudioData(toArrayBuffer(audioBytes));
+      markSharedRuntimeVoiceTrace(
+        "audio_decode_end",
+        task.telemetry?.voiceTraceId,
+      );
+      measureSharedRuntimeVoiceTrace(
+        "audio_decode_end",
+        "audio_decode_start",
+        "audio_decode_end",
+        task.telemetry?.voiceTraceId,
+      );
       if (generation !== generationRef.current) return;
 
       const analyser = ctx.createAnalyser();
@@ -1993,6 +2053,16 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
         const finish = () => {
           if (finished) return;
           finished = true;
+          markSharedRuntimeVoiceTrace(
+            "playback_end",
+            task.telemetry?.voiceTraceId,
+          );
+          measureSharedRuntimeVoiceTrace(
+            "playback_end",
+            "playback_start",
+            "playback_end",
+            task.telemetry?.voiceTraceId,
+          );
           if (wrappedFinish && activeTaskFinishRef.current === wrappedFinish) {
             activeTaskFinishRef.current = null;
           }
@@ -2033,6 +2103,10 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
         );
 
         source.start(0);
+        markSharedRuntimeVoiceTrace(
+          "playback_start",
+          task.telemetry?.voiceTraceId,
+        );
         emitPlaybackStart({
           text,
           segment: task.segment,

--- a/packages/ui/src/voice/local-asr-transcribe.ts
+++ b/packages/ui/src/voice/local-asr-transcribe.ts
@@ -17,8 +17,11 @@ import { resolveApiUrl } from "../utils";
 import {
   buildSharedRuntimeSttBody,
   currentSharedRuntimeVoiceOrigin,
+  markSharedRuntimeVoiceTrace,
+  measureSharedRuntimeVoiceTrace,
   parseSharedRuntimeSttResponse,
   sharedRuntimeSttUrl,
+  sharedRuntimeVoiceTraceHeaders,
 } from "./shared-runtime-voice";
 
 export interface TranscribeWavOptions {
@@ -38,6 +41,8 @@ export interface TranscribeCloudWavOptions extends TranscribeWavOptions {
    * before surfacing the error. Defaults to {@link DEFAULT_CLOUD_STT_TIMEOUT_MS}.
    */
   timeoutMs?: number;
+  /** Shared-runtime per-turn trace id; STT retries retain the same value. */
+  traceId?: string;
 }
 
 /**
@@ -173,6 +178,7 @@ export async function transcribeCloudWav(
 ): Promise<string> {
   const timeoutMs = options?.timeoutMs ?? DEFAULT_CLOUD_STT_TIMEOUT_MS;
   const callerSignal = options?.signal;
+  const traceId = options?.traceId;
 
   // One attempt: arm a per-attempt timeout AbortController, compose it with the
   // caller's signal, POST, and classify any failure as retryable or terminal.
@@ -196,11 +202,16 @@ export async function transcribeCloudWav(
       // File in, `{ transcript }` out. Dedicated-tier agents keep the raw-WAV
       // `/api/asr/cloud` proxy path unchanged (sharedOrigin is null for them).
       const sharedOrigin = currentSharedRuntimeVoiceOrigin();
+      if (sharedOrigin) {
+        markSharedRuntimeVoiceTrace("stt_request_start", traceId);
+      }
       const res = sharedOrigin
         ? await fetchWithCsrf(sharedRuntimeSttUrl(sharedOrigin), {
             method: "POST",
             // No explicit Content-Type: the browser sets the multipart boundary.
-            headers: { Accept: "application/json" },
+            headers: sharedRuntimeVoiceTraceHeaders(traceId, {
+              Accept: "application/json",
+            }),
             body: buildSharedRuntimeSttBody(audio),
             signal: timeoutController.signal,
           })
@@ -216,6 +227,15 @@ export async function transcribeCloudWav(
             body: audio as BodyInit,
             signal: timeoutController.signal,
           });
+      if (sharedOrigin) {
+        markSharedRuntimeVoiceTrace("stt_request_end", traceId);
+        measureSharedRuntimeVoiceTrace(
+          "stt_request_end",
+          "stt_request_start",
+          "stt_request_end",
+          traceId,
+        );
+      }
       if (!res.ok) {
         // error-policy:J6 the error body is diagnostic-only; a failed read must
         // not mask the HTTP status the error below already carries.
@@ -243,6 +263,15 @@ export async function transcribeCloudWav(
         throw new CloudSttError("Cloud ASR returned an empty transcript", {
           retryable: false,
         });
+      }
+      if (sharedOrigin) {
+        markSharedRuntimeVoiceTrace("transcript_received", traceId);
+        measureSharedRuntimeVoiceTrace(
+          "transcript_received",
+          "stt_request_start",
+          "transcript_received",
+          traceId,
+        );
       }
       return text;
     } catch (err) {

--- a/packages/ui/src/voice/local-asr-transcribe.voice-trace.test.ts
+++ b/packages/ui/src/voice/local-asr-transcribe.voice-trace.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+
+/**
+ * Shared-runtime cloud STT trace propagation.
+ *
+ * The helper owns the retry loop, so this test locks the per-turn trace header
+ * to a single value across the first failed attempt and the successful retry.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../api/csrf-client", () => ({
+  fetchWithCsrf: vi.fn(),
+}));
+
+vi.mock("../utils/eliza-globals", () => ({
+  getElizaApiBase: vi.fn(),
+}));
+
+vi.mock("../utils", () => ({
+  resolveApiUrl: (path: string) => path,
+}));
+
+vi.mock("../utils/cloud-agent-base", () => ({
+  normalizeDirectCloudSharedAgentApiBase: (value: string) =>
+    value.replace(/\/bridge\/?$/, ""),
+}));
+
+import { fetchWithCsrf } from "../api/csrf-client";
+import { getElizaApiBase } from "../utils/eliza-globals";
+import { transcribeCloudWav } from "./local-asr-transcribe";
+import { VOICE_TRACE_HEADER } from "./shared-runtime-voice";
+
+const fetchWithCsrfMock = vi.mocked(fetchWithCsrf);
+const getElizaApiBaseMock = vi.mocked(getElizaApiBase);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("transcribeCloudWav shared-runtime voice tracing", () => {
+  it("sends the same trace id on the retry and parses the v1 transcript", async () => {
+    getElizaApiBaseMock.mockReturnValue(
+      "https://api.elizacloud.ai/api/v1/eliza/agents/agent-1",
+    );
+    fetchWithCsrfMock
+      .mockResolvedValueOnce(new Response("upstream busy", { status: 503 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ transcript: " hello traced voice " }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+    const text = await transcribeCloudWav(new Uint8Array([82, 73, 70, 70]), {
+      traceId: "trace-turn-1",
+      timeoutMs: 1000,
+    });
+
+    expect(text).toBe("hello traced voice");
+    expect(fetchWithCsrfMock).toHaveBeenCalledTimes(2);
+    for (const call of fetchWithCsrfMock.mock.calls) {
+      expect(call[0]).toBe("https://api.elizacloud.ai/api/v1/voice/stt");
+      expect((call[1] as RequestInit).headers).toMatchObject({
+        Accept: "application/json",
+        [VOICE_TRACE_HEADER]: "trace-turn-1",
+      });
+    }
+  });
+
+  it("does not add the v1 trace header on the dedicated cloud STT proxy path", async () => {
+    getElizaApiBaseMock.mockReturnValue("https://agent-1.elizacloud.ai");
+    fetchWithCsrfMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ text: "dedicated" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    await transcribeCloudWav(new Uint8Array([1, 2, 3]), {
+      traceId: "trace-not-forwarded",
+      timeoutMs: 1000,
+    });
+
+    expect(fetchWithCsrfMock).toHaveBeenCalledWith(
+      "/api/asr/cloud",
+      expect.objectContaining({
+        headers: expect.not.objectContaining({
+          [VOICE_TRACE_HEADER]: "trace-not-forwarded",
+        }),
+      }),
+    );
+  });
+});

--- a/packages/ui/src/voice/shared-runtime-voice.test.ts
+++ b/packages/ui/src/voice/shared-runtime-voice.test.ts
@@ -14,15 +14,25 @@ vi.mock("../utils/eliza-globals", () => ({
   getElizaApiBase: vi.fn<() => string | undefined>(),
 }));
 
+vi.mock("../utils/cloud-agent-base", () => ({
+  normalizeDirectCloudSharedAgentApiBase: (value: string) =>
+    value.replace(/\/bridge\/?$/, ""),
+}));
+
 import { getElizaApiBase } from "../utils/eliza-globals";
 import {
   buildSharedRuntimeSttBody,
   currentSharedRuntimeVoiceOrigin,
   isVoiceTargetResolvableForActiveAgent,
+  markSharedRuntimeVoiceTrace,
+  measureSharedRuntimeVoiceTrace,
   parseSharedRuntimeSttResponse,
   sharedRuntimeSttUrl,
   sharedRuntimeTtsUrl,
+  sharedRuntimeVoiceMarkName,
   sharedRuntimeVoiceOrigin,
+  sharedRuntimeVoiceTraceHeaders,
+  VOICE_TRACE_HEADER,
 } from "./shared-runtime-voice";
 
 const getElizaApiBaseMock = vi.mocked(getElizaApiBase);
@@ -97,6 +107,27 @@ describe("v1 route URL builders", () => {
   });
 });
 
+describe("shared-runtime voice trace headers", () => {
+  it("adds X-Eliza-Voice-Trace-Id without changing stable base headers", () => {
+    expect(
+      sharedRuntimeVoiceTraceHeaders("trace-turn-1", {
+        Accept: "audio/wav",
+      }),
+    ).toEqual({
+      Accept: "audio/wav",
+      [VOICE_TRACE_HEADER]: "trace-turn-1",
+    });
+  });
+
+  it("leaves headers unchanged when no shared-runtime trace id exists", () => {
+    expect(
+      sharedRuntimeVoiceTraceHeaders(undefined, {
+        Accept: "audio/wav",
+      }),
+    ).toEqual({ Accept: "audio/wav" });
+  });
+});
+
 describe("STT request/response adaptation", () => {
   it("builds a multipart body with the WAV as an `audio` File (audio/wav)", () => {
     const wav = new Uint8Array([82, 73, 70, 70]); // "RIFF"
@@ -145,5 +176,204 @@ describe("isVoiceTargetResolvableForActiveAgent (mic-affordance guard)", () => {
       "https://api.elizacloud.ai/api/v1/eliza/agents/abc",
     );
     expect(isVoiceTargetResolvableForActiveAgent()).toBe(true);
+  });
+});
+
+describe("shared-runtime voice performance helpers", () => {
+  it("uses trace-scoped mark names and stores traceId in detail", () => {
+    const marks: Array<{ name: string; detail?: unknown }> = [];
+    const measures: Array<{ name: string; detail?: unknown }> = [];
+    const originalPerformance = globalThis.performance;
+    Object.defineProperty(globalThis, "performance", {
+      configurable: true,
+      value: {
+        mark: vi.fn((name: string, options?: PerformanceMarkOptions) => {
+          marks.push({ name, detail: options?.detail });
+        }),
+        measure: vi.fn(
+          (
+            name: string,
+            options?: PerformanceMeasureOptions | string,
+            _end?: string,
+          ) => {
+            measures.push({
+              name,
+              detail:
+                typeof options === "object" && options !== null
+                  ? options.detail
+                  : undefined,
+            });
+          },
+        ),
+      },
+    });
+
+    try {
+      markSharedRuntimeVoiceTrace("stt_request_start", "trace-1");
+      markSharedRuntimeVoiceTrace("stt_request_end", "trace-1");
+      measureSharedRuntimeVoiceTrace(
+        "stt_request_end",
+        "stt_request_start",
+        "stt_request_end",
+        "trace-1",
+      );
+    } finally {
+      Object.defineProperty(globalThis, "performance", {
+        configurable: true,
+        value: originalPerformance,
+      });
+    }
+
+    // Mark names are trace-qualified so two turns cannot collide.
+    expect(marks).toEqual([
+      {
+        name: sharedRuntimeVoiceMarkName("stt_request_start", "trace-1"),
+        detail: { traceId: "trace-1" },
+      },
+      {
+        name: sharedRuntimeVoiceMarkName("stt_request_end", "trace-1"),
+        detail: { traceId: "trace-1" },
+      },
+    ]);
+    // The measure resolves start/end by the SAME trace-scoped names.
+    expect(marks[0].name).toContain("trace-1");
+    expect(measures).toEqual([
+      {
+        name: sharedRuntimeVoiceMarkName("stt_request_end", "trace-1"),
+        detail: { traceId: "trace-1" },
+      },
+    ]);
+  });
+
+  it("gives interleaved sessions disjoint mark namespaces (no cross-contamination)", () => {
+    // Simulate a real PerformanceObserver-ish store keyed by name, resolving
+    // measures the way the browser does: start/end looked up by NAME, most
+    // recent mark wins. If mark names were global, turn B's start_request_start
+    // would shadow turn A's and A's measure would pair A.start's timestamp with
+    // ... whichever mark the shared name currently points at. Trace-scoped
+    // names must prevent that entirely.
+    const markStore = new Map<string, number>();
+    const resolvedMeasures: Array<{
+      name: string;
+      startName: string;
+      endName: string;
+      startTime: number;
+      endTime: number;
+      traceId: unknown;
+    }> = [];
+    let clock = 0;
+
+    const originalPerformance = globalThis.performance;
+    Object.defineProperty(globalThis, "performance", {
+      configurable: true,
+      value: {
+        mark: vi.fn((name: string) => {
+          markStore.set(name, ++clock);
+        }),
+        measure: vi.fn(
+          (name: string, options?: PerformanceMeasureOptions | string) => {
+            if (typeof options !== "object" || options === null) return;
+            const startName = String(options.start);
+            const endName = String(options.end);
+            const startTime = markStore.get(startName);
+            const endTime = markStore.get(endName);
+            // Browser semantics: a measure only exists if BOTH named marks
+            // resolve. With trace-scoping each turn's names are unique.
+            if (startTime === undefined || endTime === undefined) return;
+            resolvedMeasures.push({
+              name,
+              startName,
+              endName,
+              startTime,
+              endTime,
+              traceId: options.detail
+                ? (options.detail as { traceId?: unknown }).traceId
+                : undefined,
+            });
+          },
+        ),
+      },
+    });
+
+    try {
+      // Interleave two turns: A.start, B.start, A.end, B.end
+      markSharedRuntimeVoiceTrace("stt_request_start", "trace-A"); // t=1
+      markSharedRuntimeVoiceTrace("stt_request_start", "trace-B"); // t=2
+      markSharedRuntimeVoiceTrace("stt_request_end", "trace-A"); // t=3
+      markSharedRuntimeVoiceTrace("stt_request_end", "trace-B"); // t=4
+
+      measureSharedRuntimeVoiceTrace(
+        "stt_request_end",
+        "stt_request_start",
+        "stt_request_end",
+        "trace-A",
+      );
+      measureSharedRuntimeVoiceTrace(
+        "stt_request_end",
+        "stt_request_start",
+        "stt_request_end",
+        "trace-B",
+      );
+    } finally {
+      Object.defineProperty(globalThis, "performance", {
+        configurable: true,
+        value: originalPerformance,
+      });
+    }
+
+    expect(resolvedMeasures).toHaveLength(2);
+    const measureA = resolvedMeasures.find((m) => m.traceId === "trace-A");
+    const measureB = resolvedMeasures.find((m) => m.traceId === "trace-B");
+    if (!measureA || !measureB) {
+      throw new Error("both trace-scoped measures must resolve");
+    }
+
+    // A must span A.start(t=1) -> A.end(t=3) = 2 ticks. If names were global,
+    // A.start (t=1) would have been overwritten by B.start (t=2) and A would
+    // measure 1 tick (t=2 -> t=3), silently attributing B's start to A.
+    expect(measureA.startTime).toBe(1);
+    expect(measureA.endTime).toBe(3);
+    expect(measureA.endTime - measureA.startTime).toBe(2);
+
+    // B must span B.start(t=2) -> B.end(t=4) = 2 ticks, uncontaminated by A.
+    expect(measureB.startTime).toBe(2);
+    expect(measureB.endTime).toBe(4);
+    expect(measureB.endTime - measureB.startTime).toBe(2);
+
+    // The two turns' marks live in disjoint namespaces.
+    expect(measureA.startName).toContain("trace-A");
+    expect(measureB.startName).toContain("trace-B");
+    expect(measureA.startName).not.toBe(measureB.startName);
+  });
+
+  it("does not throw when performance APIs are absent or partial", () => {
+    const originalPerformance = globalThis.performance;
+    Object.defineProperty(globalThis, "performance", {
+      configurable: true,
+      value: {
+        mark: vi.fn(() => {
+          throw new Error("partial mark mock");
+        }),
+      },
+    });
+
+    try {
+      expect(() =>
+        markSharedRuntimeVoiceTrace("tts_request_start", "trace-1"),
+      ).not.toThrow();
+      expect(() =>
+        measureSharedRuntimeVoiceTrace(
+          "tts_end",
+          "tts_request_start",
+          "tts_end",
+          "trace-1",
+        ),
+      ).not.toThrow();
+    } finally {
+      Object.defineProperty(globalThis, "performance", {
+        configurable: true,
+        value: originalPerformance,
+      });
+    }
   });
 });

--- a/packages/ui/src/voice/shared-runtime-voice.ts
+++ b/packages/ui/src/voice/shared-runtime-voice.ts
@@ -26,6 +26,116 @@
 import { normalizeDirectCloudSharedAgentApiBase } from "../utils/cloud-agent-base";
 import { getElizaApiBase } from "../utils/eliza-globals";
 
+export const VOICE_TRACE_HEADER = "X-Eliza-Voice-Trace-Id";
+
+export type SharedRuntimeVoiceTraceMark =
+  | "stt_request_start"
+  | "stt_request_end"
+  | "transcript_received"
+  | "tts_request_start"
+  | "tts_first_byte"
+  | "tts_end"
+  | "audio_decode_start"
+  | "audio_decode_end"
+  | "playback_start"
+  | "playback_end";
+
+export function createSharedRuntimeVoiceTraceId(): string {
+  const cryptoApi = globalThis.crypto;
+  if (typeof cryptoApi?.randomUUID === "function") {
+    return cryptoApi.randomUUID();
+  }
+  const random =
+    typeof cryptoApi?.getRandomValues === "function"
+      ? cryptoApi.getRandomValues(new Uint32Array(2)).join("")
+      : Math.random().toString(36).slice(2);
+  return `voice-${Date.now().toString(36)}-${random}`;
+}
+
+/**
+ * Build the performance-entry name for a mark/measure.
+ *
+ * Trace-scoping (#15931 re-land, defect #2): the name MUST include the trace id
+ * when one exists. `performance.measure(name, { start, end })` resolves its
+ * start/end marks by NAME. If two concurrent (or retried) voice turns both
+ * emitted a globally-named `eliza.voice.stt_request_start`, a later measure
+ * could pair a start mark from turn A with an end mark from turn B and report a
+ * fabricated duration. Qualifying the name with the trace id gives every turn
+ * its own mark namespace, so measures can only ever pair marks from the SAME
+ * turn.
+ *
+ * The id is already canonical (bounded, `[a-z0-9-]`) at mint time, so it is
+ * safe to embed in the name. When no trace id exists (dedicated tier, or a
+ * turn that never ran on a shared origin) we fall back to the legacy global
+ * name — but in that case no marks are emitted at all (the mark/measure
+ * helpers no-op on a falsy id), so no cross-contamination is possible.
+ */
+export function sharedRuntimeVoiceMarkName(
+  mark: SharedRuntimeVoiceTraceMark,
+  traceId?: string | null,
+): string {
+  return traceId ? `eliza.voice.${traceId}.${mark}` : `eliza.voice.${mark}`;
+}
+
+export function sharedRuntimeVoiceTraceHeaders(
+  traceId: string | null | undefined,
+  headers: Record<string, string>,
+): Record<string, string> {
+  return traceId ? { ...headers, [VOICE_TRACE_HEADER]: traceId } : headers;
+}
+
+export function markSharedRuntimeVoiceTrace(
+  mark: SharedRuntimeVoiceTraceMark,
+  traceId: string | null | undefined,
+): void {
+  const perf = globalThis.performance;
+  if (!traceId || typeof perf?.mark !== "function") return;
+  // Trace-scoped name: two interleaved turns get disjoint mark namespaces so a
+  // later measure cannot pair marks across turns (#15931 defect #2).
+  const name = sharedRuntimeVoiceMarkName(mark, traceId);
+  try {
+    perf.mark(name, {
+      detail: { traceId },
+    } as PerformanceMarkOptions);
+  } catch {
+    try {
+      perf.mark(name);
+    } catch {
+      // Partial test/browser performance mocks may expose mark but still throw.
+      return;
+    }
+  }
+}
+
+export function measureSharedRuntimeVoiceTrace(
+  measure: SharedRuntimeVoiceTraceMark,
+  start: SharedRuntimeVoiceTraceMark,
+  end: SharedRuntimeVoiceTraceMark,
+  traceId: string | null | undefined,
+): void {
+  const perf = globalThis.performance;
+  if (!traceId || typeof perf?.measure !== "function") return;
+  // Resolve start/end by trace-scoped names so the measure can only ever pair
+  // marks from THIS trace, never another concurrent turn's (#15931 defect #2).
+  const measureName = sharedRuntimeVoiceMarkName(measure, traceId);
+  const startName = sharedRuntimeVoiceMarkName(start, traceId);
+  const endName = sharedRuntimeVoiceMarkName(end, traceId);
+  try {
+    perf.measure(measureName, {
+      start: startName,
+      end: endName,
+      detail: { traceId },
+    } as PerformanceMeasureOptions);
+  } catch {
+    try {
+      perf.measure(measureName, startName, endName);
+    } catch {
+      // Missing marks or partial mocks should not affect voice playback.
+      return;
+    }
+  }
+}
+
 /**
  * Derive the cloud API worker origin from a shared-runtime agent base.
  *

--- a/packages/ui/src/voice/voice-chat-types.ts
+++ b/packages/ui/src/voice/voice-chat-types.ts
@@ -164,6 +164,7 @@ export interface VoicePlaybackStartEvent {
   assistantFirstTextAtMs?: number;
   assistantTextUpdatedAtMs?: number;
   queuedAtMs?: number;
+  voiceTraceId?: string;
 }
 
 export interface VoiceTranscriptPreviewEvent {
@@ -215,6 +216,8 @@ export interface VoiceAssistantSpeechTelemetry {
   assistantFirstTextAtMs?: number;
   /** UI monotonic timestamp for this visible text update. */
   assistantTextUpdatedAtMs?: number;
+  /** Shared-runtime cloud voice trace id propagated from STT to sequential TTS. */
+  voiceTraceId?: string;
 }
 
 export interface QueueAssistantSpeechOptions {


### PR DESCRIPTION
**Re-land of #15931** (voice trace instrumentation), rebased onto current `develop`, addressing the two **code-level** closure findings from the trace-integrity/boundary review. Surgical scope: boundary validation + per-session mark scoping. Marked **DRAFT / ready-pending-orchestrator-review** — the voice-evidence bar (real STT→chat→TTS roundtrip, audio + narrated walkthrough, both-side logs, exported perf marks/Server-Timing) is owned by the integration seat and attached before this flips to ready.

## Closure findings, point by point

### Finding 1 — Worker accepts any non-empty `X-Eliza-Voice-Trace-Id`, logs + echoes it with no canonical format or length bound (untrusted boundary)

**Fixed.** `packages/cloud/api/v1/voice/trace.ts`:
- Defined a **canonical trace-ID format**: ASCII lowercase alphanumerics grouped by single hyphens (`^[a-z0-9]+(?:-[a-z0-9]+)*$`), **length ≤ 200**. This is the union of the client minter's two shapes (`crypto.randomUUID()` and the `voice-<base36>-<base36>` fallback), both of which are lowercase/hyphen/ASCII.
- Added `parseVoiceTraceId(raw): { traceId, invalid }` — an **explicit valid/invalid parse**. Absent header → `{null,false}`; present+valid → `{id,false}`; present+malformed → `{null,true}` (so rejections are countable/observable).
- **Design choice (documented in-code): invalid IDs are observably ignored, not rejected.** The route still runs and still emits `Server-Timing`, but a malformed id never reaches logs or the echoed response header. Rationale: telemetry correctness must not become a new failure mode for the actual voice turn; "served untraced" is the safe degrade. This matches the reviewer's "rejected **or** observably ignored" framing.
- **Defense in depth at the echo boundary:** `voiceTraceHeaders` (trace.ts) and `buildTtsObservabilityHeaders` (tts/route.ts) both re-validate before setting the header, so a future caller that skips validation still can't reflect attacker bytes.

**Adversarial tests** (`trace.test.ts`, 13 pass): oversized (>200), CR/LF + header-injection shapes, NUL/BEL/control chars, embedded whitespace/tab, uppercase, unicode/emoji, log-separator punctuation (`; , = " . _`), leading/trailing/doubled hyphens, and empty/absent (treated as absent, not invalid). Plus request-boundary tests proving `readVoiceTraceId` returns the canonical id for valid input and `null` (route proceeds) for malformed input, and echo-boundary tests proving a hostile id passed directly is never reflected while `Server-Timing` is retained.

### Finding 2 — Browser marks named globally; `performance.measure` resolves by shared name → concurrent sessions cross-contaminate

**Fixed.** `packages/ui/src/voice/shared-runtime-voice.ts`:
- `sharedRuntimeVoiceMarkName(mark, traceId?)` now embeds the trace id: **`eliza.voice.<traceId>.<mark>`**. `markSharedRuntimeVoiceTrace` and `measureSharedRuntimeVoiceTrace` resolve start/end by these **trace-scoped** names, so a measure can only ever pair marks from the same turn. (Falsy id → legacy global name, but in that case no marks are emitted at all — the helpers no-op on a falsy id — so no collision is possible.)

**Concurrency test** (`shared-runtime-voice.test.ts`, 20 pass): a `performance`-shim keyed by mark name (browser semantics: measure resolves start/end by name) drives **two interleaved sessions** — `A.start, B.start, A.end, B.end` — then measures each trace. Proves A spans `A.start(t=1)→A.end(t=3)` and B spans `B.start(t=2)→B.end(t=4)`, each 2 ticks, **uncontaminated**. With the old global names, `A.start` would have been overwritten by `B.start` and A would have silently measured 1 tick against B's start. Also asserts the two turns' mark names live in disjoint namespaces.

## Not in scope for this re-land (explicit)

The closure also listed two **larger structural** items (#3 `tts_first_byte` = time-to-headers not first-audio-byte; #4 trace-ID propagation through the chat/generation leg). Those are follow-on vertical-slice work owned by the integration seat, not the two surgical code-level defects this branch targets. Called out so review scope is unambiguous.

## Evidence (code-level, inline)

**Cloud trace suite — `bun test api/v1/voice/trace.test.ts`:**
```
 13 pass  0 fail  38 expect() calls   [302ms]
```
**UI voice suites — vitest:**
```
✓ src/voice/shared-runtime-voice.test.ts (20 tests)   16ms
✓ src/voice/local-asr-transcribe.voice-trace.test.ts (2 tests)   23ms
 22 passed
```
**CORS — `bun test shared/src/lib/cors/cloud-api-hono-cors.test.ts`:** `16 pass  0 fail` (allow-list includes `X-Eliza-Voice-Trace-Id`).

**Typecheck (tsgo `--noEmit`, both packages):** zero errors in every touched file (`trace.ts`, `trace.test.ts`, `stt/route.ts`, `tts/route.ts`, `shared-runtime-voice.ts`, `useVoiceChat.ts`, `local-asr-transcribe.ts`, `voice-chat-types.ts`, `chat-view-hooks.tsx`). Pre-existing cross-package resolution errors (core/plugin-sql/logger/i18n/pendant) are unrelated and present on baseline `develop` too — diffed to confirm the delta contains no voice files.

**Biome:** clean on all touched files.

Rebased onto `develop` @ `80e4223540f`; the STT route conflict (verbose_json timestamps vs trace Server-Timing) resolved to keep both.

— [sol-cloud]
