### PR TITLE
fix(ui): stabilize post-merge chat validation

### DIFF
--- a/packages/app/scripts/lib/playwright-node-options.test.ts
+++ b/packages/app/scripts/lib/playwright-node-options.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { withElizaSourceNodeOptions } from "../scripts/lib/playwright-node-options.mjs";
+import { withElizaSourceNodeOptions } from "./playwright-node-options.mjs";
 
 describe("withElizaSourceNodeOptions", () => {
   it("adds the source condition", () => {

--- a/packages/app/test/dev-smoke/live-onboarding.ts
+++ b/packages/app/test/dev-smoke/live-onboarding.ts
@@ -199,9 +199,22 @@ export async function seedCompletedFirstRunStorage(page: Page): Promise<void> {
 
 export async function gotoChatComposer(page: Page): Promise<Locator> {
   let lastError: unknown;
+  const composer = page.locator(CHAT_COMPOSER_SELECTOR).first();
+
+  // Reuse the live chat route between warm-up and the asserted turn. Reloading
+  // here can create a second conversation while startup is still resolving the
+  // previous active conversation, causing the UI to switch threads mid-send.
+  if (new URL(page.url()).pathname === "/chat") {
+    try {
+      await expect(composer).toBeVisible({ timeout: 5_000 });
+      return composer;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
   for (let attempt = 1; attempt <= 3; attempt += 1) {
     await page.goto("/chat");
-    const composer = page.locator(CHAT_COMPOSER_SELECTOR).first();
     try {
       await expect(composer).toBeVisible({ timeout: 90_000 });
       return composer;
@@ -220,7 +233,9 @@ export async function sendChat(page: Page, prompt: string): Promise<void> {
   const composer = await gotoChatComposer(page);
   await composer.fill(prompt);
   await composer.press("Enter");
-  const conversation = page.getByRole("log", { name: /conversation history/i });
+  const conversation = page.getByRole("region", {
+    name: /conversation history/i,
+  });
   await expect(conversation).toContainText(prompt, { timeout: 30_000 });
 }
 

--- a/packages/app/test/ui-smoke/assistant-home-flow.spec.ts
+++ b/packages/app/test/ui-smoke/assistant-home-flow.spec.ts
@@ -463,7 +463,7 @@ async function openHomeLauncher(page: Page): Promise<void> {
 }
 
 function conversationLog(page: Page) {
-  return page.getByRole("log", { name: /conversation history/i });
+  return page.getByRole("region", { name: /conversation history/i });
 }
 
 function conversationText(page: Page, text: string | RegExp) {

--- a/packages/app/test/ui-smoke/cloud-provisioning-startup.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-provisioning-startup.spec.ts
@@ -82,7 +82,7 @@ function chatSendButton(page: Page): Locator {
 }
 
 function conversationLog(page: Page): Locator {
-  return page.getByRole("log", { name: /conversation history/i });
+  return page.getByRole("region", { name: /conversation history/i });
 }
 
 function userMessage(page: Page, text: string): Locator {

--- a/packages/app/test/ui-smoke/live-agent-chat.spec.ts
+++ b/packages/app/test/ui-smoke/live-agent-chat.spec.ts
@@ -204,7 +204,7 @@ function chatSendButton(page: Page) {
 }
 
 function conversationLog(page: Page) {
-  return page.getByRole("log", { name: /conversation history/i });
+  return page.getByRole("region", { name: /conversation history/i });
 }
 
 function userMessage(page: Page, text: string) {

--- a/packages/app/test/ui-smoke/view-switching-chat-e2e.spec.ts
+++ b/packages/app/test/ui-smoke/view-switching-chat-e2e.spec.ts
@@ -394,7 +394,7 @@ function userMessage(page: Page, text: string): Locator {
     .last()
     .or(
       page
-        .getByRole("log", { name: /conversation history/i })
+        .getByRole("region", { name: /conversation history/i })
         .getByText(text)
         .last(),
     )

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -2463,7 +2463,7 @@ describe("ContinuousChatOverlay", () => {
     expect(toggleTranscriptionMode).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps the waveform available but neutral while the mic transcribes", () => {
+  it("keeps the waveform pressed but visually neutral while the mic transcribes", () => {
     render(
       <ContinuousChatOverlay
         controller={makeController({
@@ -2473,8 +2473,9 @@ describe("ContinuousChatOverlay", () => {
       />,
     );
     const waveform = screen.getByTestId("chat-composer-mic");
-    expect(waveform.getAttribute("aria-pressed")).toBe("false");
+    expect(waveform.getAttribute("aria-pressed")).toBe("true");
     expect(waveform.className).toContain("animate-pulse");
+    expect(waveform.className).toContain("text-muted-strong");
     expect(waveform.className).not.toContain("text-accent");
   });
 

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -494,6 +494,7 @@ function SoftButton({
   onPointerLeave,
   disabled,
   active,
+  pressed,
   pulse,
   testId,
 }: {
@@ -508,6 +509,8 @@ function SoftButton({
   onPointerLeave?: React.PointerEventHandler<HTMLButtonElement>;
   disabled?: boolean;
   active?: boolean;
+  /** Accessible toggle state when it is intentionally broader than the accent state. */
+  pressed?: boolean;
   /** Breathe the accent glyph while a live capture is hot. */
   pulse?: boolean;
   testId?: string;
@@ -518,7 +521,7 @@ function SoftButton({
       size="icon-lg"
       data-testid={testId}
       aria-label={label}
-      aria-pressed={active}
+      aria-pressed={pressed ?? active}
       // aria-disabled (not the native attr) so the button stays focusable and its
       // label/reason is announceable; the click is guarded instead.
       aria-disabled={disabled}
@@ -5917,6 +5920,10 @@ export function ContinuousChatOverlay({
                       // orange active state belongs only to conversation mode
                       // initiated by this waveform (or its push-to-talk hold).
                       active={handsFree || pttHolding}
+                      // Recording can also be owned by the adjacent transcription
+                      // control. Report the live voice state without coloring this
+                      // separate waveform control as active.
+                      pressed={recording || handsFree || transcriptionMode}
                       pulse={recording || handsFree || transcriptionMode}
                       onClick={handleMicClick}
                       onPointerDown={micHoldHandlers.onPointerDown}

--- a/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
@@ -3409,9 +3409,8 @@ try {
     await p.close();
   }
 
-  // ── STREAMING (bug 2): the in-flight (empty) assistant turn breathes the dots
-  // ANCHORED inside its own bubble, not as a detached "..." sibling — so the
-  // streamed text fills in right there.
+  // ── STREAMING: the in-flight assistant turn keeps the approved shimmering
+  // status marker inside its own bubble, where streamed text replaces it.
   {
     const p = await ctrl();
     attachConsole(p, sink);
@@ -3421,14 +3420,23 @@ try {
     // Open the thread so the in-flight assistant bubble is on screen.
     await gesture(p, 400, { pointer: "mouse", slow: false, steps: 1 });
     await p.waitForTimeout(SETTLE);
-    const dotsInBubble = await p
+    const statusInBubble = p
       .locator(
-        '[data-testid="thread-line"][data-role="assistant"] [data-testid="typing-dots"]',
-      )
-      .count();
+        '[data-testid="thread-line"][data-role="assistant"] [data-testid="turn-status-indicator"]',
+      );
     assert(
-      dotsInBubble >= 1,
-      `STREAMING: dots are anchored inside the in-flight assistant bubble (found ${dotsInBubble})`,
+      (await statusInBubble.count()) >= 1,
+      "STREAMING: status marker is anchored inside the in-flight assistant bubble",
+    );
+    assert(
+      await statusInBubble
+        .getByTestId("turn-status-label")
+        .evaluate((el) => el.className.includes("shimmer")),
+      "STREAMING: in-bubble status uses the approved shimmer treatment",
+    );
+    assert(
+      (await p.getByTestId("typing-dots").count()) === 0,
+      "STREAMING: legacy typing dots stay removed",
     );
     await snap(p, "state-streaming-dots-in-bubble");
     await p.close();
@@ -3544,14 +3552,9 @@ try {
     );
     await snap(p, "state-onboarding-full-screen");
 
-    // OPAQUE BACKDROP (#12178 impl / #12364 proof): a solid bg-bg plane covers
-    // the launcher/home so no launcher pixel shows through — the fixture's
-    // "Workspace" view content behind the chat must be fully hidden. Assert the
-    // backdrop is present, opaque, full-viewport, solid-colored, and that the
-    // real rendered pixel over the fixture heading reads as the dark onboarding
-    // layer rather than the orange home backdrop. The full-screen sheet may cover
-    // this coordinate above the backdrop, so this proves the user-visible
-    // invariant rather than one specific stacking-layer color.
+    // WALLPAPER SCRIM: onboarding preserves the configured wallpaper behind a
+    // full-viewport neutral dim layer. The element itself is fully applied while
+    // open, but its paint is translucent so the wallpaper remains visible.
     const backdrop = await p.evaluate(() => {
       const el = document.querySelector(
         '[data-testid="chat-first-run-backdrop"]',
@@ -3573,28 +3576,41 @@ try {
     );
     assert(
       backdrop.opaque === "true" && backdrop.opacity === "1",
-      `ONBOARDING: backdrop is fully opaque while onboarding is open (opaque ${backdrop?.opaque}, opacity ${backdrop?.opacity})`,
+      `ONBOARDING: wallpaper scrim is fully applied while onboarding is open (phase ${backdrop?.opaque}, opacity ${backdrop?.opacity})`,
     );
+    const scrim = parseColor(backdrop.bg);
     assert(
-      backdrop.bg !== "rgba(0, 0, 0, 0)" && backdrop.bg !== "transparent",
-      `ONBOARDING: backdrop paints a solid bg-bg color (got ${backdrop?.bg})`,
+      scrim !== null && scrim.a > 0 && scrim.a < 0.4,
+      `ONBOARDING: backdrop paints a subtle translucent scrim (got ${backdrop?.bg})`,
     );
     assert(
       backdrop.coversW && backdrop.coversH,
       "ONBOARDING: backdrop spans the whole viewport (inset-0)",
     );
-    const headingCenter = await p.evaluate(() => {
-      const h = document.querySelector('[data-testid="view-content"] h1');
-      const r = h.getBoundingClientRect();
-      return { x: Math.round(r.left + r.width / 2), y: Math.round(r.top + 4) };
-    });
-    const hidePx = await pixelAt(p, headingCenter.x, headingCenter.y);
-    // The onboarding surface over the heading may be the dark opaque backdrop
-    // OR the light full-screen panel (theme-dependent) — what it must NEVER be
-    // is the fixture's orange home backdrop showing through.
+    const wallpaper = parseColor(
+      await p
+        .getByTestId("fake-view")
+        .evaluate((el) => getComputedStyle(el).backgroundColor),
+    );
+    const scrimmedWallpaperPx = await pixelAt(p, 8, 8);
+    const expectedScrimmedWallpaper =
+      wallpaper && scrim
+        ? {
+            r: wallpaper.r * (1 - scrim.a) + scrim.r * scrim.a,
+            g: wallpaper.g * (1 - scrim.a) + scrim.g * scrim.a,
+            b: wallpaper.b * (1 - scrim.a) + scrim.b * scrim.a,
+          }
+        : null;
+    const scrimDelta = expectedScrimmedWallpaper
+      ? Math.max(
+          Math.abs(scrimmedWallpaperPx.r - expectedScrimmedWallpaper.r),
+          Math.abs(scrimmedWallpaperPx.g - expectedScrimmedWallpaper.g),
+          Math.abs(scrimmedWallpaperPx.b - expectedScrimmedWallpaper.b),
+        )
+      : Number.POSITIVE_INFINITY;
     assert(
-      !(hidePx.r > 200 && hidePx.g < 140 && hidePx.b < 90),
-      `ONBOARDING: launcher/home behind is hidden — pixel over the heading is an onboarding layer, not the orange home backdrop (got rgb(${hidePx.r}, ${hidePx.g}, ${hidePx.b}))`,
+      scrimDelta <= 8,
+      `ONBOARDING: configured wallpaper remains visible through the neutral scrim (max channel delta ${Math.round(scrimDelta)})`,
     );
     await snap(p, "state-onboarding-opaque-backdrop");
 
@@ -3613,10 +3629,17 @@ try {
       revealOpaque !== "true",
       `REVEAL: backdrop drops its opaque state after onboarding completes (got ${revealOpaque})`,
     );
-    const revealPx = await pixelAt(p, headingCenter.x, headingCenter.y);
+    const revealPx = await pixelAt(p, 8, 8);
+    const revealDelta = wallpaper
+      ? Math.max(
+          Math.abs(revealPx.r - wallpaper.r),
+          Math.abs(revealPx.g - wallpaper.g),
+          Math.abs(revealPx.b - wallpaper.b),
+        )
+      : Number.POSITIVE_INFINITY;
     assert(
-      !(revealPx.r < 40 && revealPx.g < 40 && revealPx.b < 50),
-      `REVEAL: the home surface is painted again once the backdrop reveals (pixel rgb(${revealPx.r}, ${revealPx.g}, ${revealPx.b}) is no longer the opaque bg)`,
+      revealDelta <= 8,
+      `REVEAL: the undimmed wallpaper is restored after onboarding (max channel delta ${Math.round(revealDelta)})`,
     );
     assert(
       (await detent(p)) === "half",


### PR DESCRIPTION
## Summary
- separate accessible mic pressed state from the waveform accent state
- align chat/onboarding browser assertions with the current shadcn message scroller and wallpaper scrim
- preserve the active conversation between live smoke turns instead of reloading `/chat` mid-run
- keep Bun-only Playwright helper coverage in the package script-test lane

## Validation
- `bun run --cwd packages/ui typecheck`
- `bun run --cwd packages/ui test ContinuousChatOverlay.test.tsx` (170 passed)
- `bun run --cwd packages/ui test:chat-sheet-e2e` (72 states passed)
- `bun run --cwd packages/app test` (493 Bun + 554 Vitest passed)
- real local dev smoke through onboarding, warm-up, send, and cloud-backed reply (passed)

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16073-after-desktop-mobile.jpg)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16074-after-desktop-mobile.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence/16074-chat-sheet-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend implementation or server route changed; the live smoke used the existing backend unchanged.

<!-- evidence-row:frontend-logs -->
- [x] [16074-frontend-validation.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16074-frontend-validation.log)

<!-- evidence-row:llm-trajectory -->
- [x] [16074-tj-967920188c39ae.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16074-tj-967920188c39ae.json)

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database, memory, scheduling, wallet, on-chain, audio, or device artifact contract changed.

<!-- evidence-row:ocr-review -->
- [x] [16074-ocr-visual-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16074-ocr-visual-review.txt)
