### PR TITLE
fix(core): guard evaluator output against model drift leaking as the answer

### DIFF
--- a/packages/core/src/runtime/__tests__/evaluator.test.ts
+++ b/packages/core/src/runtime/__tests__/evaluator.test.ts
@@ -744,3 +744,135 @@ Result: / and /home are on /dev/sda1, 387G total, 223G used, 165G free, 58% used
 		);
 	});
 });
+
+describe("envelope-then-prose repair (leading fenced verdict + answer)", () => {
+	it("takes the fenced envelope as the verdict and the prose as messageToUser", () => {
+		const raw = [
+			"```json",
+			'{',
+			'  "success": true,',
+			'  "decision": "FINISH",',
+			'  "thought": "Retrieved the commit info."',
+			"}",
+			"```",
+			"",
+			"Last commit:",
+			"SHA: 2e240df0a1ecab779ccca5e17eecd4bc532f1d25",
+		].join("\n");
+		const parsed = parseEvaluatorOutput(raw);
+		expect(parsed.decision).toBe("FINISH");
+		expect(parsed.success).toBe(true);
+		expect(parsed.messageToUser).toContain("Last commit:");
+		// The raw envelope must never reach the user-facing message.
+		expect(parsed.messageToUser).not.toContain("```json");
+		expect(parsed.messageToUser).not.toContain('"decision"');
+	});
+
+	it("keeps an explicit messageToUser from the envelope over trailing prose", () => {
+		const raw = [
+			"```json",
+			'{ "success": true, "decision": "FINISH", "messageToUser": "The answer is 42." }',
+			"```",
+			"stray trailing text",
+		].join("\n");
+		const parsed = parseEvaluatorOutput(raw);
+		expect(parsed.messageToUser).toBe("The answer is 42.");
+	});
+
+	it("reports invalid when the trailing prose is XML tool syntax", () => {
+		const raw = [
+			"```json",
+			'{ "success": true, "decision": "FINISH", "thought": "done" }',
+			"```",
+			"<tool_call>",
+			"<arg_key>location</arg_key>",
+			"<arg_value>Tokyo</arg_value>",
+			"</tool_call>",
+		].join("\n");
+		const parsed = parseEvaluatorOutput(raw);
+		// The model was trying to act, not answer: the response is invalid and
+		// the loop replans — the tool syntax never becomes the user message and
+		// the turn never ends on a silent no-message FINISH.
+		expect(parsed.parseError).toBeDefined();
+		expect(parsed.decision).toBe("CONTINUE");
+		expect(parsed.messageToUser).toBeUndefined();
+	});
+
+	it("reports invalid when the trailing prose is a bare action name + JSON args", () => {
+		const raw = [
+			"```json",
+			'{ "success": true, "decision": "FINISH", "thought": "done" }',
+			"```",
+			"GET_WEATHER",
+			'{ "location": "Tokyo" }',
+		].join("\n");
+		const parsed = parseEvaluatorOutput(raw);
+		expect(parsed.parseError).toBeDefined();
+		expect(parsed.decision).toBe("CONTINUE");
+		expect(parsed.messageToUser).toBeUndefined();
+	});
+});
+
+describe("structured evaluator output shape gate", () => {
+	it("rejects a structured object with no verdict fields as a parse error", () => {
+		const parsed = parseEvaluatorOutput({
+			object: { command: "curl https://example.com" },
+		});
+		expect(parsed.parseError).toContain("not evaluator-shaped");
+		expect(parsed.decision).toBe("CONTINUE");
+		expect(parsed.success).toBe(false);
+	});
+
+	it("accepts a structured object that carries a verdict field", () => {
+		const parsed = parseEvaluatorOutput({
+			object: { success: true, decision: "FINISH", messageToUser: "Done." },
+		});
+		expect(parsed.parseError).toBeUndefined();
+		expect(parsed.decision).toBe("FINISH");
+		expect(parsed.messageToUser).toBe("Done.");
+	});
+});
+
+describe("native tool dialects never recover as the user-facing answer", () => {
+	async function runWithModelText(text: string) {
+		const runtime = { useModel: vi.fn(async () => text) };
+		return await runEvaluator({
+			runtime,
+			context: {
+				id: "ctx",
+				staticPrefix: {
+					characterPrompt: { content: "agent_name: Eliza", stable: true },
+				},
+				events: [],
+			},
+			trajectory: {
+				context: { id: "ctx" },
+				steps: [
+					{
+						toolCall: { id: "tool-1", name: "SHELL", params: {} },
+						result: { success: true, text: "tool ran" },
+					},
+				],
+				archivedSteps: [],
+				plannedQueue: [],
+				evaluatorOutputs: [],
+			},
+		});
+	}
+
+	it("does not deliver standalone XML tool syntax", async () => {
+		const result = await runWithModelText(
+			"<tool_call>\n<arg_key>location</arg_key>\n<arg_value>Tokyo</arg_value>\n</tool_call>",
+		);
+		expect(result.messageToUser ?? "").not.toContain("tool_call");
+		expect(result.messageToUser ?? "").not.toContain("arg_key");
+	});
+
+	it("does not deliver a standalone bare action name + JSON args block", async () => {
+		const result = await runWithModelText(
+			'GET_WEATHER\n{ "location": "Tokyo" }',
+		);
+		expect(result.messageToUser ?? "").not.toContain("GET_WEATHER");
+		expect(result.messageToUser ?? "").not.toContain("location");
+	});
+});

--- a/packages/core/src/runtime/evaluator.ts
+++ b/packages/core/src/runtime/evaluator.ts
@@ -651,6 +651,17 @@ function looksLikeUserFacingAnswer(text: string): boolean {
 	if (/\{\s*"(?:action|tool|name|parameters|command)"\s*:/i.test(text)) {
 		return false;
 	}
+	// Native model tool syntax is machine output, never a user-facing answer.
+	// Two dialects need their own screens because neither carries the JSON keys
+	// the guard above matches: XML-style tool markup (<tool_call>/<arg_key>),
+	// and a bare ALL_CAPS action name followed by a JSON args object
+	// ("GET_WEATHER\n{\"location\":\"Tokyo\"}").
+	if (/<\/?(?:tool_call|function_call|arg_key|arg_value)\b/i.test(text)) {
+		return false;
+	}
+	if (/^\s*[A-Z][A-Z0-9_]{2,}\s*\n\s*\{/.test(text)) {
+		return false;
+	}
 	if (
 		/\b(?:need|needs|should|must|will)\s+(?:to\s+)?(?:run|call|use|invoke|execute)\b/i.test(
 			text,
@@ -806,12 +817,57 @@ function getStructuredEvaluatorObject(
 		typeof raw.object === "object" &&
 		!Array.isArray(raw.object)
 	) {
+		// Same shape gate the text path applies: a structured object carrying
+		// none of success/decision/route (e.g. a bare {"command": ...} tool-call
+		// shape) is model drift, not an evaluator verdict. It routes through the
+		// parse-error path so the loop sees a malformed evaluation and retries,
+		// instead of a silent default verdict.
+		if (!isEvaluatorShapedObject(raw.object)) {
+			return {
+				object: null,
+				parseError: `structured evaluator output is not evaluator-shaped: ${JSON.stringify(raw.object).slice(0, 200)}`,
+			};
+		}
 		return { object: raw.object as RawEvaluatorOutput };
 	}
 	if (typeof raw.text === "string") {
 		return parseEvaluatorText(raw.text);
 	}
 	return { object: null, parseError: "missing evaluator text/object" };
+}
+
+/**
+ * Split a response that BEGINS with a fenced JSON block into the block and the
+ * prose after it. Some evaluator models emit a fenced verdict envelope followed
+ * by the user-facing answer as trailing prose; a whole-string JSON parse
+ * rejects that shape, so the envelope and the prose must be separated before
+ * either can be used.
+ */
+function extractLeadingJsonFence(
+	text: string,
+): { block: string; rest: string } | null {
+	if (!text.startsWith("```")) return null;
+	const firstLineEnd = text.indexOf("\n");
+	if (firstLineEnd < 0) return null;
+	const closeIdx = text.indexOf("\n```", firstLineEnd);
+	if (closeIdx < 0) return null;
+	const afterClose = text.indexOf("\n", closeIdx + 1);
+	const block = text.slice(firstLineEnd + 1, closeIdx).trim();
+	const rest = afterClose < 0 ? "" : text.slice(afterClose + 1);
+	if (!block) return null;
+	return { block, rest };
+}
+
+/** JSON.parse that reports failure as null instead of throwing. */
+function tryParseJson(candidate: string): unknown {
+	try {
+		return JSON.parse(candidate);
+	} catch {
+		// error-policy:J3 the fenced block is untrusted model output; a parse
+		// failure means "not a verdict", reported as null so the caller falls
+		// through to the tolerant parse instead of treating it as valid.
+		return null;
+	}
 }
 
 function parseEvaluatorText(text: string): ParsedEvaluatorObject {
@@ -829,6 +885,35 @@ function parseEvaluatorText(text: string): ParsedEvaluatorObject {
 		}
 		return { object: parsed };
 	} catch {
+		// Envelope-then-prose repair: a leading fenced evaluator verdict with the
+		// answer following it is a valid response — the envelope is the verdict
+		// and the prose is the user-facing message. The prose must pass the same
+		// machine-output screen every other recovery path uses: an envelope
+		// followed by native tool syntax means the model was trying to ACT, so
+		// the whole response is reported invalid (the loop retries/continues)
+		// rather than finishing the turn with tool syntax as the answer or a
+		// silent no-message FINISH.
+		const leading = extractLeadingJsonFence(text.trim());
+		if (leading) {
+			const parsedBlock = tryParseJson(leading.block);
+			if (parsedBlock && isEvaluatorShapedObject(parsedBlock)) {
+				const prose = leading.rest.trim();
+				const record = parsedBlock as RawEvaluatorOutput & {
+					messageToUser?: unknown;
+				};
+				if (prose && typeof record.messageToUser !== "string") {
+					if (!looksLikeUserFacingAnswer(prose)) {
+						return {
+							object: null,
+							parseError:
+								"leading evaluator envelope followed by machine output (tool syntax), not a user-facing answer",
+						};
+					}
+					record.messageToUser = prose;
+				}
+				return { object: record };
+			}
+		}
 		const tolerant = parseJsonObject<RawEvaluatorOutput>(candidate);
 		if (isEvaluatorShapedObject(tolerant)) {
 			return {


### PR DESCRIPTION
Successor of #16007, rebuilt to its closing reviews — including the blocking correctness finding (the envelope-then-prose path could deliver tool syntax as the user message; it now reports an explicit invalid/CONTINUE), deterministic tests for every changed branch, the `error-policy:J3` annotation, and durable comments.

## The three defects (one causal area: evaluator output parsing/recovery)
1. **Structured `raw.object` had zero shape validation** — a bare tool-call-shaped object (`{"command": ...}`) was accepted as a verdict and became a silent default-CONTINUE. It now passes the same `isEvaluatorShapedObject` gate as the text path and reports a parse error the loop can act on.
2. **Prose recovery delivered native tool dialects verbatim** — XML tool markup (`<tool_call>`/`<arg_key>`) and a bare `ALL_CAPS_ACTION` + JSON args block carry none of the JSON keys the existing guard matches; both dialects are now screened by `looksLikeUserFacingAnswer`.
3. **Envelope-then-prose** — a leading fenced verdict with trailing prose is split: the prose becomes `messageToUser` only when it passes the same machine-output screen. An envelope followed by tool syntax reports the whole response **invalid (explicit CONTINUE/replan)** — per the review, never a silent no-message FINISH and never tool syntax as the answer.

## Tests — every changed branch, through the public surface
`parseEvaluatorOutput` (text + object forms) and `runEvaluator` prose recovery: structured non-verdict object (reject) + structured verdict object (accept), standalone XML dialect, standalone bare-action dialect, fenced+XML → invalid, fenced+bare-action → invalid, benign envelope-then-prose → prose delivered, explicit envelope `messageToUser` kept. Suite: **28/28**. No new empty catch — the fenced-block parse failure reports null via a helper with an `error-policy:J3` justification.

## Coverage (CI awk gate, changed tests only)
`evaluator.ts` **84.4%** (floor 50%).

## Evidence
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - runtime parsing change, no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - runtime parsing change, no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no user-visible surface beyond chat text; behavior is pinned by the branch-matrix tests`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: [vitest + coverage-gate output](https://gist.github.com/NubsCarson/f71afeb8273871326bc380d6d3ead0a2#file-16053-vitest-txt): vitest 28/28 below; the drift shapes and their dispositions are asserted directly.
<details><summary>test results</summary>

```
evaluator.test.ts   Tests  28 passed (28)
coverage gate: 84.37% (threshold 50%) — OK
```
</details>
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: [full trajectory JSON](https://gist.github.com/NubsCarson/f71afeb8273871326bc380d6d3ead0a2#file-live-trajectory-tj-a279e861a12022-json): live production trajectory (cerebras planner/evaluator, 2026-07-10) for the originally-affected prompt, running this change — the evaluator FINISHes with the real user-facing answer, no tool-syntax leak:
<details><summary>trajectory excerpt (tj-a279e861a12022)</summary>

```
stages: messageHandler → toolSearch → planner → tool → evaluation
EVAL decision: FINISH
messageToUser: "Based on the GitHub API data for the elizaos/eliza repo, the top 3 contributors
by contribution count are: 1. **lalalune** (3,997 contributions) 2. **NubsCarso…"
```
</details>
The *before* shapes (raw `<tool_call>` XML and `GET_WEATHER\n{...}` delivered to the channel) are the live incidents that motivated each guard; each is reproduced byte-for-byte as a deterministic test input.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [artifact](https://gist.github.com/NubsCarson/f71afeb8273871326bc380d6d3ead0a2#file-live-trajectory-tj-a279e861a12022-json): the parsed verdict objects for every drift shape are asserted in-test (decision/parseError/messageToUser per case).

