### PR TITLE
ci: add supersession-proof develop format guard (#15959)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -9,6 +9,7 @@ This directory contains GitHub Actions workflows for the elizaOS project (v2.0.0
 | `ci.yaml` | Push/PR to main | Main-specific CI - typecheck, tests, lint, build, dev startup |
 | `test.yml` | Push/PR to develop, manual, schedule | Broader develop tests plus required zero-key deterministic E2E; live jobs are separate |
 | `quality.yml` | Push/PR to main/develop, manual | Develop/main quality gates: format, type-safety ratchet, prompt-secret scan, UI determinism, lint |
+| `develop-format-guard.yml` | Push to develop, manual | Per-sha, never-superseded `format:check` so every trunk commit gets a completed format verdict |
 | `scenario-pr.yml` | PR to main/develop, manual | Secret-free deterministic scenario/browser E2E gate |
 | `scenario-matrix.yml` | Develop/manual opt-in | Real-service scenario matrix; not a PR gate |
 | `pr.yaml` | PR opened/edited | PR title validation |
@@ -77,7 +78,13 @@ in the `changes` job, #13617):
    regression is refused by the merge queue on develop, not just on `main`. It
    runs on `merge_group` + develop `push`. The lightweight `develop-pr.yml`
    lint job also runs `format:check`, so formatting fails on the PR even when a
-   busy push wave supersedes post-merge quality runs (#15959).
+   busy push wave supersedes post-merge quality runs (#15959). Because merges
+   can still complete while PR checks are pending (no branch protection),
+   `develop-format-guard.yml` re-runs `format:check` on every develop push in a
+   per-sha concurrency group on hosted runners — merge waves cannot supersede
+   it, so a formatting regression goes red on the exact commit that introduced
+   it. The contract enforces the guard's trigger, per-sha group, hosted runner,
+   and `format:check` step.
 
 CodeQL is a separate exception: trusted push, scheduled, and manual CodeQL runs
 use `self-hosted, Linux, X64, hetzner-robot` because full JavaScript analysis is

--- a/.github/workflows/develop-format-guard.yml
+++ b/.github/workflows/develop-format-guard.yml
@@ -1,0 +1,68 @@
+name: Develop Format Guard
+
+# Supersession-proof formatting detector for the develop trunk (#15959).
+#
+# The pre-merge gates (develop-pr.yml's lint job and test.yml's
+# merge-quality-gate) run `format:check`, but the repository has no branch
+# protection, so a REST/manual merge can complete while those checks are still
+# pending. The post-merge lanes (test.yml, quality.yml) deliberately share a
+# per-ref concurrency group with cancel-in-progress on push — a merge wave
+# supersedes them, so a formatting regression can sit invisibly on develop
+# until a quality run finally survives, and then it blames the wrong commit.
+#
+# This lane closes the detection gap: a per-sha concurrency group means no
+# develop push can ever cancel another's run, so every trunk commit gets a
+# completed format verdict, and a regression goes red on the exact commit
+# that introduced it. It is detection, not enforcement — blocking merges on
+# pending checks requires a repository ruleset (owner action, see #15959).
+# Hosted-only on purpose: the check must not depend on self-hosted fleet
+# health, and a merge wave costs only that many ~5-minute hosted jobs.
+# ci-merge-gate-contract.mjs enforces this file's trigger, concurrency, and
+# runner invariants.
+
+on:
+  push:
+    branches: [develop]
+  workflow_dispatch:
+
+# Per-sha group: every push gets its own group, so cancel-in-progress can
+# never apply across commits and each run completes. Do not key this on
+# github.ref — that reintroduces the supersession this workflow exists to
+# avoid.
+concurrency:
+  group: develop-format-guard-${{ github.sha }}
+
+permissions:
+  contents: read
+
+jobs:
+  format-check:
+    name: Format check (per-commit, never superseded)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24.15.0"
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: "1.3.14" # pinned: floating canary hangs bun install on hosted runners and writes lockfileVersion 2 (#11184/#9454)
+          install-command: bun install --ignore-scripts --no-frozen-lockfile
+          install-native-deps: "false"
+          # Biome only needs JS dependencies; the lean install keeps this lane
+          # fast so a merge wave stays cheap on hosted runners.
+          setup-python: "false"
+          install-protoc: "false"
+          run-postinstall: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      - name: Run biome format check
+        run: bun run format:check

--- a/packages/scripts/ci-merge-gate-contract.mjs
+++ b/packages/scripts/ci-merge-gate-contract.mjs
@@ -5,7 +5,10 @@
  * and required test lanes retain a hosted fallback; `ci-ok` owns lint, format,
  * type, stale-base, and secret checks; and the lightweight develop PR lane runs
  * formatting before merge because superseded post-merge runs cannot reliably
- * be the first detector (#15959).
+ * be the first detector (#15959). Because merges can complete while those PR
+ * checks are pending (no branch protection), the develop format guard must
+ * stay a per-sha, hosted, never-superseded push lane so every trunk commit
+ * still gets a completed format verdict.
  *
  * The checker text-scans YAML to avoid a workflow-time parser dependency. Its
  * synthetic self-test must reject every missing dependency or command so the
@@ -30,9 +33,11 @@ const CONTRACT_WORKFLOWS = [
   "windows-dev-smoke.yml",
   "windows-desktop-preload-smoke.yml",
   "develop-pr.yml",
+  "develop-format-guard.yml",
 ];
 
 const DEVELOP_PR_WORKFLOW = "develop-pr.yml";
+const FORMAT_GUARD_WORKFLOW = "develop-format-guard.yml";
 
 const FLEET_FALLBACK_VAR = "HETZNER_FLEET_ONLINE";
 const BARE_SELF_HOSTED = /runs-on:\s*\[\s*self-hosted\s*,\s*hetzner-robot\s*\]/;
@@ -279,6 +284,36 @@ function checkWorkflowText(fileName, text, problems) {
       }
     }
   }
+
+  if (fileName === FORMAT_GUARD_WORKFLOW) {
+    if (!/ {2}push:\s*\n {4}branches:\s*\[develop\]/.test(text)) {
+      problems.push(
+        `${fileName}: missing 'push: branches: [develop]' trigger — the guard must run on every develop push`,
+      );
+    }
+    if (!/^ {2}group:[^\n]*\$\{\{\s*github\.sha\s*\}\}/m.test(text)) {
+      problems.push(
+        `${fileName}: concurrency group must include github.sha — a per-ref group lets merge waves supersede the run, which is the regression this guard exists to prevent (#15959)`,
+      );
+    }
+    const guardJob = jobBody(text, "format-check");
+    if (guardJob === null) {
+      problems.push(`${fileName}: no 'format-check' job found`);
+    } else {
+      const guardRunsOn =
+        guardJob.match(/^\s+runs-on:\s*(.+?)\s*$/m)?.[1] ?? "";
+      if (!guardRunsOn.startsWith("ubuntu-")) {
+        problems.push(
+          `${fileName}: 'format-check' runs-on is '${guardRunsOn || "missing"}', expected a hosted ubuntu-* runner — the guard must not depend on self-hosted fleet health`,
+        );
+      }
+      if (!/bun run format:check\b/.test(guardJob)) {
+        problems.push(
+          `${fileName}: 'format-check' job is missing bun run format:check`,
+        );
+      }
+    }
+  }
 }
 
 function run(repoRoot) {
@@ -473,8 +508,61 @@ function selfTest() {
       );
     }
   }
+
+  const goodFormatGuard = `on:
+  push:
+    branches: [develop]
+concurrency:
+  group: develop-format-guard-\${{ github.sha }}
+jobs:
+  format-check:
+    runs-on: ubuntu-latest
+    steps:
+      - run: bun run format:check
+`;
+  const guardProblems = [];
+  checkWorkflowText(FORMAT_GUARD_WORKFLOW, goodFormatGuard, guardProblems);
+  if (guardProblems.length !== 0) {
+    throw new Error(
+      `self-test: valid format guard fixture reported problems:\n  ${guardProblems.join("\n  ")}`,
+    );
+  }
+  const badGuardCases = [
+    {
+      name: "guard missing develop push trigger",
+      text: goodFormatGuard.replace(
+        "  push:\n    branches: [develop]\n",
+        "  workflow_dispatch:\n",
+      ),
+    },
+    {
+      name: "guard concurrency keyed per-ref (supersedable)",
+      text: goodFormatGuard.replace(
+        "develop-format-guard-$" + "{{ github.sha }}",
+        "develop-format-guard-$" + "{{ github.ref }}",
+      ),
+    },
+    {
+      name: "guard missing format:check step",
+      text: goodFormatGuard.replace("      - run: bun run format:check\n", ""),
+    },
+    {
+      name: "guard on self-hosted fleet",
+      text: goodFormatGuard.replace(
+        "runs-on: ubuntu-latest",
+        "runs-on: [self-hosted, hetzner-robot]",
+      ),
+    },
+  ];
+  for (const { name, text } of badGuardCases) {
+    const problems = [];
+    checkWorkflowText(FORMAT_GUARD_WORKFLOW, text, problems);
+    if (problems.length === 0) {
+      throw new Error(`self-test: invalid fixture '${name}' was not caught`);
+    }
+  }
   console.log(
-    `ci-merge-gate-contract self-test: ${badCases.length + 4} cases passed`,
+    `ci-merge-gate-contract self-test: ${badCases.length + badGuardCases.length + 5} cases passed`,
   );
 }
 


### PR DESCRIPTION
Part of #15959

## Summary

Formatting regressions keep landing because merges complete while the PR's Lint/`format:check` is still pending (the repo has no branch protection, so REST/manual merges bypass pending checks), and every post-merge lane that runs `format:check` (`test.yml`, `quality.yml`) shares a per-ref `cancel-in-progress` concurrency group — a merge wave supersedes the runs, so breaks accumulate invisibly until one run finally survives, and then it blames the wrong commit.

#15975 already landed the pre-merge half (`develop-pr.yml` lint runs `format:check`; `test.yml`'s `ci-ok` needs `merge-quality-gate` which runs it — both contract-enforced). This PR implements **option 3 from the issue body**, the detection half that no merge mode can bypass:

- **`.github/workflows/develop-format-guard.yml`** (new): runs `bun run format:check` on every push to `develop` in a **per-sha concurrency group** (`develop-format-guard-${{ github.sha }}`), so no push can ever supersede another's run — every trunk commit gets a completed format verdict, and a regression goes red on the exact commit that introduced it. Hosted `ubuntu-latest` on purpose: the guard must not depend on self-hosted fleet health, and the lean install (no postinstall/python/protoc) keeps a merge wave cheap (~5-minute jobs).
- **`packages/scripts/ci-merge-gate-contract.mjs`**: the merge-gate contract now enforces the guard's four invariants — `push: branches: [develop]` trigger, concurrency group containing `github.sha`, hosted `ubuntu-*` runner, and the `bun run format:check` step — with four new synthetic self-test cases proving each violation is caught (25 cases total). The contract runs in `test.yml`'s `changes` job, so weakening the guard fails CI.
- **`.github/workflows/README.md`**: workflow table row + the hosted-quality-parity section now document the guard and why it exists.

## Remaining

Detection is now guaranteed per-commit, but **prevention** (blocking a merge while `format:check` is pending/failing) requires a `develop` ruleset requiring the pre-merge lint job with bypass disallowed for ordinary merge actors. `GET /branches/develop/protection` returns "Branch protection has been disabled" and `GET /rulesets` is `[]` as of this PR. That is a repository-policy change for an owner to make — deliberately not performed by an autonomous agent (a no-bypass ruleset can wedge the merge flow if the required check ever stops reporting), consistent with the deferral recorded on #15959. The issue stays open to track it.

## Verification

Full tee'd log: [15959-verification.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15959-verification.log)

- `node packages/scripts/ci-merge-gate-contract.mjs --self-test` — 25 cases pass (4 new guard cases: missing develop-push trigger, per-ref group, missing `format:check` step, self-hosted runner).
- `node packages/scripts/ci-merge-gate-contract.mjs` — pass against the real workflows including the new guard.
- **Red/green against the real file**: switching the guard's group to `${{ github.ref }}` → contract exits 1 (`concurrency group must include github.sha`); deleting the `format:check` step → contract exits 1 (`'format-check' job is missing bun run format:check`); restored → exit 0. Both in the log above.
- `node packages/scripts/ci-workflow-dedup-contract.mjs` — pass.
- `Bun.YAML.parse` structural check of the new workflow — parses; `on: [push, workflow_dispatch]`, `push.branches: [develop]`, per-sha group, `ubuntu-latest`, 4 steps ending in `bun run format:check`.
- Biome check on the changed script — clean. `error-policy-ratchet` — 0 changed production files, clean.
- Branch is even with `origin/develop` (`5e1da4085f`) at push time.

## Evidence matrix

<!-- evidence-row:before-screenshots -->
- [x] `N/A - CI workflow + contract script + workflow docs only; no rendered UI surface.`

<!-- evidence-row:after-screenshots -->
- [x] `N/A - CI workflow + contract script + workflow docs only; no rendered UI surface.`

<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing application flow; the change is a push-triggered CI lane.`

<!-- evidence-row:backend-logs -->
- [x] `N/A - no server runtime path; the deterministic contract-run output is the executable proof:` [15959-verification.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15959-verification.log)

<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend runtime path.`

<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent, action, provider, prompt, or model behavior changes.`

<!-- evidence-row:domain-artifacts -->
- [x] Contract red/green runs + self-test + YAML structural parse, tee'd and reviewed by hand: [15959-verification.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15959-verification.log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
