### PR TITLE
fix(cloud): make tier-upgrade single-flight span target creation through provision enqueue

### DIFF
--- a/packages/cloud/api/v1/eliza/agents/[agentId]/upgrade-tier/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/upgrade-tier/route.ts
@@ -25,12 +25,15 @@
  *    reconstruct identity from DTOs (onboarding-created shared agents keep
  *    name/bio only in agent_config).
  *  - 2xx `alreadyInProgress:true` reattach when this shared agent already has a
- *    live migration target (the `__agentUpgradedFrom` marker): a per-source
- *    database lock makes retries and concurrent tabs resume the SAME upgrade.
+ *    live migration target (the `__agentUpgradedFrom` marker): the single-flight
+ *    service (per-source database lock spanning target creation through the
+ *    provision enqueue, #15943) makes retries and concurrent tabs resume the
+ *    SAME upgrade, with target and job committed atomically — so a reattach
+ *    never prepares credentials or environment state; it only reads (or
+ *    re-arms, for stopped/sleeping/dead-job targets) durable state.
  */
 
 import { Hono } from "hono";
-import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
 import { errorToResponse } from "@/lib/api/errors";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
 import { AGENT_PRICING } from "@/lib/constants/agent-pricing";
@@ -38,11 +41,9 @@ import { getMaxNonTerminalAgentsForOrg } from "@/lib/constants/agent-sandbox-quo
 import { checkAgentTierUpgradeCreditGate } from "@/lib/services/agent-billing-gate";
 import { insufficientCredits402 } from "@/lib/services/agent-billing-gate-402";
 import {
-  createTierUpgradeTarget,
-  findActiveTierUpgradeProvisionJob,
+  createTierUpgradeTargetWithProvision,
+  findLiveTierUpgradeTarget,
 } from "@/lib/services/agent-tier-upgrade-target";
-import { readUpgradedFromAgentId } from "@/lib/services/eliza-agent-config";
-import { prepareManagedElizaEnvironment } from "@/lib/services/eliza-managed-launch";
 import {
   AgentQuotaExceededError,
   elizaSandboxService,
@@ -59,18 +60,13 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 const CORS_METHODS = "POST, OPTIONS";
 
-/** Statuses under which an existing migration target still owns the upgrade. */
-const LIVE_TARGET_STATUSES = new Set([
-  "pending",
-  "provisioning",
-  "running",
-  "stopped",
-  "sleeping",
-]);
-
 type AgentRow = NonNullable<
   Awaited<ReturnType<typeof elizaSandboxService.getAgentForWrite>>
 >;
+
+type AuthedUser = Awaited<
+  ReturnType<typeof requireAuthOrApiKeyWithOrg>
+>["user"];
 
 function json(body: unknown, status = 200): Response {
   return applyCorsHeaders(Response.json(body, { status }), CORS_METHODS);
@@ -82,21 +78,6 @@ function pollingBody(jobId: string) {
     intervalMs: 5000,
     expectedDurationMs: 90000,
   };
-}
-
-async function waitForConcurrentProvisionJob(
-  agentId: string,
-  organizationId: string,
-) {
-  for (let attempt = 0; attempt < 200; attempt += 1) {
-    const job = await findActiveTierUpgradeProvisionJob(
-      agentId,
-      organizationId,
-    );
-    if (job) return job;
-    await new Promise((resolve) => setTimeout(resolve, 50));
-  }
-  return undefined;
 }
 
 function asConfigRecord(value: unknown): Record<string, unknown> {
@@ -115,69 +96,99 @@ function asEnvRecord(value: unknown): Record<string, string> {
 }
 
 /**
- * The org's live migration target for this shared agent, if one exists.
- * The atomic find-or-create service repeats this lookup under its per-source
- * database lock before inserting, closing the concurrent double-mint window.
+ * Respond for a live migration target that already owns this upgrade — both
+ * the pre-checked reattach and the race loser whose single-flight call
+ * returned another request's committed target. Running and
+ * already-provisioning targets reattach without a second credit gate: nothing
+ * new starts billing. Resuming a stopped/sleeping target does start compute
+ * again, so that path must prove the same dedicated runway as a fresh upgrade
+ * before it may enqueue work. The enqueue is safe from any state because a
+ * committed target's environment was fully prepared at creation — re-arming a
+ * dead job never re-mints credentials.
  */
-async function findLiveUpgradeTarget(
-  organizationId: string,
+async function respondToLiveTarget(
+  target: AgentRow,
   sharedAgentId: string,
-): Promise<AgentRow | null> {
-  const agents =
-    await agentSandboxesRepository.listByOrganization(organizationId);
-  return (
-    agents.find(
-      (agent) =>
-        agent.id !== sharedAgentId &&
-        // The marker alone is not proof of a migration target: agent_config is
-        // PATCHable, so a marker planted on a non-dedicated row must never be
-        // reattached to — only a dedicated-always row can own the upgrade.
-        agent.execution_tier === "dedicated-always" &&
-        LIVE_TARGET_STATUSES.has(agent.status) &&
-        readUpgradedFromAgentId(asConfigRecord(agent.agent_config)) ===
-          sharedAgentId,
-    ) ?? null
-  );
-}
-
-/**
- * Run the post-create span and delete the just-minted target if any step
- * throws, so an error between the insert and the provision-job enqueue never
- * leaves a `pending` row no worker will ever claim (same rationale as the
- * create route's orphan cleanup; the cleanup-stuck-provisioning cron is the
- * safety net for rows that slip through).
- */
-async function withUpgradeOrphanCleanup<T>(
-  dedicatedAgentId: string,
-  organizationId: string,
-  fn: () => Promise<T>,
-): Promise<T> {
-  try {
-    return await fn();
-  } catch (err) {
-    try {
-      await agentSandboxesRepository.delete(dedicatedAgentId, organizationId);
-      logger.info(
-        "[agent-upgrade-tier] Cleaned up migration target after create→enqueue failure",
-        { agentId: dedicatedAgentId, orgId: organizationId },
-      );
-    } catch (cleanupErr) {
-      // error-policy:J6 best-effort teardown of the just-created row; the
-      // original failure below is what the caller must see.
-      logger.error(
-        "[agent-upgrade-tier] Failed to clean up migration target after create→enqueue failure",
-        {
-          agentId: dedicatedAgentId,
-          orgId: organizationId,
-          error:
-            cleanupErr instanceof Error
-              ? cleanupErr.message
-              : String(cleanupErr),
-        },
+  user: AuthedUser,
+  env: AppEnv["Bindings"],
+): Promise<Response> {
+  logger.info("[agent-upgrade-tier] Reattaching to in-flight upgrade", {
+    sharedAgentId,
+    dedicatedAgentId: target.id,
+    orgId: user.organization_id,
+    status: target.status,
+  });
+  if (target.status === "running") {
+    return json({
+      success: true,
+      created: false,
+      alreadyInProgress: true,
+      data: {
+        id: target.id,
+        agentId: target.id,
+        dedicatedAgentId: target.id,
+        sharedAgentId,
+        agentName: target.agent_name,
+        status: target.status,
+        executionTier: target.execution_tier,
+      },
+    });
+  }
+  if (target.status === "stopped" || target.status === "sleeping") {
+    const resumeCreditCheck = await checkAgentTierUpgradeCreditGate(
+      user.organization_id,
+    );
+    if (!resumeCreditCheck.allowed) {
+      return json(
+        insufficientCredits402(
+          resumeCreditCheck,
+          "[agent-upgrade-tier] Resume blocked: insufficient hosting runway",
+          {
+            sharedAgentId,
+            dedicatedAgentId: target.id,
+            orgId: user.organization_id,
+          },
+          { requiredBalance: AGENT_PRICING.UPGRADE_MINIMUM_BALANCE },
+        ),
+        402,
       );
     }
-    throw err;
   }
+  // pending/provisioning (or stopped/sleeping after an interrupted boot):
+  // hand back the active provision job — enqueue reuses an in-flight job
+  // and only mints a new one when the previous attempt died.
+  const reattach = await provisioningJobService.enqueueAgentProvisionOnce({
+    agentId: target.id,
+    organizationId: user.organization_id,
+    userId: user.id,
+    agentName: target.agent_name ?? target.id,
+  });
+  if (reattach.created) {
+    void provisioningJobService.triggerImmediate(env).catch(() => {
+      // error-policy:J5 fire-and-forget nudge; the job is persisted and the
+      // provisioning cron is the safety net (failure logged in the service).
+    });
+  }
+  return json(
+    {
+      success: true,
+      created: false,
+      alreadyInProgress: true,
+      data: {
+        id: target.id,
+        agentId: target.id,
+        dedicatedAgentId: target.id,
+        sharedAgentId,
+        agentName: target.agent_name,
+        status: reattach.job.status,
+        jobId: reattach.job.id,
+        estimatedCompletionAt: reattach.job.estimated_completion_at,
+        executionTier: target.execution_tier,
+      },
+      polling: pollingBody(reattach.job.id),
+    },
+    202,
+  );
 }
 
 async function __hono_POST(
@@ -223,95 +234,12 @@ async function __hono_POST(
     }
 
     // ── Reattach: an upgrade for this shared agent is already under way. ──
-    // Running and already-provisioning targets reattach without a second gate:
-    // nothing new starts billing. Resuming a stopped/sleeping target does start
-    // compute again, so that path must prove the same dedicated runway as a
-    // fresh upgrade before it may enqueue work.
-    const existingTarget = await findLiveUpgradeTarget(
+    const existingTarget = await findLiveTierUpgradeTarget(
       user.organization_id,
       agentId,
     );
     if (existingTarget) {
-      logger.info("[agent-upgrade-tier] Reattaching to in-flight upgrade", {
-        sharedAgentId: agentId,
-        dedicatedAgentId: existingTarget.id,
-        orgId: user.organization_id,
-        status: existingTarget.status,
-      });
-      if (existingTarget.status === "running") {
-        return json({
-          success: true,
-          created: false,
-          alreadyInProgress: true,
-          data: {
-            id: existingTarget.id,
-            agentId: existingTarget.id,
-            dedicatedAgentId: existingTarget.id,
-            sharedAgentId: agentId,
-            agentName: existingTarget.agent_name,
-            status: existingTarget.status,
-            executionTier: existingTarget.execution_tier,
-          },
-        });
-      }
-      if (
-        existingTarget.status === "stopped" ||
-        existingTarget.status === "sleeping"
-      ) {
-        const resumeCreditCheck = await checkAgentTierUpgradeCreditGate(
-          user.organization_id,
-        );
-        if (!resumeCreditCheck.allowed) {
-          return json(
-            insufficientCredits402(
-              resumeCreditCheck,
-              "[agent-upgrade-tier] Resume blocked: insufficient hosting runway",
-              {
-                sharedAgentId: agentId,
-                dedicatedAgentId: existingTarget.id,
-                orgId: user.organization_id,
-              },
-              { requiredBalance: AGENT_PRICING.UPGRADE_MINIMUM_BALANCE },
-            ),
-            402,
-          );
-        }
-      }
-      // pending/provisioning (or stopped/sleeping after an interrupted boot):
-      // hand back the active provision job — enqueue reuses an in-flight job
-      // and only mints a new one when the previous attempt died.
-      const reattach = await provisioningJobService.enqueueAgentProvisionOnce({
-        agentId: existingTarget.id,
-        organizationId: user.organization_id,
-        userId: user.id,
-        agentName: existingTarget.agent_name ?? existingTarget.id,
-      });
-      if (reattach.created) {
-        void provisioningJobService.triggerImmediate(env).catch(() => {
-          // error-policy:J5 fire-and-forget nudge; the job is persisted and the
-          // provisioning cron is the safety net (failure logged in the service).
-        });
-      }
-      return json(
-        {
-          success: true,
-          created: false,
-          alreadyInProgress: true,
-          data: {
-            id: existingTarget.id,
-            agentId: existingTarget.id,
-            dedicatedAgentId: existingTarget.id,
-            sharedAgentId: agentId,
-            agentName: existingTarget.agent_name,
-            status: reattach.job.status,
-            jobId: reattach.job.id,
-            estimatedCompletionAt: reattach.job.estimated_completion_at,
-            executionTier: existingTarget.execution_tier,
-          },
-          polling: pollingBody(reattach.job.id),
-        },
-        202,
-      );
+      return await respondToLiveTarget(existingTarget, agentId, user, env);
     }
 
     // ── Credit gate: N days of dedicated hosting runway, not the bare create
@@ -332,19 +260,44 @@ async function __hono_POST(
       );
     }
 
+    // ── Worker health, BEFORE anything durable is minted. The single-flight
+    // service commits the target together with its provision job, so a dead
+    // worker checked here means nothing gets created at all — no fresh row to
+    // roll back, no compensation window. (A worker dying between this check
+    // and the commit leaves a valid job the recovering worker picks up.)
+    const workerHealth = await checkProvisioningWorkerHealth();
+    if (!workerHealth.ok) {
+      logger.warn(
+        "[agent-upgrade-tier] Upgrade blocked: provisioning worker unavailable",
+        {
+          sharedAgentId: agentId,
+          orgId: user.organization_id,
+          code: workerHealth.code,
+        },
+      );
+      return json(
+        provisioningWorkerFailureBody(workerHealth),
+        workerHealth.status,
+      );
+    }
+
     // ── Mint the dedicated migration target, copying identity server-side. ──
     // Reserved platform env keys are stripped from the copy so the new agent
     // gets ITS OWN minted tokens/identity (ELIZA_API_TOKEN, ELIZA_CLOUD_AGENT_ID,
     // PUBLIC_BASE_URL, …) while the user's BYO env — including `enc:v1:`
     // ciphertext, which the storage encryptor passes through untouched and the
-    // same-org materialization path decrypts — survives verbatim.
+    // same-org materialization path decrypts — survives verbatim. Environment
+    // preparation, target insert, and provision enqueue all happen inside the
+    // service's single-flight boundary.
     const sourceConfig = asConfigRecord(shared.agent_config);
     const sourceEnv = stripReservedEnvKeys(
       asEnvRecord(shared.environment_vars),
     );
-    let created: Awaited<ReturnType<typeof createTierUpgradeTarget>>;
+    let result: Awaited<
+      ReturnType<typeof createTierUpgradeTargetWithProvision>
+    >;
     try {
-      created = await createTierUpgradeTarget({
+      result = await createTierUpgradeTargetWithProvision({
         sourceAgentId: agentId,
         organizationId: user.organization_id,
         userId: user.id,
@@ -377,192 +330,48 @@ async function __hono_POST(
       }
       throw error;
     }
-    const dedicated = created.agent;
 
-    if (created.idempotent) {
-      if (dedicated.status === "running") {
-        return json({
-          success: true,
-          created: false,
-          alreadyInProgress: true,
-          data: {
-            id: dedicated.id,
-            agentId: dedicated.id,
-            dedicatedAgentId: dedicated.id,
-            sharedAgentId: agentId,
-            agentName: dedicated.agent_name,
-            status: dedicated.status,
-            executionTier: dedicated.execution_tier,
-          },
-        });
-      }
-      const concurrentJob = await waitForConcurrentProvisionJob(
-        dedicated.id,
-        user.organization_id,
-      );
-      if (concurrentJob) {
-        return json(
-          {
-            success: true,
-            created: false,
-            alreadyInProgress: true,
-            data: {
-              id: dedicated.id,
-              agentId: dedicated.id,
-              dedicatedAgentId: dedicated.id,
-              sharedAgentId: agentId,
-              agentName: dedicated.agent_name,
-              status: concurrentJob.status,
-              jobId: concurrentJob.id,
-              estimatedCompletionAt: concurrentJob.estimated_completion_at,
-              executionTier: dedicated.execution_tier,
-            },
-            polling: pollingBody(concurrentJob.id),
-          },
-          202,
-        );
-      }
-      const workerHealth = await checkProvisioningWorkerHealth();
-      if (!workerHealth.ok) {
-        return json(
-          provisioningWorkerFailureBody(workerHealth),
-          workerHealth.status,
-        );
-      }
-      const managedEnvironment = await prepareManagedElizaEnvironment({
-        existingEnv: sourceEnv,
-        organizationId: user.organization_id,
-        userId: user.id,
-        agentSandboxId: dedicated.id,
-      });
-      if (managedEnvironment.changed) {
-        await elizaSandboxService.updateAgentEnvironment(
-          dedicated.id,
-          user.organization_id,
-          managedEnvironment.environmentVars,
-        );
-      }
-      const reattach = await provisioningJobService.enqueueAgentProvisionOnce({
-        agentId: dedicated.id,
-        organizationId: user.organization_id,
-        userId: user.id,
-        agentName: dedicated.agent_name ?? dedicated.id,
-      });
-      if (reattach.created) {
-        void provisioningJobService.triggerImmediate(env).catch(() => {
-          // error-policy:J5 fire-and-forget nudge; the job is persisted and the
-          // provisioning cron is the safety net (failure logged in the service).
-        });
-      }
-      return json(
-        {
-          success: true,
-          created: false,
-          alreadyInProgress: true,
-          data: {
-            id: dedicated.id,
-            agentId: dedicated.id,
-            dedicatedAgentId: dedicated.id,
-            sharedAgentId: agentId,
-            agentName: dedicated.agent_name,
-            status: reattach.job.status,
-            jobId: reattach.job.id,
-            estimatedCompletionAt: reattach.job.estimated_completion_at,
-            executionTier: dedicated.execution_tier,
-          },
-          polling: pollingBody(reattach.job.id),
-        },
-        202,
-      );
+    // Race loser: another request committed the target (and its job) while
+    // this one was in flight — reattach to that durable state.
+    if (!result.created) {
+      return await respondToLiveTarget(result.agent, agentId, user, env);
     }
+    const dedicated = result.agent;
+    const job = result.job;
 
-    return await withUpgradeOrphanCleanup(
-      dedicated.id,
-      user.organization_id,
-      async () => {
-        const managedEnvironment = await prepareManagedElizaEnvironment({
-          existingEnv: sourceEnv,
-          organizationId: user.organization_id,
-          userId: user.id,
-          agentSandboxId: dedicated.id,
-        });
-        if (managedEnvironment.changed) {
-          await elizaSandboxService.updateAgentEnvironment(
-            dedicated.id,
-            user.organization_id,
-            managedEnvironment.environmentVars,
-          );
-        }
+    void provisioningJobService.triggerImmediate(env).catch(() => {
+      // error-policy:J5 fire-and-forget nudge; the job is persisted and the
+      // provisioning cron is the safety net (failure logged in the service).
+    });
 
-        // Only the cold provisioning job needs a live worker; check at the
-        // enqueue boundary. A dead worker rolls the fresh row back explicitly
-        // (returning is success to the cleanup wrapper) so the org is not left
-        // holding an unclaimable `pending` target. The warm-pool fast path is
-        // intentionally skipped: upgrades are not latency-critical and always
-        // take the async job path.
-        const workerHealth = await checkProvisioningWorkerHealth();
-        if (!workerHealth.ok) {
-          await agentSandboxesRepository.delete(
-            dedicated.id,
-            user.organization_id,
-          );
-          logger.warn(
-            "[agent-upgrade-tier] Upgrade blocked: provisioning worker unavailable",
-            {
-              sharedAgentId: agentId,
-              dedicatedAgentId: dedicated.id,
-              orgId: user.organization_id,
-              code: workerHealth.code,
-            },
-          );
-          return json(
-            provisioningWorkerFailureBody(workerHealth),
-            workerHealth.status,
-          );
-        }
+    logger.info("[agent-upgrade-tier] Upgrade started", {
+      sharedAgentId: agentId,
+      dedicatedAgentId: dedicated.id,
+      orgId: user.organization_id,
+      jobId: job.id,
+      balance: creditCheck.balance,
+    });
 
-        const { job } = await provisioningJobService.enqueueAgentProvisionOnce({
+    return json(
+      {
+        success: true,
+        created: true,
+        message:
+          "Dedicated agent created. Provisioning job started — poll the job endpoint, then run the conversation handoff.",
+        data: {
+          id: dedicated.id,
           agentId: dedicated.id,
-          organizationId: user.organization_id,
-          userId: user.id,
-          agentName: dedicated.agent_name ?? dedicated.id,
-        });
-
-        void provisioningJobService.triggerImmediate(env).catch(() => {
-          // error-policy:J5 fire-and-forget nudge; the job is persisted and the
-          // provisioning cron is the safety net (failure logged in the service).
-        });
-
-        logger.info("[agent-upgrade-tier] Upgrade started", {
-          sharedAgentId: agentId,
           dedicatedAgentId: dedicated.id,
-          orgId: user.organization_id,
+          sharedAgentId: agentId,
+          agentName: dedicated.agent_name,
+          status: job.status,
           jobId: job.id,
-          balance: creditCheck.balance,
-        });
-
-        return json(
-          {
-            success: true,
-            created: true,
-            message:
-              "Dedicated agent created. Provisioning job started — poll the job endpoint, then run the conversation handoff.",
-            data: {
-              id: dedicated.id,
-              agentId: dedicated.id,
-              dedicatedAgentId: dedicated.id,
-              sharedAgentId: agentId,
-              agentName: dedicated.agent_name,
-              status: job.status,
-              jobId: job.id,
-              estimatedCompletionAt: job.estimated_completion_at,
-              executionTier: dedicated.execution_tier,
-            },
-            polling: pollingBody(job.id),
-          },
-          202,
-        );
+          estimatedCompletionAt: job.estimated_completion_at,
+          executionTier: dedicated.execution_tier,
+        },
+        polling: pollingBody(job.id),
       },
+      202,
     );
   } catch (error) {
     return applyCorsHeaders(errorToResponse(error), CORS_METHODS);

--- a/packages/cloud/shared/src/lib/services/agent-tier-upgrade-target-lock.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-tier-upgrade-target-lock.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Discriminating regression test for the tier-upgrade single-flight SPAN
+ * (#15943). Single-connection PGlite serializes every statement, so the
+ * behavioral suite in `agent-tier-upgrade-target.test.ts` passes identically
+ * whether the advisory lock is present, moved, or the provision enqueue is
+ * hoisted back out of the transaction — it cannot catch the exact regression
+ * #15929 shipped (lock released at the target commit, enqueue left outside).
+ *
+ * This suite closes that gap the way `inference-billing-ledger-advisory-lock`
+ * does for its lock: it mocks ONLY the transaction seam, records every
+ * statement each transaction runs, and asserts the boundary transaction takes
+ * the per-source tier-upgrade lock FIRST, re-checks for a live target under
+ * it, and inserts the target AND its provision job (behind the nested
+ * per-agent provision lock) before committing. Move the enqueue outside the
+ * transaction, drop either lock, or reorder the re-check, and this fails.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS ||= "1";
+
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+import * as helpersActual from "../../db/helpers";
+import { agentSandboxes } from "../../db/schemas/agent-sandboxes";
+import * as apiKeysActual from "./api-keys";
+import * as managedConfigActual from "./managed-eliza-config";
+
+const ORG = "11111111-1111-4111-8111-111111111111";
+const USER = "aaaaaaaa-1111-4111-8111-111111111111";
+const SRC = "cccccccc-1111-4111-8111-111111111111";
+const WINNER_TARGET_ID = "eeeeeeee-1111-4111-8111-111111111111";
+
+interface TxEvent {
+  tx: number;
+  kind: string;
+  detail?: string;
+}
+
+type SandboxRow = Record<string, unknown>;
+
+const events: TxEvent[] = [];
+let txCounter = 0;
+/** What the live-target re-check returns, per transaction index — lets the
+ * race-loser test show a competitor's commit between phase 1 and phase 3. */
+let liveTargetRowsForTx: (txIndex: number) => SandboxRow[] = () => [];
+let insertedTarget: SandboxRow | undefined;
+let prepCalls = 0;
+const revokeForAgent = mock(async (_agentSandboxId: string) => {});
+
+function makeTx(txIndex: number) {
+  return {
+    execute: async (query: SQL) => {
+      const { sql: text, params } = new PgDialect().sqlToQuery(query);
+      if (text.includes("pg_advisory_xact_lock")) {
+        events.push({ tx: txIndex, kind: "lock", detail: String(params[1] ?? "") });
+      } else {
+        events.push({ tx: txIndex, kind: "execute" });
+      }
+      return { rows: [] };
+    },
+    select: () => {
+      const state = { table: undefined as unknown, hasOrderBy: false };
+      const chain = {
+        from: (table: unknown) => {
+          state.table = table;
+          return chain;
+        },
+        where: (_clause: SQL | undefined) => chain,
+        orderBy: () => {
+          state.hasOrderBy = true;
+          return chain;
+        },
+        limit: () => {
+          // The live-target re-check orders by created_at; the enqueue's
+          // sandbox-existence probe does not — that distinguishes them.
+          if (state.table === agentSandboxes && state.hasOrderBy) {
+            events.push({ tx: txIndex, kind: "select-live-target" });
+            return liveTargetRowsForTx(txIndex);
+          }
+          if (state.table === agentSandboxes) {
+            events.push({ tx: txIndex, kind: "select-sandbox-for-enqueue" });
+            return insertedTarget ? [insertedTarget] : [];
+          }
+          events.push({ tx: txIndex, kind: "select-active-job" });
+          return [];
+        },
+        // biome-ignore lint/suspicious/noThenProperty: Drizzle's count chain is awaited at `.where()`, so this mock must be thenable.
+        then: (resolve: (rows: Array<{ count: number }>) => unknown) => {
+          events.push({ tx: txIndex, kind: "select-quota-count" });
+          return resolve([{ count: 0 }]);
+        },
+      };
+      return chain;
+    },
+    insert: (table: unknown) => ({
+      values: (value: SandboxRow) => ({
+        returning: async () => {
+          if (table === agentSandboxes) {
+            events.push({ tx: txIndex, kind: "insert-target" });
+            insertedTarget = { updated_at: new Date(), ...value };
+            return [insertedTarget];
+          }
+          events.push({ tx: txIndex, kind: "insert-provision-job" });
+          return [{ ...value }];
+        },
+      }),
+    }),
+  };
+}
+
+const transaction = mock(async (fn: (tx: ReturnType<typeof makeTx>) => Promise<unknown>) => {
+  txCounter += 1;
+  return fn(makeTx(txCounter));
+});
+
+mock.module("../../db/helpers", () => ({
+  ...helpersActual,
+  dbWrite: { transaction },
+  writeTransaction: (fn: (tx: ReturnType<typeof makeTx>) => Promise<unknown>) => transaction(fn),
+}));
+
+// Spread the actual module so its OTHER named exports (consumed by transitive
+// importers like eliza-managed-launch) still resolve — a partial mock.module
+// throws "Export not found" at link time.
+mock.module("./managed-eliza-config", () => ({
+  ...managedConfigActual,
+  prepareManagedElizaSharedEnvironment: async (params: { agentSandboxId: string }) => {
+    prepCalls += 1;
+    return {
+      apiToken: "agent_locktest",
+      changed: true,
+      environmentVars: {
+        ELIZA_API_TOKEN: "agent_locktest",
+        ELIZA_CLOUD_AGENT_ID: params.agentSandboxId,
+      },
+      agentApiKey: "ek_locktest",
+    };
+  },
+}));
+
+mock.module("./api-keys", () => ({
+  ...apiKeysActual,
+  apiKeysService: { revokeForAgent },
+}));
+
+mock.module("../utils/logger", () => ({
+  logger: { warn: () => {}, info: () => {}, error: () => {}, debug: () => {} },
+}));
+
+const { createTierUpgradeTargetWithProvision } = await import("./agent-tier-upgrade-target");
+
+afterEach(() => {
+  events.length = 0;
+  txCounter = 0;
+  liveTargetRowsForTx = () => [];
+  insertedTarget = undefined;
+  prepCalls = 0;
+  transaction.mockClear();
+  revokeForAgent.mockClear();
+});
+
+function upgrade() {
+  return createTierUpgradeTargetWithProvision({
+    sourceAgentId: SRC,
+    organizationId: ORG,
+    userId: USER,
+    agentName: "lock-span-target",
+    environmentVars: {},
+    maxNonTerminalAgents: 5,
+  });
+}
+
+describe("tier-upgrade single-flight span (#15943)", () => {
+  test("the boundary transaction spans lock → re-check → target insert → provision lock → job insert", async () => {
+    const result = await upgrade();
+    expect(result.created).toBe(true);
+
+    // Exactly two transactions: the phase-1 pre-check and the phase-3 boundary.
+    expect(txCounter).toBe(2);
+
+    const phase1 = events.filter((event) => event.tx === 1);
+    expect(phase1.map((event) => event.kind)).toEqual([
+      "lock",
+      "select-live-target",
+      "select-quota-count",
+    ]);
+    expect(phase1[0]?.detail).toBe(`tier-upgrade:${SRC}`);
+
+    // The load-bearing assertion: target insert AND provision-job insert are
+    // statements of the SAME transaction that took the tier-upgrade lock as
+    // its first statement. Hoist the enqueue out of the transaction and the
+    // job insert disappears from this list; release the lock earlier and the
+    // re-check/insert stop being its first statements.
+    const phase3 = events.filter((event) => event.tx === 2);
+    expect(phase3.map((event) => event.kind)).toEqual([
+      "lock",
+      "select-live-target",
+      "select-quota-count",
+      "insert-target",
+      "lock",
+      "select-sandbox-for-enqueue",
+      "select-active-job",
+      "insert-provision-job",
+    ]);
+    expect(phase3[0]?.detail).toBe(`tier-upgrade:${SRC}`);
+    // The nested provision lock is keyed on the freshly minted target id
+    // (lock order: tier-upgrade → provision; never the reverse).
+    expect(phase3[4]?.detail).toBe(result.agent.id);
+
+    // Happy path: the prepared credentials were adopted, not revoked.
+    expect(prepCalls).toBe(1);
+    expect(revokeForAgent).not.toHaveBeenCalled();
+  });
+
+  test("a live target found under the phase-1 lock reattaches without preparing or opening the boundary", async () => {
+    liveTargetRowsForTx = () => [
+      {
+        id: WINNER_TARGET_ID,
+        organization_id: ORG,
+        execution_tier: "dedicated-always",
+        status: "pending",
+        agent_config: { __agentUpgradedFrom: SRC },
+      },
+    ];
+
+    const result = await upgrade();
+    expect(result.created).toBe(false);
+    // One transaction only — no preparation, no candidate credentials to revoke.
+    expect(txCounter).toBe(1);
+    expect(prepCalls).toBe(0);
+    expect(revokeForAgent).not.toHaveBeenCalled();
+    expect(events.map((event) => event.kind)).toEqual(["lock", "select-live-target"]);
+  });
+
+  test("losing the race inside the boundary revokes the candidate credentials and adopts the winner's target", async () => {
+    // Phase 1 sees nothing; the boundary re-check finds a competitor's target
+    // committed in the window between the two transactions.
+    liveTargetRowsForTx = (txIndex) =>
+      txIndex >= 2
+        ? [
+            {
+              id: WINNER_TARGET_ID,
+              organization_id: ORG,
+              execution_tier: "dedicated-always",
+              status: "pending",
+              agent_config: { __agentUpgradedFrom: SRC },
+            },
+          ]
+        : [];
+
+    const result = await upgrade();
+    expect(result.created).toBe(false);
+    expect(result.agent.id).toBe(WINNER_TARGET_ID);
+
+    // The loser prepared once, made nothing durable, and dropped its own
+    // candidate key — never the winner's (the revoke is keyed on the loser's
+    // prospective id, which is not the winner's target id).
+    expect(prepCalls).toBe(1);
+    expect(events.filter((event) => event.kind === "insert-target")).toHaveLength(0);
+    expect(events.filter((event) => event.kind === "insert-provision-job")).toHaveLength(0);
+    expect(revokeForAgent).toHaveBeenCalledTimes(1);
+    const revokedId = revokeForAgent.mock.calls[0]?.[0];
+    expect(revokedId).toBeTruthy();
+    expect(revokedId).not.toBe(WINNER_TARGET_ID);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/agent-tier-upgrade-target.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-tier-upgrade-target.test.ts
@@ -1,0 +1,482 @@
+/**
+ * Real-DB coverage for the tier-upgrade single-flight boundary (#15943):
+ * target creation, managed-environment preparation, and provision-job enqueue
+ * as one durable unit. Real service + real repositories + real provisioning
+ * job service against in-process PGlite; the only instrumented seam is
+ * `prepareManagedElizaSharedEnvironment` (wrapped, not replaced — it delegates
+ * to the real implementation) so tests can delay or fail the credential-mint
+ * phase and prove losers/retries never double-prepare, plus one spy on the
+ * enqueue step to prove target+job atomicity under rollback.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, mock, spyOn, test } from "bun:test";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { eq, like } from "drizzle-orm";
+import * as managedConfigActual from "./managed-eliza-config";
+
+// ---- instrumented prep seam: delay / fail / count, delegating to the real fn ----
+// The namespace import is a LIVE binding that mock.module rewires, so the real
+// implementation must be captured by value here or the wrapper would recurse.
+const realPrepareManagedElizaSharedEnvironment =
+  managedConfigActual.prepareManagedElizaSharedEnvironment;
+let prepDelayMs = 0;
+let prepFailNext = false;
+let prepCalls = 0;
+
+mock.module("./managed-eliza-config", () => ({
+  ...managedConfigActual,
+  prepareManagedElizaSharedEnvironment: async (
+    params: Parameters<typeof realPrepareManagedElizaSharedEnvironment>[0],
+  ) => {
+    prepCalls += 1;
+    if (prepFailNext) {
+      prepFailNext = false;
+      throw new Error("simulated credential-mint failure");
+    }
+    if (prepDelayMs > 0) {
+      const delay = prepDelayMs;
+      prepDelayMs = 0;
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+    return realPrepareManagedElizaSharedEnvironment(params);
+  },
+}));
+
+const ORG_A = "11111111-1111-4111-8111-111111111111";
+const ORG_QUOTA = "22222222-2222-4222-8222-222222222222";
+const USER_A = "aaaaaaaa-1111-4111-8111-111111111111";
+const USER_QUOTA = "bbbbbbbb-1111-4111-8111-111111111111";
+const CHARACTER_A = "eeeeeeee-1111-4111-8111-111111111111";
+const SRC_BASIC = "cccccccc-1111-4111-8111-111111111111";
+const SRC_CONCURRENT = "cccccccc-2222-4222-8222-222222222222";
+const SRC_DELAYED = "cccccccc-3333-4333-8333-333333333333";
+const SRC_ENQUEUE_FAIL = "cccccccc-4444-4444-8444-444444444444";
+const SRC_PREP_FAIL = "cccccccc-5555-4555-8555-555555555555";
+const SRC_ADOPTED = "cccccccc-6666-4666-8666-666666666666";
+const SRC_QUOTA = "cccccccc-7777-4777-8777-777777777777";
+const SRC_FORGED = "cccccccc-8888-4888-8888-888888888888";
+const QUOTA_EXISTING = "dddddddd-1111-4111-8111-111111111111";
+
+const PGLITE_TIMEOUT = 120_000;
+let pgliteReady = true;
+
+type Db = typeof import("../../db/client").dbWrite;
+let dbWrite: Db;
+let closeDb: (() => Promise<void>) | undefined;
+let agentSandboxes: typeof import("../../db/schemas/agent-sandboxes").agentSandboxes;
+let jobs: typeof import("../../db/schemas/jobs").jobs;
+let apiKeys: typeof import("../../db/schemas/api-keys").apiKeys;
+let svc: typeof import("./agent-tier-upgrade-target");
+
+beforeAll(async () => {
+  try {
+    const client = await import("../../db/client");
+    dbWrite = client.dbWrite;
+    closeDb = client.closeDatabaseConnectionsForTests;
+
+    const { organizations } = await import("../../db/schemas/organizations");
+    const { users } = await import("../../db/schemas/users");
+    const { userCharacters } = await import("../../db/schemas/user-characters");
+    ({ agentSandboxes } = await import("../../db/schemas/agent-sandboxes"));
+    ({ apiKeys } = await import("../../db/schemas/api-keys"));
+    // jobs → generations → usage_records is a pure FK chain; the extra tables
+    // exist only so the pushed schema's constraints resolve.
+    const { usageRecords } = await import("../../db/schemas/usage-records");
+    const { generations } = await import("../../db/schemas/generations");
+    ({ jobs } = await import("../../db/schemas/jobs"));
+    const { pushSchema } = await import("../../db/push-schema-for-tests");
+    const { apply } = await pushSchema(
+      {
+        organizations,
+        users,
+        userCharacters,
+        agentSandboxes,
+        apiKeys,
+        usageRecords,
+        generations,
+        jobs,
+      } as never,
+      dbWrite as never,
+    );
+    await apply();
+
+    await dbWrite.insert(organizations).values([
+      { id: ORG_A, name: "Org A", slug: "org-a", credit_balance: "100" },
+      { id: ORG_QUOTA, name: "Org Quota", slug: "org-quota", credit_balance: "100" },
+    ]);
+    await dbWrite.insert(users).values([
+      {
+        id: USER_A,
+        email: "owner-a@test.test",
+        organization_id: ORG_A,
+        role: "owner",
+        steward_user_id: `steward-${USER_A}`,
+      },
+      {
+        id: USER_QUOTA,
+        email: "owner-quota@test.test",
+        organization_id: ORG_QUOTA,
+        role: "owner",
+        steward_user_id: `steward-${USER_QUOTA}`,
+      },
+    ]);
+    await dbWrite.insert(userCharacters).values([
+      {
+        id: CHARACTER_A,
+        organization_id: ORG_A,
+        user_id: USER_A,
+        name: "Aurora",
+        bio: ["An autonomous AI agent."],
+        character_data: { name: "Aurora", system: "Shared front persona." },
+      },
+    ]);
+    // Live sandbox that fills ORG_QUOTA's entire cap for the quota test.
+    await dbWrite.insert(agentSandboxes).values({
+      id: QUOTA_EXISTING,
+      organization_id: ORG_QUOTA,
+      user_id: USER_QUOTA,
+      agent_name: "Quota Filler",
+      execution_tier: "dedicated-always",
+      status: "running",
+      database_status: "none",
+    });
+
+    svc = await import("./agent-tier-upgrade-target");
+  } catch (error) {
+    pgliteReady = false;
+    console.error("[agent-tier-upgrade-target.test] setup failed — failing.", error);
+  }
+}, PGLITE_TIMEOUT);
+
+afterEach(() => {
+  prepDelayMs = 0;
+  prepFailNext = false;
+});
+
+function upgradeParams(sourceAgentId: string, overrides: Record<string, unknown> = {}) {
+  return {
+    sourceAgentId,
+    organizationId: ORG_A,
+    userId: USER_A,
+    agentName: `upgrade-of-${sourceAgentId.slice(0, 8)}`,
+    agentConfig: { character: { name: "Aurora" }, __agentUpgradedFrom: "forged-by-caller" },
+    environmentVars: { MY_CUSTOM_VAR: "keep-me" },
+    maxNonTerminalAgents: 50,
+    ...overrides,
+  };
+}
+
+async function targetsForSource(sourceAgentId: string) {
+  const rows = await dbWrite.select().from(agentSandboxes);
+  return rows.filter(
+    (row) =>
+      (row.agent_config as Record<string, unknown> | null)?.__agentUpgradedFrom === sourceAgentId &&
+      row.execution_tier === "dedicated-always",
+  );
+}
+
+async function jobsForAgent(agentId: string) {
+  return dbWrite.select().from(jobs).where(eq(jobs.agent_id, agentId));
+}
+
+/**
+ * Global no-dangling-credentials invariant: every `agent-sandbox:<id>` API key
+ * must belong to an EXISTING sandbox row. Candidates minted by losers/failed
+ * attempts are revoked, so keys for never-committed ids may not survive.
+ */
+async function expectNoOrphanAgentKeys() {
+  const keyRows = await dbWrite.select().from(apiKeys).where(like(apiKeys.name, "agent-sandbox:%"));
+  const sandboxIds = new Set((await dbWrite.select().from(agentSandboxes)).map((row) => row.id));
+  for (const key of keyRows) {
+    const boundId = key.name.slice("agent-sandbox:".length);
+    expect(sandboxIds.has(boundId)).toBe(true);
+  }
+}
+
+describe("createTierUpgradeTargetWithProvision — durable single-flight boundary", () => {
+  test(
+    "fresh mint commits target + prepared environment + provision job as one unit, through the canonical builder",
+    async () => {
+      expect(pgliteReady).toBe(true);
+
+      const result = await svc.createTierUpgradeTargetWithProvision(
+        upgradeParams(SRC_BASIC, { characterId: CHARACTER_A }),
+      );
+      expect(result.created).toBe(true);
+      if (!result.created) throw new Error("expected fresh mint");
+
+      const [target] = await targetsForSource(SRC_BASIC);
+      expect(target).toBeTruthy();
+      expect(target?.id).toBe(result.agent.id);
+
+      // Canonical-builder values: tier→status derivation, defaults, character
+      // ownership, and the reserved-namespace strip (the caller-forged marker
+      // was dropped; the server marker points at the real source).
+      expect(target?.execution_tier).toBe("dedicated-always");
+      expect(target?.status).toBe("pending");
+      expect(target?.database_status).toBe("none");
+      expect(target?.character_id).toBe(CHARACTER_A);
+      const config = target?.agent_config as Record<string, unknown>;
+      expect(config.__agentUpgradedFrom).toBe(SRC_BASIC);
+      expect(config.__agentCharacterOwnership).toBe("reuse-existing");
+      expect(config.character).toEqual({ name: "Aurora" });
+
+      // Environment prepared at creation — not patched in afterwards. BYO
+      // survives; platform identity binds to the NEW record.
+      const env = target?.environment_vars as Record<string, string>;
+      expect(env.MY_CUSTOM_VAR).toBe("keep-me");
+      expect(env.ELIZA_CLOUD_AGENT_ID).toBe(result.agent.id);
+      expect(env.ELIZA_API_TOKEN).toMatch(/^agent_/);
+
+      // The provision job committed with the target.
+      const jobRows = await jobsForAgent(result.agent.id);
+      expect(jobRows).toHaveLength(1);
+      expect(jobRows[0]?.type).toBe("agent_provision");
+      expect(jobRows[0]?.status).toBe("pending");
+      expect(result.job.id).toBe(jobRows[0]?.id ?? "");
+
+      // Exactly one credential set, bound to the committed target.
+      const keyRows = await dbWrite
+        .select()
+        .from(apiKeys)
+        .where(eq(apiKeys.name, `agent-sandbox:${result.agent.id}`));
+      expect(keyRows).toHaveLength(1);
+      await expectNoOrphanAgentKeys();
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a retry reattaches to durable state without invoking preparation at all",
+    async () => {
+      expect(pgliteReady).toBe(true);
+
+      const callsBefore = prepCalls;
+      const result = await svc.createTierUpgradeTargetWithProvision(upgradeParams(SRC_BASIC));
+      expect(result.created).toBe(false);
+      const [target] = await targetsForSource(SRC_BASIC);
+      expect(result.agent.id).toBe(target?.id ?? "");
+      // Reattach is read-only: no second preparation, no second job, no key churn.
+      expect(prepCalls).toBe(callsBefore);
+      expect(await jobsForAgent(result.agent.id)).toHaveLength(1);
+      const keyRows = await dbWrite
+        .select()
+        .from(apiKeys)
+        .where(eq(apiKeys.name, `agent-sandbox:${result.agent.id}`));
+      expect(keyRows).toHaveLength(1);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a burst of concurrent upgrades converges on one target, one job, one credential set",
+    async () => {
+      expect(pgliteReady).toBe(true);
+
+      const results = await Promise.all(
+        Array.from({ length: 6 }, () =>
+          svc.createTierUpgradeTargetWithProvision(upgradeParams(SRC_CONCURRENT)),
+        ),
+      );
+      const targetIds = new Set(results.map((result) => result.agent.id));
+      expect(targetIds.size).toBe(1);
+      expect(results.filter((result) => result.created)).toHaveLength(1);
+
+      const targets = await targetsForSource(SRC_CONCURRENT);
+      expect(targets).toHaveLength(1);
+      expect(await jobsForAgent(targets[0]!.id)).toHaveLength(1);
+      const keyRows = await dbWrite
+        .select()
+        .from(apiKeys)
+        .where(eq(apiKeys.name, `agent-sandbox:${targets[0]!.id}`));
+      expect(keyRows).toHaveLength(1);
+      // Losers' candidate credentials (minted for their own prospective ids)
+      // were revoked — nothing dangles.
+      await expectNoOrphanAgentKeys();
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a winner delayed >10s in credential minting yields to the concurrent request and reattaches — exactly one credential/environment mutation and one job",
+    async () => {
+      expect(pgliteReady).toBe(true);
+
+      // First caller stalls 10.5s inside preparation (longer than the removed
+      // 10s job-wait window that used to make losers take over); second caller
+      // runs at full speed and commits the durable target+job.
+      prepDelayMs = 10_500;
+      const delayed = svc.createTierUpgradeTargetWithProvision(upgradeParams(SRC_DELAYED));
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      const fast = await svc.createTierUpgradeTargetWithProvision(upgradeParams(SRC_DELAYED));
+      const late = await delayed;
+
+      expect(fast.created).toBe(true);
+      expect(late.created).toBe(false);
+      expect(late.agent.id).toBe(fast.agent.id);
+
+      const targets = await targetsForSource(SRC_DELAYED);
+      expect(targets).toHaveLength(1);
+      const target = targets[0]!;
+
+      // The stalled caller never wrote the winner's row: the environment still
+      // binds to the committed target id (a takeover would have stamped the
+      // loser's own prospective id), and the row was never updated post-insert.
+      const env = target.environment_vars as Record<string, string>;
+      expect(env.ELIZA_CLOUD_AGENT_ID).toBe(fast.agent.id);
+      expect(target.updated_at?.getTime()).toBe(target.created_at?.getTime() ?? Number.NaN);
+
+      expect(await jobsForAgent(target.id)).toHaveLength(1);
+      const keyRows = await dbWrite
+        .select()
+        .from(apiKeys)
+        .where(eq(apiKeys.name, `agent-sandbox:${target.id}`));
+      expect(keyRows).toHaveLength(1);
+      await expectNoOrphanAgentKeys();
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "an enqueue failure rolls the target back with the job and revokes the candidate credentials; the retry converges",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const { provisioningJobService } = await import("./provisioning-jobs");
+
+      const enqueueSpy = spyOn(provisioningJobService, "enqueueAgentProvisionOnceInTx");
+      enqueueSpy.mockImplementationOnce(async () => {
+        throw new Error("simulated enqueue failure inside the boundary");
+      });
+      try {
+        await expect(
+          svc.createTierUpgradeTargetWithProvision(upgradeParams(SRC_ENQUEUE_FAIL)),
+        ).rejects.toThrow("simulated enqueue failure inside the boundary");
+
+        // Atomic rollback: no half-created target a cleanup would have to
+        // delete, no job, no surviving candidate credentials.
+        expect(await targetsForSource(SRC_ENQUEUE_FAIL)).toHaveLength(0);
+        await expectNoOrphanAgentKeys();
+
+        // Retry (spy restored to the real implementation) converges cleanly.
+        const retry = await svc.createTierUpgradeTargetWithProvision(
+          upgradeParams(SRC_ENQUEUE_FAIL),
+        );
+        expect(retry.created).toBe(true);
+        expect(await targetsForSource(SRC_ENQUEUE_FAIL)).toHaveLength(1);
+        expect(await jobsForAgent(retry.agent.id)).toHaveLength(1);
+        await expectNoOrphanAgentKeys();
+      } finally {
+        enqueueSpy.mockRestore();
+      }
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a credential-mint failure leaves nothing durable; the retry converges",
+    async () => {
+      expect(pgliteReady).toBe(true);
+
+      prepFailNext = true;
+      await expect(
+        svc.createTierUpgradeTargetWithProvision(upgradeParams(SRC_PREP_FAIL)),
+      ).rejects.toThrow("simulated credential-mint failure");
+      expect(await targetsForSource(SRC_PREP_FAIL)).toHaveLength(0);
+      await expectNoOrphanAgentKeys();
+
+      const retry = await svc.createTierUpgradeTargetWithProvision(upgradeParams(SRC_PREP_FAIL));
+      expect(retry.created).toBe(true);
+      expect(await jobsForAgent(retry.agent.id)).toHaveLength(1);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a failing follow-up request can never remove a committed target owned by a live job (no compensation surface)",
+    async () => {
+      expect(pgliteReady).toBe(true);
+
+      const minted = await svc.createTierUpgradeTargetWithProvision(upgradeParams(SRC_ADOPTED));
+      expect(minted.created).toBe(true);
+      const jobBefore = await jobsForAgent(minted.agent.id);
+      expect(jobBefore).toHaveLength(1);
+
+      // Arm the prep seam to fail — a reattach must return BEFORE preparation,
+      // so the armed failure must never fire and nothing durable may change.
+      prepFailNext = true;
+      const callsBefore = prepCalls;
+      const reattach = await svc.createTierUpgradeTargetWithProvision(upgradeParams(SRC_ADOPTED));
+      expect(reattach.created).toBe(false);
+      expect(reattach.agent.id).toBe(minted.agent.id);
+      expect(prepCalls).toBe(callsBefore);
+      prepFailNext = false;
+
+      expect(await targetsForSource(SRC_ADOPTED)).toHaveLength(1);
+      expect(await jobsForAgent(minted.agent.id)).toHaveLength(1);
+      expect((await jobsForAgent(minted.agent.id))[0]?.id).toBe(jobBefore[0]?.id ?? "");
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "an over-quota upgrade is refused before any credential is minted",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const { AgentQuotaExceededError } = await import("./eliza-sandbox");
+
+      const callsBefore = prepCalls;
+      await expect(
+        svc.createTierUpgradeTargetWithProvision(
+          upgradeParams(SRC_QUOTA, {
+            organizationId: ORG_QUOTA,
+            userId: USER_QUOTA,
+            maxNonTerminalAgents: 1,
+          }),
+        ),
+      ).rejects.toBeInstanceOf(AgentQuotaExceededError);
+      // Phase-1 refusal: preparation never ran, so no key was minted at all.
+      expect(prepCalls).toBe(callsBefore);
+      expect(await targetsForSource(SRC_QUOTA)).toHaveLength(0);
+      await expectNoOrphanAgentKeys();
+    },
+    PGLITE_TIMEOUT,
+  );
+});
+
+describe("findLiveTierUpgradeTarget", () => {
+  test(
+    "returns the live dedicated target, and never a forged marker on a non-dedicated row",
+    async () => {
+      expect(pgliteReady).toBe(true);
+
+      const live = await svc.findLiveTierUpgradeTarget(ORG_A, SRC_BASIC);
+      expect(live?.id).toBe((await targetsForSource(SRC_BASIC))[0]?.id ?? "");
+
+      // A marker planted on a SHARED row (agent_config is PATCHable) must not
+      // read as a migration target — only dedicated-always rows own upgrades.
+      const FORGED = "dddddddd-2222-4222-8222-222222222222";
+      await dbWrite.insert(agentSandboxes).values({
+        id: FORGED,
+        organization_id: ORG_A,
+        user_id: USER_A,
+        agent_name: "Marker Forgery",
+        agent_config: { __agentUpgradedFrom: SRC_FORGED },
+        execution_tier: "shared",
+        status: "running",
+        database_status: "none",
+      });
+      expect(await svc.findLiveTierUpgradeTarget(ORG_A, SRC_FORGED)).toBeNull();
+    },
+    PGLITE_TIMEOUT,
+  );
+});
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+  mock.restore();
+});

--- a/packages/cloud/shared/src/lib/services/agent-tier-upgrade-target.ts
+++ b/packages/cloud/shared/src/lib/services/agent-tier-upgrade-target.ts
@@ -1,25 +1,54 @@
 /**
- * Atomically creates or rejoins the dedicated target for a shared-agent tier
- * upgrade. The route consumes this narrow persistence boundary so target
- * identity, quota enforcement, and concurrent request convergence share one
- * transaction without broadening the general sandbox lifecycle service.
+ * Single-flight mint of the dedicated target for a shared-agent tier upgrade
+ * (#15355, hardened in #15943). One boundary owns the WHOLE span — managed
+ * credential minting, environment preparation, target insertion, and the
+ * provision-job enqueue — so concurrent upgrade requests for one source agent
+ * converge on exactly one target, one prepared environment, and one job.
+ *
+ * The invariant that makes the compensation problem disappear: the target row
+ * and its provision job commit in ONE transaction under the per-source
+ * advisory lock. A failure anywhere in that transaction rolls back the target
+ * with the job, so there is never a committed target awaiting an enqueue that
+ * a cleanup path might delete out from under a live job — the delete path
+ * simply does not exist. Conversely every committed target is born with its
+ * full managed environment and an active provision job, so reattaching
+ * callers only ever read durable state; they never prepare credentials or
+ * write environment state of their own.
+ *
+ * Credential minting (the agent API key) cannot run inside the transaction:
+ * it goes through the api-keys service on its own connection, and against
+ * single-session PGlite a nested query would deadlock the open transaction.
+ * So preparation happens UNLOCKED against a pre-generated target id, and the
+ * locked transaction re-checks for a competing target before making anything
+ * durable. Two near-simultaneous fresh requests may therefore each mint a
+ * candidate key, but each key is bound to its caller's own prospective id —
+ * the loser's key never touches any row and is revoked on the spot, so the
+ * durable end state is always exactly one credential set for the one target.
+ *
+ * Consumed only by the upgrade-tier route (cloud/api), which resolves quota
+ * and identity-copy inputs before calling in.
  */
 
 import { and, desc, eq, inArray, sql } from "drizzle-orm";
+import type { DbTransaction } from "../../db/client";
 import { dbWrite } from "../../db/helpers";
-import { type AgentSandbox, type AgentSandboxStatus } from "../../db/repositories/agent-sandboxes";
-import { jobsRepository } from "../../db/repositories/jobs";
+import type { AgentSandbox, AgentSandboxStatus } from "../../db/repositories/agent-sandboxes";
+import type { Job } from "../../db/repositories/jobs";
 import { agentSandboxes } from "../../db/schemas/agent-sandboxes";
+import { logger } from "../utils/logger";
 import { encryptAgentEnvVarsForStorage } from "./agent-env-crypto";
-import {
-  AGENT_UPGRADED_FROM_KEY,
-  stripReservedElizaConfigKeys,
-  withReusedElizaCharacterOwnership,
-} from "./eliza-agent-config";
+import { apiKeysService } from "./api-keys";
+import { AGENT_UPGRADED_FROM_KEY } from "./eliza-agent-config";
 import { elizaAgentTierUpgradeAdvisoryLockSql } from "./eliza-provision-lock";
-import { AgentQuotaExceededError } from "./eliza-sandbox";
-import { JOB_TYPES } from "./provisioning-job-types";
+import { assertOrgAgentQuota, buildAgentSandboxInsertValues } from "./eliza-sandbox";
+import { prepareManagedElizaSharedEnvironment } from "./managed-eliza-config";
+import { provisioningJobService } from "./provisioning-jobs";
 
+/**
+ * Statuses under which an existing migration target still owns the upgrade.
+ * Matches the quota-counted set: any resource-holding target must be resumed
+ * or reattached to, never shadowed by a second mint.
+ */
 const LIVE_TARGET_STATUSES: AgentSandboxStatus[] = [
   "pending",
   "provisioning",
@@ -34,86 +63,186 @@ export interface CreateTierUpgradeTargetParams {
   userId: string;
   agentName: string;
   agentConfig?: Record<string, unknown>;
+  /** BYO env copied from the source row, already stripped of reserved platform keys. */
   environmentVars?: Record<string, string>;
   characterId?: string;
   maxNonTerminalAgents: number;
 }
 
-export async function createTierUpgradeTarget(
-  params: CreateTierUpgradeTargetParams,
-): Promise<{ agent: AgentSandbox; idempotent: boolean }> {
-  const environmentVars = params.environmentVars
-    ? await encryptAgentEnvVarsForStorage(params.organizationId, params.environmentVars)
-    : {};
-  const sanitizedConfig = stripReservedElizaConfigKeys(params.agentConfig);
-  const agentConfig = params.characterId
-    ? withReusedElizaCharacterOwnership(sanitizedConfig)
-    : sanitizedConfig;
+export type TierUpgradeTargetResult =
+  | { created: true; agent: AgentSandbox; job: Job }
+  | { created: false; agent: AgentSandbox };
 
-  return dbWrite.transaction(async (tx) => {
+function liveTargetWhere(organizationId: string, sourceAgentId: string) {
+  return and(
+    eq(agentSandboxes.organization_id, organizationId),
+    // The marker alone is not proof of a migration target: agent_config is
+    // PATCHable, so a marker planted on a non-dedicated row must never be
+    // reattached to — only a dedicated-always row can own the upgrade.
+    eq(agentSandboxes.execution_tier, "dedicated-always"),
+    inArray(agentSandboxes.status, LIVE_TARGET_STATUSES),
+    sql`${agentSandboxes.agent_config} ->> ${AGENT_UPGRADED_FROM_KEY} = ${sourceAgentId}`,
+  );
+}
+
+async function findLiveTargetInTx(
+  tx: DbTransaction,
+  organizationId: string,
+  sourceAgentId: string,
+): Promise<AgentSandbox | undefined> {
+  const [existing] = await tx
+    .select()
+    .from(agentSandboxes)
+    .where(liveTargetWhere(organizationId, sourceAgentId))
+    .orderBy(desc(agentSandboxes.created_at))
+    .limit(1);
+  return existing;
+}
+
+/**
+ * The org's live migration target for this shared agent, if one exists. Plain
+ * (unlocked) read for the route's reattach fast path; the single-flight mint
+ * repeats this lookup under the per-source advisory lock before inserting.
+ */
+export async function findLiveTierUpgradeTarget(
+  organizationId: string,
+  sourceAgentId: string,
+): Promise<AgentSandbox | null> {
+  const [existing] = await dbWrite
+    .select()
+    .from(agentSandboxes)
+    .where(liveTargetWhere(organizationId, sourceAgentId))
+    .orderBy(desc(agentSandboxes.created_at))
+    .limit(1);
+  return existing ?? null;
+}
+
+/**
+ * Best-effort teardown of the credentials prepared for a prospective target
+ * that never became durable (lost the mint race, or the mint transaction
+ * failed). The key is bound to the prospective id's name, so this can never
+ * touch a live target's credentials.
+ */
+async function revokeAbandonedTargetCredentials(prospectiveTargetId: string): Promise<void> {
+  try {
+    await apiKeysService.revokeForAgent(prospectiveTargetId);
+  } catch (error) {
+    // error-policy:J6 best-effort teardown — the key references a target id
+    // that never existed and is unreachable; the caller's primary outcome
+    // (reattach or the original failure) is what must surface.
+    logger.warn(
+      "[agent-tier-upgrade] Failed to revoke credentials of an abandoned target candidate",
+      {
+        prospectiveTargetId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+  }
+}
+
+/**
+ * Find-or-create the dedicated migration target for a shared agent, with its
+ * managed environment prepared and its provision job enqueued as one durable
+ * unit. Reattaching callers get `{ created: false }` with the existing target
+ * and cause no writes. Throws `AgentQuotaExceededError` when a fresh mint
+ * would exceed the org's non-terminal-agent cap.
+ */
+export async function createTierUpgradeTargetWithProvision(
+  params: CreateTierUpgradeTargetParams,
+): Promise<TierUpgradeTargetResult> {
+  // Phase 1 — reattach fast path and pre-mint quota refusal under the lock.
+  // Anything durable a previous winner committed is visible here, so retries
+  // and post-commit racers return without preparing any state of their own.
+  const preexisting = await dbWrite.transaction(async (tx) => {
     await tx.execute(
       elizaAgentTierUpgradeAdvisoryLockSql(params.organizationId, params.sourceAgentId),
     );
+    const existing = await findLiveTargetInTx(tx, params.organizationId, params.sourceAgentId);
+    if (existing) return existing;
+    // Refuse over-quota upgrades before any credential is minted. The locked
+    // insert transaction below re-asserts this authoritatively.
+    await assertOrgAgentQuota(tx, params.organizationId, params.maxNonTerminalAgents);
+    return undefined;
+  });
+  if (preexisting) return { created: false, agent: preexisting };
 
-    const [existing] = await tx
-      .select()
-      .from(agentSandboxes)
-      .where(
-        and(
-          eq(agentSandboxes.organization_id, params.organizationId),
-          eq(agentSandboxes.execution_tier, "dedicated-always"),
-          inArray(agentSandboxes.status, LIVE_TARGET_STATUSES),
-          sql`${agentSandboxes.agent_config} ->> ${AGENT_UPGRADED_FROM_KEY} = ${params.sourceAgentId}`,
-        ),
-      )
-      .orderBy(desc(agentSandboxes.created_at))
-      .limit(1);
-    if (existing) return { agent: existing, idempotent: true };
+  // Phase 2 — prepare the target's managed environment UNLOCKED against a
+  // pre-generated id. Mints the agent API key and the platform tokens the
+  // container boots with; nothing here references or mutates existing rows.
+  const targetId = crypto.randomUUID();
+  const prepared = await prepareManagedElizaSharedEnvironment({
+    existingEnv: params.environmentVars ?? {},
+    organizationId: params.organizationId,
+    userId: params.userId,
+    agentSandboxId: targetId,
+  });
+  const storedEnvironmentVars = await encryptAgentEnvVarsForStorage(
+    params.organizationId,
+    prepared.environmentVars,
+  );
 
-    const [{ count } = { count: 0 }] = await tx
-      .select({ count: sql<number>`count(*)::int` })
-      .from(agentSandboxes)
-      .where(
-        and(
-          eq(agentSandboxes.organization_id, params.organizationId),
-          sql`${agentSandboxes.pool_status} IS NULL`,
-          inArray(agentSandboxes.status, LIVE_TARGET_STATUSES),
-        ),
+  let result: TierUpgradeTargetResult;
+  try {
+    // Phase 3 — the durable single-flight boundary: re-check, quota-check,
+    // insert the target, and enqueue its provision job in ONE transaction
+    // under the per-source lock. A failure rolls back target and job together.
+    result = await dbWrite.transaction(async (tx) => {
+      await tx.execute(
+        elizaAgentTierUpgradeAdvisoryLockSql(params.organizationId, params.sourceAgentId),
       );
-    if (count >= params.maxNonTerminalAgents) {
-      throw new AgentQuotaExceededError(count, params.maxNonTerminalAgents);
-    }
 
-    const [created] = await tx
-      .insert(agentSandboxes)
-      .values({
-        organization_id: params.organizationId,
-        user_id: params.userId,
-        agent_name: params.agentName,
-        agent_config: {
-          ...agentConfig,
-          [AGENT_UPGRADED_FROM_KEY]: params.sourceAgentId,
-        },
-        environment_vars: environmentVars,
-        execution_tier: "dedicated-always",
-        status: "pending",
-        database_status: "none",
-        ...(params.characterId ? { character_id: params.characterId } : {}),
-      })
-      .returning();
-    if (!created) throw new Error("Failed to create tier-upgrade target");
-    return { agent: created, idempotent: false };
-  });
-}
+      const existing = await findLiveTargetInTx(tx, params.organizationId, params.sourceAgentId);
+      if (existing) return { created: false as const, agent: existing };
 
-/** Returns the active provision job created by a winning concurrent request. */
-export async function findActiveTierUpgradeProvisionJob(agentId: string, organizationId: string) {
-  const jobs = await jobsRepository.findByDataFieldForWrite({
-    type: JOB_TYPES.AGENT_PROVISION,
-    organizationId,
-    dataField: "agentId",
-    dataValue: agentId,
-    orderBy: "desc",
-  });
-  return jobs.find((job) => job.status === "pending" || job.status === "in_progress");
+      await assertOrgAgentQuota(tx, params.organizationId, params.maxNonTerminalAgents);
+
+      const canonical = buildAgentSandboxInsertValues({
+        organizationId: params.organizationId,
+        userId: params.userId,
+        agentName: params.agentName,
+        agentConfig: params.agentConfig,
+        environmentVars: storedEnvironmentVars,
+        executionTier: "dedicated-always",
+        ...(params.characterId ? { characterId: params.characterId } : {}),
+      });
+      const [created] = await tx
+        .insert(agentSandboxes)
+        .values({
+          ...canonical,
+          id: targetId,
+          agent_config: {
+            // The canonical builder strips the reserved `__agent` namespace
+            // from caller config; the upgraded-from marker is server-owned and
+            // re-applied on top so reattach lookups can find this target.
+            ...(canonical.agent_config ?? {}),
+            [AGENT_UPGRADED_FROM_KEY]: params.sourceAgentId,
+          },
+        })
+        .returning();
+      if (!created) throw new Error("Failed to create tier-upgrade target");
+
+      const { job } = await provisioningJobService.enqueueAgentProvisionOnceInTx(tx, {
+        agentId: created.id,
+        organizationId: params.organizationId,
+        userId: params.userId,
+        agentName: created.agent_name ?? created.id,
+      });
+
+      logger.info("[agent-tier-upgrade] Created migration target with provision job", {
+        sourceAgentId: params.sourceAgentId,
+        dedicatedAgentId: created.id,
+        orgId: params.organizationId,
+        jobId: job.id,
+      });
+      return { created: true as const, agent: created, job };
+    });
+  } catch (error) {
+    await revokeAbandonedTargetCredentials(targetId);
+    throw error;
+  }
+
+  // Lost the race between phases 1 and 3: another request committed the
+  // target first. Our prepared credentials were never referenced — drop them.
+  if (!result.created) await revokeAbandonedTargetCredentials(targetId);
+  return result;
 }

--- a/packages/cloud/shared/src/lib/services/eliza-provision-lock.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-provision-lock.ts
@@ -33,9 +33,13 @@ export function elizaAgentCreateAdvisoryLockSql(organizationId: string) {
 }
 
 /**
- * Per-source-agent tier-upgrade lock. The target service holds this across its
- * durable re-check and initial insert so concurrent requests can only observe
- * and reattach to the first request's target.
+ * Per-source-agent tier-upgrade lock. The target service holds this across
+ * the durable re-check, the target insert, AND the provision-job enqueue
+ * (one transaction, #15943) so concurrent requests can only observe and
+ * reattach to the first request's committed target-plus-job. Lock order:
+ * this lock is acquired BEFORE the per-agent provision lock (the job enqueue
+ * nests inside the tier-upgrade transaction); no path acquires them in the
+ * reverse order.
  */
 export function elizaAgentTierUpgradeAdvisoryLockSql(
   organizationId: string,

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -6,6 +6,7 @@
 import crypto from "node:crypto";
 import { isIP } from "node:net";
 import { and, desc, eq, inArray, sql } from "drizzle-orm";
+import type { DbTransaction } from "../../db/client";
 import { type Database, dbWrite } from "../../db/helpers";
 import { agentBillingRepository } from "../../db/repositories/agent-billing";
 import {
@@ -170,6 +171,66 @@ export class AgentQuotaExceededError extends Error {
     this.name = "AgentQuotaExceededError";
     this.count = count;
     this.max = max;
+  }
+}
+
+/**
+ * Canonical value builder for a fresh `agent_sandboxes` insert. Every create
+ * path — the sandbox service's own create/coding-container methods and the
+ * tier-upgrade target mint (#15943) — MUST assemble its insert through this
+ * function so config sanitization, character ownership, tier→status derivation,
+ * and column defaults cannot drift between paths. `environmentVars` is expected
+ * storage-ready (already passed through `encryptAgentEnvVarsForStorage`).
+ */
+export function buildAgentSandboxInsertValues(params: CreateAgentParams): NewAgentSandbox {
+  const sanitizedConfig = stripReservedElizaConfigKeys(params.agentConfig);
+  const agentConfig = params.characterId
+    ? withReusedElizaCharacterOwnership(sanitizedConfig)
+    : sanitizedConfig;
+
+  const executionTier: AgentExecutionTier = params.executionTier ?? "shared";
+  const status = executionTier === "shared" ? "running" : "pending";
+
+  return {
+    organization_id: params.organizationId,
+    user_id: params.userId,
+    agent_name: params.agentName,
+    agent_config: agentConfig,
+    environment_vars: params.environmentVars ?? {},
+    status,
+    execution_tier: executionTier,
+    database_status: "none",
+    ...(params.characterId && { character_id: params.characterId }),
+    ...(params.dockerImage && { docker_image: params.dockerImage }),
+  };
+}
+
+/**
+ * Enforce `maxNonTerminalAgents` for an org: count its quota-holding
+ * ({@link QUOTA_COUNTED_STATUSES}), non-pool sandboxes and throw
+ * {@link AgentQuotaExceededError} at/past the cap. MUST run inside a
+ * transaction that already holds an org-serializing advisory lock (the
+ * agent-create lock, or the tier-upgrade lock for a fixed source agent) so
+ * the count→insert is atomic — two concurrent creates can't both read
+ * `count = max-1` and both insert.
+ */
+export async function assertOrgAgentQuota(
+  tx: DbTransaction,
+  organizationId: string,
+  cap: number,
+): Promise<void> {
+  const [{ count } = { count: 0 }] = await tx
+    .select({ count: sql<number>`count(*)::int` })
+    .from(agentSandboxes)
+    .where(
+      and(
+        eq(agentSandboxes.organization_id, organizationId),
+        sql`${agentSandboxes.pool_status} IS NULL`,
+        inArray(agentSandboxes.status, QUOTA_COUNTED_STATUSES),
+      ),
+    );
+  if (count >= cap) {
+    throw new AgentQuotaExceededError(count, cap);
   }
 }
 
@@ -935,57 +996,6 @@ export class ElizaSandboxService {
 
   // Agent CRUD
 
-  private buildAgentInsertData(params: CreateAgentParams): NewAgentSandbox {
-    const sanitizedConfig = stripReservedElizaConfigKeys(params.agentConfig);
-    const agentConfig = params.characterId
-      ? withReusedElizaCharacterOwnership(sanitizedConfig)
-      : sanitizedConfig;
-
-    const executionTier: AgentExecutionTier = params.executionTier ?? "shared";
-    const status = executionTier === "shared" ? "running" : "pending";
-
-    return {
-      organization_id: params.organizationId,
-      user_id: params.userId,
-      agent_name: params.agentName,
-      agent_config: agentConfig,
-      environment_vars: params.environmentVars ?? {},
-      status,
-      execution_tier: executionTier,
-      database_status: "none",
-      ...(params.characterId && { character_id: params.characterId }),
-      ...(params.dockerImage && { docker_image: params.dockerImage }),
-    };
-  }
-
-  /**
-   * Enforce `maxNonTerminalAgents` for an org: count its quota-holding
-   * ({@link QUOTA_COUNTED_STATUSES}), non-pool sandboxes and throw
-   * {@link AgentQuotaExceededError} at/past the cap. MUST run inside a
-   * transaction that already holds the org's agent-create advisory lock so
-   * the count→insert is atomic — two concurrent creates can't both read
-   * `count = max-1` and both insert.
-   */
-  private async assertOrgAgentQuota(
-    tx: LifecycleTx,
-    organizationId: string,
-    cap: number,
-  ): Promise<void> {
-    const [{ count } = { count: 0 }] = await tx
-      .select({ count: sql<number>`count(*)::int` })
-      .from(agentSandboxes)
-      .where(
-        and(
-          eq(agentSandboxes.organization_id, organizationId),
-          sql`${agentSandboxes.pool_status} IS NULL`,
-          inArray(agentSandboxes.status, QUOTA_COUNTED_STATUSES),
-        ),
-      );
-    if (count >= cap) {
-      throw new AgentQuotaExceededError(count, cap);
-    }
-  }
-
   async createAgent(params: CreateAgentParams): Promise<{
     agent: AgentSandbox;
     idempotent: boolean;
@@ -1020,7 +1030,9 @@ export class ElizaSandboxService {
     if (!params.reuseExistingNonTerminal) {
       // Uncapped fast path for trusted internal multi-agent callers.
       if (params.maxNonTerminalAgents === undefined) {
-        const created = await agentSandboxesRepository.create(this.buildAgentInsertData(params));
+        const created = await agentSandboxesRepository.create(
+          buildAgentSandboxInsertValues(params),
+        );
         return { agent: created, idempotent: false };
       }
 
@@ -1031,11 +1043,11 @@ export class ElizaSandboxService {
       const cap = params.maxNonTerminalAgents;
       return dbWrite.transaction(async (tx) => {
         await tx.execute(elizaAgentCreateAdvisoryLockSql(params.organizationId));
-        await this.assertOrgAgentQuota(tx, params.organizationId, cap);
+        await assertOrgAgentQuota(tx, params.organizationId, cap);
 
         const [created] = await tx
           .insert(agentSandboxes)
-          .values(this.buildAgentInsertData(params))
+          .values(buildAgentSandboxInsertValues(params))
           .returning();
         if (!created) throw new Error("Failed to create agent record");
         return { agent: created, idempotent: false };
@@ -1075,12 +1087,12 @@ export class ElizaSandboxService {
       // (#11023 residual). Enforce the same per-org ceiling, still under the
       // org advisory lock.
       if (params.maxNonTerminalAgents !== undefined) {
-        await this.assertOrgAgentQuota(tx, params.organizationId, params.maxNonTerminalAgents);
+        await assertOrgAgentQuota(tx, params.organizationId, params.maxNonTerminalAgents);
       }
 
       const [created] = await tx
         .insert(agentSandboxes)
-        .values(this.buildAgentInsertData(params))
+        .values(buildAgentSandboxInsertValues(params))
         .returning();
       if (!created) throw new Error("Failed to create agent record");
       return { agent: created, idempotent: false };
@@ -1149,7 +1161,7 @@ export class ElizaSandboxService {
       // the org lock so the count→insert is atomic against concurrent creates.
       // Trusted internal callers pass no cap and stay uncapped.
       if (createParams.maxNonTerminalAgents !== undefined) {
-        await this.assertOrgAgentQuota(
+        await assertOrgAgentQuota(
           tx,
           createParams.organizationId,
           createParams.maxNonTerminalAgents,
@@ -1158,7 +1170,7 @@ export class ElizaSandboxService {
 
       const [created] = await tx
         .insert(agentSandboxes)
-        .values(this.buildAgentInsertData(createParams))
+        .values(buildAgentSandboxInsertValues(createParams))
         .returning();
       if (!created) throw new Error("Failed to create coding-container agent record");
       return { agent: created, idempotent: false };
@@ -1720,7 +1732,7 @@ export class ElizaSandboxService {
         //
         // Non-docker providers (local-docker, memory) have no node concept and
         // are unaffected. This does NOT touch the shared-tier insert path
-        // (buildAgentInsertData), which is running-with-null-node BY DESIGN.
+        // (buildAgentSandboxInsertValues), which is running-with-null-node BY DESIGN.
         if (isDockerBackedMetadata(handle.metadata) && !dockerMeta?.nodeId) {
           logger.warn(
             "[agent-sandbox] Refusing to flip running: docker-backed handle has no durable node_id",

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -917,6 +917,24 @@ export class ProvisioningJobService {
       await assertSafeOutboundUrl(opts.webhookUrl);
     }
 
+    return await dbWrite.transaction(async (tx) => this.enqueueLifecycleJobInTx(tx, opts));
+  }
+
+  /**
+   * Transaction-scoped body of {@link enqueueLifecycleJob} for callers that
+   * must couple the enqueue to other writes in ONE transaction (the
+   * tier-upgrade single-flight boundary creates the sandbox row and its
+   * provision job atomically, #15943). Runs entirely on the caller's `tx`:
+   * a sandbox row inserted earlier in the same transaction is visible to the
+   * existence check, and a rollback discards the job together with it. The
+   * caller must pass any `webhookUrl` through {@link assertSafeOutboundUrl}
+   * BEFORE opening the transaction — URL validation resolves DNS and must not
+   * run while the transaction (and its advisory locks) are held open.
+   */
+  private async enqueueLifecycleJobInTx<TData extends object>(
+    tx: DbTransaction,
+    opts: LifecycleJobOptions<TData>,
+  ): Promise<{ job: Job; created: boolean }> {
     const newJob: NewJob = {
       type: opts.jobType,
       status: "pending",
@@ -929,75 +947,73 @@ export class ProvisioningJobService {
       estimated_completion_at: new Date(Date.now() + opts.estimatedDurationMs),
     };
 
-    return await dbWrite.transaction(async (tx) => {
-      await tx.execute(elizaProvisionAdvisoryLockSql(opts.organizationId, opts.agentId));
+    await tx.execute(elizaProvisionAdvisoryLockSql(opts.organizationId, opts.agentId));
 
-      const [sandbox] = await tx
-        .select({
-          id: agentSandboxes.id,
-          status: agentSandboxes.status,
-          updated_at: agentSandboxes.updated_at,
-        })
-        .from(agentSandboxes)
-        .where(
-          and(
-            eq(agentSandboxes.id, opts.agentId),
-            eq(agentSandboxes.organization_id, opts.organizationId),
-          ),
-        )
-        .limit(1);
+    const [sandbox] = await tx
+      .select({
+        id: agentSandboxes.id,
+        status: agentSandboxes.status,
+        updated_at: agentSandboxes.updated_at,
+      })
+      .from(agentSandboxes)
+      .where(
+        and(
+          eq(agentSandboxes.id, opts.agentId),
+          eq(agentSandboxes.organization_id, opts.organizationId),
+        ),
+      )
+      .limit(1);
 
-      if (!sandbox) {
-        throw new Error("Agent not found");
-      }
+    if (!sandbox) {
+      throw new Error("Agent not found");
+    }
 
-      opts.validateSandbox?.(sandbox);
+    opts.validateSandbox?.(sandbox);
 
-      const [existing] = await tx
-        .select()
-        .from(jobs)
-        .where(
-          and(
-            eq(jobs.type, opts.jobType),
-            eq(jobs.organization_id, opts.organizationId),
-            eq(jobs.agent_id, opts.agentId),
-            ...(opts.idempotencyPredicates ?? []),
-            sql`${jobs.status} IN ('pending', 'in_progress')`,
-          ),
-        )
-        .orderBy(desc(jobs.created_at))
-        .limit(1);
+    const [existing] = await tx
+      .select()
+      .from(jobs)
+      .where(
+        and(
+          eq(jobs.type, opts.jobType),
+          eq(jobs.organization_id, opts.organizationId),
+          eq(jobs.agent_id, opts.agentId),
+          ...(opts.idempotencyPredicates ?? []),
+          sql`${jobs.status} IN ('pending', 'in_progress')`,
+        ),
+      )
+      .orderBy(desc(jobs.created_at))
+      .limit(1);
 
-      const logFields = {
-        agentId: opts.agentId,
-        orgId: opts.organizationId,
-        ...(opts.logExtras ?? {}),
-      };
+    const logFields = {
+      agentId: opts.agentId,
+      orgId: opts.organizationId,
+      ...(opts.logExtras ?? {}),
+    };
 
-      if (existing) {
-        const hydrated = await hydrateJob(existing);
-        opts.validateReuse?.(hydrated);
-        logger.info(`[provisioning-jobs] Reusing active ${opts.logName} job`, {
-          jobId: existing.id,
-          ...logFields,
-        });
-        return { job: hydrated, created: false };
-      }
-
-      await opts.beforeInsert?.(tx, sandbox);
-
-      const [job] = await tx
-        .insert(jobs)
-        .values(await prepareJobInsertData(newJob))
-        .returning();
-
-      logger.info(`[provisioning-jobs] Enqueued ${opts.logName} job`, {
-        jobId: job.id,
+    if (existing) {
+      const hydrated = await hydrateJob(existing);
+      opts.validateReuse?.(hydrated);
+      logger.info(`[provisioning-jobs] Reusing active ${opts.logName} job`, {
+        jobId: existing.id,
         ...logFields,
       });
+      return { job: hydrated, created: false };
+    }
 
-      return { job: await hydrateJob(job), created: true };
+    await opts.beforeInsert?.(tx, sandbox);
+
+    const [job] = await tx
+      .insert(jobs)
+      .values(await prepareJobInsertData(newJob))
+      .returning();
+
+    logger.info(`[provisioning-jobs] Enqueued ${opts.logName} job`, {
+      jobId: job.id,
+      ...logFields,
     });
+
+    return { job: await hydrateJob(job), created: true };
   }
 
   /**
@@ -1023,8 +1039,48 @@ export class ProvisioningJobService {
     webhookUrl?: string;
     expectedUpdatedAt?: Date | string | null;
   }): Promise<EnqueueAgentProvisionResult> {
+    return this.enqueueLifecycleJob<AgentProvisionJobData>(
+      this.agentProvisionLifecycleOptions(params),
+    );
+  }
+
+  /**
+   * Transaction-scoped variant of {@link enqueueAgentProvisionOnce} for
+   * callers that must make the provision job durable ATOMICALLY with other
+   * writes in the same transaction — the tier-upgrade single-flight boundary
+   * inserts the target sandbox row and this job as one commit, so an enqueue
+   * failure can never strand a committed target without a job, and a target
+   * referenced by a committed job can never be compensation-deleted (#15943).
+   * No webhook support: URL validation resolves DNS and must not run inside an
+   * open transaction. The caller must already hold a lock that serializes this
+   * agent's creation; the per-(org,agent) provision advisory lock is still
+   * acquired here (lock order: caller's org-scoped lock → provision lock).
+   */
+  async enqueueAgentProvisionOnceInTx(
+    tx: DbTransaction,
+    params: {
+      agentId: string;
+      organizationId: string;
+      userId: string;
+      agentName: string;
+    },
+  ): Promise<EnqueueAgentProvisionResult> {
+    return this.enqueueLifecycleJobInTx<AgentProvisionJobData>(
+      tx,
+      this.agentProvisionLifecycleOptions(params),
+    );
+  }
+
+  private agentProvisionLifecycleOptions(params: {
+    agentId: string;
+    organizationId: string;
+    userId: string;
+    agentName: string;
+    webhookUrl?: string;
+    expectedUpdatedAt?: Date | string | null;
+  }): LifecycleJobOptions<AgentProvisionJobData> {
     const expected = params.expectedUpdatedAt;
-    return this.enqueueLifecycleJob<AgentProvisionJobData>({
+    return {
       jobType: JOB_TYPES.AGENT_PROVISION,
       jobData: {
         agentId: params.agentId,
@@ -1056,7 +1112,7 @@ export class ProvisioningJobService {
             }
           }
         : undefined,
-    });
+    };
   }
 
   /**


### PR DESCRIPTION
Fixes #15943

## Problem

`#15929` serialized only the migration-target lookup+insert: the advisory lock was released when `createTierUpgradeTarget` committed, while managed credential minting, environment writes, the worker-health rollback delete, and `enqueueAgentProvisionOnce` stayed route-level work. A losing concurrent request polled 10s for a job, then independently minted credentials and overwrote the target's environment (a second `createForAgent` for the same target revokes-by-name, so interleaved writes could leave the row pointing at a revoked key). The fresh-target compensation wrapper deleted the target on any create→enqueue throw — including after an enqueue that durably committed, deleting a target owned by a live job. The target insert also hand-assembled `agentSandboxes` values instead of using the canonical builder.

## Fix

**One durable single-flight boundary** — `createTierUpgradeTargetWithProvision` (`packages/cloud/shared/src/lib/services/agent-tier-upgrade-target.ts`) now owns the whole span:

- **Phase 1 (locked tx):** reattach fast-path + pre-mint quota refusal under the per-source `pg_advisory_xact_lock`. Anything a winner committed is visible here, so retries return without preparing any state.
- **Phase 2 (unlocked):** managed environment prepared against a **pre-generated target id** (the api-key mint runs on its own connection and cannot live inside a transaction — single-session PGlite would deadlock). Two near-simultaneous fresh callers can each mint a *candidate* key, but each key is bound to its caller's own prospective id — never the winner's target.
- **Phase 3 (locked tx, the boundary):** re-check → quota assert (`assertOrgAgentQuota`, now shared) → target insert through the **canonical builder** (`buildAgentSandboxInsertValues`, extracted from `ElizaSandboxService` and used by every create path) with the fully-prepared, storage-encrypted environment → **provision job insert in the same transaction** via new `provisioningJobService.enqueueAgentProvisionOnceInTx` (nested per-agent provision lock; lock order tier-upgrade → provision documented in `eliza-provision-lock.ts`).

Consequences:

- **Target + job are atomic.** An enqueue failure rolls the target back with it, so the compensation delete (`withUpgradeOrphanCleanup` + the worker-health rollback delete) is **removed entirely** — there is no path that can delete a target referenced by a committed job. An ambiguous commit surfaces as an error; the retry reattaches to the durable pair.
- **Losers only reattach to durable state.** The 10s `waitForConcurrentProvisionJob` poll is gone; a committed target always has its job. Race losers' candidate credentials are revoked on the spot (J6, keyed on their own prospective id). Reattach never prepares credentials or writes environment state — re-arming a dead job is safe because the row's environment was complete at birth.
- **Worker health** is checked before anything durable is minted (route), so a dead worker creates nothing at all.
- Route (`packages/cloud/api/v1/eliza/agents/[agentId]/upgrade-tier/route.ts`) keeps only HTTP mapping: both the pre-checked reattach and the race-loser funnel through one `respondToLiveTarget` (running → 200; stopped/sleeping → credit gate; else idempotent re-enqueue → 202).

## Acceptance criteria → proof

| Criterion | Where proven |
|---|---|
| One boundary owns creation→prep→enqueue | lock-span suite asserts the boundary tx runs `lock → re-check → quota → target insert → provision lock → job insert` as statements of ONE transaction |
| Losers never mint/overwrite after a timeout | service test: winner delayed **10.5s** in credential minting; the concurrent request commits; the delayed caller reattaches (`created:false`), row env still binds the committed id, `updated_at == created_at`, exactly 1 key/1 job |
| Ambiguous enqueue failure cannot delete an adopted target | enqueue forced to throw inside the boundary → full rollback (no target/job/key residue), retry converges; a failing follow-up on an existing target+job changes nothing (no delete surface exists) |
| Canonical sandbox builder | `buildAgentSandboxInsertValues` extracted + used by both paths; service test asserts tier→status derivation, character ownership, reserved-namespace strip (caller-forged `__agentUpgradedFrom` dropped, server marker applied) |
| >10s delayed-winner concurrency regression | `agent-tier-upgrade-target.test.ts` "winner delayed >10s…" (real PGlite) |
| Insert-to-enqueue failure regression | `agent-tier-upgrade-target.test.ts` "an enqueue failure rolls the target back…" |
| Structured logs + real DB rows from a concurrent run | evidence below |

## Evidence

**Concurrent request run (5 parallel upgrades, fully unmocked service against PGlite) — structured logs + real DB rows:**

<details><summary>Run transcript: 5 concurrent requests → 1 target, 1 job, 1 credential set; 4 losers revoke their candidates</summary>

```
=== five concurrent upgrade-tier requests for one source agent ===
[provisioning-jobs] Enqueued agent_provision job {
  jobId: "ebcfb9a4-3617-4de3-b2a6-4ff22f97769a",
  agentId: "1cc40a86-1f5f-4316-a5b4-d7c9381f8f52",
  orgId: "11111111-1111-4111-8111-111111111111",
}
[agent-tier-upgrade] Created migration target with provision job {
  sourceAgentId: "cccccccc-1111-4111-8111-111111111111",
  dedicatedAgentId: "1cc40a86-1f5f-4316-a5b4-d7c9381f8f52",
  orgId: "11111111-1111-4111-8111-111111111111",
  jobId: "ebcfb9a4-3617-4de3-b2a6-4ff22f97769a",
}
[ApiKeys] Invalidated API key + inference auth-context cache   <- x4: each loser
[ApiKeys] Invalidated API key + inference auth-context cache      revokes its own
[ApiKeys] Invalidated API key + inference auth-context cache      candidate key
[ApiKeys] Invalidated API key + inference auth-context cache

=== per-request outcomes ===
request[0]: created=true  targetId=1cc40a86-... jobId=ebcfb9a4-...
request[1]: created=false targetId=1cc40a86-...
request[2]: created=false targetId=1cc40a86-...
request[3]: created=false targetId=1cc40a86-...
request[4]: created=false targetId=1cc40a86-...

=== agent_sandboxes rows ===
{
  id: "1cc40a86-1f5f-4316-a5b4-d7c9381f8f52",
  execution_tier: "dedicated-always",
  status: "pending",
  upgraded_from: "cccccccc-1111-4111-8111-111111111111",
  env_ELIZA_CLOUD_AGENT_ID: "1cc40a86-1f5f-4316-a5b4-d7c9381f8f52",   <- env born bound to the row
  env_ELIZA_API_TOKEN_prefix: "agent_027e25",
  env_MY_CUSTOM_VAR: "keep-me",                                        <- BYO env survives
  created_at: "2026-07-10T09:38:28.481Z",
  updated_at: "2026-07-10T09:38:28.481Z",                              <- never updated post-insert
}

=== jobs rows ===
{
  id: "ebcfb9a4-3617-4de3-b2a6-4ff22f97769a",
  type: "agent_provision",
  status: "pending",
  agent_id: "1cc40a86-1f5f-4316-a5b4-d7c9381f8f52",
  organization_id: "11111111-1111-4111-8111-111111111111",
}

=== api_keys rows (agent-sandbox:*) ===
{
  name: "agent-sandbox:1cc40a86-1f5f-4316-a5b4-d7c9381f8f52",          <- exactly ONE key,
  is_active: true,                                                     <- bound to the target
  key_prefix: "eliza_0fcc35",
}
```
</details>

**Test transcripts:**

<details><summary>Service single-flight suite (real PGlite, real repositories/services) — 9 pass, includes 10.5s delayed-winner run</summary>

```
$ cd packages/cloud/shared && bun test src/lib/services/agent-tier-upgrade-target.test.ts
bun test v1.4.0-canary.1

 9 pass
 0 fail
 90 expect() calls
Ran 9 tests across 1 file. [23.01s]
```

Tests: fresh mint commits target+env+job as one unit through the canonical builder · retry reattaches without invoking preparation · 6-way concurrent burst converges on 1 target/1 job/1 credential set (no orphan keys) · winner delayed **>10s** in credential minting yields and reattaches (exactly one credential/environment mutation and one job) · enqueue failure rolls target back with the job, candidate credentials revoked, retry converges · credential-mint failure leaves nothing durable, retry converges · failing follow-up can never remove a committed target owned by a live job · over-quota refused before any credential is minted · `findLiveTierUpgradeTarget` ignores forged markers on non-dedicated rows.
</details>

<details><summary>Lock-span regression suite (SQL-capture; catches exactly the #15929 shape) — 3 pass</summary>

```
$ cd packages/cloud/shared && bun test src/lib/services/agent-tier-upgrade-target-lock.test.ts
bun test v1.4.0-canary.1

 3 pass
 0 fail
 22 expect() calls
Ran 3 tests across 1 file. [1.3s]
```

Asserts the boundary transaction's statement order is `tier-upgrade lock → live-target re-check → quota count → target insert → provision lock(target id) → sandbox probe → job reuse check → job insert` — hoist the enqueue out of the transaction, drop either lock, or reorder the re-check and this fails (single-session PGlite cannot catch this; see the suite header).
</details>

<details><summary>Existing route contract suite (unchanged, real PGlite through the real route) — 11 pass; wider touched-area sweep — 222 pass</summary>

```
$ cd packages/cloud/api && bun test __tests__/eliza-agents-upgrade-tier.test.ts
 11 pass
 0 fail
 83 expect() calls
Ran 11 tests across 1 file. [4.69s]

$ cd packages/cloud/shared && bun test --isolate src/lib/services/agent-tier-upgrade-target.test.ts \
    src/lib/services/agent-tier-upgrade-target-lock.test.ts \
    src/lib/services/eliza-sandbox-create-idempotency.test.ts src/lib/services/eliza-sandbox.test.ts \
    src/lib/services/provisioning-jobs-*.test.ts src/lib/services/eliza-sandbox-dedicated-bootstrap.test.ts \
    src/lib/services/eliza-sandbox-shared-billing.test.ts
 222 pass
 0 fail
Ran 222 tests across 18 files. [82.82s]
```
</details>

**Verification:** `tsc --noEmit` clean for `packages/cloud/shared` and `packages/cloud/api` · `biome check` clean on all touched files · `bun run audit:error-policy-ratchet` → "no new fallback-slop in touched files" (the removed J6 compensation catch is gone with its path; remaining J5/J6 annotations carried over).

**Evidence rows N/A:** UI screenshots/video — N/A, backend-only change with no rendered surface. Real-LLM trajectories — N/A, no agent/action/provider/prompt/model behavior touched. Per-platform capture — N/A, cloud backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Evidence checklist

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only cloud API/shared service change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only cloud API/shared service change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend-only cloud API/shared service change with no user-facing flow to record.
<!-- evidence-row:backend-logs -->
- [x] Concurrent request run, service suite, lock-span suite, route suite, and touched-area sweep logs are embedded in the PR body: https://github.com/elizaOS/eliza/pull/16042
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, model, or scenario behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Real PGlite rows and provisioning artifacts are embedded in the PR body; changed files are visible at https://github.com/elizaOS/eliza/pull/16042/files
