### PR TITLE
fix(agent): harden IPC response byte classification and surface partial-write failures

### DIFF
--- a/packages/agent/src/api/__fixtures__/stdio-envelope-child.ts
+++ b/packages/agent/src/api/__fixtures__/stdio-envelope-child.ts
@@ -1,0 +1,128 @@
+/**
+ * Bun-subprocess half of the IPC byte-envelope round-trip proof
+ * (`dispatch-route-stdio-envelope.test.ts`). Serves the REAL NDJSON
+ * stdio-bridge kernel (`createStdioBridge`) over this process's actual
+ * stdin/stdout — the same kernel + envelope the Android UDS bridge, the iOS
+ * stdio pipe, and the Electrobun local-agent child speak — with requests
+ * dispatched through the real `dispatchBufferedRequest` → `dispatchRoute`
+ * kernel against a real `AgentRuntime` route table.
+ *
+ * Routes (argv[2] is the base64 payload the audio route serves):
+ *   GET /api/envelope/audio    → binary bytes, `Audio/WAV; Charset=UTF-8`
+ *                                (mixed case + parameter — the exact shape the
+ *                                old substring classifier corrupted)
+ *   GET /api/envelope/partial  → writes a chunk, then throws (partial write)
+ *   GET /api/envelope/bad-json → declares JSON, emits a malformed body
+ *
+ * stdout carries ONLY protocol frames plus whatever the runtime logger emits;
+ * the parent filters to JSON frames keyed by request id, exactly like the
+ * production Electrobun dispatcher does on the shared pipe.
+ */
+
+import { Buffer } from "node:buffer";
+import process from "node:process";
+import { createInterface } from "node:readline";
+import {
+  AgentRuntime,
+  type Character,
+  type Route,
+  type RouteResponse,
+} from "@elizaos/core";
+import {
+  type AndroidRequestPayload,
+  dispatchBufferedRequest,
+} from "../../../../../plugins/plugin-capacitor-bridge/src/android/dispatch.ts";
+import {
+  createStdioBridge,
+  type StdioBridgeRequestFrame,
+} from "../../../../../plugins/plugin-capacitor-bridge/src/shared/stdio-bridge.ts";
+import { dispatchRoute } from "../dispatch-route.ts";
+
+interface ShimResponse extends RouteResponse {
+  setHeader(name: string, value: string | string[]): RouteResponse;
+  write(chunk: unknown): boolean;
+  end(chunk?: unknown): RouteResponse;
+}
+
+function isShimResponse(res: RouteResponse): res is ShimResponse {
+  const candidate = res as Partial<
+    Record<"setHeader" | "write" | "end", unknown>
+  >;
+  return (
+    typeof candidate.setHeader === "function" &&
+    typeof candidate.write === "function" &&
+    typeof candidate.end === "function"
+  );
+}
+
+function legacyRoute(
+  path: string,
+  handler: (response: ShimResponse) => void,
+): Route {
+  return {
+    type: "GET",
+    path,
+    name: `envelope-fixture${path.replaceAll("/", "-")}`,
+    public: true,
+    publicReason: "Test-only IPC envelope round-trip fixture.",
+    handler: async (_req, res) => {
+      if (!isShimResponse(res)) {
+        throw new Error(
+          "legacy shim response no longer exposes setHeader/write/end",
+        );
+      }
+      handler(res);
+    },
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function framePayload(frame: StdioBridgeRequestFrame): AndroidRequestPayload {
+  return isRecord(frame.payload) ? frame.payload : {};
+}
+
+const payloadBase64 = process.argv[2];
+if (!payloadBase64) {
+  process.stderr.write("usage: bun stdio-envelope-child.ts <base64-bytes>\n");
+  process.exit(2);
+}
+const audioBytes = Buffer.from(payloadBase64, "base64");
+
+const character: Character = { name: "stdio-envelope-fixture" };
+const runtime = new AgentRuntime({ character });
+runtime.routes.push(
+  legacyRoute("/api/envelope/audio", (res) => {
+    res.setHeader("Content-Type", "Audio/WAV; Charset=UTF-8");
+    res.end(audioBytes);
+  }),
+  legacyRoute("/api/envelope/partial", (res) => {
+    res.setHeader("content-type", "text/event-stream");
+    res.write("data: token-1\n\n");
+    throw new Error("model backend fell over mid-stream");
+  }),
+  legacyRoute("/api/envelope/bad-json", (res) => {
+    res.setHeader("content-type", "application/json");
+    res.end("{not-json");
+  }),
+);
+
+const bridge = createStdioBridge({
+  request: async (frame) =>
+    dispatchBufferedRequest(runtime, dispatchRoute, framePayload(frame)),
+  writeFrame: (frame) => {
+    process.stdout.write(`${JSON.stringify(frame)}\n`);
+  },
+});
+
+const lines = createInterface({ input: process.stdin });
+lines.on("line", (line) => {
+  void bridge.handleLine(line);
+});
+lines.once("close", () => {
+  void bridge.drain().then(() => {
+    process.exit(0);
+  });
+});

--- a/packages/agent/src/api/__tests__/stdio-envelope-child.ts
+++ b/packages/agent/src/api/__tests__/stdio-envelope-child.ts
@@ -17,6 +17,10 @@
  * stdout carries ONLY protocol frames plus whatever the runtime logger emits;
  * the parent filters to JSON frames keyed by request id, exactly like the
  * production Electrobun dispatcher does on the shared pipe.
+ *
+ * Lives under `__tests__/` (without a `.test.ts` suffix) so the coverage
+ * changed-source classifier treats it as test support while no test collector
+ * tries to run it in-process; spawn it with `bun --conditions=eliza-source`.
  */
 
 import { Buffer } from "node:buffer";
@@ -28,14 +32,18 @@ import {
   type Route,
   type RouteResponse,
 } from "@elizaos/core";
+// Package-entry imports (not relative paths into the sibling package): the
+// agent build's boundary guard forbids relative escapes, and the spawn runs
+// with `--conditions=eliza-source` so these resolve to the plugin's TS sources
+// without requiring a built dist.
 import {
   type AndroidRequestPayload,
   dispatchBufferedRequest,
-} from "../../../../../plugins/plugin-capacitor-bridge/src/android/dispatch.ts";
+} from "@elizaos/plugin-capacitor-bridge/android/dispatch";
 import {
   createStdioBridge,
   type StdioBridgeRequestFrame,
-} from "../../../../../plugins/plugin-capacitor-bridge/src/shared/stdio-bridge.ts";
+} from "@elizaos/plugin-capacitor-bridge/shared/stdio-bridge";
 import { dispatchRoute } from "../dispatch-route.ts";
 
 interface ShimResponse extends RouteResponse {

--- a/packages/agent/src/api/dispatch-route-binary-response.test.ts
+++ b/packages/agent/src/api/dispatch-route-binary-response.test.ts
@@ -1,41 +1,82 @@
 /**
- * Verifies lossless response finalization across the legacy route and native IPC boundary.
+ * Byte-classification regression suite for the legacy-route response capture in
+ * `dispatchRoute` (#15944 follow-up). Drives the real dispatcher against a real
+ * `AgentRuntime` route table — no mock of the unit under test — and asserts the
+ * RFC 9110 media-type-essence rules: parameters (`charset=…`) never reclassify
+ * binary media as text, comparison is case-insensitive, non-identity
+ * content-encoding forces byte passthrough, and a declared-JSON body that does
+ * not parse fails typed instead of returning raw text as success.
  */
 
 import { Buffer } from "node:buffer";
-import type { IAgentRuntime, Route } from "@elizaos/core";
+import { gzipSync } from "node:zlib";
+import {
+  AgentRuntime,
+  type Character,
+  isElizaError,
+  type Route,
+  type RouteResponse,
+} from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import { dispatchBufferedRequest } from "../../../../plugins/plugin-capacitor-bridge/src/android/dispatch.ts";
 import { dispatchRoute } from "./dispatch-route.ts";
 
-function runtimeWithHandler(
-  handler: (response: {
-    setHeader(name: string, value: string): void;
-    end(body?: unknown): void;
-  }) => void,
-): IAgentRuntime {
-  const route = {
-    type: "GET",
-    path: "/api/response",
-    public: true,
-    publicReason: "Test-only response finalization fixture.",
-    handler: async (_request: unknown, response: unknown) => {
-      handler(
-        response as {
-          setHeader(name: string, value: string): void;
-          end(body?: unknown): void;
-        },
-      );
-    },
-  } as unknown as Route;
-  return { routes: [route] } as unknown as IAgentRuntime;
+/**
+ * The response surface the legacy shim actually provides. `RouteResponse`
+ * types the conservative subset plugin authors may rely on; the shim also
+ * accepts an optional chunk on `end` and exposes `write`, which legacy
+ * Express-shaped handlers use. Narrowed via a runtime guard rather than a
+ * cast so the fixture fails loudly if the shim contract regresses.
+ */
+interface ShimResponse extends RouteResponse {
+  setHeader(name: string, value: string | string[]): RouteResponse;
+  write(chunk: unknown): boolean;
+  end(chunk?: unknown): RouteResponse;
 }
 
-async function dispatch(runtime: IAgentRuntime, inProcess = true) {
+function isShimResponse(res: RouteResponse): res is ShimResponse {
+  const candidate = res as Partial<
+    Record<"setHeader" | "write" | "end", unknown>
+  >;
+  return (
+    typeof candidate.setHeader === "function" &&
+    typeof candidate.write === "function" &&
+    typeof candidate.end === "function"
+  );
+}
+
+const FIXTURE_PATH = "/api/response";
+
+/** Real runtime whose route table serves the fixture handler. */
+function runtimeWithHandler(
+  handler: (response: ShimResponse) => void,
+): AgentRuntime {
+  const character: Character = { name: "dispatch-route-fixture" };
+  const runtime = new AgentRuntime({ character });
+  const route: Route = {
+    type: "GET",
+    path: FIXTURE_PATH,
+    name: "dispatch-response-fixture",
+    public: true,
+    publicReason: "Test-only response finalization fixture.",
+    handler: async (_req, res) => {
+      if (!isShimResponse(res)) {
+        throw new Error(
+          "legacy shim response no longer exposes setHeader/write/end",
+        );
+      }
+      handler(res);
+    },
+  };
+  runtime.routes.push(route);
+  return runtime;
+}
+
+async function dispatch(runtime: AgentRuntime, inProcess = true) {
   return dispatchRoute({
     runtime,
     method: "GET",
-    path: "/api/response",
+    path: FIXTURE_PATH,
     headers: {},
     inProcess,
     isAuthorized: () => true,
@@ -52,7 +93,7 @@ describe("dispatchRoute captured response finalization", () => {
 
     const result = await dispatchBufferedRequest(runtime, dispatchRoute, {
       method: "GET",
-      path: "/api/response",
+      path: FIXTURE_PATH,
     });
 
     expect(result.bodyEncoding).toBe("base64");
@@ -75,10 +116,75 @@ describe("dispatchRoute captured response finalization", () => {
     expect(result?.body).toEqual(bytes);
   });
 
+  it("does not let a charset parameter reclassify binary media as text", async () => {
+    // The original substring classifier matched `charset` and decoded these
+    // bytes as UTF-8, corrupting them through the base64 IPC envelope.
+    const bytes = Buffer.from([0x52, 0x49, 0x46, 0x46, 0xff, 0x00, 0x80, 0x7f]);
+    const runtime = runtimeWithHandler((response) => {
+      response.setHeader("content-type", "audio/wav; charset=utf-8");
+      response.end(bytes);
+    });
+
+    const result = await dispatch(runtime);
+
+    expect(Buffer.isBuffer(result?.body)).toBe(true);
+    expect(result?.body).toEqual(bytes);
+  });
+
+  it("classifies mixed-case media types case-insensitively", async () => {
+    // RFC 9110 §8.3: media types compare case-insensitively. Header values are
+    // not case-normalized at capture, so the essence comparison must be.
+    const bytes = Buffer.from([0x52, 0x49, 0x46, 0x46, 0xff, 0x00, 0x80]);
+    const binaryRuntime = runtimeWithHandler((response) => {
+      response.setHeader("content-type", "Audio/WAV; Charset=UTF-8");
+      response.end(bytes);
+    });
+    const jsonRuntime = runtimeWithHandler((response) => {
+      response.setHeader("content-type", "APPLICATION/JSON");
+      response.end('{"ok":true}');
+    });
+    const suffixRuntime = runtimeWithHandler((response) => {
+      response.setHeader("content-type", "Application/Problem+JSON");
+      response.end('{"error":"bad request"}');
+    });
+    const textRuntime = runtimeWithHandler((response) => {
+      response.setHeader("content-type", "TEXT/Plain");
+      response.end("upper text");
+    });
+
+    const binaryResult = await dispatch(binaryRuntime);
+    expect(Buffer.isBuffer(binaryResult?.body)).toBe(true);
+    expect(binaryResult?.body).toEqual(bytes);
+
+    await expect(dispatch(jsonRuntime)).resolves.toMatchObject({
+      body: { ok: true },
+    });
+    await expect(dispatch(suffixRuntime)).resolves.toMatchObject({
+      body: { error: "bad request" },
+    });
+    await expect(dispatch(textRuntime)).resolves.toMatchObject({
+      body: "upper text",
+    });
+  });
+
   it("does not decode content-encoded text before the client handles it", async () => {
-    const encoded = Buffer.from([0x1f, 0x8b, 0x08, 0x00, 0xff, 0x00]);
+    const encoded = gzipSync("hello from the route");
     const runtime = runtimeWithHandler((response) => {
       response.setHeader("content-type", "text/plain; charset=utf-8");
+      response.setHeader("content-encoding", "gzip");
+      response.end(encoded);
+    });
+
+    const result = await dispatch(runtime);
+
+    expect(Buffer.isBuffer(result?.body)).toBe(true);
+    expect(result?.body).toEqual(encoded);
+  });
+
+  it("keeps gzip-encoded JSON as bytes rather than parsing compressed data", async () => {
+    const encoded = gzipSync('{"compressed":true}');
+    const runtime = runtimeWithHandler((response) => {
+      response.setHeader("content-type", "application/json");
       response.setHeader("content-encoding", "gzip");
       response.end(encoded);
     });
@@ -94,6 +200,10 @@ describe("dispatchRoute captured response finalization", () => {
       response.setHeader("content-type", "application/problem+json");
       response.end('{"error":"bad request"}');
     });
+    const xmlRuntime = runtimeWithHandler((response) => {
+      response.setHeader("content-type", "image/svg+xml");
+      response.end("<svg/>");
+    });
     const textRuntime = runtimeWithHandler((response) => {
       response.setHeader("content-type", "text/plain");
       response.end("plain text");
@@ -101,6 +211,9 @@ describe("dispatchRoute captured response finalization", () => {
 
     await expect(dispatch(jsonRuntime)).resolves.toMatchObject({
       body: { error: "bad request" },
+    });
+    await expect(dispatch(xmlRuntime)).resolves.toMatchObject({
+      body: "<svg/>",
     });
     await expect(dispatch(textRuntime)).resolves.toMatchObject({
       body: "plain text",
@@ -136,19 +249,53 @@ describe("dispatchRoute captured response finalization", () => {
     });
   });
 
-  it("returns malformed JSON as raw text and empty responses as undefined", async () => {
+  it("throws typed ROUTE_RESPONSE_INVALID_JSON for malformed declared JSON", async () => {
     const invalidJsonRuntime = runtimeWithHandler((response) => {
-      response.setHeader("content-type", "application/json");
+      response.setHeader("content-type", "application/json; charset=utf-8");
       response.end("{not-json");
     });
+
+    const failure = await dispatch(invalidJsonRuntime).then(
+      () => null,
+      (err: unknown) => err,
+    );
+    if (!isElizaError(failure)) {
+      throw new Error(
+        `expected an ElizaError rejection, got ${String(failure)}`,
+      );
+    }
+    expect(failure.code).toBe("ROUTE_RESPONSE_INVALID_JSON");
+    expect(failure.cause).toBeInstanceOf(SyntaxError);
+    expect(failure.context).toMatchObject({
+      contentType: "application/json; charset=utf-8",
+      status: 200,
+    });
+  });
+
+  it("throws typed ROUTE_RESPONSE_INVALID_JSON for malformed structured-suffix JSON", async () => {
+    const runtime = runtimeWithHandler((response) => {
+      response.setHeader("content-type", "application/problem+json");
+      response.end("{broken");
+    });
+
+    const failure = await dispatch(runtime).then(
+      () => null,
+      (err: unknown) => err,
+    );
+    if (!isElizaError(failure)) {
+      throw new Error(
+        `expected an ElizaError rejection, got ${String(failure)}`,
+      );
+    }
+    expect(failure.code).toBe("ROUTE_RESPONSE_INVALID_JSON");
+  });
+
+  it("returns empty responses as undefined with the handler status", async () => {
     const emptyRuntime = runtimeWithHandler((response) => {
       response.setHeader("content-type", "audio/wav");
       response.end();
     });
 
-    await expect(dispatch(invalidJsonRuntime)).resolves.toMatchObject({
-      body: "{not-json",
-    });
     await expect(dispatch(emptyRuntime)).resolves.toMatchObject({
       status: 200,
       body: undefined,

--- a/packages/agent/src/api/dispatch-route-partial-write.test.ts
+++ b/packages/agent/src/api/dispatch-route-partial-write.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Failure-observability suite for a legacy route handler that throws after
+ * writing part (or all) of its response. `dispatchRoute` used to return the
+ * captured bytes as a healthy result, masking the failure at every transport.
+ * These tests drive the real dispatcher, the real Hono adapter, and the real
+ * NDJSON stdio-bridge kernel (the Android/iOS/Electrobun IPC transport) and
+ * prove each CALLER observes the typed `ROUTE_HANDLER_PARTIAL_WRITE_FAILURE` —
+ * while chunks already streamed before the failure stay delivered.
+ */
+
+import { Buffer } from "node:buffer";
+import {
+  AgentRuntime,
+  type Character,
+  isElizaError,
+  type Route,
+  type RouteResponse,
+} from "@elizaos/core";
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import {
+  dispatchBufferedRequest,
+  dispatchStreamingRequest,
+} from "../../../../plugins/plugin-capacitor-bridge/src/android/dispatch.ts";
+import {
+  createStdioBridge,
+  type StdioBridgeResponseFrame,
+} from "../../../../plugins/plugin-capacitor-bridge/src/shared/stdio-bridge.ts";
+import { dispatchRoute } from "./dispatch-route.ts";
+import { mountRoutesOnHono } from "./hono-adapter.ts";
+
+/** Shim surface the legacy handler drives; see dispatch-route-binary-response.test.ts. */
+interface ShimResponse extends RouteResponse {
+  setHeader(name: string, value: string | string[]): RouteResponse;
+  write(chunk: unknown): boolean;
+  end(chunk?: unknown): RouteResponse;
+}
+
+function isShimResponse(res: RouteResponse): res is ShimResponse {
+  const candidate = res as Partial<
+    Record<"setHeader" | "write" | "end", unknown>
+  >;
+  return (
+    typeof candidate.setHeader === "function" &&
+    typeof candidate.write === "function" &&
+    typeof candidate.end === "function"
+  );
+}
+
+const FIXTURE_PATH = "/api/partial";
+
+function runtimeWithHandler(
+  handler: (response: ShimResponse) => void,
+): AgentRuntime {
+  const character: Character = { name: "partial-write-fixture" };
+  const runtime = new AgentRuntime({ character });
+  const route: Route = {
+    type: "GET",
+    path: FIXTURE_PATH,
+    name: "partial-write-fixture",
+    public: true,
+    publicReason: "Test-only partial-write failure fixture.",
+    handler: async (_req, res) => {
+      if (!isShimResponse(res)) {
+        throw new Error(
+          "legacy shim response no longer exposes setHeader/write/end",
+        );
+      }
+      handler(res);
+    },
+  };
+  runtime.routes.push(route);
+  return runtime;
+}
+
+function dispatchArgs(
+  runtime: AgentRuntime,
+  onChunk?: (chunk: Buffer) => void,
+) {
+  return {
+    runtime,
+    method: "GET",
+    path: FIXTURE_PATH,
+    headers: {},
+    inProcess: true,
+    isAuthorized: () => true,
+    ...(onChunk ? { onChunk } : {}),
+  };
+}
+
+async function rejectionOf(promise: Promise<unknown>): Promise<unknown> {
+  return promise.then(
+    () => null,
+    (err: unknown) => err,
+  );
+}
+
+describe("dispatchRoute partial-write failure — direct caller", () => {
+  it("rejects typed when the handler throws after streaming a chunk, keeping delivered chunks", async () => {
+    const delivered: Buffer[] = [];
+    const runtime = runtimeWithHandler((res) => {
+      res.setHeader("content-type", "text/event-stream");
+      res.write("data: token-1\n\n");
+      throw new Error("model backend fell over mid-stream");
+    });
+
+    const failure = await rejectionOf(
+      dispatchRoute(dispatchArgs(runtime, (chunk) => delivered.push(chunk))),
+    );
+
+    if (!isElizaError(failure)) {
+      throw new Error(
+        `expected an ElizaError rejection, got ${String(failure)}`,
+      );
+    }
+    expect(failure.code).toBe("ROUTE_HANDLER_PARTIAL_WRITE_FAILURE");
+    expect(failure.cause).toBeInstanceOf(Error);
+    expect(failure.context).toMatchObject({
+      method: "GET",
+      path: FIXTURE_PATH,
+      ended: false,
+    });
+    expect(failure.context?.partialBodyBytes).toBe(
+      Buffer.byteLength("data: token-1\n\n"),
+    );
+    // Chunks flushed before the failure were already forwarded to the
+    // streaming sink — the failure does not retract prior delivery.
+    expect(Buffer.concat(delivered).toString("utf8")).toBe("data: token-1\n\n");
+  });
+
+  it("rejects typed when the handler ends the response and then throws", async () => {
+    const runtime = runtimeWithHandler((res) => {
+      res.setHeader("content-type", "application/json");
+      res.end('{"ok":true}');
+      throw new Error("post-response bookkeeping failed");
+    });
+
+    const failure = await rejectionOf(dispatchRoute(dispatchArgs(runtime)));
+
+    if (!isElizaError(failure)) {
+      throw new Error(
+        `expected an ElizaError rejection, got ${String(failure)}`,
+      );
+    }
+    expect(failure.code).toBe("ROUTE_HANDLER_PARTIAL_WRITE_FAILURE");
+    expect(failure.context).toMatchObject({ ended: true });
+    expect(failure.context?.partialBodyBase64Prefix).toBe(
+      Buffer.from('{"ok":true}', "utf8").toString("base64"),
+    );
+  });
+
+  it("still translates a handler that throws before any write into a structured 500", async () => {
+    const runtime = runtimeWithHandler(() => {
+      throw new Error("nothing was written");
+    });
+
+    await expect(dispatchRoute(dispatchArgs(runtime))).resolves.toMatchObject({
+      status: 500,
+      body: { error: "nothing was written" },
+    });
+  });
+});
+
+describe("dispatchRoute partial-write failure — HTTP boundary (Hono adapter)", () => {
+  it("surfaces as a 500 to the HTTP caller instead of a truncated 200", async () => {
+    const runtime = runtimeWithHandler((res) => {
+      res.write("partial body");
+      throw new Error("disk vanished mid-write");
+    });
+    const app = new Hono();
+    mountRoutesOnHono(app, runtime, { isAuthorized: () => true });
+
+    const response = await app.request(FIXTURE_PATH);
+
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      error: "legacy route handler threw after writing its response",
+    });
+  });
+
+  it("surfaces malformed declared JSON as a 500 to the HTTP caller", async () => {
+    const runtime = runtimeWithHandler((res) => {
+      res.setHeader("content-type", "application/json");
+      res.end("{not-json");
+    });
+    const app = new Hono();
+    mountRoutesOnHono(app, runtime, { isAuthorized: () => true });
+
+    const response = await app.request(FIXTURE_PATH);
+
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      error: "legacy route declared JSON but body is malformed",
+    });
+  });
+});
+
+describe("dispatchRoute partial-write failure — stdio-bridge IPC boundary", () => {
+  // The same kernel serves the Android UDS, the iOS stdio pipe, and the
+  // Electrobun local-agent child; an `{ok:false}` frame is what the desktop
+  // LocalAgentStdioDispatcher translates into a rejected renderer RPC.
+  function bridgeFor(runtime: AgentRuntime) {
+    const frames: StdioBridgeResponseFrame[] = [];
+    const bridge = createStdioBridge({
+      request: async () =>
+        dispatchBufferedRequest(runtime, dispatchRoute, {
+          method: "GET",
+          path: FIXTURE_PATH,
+        }),
+      requestStream: async (_frame, sink) =>
+        dispatchStreamingRequest(
+          runtime,
+          dispatchRoute,
+          { method: "GET", path: FIXTURE_PATH },
+          sink,
+        ),
+      writeFrame: (frame) => {
+        frames.push(frame);
+      },
+    });
+    return { bridge, frames };
+  }
+
+  it("buffered request surfaces {ok:false} with the typed failure message", async () => {
+    const runtime = runtimeWithHandler((res) => {
+      res.write("partial body");
+      throw new Error("disk vanished mid-write");
+    });
+    const { bridge, frames } = bridgeFor(runtime);
+
+    await bridge.handleLine(
+      JSON.stringify({ id: 7, method: "http_request", payload: {} }),
+    );
+
+    expect(frames).toHaveLength(1);
+    expect(frames[0]).toMatchObject({
+      id: 7,
+      ok: false,
+      error: "legacy route handler threw after writing its response",
+    });
+  });
+
+  it("buffered request surfaces {ok:false} for malformed declared JSON", async () => {
+    const runtime = runtimeWithHandler((res) => {
+      res.setHeader("content-type", "application/json");
+      res.end("{not-json");
+    });
+    const { bridge, frames } = bridgeFor(runtime);
+
+    await bridge.handleLine(
+      JSON.stringify({ id: 8, method: "http_request", payload: {} }),
+    );
+
+    expect(frames).toHaveLength(1);
+    expect(frames[0]).toMatchObject({
+      id: 8,
+      ok: false,
+      error: "legacy route declared JSON but body is malformed",
+    });
+  });
+
+  it("streaming request delivers flushed chunks, then terminates with an error frame", async () => {
+    const runtime = runtimeWithHandler((res) => {
+      res.setHeader("content-type", "text/event-stream");
+      res.write("data: token-1\n\n");
+      throw new Error("model backend fell over mid-stream");
+    });
+    const { bridge, frames } = bridgeFor(runtime);
+
+    await bridge.handleLine(
+      JSON.stringify({
+        id: 9,
+        method: "http_request_stream",
+        stream: true,
+        payload: {},
+      }),
+    );
+
+    // Head and the pre-failure chunk were delivered; the terminal frame is an
+    // error, not a clean complete — the WebView/renderer consumer sees the
+    // stream fail rather than silently end.
+    expect(frames.map((frame) => frame.stream)).toEqual([
+      "response",
+      "chunk",
+      "complete",
+    ]);
+    const chunkFrame = frames[1];
+    if (typeof chunkFrame.dataBase64 !== "string") {
+      throw new Error("expected a base64 chunk frame before the failure");
+    }
+    expect(Buffer.from(chunkFrame.dataBase64, "base64").toString("utf8")).toBe(
+      "data: token-1\n\n",
+    );
+    expect(frames[2]).toMatchObject({
+      stream: "complete",
+      error: "legacy route handler threw after writing its response",
+    });
+  });
+});

--- a/packages/agent/src/api/dispatch-route-stdio-envelope.test.ts
+++ b/packages/agent/src/api/dispatch-route-stdio-envelope.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Process-boundary round-trip proof for the IPC response envelope: spawns
+ * `__fixtures__/stdio-envelope-child.ts` under a real Bun child process, writes
+ * request frames to its actual stdin, reads `{ok, result}` frames from its
+ * actual stdout, and asserts sha256 byte-equality of the binary body across the
+ * base64 envelope — plus typed `{ok:false}` failure frames for a partial-write
+ * handler and malformed declared JSON. This is the same NDJSON kernel + frame
+ * shape the Android UDS bridge, iOS stdio pipe, and Electrobun local-agent
+ * child use, exercised over a true OS pipe rather than an in-process call.
+ *
+ * Like `server-skip-listen.test.ts`, the subprocess needs the installed
+ * workspace module graph; when it cannot boot (sparse checkout) the behavioral
+ * cases skip explicitly instead of claiming coverage.
+ */
+
+import { Buffer } from "node:buffer";
+import {
+  type ChildProcessWithoutNullStreams,
+  execFileSync,
+  spawn,
+} from "node:child_process";
+import { createHash, randomBytes } from "node:crypto";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { createInterface } from "node:readline";
+import { describe, expect, it } from "vitest";
+
+const CHILD_PATH = join(
+  import.meta.dirname,
+  "__fixtures__",
+  "stdio-envelope-child.ts",
+);
+
+/** Locate a `bun` executable; the fixture imports the TS module graph. */
+function resolveBunExecutable(): string | null {
+  if (typeof (globalThis as { Bun?: unknown }).Bun !== "undefined") {
+    return process.execPath;
+  }
+  const locator = process.platform === "win32" ? "where" : "which";
+  try {
+    const resolved = execFileSync(locator, ["bun"], { encoding: "utf8" })
+      .split("\n")
+      .map((line) => line.trim())
+      .find(Boolean);
+    if (resolved && existsSync(resolved)) return resolved;
+  } catch {
+    // error-policy:J3 not on PATH — fall through to absolute install locations.
+  }
+  const candidates = [
+    process.env.BUN_INSTALL ? join(process.env.BUN_INSTALL, "bin", "bun") : "",
+    "/usr/local/bin/bun",
+    "/opt/homebrew/bin/bun",
+  ].filter(Boolean);
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+interface EnvelopeFrame {
+  id?: unknown;
+  ok?: unknown;
+  result?: unknown;
+  error?: unknown;
+}
+
+interface EnvelopeResult {
+  status: number;
+  headers: Record<string, string>;
+  bodyBase64: string;
+  bodyEncoding: string;
+}
+
+function isEnvelopeResult(value: unknown): value is EnvelopeResult {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Partial<EnvelopeResult>;
+  return (
+    typeof candidate.status === "number" &&
+    typeof candidate.bodyBase64 === "string" &&
+    typeof candidate.bodyEncoding === "string" &&
+    typeof candidate.headers === "object" &&
+    candidate.headers !== null
+  );
+}
+
+function sha256(bytes: Buffer): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+/**
+ * Drive the child over its real stdio: write one request frame per path, then
+ * collect the matching response frames. The child multiplexes runtime logs on
+ * stdout, so only lines that parse as JSON frames with a pending numeric id
+ * count — the same filtering the production Electrobun dispatcher applies.
+ */
+async function runEnvelopeChild(
+  bun: string,
+  payload: Buffer,
+): Promise<Map<number, EnvelopeFrame> | { bootError: string }> {
+  const requests = [
+    { id: 1, path: "/api/envelope/audio" },
+    { id: 2, path: "/api/envelope/partial" },
+    { id: 3, path: "/api/envelope/bad-json" },
+  ];
+  const child: ChildProcessWithoutNullStreams = spawn(
+    bun,
+    [CHILD_PATH, payload.toString("base64")],
+    { env: { ...process.env, LOG_LEVEL: "error" }, stdio: "pipe" },
+  );
+
+  const frames = new Map<number, EnvelopeFrame>();
+  let stderrTail = "";
+  child.stderr.on("data", (chunk: Buffer) => {
+    stderrTail = `${stderrTail}${chunk.toString("utf8")}`.slice(-4000);
+  });
+
+  const outcome = await new Promise<Map<number, EnvelopeFrame> | null>(
+    (resolve) => {
+      const timer = setTimeout(() => {
+        child.kill();
+        resolve(null);
+      }, 90_000);
+      const finish = (value: Map<number, EnvelopeFrame> | null): void => {
+        clearTimeout(timer);
+        resolve(value);
+      };
+      const lines = createInterface({ input: child.stdout });
+      lines.on("line", (line) => {
+        let frame: EnvelopeFrame;
+        try {
+          frame = JSON.parse(line) as EnvelopeFrame;
+        } catch {
+          // error-policy:J3 non-JSON stdout line = child log noise, not a frame.
+          return;
+        }
+        if (typeof frame.id !== "number") return;
+        frames.set(frame.id, frame);
+        if (frames.size === requests.length) {
+          child.stdin.end();
+          finish(frames);
+        }
+      });
+      child.once("error", () => finish(null));
+      child.once("exit", () => {
+        finish(frames.size === requests.length ? frames : null);
+      });
+      for (const request of requests) {
+        child.stdin.write(
+          `${JSON.stringify({
+            id: request.id,
+            method: "http_request",
+            payload: { method: "GET", path: request.path },
+          })}\n`,
+        );
+      }
+    },
+  );
+  child.kill();
+  if (outcome === null) {
+    return { bootError: stderrTail || "child produced no response frames" };
+  }
+  return outcome;
+}
+
+describe("IPC byte envelope — real child process over real stdio", () => {
+  it("has the child fixture", () => {
+    expect(existsSync(CHILD_PATH)).toBe(true);
+  });
+
+  it("round-trips binary bytes sha256-exact and surfaces typed failures", async () => {
+    const bun = resolveBunExecutable();
+    if (!bun) {
+      console.warn(
+        "[stdio-envelope] bun executable not found; skipping process-boundary case",
+      );
+      return;
+    }
+    // Guaranteed-invalid UTF-8 prefix + RIFF magic + random tail: any UTF-8
+    // decode/re-encode on the path corrupts these bytes, so sha256 equality
+    // proves the envelope is byte-exact.
+    const payload = Buffer.concat([
+      Buffer.from([0xff, 0xfe, 0x00, 0x80]),
+      Buffer.from("RIFF", "ascii"),
+      randomBytes(4096),
+    ]);
+
+    const outcome = await runEnvelopeChild(bun, payload);
+    if ("bootError" in outcome) {
+      // Sparse checkout: the fixture's module graph needs the installed
+      // workspace. Skip explicitly rather than claiming coverage.
+      console.warn(
+        `[stdio-envelope] child unavailable in this environment: ${outcome.bootError}`,
+      );
+      return;
+    }
+
+    const audio = outcome.get(1);
+    expect(audio?.ok).toBe(true);
+    if (!isEnvelopeResult(audio?.result)) {
+      throw new Error("audio frame result is not a buffered response envelope");
+    }
+    expect(audio.result.status).toBe(200);
+    expect(audio.result.bodyEncoding).toBe("base64");
+    // The mixed-case, parameterized content type must classify as binary and
+    // survive the envelope untouched.
+    expect(audio.result.headers["content-type"]).toBe(
+      "Audio/WAV; Charset=UTF-8",
+    );
+    const received = Buffer.from(audio.result.bodyBase64, "base64");
+    expect(received.length).toBe(payload.length);
+    expect(sha256(received)).toBe(sha256(payload));
+
+    const partial = outcome.get(2);
+    expect(partial?.ok).toBe(false);
+    expect(partial?.error).toBe(
+      "legacy route handler threw after writing its response",
+    );
+
+    const badJson = outcome.get(3);
+    expect(badJson?.ok).toBe(false);
+    expect(badJson?.error).toBe(
+      "legacy route declared JSON but body is malformed",
+    );
+  }, 120_000);
+});

--- a/packages/agent/src/api/dispatch-route-stdio-envelope.test.ts
+++ b/packages/agent/src/api/dispatch-route-stdio-envelope.test.ts
@@ -1,6 +1,6 @@
 /**
  * Process-boundary round-trip proof for the IPC response envelope: spawns
- * `__fixtures__/stdio-envelope-child.ts` under a real Bun child process, writes
+ * `__tests__/stdio-envelope-child.ts` under a real Bun child process, writes
  * request frames to its actual stdin, reads `{ok, result}` frames from its
  * actual stdout, and asserts sha256 byte-equality of the binary body across the
  * base64 envelope — plus typed `{ok:false}` failure frames for a partial-write
@@ -8,9 +8,10 @@
  * shape the Android UDS bridge, iOS stdio pipe, and Electrobun local-agent
  * child use, exercised over a true OS pipe rather than an in-process call.
  *
- * Like `server-skip-listen.test.ts`, the subprocess needs the installed
- * workspace module graph; when it cannot boot (sparse checkout) the behavioral
- * cases skip explicitly instead of claiming coverage.
+ * The subprocess needs the installed workspace module graph (resolved from
+ * sources via `--conditions=eliza-source`, no dist required). When it cannot
+ * boot, the behavioral case skips explicitly on a local sparse checkout and
+ * hard-fails in CI so a child-boot regression can never go green.
  */
 
 import { Buffer } from "node:buffer";
@@ -27,9 +28,24 @@ import { describe, expect, it } from "vitest";
 
 const CHILD_PATH = join(
   import.meta.dirname,
-  "__fixtures__",
+  "__tests__",
   "stdio-envelope-child.ts",
 );
+
+/**
+ * Locally a missing bun / unbootable child skips with a warning (sparse
+ * checkout); in CI that same skip would hide a child-boot regression behind a
+ * green run, so it hard-fails there instead.
+ */
+function failOrSkip(reason: string): boolean {
+  if (process.env.CI) {
+    throw new Error(
+      `[stdio-envelope] required process-boundary case cannot run in CI: ${reason}`,
+    );
+  }
+  console.warn(`[stdio-envelope] skipping process-boundary case: ${reason}`);
+  return true;
+}
 
 /** Locate a `bun` executable; the fixture imports the TS module graph. */
 function resolveBunExecutable(): string | null {
@@ -102,9 +118,12 @@ async function runEnvelopeChild(
     { id: 2, path: "/api/envelope/partial" },
     { id: 3, path: "/api/envelope/bad-json" },
   ];
+  // `--conditions=eliza-source` resolves @elizaos/* package entries to their
+  // TS sources (the same condition the coverage gate's bun lane uses), so the
+  // child needs no built dist.
   const child: ChildProcessWithoutNullStreams = spawn(
     bun,
-    [CHILD_PATH, payload.toString("base64")],
+    ["--conditions=eliza-source", CHILD_PATH, payload.toString("base64")],
     { env: { ...process.env, LOG_LEVEL: "error" }, stdio: "pipe" },
   );
 
@@ -170,9 +189,7 @@ describe("IPC byte envelope — real child process over real stdio", () => {
   it("round-trips binary bytes sha256-exact and surfaces typed failures", async () => {
     const bun = resolveBunExecutable();
     if (!bun) {
-      console.warn(
-        "[stdio-envelope] bun executable not found; skipping process-boundary case",
-      );
+      failOrSkip("bun executable not found on this host");
       return;
     }
     // Guaranteed-invalid UTF-8 prefix + RIFF magic + random tail: any UTF-8
@@ -187,10 +204,8 @@ describe("IPC byte envelope — real child process over real stdio", () => {
     const outcome = await runEnvelopeChild(bun, payload);
     if ("bootError" in outcome) {
       // Sparse checkout: the fixture's module graph needs the installed
-      // workspace. Skip explicitly rather than claiming coverage.
-      console.warn(
-        `[stdio-envelope] child unavailable in this environment: ${outcome.bootError}`,
-      );
+      // workspace. Never a silent skip in CI.
+      failOrSkip(`child unavailable in this environment: ${outcome.bootError}`);
       return;
     }
 

--- a/packages/agent/src/api/dispatch-route.ts
+++ b/packages/agent/src/api/dispatch-route.ts
@@ -27,6 +27,7 @@ import {
   type AccessContext,
   type AgentRuntime,
   assertPublicRouteIntent,
+  ElizaError,
   type IAgentRuntime,
   type LegacyRouteHandler,
   logger,
@@ -235,6 +236,14 @@ interface CapturedResponse {
   ended: boolean;
 }
 
+/**
+ * Cap on the partial-body excerpt carried in a
+ * `ROUTE_HANDLER_PARTIAL_WRITE_FAILURE` error context. The full captured body
+ * may be arbitrarily large (a failed streaming route); the context exists for
+ * diagnosis, not replay, so only a bounded prefix travels with the error.
+ */
+const PARTIAL_BODY_CONTEXT_LIMIT = 512;
+
 function asCapturedServerResponse(res: unknown): ServerResponse {
   return res as ServerResponse;
 }
@@ -421,15 +430,28 @@ function buildLegacyShim(args: {
   };
 }
 
+/**
+ * Extract the media-type essence (RFC 9110 §8.3): everything before the first
+ * `;` parameter separator, trimmed and lowercased. Media types compare
+ * case-insensitively and parameters (`charset=…`, `boundary=…`) never change
+ * the underlying type, so classification must ignore both. Header values are
+ * normalized to lowercase at capture, but the essence is lowercased here again
+ * so the comparison stays correct even for a caller that bypasses capture.
+ */
+function mediaTypeEssence(contentType: string): string {
+  const separatorIndex = contentType.indexOf(";");
+  return (
+    separatorIndex === -1 ? contentType : contentType.slice(0, separatorIndex)
+  )
+    .trim()
+    .toLowerCase();
+}
+
 function capturedToResult(captured: CapturedResponse): RouteHandlerResult {
   const buffer = Buffer.concat(captured.chunks);
   // Missing headers are meaningful here because undeclared bodies retain the
   // bridge's historical UTF-8 behavior.
   const contentTypeHeader = captured.headers["content-type"];
-  const contentType =
-    typeof contentTypeHeader === "string"
-      ? contentTypeHeader.toLowerCase()
-      : undefined;
   const contentEncodingHeader = captured.headers["content-encoding"];
   const contentEncoding =
     typeof contentEncodingHeader === "string"
@@ -442,24 +464,32 @@ function capturedToResult(captured: CapturedResponse): RouteHandlerResult {
       body: undefined,
     };
   }
-  // Content encodings describe bytes that the client must decode even when the
-  // underlying media type is textual; interpreting either encoded or binary
-  // bytes as UTF-8 would make the downstream IPC base64 envelope lossy.
-  const hasTransferEncoding =
+  const mediaType =
+    typeof contentTypeHeader === "string"
+      ? mediaTypeEssence(contentTypeHeader)
+      : undefined;
+  const isJson =
+    mediaType !== undefined &&
+    (mediaType === "application/json" || mediaType.endsWith("+json"));
+  // Content-Encoding describes the bytes on the wire: even a textual media
+  // type stays compressed until the receiving stack decodes it, so any
+  // non-identity encoding forces byte passthrough — decoding as UTF-8 would
+  // make the downstream IPC base64 envelope lossy.
+  const isEncoded =
     contentEncoding !== undefined &&
     contentEncoding !== "" &&
     contentEncoding !== "identity";
   const isTextual =
-    !hasTransferEncoding &&
-    (contentType === undefined ||
-      contentType === "" ||
-      contentType.startsWith("text/") ||
-      contentType.includes("json") ||
-      contentType.includes("xml") ||
-      contentType.includes("javascript") ||
-      contentType.includes("x-www-form-urlencoded") ||
-      contentType.includes("charset"));
-  if (!isTextual) {
+    mediaType === undefined ||
+    mediaType === "" ||
+    mediaType.startsWith("text/") ||
+    isJson ||
+    mediaType === "application/xml" ||
+    mediaType.endsWith("+xml") ||
+    mediaType === "application/javascript" ||
+    mediaType === "application/x-javascript" ||
+    mediaType === "application/x-www-form-urlencoded";
+  if (isEncoded || !isTextual) {
     return {
       status: captured.statusCode || 200,
       headers: captured.headers,
@@ -468,11 +498,22 @@ function capturedToResult(captured: CapturedResponse): RouteHandlerResult {
   }
   const text = buffer.toString("utf8");
   let body: unknown = text;
-  if (contentType?.includes("json")) {
+  if (isJson) {
     try {
       body = JSON.parse(text);
-    } catch {
-      // error-policy:J3 malformed JSON stays explicit raw text at this transport boundary
+    } catch (error) {
+      // error-policy:J2 context-adding rethrow: a declared-JSON body that does
+      // not parse is a route failure; returning the raw text would let a broken
+      // handler masquerade as success at every transport boundary.
+      throw new ElizaError("legacy route declared JSON but body is malformed", {
+        code: "ROUTE_RESPONSE_INVALID_JSON",
+        cause: error,
+        context: {
+          contentType: contentTypeHeader,
+          status: captured.statusCode,
+          bodyBytes: buffer.length,
+        },
+      });
     }
   }
   return {
@@ -572,7 +613,11 @@ export async function dispatchRoute(
           runtime as IAgentRuntime,
         );
       } catch (err) {
-        if (!captured.ended) {
+        // error-policy:J1 route-dispatch failure translation: a handler that
+        // throws before producing any observable output becomes the structured
+        // 500 every transport serves; a handler that already wrote or ended is
+        // rethrown as a typed failure below — never returned as success.
+        if (!captured.ended && captured.chunks.length === 0) {
           return {
             status: 500,
             headers: { "content-type": "application/json; charset=utf-8" },
@@ -582,7 +627,32 @@ export async function dispatchRoute(
             },
           };
         }
-        // Handler partially wrote; surface what we have.
+        // The handler failed after writing: any chunks are already delivered
+        // to a streaming consumer via onChunk (that delivery is not retracted),
+        // but the buffered result would fabricate a healthy response for a
+        // route that broke mid-write. Rethrow typed so every boundary surfaces
+        // the failure — HTTP 500 (hono-adapter), `{ok:false}` IPC frame
+        // (stdio-bridge kernel), terminal stream error frame (streaming sink).
+        const partialBody = Buffer.concat(captured.chunks);
+        throw new ElizaError(
+          "legacy route handler threw after writing its response",
+          {
+            code: "ROUTE_HANDLER_PARTIAL_WRITE_FAILURE",
+            cause: err,
+            context: {
+              method,
+              path: args.path,
+              status: captured.statusCode,
+              ended: captured.ended,
+              partialBodyBytes: partialBody.length,
+              // Bounded so the log/error-event payload stays small even when a
+              // handler streamed megabytes before failing.
+              partialBodyBase64Prefix: partialBody
+                .subarray(0, PARTIAL_BODY_CONTEXT_LIMIT)
+                .toString("base64"),
+            },
+          },
+        );
       }
       return capturedToResult(captured);
     } finally {

--- a/packages/agent/src/api/dispatch-route.ts
+++ b/packages/agent/src/api/dispatch-route.ts
@@ -241,6 +241,8 @@ interface CapturedResponse {
  * `ROUTE_HANDLER_PARTIAL_WRITE_FAILURE` error context. The full captured body
  * may be arbitrarily large (a failed streaming route); the context exists for
  * diagnosis, not replay, so only a bounded prefix travels with the error.
+ * The prefix may still contain response payload — J1 boundaries handling this
+ * error must not log the full context verbatim for sensitive routes.
  */
 const PARTIAL_BODY_CONTEXT_LIMIT = 512;
 

--- a/plugins/plugin-capacitor-bridge/package.json
+++ b/plugins/plugin-capacitor-bridge/package.json
@@ -34,6 +34,11 @@
 		"./*.css": "./dist/*.css",
 		"./*": {
 			"types": "./dist/*.d.ts",
+			"eliza-source": {
+				"types": "./src/*.ts",
+				"import": "./src/*.ts",
+				"default": "./src/*.ts"
+			},
 			"import": "./dist/*.js",
 			"default": "./dist/*.js"
 		}


### PR DESCRIPTION
## Summary

Reworks closed #15992 per its closing review; builds on #16005 (undefined-aware header absence handling is preserved).

`dispatchRoute` is the canonical route kernel behind four transports: the Hono HTTP adapter, the Android UDS bridge, the iOS stdio pipe, and the Electrobun local-agent child (all three IPC transports share the `createStdioBridge` NDJSON kernel and its base64 body envelope). Two defects remained after #15944/#16005:

1. **Substring MIME classification.** Any content type containing `charset`, `json`, or `xml` was treated as textual, so binary media with a charset parameter (`audio/wav; charset=utf-8`) was decoded as UTF-8 and corrupted through the base64 IPC envelope. Malformed declared-JSON was returned as raw text posing as success.
2. **Masked partial-write failures.** A legacy handler that threw *after* writing/ending its response had the captured bytes returned as a healthy `RouteHandlerResult` — a broken route rendered as a truncated 200 at every boundary.

## How each closing-review demand is met

1. **Typed observable partial-write failure.** The `// Handler partially wrote; surface what we have.` catch is gone. A handler that throws after producing observable output (ended, or chunks already forwarded to `onChunk`) now rethrows as `ElizaError` `ROUTE_HANDLER_PARTIAL_WRITE_FAILURE` with `cause` and captured context (`method`, `path`, `status`, `ended`, `partialBodyBytes`, bounded `partialBodyBase64Prefix`). Every consumer boundary surfaces it: `hono-adapter.ts` catch → HTTP 500; `stdio-bridge.ts` kernel → `{ok:false, error}` frame (Android/iOS/Electrobun buffered) or terminal `{stream:"complete", error}` frame (streaming); `local-agent-stdio-dispatcher.ts` translates the error frame into a rejected renderer RPC (existing coverage `local-agent-stdio-dispatcher.test.ts`, re-run green). Chunks flushed before the failure stay delivered to streaming consumers — asserted explicitly. A handler that throws before *any* write keeps the structured 500 translation (now `error-policy:J1` annotated). `dispatch-route-partial-write.test.ts` proves the caller observes the failure at the direct, Hono-HTTP, buffered-IPC, and streaming-IPC boundary shapes.
2. **MIME classification hardening.** Classification is by media-type essence — `slice` before the first `;`, `trim()`, **`toLowerCase()` at the comparison site** (RFC 9110 §8.3 case-insensitivity, applied defensively even though capture lowercases header names) — with structured-suffix `+json`/`+xml` support, explicit textual set (`text/*`, `application/json|xml|javascript|x-javascript|x-www-form-urlencoded`), non-identity `content-encoding` → byte passthrough, and malformed declared-JSON → typed `ROUTE_RESPONSE_INVALID_JSON` `ElizaError` (J2 cause-preserving rethrow). Mixed-case coverage: `Audio/WAV; Charset=UTF-8` → bytes, `APPLICATION/JSON` → parsed, `Application/Problem+JSON` → parsed, `TEXT/Plain` → text. #16005's undefined-aware absence handling (absent vs `""` content-type, `identity` encoding, empty body → `undefined`) is retained with its tests.
3. **Real bridge byte-envelope artifact.** `dispatch-route-stdio-envelope.test.ts` + `__tests__/stdio-envelope-child.ts` spawn a real Bun child process serving the REAL `createStdioBridge` kernel over its actual stdin/stdout, dispatching through the real `dispatchBufferedRequest` → `dispatchRoute` against a real `AgentRuntime` route table. The parent writes request frames over the OS pipe, reads `{ok, result}` frames back, and asserts sha256 byte-equality of a 4104-byte invalid-UTF-8 payload served as `Audio/WAV; Charset=UTF-8`, plus typed `{ok:false}` frames for the partial-write and malformed-JSON routes. Transcript + hashes below. The packaged-Electrobun path was not used because desktop local-agent IPC mode is opt-in and `attachLocalAgentStdioBridge` has no production caller yet — the packaged app serves the renderer over loopback HTTP, so a packaged-app run would not traverse the stdio envelope at all; the spawned-kernel round trip is the true process-boundary proof for the frames all three device bridges speak.
4. **Current base + evidence.** Branch is cut from `origin/develop` head `6b80bf18fcf` (#16005). Evidence rows below are all checked and machine-readable.

Also fixed per the review's fixture complaint: the test fixtures no longer construct `Route`/`IAgentRuntime` via `as unknown as` — they build a real `AgentRuntime`, push a properly-typed `Route` literal, and narrow the legacy shim response through a runtime-validated type predicate.

**Deliberate assertion update:** #16005's "returns malformed JSON as raw text" assertion codified the behavior this review ordered removed; it now asserts the typed `ROUTE_RESPONSE_INVALID_JSON` rejection. Its sibling #16005 cases (identity encoding, empty content type, empty body, absent content type) are unchanged and green.

**Review follow-up (`456b07689dd`):** the spawn-only child moved to `src/api/__tests__/` with `@elizaos/plugin-capacitor-bridge` package-entry imports, so the agent build's package-boundary guard passes and the coverage changed-source classifier excludes it (classifier output: `files` = `dispatch-route.ts` only); the plugin's wildcard export gained an `eliza-source` condition (mirroring `@elizaos/core`) for dist-free source resolution; the CI skip is now a hard failure (negative-control verified: deleting the child fails the suite under `CI=1`); and the bounded `partialBody` prefix carries a redaction note for J1 boundaries. Local: `bun run --cwd packages/agent build` green (guard + tsc emit), coverage gate reproduced with the exact CI awk invocation — `52.88% >= 50%`, exit 0.

## Verification (exact head)

- Focused dispatcher suites (`dispatch-route-binary-response`, `dispatch-route-partial-write`, `dispatch-route-stdio-envelope`, `dispatch-route-onchunk`, `dispatch-route.x402`): **5 files, 33/33 pass**.
- Fail-before proof: the same suites against develop's `dispatch-route.ts` (test-only stash): **11 fail** (charset-param, mixed-case, malformed-JSON, all partial-write observability cases) — non-vacuous.
- `plugin-capacitor-bridge` kernel + Android dispatch suites: **27/27 pass**. Electrobun `local-agent-stdio-dispatcher.test.ts`: **7/7 pass**.
- Related adapter suites (`hono-adapter.stream-headers`, `hono-mount.path-normalization`, `runtime-plugin-routes`, `media-runtime`): **33/33 pass**.
- Biome: clean on all changed files. `packages/agent` typecheck (`tsgo --noEmit`): clean.
- `bun run audit:error-policy-ratchet`: `dispatch-route.ts: emptyCatch 1->0, serverConsole 0->0` — no new fallback-slop.
- Type-safety ratchet: all counters at baseline (no new weak types/fallbacks).

<details>
<summary>Process-boundary byte-envelope artifact — real Bun child over real stdio (transcript + sha256)</summary>

```
sent bytes: 4104
sent sha256: 24dcdb34603dcdb838de0022119a638b0657a5fad71ae86175356fa2392fadc0
>> {"id":1,"method":"http_request","payload":{"method":"GET","path":"/api/envelope/audio"}}
>> {"id":2,"method":"http_request","payload":{"method":"GET","path":"/api/envelope/partial"}}
>> {"id":3,"method":"http_request","payload":{"method":"GET","path":"/api/envelope/bad-json"}}
frame id=1 ok=true status=200 content-type="Audio/WAV; Charset=UTF-8" bodyEncoding=base64
received bytes: 4104
received sha256: 24dcdb34603dcdb838de0022119a638b0657a5fad71ae86175356fa2392fadc0
byte-exact: true
frame id=2 ok=false error="legacy route handler threw after writing its response"
frame id=3 ok=false error="legacy route declared JSON but body is malformed"
child exit code: 0
```

Payload = `[0xff, 0xfe, 0x00, 0x80] + "RIFF" + 4096 random bytes` (guaranteed-invalid UTF-8: any decode/re-encode on the path corrupts it). The child is `packages/agent/src/api/__tests__/stdio-envelope-child.ts` (spawned with `bun --conditions=eliza-source`, so the kernel resolves from plugin sources with no built dist); the same round trip runs in CI as `dispatch-route-stdio-envelope.test.ts`, which skips only on a local sparse checkout and hard-fails under CI so a child-boot regression cannot go green.

</details>

<details>
<summary>Focused suite + ratchet output</summary>

```
 Test Files  5 passed (5)
      Tests  33 passed (33)   # dispatch-route-* suites, packages/agent

 Test Files  2 passed (2)
      Tests  27 passed (27)   # plugin-capacitor-bridge android/dispatch + shared/stdio-bridge

 Test Files  1 passed (1)
      Tests  7 passed (7)     # app-core electrobun local-agent-stdio-dispatcher

fail-before (develop dispatch-route.ts, new suites):
 Test Files  2 failed (2)
      Tests  11 failed | 10 passed (21)

[error-policy-ratchet] base origin/develop (6b80bf18fc); 1 changed production source file(s)
[error-policy-ratchet]   packages/agent/src/api/dispatch-route.ts: emptyCatch 1->0, serverConsole 0->0
[error-policy-ratchet] no new fallback-slop in touched files
```

</details>

<!-- evidence-row:before-screenshots -->
- [x] N/A - transport-only backend correction; no rendered UI surface changes

<!-- evidence-row:after-screenshots -->
- [x] N/A - transport-only backend correction; no rendered UI surface changes

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing interaction; the observable behavior is the IPC frame/HTTP status contract, proven by the stdio round-trip transcript above

<!-- evidence-row:backend-logs -->
- [x] [16046-stdio-envelope-transcript.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16046-stdio-envelope-transcript.txt)

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code in this change

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt/model/action/provider behavior change; pure transport byte classification and failure surfacing

<!-- evidence-row:domain-artifacts -->
- [x] [16046-byte-envelope-verification.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16046-byte-envelope-verification.txt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)