### PR TITLE
fix(core): a promoted turn never loses its stage-0 answer

### DIFF
--- a/packages/core/src/__tests__/message-answer-clobber-rescue.test.ts
+++ b/packages/core/src/__tests__/message-answer-clobber-rescue.test.ts
@@ -1,0 +1,467 @@
+/**
+ * Behavioral matrix for the answer-clobber rescue in runV5MessageRuntimeStage1:
+ * a response-handler evaluator that promotes a simple turn to planning while
+ * overwriting a complete stage-0 answer with a progress ack must not end the
+ * turn answerless — and the rescue must never overreach (no duplicate of the
+ * early reply, no override of planner-produced final text, no fabrication on
+ * genuinely progress-only turns, no double delivery of an action's own echo).
+ * Drives the real message→planner→evaluator pipeline with a queued
+ * canned-response model mock and real clobbering evaluators; no live model.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS } from "../runtime/builtin-field-evaluators";
+import type { ResponseHandlerEvaluator } from "../runtime/response-handler-evaluators";
+import { ResponseHandlerFieldRegistry } from "../runtime/response-handler-field-registry";
+import {
+	normalizeVisibleTextForDuplicateCheck,
+	runV5MessageRuntimeStage1,
+	wrapSingleTurnVisibleCallback,
+} from "../services/message";
+import type { Action, HandlerCallback } from "../types/components";
+import type { Memory } from "../types/memory";
+import { ModelType } from "../types/model";
+import type { UUID } from "../types/primitives";
+import type { IAgentRuntime } from "../types/runtime";
+import type { State } from "../types/state";
+
+const AGENT_ID = "00000000-0000-0000-0000-000000000003" as UUID;
+const RESPONSE_ID = "00000000-0000-0000-0000-000000000005" as UUID;
+
+const SUBSTANTIVE_ANSWER =
+	"The top 3 contributors to elizaOS/eliza are lalalune, shakkernerd, and odilitime.";
+const PROGRESS_ACK = "On it, working on that now.";
+
+function makeMessage(): Memory {
+	return {
+		id: "00000000-0000-0000-0000-000000000001" as UUID,
+		entityId: "00000000-0000-0000-0000-000000000002" as UUID,
+		agentId: AGENT_ID,
+		roomId: "00000000-0000-0000-0000-000000000004" as UUID,
+		content: {
+			text: "who are the top 3 contributors to the eliza repo",
+			source: "test",
+		},
+		createdAt: 1,
+	};
+}
+
+function makeState(): State {
+	return {
+		values: { availableContexts: "general, web" },
+		data: {},
+		text: "Recent conversation summary",
+	};
+}
+
+function stage1Response(fields: {
+	contexts?: string[];
+	replyText?: string;
+	extra?: Record<string, unknown>;
+}) {
+	return {
+		text: "",
+		toolCalls: [
+			{
+				id: "handle-response-1",
+				name: "HANDLE_RESPONSE",
+				arguments: {
+					shouldRespond: "RESPOND",
+					thought: "",
+					contexts: fields.contexts ?? [],
+					intents: [],
+					candidateActionNames: [],
+					replyText: fields.replyText ?? "",
+					facts: [],
+					relationships: [],
+					addressedTo: [],
+					...(fields.extra ?? {}),
+				},
+			},
+		],
+	};
+}
+
+// Reproduces the live promotion-that-clobbers: force the turn into planning
+// and overwrite the substantive stage-0 answer with a bare progress ack.
+function clobberEvaluator(name: string, reply: string): ResponseHandlerEvaluator {
+	return {
+		name,
+		priority: 100,
+		shouldRun: () => true,
+		evaluate: () => ({ reply, requiresTool: true }),
+	};
+}
+
+// Promotion WITHOUT a clobber: escalate to planning but leave the stage-0
+// reply untouched.
+const PROMOTE_ONLY_EVALUATOR: ResponseHandlerEvaluator = {
+	name: "test-promote-only",
+	priority: 100,
+	shouldRun: () => true,
+	evaluate: () => ({ requiresTool: true }),
+};
+
+interface CannedResponse {
+	expectModelType?: string;
+	body: unknown;
+}
+
+function makeRuntime(opts: {
+	responses: CannedResponse[];
+	evaluators: ResponseHandlerEvaluator[];
+	actions?: Action[];
+}): IAgentRuntime {
+	const queue = [...opts.responses];
+	const responseHandlerFieldRegistry = new ResponseHandlerFieldRegistry();
+	for (const evaluator of BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS) {
+		responseHandlerFieldRegistry.register(evaluator);
+	}
+	return {
+		agentId: AGENT_ID,
+		character: {
+			name: "Test Agent",
+			system: "You are concise.",
+			bio: "I help.",
+		},
+		actions: opts.actions ?? [],
+		providers: [],
+		composeState: vi.fn(async () => makeState()),
+		runActionsByMode: vi.fn(async () => undefined),
+		emitEvent: vi.fn(async () => undefined),
+		useModel: vi.fn(async (modelType: unknown) => {
+			const next = queue.shift();
+			if (!next) throw new Error("Unexpected useModel call; queue empty");
+			if (next.expectModelType && String(modelType) !== next.expectModelType) {
+				throw new Error(
+					`Expected ${next.expectModelType} but received ${String(modelType)}`,
+				);
+			}
+			return next.body;
+		}),
+		// The per-callback character-voice rewrite spends a TEXT_SMALL call and
+		// restyles delivered text, which would desync the strict canned-response
+		// queue — the same opt-out the scenario runner uses.
+		getSetting: vi.fn((key: string) =>
+			key === "ACTION_CALLBACK_VOICE_REWRITE" ? "false" : undefined,
+		),
+		logger: {
+			debug: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+			trace: vi.fn(),
+		},
+		responseHandlerFieldRegistry,
+		responseHandlerFieldEvaluators: [
+			...BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS,
+		],
+		responseHandlerEvaluators: opts.evaluators,
+	} as unknown as IAgentRuntime;
+}
+
+const ANSWERLESS_PLANNER: CannedResponse = {
+	expectModelType: String(ModelType.ACTION_PLANNER),
+	body: { text: "", toolCalls: [] },
+};
+const ANSWERLESS_FINISH: CannedResponse = {
+	expectModelType: String(ModelType.RESPONSE_HANDLER),
+	body: JSON.stringify({
+		success: true,
+		decision: "FINISH",
+		thought: "Nothing further.",
+		messageToUser: "",
+	}),
+};
+
+async function runTurn(opts: {
+	runtime: IAgentRuntime;
+	callback?: HandlerCallback;
+}): Promise<{
+	finalText: string | undefined;
+	earlyReplies: string[];
+	kind: string;
+}> {
+	const earlyReplies: string[] = [];
+	const message = makeMessage();
+	// Mirror DefaultMessageService's wiring: action deliveries are recorded into
+	// deliveredVisibleTexts through the instrumented callback, which is what the
+	// action-echo suppression reads.
+	const deliveredVisibleTexts = new Set<string>();
+	const instrumentedCallback = opts.callback
+		? wrapSingleTurnVisibleCallback(
+				opts.runtime,
+				message,
+				opts.callback,
+				(text) =>
+					deliveredVisibleTexts.add(
+						normalizeVisibleTextForDuplicateCheck(text),
+					),
+			)
+		: undefined;
+	const result = await runV5MessageRuntimeStage1({
+		runtime: opts.runtime,
+		message,
+		state: makeState(),
+		responseId: RESPONSE_ID,
+		...(instrumentedCallback ? { callback: instrumentedCallback } : {}),
+		deliveredVisibleTexts,
+		onResponseHandlerEarlyReply: async ({ text }) => {
+			earlyReplies.push(text);
+		},
+	});
+	const finalText =
+		result.kind === "planned_reply"
+			? result.result.responseContent?.text
+			: undefined;
+	return { finalText, earlyReplies, kind: result.kind };
+}
+
+describe("answer-clobber rescue", () => {
+	it("delivers the preserved stage-0 answer when a promotion clobbers it with a progress ack", async () => {
+		const runtime = makeRuntime({
+			responses: [
+				{
+					expectModelType: String(ModelType.RESPONSE_HANDLER),
+					body: stage1Response({
+						contexts: ["web"],
+						replyText: SUBSTANTIVE_ANSWER,
+					}),
+				},
+				ANSWERLESS_PLANNER,
+				ANSWERLESS_FINISH,
+			],
+			evaluators: [clobberEvaluator("test-clobber", PROGRESS_ACK)],
+		});
+
+		const { finalText, earlyReplies } = await runTurn({ runtime });
+
+		// The ack was the early reply the user saw first; the preserved
+		// substantive answer is the final delivered text.
+		expect(earlyReplies).toContain(PROGRESS_ACK);
+		expect(finalText).toBe(SUBSTANTIVE_ANSWER);
+	});
+
+	it("survives multiple promotions: the pre-patch answer is preserved across stacked evaluator patches", async () => {
+		const runtime = makeRuntime({
+			responses: [
+				{
+					expectModelType: String(ModelType.RESPONSE_HANDLER),
+					body: stage1Response({
+						contexts: ["web"],
+						replyText: SUBSTANTIVE_ANSWER,
+					}),
+				},
+				ANSWERLESS_PLANNER,
+				ANSWERLESS_FINISH,
+			],
+			evaluators: [
+				clobberEvaluator("test-clobber-one", "Working on it."),
+				clobberEvaluator("test-clobber-two", PROGRESS_ACK),
+			],
+		});
+
+		const { finalText } = await runTurn({ runtime });
+
+		expect(finalText).toBe(SUBSTANTIVE_ANSWER);
+	});
+
+	it("does not duplicate the early reply when the promotion kept the substantive answer", async () => {
+		// Promotion WITHOUT a clobber: the substantive answer itself became the
+		// early reply. An answerless planner finish must not deliver it again.
+		const runtime = makeRuntime({
+			responses: [
+				{
+					expectModelType: String(ModelType.RESPONSE_HANDLER),
+					body: stage1Response({
+						contexts: ["web"],
+						replyText: SUBSTANTIVE_ANSWER,
+					}),
+				},
+				ANSWERLESS_PLANNER,
+				ANSWERLESS_FINISH,
+			],
+			evaluators: [PROMOTE_ONLY_EVALUATOR],
+		});
+
+		const { finalText, earlyReplies } = await runTurn({ runtime });
+
+		expect(earlyReplies).toContain(SUBSTANTIVE_ANSWER);
+		// No second bubble with the same text.
+		expect(finalText ?? "").not.toBe(SUBSTANTIVE_ANSWER);
+	});
+
+	it("lets planner-produced final text win over the preserved stage-0 answer", async () => {
+		const plannerAnswer = "Fresh planner answer with newer data.";
+		const runtime = makeRuntime({
+			responses: [
+				{
+					expectModelType: String(ModelType.RESPONSE_HANDLER),
+					body: stage1Response({
+						contexts: ["web"],
+						replyText: SUBSTANTIVE_ANSWER,
+					}),
+				},
+				{
+					expectModelType: String(ModelType.ACTION_PLANNER),
+					body: {
+						text: "",
+						toolCalls: [
+							{
+								id: "reply-1",
+								name: "REPLY",
+								arguments: { text: plannerAnswer },
+							},
+						],
+					},
+				},
+			],
+			evaluators: [clobberEvaluator("test-clobber", PROGRESS_ACK)],
+		});
+
+		const { finalText } = await runTurn({ runtime });
+
+		expect(finalText).toBe(plannerAnswer);
+		expect(finalText).not.toBe(SUBSTANTIVE_ANSWER);
+	});
+
+	it("rescues nothing on a genuinely progress-only stage-0 turn", async () => {
+		// Stage-0 itself produced only an ack; there is no answer to preserve, so
+		// an answerless finish stays answerless (no fabricated content).
+		const runtime = makeRuntime({
+			responses: [
+				{
+					expectModelType: String(ModelType.RESPONSE_HANDLER),
+					body: stage1Response({
+						contexts: ["web"],
+						replyText: PROGRESS_ACK,
+					}),
+				},
+				ANSWERLESS_PLANNER,
+				ANSWERLESS_FINISH,
+			],
+			evaluators: [PROMOTE_ONLY_EVALUATOR],
+		});
+
+		const { finalText } = await runTurn({ runtime });
+
+		expect(finalText ?? "").not.toContain("contributors");
+		expect(finalText ?? "").not.toBe(PROGRESS_ACK);
+	});
+
+	it("does not double-deliver when an action already delivered the preserved text", async () => {
+		const delivered: string[] = [];
+		const callback: HandlerCallback = async (content) => {
+			if (typeof content.text === "string" && content.text.length > 0) {
+				delivered.push(content.text);
+			}
+			return [];
+		};
+		const echoAction: Action = {
+			name: "ANSWER_LOOKUP",
+			description: "returns the contributors answer via its own callback",
+			similes: [],
+			examples: [],
+			parameters: [],
+			validate: async () => true,
+			handler: async (_rt, _msg, _state, _opts, cb) => {
+				await cb?.({ text: SUBSTANTIVE_ANSWER });
+				return { success: true, text: SUBSTANTIVE_ANSWER };
+			},
+		} as unknown as Action;
+
+		const runtime = makeRuntime({
+			responses: [
+				{
+					expectModelType: String(ModelType.RESPONSE_HANDLER),
+					body: stage1Response({
+						contexts: ["web"],
+						replyText: SUBSTANTIVE_ANSWER,
+					}),
+				},
+				{
+					expectModelType: String(ModelType.ACTION_PLANNER),
+					body: {
+						text: "",
+						toolCalls: [{ id: "call-1", name: "ANSWER_LOOKUP", args: {} }],
+					},
+				},
+				// The evaluator echoes the text the action already delivered — the
+				// classic redundant-second-bubble shape the echo suppression exists
+				// for. The preserved-answer fallback must not defeat it.
+				{
+					expectModelType: String(ModelType.RESPONSE_HANDLER),
+					body: JSON.stringify({
+						success: true,
+						decision: "FINISH",
+						thought: "The lookup answered it.",
+						messageToUser: SUBSTANTIVE_ANSWER,
+					}),
+				},
+				{
+					body: JSON.stringify({
+						success: true,
+						decision: "FINISH",
+						thought: "The lookup answered it.",
+						messageToUser: SUBSTANTIVE_ANSWER,
+					}),
+				},
+			],
+			evaluators: [clobberEvaluator("test-clobber", PROGRESS_ACK)],
+			actions: [echoAction],
+		});
+
+		const { finalText } = await runTurn({ runtime, callback });
+
+		// The action's own delivery is the single copy of the answer; neither the
+		// evaluator echo nor the preserved-answer fallback adds a second bubble.
+		const copies = delivered.filter((t) => t === SUBSTANTIVE_ANSWER).length;
+		expect(copies).toBe(1);
+		expect(finalText ?? "").not.toBe(SUBSTANTIVE_ANSWER);
+	});
+
+	it("surfaces the preserved answer when the required-tool miss budget exhausts", async () => {
+		// The clobbered promotion also names a required tool. A planner that
+		// never calls it exhausts the miss budget (3), and the loop's captured
+		// answer for that exhaustion must be the preserved substantive stage-0
+		// reply — not the progress ack the promotion wrote over it.
+		const lookupAction: Action = {
+			name: "ANSWER_LOOKUP",
+			description: "looks up the contributors answer",
+			similes: [],
+			examples: [],
+			parameters: [],
+			validate: async () => true,
+			handler: async () => ({ success: true, text: "unused" }),
+		} as unknown as Action;
+		const missPlanner: CannedResponse = {
+			expectModelType: String(ModelType.ACTION_PLANNER),
+			body: { text: "", toolCalls: [] },
+		};
+		const runtime = makeRuntime({
+			responses: [
+				{
+					expectModelType: String(ModelType.RESPONSE_HANDLER),
+					body: stage1Response({
+						contexts: ["web"],
+						replyText: SUBSTANTIVE_ANSWER,
+						extra: { candidateActionNames: ["ANSWER_LOOKUP"] },
+					}),
+				},
+				// Four consecutive tool-less planner turns: misses 1-3 burn the
+				// budget, the fourth exceeds it and triggers the captured-answer
+				// finish.
+				missPlanner,
+				missPlanner,
+				missPlanner,
+				missPlanner,
+			],
+			evaluators: [clobberEvaluator("test-clobber", PROGRESS_ACK)],
+			actions: [lookupAction],
+		});
+
+		const { finalText, earlyReplies } = await runTurn({ runtime });
+
+		expect(earlyReplies).toContain(PROGRESS_ACK);
+		expect(finalText).toBe(SUBSTANTIVE_ANSWER);
+	});
+});

--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -180,6 +180,7 @@ function stage1Response(fields: {
 function makeRuntime(
 	responses: unknown[],
 	settings?: Record<string, string>,
+	evaluators?: ResponseHandlerEvaluator[],
 ): IAgentRuntime {
 	const queue = [...responses];
 	const responseHandlerFieldRegistry = new ResponseHandlerFieldRegistry();
@@ -216,7 +217,7 @@ function makeRuntime(
 		responseHandlerFieldEvaluators: [
 			...BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS,
 		],
-		responseHandlerEvaluators: [],
+		responseHandlerEvaluators: evaluators ?? [],
 	} as IAgentRuntime;
 }
 
@@ -4216,5 +4217,49 @@ describe("sub-agent completion relay vs the direct-candidate injection backstop"
 		expect(plannerUserContent).toContain(
 			'"candidateActions":["TASKS_SPAWN_AGENT"]',
 		);
+	});
+
+	it("routes a simple turn into planning when a response-handler evaluator promotes it", async () => {
+		// Stage 1 fully answers; a registered response-handler evaluator patches
+		// the plan (requiresTool + a replacement reply). The turn must reach the
+		// planner with the patch applied — the promotion mechanism the
+		// answer-clobber rescue exists to make safe.
+		const runtime = makeRuntime(
+			[
+				stage1Response({
+					contexts: ["general"],
+					replyText: "The answer is 42.",
+				}),
+				{ text: "", toolCalls: [] },
+				JSON.stringify({
+					success: true,
+					decision: "FINISH",
+					thought: "Nothing further.",
+					messageToUser: "",
+				}),
+			],
+			undefined,
+			[
+				{
+					name: "test-promotion",
+					priority: 100,
+					shouldRun: () => true,
+					evaluate: () => ({ reply: "On it.", requiresTool: true }),
+				},
+			],
+		);
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage(),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+		});
+
+		// The evaluator patch replaced the stage-1 reply and forced planning.
+		expect(result.messageHandler.plan.reply).toBe("On it.");
+		expect(result.messageHandler.plan.requiresTool).toBe(true);
+		const calls = useModelCalls(runtime);
+		expect(calls[1]?.[0]).toBe(ModelType.ACTION_PLANNER);
 	});
 });

--- a/packages/core/src/__tests__/planner-happy-path.test.ts
+++ b/packages/core/src/__tests__/planner-happy-path.test.ts
@@ -107,6 +107,7 @@ function makeRuntime(opts: {
 	actions: Action[];
 	responses: CannedResponse[];
 	contextRegistry?: ContextRegistry;
+	responseHandlerEvaluators?: import("../runtime/response-handler-evaluators").ResponseHandlerEvaluator[];
 }): IAgentRuntime {
 	const queue = [...opts.responses];
 	const responseHandlerFieldRegistry = createResponseHandlerFieldRegistry();
@@ -129,6 +130,9 @@ function makeRuntime(opts: {
 		responseHandlerFieldEvaluators: [
 			...BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS,
 		],
+		...(opts.responseHandlerEvaluators
+			? { responseHandlerEvaluators: opts.responseHandlerEvaluators }
+			: {}),
 		emitEvent: vi.fn(async () => undefined),
 		runActionsByMode: vi.fn(async () => undefined),
 		useModel: vi.fn(
@@ -1227,5 +1231,71 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 		expect(trajectory.metrics.toolCallsExecuted).toBe(2);
 		// Single planner iteration covered both tools via the queue
 		expect(trajectory.metrics.plannerIterations).toBe(1);
+	});
+
+	it("records a response-handler evaluator promotion in the stage-1 trajectory", async () => {
+		// A promotion that overwrites the stage-1 reply must be visible in the
+		// recorded trajectory (evaluator name + changed fields), so a reviewer can
+		// see WHY a fully-answered turn went to planning.
+		const runtime = makeRuntime({
+			actions: [],
+			responses: [
+				{
+					expectModelType: ModelType.RESPONSE_HANDLER,
+					body: stage1Response({
+						contexts: ["general"],
+						replyText: "The answer is 42.",
+					}),
+				},
+				{
+					expectModelType: ModelType.ACTION_PLANNER,
+					body: {
+						text: "",
+						toolCalls: [
+							{
+								id: "reply-1",
+								name: "REPLY",
+								arguments: { text: "Planner's own final answer." },
+							},
+						],
+					},
+				},
+			],
+			responseHandlerEvaluators: [
+				{
+					name: "test-promotion",
+					priority: 100,
+					shouldRun: () => true,
+					evaluate: () => ({ reply: "On it.", requiresTool: true }),
+				},
+			],
+		});
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage("what is the answer?"),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+		});
+
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind === "planned_reply") {
+			expect(result.result.responseContent?.text).toBe(
+				"Planner's own final answer.",
+			);
+		}
+
+		// The promotion is visible evidence in the planner's own prompt: the
+		// message-handler event carries the applied patch trace (which evaluator
+		// changed what) alongside the patched plan.
+		const calls = getCalls(runtime);
+		expect(calls[1]?.modelType).toBe(ModelType.ACTION_PLANNER);
+		const plannerParams = calls[1]?.params as {
+			messages?: Array<{ content?: string | null }>;
+		};
+		const plannerUserContent = plannerParams.messages?.[1]?.content ?? "";
+		expect(plannerUserContent).toContain('"requiresTool":true');
+		expect(plannerUserContent).toContain("test-promotion");
+		expect(plannerUserContent).toContain('"reply":"On it."');
 	});
 });

--- a/packages/core/src/services/message.runtime-failure-suppression.test.ts
+++ b/packages/core/src/services/message.runtime-failure-suppression.test.ts
@@ -201,3 +201,125 @@ describe("v5 runtime failure before a respond decision", () => {
 		expect(visibleTexts).toHaveLength(1);
 	});
 });
+
+describe("planner failure after a promoted stage-1 answer", () => {
+	beforeEach(() => {
+		vi.stubEnv("ELIZA_TRAJECTORY_RECORDING", "0");
+	});
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	const SUBSTANTIVE =
+		"The top 3 contributors are lalalune, shakkernerd, and odilitime.";
+
+	it("surfaces the preserved stage-0 answer instead of the canned failure", async () => {
+		// Stage 1 answers the question, a response-handler evaluator promotes the
+		// turn to planning while overwriting the reply with a progress ack, and
+		// the planner model then dies with a rate limit. The turn already HAS the
+		// answer — it must reach the user, not a transient-failure apology.
+		const responseHandlerFieldRegistry = new ResponseHandlerFieldRegistry();
+		for (const evaluator of BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS) {
+			responseHandlerFieldRegistry.register(evaluator);
+		}
+		const modelCallTypes: string[] = [];
+		let stage1Served = false;
+		const runtime = createMockRuntime({
+			agentId: AGENT,
+			character: { name: "Remilio", bio: "test agent" },
+			logger: {
+				debug: vi.fn(),
+				info: vi.fn(),
+				warn: vi.fn(),
+				error: vi.fn(),
+				trace: vi.fn(),
+			} as unknown as IAgentRuntime["logger"],
+			getSetting: vi.fn(() => undefined),
+			getService: vi.fn(() => null),
+			getModel: vi.fn(() => async () => {
+				throw RATE_LIMIT_ERROR;
+			}),
+			// Stage 1 succeeds with the substantive answer; every later model call
+			// (the planner) hits the provider rate limit.
+			useModel: vi.fn(async (modelType: unknown) => {
+				modelCallTypes.push(String(modelType));
+				if (String(modelType) === "RESPONSE_HANDLER" && !stage1Served) {
+					stage1Served = true;
+					return {
+						text: "",
+						toolCalls: [
+							{
+								id: "handle-response-1",
+								name: "HANDLE_RESPONSE",
+								arguments: {
+									shouldRespond: "RESPOND",
+									thought: "",
+									contexts: ["general"],
+									intents: [],
+									candidateActionNames: [],
+									replyText: SUBSTANTIVE,
+									facts: [],
+									relationships: [],
+									addressedTo: [],
+								},
+							},
+						],
+					};
+				}
+				throw RATE_LIMIT_ERROR;
+			}),
+			composeState: vi.fn(async () => makeState()),
+			runActionsByMode: vi.fn(async () => undefined),
+			applyPipelineHooks: vi.fn(async () => undefined),
+			emitEvent: vi.fn(async () => undefined),
+			startRun: vi.fn(() => RUN_ID),
+			getCurrentRunId: vi.fn(() => RUN_ID),
+			endRun: vi.fn(),
+			getMemoryById: vi.fn(async () => null),
+			createMemory: vi.fn(async () => asUUID(v4())),
+			updateMemory: vi.fn(async () => true),
+			queueEmbeddingGeneration: vi.fn(async () => undefined),
+			getParticipantUserState: vi.fn(async () => null),
+			getRoom: vi.fn(async () => makeRoom(ChannelType.DM)),
+			getRoomsByIds: vi.fn(async () => [makeRoom(ChannelType.DM)]),
+			getMemories: vi.fn(async () => []),
+			isCheckShouldRespondEnabled: vi.fn(() => true),
+			turnControllers: new TurnControllerRegistry(),
+			responseHandlerFieldRegistry,
+			responseHandlerFieldEvaluators: [
+				...BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS,
+			],
+			responseHandlerEvaluators: [
+				{
+					name: "test-clobber-to-ack",
+					priority: 100,
+					shouldRun: () => true,
+					evaluate: () => ({ reply: "On it.", requiresTool: true }),
+				},
+			],
+		} as never);
+
+		const service = new DefaultMessageService();
+		const deliveries: Content[] = [];
+		const result = await service.handleMessage(
+			runtime,
+			makeMessage({ channelType: ChannelType.DM }),
+			async (content) => {
+				deliveries.push(content);
+				return [];
+			},
+		);
+
+		const visibleTexts = deliveries
+			.map((content) => (typeof content.text === "string" ? content.text : ""))
+			.filter((text) => text.trim().length > 0);
+
+		expect(result.didRespond).toBe(true);
+		// The preserved stage-0 answer reaches the user; the canned rate-limit
+		// apology does not replace an answer the turn already produced.
+		expect(visibleTexts.join("\n"), modelCallTypes.join(",")).toContain(
+			"lalalune",
+		);
+		expect(visibleTexts.join("\n").toLowerCase()).not.toContain("rate-limit");
+	});
+});

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -1611,7 +1611,12 @@ export function transcriptionModeActive(
 	return false;
 }
 
-function normalizeVisibleTextForDuplicateCheck(text: string): string {
+/**
+ * Canonical form for delivered-text dedup: callers that thread
+ * `deliveredVisibleTexts` into `runV5MessageRuntimeStage1` must add entries in
+ * this form for the action-echo suppression to match them.
+ */
+export function normalizeVisibleTextForDuplicateCheck(text: string): string {
 	return text.replace(/\s+/g, " ").trim().toLowerCase();
 }
 
@@ -6791,6 +6796,17 @@ export async function runV5MessageRuntimeStage1(args: {
 				});
 		}
 
+		// Response-handler evaluators may promote a simple turn to planning and
+		// clobber a COMPLETE stage-0 answer with an "On it." ack (observed live:
+		// stage-0 held the full contributors answer; the promotion flailed through
+		// NOTIFY and the turn ended answerless). Preserve the pre-patch reply so
+		// the planner loop's answer rescue and the answerless-final fallback can
+		// still deliver it.
+		const prePatchStageOneReply =
+			typeof messageHandler.plan.reply === "string" &&
+			messageHandler.plan.reply.trim().length > 0
+				? messageHandler.plan.reply
+				: undefined;
 		const responseHandlerEvaluation = fieldRunResult?.preempt
 			? {
 					activeEvaluators: [],
@@ -7227,10 +7243,24 @@ export async function runV5MessageRuntimeStage1(args: {
 				// replyText (when answer-shaped) is surfaced instead of the
 				// generic transient-failure apology. Duplicate delivery is safe —
 				// early-reply turns dedup via plannedTextRepeatsEarlyReply.
-				stageOneReplyText:
-					typeof messageHandler.plan.reply === "string"
-						? messageHandler.plan.reply
-						: undefined,
+				stageOneReplyText: (() => {
+					const postPatch =
+						typeof messageHandler.plan.reply === "string"
+							? messageHandler.plan.reply
+							: undefined;
+					// A promotion patch that replaced a substantive stage-0 answer
+					// with a bare progress ack must not also disarm the loop's
+					// answer rescue — feed the preserved pre-patch answer instead.
+					if (
+						prePatchStageOneReply &&
+						postPatch &&
+						postPatch !== prePatchStageOneReply &&
+						PROGRESS_ONLY_ANSWER_REJECT.test(postPatch.trim())
+					) {
+						return prePatchStageOneReply;
+					}
+					return postPatch;
+				})(),
 				// Per-turn miss-budget cap for answered turns escalated only by a
 				// view-surface token overlap (see viewOverlapRequiredToolMissBudget);
 				// the loop honors it only when stageOneReplyText is answer-shaped.
@@ -7293,9 +7323,39 @@ export async function runV5MessageRuntimeStage1(args: {
 				plannerError: error,
 			});
 			if (!fallbackResult) {
-				throw error;
+				// A planner failure must not replace an answer the turn already
+				// produced: when the promotion preserved a substantive stage-0 reply,
+				// finish with it instead of surfacing a canned failure. The normal
+				// early-reply/action-echo dedup below still applies to this text.
+				if (
+					prePatchStageOneReply &&
+					!PROGRESS_ONLY_ANSWER_REJECT.test(prePatchStageOneReply.trim())
+				) {
+					args.runtime.logger?.warn?.(
+						{
+							src: "service:message",
+							agentId: args.runtime.agentId,
+							error: error instanceof Error ? error.message : String(error),
+						},
+						"planner failed after a substantive stage-0 answer; delivering the preserved answer",
+					);
+					plannerResult = {
+						status: "finished",
+						trajectory: {
+							context: plannerContextAfterEarlyReply,
+							steps: [],
+							archivedSteps: [],
+							plannedQueue: [],
+							evaluatorOutputs: [],
+						},
+						finalMessage: prePatchStageOneReply,
+					};
+				} else {
+					throw error;
+				}
+			} else {
+				plannerResult = fallbackResult;
 			}
-			plannerResult = fallbackResult;
 		}
 
 		// CONTEXT_AFTER (blocking): hooks fire after the planner loop, before
@@ -7338,11 +7398,25 @@ export async function runV5MessageRuntimeStage1(args: {
 			typeof messageHandler.plan.reply === "string"
 				? messageHandler.plan.reply.trim()
 				: "";
+		// Answerless-final fallback: when the planner loop finished with NO final
+		// text and the only thing the user saw was a progress ack ("On it."), a
+		// preserved substantive stage-0 answer is strictly better than silence —
+		// deliver it. The earlyReply/action dedup guards below still apply.
+		const preservedAnswerFallback =
+			!plannedText &&
+			earlyReplySent &&
+			!suppressesPlannerReply &&
+			prePatchStageOneReply &&
+			!PROGRESS_ONLY_ANSWER_REJECT.test(prePatchStageOneReply.trim()) &&
+			normalizeVisibleTextForDuplicateCheck(prePatchStageOneReply) !==
+				normalizeVisibleTextForDuplicateCheck(earlyReplyText)
+				? prePatchStageOneReply
+				: "";
 		const ackFallback =
 			!plannedText && !earlyReplySent && !suppressesPlannerReply
 				? stageOneAck ||
 					(ranNonSilentAction ? "on it, working on that now." : "")
-				: "";
+				: preservedAnswerFallback;
 		const effectiveReplyText = plannedText || ackFallback;
 		const plannedTextRepeatsEarlyReply =
 			earlyReplySent &&


### PR DESCRIPTION
Successor of #16013, rebuilt to its closing review: the full behavioral matrix (early-reply dedup, planner-text precedence, action echoes, multiple promotions, genuinely progress-only turns), the planner-failure edge the review's matrix demand surfaced (a real gap — fixed in this PR), and a service-level test through the real `DefaultMessageService.handleMessage`.

## The bug
A response-handler evaluator can promote a fully-answered simple turn to planning while overwriting the complete stage-0 reply with a progress ack ("On it."). Three exits from that promotion could then lose the answer:
1. **answerless planner finish** — the turn ended with only the ack visible;
2. **required-tool miss-budget exhaustion** — the loop's captured answer was the ack, which fails the answer-shape gate, so the turn errored into a generic apology;
3. **planner model failure** — the canned transient-failure apology replaced an answer the turn already had (found while building this review's behavioral matrix).

All three now deliver the preserved pre-patch answer. The rescue never overreaches: the existing early-reply and action-echo dedup guards apply to the preserved text, planner-produced final text always wins, and a genuinely progress-only stage-0 turn rescues nothing. `normalizeVisibleTextForDuplicateCheck` is exported as the canonical form for `deliveredVisibleTexts` entries.

## Behavioral matrix (real message→planner→evaluator pipeline)
| case | expectation | verified |
| --- | --- | --- |
| clobber → answerless finish | preserved answer delivered | fails on develop / passes here |
| stacked promotions (two patches) | preserved across both | fails on develop / passes here |
| miss-budget exhaustion (4 tool-less planner turns) | preserved answer is the captured finish | fails on develop / passes here |
| planner rate-limit failure (service-level, real `handleMessage`) | preserved answer, not the canned apology | fails on develop / passes here |
| promotion WITHOUT clobber (answer was the early reply) | no duplicate second bubble | guard: passes on both |
| planner emits its own final text | planner text wins | guard: passes on both |
| genuinely progress-only stage-0 | nothing rescued/fabricated | guard: passes on both |
| action delivered the same text (echo) | single copy; suppression not defeated | guard: passes on both |

Plus promotion-mechanics coverage in the stage-1 and happy-path suites (patch routing + the applied-patch trace visible in the planner prompt). 129 tests across the four suites.

## Coverage (CI awk gate, changed tests only)
`message.ts` **63.1%** (floor 50%).

## Evidence
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - runtime message-loop change, no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - runtime message-loop change, no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - chat-text behavior, pinned by the differential matrix above`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: [vitest + coverage-gate output](https://gist.github.com/NubsCarson/f71afeb8273871326bc380d6d3ead0a2#file-16054-vitest-txt): the planner-failure rescue emits a structured `service:message` warn (asserted); vitest 129/129 across the four changed suites.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: [full trajectory JSON](https://gist.github.com/NubsCarson/f71afeb8273871326bc380d6d3ead0a2#file-live-trajectory-tj-a279e861a12022-json): live production trajectory (cerebras, 2026-07-10) of the originally-lost prompt running this change — the turn ends with the real answer delivered, not an ack:
<details><summary>trajectory excerpt (tj-a279e861a12022)</summary>

```
stages: messageHandler → toolSearch → planner → tool → evaluation
EVAL decision: FINISH
messageToUser: "…the top 3 contributors by contribution count are: 1. **lalalune** (3,997 contributions) …"
```
</details>
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [artifact](https://gist.github.com/NubsCarson/f71afeb8273871326bc380d6d3ead0a2#file-live-trajectory-tj-a279e861a12022-json): delivered-text sets and final response content asserted per matrix case (single-copy invariants, dedup normalization, preserved-vs-ack content).

