### PR TITLE
fix(plugin-elizacloud): stop logging full prompts

### DIFF
--- a/plugins/plugin-elizacloud/__tests__/text-streaming.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/text-streaming.test.ts
@@ -9,7 +9,7 @@
  * No live API — `requestRaw` is mocked to return constructed `Response`s.
  */
 import type { IAgentRuntime, ResponseSkeleton } from "@elizaos/core";
-import { ResponseSkeletonStreamExtractor } from "@elizaos/core";
+import { logger, ResponseSkeletonStreamExtractor } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 type Deferred = {
@@ -59,6 +59,7 @@ import {
   buildStreamAbortSignal,
   finalizeStreamedToolCalls,
   handleResponseHandler,
+  handleTextSmall,
   parseOpenAiSseStream,
   resolveStreamingEnabled,
   resolveTextTimeoutMs,
@@ -846,6 +847,41 @@ describe("cloud streaming gate decision (wantsStream)", () => {
       prompt: "hi",
     } as never);
     expect(lastJson().max_output_tokens).toBe(8192);
+  });
+
+  it("never logs rendered prompt content while preserving the provider request", async () => {
+    const promptMarker = "secret-prompt-marker-16083";
+    const loggerSpies = [
+      vi.spyOn(logger, "trace").mockImplementation(() => undefined),
+      vi.spyOn(logger, "debug").mockImplementation(() => undefined),
+      vi.spyOn(logger, "info").mockImplementation(() => undefined),
+      vi.spyOn(logger, "warn").mockImplementation(() => undefined),
+      vi.spyOn(logger, "error").mockImplementation(() => undefined),
+      vi.spyOn(logger, "fatal").mockImplementation(() => undefined),
+      vi.spyOn(logger, "success").mockImplementation(() => undefined),
+      vi.spyOn(logger, "progress").mockImplementation(() => undefined),
+      vi.spyOn(logger, "log").mockImplementation(() => undefined),
+    ];
+
+    try {
+      nextResponse = bufferedChatResponse("safe response");
+      await expect(
+        handleTextSmall(fakeRuntime(), {
+          prompt: "fallback prompt",
+          messages: [{ role: "user", content: promptMarker }],
+        } as never)
+      ).resolves.toMatchObject({ text: "safe response" });
+
+      expect(JSON.stringify(lastJson())).toContain(promptMarker);
+      expect(JSON.stringify(loggerSpies.flatMap((spy) => spy.mock.calls))).not.toContain(
+        promptMarker
+      );
+      expect(loggerSpies.at(-1)).toHaveBeenCalledWith(
+        expect.stringContaining("Using TEXT_SMALL model")
+      );
+    } finally {
+      for (const spy of loggerSpies) spy.mockRestore();
+    }
   });
 });
 

--- a/plugins/plugin-elizacloud/src/models/text.ts
+++ b/plugins/plugin-elizacloud/src/models/text.ts
@@ -1014,7 +1014,6 @@ async function generateTextWithModel(
     resolveStreamingEnabled();
 
   logger.log(`[ELIZAOS_CLOUD] Using ${modelType} model: ${modelName}`);
-  logger.log(prompt);
 
   if (hasNativeTransportOptions(paramsWithNative)) {
     if (wantsStream) {


### PR DESCRIPTION
# Relates to

Fixes #16083.

- [x] This PR targets `develop` and was based on the latest `origin/develop` with zero conflicts.
- [ ] Root `bun run verify` has not been run; focused plugin tests, typecheck, Biome, and policy checks pass.
- [x] The regression test demonstrates both sides of the contract: the prompt reaches the provider request but never the logger.

# Sync with develop

- [x] Latest `origin/develop` was fetched and the branch had `0 0` divergence before commit.
- [ ] Full root verification remains a pre-merge follow-up; package-scoped checks are green.

# Risks

Low. The production change removes one unbounded log call. The provider request and bounded model diagnostics remain unchanged and are asserted by the regression test.

# Background

## What does this PR do?

Removes `logger.log(prompt)` from the ElizaCloud text-model adapter. Rendered prompts can contain user messages, system instructions, and tool context, none of which should be copied into ordinary application logs.

The regression added to the existing text-adapter suite places a unique marker in the rendered input and proves:

- the marker is still sent in the intended provider request;
- no logger level receives the marker;
- bounded model/type diagnostics remain available.

## What kind of change is this?

Bug fix (privacy and logging correctness).

# Documentation changes needed?

No. This restores the expected logging policy without changing the public API.

# Testing

## Where should a reviewer start?

Start with the prompt-logging regression in `plugins/plugin-elizacloud/__tests__/text-streaming.test.ts`, then confirm the one-line removal in `src/models/text.ts`.

## Detailed testing steps

- `node packages/scripts/run-changed-vitest-coverage.mjs plugins/plugin-elizacloud/__tests__/text-streaming.test.ts` — 36/36 tests passed.
- Enforced changed-file coverage — `text.ts` 66.61%, above the 50% threshold.
- `bun run --cwd plugins/plugin-elizacloud typecheck` — passed.
- Biome check on both changed files — passed.
- Error-policy ratchet — passed.
- `git diff --check` — passed.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A — backend logging only; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A — backend logging only; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A — no interactive user flow changed.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no live deployment is required for a removed local log side effect; the focused regression captures every logger level and proves the unique prompt marker is absent while bounded model diagnostics remain.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A — no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A — the provider request and prompt are unchanged; only an application log side effect is removed, and the test explicitly proves the request body still contains the rendered marker.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A — no persisted data or generated artifacts changed.

# Evidence Details

## Real LLM-call trajectory

N/A — model selection, prompt rendering, and provider request transmission are unchanged. A live model call cannot provide stronger evidence about a removed local logger call than the logger-spy/provider-body regression.

## Backend + frontend logs

The regression spies on `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `success`, `progress`, and `log`; the secret marker appears in the captured provider request and in none of the captured logger arguments.

## Screenshots (before / after) + video walkthrough

N/A — backend-only logging change.

## Audio / voice walkthrough

N/A — no voice, TTS, or STT code changed.

## Known gaps / failures

- Root `bun run verify` has not been run. Focused regression tests, adjacent plugin tests, plugin typecheck, Biome, error-policy ratchet, and diff checks pass.

# Deploy Notes

No migration or manual configuration is required. Normal plugin release/deployment is sufficient.
