### PR TITLE
fix(app): unblock affected-typecheck — @elizaos/ui ChatWidgetHarness resolution

### DIFF
--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -2986,7 +2986,7 @@ const ChatWidgetHarness = lazy(async () => {
   if (__ELIZA_CHAT_UI_HARNESS__ !== true) {
     throw new Error("ChatWidgetHarness is disabled in this build");
   }
-  const mod = await import("@elizaos/ui");
+  const mod = await import("@elizaos/ui/components/chat/ChatWidgetHarness");
   return { default: mod.ChatWidgetHarness };
 });
 


### PR DESCRIPTION
## Summary

`@elizaos/app#typecheck` was failing repo-wide in CI ("Run typecheck (affected)"), blocking PRs #16115, #16150, and any other PR touching the affected cone that includes `@elizaos/app`.

## Root cause

`packages/app/src/main.tsx` lazily loads the (build-flag-gated, simulator-only)
chat gallery via `const mod = await import("@elizaos/ui")` — a bare-specifier
dynamic import of the full `@elizaos/ui` barrel — then reads
`mod.ChatWidgetHarness`.

`ChatWidgetHarness` is a real, correctly-declared named export of
`packages/ui/src/index.ts` (added by #16151, merged into `develop`) and is
present both in `src/index.ts` and in the built `dist/index.d.ts`. However,
reproducing the CI command exactly
(`node packages/scripts/run-turbo.mjs run typecheck --filter=@elizaos/app`,
after `bun run build:core`) against a clean `origin/develop` worktree fails
locally with the identical `TS2339` on `src/main.tsx(2990,25)`.

Using the TypeScript compiler API directly against `packages/app`'s own
`tsconfig.typecheck.json`/program to inspect the resolved type of the `@elizaos/ui`
bare-specifier module at that call site shows the checker computes a truncated,
~69-property synthetic type for it that includes only names sourced through
`export *` re-export chains in `packages/ui/src/index.ts` — every *explicitly
named* re-export (`export { X } from "./Y"`, including `ChatWidgetHarness` at
`packages/ui/src/index.ts:160`) is missing from that synthetic type, even
though `checker.getExportsOfModule()` on the real `index.ts` module symbol
correctly returns all ~3265 exports including `ChatWidgetHarness`. The same
truncation reproduces with a completely isolated probe file and with both a
type-only static import and the dynamic `import()` form — it is specific to
resolving the **bare** `@elizaos/ui` package specifier as a value/type
position in this program, not to `ChatWidgetHarness` itself, `tsgo`, or CI
infra (stock `typescript@6.0.3`'s `tsc` reproduces it too).

Given every other `@elizaos/ui` import in `main.tsx` already uses a concrete
subpath (`@elizaos/ui/App`, `@elizaos/ui/api`, `@elizaos/ui/bridge`, …) and the
package publishes a `./components/*` export subpath, the fix routes this one
remaining bare-specifier import through the same concrete-subpath pattern
instead of working around (or chasing) the underlying barrel-resolution
behavior.

## Fix

Load the harness module by its concrete subpath instead of the full barrel:

```diff
-  const mod = await import("@elizaos/ui");
+  const mod = await import("@elizaos/ui/components/chat/ChatWidgetHarness");
   return { default: mod.ChatWidgetHarness };
```

`@elizaos/ui/components/*` is an existing published export subpath
(`packages/ui/package.json`), and `packages/app/tsconfig.typecheck.json`
already maps `@elizaos/ui/*` to `../ui/src/*`, so this resolves cleanly under
both the source-mode typecheck config and the published package.

## Verification

Reproduced the exact CI failure, then the fix, in an isolated `origin/develop`
worktree:

```
$ bun run build:core
$ node packages/scripts/run-turbo.mjs run typecheck --filter=@elizaos/app --concurrency=4
# before fix: @elizaos/app:typecheck: src/main.tsx(2990,25): error TS2339: ...
# after fix:  Tasks: 77 successful, 77 total
```

Also confirmed with stock `typescript@6.0.3` `tsc --noEmit -p tsconfig.typecheck.json` directly (same before/after result), independent of `tsgo`.

## Evidence

<!-- evidence-row:trajectories -->
N/A - infra/typecheck-only fix, no agent/action/prompt/model behavior changed.

<!-- evidence-row:backend-logs -->
N/A - no backend runtime code changed; this is a build-time type resolution fix.

<!-- evidence-row:frontend-logs -->
N/A - no runtime UI behavior changed (module specifier only, same runtime file/export).

<!-- evidence-row:screenshots -->
N/A - no visual/UI change; `ChatWidgetHarness` is a dev-only, build-flag-gated (`__ELIZA_CHAT_UI_HARNESS__`) simulator chat gallery whose rendered output and code path are byte-identical after the fix.

<!-- evidence-row:video -->
N/A - no visual/UI change (see above).

<!-- evidence-row:per-platform -->
N/A - typecheck-only change; not a native/mobile/desktop capture surface.

<!-- evidence-row:domain-artifacts -->
Failing CI runs this PR unblocks:
- https://github.com/elizaOS/eliza/actions/runs/29171050004/job/86592203064 (PR #16115)
- https://github.com/elizaOS/eliza/actions/runs/29170432908 (PR #16150, commit d9340c9)

Local reproduction + fix verification transcript:
```
@elizaos/app:typecheck: src/main.tsx(2990,25): error TS2339: Property 'ChatWidgetHarness' does not exist on type '{ AGENT_READY_EVENT: string; ...; default: typeof import("@elizaos/ui"); }'.
error: script "typecheck" exited with code 1
```
→ after fix:
```
Tasks:    77 successful, 77 total
Cached:    76 cached, 77 total
```
