### PR TITLE
feat(wallet): add governed native TRADE action

### DIFF
--- a/packages/docs/action-catalog.md
+++ b/packages/docs/action-catalog.md
@@ -15,7 +15,7 @@ This catalog is generated from `packages/prompts/specs/**` by `bun run --cwd pac
 - **Plugin overlay actions:** 9
 - **Canonical providers:** 23
 - **Core providers:** 23
-- **Registered runtime actions:** 186
+- **Registered runtime actions:** 187
 
 ## Actions
 
@@ -489,6 +489,7 @@ section drifts from source.
 - `TAU_BENCH_TOOL` — `plugins/plugin-benchmarks/src/actions/tau-bench.ts`
 - `TERMINAL_SHELL` — `packages/agent/src/actions/terminal.ts`
 - `TODO` — `plugins/plugin-todos/src/actions/todo.ts`
+- `TRADE` — `plugins/plugin-wallet/src/actions/trade-action.ts`
 - `TRIGGER` — `packages/agent/src/actions/trigger.ts`
 - `TRUST` — `packages/core/src/features/trust/actions/trust.ts`
 - `TUNNEL_CREDENTIAL_TO_CHILD_SESSION` — `packages/core/src/features/sub-agent-credentials/actions/tunnel-credential-to-child-session.ts`

--- a/plugins/plugin-wallet/AGENTS.md
+++ b/plugins/plugin-wallet/AGENTS.md
@@ -19,6 +19,7 @@ Adds a unified wallet action+provider surface to an Eliza agent, replacing the p
 | `WALLET` | `pump_fun_buy` | Buy a pump.fun token on Solana via PumpPortal trade-local, local signing, browser coin-page open, and Solana RPC submission. |
 | `WALLET` | `token_info` | Read-only token/market data (DexScreener, Birdeye, CoinGecko). |
 | `WALLET` | `search_address` | Birdeye wallet/portfolio lookup by address. |
+| `TRADE` | `inspect_account`, `inspect_session`, `submit_order` | Governed Steward trading account/session inspection and confirmed order intent for Hyperliquid and Polymarket. |
 
 Similes handled: `SWAP`, `SWAP_SOLANA`, `TRANSFER`, `TRANSFER_TOKEN`, `WALLET_SWAP`, `WALLET_TRANSFER`, `CROSS_CHAIN_TRANSFER`, `PREPARE_TRANSFER`, `WALLET_ACTION`, `WALLET_GOV`, `PUMP_FUN_BUY`, `PUMPFUN_BUY`, `TOKEN_INFO`, `BIRDEYE_LOOKUP`, `BIRDEYE_SEARCH`, `WALLET_SEARCH_ADDRESS`.
 
@@ -29,6 +30,7 @@ All on-chain subactions (`transfer`, `swap`, `bridge`, `gov`, `pump_fun_buy`) re
 | Name | File | Description |
 |------|------|-------------|
 | `wallet` | `src/providers/wallet-provider.ts` | Injects EVM + Solana addresses into planner context (finance/crypto/wallet contexts, OWNER+ role gate). |
+| `stewardTrading` | `src/providers/steward-trading-provider.ts` | Injects Steward trading capability and governed Hyperliquid/Polymarket session status without secrets. |
 | `evmWalletProvider` | `src/chains/evm/providers/wallet.ts` | EVM-specific wallet context (viem `Account`). |
 | `tokenBalanceProvider` | `src/chains/evm/providers/get-balance.ts` | EVM token balances. |
 | `agentPortfolioProvider` | `src/analytics/birdeye/providers/agent-portfolio-provider.ts` | Birdeye portfolio for configured `BIRDEYE_WALLET_ADDR`. Registered when that setting is present. |
@@ -41,6 +43,7 @@ All on-chain subactions (`transfer`, `swap`, `bridge`, `gov`, `pump_fun_buy`) re
 | Name | Service type key | File | Description |
 |------|-----------------|------|-------------|
 | `WalletBackendService` | `"wallet-backend"` | `src/services/wallet-backend-service.ts` | Core signing router — resolves `WalletBackend`, registers chain handlers, dispatches `routeWalletAction`. |
+| `StewardTradingService` | `"steward-trading"` | `src/services/steward-trading-service.ts` | Governed Steward trading HTTP client for Hyperliquid/Polymarket sessions, accounts, and idempotent order submission. |
 | `EVMService` | EVM service type | `src/chains/evm/service.ts` | EVM RPC + wallet management. |
 | `SolanaService` | `SOLANA_SERVICE_NAME` | `src/chains/solana/service.ts` | Solana RPC, swap routing (Jupiter), portfolio. |
 | `SolanaWalletService` | compat alias | `src/chains/solana/service.ts` | Compatibility alias for consumers expecting the old service name. |

--- a/plugins/plugin-wallet/CLAUDE.md
+++ b/plugins/plugin-wallet/CLAUDE.md
@@ -19,6 +19,7 @@ Adds a unified wallet action+provider surface to an Eliza agent, replacing the p
 | `WALLET` | `pump_fun_buy` | Buy a pump.fun token on Solana via PumpPortal trade-local, local signing, browser coin-page open, and Solana RPC submission. |
 | `WALLET` | `token_info` | Read-only token/market data (DexScreener, Birdeye, CoinGecko). |
 | `WALLET` | `search_address` | Birdeye wallet/portfolio lookup by address. |
+| `TRADE` | `inspect_account`, `inspect_session`, `submit_order` | Governed Steward trading account/session inspection and confirmed order intent for Hyperliquid and Polymarket. |
 
 Similes handled: `SWAP`, `SWAP_SOLANA`, `TRANSFER`, `TRANSFER_TOKEN`, `WALLET_SWAP`, `WALLET_TRANSFER`, `CROSS_CHAIN_TRANSFER`, `PREPARE_TRANSFER`, `WALLET_ACTION`, `WALLET_GOV`, `PUMP_FUN_BUY`, `PUMPFUN_BUY`, `TOKEN_INFO`, `BIRDEYE_LOOKUP`, `BIRDEYE_SEARCH`, `WALLET_SEARCH_ADDRESS`.
 
@@ -29,6 +30,7 @@ All on-chain subactions (`transfer`, `swap`, `bridge`, `gov`, `pump_fun_buy`) re
 | Name | File | Description |
 |------|------|-------------|
 | `wallet` | `src/providers/wallet-provider.ts` | Injects EVM + Solana addresses into planner context (finance/crypto/wallet contexts, OWNER+ role gate). |
+| `stewardTrading` | `src/providers/steward-trading-provider.ts` | Injects Steward trading capability and governed Hyperliquid/Polymarket session status without secrets. |
 | `evmWalletProvider` | `src/chains/evm/providers/wallet.ts` | EVM-specific wallet context (viem `Account`). |
 | `tokenBalanceProvider` | `src/chains/evm/providers/get-balance.ts` | EVM token balances. |
 | `agentPortfolioProvider` | `src/analytics/birdeye/providers/agent-portfolio-provider.ts` | Birdeye portfolio for configured `BIRDEYE_WALLET_ADDR`. Registered when that setting is present. |
@@ -41,6 +43,7 @@ All on-chain subactions (`transfer`, `swap`, `bridge`, `gov`, `pump_fun_buy`) re
 | Name | Service type key | File | Description |
 |------|-----------------|------|-------------|
 | `WalletBackendService` | `"wallet-backend"` | `src/services/wallet-backend-service.ts` | Core signing router — resolves `WalletBackend`, registers chain handlers, dispatches `routeWalletAction`. |
+| `StewardTradingService` | `"steward-trading"` | `src/services/steward-trading-service.ts` | Governed Steward trading HTTP client for Hyperliquid/Polymarket sessions, accounts, and idempotent order submission. |
 | `EVMService` | EVM service type | `src/chains/evm/service.ts` | EVM RPC + wallet management. |
 | `SolanaService` | `SOLANA_SERVICE_NAME` | `src/chains/solana/service.ts` | Solana RPC, swap routing (Jupiter), portfolio. |
 | `SolanaWalletService` | compat alias | `src/chains/solana/service.ts` | Compatibility alias for consumers expecting the old service name. |

--- a/plugins/plugin-wallet/src/__tests__/core-vitest-mock.ts
+++ b/plugins/plugin-wallet/src/__tests__/core-vitest-mock.ts
@@ -1,5 +1,5 @@
 /**
- * Minimal core runtime surface for wallet unit tests that exercise plugin
+ * Minimal core runtime surface used by wallet unit tests that exercise plugin
  * wiring without loading the full `@elizaos/core` source graph. Sparse CI lanes
  * do not install every transitive core dependency, so tests import this through
  * `vi.mock("@elizaos/core", ...)` before loading wallet modules.

--- a/plugins/plugin-wallet/src/actions/failure-codes.test.ts
+++ b/plugins/plugin-wallet/src/actions/failure-codes.test.ts
@@ -6,7 +6,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@elizaos/core", async () => {
-  return await import("../test-utils/core-vitest-mock.js");
+  return await import("../__tests__/core-vitest-mock.js");
 });
 
 import { StewardTradingService } from "../services/steward-trading-service.js";

--- a/plugins/plugin-wallet/src/actions/failure-codes.test.ts
+++ b/plugins/plugin-wallet/src/actions/failure-codes.test.ts
@@ -4,6 +4,11 @@
  * approval, idempotency, venue, credential, transport, and execution failures.
  */
 import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@elizaos/core", async () => {
+  return await import("../test-utils/core-vitest-mock.js");
+});
+
 import { StewardTradingService } from "../services/steward-trading-service.js";
 import {
   type ActionFailureCode,

--- a/plugins/plugin-wallet/src/actions/index.ts
+++ b/plugins/plugin-wallet/src/actions/index.ts
@@ -1,2 +1,6 @@
-/** Barrel re-export for wallet action failure codes. */
+/** Barrel re-export for wallet action failure codes and native actions. */
 export * from "./failure-codes.js";
+export {
+  default as tradeRouterAction,
+  tradeRouterAction as TRADE,
+} from "./trade-action.js";

--- a/plugins/plugin-wallet/src/actions/trade-action.test.ts
+++ b/plugins/plugin-wallet/src/actions/trade-action.test.ts
@@ -1,0 +1,360 @@
+/**
+ * Tests the native `TRADE` router through the real StewardTradingService
+ * contract with injected HTTP fixtures. This keeps order confirmation,
+ * idempotency handoff, and outcome rendering deterministic without live
+ * Steward, Hyperliquid, Polymarket, or network access.
+ */
+import type { HandlerOptions, IAgentRuntime, Memory } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { actionToJsonSchema } from "../../../../packages/core/src/actions/action-schema.js";
+import {
+  requireTradeOrderConfirmation,
+  TRADE_CONFIRM_ACTION,
+  tradeOrderPendingKey,
+} from "../security/trade-confirmation.js";
+import { stewardFixtures } from "../services/__fixtures__/steward-trade-responses.js";
+import { StewardTradingService } from "../services/steward-trading-service.js";
+import { tradeRouterAction } from "./trade-action.js";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function createRuntime(fetchMock: typeof fetch): {
+  readonly runtime: IAgentRuntime;
+  readonly service: StewardTradingService;
+  readonly cache: Map<string, unknown>;
+} {
+  const cache = new Map<string, unknown>();
+  const getService = vi.fn(() => null);
+  const getSetting = vi.fn((key: string) => {
+    const settings: Record<string, string> = {
+      STEWARD_API_URL: "https://steward.local",
+      STEWARD_AGENT_ID: "agent-fixture",
+      STEWARD_AGENT_TOKEN: "token-fixture",
+      STEWARD_HYPERLIQUID_TRADE_SESSION_ID: "sess_hl_fixture",
+      STEWARD_POLYMARKET_TRADE_SESSION_ID: "sess_pm_fixture",
+    };
+    return settings[key];
+  });
+  const runtime = {
+    agentId: "test-agent",
+    character: { name: "Test Agent", settings: {} },
+    getSetting,
+    getService,
+    getCache: vi.fn(async <T>(key: string) => cache.get(key) as T | undefined),
+    setCache: vi.fn(async (key: string, value: unknown) => {
+      cache.set(key, value);
+      return true;
+    }),
+    deleteCache: vi.fn(async (key: string) => {
+      cache.delete(key);
+      return true;
+    }),
+    logger: {
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      log: vi.fn(),
+      warn: vi.fn(),
+    },
+  } as unknown as IAgentRuntime;
+  const service = new StewardTradingService(runtime, {
+    fetch: fetchMock,
+    sleep: async () => undefined,
+    maxRetries: 1,
+  });
+  getService.mockImplementation((name: string) =>
+    name === StewardTradingService.serviceType ? service : null,
+  );
+  return { runtime, service, cache };
+}
+
+function message(text: string): Memory {
+  return {
+    id: "00000000-0000-0000-0000-000000000001",
+    entityId: "00000000-0000-0000-0000-000000000002",
+    agentId: "00000000-0000-0000-0000-000000000003",
+    roomId: "00000000-0000-0000-0000-000000000004",
+    content: { text },
+    createdAt: Date.now(),
+  } as Memory;
+}
+
+async function run(
+  runtime: IAgentRuntime,
+  text: string,
+  parameters: Record<string, unknown>,
+) {
+  return tradeRouterAction.handler(runtime, message(text), undefined, {
+    parameters,
+  } as HandlerOptions);
+}
+
+const hyperliquidOrder = {
+  operation: "submit_order",
+  venue: "hyperliquid",
+  sessionId: "sess_hl_fixture",
+  coin: "BTC",
+  side: "buy",
+  size: 0.01,
+  limitPx: 61_000,
+  leverage: 2,
+  tif: "Ioc",
+};
+
+describe("tradeRouterAction", () => {
+  it("inspects governed account state through StewardTradingService", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse(200, stewardFixtures.tokenStatusObserved),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, stewardFixtures.activeHyperliquidSession),
+      );
+    const { runtime } = createRuntime(fetchMock as unknown as typeof fetch);
+
+    const result = await run(runtime, "inspect hyperliquid", {
+      operation: "inspect_account",
+      venue: "hyperliquid",
+    });
+
+    expect(result?.success).toBe(true);
+    expect(result?.data?.account).toMatchObject({
+      venue: "hyperliquid",
+      status: "active",
+      accountId: "wallet_fixture",
+    });
+    expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
+      "https://steward.local/v1/trade/token-status?agentId=agent-fixture",
+      "https://steward.local/v1/trade/sessions/sess_hl_fixture",
+    ]);
+  });
+
+  it("is not selectable when Steward trading is unconfigured", async () => {
+    const { runtime, service } = createRuntime(
+      vi.fn() as unknown as typeof fetch,
+    );
+    service.capability = vi.fn().mockReturnValue({
+      configured: false,
+      canTrade: false,
+      venues: ["hyperliquid", "polymarket"],
+    });
+
+    await expect(
+      tradeRouterAction.validate?.(
+        runtime,
+        message("inspect hyperliquid"),
+        undefined,
+        {
+          parameters: {
+            operation: "inspect_account",
+            venue: "hyperliquid",
+          },
+        } as HandlerOptions,
+      ),
+    ).resolves.toBe(false);
+  });
+
+  it("does not label Steward service failures as invalid parameters", async () => {
+    const { runtime, service } = createRuntime(
+      vi.fn() as unknown as typeof fetch,
+    );
+    service.resolveAccount = vi
+      .fn()
+      .mockRejectedValue(new Error("Steward runtime unavailable"));
+    const callback = vi.fn();
+
+    await expect(
+      tradeRouterAction.handler(
+        runtime,
+        message("inspect hyperliquid"),
+        undefined,
+        {
+          parameters: {
+            operation: "inspect_account",
+            venue: "hyperliquid",
+          },
+        } as HandlerOptions,
+        callback,
+      ),
+    ).rejects.toThrow("Steward runtime unavailable");
+
+    expect(callback).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.objectContaining({ error: "INVALID_PARAMS" }),
+      }),
+    );
+  });
+
+  it("persists the idempotency key before confirmation and reuses it on submit", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse(200, stewardFixtures.tokenStatusObserved),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, stewardFixtures.activeHyperliquidSession),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, stewardFixtures.tokenStatusObserved),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, stewardFixtures.activeHyperliquidSession),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, stewardFixtures.hyperliquidOrderAccepted),
+      );
+    const { runtime, cache } = createRuntime(
+      fetchMock as unknown as typeof fetch,
+    );
+
+    const pending = await run(runtime, "buy btc", hyperliquidOrder);
+    expect(pending?.data?.requiresConfirmation).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const cacheKey = `confirmation:00000000-0000-0000-0000-000000000002:${TRADE_CONFIRM_ACTION}:${tradeOrderPendingKey(hyperliquidOrder)}`;
+    const pendingRecord = cache.get(cacheKey) as
+      | { metadata?: { idempotencyKey?: string } }
+      | undefined;
+    const persistedKey = pendingRecord?.metadata?.idempotencyKey;
+    expect(persistedKey).toEqual(expect.any(String));
+
+    const confirmed = await run(runtime, "yes, confirm", hyperliquidOrder);
+    expect(confirmed?.success).toBe(true);
+    expect(confirmed?.data?.idempotencyKey).toBe(persistedKey);
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+
+    const submit = fetchMock.mock.calls[4];
+    expect(submit?.[0]).toBe(
+      "https://steward.local/v1/trade/hyperliquid/order",
+    );
+    const headers = submit?.[1]?.headers as Record<string, string>;
+    const body = JSON.parse(String(submit?.[1]?.body));
+    expect(headers["Idempotency-Key"]).toBe(persistedKey);
+    expect(body.idempotencyKey).toBe(persistedKey);
+  });
+
+  it("generates one idempotency key for a pending logical order", async () => {
+    const { runtime } = createRuntime(vi.fn() as unknown as typeof fetch);
+    const keyFactory = vi.fn(() => "trade-key-1");
+    const first = await requireTradeOrderConfirmation({
+      runtime,
+      message: message("buy btc"),
+      order: hyperliquidOrder,
+      prompt: "Confirm?",
+      keyFactory,
+    });
+    const second = await requireTradeOrderConfirmation({
+      runtime,
+      message: message("yes"),
+      order: hyperliquidOrder,
+      prompt: "Confirm?",
+      keyFactory,
+    });
+
+    expect(first.status).toBe("pending");
+    expect(second).toEqual({
+      status: "confirmed",
+      metadata: {
+        venue: "hyperliquid",
+        sessionId: "sess_hl_fixture",
+        idempotencyKey: "trade-key-1",
+      },
+    });
+    expect(keyFactory).toHaveBeenCalledTimes(1);
+  });
+
+  it("declares every handler-supported order field in the closed tool schema", () => {
+    const schema = actionToJsonSchema(tradeRouterAction);
+    expect(schema.additionalProperties).toBe(false);
+    expect(schema.properties).toMatchObject({
+      leverage: { type: "number" },
+      reduceOnly: { type: "boolean" },
+      tif: { type: "string", enum: ["Alo", "Ioc", "Gtc"] },
+      tickSize: { type: "string", enum: ["0.1", "0.01", "0.001", "0.0001"] },
+      negRisk: { type: "boolean" },
+    });
+  });
+
+  it("does not submit when the model supplies confirmed without a user reply", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse(200, stewardFixtures.tokenStatusObserved),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, stewardFixtures.activeHyperliquidSession),
+      );
+    const { runtime } = createRuntime(fetchMock as unknown as typeof fetch);
+
+    const result = await run(runtime, "buy btc", {
+      ...hyperliquidOrder,
+      confirmed: true,
+    });
+
+    expect(result?.data?.requiresConfirmation).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(
+      fetchMock.mock.calls.some((call) => String(call[0]).includes("/order")),
+    ).toBe(false);
+  });
+
+  it("renders missing sessions as session_required without confirmation", async () => {
+    const fetchMock = vi.fn();
+    const { runtime } = createRuntime(fetchMock as unknown as typeof fetch);
+    (runtime.getSetting as ReturnType<typeof vi.fn>).mockImplementation(
+      (key: string) => {
+        const settings: Record<string, string> = {
+          STEWARD_API_URL: "https://steward.local",
+          STEWARD_AGENT_ID: "agent-fixture",
+          STEWARD_AGENT_TOKEN: "token-fixture",
+        };
+        return settings[key];
+      },
+    );
+
+    const result = await run(runtime, "buy btc", hyperliquidOrder);
+
+    expect(result?.success).toBe(false);
+    expect(result?.data).toMatchObject({
+      outcome: "session_required",
+      error: "SESSION_REQUIRED",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("marks unknown submit results as poll and do-not-retry", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse(200, stewardFixtures.tokenStatusObserved),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, stewardFixtures.activeHyperliquidSession),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, stewardFixtures.tokenStatusObserved),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, stewardFixtures.activeHyperliquidSession),
+      )
+      .mockResolvedValueOnce(jsonResponse(502, stewardFixtures.unknownSubmit));
+    const { runtime } = createRuntime(fetchMock as unknown as typeof fetch);
+
+    await run(runtime, "buy btc", hyperliquidOrder);
+    const result = await run(runtime, "yes", hyperliquidOrder);
+
+    expect(result?.success).toBe(false);
+    expect(result?.data).toMatchObject({
+      outcome: "unknown",
+      pollRequired: true,
+      doNotRetry: true,
+      retrySafe: false,
+    });
+    expect(String(result?.text)).toContain("do not resubmit");
+  });
+});

--- a/plugins/plugin-wallet/src/actions/trade-action.test.ts
+++ b/plugins/plugin-wallet/src/actions/trade-action.test.ts
@@ -7,10 +7,6 @@
 import type { HandlerOptions, IAgentRuntime, Memory } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("@elizaos/core", async () => {
-  return await import("../test-utils/core-vitest-mock.js");
-});
-
 import { actionToJsonSchema } from "../../../../packages/core/src/actions/action-schema.js";
 import {
   requireTradeOrderConfirmation,

--- a/plugins/plugin-wallet/src/actions/trade-action.test.ts
+++ b/plugins/plugin-wallet/src/actions/trade-action.test.ts
@@ -6,6 +6,11 @@
  */
 import type { HandlerOptions, IAgentRuntime, Memory } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@elizaos/core", async () => {
+  return await import("../test-utils/core-vitest-mock.js");
+});
+
 import { actionToJsonSchema } from "../../../../packages/core/src/actions/action-schema.js";
 import {
   requireTradeOrderConfirmation,

--- a/plugins/plugin-wallet/src/actions/trade-action.ts
+++ b/plugins/plugin-wallet/src/actions/trade-action.ts
@@ -1,0 +1,635 @@
+/**
+ * Native trading router for governed Steward venue execution. The action keeps
+ * Eliza on the neutral contract boundary: it inspects Steward capability,
+ * sessions, and accounts, then submits only normalized Hyperliquid or
+ * Polymarket order intent after core confirmation has resolved.
+ */
+import type {
+  Action,
+  ActionResult,
+  HandlerCallback,
+  HandlerOptions,
+  IAgentRuntime,
+  Memory,
+  ProviderDataRecord,
+  ProviderValue,
+  State,
+} from "@elizaos/core";
+import { requireTradeOrderConfirmation } from "../security/trade-confirmation.js";
+import { StewardTradingService } from "../services/steward-trading-service.js";
+import type {
+  HyperliquidSubmitOrderRequest,
+  PolymarketSubmitOrderRequest,
+  SubmitOrderRequest,
+  TradeEnvelope,
+  Venue,
+} from "../types/trade.js";
+
+const VENUES = ["hyperliquid", "polymarket"] as const;
+const OPERATIONS = [
+  "inspect_account",
+  "inspect_session",
+  "submit_order",
+] as const;
+const POLYMARKET_TICK_SIZES = ["0.1", "0.01", "0.001", "0.0001"] as const;
+
+type TradeOperation = (typeof OPERATIONS)[number];
+type ParsedTradeParams =
+  | { operation: "inspect_account"; venue: Venue }
+  | { operation: "inspect_session"; sessionId: string }
+  | { operation: "submit_order"; order: SubmitOrderRequest };
+type TradeActionOutcome =
+  | "policy_denied"
+  | "session_required"
+  | "rejected"
+  | "not_attempted"
+  | "unknown";
+
+function objectRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+function booleanValue(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") return value;
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (["true", "1", "yes"].includes(normalized)) return true;
+  if (["false", "0", "no"].includes(normalized)) return false;
+  return undefined;
+}
+
+function venueValue(value: unknown): Venue | undefined {
+  const normalized = stringValue(value)?.toLowerCase();
+  return (VENUES as readonly string[]).includes(normalized ?? "")
+    ? (normalized as Venue)
+    : undefined;
+}
+
+function operationValue(value: unknown): TradeOperation | undefined {
+  const normalized = stringValue(value)
+    ?.toLowerCase()
+    .replace(/[.\s-]+/g, "_");
+  return (OPERATIONS as readonly string[]).includes(normalized ?? "")
+    ? (normalized as TradeOperation)
+    : undefined;
+}
+
+function rawParams(
+  message: Memory,
+  state?: State,
+  options?: HandlerOptions | Record<string, unknown>,
+): Record<string, unknown> {
+  const optionRecord = objectRecord(options);
+  const optionParams = objectRecord(optionRecord?.parameters);
+  if (optionParams) return optionParams;
+  if (optionRecord && ("operation" in optionRecord || "venue" in optionRecord))
+    return optionRecord;
+  const stateRecord = objectRecord(state);
+  const stateParams = objectRecord(stateRecord?.tradeRouterParams);
+  if (stateParams) return stateParams;
+  return objectRecord(message.content) ?? {};
+}
+
+function requireVenue(raw: Record<string, unknown>): Venue {
+  const venue = venueValue(raw.venue ?? raw.marketVenue ?? raw.exchange);
+  if (!venue) {
+    throw new Error("venue must be hyperliquid or polymarket");
+  }
+  return venue;
+}
+
+function requireSide(value: unknown): "buy" | "sell" {
+  const side = stringValue(value)?.toLowerCase();
+  if (side === "buy" || side === "sell") return side;
+  throw new Error("side must be buy or sell");
+}
+
+function requireString(raw: Record<string, unknown>, key: string): string {
+  const value = stringValue(raw[key]);
+  if (!value) throw new Error(`${key} is required`);
+  return value;
+}
+
+function requireNumber(raw: Record<string, unknown>, key: string): number {
+  const value = numberValue(raw[key]);
+  if (value === undefined) throw new Error(`${key} must be a number`);
+  return value;
+}
+
+function parseOrder(raw: Record<string, unknown>): SubmitOrderRequest {
+  const venue = requireVenue(raw);
+  const sessionId = requireString(raw, "sessionId");
+  const side = requireSide(raw.side);
+  if (venue === "hyperliquid") {
+    const order: HyperliquidSubmitOrderRequest = {
+      venue,
+      sessionId,
+      coin: requireString(raw, "coin"),
+      side,
+      size: requireNumber(raw, "size"),
+      limitPx: stringValue(raw.limitPx) ?? numberValue(raw.limitPx),
+      leverage: numberValue(raw.leverage),
+      reduceOnly: booleanValue(raw.reduceOnly),
+      tif: stringValue(raw.tif) as HyperliquidSubmitOrderRequest["tif"],
+    };
+    if (order.tif && !["Alo", "Ioc", "Gtc"].includes(order.tif)) {
+      throw new Error("tif must be Alo, Ioc, or Gtc");
+    }
+    return order;
+  }
+  const tickSize = stringValue(raw.tickSize);
+  if (
+    tickSize &&
+    !(POLYMARKET_TICK_SIZES as readonly string[]).includes(tickSize)
+  ) {
+    throw new Error("tickSize must be 0.1, 0.01, 0.001, or 0.0001");
+  }
+  return {
+    venue,
+    sessionId,
+    tokenId: requireString(raw, "tokenId"),
+    side,
+    amount: stringValue(raw.amount) ?? requireNumber(raw, "amount"),
+    price: stringValue(raw.price) ?? requireNumber(raw, "price"),
+    tickSize: tickSize as PolymarketSubmitOrderRequest["tickSize"],
+    negRisk: booleanValue(raw.negRisk),
+  };
+}
+
+function parseTradeParams(raw: Record<string, unknown>): ParsedTradeParams {
+  const operation = operationValue(
+    raw.operation ?? raw.action ?? raw.subaction,
+  );
+  if (!operation) throw new Error("operation is required");
+  if (operation === "inspect_account") {
+    return { operation, venue: requireVenue(raw) };
+  }
+  if (operation === "inspect_session") {
+    return { operation, sessionId: requireString(raw, "sessionId") };
+  }
+  return { operation, order: parseOrder(raw) };
+}
+
+function serviceFromRuntime(
+  runtime: IAgentRuntime,
+): StewardTradingService | null {
+  const service = runtime.getService(StewardTradingService.serviceType);
+  if (
+    service &&
+    typeof (service as StewardTradingService).capability === "function" &&
+    typeof (service as StewardTradingService).resolveAccount === "function" &&
+    typeof (service as StewardTradingService).getSession === "function" &&
+    typeof (service as StewardTradingService).submitOrder === "function"
+  ) {
+    return service as StewardTradingService;
+  }
+  return null;
+}
+
+function providerValue(value: unknown): ProviderValue {
+  if (value === undefined) return undefined;
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+  if (Array.isArray(value)) return value.map((item) => providerValue(item));
+  if (typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, item]) => [
+        key,
+        providerValue(item),
+      ]),
+    );
+  }
+  return String(value);
+}
+
+function providerRecord(value: Record<string, unknown>): ProviderDataRecord {
+  return Object.fromEntries(
+    Object.entries(value).map(([key, item]) => [key, providerValue(item)]),
+  );
+}
+
+function actionOutcome<T>(envelope: TradeEnvelope<T>): TradeActionOutcome {
+  if (envelope.ok) return "not_attempted";
+  if (envelope.error === "SESSION_REQUIRED") return "session_required";
+  return envelope.outcome;
+}
+
+function failureData<T>(
+  envelope: Extract<TradeEnvelope<T>, { ok: false }>,
+  extra: Record<string, unknown> = {},
+): ProviderDataRecord {
+  const outcome = actionOutcome(envelope);
+  return providerRecord({
+    success: false,
+    outcome,
+    error: envelope.error,
+    detail: envelope.detail,
+    retryable: envelope.retryable,
+    retrySafe: outcome === "not_attempted",
+    pollRequired: outcome === "unknown",
+    doNotRetry: outcome === "unknown",
+    retryAfterMs: envelope.retryAfterMs,
+    policy: envelope.policy,
+    ...extra,
+  });
+}
+
+function failureText<T>(envelope: Extract<TradeEnvelope<T>, { ok: false }>) {
+  const outcome = actionOutcome(envelope);
+  if (outcome === "unknown") {
+    return `${envelope.detail} Poll Steward for the order status; do not resubmit this order intent.`;
+  }
+  if (outcome === "not_attempted") {
+    return `${envelope.detail} No venue submission was attempted; it is safe to retry after correcting the cause.`;
+  }
+  return envelope.detail;
+}
+
+function orderPreview(order: SubmitOrderRequest): string {
+  if (order.venue === "hyperliquid") {
+    return `Submit Hyperliquid ${order.side} ${order.size} ${order.coin}${order.limitPx === undefined ? "" : ` at ${order.limitPx}`} under governed session ${order.sessionId}? Reply yes to submit or no to cancel.`;
+  }
+  return `Submit Polymarket ${order.side} ${order.amount} token ${order.tokenId} at ${order.price} under governed session ${order.sessionId}? Reply yes to submit or no to cancel.`;
+}
+
+async function inspectAccount(
+  service: StewardTradingService,
+  venue: Venue,
+): Promise<ActionResult> {
+  const result = await service.resolveAccount(venue);
+  if (!result.ok) {
+    return {
+      success: false,
+      text: failureText(result),
+      data: failureData(result, { venue }),
+      values: { tradeOutcome: actionOutcome(result), tradeVenue: venue },
+    };
+  }
+  const text = `${venue} governed account is active.`;
+  return {
+    success: true,
+    text,
+    userFacingText: text,
+    verifiedUserFacing: true,
+    data: providerRecord({ success: true, venue, account: result.data }),
+    values: { tradeOutcome: "not_attempted", tradeVenue: venue },
+  };
+}
+
+async function inspectSession(
+  service: StewardTradingService,
+  sessionId: string,
+): Promise<ActionResult> {
+  const result = await service.getSession(sessionId);
+  if (!result.ok) {
+    return {
+      success: false,
+      text: failureText(result),
+      data: failureData(result, { sessionId }),
+      values: { tradeOutcome: actionOutcome(result) },
+    };
+  }
+  const text = `Governed ${result.data.venue ?? "trade"} session ${result.data.sessionId} is ${result.data.status ?? "available"}.`;
+  return {
+    success: true,
+    text,
+    userFacingText: text,
+    verifiedUserFacing: true,
+    data: providerRecord({ success: true, session: result.data }),
+    values: {
+      tradeOutcome: "not_attempted",
+      tradeVenue: result.data.venue,
+    },
+  };
+}
+
+async function submitOrder(
+  runtime: IAgentRuntime,
+  message: Memory,
+  service: StewardTradingService,
+  order: SubmitOrderRequest,
+  callback?: HandlerCallback,
+): Promise<ActionResult> {
+  const account = await service.resolveAccount(order.venue);
+  if (!account.ok) {
+    return {
+      success: false,
+      text: failureText(account),
+      data: failureData(account, { venue: order.venue }),
+      values: {
+        tradeOutcome: actionOutcome(account),
+        tradeVenue: order.venue,
+      },
+    };
+  }
+
+  const decision = await requireTradeOrderConfirmation({
+    runtime,
+    message,
+    order,
+    prompt: orderPreview(order),
+    callback,
+  });
+  if (decision.status === "pending") {
+    return {
+      success: true,
+      text: orderPreview(order),
+      userFacingText: orderPreview(order),
+      verifiedUserFacing: true,
+      data: providerRecord({
+        requiresConfirmation: true,
+        confirmationStatus: "pending",
+        awaitingUserInput: true,
+        venue: order.venue,
+        sessionId: order.sessionId,
+      }),
+      values: {
+        tradeActionPrepared: true,
+        tradeActionSucceeded: false,
+        tradeVenue: order.venue,
+      },
+    };
+  }
+  if (decision.status !== "confirmed") {
+    return {
+      success: true,
+      text: "Trade order cancelled.",
+      userFacingText: "Trade order cancelled.",
+      verifiedUserFacing: true,
+      data: providerRecord({
+        confirmationStatus: "cancelled",
+        venue: order.venue,
+        sessionId: order.sessionId,
+      }),
+      values: {
+        tradeActionPrepared: false,
+        tradeActionSucceeded: false,
+        tradeVenue: order.venue,
+      },
+    };
+  }
+
+  const { idempotencyKey } = decision.metadata;
+  const result = await service.submitOrder({ ...order, idempotencyKey });
+  if (!result.ok) {
+    return {
+      success: false,
+      text: failureText(result),
+      data: failureData(result, {
+        venue: order.venue,
+        sessionId: order.sessionId,
+        idempotencyKey,
+      }),
+      values: {
+        tradeActionSucceeded: false,
+        tradeOutcome: actionOutcome(result),
+        tradeVenue: order.venue,
+      },
+    };
+  }
+  const text = `Submitted ${order.venue} order ${result.data.orderId}.`;
+  return {
+    success: true,
+    text,
+    userFacingText: text,
+    verifiedUserFacing: true,
+    data: providerRecord({
+      success: true,
+      outcome: "submitted",
+      venue: order.venue,
+      order: result.data,
+      idempotencyKey,
+    }),
+    values: {
+      tradeActionSucceeded: true,
+      tradeVenue: order.venue,
+      tradeOrderId: result.data.orderId,
+    },
+  };
+}
+
+export const tradeRouterAction: Action = {
+  name: "TRADE",
+  description:
+    "Inspect governed Steward trading accounts/sessions and submit confirmed order intent for Hyperliquid or Polymarket. Use operation=inspect_account, inspect_session, or submit_order. Order submission requires a separate user yes confirmation and never accepts venue SDK payloads or credentials.",
+  descriptionCompressed:
+    "TRADE inspect_account|inspect_session|submit_order via Steward for Hyperliquid/Polymarket; submit requires confirmation",
+  contexts: ["finance", "crypto", "wallet"],
+  contextGate: { anyOf: ["finance", "crypto", "wallet"] },
+  roleGate: { minRole: "ADMIN" },
+  similes: [
+    "STEWARD_TRADE",
+    "HYPERLIQUID_TRADE",
+    "POLYMARKET_TRADE",
+    "TRADE_ORDER",
+    "TRADING_ACCOUNT",
+  ],
+  parameters: [
+    {
+      name: "operation",
+      description:
+        "Trading operation: inspect_account, inspect_session, or submit_order.",
+      required: true,
+      schema: { type: "string", enum: [...OPERATIONS] },
+    },
+    {
+      name: "venue",
+      description: "Venue for account/order operations.",
+      required: false,
+      schema: { type: "string", enum: [...VENUES] },
+    },
+    {
+      name: "sessionId",
+      description: "Governed Steward trading session id.",
+      required: false,
+      schema: { type: "string" },
+    },
+    {
+      name: "side",
+      description: "Order side for submit_order.",
+      required: false,
+      schema: { type: "string", enum: ["buy", "sell"] },
+    },
+    {
+      name: "coin",
+      description: "Hyperliquid coin symbol.",
+      required: false,
+      schema: { type: "string" },
+    },
+    {
+      name: "size",
+      description: "Hyperliquid order size.",
+      required: false,
+      schema: { type: "number" },
+    },
+    {
+      name: "limitPx",
+      description: "Hyperliquid limit price.",
+      required: false,
+      schema: {
+        type: "string",
+        anyOf: [{ type: "number" }, { type: "string" }],
+      },
+    },
+    {
+      name: "leverage",
+      description: "Hyperliquid leverage for the submitted order.",
+      required: false,
+      schema: { type: "number" },
+    },
+    {
+      name: "reduceOnly",
+      description: "Whether the Hyperliquid order may only reduce exposure.",
+      required: false,
+      schema: { type: "boolean" },
+    },
+    {
+      name: "tif",
+      description: "Hyperliquid time-in-force.",
+      required: false,
+      schema: { type: "string", enum: ["Alo", "Ioc", "Gtc"] },
+    },
+    {
+      name: "tokenId",
+      description: "Polymarket outcome token id.",
+      required: false,
+      schema: { type: "string" },
+    },
+    {
+      name: "amount",
+      description: "Polymarket order amount.",
+      required: false,
+      schema: {
+        type: "string",
+        anyOf: [{ type: "number" }, { type: "string" }],
+      },
+    },
+    {
+      name: "price",
+      description: "Polymarket order price.",
+      required: false,
+      schema: {
+        type: "string",
+        anyOf: [{ type: "number" }, { type: "string" }],
+      },
+    },
+    {
+      name: "tickSize",
+      description: "Optional Polymarket tick-size hint.",
+      required: false,
+      schema: {
+        type: "string",
+        enum: [...POLYMARKET_TICK_SIZES],
+      },
+    },
+    {
+      name: "negRisk",
+      description: "Optional Polymarket negative-risk hint.",
+      required: false,
+      schema: { type: "boolean" },
+    },
+  ],
+  validate: async (runtime, message, state, options) => {
+    const service = serviceFromRuntime(runtime);
+    if (!service?.capability().canTrade) return false;
+    const raw = rawParams(message, state, options);
+    return (
+      operationValue(raw.operation ?? raw.action ?? raw.subaction) !== undefined
+    );
+  },
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    state?: State,
+    options?: HandlerOptions | Record<string, unknown>,
+    callback?: HandlerCallback,
+  ): Promise<ActionResult> => {
+    const service = serviceFromRuntime(runtime);
+    if (!service) {
+      const text = "Steward trading service is not available.";
+      await callback?.({ text, content: { error: "PROVIDER_UNAVAILABLE" } });
+      return {
+        success: false,
+        text,
+        data: providerRecord({
+          outcome: "not_attempted",
+          error: "PROVIDER_UNAVAILABLE",
+          retrySafe: true,
+        }),
+      };
+    }
+
+    let parsed: ParsedTradeParams;
+    try {
+      parsed = parseTradeParams(rawParams(message, state, options));
+    } catch (error) {
+      const text = `Invalid trade parameters: ${
+        error instanceof Error ? error.message : String(error)
+      }`;
+      await callback?.({ text, content: { error: "INVALID_PARAMS" } });
+      return {
+        success: false,
+        text,
+        data: providerRecord({
+          outcome: "rejected",
+          error: "INVALID_PARAMS",
+          detail: text,
+          retrySafe: false,
+        }),
+        values: { tradeOutcome: "rejected" },
+      };
+    }
+
+    if (parsed.operation === "inspect_account") {
+      return inspectAccount(service, parsed.venue);
+    }
+    if (parsed.operation === "inspect_session") {
+      return inspectSession(service, parsed.sessionId);
+    }
+    return submitOrder(runtime, message, service, parsed.order, callback);
+  },
+  examples: [
+    [
+      {
+        name: "{{user1}}",
+        content: { text: "Check whether Hyperliquid trading is ready." },
+      },
+      {
+        name: "{{agent}}",
+        content: { text: "Inspecting the governed account.", action: "TRADE" },
+      },
+    ],
+    [
+      {
+        name: "{{user1}}",
+        content: { text: "Buy 5 Polymarket outcome tokens at 42 cents." },
+      },
+      {
+        name: "{{agent}}",
+        content: { text: "Preparing a governed trade order.", action: "TRADE" },
+      },
+    ],
+  ],
+};
+
+export default tradeRouterAction;

--- a/plugins/plugin-wallet/src/index.steward-trading-exports.test.ts
+++ b/plugins/plugin-wallet/src/index.steward-trading-exports.test.ts
@@ -6,7 +6,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@elizaos/core", async () => {
-  return await import("./test-utils/core-vitest-mock.js");
+  return await import("./__tests__/core-vitest-mock.js");
 });
 
 // Keep package-barrel evaluation hermetic: these unrelated registration and

--- a/plugins/plugin-wallet/src/index.steward-trading-exports.test.ts
+++ b/plugins/plugin-wallet/src/index.steward-trading-exports.test.ts
@@ -5,19 +5,72 @@
  */
 import { describe, expect, it, vi } from "vitest";
 
+vi.mock("@elizaos/core", async () => {
+  return await import("./test-utils/core-vitest-mock.js");
+});
+
 // Keep package-barrel evaluation hermetic: these unrelated registration and
 // backend-selection modules depend on the built @elizaos/shared package, which
 // is intentionally unavailable in the changed-file test lane.
 vi.mock("./api/wallet-routes.js", () => ({}));
+vi.mock("./analytics/lpinfo/index.js", () => ({
+  kaminoPlugin: { name: "kamino" },
+  lpinfoPlugin: { name: "lpinfo" },
+  steerPlugin: { name: "steer" },
+}));
 vi.mock("./automation-node-contributor.js", () => ({
   registerWalletAutomationNodeContributor: vi.fn(),
+}));
+vi.mock("./chains/evm/bridge-router.js", () => ({
+  validateWalletBridgeParams: vi.fn(() => null),
+}));
+vi.mock("./chains/evm/index.js", () => ({
+  default: {
+    name: "evm",
+    services: [],
+    providers: [],
+    actions: [],
+    routes: [],
+  },
+}));
+vi.mock("./chains/registry.js", () => ({
+  registerDefaultWalletChainHandlers: vi.fn(),
+}));
+vi.mock("./chains/solana/index.js", () => ({
+  default: {
+    name: "solana",
+    services: [],
+    providers: [],
+    actions: [],
+    routes: [],
+  },
+}));
+vi.mock("./lp/lp-manager-entry.js", () => ({
+  AerodromeLpService: class AerodromeLpService {},
+  aerodromePlugin: { name: "aerodrome" },
+  ConcentratedLiquidityService: class ConcentratedLiquidityService {},
+  DexInteractionService: class DexInteractionService {},
+  default: { name: "lp-manager" },
+  LP_MANAGER_PLUGIN_NAME: "@elizaos/plugin-lp-manager",
+  orcaPlugin: { name: "orca" },
+  PancakeSwapV3LpService: class PancakeSwapV3LpService {},
+  pancakeswapPlugin: { name: "pancakeswap" },
+  raydiumPlugin: { name: "raydium" },
+  UniswapV3LpService: class UniswapV3LpService {},
+  uniswapPlugin: { name: "uniswap" },
+  UserLpProfileService: class UserLpProfileService {},
+  VaultService: class VaultService {},
+  YieldOptimizationService: class YieldOptimizationService {},
 }));
 vi.mock("./wallet/select-backend.js", () => ({
   resolveWalletBackend: vi.fn(),
 }));
+vi.mock("./wallet/index.js", () => ({}));
 vi.mock("./lib/server-wallet-trade.js", () => ({}));
 vi.mock("./lib/wallet-export-guard.js", () => ({}));
 vi.mock("./routes/plugin.js", () => ({}));
+vi.mock("./sdk/index.js", () => ({}));
+vi.mock("./wallet-action.js", () => ({}));
 
 import walletPluginDefault, {
   createTradeIdempotencyKey,

--- a/plugins/plugin-wallet/src/index.ts
+++ b/plugins/plugin-wallet/src/index.ts
@@ -12,6 +12,7 @@ void walletRouteRegistration;
 registerWalletAutomationNodeContributor();
 
 export * from "./actions/index.js";
+export { tradeRouterAction } from "./actions/trade-action.js";
 export { BirdeyeService } from "./analytics/birdeye/service.js";
 export { DexScreenerService } from "./analytics/dexscreener/index.js";
 // Analytics surface (formerly @elizaos/plugin-{lpinfo,dexscreener,defi-news,birdeye}).
@@ -76,17 +77,19 @@ export * from "./lp/types.js";
 export { default, walletPlugin } from "./plugin.js";
 export * from "./policy/policy.js";
 export * from "./providers/canonical-provider.js";
+export { stewardTradingProvider } from "./providers/steward-trading-provider.js";
 export { walletProvider } from "./providers/wallet-provider.js";
 export * from "./register-routes.js";
 export * from "./routes/plugin.js";
 /** ERC-6551 / x402 / CCTP / swaps are available from the package barrel. */
 export * from "./sdk/index.js";
+export * from "./security/trade-confirmation.js";
+export type { StewardTradingServiceOptions } from "./services/steward-trading-service.js";
 export {
-  STEWARD_TRADING_SERVICE_TYPE,
   createTradeIdempotencyKey,
+  STEWARD_TRADING_SERVICE_TYPE,
   StewardTradingService,
 } from "./services/steward-trading-service.js";
-export type { StewardTradingServiceOptions } from "./services/steward-trading-service.js";
 export {
   WALLET_BACKEND_SERVICE_TYPE,
   WalletBackendService,

--- a/plugins/plugin-wallet/src/plugin.steward-trading-lifecycle.test.ts
+++ b/plugins/plugin-wallet/src/plugin.steward-trading-lifecycle.test.ts
@@ -7,7 +7,7 @@ import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@elizaos/core", async () => {
-  return await import("./test-utils/core-vitest-mock.js");
+  return await import("./__tests__/core-vitest-mock.js");
 });
 
 // Backend selection is unrelated to plugin composition and requires the built

--- a/plugins/plugin-wallet/src/plugin.steward-trading-lifecycle.test.ts
+++ b/plugins/plugin-wallet/src/plugin.steward-trading-lifecycle.test.ts
@@ -6,8 +6,36 @@
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+vi.mock("@elizaos/core", async () => {
+  return await import("./test-utils/core-vitest-mock.js");
+});
+
 // Backend selection is unrelated to plugin composition and requires the built
 // @elizaos/shared entrypoint, which the changed-file CI lane does not provide.
+vi.mock("./chains/evm/bridge-router.js", () => ({
+  validateWalletBridgeParams: vi.fn(() => null),
+}));
+vi.mock("./chains/evm/index.js", () => ({
+  default: {
+    name: "evm",
+    services: [],
+    providers: [],
+    actions: [],
+    routes: [],
+  },
+}));
+vi.mock("./chains/registry.js", () => ({
+  registerDefaultWalletChainHandlers: vi.fn(),
+}));
+vi.mock("./chains/solana/index.js", () => ({
+  default: {
+    name: "solana",
+    services: [],
+    providers: [],
+    actions: [],
+    routes: [],
+  },
+}));
 vi.mock("./wallet/select-backend.js", () => ({
   resolveWalletBackend: vi.fn(),
 }));

--- a/plugins/plugin-wallet/src/plugin.ts
+++ b/plugins/plugin-wallet/src/plugin.ts
@@ -12,6 +12,7 @@ import {
   parseBooleanFromText,
   type ServiceClass,
 } from "@elizaos/core";
+import { tradeRouterAction } from "./actions/trade-action.js";
 import { agentPortfolioProvider } from "./analytics/birdeye/providers/agent-portfolio-provider.js";
 import { marketProvider } from "./analytics/birdeye/providers/market.js";
 import { trendingProvider } from "./analytics/birdeye/providers/trending.js";
@@ -25,19 +26,20 @@ import { DexScreenerService } from "./analytics/dexscreener/service.js";
 import { TokenInfoService } from "./analytics/token-info/service.js";
 import evmPlugin from "./chains/evm/index.js";
 import solanaPlugin from "./chains/solana/index.js";
+import { stewardTradingProvider } from "./providers/steward-trading-provider.js";
 import { walletProvider } from "./providers/wallet-provider.js";
+import { StewardTradingService } from "./services/steward-trading-service.js";
 import {
   WALLET_BACKEND_SERVICE_TYPE,
   WalletBackendService,
 } from "./services/wallet-backend-service.js";
-import { StewardTradingService } from "./services/steward-trading-service.js";
 
 const coreWalletPlugin: Plugin = {
   name: "wallet-backend",
   description: "Wallet backend service + wallet provider (Steward / local).",
   services: [WalletBackendService, StewardTradingService],
-  providers: [walletProvider],
-  actions: [],
+  providers: [walletProvider, stewardTradingProvider],
+  actions: [tradeRouterAction],
 };
 
 function concatServices(

--- a/plugins/plugin-wallet/src/providers/steward-trading-provider.test.ts
+++ b/plugins/plugin-wallet/src/providers/steward-trading-provider.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Provider coverage for Steward trading planner state. The provider is driven
+ * through the real StewardTradingService with sanitized HTTP fixtures so it
+ * proves capability/session exposure without live credentials or network.
+ */
+import type { IAgentRuntime, Memory, State } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { stewardFixtures } from "../services/__fixtures__/steward-trade-responses.js";
+import { StewardTradingService } from "../services/steward-trading-service.js";
+import { stewardTradingProvider } from "./steward-trading-provider.js";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function runtimeWithService(fetchMock: typeof fetch): IAgentRuntime {
+  const getService = vi.fn(() => null);
+  const runtime = {
+    agentId: "test-agent",
+    getSetting: vi.fn((key: string) => {
+      const settings: Record<string, string> = {
+        STEWARD_API_URL: "https://steward.local",
+        STEWARD_AGENT_ID: "agent-fixture",
+        STEWARD_AGENT_TOKEN: "token-fixture",
+        STEWARD_HYPERLIQUID_TRADE_SESSION_ID: "sess_hl_fixture",
+        STEWARD_POLYMARKET_TRADE_SESSION_ID: "sess_pm_fixture",
+      };
+      return settings[key];
+    }),
+    getService,
+  } as unknown as IAgentRuntime;
+  const service = new StewardTradingService(runtime, {
+    fetch: fetchMock,
+    sleep: async () => undefined,
+    maxRetries: 1,
+  });
+  getService.mockImplementation((name: string) =>
+    name === StewardTradingService.serviceType ? service : null,
+  );
+  return runtime;
+}
+
+describe("stewardTradingProvider", () => {
+  it("exposes capability and venue session status without secrets", async () => {
+    const activePolymarketSession = {
+      ok: true,
+      data: {
+        id: "sess_pm_fixture",
+        agentId: "agent-fixture",
+        venue: "polymarket",
+        walletAddress: "0x1111111111111111111111111111111111111111",
+        status: "active",
+      },
+    };
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/token-status")) {
+        return jsonResponse(200, stewardFixtures.tokenStatusObserved);
+      }
+      if (url.endsWith("/v1/trade/sessions/sess_hl_fixture")) {
+        return jsonResponse(200, stewardFixtures.activeHyperliquidSession);
+      }
+      if (url.endsWith("/v1/trade/sessions/sess_pm_fixture")) {
+        return jsonResponse(200, activePolymarketSession);
+      }
+      return jsonResponse(404, { ok: false, error: "unexpected route" });
+    });
+    const runtime = runtimeWithService(fetchMock as unknown as typeof fetch);
+
+    const result = await stewardTradingProvider.get(
+      runtime,
+      { content: {} } as Memory,
+      {} as State,
+    );
+
+    expect(result.values).toMatchObject({
+      stewardTradingReady: true,
+      stewardTradingCapability: "steward-self",
+      stewardTradingAgentId: "agent-fixture",
+    });
+    expect(result.values?.stewardTradingAccounts).toEqual([
+      {
+        venue: "hyperliquid",
+        status: "active",
+        accountId: "wallet_fixture",
+        sessionId: "sess_hl_fixture",
+      },
+      {
+        venue: "polymarket",
+        status: "active",
+        accountId: "0x1111111111111111111111111111111111111111",
+        sessionId: "sess_pm_fixture",
+      },
+    ]);
+    expect(JSON.stringify(result)).not.toContain("token-fixture");
+  });
+});

--- a/plugins/plugin-wallet/src/providers/steward-trading-provider.test.ts
+++ b/plugins/plugin-wallet/src/providers/steward-trading-provider.test.ts
@@ -5,6 +5,11 @@
  */
 import type { IAgentRuntime, Memory, State } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@elizaos/core", async () => {
+  return await import("../test-utils/core-vitest-mock.js");
+});
+
 import { stewardFixtures } from "../services/__fixtures__/steward-trade-responses.js";
 import { StewardTradingService } from "../services/steward-trading-service.js";
 import { stewardTradingProvider } from "./steward-trading-provider.js";

--- a/plugins/plugin-wallet/src/providers/steward-trading-provider.test.ts
+++ b/plugins/plugin-wallet/src/providers/steward-trading-provider.test.ts
@@ -7,7 +7,7 @@ import type { IAgentRuntime, Memory, State } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@elizaos/core", async () => {
-  return await import("../test-utils/core-vitest-mock.js");
+  return await import("../__tests__/core-vitest-mock.js");
 });
 
 import { stewardFixtures } from "../services/__fixtures__/steward-trade-responses.js";

--- a/plugins/plugin-wallet/src/providers/steward-trading-provider.ts
+++ b/plugins/plugin-wallet/src/providers/steward-trading-provider.ts
@@ -1,0 +1,118 @@
+/**
+ * Steward trading provider for planner context. It exposes configured trading
+ * capability and governed venue readiness without leaking bearer tokens,
+ * tenant secrets, SDK payloads, or raw venue responses.
+ */
+import type {
+  IAgentRuntime,
+  Memory,
+  Provider,
+  ProviderResult,
+  State,
+} from "@elizaos/core";
+import { StewardTradingService } from "../services/steward-trading-service.js";
+import type { TradingCapability, Venue } from "../types/trade.js";
+
+const VENUES = [
+  "hyperliquid",
+  "polymarket",
+] as const satisfies readonly Venue[];
+
+function serviceFromRuntime(
+  runtime: IAgentRuntime,
+): StewardTradingService | null {
+  const service = runtime.getService(StewardTradingService.serviceType);
+  if (
+    service &&
+    typeof (service as StewardTradingService).capability === "function" &&
+    typeof (service as StewardTradingService).resolveAccount === "function"
+  ) {
+    return service as StewardTradingService;
+  }
+  return null;
+}
+
+function summarizeCapability(capability: TradingCapability): string {
+  if (!capability.canTrade) return `Unavailable: ${capability.reason}`;
+  return `${capability.kind} configured for agent ${capability.agentId ?? "unknown"}`;
+}
+
+export const stewardTradingProvider: Provider = {
+  name: "stewardTrading",
+  description:
+    "Governed trading capability/session status for Hyperliquid and Polymarket.",
+  descriptionCompressed:
+    "Steward trading readiness for Hyperliquid/Polymarket; no secrets",
+  contexts: ["finance", "crypto", "wallet"],
+  contextGate: { anyOf: ["finance", "crypto", "wallet"] },
+  roleGate: { minRole: "OWNER" },
+  cacheStable: false,
+  cacheScope: "turn",
+  dynamic: true,
+  get: async (
+    runtime: IAgentRuntime,
+    _message: Memory,
+    _state: State,
+  ): Promise<ProviderResult> => {
+    void _message;
+    void _state;
+    const service = serviceFromRuntime(runtime);
+    if (!service) {
+      return {
+        text: "## Steward Trading\nSteward trading service is not running.",
+        values: { stewardTradingReady: false },
+      };
+    }
+
+    const capability = service.capability();
+    if (!capability.canTrade) {
+      return {
+        text: `## Steward Trading\n${summarizeCapability(capability)}`,
+        values: {
+          stewardTradingReady: false,
+          stewardTradingCapability: capability.kind,
+          stewardTradingReason: capability.reason,
+        },
+      };
+    }
+
+    const accounts = await Promise.all(
+      VENUES.map(async (venue) => {
+        const result = await service.resolveAccount(venue);
+        return result.ok
+          ? {
+              venue,
+              status: result.data.status,
+              accountId: result.data.accountId,
+              sessionId: result.audit.sessionId,
+            }
+          : {
+              venue,
+              status:
+                result.error === "SESSION_REQUIRED"
+                  ? "session_required"
+                  : result.outcome,
+              detail: result.detail,
+              retryable: result.retryable,
+            };
+      }),
+    );
+
+    const lines = accounts.map((account) =>
+      account.status === "active"
+        ? `- ${account.venue}: active (${account.accountId})`
+        : `- ${account.venue}: ${account.status}`,
+    );
+    return {
+      text: `## Steward Trading\n${summarizeCapability(capability)}\n${lines.join("\n")}`,
+      values: {
+        stewardTradingReady: accounts.some(
+          (account) => account.status === "active",
+        ),
+        stewardTradingCapability: capability.kind,
+        stewardTradingAgentId: capability.agentId,
+        stewardTradingAccounts: accounts,
+      },
+    };
+  },
+};

--- a/plugins/plugin-wallet/src/security/trade-confirmation.ts
+++ b/plugins/plugin-wallet/src/security/trade-confirmation.ts
@@ -1,0 +1,159 @@
+/**
+ * Confirmation metadata bridge for governed trade submission. The helper keeps
+ * the core confirmation record as the authority and binds one idempotency key
+ * to a logical order before the user sees the first confirmation prompt.
+ */
+import {
+  type HandlerCallback,
+  type IAgentRuntime,
+  type Memory,
+  requireConfirmation,
+} from "@elizaos/core";
+import { createTradeIdempotencyKey } from "../services/steward-trading-service.js";
+import type { SubmitOrderRequest } from "../types/trade.js";
+
+export const TRADE_CONFIRM_ACTION = "TRADE_ORDER";
+
+const DEFAULT_CONFIRMATION_TTL_MS = 5 * 60_000;
+
+export interface TradeConfirmationMetadata {
+  readonly venue: SubmitOrderRequest["venue"];
+  readonly sessionId: string;
+  readonly idempotencyKey: string;
+}
+
+export type TradeConfirmationDecision =
+  | { readonly status: "pending" }
+  | {
+      readonly status: "cancelled";
+      readonly metadata?: Record<string, unknown>;
+    }
+  | {
+      readonly status: "confirmed";
+      readonly metadata: TradeConfirmationMetadata;
+    };
+
+export type TradeIdempotencyKeyFactory = () => string;
+
+interface PendingConfirmationRecord {
+  readonly createdAt?: number;
+  readonly ttlMs?: number;
+}
+
+function confirmationCacheKey(
+  userId: string,
+  actionName: string,
+  pendingKey: string,
+): string {
+  return `confirmation:${userId}:${actionName}:${pendingKey}`;
+}
+
+function isFreshPendingRecord(
+  record: PendingConfirmationRecord | undefined,
+): boolean {
+  if (!record) return false;
+  if (typeof record.createdAt !== "number") return false;
+  const ttlMs =
+    typeof record.ttlMs === "number"
+      ? record.ttlMs
+      : DEFAULT_CONFIRMATION_TTL_MS;
+  return Date.now() - record.createdAt <= ttlMs;
+}
+
+function readMetadata(
+  value: Record<string, unknown> | undefined,
+): TradeConfirmationMetadata | null {
+  if (!value) return null;
+  const { venue, sessionId, idempotencyKey } = value;
+  if (
+    (venue !== "hyperliquid" && venue !== "polymarket") ||
+    typeof sessionId !== "string" ||
+    !sessionId.trim() ||
+    typeof idempotencyKey !== "string" ||
+    !idempotencyKey.trim()
+  ) {
+    return null;
+  }
+  return { venue, sessionId, idempotencyKey };
+}
+
+export function tradeOrderPendingKey(order: SubmitOrderRequest): string {
+  const entries =
+    order.venue === "hyperliquid"
+      ? [
+          ["venue", order.venue],
+          ["sessionId", order.sessionId],
+          ["coin", order.coin.toUpperCase()],
+          ["side", order.side],
+          ["size", String(order.size)],
+          ["limitPx", order.limitPx === undefined ? "" : String(order.limitPx)],
+          [
+            "leverage",
+            order.leverage === undefined ? "" : String(order.leverage),
+          ],
+          [
+            "reduceOnly",
+            order.reduceOnly === undefined ? "" : String(order.reduceOnly),
+          ],
+          ["tif", order.tif ?? ""],
+        ]
+      : [
+          ["venue", order.venue],
+          ["sessionId", order.sessionId],
+          ["tokenId", order.tokenId],
+          ["side", order.side],
+          ["amount", String(order.amount)],
+          ["price", String(order.price)],
+          ["tickSize", order.tickSize ?? ""],
+          ["negRisk", order.negRisk === undefined ? "" : String(order.negRisk)],
+        ];
+  return entries.map(([key, value]) => `${key}=${value}`).join("|");
+}
+
+export async function requireTradeOrderConfirmation(args: {
+  readonly runtime: IAgentRuntime;
+  readonly message: Memory;
+  readonly order: SubmitOrderRequest;
+  readonly prompt: string;
+  readonly callback?: HandlerCallback;
+  readonly keyFactory?: TradeIdempotencyKeyFactory;
+}): Promise<TradeConfirmationDecision> {
+  const pendingKey = tradeOrderPendingKey(args.order);
+  const cacheKey = confirmationCacheKey(
+    String(args.message.entityId),
+    TRADE_CONFIRM_ACTION,
+    pendingKey,
+  );
+  const existing =
+    await args.runtime.getCache<PendingConfirmationRecord>(cacheKey);
+
+  const metadata = isFreshPendingRecord(existing)
+    ? undefined
+    : {
+        venue: args.order.venue,
+        sessionId: args.order.sessionId,
+        idempotencyKey: (args.keyFactory ?? createTradeIdempotencyKey)(),
+      };
+
+  const decision = await requireConfirmation({
+    runtime: args.runtime,
+    message: args.message,
+    actionName: TRADE_CONFIRM_ACTION,
+    pendingKey,
+    prompt: args.prompt,
+    callback: args.callback,
+    metadata,
+  });
+
+  if (decision.status === "pending") return { status: "pending" };
+  if (decision.status === "cancelled") {
+    return { status: "cancelled", metadata: decision.metadata };
+  }
+  const confirmedMetadata = readMetadata(decision.metadata);
+  if (!confirmedMetadata) {
+    throw new Error(
+      "Trade confirmation metadata is missing its idempotency key; refusing to regenerate.",
+    );
+  }
+  return { status: "confirmed", metadata: confirmedMetadata };
+}

--- a/plugins/plugin-wallet/src/services/steward-trading-service.test.ts
+++ b/plugins/plugin-wallet/src/services/steward-trading-service.test.ts
@@ -7,7 +7,7 @@ import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@elizaos/core", async () => {
-  return await import("../test-utils/core-vitest-mock.js");
+  return await import("../__tests__/core-vitest-mock.js");
 });
 
 import { stewardFixtures } from "./__fixtures__/steward-trade-responses.js";

--- a/plugins/plugin-wallet/src/services/steward-trading-service.test.ts
+++ b/plugins/plugin-wallet/src/services/steward-trading-service.test.ts
@@ -5,6 +5,11 @@
  */
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@elizaos/core", async () => {
+  return await import("../test-utils/core-vitest-mock.js");
+});
+
 import { stewardFixtures } from "./__fixtures__/steward-trade-responses.js";
 import {
   STEWARD_TRADING_SERVICE_TYPE,

--- a/plugins/plugin-wallet/src/services/steward-trading-service.test.ts
+++ b/plugins/plugin-wallet/src/services/steward-trading-service.test.ts
@@ -106,6 +106,35 @@ describe("StewardTradingService", () => {
     );
   });
 
+  it("sends tenant API key alongside the agent bearer when both are configured", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse(200, stewardFixtures.tokenStatusObserved),
+    );
+    const service = new StewardTradingService(
+      runtime({
+        STEWARD_API_URL: "https://steward.local",
+        STEWARD_AGENT_ID: "agent-fixture",
+        STEWARD_AGENT_TOKEN: "token-fixture",
+        STEWARD_API_KEY: "tenant-key-fixture",
+        STEWARD_TENANT_ID: "tenant-fixture",
+      }),
+      {
+        fetch: fetchMock as unknown as typeof fetch,
+        sleep: async () => undefined,
+      },
+    );
+
+    await service.tokenStatus();
+
+    const headers = fetchMock.mock.calls[0]?.[1]?.headers as Record<
+      string,
+      string
+    >;
+    expect(headers.Authorization).toBe("Bearer token-fixture");
+    expect(headers["X-Steward-Key"]).toBe("tenant-key-fixture");
+    expect(headers["X-Steward-Tenant"]).toBe("tenant-fixture");
+  });
+
   it("opens sessions through the versioned route with Steward request names", async () => {
     const fetchMock = vi.fn(async () =>
       jsonResponse(201, stewardFixtures.openHyperliquidSession),

--- a/plugins/plugin-wallet/src/services/steward-trading-service.ts
+++ b/plugins/plugin-wallet/src/services/steward-trading-service.ts
@@ -787,7 +787,8 @@ export class StewardTradingService extends Service {
     };
     if (config.agentToken) {
       headers.Authorization = `Bearer ${config.agentToken}`;
-    } else if (config.apiKey) {
+    }
+    if (config.apiKey) {
       headers["X-Steward-Key"] = config.apiKey;
     }
     if (config.tenantId) headers["X-Steward-Tenant"] = config.tenantId;

--- a/plugins/plugin-wallet/src/test-utils/core-vitest-mock.ts
+++ b/plugins/plugin-wallet/src/test-utils/core-vitest-mock.ts
@@ -1,0 +1,103 @@
+/**
+ * Minimal core runtime surface for wallet unit tests that exercise plugin
+ * wiring without loading the full `@elizaos/core` source graph. Sparse CI lanes
+ * do not install every transitive core dependency, so tests import this through
+ * `vi.mock("@elizaos/core", ...)` before loading wallet modules.
+ */
+
+type RuntimeCache = {
+  getCache?<T>(key: string): Promise<T | undefined>;
+  setCache?(key: string, value: unknown): Promise<unknown>;
+  deleteCache?(key: string): Promise<unknown>;
+};
+
+export class Service {
+  static serviceType = "service";
+
+  readonly runtime: unknown;
+
+  constructor(runtime?: unknown) {
+    this.runtime = runtime;
+  }
+
+  static async start(runtime: unknown): Promise<Service> {
+    return new Service(runtime);
+  }
+
+  async stop(): Promise<void> {}
+}
+
+export const ServiceType = {
+  WALLET: "wallet",
+  TOKEN_DATA: "token-data",
+} as const;
+
+export const ModelType = {
+  TEXT_SMALL: "TEXT_SMALL",
+  TEXT_LARGE: "TEXT_LARGE",
+} as const;
+
+export const logger = {
+  debug: () => undefined,
+  error: () => undefined,
+  info: () => undefined,
+  log: () => undefined,
+  warn: () => undefined,
+};
+
+export const elizaLogger = logger;
+
+export function parseBooleanFromText(value: string): boolean {
+  return /^(1|true|yes|y|on)$/i.test(value.trim());
+}
+
+export function parseJSONObjectFromText(value: string): unknown {
+  return JSON.parse(value);
+}
+
+export function composePromptFromState(): string {
+  return "";
+}
+
+export function promoteSubactionsToActions(action: unknown): unknown[] {
+  return Array.isArray(action) ? action : [action];
+}
+
+export function registerAppRoutePluginLoader(): void {}
+
+export async function requireConfirmation(args: {
+  readonly runtime: RuntimeCache;
+  readonly message: { readonly entityId?: string; readonly content?: unknown };
+  readonly actionName: string;
+  readonly pendingKey: string;
+  readonly metadata?: Record<string, unknown>;
+}): Promise<{
+  readonly status: "pending" | "confirmed" | "cancelled";
+  readonly metadata?: Record<string, unknown>;
+}> {
+  const userId = String(args.message.entityId);
+  const cacheKey = `confirmation:${userId}:${args.actionName}:${args.pendingKey}`;
+  const existing = await args.runtime.getCache?.<{
+    metadata?: Record<string, unknown>;
+  }>(cacheKey);
+  const text =
+    typeof (args.message.content as { text?: unknown } | undefined)?.text ===
+    "string"
+      ? String((args.message.content as { text: string }).text).toLowerCase()
+      : "";
+
+  if (existing && /\b(yes|confirm|confirmed|approve)\b/.test(text)) {
+    await args.runtime.deleteCache?.(cacheKey);
+    return { status: "confirmed", metadata: existing.metadata };
+  }
+
+  if (!existing && args.metadata) {
+    await args.runtime.setCache?.(cacheKey, {
+      createdAt: Date.now(),
+      ttlMs: 5 * 60_000,
+      metadata: args.metadata,
+    });
+  }
+
+  return { status: "pending" };
+}

--- a/plugins/plugin-wallet/src/test-utils/core-vitest-mock.ts
+++ b/plugins/plugin-wallet/src/test-utils/core-vitest-mock.ts
@@ -11,6 +11,30 @@ type RuntimeCache = {
   deleteCache?(key: string): Promise<unknown>;
 };
 
+export class ElizaError extends Error {
+  readonly code: string;
+  readonly context?: Record<string, unknown>;
+  readonly severity?: "ephemeral" | "fatal";
+
+  constructor(
+    message: string,
+    options: {
+      code: string;
+      cause?: unknown;
+      context?: Record<string, unknown>;
+      severity?: "ephemeral" | "fatal";
+    },
+  ) {
+    super(
+      message,
+      options.cause === undefined ? undefined : { cause: options.cause },
+    );
+    this.code = options.code;
+    this.context = options.context;
+    this.severity = options.severity;
+  }
+}
+
 export class Service {
   static serviceType = "service";
 


### PR DESCRIPTION
## Summary

Stacked on #16068. Adds a production-registered native `TRADE` action and secret-safe Steward trading provider to `plugin-wallet`.

Supported operations:

- `inspect_account`
- `inspect_session`
- `submit_order`

Supported venues:

- Hyperliquid
- Polymarket

The action consumes the parent PR's `StewardTradingService`; it imports no venue SDKs, keys, raw venue payloads, or signing authority.

## Governance and confirmation

- action is hidden when Steward trading is unconfigured
- core-backed confirmation is mandatory before order submission
- one idempotency key is generated before confirmation
- the key is persisted in pending metadata and reused on the confirmed turn
- finite outcomes distinguish policy denial, missing session, rejection, retry-safe `not_attempted`, and poll/do-not-retry `unknown`
- provider exposes planner-useful capability/session state without API URL or credential leakage

## Verification

- exact changed-Vitest coverage: 6 files, 30 tests passed
- changed-source coverage: 83.68% mean, threshold 50%
- `trade-action.ts`: 69.40%
- lane coverage: 142 plugins scanned, no blocking issues
- focused Vitest, Biome, and `git diff --check`: passed
- Codex findings fixed: complete schema, service-error classification, unconfigured action visibility, confirmation/idempotency binding, clean-CI optional dependency traversal
- final Codex review: no actionable findings

No network calls, live orders, fund movement, signing, or production configuration changes.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots/visual baseline: N/A - no rendered UI source changed; this is a native action/provider runtime surface.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots/visual check: N/A - no rendered UI source changed; deterministic action/provider tests prove the behavior.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no rendered or interactive UI flow changed.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no live Steward or venue backend was called; the real service contract runs against injected deterministic responses.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend runtime or browser network surface changed.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - this PR changes deterministic action execution and confirmation contracts, not prompts, models, or provider trajectories; no live model was needed to prove the finite handler behavior.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [PR diff and deterministic action/provider contracts](https://github.com/elizaOS/eliza/pull/16070/files). Tests prove pending confirmation metadata, idempotency reuse, normalized trade envelopes, and secret-safe provider state.

## Stack

Base: #16068 / `feat/steward-trading-capability`

— [sol-orch]

