### PR TITLE
fix(cloud): preserve Cerebras prompt cache key

### DIFF
--- a/packages/cloud/api/__tests__/cerebras-prompt-cache-sdk-boundary.test.ts
+++ b/packages/cloud/api/__tests__/cerebras-prompt-cache-sdk-boundary.test.ts
@@ -13,10 +13,10 @@ function createCapturingProvider(response: Response, bodies: unknown[]) {
   const provider = createOpenAI({
     apiKey: "test-cerebras-key",
     baseURL: "https://api.cerebras.ai/v1",
-    fetch: async (_input, init) => {
+    fetch: (async (_input, init) => {
       bodies.push(JSON.parse(String(init?.body)));
       return response;
-    },
+    }) as typeof fetch,
   });
   return provider.chat("gpt-oss-120b");
 }

--- a/packages/cloud/api/__tests__/cerebras-prompt-cache-sdk-boundary.test.ts
+++ b/packages/cloud/api/__tests__/cerebras-prompt-cache-sdk-boundary.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Verifies the AI SDK's OpenAI-compatible transport emits Cerebras prompt-cache
+ * keys on the provider wire for both complete and streamed generations.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { createOpenAI } from "@ai-sdk/openai";
+import { generateText, streamText } from "ai";
+
+const PROMPT_CACHE_KEY = "v5:stable-prefix";
+
+function createCapturingProvider(response: Response, bodies: unknown[]) {
+  const provider = createOpenAI({
+    apiKey: "test-cerebras-key",
+    baseURL: "https://api.cerebras.ai/v1",
+    fetch: async (_input, init) => {
+      bodies.push(JSON.parse(String(init?.body)));
+      return response;
+    },
+  });
+  return provider.chat("gpt-oss-120b");
+}
+
+const providerOptions = {
+  openai: { promptCacheKey: PROMPT_CACHE_KEY },
+};
+
+describe("Cerebras prompt cache key AI SDK boundary", () => {
+  test("generateText serializes prompt_cache_key", async () => {
+    const bodies: unknown[] = [];
+    const model = createCapturingProvider(
+      Response.json({
+        id: "chatcmpl-cache-key",
+        object: "chat.completion",
+        created: 1,
+        model: "gpt-oss-120b",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "ok" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      }),
+      bodies,
+    );
+
+    await generateText({ model, prompt: "hello", providerOptions });
+
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0]).toMatchObject({ prompt_cache_key: PROMPT_CACHE_KEY });
+    expect(bodies[0]).not.toHaveProperty("promptCacheKey");
+  });
+
+  test("streamText serializes prompt_cache_key", async () => {
+    const bodies: unknown[] = [];
+    const model = createCapturingProvider(
+      new Response(
+        `data: {"id":"chatcmpl-cache-key","object":"chat.completion.chunk","created":1,"model":"gpt-oss-120b","choices":[{"index":0,"delta":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n`,
+        { headers: { "Content-Type": "text/event-stream" } },
+      ),
+      bodies,
+    );
+
+    const result = streamText({ model, prompt: "hello", providerOptions });
+    await result.text;
+
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0]).toMatchObject({ prompt_cache_key: PROMPT_CACHE_KEY });
+    expect(bodies[0]).not.toHaveProperty("promptCacheKey");
+  });
+});

--- a/packages/cloud/api/__tests__/chat-completions-optimistic-billing.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-optimistic-billing.test.ts
@@ -88,9 +88,6 @@ const admitInferenceChargeViaLedger = mock(async () => ({
 }));
 const createLedgerDebitSettler = mock(() => ledgerInnerSettler);
 const createCreditReservationSettler = mock(() => async () => null);
-const generateText = mock((_options: Record<string, unknown>) => {
-  throw new Error("model-call-stub");
-});
 
 // Auth: resolve straight to an authorized org user via the hot-path resolver so
 // the org-credits branch (not app-credits) is taken and moderation is skipped.

--- a/packages/cloud/api/__tests__/chat-completions-optimistic-billing.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-optimistic-billing.test.ts
@@ -88,6 +88,9 @@ const admitInferenceChargeViaLedger = mock(async () => ({
 }));
 const createLedgerDebitSettler = mock(() => ledgerInnerSettler);
 const createCreditReservationSettler = mock(() => async () => null);
+const generateText = mock((_options: Record<string, unknown>) => {
+  throw new Error("model-call-stub");
+});
 
 // Auth: resolve straight to an authorized org user via the hot-path resolver so
 // the org-credits branch (not app-credits) is taken and moderation is skipped.
@@ -300,6 +303,23 @@ describe("chat/completions optimistic-billing route decision (#9899/#10066)", ()
     createCreditReservationSettler.mockClear();
     generateText.mockClear();
     streamText.mockClear();
+  });
+
+  test("forwards the prompt cache key through the full Cerebras route", async () => {
+    await handleChatCompletionsPOST(
+      makeRequest(undefined, {
+        model: "gpt-oss-120b",
+        prompt_cache_key: "v5:optimistic-route",
+      }),
+      { skipOrgRateLimit: true },
+    );
+
+    expect(generateText).toHaveBeenCalledTimes(1);
+    expect(generateText.mock.calls[0]?.[0]).toMatchObject({
+      providerOptions: {
+        openai: { promptCacheKey: "v5:optimistic-route" },
+      },
+    });
   });
 
   test("eligible org takes the optimistic path: writes backstop, skips the synchronous reserve", async () => {

--- a/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
@@ -212,12 +212,12 @@ function makeLedgerReservation(startBalance: number, hold: number) {
   };
 }
 
-const QUALIFYING_REQUEST = {
+const QUALIFYING_REQUEST: Record<string, unknown> = {
   model: MODEL,
   messages: [{ role: "user", content: "hello" }],
   stream: true,
   stream_options: { include_usage: true },
-} as never;
+};
 
 function callStreaming(
   settleReservation: (actualCost: number) => Promise<unknown> | unknown,

--- a/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
@@ -434,7 +434,10 @@ describe("passthrough streaming — qualifying request pipes bytes verbatim and 
     const settle = createCreditReservationSettler(ledger.reservation);
     fetchImpl = async () => sseResponse(UPSTREAM_SSE);
 
-    const res = await callStreaming(settle, { effectiveMaxTokens: 4096 });
+    const res = await callStreaming(settle, {
+      effectiveMaxTokens: 4096,
+      request: { ...QUALIFYING_REQUEST, prompt_cache_key: "v5:stable-prefix" },
+    });
     const body = await res.text();
 
     // Byte-for-byte pass-through: vendor fields, reasoning delta, upstream id,
@@ -461,6 +464,8 @@ describe("passthrough streaming — qualifying request pipes bytes verbatim and 
     expect(sentBody.stream).toBe(true);
     expect(sentBody.stream_options).toEqual({ include_usage: true });
     expect(sentBody.max_tokens).toBe(4096);
+    expect(sentBody.prompt_cache_key).toBe("v5:stable-prefix");
+    expect(sentBody).not.toHaveProperty("promptCacheKey");
     expect(sentBody.messages).toEqual([{ role: "user", content: "hello" }]);
 
     // Billing: the terminal usage frame's tokens, through the real settler.

--- a/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
@@ -784,6 +784,29 @@ describe("passthrough streaming — upstream errors fail closed and refund the h
     expect(streamText).not.toHaveBeenCalled();
   });
 
+  test("redacts an echoed prompt cache key from an upstream error", async () => {
+    const promptCacheKey = "opaque-cache-key-secret";
+    fetchImpl = async () =>
+      Response.json(
+        {
+          error: {
+            message: `prompt cache key ${promptCacheKey} is invalid`,
+            type: "invalid_request_error",
+          },
+        },
+        { status: 400 },
+      );
+
+    const res = await callStreaming(async () => null, {
+      request: { ...QUALIFYING_REQUEST, prompt_cache_key: promptCacheKey },
+    });
+    const body = await res.text();
+
+    expect(res.status).toBe(400);
+    expect(body).toContain("[REDACTED_PROMPT_CACHE_KEY]");
+    expect(body).not.toContain(promptCacheKey);
+  });
+
   test("upstream 500 surfaces as 503 service_unavailable; hold refunded", async () => {
     const ledger = makeLedgerReservation(100, 0.9);
     const settle = createCreditReservationSettler(ledger.reservation);

--- a/packages/cloud/api/__tests__/chat-completions-tool-choice.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-tool-choice.test.ts
@@ -547,6 +547,9 @@ describe("Cerebras prompt cache key", () => {
       "v5:abc",
     );
     expect(merged.providerOptions?.anthropic).toBeDefined();
+    expect(merged.providerOptions?.openai).toMatchObject({
+      promptCacheKey: "v5:abc",
+    });
     expect(merged.providerOptions?.cerebras).toMatchObject({
       prompt_cache_key: "v5:abc",
       promptCacheKey: "v5:abc",
@@ -554,5 +557,17 @@ describe("Cerebras prompt cache key", () => {
     expect(merged.providerOptions?.eliza).toMatchObject({
       promptCacheKey: "v5:abc",
     });
+  });
+  test("redacts an echoed cache key without changing unrelated errors", () => {
+    const { redactPromptCacheKey } = __nativeToolingTestHooks;
+    expect(
+      redactPromptCacheKey(
+        "provider rejected opaque-cache-key in request",
+        "opaque-cache-key",
+      ),
+    ).toBe("provider rejected [REDACTED_PROMPT_CACHE_KEY] in request");
+    expect(redactPromptCacheKey("queue is saturated", "opaque-cache-key")).toBe(
+      "queue is saturated",
+    );
   });
 });

--- a/packages/cloud/api/__tests__/chat-completions-tool-choice.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-tool-choice.test.ts
@@ -29,6 +29,8 @@ const {
   buildReasoningEffortProviderOptions,
   isEmptyButBilled,
   toOpenAiFinishReason,
+  resolvePromptCacheKey,
+  mergePromptCacheProviderOptions,
 } = __nativeToolingTestHooks;
 const { getRecoverableProviderErrorStatus } = __streamingCreditTestHooks;
 const { qualifiesForPassthroughStreaming, mapPassthroughUpstreamStatus } =
@@ -511,5 +513,46 @@ describe("mapPassthroughUpstreamStatus", () => {
     expect(mapPassthroughUpstreamStatus(401)).toBe(503);
     expect(mapPassthroughUpstreamStatus(403)).toBe(503);
     expect(mapPassthroughUpstreamStatus(500)).toBe(503);
+  });
+});
+
+describe("Cerebras prompt cache key", () => {
+  test("accepts canonical and compatibility forms with canonical precedence", () => {
+    expect(
+      resolvePromptCacheKey({ prompt_cache_key: "v5:abc" } as never),
+    ).toEqual({ key: "v5:abc" });
+    expect(
+      resolvePromptCacheKey({ promptCacheKey: "legacy" } as never),
+    ).toEqual({ key: "legacy" });
+    expect(
+      resolvePromptCacheKey({
+        prompt_cache_key: "canonical",
+        promptCacheKey: "legacy",
+      } as never),
+    ).toEqual({ key: "canonical" });
+  });
+  test("rejects empty, oversized, and non-string values", () => {
+    for (const value of ["", "x".repeat(1025), 42, null])
+      expect(
+        resolvePromptCacheKey({ prompt_cache_key: value } as never),
+      ).toHaveProperty("error");
+  });
+  test("merges provider options without overwriting existing providers", () => {
+    const merged = mergePromptCacheProviderOptions(
+      {
+        providerOptions: {
+          anthropic: { thinking: { type: "enabled", budgetTokens: 1024 } },
+        },
+      } as never,
+      "v5:abc",
+    );
+    expect(merged.providerOptions?.anthropic).toBeDefined();
+    expect(merged.providerOptions?.cerebras).toMatchObject({
+      prompt_cache_key: "v5:abc",
+      promptCacheKey: "v5:abc",
+    });
+    expect(merged.providerOptions?.eliza).toMatchObject({
+      promptCacheKey: "v5:abc",
+    });
   });
 });

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -268,8 +268,33 @@ function buildReasoningEffortProviderOptions(
 }
 
 /**
- * Computes the provider-facing max_tokens without overriding an explicit caller
- * ceiling. Reasoning models get a safer default only when max_tokens is omitted.
+ * Merges spreadable `{ providerOptions }` fragments (Anthropic CoT +
+ * prompt-cache-key, OpenAI-style reasoning effort) into one spread so a naive
+ * `...a, ...b` cannot clobber the earlier fragment's `providerOptions` key.
+ * Provider namespaces are merged shallowly; they are disjoint today
+ * (anthropic/google/cerebras/eliza vs openai).
+ */
+function combineProviderOptions(
+  ...parts: ReadonlyArray<Record<string, unknown>>
+): Record<string, unknown> {
+  const merged: Record<string, unknown> = {};
+  const providerOptions: Record<string, unknown> = {};
+  let hasProviderOptions = false;
+  for (const part of parts) {
+    for (const [key, value] of Object.entries(part)) {
+      if (key === "providerOptions" && value && typeof value === "object") {
+        Object.assign(providerOptions, value as Record<string, unknown>);
+        hasProviderOptions = true;
+      } else {
+        merged[key] = value;
+      }
+    }
+  }
+  return hasProviderOptions ? { ...merged, providerOptions } : merged;
+}
+
+/**
+ * Computes effective max_tokens, reserving response capacity for reasoning models.
  *
  * Reasoning models (Anthropic extended-thinking, OpenAI o-series, DeepSeek R,
  * MiniMax M, and similar families) spend output tokens on hidden chain-of-thought
@@ -353,6 +378,9 @@ interface ChatRequest {
   messages: ChatMessage[];
   temperature?: number;
   max_tokens?: number;
+  /** Cerebras prompt-cache routing hint (camelCase accepted for compatibility). */
+  prompt_cache_key?: unknown;
+  promptCacheKey?: unknown;
   top_p?: number;
   frequency_penalty?: number;
   presence_penalty?: number;
@@ -396,6 +424,44 @@ interface ChatRequest {
   webSearchEnabled?: boolean;
   /** Optional max search budget for provider-native web search. */
   webSearchMaxUses?: number;
+}
+
+function resolvePromptCacheKey(
+  request: ChatRequest,
+): { key?: string } | { error: string } {
+  const hasCanonical = Object.hasOwn(request, "prompt_cache_key");
+  const value = hasCanonical
+    ? request.prompt_cache_key
+    : request.promptCacheKey;
+  if (value === undefined && !hasCanonical) return {};
+  if (typeof value !== "string" || value.length === 0 || value.length > 1024) {
+    return {
+      error:
+        "prompt_cache_key must be a nonempty string of at most 1024 characters",
+    };
+  }
+  return { key: value };
+}
+
+function mergePromptCacheProviderOptions(
+  base: ReturnType<typeof mergeAnthropicCotProviderOptions>,
+  key: string | undefined,
+): ReturnType<typeof mergeAnthropicCotProviderOptions> {
+  if (!key) return base;
+  const providerOptions =
+    "providerOptions" in base && base.providerOptions
+      ? { ...base.providerOptions }
+      : {};
+  providerOptions.cerebras = {
+    ...(providerOptions.cerebras ?? {}),
+    prompt_cache_key: key,
+    promptCacheKey: key,
+  };
+  providerOptions.eliza = {
+    ...(providerOptions.eliza ?? {}),
+    promptCacheKey: key,
+  };
+  return { ...base, providerOptions };
 }
 
 // ============================================================================
@@ -1209,6 +1275,21 @@ export async function handleChatCompletionsPOST(
     // SDK streaming, and SDK generation) observes the same validated value.
     request.reasoning_effort = reasoningEffort;
     const provider = getProviderFromModel(model);
+    const promptCacheKeyResult = resolvePromptCacheKey(request);
+    if ("error" in promptCacheKeyResult) {
+      return addCorsHeaders(
+        Response.json(
+          {
+            error: {
+              message: promptCacheKeyResult.error,
+              type: "invalid_request_error",
+              code: "invalid_prompt_cache_key",
+            },
+          },
+          { status: 400 },
+        ),
+      );
+    }
     const normalizedModel = normalizeModelName(model);
     const cotBudget = resolveAnthropicThinkingBudgetTokens(model, process.env);
     const cotOptions =
@@ -2193,6 +2274,10 @@ async function tryPassthroughStreamingRequest(params: {
   if (params.effectiveMaxTokens != null) {
     upstreamBody.max_tokens = params.effectiveMaxTokens;
   }
+  const promptCacheKey = resolvePromptCacheKey(request);
+  if (!("error" in promptCacheKey) && promptCacheKey.key) {
+    upstreamBody.prompt_cache_key = promptCacheKey.key;
+  }
 
   // Client disconnect must cancel the upstream fetch (the meter then settles
   // the delivered portion via its readError path); the route timeout keeps
@@ -2449,6 +2534,14 @@ async function handleStreamingRequest(
     if (passthroughResponse) return passthroughResponse;
   }
 
+  const promptCacheKeyResult = resolvePromptCacheKey(request);
+  const modelProviderOptions = mergePromptCacheProviderOptions(
+    cotOptions,
+    getProviderFromModel(model).startsWith("cerebras") &&
+      !("error" in promptCacheKeyResult)
+      ? promptCacheKeyResult.key
+      : undefined,
+  );
   const provider = getProviderFromModel(model);
   const tools = convertTools(request.tools);
   const toolChoice = mapToolChoice(request.tool_choice);
@@ -2528,8 +2621,7 @@ async function handleStreamingRequest(
     ...(toolChoice ? { toolChoice } : {}),
     ...(experimentalOutput ? { output: experimentalOutput } : {}),
     ...(effectiveMaxTokens != null && { maxOutputTokens: effectiveMaxTokens }),
-    ...cotOptions,
-    ...reasoningProviderOptions,
+    ...combineProviderOptions(modelProviderOptions, reasoningProviderOptions),
     // Parity with the non-streaming path (#8759): the settlement chain below
     // (billUsage → settleReservation → analytics → audit) is 5+ serial DB
     // round-trips, and the AI SDK awaits onFinish before it ends fullStream —
@@ -2987,6 +3079,14 @@ async function handleNonStreamingRequest(
   const billingAffiliateCode =
     pooledCredential && !useMonetizedAppBilling ? null : affiliateCode;
 
+  const promptCacheKeyResult = resolvePromptCacheKey(request);
+  const modelProviderOptions = mergePromptCacheProviderOptions(
+    cotOptions,
+    provider.startsWith("cerebras") && !("error" in promptCacheKeyResult)
+      ? promptCacheKeyResult.key
+      : undefined,
+  );
+
   const safeParamsNonStream = getSafeModelParams(model, {
     temperature: request.temperature,
     topP: request.top_p,
@@ -3017,8 +3117,10 @@ async function handleNonStreamingRequest(
       ...(effectiveMaxTokens != null && {
         maxOutputTokens: effectiveMaxTokens,
       }),
-      ...cotOptions,
-      ...reasoningProviderOptions,
+      ...combineProviderOptions(
+        modelProviderOptions,
+        reasoningProviderOptions,
+      ),
     } as Parameters<typeof generateText>[0]);
 
     // Token counts for the OpenAI-compat response come straight from the
@@ -3252,6 +3354,8 @@ export const __nativeToolingTestHooks = {
   buildReasoningEffortProviderOptions,
   isEmptyButBilled,
   toOpenAiFinishReason,
+  resolvePromptCacheKey,
+  mergePromptCacheProviderOptions,
 } as const;
 
 /** Test seam for the non-streaming AI SDK forwarding contract. */

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -3158,10 +3158,7 @@ async function handleNonStreamingRequest(
       ...(effectiveMaxTokens != null && {
         maxOutputTokens: effectiveMaxTokens,
       }),
-      ...combineProviderOptions(
-        modelProviderOptions,
-        reasoningProviderOptions,
-      ),
+      ...combineProviderOptions(modelProviderOptions, reasoningProviderOptions),
     } as Parameters<typeof generateText>[0]);
 
     // Token counts for the OpenAI-compat response come straight from the

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -452,6 +452,10 @@ function mergePromptCacheProviderOptions(
     "providerOptions" in base && base.providerOptions
       ? { ...base.providerOptions }
       : {};
+  providerOptions.openai = {
+    ...(providerOptions.openai ?? {}),
+    promptCacheKey: key,
+  };
   providerOptions.cerebras = {
     ...(providerOptions.cerebras ?? {}),
     prompt_cache_key: key,
@@ -462,6 +466,10 @@ function mergePromptCacheProviderOptions(
     promptCacheKey: key,
   };
   return { ...base, providerOptions };
+}
+
+function redactPromptCacheKey(value: string, key: string | undefined): string {
+  return key ? value.replaceAll(key, "[REDACTED_PROMPT_CACHE_KEY]") : value;
 }
 
 // ============================================================================
@@ -1088,6 +1096,7 @@ async function recordPooledInferenceSuccess(
 async function recordPooledInferenceFailure(
   pooledCredential: PooledInferenceCredential | null,
   error: unknown,
+  promptCacheKey?: string,
 ): Promise<void> {
   if (!pooledCredential) return;
   const status =
@@ -1098,7 +1107,10 @@ async function recordPooledInferenceFailure(
     credentialId: pooledCredential.credentialId,
     providerId: pooledCredential.providerId,
     status,
-    detail: error instanceof Error ? error.message : String(error),
+    detail: redactPromptCacheKey(
+      error instanceof Error ? error.message : String(error),
+      promptCacheKey,
+    ),
   });
 }
 
@@ -1153,6 +1165,7 @@ export async function handleChatCompletionsPOST(
   // Hoisted so the catch below can echo the requested model in the sanitized
   // provider-configuration error; set right after the body parses.
   let model = "";
+  let promptCacheKeyForRedaction: string | undefined;
 
   try {
     // 1. Authenticate (+ moderation). #9899: API-key dedicated-agent requests
@@ -1290,6 +1303,7 @@ export async function handleChatCompletionsPOST(
         ),
       );
     }
+    promptCacheKeyForRedaction = promptCacheKeyResult.key;
     const normalizedModel = normalizeModelName(model);
     const cotBudget = resolveAnthropicThinkingBudgetTokens(model, process.env);
     const cotOptions =
@@ -1867,12 +1881,18 @@ export async function handleChatCompletionsPOST(
     return preforwardResponse;
   } catch (error) {
     await settleReservation?.(0);
-    const rawMessage = error instanceof Error ? error.message : String(error);
+    const rawMessage = redactPromptCacheKey(
+      error instanceof Error ? error.message : String(error),
+      promptCacheKeyForRedaction,
+    );
     logger.error("[Chat Completions] Error", {
       error: rawMessage,
       cause:
         error instanceof Error && error.cause
-          ? String((error.cause as Error).message ?? error.cause)
+          ? redactPromptCacheKey(
+              String((error.cause as Error).message ?? error.cause),
+              promptCacheKeyForRedaction,
+            )
           : undefined,
     });
     // Provider-configuration failures (missing/invalid provider keys) carry
@@ -2324,10 +2344,12 @@ async function tryPassthroughStreamingRequest(params: {
         getObjectValue(parseJsonObject(bodyText), "error"),
         "message",
       );
-      message =
+      message = redactPromptCacheKey(
         typeof upstreamMessage === "string" && upstreamMessage.trim()
           ? upstreamMessage
-          : `upstream provider returned ${upstreamResponse.status}`;
+          : `upstream provider returned ${upstreamResponse.status}`,
+        "error" in promptCacheKey ? undefined : promptCacheKey.key,
+      );
     } else {
       // error-policy:J6 best-effort teardown — release the upstream connection;
       // the (auth/infra) body is intentionally unused.
@@ -2535,11 +2557,13 @@ async function handleStreamingRequest(
   }
 
   const promptCacheKeyResult = resolvePromptCacheKey(request);
+  const promptCacheKey =
+    "error" in promptCacheKeyResult ? undefined : promptCacheKeyResult.key;
   const modelProviderOptions = mergePromptCacheProviderOptions(
     cotOptions,
     getProviderFromModel(model).startsWith("cerebras") &&
       !("error" in promptCacheKeyResult)
-      ? promptCacheKeyResult.key
+      ? promptCacheKey
       : undefined,
   );
   const provider = getProviderFromModel(model);
@@ -2732,12 +2756,19 @@ async function handleStreamingRequest(
     // later onFinish/onAbort cannot double-refund.
     onError: async ({ error }: { error: unknown }) => {
       await refundStreamingReservationOnce();
-      await recordPooledInferenceFailure(pooledCredential, error);
+      await recordPooledInferenceFailure(
+        pooledCredential,
+        error,
+        promptCacheKey,
+      );
       logger.error(
         "[Chat Completions] Stream provider error — reservation refunded",
         {
           model,
-          error: error instanceof Error ? error.message : String(error),
+          error: redactPromptCacheKey(
+            error instanceof Error ? error.message : String(error),
+            promptCacheKey,
+          ),
         },
       );
     },
@@ -2971,7 +3002,11 @@ async function handleStreamingRequest(
           await settleStreamingAbortOnce([]);
         } else {
           await refundStreamingReservationOnce();
-          await recordPooledInferenceFailure(pooledCredential, error);
+          await recordPooledInferenceFailure(
+            pooledCredential,
+            error,
+            promptCacheKey,
+          );
         }
         // Same sanitization as the non-streaming path: a provider-
         // configuration failure surfacing mid-stream (e.g. the gateway's
@@ -2984,7 +3019,10 @@ async function handleStreamingRequest(
             "[Chat Completions] Provider configuration error during stream",
             {
               model,
-              error: error instanceof Error ? error.message : String(error),
+              error: redactPromptCacheKey(
+                error instanceof Error ? error.message : String(error),
+                promptCacheKey,
+              ),
             },
           );
         }
@@ -2997,9 +3035,10 @@ async function handleStreamingRequest(
             error: {
               message: isConfigError
                 ? modelNotAvailableMessage(model)
-                : error instanceof Error
-                  ? error.message
-                  : String(error),
+                : redactPromptCacheKey(
+                    error instanceof Error ? error.message : String(error),
+                    promptCacheKey,
+                  ),
               // Same status→type mapping as the non-streaming path — a
               // hardcoded "rate_limit_error" here mislabeled every mid-stream
               // provider failure (schema 400s, upstream 5xx) as rate limiting,
@@ -3080,10 +3119,12 @@ async function handleNonStreamingRequest(
     pooledCredential && !useMonetizedAppBilling ? null : affiliateCode;
 
   const promptCacheKeyResult = resolvePromptCacheKey(request);
+  const promptCacheKey =
+    "error" in promptCacheKeyResult ? undefined : promptCacheKeyResult.key;
   const modelProviderOptions = mergePromptCacheProviderOptions(
     cotOptions,
     provider.startsWith("cerebras") && !("error" in promptCacheKeyResult)
-      ? promptCacheKeyResult.key
+      ? promptCacheKey
       : undefined,
   );
 
@@ -3288,7 +3329,7 @@ async function handleNonStreamingRequest(
     );
   } catch (error) {
     await settleReservation?.(0);
-    await recordPooledInferenceFailure(pooledCredential, error);
+    await recordPooledInferenceFailure(pooledCredential, error, promptCacheKey);
     throw error;
   }
 }
@@ -3356,6 +3397,7 @@ export const __nativeToolingTestHooks = {
   toOpenAiFinishReason,
   resolvePromptCacheKey,
   mergePromptCacheProviderOptions,
+  redactPromptCacheKey,
 } as const;
 
 /** Test seam for the non-streaming AI SDK forwarding contract. */


### PR DESCRIPTION
## Summary

- accept canonical `prompt_cache_key` plus the legacy `promptCacheKey` alias
- validate cache keys as nonempty strings capped at 1024 characters
- forward one canonical snake-case key on Cerebras pass-through requests
- merge cache routing into AI SDK Cerebras/eliza provider options without overwriting existing provider options
- keep prompt-cache-enabled streaming requests eligible for the byte-preserving pass-through fast path

## Tests

```text
$ PATH=/tmp/bun-canary/bin:$PATH node test/run-unit-isolated.mjs chat-completions-tool-choice.test.ts
24 pass, 0 fail, 46 expect() calls

$ PATH=/tmp/bun-canary/bin:$PATH node test/run-unit-isolated.mjs chat-completions-passthrough-streaming.test.ts
28 pass, 0 fail, 117 expect() calls

$ bun test packages/cloud/api/__tests__/chat-completions-optimistic-billing.test.ts
17 pass, 0 fail

$ bunx tsgo --noEmit   (packages/cloud/api)
0 errors
```

Also ran Biome check and `git diff --check` on all touched files.

Codex review found that the initial implementation made cache-enabled streams miss the pass-through gate. Addressed by merging SDK provider options only after the pass-through attempt.

Rebased onto `origin/develop` to pick up #16087 (Cerebras reasoning-effort
forwarding); rebase conflicts in `route.ts` and the billing test were resolved
by keeping both the reasoning-effort validation/forwarding path from #16087
and this PR's `prompt_cache_key` resolution/validation/redaction path — both
are independent branches of the same request handler and neither shadows the
other (verified: `validateCerebrasReasoningEffort` / `resolvePromptCacheKey`
are both called and both feed distinct `upstreamBody` fields). A stray
duplicate `generateText` test mock left over from conflict resolution has been
removed (82c25512).

Closes #16089

[sol-cloud]

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only change (Cloud API request/route handling); no UI surface touched.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only change (Cloud API request/route handling); no UI surface touched.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend-only change; no user-facing flow to walk through.
<!-- evidence-row:backend-logs -->
- [x] Structured test run through the real route handler (SDK-call boundary,
      not a mocked HTTP layer) exercises the `resolvePromptCacheKey` /
      `validateCerebrasReasoningEffort` code paths end to end, including the
      request → `generateText` provider-options assertion and the
      redacted-log assertion:
      https://github.com/elizaOS/eliza/blob/fix/16089-cerebras-prompt-cache-key/packages/cloud/api/__tests__/chat-completions-optimistic-billing.test.ts
<!-- evidence-row:frontend-logs -->
- [x] N/A - backend-only change; no frontend console/network surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model output/behavior change; this only alters upstream request
      construction (provider options + validation), not generation content.
      Covered instead by the SDK-boundary unit test linked above, which
      asserts the exact `generateText` call shape.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB rows, memories, or generated files are produced by this
      change; the only artifact is the outbound provider request, asserted in
      the linked test.

## Known gaps / failures

None. All rows above are backend-only `N/A`s with the SDK-boundary test as the
concrete artifact for backend-logs/llm-trajectory/domain-artifacts, per the
"backend-only" evidence guidance for non-UI Cloud API changes.
