### PR TITLE
fix(ci): compute PR changed files from merge-base, not base tip (#16125)

### DIFF
--- a/packages/scripts/ci-path-gate.mjs
+++ b/packages/scripts/ci-path-gate.mjs
@@ -375,8 +375,28 @@ function matches(pattern, path) {
   return patternCache.get(pattern).test(path);
 }
 
+// Diffs from the merge-base of base..head, not from the base TIP. The base
+// SHA the workflow passes is `pull_request.base.sha` — the base branch's tip,
+// which advances as other PRs merge. A plain two-dot `git diff base head`
+// would charge a PR that trails its base branch with every develop-side file
+// it never touched, over-triggering heavy lanes (including the fail-safe
+// lanes) for unrelated changes (#16125). The merge-base diff is exactly what
+// the GitHub "Files changed" tab shows. Callers check out with fetch-depth: 0
+// so the merge-base is resolvable; if it is not (bad fetch depth, unrelated
+// histories), fail loud rather than silently diffing the entire tree.
 function gitChangedFiles(base, head) {
-  const result = spawnSync("git", ["diff", "--name-only", base, head], {
+  const mergeBaseResult = spawnSync("git", ["merge-base", base, head], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const mergeBase = mergeBaseResult.stdout.trim();
+  if (mergeBaseResult.status !== 0 || !mergeBase) {
+    throw new Error(
+      `no merge-base between ${base} and ${head} — insufficient fetch depth or unrelated histories` +
+        (mergeBaseResult.stderr ? `: ${mergeBaseResult.stderr.trim()}` : ""),
+    );
+  }
+  const result = spawnSync("git", ["diff", "--name-only", mergeBase, head], {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
   });

--- a/packages/scripts/ci-path-gate.mjs
+++ b/packages/scripts/ci-path-gate.mjs
@@ -384,8 +384,9 @@ function matches(pattern, path) {
 // the GitHub "Files changed" tab shows. Callers check out with fetch-depth: 0
 // so the merge-base is resolvable; if it is not (bad fetch depth, unrelated
 // histories), fail loud rather than silently diffing the entire tree.
-function gitChangedFiles(base, head) {
+export function gitChangedFiles(base, head, cwd) {
   const mergeBaseResult = spawnSync("git", ["merge-base", base, head], {
+    cwd,
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -397,6 +398,7 @@ function gitChangedFiles(base, head) {
     );
   }
   const result = spawnSync("git", ["diff", "--name-only", mergeBase, head], {
+    cwd,
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -614,4 +616,6 @@ function main() {
   }
 }
 
-main();
+if (import.meta.main) {
+  main();
+}

--- a/packages/scripts/ci-path-gate.self-test.mjs
+++ b/packages/scripts/ci-path-gate.self-test.mjs
@@ -1,9 +1,15 @@
 #!/usr/bin/env node
 // Exercises ci path gate.self test automation behavior with deterministic script fixtures.
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const script = fileURLToPath(new URL("./ci-path-gate.mjs", import.meta.url));
@@ -195,5 +201,139 @@ assertGate(
     server: "true",
   },
 );
+
+// --- git-diff path (--base/--head, no --changed-files) ---------------------
+// The base SHA the workflows pass is the base branch TIP, which advances as
+// other PRs merge. The gate must diff from the MERGE-BASE so a PR trailing its
+// base branch is not charged with develop-side files it never touched, which
+// over-triggered unrelated heavy lanes (#16125). Exercised against a real
+// throwaway git history: base branch advances with an app (client-lane) file
+// after the PR branches; the PR itself only touches a docs file.
+
+function gitIn(cwd, ...args) {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8" });
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${result.stderr}`);
+  }
+  return result.stdout.trim();
+}
+
+function writeIn(cwd, relPath, contents) {
+  const full = join(cwd, relPath);
+  mkdirSync(dirname(full), { recursive: true });
+  writeFileSync(full, contents);
+}
+
+function runGateGit({ config, cwd, base, head }) {
+  const dir = mkdtempSync(join(tmpdir(), "ci-path-gate-git-"));
+  const output = join(dir, "github-output.txt");
+  const summary = join(dir, "summary.md");
+  const result = spawnSync(
+    process.execPath,
+    [
+      script,
+      "--config",
+      config,
+      "--event",
+      "pull_request",
+      "--base",
+      base,
+      "--head",
+      head,
+      "--labels",
+      "",
+      "--output",
+      output,
+      "--summary",
+      summary,
+    ],
+    { cwd, encoding: "utf8" },
+  );
+  if (result.status !== 0) {
+    rmSync(dir, { recursive: true, force: true });
+    return { status: result.status, stderr: result.stderr };
+  }
+  const values = Object.fromEntries(
+    readOutput(output).map((line) => {
+      const [key, value] = line.split("=");
+      return [key, value];
+    }),
+  );
+  rmSync(dir, { recursive: true, force: true });
+  return { status: 0, values };
+}
+
+const repo = mkdtempSync(join(tmpdir(), "ci-path-gate-repo-"));
+try {
+  gitIn(repo, "init", "-q");
+  gitIn(repo, "config", "user.email", "test@example.com");
+  gitIn(repo, "config", "user.name", "test");
+  gitIn(repo, "checkout", "-q", "-b", "develop");
+
+  // Merge-base commit: the point the PR branch forks from.
+  writeIn(repo, "README.md", "base\n");
+  gitIn(repo, "add", ".");
+  gitIn(repo, "commit", "-q", "-m", "base");
+
+  // PR branch changes only a docs page (matches no test lane).
+  gitIn(repo, "checkout", "-q", "-b", "pr");
+  writeIn(repo, "packages/docs/pages/only.mdx", "# docs\n");
+  gitIn(repo, "add", ".");
+  gitIn(repo, "commit", "-q", "-m", "docs-only PR change");
+  const headSha = gitIn(repo, "rev-parse", "HEAD");
+
+  // develop advances past the branch point with an app file (client lane).
+  gitIn(repo, "checkout", "-q", "develop");
+  writeIn(repo, "packages/app/src/App.tsx", "export default 1;\n");
+  gitIn(repo, "add", ".");
+  gitIn(repo, "commit", "-q", "-m", "develop advances with app change");
+  const baseTipSha = gitIn(repo, "rev-parse", "HEAD");
+
+  const stale = runGateGit({
+    config: "test",
+    cwd: repo,
+    base: baseTipSha,
+    head: headSha,
+  });
+  assertEqual(stale.status, 0, "stale-base git diff run exit status");
+  assertGate(
+    "stale base is not charged with develop-side files",
+    stale.values,
+    {
+      server: "false",
+      client: "false",
+      plugins: "false",
+      desktop: "false",
+      zero_key: "false",
+      cloud: "false",
+    },
+  );
+
+  // No merge-base (unrelated histories / bad fetch depth) must fail loud, not
+  // silently diff the entire tree.
+  gitIn(repo, "checkout", "-q", "--orphan", "unrelated");
+  gitIn(repo, "rm", "-rfq", "--cached", ".");
+  writeIn(repo, "orphan.txt", "no shared history\n");
+  gitIn(repo, "add", "orphan.txt");
+  gitIn(repo, "commit", "-q", "-m", "orphan root");
+  const orphanSha = gitIn(repo, "rev-parse", "HEAD");
+
+  const noMergeBase = runGateGit({
+    config: "test",
+    cwd: repo,
+    base: orphanSha,
+    head: headSha,
+  });
+  if (noMergeBase.status === 0) {
+    throw new Error("expected the gate to fail when no merge-base exists");
+  }
+  if (!/no merge-base/.test(noMergeBase.stderr)) {
+    throw new Error(
+      `expected a 'no merge-base' error, got: ${noMergeBase.stderr}`,
+    );
+  }
+} finally {
+  rmSync(repo, { recursive: true, force: true });
+}
 
 console.log("ci-path-gate self-test passed");

--- a/packages/scripts/ci-path-gate.test.mjs
+++ b/packages/scripts/ci-path-gate.test.mjs
@@ -1,0 +1,79 @@
+/**
+ * Verifies the shared CI classifier derives pull-request files from the branch
+ * merge-base and fails when the compared histories are unrelated.
+ */
+import { afterEach, describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { gitChangedFiles } from "./ci-path-gate.mjs";
+
+const repos = [];
+
+function git(cwd, ...args) {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8" });
+  if (result.status !== 0) {
+    throw new Error(result.stderr || `git ${args.join(" ")} failed`);
+  }
+  return result.stdout.trim();
+}
+
+function write(cwd, path, contents) {
+  const fullPath = join(cwd, path);
+  mkdirSync(dirname(fullPath), { recursive: true });
+  writeFileSync(fullPath, contents);
+}
+
+function makeRepo() {
+  const repo = mkdtempSync(join(tmpdir(), "ci-path-gate-unit-"));
+  repos.push(repo);
+  git(repo, "init", "-q");
+  git(repo, "config", "user.email", "test@example.com");
+  git(repo, "config", "user.name", "test");
+  git(repo, "checkout", "-q", "-b", "develop");
+  write(repo, "README.md", "base\n");
+  git(repo, "add", ".");
+  git(repo, "commit", "-q", "-m", "base");
+  return repo;
+}
+
+afterEach(() => {
+  for (const repo of repos.splice(0)) {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+describe("gitChangedFiles", () => {
+  it("excludes files added only after the pull-request branch point", () => {
+    const repo = makeRepo();
+    git(repo, "checkout", "-q", "-b", "feature");
+    write(repo, "packages/docs/feature.mdx", "# feature\n");
+    git(repo, "add", ".");
+    git(repo, "commit", "-q", "-m", "feature");
+    const head = git(repo, "rev-parse", "HEAD");
+
+    git(repo, "checkout", "-q", "develop");
+    write(repo, "packages/app/src/App.tsx", "export default 1;\n");
+    git(repo, "add", ".");
+    git(repo, "commit", "-q", "-m", "develop advances");
+    const base = git(repo, "rev-parse", "HEAD");
+
+    expect(gitChangedFiles(base, head, repo)).toEqual([
+      "packages/docs/feature.mdx",
+    ]);
+  });
+
+  it("fails when the revisions have no merge-base", () => {
+    const repo = makeRepo();
+    const base = git(repo, "rev-parse", "HEAD");
+    git(repo, "checkout", "-q", "--orphan", "unrelated");
+    git(repo, "rm", "-rfq", "--cached", ".");
+    write(repo, "orphan.txt", "unrelated\n");
+    git(repo, "add", "orphan.txt");
+    git(repo, "commit", "-q", "-m", "orphan");
+    const head = git(repo, "rev-parse", "HEAD");
+
+    expect(() => gitChangedFiles(base, head, repo)).toThrow(/no merge-base/);
+  });
+});

--- a/scripts/security/coverage-node-self-tests.txt
+++ b/scripts/security/coverage-node-self-tests.txt
@@ -1,2 +1,3 @@
+packages/scripts/ci-path-gate.self-test.mjs
 scripts/security/coverage-changed-files.self-test.mjs
 scripts/security/coverage-gate.self-test.mjs


### PR DESCRIPTION
Companion to #16126 (which fixes the same bug in the check-pr-evidence gate). Closes the remaining two-dot consumer from the #16125 audit.

## Why

`packages/scripts/ci-path-gate.mjs` computes a PR's changed files with a **two-dot** diff:

```
gitChangedFiles(base, head)  ->  git diff --name-only BASE HEAD
```

where `BASE` is `pull_request.base.sha` — the base branch **tip**, which advances as other PRs merge. A PR that trails `develop` is therefore charged with every develop-side file it never touched. Consumers: `test.yml`, `dev-smoke.yml`, `docker-ci-smoke.yml`, `mobile-build-smoke.yml`, `scenario-pr.yml`, `windows-desktop-preload-smoke.yml`, `windows-dev-smoke.yml`. Effect: unrelated heavy lanes (including the fail-safe lanes) over-trigger on stale PRs — the wasted-CI polarity of the same root cause #16126 fixes for false-red evidence gates. Same class as #15845/#15882 (coverage-gate).

## What

- `gitChangedFiles()` resolves `git merge-base BASE HEAD` first and diffs `MERGE_BASE..HEAD` — the same boundary the GitHub "Files changed" tab shows.
- **Fail loud on a missing merge-base** (insufficient fetch depth / unrelated histories) instead of silently diffing the entire tree. All seven consumer workflows already check out with `fetch-depth: 0`, so no workflow change is needed.
- Self-test: new coverage for the real git-diff path (`--base/--head`) against a throwaway repo — develop advances past the branch point with a `packages/app` file while the PR touches only docs; asserts **no lane triggers**, and that a missing merge-base fails with a `no merge-base` error.

No behavior change for an up-to-date PR (merge-base == base tip → identical diff).

## Verification

- `node packages/scripts/ci-path-gate.self-test.mjs` → passes (including the two new cases; the stale-base case fails against the old two-dot code).
- codex review: no actionable findings.
- biome format/lint clean (warnings match develop baseline).

⚠️ **CI-infrastructure change — maintainer eyes requested before merge.** No self-merge; this alters which test lanes PRs trigger.

# Evidence Gate

CI path-gate script change — no runtime code, UI, or model path.

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI script change; no UI surface rendered or touched.
<!-- evidence-row:after-screenshots -->
- [x] N/A - CI script change; no UI surface rendered or touched.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; a CI lane-selection script.
<!-- evidence-row:backend-logs -->
- [x] N/A - no runtime/backend path; deterministic self-test output above verifies the change.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or API surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB/schema/on-chain/generated-file change; CI gate logic only.

## Known gaps / failures

None. The audit of remaining `pull_request.base.sha` consumers is on #16125 (comment): coverage-gate already fixed (#15882), gitleaks uses `git log` two-dot which is already merge-base semantics, quality.yml homepage-scope already uses merge-base.

[sol-orch]
