### PR TITLE
fix(ci): aggregate coverage per file across LCOV inputs before thresholding (#16043)

### DIFF
--- a/scripts/security/coverage-gate.awk
+++ b/scripts/security/coverage-gate.awk
@@ -68,11 +68,15 @@ function path_matches_lcov(current_path, changed_path,    current_len, changed_l
       }
     }
     if (matched != "") {
-      matched_map[matched] = 1
-      changed_count++
-      changed_sum += pct
-      printf "  %6.2f%% %s\n", pct, matched
-      if (pct + 0 < threshold + 0) below[matched] = pct
+      # Aggregate per file across ALL lcov inputs BEFORE thresholding. The same
+      # source can appear in several lane reports — its own focused lane at real
+      # coverage plus another package's lane that merely imports it at ~2%. Keep
+      # the file's BEST-lane percentage so an incidental low record cannot fail a
+      # file whose real coverage clears the floor (#16043). Counting, the mean,
+      # and the below[] verdict are all computed from file_pct in END.
+      if (!(matched in file_pct) || pct + 0 > file_pct[matched] + 0) {
+        file_pct[matched] = pct
+      }
     }
   }
   current = ""; lines_found = 0; lines_hit = 0
@@ -80,10 +84,17 @@ function path_matches_lcov(current_path, changed_path,    current_len, changed_l
 
 END {
   missing_count = 0
+  changed_count = 0
+  changed_sum = 0
   for (f in changed_map) {
-    if (!(f in matched_map)) {
+    if (!(f in file_pct)) {
       printf "  MISSING: %s\n", f
       missing_count++
+    } else {
+      changed_count++
+      changed_sum += file_pct[f]
+      printf "  %6.2f%% %s\n", file_pct[f], f
+      if (file_pct[f] + 0 < threshold + 0) below[f] = file_pct[f]
     }
   }
 

--- a/scripts/security/coverage-gate.self-test.mjs
+++ b/scripts/security/coverage-gate.self-test.mjs
@@ -37,10 +37,25 @@ function writeLcovRecords(dir, sourcePaths) {
   return file;
 }
 
+// Write a single-record lcov under an explicit filename so a test can hand the
+// awk MULTIPLE lcov inputs (one per lane), exactly as the CI does with the
+// per-nearest-config lcov.info files.
+function writeLcovAs(dir, name, sourcePath, found, hit) {
+  const file = join(dir, name);
+  writeFileSync(
+    file,
+    [`SF:${sourcePath}`, `LF:${found}`, `LH:${hit}`, "end_of_record", ""].join(
+      "\n",
+    ),
+  );
+  return file;
+}
+
 function runGate({ changed, lcov, enforce = true, threshold = 50 }) {
   const changedArgument = changed
     .replaceAll("\\", "\\\\")
     .replaceAll("\n", "\\n");
+  const lcovArgs = Array.isArray(lcov) ? lcov : [lcov];
   return spawnSync(
     "awk",
     [
@@ -50,7 +65,7 @@ function runGate({ changed, lcov, enforce = true, threshold = 50 }) {
       `threshold=${threshold}`,
       "-f",
       awkScript,
-      lcov,
+      ...lcovArgs,
     ],
     {
       cwd: root,
@@ -136,6 +151,42 @@ try {
     assert.match(result.stdout, /MISSING: packages\/demo\/src\/runtime[.]ts/);
     assert.match(result.stdout, /changed source missing from LCOV/);
   });
+  assertGate(
+    "aggregates a file across lanes: an incidental low record does not fail a file whose real lane clears the floor (#16043)",
+    () => {
+      const src = "packages/core/src/features/documents/service.ts";
+      // Its own focused lane covers it well (8/10 = 80%); another package's lane
+      // merely imports it (1/50 = 2%). Pre-fix, the 2% record alone failed the gate.
+      const ownLane = writeLcovAs(dir, "core.lcov", src, 10, 8);
+      const importLane = writeLcovAs(dir, "meetings.lcov", src, 50, 1);
+      const result = runGate({ changed: src, lcov: [ownLane, importLane] });
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stdout, /coverage gate OK/);
+      // Counted once, at the best lane's percentage — not the 2% record.
+      assert.match(result.stdout, /changed files: 1,/);
+      assert.match(
+        result.stdout,
+        /80\.00% packages\/core\/src\/features\/documents\/service\.ts/,
+      );
+    },
+  );
+
+  assertGate(
+    "still fails a file that is genuinely below the floor in every lane (#16043)",
+    () => {
+      const src = "packages/core/src/features/documents/service.ts";
+      // Both lanes under 50% (19.90% and 2%). The aggregated best is still below,
+      // so the gate must fail — aggregation must not blanket-pass shared files.
+      const laneA = writeLcovAs(dir, "a.lcov", src, 1000, 199);
+      const laneB = writeLcovAs(dir, "b.lcov", src, 50, 1);
+      const result = runGate({ changed: src, lcov: [laneA, laneB] });
+      assert.equal(result.status, 1, result.stdout);
+      assert.match(
+        result.stdout,
+        /BELOW: packages\/core\/src\/features\/documents\/service\.ts/,
+      );
+    },
+  );
 } finally {
   rmSync(dir, { recursive: true, force: true });
 }


### PR DESCRIPTION
Fixes #16043.

## Why

`scripts/security/coverage-gate.awk` evaluated each `SF:` record independently and added a file to `below[]` whenever **any** record was under threshold. When the changed-Vitest runner emits multiple `lcov.info` files and the same source appears in more than one—its focused lane at real coverage plus another package's lane that merely imports it at ~2%—the gate failed on the incidental low record even though the file's real best-lane coverage cleared the floor. Per-record increments also double-counted the file in the reported mean.

## What

Aggregate per matched path before thresholding. The record parser retains the maximum percentage seen per file; `END` computes one count, mean contribution, and verdict per changed file.

The rebased implementation preserves current `develop`'s fail-closed behavior:

- every executable changed source must appear in LCOV;
- `LF:0` remains missing rather than healthy zero-work coverage;
- overlapping paths use the longest exact path-segment suffix;
- a file below the floor in every lane still fails.

## Testing

`node scripts/security/coverage-gate.self-test.mjs` — **9/9 passed** at `90d4484d0c47feabd18cb898722665bbb950c11b`:

- the seven current-`develop` path attribution, missing-source, longest-suffix, and `LF:0` protections;
- good focused lane (80%) plus incidental import lane (2%) → gate OK, counted once at 80%;
- below-floor in every lane (19.9% plus 2%) → gate fails with `BELOW`.

`git diff origin/develop...HEAD --check` also passes.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI/awk tooling change; no UI surface is rendered or touched.
<!-- evidence-row:after-screenshots -->
- [x] N/A - CI/awk tooling change; no UI surface is rendered or touched.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; the real awk executable is exercised by its deterministic self-test.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend runtime or deployed service is touched; exact-head execution of `node scripts/security/coverage-gate.self-test.mjs` passed all 9 real awk cases.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or API surface in this change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB/schema/on-chain/generated runtime artifact; this changes a build-time coverage gate only.

[stan-cloud] [shaw-agent goal lane repair]