### PR TITLE
fix(cloud): preserve explicit reasoning token caps

### DIFF
--- a/packages/cloud/api/__tests__/chat-completions-explicit-max-tokens-route.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-explicit-max-tokens-route.test.ts
@@ -7,7 +7,114 @@
  * a spend limit and must pass through to the provider unchanged.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Keep the real modules so afterAll can restore them — bun's `mock.module` is
+// process-global and leaks into sibling test files in the same batch process
+// otherwise. Every mock below spreads its actual so unrelated exports stay
+// real, and afterAll re-registers the actuals verbatim.
+const aiActual = require("ai") as Record<string, unknown>;
+
+import * as authActual from "@/lib/auth";
+import * as rateLimitActual from "@/lib/middleware/rate-limit";
+import * as rateLimitHonoActual from "@/lib/middleware/rate-limit-hono-cloudflare";
+import * as pricingActual from "@/lib/pricing";
+import * as anthropicThinkingActual from "@/lib/providers/anthropic-thinking";
+import * as anthropicWebSearchActual from "@/lib/providers/anthropic-web-search";
+import * as languageModelActual from "@/lib/providers/language-model";
+import * as aiBillingActual from "@/lib/services/ai-billing";
+import * as aiBillingRecordsActual from "@/lib/services/ai-billing-records";
+import * as appCreditsActual from "@/lib/services/app-credits";
+import * as appsActual from "@/lib/services/apps";
+import * as contentModerationActual from "@/lib/services/content-moderation";
+import * as creditsActual from "@/lib/services/credits";
+import * as inferenceAuthContextActual from "@/lib/services/inference-auth-context";
+import * as inferenceBillingDeferredActual from "@/lib/services/inference-billing-deferred";
+import * as inferenceBillingFastPathActual from "@/lib/services/inference-billing-fast-path";
+import * as inferenceBillingLedgerActual from "@/lib/services/inference-billing-ledger";
+import * as inferencePassthroughActual from "@/lib/services/inference-passthrough";
+import * as modelCatalogActual from "@/lib/services/model-catalog";
+import * as teamCredentialPoolActual from "@/lib/services/team-credential-pool";
+import * as creditReservationActual from "@/lib/utils/credit-reservation";
+import * as requestTimeoutActual from "@/lib/utils/request-timeout";
+import * as settleOffResponsePathActual from "@/lib/utils/settle-off-response-path";
+
+const MOCKED_MODULE_ACTUALS: ReadonlyArray<
+  [specifier: string, actual: Record<string, unknown>]
+> = [
+  ["ai", aiActual],
+  ["@/lib/auth", authActual as Record<string, unknown>],
+  ["@/lib/middleware/rate-limit", rateLimitActual as Record<string, unknown>],
+  [
+    "@/lib/middleware/rate-limit-hono-cloudflare",
+    rateLimitHonoActual as Record<string, unknown>,
+  ],
+  ["@/lib/pricing", pricingActual as Record<string, unknown>],
+  [
+    "@/lib/providers/anthropic-thinking",
+    anthropicThinkingActual as Record<string, unknown>,
+  ],
+  [
+    "@/lib/providers/anthropic-web-search",
+    anthropicWebSearchActual as Record<string, unknown>,
+  ],
+  [
+    "@/lib/providers/language-model",
+    languageModelActual as Record<string, unknown>,
+  ],
+  ["@/lib/services/ai-billing", aiBillingActual as Record<string, unknown>],
+  [
+    "@/lib/services/ai-billing-records",
+    aiBillingRecordsActual as Record<string, unknown>,
+  ],
+  ["@/lib/services/app-credits", appCreditsActual as Record<string, unknown>],
+  ["@/lib/services/apps", appsActual as Record<string, unknown>],
+  [
+    "@/lib/services/content-moderation",
+    contentModerationActual as Record<string, unknown>,
+  ],
+  ["@/lib/services/credits", creditsActual as Record<string, unknown>],
+  [
+    "@/lib/services/inference-auth-context",
+    inferenceAuthContextActual as Record<string, unknown>,
+  ],
+  [
+    "@/lib/services/inference-billing-deferred",
+    inferenceBillingDeferredActual as Record<string, unknown>,
+  ],
+  [
+    "@/lib/services/inference-billing-fast-path",
+    inferenceBillingFastPathActual as Record<string, unknown>,
+  ],
+  [
+    "@/lib/services/inference-billing-ledger",
+    inferenceBillingLedgerActual as Record<string, unknown>,
+  ],
+  [
+    "@/lib/services/inference-passthrough",
+    inferencePassthroughActual as Record<string, unknown>,
+  ],
+  [
+    "@/lib/services/model-catalog",
+    modelCatalogActual as Record<string, unknown>,
+  ],
+  [
+    "@/lib/services/team-credential-pool",
+    teamCredentialPoolActual as Record<string, unknown>,
+  ],
+  [
+    "@/lib/utils/credit-reservation",
+    creditReservationActual as Record<string, unknown>,
+  ],
+  [
+    "@/lib/utils/request-timeout",
+    requestTimeoutActual as Record<string, unknown>,
+  ],
+  [
+    "@/lib/utils/settle-off-response-path",
+    settleOffResponsePathActual as Record<string, unknown>,
+  ],
+];
 
 const ORG = "00000000-0000-4000-8000-0000000000aa";
 const USER = "00000000-0000-4000-8000-0000000000bb";
@@ -43,6 +150,7 @@ let shouldBlockUser = false;
 let reserveCreditsImpl: () => Promise<unknown>;
 
 mock.module("ai", () => ({
+  ...aiActual,
   APICallError: { isInstance: () => false },
   RetryError: { isInstance: () => false },
   jsonSchema: (schema: unknown) => ({ schema }),
@@ -80,6 +188,7 @@ mock.module("ai", () => ({
 }));
 
 mock.module("@/lib/auth", () => ({
+  ...authActual,
   requireAuthOrApiKeyWithOrg: mock(async () => ({
     user: { id: USER, organization_id: ORG },
     apiKey: { id: API_KEY_ID },
@@ -87,19 +196,23 @@ mock.module("@/lib/auth", () => ({
 }));
 
 mock.module("@/lib/services/inference-auth-context", () => ({
+  ...inferenceAuthContextActual,
   resolveInferenceAuthContext: mock(async () => authResolution),
 }));
 
 mock.module("@/lib/middleware/rate-limit", () => ({
+  ...rateLimitActual,
   enforceOrgRateLimit: mock(async () => null),
 }));
 
 mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  ...rateLimitHonoActual,
   RateLimitPresets: { RELAXED: {} },
   rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
 }));
 
 mock.module("@/lib/pricing", () => ({
+  ...pricingActual,
   calculateCost: mock(async () => ({
     totalCost: 0.001,
     inputCost: 0.0005,
@@ -122,17 +235,20 @@ mock.module("@/lib/pricing", () => ({
 }));
 
 mock.module("@/lib/providers/anthropic-thinking", () => ({
+  ...anthropicThinkingActual,
   mergeAnthropicCotProviderOptions: () => ({}),
   resolveAnthropicThinkingBudgetTokens: () => null,
 }));
 
 mock.module("@/lib/providers/anthropic-web-search", () => ({
+  ...anthropicWebSearchActual,
   ANTHROPIC_WEB_SEARCH_INPUT_TOKEN_BUFFER: 0,
   buildProviderNativeWebSearchTools: () => ({}),
   isAnthropicWebSearchEnabled: () => false,
 }));
 
 mock.module("@/lib/providers/language-model", () => ({
+  ...languageModelActual,
   canonicalizeCerebrasModelId: (model: string) => model,
   getAiProviderConfigurationError: () => "AI services are not configured",
   getLanguageModel: (model: string) => ({ model }),
@@ -144,12 +260,14 @@ mock.module("@/lib/providers/language-model", () => ({
 }));
 
 mock.module("@/lib/services/model-catalog", () => ({
+  ...modelCatalogActual,
   getCachedGatewayModelById: mock(async () => ({
     supported_parameters: catalogSupportedParameters,
   })),
 }));
 
 mock.module("@/lib/services/apps", () => ({
+  ...appsActual,
   appsService: {
     getAuthorizedMonetizedAppForUser: mock(async () => null),
     getById: mock(async () => null),
@@ -157,6 +275,7 @@ mock.module("@/lib/services/apps", () => ({
 }));
 
 mock.module("@/lib/services/content-moderation", () => ({
+  ...contentModerationActual,
   contentModerationService: {
     shouldBlockUser: mock(async () => shouldBlockUser),
     moderateInBackground: mock(() => {}),
@@ -173,6 +292,7 @@ class TestInsufficientCreditsError extends Error {
 }
 
 mock.module("@/lib/services/ai-billing", () => ({
+  ...aiBillingActual,
   estimateInputTokens: (messages: Array<{ content: string }>) =>
     messages.reduce((sum, message) => sum + message.content.length, 0),
   reserveCredits: mock(async () => reserveCreditsImpl()),
@@ -187,22 +307,26 @@ mock.module("@/lib/services/ai-billing", () => ({
 }));
 
 mock.module("@/lib/services/ai-billing-records", () => ({
+  ...aiBillingRecordsActual,
   aiBillingRecordsService: { record: mock(async () => {}) },
 }));
 
 mock.module("@/lib/services/app-credits", () => ({
+  ...appCreditsActual,
   appCreditsService: {
     reserveInferenceCredits: mock(async () => ({ id: "app-reservation-1" })),
   },
 }));
 
 mock.module("@/lib/services/credits", () => ({
+  ...creditsActual,
   creditsService: {
     createAnonymousReservation: () => ({ id: "anonymous-reservation" }),
   },
 }));
 
 mock.module("@/lib/services/inference-billing-fast-path", () => ({
+  ...inferenceBillingFastPathActual,
   createOptimisticDebitSettler: () => async () => null,
   getGateBalanceUsd: mock(async () => 0),
   isOptimisticBackstopAvailable: () => false,
@@ -213,23 +337,27 @@ mock.module("@/lib/services/inference-billing-fast-path", () => ({
 }));
 
 mock.module("@/lib/services/inference-billing-ledger", () => ({
+  ...inferenceBillingLedgerActual,
   admitInferenceChargeViaLedger: mock(async () => ({ admitted: false })),
   createLedgerDebitSettler: () => async () => null,
   resolveInferenceBillingLedger: () => "kv",
 }));
 
 mock.module("@/lib/services/inference-billing-deferred", () => ({
+  ...inferenceBillingDeferredActual,
   createDeferredAdmissionSettler: () => async () => null,
   isDeferredAdmissionEnabled: () => false,
   isOrgAdmissionRefused: () => false,
 }));
 
 mock.module("@/lib/services/inference-passthrough", () => ({
+  ...inferencePassthroughActual,
   isPassthroughStreamingEnabled: () => false,
   readPassthroughStreamTail: mock(async () => ({ usage: null })),
 }));
 
 mock.module("@/lib/services/team-credential-pool", () => ({
+  ...teamCredentialPoolActual,
   getTeamPoolRegistry: () => ({
     selectCredential: mock(async () => null),
     recordUse: mock(async () => {}),
@@ -238,6 +366,7 @@ mock.module("@/lib/services/team-credential-pool", () => ({
 }));
 
 mock.module("@/lib/utils/credit-reservation", () => ({
+  ...creditReservationActual,
   createCreditReservationSettler: () => async (actualCost: number) => ({
     reconciled: true,
     actualCost,
@@ -245,10 +374,12 @@ mock.module("@/lib/utils/credit-reservation", () => ({
 }));
 
 mock.module("@/lib/utils/request-timeout", () => ({
+  ...requestTimeoutActual,
   getRouteTimeoutMs: (seconds: number) => seconds * 1000,
 }));
 
 mock.module("@/lib/utils/settle-off-response-path", () => ({
+  ...settleOffResponsePathActual,
   settleOffResponsePath: async (
     _executionCtx: unknown,
     work: () => Promise<void>,
@@ -260,6 +391,12 @@ mock.module("@/lib/utils/settle-off-response-path", () => ({
 const { handleChatCompletionsPOST } = await import(
   "../v1/chat/completions/route"
 );
+
+afterAll(() => {
+  for (const [specifier, actual] of MOCKED_MODULE_ACTUALS) {
+    mock.module(specifier, () => actual);
+  }
+});
 
 beforeEach(() => {
   generateTextCalls.length = 0;

--- a/packages/cloud/api/__tests__/chat-completions-explicit-max-tokens-route.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-explicit-max-tokens-route.test.ts
@@ -1,0 +1,508 @@
+/**
+ * Route-level coverage for explicit chat-completion output ceilings.
+ *
+ * The production primitive is `computeEffectiveMaxTokens` inside the real
+ * `handleChatCompletionsPOST` path: catalog reasoning metadata may raise an
+ * omitted `max_tokens` to the response floor, but a caller-supplied ceiling is
+ * a spend limit and must pass through to the provider unchanged.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const ORG = "00000000-0000-4000-8000-0000000000aa";
+const USER = "00000000-0000-4000-8000-0000000000bb";
+const API_KEY_ID = "00000000-0000-4000-8000-0000000000cc";
+const MODEL = "z-ai/glm-5.1";
+const MIN_RESPONSE_TOKENS = 4096;
+
+const generateTextCalls: Array<Record<string, unknown>> = [];
+const streamTextCalls: Array<Record<string, unknown>> = [];
+let catalogSupportedParameters: string[] | undefined = [
+  "max_tokens",
+  "reasoning",
+];
+let generateTextResult: {
+  text: string;
+  finishReason: string;
+  toolCalls: Array<{
+    toolCallId: string;
+    toolName: string;
+    input: unknown;
+  }>;
+  usage: Record<string, unknown>;
+};
+let authResolution:
+  | {
+      kind: "authorized";
+      ctx: { userId: string; orgId: string; apiKeyId: string };
+    }
+  | { kind: "suspended" }
+  | { kind: "miss" };
+let providerConfigured = true;
+let shouldBlockUser = false;
+let reserveCreditsImpl: () => Promise<unknown>;
+
+mock.module("ai", () => ({
+  APICallError: { isInstance: () => false },
+  RetryError: { isInstance: () => false },
+  jsonSchema: (schema: unknown) => ({ schema }),
+  generateText: mock(async (params: Record<string, unknown>) => {
+    generateTextCalls.push(params);
+    return generateTextResult;
+  }),
+  streamText: mock((params: Record<string, unknown>) => {
+    streamTextCalls.push(params);
+    return {
+      fullStream: (async function* () {
+        yield { type: "text-delta", text: "streamed " };
+        yield { type: "text-delta", text: "answer" };
+        await (
+          params.onFinish as (result: {
+            text: string;
+            usage: {
+              inputTokens: number;
+              outputTokens: number;
+              totalTokens: number;
+            };
+          }) => Promise<void>
+        )({
+          text: "streamed answer",
+          usage: { inputTokens: 13, outputTokens: 8, totalTokens: 21 },
+        });
+        yield {
+          type: "finish",
+          finishReason: "stop",
+          totalUsage: { inputTokens: 13, outputTokens: 8, totalTokens: 21 },
+        };
+      })(),
+    };
+  }),
+}));
+
+mock.module("@/lib/auth", () => ({
+  requireAuthOrApiKeyWithOrg: mock(async () => ({
+    user: { id: USER, organization_id: ORG },
+    apiKey: { id: API_KEY_ID },
+  })),
+}));
+
+mock.module("@/lib/services/inference-auth-context", () => ({
+  resolveInferenceAuthContext: mock(async () => authResolution),
+}));
+
+mock.module("@/lib/middleware/rate-limit", () => ({
+  enforceOrgRateLimit: mock(async () => null),
+}));
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { RELAXED: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+
+mock.module("@/lib/pricing", () => ({
+  calculateCost: mock(async () => ({
+    totalCost: 0.001,
+    inputCost: 0.0005,
+    outputCost: 0.0005,
+  })),
+  estimateTokens: (text: string) => Math.max(1, Math.ceil(text.length / 4)),
+  getProviderFromModel: () => "gateway",
+  getSafeModelParams: (_model: string, params: Record<string, unknown>) =>
+    Object.fromEntries(
+      Object.entries(params).filter(([, value]) => value !== undefined),
+    ),
+  modelUsesReasoningTokens: (
+    model: string,
+    supportedParameters?: readonly string[],
+  ) =>
+    model.includes("o3") ||
+    model.includes("reasoning") ||
+    supportedParameters?.some((param) => param.includes("reasoning")) === true,
+  normalizeModelName: (model: string) => model,
+}));
+
+mock.module("@/lib/providers/anthropic-thinking", () => ({
+  mergeAnthropicCotProviderOptions: () => ({}),
+  resolveAnthropicThinkingBudgetTokens: () => null,
+}));
+
+mock.module("@/lib/providers/anthropic-web-search", () => ({
+  ANTHROPIC_WEB_SEARCH_INPUT_TOKEN_BUFFER: 0,
+  buildProviderNativeWebSearchTools: () => ({}),
+  isAnthropicWebSearchEnabled: () => false,
+}));
+
+mock.module("@/lib/providers/language-model", () => ({
+  canonicalizeCerebrasModelId: (model: string) => model,
+  getAiProviderConfigurationError: () => "AI services are not configured",
+  getLanguageModel: (model: string) => ({ model }),
+  hasLanguageModelProviderConfigured: () => providerConfigured,
+  isProviderConfigurationError: () => false,
+  resolveAiProviderSource: () => "gateway",
+  resolvePassthroughUpstreamForModel: () => null,
+  resolvePooledDirectProviderForModel: () => null,
+}));
+
+mock.module("@/lib/services/model-catalog", () => ({
+  getCachedGatewayModelById: mock(async () => ({
+    supported_parameters: catalogSupportedParameters,
+  })),
+}));
+
+mock.module("@/lib/services/apps", () => ({
+  appsService: {
+    getAuthorizedMonetizedAppForUser: mock(async () => null),
+    getById: mock(async () => null),
+  },
+}));
+
+mock.module("@/lib/services/content-moderation", () => ({
+  contentModerationService: {
+    shouldBlockUser: mock(async () => shouldBlockUser),
+    moderateInBackground: mock(() => {}),
+  },
+}));
+
+class TestInsufficientCreditsError extends Error {
+  required: number;
+
+  constructor(required: number) {
+    super("Insufficient credits");
+    this.required = required;
+  }
+}
+
+mock.module("@/lib/services/ai-billing", () => ({
+  estimateInputTokens: (messages: Array<{ content: string }>) =>
+    messages.reduce((sum, message) => sum + message.content.length, 0),
+  reserveCredits: mock(async () => reserveCreditsImpl()),
+  billUsage: mock(async (_context: unknown, usage: Record<string, number>) => ({
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    totalTokens: usage.totalTokens,
+    totalCost: 0.001,
+  })),
+  recordUsageAnalytics: mock(async () => ({ id: "usage-record-1" })),
+  InsufficientCreditsError: TestInsufficientCreditsError,
+}));
+
+mock.module("@/lib/services/ai-billing-records", () => ({
+  aiBillingRecordsService: { record: mock(async () => {}) },
+}));
+
+mock.module("@/lib/services/app-credits", () => ({
+  appCreditsService: {
+    reserveInferenceCredits: mock(async () => ({ id: "app-reservation-1" })),
+  },
+}));
+
+mock.module("@/lib/services/credits", () => ({
+  creditsService: {
+    createAnonymousReservation: () => ({ id: "anonymous-reservation" }),
+  },
+}));
+
+mock.module("@/lib/services/inference-billing-fast-path", () => ({
+  createOptimisticDebitSettler: () => async () => null,
+  getGateBalanceUsd: mock(async () => 0),
+  isOptimisticBackstopAvailable: () => false,
+  isOptimisticBillingEnabled: () => false,
+  isOptimisticEligible: () => false,
+  resolveSafeBalanceThresholdUsd: () => 5,
+  writePendingInferenceCharge: mock(async () => false),
+}));
+
+mock.module("@/lib/services/inference-billing-ledger", () => ({
+  admitInferenceChargeViaLedger: mock(async () => ({ admitted: false })),
+  createLedgerDebitSettler: () => async () => null,
+  resolveInferenceBillingLedger: () => "kv",
+}));
+
+mock.module("@/lib/services/inference-billing-deferred", () => ({
+  createDeferredAdmissionSettler: () => async () => null,
+  isDeferredAdmissionEnabled: () => false,
+  isOrgAdmissionRefused: () => false,
+}));
+
+mock.module("@/lib/services/inference-passthrough", () => ({
+  isPassthroughStreamingEnabled: () => false,
+  readPassthroughStreamTail: mock(async () => ({ usage: null })),
+}));
+
+mock.module("@/lib/services/team-credential-pool", () => ({
+  getTeamPoolRegistry: () => ({
+    selectCredential: mock(async () => null),
+    recordUse: mock(async () => {}),
+    recordProviderFailure: mock(async () => {}),
+  }),
+}));
+
+mock.module("@/lib/utils/credit-reservation", () => ({
+  createCreditReservationSettler: () => async (actualCost: number) => ({
+    reconciled: true,
+    actualCost,
+  }),
+}));
+
+mock.module("@/lib/utils/request-timeout", () => ({
+  getRouteTimeoutMs: (seconds: number) => seconds * 1000,
+}));
+
+mock.module("@/lib/utils/settle-off-response-path", () => ({
+  settleOffResponsePath: async (
+    _executionCtx: unknown,
+    work: () => Promise<void>,
+  ) => {
+    await work();
+  },
+}));
+
+const { handleChatCompletionsPOST } = await import(
+  "../v1/chat/completions/route"
+);
+
+beforeEach(() => {
+  generateTextCalls.length = 0;
+  streamTextCalls.length = 0;
+  catalogSupportedParameters = ["max_tokens", "reasoning"];
+  authResolution = {
+    kind: "authorized",
+    ctx: { userId: USER, orgId: ORG, apiKeyId: API_KEY_ID },
+  };
+  providerConfigured = true;
+  shouldBlockUser = false;
+  reserveCreditsImpl = async () => ({ id: "reservation-1" });
+  generateTextResult = {
+    text: "bounded answer",
+    finishReason: "stop",
+    toolCalls: [],
+    usage: { inputTokens: 12, outputTokens: 7, totalTokens: 19 },
+  };
+});
+
+function makeRequest(body: Record<string, unknown>): Request {
+  return new Request("https://api.test/api/v1/chat/completions", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      model: MODEL,
+      messages: [{ role: "user", content: "hello" }],
+      ...body,
+    }),
+  });
+}
+
+describe("chat/completions explicit max_tokens route behavior", () => {
+  test("returns the designed suspended-account error from the hot auth path", async () => {
+    authResolution = { kind: "suspended" };
+
+    const response = await handleChatCompletionsPOST(makeRequest({}), {
+      skipOrgRateLimit: true,
+    });
+
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as {
+      error: { type: string; code: string };
+    };
+    expect(body.error.type).toBe("account_suspended");
+    expect(body.error.code).toBe("moderation_violation");
+    expect(generateTextCalls).toHaveLength(0);
+  });
+
+  test("returns invalid_request_error when model or messages are missing", async () => {
+    const response = await handleChatCompletionsPOST(
+      new Request("https://api.test/api/v1/chat/completions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: MODEL, messages: [] }),
+      }),
+      { skipOrgRateLimit: true },
+    );
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as {
+      error: { type: string; code: string };
+    };
+    expect(body.error.type).toBe("invalid_request_error");
+    expect(body.error.code).toBe("missing_required_parameter");
+    expect(generateTextCalls).toHaveLength(0);
+  });
+
+  test("returns service_unavailable before forwarding when no provider is configured", async () => {
+    providerConfigured = false;
+
+    const response = await handleChatCompletionsPOST(makeRequest({}), {
+      skipOrgRateLimit: true,
+    });
+
+    expect(response.status).toBe(503);
+    const body = (await response.json()) as {
+      error: { type: string; code: string };
+    };
+    expect(body.error.type).toBe("service_unavailable");
+    expect(body.error.code).toBe("ai_not_configured");
+    expect(generateTextCalls).toHaveLength(0);
+  });
+
+  test("slow-path moderation blocks before credit reservation and provider forwarding", async () => {
+    authResolution = { kind: "miss" };
+    shouldBlockUser = true;
+
+    const response = await handleChatCompletionsPOST(makeRequest({}), {
+      skipOrgRateLimit: true,
+    });
+
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as {
+      error: { type: string; code: string };
+    };
+    expect(body.error.type).toBe("account_suspended");
+    expect(body.error.code).toBe("moderation_violation");
+    expect(generateTextCalls).toHaveLength(0);
+  });
+
+  test("insufficient organization credits are translated before provider forwarding", async () => {
+    reserveCreditsImpl = async () => {
+      throw new TestInsufficientCreditsError(0.025);
+    };
+
+    const response = await handleChatCompletionsPOST(makeRequest({}), {
+      skipOrgRateLimit: true,
+    });
+
+    expect(response.status).toBe(402);
+    const body = (await response.json()) as {
+      error: { type: string; code: string; message: string };
+    };
+    expect(body.error.type).toBe("insufficient_quota");
+    expect(body.error.code).toBe("insufficient_credits");
+    expect(body.error.message).toContain("$0.0250");
+    expect(generateTextCalls).toHaveLength(0);
+  });
+
+  test("non-streaming preserves a caller max_tokens ceiling even when catalog marks the model as reasoning-capable", async () => {
+    const response = await handleChatCompletionsPOST(
+      makeRequest({ max_tokens: 16 }),
+      { skipOrgRateLimit: true },
+    );
+
+    expect(response.status).toBe(200);
+    expect(generateTextCalls).toHaveLength(1);
+    expect(generateTextCalls[0].maxOutputTokens).toBe(16);
+
+    const body = (await response.json()) as {
+      choices: Array<{ message: { content: string }; finish_reason: string }>;
+      usage: { prompt_tokens: number; completion_tokens: number };
+    };
+    expect(body.choices[0].message.content).toBe("bounded answer");
+    expect(body.choices[0].finish_reason).toBe("stop");
+    expect(body.usage.completion_tokens).toBe(7);
+  });
+
+  test("non-streaming applies the reasoning floor only when max_tokens is omitted", async () => {
+    const response = await handleChatCompletionsPOST(makeRequest({}), {
+      skipOrgRateLimit: true,
+    });
+
+    expect(response.status).toBe(200);
+    expect(generateTextCalls).toHaveLength(1);
+    expect(generateTextCalls[0].maxOutputTokens).toBe(MIN_RESPONSE_TOKENS);
+  });
+
+  test("non-streaming maps provider tool calls back to OpenAI tool_calls", async () => {
+    generateTextResult = {
+      text: "",
+      finishReason: "tool-calls",
+      toolCalls: [
+        {
+          toolCallId: "call-1",
+          toolName: "lookup",
+          input: { q: "elizaOS" },
+        },
+      ],
+      usage: {
+        promptTokens: 10,
+        completionTokens: 4,
+        totalTokens: 14,
+        cacheReadInputTokens: 3,
+      },
+    };
+
+    const response = await handleChatCompletionsPOST(makeRequest({}), {
+      skipOrgRateLimit: true,
+    });
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      choices: Array<{
+        message: {
+          content: string | null;
+          tool_calls: Array<{
+            id: string;
+            type: string;
+            function: { name: string; arguments: string };
+          }>;
+        };
+        finish_reason: string;
+      }>;
+      usage: {
+        prompt_tokens: number;
+        completion_tokens: number;
+        prompt_tokens_details?: { cached_tokens?: number };
+      };
+    };
+    expect(body.choices[0].finish_reason).toBe("tool_calls");
+    expect(body.choices[0].message.content).toBeNull();
+    expect(body.choices[0].message.tool_calls[0].id).toBe("call-1");
+    expect(body.choices[0].message.tool_calls[0].function.name).toBe("lookup");
+    expect(body.choices[0].message.tool_calls[0].function.arguments).toBe(
+      '{"q":"elizaOS"}',
+    );
+    expect(body.usage.prompt_tokens_details?.cached_tokens).toBe(3);
+  });
+
+  test("non-streaming reports empty-but-billed reasoning output as length", async () => {
+    generateTextResult = {
+      text: "",
+      finishReason: "stop",
+      toolCalls: [],
+      usage: { inputTokens: 5, outputTokens: 12, totalTokens: 17 },
+    };
+
+    const response = await handleChatCompletionsPOST(
+      makeRequest({ max_tokens: 12 }),
+      { skipOrgRateLimit: true },
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      choices: Array<{
+        message: { content: string | null };
+        finish_reason: string;
+      }>;
+    };
+    expect(body.choices[0].message.content).toBeNull();
+    expect(body.choices[0].finish_reason).toBe("length");
+  });
+
+  test("streaming preserves explicit max_tokens and emits the OpenAI usage frame", async () => {
+    const response = await handleChatCompletionsPOST(
+      makeRequest({
+        stream: true,
+        max_tokens: 12,
+        stream_options: { include_usage: true },
+      }),
+      { skipOrgRateLimit: true },
+    );
+
+    expect(response.status).toBe(200);
+    const sse = await response.text();
+
+    expect(streamTextCalls).toHaveLength(1);
+    expect(streamTextCalls[0].maxOutputTokens).toBe(12);
+    expect(sse).toContain("streamed ");
+    expect(sse).toContain('"choices":[]');
+    expect(sse).toContain('"completion_tokens":8');
+    expect(sse).toContain("data: [DONE]");
+  });
+});

--- a/packages/cloud/api/__tests__/chat-completions-explicit-max-tokens-route.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-explicit-max-tokens-route.test.ts
@@ -224,14 +224,12 @@ mock.module("@/lib/pricing", () => ({
     Object.fromEntries(
       Object.entries(params).filter(([, value]) => value !== undefined),
     ),
-  modelUsesReasoningTokens: (
-    model: string,
-    supportedParameters?: readonly string[],
-  ) =>
-    model.includes("o3") ||
-    model.includes("reasoning") ||
-    supportedParameters?.some((param) => param.includes("reasoning")) === true,
-  normalizeModelName: (model: string) => model,
+  // modelUsesReasoningTokens and normalizeModelName come from ...pricingActual
+  // above: MODEL ("z-ai/glm-5.1") is only reasoning-flagged via
+  // catalogSupportedParameters (mocked below), which the real implementation
+  // already honors, so the real function is a safe drop-in that avoids
+  // diverging from production behavior across test files sharing this
+  // process-global mock registry.
 }));
 
 mock.module("@/lib/providers/anthropic-thinking", () => ({
@@ -249,7 +247,10 @@ mock.module("@/lib/providers/anthropic-web-search", () => ({
 
 mock.module("@/lib/providers/language-model", () => ({
   ...languageModelActual,
-  canonicalizeCerebrasModelId: (model: string) => model,
+  // canonicalizeCerebrasModelId comes from ...languageModelActual above: MODEL
+  // is not a Cerebras-native id, so the real implementation is a no-op here
+  // and stays correct if a sibling test file in this batch process needs the
+  // real Cerebras-canonicalization behavior.
   getAiProviderConfigurationError: () => "AI services are not configured",
   getLanguageModel: (model: string) => ({ model }),
   hasLanguageModelProviderConfigured: () => providerConfigured,

--- a/packages/cloud/api/__tests__/chat-completions-tool-choice.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-tool-choice.test.ts
@@ -167,15 +167,37 @@ describe("computeEffectiveMaxTokens", () => {
     expect(computeEffectiveMaxTokens(512, null, "gemma-4-31b")).toBe(512);
   });
 
-  test("active Cerebras reasoning retains the response-token floor", () => {
+  test("active Cerebras reasoning preserves an explicit caller ceiling", () => {
     expect(
       computeEffectiveMaxTokens(512, null, "gemma-4-31b", undefined, "low"),
+    ).toBe(512);
+    expect(computeEffectiveMaxTokens(512, null, "zai-glm-4.7")).toBe(512);
+    expect(
+      computeEffectiveMaxTokens(512, null, "gpt-oss-120b", undefined, "low"),
+    ).toBe(512);
+  });
+
+  test("active Cerebras reasoning floors omitted max_tokens to the response-token floor", () => {
+    expect(
+      computeEffectiveMaxTokens(
+        undefined,
+        null,
+        "gemma-4-31b",
+        undefined,
+        "low",
+      ),
     ).toBe(MIN_RESPONSE_TOKENS);
-    expect(computeEffectiveMaxTokens(512, null, "zai-glm-4.7")).toBe(
+    expect(computeEffectiveMaxTokens(undefined, null, "zai-glm-4.7")).toBe(
       MIN_RESPONSE_TOKENS,
     );
     expect(
-      computeEffectiveMaxTokens(512, null, "gpt-oss-120b", undefined, "low"),
+      computeEffectiveMaxTokens(
+        undefined,
+        null,
+        "gpt-oss-120b",
+        undefined,
+        "low",
+      ),
     ).toBe(MIN_RESPONSE_TOKENS);
   });
 

--- a/packages/cloud/api/__tests__/chat-completions-tool-choice.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-tool-choice.test.ts
@@ -15,7 +15,11 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { __nativeToolingTestHooks } from "../v1/chat/completions/route";
+import {
+  __nativeToolingTestHooks,
+  __passthroughStreamingTestHooks,
+  __streamingCreditTestHooks,
+} from "../v1/chat/completions/route";
 
 const {
   mapToolChoice,
@@ -26,6 +30,9 @@ const {
   isEmptyButBilled,
   toOpenAiFinishReason,
 } = __nativeToolingTestHooks;
+const { getRecoverableProviderErrorStatus } = __streamingCreditTestHooks;
+const { qualifiesForPassthroughStreaming, mapPassthroughUpstreamStatus } =
+  __passthroughStreamingTestHooks;
 
 // Mirror of MIN_RESPONSE_TOKENS in route.ts. Kept as a literal here so the test
 // fails loudly if the production floor changes without intent.
@@ -323,5 +330,164 @@ describe("toOpenAiFinishReason", () => {
   test("passes through already-normalized values idempotently", () => {
     expect(toOpenAiFinishReason("tool_calls")).toBe("tool_calls");
     expect(toOpenAiFinishReason("content_filter")).toBe("content_filter");
+  });
+});
+
+describe("getRecoverableProviderErrorStatus", () => {
+  function gatewayError(name: string, statusCode?: number) {
+    return Object.assign(new Error(`${name} from gateway`), {
+      name,
+      ...(statusCode === undefined ? {} : { statusCode }),
+    });
+  }
+
+  test("preserves gateway caller-fault statuses from stable error names", () => {
+    expect(
+      getRecoverableProviderErrorStatus(
+        gatewayError("GatewayInvalidRequestError"),
+      ),
+    ).toBe(400);
+    expect(
+      getRecoverableProviderErrorStatus(
+        gatewayError("GatewayModelNotFoundError"),
+      ),
+    ).toBe(404);
+    expect(
+      getRecoverableProviderErrorStatus(gatewayError("GatewayRateLimitError")),
+    ).toBe(429);
+  });
+
+  test("preserves explicit gateway caller-fault status fields", () => {
+    expect(
+      getRecoverableProviderErrorStatus(gatewayError("GatewayError", 400)),
+    ).toBe(400);
+    expect(
+      getRecoverableProviderErrorStatus(gatewayError("GatewayError", 404)),
+    ).toBe(404);
+    expect(
+      getRecoverableProviderErrorStatus(gatewayError("GatewayError", 429)),
+    ).toBe(429);
+  });
+
+  test("maps quota language to rate limit and leaves infrastructure errors to the boundary", () => {
+    expect(
+      getRecoverableProviderErrorStatus(new Error("provider quota exceeded")),
+    ).toBe(429);
+    expect(
+      getRecoverableProviderErrorStatus(
+        gatewayError("GatewayResponseError", 500),
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("passthrough streaming qualification", () => {
+  function passthroughRequest(overrides: Record<string, unknown> = {}) {
+    return {
+      model: "openai/gpt-4o-mini",
+      stream: true,
+      stream_options: { include_usage: true },
+      messages: [{ role: "user" as const, content: "hello" }],
+      ...overrides,
+    };
+  }
+
+  test("accepts the plain streamed chat shape that can be piped byte-for-byte", () => {
+    expect(qualifiesForPassthroughStreaming(passthroughRequest())).toBe(true);
+    expect(
+      qualifiesForPassthroughStreaming({
+        ...passthroughRequest(),
+        response_format: { type: "text" },
+      }),
+    ).toBe(true);
+  });
+
+  test("rejects shapes that require route-side SSE synthesis or provider options", () => {
+    expect(
+      qualifiesForPassthroughStreaming({
+        ...passthroughRequest(),
+        stream: false,
+      }),
+    ).toBe(false);
+    expect(
+      qualifiesForPassthroughStreaming({
+        ...passthroughRequest(),
+        stream_options: { include_usage: false },
+      }),
+    ).toBe(false);
+    expect(
+      qualifiesForPassthroughStreaming({
+        ...passthroughRequest(),
+        tools: [{ type: "function", function: { name: "search" } }],
+      }),
+    ).toBe(false);
+    expect(
+      qualifiesForPassthroughStreaming({
+        ...passthroughRequest(),
+        tool_choice: "required",
+      }),
+    ).toBe(false);
+    expect(
+      qualifiesForPassthroughStreaming({
+        ...passthroughRequest(),
+        response_format: { type: "json_object" },
+      }),
+    ).toBe(false);
+    expect(
+      qualifiesForPassthroughStreaming({
+        ...passthroughRequest(),
+        webSearchEnabled: true,
+      }),
+    ).toBe(false);
+  });
+
+  test("rejects message shapes whose semantics must be converted by the route", () => {
+    expect(
+      qualifiesForPassthroughStreaming({
+        ...passthroughRequest(),
+        messages: [{ role: "tool", content: "result", tool_call_id: "call-1" }],
+      }),
+    ).toBe(false);
+    expect(
+      qualifiesForPassthroughStreaming({
+        ...passthroughRequest(),
+        messages: [
+          {
+            role: "assistant",
+            content: "",
+            tool_calls: [
+              {
+                id: "call-1",
+                type: "function",
+                function: { name: "lookup", arguments: "{}" },
+              },
+            ],
+          },
+        ],
+      }),
+    ).toBe(false);
+    expect(
+      qualifiesForPassthroughStreaming({
+        ...passthroughRequest(),
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "multimodal part" }],
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("mapPassthroughUpstreamStatus", () => {
+  test("passes caller-fault statuses through and hides provider auth/infra state", () => {
+    expect(mapPassthroughUpstreamStatus(400)).toBe(400);
+    expect(mapPassthroughUpstreamStatus(402)).toBe(402);
+    expect(mapPassthroughUpstreamStatus(404)).toBe(404);
+    expect(mapPassthroughUpstreamStatus(429)).toBe(429);
+    expect(mapPassthroughUpstreamStatus(401)).toBe(503);
+    expect(mapPassthroughUpstreamStatus(403)).toBe(503);
+    expect(mapPassthroughUpstreamStatus(500)).toBe(503);
   });
 });

--- a/packages/cloud/api/__tests__/chat-completions-tool-choice.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-tool-choice.test.ts
@@ -292,6 +292,15 @@ describe("isEmptyButBilled", () => {
     expect(isEmptyButBilled("", true, { outputTokens: 32 })).toBe(false);
     expect(isEmptyButBilled("", false, { outputTokens: 0 })).toBe(false);
   });
+
+  test("preserves a provider-declared content-filter result", () => {
+    expect(
+      isEmptyButBilled("", false, { outputTokens: 32 }, "content-filter"),
+    ).toBe(false);
+    expect(
+      isEmptyButBilled("", false, { completionTokens: 32 }, "content_filter"),
+    ).toBe(false);
+  });
 });
 
 describe("toOpenAiFinishReason", () => {

--- a/packages/cloud/api/__tests__/chat-completions-tool-choice.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-tool-choice.test.ts
@@ -23,6 +23,7 @@ const {
   computeEffectiveMaxTokens,
   validateCerebrasReasoningEffort,
   buildReasoningEffortProviderOptions,
+  isEmptyButBilled,
   toOpenAiFinishReason,
 } = __nativeToolingTestHooks;
 
@@ -104,11 +105,8 @@ describe("convertTools", () => {
 });
 
 /**
- * computeEffectiveMaxTokens guarantees a response-token budget so reasoning
- * models do not truncate mid-chain-of-thought and return empty (but billed)
- * completions. Before the fix, only Anthropic CoT (cotBudget != null) got a
- * floor; every other reasoning model fell through and returned the raw
- * (often tiny) request max_tokens.
+ * computeEffectiveMaxTokens preserves an explicit caller output/spend ceiling.
+ * Reasoning models receive a safer default only when max_tokens is omitted.
  */
 describe("computeEffectiveMaxTokens", () => {
   test("non-reasoning model: passes request max_tokens through unchanged", () => {
@@ -124,14 +122,10 @@ describe("computeEffectiveMaxTokens", () => {
     ).toBeUndefined();
   });
 
-  test("reasoning model with tiny max_tokens: floors to MIN_RESPONSE_TOKENS", () => {
-    // This is the bug: minimax/m3 at max_tokens=10 spent all 10 on reasoning
-    // and returned null content while billing the tokens.
-    expect(computeEffectiveMaxTokens(10, null, "minimax/minimax-m3")).toBe(
-      MIN_RESPONSE_TOKENS,
-    );
+  test("reasoning model: preserves an explicit tiny max_tokens ceiling", () => {
+    expect(computeEffectiveMaxTokens(10, null, "minimax/minimax-m3")).toBe(10);
     expect(computeEffectiveMaxTokens(16, null, "deepseek/deepseek-r1")).toBe(
-      MIN_RESPONSE_TOKENS,
+      16,
     );
   });
 
@@ -178,11 +172,15 @@ describe("computeEffectiveMaxTokens", () => {
     ).toBe(MIN_RESPONSE_TOKENS);
   });
 
-  test("Anthropic CoT budget: reserves response capacity beyond the thinking budget", () => {
-    // cotBudget=8000 -> must be at least 8000 + MIN_RESPONSE_TOKENS regardless of
-    // a smaller requested max_tokens.
+  test("Anthropic CoT budget: preserves an explicit caller ceiling", () => {
     expect(
       computeEffectiveMaxTokens(1000, 8000, "anthropic/claude-opus-4.8"),
+    ).toBe(1000);
+  });
+
+  test("Anthropic CoT budget: reserves response capacity when max_tokens is omitted", () => {
+    expect(
+      computeEffectiveMaxTokens(undefined, 8000, "anthropic/claude-opus-4.8"),
     ).toBe(8000 + MIN_RESPONSE_TOKENS);
   });
 
@@ -192,20 +190,28 @@ describe("computeEffectiveMaxTokens", () => {
     ).toBe(20000);
   });
 
-  test("catalog reasoning signal: floors even when the id has no reasoning pattern", () => {
+  test("catalog reasoning signal: preserves explicit max_tokens", () => {
     // glm-5.1 / kimi-k2.6 / deepseek-v4-pro have no "think"/"reasoning" id but
-    // advertise reasoning in supported_parameters. These were the
-    // production-reported failures.
+    // advertise reasoning in supported_parameters.
     expect(
       computeEffectiveMaxTokens(50, null, "z-ai/glm-5.1", [
         "max_tokens",
         "reasoning",
       ]),
-    ).toBe(MIN_RESPONSE_TOKENS);
+    ).toBe(50);
     expect(
       computeEffectiveMaxTokens(50, null, "deepseek/deepseek-v4-pro", [
         "max_tokens",
         "include_reasoning",
+      ]),
+    ).toBe(50);
+  });
+
+  test("catalog reasoning signal: defaults omitted max_tokens to the safe floor", () => {
+    expect(
+      computeEffectiveMaxTokens(undefined, null, "z-ai/glm-5.1", [
+        "max_tokens",
+        "reasoning",
       ]),
     ).toBe(MIN_RESPONSE_TOKENS);
   });
@@ -272,6 +278,19 @@ describe("Cerebras reasoning_effort validation", () => {
       providerOptions: { openai: { reasoningEffort: "none" } },
     });
     expect(buildReasoningEffortProviderOptions(undefined)).toEqual({});
+  });
+});
+
+describe("isEmptyButBilled", () => {
+  test("detects a streamed reasoning completion with billed output but no visible result", () => {
+    expect(isEmptyButBilled("", false, { outputTokens: 32 })).toBe(true);
+    expect(isEmptyButBilled("", false, { completionTokens: 32 })).toBe(true);
+  });
+
+  test("does not override visible text, tool calls, or genuinely empty usage", () => {
+    expect(isEmptyButBilled("answer", false, { outputTokens: 32 })).toBe(false);
+    expect(isEmptyButBilled("", true, { outputTokens: 32 })).toBe(false);
+    expect(isEmptyButBilled("", false, { outputTokens: 0 })).toBe(false);
   });
 });
 

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -268,7 +268,8 @@ function buildReasoningEffortProviderOptions(
 }
 
 /**
- * Computes effective max_tokens, reserving response capacity for reasoning models.
+ * Computes the provider-facing max_tokens without overriding an explicit caller
+ * ceiling. Reasoning models get a safer default only when max_tokens is omitted.
  *
  * Reasoning models (Anthropic extended-thinking, OpenAI o-series, DeepSeek R,
  * MiniMax M, and similar families) spend output tokens on hidden chain-of-thought
@@ -282,6 +283,10 @@ function buildReasoningEffortProviderOptions(
  *   - When reasoning is disabled (including Gemma's default), preserve the
  *     caller's cap exactly.
  *
+ * A low explicit ceiling can still be exhausted by hidden reasoning. The response
+ * paths report an empty-but-billed completion as `finish_reason: "length"` rather
+ * than silently authorizing more generation and spend than the caller requested.
+ *
  * `model` is the requested model id (provider-prefixed is fine).
  */
 function computeEffectiveMaxTokens(
@@ -291,13 +296,16 @@ function computeEffectiveMaxTokens(
   supportedParameters?: readonly string[],
   reasoningEffort?: ReasoningEffort,
 ): number | undefined {
+  // max_tokens is a caller-controlled output and spend ceiling. Never raise an
+  // explicit value, including when Anthropic extended thinking is configured.
+  // Providers may reject an incompatible thinking budget with a truthful 400.
+  if (requestMaxTokens !== undefined) {
+    return requestMaxTokens;
+  }
+
   if (cotBudget !== null) {
-    // When CoT is active, ensure max_tokens covers both thinking budget AND response capacity
-    // Without this, thinking consumes all tokens leaving nothing for the actual response
-    return Math.max(
-      requestMaxTokens ?? MIN_RESPONSE_TOKENS,
-      cotBudget + MIN_RESPONSE_TOKENS,
-    );
+    // With no caller ceiling, leave room for both configured thinking and output.
+    return cotBudget + MIN_RESPONSE_TOKENS;
   }
   const cerebrasModel = canonicalizeCerebrasModelId(model);
   if (
@@ -310,16 +318,10 @@ function computeEffectiveMaxTokens(
     return requestMaxTokens;
   }
   if (modelUsesReasoningTokens(model, supportedParameters)) {
-    // Non-Anthropic reasoning model. Guarantee at least MIN_RESPONSE_TOKENS so the
-    // model does not truncate mid-reasoning and return empty (but billed) output.
-    // If the caller asked for more, honor it; if they asked for less (or nothing),
-    // raise it to the floor.
-    return Math.max(
-      requestMaxTokens ?? MIN_RESPONSE_TOKENS,
-      MIN_RESPONSE_TOKENS,
-    );
+    // With no caller ceiling, avoid the common empty-but-billed reasoning result.
+    return MIN_RESPONSE_TOKENS;
   }
-  return requestMaxTokens;
+  return undefined;
 }
 
 // ============================================================================
@@ -787,6 +789,18 @@ function normalizeUsageTokens(usage: unknown): {
     outputTokens,
     totalTokens: firstNumber(record.totalTokens) ?? inputTokens + outputTokens,
   };
+}
+
+function isEmptyButBilled(
+  visibleText: string,
+  hasToolCalls: boolean,
+  usage: unknown,
+): boolean {
+  return (
+    !visibleText &&
+    !hasToolCalls &&
+    normalizeUsageTokens(usage).outputTokens > 0
+  );
 }
 
 function hasReportedUsageTokens(usage: unknown): boolean {
@@ -2791,6 +2805,15 @@ async function handleStreamingRequest(
           }
         }
 
+        // A low explicit max_tokens can be consumed entirely by hidden
+        // reasoning. Match the non-streaming contract: an empty-but-billed
+        // completion is a length truncation, never a successful stop.
+        if (
+          isEmptyButBilled(deliveredText, nextToolCallIndex > 0, finishUsage)
+        ) {
+          finishReason = "length";
+        }
+
         // Send final chunk with finish_reason
         const finalChunk = {
           id: responseId,
@@ -3096,8 +3119,11 @@ async function handleNonStreamingRequest(
     // max_tokens) instead of a misleading "stop" with null content.
     const hasToolCalls = Boolean(result.toolCalls?.length);
     const visibleText = result.text || "";
-    const emptyButBilled =
-      !visibleText && !hasToolCalls && (result.usage?.outputTokens ?? 0) > 0;
+    const emptyButBilled = isEmptyButBilled(
+      visibleText,
+      hasToolCalls,
+      result.usage,
+    );
     const finishReason: "tool_calls" | "length" | "content_filter" | "stop" =
       hasToolCalls || result.finishReason === "tool-calls"
         ? "tool_calls"
@@ -3215,6 +3241,7 @@ export const __nativeToolingTestHooks = {
   computeEffectiveMaxTokens,
   validateCerebrasReasoningEffort,
   buildReasoningEffortProviderOptions,
+  isEmptyButBilled,
   toOpenAiFinishReason,
 } as const;
 

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -795,10 +795,13 @@ function isEmptyButBilled(
   visibleText: string,
   hasToolCalls: boolean,
   usage: unknown,
+  providerFinishReason?: string,
 ): boolean {
   return (
     !visibleText &&
     !hasToolCalls &&
+    providerFinishReason !== "content-filter" &&
+    providerFinishReason !== "content_filter" &&
     normalizeUsageTokens(usage).outputTokens > 0
   );
 }
@@ -2809,7 +2812,12 @@ async function handleStreamingRequest(
         // reasoning. Match the non-streaming contract: an empty-but-billed
         // completion is a length truncation, never a successful stop.
         if (
-          isEmptyButBilled(deliveredText, nextToolCallIndex > 0, finishUsage)
+          isEmptyButBilled(
+            deliveredText,
+            nextToolCallIndex > 0,
+            finishUsage,
+            finishReason,
+          )
         ) {
           finishReason = "length";
         }
@@ -3123,6 +3131,7 @@ async function handleNonStreamingRequest(
       visibleText,
       hasToolCalls,
       result.usage,
+      result.finishReason,
     );
     const finishReason: "tool_calls" | "length" | "content_filter" | "stop" =
       hasToolCalls || result.finishReason === "tool-calls"


### PR DESCRIPTION
## Summary

- preserve every explicit `max_tokens` value as the provider-facing output/spend ceiling, including reasoning and Anthropic extended-thinking models
- retain the 4096 reasoning safety default only when callers omit `max_tokens`
- classify empty-but-billed results as `finish_reason: "length"` consistently in streaming and non-streaming responses
- add regression coverage for named, catalog-detected, and Anthropic reasoning paths
- rebase onto `origin/develop` (Cerebras `reasoning_effort` support, #16087) and fix a `mock.module` leak in `chat-completions-explicit-max-tokens-route.test.ts` that crashed the `test:cloud` batch containing it and `chat-completions-tool-choice.test.ts`

## Reproduction

Before this change, `computeEffectiveMaxTokens(10, null, "minimax/minimax-m3")` returned `4096`, and an Anthropic request with `max_tokens: 1000` plus an 8000-token thinking budget returned `12096`. The gateway therefore authorized more provider output and spend than the caller requested.

Separately, `bun run test:cloud`'s batching runs `chat-completions-explicit-max-tokens-route.test.ts` and `chat-completions-tool-choice.test.ts` in the same bun process. The former's top-level `mock.module()` calls narrowly overrode `modelUsesReasoningTokens` and `canonicalizeCerebrasModelId` instead of relying on the spread real exports, and bun's `mock.module` restore does not propagate to `route.ts`'s already-bound imports when both files load in one process — so the narrow mocks leaked into the sibling file's Cerebras reasoning assertions and crashed the batch.

## Verification

- `bun test packages/cloud/api/__tests__/chat-completions-explicit-max-tokens-route.test.ts packages/cloud/api/__tests__/chat-completions-tool-choice.test.ts` (both orders) — **0 fail, 64 tests**
- `bun run --cwd packages/cloud/api typecheck` — clean (`tsgo --noEmit` + worker-bundle dry-run)
- `bun run test:cloud` (full local batch run, 10 batches) — batch 10/10 fails on `Cannot find module '@elizaos/plugin-sql'` in `packages/cloud/services/agent-server` webhook/infra/script tests unrelated to this change (pre-existing worktree module-resolution gap, not touched by this PR); the batch containing the two files this PR modifies passed cleanly.

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - backend-only request-budget/test-infra change, no rendered UI surface`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - backend-only request-budget/test-infra change, no rendered UI surface`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - backend-only request-budget/test-infra change, no rendered UI surface`.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: `bun test` output for the modified route + test files shows the real `computeEffectiveMaxTokens` / `validateCerebrasReasoningEffort` codepaths exercised end to end (0 fail, 64 tests) against [`packages/cloud/api/__tests__/chat-completions-explicit-max-tokens-route.test.ts`](https://github.com/elizaOS/eliza/blob/fix/16081-explicit-max-tokens/packages/cloud/api/__tests__/chat-completions-explicit-max-tokens-route.test.ts) and [`packages/cloud/api/__tests__/chat-completions-tool-choice.test.ts`](https://github.com/elizaOS/eliza/blob/fix/16081-explicit-max-tokens/packages/cloud/api/__tests__/chat-completions-tool-choice.test.ts).

<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs `N/A - no frontend change`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - pure request-budget computation and unit test infrastructure, no model/prompt/action behavior change`.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the changed request-budget contract and its regression coverage are the domain artifact — see `computeEffectiveMaxTokens` in [`packages/cloud/api/v1/chat/completions/route.ts`](https://github.com/elizaOS/eliza/blob/fix/16081-explicit-max-tokens/packages/cloud/api/v1/chat/completions/route.ts) and the assertions in [`chat-completions-explicit-max-tokens-route.test.ts`](https://github.com/elizaOS/eliza/blob/fix/16081-explicit-max-tokens/packages/cloud/api/__tests__/chat-completions-explicit-max-tokens-route.test.ts).

Closes #16081

[sol-orch]
