### PR TITLE
fix(discord,commands): declutter the Discord command picker

### DIFF
--- a/plugins/plugin-commands/__tests__/connector-catalog.test.ts
+++ b/plugins/plugin-commands/__tests__/connector-catalog.test.ts
@@ -214,3 +214,25 @@ describe("connector catalog — view-scoped command visibility (#8798)", () => {
 		expect(discord.some((c) => c.name === "calendar-add")).toBe(false);
 	});
 });
+
+describe("connector catalog — navigation command surface filtering (#picker-clutter)", () => {
+	it("keeps navigation commands on the shipped in-app surface", () => {
+		const names = new Set(getConnectorCommands("gui").map((c) => c.name));
+		for (const name of ["views", "wallet", "tasks", "knowledge", "plugins"]) {
+			expect(names.has(name), `${name} must stay on gui`).toBe(true);
+		}
+	});
+
+	it("filters navigation commands off chat connectors (discord/telegram)", () => {
+		// Navigating needs a viewport: on a chat connector these commands could
+		// only reply with a text description of a destination the user cannot
+		// see, while adding a dozen entries to every member's command picker.
+		for (const surface of ["discord", "telegram"]) {
+			const cmds = getConnectorCommands(surface);
+			expect(
+				cmds.some((c) => c.target.kind === "navigate"),
+				`${surface} must carry no navigate targets`,
+			).toBe(false);
+		}
+	});
+});

--- a/plugins/plugin-commands/src/navigation-commands.ts
+++ b/plugins/plugin-commands/src/navigation-commands.ts
@@ -23,7 +23,12 @@ import type { CommandDefinition, CommandSurface } from "./types";
 
 const IN_APP_SURFACES: CommandSurface[] = ["gui"];
 
-/** Navigation destinations — open an in-app route on any surface. */
+/**
+ * Navigation destinations — open an in-app route. App-surface only
+ * (`IN_APP_SURFACES`): navigating needs a viewport, so on chat connectors
+ * (Discord/Telegram) these would only reply with a text description of a
+ * destination the user cannot see — a dozen commands of picker clutter.
+ */
 const NAVIGATE_COMMANDS: CommandDefinition[] = [
 	{
 		key: "settings",
@@ -31,6 +36,7 @@ const NAVIGATE_COMMANDS: CommandDefinition[] = [
 		description: "Open agent settings",
 		textAliases: ["/settings"],
 		scope: "both",
+		surfaces: IN_APP_SURFACES,
 		category: "docks",
 		icon: "settings",
 		target: { kind: "navigate", path: "/settings", tab: "settings" },
@@ -51,6 +57,7 @@ const NAVIGATE_COMMANDS: CommandDefinition[] = [
 		description: "Return to the chat",
 		textAliases: ["/chat"],
 		scope: "both",
+		surfaces: IN_APP_SURFACES,
 		category: "docks",
 		icon: "message-circle",
 		target: { kind: "navigate", path: "/chat", tab: "chat" },
@@ -61,6 +68,7 @@ const NAVIGATE_COMMANDS: CommandDefinition[] = [
 		description: "Open the agent's views",
 		textAliases: ["/views"],
 		scope: "both",
+		surfaces: IN_APP_SURFACES,
 		category: "docks",
 		icon: "layout-grid",
 		target: { kind: "navigate", path: "/views", tab: "views" },
@@ -80,6 +88,7 @@ const NAVIGATE_COMMANDS: CommandDefinition[] = [
 		description: "Open the agent orchestrator",
 		textAliases: ["/orchestrator"],
 		scope: "both",
+		surfaces: IN_APP_SURFACES,
 		category: "docks",
 		icon: "workflow",
 		target: { kind: "navigate", path: "/orchestrator", viewId: "orchestrator" },
@@ -90,6 +99,7 @@ const NAVIGATE_COMMANDS: CommandDefinition[] = [
 		description: "Open the character editor",
 		textAliases: ["/character"],
 		scope: "both",
+		surfaces: IN_APP_SURFACES,
 		category: "docks",
 		icon: "user",
 		target: { kind: "navigate", path: "/character", tab: "character" },
@@ -100,6 +110,7 @@ const NAVIGATE_COMMANDS: CommandDefinition[] = [
 		description: "Open the knowledge base",
 		textAliases: ["/knowledge"],
 		scope: "both",
+		surfaces: IN_APP_SURFACES,
 		category: "docks",
 		icon: "book-open",
 		target: {
@@ -114,6 +125,7 @@ const NAVIGATE_COMMANDS: CommandDefinition[] = [
 		description: "Open the wallet & inventory",
 		textAliases: ["/wallet"],
 		scope: "both",
+		surfaces: IN_APP_SURFACES,
 		category: "docks",
 		icon: "wallet",
 		target: { kind: "navigate", path: "/wallet", tab: "inventory" },
@@ -124,6 +136,7 @@ const NAVIGATE_COMMANDS: CommandDefinition[] = [
 		description: "Open automations",
 		textAliases: ["/automations"],
 		scope: "both",
+		surfaces: IN_APP_SURFACES,
 		category: "docks",
 		icon: "zap",
 		target: { kind: "navigate", path: "/automations", tab: "automations" },
@@ -134,6 +147,7 @@ const NAVIGATE_COMMANDS: CommandDefinition[] = [
 		description: "Open tasks",
 		textAliases: ["/tasks"],
 		scope: "both",
+		surfaces: IN_APP_SURFACES,
 		category: "docks",
 		icon: "check-square",
 		target: { kind: "navigate", path: "/apps/tasks", tab: "tasks" },
@@ -144,6 +158,7 @@ const NAVIGATE_COMMANDS: CommandDefinition[] = [
 		description: "Open the skills library",
 		textAliases: ["/skills"],
 		scope: "both",
+		surfaces: IN_APP_SURFACES,
 		category: "docks",
 		icon: "sparkles",
 		target: { kind: "navigate", path: "/apps/skills", tab: "skills" },
@@ -154,6 +169,7 @@ const NAVIGATE_COMMANDS: CommandDefinition[] = [
 		description: "Open installed plugins",
 		textAliases: ["/plugins"],
 		scope: "both",
+		surfaces: IN_APP_SURFACES,
 		category: "docks",
 		icon: "plug",
 		target: { kind: "navigate", path: "/apps/plugins", tab: "plugins" },
@@ -164,6 +180,7 @@ const NAVIGATE_COMMANDS: CommandDefinition[] = [
 		description: "Open the logs",
 		textAliases: ["/logs"],
 		scope: "both",
+		surfaces: IN_APP_SURFACES,
 		category: "docks",
 		icon: "scroll-text",
 		target: { kind: "navigate", path: "/apps/logs", tab: "logs" },
@@ -174,6 +191,7 @@ const NAVIGATE_COMMANDS: CommandDefinition[] = [
 		description: "Open the database browser",
 		textAliases: ["/database"],
 		scope: "both",
+		surfaces: IN_APP_SURFACES,
 		category: "docks",
 		icon: "database",
 		target: { kind: "navigate", path: "/apps/database", tab: "database" },

--- a/plugins/plugin-discord/__tests__/catalog-commands.test.ts
+++ b/plugins/plugin-discord/__tests__/catalog-commands.test.ts
@@ -106,22 +106,27 @@ describe("catalog → DiscordSlashCommand mapping", () => {
 		}
 	});
 
-	it("maps option choices for the /settings section option", () => {
-		const catalogSettings = getConnectorCommands("discord").find(
-			(c) => c.name === "settings",
-		);
-		expect(catalogSettings).toBeDefined();
-
-		const mapped = mapCatalogCommand(
-			catalogSettings as NonNullable<typeof catalogSettings>,
-		);
+	it("caps mapped option choices at Discord's 25 and keeps token shape", () => {
+		// Navigation commands (the old /settings source of a choices-bearing
+		// option) are app-surface-only now, so drive the mapper directly.
+		const mapped = mapCatalogCommand({
+			name: "pick",
+			description: "Pick a token",
+			target: { kind: "agent" },
+			options: [
+				{
+					name: "section",
+					description: "Token",
+					required: false,
+					choices: Array.from({ length: 30 }, (_, i) => `token-${i}`),
+				},
+			],
+		});
 		const section = mapped.options?.find((o) => o.name === "section");
 		expect(section).toBeDefined();
 		expect(section?.type).toBe("string");
 		// Discord caps option choices at 25; mapping must respect that.
-		expect(section?.choices?.length).toBeGreaterThan(0);
-		expect(section?.choices?.length).toBeLessThanOrEqual(25);
-		// Choice name + value should be the catalog token.
+		expect(section?.choices?.length).toBe(25);
 		for (const choice of section?.choices ?? []) {
 			expect(choice.name.length).toBeLessThanOrEqual(100);
 			expect(choice.value.length).toBeGreaterThan(0);
@@ -129,8 +134,8 @@ describe("catalog → DiscordSlashCommand mapping", () => {
 	});
 
 	it("omits options for argless commands", () => {
-		const orchestrator = findCatalog("orchestrator");
-		expect(orchestrator.options).toBeUndefined();
+		const whoami = findCatalog("whoami");
+		expect(whoami.options).toBeUndefined();
 	});
 });
 
@@ -138,14 +143,17 @@ describe("buildCatalogSlashCommands dedupe", () => {
 	it("excludes names already present (built-ins win)", () => {
 		const withoutDedupe = buildCatalogSlashCommands();
 		const names = new Set(withoutDedupe.map((c) => c.name));
-		expect(names.has("settings")).toBe(true);
+		expect(names.has("whoami")).toBe(true);
+		// Navigation commands are app-surface-only and never reach Discord.
+		expect(names.has("orchestrator")).toBe(false);
+		expect(names.has("views")).toBe(false);
 
-		const deduped = buildCatalogSlashCommands(new Set(["settings", "help"]));
+		const deduped = buildCatalogSlashCommands(new Set(["whoami", "help"]));
 		const dedupedNames = deduped.map((c) => c.name);
-		expect(dedupedNames).not.toContain("settings");
+		expect(dedupedNames).not.toContain("whoami");
 		expect(dedupedNames).not.toContain("help");
 		// Non-overlapping commands still come through.
-		expect(dedupedNames).toContain("orchestrator");
+		expect(dedupedNames).toContain("think");
 	});
 
 	it("never emits duplicate names", () => {
@@ -155,8 +163,19 @@ describe("buildCatalogSlashCommands dedupe", () => {
 });
 
 describe("per-target execute branching", () => {
-	it("navigate: replies ephemerally describing the destination", async () => {
-		const orchestrator = findCatalog("orchestrator");
+	it("navigate: replies ephemerally describing the destination (defensive)", async () => {
+		// Navigation commands are filtered off connector surfaces upstream; the
+		// branch stays as defensive handling, mirroring the client-target case.
+		const orchestrator = mapCatalogCommand({
+			name: "orchestrator",
+			description: "Open the orchestrator",
+			target: {
+				kind: "navigate",
+				path: "/orchestrator",
+				viewId: "orchestrator",
+			},
+			options: [],
+		});
 		const interaction = makeInteraction();
 		await orchestrator.execute(interaction as never, makeRuntime());
 
@@ -167,12 +186,23 @@ describe("per-target execute branching", () => {
 		};
 		expect(arg.ephemeral).toBe(true);
 		expect(arg.content).toContain("orchestrator");
-		expect(arg.content).toContain("/orchestrator");
 		expect(interaction.deferReply).not.toHaveBeenCalled();
 	});
 
-	it("navigate: resolves the /settings section alias to its canonical id", async () => {
-		const settings = findCatalog("settings");
+	it("navigate: resolves the /settings section alias to its canonical id (defensive)", async () => {
+		const settings = mapCatalogCommand({
+			name: "settings",
+			description: "Open agent settings",
+			target: { kind: "navigate", path: "/settings", tab: "settings" },
+			options: [
+				{
+					name: "section",
+					description: "Settings section to open",
+					required: false,
+					choices: [],
+				},
+			],
+		});
 		const interaction = makeInteraction({ section: "providers" });
 		await settings.execute(interaction as never, makeRuntime());
 
@@ -410,7 +440,8 @@ describe("registerCatalogSlashCommands", () => {
 			} else {
 				expect(names).toContain("app");
 			}
-			expect(names).toContain("orchestrator");
+			// Navigation commands are app-surface-only and never reach Discord.
+			expect(names).not.toContain("orchestrator");
 			expect(names).toContain("think");
 
 			const registry = getRegisteredCommands();

--- a/plugins/plugin-discord/__tests__/slash-commands.test.ts
+++ b/plugins/plugin-discord/__tests__/slash-commands.test.ts
@@ -241,3 +241,47 @@ describe("slash command dispatcher role gates (#14710)", () => {
 		expect(lastReply(interaction).content).toContain("OWNER");
 	});
 });
+
+describe("builtin command surface (privileged plumbing hidden from pickers)", () => {
+	it("does not register the removed placebo /model command", () => {
+		// /model claimed "switching is noted" while changing nothing — the real
+		// model surface is the app's Models & Providers screen.
+		expect(getRegisteredCommands().has("model")).toBe(false);
+	});
+
+	it("marks privileged builtins with requiredPermissions and leaves user commands open", () => {
+		const commands = getRegisteredCommands();
+		for (const name of ["settings", "setup", "app", "transcribe"]) {
+			expect(
+				commands.get(name)?.requiredPermissions,
+				`${name} must carry requiredPermissions`,
+			).toBeTruthy();
+		}
+		for (const name of ["help", "status", "search", "clear"]) {
+			expect(
+				commands.get(name)?.requiredPermissions,
+				`${name} must stay visible to everyone`,
+			).toBeUndefined();
+		}
+	});
+
+	it("transforms requiredPermissions into default_member_permissions on the wire", async () => {
+		const { transformCommandToDiscordApi } = await import(
+			"../discord-commands"
+		);
+		const setup = getRegisteredCommands().get("setup");
+		const help = getRegisteredCommands().get("help");
+		if (!setup || !help) throw new Error("builtins missing");
+		const wireSetup = transformCommandToDiscordApi(
+			setup as never,
+		) as unknown as {
+			default_member_permissions?: string;
+		};
+		const wireHelp = transformCommandToDiscordApi(help as never) as unknown as {
+			default_member_permissions?: string;
+		};
+		// Administrator bit, stringified for the REST payload.
+		expect(wireSetup.default_member_permissions).toBe("8");
+		expect(wireHelp.default_member_permissions).toBeUndefined();
+	});
+});

--- a/plugins/plugin-discord/catalog-commands.ts
+++ b/plugins/plugin-discord/catalog-commands.ts
@@ -15,8 +15,11 @@
  * handlers (some with autocomplete and Discord-specific behavior). To PRESERVE
  * all existing behavior we register only the catalog commands whose sanitized
  * name does NOT already exist in the registry — built-ins always win. This adds
- * the new catalog commands (think, reasoning, views, orchestrator, knowledge,
- * plugins, …) without touching the tested built-in command surface.
+ * the new catalog agent commands (think, reasoning, models, usage, queue, …)
+ * without touching the tested built-in command surface. Navigation commands
+ * never reach this bridge: they are app-surface-only (`surfaces` in
+ * `navigation-commands.ts`) because navigating needs a viewport a chat
+ * connector doesn't have.
  *
  * Per-target dispatch:
  *   - `agent`    → deterministic commands
@@ -24,8 +27,9 @@
  *                  via `resolveCommand`; pipeline-owned agent commands route
  *                  the reconstructed command text through the runtime's message
  *                  pipeline and reply with the agent's answer.
- *   - `navigate` → reply (ephemeral) describing the destination, resolving the
- *                  `/settings <section>` argument when present.
+ *   - `navigate` → filtered off connector surfaces upstream; handled
+ *                  defensively with an ephemeral destination description,
+ *                  resolving the `/settings <section>` argument when present.
  *   - `client`   → local-client behaviors are filtered out of the discord
  *                  surface upstream; handled defensively with a short reply.
  *

--- a/plugins/plugin-discord/slash-commands.ts
+++ b/plugins/plugin-discord/slash-commands.ts
@@ -14,7 +14,7 @@ import type {
 	AutocompleteInteraction,
 	ChatInputCommandInteraction,
 } from "discord.js";
-import { ApplicationCommandOptionType } from "discord.js";
+import { ApplicationCommandOptionType, PermissionFlagsBits } from "discord.js";
 import { getPreset, listPresets } from "./actions/setup-credentials";
 import type { DiscordSlashCommand } from "./types";
 import type { VoiceManager } from "./voice";
@@ -30,6 +30,10 @@ export interface SlashCommand {
 	ownerOnly?: boolean;
 	/** Minimum elizaOS role required to execute this command. */
 	requiredRole?: SlashCommandRole;
+	/** Discord permission bitfield for `default_member_permissions` —
+	 * hides the command from pickers of members lacking it. Execute-time
+	 * `requiredRole` (the eliza role model) remains the actual gate. */
+	requiredPermissions?: bigint | string | null;
 	execute: (
 		interaction: ChatInputCommandInteraction,
 		runtime: IAgentRuntime,
@@ -76,56 +80,6 @@ const OPTION_TYPE_MAP: Record<string, number> = {
 
 const commands = new Map<string, SlashCommand>();
 const cooldowns = new Map<string, Map<string, number>>();
-
-const FALLBACK_KNOWN_MODELS = [
-	"gpt-4o",
-	"gpt-5-mini",
-	"gpt-5.5",
-	"gpt-3.5-turbo",
-	"claude-sonnet-4-6",
-	"claude-opus-4-7",
-	"claude-3.5-haiku",
-	"openai/gpt-oss-120b",
-	"eliza-1-4b",
-	"gemini-2.5-pro",
-	"gemini-2.5-flash",
-	"mistral-large",
-	"mistral-medium",
-] as const;
-
-function parseStringList(value: unknown): string[] {
-	if (Array.isArray(value)) {
-		return value
-			.map((entry) => (typeof entry === "string" ? entry.trim() : ""))
-			.filter(Boolean);
-	}
-	if (typeof value !== "string") {
-		return [];
-	}
-	const trimmed = value.trim();
-	if (!trimmed) {
-		return [];
-	}
-	try {
-		const parsed = JSON.parse(trimmed) as unknown;
-		if (Array.isArray(parsed)) {
-			return parseStringList(parsed);
-		}
-	} catch {
-		// Fall back to comma-separated parsing.
-	}
-	return trimmed
-		.split(",")
-		.map((entry) => entry.trim())
-		.filter(Boolean);
-}
-
-function getKnownModels(runtime: IAgentRuntime): string[] {
-	const configured =
-		parseStringList(runtime.getSetting("DISCORD_KNOWN_MODELS")) ??
-		parseStringList(runtime.getSetting("KNOWN_MODELS"));
-	return configured.length > 0 ? configured : [...FALLBACK_KNOWN_MODELS];
-}
 
 const helpCommand: SlashCommand = {
 	name: "help",
@@ -259,6 +213,12 @@ const settingsCommand: SlashCommand = {
 	name: "settings",
 	description: "View the current Discord bot settings",
 	requiredRole: "ADMIN",
+	// Hide from the pickers of members who lack the Discord permission —
+	// execute-time `hasRoleAccess` (the eliza role model) stays the actual
+	// gate; this only sets default_member_permissions so privileged plumbing
+	// doesn't clutter every member's command list. Server admins can re-grant
+	// visibility per-role under Server Settings → Integrations as usual.
+	requiredPermissions: PermissionFlagsBits.ManageGuild,
 	options: [
 		{
 			name: "action",
@@ -301,6 +261,8 @@ const setupCommand: SlashCommand = {
 	name: "setup",
 	description: "Set up API credentials for third-party services",
 	requiredRole: "OWNER",
+	// Owner-level credential plumbing — visible only to Administrator members.
+	requiredPermissions: PermissionFlagsBits.Administrator,
 	options: [
 		{
 			name: "service",
@@ -390,49 +352,6 @@ const setupCommand: SlashCommand = {
 	},
 };
 
-const modelCommand: SlashCommand = {
-	name: "model",
-	description: "View or change the active AI model",
-	requiredRole: "ADMIN",
-	options: [
-		{
-			name: "name",
-			description: "Model name to switch to (leave empty to view current)",
-			type: "string",
-			autocomplete: true,
-		},
-	],
-	ephemeral: true,
-	async execute(interaction, runtime) {
-		const modelName = interaction.options.getString("name");
-		if (!modelName) {
-			await interaction.reply({
-				content: `**Current model:** \`${runtime.getSetting("MODEL") ?? runtime.getSetting("DEFAULT_MODEL") ?? "(not configured)"}\``,
-				ephemeral: true,
-			});
-			return;
-		}
-
-		await interaction.reply({
-			content: `Model switching to \`${modelName}\` is noted. The runtime model is still controlled by configuration, so update the setting and restart to switch permanently.`,
-			ephemeral: true,
-		});
-	},
-	async autocomplete(interaction) {
-		const runtime = (interaction.client as { runtime?: IAgentRuntime }).runtime;
-		const models = runtime
-			? getKnownModels(runtime)
-			: [...FALLBACK_KNOWN_MODELS];
-		const focused = interaction.options.getFocused().toLowerCase();
-		const filtered = models
-			.filter((model) => model.toLowerCase().includes(focused))
-			.slice(0, 25);
-		await interaction.respond(
-			filtered.map((model) => ({ name: model, value: model })),
-		);
-	},
-};
-
 /** Label on the embedded-app launch link. */
 const APP_LAUNCH_LABEL = "Open Eliza App";
 
@@ -485,6 +404,7 @@ const appCommand: SlashCommand = {
 	description: "Launch the embedded Eliza app (admins only)",
 	ephemeral: true,
 	requiredRole: "ADMIN",
+	requiredPermissions: PermissionFlagsBits.ManageGuild,
 	async execute(interaction, runtime) {
 		const memory: Memory = {
 			id: createUniqueUuid(runtime, `${interaction.id}-app`) as UUID,
@@ -551,8 +471,9 @@ const transcribeCommand: SlashCommand = {
 	description:
 		"Start or stop live meeting transcription for the current voice channel",
 	// Recording a voice channel is a consent-sensitive mutation — gate it to
-	// ADMIN, matching the other mutating commands (settings/model/app).
+	// ADMIN, matching the other mutating commands (settings/app).
 	requiredRole: "ADMIN",
+	requiredPermissions: PermissionFlagsBits.ManageGuild,
 	options: [
 		{
 			name: "mode",
@@ -667,7 +588,6 @@ function registerBuiltins(): void {
 		searchCommand,
 		clearCommand,
 		settingsCommand,
-		modelCommand,
 		setupCommand,
 		appCommand,
 		transcribeCommand,


### PR DESCRIPTION
## What changed

The live agent registered **40+ Discord slash commands**; every member's picker was full of app-console plumbing. Three structural fixes:

1. **Navigation commands are app-surface-only.** Added `surfaces: IN_APP_SURFACES` to every `navigate` definition — the exact mechanism client commands (`/clear`, `/fullscreen`) already use. Navigating needs a viewport: on Discord/Telegram these 12 commands (`/views`, `/orchestrator`, `/wallet`, `/tasks`, `/knowledge`, `/plugins`, `/logs`, `/database`, …) could only reply with a text description of a destination the user cannot see. The Discord bridge keeps a defensive `navigate` branch, mirroring the client-target precedent.

2. **Removed the built-in `/model` placebo.** It read a setting nothing populates and answered "switching to X is noted… update the setting and restart" — a fake action. Removing it also **unshadows the catalog's real agent `/model`** (built-ins win dedupe), so `/model` on Discord now actually routes instead of lying.

3. **Privileged built-ins are hidden from non-privileged pickers.** `/settings`, `/app`, `/transcribe` declare `requiredPermissions: ManageGuild` and `/setup` (credential plumbing) `Administrator`, flowing into `default_member_permissions` at registration. Execute-time `hasRoleAccess` (the eliza role model) remains the actual gate — this only stops the plumbing from cluttering every member's command list. Server admins can re-grant visibility per-role under Server Settings → Integrations as usual.

Follow-up (not in this PR): catalog agent commands with `requiresElevated` are still visible-but-refused for regular members; hiding them needs the auth flags added to the shared `ConnectorCommand` contract (Telegram parity included).

## Evidence

- Live registration before: 44 commands (log: `Registering built-in slash commands (count=44, names=[…, "views","orchestrator","character","knowledge","wallet","automations","tasks","skills","plugins","logs","database"])`).
- After (verified on a live agent): navigate commands absent, `getConnectorCommands("discord")` = 22 agent-target commands, 0 navigate.
- Tests: plugin-discord **304/304** (incl. rewritten catalog-bridge tests driving the defensive navigate branch with synthetic commands, and new picker-surface tests); plugin-commands suite + typecheck green (new tests: navigate kept on `gui`, filtered off `discord`/`telegram`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
