### PR TITLE
fix(accounts): backfill identity (email) for existing accounts at usage refresh

### DIFF
--- a/packages/app-core/src/services/account-pool.test.ts
+++ b/packages/app-core/src/services/account-pool.test.ts
@@ -7,8 +7,9 @@
  * injected readAccounts/writeAccount and a stubbed fetch, so no real credential
  * store or provider API is touched.
  */
+import { logger } from "@elizaos/core";
 import type { LinkedAccountConfig } from "@elizaos/shared";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { AccountPool } from "./account-pool";
 
 function account(
@@ -106,6 +107,118 @@ describe("AccountPool provider-scoped account resolution", () => {
     expect(writes).toHaveLength(1);
     expect(writes[0]?.providerId).toBe("openai-codex");
     expect(writes[0]?.usage?.sessionPct).toBe(12);
+  });
+
+  it("backfills the Anthropic email from the profile probe during a usage refresh", async () => {
+    const writes: LinkedAccountConfig[] = [];
+    const accounts = {
+      "anthropic-subscription:no-email": account("anthropic-subscription", {
+        id: "no-email",
+      }),
+    };
+    const pool = new AccountPool({
+      readAccounts: () => accounts,
+      writeAccount: async (next) => {
+        writes.push(next);
+      },
+    });
+
+    // One fetch stub answers both the usage and profile endpoints by URL.
+    await pool.refreshUsage("no-email", "token", {
+      providerId: "anthropic-subscription",
+      fetch: (async (url: string | URL | Request) =>
+        String(url).includes("/profile")
+          ? new Response(
+              JSON.stringify({ account: { email: "backfilled@example.com" } }),
+              { status: 200 },
+            )
+          : new Response(JSON.stringify({ five_hour: { utilization: 0 } }), {
+              status: 200,
+            })) as unknown as typeof fetch,
+    });
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0]?.email).toBe("backfilled@example.com");
+    expect(writes[0]?.usage?.sessionPct).toBe(0);
+  });
+
+  it("preserves the fetched usage and reports (not fabricates) a failed profile backfill", async () => {
+    // The profile boundary throws typed errors (401/5xx/malformed/transport).
+    // refreshUsage must NOT let that discard the successfully fetched usage,
+    // must NOT write an email, and must surface the failure observably.
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    try {
+      for (const profileResponse of [
+        () => new Response("{}", { status: 500 }),
+        () => new Response("{}", { status: 401 }),
+        () => new Response("not-json", { status: 200 }),
+        () => {
+          throw new TypeError("network down");
+        },
+      ]) {
+        warnSpy.mockClear();
+        const writes: LinkedAccountConfig[] = [];
+        const accounts = {
+          "anthropic-subscription:no-email": account("anthropic-subscription", {
+            id: "no-email",
+          }),
+        };
+        const pool = new AccountPool({
+          readAccounts: () => accounts,
+          writeAccount: async (next) => {
+            writes.push(next);
+          },
+        });
+
+        await pool.refreshUsage("no-email", "token", {
+          providerId: "anthropic-subscription",
+          fetch: (async (url: string | URL | Request) =>
+            String(url).includes("/profile")
+              ? profileResponse()
+              : new Response(
+                  JSON.stringify({ five_hour: { utilization: 0.5 } }),
+                  { status: 200 },
+                )) as unknown as typeof fetch,
+        });
+
+        // Usage survived the identity failure…
+        expect(writes).toHaveLength(1);
+        expect(writes[0]?.usage?.sessionPct).toBe(50);
+        // …no fabricated identity…
+        expect(writes[0]?.email).toBeUndefined();
+        // …and the failure was reported, not swallowed.
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(String(warnSpy.mock.calls[0]?.[0])).toContain("no-email");
+      }
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("does NOT re-probe the profile when the account already has an email", async () => {
+    const profileUrls: string[] = [];
+    const accounts = {
+      "anthropic-subscription:has-email": account("anthropic-subscription", {
+        id: "has-email",
+        email: "existing@example.com",
+      }),
+    };
+    const pool = new AccountPool({
+      readAccounts: () => accounts,
+      writeAccount: async () => {},
+    });
+
+    await pool.refreshUsage("has-email", "token", {
+      providerId: "anthropic-subscription",
+      fetch: (async (url: string | URL | Request) => {
+        if (String(url).includes("/profile")) profileUrls.push(String(url));
+        return new Response(JSON.stringify({ five_hour: { utilization: 0 } }), {
+          status: 200,
+        });
+      }) as unknown as typeof fetch,
+    });
+
+    expect(profileUrls).toHaveLength(0);
   });
 
   it("selects among multiple accounts for the same provider by priority", async () => {

--- a/packages/app-core/src/services/account-pool.ts
+++ b/packages/app-core/src/services/account-pool.ts
@@ -37,6 +37,7 @@ import {
   isSubscriptionProvider,
   type SubscriptionProvider,
 } from "@elizaos/auth/types";
+import { fetchAnthropicOAuthProfile } from "@elizaos/auth/oauth-flow";
 import {
   type AnthropicAccountPoolBridge,
   logger,
@@ -378,8 +379,29 @@ export class AccountPool {
     if (!account) return;
 
     let usage: LinkedAccountUsage;
+    // Anthropic's OAuth token is opaque (no OIDC claims), so accounts linked
+    // before the OAuth flow started persisting the profile email — or imported
+    // from a CLI login — have no identity to display. Backfill it here from the
+    // same profile endpoint the link flow uses.
+    let email: string | undefined;
     if (account.providerId === "anthropic-subscription") {
       usage = await pollAnthropicUsage(accessToken, opts?.fetch);
+      if (!account.email) {
+        try {
+          email = (await fetchAnthropicOAuthProfile(accessToken, opts?.fetch))
+            .email;
+        } catch (err) {
+          // error-policy:J7 diagnostics-must-not-kill-the-loop — the identity
+          // backfill is enrichment on top of the usage refresh. A profile
+          // failure is REPORTED here (typed ElizaError from the profile
+          // boundary, logged with the account id) and the email stays absent —
+          // never fabricated as a healthy empty identity — while the
+          // successfully fetched usage snapshot below is still persisted.
+          logger.warn(
+            `[AccountPool] Anthropic profile backfill failed for account ${accountId}: ${String(err)}`,
+          );
+        }
+      }
     } else if (account.providerId === "openai-codex") {
       const codexAccountId = opts?.codexAccountId ?? account.organizationId;
       if (!codexAccountId) {
@@ -397,6 +419,7 @@ export class AccountPool {
       ...account,
       health: "ok",
       usage,
+      ...(email ? { email } : {}),
     });
   }
 
@@ -612,6 +635,11 @@ interface PoolMetaFields {
    * dashboard and the least-used age tiebreak (the credential record's own
    * lastUsedAt is only bumped by touchAccount, not by usage recording). */
   lastUsedAt?: number;
+  /** Account email. New OAuth links persist it on the credential record, but
+   * Anthropic's token is opaque, so accounts linked earlier (or imported from a
+   * CLI login) get it backfilled by refreshUsage's profile probe and persisted
+   * HERE — the credential file is never rewritten for display metadata. */
+  email?: string;
 }
 
 type PoolMetaStore = Record<PoolProviderId, Record<string, PoolMetaFields>>;
@@ -679,8 +707,35 @@ function recordToLinked(
     ...(meta?.usage ? { usage: meta.usage } : {}),
     ...(record.organizationId ? { organizationId: record.organizationId } : {}),
     ...(record.userId ? { userId: record.userId } : {}),
-    ...(record.email ? { email: record.email } : {}),
+    ...(() => {
+      // Show WHO an account is: prefer the credential record's email (new OAuth
+      // links persist it), then the pool-meta backfill (refreshUsage profile
+      // probe for older Anthropic links), then derive it from the id_token's
+      // OIDC `email` claim (Codex CLI imports carry an id_token; providers
+      // without one simply have no email to show).
+      const email =
+        record.email ??
+        meta?.email ??
+        emailFromIdToken(record.credentials.idToken);
+      return email ? { email } : {};
+    })(),
   };
+}
+
+/** The OIDC `email` claim from a JWT id_token, or undefined. */
+function emailFromIdToken(idToken: string | undefined): string | undefined {
+  if (!idToken) return undefined;
+  try {
+    const payload = JSON.parse(
+      Buffer.from(idToken.split(".")[1] ?? "", "base64url").toString("utf8"),
+    ) as { email?: unknown };
+    return typeof payload.email === "string" && payload.email.includes("@")
+      ? payload.email
+      : undefined;
+  } catch {
+    // error-policy:J3 untrusted id_token payload — undecodable ⇒ no email.
+    return undefined;
+  }
 }
 
 function loadAllAccounts(): Record<string, LinkedAccountConfig> {
@@ -720,6 +775,7 @@ async function persistAccount(account: LinkedAccountConfig): Promise<void> {
     ...(account.lastUsedAt !== undefined
       ? { lastUsedAt: account.lastUsedAt }
       : {}),
+    ...(account.email ? { email: account.email } : {}),
   };
   writeMetaStore(store);
 }


### PR DESCRIPTION
## What changed

> Stacked on #16090 (`agent/fix-remote-oauth-session-auth` is the base branch) — complements its link-time identity work.

#16090 persists the account email when a **new** OAuth link completes. Accounts linked **before** that (or imported from a CLI login) still render with no identity in the dashboard: Anthropic's OAuth access token is opaque (no OIDC claims), and Codex CLI imports only carry an id_token that nothing decoded. This PR backfills identity for those existing accounts:

- `AccountPool.refreshUsage` probes the same `fetchAnthropicOAuthProfile` the link flow uses — only when the account has no email, best-effort (`{}` on failure never fails the usage refresh) — and persists the email in **pool metadata**; credential files are never rewritten for display metadata.
- `recordToLinked` resolves the displayed email as `record.email` (new links) → `meta.email` (this backfill) → id_token OIDC `email` claim (Codex imports).
- `fetchAnthropicOAuthProfile` gains an optional injectable `fetchImpl` (backward-compatible; used by the new tests).

## Evidence

Live on a VPS agent with 2 pre-existing Claude Max links + 1 CLI-imported Codex account, running this branch's base:

**Before** (`GET /api/accounts`): all three accounts `email=None`.

**After** one "Refresh" per account:

```
Claude Max (bot account 2)   email=claude3@nubs.site    usage=0%
Claude Max (bot account 3)   email=nubsvault@gmail.com  usage=0%
ChatGPT Codex (bot account 2) email=shawgotbags@gmail.com usage=8%
```

- New tests: profile-probe backfill during refresh; no re-probe when an email already exists — `packages/app-core` account-pool suite **15/15** pass; `packages/auth` oauth-flow suite **5/5** pass.
- Typecheck clean for `packages/auth` + `packages/app-core`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
