### PR TITLE
fix(ci): evidence gate diffs the PR's own changes, not the base branch's advance (#16125)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -22,6 +22,11 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          # Full history so the merge-base of the PR base and head resolves — the
+          # evidence diff must reflect only THIS PR's changes, not whatever landed
+          # on the base branch after the PR's branch point (#16125).
+          fetch-depth: 0
 
       - name: Validate PR evidence rows
         run: |
@@ -29,9 +34,11 @@ jobs:
           PR_LABELS=$(jq -r '.pull_request.labels | map(.name) | join(",")' "$GITHUB_EVENT_PATH")
           BASE_SHA=$(jq -r '.pull_request.base.sha' "$GITHUB_EVENT_PATH")
           HEAD_SHA=$(jq -r '.pull_request.head.sha' "$GITHUB_EVENT_PATH")
-          git fetch --no-tags --depth=1 origin "$BASE_SHA" "$HEAD_SHA"
-          git diff --name-only --diff-filter=ACMRT "$BASE_SHA" "$HEAD_SHA" > "$RUNNER_TEMP/pr-changed-files.txt"
-          git diff --name-only --diff-filter=A "$BASE_SHA" "$HEAD_SHA" > "$RUNNER_TEMP/pr-added-files.txt"
+          git fetch --no-tags origin "$BASE_SHA" "$HEAD_SHA"
+          # Three-dot: diff the merge-base..head, i.e. only what THIS PR changed,
+          # not files the base branch advanced past the branch point (#16125).
+          git diff --name-only --diff-filter=ACMRT "$BASE_SHA...$HEAD_SHA" > "$RUNNER_TEMP/pr-changed-files.txt"
+          git diff --name-only --diff-filter=A "$BASE_SHA...$HEAD_SHA" > "$RUNNER_TEMP/pr-added-files.txt"
           node scripts/check-pr-evidence.mjs \
             --body-file "$RUNNER_TEMP/pr-body.md" \
             --labels "$PR_LABELS" \


### PR DESCRIPTION
Fixes #16125.

## Why

`check-pr-evidence` (`.github/workflows/pr.yaml`) computed the PR's changed files with a **two-dot** diff:

```
BASE_SHA = pull_request.base.sha   # the base-branch TIP — advances as other PRs merge
git diff --diff-filter=ACMRT "$BASE_SHA" "$HEAD_SHA"
```

`git diff A B` lists every path that differs between the current `develop` tip and the PR head. Files that land on `develop` **after** the PR's branch point differ from the (older) head and are reported as the PR's modifications. `requiresSurfaceArtifactsFromFiles` then sees a `.tsx`/`.svg`/etc. under a UI package and demands screenshots/OCR that a backend/config/docs-only PR cannot produce — so the gate fails on files the PR never touched.

Observed live: **#16059** changed only `turbo.json`; while its CI ran, `develop` merged a UI PR, and the gate reported `before-screenshots: artifact-required` / `ocr-review: ocr-required`. Rebasing (so `base.sha ≈ head`) made it pass unchanged — the failure tracked branch staleness, not the diff.

## What

Diff the **merge-base..head** (three-dot `BASE...HEAD`) — exactly the PR's own changes, and what the GitHub "Files changed" tab shows. Check out with `fetch-depth: 0` so the merge-base is resolvable (the prior `--depth=1` fetch of the two tips shared no common ancestor).

Two-line semantic change; no behavior change for an up-to-date PR (merge-base == base tip → identical result).

# Evidence Gate

CI workflow change (`.github/workflows/pr.yaml`) — no runtime code, UI, or model path. Correctness is in the diff semantics (three-dot vs two-dot), verifiable by reading the change.

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI workflow change; no UI surface is rendered or touched.
<!-- evidence-row:after-screenshots -->
- [x] N/A - CI workflow change; no UI surface is rendered or touched.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; a build-time gate's diff computation.
<!-- evidence-row:backend-logs -->
- [x] N/A - no runtime/backend path; the change is `git diff` two-dot -> three-dot plus `fetch-depth: 0`, verifiable by inspection.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or API surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB/schema/on-chain/generated-file change; a CI gate config only.

## Known gaps / failures

This PR is itself fresh off `develop`, so it exercises the fixed path (its own evidence gate passes on the merge-base diff). The same two-dot pattern on `pull_request.base.sha` in the coverage-changed-files and gitleaks range steps is worth a follow-up audit (noted in #16125). All evidence rows are `N/A` — a CI-config change has no UI/LLM/domain artifacts.

[stan-cloud]