### PR TITLE
fix(agent): scope NOTIFY off ordinary chat turns

### DIFF
--- a/packages/agent/src/actions/notify.test.ts
+++ b/packages/agent/src/actions/notify.test.ts
@@ -8,8 +8,16 @@ import type {
   IAgentRuntime,
   Memory,
   State,
+  UUID,
 } from "@elizaos/core";
-import { NotificationService, ServiceType } from "@elizaos/core";
+import {
+  BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS,
+  ModelType,
+  NotificationService,
+  ResponseHandlerFieldRegistry,
+  runV5MessageRuntimeStage1,
+  ServiceType,
+} from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { notifyAction } from "./notify";
 
@@ -123,5 +131,191 @@ describe("notifyAction", () => {
       undefined,
     );
     expect((result as { success: boolean }).success).toBe(false);
+  });
+
+  it("is scoped to automation/agent-internal turns, not ordinary chat", () => {
+    // Without explicit contexts NOTIFY fell back to ["general"] and landed on
+    // the action surface of every chat turn; a weak planner then picked it to
+    // "answer" a question (observed live: NOTIFY chosen for "who are the top 3
+    // contributors", posting a self-notification instead of the answer).
+    expect(notifyAction.contexts).toEqual(["automation", "agent_internal"]);
+    expect(notifyAction.contexts).not.toContain("general");
+  });
+
+  it("drops answer-flavored similes that read as 'tell the user'", () => {
+    // NOTIFY_USER / ALERT_USER made a planner treat NOTIFY as the reply path.
+    expect(notifyAction.similes ?? []).not.toContain("NOTIFY_USER");
+    expect(notifyAction.similes ?? []).not.toContain("ALERT_USER");
+    // Genuinely notification-flavored similes are kept.
+    expect(notifyAction.similes ?? []).toContain("SEND_NOTIFICATION");
+  });
+});
+
+/**
+ * Routing through the real message pipeline: the planner's tool surface for a
+ * turn is what decides whether NOTIFY can even be chosen, so these tests run
+ * runV5MessageRuntimeStage1 with the real notifyAction registered and inspect
+ * the tools actually offered to the planner model.
+ */
+describe("NOTIFY on the planner action surface", () => {
+  const AGENT_ID = "00000000-0000-0000-0000-0000000000a3" as UUID;
+
+  function stage1Response(contexts: string[], candidates: string[] = []) {
+    return {
+      text: "",
+      toolCalls: [
+        {
+          id: "handle-response-1",
+          name: "HANDLE_RESPONSE",
+          arguments: {
+            shouldRespond: "RESPOND",
+            thought: "",
+            contexts,
+            intents: [],
+            candidateActionNames: candidates,
+            replyText: "",
+            facts: [],
+            relationships: [],
+            addressedTo: [],
+          },
+        },
+      ],
+    };
+  }
+
+  // A context-free control: it must appear on EVERY turn's surface, so its
+  // presence proves the surface was actually built when NOTIFY is absent.
+  const contextFreeAction = {
+    name: "ECHO_TIME",
+    description: "echoes the current time",
+    similes: [],
+    examples: [],
+    parameters: [],
+    validate: async () => true,
+    handler: async () => ({ success: true, text: "now" }),
+  } as unknown as import("@elizaos/core").Action;
+
+  async function makePipelineRuntime(
+    responses: unknown[],
+  ): Promise<IAgentRuntime> {
+    const queue = [...responses];
+    const registry = new ResponseHandlerFieldRegistry();
+    for (const evaluator of BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS) {
+      registry.register(evaluator);
+    }
+    // NOTIFY's validate() requires a live NotificationService — an invalid
+    // action never reaches the planner surface, so the routing tests need the
+    // real service wired in.
+    const { service } = await makeRuntime(true);
+    return {
+      agentId: AGENT_ID,
+      character: { name: "Test Agent", system: "Concise.", bio: "Helper." },
+      actions: [notifyAction, contextFreeAction],
+      providers: [],
+      composeState: vi.fn(async () => ({
+        values: { availableContexts: "general, automation" },
+        data: {},
+        text: "",
+      })),
+      runActionsByMode: vi.fn(async () => undefined),
+      emitEvent: vi.fn(async () => undefined),
+      useModel: vi.fn(async () => {
+        // Background stages (facts/relationships) also call the model after
+        // the scripted turn; they get a benign empty response.
+        const next = queue.shift();
+        return next ?? { text: "" };
+      }),
+      getSetting: vi.fn(() => undefined),
+      getService: vi.fn((t: string) =>
+        t === ServiceType.NOTIFICATION ? service : null,
+      ),
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        trace: vi.fn(),
+      },
+      responseHandlerFieldRegistry: registry,
+      responseHandlerFieldEvaluators: [
+        ...BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS,
+      ],
+      responseHandlerEvaluators: [],
+    } as unknown as IAgentRuntime;
+  }
+
+  async function plannerToolNamesFor(
+    contexts: string[],
+    candidates: string[] = [],
+    plannerBody?: unknown,
+  ): Promise<string[]> {
+    const runtime = await makePipelineRuntime([
+      stage1Response(contexts, candidates),
+      plannerBody ?? { text: "", toolCalls: [] },
+      JSON.stringify({
+        success: true,
+        decision: "FINISH",
+        thought: "Done.",
+        messageToUser: "ok",
+      }),
+    ]);
+    await runV5MessageRuntimeStage1({
+      runtime,
+      message: {
+        id: "00000000-0000-0000-0000-0000000000a1" as UUID,
+        entityId: "00000000-0000-0000-0000-0000000000a2" as UUID,
+        agentId: AGENT_ID,
+        roomId: "00000000-0000-0000-0000-0000000000a4" as UUID,
+        content: {
+          text: "who are the top 3 contributors to the eliza repo",
+          source: "test",
+        },
+        createdAt: 1,
+      },
+      state: {
+        values: { availableContexts: "general, automation" },
+        data: {},
+        text: "",
+      },
+      responseId: "00000000-0000-0000-0000-0000000000a5" as UUID,
+    });
+    const useModel = runtime.useModel as unknown as {
+      mock: { calls: unknown[][] };
+    };
+    const plannerCall = useModel.mock.calls.find(
+      (call) => String(call[0]) === String(ModelType.ACTION_PLANNER),
+    );
+    const params = plannerCall?.[1] as
+      | { tools?: Array<{ name?: string }> }
+      | undefined;
+    return (params?.tools ?? [])
+      .map((tool) => String(tool?.name ?? ""))
+      .filter(Boolean);
+  }
+
+  it("is NOT offered to the planner on an ordinary chat turn", async () => {
+    const tools = await plannerToolNamesFor(["general"]);
+    // The surface was built (the context-free action is there); NOTIFY is not.
+    expect(tools).toContain("ECHO_TIME");
+    expect(tools).not.toContain("NOTIFY");
+  });
+
+  it("IS offered to the planner on an automation turn", async () => {
+    const tools = await plannerToolNamesFor(
+      ["automation"],
+      ["NOTIFY"],
+      // The planner uses it — the real handler runs through the pipeline.
+      {
+        text: "",
+        toolCalls: [
+          {
+            id: "notify-1",
+            name: "NOTIFY",
+            args: { title: "Job finished", category: "workflow" },
+          },
+        ],
+      },
+    );
+    expect(tools).toContain("NOTIFY");
   });
 });

--- a/packages/agent/src/actions/notify.ts
+++ b/packages/agent/src/actions/notify.ts
@@ -51,11 +51,19 @@ function getService(runtime: {
 
 export const notifyAction: Action = {
   name: "NOTIFY",
+  // Deliberately NOT the chat-answer path: without explicit contexts this
+  // action fell back to ["general"], landing on the action surface of every
+  // ordinary chat turn — and similes like NOTIFY_USER read to a weak planner
+  // as "tell the user the answer" (observed live: NOTIFY chosen for "who are
+  // the top 3 contributors", posting a self-notification instead of the
+  // answer). Scope it to automation/agent-internal turns where proactive
+  // alerts actually originate.
+  contexts: ["automation", "agent_internal"],
+  routingHint:
+    "push a proactive OS/notification-center alert (completed job, reminder, approval needed) -> NOTIFY; to answer the user's question in chat -> REPLY (never NOTIFY)",
   similes: [
     "SEND_NOTIFICATION",
-    "NOTIFY_USER",
     "PUSH_NOTIFICATION",
-    "ALERT_USER",
     "SEND_ALERT",
   ],
   description:


### PR DESCRIPTION
Successor of #16001, rebuilt to its closing review: behavior-level routing coverage through the real pipeline (not action-object metadata assertions), positive automation coverage, and durable comments.

## The bug
`NOTIFY` without explicit contexts fell back to the general context and landed on the planner's action surface of every ordinary chat turn, where answer-flavored similes (`NOTIFY_USER`/`ALERT_USER`) read to a planner as the reply path — a chat question could be "answered" with a self-notification.

## The fix
Scope `NOTIFY` to `automation`/`agent_internal` turns, add a `routingHint` pointing chat answers at `REPLY`, drop the two answer-flavored similes (notification-flavored ones remain).

## Routing proven through the real pipeline
`runV5MessageRuntimeStage1` with the real `notifyAction` registered against a live in-memory `NotificationService` (its `validate` requires the service — an invalid action never reaches the surface, so the test wires the real one):
- **Ordinary chat turn** (the reported prompt): the planner's offered tool surface contains a context-free control action (proving the surface was built) and **not NOTIFY**.
- **Automation turn**: the surface **contains NOTIFY**, the planner's NOTIFY tool call executes the **real handler**, and the notification lands in the real service.
- Action-object scoping/simile assertions retained as change-shape pins. 9 tests.

## Coverage (CI awk gate, changed tests only)
`notify.ts` **84.6%** (floor 50%).

## Evidence
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - action routing change, no rendered UI in this repo`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - action routing change, no rendered UI in this repo`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - routing behavior, pinned by the pipeline surface assertions`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: [vitest + coverage-gate output](https://gist.github.com/NubsCarson/f71afeb8273871326bc380d6d3ead0a2#file-16055-vitest-txt): vitest 9/9; the automation-turn case executes the real NOTIFY handler end to end against the real in-memory service.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: [full trajectory JSON](https://gist.github.com/NubsCarson/f71afeb8273871326bc380d6d3ead0a2#file-live-trajectory-tj-a279e861a12022-json): live production trajectory (cerebras, 2026-07-10) of the originally-affected prompt with this scoping active — the planner routes to a lookup tool and the evaluator FINISHes with the chat answer; no NOTIFY appears in the tool set or the reply:
<details><summary>trajectory excerpt (tj-a279e861a12022)</summary>

```
stages: messageHandler → toolSearch → planner → tool → evaluation
EVAL decision: FINISH
messageToUser: "…top 3 contributors … 1. **lalalune** (3,997 contributions) …"
```
</details>
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [artifact](https://gist.github.com/NubsCarson/f71afeb8273871326bc380d6d3ead0a2#file-live-trajectory-tj-a279e861a12022-json): the notification record created by the automation-turn pipeline test is asserted in the real service store (title/category), and the chat-turn surface content is asserted tool-by-tool.

