### PR TITLE
fix(openrouter): cache tools and trajectory for Anthropic

### DIFF
--- a/plugins/plugin-openrouter/__tests__/anthropic-cache.shape.test.ts
+++ b/plugins/plugin-openrouter/__tests__/anthropic-cache.shape.test.ts
@@ -37,7 +37,9 @@ function mockModules() {
   }));
   vi.doMock("ai", () => ({ generateText, streamText: vi.fn() }));
   vi.doMock("../providers", () => ({
-    createOpenRouterProvider: () => ({ chat: (m: string) => ({ modelName: m }) }),
+    createOpenRouterProvider: () => ({
+      chat: (m: string) => ({ modelName: m }),
+    }),
   }));
   return { generateText };
 }
@@ -78,7 +80,10 @@ describe("Anthropic cache injection — runtime cacheControl fallback", () => {
     const anthropicOpts = (messages?.[0]?.providerOptions as Record<string, unknown>)?.anthropic as
       | Record<string, unknown>
       | undefined;
-    expect(anthropicOpts?.cacheControl).toEqual({ type: "ephemeral", ttl: "1h" });
+    expect(anthropicOpts?.cacheControl).toEqual({
+      type: "ephemeral",
+      ttl: "1h",
+    });
   });
 
   it("does NOT inject cacheControl for non-Anthropic models even when ANTHROPIC_PROMPT_CACHE_TTL is set", async () => {
@@ -197,7 +202,10 @@ describe("Anthropic cache injection — segmented user content", () => {
       providerOptions: {
         anthropic: {
           cacheBreakpoints: [
-            { segmentIndex: "not-a-number", cacheControl: { type: "ephemeral" } },
+            {
+              segmentIndex: "not-a-number",
+              cacheControl: { type: "ephemeral" },
+            },
             { segmentIndex: 0, cacheControl: { type: "invalid" } },
             null,
             42,
@@ -272,9 +280,14 @@ describe("Anthropic cache injection — caller providerOptions survive verbatim"
     const call = generateText.mock.calls[0][0] as Record<string, unknown>;
     const providerOpts = call.providerOptions as Record<string, unknown>;
     // Caller keys survive unchanged into the serialized request.
-    expect(providerOpts.openrouter).toEqual({ promptCacheKey: "caller-key-123" });
+    expect(providerOpts.openrouter).toEqual({
+      promptCacheKey: "caller-key-123",
+    });
     expect(providerOpts.gateway).toEqual({ caching: "auto" });
-    expect(providerOpts.customProvider).toEqual({ nested: { flag: true }, count: 7 });
+    expect(providerOpts.customProvider).toEqual({
+      nested: { flag: true },
+      count: 7,
+    });
     // And the injected message-level cacheControl is still applied on the system message.
     const messages = call.messages as Array<Record<string, unknown>>;
     const anthropicOpts = (messages?.[0]?.providerOptions as Record<string, unknown>)?.anthropic as
@@ -333,7 +346,9 @@ describe("Anthropic cache injection — malformed cacheControl fails loudly", ()
     await expect(
       handleTextLarge(createRuntime(), {
         prompt: "hello",
-        providerOptions: { anthropic: { cacheControl: { type: "persistent" } } },
+        providerOptions: {
+          anthropic: { cacheControl: { type: "persistent" } },
+        },
       } as never)
     ).rejects.toThrow(/cacheControl/);
   });
@@ -357,7 +372,9 @@ describe("Anthropic cache injection — malformed cacheControl fails loudly", ()
     await expect(
       handleTextLarge(createRuntime(), {
         prompt: "hello",
-        providerOptions: { anthropic: { cacheControl: { type: "ephemeral", ttl: "2h" } } },
+        providerOptions: {
+          anthropic: { cacheControl: { type: "ephemeral", ttl: "2h" } },
+        },
       } as never)
     ).rejects.toThrow(/ttl/);
   });
@@ -388,5 +405,112 @@ describe("Anthropic cache injection — cacheSystem:false opt-out", () => {
         expect(msg?.providerOptions).toBeUndefined();
       }
     }
+  });
+});
+
+describe("Anthropic cache injection — tools and trajectory breakpoints", () => {
+  const trajectory = [
+    { role: "user", content: [{ type: "text", text: "question" }] },
+    {
+      role: "assistant",
+      content: [{ type: "tool-call", toolCallId: "1", toolName: "READ", input: {} }],
+    },
+    {
+      role: "tool",
+      content: [
+        {
+          type: "tool-result",
+          toolCallId: "1",
+          toolName: "READ",
+          output: { type: "text", value: "result" },
+        },
+      ],
+    },
+  ];
+
+  it("stamps only the last tool and the kept-trajectory tail", async () => {
+    const { generateText } = mockModules();
+    const { handleTextLarge } = await import("../models/text");
+    await handleTextLarge(createRuntime(), {
+      prompt: "ignored",
+      messages: trajectory,
+      tools: {
+        READ: { description: "Read", inputSchema: { type: "object" } },
+        WRITE: { description: "Write", inputSchema: { type: "object" } },
+      },
+    } as never);
+
+    const call = generateText.mock.calls[0][0] as Record<string, unknown>;
+    const tools = call.tools as Record<string, Record<string, unknown>>;
+    expect(tools.READ.providerOptions).toBeUndefined();
+    expect(tools.WRITE.providerOptions).toEqual({
+      anthropic: { cacheControl: { type: "ephemeral" } },
+    });
+    const messages = call.messages as Array<Record<string, unknown>>;
+    const tail = (messages.at(-1)?.content as Array<Record<string, unknown>>).at(-1);
+    expect(tail?.providerOptions).toEqual({
+      anthropic: { cacheControl: { type: "ephemeral" } },
+    });
+    const leadingUserPart = (messages[1]?.content as Array<Record<string, unknown>>)[0];
+    expect(leadingUserPart.providerOptions).toBeUndefined();
+  });
+
+  it("honors opt-outs, strips local flags, and preserves the runtime TTL", async () => {
+    const { generateText } = mockModules();
+    const { handleTextLarge } = await import("../models/text");
+    await handleTextLarge(createRuntime({ ANTHROPIC_PROMPT_CACHE_TTL: "1h" }), {
+      prompt: "ignored",
+      messages: trajectory,
+      tools: { READ: { description: "Read", inputSchema: { type: "object" } } },
+      providerOptions: {
+        anthropic: { cacheTools: false, cacheTrajectory: false },
+      },
+    } as never);
+
+    const call = generateText.mock.calls[0][0] as Record<string, unknown>;
+    const tools = call.tools as Record<string, Record<string, unknown>>;
+    expect(tools.READ.providerOptions).toBeUndefined();
+    const messages = call.messages as Array<Record<string, unknown>>;
+    const tail = (messages.at(-1)?.content as Array<Record<string, unknown>>).at(-1);
+    expect(tail?.providerOptions).toBeUndefined();
+    expect(JSON.stringify(call.providerOptions ?? {})).not.toContain("cacheTools");
+    expect(JSON.stringify(call.providerOptions ?? {})).not.toContain("cacheTrajectory");
+    const systemAnthropic = (messages[0]?.providerOptions as Record<string, unknown>)?.anthropic;
+    expect(systemAnthropic).toEqual({
+      cacheControl: { type: "ephemeral", ttl: "1h" },
+    });
+  });
+});
+
+describe("Anthropic cache injection — breakpoint budget", () => {
+  it("reserves one of the four cache slots for the tools breakpoint", async () => {
+    const { generateText } = mockModules();
+    const { handleTextLarge } = await import("../models/text");
+    await handleTextLarge(createRuntime(), {
+      prompt: "s0s1s2",
+      promptSegments: [
+        { content: "s0", stable: true },
+        { content: "s1", stable: true },
+        { content: "s2", stable: true },
+      ],
+      tools: { READ: { description: "Read", inputSchema: { type: "object" } } },
+      providerOptions: {
+        anthropic: {
+          maxBreakpoints: 3,
+          cacheBreakpoints: [
+            { segmentIndex: 0, cacheControl: { type: "ephemeral" } },
+            { segmentIndex: 1, cacheControl: { type: "ephemeral" } },
+            { segmentIndex: 2, cacheControl: { type: "ephemeral" } },
+          ],
+        },
+      },
+    } as never);
+    const call = generateText.mock.calls[0][0] as Record<string, unknown>;
+    const messages = call.messages as Array<Record<string, unknown>>;
+    const segmentParts = messages[1]?.content as Array<Record<string, unknown>>;
+    expect(segmentParts.filter((part) => part.providerOptions)).toHaveLength(2);
+    expect(
+      (call.tools as Record<string, Record<string, unknown>>).READ.providerOptions
+    ).toBeDefined();
   });
 });

--- a/plugins/plugin-openrouter/models/text.ts
+++ b/plugins/plugin-openrouter/models/text.ts
@@ -100,6 +100,8 @@ type GenerateTextParamsWithAttachments = GenerateTextParams & {
       cacheSystem?: boolean;
       cacheBreakpoints?: unknown[];
       maxBreakpoints?: number;
+      cacheTools?: boolean;
+      cacheTrajectory?: boolean;
     };
   };
 };
@@ -300,7 +302,10 @@ function readAnthropicCacheControl(
         severity: "fatal",
       });
     }
-    return { type: "ephemeral", ...(ttl === "5m" || ttl === "1h" ? { ttl } : {}) };
+    return {
+      type: "ephemeral",
+      ...(ttl === "5m" || ttl === "1h" ? { ttl } : {}),
+    };
   }
   return anthropicOptions.cacheSystem === true ? { type: "ephemeral" } : undefined;
 }
@@ -319,9 +324,78 @@ function stripLocalAnthropicCacheOptions(
     cacheSystem: _cacheSystem,
     cacheBreakpoints: _cacheBreakpoints,
     maxBreakpoints: _maxBreakpoints,
+    cacheTools: _cacheTools,
+    cacheTrajectory: _cacheTrajectory,
     ...wireOptions
   } = anthropicOptions;
   return Object.keys(wireOptions).length > 0 ? wireOptions : undefined;
+}
+
+function applyToolsCacheBreakpoint(tools: ToolSet, cacheControl: AnthropicCacheControl): ToolSet {
+  const names = Object.keys(tools);
+  const lastName = names[names.length - 1];
+  if (!lastName) return tools;
+  const lastTool = tools[lastName];
+  if (!isRecord(lastTool)) return tools;
+  const existingProviderOptions = isRecord(lastTool.providerOptions)
+    ? lastTool.providerOptions
+    : {};
+  const existingAnthropic = isRecord(existingProviderOptions.anthropic)
+    ? existingProviderOptions.anthropic
+    : {};
+  if (existingAnthropic.cacheControl) return tools;
+  return {
+    ...tools,
+    [lastName]: {
+      ...lastTool,
+      providerOptions: {
+        ...existingProviderOptions,
+        anthropic: { ...existingAnthropic, cacheControl },
+      },
+    },
+  } as ToolSet;
+}
+
+const TRAJECTORY_CACHEABLE_PART_TYPES = new Set(["text", "tool-call", "tool-result"]);
+
+function applyTrajectoryTailCacheBreakpoint(
+  messages: ModelMessage[],
+  cacheControl: AnthropicCacheControl
+): ModelMessage[] {
+  const lastIndex = messages.length - 1;
+  const last = messages[lastIndex];
+  if (!last || (last.role !== "assistant" && last.role !== "tool")) return messages;
+  if (!Array.isArray(last.content) || last.content.length === 0) return messages;
+  const parts = last.content as unknown[];
+  const lastPart = parts[parts.length - 1];
+  if (
+    !isRecord(lastPart) ||
+    typeof lastPart.type !== "string" ||
+    !TRAJECTORY_CACHEABLE_PART_TYPES.has(lastPart.type)
+  )
+    return messages;
+  const existingProviderOptions = isRecord(lastPart.providerOptions)
+    ? lastPart.providerOptions
+    : {};
+  const existingAnthropic = isRecord(existingProviderOptions.anthropic)
+    ? existingProviderOptions.anthropic
+    : {};
+  if (existingAnthropic.cacheControl) return messages;
+  const nextMessages = [...messages];
+  nextMessages[lastIndex] = {
+    ...last,
+    content: [
+      ...parts.slice(0, -1),
+      {
+        ...lastPart,
+        providerOptions: {
+          ...existingProviderOptions,
+          anthropic: { ...existingAnthropic, cacheControl },
+        },
+      },
+    ],
+  } as ModelMessage;
+  return nextMessages;
 }
 
 function getRuntimeCacheControl(runtime: IAgentRuntime): AnthropicCacheControl {
@@ -329,7 +403,10 @@ function getRuntimeCacheControl(runtime: IAgentRuntime): AnthropicCacheControl {
   return ttl === "1h" ? { type: "ephemeral", ttl: "1h" } : { type: "ephemeral" };
 }
 
-type AnthropicCacheBreakpoint = { segmentIndex: number; cacheControl: AnthropicCacheControl };
+type AnthropicCacheBreakpoint = {
+  segmentIndex: number;
+  cacheControl: AnthropicCacheControl;
+};
 
 function isAnthropicCacheBreakpoint(value: unknown): value is AnthropicCacheBreakpoint {
   return (
@@ -344,11 +421,13 @@ function isAnthropicCacheBreakpoint(value: unknown): value is AnthropicCacheBrea
 
 function readAnthropicCacheBreakpoints(
   anthropicOptions: Record<string, unknown> | undefined,
-  maxBreakpoints: number
+  maxBreakpoints: number,
+  keepLatest = false
 ): AnthropicCacheBreakpoint[] {
   const raw = anthropicOptions?.cacheBreakpoints;
-  if (!Array.isArray(raw)) return [];
-  return raw.filter(isAnthropicCacheBreakpoint).slice(0, maxBreakpoints);
+  if (!Array.isArray(raw) || maxBreakpoints <= 0) return [];
+  const valid = raw.filter(isAnthropicCacheBreakpoint);
+  return keepLatest ? valid.slice(-maxBreakpoints) : valid.slice(0, maxBreakpoints);
 }
 
 /**
@@ -363,7 +442,10 @@ function buildSegmentedPromptUserContent(
   cacheBreakpoints: AnthropicCacheBreakpoint[]
 ): TextPart[] {
   if (cacheBreakpoints.length === 0) {
-    return promptSegments.map((seg) => ({ type: "text" as const, text: seg.content }));
+    return promptSegments.map((seg) => ({
+      type: "text" as const,
+      text: seg.content,
+    }));
   }
   const breakpointMap = new Map<number, AnthropicCacheControl>(
     cacheBreakpoints.map((bp) => [bp.segmentIndex, bp.cacheControl])
@@ -477,7 +559,11 @@ function buildStructuredOutput(responseSchema: unknown): NativeOutput {
 
   const schemaOptions =
     responseSchema && typeof responseSchema === "object" && "schema" in responseSchema
-      ? (responseSchema as { schema: unknown; name?: string; description?: string })
+      ? (responseSchema as {
+          schema: unknown;
+          name?: string;
+          description?: string;
+        })
       : { schema: responseSchema };
 
   return {
@@ -628,18 +714,31 @@ function buildGenerateParams(
   // Collect cacheBreakpoints for per-segment user-content injection.
   // Only used on the prompt-only path (no messages) together with promptSegments.
   // maxBreakpoints caps the number of slots used (Anthropic allows up to 3 user-content).
-  const maxBreakpoints =
+  const requestedMaxBreakpoints =
     typeof anthropicOptions?.maxBreakpoints === "number" &&
     Number.isInteger(anthropicOptions.maxBreakpoints) &&
     anthropicOptions.maxBreakpoints >= 0
       ? anthropicOptions.maxBreakpoints
       : 3;
-  const cacheBreakpoints = readAnthropicCacheBreakpoints(anthropicOptions, maxBreakpoints);
+  const reservesToolsBreakpoint =
+    isAnthropic &&
+    anthropicCacheControl &&
+    anthropicOptions?.cacheTools !== false &&
+    Boolean(paramsWithAttachments.tools && Object.keys(paramsWithAttachments.tools).length > 0);
+  const maxBreakpoints = Math.min(requestedMaxBreakpoints, reservesToolsBreakpoint ? 2 : 3);
+  const cacheBreakpoints = readAnthropicCacheBreakpoints(
+    anthropicOptions,
+    maxBreakpoints,
+    Boolean(reservesToolsBreakpoint)
+  );
   const promptSegments = Array.isArray(
     (paramsWithAttachments as { promptSegments?: unknown }).promptSegments
   )
-    ? ((paramsWithAttachments as { promptSegments?: Array<{ content: string; stable?: boolean }> })
-        .promptSegments ?? [])
+    ? ((
+        paramsWithAttachments as {
+          promptSegments?: Array<{ content: string; stable?: boolean }>;
+        }
+      ).promptSegments ?? [])
     : [];
 
   let finalWireMessages = wireMessages;
@@ -707,7 +806,7 @@ function buildGenerateParams(
   };
 
   // Strip local Anthropic cache options if we injected message-level cache
-  const wireAnthropicOptions = shouldInjectMessageLevelCache
+  const wireAnthropicOptions = isAnthropic
     ? stripLocalAnthropicCacheOptions(anthropicOptions)
     : anthropicOptions;
 
@@ -720,11 +819,26 @@ function buildGenerateParams(
     Object.keys(mergedProviderOptions).length > 0 ? mergedProviderOptions : undefined;
   const normalizedTools = readToolSet(paramsWithAttachments.tools);
   const normalizedToolChoice = readToolChoice(paramsWithAttachments.toolChoice);
+  const cacheToolsEnabled = anthropicOptions?.cacheTools !== false;
+  const wireTools =
+    isAnthropic && normalizedTools && cacheToolsEnabled && anthropicCacheControl
+      ? applyToolsCacheBreakpoint(normalizedTools, anthropicCacheControl)
+      : normalizedTools;
+  const cacheTrajectoryEnabled = anthropicOptions?.cacheTrajectory !== false;
+  const finalPromptOrMessages: NativePrompt =
+    isAnthropic && anthropicCacheControl && cacheTrajectoryEnabled && promptOrMessages.messages
+      ? {
+          messages: applyTrajectoryTailCacheBreakpoint(
+            promptOrMessages.messages,
+            anthropicCacheControl
+          ),
+        }
+      : promptOrMessages;
 
   type NativeProviderOptions = NativeTextParams["providerOptions"];
   const generateParams: NativeTextParams = {
     model: openrouter.chat(modelName) as LanguageModel,
-    ...promptOrMessages,
+    ...finalPromptOrMessages,
     // Omit system parameter when we injected message-level cache to prevent duplication
     ...(shouldInjectMessageLevelCache ? {} : { system: systemPrompt }),
     ...(supportsSampling
@@ -736,7 +850,7 @@ function buildGenerateParams(
         }
       : {}),
     ...(resolvedMaxOutput !== undefined ? { maxOutputTokens: resolvedMaxOutput } : {}),
-    ...(normalizedTools ? { tools: normalizedTools } : {}),
+    ...(wireTools ? { tools: wireTools } : {}),
     ...(normalizedToolChoice ? { toolChoice: normalizedToolChoice } : {}),
     ...(paramsWithAttachments.responseSchema
       ? { output: buildStructuredOutput(paramsWithAttachments.responseSchema) }


### PR DESCRIPTION
## Summary
- mirror plugin-anthropic's tools-array cache breakpoint in plugin-openrouter for Anthropic models
- stamp the final assistant/tool trajectory part on native-messages requests
- honor `cacheTools` / `cacheTrajectory` opt-outs and strip local controls before provider wire serialization
- reserve Anthropic's four-breakpoint budget and keep the latest planned segment breakpoints when tools consume a slot

Fixes #16129

## Verification (clean worktree, 2026-07-11)
Re-run in a fresh detached worktree of `origin/sol/16129-openrouter-cache` after `bun install` + `packages/core` build (the original description's "13 skipped / dependency skew" was an artifact of the author's broken pooled `node_modules` — there are **no** skip markers in the cache test file):

- `bun run --cwd plugins/plugin-openrouter typecheck` — **pass, 0 errors**
- `bun run --cwd plugins/plugin-openrouter test` (full unit lane) — **7 files, 59/59 passed, 0 skipped**
- `bunx vitest run __tests__/anthropic-cache.shape.test.ts` — **17/17 passed, 0 skipped**
- `bun run --cwd plugins/plugin-openrouter test:harness` (real-PGLite lane) — **1 file, 2/2 passed**

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - provider cache plumbing in plugins/plugin-openrouter/models/text.ts, no UI surface`.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - provider cache plumbing, no UI surface`.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - provider cache plumbing, no user-visible flow to record`.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: full plugin unit suite (59/59) + harness lane (2/2) + typecheck run clean in a fresh worktree at head commit `1a035a1`. The cache shape suite asserts the exact request bodies handed to the OpenRouter transport (tools-array breakpoint, trajectory-tail breakpoint, opt-outs, TTL, 4-breakpoint budget): [anthropic-cache.shape.test.ts](https://github.com/elizaOS/eliza/blob/1a035a1081827cc2190e15a4520671e5d68bf8a7/plugins/plugin-openrouter/__tests__/anthropic-cache.shape.test.ts).
  <details><summary>Test run output</summary>

  ```text
  RUN  v4.1.5 plugins/plugin-openrouter
  Test Files  7 passed (7)
       Tests  59 passed (59)
    Duration  6.60s

  anthropic-cache.shape.test.ts
  Test Files  1 passed (1)
       Tests  17 passed (17)

  test:harness (vitest.harness.config.ts, real PGLite)
  Test Files  1 passed (1)
       Tests  2 passed (2)

  typecheck: tsgo --noEmit -p tsconfig.json — exit 0
  ```
  </details>

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no live Anthropic-via-OpenRouter cache-write capture exists for this change; stating that honestly rather than fabricating one.` What is proven instead: deterministic shape tests intercept the outgoing provider request and assert `cache_control` placement on the tools array and trajectory tail exactly as Anthropic's API requires ([anthropic-cache.shape.test.ts](https://github.com/elizaOS/eliza/blob/1a035a1081827cc2190e15a4520671e5d68bf8a7/plugins/plugin-openrouter/__tests__/anthropic-cache.shape.test.ts)). No prompt/response semantics change — only cache breakpoint stamping on the wire format.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - provider cache plumbing, no frontend code path touched`.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the implementation and its wire-format proof on the branch — [models/text.ts](https://github.com/elizaOS/eliza/blob/1a035a1081827cc2190e15a4520671e5d68bf8a7/plugins/plugin-openrouter/models/text.ts) (tools + trajectory breakpoints, `cacheTools`/`cacheTrajectory` opt-outs, breakpoint-budget reservation, local-control stripping before serialization) and [anthropic-cache.shape.test.ts](https://github.com/elizaOS/eliza/blob/1a035a1081827cc2190e15a4520671e5d68bf8a7/plugins/plugin-openrouter/__tests__/anthropic-cache.shape.test.ts) (17 assertions over the serialized request bodies). Reviewed by hand: caller-provided per-tool/per-part cache control wins; non-Anthropic models untouched.

## Safety
- no lockfiles, binaries, Vite config, or HTML files changed
- no behavior change for non-Anthropic OpenRouter models
- existing caller-provided per-tool/per-part cache control wins
