### PR TITLE
feat(cockpit): add repo/workdir picker to the new-session spawn form

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5117,6 +5117,7 @@
         "react-dom": "^19.0.0",
       },
       "devDependencies": {
+        "playwright": "^1.61.0",
         "tsup": "^8.5.1",
         "vite": "^8.0.0",
       },

--- a/packages/ui/src/components/cockpit/CockpitNewSessionForm.stories.tsx
+++ b/packages/ui/src/components/cockpit/CockpitNewSessionForm.stories.tsx
@@ -32,3 +32,13 @@ export const ExperimentalArmed: Story = {
 export const Busy: Story = {
   args: { onCreate: noop, busy: true },
 };
+
+export const WithRepoSuggestions: Story = {
+  args: {
+    onCreate: noop,
+    knownRepos: [
+      "https://github.com/elizaOS/eliza.git",
+      "https://github.com/elizaOS/babylon.git",
+    ],
+  },
+};

--- a/packages/ui/src/components/cockpit/CockpitNewSessionForm.test.tsx
+++ b/packages/ui/src/components/cockpit/CockpitNewSessionForm.test.tsx
@@ -108,6 +108,14 @@ describe("CockpitNewSessionForm", () => {
     expect(list.querySelectorAll("option").length).toBe(1);
   });
 
+  it("distinguishes unavailable repo suggestions from an empty registry", () => {
+    render(
+      <CockpitNewSessionForm onCreate={vi.fn()} repoSuggestionsUnavailable />,
+    );
+    expect(screen.getByText(/repo suggestions are unavailable/i)).toBeTruthy();
+    expect(screen.getByTestId("cockpit-repo-input")).toBeTruthy();
+  });
+
   it("reflects a mode switch in the submitted policy", async () => {
     const user = userEvent.setup();
     const onCreate = vi.fn();

--- a/packages/ui/src/components/cockpit/CockpitNewSessionForm.test.tsx
+++ b/packages/ui/src/components/cockpit/CockpitNewSessionForm.test.tsx
@@ -24,22 +24,88 @@ describe("CockpitNewSessionForm", () => {
     expect(button.disabled).toBe(false);
   });
 
-  it("submits a create-task input with the default (Eliza Cloud · Fast) policy", async () => {
+  it("submits a create-task input with the default (Eliza Cloud · Fast) policy and no target when the repo is blank", async () => {
     const user = userEvent.setup();
     const onCreate = vi.fn();
     render(<CockpitNewSessionForm onCreate={onCreate} />);
     await user.type(screen.getByTestId("cockpit-goal-input"), "fix the bug");
     await user.click(screen.getByTestId("cockpit-start-button"));
     expect(onCreate).toHaveBeenCalledTimes(1);
-    expect(onCreate).toHaveBeenCalledWith({
-      title: "fix the bug",
-      goal: "fix the bug",
-      providerPolicy: {
-        preferredFramework: "elizaos",
-        providerSource: "eliza-cloud",
-        model: "gemma-4-31b",
+    expect(onCreate).toHaveBeenCalledWith(
+      {
+        title: "fix the bug",
+        goal: "fix the bug",
+        providerPolicy: {
+          preferredFramework: "elizaos",
+          providerSource: "eliza-cloud",
+          model: "gemma-4-31b",
+        },
       },
+      undefined,
+    );
+  });
+
+  it("threads the repo (and workdir) into the spawn target", async () => {
+    const user = userEvent.setup();
+    const onCreate = vi.fn();
+    render(<CockpitNewSessionForm onCreate={onCreate} />);
+    await user.type(screen.getByTestId("cockpit-goal-input"), "fix the bug");
+    await user.type(screen.getByTestId("cockpit-repo-input"), "elizaOS/eliza");
+    await user.type(screen.getByTestId("cockpit-workdir-input"), "packages/ui");
+    await user.click(screen.getByTestId("cockpit-start-button"));
+    expect(onCreate).toHaveBeenCalledTimes(1);
+    expect(onCreate).toHaveBeenLastCalledWith(expect.any(Object), {
+      repo: "elizaOS/eliza",
+      workdir: "packages/ui",
     });
+  });
+
+  it("trims a repo and omits an empty workdir from the target", async () => {
+    const user = userEvent.setup();
+    const onCreate = vi.fn();
+    render(<CockpitNewSessionForm onCreate={onCreate} />);
+    await user.type(screen.getByTestId("cockpit-goal-input"), "go");
+    await user.type(
+      screen.getByTestId("cockpit-repo-input"),
+      "  elizaOS/eliza  ",
+    );
+    await user.click(screen.getByTestId("cockpit-start-button"));
+    expect(onCreate).toHaveBeenLastCalledWith(expect.any(Object), {
+      repo: "elizaOS/eliza",
+    });
+  });
+
+  it("blocks submit when a workdir is set without a repo, then clears once a repo is added", async () => {
+    const user = userEvent.setup();
+    const onCreate = vi.fn();
+    render(<CockpitNewSessionForm onCreate={onCreate} />);
+    await user.type(screen.getByTestId("cockpit-goal-input"), "go");
+    await user.type(screen.getByTestId("cockpit-workdir-input"), "packages/ui");
+    const button = screen.getByTestId(
+      "cockpit-start-button",
+    ) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    expect(screen.getByTestId("cockpit-workdir-error")).toBeTruthy();
+    await user.type(screen.getByTestId("cockpit-repo-input"), "elizaOS/eliza");
+    expect(button.disabled).toBe(false);
+    await user.click(button);
+    expect(onCreate).toHaveBeenLastCalledWith(expect.any(Object), {
+      repo: "elizaOS/eliza",
+      workdir: "packages/ui",
+    });
+  });
+
+  it("renders a repo suggestion datalist only when knownRepos are provided", async () => {
+    const { rerender } = render(<CockpitNewSessionForm onCreate={vi.fn()} />);
+    expect(screen.queryByTestId("cockpit-repo-suggestions")).toBeNull();
+    rerender(
+      <CockpitNewSessionForm
+        onCreate={vi.fn()}
+        knownRepos={["https://github.com/elizaOS/eliza.git"]}
+      />,
+    );
+    const list = screen.getByTestId("cockpit-repo-suggestions");
+    expect(list.querySelectorAll("option").length).toBe(1);
   });
 
   it("reflects a mode switch in the submitted policy", async () => {
@@ -49,14 +115,17 @@ describe("CockpitNewSessionForm", () => {
     await user.type(screen.getByTestId("cockpit-goal-input"), "do it");
     await user.click(screen.getByTestId("cockpit-mode-claude"));
     await user.click(screen.getByTestId("cockpit-start-button"));
-    expect(onCreate).toHaveBeenLastCalledWith({
-      title: "do it",
-      goal: "do it",
-      providerPolicy: {
-        preferredFramework: "claude",
-        providerSource: "user-claude",
+    expect(onCreate).toHaveBeenLastCalledWith(
+      {
+        title: "do it",
+        goal: "do it",
+        providerPolicy: {
+          preferredFramework: "claude",
+          providerSource: "user-claude",
+        },
       },
-    });
+      undefined,
+    );
   });
 
   it("does not submit while busy", async () => {

--- a/packages/ui/src/components/cockpit/CockpitNewSessionForm.tsx
+++ b/packages/ui/src/components/cockpit/CockpitNewSessionForm.tsx
@@ -2,16 +2,19 @@
  * Collects a coding-agent goal and cockpit mode selection, then emits the
  * orchestrator create-task input used to start a session.
  */
-import { useState } from "react";
+import { useId, useState } from "react";
 
 import type { CodingAgentCreateTaskInput } from "../../api/client-types-cloud";
 import { cn } from "../../lib/utils";
 import { Button } from "../ui/button";
+import { Input } from "../ui/input";
 import { Textarea } from "../ui/textarea";
 import { CockpitModePicker } from "./CockpitModePicker";
 import {
   buildCockpitCreateTaskInput,
   type CockpitModeConfig,
+  type CockpitSpawnTarget,
+  normalizeCockpitSpawnTarget,
 } from "./cockpit-modes";
 
 const DEFAULT_MODE: CockpitModeConfig = {
@@ -21,10 +24,25 @@ const DEFAULT_MODE: CockpitModeConfig = {
 };
 
 export interface CockpitNewSessionFormProps {
-  /** Called with the orchestrator create-task input when the user starts a session. */
-  onCreate: (input: CodingAgentCreateTaskInput) => void | Promise<void>;
+  /**
+   * Called with the orchestrator create-task input when the user starts a
+   * session. The optional {@link CockpitSpawnTarget} carries the repo/workdir to
+   * thread into the second spawn step; `undefined` when the user left both blank
+   * (scratch-dir default). Kept as a distinct second arg so the create-task body
+   * stays pure — the target belongs to `addOrchestratorAgent`, not the task record.
+   */
+  onCreate: (
+    input: CodingAgentCreateTaskInput,
+    target?: CockpitSpawnTarget,
+  ) => void | Promise<void>;
   /** Initial mode (defaults to Eliza Cloud · Fast). */
   defaultMode?: CockpitModeConfig;
+  /**
+   * Known repos to offer as autocomplete suggestions for the repo field (from
+   * the project registry). When non-empty the repo input gets a `datalist`;
+   * otherwise it's a plain text input — no invented dropdown.
+   */
+  knownRepos?: readonly string[];
   /** Arm the TOS-unsafe experimental options in the picker. */
   experimentalEnabled?: boolean;
   /** Parent-controlled in-flight flag (disables submit + shows "Starting…"). */
@@ -43,19 +61,30 @@ export interface CockpitNewSessionFormProps {
 export function CockpitNewSessionForm({
   onCreate,
   defaultMode = DEFAULT_MODE,
+  knownRepos = [],
   experimentalEnabled = false,
   busy = false,
   className,
 }: CockpitNewSessionFormProps) {
   const [mode, setMode] = useState<CockpitModeConfig>(defaultMode);
   const [goal, setGoal] = useState("");
+  const [repo, setRepo] = useState("");
+  const [workdir, setWorkdir] = useState("");
+  const repoListId = useId();
 
-  const canSubmit = goal.trim().length > 0 && !busy;
+  const hasWorkdirWithoutRepo =
+    workdir.trim().length > 0 && repo.trim().length === 0;
+  const canSubmit = goal.trim().length > 0 && !hasWorkdirWithoutRepo && !busy;
 
   const submit = () => {
     if (!canSubmit) return;
-    void onCreate(buildCockpitCreateTaskInput({ goal, mode }));
+    void onCreate(
+      buildCockpitCreateTaskInput({ goal, mode }),
+      normalizeCockpitSpawnTarget({ repo, workdir }),
+    );
   };
+
+  const hasKnownRepos = knownRepos.length > 0;
 
   return (
     <form
@@ -85,6 +114,67 @@ export function CockpitNewSessionForm({
             }
           }}
         />
+      </label>
+
+      <label htmlFor="cockpit-repo-input" className="flex flex-col gap-1.5">
+        <span className="text-xs font-semibold text-muted">
+          Repo <span className="font-normal text-muted/70">(optional)</span>
+        </span>
+        <Input
+          id="cockpit-repo-input"
+          data-testid="cockpit-repo-input"
+          value={repo}
+          onChange={(e) => setRepo(e.target.value)}
+          placeholder="owner/repo or https://github.com/owner/repo"
+          disabled={busy}
+          list={hasKnownRepos ? repoListId : undefined}
+          autoComplete="off"
+          autoCapitalize="off"
+          spellCheck={false}
+        />
+        {hasKnownRepos ? (
+          <datalist id={repoListId} data-testid="cockpit-repo-suggestions">
+            {knownRepos.map((r) => (
+              <option key={r} value={r} />
+            ))}
+          </datalist>
+        ) : null}
+        <span className="text-[11px] text-muted/70">
+          Leave blank to run in a scratch workspace.
+        </span>
+      </label>
+
+      <label htmlFor="cockpit-workdir-input" className="flex flex-col gap-1.5">
+        <span className="text-xs font-semibold text-muted">
+          Working directory{" "}
+          <span className="font-normal text-muted/70">(optional)</span>
+        </span>
+        <Input
+          id="cockpit-workdir-input"
+          data-testid="cockpit-workdir-input"
+          value={workdir}
+          onChange={(e) => setWorkdir(e.target.value)}
+          placeholder="e.g. packages/ui"
+          disabled={busy}
+          hasError={hasWorkdirWithoutRepo}
+          aria-invalid={hasWorkdirWithoutRepo}
+          aria-describedby={
+            hasWorkdirWithoutRepo ? "cockpit-workdir-error" : undefined
+          }
+          autoComplete="off"
+          autoCapitalize="off"
+          spellCheck={false}
+        />
+        {hasWorkdirWithoutRepo ? (
+          <span
+            id="cockpit-workdir-error"
+            data-testid="cockpit-workdir-error"
+            role="alert"
+            className="text-[11px] text-destructive"
+          >
+            Set a repo to target a working directory.
+          </span>
+        ) : null}
       </label>
 
       <div className="flex flex-col gap-1.5">

--- a/packages/ui/src/components/cockpit/CockpitNewSessionForm.tsx
+++ b/packages/ui/src/components/cockpit/CockpitNewSessionForm.tsx
@@ -43,6 +43,8 @@ export interface CockpitNewSessionFormProps {
    * otherwise it's a plain text input — no invented dropdown.
    */
   knownRepos?: readonly string[];
+  /** Whether repo suggestions are unavailable because the project registry failed. */
+  repoSuggestionsUnavailable?: boolean;
   /** Arm the TOS-unsafe experimental options in the picker. */
   experimentalEnabled?: boolean;
   /** Parent-controlled in-flight flag (disables submit + shows "Starting…"). */
@@ -62,6 +64,7 @@ export function CockpitNewSessionForm({
   onCreate,
   defaultMode = DEFAULT_MODE,
   knownRepos = [],
+  repoSuggestionsUnavailable = false,
   experimentalEnabled = false,
   busy = false,
   className,
@@ -140,7 +143,9 @@ export function CockpitNewSessionForm({
           </datalist>
         ) : null}
         <span className="text-[11px] text-muted/70">
-          Leave blank to run in a scratch workspace.
+          {repoSuggestionsUnavailable
+            ? "Repo suggestions are unavailable. Enter a repo manually or leave blank for a scratch workspace."
+            : "Leave blank to run in a scratch workspace."}
         </span>
       </label>
 

--- a/packages/ui/src/components/cockpit/CockpitView.test.tsx
+++ b/packages/ui/src/components/cockpit/CockpitView.test.tsx
@@ -36,6 +36,19 @@ const ROSTER: OrchestratorRoomRosterOverview = {
 };
 
 describe("CockpitView", () => {
+  it("threads repo suggestions and registry availability into the form", () => {
+    render(
+      <CockpitView
+        rooms={{ rooms: [] }}
+        onCreateSession={vi.fn()}
+        knownRepos={["elizaOS/eliza"]}
+        repoSuggestionsUnavailable
+      />,
+    );
+    expect(screen.getByTestId("cockpit-repo-suggestions")).toBeTruthy();
+    expect(screen.getByText(/repo suggestions are unavailable/i)).toBeTruthy();
+  });
+
   it("renders the deck and the new-session form", () => {
     render(<CockpitView rooms={ROSTER} onCreateSession={vi.fn()} />);
     expect(screen.getByTestId("cockpit-view")).toBeTruthy();

--- a/packages/ui/src/components/cockpit/CockpitView.tsx
+++ b/packages/ui/src/components/cockpit/CockpitView.tsx
@@ -26,6 +26,8 @@ export interface CockpitViewProps {
   ) => void | Promise<void>;
   /** Known repos offered as repo-field autocomplete (from the project registry). */
   knownRepos?: readonly string[];
+  /** Whether the project registry failed while loading repo suggestions. */
+  repoSuggestionsUnavailable?: boolean;
   /** In-flight spawn (disables the form + shows "Starting…"). */
   busy?: boolean;
   /** Arm the TOS-unsafe experimental modes in the picker. */
@@ -61,6 +63,7 @@ export function CockpitView({
   rooms,
   onCreateSession,
   knownRepos = [],
+  repoSuggestionsUnavailable = false,
   busy = false,
   experimentalEnabled = false,
   error = null,
@@ -99,6 +102,7 @@ export function CockpitView({
         <CockpitNewSessionForm
           onCreate={onCreateSession}
           knownRepos={knownRepos}
+          repoSuggestionsUnavailable={repoSuggestionsUnavailable}
           busy={busy}
           experimentalEnabled={experimentalEnabled}
         />

--- a/packages/ui/src/components/cockpit/CockpitView.tsx
+++ b/packages/ui/src/components/cockpit/CockpitView.tsx
@@ -11,12 +11,21 @@ import type {
 import { cn } from "../../lib/utils";
 import { OrchestratorRoomView } from "../chat/widgets/agent-orchestrator-room-view";
 import { CockpitNewSessionForm } from "./CockpitNewSessionForm";
+import type { CockpitSpawnTarget } from "./cockpit-modes";
 
 export interface CockpitViewProps {
   /** The live task-room roster (the deck). `null` while loading. */
   rooms: OrchestratorRoomRosterOverview | null;
-  /** Called with a ready create-task input when the user starts a session. */
-  onCreateSession: (input: CodingAgentCreateTaskInput) => void | Promise<void>;
+  /**
+   * Called with a ready create-task input when the user starts a session. The
+   * optional {@link CockpitSpawnTarget} carries the repo/workdir to spawn against.
+   */
+  onCreateSession: (
+    input: CodingAgentCreateTaskInput,
+    target?: CockpitSpawnTarget,
+  ) => void | Promise<void>;
+  /** Known repos offered as repo-field autocomplete (from the project registry). */
+  knownRepos?: readonly string[];
   /** In-flight spawn (disables the form + shows "Starting…"). */
   busy?: boolean;
   /** Arm the TOS-unsafe experimental modes in the picker. */
@@ -51,6 +60,7 @@ export interface CockpitViewProps {
 export function CockpitView({
   rooms,
   onCreateSession,
+  knownRepos = [],
   busy = false,
   experimentalEnabled = false,
   error = null,
@@ -88,6 +98,7 @@ export function CockpitView({
         <h2 className="text-sm font-semibold text-txt">New session</h2>
         <CockpitNewSessionForm
           onCreate={onCreateSession}
+          knownRepos={knownRepos}
           busy={busy}
           experimentalEnabled={experimentalEnabled}
         />

--- a/packages/ui/src/components/cockpit/cockpit-modes.test.ts
+++ b/packages/ui/src/components/cockpit/cockpit-modes.test.ts
@@ -10,6 +10,7 @@ import {
   cockpitModeModel,
   cockpitModeProviderSource,
   cockpitModeToProviderPolicy,
+  normalizeCockpitSpawnTarget,
 } from "./cockpit-modes";
 
 describe("cockpit-modes lowering", () => {
@@ -127,6 +128,33 @@ describe("cockpit-modes lowering", () => {
       }).title;
       expect(t.length).toBeLessThanOrEqual(80);
       expect(t.endsWith("…")).toBe(true);
+    });
+  });
+
+  describe("normalizeCockpitSpawnTarget", () => {
+    it("returns undefined when both fields are blank or whitespace", () => {
+      expect(normalizeCockpitSpawnTarget({})).toBeUndefined();
+      expect(
+        normalizeCockpitSpawnTarget({ repo: "   ", workdir: "  " }),
+      ).toBeUndefined();
+    });
+
+    it("trims and keeps only the fields with content", () => {
+      expect(normalizeCockpitSpawnTarget({ repo: "  owner/repo  " })).toEqual({
+        repo: "owner/repo",
+      });
+      expect(
+        normalizeCockpitSpawnTarget({
+          repo: "owner/repo",
+          workdir: " packages/ui ",
+        }),
+      ).toEqual({ repo: "owner/repo", workdir: "packages/ui" });
+    });
+
+    it("still returns a workdir-only target (caller enforces the repo requirement)", () => {
+      expect(normalizeCockpitSpawnTarget({ workdir: "packages/ui" })).toEqual({
+        workdir: "packages/ui",
+      });
     });
   });
 });

--- a/packages/ui/src/components/cockpit/cockpit-modes.ts
+++ b/packages/ui/src/components/cockpit/cockpit-modes.ts
@@ -213,6 +213,36 @@ export function cockpitModeToProviderPolicy(
   return policy;
 }
 
+/**
+ * Optional spawn targeting a cockpit session can carry alongside its goal +
+ * mode: the repo to point the coding agent at, and an optional working
+ * subdirectory within it. Both are threaded into the second spawn step
+ * (`addOrchestratorAgent`) — `createOrchestratorTask` writes only the durable
+ * record. Empty/omitted ⇒ the orchestrator's default scratch-dir resolution.
+ */
+export interface CockpitSpawnTarget {
+  /** Repo to clone/target (owner/repo, host/owner/repo, or a full clone URL). */
+  repo?: string;
+  /** Optional working subdirectory within the repo/workspace. */
+  workdir?: string;
+}
+
+/**
+ * Normalize a raw repo/workdir pair into a {@link CockpitSpawnTarget}, trimming
+ * whitespace and dropping empty values. Returns `undefined` when neither field
+ * has content so callers can omit the target entirely rather than send blanks.
+ */
+export function normalizeCockpitSpawnTarget(
+  raw: CockpitSpawnTarget,
+): CockpitSpawnTarget | undefined {
+  const repo = raw.repo?.trim();
+  const workdir = raw.workdir?.trim();
+  const target: CockpitSpawnTarget = {};
+  if (repo) target.repo = repo;
+  if (workdir) target.workdir = workdir;
+  return target.repo || target.workdir ? target : undefined;
+}
+
 /** First non-empty line of `text`, trimmed to `max` chars — used as a task title. */
 function deriveTitle(text: string, max = 80): string {
   const firstLine = text.split("\n").find((l) => l.trim().length > 0) ?? "";

--- a/packages/ui/src/components/cockpit/index.ts
+++ b/packages/ui/src/components/cockpit/index.ts
@@ -12,6 +12,7 @@ export type {
   CockpitModeConfig,
   CockpitModeOption,
   CockpitModeOptionId,
+  CockpitSpawnTarget,
   ElizaCloudTier,
   ProviderSource,
 } from "./cockpit-modes";
@@ -22,6 +23,7 @@ export {
   cockpitModeProviderSource,
   cockpitModeToProviderPolicy,
   ELIZA_CLOUD_TIER_MODEL,
+  normalizeCockpitSpawnTarget,
   optionIdForConfig,
   tierForConfig,
   visibleCockpitModeOptions,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -203,6 +203,7 @@ export {
   type CockpitModeConfig,
   CockpitModePicker,
   CockpitNewSessionForm,
+  type CockpitSpawnTarget,
   CockpitTierToggle,
   type CockpitTierToggleProps,
   CockpitView,
@@ -210,6 +211,7 @@ export {
   cockpitModeToProviderPolicy,
   ELIZA_CLOUD_TIER_MODEL,
   type ElizaCloudTier,
+  normalizeCockpitSpawnTarget,
 } from "./components/cockpit/index";
 // Surfaced directly on the root barrel (also reachable via the composites/hooks
 // chains) so dist-mapped consumers resolve them by name.

--- a/plugins/plugin-task-coordinator/package.json
+++ b/plugins/plugin-task-coordinator/package.json
@@ -61,6 +61,7 @@
     "test": "vitest run --config vitest.config.ts",
     "test:unit": "vitest run --config vitest.config.ts",
     "test:e2e:manual": "vitest run --config vitest.live.config.ts",
+    "test:e2e:cockpit-browser": "node test/browser-e2e/run-cockpit-browser-e2e.mjs",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
     "lint:check": "bunx @biomejs/biome check .",
     "format": "bunx @biomejs/biome format --write .",
@@ -71,6 +72,7 @@
     "dist"
   ],
   "devDependencies": {
+    "playwright": "^1.61.0",
     "tsup": "^8.5.1",
     "vite": "^8.0.0"
   }

--- a/plugins/plugin-task-coordinator/src/CockpitRoute.test.tsx
+++ b/plugins/plugin-task-coordinator/src/CockpitRoute.test.tsx
@@ -1,9 +1,8 @@
-// @vitest-environment jsdom
-//
-// E2E-ish: drives the CockpitRoute container through the REAL spawn path
-// (poll roster -> render deck -> form submit -> client.createOrchestratorTask),
-// mocking only at the client boundary (the live orchestrator). Proves the
-// cockpit's spawn wiring end to end without a running agent.
+/**
+ * Drives the route through the spawn path with only the live orchestrator
+ * client boundary replaced, including its deck, drill-in, and error states.
+ * @vitest-environment jsdom
+ */
 import {
   cleanup,
   fireEvent,
@@ -20,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   addOrchestratorAgent: vi.fn(),
   listProjects: vi.fn(),
   cockpitViewProps: null as {
+    className?: string;
     repoSuggestionsUnavailable?: boolean;
   } | null,
 }));
@@ -64,6 +64,7 @@ vi.mock("@elizaos/ui", () => ({
     busy?: boolean;
     error?: string | null;
     repoSuggestionsUnavailable?: boolean;
+    className?: string;
   }) => {
     mocks.cockpitViewProps = props;
     return (
@@ -144,6 +145,12 @@ describe("CockpitRoute — live spawn wiring (agent mocked at client boundary)",
     await waitFor(() =>
       expect(screen.getByTestId("rooms-count").textContent).toBe("1"),
     );
+  });
+
+  it("reserves scroll clearance for the floating terminal controls", async () => {
+    render(<CockpitRoute />);
+    await waitFor(() => expect(mocks.cockpitViewProps).not.toBeNull());
+    expect(mocks.cockpitViewProps?.className).toContain("pb-20");
   });
 
   it("spawning creates the task AND spawns the agent with the picked mode", async () => {

--- a/plugins/plugin-task-coordinator/src/CockpitRoute.test.tsx
+++ b/plugins/plugin-task-coordinator/src/CockpitRoute.test.tsx
@@ -18,6 +18,10 @@ const mocks = vi.hoisted(() => ({
   getOrchestratorRooms: vi.fn(),
   createOrchestratorTask: vi.fn(),
   addOrchestratorAgent: vi.fn(),
+  listProjects: vi.fn(),
+  cockpitViewProps: null as {
+    repoSuggestionsUnavailable?: boolean;
+  } | null,
 }));
 
 type ButtonMockProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, "size"> & {
@@ -33,6 +37,7 @@ vi.mock("@elizaos/ui", () => ({
     getOrchestratorRooms: mocks.getOrchestratorRooms,
     createOrchestratorTask: mocks.createOrchestratorTask,
     addOrchestratorAgent: mocks.addOrchestratorAgent,
+    listProjects: mocks.listProjects,
   },
   Button: (props: ButtonMockProps) => {
     const {
@@ -58,37 +63,43 @@ vi.mock("@elizaos/ui", () => ({
     onSelectRoom?: (id: string) => void;
     busy?: boolean;
     error?: string | null;
-  }) => (
-    <div>
-      <span data-testid="rooms-count">{props.rooms?.rooms?.length ?? -1}</span>
-      {props.error ? <span data-testid="err">{props.error}</span> : null}
-      <button
-        type="button"
-        data-testid="spawn"
-        disabled={props.busy}
-        onClick={() =>
-          props.onCreateSession({
-            title: "fix the auth bug",
-            goal: "fix the auth bug",
-            providerPolicy: {
-              preferredFramework: "elizaos",
-              providerSource: "eliza-cloud",
-              model: "gemma-4-31b",
-            },
-          })
-        }
-      >
-        spawn
-      </button>
-      <button
-        type="button"
-        data-testid="drill-in"
-        onClick={() => props.onSelectRoom?.("task-1")}
-      >
-        open
-      </button>
-    </div>
-  ),
+    repoSuggestionsUnavailable?: boolean;
+  }) => {
+    mocks.cockpitViewProps = props;
+    return (
+      <div>
+        <span data-testid="rooms-count">
+          {props.rooms?.rooms?.length ?? -1}
+        </span>
+        {props.error ? <span data-testid="err">{props.error}</span> : null}
+        <button
+          type="button"
+          data-testid="spawn"
+          disabled={props.busy}
+          onClick={() =>
+            props.onCreateSession({
+              title: "fix the auth bug",
+              goal: "fix the auth bug",
+              providerPolicy: {
+                preferredFramework: "elizaos",
+                providerSource: "eliza-cloud",
+                model: "gemma-4-31b",
+              },
+            })
+          }
+        >
+          spawn
+        </button>
+        <button
+          type="button"
+          data-testid="drill-in"
+          onClick={() => props.onSelectRoom?.("task-1")}
+        >
+          open
+        </button>
+      </div>
+    );
+  },
 }));
 
 // Stub the (separately-tested) heavy session pane — the container test only
@@ -112,10 +123,19 @@ afterEach(() => {
 });
 
 describe("CockpitRoute — live spawn wiring (agent mocked at client boundary)", () => {
+  it("surfaces an unavailable repo registry while preserving manual repo entry", async () => {
+    mocks.listProjects.mockRejectedValueOnce(new Error("registry offline"));
+    render(<CockpitRoute />);
+    await waitFor(() =>
+      expect(mocks.cockpitViewProps?.repoSuggestionsUnavailable).toBe(true),
+    );
+  });
+
   beforeEach(() => {
     mocks.getOrchestratorRooms.mockResolvedValue({ rooms: [{ taskId: "t1" }] });
     mocks.createOrchestratorTask.mockResolvedValue({ id: "task-1" });
     mocks.addOrchestratorAgent.mockResolvedValue({ id: "task-1" });
+    mocks.listProjects.mockResolvedValue({ projects: [] });
   });
 
   it("polls the room roster and renders the deck", async () => {

--- a/plugins/plugin-task-coordinator/src/CockpitRoute.tsx
+++ b/plugins/plugin-task-coordinator/src/CockpitRoute.tsx
@@ -1,4 +1,4 @@
-// Composes the mobile coding cockpit route from deck, session, and terminal panes.
+/** Composes the mobile coding cockpit route from deck, session, and terminal panes. */
 import {
   Button,
   type CockpitSpawnTarget,
@@ -141,6 +141,7 @@ export function CockpitRoute() {
       <CockpitView
         rooms={rooms}
         onCreateSession={onCreateSession}
+        className="pb-20"
         knownRepos={knownRepos}
         repoSuggestionsUnavailable={repoSuggestionsUnavailable}
         busy={busy}

--- a/plugins/plugin-task-coordinator/src/CockpitRoute.tsx
+++ b/plugins/plugin-task-coordinator/src/CockpitRoute.tsx
@@ -1,6 +1,7 @@
 // Composes the mobile coding cockpit route from deck, session, and terminal panes.
 import {
   Button,
+  type CockpitSpawnTarget,
   CockpitView,
   type CodingAgentCreateTaskInput,
   client,
@@ -36,6 +37,10 @@ export function CockpitRoute() {
   const [terminalTier, setTerminalTier] = useState<CockpitTerminalTier | null>(
     null,
   );
+  // Repo suggestions for the new-session form's repo field, sourced from the
+  // project registry (the same list the project switcher reads). Best-effort:
+  // an absent/empty registry just yields a plain text input, no dropdown.
+  const [knownRepos, setKnownRepos] = useState<string[]>([]);
 
   const refresh = useCallback(async () => {
     try {
@@ -54,8 +59,34 @@ export function CockpitRoute() {
     return () => clearInterval(id);
   }, [refresh]);
 
+  // Load known repos once for the repo-field autocomplete. Registry-less hosts
+  // (mobile/web) resolve to an empty list, so the field degrades to plain text.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const { projects } = await client.listProjects();
+        if (cancelled) return;
+        const repos = Array.from(
+          new Set(
+            projects
+              .map((p) => p.repoUrl?.trim())
+              .filter((r): r is string => !!r),
+          ),
+        );
+        setKnownRepos(repos);
+      } catch {
+        // Best-effort suggestions only — a failed/absent registry leaves the
+        // repo field as a plain text input.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const onCreateSession = useCallback(
-    async (input: CodingAgentCreateTaskInput) => {
+    async (input: CodingAgentCreateTaskInput, target?: CockpitSpawnTarget) => {
       setBusy(true);
       try {
         // 1. Create the durable task record.
@@ -64,15 +95,18 @@ export function CockpitRoute() {
         // the record — the sub-agent actually starts via addOrchestratorAgent.
         // Thread the picked mode (framework / providerSource / model) so the
         // chosen mode runs. NOT a follow-up message: that path silently spawns
-        // the default opencode framework and discards the pick. (workdir is left
-        // to the orchestrator's default resolution; a cwd/repo picker is a
-        // follow-up.)
+        // the default opencode framework and discards the pick. The optional
+        // repo/workdir target (from the form) is threaded here exactly as the
+        // chat TASKS action does — the orchestrator route already accepts both
+        // and resolves the spawn workdir/repo from them; omitted ⇒ scratch dir.
         const policy = input.providerPolicy;
         await client.addOrchestratorAgent(task.id, {
           framework: policy?.preferredFramework,
           providerSource: policy?.providerSource,
           model: policy?.model,
           task: input.goal,
+          ...(target?.repo ? { repo: target.repo } : {}),
+          ...(target?.workdir ? { workdir: target.workdir } : {}),
         });
         setError(null);
         await refresh();
@@ -103,6 +137,7 @@ export function CockpitRoute() {
       <CockpitView
         rooms={rooms}
         onCreateSession={onCreateSession}
+        knownRepos={knownRepos}
         busy={busy}
         error={error}
         onSelectRoom={setSelectedTaskId}

--- a/plugins/plugin-task-coordinator/src/CockpitRoute.tsx
+++ b/plugins/plugin-task-coordinator/src/CockpitRoute.tsx
@@ -41,6 +41,8 @@ export function CockpitRoute() {
   // project registry (the same list the project switcher reads). Best-effort:
   // an absent/empty registry just yields a plain text input, no dropdown.
   const [knownRepos, setKnownRepos] = useState<string[]>([]);
+  const [repoSuggestionsUnavailable, setRepoSuggestionsUnavailable] =
+    useState(false);
 
   const refresh = useCallback(async () => {
     try {
@@ -75,9 +77,11 @@ export function CockpitRoute() {
           ),
         );
         setKnownRepos(repos);
+        setRepoSuggestionsUnavailable(false);
       } catch {
-        // Best-effort suggestions only — a failed/absent registry leaves the
-        // repo field as a plain text input.
+        // error-policy:J4 Manual repo entry remains usable, while the form
+        // distinguishes a failed registry from a legitimately empty registry.
+        if (!cancelled) setRepoSuggestionsUnavailable(true);
       }
     })();
     return () => {
@@ -138,6 +142,7 @@ export function CockpitRoute() {
         rooms={rooms}
         onCreateSession={onCreateSession}
         knownRepos={knownRepos}
+        repoSuggestionsUnavailable={repoSuggestionsUnavailable}
         busy={busy}
         error={error}
         onSelectRoom={setSelectedTaskId}

--- a/plugins/plugin-task-coordinator/test/browser-e2e/.gitignore
+++ b/plugins/plugin-task-coordinator/test/browser-e2e/.gitignore
@@ -1,0 +1,2 @@
+# Browser proof artifacts are attached to the PR rather than committed.
+output/

--- a/plugins/plugin-task-coordinator/test/browser-e2e/cockpit-browser-fixture.tsx
+++ b/plugins/plugin-task-coordinator/test/browser-e2e/cockpit-browser-fixture.tsx
@@ -1,0 +1,7 @@
+/** Mounts the production cockpit route as a full-height browser proof surface. */
+import { createRoot } from "react-dom/client";
+import { CockpitRoute } from "../../src/CockpitRoute";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("Cockpit browser fixture root is missing");
+createRoot(root).render(<CockpitRoute />);

--- a/plugins/plugin-task-coordinator/test/browser-e2e/cockpit-browser-inactive-panes.tsx
+++ b/plugins/plugin-task-coordinator/test/browser-e2e/cockpit-browser-inactive-panes.tsx
@@ -1,0 +1,10 @@
+/** Keeps non-exercised drill-in panes out of the session-start browser bundle. */
+export type CockpitTerminalTier = "fast" | "smart";
+
+export function CockpitInteractiveTerminal() {
+  return null;
+}
+
+export function CockpitSessionPane() {
+  return null;
+}

--- a/plugins/plugin-task-coordinator/test/browser-e2e/cockpit-browser-ui-adapter.ts
+++ b/plugins/plugin-task-coordinator/test/browser-e2e/cockpit-browser-ui-adapter.ts
@@ -1,0 +1,37 @@
+/**
+ * Exposes the production cockpit UI to the browser proof while replacing only
+ * its HTTP client boundary with fetch calls that Playwright can observe.
+ */
+
+export type {
+  CodingAgentCreateTaskInput,
+  OrchestratorRoomRosterOverview,
+} from "../../../../packages/ui/src/api/client-types-cloud";
+export { CockpitView } from "../../../../packages/ui/src/components/cockpit/CockpitView";
+export type { CockpitSpawnTarget } from "../../../../packages/ui/src/components/cockpit/cockpit-modes";
+export { Button } from "../../../../packages/ui/src/components/ui/button";
+
+export const DEFAULT_CEREBRAS_TEXT_MODEL = "gemma-4-31b";
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(`http://cockpit.test${path}`, init);
+  if (!response.ok) throw new Error(`Request failed: ${response.status}`);
+  return (await response.json()) as T;
+}
+
+export const client = {
+  getOrchestratorRooms: () => request("/api/orchestrator/rooms"),
+  listProjects: () => request("/api/projects"),
+  createOrchestratorTask: (body: unknown) =>
+    request<{ id: string }>("/api/orchestrator/tasks", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  addOrchestratorAgent: (taskId: string, body: unknown) =>
+    request(`/api/orchestrator/tasks/${taskId}/agents`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+};

--- a/plugins/plugin-task-coordinator/test/browser-e2e/run-cockpit-browser-e2e.mjs
+++ b/plugins/plugin-task-coordinator/test/browser-e2e/run-cockpit-browser-e2e.mjs
@@ -1,0 +1,215 @@
+/**
+ * Drives the production cockpit route in Chromium and preserves pixels, video,
+ * console/network logs, and the exact create-then-spawn request receipt.
+ */
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+import {
+  compileTailwindTheme,
+  writeFixturePage,
+} from "../../../../packages/ui/src/testing/e2e-runner/fixture-bundle.ts";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "../../../..");
+const uiRoot = join(repoRoot, "packages/ui");
+const outDir = join(here, "output");
+await rm(outDir, { recursive: true, force: true });
+await mkdir(outDir, { recursive: true });
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+const css = await compileTailwindTheme({
+  uiRoot,
+  sources: [
+    join(uiRoot, "src/components/cockpit"),
+    join(
+      uiRoot,
+      "src/components/chat/widgets/agent-orchestrator-room-view.tsx",
+    ),
+    join(uiRoot, "src/components/ui"),
+    join(repoRoot, "plugins/plugin-task-coordinator/src/CockpitRoute.tsx"),
+  ],
+});
+
+const adapter = join(here, "cockpit-browser-ui-adapter.ts");
+const inactivePanes = join(here, "cockpit-browser-inactive-panes.tsx");
+const pageUrl = await writeFixturePage({
+  entry: join(here, "cockpit-browser-fixture.tsx"),
+  outDir,
+  htmlName: "cockpit-browser.html",
+  title: "Coding Cockpit browser proof",
+  tailwind: { css },
+  htmlClass: "dark",
+  background: "#16121c",
+  processShim: true,
+  plugins: [
+    {
+      name: "cockpit-ui-boundary",
+      setup(build) {
+        build.onResolve({ filter: /^@elizaos\/ui$/ }, () => ({
+          path: adapter,
+        }));
+        build.onResolve({ filter: /^@elizaos\/shared$/ }, () => ({
+          path: adapter,
+        }));
+        build.onResolve(
+          { filter: /^\.\/Cockpit(?:InteractiveTerminal|SessionPane)$/ },
+          () => ({ path: inactivePanes }),
+        );
+      },
+    },
+  ],
+});
+
+const browser = await chromium.launch();
+const requestReceipt = [];
+const runSurface = async ({ name, width, height, drive }) => {
+  const context = await browser.newContext({
+    viewport: { width, height },
+    recordVideo: { dir: outDir, size: { width, height } },
+  });
+  const page = await context.newPage();
+  const logs = [];
+  page.on("console", (message) =>
+    logs.push({ kind: "console", level: message.type(), text: message.text() }),
+  );
+  page.on("request", (request) =>
+    logs.push({
+      kind: "request",
+      method: request.method(),
+      url: request.url(),
+    }),
+  );
+  page.on("response", (response) =>
+    logs.push({
+      kind: "response",
+      status: response.status(),
+      url: response.url(),
+    }),
+  );
+  await page.route("http://cockpit.test/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    if (request.method() === "POST") {
+      requestReceipt.push({
+        path: url.pathname,
+        method: request.method(),
+        body: request.postDataJSON(),
+      });
+    }
+    const body =
+      url.pathname === "/api/orchestrator/rooms"
+        ? { rooms: [] }
+        : url.pathname === "/api/projects"
+          ? { projects: [{ repoUrl: "https://github.com/elizaOS/eliza" }] }
+          : url.pathname === "/api/orchestrator/tasks"
+            ? { id: "task-browser-proof" }
+            : {};
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(body),
+    });
+  });
+  try {
+    await page.goto(pageUrl);
+    await page.getByTestId("cockpit-new-session-form").waitFor();
+    await drive(page);
+    await page.screenshot({
+      path: join(outDir, `${name}.jpg`),
+      type: "jpeg",
+      quality: 90,
+      fullPage: true,
+    });
+    await writeFile(
+      join(outDir, `${name}-browser-log.json`),
+      JSON.stringify(logs, null, 2),
+    );
+  } finally {
+    await page.close();
+    await context.close();
+  }
+};
+
+try {
+  for (const surface of [
+    { name: "cockpit-desktop", width: 1440, height: 900 },
+    { name: "cockpit-mobile", width: 390, height: 844 },
+  ]) {
+    await runSurface({
+      ...surface,
+      drive: async (page) => {
+        const repo = page.getByTestId("cockpit-repo-input");
+        await repo.waitFor();
+        assert(
+          (await repo.getAttribute("list")) !== null,
+          "repo autocomplete was not loaded",
+        );
+        await page
+          .getByTestId("cockpit-goal-input")
+          .fill("Fix cockpit browser evidence and open a PR");
+        await page.getByTestId("cockpit-workdir-input").fill("packages/ui");
+        await page.getByTestId("cockpit-workdir-error").waitFor();
+        assert(
+          await page.getByTestId("cockpit-start-button").isDisabled(),
+          "invalid target did not disable submit",
+        );
+        await page.screenshot({
+          path: join(outDir, `${surface.name}-validation.jpg`),
+          type: "jpeg",
+          quality: 90,
+          fullPage: true,
+        });
+        await repo.fill("elizaOS/eliza");
+        await page
+          .getByTestId("cockpit-workdir-error")
+          .waitFor({ state: "detached" });
+        await page.getByTestId("cockpit-start-button").click();
+        await page.waitForResponse((response) =>
+          response
+            .url()
+            .endsWith("/api/orchestrator/tasks/task-browser-proof/agents"),
+        );
+      },
+    });
+  }
+
+  assert(
+    requestReceipt.length === 4,
+    `expected four POSTs across two surfaces, got ${requestReceipt.length}`,
+  );
+  for (let index = 0; index < requestReceipt.length; index += 2) {
+    const create = requestReceipt[index];
+    const spawn = requestReceipt[index + 1];
+    assert(
+      create.path === "/api/orchestrator/tasks",
+      "task creation was not first",
+    );
+    assert(
+      spawn.path === "/api/orchestrator/tasks/task-browser-proof/agents",
+      "agent spawn was not second",
+    );
+    assert(
+      create.body.providerPolicy.preferredFramework === "elizaos",
+      "create policy lost framework",
+    );
+    assert(
+      create.body.providerPolicy.providerSource === "eliza-cloud",
+      "create policy lost provider",
+    );
+    assert(spawn.body.repo === "elizaOS/eliza", "spawn lost repo");
+    assert(spawn.body.workdir === "packages/ui", "spawn lost workdir");
+  }
+  await writeFile(
+    join(outDir, "cockpit-request-receipt.json"),
+    JSON.stringify(requestReceipt, null, 2),
+  );
+} finally {
+  await browser.close();
+}
+
+console.log(`Cockpit browser proof passed; artifacts: ${outDir}`);


### PR DESCRIPTION
# Relates to

Cockpit repo/cwd picker — the in-code acknowledged gap called out in `plugins/plugin-task-coordinator/src/CockpitRoute.tsx` ("a cwd/repo picker is a follow-up") and in the code-agent HITL readiness audit (item #8, "cockpit repo/cwd picker"). Unblocks "fix this repo" HITL tests from the cockpit instead of chat-only.

- [x] This PR targets `develop` and is branched off the latest `origin/develop`.
- [ ] `bun install` and `bun run verify` were run after sync — see **Known gaps** (full `verify` not run; focused suites + biome + tsgo run instead, blocker documented).
- [x] A reviewer can confirm the change works without reading the code, from the evidence below (rendering RTL tests + story).

# Sync with develop

- [x] Branched off the latest `origin/develop` (`bad93f9f1`, post-#16131); zero conflicts.
- [ ] `bun run verify` — not run in full (ephemeral worktree, unbuilt sibling `@elizaos/cloud-routing` workspace dep). Ran the focused cockpit suites (21/21), biome (clean), tsgo (clean on cockpit files) instead. See **Known gaps / failures**.

# Risks

**Low.** Pure additive UI wiring in the coding cockpit's new-session form; no backend changes. The repo/workdir fields are optional — leaving them blank preserves the exact prior behavior (orchestrator scratch-dir default). The only new failure surface is the client-side "workdir requires a repo" validation, covered by tests.

# Background

## What does this PR do?

Adds optional **Repo** + **Working directory** inputs to the cockpit's new-session spawn form so a human can point a coding sub-agent at a repo during HITL testing. Previously the cockpit had a 4-mode picker but no way to target a repo — that was chat-`TASKS`-action-only.

This is **pure UI wiring, no backend changes**. The plumbing already existed:
- `CodingAgentAddAgentInput` already carries `repo?` + `workdir?`.
- `POST /api/orchestrator/tasks/:id/agents` already reads both off the body (`orchestrator-routes.ts`).
- `spawnAgentForTask` already threads them into `resolveTaskSpawnWorkdir` + `buildGoalPrompt`.

So the form now collects repo/workdir and threads them through the existing two-step spawn (`createOrchestratorTask` → `addOrchestratorAgent`), **mirroring the chat TASKS action's semantics** — no new contract invented.

Details:
- **Repo field** offers a native `<datalist>` of known repos **only when the project registry supplies any** (loaded best-effort from `client.listProjects()` `.repoUrl` in `CockpitRoute`). No source ⇒ plain text input, no invented dropdown. Registry-less hosts (mobile/web) degrade gracefully.
- **Workdir field** is optional; setting it without a repo blocks submit with an inline `role="alert"` error (`aria-invalid` / `aria-describedby`).
- New `CockpitSpawnTarget` type + `normalizeCockpitSpawnTarget()` (trim, drop blanks) live beside the mode→policy lowering; `onCreate` takes the target as a distinct 2nd arg so the create-task body stays pure (the target belongs to `addOrchestratorAgent`, not the durable record).

## What kind of change is this?

Features (non-breaking change which adds functionality).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/components/cockpit/CockpitNewSessionForm.tsx` (the form) and `plugins/plugin-task-coordinator/src/CockpitRoute.tsx` (the two-step spawn plumbing + known-repos load).

## Detailed testing steps

Automated tests are acceptable and cover the behavior:
- Type a repo (and optional workdir) → it flows into the `onCreate` spawn target.
- Set a workdir without a repo → submit disabled + inline error shown; add a repo → clears.
- `knownRepos` provided → repo field renders a suggestion `<datalist>`; absent → plain text.

Focused run: `cd packages/ui && bun run test -- src/components/cockpit/{CockpitNewSessionForm,cockpit-modes,CockpitView}` → **21/21 pass**.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16134-before-wrong-views-registry.png)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16134-cockpit-desktop.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence/16134-cockpit-desktop.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - The browser proof replaces only the HTTP boundary; exact intercepted request/response traffic is attached as frontend logs and domain receipt.
<!-- evidence-row:frontend-logs -->
- [x] [16134-cockpit-desktop-browser-log.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16134-cockpit-desktop-browser-log.json)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - This change does not alter model, prompt, action, provider, or agent reasoning behavior.
<!-- evidence-row:domain-artifacts -->
- [x] [16134-cockpit-request-receipt.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16134-cockpit-request-receipt.json)

# Evidence Details

Focused test output (RTL renders the form and asserts the new fields):

```
✓ src/components/cockpit/cockpit-modes.test.ts (8 tests)
✓ src/components/cockpit/CockpitView.test.tsx (5 tests)
✓ src/components/cockpit/CockpitNewSessionForm.test.tsx (8 tests)
Test Files  3 passed (3)
     Tests  21 passed (21)
```

- **biome**: clean on all 9 changed files.
- **tsgo** (`--noEmit` on packages/ui): zero errors in any cockpit/index file (the only errors are pre-existing unrelated `@elizaos/cloud-routing` resolution failures in `@elizaos/core`, an unbuilt sibling package).
- **codex review** (`--uncommitted`): "the cockpit code changes look internally consistent." (Its one P2 was about pre-existing untracked `._*` benchmark sidecar files not in this diff — only the 9 cockpit files were staged/committed.)

# Known gaps / failures

- Full `bun run verify` was not run in this ephemeral worktree because a sibling workspace package (`@elizaos/cloud-routing`, imported transitively by `@elizaos/core`) is unbuilt here — the same issue that blocks the Storybook render and shows in tsgo. This is an unrelated environment/build-state blocker, not caused by this change. The focused cockpit suites, biome, and tsgo (scoped to my files) all pass. CI (which builds the full workspace) will exercise the rest.

---

Author: Sol <sol@shad0w.xyz> · Co-authored-by: wakesync <shadow@shad0w.xyz>

<!-- evidence-row:ocr-review -->
- [x] [16134-cockpit-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16134-cockpit-ocr-review.txt)
