### PR TITLE
fix(ci): format wallet trade types

### DIFF
--- a/plugins/plugin-wallet/src/types/trade.ts
+++ b/plugins/plugin-wallet/src/types/trade.ts
@@ -9,7 +9,10 @@ import type { FailureCode } from "../actions/failure-codes.js";
 export type Venue = "hyperliquid" | "polymarket";
 
 export type TradeOutcomeClass =
-  "not_attempted" | "rejected" | "unknown" | "policy_denied";
+  | "not_attempted"
+  | "rejected"
+  | "unknown"
+  | "policy_denied";
 
 export type PolicyDenyReason =
   | "market-not-allowed"
@@ -100,7 +103,8 @@ export type PolymarketSubmitOrderRequest = {
 };
 
 export type SubmitOrderRequest =
-  HyperliquidSubmitOrderRequest | PolymarketSubmitOrderRequest;
+  | HyperliquidSubmitOrderRequest
+  | PolymarketSubmitOrderRequest;
 
 export interface CancelOrderRequest {
   readonly venue: Venue;


### PR DESCRIPTION
# Relates to

Closes #16139 (repository-side format failure; the issue remains the coordination record for the separate rejected Hetzner credential).

- [x] Targets `develop` and was branched from latest `origin/develop` (`12502f6aa5`).
- [x] `bun install` completed.
- [ ] `bun run verify` reached 356/365 tasks, then failed in the unrelated `@elizaos/plugin-hyperliquid#typecheck` lane because `@elizaos/ui` package exports were unavailable during the parallel build.

# Risks

Low. This is Biome-only formatting of two union types; TypeScript tokens and runtime behavior are unchanged.

# Background

## What does this PR do?

Applies the exact Biome formatting reported by the failing `Quality (Extended)` run on `develop`: https://github.com/elizaOS/eliza/actions/runs/29164011226

## What kind of change is this?

Bug fix (non-breaking CI repair).

# Documentation changes needed?

N/A - formatting-only CI repair does not alter documented behavior.

# Testing

## Where should a reviewer start?

Run `bun run --cwd plugins/plugin-wallet format:check`.

## Detailed testing steps

- `bun run --cwd plugins/plugin-wallet format:check` — passes; 242 files checked, no fixes applied.
- `git diff --check` — passes.
- `bun run verify` — unrelated existing `plugin-hyperliquid` typecheck failure described below.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI or rendered pixels changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI or rendered pixels changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow changed.
<!-- evidence-row:backend-logs -->
- [x] CI log: the failing format job identifies `src/types/trade.ts` and the exact formatter output: https://github.com/elizaOS/eliza/actions/runs/29164011226/job/86573881869
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - formatting-only change produces no domain artifact.

# Evidence Details

## Known gaps / failures

`bun run verify` completed 356 of 365 Turbo tasks before `@elizaos/plugin-hyperliquid#typecheck` failed on unresolved `@elizaos/ui` exports during the parallel build plus pre-existing errors in `useHyperliquidState.ts`. The touched `plugin-wallet` formatting check and build both passed before that unrelated lane failed.

The manually dispatched Hetzner E2E remains blocked by an environment-owned credential: Hetzner returns HTTP 401 for `HCLOUD_TOKEN_CI`. This PR intentionally does not weaken that fail-fast check.