### PR TITLE
fix(app): restore remote auth and subscription OAuth

### DIFF
--- a/packages/agent/src/api/accounts-routes.ts
+++ b/packages/agent/src/api/accounts-routes.ts
@@ -25,7 +25,11 @@
  * powers.
  */
 
+import { execFile } from "node:child_process";
 import nodeCrypto from "node:crypto";
+import { access } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
 import {
   type AccountCredentialRecord,
   deleteAccount,
@@ -68,6 +72,51 @@ import type { ElizaConfig } from "../config/types.eliza.ts";
 import { getAgentHostBridge } from "../runtime/host-bridge.ts";
 
 const z = (zod as typeof zod & { z?: typeof zod }).z ?? zod;
+const execFileAsync = promisify(execFile);
+
+async function commandAvailable(command: string): Promise<boolean> {
+  for (const dir of (process.env.PATH ?? "").split(path.delimiter)) {
+    if (!dir) continue;
+    try {
+      await access(path.join(dir, command));
+      return true;
+    } catch {
+      // Continue through PATH.
+    }
+  }
+  return false;
+}
+
+async function ensureSubscriptionCli(
+  providerId: "anthropic-subscription" | "openai-codex",
+): Promise<void> {
+  const command = providerId === "openai-codex" ? "codex" : "claude";
+  if (await commandAvailable(command)) return;
+  const packageName =
+    providerId === "openai-codex"
+      ? "@openai/codex"
+      : "@anthropic-ai/claude-code";
+  logger.info(`[accounts] Installing missing ${command} CLI for device login`);
+  await execFileAsync("npm", ["install", "-g", packageName], {
+    timeout: 2 * 60 * 1000,
+  });
+  if (!(await commandAvailable(command))) {
+    throw new Error(`${command} CLI installation completed but is not on PATH`);
+  }
+}
+
+function requestUsesLocalRoot(req: RouteRequestContext["req"]): boolean {
+  const raw =
+    (typeof req.headers.origin === "string" && req.headers.origin) ||
+    (typeof req.headers.referer === "string" && req.headers.referer) ||
+    `http://${req.headers.host ?? ""}`;
+  try {
+    const host = new URL(raw).hostname;
+    return host === "localhost" || host === "127.0.0.1" || host === "::1";
+  } catch {
+    return false;
+  }
+}
 
 // ─── Account pool (single source of truth) ──────────────────────────
 //
@@ -150,6 +199,7 @@ const apiKeyAccountSchema = z.object({
 
 const oauthStartSchema = z.object({
   label: z.string().trim().min(1).max(120),
+  mode: z.enum(["auto", "localhost", "device"]).optional(),
 });
 
 const oauthSubmitCodeSchema = z.object({
@@ -683,7 +733,10 @@ async function handleOAuthRoutes(
   const action = rest[0];
 
   if (action === "start" && method === "POST") {
-    const body = await readJsonBody<{ label?: string }>(req, res);
+    const body = await readJsonBody<{ label?: string; mode?: string }>(
+      req,
+      res,
+    );
     if (!body) return true;
     const parsed = oauthStartSchema.safeParse(body);
     if (!parsed.success) {
@@ -725,10 +778,21 @@ async function handleOAuthRoutes(
         : startCodexOAuthFlow;
     let handle: Awaited<ReturnType<typeof startFlow>>;
     try {
+      if (parsed.data.mode === "device" || parsed.data.mode === "localhost") {
+        await ensureSubscriptionCli(subscription);
+      }
       handle = await startFlow({
         label: parsed.data.label,
         accountId,
         onAccountSaved,
+        ...(subscription === "openai-codex"
+          ? {
+              headless:
+                parsed.data.mode === "device" ||
+                (parsed.data.mode !== "localhost" &&
+                  !requestUsesLocalRoot(req)),
+            }
+          : {}),
       });
     } catch (err) {
       logger.error(
@@ -741,6 +805,7 @@ async function handleOAuthRoutes(
       sessionId: handle.sessionId,
       authUrl: handle.authUrl,
       needsCodeSubmission: handle.needsCodeSubmission,
+      ...(handle.userCode ? { userCode: handle.userCode } : {}),
     });
     return true;
   }

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -237,8 +237,7 @@ type BrowserWorkspaceTabKind = NonNullable<
 >;
 
 let agentSkillsApiPromise:
-  | Promise<typeof import("@elizaos/plugin-agent-skills")>
-  | undefined;
+  Promise<typeof import("@elizaos/plugin-agent-skills")> | undefined;
 function getAgentSkillsApi(): Promise<
   typeof import("@elizaos/plugin-agent-skills")
 > {
@@ -249,8 +248,7 @@ function getAgentSkillsApi(): Promise<
 }
 
 let appManagerApiPromise:
-  | Promise<typeof import("@elizaos/plugin-app-manager")>
-  | undefined;
+  Promise<typeof import("@elizaos/plugin-app-manager")> | undefined;
 function getAppManagerApi(): Promise<
   typeof import("@elizaos/plugin-app-manager")
 > {
@@ -261,8 +259,7 @@ function getAppManagerApi(): Promise<
 }
 
 let walletApiPromise:
-  | Promise<typeof import("@elizaos/plugin-wallet")>
-  | undefined;
+  Promise<typeof import("@elizaos/plugin-wallet")> | undefined;
 function getWalletApi(): Promise<typeof import("@elizaos/plugin-wallet")> {
   walletApiPromise ??= importOptionalPlugin<
     typeof import("@elizaos/plugin-wallet")
@@ -1753,7 +1750,26 @@ async function handleRequest(
     method === "GET" &&
     pathname === "/api/first-run/status" &&
     isCloudProvisioned;
+  // app-core authenticates these session-tier dashboard reads before
+  // forwarding into the agent server. Do not require a second token here:
+  // browser sessions are stored by app-core and are intentionally opaque to
+  // the lower agent HTTP boundary.
+  const isAppCoreSessionCloudRead =
+    method === "GET" &&
+    (pathname === "/api/cloud/status" || pathname === "/api/cloud/credits");
   const isAuthProtectedPath = isAuthProtectedRoute(pathname);
+  let hostSessionAuthorized = false;
+  let hostSessionAuthorizationAttempted = false;
+  const isHostSessionAuthorized = async (): Promise<boolean> => {
+    if (hostSessionAuthorizationAttempted) return hostSessionAuthorized;
+    hostSessionAuthorizationAttempted = true;
+    const authorize = getAgentHostBridge().isHttpRequestAuthorized;
+    hostSessionAuthorized =
+      typeof authorize === "function"
+        ? await authorize(req, state.runtime)
+        : false;
+    return hostSessionAuthorized;
+  };
 
   const canonicalizeRestartReason = (reason: string): string => {
     if (
@@ -1903,11 +1919,13 @@ async function handleRequest(
     !isAuthEndpoint &&
     !isHealthEndpoint &&
     !isCloudFirstRunStatusEndpoint &&
+    !isAppCoreSessionCloudRead &&
     !isPublicRuntimePluginRoute({
       runtime: state.runtime,
       method,
       pathname,
     }) &&
+    !(await isHostSessionAuthorized()) &&
     !isAuthorized(req) &&
     !isBoundaryRoleAuthorized(req, method, pathname)
   ) {
@@ -2091,13 +2109,9 @@ async function handleRequest(
       }
       return Boolean(
         localInferenceServerApi.handleLocalInferenceTtsRoute &&
-          (await localInferenceServerApi.handleLocalInferenceTtsRoute(
-            req,
-            res,
-            {
-              current: state.runtime,
-            },
-          )),
+        (await localInferenceServerApi.handleLocalInferenceTtsRoute(req, res, {
+          current: state.runtime,
+        })),
       );
     })())
   ) {
@@ -2570,9 +2584,8 @@ async function handleRequest(
       return;
     }
     try {
-      const { unloadPluginFromDirectory } = await import(
-        "../runtime/load-plugin-from-directory.ts"
-      );
+      const { unloadPluginFromDirectory } =
+        await import("../runtime/load-plugin-from-directory.ts");
       const result = await unloadPluginFromDirectory({
         runtime: state.runtime as Parameters<
           typeof unloadPluginFromDirectory
@@ -3469,7 +3482,7 @@ async function handleRequest(
       pathname,
       url,
       runtime: state.runtime,
-      isAuthorized: () => isAuthorized(req),
+      isAuthorized: () => hostSessionAuthorized || isAuthorized(req),
       hostContext: {
         config: state.config as Record<string, unknown>,
         saveConfig: (nextConfig) => {
@@ -3554,14 +3567,18 @@ async function handleRequest(
       // routes, so the dispatch-level re-check must accept it too — otherwise
       // resolver-authorized requests pass the outer gate and 401 in dispatch.
       isAuthorized: () =>
-        isAuthorized(req) || isBoundaryRoleAuthorized(req, method, pathname),
+        hostSessionAuthorized ||
+        isAuthorized(req) ||
+        isBoundaryRoleAuthorized(req, method, pathname),
       isTrustedLocal: () => isTrustedLocalRequest(req),
       // Per-viewer principal for DTO selection (#14781). Trunk-authorized
       // callers stay on the single-owner boundary (no context → routes serve
       // unfiltered, unchanged); only resolver-recognized viewer tokens
       // (WaifuChat, artifact share-viewer) carry a principal into dispatch.
       accessContext: () =>
-        isAuthorized(req) ? undefined : resolveHttpAccessContext(req),
+        hostSessionAuthorized || isAuthorized(req)
+          ? undefined
+          : resolveHttpAccessContext(req),
     })
   ) {
     return;
@@ -4357,9 +4374,8 @@ export async function startApiServer(opts?: {
 
         // Build destination registry — all configured destinations
         const _connectors = state.config.connectors ?? {};
-        const streaming = (state.config as Record<string, unknown>).streaming as
-          | Record<string, unknown>
-          | undefined;
+        const streaming = (state.config as Record<string, unknown>)
+          .streaming as Record<string, unknown> | undefined;
         const destinations = new Map<string, StreamRouteDestination>();
 
         try {
@@ -5236,8 +5252,7 @@ export async function startApiServer(opts?: {
           ? Object.fromEntries(Object.entries(dbAgent))
           : null;
       const saved = agentRecord?.character as
-        | Record<string, unknown>
-        | undefined;
+        Record<string, unknown> | undefined;
       if (!saved || typeof saved !== "object") return;
 
       const c = rt.character;

--- a/packages/agent/src/api/subscription-routes.test.ts
+++ b/packages/agent/src/api/subscription-routes.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Exercises the legacy OpenAI exchange boundary when an account OAuth flow
+ * owns the live PKCE verifier; provider transport remains behind its injected seam.
+ */
+import type http from "node:http";
+import type { AccountCredentialRecord } from "@elizaos/auth/account-storage";
+import type { OAuthFlowHandle } from "@elizaos/auth/oauth-flow";
+import { describe, expect, it, vi } from "vitest";
+import type { ElizaConfig } from "../config/types.eliza.ts";
+import {
+  handleSubscriptionRoutes,
+  type SubscriptionAuthApi,
+  type SubscriptionRouteContext,
+} from "./subscription-routes.ts";
+
+const CALLBACK =
+  "http://localhost:1455/auth/callback?code=codex-code&state=flow-state";
+
+function account(expires = 123_456): AccountCredentialRecord {
+  return {
+    id: "account-1",
+    providerId: "openai-codex",
+    label: "Personal",
+    source: "oauth",
+    credentials: {
+      access: "access-token",
+      refresh: "refresh-token",
+      expires,
+    },
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+function accountFlow(
+  completion: OAuthFlowHandle["completion"],
+): OAuthFlowHandle {
+  return {
+    sessionId: "session-1",
+    authUrl: "https://auth.openai.com/authorize?state=flow-state",
+    needsCodeSubmission: true,
+    completion,
+    submitCode: vi.fn(),
+    cancel: vi.fn(),
+  };
+}
+
+function context(args: {
+  submit: SubscriptionAuthApi["submitProviderFlowCode"];
+  json?: ReturnType<typeof vi.fn>;
+  error?: ReturnType<typeof vi.fn>;
+}): SubscriptionRouteContext {
+  return {
+    req: {} as http.IncomingMessage,
+    res: {} as http.ServerResponse,
+    method: "POST",
+    pathname: "/api/subscription/openai/exchange",
+    state: { config: {} as ElizaConfig },
+    saveConfig: vi.fn(),
+    readJsonBody: vi.fn().mockResolvedValue({ code: CALLBACK }),
+    json: args.json ?? vi.fn(),
+    error: args.error ?? vi.fn(),
+    loadSubscriptionAuth: vi.fn().mockResolvedValue({
+      submitProviderFlowCode: args.submit,
+    } as SubscriptionAuthApi),
+  } as unknown as SubscriptionRouteContext;
+}
+
+describe("subscription OpenAI account-flow bridge", () => {
+  it("submits the callback to the matching account flow and awaits persistence", async () => {
+    const json = vi.fn();
+    const error = vi.fn();
+    const flow = accountFlow(Promise.resolve({ account: account() }));
+    const submit = vi.fn().mockReturnValue(flow);
+
+    const handled = await handleSubscriptionRoutes(
+      context({ submit, json, error }),
+    );
+
+    expect(handled).toBe(true);
+    expect(submit).toHaveBeenCalledWith("openai-codex", CALLBACK);
+    expect(json).toHaveBeenCalledWith(expect.anything(), {
+      success: true,
+      expiresAt: 123_456,
+    });
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it("rejects a callback that cannot be matched to one pending flow", async () => {
+    const json = vi.fn();
+    const error = vi.fn();
+
+    await handleSubscriptionRoutes(
+      context({ submit: vi.fn().mockReturnValue(null), json, error }),
+    );
+
+    expect(error).toHaveBeenCalledWith(
+      expect.anything(),
+      "No matching active flow — start login again",
+      400,
+    );
+    expect(json).not.toHaveBeenCalled();
+  });
+
+  it("translates account-flow exchange failure at the HTTP boundary", async () => {
+    const json = vi.fn();
+    const error = vi.fn();
+    const flow = accountFlow(Promise.reject(new Error("provider rejected")));
+
+    await handleSubscriptionRoutes(
+      context({ submit: vi.fn().mockReturnValue(flow), json, error }),
+    );
+
+    expect(error).toHaveBeenCalledWith(
+      expect.anything(),
+      "OpenAI exchange failed",
+      500,
+    );
+    expect(json).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent/src/api/subscription-routes.ts
+++ b/packages/agent/src/api/subscription-routes.ts
@@ -9,8 +9,8 @@
  * `process.env` (TOS restriction).
  */
 import crypto from "node:crypto";
-import type { AnthropicFlow } from "@elizaos/auth/anthropic";
 import { loadAccount, saveAccount } from "@elizaos/auth/account-storage";
+import type { AnthropicFlow } from "@elizaos/auth/anthropic";
 import type { CodexFlow } from "@elizaos/auth/openai-codex";
 import {
   isSubscriptionProvider,
@@ -40,6 +40,7 @@ export type SubscriptionAuthApi = Pick<
   | "fetchAnthropicOAuthProfile"
   | "startAnthropicLogin"
   | "startCodexLogin"
+  | "submitProviderFlowCode"
   | "saveCredentials"
   | "applySubscriptionCredentials"
   | "deleteCredentials"
@@ -315,12 +316,35 @@ export async function handleSubscriptionRoutes(
     }
     const body = parsedOaeb.data;
     try {
-      const { saveCredentials, applySubscriptionCredentials } =
-        await loadSubscriptionAuth();
+      const {
+        saveCredentials,
+        applySubscriptionCredentials,
+        submitProviderFlowCode,
+      } = await loadSubscriptionAuth();
       const flow = state._codexFlow ?? activeCodexFlow;
 
       if (!flow) {
-        error(res, "No active flow — call /start first", 400);
+        if (!body.code) {
+          error(res, "No active flow — call /start first", 400);
+          return true;
+        }
+        const accountFlow = submitProviderFlowCode("openai-codex", body.code);
+        if (!accountFlow) {
+          error(res, "No matching active flow — start login again", 400);
+          return true;
+        }
+        try {
+          const { account } = await accountFlow.completion;
+          json(res, {
+            success: true,
+            expiresAt: account.credentials.expires,
+          });
+        } catch (err) {
+          logger.error(
+            `[api] OpenAI account-flow exchange failed: ${String(err)}`,
+          );
+          error(res, "OpenAI exchange failed", 500);
+        }
         return true;
       }
 

--- a/packages/agent/src/api/subscription-routes.ts
+++ b/packages/agent/src/api/subscription-routes.ts
@@ -34,6 +34,7 @@ type AuthModule = typeof import("@elizaos/auth");
 export type SubscriptionAuthApi = Pick<
   AuthModule,
   | "getSubscriptionStatus"
+  | "exchangeAnthropicAuthorizationCode"
   | "startAnthropicLogin"
   | "startCodexLogin"
   | "saveCredentials"
@@ -54,6 +55,12 @@ export interface SubscriptionRouteContext extends RouteRequestContext {
   saveConfig: (config: ElizaConfig) => void;
   loadSubscriptionAuth: () => Promise<SubscriptionAuthApi>;
 }
+
+// Runtime reloads replace the request state while an OAuth browser is open.
+// Codex's PKCE verifier cannot be reconstructed from its localhost callback,
+// so retain the live flow in this process-level module across runtime swaps.
+let activeCodexFlow: CodexFlow | undefined;
+let activeCodexFlowTimer: ReturnType<typeof setTimeout> | undefined;
 
 export async function handleSubscriptionRoutes(
   ctx: SubscriptionRouteContext,
@@ -139,15 +146,15 @@ export async function handleSubscriptionRoutes(
     }
     const body = parsedAxe.data;
     try {
-      const { saveCredentials, applySubscriptionCredentials } =
-        await loadSubscriptionAuth();
+      const {
+        saveCredentials,
+        applySubscriptionCredentials,
+        exchangeAnthropicAuthorizationCode,
+      } = await loadSubscriptionAuth();
       const flow = state._anthropicFlow;
-      if (!flow) {
-        error(res, "No active flow — call /start first", 400);
-        return true;
-      }
-      flow.submitCode(body.code);
-      const credentials = await flow.credentials;
+      const credentials = flow
+        ? (flow.submitCode(body.code), await flow.credentials)
+        : await exchangeAnthropicAuthorizationCode(body.code);
       saveCredentials("anthropic-subscription", credentials);
       await applySubscriptionCredentials(state.config);
       delete state._anthropicFlow;
@@ -202,9 +209,10 @@ export async function handleSubscriptionRoutes(
   if (method === "POST" && pathname === "/api/subscription/openai/start") {
     try {
       const { startCodexLogin } = await loadSubscriptionAuth();
-      if (state._codexFlow) {
+      const previousFlow = state._codexFlow ?? activeCodexFlow;
+      if (previousFlow) {
         try {
-          state._codexFlow.close();
+          previousFlow.close();
         } catch (err) {
           logger.debug(
             `[api] OAuth flow cleanup failed: ${err instanceof Error ? err.message : err}`,
@@ -212,9 +220,11 @@ export async function handleSubscriptionRoutes(
         }
       }
       clearTimeout(state._codexFlowTimer);
+      clearTimeout(activeCodexFlowTimer);
 
       const flow = await startCodexLogin();
       state._codexFlow = flow;
+      activeCodexFlow = flow;
       state._codexFlowTimer = setTimeout(
         () => {
           try {
@@ -226,9 +236,12 @@ export async function handleSubscriptionRoutes(
           }
           delete state._codexFlow;
           delete state._codexFlowTimer;
+          if (activeCodexFlow === flow) activeCodexFlow = undefined;
+          activeCodexFlowTimer = undefined;
         },
         10 * 60 * 1000,
       );
+      activeCodexFlowTimer = state._codexFlowTimer;
       json(res, {
         authUrl: flow.authUrl,
         state: flow.state,
@@ -259,7 +272,7 @@ export async function handleSubscriptionRoutes(
     try {
       const { saveCredentials, applySubscriptionCredentials } =
         await loadSubscriptionAuth();
-      const flow = state._codexFlow;
+      const flow = state._codexFlow ?? activeCodexFlow;
 
       if (!flow) {
         error(res, "No active flow — call /start first", 400);
@@ -287,6 +300,9 @@ export async function handleSubscriptionRoutes(
         delete state._codexFlow;
         clearTimeout(state._codexFlowTimer);
         delete state._codexFlowTimer;
+        activeCodexFlow = undefined;
+        clearTimeout(activeCodexFlowTimer);
+        activeCodexFlowTimer = undefined;
         logger.error(`[api] OpenAI exchange failed: ${String(err)}`);
         error(res, "OpenAI exchange failed", 500);
         return true;
@@ -297,6 +313,9 @@ export async function handleSubscriptionRoutes(
       delete state._codexFlow;
       clearTimeout(state._codexFlowTimer);
       delete state._codexFlowTimer;
+      activeCodexFlow = undefined;
+      clearTimeout(activeCodexFlowTimer);
+      activeCodexFlowTimer = undefined;
       json(res, {
         success: true,
         expiresAt: credentials.expires,

--- a/packages/agent/src/api/subscription-routes.ts
+++ b/packages/agent/src/api/subscription-routes.ts
@@ -8,7 +8,9 @@
  * Anthropic setup token is stored for task-agent CLI use only, never applied to
  * `process.env` (TOS restriction).
  */
+import crypto from "node:crypto";
 import type { AnthropicFlow } from "@elizaos/auth/anthropic";
+import { loadAccount, saveAccount } from "@elizaos/auth/account-storage";
 import type { CodexFlow } from "@elizaos/auth/openai-codex";
 import {
   isSubscriptionProvider,
@@ -35,6 +37,7 @@ export type SubscriptionAuthApi = Pick<
   AuthModule,
   | "getSubscriptionStatus"
   | "exchangeAnthropicAuthorizationCode"
+  | "fetchAnthropicOAuthProfile"
   | "startAnthropicLogin"
   | "startCodexLogin"
   | "saveCredentials"
@@ -150,12 +153,54 @@ export async function handleSubscriptionRoutes(
         saveCredentials,
         applySubscriptionCredentials,
         exchangeAnthropicAuthorizationCode,
+        fetchAnthropicOAuthProfile,
       } = await loadSubscriptionAuth();
       const flow = state._anthropicFlow;
       const credentials = flow
         ? (flow.submitCode(body.code), await flow.credentials)
         : await exchangeAnthropicAuthorizationCode(body.code);
-      saveCredentials("anthropic-subscription", credentials);
+      const profile = await fetchAnthropicOAuthProfile(credentials.access);
+      const accountId = profile.accountId ?? crypto.randomUUID();
+      saveCredentials("anthropic-subscription", credentials, accountId);
+      const stored = loadAccount("anthropic-subscription", accountId);
+      if (stored && profile.email) {
+        saveAccount({
+          ...stored,
+          label: profile.email,
+          email: profile.email,
+          ...(profile.organizationId
+            ? { organizationId: profile.organizationId }
+            : {}),
+        });
+      }
+      const pool = getAgentHostBridge().getDefaultAccountPool() as {
+        list(providerId?: string): LinkedAccountConfig[];
+        upsert(account: LinkedAccountConfig): Promise<void>;
+      };
+      const existing = pool.list("anthropic-subscription");
+      const prior = existing.find((account) => account.id === accountId);
+      const priority =
+        prior?.priority ??
+        (existing.length === 0
+          ? 0
+          : Math.max(...existing.map((account) => account.priority)) + 1);
+      await pool.upsert({
+        id: accountId,
+        providerId: "anthropic-subscription",
+        label:
+          profile.email ??
+          prior?.label ??
+          `Claude account ${existing.length + 1}`,
+        source: "oauth",
+        enabled: prior?.enabled ?? true,
+        priority,
+        createdAt: prior?.createdAt ?? Date.now(),
+        health: "ok",
+        ...(profile.email ? { email: profile.email } : {}),
+        ...(profile.organizationId
+          ? { organizationId: profile.organizationId }
+          : {}),
+      });
       await applySubscriptionCredentials(state.config);
       delete state._anthropicFlow;
       json(res, { success: true, expiresAt: credentials.expires });

--- a/packages/agent/src/runtime/host-bridge.ts
+++ b/packages/agent/src/runtime/host-bridge.ts
@@ -23,6 +23,7 @@ import type {
   IncomingMessage as HttpIncomingMessage,
   ServerResponse as HttpServerResponse,
 } from "node:http";
+import type { AgentRuntime } from "@elizaos/core";
 import type { resolveServiceRoutingInConfig } from "@elizaos/shared";
 import type { Vault } from "@elizaos/vault";
 
@@ -56,6 +57,15 @@ export interface AgentHostBridge {
   startAccountPoolKeepAlive(): void;
   getBuildVariant(): "store" | "direct";
   isStoreBuild(): boolean;
+  /**
+   * Let an embedding host recognize its own HTTP authentication mechanism
+   * (for example app-core's browser session cookie). The standalone agent
+   * has no host session model, so the default remains deny-by-default.
+   */
+  isHttpRequestAuthorized?(
+    req: HttpIncomingMessage,
+    runtime: AgentRuntime | null,
+  ): Promise<boolean> | boolean;
   /**
    * Cloud-SSO popup handoff (`GET /pair?token=…`). Owned by the host; a
    * local-only agent never legitimately serves it, so absence is a no-op that

--- a/packages/agent/src/runtime/operations/repository.ts
+++ b/packages/agent/src/runtime/operations/repository.ts
@@ -95,9 +95,7 @@ async function readOperationFile(
   return parsed;
 }
 
-export class FilesystemRuntimeOperationRepository
-  implements RuntimeOperationRepository
-{
+export class FilesystemRuntimeOperationRepository implements RuntimeOperationRepository {
   private readonly dir: string;
   private readonly byId: Map<string, RuntimeOperation> = new Map();
   private readonly byIdempotencyKey: Map<string, string> = new Map();
@@ -364,6 +362,22 @@ export class FilesystemRuntimeOperationRepository
       return null;
     }
     if (op.status !== "pending" && op.status !== "running") {
+      this.activeId = null;
+      return null;
+    }
+    // A process exit can leave the filesystem-backed single-flight slot in a
+    // permanently active state. Runtime operations normally finish in
+    // seconds; recover abandoned records after two minutes so a dead process
+    // cannot block every future provider switch.
+    if (Date.now() - op.startedAt > 2 * 60 * 1000) {
+      await this.update(op.id, {
+        status: "failed",
+        finishedAt: Date.now(),
+        error: {
+          code: "strategy-failed",
+          message: "Operation abandoned by a previous process",
+        },
+      });
       this.activeId = null;
       return null;
     }

--- a/packages/app-core/src/api/auth.ts
+++ b/packages/app-core/src/api/auth.ts
@@ -46,8 +46,7 @@ export {
 
 export interface CompatStateLike {
   current:
-    | (EmbedSessionSecretRuntime & { adapter?: { db?: unknown } | null })
-    | null;
+    (EmbedSessionSecretRuntime & { adapter?: { db?: unknown } | null }) | null;
 }
 
 /**
@@ -382,7 +381,7 @@ function ensureMinRole(
   return roleRank(resolveBoundaryRole(req, env)) >= roleRank(minRole);
 }
 
-type RouteRoleResolution =
+export type RouteRoleResolution =
   | { ok: true; role: RoleGateRole }
   | { ok: false; status: 401 | 403 | 429; reason: string };
 
@@ -426,7 +425,7 @@ async function resolveSessionRole(
   return roleForIdentityKind(identity?.kind);
 }
 
-async function resolveAuthorizedRouteRole(
+export async function resolveAuthorizedRouteRole(
   req: Pick<http.IncomingMessage, "headers" | "socket" | "method">,
   options: AuthorizedRouteRoleOptions,
 ): Promise<RouteRoleResolution> {

--- a/packages/app-core/src/api/route-auth-policy.ts
+++ b/packages/app-core/src/api/route-auth-policy.ts
@@ -34,6 +34,7 @@ export interface CompatRouteAuthPolicy {
 const METHODS = {
   GET: ["GET"],
   POST: ["POST"],
+  PUT: ["PUT"],
 } as const;
 
 const publicExact = (
@@ -114,7 +115,10 @@ export const COMPAT_ROUTE_AUTH_POLICIES: readonly CompatRouteAuthPolicy[] = [
   publicExact("tts.elevenlabs-passthrough", "POST", "/api/tts/elevenlabs"),
 
   sessionExact("runtime.mode", "GET", "/api/runtime/mode"),
+  sessionExact("cloud.status", "GET", "/api/cloud/status"),
+  sessionExact("cloud.credits", "GET", "/api/cloud/credits"),
   sessionExact("cloud.login", "POST", "/api/cloud/login"),
+  sessionExact("cloud.login.persist", "POST", "/api/cloud/login/persist"),
   sessionExact("cloud.disconnect", "POST", "/api/cloud/disconnect"),
   sessionPrefix("cloud.compat", "/api/cloud/compat/"),
   sessionPrefix("cloud.v1", "/api/cloud/v1/"),
@@ -145,6 +149,7 @@ export const COMPAT_ROUTE_AUTH_POLICIES: readonly CompatRouteAuthPolicy[] = [
     /^\/api\/auth\/sessions\/[^/]+\/revoke$/,
   ),
   sessionExact("first-run.status", "GET", "/api/first-run/status"),
+  sessionExact("first-run.options", "GET", "/api/first-run/options"),
   sessionExact(
     "background.run-due-tasks",
     "POST",

--- a/packages/app-core/src/runtime/install-agent-host-bridge.ts
+++ b/packages/app-core/src/runtime/install-agent-host-bridge.ts
@@ -18,8 +18,8 @@ import {
   setAgentHostBridge,
 } from "@elizaos/agent/runtime/host-bridge";
 import { getBuildVariant, isStoreBuild } from "@elizaos/core";
-import { handleCloudPairRoute } from "../api/cloud-pair-route";
 import { resolveAuthorizedRouteRole } from "../api/auth";
+import { handleCloudPairRoute } from "../api/cloud-pair-route";
 import {
   captureWalletEnvBootBaseline,
   hydrateWalletKeysFromNodePlatformSecureStore,
@@ -56,8 +56,6 @@ export function installAgentHostBridge(): void {
         skipCsrf: true,
         state: {
           current: runtime,
-          pendingAgentName: null,
-          pendingRestartReasons: [],
         },
       });
       return resolved.ok;

--- a/packages/app-core/src/runtime/install-agent-host-bridge.ts
+++ b/packages/app-core/src/runtime/install-agent-host-bridge.ts
@@ -19,6 +19,7 @@ import {
 } from "@elizaos/agent/runtime/host-bridge";
 import { getBuildVariant, isStoreBuild } from "@elizaos/core";
 import { handleCloudPairRoute } from "../api/cloud-pair-route";
+import { resolveAuthorizedRouteRole } from "../api/auth";
 import {
   captureWalletEnvBootBaseline,
   hydrateWalletKeysFromNodePlatformSecureStore,
@@ -46,6 +47,21 @@ export function installAgentHostBridge(): void {
     getBuildVariant,
     isStoreBuild,
     handleCloudPairRoute,
+    isHttpRequestAuthorized: async (req, runtime) => {
+      const resolved = await resolveAuthorizedRouteRole(req, {
+        // Agent-owned legacy mutations predate app-core's CSRF header and the
+        // web client does not attach it to that surface. These requests have
+        // already passed the server's strict Origin/CORS gate; validate the
+        // host session here without imposing the compat-route CSRF contract.
+        skipCsrf: true,
+        state: {
+          current: runtime,
+          pendingAgentName: null,
+          pendingRestartReasons: [],
+        },
+      });
+      return resolved.ok;
+    },
   };
   setAgentHostBridge(bridge);
   installed = true;

--- a/packages/app-core/src/services/account-usage.test.ts
+++ b/packages/app-core/src/services/account-usage.test.ts
@@ -111,12 +111,19 @@ describe("pollAnthropicUsage", () => {
     expect(snap.weeklyPct).toBe(80);
   });
 
-  it("clamps utilization above 1.0 down to 100 (>100 edge case)", async () => {
+  it("preserves utilization already expressed as a 0..100 percentage", async () => {
     stubFetch(jsonResponse({ five_hour_utilization: 5 }));
 
     const snap = await pollAnthropicUsage("over-token");
 
-    // 5 * 100 = 500 -> clamped to 100.
+    expect(snap.sessionPct).toBe(5);
+  });
+
+  it("clamps percentage utilization above 100", async () => {
+    stubFetch(jsonResponse({ five_hour_utilization: 150 }));
+
+    const snap = await pollAnthropicUsage("over-token");
+
     expect(snap.sessionPct).toBe(100);
   });
 

--- a/packages/app-core/src/services/account-usage.test.ts
+++ b/packages/app-core/src/services/account-usage.test.ts
@@ -21,8 +21,23 @@
  *  - not throwing (with the HTTP status) on a non-ok response.
  */
 
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { pollAnthropicUsage, pollCodexUsage } from "./account-usage";
+import {
+  appendFileSync,
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  pollAnthropicUsage,
+  pollCodexUsage,
+  readTodayCounters,
+  recordCall,
+} from "./account-usage";
 
 /** Build a minimal Response-like object the probes consume (ok + json()). */
 function jsonResponse(body: unknown, init?: { ok?: boolean; status?: number }) {
@@ -275,5 +290,93 @@ describe("pollCodexUsage", () => {
     stubFetch(jsonResponse({}, { ok: false, status: 401 }));
 
     await expect(pollCodexUsage("t", "a")).rejects.toThrow(/401/);
+  });
+});
+
+/**
+ * The local JSONL counters (`recordCall` / `readTodayCounters`) are the other
+ * public surface of this module and shipped without coverage. They resolve
+ * their storage root through `resolveStateDir`, which honors `ELIZA_STATE_DIR`,
+ * so each test points that at an isolated temp dir and asserts the append +
+ * aggregate round-trip, the empty-file default, and that unparseable JSONL
+ * lines are skipped rather than throwing.
+ */
+describe("local JSONL usage counters", () => {
+  let stateDir: string;
+  const prevStateDir = process.env.ELIZA_STATE_DIR;
+
+  beforeEach(() => {
+    stateDir = mkdtempSync(path.join(tmpdir(), "eliza-usage-"));
+    process.env.ELIZA_STATE_DIR = stateDir;
+  });
+
+  afterEach(() => {
+    if (prevStateDir === undefined) delete process.env.ELIZA_STATE_DIR;
+    else process.env.ELIZA_STATE_DIR = prevStateDir;
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("returns zeroed counters when no file has been written yet", () => {
+    expect(readTodayCounters("anthropic", "acct-1")).toEqual({
+      calls: 0,
+      tokens: 0,
+      errors: 0,
+    });
+  });
+
+  it("appends one JSONL line per call and aggregates calls/tokens/errors", () => {
+    recordCall("anthropic", "acct-1", { ok: true, tokens: 100 });
+    recordCall("anthropic", "acct-1", { ok: true, tokens: 50 });
+    recordCall("anthropic", "acct-1", { ok: false, errorCode: "429" });
+
+    expect(readTodayCounters("anthropic", "acct-1")).toEqual({
+      calls: 3,
+      tokens: 150,
+      errors: 1,
+    });
+  });
+
+  it("keeps counters isolated per (provider, account) pair", () => {
+    recordCall("anthropic", "acct-1", { ok: true, tokens: 10 });
+    recordCall("codex", "acct-2", { ok: true, tokens: 999 });
+
+    expect(readTodayCounters("anthropic", "acct-1").tokens).toBe(10);
+    expect(readTodayCounters("codex", "acct-2").tokens).toBe(999);
+  });
+
+  it("skips unparseable JSONL lines instead of throwing", () => {
+    recordCall("anthropic", "acct-1", { ok: true, tokens: 20 });
+    // Corrupt the day file with a non-JSON line between valid entries.
+    const dir = path.join(stateDir, "usage", "anthropic", "acct-1");
+    const [file] = readdirSync(dir);
+    const full = path.join(dir, file);
+    appendFileSync(full, "not-json\n");
+    recordCall("anthropic", "acct-1", { ok: false });
+
+    const counters = readTodayCounters("anthropic", "acct-1");
+    expect(counters.calls).toBe(2);
+    expect(counters.tokens).toBe(20);
+    expect(counters.errors).toBe(1);
+  });
+
+  it("ignores non-finite token values when aggregating", () => {
+    recordCall("anthropic", "acct-1", {
+      ok: true,
+      tokens: Number.NaN,
+    });
+    recordCall("anthropic", "acct-1", { ok: true, tokens: 5 });
+
+    expect(readTodayCounters("anthropic", "acct-1").tokens).toBe(5);
+  });
+
+  it("creates the day directory on demand and writes a real file", () => {
+    expect(existsSync(path.join(stateDir, "usage"))).toBe(false);
+    recordCall("anthropic", "acct-1", { ok: true });
+    const dir = path.join(stateDir, "usage", "anthropic", "acct-1");
+    expect(existsSync(dir)).toBe(true);
+    const [file] = readdirSync(dir);
+    const line = readFileSync(path.join(dir, file), "utf-8").trim();
+    expect(JSON.parse(line)).toMatchObject({ ok: true });
+    expect(JSON.parse(line).ts).toEqual(expect.any(Number));
   });
 });

--- a/packages/app-core/src/services/account-usage.ts
+++ b/packages/app-core/src/services/account-usage.ts
@@ -42,9 +42,10 @@ type FetchLike = typeof fetch;
 
 function utilizationToPct(value: unknown): number | undefined {
   if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
-  // Provider returns either 0..1 (legacy) or 0..100 — both are normalized
-  // to percent. Anthropic ships 0..1, so we always multiply.
-  return Math.max(0, Math.min(100, value * 100));
+  // Anthropic has returned both fractional (0..1) and percentage (0..100)
+  // shapes. Scale only fractional values; otherwise 5% becomes 500%/clamped.
+  const percent = value >= 0 && value <= 1 ? value * 100 : value;
+  return Math.max(0, Math.min(100, percent));
 }
 
 function normalizeResetTimestamp(value: unknown): number | undefined {

--- a/packages/app/public/sw.js
+++ b/packages/app/public/sw.js
@@ -39,7 +39,7 @@ const VIEWS_CACHE_NAME = "elizaos-views-v1";
 // v5: black launch baseline (theme-color + launch-bg -> #000000; the home
 // background is the black field with the orange ember glow, and boot no
 // longer paints orange). Bump drops any cached prior shell.
-const SHELL_CACHE_NAME = "elizaos-shell-v5";
+const SHELL_CACHE_NAME = "elizaos-shell-v6";
 // Immutable runtime cache for Vite's content-hashed build output (/assets/*).
 // The filename hash IS the cache key's freshness guarantee: any byte change
 // produces a new filename, so cache-first can never serve a stale asset. This
@@ -95,6 +95,22 @@ self.addEventListener("activate", (event) => {
       }
 
       await self.clients.claim();
+
+      // A newly activated worker means a new renderer was deployed. Existing
+      // tabs still execute their old JS indefinitely (notably across an OAuth
+      // app-pause/resume), so navigate same-origin windows once to load the
+      // current content-hashed renderer.
+      const windows = await self.clients.matchAll({
+        type: "window",
+        includeUncontrolled: true,
+      });
+      await Promise.all(
+        windows.map((client) =>
+          typeof client.navigate === "function"
+            ? client.navigate(client.url).catch(() => undefined)
+            : undefined,
+        ),
+      );
     })(),
   );
 });

--- a/packages/auth/src/anthropic.ts
+++ b/packages/auth/src/anthropic.ts
@@ -7,9 +7,12 @@
 
 import type { OAuthCredentials } from "./types.ts";
 import {
+  exchangeAnthropicAuthorizationCode,
   loginAnthropic as loginAnthropicFlow,
   refreshAnthropicToken as refreshAnthropicTokenFlow,
 } from "./vendor/pi-oauth/anthropic-login.ts";
+
+export { exchangeAnthropicAuthorizationCode };
 
 export interface AnthropicFlow {
   authUrl: string;

--- a/packages/auth/src/codex-device.ts
+++ b/packages/auth/src/codex-device.ts
@@ -1,0 +1,109 @@
+import { spawn } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { OAuthCredentials } from "./types.ts";
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: strips terminal ANSI color sequences from CLI output.
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
+const DEVICE_URL_RE = /https:\/\/auth\.openai\.com\/codex\/device/;
+const DEVICE_CODE_RE = /\b[A-Z0-9]{4}-[A-Z0-9]{5}\b/;
+
+export interface CodexDeviceFlow {
+  authUrl: string;
+  userCode: string;
+  credentials: Promise<OAuthCredentials>;
+  close: () => void;
+}
+
+function expiryFromJwt(token: string): number {
+  try {
+    const payload = JSON.parse(
+      Buffer.from(token.split(".")[1] ?? "", "base64url").toString("utf8"),
+    ) as { exp?: unknown };
+    if (typeof payload.exp === "number") return payload.exp * 1000;
+  } catch {
+    // Fall through to a conservative one-hour lifetime.
+  }
+  return Date.now() + 60 * 60 * 1000;
+}
+
+export function startCodexDeviceLogin(): Promise<CodexDeviceFlow> {
+  const codexHome = mkdtempSync(path.join(os.tmpdir(), "eliza-codex-device-"));
+  const child = spawn("codex", ["login", "--device-auth"], {
+    env: { ...process.env, CODEX_HOME: codexHome, NO_COLOR: "1" },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let output = "";
+  let settledStart = false;
+  let resolveCredentials!: (credentials: OAuthCredentials) => void;
+  let rejectCredentials!: (error: Error) => void;
+  const credentials = new Promise<OAuthCredentials>((resolve, reject) => {
+    resolveCredentials = resolve;
+    rejectCredentials = reject;
+  });
+  void credentials.catch(() => undefined);
+
+  return new Promise<CodexDeviceFlow>((resolve, reject) => {
+    const inspect = (chunk: Buffer | string) => {
+      output += String(chunk).replace(ANSI_RE, "");
+      if (settledStart) return;
+      const url = output.match(DEVICE_URL_RE)?.[0];
+      const userCode = output.match(DEVICE_CODE_RE)?.[0];
+      if (!url || !userCode) return;
+      settledStart = true;
+      resolve({
+        authUrl: url,
+        userCode,
+        credentials,
+        close: () => child.kill("SIGTERM"),
+      });
+    };
+    child.stdout.on("data", inspect);
+    child.stderr.on("data", inspect);
+    child.once("error", (err) => {
+      if (!settledStart) reject(err);
+      rejectCredentials(err);
+      rmSync(codexHome, { recursive: true, force: true });
+    });
+    child.once("exit", (code, signal) => {
+      if (code !== 0) {
+        const err = new Error(
+          `Codex device login exited ${signal ? `with ${signal}` : `with code ${code}`}`,
+        );
+        if (!settledStart) reject(err);
+        rejectCredentials(err);
+        rmSync(codexHome, { recursive: true, force: true });
+        return;
+      }
+      try {
+        const parsed = JSON.parse(
+          readFileSync(path.join(codexHome, "auth.json"), "utf8"),
+        ) as {
+          tokens?: {
+            access_token?: string;
+            refresh_token?: string;
+            id_token?: string;
+          };
+        };
+        const access = parsed.tokens?.access_token;
+        const refresh = parsed.tokens?.refresh_token;
+        if (!access || !refresh)
+          throw new Error("Codex device login returned no tokens");
+        resolveCredentials({
+          access,
+          refresh,
+          expires: expiryFromJwt(access),
+          ...(parsed.tokens?.id_token
+            ? { idToken: parsed.tokens.id_token }
+            : {}),
+        });
+      } catch (err) {
+        rejectCredentials(err instanceof Error ? err : new Error(String(err)));
+      } finally {
+        rmSync(codexHome, { recursive: true, force: true });
+      }
+    });
+  });
+}

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -4,4 +4,5 @@ export * from "./claude-code-stealth.ts";
 export * from "./credentials.ts";
 export * from "./oauth-flow.ts";
 export * from "./openai-codex.ts";
+export * from "./codex-device.ts";
 export * from "./types.ts";

--- a/packages/auth/src/oauth-flow.test.ts
+++ b/packages/auth/src/oauth-flow.test.ts
@@ -1,13 +1,11 @@
 /**
- * Tests the OAuth flow orchestrator's state broadcast: the `FlowState`
- * emitted to `/api/accounts/:provider/oauth/status` SSE subscribers must
- * never carry the OAuth access/refresh tokens, while the in-process
- * `OAuthFlowHandle.completion` promise and the on-disk credential record
- * keep the full credentials.
+ * Tests OAuth profile loading and the orchestrator's credential-free state
+ * broadcast. Profile failures must remain typed failures, while SSE frames
+ * must never carry access or refresh tokens and in-process/on-disk records
+ * retain the complete credentials.
  *
- * Only the vendor OAuth network layer (`startCodexLogin`) is faked — the
- * real `startGenericFlow`, `persistAccount`/`saveAccount`, `setTerminal`,
- * and listener emit paths all run for real against a temp ELIZA_HOME.
+ * Provider HTTP is injected at the fetch boundary; the real generic flow,
+ * persistence, terminal state, and listener paths run against a temp home.
  */
 
 import fs from "node:fs";
@@ -18,6 +16,7 @@ import { loadAccount } from "./account-storage";
 import {
   _resetFlowRegistry,
   type FlowState,
+  fetchAnthropicOAuthProfile,
   startCodexOAuthFlow,
   submitProviderFlowCode,
   subscribeFlow,
@@ -35,6 +34,70 @@ const REFRESH_TOKEN = "codex-refresh-token-SECRET";
 const ID_TOKEN = "codex-id-token-SECRET";
 
 const tempHomes: string[] = [];
+
+describe("fetchAnthropicOAuthProfile", () => {
+  it("returns validated identity fields from the authenticated profile", async () => {
+    const profile = await fetchAnthropicOAuthProfile("access-token", (async (
+      _input,
+      init,
+    ) => {
+      expect((init?.headers as Record<string, string>).Authorization).toBe(
+        "Bearer access-token",
+      );
+      return Response.json({
+        account: { uuid: "account-1", email: "person@example.com" },
+        organization: { uuid: "organization-1" },
+      });
+    }) as typeof fetch);
+
+    expect(profile).toEqual({
+      email: "person@example.com",
+      accountId: "account-1",
+      organizationId: "organization-1",
+    });
+  });
+
+  it.each([
+    ...[401, 429, 503].map(
+      (status) =>
+        [
+          `HTTP ${status}`,
+          async () => new Response("private body", { status }),
+          "anthropic_oauth.profile_http_error",
+        ] as const,
+    ),
+    [
+      "malformed JSON",
+      async () => new Response("not-json"),
+      "anthropic_oauth.profile_invalid_json",
+    ],
+    [
+      "invalid shape",
+      async () => Response.json([]),
+      "anthropic_oauth.profile_invalid_shape",
+    ],
+    [
+      "transport failure",
+      async () => {
+        throw new Error("network down");
+      },
+      "anthropic_oauth.profile_request_failed",
+    ],
+    [
+      "timeout",
+      async () => {
+        throw Object.assign(new Error("timed out"), { name: "TimeoutError" });
+      },
+      "anthropic_oauth.profile_request_failed",
+    ],
+  ] as Array<
+    [string, () => Promise<Response>, string]
+  >)("surfaces %s instead of fabricating an empty profile", async (_name, fetchImpl, code) => {
+    await expect(
+      fetchAnthropicOAuthProfile("access-token", fetchImpl as typeof fetch),
+    ).rejects.toMatchObject({ code });
+  });
+});
 
 function useTempElizaHome(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-oauth-flow-test-"));

--- a/packages/auth/src/oauth-flow.test.ts
+++ b/packages/auth/src/oauth-flow.test.ts
@@ -32,6 +32,7 @@ vi.mock("./openai-codex.ts", () => ({
 
 const ACCESS_TOKEN = "codex-access-token-SECRET";
 const REFRESH_TOKEN = "codex-refresh-token-SECRET";
+const ID_TOKEN = "codex-id-token-SECRET";
 
 const tempHomes: string[] = [];
 
@@ -123,6 +124,7 @@ describe("oauth-flow FlowState broadcast", () => {
       access: ACCESS_TOKEN,
       refresh: REFRESH_TOKEN,
       expires: Date.now() + 60_000,
+      idToken: ID_TOKEN,
     });
     await handle.completion;
 
@@ -185,17 +187,20 @@ describe("oauth-flow FlowState broadcast", () => {
       access: ACCESS_TOKEN,
       refresh: REFRESH_TOKEN,
       expires: Date.now() + 60_000,
+      idToken: ID_TOKEN,
     });
 
     // In-process consumers (CLI, credential pool) still get the tokens.
     const { account } = await handle.completion;
     expect(account.credentials.access).toBe(ACCESS_TOKEN);
     expect(account.credentials.refresh).toBe(REFRESH_TOKEN);
+    expect(account.credentials.idToken).toBe(ID_TOKEN);
 
     // And the persisted record is intact.
     const saved = loadAccount("openai-codex", "acct-3");
     expect(saved?.credentials.access).toBe(ACCESS_TOKEN);
     expect(saved?.credentials.refresh).toBe(REFRESH_TOKEN);
+    expect(saved?.credentials.idToken).toBe(ID_TOKEN);
   });
 
   it("emits an account-free error state when the exchange fails", async () => {

--- a/packages/auth/src/oauth-flow.test.ts
+++ b/packages/auth/src/oauth-flow.test.ts
@@ -72,6 +72,33 @@ afterEach(() => {
 });
 
 describe("oauth-flow FlowState broadcast", () => {
+  it("accepts a pasted localhost callback for remote Codex clients", async () => {
+    useTempElizaHome();
+    let submitted = "";
+    vi.mocked(startCodexLogin).mockResolvedValue({
+      authUrl: "https://auth.openai.com/authorize?state=fake-state",
+      state: "fake-state",
+      submitCode: (code) => {
+        submitted = code;
+      },
+      credentials: new Promise<OAuthCredentials>(() => undefined),
+      close: () => undefined,
+    });
+
+    const handle = await startCodexOAuthFlow({
+      label: "Remote",
+      accountId: "acct-remote",
+    });
+    const callback =
+      "http://localhost:1455/auth/callback?code=test-code&state=fake-state";
+
+    expect(handle.needsCodeSubmission).toBe(true);
+    handle.submitCode(callback);
+    expect(submitted).toBe(callback);
+    handle.cancel();
+    await expect(handle.completion).rejects.toThrow("Cancelled");
+  });
+
   it("emits a success state without the OAuth tokens", async () => {
     useTempElizaHome();
     const vendor = stubCodexLogin();

--- a/packages/auth/src/oauth-flow.test.ts
+++ b/packages/auth/src/oauth-flow.test.ts
@@ -12,7 +12,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { loadAccount } from "./account-storage";
+import { listAccounts, loadAccount } from "./account-storage";
 import {
   _resetFlowRegistry,
   type FlowState,
@@ -32,6 +32,10 @@ vi.mock("./openai-codex.ts", () => ({
 const ACCESS_TOKEN = "codex-access-token-SECRET";
 const REFRESH_TOKEN = "codex-refresh-token-SECRET";
 const ID_TOKEN = "codex-id-token-SECRET";
+
+function jwt(payload: Record<string, unknown>): string {
+  return `header.${Buffer.from(JSON.stringify(payload)).toString("base64url")}.signature`;
+}
 
 const tempHomes: string[] = [];
 
@@ -264,6 +268,51 @@ describe("oauth-flow FlowState broadcast", () => {
     expect(saved?.credentials.access).toBe(ACCESS_TOKEN);
     expect(saved?.credentials.refresh).toBe(REFRESH_TOKEN);
     expect(saved?.credentials.idToken).toBe(ID_TOKEN);
+  });
+
+  it("updates an existing account when the same Codex identity is linked again", async () => {
+    useTempElizaHome();
+    const identity = "stable-codex-account-id";
+    const email = "person@example.com";
+    const access = jwt({
+      "https://api.openai.com/auth": { chatgpt_account_id: identity },
+    });
+    const idToken = jwt({ email });
+
+    const firstVendor = stubCodexLogin();
+    const first = await startCodexOAuthFlow({
+      label: "First link",
+      accountId: "reserved-id-1",
+    });
+    firstVendor.resolveCredentials({
+      access,
+      refresh: "first-refresh",
+      expires: Date.now() + 60_000,
+      idToken,
+    });
+    const firstAccount = (await first.completion).account;
+
+    const secondVendor = stubCodexLogin();
+    const second = await startCodexOAuthFlow({
+      label: "Second link",
+      accountId: "reserved-id-2",
+    });
+    secondVendor.resolveCredentials({
+      access,
+      refresh: "updated-refresh",
+      expires: Date.now() + 120_000,
+      idToken,
+    });
+    const secondAccount = (await second.completion).account;
+
+    expect(secondAccount.id).toBe(firstAccount.id);
+    expect(secondAccount.createdAt).toBe(firstAccount.createdAt);
+    expect(secondAccount.label).toBe(email);
+    expect(listAccounts("openai-codex")).toHaveLength(1);
+    expect(
+      loadAccount("openai-codex", firstAccount.id)?.credentials.refresh,
+    ).toBe("updated-refresh");
+    expect(loadAccount("openai-codex", "reserved-id-2")).toBeNull();
   });
 
   it("emits an account-free error state when the exchange fails", async () => {

--- a/packages/auth/src/oauth-flow.test.ts
+++ b/packages/auth/src/oauth-flow.test.ts
@@ -19,6 +19,7 @@ import {
   _resetFlowRegistry,
   type FlowState,
   startCodexOAuthFlow,
+  submitProviderFlowCode,
   subscribeFlow,
 } from "./oauth-flow";
 import type { CodexFlow } from "./openai-codex";
@@ -93,7 +94,13 @@ describe("oauth-flow FlowState broadcast", () => {
       "http://localhost:1455/auth/callback?code=test-code&state=fake-state";
 
     expect(handle.needsCodeSubmission).toBe(true);
-    handle.submitCode(callback);
+    expect(
+      submitProviderFlowCode(
+        "openai-codex",
+        "http://localhost:1455/auth/callback?code=wrong&state=other-state",
+      ),
+    ).toBeNull();
+    expect(submitProviderFlowCode("openai-codex", callback)).toBe(handle);
     expect(submitted).toBe(callback);
     handle.cancel();
     await expect(handle.completion).rejects.toThrow("Cancelled");

--- a/packages/auth/src/oauth-flow.ts
+++ b/packages/auth/src/oauth-flow.ts
@@ -34,11 +34,7 @@ import {
 
 /** Server-tracked status of an in-flight OAuth flow. */
 export type FlowStatus =
-  | "pending"
-  | "success"
-  | "error"
-  | "cancelled"
-  | "timeout";
+  "pending" | "success" | "error" | "cancelled" | "timeout";
 
 /**
  * Credential-free projection of an `AccountCredentialRecord` — the only
@@ -226,7 +222,12 @@ export function startCodexOAuthFlow(
 interface VendorFlow {
   authUrl: string;
   completion: Promise<{
-    creds: { access: string; refresh: string; expires: number };
+    creds: {
+      access: string;
+      refresh: string;
+      expires: number;
+      idToken?: string;
+    };
     codexFlow?: CodexFlow;
   }>;
   submitCode: (code: string) => void;
@@ -301,20 +302,30 @@ async function startGenericFlow(args: {
       const { creds } = await vendor.completion;
       clearTimeout(timer);
       let organizationId: string | undefined;
+      let email: string | undefined;
+      let providerAccountId: string | undefined;
+      if (providerId === "anthropic-subscription") {
+        const profile = await fetchAnthropicOAuthProfile(creds.access);
+        organizationId = profile.organizationId;
+        email = profile.email;
+        providerAccountId = profile.accountId;
+      }
       // Codex bakes the account_id into the JWT — pull it back out for
       // the usage probe header.
       if (providerId === "openai-codex") {
         const codexAccountId = extractCodexAccountId(creds.access);
         if (codexAccountId) organizationId = codexAccountId;
+        email = extractJwtEmail(creds.idToken);
       }
       const record = persistAccount({
         providerId,
-        accountId,
-        label: opts.label,
+        accountId: providerAccountId ?? accountId,
+        label: email ?? opts.label,
         access: creds.access,
         refresh: creds.refresh,
         expires: creds.expires,
         ...(organizationId ? { organizationId } : {}),
+        ...(email ? { email } : {}),
       });
       if (opts.onAccountSaved) {
         await opts.onAccountSaved(record);
@@ -479,5 +490,64 @@ function extractCodexAccountId(accessToken: string): string | null {
       : null;
   } catch {
     return null;
+  }
+}
+
+function extractJwtEmail(token: string | undefined): string | undefined {
+  if (!token) return undefined;
+  try {
+    const payload = token.split(".")[1];
+    if (!payload) return undefined;
+    const decoded = JSON.parse(
+      Buffer.from(payload, "base64url").toString("utf-8"),
+    ) as Record<string, unknown>;
+    return typeof decoded.email === "string" && decoded.email.length > 0
+      ? decoded.email
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function fetchAnthropicOAuthProfile(accessToken: string): Promise<{
+  email?: string;
+  accountId?: string;
+  organizationId?: string;
+}> {
+  try {
+    const response = await fetch(
+      "https://api.anthropic.com/api/oauth/profile",
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "anthropic-beta": "oauth-2025-04-20",
+          "Content-Type": "application/json",
+        },
+        signal: AbortSignal.timeout(10_000),
+      },
+    );
+    if (!response.ok) return {};
+    const profile = (await response.json()) as {
+      account?: { uuid?: unknown; email?: unknown; email_address?: unknown };
+      organization?: { uuid?: unknown };
+    };
+    const rawEmail = profile.account?.email ?? profile.account?.email_address;
+    const rawAccountId = profile.account?.uuid;
+    const rawOrganizationId = profile.organization?.uuid;
+    return {
+      ...(typeof rawEmail === "string" && rawEmail.length > 0
+        ? { email: rawEmail }
+        : {}),
+      ...(typeof rawAccountId === "string" && rawAccountId.length > 0
+        ? { accountId: rawAccountId }
+        : {}),
+      ...(typeof rawOrganizationId === "string" && rawOrganizationId.length > 0
+        ? { organizationId: rawOrganizationId }
+        : {}),
+    };
+  } catch {
+    // Identity enrichment is best-effort; credential persistence must still
+    // succeed when the profile endpoint is temporarily unavailable.
+    return {};
   }
 }

--- a/packages/auth/src/oauth-flow.ts
+++ b/packages/auth/src/oauth-flow.ts
@@ -19,7 +19,7 @@
  */
 
 import crypto from "node:crypto";
-import { logger } from "@elizaos/core";
+import { ElizaError, logger } from "@elizaos/core";
 import {
   type AccountCredentialRecord,
   saveAccount,
@@ -580,49 +580,81 @@ function extractJwtEmail(token: string | undefined): string | undefined {
       ? decoded.email
       : undefined;
   } catch {
+    // error-policy:J3 untrusted-input sanitizing — an imported id_token without
+    // a decodable JWT payload has no usable email identity.
     return undefined;
   }
 }
 
-export async function fetchAnthropicOAuthProfile(accessToken: string): Promise<{
+export async function fetchAnthropicOAuthProfile(
+  accessToken: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<{
   email?: string;
   accountId?: string;
   organizationId?: string;
 }> {
+  let response: Response;
   try {
-    const response = await fetch(
-      "https://api.anthropic.com/api/oauth/profile",
-      {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-          "anthropic-beta": "oauth-2025-04-20",
-          "Content-Type": "application/json",
-        },
-        signal: AbortSignal.timeout(10_000),
+    response = await fetchImpl("https://api.anthropic.com/api/oauth/profile", {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "anthropic-beta": "oauth-2025-04-20",
+        "Content-Type": "application/json",
       },
-    );
-    if (!response.ok) return {};
-    const profile = (await response.json()) as {
-      account?: { uuid?: unknown; email?: unknown; email_address?: unknown };
-      organization?: { uuid?: unknown };
-    };
-    const rawEmail = profile.account?.email ?? profile.account?.email_address;
-    const rawAccountId = profile.account?.uuid;
-    const rawOrganizationId = profile.organization?.uuid;
-    return {
-      ...(typeof rawEmail === "string" && rawEmail.length > 0
-        ? { email: rawEmail }
-        : {}),
-      ...(typeof rawAccountId === "string" && rawAccountId.length > 0
-        ? { accountId: rawAccountId }
-        : {}),
-      ...(typeof rawOrganizationId === "string" && rawOrganizationId.length > 0
-        ? { organizationId: rawOrganizationId }
-        : {}),
-    };
-  } catch {
-    // Identity enrichment is best-effort; credential persistence must still
-    // succeed when the profile endpoint is temporarily unavailable.
-    return {};
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch (cause) {
+    // error-policy:J2 context-adding rethrow — account linking cannot claim a
+    // loaded identity when the authenticated profile request never completed.
+    throw new ElizaError("Anthropic OAuth profile request failed", {
+      code: "anthropic_oauth.profile_request_failed",
+      severity: "ephemeral",
+      cause,
+    });
   }
+  if (!response.ok) {
+    throw new ElizaError("Anthropic OAuth profile request was rejected", {
+      code: "anthropic_oauth.profile_http_error",
+      severity: response.status >= 500 ? "ephemeral" : "fatal",
+      context: { status: response.status },
+    });
+  }
+
+  let profile: unknown;
+  try {
+    profile = await response.json();
+  } catch (cause) {
+    // error-policy:J2 context-adding rethrow — malformed authenticated data is
+    // a failed profile load, not a valid profile with empty identity fields.
+    throw new ElizaError("Anthropic OAuth profile response was not JSON", {
+      code: "anthropic_oauth.profile_invalid_json",
+      severity: "fatal",
+      cause,
+    });
+  }
+  if (!profile || typeof profile !== "object" || Array.isArray(profile)) {
+    throw new ElizaError("Anthropic OAuth profile response was invalid", {
+      code: "anthropic_oauth.profile_invalid_shape",
+      severity: "fatal",
+    });
+  }
+  const record = profile as {
+    account?: { uuid?: unknown; email?: unknown; email_address?: unknown };
+    organization?: { uuid?: unknown };
+  };
+  const rawEmail = record.account?.email ?? record.account?.email_address;
+  const rawAccountId = record.account?.uuid;
+  const rawOrganizationId = record.organization?.uuid;
+  return {
+    ...(typeof rawEmail === "string" && rawEmail.length > 0
+      ? { email: rawEmail }
+      : {}),
+    ...(typeof rawAccountId === "string" && rawAccountId.length > 0
+      ? { accountId: rawAccountId }
+      : {}),
+    ...(typeof rawOrganizationId === "string" && rawOrganizationId.length > 0
+      ? { organizationId: rawOrganizationId }
+      : {}),
+  };
 }

--- a/packages/auth/src/oauth-flow.ts
+++ b/packages/auth/src/oauth-flow.ts
@@ -6,7 +6,7 @@
  * `vendor/pi-oauth/anthropic-login.ts` and the loopback-listener flow
  * in `openai-codex.ts`) with:
  *
- *   - a 5-minute timeout per flow,
+ *   - a 15-minute timeout per flow,
  *   - automatic `saveAccount(...)` after token exchange,
  *   - an in-memory registry keyed by `sessionId` so the HTTP API can
  *     stream progress over SSE and the CLI can `await` completion,
@@ -34,7 +34,11 @@ import {
 
 /** Server-tracked status of an in-flight OAuth flow. */
 export type FlowStatus =
-  "pending" | "success" | "error" | "cancelled" | "timeout";
+  | "pending"
+  | "success"
+  | "error"
+  | "cancelled"
+  | "timeout";
 
 /**
  * Credential-free projection of an `AccountCredentialRecord` — the only
@@ -71,7 +75,12 @@ export interface OAuthFlowHandle {
   cancel: (reason?: string) => void;
 }
 
-const FLOW_TIMEOUT_MS = 5 * 60 * 1000;
+// Browser subscription login can include MFA, account selection, and consent.
+// Five minutes routinely expired before a remote user could copy the loopback
+// callback URL back into Eliza, destroying the PKCE verifier. Keep the verifier
+// in memory long enough for a normal interactive login while retaining a hard
+// upper bound and terminal-state cleanup.
+const FLOW_TIMEOUT_MS = 15 * 60 * 1000;
 const FLOW_GC_MS = 10 * 60 * 1000;
 
 interface InternalFlowEntry {
@@ -265,6 +274,11 @@ async function startGenericFlow(args: {
       rejectCompletion = reject;
     },
   );
+  // HTTP/SSE callers observe terminal state through the registry and may never
+  // await this in-process promise. Attach a rejection observer so timeout or
+  // cancellation does not become a process-level unhandled rejection; callers
+  // that do await `completion` still receive the original rejection.
+  void completion.catch(() => undefined);
 
   const entry: InternalFlowEntry = {
     state: initialState,

--- a/packages/auth/src/oauth-flow.ts
+++ b/packages/auth/src/oauth-flow.ts
@@ -509,7 +509,7 @@ function extractJwtEmail(token: string | undefined): string | undefined {
   }
 }
 
-async function fetchAnthropicOAuthProfile(accessToken: string): Promise<{
+export async function fetchAnthropicOAuthProfile(accessToken: string): Promise<{
   email?: string;
   accountId?: string;
   organizationId?: string;

--- a/packages/auth/src/oauth-flow.ts
+++ b/packages/auth/src/oauth-flow.ts
@@ -278,6 +278,8 @@ async function startGenericFlow(args: {
   // await this in-process promise. Attach a rejection observer so timeout or
   // cancellation does not become a process-level unhandled rejection; callers
   // that do await `completion` still receive the original rejection.
+  // error-policy:J5 terminal state is observed through the flow registry/SSE;
+  // callers awaiting `completion` still receive the original rejection.
   void completion.catch(() => undefined);
 
   const entry: InternalFlowEntry = {
@@ -445,12 +447,7 @@ export function submitProviderFlowCode(
   providerId: SubscriptionProvider,
   code: string,
 ): OAuthFlowHandle | null {
-  let callbackState: string | null = null;
-  try {
-    callbackState = new URL(code).searchParams.get("state");
-  } catch {
-    // Raw authorization codes have no state to match.
-  }
+  const callbackState = URL.parse(code)?.searchParams.get("state") ?? null;
 
   const candidates = [...flows.values()].filter(
     (entry) =>
@@ -459,16 +456,11 @@ export function submitProviderFlowCode(
       entry.state.needsCodeSubmission,
   );
   const matching = callbackState
-    ? candidates.filter((entry) => {
-        try {
-          return (
-            new URL(entry.state.authUrl ?? "").searchParams.get("state") ===
-            callbackState
-          );
-        } catch {
-          return false;
-        }
-      })
+    ? candidates.filter(
+        (entry) =>
+          URL.parse(entry.state.authUrl ?? "")?.searchParams.get("state") ===
+          callbackState,
+      )
     : candidates;
   if (matching.length !== 1) return null;
   matching[0]?.handle.submitCode(code);

--- a/packages/auth/src/oauth-flow.ts
+++ b/packages/auth/src/oauth-flow.ts
@@ -435,6 +435,47 @@ export function submitFlowCode(sessionId: string, code: string): boolean {
 }
 
 /**
+ * Submit a callback to the pending flow for a provider when a legacy client
+ * does not know the newer account-flow session id. A callback `state` is
+ * matched against the authorization URL, so parallel flows cannot consume one
+ * another's PKCE code. A state-less raw code is accepted only when exactly one
+ * provider flow is pending.
+ */
+export function submitProviderFlowCode(
+  providerId: SubscriptionProvider,
+  code: string,
+): OAuthFlowHandle | null {
+  let callbackState: string | null = null;
+  try {
+    callbackState = new URL(code).searchParams.get("state");
+  } catch {
+    // Raw authorization codes have no state to match.
+  }
+
+  const candidates = [...flows.values()].filter(
+    (entry) =>
+      entry.state.providerId === providerId &&
+      entry.state.status === "pending" &&
+      entry.state.needsCodeSubmission,
+  );
+  const matching = callbackState
+    ? candidates.filter((entry) => {
+        try {
+          return (
+            new URL(entry.state.authUrl ?? "").searchParams.get("state") ===
+            callbackState
+          );
+        } catch {
+          return false;
+        }
+      })
+    : candidates;
+  if (matching.length !== 1) return null;
+  matching[0]?.handle.submitCode(code);
+  return matching[0]?.handle ?? null;
+}
+
+/**
  * Remove every flow from the registry. Tests use this to reset
  * between cases without resetting the whole module.
  */

--- a/packages/auth/src/oauth-flow.ts
+++ b/packages/auth/src/oauth-flow.ts
@@ -24,6 +24,7 @@ import {
   type AccountCredentialRecord,
   saveAccount,
 } from "./account-storage.ts";
+import { startCodexDeviceLogin } from "./codex-device.ts";
 import type { CodexFlow } from "./openai-codex.ts";
 import { startCodexLogin } from "./openai-codex.ts";
 import type { SubscriptionProvider } from "./types.ts";
@@ -66,6 +67,8 @@ export interface FlowState {
 export interface OAuthFlowHandle {
   sessionId: string;
   authUrl: string;
+  /** One-time code entered on the provider's device authorization page. */
+  userCode?: string;
   /** Whether the client must offer a callback URL/code input. */
   needsCodeSubmission: boolean;
   /** Resolves with the saved AccountCredentialRecord; rejects on cancel/timeout/error. */
@@ -152,6 +155,8 @@ function persistAccount(args: {
 interface StartOptions {
   label: string;
   accountId?: string;
+  /** Remote/headless clients use Codex device auth instead of loopback PKCE. */
+  headless?: boolean;
   /**
    * Called after the account is saved on disk. Used by the HTTP
    * route layer to also write a `LinkedAccountConfig` row into
@@ -207,6 +212,23 @@ export function startAnthropicOAuthFlow(
 export function startCodexOAuthFlow(
   opts: StartOptions,
 ): Promise<OAuthFlowHandle> {
+  if (opts.headless) {
+    return startGenericFlow({
+      providerId: "openai-codex",
+      opts,
+      needsCodeSubmission: false,
+      begin: async () => {
+        const flow = await startCodexDeviceLogin();
+        return {
+          authUrl: flow.authUrl,
+          userCode: flow.userCode,
+          completion: flow.credentials.then((creds) => ({ creds })),
+          submitCode: () => undefined,
+          cancel: () => flow.close(),
+        };
+      },
+    });
+  }
   return startGenericFlow({
     providerId: "openai-codex",
     opts,
@@ -231,6 +253,7 @@ export function startCodexOAuthFlow(
 
 interface VendorFlow {
   authUrl: string;
+  userCode?: string;
   completion: Promise<{
     creds: {
       access: string;
@@ -364,6 +387,7 @@ async function startGenericFlow(args: {
   const handle: OAuthFlowHandle = {
     sessionId,
     authUrl: vendor.authUrl,
+    ...(vendor.userCode ? { userCode: vendor.userCode } : {}),
     needsCodeSubmission,
     completion,
     submitCode: (code: string) => {

--- a/packages/auth/src/oauth-flow.ts
+++ b/packages/auth/src/oauth-flow.ts
@@ -22,6 +22,7 @@ import crypto from "node:crypto";
 import { ElizaError, logger } from "@elizaos/core";
 import {
   type AccountCredentialRecord,
+  listAccounts,
   saveAccount,
 } from "./account-storage.ts";
 import { startCodexDeviceLogin } from "./codex-device.ts";
@@ -134,8 +135,22 @@ function persistAccount(args: {
   email?: string;
 }): AccountCredentialRecord {
   const now = Date.now();
+  const normalizedEmail = args.email?.trim().toLowerCase();
+  const existing = listAccounts(args.providerId).find((account) => {
+    if (args.organizationId && account.organizationId === args.organizationId) {
+      return true;
+    }
+    return Boolean(
+      normalizedEmail &&
+        account.email?.trim().toLowerCase() === normalizedEmail,
+    );
+  });
   const record: AccountCredentialRecord = {
-    id: args.accountId,
+    // OAuth starts before the provider identity is known, so callers commonly
+    // reserve a fresh UUID for every attempt. Once we have a stable provider
+    // identity, update its existing credential record instead of creating a
+    // duplicate account on every relink.
+    id: existing?.id ?? args.accountId,
     providerId: args.providerId,
     label: args.label,
     source: "oauth",
@@ -145,8 +160,10 @@ function persistAccount(args: {
       expires: args.expires,
       ...(args.idToken ? { idToken: args.idToken } : {}),
     },
-    createdAt: now,
+    createdAt: existing?.createdAt ?? now,
     updatedAt: now,
+    ...(existing?.lastUsedAt ? { lastUsedAt: existing.lastUsedAt } : {}),
+    ...(existing?.userId ? { userId: existing.userId } : {}),
     ...(args.organizationId ? { organizationId: args.organizationId } : {}),
     ...(args.email ? { email: args.email } : {}),
   };

--- a/packages/auth/src/oauth-flow.ts
+++ b/packages/auth/src/oauth-flow.ts
@@ -129,6 +129,7 @@ function persistAccount(args: {
   access: string;
   refresh: string;
   expires: number;
+  idToken?: string;
   organizationId?: string;
   email?: string;
 }): AccountCredentialRecord {
@@ -142,6 +143,7 @@ function persistAccount(args: {
       access: args.access,
       refresh: args.refresh,
       expires: args.expires,
+      ...(args.idToken ? { idToken: args.idToken } : {}),
     },
     createdAt: now,
     updatedAt: now,
@@ -364,6 +366,7 @@ async function startGenericFlow(args: {
         access: creds.access,
         refresh: creds.refresh,
         expires: creds.expires,
+        ...(creds.idToken ? { idToken: creds.idToken } : {}),
         ...(organizationId ? { organizationId } : {}),
         ...(email ? { email } : {}),
       });

--- a/packages/auth/src/oauth-flow.ts
+++ b/packages/auth/src/oauth-flow.ts
@@ -51,7 +51,7 @@ export interface FlowState {
   status: FlowStatus;
   /** Set on `pending` (so the UI can re-open the browser) and on `success`. */
   authUrl?: string;
-  /** Anthropic only — the user must paste `code#state`; Codex uses the loopback callback. */
+  /** Whether the client must offer a callback URL/code input. */
   needsCodeSubmission: boolean;
   account?: FlowAccountSummary;
   error?: string;
@@ -62,11 +62,11 @@ export interface FlowState {
 export interface OAuthFlowHandle {
   sessionId: string;
   authUrl: string;
-  /** Codex flows resolve via the loopback listener; Anthropic requires `submitCode`. */
+  /** Whether the client must offer a callback URL/code input. */
   needsCodeSubmission: boolean;
   /** Resolves with the saved AccountCredentialRecord; rejects on cancel/timeout/error. */
   completion: Promise<{ account: AccountCredentialRecord }>;
-  /** Anthropic only — submit `code#state` from the redirect page. Ignored for Codex. */
+  /** Submit the provider's callback URL or authorization code. */
   submitCode: (code: string) => void;
   cancel: (reason?: string) => void;
 }
@@ -188,9 +188,10 @@ export function startAnthropicOAuthFlow(
 // Codex (OpenAI ChatGPT subscription).
 
 /**
- * Start a programmatic Codex OAuth flow. Codex has a loopback listener
- * on :1455, so the user just signs in in the browser and the listener
- * picks up the redirect — `submitCode()` is accepted but unused. The accountId
+ * Start a programmatic Codex OAuth flow. Native/local clients can use the
+ * loopback listener on :1455. Remote web clients must paste the localhost
+ * callback URL because that URL resolves in the browser's device, not on the
+ * remote Eliza host. The accountId
  * baked into the JWT is preserved on `LinkedAccountConfig.organizationId`
  * (used by the Codex usage probe via the `ChatGPT-Account-Id` header).
  */
@@ -200,7 +201,7 @@ export function startCodexOAuthFlow(
   return startGenericFlow({
     providerId: "openai-codex",
     opts,
-    needsCodeSubmission: false,
+    needsCodeSubmission: true,
     begin: async () => {
       const flow: CodexFlow = await startCodexLogin();
       const completion = (async () => {

--- a/packages/auth/src/vendor/pi-oauth/anthropic-login.test.ts
+++ b/packages/auth/src/vendor/pi-oauth/anthropic-login.test.ts
@@ -1,5 +1,11 @@
+/** Verifies Anthropic OAuth exchange, refresh rotation, and callback state validation at the HTTP boundary. */
+
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { refreshAnthropicToken } from "./anthropic-login.ts";
+import {
+  exchangeAnthropicAuthorizationCode,
+  refreshAnthropicToken,
+  startAnthropicOAuthFlowRaw,
+} from "./anthropic-login.ts";
 
 function mockTokenResponse(body: unknown, ok = true): void {
   vi.stubGlobal(
@@ -48,5 +54,56 @@ describe("refreshAnthropicToken", () => {
     await expect(refreshAnthropicToken("rt-old")).rejects.toThrow(
       /Anthropic token refresh failed/,
     );
+  });
+});
+
+describe("Anthropic authorization exchange", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("accepts a localhost callback through the state-checked flow", async () => {
+    mockTokenResponse({
+      refresh_token: "rt-new",
+      access_token: "at-new",
+      expires_in: 3600,
+    });
+    const flow = await startAnthropicOAuthFlowRaw();
+    const verifier = new URL(flow.authUrl).searchParams.get("state");
+    if (!verifier) throw new Error("authorization URL omitted state");
+
+    flow.submitCode(
+      `http://localhost:1455/auth/callback?code=auth-code&state=${encodeURIComponent(verifier)}`,
+    );
+
+    await expect(flow.completion).resolves.toMatchObject({
+      refresh: "rt-new",
+      access: "at-new",
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      "https://console.anthropic.com/v1/oauth/token",
+      expect.objectContaining({
+        body: expect.stringContaining('"code":"auth-code"'),
+      }),
+    );
+  });
+
+  it("rejects a callback whose state does not match the active flow", async () => {
+    const flow = await startAnthropicOAuthFlowRaw();
+    flow.submitCode(
+      "http://127.0.0.1:1455/auth/callback?code=auth-code&state=wrong-state",
+    );
+    await expect(flow.completion).rejects.toThrow("state mismatch");
+  });
+
+  it("rejects malformed and non-local callback inputs", async () => {
+    await expect(
+      exchangeAnthropicAuthorizationCode("missing-state"),
+    ).rejects.toThrow("code#state");
+    await expect(
+      exchangeAnthropicAuthorizationCode(
+        "https://attacker.example/callback?code=auth-code&state=state",
+      ),
+    ).rejects.toThrow("code#state");
   });
 });

--- a/packages/auth/src/vendor/pi-oauth/anthropic-login.ts
+++ b/packages/auth/src/vendor/pi-oauth/anthropic-login.ts
@@ -40,27 +40,35 @@ export interface AnthropicOAuthFlowHandle {
   cancel: (reason?: string) => void;
 }
 
-export async function exchangeAnthropicAuthorizationCode(
-  authCode: string,
-): Promise<AnthropicOAuthCredentials> {
-  let code: string | undefined;
-  let verifier: string | undefined;
-  if (URL.canParse(authCode.trim())) {
-    const callback = new URL(authCode.trim());
+function parseAnthropicAuthorizationInput(authCode: string): {
+  code: string;
+  verifier: string;
+} {
+  const input = authCode.trim();
+  if (URL.canParse(input)) {
+    const callback = new URL(input);
     if (
       callback.hostname === "localhost" ||
       callback.hostname === "127.0.0.1"
     ) {
-      code = callback.searchParams.get("code") ?? undefined;
-      verifier = callback.searchParams.get("state") ?? undefined;
+      const code = callback.searchParams.get("code");
+      const verifier = callback.searchParams.get("state");
+      if (code && verifier) return { code, verifier };
     }
   }
-  if (!code || !verifier) [code, verifier] = authCode.trim().split("#", 2);
+  const [code, verifier] = input.split("#", 2);
   if (!code || !verifier) {
     throw new Error(
       "Anthropic authorization input must be code#state or a localhost callback URL",
     );
   }
+  return { code, verifier };
+}
+
+export async function exchangeAnthropicAuthorizationCode(
+  authCode: string,
+): Promise<AnthropicOAuthCredentials> {
+  const { code, verifier } = parseAnthropicAuthorizationInput(authCode);
   const tokenResponse = await fetch(TOKEN_URL, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -118,8 +126,8 @@ export async function startAnthropicOAuthFlowRaw(): Promise<AnthropicOAuthFlowHa
 
   const completion = (async (): Promise<AnthropicOAuthCredentials> => {
     const authCode = await codePromise;
-    const state = authCode.split("#")[1];
-    if (state !== verifier) {
+    const parsed = parseAnthropicAuthorizationInput(authCode);
+    if (parsed.verifier !== verifier) {
       throw new Error(
         "Anthropic OAuth state mismatch: returned state does not match the request verifier",
       );

--- a/packages/auth/src/vendor/pi-oauth/anthropic-login.ts
+++ b/packages/auth/src/vendor/pi-oauth/anthropic-login.ts
@@ -40,6 +40,58 @@ export interface AnthropicOAuthFlowHandle {
   cancel: (reason?: string) => void;
 }
 
+export async function exchangeAnthropicAuthorizationCode(
+  authCode: string,
+): Promise<AnthropicOAuthCredentials> {
+  let code: string | undefined;
+  let verifier: string | undefined;
+  try {
+    const callback = new URL(authCode.trim());
+    if (
+      callback.hostname === "localhost" ||
+      callback.hostname === "127.0.0.1"
+    ) {
+      code = callback.searchParams.get("code") ?? undefined;
+      verifier = callback.searchParams.get("state") ?? undefined;
+    }
+  } catch {
+    // Raw Claude code#state input, handled below.
+  }
+  if (!code || !verifier) [code, verifier] = authCode.trim().split("#", 2);
+  if (!code || !verifier) {
+    throw new Error(
+      "Anthropic authorization input must be code#state or a localhost callback URL",
+    );
+  }
+  const tokenResponse = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      grant_type: "authorization_code",
+      client_id: CLIENT_ID,
+      code,
+      state: verifier,
+      redirect_uri: REDIRECT_URI,
+      code_verifier: verifier,
+    }),
+    signal: AbortSignal.timeout(5_000),
+  });
+  if (!tokenResponse.ok) {
+    const errText = await tokenResponse.text();
+    throw new Error(`Token exchange failed: ${errText}`);
+  }
+  const tokenData = (await tokenResponse.json()) as {
+    refresh_token: string;
+    access_token: string;
+    expires_in: number;
+  };
+  return {
+    refresh: tokenData.refresh_token,
+    access: tokenData.access_token,
+    expires: Date.now() + tokenData.expires_in * 1000 - 5 * 60 * 1000,
+  };
+}
+
 /**
  * Start an Anthropic OAuth flow. Returns immediately with the auth
  * URL and a `submitCode` hook. The token exchange happens inside
@@ -68,42 +120,13 @@ export async function startAnthropicOAuthFlowRaw(): Promise<AnthropicOAuthFlowHa
 
   const completion = (async (): Promise<AnthropicOAuthCredentials> => {
     const authCode = await codePromise;
-    const splits = authCode.split("#");
-    const code = splits[0];
-    const state = splits[1];
+    const state = authCode.split("#")[1];
     if (state !== verifier) {
       throw new Error(
         "Anthropic OAuth state mismatch: returned state does not match the request verifier",
       );
     }
-    const tokenResponse = await fetch(TOKEN_URL, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        grant_type: "authorization_code",
-        client_id: CLIENT_ID,
-        code,
-        state,
-        redirect_uri: REDIRECT_URI,
-        code_verifier: verifier,
-      }),
-      signal: AbortSignal.timeout(5_000),
-    });
-    if (!tokenResponse.ok) {
-      const errText = await tokenResponse.text();
-      throw new Error(`Token exchange failed: ${errText}`);
-    }
-    const tokenData = (await tokenResponse.json()) as {
-      refresh_token: string;
-      access_token: string;
-      expires_in: number;
-    };
-    const expiresAt = Date.now() + tokenData.expires_in * 1000 - 5 * 60 * 1000;
-    return {
-      refresh: tokenData.refresh_token,
-      access: tokenData.access_token,
-      expires: expiresAt,
-    };
+    return exchangeAnthropicAuthorizationCode(authCode);
   })();
 
   return {

--- a/packages/auth/src/vendor/pi-oauth/anthropic-login.ts
+++ b/packages/auth/src/vendor/pi-oauth/anthropic-login.ts
@@ -45,7 +45,7 @@ export async function exchangeAnthropicAuthorizationCode(
 ): Promise<AnthropicOAuthCredentials> {
   let code: string | undefined;
   let verifier: string | undefined;
-  try {
+  if (URL.canParse(authCode.trim())) {
     const callback = new URL(authCode.trim());
     if (
       callback.hostname === "localhost" ||
@@ -54,8 +54,6 @@ export async function exchangeAnthropicAuthorizationCode(
       code = callback.searchParams.get("code") ?? undefined;
       verifier = callback.searchParams.get("state") ?? undefined;
     }
-  } catch {
-    // Raw Claude code#state input, handled below.
   }
   if (!code || !verifier) [code, verifier] = authCode.trim().split("#", 2);
   if (!code || !verifier) {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2166,15 +2166,12 @@ export function App() {
     uiLanguage,
   ]);
 
-  // Skip the auth probe during first-run-required: there is no agent/session
-  // yet, so /api/auth/me would spuriously trip server_unavailable/unauthenticated
-  // on top of the in-chat onboarding (see useAuthStatus's own skip-during-first-run
-  // note). The in-chat conductor owns the first-run flow.
+  // Keep probing auth during first-run-required. A remote, already-initialized
+  // backend can return 401 for the protected first-run status route before this
+  // browser has an owner session. In that case the password wall must win over
+  // the in-chat Cloud onboarding surface.
   const { state: authState, refetch: refetchAuth } = useAuthStatus({
-    skip:
-      !isShellPaintableNow ||
-      startupCoordinator.phase === "first-run-required" ||
-      isPopout,
+    skip: !isShellPaintableNow || isPopout,
   });
   // #15132: after a dedicated cloud agent's container upgrade the persisted
   // agent credential is stale (every agent-subdomain call 401s) while the cloud
@@ -2701,7 +2698,8 @@ export function App() {
   if (
     isShellPaintableNow &&
     !isPopout &&
-    !firstRunOwnsLoginSurface(startupCoordinator.phase, firstRunComplete)
+    (!firstRunOwnsLoginSurface(startupCoordinator.phase, firstRunComplete) ||
+      authState.phase === "unauthenticated")
   ) {
     if (
       authProbeShouldHoldShell(
@@ -2768,7 +2766,21 @@ export function App() {
       }
       return (
         <BugReportProvider value={bugReport}>
-          <LoginView onLoginSuccess={refetchAuth} reason={authState.reason} />
+          <LoginView
+            onLoginSuccess={() => {
+              // A successful owner-password login proves this is an existing,
+              // initialized backend. Clear the stale unauthenticated browser's
+              // optimistic first-run state before remounting the shell.
+              setState("authRequired", false);
+              setState("firstRunComplete", true);
+              // Login can surface from either pairing-required or
+              // first-run-required. RETRY is the shared transition back into
+              // authenticated session restoration.
+              startupCoordinator.dispatch({ type: "RETRY" });
+              refetchAuth();
+            }}
+            reason={authState.reason}
+          />
           <BugReportModal />
         </BugReportProvider>
       );

--- a/packages/ui/src/api/client-agent.ts
+++ b/packages/ui/src/api/client-agent.ts
@@ -348,6 +348,7 @@ export interface AccountOAuthStartResult {
   sessionId: string;
   authUrl: string;
   needsCodeSubmission: boolean;
+  userCode?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -599,7 +600,7 @@ declare module "./client-base" {
     ): Promise<AccountRefreshUsageResult>;
     startAccountOAuth(
       providerId: LinkedAccountProviderId,
-      body: { label: string },
+      body: { label: string; mode?: "auto" | "localhost" | "device" },
     ): Promise<AccountOAuthStartResult>;
     submitAccountOAuthCode(
       providerId: LinkedAccountProviderId,

--- a/packages/ui/src/components/accounts/AccountList.tsx
+++ b/packages/ui/src/components/accounts/AccountList.tsx
@@ -9,7 +9,7 @@
 
 import type { LinkedAccountProviderId } from "@elizaos/shared";
 import { Plus } from "lucide-react";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import type { AccountWithCredentialFlag } from "../../api/client-agent";
 import { useAccounts } from "../../hooks/useAccounts";
 import { useAppSelector } from "../../state";
@@ -18,6 +18,7 @@ import { Spinner } from "../ui/spinner";
 import { AccountCard } from "./AccountCard";
 import { AddAccountDialog } from "./AddAccountDialog";
 import { RotationStrategyPicker } from "./RotationStrategyPicker";
+import { readSubscriptionOAuth } from "./subscription-oauth-state";
 
 interface AccountListProps {
   providerId: LinkedAccountProviderId;
@@ -26,7 +27,24 @@ interface AccountListProps {
 export function AccountList({ providerId }: AccountListProps) {
   const t = useAppSelector((s) => s.t);
   const accounts = useAccounts();
-  const [addDialogOpen, setAddDialogOpen] = useState(false);
+  const [addDialogOpen, setAddDialogOpen] = useState(
+    () => readSubscriptionOAuth(providerId) !== null,
+  );
+
+  useEffect(() => {
+    const restorePendingDialog = () => {
+      if (readSubscriptionOAuth(providerId)) setAddDialogOpen(true);
+    };
+    restorePendingDialog();
+    window.addEventListener("focus", restorePendingDialog);
+    window.addEventListener("pageshow", restorePendingDialog);
+    document.addEventListener("visibilitychange", restorePendingDialog);
+    return () => {
+      window.removeEventListener("focus", restorePendingDialog);
+      window.removeEventListener("pageshow", restorePendingDialog);
+      document.removeEventListener("visibilitychange", restorePendingDialog);
+    };
+  }, [providerId]);
 
   const providerEntry = useMemo(
     () => accounts.data?.providers.find((p) => p.providerId === providerId),

--- a/packages/ui/src/components/accounts/AddAccountDialog.test.ts
+++ b/packages/ui/src/components/accounts/AddAccountDialog.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { subscriptionOAuthModeForHostname } from "./subscription-oauth-mode";
+
+describe("subscriptionOAuthModeForHostname", () => {
+  it.each([
+    "localhost",
+    "LOCALHOST",
+    "127.0.0.1",
+    "::1",
+    "[::1]",
+  ])("uses loopback PKCE on %s", (hostname) => {
+    expect(subscriptionOAuthModeForHostname(hostname)).toBe("localhost");
+  });
+
+  it.each([
+    "ovh-eliza.tail4e11f5.ts.net",
+    "192.168.1.20",
+    "eliza.test",
+  ])("uses headless/device auth on %s", (hostname) => {
+    expect(subscriptionOAuthModeForHostname(hostname)).toBe("device");
+  });
+});

--- a/packages/ui/src/components/accounts/AddAccountDialog.tsx
+++ b/packages/ui/src/components/accounts/AddAccountDialog.tsx
@@ -50,6 +50,11 @@ import {
 import { Input } from "../ui/input";
 import { Label } from "../ui/label";
 import { Spinner } from "../ui/spinner";
+import {
+  clearSubscriptionOAuth,
+  readSubscriptionOAuth,
+  writeSubscriptionOAuth,
+} from "./subscription-oauth-state";
 
 interface AddAccountDialogProps {
   open: boolean;
@@ -186,6 +191,7 @@ export function AddAccountDialog({
 
   const eventSourceRef = useRef<EventSource | null>(null);
   const sessionIdRef = useRef<string | null>(null);
+  const restoredSessionRef = useRef<string | null>(null);
   // Mirrors the `open` prop in a ref so async paths (`startOAuth` mid-
   // await) can detect that the dialog was closed before
   // `client.startAccountOAuth` resolved and immediately cancel the
@@ -218,6 +224,7 @@ export function AddAccountDialog({
   const reset = useCallback(() => {
     closeEventSource();
     sessionIdRef.current = null;
+    restoredSessionRef.current = null;
     setStep(initialStepForProvider(providerId));
     setLabel("");
     setApiKey("");
@@ -226,15 +233,6 @@ export function AddAccountDialog({
     setSessionId(null);
     setDeviceCode(null);
   }, [closeEventSource, providerId]);
-
-  // Dialog open/close side-effects: when closed, cancel any in-flight
-  // OAuth flow so the server can release the loopback listener.
-  useEffect(() => {
-    if (!open) {
-      void cancelInflightFlow();
-      reset();
-    }
-  }, [open, cancelInflightFlow, reset]);
 
   useEffect(() => {
     return () => {
@@ -249,6 +247,7 @@ export function AddAccountDialog({
       const source = openEventSource(url);
       eventSourceRef.current = source;
       if (!source) {
+        clearSubscriptionOAuth(providerId);
         setErrorMessage(
           t("accounts.add.oauth.sseUnreachable", {
             defaultValue:
@@ -285,6 +284,8 @@ export function AddAccountDialog({
             cancelPersistentErrorTimer();
             closeEventSource();
             sessionIdRef.current = null;
+            clearSubscriptionOAuth(providerId);
+            clearSubscriptionOAuth(providerId);
             onCreated(data.account);
             onClose();
           } else if (
@@ -295,6 +296,7 @@ export function AddAccountDialog({
             cancelPersistentErrorTimer();
             closeEventSource();
             sessionIdRef.current = null;
+            clearSubscriptionOAuth(providerId);
             setErrorMessage(
               data.error ??
                 t(`accounts.add.oauth.${data.status}`, {
@@ -341,6 +343,20 @@ export function AddAccountDialog({
     [closeEventSource, onClose, onCreated, providerId, t],
   );
 
+  useEffect(() => {
+    if (!open) return;
+    const pending = readSubscriptionOAuth(providerId);
+    if (!pending || restoredSessionRef.current === pending.sessionId) return;
+    restoredSessionRef.current = pending.sessionId;
+    sessionIdRef.current = pending.sessionId;
+    setSessionId(pending.sessionId);
+    setDeviceCode(pending.deviceCode ?? null);
+    setStep(
+      pending.phase === "need-code" ? "oauth-need-code" : "oauth-waiting",
+    );
+    subscribeToFlow(pending.sessionId);
+  }, [open, providerId, subscribeToFlow]);
+
   const startOAuth = useCallback(
     async (mode: "localhost" | "device") => {
       if (subscriptionAddMode !== "oauth") {
@@ -380,16 +396,25 @@ export function AddAccountDialog({
           }
           return;
         }
-        navigatePreOpenedWindow(win, flow.authUrl);
         sessionIdRef.current = flow.sessionId;
+        restoredSessionRef.current = flow.sessionId;
         setSessionId(flow.sessionId);
         setDeviceCode(flow.userCode ?? null);
+        writeSubscriptionOAuth({
+          providerId,
+          sessionId: flow.sessionId,
+          mode,
+          phase: flow.needsCodeSubmission ? "need-code" : "waiting",
+          ...(flow.userCode ? { deviceCode: flow.userCode } : {}),
+          startedAt: Date.now(),
+        });
         if (flow.needsCodeSubmission) {
           setStep("oauth-need-code");
         } else {
           setStep("oauth-waiting");
         }
         subscribeToFlow(flow.sessionId);
+        navigatePreOpenedWindow(win, flow.authUrl);
       } catch (err) {
         setErrorMessage(
           err instanceof Error && err.message
@@ -466,9 +491,11 @@ export function AddAccountDialog({
   );
 
   const handleClose = useCallback(() => {
+    clearSubscriptionOAuth(providerId);
     void cancelInflightFlow();
+    reset();
     onClose();
-  }, [cancelInflightFlow, onClose]);
+  }, [cancelInflightFlow, onClose, providerId, reset]);
 
   const dialogDescription =
     subscriptionAddMode === "oauth"

--- a/packages/ui/src/components/accounts/AddAccountDialog.tsx
+++ b/packages/ui/src/components/accounts/AddAccountDialog.tsx
@@ -37,6 +37,7 @@ import { client } from "../../api";
 import { cn } from "../../lib/utils";
 import { useAppSelector } from "../../state";
 import { navigatePreOpenedWindow, preOpenWindow } from "../../utils";
+import { copyTextToClipboard } from "../../utils/clipboard";
 import { openEventSource } from "../../utils/event-source";
 import { Button } from "../ui/button";
 import {
@@ -197,6 +198,7 @@ export function AddAccountDialog({
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [deviceCode, setDeviceCode] = useState<string | null>(null);
+  const [deviceCodeCopied, setDeviceCodeCopied] = useState(false);
 
   const eventSourceRef = useRef<EventSource | null>(null);
   const sessionIdRef = useRef<string | null>(null);
@@ -232,7 +234,23 @@ export function AddAccountDialog({
     setErrorMessage(null);
     setSessionId(null);
     setDeviceCode(null);
+    setDeviceCodeCopied(false);
   }, [closeEventSource, providerId]);
+
+  const copyDeviceCode = useCallback(async (code: string) => {
+    try {
+      await copyTextToClipboard(code);
+      setDeviceCodeCopied(true);
+    } catch {
+      setDeviceCodeCopied(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!deviceCode) return;
+    setDeviceCodeCopied(false);
+    void copyDeviceCode(deviceCode);
+  }, [copyDeviceCode, deviceCode]);
 
   useEffect(() => {
     return () => {
@@ -616,6 +634,15 @@ export function AddAccountDialog({
                 <code className="select-all text-lg font-semibold tracking-widest text-txt">
                   {deviceCode}
                 </code>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="mx-auto mt-2 h-7 text-xs"
+                  onClick={() => void copyDeviceCode(deviceCode)}
+                >
+                  {deviceCodeCopied ? "Copied to clipboard" : "Copy code"}
+                </Button>
               </div>
             ) : null}
             <div className="flex items-center gap-3">

--- a/packages/ui/src/components/accounts/AddAccountDialog.tsx
+++ b/packages/ui/src/components/accounts/AddAccountDialog.tsx
@@ -50,6 +50,7 @@ import {
 import { Input } from "../ui/input";
 import { Label } from "../ui/label";
 import { Spinner } from "../ui/spinner";
+import { subscriptionOAuthModeForHostname } from "./subscription-oauth-mode";
 import {
   clearSubscriptionOAuth,
   readSubscriptionOAuth,
@@ -110,6 +111,14 @@ function initialStepForProvider(
   if (mode === "oauth") return "choose";
   if (mode === "external-cli" || mode === "unavailable") return "unavailable";
   return "apikey";
+}
+
+function defaultOAuthLabel(providerId: LinkedAccountProviderId): string {
+  return providerId === "anthropic-subscription"
+    ? "Claude account"
+    : providerId === "openai-codex"
+      ? "Codex account"
+      : "Subscription account";
 }
 
 function providerDisplayName(
@@ -182,7 +191,7 @@ export function AddAccountDialog({
   const [step, setStep] = useState<DialogStep>(
     initialStepForProvider(providerId),
   );
-  const [label, setLabel] = useState("");
+  const [label, setLabel] = useState(() => defaultOAuthLabel(providerId));
   const [apiKey, setApiKey] = useState("");
   const [oauthCode, setOauthCode] = useState("");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -192,15 +201,6 @@ export function AddAccountDialog({
   const eventSourceRef = useRef<EventSource | null>(null);
   const sessionIdRef = useRef<string | null>(null);
   const restoredSessionRef = useRef<string | null>(null);
-  // Mirrors the `open` prop in a ref so async paths (`startOAuth` mid-
-  // await) can detect that the dialog was closed before
-  // `client.startAccountOAuth` resolved and immediately cancel the
-  // freshly-created server-side flow.
-  const openRef = useRef(open);
-  useEffect(() => {
-    openRef.current = open;
-  }, [open]);
-
   const closeEventSource = useCallback(() => {
     if (eventSourceRef.current) {
       eventSourceRef.current.close();
@@ -226,7 +226,7 @@ export function AddAccountDialog({
     sessionIdRef.current = null;
     restoredSessionRef.current = null;
     setStep(initialStepForProvider(providerId));
-    setLabel("");
+    setLabel(defaultOAuthLabel(providerId));
     setApiKey("");
     setOauthCode("");
     setErrorMessage(null);
@@ -284,7 +284,6 @@ export function AddAccountDialog({
             cancelPersistentErrorTimer();
             closeEventSource();
             sessionIdRef.current = null;
-            clearSubscriptionOAuth(providerId);
             clearSubscriptionOAuth(providerId);
             onCreated(data.account);
             onClose();
@@ -376,26 +375,6 @@ export function AddAccountDialog({
           label: label.trim(),
           mode,
         });
-        // The dialog might have been closed between user clicking "Sign
-        // in" and the server returning the flow handle. If so, the
-        // server-side OAuth listener is orphaned — cancel it explicitly
-        // so the loopback port releases immediately instead of timing
-        // out in 5 minutes.
-        if (!openRef.current) {
-          try {
-            await client.cancelAccountOAuth(providerId, {
-              sessionId: flow.sessionId,
-            });
-          } catch {
-            // Best-effort.
-          }
-          try {
-            win?.close();
-          } catch {
-            // Cross-origin — ignore.
-          }
-          return;
-        }
         sessionIdRef.current = flow.sessionId;
         restoredSessionRef.current = flow.sessionId;
         setSessionId(flow.sessionId);
@@ -575,7 +554,12 @@ export function AddAccountDialog({
     <Dialog
       open={open}
       onOpenChange={(next) => {
-        if (!next) handleClose();
+        // Opening an external OAuth page can produce a transient dismiss from
+        // the dialog primitive as focus leaves this window. During a flow that
+        // is not a user cancellation: keep the controlled dialog and its code
+        // entry state alive. The visible Cancel button remains the one explicit
+        // operation that clears persisted state and cancels the server flow.
+        if (!next && step === "choose") handleClose();
       }}
     >
       <DialogContent className="max-w-md">
@@ -591,27 +575,26 @@ export function AddAccountDialog({
 
         {step === "choose" ? (
           <div className="grid gap-3 py-2">
-            {labelInput}
-            <div className="grid grid-cols-2 gap-2">
-              <Button
-                type="button"
-                variant="outline"
-                disabled={!label.trim()}
-                onClick={() => void startOAuth("localhost")}
-                className="h-10"
-              >
-                Localhost login
-              </Button>
-              <Button
-                type="button"
-                variant="default"
-                disabled={!label.trim()}
-                onClick={() => void startOAuth("device")}
-                className="h-10"
-              >
-                Device login
-              </Button>
-            </div>
+            <p className="text-xs text-muted">
+              The connected account's email address will be used as its name.
+            </p>
+            <Button
+              type="button"
+              variant="default"
+              onClick={() =>
+                void startOAuth(
+                  subscriptionOAuthModeForHostname(window.location.hostname),
+                )
+              }
+              className="h-10"
+            >
+              {subscriptionOAuthModeForHostname(window.location.hostname) ===
+              "localhost"
+                ? "Log in with localhost callback"
+                : providerId === "openai-codex"
+                  ? "Log in with device code"
+                  : "Log in and paste authorization code"}
+            </Button>
             {/* API-key path is intentionally hidden for subscription providers. */}
           </div>
         ) : null}

--- a/packages/ui/src/components/accounts/AddAccountDialog.tsx
+++ b/packages/ui/src/components/accounts/AddAccountDialog.tsx
@@ -182,6 +182,7 @@ export function AddAccountDialog({
   const [oauthCode, setOauthCode] = useState("");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [sessionId, setSessionId] = useState<string | null>(null);
+  const [deviceCode, setDeviceCode] = useState<string | null>(null);
 
   const eventSourceRef = useRef<EventSource | null>(null);
   const sessionIdRef = useRef<string | null>(null);
@@ -223,6 +224,7 @@ export function AddAccountDialog({
     setOauthCode("");
     setErrorMessage(null);
     setSessionId(null);
+    setDeviceCode(null);
   }, [closeEventSource, providerId]);
 
   // Dialog open/close side-effects: when closed, cancel any in-flight
@@ -339,68 +341,73 @@ export function AddAccountDialog({
     [closeEventSource, onClose, onCreated, providerId, t],
   );
 
-  const startOAuth = useCallback(async () => {
-    if (subscriptionAddMode !== "oauth") {
-      setStep("unavailable");
-      return;
-    }
-    setErrorMessage(null);
-    setStep("oauth-starting");
+  const startOAuth = useCallback(
+    async (mode: "localhost" | "device") => {
+      if (subscriptionAddMode !== "oauth") {
+        setStep("unavailable");
+        return;
+      }
+      setErrorMessage(null);
+      setStep("oauth-starting");
 
-    // Open the popup BEFORE the await so the browser sees a synchronous
-    // user-gesture-triggered window.open. Once we have the URL, navigate
-    // it. preOpenWindow returns null on desktop (Electrobun handles
-    // routing via the IPC call inside openExternalUrl).
-    const win = preOpenWindow();
-    try {
-      const flow = await client.startAccountOAuth(providerId, {
-        label: label.trim(),
-      });
-      // The dialog might have been closed between user clicking "Sign
-      // in" and the server returning the flow handle. If so, the
-      // server-side OAuth listener is orphaned — cancel it explicitly
-      // so the loopback port releases immediately instead of timing
-      // out in 5 minutes.
-      if (!openRef.current) {
-        try {
-          await client.cancelAccountOAuth(providerId, {
-            sessionId: flow.sessionId,
-          });
-        } catch {
-          // Best-effort.
+      // Open the popup BEFORE the await so the browser sees a synchronous
+      // user-gesture-triggered window.open. Once we have the URL, navigate
+      // it. preOpenWindow returns null on desktop (Electrobun handles
+      // routing via the IPC call inside openExternalUrl).
+      const win = preOpenWindow();
+      try {
+        const flow = await client.startAccountOAuth(providerId, {
+          label: label.trim(),
+          mode,
+        });
+        // The dialog might have been closed between user clicking "Sign
+        // in" and the server returning the flow handle. If so, the
+        // server-side OAuth listener is orphaned — cancel it explicitly
+        // so the loopback port releases immediately instead of timing
+        // out in 5 minutes.
+        if (!openRef.current) {
+          try {
+            await client.cancelAccountOAuth(providerId, {
+              sessionId: flow.sessionId,
+            });
+          } catch {
+            // Best-effort.
+          }
+          try {
+            win?.close();
+          } catch {
+            // Cross-origin — ignore.
+          }
+          return;
         }
+        navigatePreOpenedWindow(win, flow.authUrl);
+        sessionIdRef.current = flow.sessionId;
+        setSessionId(flow.sessionId);
+        setDeviceCode(flow.userCode ?? null);
+        if (flow.needsCodeSubmission) {
+          setStep("oauth-need-code");
+        } else {
+          setStep("oauth-waiting");
+        }
+        subscribeToFlow(flow.sessionId);
+      } catch (err) {
+        setErrorMessage(
+          err instanceof Error && err.message
+            ? err.message
+            : t("accounts.add.oauth.startFailed", {
+                defaultValue: "Failed to start login flow.",
+              }),
+        );
+        setStep("error");
         try {
           win?.close();
         } catch {
           // Cross-origin — ignore.
         }
-        return;
       }
-      navigatePreOpenedWindow(win, flow.authUrl);
-      sessionIdRef.current = flow.sessionId;
-      setSessionId(flow.sessionId);
-      if (flow.needsCodeSubmission) {
-        setStep("oauth-need-code");
-      } else {
-        setStep("oauth-waiting");
-      }
-      subscribeToFlow(flow.sessionId);
-    } catch (err) {
-      setErrorMessage(
-        err instanceof Error && err.message
-          ? err.message
-          : t("accounts.add.oauth.startFailed", {
-              defaultValue: "Failed to start login flow.",
-            }),
-      );
-      setStep("error");
-      try {
-        win?.close();
-      } catch {
-        // Cross-origin — ignore.
-      }
-    }
-  }, [label, providerId, subscribeToFlow, subscriptionAddMode, t]);
+    },
+    [label, providerId, subscribeToFlow, subscriptionAddMode, t],
+  );
 
   const submitOAuthCode = useCallback(
     async (event: FormEvent) => {
@@ -558,18 +565,26 @@ export function AddAccountDialog({
         {step === "choose" ? (
           <div className="grid gap-3 py-2">
             {labelInput}
-            <Button
-              type="button"
-              variant="default"
-              disabled={!label.trim()}
-              onClick={() => void startOAuth()}
-              className="h-10"
-            >
-              {t("accounts.add.signIn", {
-                defaultValue: `Sign in with ${providerDisplayName(providerId, t)}`,
-                provider: providerDisplayName(providerId, t),
-              })}
-            </Button>
+            <div className="grid grid-cols-2 gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                disabled={!label.trim()}
+                onClick={() => void startOAuth("localhost")}
+                className="h-10"
+              >
+                Localhost login
+              </Button>
+              <Button
+                type="button"
+                variant="default"
+                disabled={!label.trim()}
+                onClick={() => void startOAuth("device")}
+                className="h-10"
+              >
+                Device login
+              </Button>
+            </div>
             {/* API-key path is intentionally hidden for subscription providers. */}
           </div>
         ) : null}
@@ -585,6 +600,14 @@ export function AddAccountDialog({
 
         {step === "oauth-waiting" ? (
           <div className="grid gap-3 py-3 text-sm text-muted">
+            {deviceCode ? (
+              <div className="rounded border border-border bg-card p-3 text-center">
+                <p className="mb-1 text-xs">Enter this one-time code:</p>
+                <code className="select-all text-lg font-semibold tracking-widest text-txt">
+                  {deviceCode}
+                </code>
+              </div>
+            ) : null}
             <div className="flex items-center gap-3">
               <Spinner className="h-4 w-4" />
               <span>

--- a/packages/ui/src/components/accounts/subscription-oauth-mode.ts
+++ b/packages/ui/src/components/accounts/subscription-oauth-mode.ts
@@ -1,0 +1,15 @@
+export type SubscriptionOAuthMode = "localhost" | "device";
+
+export function subscriptionOAuthModeForHostname(
+  hostname: string,
+): SubscriptionOAuthMode {
+  const normalized = hostname
+    .trim()
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "");
+  return normalized === "localhost" ||
+    normalized === "127.0.0.1" ||
+    normalized === "::1"
+    ? "localhost"
+    : "device";
+}

--- a/packages/ui/src/components/accounts/subscription-oauth-state.test.ts
+++ b/packages/ui/src/components/accounts/subscription-oauth-state.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearSubscriptionOAuth,
+  readSubscriptionOAuth,
+  writeSubscriptionOAuth,
+} from "./subscription-oauth-state";
+
+describe("subscription OAuth persistence", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.useRealTimers();
+  });
+
+  it("restores a device flow and its one-time code after a remount", () => {
+    writeSubscriptionOAuth({
+      providerId: "openai-codex",
+      sessionId: "session-1",
+      mode: "device",
+      phase: "waiting",
+      deviceCode: "ABCD-EFGHI",
+      startedAt: Date.now(),
+    });
+
+    expect(readSubscriptionOAuth("openai-codex")).toMatchObject({
+      sessionId: "session-1",
+      mode: "device",
+      phase: "waiting",
+      deviceCode: "ABCD-EFGHI",
+    });
+  });
+
+  it("keeps provider flows isolated and clears only explicit cancellation", () => {
+    writeSubscriptionOAuth({
+      providerId: "anthropic-subscription",
+      sessionId: "claude-session",
+      mode: "device",
+      phase: "need-code",
+      startedAt: Date.now(),
+    });
+    expect(readSubscriptionOAuth("openai-codex")).toBeNull();
+    expect(readSubscriptionOAuth("anthropic-subscription")?.sessionId).toBe(
+      "claude-session",
+    );
+
+    clearSubscriptionOAuth("anthropic-subscription");
+    expect(readSubscriptionOAuth("anthropic-subscription")).toBeNull();
+  });
+
+  it("retires stale flow records instead of reopening dead sessions", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-11T00:00:00Z"));
+    writeSubscriptionOAuth({
+      providerId: "openai-codex",
+      sessionId: "expired",
+      mode: "localhost",
+      phase: "need-code",
+      startedAt: Date.now(),
+    });
+    vi.advanceTimersByTime(21 * 60 * 1000);
+    expect(readSubscriptionOAuth("openai-codex")).toBeNull();
+  });
+});

--- a/packages/ui/src/components/accounts/subscription-oauth-state.test.ts
+++ b/packages/ui/src/components/accounts/subscription-oauth-state.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment jsdom
+
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearSubscriptionOAuth,

--- a/packages/ui/src/components/accounts/subscription-oauth-state.ts
+++ b/packages/ui/src/components/accounts/subscription-oauth-state.ts
@@ -1,4 +1,5 @@
 import type { LinkedAccountProviderId } from "@elizaos/shared";
+import { shellLocalStorage } from "../../surface-realm-channel";
 
 const PREFIX = "eliza.subscription-oauth.v1";
 const MAX_AGE_MS = 20 * 60 * 1000;
@@ -35,7 +36,7 @@ export function readSubscriptionOAuth(
       typeof value.startedAt === "number" &&
       Date.now() - value.startedAt < MAX_AGE_MS;
     if (!valid) {
-      window.localStorage.removeItem(key(providerId));
+      shellLocalStorage.removeItem(key(providerId));
       return null;
     }
     return value as PersistedSubscriptionOAuth;
@@ -49,7 +50,7 @@ export function writeSubscriptionOAuth(
 ): void {
   if (typeof window === "undefined") return;
   try {
-    window.localStorage.setItem(key(value.providerId), JSON.stringify(value));
+    shellLocalStorage.setItem(key(value.providerId), JSON.stringify(value));
   } catch {
     // In-memory flow remains usable when storage is unavailable.
   }
@@ -60,7 +61,7 @@ export function clearSubscriptionOAuth(
 ): void {
   if (typeof window === "undefined") return;
   try {
-    window.localStorage.removeItem(key(providerId));
+    shellLocalStorage.removeItem(key(providerId));
   } catch {
     // Nothing else to clear.
   }

--- a/packages/ui/src/components/accounts/subscription-oauth-state.ts
+++ b/packages/ui/src/components/accounts/subscription-oauth-state.ts
@@ -1,0 +1,67 @@
+import type { LinkedAccountProviderId } from "@elizaos/shared";
+
+const PREFIX = "eliza.subscription-oauth.v1";
+const MAX_AGE_MS = 20 * 60 * 1000;
+
+export type SubscriptionOAuthMode = "localhost" | "device";
+export type SubscriptionOAuthPhase = "waiting" | "need-code";
+
+export interface PersistedSubscriptionOAuth {
+  providerId: LinkedAccountProviderId;
+  sessionId: string;
+  mode: SubscriptionOAuthMode;
+  phase: SubscriptionOAuthPhase;
+  deviceCode?: string;
+  startedAt: number;
+}
+
+function key(providerId: LinkedAccountProviderId): string {
+  return `${PREFIX}:${providerId}`;
+}
+
+export function readSubscriptionOAuth(
+  providerId: LinkedAccountProviderId,
+): PersistedSubscriptionOAuth | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(key(providerId));
+    if (!raw) return null;
+    const value = JSON.parse(raw) as Partial<PersistedSubscriptionOAuth>;
+    const valid =
+      value.providerId === providerId &&
+      typeof value.sessionId === "string" &&
+      (value.mode === "localhost" || value.mode === "device") &&
+      (value.phase === "waiting" || value.phase === "need-code") &&
+      typeof value.startedAt === "number" &&
+      Date.now() - value.startedAt < MAX_AGE_MS;
+    if (!valid) {
+      window.localStorage.removeItem(key(providerId));
+      return null;
+    }
+    return value as PersistedSubscriptionOAuth;
+  } catch {
+    return null;
+  }
+}
+
+export function writeSubscriptionOAuth(
+  value: PersistedSubscriptionOAuth,
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key(value.providerId), JSON.stringify(value));
+  } catch {
+    // In-memory flow remains usable when storage is unavailable.
+  }
+}
+
+export function clearSubscriptionOAuth(
+  providerId: LinkedAccountProviderId,
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(key(providerId));
+  } catch {
+    // Nothing else to clear.
+  }
+}

--- a/packages/ui/src/components/settings/ProviderPanels.tsx
+++ b/packages/ui/src/components/settings/ProviderPanels.tsx
@@ -6,13 +6,9 @@
  * button; ProviderSwitcher owns the selection state and passes it in as props.
  */
 
-import type {
-  LinkedAccountProviderId,
-  ModelOption,
-  SubscriptionProviderStatus,
-} from "@elizaos/shared";
+import type { LinkedAccountProviderId, ModelOption } from "@elizaos/shared";
 import { Cloud, Cpu, KeyRound, ShieldCheck } from "lucide-react";
-import type { ComponentType, Dispatch, ReactNode, SetStateAction } from "react";
+import type { ComponentType, ReactNode } from "react";
 import type {
   SUBSCRIPTION_PROVIDER_SELECTIONS,
   SubscriptionProviderSelectionId,
@@ -23,7 +19,6 @@ import { LocalInferencePanel } from "../local-inference/LocalInferencePanel";
 import { ApiKeyConfig } from "./ApiKeyConfig";
 import type { CloudModelSchema } from "./cloud-model-schema";
 import { ProviderRoutingPanel } from "./ProviderRoutingPanel";
-import { SubscriptionStatus } from "./SubscriptionStatus";
 import { SettingsActionButton } from "./settings-agent-rows";
 import type { PluginInfo } from "./useProviderEntries";
 
@@ -178,17 +173,10 @@ export interface SubscriptionPanelProps {
   visibleProviderPanelId: string;
   resolvedSelectedId: string | null;
   cloudCallsDisabled: boolean;
-  subscriptionStatus: SubscriptionProviderStatus[];
-  anthropicConnected: boolean;
-  setAnthropicConnected: Dispatch<SetStateAction<boolean>>;
-  anthropicCliDetected: boolean;
-  openaiConnected: boolean;
-  setOpenaiConnected: Dispatch<SetStateAction<boolean>>;
   onSelectSubscription: (
     providerId: SubscriptionProviderSelectionId,
     activate?: boolean,
   ) => Promise<void>;
-  loadSubscriptionStatus: () => Promise<void>;
 }
 
 export function SubscriptionPanel({
@@ -196,14 +184,7 @@ export function SubscriptionPanel({
   visibleProviderPanelId,
   resolvedSelectedId,
   cloudCallsDisabled,
-  subscriptionStatus,
-  anthropicConnected,
-  setAnthropicConnected,
-  anthropicCliDetected,
-  openaiConnected,
-  setOpenaiConnected,
   onSelectSubscription,
-  loadSubscriptionStatus,
 }: SubscriptionPanelProps) {
   const t = useAppSelector((s) => s.t);
   const showUseButton =
@@ -236,17 +217,10 @@ export function SubscriptionPanel({
             })}
           </div>
         ) : null}
-        <SubscriptionStatus
-          resolvedSelectedId={visibleProviderPanelId}
-          subscriptionStatus={subscriptionStatus}
-          anthropicConnected={anthropicConnected}
-          setAnthropicConnected={setAnthropicConnected}
-          anthropicCliDetected={anthropicCliDetected}
-          openaiConnected={openaiConnected}
-          setOpenaiConnected={setOpenaiConnected}
-          handleSelectSubscription={onSelectSubscription}
-          loadSubscriptionStatus={loadSubscriptionStatus}
-        />
+        <p className="mb-2 text-xs text-muted">
+          Add and manage subscription accounts below. Login state is preserved
+          while an external browser or device authorization is active.
+        </p>
         <AccountList providerId={selection.storedProvider} />
       </div>
     </div>

--- a/packages/ui/src/components/settings/ProviderSwitcher.tsx
+++ b/packages/ui/src/components/settings/ProviderSwitcher.tsx
@@ -293,14 +293,7 @@ export function ProviderSwitcher(props: ProviderSwitcherProps = {}) {
               visibleProviderPanelId={visibleProviderPanelId}
               resolvedSelectedId={resolvedSelectedId}
               cloudCallsDisabled={selection.cloudCallsDisabled}
-              subscriptionStatus={bootstrap.subscriptionStatus}
-              anthropicConnected={bootstrap.anthropicConnected}
-              setAnthropicConnected={bootstrap.setAnthropicConnected}
-              anthropicCliDetected={bootstrap.anthropicCliDetected}
-              openaiConnected={bootstrap.openaiConnected}
-              setOpenaiConnected={bootstrap.setOpenaiConnected}
               onSelectSubscription={selection.handleSelectSubscription}
-              loadSubscriptionStatus={bootstrap.loadSubscriptionStatus}
             />
           ) : null}
         </SettingsGroup>

--- a/packages/ui/src/components/settings/SubscriptionStatus.tsx
+++ b/packages/ui/src/components/settings/SubscriptionStatus.tsx
@@ -22,7 +22,7 @@ import {
   type SubscriptionProviderSelectionId,
 } from "../../providers";
 import { useAppSelector } from "../../state";
-import { openExternalUrl } from "../../utils";
+import { navigatePreOpenedWindow, preOpenWindow } from "../../utils";
 import {
   formatSubscriptionRequestError,
   normalizeOpenAICallbackInput,
@@ -67,6 +67,34 @@ export interface SubscriptionStatusProps {
     activate?: boolean,
   ) => Promise<void>;
   loadSubscriptionStatus: () => Promise<void>;
+}
+
+const ANTHROPIC_OAUTH_STORAGE_KEY = "eliza.settings.anthropic.oauth-active";
+
+function readAnthropicOAuthActive(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return (
+      new URLSearchParams(window.location.search).get("setup") === "oauth" ||
+      window.localStorage.getItem(ANTHROPIC_OAUTH_STORAGE_KEY) === "1"
+    );
+  } catch {
+    return false;
+  }
+}
+
+function rememberAnthropicOAuthActive(active: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (active) window.localStorage.setItem(ANTHROPIC_OAUTH_STORAGE_KEY, "1");
+    else window.localStorage.removeItem(ANTHROPIC_OAUTH_STORAGE_KEY);
+    const url = new URL(window.location.href);
+    if (active) url.searchParams.set("setup", "oauth");
+    else url.searchParams.delete("setup");
+    window.history.replaceState(null, "", url);
+  } catch {
+    // Storage can be unavailable in privacy-restricted webviews.
+  }
 }
 
 type SubscriptionStatusRow =
@@ -341,12 +369,14 @@ export function SubscriptionStatus({
 
   /* ── Anthropic ─────────────────────────────────────────────────── */
   const [subscriptionTab, setSubscriptionTab] = useState<"token" | "oauth">(
-    "token",
+    () => (readAnthropicOAuthActive() ? "oauth" : "token"),
   );
   const [setupTokenValue, setSetupTokenValue] = useState("");
   const [setupTokenSaving, setSetupTokenSaving] = useState(false);
   const [setupTokenSuccess, setSetupTokenSuccess] = useState(false);
-  const [anthropicOAuthStarted, setAnthropicOAuthStarted] = useState(false);
+  const [anthropicOAuthStarted, setAnthropicOAuthStarted] = useState(() =>
+    readAnthropicOAuthActive(),
+  );
   const [anthropicCode, setAnthropicCode] = useState("");
   const [anthropicError, setAnthropicError] = useState("");
   const [anthropicExchangeBusy, setAnthropicExchangeBusy] = useState(false);
@@ -465,15 +495,19 @@ export function SubscriptionStatus({
 
   const handleAnthropicStart = useCallback(async () => {
     setAnthropicError("");
+    const popup = preOpenWindow();
     try {
       const { authUrl } = await client.startAnthropicLogin();
       if (authUrl) {
-        await openExternalUrl(authUrl);
+        navigatePreOpenedWindow(popup, authUrl);
+        rememberAnthropicOAuthActive(true);
         setAnthropicOAuthStarted(true);
         return;
       }
+      popup?.close();
       setAnthropicError(t("settings.subscription.failedToGetAuthUrl"));
     } catch (err) {
+      popup?.close();
       setAnthropicError(
         t("settings.subscription.failedToStartLogin", {
           message: formatSubscriptionRequestError(err),
@@ -490,12 +524,13 @@ export function SubscriptionStatus({
     try {
       const result = await client.exchangeAnthropicCode(code);
       if (result.success) {
+        rememberAnthropicOAuthActive(false);
         setAnthropicConnected(true);
         setAnthropicOAuthStarted(false);
         setAnthropicCode("");
         await handleSelectSubscription("anthropic-subscription");
-        await loadSubscriptionStatus();
         await client.restartAgent();
+        await loadSubscriptionStatus();
         return;
       }
       setAnthropicError(
@@ -556,8 +591,8 @@ export function SubscriptionStatus({
         setOpenaiOAuthStarted(false);
         setOpenaiCallbackUrl("");
         await handleSelectSubscription("openai-subscription");
-        await loadSubscriptionStatus();
         await client.restartAgent();
+        await loadSubscriptionStatus();
         return;
       }
       const msg = data.error ?? t("settings.subscription.exchangeFailed");
@@ -656,7 +691,12 @@ export function SubscriptionStatus({
           agentId={`sub-anthropic-tab-${id}`}
           label={label}
           active={subscriptionTab === id}
-          onSelect={() => setSubscriptionTab(id)}
+          onSelect={() => {
+            setSubscriptionTab(id);
+            if (id === "oauth") return;
+            rememberAnthropicOAuthActive(false);
+            setAnthropicOAuthStarted(false);
+          }}
         />
       ))}
     </div>
@@ -748,6 +788,7 @@ export function SubscriptionStatus({
           onStartOauth={() => void handleAnthropicStart()}
           onExchange={() => void handleAnthropicExchange()}
           onResetFlow={() => {
+            rememberAnthropicOAuthActive(false);
             setAnthropicOAuthStarted(false);
             setAnthropicCode("");
             setAnthropicError("");

--- a/packages/ui/src/components/settings/SubscriptionStatus.tsx
+++ b/packages/ui/src/components/settings/SubscriptionStatus.tsx
@@ -473,9 +473,8 @@ export function SubscriptionStatus({
       }
       setSetupTokenSuccess(true);
       setSetupTokenValue("");
-      await handleSelectSubscription("anthropic-subscription");
+      await handleSelectSubscription("anthropic-subscription", false);
       await loadSubscriptionStatus();
-      await client.restartAgent();
       setTimeout(() => setSetupTokenSuccess(false), 2000);
     } catch (err) {
       setAnthropicError(
@@ -530,8 +529,7 @@ export function SubscriptionStatus({
         setAnthropicConnected(true);
         setAnthropicOAuthStarted(false);
         setAnthropicCode("");
-        await handleSelectSubscription("anthropic-subscription");
-        await client.restartAgent();
+        await handleSelectSubscription("anthropic-subscription", false);
         await loadSubscriptionStatus();
         return;
       }
@@ -592,8 +590,7 @@ export function SubscriptionStatus({
         setOpenaiConnected(true);
         setOpenaiOAuthStarted(false);
         setOpenaiCallbackUrl("");
-        await handleSelectSubscription("openai-subscription");
-        await client.restartAgent();
+        await handleSelectSubscription("openai-subscription", false);
         await loadSubscriptionStatus();
         return;
       }

--- a/packages/ui/src/components/settings/SubscriptionStatus.tsx
+++ b/packages/ui/src/components/settings/SubscriptionStatus.tsx
@@ -289,7 +289,9 @@ function SubscriptionProviderPanel({
       {preOauthSlot}
 
       {bodyOverride ??
-        (connected ? (
+        // Keep an in-progress add-account OAuth form visible even when a
+        // background refresh reports that another account is connected.
+        (!oauthStarted && connected ? (
           <p className="text-xs text-muted">{connectedSummary}</p>
         ) : !oauthStarted ? (
           <div className="space-y-1.5">

--- a/packages/ui/src/components/settings/SubscriptionStatus.tsx
+++ b/packages/ui/src/components/settings/SubscriptionStatus.tsx
@@ -80,7 +80,8 @@ function readOAuthActive(storageKey: string): boolean {
   if (typeof window === "undefined") return false;
   try {
     return (
-      new URLSearchParams(window.location.search).get("setup") === "oauth" ||
+      (storageKey === ANTHROPIC_OAUTH_STORAGE_KEY &&
+        new URLSearchParams(window.location.search).get("setup") === "oauth") ||
       window.localStorage.getItem(storageKey) === "1"
     );
   } catch {
@@ -93,10 +94,15 @@ function rememberOAuthActive(storageKey: string, active: boolean): void {
   try {
     if (active) window.localStorage.setItem(storageKey, "1");
     else window.localStorage.removeItem(storageKey);
-    const url = new URL(window.location.href);
-    if (active) url.searchParams.set("setup", "oauth");
-    else url.searchParams.delete("setup");
-    window.history.replaceState(null, "", url);
+    // `setup=oauth` is the established Anthropic deep link. OpenAI tracks its
+    // pending handoff only in its provider-specific storage key so restoring
+    // one provider cannot open both callback forms after a renderer remount.
+    if (storageKey === ANTHROPIC_OAUTH_STORAGE_KEY) {
+      const url = new URL(window.location.href);
+      if (active) url.searchParams.set("setup", "oauth");
+      else url.searchParams.delete("setup");
+      window.history.replaceState(null, "", url);
+    }
   } catch {
     // error-policy:J4 OAuth remains usable for this session when persistence is unavailable.
     return;

--- a/packages/ui/src/components/settings/SubscriptionStatus.tsx
+++ b/packages/ui/src/components/settings/SubscriptionStatus.tsx
@@ -22,7 +22,11 @@ import {
   type SubscriptionProviderSelectionId,
 } from "../../providers";
 import { useAppSelector } from "../../state";
-import { navigatePreOpenedWindow, preOpenWindow } from "../../utils";
+import {
+  navigatePreOpenedWindow,
+  openExternalUrl,
+  preOpenWindow,
+} from "../../utils";
 import {
   formatSubscriptionRequestError,
   normalizeOpenAICallbackInput,
@@ -70,24 +74,25 @@ export interface SubscriptionStatusProps {
 }
 
 const ANTHROPIC_OAUTH_STORAGE_KEY = "eliza.settings.anthropic.oauth-active";
+const OPENAI_OAUTH_STORAGE_KEY = "eliza.settings.openai.oauth-active";
 
-function readAnthropicOAuthActive(): boolean {
+function readOAuthActive(storageKey: string): boolean {
   if (typeof window === "undefined") return false;
   try {
     return (
       new URLSearchParams(window.location.search).get("setup") === "oauth" ||
-      window.localStorage.getItem(ANTHROPIC_OAUTH_STORAGE_KEY) === "1"
+      window.localStorage.getItem(storageKey) === "1"
     );
   } catch {
     return false;
   }
 }
 
-function rememberAnthropicOAuthActive(active: boolean): void {
+function rememberOAuthActive(storageKey: string, active: boolean): void {
   if (typeof window === "undefined") return;
   try {
-    if (active) window.localStorage.setItem(ANTHROPIC_OAUTH_STORAGE_KEY, "1");
-    else window.localStorage.removeItem(ANTHROPIC_OAUTH_STORAGE_KEY);
+    if (active) window.localStorage.setItem(storageKey, "1");
+    else window.localStorage.removeItem(storageKey);
     const url = new URL(window.location.href);
     if (active) url.searchParams.set("setup", "oauth");
     else url.searchParams.delete("setup");
@@ -372,13 +377,13 @@ export function SubscriptionStatus({
 
   /* ── Anthropic ─────────────────────────────────────────────────── */
   const [subscriptionTab, setSubscriptionTab] = useState<"token" | "oauth">(
-    () => (readAnthropicOAuthActive() ? "oauth" : "token"),
+    () => (readOAuthActive(ANTHROPIC_OAUTH_STORAGE_KEY) ? "oauth" : "token"),
   );
   const [setupTokenValue, setSetupTokenValue] = useState("");
   const [setupTokenSaving, setSetupTokenSaving] = useState(false);
   const [setupTokenSuccess, setSetupTokenSuccess] = useState(false);
   const [anthropicOAuthStarted, setAnthropicOAuthStarted] = useState(() =>
-    readAnthropicOAuthActive(),
+    readOAuthActive(ANTHROPIC_OAUTH_STORAGE_KEY),
   );
   const [anthropicCode, setAnthropicCode] = useState("");
   const [anthropicError, setAnthropicError] = useState("");
@@ -398,10 +403,37 @@ export function SubscriptionStatus({
     });
 
   /* ── OpenAI ────────────────────────────────────────────────────── */
-  const [openaiOAuthStarted, setOpenaiOAuthStarted] = useState(false);
+  const [openaiOAuthStarted, setOpenaiOAuthStarted] = useState(() =>
+    readOAuthActive(OPENAI_OAUTH_STORAGE_KEY),
+  );
   const [openaiCallbackUrl, setOpenaiCallbackUrl] = useState("");
   const [openaiError, setOpenaiError] = useState("");
   const [openaiExchangeBusy, setOpenaiExchangeBusy] = useState(false);
+
+  // Native browser handoff pauses the renderer, and some shells remount the
+  // settings surface on resume. Restore the pending form both on mount and
+  // when the browser/app becomes active again so an account refresh cannot
+  // replace it with the default or already-connected summary.
+  useEffect(() => {
+    const restorePendingOAuth = () => {
+      if (readOAuthActive(ANTHROPIC_OAUTH_STORAGE_KEY)) {
+        setSubscriptionTab("oauth");
+        setAnthropicOAuthStarted(true);
+      }
+      if (readOAuthActive(OPENAI_OAUTH_STORAGE_KEY)) {
+        setOpenaiOAuthStarted(true);
+      }
+    };
+    restorePendingOAuth();
+    window.addEventListener("focus", restorePendingOAuth);
+    window.addEventListener("pageshow", restorePendingOAuth);
+    document.addEventListener("visibilitychange", restorePendingOAuth);
+    return () => {
+      window.removeEventListener("focus", restorePendingOAuth);
+      window.removeEventListener("pageshow", restorePendingOAuth);
+      document.removeEventListener("visibilitychange", restorePendingOAuth);
+    };
+  }, []);
 
   /* ── Shared disconnect lock ────────────────────────────────────── */
   const [subscriptionDisconnecting, setSubscriptionDisconnecting] = useState<
@@ -497,19 +529,26 @@ export function SubscriptionStatus({
 
   const handleAnthropicStart = useCallback(async () => {
     setAnthropicError("");
+    // Persist before opening or awaiting anything: native browser handoff can
+    // pause/remount the renderer as soon as the external window is requested.
+    rememberOAuthActive(ANTHROPIC_OAUTH_STORAGE_KEY, true);
+    setSubscriptionTab("oauth");
+    setAnthropicOAuthStarted(true);
     const popup = preOpenWindow();
     try {
       const { authUrl } = await client.startAnthropicLogin();
       if (authUrl) {
         navigatePreOpenedWindow(popup, authUrl);
-        rememberAnthropicOAuthActive(true);
-        setAnthropicOAuthStarted(true);
         return;
       }
       popup?.close();
+      rememberOAuthActive(ANTHROPIC_OAUTH_STORAGE_KEY, false);
+      setAnthropicOAuthStarted(false);
       setAnthropicError(t("settings.subscription.failedToGetAuthUrl"));
     } catch (err) {
       popup?.close();
+      rememberOAuthActive(ANTHROPIC_OAUTH_STORAGE_KEY, false);
+      setAnthropicOAuthStarted(false);
       setAnthropicError(
         t("settings.subscription.failedToStartLogin", {
           message: formatSubscriptionRequestError(err),
@@ -526,7 +565,7 @@ export function SubscriptionStatus({
     try {
       const result = await client.exchangeAnthropicCode(code);
       if (result.success) {
-        rememberAnthropicOAuthActive(false);
+        rememberOAuthActive(ANTHROPIC_OAUTH_STORAGE_KEY, false);
         setAnthropicConnected(true);
         setAnthropicOAuthStarted(false);
         setAnthropicCode("");
@@ -558,15 +597,20 @@ export function SubscriptionStatus({
   /* ── OpenAI handlers ───────────────────────────────────────────── */
   const handleOpenAIStart = useCallback(async () => {
     setOpenaiError("");
+    rememberOAuthActive(OPENAI_OAUTH_STORAGE_KEY, true);
+    setOpenaiOAuthStarted(true);
     try {
       const { authUrl } = await client.startOpenAILogin();
       if (authUrl) {
         await openExternalUrl(authUrl);
-        setOpenaiOAuthStarted(true);
         return;
       }
+      rememberOAuthActive(OPENAI_OAUTH_STORAGE_KEY, false);
+      setOpenaiOAuthStarted(false);
       setOpenaiError(t("settings.subscription.noAuthUrlReturned"));
     } catch (err) {
+      rememberOAuthActive(OPENAI_OAUTH_STORAGE_KEY, false);
+      setOpenaiOAuthStarted(false);
       setOpenaiError(
         t("settings.subscription.failedToStartLogin", {
           message: formatSubscriptionRequestError(err),
@@ -588,6 +632,7 @@ export function SubscriptionStatus({
     try {
       const data = await client.exchangeOpenAICode(normalized.code);
       if (data.success) {
+        rememberOAuthActive(OPENAI_OAUTH_STORAGE_KEY, false);
         setOpenaiConnected(true);
         setOpenaiOAuthStarted(false);
         setOpenaiCallbackUrl("");
@@ -694,7 +739,7 @@ export function SubscriptionStatus({
           onSelect={() => {
             setSubscriptionTab(id);
             if (id === "oauth") return;
-            rememberAnthropicOAuthActive(false);
+            rememberOAuthActive(ANTHROPIC_OAUTH_STORAGE_KEY, false);
             setAnthropicOAuthStarted(false);
           }}
         />
@@ -788,7 +833,7 @@ export function SubscriptionStatus({
           onStartOauth={() => void handleAnthropicStart()}
           onExchange={() => void handleAnthropicExchange()}
           onResetFlow={() => {
-            rememberAnthropicOAuthActive(false);
+            rememberOAuthActive(ANTHROPIC_OAUTH_STORAGE_KEY, false);
             setAnthropicOAuthStarted(false);
             setAnthropicCode("");
             setAnthropicError("");
@@ -841,6 +886,7 @@ export function SubscriptionStatus({
           onStartOauth={() => void handleOpenAIStart()}
           onExchange={() => void handleOpenAIExchange()}
           onResetFlow={() => {
+            rememberOAuthActive(OPENAI_OAUTH_STORAGE_KEY, false);
             setOpenaiOAuthStarted(false);
             setOpenaiCallbackUrl("");
             setOpenaiError("");

--- a/packages/ui/src/components/settings/SubscriptionStatus.tsx
+++ b/packages/ui/src/components/settings/SubscriptionStatus.tsx
@@ -93,7 +93,8 @@ function rememberAnthropicOAuthActive(active: boolean): void {
     else url.searchParams.delete("setup");
     window.history.replaceState(null, "", url);
   } catch {
-    // Storage can be unavailable in privacy-restricted webviews.
+    // error-policy:J4 OAuth remains usable for this session when persistence is unavailable.
+    return;
   }
 }
 

--- a/packages/ui/src/components/settings/useProviderSelection.ts
+++ b/packages/ui/src/components/settings/useProviderSelection.ts
@@ -46,7 +46,8 @@ function rememberProviderPanel(panelId: ProviderPanelId): void {
     url.searchParams.set("provider", panelId);
     window.history.replaceState(null, "", url);
   } catch {
-    // Storage can be unavailable in privacy-restricted webviews.
+    // error-policy:J4 Panel selection remains usable for this session when persistence is unavailable.
+    return;
   }
 }
 

--- a/packages/ui/src/components/settings/useProviderSelection.ts
+++ b/packages/ui/src/components/settings/useProviderSelection.ts
@@ -24,6 +24,32 @@ import { useAppSelectorShallow } from "../../state";
 
 export type ProviderPanelId = "__cloud__" | "__local__" | string;
 
+const PROVIDER_PANEL_STORAGE_KEY = "eliza.settings.ai-model.panel";
+
+function readRememberedProviderPanel(): ProviderPanelId | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return (
+      new URLSearchParams(window.location.search).get("provider") ??
+      window.localStorage.getItem(PROVIDER_PANEL_STORAGE_KEY)
+    );
+  } catch {
+    return null;
+  }
+}
+
+function rememberProviderPanel(panelId: ProviderPanelId): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(PROVIDER_PANEL_STORAGE_KEY, panelId);
+    const url = new URL(window.location.href);
+    url.searchParams.set("provider", panelId);
+    window.history.replaceState(null, "", url);
+  } catch {
+    // Storage can be unavailable in privacy-restricted webviews.
+  }
+}
+
 interface AiProviderLike {
   id: string;
 }
@@ -88,7 +114,10 @@ export function useProviderSelection(
   );
   const hasManualPanelSelection = useRef(false);
   const [selectedProviderPanelId, setSelectedProviderPanelId] =
-    useState<ProviderPanelId | null>(null);
+    useState<ProviderPanelId | null>(() => readRememberedProviderPanel());
+  if (selectedProviderPanelId !== null) {
+    hasManualPanelSelection.current = true;
+  }
 
   const readCloudCallsDisabled = useCallback(
     (cfg: Record<string, unknown>): boolean => {
@@ -294,6 +323,7 @@ export function useProviderSelection(
       if (cloudRuntimeLocked && panelId === "__local__") return;
       hasManualPanelSelection.current = true;
       setSelectedProviderPanelId(panelId);
+      rememberProviderPanel(panelId);
     },
     [cloudRuntimeLocked],
   );

--- a/packages/ui/src/components/settings/useProviderSelection.ts
+++ b/packages/ui/src/components/settings/useProviderSelection.ts
@@ -21,6 +21,7 @@ import {
   type SubscriptionProviderSelectionId,
 } from "../../providers";
 import { useAppSelectorShallow } from "../../state";
+import { shellHistory, shellLocalStorage } from "../../surface-realm-channel";
 
 export type ProviderPanelId = "__cloud__" | "__local__" | string;
 
@@ -41,10 +42,10 @@ function readRememberedProviderPanel(): ProviderPanelId | null {
 function rememberProviderPanel(panelId: ProviderPanelId): void {
   if (typeof window === "undefined") return;
   try {
-    window.localStorage.setItem(PROVIDER_PANEL_STORAGE_KEY, panelId);
+    shellLocalStorage.setItem(PROVIDER_PANEL_STORAGE_KEY, panelId);
     const url = new URL(window.location.href);
     url.searchParams.set("provider", panelId);
-    window.history.replaceState(null, "", url);
+    shellHistory.replaceState(null, "", url);
   } catch {
     // error-policy:J4 Panel selection remains usable for this session when persistence is unavailable.
     return;

--- a/packages/ui/src/utils/openExternalUrl.ts
+++ b/packages/ui/src/utils/openExternalUrl.ts
@@ -118,15 +118,18 @@ export function navigatePreOpenedWindow(
   options?: { preserveOpener?: boolean },
 ): void {
   if (popup && !popup.closed) {
-    popup.location.href = url;
     if (!options?.preserveOpener) {
-      // Security: sever the opener reference now that navigation is done.
+      // Security: sever the opener while the pre-opened about:blank document
+      // is still same-origin. Doing this after assigning the cross-origin URL
+      // races navigation and can leave the OAuth page able to reset/navigate
+      // the app window in some browsers.
       try {
         popup.opener = null;
       } catch {
-        /* cross-origin — fine */
+        /* Browser denied opener mutation — navigation still proceeds. */
       }
     }
+    popup.location.href = url;
     return;
   }
   // Fallback — desktop RPC or retry window.open

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -670,7 +670,9 @@ describe("AcpService", () => {
     expect(nativeClientMock.instances).toHaveLength(1);
     // The "elizaos" agent type resolves to the eliza-code ACP server binary
     // (the elizaos CLI has no ACP mode); the spawn command is eliza-code-acp.
-    expect(nativeClientMock.instances[0]?.opts.command).toBe("eliza-code-acp");
+    expect(nativeClientMock.instances[0]?.opts.command).toMatch(
+      /eliza-code-acp|packages\/examples\/code\/dist\/acp\.js/,
+    );
   });
 
   it("honors explicit elizaos ACP command overrides", async () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -183,7 +183,15 @@ function runtime(
   settings: Record<string, string | undefined> = {},
   services: Record<string, unknown> = {},
 ) {
-  const values = { ELIZA_ACP_TRANSPORT: "cli", ...settings };
+  // Unit tests mock child_process.spawnSync as a failed process. Pin the
+  // elizaos adapter command so unrelated AcpService tests never accidentally
+  // exercise first-use provisioning through that mock; the real provisioning
+  // path has its own focused eliza-code-acp-install.test.ts coverage.
+  const values = {
+    ELIZA_ACP_TRANSPORT: "cli",
+    ELIZA_ELIZAOS_ACP_COMMAND: "eliza-code-acp",
+    ...settings,
+  };
   return {
     logger: {
       debug: vi.fn(),

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/eliza-code-acp-install.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/eliza-code-acp-install.test.ts
@@ -1,0 +1,43 @@
+/** Verifies first-use provisioning of the workspace-native elizaOS ACP executable. */
+import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ensureWorkspaceElizaCodeAcp } from "../../src/services/acp-service";
+
+const roots: string[] = [];
+const originalPath = process.env.PATH;
+
+afterEach(async () => {
+  process.env.PATH = originalPath;
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { recursive: true })),
+  );
+});
+
+describe("eliza-code-acp first-use provisioning", () => {
+  it("builds a missing workspace executable and returns its Bun command", async () => {
+    const root = await mkdtemp(join(tmpdir(), "eliza-acp-install-"));
+    roots.push(root);
+    const packageDir = join(root, "packages", "examples", "code");
+    const binDir = join(root, "bin");
+    mkdirSync(join(packageDir, "src"), { recursive: true });
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(join(packageDir, "src", "acp.ts"), "export {};\n");
+    const fakeBun = join(binDir, "bun");
+    writeFileSync(
+      fakeBun,
+      '#!/bin/sh\nmkdir -p "$3/dist"\nprintf "built" > "$3/dist/acp.js"\n',
+    );
+    chmodSync(fakeBun, 0o755);
+    process.env.PATH = `${binDir}${delimiter}${originalPath ?? ""}`;
+
+    const command = ensureWorkspaceElizaCodeAcp(root);
+
+    expect(command).toBe(`${fakeBun} ${join(packageDir, "dist", "acp.js")}`);
+    expect(await readFile(join(packageDir, "dist", "acp.js"), "utf8")).toBe(
+      "built",
+    );
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/api/agent-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/agent-routes.ts
@@ -576,7 +576,10 @@ export async function handleAgentRoutes(
       }
 
       // Check concurrency limit before spawning
-      const activeSessions = await ctx.acpService.listSessions();
+      const sessions = await ctx.acpService.listSessions();
+      const activeSessions = sessions.filter(
+        (session) => !TERMINAL_SESSION_STATUSES.has(session.status),
+      );
       const maxSessions = 8;
       if (activeSessions.length >= maxSessions) {
         sendError(

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -20,7 +20,7 @@ import {
   spawnSync,
 } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { existsSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import {
   chmod,
   copyFile,
@@ -32,7 +32,7 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
-import { basename, dirname, join, resolve, sep } from "node:path";
+import { basename, delimiter, dirname, join, resolve, sep } from "node:path";
 import {
   SUB_AGENT_CREDENTIAL_PARENT_CAPABILITY_SERVICE as CORE_SUB_AGENT_CREDENTIAL_PARENT_CAPABILITY_SERVICE,
   type IAgentRuntime,
@@ -211,6 +211,60 @@ function findGitBinaryForAcp(): string {
     if (existsSync(candidate)) return candidate;
   }
   return "git";
+}
+
+function findExecutableOnPath(name: string): string | undefined {
+  for (const dir of (process.env.PATH ?? "").split(delimiter)) {
+    if (!dir) continue;
+    const candidate = join(dir, name);
+    if (existsSync(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+function findWorkspaceElizaCodePackage(startDir: string): string | undefined {
+  let dir = resolve(startDir);
+  while (true) {
+    const candidate = join(dir, "packages", "examples", "code");
+    if (existsSync(join(candidate, "src", "acp.ts"))) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) return undefined;
+    dir = parent;
+  }
+}
+
+/**
+ * Provision the workspace-native ACP executable on first use. Development and
+ * self-hosted checkouts deliberately do not require a global npm install: the
+ * package is built into its normal dist directory and launched with the same
+ * Bun executable that performed the build.
+ */
+export function ensureWorkspaceElizaCodeAcp(
+  startDir: string = process.cwd(),
+): string | undefined {
+  const packageDir = findWorkspaceElizaCodePackage(startDir);
+  const bun = findExecutableOnPath("bun");
+  if (!packageDir || !bun) return undefined;
+  const source = join(packageDir, "src", "acp.ts");
+  const output = join(packageDir, "dist", "acp.js");
+  const needsBuild =
+    !existsSync(output) || statSync(source).mtimeMs > statSync(output).mtimeMs;
+  if (needsBuild) {
+    const result = spawnSync(bun, ["run", "--cwd", packageDir, "build"], {
+      cwd: packageDir,
+      env: process.env,
+      encoding: "utf8",
+      timeout: 120_000,
+      maxBuffer: 8 * 1024 * 1024,
+    });
+    if (result.status !== 0 || !existsSync(output)) {
+      const detail = String(
+        result.stderr || result.stdout || "build failed",
+      ).trim();
+      throw new Error(`Failed to auto-install eliza-code-acp: ${detail}`);
+    }
+  }
+  return `${bun} ${output}`;
 }
 
 async function runGitForAcp(
@@ -2742,7 +2796,12 @@ export class AcpService extends Service {
     // ACP mode, so the bare-name fallback below would spawn the wrong binary —
     // resolve to the eliza-code bin unless an explicit command is configured.
     if (normalizedAgentType === "elizaos")
-      return this.setting("ELIZA_ELIZAOS_ACP_COMMAND") ?? "eliza-code-acp";
+      return (
+        this.setting("ELIZA_ELIZAOS_ACP_COMMAND") ??
+        findExecutableOnPath("eliza-code-acp") ??
+        ensureWorkspaceElizaCodeAcp() ??
+        "npx -y --package @elizaos/example-code@2.0.0-beta.1 eliza-code-acp"
+      );
     return String(normalizedAgentType);
   }
 

--- a/plugins/plugin-app-control/src/actions/app-create.ts
+++ b/plugins/plugin-app-control/src/actions/app-create.ts
@@ -27,12 +27,7 @@ import type {
 	IAgentRuntime,
 	Memory,
 } from "@elizaos/core";
-import {
-	findCodingDelegationActionName,
-	logger,
-	ModelType,
-	spawnWithTrajectoryLink,
-} from "@elizaos/core";
+import { logger, ModelType, spawnWithTrajectoryLink } from "@elizaos/core";
 import {
 	type AppControlClient,
 	createAppControlClient,
@@ -40,6 +35,7 @@ import {
 import { readStringOption } from "../params.js";
 import type { InstalledAppInfo } from "../types.js";
 import {
+	findAsyncCodingDelegationActionName,
 	preflightCodingDispatch,
 	resolveScaffoldTemplateDir,
 	templateMissingGuidance,
@@ -329,8 +325,12 @@ function readStringField(
 }
 
 function readTaskAgents(result: ActionResult | undefined): TaskAgentStatus[] {
-	const agents = result?.data?.agents;
-	if (!Array.isArray(agents)) return [];
+	const data = result?.data;
+	const agents = Array.isArray(data?.agents)
+		? data.agents
+		: data && typeof data === "object" && "sessionId" in data
+			? [data]
+			: [];
 
 	return agents.flatMap((agent): TaskAgentStatus[] => {
 		if (!agent || typeof agent !== "object" || Array.isArray(agent)) {
@@ -405,7 +405,9 @@ async function dispatchCodingAgent({
 	originRoomId,
 	callback,
 }: DispatchInput): Promise<DispatchResult> {
-	const createTaskName = findCodingDelegationActionName(runtime.actions ?? []);
+	const createTaskName = findAsyncCodingDelegationActionName(
+		runtime.actions ?? [],
+	);
 	const createTask = runtime.actions.find((a) => a.name === createTaskName);
 	if (!createTask) {
 		return {

--- a/plugins/plugin-app-control/src/actions/scaffold-env.test.ts
+++ b/plugins/plugin-app-control/src/actions/scaffold-env.test.ts
@@ -15,6 +15,7 @@ import path from "node:path";
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+	findAsyncCodingDelegationActionName,
 	findCodingCliOnPath,
 	hasVendoredOpencodeShim,
 	preflightCodingDispatch,
@@ -163,6 +164,23 @@ describe("findCodingCliOnPath", () => {
 	it("returns undefined when no coding CLI is installed", async () => {
 		process.env.PATH = tempDir("empty-path-");
 		expect(await findCodingCliOnPath()).toBeUndefined();
+	});
+});
+
+describe("findAsyncCodingDelegationActionName", () => {
+	it("prefers the non-blocking spawn operation over legacy synchronous create", () => {
+		expect(
+			findAsyncCodingDelegationActionName([
+				{ name: "START_CODING_TASK" },
+				{ name: "TASKS_SPAWN_AGENT" },
+			]),
+		).toBe("TASKS_SPAWN_AGENT");
+	});
+
+	it("retains compatibility with runtimes that only expose the legacy action", () => {
+		expect(
+			findAsyncCodingDelegationActionName([{ name: "START_CODING_TASK" }]),
+		).toBe("START_CODING_TASK");
 	});
 });
 

--- a/plugins/plugin-app-control/src/actions/scaffold-env.ts
+++ b/plugins/plugin-app-control/src/actions/scaffold-env.ts
@@ -84,6 +84,21 @@ export interface TemplateResolution {
 	tried: string[];
 }
 
+/**
+ * Pick the non-blocking orchestrator operation for scaffold dispatches.
+ * `START_CODING_TASK` is a legacy alias of TASKS/create and waits for the
+ * entire coding turn to finish; scaffold flows must return as soon as the ACP
+ * session is ready because their verification bridge reports completion.
+ */
+export function findAsyncCodingDelegationActionName(
+	actions: readonly { name: string }[],
+): string | undefined {
+	if (actions.some((action) => action.name === "TASKS_SPAWN_AGENT")) {
+		return "TASKS_SPAWN_AGENT";
+	}
+	return findCodingDelegationActionName(actions);
+}
+
 async function isDirectory(dir: string): Promise<boolean> {
 	const stat = await fs.stat(dir).catch(() => null);
 	return stat?.isDirectory() ?? false;
@@ -276,7 +291,7 @@ export async function preflightCodingDispatch(
 	const guidance: string[] = [];
 
 	const hasCreateTask = Boolean(
-		findCodingDelegationActionName(runtime.actions ?? []),
+		findAsyncCodingDelegationActionName(runtime.actions ?? []),
 	);
 	if (!hasCreateTask) {
 		guidance.push(

--- a/plugins/plugin-app-control/src/actions/views-create.ts
+++ b/plugins/plugin-app-control/src/actions/views-create.ts
@@ -22,14 +22,10 @@ import type {
 	IAgentRuntime,
 	Memory,
 } from "@elizaos/core";
-import {
-	findCodingDelegationActionName,
-	logger,
-	ModelType,
-	spawnWithTrajectoryLink,
-} from "@elizaos/core";
+import { logger, ModelType, spawnWithTrajectoryLink } from "@elizaos/core";
 import { readStringOption } from "../params.js";
 import {
+	findAsyncCodingDelegationActionName,
 	preflightCodingDispatch,
 	resolvePluginScaffoldBaseDir,
 	resolveScaffoldTemplateDir,
@@ -281,8 +277,12 @@ function readStringField(
 }
 
 function readTaskAgents(result: ActionResult | undefined): TaskAgentStatus[] {
-	const agents = result?.data?.agents;
-	if (!Array.isArray(agents)) return [];
+	const data = result?.data;
+	const agents = Array.isArray(data?.agents)
+		? data.agents
+		: data && typeof data === "object" && "sessionId" in data
+			? [data]
+			: [];
 	return agents.flatMap((agent): TaskAgentStatus[] => {
 		if (!agent || typeof agent !== "object" || Array.isArray(agent)) return [];
 		const record = agent as Record<string, unknown>;
@@ -324,7 +324,9 @@ async function dispatchCodingAgent({
 	originRoomId: string;
 	callback?: HandlerCallback;
 }): Promise<DispatchResult> {
-	const createTaskName = findCodingDelegationActionName(runtime.actions ?? []);
+	const createTaskName = findAsyncCodingDelegationActionName(
+		runtime.actions ?? [],
+	);
 	const createTask = runtime.actions.find((a) => a.name === createTaskName);
 	if (!createTask) {
 		return {

--- a/plugins/plugin-app-control/src/actions/views-edit.ts
+++ b/plugins/plugin-app-control/src/actions/views-edit.ts
@@ -19,12 +19,9 @@ import type {
 	IAgentRuntime,
 	Memory,
 } from "@elizaos/core";
-import {
-	findCodingDelegationActionName,
-	logger,
-	spawnWithTrajectoryLink,
-} from "@elizaos/core";
+import { logger, spawnWithTrajectoryLink } from "@elizaos/core";
 import { readStringOption } from "../params.js";
+import { findAsyncCodingDelegationActionName } from "./scaffold-env.js";
 import type { ViewSummary } from "./views-client.js";
 import { isRestrictedPlatform } from "./views-platform.js";
 import { locatePluginSourceDir } from "./views-plugin-source.js";
@@ -140,8 +137,12 @@ interface TaskAgentStatus {
 }
 
 function readTaskAgents(result: ActionResult | undefined): TaskAgentStatus[] {
-	const agents = result?.data?.agents;
-	if (!Array.isArray(agents)) return [];
+	const data = result?.data;
+	const agents = Array.isArray(data?.agents)
+		? data.agents
+		: data && typeof data === "object" && "sessionId" in data
+			? [data]
+			: [];
 	return agents.flatMap((agent): TaskAgentStatus[] => {
 		if (!agent || typeof agent !== "object" || Array.isArray(agent)) return [];
 		const r = agent as Record<string, unknown>;
@@ -170,7 +171,9 @@ async function dispatchEditAgent({
 	originRoomId: string;
 	callback?: HandlerCallback;
 }): Promise<ActionResult> {
-	const createTaskName = findCodingDelegationActionName(runtime.actions ?? []);
+	const createTaskName = findAsyncCodingDelegationActionName(
+		runtime.actions ?? [],
+	);
 	const createTask = runtime.actions.find((a) => a.name === createTaskName);
 	if (!createTask) {
 		const text =


### PR DESCRIPTION
## What changed

- allow app-core browser sessions to authenticate agent-owned HTTP routes without requiring a second API token
- restore the password-login UI during first-run and resume startup after login
- protect cloud status/credits and related compat routes with session-aware policy
- preserve Claude/Codex setup state through settings remounts, OAuth pause/resume, and renderer updates
- open OAuth windows without retaining an opener capable of navigating the Eliza tab
- accept Claude `code#state` and localhost callback URL inputs, including after a runtime restart
- retain the active Codex PKCE flow across runtime swaps so pasted localhost callback URLs can complete
- refresh subscription state after the runtime restart so newly linked accounts appear immediately
- correctly normalize Anthropic usage returned as either `0..1` fractions or `0..100` percentages
- activate updated service workers and refresh tabs that are still executing an old renderer

## Root cause

The remote web shell authenticated users in app-core, but the lower agent HTTP boundary could not recognize app-core session cookies and returned 401s. Subscription OAuth state was also held in transient component/runtime state, which was discarded when the browser paused or the runtime reloaded. Anthropic usage values were always multiplied by 100 even when already expressed as percentages.

## Impact

Remote deployments behind HTTPS tunnels can use password sessions, cloud APIs, chat, Claude OAuth, and Codex manual localhost callback exchange without exposing an API token. OAuth setup survives lifecycle transitions and usage percentages reflect provider data correctly.

## Validation

- `bun run build:server`
- `bun run --cwd packages/app build:web`
- `bunx vitest run packages/app-core/src/services/account-usage.test.ts --config packages/app-core/vitest.config.ts` (16 tests passed)
- real Chromium validation through a Tailscale Funnel: password login, session-authenticated APIs, cloud status, chat streaming, settings deep-link restoration, and OAuth popup handoff

@wakesync — please take a look at the remote deployment/session and subscription OAuth changes.
