### PR TITLE
feat(orchestrator): per-spawn git identity for coding sub-agents

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/shared-runtime-env.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/shared-runtime-env.ts
@@ -1,0 +1,6 @@
+/** Exposes the shared runtime helpers used by orchestrator tests without loading the generated-data barrel. */
+export {
+  isAndroidMobile,
+  resolvePlatform,
+} from "../../../packages/shared/src/runtime-env.js";
+export { readAliasedEnv } from "../../../packages/shared/src/utils/env.js";

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -154,6 +154,31 @@ type MockProc = EventEmitter & {
 
 const spawnMock = spawn as unknown as ReturnType<typeof vi.fn>;
 
+const GIT_IDENTITY_ENV_KEYS = [
+  "GIT_AUTHOR_NAME",
+  "GIT_AUTHOR_EMAIL",
+  "GIT_COMMITTER_NAME",
+  "GIT_COMMITTER_EMAIL",
+  "ELIZA_CODING_GIT_AUTHOR_NAME",
+  "ELIZA_CODING_GIT_AUTHOR_EMAIL",
+  "ELIZA_CODING_GIT_COMMITTER_NAME",
+  "ELIZA_CODING_GIT_COMMITTER_EMAIL",
+  "ELIZA_CONFIG_PATH",
+] as const;
+
+function snapshotEnv(
+  keys: readonly string[],
+): Record<string, string | undefined> {
+  return Object.fromEntries(keys.map((key) => [key, process.env[key]]));
+}
+
+function restoreEnv(snapshot: Record<string, string | undefined>) {
+  for (const [key, value] of Object.entries(snapshot)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
 function runtime(
   settings: Record<string, string | undefined> = {},
   services: Record<string, unknown> = {},
@@ -373,6 +398,49 @@ describe("AcpService", () => {
     expect(env?.PARALLAX_SESSION_ID).toBe(result.sessionId);
   });
 
+  it("pins configured coding git identity over inherited GIT env on CLI spawns", async () => {
+    const previousEnv = snapshotEnv(GIT_IDENTITY_ENV_KEYS);
+    process.env.GIT_AUTHOR_NAME = "Hostile Author";
+    process.env.GIT_AUTHOR_EMAIL = "hostile-author@example.invalid";
+    process.env.GIT_COMMITTER_NAME = "Hostile Committer";
+    process.env.GIT_COMMITTER_EMAIL = "hostile-committer@example.invalid";
+    process.env.ELIZA_CODING_GIT_AUTHOR_NAME = "Configured Author";
+    process.env.ELIZA_CODING_GIT_AUTHOR_EMAIL = "author@example.test";
+    process.env.ELIZA_CODING_GIT_COMMITTER_NAME = "Configured Committer";
+    process.env.ELIZA_CODING_GIT_COMMITTER_EMAIL = "committer@example.test";
+    process.env.ELIZA_CONFIG_PATH = join(
+      tmpdir(),
+      "acp-git-identity-config-does-not-exist.json",
+    );
+    try {
+      const reg = nextProc();
+      const service = new AcpService(runtime({ ELIZA_ACP_TRANSPORT: "cli" }));
+      await service.start();
+
+      const spawned = service.spawnSession({
+        name: "configured-git-identity-cli",
+        agentType: "codex",
+        workdir: "/tmp/acp-test",
+      });
+      await waitForSpawn(reg);
+      closeOk(reg);
+      await spawned;
+      await service.stop();
+
+      const env = spawnMock.mock.calls[0]?.[2]?.env as
+        | Record<string, string>
+        | undefined;
+      expect(env).toMatchObject({
+        GIT_AUTHOR_NAME: "Configured Author",
+        GIT_AUTHOR_EMAIL: "author@example.test",
+        GIT_COMMITTER_NAME: "Configured Committer",
+        GIT_COMMITTER_EMAIL: "committer@example.test",
+      });
+    } finally {
+      restoreEnv(previousEnv);
+    }
+  });
+
   it("writes SKILLS.md into every spawn workspace (shared spawn path)", async () => {
     const dir = mkdtempSync(join(tmpdir(), "acp-skills-"));
     try {
@@ -544,6 +612,48 @@ describe("AcpService", () => {
     expect(nativeClientMock.instances[0]?.opts.env?.PARALLAX_SESSION_ID).toBe(
       spawned.sessionId,
     );
+  });
+
+  it("pins the default coding git identity over inherited GIT env on native spawns", async () => {
+    const previousEnv = snapshotEnv(GIT_IDENTITY_ENV_KEYS);
+    process.env.GIT_AUTHOR_NAME = "Hostile Author";
+    process.env.GIT_AUTHOR_EMAIL = "hostile-author@example.invalid";
+    process.env.GIT_COMMITTER_NAME = "Hostile Committer";
+    process.env.GIT_COMMITTER_EMAIL = "hostile-committer@example.invalid";
+    delete process.env.ELIZA_CODING_GIT_AUTHOR_NAME;
+    delete process.env.ELIZA_CODING_GIT_AUTHOR_EMAIL;
+    delete process.env.ELIZA_CODING_GIT_COMMITTER_NAME;
+    delete process.env.ELIZA_CODING_GIT_COMMITTER_EMAIL;
+    process.env.ELIZA_CONFIG_PATH = join(
+      tmpdir(),
+      "acp-git-identity-config-does-not-exist.json",
+    );
+    try {
+      const service = new AcpService(
+        runtime({
+          ELIZA_ACP_TRANSPORT: "native",
+          ELIZA_CODEX_ACP_COMMAND: "codex-acp --stdio",
+        }),
+      );
+      await service.start();
+
+      await service.spawnSession({
+        name: "default-git-identity-native",
+        agentType: "codex",
+        workdir: "/tmp/acp-test",
+      });
+      await service.stop();
+
+      expect(nativeClientMock.instances).toHaveLength(1);
+      expect(nativeClientMock.instances[0]?.opts.env).toMatchObject({
+        GIT_AUTHOR_NAME: "elizaOS Coding Agent",
+        GIT_AUTHOR_EMAIL: "coding-agent.no-reply@elizaos.local",
+        GIT_COMMITTER_NAME: "elizaOS Coding Agent",
+        GIT_COMMITTER_EMAIL: "coding-agent.no-reply@elizaos.local",
+      });
+    } finally {
+      restoreEnv(previousEnv);
+    }
   });
 
   it("defaults untyped native sessions to the elizaos agent via eliza-code-acp", async () => {

--- a/plugins/plugin-agent-orchestrator/src/__tests__/git-identity-env.integration.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/git-identity-env.integration.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Exercises the default coding-agent identity through a real git commit on a
+ * repository with no local or global user identity.
+ */
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildGitIdentityEnvPatch,
+  DEFAULT_GIT_IDENTITY_EMAIL,
+  DEFAULT_GIT_IDENTITY_NAME,
+  resolveGitIdentityConfig,
+} from "../services/git-identity-env";
+
+describe("default coding git identity", () => {
+  const directories: string[] = [];
+
+  afterEach(() => {
+    for (const directory of directories.splice(0)) {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("creates a commit without inheriting or configuring an operator identity", () => {
+    const repository = mkdtempSync(join(tmpdir(), "coding-git-identity-"));
+    const home = mkdtempSync(join(tmpdir(), "coding-git-home-"));
+    directories.push(repository, home);
+    const env = {
+      ...process.env,
+      HOME: home,
+      GIT_CONFIG_NOSYSTEM: "1",
+      ...buildGitIdentityEnvPatch(resolveGitIdentityConfig(() => undefined)),
+    };
+
+    execFileSync("git", ["init", "--quiet"], { cwd: repository, env });
+    writeFileSync(join(repository, "proof.txt"), "identity proof\n", "utf8");
+    execFileSync("git", ["add", "proof.txt"], { cwd: repository, env });
+    execFileSync("git", ["commit", "--quiet", "-m", "identity proof"], {
+      cwd: repository,
+      env,
+    });
+
+    const identity = execFileSync(
+      "git",
+      ["show", "-s", "--format=%an|%ae|%cn|%ce", "HEAD"],
+      { cwd: repository, env, encoding: "utf8" },
+    ).trim();
+    expect(identity).toBe(
+      `${DEFAULT_GIT_IDENTITY_NAME}|${DEFAULT_GIT_IDENTITY_EMAIL}|${DEFAULT_GIT_IDENTITY_NAME}|${DEFAULT_GIT_IDENTITY_EMAIL}`,
+    );
+    const localIdentity = spawnSync(
+      "git",
+      ["config", "--local", "--get-regexp", "^user\\."],
+      { cwd: repository, env, encoding: "utf8" },
+    );
+    expect(localIdentity.status).toBe(1);
+    expect(localIdentity.stdout).toBe("");
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/git-identity-env.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/git-identity-env.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Unit tests for the per-spawn git identity materialization. Pure functions:
+ * a synthetic value source stands in for `readConfigEnvKey`, so no config file,
+ * env mutation, or spawn is needed. Covers the fail-safe (nothing configured =>
+ * empty patch => untouched spawn env), the half-configured guards, committer
+ * defaulting, and the Co-authored-by trailer rendering.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  buildGitIdentityEnvPatch,
+  GIT_IDENTITY_AUTHOR_EMAIL_KEY,
+  GIT_IDENTITY_AUTHOR_NAME_KEY,
+  GIT_IDENTITY_CO_AUTHOR_KEY,
+  GIT_IDENTITY_COMMITTER_EMAIL_KEY,
+  GIT_IDENTITY_COMMITTER_NAME_KEY,
+  parseCoAuthor,
+  renderCoAuthorTrailer,
+  resolveGitIdentityConfig,
+  syntheticNoReplyEmail,
+} from "../services/git-identity-env";
+
+/** Build a value source from a plain record (missing keys => undefined). */
+function source(map: Record<string, string>) {
+  return (key: string): string | undefined => map[key];
+}
+
+describe("resolveGitIdentityConfig", () => {
+  it("returns undefined when nothing is configured (fail-safe)", () => {
+    expect(resolveGitIdentityConfig(source({}))).toBeUndefined();
+  });
+
+  it("treats whitespace-only values as unconfigured", () => {
+    expect(
+      resolveGitIdentityConfig(
+        source({
+          [GIT_IDENTITY_AUTHOR_NAME_KEY]: "   ",
+          [GIT_IDENTITY_AUTHOR_EMAIL_KEY]: "\t",
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  it("trims and returns each configured field", () => {
+    const cfg = resolveGitIdentityConfig(
+      source({
+        [GIT_IDENTITY_AUTHOR_NAME_KEY]: "  Eliza Agent  ",
+        [GIT_IDENTITY_AUTHOR_EMAIL_KEY]: " agent@elizaos.ai ",
+        [GIT_IDENTITY_COMMITTER_NAME_KEY]: "CI Bot",
+        [GIT_IDENTITY_COMMITTER_EMAIL_KEY]: "ci@elizaos.ai",
+        [GIT_IDENTITY_CO_AUTHOR_KEY]: "Shadow <shadow@shad0w.xyz>",
+      }),
+    );
+    expect(cfg).toEqual({
+      authorName: "Eliza Agent",
+      authorEmail: "agent@elizaos.ai",
+      committerName: "CI Bot",
+      committerEmail: "ci@elizaos.ai",
+      coAuthor: "Shadow <shadow@shad0w.xyz>",
+    });
+  });
+
+  it("returns a config for a co-author-only setup", () => {
+    const cfg = resolveGitIdentityConfig(
+      source({ [GIT_IDENTITY_CO_AUTHOR_KEY]: "Pair <pair@x.dev>" }),
+    );
+    expect(cfg).toEqual({ coAuthor: "Pair <pair@x.dev>" });
+  });
+});
+
+describe("buildGitIdentityEnvPatch", () => {
+  it("returns an empty patch for undefined config (spawn env untouched)", () => {
+    expect(buildGitIdentityEnvPatch(undefined)).toEqual({});
+  });
+
+  it("returns an empty patch for a co-author-only config (trailer, not env)", () => {
+    expect(
+      buildGitIdentityEnvPatch({ coAuthor: "Pair <pair@x.dev>" }),
+    ).toEqual({});
+  });
+
+  it("materializes author + defaults committer to the author", () => {
+    const patch = buildGitIdentityEnvPatch({
+      authorName: "Eliza Agent",
+      authorEmail: "agent@elizaos.ai",
+    });
+    expect(patch).toEqual({
+      GIT_AUTHOR_NAME: "Eliza Agent",
+      GIT_AUTHOR_EMAIL: "agent@elizaos.ai",
+      GIT_COMMITTER_NAME: "Eliza Agent",
+      GIT_COMMITTER_EMAIL: "agent@elizaos.ai",
+    });
+  });
+
+  it("honors a distinct committer identity", () => {
+    const patch = buildGitIdentityEnvPatch({
+      authorName: "Eliza Agent",
+      authorEmail: "agent@elizaos.ai",
+      committerName: "CI Bot",
+      committerEmail: "ci@elizaos.ai",
+    });
+    expect(patch).toEqual({
+      GIT_AUTHOR_NAME: "Eliza Agent",
+      GIT_AUTHOR_EMAIL: "agent@elizaos.ai",
+      GIT_COMMITTER_NAME: "CI Bot",
+      GIT_COMMITTER_EMAIL: "ci@elizaos.ai",
+    });
+  });
+
+  it("synthesizes a no-reply email when only the author name is configured", () => {
+    const patch = buildGitIdentityEnvPatch({ authorName: "Eliza Agent" });
+    expect(patch.GIT_AUTHOR_NAME).toBe("Eliza Agent");
+    expect(patch.GIT_AUTHOR_EMAIL).toBe("eliza-agent.no-reply@elizaos.local");
+    // committer defaults to the (now fully-formed) author.
+    expect(patch.GIT_COMMITTER_NAME).toBe("Eliza Agent");
+    expect(patch.GIT_COMMITTER_EMAIL).toBe(
+      "eliza-agent.no-reply@elizaos.local",
+    );
+  });
+
+  it("drops an email-only config (no name => git can't use it)", () => {
+    expect(
+      buildGitIdentityEnvPatch({ authorEmail: "agent@elizaos.ai" }),
+    ).toEqual({});
+  });
+
+  it("seeds the author from a committer-only config (no leak / no fresh-box fail)", () => {
+    // Committer-only must NOT leave GIT_AUTHOR_* unset — git would then resolve
+    // the author from the child's global config or fail on a fresh host.
+    const patch = buildGitIdentityEnvPatch({
+      committerName: "CI Bot",
+      committerEmail: "ci@elizaos.ai",
+    });
+    expect(patch).toEqual({
+      GIT_AUTHOR_NAME: "CI Bot",
+      GIT_AUTHOR_EMAIL: "ci@elizaos.ai",
+      GIT_COMMITTER_NAME: "CI Bot",
+      GIT_COMMITTER_EMAIL: "ci@elizaos.ai",
+    });
+  });
+
+  it("seeds the author from a committer-name-only config with a synthetic email", () => {
+    const patch = buildGitIdentityEnvPatch({ committerName: "CI Bot" });
+    expect(patch).toEqual({
+      GIT_AUTHOR_NAME: "CI Bot",
+      GIT_AUTHOR_EMAIL: "ci-bot.no-reply@elizaos.local",
+      GIT_COMMITTER_NAME: "CI Bot",
+      GIT_COMMITTER_EMAIL: "ci-bot.no-reply@elizaos.local",
+    });
+  });
+
+  it("synthesizes a committer email when only a committer name is given", () => {
+    const patch = buildGitIdentityEnvPatch({
+      authorName: "Eliza Agent",
+      authorEmail: "agent@elizaos.ai",
+      committerName: "CI Bot",
+    });
+    expect(patch.GIT_COMMITTER_NAME).toBe("CI Bot");
+    expect(patch.GIT_COMMITTER_EMAIL).toBe("ci-bot.no-reply@elizaos.local");
+  });
+});
+
+describe("syntheticNoReplyEmail", () => {
+  it("slugifies the name into a stable local no-reply address", () => {
+    expect(syntheticNoReplyEmail("Eliza Agent")).toBe(
+      "eliza-agent.no-reply@elizaos.local",
+    );
+    expect(syntheticNoReplyEmail("  Weird!!Name## ")).toBe(
+      "weird-name.no-reply@elizaos.local",
+    );
+  });
+
+  it("falls back to `agent` when the name slugifies to empty", () => {
+    expect(syntheticNoReplyEmail("###")).toBe("agent.no-reply@elizaos.local");
+  });
+});
+
+describe("parseCoAuthor", () => {
+  it("splits `Name <email>`", () => {
+    expect(parseCoAuthor("Shadow <shadow@shad0w.xyz>")).toEqual({
+      name: "Shadow",
+      email: "shadow@shad0w.xyz",
+    });
+  });
+
+  it("returns a bare name when no email is present", () => {
+    expect(parseCoAuthor("Just A Name")).toEqual({ name: "Just A Name" });
+  });
+
+  it("returns undefined for empty / whitespace", () => {
+    expect(parseCoAuthor(undefined)).toBeUndefined();
+    expect(parseCoAuthor("   ")).toBeUndefined();
+  });
+
+  it("rejects an angle-only string with no name", () => {
+    expect(parseCoAuthor("<only@email.dev>")).toBeUndefined();
+  });
+});
+
+describe("renderCoAuthorTrailer", () => {
+  it("renders the trailer line from a Name <email> config", () => {
+    expect(
+      renderCoAuthorTrailer({ coAuthor: "Shadow <shadow@shad0w.xyz>" }),
+    ).toBe("Co-authored-by: Shadow <shadow@shad0w.xyz>");
+  });
+
+  it("synthesizes an email for a bare-name co-author", () => {
+    expect(renderCoAuthorTrailer({ coAuthor: "Shadow" })).toBe(
+      "Co-authored-by: Shadow <shadow.no-reply@elizaos.local>",
+    );
+  });
+
+  it("returns undefined when no co-author is configured", () => {
+    expect(renderCoAuthorTrailer(undefined)).toBeUndefined();
+    expect(renderCoAuthorTrailer({ authorName: "X" })).toBeUndefined();
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/git-identity-env.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/git-identity-env.test.ts
@@ -9,6 +9,8 @@
 import { describe, expect, it } from "vitest";
 import {
   buildGitIdentityEnvPatch,
+  DEFAULT_GIT_IDENTITY_EMAIL,
+  DEFAULT_GIT_IDENTITY_NAME,
   GIT_IDENTITY_AUTHOR_EMAIL_KEY,
   GIT_IDENTITY_AUTHOR_NAME_KEY,
   GIT_IDENTITY_CO_AUTHOR_KEY,
@@ -26,8 +28,13 @@ function source(map: Record<string, string>) {
 }
 
 describe("resolveGitIdentityConfig", () => {
-  it("returns undefined when nothing is configured (fail-safe)", () => {
-    expect(resolveGitIdentityConfig(source({}))).toBeUndefined();
+  it("returns a deterministic local-only identity when nothing is configured", () => {
+    expect(resolveGitIdentityConfig(source({}))).toEqual({
+      authorName: DEFAULT_GIT_IDENTITY_NAME,
+      authorEmail: DEFAULT_GIT_IDENTITY_EMAIL,
+      committerName: DEFAULT_GIT_IDENTITY_NAME,
+      committerEmail: DEFAULT_GIT_IDENTITY_EMAIL,
+    });
   });
 
   it("treats whitespace-only values as unconfigured", () => {
@@ -38,7 +45,12 @@ describe("resolveGitIdentityConfig", () => {
           [GIT_IDENTITY_AUTHOR_EMAIL_KEY]: "\t",
         }),
       ),
-    ).toBeUndefined();
+    ).toEqual({
+      authorName: DEFAULT_GIT_IDENTITY_NAME,
+      authorEmail: DEFAULT_GIT_IDENTITY_EMAIL,
+      committerName: DEFAULT_GIT_IDENTITY_NAME,
+      committerEmail: DEFAULT_GIT_IDENTITY_EMAIL,
+    });
   });
 
   it("trims and returns each configured field", () => {
@@ -66,17 +78,39 @@ describe("resolveGitIdentityConfig", () => {
     );
     expect(cfg).toEqual({ coAuthor: "Pair <pair@x.dev>" });
   });
+
+  it.each([
+    "bad\nname",
+    "bad\remail",
+    "bad\0trailer",
+  ])("rejects control characters in configured identity values", (value) => {
+    expect(() =>
+      resolveGitIdentityConfig(
+        source({ [GIT_IDENTITY_AUTHOR_NAME_KEY]: value }),
+      ),
+    ).toThrow("Coding git identity contains a control character");
+  });
 });
 
 describe("buildGitIdentityEnvPatch", () => {
-  it("returns an empty patch for undefined config (spawn env untouched)", () => {
-    expect(buildGitIdentityEnvPatch(undefined)).toEqual({});
+  it("materializes the deterministic default for undefined config", () => {
+    expect(buildGitIdentityEnvPatch(undefined)).toEqual({
+      GIT_AUTHOR_NAME: DEFAULT_GIT_IDENTITY_NAME,
+      GIT_AUTHOR_EMAIL: DEFAULT_GIT_IDENTITY_EMAIL,
+      GIT_COMMITTER_NAME: DEFAULT_GIT_IDENTITY_NAME,
+      GIT_COMMITTER_EMAIL: DEFAULT_GIT_IDENTITY_EMAIL,
+    });
   });
 
-  it("returns an empty patch for a co-author-only config (trailer, not env)", () => {
-    expect(
-      buildGitIdentityEnvPatch({ coAuthor: "Pair <pair@x.dev>" }),
-    ).toEqual({});
+  it("uses the default commit identity for a co-author-only config", () => {
+    expect(buildGitIdentityEnvPatch({ coAuthor: "Pair <pair@x.dev>" })).toEqual(
+      {
+        GIT_AUTHOR_NAME: DEFAULT_GIT_IDENTITY_NAME,
+        GIT_AUTHOR_EMAIL: DEFAULT_GIT_IDENTITY_EMAIL,
+        GIT_COMMITTER_NAME: DEFAULT_GIT_IDENTITY_NAME,
+        GIT_COMMITTER_EMAIL: DEFAULT_GIT_IDENTITY_EMAIL,
+      },
+    );
   });
 
   it("materializes author + defaults committer to the author", () => {
@@ -118,10 +152,15 @@ describe("buildGitIdentityEnvPatch", () => {
     );
   });
 
-  it("drops an email-only config (no name => git can't use it)", () => {
+  it("pairs an email-only override with the deterministic default name", () => {
     expect(
       buildGitIdentityEnvPatch({ authorEmail: "agent@elizaos.ai" }),
-    ).toEqual({});
+    ).toEqual({
+      GIT_AUTHOR_NAME: DEFAULT_GIT_IDENTITY_NAME,
+      GIT_AUTHOR_EMAIL: "agent@elizaos.ai",
+      GIT_COMMITTER_NAME: DEFAULT_GIT_IDENTITY_NAME,
+      GIT_COMMITTER_EMAIL: "agent@elizaos.ai",
+    });
   });
 
   it("seeds the author from a committer-only config (no leak / no fresh-box fail)", () => {

--- a/plugins/plugin-agent-orchestrator/src/__tests__/sub-agent-identity-git-trailer.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/sub-agent-identity-git-trailer.test.ts
@@ -8,7 +8,12 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../services/config-env.js", () => ({
+  readConfigEnvKey: (key: string): string | undefined => process.env[key],
+}));
+
 import {
   buildSubAgentIdentityMd,
   writeWorkspaceIdentity,
@@ -27,7 +32,9 @@ describe("buildSubAgentIdentityMd git-trailer section", () => {
       coAuthorTrailer: "Co-authored-by: Shadow <shadow@shad0w.xyz>",
     });
     expect(md).not.toContain("{{GIT_TRAILER_SECTION}}");
-    expect(md).toContain("## Commit message trailer (REQUIRED when you commit)");
+    expect(md).toContain(
+      "## Commit message trailer (REQUIRED when you commit)",
+    );
     expect(md).toContain("Co-authored-by: Shadow <shadow@shad0w.xyz>");
     // It must tell the agent NOT to set its own identity (that's env-pinned).
     expect(md).toContain("do not run `git config user.name/email`");

--- a/plugins/plugin-agent-orchestrator/src/__tests__/sub-agent-identity-git-trailer.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/sub-agent-identity-git-trailer.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests that the operating manual renders/strips the git commit-trailer section
+ * correctly, and that a fully-unconfigured render never leaves a dangling
+ * `{{GIT_TRAILER_SECTION}}` placeholder or advertises a trailer the spawn env
+ * did not pin.
+ */
+
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  buildSubAgentIdentityMd,
+  writeWorkspaceIdentity,
+} from "../services/sub-agent-identity";
+
+describe("buildSubAgentIdentityMd git-trailer section", () => {
+  it("strips the placeholder when no co-author trailer is provided", () => {
+    const md = buildSubAgentIdentityMd({});
+    expect(md).not.toContain("{{GIT_TRAILER_SECTION}}");
+    expect(md).not.toContain("Commit message trailer");
+    expect(md).not.toContain("Co-authored-by:");
+  });
+
+  it("embeds the trailer instruction + exact line when configured", () => {
+    const md = buildSubAgentIdentityMd({
+      coAuthorTrailer: "Co-authored-by: Shadow <shadow@shad0w.xyz>",
+    });
+    expect(md).not.toContain("{{GIT_TRAILER_SECTION}}");
+    expect(md).toContain("## Commit message trailer (REQUIRED when you commit)");
+    expect(md).toContain("Co-authored-by: Shadow <shadow@shad0w.xyz>");
+    // It must tell the agent NOT to set its own identity (that's env-pinned).
+    expect(md).toContain("do not run `git config user.name/email`");
+  });
+
+  it("still fills the broker placeholder independently of the trailer", () => {
+    const md = buildSubAgentIdentityMd({
+      brokerWired: true,
+      coAuthorTrailer: "Co-authored-by: Pair <pair@x.dev>",
+    });
+    expect(md).not.toContain("{{BROKER_SECTION}}");
+    expect(md).not.toContain("{{GIT_TRAILER_SECTION}}");
+    expect(md).toContain("Co-authored-by: Pair <pair@x.dev>");
+  });
+});
+
+describe("writeWorkspaceIdentity — never mutates a real repo's tracked manuals", () => {
+  let dir: string;
+  const prevCoAuthor = process.env.ELIZA_CODING_GIT_CO_AUTHOR;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "acp-identity-"));
+    delete process.env.ELIZA_CODING_GIT_CO_AUTHOR;
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    if (prevCoAuthor === undefined)
+      delete process.env.ELIZA_CODING_GIT_CO_AUTHOR;
+    else process.env.ELIZA_CODING_GIT_CO_AUTHOR = prevCoAuthor;
+  });
+
+  it("leaves an existing AGENTS.md byte-identical even with a co-author configured", async () => {
+    // A tracked repo manual must NEVER be dirtied by a spawn — appending an
+    // Eliza stanza would leak into the agent's own `git add -A` commit/PR.
+    const agentsPath = join(dir, "AGENTS.md");
+    const original = "# Real repo manual\n\nDo the project-specific thing.\n";
+    writeFileSync(agentsPath, original, "utf8");
+    await writeWorkspaceIdentity(dir, {
+      coAuthorTrailer: "Co-authored-by: Shadow <shadow@shad0w.xyz>",
+    });
+    expect(readFileSync(agentsPath, "utf8")).toBe(original);
+  });
+
+  it("scaffolds the trailer into a BARE workspace's manual", async () => {
+    await writeWorkspaceIdentity(dir, {
+      coAuthorTrailer: "Co-authored-by: Shadow <shadow@shad0w.xyz>",
+    });
+    const agents = readFileSync(join(dir, "AGENTS.md"), "utf8");
+    expect(agents).toContain("Commit message trailer");
+    expect(agents).toContain("Co-authored-by: Shadow <shadow@shad0w.xyz>");
+  });
+
+  it("scaffolds a bare workspace WITHOUT the trailer section when unconfigured", async () => {
+    await writeWorkspaceIdentity(dir, {});
+    const agents = readFileSync(join(dir, "AGENTS.md"), "utf8");
+    expect(agents).not.toContain("{{GIT_TRAILER_SECTION}}");
+    expect(agents).not.toContain("Commit message trailer");
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -59,13 +59,13 @@ import {
 } from "./coding-account-selection.js";
 import { readConfigEnvKey, readConfigMcpServers } from "./config-env.js";
 import {
-  buildGitIdentityEnvPatch,
-  resolveGitIdentityConfig,
-} from "./git-identity-env.js";
-import {
   applyCredentialProxyEnv,
   resolveOrchestratorCredentialProxyConfig,
 } from "./credential-proxy-env.js";
+import {
+  buildGitIdentityEnvPatch,
+  resolveGitIdentityConfig,
+} from "./git-identity-env.js";
 import {
   applyModelGatewayEnv,
   MODEL_GATEWAY_EXCLUDED_PROVIDER_KEYS,
@@ -3719,8 +3719,8 @@ export class AcpService extends Service {
     // user.name/email (a provenance leak, and on a fresh box git refuses to
     // commit at all without one). Materialized as GIT_AUTHOR_*/GIT_COMMITTER_*
     // env — disjoint from the credential-proxy's GIT_CONFIG_* keys below, so the
-    // two never collide. No-op (env untouched, current gitconfig inheritance
-    // preserved exactly) when nothing is configured.
+    // two never collide. A stable local-only default is always emitted when no
+    // operator override exists, so fresh hosts work without identity leakage.
     const gitIdentity = buildGitIdentityEnvPatch(
       resolveGitIdentityConfig(readConfigEnvKey),
     );

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -59,6 +59,10 @@ import {
 } from "./coding-account-selection.js";
 import { readConfigEnvKey, readConfigMcpServers } from "./config-env.js";
 import {
+  buildGitIdentityEnvPatch,
+  resolveGitIdentityConfig,
+} from "./git-identity-env.js";
+import {
   applyCredentialProxyEnv,
   resolveOrchestratorCredentialProxyConfig,
 } from "./credential-proxy-env.js";
@@ -3709,6 +3713,25 @@ export class AcpService extends Service {
           vendored: Boolean(opencode.vendoredShimDir),
         });
       }
+    }
+    // Per-spawn git identity: pin an explicit author/committer for every agent
+    // commit so the child never inherits the operator's personal `~/.gitconfig`
+    // user.name/email (a provenance leak, and on a fresh box git refuses to
+    // commit at all without one). Materialized as GIT_AUTHOR_*/GIT_COMMITTER_*
+    // env — disjoint from the credential-proxy's GIT_CONFIG_* keys below, so the
+    // two never collide. No-op (env untouched, current gitconfig inheritance
+    // preserved exactly) when nothing is configured.
+    const gitIdentity = buildGitIdentityEnvPatch(
+      resolveGitIdentityConfig(readConfigEnvKey),
+    );
+    if (Object.keys(gitIdentity).length > 0) {
+      Object.assign(env, gitIdentity);
+      this.log("debug", "pinned per-spawn git identity for sub-agent", {
+        agentType,
+        sessionId: childSessionId,
+        authorName: gitIdentity.GIT_AUTHOR_NAME,
+        committerName: gitIdentity.GIT_COMMITTER_NAME,
+      });
     }
     // Gateway mode runs LAST so no earlier merge step (host forwarding,
     // customCredentials, spawn extras, account selection) can reintroduce a

--- a/plugins/plugin-agent-orchestrator/src/services/git-identity-env.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/git-identity-env.ts
@@ -15,12 +15,17 @@
  * `GIT_CONFIG_*` block (that one sets `credential.helper`, this one sets
  * author/committer; disjoint keys, no collision) and needs no on-disk gitconfig.
  *
- * Fail-safe: when nothing is configured, {@link buildGitIdentityEnvPatch}
- * returns an empty patch and the spawn env is byte-identical to before — the
- * existing gitconfig-inheritance behavior is preserved exactly.
+ * When nothing is configured, a stable local-only coding-agent identity is
+ * emitted. This keeps fresh hosts commit-capable and prevents an operator's
+ * global gitconfig from becoming an accidental provenance source.
  *
  * @module services/git-identity-env
  */
+
+import { ElizaError } from "@elizaos/core";
+
+export const DEFAULT_GIT_IDENTITY_NAME = "elizaOS Coding Agent";
+export const DEFAULT_GIT_IDENTITY_EMAIL = "coding-agent.no-reply@elizaos.local";
 
 /**
  * Config keys (read from the eliza config `env` section OR process.env via
@@ -62,8 +67,14 @@ export interface GitIdentityConfig {
  * unit-testable (pass a synthetic lookup); production passes `readConfigEnvKey`. */
 export type GitIdentityConfigSource = (key: string) => string | undefined;
 
-function clean(value: string | undefined): string | undefined {
+function clean(value: string | undefined, key: string): string | undefined {
   if (typeof value !== "string") return undefined;
+  if (/[\0\r\n]/u.test(value)) {
+    throw new ElizaError("Coding git identity contains a control character", {
+      code: "INVALID_CODING_GIT_IDENTITY",
+      context: { key },
+    });
+  }
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : undefined;
 }
@@ -71,17 +82,32 @@ function clean(value: string | undefined): string | undefined {
 /**
  * Resolve the configured coding git identity from a value source. Pure: no
  * process.env / config read of its own — pass `readConfigEnvKey` (or a synthetic
- * lookup in tests). Returns `undefined` when NOTHING is configured, so callers
- * can preserve current behavior exactly (see {@link buildGitIdentityEnvPatch}).
+ * lookup in tests). Returns the deterministic local-only identity when no
+ * override is configured.
  */
 export function resolveGitIdentityConfig(
   read: GitIdentityConfigSource,
 ): GitIdentityConfig | undefined {
-  const authorName = clean(read(GIT_IDENTITY_AUTHOR_NAME_KEY));
-  const authorEmail = clean(read(GIT_IDENTITY_AUTHOR_EMAIL_KEY));
-  const committerName = clean(read(GIT_IDENTITY_COMMITTER_NAME_KEY));
-  const committerEmail = clean(read(GIT_IDENTITY_COMMITTER_EMAIL_KEY));
-  const coAuthor = clean(read(GIT_IDENTITY_CO_AUTHOR_KEY));
+  const authorName = clean(
+    read(GIT_IDENTITY_AUTHOR_NAME_KEY),
+    GIT_IDENTITY_AUTHOR_NAME_KEY,
+  );
+  const authorEmail = clean(
+    read(GIT_IDENTITY_AUTHOR_EMAIL_KEY),
+    GIT_IDENTITY_AUTHOR_EMAIL_KEY,
+  );
+  const committerName = clean(
+    read(GIT_IDENTITY_COMMITTER_NAME_KEY),
+    GIT_IDENTITY_COMMITTER_NAME_KEY,
+  );
+  const committerEmail = clean(
+    read(GIT_IDENTITY_COMMITTER_EMAIL_KEY),
+    GIT_IDENTITY_COMMITTER_EMAIL_KEY,
+  );
+  const coAuthor = clean(
+    read(GIT_IDENTITY_CO_AUTHOR_KEY),
+    GIT_IDENTITY_CO_AUTHOR_KEY,
+  );
   if (
     !authorName &&
     !authorEmail &&
@@ -89,8 +115,12 @@ export function resolveGitIdentityConfig(
     !committerEmail &&
     !coAuthor
   ) {
-    // Nothing configured — signal "no identity" so the spawn env is untouched.
-    return undefined;
+    return {
+      authorName: DEFAULT_GIT_IDENTITY_NAME,
+      authorEmail: DEFAULT_GIT_IDENTITY_EMAIL,
+      committerName: DEFAULT_GIT_IDENTITY_NAME,
+      committerEmail: DEFAULT_GIT_IDENTITY_EMAIL,
+    };
   }
   return {
     ...(authorName ? { authorName } : {}),
@@ -121,10 +151,8 @@ export function syntheticNoReplyEmail(name: string): string {
 
 /**
  * Materialize the resolved identity into a `GIT_AUTHOR_*` / `GIT_COMMITTER_*`
- * env patch. Returns an EMPTY object when `config` is undefined (nothing
- * configured) or carries no usable author/committer — so merging it into the
- * spawn env is a no-op and preserves the pre-existing gitconfig inheritance
- * exactly (the co-author-only case configures a trailer, not env identity).
+ * env patch. Undefined or co-author-only input uses the stable default rather
+ * than inheriting the spawning operator's gitconfig.
  *
  * Only sets a `*_EMAIL` alongside a `*_NAME`: git requires both to accept an
  * explicit identity, so a name with no email (and none derivable) is dropped
@@ -135,7 +163,10 @@ export function buildGitIdentityEnvPatch(
   config: GitIdentityConfig | undefined,
 ): Record<string, string> {
   const patch: Record<string, string> = {};
-  if (!config) return patch;
+  const effectiveConfig = config ?? {
+    authorName: DEFAULT_GIT_IDENTITY_NAME,
+    authorEmail: DEFAULT_GIT_IDENTITY_EMAIL,
+  };
 
   // Resolve author + committer symmetrically. Whichever ROLE an operator
   // configured, BOTH GIT_AUTHOR_* and GIT_COMMITTER_* must be emitted together:
@@ -145,26 +176,39 @@ export function buildGitIdentityEnvPatch(
   // exists to prevent. So a lone committer identity also seeds the author, and a
   // lone author identity also seeds the committer (the common author==committer
   // case).
-  const authorName = config.authorName ?? config.committerName;
+  const authorName =
+    effectiveConfig.authorName ??
+    effectiveConfig.committerName ??
+    DEFAULT_GIT_IDENTITY_NAME;
+  const hasExplicitIdentity = Boolean(
+    effectiveConfig.authorName ||
+      effectiveConfig.authorEmail ||
+      effectiveConfig.committerName ||
+      effectiveConfig.committerEmail,
+  );
   const authorEmail =
-    config.authorEmail ??
-    config.committerEmail ??
-    (authorName ? syntheticNoReplyEmail(authorName) : undefined);
+    effectiveConfig.authorEmail ??
+    effectiveConfig.committerEmail ??
+    (!hasExplicitIdentity
+      ? DEFAULT_GIT_IDENTITY_EMAIL
+      : authorName
+        ? syntheticNoReplyEmail(authorName)
+        : undefined);
   if (authorName && authorEmail) {
     patch.GIT_AUTHOR_NAME = authorName;
     patch.GIT_AUTHOR_EMAIL = authorEmail;
   }
 
-  const committerName = config.committerName ?? authorName;
+  const committerName = effectiveConfig.committerName ?? authorName;
   // A DISTINCT committer name (explicitly configured) with no email gets a
   // synthetic email of its OWN rather than borrowing the author's — a separate
   // committer identity should read as separate. Only when the committer is
   // implicitly the author (no committerName configured) does it inherit the
   // author's email verbatim.
   const committerEmail =
-    config.committerEmail ??
-    (config.committerName
-      ? syntheticNoReplyEmail(config.committerName)
+    effectiveConfig.committerEmail ??
+    (effectiveConfig.committerName
+      ? syntheticNoReplyEmail(effectiveConfig.committerName)
       : authorEmail);
   if (committerName && committerEmail) {
     patch.GIT_COMMITTER_NAME = committerName;
@@ -180,7 +224,7 @@ export function buildGitIdentityEnvPatch(
 export function parseCoAuthor(
   value: string | undefined,
 ): { name: string; email?: string } | undefined {
-  const raw = clean(value);
+  const raw = clean(value, GIT_IDENTITY_CO_AUTHOR_KEY);
   if (!raw) return undefined;
   const match = raw.match(/^(.*?)\s*<([^<>]+)>\s*$/);
   if (match) {

--- a/plugins/plugin-agent-orchestrator/src/services/git-identity-env.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/git-identity-env.ts
@@ -1,0 +1,210 @@
+/**
+ * Deterministic, configurable git identity for coding sub-agent spawns.
+ *
+ * A coding sub-agent (claude / codex / opencode / elizaos / pi-agent) commits
+ * inside its workspace. Without an explicit identity, git falls back to whatever
+ * `user.name` / `user.email` the child's global/system `~/.gitconfig` (or
+ * `EMAIL` / `GIT_AUTHOR_*` env) happens to carry — i.e. the operator's personal
+ * identity leaks onto every agent commit, and on a fresh box git can outright
+ * refuse to commit ("Please tell me who you are"). This module lets an operator
+ * pin an explicit author/committer + a `Co-authored-by:` trailer for every
+ * agent commit, deterministically, from the existing config surface.
+ *
+ * Materialization is pure `GIT_AUTHOR_*` / `GIT_COMMITTER_*` env — the same
+ * mechanism git itself documents — so it composes with the credential-proxy's
+ * `GIT_CONFIG_*` block (that one sets `credential.helper`, this one sets
+ * author/committer; disjoint keys, no collision) and needs no on-disk gitconfig.
+ *
+ * Fail-safe: when nothing is configured, {@link buildGitIdentityEnvPatch}
+ * returns an empty patch and the spawn env is byte-identical to before — the
+ * existing gitconfig-inheritance behavior is preserved exactly.
+ *
+ * @module services/git-identity-env
+ */
+
+/**
+ * Config keys (read from the eliza config `env` section OR process.env via
+ * {@link readConfigEnvKey}, so a UI / service.env / shell export all work and
+ * take effect without a restart).
+ *
+ * - `ELIZA_CODING_GIT_AUTHOR_NAME` / `_EMAIL`: the commit author. When only the
+ *   name is set, git still needs an email; we synthesize a stable no-reply email
+ *   from the name so a half-configured identity never falls back to the leaky
+ *   global one.
+ * - `ELIZA_CODING_GIT_COMMITTER_NAME` / `_EMAIL`: the committer. Defaults to the
+ *   author when unset (the common case: author == committer).
+ * - `ELIZA_CODING_GIT_CO_AUTHOR`: one `Name <email>` co-author whose
+ *   `Co-authored-by:` trailer the operating manual instructs the agent to append
+ *   (provenance for the human/agent pairing). Documented, not force-injected,
+ *   because the trailer must land in the commit *message* body, which only the
+ *   agent (or a commit-msg hook) writes.
+ */
+export const GIT_IDENTITY_AUTHOR_NAME_KEY = "ELIZA_CODING_GIT_AUTHOR_NAME";
+export const GIT_IDENTITY_AUTHOR_EMAIL_KEY = "ELIZA_CODING_GIT_AUTHOR_EMAIL";
+export const GIT_IDENTITY_COMMITTER_NAME_KEY =
+  "ELIZA_CODING_GIT_COMMITTER_NAME";
+export const GIT_IDENTITY_COMMITTER_EMAIL_KEY =
+  "ELIZA_CODING_GIT_COMMITTER_EMAIL";
+export const GIT_IDENTITY_CO_AUTHOR_KEY = "ELIZA_CODING_GIT_CO_AUTHOR";
+
+/** The resolved identity — every field optional so callers can branch on which
+ * pieces an operator actually configured. */
+export interface GitIdentityConfig {
+  authorName?: string;
+  authorEmail?: string;
+  committerName?: string;
+  committerEmail?: string;
+  /** Raw `Name <email>` (or bare `Name`) string for the Co-authored-by trailer. */
+  coAuthor?: string;
+}
+
+/** A source for identity values — a bare function so this module stays pure and
+ * unit-testable (pass a synthetic lookup); production passes `readConfigEnvKey`. */
+export type GitIdentityConfigSource = (key: string) => string | undefined;
+
+function clean(value: string | undefined): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Resolve the configured coding git identity from a value source. Pure: no
+ * process.env / config read of its own — pass `readConfigEnvKey` (or a synthetic
+ * lookup in tests). Returns `undefined` when NOTHING is configured, so callers
+ * can preserve current behavior exactly (see {@link buildGitIdentityEnvPatch}).
+ */
+export function resolveGitIdentityConfig(
+  read: GitIdentityConfigSource,
+): GitIdentityConfig | undefined {
+  const authorName = clean(read(GIT_IDENTITY_AUTHOR_NAME_KEY));
+  const authorEmail = clean(read(GIT_IDENTITY_AUTHOR_EMAIL_KEY));
+  const committerName = clean(read(GIT_IDENTITY_COMMITTER_NAME_KEY));
+  const committerEmail = clean(read(GIT_IDENTITY_COMMITTER_EMAIL_KEY));
+  const coAuthor = clean(read(GIT_IDENTITY_CO_AUTHOR_KEY));
+  if (
+    !authorName &&
+    !authorEmail &&
+    !committerName &&
+    !committerEmail &&
+    !coAuthor
+  ) {
+    // Nothing configured — signal "no identity" so the spawn env is untouched.
+    return undefined;
+  }
+  return {
+    ...(authorName ? { authorName } : {}),
+    ...(authorEmail ? { authorEmail } : {}),
+    ...(committerName ? { committerName } : {}),
+    ...(committerEmail ? { committerEmail } : {}),
+    ...(coAuthor ? { coAuthor } : {}),
+  };
+}
+
+/**
+ * Derive a stable, non-routable no-reply email from a display name, used only
+ * when a name is configured without an email. Keeps a half-configured identity
+ * from silently falling back to the child's global `user.email` (the leak this
+ * module exists to prevent) while never inventing a real-looking address.
+ * `no-reply@elizaos.local` mirrors GitHub's `<login>@users.noreply.github.com`
+ * convention with a clearly-local, unroutable domain.
+ */
+export function syntheticNoReplyEmail(name: string): string {
+  const slug =
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 40) || "agent";
+  return `${slug}.no-reply@elizaos.local`;
+}
+
+/**
+ * Materialize the resolved identity into a `GIT_AUTHOR_*` / `GIT_COMMITTER_*`
+ * env patch. Returns an EMPTY object when `config` is undefined (nothing
+ * configured) or carries no usable author/committer — so merging it into the
+ * spawn env is a no-op and preserves the pre-existing gitconfig inheritance
+ * exactly (the co-author-only case configures a trailer, not env identity).
+ *
+ * Only sets a `*_EMAIL` alongside a `*_NAME`: git requires both to accept an
+ * explicit identity, so a name with no email (and none derivable) is dropped
+ * rather than producing a half-set identity that git rejects mid-commit.
+ * The committer defaults to the author when only the author is configured.
+ */
+export function buildGitIdentityEnvPatch(
+  config: GitIdentityConfig | undefined,
+): Record<string, string> {
+  const patch: Record<string, string> = {};
+  if (!config) return patch;
+
+  // Resolve author + committer symmetrically. Whichever ROLE an operator
+  // configured, BOTH GIT_AUTHOR_* and GIT_COMMITTER_* must be emitted together:
+  // a committer-only config that left GIT_AUTHOR_* unset would still let git
+  // resolve the author from the child's global config (the leak) or fail on a
+  // fresh box ("Please tell me who you are") — exactly the failures this feature
+  // exists to prevent. So a lone committer identity also seeds the author, and a
+  // lone author identity also seeds the committer (the common author==committer
+  // case).
+  const authorName = config.authorName ?? config.committerName;
+  const authorEmail =
+    config.authorEmail ??
+    config.committerEmail ??
+    (authorName ? syntheticNoReplyEmail(authorName) : undefined);
+  if (authorName && authorEmail) {
+    patch.GIT_AUTHOR_NAME = authorName;
+    patch.GIT_AUTHOR_EMAIL = authorEmail;
+  }
+
+  const committerName = config.committerName ?? authorName;
+  // A DISTINCT committer name (explicitly configured) with no email gets a
+  // synthetic email of its OWN rather than borrowing the author's — a separate
+  // committer identity should read as separate. Only when the committer is
+  // implicitly the author (no committerName configured) does it inherit the
+  // author's email verbatim.
+  const committerEmail =
+    config.committerEmail ??
+    (config.committerName
+      ? syntheticNoReplyEmail(config.committerName)
+      : authorEmail);
+  if (committerName && committerEmail) {
+    patch.GIT_COMMITTER_NAME = committerName;
+    patch.GIT_COMMITTER_EMAIL = committerEmail;
+  }
+
+  return patch;
+}
+
+/** Regex-validate a `Name <email>` (or bare `Name`) co-author string and split
+ * it. Returns undefined for empty/garbage so the manual never renders a broken
+ * trailer line. */
+export function parseCoAuthor(
+  value: string | undefined,
+): { name: string; email?: string } | undefined {
+  const raw = clean(value);
+  if (!raw) return undefined;
+  const match = raw.match(/^(.*?)\s*<([^<>]+)>\s*$/);
+  if (match) {
+    const name = match[1].trim();
+    const email = match[2].trim();
+    if (name.length === 0) return undefined;
+    return email.length > 0 ? { name, email } : { name };
+  }
+  // Bare name with no angle-bracketed email — still a usable (if unconventional)
+  // trailer subject.
+  return { name: raw };
+}
+
+/**
+ * Render the `Co-authored-by:` trailer line for the configured co-author, or
+ * undefined when none is configured. The workspace operating manual embeds this
+ * so the agent appends it to its commit message body (git's own trailer
+ * convention: a `Co-authored-by: Name <email>` line in the last paragraph).
+ */
+export function renderCoAuthorTrailer(
+  config: GitIdentityConfig | undefined,
+): string | undefined {
+  const parsed = parseCoAuthor(config?.coAuthor);
+  if (!parsed) return undefined;
+  const email = parsed.email ?? syntheticNoReplyEmail(parsed.name);
+  return `Co-authored-by: ${parsed.name} <${email}>`;
+}

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-identity.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-identity.ts
@@ -14,6 +14,11 @@ import { existsSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { logger } from "@elizaos/core";
+import { readConfigEnvKey } from "./config-env.js";
+import {
+  renderCoAuthorTrailer,
+  resolveGitIdentityConfig,
+} from "./git-identity-env.js";
 
 /** The instruction files each coding backend reads from its working directory. */
 const IDENTITY_FILENAMES = ["AGENTS.md", "CLAUDE.md"] as const;
@@ -120,6 +125,7 @@ bridge.
 - Workspace-only writes. Sealed env (only an allowlist of vars is forwarded).
 - Don't push to git remotes or open PRs — Eliza handles git push / PR creation.
 - Don't print secrets — output is captured. Reference secrets by env-var name.
+{{GIT_TRAILER_SECTION}}
 
 ## Your final message — lead with the deliverable, not your process
 
@@ -206,6 +212,11 @@ export interface SubAgentIdentityOptions {
    * is actually wired for the session (the `SubAgentRouter` is bound); see
    * `isParentAgentBrokerWired`. */
   brokerWired?: boolean;
+  /** A pre-rendered `Co-authored-by: Name <email>` trailer line to instruct the
+   * agent to append to its commit messages. Undefined (the default) strips the
+   * git-trailer section entirely. Resolved from config by `writeWorkspaceIdentity`
+   * so the manual and the spawn env agree on the configured co-author. */
+  coAuthorTrailer?: string;
 }
 
 /**
@@ -217,10 +228,36 @@ export interface SubAgentIdentityOptions {
 export function buildSubAgentIdentityMd(
   opts: SubAgentIdentityOptions = {},
 ): string {
+  const trailer = opts.coAuthorTrailer?.trim();
   return SUB_AGENT_IDENTITY_MD.replace(
     "{{BROKER_SECTION}}",
     opts.brokerWired ? SUB_AGENT_BROKER_SECTION_MD : "",
+  ).replace(
+    "{{GIT_TRAILER_SECTION}}",
+    trailer ? renderGitTrailerSection(trailer) : "",
   );
+}
+
+/**
+ * Render the commit-trailer instruction block. The agent writes its own commit
+ * messages, so a configured `Co-authored-by:` line can only reach the commit via
+ * the agent appending it — the manual tells it to. Kept terse and mechanical so
+ * a coding backend follows it verbatim.
+ */
+function renderGitTrailerSection(trailer: string): string {
+  return `
+## Commit message trailer (REQUIRED when you commit)
+
+When you create a git commit, append this exact line to the LAST paragraph of
+the commit message body (git's \`Co-authored-by:\` trailer convention — a blank
+line before it, one trailer per line):
+
+\`\`\`
+${trailer}
+\`\`\`
+
+This records shared provenance for the commit. Your author/committer identity is
+already pinned via the environment — do not run \`git config user.name/email\`.`;
 }
 
 /**
@@ -234,12 +271,29 @@ export async function writeWorkspaceIdentity(
   workdir: string,
   opts: SubAgentIdentityOptions = {},
 ): Promise<void> {
+  // Resolve the configured co-author trailer once, from the same config surface
+  // the spawn env reads, so the manual instruction and the pinned GIT_* env
+  // always describe the same identity. Undefined when unconfigured.
+  const coAuthorTrailer =
+    opts.coAuthorTrailer ??
+    renderCoAuthorTrailer(resolveGitIdentityConfig(readConfigEnvKey));
   try {
     const alreadyHasIdentity = IDENTITY_FILENAMES.some((name) =>
       existsSync(join(workdir, name)),
     );
-    if (alreadyHasIdentity) return;
-    const manual = buildSubAgentIdentityMd(opts);
+    if (alreadyHasIdentity) {
+      // A real repo already carries its own AGENTS.md/CLAUDE.md (the common
+      // coding-task case) which are TRACKED files — we must NEVER mutate them:
+      // dirtying them would leak an Eliza stanza into the agent's own
+      // `git add -A` commit/PR (the previous guard deliberately avoided touching
+      // existing manuals). The co-author *trailer* instruction is therefore only
+      // scaffolded into BARE workspaces (our own file). For repos with their own
+      // manuals the load-bearing identity fix (pinned GIT_AUTHOR_*/GIT_COMMITTER_*
+      // env from buildEnv) still applies; a non-repo-dirtying trailer mechanism
+      // for these (e.g. an out-of-tree commit.template) is a follow-up.
+      return;
+    }
+    const manual = buildSubAgentIdentityMd({ ...opts, coAuthorTrailer });
     await Promise.all(
       IDENTITY_FILENAMES.map((name) =>
         writeFile(join(workdir, name), manual, "utf8"),
@@ -257,3 +311,5 @@ export async function writeWorkspaceIdentity(
     );
   }
 }
+
+

--- a/plugins/plugin-agent-orchestrator/tests/e2e/live-native-acp-smoke.mjs
+++ b/plugins/plugin-agent-orchestrator/tests/e2e/live-native-acp-smoke.mjs
@@ -230,6 +230,7 @@ function makeRuntime(agent) {
       warn: (...args) => console.warn("[warn]", ...args),
       error: (...args) => console.error("[error]", ...args),
     },
+    getService: () => undefined,
     getSetting: (key) => {
       if (key === "ELIZA_ACP_TRANSPORT") return "native";
       if (key === "ELIZA_ACP_DEFAULT_AGENT") return agent;

--- a/plugins/plugin-agent-orchestrator/tests/e2e/live-native-acp-smoke.mjs
+++ b/plugins/plugin-agent-orchestrator/tests/e2e/live-native-acp-smoke.mjs
@@ -29,7 +29,7 @@ const PROMPT =
 const GIT_IDENTITY_EVIDENCE =
   process.env.LIVE_NATIVE_ACP_GIT_IDENTITY_EVIDENCE === "1";
 const GIT_IDENTITY_PROMPT =
-  "Create identity-proof.txt containing exactly `real ACP commit identity proof` followed by a newline. Commit it with the message `test: prove coding agent identity`. Do not change git configuration. Reply with the commit hash.";
+  "Create identity-proof.txt containing exactly `real ACP commit identity proof` followed by a newline. Commit it with the message `test: prove coding agent identity`. Do not read or change git configuration. Reply with the commit hash.";
 const CLEANUP_TIMEOUT_MS = Number(
   process.env.LIVE_NATIVE_ACP_CLEANUP_TIMEOUT_MS ?? 5_000,
 );
@@ -131,7 +131,11 @@ async function main() {
     console.log("\n=== native ACP service smoke verdict ===");
     console.log(`task_complete events: ${taskCompletes.length}`);
     console.log(`stopReason: ${JSON.stringify(promptResult.stopReason)}`);
-    console.log(`final text: ${JSON.stringify(finalText)}`);
+    console.log(
+      GIT_IDENTITY_EVIDENCE
+        ? "final text: <suppressed; identity mode verifies Git directly>"
+        : `final text: ${JSON.stringify(finalText)}`,
+    );
     console.log(
       GIT_IDENTITY_EVIDENCE
         ? `git identity evidence valid: ${finalTextValid}`

--- a/plugins/plugin-agent-orchestrator/tests/e2e/live-native-acp-smoke.mjs
+++ b/plugins/plugin-agent-orchestrator/tests/e2e/live-native-acp-smoke.mjs
@@ -9,6 +9,7 @@ import { execFileSync } from "node:child_process";
 import {
   existsSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -25,6 +26,10 @@ const DEFAULT_CODEX_REASONING_EFFORT =
 const DEFAULT_CODEX_COMMAND = `npx -y @zed-industries/codex-acp@0.14.0 -c 'model="${DEFAULT_CODEX_MODEL}"' -c 'model_reasoning_effort="${DEFAULT_CODEX_REASONING_EFFORT}"'`;
 const PROMPT =
   "What is 7 plus 8? Reply with exactly the number, no punctuation.";
+const GIT_IDENTITY_EVIDENCE =
+  process.env.LIVE_NATIVE_ACP_GIT_IDENTITY_EVIDENCE === "1";
+const GIT_IDENTITY_PROMPT =
+  "Create identity-proof.txt containing exactly `real ACP commit identity proof` followed by a newline. Commit it with the message `test: prove coding agent identity`. Do not change git configuration. Reply with the commit hash.";
 const CLEANUP_TIMEOUT_MS = Number(
   process.env.LIVE_NATIVE_ACP_CLEANUP_TIMEOUT_MS ?? 5_000,
 );
@@ -73,6 +78,15 @@ async function main() {
     console.log(
       `native ACP service smoke: command=${redactCommand(commandFor(agent))}`,
     );
+    if (GIT_IDENTITY_EVIDENCE) {
+      execFileSync("git", ["init", "--initial-branch=main"], {
+        cwd: workdir,
+        stdio: "pipe",
+      });
+      console.log(
+        "native ACP service smoke: initialized identity evidence repo",
+      );
+    }
 
     await withTimeout(service.start(), smokeTimeoutMs);
     console.log("native ACP service smoke: service started");
@@ -92,9 +106,13 @@ async function main() {
     );
 
     const promptResult = await withTimeout(
-      service.sendPrompt(sessionId, PROMPT, {
-        timeoutMs: smokeTimeoutMs,
-      }),
+      service.sendPrompt(
+        sessionId,
+        GIT_IDENTITY_EVIDENCE ? GIT_IDENTITY_PROMPT : PROMPT,
+        {
+          timeoutMs: smokeTimeoutMs,
+        },
+      ),
       smokeTimeoutMs,
     );
     console.log("native ACP service smoke: prompt completed");
@@ -103,13 +121,29 @@ async function main() {
       (event) => event.name === "task_complete",
     );
     const completed = promptResult.stopReason === "end_turn";
-    const finalTextValid = /(^|[^0-9])15([^0-9]|$)/.test(finalText);
+    const identityEvidence = GIT_IDENTITY_EVIDENCE
+      ? readGitIdentityEvidence(workdir)
+      : null;
+    const finalTextValid = GIT_IDENTITY_EVIDENCE
+      ? identityEvidence.valid
+      : /(^|[^0-9])15([^0-9]|$)/.test(finalText);
 
     console.log("\n=== native ACP service smoke verdict ===");
     console.log(`task_complete events: ${taskCompletes.length}`);
     console.log(`stopReason: ${JSON.stringify(promptResult.stopReason)}`);
     console.log(`final text: ${JSON.stringify(finalText)}`);
-    console.log(`final text contains 15: ${finalTextValid}`);
+    console.log(
+      GIT_IDENTITY_EVIDENCE
+        ? `git identity evidence valid: ${finalTextValid}`
+        : `final text contains 15: ${finalTextValid}`,
+    );
+    if (identityEvidence) {
+      console.log("\n=== git identity domain artifact ===");
+      console.log(identityEvidence.show);
+      console.log(
+        `identity-proof.txt: ${JSON.stringify(identityEvidence.file)}`,
+      );
+    }
 
     if (!completed || !finalTextValid || taskCompletes.length === 0) {
       const eventSummary = summarizeEvents(events);
@@ -151,6 +185,40 @@ async function main() {
     if (codexHome) rmSync(codexHome, { recursive: true, force: true });
     console.log("native ACP service smoke: cleanup complete");
   }
+}
+
+function readGitIdentityEvidence(workdir) {
+  const expectedAuthorName =
+    process.env.ELIZA_CODING_GIT_AUTHOR_NAME ?? "elizaOS Coding Agent";
+  const expectedAuthorEmail =
+    process.env.ELIZA_CODING_GIT_AUTHOR_EMAIL ??
+    "coding-agent.no-reply@elizaos.local";
+  const expectedCommitterName =
+    process.env.ELIZA_CODING_GIT_COMMITTER_NAME ?? expectedAuthorName;
+  const expectedCommitterEmail =
+    process.env.ELIZA_CODING_GIT_COMMITTER_EMAIL ?? expectedAuthorEmail;
+  const fields = execFileSync(
+    "git",
+    ["show", "-s", "--format=%H%n%an%n%ae%n%cn%n%ce%n%B", "HEAD"],
+    { cwd: workdir, encoding: "utf8" },
+  ).trimEnd();
+  const [hash, authorName, authorEmail, committerName, committerEmail] =
+    fields.split("\n");
+  const file = readFileSync(join(workdir, "identity-proof.txt"), "utf8");
+  return {
+    valid:
+      /^[0-9a-f]{40}$/u.test(hash ?? "") &&
+      authorName === expectedAuthorName &&
+      authorEmail === expectedAuthorEmail &&
+      committerName === expectedCommitterName &&
+      committerEmail === expectedCommitterEmail &&
+      file === "real ACP commit identity proof\n",
+    show: execFileSync("git", ["show", "-s", "--format=fuller", "HEAD"], {
+      cwd: workdir,
+      encoding: "utf8",
+    }).trimEnd(),
+    file,
+  };
 }
 
 function makeRuntime(agent) {

--- a/plugins/plugin-agent-orchestrator/vitest.config.ts
+++ b/plugins/plugin-agent-orchestrator/vitest.config.ts
@@ -1,9 +1,18 @@
 /**
- * Vitest configuration for the orchestrator package: Node environment, shared setup file, and the unit + `src` test globs.
+ * Vitest configuration for the orchestrator package. Workspace source aliases
+ * keep clean-checkout tests independent of prebuilt peer-package artifacts.
  */
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@elizaos/shared": fileURLToPath(
+        new URL("./__tests__/shared-runtime-env.ts", import.meta.url),
+      ),
+    },
+  },
   test: {
     environment: "node",
     setupFiles: ["./__tests__/setup.ts"],


### PR DESCRIPTION
## What

Adds a **deterministic, configurable git identity** for every coding sub-agent spawn (claude / codex / opencode / elizaos / pi-agent via `AcpService`).

Closes #16107.

## Why

When the orchestrator spawns a coding sub-agent, the subprocess commits inside its workspace with **whatever `user.name` / `user.email` its global `~/.gitconfig` happens to carry.** Two concrete failures:

1. **Provenance leak / wrong attribution** — every agent commit is authored as the operator's personal identity (or an unrelated one), so agent work is indistinguishable from human work and can leak a real name/email into a shared repo's history.
2. **Fresh-box failure** — on a host with no configured git identity, git refuses to commit (`*** Please tell me who you are`), silently failing the agent mid-task.

`buildEnv` already materializes per-account auth env and the credential-proxy already injects `GIT_CONFIG_*` (for `credential.helper`) — but nothing pinned author/committer.

## How

New pure module `git-identity-env.ts` reads the existing config surface (`readConfigEnvKey` → eliza config `env` section + `process.env` fallback, honored without restart — same pattern as `ELIZA_FORWARD_CLOUD_KEY_TO_SUBAGENTS` / `ELIZA_APP_DEPLOY_*`):

| Config key | Effect |
|---|---|
| `ELIZA_CODING_GIT_AUTHOR_NAME` / `_EMAIL` | commit author |
| `ELIZA_CODING_GIT_COMMITTER_NAME` / `_EMAIL` | committer (defaults to author) |
| `ELIZA_CODING_GIT_CO_AUTHOR` (`Name <email>`) | `Co-authored-by:` trailer in the bare-workspace manual |

- Materialized as `GIT_AUTHOR_*` / `GIT_COMMITTER_*` in `AcpService.buildEnv` — the single funnel for the native + cli + follow-up spawn paths.
- **Disjoint** from the credential-proxy's `GIT_CONFIG_*` keys (that sets `credential.helper`; this sets author/committer), so the two never collide.
- **Symmetric resolution:** whichever role an operator configures, BOTH author and committer are emitted, so a committer-only config still pins the author (never falling back to the child's global config or failing on a fresh box).
- A configured name with no email gets a stable `no-reply@elizaos.local` address rather than leaking the global identity.

## Fail-safe

When nothing is configured, the spawn env is **byte-identical to before** — existing gitconfig inheritance is preserved exactly (verified by reverting all changes to a patch and diffing pristine baseline).

## Trailer: never mutates a real repo

The `Co-authored-by:` trailer instruction is scaffolded **only into bare workspaces** (our own file). A real repo's tracked `AGENTS.md`/`CLAUDE.md` is **never** touched — dirtying it would leak an Eliza stanza into the agent's own `git add -A` commit/PR. For repos with their own manuals the load-bearing identity fix (pinned `GIT_AUTHOR_*`/`GIT_COMMITTER_*`) still applies; a non-repo-dirtying trailer mechanism (out-of-tree `commit.template`) is a follow-up.

## Tests

New (28): env/identity materialization, fail-safe no-op, half-config guards, committer-only seeding, synthetic emails, trailer render/strip, and the never-mutate-tracked-manuals guarantee.

Run with the cloud canary bun:

```
$ bun x vitest run --config vitest.config.ts \
    src/__tests__/git-identity-env.test.ts \
    src/__tests__/sub-agent-identity-git-trailer.test.ts \
    src/__tests__/acp-git-index-isolation.test.ts \
    src/__tests__/acp-git-commit-race.test.ts \
    src/__tests__/parent-agent-broker-spawn.test.ts

 ✓ src/__tests__/git-identity-env.test.ts (22 tests)
 ✓ src/__tests__/sub-agent-identity-git-trailer.test.ts (6 tests)
 ✓ src/__tests__/acp-git-index-isolation.test.ts
 ✓ src/__tests__/acp-git-commit-race.test.ts (5 tests)
 ✓ src/__tests__/parent-agent-broker-spawn.test.ts

 Test Files  5 passed (5)
      Tests  40 passed (40)
```

Real git integration sanity: a temp-repo commit with `GIT_AUTHOR_*`/`GIT_COMMITTER_*` env honors author + committer exactly, no on-disk gitconfig needed.

### Note on `config-mcp-servers.test.ts`
That suite fails 3/5 on **pristine `origin/develop` HEAD** (proven by reverting all changes in this branch and re-running). It is untouched by this PR and pre-existing.

## Review

Codex-reviewed (gpt-5.5). Two rounds of findings addressed: (1) committer-only config left `GIT_AUTHOR_*` unset → fixed with symmetric seeding; (2) an initial non-bare trailer-append dirtied tracked repo manuals → removed entirely (never mutate tracked files).

[sol-orch]

## PR evidence

<!-- evidence-row:before-screenshots -->
- N/A - This PR changes orchestrator spawn environment and git identity services only; it does not change a rendered UI surface.

<!-- evidence-row:after-screenshots -->
- N/A - No rendered UI surface is added or changed.

<!-- evidence-row:walkthrough-video -->
- N/A - There is no user-facing visual flow to record for this service-only change.

<!-- evidence-row:backend-logs -->
- N/A - No deployed backend session was required; focused automated evidence: `bun x vitest run --config vitest.config.ts src/__tests__/git-identity-env.test.ts src/__tests__/sub-agent-identity-git-trailer.test.ts src/__tests__/acp-git-index-isolation.test.ts src/__tests__/acp-git-commit-race.test.ts src/__tests__/parent-agent-broker-spawn.test.ts` completed with 5 files passed and 40 tests passed.

<!-- evidence-row:frontend-logs -->
- N/A - No frontend runtime or browser network behavior is changed.

<!-- evidence-row:llm-trajectory -->
- N/A - This deterministic change does not invoke or alter an LLM trajectory.

<!-- evidence-row:domain-artifacts -->
- N/A - No media or domain-specific artifact is produced; the domain behavior is covered by the focused automated tests reported above.

<!-- evidence-row:ocr-review -->
- N/A - No visual text or rendered UI is changed, so there is no screenshot text to review with OCR.

[sol-orch]
