### PR TITLE
fix(scenarios): complete credentialed live lanes

### DIFF
--- a/.github/workflows/live-scenarios.yml
+++ b/.github/workflows/live-scenarios.yml
@@ -139,10 +139,17 @@ jobs:
 
       - name: Build live scenario runtime packages
         id: build
-        # The live runner executes TypeScript sources directly, but its workspace
-        # dependencies export dist/* entry points. Building the Turbo dependency
-        # closure keeps those transitive exports available after the deliberately
-        # script-free install without duplicating the package graph here.
+        # The live runner executes TypeScript sources directly, but several
+        # workspace packages intentionally export dist/* entry points. Because
+        # dependency installation ignores postinstall scripts, build only the
+        # packages that the live scenario runtime imports through those exports.
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
         run: |
           echo "::group::Build packages/core"
           bun run --cwd packages/core build

--- a/.github/workflows/live-scenarios.yml
+++ b/.github/workflows/live-scenarios.yml
@@ -139,17 +139,10 @@ jobs:
 
       - name: Build live scenario runtime packages
         id: build
-        # The live runner executes TypeScript sources directly, but several
-        # workspace packages intentionally export dist/* entry points. Because
-        # dependency installation ignores postinstall scripts, build only the
-        # packages that the live scenario runtime imports through those exports.
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+        # The live runner executes TypeScript sources directly, but its workspace
+        # dependencies export dist/* entry points. Building the Turbo dependency
+        # closure keeps those transitive exports available after the deliberately
+        # script-free install without duplicating the package graph here.
         run: |
           echo "::group::Build packages/core"
           bun run --cwd packages/core build
@@ -243,6 +236,10 @@ jobs:
       - name: Run EA + connector live scenarios
         id: run
         env:
+          # The runner and ordinary workspace dependencies stay on checkout
+          # sources; generated/native and dist-only artifacts come from the
+          # dependency-closure build above.
+          NODE_OPTIONS: "--conditions=eliza-source"
           # LLM providers
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
@@ -305,6 +302,7 @@ jobs:
       - name: Run plugin-health live scenarios
         id: run-health
         env:
+          NODE_OPTIONS: "--conditions=eliza-source"
           # LLM providers
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
@@ -331,6 +329,7 @@ jobs:
         id: run-app-control
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         env:
+          NODE_OPTIONS: "--conditions=eliza-source"
           # LLM providers
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}

--- a/bun.lock
+++ b/bun.lock
@@ -107,6 +107,7 @@
         "@elizaos/plugin-anthropic": "workspace:*",
         "@elizaos/plugin-aosp-local-inference": "workspace:*",
         "@elizaos/plugin-app-control": "workspace:*",
+        "@elizaos/plugin-app-manager": "workspace:*",
         "@elizaos/plugin-background-runner": "workspace:*",
         "@elizaos/plugin-birdclaw": "workspace:*",
         "@elizaos/plugin-browser": "workspace:*",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -300,6 +300,7 @@
     "@elizaos/plugin-anthropic": "workspace:*",
     "@elizaos/plugin-aosp-local-inference": "workspace:*",
     "@elizaos/plugin-app-control": "workspace:*",
+    "@elizaos/plugin-app-manager": "workspace:*",
     "@elizaos/plugin-background-runner": "workspace:*",
     "@elizaos/plugin-browser": "workspace:*",
     "@elizaos/plugin-capacitor-bridge": "workspace:*",

--- a/packages/scripts/__tests__/live-scenarios-workflow.test.ts
+++ b/packages/scripts/__tests__/live-scenarios-workflow.test.ts
@@ -1,6 +1,7 @@
 /**
- * Pins the credentialed scenario workflow's clean-checkout build prerequisites
- * to every dist-exported package imported before scenario selection.
+ * Ensures the credentialed scenario workflow builds the scenario runner's full
+ * workspace dependency closure, including dynamically loaded API libraries,
+ * before launching the CLI from a clean checkout.
  */
 import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
@@ -9,17 +10,38 @@ import { fileURLToPath } from "node:url";
 const workflowPath = fileURLToPath(
   new URL("../../../.github/workflows/live-scenarios.yml", import.meta.url),
 );
+const agentPackagePath = fileURLToPath(
+  new URL("../../agent/package.json", import.meta.url),
+);
 
-test("builds the local-inference voice-workbench export before the scenario CLI starts", () => {
+test("builds the scenario runner dependency closure before the scenario CLI starts", () => {
   const workflow = readFileSync(workflowPath, "utf8");
-  expect(workflow).toMatch(
-    /package_dirs=\([\s\S]*plugins\/plugin-local-inference[\s\S]*\)[\s\S]*for package_dir in "\$\{package_dirs\[@\]\}"/,
+  const buildCommand =
+    "node packages/scripts/run-turbo.mjs run build --filter=@elizaos/scenario-runner... --concurrency=8";
+  const runStep = "- name: Run EA + connector live scenarios";
+
+  expect(workflow).toContain(buildCommand);
+  expect(workflow.indexOf(buildCommand)).toBeLessThan(
+    workflow.indexOf(runStep),
+  );
+  expect(workflow).not.toMatch(
+    /package_dirs=\([\s\S]*for package_dir in "\$\{package_dirs\[@\]\}"/,
   );
 });
 
-test("builds the blocker engine imported by personal-assistant scenarios", () => {
+test("runs every live scenario root against workspace source exports", () => {
   const workflow = readFileSync(workflowPath, "utf8");
-  expect(workflow).toMatch(
-    /package_dirs=\([\s\S]*plugins\/plugin-blocker[\s\S]*\)[\s\S]*for package_dir in "\$\{package_dirs\[@\]\}"/,
+  const sourceConditionEntries = [
+    ...workflow.matchAll(/NODE_OPTIONS: "--conditions=eliza-source"/g),
+  ];
+  expect(sourceConditionEntries).toHaveLength(3);
+});
+
+test("includes the dynamically loaded app manager in the agent build graph", () => {
+  const packageJson = JSON.parse(readFileSync(agentPackagePath, "utf8")) as {
+    dependencies?: Record<string, string>;
+  };
+  expect(packageJson.dependencies?.["@elizaos/plugin-app-manager"]).toBe(
+    "workspace:*",
   );
 });

--- a/packages/scripts/__tests__/live-scenarios-workflow.test.ts
+++ b/packages/scripts/__tests__/live-scenarios-workflow.test.ts
@@ -1,7 +1,7 @@
 /**
- * Ensures the credentialed scenario workflow builds the scenario runner's full
- * workspace dependency closure, including dynamically loaded API libraries,
- * before launching the CLI from a clean checkout.
+ * Pins the credentialed scenario workflow's clean-checkout build prerequisites
+ * to every dist-exported package imported before scenario selection, and the
+ * source-export conditions each live lane runs under.
  */
 import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
@@ -14,18 +14,18 @@ const agentPackagePath = fileURLToPath(
   new URL("../../agent/package.json", import.meta.url),
 );
 
-test("builds the scenario runner dependency closure before the scenario CLI starts", () => {
+test("builds the dist-exported runtime packages before the scenario CLI starts", () => {
   const workflow = readFileSync(workflowPath, "utf8");
-  const buildCommand =
-    "node packages/scripts/run-turbo.mjs run build --filter=@elizaos/scenario-runner... --concurrency=8";
   const runStep = "- name: Run EA + connector live scenarios";
 
-  expect(workflow).toContain(buildCommand);
-  expect(workflow.indexOf(buildCommand)).toBeLessThan(
-    workflow.indexOf(runStep),
+  expect(workflow).toMatch(
+    /package_dirs=\([\s\S]*plugins\/plugin-local-inference[\s\S]*plugins\/plugin-app-control[\s\S]*plugins\/plugin-health[\s\S]*\)[\s\S]*for package_dir in "\$\{package_dirs\[@\]\}"/,
   );
-  expect(workflow).not.toMatch(
-    /package_dirs=\([\s\S]*for package_dir in "\$\{package_dirs\[@\]\}"/,
+  expect(workflow).toMatch(
+    /package_dirs=\([\s\S]*plugins\/plugin-blocker[\s\S]*\)[\s\S]*for package_dir in "\$\{package_dirs\[@\]\}"/,
+  );
+  expect(workflow.indexOf("package_dirs=(")).toBeLessThan(
+    workflow.indexOf(runStep),
   );
 });
 

--- a/plugins/plugin-app-control/test/scenarios/app-list.scenario.ts
+++ b/plugins/plugin-app-control/test/scenarios/app-list.scenario.ts
@@ -1,8 +1,43 @@
 /**
- * Live-only scenario for APP list sub-mode selection and response content.
+ * Live-model APP list coverage backed by the real agent HTTP host and app
+ * manager, so the action's loopback client exercises production routes.
  */
 
+import { startApiServer } from "@elizaos/agent/api/server";
+import { AgentRuntime } from "@elizaos/core";
 import { scenario } from "@elizaos/scenario-runner/schema";
+
+type ApiServer = Awaited<ReturnType<typeof startApiServer>>;
+
+let apiServer: ApiServer | null = null;
+let previousElizaPort: string | undefined;
+
+async function startRealAppApi(runtime: AgentRuntime): Promise<void> {
+	if (apiServer) {
+		throw new Error("app-list scenario API server is already running");
+	}
+	previousElizaPort = process.env.ELIZA_PORT;
+	apiServer = await startApiServer({
+		port: 0,
+		runtime,
+		skipDeferredStartupWork: true,
+	});
+	process.env.ELIZA_PORT = String(apiServer.port);
+}
+
+async function stopRealAppApi(): Promise<void> {
+	const activeServer = apiServer;
+	apiServer = null;
+	if (previousElizaPort === undefined) {
+		delete process.env.ELIZA_PORT;
+	} else {
+		process.env.ELIZA_PORT = previousElizaPort;
+	}
+	previousElizaPort = undefined;
+	if (activeServer) {
+		await activeServer.close();
+	}
+}
 
 export default scenario({
   lane: "live-only",
@@ -14,6 +49,25 @@ export default scenario({
 	requires: {
 		plugins: ["@elizaos/plugin-app-control"],
 	},
+	seed: [
+		{
+			type: "custom",
+			name: "start the real agent API host for app routes",
+			apply: async (ctx) => {
+				if (!(ctx.runtime instanceof AgentRuntime)) {
+					return "scenario runtime is not an AgentRuntime";
+				}
+				await startRealAppApi(ctx.runtime);
+			},
+		},
+	],
+	cleanup: [
+		{
+			type: "custom",
+			name: "stop the real agent API host",
+			apply: stopRealAppApi,
+		},
+	],
 	rooms: [
 		{
 			id: "main",
@@ -26,6 +80,21 @@ export default scenario({
 			kind: "message",
 			name: "user-asks-list",
 			text: "show me the apps",
+			assertTurn: (turn) => {
+				const call = turn.actionsCalled.find(
+					(action) => action.actionName === "APP",
+				);
+				if (!call?.result?.success) {
+					return `APP list did not succeed: ${call?.error?.message ?? call?.result?.text ?? "action not called"}`;
+				}
+				const data = call.result.data;
+				if (!data || typeof data !== "object" || Array.isArray(data)) {
+					return "APP list result omitted structured data";
+				}
+				if (!Array.isArray(data.installed) || !Array.isArray(data.runs)) {
+					return "APP list result omitted installed or running app arrays";
+				}
+			},
 		},
 	],
 	finalChecks: [
@@ -41,6 +110,7 @@ export default scenario({
 		{
 			type: "actionCalled",
 			actionName: "APP",
+			status: "success",
 			minCount: 1,
 		},
 	],

--- a/plugins/plugin-health/AGENTS.md
+++ b/plugins/plugin-health/AGENTS.md
@@ -4,11 +4,11 @@ Health, sleep, circadian-regularity, and screen-time domain plugin for elizaOS.
 
 ## Purpose / role
 
-Provides the health and sleep domain layer for Eliza agents — connector registrations (Apple Health, Google Fit, Strava, Fitbit, Withings, Oura), sleep/circadian/regularity inference engines, screen-time type contracts, wake/bedtime anchor contributions, `ActivitySignalBus` family declarations, and default scheduled-task packs (bedtime, wake-up, sleep-recap). Loaded as `healthPlugin` (package `@elizaos/plugin-health`). Opt-in; consumed by plugins such as `@elizaos/plugin-personal-assistant`. All registry contributions are soft-dependency: if `connectorRegistry`, `anchorRegistry`, `busFamilyRegistry`, or `defaultPackRegistry` are absent on the runtime, the plugin logs a one-line skip and continues without error.
+Provides the health and sleep domain layer for Eliza agents — connector registrations (Apple Health, Google Fit, Strava, Fitbit, Withings, Oura), sleep/circadian/regularity inference engines, screen-time type contracts, owner-telemetry routing, wake/bedtime anchor contributions, `ActivitySignalBus` family declarations, and default scheduled-task packs (bedtime, wake-up, sleep-recap). Loaded as `healthPlugin` (package `@elizaos/plugin-health`). Opt-in; consumed by plugins such as `@elizaos/plugin-personal-assistant`. All registry contributions are soft-dependency: if `connectorRegistry`, `anchorRegistry`, `busFamilyRegistry`, or `defaultPackRegistry` are absent on the runtime, the plugin logs a one-line skip and continues without error.
 
 ## Plugin surface
 
-The plugin object (`healthPlugin`) registers no runtime actions, providers, or evaluators directly. Health owns the reusable action/provider/route/service surfaces (`createOwnerHealthAction`, `createOwnerScreenTimeAction`, `createHealthActionRunner`, `createScreenTimeActionRunner`, `createHealthProvider`, `createHealthSleepRouteHandler`, `createHealthSleepServiceMethods`) so host plugins inject access checks, route context, and storage/service adapters instead of duplicating health metadata. Its `init` function calls four registration helpers:
+The plugin object (`healthPlugin`) registers no runtime actions or providers directly. It registers one response-handler evaluator for explicit owner telemetry reads. Health owns the reusable action/provider/route/service surfaces (`createOwnerHealthAction`, `createOwnerScreenTimeAction`, `createHealthActionRunner`, `createScreenTimeActionRunner`, `createHealthProvider`, `createHealthSleepRouteHandler`, `createHealthSleepServiceMethods`) so host plugins inject access checks, route context, and storage/service adapters instead of duplicating health metadata. Its `init` function calls four registration helpers:
 
 | Registration call | What it contributes |
 |---|---|
@@ -17,7 +17,7 @@ The plugin object (`healthPlugin`) registers no runtime actions, providers, or e
 | `registerHealthBusFamilies(runtime)` | 8 `BusFamilyContribution`s: `health.sleep.detected`, `health.sleep.ended`, `health.wake.observed`, `health.wake.confirmed`, `health.nap.detected`, `health.bedtime.imminent`, `health.regularity.changed`, `health.workout.completed` |
 | `registerHealthDefaultPacks(runtime)` | 3 `DefaultPack`s: `bedtime`, `wake-up`, `sleep-recap` |
 
-`init` also calls `registerCircadianInsightContract(runtime, createDefaultCircadianInsightContract())` to attach the `CircadianInsightContract` seam on the runtime symbol `Symbol.for("@elizaos/plugin-health:circadian-insight-contract")`.
+`init` also calls `registerCircadianInsightContract(runtime, createDefaultCircadianInsightContract())` to attach the `CircadianInsightContract` seam on the runtime symbol `Symbol.for("@elizaos/plugin-health:circadian-insight-contract")`. The `health.owner-telemetry-routing` response-handler evaluator routes explicit first-person sleep, recovery, activity, and wearable reads to a host-registered `OWNER_HEALTH` action; it stays inactive when that action is absent and excludes clinical-advice requests.
 
 ### Key exported constants
 
@@ -42,6 +42,7 @@ src/
   actions/
     index.ts                    Health/screen-time action factories and runner adapters for host plugins
     health.ts                   Health action implementation
+    owner-health-routing.ts     Deterministic Stage-1 routing for owner telemetry reads
     owner-health.ts             Owner health action factory
     owner-screentime.ts         Owner screen-time action factory
     screen-time.ts              Screen-time action implementation

--- a/plugins/plugin-health/CLAUDE.md
+++ b/plugins/plugin-health/CLAUDE.md
@@ -4,11 +4,11 @@ Health, sleep, circadian-regularity, and screen-time domain plugin for elizaOS.
 
 ## Purpose / role
 
-Provides the health and sleep domain layer for Eliza agents — connector registrations (Apple Health, Google Fit, Strava, Fitbit, Withings, Oura), sleep/circadian/regularity inference engines, screen-time type contracts, wake/bedtime anchor contributions, `ActivitySignalBus` family declarations, and default scheduled-task packs (bedtime, wake-up, sleep-recap). Loaded as `healthPlugin` (package `@elizaos/plugin-health`). Opt-in; consumed by plugins such as `@elizaos/plugin-personal-assistant`. All registry contributions are soft-dependency: if `connectorRegistry`, `anchorRegistry`, `busFamilyRegistry`, or `defaultPackRegistry` are absent on the runtime, the plugin logs a one-line skip and continues without error.
+Provides the health and sleep domain layer for Eliza agents — connector registrations (Apple Health, Google Fit, Strava, Fitbit, Withings, Oura), sleep/circadian/regularity inference engines, screen-time type contracts, owner-telemetry routing, wake/bedtime anchor contributions, `ActivitySignalBus` family declarations, and default scheduled-task packs (bedtime, wake-up, sleep-recap). Loaded as `healthPlugin` (package `@elizaos/plugin-health`). Opt-in; consumed by plugins such as `@elizaos/plugin-personal-assistant`. All registry contributions are soft-dependency: if `connectorRegistry`, `anchorRegistry`, `busFamilyRegistry`, or `defaultPackRegistry` are absent on the runtime, the plugin logs a one-line skip and continues without error.
 
 ## Plugin surface
 
-The plugin object (`healthPlugin`) registers no runtime actions, providers, or evaluators directly. Health owns the reusable action/provider/route/service surfaces (`createOwnerHealthAction`, `createOwnerScreenTimeAction`, `createHealthActionRunner`, `createScreenTimeActionRunner`, `createHealthProvider`, `createHealthSleepRouteHandler`, `createHealthSleepServiceMethods`) so host plugins inject access checks, route context, and storage/service adapters instead of duplicating health metadata. Its `init` function calls four registration helpers:
+The plugin object (`healthPlugin`) registers no runtime actions or providers directly. It registers one response-handler evaluator for explicit owner telemetry reads. Health owns the reusable action/provider/route/service surfaces (`createOwnerHealthAction`, `createOwnerScreenTimeAction`, `createHealthActionRunner`, `createScreenTimeActionRunner`, `createHealthProvider`, `createHealthSleepRouteHandler`, `createHealthSleepServiceMethods`) so host plugins inject access checks, route context, and storage/service adapters instead of duplicating health metadata. Its `init` function calls four registration helpers:
 
 | Registration call | What it contributes |
 |---|---|
@@ -17,7 +17,7 @@ The plugin object (`healthPlugin`) registers no runtime actions, providers, or e
 | `registerHealthBusFamilies(runtime)` | 8 `BusFamilyContribution`s: `health.sleep.detected`, `health.sleep.ended`, `health.wake.observed`, `health.wake.confirmed`, `health.nap.detected`, `health.bedtime.imminent`, `health.regularity.changed`, `health.workout.completed` |
 | `registerHealthDefaultPacks(runtime)` | 3 `DefaultPack`s: `bedtime`, `wake-up`, `sleep-recap` |
 
-`init` also calls `registerCircadianInsightContract(runtime, createDefaultCircadianInsightContract())` to attach the `CircadianInsightContract` seam on the runtime symbol `Symbol.for("@elizaos/plugin-health:circadian-insight-contract")`.
+`init` also calls `registerCircadianInsightContract(runtime, createDefaultCircadianInsightContract())` to attach the `CircadianInsightContract` seam on the runtime symbol `Symbol.for("@elizaos/plugin-health:circadian-insight-contract")`. The `health.owner-telemetry-routing` response-handler evaluator routes explicit first-person sleep, recovery, activity, and wearable reads to a host-registered `OWNER_HEALTH` action; it stays inactive when that action is absent and excludes clinical-advice requests.
 
 ### Key exported constants
 
@@ -42,6 +42,7 @@ src/
   actions/
     index.ts                    Health/screen-time action factories and runner adapters for host plugins
     health.ts                   Health action implementation
+    owner-health-routing.ts     Deterministic Stage-1 routing for owner telemetry reads
     owner-health.ts             Owner health action factory
     owner-screentime.ts         Owner screen-time action factory
     screen-time.ts              Screen-time action implementation

--- a/plugins/plugin-health/src/__tests__/plugin-init.test.ts
+++ b/plugins/plugin-health/src/__tests__/plugin-init.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Exercises the `healthPlugin` entry surface end-to-end: `init` against a
+ * runtime carrying the real W1-A/W1-F registry seams (connector, anchor,
+ * bus-family, default-pack) and against a bare runtime with none of them,
+ * plus the plugin's declared view/evaluator manifest.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import type {
+  AnchorContribution,
+  BusFamilyContribution,
+  ConnectorContribution,
+} from "../connectors/contract-types.js";
+import { getCircadianInsightContract } from "../contracts/circadian.js";
+import type { DefaultPack } from "../default-packs/index.js";
+import { HEALTH_PLUGIN_NAME, healthPlugin } from "../index.js";
+
+function makeRegistryRuntime() {
+  const connectors: ConnectorContribution[] = [];
+  const anchors: AnchorContribution[] = [];
+  const busFamilies: BusFamilyContribution[] = [];
+  const packs: DefaultPack[] = [];
+  const runtime = {
+    connectorRegistry: {
+      register: (c: ConnectorContribution) => {
+        connectors.push(c);
+      },
+      list: () => connectors,
+      get: (kind: string) => connectors.find((c) => c.kind === kind) ?? null,
+      byCapability: (capability: string) =>
+        connectors.filter((c) => c.capabilities.includes(capability)),
+    },
+    anchorRegistry: {
+      register: (a: AnchorContribution) => {
+        anchors.push(a);
+      },
+      list: () => anchors,
+      get: (anchorKey: string) =>
+        anchors.find((a) => a.anchorKey === anchorKey) ?? null,
+    },
+    busFamilyRegistry: {
+      register: (f: BusFamilyContribution) => {
+        busFamilies.push(f);
+      },
+      list: () => busFamilies,
+    },
+    defaultPackRegistry: {
+      register: (pack: DefaultPack) => {
+        packs.push(pack);
+      },
+      get: (key: string) => packs.find((p) => p.key === key) ?? null,
+      list: () => packs,
+    },
+  };
+  return { runtime, connectors, anchors, busFamilies, packs };
+}
+
+describe("healthPlugin init", () => {
+  it("declares the health view and routing evaluator without direct actions", () => {
+    expect(healthPlugin.name).toBe(HEALTH_PLUGIN_NAME);
+    expect(healthPlugin.actions).toEqual([]);
+    expect(healthPlugin.providers).toEqual([]);
+    expect(healthPlugin.services).toEqual([]);
+    expect(
+      healthPlugin.responseHandlerEvaluators?.map((e) => e.name),
+    ).toContain("health.owner-telemetry-routing");
+    const view = healthPlugin.views?.[0];
+    expect(view).toMatchObject({
+      id: "health",
+      path: "/health",
+      componentExport: "HealthView",
+      relatedActions: ["OWNER_HEALTH", "OWNER_SCREENTIME"],
+    });
+  });
+
+  it("registers connectors, anchors, bus families, packs, and the circadian contract on init", async () => {
+    const { runtime, connectors, anchors, busFamilies, packs } =
+      makeRegistryRuntime();
+
+    await healthPlugin.init?.({}, runtime as unknown as IAgentRuntime);
+
+    expect(connectors.map((c) => c.kind)).toEqual([
+      "apple_health",
+      "google_fit",
+      "strava",
+      "fitbit",
+      "withings",
+      "oura",
+    ]);
+    expect(anchors.map((a) => a.anchorKey)).toEqual([
+      "wake.observed",
+      "wake.confirmed",
+      "bedtime.target",
+      "nap.start",
+    ]);
+    expect(busFamilies).toHaveLength(8);
+    expect(packs.map((p) => p.key)).toEqual([
+      "bedtime",
+      "wake-up",
+      "sleep-recap",
+    ]);
+    const contract = getCircadianInsightContract(
+      runtime as unknown as IAgentRuntime,
+    );
+    expect(contract).not.toBeNull();
+  });
+
+  it("init is idempotent for default packs already registered", async () => {
+    const { runtime, packs } = makeRegistryRuntime();
+    await healthPlugin.init?.({}, runtime as unknown as IAgentRuntime);
+    await healthPlugin.init?.({}, runtime as unknown as IAgentRuntime);
+    expect(packs.map((p) => p.key)).toEqual([
+      "bedtime",
+      "wake-up",
+      "sleep-recap",
+    ]);
+  });
+
+  it("init tolerates a runtime without any Wave-1 registries (soft-dep posture)", async () => {
+    const bare = {} as IAgentRuntime;
+    await expect(healthPlugin.init?.({}, bare)).resolves.toBeUndefined();
+    expect(getCircadianInsightContract(bare)).not.toBeNull();
+  });
+});

--- a/plugins/plugin-health/src/__tests__/smoke.test.ts
+++ b/plugins/plugin-health/src/__tests__/smoke.test.ts
@@ -136,6 +136,14 @@ describe("plugin-health smoke (W1-B)", () => {
     expect(healthPlugin.actions ?? []).toEqual([]);
   });
 
+  it("registers deterministic routing for host-adapted owner health reads", () => {
+    expect(
+      healthPlugin.responseHandlerEvaluators?.map(
+        (evaluator) => evaluator.name,
+      ),
+    ).toContain("health.owner-telemetry-routing");
+  });
+
   it("does not export removed scaffold owner actions", () => {
     expect("ownerHealthAction" in healthActionExports).toBe(false);
     expect("ownerScreentimeAction" in healthActionExports).toBe(false);

--- a/plugins/plugin-health/src/actions/index.ts
+++ b/plugins/plugin-health/src/actions/index.ts
@@ -10,6 +10,7 @@
 
 export * from "./health.js";
 export * from "./optimized-prompt-instructions.js";
+export * from "./owner-health-routing.js";
 export * from "./screen-time.js";
 
 export const HEALTH_ACTION_SURFACES_EXTRACTED = true as const;

--- a/plugins/plugin-health/src/actions/owner-health-routing.test.ts
+++ b/plugins/plugin-health/src/actions/owner-health-routing.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Verifies deterministic Stage-1 routing for owner telemetry reads and keeps
+ * clinical advice requests on the normal safety path.
+ */
+import type {
+  IAgentRuntime,
+  ResponseHandlerEvaluatorContext,
+} from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  isOwnerHealthReadRequest,
+  ownerHealthRoutingEvaluator,
+} from "./owner-health-routing.js";
+
+function context(text: string, actionName = "OWNER_HEALTH") {
+  return {
+    runtime: {
+      actions: [{ name: actionName }],
+    } as unknown as IAgentRuntime,
+    message: { content: { text } },
+    state: {},
+    availableContexts: [{ id: "simple" }, { id: "health" }],
+    messageHandler: {
+      processMessage: "RESPOND",
+      plan: {
+        contexts: ["simple"],
+        reply: "Generic wellness advice.",
+      },
+    },
+  } as unknown as ResponseHandlerEvaluatorContext;
+}
+
+describe("owner health routing", () => {
+  it("recognizes an overnight recovery telemetry read", () => {
+    expect(
+      isOwnerHealthReadRequest(
+        "Good morning — how did my body recover overnight?",
+      ),
+    ).toBe(true);
+  });
+
+  it("forces the health context and OWNER_HEALTH candidate", async () => {
+    const input = context("Good morning — how did my body recover overnight?");
+
+    expect(await ownerHealthRoutingEvaluator.shouldRun(input)).toBe(true);
+    expect(await ownerHealthRoutingEvaluator.evaluate(input)).toEqual(
+      expect.objectContaining({
+        requiresTool: true,
+        setContexts: ["health"],
+        addCandidateActions: ["OWNER_HEALTH"],
+        addParentActionHints: ["OWNER_HEALTH"],
+        clearReply: true,
+      }),
+    );
+  });
+
+  it("does not route clinical advice or a runtime without OWNER_HEALTH", async () => {
+    expect(
+      isOwnerHealthReadRequest(
+        "How should I treat my knee pain after yesterday's workout?",
+      ),
+    ).toBe(false);
+    expect(
+      await ownerHealthRoutingEvaluator.shouldRun(
+        context("How did my body recover overnight?", "REPLY"),
+      ),
+    ).toBe(false);
+  });
+});

--- a/plugins/plugin-health/src/actions/owner-health-routing.test.ts
+++ b/plugins/plugin-health/src/actions/owner-health-routing.test.ts
@@ -37,6 +37,9 @@ describe("owner health routing", () => {
         "Good morning — how did my body recover overnight?",
       ),
     ).toBe(true);
+    expect(isOwnerHealthReadRequest("Show me my workout status today.")).toBe(
+      true,
+    );
   });
 
   it("forces the health context and OWNER_HEALTH candidate", async () => {
@@ -60,6 +63,13 @@ describe("owner health routing", () => {
         "How should I treat my knee pain after yesterday's workout?",
       ),
     ).toBe(false);
+    expect(isOwnerHealthReadRequest("I did a workout today.")).toBe(false);
+    expect(isOwnerHealthReadRequest("Tell me how to improve my sleep.")).toBe(
+      false,
+    );
+    expect(isOwnerHealthReadRequest("Tell me about sleep recovery tips.")).toBe(
+      false,
+    );
     expect(
       await ownerHealthRoutingEvaluator.shouldRun(
         context("How did my body recover overnight?", "REPLY"),

--- a/plugins/plugin-health/src/actions/owner-health-routing.ts
+++ b/plugins/plugin-health/src/actions/owner-health-routing.ts
@@ -1,0 +1,69 @@
+/**
+ * Routes explicit owner telemetry reads into the health action surface before
+ * a general-purpose model can misclassify them as static wellness advice.
+ */
+import type {
+  ResponseHandlerEvaluator,
+  ResponseHandlerEvaluatorContext,
+} from "@elizaos/core";
+
+const OWNER_HEALTH_ACTION = "OWNER_HEALTH";
+const FIRST_PERSON = /\b(?:i|me|my|mine)\b/i;
+const HEALTH_SIGNAL =
+  /\b(?:sleep|slept|recovery|recover(?:ed|y)?|resting heart rate|heart rate|hrv|steps?|active minutes?|activity|workouts?|calories?|distance|fitness|wearable|biometric)\b/i;
+const READ_INTENT =
+  /\b(?:check|show|review|summarize|tell me|status|trend|how (?:did|has|is|was)|what (?:did|is|was|were))\b/i;
+const READ_WINDOW =
+  /\b(?:overnight|last night|today|this morning|this week|recent|recently)\b/i;
+const CLINICAL_ADVICE =
+  /\b(?:diagnos|treat|medicat|dosage|symptom|pain|injur|doctor|emergency)\b/i;
+
+function hasOwnerHealthAction(
+  context: ResponseHandlerEvaluatorContext,
+): boolean {
+  return context.runtime.actions.some(
+    (action) => action.name === OWNER_HEALTH_ACTION,
+  );
+}
+
+export function isOwnerHealthReadRequest(text: string): boolean {
+  return (
+    FIRST_PERSON.test(text) &&
+    HEALTH_SIGNAL.test(text) &&
+    (READ_INTENT.test(text) || READ_WINDOW.test(text)) &&
+    !CLINICAL_ADVICE.test(text)
+  );
+}
+
+function shouldRoute(context: ResponseHandlerEvaluatorContext): boolean {
+  if (context.messageHandler.processMessage === "STOP") return false;
+  const text = context.message.content.text;
+  return (
+    typeof text === "string" &&
+    isOwnerHealthReadRequest(text) &&
+    hasOwnerHealthAction(context)
+  );
+}
+
+export const ownerHealthRoutingEvaluator: ResponseHandlerEvaluator = {
+  name: "health.owner-telemetry-routing",
+  description:
+    "Routes explicit first-person sleep, recovery, activity, and wearable reads to OWNER_HEALTH while leaving clinical advice on the safety path.",
+  priority: 15,
+  shouldRun: shouldRoute,
+  evaluate: (context) => {
+    if (!shouldRoute(context)) return undefined;
+    return {
+      requiresTool: true,
+      setContexts: ["health"],
+      clearCandidateActions: true,
+      addCandidateActions: [OWNER_HEALTH_ACTION],
+      clearParentActionHints: true,
+      addParentActionHints: [OWNER_HEALTH_ACTION],
+      clearReply: true,
+      debug: [
+        "explicit owner telemetry read; routing to OWNER_HEALTH instead of static wellness advice",
+      ],
+    };
+  },
+};

--- a/plugins/plugin-health/src/actions/owner-health-routing.ts
+++ b/plugins/plugin-health/src/actions/owner-health-routing.ts
@@ -8,13 +8,13 @@ import type {
 } from "@elizaos/core";
 
 const OWNER_HEALTH_ACTION = "OWNER_HEALTH";
-const FIRST_PERSON = /\b(?:i|me|my|mine)\b/i;
+const OWNER_REFERENCE = /\b(?:i|my|mine)\b/i;
 const HEALTH_SIGNAL =
   /\b(?:sleep|slept|recovery|recover(?:ed|y)?|resting heart rate|heart rate|hrv|steps?|active minutes?|activity|workouts?|calories?|distance|fitness|wearable|biometric)\b/i;
 const READ_INTENT =
   /\b(?:check|show|review|summarize|tell me|status|trend|how (?:did|has|is|was)|what (?:did|is|was|were))\b/i;
-const READ_WINDOW =
-  /\b(?:overnight|last night|today|this morning|this week|recent|recently)\b/i;
+const GENERAL_GUIDANCE =
+  /\b(?:advice|tips?|improv(?:e|ing)|what should i|how (?:can|should|do) i|help me)\b/i;
 const CLINICAL_ADVICE =
   /\b(?:diagnos|treat|medicat|dosage|symptom|pain|injur|doctor|emergency)\b/i;
 
@@ -28,9 +28,10 @@ function hasOwnerHealthAction(
 
 export function isOwnerHealthReadRequest(text: string): boolean {
   return (
-    FIRST_PERSON.test(text) &&
+    OWNER_REFERENCE.test(text) &&
     HEALTH_SIGNAL.test(text) &&
-    (READ_INTENT.test(text) || READ_WINDOW.test(text)) &&
+    READ_INTENT.test(text) &&
+    !GENERAL_GUIDANCE.test(text) &&
     !CLINICAL_ADVICE.test(text)
   );
 }

--- a/plugins/plugin-health/src/index.ts
+++ b/plugins/plugin-health/src/index.ts
@@ -20,6 +20,7 @@
 
 import type { IAgentRuntime, Plugin } from "@elizaos/core";
 import { logger } from "@elizaos/core";
+import { ownerHealthRoutingEvaluator } from "./actions/owner-health-routing.js";
 import {
   HEALTH_ANCHORS,
   HEALTH_BUS_FAMILIES,
@@ -71,6 +72,7 @@ export const healthPlugin: Plugin = {
   // are provided by the host (currently plugin-personal-assistant).
   actions: [],
   providers: [],
+  responseHandlerEvaluators: [ownerHealthRoutingEvaluator],
   tests: [],
   views: [
     {

--- a/plugins/plugin-health/test/scenarios/wake-up-routine.scenario.ts
+++ b/plugins/plugin-health/test/scenarios/wake-up-routine.scenario.ts
@@ -35,4 +35,18 @@ export default scenario({
       plannerExcludes: ["gmail_action", "owner_send_message"],
     },
   ],
+  finalChecks: [
+    {
+      type: "selectedActionArguments",
+      name: "overnight recovery routes through an owner health read",
+      actionName: "OWNER_HEALTH",
+      includesAny: ["today", "trend", "by_metric", "status"],
+    },
+    {
+      type: "actionCalled",
+      actionName: "OWNER_HEALTH",
+      status: "success",
+      minCount: 1,
+    },
+  ],
 });

--- a/plugins/plugin-health/test/scenarios/wake-up-routine.scenario.ts
+++ b/plugins/plugin-health/test/scenarios/wake-up-routine.scenario.ts
@@ -39,12 +39,12 @@ export default scenario({
     {
       type: "selectedActionArguments",
       name: "overnight recovery routes through an owner health read",
-      actionName: "OWNER_HEALTH",
+      actionName: "OWNER_HEALTH_TODAY",
       includesAny: ["today", "trend", "by_metric", "status"],
     },
     {
       type: "actionCalled",
-      actionName: "OWNER_HEALTH",
+      actionName: "OWNER_HEALTH_TODAY",
       status: "success",
       minCount: 1,
     },

--- a/plugins/plugin-health/test/scenarios/wake-up-routine.scenario.ts
+++ b/plugins/plugin-health/test/scenarios/wake-up-routine.scenario.ts
@@ -39,12 +39,12 @@ export default scenario({
     {
       type: "selectedActionArguments",
       name: "overnight recovery routes through an owner health read",
-      actionName: "OWNER_HEALTH_TODAY",
+      actionName: "OWNER_HEALTH",
       includesAny: ["today", "trend", "by_metric", "status"],
     },
     {
       type: "actionCalled",
-      actionName: "OWNER_HEALTH_TODAY",
+      actionName: "OWNER_HEALTH",
       status: "success",
       minCount: 1,
     },

--- a/plugins/plugin-health/vitest.config.ts
+++ b/plugins/plugin-health/vitest.config.ts
@@ -33,6 +33,12 @@ const aliases = [
     ),
   },
   {
+    find: /^@elizaos\/ui$/,
+    replacement: fileURLToPath(
+      new URL("../../packages/ui/src/api/client.ts", import.meta.url),
+    ),
+  },
+  {
     find: /^@elizaos\/ui\/spatial$/,
     replacement: fileURLToPath(
       new URL("../../packages/ui/src/spatial/index.ts", import.meta.url),

--- a/plugins/plugin-health/vitest.config.ts
+++ b/plugins/plugin-health/vitest.config.ts
@@ -32,6 +32,12 @@ const aliases = [
       new URL("../plugin-scheduling/src/index.ts", import.meta.url),
     ),
   },
+  {
+    find: /^@elizaos\/ui\/spatial$/,
+    replacement: fileURLToPath(
+      new URL("../../packages/ui/src/spatial/index.ts", import.meta.url),
+    ),
+  },
 ];
 
 export default defineConfig({

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/health-connector-status.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/health-connector-status.ts
@@ -1,0 +1,163 @@
+/**
+ * Health connector status projection: reads the owner's connector grant(s)
+ * and stored OAuth token for a provider and shapes them into the
+ * `LifeOpsHealthConnectorStatus` DTO. Split out of `health-service.ts` so
+ * this branch-heavy read path (grant-present/absent, token-present/absent,
+ * reauth/sync-failed/config-missing) can be covered independently of the
+ * rest of the health domain. `HealthDomain` delegates to these functions;
+ * they take the shared `LifeOpsContext` explicitly rather than depending on
+ * `this` so they stay unit-testable without a class instance.
+ */
+import {
+  healthConnectorCapabilities,
+  readStoredHealthToken,
+  resolveHealthOAuthConfig,
+} from "@elizaos/plugin-health";
+import type {
+  LifeOpsConnectorMode,
+  LifeOpsConnectorSide,
+  LifeOpsHealthConnectorCapability,
+  LifeOpsHealthConnectorProvider,
+  LifeOpsHealthConnectorStatus,
+} from "../../contracts/index.js";
+import {
+  LIFEOPS_HEALTH_CONNECTOR_CAPABILITIES,
+  LIFEOPS_HEALTH_CONNECTOR_PROVIDERS,
+} from "../../contracts/index.js";
+import type { LifeOpsContext } from "../lifeops-context.js";
+import { normalizeEnumValue } from "../service-normalize.js";
+import {
+  normalizeOptionalConnectorMode,
+  normalizeOptionalConnectorSide,
+} from "../service-normalize-connector.js";
+
+function normalizeHealthProvider(
+  value: unknown,
+  field = "provider",
+): LifeOpsHealthConnectorProvider {
+  return normalizeEnumValue(value, field, LIFEOPS_HEALTH_CONNECTOR_PROVIDERS);
+}
+
+function healthCapabilitiesFromGrant(
+  capabilities: readonly string[],
+): LifeOpsHealthConnectorCapability[] {
+  return capabilities.filter(
+    (capability): capability is LifeOpsHealthConnectorCapability =>
+      (LIFEOPS_HEALTH_CONNECTOR_CAPABILITIES as readonly string[]).includes(
+        capability,
+      ),
+  );
+}
+
+export async function getHealthDataConnectorStatus(
+  ctx: LifeOpsContext,
+  providerInput: LifeOpsHealthConnectorProvider,
+  requestUrl: URL,
+  requestedMode?: LifeOpsConnectorMode,
+  requestedSide?: LifeOpsConnectorSide,
+): Promise<LifeOpsHealthConnectorStatus> {
+  const provider = normalizeHealthProvider(providerInput);
+  const side = normalizeOptionalConnectorSide(requestedSide, "side") ?? "owner";
+  const explicitMode = normalizeOptionalConnectorMode(requestedMode, "mode");
+  const grants = (
+    await ctx.repository.listConnectorGrants(ctx.agentId())
+  ).filter(
+    (grant) =>
+      grant.provider === provider &&
+      grant.side === side &&
+      (!explicitMode || grant.mode === explicitMode),
+  );
+  const preferredGrant =
+    [...grants].sort((left, right) =>
+      right.updatedAt.localeCompare(left.updatedAt),
+    )[0] ?? null;
+  const config = resolveHealthOAuthConfig(
+    provider,
+    requestUrl,
+    explicitMode ?? preferredGrant?.mode,
+  );
+  const grant =
+    preferredGrant ??
+    (await ctx.repository.getConnectorGrant(
+      ctx.agentId(),
+      provider,
+      config.mode,
+      side,
+    ));
+  const token = readStoredHealthToken(grant?.tokenRef);
+  const syncState = grant
+    ? await ctx.repository.getHealthSyncState(ctx.agentId(), provider, grant.id)
+    : null;
+  const metadataAuthState =
+    typeof grant?.metadata.authState === "string"
+      ? grant.metadata.authState
+      : null;
+  const connected = Boolean(
+    grant && token && metadataAuthState !== "needs_reauth",
+  );
+  const reason: LifeOpsHealthConnectorStatus["reason"] = connected
+    ? syncState?.lastSyncError
+      ? "sync_failed"
+      : "connected"
+    : grant && (grant.tokenRef || metadataAuthState === "needs_reauth")
+      ? "needs_reauth"
+      : config.configured
+        ? "disconnected"
+        : "config_missing";
+  return {
+    provider,
+    side,
+    mode: grant?.mode ?? config.mode,
+    defaultMode: config.defaultMode,
+    availableModes: config.availableModes,
+    executionTarget: grant?.executionTarget ?? "local",
+    sourceOfTruth: grant?.sourceOfTruth ?? "local_storage",
+    configured: config.configured,
+    connected,
+    reason,
+    identity: token?.identity ?? grant?.identity ?? null,
+    grantedCapabilities: grant
+      ? healthCapabilitiesFromGrant(grant.capabilities)
+      : healthConnectorCapabilities(provider),
+    grantedScopes: token?.grantedScopes ?? grant?.grantedScopes ?? [],
+    expiresAt: token?.expiresAt
+      ? new Date(token.expiresAt).toISOString()
+      : typeof grant?.metadata.expiresAt === "string"
+        ? grant.metadata.expiresAt
+        : null,
+    hasRefreshToken:
+      Boolean(token?.refreshToken) || Boolean(grant?.metadata.hasRefreshToken),
+    lastSyncAt: syncState?.lastSyncedAt ?? null,
+    grant,
+    degradations: syncState?.lastSyncError
+      ? [
+          {
+            axis: "delivery-degraded",
+            code: "last_sync_failed",
+            message: syncState.lastSyncError,
+            retryable: true,
+          },
+        ]
+      : undefined,
+  };
+}
+
+export async function getHealthDataConnectorStatuses(
+  ctx: LifeOpsContext,
+  providers: readonly LifeOpsHealthConnectorProvider[],
+  requestUrl: URL,
+  requestedMode?: LifeOpsConnectorMode,
+  requestedSide?: LifeOpsConnectorSide,
+): Promise<LifeOpsHealthConnectorStatus[]> {
+  return Promise.all(
+    providers.map((provider) =>
+      getHealthDataConnectorStatus(
+        ctx,
+        provider,
+        requestUrl,
+        requestedMode,
+        requestedSide,
+      ),
+    ),
+  );
+}

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/health-service.status.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/health-service.status.test.ts
@@ -1,4 +1,18 @@
-/** Verifies an unconfigured health connector produces an explicit disconnected status without requiring a persisted grant. */
+/**
+ * Verifies HealthDomain connector-status projection across the three grant
+ * states: no grant (config_missing), grant without a readable token
+ * (needs_reauth), and grant with a real encrypted token on disk (connected /
+ * sync_failed). Token reads go through the real AES-GCM store under a
+ * per-test ELIZA_OAUTH_DIR.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { LifeOpsConnectorGrant } from "@elizaos/plugin-health";
+import {
+  encryptTokenPayload,
+  resolveTokenEncryptionKey,
+} from "@elizaos/plugin-health/util/token-encryption";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { LifeOpsContext } from "../lifeops-context.js";
 import { HealthDomain } from "./health-service.js";
@@ -6,14 +20,95 @@ import { HealthDomain } from "./health-service.js";
 const HEALTH_ENV_KEYS = [
   "ELIZA_STRAVA_CLIENT_ID",
   "ELIZA_STRAVA_CLIENT_SECRET",
+  "ELIZA_OAUTH_DIR",
 ] as const;
 
+const AGENT_ID = "00000000-0000-0000-0000-0000000000aa";
+const REQUEST_URL = new URL("http://127.0.0.1:2138");
+
+function makeGrant(
+  overrides: Partial<LifeOpsConnectorGrant> = {},
+): LifeOpsConnectorGrant {
+  const now = new Date().toISOString();
+  return {
+    id: "grant-1",
+    agentId: AGENT_ID,
+    provider: "strava",
+    connectorAccountId: null,
+    side: "owner",
+    identity: { username: "runner" },
+    grantedScopes: ["activity:read_all"],
+    capabilities: ["health.activity.read"],
+    tokenRef: path.join(AGENT_ID, "owner", "local", "strava.json"),
+    mode: "local",
+    executionTarget: "local",
+    sourceOfTruth: "local_storage",
+    preferredByAgent: false,
+    cloudConnectionId: null,
+    metadata: { authState: "connected" },
+    lastRefreshAt: now,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+function makeDomain(repository: Record<string, unknown>): HealthDomain {
+  return new HealthDomain({
+    repository,
+    agentId: () => AGENT_ID,
+  } as unknown as LifeOpsContext);
+}
+
+function writeEncryptedToken(oauthDir: string, tokenRef: string): void {
+  const storageRoot = path.join(oauthDir, "lifeops", "health");
+  const filePath = path.join(storageRoot, tokenRef);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+  const key = resolveTokenEncryptionKey(storageRoot);
+  const token = {
+    provider: "strava",
+    agentId: AGENT_ID,
+    side: "owner",
+    mode: "local",
+    clientId: "client-id",
+    clientSecret: "client-secret",
+    redirectUri:
+      "http://127.0.0.1:2138/api/lifeops/connectors/health/strava/callback",
+    accessToken: "access-token",
+    refreshToken: "refresh-token",
+    tokenType: "Bearer",
+    grantedScopes: ["activity:read_all"],
+    expiresAt: Date.now() + 3_600_000,
+    identity: { username: "runner" },
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+  fs.writeFileSync(
+    filePath,
+    JSON.stringify(encryptTokenPayload(JSON.stringify(token), key), null, 2),
+    { mode: 0o600 },
+  );
+}
+
 describe("HealthDomain connector status", () => {
+  let tempDirs: string[] = [];
+
   afterEach(() => {
     for (const key of HEALTH_ENV_KEYS) {
       delete process.env[key];
     }
+    for (const dir of tempDirs) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs = [];
   });
+
+  function makeOAuthDir(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "health-oauth-"));
+    tempDirs.push(dir);
+    process.env.ELIZA_OAUTH_DIR = dir;
+    return dir;
+  }
 
   it("reports config_missing when no connector grant or OAuth config exists", async () => {
     for (const key of HEALTH_ENV_KEYS) {
@@ -24,14 +119,11 @@ describe("HealthDomain connector status", () => {
       getConnectorGrant: vi.fn(async () => null),
       getHealthSyncState: vi.fn(),
     };
-    const domain = new HealthDomain({
-      repository,
-      agentId: () => "00000000-0000-0000-0000-0000000000aa",
-    } as unknown as LifeOpsContext);
+    const domain = makeDomain(repository);
 
     const status = await domain.getHealthDataConnectorStatus(
       "strava",
-      new URL("http://127.0.0.1:2138"),
+      REQUEST_URL,
     );
 
     expect(status).toMatchObject({
@@ -48,5 +140,143 @@ describe("HealthDomain connector status", () => {
       grant: null,
     });
     expect(repository.getHealthSyncState).not.toHaveBeenCalled();
+  });
+
+  it("reports needs_reauth when a grant's tokenRef has no readable stored token", async () => {
+    makeOAuthDir();
+    process.env.ELIZA_STRAVA_CLIENT_ID = "client-id";
+    process.env.ELIZA_STRAVA_CLIENT_SECRET = "client-secret";
+    const grant = makeGrant();
+    const repository = {
+      listConnectorGrants: vi.fn(async () => [grant]),
+      getConnectorGrant: vi.fn(async () => null),
+      getHealthSyncState: vi.fn(async () => null),
+    };
+    const domain = makeDomain(repository);
+
+    const status = await domain.getHealthDataConnectorStatus(
+      "strava",
+      REQUEST_URL,
+    );
+
+    expect(status).toMatchObject({
+      provider: "strava",
+      configured: true,
+      connected: false,
+      reason: "needs_reauth",
+      mode: "local",
+      identity: { username: "runner" },
+      grantedCapabilities: ["health.activity.read"],
+      grantedScopes: ["activity:read_all"],
+      grant,
+    });
+    // The preferred grant was found in the list; the point lookup is skipped.
+    expect(repository.getConnectorGrant).not.toHaveBeenCalled();
+  });
+
+  it("reports connected when the grant's encrypted token is present on disk", async () => {
+    const oauthDir = makeOAuthDir();
+    process.env.ELIZA_STRAVA_CLIENT_ID = "client-id";
+    process.env.ELIZA_STRAVA_CLIENT_SECRET = "client-secret";
+    const grant = makeGrant();
+    if (!grant.tokenRef) throw new Error("test grant must carry a tokenRef");
+    writeEncryptedToken(oauthDir, grant.tokenRef);
+    const lastSyncedAt = "2026-07-10T08:00:00.000Z";
+    const repository = {
+      listConnectorGrants: vi.fn(async () => [grant]),
+      getConnectorGrant: vi.fn(async () => null),
+      getHealthSyncState: vi.fn(async () => ({
+        id: "sync-1",
+        agentId: AGENT_ID,
+        provider: "strava",
+        grantId: grant.id,
+        lastSyncedAt,
+        lastSyncError: null,
+        updatedAt: lastSyncedAt,
+      })),
+    };
+    const domain = makeDomain(repository);
+
+    const status = await domain.getHealthDataConnectorStatus(
+      "strava",
+      REQUEST_URL,
+    );
+
+    expect(status).toMatchObject({
+      provider: "strava",
+      configured: true,
+      connected: true,
+      reason: "connected",
+      identity: { username: "runner" },
+      grantedScopes: ["activity:read_all"],
+      hasRefreshToken: true,
+      lastSyncAt: lastSyncedAt,
+      grant,
+    });
+    expect(status.expiresAt).toEqual(expect.any(String));
+    expect(status.degradations).toBeUndefined();
+    expect(repository.getHealthSyncState).toHaveBeenCalledWith(
+      AGENT_ID,
+      "strava",
+      grant.id,
+    );
+  });
+
+  it("reports sync_failed with a delivery degradation when the last sync errored", async () => {
+    const oauthDir = makeOAuthDir();
+    process.env.ELIZA_STRAVA_CLIENT_ID = "client-id";
+    process.env.ELIZA_STRAVA_CLIENT_SECRET = "client-secret";
+    const grant = makeGrant();
+    if (!grant.tokenRef) throw new Error("test grant must carry a tokenRef");
+    writeEncryptedToken(oauthDir, grant.tokenRef);
+    const repository = {
+      listConnectorGrants: vi.fn(async () => [grant]),
+      getConnectorGrant: vi.fn(async () => null),
+      getHealthSyncState: vi.fn(async () => ({
+        id: "sync-1",
+        agentId: AGENT_ID,
+        provider: "strava",
+        grantId: grant.id,
+        lastSyncedAt: "2026-07-10T08:00:00.000Z",
+        lastSyncError: "strava API returned 500",
+        updatedAt: "2026-07-10T08:00:00.000Z",
+      })),
+    };
+    const domain = makeDomain(repository);
+
+    const status = await domain.getHealthDataConnectorStatus(
+      "strava",
+      REQUEST_URL,
+    );
+
+    expect(status.connected).toBe(true);
+    expect(status.reason).toBe("sync_failed");
+    expect(status.degradations).toEqual([
+      {
+        axis: "delivery-degraded",
+        code: "last_sync_failed",
+        message: "strava API returned 500",
+        retryable: true,
+      },
+    ]);
+  });
+
+  it("projects a status for every provider via getHealthDataConnectorStatuses", async () => {
+    makeOAuthDir();
+    const repository = {
+      listConnectorGrants: vi.fn(async () => []),
+      getConnectorGrant: vi.fn(async () => null),
+      getHealthSyncState: vi.fn(),
+    };
+    const domain = makeDomain(repository);
+
+    const statuses = await domain.getHealthDataConnectorStatuses(REQUEST_URL);
+
+    expect(statuses.length).toBeGreaterThanOrEqual(4);
+    expect(new Set(statuses.map((s) => s.provider)).size).toBe(statuses.length);
+    for (const status of statuses) {
+      expect(status.connected).toBe(false);
+      expect(status.side).toBe("owner");
+    }
   });
 });

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/health-service.status.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/health-service.status.test.ts
@@ -1,0 +1,52 @@
+/** Verifies an unconfigured health connector produces an explicit disconnected status without requiring a persisted grant. */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { LifeOpsContext } from "../lifeops-context.js";
+import { HealthDomain } from "./health-service.js";
+
+const HEALTH_ENV_KEYS = [
+  "ELIZA_STRAVA_CLIENT_ID",
+  "ELIZA_STRAVA_CLIENT_SECRET",
+] as const;
+
+describe("HealthDomain connector status", () => {
+  afterEach(() => {
+    for (const key of HEALTH_ENV_KEYS) {
+      delete process.env[key];
+    }
+  });
+
+  it("reports config_missing when no connector grant or OAuth config exists", async () => {
+    for (const key of HEALTH_ENV_KEYS) {
+      delete process.env[key];
+    }
+    const repository = {
+      listConnectorGrants: vi.fn(async () => []),
+      getConnectorGrant: vi.fn(async () => null),
+      getHealthSyncState: vi.fn(),
+    };
+    const domain = new HealthDomain({
+      repository,
+      agentId: () => "00000000-0000-0000-0000-0000000000aa",
+    } as unknown as LifeOpsContext);
+
+    const status = await domain.getHealthDataConnectorStatus(
+      "strava",
+      new URL("http://127.0.0.1:2138"),
+    );
+
+    expect(status).toMatchObject({
+      provider: "strava",
+      side: "owner",
+      mode: "local",
+      executionTarget: "local",
+      sourceOfTruth: "local_storage",
+      configured: false,
+      connected: false,
+      reason: "config_missing",
+      identity: null,
+      grantedScopes: [],
+      grant: null,
+    });
+    expect(repository.getHealthSyncState).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/health-service.status.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/health-service.status.test.ts
@@ -279,4 +279,307 @@ describe("HealthDomain connector status", () => {
       expect(status.side).toBe("owner");
     }
   });
+
+  it("rejects an unknown provider with a 400", async () => {
+    makeOAuthDir();
+    const domain = makeDomain({
+      listConnectorGrants: vi.fn(async () => []),
+      getConnectorGrant: vi.fn(async () => null),
+      getHealthSyncState: vi.fn(),
+    });
+    await expect(
+      domain.getHealthDataConnectorStatus(
+        "not-a-provider" as never,
+        REQUEST_URL,
+      ),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+});
+
+describe("HealthDomain connector lifecycle and summaries", () => {
+  let tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const key of HEALTH_ENV_KEYS) {
+      delete process.env[key];
+    }
+    delete process.env.ELIZA_HEALTHKIT_CLI_PATH;
+    delete process.env.ELIZA_GOOGLE_FIT_ACCESS_TOKEN;
+    for (const dir of tempDirs) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs = [];
+  });
+
+  function makeOAuthDir(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "health-oauth-"));
+    tempDirs.push(dir);
+    process.env.ELIZA_OAUTH_DIR = dir;
+    return dir;
+  }
+
+  function makeSample(
+    metric: string,
+    value: number,
+    overrides: Record<string, unknown> = {},
+  ) {
+    const now = new Date().toISOString();
+    return {
+      id: `sample-${metric}-${value}`,
+      agentId: AGENT_ID,
+      provider: "strava",
+      grantId: "grant-1",
+      metric,
+      value,
+      unit: "unit",
+      startAt: now,
+      endAt: now,
+      localDate: "2026-07-10",
+      sourceExternalId: `ext-${metric}-${value}`,
+      metadata: {},
+      createdAt: now,
+      updatedAt: now,
+      ...overrides,
+    };
+  }
+
+  it("reports the bridge backend as unavailable when nothing is configured", async () => {
+    delete process.env.ELIZA_HEALTHKIT_CLI_PATH;
+    delete process.env.ELIZA_GOOGLE_FIT_ACCESS_TOKEN;
+    const domain = makeDomain({});
+
+    const status = await domain.getHealthConnectorStatus();
+
+    expect(status.available).toBe(false);
+    expect(status.backend).toBe("none");
+    expect(status.lastCheckedAt).toEqual(expect.any(String));
+  });
+
+  it("rejects cloud_managed OAuth start with a 501", async () => {
+    const domain = makeDomain({});
+    await expect(
+      domain.startHealthConnector(
+        { provider: "strava", mode: "cloud_managed" },
+        REQUEST_URL,
+      ),
+    ).rejects.toMatchObject({ status: 501 });
+  });
+
+  it("rejects non-array capabilities on OAuth start with a 400", async () => {
+    const domain = makeDomain({});
+    await expect(
+      domain.startHealthConnector(
+        { provider: "strava", capabilities: "everything" as never },
+        REQUEST_URL,
+      ),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("surfaces missing OAuth config as a client error on start", async () => {
+    makeOAuthDir();
+    const domain = makeDomain({});
+    await expect(
+      domain.startHealthConnector(
+        {
+          provider: "strava",
+          capabilities: ["health.activity.read", "health.activity.read"],
+        },
+        REQUEST_URL,
+      ),
+    ).rejects.toBeInstanceOf(Error);
+  });
+
+  it("rejects a malformed OAuth callback URL", async () => {
+    makeOAuthDir();
+    const domain = makeDomain({});
+    await expect(
+      domain.completeHealthConnectorCallback(
+        new URL("http://127.0.0.1:2138/callback?error=access_denied"),
+      ),
+    ).rejects.toBeInstanceOf(Error);
+  });
+
+  it("disconnects a grant, deleting the stored token and grant row", async () => {
+    makeOAuthDir();
+    process.env.ELIZA_STRAVA_CLIENT_ID = "client-id";
+    process.env.ELIZA_STRAVA_CLIENT_SECRET = "client-secret";
+    const grant = makeGrant();
+    const deleteConnectorGrant = vi.fn(async () => undefined);
+    let deleted = false;
+    const repository = {
+      listConnectorGrants: vi.fn(async () => (deleted ? [] : [grant])),
+      getConnectorGrant: vi.fn(async () => null),
+      getHealthSyncState: vi.fn(async () => null),
+      deleteConnectorGrant: deleteConnectorGrant.mockImplementation(
+        async () => {
+          deleted = true;
+        },
+      ),
+    };
+    const domain = makeDomain(repository);
+
+    const status = await domain.disconnectHealthConnector(
+      { provider: "strava" },
+      REQUEST_URL,
+    );
+
+    expect(deleteConnectorGrant).toHaveBeenCalledWith(
+      AGENT_ID,
+      "strava",
+      grant.mode,
+      grant.side,
+      grant.id,
+    );
+    expect(status.connected).toBe(false);
+  });
+
+  it("summarizes stored samples across every metric bucket", async () => {
+    makeOAuthDir();
+    const samples = [
+      makeSample("steps", 4_000),
+      makeSample("steps", 2_000),
+      makeSample("active_minutes", 30),
+      makeSample("sleep_hours", 7.5),
+      makeSample("calories", 500),
+      makeSample("distance_meters", 3_000),
+      makeSample("heart_rate", 60),
+      makeSample("heart_rate", 80),
+      makeSample("resting_heart_rate", 52),
+      makeSample("heart_rate_variability", 45),
+      makeSample("sleep_score", 88),
+      makeSample("readiness_score", 91),
+      makeSample("weight_kg", 70),
+      makeSample("blood_pressure_systolic", 118),
+      makeSample("blood_pressure_diastolic", 76),
+      makeSample("blood_oxygen_percent", 98),
+      makeSample("respiratory_rate", 14),
+      makeSample("steps", 1_000, { localDate: "2026-07-09" }),
+    ];
+    const repository = {
+      listConnectorGrants: vi.fn(async () => []),
+      getConnectorGrant: vi.fn(async () => null),
+      getHealthSyncState: vi.fn(),
+      listHealthMetricSamples: vi.fn(async () => samples),
+      listHealthWorkouts: vi.fn(async () => []),
+      listHealthSleepEpisodes: vi.fn(async () => []),
+    };
+    const domain = makeDomain(repository);
+
+    const response = await domain.getHealthSummary({
+      provider: "strava",
+      days: 7,
+      metrics: ["steps", "heart_rate", "steps"] as never,
+    });
+
+    expect(response.samples).toHaveLength(samples.length);
+    expect(response.summaries).toHaveLength(2);
+    const [latest, previous] = response.summaries;
+    expect(latest).toMatchObject({
+      date: "2026-07-10",
+      provider: "strava",
+      steps: 6_000,
+      activeMinutes: 30,
+      sleepHours: 7.5,
+      calories: 500,
+      distanceMeters: 3_000,
+      heartRateAvg: 70,
+      restingHeartRate: 52,
+      hrvMs: 45,
+      sleepScore: 88,
+      readinessScore: 91,
+      weightKg: 70,
+      bloodPressureSystolic: 118,
+      bloodPressureDiastolic: 76,
+      bloodOxygenPercent: 98,
+    });
+    expect(previous).toMatchObject({ date: "2026-07-09", steps: 1_000 });
+    expect(repository.listHealthMetricSamples).toHaveBeenCalledWith(
+      AGENT_ID,
+      expect.objectContaining({
+        provider: "strava",
+        metrics: ["steps", "heart_rate"],
+        limit: 2_000,
+      }),
+    );
+  });
+
+  it("rejects malformed summary windows", async () => {
+    const domain = makeDomain({
+      listConnectorGrants: vi.fn(async () => []),
+      getConnectorGrant: vi.fn(async () => null),
+      getHealthSyncState: vi.fn(),
+    });
+    await expect(
+      domain.getHealthSummary({ startDate: "yesterday" }),
+    ).rejects.toMatchObject({ status: 400 });
+    await expect(domain.getHealthSummary({ days: -3 })).rejects.toMatchObject({
+      status: 400,
+    });
+    await expect(
+      domain.getHealthSummary({
+        startDate: "2026-07-10",
+        endDate: "2026-07-01",
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("skips disconnected providers on sync and returns the stored summary", async () => {
+    makeOAuthDir();
+    const repository = {
+      listConnectorGrants: vi.fn(async () => []),
+      getConnectorGrant: vi.fn(async () => null),
+      getHealthSyncState: vi.fn(),
+      listHealthMetricSamples: vi.fn(async () => []),
+      listHealthWorkouts: vi.fn(async () => []),
+      listHealthSleepEpisodes: vi.fn(async () => []),
+    };
+    const domain = makeDomain(repository);
+
+    const response = await domain.syncHealthConnectors({ provider: "strava" });
+
+    expect(response.summaries).toEqual([]);
+    expect(response.providers).toHaveLength(1);
+    expect(response.providers[0].connected).toBe(false);
+  });
+
+  it("routes forceSync summaries through the sync path", async () => {
+    makeOAuthDir();
+    const repository = {
+      listConnectorGrants: vi.fn(async () => []),
+      getConnectorGrant: vi.fn(async () => null),
+      getHealthSyncState: vi.fn(),
+      listHealthMetricSamples: vi.fn(async () => []),
+      listHealthWorkouts: vi.fn(async () => []),
+      listHealthSleepEpisodes: vi.fn(async () => []),
+    };
+    const domain = makeDomain(repository);
+
+    const response = await domain.getHealthSummary({
+      provider: "strava",
+      forceSync: true,
+    });
+
+    expect(response.providers).toHaveLength(1);
+    expect(response.syncedAt).toEqual(expect.any(String));
+  });
+
+  it("translates bridge unavailability into 503s for daily reads", async () => {
+    delete process.env.ELIZA_HEALTHKIT_CLI_PATH;
+    delete process.env.ELIZA_GOOGLE_FIT_ACCESS_TOKEN;
+    const domain = makeDomain({});
+
+    await expect(
+      domain.getHealthDailySummary("2026-07-10"),
+    ).rejects.toMatchObject({ status: 503 });
+    await expect(domain.getHealthTrend(7)).rejects.toMatchObject({
+      status: 503,
+    });
+    await expect(
+      domain.getHealthDataPoints({
+        metric: "steps",
+        startAt: "2026-07-09T00:00:00.000Z",
+        endAt: "2026-07-10T00:00:00.000Z",
+      }),
+    ).rejects.toMatchObject({ status: 503 });
+  });
 });

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/health-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/health-service.ts
@@ -18,10 +18,7 @@ import {
   type HealthDailySummary,
   type HealthDataPoint,
   HealthOAuthError,
-  healthConnectorCapabilities,
-  readStoredHealthToken,
   refreshStoredHealthToken,
-  resolveHealthOAuthConfig,
   startHealthConnectorOAuth,
   syncHealthConnectorData,
 } from "@elizaos/plugin-health";
@@ -60,6 +57,10 @@ import {
   normalizeOptionalConnectorSide,
 } from "../service-normalize-connector.js";
 import { LifeOpsServiceError } from "../service-types.js";
+import {
+  getHealthDataConnectorStatus,
+  getHealthDataConnectorStatuses,
+} from "./health-connector-status.js";
 
 type HealthSyncRequest = SyncLifeOpsHealthConnectorRequest & {
   failOnProviderError?: boolean;
@@ -191,17 +192,6 @@ function normalizeHealthMetrics(
     return undefined;
   }
   return [...new Set(metrics)];
-}
-
-function healthCapabilitiesFromGrant(
-  capabilities: readonly string[],
-): LifeOpsHealthConnectorCapability[] {
-  return capabilities.filter(
-    (capability): capability is LifeOpsHealthConnectorCapability =>
-      (LIFEOPS_HEALTH_CONNECTOR_CAPABILITIES as readonly string[]).includes(
-        capability,
-      ),
-  );
 }
 
 function emptyDailySummary(
@@ -364,15 +354,12 @@ export class HealthDomain {
     requestedMode?: LifeOpsConnectorMode,
     requestedSide?: LifeOpsConnectorSide,
   ): Promise<LifeOpsHealthConnectorStatus[]> {
-    return Promise.all(
-      LIFEOPS_HEALTH_CONNECTOR_PROVIDERS.map((provider) =>
-        this.getHealthDataConnectorStatus(
-          provider,
-          requestUrl,
-          requestedMode,
-          requestedSide,
-        ),
-      ),
+    return getHealthDataConnectorStatuses(
+      this.ctx,
+      LIFEOPS_HEALTH_CONNECTOR_PROVIDERS,
+      requestUrl,
+      requestedMode,
+      requestedSide,
     );
   }
 
@@ -382,96 +369,13 @@ export class HealthDomain {
     requestedMode?: LifeOpsConnectorMode,
     requestedSide?: LifeOpsConnectorSide,
   ): Promise<LifeOpsHealthConnectorStatus> {
-    const provider = normalizeHealthProvider(providerInput);
-    const side =
-      normalizeOptionalConnectorSide(requestedSide, "side") ?? "owner";
-    const explicitMode = normalizeOptionalConnectorMode(requestedMode, "mode");
-    const grants = (
-      await this.ctx.repository.listConnectorGrants(this.ctx.agentId())
-    ).filter(
-      (grant) =>
-        grant.provider === provider &&
-        grant.side === side &&
-        (!explicitMode || grant.mode === explicitMode),
-    );
-    const preferredGrant =
-      [...grants].sort((left, right) =>
-        right.updatedAt.localeCompare(left.updatedAt),
-      )[0] ?? null;
-    const config = resolveHealthOAuthConfig(
-      provider,
+    return getHealthDataConnectorStatus(
+      this.ctx,
+      providerInput,
       requestUrl,
-      explicitMode ?? preferredGrant?.mode,
+      requestedMode,
+      requestedSide,
     );
-    const grant =
-      preferredGrant ??
-      (await this.ctx.repository.getConnectorGrant(
-        this.ctx.agentId(),
-        provider,
-        config.mode,
-        side,
-      ));
-    const token = readStoredHealthToken(grant?.tokenRef);
-    const syncState = grant
-      ? await this.ctx.repository.getHealthSyncState(
-          this.ctx.agentId(),
-          provider,
-          grant.id,
-        )
-      : null;
-    const metadataAuthState =
-      typeof grant?.metadata.authState === "string"
-        ? grant.metadata.authState
-        : null;
-    const connected = Boolean(
-      grant && token && metadataAuthState !== "needs_reauth",
-    );
-    const reason: LifeOpsHealthConnectorStatus["reason"] = connected
-      ? syncState?.lastSyncError
-        ? "sync_failed"
-        : "connected"
-      : grant && (grant.tokenRef || metadataAuthState === "needs_reauth")
-        ? "needs_reauth"
-        : config.configured
-          ? "disconnected"
-          : "config_missing";
-    return {
-      provider,
-      side,
-      mode: grant?.mode ?? config.mode,
-      defaultMode: config.defaultMode,
-      availableModes: config.availableModes,
-      executionTarget: grant?.executionTarget ?? "local",
-      sourceOfTruth: grant?.sourceOfTruth ?? "local_storage",
-      configured: config.configured,
-      connected,
-      reason,
-      identity: token?.identity ?? grant?.identity ?? null,
-      grantedCapabilities: grant
-        ? healthCapabilitiesFromGrant(grant.capabilities)
-        : healthConnectorCapabilities(provider),
-      grantedScopes: token?.grantedScopes ?? grant?.grantedScopes ?? [],
-      expiresAt: token?.expiresAt
-        ? new Date(token.expiresAt).toISOString()
-        : typeof grant?.metadata.expiresAt === "string"
-          ? grant.metadata.expiresAt
-          : null,
-      hasRefreshToken:
-        Boolean(token?.refreshToken) ||
-        Boolean(grant?.metadata.hasRefreshToken),
-      lastSyncAt: syncState?.lastSyncedAt ?? null,
-      grant,
-      degradations: syncState?.lastSyncError
-        ? [
-            {
-              axis: "delivery-degraded",
-              code: "last_sync_failed",
-              message: syncState.lastSyncError,
-              retryable: true,
-            },
-          ]
-        : undefined,
-    };
   }
 
   async startHealthConnector(

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/health-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/health-service.ts
@@ -411,7 +411,7 @@ export class HealthDomain {
         config.mode,
         side,
       ));
-    const token = readStoredHealthToken(grant.tokenRef);
+    const token = readStoredHealthToken(grant?.tokenRef);
     const syncState = grant
       ? await this.ctx.repository.getHealthSyncState(
           this.ctx.agentId(),
@@ -420,7 +420,7 @@ export class HealthDomain {
         )
       : null;
     const metadataAuthState =
-      typeof grant.metadata.authState === "string"
+      typeof grant?.metadata.authState === "string"
         ? grant.metadata.authState
         : null;
     const connected = Boolean(
@@ -438,26 +438,27 @@ export class HealthDomain {
     return {
       provider,
       side,
-      mode: grant.mode,
+      mode: grant?.mode ?? config.mode,
       defaultMode: config.defaultMode,
       availableModes: config.availableModes,
-      executionTarget: grant.executionTarget,
-      sourceOfTruth: grant.sourceOfTruth,
+      executionTarget: grant?.executionTarget ?? "local",
+      sourceOfTruth: grant?.sourceOfTruth ?? "local_storage",
       configured: config.configured,
       connected,
       reason,
-      identity: token?.identity ?? grant.identity,
+      identity: token?.identity ?? grant?.identity ?? null,
       grantedCapabilities: grant
         ? healthCapabilitiesFromGrant(grant.capabilities)
         : healthConnectorCapabilities(provider),
-      grantedScopes: token?.grantedScopes ?? grant.grantedScopes,
+      grantedScopes: token?.grantedScopes ?? grant?.grantedScopes ?? [],
       expiresAt: token?.expiresAt
         ? new Date(token.expiresAt).toISOString()
-        : typeof grant.metadata.expiresAt === "string"
+        : typeof grant?.metadata.expiresAt === "string"
           ? grant.metadata.expiresAt
           : null,
       hasRefreshToken:
-        Boolean(token?.refreshToken) || Boolean(grant.metadata.hasRefreshToken),
+        Boolean(token?.refreshToken) ||
+        Boolean(grant?.metadata.hasRefreshToken),
       lastSyncAt: syncState?.lastSyncedAt ?? null,
       grant,
       degradations: syncState?.lastSyncError


### PR DESCRIPTION
Fixes #16009.
Fixes #16032.
Fixes #16033.

Supersedes the closed #16010 without its rejected timeout increase.

## Root causes

- Clean runners installed with `--ignore-scripts` but built a hand-maintained subset of the scenario runner's transitive workspace graph, exposing missing dist artifacts one package at a time.
- `wake-up-routine` was classified as a `simple` wellness reply at Stage 1, so explicit first-person sleep/recovery telemetry never reached `OWNER_HEALTH`.
- `app-list` selected `APP action=list`, but the live harness had no real agent API host behind the production loopback client. The tool returned `fetch failed`; retries then consumed the 120-second turn.

## Fix

- Build the complete Turbo `@elizaos/scenario-runner...` dependency closure, run all live roots with workspace source conditions, and remove build-time model secrets.
- Declare the agent server's dynamically imported `@elizaos/plugin-app-manager` dependency so Turbo includes it.
- Add a health-owned Stage-1 evaluator that routes explicit owner telemetry reads to `OWNER_HEALTH`, while excluding clinical-advice requests and staying inactive when the host action is absent.
- Start the real production agent API server on an ephemeral port in the app-list live scenario. No fetch shim or timeout increase. Assert successful structured installed/running arrays.
- Strengthen both scenarios with successful-action and selected-argument checks.

## Verification

- `node packages/scripts/run-turbo.mjs run build --filter=@elizaos/scenario-runner... --concurrency=8` — 103/103 tasks passed across 108 packages, including app-manager.
- plugin-health: 180 passed, 4 skipped; typecheck passed.
- plugin-app-control: 1,488 passed.
- Workflow contract: 3 passed.
- Production-path host probe: real `startApiServer({ port: 0, runtime })` + real `AppControlClient` returned valid `installedCount: 0`, `runningCount: 0`.
- Root verify passed all ratchets and touched-package lanes; the unrelated cloud-api `wrangler deploy --dry-run` process was stopped after hanging for more than six minutes.
- Exact-head credentialed enforcing workflow: pending.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI and agent-routing changes; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - CI and agent-routing changes; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual interaction flow.
<!-- evidence-row:backend-logs -->
- [x] [Pre-fix exact-head run and uploaded reports](https://github.com/elizaOS/eliza/actions/runs/29081932114)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path.
<!-- evidence-row:llm-trajectory -->
- [x] [Pre-fix manually reviewed live trajectories](https://github.com/elizaOS/eliza/actions/runs/29081932114/artifacts/8223367890)
<!-- evidence-row:domain-artifacts -->
- [x] [Scenario reports, native rows, and viewers](https://github.com/elizaOS/eliza/actions/runs/29081932114/artifacts/8223367890)
