### PR TITLE
fix(ui): open hosted OAuth in a separate desktop tab

### DIFF
--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.oauth-launch.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.oauth-launch.test.tsx
@@ -1,5 +1,10 @@
 // @vitest-environment jsdom
 
+/**
+ * Exercises hosted OAuth popup navigation and PKCE failure cleanup with an
+ * in-memory Steward provider boundary; no live browser or OAuth service runs.
+ */
+
 import {
   cleanup,
   fireEvent,
@@ -18,6 +23,7 @@ const oauthState = vi.hoisted(() => ({
 
 vi.mock("../../../../state/cloud-login-launch", () => ({
   preOpenCloudLoginWindow: () => oauthState.popup,
+  canNavigateSameTabForBlockedPopup: () => true,
 }));
 
 vi.mock("@stwd/sdk", () => ({

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.oauth-launch.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.oauth-launch.test.tsx
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const oauthState = vi.hoisted(() => ({
+  popup: null as Window | null,
+  pkceError: null as Error | null,
+  storeVerifier: true,
+}));
+
+vi.mock("../../../../state/cloud-login-launch", () => ({
+  preOpenCloudLoginWindow: () => oauthState.popup,
+}));
+
+vi.mock("@stwd/sdk", () => ({
+  StewardAuth: class {
+    getSession() {
+      return null;
+    }
+    getProviders() {
+      return Promise.resolve({
+        passkey: false,
+        email: true,
+        siwe: false,
+        siws: false,
+        google: true,
+        discord: false,
+        github: false,
+        twitter: false,
+        oauth: ["google"],
+      });
+    }
+    refreshSession() {
+      return Promise.resolve(null);
+    }
+  },
+}));
+
+vi.mock("./passkey-capability", () => ({
+  resolveWebPasskeyCapability: () =>
+    Promise.resolve({ usable: false, reason: "native-without-bridge" }),
+}));
+
+vi.mock("../../../shell/steward-url", () => ({
+  resolveBrowserStewardApiUrl: () => "https://api.example.test",
+}));
+
+vi.mock("../../../shell/steward-config", () => ({
+  configuredStewardTenantId: () => "elizacloud",
+  DEFAULT_STEWARD_TENANT_ID: "elizacloud",
+}));
+
+vi.mock("../../../shell/CloudI18nProvider", () => ({
+  useCloudT: () => (_key: string, opts?: { defaultValue?: string }) =>
+    opts?.defaultValue ?? _key,
+}));
+
+vi.mock("../../lib/steward-session", () => ({
+  hasStewardOAuthCallbackInUrl: () => false,
+  consumeStewardCodeFromQuery: () => null,
+  consumeStewardTokensFromHash: () => null,
+  exchangeStewardCodeViaApi: () => Promise.resolve({}),
+  refreshStewardSessionViaCookie: () => Promise.resolve({ ok: true as const }),
+  syncStewardSessionCookie: () => Promise.resolve(),
+}));
+
+vi.mock("../../lib/login-return-to", () => ({
+  resolveLoginReturnTo: () => "/dashboard",
+  consumePendingOAuthReturnTo: () => null,
+  storePendingOAuthReturnTo: () => undefined,
+}));
+
+vi.mock("../../lib/steward-oauth-url", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../lib/steward-oauth-url")
+  >("../../lib/steward-oauth-url");
+  return {
+    ...actual,
+    createStewardPkcePair: async () => {
+      if (oauthState.pkceError) throw oauthState.pkceError;
+      return { verifier: "verifier", challenge: "challenge" };
+    },
+    storeStewardPkceVerifier: () => oauthState.storeVerifier,
+    buildStewardOAuthAuthorizeUrl: () =>
+      "https://api.example.test/steward/auth/oauth/google/authorize",
+  };
+});
+
+import StewardLoginSection from "./steward-login-section";
+
+function renderSection() {
+  return render(
+    <MemoryRouter initialEntries={["/login"]}>
+      <StewardLoginSection />
+    </MemoryRouter>,
+  );
+}
+
+function makePopup() {
+  return {
+    closed: false,
+    location: { href: "" },
+    opener: window,
+    close: vi.fn(),
+  } as unknown as Window;
+}
+
+describe("StewardLoginSection OAuth launch", () => {
+  beforeEach(() => {
+    oauthState.popup = makePopup();
+    oauthState.pkceError = null;
+    oauthState.storeVerifier = true;
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("navigates a pre-opened desktop popup after PKCE resolves", async () => {
+    renderSection();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Google" }));
+
+    await waitFor(() =>
+      expect((oauthState.popup?.location as Location).href).toContain(
+        "/steward/auth/oauth/google/authorize",
+      ),
+    );
+    expect(oauthState.popup?.opener).toBeNull();
+  });
+
+  it("closes the popup when browser storage cannot save the verifier", async () => {
+    oauthState.storeVerifier = false;
+    renderSection();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Google" }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/browser storage is unavailable/i)).toBeTruthy(),
+    );
+    expect(oauthState.popup?.close).toHaveBeenCalledOnce();
+  });
+
+  it("closes the popup when PKCE creation fails", async () => {
+    oauthState.pkceError = new Error("crypto unavailable");
+    renderSection();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Google" }));
+
+    await waitFor(() =>
+      expect(screen.getByText("crypto unavailable")).toBeTruthy(),
+    );
+    expect(oauthState.popup?.close).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.passkey-capability.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.passkey-capability.test.tsx
@@ -128,6 +128,7 @@ describe("StewardLoginSection passkey capability gating", () => {
     expect(input.getAttribute("autocomplete")).toBe("email");
     expect(screen.queryByRole("button", { name: /Passkey/i })).toBeNull();
     expect(screen.getByRole("button", { name: /Magic Link/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Google/i })).toBeTruthy();
     expect(
       screen.getByText(
         "Passkey sign-in is not available here. Use Google, Discord, or Magic Link, or open this sign-in link on another device.",

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -38,7 +38,11 @@ import { DiscordIcon } from "../../../../cloud-ui/components/icons";
 import { Alert, AlertDescription } from "../../../../components/primitives";
 import { Button } from "../../../../components/ui/button";
 import { Input } from "../../../../components/ui/input";
-import { preOpenCloudLoginWindow } from "../../../../state/cloud-login-launch";
+import {
+  canNavigateSameTabForBlockedPopup,
+  preOpenCloudLoginWindow,
+} from "../../../../state/cloud-login-launch";
+import { navigatePreOpenedWindow } from "../../../../utils/openExternalUrl";
 import { useCloudT } from "../../../shell/CloudI18nProvider";
 import {
   configuredStewardTenantId,
@@ -620,15 +624,13 @@ export default function StewardLoginSection() {
       codeChallenge,
     });
     if (authWindow && !authWindow.closed) {
-      authWindow.location.href = authorizeUrl;
-      try {
-        authWindow.opener = null;
-      } catch {
-        // Cross-origin window handles can reject opener assignment.
-      }
-    } else {
-      // Popup blocked or touch-primary browser: preserve the working fallback.
+      navigatePreOpenedWindow(authWindow, authorizeUrl);
+    } else if (canNavigateSameTabForBlockedPopup()) {
+      // Plain web can safely preserve the sign-in round trip in this tab.
       window.location.href = authorizeUrl;
+    } else {
+      // Native and desktop shells must retain their platform browser bridges.
+      navigatePreOpenedWindow(null, authorizeUrl);
     }
   }
 

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -38,6 +38,7 @@ import { DiscordIcon } from "../../../../cloud-ui/components/icons";
 import { Alert, AlertDescription } from "../../../../components/primitives";
 import { Button } from "../../../../components/ui/button";
 import { Input } from "../../../../components/ui/input";
+import { preOpenCloudLoginWindow } from "../../../../state/cloud-login-launch";
 import { useCloudT } from "../../../shell/CloudI18nProvider";
 import {
   configuredStewardTenantId,
@@ -583,6 +584,11 @@ export default function StewardLoginSection() {
   }
 
   async function handleOAuth(provider: StewardOAuthProvider) {
+    // Open synchronously while the click still has user-gesture context. The
+    // PKCE challenge is asynchronous, so opening after it resolves is blocked
+    // by browsers. Touch-primary browsers intentionally return null here and
+    // continue in the current tab.
+    const authWindow = preOpenCloudLoginWindow();
     setLoading(provider);
     setError(null);
     const host = window.location.hostname.toLowerCase();
@@ -593,6 +599,7 @@ export default function StewardLoginSection() {
     try {
       const pkce = await createStewardPkcePair();
       if (!storeStewardPkceVerifier(pkce.verifier)) {
+        authWindow?.close();
         setError(
           "Could not start sign-in — browser storage is unavailable. Enable cookies / site data and try again.",
         );
@@ -601,16 +608,28 @@ export default function StewardLoginSection() {
       }
       codeChallenge = pkce.challenge;
     } catch (e: unknown) {
+      authWindow?.close();
       setError(getErrorMessage(e, "Could not start sign-in"));
       setLoading(null);
       return;
     }
     storePendingOAuthReturnTo(searchParams);
-    window.location.href = buildStewardOAuthAuthorizeUrl(
-      provider,
-      oauthOrigin,
-      { stewardApiUrl, stewardTenantId: STEWARD_TENANT_ID, codeChallenge },
-    );
+    const authorizeUrl = buildStewardOAuthAuthorizeUrl(provider, oauthOrigin, {
+      stewardApiUrl,
+      stewardTenantId: STEWARD_TENANT_ID,
+      codeChallenge,
+    });
+    if (authWindow && !authWindow.closed) {
+      authWindow.location.href = authorizeUrl;
+      try {
+        authWindow.opener = null;
+      } catch {
+        // Cross-origin window handles can reject opener assignment.
+      }
+    } else {
+      // Popup blocked or touch-primary browser: preserve the working fallback.
+      window.location.href = authorizeUrl;
+    }
   }
 
   // First wallet click: mount the lazy wallet stack and remember which chain

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.wallet.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.wallet.test.tsx
@@ -12,11 +12,31 @@
  *  - flags off → no wallet UI at all (the pre-port behavior).
  */
 
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const providerFlags = vi.hoisted(() => ({ siwe: false, siws: false }));
+const oauthLaunch = vi.hoisted(() => ({
+  popup: null as Window | null,
+  sameTabAllowed: true,
+  navigate: vi.fn(),
+}));
+
+vi.mock("../../../../state/cloud-login-launch", () => ({
+  preOpenCloudLoginWindow: () => oauthLaunch.popup,
+  canNavigateSameTabForBlockedPopup: () => oauthLaunch.sameTabAllowed,
+}));
+
+vi.mock("../../../../utils/openExternalUrl", () => ({
+  navigatePreOpenedWindow: oauthLaunch.navigate,
+}));
 
 vi.mock("../../lib/steward-session", () => ({
   hasStewardOAuthCallbackInUrl: () => false,
@@ -73,6 +93,10 @@ vi.mock("../../lib/steward-oauth-url", async () => {
     ...actual,
     consumeStewardPkceVerifier: () => undefined,
     buildStewardOAuthRedirectUri: () => "https://app.example.test/login",
+    createStewardPkcePair: () =>
+      Promise.resolve({ verifier: "verifier", challenge: "challenge" }),
+    storeStewardPkceVerifier: () => true,
+    buildStewardOAuthAuthorizeUrl: () => "https://auth.example.test/authorize",
   };
 });
 
@@ -101,6 +125,8 @@ describe("StewardLoginSection — wallet sign-in gating (SIWE/SIWS port)", () =>
   beforeEach(() => {
     providerFlags.siwe = false;
     providerFlags.siws = false;
+    oauthLaunch.popup = null;
+    oauthLaunch.sameTabAllowed = true;
   });
 
   afterEach(() => {
@@ -142,5 +168,34 @@ describe("StewardLoginSection — wallet sign-in gating (SIWE/SIWS port)", () =>
     expect(screen.queryByText("or sign in with a wallet")).toBeNull();
     expect(screen.queryByRole("button", { name: /EVM wallet/i })).toBeNull();
     expect(screen.queryByRole("button", { name: /Solana wallet/i })).toBeNull();
+  });
+
+  it("navigates a live OAuth popup through the shared opener-safe helper", async () => {
+    const popup = { closed: false } as Window;
+    oauthLaunch.popup = popup;
+    await renderSection();
+
+    fireEvent.click(await screen.findByRole("button", { name: /Google/i }));
+
+    await waitFor(() =>
+      expect(oauthLaunch.navigate).toHaveBeenCalledWith(
+        popup,
+        "https://auth.example.test/authorize",
+      ),
+    );
+  });
+
+  it("uses the platform browser bridge when native or desktop cannot pre-open a popup", async () => {
+    oauthLaunch.sameTabAllowed = false;
+    await renderSection();
+
+    fireEvent.click(await screen.findByRole("button", { name: /Google/i }));
+
+    await waitFor(() =>
+      expect(oauthLaunch.navigate).toHaveBeenCalledWith(
+        null,
+        "https://auth.example.test/authorize",
+      ),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- open hosted Google/Discord/GitHub OAuth in a separate desktop tab
- preserve current-tab fallback for touch-primary and popup-blocked browsers
- close a pre-opened tab if PKCE setup fails

## Validation
- `packages/ui`: cloud-login-launch tests (23 passed)
- `packages/ui`: typecheck
- production and staging Google authorization endpoints verified

The production and staging Steward tenant redirect allowlists were also corrected separately to include the app login callback URLs.

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16091-before-desktop.jpg)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16091-after-desktop.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence/16091-after-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [x] [16091-backend-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16091-backend-logs.txt)

<!-- evidence-row:frontend-logs -->
- [x] [16091-frontend-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16091-frontend-logs.txt)

<!-- evidence-row:ocr-review -->
- [x] [16091-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16091-ocr-review.txt)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, provider, prompt, or agent behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain artifact or persisted user data changed
