### PR TITLE
fix(ui): preserve cloud app onboarding auth surface

### DIFF
--- a/packages/ui/src/App.navigate-view-wiring.test.tsx
+++ b/packages/ui/src/App.navigate-view-wiring.test.tsx
@@ -20,8 +20,19 @@ import { DEFAULT_BOOT_CONFIG, setBootConfig } from "./config/boot-config";
 import type { ViewRegistryEntry } from "./hooks/useAvailableViews";
 
 const appState = vi.hoisted(() => ({
+  firstRunComplete: true,
   setTab: vi.fn(),
+  startupPhase: "ready",
   tab: "chat",
+}));
+
+const authStatusMock = vi.hoisted(() => ({
+  phase: "authenticated" as "authenticated" | "unauthenticated",
+  use: vi.fn(),
+}));
+
+const cloudOriginMock = vi.hoisted(() => ({
+  agentless: false,
 }));
 
 const desktopTabsMock = vi.hoisted(() => ({
@@ -233,13 +244,31 @@ vi.mock("./hooks/useAvailableViews", () => ({
 }));
 
 vi.mock("./hooks/useAuthStatus", () => ({
-  useAuthStatus: () => ({
-    state: { phase: "authenticated" },
-    refetch: vi.fn(),
-  }),
+  useAuthStatus: (options: { skip?: boolean } = {}) => {
+    authStatusMock.use(options);
+    return {
+      state: { phase: authStatusMock.phase },
+      refetch: vi.fn(),
+    };
+  },
   // Home widgets gate their loaders on this (#11084); the mounted App renders
   // them, so the mock must export it alongside useAuthStatus.
-  useIsAuthenticated: () => true,
+  useIsAuthenticated: () => authStatusMock.phase === "authenticated",
+}));
+
+vi.mock("./utils/cloud-agent-base", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("./utils/cloud-agent-base")>();
+  return {
+    ...actual,
+    isElizaCloudControlPlaneAgentlessBase: () => cloudOriginMock.agentless,
+  };
+});
+
+vi.mock("./first-run/use-first-run-conductor", () => ({
+  FirstRunConductorMount: () => <div data-testid="first-run-conductor-mount" />,
+  surfaceCloudLoginRetryTurn: vi.fn(),
+  useFirstRunConductor: vi.fn(),
 }));
 
 vi.mock("./hooks/useMediaQuery", () => ({
@@ -288,7 +317,7 @@ vi.mock("./state", async () => {
     gameOverlayEnabled: false,
     handlePluginToggle: vi.fn(),
     loadDropStatus: vi.fn(async () => undefined),
-    firstRunComplete: true,
+    firstRunComplete: appState.firstRunComplete,
     firstRunName: "",
     ownerName: "Test Owner",
     plugins: [],
@@ -300,7 +329,7 @@ vi.mock("./state", async () => {
     setUiTheme: vi.fn(),
     setUiThemeMode: vi.fn(),
     startupCoordinator: {
-      phase: "ready",
+      phase: appState.startupPhase,
       retry: vi.fn(),
     },
     startupError: null,
@@ -447,11 +476,16 @@ describe("App navigate-view event wiring", () => {
     Reflect.deleteProperty(window, "__ELIZAOS_API_BASE__");
     Reflect.deleteProperty(window, "__ELIZA_API_TOKEN__");
     Reflect.deleteProperty(window, "__ELIZAOS_API_TOKEN__");
+    appState.firstRunComplete = true;
+    appState.startupPhase = "ready";
     appState.tab = "chat";
+    authStatusMock.phase = "authenticated";
+    cloudOriginMock.agentless = false;
     mediaQueryState.matches = false;
     desktopTabsState.tabs = [];
     resetMockAvailableViews();
     appState.setTab.mockClear();
+    authStatusMock.use.mockClear();
     desktopTabsMock.openTab.mockClear();
     desktopTabsMock.closeTab.mockClear();
     desktopBridgeMock.invokeDesktopBridgeRequest.mockClear();
@@ -463,6 +497,22 @@ describe("App navigate-view event wiring", () => {
   afterEach(() => {
     cleanup();
     vi.unstubAllGlobals();
+  });
+
+  it("keeps an unauthenticated shared Cloud app inside first-run onboarding", () => {
+    window.history.replaceState(null, "", "/?shellMode=full");
+    appState.firstRunComplete = false;
+    appState.startupPhase = "first-run-required";
+    authStatusMock.phase = "unauthenticated";
+    cloudOriginMock.agentless = true;
+
+    render(<App />);
+
+    expect(authStatusMock.use).toHaveBeenCalledWith(
+      expect.objectContaining({ skip: true }),
+    );
+    expect(screen.getByTestId("first-run-conductor-mount")).toBeTruthy();
+    expect(screen.queryByText("Open this agent from Eliza Cloud")).toBeNull();
   });
 
   it("routes view-manager events through the mounted App listener", async () => {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -140,6 +140,7 @@ import { isShellPaintable } from "./state/startup-coordinator";
 import {
   authProbeShouldHoldShell,
   firstRunOwnsLoginSurface,
+  topLevelAuthGateOwnsSurface,
 } from "./state/top-level-auth-gate";
 import { isLoopbackGatewayHost } from "./state/use-startup-shell-controller";
 import {
@@ -148,6 +149,7 @@ import {
 } from "./surface-realm-broker";
 import { shellHistory } from "./surface-realm-channel";
 import { TutorialConductorMount } from "./tutorial/TutorialConductor";
+import { isElizaCloudControlPlaneAgentlessBase } from "./utils/cloud-agent-base";
 import { confirmDesktopAction } from "./utils/desktop-dialogs";
 import { VoiceSelfTestShell } from "./voice/voice-selftest/VoiceSelfTestShell";
 import { VoiceWorkbenchShell } from "./voice/voice-selftest/VoiceWorkbenchShell";
@@ -2166,12 +2168,20 @@ export function App() {
     uiLanguage,
   ]);
 
-  // Keep probing auth during first-run-required. A remote, already-initialized
-  // backend can return 401 for the protected first-run status route before this
-  // browser has an owner session. In that case the password wall must win over
-  // the in-chat Cloud onboarding surface.
+  const isAgentlessCloudOrigin =
+    typeof window !== "undefined" &&
+    isElizaCloudControlPlaneAgentlessBase(window.location.origin);
+
+  // Existing remote backends still probe during first-run so a real 401 can
+  // surface their password wall. The shared Cloud app defers that probe because
+  // its in-chat first-run conductor owns Cloud sign-in; its same-origin 401 is
+  // not evidence that this browser is on a dedicated agent host.
   const { state: authState, refetch: refetchAuth } = useAuthStatus({
-    skip: !isShellPaintableNow || isPopout,
+    skip:
+      !isShellPaintableNow ||
+      isPopout ||
+      (isAgentlessCloudOrigin &&
+        firstRunOwnsLoginSurface(startupCoordinator.phase, firstRunComplete)),
   });
   // #15132: after a dedicated cloud agent's container upgrade the persisted
   // agent credential is stale (every agent-subdomain call 401s) while the cloud
@@ -2698,8 +2708,12 @@ export function App() {
   if (
     isShellPaintableNow &&
     !isPopout &&
-    (!firstRunOwnsLoginSurface(startupCoordinator.phase, firstRunComplete) ||
-      authState.phase === "unauthenticated")
+    topLevelAuthGateOwnsSurface(
+      startupCoordinator.phase,
+      firstRunComplete,
+      authState.phase,
+      isAgentlessCloudOrigin,
+    )
   ) {
     if (
       authProbeShouldHoldShell(

--- a/packages/ui/src/api/client-cloud-agent-base.test.ts
+++ b/packages/ui/src/api/client-cloud-agent-base.test.ts
@@ -158,6 +158,14 @@ describe("cloud-agent-base helpers", () => {
 
   it("isElizaCloudControlPlaneAgentlessBase is host-checked (only cloud hosts)", () => {
     expect(
+      isElizaCloudControlPlaneAgentlessBase("https://app.elizacloud.ai"),
+    ).toBe(true);
+    expect(
+      isElizaCloudControlPlaneAgentlessBase(
+        "https://app-staging.elizacloud.ai",
+      ),
+    ).toBe(true);
+    expect(
       isElizaCloudControlPlaneAgentlessBase("https://api.elizacloud.ai"),
     ).toBe(true);
     expect(
@@ -173,6 +181,11 @@ describe("cloud-agent-base helpers", () => {
     // A raw dedicated bridge (non-cloud host) is NOT agentless.
     expect(
       isElizaCloudControlPlaneAgentlessBase("http://195.201.57.227:19411"),
+    ).toBe(false);
+    expect(
+      isElizaCloudControlPlaneAgentlessBase(
+        "https://ff479713-41c8-4d82-92b8-5f0881062189.elizacloud.ai",
+      ),
     ).toBe(false);
   });
 });

--- a/packages/ui/src/state/top-level-auth-gate.test.ts
+++ b/packages/ui/src/state/top-level-auth-gate.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 import {
   authProbeShouldHoldShell,
   firstRunOwnsLoginSurface,
+  topLevelAuthGateOwnsSurface,
 } from "./top-level-auth-gate";
 
 describe("firstRunOwnsLoginSurface — top-level LoginView vs in-chat onboarding", () => {
@@ -41,6 +42,42 @@ describe("firstRunOwnsLoginSurface — top-level LoginView vs in-chat onboarding
     // or a normal session could be locked out of the top-level login.
     expect(firstRunOwnsLoginSurface("ready", undefined)).toBe(false);
     expect(firstRunOwnsLoginSurface("ready", null)).toBe(false);
+  });
+});
+
+describe("topLevelAuthGateOwnsSurface — first-run 401 routing", () => {
+  it("keeps a shared Cloud app 401 inside in-chat onboarding", () => {
+    expect(
+      topLevelAuthGateOwnsSurface(
+        "first-run-required",
+        false,
+        "unauthenticated",
+        true,
+      ),
+    ).toBe(false);
+    expect(
+      topLevelAuthGateOwnsSurface("hydrating", false, "unauthenticated", true),
+    ).toBe(false);
+  });
+
+  it("lets a real agent backend 401 override optimistic first-run", () => {
+    expect(
+      topLevelAuthGateOwnsSurface(
+        "first-run-required",
+        false,
+        "unauthenticated",
+        false,
+      ),
+    ).toBe(true);
+  });
+
+  it("activates normally after first-run on every origin", () => {
+    expect(topLevelAuthGateOwnsSurface("ready", true, "loading", true)).toBe(
+      true,
+    );
+    expect(
+      topLevelAuthGateOwnsSurface("ready", true, "authenticated", false),
+    ).toBe(true);
   });
 });
 

--- a/packages/ui/src/state/top-level-auth-gate.ts
+++ b/packages/ui/src/state/top-level-auth-gate.ts
@@ -29,6 +29,23 @@ export function firstRunOwnsLoginSurface(
 }
 
 /**
+ * Whether App's top-level auth gate owns the current surface. A resolved 401
+ * may override first-run for real agent backends, but never for the agentless
+ * Cloud app origin whose first-run conductor is the Cloud login surface.
+ */
+export function topLevelAuthGateOwnsSurface(
+  coordinatorPhase: string,
+  firstRunComplete: boolean | null | undefined,
+  authPhase: string,
+  isAgentlessCloudOrigin: boolean,
+): boolean {
+  return (
+    !firstRunOwnsLoginSurface(coordinatorPhase, firstRunComplete) ||
+    (authPhase === "unauthenticated" && !isAgentlessCloudOrigin)
+  );
+}
+
+/**
  * Whether the main shell should stay unmounted while the top-level auth probe is
  * still deciding. Returning users with an expired Cloud session can have a
  * persisted agent base in localStorage; mounting the shell before `/api/auth/me`


### PR DESCRIPTION
# Relates to

Regression introduced by #16090; launch QA context: #13406.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and scoped verification were run after sync. Full `bun run verify` is blocked by the existing repository-wide type-safety ratchet failure recorded below.
- [x] A reviewer can confirm the affected mobile flow from the attached before/after screenshots, walkthrough, visible-text review, and frontend log.

# Sync with develop

- [x] Rebased onto `72dafb3668df5f34b2df4fff3c1642e0ed4618d2`; zero conflicts.
- [ ] `bun run verify` passes post-sync. See the exact unrelated blocker under **Known gaps / failures**.

# Risks

Low. The change only distinguishes bare Eliza Cloud app origins from dedicated agent origins while first-run owns the login surface. Dedicated-agent 401 behavior is retained and covered by tests.

# Background

## What does this PR do?

Prevents a same-origin unauthenticated auth snapshot on `app.elizacloud.ai` and `app-staging.elizacloud.ai` from replacing in-chat Cloud onboarding with the dedicated-agent “Open this agent from Eliza Cloud” notice.

It reuses the existing control-plane host classifier. Bare Cloud app origins defer the auth probe while first-run owns the surface; dedicated agent origins continue probing and can surface their password wall on a real 401.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No documentation change is required; this restores the intended onboarding routing contract.

# Testing

## Where should a reviewer start?

- `packages/ui/src/App.tsx`
- `packages/ui/src/state/top-level-auth-gate.ts`
- `packages/ui/src/state/top-level-auth-gate.test.ts`

## Detailed testing steps

1. Open a clean browser context at the staging or production Cloud app origin.
2. Verify the in-chat first-run Cloud sign-in surface appears.
3. Verify the dedicated-agent “Open this agent from Eliza Cloud” notice does not appear.
4. Open a real dedicated agent origin without a valid owner session.
5. Verify its 401 still routes to the dedicated auth wall.

Automated checks:
- `bunx vitest run --config ./vitest.config.ts src/App.navigate-view-wiring.test.tsx src/state/top-level-auth-gate.test.ts src/api/client-cloud-agent-base.test.ts`: 37/37 passed.
- Enforced changed-file coverage: `App.tsx` 64.30%; `top-level-auth-gate.ts` 100%.
- `bun run --cwd packages/ui typecheck`: passed.
- Biome on all five changed files: passed.
- `git diff --check`: passed.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16157-before-mobile.png)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16157-after-mobile.png)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence/16157-after-mobile-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend behavior changes
<!-- evidence-row:frontend-logs -->
- [x] [16157-after-mobile-readout.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16157-after-mobile-readout.txt)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent or model behavior changes
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain artifacts are produced

# Evidence Details

## Real LLM-call trajectory

N/A - this is client-side first-run/auth surface routing only.

## Backend + frontend logs

Backend: N/A - no backend behavior changed.

Frontend: [fresh mobile visible-text and network readout](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16157-after-mobile-readout.txt). Expected unauthenticated 401s remain on protected endpoints; the fixed client keeps ownership in the first-run conductor.

## Screenshots (before / after) + video walkthrough

### Before

[Live staging mobile regression](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16157-before-mobile.png): a fresh shared-app session incorrectly renders the dedicated-agent notice.

### After

[Fixed mobile flow](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16157-after-mobile.png): the same clean session remains in in-chat Cloud onboarding.

### Walkthrough video

[Fresh-load mobile walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16157-after-mobile-walkthrough.mp4).

## Known gaps / failures

`bun run verify` reaches the existing repository type-safety ratchet and fails on current `develop` before package checks:

```text
[type-safety-ratchet] `?? ""` (core/agent/app-core): 582 current > 579 baseline
```

This branch does not touch any listed core/agent files. The changed UI package passes its focused tests, typecheck, Biome check, and diff check.

<!-- evidence-row:ocr-review -->
- [x] [16157-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16157-ocr-review.txt)
