### PR TITLE
fix(voice): remove transcripts and provider payloads from STT/TTS logs

### DIFF
--- a/packages/cloud/api/v1/voice/stt/route.test.ts
+++ b/packages/cloud/api/v1/voice/stt/route.test.ts
@@ -38,6 +38,11 @@ const billFlatUsage = mock(async () => ({
 mock.module("@/lib/services/ai-billing", () => ({ billFlatUsage }));
 mock.module("@/lib/services/ai-pricing", () => ({
   calculateSTTCostFromCatalog: mock(async () => ({ totalCost: 0 })),
+  calculateTTSCostFromCatalog: mock(async () => ({
+    totalCost: 0,
+    baseTotalCost: 0,
+    platformMarkup: 0,
+  })),
 }));
 class MockInsufficientCreditsError extends Error {
   required: number;
@@ -56,16 +61,63 @@ const speechToText = mock(
   async (_args: { audioFile: File; languageCode?: string }) =>
     "elevenlabs transcript",
 );
+const textToSpeech = mock(
+  async (_args: { text: string; voiceId?: string; modelId?: string }) =>
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([73, 68, 51]));
+        controller.close();
+      },
+    }),
+);
 mock.module("@/lib/services/elevenlabs", () => ({
-  getElevenLabsService: mock(() => ({ speechToText })),
+  getElevenLabsService: mock(() => ({ speechToText, textToSpeech })),
 }));
 const usageCreate = mock(async (_record: Record<string, unknown>) => ({}));
 mock.module("@/lib/services/usage", () => ({
   usageService: { create: usageCreate },
 }));
+// Minimal TTS route seams let this same changed test file cover both changed
+// source files without cross-file Bun mock collisions in the coverage lane.
+mock.module("@/db/repositories/user-voices", () => ({
+  userVoicesRepository: {
+    findByElevenLabsVoiceId: async () => null,
+    incrementUsageCount: async () => undefined,
+  },
+}));
+mock.module("@/lib/services/content-safety", () => ({
+  contentSafetyService: { assertSafeForPublicUse: async () => undefined },
+}));
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  ApiError: class ApiError extends Error {
+    status = 500;
+    toJSON() {
+      return { error: this.message };
+    }
+  },
+}));
+mock.module("@/lib/services/pcm16-wav", () => ({
+  drainPcm16Stream: async () => new Uint8Array(),
+  pcm16ToWav: () => new Uint8Array(),
+}));
+mock.module("@/lib/services/tts-first-line-cache", () => ({
+  fingerprintCloudVoiceSettings: () => "fp-test",
+  getCloudFirstLineCacheService: () => ({
+    get: async () => null,
+    has: async () => true,
+    put: async () => true,
+  }),
+  shouldBypassCloudFirstLineCache: () => true,
+}));
+mock.module("@/lib/pricing-constants", () => ({
+  CUSTOM_VOICE_TTS_MARKUP: 1.2,
+}));
 
 const sttRoute = (await import("./route")).default;
-const app = new Hono().route("/api/v1/voice/stt", sttRoute);
+const ttsRoute = (await import("../tts/route")).default;
+const app = new Hono()
+  .route("/api/v1/voice/stt", sttRoute)
+  .route("/api/v1/voice/tts", ttsRoute);
 
 /** A real RIFF/WAVE mono PCM16 file so the route's magic-number check passes. */
 function synthWav(durationS = 0.25, rate = 8000): Uint8Array {
@@ -188,6 +240,11 @@ const upstream = Bun.serve({
       }
       return upstreamReply();
     }
+    if (req.method === "POST" && url.pathname === "/api/tts") {
+      return new Response(new Uint8Array([82, 73, 70, 70]), {
+        headers: { "content-type": "audio/wav" },
+      });
+    }
     return new Response("not found", { status: 404 });
   },
 });
@@ -247,6 +304,16 @@ beforeEach(() => {
   reconcile.mockClear();
   speechToText.mockReset();
   speechToText.mockResolvedValue("elevenlabs transcript");
+  textToSpeech.mockReset();
+  textToSpeech.mockImplementation(
+    async () =>
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array([73, 68, 51]));
+          controller.close();
+        },
+      }),
+  );
   upstreamReply = () => Response.json({ text: "" });
 });
 
@@ -618,6 +685,71 @@ describe("POST /api/v1/voice/stt — billed ElevenLabs lane", () => {
       error: "Failed to transcribe audio. Please try again.",
     });
     expect(reconcile).toHaveBeenCalledWith(0);
+  });
+});
+
+describe("POST /api/v1/voice/tts — log redaction", () => {
+  test("keeps the paid ElevenLabs response contract", async () => {
+    const res = await app.request(
+      new Request("http://localhost/api/v1/voice/tts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ text: "A normal synthesized response." }),
+      }),
+      undefined,
+      {} as never,
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("audio/mpeg");
+    expect(await res.arrayBuffer()).toEqual(
+      new Uint8Array([73, 68, 51]).buffer,
+    );
+    expect(textToSpeech).toHaveBeenCalledTimes(1);
+    await Bun.sleep(0);
+    expect(usageCreate).toHaveBeenCalledTimes(1);
+  });
+
+  test("keeps the free Kokoro response contract", async () => {
+    const res = await app.request(
+      new Request("http://localhost/api/v1/voice/tts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          text: "A normal synthesized response.",
+          voiceId: "EXAVITQu4vr4xnSDxMaL",
+        }),
+      }),
+      undefined,
+      { KOKORO_TTS_URL: `http://localhost:${upstream.port}` } as never,
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("audio/wav");
+    expect(res.headers.get("x-eliza-tts-provider")).toBe("kokoro");
+    expect(textToSpeech).not.toHaveBeenCalled();
+  });
+
+  test("logs only the error type when synthesis errors contain private text", async () => {
+    textToSpeech.mockRejectedValueOnce(
+      new Error('provider payload echoed: "private medical transcript"'),
+    );
+
+    const res = await app.request(
+      new Request("http://localhost/api/v1/voice/tts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ text: "private medical transcript" }),
+      }),
+      undefined,
+      {} as never,
+    );
+
+    expect(res.status).toBe(500);
+    const logs = allLoggedContent();
+    expect(logs).not.toContain("private medical transcript");
+    expect(logs).not.toContain("provider payload echoed");
+    expect(logs).toContain('"errorType":"Error"');
   });
 });
 

--- a/packages/cloud/api/v1/voice/stt/route.test.ts
+++ b/packages/cloud/api/v1/voice/stt/route.test.ts
@@ -17,6 +17,15 @@ const requireAuthOrApiKeyWithOrg = mock<() => Promise<unknown>>();
 mock.module("@/lib/auth", () => ({
   requireAuthOrApiKeyWithOrg,
 }));
+// The logger is captured (not silenced) so tests can assert on what reaches
+// log output: transcripts, upload filenames, and provider response bodies
+// must never appear there (SEC log hygiene).
+const logError = mock(() => {});
+const logInfo = mock(() => {});
+const logWarn = mock(() => {});
+mock.module("@/lib/utils/logger", () => ({
+  logger: { error: logError, info: logInfo, warn: logWarn },
+}));
 // Billing and provider modules are mocked so importing the route does not
 // initialize DB-backed services in a unit-test process; their behavior is
 // mutable per test so both lanes (free whisper, billed ElevenLabs) and the
@@ -50,8 +59,9 @@ const speechToText = mock(
 mock.module("@/lib/services/elevenlabs", () => ({
   getElevenLabsService: mock(() => ({ speechToText })),
 }));
+const usageCreate = mock(async (_record: Record<string, unknown>) => ({}));
 mock.module("@/lib/services/usage", () => ({
-  usageService: { create: mock(async () => ({})) },
+  usageService: { create: usageCreate },
 }));
 
 const sttRoute = (await import("./route")).default;
@@ -212,7 +222,20 @@ const LIVE_SHAPE = {
   ],
 };
 
+/** Every string that reached any logger method in this test, joined. */
+function allLoggedContent(): string {
+  return JSON.stringify([
+    ...logError.mock.calls,
+    ...logInfo.mock.calls,
+    ...logWarn.mock.calls,
+  ]);
+}
+
 beforeEach(() => {
+  logError.mockClear();
+  logInfo.mockClear();
+  logWarn.mockClear();
+  usageCreate.mockClear();
   requireAuthOrApiKeyWithOrg.mockReset();
   requireAuthOrApiKeyWithOrg.mockResolvedValue({
     user: { id: "user-1", organization_id: "org-1" },
@@ -413,12 +436,53 @@ describe("POST /api/v1/voice/stt — whisper lane (#14806)", () => {
     expect(await readJson(res)).toEqual({ error: "Speech-to-text failed" });
   });
 
-  test("an upstream 5xx stays a structured 502", async () => {
-    upstreamReply = () => new Response("boom", { status: 500 });
+  test("an upstream 5xx stays a structured 502 without logging its body", async () => {
+    upstreamReply = () =>
+      new Response("secret transcript and provider token", { status: 500 });
     const res = await app.request(sttRequest(), undefined, whisperEnv);
 
     expect(res.status).toBe(502);
     expect(await readJson(res)).toEqual({ error: "Speech-to-text failed" });
+    // The provider error body must not reach logs — only the status code.
+    const logs = allLoggedContent();
+    expect(logs).not.toContain("secret transcript");
+    expect(logs).not.toContain("provider token");
+    expect(logs).toContain('"status":500');
+  });
+
+  test("a successful whisper transcription never logs the transcript or filename", async () => {
+    upstreamReply = () => Response.json(LIVE_SHAPE);
+    const res = await app.request(
+      sttRequest(wavFile("user-recording-2026.wav")),
+      undefined,
+      whisperEnv,
+    );
+
+    expect(res.status).toBe(200);
+    const logs = allLoggedContent();
+    expect(logs).not.toContain("Hello there world");
+    expect(logs).not.toContain("user-recording-2026.wav");
+    // Redaction keeps observability: length metadata still lands in logs.
+    expect(logs).toContain("transcriptLength");
+  });
+
+  test("rejected uploads log size and mime metadata, not the filename", async () => {
+    const res = await app.request(
+      sttRequest(
+        bytesFile(
+          new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]),
+          "private-meeting-notes.wav",
+          "audio/wav",
+        ),
+      ),
+      undefined,
+      whisperEnv,
+    );
+
+    expect(res.status).toBe(400);
+    const logs = allLoggedContent();
+    expect(logs).not.toContain("private-meeting-notes.wav");
+    expect(logs).toContain("audioSizeBytes");
   });
 });
 
@@ -443,6 +507,27 @@ describe("POST /api/v1/voice/stt — billed ElevenLabs lane", () => {
     const call = speechToText.mock.calls[0][0];
     expect(call.audioFile.name).toBe("probe.wav");
     expect(call.languageCode).toBe("fr");
+
+    // Log hygiene: the transcript and upload filename reach the provider and
+    // the response, but never the logs.
+    const logs = allLoggedContent();
+    expect(logs).not.toContain("elevenlabs transcript");
+    expect(logs).not.toContain("probe.wav");
+    expect(logs).toContain("transcriptLength");
+
+    // Usage-record hygiene: metadata drops the raw filename (can carry PII)
+    // but keeps size/duration/length metrics and the languageCode enum.
+    await Bun.sleep(0); // usage record write is fire-and-forget
+    expect(usageCreate).toHaveBeenCalledTimes(1);
+    const usageRecord = usageCreate.mock.calls[0][0] as {
+      metadata: Record<string, unknown>;
+    };
+    expect(usageRecord.metadata.audioFileName).toBeUndefined();
+    expect(usageRecord.metadata.languageCode).toBe("fr");
+    expect(usageRecord.metadata.audioSizeBytes).toBeGreaterThan(0);
+    expect(usageRecord.metadata.transcriptLength).toBe(
+      "elevenlabs transcript".length,
+    );
   });
 
   test("insufficient credits is a 402 carrying the required amount", async () => {
@@ -466,6 +551,24 @@ describe("POST /api/v1/voice/stt — billed ElevenLabs lane", () => {
       error: "Rate limit exceeded. Please try again in a moment.",
     });
     expect(reconcile).toHaveBeenCalledWith(0);
+  });
+
+  test("a provider error embedding request content is logged as its type only", async () => {
+    // Provider SDK errors can carry the request/response payload in their
+    // message. The route's catch must log only the error type, never the
+    // message or the error object itself.
+    speechToText.mockRejectedValue(
+      new Error(
+        'transcription failed for utterance: "my social security number is"',
+      ),
+    );
+    const res = await app.request(sttRequest(), undefined, elevenLabsEnv);
+
+    expect(res.status).toBe(500);
+    const logs = allLoggedContent();
+    expect(logs).not.toContain("social security");
+    expect(logs).not.toContain("utterance");
+    expect(logs).toContain('"errorType":"Error"');
   });
 
   test("a quota failure naming a paid tier is a 402 upgrade prompt", async () => {

--- a/packages/cloud/api/v1/voice/stt/route.ts
+++ b/packages/cloud/api/v1/voice/stt/route.ts
@@ -148,9 +148,9 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
     const fileTypeResult = await fileTypeFromBuffer(buffer);
 
     if (!fileTypeResult) {
-      logger.warn(
-        `[Voice STT API] Unable to detect file type for ${audioFile.name} - rejecting`,
-      );
+      logger.warn("[Voice STT API] Unable to detect audio file type", {
+        audioSizeBytes: audioFile.size,
+      });
       return Response.json(
         {
           error:
@@ -161,9 +161,10 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
     }
 
     if (!ALLOWED_AUDIO_SIGNATURES.has(fileTypeResult.mime)) {
-      logger.warn(
-        `[Voice STT API] File signature mismatch for ${audioFile.name}: claimed=${baseMimeType}, actual=${fileTypeResult.mime}`,
-      );
+      logger.warn("[Voice STT API] Audio file signature mismatch", {
+        actualMimeType: fileTypeResult.mime,
+        claimedMimeType: baseMimeType,
+      });
       return Response.json(
         {
           error: `File content does not match the declared format. Detected: ${fileTypeResult.mime}, Expected audio format.`,
@@ -180,9 +181,12 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
       finalMimeType = "audio/webm";
     }
 
-    logger.info(
-      `[Voice STT API] Processing for user ${user.id}: ${audioFile.name} (${audioFile.size} bytes, verified: ${fileTypeResult.mime}, final: ${finalMimeType})`,
-    );
+    logger.info("[Voice STT API] Processing verified audio", {
+      audioSizeBytes: audioFile.size,
+      finalMimeType,
+      userId: user.id,
+      verifiedMimeType: fileTypeResult.mime,
+    });
 
     // -------------------------------------------------------------------------
     // Free default STT: self-hosted Whisper (OpenAI-compatible
@@ -213,10 +217,10 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
         { method: "POST", body: form },
       );
       if (!whisperResponse.ok) {
-        const detail = await whisperResponse.text().catch(() => "");
-        logger.error(
-          `[Voice STT API] Whisper failed (${whisperResponse.status}): ${detail.slice(0, 200)}`,
-        );
+        await whisperResponse.body?.cancel().catch(() => undefined);
+        logger.error("[Voice STT API] Whisper request failed", {
+          status: whisperResponse.status,
+        });
         return Response.json(
           { error: "Speech-to-text failed" },
           { status: 502 },
@@ -228,10 +232,8 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
       let whisperPayload: unknown;
       try {
         whisperPayload = await whisperResponse.json();
-      } catch (parseError) {
-        logger.error(
-          `[Voice STT API] Whisper returned unparseable JSON: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
-        );
+      } catch {
+        logger.error("[Voice STT API] Whisper returned unparseable JSON");
         return Response.json(
           { error: "Speech-to-text failed" },
           { status: 502 },
@@ -346,9 +348,10 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
       reservation,
     );
 
-    logger.info(
-      `[Voice STT API] Completed in ${duration}ms: "${transcript.substring(0, 100)}..."`,
-    );
+    logger.info("[Voice STT API] Completed", {
+      durationMs: duration,
+      transcriptLength: transcript.length,
+    });
 
     (async () => {
       try {
@@ -367,7 +370,9 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
           duration_ms: duration,
           is_successful: true,
           metadata: {
-            audioFileName: audioFile.name,
+            // audioFileName removed: user-supplied filenames can carry PII
+            // (e.g. "john-therapy-session.wav"). languageCode is a BCP-47 enum,
+            // not sensitive content, so it stays.
             audioSizeBytes: audioFile.size,
             estimatedDurationMinutes,
             durationSeconds,
@@ -379,7 +384,7 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
         });
       } catch (error) {
         logger.error("[Voice STT API] Failed to create usage record", {
-          error: error instanceof Error ? error.message : String(error),
+          errorType: error instanceof Error ? error.name : "unknown",
         });
       }
     })();
@@ -389,7 +394,11 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
       duration_ms: duration,
     });
   } catch (error) {
-    logger.error("[Voice STT API] Error:", error);
+    // Redaction boundary: provider SDK errors can embed request/response
+    // bodies (transcripts, tokens) in their message — log only the error type.
+    logger.error("[Voice STT API] Request failed", {
+      errorType: error instanceof Error ? error.name : "unknown",
+    });
 
     if (reservation) {
       await reservation.reconcile(0);

--- a/packages/cloud/api/v1/voice/tts/route.ts
+++ b/packages/cloud/api/v1/voice/tts/route.ts
@@ -267,7 +267,10 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
           // error-policy:J4 cache lookup failure degrades to fresh synthesis;
           // the upstream Railway request below is the source of truth.
           logger.warn?.(
-            `[Voice TTS API] Kokoro first-line cache lookup failed: ${err instanceof Error ? err.message : String(err)}`,
+            "[Voice TTS API] Kokoro first-line cache lookup failed",
+            {
+              errorType: err instanceof Error ? err.name : "unknown",
+            },
           );
         }
       }
@@ -323,7 +326,10 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
             // error-policy:J7 populate is a background write; a failure must not
             // affect the response the user already receives below.
             logger.warn?.(
-              `[Voice TTS API] Kokoro first-line cache populate failed: ${err instanceof Error ? err.message : String(err)}`,
+              "[Voice TTS API] Kokoro first-line cache populate failed",
+              {
+                errorType: err instanceof Error ? err.name : "unknown",
+              },
             );
           });
 
@@ -363,8 +369,7 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
         userVoicesRepository.incrementUsageCount(voice.id).catch((err) =>
           logger.error("[Voice TTS API] Failed to increment voice usage", {
             voiceId: voice.id,
-            voiceName: voice.name,
-            error: err instanceof Error ? err.message : String(err),
+            errorType: err instanceof Error ? err.name : "unknown",
           }),
         );
 
@@ -438,9 +443,9 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
       } catch (err) {
         // error-policy:J4 cache lookup failure degrades to fresh synthesis; the
         // ElevenLabs request below remains the source of truth.
-        logger.warn?.(
-          `[Voice TTS API] first-line cache lookup failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
+        logger.warn?.("[Voice TTS API] first-line cache lookup failed", {
+          errorType: err instanceof Error ? err.name : "unknown",
+        });
       }
     }
 
@@ -557,7 +562,7 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
         });
       } catch (error) {
         logger.error("[Voice TTS API] Failed to create usage record", {
-          error: error instanceof Error ? error.message : String(error),
+          errorType: error instanceof Error ? error.name : "unknown",
           userVoiceId,
         });
       }
@@ -624,9 +629,9 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
             `[Voice TTS API] first-line cache POPULATE ok (${cacheScope}, ${total}B, words=${snipResult.wordCount})`,
           );
         } catch (err) {
-          logger.warn?.(
-            `[Voice TTS API] first-line cache populate failed: ${err instanceof Error ? err.message : String(err)}`,
-          );
+          logger.warn?.("[Voice TTS API] first-line cache populate failed", {
+            errorType: err instanceof Error ? err.name : "unknown",
+          });
         }
       })();
     }
@@ -654,7 +659,11 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
       },
     });
   } catch (error) {
-    logger.error("[Voice TTS API] Error:", error);
+    // Redaction boundary: provider SDK errors can embed the synthesis text or
+    // provider response bodies in their message — log only the error type.
+    logger.error("[Voice TTS API] Request failed", {
+      errorType: error instanceof Error ? error.name : "unknown",
+    });
 
     if (reservation) {
       await reservation.reconcile(0);


### PR DESCRIPTION
## What

Remove sensitive voice content from STT/TTS logs and usage metadata. **One causal boundary only:** *sensitive content must not reach logs.*

- **STT** (`v1/voice/stt/route.ts`):
  - Drop the upload **filename** from the two `warn` lines and the `info` "processing" line (filenames can carry PII, e.g. `john-therapy-session.wav`).
  - Stop logging the **transcript** in the completion line (kept `transcriptLength`).
  - On a non-2xx Whisper response, **cancel** the body and never log it (was `detail.slice(0,200)` — a raw provider payload).
  - Log the **error type** (`error.name`), not the raw `error`/`error.message`, in the request-failed catch, the usage-record catch, and the unparseable-JSON path.
  - Usage-record metadata: drop `audioFileName`. `languageCode` (a BCP-47 enum, not content) is intentionally retained.
- **TTS** (`v1/voice/tts/route.ts`):
  - Log the **error type**, not the raw provider message, across the cache lookup/populate warns, the increment-usage error (also drop the redundant `voiceName` from that error line), the usage-record catch, and the top-level request-failed catch.

## Why (closure lesson addressed)

Re-lands the **log-redaction slice** of the closed #16029, which was correctly closed as an *"unverified multi-causal security bundle."* The maintainer's binding rule: **one security boundary per PR, small and independently rollbackable.** This PR is *only* log hygiene — no metering, no Redis, no request-size limits, no provider training policy. Those re-land separately (metering into the integrated voice slice where it has a runtime consumer + can be default-on; request limits as their own PR with real-Redis/real-infra proof).

## Evidence — before/after log capture

Captured by driving the **real Hono route** end to end (provider boundary mocked at the module seam) and printing every `logger` call verbatim. Same three lanes, pristine `develop` route vs this change:

<details><summary>BEFORE (develop) — sensitive content in logs</summary>

```
=== whisper success ===
info: [Voice STT API] Processing for user user-1: patient-visit-recording.wav (4044 bytes, verified: audio/wav, final: audio/wav)
info: [Voice STT API] Whisper completed {"billing":"free","durationMs":1,"model":"...","transcriptLength":47}

=== whisper upstream 500 ===
info: [Voice STT API] Processing for user user-1: patient-visit-recording.wav (4044 bytes, ...)
error: [Voice STT API] Whisper failed (500): internal: transcript buffer contained 'secret phrase'

=== billed elevenlabs success ===
info: [Voice STT API] Processing for user user-1: patient-visit-recording.wav (4044 bytes, ...)
info: [Voice STT API] Completed in 0ms: "the user said something private here..."
usage-metadata: {"audioFileName":"patient-visit-recording.wav", ... ,"languageCode":"fr","transcriptLength":36, ...}
```
Leaks: **filename** (x3), **provider error body** ("secret phrase"), **transcript** ("the user said something private here").
</details>

<details><summary>AFTER (this PR) — content redacted, observability kept</summary>

```
=== whisper success ===
info: [Voice STT API] Processing verified audio {"audioSizeBytes":4044,"finalMimeType":"audio/wav","userId":"user-1","verifiedMimeType":"audio/wav"}
info: [Voice STT API] Whisper completed {"billing":"free","durationMs":2,"model":"...","transcriptLength":47}

=== whisper upstream 500 ===
info: [Voice STT API] Processing verified audio {"audioSizeBytes":4044, ...}
error: [Voice STT API] Whisper request failed {"status":500}

=== billed elevenlabs success ===
info: [Voice STT API] Processing verified audio {"audioSizeBytes":4044, ...}
info: [Voice STT API] Completed {"durationMs":0,"transcriptLength":36}
usage-metadata: {"audioSizeBytes":4044,"estimatedDurationMinutes":0.0166...,"durationSeconds":1,"transcriptLength":36, ... }
```
No filename, no provider error body, no transcript. Length/size/duration metrics preserved.
</details>

## Tests

Focused redaction tests added to `stt/route.test.ts` (real route, logger captured not silenced) assert transcripts, filenames, and provider error bodies **never** appear in captured logger output while length/size metrics do; plus a usage-metadata hygiene assertion (`audioFileName` undefined, `languageCode` retained, `transcriptLength` correct) and a provider-error test proving the catch logs `errorType` only, never the message.

```
POST /api/v1/voice/stt — 24 pass, 1 skip (live-Railway gated), 0 fail
  ✓ an upstream 5xx stays a structured 502 without logging its body
  ✓ a successful whisper transcription never logs the transcript or filename
  ✓ rejected uploads log size and mime metadata, not the filename
  ✓ transcribes, bills, keeps DTO — and never logs transcript/filename; metadata drops filename, keeps languageCode
  ✓ a provider error embedding request content is logged as its type only
```

- `biome check` clean on all 3 files.
- Rebased on `origin/develop` (0 behind).
- **N/A — live-provider run / audio walkthrough:** this boundary is *log content*, provable by unit tests + the before/after capture above. No provider/model/audio behavior changes (the response bytes are byte-identical; only log strings changed). The gated live-Railway STT test remains available (`ELIZA_VOICE_LIVE_RAILWAY=1`) but isn't required to prove a log-string change.

## Not in this PR (per the #16029 closure split)
- `mip_opt_out` provider training policy (SEC-11) — **verified NOT on develop**; separate PR.
- daily metering / Redis quota (SEC-15) — absorbed into the integrated voice slice (runtime consumer + default-on).
- request-size limits — own PR with real-Redis/real-infra proof.

No self-merge — requesting human review.

[sol-cloud]


## Required evidence rows

<!-- evidence-row:before-screenshots -->
- [x] **Before screenshots:** N/A - backend-only log hygiene change with no rendered UI.

<!-- evidence-row:after-screenshots -->
- [x] **After screenshots:** N/A - backend-only log hygiene change with no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [x] **Walkthrough video:** N/A - no visual or interactive flow changed.

<!-- evidence-row:backend-logs -->
- [x] **Backend logs:** [Inline before/after real-route logger capture](https://github.com/elizaOS/eliza/pull/16060) in the “Evidence — before/after log capture” section above, manually reviewed for filename, transcript, and provider-payload leakage.

<!-- evidence-row:frontend-logs -->
- [x] **Frontend console/network logs:** N/A - no frontend source or request behavior changed.

<!-- evidence-row:llm-trajectory -->
- [x] **Real-LLM trajectory:** N/A - no agent, model, prompt, provider selection, or action behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] **Domain artifacts:** N/A - this change only removes sensitive fields from backend logs; the applicable before/after log artifact is linked above.
