### PR TITLE
test(harness): run scenario assertion units in recurring lane

### DIFF
--- a/packages/test/harness/vitest.config.ts
+++ b/packages/test/harness/vitest.config.ts
@@ -9,7 +9,12 @@ import { buildHarnessSourceAliases } from "./source-aliases.ts";
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["harness/**/*.test.ts"],
+    // `scenarios/**` holds .scenario.ts specs for the scenario runner, but unit
+    // tests of their assertion modules live alongside them as *.test.ts. This
+    // package's `test` script is their only recurring lane (server lane on
+    // develop pushes + nightly), so they must be included here or they run
+    // nowhere (#16020).
+    include: ["harness/**/*.test.ts", "scenarios/**/*.test.ts"],
     exclude: ["dist/**", "**/node_modules/**"],
     testTimeout: 180_000,
     hookTimeout: 180_000,

--- a/packages/test/scenarios/cross-cutting/planner.missing-input-terminal-relay.test.ts
+++ b/packages/test/scenarios/cross-cutting/planner.missing-input-terminal-relay.test.ts
@@ -2,8 +2,9 @@
  * Pins the missing-input live scenario's action provenance before credentialed
  * execution so parent and generated child routes share the same strict result bar.
  */
-import { describe, expect, test } from "bun:test";
+
 import type { CapturedAction } from "@elizaos/scenario-runner/schema";
+import { describe, expect, test } from "vitest";
 import { expectMissingInputTerminalRelay } from "./planner.missing-input-terminal-relay.assertion";
 
 const CLARIFICATION =


### PR DESCRIPTION
Fixes #16020

## Summary

`packages/test/scenarios/cross-cutting/planner.missing-input-terminal-relay.test.ts` was only reached by changed-file coverage when that file itself changed. The package test script uses `harness/vitest.config.ts`, whose include previously covered only `harness/**/*.test.ts`.

- Add `scenarios/**/*.test.ts` to the existing package Vitest project, which already runs in the recurring server lane.
- Switch the scenario assertion unit from `bun:test` to `vitest`, matching the runner that now owns it.
- Preserve the existing `.scenario.ts` corpus behavior; only adjacent `*.test.ts` assertion units are added to discovery.

Exact head: `fa2a09b1f4a7911344e32e342708509dcf7799a9`
Base: `6b80bf18fcfa4f827b58c8aedadb939dc2aa81d1`

## Verification

- `bun run --cwd packages/test test` — 8 files, 24 tests passed.
- Explicit verbose run of `planner.missing-input-terminal-relay.test.ts` through the same config — 1 file, 5 tests passed, including parent/child acceptance and unrelated/failed/missing-authority/paraphrase rejection.
- Biome check on both touched files — clean.
- `git diff --check origin/develop` — clean.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - test discovery configuration only; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test discovery configuration only; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow changed; the executable artifact is the recurring test run.
<!-- evidence-row:backend-logs -->
- [x] Package test transcript and CI logs: https://github.com/elizaOS/eliza/pull/16040/checks
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or browser path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, action, provider, or scenario behavior changed; this wires an existing deterministic assertion unit into its recurring runner.
<!-- evidence-row:domain-artifacts -->
- [x] Recurring lane diff showing scenario assertion unit inclusion: https://github.com/elizaOS/eliza/pull/16040/files