### PR TITLE
fix(build): ignore dependency shadows in stale-js guard

### DIFF
--- a/packages/scripts/stale-js-shadow-guard.mjs
+++ b/packages/scripts/stale-js-shadow-guard.mjs
@@ -13,8 +13,17 @@ const scriptRoot = resolve(fileURLToPath(new URL("../..", import.meta.url)));
 export function findStaleJsShadows(root = scriptRoot) {
   const output = execFileSync(
     "git",
-    ["ls-files", "--others", "--ignored", "--exclude-standard", "-z", "--", ":(glob)**/src/**/*.js"],
-    { cwd: root, encoding: "utf8" },
+    [
+      "ls-files",
+      "--others",
+      "--ignored",
+      "--exclude-standard",
+      "-z",
+      "--",
+      ":(glob)**/src/**/*.js",
+      ":(exclude,glob)**/node_modules/**",
+    ],
+    { cwd: root, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
   );
 
   return output

--- a/packages/scripts/stale-js-shadow-guard.test.mjs
+++ b/packages/scripts/stale-js-shadow-guard.test.mjs
@@ -34,6 +34,17 @@ test("finds only ignored JavaScript files that shadow TypeScript under src", (t)
   ]);
 });
 
+test("ignores JavaScript shadows inside dependency directories", (t) => {
+  const root = fixture();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  mkdirSync(join(root, "node_modules/example/src"), { recursive: true });
+  writeFileSync(join(root, "node_modules/example/src/index.ts"), "export {};\n");
+  writeFileSync(join(root, "node_modules/example/src/index.js"), "dependency output\n");
+
+  assert.deepEqual(findStaleJsShadows(root), []);
+});
+
 test("clean mode removes every detected shadow and preserves unrelated JavaScript", (t) => {
   const root = fixture();
   t.after(() => rmSync(root, { recursive: true, force: true }));


### PR DESCRIPTION
## What changed

- Exclude `node_modules` from stale JavaScript shadow discovery at the Git pathspec boundary.
- Retain a larger output buffer for large workspaces.
- Add regression coverage proving dependency source files are never reported or cleaned.

## Why

The guard scanned ignored dependency files and instructed developers to delete valid JavaScript from installed packages. Following that instruction broke Smithers runtime imports during local startup. On large dependency trees, the same scan could also exceed Node's default child-process output buffer.

## Validation

- `node --test packages/scripts/stale-js-shadow-guard.test.mjs`
- Patched `findStaleJsShadows` against the restored real workspace dependency tree: no false positives.
- `git diff --check`

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] N/A - developer build tooling only; no UI surface changes.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - developer build tooling only; no UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - behavior is covered by the focused guard test and real-workspace scan above.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend behavior or network contract changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain data or persistent artifacts are produced.
