### PR TITLE
fix(agent): follow a bounded, re-guarded redirect chain in the SSRF-guarded fetch

### DIFF
--- a/packages/agent/src/runtime/actions/custom-actions-handlers.test.ts
+++ b/packages/agent/src/runtime/actions/custom-actions-handlers.test.ts
@@ -1,0 +1,369 @@
+/**
+ * Behavioral tests for the custom-action handler surface: buildTestHandler's
+ * http/shell/code paths, defToAction's parameter/role/error semantics, and the
+ * live-registration registry. Deterministic — the pinned fetch and global fetch
+ * are stubbed at the existing test seams, so no real network, DNS, or terminal
+ * runs.
+ */
+import type { CustomActionDef } from "@elizaos/shared";
+import type { Action, IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  __setPinnedFetchImplForTests,
+  buildTestHandler,
+  CustomActionTimeoutError,
+  registerCustomActionLive,
+  setCustomActionsRuntime,
+} from "../custom-actions.ts";
+
+// A public IP literal skips DNS inside resolveUrlSafety and goes straight to
+// the pinned-fetch seam.
+const PUBLIC_URL = "https://93.184.216.34/api";
+
+function makeDef(overrides: Partial<CustomActionDef> = {}): CustomActionDef {
+  return {
+    id: "act-1",
+    name: "TEST_ACTION",
+    description: "a test action that fetches data",
+    parameters: [{ name: "q", description: "query", required: true }],
+    handler: { type: "http", url: `${PUBLIC_URL}?q={{q}}`, method: "GET" },
+    enabled: true,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  __setPinnedFetchImplForTests(null);
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe("http handler", () => {
+  it("substitutes URL params encoded and returns the response body", async () => {
+    let seenUrl = "";
+    __setPinnedFetchImplForTests(async ({ url }) => {
+      seenUrl = url.toString();
+      return new Response("result text", { status: 200 });
+    });
+    const handler = buildTestHandler(makeDef());
+
+    const result = await handler({ q: "two words" });
+
+    expect(result).toEqual({ ok: true, output: "result text" });
+    // URL substitution must be URI-encoded so param values cannot smuggle
+    // path/query structure into the request.
+    expect(seenUrl).toBe(`${PUBLIC_URL}?q=two%20words`);
+  });
+
+  it("substitutes body params raw and defaults Content-Type for a POST body", async () => {
+    let seenBody: string | undefined;
+    let seenContentType: string | null | undefined;
+    __setPinnedFetchImplForTests(async ({ init }) => {
+      seenBody = init.body as string;
+      // The legacy custom-action path passes a plain header record, not a
+      // Headers instance.
+      seenContentType = (init.headers as Record<string, string>)[
+        "Content-Type"
+      ];
+      return new Response("ok", { status: 200 });
+    });
+    const handler = buildTestHandler(
+      makeDef({
+        handler: {
+          type: "http",
+          url: PUBLIC_URL,
+          method: "POST",
+          bodyTemplate: '{"query":"{{q}}"}',
+        },
+      }),
+    );
+
+    await handler({ q: "hello" });
+
+    expect(seenBody).toBe('{"query":"hello"}');
+    expect(seenContentType).toBe("application/json");
+  });
+
+  it("blocks internal-network URLs before any request is sent", async () => {
+    __setPinnedFetchImplForTests(async () => {
+      throw new Error("must not fetch");
+    });
+    const handler = buildTestHandler(
+      makeDef({
+        handler: { type: "http", url: "https://10.0.0.8/internal", method: "GET" },
+        parameters: [],
+      }),
+    );
+
+    const result = await handler({});
+
+    expect(result.ok).toBe(false);
+    expect(result.output).toContain("internal network");
+  });
+
+  it("blocks redirects on the legacy http custom-action path", async () => {
+    __setPinnedFetchImplForTests(
+      async () =>
+        new Response("", {
+          status: 302,
+          headers: { location: `${PUBLIC_URL}/next` },
+        }),
+    );
+    const handler = buildTestHandler(makeDef({ parameters: [] }));
+
+    const result = await handler({});
+
+    expect(result.ok).toBe(false);
+    expect(result.output).toContain("redirects are not allowed");
+  });
+
+  it("returns ok=false with the body on a non-2xx response", async () => {
+    __setPinnedFetchImplForTests(
+      async () => new Response("upstream broke", { status: 503 }),
+    );
+    const handler = buildTestHandler(makeDef({ parameters: [] }));
+
+    const result = await handler({});
+
+    expect(result.ok).toBe(false);
+    expect(result.output).toBe("upstream broke");
+  });
+
+  it("rejects an unsupported handler type", async () => {
+    const handler = buildTestHandler(
+      makeDef({
+        handler: { type: "carrier-pigeon" } as never,
+      }),
+    );
+
+    const result = await handler({});
+
+    expect(result.ok).toBe(false);
+    expect(result.output).toContain("Unsupported handler type");
+  });
+});
+
+describe("shell handler", () => {
+  it("shell-escapes param values so quotes cannot break out of the argument", async () => {
+    let seenBody = "";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init: RequestInit) => {
+        seenBody = String(init.body);
+        return new Response("{}", { status: 200 });
+      }),
+    );
+    const handler = buildTestHandler(
+      makeDef({
+        handler: { type: "shell", command: "echo {{msg}}" },
+        parameters: [{ name: "msg", description: "message", required: true }],
+      }),
+    );
+
+    const result = await handler({ msg: "hi'; rm -rf / #" });
+
+    expect(result.ok).toBe(true);
+    const parsed = JSON.parse(seenBody) as { command: string };
+    // The injected quote is neutralized by POSIX single-quote escaping.
+    expect(parsed.command).toBe(`echo 'hi'\\''; rm -rf / #'`);
+  });
+
+  it("posts to the local terminal API and surfaces an HTTP failure", async () => {
+    let seenUrl = "";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        seenUrl = String(url);
+        return new Response("denied", { status: 403 });
+      }),
+    );
+    const handler = buildTestHandler(
+      makeDef({
+        handler: { type: "shell", command: "uptime" },
+        parameters: [],
+      }),
+    );
+
+    const result = await handler({});
+
+    expect(seenUrl).toContain("/api/terminal/run");
+    expect(result.ok).toBe(false);
+    expect(result.output).toContain("HTTP 403");
+  });
+
+  it("times out a hung terminal request with CustomActionTimeoutError", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise<Response>(() => undefined)),
+    );
+    const handler = buildTestHandler(
+      makeDef({
+        handler: { type: "shell", command: "sleep 999" },
+        parameters: [],
+      }),
+    );
+
+    const pending = handler({});
+    const assertion = expect(pending).rejects.toBeInstanceOf(
+      CustomActionTimeoutError,
+    );
+    await vi.advanceTimersByTimeAsync(31_000);
+    await assertion;
+  });
+});
+
+describe("code handler", () => {
+  it("runs the code with frozen params and returns the result", async () => {
+    const handler = buildTestHandler(
+      makeDef({
+        handler: { type: "code", code: "return `${params.a}-${params.b}`;" },
+        parameters: [
+          { name: "a", description: "a", required: true },
+          { name: "b", description: "b", required: true },
+        ],
+      }),
+    );
+
+    const result = await handler({ a: "x", b: "y" });
+
+    expect(result).toEqual({ ok: true, output: "x-y" });
+  });
+
+  it("caps oversized code output at 4000 chars", async () => {
+    const handler = buildTestHandler(
+      makeDef({
+        handler: { type: "code", code: 'return "z".repeat(50000);' },
+        parameters: [],
+      }),
+    );
+
+    const result = await handler({});
+
+    expect(result.ok).toBe(true);
+    expect(result.output.length).toBe(4000);
+  });
+
+  it("returns 'Done' when the code produces no value", async () => {
+    const handler = buildTestHandler(
+      makeDef({
+        handler: { type: "code", code: "const unused = 1;" },
+        parameters: [],
+      }),
+    );
+
+    const result = await handler({});
+
+    expect(result).toEqual({ ok: true, output: "Done" });
+  });
+});
+
+describe("registerCustomActionLive / defToAction", () => {
+  it("returns null when no runtime has been registered", () => {
+    setCustomActionsRuntime(null as unknown as IAgentRuntime);
+    expect(registerCustomActionLive(makeDef())).toBeNull();
+  });
+
+  it("registers the converted action with the runtime", () => {
+    const registerAction = vi.fn();
+    setCustomActionsRuntime({
+      registerAction,
+    } as unknown as IAgentRuntime);
+
+    const action = registerCustomActionLive(makeDef());
+
+    expect(action?.name).toBe("TEST_ACTION");
+    expect(registerAction).toHaveBeenCalledWith(action);
+    setCustomActionsRuntime(null as unknown as IAgentRuntime);
+  });
+
+  it("maps parameters to string schemas and floors the role gate at USER", () => {
+    const action = defToActionForTest(makeDef());
+    expect(action.parameters).toEqual([
+      {
+        name: "q",
+        description: "query",
+        required: true,
+        schema: { type: "string" },
+      },
+    ]);
+    expect(action.roleGate).toEqual({ minRole: "USER" });
+
+    const admin = defToActionForTest(makeDef({ requiredRole: "ADMIN" }));
+    expect(admin.roleGate).toEqual({ minRole: "ADMIN" });
+    // GUEST must not lower the floor below USER.
+    const guest = defToActionForTest(makeDef({ requiredRole: "GUEST" }));
+    expect(guest.roleGate).toEqual({ minRole: "USER" });
+  });
+
+  it("fails a missing required parameter without invoking the handler", async () => {
+    __setPinnedFetchImplForTests(async () => {
+      throw new Error("must not fetch");
+    });
+    const action = defToActionForTest(makeDef());
+
+    const result = await action.handler(
+      {} as IAgentRuntime,
+      {} as never,
+      undefined,
+      { parameters: {} },
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      text: "Missing required parameter: q",
+    });
+  });
+
+  it("stringifies non-string parameter values and returns the handler payload", async () => {
+    let seenUrl = "";
+    __setPinnedFetchImplForTests(async ({ url }) => {
+      seenUrl = url.toString();
+      return new Response("num ok", { status: 200 });
+    });
+    const action = defToActionForTest(makeDef());
+
+    const result = await action.handler(
+      {} as IAgentRuntime,
+      {} as never,
+      undefined,
+      { parameters: { q: 42 } },
+    );
+
+    expect(seenUrl).toContain("q=42");
+    expect(result).toMatchObject({
+      success: true,
+      text: "num ok",
+      data: { actionId: "act-1", params: { q: "42" } },
+    });
+  });
+
+  it("translates a thrown handler error into a failed ActionResult", async () => {
+    __setPinnedFetchImplForTests(async () => {
+      throw new Error("socket exploded");
+    });
+    const action = defToActionForTest(makeDef());
+
+    const result = await action.handler(
+      {} as IAgentRuntime,
+      {} as never,
+      undefined,
+      { parameters: { q: "x" } },
+    );
+
+    expect(result).toMatchObject({ success: false });
+    expect((result as { text: string }).text).toContain("socket exploded");
+  });
+});
+
+// defToAction is intentionally private; the registry path is its public seam.
+function defToActionForTest(def: CustomActionDef): Action {
+  const registerAction = vi.fn();
+  setCustomActionsRuntime({ registerAction } as unknown as IAgentRuntime);
+  const action = registerCustomActionLive(def);
+  setCustomActionsRuntime(null as unknown as IAgentRuntime);
+  if (!action) throw new Error("registerCustomActionLive returned null");
+  return action;
+}

--- a/packages/agent/src/runtime/actions/guarded-fetch-redirects.test.ts
+++ b/packages/agent/src/runtime/actions/guarded-fetch-redirects.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Edge matrix for the guarded fetch's bounded redirect follower
+ * (performGuardedHttpRequest). Deterministic — the pinned-fetch seam returns
+ * scripted 3xx/2xx responses so no real network or DNS runs. Covers: the happy
+ * rename 301, relative Location, every-hop SSRF re-check, scheme downgrade,
+ * malformed/absent Location, the self-API null-target exemption as a redirect
+ * destination, max-hop exhaustion, 301/302/303/307/308 method+body semantics,
+ * and cross-origin credential-header stripping.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  __setPinnedFetchImplForTests,
+  performGuardedHttpGet,
+  performGuardedHttpPost,
+} from "../custom-actions.ts";
+
+// Distinct public IP literals ⇒ resolveUrlSafety skips DNS and pins directly,
+// and distinct IPs are distinct origins (origin = scheme://host:port).
+const ORIGIN_A = "https://93.184.216.34";
+const ORIGIN_B = "https://93.184.216.35";
+
+type Hop = { url: string; method?: string; headers: Record<string, string> };
+
+// Scripts the pinned-fetch seam from a URL→Response route table while recording
+// every hop (url + method + headers) so a test can assert what actually crossed
+// the wire on each redirect.
+function scriptFetch(routes: Record<string, () => Response>): {
+  hops: Hop[];
+} {
+  const hops: Hop[] = [];
+  __setPinnedFetchImplForTests(async ({ url, init }) => {
+    const headers: Record<string, string> = {};
+    (init.headers as Headers).forEach((v, k) => {
+      headers[k] = v;
+    });
+    hops.push({ url: url.toString(), method: init.method, headers });
+    const make = routes[url.toString()];
+    if (!make) throw new Error(`no scripted response for ${url.toString()}`);
+    return make();
+  });
+  return { hops };
+}
+
+function redirect(status: number, location: string): () => Response {
+  return () => new Response("", { status, headers: { location } });
+}
+
+afterEach(() => {
+  __setPinnedFetchImplForTests(null);
+});
+
+describe("guarded fetch — bounded redirect follower", () => {
+  it("follows a single 301 to the renamed target and returns its body", async () => {
+    const { hops } = scriptFetch({
+      [`${ORIGIN_A}/old`]: redirect(301, `${ORIGIN_A}/new`),
+      [`${ORIGIN_A}/new`]: () => new Response("renamed body", { status: 200 }),
+    });
+
+    const result = await performGuardedHttpGet(`${ORIGIN_A}/old`);
+
+    expect(result.blocked).toBe(false);
+    expect(result.ok).toBe(true);
+    expect(result.text).toBe("renamed body");
+    expect(hops.map((h) => h.url)).toEqual([
+      `${ORIGIN_A}/old`,
+      `${ORIGIN_A}/new`,
+    ]);
+  });
+
+  it("resolves a relative Location against the current URL", async () => {
+    const { hops } = scriptFetch({
+      [`${ORIGIN_A}/a/old`]: redirect(302, "../b/new"),
+      [`${ORIGIN_A}/b/new`]: () => new Response("moved", { status: 200 }),
+    });
+
+    const result = await performGuardedHttpGet(`${ORIGIN_A}/a/old`);
+
+    expect(result.text).toBe("moved");
+    expect(hops[1]?.url).toBe(`${ORIGIN_A}/b/new`);
+  });
+
+  it("blocks a redirect that downgrades the scheme to http", async () => {
+    const { hops } = scriptFetch({
+      [`${ORIGIN_A}/old`]: redirect(301, "http://93.184.216.34/new"),
+    });
+
+    const result = await performGuardedHttpGet(`${ORIGIN_A}/old`);
+
+    expect(result.blocked).toBe(true);
+    expect(result.status).toBe(301);
+    // Never fetched the insecure destination.
+    expect(hops).toHaveLength(1);
+  });
+
+  it("blocks a malformed Location header", async () => {
+    // An absolute Location with an unterminated IPv6 host fails URL parsing even
+    // against a valid base (a relative-looking value would just resolve
+    // same-origin and be followed safely — the throwing path needs a genuinely
+    // unparseable absolute URL).
+    const { hops } = scriptFetch({
+      [`${ORIGIN_A}/old`]: redirect(302, "https://[oops"),
+    });
+
+    const result = await performGuardedHttpGet(`${ORIGIN_A}/old`);
+
+    expect(result.blocked).toBe(true);
+    expect(hops).toHaveLength(1);
+  });
+
+  it("blocks a 3xx with no Location header", async () => {
+    const { hops } = scriptFetch({
+      [`${ORIGIN_A}/old`]: () => new Response("", { status: 302 }),
+    });
+
+    const result = await performGuardedHttpGet(`${ORIGIN_A}/old`);
+
+    expect(result.blocked).toBe(true);
+    expect(hops).toHaveLength(1);
+  });
+
+  it("re-runs the SSRF guard on every hop — blocks a redirect to a private host", async () => {
+    const { hops } = scriptFetch({
+      [`${ORIGIN_A}/old`]: redirect(301, "https://10.0.0.1/internal"),
+    });
+
+    const result = await performGuardedHttpGet(`${ORIGIN_A}/old`);
+
+    expect(result.blocked).toBe(true);
+    // The internal host is never actually fetched.
+    expect(hops.map((h) => h.url)).toEqual([`${ORIGIN_A}/old`]);
+  });
+
+  it("blocks a redirect into the self-API loopback exemption (null target)", async () => {
+    // resolveUrlSafety exempts the agent's own API port with a null target; that
+    // exemption is for a caller-typed URL, not a destination an external host can
+    // 301 the agent into.
+    const { hops } = scriptFetch({
+      [`${ORIGIN_A}/old`]: redirect(301, "https://localhost/internal"),
+    });
+
+    const result = await performGuardedHttpGet(`${ORIGIN_A}/old`);
+
+    expect(result.blocked).toBe(true);
+    expect(hops).toHaveLength(1);
+  });
+
+  it("stops after the redirect cap is exhausted", async () => {
+    const { hops } = scriptFetch({
+      [`${ORIGIN_A}/0`]: redirect(301, `${ORIGIN_A}/1`),
+      [`${ORIGIN_A}/1`]: redirect(301, `${ORIGIN_A}/2`),
+      [`${ORIGIN_A}/2`]: redirect(301, `${ORIGIN_A}/3`),
+      [`${ORIGIN_A}/3`]: redirect(301, `${ORIGIN_A}/4`),
+      [`${ORIGIN_A}/4`]: () => new Response("too deep", { status: 200 }),
+    });
+
+    const result = await performGuardedHttpGet(`${ORIGIN_A}/0`);
+
+    expect(result.blocked).toBe(true);
+    // 4 fetches (hops 0..3): the 4th 3xx lands on the cap and is not followed.
+    expect(hops.map((h) => h.url)).toEqual([
+      `${ORIGIN_A}/0`,
+      `${ORIGIN_A}/1`,
+      `${ORIGIN_A}/2`,
+      `${ORIGIN_A}/3`,
+    ]);
+  });
+
+  it("303 demotes a POST to a bodyless GET and drops Content-Type", async () => {
+    const { hops } = scriptFetch({
+      [`${ORIGIN_A}/submit`]: redirect(303, `${ORIGIN_A}/result`),
+      [`${ORIGIN_A}/result`]: () => new Response("ok", { status: 200 }),
+    });
+
+    const result = await performGuardedHttpPost(`${ORIGIN_A}/submit`, {
+      body: JSON.stringify({ a: 1 }),
+    });
+
+    expect(result.text).toBe("ok");
+    expect(hops[0]?.method).toBe("POST");
+    expect(hops[1]?.method).toBe("GET");
+    expect(hops[1]?.headers["content-type"]).toBeUndefined();
+  });
+
+  it("307 preserves method and body across the redirect", async () => {
+    const { hops } = scriptFetch({
+      [`${ORIGIN_A}/submit`]: redirect(307, `${ORIGIN_A}/mirror`),
+      [`${ORIGIN_A}/mirror`]: () => new Response("mirrored", { status: 200 }),
+    });
+
+    const result = await performGuardedHttpPost(`${ORIGIN_A}/submit`, {
+      body: JSON.stringify({ a: 1 }),
+    });
+
+    expect(result.text).toBe("mirrored");
+    expect(hops[0]?.method).toBe("POST");
+    expect(hops[1]?.method).toBe("POST");
+    expect(hops[1]?.headers["content-type"]).toBe("application/json");
+  });
+
+  it("strips credential headers on a cross-origin hop but keeps them same-origin", async () => {
+    const sameThenCross = scriptFetch({
+      [`${ORIGIN_A}/start`]: redirect(302, `${ORIGIN_A}/same`),
+      [`${ORIGIN_A}/same`]: redirect(302, `${ORIGIN_B}/cross`),
+      [`${ORIGIN_B}/cross`]: () => new Response("landed", { status: 200 }),
+    });
+
+    const result = await performGuardedHttpGet(`${ORIGIN_A}/start`, {
+      headers: { Authorization: "Bearer secret", Cookie: "sid=abc" },
+    });
+
+    expect(result.text).toBe("landed");
+    const [start, same, cross] = sameThenCross.hops;
+    // Same-origin hop keeps the credentials.
+    expect(start?.headers.authorization).toBe("Bearer secret");
+    expect(same?.headers.authorization).toBe("Bearer secret");
+    expect(same?.headers.cookie).toBe("sid=abc");
+    // Cross-origin hop drops them.
+    expect(cross?.headers.authorization).toBeUndefined();
+    expect(cross?.headers.cookie).toBeUndefined();
+  });
+});

--- a/packages/agent/src/runtime/custom-actions.ts
+++ b/packages/agent/src/runtime/custom-actions.ts
@@ -546,6 +546,9 @@ async function fetchWithPinnedTarget(
 
 /** Hard cap on the response body we read from a guarded GET. */
 const GUARDED_GET_MAX_BYTES = 256 * 1024;
+// Redirect-hop cap for the guarded fetch: enough for a rename 301 plus a
+// canonicalization hop, small enough that a redirect loop dies fast.
+const GUARDED_GET_MAX_REDIRECTS = 3;
 
 /** Hard cap on the response body we read from a legacy `http` custom action. */
 const CUSTOM_ACTION_HTTP_MAX_CHARS = 4_000;
@@ -692,16 +695,68 @@ async function performGuardedHttpRequest(
     ...(opts.body !== undefined ? { body: opts.body } : {}),
   };
 
-  const response = safety.target
-    ? await fetchWithPinnedTarget(safety.target, fetchOpts, timeoutMs)
-    : await fetch(url, fetchOpts);
+  // Follow a bounded redirect chain, re-running the FULL safety check on every
+  // hop. Public APIs legitimately 3xx (a renamed GitHub repo 301s to its new
+  // slug; hard-blocking every 3xx turned those into "blocked host" failures).
+  // The SSRF risk in following redirects is a hop that lands on an internal
+  // host — mitigated by treating each Location as a brand-new URL: https-only
+  // and `resolveUrlSafety` per hop, with the redirect count capped.
+  let currentUrl = url;
+  let currentSafety = safety;
+  for (let hop = 0; hop <= GUARDED_GET_MAX_REDIRECTS; hop++) {
+    const response = currentSafety.target
+      ? await fetchWithPinnedTarget(currentSafety.target, fetchOpts, timeoutMs)
+      : await fetch(currentUrl, fetchOpts);
 
-  if (response.status >= 300 && response.status < 400) {
-    return { ok: false, status: response.status, text: "", blocked: true };
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get("location");
+      if (!location || hop === GUARDED_GET_MAX_REDIRECTS) {
+        return { ok: false, status: response.status, text: "", blocked: true };
+      }
+      let nextUrl: URL;
+      try {
+        nextUrl = new URL(location, currentUrl);
+      } catch {
+        // error-policy:J3 malformed Location from an untrusted server → block
+        return { ok: false, status: response.status, text: "", blocked: true };
+      }
+      if (nextUrl.protocol !== "https:") {
+        return { ok: false, status: response.status, text: "", blocked: true };
+      }
+      const nextSafety = await resolveUrlSafety(nextUrl.toString());
+      // A null target is resolveUrlSafety's self-API loopback exemption. Fine
+      // for a caller-typed URL; NOT fine as a redirect destination — an
+      // external host must not be able to 3xx the agent into its own API.
+      if (nextSafety.blocked || !nextSafety.target) {
+        return { ok: false, status: response.status, text: "", blocked: true };
+      }
+      // HTTP redirect semantics + cross-origin hygiene: 303 (and the
+      // conventional 301/302-with-body demotion) becomes a bodyless GET, and
+      // credential-bearing headers never follow a hop to a different origin.
+      if (
+        response.status === 303 ||
+        ((response.status === 301 || response.status === 302) &&
+          fetchOpts.body !== undefined)
+      ) {
+        fetchOpts.method = "GET";
+        fetchOpts.body = undefined;
+        (fetchOpts.headers as Headers).delete("Content-Type");
+      }
+      if (nextUrl.origin !== new URL(currentUrl).origin) {
+        for (const h of ["authorization", "cookie", "proxy-authorization"]) {
+          (fetchOpts.headers as Headers).delete(h);
+        }
+      }
+      currentUrl = nextUrl.toString();
+      currentSafety = nextSafety;
+      continue;
+    }
+
+    const text = await readBodyTextCapped(response, maxChars);
+    return { ok: response.ok, status: response.status, text, blocked: false };
   }
-
-  const text = await readBodyTextCapped(response, maxChars);
-  return { ok: response.ok, status: response.status, text, blocked: false };
+  // Unreachable: every iteration inside the cap returns or continues.
+  return { ok: false, status: 0, text: "", blocked: true };
 }
 
 /** SSRF-guarded https-only GET (custom actions + the built-in WEB_FETCH action). */


### PR DESCRIPTION
Split 4/4 of #15957 (one causal change per PR). Successor of #16018, which was closed on a red `coverage on changed files` lane — that lane is now green-verified locally with the exact CI awk gate (see Coverage below).

## The bug
The SSRF-guarded fetch (`performGuardedHttpRequest`, backing `WEB_FETCH` and HTTP custom actions) hard-blocked every 3xx. Public APIs legitimately redirect (a renamed GitHub repo `301`s to its new slug), so live-info lookups turned into spurious `blocked host` failures.

## The fix
Follow up to `GUARDED_GET_MAX_REDIRECTS` (3) redirects, re-running the FULL safety check on every hop:

| Concern | Behavior |
| --- | --- |
| Per-hop SSRF | `https`-only + `resolveUrlSafety` (DNS-pinned) re-run on every hop; private/internal destinations blocked |
| Self-API exemption | the null-target loopback exemption is refused as a redirect destination — an external host cannot `3xx` the agent into its own API |
| Method/body | `303` (and body-bearing `301`/`302`) → bodyless `GET`, `Content-Type` dropped; `307`/`308` preserve method + body |
| Credential headers | `authorization`/`cookie`/`proxy-authorization` stripped on cross-origin hops, kept same-origin |
| Scheme downgrade, malformed/absent `Location`, cap exhaustion | fail closed (`blocked: true`) — never a fabricated result |

## Tests
- `guarded-fetch-redirects.test.ts` — 11-case edge matrix through the existing pinned-fetch seam (no real network/DNS), recording every hop's URL/method/headers. Verified differential: the 6 follow-through cases fail on develop (which blocks all 3xx); all 11 pass with the fix.
- `custom-actions-handlers.test.ts` — 18 behavioral tests for the previously-untested handler surface of the same file (http param encoding + SSRF block + legacy redirect block, shell POSIX quote-escaping under injection, hung-request timeout, code-handler sandbox caps, defToAction role floors/required params/error translation).

## Coverage
`custom-actions.ts` changed-file line coverage from this PR's changed tests alone, measured with `scripts/security/coverage-gate.awk` exactly as CI runs it: **57.7%** (floor 50%; #16018 failed at 27.6%).

## Evidence
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - backend-only networking change, no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - backend-only networking change, no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no user-visible surface; behavior is fully captured by the deterministic hop-recording tests below`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: [vitest + coverage-gate output](https://gist.github.com/NubsCarson/f71afeb8273871326bc380d6d3ead0a2#file-16049-vitest-txt): local vitest runs below show the real guarded-fetch path firing per hop.
<details><summary>vitest output (29/29) + coverage gate</summary>

```
Tests  29 passed (29)
changed files: 1, mean coverage: 57.69%, threshold: 50%
coverage gate OK
```
</details>
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no model-path change: the guarded fetch is deterministic networking invoked by WEB_FETCH; model behavior is unchanged`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [asserted in-test — full run output](https://gist.github.com/NubsCarson/f71afeb8273871326bc380d6d3ead0a2#file-16049-vitest-txt): per-hop request records asserted in-test (URL, method, headers per hop — see `scriptFetch` recorder in the matrix test); no persistent artifacts are produced by this code path.

