### PR TITLE
fix(build): include non-src/ source in the turbo `build` cache key (#16058)

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -28,6 +28,13 @@
       "outputs": ["dist/**"],
       "inputs": [
         "src/**",
+        "**/*.ts",
+        "**/*.tsx",
+        "!**/*.test.ts",
+        "!**/*.test.tsx",
+        "!**/*.spec.ts",
+        "!**/*.spec.tsx",
+        "!**/__tests__/**",
         "index.ts",
         "index.node.ts",
         "index.browser.ts",


### PR DESCRIPTION
Fixes #16058.

## Why

The root `turbo.json` generic `build` task declared `inputs: ["src/**", …]`, but ~18 plugins have **no `src/` directory** — their source lives under `models/`, `providers/`, `utils/`, `types/`, `actions/`, `services/`, `managers/`, `client/`, `routes/`, … plus root files like `plugin.ts` / `init.ts`. None of those were part of Turbo's cache key, so `turbo run build --filter <plugin>` could replay a **stale `dist/`** on a reported "cache hit" even when the source genuinely changed — a silent wrong-output bug that reads as "the fix didn't build".

## What

Add `**/*.ts` + `**/*.tsx` to the generic `build` task's `inputs` so source is captured regardless of directory layout, and exclude test/spec files (`!**/*.test.ts`, `!**/*.spec.ts`, `!**/__tests__/**`, …) so the existing intent — **tests do not bust the build cache** — is preserved. Turbo already drops `.gitignore`'d paths and the task `outputs` (`dist/**`) from inputs, so `dist/`/`node_modules/` are not hashed.

The package-specific `@elizaos/{core,app,prompts}#build` overrides are **untouched** — those packages have a real `src/`, so their narrower inputs are correct.

## Testing / evidence

`turbo run build --filter @elizaos/plugin-openrouter --dry=json` (a plugin with no `src/`):

```
before (develop):  9 inputs — models/=0, providers/=0   ← source invisible to the cache key
after  (this PR):  28 inputs — 12 files across models//providers//utils//types/,
                    test/spec/__tests__ files = 0        ← source hashed, tests still excluded
```

So an edit under `models/` (etc.) now correctly produces a cache **miss** and a rebuild, while a test edit still does not.

# Evidence Gate

Build/CI config change (`turbo.json`) — no rendered UI, no agent/model path, no runtime code. Proven by the Turbo dry-run input diff above.

<!-- evidence-row:before-screenshots -->
- [x] N/A - build-config change; no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - build-config change; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - build-config change; no runtime/backend path executes. The real cache-key change is proven by the `turbo --dry=json` input diff in the Testing section above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or API surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB/schema/on-chain/generated-file change; a build-cache-key config only.

## Known gaps / failures

Non-`.ts` source outside `src/` (e.g. a bundled `.json`/`.wasm` under a non-`src/` dir) is still not individually hashed — out of scope for this TS-source fix; flagged for a follow-up if any plugin relies on it. Visual/LLM rows are `N/A` (a build-config change has none).

[stan-cloud]