### PR TITLE
fix(plugin-openrouter): read cache-write tokens from inputTokenDetails

### DIFF
--- a/plugins/plugin-openrouter/__tests__/cache-write-usage.shape.test.ts
+++ b/plugins/plugin-openrouter/__tests__/cache-write-usage.shape.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Regression coverage for the cache-write token drop: `ai@^6` reports cache-write
+ * counts at `usage.inputTokenDetails.cacheWriteTokens`, not the `cacheCreationInputTokens`
+ * top-level field both `emitModelUsageEvent` and `buildNativeTextResult` used to read (which
+ * the SDK never populates). AI SDK and provider are mocked with a realistic `LanguageModelUsage`
+ * shape — no network calls, deterministic fixtures.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { extractCacheTokens } from "../utils/events";
+
+function createRuntime(settings: Record<string, string> = {}) {
+  const emitEvent = vi.fn(async () => undefined);
+  return {
+    runtime: {
+      character: { system: "system prompt" },
+      emitEvent,
+      getSetting: vi.fn((key: string) => {
+        return ({
+          OPENROUTER_API_KEY: "test-key",
+          OPENROUTER_LARGE_MODEL: "anthropic/claude-opus-4-8",
+          ...settings,
+        } as Record<string, string>)[key] ?? null;
+      }),
+    } as IAgentRuntime,
+    emitEvent,
+  };
+}
+
+// Shape actually produced by `ai@^6`'s `generateText`/`streamText` result for
+// a provider that reports cache reuse — see `node_modules/ai/dist/index.js`
+// `convertV3UsageToV4`/`convertUsage` and `index.d.ts:275-290`.
+const realSdkUsage = {
+  inputTokens: 9592,
+  outputTokens: 219,
+  totalTokens: 9811,
+  cachedInputTokens: 0, // deprecated read-only alias — never carries write counts
+  inputTokenDetails: {
+    noCacheTokens: 727,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 8865,
+  },
+};
+
+afterEach(() => {
+  vi.doUnmock("ai");
+  vi.doUnmock("../providers");
+  vi.clearAllMocks();
+  vi.resetModules();
+});
+
+describe("extractCacheTokens", () => {
+  it("reads cache-write tokens from inputTokenDetails.cacheWriteTokens (ai@^6 real shape)", () => {
+    const { cacheRead, cacheCreation } = extractCacheTokens(realSdkUsage);
+    expect(cacheCreation).toBe(8865);
+    expect(cacheRead).toBe(0);
+  });
+
+  it("prefers the explicit cacheReadInputTokens field over inputTokenDetails when a caller sets it directly", () => {
+    const { cacheRead } = extractCacheTokens({
+      cacheReadInputTokens: 999,
+      inputTokenDetails: { cacheReadTokens: 8865, cacheWriteTokens: 0 },
+    });
+    expect(cacheRead).toBe(999);
+  });
+
+  it("falls back to the legacy cacheCreationInputTokens field for callers that set it directly", () => {
+    const { cacheCreation } = extractCacheTokens({ cacheCreationInputTokens: 1234 });
+    expect(cacheCreation).toBe(1234);
+  });
+
+  it("returns undefined for both when no cache fields are present anywhere", () => {
+    const { cacheRead, cacheCreation } = extractCacheTokens({
+      inputTokens: 10,
+      outputTokens: 2,
+      totalTokens: 12,
+    });
+    expect(cacheRead).toBeUndefined();
+    expect(cacheCreation).toBeUndefined();
+  });
+});
+
+describe("emitModelUsageEvent — cache-write tokens on the real ai@^6 usage shape", () => {
+  it("includes cacheCreationInputTokens in the MODEL_USED payload and the returned NormalizedModelUsage", async () => {
+    const { emitModelUsageEvent } = await import("../utils/events");
+    const { runtime, emitEvent } = createRuntime();
+
+    const result = emitModelUsageEvent(
+      runtime,
+      "RESPONSE_HANDLER" as never,
+      "prompt",
+      realSdkUsage,
+      "anthropic/claude-opus-4-8",
+      "RESPONSE_HANDLER",
+    );
+
+    expect(result.cacheCreationInputTokens).toBe(8865);
+    expect(emitEvent).toHaveBeenCalledTimes(1);
+    const payload = emitEvent.mock.calls[0][1] as { tokens?: Record<string, unknown> };
+    expect(payload.tokens?.cacheCreationInputTokens).toBe(8865);
+  });
+});
+
+describe("buildNativeTextResult (via handleTextLarge) — cache-write tokens on the real ai@^6 usage shape", () => {
+  it("carries cacheCreationInputTokens through to the native result's usage field", async () => {
+    const generateText = vi.fn(async () => ({
+      text: "ok",
+      finishReason: "stop",
+      usage: realSdkUsage,
+    }));
+    vi.doMock("ai", () => ({ generateText, streamText: vi.fn() }));
+    vi.doMock("../providers", () => ({
+      createOpenRouterProvider: () => ({ chat: (m: string) => ({ modelName: m }) }),
+    }));
+
+    const { handleTextLarge } = await import("../models/text");
+    const { runtime } = createRuntime();
+
+    const result = (await handleTextLarge(runtime, {
+      prompt: "hello",
+      messages: [{ role: "user", content: "hello" }],
+      tools: {},
+    } as never)) as unknown as { usage?: { cacheCreationInputTokens?: number } };
+
+    expect(result.usage?.cacheCreationInputTokens).toBe(8865);
+  });
+});

--- a/plugins/plugin-openrouter/models/text.ts
+++ b/plugins/plugin-openrouter/models/text.ts
@@ -59,7 +59,7 @@ import {
   getResponseHandlerModel,
   getSmallModel,
 } from "../utils/config";
-import { emitModelUsageEvent } from "../utils/events";
+import { emitModelUsageEvent, extractCacheTokens } from "../utils/events";
 
 const RESPONSES_ROUTED_PREFIXES = ["openai/", "anthropic/"] as const;
 const NO_SAMPLING_MODEL_PATTERNS = ["o1", "o3", "o4", "gpt-5", "gpt-5-mini"] as const;
@@ -807,6 +807,10 @@ function buildNativeTextResult(result: {
     cachedInputTokens?: number;
     cacheReadInputTokens?: number;
     cacheCreationInputTokens?: number;
+    // Real location of cache-write counts on `ai@^6` results — see
+    // `extractCacheTokens` in utils/events.ts for why the fields above alone
+    // under-report.
+    inputTokenDetails?: { cacheReadTokens?: number; cacheWriteTokens?: number };
   };
 }): NativeGenerateTextResult {
   const inputTokens = result.usage?.inputTokens ?? result.usage?.promptTokens ?? 0;
@@ -820,8 +824,7 @@ function buildNativeTextResult(result: {
     };
   }
 
-  const cacheRead = result.usage.cacheReadInputTokens ?? result.usage.cachedInputTokens;
-  const cacheCreation = result.usage.cacheCreationInputTokens;
+  const { cacheRead, cacheCreation } = extractCacheTokens(result.usage);
 
   const usage: NormalizedUsage = {
     promptTokens: inputTokens,

--- a/plugins/plugin-openrouter/utils/events.ts
+++ b/plugins/plugin-openrouter/utils/events.ts
@@ -14,14 +14,23 @@ interface AIUsage {
   promptTokens?: number;
   completionTokens?: number;
   totalTokens?: number;
-  // Cache fields: only present on the streamed-usage object the AI SDK
-  // resolves after a stream finishes (`streamResult.usage`) for providers
-  // that report cache reuse (e.g. Anthropic cache_control). The non-streaming
-  // path already carried these through `buildNativeTextResult` in
-  // models/text.ts — this interface/emitter was the streaming path's gap.
+  // Legacy/direct-set cache fields: some non-AI-SDK callers (or older SDK
+  // versions) set these directly. Real `ai@^6` results never populate
+  // `cacheCreationInputTokens` — see `inputTokenDetails` below.
   cacheReadInputTokens?: number;
   cachedInputTokens?: number;
   cacheCreationInputTokens?: number;
+  // The AI SDK's actual home for cache token counts (`ai@^6`
+  // `LanguageModelUsage.inputTokenDetails`, `node_modules/ai/dist/index.js`
+  // `convertUsage`). `cacheReadTokens` duplicates the deprecated top-level
+  // `cachedInputTokens`; `cacheWriteTokens` has no top-level alias at all —
+  // reading only `cacheCreationInputTokens` (which the SDK never sets)
+  // silently dropped every cache-write count reported by Anthropic-family
+  // models routed through OpenRouter.
+  inputTokenDetails?: {
+    cacheReadTokens?: number;
+    cacheWriteTokens?: number;
+  };
 }
 
 export type NormalizedModelUsage = {
@@ -31,6 +40,21 @@ export type NormalizedModelUsage = {
   cacheReadInputTokens?: number;
   cacheCreationInputTokens?: number;
 };
+
+/**
+ * Reads cache read/write token counts off an AI SDK usage object, preferring
+ * the SDK's real `inputTokenDetails` location and falling back to the
+ * legacy/direct fields for callers that set them explicitly.
+ */
+export function extractCacheTokens(usage: AIUsage): {
+  cacheRead?: number;
+  cacheCreation?: number;
+} {
+  const cacheRead =
+    usage.cacheReadInputTokens ?? usage.cachedInputTokens ?? usage.inputTokenDetails?.cacheReadTokens;
+  const cacheCreation = usage.cacheCreationInputTokens ?? usage.inputTokenDetails?.cacheWriteTokens;
+  return { cacheRead, cacheCreation };
+}
 
 export function emitModelUsageEvent(
   runtime: IAgentRuntime,
@@ -44,8 +68,7 @@ export function emitModelUsageEvent(
   const outputTokens = usage.outputTokens ?? usage.completionTokens ?? 0;
   const totalTokens = usage.totalTokens ?? inputTokens + outputTokens;
   const model = modelName?.trim() || modelLabel?.trim() || String(modelType);
-  const cacheRead = usage.cacheReadInputTokens ?? usage.cachedInputTokens;
-  const cacheCreation = usage.cacheCreationInputTokens;
+  const { cacheRead, cacheCreation } = extractCacheTokens(usage);
 
   runtime.emitEvent(EventType.MODEL_USED, {
     runtime,


### PR DESCRIPTION
## Summary

`emitModelUsageEvent` and `buildNativeTextResult` both read cache-write token counts off `usage.cacheCreationInputTokens` — a field `ai@^6` never populates. Every Anthropic-family cache write routed through OpenRouter has been silently reporting `0`, even when the provider genuinely wrote to cache and billed for it.

## Root cause

`ai@^6`'s `LanguageModelUsage` type carries cache counts at `usage.inputTokenDetails` (`cacheReadTokens` / `cacheWriteTokens`), not as flat top-level fields:

```ts
// node_modules/ai/dist/index.d.ts:275-290
inputTokenDetails: {
  noCacheTokens: number | undefined;
  cacheReadTokens: number | undefined;
  cacheWriteTokens: number | undefined;
};
```

`cachedInputTokens` exists as a deprecated top-level alias for the *read* count only (`index.d.ts:317`, `"@deprecated Use inputTokenDetails.cacheReadTokens instead."`). There is no equivalent alias for the *write* count — `cacheCreationInputTokens` isn't a real field on this type at all. Both consumers in this plugin were reading it anyway:

- `utils/events.ts` — `emitModelUsageEvent`'s `AIUsage` interface declared `cacheCreationInputTokens?: number`, always `undefined` at runtime.
- `models/text.ts` — `buildNativeTextResult` had the identical bug for the non-streaming result path.

Net effect: the `MODEL_USED` event, and anything reading the native-result `.usage` field, always saw `cacheCreationInputTokens: 0`, regardless of what the provider actually reported.

## Fix

Added `extractCacheTokens()` in `utils/events.ts` — a single shared helper that reads `inputTokenDetails.cacheWriteTokens`/`cacheReadTokens` first, falling back to the legacy top-level fields for any caller that sets them directly. Both `emitModelUsageEvent` and `buildNativeTextResult` now route through it instead of duplicating (buggy) extraction logic.

## Evidence

**Unit tests** (`__tests__/cache-write-usage.shape.test.ts`, 6 new tests, all passing): exercise `extractCacheTokens` and both consumers against a realistic `ai@^6` usage fixture (`inputTokenDetails.cacheWriteTokens: 8865`), asserting the previously-dropped value now surfaces correctly. Full plugin suite: 57/57 passing (51 existing + 6 new).

**Live end-to-end proof**, real Anthropic-via-OpenRouter call, before/after:

Before (this plugin's current `develop`):
```
[MODEL_USED] type=RESPONSE_HANDLER tokens={"prompt":9612,"completion":222,"total":9834,"cacheReadInputTokens":8865,"cacheCreationInputTokens":0}
```
(a real cold write of 8,874 tokens happened on the wire — OpenRouter's raw response showed `cache_write_tokens: 8874` — but the event reported `0`.)

After (this branch):
```
[MODEL_USED] type=RESPONSE_HANDLER tokens={"prompt":9621,"completion":220,"total":9841,"cacheReadInputTokens":0,"cacheCreationInputTokens":8874}
```
Next tick reads it back correctly:
```
[MODEL_USED] type=RESPONSE_HANDLER tokens={"prompt":9663,"completion":219,"total":9882,"cacheReadInputTokens":8874,"cacheCreationInputTokens":0}
```

Reproduction: a runtime with `plugin-sql` + `plugin-openrouter` + `plugin-openai`, a throwaway `cacheStable: true` `Provider` carrying a >1024-token static block, and a run-unique `character.system` prefix (to guarantee a cold cache entry rather than reading back a previous run's warm write within the ~5min TTL). Two `messageService.handleMessage` calls ~15s apart, listening on `EventType.MODEL_USED`.

## Test plan

- [x] `bun run --cwd plugins/plugin-openrouter typecheck`
- [x] `bun run --cwd plugins/plugin-openrouter test:unit` — 57/57 passing
- [x] Live call against real `anthropic/claude-sonnet-4.5` via OpenRouter, cold + warm tick, `MODEL_USED` payload inspected directly (see Evidence above)

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots: N/A - provider accounting fix, no UI changed
<!-- /evidence-row:before-screenshots -->

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots: N/A - provider accounting fix, no UI changed
<!-- /evidence-row:after-screenshots -->

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: N/A - provider accounting fix; live proof in Summary section above
<!-- /evidence-row:walkthrough-video -->

<!-- evidence-row:backend-logs -->
- [x] Backend logs: Live MODEL_USED event payloads captured (real Anthropic-via-OpenRouter calls, cache-write token counts before/after fix shown in Summary)
<!-- /evidence-row:backend-logs -->

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: N/A - backend provider fix only
<!-- /evidence-row:frontend-logs -->

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: Anthropic-via-OpenRouter calls shown in Summary's before/after MODEL_USED payloads; full proof captured via spike-cache-mechanism-proof.ts with wire-level inspection
<!-- /evidence-row:llm-trajectory -->

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: Unit test suite 57/57 passing (51 existing + 6 new regression tests for cache-write token extraction)
<!-- /evidence-row:domain-artifacts -->
