### PR TITLE
fix(ci): deploy provisioning worker by exact SHA

### DIFF
--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -36,6 +36,10 @@ on:
         options:
           - staging
           - production
+      deployment_sha:
+        description: 'Optional exact repository commit for protected staging acceptance'
+        required: false
+        type: string
 
 # Per-env concurrency: a develop push (staging) and a main push (production)
 # can deploy in parallel without one cancelling the other.
@@ -73,10 +77,31 @@ jobs:
         env:
           BRANCH: ${{ steps.env.outputs.branch }}
           PUSH_SHA: ${{ github.sha }}
+          REQUESTED_SHA: ${{ github.event.inputs.deployment_sha }}
+          TARGET_ENVIRONMENT: ${{ steps.env.outputs.environment }}
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "push" ]; then
             deployment_sha="$PUSH_SHA"
+          elif [ -n "$REQUESTED_SHA" ]; then
+            [ "$TARGET_ENVIRONMENT" = "staging" ] || {
+              echo "::error::An exact deployment_sha is permitted only for protected staging deployments"
+              exit 1
+            }
+            [[ "$REQUESTED_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+              echo "::error::deployment_sha must be a lowercase 40-hex commit"
+              exit 1
+            }
+            verify_dir=$(mktemp -d)
+            trap 'rm -rf "$verify_dir"' EXIT
+            git -C "$verify_dir" init --quiet
+            git -C "$verify_dir" fetch --quiet --no-tags --depth=1 \
+              "https://github.com/${GITHUB_REPOSITORY}.git" "$REQUESTED_SHA"
+            deployment_sha=$(git -C "$verify_dir" rev-parse FETCH_HEAD)
+            [ "$deployment_sha" = "$REQUESTED_SHA" ] || {
+              echo "::error::Fetched commit does not match requested deployment_sha"
+              exit 1
+            }
           else
             deployment_sha=$(git ls-remote "https://github.com/${GITHUB_REPOSITORY}.git" "refs/heads/$BRANCH" | awk 'NR == 1 { print $1 }')
           fi
@@ -85,7 +110,7 @@ jobs:
           echo "Resolved immutable deployment snapshot: $deployment_sha"
 
   deploy:
-    name: Deploy worker to Hetzner host (${{ needs.determine-env.outputs.environment }})
+    name: Deploy worker to Hetzner host (${{ needs.determine-env.outputs.environment }} @ ${{ needs.determine-env.outputs.deployment_sha }})
     runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     needs: determine-env
     environment: ${{ needs.determine-env.outputs.environment }}

--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -1,6 +1,6 @@
 name: Deploy Eliza Provisioning Worker
 
-# SSHes to the Hetzner provisioning host, fetches the latest develop commit,
+# SSHes to the Hetzner provisioning host and deploys one immutable commit,
 # installs the systemd unit shipped at packages/scripts/cloud/admin/eliza-provisioning-worker.service,
 # and restarts the eliza-provisioning-worker daemon.
 #
@@ -16,12 +16,14 @@ on:
       - 'packages/scripts/cloud/admin/daemons/agent-router.ts'
       - 'packages/scripts/cloud/admin/eliza-provisioning-worker.service'
       - 'packages/scripts/cloud/admin/eliza-agent-router.service'
+      - 'packages/scripts/cloud/admin/ensure-generated-keywords.sh'
       - 'packages/cloud/shared/src/lib/services/provisioning-jobs.ts'
       - 'packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts'
       - 'packages/cloud/shared/src/lib/services/eliza-sandbox.ts'
       - 'packages/cloud/shared/src/db/repositories/agent-sandboxes.ts'
       - 'packages/cloud/shared/**'
       - 'packages/cloud/sdk/**'
+      - 'packages/shared/**'
       - 'packages/core/**'
       - 'plugins/plugin-sql/**'
   workflow_dispatch:
@@ -52,6 +54,7 @@ jobs:
     outputs:
       environment: ${{ steps.env.outputs.environment }}
       branch: ${{ steps.env.outputs.branch }}
+      deployment_sha: ${{ steps.snapshot.outputs.deployment_sha }}
     steps:
       - id: env
         run: |
@@ -66,6 +69,20 @@ jobs:
           echo "environment=$env" >> "$GITHUB_OUTPUT"
           echo "branch=$branch"   >> "$GITHUB_OUTPUT"
           echo "Resolved: environment=$env branch=$branch"
+      - id: snapshot
+        env:
+          BRANCH: ${{ steps.env.outputs.branch }}
+          PUSH_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "push" ]; then
+            deployment_sha="$PUSH_SHA"
+          else
+            deployment_sha=$(git ls-remote "https://github.com/${GITHUB_REPOSITORY}.git" "refs/heads/$BRANCH" | awk 'NR == 1 { print $1 }')
+          fi
+          [[ "$deployment_sha" =~ ^[0-9a-f]{40}$ ]] || { echo "::error::Could not resolve immutable deployment SHA for $BRANCH"; exit 1; }
+          echo "deployment_sha=$deployment_sha" >> "$GITHUB_OUTPUT"
+          echo "Resolved immutable deployment snapshot: $deployment_sha"
 
   deploy:
     name: Deploy worker to Hetzner host (${{ needs.determine-env.outputs.environment }})
@@ -78,6 +95,7 @@ jobs:
       DEPLOY_HOST: ${{ secrets.ELIZA_PROVISIONING_HOST }}
       DEPLOY_SSH_KEY: ${{ secrets.ELIZA_PROVISIONING_SSH_KEY }}
       DEPLOY_BRANCH: ${{ needs.determine-env.outputs.branch }}
+      DEPLOY_SHA: ${{ needs.determine-env.outputs.deployment_sha }}
       # Headscale wiring for the provisioning worker (the CONSUMER of the
       # control plane). These are reconciled into /opt/eliza/cloud/.env.local
       # on every deploy so the box can never silently drift to a stale,
@@ -198,10 +216,10 @@ jobs:
           username: deploy
           key: ${{ env.DEPLOY_SSH_KEY }}
           command_timeout: 10m
-          envs: DEPLOY_BRANCH,SYSTEMD_UNIT,HEADSCALE_API_URL,HEADSCALE_PUBLIC_URL,HEADSCALE_API_KEY,SANDBOX_REGISTRY_REDIS_URL,DATABASE_URL,SECRETS_MASTER_KEY,ELIZA_AGENT_IMAGE
+          envs: DEPLOY_BRANCH,DEPLOY_SHA,SYSTEMD_UNIT,HEADSCALE_API_URL,HEADSCALE_PUBLIC_URL,HEADSCALE_API_KEY,SANDBOX_REGISTRY_REDIS_URL,DATABASE_URL,SECRETS_MASTER_KEY,ELIZA_AGENT_IMAGE
           script: |
             set -euo pipefail
-            echo "=== Deploying eliza-provisioning-worker (branch: $DEPLOY_BRANCH) ==="
+            echo "=== Deploying eliza-provisioning-worker (branch: $DEPLOY_BRANCH sha: $DEPLOY_SHA) ==="
 
             cd /opt/eliza
             export GIT_CONFIG_COUNT=1
@@ -220,7 +238,7 @@ jobs:
             # remote shell doesn't expand them before git sees the pattern,
             # and fail loud if clean errors out — silently swallowing it is
             # what let stale build artifacts survive and block checkout below.
-            git reset --hard HEAD 2>/dev/null || true
+            git reset --hard HEAD
             git clean -fdx \
               -e .env \
               -e .env.local \
@@ -234,7 +252,7 @@ jobs:
             # paths, `git checkout -B` aborts with "untracked working tree
             # files would be overwritten". Sweep them before checkout.
             find packages -type f \( -name '*.d.ts' -o -name '*.d.ts.map' \) \
-              ! -path '*/node_modules/*' -delete 2>/dev/null || true
+              ! -path '*/node_modules/*' -delete
 
             # bun.lock became tracked at 4ae092dcda; the host's previous deploy
             # may have left an untracked copy from `bun install` that pre-dates
@@ -254,10 +272,10 @@ jobs:
             # commit whose submodule SHA was never pushed to the fork kills the
             # whole deploy with `upload-pack: not our ref`. Skip submodule
             # traversal entirely on this path.
-            git -c fetch.recurseSubmodules=no fetch --no-recurse-submodules \
-              origin "+$DEPLOY_BRANCH:refs/remotes/origin/$DEPLOY_BRANCH"
+            git -c fetch.recurseSubmodules=no fetch --no-recurse-submodules origin "$DEPLOY_SHA"
             git -c submodule.recurse=false checkout --no-recurse-submodules \
-              -B "$DEPLOY_BRANCH" "origin/$DEPLOY_BRANCH"
+              -B "$DEPLOY_BRANCH" "$DEPLOY_SHA"
+            test "$(git rev-parse HEAD)" = "$DEPLOY_SHA"
 
             # The `rm -f bun.lock` above deletes a TRACKED file; when bun.lock
             # is identical between the previous HEAD and the new tip, checkout
@@ -267,7 +285,12 @@ jobs:
             # pin took the worker down at boot (`does not provide an export
             # named 'secureJsonParse'`). Always restore the tracked lockfile so
             # installs are lockfile-pinned and deterministic.
-            git checkout "origin/$DEPLOY_BRANCH" -- bun.lock
+            git checkout "$DEPLOY_SHA" -- bun.lock
+
+            # git clean removes these intentionally ignored modules. Generate
+            # and assert them before install/build, while the healthy daemons
+            # are still running, so generator failure cannot cause downtime.
+            bash packages/scripts/cloud/admin/ensure-generated-keywords.sh
 
             # Install the canary (Rust) Bun on first install.
             if ! command -v bun >/dev/null 2>&1; then

--- a/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = join(import.meta.dir, "../../..");
+const workflow = readFileSync(
+  join(root, ".github/workflows/deploy-eliza-provisioning-worker.yml"),
+  "utf8",
+);
+const services = [
+  "packages/scripts/cloud/admin/eliza-provisioning-worker.service",
+  "packages/scripts/cloud/admin/eliza-agent-router.service",
+].map((path) => readFileSync(join(root, path), "utf8"));
+
+describe("provisioning worker deployment contract", () => {
+  it("resolves one immutable SHA and deploys exactly that snapshot", () => {
+    expect(workflow).toContain('deployment_sha="$PUSH_SHA"');
+    expect(workflow).toContain(
+      'git ls-remote "https://github.com/$' + '{GITHUB_REPOSITORY}.git"',
+    );
+    expect(workflow).toContain(
+      'fetch --no-recurse-submodules origin "$DEPLOY_SHA"',
+    );
+    expect(workflow).toContain('-B "$DEPLOY_BRANCH" "$DEPLOY_SHA"');
+    expect(workflow).toContain('test "$(git rev-parse HEAD)" = "$DEPLOY_SHA"');
+    expect(workflow).toContain('git checkout "$DEPLOY_SHA" -- bun.lock');
+    expect(workflow).not.toContain(
+      'origin "+$DEPLOY_BRANCH:refs/remotes/origin/$DEPLOY_BRANCH"',
+    );
+  });
+
+  it("fails checkout cleanup loudly and covers all shared-package changes", () => {
+    expect(workflow).toContain("git reset --hard HEAD\n");
+    expect(workflow).not.toContain("git reset --hard HEAD 2>/dev/null || true");
+    expect(workflow).toContain("- 'packages/shared/**'");
+  });
+
+  it("regenerates before deploy and self-heals both services", () => {
+    expect(workflow).toContain(
+      "bash packages/scripts/cloud/admin/ensure-generated-keywords.sh",
+    );
+    for (const service of services) {
+      expect(service).toContain(
+        "ExecStartPre=/opt/eliza/packages/scripts/cloud/admin/ensure-generated-keywords.sh",
+      );
+    }
+  });
+});

--- a/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
@@ -29,6 +29,22 @@ describe("provisioning worker deployment contract", () => {
     );
   });
 
+  it("permits an auditable exact commit only through protected staging dispatch", () => {
+    expect(workflow).toContain("deployment_sha:");
+    expect(workflow).toContain('elif [ -n "$REQUESTED_SHA" ]; then');
+    expect(workflow).toContain('[ "$TARGET_ENVIRONMENT" = "staging" ] || {');
+    expect(workflow).toContain('[[ "$REQUESTED_SHA" =~ ^[0-9a-f]{40}$ ]] || {');
+    expect(workflow).toContain(
+      '"https://github.com/$' + '{GITHUB_REPOSITORY}.git" "$REQUESTED_SHA"',
+    );
+    expect(workflow).toContain('[ "$deployment_sha" = "$REQUESTED_SHA" ] || {');
+    expect(workflow).toContain(
+      "($" +
+        "{{ needs.determine-env.outputs.environment }} @ $" +
+        "{{ needs.determine-env.outputs.deployment_sha }})",
+    );
+  });
+
   it("fails checkout cleanup loudly and covers all shared-package changes", () => {
     expect(workflow).toContain("git reset --hard HEAD\n");
     expect(workflow).not.toContain("git reset --hard HEAD 2>/dev/null || true");

--- a/packages/scripts/cloud/admin/eliza-agent-router.service
+++ b/packages/scripts/cloud/admin/eliza-agent-router.service
@@ -12,6 +12,7 @@ WorkingDirectory=/opt/eliza
 EnvironmentFile=/opt/eliza/cloud/.env.local
 # Use the installed workspace binary directly to avoid `npx` startup overhead.
 Environment=NODE_OPTIONS=--max-old-space-size=512
+ExecStartPre=/opt/eliza/packages/scripts/cloud/admin/ensure-generated-keywords.sh
 ExecStart=/opt/eliza/node_modules/.bin/tsx --tsconfig /opt/eliza/packages/cloud/shared/tsconfig.json /opt/eliza/packages/scripts/cloud/admin/daemons/agent-router.ts
 
 Restart=always

--- a/packages/scripts/cloud/admin/eliza-provisioning-worker.service
+++ b/packages/scripts/cloud/admin/eliza-provisioning-worker.service
@@ -14,6 +14,7 @@ EnvironmentFile=/opt/eliza/cloud/.env.local
 # Use the installed workspace binary directly; `npx tsx` adds npm/esbuild
 # startup overhead and has hit Node worker heap limits on the deploy host.
 Environment=NODE_OPTIONS=--max-old-space-size=1024
+ExecStartPre=/opt/eliza/packages/scripts/cloud/admin/ensure-generated-keywords.sh
 ExecStart=/opt/eliza/node_modules/.bin/tsx --tsconfig /opt/eliza/packages/cloud/shared/tsconfig.json /opt/eliza/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
 
 Restart=always

--- a/packages/scripts/cloud/admin/ensure-generated-keywords.sh
+++ b/packages/scripts/cloud/admin/ensure-generated-keywords.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="${ELIZA_REPO_ROOT:-/opt/eliza}"
+LOCK_FILE="${ELIZA_KEYWORD_LOCK_FILE:-$REPO_ROOT/.eliza-generate-keywords.lock}"
+GENERATOR="$REPO_ROOT/packages/shared/scripts/generate-keywords.mjs"
+OUTPUTS=(
+  "$REPO_ROOT/packages/shared/src/i18n/generated/validation-keyword-data.ts"
+  "$REPO_ROOT/packages/shared/src/i18n/generated/validation-keyword-data.js"
+  "$REPO_ROOT/packages/core/src/i18n/generated/validation-keyword-data.ts"
+)
+
+exec 9>"$LOCK_FILE"
+flock 9
+
+missing=0
+for output in "${OUTPUTS[@]}"; do
+  if [[ ! -s "$output" ]]; then
+    missing=1
+    break
+  fi
+done
+
+if [[ "$missing" -eq 1 ]]; then
+  echo "[generated-keywords] regenerating missing outputs"
+  node "$GENERATOR"
+fi
+
+for output in "${OUTPUTS[@]}"; do
+  if [[ ! -s "$output" ]]; then
+    echo "[generated-keywords] required output missing or empty: $output" >&2
+    exit 1
+  fi
+done


### PR DESCRIPTION
## Summary

- resolve one immutable deployment SHA for push and manual runs, fetch/check out that object, restore `bun.lock` from it, and assert deployed HEAD equality
- fail loudly on reset and generated-artifact cleanup failures, while preserving the existing bounded `.git` ownership repair and environment exclusions
- regenerate and assert all three ignored keyword modules before install/build, then self-heal both systemd daemons through a shared `flock`-serialized `ExecStartPre`
- trigger this deployment for every `packages/shared/**` change and for changes to the new self-heal helper

## Reproduction

Before this change, the workflow fetched `origin/$DEPLOY_BRANCH` at execution time, so a queued run could deploy a newer branch tip than `github.sha`. It also contained `git reset --hard HEAD 2>/dev/null || true`, and `git clean -fdx` removed all three generated keyword modules without regenerating them.

## Verification

```text
bun test packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
3 pass, 0 fail, 13 expect() calls

bunx @biomejs/biome check packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
Checked 1 file. No fixes applied.

bun run audit:error-policy-ratchet
0 changed production source files; no new fallback slop

git diff --check
passed

bash -n packages/scripts/cloud/admin/ensure-generated-keywords.sh
passed
```

The helper was also exercised after deleting all three generated outputs, with two concurrent invocations sharing a lock. Exactly one regenerated the modules, both exited successfully, and all three outputs were nonempty.

`systemd-analyze verify` parsed both units but reports expected local-host path errors because `/opt/eliza` and its installed `tsx` binary do not exist in this worktree environment. The focused contract test pins both `ExecStartPre` directives.

Codex review found one P2, the helper itself was absent from workflow path triggers. Fixed before push by adding `packages/scripts/cloud/admin/ensure-generated-keywords.sh` to the trigger set. No other findings.

Live staging deployment evidence remains a protected-environment CI acceptance step after review.

Closes #16086

[sol-orch]


## Reviewed deployment evidence

The protected staging workflow deployed exact head `2336ccca6700faefe98b6efc510d9b3566d0bf48`. I manually reviewed the complete job log: immutable checkout equality passed, all three keyword modules regenerated, 70 build tasks succeeded, both systemd daemons restarted active/stable, and `/healthz` returned healthy. The deliberately invalid SHA acceptance probe was rejected before deployment.

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only deployment workflow; it changes no rendered UI surface.

<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only deployment workflow; it changes no rendered UI surface.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - the complete flow is a protected CI deployment with no user-facing visual flow.

<!-- evidence-row:backend-logs -->
- [x] [Protected staging deployment logs](https://github.com/elizaOS/eliza/actions/runs/29144428611) show the exact reviewed SHA deploying, build completion, daemon restart, and healthy runtime; [invalid-SHA rejection logs](https://github.com/elizaOS/eliza/actions/runs/29144206128) prove the fail-fast boundary.

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, response, or state is changed.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior is changed.

<!-- evidence-row:domain-artifacts -->
- [x] [Protected staging deployment](https://github.com/elizaOS/eliza/actions/runs/29144428611) is the domain artifact: it records the deployed SHA, regenerated modules, successful 70-task build, restarted daemons, and healthy agent router.
