### PR TITLE
test(cloud): cover dedicated restore and proxy edges

### DIFF
--- a/packages/ui/src/api/client-cloud-direct-auth.test.ts
+++ b/packages/ui/src/api/client-cloud-direct-auth.test.ts
@@ -262,6 +262,23 @@ describe("ElizaClient direct Cloud auth on native", () => {
         }),
       ],
     });
+    if (!result.success) throw new Error("Expected the agent list to load");
+    const selected = await client.selectOrProvisionCloudAgent({
+      cloudApiBase: "https://api.elizacloud.ai/api/v1",
+      authToken: "cloud-api-key",
+      name: "My Agent",
+      knownAgents: result.data,
+      preferSharedTier: true,
+      preferStewardAgentAdapter: true,
+    });
+    expect(selected).toEqual(
+      expect.objectContaining({
+        agentId: "agent-1",
+        apiBase: "https://agent-1.example.test",
+        created: false,
+      }),
+    );
+    expect(capacitorMocks.request).toHaveBeenCalledTimes(1);
     expectNoLocalPersistOrStatusProbe();
   });
 

--- a/packages/ui/src/state/startup-phase-restore.concurrency.test.ts
+++ b/packages/ui/src/state/startup-phase-restore.concurrency.test.ts
@@ -187,6 +187,7 @@ describe("cloud restore routes the client without waiting on the Steward refresh
       kind: "cloud",
       label: "Eliza Cloud",
       apiBase: sharedApiBase,
+      accessToken: "paired-token",
     };
 
     const dedicatedClient = { setBaseUrl: vi.fn(), setToken: vi.fn() };
@@ -197,6 +198,7 @@ describe("cloud restore routes the client without waiting on the Steward refresh
     expect(dedicatedClient.setBaseUrl).toHaveBeenCalledWith(
       "https://shared-agent.elizacloud.ai",
     );
+    expect(dedicatedClient.setToken).toHaveBeenCalledWith("paired-token");
 
     setBootConfig({ ...DEFAULT_BOOT_CONFIG, preferSharedCloudTier: true });
     const sharedClient = { setBaseUrl: vi.fn(), setToken: vi.fn() };
@@ -205,6 +207,7 @@ describe("cloud restore routes the client without waiting on the Steward refresh
       clientRef: sharedClient,
     });
     expect(sharedClient.setBaseUrl).toHaveBeenCalledWith(sharedApiBase);
+    expect(sharedClient.setToken).toHaveBeenCalledWith("paired-token");
   });
 });
 

--- a/packages/ui/src/state/startup-phase-restore.steward-refresh.test.ts
+++ b/packages/ui/src/state/startup-phase-restore.steward-refresh.test.ts
@@ -119,6 +119,9 @@ describe("applyRestoredConnection — cloud Steward token refresh at restore", (
     });
 
     expect(fetchMock).not.toHaveBeenCalled();
+    expect(client.setBaseUrl).toHaveBeenCalledWith(
+      "https://agent-123.example.com",
+    );
     expect(client.setToken).toHaveBeenCalledWith(valid);
     expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBe(valid);
   });


### PR DESCRIPTION
## Summary

Rebased onto current `develop`. The production implementation from the original branch is already upstream, so Git dropped those commits. The remaining exact-head delta adds three regression assertions:

- direct native Cloud authentication selects an existing dedicated agent without another Capacitor request
- restored dedicated/shared Cloud connections preserve the paired token
- Steward refresh restores the dedicated agent base URL before applying the token

## Verification

- `bunx vitest run src/api/client-cloud-direct-auth.test.ts src/state/startup-phase-restore.concurrency.test.ts src/state/startup-phase-restore.steward-refresh.test.ts`: 41 passed
- Biome: clean
- `git diff --check`: clean

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots/visual baseline: N/A - the rebased diff changes tests only; no production or rendered source remains.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots/visual check: N/A - the rebased diff changes tests only; no pixels can differ.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no executable product behavior remains in the diff.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - deterministic regression assertions only; no backend implementation changed.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - deterministic regression assertions only; no frontend implementation changed.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no model, prompt, action, provider, or agent behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - the durable artifact is the test coverage itself; the production behavior is already on `develop`.