### PR TITLE
feat(corpus): keyless Signal SQLCipher collector + shared collector infra (#14762)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -484,15 +484,6 @@
         "vitest": "4.1.10",
       },
     },
-    "packages/benchmarks/voice-rtt": {
-      "name": "@elizaos/voice-rtt-bench",
-      "version": "0.1.0",
-      "devDependencies": {
-        "@types/node": "^25.0.3",
-        "typescript": "^6.0.3",
-        "vitest": "4.1.10",
-      },
-    },
     "packages/benchmarks/lib": {
       "name": "@elizaos-benchmarks/lib",
       "version": "0.1.0",
@@ -532,6 +523,15 @@
       "devDependencies": {
         "@types/node": "^25.0.3",
         "bun-types": "1.3.14",
+        "typescript": "^6.0.3",
+        "vitest": "4.1.10",
+      },
+    },
+    "packages/benchmarks/voice-rtt": {
+      "name": "@elizaos/voice-rtt-bench",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^25.0.3",
         "typescript": "^6.0.3",
         "vitest": "4.1.10",
       },
@@ -6404,8 +6404,6 @@
 
     "@elizaos/interrupt-bench": ["@elizaos/interrupt-bench@workspace:packages/benchmarks/interrupt-bench"],
 
-    "@elizaos/voice-rtt-bench": ["@elizaos/voice-rtt-bench@workspace:packages/benchmarks/voice-rtt"],
-
     "@elizaos/ios-native-deps": ["@elizaos/ios-native-deps@workspace:packages/native/ios-deps"],
 
     "@elizaos/lifeops-bench": ["@elizaos/lifeops-bench@workspace:packages/lifeops-bench"],
@@ -6693,6 +6691,8 @@
     "@elizaos/vercel-edge-examples": ["@elizaos/vercel-edge-examples@workspace:packages/examples/vercel"],
 
     "@elizaos/vitest-vite": ["vite@7.3.3", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA=="],
+
+    "@elizaos/voice-rtt-bench": ["@elizaos/voice-rtt-bench@workspace:packages/benchmarks/voice-rtt"],
 
     "@elysiajs/cors": ["@elysiajs/cors@1.4.2", "", { "peerDependencies": { "elysia": ">= 1.4.0" } }, "sha512-FTCcbH35brTLigF1W7BYySRZomgI/dBEMK9BgK9RP9Nez7zmpGh4koL/Yr1BFv8nYz7CfhRvcM8d/c+XnwMaVQ=="],
 

--- a/packages/corpus-tools/AGENTS.md
+++ b/packages/corpus-tools/AGENTS.md
@@ -27,5 +27,11 @@ work.
   mine candidates, gazetteer, deletion rules/review/approval chain, placeholder
   registry, scanner config, and final corpus bytes. Report self-hashes detect
   corruption but never substitute for a fresh rerun or owner authorization.
+- Collectors (`src/collectors/`) share `checkpoint.ts` + `shard-writer.ts` and
+  fail closed with a typed `CollectorError`; they never fabricate a partial pull.
+  A collector must never operate on a live source database or leave decrypted
+  copies/key material behind — copy, read, then wipe with a teardown assert. The
+  live credential/device pull is the only owner-gated step; the parsing,
+  normalization, and resume logic is exercised keyless against fixtures.
 
 Repo-wide rules and evidence standards are in the root `AGENTS.md`.

--- a/packages/corpus-tools/CLAUDE.md
+++ b/packages/corpus-tools/CLAUDE.md
@@ -27,5 +27,11 @@ work.
   mine candidates, gazetteer, deletion rules/review/approval chain, placeholder
   registry, scanner config, and final corpus bytes. Report self-hashes detect
   corruption but never substitute for a fresh rerun or owner authorization.
+- Collectors (`src/collectors/`) share `checkpoint.ts` + `shard-writer.ts` and
+  fail closed with a typed `CollectorError`; they never fabricate a partial pull.
+  A collector must never operate on a live source database or leave decrypted
+  copies/key material behind — copy, read, then wipe with a teardown assert. The
+  live credential/device pull is the only owner-gated step; the parsing,
+  normalization, and resume logic is exercised keyless against fixtures.
 
 Repo-wide rules and evidence standards are in the root `AGENTS.md`.

--- a/packages/corpus-tools/README.md
+++ b/packages/corpus-tools/README.md
@@ -96,6 +96,46 @@ self-hash detects corruption but is not an authorization signature. Owner sample
 review remains a separate authorization bound to that machine report; the
 machine report alone does not satisfy the final human sign-off.
 
+## Collectors
+
+Collectors live under `src/collectors/` and share the resume/shard infra:
+`checkpoint.ts` (durable per-account high-water marks, atomic writes,
+fail-closed on a corrupt marker) and `shard-writer.ts` (idempotent
+`<platform>/<account>/<yyyy-mm>.jsonl` output in the exact layout `validate`
+reads back). Collector failures are typed `CollectorError`s
+(`src/collectors/errors.ts`) so the CLI maps a key/decrypt/IO failure to a
+distinct exit path instead of shipping a truncated pull.
+
+### Signal (`#14762`)
+
+`corpus collect signal` reads Signal Desktop's SQLCipher `db.sqlite`. It:
+
+1. Resolves the 256-bit key from `<Signal>/config.json` — plaintext `key`
+   (legacy) or the Electron `safeStorage` `encryptedKey`, unwrapped via the
+   Chromium OSCrypt v10 scheme keyed by the macOS Keychain item
+   "Signal Safe Storage". The key is never persisted.
+2. Copies `db.sqlite` into the local `.state` dir and reads the **copy**
+   read-only (never the live file), then normalizes `messages` (joined to
+   `conversations`) into `CorpusMessage` rows.
+3. Writes idempotent month shards and advances a `max(received_at)` checkpoint,
+   then **wipes the decrypted copy** and asserts it is gone — a failed wipe is a
+   fail-closed error, not a warning.
+
+```bash
+bun run --cwd packages/corpus-tools corpus collect signal \
+  --owner-id <your-service-id> --owner-display "You" \
+  --account primary --output data --state-dir data/.state
+```
+
+The SQLCipher engine (`better-sqlite3-multiple-ciphers`) is an
+**optional dependency** loaded only for a live owner-machine pull; when absent
+the collector fails closed with `sqlcipher_unavailable`. The query and
+normalization path is exercised keyless in tests against a plaintext SQLite build
+of Signal's schema (the injected `openDatabase` seam), so the only owner-gated
+step is the live `PRAGMA key` decrypt plus the Keychain approval prompt.
+Attachment bytes are out of scope; body-less rows (reactions, attachment-only,
+membership events) are skipped, never fabricated into empty-text messages.
+
 ## X Mapping
 
 The canonical schema includes platform `x`. The existing LifeOps simulator

--- a/packages/corpus-tools/package.json
+++ b/packages/corpus-tools/package.json
@@ -26,6 +26,9 @@
     "@elizaos/core": "workspace:*",
     "zod": "^4.4.3"
   },
+  "optionalDependencies": {
+    "better-sqlite3-multiple-ciphers": "^12.11.1"
+  },
   "devDependencies": {
     "@types/node": "^24.0.0"
   },

--- a/packages/corpus-tools/src/cli.ts
+++ b/packages/corpus-tools/src/cli.ts
@@ -4,6 +4,16 @@
  * diagnostics; this file is the only place that prints and converts validation
  * failure into a process exit code.
  */
+import { execFile } from "node:child_process";
+import { homedir } from "node:os";
+import { promisify } from "node:util";
+import {
+  type CollectSignalResult,
+  collectSignal,
+  defaultSignalDir,
+  defaultSignalStateDir,
+} from "./collectors/signal.ts";
+import { macosKeychainPasswordReader } from "./collectors/signal-key.ts";
 import {
   runScrubPipeline,
   type ScrubMode,
@@ -11,6 +21,8 @@ import {
 } from "./pipeline/driver.ts";
 import { validateCorpusTarget } from "./validator.ts";
 import { type VerifyCorpusOptions, verifyCorpus } from "./verification.ts";
+
+const execFileAsync = promisify(execFile);
 
 interface ScrubCliOptions {
   targetPath: string;
@@ -91,8 +103,58 @@ function parseScrubCliOptions(args: string[]): ScrubCliOptions {
   };
 }
 
+async function collectSignalFromCli(
+  args: string[],
+): Promise<CollectSignalResult> {
+  const signalDir =
+    readFlagValue(args, "--signal-dir") ?? defaultSignalDir(homedir());
+  const outputDir = readFlagValue(args, "--output") ?? "data";
+  const stateDir =
+    readFlagValue(args, "--state-dir") ?? defaultSignalStateDir();
+  const accountId = readFlagValue(args, "--account") ?? "primary";
+  const ownerId = requireFlagValue(args, "--owner-id");
+  const ownerDisplay = readFlagValue(args, "--owner-display") ?? ownerId;
+  return collectSignal({
+    signalDir,
+    outputDir,
+    stateDir,
+    accountId,
+    ownerId,
+    ownerDisplay,
+    readKeychainPassword: macosKeychainPasswordReader(
+      async (command, cmdArgs) => {
+        // error-policy:J1 CLI boundary: translate a Keychain lookup failure into
+        // a non-zero status the resolver maps to a typed key error.
+        try {
+          const { stdout } = await execFileAsync(command, cmdArgs);
+          return { stdout, status: 0 };
+        } catch (error) {
+          return {
+            stdout: "",
+            status:
+              typeof (error as { code?: number }).code === "number"
+                ? (error as { code: number }).code
+                : 1,
+          };
+        }
+      },
+    ),
+  });
+}
+
 async function main(argv: string[]): Promise<number> {
   const [command, maybeTarget = "data", ...rest] = argv;
+  if (command === "collect") {
+    const platform = maybeTarget;
+    if (platform !== "signal") {
+      process.stderr.write(`unsupported collect platform ${platform}\n`);
+      return 2;
+    }
+    const result = await collectSignalFromCli(rest);
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return 0;
+  }
+
   if (command === "validate") {
     const result = await validateCorpusTarget(maybeTarget);
     process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
@@ -115,7 +177,7 @@ async function main(argv: string[]): Promise<number> {
   }
 
   process.stderr.write(
-    "usage: corpus validate <file-or-dir>\n       corpus scrub --target <file-or-dir> --stage <stage|all> --mode <deep|fast-track> [--resume] [--dry-run]\n       corpus verify --target <dir> --manifest <file> --candidates <file> --canaries <file> --ledger <file> --gazetteer <file> --deletion-rules <file> --deletion-review-queue <file> --deletion-review-decision <file> --deletion-approval <file> --placeholder-registry <file> --ruleset-version <version> --report <file>\n",
+    "usage: corpus validate <file-or-dir>\n       corpus collect signal --owner-id <id> [--account <id>] [--signal-dir <dir>] [--output <dir>] [--state-dir <dir>] [--owner-display <name>]\n       corpus scrub --target <file-or-dir> --stage <stage|all> --mode <deep|fast-track> [--resume] [--dry-run]\n       corpus verify --target <dir> --manifest <file> --candidates <file> --canaries <file> --ledger <file> --gazetteer <file> --deletion-rules <file> --deletion-review-queue <file> --deletion-review-decision <file> --deletion-approval <file> --placeholder-registry <file> --ruleset-version <version> --report <file>\n",
   );
   return 2;
 }

--- a/packages/corpus-tools/src/collectors/checkpoint.test.ts
+++ b/packages/corpus-tools/src/collectors/checkpoint.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Collector checkpoint tests. Verifies the resume marker round-trips atomically,
+ * treats a first run (no file) as null, and fails closed on a corrupted marker
+ * rather than silently restarting a backfill from zero.
+ */
+import { mkdir, mkdtemp, readdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { readCheckpoint, writeCheckpoint } from "./checkpoint.ts";
+
+async function stateDir(): Promise<string> {
+  return mkdtemp(path.join(tmpdir(), "signal-checkpoint-"));
+}
+
+describe("collector checkpoint", () => {
+  it("returns null before any checkpoint is written", async () => {
+    const dir = await stateDir();
+    expect(await readCheckpoint(dir, "signal", "primary")).toBeNull();
+  });
+
+  it("round-trips a checkpoint", async () => {
+    const dir = await stateDir();
+    await writeCheckpoint(dir, {
+      platform: "signal",
+      accountId: "primary",
+      lastTs: 1_720_000_000_000,
+      lastId: "signal:primary:m9",
+      messageCount: 42,
+      updatedAt: new Date().toISOString(),
+    });
+    const loaded = await readCheckpoint(dir, "signal", "primary");
+    expect(loaded?.lastTs).toBe(1_720_000_000_000);
+    expect(loaded?.lastId).toBe("signal:primary:m9");
+    expect(loaded?.messageCount).toBe(42);
+  });
+
+  it("leaves no temp file after an atomic write", async () => {
+    const dir = await stateDir();
+    await writeCheckpoint(dir, {
+      platform: "signal",
+      accountId: "primary",
+      lastTs: 1,
+      messageCount: 1,
+      updatedAt: new Date().toISOString(),
+    });
+    const entries = await readdir(path.join(dir, "signal"));
+    expect(entries.some((name) => name.endsWith(".tmp"))).toBe(false);
+  });
+
+  it("fails closed on a corrupt checkpoint", async () => {
+    const dir = await stateDir();
+    const file = path.join(dir, "signal", "primary.checkpoint.json");
+    await mkdir(path.dirname(file), { recursive: true });
+    await writeFile(file, '{"platform":"signal"}', "utf8");
+    await expect(readCheckpoint(dir, "signal", "primary")).rejects.toThrow(
+      /corrupt checkpoint/,
+    );
+  });
+});

--- a/packages/corpus-tools/src/collectors/checkpoint.ts
+++ b/packages/corpus-tools/src/collectors/checkpoint.ts
@@ -1,0 +1,90 @@
+/**
+ * Durable per-account collector checkpoints. A 2-year backfill must survive
+ * interruption and rerun idempotently, so each collector records the high-water
+ * mark of what it has already emitted (the newest source timestamp and the last
+ * seen source id) and resumes strictly forward from it. The store is a plain
+ * JSON file under the collector's local `.state` dir — never the git tree — and
+ * is written atomically (temp + rename) so a crash mid-write cannot leave a
+ * half-written checkpoint that would silently skip or re-emit messages.
+ *
+ * Consumed by every `src/collectors/*` collector; the shape is intentionally
+ * platform-neutral so resume semantics stay identical across Gmail, Telegram,
+ * Discord, iMessage, Signal, and X.
+ */
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { z } from "zod";
+import type { CorpusPlatform } from "../schema.ts";
+
+export const collectorCheckpointSchema = z.object({
+  platform: z.string().min(1),
+  accountId: z.string().min(1),
+  // Newest source timestamp (ms since epoch) already written to a shard. The
+  // next run pulls strictly greater-than this to avoid re-emitting the boundary
+  // message while never skipping a gap.
+  lastTs: z.number().int().nonnegative(),
+  // Newest source-native id at `lastTs`, used to break ties when two messages
+  // share a millisecond so a resume neither drops nor duplicates them.
+  lastId: z.string().min(1).optional(),
+  messageCount: z.number().int().nonnegative(),
+  updatedAt: z.string().min(1),
+});
+
+export type CollectorCheckpoint = z.infer<typeof collectorCheckpointSchema>;
+
+function checkpointPath(
+  stateDir: string,
+  platform: CorpusPlatform,
+  accountId: string,
+): string {
+  const safeAccount = accountId.replace(/[^a-zA-Z0-9._-]/g, "_");
+  return path.join(stateDir, platform, `${safeAccount}.checkpoint.json`);
+}
+
+/**
+ * Load an account's checkpoint, or `null` on a first run. A checkpoint file that
+ * exists but fails the schema is a corrupted resume marker, not an empty one:
+ * we throw so the collector fails closed rather than silently restarting a
+ * multi-hour backfill from zero and duplicating everything.
+ */
+export async function readCheckpoint(
+  stateDir: string,
+  platform: CorpusPlatform,
+  accountId: string,
+): Promise<CollectorCheckpoint | null> {
+  const file = checkpointPath(stateDir, platform, accountId);
+  let raw: string;
+  try {
+    raw = await fs.readFile(file, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+  // error-policy:J3 checkpoint file is untrusted on-disk state; a parse/schema
+  // failure is a corrupted marker and must fail closed, never reset to zero.
+  const parsed = collectorCheckpointSchema.safeParse(JSON.parse(raw));
+  if (!parsed.success) {
+    throw new Error(
+      `corrupt checkpoint at ${file}: ${parsed.error.issues
+        .map((issue) => `${issue.path.join(".")}: ${issue.message}`)
+        .join("; ")}`,
+    );
+  }
+  return parsed.data;
+}
+
+export async function writeCheckpoint(
+  stateDir: string,
+  checkpoint: CollectorCheckpoint,
+): Promise<void> {
+  const validated = collectorCheckpointSchema.parse(checkpoint);
+  const file = checkpointPath(
+    stateDir,
+    validated.platform as CorpusPlatform,
+    validated.accountId,
+  );
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  const tmp = `${file}.${process.pid}.tmp`;
+  await fs.writeFile(tmp, `${JSON.stringify(validated, null, 2)}\n`, "utf8");
+  await fs.rename(tmp, file);
+}

--- a/packages/corpus-tools/src/collectors/errors.ts
+++ b/packages/corpus-tools/src/collectors/errors.ts
@@ -1,0 +1,55 @@
+/**
+ * Typed failures for corpus collectors. Every collector fails closed on a
+ * classifiable condition — a missing or wrong SQLCipher key, an unreadable
+ * source database, a malformed export archive — rather than returning a
+ * partial or fabricated corpus, so a broken pull is observable at the boundary
+ * (the CLI translates the code to an exit status) instead of silently shipping
+ * a truncated dataset. The `code` union is the contract the CLI and tests
+ * branch on; widen it additively as new collectors land.
+ */
+import { ElizaError } from "@elizaos/core";
+
+export type CollectorErrorCode =
+  | "key_source_unavailable"
+  | "key_decrypt_failed"
+  | "sqlcipher_unavailable"
+  | "db_open_failed"
+  | "db_query_failed"
+  | "source_missing"
+  | "malformed_export"
+  | "teardown_failed";
+
+/**
+ * Collector-scoped {@link ElizaError}. Carries the platform and a
+ * machine-classifiable code so the CLI can map a decrypt/key/IO failure to a
+ * distinct exit path and tests can assert the exact failure mode without
+ * string-matching messages.
+ */
+export class CollectorError extends ElizaError {
+  readonly collectorCode: CollectorErrorCode;
+
+  constructor(
+    message: string,
+    options: {
+      collectorCode: CollectorErrorCode;
+      platform: string;
+      cause?: unknown;
+      context?: Record<string, unknown>;
+    },
+  ) {
+    super(message, {
+      code: `collector:${options.platform}:${options.collectorCode}`,
+      cause: options.cause,
+      context: { platform: options.platform, ...options.context },
+    });
+    this.collectorCode = options.collectorCode;
+  }
+}
+
+export function isCollectorError(
+  value: unknown,
+  code?: CollectorErrorCode,
+): value is CollectorError {
+  if (!(value instanceof CollectorError)) return false;
+  return code === undefined || value.collectorCode === code;
+}

--- a/packages/corpus-tools/src/collectors/index.ts
+++ b/packages/corpus-tools/src/collectors/index.ts
@@ -1,0 +1,8 @@
+/** Public entry for corpus collectors and their shared shard/checkpoint infra. */
+export * from "./checkpoint.ts";
+export * from "./errors.ts";
+export * from "./shard-writer.ts";
+export * from "./signal.ts";
+export * from "./signal-db.ts";
+export * from "./signal-key.ts";
+export * from "./signal-normalize.ts";

--- a/packages/corpus-tools/src/collectors/shard-writer.test.ts
+++ b/packages/corpus-tools/src/collectors/shard-writer.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Shard-writer tests. Proves collector output lands in the exact
+ * <platform>/<account>/<yyyy-mm>.jsonl layout the validator reads back, merges
+ * idempotently on rerun (new-count accurate, no duplicates), splits across
+ * months, rejects cross-account rows, and passes a full `validateCorpusTarget`
+ * round-trip against real files on disk.
+ */
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { CORPUS_CUTOFF_MS, type CorpusMessage } from "../schema.ts";
+import { validateCorpusTarget } from "../validator.ts";
+import { writeShards } from "./shard-writer.ts";
+
+const JULY = Date.parse("2024-07-10T12:00:00.000Z");
+const AUGUST = Date.parse("2024-08-02T09:00:00.000Z");
+
+function message(id: string, ts: number): CorpusMessage {
+  return {
+    id: `signal:primary:${id}`,
+    platform: "signal",
+    accountId: "primary",
+    threadId: "signal:primary:conv-1",
+    ts,
+    direction: "in",
+    senderId: "peer",
+    senderDisplay: "Peer",
+    recipients: [{ id: "owner" }],
+    text: `body ${id}`,
+    labels: [],
+    attachments: [],
+    scrubState: "raw",
+  };
+}
+
+async function outDir(): Promise<string> {
+  return mkdtemp(path.join(tmpdir(), "signal-shards-"));
+}
+
+describe("writeShards", () => {
+  it("writes month shards in the validator layout and validates", async () => {
+    const dir = await outDir();
+    const summary = await writeShards(dir, "signal", "primary", [
+      message("m1", JULY),
+      message("m2", JULY + 1000),
+      message("m3", AUGUST),
+    ]);
+    expect(summary.shardsWritten).toBe(2);
+    expect(summary.messagesAdded).toBe(3);
+    expect(summary.paths).toContain(
+      path.join(dir, "signal", "primary", "2024-07.jsonl"),
+    );
+
+    const validation = await validateCorpusTarget(dir);
+    expect(validation.ok).toBe(true);
+    expect(validation.manifest.totals.messages).toBe(3);
+  });
+
+  it("is idempotent on rerun and reports only newly added rows", async () => {
+    const dir = await outDir();
+    await writeShards(dir, "signal", "primary", [
+      message("m1", JULY),
+      message("m2", JULY + 1000),
+    ]);
+    const second = await writeShards(dir, "signal", "primary", [
+      message("m2", JULY + 1000),
+      message("m3", JULY + 2000),
+    ]);
+    expect(second.messagesAdded).toBe(1);
+
+    const shard = await readFile(
+      path.join(dir, "signal", "primary", "2024-07.jsonl"),
+      "utf8",
+    );
+    const ids = shard
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line).id);
+    expect(ids).toEqual([
+      "signal:primary:m1",
+      "signal:primary:m2",
+      "signal:primary:m3",
+    ]);
+  });
+
+  it("rejects a row that does not belong to the shard target", async () => {
+    const dir = await outDir();
+    const foreign = { ...message("x", JULY), accountId: "secondary" };
+    await expect(
+      writeShards(dir, "signal", "primary", [foreign]),
+    ).rejects.toThrow(/does not match shard target/);
+  });
+
+  it("rejects an off-cutoff row via schema validation", async () => {
+    const dir = await outDir();
+    const tooOld = { ...message("old", CORPUS_CUTOFF_MS - 1) };
+    await expect(
+      writeShards(dir, "signal", "primary", [tooOld]),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/corpus-tools/src/collectors/shard-writer.ts
+++ b/packages/corpus-tools/src/collectors/shard-writer.ts
@@ -1,0 +1,129 @@
+/**
+ * Month-sharded JSONL writer for collector output. Collectors emit validated
+ * `CorpusMessage` rows; this module lays them out on disk exactly as
+ * `validator.ts` expects to read them back — `<root>/<platform>/<account>/<yyyy-mm>.jsonl`,
+ * one JSON object per line, sorted by `(ts, id)` — so a collect run and a later
+ * `corpus validate` agree on shape, path, and hash without a second contract.
+ *
+ * Writes merge into existing shards on resume: a re-run appends only rows whose
+ * id is not already present, keeping the output idempotent so an interrupted
+ * 2-year backfill can be restarted without duplicating or dropping messages.
+ * Every row is schema-validated before it is written — a collector cannot emit
+ * an off-contract message and have it surface only later at validate time.
+ */
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import {
+  type CorpusMessage,
+  type CorpusPlatform,
+  corpusMessageSchema,
+} from "../schema.ts";
+
+export interface ShardWriteSummary {
+  shardsWritten: number;
+  /** Total rows present across the written shards after the merge. */
+  messagesWritten: number;
+  /** Rows whose id was not already on disk — the true new-message count. */
+  messagesAdded: number;
+  paths: string[];
+}
+
+function monthKey(ts: number): string {
+  return new Date(ts).toISOString().slice(0, 7);
+}
+
+function sha256(bytes: string): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function sortMessages(messages: CorpusMessage[]): CorpusMessage[] {
+  return [...messages].sort((a, b) => a.ts - b.ts || a.id.localeCompare(b.id));
+}
+
+async function readExistingShard(file: string): Promise<CorpusMessage[]> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(file, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+  return raw
+    .split(/\r?\n/)
+    .filter((line) => line.trim().length > 0)
+    .map((line) => corpusMessageSchema.parse(JSON.parse(line)));
+}
+
+/**
+ * Write `messages` into month shards under `rootDir`, merging with any rows
+ * already on disk for the same account/month. Each incoming row is validated
+ * against the corpus schema first; a row on the wrong platform/account for its
+ * requested shard is rejected here rather than corrupting the layout the
+ * validator derives platform/account from.
+ */
+export async function writeShards(
+  rootDir: string,
+  platform: CorpusPlatform,
+  accountId: string,
+  messages: CorpusMessage[],
+): Promise<ShardWriteSummary> {
+  const byMonth = new Map<string, Map<string, CorpusMessage>>();
+
+  for (const raw of messages) {
+    const message = corpusMessageSchema.parse(raw);
+    if (message.platform !== platform || message.accountId !== accountId) {
+      throw new Error(
+        `message ${message.id} platform/account (${message.platform}/${message.accountId}) does not match shard target ${platform}/${accountId}`,
+      );
+    }
+    const month = monthKey(message.ts);
+    const bucket = byMonth.get(month) ?? new Map<string, CorpusMessage>();
+    bucket.set(message.id, message);
+    byMonth.set(month, bucket);
+  }
+
+  const summary: ShardWriteSummary = {
+    shardsWritten: 0,
+    messagesWritten: 0,
+    messagesAdded: 0,
+    paths: [],
+  };
+
+  for (const [month, incoming] of [...byMonth.entries()].sort(([a], [b]) =>
+    a.localeCompare(b),
+  )) {
+    const file = path.join(rootDir, platform, accountId, `${month}.jsonl`);
+    await fs.mkdir(path.dirname(file), { recursive: true });
+
+    const merged = new Map<string, CorpusMessage>();
+    for (const existing of await readExistingShard(file)) {
+      merged.set(existing.id, existing);
+    }
+    for (const [id, message] of incoming) {
+      if (!merged.has(id)) summary.messagesAdded += 1;
+      merged.set(id, message);
+    }
+
+    const rows = sortMessages([...merged.values()]);
+    const body = `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`;
+    const tmp = `${file}.${process.pid}.tmp`;
+    await fs.writeFile(tmp, body, "utf8");
+    await fs.rename(tmp, file);
+
+    summary.shardsWritten += 1;
+    summary.messagesWritten += rows.length;
+    summary.paths.push(file);
+  }
+
+  return summary;
+}
+
+/**
+ * Content hash of a shard file, matching `validator.ts`'s hash of the raw
+ * bytes. Exposed so a collector can report a manifest-style digest for its
+ * output without re-reading and re-serializing rows.
+ */
+export async function shardSha256(file: string): Promise<string> {
+  return sha256(await fs.readFile(file, "utf8"));
+}

--- a/packages/corpus-tools/src/collectors/signal-db.ts
+++ b/packages/corpus-tools/src/collectors/signal-db.ts
@@ -1,0 +1,200 @@
+/**
+ * SQLCipher-backed read surface for the Signal Desktop database. Signal stores
+ * every message in an encrypted `db.sqlite` (SQLCipher); once the `PRAGMA key`
+ * is applied the queryable shape is ordinary SQLite. This module isolates the
+ * two concerns so the collector stays testable: `SignalDatabase` is the small
+ * query interface the collector consumes, and `openSqlcipherDatabase` is the
+ * production adapter that applies the key and runs the queries.
+ *
+ * The adapter loads `better-sqlite3-multiple-ciphers` dynamically (an optional
+ * dependency, needed only for a live owner-machine pull) and fails closed with a
+ * typed `sqlcipher_unavailable` error when it is absent, rather than silently
+ * degrading. Tests inject an in-memory `SignalDatabase` (or a plaintext SQLite
+ * build of the same schema) so the row-selection and normalization path is
+ * exercised against a real query engine without shipping the native cipher.
+ */
+import { logger } from "@elizaos/core";
+import { CollectorError } from "./errors.ts";
+
+/**
+ * Raw row shape as it comes out of Signal's `messages` table joined to
+ * `conversations`. Columns are nullable exactly as SQLite returns them; the
+ * `json` column is the canonical message object and is parsed by the normalizer.
+ */
+export interface SignalMessageRow {
+  id: string;
+  json: string | null;
+  sent_at: number | null;
+  received_at: number | null;
+  conversationId: string | null;
+  type: string | null;
+  body: string | null;
+  source: string | null;
+  sourceServiceId: string | null;
+  conversationName: string | null;
+  conversationType: string | null;
+  conversationE164: string | null;
+  conversationServiceId: string | null;
+}
+
+export interface SignalDatabase {
+  /**
+   * Return messages with `received_at >= cutoffMs`, ascending by
+   * `(received_at, id)` so the collector can checkpoint forward deterministically.
+   */
+  queryMessages(cutoffMs: number): SignalMessageRow[];
+  close(): void;
+}
+
+/** Minimal shape of the `better-sqlite3-multiple-ciphers` handle we rely on. */
+interface CipherStatement {
+  all(...params: unknown[]): unknown[];
+}
+interface CipherDatabase {
+  pragma(source: string): unknown;
+  prepare(sql: string): CipherStatement;
+  close(): void;
+}
+type CipherDatabaseCtor = new (
+  path: string,
+  options?: { readonly?: boolean; fileMustExist?: boolean },
+) => CipherDatabase;
+
+/**
+ * Minimal SQLite execution surface both openers bind to. Keeping the collector's
+ * query in one place means the SQLCipher production path and the plaintext test
+ * path run the identical SQL against the identical schema — the only difference
+ * is the encryption, which is exactly the owner-gated part.
+ */
+export interface SignalSqliteExec {
+  all(sql: string, params: unknown[]): unknown[];
+  close(): void;
+}
+
+// Signal joins each message to its conversation to recover peer identity for
+// 1:1 threads; the row shape above mirrors this projection exactly.
+export const SIGNAL_MESSAGE_QUERY = `
+  SELECT
+    m.id AS id,
+    m.json AS json,
+    m.sent_at AS sent_at,
+    m.received_at AS received_at,
+    m.conversationId AS conversationId,
+    m.type AS type,
+    m.body AS body,
+    m.source AS source,
+    m.sourceServiceId AS sourceServiceId,
+    c.name AS conversationName,
+    c.type AS conversationType,
+    c.e164 AS conversationE164,
+    c.serviceId AS conversationServiceId
+  FROM messages m
+  LEFT JOIN conversations c ON c.id = m.conversationId
+  WHERE m.received_at >= ?
+  ORDER BY m.received_at ASC, m.id ASC
+`;
+
+/**
+ * Bind a `SignalDatabase` to any SQLite exec surface. Query failures become a
+ * typed `db_query_failed` so a schema drift in a real Signal export surfaces at
+ * the boundary rather than as a silently empty pull.
+ */
+export function createSignalDatabase(exec: SignalSqliteExec): SignalDatabase {
+  return {
+    queryMessages(cutoffMs: number): SignalMessageRow[] {
+      try {
+        return exec.all(SIGNAL_MESSAGE_QUERY, [cutoffMs]) as SignalMessageRow[];
+      } catch (error) {
+        throw new CollectorError("Signal message query failed", {
+          collectorCode: "db_query_failed",
+          platform: "signal",
+          cause: error,
+        });
+      }
+    },
+    close(): void {
+      try {
+        exec.close();
+      } catch (error) {
+        // error-policy:J6 best-effort teardown of the read handle; a
+        // double-close is benign and only logged for diagnostics.
+        logger.debug(
+          `[SignalDatabase] read handle close failed: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    },
+  };
+}
+
+// Kept non-literal so TypeScript does not statically resolve an optional native
+// dependency that is only installed for a live owner-machine pull.
+const CIPHER_MODULE_SPECIFIER = "better-sqlite3-multiple-ciphers";
+
+async function loadCipherCtor(): Promise<CipherDatabaseCtor> {
+  try {
+    const mod = (await import(/* @vite-ignore */ CIPHER_MODULE_SPECIFIER)) as {
+      default?: CipherDatabaseCtor;
+    } & CipherDatabaseCtor;
+    const ctor = (mod.default ?? mod) as CipherDatabaseCtor;
+    if (typeof ctor !== "function") {
+      throw new Error("module did not export a Database constructor");
+    }
+    return ctor;
+  } catch (error) {
+    // error-policy:J1 boundary: a live Signal pull requires the native cipher.
+    // Its absence is fail-closed, not a degraded empty read.
+    throw new CollectorError(
+      "better-sqlite3-multiple-ciphers is required for a live Signal pull",
+      {
+        collectorCode: "sqlcipher_unavailable",
+        platform: "signal",
+        cause: error,
+      },
+    );
+  }
+}
+
+/**
+ * Open a copy of Signal's encrypted `db.sqlite` read-only and bind it to the
+ * message query. Applies `PRAGMA key`, then a lightweight probe query so a wrong
+ * key or corrupt file fails here (typed `db_open_failed`) rather than surfacing
+ * as an empty message list downstream.
+ */
+export async function openSqlcipherDatabase(
+  dbPath: string,
+  keyHex: string,
+): Promise<SignalDatabase> {
+  const Database = await loadCipherCtor();
+  let db: CipherDatabase;
+  try {
+    db = new Database(dbPath, { readonly: true, fileMustExist: true });
+    // SQLCipher takes the raw 256-bit key as a hex literal; `PRAGMA cipher_...`
+    // stays at Signal's defaults (SQLCipher 4) so we don't override page size.
+    db.pragma(`key = "x'${keyHex}'"`);
+    // Force a read so an incorrect key fails now with a decrypt error.
+    db.prepare("SELECT count(*) AS n FROM sqlite_master").all();
+  } catch (error) {
+    throw new CollectorError("failed to open the Signal database copy", {
+      collectorCode: "db_open_failed",
+      platform: "signal",
+      cause: error,
+      context: { dbPath },
+    });
+  }
+
+  return createSignalDatabase({
+    all(sql: string, params: unknown[]): unknown[] {
+      return db.prepare(sql).all(...params);
+    },
+    close(): void {
+      db.close();
+    },
+  });
+}
+
+export type SignalDatabaseOpener = (
+  dbPath: string,
+  keyHex: string,
+) => Promise<SignalDatabase>;

--- a/packages/corpus-tools/src/collectors/signal-key.test.ts
+++ b/packages/corpus-tools/src/collectors/signal-key.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Signal key-acquisition tests. Exercises the real Chromium/Electron
+ * safeStorage v10 scheme by encrypting a known key with a known Keychain
+ * password in-test and asserting the unwrap recovers it byte-for-byte, plus the
+ * config.json plaintext path and every fail-closed branch (wrong password, bad
+ * prefix, missing key, unreadable config). No mock of the module under test — the
+ * only injected seam is the Keychain reader.
+ */
+import { createCipheriv, pbkdf2Sync } from "node:crypto";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { isCollectorError } from "./errors.ts";
+import { resolveSignalKey, unwrapSafeStorageKey } from "./signal-key.ts";
+
+const SAMPLE_KEY =
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+const KEYCHAIN_PASSWORD = "s3cr3t-safe-storage-password";
+
+/** Produce a genuine OSCrypt v10 blob so the unwrap is tested against real bytes. */
+function encryptV10(plaintext: string, password: string): Buffer {
+  const key = pbkdf2Sync(password, "saltysalt", 1003, 16, "sha1");
+  const iv = Buffer.alloc(16, " ");
+  const cipher = createCipheriv("aes-128-cbc", key, iv);
+  const body = Buffer.concat([
+    cipher.update(Buffer.from(plaintext, "utf8")),
+    cipher.final(),
+  ]);
+  return Buffer.concat([Buffer.from("v10", "utf8"), body]);
+}
+
+async function writeConfig(contents: unknown): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "signal-key-"));
+  const file = path.join(dir, "config.json");
+  await writeFile(file, JSON.stringify(contents), "utf8");
+  return file;
+}
+
+describe("unwrapSafeStorageKey", () => {
+  it("round-trips a real v10 blob with the correct password", () => {
+    const blob = encryptV10(SAMPLE_KEY, KEYCHAIN_PASSWORD);
+    expect(unwrapSafeStorageKey(blob, KEYCHAIN_PASSWORD)).toBe(SAMPLE_KEY);
+  });
+
+  it("fails closed on the wrong password", () => {
+    const blob = encryptV10(SAMPLE_KEY, KEYCHAIN_PASSWORD);
+    try {
+      unwrapSafeStorageKey(blob, "wrong-password");
+      throw new Error("expected a decrypt failure");
+    } catch (error) {
+      expect(isCollectorError(error, "key_decrypt_failed")).toBe(true);
+    }
+  });
+
+  it("rejects a blob without the v10 prefix", () => {
+    const blob = Buffer.concat([
+      Buffer.from("v11", "utf8"),
+      Buffer.alloc(32, 1),
+    ]);
+    try {
+      unwrapSafeStorageKey(blob, KEYCHAIN_PASSWORD);
+      throw new Error("expected a prefix failure");
+    } catch (error) {
+      expect(isCollectorError(error, "key_decrypt_failed")).toBe(true);
+    }
+  });
+});
+
+describe("resolveSignalKey", () => {
+  it("returns the plaintext legacy key", async () => {
+    const configPath = await writeConfig({ key: SAMPLE_KEY });
+    expect(await resolveSignalKey({ configPath })).toBe(SAMPLE_KEY);
+  });
+
+  it("normalizes an uppercase hex key to lowercase", async () => {
+    const configPath = await writeConfig({ key: SAMPLE_KEY.toUpperCase() });
+    expect(await resolveSignalKey({ configPath })).toBe(SAMPLE_KEY);
+  });
+
+  it("unwraps an encrypted key via the injected Keychain reader", async () => {
+    const encryptedKey = encryptV10(SAMPLE_KEY, KEYCHAIN_PASSWORD).toString(
+      "hex",
+    );
+    const configPath = await writeConfig({ encryptedKey });
+    const key = await resolveSignalKey({
+      configPath,
+      readKeychainPassword: () => KEYCHAIN_PASSWORD,
+    });
+    expect(key).toBe(SAMPLE_KEY);
+  });
+
+  it("fails closed when an encrypted key has no Keychain reader", async () => {
+    const encryptedKey = encryptV10(SAMPLE_KEY, KEYCHAIN_PASSWORD).toString(
+      "hex",
+    );
+    const configPath = await writeConfig({ encryptedKey });
+    try {
+      await resolveSignalKey({ configPath });
+      throw new Error("expected a key-source failure");
+    } catch (error) {
+      expect(isCollectorError(error, "key_source_unavailable")).toBe(true);
+    }
+  });
+
+  it("fails closed on a config with neither key form", async () => {
+    const configPath = await writeConfig({ version: 7 });
+    try {
+      await resolveSignalKey({ configPath });
+      throw new Error("expected a key-source failure");
+    } catch (error) {
+      expect(isCollectorError(error, "key_source_unavailable")).toBe(true);
+    }
+  });
+
+  it("fails closed on a non-hex resolved key", async () => {
+    const configPath = await writeConfig({ key: "not-a-hex-key" });
+    try {
+      await resolveSignalKey({ configPath });
+      throw new Error("expected a decrypt-format failure");
+    } catch (error) {
+      expect(isCollectorError(error, "key_decrypt_failed")).toBe(true);
+    }
+  });
+
+  it("fails closed on a missing config file", async () => {
+    try {
+      await resolveSignalKey({ configPath: "/no/such/config.json" });
+      throw new Error("expected a source-missing failure");
+    } catch (error) {
+      expect(isCollectorError(error, "source_missing")).toBe(true);
+    }
+  });
+});

--- a/packages/corpus-tools/src/collectors/signal-key.ts
+++ b/packages/corpus-tools/src/collectors/signal-key.ts
@@ -1,0 +1,236 @@
+/**
+ * SQLCipher key acquisition for the Signal Desktop collector. Signal stores its
+ * 256-bit database key in `<Signal>/config.json` — legacy installs keep it in
+ * plaintext (`key`), newer installs wrap it with Electron `safeStorage`
+ * (`encryptedKey`), which on macOS is Chromium's OSCrypt v10 scheme keyed by a
+ * random password held in the login Keychain under the "Signal Safe Storage"
+ * service.
+ *
+ * This module resolves that key without ever persisting it: it reads config.json,
+ * and — when the key is wrapped — derives the AES key from the Keychain password
+ * and decrypts the v10 blob in-process. The Keychain read is injected as a
+ * command runner so the unwrap crypto is exercised deterministically in tests
+ * while production shells out to `security`. Nothing here writes the key to disk;
+ * the caller holds it only for the lifetime of one collect run.
+ */
+import { createDecipheriv, pbkdf2Sync, timingSafeEqual } from "node:crypto";
+import { promises as fs } from "node:fs";
+import { CollectorError } from "./errors.ts";
+
+/**
+ * Chromium OSCrypt v10 parameters (macOS). safeStorage on Electron reuses these
+ * exact constants: PBKDF2-HMAC-SHA1 over the Keychain password with a fixed salt
+ * and iteration count yields a 128-bit AES-CBC key, and every ciphertext is
+ * prefixed with the ASCII version tag and decrypted with an all-spaces IV.
+ */
+const OSCRYPT_SALT = "saltysalt";
+const OSCRYPT_ITERATIONS_MACOS = 1003;
+const OSCRYPT_KEY_LENGTH = 16;
+const OSCRYPT_IV = Buffer.alloc(16, " ");
+const OSCRYPT_VERSION_PREFIX = Buffer.from("v10", "utf8");
+
+export interface SignalConfig {
+  /** Plaintext SQLCipher key hex (legacy installs). */
+  key?: string;
+  /** safeStorage-wrapped SQLCipher key, hex-encoded ciphertext (newer installs). */
+  encryptedKey?: string;
+}
+
+/** Runs a Keychain lookup; injected so the unwrap path is testable without macOS. */
+export type KeychainPasswordReader = (
+  service: string,
+) => Promise<string> | string;
+
+export interface ResolveKeyOptions {
+  configPath: string;
+  /** Keychain service holding the safeStorage password; defaults to Signal's. */
+  keychainService?: string;
+  readKeychainPassword?: KeychainPasswordReader;
+}
+
+const SQLCIPHER_KEY_HEX = /^[0-9a-fA-F]{64}$/;
+
+function assertSqlcipherKey(key: string): string {
+  const trimmed = key.trim();
+  if (!SQLCIPHER_KEY_HEX.test(trimmed)) {
+    throw new CollectorError(
+      "resolved Signal key is not a 256-bit hex string",
+      {
+        collectorCode: "key_decrypt_failed",
+        platform: "signal",
+        context: { keyLength: trimmed.length },
+      },
+    );
+  }
+  return trimmed.toLowerCase();
+}
+
+/**
+ * Decrypt a Chromium/Electron safeStorage v10 blob given the Keychain password.
+ * Exposed on its own so the exact OSCrypt scheme can be round-tripped in tests
+ * with a known password and ciphertext. Fails closed with a typed error on a
+ * missing version prefix or a padding/decrypt failure — a wrong key must never
+ * yield a partial or fabricated result.
+ */
+export function unwrapSafeStorageKey(
+  encryptedKey: Buffer,
+  keychainPassword: string,
+): string {
+  if (encryptedKey.length <= OSCRYPT_VERSION_PREFIX.length) {
+    throw new CollectorError("safeStorage blob is too short to be v10", {
+      collectorCode: "key_decrypt_failed",
+      platform: "signal",
+      context: { blobBytes: encryptedKey.length },
+    });
+  }
+  const prefix = encryptedKey.subarray(0, OSCRYPT_VERSION_PREFIX.length);
+  if (
+    prefix.length !== OSCRYPT_VERSION_PREFIX.length ||
+    !timingSafeEqual(prefix, OSCRYPT_VERSION_PREFIX)
+  ) {
+    throw new CollectorError(
+      "safeStorage blob missing the v10 version prefix",
+      {
+        collectorCode: "key_decrypt_failed",
+        platform: "signal",
+        context: { prefix: prefix.toString("latin1") },
+      },
+    );
+  }
+
+  const derivedKey = pbkdf2Sync(
+    keychainPassword,
+    OSCRYPT_SALT,
+    OSCRYPT_ITERATIONS_MACOS,
+    OSCRYPT_KEY_LENGTH,
+    "sha1",
+  );
+  const ciphertext = encryptedKey.subarray(OSCRYPT_VERSION_PREFIX.length);
+
+  try {
+    const decipher = createDecipheriv("aes-128-cbc", derivedKey, OSCRYPT_IV);
+    const plaintext = Buffer.concat([
+      decipher.update(ciphertext),
+      decipher.final(),
+    ]);
+    return plaintext.toString("utf8");
+  } catch (error) {
+    // error-policy:J2 wrong Keychain password surfaces as a PKCS7 padding
+    // failure; rethrow as a typed fail-closed decrypt error with the cause.
+    throw new CollectorError("safeStorage decryption failed", {
+      collectorCode: "key_decrypt_failed",
+      platform: "signal",
+      cause: error,
+    });
+  }
+}
+
+async function readConfig(configPath: string): Promise<SignalConfig> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(configPath, "utf8");
+  } catch (error) {
+    throw new CollectorError("Signal config.json is unreadable", {
+      collectorCode: "source_missing",
+      platform: "signal",
+      cause: error,
+      context: { configPath },
+    });
+  }
+  // error-policy:J3 config.json is untrusted local state; a parse failure is a
+  // typed source error, not a silent fall-through to an empty config.
+  try {
+    return JSON.parse(raw) as SignalConfig;
+  } catch (error) {
+    throw new CollectorError("Signal config.json is not valid JSON", {
+      collectorCode: "source_missing",
+      platform: "signal",
+      cause: error,
+      context: { configPath },
+    });
+  }
+}
+
+/**
+ * Resolve the SQLCipher key from a Signal install directory's config.json,
+ * unwrapping the safeStorage-encrypted form via the injected Keychain reader
+ * when present. Throws a typed error (never returns a placeholder) if neither a
+ * plaintext nor an unwrappable encrypted key is available.
+ */
+export async function resolveSignalKey(
+  options: ResolveKeyOptions,
+): Promise<string> {
+  const config = await readConfig(options.configPath);
+
+  if (config.key) {
+    return assertSqlcipherKey(config.key);
+  }
+
+  if (config.encryptedKey) {
+    const reader = options.readKeychainPassword;
+    if (!reader) {
+      throw new CollectorError(
+        "Signal key is safeStorage-wrapped but no Keychain reader was provided",
+        {
+          collectorCode: "key_source_unavailable",
+          platform: "signal",
+          context: { configPath: options.configPath },
+        },
+      );
+    }
+    const service = options.keychainService ?? "Signal Safe Storage";
+    const password = await reader(service);
+    if (!password) {
+      throw new CollectorError(
+        "Keychain returned an empty safeStorage password",
+        {
+          collectorCode: "key_source_unavailable",
+          platform: "signal",
+          context: { service },
+        },
+      );
+    }
+    const decrypted = unwrapSafeStorageKey(
+      Buffer.from(config.encryptedKey, "hex"),
+      password,
+    );
+    return assertSqlcipherKey(decrypted);
+  }
+
+  throw new CollectorError(
+    "Signal config.json has neither a plaintext nor an encrypted key",
+    {
+      collectorCode: "key_source_unavailable",
+      platform: "signal",
+      context: { configPath: options.configPath },
+    },
+  );
+}
+
+/**
+ * Production Keychain reader: reads the safeStorage password with the macOS
+ * `security` tool. Kept as the default injected implementation so the live path
+ * uses no third-party dependency, while tests substitute a deterministic reader.
+ */
+export function macosKeychainPasswordReader(
+  runCommand: (
+    command: string,
+    args: string[],
+  ) => Promise<{ stdout: string; status: number }>,
+): KeychainPasswordReader {
+  return async (service: string) => {
+    const result = await runCommand("security", [
+      "find-generic-password",
+      "-ws",
+      service,
+    ]);
+    if (result.status !== 0) {
+      throw new CollectorError("security find-generic-password failed", {
+        collectorCode: "key_source_unavailable",
+        platform: "signal",
+        context: { service, status: result.status },
+      });
+    }
+    return result.stdout.trim();
+  };
+}

--- a/packages/corpus-tools/src/collectors/signal-normalize.test.ts
+++ b/packages/corpus-tools/src/collectors/signal-normalize.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Signal row → CorpusMessage normalization tests. Drives the real normalizer
+ * over Signal-shaped rows (json column authoritative, columns as fallback) and
+ * asserts direction, sender/thread identity, timestamp precedence, and every
+ * skip branch. Every produced message is validated against the corpus schema so
+ * a mapping regression fails here, not at publish time.
+ */
+import { describe, expect, it } from "vitest";
+import { CORPUS_CUTOFF_MS, corpusMessageSchema } from "../schema.ts";
+import type { SignalMessageRow } from "./signal-db.ts";
+import { normalizeSignalRow } from "./signal-normalize.ts";
+
+const OPTIONS = {
+  accountId: "primary",
+  ownerId: "owner-uuid",
+  ownerDisplay: "Owner",
+};
+
+const AFTER_CUTOFF = CORPUS_CUTOFF_MS + 86_400_000;
+
+function row(overrides: Partial<SignalMessageRow>): SignalMessageRow {
+  return {
+    id: "m1",
+    json: null,
+    sent_at: null,
+    received_at: AFTER_CUTOFF,
+    conversationId: "conv-1",
+    type: "incoming",
+    body: "hello",
+    source: "peer-uuid",
+    sourceServiceId: null,
+    conversationName: "Alice",
+    conversationType: "private",
+    conversationE164: "+15551230000",
+    conversationServiceId: "peer-service-id",
+    ...overrides,
+  };
+}
+
+describe("normalizeSignalRow", () => {
+  it("maps an incoming message to a validated CorpusMessage", () => {
+    const result = normalizeSignalRow(row({}), OPTIONS);
+    expect(result.skipped).toBeUndefined();
+    const message = result.message;
+    expect(message).toBeDefined();
+    if (!message) throw new Error("unreachable");
+    expect(corpusMessageSchema.parse(message)).toBeTruthy();
+    expect(message.direction).toBe("in");
+    expect(message.senderId).toBe("peer-uuid");
+    expect(message.senderDisplay).toBe("Alice");
+    expect(message.threadId).toBe("signal:primary:conv-1");
+    expect(message.id).toBe("signal:primary:m1");
+    expect(message.recipients[0].id).toBe("owner-uuid");
+    expect(message.ts).toBe(AFTER_CUTOFF);
+  });
+
+  it("maps an outgoing message from the owner", () => {
+    const result = normalizeSignalRow(
+      row({ id: "m2", type: "outgoing", body: "sent" }),
+      OPTIONS,
+    );
+    const message = result.message;
+    if (!message) throw new Error("expected a message");
+    expect(message.direction).toBe("out");
+    expect(message.senderId).toBe("owner-uuid");
+    expect(message.senderDisplay).toBe("Owner");
+    expect(message.recipients[0].id).toBe("peer-uuid");
+    expect(message.recipients[0].display).toBe("Alice");
+  });
+
+  it("reads body and timestamp from the json column when columns are null", () => {
+    const result = normalizeSignalRow(
+      row({
+        body: null,
+        received_at: null,
+        type: null,
+        json: JSON.stringify({
+          body: "from json",
+          received_at: AFTER_CUTOFF + 5,
+          type: "incoming",
+        }),
+      }),
+      OPTIONS,
+    );
+    const message = result.message;
+    if (!message) throw new Error("expected a message");
+    expect(message.text).toBe("from json");
+    expect(message.ts).toBe(AFTER_CUTOFF + 5);
+  });
+
+  it("prefers received_at over sent_at for ordering", () => {
+    const result = normalizeSignalRow(
+      row({ received_at: AFTER_CUTOFF + 100, sent_at: AFTER_CUTOFF }),
+      OPTIONS,
+    );
+    expect(result.message?.ts).toBe(AFTER_CUTOFF + 100);
+  });
+
+  it("skips a message with no readable body", () => {
+    const result = normalizeSignalRow(
+      row({ body: null, json: JSON.stringify({ type: "incoming" }) }),
+      OPTIONS,
+    );
+    expect(result.skipped).toBe("empty-body");
+    expect(result.message).toBeUndefined();
+  });
+
+  it("skips a message with an unknown direction type", () => {
+    const result = normalizeSignalRow(
+      row({ type: "group-update", json: JSON.stringify({}) }),
+      OPTIONS,
+    );
+    expect(result.skipped).toBe("empty-body");
+  });
+
+  it("skips a message before the corpus cutoff", () => {
+    const result = normalizeSignalRow(
+      row({ received_at: CORPUS_CUTOFF_MS - 1 }),
+      OPTIONS,
+    );
+    expect(result.skipped).toBe("before-cutoff");
+  });
+
+  it("skips a message with no resolvable timestamp", () => {
+    const result = normalizeSignalRow(
+      row({
+        received_at: null,
+        sent_at: null,
+        json: JSON.stringify({ body: "x", type: "incoming" }),
+      }),
+      OPTIONS,
+    );
+    expect(result.skipped).toBe("no-timestamp");
+  });
+});

--- a/packages/corpus-tools/src/collectors/signal-normalize.ts
+++ b/packages/corpus-tools/src/collectors/signal-normalize.ts
@@ -1,0 +1,160 @@
+/**
+ * Signal `messages` row → canonical `CorpusMessage` normalization. Signal keeps
+ * the authoritative message content in the row's `json` column (an object with
+ * `body`, `sent_at`, `type`, `source`, `conversationId`, …); the top-level SQL
+ * columns are a partial denormalization that is often null. This module reads
+ * the JSON first and falls back to the columns, so the mapping is faithful to
+ * how Signal Desktop actually stores a message rather than to the subset SQLite
+ * happens to project.
+ *
+ * Direction, sender identity, and thread id are derived structurally. Rows with
+ * no readable body (reactions, attachment-only, group-membership events) are not
+ * fabricated into empty-text messages — the schema requires non-empty text, so
+ * the caller drops them and counts them as skipped. Attachment bytes are out of
+ * scope for this collector.
+ */
+import {
+  CORPUS_CUTOFF_MS,
+  type CorpusDirection,
+  type CorpusMessage,
+} from "../schema.ts";
+import type { SignalMessageRow } from "./signal-db.ts";
+
+interface SignalMessageJson {
+  body?: unknown;
+  sent_at?: unknown;
+  received_at?: unknown;
+  timestamp?: unknown;
+  type?: unknown;
+  source?: unknown;
+  sourceServiceId?: unknown;
+  conversationId?: unknown;
+}
+
+export interface NormalizeSignalOptions {
+  /** Stable label for the owner's linked account, e.g. "primary". */
+  accountId: string;
+  /** Owner's own sender id used for outgoing messages. */
+  ownerId: string;
+  /** Owner's display name used for outgoing messages. */
+  ownerDisplay: string;
+}
+
+export type SkipReason = "empty-body" | "before-cutoff" | "no-timestamp";
+
+export interface NormalizedSignalMessage {
+  message?: CorpusMessage;
+  skipped?: SkipReason;
+}
+
+function asString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "bigint") return Number(value);
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function parseJson(raw: string | null): SignalMessageJson {
+  if (!raw) return {};
+  // error-policy:J3 the json column is untrusted export content; a parse
+  // failure degrades to the SQL columns rather than throwing away the row.
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object"
+      ? (parsed as SignalMessageJson)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function directionFromType(type: string | undefined): CorpusDirection | null {
+  if (type === "outgoing") return "out";
+  if (type === "incoming") return "in";
+  return null;
+}
+
+/**
+ * Normalize a single Signal row. Returns either a `CorpusMessage` or a skip
+ * reason; it never returns a message with fabricated empty text or a timestamp
+ * before the corpus cutoff. The `id` is prefixed with the account so ids stay
+ * unique across a multi-account merge.
+ */
+export function normalizeSignalRow(
+  row: SignalMessageRow,
+  options: NormalizeSignalOptions,
+): NormalizedSignalMessage {
+  const json = parseJson(row.json);
+
+  const direction = directionFromType(
+    asString(row.type) ?? asString(json.type),
+  );
+  if (!direction) return { skipped: "empty-body" };
+
+  const body = asString(row.body) ?? asString(json.body);
+  if (!body) return { skipped: "empty-body" };
+
+  const ts =
+    asNumber(row.received_at) ??
+    asNumber(json.received_at) ??
+    asNumber(row.sent_at) ??
+    asNumber(json.sent_at) ??
+    asNumber(json.timestamp);
+  if (ts === undefined) return { skipped: "no-timestamp" };
+  if (ts < CORPUS_CUTOFF_MS) return { skipped: "before-cutoff" };
+
+  const threadId =
+    asString(row.conversationId) ??
+    asString(json.conversationId) ??
+    `signal-unknown-thread`;
+
+  const peerDisplay =
+    asString(row.conversationName) ??
+    asString(row.conversationE164) ??
+    asString(row.conversationServiceId) ??
+    threadId;
+  const peerId =
+    asString(row.source) ??
+    asString(json.source) ??
+    asString(row.sourceServiceId) ??
+    asString(json.sourceServiceId) ??
+    asString(row.conversationServiceId) ??
+    threadId;
+
+  // The peer is always the other party in the thread; the owner is the local
+  // account. Direction only decides which of the two is sender vs. recipient,
+  // so identity stays symmetric between an inbound and its outbound reply.
+  const senderId = direction === "out" ? options.ownerId : peerId;
+  const senderDisplay =
+    direction === "out" ? options.ownerDisplay : peerDisplay;
+  const recipientId = direction === "out" ? peerId : options.ownerId;
+  const recipientDisplay =
+    direction === "out" ? peerDisplay : options.ownerDisplay;
+
+  const message: CorpusMessage = {
+    id: `signal:${options.accountId}:${row.id}`,
+    platform: "signal",
+    accountId: options.accountId,
+    threadId: `signal:${options.accountId}:${threadId}`,
+    ts,
+    direction,
+    senderId,
+    senderDisplay,
+    recipients: [{ id: recipientId, display: recipientDisplay }],
+    text: body,
+    labels: [],
+    attachments: [],
+    scrubState: "raw",
+  };
+
+  return { message };
+}

--- a/packages/corpus-tools/src/collectors/signal.test.ts
+++ b/packages/corpus-tools/src/collectors/signal.test.ts
@@ -1,0 +1,348 @@
+/**
+ * End-to-end Signal collector test. Builds a real SQLite database with Signal's
+ * `messages`/`conversations` schema, writes it where the collector expects the
+ * encrypted db, and injects a plaintext opener that runs the production query
+ * (the SQLCipher `PRAGMA key` step is the only owner-gated difference). This
+ * drives the full path — key resolve, db copy, real query, normalization, shard
+ * write, checkpoint — against a real query engine, then asserts the output
+ * validates, resumes idempotently, and that the decrypted copy is wiped even
+ * when the read fails.
+ *
+ * Runs under whichever SQLite runtime the harness provides (`node:sqlite` on
+ * Node 24, `bun:sqlite` under Bun); it skips only if neither exists.
+ */
+
+import { mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { CORPUS_CUTOFF_MS } from "../schema.ts";
+import { validateCorpusTarget } from "../validator.ts";
+import { isCollectorError } from "./errors.ts";
+import { collectSignal } from "./signal.ts";
+import {
+  createSignalDatabase,
+  openSqlcipherDatabase,
+  type SignalDatabase,
+  type SignalDatabaseOpener,
+} from "./signal-db.ts";
+
+const runtimeRequire = createRequire(import.meta.url);
+const SAMPLE_KEY =
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+const JULY = Date.parse("2024-07-10T12:00:00.000Z");
+
+interface FixtureDb {
+  exec(sql: string): void;
+  run(sql: string, params: unknown[]): void;
+  openReadonly(): {
+    all(sql: string, params: unknown[]): unknown[];
+    close(): void;
+  };
+  close(): void;
+}
+
+/** Resolve a SQLite runtime (Node built-in preferred, then Bun) or null. */
+async function loadSqlite(): Promise<
+  ((filePath: string, readOnly: boolean) => FixtureDb) | null
+> {
+  try {
+    const mod = (await import("node:sqlite")) as {
+      DatabaseSync?: new (
+        p: string,
+        o?: { readOnly?: boolean },
+      ) => {
+        exec(sql: string): void;
+        prepare(sql: string): {
+          all(...p: unknown[]): unknown[];
+          run(...p: unknown[]): unknown;
+        };
+        close(): void;
+      };
+    };
+    const DatabaseSync = mod.DatabaseSync;
+    if (DatabaseSync) {
+      return (filePath, readOnly) => {
+        const db = new DatabaseSync(filePath, { readOnly });
+        return {
+          exec: (sql) => db.exec(sql),
+          run: (sql, params) => {
+            db.prepare(sql).run(...params);
+          },
+          openReadonly: () => ({
+            all: (sql, params) => db.prepare(sql).all(...params) as unknown[],
+            close: () => db.close(),
+          }),
+          close: () => db.close(),
+        };
+      };
+    }
+  } catch {
+    // fall through to Bun
+  }
+  try {
+    const mod = runtimeRequire("bun:sqlite") as {
+      Database?: new (
+        p: string,
+        o?: { readonly?: boolean },
+      ) => {
+        run(sql: string, ...p: unknown[]): unknown;
+        query(sql: string): { all(...p: unknown[]): unknown[] };
+        close(): void;
+      };
+    };
+    const Database = mod.Database;
+    if (Database) {
+      return (filePath, readOnly) => {
+        const db = new Database(filePath, { readonly: readOnly });
+        return {
+          exec: (sql) => {
+            db.run(sql);
+          },
+          run: (sql, params) => {
+            db.run(sql, ...params);
+          },
+          openReadonly: () => ({
+            all: (sql, params) => db.query(sql).all(...params),
+            close: () => db.close(),
+          }),
+          close: () => db.close(),
+        };
+      };
+    }
+  } catch {
+    // neither runtime
+  }
+  return null;
+}
+
+const SCHEMA = `
+  CREATE TABLE conversations (
+    id TEXT PRIMARY KEY,
+    json TEXT,
+    type TEXT,
+    name TEXT,
+    e164 TEXT,
+    serviceId TEXT
+  );
+  CREATE TABLE messages (
+    id TEXT PRIMARY KEY,
+    json TEXT,
+    sent_at INTEGER,
+    received_at INTEGER,
+    conversationId TEXT,
+    type TEXT,
+    body TEXT,
+    source TEXT,
+    sourceServiceId TEXT
+  );
+`;
+
+async function seedSignalDir(
+  openDb: (filePath: string, readOnly: boolean) => FixtureDb,
+): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "signal-e2e-"));
+  await writeFile(
+    path.join(dir, "config.json"),
+    JSON.stringify({ key: SAMPLE_KEY }),
+    "utf8",
+  );
+  await mkdir(path.join(dir, "sql"), { recursive: true });
+  const dbPath = path.join(dir, "sql", "db.sqlite");
+  const db = openDb(dbPath, false);
+  db.exec(SCHEMA);
+  db.run(
+    "INSERT INTO conversations (id, type, name, e164, serviceId) VALUES (?, ?, ?, ?, ?)",
+    ["conv-1", "private", "Alice", "+15551230000", "peer-service"],
+  );
+  const insert = (row: {
+    id: string;
+    received_at: number;
+    type: string;
+    body: string | null;
+    source: string;
+    json?: string;
+  }) =>
+    db.run(
+      "INSERT INTO messages (id, json, sent_at, received_at, conversationId, type, body, source, sourceServiceId) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      [
+        row.id,
+        row.json ?? null,
+        row.received_at - 50,
+        row.received_at,
+        "conv-1",
+        row.type,
+        row.body,
+        row.source,
+        null,
+      ],
+    );
+  insert({
+    id: "m1",
+    received_at: JULY,
+    type: "incoming",
+    body: "hi there",
+    source: "peer-uuid",
+  });
+  insert({
+    id: "m2",
+    received_at: JULY + 1000,
+    type: "outgoing",
+    body: "reply",
+    source: "",
+  });
+  // Attachment-only row (no body) — must be skipped, not fabricated.
+  insert({
+    id: "m3",
+    received_at: JULY + 2000,
+    type: "incoming",
+    body: null,
+    source: "peer-uuid",
+  });
+  // Body only in the json column.
+  insert({
+    id: "m4",
+    received_at: JULY + 3000,
+    type: "incoming",
+    body: null,
+    source: "peer-uuid",
+    json: JSON.stringify({
+      body: "from json",
+      type: "incoming",
+      received_at: JULY + 3000,
+    }),
+  });
+  // Pre-cutoff row — must be excluded by the query bound / normalizer.
+  insert({
+    id: "m0",
+    received_at: CORPUS_CUTOFF_MS - 5000,
+    type: "incoming",
+    body: "ancient",
+    source: "peer-uuid",
+  });
+  db.close();
+  return dir;
+}
+
+function plaintextOpener(
+  openDb: (filePath: string, readOnly: boolean) => FixtureDb,
+): SignalDatabaseOpener {
+  return async (dbPath: string): Promise<SignalDatabase> => {
+    const handle = openDb(dbPath, true).openReadonly();
+    return createSignalDatabase(handle);
+  };
+}
+
+describe("collectSignal (real SQLite path)", () => {
+  it("collects, normalizes, shards, checkpoints, and wipes the copy", async () => {
+    const openDb = await loadSqlite();
+    if (!openDb) {
+      // No SQLite runtime available; the pure key/normalize/shard suites still
+      // cover the collector logic keyless.
+      return;
+    }
+    const signalDir = await seedSignalDir(openDb);
+    const outputDir = await mkdtemp(path.join(tmpdir(), "signal-out-"));
+    const stateDir = await mkdtemp(path.join(tmpdir(), "signal-state-"));
+
+    const result = await collectSignal({
+      signalDir,
+      outputDir,
+      stateDir,
+      accountId: "primary",
+      ownerId: "owner-uuid",
+      ownerDisplay: "Owner",
+      openDatabase: plaintextOpener(openDb),
+    });
+
+    expect(result.messagesAdded).toBe(3); // m1, m2, m4
+    expect(result.skipped["empty-body"]).toBe(1); // m3 has no body
+    // m0 is excluded at the SQL cutoff bound, so it never reaches the normalizer.
+    expect(result.skipped["before-cutoff"]).toBe(0);
+    expect(result.dbCopyDeleted).toBe(true);
+    expect(result.checkpoint.lastTs).toBe(JULY + 3000);
+    expect(result.checkpoint.messageCount).toBe(3);
+
+    const validation = await validateCorpusTarget(outputDir);
+    expect(validation.ok).toBe(true);
+    expect(validation.manifest.totals.messages).toBe(3);
+
+    // No leftover decrypted copies in the state dir.
+    const stateEntries = await readdir(stateDir);
+    expect(stateEntries.some((name) => name.startsWith("signal-db-"))).toBe(
+      false,
+    );
+
+    // Rerun is idempotent: nothing new added, output unchanged.
+    const rerun = await collectSignal({
+      signalDir,
+      outputDir,
+      stateDir,
+      accountId: "primary",
+      ownerId: "owner-uuid",
+      ownerDisplay: "Owner",
+      openDatabase: plaintextOpener(openDb),
+    });
+    expect(rerun.messagesAdded).toBe(0);
+    expect(rerun.checkpoint.messageCount).toBe(3);
+    const revalidation = await validateCorpusTarget(outputDir);
+    expect(revalidation.manifest.totals.messages).toBe(3);
+
+    await rm(signalDir, { recursive: true, force: true });
+    await rm(outputDir, { recursive: true, force: true });
+    await rm(stateDir, { recursive: true, force: true });
+  });
+
+  it("wipes the decrypted copy even when the read fails", async () => {
+    const openDb = await loadSqlite();
+    if (!openDb) return;
+    const signalDir = await seedSignalDir(openDb);
+    const outputDir = await mkdtemp(path.join(tmpdir(), "signal-out-"));
+    const stateDir = await mkdtemp(path.join(tmpdir(), "signal-state-"));
+
+    const failingOpener: SignalDatabaseOpener = async () => {
+      throw new Error("boom decrypt");
+    };
+
+    await expect(
+      collectSignal({
+        signalDir,
+        outputDir,
+        stateDir,
+        accountId: "primary",
+        ownerId: "owner-uuid",
+        ownerDisplay: "Owner",
+        openDatabase: failingOpener,
+      }),
+    ).rejects.toThrow(/boom decrypt/);
+
+    const stateEntries = await readdir(stateDir);
+    expect(stateEntries.some((name) => name.startsWith("signal-db-"))).toBe(
+      false,
+    );
+
+    await rm(signalDir, { recursive: true, force: true });
+    await rm(outputDir, { recursive: true, force: true });
+    await rm(stateDir, { recursive: true, force: true });
+  });
+});
+
+describe("openSqlcipherDatabase", () => {
+  it("fails closed on a non-database file (or absent cipher)", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "signal-bad-"));
+    const notADb = path.join(dir, "db.sqlite");
+    await writeFile(notADb, "this is not sqlcipher", "utf8");
+    try {
+      await openSqlcipherDatabase(notADb, SAMPLE_KEY);
+      throw new Error("expected a fail-closed error");
+    } catch (error) {
+      expect(
+        isCollectorError(error, "sqlcipher_unavailable") ||
+          isCollectorError(error, "db_open_failed"),
+      ).toBe(true);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/corpus-tools/src/collectors/signal.ts
+++ b/packages/corpus-tools/src/collectors/signal.ts
@@ -1,0 +1,227 @@
+/**
+ * Signal Desktop corpus collector. Signal keeps ~years of history in a single
+ * SQLCipher-encrypted `db.sqlite`; this collector resolves the database key
+ * (config.json plaintext or Electron safeStorage via the Keychain), reads a
+ * date-bounded slice of messages, normalizes them to the canonical corpus
+ * schema, and writes idempotent month shards with a resume checkpoint.
+ *
+ * Safety invariants that make it publishable evidence:
+ * - It never opens the live database. It copies `db.sqlite` into a local
+ *   `.state` dir (outside git) and reads the copy read-only.
+ * - The copy and the in-memory key are torn down in a `finally`, and teardown
+ *   asserts the copy is gone — a failed wipe is a fail-closed error, not a
+ *   warning, because a decrypted database copy must not outlive the run.
+ * - The SQLCipher engine is injected (`openDatabase`) so the query/normalization
+ *   path is tested against a real SQLite engine without shipping the native
+ *   cipher, while the production default fails closed if the cipher is absent.
+ *
+ * Live decryption on the owner's machine (Keychain approval, real key) is the
+ * only owner-gated step; everything here is exercised keyless in tests.
+ */
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { logger } from "@elizaos/core";
+import { CORPUS_CUTOFF_MS, type CorpusMessage } from "../schema.ts";
+import {
+  type CollectorCheckpoint,
+  readCheckpoint,
+  writeCheckpoint,
+} from "./checkpoint.ts";
+import { CollectorError } from "./errors.ts";
+import { writeShards } from "./shard-writer.ts";
+import {
+  openSqlcipherDatabase,
+  type SignalDatabaseOpener,
+} from "./signal-db.ts";
+import { type KeychainPasswordReader, resolveSignalKey } from "./signal-key.ts";
+import { normalizeSignalRow, type SkipReason } from "./signal-normalize.ts";
+
+export interface CollectSignalOptions {
+  /** Signal install dir holding `config.json` and `sql/db.sqlite`. */
+  signalDir: string;
+  /** Corpus output root; shards land under `<outputDir>/signal/<accountId>/`. */
+  outputDir: string;
+  /** Local scratch dir for the db copy + checkpoints; never the git tree. */
+  stateDir: string;
+  accountId: string;
+  ownerId: string;
+  ownerDisplay: string;
+  keychainService?: string;
+  readKeychainPassword?: KeychainPasswordReader;
+  /** SQLCipher opener; defaults to the native adapter. Injected in tests. */
+  openDatabase?: SignalDatabaseOpener;
+}
+
+export interface CollectSignalResult {
+  accountId: string;
+  messagesAdded: number;
+  messagesWritten: number;
+  shardsWritten: number;
+  shardPaths: string[];
+  skipped: Record<SkipReason, number>;
+  checkpoint: CollectorCheckpoint;
+  dbCopyDeleted: boolean;
+}
+
+function emptySkipCounts(): Record<SkipReason, number> {
+  return { "empty-body": 0, "before-cutoff": 0, "no-timestamp": 0 };
+}
+
+async function pathExists(target: string): Promise<boolean> {
+  try {
+    await fs.stat(target);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+/**
+ * Copy the encrypted database to a private scratch path. Reading a copy — not
+ * the live file — avoids racing Signal's own writers and keeps the source
+ * untouched. Returns the copy path; the caller is responsible for teardown.
+ */
+async function copyDatabase(
+  sourceDbPath: string,
+  stateDir: string,
+): Promise<string> {
+  if (!(await pathExists(sourceDbPath))) {
+    throw new CollectorError("Signal db.sqlite not found", {
+      collectorCode: "source_missing",
+      platform: "signal",
+      context: { sourceDbPath },
+    });
+  }
+  const scratch = await fs.mkdtemp(path.join(stateDir, "signal-db-"));
+  const copyPath = path.join(scratch, "db.sqlite");
+  await fs.copyFile(sourceDbPath, copyPath);
+  return copyPath;
+}
+
+/**
+ * Delete the database copy and its scratch dir, then assert it is gone. A
+ * decrypted copy that survives the run is a data-exfiltration hazard, so a
+ * failed wipe throws rather than logging and continuing.
+ */
+async function teardownCopy(copyPath: string): Promise<void> {
+  await fs.rm(path.dirname(copyPath), { recursive: true, force: true });
+  if (await pathExists(copyPath)) {
+    throw new CollectorError(
+      "Signal database copy still present after teardown",
+      {
+        collectorCode: "teardown_failed",
+        platform: "signal",
+        context: { copyPath },
+      },
+    );
+  }
+}
+
+/**
+ * Run one Signal collection pass. Resumes from the account checkpoint, pulls
+ * messages at or after both the corpus cutoff and the last high-water mark,
+ * normalizes and writes them, and advances the checkpoint to the newest message
+ * written. Every exit path — success or failure — wipes the decrypted copy.
+ */
+export async function collectSignal(
+  options: CollectSignalOptions,
+): Promise<CollectSignalResult> {
+  await fs.mkdir(options.stateDir, { recursive: true });
+
+  const configPath = path.join(options.signalDir, "config.json");
+  const sourceDbPath = path.join(options.signalDir, "sql", "db.sqlite");
+
+  let keyHex = await resolveSignalKey({
+    configPath,
+    keychainService: options.keychainService,
+    readKeychainPassword: options.readKeychainPassword,
+  });
+
+  const previous = await readCheckpoint(
+    options.stateDir,
+    "signal",
+    options.accountId,
+  );
+  const cutoffMs = Math.max(CORPUS_CUTOFF_MS, previous?.lastTs ?? 0);
+
+  const openDatabase = options.openDatabase ?? openSqlcipherDatabase;
+  const copyPath = await copyDatabase(sourceDbPath, options.stateDir);
+
+  try {
+    const db = await openDatabase(copyPath, keyHex);
+    const skipped = emptySkipCounts();
+    const messages: CorpusMessage[] = [];
+    try {
+      for (const row of db.queryMessages(cutoffMs)) {
+        const result = normalizeSignalRow(row, {
+          accountId: options.accountId,
+          ownerId: options.ownerId,
+          ownerDisplay: options.ownerDisplay,
+        });
+        if (result.skipped) {
+          skipped[result.skipped] += 1;
+          continue;
+        }
+        if (result.message) messages.push(result.message);
+      }
+    } finally {
+      db.close();
+    }
+
+    const summary = await writeShards(
+      options.outputDir,
+      "signal",
+      options.accountId,
+      messages,
+    );
+
+    const newestTs = messages.reduce((max, m) => Math.max(max, m.ts), 0);
+    const newestId = messages
+      .filter((m) => m.ts === newestTs)
+      .map((m) => m.id)
+      .sort()
+      .at(-1);
+
+    const checkpoint: CollectorCheckpoint = {
+      platform: "signal",
+      accountId: options.accountId,
+      lastTs: Math.max(previous?.lastTs ?? 0, newestTs),
+      lastId: newestId ?? previous?.lastId,
+      messageCount: (previous?.messageCount ?? 0) + summary.messagesAdded,
+      updatedAt: new Date().toISOString(),
+    };
+    await writeCheckpoint(options.stateDir, checkpoint);
+
+    logger.info(
+      `[SignalCollector] account=${options.accountId} added=${summary.messagesAdded} shards=${summary.shardsWritten} skipped=${JSON.stringify(skipped)}`,
+    );
+
+    return {
+      accountId: options.accountId,
+      messagesAdded: summary.messagesAdded,
+      messagesWritten: summary.messagesWritten,
+      shardsWritten: summary.shardsWritten,
+      shardPaths: summary.paths,
+      skipped,
+      checkpoint,
+      dbCopyDeleted: true,
+    };
+  } finally {
+    // Wipe the decrypted copy and scrub the key from memory regardless of
+    // outcome; teardown asserts the copy is gone.
+    await teardownCopy(copyPath);
+    keyHex = "";
+  }
+}
+
+/** Default Signal install directory on macOS. */
+export function defaultSignalDir(homeDir: string): string {
+  return path.join(homeDir, "Library", "Application Support", "Signal");
+}
+
+/** Default local scratch/checkpoint dir for the collector. */
+export function defaultSignalStateDir(): string {
+  return path.join(tmpdir(), "eliza-corpus-signal-state");
+}

--- a/packages/corpus-tools/src/index.ts
+++ b/packages/corpus-tools/src/index.ts
@@ -2,6 +2,7 @@
  * Public entry for corpus schema consumers, scrub stages, validators, and mock
  * loader adapters.
  */
+export * from "./collectors/index.ts";
 export * from "./mappers.ts";
 export * from "./pipeline/driver.ts";
 export * from "./pipeline/llm-pii.ts";


### PR DESCRIPTION
Part of #14762, part of #14747

## Summary

Adds the **Signal Desktop corpus collector** (`packages/corpus-tools/src/collectors/signal.ts`) plus the shared collector infra the remaining collector lanes will reuse. This is the keyless code + fixture-test scope of #14762; the live decrypt on the owner's Mac (Keychain approval + real key) is the only owner-gated step and remains a gated evidence row.

What lands:

- **Key acquisition** (`signal-key.ts`) — resolves the SQLCipher key from `<Signal>/config.json`: plaintext `key` (legacy) or the Electron `safeStorage` `encryptedKey`, unwrapped in-process via the Chromium **OSCrypt v10** scheme (PBKDF2-HMAC-SHA1 / `saltysalt` / 1003 iters / AES-128-CBC / all-spaces IV) keyed by the macOS Keychain item *"Signal Safe Storage"*. The Keychain read is an injected seam (`security find-generic-password` in production). The key is never persisted.
- **DB read** (`signal-db.ts`) — a `SignalDatabase` query seam and the production `openSqlcipherDatabase` adapter that applies `PRAGMA key` and probes before reading. The native cipher (`better-sqlite3-multiple-ciphers`) is an **optional dependency** loaded dynamically and **fails closed** (`sqlcipher_unavailable`) when absent. The collector's SQL + normalization path is shared between production and tests (`createSignalDatabase` + one `SIGNAL_MESSAGE_QUERY`), so tests exercise it against a real SQLite engine without shipping the cipher.
- **Normalization** (`signal-normalize.ts`) — Signal row (json column authoritative, SQL columns as fallback) → `CorpusMessage`, with structural direction/sender/thread derivation. Body-less rows (reactions, attachment-only, membership events) and pre-cutoff rows are **skipped and counted, never fabricated into empty-text messages**.
- **Orchestrator** (`signal.ts`) — resolves the key, **copies** `db.sqlite` and reads the copy read-only (never the live DB), writes idempotent month shards, advances a `max(received_at)` resume checkpoint, and in `finally` **wipes the decrypted copy and asserts it is gone** (a failed wipe is a fail-closed error, not a warning).
- **Shared infra** — `checkpoint.ts` (atomic per-account resume markers, fail-closed on a corrupt marker) and `shard-writer.ts` (idempotent `<platform>/<account>/<yyyy-mm>.jsonl` in the exact layout `validate` reads back), plus typed `CollectorError` (`errors.ts`). Reused by the other five collector lanes.
- **CLI** — `corpus collect signal` subcommand; typed exit codes (1 fail-closed, 2 usage).

Deviation from the issue's "commit an encrypted fixture DB": the tests **generate a real SQLite fixture with Signal's schema at test time** and inject a plaintext opener, so the whole query/normalization/shard/checkpoint/teardown path runs against a real query engine keyless — no opaque encrypted binary blob in git, and the only untested-locally step is the `PRAGMA key` decrypt itself, which is exactly the owner-gated part.

## Verification

Run from `packages/corpus-tools` under Node 24 (the harness resolves `.nvmrc` = 24.15.0, where `node:sqlite` is available so the real-SQLite e2e executes rather than skipping):

```
node ../scripts/run-vitest.mjs run --config ./vitest.config.ts src/collectors   # 29 passed (5 files)
bun run typecheck        # tsgo --noEmit, exit 0 (after @elizaos/core build)
bunx @biomejs/biome check src/collectors src/cli.ts   # clean
bun run audit:error-policy-ratchet   # no new fallback-slop in touched files
```

Red/green confirmed the real-SQLite e2e actually executes: forcing `messagesAdded` to `999` fails with `expected 3 to be 999` under Node 24 (35ms real query), and the check is green when reverted. Full suite (existing + new) = **110 passed**.

<details><summary>Collector test suite (29 passed, real SQLite path)</summary>

```
(uploaded: 14762-signal-collector-tests.txt)
 ✓ signal-normalize.test.ts  (8) — direction/sender/thread mapping, json fallback, all skip branches
 ✓ checkpoint.test.ts        (4) — round-trip, first-run null, atomic write, fail-closed on corrupt marker
 ✓ shard-writer.test.ts      (4) — validator-layout write + validateCorpusTarget round-trip, idempotent rerun, cross-account/off-cutoff rejection
 ✓ signal-key.test.ts       (10) — real OSCrypt v10 round-trip, wrong-password/bad-prefix fail-closed, legacy+encrypted config paths, missing-key/missing-config fail-closed
 ✓ signal.test.ts            (3) — end-to-end collect over a real SQLite Signal DB: normalize+shard+checkpoint+wipe, copy wiped even when read fails, openSqlcipher fails closed on a non-db file
 Test Files  5 passed (5)
      Tests  29 passed (29)
```
</details>

<details><summary>typecheck + biome + CLI exit codes + error-policy ratchet</summary>

```
### typecheck (tsgo --noEmit -p tsconfig.json)  -> exit 0
### biome check src/collectors src/cli.ts       -> Checked 14 files. No fixes applied.
### CLI fail-closed exit codes
source-missing exit=1 (expect 1)
unsupported-platform exit=2 (expect 2)
missing-required-flag exit=1 (expect 1)
### error-policy ratchet -> no new fallback-slop in touched files
```
</details>

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots — `N/A - library + CLI only, no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots — `N/A - library + CLI only, no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video — `N/A - no UI; CLI behavior shown via typed exit codes above`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs — collector emits `[SignalCollector] account=… added=… shards=… skipped=…` via the structured logger; full test suite + CLI exit-code capture: [14762-signal-collector-verify.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/14762-signal-collector-verify.txt) (also inline in the collapsed section above).
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs — `N/A - no frontend`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory — `N/A - deterministic file/SQLite parsing; no agent/action/prompt/model behavior`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the e2e writes real `CorpusMessage` JSONL shards + a resume checkpoint and asserts `validateCorpusTarget` passes (`manifest.totals.messages === 3`) and that a rerun adds 0. Full run log: [14762-signal-collector-tests.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/14762-signal-collector-tests.txt).
<!-- evidence-row:ocr-review -->
- [ ] OCR visual text review — `N/A - no rendered UI text`.

## Remaining units (this epic, not this PR)

- The other five collectors (#14758 Gmail, #14759 Telegram, #14760 Discord, #14761 iMessage, #14763 X) — separate lanes; they reuse `checkpoint.ts` / `shard-writer.ts` / `errors.ts` from this PR.
- #14762 live evidence: a real decrypt+pull on the owner's Mac with Keychain approval, plus a native `better-sqlite3-multiple-ciphers` build — owner-gated, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)