### PR TITLE
fix(ci): bootstrap Node before coverage classification

### DIFF
--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -40,6 +40,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  NODE_VERSION: "24.15.0"
+
 jobs:
   coverage:
     name: coverage on changed files
@@ -50,6 +53,13 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
+
+      - name: Setup Node.js for source classification
+        # The classifier is Node-based and runs before optional Bun workspace
+        # setup, including for JSON-only PRs on runners without system Node.
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Determine changed files
         id: changed

--- a/packages/scripts/__tests__/coverage-workflow-source-condition.test.ts
+++ b/packages/scripts/__tests__/coverage-workflow-source-condition.test.ts
@@ -23,3 +23,18 @@ test("changed Vitest coverage tests use package-aware source configuration", () 
     /node packages\/scripts\/run-changed-vitest-coverage[.]mjs "\$\{changed_tests\[@\]\}"/,
   );
 });
+
+test("Node is available before changed-source classification", () => {
+  const workflow = readFileSync(workflowPath, "utf8");
+  const setupNode = workflow.indexOf(
+    "- name: Setup Node.js for source classification",
+  );
+  const determineChanged = workflow.indexOf("- name: Determine changed files");
+
+  expect(setupNode).toBeGreaterThan(-1);
+  expect(workflow).toContain(
+    "uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",
+  );
+  expect(workflow).toContain("node-version: ${{ env.NODE_VERSION }}");
+  expect(setupNode).toBeLessThan(determineChanged);
+});


### PR DESCRIPTION
## Summary

- install the repository-pinned Node 24 runtime before the coverage workflow invokes its Node-based changed-source classifier
- preserve lightweight conditional Bun workspace setup
- pin workflow ordering with a focused regression assertion

## Root cause

`coverage-changed-files.sh` calls `coverage-source-classifier.mjs` during “Determine changed files,” before the optional workspace setup. Self-hosted runners without a system `node` therefore failed with exit 127 even for JSON-only registry PRs.

Fixes #16082.

## Validation

- `bun test packages/scripts/__tests__/coverage-workflow-source-condition.test.ts packages/scripts/__tests__/coverage-gate-test-only-pr.test.ts`: 10 passed, 34 assertions
- Biome: clean
- actionlint: clean
- `git diff --check`: clean

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - CI workflow/test change only; no rendered UI source changed.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - CI workflow/test change only; no rendered UI source changed.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no interactive product flow changed.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no runtime backend code changed; the failing Actions log is linked in #16082.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend code changed.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no model or agent behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no persistent domain state is produced.
