### PR TITLE
fix(cloud): route-level wake contract tests, strict wake body, freshness edge proof (#15804)

### DIFF
--- a/packages/cloud/api/__tests__/eliza-agents-wake-route.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-wake-route.test.ts
@@ -1,0 +1,625 @@
+/**
+ * Route-level contract for POST /api/v1/eliza/agents/:agentId/wake (#15804).
+ *
+ * The wake boundary landed in #15789 with service-level coverage only; this
+ * suite proves the public HTTP contract through the REAL route module with
+ * NOTHING mocked: real API-key authentication (seeded sha256 hashes resolved
+ * by `requireAuthOrApiKey` against the DB), real `elizaSandboxService` agent
+ * and backup-metadata lookups, the real credit gate reading
+ * `organizations.credit_balance`, the real provisioning-worker health check
+ * against the process-global MOCK_REDIS store, and the real
+ * `enqueueAgentWakeOnce` Drizzle transaction (advisory lock, reuse lookup,
+ * jobs insert) — all on in-process PGlite via drizzle-kit `pushSchema`.
+ *
+ * Covers: authentication, tenant isolation, malformed / unknown / invalid
+ * JSON bodies, restoreBackupId⊕forceFreshBoot mutual exclusion, cross-org
+ * backup ownership (no existence oracle), the failed-verification-backup 409,
+ * the credit and worker gates, in-flight-job param conflicts, and the
+ * shared-tier / already-running short-circuits. Job rows are asserted in the
+ * database, not inferred from the response.
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { createHash } from "node:crypto";
+import { z } from "zod";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+process.env.SKIP_AGENT_SANDBOX_ENSURE = "1";
+
+import { Hono } from "hono";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+const ORG_A = "11111111-1111-4111-8111-111111111111";
+const ORG_B = "22222222-2222-4222-8222-222222222222";
+const ORG_POOR = "33333333-3333-4333-8333-333333333333";
+const USER_A = "aaaaaaaa-1111-4111-8111-111111111111";
+const USER_B = "bbbbbbbb-2222-4222-8222-222222222222";
+const USER_POOR = "cccccccc-3333-4333-8333-333333333333";
+const AGENT_A = "dddddddd-1111-4111-8111-111111111111";
+const AGENT_B = "dddddddd-2222-4222-8222-222222222222";
+const AGENT_POOR = "dddddddd-3333-4333-8333-333333333333";
+const AGENT_SHARED = "dddddddd-4444-4444-8444-444444444444";
+const AGENT_RUNNING = "dddddddd-5555-4555-8555-555555555555";
+const BACKUP_A_OK = "eeeeeeee-1111-4111-8111-111111111111";
+const BACKUP_A_FAILED = "eeeeeeee-2222-4222-8222-222222222222";
+const BACKUP_B = "eeeeeeee-3333-4333-8333-333333333333";
+const MISSING_BACKUP = "eeeeeeee-9999-4999-8999-999999999999";
+
+// Plaintext API keys; only their sha256 hashes are stored, exactly as the
+// production key-mint path does, so `requireAuthOrApiKey` resolves them for real.
+const KEY_A = "eliza_wake_route_test_org_a";
+const KEY_B = "eliza_wake_route_test_org_b";
+const KEY_POOR = "eliza_wake_route_test_org_poor";
+
+function sha256Hex(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+// Response DTO schemas — strict runtime validation instead of `as` casts, so a
+// drifted wire shape fails the suite instead of silently passing vacuous asserts.
+const errorBody = z.object({
+  success: z.literal(false),
+  error: z.string(),
+  code: z.string().optional(),
+  details: z.unknown().optional(),
+});
+
+const zodRejectionBody = z.object({
+  success: z.literal(false),
+  error: z.literal("Invalid request"),
+  details: z.array(z.object({ code: z.string(), message: z.string() })),
+});
+
+const wakeEnqueuedBody = z.object({
+  success: z.literal(true),
+  created: z.boolean(),
+  alreadyInProgress: z.boolean(),
+  data: z.object({
+    agentId: z.string(),
+    action: z.literal("wake"),
+    jobId: z.string(),
+    status: z.string(),
+    previousStatus: z.string(),
+    restoreBackupId: z.string().nullable(),
+    forceFreshBoot: z.boolean(),
+    message: z.string(),
+  }),
+  polling: z.object({
+    endpoint: z.string(),
+    intervalMs: z.number(),
+    expectedDurationMs: z.number(),
+  }),
+});
+
+const conflictDetails = z.object({
+  conflictingJobId: z.string(),
+  activeRestoreBackupId: z.string().nullable(),
+  activeForceFreshBoot: z.boolean(),
+  requestedRestoreBackupId: z.string().nullable(),
+  requestedForceFreshBoot: z.boolean(),
+});
+
+const sharedRuntimeBody = z.object({
+  success: z.literal(true),
+  source: z.literal("shared_runtime"),
+  data: z.object({
+    agentId: z.string(),
+    action: z.literal("wake"),
+    message: z.string(),
+    status: z.string(),
+    executionTier: z.string(),
+  }),
+});
+
+const alreadyRunningBody = z.object({
+  success: z.literal(true),
+  data: z.object({
+    agentId: z.string(),
+    action: z.literal("wake"),
+    message: z.literal("Agent is already running"),
+    status: z.literal("running"),
+  }),
+});
+
+let pgliteReady = true;
+let closeDb: (() => Promise<void>) | undefined;
+let clearJobs: (() => Promise<void>) | undefined;
+let countWakeJobs: ((agentId: string) => Promise<number>) | undefined;
+let publishHeartbeat: (() => Promise<boolean>) | undefined;
+let app: Hono<AppEnv>;
+
+beforeAll(async () => {
+  try {
+    const { closeDatabaseConnectionsForTests, dbWrite } = await import(
+      "@/db/client"
+    );
+    closeDb = closeDatabaseConnectionsForTests;
+
+    const { organizations } = await import("@/db/schemas/organizations");
+    const { users } = await import("@/db/schemas/users");
+    const { userCharacters } = await import("@/db/schemas/user-characters");
+    const { agentSandboxes, agentSandboxBackups } = await import(
+      "@/db/schemas/agent-sandboxes"
+    );
+    const { apiKeys } = await import("@/db/schemas/api-keys");
+    const { generations } = await import("@/db/schemas/generations");
+    const { jobs } = await import("@/db/schemas/jobs");
+    const { usageRecords } = await import("@/db/schemas/usage-records");
+    const { pushSchemaToTestDb } = await import("@/db/push-schema-for-tests");
+    const { eq, and } = await import("drizzle-orm");
+
+    await pushSchemaToTestDb({
+      organizations,
+      users,
+      userCharacters,
+      agentSandboxes,
+      agentSandboxBackups,
+      apiKeys,
+      generations,
+      jobs,
+      usageRecords,
+    });
+
+    clearJobs = async () => {
+      await dbWrite.delete(jobs);
+    };
+    countWakeJobs = async (agentId: string) => {
+      const rows = await dbWrite
+        .select({ id: jobs.id })
+        .from(jobs)
+        .where(and(eq(jobs.type, "agent_wake"), eq(jobs.agent_id, agentId)));
+      return rows.length;
+    };
+
+    const { publishProvisioningWorkerHeartbeat } = await import(
+      "@/lib/services/provisioning-worker-health"
+    );
+    publishHeartbeat = () => publishProvisioningWorkerHeartbeat();
+
+    await dbWrite.insert(organizations).values([
+      { id: ORG_A, name: "Org A", slug: "wake-org-a", credit_balance: "25" },
+      { id: ORG_B, name: "Org B", slug: "wake-org-b", credit_balance: "25" },
+      // Exactly the MINIMUM_DEPOSIT boundary: the gate requires balance to
+      // EXCEED the minimum, so 0.1 is denied.
+      {
+        id: ORG_POOR,
+        name: "Org Poor",
+        slug: "wake-org-poor",
+        credit_balance: "0.1",
+      },
+    ]);
+    await dbWrite.insert(users).values([
+      {
+        id: USER_A,
+        email: "wake-owner-a@test.test",
+        organization_id: ORG_A,
+        role: "owner",
+        steward_user_id: `steward-${USER_A}`,
+      },
+      {
+        id: USER_B,
+        email: "wake-owner-b@test.test",
+        organization_id: ORG_B,
+        role: "owner",
+        steward_user_id: `steward-${USER_B}`,
+      },
+      {
+        id: USER_POOR,
+        email: "wake-owner-poor@test.test",
+        organization_id: ORG_POOR,
+        role: "owner",
+        steward_user_id: `steward-${USER_POOR}`,
+      },
+    ]);
+    await dbWrite.insert(apiKeys).values([
+      {
+        name: "wake test key org A",
+        key_hash: sha256Hex(KEY_A),
+        key_prefix: KEY_A.slice(0, 8),
+        organization_id: ORG_A,
+        user_id: USER_A,
+      },
+      {
+        name: "wake test key org B",
+        key_hash: sha256Hex(KEY_B),
+        key_prefix: KEY_B.slice(0, 8),
+        organization_id: ORG_B,
+        user_id: USER_B,
+      },
+      {
+        name: "wake test key org POOR",
+        key_hash: sha256Hex(KEY_POOR),
+        key_prefix: KEY_POOR.slice(0, 8),
+        organization_id: ORG_POOR,
+        user_id: USER_POOR,
+      },
+    ]);
+
+    await dbWrite.insert(agentSandboxes).values([
+      {
+        id: AGENT_A,
+        organization_id: ORG_A,
+        user_id: USER_A,
+        agent_name: "Wake Agent A",
+        execution_tier: "dedicated-lazy",
+        status: "sleeping",
+      },
+      {
+        id: AGENT_B,
+        organization_id: ORG_B,
+        user_id: USER_B,
+        agent_name: "Wake Agent B",
+        execution_tier: "dedicated-lazy",
+        status: "sleeping",
+      },
+      {
+        id: AGENT_POOR,
+        organization_id: ORG_POOR,
+        user_id: USER_POOR,
+        agent_name: "Wake Agent Poor",
+        execution_tier: "dedicated-lazy",
+        status: "sleeping",
+      },
+      {
+        id: AGENT_SHARED,
+        organization_id: ORG_A,
+        user_id: USER_A,
+        agent_name: "Wake Agent Shared",
+        execution_tier: "shared",
+        status: "running",
+      },
+      {
+        id: AGENT_RUNNING,
+        organization_id: ORG_A,
+        user_id: USER_A,
+        agent_name: "Wake Agent Running",
+        execution_tier: "dedicated-always",
+        status: "running",
+        bridge_url: "http://bridge.test.internal",
+        health_url: "http://health.test.internal",
+      },
+    ]);
+
+    await dbWrite.insert(agentSandboxBackups).values([
+      {
+        id: BACKUP_A_OK,
+        sandbox_record_id: AGENT_A,
+        snapshot_type: "manual",
+        state_data: { memories: [], config: {}, workspaceFiles: {} },
+        size_bytes: 16,
+      },
+      {
+        id: BACKUP_A_FAILED,
+        sandbox_record_id: AGENT_A,
+        snapshot_type: "pre-shutdown",
+        state_data: { memories: [], config: {}, workspaceFiles: {} },
+        size_bytes: 16,
+        verification_status: "failed",
+        verified_at: new Date("2026-07-09T00:00:00.000Z"),
+        verification_error: "decrypt-failed: AEAD decrypt failed",
+      },
+      {
+        id: BACKUP_B,
+        sandbox_record_id: AGENT_B,
+        snapshot_type: "manual",
+        state_data: { memories: [], config: {}, workspaceFiles: {} },
+        size_bytes: 16,
+      },
+    ]);
+
+    const wakeRoute = (await import("../v1/eliza/agents/[agentId]/wake/route"))
+      .default;
+    app = new Hono<AppEnv>();
+    app.route("/api/v1/eliza/agents/:agentId/wake", wakeRoute);
+  } catch (error) {
+    pgliteReady = false;
+    console.error(
+      "[eliza-agents-wake-route.test] setup failed — failing.",
+      error,
+    );
+  }
+}, 120_000);
+
+beforeEach(async () => {
+  expect(pgliteReady).toBe(true);
+  if (!clearJobs) throw new Error("harness not initialized");
+  // Each test starts with an empty job queue so enqueue/conflict outcomes are
+  // its own, not residue from a previous case.
+  await clearJobs();
+});
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+async function wake(
+  agentId: string,
+  init: { key?: string; body?: BodyInit } = {},
+): Promise<Response> {
+  const headers = new Headers();
+  if (init.key !== undefined) headers.set("X-API-Key", init.key);
+  if (init.body !== undefined) headers.set("Content-Type", "application/json");
+  return app.request(`/api/v1/eliza/agents/${agentId}/wake`, {
+    method: "POST",
+    headers,
+    ...(init.body === undefined ? {} : { body: init.body }),
+  });
+}
+
+describe("authentication", () => {
+  test("no credentials at all is a 401, not an enqueued job", async () => {
+    const res = await wake(AGENT_A);
+    expect(res.status).toBe(401);
+    const body = errorBody.parse(await res.json());
+    expect(body.error).toBe("Authentication required");
+    if (!countWakeJobs) throw new Error("harness not initialized");
+    expect(await countWakeJobs(AGENT_A)).toBe(0);
+  });
+
+  test("an unknown API key is a 401", async () => {
+    const res = await wake(AGENT_A, { key: "eliza_wake_route_test_bogus" });
+    expect(res.status).toBe(401);
+    const body = errorBody.parse(await res.json());
+    expect(body.error).toBe("Invalid or expired API key");
+  });
+});
+
+describe("tenant isolation", () => {
+  test("another org's key cannot wake the agent — 404, indistinguishable from missing", async () => {
+    const crossOrg = await wake(AGENT_A, { key: KEY_B });
+    expect(crossOrg.status).toBe(404);
+    expect(errorBody.parse(await crossOrg.json()).error).toBe(
+      "Agent not found",
+    );
+
+    const missing = await wake("99999999-9999-4999-8999-999999999999", {
+      key: KEY_B,
+    });
+    expect(missing.status).toBe(404);
+    expect(errorBody.parse(await missing.json()).error).toBe("Agent not found");
+
+    if (!countWakeJobs) throw new Error("harness not initialized");
+    expect(await countWakeJobs(AGENT_A)).toBe(0);
+  });
+});
+
+describe("request body validation", () => {
+  test("malformed JSON is a typed 400, not a 500", async () => {
+    const res = await wake(AGENT_A, { key: KEY_A, body: "{nope" });
+    expect(res.status).toBe(400);
+    expect(errorBody.parse(await res.json()).error).toBe("Invalid JSON body");
+  });
+
+  test("unknown JSON fields are rejected, not silently dropped", async () => {
+    // A typo'd restore field silently ignored would turn an explicit
+    // restore-point choice into a default latest-backup wake.
+    const res = await wake(AGENT_A, {
+      key: KEY_A,
+      body: JSON.stringify({ restoreBackupID: BACKUP_A_OK }),
+    });
+    expect(res.status).toBe(400);
+    const body = zodRejectionBody.parse(await res.json());
+    expect(body.details.map((issue) => issue.code)).toContain(
+      "unrecognized_keys",
+    );
+    if (!countWakeJobs) throw new Error("harness not initialized");
+    expect(await countWakeJobs(AGENT_A)).toBe(0);
+  });
+
+  test("non-uuid restoreBackupId is a 400", async () => {
+    const res = await wake(AGENT_A, {
+      key: KEY_A,
+      body: JSON.stringify({ restoreBackupId: "latest" }),
+    });
+    expect(res.status).toBe(400);
+    zodRejectionBody.parse(await res.json());
+  });
+
+  test("restoreBackupId and forceFreshBoot are mutually exclusive", async () => {
+    const res = await wake(AGENT_A, {
+      key: KEY_A,
+      body: JSON.stringify({
+        restoreBackupId: BACKUP_A_OK,
+        forceFreshBoot: true,
+      }),
+    });
+    expect(res.status).toBe(400);
+    expect(errorBody.parse(await res.json()).error).toBe(
+      "restoreBackupId and forceFreshBoot are mutually exclusive",
+    );
+  });
+});
+
+describe("backup ownership", () => {
+  test("another agent's backupId and a nonexistent one are the same 404 (no existence oracle)", async () => {
+    const foreign = await wake(AGENT_A, {
+      key: KEY_A,
+      body: JSON.stringify({ restoreBackupId: BACKUP_B }),
+    });
+    expect(foreign.status).toBe(404);
+    const foreignBody = errorBody.parse(await foreign.json());
+
+    const missing = await wake(AGENT_A, {
+      key: KEY_A,
+      body: JSON.stringify({ restoreBackupId: MISSING_BACKUP }),
+    });
+    expect(missing.status).toBe(404);
+    const missingBody = errorBody.parse(await missing.json());
+
+    expect(foreignBody.error).toBe("No backup found");
+    expect(missingBody.error).toBe(foreignBody.error);
+  });
+
+  test("a backup stamped failed is refused up front with the escape hatches named", async () => {
+    const res = await wake(AGENT_A, {
+      key: KEY_A,
+      body: JSON.stringify({ restoreBackupId: BACKUP_A_FAILED }),
+    });
+    expect(res.status).toBe(409);
+    const body = errorBody.parse(await res.json());
+    expect(body.error).toContain("previously failed restore-integrity");
+    expect(body.error).toContain("AEAD decrypt failed");
+    expect(body.error).toContain("forceFreshBoot");
+  });
+});
+
+describe("credit gate", () => {
+  test("an org at the minimum deposit boundary is denied with the canonical 402 body", async () => {
+    const res = await wake(AGENT_POOR, { key: KEY_POOR });
+    expect(res.status).toBe(402);
+    const body = z
+      .object({
+        success: z.literal(false),
+        code: z.literal("insufficient_credits"),
+        error: z.string(),
+        requiredBalance: z.number(),
+        currentBalance: z.number(),
+      })
+      .parse(await res.json());
+    expect(body.currentBalance).toBe(0.1);
+    if (!countWakeJobs) throw new Error("harness not initialized");
+    expect(await countWakeJobs(AGENT_POOR)).toBe(0);
+  });
+});
+
+describe("provisioning worker gate", () => {
+  test("when the worker is required, wake fails closed on a missing heartbeat and opens on a fresh one", async () => {
+    if (!publishHeartbeat || !countWakeJobs)
+      throw new Error("harness not initialized");
+    process.env.REQUIRE_PROVISIONING_WORKER = "true";
+    try {
+      const blocked = await wake(AGENT_A, { key: KEY_A });
+      expect(blocked.status).toBe(503);
+      const blockedBody = z
+        .object({
+          success: z.literal(false),
+          code: z.literal("PROVISIONING_WORKER_UNHEALTHY"),
+          error: z.string(),
+          retryable: z.literal(true),
+        })
+        .parse(await blocked.json());
+      expect(blockedBody.error).toContain("heartbeat");
+      expect(await countWakeJobs(AGENT_A)).toBe(0);
+
+      // The daemon's real heartbeat publisher writes to the same MOCK_REDIS
+      // store the health check reads — the gate opens without any stubbing.
+      expect(await publishHeartbeat()).toBe(true);
+      const allowed = await wake(AGENT_A, { key: KEY_A });
+      expect(allowed.status).toBe(202);
+      wakeEnqueuedBody.parse(await allowed.json());
+      expect(await countWakeJobs(AGENT_A)).toBe(1);
+    } finally {
+      delete process.env.REQUIRE_PROVISIONING_WORKER;
+    }
+  });
+});
+
+describe("enqueue and in-flight conflicts", () => {
+  test("bodyless wake enqueues a real job; a bare retry reuses it as a 409 already-in-progress", async () => {
+    if (!countWakeJobs) throw new Error("harness not initialized");
+
+    const first = await wake(AGENT_A, { key: KEY_A });
+    expect(first.status).toBe(202);
+    const firstBody = wakeEnqueuedBody.parse(await first.json());
+    expect(firstBody.created).toBe(true);
+    expect(firstBody.alreadyInProgress).toBe(false);
+    expect(firstBody.data.agentId).toBe(AGENT_A);
+    expect(firstBody.data.previousStatus).toBe("sleeping");
+    expect(firstBody.data.restoreBackupId).toBeNull();
+    expect(firstBody.data.forceFreshBoot).toBe(false);
+    expect(firstBody.polling.endpoint).toBe(
+      `/api/v1/jobs/${firstBody.data.jobId}`,
+    );
+    expect(await countWakeJobs(AGENT_A)).toBe(1);
+
+    const retry = await wake(AGENT_A, { key: KEY_A });
+    expect(retry.status).toBe(409);
+    const retryBody = wakeEnqueuedBody.parse(await retry.json());
+    expect(retryBody.created).toBe(false);
+    expect(retryBody.alreadyInProgress).toBe(true);
+    expect(retryBody.data.jobId).toBe(firstBody.data.jobId);
+    // Still exactly one job row: the retry reused, not duplicated.
+    expect(await countWakeJobs(AGENT_A)).toBe(1);
+  });
+
+  test("a param-bearing request conflicting with the in-flight job is a typed 409 naming that job", async () => {
+    if (!countWakeJobs) throw new Error("harness not initialized");
+
+    const first = await wake(AGENT_A, { key: KEY_A });
+    expect(first.status).toBe(202);
+    const firstBody = wakeEnqueuedBody.parse(await first.json());
+
+    const conflicting = await wake(AGENT_A, {
+      key: KEY_A,
+      body: JSON.stringify({ forceFreshBoot: true }),
+    });
+    expect(conflicting.status).toBe(409);
+    const conflictBody = errorBody.parse(await conflicting.json());
+    expect(conflictBody.error).toContain("different restore parameters");
+    const details = conflictDetails.parse(conflictBody.details);
+    expect(details.conflictingJobId).toBe(firstBody.data.jobId);
+    expect(details.activeForceFreshBoot).toBe(false);
+    expect(details.requestedForceFreshBoot).toBe(true);
+    expect(await countWakeJobs(AGENT_A)).toBe(1);
+  });
+
+  test("a bare retry over a param-bearing in-flight job echoes the params the job will ACTUALLY apply", async () => {
+    const first = await wake(AGENT_A, {
+      key: KEY_A,
+      body: JSON.stringify({ restoreBackupId: BACKUP_A_OK }),
+    });
+    expect(first.status).toBe(202);
+    const firstBody = wakeEnqueuedBody.parse(await first.json());
+    expect(firstBody.data.restoreBackupId).toBe(BACKUP_A_OK);
+
+    // The bare retry rides the active job; the response must report the
+    // active job's restore point, never the caller's unapplied defaults.
+    const retry = await wake(AGENT_A, { key: KEY_A });
+    expect(retry.status).toBe(409);
+    const retryBody = wakeEnqueuedBody.parse(await retry.json());
+    expect(retryBody.alreadyInProgress).toBe(true);
+    expect(retryBody.data.jobId).toBe(firstBody.data.jobId);
+    expect(retryBody.data.restoreBackupId).toBe(BACKUP_A_OK);
+  });
+});
+
+describe("short-circuits", () => {
+  test("a shared-tier agent needs no wake job", async () => {
+    if (!countWakeJobs) throw new Error("harness not initialized");
+    const res = await wake(AGENT_SHARED, { key: KEY_A });
+    expect(res.status).toBe(200);
+    const body = sharedRuntimeBody.parse(await res.json());
+    expect(body.data.executionTier).toBe("shared");
+    expect(await countWakeJobs(AGENT_SHARED)).toBe(0);
+  });
+
+  test("an already-running dedicated agent needs no wake job", async () => {
+    if (!countWakeJobs) throw new Error("harness not initialized");
+    const res = await wake(AGENT_RUNNING, { key: KEY_A });
+    expect(res.status).toBe(200);
+    alreadyRunningBody.parse(await res.json());
+    expect(await countWakeJobs(AGENT_RUNNING)).toBe(0);
+  });
+});
+
+describe("CORS preflight", () => {
+  test("OPTIONS answers 204 with the route's method allowlist", async () => {
+    const res = await app.request(`/api/v1/eliza/agents/${AGENT_A}/wake`, {
+      method: "OPTIONS",
+    });
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Methods")).toBe(
+      "POST, OPTIONS",
+    );
+  });
+});

--- a/packages/cloud/api/__tests__/eliza-agents-wake-route.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-wake-route.test.ts
@@ -4,7 +4,8 @@
  * The wake boundary landed in #15789 with service-level coverage only; this
  * suite proves the public HTTP contract through the REAL route module with
  * NOTHING mocked: real API-key authentication (seeded sha256 hashes resolved
- * by `requireAuthOrApiKey` against the DB), real `elizaSandboxService` agent
+ * by `requireAuthOrApiKeyWithOrg` against the DB), real `elizaSandboxService`
+ * agent
  * and backup-metadata lookups, the real credit gate reading
  * `organizations.credit_balance`, the real provisioning-worker health check
  * against the process-global MOCK_REDIS store, and the real

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/wake/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/wake/route.ts
@@ -17,7 +17,11 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 const CORS_METHODS = "POST, OPTIONS";
 
-const wakeSchema = z.object({
+// Strict: this body selects between integrity-relevant wake modes, so an
+// unrecognized key (e.g. a typo'd `restoreBackupID`) must be a 400, not a
+// silently-ignored field that turns an explicit restore-point/fresh-boot
+// choice into the default latest-backup wake.
+const wakeSchema = z.strictObject({
   restoreBackupId: z.string().uuid().optional(),
   forceFreshBoot: z.boolean().optional(),
 });

--- a/packages/cloud/shared/src/db/client.ts
+++ b/packages/cloud/shared/src/db/client.ts
@@ -75,22 +75,23 @@ function parsePGliteDataDir(url: string): string {
 }
 
 /**
+ * The live PGlite instance behind the write connection, captured for
+ * `getPgliteClientForTests`. Test-only surface: PGlite-backed suites need the
+ * raw client to apply generated DDL (drizzle-kit `pushSchema`) to the SAME
+ * in-memory database the exported `db`/`dbRead`/`dbWrite` proxies query.
+ * `instanceof` probing from callers cannot do this — the CJS require in
+ * `createPGliteClient` and an ESM `import` resolve two distinct copies of the
+ * PGlite class.
+ */
+let pgliteClientForTests: import("@electric-sql/pglite").PGlite | null = null;
+
+/**
  * Build a PGlite instance with the `vector` extension loaded so the
  * cloud schema's pgvector columns (used by trajectories, embeddings, etc.)
  * resolve at migration and query time. Synchronous module require keeps the
  * call site type as `Database`; PGlite is bun/node-only and does not exist
  * on the Workers runtime.
  */
-/**
- * The live PGlite instance behind the write connection, captured for
- * `getPgliteClientForTests`. Test-only surface: PGlite-backed suites need the
- * raw client to apply generated DDL (drizzle-kit `pushSchema`) to the SAME
- * in-memory database the exported `db`/`dbRead`/`dbWrite` proxies query.
- * `instanceof` probing from callers cannot do this — the CJS require below
- * and an ESM `import` resolve two distinct copies of the PGlite class.
- */
-let pgliteClientForTests: import("@electric-sql/pglite").PGlite | null = null;
-
 function createPGliteClient(dataDir: string): Database {
   const { PGlite } = require("@electric-sql/pglite") as typeof import("@electric-sql/pglite");
   const { vector } =

--- a/packages/cloud/shared/src/db/client.ts
+++ b/packages/cloud/shared/src/db/client.ts
@@ -81,6 +81,16 @@ function parsePGliteDataDir(url: string): string {
  * call site type as `Database`; PGlite is bun/node-only and does not exist
  * on the Workers runtime.
  */
+/**
+ * The live PGlite instance behind the write connection, captured for
+ * `getPgliteClientForTests`. Test-only surface: PGlite-backed suites need the
+ * raw client to apply generated DDL (drizzle-kit `pushSchema`) to the SAME
+ * in-memory database the exported `db`/`dbRead`/`dbWrite` proxies query.
+ * `instanceof` probing from callers cannot do this — the CJS require below
+ * and an ESM `import` resolve two distinct copies of the PGlite class.
+ */
+let pgliteClientForTests: import("@electric-sql/pglite").PGlite | null = null;
+
 function createPGliteClient(dataDir: string): Database {
   const { PGlite } = require("@electric-sql/pglite") as typeof import("@electric-sql/pglite");
   const { vector } =
@@ -89,6 +99,7 @@ function createPGliteClient(dataDir: string): Database {
     dataDir: dataDir === "memory://" ? undefined : dataDir,
     extensions: { vector },
   });
+  pgliteClientForTests = client;
   const database: PgliteDatabase<typeof schema> = drizzlePGlite({ client, schema });
   return registerDatabaseCloser(database as Database, async () => {
     await client.close();
@@ -484,6 +495,22 @@ export function getDbConnectionInfo() {
  */
 export async function closeDatabaseConnectionsForTests(): Promise<void> {
   await connectionManager.closeAll();
+}
+
+/**
+ * TEST-ONLY: the raw PGlite instance behind the write connection, forcing the
+ * lazy connection to materialize first. Throws when the configured database
+ * is not PGlite — pushing test DDL into a shared Postgres would mutate schema
+ * other suites depend on, so this fails closed instead of returning null.
+ */
+export function getPgliteClientForTests(): import("@electric-sql/pglite").PGlite {
+  connectionManager.getWriteConnection();
+  if (!pgliteClientForTests) {
+    throw new Error(
+      "getPgliteClientForTests requires a PGlite-backed database (DATABASE_URL=pglite://…)",
+    );
+  }
+  return pgliteClientForTests;
 }
 
 /**

--- a/packages/cloud/shared/src/db/push-schema-for-tests.ts
+++ b/packages/cloud/shared/src/db/push-schema-for-tests.ts
@@ -1,5 +1,5 @@
 /**
- * TEST-ONLY re-export of drizzle-kit's `pushSchema` for PGlite-backed suites.
+ * TEST-ONLY schema-push helpers for PGlite-backed suites.
  *
  * `drizzle-kit` is a devDependency of @elizaos/cloud-shared, so a test that
  * lives in another package (e.g. cloud-api's route integration tests) cannot
@@ -8,4 +8,23 @@
  * code — drizzle-kit is not installed for production consumers.
  */
 
-export { pushSchema } from "drizzle-kit/api";
+import { pushSchema } from "drizzle-kit/api";
+import { drizzle as drizzlePglite } from "drizzle-orm/pglite";
+import { getPgliteClientForTests } from "./client";
+
+export { pushSchema };
+
+/**
+ * Apply the given Drizzle tables' DDL to the same PGlite database the
+ * exported `db`/`dbRead`/`dbWrite` proxies query. drizzle-kit's `pushSchema`
+ * parameter is typed as a schema-LESS `PgDatabase`, so the repo's
+ * schema-typed `Database` cannot be passed directly without a type assertion;
+ * wrapping the raw PGlite client in a fresh schema-less drizzle instance
+ * keeps the whole path type-checked while targeting the identical database.
+ * Fails closed (via `getPgliteClientForTests`) when the ambient DATABASE_URL
+ * is a shared non-PGlite Postgres.
+ */
+export async function pushSchemaToTestDb(tables: Record<string, unknown>): Promise<void> {
+  const { apply } = await pushSchema(tables, drizzlePglite({ client: getPgliteClientForTests() }));
+  await apply();
+}

--- a/packages/cloud/shared/src/lib/services/wake-restore-integrity.test.ts
+++ b/packages/cloud/shared/src/lib/services/wake-restore-integrity.test.ts
@@ -325,6 +325,75 @@ describe("runWakeRestoreIntegrityGate", () => {
     expect(alerts.map((entry) => entry.dedupKey)).toEqual(["agent-wake-restore-integrity"]);
   });
 
+  // The freshness contract has zero clock-skew tolerance: `0 <= age <=
+  // freshnessMs` is fresh, anything outside re-verifies. Each edge case below
+  // corrupts the ciphertext AFTER stamping, so the outcome proves which path
+  // ran: `fresh-stamp` means the stamp was trusted (payload never touched);
+  // `decrypt-failed` means the gate re-decrypted for real.
+  test("freshness edge: a stamp at exactly `now` (age 0) is fresh — the stamp is trusted", async () => {
+    const { sandboxId } = await seedSandbox();
+    const backupId = await seedFullBackup(sandboxId, sampleState("edge-age-zero"), NOW);
+    await stampRow(backupId, "verified", NOW);
+    await corruptBackupCiphertext(backupId);
+
+    const result = await runWakeRestoreIntegrityGate(
+      { sandboxRecordId: sandboxId },
+      { config: GATE_CONFIG, now: () => NOW },
+    );
+    expect(result).toEqual({ ok: true, backupId, verification: "fresh-stamp" });
+  });
+
+  test("freshness edge: a stamp aged exactly freshnessMs is still fresh (inclusive window)", async () => {
+    const { sandboxId } = await seedSandbox();
+    const backupId = await seedFullBackup(sandboxId, sampleState("edge-window"), NOW);
+    await stampRow(backupId, "verified", new Date(NOW.getTime() - GATE_CONFIG.verifiedFreshnessMs));
+    await corruptBackupCiphertext(backupId);
+
+    const result = await runWakeRestoreIntegrityGate(
+      { sandboxRecordId: sandboxId },
+      { config: GATE_CONFIG, now: () => NOW },
+    );
+    expect(result).toEqual({ ok: true, backupId, verification: "fresh-stamp" });
+  });
+
+  test("freshness edge: a stamp aged freshnessMs + 1ms re-verifies and catches corruption", async () => {
+    const { sandboxId } = await seedSandbox();
+    const backupId = await seedFullBackup(sandboxId, sampleState("edge-window-past"), NOW);
+    await stampRow(
+      backupId,
+      "verified",
+      new Date(NOW.getTime() - GATE_CONFIG.verifiedFreshnessMs - 1),
+    );
+    await corruptBackupCiphertext(backupId);
+
+    const { alert } = makeAlertSpy();
+    const result = await runWakeRestoreIntegrityGate(
+      { sandboxRecordId: sandboxId },
+      { config: GATE_CONFIG, now: () => NOW, alert },
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.failure.kind).toBe("decrypt-failed");
+    expect((await readBackupRow(backupId)).verification_status).toBe("failed");
+  });
+
+  test("freshness edge: a stamp 1ms in the FUTURE re-verifies — zero skew tolerance", async () => {
+    const { sandboxId } = await seedSandbox();
+    const backupId = await seedFullBackup(sandboxId, sampleState("edge-future-1ms"), NOW);
+    await stampRow(backupId, "verified", new Date(NOW.getTime() + 1));
+    await corruptBackupCiphertext(backupId);
+
+    const { alert } = makeAlertSpy();
+    const result = await runWakeRestoreIntegrityGate(
+      { sandboxRecordId: sandboxId },
+      { config: GATE_CONFIG, now: () => NOW, alert },
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.failure.kind).toBe("decrypt-failed");
+    expect((await readBackupRow(backupId)).verification_status).toBe("failed");
+  });
+
   test("freshness window is tunable: a 1h window re-verifies a 2h-old stamp", async () => {
     const { sandboxId } = await seedSandbox();
     const backupId = await seedFullBackup(sandboxId, sampleState("tight-window"), NOW);

--- a/packages/cloud/shared/src/lib/services/wake-restore-integrity.ts
+++ b/packages/cloud/shared/src/lib/services/wake-restore-integrity.ts
@@ -210,6 +210,12 @@ export interface WakeRestoreGateDeps {
 
 const WAKE_INTEGRITY_ALERT_DEDUP_KEY = "agent-wake-restore-integrity";
 
+// Freshness accepts `0 <= age <= freshnessMs`, with ZERO clock-skew tolerance
+// on the future side: a stamp even 1ms ahead of `now` is evidence of clock
+// corruption or a tampered row, and the safe response is a real re-decrypt
+// (cost: one KMS verification), never trusting the stamp. Both edges are
+// deliberate: age 0 (stamped this instant) and age == freshnessMs are fresh;
+// age < 0 and age > freshnessMs re-verify.
 function isFreshVerifiedStamp(
   row: { verification_status: string | null; verified_at: Date | null },
   now: Date,


### PR DESCRIPTION
Fixes #15804. Follow-up to #15810 (config fail-closed + future-stamp rejection) and #15789 (the wake gate itself); this PR closes the remaining acceptance criteria: the route-level contract matrix, the freshness-window edge proof, and a fail-closed wake body.

## Summary

- **Route-level test matrix through the real Hono wake boundary** — new `packages/cloud/api/__tests__/eliza-agents-wake-route.test.ts` drives the REAL route module with nothing mocked: real API-key authentication (seeded sha256 `key_hash` rows resolved by `requireAuthOrApiKey` against the DB), real `elizaSandboxService` agent/backup-metadata lookups, the real credit gate reading `organizations.credit_balance`, the real provisioning-worker heartbeat check against the process-global `MOCK_REDIS` store (heartbeat published by the daemon's real `publishProvisioningWorkerHeartbeat`), and the real `enqueueAgentWakeOnce` Drizzle transaction — all on in-process PGlite. Covers authentication (401s), tenant isolation (cross-org 404 indistinguishable from missing), malformed/unknown/invalid JSON, `restoreBackupId`⊕`forceFreshBoot` mutual exclusion, backup ownership (no cross-agent existence oracle), the failed-stamp 409, the credit (402) and worker (503) gates, in-flight wake param conflicts + applied-params echo, the shared-tier/already-running short-circuits, and CORS preflight. Job rows are asserted **in the `jobs` table**, not inferred from responses.
- **Strict wake body** — `wakeSchema` is now `z.strictObject`: an unrecognized key (e.g. a typo'd `restoreBackupID`) is a 400, not a silently-dropped field that turns an explicit restore-point or fresh-boot choice into the default latest-backup wake. No in-repo client sends extra fields (SDK sends none).
- **Freshness clock-skew tolerance explicit and tested at both edges** — the stamp window accepts `0 <= age <= freshnessMs` with ZERO future tolerance, now documented at `isFreshVerifiedStamp` and locked by four edge tests on real encrypted rows (ciphertext corrupted AFTER stamping, so the outcome proves which path ran): age 0 and age == freshnessMs ride the stamp; age == freshnessMs + 1ms and a stamp **1ms in the future** re-decrypt for real and catch the tampered envelope.
- **Cast-free PGlite DDL harness** — `pushSchemaToTestDb` in `push-schema-for-tests.ts` plus a `getPgliteClientForTests` accessor in `db/client.ts` (alongside the existing `closeDatabaseConnectionsForTests` test surface): applies drizzle-kit DDL to the identical in-memory database without `as never` bridging of drizzle-kit's schema-less parameter type. (`instanceof` probing from callers cannot work — the CJS `require` in `db/client` and an ESM `import` resolve two distinct copies of the PGlite class.) New test code contains zero `as` casts; response DTOs are validated with strict zod schemas instead.

Per the issue's alternative clause, real production object-storage/KMS/compute sleep→wake evidence **remains explicitly open on #15603** — this PR does not claim that production-boundary requirement.

## Would-fail-on-base proof (mutation matrix)

Each new guard/assertion was verified non-vacuous by reverting the guarded behavior and re-running the test:

| Mutation | Test | Result |
| --- | --- | --- |
| `z.strictObject` → `z.object` (base behavior) | `unknown JSON fields are rejected, not silently dropped` | **FAILS** (route 202-enqueues instead of 400) |
| mutual-exclusion 400 disabled | `restoreBackupId and forceFreshBoot are mutually exclusive` | **FAILS** |
| `ageMs >= 0 &&` removed (pre-#15810 fail-open) | `freshness edge: a stamp 1ms in the FUTURE re-verifies` | **FAILS** (corrupt backup wakes on the stamp) |
| `ageMs <= freshnessMs` → `<` | `freshness edge: a stamp aged exactly freshnessMs is still fresh` | **FAILS** |

## Verification

- `bun test __tests__/eliza-agents-wake-route.test.ts` (cloud/api): **17 pass, 0 fail, 86 expect()**
- `bun test src/lib/services/wake-restore-integrity.test.ts` (cloud/shared): **35 pass, 0 fail, 175 expect()**
- `bun test __tests__/eliza-agents-restore-body-guard.test.ts` (existing `pushSchema` consumer): 9 pass
- `bun test src/lib/services/provisioning-jobs-wake-enqueue.test.ts`: 5 pass
- `bunx tsgo --noEmit` (cloud/api) — pass; `bun run typecheck` (cloud/shared) — pass
- `bun run check:worker-bundle` (wrangler dry-run, covers the `db/client.ts` change in the Worker bundle) — pass
- Biome check on all touched files — clean
- `bun run audit:error-policy-ratchet` — no new fallback-slop in touched files
- Rebased on `origin/develop` (473bba4df47); suites + typechecks re-run green post-rebase

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - headless API contract + integrity policy; no rendered UI changed.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - no visual surface changed.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - headless backend change; the executable test transcripts below are the proof surface.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: [15804-wake-route-suite.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15804-wake-route-suite.log) — real `[agent-api]` structured output from the route under test (`Wake blocked: insufficient credits`, `Wake blocked: provisioning worker unavailable`, `Agent wake enqueued`), plus [15804-wake-integrity-suite.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15804-wake-integrity-suite.log) with `[WakeRestoreIntegrity]` blocked-wake output for corrupted future-stamped AEAD envelopes.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend code or request path changed.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, prompt, action, provider, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [15804-wake-integrity-suite.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15804-wake-integrity-suite.log) and [15804-wake-route-suite.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15804-wake-route-suite.log) — PGlite `jobs` rows created/reused/counted by the enqueue tests, backup rows re-stamped `failed` by the edge-case re-verifications, and provisioning ops alerts (`agent-wake-restore-integrity` dedup key), all asserted in-database by the suites and reviewed by hand.

Production sleep→wake against real object storage/KMS/compute: N/A - explicitly remains open on #15603 per this issue's acceptance criteria ("or the remaining production-boundary requirement stays explicitly open on #15603").

<details>
<summary>Route suite transcript (17/17, real PGlite + real auth + real gates)</summary>

```
(pass) authentication > no credentials at all is a 401, not an enqueued job
(pass) authentication > an unknown API key is a 401
(pass) tenant isolation > another org's key cannot wake the agent — 404, indistinguishable from missing
(pass) request body validation > malformed JSON is a typed 400, not a 500
(pass) request body validation > unknown JSON fields are rejected, not silently dropped
(pass) request body validation > non-uuid restoreBackupId is a 400
(pass) request body validation > restoreBackupId and forceFreshBoot are mutually exclusive
(pass) backup ownership > another agent's backupId and a nonexistent one are the same 404 (no existence oracle)
(pass) backup ownership > a backup stamped failed is refused up front with the escape hatches named
(pass) credit gate > an org at the minimum deposit boundary is denied with the canonical 402 body
(pass) provisioning worker gate > when the worker is required, wake fails closed on a missing heartbeat and opens on a fresh one
(pass) enqueue and in-flight conflicts > bodyless wake enqueues a real job; a bare retry reuses it as a 409 already-in-progress
(pass) enqueue and in-flight conflicts > a param-bearing request conflicting with the in-flight job is a typed 409 naming that job
(pass) enqueue and in-flight conflicts > a bare retry over a param-bearing in-flight job echoes the params the job will ACTUALLY apply
(pass) short-circuits > a shared-tier agent needs no wake job
(pass) short-circuits > an already-running dedicated agent needs no wake job
(pass) CORS preflight > OPTIONS answers 204 with the route's method allowlist

17 pass / 0 fail / 86 expect() calls
```
</details>

<details>
<summary>Wake-restore-integrity suite transcript (35/35, incl. the 4 new freshness edges)</summary>

```
(pass) readWakeRestoreGateConfig > defaults: enabled, 24h verified freshness, scan limit 25
(pass) readWakeRestoreGateConfig > kill switch and tunables parse
(pass) readWakeRestoreGateConfig > present invalid config WAKE_RESTORE_INTEGRITY_ENABLED="sometimes" fails fast
(pass) readWakeRestoreGateConfig > present invalid config WAKE_RESTORE_INTEGRITY_ENABLED="" fails fast
(pass) readWakeRestoreGateConfig > present invalid config WAKE_RESTORE_VERIFIED_FRESHNESS_HOURS="-3" fails fast
(pass) readWakeRestoreGateConfig > present invalid config WAKE_RESTORE_VERIFIED_FRESHNESS_HOURS="1.5" fails fast
(pass) readWakeRestoreGateConfig > present invalid config WAKE_RESTORE_ALTERNATIVE_SCAN_LIMIT="banana" fails fast
(pass) readWakeRestoreGateConfig > present invalid config WAKE_RESTORE_ALTERNATIVE_SCAN_LIMIT="0" fails fast
(pass) runWakeRestoreIntegrityGate > healthy encrypted backup verifies for real and is stamped verified
(pass) runWakeRestoreIntegrityGate > no backups at all: wake may proceed fresh — there is no durable state to discard
(pass) runWakeRestoreIntegrityGate > fresh 'verified' stamp skips re-verification: corrupted-after-stamp ciphertext still wakes
(pass) runWakeRestoreIntegrityGate > stale 'verified' stamp re-verifies for real and catches corruption
(pass) runWakeRestoreIntegrityGate > a future 'verified' stamp re-verifies for real and catches corruption
(pass) runWakeRestoreIntegrityGate > freshness edge: a stamp at exactly `now` (age 0) is fresh — the stamp is trusted
(pass) runWakeRestoreIntegrityGate > freshness edge: a stamp aged exactly freshnessMs is still fresh (inclusive window)
(pass) runWakeRestoreIntegrityGate > freshness edge: a stamp aged freshnessMs + 1ms re-verifies and catches corruption
(pass) runWakeRestoreIntegrityGate > freshness edge: a stamp 1ms in the FUTURE re-verifies — zero skew tolerance
(pass) runWakeRestoreIntegrityGate > freshness window is tunable: a 1h window re-verifies a 2h-old stamp
(pass) runWakeRestoreIntegrityGate > 'failed' stamp hard-fails immediately without re-decrypt (healthy payload stays blocked)
(pass) runWakeRestoreIntegrityGate > corrupted latest with an older valid backup: failure names the alternative and stamps both rows
(pass) runWakeRestoreIntegrityGate > corrupted latest with NO valid alternative: failure says so
(pass) runWakeRestoreIntegrityGate > wrong KMS key (#15310 signature): key-unavailable, wake blocked
(pass) runWakeRestoreIntegrityGate > requestedBackupId: an older valid backup validates and is the wake's restore point
(pass) runWakeRestoreIntegrityGate > requestedBackupId owned by ANOTHER sandbox is indistinguishable from missing (no existence oracle)
(pass) runWakeRestoreIntegrityGate > kill switch: gate disabled passes a corrupt latest through (legacy behavior, loudly logged)
(pass) executeWake with the restore-integrity gate > healthy latest backup: wake proceeds and restores it
(pass) executeWake with the restore-integrity gate > no backups at all: wake boots fresh with no restore override and reports no restored backup
(pass) executeWake with the restore-integrity gate > gate pass on a fresh stamp cannot boot empty: a failed restore fails the wake, sandbox stays sleeping, chain is NOT pruned
(pass) executeWake with the restore-integrity gate > kill switch: wake reverts to the ungated legacy restore and still reports the latest backup id
(pass) executeWake with the restore-integrity gate > corrupted latest: wake FAILS, provision never runs, sandbox stays sleeping, error names the older valid backup
(pass) executeWake with the restore-integrity gate > restoreBackupId: wake succeeds from the validated older backup via the provision override
(pass) executeWake with the restore-integrity gate > restoreBackupId from another sandbox: wake fails as backup-not-found, provision never runs
(pass) executeWake with the restore-integrity gate > forceFreshBoot: fresh boot happens ONLY with the flag — same corrupt backup blocks the flagless wake
(pass) executeWake with the restore-integrity gate > restoreBackupId and forceFreshBoot together are rejected before any side effect
(pass) executeWake with the restore-integrity gate > 'failed'-stamped latest short-circuits the wake without re-decrypt

35 pass / 0 fail / 175 expect() calls
```
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

