### PR TITLE
fix(cloud): forward Cerebras reasoning effort

### DIFF
--- a/packages/cloud/api/__tests__/chat-completions-optimistic-billing.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-optimistic-billing.test.ts
@@ -189,14 +189,18 @@ mock.module("@/lib/utils/credit-reservation", () => ({
 }));
 
 // Stub the model call so the handler returns right after the billing decision.
+// Keep spies so reasoning-effort tests can also assert the exact configuration
+// that survives the full route pipeline.
+const generateText = mock((_config: Record<string, unknown>) => {
+  throw new Error("model-call-stub");
+});
+const streamText = mock((_config: Record<string, unknown>) => {
+  throw new Error("model-call-stub");
+});
 mock.module("ai", () => ({
   ...aiActual,
-  generateText: () => {
-    throw new Error("model-call-stub");
-  },
-  streamText: () => {
-    throw new Error("model-call-stub");
-  },
+  generateText,
+  streamText,
 }));
 
 // Import the route AFTER the mocks so it binds to the stubs.
@@ -234,7 +238,10 @@ afterAll(() => {
   mock.module("@/lib/utils/credit-reservation", () => creditReservationActual);
 });
 
-function makeRequest(affiliateCode?: string): Request {
+function makeRequest(
+  affiliateCode?: string,
+  overrides: Record<string, unknown> = {},
+): Request {
   return new Request("https://api.test/api/v1/chat/completions", {
     method: "POST",
     headers: {
@@ -246,6 +253,7 @@ function makeRequest(affiliateCode?: string): Request {
       model: "gpt-4o-mini",
       messages: [{ role: "user", content: "hello" }],
       stream: false,
+      ...overrides,
     }),
   });
 }
@@ -290,6 +298,8 @@ describe("chat/completions optimistic-billing route decision (#9899/#10066)", ()
     createLedgerDebitSettler.mockClear();
     ledgerInnerSettler.mockClear();
     createCreditReservationSettler.mockClear();
+    generateText.mockClear();
+    streamText.mockClear();
   });
 
   test("eligible org takes the optimistic path: writes backstop, skips the synchronous reserve", async () => {
@@ -317,6 +327,52 @@ describe("chat/completions optimistic-billing route decision (#9899/#10066)", ()
     expect(pending.requestId).toMatch(UUID_RE);
     expect(pending.requestId).not.toBe(CLIENT_REQUEST_ID);
     expect(settler.requestId).toBe(pending.requestId);
+  });
+
+  test("invalid Cerebras reasoning_effort is rejected before billing or provider dispatch", async () => {
+    const res = await handleChatCompletionsPOST(
+      makeRequest(undefined, {
+        model: "openai/gpt-oss-120b:nitro",
+        reasoning_effort: "none",
+        max_tokens: 512,
+      }),
+      { skipOrgRateLimit: true },
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: {
+        message:
+          "reasoning_effort for model 'gpt-oss-120b' must be one of: low, medium, high",
+        type: "invalid_request_error",
+        code: "invalid_reasoning_effort",
+      },
+    });
+    expect(writePendingInferenceCharge).not.toHaveBeenCalled();
+    expect(reserveCredits).not.toHaveBeenCalled();
+    expect(generateText).not.toHaveBeenCalled();
+    expect(streamText).not.toHaveBeenCalled();
+  });
+
+  test("valid GLM reasoning_effort=none preserves max_tokens through the full route", async () => {
+    const res = await handleChatCompletionsPOST(
+      makeRequest(undefined, {
+        model: "zai-glm-4.7",
+        reasoning_effort: "none",
+        max_tokens: 512,
+      }),
+      { skipOrgRateLimit: true },
+    );
+
+    // The model stub throws after dispatch; reaching it proves the request
+    // passed route validation and billing without silently changing the cap.
+    expect(res.status).toBe(500);
+    expect(writePendingInferenceCharge).toHaveBeenCalledTimes(1);
+    expect(generateText).toHaveBeenCalledTimes(1);
+    expect(generateText.mock.calls[0]?.[0]).toMatchObject({
+      maxOutputTokens: 512,
+      providerOptions: { openai: { reasoningEffort: "none" } },
+    });
   });
 
   test("balance below SAFE_BALANCE_THRESHOLD falls back to the synchronous reserve", async () => {

--- a/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
@@ -525,7 +525,6 @@ describe("passthrough streaming — qualifying request pipes bytes verbatim and 
     });
     await res.text();
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     const sentBody = JSON.parse(init.body as string) as Record<string, unknown>;
     expect(sentBody.model).toBe(model);

--- a/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
@@ -34,6 +34,12 @@ const USER = "00000000-0000-4000-8000-0000000000bb";
 const MODEL = "openai/gpt-oss-120b";
 
 // --- module mocks (same boundaries as the sibling streaming suites) ---------
+let generateTextImpl: ((config: Record<string, unknown>) => unknown) | null =
+  null;
+const generateText = mock((config: Record<string, unknown>) => {
+  if (!generateTextImpl) throw new Error("generateTextImpl not set");
+  return generateTextImpl(config);
+});
 let streamTextImpl: ((config: Record<string, unknown>) => unknown) | null =
   null;
 const streamText = mock((config: Record<string, unknown>) => {
@@ -42,6 +48,7 @@ const streamText = mock((config: Record<string, unknown>) => {
 });
 mock.module("ai", () => ({
   ...aiActual,
+  generateText,
   streamText,
 }));
 
@@ -110,9 +117,13 @@ mock.module("@/lib/services/team-credential-pool", () => ({
 }));
 
 // Import the route AFTER the mocks so it binds to the stubs.
-const { __streamingCreditTestHooks, __passthroughStreamingTestHooks } =
-  await import("../v1/chat/completions/route");
+const {
+  __streamingCreditTestHooks,
+  __passthroughStreamingTestHooks,
+  __reasoningEffortTestHooks,
+} = await import("../v1/chat/completions/route");
 const { handleStreamingRequest } = __streamingCreditTestHooks;
+const { handleNonStreamingRequest } = __reasoningEffortTestHooks;
 const { qualifiesForPassthroughStreaming, mapPassthroughUpstreamStatus } =
   __passthroughStreamingTestHooks;
 
@@ -155,6 +166,7 @@ afterAll(() => {
 });
 
 beforeEach(() => {
+  generateText.mockClear();
   streamText.mockClear();
   billUsage.mockClear();
   recordUsageAnalytics.mockClear();
@@ -162,6 +174,7 @@ beforeEach(() => {
   poolRecordUse.mockClear();
   poolRecordProviderFailure.mockClear();
   fetchMock.mockClear();
+  generateTextImpl = null;
   streamTextImpl = null;
   fetchImpl = null;
   billUsageGate = null;
@@ -209,6 +222,7 @@ const QUALIFYING_REQUEST = {
 function callStreaming(
   settleReservation: (actualCost: number) => Promise<unknown> | unknown,
   options: {
+    model?: string;
     request?: unknown;
     estimatedInputTokens?: number;
     signal?: AbortSignal;
@@ -218,7 +232,7 @@ function callStreaming(
   } = {},
 ) {
   return handleStreamingRequest(
-    MODEL,
+    options.model ?? MODEL,
     undefined,
     [{ role: "user", content: "hello" }] as never,
     (options.request ?? QUALIFYING_REQUEST) as never,
@@ -240,6 +254,36 @@ function callStreaming(
     (options.pooledCredential ?? null) as never,
     false,
     options.executionCtx,
+  );
+}
+
+function callNonStreaming(model: string, reasoningEffort: "none" | "low") {
+  return handleNonStreamingRequest(
+    model,
+    undefined,
+    [{ role: "user", content: "hello" }] as never,
+    {
+      model,
+      messages: [{ role: "user", content: "hello" }],
+      reasoning_effort: reasoningEffort,
+    } as never,
+    { id: USER, organization_id: ORG },
+    null,
+    null,
+    "idem-1",
+    "req-1",
+    null,
+    Date.now(),
+    undefined,
+    30_000,
+    async () => null,
+    {} as never,
+    512,
+    {} as never,
+    "cerebras" as never,
+    null,
+    false,
+    undefined,
   );
 }
 
@@ -464,6 +508,30 @@ describe("passthrough streaming — qualifying request pipes bytes verbatim and 
     expect(passthroughUsage.outputTokens).toBe(sdkUsage.outputTokens);
     expect(passthroughUsage.totalTokens).toBe(sdkUsage.totalTokens);
   });
+
+  test("forwards validated reasoning_effort and the exact disabled-reasoning cap", async () => {
+    fetchImpl = async () => sseResponse(UPSTREAM_SSE);
+    const model = "zai-glm-4.7";
+    const res = await callStreaming(async () => null, {
+      model,
+      request: {
+        model,
+        messages: [{ role: "user", content: "hello" }],
+        stream: true,
+        stream_options: { include_usage: true },
+        reasoning_effort: "none",
+      },
+      effectiveMaxTokens: 512,
+    });
+    await res.text();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const sentBody = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(sentBody.model).toBe(model);
+    expect(sentBody.reasoning_effort).toBe("none");
+    expect(sentBody.max_tokens).toBe(512);
+  });
 });
 
 describe("passthrough streaming — fallthrough to the SDK path", () => {
@@ -541,6 +609,53 @@ describe("passthrough streaming — fallthrough to the SDK path", () => {
     expect(streamText).toHaveBeenCalledTimes(1);
     expect(body).toContain("Hello");
     expect(res.headers.get("X-Eliza-Inference-Path")).toBeNull();
+  });
+
+  test("SDK streaming forwards reasoning_effort through OpenAI provider options", async () => {
+    sdkFaithfulStream();
+    const model = "zai-glm-4.7";
+    const res = await callStreaming(async () => null, {
+      model,
+      request: {
+        model,
+        messages: [{ role: "user", content: "hello" }],
+        stream: true,
+        stream_options: { include_usage: true },
+        reasoning_effort: "none",
+        tools: [
+          {
+            type: "function",
+            function: { name: "get_weather", parameters: {} },
+          },
+        ],
+      },
+      effectiveMaxTokens: 512,
+    });
+    await res.text();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(streamText).toHaveBeenCalledTimes(1);
+    expect(streamText.mock.calls[0]?.[0]).toMatchObject({
+      maxOutputTokens: 512,
+      providerOptions: { openai: { reasoningEffort: "none" } },
+    });
+  });
+
+  test("SDK non-streaming forwards reasoning_effort through OpenAI provider options", async () => {
+    generateTextImpl = () => ({
+      text: "Hello",
+      toolCalls: [],
+      finishReason: "stop",
+      usage: { inputTokens: 72, outputTokens: 1, totalTokens: 73 },
+    });
+
+    const res = await callNonStreaming("zai-glm-4.7", "none");
+    expect(res.status).toBe(200);
+    expect(generateText).toHaveBeenCalledTimes(1);
+    expect(generateText.mock.calls[0]?.[0]).toMatchObject({
+      maxOutputTokens: 512,
+      providerOptions: { openai: { reasoningEffort: "none" } },
+    });
   });
 
   test("missing provider key → SDK path (no half-configured passthrough)", async () => {

--- a/packages/cloud/api/__tests__/chat-completions-tool-choice.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-tool-choice.test.ts
@@ -21,6 +21,8 @@ const {
   mapToolChoice,
   convertTools,
   computeEffectiveMaxTokens,
+  validateCerebrasReasoningEffort,
+  buildReasoningEffortProviderOptions,
   toOpenAiFinishReason,
 } = __nativeToolingTestHooks;
 
@@ -145,6 +147,37 @@ describe("computeEffectiveMaxTokens", () => {
     );
   });
 
+  test("reasoning disabled: preserves the caller's exact max_tokens", () => {
+    expect(
+      computeEffectiveMaxTokens(260, null, "zai-glm-4.7", undefined, "none"),
+    ).toBe(260);
+    expect(
+      computeEffectiveMaxTokens(
+        512,
+        null,
+        "cerebras:gemma-4-31b",
+        undefined,
+        "none",
+      ),
+    ).toBe(512);
+  });
+
+  test("Gemma's omitted reasoning_effort uses its no-reasoning default", () => {
+    expect(computeEffectiveMaxTokens(512, null, "gemma-4-31b")).toBe(512);
+  });
+
+  test("active Cerebras reasoning retains the response-token floor", () => {
+    expect(
+      computeEffectiveMaxTokens(512, null, "gemma-4-31b", undefined, "low"),
+    ).toBe(MIN_RESPONSE_TOKENS);
+    expect(computeEffectiveMaxTokens(512, null, "zai-glm-4.7")).toBe(
+      MIN_RESPONSE_TOKENS,
+    );
+    expect(
+      computeEffectiveMaxTokens(512, null, "gpt-oss-120b", undefined, "low"),
+    ).toBe(MIN_RESPONSE_TOKENS);
+  });
+
   test("Anthropic CoT budget: reserves response capacity beyond the thinking budget", () => {
     // cotBudget=8000 -> must be at least 8000 + MIN_RESPONSE_TOKENS regardless of
     // a smaller requested max_tokens.
@@ -184,6 +217,61 @@ describe("computeEffectiveMaxTokens", () => {
         "temperature",
       ]),
     ).toBe(50);
+  });
+});
+
+describe("Cerebras reasoning_effort validation", () => {
+  test.each([
+    ["gemma-4-31b", "none"],
+    ["gemma-4-31b", "low"],
+    ["gemma-4-31b", "medium"],
+    ["gemma-4-31b", "high"],
+    ["gpt-oss-120b", "low"],
+    ["gpt-oss-120b", "medium"],
+    ["gpt-oss-120b", "high"],
+    ["zai-glm-4.7", "none"],
+  ])("accepts %s reasoning_effort=%s", (model, effort) => {
+    expect(validateCerebrasReasoningEffort(model, effort)).toEqual({
+      ok: true,
+      value: effort,
+    });
+  });
+
+  test("canonicalizes decorated Cerebras ids before validation", () => {
+    expect(
+      validateCerebrasReasoningEffort("openai/gpt-oss-120b:nitro", "high"),
+    ).toEqual({ ok: true, value: "high" });
+  });
+
+  test.each([undefined, null])("treats %s as provider default", (effort) => {
+    expect(validateCerebrasReasoningEffort("zai-glm-4.7", effort)).toEqual({
+      ok: true,
+      value: undefined,
+    });
+  });
+
+  test.each([
+    ["zai-glm-4.7", "low"],
+    ["gpt-oss-120b", "none"],
+    ["gemma-4-31b", "minimal"],
+    ["gemma-4-31b", 1],
+  ])("rejects %s reasoning_effort=%s", (model, effort) => {
+    expect(validateCerebrasReasoningEffort(model, effort)).toMatchObject({
+      ok: false,
+    });
+  });
+
+  test("rejects reasoning_effort for a non-Cerebras model", () => {
+    expect(
+      validateCerebrasReasoningEffort("openai/gpt-4o-mini", "low"),
+    ).toMatchObject({ ok: false });
+  });
+
+  test("builds the AI SDK provider option that maps to wire reasoning_effort", () => {
+    expect(buildReasoningEffortProviderOptions("none")).toEqual({
+      providerOptions: { openai: { reasoningEffort: "none" } },
+    });
+    expect(buildReasoningEffortProviderOptions(undefined)).toEqual({});
   });
 });
 

--- a/packages/cloud/api/__tests__/chat-completions-tool-choice.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-tool-choice.test.ts
@@ -230,7 +230,7 @@ describe("Cerebras reasoning_effort validation", () => {
     ["gpt-oss-120b", "medium"],
     ["gpt-oss-120b", "high"],
     ["zai-glm-4.7", "none"],
-  ])("accepts %s reasoning_effort=%s", (model, effort) => {
+  ] as const)("accepts %s reasoning_effort=%s", (model, effort) => {
     expect(validateCerebrasReasoningEffort(model, effort)).toEqual({
       ok: true,
       value: effort,

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -203,6 +203,70 @@ function buildChatPromptForBilling(request: ChatRequest): string {
     .join("\n");
 }
 
+type ReasoningEffort = "none" | "low" | "medium" | "high";
+
+const CEREBRAS_REASONING_EFFORTS = {
+  "gemma-4-31b": ["none", "low", "medium", "high"],
+  "gpt-oss-120b": ["low", "medium", "high"],
+  "zai-glm-4.7": ["none"],
+} as const satisfies Record<string, readonly ReasoningEffort[]>;
+
+type ReasoningEffortValidation =
+  | { ok: true; value: ReasoningEffort | undefined }
+  | { ok: false; message: string };
+
+/**
+ * Validate the OpenAI-compatible reasoning knob against Cerebras's per-model
+ * contract before reserving credits or contacting the provider.
+ *
+ * Cerebras intentionally exposes different values for each served model:
+ * Gemma can toggle reasoning, GPT-OSS always reasons at a selected effort, and
+ * GLM accepts only `none` as an explicit override (omission enables reasoning).
+ * Treat `null` like omission, matching the nullable upstream API field.
+ * Source: https://inference-docs.cerebras.ai/capabilities/reasoning
+ */
+function validateCerebrasReasoningEffort(
+  model: string,
+  value: unknown,
+): ReasoningEffortValidation {
+  if (value == null) return { ok: true, value: undefined };
+
+  const modelId = canonicalizeCerebrasModelId(model);
+  const allowed =
+    CEREBRAS_REASONING_EFFORTS[
+      modelId as keyof typeof CEREBRAS_REASONING_EFFORTS
+    ];
+  if (!allowed) {
+    return {
+      ok: false,
+      message: `reasoning_effort is not supported for model '${model}'`,
+    };
+  }
+  if (
+    typeof value !== "string" ||
+    !(allowed as readonly string[]).includes(value)
+  ) {
+    return {
+      ok: false,
+      message: `reasoning_effort for model '${modelId}' must be one of: ${allowed.join(", ")}`,
+    };
+  }
+  return { ok: true, value: value as ReasoningEffort };
+}
+
+/** AI SDK's OpenAI provider maps this option to wire `reasoning_effort`. */
+function buildReasoningEffortProviderOptions(
+  reasoningEffort: ReasoningEffort | undefined,
+): Record<string, unknown> {
+  return reasoningEffort
+    ? {
+        providerOptions: {
+          openai: { reasoningEffort },
+        },
+      }
+    : {};
+}
+
 /**
  * Computes effective max_tokens, reserving response capacity for reasoning models.
  *
@@ -213,8 +277,10 @@ function buildChatPromptForBilling(request: ChatRequest): string {
  * the consumed tokens. To prevent that:
  *   - Anthropic CoT: max_tokens must be >= thinking budget + response capacity
  *     (the API also hard-rejects max_tokens < thinking budget).
- *   - Any other reasoning model: floor max_tokens at MIN_RESPONSE_TOKENS so there
- *     is always room for an answer after the reasoning.
+ *   - Any other model with reasoning active: floor max_tokens at
+ *     MIN_RESPONSE_TOKENS so there is always room for an answer after reasoning.
+ *   - When reasoning is disabled (including Gemma's default), preserve the
+ *     caller's cap exactly.
  *
  * `model` is the requested model id (provider-prefixed is fine).
  */
@@ -223,6 +289,7 @@ function computeEffectiveMaxTokens(
   cotBudget: number | null,
   model: string,
   supportedParameters?: readonly string[],
+  reasoningEffort?: ReasoningEffort,
 ): number | undefined {
   if (cotBudget !== null) {
     // When CoT is active, ensure max_tokens covers both thinking budget AND response capacity
@@ -231,6 +298,16 @@ function computeEffectiveMaxTokens(
       requestMaxTokens ?? MIN_RESPONSE_TOKENS,
       cotBudget + MIN_RESPONSE_TOKENS,
     );
+  }
+  const cerebrasModel = canonicalizeCerebrasModelId(model);
+  if (
+    reasoningEffort === "none" ||
+    (reasoningEffort === undefined && cerebrasModel === "gemma-4-31b")
+  ) {
+    // No hidden reasoning tokens consume the caller's output budget. Preserve
+    // the advertised max_tokens contract exactly instead of silently raising a
+    // short formatting call (often 260-512 tokens) to 4096.
+    return requestMaxTokens;
   }
   if (modelUsesReasoningTokens(model, supportedParameters)) {
     // Non-Anthropic reasoning model. Guarantee at least MIN_RESPONSE_TOKENS so the
@@ -277,6 +354,8 @@ interface ChatRequest {
   top_p?: number;
   frequency_penalty?: number;
   presence_penalty?: number;
+  /** Cerebras model-specific control for hidden reasoning generation. */
+  reasoning_effort?: ReasoningEffort | null;
   stream?: boolean;
   /**
    * OpenAI `stream_options`: when `include_usage` is true the stream carries
@@ -1090,6 +1169,28 @@ export async function handleChatCompletionsPOST(
     // by dedicated agents) to the bare Cerebras id so pricing, routing, and
     // billing all agree and route to cerebras-direct instead of OpenRouter.
     model = canonicalizeCerebrasModelId(request.model);
+    const reasoningEffortValidation = validateCerebrasReasoningEffort(
+      model,
+      request.reasoning_effort,
+    );
+    if (!reasoningEffortValidation.ok) {
+      return addCorsHeaders(
+        Response.json(
+          {
+            error: {
+              message: reasoningEffortValidation.message,
+              type: "invalid_request_error",
+              code: "invalid_reasoning_effort",
+            },
+          },
+          { status: 400 },
+        ),
+      );
+    }
+    const reasoningEffort = reasoningEffortValidation.value;
+    // Normalize nullable omission once so every downstream path (passthrough,
+    // SDK streaming, and SDK generation) observes the same validated value.
+    request.reasoning_effort = reasoningEffort;
     const provider = getProviderFromModel(model);
     const normalizedModel = normalizeModelName(model);
     const cotBudget = resolveAnthropicThinkingBudgetTokens(model, process.env);
@@ -1174,6 +1275,7 @@ export async function handleChatCompletionsPOST(
       cotBudget,
       model,
       modelSupportedParameters,
+      reasoningEffort,
     );
     const webSearchEnabled = request.webSearchEnabled === true;
     const webSearchActive = isAnthropicWebSearchEnabled(
@@ -2068,6 +2170,9 @@ async function tryPassthroughStreamingRequest(params: {
   if (safeParams.stopSequences?.length) {
     upstreamBody.stop = safeParams.stopSequences;
   }
+  if (request.reasoning_effort !== undefined) {
+    upstreamBody.reasoning_effort = request.reasoning_effort;
+  }
   if (params.effectiveMaxTokens != null) {
     upstreamBody.max_tokens = params.effectiveMaxTokens;
   }
@@ -2390,6 +2495,9 @@ async function handleStreamingRequest(
         : [request.stop]
       : undefined,
   });
+  const reasoningProviderOptions = buildReasoningEffortProviderOptions(
+    request.reasoning_effort ?? undefined,
+  );
 
   const result = streamText({
     model: getLanguageModel(model, pooledCredential ?? undefined),
@@ -2404,6 +2512,7 @@ async function handleStreamingRequest(
     ...(experimentalOutput ? { output: experimentalOutput } : {}),
     ...(effectiveMaxTokens != null && { maxOutputTokens: effectiveMaxTokens }),
     ...cotOptions,
+    ...reasoningProviderOptions,
     // Parity with the non-streaming path (#8759): the settlement chain below
     // (billUsage → settleReservation → analytics → audit) is 5+ serial DB
     // round-trips, and the AI SDK awaits onFinish before it ends fullStream —
@@ -2858,6 +2967,9 @@ async function handleNonStreamingRequest(
         : [request.stop]
       : undefined,
   });
+  const reasoningProviderOptions = buildReasoningEffortProviderOptions(
+    request.reasoning_effort ?? undefined,
+  );
 
   try {
     const result = await generateText({
@@ -2875,6 +2987,7 @@ async function handleNonStreamingRequest(
         maxOutputTokens: effectiveMaxTokens,
       }),
       ...cotOptions,
+      ...reasoningProviderOptions,
     } as Parameters<typeof generateText>[0]);
 
     // Token counts for the OpenAI-compat response come straight from the
@@ -3100,7 +3213,14 @@ export const __nativeToolingTestHooks = {
   mapToolChoice,
   convertTools,
   computeEffectiveMaxTokens,
+  validateCerebrasReasoningEffort,
+  buildReasoningEffortProviderOptions,
   toOpenAiFinishReason,
+} as const;
+
+/** Test seam for the non-streaming AI SDK forwarding contract. */
+export const __reasoningEffortTestHooks = {
+  handleNonStreamingRequest,
 } as const;
 
 /**


### PR DESCRIPTION
Fixes #16080. Partially addresses #16081 and provides live evidence for #16079.

## Summary

The Cloud gateway accepted `reasoning_effort` in its schema but dropped it before Cerebras. GLM-4.7 therefore kept its default hidden reasoning when callers requested `none`, increasing time to visible content and consuming output budget.

This change:

- validates model-specific Cerebras reasoning controls after canonicalization;
- forwards the exact value through pass-through, AI SDK streaming, and AI SDK non-streaming paths;
- preserves an explicit caller token cap when reasoning is disabled;
- treats omitted Gemma reasoning as Gemma's provider-default no-reasoning mode;
- retains the existing 4096 safety floor when reasoning remains active.

Unsupported model/value combinations fail with HTTP 400 before billing/provider dispatch instead of being silently ignored.

## Current base and verification

- Current base: `307988a7dd93b4d4c878c3f519eb10a9ed1a0cff` (`develop`).
- Current head: `d351a746a3c33e9337b595a9dbd7a007c5e57937`.
- `git range-diff` proves all four commits are patch-identical to the exact live-tested head `f1fd02a904f96c2515e8f5be4af76ec854b36dab`; the intervening base change does not touch these Cloud files.
- Focused suite: 88/88 tests, 256 assertions.
- Changed-source coverage: 68.07% for `chat/completions/route.ts` (50% required).
- Cloud Worker typecheck/dry-run, Biome, `audit:test-realness`, and diff checks pass.
- Exact-head GitHub CI is the merge gate for the final rebased head.

## Exact staging and real-model evidence

- [Exact f1fd staging deploy, health check, and routing verification](https://github.com/elizaOS/eliza/actions/runs/29167392253)
- [Hardened paired Cerebras run 29167994915](https://github.com/elizaOS/eliza/actions/runs/29167994915)
- [Live job](https://github.com/elizaOS/eliza/actions/runs/29167994915/job/86584408510)
- [Privacy-safe exact-SHA JSONL artifact](https://github.com/elizaOS/eliza/actions/runs/29167994915/artifacts/8252811951)

The run verified `f1fd02a…` before paid requests. Its probe completed at 21:12:31 UTC; the later unrelated `develop` Worker did not deploy until 21:13:28 UTC, so all samples were served by the exact tested candidate.

Integrity results:

- 320/320 HTTP 200 records; 0 transport, malformed SSE, missing `[DONE]`, or missing finish-reason failures;
- 160 valid direct/gateway pairs, exactly balanced by target-first order;
- 30 warm pairs per case plus cold and genuinely post-idle samples;
- one clean semantic proof miss (0.3125%), below the declared 5% limit;
- privacy scan found no credential, authorization, prompt, output text, or arbitrary provider body.

Reasoning correctness across cold, warm, and post-idle samples:

- GLM-4.7 `none` at 512 and 4096: zero hidden-reasoning frames on direct and gateway paths;
- GLM-4.7 omitted reasoning: hidden-reasoning frames on every direct and gateway completion;
- Gemma omitted and `none`: zero hidden-reasoning frames on both paths.

Warm TTFT p50 (direct → gateway; paired gateway overhead):

| case | direct | gateway | paired delta |
| --- | ---: | ---: | ---: |
| Gemma `none` / 512 | 87 ms | 472 ms | +380 ms |
| Gemma omitted / 512 | 91 ms | 962 ms | +869 ms |
| GLM `none` / 4096 | 109 ms | 485 ms | +367 ms |
| GLM `none` / 512 | 101 ms | 973 ms | +849 ms |
| GLM omitted / 4096 | 323 ms | 587 ms | +170 ms |

The live data proves the reasoning fix. It also shows a separate observability/performance gap: `Server-Timing` is absent, and post-idle gateway TTFT remains 4.48–5.49 seconds versus 0.086–0.365 seconds direct. Truthful hop timing remains tracked in #16079/#16098 and is not hidden by this PR.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - backend-only provider request handling; no rendered UI changes.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - backend-only provider request handling; no rendered UI changes.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no interactive or visual surface changed.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: [exact deploy and routing logs](https://github.com/elizaOS/eliza/actions/runs/29167392253) plus the [exact live job](https://github.com/elizaOS/eliza/actions/runs/29167994915/job/86584408510).

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend/browser code changed.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: [320-record Gemma/GLM direct+gateway run](https://github.com/elizaOS/eliza/actions/runs/29167994915) with exact-SHA health verification.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [privacy-safe JSONL artifact](https://github.com/elizaOS/eliza/actions/runs/29167994915/artifacts/8252811951), upload digest `f3e70a4dbe33495c8e156ffa205217c6c6671f6aa0023f314332aac472fe2155`.

## Deploy notes

No manual production deployment is requested. Merge to `develop`; production promotion remains on the normal guarded path.
