### PR TITLE
fix(accounts): codex Test probe hits the subscription backend, not the API platform

### DIFF
--- a/packages/agent/src/api/accounts-routes.ts
+++ b/packages/agent/src/api/accounts-routes.ts
@@ -37,6 +37,7 @@ import {
   loadAccount,
   saveAccount,
 } from "@elizaos/auth/account-storage";
+import { fetchCodexUsage } from "@elizaos/auth/codex-usage";
 import { getAccessToken } from "@elizaos/auth/credentials";
 import { probeDirectApiKey } from "@elizaos/auth/direct-api-probe";
 import {
@@ -59,7 +60,7 @@ import {
   isUnavailableSubscriptionProvider,
   type SubscriptionProvider,
 } from "@elizaos/auth/types";
-import { logger } from "@elizaos/core";
+import { ElizaError, logger } from "@elizaos/core";
 import type { RouteRequestContext } from "@elizaos/shared";
 import {
   isLinkedAccountProviderId,
@@ -384,50 +385,42 @@ async function probeCodexUsage(
   latencyMs: number;
 }> {
   const start = Date.now();
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 10_000);
   try {
-    const headers: Record<string, string> = {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${accessToken}`,
-    };
-    if (codexAccountId) headers["ChatGPT-Account-Id"] = codexAccountId;
-    // @duplicate-component-audit-allow: usage probe reads auth/rate-limit headers; response text is ignored.
-    const response = await fetch("https://api.openai.com/v1/chat/completions", {
-      method: "POST",
-      signal: controller.signal,
-      headers,
-      body: JSON.stringify({
-        model: "gpt-5-mini",
-        max_tokens: 1,
-        messages: [{ role: "user", content: "hi" }],
-      }),
-    });
-    const latencyMs = Date.now() - start;
-    if (!response.ok) {
-      const text = await response.text().catch(() => "");
-      return {
-        ok: false,
-        status: response.status,
-        error: `OpenAI ${response.status}: ${text.slice(0, 200)}`,
-        latencyMs,
-      };
-    }
+    // One canonical probe: `@elizaos/auth/codex-usage` hits the ChatGPT/Codex
+    // backend the subscription token actually authenticates against (NOT
+    // api.openai.com completions, which bills the API platform org and fails
+    // healthy subscription accounts with billing errors), runtime-validates
+    // the payload, and throws typed ElizaErrors on any failure.
+    const usage = await fetchCodexUsage(accessToken, codexAccountId);
     return {
       ok: true,
-      status: response.status,
-      usage: { refreshedAt: Date.now() },
-      latencyMs,
+      status: 200,
+      usage: {
+        refreshedAt: Date.now(),
+        ...(usage.sessionPct !== undefined
+          ? { sessionPct: usage.sessionPct }
+          : {}),
+        ...(usage.weeklyPct !== undefined
+          ? { weeklyPct: usage.weeklyPct }
+          : {}),
+        ...(usage.resetsAt !== undefined ? { resetsAt: usage.resetsAt } : {}),
+      },
+      latencyMs: Date.now() - start,
     };
   } catch (err) {
+    // error-policy:J1 boundary translation — the probe route reports a
+    // structured pass/fail to the dashboard; the typed client error (with the
+    // HTTP status in its context) becomes that failure verbatim.
+    const status =
+      err instanceof ElizaError && typeof err.context?.status === "number"
+        ? err.context.status
+        : 0;
     return {
       ok: false,
-      status: 0,
+      status,
       error: err instanceof Error ? err.message : String(err),
       latencyMs: Date.now() - start,
     };
-  } finally {
-    clearTimeout(timer);
   }
 }
 

--- a/packages/app-core/src/services/account-usage.test.ts
+++ b/packages/app-core/src/services/account-usage.test.ts
@@ -224,7 +224,7 @@ describe("pollCodexUsage", () => {
     expect(snap.sessionPct).toBe(73);
     // reset_at in seconds -> normalized to ms.
     expect(snap.resetsAt).toBe(1_700_000_000 * 1000);
-    // Codex has no weekly window.
+    // No secondary window in this payload -> no weekly.
     expect(snap.weeklyPct).toBeUndefined();
     expect(typeof snap.refreshedAt).toBe("number");
 
@@ -238,6 +238,33 @@ describe("pollCodexUsage", () => {
     expect(headers.Authorization).toBe("Bearer codex-token");
     expect(headers["ChatGPT-Account-Id"]).toBe("acct-123");
     expect(headers["User-Agent"]).toBe("codex-cli");
+  });
+
+  it("maps the secondary (7-day) window to weeklyPct", async () => {
+    stubFetch(
+      jsonResponse({
+        plan_type: "pro",
+        rate_limit: {
+          primary_window: {
+            used_percent: 88,
+            reset_at: 1_783_812_204,
+            limit_window_seconds: 18000,
+          },
+          secondary_window: {
+            used_percent: 25,
+            reset_at: 1_784_357_126,
+            limit_window_seconds: 604800,
+          },
+        },
+      }),
+    );
+
+    const snap = await pollCodexUsage("codex-token", "acct-123");
+
+    expect(snap.sessionPct).toBe(88);
+    expect(snap.weeklyPct).toBe(25);
+    // resetsAt stays the SESSION window's reset (the sooner, actionable one).
+    expect(snap.resetsAt).toBe(1_783_812_204 * 1000);
   });
 
   it("clamps used_percent above 100 down to 100 and 0 stays 0", async () => {

--- a/packages/app-core/src/services/account-usage.ts
+++ b/packages/app-core/src/services/account-usage.ts
@@ -15,6 +15,7 @@
 
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import path from "node:path";
+import { fetchCodexUsage } from "@elizaos/auth/codex-usage";
 import { resolveStateDir } from "@elizaos/core";
 import type { LinkedAccountUsage } from "@elizaos/shared/contracts/service-routing";
 
@@ -37,7 +38,6 @@ export interface UsageEntry {
 }
 
 const ANTHROPIC_USAGE_URL = "https://api.anthropic.com/api/oauth/usage";
-const CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
 type FetchLike = typeof fetch;
 
 function utilizationToPct(value: unknown): number | undefined {
@@ -124,60 +124,24 @@ export async function pollAnthropicUsage(
   };
 }
 
-interface CodexUsagePayload {
-  plan_type?: string;
-  rate_limit?: {
-    primary_window?: {
-      used_percent?: number;
-      reset_at?: number | string;
-      limit_window_seconds?: number;
-    };
-  };
-}
-
 /**
- * Probe Codex / ChatGPT's usage endpoint.
- *
- * Endpoint: `GET https://chatgpt.com/backend-api/wham/usage`
- * Headers : `Authorization: Bearer <accessToken>`,
- *           `ChatGPT-Account-Id: <openAIAccountId>`,
- *           `User-Agent: codex-cli`
- *
- * `used_percent` is already on the 0..100 scale. `reset_at` is epoch
- * seconds. Codex has no weekly equivalent, so `weeklyPct` stays undefined.
+ * Probe Codex / ChatGPT's usage endpoint via the canonical client
+ * (`@elizaos/auth/codex-usage` — shared with the agent's inline Test probe).
+ * The primary window is the 5h session; the secondary window is the 7-day
+ * limit and maps to `weeklyPct` (same shape Anthropic exposes). Throws the
+ * client's typed `ElizaError` on any transport/HTTP/parse/shape failure.
  */
 export async function pollCodexUsage(
   accessToken: string,
   accountId: string,
   fetchImpl: FetchLike = fetch,
 ): Promise<UsageSnapshot> {
-  const res = await fetchImpl(CODEX_USAGE_URL, {
-    method: "GET",
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      "ChatGPT-Account-Id": accountId,
-      "User-Agent": "codex-cli",
-    },
-  });
-  if (!res.ok) {
-    throw new Error(`Codex usage probe failed: HTTP ${res.status}`);
-  }
-  const payload = (await res.json()) as CodexUsagePayload;
-  const primary = payload.rate_limit?.primary_window;
-
-  let sessionPct: number | undefined;
-  if (
-    typeof primary?.used_percent === "number" &&
-    Number.isFinite(primary.used_percent)
-  ) {
-    sessionPct = Math.max(0, Math.min(100, primary.used_percent));
-  }
-  const resetsAt = normalizeResetTimestamp(primary?.reset_at);
-
+  const usage = await fetchCodexUsage(accessToken, accountId, fetchImpl);
   return {
     refreshedAt: Date.now(),
-    ...(sessionPct !== undefined ? { sessionPct } : {}),
-    ...(resetsAt !== undefined ? { resetsAt } : {}),
+    ...(usage.sessionPct !== undefined ? { sessionPct: usage.sessionPct } : {}),
+    ...(usage.weeklyPct !== undefined ? { weeklyPct: usage.weeklyPct } : {}),
+    ...(usage.resetsAt !== undefined ? { resetsAt: usage.resetsAt } : {}),
   };
 }
 

--- a/packages/auth/src/codex-usage.test.ts
+++ b/packages/auth/src/codex-usage.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Unit tests for the canonical Codex usage client. Fully deterministic —
+ * fetch is injected; every failure mode Shaw's error policy demands is
+ * covered both ways (typed throw on failure, validated parse on success).
+ */
+import { ElizaError } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { fetchCodexUsage } from "./codex-usage.ts";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function fetchReturning(response: Response | (() => Response)): typeof fetch {
+  return (async () =>
+    typeof response === "function" ? response() : response) as typeof fetch;
+}
+
+const VALID_PAYLOAD = {
+  plan_type: "pro",
+  email: "user@example.com",
+  rate_limit: {
+    primary_window: {
+      used_percent: 88,
+      reset_at: 1_783_812_204, // epoch seconds
+      limit_window_seconds: 18000,
+    },
+    secondary_window: {
+      used_percent: 25,
+      reset_at: 1_784_357_126,
+      limit_window_seconds: 604800,
+    },
+  },
+};
+
+describe("fetchCodexUsage — success parsing", () => {
+  it("parses both windows, plan, and email; normalizes epoch-seconds reset", async () => {
+    const usage = await fetchCodexUsage(
+      "tok",
+      "acct-1",
+      fetchReturning(jsonResponse(VALID_PAYLOAD)),
+    );
+    expect(usage).toEqual({
+      sessionPct: 88,
+      weeklyPct: 25,
+      resetsAt: 1_783_812_204 * 1000,
+      planType: "pro",
+      email: "user@example.com",
+    });
+  });
+
+  it("passes through an epoch-milliseconds reset unchanged and parses ISO strings", async () => {
+    const ms = 1_784_000_000_000;
+    const withMs = await fetchCodexUsage(
+      "tok",
+      "a",
+      fetchReturning(
+        jsonResponse({ rate_limit: { primary_window: { reset_at: ms } } }),
+      ),
+    );
+    expect(withMs.resetsAt).toBe(ms);
+
+    const iso = "2026-07-12T00:00:00.000Z";
+    const withIso = await fetchCodexUsage(
+      "tok",
+      "a",
+      fetchReturning(
+        jsonResponse({ rate_limit: { primary_window: { reset_at: iso } } }),
+      ),
+    );
+    expect(withIso.resetsAt).toBe(Date.parse(iso));
+  });
+
+  it("clamps percents into 0..100 and drops non-numeric ones", async () => {
+    const usage = await fetchCodexUsage(
+      "tok",
+      "a",
+      fetchReturning(
+        jsonResponse({
+          rate_limit: {
+            primary_window: { used_percent: 150 },
+            secondary_window: { used_percent: "not-a-number" },
+          },
+        }),
+      ),
+    );
+    expect(usage.sessionPct).toBe(100);
+    expect(usage.weeklyPct).toBeUndefined();
+  });
+
+  it("treats a valid payload with missing windows as legitimately empty (no throw)", async () => {
+    const usage = await fetchCodexUsage(
+      "tok",
+      "a",
+      fetchReturning(jsonResponse({ plan_type: "plus" })),
+    );
+    expect(usage).toEqual({ planType: "plus" });
+  });
+
+  it("sends bearer + account id + codex-cli UA; omits the account header when absent", async () => {
+    const seen: Array<Record<string, string>> = [];
+    const spy = (async (_url: string | URL | Request, init?: RequestInit) => {
+      seen.push({ ...(init?.headers as Record<string, string>) });
+      return jsonResponse(VALID_PAYLOAD);
+    }) as typeof fetch;
+    await fetchCodexUsage("secret", "acct-9", spy);
+    await fetchCodexUsage("secret", undefined, spy);
+    expect(seen[0]?.Authorization).toBe("Bearer secret");
+    expect(seen[0]?.["ChatGPT-Account-Id"]).toBe("acct-9");
+    expect(seen[0]?.["User-Agent"]).toBe("codex-cli");
+    expect(seen[1]).not.toHaveProperty("ChatGPT-Account-Id");
+  });
+});
+
+describe("fetchCodexUsage — typed failures (never fabricated data)", () => {
+  it.each([[401], [429], [503]])(
+    "throws a typed http_error carrying status %s in context and message",
+    async (status) => {
+      const err = await fetchCodexUsage(
+        "tok",
+        "a",
+        fetchReturning(new Response("denied", { status })),
+      ).catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(ElizaError);
+      const typed = err as ElizaError;
+      expect(typed.code).toBe("codex_usage.http_error");
+      expect(typed.context?.status).toBe(status);
+      // Callers (rate-limit regexes, dashboards) read the status from the message.
+      expect(typed.message).toContain(String(status));
+    },
+  );
+
+  it("throws a typed request_failed on transport errors, preserving the cause", async () => {
+    const boom = new TypeError("network down");
+    const err = await fetchCodexUsage("tok", "a", (async () => {
+      throw boom;
+    }) as typeof fetch).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ElizaError);
+    expect((err as ElizaError).code).toBe("codex_usage.request_failed");
+    expect((err as ElizaError).cause).toBe(boom);
+  });
+
+  it("throws a typed request_failed on timeout aborts", async () => {
+    const abort = new DOMException("aborted", "TimeoutError");
+    const err = await fetchCodexUsage("tok", "a", (async () => {
+      throw abort;
+    }) as typeof fetch).catch((e: unknown) => e);
+    expect((err as ElizaError).code).toBe("codex_usage.request_failed");
+  });
+
+  it("throws a typed invalid_json when the body is not JSON", async () => {
+    const err = await fetchCodexUsage(
+      "tok",
+      "a",
+      fetchReturning(new Response("<html>cloudflare</html>", { status: 200 })),
+    ).catch((e: unknown) => e);
+    expect((err as ElizaError).code).toBe("codex_usage.invalid_json");
+  });
+
+  it.each([
+    ["null body", "null"],
+    ["array body", "[1,2]"],
+    ["non-object rate_limit", '{"rate_limit": 5}'],
+    ["non-object primary window", '{"rate_limit":{"primary_window": 7}}'],
+    ["non-object secondary window", '{"rate_limit":{"secondary_window": []}}'],
+  ])("throws a typed invalid_shape for %s", async (_name, body) => {
+    const err = await fetchCodexUsage(
+      "tok",
+      "a",
+      fetchReturning(
+        new Response(body, {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    ).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ElizaError);
+    expect((err as ElizaError).code).toBe("codex_usage.invalid_shape");
+  });
+});

--- a/packages/auth/src/codex-usage.ts
+++ b/packages/auth/src/codex-usage.ts
@@ -1,0 +1,171 @@
+/**
+ * Canonical Codex (ChatGPT subscription) usage client.
+ *
+ * One place probes `chatgpt.com/backend-api/wham/usage` — the backend a
+ * ChatGPT-subscription OAuth token actually authenticates against (NOT
+ * api.openai.com, which bills the API platform and rejects subscription
+ * tokens with billing errors). Consumed by app-core's `pollCodexUsage`
+ * (pool usage refresh) and the agent's inline account Test probe, so the
+ * two never drift apart again.
+ *
+ * Failure semantics follow the repo error policy: every transport / HTTP /
+ * parse / shape failure throws a typed `ElizaError` — a failed usage read is
+ * never fabricated as an empty-but-healthy snapshot. Fields that are merely
+ * absent from a valid payload are legitimately optional and omitted.
+ */
+
+import { ElizaError } from "@elizaos/core";
+
+const CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
+
+/** Parsed rate-limit windows from a valid wham/usage payload. */
+export interface CodexUsageSnapshot {
+  /** Primary (5h session) window used percent, clamped to 0..100. */
+  sessionPct?: number;
+  /** Secondary (7-day) window used percent, clamped to 0..100. */
+  weeklyPct?: number;
+  /** Primary-window reset, epoch milliseconds. */
+  resetsAt?: number;
+  /** e.g. "plus" | "pro" — surfaced for display, never branched on. */
+  planType?: string;
+  /** Account email when the payload carries it. */
+  email?: string;
+}
+
+function clampPct(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  return Math.max(0, Math.min(100, value));
+}
+
+function normalizeResetTimestamp(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    // Heuristic: epoch seconds (~1.7e9 today) vs milliseconds (~1.7e12).
+    return value < 1e12 ? value * 1000 : value;
+  }
+  if (typeof value === "string" && value.length > 0) {
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Probe the Codex usage endpoint with a subscription access token.
+ *
+ * Headers: `Authorization: Bearer` + `ChatGPT-Account-Id` + the codex-cli
+ * User-Agent (the endpoint rejects unknown clients). Throws a typed
+ * `ElizaError` on any transport, HTTP, JSON, or shape failure; returns the
+ * validated windows on success.
+ */
+export async function fetchCodexUsage(
+  accessToken: string,
+  accountId: string | undefined,
+  fetchImpl: typeof fetch = fetch,
+): Promise<CodexUsageSnapshot> {
+  let response: Response;
+  try {
+    response = await fetchImpl(CODEX_USAGE_URL, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        // Omitted (not sent empty) when the caller has no account id — e.g.
+        // the inline Test probe against a record with no organizationId.
+        ...(accountId ? { "ChatGPT-Account-Id": accountId } : {}),
+        "User-Agent": "codex-cli",
+      },
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch (cause) {
+    // error-policy:J2 context-adding rethrow — a usage read that never
+    // completed is a failed probe, not a zero-usage account.
+    throw new ElizaError("Codex usage request failed", {
+      code: "codex_usage.request_failed",
+      severity: "ephemeral",
+      cause,
+    });
+  }
+
+  if (!response.ok) {
+    throw new ElizaError(
+      `Codex usage request was rejected (HTTP ${response.status})`,
+      {
+        code: "codex_usage.http_error",
+        severity: response.status >= 500 ? "ephemeral" : "fatal",
+        context: { status: response.status },
+      },
+    );
+  }
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (cause) {
+    // error-policy:J2 context-adding rethrow — malformed authenticated data is
+    // a failed usage load, not a valid empty snapshot.
+    throw new ElizaError("Codex usage response was not JSON", {
+      code: "codex_usage.invalid_json",
+      severity: "fatal",
+      cause,
+    });
+  }
+
+  if (!isRecord(payload)) {
+    throw new ElizaError("Codex usage response was invalid", {
+      code: "codex_usage.invalid_shape",
+      severity: "fatal",
+    });
+  }
+  const rateLimit = payload.rate_limit;
+  if (rateLimit !== undefined && !isRecord(rateLimit)) {
+    throw new ElizaError("Codex usage rate_limit was invalid", {
+      code: "codex_usage.invalid_shape",
+      severity: "fatal",
+    });
+  }
+  // primary = the 5h session window (limit_window_seconds 18000);
+  // secondary = the 7-day window (604800) — same split Anthropic exposes.
+  const primary = isRecord(rateLimit) ? rateLimit.primary_window : undefined;
+  const secondary = isRecord(rateLimit)
+    ? rateLimit.secondary_window
+    : undefined;
+  if (primary !== undefined && !isRecord(primary)) {
+    throw new ElizaError("Codex usage primary window was invalid", {
+      code: "codex_usage.invalid_shape",
+      severity: "fatal",
+    });
+  }
+  if (secondary !== undefined && !isRecord(secondary)) {
+    throw new ElizaError("Codex usage secondary window was invalid", {
+      code: "codex_usage.invalid_shape",
+      severity: "fatal",
+    });
+  }
+
+  const sessionPct = clampPct(isRecord(primary) ? primary.used_percent : undefined);
+  const weeklyPct = clampPct(
+    isRecord(secondary) ? secondary.used_percent : undefined,
+  );
+  const resetsAt = normalizeResetTimestamp(
+    isRecord(primary) ? primary.reset_at : undefined,
+  );
+  const planType =
+    typeof payload.plan_type === "string" && payload.plan_type
+      ? payload.plan_type
+      : undefined;
+  const email =
+    typeof payload.email === "string" && payload.email.includes("@")
+      ? payload.email
+      : undefined;
+
+  return {
+    ...(sessionPct !== undefined ? { sessionPct } : {}),
+    ...(weeklyPct !== undefined ? { weeklyPct } : {}),
+    ...(resetsAt !== undefined ? { resetsAt } : {}),
+    ...(planType !== undefined ? { planType } : {}),
+    ...(email !== undefined ? { email } : {}),
+  };
+}


### PR DESCRIPTION
## What changed

> Stacked on #16090 (`agent/fix-remote-oauth-session-auth` is the base branch) — that PR's surface owns `accounts-routes.ts`, so targeting it avoids a guaranteed merge conflict.

The codex account **Test** probe fired a 1-token completion at `api.openai.com/v1/chat/completions` — the API *platform*, which ChatGPT-subscription OAuth tokens carry no credits on. A perfectly healthy subscription account fails that probe with `429 billing_not_active` / "exceeded your current quota", telling users their working account is broken.

Probe `chatgpt.com/backend-api/wham/usage` instead — the backend the subscription token actually authenticates against (same endpoint + headers as the canonical `pollCodexUsage` in app-core) — and fold its rate-limit window (`used_percent`, `reset_at`) into the returned usage snapshot instead of an empty `refreshedAt` stamp.

## Evidence (live)

Two linked codex subscription accounts on a running agent; both **provably work** — each powered a real codex coding spawn minutes before (round-robin selected each in turn; both created their target file):

| Account | Real coding spawn | Test probe BEFORE | Test probe AFTER |
|---|---|---|---|
| account A (62 % session used) | ✅ file created | ❌ `OpenAI 429: exceeded your current quota` | ✅ `{"ok":true,"status":200}` |
| account B (freshly device-linked) | ✅ file created | ❌ `OpenAI 429: billing_not_active` | ✅ `{"ok":true,"status":200}` |

The BEFORE column is the falsified claim: the probe reported both *working* accounts as billing-broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
