### PR TITLE
feat(cloud): add privacy-safe chat latency probe

### DIFF
--- a/.github/workflows/chat-latency-live.yml
+++ b/.github/workflows/chat-latency-live.yml
@@ -154,6 +154,33 @@ jobs:
           set -e
           echo "status=$probe_status" >> "$GITHUB_OUTPUT"
 
+      - name: Reverify the exact deployed gateway SHA
+        if: always()
+        env:
+          EXPECTED_GATEWAY_SHA: ${{ inputs.expected_gateway_sha }}
+        run: |
+          node --input-type=module - <<'NODE'
+          const expected = process.env.EXPECTED_GATEWAY_SHA ?? "";
+          const base = process.env.ELIZA_CLOUD_CHAT_LATENCY_BASE_URL ?? "";
+          const response = await fetch(base + "/api/health", {
+            headers: { "user-agent": "eliza-chat-latency/1.0" },
+            signal: AbortSignal.timeout(30_000),
+          });
+          if (!response.ok) {
+            throw new Error("Gateway health returned HTTP " + response.status);
+          }
+          const body = await response.json();
+          if (body?.commit !== expected) {
+            throw new Error(
+              "Gateway changed during the benchmark: served " +
+                (body?.commit ?? "<missing>") +
+                ", expected " +
+                expected,
+            );
+          }
+          console.log("Gateway deployment remained exact through benchmark completion");
+          NODE
+
       - name: Add privacy-safe timing table to summary
         if: always() && hashFiles(env.REPORT_PATH) != ''
         run: |

--- a/.github/workflows/chat-latency-live.yml
+++ b/.github/workflows/chat-latency-live.yml
@@ -59,20 +59,17 @@ jobs:
           node --test packages/scripts/cloud/chat-latency.test.mjs
 
   live:
-    name: ${{ matrix.target }} (${{ inputs.environment }})
+    name: paired direct + gateway (${{ inputs.environment }})
     if: github.event_name == 'workflow_dispatch'
     needs: contract
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     environment: ${{ inputs.environment }}
-    strategy:
-      fail-fast: false
-      matrix:
-        target: [direct, gateway]
     env:
-      CHAT_LATENCY_API_KEY: ${{ matrix.target == 'direct' && secrets.CEREBRAS_API_KEY || secrets.ELIZACLOUD_API_KEY }}
-      CHAT_LATENCY_BASE_URL: ${{ matrix.target == 'direct' && 'https://api.cerebras.ai' || (inputs.environment == 'production' && 'https://api.elizacloud.ai' || 'https://api-staging.elizacloud.ai') }}
-      REPORT_PATH: reports/chat-latency-${{ matrix.target }}-${{ inputs.environment }}.jsonl
+      CEREBRAS_CHAT_LATENCY_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
+      ELIZA_CLOUD_CHAT_LATENCY_API_KEY: ${{ secrets.ELIZACLOUD_API_KEY }}
+      ELIZA_CLOUD_CHAT_LATENCY_BASE_URL: ${{ inputs.environment == 'production' && 'https://api.elizacloud.ai' || 'https://api-staging.elizacloud.ai' }}
+      REPORT_PATH: reports/chat-latency-paired-${{ inputs.environment }}.jsonl
     steps:
       - name: Checkout exact requested ref
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -82,23 +79,30 @@ jobs:
         with:
           node-version: "24.15.0"
 
-      - name: Require target credential
+      - name: Require both target credentials
         run: |
-          if [ -z "${CHAT_LATENCY_API_KEY:-}" ]; then
-            echo "::error::Required credential is not configured for target ${{ matrix.target }} in environment ${{ inputs.environment }}."
+          missing=()
+          [ -z "${CEREBRAS_CHAT_LATENCY_API_KEY:-}" ] && missing+=("CEREBRAS_API_KEY")
+          [ -z "${ELIZA_CLOUD_CHAT_LATENCY_API_KEY:-}" ] && missing+=("ELIZACLOUD_API_KEY")
+          if [ "${#missing[@]}" -ne 0 ]; then
+            echo "::error::Required latency credential(s) are not configured in environment ${{ inputs.environment }}: ${missing[*]}"
             exit 1
           fi
 
-      - name: Probe Gemma and GLM reasoning modes
+      - name: Probe Gemma and GLM reasoning modes on one runner
         id: probe
         shell: bash
         run: |
           mkdir -p reports
           set +e
+
+          # Both commands execute in this same job so host, runner region, Node
+          # version, and observation clock are held constant. Direct runs first
+          # and gateway follows immediately with the identical case matrix.
           node packages/scripts/cloud/chat-latency.mjs \
-            --target "${{ matrix.target }}" \
-            --base-url "$CHAT_LATENCY_BASE_URL" \
-            --api-key-env CHAT_LATENCY_API_KEY \
+            --target direct \
+            --base-url https://api.cerebras.ai \
+            --api-key-env CEREBRAS_CHAT_LATENCY_API_KEY \
             --repeat "${{ inputs.repeats }}" \
             --timeout-ms 120000 \
             --case gemma-4-31b@omit@512 \
@@ -106,8 +110,26 @@ jobs:
             --case zai-glm-4.7@omit@4096 \
             --case zai-glm-4.7@none@512 \
             | tee "$REPORT_PATH"
-          probe_status="${PIPESTATUS[0]}"
+          direct_status="${PIPESTATUS[0]}"
+
+          node packages/scripts/cloud/chat-latency.mjs \
+            --target gateway \
+            --base-url "$ELIZA_CLOUD_CHAT_LATENCY_BASE_URL" \
+            --api-key-env ELIZA_CLOUD_CHAT_LATENCY_API_KEY \
+            --repeat "${{ inputs.repeats }}" \
+            --timeout-ms 120000 \
+            --case gemma-4-31b@omit@512 \
+            --case gemma-4-31b@none@512 \
+            --case zai-glm-4.7@omit@4096 \
+            --case zai-glm-4.7@none@512 \
+            | tee -a "$REPORT_PATH"
+          gateway_status="${PIPESTATUS[0]}"
+
           set -e
+          probe_status=0
+          if [ "$direct_status" -ne 0 ] || [ "$gateway_status" -ne 0 ]; then
+            probe_status=2
+          fi
           echo "status=$probe_status" >> "$GITHUB_OUTPUT"
 
       - name: Add privacy-safe timing table to summary
@@ -120,13 +142,14 @@ jobs:
             .split(/\r?\n/)
             .filter(Boolean)
             .map((line) => JSON.parse(line));
-          console.log("### Chat latency: ${{ matrix.target }} / ${{ inputs.environment }}");
+          console.log("### Paired chat latency: direct + gateway / ${{ inputs.environment }}");
           console.log("");
-          console.log("| model | reasoning | run | ok | headers ms | first event ms | first reasoning ms | first token ms | total ms | preforward ms |");
-          console.log("| --- | --- | ---: | :---: | ---: | ---: | ---: | ---: | ---: | ---: |");
+          console.log("| target | model | reasoning | run | ok | headers ms | first event ms | first reasoning ms | first token ms | total ms | preforward ms |");
+          console.log("| --- | --- | --- | ---: | :---: | ---: | ---: | ---: | ---: | ---: | ---: |");
           for (const row of records) {
             const preforward = row.serverTiming?.gateway_preforward ?? "—";
             const values = [
+              row.target,
               row.model ?? "configured agent",
               row.reasoningEffort ?? "configured",
               row.sequence,
@@ -146,7 +169,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: chat-latency-${{ matrix.target }}-${{ inputs.environment }}-${{ github.sha }}
+          name: chat-latency-paired-${{ inputs.environment }}-${{ github.sha }}
           path: ${{ env.REPORT_PATH }}
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/chat-latency-live.yml
+++ b/.github/workflows/chat-latency-live.yml
@@ -1,0 +1,162 @@
+name: Chat Latency Live
+
+# Manual, privacy-safe comparison of Cerebras direct and the Eliza Cloud model
+# gateway from the same GitHub-hosted runner. Production is never automatic:
+# selecting it binds the job to the protected production environment.
+on:
+  pull_request:
+    branches: [develop, main]
+    paths:
+      - ".github/workflows/chat-latency-live.yml"
+      - "packages/scripts/cloud/chat-latency.mjs"
+      - "packages/scripts/cloud/chat-latency.test.mjs"
+      - "packages/scripts/__tests__/chat-latency-workflow.test.ts"
+      - "package.json"
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Eliza Cloud gateway environment
+        required: true
+        default: staging
+        type: choice
+        options:
+          - staging
+          - production
+      repeats:
+        description: Repetitions for each model/reasoning case
+        required: true
+        default: "3"
+        type: choice
+        options:
+          - "1"
+          - "3"
+          - "5"
+
+concurrency:
+  group: chat-latency-live-${{ github.event_name }}-${{ inputs.environment || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    name: Probe contract
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24.15.0"
+
+      - name: Validate probe syntax and privacy contract
+        run: |
+          node --check packages/scripts/cloud/chat-latency.mjs
+          node --test packages/scripts/cloud/chat-latency.test.mjs
+
+  live:
+    name: ${{ matrix.target }} (${{ inputs.environment }})
+    if: github.event_name == 'workflow_dispatch'
+    needs: contract
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    environment: ${{ inputs.environment }}
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [direct, gateway]
+    env:
+      CHAT_LATENCY_API_KEY: ${{ matrix.target == 'direct' && secrets.CEREBRAS_API_KEY || secrets.ELIZACLOUD_API_KEY }}
+      CHAT_LATENCY_BASE_URL: ${{ matrix.target == 'direct' && 'https://api.cerebras.ai' || (inputs.environment == 'production' && 'https://api.elizacloud.ai' || 'https://api-staging.elizacloud.ai') }}
+      REPORT_PATH: reports/chat-latency-${{ matrix.target }}-${{ inputs.environment }}.jsonl
+    steps:
+      - name: Checkout exact requested ref
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24.15.0"
+
+      - name: Require target credential
+        run: |
+          if [ -z "${CHAT_LATENCY_API_KEY:-}" ]; then
+            echo "::error::Required credential is not configured for target ${{ matrix.target }} in environment ${{ inputs.environment }}."
+            exit 1
+          fi
+
+      - name: Probe Gemma and GLM reasoning modes
+        id: probe
+        shell: bash
+        run: |
+          mkdir -p reports
+          set +e
+          node packages/scripts/cloud/chat-latency.mjs \
+            --target "${{ matrix.target }}" \
+            --base-url "$CHAT_LATENCY_BASE_URL" \
+            --api-key-env CHAT_LATENCY_API_KEY \
+            --repeat "${{ inputs.repeats }}" \
+            --timeout-ms 120000 \
+            --case gemma-4-31b@omit@512 \
+            --case gemma-4-31b@none@512 \
+            --case zai-glm-4.7@omit@4096 \
+            --case zai-glm-4.7@none@512 \
+            | tee "$REPORT_PATH"
+          probe_status="${PIPESTATUS[0]}"
+          set -e
+          echo "status=$probe_status" >> "$GITHUB_OUTPUT"
+
+      - name: Add privacy-safe timing table to summary
+        if: always() && hashFiles(env.REPORT_PATH) != ''
+        run: |
+          node - "$REPORT_PATH" >> "$GITHUB_STEP_SUMMARY" <<'NODE'
+          const { readFileSync } = require("node:fs");
+          const path = process.argv[2];
+          const records = readFileSync(path, "utf8")
+            .split(/\r?\n/)
+            .filter(Boolean)
+            .map((line) => JSON.parse(line));
+          console.log("### Chat latency: ${{ matrix.target }} / ${{ inputs.environment }}");
+          console.log("");
+          console.log("| model | reasoning | run | ok | headers ms | first event ms | first reasoning ms | first token ms | total ms | preforward ms |");
+          console.log("| --- | --- | ---: | :---: | ---: | ---: | ---: | ---: | ---: | ---: |");
+          for (const row of records) {
+            const preforward = row.serverTiming?.gateway_preforward ?? "—";
+            const values = [
+              row.model ?? "configured agent",
+              row.reasoningEffort ?? "configured",
+              row.sequence,
+              row.ok ? "yes" : "no",
+              row.responseHeadersMs ?? "—",
+              row.firstEventMs ?? "—",
+              row.firstReasoningMs ?? "—",
+              row.firstTokenMs ?? "—",
+              row.totalMs ?? "—",
+              preforward,
+            ];
+            console.log("| " + values.join(" | ") + " |");
+          }
+          NODE
+
+      - name: Upload exact-SHA latency evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: chat-latency-${{ matrix.target }}-${{ inputs.environment }}-${{ github.sha }}
+          path: ${{ env.REPORT_PATH }}
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Enforce probe result
+        if: always()
+        run: |
+          status="${{ steps.probe.outputs.status }}"
+          if [ -z "$status" ]; then
+            echo "::error::Probe did not produce a status."
+            exit 1
+          fi
+          exit "$status"

--- a/.github/workflows/chat-latency-live.yml
+++ b/.github/workflows/chat-latency-live.yml
@@ -127,8 +127,9 @@ jobs:
           set +e
 
           # One process holds runner, clock, prompts, and case set constant.
-          # It randomizes case order, counterbalances target order inside each
-          # proof-identical pair, and labels cold/warm/post-idle phases.
+          # It randomizes case order, alternates target-first order exactly for
+          # each case and labels cold/warm/post-idle phases.
+          # It idles before every target labeled post-idle.
           node packages/scripts/cloud/chat-latency.mjs \
             --target paired \
             --direct-base-url https://api.cerebras.ai \

--- a/.github/workflows/chat-latency-live.yml
+++ b/.github/workflows/chat-latency-live.yml
@@ -25,12 +25,16 @@ on:
       repeats:
         description: Repetitions for each model/reasoning case
         required: true
-        default: "3"
+        default: "30"
         type: choice
         options:
-          - "1"
           - "3"
-          - "5"
+          - "10"
+          - "30"
+      expected_gateway_sha:
+        description: Exact 40-character commit expected from /api/health
+        required: true
+        type: string
 
 concurrency:
   group: chat-latency-live-${{ github.event_name }}-${{ inputs.environment || github.ref }}
@@ -63,12 +67,11 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     needs: contract
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 90
     environment: ${{ inputs.environment }}
     env:
-      CEREBRAS_CHAT_LATENCY_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
-      ELIZA_CLOUD_CHAT_LATENCY_API_KEY: ${{ secrets.ELIZACLOUD_API_KEY }}
       ELIZA_CLOUD_CHAT_LATENCY_BASE_URL: ${{ inputs.environment == 'production' && 'https://api.elizacloud.ai' || 'https://api-staging.elizacloud.ai' }}
+      ELIZA_GATEWAY_DEPLOY_SHA: ${{ inputs.expected_gateway_sha }}
       REPORT_PATH: reports/chat-latency-paired-${{ inputs.environment }}.jsonl
     steps:
       - name: Checkout exact requested ref
@@ -79,97 +82,130 @@ jobs:
         with:
           node-version: "24.15.0"
 
-      - name: Require both target credentials
+      - name: Verify the exact deployed gateway SHA
+        env:
+          EXPECTED_GATEWAY_SHA: ${{ inputs.expected_gateway_sha }}
         run: |
-          missing=()
-          [ -z "${CEREBRAS_CHAT_LATENCY_API_KEY:-}" ] && missing+=("CEREBRAS_API_KEY")
-          [ -z "${ELIZA_CLOUD_CHAT_LATENCY_API_KEY:-}" ] && missing+=("ELIZACLOUD_API_KEY")
-          if [ "${#missing[@]}" -ne 0 ]; then
-            echo "::error::Required latency credential(s) are not configured in environment ${{ inputs.environment }}: ${missing[*]}"
-            exit 1
-          fi
+          node --input-type=module - <<'NODE'
+          const expected = process.env.EXPECTED_GATEWAY_SHA ?? "";
+          const base = process.env.ELIZA_CLOUD_CHAT_LATENCY_BASE_URL ?? "";
+          if (!/^[a-f0-9]{40}$/.test(expected)) {
+            throw new Error("expected_gateway_sha must be a 40-character lowercase commit");
+          }
+          const response = await fetch(base + "/api/health", {
+            headers: { "user-agent": "eliza-chat-latency/1.0" },
+            signal: AbortSignal.timeout(30_000),
+          });
+          if (!response.ok) {
+            throw new Error("Gateway health returned HTTP " + response.status);
+          }
+          const body = await response.json();
+          if (body?.commit !== expected) {
+            throw new Error(
+              "Gateway serves " + (body?.commit ?? "<missing>") + ", expected " + expected,
+            );
+          }
+          console.log(
+            "Verified gateway deployment " +
+              expected +
+              " (" +
+              (body.environment ?? "unknown") +
+              ")",
+          );
+          NODE
 
       - name: Probe Gemma and GLM reasoning modes on one runner
         id: probe
         shell: bash
+        env:
+          CEREBRAS_CHAT_LATENCY_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
+          ELIZA_CLOUD_CHAT_LATENCY_API_KEY: ${{ secrets.ELIZACLOUD_API_KEY }}
+          ELIZA_GATEWAY_DEPLOY_SHA: ${{ inputs.expected_gateway_sha }}
+          BENCHMARK_SEED: ${{ github.run_id }}-${{ github.run_attempt }}
         run: |
           mkdir -p reports
           set +e
 
-          # Both commands execute in this same job so host, runner region, Node
-          # version, and observation clock are held constant. Direct runs first
-          # and gateway follows immediately with the identical case matrix.
+          # One process holds runner, clock, prompts, and case set constant.
+          # It randomizes case order, counterbalances target order inside each
+          # proof-identical pair, and labels cold/warm/post-idle phases.
           node packages/scripts/cloud/chat-latency.mjs \
-            --target direct \
-            --base-url https://api.cerebras.ai \
-            --api-key-env CEREBRAS_CHAT_LATENCY_API_KEY \
+            --target paired \
+            --direct-base-url https://api.cerebras.ai \
+            --gateway-base-url "$ELIZA_CLOUD_CHAT_LATENCY_BASE_URL" \
+            --direct-api-key-env CEREBRAS_CHAT_LATENCY_API_KEY \
+            --gateway-api-key-env ELIZA_CLOUD_CHAT_LATENCY_API_KEY \
             --repeat "${{ inputs.repeats }}" \
-            --timeout-ms 120000 \
+            --timeout-ms 30000 \
+            --idle-ms 30000 \
+            --max-proof-miss-rate 0.05 \
+            --seed "$BENCHMARK_SEED" \
             --case gemma-4-31b@omit@512 \
             --case gemma-4-31b@none@512 \
             --case zai-glm-4.7@omit@4096 \
+            --case zai-glm-4.7@none@4096 \
             --case zai-glm-4.7@none@512 \
             | tee "$REPORT_PATH"
-          direct_status="${PIPESTATUS[0]}"
-
-          node packages/scripts/cloud/chat-latency.mjs \
-            --target gateway \
-            --base-url "$ELIZA_CLOUD_CHAT_LATENCY_BASE_URL" \
-            --api-key-env ELIZA_CLOUD_CHAT_LATENCY_API_KEY \
-            --repeat "${{ inputs.repeats }}" \
-            --timeout-ms 120000 \
-            --case gemma-4-31b@omit@512 \
-            --case gemma-4-31b@none@512 \
-            --case zai-glm-4.7@omit@4096 \
-            --case zai-glm-4.7@none@512 \
-            | tee -a "$REPORT_PATH"
-          gateway_status="${PIPESTATUS[0]}"
-
+          probe_status="${PIPESTATUS[0]}"
           set -e
-          probe_status=0
-          if [ "$direct_status" -ne 0 ] || [ "$gateway_status" -ne 0 ]; then
-            probe_status=2
-          fi
           echo "status=$probe_status" >> "$GITHUB_OUTPUT"
 
       - name: Add privacy-safe timing table to summary
         if: always() && hashFiles(env.REPORT_PATH) != ''
         run: |
-          node - "$REPORT_PATH" >> "$GITHUB_STEP_SUMMARY" <<'NODE'
-          const { readFileSync } = require("node:fs");
+          node --input-type=module - "$REPORT_PATH" >> "$GITHUB_STEP_SUMMARY" <<'NODE'
+          import { readFileSync } from "node:fs";
+          import { summarizeLatencyRecords } from "./packages/scripts/cloud/chat-latency.mjs";
           const path = process.argv[2];
           const records = readFileSync(path, "utf8")
             .split(/\r?\n/)
             .filter(Boolean)
             .map((line) => JSON.parse(line));
+          const summaries = summarizeLatencyRecords(records);
           console.log("### Paired chat latency: direct + gateway / ${{ inputs.environment }}");
           console.log("");
-          console.log("| target | model | reasoning | run | ok | headers ms | first event ms | first reasoning ms | first token ms | total ms | preforward ms |");
-          console.log("| --- | --- | --- | ---: | :---: | ---: | ---: | ---: | ---: | ---: | ---: |");
-          for (const row of records) {
-            const preforward = row.serverTiming?.gateway_preforward ?? "—";
+          console.log(
+            "Gateway deployment: " +
+              (process.env.ELIZA_GATEWAY_DEPLOY_SHA ?? "unknown"),
+          );
+          console.log("");
+          console.log("| target | model | reasoning | cap | ok/total | TTFT p50/p90/p95 ms | total p50/p90/p95 ms | preforward p50/p90/p95 ms |");
+          console.log("| --- | --- | --- | ---: | ---: | ---: | ---: | ---: |");
+          const fmt = (metric) =>
+            [metric.p50, metric.p90, metric.p95]
+              .map((value) => value ?? "—")
+              .join(" / ");
+          for (const row of summaries) {
             const values = [
               row.target,
-              row.model ?? "configured agent",
-              row.reasoningEffort ?? "configured",
-              row.sequence,
-              row.ok ? "yes" : "no",
-              row.responseHeadersMs ?? "—",
-              row.firstEventMs ?? "—",
-              row.firstReasoningMs ?? "—",
-              row.firstTokenMs ?? "—",
-              row.totalMs ?? "—",
-              preforward,
+              row.model,
+              row.reasoningEffort,
+              row.maxTokens,
+              row.successes + "/" + row.samples,
+              fmt(row.firstTokenMs),
+              fmt(row.totalMs),
+              fmt(row.preforwardMs),
             ];
             console.log("| " + values.join(" | ") + " |");
           }
+          const phaseCounts = Object.groupBy(
+            records,
+            (row) => row.phase ?? "unlabelled",
+          );
+          console.log("");
+          console.log(
+            "Phases: " +
+              Object.entries(phaseCounts)
+                .map(([phase, rows]) => phase + "=" + rows.length)
+                .join(", "),
+          );
           NODE
 
       - name: Upload exact-SHA latency evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: chat-latency-paired-${{ inputs.environment }}-${{ github.sha }}
+          name: chat-latency-paired-${{ inputs.environment }}-${{ inputs.expected_gateway_sha }}
           path: ${{ env.REPORT_PATH }}
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/chat-latency-live.yml
+++ b/.github/workflows/chat-latency-live.yml
@@ -130,6 +130,8 @@ jobs:
           # It randomizes case order, alternates target-first order exactly for
           # each case and labels cold/warm/post-idle phases.
           # It idles before every target labeled post-idle.
+          # Warm pairs are paced at 40 gateway requests/minute, below the
+          # lowest Cloud organization tier, so this remains a latency test.
           node packages/scripts/cloud/chat-latency.mjs \
             --target paired \
             --direct-base-url https://api.cerebras.ai \
@@ -139,6 +141,7 @@ jobs:
             --repeat "${{ inputs.repeats }}" \
             --timeout-ms 30000 \
             --idle-ms 30000 \
+            --pair-interval-ms 1500 \
             --max-proof-miss-rate 0.05 \
             --seed "$BENCHMARK_SEED" \
             --case gemma-4-31b@omit@512 \

--- a/package.json
+++ b/package.json
@@ -194,6 +194,8 @@
     "test:cloud:full": "bun run test:cloud && bun run test:cloud:e2e",
     "test:cloud:e2e": "bun run --cwd packages/cloud/api test:e2e",
     "test:cloud:integration": "node packages/scripts/cloud/admin/run-integration-tests.mjs",
+    "cloud:chat-latency": "node packages/scripts/cloud/chat-latency.mjs",
+    "test:chat-latency": "node --test packages/scripts/cloud/chat-latency.test.mjs",
     "cloud:e2e": "bun run --cwd packages/test/cloud-e2e test",
     "cloud:e2e:headed": "bun run --cwd packages/test/cloud-e2e test:headed",
     "cloud:e2e:ui": "bun run --cwd packages/test/cloud-e2e test:ui",

--- a/packages/scripts/__tests__/chat-latency-workflow.test.ts
+++ b/packages/scripts/__tests__/chat-latency-workflow.test.ts
@@ -39,7 +39,7 @@ describe("chat latency live workflow", () => {
     expect(workflow).toContain("--target paired");
     expect(workflow).toContain("--direct-base-url");
     expect(workflow).toContain("--gateway-base-url");
-    expect(workflow).toContain("counterbalances target order inside each");
+    expect(workflow).toContain("alternates target-first order exactly");
     expect(workflow).toContain("runs-on: ubuntu-24.04");
     expect(workflow).toContain("https://api.cerebras.ai");
     expect(workflow).toContain("https://api-staging.elizacloud.ai");
@@ -99,6 +99,7 @@ describe("chat latency live workflow", () => {
   test("collects statistical warm evidence plus cold and post-idle labels", () => {
     expect(workflow).toContain('default: "30"');
     expect(workflow).toContain("--idle-ms 30000");
+    expect(workflow).toContain("idles before every target labeled post-idle");
     expect(workflow).toContain("p50/p90/p95");
     expect(workflow).toContain("cold/warm/post-idle");
   });

--- a/packages/scripts/__tests__/chat-latency-workflow.test.ts
+++ b/packages/scripts/__tests__/chat-latency-workflow.test.ts
@@ -99,6 +99,9 @@ describe("chat latency live workflow", () => {
   test("collects statistical warm evidence plus cold and post-idle labels", () => {
     expect(workflow).toContain('default: "30"');
     expect(workflow).toContain("--idle-ms 30000");
+    expect(workflow).toContain("--pair-interval-ms 1500");
+    expect(workflow).toContain("below the");
+    expect(workflow).toContain("lowest Cloud organization tier");
     expect(workflow).toContain("idles before every target labeled post-idle");
     expect(workflow).toContain("p50/p90/p95");
     expect(workflow).toContain("cold/warm/post-idle");

--- a/packages/scripts/__tests__/chat-latency-workflow.test.ts
+++ b/packages/scripts/__tests__/chat-latency-workflow.test.ts
@@ -1,10 +1,28 @@
 import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 
 const workflow = readFileSync(
   new URL("../../../.github/workflows/chat-latency-live.yml", import.meta.url),
   "utf8",
 );
+
+function extractRun(stepName: string): string {
+  const escaped = stepName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const body = workflow.match(
+    new RegExp(
+      `^      - name: ${escaped}\\n(?<step>[\\s\\S]*?)(?=^      - name: |$(?![\\s\\S]))`,
+      "m",
+    ),
+  )?.groups?.step;
+  const run = body?.match(/^ {8}run: \|\n(?<run>(?: {10}.*(?:\n|$))*)/m)?.groups
+    ?.run;
+  if (!run) throw new Error(`Missing run body for ${stepName}`);
+  return run
+    .split("\n")
+    .map((line) => line.replace(/^ {10}/, ""))
+    .join("\n");
+}
 
 describe("chat latency live workflow", () => {
   test("keeps paid live probes manual and production environment-gated", () => {
@@ -18,11 +36,10 @@ describe("chat latency live workflow", () => {
 
   test("compares direct and gateway from one fixed runner contract", () => {
     expect(workflow).not.toContain("matrix:");
-    expect(workflow).toContain("--target direct");
-    expect(workflow).toContain("--target gateway");
-    expect(workflow).toContain(
-      "Both commands execute in this same job so host, runner region, Node",
-    );
+    expect(workflow).toContain("--target paired");
+    expect(workflow).toContain("--direct-base-url");
+    expect(workflow).toContain("--gateway-base-url");
+    expect(workflow).toContain("counterbalances target order inside each");
     expect(workflow).toContain("runs-on: ubuntu-24.04");
     expect(workflow).toContain("https://api.cerebras.ai");
     expect(workflow).toContain("https://api-staging.elizacloud.ai");
@@ -34,6 +51,7 @@ describe("chat latency live workflow", () => {
       "gemma-4-31b@omit@512",
       "gemma-4-31b@none@512",
       "zai-glm-4.7@omit@4096",
+      "zai-glm-4.7@none@4096",
       "zai-glm-4.7@none@512",
     ]) {
       expect(workflow).toContain(`--case ${probeCase}`);
@@ -43,13 +61,31 @@ describe("chat latency live workflow", () => {
   test("uses secrets only through an environment variable and retains evidence", () => {
     expect(workflow).toContain("secrets.CEREBRAS_API_KEY");
     expect(workflow).toContain("secrets.ELIZACLOUD_API_KEY");
-    expect(workflow).toContain("--api-key-env CEREBRAS_CHAT_LATENCY_API_KEY");
     expect(workflow).toContain(
-      "--api-key-env ELIZA_CLOUD_CHAT_LATENCY_API_KEY",
+      "--direct-api-key-env CEREBRAS_CHAT_LATENCY_API_KEY",
+    );
+    expect(workflow).toContain(
+      "--gateway-api-key-env ELIZA_CLOUD_CHAT_LATENCY_API_KEY",
     );
     expect(workflow).not.toContain("--api-key ${{");
+    const liveJobHeader = workflow.slice(
+      workflow.indexOf("  live:"),
+      workflow.indexOf("    steps:", workflow.indexOf("  live:")),
+    );
+    expect(liveJobHeader).not.toContain("secrets.");
+    const probeStep = workflow.slice(
+      workflow.indexOf("- name: Probe Gemma and GLM"),
+      workflow.indexOf(
+        "- name: Add privacy-safe timing table",
+        workflow.indexOf("- name: Probe Gemma and GLM"),
+      ),
+    );
+    expect(probeStep).toContain("secrets.CEREBRAS_API_KEY");
+    expect(probeStep).toContain("secrets.ELIZACLOUD_API_KEY");
     expect(workflow).toContain("Upload exact-SHA latency evidence");
     expect(workflow).toContain("retention-days: 14");
+    expect(workflow).toContain("Verify the exact deployed gateway SHA");
+    expect(workflow).toContain("expected_gateway_sha");
   });
 
   test("runs the privacy and parser self-test before live requests", () => {
@@ -58,5 +94,40 @@ describe("chat latency live workflow", () => {
     );
     expect(workflow).toContain("needs: contract");
     expect(workflow).toContain("Enforce probe result");
+  });
+
+  test("collects statistical warm evidence plus cold and post-idle labels", () => {
+    expect(workflow).toContain('default: "30"');
+    expect(workflow).toContain("--idle-ms 30000");
+    expect(workflow).toContain("p50/p90/p95");
+    expect(workflow).toContain("cold/warm/post-idle");
+  });
+
+  test("keeps every live shell and embedded Node program syntactically valid", () => {
+    const steps = [
+      "Verify the exact deployed gateway SHA",
+      "Probe Gemma and GLM reasoning modes on one runner",
+      "Add privacy-safe timing table to summary",
+      "Enforce probe result",
+    ];
+    for (const step of steps) {
+      const shell = extractRun(step);
+      const bash = spawnSync("bash", ["-n"], {
+        input: shell,
+        encoding: "utf8",
+      });
+      expect(bash.status, `${step}: ${bash.stderr}`).toBe(0);
+
+      const nodeBody = shell.match(/<<'NODE'\n(?<node>[\s\S]*?)\nNODE(?:\n|$)/)
+        ?.groups?.node;
+      if (nodeBody) {
+        const node = spawnSync(
+          process.execPath,
+          ["--input-type=module", "--check"],
+          { input: nodeBody, encoding: "utf8" },
+        );
+        expect(node.status, `${step}: ${node.stderr}`).toBe(0);
+      }
+    }
   });
 });

--- a/packages/scripts/__tests__/chat-latency-workflow.test.ts
+++ b/packages/scripts/__tests__/chat-latency-workflow.test.ts
@@ -85,6 +85,8 @@ describe("chat latency live workflow", () => {
     expect(workflow).toContain("Upload exact-SHA latency evidence");
     expect(workflow).toContain("retention-days: 14");
     expect(workflow).toContain("Verify the exact deployed gateway SHA");
+    expect(workflow).toContain("Reverify the exact deployed gateway SHA");
+    expect(workflow).toContain("Gateway changed during the benchmark");
     expect(workflow).toContain("expected_gateway_sha");
   });
 
@@ -111,6 +113,7 @@ describe("chat latency live workflow", () => {
     const steps = [
       "Verify the exact deployed gateway SHA",
       "Probe Gemma and GLM reasoning modes on one runner",
+      "Reverify the exact deployed gateway SHA",
       "Add privacy-safe timing table to summary",
       "Enforce probe result",
     ];

--- a/packages/scripts/__tests__/chat-latency-workflow.test.ts
+++ b/packages/scripts/__tests__/chat-latency-workflow.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const workflow = readFileSync(
+  new URL("../../../.github/workflows/chat-latency-live.yml", import.meta.url),
+  "utf8",
+);
+
+describe("chat latency live workflow", () => {
+  test("keeps paid live probes manual and production environment-gated", () => {
+    expect(workflow).toContain("workflow_dispatch:");
+    expect(workflow).not.toContain("pull_request_target:");
+    expect(workflow).toContain("if: github.event_name == 'workflow_dispatch'");
+    expect(workflow).toMatch(/environment: \$\{\{ inputs\.environment \}\}/);
+    expect(workflow).toContain("- staging");
+    expect(workflow).toContain("- production");
+  });
+
+  test("compares direct and gateway from one fixed runner contract", () => {
+    expect(workflow).toContain("target: [direct, gateway]");
+    expect(workflow).toContain("runs-on: ubuntu-24.04");
+    expect(workflow).toContain("https://api.cerebras.ai");
+    expect(workflow).toContain("https://api-staging.elizacloud.ai");
+    expect(workflow).toContain("https://api.elizacloud.ai");
+  });
+
+  test("covers Gemma and GLM with reasoning omitted and disabled", () => {
+    for (const probeCase of [
+      "gemma-4-31b@omit@512",
+      "gemma-4-31b@none@512",
+      "zai-glm-4.7@omit@4096",
+      "zai-glm-4.7@none@512",
+    ]) {
+      expect(workflow).toContain(`--case ${probeCase}`);
+    }
+  });
+
+  test("uses secrets only through an environment variable and retains evidence", () => {
+    expect(workflow).toContain("secrets.CEREBRAS_API_KEY");
+    expect(workflow).toContain("secrets.ELIZACLOUD_API_KEY");
+    expect(workflow).toContain("--api-key-env CHAT_LATENCY_API_KEY");
+    expect(workflow).not.toContain("--api-key ${{");
+    expect(workflow).toContain("Upload exact-SHA latency evidence");
+    expect(workflow).toContain("retention-days: 14");
+  });
+
+  test("runs the privacy and parser self-test before live requests", () => {
+    expect(workflow).toContain(
+      "node --test packages/scripts/cloud/chat-latency.test.mjs",
+    );
+    expect(workflow).toContain("needs: contract");
+    expect(workflow).toContain("Enforce probe result");
+  });
+});

--- a/packages/scripts/__tests__/chat-latency-workflow.test.ts
+++ b/packages/scripts/__tests__/chat-latency-workflow.test.ts
@@ -17,7 +17,12 @@ describe("chat latency live workflow", () => {
   });
 
   test("compares direct and gateway from one fixed runner contract", () => {
-    expect(workflow).toContain("target: [direct, gateway]");
+    expect(workflow).not.toContain("matrix:");
+    expect(workflow).toContain("--target direct");
+    expect(workflow).toContain("--target gateway");
+    expect(workflow).toContain(
+      "Both commands execute in this same job so host, runner region, Node",
+    );
     expect(workflow).toContain("runs-on: ubuntu-24.04");
     expect(workflow).toContain("https://api.cerebras.ai");
     expect(workflow).toContain("https://api-staging.elizacloud.ai");
@@ -38,7 +43,10 @@ describe("chat latency live workflow", () => {
   test("uses secrets only through an environment variable and retains evidence", () => {
     expect(workflow).toContain("secrets.CEREBRAS_API_KEY");
     expect(workflow).toContain("secrets.ELIZACLOUD_API_KEY");
-    expect(workflow).toContain("--api-key-env CHAT_LATENCY_API_KEY");
+    expect(workflow).toContain("--api-key-env CEREBRAS_CHAT_LATENCY_API_KEY");
+    expect(workflow).toContain(
+      "--api-key-env ELIZA_CLOUD_CHAT_LATENCY_API_KEY",
+    );
     expect(workflow).not.toContain("--api-key ${{");
     expect(workflow).toContain("Upload exact-SHA latency evidence");
     expect(workflow).toContain("retention-days: 14");

--- a/packages/scripts/cloud/chat-latency.mjs
+++ b/packages/scripts/cloud/chat-latency.mjs
@@ -16,6 +16,7 @@ import { parseArgs } from "node:util";
 const TARGETS = new Set(["direct", "gateway", "paired", "dedicated"]);
 const REASONING_EFFORTS = new Set(["omit", "none", "low", "medium", "high"]);
 const SAFE_RESPONSE_HEADERS = [
+  "cf-placement",
   "cf-ray",
   "server-timing",
   "x-eliza-trace-id",

--- a/packages/scripts/cloud/chat-latency.mjs
+++ b/packages/scripts/cloud/chat-latency.mjs
@@ -8,12 +8,12 @@
  * usage, output length, and whether a random proof nonce was returned.
  */
 
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { parseArgs } from "node:util";
 
-const TARGETS = new Set(["direct", "gateway", "dedicated"]);
+const TARGETS = new Set(["direct", "gateway", "paired", "dedicated"]);
 const REASONING_EFFORTS = new Set(["omit", "none", "low", "medium", "high"]);
 const SAFE_RESPONSE_HEADERS = [
   "cf-ray",
@@ -28,6 +28,8 @@ export const DEFAULT_PROBE_CASES = [
   "gemma-4-31b@omit@512",
   "gemma-4-31b@none@512",
   "zai-glm-4.7@omit@4096",
+  "zai-glm-4.7@none@4096",
+  // Separate correctness case: explicit `none` must preserve a small cap.
   "zai-glm-4.7@none@512",
 ];
 
@@ -37,6 +39,14 @@ function boundedInteger(value, label, minimum, maximum) {
     throw new Error(
       `${label} must be an integer between ${minimum} and ${maximum}`,
     );
+  }
+  return parsed;
+}
+
+function boundedNumber(value, label, minimum, maximum) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < minimum || parsed > maximum) {
+    throw new Error(`${label} must be between ${minimum} and ${maximum}`);
   }
   return parsed;
 }
@@ -86,6 +96,53 @@ export function parseServerTiming(value) {
     if (Number.isFinite(number) && number >= 0) result[name] = round(number);
   }
   return result;
+}
+
+export function parsePreforwardHeader(value) {
+  if (!value) return {};
+  const result = {};
+  for (const field of value.split(";")) {
+    const [rawName, rawDuration] = field.split("=", 2);
+    const name = rawName?.trim();
+    const duration = Number(rawDuration);
+    if (
+      name &&
+      /^[A-Za-z0-9_-]+$/.test(name) &&
+      Number.isFinite(duration) &&
+      duration >= 0
+    ) {
+      result[name] = round(duration);
+    }
+  }
+  return result;
+}
+
+export function buildProofPrompt(promptOverride, proof) {
+  const instruction = `Include this exact token in the answer: ${proof}`;
+  const custom = promptOverride?.trim();
+  return custom
+    ? `${custom}\n\n${instruction}`
+    : `Reply briefly. ${instruction}`;
+}
+
+function seededRandom(seed) {
+  let state = createHash("sha256").update(seed).digest().readUInt32LE(0);
+  return () => {
+    state += 0x6d2b79f5;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4_294_967_296;
+  };
+}
+
+function shuffled(values, random) {
+  const copy = [...values];
+  for (let index = copy.length - 1; index > 0; index -= 1) {
+    const swapIndex = Math.floor(random() * (index + 1));
+    [copy[index], copy[swapIndex]] = [copy[swapIndex], copy[index]];
+  }
+  return copy;
 }
 
 export function selectedResponseHeaders(headers) {
@@ -209,15 +266,22 @@ export async function readSse(
   let finishReason = null;
   let providerError = null;
   let terminal = null;
+  let sawDone = false;
+  let malformedEvents = 0;
 
   const consumeLine = (line) => {
     if (!line.startsWith("data:")) return;
     const payload = line.slice(5).trim();
-    if (!payload || payload === "[DONE]") return;
+    if (!payload) return;
+    if (payload === "[DONE]") {
+      sawDone = true;
+      return;
+    }
     let event;
     try {
       event = JSON.parse(payload);
     } catch {
+      malformedEvents += 1;
       return;
     }
     if (firstEventMs === null) firstEventMs = elapsed(now, startedAt);
@@ -264,34 +328,73 @@ export async function readSse(
     finishReason,
     providerError,
     terminal,
+    sawDone,
+    malformedEvents,
   };
 }
 
-function safeTerminalTelemetry(value, depth = 0) {
-  if (!value || typeof value !== "object" || depth > 3) return null;
-  const allowedKey =
-    /(?:trace|timing|latency|duration|elapsed|ttf|first|done|status|stage|hop|path|provider|model|request)/i;
-  const entries = [];
-  for (const [key, child] of Object.entries(value)) {
-    if (!allowedKey.test(key)) continue;
-    if (
-      typeof child === "number" ||
-      typeof child === "boolean" ||
-      (typeof child === "string" && child.length <= 160)
-    ) {
-      entries.push([key, child]);
-      continue;
-    }
-    const nested = safeTerminalTelemetry(child, depth + 1);
-    if (nested && Object.keys(nested).length > 0) entries.push([key, nested]);
+function finiteFields(source, allowed) {
+  if (!source || typeof source !== "object") return null;
+  const result = Object.fromEntries(
+    allowed
+      .map((key) => [key, source[key]])
+      .filter(([, value]) => Number.isFinite(value) && value >= 0),
+  );
+  return Object.keys(result).length > 0 ? result : null;
+}
+
+function finiteRecord(source) {
+  if (!source || typeof source !== "object" || Array.isArray(source)) {
+    return null;
   }
-  return Object.fromEntries(entries);
+  const result = Object.fromEntries(
+    Object.entries(source).filter(
+      ([key, value]) =>
+        /^[A-Za-z0-9_.:-]{1,100}$/.test(key) &&
+        Number.isFinite(value) &&
+        value >= 0,
+    ),
+  );
+  return Object.keys(result).length > 0 ? result : null;
+}
+
+export function safeTerminalTelemetry(value) {
+  if (!value || typeof value !== "object") return null;
+  const agentRoute = finiteFields(value.agentRoute, [
+    "ingressToSseOpenMs",
+    "ingressToFirstStatusMs",
+    "ingressToFirstTokenMs",
+    "ingressToDoneMs",
+    "ingressToErrorMs",
+  ]);
+  const runtimeSource =
+    value.runtime && typeof value.runtime === "object" ? value.runtime : null;
+  const runtimeScalars = finiteFields(runtimeSource, [
+    "totalMs",
+    "replyReadyMs",
+    "modelFirstSafeChunkMs",
+  ]);
+  const provider = safeErrorToken(runtimeSource?.provider);
+  const contributions = finiteRecord(runtimeSource?.contributions);
+  const marks = finiteRecord(runtimeSource?.marks);
+  const runtime = {
+    ...(runtimeScalars || {}),
+    ...(provider ? { provider } : {}),
+    ...(contributions ? { contributions } : {}),
+    ...(marks ? { marks } : {}),
+  };
+  const result = {
+    ...(agentRoute ? { agentRoute } : {}),
+    ...(Object.keys(runtime).length > 0 ? { runtime } : {}),
+  };
+  return Object.keys(result).length > 0 ? result : null;
 }
 
 function ciContext() {
   const env = (name) => process.env[name] || null;
   return {
     sha: env("GITHUB_SHA"),
+    gatewayDeploySha: env("ELIZA_GATEWAY_DEPLOY_SHA"),
     runId: env("GITHUB_RUN_ID"),
     runAttempt: env("GITHUB_RUN_ATTEMPT"),
     runnerOs: env("RUNNER_OS"),
@@ -299,29 +402,31 @@ function ciContext() {
   };
 }
 
-function baseRecord(target, sequence) {
+function baseRecord(target, sequence, metadata = {}) {
   return {
     schemaVersion: 1,
     observedAt: new Date().toISOString(),
     target,
     sequence,
     ci: ciContext(),
+    ...metadata,
   };
 }
 
-async function probeOpenAi({
+export async function probeOpenAi({
   target,
   probeCase,
   baseUrl,
   apiKey,
   promptOverride,
+  proof,
   timeoutMs,
   sequence,
+  metadata,
   fetchImpl = fetch,
 }) {
-  const proof = `latency-proof-${randomUUID()}`;
-  const prompt =
-    promptOverride || `Reply with one short sentence containing ${proof}`;
+  const expectedProof = proof || ["latency-proof", randomUUID()].join("-");
+  const prompt = buildProofPrompt(promptOverride, expectedProof);
   const traceId = `latency_${randomUUID()}`;
   const root = baseUrl.replace(/\/+$/, "");
   const url = `${root + (target === "direct" ? "/v1" : "/api/v1")}/chat/completions`;
@@ -343,8 +448,9 @@ async function probeOpenAi({
     });
   } catch (error) {
     return {
-      ...baseRecord(target, sequence),
+      ...baseRecord(target, sequence, metadata),
       ok: false,
+      transportOk: false,
       model: probeCase.model,
       reasoningEffort: probeCase.reasoningEffort,
       maxTokens: probeCase.maxTokens,
@@ -359,8 +465,9 @@ async function probeOpenAi({
   const serverTiming = parseServerTiming(response.headers.get("server-timing"));
   if (!response.ok) {
     return {
-      ...baseRecord(target, sequence),
+      ...baseRecord(target, sequence, metadata),
       ok: false,
+      transportOk: false,
       model: probeCase.model,
       reasoningEffort: probeCase.reasoningEffort,
       maxTokens: probeCase.maxTokens,
@@ -375,10 +482,16 @@ async function probeOpenAi({
 
   const stream = await readSse(response.body, startedAt, consumeOpenAiEvent);
   const totalMs = round(performance.now() - startedAt);
-  const proofMatched = stream.outputText.includes(proof);
+  const proofMatched = stream.outputText.includes(expectedProof);
+  const cleanCompletion =
+    stream.sawDone &&
+    stream.malformedEvents === 0 &&
+    stream.finishReason !== null &&
+    !stream.providerError;
   return {
-    ...baseRecord(target, sequence),
-    ok: !stream.providerError && proofMatched,
+    ...baseRecord(target, sequence, metadata),
+    ok: cleanCompletion && proofMatched,
+    transportOk: cleanCompletion,
     model: probeCase.model,
     reasoningEffort: probeCase.reasoningEffort,
     maxTokens: probeCase.maxTokens,
@@ -405,10 +518,16 @@ async function probeOpenAi({
     outputCharacters: stream.outputCharacters,
     reasoningCharacters: stream.reasoningCharacters,
     finishReason: stream.finishReason,
+    sawDone: stream.sawDone,
+    malformedEvents: stream.malformedEvents,
+    cleanCompletion,
     usage: stream.usage,
     providerError: stream.providerError,
     headers,
     serverTiming,
+    preforward: parsePreforwardHeader(
+      response.headers.get("x-eliza-preforward-ms"),
+    ),
   };
 }
 
@@ -433,21 +552,22 @@ async function createConversation(baseUrl, apiKey, traceId, fetchImpl) {
   return id;
 }
 
-async function probeDedicated({
+export async function probeDedicated({
   agentId,
   baseUrl,
   apiKey,
   promptOverride,
+  proof,
   timeoutMs,
   sequence,
+  metadata,
   keepConversation,
   fetchImpl = fetch,
 }) {
   const target = "dedicated";
   const traceId = `latency_${randomUUID()}`;
-  const proof = `latency-proof-${randomUUID()}`;
-  const prompt =
-    promptOverride || `Reply with one short sentence containing ${proof}`;
+  const expectedProof = proof || ["latency-proof", randomUUID()].join("-");
+  const prompt = buildProofPrompt(promptOverride, expectedProof);
   let conversationId = null;
   try {
     conversationId = await createConversation(
@@ -487,8 +607,9 @@ async function probeDedicated({
     );
     if (!response.ok) {
       return {
-        ...baseRecord(target, sequence),
+        ...baseRecord(target, sequence, metadata),
         ok: false,
+        transportOk: false,
         agentId,
         traceId: response.headers.get("x-eliza-trace-id") || traceId,
         responseHeadersMs,
@@ -500,10 +621,14 @@ async function probeDedicated({
     }
     const stream = await readSse(response.body, startedAt, consumeAgentEvent);
     const totalMs = round(performance.now() - startedAt);
-    const proofMatched = stream.outputText.includes(proof);
+    const proofMatched = stream.outputText.includes(expectedProof);
+    const terminalType = stream.terminal?.type ?? null;
+    const cleanCompletion =
+      terminalType === "done" && stream.malformedEvents === 0;
     return {
-      ...baseRecord(target, sequence),
-      ok: proofMatched,
+      ...baseRecord(target, sequence, metadata),
+      ok: cleanCompletion && proofMatched,
+      transportOk: cleanCompletion,
       agentId,
       status: response.status,
       traceId: response.headers.get("x-eliza-trace-id") || traceId,
@@ -520,15 +645,22 @@ async function probeDedicated({
           ? null
           : round(totalMs - stream.firstTokenMs),
       proofMatched,
+      terminalType,
+      malformedEvents: stream.malformedEvents,
+      cleanCompletion,
       outputCharacters: stream.outputCharacters,
       headers,
       serverTiming,
+      preforward: parsePreforwardHeader(
+        response.headers.get("x-eliza-preforward-ms"),
+      ),
       terminalTelemetry: safeTerminalTelemetry(stream.terminal?.telemetry),
     };
   } catch (error) {
     return {
-      ...baseRecord(target, sequence),
+      ...baseRecord(target, sequence, metadata),
       ok: false,
+      transportOk: false,
       agentId,
       traceId,
       networkError: safeErrorToken(error?.name) || "DedicatedProbeError",
@@ -548,21 +680,155 @@ async function probeDedicated({
   }
 }
 
+export async function runPairedProbes({
+  cases,
+  repeats,
+  direct,
+  gateway,
+  promptOverride,
+  timeoutMs,
+  idleMs,
+  seed,
+  fetchImpl = fetch,
+  sleepImpl = (durationMs) =>
+    new Promise((resolvePromise) => setTimeout(resolvePromise, durationMs)),
+  onRecord = () => undefined,
+}) {
+  const random = seededRandom(seed);
+  const records = [];
+  const targets = { direct, gateway };
+
+  const runPhase = async (phase, count) => {
+    for (let sequence = 1; sequence <= count; sequence += 1) {
+      for (const probeCase of shuffled(cases, random)) {
+        const proof = `latency-proof-${randomUUID()}`;
+        const pairId = randomUUID();
+        const order =
+          random() < 0.5 ? [`direct`, `gateway`] : [`gateway`, `direct`];
+        for (const target of order) {
+          const config = targets[target];
+          const record = await probeOpenAi({
+            target,
+            probeCase,
+            baseUrl: config.baseUrl,
+            apiKey: config.apiKey,
+            promptOverride,
+            proof,
+            timeoutMs,
+            sequence,
+            metadata: {
+              phase,
+              pairId,
+              targetOrder: order.join(">"),
+              benchmarkSeed: seed,
+            },
+            fetchImpl,
+          });
+          records.push(record);
+          onRecord(record);
+        }
+      }
+    }
+  };
+
+  await runPhase("cold", 1);
+  await runPhase("warm", repeats);
+  if (idleMs > 0) await sleepImpl(idleMs);
+  await runPhase("post-idle", 1);
+  return records;
+}
+
+function percentile(values, quantile) {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((left, right) => left - right);
+  const index = (sorted.length - 1) * quantile;
+  const lower = Math.floor(index);
+  const upper = Math.ceil(index);
+  if (lower === upper) return round(sorted[lower]);
+  const weight = index - lower;
+  return round(sorted[lower] * (1 - weight) + sorted[upper] * weight);
+}
+
+export function summarizeLatencyRecords(records) {
+  const groups = new Map();
+  for (const record of records) {
+    if (record.phase !== "warm") continue;
+    const key = JSON.stringify([
+      record.target,
+      record.model,
+      record.reasoningEffort,
+      record.maxTokens,
+    ]);
+    const group = groups.get(key) || {
+      target: record.target,
+      model: record.model,
+      reasoningEffort: record.reasoningEffort,
+      maxTokens: record.maxTokens,
+      records: [],
+    };
+    group.records.push(record);
+    groups.set(key, group);
+  }
+
+  return [...groups.values()]
+    .map((group) => {
+      const successful = group.records.filter((record) => record.ok);
+      const metric = (selector) => {
+        const values = successful
+          .map(selector)
+          .filter((value) => Number.isFinite(value));
+        return {
+          p50: percentile(values, 0.5),
+          p90: percentile(values, 0.9),
+          p95: percentile(values, 0.95),
+        };
+      };
+      return {
+        target: group.target,
+        model: group.model,
+        reasoningEffort: group.reasoningEffort,
+        maxTokens: group.maxTokens,
+        samples: group.records.length,
+        successes: successful.length,
+        failures: group.records.length - successful.length,
+        responseHeadersMs: metric((record) => record.responseHeadersMs),
+        firstTokenMs: metric((record) => record.firstTokenMs),
+        totalMs: metric((record) => record.totalMs),
+        preforwardMs: metric((record) => record.preforward?.total),
+      };
+    })
+    .sort((left, right) =>
+      [left.model, left.reasoningEffort, left.maxTokens, left.target]
+        .join(":")
+        .localeCompare(
+          [
+            right.model,
+            right.reasoningEffort,
+            right.maxTokens,
+            right.target,
+          ].join(":"),
+        ),
+    );
+}
+
 function printHelp() {
   process.stdout.write(
     [
-      "Usage: chat-latency.mjs --target direct|gateway|dedicated [options]",
+      "Usage: chat-latency.mjs --target direct|gateway|paired|dedicated [options]",
       "",
       "OpenAI-compatible targets:",
       "  --case model[@omit|none|low|medium|high][@max_tokens] (repeatable)",
       "  --model model (repeatable; uses --reasoning-effort and --max-tokens)",
+      "  --target paired counterbalances identical direct/gateway requests",
       "",
       "Dedicated target:",
       "  --agent-id uuid [--base-url https://agent-host]",
       "",
       "Common:",
-      "  --repeat 1..10 --timeout-ms 1000..180000 --api-key-env NAME",
-      "  --prompt text --keep-conversation",
+      "  --repeat 1..100 --timeout-ms 1000..180000 --api-key-env NAME",
+      "  --idle-ms 0..300000 --seed SAFE_ID --prompt text",
+      "  --max-proof-miss-rate 0..1 (paired benchmark only)",
+      "  --keep-conversation",
       "",
       "Credentials are read only from environment variables and are never printed.",
       "",
@@ -585,6 +851,13 @@ export async function runCli(argv = process.argv.slice(2)) {
       repeat: { type: "string", default: "1" },
       "timeout-ms": { type: "string", default: "90000" },
       "api-key-env": { type: "string" },
+      "direct-api-key-env": { type: "string" },
+      "gateway-api-key-env": { type: "string" },
+      "direct-base-url": { type: "string" },
+      "gateway-base-url": { type: "string" },
+      "idle-ms": { type: "string", default: "30000" },
+      seed: { type: "string" },
+      "max-proof-miss-rate": { type: "string", default: "0" },
       "keep-conversation": { type: "boolean", default: false },
       help: { type: "boolean", short: "h", default: false },
     },
@@ -598,7 +871,7 @@ export async function runCli(argv = process.argv.slice(2)) {
   }
   const target = values.target;
   if (!TARGETS.has(target)) throw new Error(`Unsupported target: ${target}`);
-  const repeats = boundedInteger(values.repeat, "repeat", 1, 10);
+  const repeats = boundedInteger(values.repeat, "repeat", 1, 100);
   const timeoutMs = boundedInteger(
     values["timeout-ms"],
     "timeout-ms",
@@ -611,81 +884,140 @@ export async function runCli(argv = process.argv.slice(2)) {
     1,
     16_384,
   );
-  const defaultKeyEnv =
-    target === "direct" ? "CEREBRAS_API_KEY" : "ELIZA_CLOUD_API_KEY";
-  const keyEnv = values["api-key-env"] || defaultKeyEnv;
-  const apiKey = process.env[keyEnv]?.trim();
-  if (!apiKey) {
-    throw new Error(`Set ${keyEnv}; credential values are never printed`);
+  const idleMs = boundedInteger(values["idle-ms"], "idle-ms", 0, 300_000);
+  const maxProofMissRate = boundedNumber(
+    values["max-proof-miss-rate"],
+    "max-proof-miss-rate",
+    0,
+    1,
+  );
+  const benchmarkSeed =
+    values.seed?.trim() || ["latency", randomUUID()].join("-");
+  if (!/^[A-Za-z0-9_.:-]{1,100}$/.test(benchmarkSeed)) {
+    throw new Error("--seed must be a privacy-safe identifier");
   }
 
-  const records = [];
-  if (target === "dedicated") {
-    const agentId = values["agent-id"]?.trim();
-    if (!agentId)
-      throw new Error("--agent-id is required for dedicated probes");
-    const baseUrl = (
-      values["base-url"] || `https://${agentId}.elizacloud.ai`
-    ).replace(/\/+$/, "");
-    for (let sequence = 1; sequence <= repeats; sequence += 1) {
-      records.push(
-        await probeDedicated({
-          agentId,
-          baseUrl,
-          apiKey,
-          promptOverride: values.prompt,
-          timeoutMs,
-          sequence,
-          keepConversation: values["keep-conversation"],
-        }),
-      );
+  let cases;
+  if (values.case?.length) {
+    cases = values.case.map((value) =>
+      parseProbeCase(value, fallbackMaxTokens),
+    );
+  } else if (values.model?.length) {
+    const effort = values["reasoning-effort"];
+    if (!REASONING_EFFORTS.has(effort)) {
+      throw new Error(`Unsupported --reasoning-effort: ${effort}`);
     }
+    cases = values.model.map((model) =>
+      parseProbeCase(
+        `${model}@${effort}@${fallbackMaxTokens}`,
+        fallbackMaxTokens,
+      ),
+    );
   } else {
-    let cases;
-    if (values.case?.length) {
-      cases = values.case.map((value) =>
-        parseProbeCase(value, fallbackMaxTokens),
-      );
-    } else if (values.model?.length) {
-      const effort = values["reasoning-effort"];
-      if (!REASONING_EFFORTS.has(effort)) {
-        throw new Error(`Unsupported --reasoning-effort: ${effort}`);
-      }
-      cases = values.model.map((model) =>
-        parseProbeCase(
-          `${model}@${effort}@${fallbackMaxTokens}`,
-          fallbackMaxTokens,
-        ),
-      );
-    } else {
-      cases = DEFAULT_PROBE_CASES.map((value) =>
-        parseProbeCase(value, fallbackMaxTokens),
-      );
+    cases = DEFAULT_PROBE_CASES.map((value) =>
+      parseProbeCase(value, fallbackMaxTokens),
+    );
+  }
+
+  const readKey = (name) => {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+      throw new Error("Credential environment variable name is invalid");
     }
-    const baseUrl =
-      values["base-url"] ||
-      (target === "direct"
-        ? "https://api.cerebras.ai"
-        : "https://api.elizacloud.ai");
-    for (const probeCase of cases) {
+    const key = process.env[name]?.trim();
+    if (!key) {
+      throw new Error(`Set ${name}; credential values are never printed`);
+    }
+    return key;
+  };
+
+  let records = [];
+  let streamedRecords = false;
+  if (target === "paired") {
+    const directKeyEnv = values["direct-api-key-env"] || "CEREBRAS_API_KEY";
+    const gatewayKeyEnv =
+      values["gateway-api-key-env"] || "ELIZA_CLOUD_API_KEY";
+    records = await runPairedProbes({
+      cases,
+      repeats,
+      direct: {
+        baseUrl: values["direct-base-url"] || "https://api.cerebras.ai",
+        apiKey: readKey(directKeyEnv),
+      },
+      gateway: {
+        baseUrl: values["gateway-base-url"] || "https://api.elizacloud.ai",
+        apiKey: readKey(gatewayKeyEnv),
+      },
+      promptOverride: values.prompt,
+      timeoutMs,
+      idleMs,
+      seed: benchmarkSeed,
+      onRecord: (record) => process.stdout.write(`${JSON.stringify(record)}\n`),
+    });
+    streamedRecords = true;
+  } else {
+    const defaultKeyEnv =
+      target === "direct" ? "CEREBRAS_API_KEY" : "ELIZA_CLOUD_API_KEY";
+    const keyEnv = values["api-key-env"] || defaultKeyEnv;
+    const apiKey = readKey(keyEnv);
+    if (target === "dedicated") {
+      const agentId = values["agent-id"]?.trim();
+      if (!agentId)
+        throw new Error("--agent-id is required for dedicated probes");
+      const baseUrl = (
+        values["base-url"] || `https://${agentId}.elizacloud.ai`
+      ).replace(/\/+$/, "");
       for (let sequence = 1; sequence <= repeats; sequence += 1) {
         records.push(
-          await probeOpenAi({
-            target,
-            probeCase,
+          await probeDedicated({
+            agentId,
             baseUrl,
             apiKey,
             promptOverride: values.prompt,
             timeoutMs,
             sequence,
+            keepConversation: values["keep-conversation"],
           }),
         );
+      }
+    } else {
+      const baseUrl =
+        values["base-url"] ||
+        (target === "direct"
+          ? "https://api.cerebras.ai"
+          : "https://api.elizacloud.ai");
+      for (const probeCase of cases) {
+        for (let sequence = 1; sequence <= repeats; sequence += 1) {
+          records.push(
+            await probeOpenAi({
+              target,
+              probeCase,
+              baseUrl,
+              apiKey,
+              promptOverride: values.prompt,
+              timeoutMs,
+              sequence,
+            }),
+          );
+        }
       }
     }
   }
 
-  for (const record of records) {
-    process.stdout.write(`${JSON.stringify(record)}\n`);
+  if (!streamedRecords) {
+    for (const record of records) {
+      process.stdout.write(`${JSON.stringify(record)}\n`);
+    }
+  }
+  if (streamedRecords) {
+    const transportPassed = records.every(
+      (record) => record.transportOk === true,
+    );
+    const completed = records.filter((record) => record.transportOk === true);
+    const proofMisses = completed.filter(
+      (record) => record.proofMatched !== true,
+    ).length;
+    const proofMissRate = completed.length ? proofMisses / completed.length : 1;
+    return transportPassed && proofMissRate <= maxProofMissRate ? 0 : 2;
   }
   return records.every((record) => record.ok) ? 0 : 2;
 }

--- a/packages/scripts/cloud/chat-latency.mjs
+++ b/packages/scripts/cloud/chat-latency.mjs
@@ -1,0 +1,709 @@
+#!/usr/bin/env node
+/**
+ * Privacy-safe live latency probe for Cerebras direct, the Eliza Cloud model
+ * gateway, and dedicated agents.
+ *
+ * The probe never prints credentials, prompts, or generated text. Each JSONL
+ * record contains only timing boundaries, selected response headers, token
+ * usage, output length, and whether a random proof nonce was returned.
+ */
+
+import { randomUUID } from "node:crypto";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { parseArgs } from "node:util";
+
+const TARGETS = new Set(["direct", "gateway", "dedicated"]);
+const REASONING_EFFORTS = new Set(["omit", "none", "low", "medium", "high"]);
+const SAFE_RESPONSE_HEADERS = [
+  "cf-ray",
+  "server-timing",
+  "x-eliza-trace-id",
+  "x-eliza-preforward-ms",
+  "x-eliza-inference-path",
+  "x-request-id",
+];
+
+export const DEFAULT_PROBE_CASES = [
+  "gemma-4-31b@omit@512",
+  "gemma-4-31b@none@512",
+  "zai-glm-4.7@omit@4096",
+  "zai-glm-4.7@none@512",
+];
+
+function boundedInteger(value, label, minimum, maximum) {
+  const parsed = Number.parseInt(String(value), 10);
+  if (!Number.isSafeInteger(parsed) || parsed < minimum || parsed > maximum) {
+    throw new Error(
+      `${label} must be an integer between ${minimum} and ${maximum}`,
+    );
+  }
+  return parsed;
+}
+
+export function parseProbeCase(raw, fallbackMaxTokens = 512) {
+  const parts = String(raw).split("@");
+  if (parts.length > 3) {
+    throw new Error(
+      `Probe case must be model[@reasoning_effort][@max_tokens]: ${raw}`,
+    );
+  }
+  const model = parts[0]?.trim();
+  const reasoningEffort = (parts[1]?.trim() || "omit").toLowerCase();
+  if (!model) throw new Error("Probe case model must not be empty");
+  if (!REASONING_EFFORTS.has(reasoningEffort)) {
+    throw new Error(`Unsupported reasoning effort in probe case: ${raw}`);
+  }
+  const maxTokens = boundedInteger(
+    parts[2]?.trim() || fallbackMaxTokens,
+    "max_tokens",
+    1,
+    16_384,
+  );
+  return { model, reasoningEffort, maxTokens };
+}
+
+function round(value) {
+  return Math.round(value * 100) / 100;
+}
+
+function elapsed(now, startedAt) {
+  return round(now() - startedAt);
+}
+
+export function parseServerTiming(value) {
+  if (!value) return {};
+  const result = {};
+  for (const entry of value.split(",")) {
+    const [rawName, ...parameters] = entry.trim().split(";");
+    const name = rawName?.trim();
+    if (!name || !/^[A-Za-z0-9_-]+$/.test(name)) continue;
+    const duration = parameters
+      .map((parameter) => parameter.trim())
+      .find((parameter) => parameter.startsWith("dur="));
+    if (!duration) continue;
+    const number = Number(duration.slice(4).replace(/^"|"$/g, ""));
+    if (Number.isFinite(number) && number >= 0) result[name] = round(number);
+  }
+  return result;
+}
+
+export function selectedResponseHeaders(headers) {
+  return Object.fromEntries(
+    SAFE_RESPONSE_HEADERS.map((name) => [name, headers.get(name)]).filter(
+      ([, value]) => typeof value === "string" && value.length > 0,
+    ),
+  );
+}
+
+function normalizeUsage(value) {
+  if (!value || typeof value !== "object") return null;
+  const allowed = [
+    "prompt_tokens",
+    "completion_tokens",
+    "total_tokens",
+    "input_tokens",
+    "output_tokens",
+  ];
+  const usage = Object.fromEntries(
+    allowed
+      .map((key) => [key, value[key]])
+      .filter(([, number]) => Number.isFinite(number) && number >= 0),
+  );
+  return Object.keys(usage).length > 0 ? usage : null;
+}
+
+function safeErrorToken(value) {
+  return typeof value === "string" && /^[A-Za-z0-9_.:-]{1,100}$/.test(value)
+    ? value
+    : null;
+}
+
+export async function safeHttpError(response) {
+  let parsed = null;
+  try {
+    parsed = JSON.parse(await response.text());
+  } catch {
+    // Deliberately omit arbitrary upstream response text from evidence.
+  }
+  const source =
+    parsed?.error && typeof parsed.error === "object" ? parsed.error : parsed;
+  return {
+    status: response.status,
+    type: safeErrorToken(source?.type),
+    code: safeErrorToken(source?.code),
+  };
+}
+
+export function buildOpenAiRequestBody(probeCase, prompt) {
+  const body = {
+    model: probeCase.model,
+    messages: [{ role: "user", content: prompt }],
+    stream: true,
+    stream_options: { include_usage: true },
+    max_tokens: probeCase.maxTokens,
+  };
+  if (probeCase.reasoningEffort !== "omit") {
+    body.reasoning_effort = probeCase.reasoningEffort;
+  }
+  return body;
+}
+
+export function consumeOpenAiEvent(event) {
+  const choice = event?.choices?.[0];
+  const delta = choice?.delta;
+  const content = typeof delta?.content === "string" ? delta.content : "";
+  const reasoningCandidates = [
+    delta?.reasoning_content,
+    delta?.reasoning,
+    delta?.thinking,
+  ];
+  const reasoning =
+    reasoningCandidates.find((value) => typeof value === "string") || "";
+  const error = event?.error;
+  return {
+    content,
+    reasoning,
+    finishReason:
+      typeof choice?.finish_reason === "string" ? choice.finish_reason : null,
+    usage: normalizeUsage(event?.usage),
+    providerError:
+      error && typeof error === "object"
+        ? {
+            type: safeErrorToken(error.type),
+            code: safeErrorToken(error.code),
+          }
+        : null,
+  };
+}
+
+export function consumeAgentEvent(event) {
+  const candidates =
+    event?.type === "token"
+      ? [event.text, event.delta, event.token]
+      : [event?.delta, event?.token];
+  const content = candidates.find((value) => typeof value === "string") || "";
+  return {
+    content,
+    terminal: event?.type === "done" || event?.type === "error" ? event : null,
+  };
+}
+
+export async function readSse(
+  body,
+  startedAt,
+  consumeEvent,
+  now = () => performance.now(),
+) {
+  if (!body) throw new Error("Response has no body");
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let firstEventMs = null;
+  let firstReasoningMs = null;
+  let firstTokenMs = null;
+  let outputCharacters = 0;
+  let reasoningCharacters = 0;
+  let outputText = "";
+  let usage = null;
+  let finishReason = null;
+  let providerError = null;
+  let terminal = null;
+
+  const consumeLine = (line) => {
+    if (!line.startsWith("data:")) return;
+    const payload = line.slice(5).trim();
+    if (!payload || payload === "[DONE]") return;
+    let event;
+    try {
+      event = JSON.parse(payload);
+    } catch {
+      return;
+    }
+    if (firstEventMs === null) firstEventMs = elapsed(now, startedAt);
+    const observation = consumeEvent(event) || {};
+    if (observation.reasoning) {
+      if (firstReasoningMs === null) {
+        firstReasoningMs = elapsed(now, startedAt);
+      }
+      reasoningCharacters += observation.reasoning.length;
+    }
+    if (observation.content) {
+      if (firstTokenMs === null) firstTokenMs = elapsed(now, startedAt);
+      outputText += observation.content;
+      outputCharacters += observation.content.length;
+    }
+    if (observation.usage) usage = observation.usage;
+    if (observation.finishReason) finishReason = observation.finishReason;
+    if (observation.providerError) providerError = observation.providerError;
+    if (observation.terminal) terminal = observation.terminal;
+  };
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    let newline = buffer.indexOf("\n");
+    while (newline >= 0) {
+      consumeLine(buffer.slice(0, newline).trim());
+      buffer = buffer.slice(newline + 1);
+      newline = buffer.indexOf("\n");
+    }
+  }
+  buffer += decoder.decode();
+  if (buffer.trim()) consumeLine(buffer.trim());
+
+  return {
+    firstEventMs,
+    firstReasoningMs,
+    firstTokenMs,
+    outputCharacters,
+    reasoningCharacters,
+    outputText,
+    usage,
+    finishReason,
+    providerError,
+    terminal,
+  };
+}
+
+function safeTerminalTelemetry(value, depth = 0) {
+  if (!value || typeof value !== "object" || depth > 3) return null;
+  const allowedKey =
+    /(?:trace|timing|latency|duration|elapsed|ttf|first|done|status|stage|hop|path|provider|model|request)/i;
+  const entries = [];
+  for (const [key, child] of Object.entries(value)) {
+    if (!allowedKey.test(key)) continue;
+    if (
+      typeof child === "number" ||
+      typeof child === "boolean" ||
+      (typeof child === "string" && child.length <= 160)
+    ) {
+      entries.push([key, child]);
+      continue;
+    }
+    const nested = safeTerminalTelemetry(child, depth + 1);
+    if (nested && Object.keys(nested).length > 0) entries.push([key, nested]);
+  }
+  return Object.fromEntries(entries);
+}
+
+function ciContext() {
+  const env = (name) => process.env[name] || null;
+  return {
+    sha: env("GITHUB_SHA"),
+    runId: env("GITHUB_RUN_ID"),
+    runAttempt: env("GITHUB_RUN_ATTEMPT"),
+    runnerOs: env("RUNNER_OS"),
+    runnerArch: env("RUNNER_ARCH"),
+  };
+}
+
+function baseRecord(target, sequence) {
+  return {
+    schemaVersion: 1,
+    observedAt: new Date().toISOString(),
+    target,
+    sequence,
+    ci: ciContext(),
+  };
+}
+
+async function probeOpenAi({
+  target,
+  probeCase,
+  baseUrl,
+  apiKey,
+  promptOverride,
+  timeoutMs,
+  sequence,
+  fetchImpl = fetch,
+}) {
+  const proof = `latency-proof-${randomUUID()}`;
+  const prompt =
+    promptOverride || `Reply with one short sentence containing ${proof}`;
+  const traceId = `latency_${randomUUID()}`;
+  const root = baseUrl.replace(/\/+$/, "");
+  const url = `${root + (target === "direct" ? "/v1" : "/api/v1")}/chat/completions`;
+  const startedAt = performance.now();
+  let response;
+  try {
+    response = await fetchImpl(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+        Accept: "text/event-stream",
+        "X-Eliza-Trace-Id": traceId,
+        "X-Eliza-Telemetry": "full",
+        "User-Agent": "eliza-chat-latency/1.0",
+      },
+      body: JSON.stringify(buildOpenAiRequestBody(probeCase, prompt)),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (error) {
+    return {
+      ...baseRecord(target, sequence),
+      ok: false,
+      model: probeCase.model,
+      reasoningEffort: probeCase.reasoningEffort,
+      maxTokens: probeCase.maxTokens,
+      traceId,
+      totalMs: round(performance.now() - startedAt),
+      networkError: safeErrorToken(error?.name) || "NetworkError",
+    };
+  }
+
+  const responseHeadersMs = round(performance.now() - startedAt);
+  const headers = selectedResponseHeaders(response.headers);
+  const serverTiming = parseServerTiming(response.headers.get("server-timing"));
+  if (!response.ok) {
+    return {
+      ...baseRecord(target, sequence),
+      ok: false,
+      model: probeCase.model,
+      reasoningEffort: probeCase.reasoningEffort,
+      maxTokens: probeCase.maxTokens,
+      traceId: response.headers.get("x-eliza-trace-id") || traceId,
+      responseHeadersMs,
+      totalMs: round(performance.now() - startedAt),
+      headers,
+      serverTiming,
+      error: await safeHttpError(response),
+    };
+  }
+
+  const stream = await readSse(response.body, startedAt, consumeOpenAiEvent);
+  const totalMs = round(performance.now() - startedAt);
+  const proofMatched = stream.outputText.includes(proof);
+  return {
+    ...baseRecord(target, sequence),
+    ok: !stream.providerError && proofMatched,
+    model: probeCase.model,
+    reasoningEffort: probeCase.reasoningEffort,
+    maxTokens: probeCase.maxTokens,
+    status: response.status,
+    traceId: response.headers.get("x-eliza-trace-id") || traceId,
+    responseHeadersMs,
+    firstEventMs: stream.firstEventMs,
+    firstReasoningMs: stream.firstReasoningMs,
+    firstTokenMs: stream.firstTokenMs,
+    totalMs,
+    headersToFirstEventMs:
+      stream.firstEventMs === null
+        ? null
+        : round(stream.firstEventMs - responseHeadersMs),
+    headersToFirstTokenMs:
+      stream.firstTokenMs === null
+        ? null
+        : round(stream.firstTokenMs - responseHeadersMs),
+    firstTokenToDoneMs:
+      stream.firstTokenMs === null
+        ? null
+        : round(totalMs - stream.firstTokenMs),
+    proofMatched,
+    outputCharacters: stream.outputCharacters,
+    reasoningCharacters: stream.reasoningCharacters,
+    finishReason: stream.finishReason,
+    usage: stream.usage,
+    providerError: stream.providerError,
+    headers,
+    serverTiming,
+  };
+}
+
+async function createConversation(baseUrl, apiKey, traceId, fetchImpl) {
+  const response = await fetchImpl(`${baseUrl}/api/conversations`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+      "X-Eliza-Trace-Id": traceId,
+      "User-Agent": "eliza-chat-latency/1.0",
+    },
+    body: JSON.stringify({ title: `latency-${Date.now()}` }),
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!response.ok) {
+    throw new Error(`CreateConversationHttp${response.status}`);
+  }
+  const body = await response.json();
+  const id = body?.conversation?.id || body?.id;
+  if (typeof id !== "string") throw new Error("ConversationIdMissing");
+  return id;
+}
+
+async function probeDedicated({
+  agentId,
+  baseUrl,
+  apiKey,
+  promptOverride,
+  timeoutMs,
+  sequence,
+  keepConversation,
+  fetchImpl = fetch,
+}) {
+  const target = "dedicated";
+  const traceId = `latency_${randomUUID()}`;
+  const proof = `latency-proof-${randomUUID()}`;
+  const prompt =
+    promptOverride || `Reply with one short sentence containing ${proof}`;
+  let conversationId = null;
+  try {
+    conversationId = await createConversation(
+      baseUrl,
+      apiKey,
+      traceId,
+      fetchImpl,
+    );
+    const startedAt = performance.now();
+    const response = await fetchImpl(
+      baseUrl +
+        "/api/conversations/" +
+        encodeURIComponent(conversationId) +
+        "/messages/stream",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+          Accept: "text/event-stream",
+          "X-Eliza-Trace-Id": traceId,
+          "X-Eliza-Telemetry": "full",
+          "User-Agent": "eliza-chat-latency/1.0",
+        },
+        body: JSON.stringify({
+          text: prompt,
+          channelType: "DM",
+          clientMessageId: randomUUID(),
+        }),
+        signal: AbortSignal.timeout(timeoutMs),
+      },
+    );
+    const responseHeadersMs = round(performance.now() - startedAt);
+    const headers = selectedResponseHeaders(response.headers);
+    const serverTiming = parseServerTiming(
+      response.headers.get("server-timing"),
+    );
+    if (!response.ok) {
+      return {
+        ...baseRecord(target, sequence),
+        ok: false,
+        agentId,
+        traceId: response.headers.get("x-eliza-trace-id") || traceId,
+        responseHeadersMs,
+        totalMs: round(performance.now() - startedAt),
+        headers,
+        serverTiming,
+        error: await safeHttpError(response),
+      };
+    }
+    const stream = await readSse(response.body, startedAt, consumeAgentEvent);
+    const totalMs = round(performance.now() - startedAt);
+    const proofMatched = stream.outputText.includes(proof);
+    return {
+      ...baseRecord(target, sequence),
+      ok: proofMatched,
+      agentId,
+      status: response.status,
+      traceId: response.headers.get("x-eliza-trace-id") || traceId,
+      responseHeadersMs,
+      firstEventMs: stream.firstEventMs,
+      firstTokenMs: stream.firstTokenMs,
+      totalMs,
+      headersToFirstTokenMs:
+        stream.firstTokenMs === null
+          ? null
+          : round(stream.firstTokenMs - responseHeadersMs),
+      firstTokenToDoneMs:
+        stream.firstTokenMs === null
+          ? null
+          : round(totalMs - stream.firstTokenMs),
+      proofMatched,
+      outputCharacters: stream.outputCharacters,
+      headers,
+      serverTiming,
+      terminalTelemetry: safeTerminalTelemetry(stream.terminal?.telemetry),
+    };
+  } catch (error) {
+    return {
+      ...baseRecord(target, sequence),
+      ok: false,
+      agentId,
+      traceId,
+      networkError: safeErrorToken(error?.name) || "DedicatedProbeError",
+      errorCode: safeErrorToken(error?.message),
+    };
+  } finally {
+    if (conversationId && !keepConversation) {
+      await fetchImpl(
+        `${baseUrl}/api/conversations/${encodeURIComponent(conversationId)}`,
+        {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${apiKey}` },
+          signal: AbortSignal.timeout(15_000),
+        },
+      ).catch(() => undefined);
+    }
+  }
+}
+
+function printHelp() {
+  process.stdout.write(
+    [
+      "Usage: chat-latency.mjs --target direct|gateway|dedicated [options]",
+      "",
+      "OpenAI-compatible targets:",
+      "  --case model[@omit|none|low|medium|high][@max_tokens] (repeatable)",
+      "  --model model (repeatable; uses --reasoning-effort and --max-tokens)",
+      "",
+      "Dedicated target:",
+      "  --agent-id uuid [--base-url https://agent-host]",
+      "",
+      "Common:",
+      "  --repeat 1..10 --timeout-ms 1000..180000 --api-key-env NAME",
+      "  --prompt text --keep-conversation",
+      "",
+      "Credentials are read only from environment variables and are never printed.",
+      "",
+    ].join("\n"),
+  );
+}
+
+export async function runCli(argv = process.argv.slice(2)) {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      target: { type: "string", default: "gateway" },
+      case: { type: "string", multiple: true },
+      model: { type: "string", multiple: true },
+      "reasoning-effort": { type: "string", default: "omit" },
+      "agent-id": { type: "string" },
+      "base-url": { type: "string" },
+      prompt: { type: "string" },
+      "max-tokens": { type: "string", default: "512" },
+      repeat: { type: "string", default: "1" },
+      "timeout-ms": { type: "string", default: "90000" },
+      "api-key-env": { type: "string" },
+      "keep-conversation": { type: "boolean", default: false },
+      help: { type: "boolean", short: "h", default: false },
+    },
+    strict: true,
+    allowPositionals: false,
+  });
+
+  if (values.help) {
+    printHelp();
+    return 0;
+  }
+  const target = values.target;
+  if (!TARGETS.has(target)) throw new Error(`Unsupported target: ${target}`);
+  const repeats = boundedInteger(values.repeat, "repeat", 1, 10);
+  const timeoutMs = boundedInteger(
+    values["timeout-ms"],
+    "timeout-ms",
+    1_000,
+    180_000,
+  );
+  const fallbackMaxTokens = boundedInteger(
+    values["max-tokens"],
+    "max-tokens",
+    1,
+    16_384,
+  );
+  const defaultKeyEnv =
+    target === "direct" ? "CEREBRAS_API_KEY" : "ELIZA_CLOUD_API_KEY";
+  const keyEnv = values["api-key-env"] || defaultKeyEnv;
+  const apiKey = process.env[keyEnv]?.trim();
+  if (!apiKey) {
+    throw new Error(`Set ${keyEnv}; credential values are never printed`);
+  }
+
+  const records = [];
+  if (target === "dedicated") {
+    const agentId = values["agent-id"]?.trim();
+    if (!agentId)
+      throw new Error("--agent-id is required for dedicated probes");
+    const baseUrl = (
+      values["base-url"] || `https://${agentId}.elizacloud.ai`
+    ).replace(/\/+$/, "");
+    for (let sequence = 1; sequence <= repeats; sequence += 1) {
+      records.push(
+        await probeDedicated({
+          agentId,
+          baseUrl,
+          apiKey,
+          promptOverride: values.prompt,
+          timeoutMs,
+          sequence,
+          keepConversation: values["keep-conversation"],
+        }),
+      );
+    }
+  } else {
+    let cases;
+    if (values.case?.length) {
+      cases = values.case.map((value) =>
+        parseProbeCase(value, fallbackMaxTokens),
+      );
+    } else if (values.model?.length) {
+      const effort = values["reasoning-effort"];
+      if (!REASONING_EFFORTS.has(effort)) {
+        throw new Error(`Unsupported --reasoning-effort: ${effort}`);
+      }
+      cases = values.model.map((model) =>
+        parseProbeCase(
+          `${model}@${effort}@${fallbackMaxTokens}`,
+          fallbackMaxTokens,
+        ),
+      );
+    } else {
+      cases = DEFAULT_PROBE_CASES.map((value) =>
+        parseProbeCase(value, fallbackMaxTokens),
+      );
+    }
+    const baseUrl =
+      values["base-url"] ||
+      (target === "direct"
+        ? "https://api.cerebras.ai"
+        : "https://api.elizacloud.ai");
+    for (const probeCase of cases) {
+      for (let sequence = 1; sequence <= repeats; sequence += 1) {
+        records.push(
+          await probeOpenAi({
+            target,
+            probeCase,
+            baseUrl,
+            apiKey,
+            promptOverride: values.prompt,
+            timeoutMs,
+            sequence,
+          }),
+        );
+      }
+    }
+  }
+
+  for (const record of records) {
+    process.stdout.write(`${JSON.stringify(record)}\n`);
+  }
+  return records.every((record) => record.ok) ? 0 : 2;
+}
+
+const invokedPath = process.argv[1]
+  ? pathToFileURL(resolve(process.argv[1])).href
+  : null;
+if (invokedPath === import.meta.url) {
+  runCli()
+    .then((exitCode) => {
+      process.exitCode = exitCode;
+    })
+    .catch((error) => {
+      process.stderr.write(
+        "[chat-latency] " +
+          (error instanceof Error ? error.message : String(error)) +
+          "\n",
+      );
+      process.exitCode = 1;
+    });
+}

--- a/packages/scripts/cloud/chat-latency.mjs
+++ b/packages/scripts/cloud/chat-latency.mjs
@@ -713,6 +713,7 @@ export async function runPairedProbes({
   promptOverride,
   timeoutMs,
   idleMs,
+  pairIntervalMs = 0,
   seed,
   fetchImpl = fetch,
   sleepImpl = (durationMs) =>
@@ -724,9 +725,16 @@ export async function runPairedProbes({
   const targets = { direct, gateway };
   const nextFirstTarget = new Map();
 
-  const runPhase = async (phase, count, { idleBeforeEachTarget = false } = {}) => {
+  const runPhase = async (
+    phase,
+    count,
+    { idleBeforeEachTarget = false, pacePairs = false } = {},
+  ) => {
     for (let sequence = 1; sequence <= count; sequence += 1) {
       for (const probeCase of shuffled(cases, random)) {
+        if (pacePairs && pairIntervalMs > 0) {
+          await sleepImpl(pairIntervalMs);
+        }
         const proof = `latency-proof-${randomUUID()}`;
         const pairId = randomUUID();
         const caseKey = JSON.stringify([
@@ -760,6 +768,7 @@ export async function runPairedProbes({
               targetOrder: order.join(">"),
               benchmarkSeed: seed,
               idleBeforeTargetMs: idleBeforeEachTarget ? idleMs : 0,
+              pairIntervalMs: pacePairs ? pairIntervalMs : 0,
             },
             fetchImpl,
           });
@@ -771,7 +780,7 @@ export async function runPairedProbes({
   };
 
   await runPhase("cold", 1);
-  await runPhase("warm", repeats);
+  await runPhase("warm", repeats, { pacePairs: true });
   await runPhase("post-idle", 1, { idleBeforeEachTarget: true });
   return records;
 }
@@ -864,7 +873,8 @@ function printHelp() {
       "",
       "Common:",
       "  --repeat 1..100 --timeout-ms 1000..180000 --api-key-env NAME",
-      "  --idle-ms 0..300000 --seed SAFE_ID --prompt text",
+      "  --idle-ms 0..300000 --pair-interval-ms 0..60000",
+      "  --seed SAFE_ID --prompt text",
       "  --max-proof-miss-rate 0..1 (paired benchmark only)",
       "  --keep-conversation",
       "",
@@ -894,6 +904,7 @@ export async function runCli(argv = process.argv.slice(2)) {
       "direct-base-url": { type: "string" },
       "gateway-base-url": { type: "string" },
       "idle-ms": { type: "string", default: "30000" },
+      "pair-interval-ms": { type: "string", default: "0" },
       seed: { type: "string" },
       "max-proof-miss-rate": { type: "string", default: "0" },
       "keep-conversation": { type: "boolean", default: false },
@@ -923,6 +934,12 @@ export async function runCli(argv = process.argv.slice(2)) {
     16_384,
   );
   const idleMs = boundedInteger(values["idle-ms"], "idle-ms", 0, 300_000);
+  const pairIntervalMs = boundedInteger(
+    values["pair-interval-ms"],
+    "pair-interval-ms",
+    0,
+    60_000,
+  );
   const maxProofMissRate = boundedNumber(
     values["max-proof-miss-rate"],
     "max-proof-miss-rate",
@@ -988,6 +1005,7 @@ export async function runCli(argv = process.argv.slice(2)) {
       promptOverride: values.prompt,
       timeoutMs,
       idleMs,
+      pairIntervalMs,
       seed: benchmarkSeed,
       onRecord: (record) => process.stdout.write(`${JSON.stringify(record)}\n`),
     });

--- a/packages/scripts/cloud/chat-latency.mjs
+++ b/packages/scripts/cloud/chat-latency.mjs
@@ -722,15 +722,28 @@ export async function runPairedProbes({
   const random = seededRandom(seed);
   const records = [];
   const targets = { direct, gateway };
+  const nextFirstTarget = new Map();
 
-  const runPhase = async (phase, count) => {
+  const runPhase = async (phase, count, { idleBeforeEachTarget = false } = {}) => {
     for (let sequence = 1; sequence <= count; sequence += 1) {
       for (const probeCase of shuffled(cases, random)) {
         const proof = `latency-proof-${randomUUID()}`;
         const pairId = randomUUID();
-        const order =
-          random() < 0.5 ? [`direct`, `gateway`] : [`gateway`, `direct`];
+        const caseKey = JSON.stringify([
+          probeCase.model,
+          probeCase.reasoningEffort,
+          probeCase.maxTokens,
+        ]);
+        const first =
+          nextFirstTarget.get(caseKey) ??
+          (random() < 0.5 ? `direct` : `gateway`);
+        const second = first === `direct` ? `gateway` : `direct`;
+        const order = [first, second];
+        nextFirstTarget.set(caseKey, second);
         for (const target of order) {
+          if (idleBeforeEachTarget && idleMs > 0) {
+            await sleepImpl(idleMs);
+          }
           const config = targets[target];
           const record = await probeOpenAi({
             target,
@@ -746,6 +759,7 @@ export async function runPairedProbes({
               pairId,
               targetOrder: order.join(">"),
               benchmarkSeed: seed,
+              idleBeforeTargetMs: idleBeforeEachTarget ? idleMs : 0,
             },
             fetchImpl,
           });
@@ -758,8 +772,7 @@ export async function runPairedProbes({
 
   await runPhase("cold", 1);
   await runPhase("warm", repeats);
-  if (idleMs > 0) await sleepImpl(idleMs);
-  await runPhase("post-idle", 1);
+  await runPhase("post-idle", 1, { idleBeforeEachTarget: true });
   return records;
 }
 

--- a/packages/scripts/cloud/chat-latency.mjs
+++ b/packages/scripts/cloud/chat-latency.mjs
@@ -176,12 +176,21 @@ function safeErrorToken(value) {
     : null;
 }
 
+function dedicatedErrorCode(error) {
+  const message = error?.message;
+  return typeof message === "string" &&
+    /^(?:CreateConversationHttp\d{3}|ConversationIdMissing)$/.test(message)
+    ? message
+    : null;
+}
+
 export async function safeHttpError(response) {
   let parsed = null;
   try {
     parsed = JSON.parse(await response.text());
   } catch {
-    // Deliberately omit arbitrary upstream response text from evidence.
+    // error-policy:J3 untrusted provider bodies remain an explicit HTTP
+    // failure, but arbitrary text never enters the evidence artifact.
   }
   const source =
     parsed?.error && typeof parsed.error === "object" ? parsed.error : parsed;
@@ -664,18 +673,34 @@ export async function probeDedicated({
       agentId,
       traceId,
       networkError: safeErrorToken(error?.name) || "DedicatedProbeError",
-      errorCode: safeErrorToken(error?.message),
+      errorCode: dedicatedErrorCode(error),
     };
   } finally {
     if (conversationId && !keepConversation) {
-      await fetchImpl(
-        `${baseUrl}/api/conversations/${encodeURIComponent(conversationId)}`,
-        {
-          method: "DELETE",
-          headers: { Authorization: `Bearer ${apiKey}` },
-          signal: AbortSignal.timeout(15_000),
-        },
-      ).catch(() => undefined);
+      let cleanupFailure = null;
+      try {
+        const cleanupResponse = await fetchImpl(
+          `${baseUrl}/api/conversations/${encodeURIComponent(conversationId)}`,
+          {
+            method: "DELETE",
+            headers: { Authorization: `Bearer ${apiKey}` },
+            signal: AbortSignal.timeout(15_000),
+          },
+        );
+        if (!cleanupResponse.ok) {
+          cleanupFailure = `DeleteConversationHttp${cleanupResponse.status}`;
+        }
+      } catch (error) {
+        // error-policy:J6 teardown is best-effort, but retained benchmark state
+        // must be visible without printing arbitrary network error messages.
+        cleanupFailure =
+          safeErrorToken(error?.name) || "ConversationCleanupError";
+      }
+      if (cleanupFailure) {
+        process.stderr.write(
+          `[chat-latency] conversation cleanup failed: ${cleanupFailure}\n`,
+        );
+      }
     }
   }
 }

--- a/packages/scripts/cloud/chat-latency.test.mjs
+++ b/packages/scripts/cloud/chat-latency.test.mjs
@@ -428,6 +428,23 @@ test("probeDedicated requires a done terminal and sanitizes telemetry", async ()
   assert.doesNotMatch(JSON.stringify(errorResult), /private/);
 });
 
+test("probeDedicated never records an arbitrary transport error message", async () => {
+  const result = await probeDedicated({
+    agentId: "agent-privacy",
+    baseUrl: "https://agent.example",
+    apiKey: "private-api-key",
+    timeoutMs: 1_000,
+    sequence: 1,
+    keepConversation: false,
+    fetchImpl: async () => {
+      throw new Error("private-api-key");
+    },
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.errorCode, null);
+  assert.doesNotMatch(JSON.stringify(result), /private-api-key/);
+});
+
 test("runPairedProbes reuses prompts, counterbalances order, and labels phases", async () => {
   const seenPrompts = new Map();
   const records = await runPairedProbes({

--- a/packages/scripts/cloud/chat-latency.test.mjs
+++ b/packages/scripts/cloud/chat-latency.test.mjs
@@ -447,6 +447,7 @@ test("probeDedicated never records an arbitrary transport error message", async 
 
 test("runPairedProbes reuses prompts, counterbalances order, and labels phases", async () => {
   const seenPrompts = new Map();
+  const sleeps = [];
   const records = await runPairedProbes({
     cases: [parseProbeCase("gemma-4-31b@omit@512")],
     repeats: 2,
@@ -455,7 +456,7 @@ test("runPairedProbes reuses prompts, counterbalances order, and labels phases",
     timeoutMs: 5_000,
     idleMs: 1,
     seed: "fixed-seed",
-    sleepImpl: async () => undefined,
+    sleepImpl: async (durationMs) => sleeps.push(durationMs),
     fetchImpl: async (url, init) => {
       const body = JSON.parse(init.body);
       const prompt = body.messages[0].content;
@@ -483,6 +484,26 @@ test("runPairedProbes reuses prompts, counterbalances order, and labels phases",
     assert.equal(pair.length, 2);
     assert.equal(pair[0].targetOrder, pair[1].targetOrder);
   }
+  assert.deepEqual(
+    Object.fromEntries(
+      Map.groupBy(records, (record) => record.targetOrder)
+        .entries()
+        .map(([order, orderRecords]) => [order, orderRecords.length / 2]),
+    ),
+    { "direct>gateway": 2, "gateway>direct": 2 },
+  );
+  assert.deepEqual(sleeps, [1, 1]);
+  assert.deepEqual(
+    records
+      .filter((record) => record.phase === "post-idle")
+      .map((record) => record.idleBeforeTargetMs),
+    [1, 1],
+  );
+  assert.ok(
+    records
+      .filter((record) => record.phase !== "post-idle")
+      .every((record) => record.idleBeforeTargetMs === 0),
+  );
 });
 
 test("summarizeLatencyRecords reports warm p50, p90, and p95", () => {

--- a/packages/scripts/cloud/chat-latency.test.mjs
+++ b/packages/scripts/cloud/chat-latency.test.mjs
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildOpenAiRequestBody,
+  consumeOpenAiEvent,
+  parseProbeCase,
+  parseServerTiming,
+  readSse,
+  safeHttpError,
+  selectedResponseHeaders,
+} from "./chat-latency.mjs";
+
+test("parseProbeCase preserves model, reasoning mode, and token cap", () => {
+  assert.deepEqual(parseProbeCase("zai-glm-4.7@none@512"), {
+    model: "zai-glm-4.7",
+    reasoningEffort: "none",
+    maxTokens: 512,
+  });
+  assert.deepEqual(parseProbeCase("gemma-4-31b"), {
+    model: "gemma-4-31b",
+    reasoningEffort: "omit",
+    maxTokens: 512,
+  });
+  assert.throws(
+    () => parseProbeCase("zai-glm-4.7@invalid@512"),
+    /Unsupported reasoning effort/,
+  );
+  assert.throws(
+    () => parseProbeCase("gemma-4-31b@none@0"),
+    /max_tokens must be an integer/,
+  );
+});
+
+test("buildOpenAiRequestBody omits rather than fabricates reasoning_effort", () => {
+  const omitted = buildOpenAiRequestBody(
+    parseProbeCase("gemma-4-31b@omit@512"),
+    "private prompt",
+  );
+  assert.equal("reasoning_effort" in omitted, false);
+  assert.equal(omitted.max_tokens, 512);
+
+  const disabled = buildOpenAiRequestBody(
+    parseProbeCase("zai-glm-4.7@none@512"),
+    "private prompt",
+  );
+  assert.equal(disabled.reasoning_effort, "none");
+});
+
+test("parseServerTiming returns only valid non-negative durations", () => {
+  assert.deepEqual(
+    parseServerTiming(
+      'gateway_auth;dur=2.25, gateway_middle;dur="10", bad;dur=-1, no-duration',
+    ),
+    {
+      gateway_auth: 2.25,
+      gateway_middle: 10,
+    },
+  );
+});
+
+test("selectedResponseHeaders excludes authorization and arbitrary headers", () => {
+  const selected = selectedResponseHeaders(
+    new Headers({
+      authorization: "Bearer secret",
+      "cf-ray": "ray-id",
+      "server-timing": "gateway_auth;dur=2",
+      "x-untrusted": "private",
+    }),
+  );
+  assert.deepEqual(selected, {
+    "cf-ray": "ray-id",
+    "server-timing": "gateway_auth;dur=2",
+  });
+});
+
+test("consumeOpenAiEvent separates hidden reasoning from visible content", () => {
+  assert.deepEqual(
+    consumeOpenAiEvent({
+      choices: [
+        {
+          delta: {
+            reasoning_content: "hidden",
+            content: "visible",
+          },
+          finish_reason: "stop",
+        },
+      ],
+      usage: {
+        prompt_tokens: 5,
+        completion_tokens: 7,
+        total_tokens: 12,
+        private_internal_counter: 99,
+      },
+    }),
+    {
+      content: "visible",
+      reasoning: "hidden",
+      finishReason: "stop",
+      usage: {
+        prompt_tokens: 5,
+        completion_tokens: 7,
+        total_tokens: 12,
+      },
+      providerError: null,
+    },
+  );
+});
+
+test("readSse records first event, reasoning, visible token, and usage", async () => {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream({
+    start(controller) {
+      controller.enqueue(
+        encoder.encode(
+          'data: {"choices":[{"delta":{"reasoning_content":"think"}}]}\n\n',
+        ),
+      );
+      controller.enqueue(
+        encoder.encode(
+          'data: {"choices":[{"delta":{"content":"proof"}}],"usage":{"total_tokens":9}}\n',
+        ),
+      );
+      controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+      controller.close();
+    },
+  });
+  const readings = [110, 112, 130];
+  const result = await readSse(body, 100, consumeOpenAiEvent, () =>
+    readings.shift(),
+  );
+
+  assert.equal(result.firstEventMs, 10);
+  assert.equal(result.firstReasoningMs, 12);
+  assert.equal(result.firstTokenMs, 30);
+  assert.equal(result.reasoningCharacters, 5);
+  assert.equal(result.outputCharacters, 5);
+  assert.equal(result.outputText, "proof");
+  assert.deepEqual(result.usage, { total_tokens: 9 });
+});
+
+test("safeHttpError never returns an upstream message or body", async () => {
+  const response = new Response(
+    JSON.stringify({
+      error: {
+        type: "invalid_request_error",
+        code: "bad_model",
+        message: "prompt and credential-like detail must stay private",
+      },
+    }),
+    { status: 400 },
+  );
+  const error = await safeHttpError(response);
+  assert.deepEqual(error, {
+    status: 400,
+    type: "invalid_request_error",
+    code: "bad_model",
+  });
+  assert.equal("message" in error, false);
+});

--- a/packages/scripts/cloud/chat-latency.test.mjs
+++ b/packages/scripts/cloud/chat-latency.test.mjs
@@ -455,6 +455,7 @@ test("runPairedProbes reuses prompts, counterbalances order, and labels phases",
     gateway: { baseUrl: "https://gateway.example", apiKey: "gateway-secret" },
     timeoutMs: 5_000,
     idleMs: 1,
+    pairIntervalMs: 2,
     seed: "fixed-seed",
     sleepImpl: async (durationMs) => sleeps.push(durationMs),
     fetchImpl: async (url, init) => {
@@ -492,7 +493,7 @@ test("runPairedProbes reuses prompts, counterbalances order, and labels phases",
     ),
     { "direct>gateway": 2, "gateway>direct": 2 },
   );
-  assert.deepEqual(sleeps, [1, 1]);
+  assert.deepEqual(sleeps, [2, 2, 1, 1]);
   assert.deepEqual(
     records
       .filter((record) => record.phase === "post-idle")
@@ -503,6 +504,16 @@ test("runPairedProbes reuses prompts, counterbalances order, and labels phases",
     records
       .filter((record) => record.phase !== "post-idle")
       .every((record) => record.idleBeforeTargetMs === 0),
+  );
+  assert.ok(
+    records
+      .filter((record) => record.phase === "warm")
+      .every((record) => record.pairIntervalMs === 2),
+  );
+  assert.ok(
+    records
+      .filter((record) => record.phase !== "warm")
+      .every((record) => record.pairIntervalMs === 0),
   );
 });
 

--- a/packages/scripts/cloud/chat-latency.test.mjs
+++ b/packages/scripts/cloud/chat-latency.test.mjs
@@ -95,12 +95,14 @@ test("selectedResponseHeaders excludes authorization and arbitrary headers", () 
   const selected = selectedResponseHeaders(
     new Headers({
       authorization: "Bearer secret",
+      "cf-placement": "remote-ATL",
       "cf-ray": "ray-id",
       "server-timing": "gateway_auth;dur=2",
       "x-untrusted": "private",
     }),
   );
   assert.deepEqual(selected, {
+    "cf-placement": "remote-ATL",
     "cf-ray": "ray-id",
     "server-timing": "gateway_auth;dur=2",
   });

--- a/packages/scripts/cloud/chat-latency.test.mjs
+++ b/packages/scripts/cloud/chat-latency.test.mjs
@@ -3,13 +3,45 @@ import test from "node:test";
 
 import {
   buildOpenAiRequestBody,
+  buildProofPrompt,
   consumeOpenAiEvent,
   parseProbeCase,
   parseServerTiming,
+  probeDedicated,
+  probeOpenAi,
   readSse,
+  runCli,
+  runPairedProbes,
   safeHttpError,
+  safeTerminalTelemetry,
   selectedResponseHeaders,
+  summarizeLatencyRecords,
 } from "./chat-latency.mjs";
+
+function openAiSse(events, { done = true, status = 200, headers } = {}) {
+  const frames = events.map((event) => `data: ${JSON.stringify(event)}\n\n`);
+  if (done) frames.push("data: [DONE]\n\n");
+  return new Response(frames.join(""), {
+    status,
+    headers: {
+      "content-type": "text/event-stream",
+      ...headers,
+    },
+  });
+}
+
+function successfulOpenAiResponse(proof, options) {
+  return openAiSse(
+    [
+      { choices: [{ delta: { content: proof }, finish_reason: null }] },
+      {
+        choices: [{ delta: {}, finish_reason: "stop" }],
+        usage: { prompt_tokens: 2, completion_tokens: 3, total_tokens: 5 },
+      },
+    ],
+    options,
+  );
+}
 
 test("parseProbeCase preserves model, reasoning mode, and token cap", () => {
   assert.deepEqual(parseProbeCase("zai-glm-4.7@none@512"), {
@@ -157,4 +189,344 @@ test("safeHttpError never returns an upstream message or body", async () => {
     code: "bad_model",
   });
   assert.equal("message" in error, false);
+});
+
+test("buildProofPrompt preserves a custom prompt and always adds the nonce", () => {
+  assert.equal(
+    buildProofPrompt("Use a table", "proof-123"),
+    "Use a table\n\nInclude this exact token in the answer: proof-123",
+  );
+  assert.match(buildProofPrompt(undefined, "proof-456"), /proof-456/);
+});
+
+test("probeOpenAi requires a clean terminal frame and never records prompt text", async () => {
+  let requestBody = null;
+  const result = await probeOpenAi({
+    target: "gateway",
+    probeCase: parseProbeCase("zai-glm-4.7@none@512"),
+    baseUrl: "https://gateway.example",
+    apiKey: "super-secret",
+    promptOverride: "Custom private instruction",
+    proof: "proof-clean",
+    timeoutMs: 5_000,
+    sequence: 4,
+    metadata: { phase: "warm", pairId: "pair-1" },
+    fetchImpl: async (_url, init) => {
+      requestBody = JSON.parse(init.body);
+      return successfulOpenAiResponse("proof-clean", {
+        headers: {
+          "x-eliza-preforward-ms": "total=12;auth=2;mid=3;reserve=4;setup=3",
+          "x-eliza-trace-id": "trace-safe",
+          "x-private": "must-not-escape",
+        },
+      });
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.cleanCompletion, true);
+  assert.equal(result.sawDone, true);
+  assert.equal(result.phase, "warm");
+  assert.deepEqual(result.preforward, {
+    total: 12,
+    auth: 2,
+    mid: 3,
+    reserve: 4,
+    setup: 3,
+  });
+  assert.match(requestBody.messages[0].content, /Custom private instruction/);
+  assert.match(requestBody.messages[0].content, /proof-clean/);
+  const serialized = JSON.stringify(result);
+  assert.doesNotMatch(serialized, /super-secret/);
+  assert.doesNotMatch(serialized, /Custom private instruction/);
+  assert.doesNotMatch(serialized, /must-not-escape/);
+});
+
+test("probeOpenAi rejects truncated, malformed, and provider-error streams", async () => {
+  const common = {
+    target: "direct",
+    probeCase: parseProbeCase("gemma-4-31b@omit@512"),
+    baseUrl: "https://direct.example",
+    apiKey: "secret",
+    proof: "proof-token",
+    timeoutMs: 5_000,
+    sequence: 1,
+  };
+  const truncated = await probeOpenAi({
+    ...common,
+    fetchImpl: async () =>
+      successfulOpenAiResponse("proof-token", { done: false }),
+  });
+  assert.equal(truncated.proofMatched, true);
+  assert.equal(truncated.sawDone, false);
+  assert.equal(truncated.ok, false);
+
+  const malformed = await probeOpenAi({
+    ...common,
+    fetchImpl: async () =>
+      new Response(
+        [
+          'data: {"choices":[{"delta":{"content":"proof-token"}}]}\n\n',
+          "data: not-json\n\n",
+          'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n',
+          "data: [DONE]\n\n",
+        ].join(""),
+      ),
+  });
+  assert.equal(malformed.malformedEvents, 1);
+  assert.equal(malformed.ok, false);
+
+  const providerError = await probeOpenAi({
+    ...common,
+    fetchImpl: async () =>
+      openAiSse([
+        { choices: [{ delta: { content: "proof-token" } }] },
+        { error: { type: "provider_error", code: "overloaded" } },
+        { choices: [{ delta: {}, finish_reason: "stop" }] },
+      ]),
+  });
+  assert.deepEqual(providerError.providerError, {
+    type: "provider_error",
+    code: "overloaded",
+  });
+  assert.equal(providerError.ok, false);
+});
+
+test("probeOpenAi reduces HTTP and network errors to safe metadata", async () => {
+  const common = {
+    target: "gateway",
+    probeCase: parseProbeCase("gemma-4-31b@omit@512"),
+    baseUrl: "https://gateway.example",
+    apiKey: "secret",
+    timeoutMs: 5_000,
+    sequence: 1,
+  };
+  const http = await probeOpenAi({
+    ...common,
+    fetchImpl: async () =>
+      new Response(
+        JSON.stringify({
+          error: {
+            type: "invalid_request_error",
+            code: "bad_model",
+            message: "private upstream detail",
+          },
+        }),
+        { status: 400 },
+      ),
+  });
+  assert.deepEqual(http.error, {
+    status: 400,
+    type: "invalid_request_error",
+    code: "bad_model",
+  });
+  assert.doesNotMatch(JSON.stringify(http), /private upstream detail/);
+
+  const network = await probeOpenAi({
+    ...common,
+    fetchImpl: async () => {
+      const error = new Error("URL and private details");
+      error.name = "TimeoutError";
+      throw error;
+    },
+  });
+  assert.equal(network.networkError, "TimeoutError");
+  assert.doesNotMatch(JSON.stringify(network), /private details/);
+});
+
+test("safeTerminalTelemetry uses exact numeric paths and drops arbitrary strings", () => {
+  assert.deepEqual(
+    safeTerminalTelemetry({
+      agentRoute: {
+        ingressToSseOpenMs: 5,
+        ingressToDoneMs: 20,
+        requestBody: "private",
+      },
+      runtime: {
+        totalMs: 18,
+        provider: "cerebras",
+        providerResponse: "private generated text",
+        contributions: { model: 12, hooks: 3 },
+        marks: { "first-token": 9 },
+        timeline: [{ prompt: "private" }],
+      },
+    }),
+    {
+      agentRoute: {
+        ingressToSseOpenMs: 5,
+        ingressToDoneMs: 20,
+      },
+      runtime: {
+        totalMs: 18,
+        provider: "cerebras",
+        contributions: { model: 12, hooks: 3 },
+        marks: { "first-token": 9 },
+      },
+    },
+  );
+});
+
+test("probeDedicated requires a done terminal and sanitizes telemetry", async () => {
+  const calls = [];
+  const fetchImpl = async (url, init = {}) => {
+    calls.push({ url, method: init.method });
+    if (calls.length === 1) {
+      return Response.json({ conversation: { id: "conversation-1" } });
+    }
+    if (calls.length === 2) {
+      return new Response(
+        [
+          'data: {"type":"token","text":"proof-agent"}\n\n',
+          'data: {"type":"done","telemetry":{"agentRoute":{"ingressToDoneMs":25,"requestBody":"private"},"runtime":{"totalMs":20,"provider":"cerebras","providerResponse":"private"}}}\n\n',
+        ].join(""),
+        { status: 200 },
+      );
+    }
+    return new Response(null, { status: 204 });
+  };
+
+  const result = await probeDedicated({
+    agentId: "agent-1",
+    baseUrl: "https://agent.example",
+    apiKey: "secret",
+    proof: "proof-agent",
+    timeoutMs: 5_000,
+    sequence: 1,
+    keepConversation: false,
+    fetchImpl,
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.terminalType, "done");
+  assert.deepEqual(result.terminalTelemetry, {
+    agentRoute: { ingressToDoneMs: 25 },
+    runtime: { totalMs: 20, provider: "cerebras" },
+  });
+  assert.equal(calls.length, 3);
+  assert.equal(calls[2].method, "DELETE");
+
+  const errorResult = await probeDedicated({
+    agentId: "agent-2",
+    baseUrl: "https://agent.example",
+    apiKey: "secret",
+    proof: "proof-agent",
+    timeoutMs: 5_000,
+    sequence: 1,
+    keepConversation: true,
+    fetchImpl: async (url) =>
+      url.endsWith("/api/conversations")
+        ? Response.json({ id: "conversation-2" })
+        : new Response(
+            [
+              'data: {"type":"token","text":"proof-agent"}\n\n',
+              'data: {"type":"error","message":"private"}\n\n',
+            ].join(""),
+          ),
+  });
+  assert.equal(errorResult.proofMatched, true);
+  assert.equal(errorResult.terminalType, "error");
+  assert.equal(errorResult.ok, false);
+  assert.doesNotMatch(JSON.stringify(errorResult), /private/);
+});
+
+test("runPairedProbes reuses prompts, counterbalances order, and labels phases", async () => {
+  const seenPrompts = new Map();
+  const records = await runPairedProbes({
+    cases: [parseProbeCase("gemma-4-31b@omit@512")],
+    repeats: 2,
+    direct: { baseUrl: "https://direct.example", apiKey: "direct-secret" },
+    gateway: { baseUrl: "https://gateway.example", apiKey: "gateway-secret" },
+    timeoutMs: 5_000,
+    idleMs: 1,
+    seed: "fixed-seed",
+    sleepImpl: async () => undefined,
+    fetchImpl: async (url, init) => {
+      const body = JSON.parse(init.body);
+      const prompt = body.messages[0].content;
+      const proof = prompt.match(/latency-proof-[a-f0-9-]+/)?.[0];
+      assert.ok(proof);
+      const target = url.includes("direct.example") ? "direct" : "gateway";
+      const key = prompt;
+      const targets = seenPrompts.get(key) || new Set();
+      targets.add(target);
+      seenPrompts.set(key, targets);
+      return successfulOpenAiResponse(proof);
+    },
+  });
+
+  assert.equal(records.length, 8);
+  assert.deepEqual(
+    new Set(records.map((record) => record.phase)),
+    new Set(["cold", "warm", "post-idle"]),
+  );
+  for (const targets of seenPrompts.values()) {
+    assert.deepEqual(targets, new Set(["direct", "gateway"]));
+  }
+  const pairs = Map.groupBy(records, (record) => record.pairId);
+  for (const pair of pairs.values()) {
+    assert.equal(pair.length, 2);
+    assert.equal(pair[0].targetOrder, pair[1].targetOrder);
+  }
+});
+
+test("summarizeLatencyRecords reports warm p50, p90, and p95", () => {
+  const records = [10, 20, 30].flatMap((firstTokenMs, index) => [
+    {
+      phase: "warm",
+      target: "direct",
+      model: "gemma-4-31b",
+      reasoningEffort: "omit",
+      maxTokens: 512,
+      ok: true,
+      responseHeadersMs: firstTokenMs - 1,
+      firstTokenMs,
+      totalMs: firstTokenMs + 5,
+      preforward: {},
+      sequence: index + 1,
+    },
+  ]);
+  records.push({ ...records[0], phase: "cold", firstTokenMs: 999 });
+  const [summary] = summarizeLatencyRecords(records);
+  assert.equal(summary.samples, 3);
+  assert.equal(summary.failures, 0);
+  assert.deepEqual(summary.firstTokenMs, { p50: 20, p90: 28, p95: 29 });
+  assert.deepEqual(summary.preforwardMs, {
+    p50: null,
+    p90: null,
+    p95: null,
+  });
+});
+
+test("paired CLI distinguishes transport integrity from bounded proof misses", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalWrite = process.stdout.write;
+  const testEnv = process.env;
+  testEnv.TEST_DIRECT_CHAT_KEY = "direct-secret";
+  testEnv.TEST_GATEWAY_CHAT_KEY = "gateway-secret";
+  globalThis.fetch = async () => successfulOpenAiResponse("wrong-proof");
+  process.stdout.write = () => true;
+  const args = [
+    "--target",
+    "paired",
+    "--case",
+    "gemma-4-31b@omit@512",
+    "--repeat",
+    "1",
+    "--idle-ms",
+    "0",
+    "--direct-api-key-env",
+    "TEST_DIRECT_CHAT_KEY",
+    "--gateway-api-key-env",
+    "TEST_GATEWAY_CHAT_KEY",
+    "--seed",
+    "cli-threshold-test",
+  ];
+  try {
+    assert.equal(await runCli([...args, "--max-proof-miss-rate", "1"]), 0);
+    assert.equal(await runCli([...args, "--max-proof-miss-rate", "0"]), 2);
+  } finally {
+    globalThis.fetch = originalFetch;
+    process.stdout.write = originalWrite;
+    delete testEnv.TEST_DIRECT_CHAT_KEY;
+    delete testEnv.TEST_GATEWAY_CHAT_KEY;
+  }
 });


### PR DESCRIPTION
Closes part of #16079.

## Summary

This adds a privacy-safe latency harness for Cerebras direct inference, the Eliza Cloud gateway, and dedicated-agent SSE paths.

It records response headers, first SSE event, first hidden reasoning, first visible token, completion, token usage/output lengths, and allowlisted trace/path/`Server-Timing` fields without emitting credentials, prompts, generated text, or arbitrary provider error bodies.

## Paired benchmark design

- Direct and gateway run in one Node process on one fixed GitHub runner.
- Each pair receives the same nonce-bearing prompt.
- Case order is seeded/randomized; target-first order alternates exactly per case.
- Every warm case receives 30 pairs with 15 direct-first and 15 gateway-first observations.
- Warm pairs are paced at 40 gateway requests/minute, below the lowest Cloud organization tier.
- Cold, warm, and genuinely post-idle samples are labeled separately; every post-idle target receives the full configured idle.
- The workflow reports p50/p90/p95 and retains exact-SHA JSONL.
- Transport integrity must be perfect. Semantic proof misses are reported separately and limited to 5%.
- `/api/health` is checked before and after paid requests so a deployment race invalidates the run.
- Production remains manual and binds to the protected `production` GitHub Environment.

The fixed matrix covers Gemma reasoning omitted/disabled at 512 tokens, GLM-4.7 reasoning omitted/disabled at 4096 tokens for fair latency comparison, and GLM-4.7 reasoning disabled at 512 tokens for cap correctness.

## Privacy and safety

JSONL contains only bounded timing data, allowlisted headers, token counts, output/reasoning character counts, terminal status, and proof success. Dedicated telemetry accepts only explicit safe numeric paths/provider identifiers; arbitrary exceptions are reduced to safe local codes, and cleanup failures are visible.

## Verification

- Node probe tests: 17/17 passing
- Workflow contract tests: 7/7 passing
- Coverage lane: 24/24 passing
- Changed-source coverage: 86.34% for `chat-latency.mjs` (50% required)
- Node syntax, actionlint, Biome, `git diff --check`, test-realness/error ratchets
- Current build, typecheck, lint, unit, integration, E2E, gitleaks, and environment-audit lanes are the merge gate

## Exact live evidence

- Gateway candidate: `f1fd02a904f96c2515e8f5be4af76ec854b36dab`
- Harness used for the accepted run: `6daa69888c4315a6d8d47d3808755ce651abd089`
- [Accepted run 29167994915](https://github.com/elizaOS/eliza/actions/runs/29167994915)
- [Live job](https://github.com/elizaOS/eliza/actions/runs/29167994915/job/86584408510)
- [JSONL artifact](https://github.com/elizaOS/eliza/actions/runs/29167994915/artifacts/8252811951)
- Artifact upload digest: `f3e70a4dbe33495c8e156ffa205217c6c6671f6aa0023f314332aac472fe2155`

The probe finished at 21:12:31 UTC. A later unrelated `develop` Worker did not deploy until 21:13:28 UTC, so all samples were served by the exact preflight-verified candidate. Current head adds the postflight guard that makes this timing check automatic in future runs.

Integrity/privacy audit:

- 320/320 JSON records parsed and returned HTTP 200;
- zero transport, malformed-SSE, missing-`[DONE]`, or missing-finish failures;
- 160/160 structurally valid pairs; exact 80/80 target-first balance;
- phases: 10 cold, 300 warm, 10 post-idle;
- one clean semantic proof miss (0.3125%), below the declared 5% limit;
- no credential, authorization, prompt, generated-text, provider-body, bearer-token, or secret-like field/value.

Warm latency (milliseconds):

| case | path | n | headers p50/p90/p95 | TTFT p50/p90/p95 | total p50/p90/p95 | preforward p50/p90/p95 |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| Gemma `none` / 512 | direct | 30 | 84/105/132 | 87/152/274 | 111/181/392 | — |
| Gemma `none` / 512 | gateway | 30 | 471/1498/3094 | 472/1498/3094 | 482/1510/3103 | 249/491/806 |
| Gemma omitted / 512 | direct | 30 | 88/126/137 | 91/133/219 | 110/147/237 | — |
| Gemma omitted / 512 | gateway | 30 | 840/1254/1367 | 962/1254/1371 | 973/1271/1393 | 167/496/518 |
| GLM `none` / 4096 | direct | 30 | 81/125/173 | 109/556/646 | 127/561/663 | — |
| GLM `none` / 4096 | gateway | 30 | 259/1271/1360 | 485/1457/1752 | 494/1477/1805 | 228/463/485 |
| GLM `none` / 512 | direct | 30 | 82/130/164 | 101/182/224 | 135/232/312 | — |
| GLM `none` / 512 | gateway | 29 | 754/1267/1379 | 973/1596/2259 | 1071/1630/2281 | 314/433/624 |
| GLM omitted / 4096 | direct | 30 | 85/120/129 | 323/737/1245 | 348/769/1261 | — |
| GLM omitted / 4096 | gateway | 30 | 377/1271/1572 | 587/1960/2676 | 621/1997/2725 | 100/429/682 |

The first unpaced 30-repeat run ([29167669696](https://github.com/elizaOS/eliza/actions/runs/29167669696)) is diagnostic only: it crossed the free-tier burst envelope and returned 52 sanitized gateway 429s after 60 successful warm gateway calls. Explicit pacing eliminated every 429 in the accepted run.

The artifact also exposes the next work clearly: `Server-Timing` was absent on all records, and post-idle gateway TTFT was 4.48–5.49 seconds versus 0.086–0.365 seconds direct. Truthful per-hop timing remains tracked in #16079/#16098.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - CLI/workflow-only change; no rendered UI.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - CLI/workflow-only change; no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no interactive visual flow.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: [accepted exact-SHA live job](https://github.com/elizaOS/eliza/actions/runs/29167994915/job/86584408510) and [full run](https://github.com/elizaOS/eliza/actions/runs/29167994915).

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no browser/frontend runtime is changed or required.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: [320-record Gemma/GLM paired run](https://github.com/elizaOS/eliza/actions/runs/29167994915).

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [privacy-safe exact-SHA JSONL](https://github.com/elizaOS/eliza/actions/runs/29167994915/artifacts/8252811951).
