### PR TITLE
fix(cloud): remove Railway Redis from chat ingress

### DIFF
--- a/packages/cloud/api/__tests__/chat-completions-optimistic-billing.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-optimistic-billing.test.ts
@@ -204,9 +204,8 @@ mock.module("ai", () => ({
 }));
 
 // Import the route AFTER the mocks so it binds to the stubs.
-const { handleChatCompletionsPOST } = await import(
-  "../v1/chat/completions/route"
-);
+const { default: chatCompletionsRouter, handleChatCompletionsPOST } =
+  await import("../v1/chat/completions/route");
 
 afterAll(() => {
   mock.module("ai", () => aiActual);
@@ -241,8 +240,9 @@ afterAll(() => {
 function makeRequest(
   affiliateCode?: string,
   overrides: Record<string, unknown> = {},
+  url = "https://api.test/api/v1/chat/completions",
 ): Request {
-  return new Request("https://api.test/api/v1/chat/completions", {
+  return new Request(url, {
     method: "POST",
     headers: {
       "content-type": "application/json",
@@ -326,6 +326,41 @@ describe("chat/completions optimistic-billing route decision (#9899/#10066)", ()
     expect(createOptimisticDebitSettler).toHaveBeenCalledTimes(1);
     // The synchronous reserve write (the latency we are removing) is skipped.
     expect(reserveCredits).not.toHaveBeenCalled();
+  });
+
+  test("an allowed native route decision reaches the handler and preserves limiter headers", async () => {
+    const keys: string[] = [];
+    const waitUntilPromises: Promise<unknown>[] = [];
+    const response = await chatCompletionsRouter.fetch(
+      makeRequest(undefined, {}, "https://api.test/"),
+      {
+        NODE_ENV: "production",
+        CHAT_ROUTE_RATE_LIMITER: {
+          async limit({ key }: { key: string }) {
+            keys.push(key);
+            return { success: true };
+          },
+        },
+      } as never,
+      {
+        waitUntil(promise: Promise<unknown>) {
+          waitUntilPromises.push(promise);
+        },
+        passThroughOnException() {},
+        props: {},
+      } as never,
+    );
+
+    // The model stub throws after dispatch. A 500 here proves the native gate
+    // allowed the request into the same real route handler exercised below.
+    expect(response.status).toBe(500);
+    expect(keys).toEqual(["public"]);
+    expect(response.headers.get("X-RateLimit-Policy")).toBe(
+      "cloudflare-native",
+    );
+    expect(generateText).toHaveBeenCalledTimes(1);
+    expect(writePendingInferenceCharge).toHaveBeenCalledTimes(1);
+    await Promise.all(waitUntilPromises);
   });
 
   test("billing requestId is server-generated, not copied from x-request-id", async () => {

--- a/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
@@ -285,7 +285,11 @@ function callStreaming(
   );
 }
 
-function callNonStreaming(model: string, reasoningEffort: "none" | "low") {
+function callNonStreaming(
+  model: string,
+  reasoningEffort: "none" | "low",
+  promptCacheKey?: string,
+) {
   return handleNonStreamingRequest(
     model,
     undefined,
@@ -294,6 +298,7 @@ function callNonStreaming(model: string, reasoningEffort: "none" | "low") {
       model,
       messages: [{ role: "user", content: "hello" }],
       reasoning_effort: reasoningEffort,
+      ...(promptCacheKey ? { prompt_cache_key: promptCacheKey } : {}),
     } as never,
     { id: USER, organization_id: ORG },
     null,
@@ -643,9 +648,10 @@ describe("passthrough streaming — fallthrough to the SDK path", () => {
     expect(res.headers.get("X-Eliza-Inference-Path")).toBeNull();
   });
 
-  test("SDK streaming forwards reasoning_effort through OpenAI provider options", async () => {
+  test("SDK streaming preserves prompt_cache_key alongside reasoning_effort", async () => {
     sdkFaithfulStream();
     const model = "zai-glm-4.7";
+    const promptCacheKey = "v5:reasoning-prefix";
     const res = await callStreaming(async () => null, {
       model,
       request: {
@@ -654,6 +660,7 @@ describe("passthrough streaming — fallthrough to the SDK path", () => {
         stream: true,
         stream_options: { include_usage: true },
         reasoning_effort: "none",
+        prompt_cache_key: promptCacheKey,
         tools: [
           {
             type: "function",
@@ -669,11 +676,13 @@ describe("passthrough streaming — fallthrough to the SDK path", () => {
     expect(streamText).toHaveBeenCalledTimes(1);
     expect(streamText.mock.calls[0]?.[0]).toMatchObject({
       maxOutputTokens: 512,
-      providerOptions: { openai: { reasoningEffort: "none" } },
+      providerOptions: {
+        openai: { promptCacheKey, reasoningEffort: "none" },
+      },
     });
   });
 
-  test("SDK non-streaming forwards reasoning_effort through OpenAI provider options", async () => {
+  test("SDK non-streaming preserves prompt_cache_key alongside reasoning_effort", async () => {
     generateTextImpl = () => ({
       text: "Hello",
       toolCalls: [],
@@ -681,12 +690,15 @@ describe("passthrough streaming — fallthrough to the SDK path", () => {
       usage: { inputTokens: 72, outputTokens: 1, totalTokens: 73 },
     });
 
-    const res = await callNonStreaming("zai-glm-4.7", "none");
+    const promptCacheKey = "v5:reasoning-prefix";
+    const res = await callNonStreaming("zai-glm-4.7", "none", promptCacheKey);
     expect(res.status).toBe(200);
     expect(generateText).toHaveBeenCalledTimes(1);
     expect(generateText.mock.calls[0]?.[0]).toMatchObject({
       maxOutputTokens: 512,
-      providerOptions: { openai: { reasoningEffort: "none" } },
+      providerOptions: {
+        openai: { promptCacheKey, reasoningEffort: "none" },
+      },
     });
   });
 

--- a/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
@@ -118,6 +118,7 @@ mock.module("@/lib/services/team-credential-pool", () => ({
 
 // Import the route AFTER the mocks so it binds to the stubs.
 const {
+  default: chatCompletionsRouter,
   __streamingCreditTestHooks,
   __passthroughStreamingTestHooks,
   __reasoningEffortTestHooks,
@@ -181,6 +182,33 @@ beforeEach(() => {
   globalThis.fetch = fetchMock as unknown as typeof fetch;
   process.env.INFERENCE_PASSTHROUGH_STREAMING = "true";
   process.env.CEREBRAS_API_KEY = "test-cerebras-key";
+});
+
+test("the route invokes its dedicated native limiter before provider work", async () => {
+  const keys: string[] = [];
+  const response = await chatCompletionsRouter.fetch(
+    new Request("https://api.example.test/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(QUALIFYING_REQUEST),
+    }),
+    {
+      NODE_ENV: "production",
+      CHAT_ROUTE_RATE_LIMITER: {
+        async limit({ key }: { key: string }) {
+          keys.push(key);
+          return { success: false };
+        },
+      },
+    } as never,
+  );
+
+  expect(response.status).toBe(429);
+  expect(keys).toEqual(["public"]);
+  expect(response.headers.get("X-RateLimit-Policy")).toBe("cloudflare-native");
+  expect(generateText).not.toHaveBeenCalled();
+  expect(streamText).not.toHaveBeenCalled();
+  expect(fetchMock).not.toHaveBeenCalled();
 });
 
 /** In-memory credit ledger, identical to the credit-leak suite's. */

--- a/packages/cloud/api/auth/create-anonymous-session/route.test.ts
+++ b/packages/cloud/api/auth/create-anonymous-session/route.test.ts
@@ -1,5 +1,8 @@
 // Exercises cloud API auth create anonymous session route.test behavior with deterministic Worker route fixtures.
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import * as realRedisFactory from "@/lib/cache/redis-factory";
+
+const realRedisFactoryExports = { ...realRedisFactory };
 
 // Count how many anonymous users actually get minted (DB rows inserted).
 const createAnonymousUserAndSession = mock(async () => ({
@@ -38,6 +41,10 @@ function mint(ip: string) {
 describe("create-anonymous-session anti-sybil rate limit", () => {
   beforeEach(() => {
     createAnonymousUserAndSession.mockClear();
+  });
+
+  afterAll(() => {
+    mock.module("@/lib/cache/redis-factory", () => realRedisFactoryExports);
   });
 
   test("caps anonymous mints per IP and stops creating users after the cap", async () => {

--- a/packages/cloud/api/auth/create-anonymous-session/route.test.ts
+++ b/packages/cloud/api/auth/create-anonymous-session/route.test.ts
@@ -12,28 +12,11 @@ mock.module("@/lib/services/anonymous-session-creator", () => ({
 }));
 
 // In-memory Redis stand-in so the REAL rateLimit middleware enforces (it falls
-// open without a backing store). Implements the subset checkUpstash() uses.
-const store = new Map<string, { count: number; expireAt: number }>();
-const fakeRedis = {
-  async incr(key: string) {
-    const entry = store.get(key) ?? {
-      count: 0,
-      expireAt: Date.now() + 300_000,
-    };
-    entry.count += 1;
-    store.set(key, entry);
-    return entry.count;
-  },
-  async pexpire(key: string, ms: number) {
-    const entry = store.get(key);
-    if (entry) entry.expireAt = Date.now() + ms;
-    return 1;
-  },
-  async pttl(key: string) {
-    const entry = store.get(key);
-    return entry ? Math.max(1, entry.expireAt - Date.now()) : -1;
-  },
-};
+// open without a backing store). checkRateLimitRedis drives a sliding-window
+// sorted set through client.pipeline(), so the stand-in must be MockSocketRedis
+// (matches the CompatibleRedis pipeline surface) rather than a token-bucket shim.
+const { MockSocketRedis } = await import("@/lib/cache/mock-redis");
+const fakeRedis = new MockSocketRedis();
 
 mock.module("@/lib/cache/redis-factory", () => ({
   buildRedisClient: () => fakeRedis,
@@ -55,7 +38,6 @@ function mint(ip: string) {
 describe("create-anonymous-session anti-sybil rate limit", () => {
   beforeEach(() => {
     createAnonymousUserAndSession.mockClear();
-    store.clear();
   });
 
   test("caps anonymous mints per IP and stops creating users after the cap", async () => {

--- a/packages/cloud/api/auth/siwe/nonce/siwe-nonce-redis-outage.test.ts
+++ b/packages/cloud/api/auth/siwe/nonce/siwe-nonce-redis-outage.test.ts
@@ -16,18 +16,66 @@ let redisMode: RedisMode = "healthy";
 
 const stored = new Map<string, string>();
 
-const throwingRedis = new Proxy(
-  {},
-  {
-    get:
-      () =>
-      async (..._args: unknown[]) => {
-        throw new Error("ECONNREFUSED: redis down");
-      },
+// checkUpstash drives the counter through redis.pipeline() (incr + pttl in one
+// round-trip). A pipeline builder is synchronous — only .exec() is async — so
+// the throwing case must reject from exec(), not from the property access
+// itself: returning a rejected promise from a bare `get` trap left the
+// pipeline() call itself as an unawaited rejected promise (no `.exec()` was
+// ever called on it), which Bun reports as an unhandled rejection instead of
+// letting the middleware's try/catch translate it into the expected 503.
+function throwingPipeline() {
+  return {
+    incr: () => throwingPipeline(),
+    pttl: () => throwingPipeline(),
+    exec: async () => {
+      throw new Error("ECONNREFUSED: redis down");
+    },
+  };
+}
+
+const throwingRedis = {
+  pipeline: () => throwingPipeline(),
+  incr: async () => {
+    throw new Error("ECONNREFUSED: redis down");
   },
-);
+  pttl: async () => {
+    throw new Error("ECONNREFUSED: redis down");
+  },
+  pexpire: async () => {
+    throw new Error("ECONNREFUSED: redis down");
+  },
+  expire: async () => {
+    throw new Error("ECONNREFUSED: redis down");
+  },
+  setex: async () => {
+    throw new Error("ECONNREFUSED: redis down");
+  },
+  get: async () => {
+    throw new Error("ECONNREFUSED: redis down");
+  },
+  del: async () => {
+    throw new Error("ECONNREFUSED: redis down");
+  },
+};
+
+function healthyPipeline(ops: Array<() => Promise<unknown>>) {
+  const results: Array<() => Promise<unknown>> = [...ops];
+  const builder = {
+    incr: () => {
+      results.push(async () => 1);
+      return builder;
+    },
+    pttl: () => {
+      results.push(async () => 60_000);
+      return builder;
+    },
+    exec: async () => Promise.all(results.map((op) => op())),
+  };
+  return builder;
+}
 
 const healthyRedis = {
+  pipeline: () => healthyPipeline([]),
   incr: async () => 1,
   pttl: async () => 60_000,
   pexpire: async () => 1,

--- a/packages/cloud/api/auth/siwe/nonce/siwe-nonce-redis-outage.test.ts
+++ b/packages/cloud/api/auth/siwe/nonce/siwe-nonce-redis-outage.test.ts
@@ -8,8 +8,11 @@
  * issues + persists a bound nonce; only the Redis factory is swapped.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
+import * as realRedisFactory from "@/lib/cache/redis-factory";
+
+const realRedisFactoryExports = { ...realRedisFactory };
 
 type RedisMode = "throwing" | "null" | "healthy";
 let redisMode: RedisMode = "healthy";
@@ -136,6 +139,10 @@ beforeEach(() => {
   redisMode = "healthy";
   stored.clear();
   _resetRedisUnavailableFallbackBuckets();
+});
+
+afterAll(() => {
+  mock.module("@/lib/cache/redis-factory", () => realRedisFactoryExports);
 });
 
 describe("GET /api/auth/siwe/nonce — Redis failure boundary", () => {

--- a/packages/cloud/api/auth/siws/nonce/siws-nonce-redis-outage.test.ts
+++ b/packages/cloud/api/auth/siws/nonce/siws-nonce-redis-outage.test.ts
@@ -16,18 +16,66 @@ let redisMode: RedisMode = "healthy";
 
 const stored = new Map<string, string>();
 
-const throwingRedis = new Proxy(
-  {},
-  {
-    get:
-      () =>
-      async (..._args: unknown[]) => {
-        throw new Error("ECONNREFUSED: redis down");
-      },
+// checkUpstash drives the counter through redis.pipeline() (incr + pttl in one
+// round-trip). A pipeline builder is synchronous — only .exec() is async — so
+// the throwing case must reject from exec(), not from the property access
+// itself: returning a rejected promise from a bare `get` trap left the
+// pipeline() call itself as an unawaited rejected promise (no `.exec()` was
+// ever called on it), which Bun reports as an unhandled rejection instead of
+// letting the middleware's try/catch translate it into the expected 503.
+function throwingPipeline() {
+  return {
+    incr: () => throwingPipeline(),
+    pttl: () => throwingPipeline(),
+    exec: async () => {
+      throw new Error("ECONNREFUSED: redis down");
+    },
+  };
+}
+
+const throwingRedis = {
+  pipeline: () => throwingPipeline(),
+  incr: async () => {
+    throw new Error("ECONNREFUSED: redis down");
   },
-);
+  pttl: async () => {
+    throw new Error("ECONNREFUSED: redis down");
+  },
+  pexpire: async () => {
+    throw new Error("ECONNREFUSED: redis down");
+  },
+  expire: async () => {
+    throw new Error("ECONNREFUSED: redis down");
+  },
+  setex: async () => {
+    throw new Error("ECONNREFUSED: redis down");
+  },
+  get: async () => {
+    throw new Error("ECONNREFUSED: redis down");
+  },
+  del: async () => {
+    throw new Error("ECONNREFUSED: redis down");
+  },
+};
+
+function healthyPipeline(ops: Array<() => Promise<unknown>>) {
+  const results: Array<() => Promise<unknown>> = [...ops];
+  const builder = {
+    incr: () => {
+      results.push(async () => 1);
+      return builder;
+    },
+    pttl: () => {
+      results.push(async () => 60_000);
+      return builder;
+    },
+    exec: async () => Promise.all(results.map((op) => op())),
+  };
+  return builder;
+}
 
 const healthyRedis = {
+  pipeline: () => healthyPipeline([]),
   incr: async () => 1,
   pttl: async () => 60_000,
   pexpire: async () => 1,

--- a/packages/cloud/api/auth/siws/nonce/siws-nonce-redis-outage.test.ts
+++ b/packages/cloud/api/auth/siws/nonce/siws-nonce-redis-outage.test.ts
@@ -8,8 +8,11 @@
  * swapped.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
+import * as realRedisFactory from "@/lib/cache/redis-factory";
+
+const realRedisFactoryExports = { ...realRedisFactory };
 
 type RedisMode = "throwing" | "null" | "healthy";
 let redisMode: RedisMode = "healthy";
@@ -136,6 +139,10 @@ beforeEach(() => {
   redisMode = "healthy";
   stored.clear();
   _resetRedisUnavailableFallbackBuckets();
+});
+
+afterAll(() => {
+  mock.module("@/lib/cache/redis-factory", () => realRedisFactoryExports);
 });
 
 describe("GET /api/auth/siws/nonce — Redis failure boundary", () => {

--- a/packages/cloud/api/src/bootstrap-app.test.ts
+++ b/packages/cloud/api/src/bootstrap-app.test.ts
@@ -1,13 +1,10 @@
 /**
  * Application-shell contracts for middleware that must wrap every generated
- * route. The generated router is intentionally replaced with an empty mount:
- * these tests exercise bootstrap ordering, not the hundreds of route modules.
+ * route. These tests use the real generated router so they leave no
+ * process-global Bun module mock behind for sibling files.
  */
 
-import { expect, mock, test } from "bun:test";
-
-const mountRoutes = mock(() => {});
-mock.module("./_router.generated", () => ({ mountRoutes }));
+import { expect, test } from "bun:test";
 
 const { createApp } = await import("./bootstrap-app");
 
@@ -37,7 +34,6 @@ test("the global native limiter rejects before auth and generated routes", async
     }),
   );
 
-  expect(mountRoutes).toHaveBeenCalledTimes(1);
   expect(keys).toEqual(["global:ip:203.0.113.8"]);
   expect(response.status).toBe(429);
   expect(response.headers.get("X-RateLimit-Policy")).toBe("cloudflare-native");

--- a/packages/cloud/api/src/bootstrap-app.test.ts
+++ b/packages/cloud/api/src/bootstrap-app.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Application-shell contracts for middleware that must wrap every generated
+ * route. The generated router is intentionally replaced with an empty mount:
+ * these tests exercise bootstrap ordering, not the hundreds of route modules.
+ */
+
+import { expect, mock, test } from "bun:test";
+
+const mountRoutes = mock(() => {});
+mock.module("./_router.generated", () => ({ mountRoutes }));
+
+const { createApp } = await import("./bootstrap-app");
+
+function environment(limiter: {
+  limit(options: { key: string }): Promise<{ success: boolean }>;
+}) {
+  return {
+    ENVIRONMENT: "staging",
+    NODE_ENV: "production",
+    REDIS_RATE_LIMITING: "false",
+    GLOBAL_RATE_LIMITER: limiter,
+  } as never;
+}
+
+test("the global native limiter rejects before auth and generated routes", async () => {
+  const keys: string[] = [];
+  const app = createApp();
+  const response = await app.fetch(
+    new Request("https://api.example.test/private/generated-route", {
+      headers: { "cf-connecting-ip": "203.0.113.8" },
+    }),
+    environment({
+      async limit({ key }) {
+        keys.push(key);
+        return { success: false };
+      },
+    }),
+  );
+
+  expect(mountRoutes).toHaveBeenCalledTimes(1);
+  expect(keys).toEqual(["global:ip:203.0.113.8"]);
+  expect(response.status).toBe(429);
+  expect(response.headers.get("X-RateLimit-Policy")).toBe("cloudflare-native");
+  expect(await response.json()).toMatchObject({
+    code: "rate_limit_exceeded",
+    retryAfter: 60,
+  });
+});
+
+test("an allowed native decision preserves public locale routing", async () => {
+  const keys: string[] = [];
+  const app = createApp();
+  const response = await app.fetch(
+    new Request("https://api.example.test/api/i18n/locale", {
+      headers: {
+        "accept-language": "fr;q=0.8, ja;q=0.9",
+        "cf-connecting-ip": "203.0.113.9",
+      },
+    }),
+    environment({
+      async limit({ key }) {
+        keys.push(key);
+        return { success: true };
+      },
+    }),
+  );
+
+  expect(keys).toEqual(["global:ip:203.0.113.9"]);
+  expect(response.status).toBe(200);
+  expect(response.headers.get("X-RateLimit-Policy")).toBe("cloudflare-native");
+  const body = (await response.json()) as { language: string | null };
+  expect(body).toEqual({ language: "ja" });
+});

--- a/packages/cloud/api/src/bootstrap-app.ts
+++ b/packages/cloud/api/src/bootstrap-app.ts
@@ -315,18 +315,21 @@ export function createApp(): Hono<AppEnv> {
   // still enforce it; this only guarantees that a route which forgot to add one
   // is not completely unprotected against per-IP flooding. The ceiling is
   // deliberately generous (10 req/s sustained) so it sits above every per-route
-  // policy and never interferes with legitimate traffic. Enforced only when
-  // REDIS_RATE_LIMITING=true (falls open otherwise). Registered before
+  // policy and never interferes with legitimate traffic. Cloudflare's local
+  // protective counter avoids a network hop at ingress. Registered before
   // authMiddleware so unauthenticated routes are covered too.
   app.use(
     "*",
-    rateLimit({
-      windowMs: 60_000,
-      maxRequests: 600,
-      // Namespaced so this backstop counter never collides with a per-route
-      // IP-keyed limiter sharing the same `ip:<addr>` key.
-      keyGenerator: (c) => `global:${getIpKey(c)}`,
-    }),
+    rateLimit(
+      {
+        windowMs: 60_000,
+        maxRequests: 600,
+        // Namespaced so this backstop counter never collides with a per-route
+        // IP-keyed limiter sharing the same `ip:<addr>` key.
+        keyGenerator: (c) => `global:${getIpKey(c)}`,
+      },
+      { bindingName: "GLOBAL_RATE_LIMITER" },
+    ),
   );
 
   app.use("*", authMiddleware);

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -3339,16 +3339,22 @@ honoRouter.options("/", async (c) => {
     return failureResponse(c, error);
   }
 });
-honoRouter.post("/", rateLimit(RateLimitPresets.RELAXED), async (c) => {
-  try {
-    return await handleChatCompletionsPOST(c.req.raw, {
-      executionCtx: c.executionCtx,
-    });
-  } catch (error) {
-    // error-policy:J1 route boundary — every catch in v1/chat/* translates a thrown error into a structured HTTP failure via failureResponse (never a fabricated 200/empty completion). Credit reservations are released before rethrow on the streaming paths above.
-    return failureResponse(c, error);
-  }
-});
+honoRouter.post(
+  "/",
+  rateLimit(RateLimitPresets.RELAXED, {
+    bindingName: "CHAT_ROUTE_RATE_LIMITER",
+  }),
+  async (c) => {
+    try {
+      return await handleChatCompletionsPOST(c.req.raw, {
+        executionCtx: c.executionCtx,
+      });
+    } catch (error) {
+      // error-policy:J1 route boundary — every catch in v1/chat/* translates a thrown error into a structured HTTP failure via failureResponse (never a fabricated 200/empty completion). Credit reservations are released before rethrow on the streaming paths above.
+      return failureResponse(c, error);
+    }
+  },
+);
 export default honoRouter;
 
 /**

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -271,8 +271,9 @@ function buildReasoningEffortProviderOptions(
  * Merges spreadable `{ providerOptions }` fragments (Anthropic CoT +
  * prompt-cache-key, OpenAI-style reasoning effort) into one spread so a naive
  * `...a, ...b` cannot clobber the earlier fragment's `providerOptions` key.
- * Provider namespaces are merged shallowly; they are disjoint today
- * (anthropic/google/cerebras/eliza vs openai).
+ * Merge each provider namespace one level deeper as well: prompt caching and
+ * reasoning effort both target `openai`, so replacing that namespace would
+ * silently discard whichever option was added first.
  */
 function combineProviderOptions(
   ...parts: ReadonlyArray<Record<string, unknown>>
@@ -283,7 +284,23 @@ function combineProviderOptions(
   for (const part of parts) {
     for (const [key, value] of Object.entries(part)) {
       if (key === "providerOptions" && value && typeof value === "object") {
-        Object.assign(providerOptions, value as Record<string, unknown>);
+        for (const [provider, options] of Object.entries(
+          value as Record<string, unknown>,
+        )) {
+          const existing = providerOptions[provider];
+          providerOptions[provider] =
+            existing &&
+            typeof existing === "object" &&
+            !Array.isArray(existing) &&
+            options &&
+            typeof options === "object" &&
+            !Array.isArray(options)
+              ? {
+                  ...(existing as Record<string, unknown>),
+                  ...(options as Record<string, unknown>),
+                }
+              : options;
+        }
         hasProviderOptions = true;
       } else {
         merged[key] = value;

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -86,9 +86,11 @@ simple = { limit = 200, period = 60 }
 # Exact organization limits and non-native route limits use Railway TCP Redis
 # via REDIS_URL (in-Worker SocketRedis, RESP2 over cloudflare:sockets). The
 # global flood backstop and chat API-key gate above use Cloudflare's local
-# protective counters so Railway connection setup never blocks chat ingress.
-# Upstash REST remains a legacy fallback. Shared-runtime chat history still
-# depends on durable Redis; local dev uses embedded Wadis when unconfigured.
+# protective counters, so Railway connection setup no longer blocks those two
+# outer ingress checks. The exact organization quota remains Redis-backed in
+# the handler. Upstash REST remains a legacy fallback. Shared-runtime chat
+# history still depends on durable Redis; local dev uses embedded Wadis when
+# unconfigured.
 
 # Vectorize — embeddings (uncomment after `wrangler vectorize create`)
 # [[vectorize]]

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -73,12 +73,22 @@ crons = [
 binding = "BLOB"
 bucket_name = "eliza-cloud-blob"
 
-# Cache + rate-limit storage runs through Railway TCP Redis via REDIS_URL in
-# Worker envs (in-Worker SocketRedis, RESP2 over cloudflare:sockets); set
-# REDIS_URL as a Wrangler secret. Upstash REST (KV_REST_API_URL /
-# KV_REST_API_TOKEN) remains a legacy fallback only. Shared-runtime chat history
-# depends on this being durable across Worker requests. Local dev still uses
-# embedded Wadis by default when no Redis credentials are present.
+[[ratelimits]]
+name = "GLOBAL_RATE_LIMITER"
+namespace_id = "1615301"
+simple = { limit = 600, period = 60 }
+
+[[ratelimits]]
+name = "CHAT_ROUTE_RATE_LIMITER"
+namespace_id = "1615302"
+simple = { limit = 200, period = 60 }
+
+# Exact organization limits and non-native route limits use Railway TCP Redis
+# via REDIS_URL (in-Worker SocketRedis, RESP2 over cloudflare:sockets). The
+# global flood backstop and chat API-key gate above use Cloudflare's local
+# protective counters so Railway connection setup never blocks chat ingress.
+# Upstash REST remains a legacy fallback. Shared-runtime chat history still
+# depends on durable Redis; local dev uses embedded Wadis when unconfigured.
 
 # Vectorize — embeddings (uncomment after `wrangler vectorize create`)
 # [[vectorize]]
@@ -438,6 +448,16 @@ id = "ef65eb94c74144a3a3848ad1945571fb"
 binding = "CACHE_KV"
 id = "f7e24faaff734e7c8cd8e12b093c3571"
 
+[[env.staging.ratelimits]]
+name = "GLOBAL_RATE_LIMITER"
+namespace_id = "1615311"
+simple = { limit = 600, period = 60 }
+
+[[env.staging.ratelimits]]
+name = "CHAT_ROUTE_RATE_LIMITER"
+namespace_id = "1615312"
+simple = { limit = 200, period = 60 }
+
 [env.production]
 name = "eliza-cloud-api-prod"
 # Smart Placement (#15513, prod leg): staging soak showed mode=smart applied
@@ -603,3 +623,13 @@ id = "9f59e4ec65f048f7b87e29e7b9c5d728"
 [[env.production.kv_namespaces]]
 binding = "CACHE_KV"
 id = "1dafabf1293d4b6b97f61c5cc22d6fec"
+
+[[env.production.ratelimits]]
+name = "GLOBAL_RATE_LIMITER"
+namespace_id = "1615321"
+simple = { limit = 600, period = 60 }
+
+[[env.production.ratelimits]]
+name = "CHAT_ROUTE_RATE_LIMITER"
+namespace_id = "1615322"
+simple = { limit = 200, period = 60 }

--- a/packages/cloud/shared/src/lib/cache/__tests__/redis-factory-mock.test.ts
+++ b/packages/cloud/shared/src/lib/cache/__tests__/redis-factory-mock.test.ts
@@ -64,6 +64,79 @@ describe("buildRedisClient (MOCK_REDIS=1)", () => {
     const members = await client.smembers("members");
     expect(members.sort()).toEqual(["alice", "bob"]);
   });
+
+  test("implements the full data-structure and pipeline contract used by callers", async () => {
+    const { buildRedisClient } = await import("../redis-factory");
+    const { MockSocketRedis } = await import("../mock-redis");
+    const client = buildRedisClient();
+    if (!(client instanceof MockSocketRedis)) throw new Error("expected mock Redis client");
+    const prefix = `factory-contract:${crypto.randomUUID()}`;
+    const key = (name: string) => `${prefix}:${name}`;
+
+    await client.set(key("getdel"), { id: 1 });
+    expect(await client.getdel(key("getdel"))).toEqual({ id: 1 });
+    expect(await client.get(key("getdel"))).toBeNull();
+
+    expect(await client.incr(key("counter"))).toBe(1);
+    expect(await client.incr(key("counter"))).toBe(2);
+    await client.set(key("a"), "one");
+    await client.set(key("b"), { two: 2 });
+    expect(await client.mget(key("a"), key("b"), key("missing"))).toEqual([
+      "one",
+      { two: 2 },
+      null,
+    ]);
+    expect(await client.mget()).toEqual([]);
+
+    const [cursor, keys] = await client.scan(0, { match: `${prefix}:?`, count: 100 });
+    expect(cursor).toBe("0");
+    expect(keys).toEqual(expect.arrayContaining([key("a"), key("b")]));
+
+    expect(await client.lpush(key("list"), "middle", "first")).toBe(2);
+    expect(await client.rpush(key("list"), "last")).toBe(3);
+    expect(await client.llen(key("list"))).toBe(3);
+    expect(await client.lpop(key("list"))).toBe("first");
+    expect(await client.lpop(key("list"), 1)).toEqual(["middle"]);
+    expect(await client.rpop(key("list"))).toBe("last");
+    expect(await client.rpop(key("list"))).toBeNull();
+
+    expect(await client.sadd(key("set"), "a", "b", "a")).toBe(2);
+    expect(await client.srem(key("set"), "a", "missing")).toBe(1);
+    expect(await client.smembers(key("set"))).toEqual(["b"]);
+
+    expect(await client.zadd(key("zset"), { score: 2, member: "b" })).toBe(1);
+    expect(await client.zadd(key("zset"), { score: 1, member: "a" })).toBe(1);
+    expect(await client.zadd(key("zset"), { score: 3, member: "c" })).toBe(1);
+    expect(await client.zrange(key("zset"), 0, -1)).toEqual(["a", "b", "c"]);
+    expect(await client.zremrangebyscore(key("zset"), "-inf", 1)).toBe(1);
+    expect(await client.zrem(key("zset"), "c")).toBe(1);
+    expect(await client.zcard(key("zset"))).toBe(1);
+
+    await client.set(key("ttl"), "value");
+    const ttlPipeline = client.pipeline().pexpire(key("ttl"), 10_000).pttl(key("ttl"));
+    const [expireResult, ttl] = await ttlPipeline.exec<[number, number]>();
+    expect(expireResult).toBe(1);
+    expect(ttl).toBeGreaterThan(0);
+    expect(ttl).toBeLessThanOrEqual(10_000);
+
+    const pipelineResults = await client
+      .pipeline()
+      .set(key("pipeline-value"), { ok: true })
+      .get(key("pipeline-value"))
+      .incr(key("pipeline-counter"))
+      .setex(key("pipeline-expiring"), 60, "soon")
+      .del(key("pipeline-expiring"))
+      .exec();
+    expect(pipelineResults).toEqual(["OK", '{"ok":true}', 1, "OK", 1]);
+    expect(await client.pipeline().exec()).toEqual([]);
+
+    expect(await client.del()).toBe(0);
+    expect(await client.expire(key("missing"), 10)).toBe(0);
+    expect(await client.pexpire(key("missing"), 10)).toBe(0);
+    expect(await client.pttl(key("missing"))).toBe(-2);
+    expect(await client.ping()).toBe("PONG");
+    await expect(client.quit()).resolves.toBeUndefined();
+  });
 });
 
 describe("hasRedisConfig", () => {

--- a/packages/cloud/shared/src/lib/cache/invalidation-credit-hint.test.ts
+++ b/packages/cloud/shared/src/lib/cache/invalidation-credit-hint.test.ts
@@ -1,0 +1,92 @@
+/** Credit mutations must invalidate every balance view, including inference admission. */
+
+import { beforeEach, expect, mock, test } from "bun:test";
+import { CacheKeys } from "./keys";
+
+const deleted: string[] = [];
+const deletedPatterns: string[] = [];
+const memoryInvalidations: string[] = [];
+
+mock.module("./client", () => ({
+  cache: {
+    del: async (key: string) => {
+      deleted.push(key);
+      return true;
+    },
+    delPattern: async (pattern: string) => {
+      deletedPatterns.push(pattern);
+      return 1;
+    },
+  },
+}));
+
+mock.module("./memory-cache", () => ({
+  memoryCache: {
+    invalidateOrganization: async (organizationId: string) => {
+      memoryInvalidations.push(`organization:${organizationId}`);
+    },
+    invalidateRoom: async (roomId: string, organizationId: string) => {
+      memoryInvalidations.push(`room:${roomId}:${organizationId}`);
+    },
+    invalidateMemory: async (memoryId: string) => {
+      memoryInvalidations.push(`memory:${memoryId}`);
+    },
+    invalidateConversation: async (conversationId: string) => {
+      memoryInvalidations.push(`conversation:${conversationId}`);
+    },
+  },
+}));
+
+mock.module("../utils/logger", () => ({
+  // Bun module mocks are process-global across changed-file coverage runs, so
+  // preserve the complete logger contract for tests loaded after this file.
+  logger: {
+    debug: mock(() => undefined),
+    error: mock(() => undefined),
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+  },
+}));
+
+const { CacheInvalidation } = await import("./invalidation");
+
+beforeEach(() => {
+  deleted.length = 0;
+  deletedPatterns.length = 0;
+  memoryInvalidations.length = 0;
+});
+
+test("onCreditMutation drops the optimistic inference balance hint", async () => {
+  const organizationId = "org-credit-mutation";
+
+  await CacheInvalidation.onCreditMutation(organizationId);
+
+  expect(deleted).toContain(CacheKeys.inference.orgBalance(organizationId));
+  expect(deleted).toContain(CacheKeys.org.credits(organizationId));
+  expect(deleted).toContain(CacheKeys.eliza.orgBalance(organizationId));
+});
+
+test("central invalidation routes every mutation to its scoped cache keys", async () => {
+  const organizationId = "org-invalidation-contract";
+
+  await CacheInvalidation.onUsageRecordCreated(organizationId);
+  await CacheInvalidation.onGenerationCreated(organizationId);
+  await CacheInvalidation.onOrganizationUpdated(organizationId);
+  await CacheInvalidation.clearAll(organizationId);
+  await CacheInvalidation.onMemoryCreated(organizationId);
+  await CacheInvalidation.onMemoryCreated(organizationId, "room-1");
+  await CacheInvalidation.onMemoryDeleted(organizationId, "memory-1");
+  await CacheInvalidation.onConversationUpdated("conversation-1");
+
+  expect(deleted).toContain(CacheKeys.org.dashboard(organizationId));
+  expect(deleted).toContain(CacheKeys.org.data(organizationId));
+  expect(deletedPatterns).toContain(`analytics:overview:${organizationId}:*`);
+  expect(deletedPatterns).toContain(CacheKeys.org.pattern(organizationId));
+  expect(deletedPatterns).toContain(CacheKeys.analytics.pattern(organizationId));
+  expect(memoryInvalidations).toEqual([
+    `organization:${organizationId}`,
+    `room:room-1:${organizationId}`,
+    "memory:memory-1",
+    "conversation:conversation-1",
+  ]);
+});

--- a/packages/cloud/shared/src/lib/cache/invalidation-credit-hint.test.ts
+++ b/packages/cloud/shared/src/lib/cache/invalidation-credit-hint.test.ts
@@ -1,60 +1,59 @@
 /** Credit mutations must invalidate every balance view, including inference admission. */
 
-import { beforeEach, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, expect, spyOn, test } from "bun:test";
+import { cache } from "./client";
 import { CacheKeys } from "./keys";
+import { memoryCache } from "./memory-cache";
 
 const deleted: string[] = [];
 const deletedPatterns: string[] = [];
 const memoryInvalidations: string[] = [];
 
-mock.module("./client", () => ({
-  cache: {
-    del: async (key: string) => {
-      deleted.push(key);
-      return true;
-    },
-    delPattern: async (pattern: string) => {
-      deletedPatterns.push(pattern);
-      return 1;
-    },
+const delSpy = spyOn(cache, "del").mockImplementation(async (key: string) => {
+  deleted.push(key);
+});
+const delPatternSpy = spyOn(cache, "delPattern").mockImplementation(async (pattern: string) => {
+  deletedPatterns.push(pattern);
+});
+const invalidateOrganizationSpy = spyOn(memoryCache, "invalidateOrganization").mockImplementation(
+  async (organizationId: string) => {
+    memoryInvalidations.push(`organization:${organizationId}`);
   },
-}));
-
-mock.module("./memory-cache", () => ({
-  memoryCache: {
-    invalidateOrganization: async (organizationId: string) => {
-      memoryInvalidations.push(`organization:${organizationId}`);
-    },
-    invalidateRoom: async (roomId: string, organizationId: string) => {
-      memoryInvalidations.push(`room:${roomId}:${organizationId}`);
-    },
-    invalidateMemory: async (memoryId: string) => {
-      memoryInvalidations.push(`memory:${memoryId}`);
-    },
-    invalidateConversation: async (conversationId: string) => {
-      memoryInvalidations.push(`conversation:${conversationId}`);
-    },
+);
+const invalidateRoomSpy = spyOn(memoryCache, "invalidateRoom").mockImplementation(
+  async (roomId: string, organizationId: string) => {
+    memoryInvalidations.push(`room:${roomId}:${organizationId}`);
   },
-}));
-
-mock.module("../utils/logger", () => ({
-  // Bun module mocks are process-global across changed-file coverage runs, so
-  // preserve the complete logger contract for tests loaded after this file.
-  logger: {
-    debug: mock(() => undefined),
-    error: mock(() => undefined),
-    info: mock(() => undefined),
-    warn: mock(() => undefined),
+);
+const invalidateMemorySpy = spyOn(memoryCache, "invalidateMemory").mockImplementation(
+  async (memoryId: string) => {
+    memoryInvalidations.push(`memory:${memoryId}`);
   },
-}));
+);
+const invalidateConversationSpy = spyOn(memoryCache, "invalidateConversation").mockImplementation(
+  async (conversationId: string) => {
+    memoryInvalidations.push(`conversation:${conversationId}`);
+  },
+);
 
 const { CacheInvalidation } = await import("./invalidation");
 
-beforeEach(() => {
+afterAll(() => {
+  delSpy.mockRestore();
+  delPatternSpy.mockRestore();
+  invalidateOrganizationSpy.mockRestore();
+  invalidateRoomSpy.mockRestore();
+  invalidateMemorySpy.mockRestore();
+  invalidateConversationSpy.mockRestore();
+});
+
+function resetObservations(): void {
   deleted.length = 0;
   deletedPatterns.length = 0;
   memoryInvalidations.length = 0;
-});
+}
+
+beforeEach(resetObservations);
 
 test("onCreditMutation drops the optimistic inference balance hint", async () => {
   const organizationId = "org-credit-mutation";
@@ -66,27 +65,44 @@ test("onCreditMutation drops the optimistic inference balance hint", async () =>
   expect(deleted).toContain(CacheKeys.eliza.orgBalance(organizationId));
 });
 
-test("central invalidation routes every mutation to its scoped cache keys", async () => {
+test("each central invalidation method targets only its own cache scope", async () => {
   const organizationId = "org-invalidation-contract";
 
   await CacheInvalidation.onUsageRecordCreated(organizationId);
-  await CacheInvalidation.onGenerationCreated(organizationId);
-  await CacheInvalidation.onOrganizationUpdated(organizationId);
-  await CacheInvalidation.clearAll(organizationId);
-  await CacheInvalidation.onMemoryCreated(organizationId);
-  await CacheInvalidation.onMemoryCreated(organizationId, "room-1");
-  await CacheInvalidation.onMemoryDeleted(organizationId, "memory-1");
-  await CacheInvalidation.onConversationUpdated("conversation-1");
+  expect(deleted).toEqual([CacheKeys.org.dashboard(organizationId)]);
+  expect(deletedPatterns).toEqual([`analytics:overview:${organizationId}:*`]);
 
-  expect(deleted).toContain(CacheKeys.org.dashboard(organizationId));
-  expect(deleted).toContain(CacheKeys.org.data(organizationId));
-  expect(deletedPatterns).toContain(`analytics:overview:${organizationId}:*`);
-  expect(deletedPatterns).toContain(CacheKeys.org.pattern(organizationId));
-  expect(deletedPatterns).toContain(CacheKeys.analytics.pattern(organizationId));
-  expect(memoryInvalidations).toEqual([
-    `organization:${organizationId}`,
-    `room:room-1:${organizationId}`,
-    "memory:memory-1",
-    "conversation:conversation-1",
+  resetObservations();
+  await CacheInvalidation.onGenerationCreated(organizationId);
+  expect(deleted).toEqual([CacheKeys.org.dashboard(organizationId)]);
+
+  resetObservations();
+  await CacheInvalidation.onOrganizationUpdated(organizationId);
+  expect(deleted).toEqual([
+    CacheKeys.org.data(organizationId),
+    CacheKeys.org.dashboard(organizationId),
   ]);
+
+  resetObservations();
+  await CacheInvalidation.clearAll(organizationId);
+  expect(deletedPatterns).toEqual([
+    CacheKeys.org.pattern(organizationId),
+    CacheKeys.analytics.pattern(organizationId),
+  ]);
+  expect(memoryInvalidations).toEqual([`organization:${organizationId}`]);
+
+  resetObservations();
+  await CacheInvalidation.onMemoryCreated(organizationId);
+  expect(memoryInvalidations).toEqual([]);
+
+  await CacheInvalidation.onMemoryCreated(organizationId, "room-1");
+  expect(memoryInvalidations).toEqual([`room:room-1:${organizationId}`]);
+
+  resetObservations();
+  await CacheInvalidation.onMemoryDeleted(organizationId, "memory-1");
+  expect(memoryInvalidations).toEqual(["memory:memory-1"]);
+
+  resetObservations();
+  await CacheInvalidation.onConversationUpdated("conversation-1");
+  expect(memoryInvalidations).toEqual(["conversation:conversation-1"]);
 });

--- a/packages/cloud/shared/src/lib/cache/invalidation.ts
+++ b/packages/cloud/shared/src/lib/cache/invalidation.ts
@@ -27,6 +27,10 @@ export class CacheInvalidation {
       cache.del(CacheKeys.org.dashboard(organizationId)),
       // Invalidate Eliza org balance cache on credit changes
       cache.del(CacheKeys.eliza.orgBalance(organizationId)),
+      // Best-effort early eviction after a top-up, refund, or non-inference
+      // debit. The admission hint's short TTL and safety margin remain the
+      // correctness backstop when KV propagation or deletion is delayed.
+      cache.del(CacheKeys.inference.orgBalance(organizationId)),
     ]);
   }
 

--- a/packages/cloud/shared/src/lib/cache/mock-redis-rate-limit-contract.test.ts
+++ b/packages/cloud/shared/src/lib/cache/mock-redis-rate-limit-contract.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test";
+import { checkUpstash } from "../middleware/rate-limit-hono-cloudflare";
+import { MockSocketRedis } from "./mock-redis";
+
+test("MockSocketRedis implements the batched rate-limit pipeline contract", async () => {
+  const client = new MockSocketRedis();
+  const key = "mock-pipeline-contract";
+  await client.del(`ratelimit:${key}`);
+
+  const first = await checkUpstash(client, key, 60_000, 5);
+  const second = await checkUpstash(client, key, 60_000, 5);
+
+  expect(first.allowed).toBe(true);
+  expect(first.remaining).toBe(4);
+  expect(second.allowed).toBe(true);
+  expect(second.remaining).toBe(3);
+  expect(second.resetAt).toBeGreaterThan(Date.now());
+});

--- a/packages/cloud/shared/src/lib/cache/mock-redis.ts
+++ b/packages/cloud/shared/src/lib/cache/mock-redis.ts
@@ -585,6 +585,11 @@ export class MockPipeline {
     return this;
   }
 
+  pttl(key: string): this {
+    this.ops.push(() => this.client.pttl(key));
+    return this;
+  }
+
   async exec<T extends unknown[] = unknown[]>(): Promise<T> {
     const out: unknown[] = [];
     if (this.ops.length === 0) return out as T;

--- a/packages/cloud/shared/src/lib/cache/redis-factory.ts
+++ b/packages/cloud/shared/src/lib/cache/redis-factory.ts
@@ -17,9 +17,31 @@ import { Redis as UpstashRedis } from "@upstash/redis";
 import { MockSocketRedis } from "./mock-redis";
 import { SocketRedis } from "./socket-redis";
 
-// MockSocketRedis is duck-typed to SocketRedis; expose it as such so callers
-// don't need to widen their type signatures.
-export type CompatibleRedis = SocketRedis | UpstashRedis;
+interface CompatibleRedisPipeline {
+  zremrangebyscore(key: string, min: number | string, max: number | string): this;
+  zcard(key: string): this;
+  zadd(key: string, member: { score: number; member: string }): this;
+  zrem(key: string, ...members: string[]): this;
+  expire(key: string, seconds: number): this;
+  pexpire(key: string, ms: number): this;
+  set(key: string, value: unknown, options?: { nx?: boolean; ex?: number; px?: number }): this;
+  setex(key: string, ttlSeconds: number, value: unknown): this;
+  get(key: string): this;
+  del(...keys: string[]): this;
+  incr(key: string): this;
+  pttl(key: string): this;
+  exec<T extends unknown[] = unknown[]>(): Promise<T>;
+}
+
+// Keep the TCP side structural so both the real and mock clients must implement
+// the same public surface. This avoids a double cast (which hid pipeline drift)
+// without adding a third overloaded class to the Upstash union. Override the
+// pipeline class itself because its private fields are intentionally nominal.
+type CompatibleSocketRedis = Pick<
+  SocketRedis,
+  Exclude<Extract<keyof SocketRedis, keyof MockSocketRedis>, "pipeline">
+> & { pipeline(): CompatibleRedisPipeline };
+export type CompatibleRedis = CompatibleSocketRedis | UpstashRedis;
 
 export interface RedisFactoryEnv {
   REDIS_URL?: string;
@@ -36,7 +58,7 @@ export function buildRedisClient(env?: RedisFactoryEnvSource): CompatibleRedis |
   const e = env ?? process.env;
 
   if (e.MOCK_REDIS === "1") {
-    return new MockSocketRedis() as unknown as SocketRedis;
+    return new MockSocketRedis();
   }
 
   const url = e.REDIS_URL;

--- a/packages/cloud/shared/src/lib/cache/socket-redis-resilience.test.ts
+++ b/packages/cloud/shared/src/lib/cache/socket-redis-resilience.test.ts
@@ -98,7 +98,7 @@ describe("SocketRedis connection resilience", () => {
     await expect(first).rejects.toThrow(/timed out|closed/i);
     expect(await second).toBeNull();
     // Stall bound (1s) + second op — nowhere near an unbounded hang.
-    expect(Date.now() - started).toBeLessThan(5_000);
+    expect(Date.now() - started).toBeLessThan(2_500);
     expect(connections).toBe(2);
 
     await redis.quit();

--- a/packages/cloud/shared/src/lib/cache/socket-redis-timeout-races.test.ts
+++ b/packages/cloud/shared/src/lib/cache/socket-redis-timeout-races.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, test } from "bun:test";
+import { createSocketRedisForTests, type SocketRedisTestTransport } from "./socket-redis";
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve(value: T): void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+const encoder = new TextEncoder();
+
+function bulk(value: string): ReadableStreamReadResult<Uint8Array> {
+  return {
+    done: false,
+    value: encoder.encode(`$${encoder.encode(value).byteLength}\r\n${value}\r\n`),
+  };
+}
+
+describe("SocketRedis timeout ownership", () => {
+  test("a late timed-out operation stays on its retired reader instead of consuming its successor", async () => {
+    const firstWriteStarted = deferred<void>();
+    const releaseFirstWrite = deferred<void>();
+    const firstReaderCalled = deferred<void>();
+    const successorOpened = deferred<void>();
+    const successorWriteStarted = deferred<void>();
+    const releaseSuccessorWrite = deferred<void>();
+    let opens = 0;
+    let firstReads = 0;
+    let successorReads = 0;
+
+    const firstTransport: SocketRedisTestTransport = {
+      writer: {
+        write() {
+          firstWriteStarted.resolve();
+          return releaseFirstWrite.promise;
+        },
+        async abort() {},
+      },
+      reader: {
+        read() {
+          firstReads += 1;
+          firstReaderCalled.resolve();
+          return Promise.reject(new Error("retired reader"));
+        },
+        async cancel() {},
+      },
+      async close() {},
+    };
+
+    const successorTransport: SocketRedisTestTransport = {
+      writer: {
+        write() {
+          successorWriteStarted.resolve();
+          return releaseSuccessorWrite.promise;
+        },
+        async abort() {},
+      },
+      reader: {
+        async read() {
+          successorReads += 1;
+          return bulk("successor");
+        },
+        async cancel() {},
+      },
+      async close() {},
+    };
+
+    const redis = createSocketRedisForTests("redis://example.test:6379", {
+      async openTransport() {
+        opens += 1;
+        if (opens === 1) return firstTransport;
+        successorOpened.resolve();
+        return successorTransport;
+      },
+      operationTimeoutMs: 20,
+      closeTimeoutMs: 5,
+    });
+
+    const first = redis.get("first");
+    await firstWriteStarted.promise;
+    await expect(first).rejects.toThrow("timed out after 20ms");
+
+    const second = redis.get<string>("second");
+    await successorOpened.promise;
+    await successorWriteStarted.promise;
+
+    // The loser resumes only after its timeout teardown and after the
+    // successor has published its own state. It must still use state #1.
+    releaseFirstWrite.resolve();
+    const lateReader = await Promise.race([
+      firstReaderCalled.promise.then(() => "retired" as const),
+      new Promise<"missing">((resolve) => setTimeout(() => resolve("missing"), 100)),
+    ]);
+    expect(lateReader).toBe("retired");
+
+    releaseSuccessorWrite.resolve();
+    expect(await second).toBe("successor");
+    expect(firstReads).toBe(1);
+    expect(successorReads).toBe(1);
+    expect(opens).toBe(2);
+
+    await redis.quit();
+  });
+
+  test("a delayed stale connection cannot publish over a successor", async () => {
+    const firstOpenStarted = deferred<void>();
+    const releaseFirstOpen = deferred<SocketRedisTestTransport>();
+    const staleClosed = deferred<void>();
+    let opens = 0;
+    let staleWrites = 0;
+    let staleReads = 0;
+    let successorWrites = 0;
+    let successorReads = 0;
+
+    const staleTransport: SocketRedisTestTransport = {
+      writer: {
+        async write() {
+          staleWrites += 1;
+        },
+        async abort() {},
+      },
+      reader: {
+        async read() {
+          staleReads += 1;
+          return bulk("stale");
+        },
+        async cancel() {},
+      },
+      async close() {
+        staleClosed.resolve();
+      },
+    };
+
+    const successorTransport: SocketRedisTestTransport = {
+      writer: {
+        async write() {
+          successorWrites += 1;
+        },
+        async abort() {},
+      },
+      reader: {
+        async read() {
+          successorReads += 1;
+          return bulk("successor");
+        },
+        async cancel() {},
+      },
+      async close() {},
+    };
+
+    const redis = createSocketRedisForTests("redis://example.test:6379", {
+      async openTransport() {
+        opens += 1;
+        if (opens === 1) {
+          firstOpenStarted.resolve();
+          return await releaseFirstOpen.promise;
+        }
+        return successorTransport;
+      },
+      operationTimeoutMs: 20,
+      closeTimeoutMs: 5,
+    });
+
+    const first = redis.get("first");
+    await firstOpenStarted.promise;
+    await expect(first).rejects.toThrow("timed out after 20ms");
+
+    expect(await redis.get<string>("second")).toBe("successor");
+    expect(opens).toBe(2);
+
+    // Resolve the original open after the successor is live. The ownership
+    // check must close it locally without writing, reading, or publishing it.
+    releaseFirstOpen.resolve(staleTransport);
+    await staleClosed.promise;
+
+    expect(await redis.get<string>("third")).toBe("successor");
+    expect(opens).toBe(2);
+    expect(staleWrites).toBe(0);
+    expect(staleReads).toBe(0);
+    expect(successorWrites).toBe(2);
+    expect(successorReads).toBe(2);
+
+    await redis.quit();
+  });
+});

--- a/packages/cloud/shared/src/lib/cache/socket-redis.ts
+++ b/packages/cloud/shared/src/lib/cache/socket-redis.ts
@@ -137,6 +137,7 @@ const decoder = new TextDecoder("utf-8");
 // whole request wall-clock. With this bound a stall throws instead, and
 // CacheClient falls back to revalidate/DB — the cache degrades, never hangs.
 const SOCKET_OP_TIMEOUT_MS = 1000;
+const SOCKET_CLOSE_TIMEOUT_MS = 50;
 
 function encodeCommand(args: ReadonlyArray<string | number>): Uint8Array {
   let out = `*${args.length}${CRLF}`;
@@ -384,25 +385,34 @@ class Connection {
   }
 
   async close(): Promise<void> {
-    try {
-      await this.writer?.close();
-    } catch {
-      // ignore
-    }
-    try {
-      await this.reader?.cancel();
-    } catch {
-      // ignore
-    }
-    try {
-      await this.socket?.close();
-    } catch {
-      // ignore
-    }
+    const writer = this.writer;
+    const reader = this.reader;
+    const socket = this.socket;
     this.socket = null;
     this.writer = null;
     this.reader = null;
     this.parser = new RespParser();
+
+    // A timed-out Railway socket may never complete a graceful writer close.
+    // Detach it synchronously, abort all three stream layers in parallel, and
+    // bound teardown so the 1s operation ceiling remains a real caller-visible
+    // wall-clock ceiling. allSettled observes late failures after the deadline.
+    const cleanup = Promise.allSettled([
+      Promise.resolve().then(async () => await writer?.abort()),
+      Promise.resolve().then(async () => await reader?.cancel()),
+      Promise.resolve().then(async () => await socket?.close()),
+    ]);
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        cleanup,
+        new Promise<void>((resolve) => {
+          timer = setTimeout(resolve, SOCKET_CLOSE_TIMEOUT_MS);
+        }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
   }
 }
 
@@ -724,6 +734,11 @@ export class Pipeline {
 
   incr(key: string): this {
     this.commands.push(["INCR", key]);
+    return this;
+  }
+
+  pttl(key: string): this {
+    this.commands.push(["PTTL", key]);
     return this;
   }
 

--- a/packages/cloud/shared/src/lib/cache/socket-redis.ts
+++ b/packages/cloud/shared/src/lib/cache/socket-redis.ts
@@ -21,10 +21,13 @@ type SocketLike = {
   close(): Promise<void>;
 };
 
-type ConnectFn = (
-  address: { hostname: string; port: number },
-  options?: { secureTransport?: "on" | "off" | "starttls"; allowHalfOpen?: boolean },
-) => SocketLike;
+type SocketAddress = { hostname: string; port: number };
+type SocketOptions = {
+  secureTransport?: "on" | "off" | "starttls";
+  allowHalfOpen?: boolean;
+};
+
+type ConnectFn = (address: SocketAddress, options?: SocketOptions) => SocketLike;
 
 let cachedConnect: ConnectFn | null = null;
 
@@ -139,6 +142,46 @@ const decoder = new TextDecoder("utf-8");
 const SOCKET_OP_TIMEOUT_MS = 1000;
 const SOCKET_CLOSE_TIMEOUT_MS = 50;
 
+type SocketReader = Pick<ReadableStreamDefaultReader<Uint8Array>, "read" | "cancel">;
+type SocketWriter = Pick<WritableStreamDefaultWriter<Uint8Array>, "write" | "abort">;
+
+/**
+ * Narrow transport surface used by the test-only constructor. Production
+ * callers cannot inject it: the factory is runtime-gated to NODE_ENV=test and
+ * the constructor token stays private to this module.
+ */
+export interface SocketRedisTestTransport {
+  reader: SocketReader;
+  writer: SocketWriter;
+  close(): Promise<void>;
+}
+
+export interface SocketRedisTestHooks {
+  openTransport(address: SocketAddress, options: SocketOptions): Promise<SocketRedisTestTransport>;
+  operationTimeoutMs?: number;
+  closeTimeoutMs?: number;
+}
+
+interface ConnectionRuntime {
+  openTransport(address: SocketAddress, options: SocketOptions): Promise<SocketRedisTestTransport>;
+  operationTimeoutMs: number;
+  closeTimeoutMs: number;
+}
+
+const productionConnectionRuntime: ConnectionRuntime = {
+  async openTransport(address, options) {
+    const connect = await getConnect();
+    const socket = connect(address, options);
+    return {
+      reader: socket.readable.getReader(),
+      writer: socket.writable.getWriter(),
+      close: () => socket.close(),
+    };
+  },
+  operationTimeoutMs: SOCKET_OP_TIMEOUT_MS,
+  closeTimeoutMs: SOCKET_CLOSE_TIMEOUT_MS,
+};
+
 function encodeCommand(args: ReadonlyArray<string | number>): Uint8Array {
   let out = `*${args.length}${CRLF}`;
   for (const arg of args) {
@@ -233,42 +276,83 @@ class RespParser {
   }
 }
 
-class Connection {
-  private socket: SocketLike | null = null;
-  private writer: WritableStreamDefaultWriter<Uint8Array> | null = null;
-  private reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
-  private parser = new RespParser();
-  private readonly opts: ParsedUrl;
-  private inflight: Promise<unknown> = Promise.resolve();
-  // Bumped on every fresh socket. Failure cleanup closes a connection only if
-  // it is still the one the failing op used — a queued caller may already be
-  // on a newer socket, and a late loser must not tear that one down.
-  private generation = 0;
+interface ConnectionState {
+  readonly transport: SocketRedisTestTransport;
+  readonly parser: RespParser;
+  authenticated: boolean;
+  ownerEpoch: number;
+  closePromise: Promise<void> | null;
+}
 
-  constructor(opts: ParsedUrl) {
-    this.opts = opts;
+class StaleConnectionOperationError extends Error {
+  constructor() {
+    super("SocketRedis operation no longer owns the connection");
+    this.name = "StaleConnectionOperationError";
+  }
+}
+
+class Connection {
+  private state: ConnectionState | null = null;
+  private inflight: Promise<unknown> = Promise.resolve();
+  private ownershipEpoch = 0;
+
+  constructor(
+    private readonly opts: ParsedUrl,
+    private readonly runtime: ConnectionRuntime,
+  ) {}
+
+  private claimOwnership(): number {
+    this.ownershipEpoch += 1;
+    return this.ownershipEpoch;
   }
 
-  private async ensureOpen(): Promise<void> {
-    if (this.socket) return;
-    const connect = await getConnect();
-    this.generation += 1;
-    this.socket = connect(
+  private owns(epoch: number): boolean {
+    return this.ownershipEpoch === epoch;
+  }
+
+  private retire(epoch: number): void {
+    if (this.owns(epoch)) this.ownershipEpoch += 1;
+  }
+
+  private takeCurrent(epoch: number): ConnectionState | null {
+    if (!this.owns(epoch)) throw new StaleConnectionOperationError();
+    if (!this.state) return null;
+    this.state.ownerEpoch = epoch;
+    return this.state;
+  }
+
+  /**
+   * Construct an unpublished state for this operation. The ownership epoch is
+   * checked after the asynchronous open, so a timed-out opener can only close
+   * its local transport; it cannot overwrite a successor's published state.
+   */
+  private async openCandidate(epoch: number): Promise<ConnectionState> {
+    const transport = await this.runtime.openTransport(
       { hostname: this.opts.hostname, port: this.opts.port },
       { secureTransport: this.opts.tls ? "on" : "off", allowHalfOpen: false },
     );
-    this.writer = this.socket.writable.getWriter();
-    this.reader = this.socket.readable.getReader();
+    const candidate: ConnectionState = {
+      transport,
+      parser: new RespParser(),
+      authenticated: !this.opts.password,
+      ownerEpoch: epoch,
+      closePromise: null,
+    };
 
-    if (this.opts.password) {
-      const args = this.opts.username
-        ? ["AUTH", this.opts.username, this.opts.password]
-        : ["AUTH", this.opts.password];
-      const result = await this.sendRaw([args]);
-      if (result[0] instanceof RespError) {
-        throw result[0];
-      }
+    if (!this.owns(epoch)) {
+      await this.closeState(candidate);
+      throw new StaleConnectionOperationError();
     }
+    return candidate;
+  }
+
+  private publishCandidate(epoch: number, candidate: ConnectionState): void {
+    if (!this.owns(epoch)) throw new StaleConnectionOperationError();
+    if (this.state && this.state !== candidate) {
+      throw new Error("SocketRedis connection state changed before publication");
+    }
+    candidate.ownerEpoch = epoch;
+    this.state = candidate;
   }
 
   /** Serialize one batch of commands at a time. */
@@ -291,31 +375,58 @@ class Connection {
       const queueWait = await Promise.race([
         previous.then(() => "released" as const),
         new Promise<"orphaned">((resolve) => {
-          queueTimer = setTimeout(() => resolve("orphaned"), SOCKET_OP_TIMEOUT_MS);
+          queueTimer = setTimeout(() => resolve("orphaned"), this.runtime.operationTimeoutMs);
         }),
       ]);
       if (queueTimer) clearTimeout(queueTimer);
+
+      // Claim only after the serialization wait. This invalidates any losing
+      // predecessor before a queue-orphan teardown or a fresh open can begin.
+      const epoch = this.claimOwnership();
       if (queueWait === "orphaned") {
-        // error-policy:J6 best-effort teardown of a poisoned socket; the reconnect below is the real path.
-        await this.close().catch(() => {});
+        await this.detachAndCloseCurrent();
       }
-      let opGeneration = -1;
+
+      let opState: ConnectionState | null = null;
       try {
         return await this.withTimeout(async () => {
-          await this.ensureOpen();
-          opGeneration = this.generation;
-          return await this.sendRaw(commands);
+          // Existing state is captured synchronously before the first await.
+          // A fresh state stays unpublished until it is assigned locally,
+          // authenticated, and ownership has been rechecked.
+          opState = this.takeCurrent(epoch);
+          const needsPublication = opState === null;
+          if (!opState) opState = await this.openCandidate(epoch);
+          if (!this.owns(epoch)) {
+            this.detach(opState);
+            await this.closeState(opState);
+            throw new StaleConnectionOperationError();
+          }
+
+          if (!opState.authenticated) {
+            const password = this.opts.password;
+            if (!password) throw new Error("SocketRedis authentication state is invalid");
+            const args = this.opts.username
+              ? ["AUTH", this.opts.username, password]
+              : ["AUTH", password];
+            const result = await this.sendRaw([args], opState);
+            if (result[0] instanceof RespError) throw result[0];
+            if (!this.owns(epoch)) throw new StaleConnectionOperationError();
+            opState.authenticated = true;
+          }
+
+          if (!this.owns(epoch)) throw new StaleConnectionOperationError();
+          if (needsPublication) this.publishCandidate(epoch, opState);
+          return await this.sendRaw(commands, opState);
         });
       } catch (error) {
-        // Any mid-op failure leaves the RESP stream in an unknown state — and
-        // a cross-request I/O error means the socket belongs to a dead
-        // context. Drop the connection so the next call reconnects instead of
-        // reusing a poisoned socket for the isolate's lifetime. Guard on the
-        // generation: if a queued caller already reconnected, this failure
-        // belongs to the previous socket and must not tear down the current one.
-        if (opGeneration === -1 || opGeneration === this.generation) {
-          // error-policy:J6 best-effort teardown of a poisoned socket; the original error is rethrown below.
-          await this.close().catch(() => {});
+        // Invalidate before teardown. The timed-out async loser may continue,
+        // but it owns only its captured ConnectionState and cannot publish or
+        // touch any state created by the next serialized caller.
+        this.retire(epoch);
+        const failedState = opState ?? (this.state?.ownerEpoch === epoch ? this.state : null);
+        if (failedState) {
+          this.detach(failedState);
+          await this.closeState(failedState);
         }
         throw error;
       }
@@ -325,11 +436,11 @@ class Connection {
   }
 
   /**
-   * Bound a single connect+command to {@link SOCKET_OP_TIMEOUT_MS}. On timeout
-   * the error propagates to the caller, which falls back to its non-cached
-   * path instead of hanging. Closing the (possibly half-open or stalled)
-   * connection is `send()`'s job — it generation-guards the close so a late
-   * timeout can't tear down a successor's fresh socket.
+   * Bound a single connect+command to the configured operation timeout. On
+   * timeout the error propagates to the caller, which falls back to its
+   * non-cached path instead of hanging. The losing operation keeps running,
+   * so connection-local state and the ownership epoch provide cancellation
+   * safety without relying on the underlying socket promise being abortable.
    */
   private async withTimeout<T>(fn: () => Promise<T>): Promise<T> {
     const op = fn();
@@ -340,8 +451,10 @@ class Connection {
     let timer: ReturnType<typeof setTimeout> | undefined;
     const timeout = new Promise<never>((_, reject) => {
       timer = setTimeout(() => {
-        reject(new Error(`SocketRedis operation timed out after ${SOCKET_OP_TIMEOUT_MS}ms`));
-      }, SOCKET_OP_TIMEOUT_MS);
+        reject(
+          new Error(`SocketRedis operation timed out after ${this.runtime.operationTimeoutMs}ms`),
+        );
+      }, this.runtime.operationTimeoutMs);
     });
     try {
       return await Promise.race([op, timeout]);
@@ -352,9 +465,8 @@ class Connection {
 
   private async sendRaw(
     commands: ReadonlyArray<ReadonlyArray<string | number>>,
+    state: ConnectionState,
   ): Promise<RespValue[]> {
-    if (!this.writer || !this.reader) throw new Error("connection not open");
-
     let totalLen = 0;
     const chunks: Uint8Array[] = [];
     for (const cmd of commands) {
@@ -368,51 +480,66 @@ class Connection {
       merged.set(c, off);
       off += c.byteLength;
     }
-    await this.writer.write(merged);
+    await state.transport.writer.write(merged);
 
     const out: RespValue[] = [];
     while (out.length < commands.length) {
-      const next = this.parser.next();
+      const next = state.parser.next();
       if (next !== undefined) {
         out.push(next);
         continue;
       }
-      const { value, done } = await this.reader.read();
+      const { value, done } = await state.transport.reader.read();
       if (done) throw new Error("Redis connection closed mid-reply");
-      this.parser.push(value);
+      state.parser.push(value);
     }
     return out;
   }
 
-  async close(): Promise<void> {
-    const writer = this.writer;
-    const reader = this.reader;
-    const socket = this.socket;
-    this.socket = null;
-    this.writer = null;
-    this.reader = null;
-    this.parser = new RespParser();
+  private detach(state: ConnectionState): void {
+    if (this.state === state) this.state = null;
+  }
 
-    // A timed-out Railway socket may never complete a graceful writer close.
-    // Detach it synchronously, abort all three stream layers in parallel, and
-    // bound teardown so the 1s operation ceiling remains a real caller-visible
-    // wall-clock ceiling. allSettled observes late failures after the deadline.
-    const cleanup = Promise.allSettled([
-      Promise.resolve().then(async () => await writer?.abort()),
-      Promise.resolve().then(async () => await reader?.cancel()),
-      Promise.resolve().then(async () => await socket?.close()),
-    ]);
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    try {
-      await Promise.race([
-        cleanup,
-        new Promise<void>((resolve) => {
-          timer = setTimeout(resolve, SOCKET_CLOSE_TIMEOUT_MS);
-        }),
+  private async detachAndCloseCurrent(): Promise<void> {
+    const state = this.state;
+    if (!state) return;
+    this.state = null;
+    await this.closeState(state);
+  }
+
+  private closeState(state: ConnectionState): Promise<void> {
+    if (state.closePromise) return state.closePromise;
+
+    state.closePromise = (async () => {
+      // A timed-out Railway socket may never complete graceful teardown.
+      // Detach first, abort all three transport layers in parallel, and cap
+      // cleanup at 50ms in production. allSettled observes late failures.
+      const cleanup = Promise.allSettled([
+        Promise.resolve().then(async () => await state.transport.writer.abort()),
+        Promise.resolve().then(async () => await state.transport.reader.cancel()),
+        Promise.resolve().then(async () => await state.transport.close()),
       ]);
-    } finally {
-      if (timer) clearTimeout(timer);
-    }
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        await Promise.race([
+          cleanup,
+          new Promise<void>((resolve) => {
+            timer = setTimeout(resolve, this.runtime.closeTimeoutMs);
+          }),
+        ]);
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
+    })();
+
+    return state.closePromise;
+  }
+
+  async close(): Promise<void> {
+    // Prevent an openTransport() that is still awaiting from publishing after
+    // an explicit close, then detach the currently published state.
+    this.ownershipEpoch += 1;
+    await this.detachAndCloseCurrent();
   }
 }
 
@@ -466,6 +593,29 @@ interface ZAddMember {
   member: string;
 }
 
+const SOCKET_REDIS_TEST_CONSTRUCTOR = Symbol("SocketRedisTestConstructor");
+
+function testConnectionRuntime(hooks: SocketRedisTestHooks): ConnectionRuntime {
+  if (typeof process === "undefined" || process.env.NODE_ENV !== "test") {
+    throw new Error("SocketRedis test transport injection is disabled outside NODE_ENV=test");
+  }
+
+  const operationTimeoutMs = hooks.operationTimeoutMs ?? SOCKET_OP_TIMEOUT_MS;
+  const closeTimeoutMs = hooks.closeTimeoutMs ?? SOCKET_CLOSE_TIMEOUT_MS;
+  if (!Number.isFinite(operationTimeoutMs) || operationTimeoutMs <= 0) {
+    throw new Error("SocketRedis test operationTimeoutMs must be positive");
+  }
+  if (!Number.isFinite(closeTimeoutMs) || closeTimeoutMs <= 0) {
+    throw new Error("SocketRedis test closeTimeoutMs must be positive");
+  }
+
+  return {
+    openTransport: hooks.openTransport,
+    operationTimeoutMs,
+    closeTimeoutMs,
+  };
+}
+
 /**
  * Drop-in replacement for `@upstash/redis`'s `Redis` class — same method
  * shapes as the subset the codebase uses (rate limit, credit events, agent
@@ -477,9 +627,26 @@ interface ZAddMember {
 export class SocketRedis {
   private readonly conn: Connection;
 
-  constructor(opts: { url: string } | string) {
+  constructor(opts: { url: string } | string);
+  constructor(
+    opts: { url: string } | string,
+    testConstructor: typeof SOCKET_REDIS_TEST_CONSTRUCTOR,
+    testHooks: SocketRedisTestHooks,
+  );
+  constructor(
+    opts: { url: string } | string,
+    testConstructor?: typeof SOCKET_REDIS_TEST_CONSTRUCTOR,
+    testHooks?: SocketRedisTestHooks,
+  ) {
     const url = typeof opts === "string" ? opts : opts.url;
-    this.conn = new Connection(parseRedisUrl(url));
+    let runtime = productionConnectionRuntime;
+    if (testConstructor !== undefined || testHooks !== undefined) {
+      if (testConstructor !== SOCKET_REDIS_TEST_CONSTRUCTOR || !testHooks) {
+        throw new Error("Invalid SocketRedis test constructor token");
+      }
+      runtime = testConnectionRuntime(testHooks);
+    }
+    this.conn = new Connection(parseRedisUrl(url), runtime);
   }
 
   async get<T = string>(key: string): Promise<T | null> {
@@ -652,6 +819,18 @@ export class SocketRedis {
     }
     await this.conn.close();
   }
+}
+
+/**
+ * Create a SocketRedis instance with deterministic transport controls for
+ * resilience tests. The unexported constructor token plus the NODE_ENV guard
+ * keep this seam unavailable to accidental production construction.
+ */
+export function createSocketRedisForTests(
+  opts: { url: string } | string,
+  hooks: SocketRedisTestHooks,
+): SocketRedis {
+  return new SocketRedis(opts, SOCKET_REDIS_TEST_CONSTRUCTOR, hooks);
 }
 
 function decodeMaybeJson<T>(s: string): T {

--- a/packages/cloud/shared/src/lib/middleware/rate-limit-cloudflare-binding.test.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-cloudflare-binding.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Exercises the real Hono middleware against Cloudflare-shaped Rate Limiting
+ * bindings. Redis is not mocked: a bound request must never reach that path.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { rateLimit } from "./rate-limit-hono-cloudflare";
+
+interface FakeBinding {
+  calls: string[];
+  limit(options: { key: string }): Promise<{ success: boolean }>;
+}
+
+function binding(outcome: boolean | Error): FakeBinding {
+  const calls: string[] = [];
+  return {
+    calls,
+    async limit({ key }) {
+      calls.push(key);
+      if (outcome instanceof Error) throw outcome;
+      return { success: outcome };
+    },
+  };
+}
+
+function appWith(bindingName: string, key = "caller") {
+  const app = new Hono();
+  app.use(
+    rateLimit(
+      {
+        windowMs: 60_000,
+        maxRequests: 200,
+        keyGenerator: () => key,
+      },
+      { bindingName },
+    ),
+  );
+  app.get("/", (c) => c.json({ ok: true }));
+  return app;
+}
+
+describe("Cloudflare Rate Limiting binding middleware", () => {
+  test("allows through one native counter call and advertises the policy", async () => {
+    const limiter = binding(true);
+    const response = await appWith("LIMITER", "api-key-hash").fetch(
+      new Request("https://api.example.test/"),
+      { NODE_ENV: "production", LIMITER: limiter },
+    );
+
+    expect(response.status).toBe(200);
+    expect(limiter.calls).toEqual(["api-key-hash"]);
+    expect(response.headers.get("X-RateLimit-Policy")).toBe("cloudflare-native");
+    // The binding returns allow/deny only, so do not invent an exact reset time.
+    expect(response.headers.get("X-RateLimit-Reset")).toBeNull();
+  });
+
+  test("returns the existing 429 shape when the native binding denies", async () => {
+    const limiter = binding(false);
+    const response = await appWith("LIMITER").fetch(new Request("https://api.example.test/"), {
+      NODE_ENV: "production",
+      LIMITER: limiter,
+    });
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("Retry-After")).toBe("60");
+    expect(response.headers.get("X-RateLimit-Reset")).toBeNull();
+    expect(await response.json()).toMatchObject({
+      success: false,
+      code: "rate_limit_exceeded",
+      retryAfter: 60,
+    });
+  });
+
+  test("fails closed when a production binding is missing", async () => {
+    const response = await appWith("LIMITER").fetch(new Request("https://api.example.test/"), {
+      NODE_ENV: "production",
+    });
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({
+      success: false,
+      code: "rate_limit_unavailable",
+    });
+  });
+
+  test("fails closed when the platform binding throws", async () => {
+    const limiter = binding(new Error("binding unavailable"));
+    const response = await appWith("LIMITER").fetch(new Request("https://api.example.test/"), {
+      NODE_ENV: "production",
+      LIMITER: limiter,
+    });
+
+    expect(response.status).toBe(503);
+    expect(limiter.calls).toEqual(["caller"]);
+  });
+});

--- a/packages/cloud/shared/src/lib/middleware/rate-limit-cloudflare-binding.test.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-cloudflare-binding.test.ts
@@ -40,6 +40,24 @@ function appWith(bindingName: string, key = "caller") {
   return app;
 }
 
+function appWithNestedLimiters() {
+  const app = new Hono();
+  app.use(
+    rateLimit(
+      { windowMs: 60_000, maxRequests: 600, keyGenerator: () => "global-caller" },
+      { bindingName: "GLOBAL_LIMITER" },
+    ),
+  );
+  app.use(
+    rateLimit(
+      { windowMs: 60_000, maxRequests: 200, keyGenerator: () => "chat-caller" },
+      { bindingName: "CHAT_LIMITER" },
+    ),
+  );
+  app.get("/", (c) => c.json({ ok: true }));
+  return app;
+}
+
 describe("Cloudflare Rate Limiting binding middleware", () => {
   test("allows through one native counter call and advertises the policy", async () => {
     const limiter = binding(true);
@@ -69,6 +87,40 @@ describe("Cloudflare Rate Limiting binding middleware", () => {
       success: false,
       code: "rate_limit_exceeded",
       retryAfter: 60,
+    });
+  });
+
+  test("preserves the more specific inner limiter headers on allowed responses", async () => {
+    const globalLimiter = binding(true);
+    const chatLimiter = binding(true);
+    const response = await appWithNestedLimiters().fetch(new Request("https://api.example.test/"), {
+      NODE_ENV: "production",
+      GLOBAL_LIMITER: globalLimiter,
+      CHAT_LIMITER: chatLimiter,
+    });
+
+    expect(response.status).toBe(200);
+    expect(globalLimiter.calls).toEqual(["global-caller"]);
+    expect(chatLimiter.calls).toEqual(["chat-caller"]);
+    expect(response.headers.get("X-RateLimit-Limit")).toBe("200");
+    expect(response.headers.get("X-RateLimit-Policy")).toBe("cloudflare-native");
+  });
+
+  test("preserves inner limiter headers when it denies a nested request", async () => {
+    const globalLimiter = binding(true);
+    const chatLimiter = binding(false);
+    const response = await appWithNestedLimiters().fetch(new Request("https://api.example.test/"), {
+      NODE_ENV: "production",
+      GLOBAL_LIMITER: globalLimiter,
+      CHAT_LIMITER: chatLimiter,
+    });
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("X-RateLimit-Limit")).toBe("200");
+    expect(response.headers.get("Retry-After")).toBe("60");
+    expect(await response.json()).toMatchObject({
+      success: false,
+      message: "Rate limit exceeded. Maximum 200 requests per 60 seconds.",
     });
   });
 

--- a/packages/cloud/shared/src/lib/middleware/rate-limit-default-key.test.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-default-key.test.ts
@@ -1,5 +1,7 @@
 // Exercises rate limit default key behavior with deterministic cloud-shared lib fixtures.
+
 import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
 import type { AppContext } from "../../types/cloud-worker-env";
 import { getDefaultKey } from "./rate-limit-hono-cloudflare";
 
@@ -24,11 +26,13 @@ function ctx(headers: Record<string, string>, user?: { id: string }): AppContext
 
 describe("getDefaultKey — #11087 per-IP anonymous bucketing", () => {
   test("api key (x-api-key) → apikey: bucket", () => {
-    expect(getDefaultKey(ctx({ "x-api-key": "abc" }))).toBe("apikey:abc");
+    const hash = createHash("sha256").update("abc").digest("hex");
+    expect(getDefaultKey(ctx({ "x-api-key": "abc" }))).toBe(`apikey:${hash}`);
   });
 
   test("Bearer eliza_ token → apikey: bucket", () => {
-    expect(getDefaultKey(ctx({ authorization: "Bearer eliza_xyz" }))).toBe("apikey:eliza_xyz");
+    const hash = createHash("sha256").update("eliza_xyz").digest("hex");
+    expect(getDefaultKey(ctx({ authorization: "Bearer eliza_xyz" }))).toBe(`apikey:${hash}`);
   });
 
   test("authenticated user → user: bucket", () => {
@@ -36,7 +40,8 @@ describe("getDefaultKey — #11087 per-IP anonymous bucketing", () => {
   });
 
   test("anon session header → anon: bucket", () => {
-    expect(getDefaultKey(ctx({ "x-anonymous-session": "s1" }))).toBe("anon:s1");
+    const hash = createHash("sha256").update("s1").digest("hex");
+    expect(getDefaultKey(ctx({ "x-anonymous-session": "s1" }))).toBe(`anon:${hash}`);
   });
 
   test("UNAUTHENTICATED with an IP → per-IP bucket, NOT global 'public' (the fix)", () => {

--- a/packages/cloud/shared/src/lib/middleware/rate-limit-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-fail-closed.test.ts
@@ -12,9 +12,11 @@
 
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
+import * as loggerActual from "../utils/logger";
 
 mock.module("@elizaos/cloud-routing", () => ({}));
 mock.module("../utils/logger", () => ({
+  ...loggerActual,
   logger: {
     debug: mock(() => undefined),
     error: mock(() => undefined),
@@ -47,12 +49,6 @@ const throwingRedis = {
   },
 };
 
-mock.module("../cache/redis-factory", () => ({
-  buildRedisClient: () => throwingRedis,
-  hasRedisConfig: () => true,
-  isCloudflareWorkerRuntime: () => false,
-}));
-
 const { rateLimit, RateLimitPresets, getIpKey, _resetRedisUnavailableFallbackBuckets } =
   await import("./rate-limit-hono-cloudflare");
 
@@ -61,7 +57,7 @@ const ENV = { REDIS_URL: "redis://mock:6379", NODE_ENV: "production" };
 
 function appWith(config: Parameters<typeof rateLimit>[0]) {
   const app = new Hono();
-  app.use(rateLimit(config));
+  app.use(rateLimit(config, undefined, { buildRedisClient: () => throwingRedis }));
   app.get("/", (c) => c.json({ ok: true }));
   return app;
 }
@@ -74,6 +70,7 @@ function req() {
 }
 
 afterAll(() => {
+  mock.module("../utils/logger", () => loggerActual);
   mock.restore();
 });
 

--- a/packages/cloud/shared/src/lib/middleware/rate-limit-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-fail-closed.test.ts
@@ -35,6 +35,16 @@ const throwingRedis = {
   pexpire: async () => {
     throw new Error("ECONNREFUSED: redis down");
   },
+  pipeline: () => {
+    const pipeline = {
+      incr: () => pipeline,
+      pttl: () => pipeline,
+      exec: async () => {
+        throw new Error("ECONNREFUSED: redis down");
+      },
+    };
+    return pipeline;
+  },
 };
 
 mock.module("../cache/redis-factory", () => ({

--- a/packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts
@@ -52,6 +52,11 @@ export interface CloudflareRateLimitOptions {
   bindingName: string;
 }
 
+/** Optional construction dependencies for hosts that manage Redis lifecycle externally. */
+export interface RateLimitDependencies {
+  buildRedisClient?: (env: Bindings) => CompatibleRedis | null;
+}
+
 function getRedis(env: Bindings): CompatibleRedis | null {
   if (
     env.REDIS_RATE_LIMITING === "false" ||
@@ -397,6 +402,7 @@ export async function checkUpstash(
 export function rateLimit(
   config: RateLimitConfig,
   cloudflare?: CloudflareRateLimitOptions,
+  dependencies?: RateLimitDependencies,
 ): MiddlewareHandler<AppEnv> {
   return async (c, next) => {
     const env = (c.env ?? {}) as Bindings;
@@ -471,7 +477,9 @@ export function rateLimit(
       }
     }
 
-    const redis = getRedis(env);
+    const redis = dependencies?.buildRedisClient
+      ? dependencies.buildRedisClient(env)
+      : getRedis(env);
     if (!redis) {
       await next();
       applyRateLimitHeaders(

--- a/packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts
@@ -341,7 +341,13 @@ function checkRedisUnavailableFallback(
 
 function applyRateLimitHeaders(c: Context, headers: Record<string, string>): void {
   for (const [k, v] of Object.entries(headers)) {
-    c.res.headers.set(k, v);
+    // Hono middleware unwinds from the innermost route back to the outermost
+    // middleware. Preserve a more specific inner limiter's response metadata
+    // instead of replacing (for example) a 200/min chat limit with the outer
+    // 600/min global limit.
+    if (!c.res.headers.has(k)) {
+      c.res.headers.set(k, v);
+    }
   }
 }
 

--- a/packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts
@@ -1,12 +1,14 @@
 /**
  * Rate-limit middleware for Hono on Cloudflare Workers.
  *
- * Falls open if Redis is not configured. Adds `X-RateLimit-*` headers on success.
+ * Protective hot paths may use Cloudflare's machine-local Rate Limiting
+ * binding. Other routes use Redis and fall open if it is not configured.
  * Routes that must stay available during a Redis outage can install an
  * explicit per-isolate fallback bucket; every other sensitive route either
  * fails closed or falls open according to its config.
  */
 
+import { createHash } from "node:crypto";
 import type { Context, MiddlewareHandler } from "hono";
 import type { AppContext, AppEnv, Bindings } from "../../types/cloud-worker-env";
 import { buildRedisClient, type CompatibleRedis } from "../cache/redis-factory";
@@ -38,6 +40,16 @@ export interface RateLimitConfig {
    * that install `redisUnavailableFallback` stay available but locally bounded.
    */
   failClosed?: boolean;
+}
+
+/** Cloudflare's machine-local Rate Limiting binding. */
+export interface CloudflareRateLimitBinding {
+  limit(options: { key: string }): Promise<{ success: boolean }>;
+}
+
+export interface CloudflareRateLimitOptions {
+  /** Name of the Wrangler Rate Limiting binding in `c.env`. */
+  bindingName: string;
 }
 
 function getRedis(env: Bindings): CompatibleRedis | null {
@@ -92,6 +104,10 @@ function getIpKey(c: Context): string {
   return `ip:${getRequestIp(c) ?? "unknown"}`;
 }
 
+function hashRateLimitIdentifier(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
 function getDefaultKey(c: AppContext): string {
   const apiKey =
     c.req.header("x-api-key") ||
@@ -102,7 +118,7 @@ function getDefaultKey(c: AppContext): string {
       const token = auth.slice(7);
       return token.startsWith("eliza_") ? token : null;
     })();
-  if (apiKey) return `apikey:${apiKey}`;
+  if (apiKey) return `apikey:${hashRateLimitIdentifier(apiKey)}`;
 
   const userId = c.get("user")?.id;
   if (userId) return `user:${userId}`;
@@ -112,7 +128,7 @@ function getDefaultKey(c: AppContext): string {
     c.req.header("X-Anonymous-Session") ||
     c.req.header("cookie")?.match(/eliza-anon-session=([^;]+)/)?.[1] ||
     null;
-  if (anon) return `anon:${anon}`;
+  if (anon) return `anon:${hashRateLimitIdentifier(anon)}`;
 
   // Unauthenticated public traffic buckets PER-IP, not a global constant.
   // Returning the literal "public" put ALL anonymous traffic worldwide into one
@@ -147,6 +163,38 @@ function fallOpenResult(config: RateLimitConfig): CheckResult {
     remaining: config.maxRequests,
     resetAt: Date.now() + config.windowMs,
   };
+}
+
+function isCloudflareRateLimitBinding(value: unknown): value is CloudflareRateLimitBinding {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "limit" in value &&
+    typeof value.limit === "function"
+  );
+}
+
+function nativeRateLimitHeaders(config: RateLimitConfig) {
+  return {
+    "X-RateLimit-Limit": String(config.maxRequests),
+    "X-RateLimit-Policy": "cloudflare-native",
+  };
+}
+
+function nativeRateLimitUnavailable(c: Context, bindingName: string): Response {
+  logger.error("[RateLimit] Required Cloudflare Rate Limiting binding unavailable", {
+    bindingName,
+  });
+  return c.json(
+    {
+      success: false,
+      error: "Service temporarily unavailable",
+      code: "rate_limit_unavailable" as const,
+      message: "Rate limiter binding is unavailable; request rejected.",
+    },
+    503,
+    { "Retry-After": "30" },
+  );
 }
 
 interface LocalFallbackBucket {
@@ -310,12 +358,21 @@ export async function checkUpstash(
 ): Promise<CheckResult> {
   const fullKey = `ratelimit:${key}`;
   const carriedCount = Math.max(0, Math.floor(options?.carriedCount ?? 0));
+
+  // A lease flush may carry dozens of locally-served requests. Sending one
+  // TCP round-trip per carried request turns the first request after a quiet
+  // period into an N-second stall. Redis pipelines preserve the exact count
+  // while flushing every increment and the TTL read in one network exchange.
+  const pipeline = redis.pipeline();
   for (let i = 0; i < carriedCount; i++) {
-    await redis.incr(fullKey);
+    pipeline.incr(fullKey);
   }
-  const count = await redis.incr(fullKey);
-  let ttl = count === 1 ? null : await redis.pttl(fullKey);
-  if (count === 1 || ttl === null || ttl < 0) {
+  pipeline.incr(fullKey);
+  pipeline.pttl(fullKey);
+  const results = await pipeline.exec();
+  const count = Number(results[carriedCount] ?? 0);
+  let ttl = Number(results[carriedCount + 1] ?? -1);
+  if (count === 1 || !Number.isFinite(ttl) || ttl < 0) {
     // First request of a window — or an ORPHANED counter: if the pexpire after
     // a previous window's first incr ever failed (Workers sub-request drop),
     // the key has no TTL (pttl -1), so the counter grows forever and the
@@ -337,7 +394,10 @@ export async function checkUpstash(
   };
 }
 
-export function rateLimit(config: RateLimitConfig): MiddlewareHandler<AppEnv> {
+export function rateLimit(
+  config: RateLimitConfig,
+  cloudflare?: CloudflareRateLimitOptions,
+): MiddlewareHandler<AppEnv> {
   return async (c, next) => {
     const env = (c.env ?? {}) as Bindings;
 
@@ -359,6 +419,56 @@ export function rateLimit(config: RateLimitConfig): MiddlewareHandler<AppEnv> {
         rateLimitHeaders(effectiveConfig, fallOpenResult(effectiveConfig), "disabled"),
       );
       return;
+    }
+
+    if (cloudflare) {
+      const binding = env[cloudflare.bindingName];
+      if (isCloudflareRateLimitBinding(binding)) {
+        const key = (config.keyGenerator ?? getDefaultKey)(c);
+        let success: boolean | undefined;
+        try {
+          ({ success } = await binding.limit({ key }));
+        } catch (error) {
+          // error-policy:J1 middleware boundary translates a platform binding failure into a visible 503.
+          logger.error("[RateLimit] Cloudflare Rate Limiting binding failed", {
+            bindingName: cloudflare.bindingName,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          if (env.NODE_ENV === "production") {
+            return nativeRateLimitUnavailable(c, cloudflare.bindingName);
+          }
+        }
+
+        if (success === false) {
+          const headers = nativeRateLimitHeaders(effectiveConfig);
+          return c.json(
+            {
+              success: false,
+              error: "Too many requests",
+              code: "rate_limit_exceeded" as const,
+              message: `Rate limit exceeded. Maximum ${effectiveConfig.maxRequests} requests per ${Math.ceil(
+                effectiveConfig.windowMs / 1000,
+              )} seconds.`,
+              retryAfter: Math.ceil(effectiveConfig.windowMs / 1000),
+            },
+            429,
+            {
+              ...headers,
+              "Retry-After": String(Math.ceil(effectiveConfig.windowMs / 1000)),
+            },
+          );
+        }
+
+        if (success === true) {
+          await next();
+          applyRateLimitHeaders(c, nativeRateLimitHeaders(effectiveConfig));
+          return;
+        }
+      }
+
+      if (env.NODE_ENV === "production") {
+        return nativeRateLimitUnavailable(c, cloudflare.bindingName);
+      }
     }
 
     const redis = getRedis(env);

--- a/packages/cloud/shared/src/lib/middleware/rate-limit-hono-lease.test.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-hono-lease.test.ts
@@ -6,8 +6,9 @@
  * check, and denials lease without repeated backend round-trips.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
+import * as loggerActual from "../utils/logger";
 
 class FakeRedis {
   count = 0;
@@ -58,13 +59,8 @@ class FakeRedis {
 
 const redis = new FakeRedis();
 
-mock.module("../cache/redis-factory", () => ({
-  buildRedisClient: () => redis,
-  hasRedisConfig: () => true,
-  isCloudflareWorkerRuntime: () => false,
-}));
-
 mock.module("../utils/logger", () => ({
+  ...loggerActual,
   logger: {
     debug: mock(() => undefined),
     error: mock(() => undefined),
@@ -75,6 +71,10 @@ mock.module("../utils/logger", () => ({
 
 const { rateLimit, _resetHonoRateLimitLeases } = await import("./rate-limit-hono-cloudflare");
 
+afterAll(() => {
+  mock.module("../utils/logger", () => loggerActual);
+});
+
 const BASE_ENV = {
   NODE_ENV: "production",
   REDIS_RATE_LIMITING: "true",
@@ -83,7 +83,7 @@ const BASE_ENV = {
 
 function makeApp(config: Parameters<typeof rateLimit>[0]) {
   const app = new Hono();
-  app.use(rateLimit(config));
+  app.use(rateLimit(config, undefined, { buildRedisClient: () => redis }));
   app.get("/", (c) => c.json({ ok: true }));
   return app;
 }

--- a/packages/cloud/shared/src/lib/middleware/rate-limit-hono-lease.test.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-hono-lease.test.ts
@@ -13,6 +13,7 @@ class FakeRedis {
   count = 0;
   incrCalls = 0;
   expireCalls = 0;
+  pipelineExecCalls = 0;
   ttl = -1;
 
   async incr(): Promise<number> {
@@ -29,6 +30,29 @@ class FakeRedis {
     this.expireCalls++;
     this.ttl = windowMs;
     return 1;
+  }
+
+  pipeline() {
+    const operations: Array<"incr" | "pttl"> = [];
+    const pipeline = {
+      incr: () => {
+        operations.push("incr");
+        return pipeline;
+      },
+      pttl: () => {
+        operations.push("pttl");
+        return pipeline;
+      },
+      exec: async () => {
+        this.pipelineExecCalls++;
+        const results: number[] = [];
+        for (const operation of operations) {
+          results.push(operation === "incr" ? await this.incr() : await this.pttl());
+        }
+        return results;
+      },
+    };
+    return pipeline;
   }
 }
 
@@ -75,6 +99,7 @@ describe("Hono rateLimit lease (#15428)", () => {
     redis.count = 0;
     redis.incrCalls = 0;
     redis.expireCalls = 0;
+    redis.pipelineExecCalls = 0;
     redis.ttl = -1;
     _resetHonoRateLimitLeases();
   });
@@ -90,6 +115,7 @@ describe("Hono rateLimit lease (#15428)", () => {
     }
 
     expect(redis.incrCalls).toBe(4);
+    expect(redis.pipelineExecCalls).toBe(4);
   });
 
   test("flag-on repeats within budget skip Redis and advertise the lease policy", async () => {
@@ -125,6 +151,7 @@ describe("Hono rateLimit lease (#15428)", () => {
 
     // First authoritative hit + two carried INCRs + current authoritative hit.
     expect(redis.incrCalls).toBe(4);
+    expect(redis.pipelineExecCalls).toBe(2);
   });
 
   test("denials are leased instead of hammering Redis", async () => {

--- a/packages/cloud/shared/src/lib/middleware/rate-limit-org-lease.test.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-org-lease.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { createHash } from "node:crypto";
 import * as orgRateLimitsActual from "../services/org-rate-limits";
 import * as rateLimitRedisActual from "./rate-limit-redis";
 
@@ -27,6 +28,7 @@ let simulateWindow = false;
 let windowCount = 0;
 let pauseRedisChecks = false;
 const redisCheckWaiters: Array<() => void> = [];
+let redisKeys: string[] = [];
 
 async function waitForRedisWaiters(count: number): Promise<void> {
   for (let i = 0; i < 100; i++) {
@@ -39,12 +41,13 @@ async function waitForRedisWaiters(count: number): Promise<void> {
 mock.module("./rate-limit-redis", () => ({
   ...rateLimitRedisActual,
   checkRateLimitRedis: async (
-    _key: string,
+    key: string,
     _windowMs: number,
     maxRequests: number,
     options?: { carriedCount?: number },
   ) => {
     redisChecks++;
+    redisKeys.push(key);
     const carried = options?.carriedCount ?? 0;
     carriedCounts.push(carried);
     if (pauseRedisChecks) {
@@ -72,7 +75,17 @@ mock.module("../services/org-rate-limits", () => ({
   },
 }));
 
-const { enforceOrgRateLimit, __clearOrgRateLimitLeases } = await import("./rate-limit");
+const {
+  enforceOrgRateLimit,
+  __clearOrgRateLimitLeases,
+  checkCostBasedRateLimit,
+  checkRateLimitAsync,
+  enforceMcpOrganizationRateLimit,
+  mcpOrgRateLimitRedisKey,
+  rateLimitExceededPayload,
+  rateLimitExceededResponse,
+  withRateLimit,
+} = await import("./rate-limit");
 
 const originalRedisRateLimiting = process.env.REDIS_RATE_LIMITING;
 const originalHotPathCaches = process.env.INFERENCE_HOT_PATH_CACHES;
@@ -98,6 +111,7 @@ describe("enforceOrgRateLimit lease (#9899 Tier-3)", () => {
     process.env.INFERENCE_HOT_PATH_CACHES = "true";
     __clearOrgRateLimitLeases();
     redisChecks = 0;
+    redisKeys = [];
     tierReads = 0;
     carriedCounts = [];
     pauseRedisChecks = false;
@@ -230,6 +244,26 @@ describe("enforceOrgRateLimit lease (#9899 Tier-3)", () => {
     expect(redisChecks).toBe(2);
   });
 
+  test("turning the lease flag off flushes pending local usage before dropping the lease", async () => {
+    const org = uid();
+    redisResult = { allowed: true, remaining: 3, resetAt: Date.now() + 60_000 };
+
+    await enforceOrgRateLimit(org, "completions"); // authoritative
+    await enforceOrgRateLimit(org, "completions"); // locally leased
+    expect(redisChecks).toBe(1);
+
+    process.env.INFERENCE_HOT_PATH_CACHES = "false";
+    await enforceOrgRateLimit(org, "completions");
+    expect(redisChecks).toBe(2);
+    expect(carriedCounts).toEqual([0, 1]);
+
+    // The old lease was dropped, so switching the feature back on starts with
+    // another authoritative decision instead of reviving stale local budget.
+    process.env.INFERENCE_HOT_PATH_CACHES = "true";
+    await enforceOrgRateLimit(org, "completions");
+    expect(redisChecks).toBe(3);
+  });
+
   test("D1 convergence: a hot isolate cannot exceed the org limit by more than one in-flight lease budget", async () => {
     // Real-window simulation: carried members count like live appends. Limit
     // 120/60s → lease budget ceil(120×5/60) = 10. Drive far more traffic than
@@ -256,5 +290,122 @@ describe("enforceOrgRateLimit lease (#9899 Tier-3)", () => {
     // appended (authoritative members + flushed carries), minus at most the
     // one in-flight budget not yet flushed.
     expect(windowCount).toBeGreaterThanOrEqual(allowed - budget);
+  });
+});
+
+describe("public rate-limit contracts", () => {
+  beforeEach(() => {
+    process.env.REDIS_RATE_LIMITING = "false";
+    redisChecks = 0;
+    redisKeys = [];
+    simulateWindow = false;
+    windowCount = 0;
+    redisResult = {
+      allowed: true,
+      remaining: 99,
+      resetAt: Date.now() + 60_000,
+    };
+  });
+
+  test("hashes stable credentials before a Redis-backed decision", async () => {
+    process.env.REDIS_RATE_LIMITING = "true";
+    const apiKey = "eliza_secret-api-key";
+    const result = await checkRateLimitAsync(
+      new Request("https://api.example.test", {
+        headers: { authorization: `Bearer ${apiKey}` },
+      }),
+      { windowMs: 60_000, maxRequests: 100 },
+    );
+
+    expect(result.allowed).toBe(true);
+    expect(redisKeys).toEqual([`apikey:${createHash("sha256").update(apiKey).digest("hex")}`]);
+    expect(redisKeys[0]).not.toContain(apiKey);
+  });
+
+  test("in-memory async checks and wrapped handlers enforce one shared bucket", async () => {
+    const key = `public-contract-${uid()}`;
+    const config = { windowMs: 60_000, maxRequests: 2, keyGenerator: () => key };
+    const request = new Request("https://api.example.test");
+
+    expect((await checkRateLimitAsync(request, config)).remaining).toBe(1);
+
+    const wrapped = withRateLimit(
+      async () => new Response("ok", { status: 201, headers: { "X-Origin": "handler" } }),
+      config,
+    );
+    const allowed = await wrapped(request);
+    expect(allowed.status).toBe(201);
+    expect(allowed.headers.get("X-Origin")).toBe("handler");
+    expect(allowed.headers.get("X-RateLimit-Policy")).toBe("in-memory");
+
+    const denied = await wrapped(request);
+    expect(denied.status).toBe(429);
+    expect(await denied.json()).toMatchObject({
+      code: "rate_limit_exceeded",
+      retryAfter: 60,
+    });
+  });
+
+  test("dynamic wrapped handlers receive their route context", async () => {
+    const key = `dynamic-contract-${uid()}`;
+    const wrapped = withRateLimit<{ id: string }>(
+      async (_request, context) => Response.json({ id: (await context.params).id }),
+      { windowMs: 60_000, maxRequests: 1, keyGenerator: () => key },
+    );
+
+    const response = await wrapped(new Request("https://api.example.test"), {
+      params: Promise.resolve({ id: "route-id" }),
+    });
+    expect(await response.json()).toEqual({ id: "route-id" });
+  });
+
+  test("MCP keys and denial responses preserve the shared response contract", async () => {
+    expect(mcpOrgRateLimitRedisKey("org-1")).toBe("mcp:ratelimit:org-1");
+    expect(mcpOrgRateLimitRedisKey("org-1", "github")).toBe("mcp:ratelimit:github:org-1");
+
+    redisResult = {
+      allowed: false,
+      remaining: 0,
+      resetAt: Date.now() + 30_000,
+      retryAfter: 30,
+    };
+    const response = await enforceMcpOrganizationRateLimit("org-1", "github");
+    expect(redisKeys).toEqual(["mcp:ratelimit:github:org-1"]);
+    expect(response?.status).toBe(429);
+    expect(await response?.json()).toMatchObject({
+      code: "rate_limit_exceeded",
+      retryAfter: 30,
+    });
+
+    const payload = rateLimitExceededPayload(redisResult, 100, 60_000, "redis");
+    expect(payload.headers["X-RateLimit-Policy"]).toBe("redis");
+    expect(payload.body.message).toContain("Maximum 100 requests");
+    expect(rateLimitExceededResponse(redisResult, 100, 60_000, "redis").status).toBe(429);
+  });
+
+  test("cost limits accumulate sync and async costs without crossing identities", async () => {
+    const session = `cost-${uid()}`;
+    const request = new Request("https://api.example.test", {
+      headers: { "x-anonymous-session": session },
+    });
+    const config = {
+      windowMs: 60_000,
+      maxCost: 5,
+      getCost: async () => 3,
+    };
+
+    const first = await checkCostBasedRateLimit(request, config);
+    const second = await checkCostBasedRateLimit(request, config);
+    expect(first).toMatchObject({ allowed: true, remaining: 2 });
+    expect(second.allowed).toBe(false);
+    expect(second.retryAfter).toBe(60);
+
+    const otherIdentity = await checkCostBasedRateLimit(
+      new Request("https://api.example.test", {
+        headers: { "x-anonymous-session": `${session}-other` },
+      }),
+      config,
+    );
+    expect(otherIdentity.allowed).toBe(true);
   });
 });

--- a/packages/cloud/shared/src/lib/middleware/rate-limit-orphaned-counter.test.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-orphaned-counter.test.ts
@@ -25,6 +25,28 @@ function fakeRedis(state: { count: number; ttl: number | null }) {
       calls.push("pttl");
       return state.ttl ?? -1;
     },
+    pipeline: () => {
+      const operations: Array<"incr" | "pttl"> = [];
+      const pipeline = {
+        incr: () => {
+          operations.push("incr");
+          return pipeline;
+        },
+        pttl: () => {
+          operations.push("pttl");
+          return pipeline;
+        },
+        exec: async () => {
+          calls.push("pipeline.exec");
+          const results: number[] = [];
+          for (const operation of operations) {
+            results.push(operation === "incr" ? await redis.incr() : await redis.pttl());
+          }
+          return results;
+        },
+      };
+      return pipeline;
+    },
   } as unknown as CompatibleRedis;
   return { redis, calls, state };
 }
@@ -64,5 +86,18 @@ describe("checkUpstash — orphaned-counter self-heal", () => {
     expect(result.allowed).toBe(false);
     expect(result.retryAfter).toBeGreaterThan(0);
     expect(result.retryAfter).toBeLessThanOrEqual(60);
+  });
+
+  it("flushes a full local lease in one pipeline exchange", async () => {
+    const { redis, calls, state } = fakeRedis({ count: 10, ttl: 30_000 });
+    const result = await checkUpstash(redis, "api-key", 60_000, 600, {
+      carriedCount: 40,
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(state.count).toBe(51);
+    expect(calls.filter((call) => call === "pipeline.exec")).toHaveLength(1);
+    expect(calls.filter((call) => call === "pttl")).toHaveLength(1);
+    expect(calls.filter((call) => call === "incr")).toHaveLength(41);
   });
 });

--- a/packages/cloud/shared/src/lib/middleware/rate-limit.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit.ts
@@ -40,6 +40,23 @@ interface RateLimitEntry {
 // PRODUCTION: Always set REDIS_RATE_LIMITING=true
 const rateLimitStore = new Map<string, RateLimitEntry>();
 
+/**
+ * Background cleanup must not keep short-lived Node/Bun processes alive.
+ * Cloudflare Workers return a numeric timer handle, while Node-compatible
+ * runtimes return an object with `unref()`.
+ */
+function unrefNodeTimer(timer: ReturnType<typeof setInterval>): void {
+  const candidate: unknown = timer;
+  if (
+    typeof candidate === "object" &&
+    candidate !== null &&
+    "unref" in candidate &&
+    typeof candidate.unref === "function"
+  ) {
+    candidate.unref();
+  }
+}
+
 // Validate rate limiting configuration on startup
 let hasValidatedConfig = false;
 function validateRateLimitConfig() {
@@ -80,7 +97,7 @@ function validateRateLimitConfig() {
 /**
  * Clean up expired entries periodically
  */
-setInterval(() => {
+const rateLimitCleanupTimer = setInterval(() => {
   const now = Date.now();
   for (const [key, entry] of rateLimitStore.entries()) {
     if (entry.resetAt < now) {
@@ -88,6 +105,7 @@ setInterval(() => {
     }
   }
 }, 60000); // Clean every minute
+unrefNodeTimer(rateLimitCleanupTimer);
 
 /**
  * Mask sensitive keys for logging (never log full API keys)
@@ -668,7 +686,7 @@ export async function checkCostBasedRateLimit(
 /**
  * Clean up cost limit store periodically
  */
-setInterval(() => {
+const costLimitCleanupTimer = setInterval(() => {
   const now = Date.now();
   for (const [key, entry] of costLimitStore.entries()) {
     if (entry.resetAt < now) {
@@ -676,3 +694,4 @@ setInterval(() => {
     }
   }
 }, 60000);
+unrefNodeTimer(costLimitCleanupTimer);

--- a/packages/cloud/shared/src/lib/middleware/rate-limit.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit.ts
@@ -9,6 +9,7 @@
  * @see ANALYTICS_PR_REVIEW_ANALYSIS.md - Issue #1 (Fixed)
  */
 
+import { createHash } from "node:crypto";
 import type { RouteParams } from "../api/hono-next-style-params";
 import { isHotPathCachesEnabled } from "../services/inference-hot-path-caches";
 import type { EndpointType, OrgRateLimitConfig } from "../services/org-rate-limits";
@@ -117,6 +118,10 @@ function getIpKey(request: Request): string {
   return `ip:${ip}`;
 }
 
+function hashRateLimitIdentifier(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
 function getDefaultKey(request: Request): string {
   // Prefer stable, non-IP identifiers.
   //
@@ -136,14 +141,14 @@ function getDefaultKey(request: Request): string {
       return token.startsWith("eliza_") ? token : null;
     })();
 
-  if (apiKey) return `apikey:${apiKey}`;
+  if (apiKey) return `apikey:${hashRateLimitIdentifier(apiKey)}`;
 
   const anonSession =
     request.headers.get("x-anonymous-session") ||
     request.headers.get("X-Anonymous-Session") ||
     getRequestCookie(request, "eliza-anon-session") ||
     null;
-  if (anonSession) return `anon:${anonSession}`;
+  if (anonSession) return `anon:${hashRateLimitIdentifier(anonSession)}`;
 
   // If we truly can't identify the caller, use a shared bucket (still not IP-based).
   return "public";

--- a/packages/cloud/shared/src/lib/services/ai-pricing/lookup.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/lookup.error-policy.test.ts
@@ -217,3 +217,125 @@ test("starts input and output pricing reads concurrently on the inference hot pa
   expect(result.inputCost).toBeGreaterThan(0);
   expect(result.outputCost).toBeGreaterThan(0);
 });
+
+test("starts both missing-side fallback reads concurrently", async () => {
+  const started = new Set<string>();
+  let signalBothStarted!: () => void;
+  const bothStarted = new Promise<void>((resolve) => {
+    signalBothStarted = resolve;
+  });
+  let releaseReads!: () => void;
+  const readsReleased = new Promise<void>((resolve) => {
+    releaseReads = resolve;
+  });
+
+  pairsHandler = async () => [];
+  listHandler = async (filters: Filters) => {
+    const chargeType = filters.chargeType as "input" | "output";
+    started.add(chargeType);
+    if (started.size === 2) signalBothStarted();
+    await readsReleased;
+    return [
+      catalogRow(
+        "anthropic",
+        "anthropic/claude-opus-4-8",
+        chargeType,
+        chargeType === "input" ? 5 : 25,
+      ),
+    ];
+  };
+
+  const calculation = calculateTextCostFromCatalog({
+    model: "claude-new-model-without-an-exact-price",
+    provider: "anthropic",
+    inputTokens: 1_000,
+    outputTokens: 500,
+  });
+
+  await Promise.race([
+    bothStarted,
+    new Promise<never>((_resolve, reject) =>
+      setTimeout(() => reject(new Error("fallback reads started serially")), 250),
+    ),
+  ]);
+  expect(started).toEqual(new Set(["input", "output"]));
+  releaseReads();
+
+  const result = await calculation;
+  expect(result.inputCost).toBeGreaterThan(0);
+  expect(result.outputCost).toBeGreaterThan(0);
+});
+
+test("uses a valid environment fallback while skipping an unused zero-token side", async () => {
+  process.env.AI_PRICING_FALLBACK_INPUT_USD_PER_M = "2.5";
+
+  const result = await calculateTextCostFromCatalog({
+    model: "uncatalogued-input-only-model",
+    provider: "someprovider",
+    inputTokens: 1_000_000,
+    outputTokens: 0,
+  });
+
+  expect(result.baseInputCost).toBe(2.5);
+  expect(result.baseOutputCost).toBe(0);
+  expect(result.totalCost).toBe(3);
+});
+
+test("rejects invalid fallback environment rates instead of under-billing", async () => {
+  process.env.AI_PRICING_FALLBACK_INPUT_USD_PER_M = "not-a-number";
+  process.env.AI_PRICING_FALLBACK_OUTPUT_USD_PER_M = "-4";
+
+  await expect(
+    calculateTextCostFromCatalog({
+      model: "uncatalogued-model",
+      provider: "someprovider",
+      inputTokens: 1_000,
+      outputTokens: 500,
+    }),
+  ).rejects.toThrow("refusing to bill unknown-priced inference");
+
+  expect(
+    warnSpy.mock.calls.filter(
+      (call) => call[0] === "ai-pricing: ignoring invalid fallback-rate env value",
+    ),
+  ).toHaveLength(2);
+});
+
+test("rejects a non-finite token quantity before catalog access", async () => {
+  await expect(
+    calculateTextCostFromCatalog({
+      model: "claude-opus-4-8",
+      provider: "anthropic",
+      inputTokens: Number.NaN,
+      outputTokens: 1,
+    }),
+  ).rejects.toThrow("refusing to bill an invalid quantity");
+
+  expect(errorSpy.mock.calls[0]?.[0]).toBe("ai-pricing: refusing to bill an invalid quantity");
+});
+
+test("resolves and observes a persisted catalog alias", async () => {
+  pairsHandler = async (filters: unknown) => {
+    const chargeType = (filters as { chargeType: "input" | "output" }).chargeType;
+    return [
+      catalogRow(
+        "anthropic",
+        "anthropic:claude-opus-4-8",
+        chargeType,
+        chargeType === "input" ? 5 : 25,
+      ),
+    ];
+  };
+
+  const result = await calculateTextCostFromCatalog({
+    model: "claude-opus-4-8",
+    provider: "anthropic",
+    inputTokens: 1_000,
+    outputTokens: 500,
+  });
+
+  expect(result.totalCost).toBeGreaterThan(0);
+  expect(
+    warnSpy.mock.calls.filter((call) => call[0] === "ai-pricing: resolved pricing via alias"),
+  ).toHaveLength(2);
+});

--- a/packages/cloud/shared/src/lib/services/ai-pricing/lookup.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/lookup.error-policy.test.ts
@@ -170,3 +170,50 @@ test("exact-price read transport FAILURE degrades to the fallback tier, never cr
   expect(result.inputCost).toBeGreaterThan(0);
   expect(result.outputCost).toBeGreaterThan(0);
 });
+
+test("starts input and output pricing reads concurrently on the inference hot path", async () => {
+  const started = new Set<string>();
+  let signalBothStarted!: () => void;
+  const bothStarted = new Promise<void>((resolve) => {
+    signalBothStarted = resolve;
+  });
+  let releaseReads!: () => void;
+  const readsReleased = new Promise<void>((resolve) => {
+    releaseReads = resolve;
+  });
+
+  pairsHandler = async (filters: unknown) => {
+    const chargeType = (filters as { chargeType: "input" | "output" }).chargeType;
+    started.add(chargeType);
+    if (started.size === 2) signalBothStarted();
+    await readsReleased;
+    return [
+      catalogRow(
+        "anthropic",
+        "anthropic/claude-opus-4-8",
+        chargeType,
+        chargeType === "input" ? 5 : 25,
+      ),
+    ];
+  };
+
+  const calculation = calculateTextCostFromCatalog({
+    model: "claude-opus-4-8",
+    provider: "anthropic",
+    inputTokens: 1_000,
+    outputTokens: 500,
+  });
+
+  await Promise.race([
+    bothStarted,
+    new Promise<never>((_resolve, reject) =>
+      setTimeout(() => reject(new Error("pricing reads started serially")), 250),
+    ),
+  ]);
+  expect(started).toEqual(new Set(["input", "output"]));
+  releaseReads();
+
+  const result = await calculation;
+  expect(result.inputCost).toBeGreaterThan(0);
+  expect(result.outputCost).toBeGreaterThan(0);
+});

--- a/packages/cloud/shared/src/lib/services/ai-pricing/lookup.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/lookup.ts
@@ -422,20 +422,22 @@ export async function calculateTextCostFromCatalog(params: {
   // only when a real fallback exists (provider max → env default). If neither
   // source exists, fail closed because we should not sell inference we do not
   // know how to price (#11635).
-  const inputEntry = await resolvePreparedPricingEntry({
-    billingSource: params.billingSource,
-    provider: params.provider,
-    model: canonicalModel,
-    productFamily,
-    chargeType: "input",
-  }).catch(() => null);
-  const outputEntry = await resolvePreparedPricingEntry({
-    billingSource: params.billingSource,
-    provider: params.provider,
-    model: canonicalModel,
-    productFamily,
-    chargeType: "output",
-  }).catch(() => null);
+  const [inputEntry, outputEntry] = await Promise.all([
+    resolvePreparedPricingEntry({
+      billingSource: params.billingSource,
+      provider: params.provider,
+      model: canonicalModel,
+      productFamily,
+      chargeType: "input",
+    }).catch(() => null),
+    resolvePreparedPricingEntry({
+      billingSource: params.billingSource,
+      provider: params.provider,
+      model: canonicalModel,
+      productFamily,
+      chargeType: "output",
+    }).catch(() => null),
+  ]);
 
   // Resolve a fallback only for a side that actually bills tokens: a
   // zero-token side costs $0 at any rate, and skipping it keeps input-only
@@ -477,10 +479,10 @@ export async function calculateTextCostFromCatalog(params: {
     return fallback;
   };
 
-  const inputFallback = inputEntry ? null : await resolveMissingSide("input", params.inputTokens);
-  const outputFallback = outputEntry
-    ? null
-    : await resolveMissingSide("output", params.outputTokens);
+  const [inputFallback, outputFallback] = await Promise.all([
+    inputEntry ? null : resolveMissingSide("input", params.inputTokens),
+    outputEntry ? null : resolveMissingSide("output", params.outputTokens),
+  ]);
 
   // Defense-in-depth money-boundary guard mirroring `computeCostFromEntry`.
   // Candidate selection already drops non-finite/non-positive catalog prices, but the token

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -9,6 +9,10 @@ import type { Context } from "hono";
 import type { KvNamespaceLike } from "../lib/cache/adapters/kv-cache-adapter";
 import type { RuntimeR2Bucket } from "../lib/storage/r2-runtime-binding";
 
+export interface RuntimeRateLimitBinding {
+  limit(options: { key: string }): Promise<{ success: boolean }>;
+}
+
 export interface Bindings {
   // ---- Deployment environment ----
   /**
@@ -34,6 +38,10 @@ export interface Bindings {
    * prefers it when bound. Read via getCloudBinding("CACHE_KV").
    */
   CACHE_KV?: KvNamespaceLike;
+
+  // ---- Cloudflare machine-local protective rate limits ----
+  GLOBAL_RATE_LIMITER?: RuntimeRateLimitBinding;
+  CHAT_ROUTE_RATE_LIMITER?: RuntimeRateLimitBinding;
 
   // ---- Cloudflare Registrar/DNS ----
   CLOUDFLARE_ACCOUNT_ID?: string;


### PR DESCRIPTION
# Relates to

Fixes #16153. Cold Worker bootstrap is tracked in #16155, cold auth reconnects in #16159, cold pricing single-flight in #16162, and correlated hop telemetry in #16079/#16098.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`; final head `c70543e0e813` is rebased without conflicts onto `df36d59b4b0`.
- [x] Focused tests, the complete Cloud unit lane, TypeScript 7 checks, Worker dry-run, Biome, diff checks, and independent review pass on the final local head.
- [x] The existing live paired benchmark is attached and explicitly tied to measured candidate `5710071096e`.
- [x] Full GitHub CI on final head `c70543e0e813` passed, including Cloud unit/integration/E2E/lint-types and repository build/lint/typecheck.
- [ ] After merge, validate the exact automatically deployed `develop` merge SHA with the same 320-record paired harness before any production promotion.

# Risk

**Medium.** This changes protective counters on every Cloud API/chat request and hardens a shared Redis socket client. Missing or throwing production rate-limit bindings fail visibly with 503. Cloudflare counters are deliberately used only for the global flood backstop and chat API-key gate; exact organization/purchased-quota accounting remains Redis-backed and authoritative.

# Background

## Root cause

Paired staging/direct evidence showed Cerebras responding in roughly 89–333 ms while the Cloud gateway could spend 2.45–3.11 seconds before the handler after idle. Privacy-safe unauthenticated probes reproduced two sequential Railway TCP Redis checks at 2.38–3.46 seconds without calling a model.

The two outer protective limiters were paying cross-cloud TCP setup before every chat turn. Independent review also found that a timed-out SocketRedis operation could resume after its 50 ms teardown bound and touch a successor connection's mutable reader/parser.

## What this PR changes

- moves the global 600/min flood backstop and chat 200/min gate to Cloudflare Rate Limiting bindings;
- preserves the exact organization inference limiter on Redis;
- hashes API-key/anonymous identifiers before using them as counter keys;
- batches carried Redis lease increments and TTL lookup into one pipeline exchange;
- makes SocketRedis reader/writer/parser state connection-local and protects publication with an ownership epoch;
- bounds teardown while ensuring timeout losers cannot read from, publish over, or close successor connections;
- starts independent input/output pricing reads concurrently and evicts the short-lived balance hint on central credit mutations;
- preserves Cerebras `promptCacheKey` when `reasoningEffort` also contributes provider options, with streaming and non-streaming regressions;
- preserves the inner 200/min chat limiter's headers while Hono unwinds through the outer 600/min limiter, for both allowed and denied responses; and
- repairs/restores process-global Redis mocks used by the complete Cloud lane.

It does **not** change provider/model selection, billing rates, response streaming bytes, database schema, or production deployment state. Native rate-limit metadata is intentionally more truthful than before.

## Reviewer entry points

1. `packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts`
2. `packages/cloud/api/src/bootstrap-app.ts`
3. `packages/cloud/api/v1/chat/completions/route.ts`
4. `packages/cloud/shared/src/lib/cache/socket-redis.ts`
5. `packages/cloud/api/wrangler.toml`

# Validation

## Local gates

- On Cloud head `2357296cc6f`: standard dependency build **70/70 Turbo tasks passed**; complete `bun run test:cloud` **10/10 batches exited successfully** with no failed tests. The runner observed its documented Bun/PGlite status-99 pollution only after batches reported zero failures and handled it through the repository's guarded path.
- `develop` then added only #16184's homepage leaderboard asset/test. The nine Cloud commits rebased cleanly with no content conflict.
- On exact final head `c70543e0e813`: every branch-touched test file **119 pass, 0 fail**, including nested native-limit allow/deny and combined Cerebras option regressions.
- On exact final head `c70543e0e813`: `packages/cloud/api` native TypeScript 7 (`tsgo`) typecheck passed.
- On exact final head `c70543e0e813`: production Worker dry-run passed without deployment at **16,224.46 KiB raw / 3,626.27 KiB gzip**, with distinct `GLOBAL_RATE_LIMITER` (600/min) and `CHAT_ROUTE_RATE_LIMITER` (200/min) bindings.
- Biome and `git diff --check` passed; worktree is clean.
- Independent final review found no remaining critical/high/medium issue after the nested-header fix. Socket ownership, Redis fallback, exact org-limit behavior, pricing fail-closed behavior, provider-option composition, and Worker bindings reviewed cleanly.

## Live chat evidence for measured candidate `5710071096e`

- Baseline paired run: https://github.com/elizaOS/eliza/actions/runs/29167994915
- Candidate staging deploy: https://github.com/elizaOS/eliza/actions/runs/29171470925
- Candidate paired run: https://github.com/elizaOS/eliza/actions/runs/29171752918

Results:

- **320/320 HTTP 200** and **320/320 clean stream completions**; 319/320 deterministic proof matches, the same proof rate as baseline.
- Across 149 matched warm pairs, gateway-minus-direct response-header penalty improved p50/p90/p95 from **403.90/1210.22/1481.66 ms** to **150.82/359.90/488.41 ms** (-63%/-70%/-67%).
- Warm gateway-minus-direct TTFT penalty improved from **471/1344/1927 ms** to **172/501/655 ms**.
- Warm client-header time outside the current route timer fell from **329/943/1020 ms** to **55/62/64 ms** at p50/p90/p95.
- Warm pairs over 500 ms fell from 74/150 to 12/150; pairs over 1 second fell from 50 to 1.
- Directional 30-second post-idle median penalty improved from **4845 ms to 1176 ms**; this phase has only five pairs.

This proves the targeted Railway-Redis ingress regression on the measured candidate. The final rebased head has stronger correctness fixes and local validation, but has not been mislabeled as live-deployed evidence. The exact merged-SHA staging run is the rollout gate.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A — backend-only Worker middleware/cache change; no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A — backend-only Worker middleware/cache change; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A — no UI interaction changed.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: measured-candidate staging deploy and paired direct/gateway run passed — https://github.com/elizaOS/eliza/actions/runs/29171752918
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A — backend-only diff; streaming bytes remain unchanged and rate-limit metadata is covered by backend regressions.
<!-- evidence-row:llm-trajectory -->
- [x] Real LLM trajectory: live paired Gemma/GLM streams exercised direct and Cloud gateway paths on measured candidate `5710071096e` — https://github.com/elizaOS/eliza/actions/runs/29171752918
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A — no database migration, wallet, memory, generated media, or durable schema change.

# Known limits and follow-ups

- Cold startup is not fixed: two of five cold gateway cases remained about 5.2 seconds, with roughly 3.2 seconds in auth. The monolithic 16 MiB/646-route Worker bootstrap is #16155; cold auth reconnect investigation is #16159.
- One Gemma response had 121 ms preforward and 181 ms response headers, then 2.36 seconds from headers to first token. That tail is downstream/provider/stream scheduling, not ingress.
- `X-Eliza-Preforward-Ms total` currently freezes after the streaming handler returns a `Response`, so only named auth/mid/reserve components are individually attributable. Truthful correlated hop telemetry remains #16079/#16098.
- Parallel cold pricing misses can duplicate a provider catalog fetch because completed values, but not in-flight promises, are cached. Billing remains fail-closed/correct; promise-level single-flight is #16162.
- Chat Latency Live verifies the served SHA before/after but does not yet bind its checkout SHA internally; #16185 tracks that provenance hardening. The post-merge run will enforce both SHAs externally.
- The five cold and five post-idle samples are directional; warm conclusions are supported by 150 pairs.

# Deploy notes

Production must not be deployed from this branch. The canonical-deploy guard from #16161 rejects feature-branch workflow dispatches to canonical staging. After this PR is green and merged into `develop`, let the automatic staging deployment serve the exact merge SHA and rerun the same 320-sample paired harness before considering production promotion.
