### PR TITLE
fix(cloud): keep staging dedicated ingress environment-scoped

### DIFF
--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -129,6 +129,10 @@ jobs:
       HEADSCALE_API_URL: ${{ vars.HEADSCALE_API_URL }}
       HEADSCALE_PUBLIC_URL: ${{ vars.HEADSCALE_PUBLIC_URL }}
       HEADSCALE_API_KEY: ${{ secrets.HEADSCALE_API_KEY }}
+      # Base64 private key used by the daemon to reach dedicated-agent nodes.
+      # Keep this in the protected environment instead of relying on a
+      # hand-copied file that can drift or disappear when the CP host is rebuilt.
+      CONTAINERS_SSH_KEY: ${{ secrets.CONTAINERS_SSH_KEY }}
       # Sandbox-registry Redis (TCP redis:// proxy, sandbox-reachable — never a
       # *.railway.internal host) so provisioned sandboxes self-register and
       # Discord/Telegram inbound routing works (#8621 / #8756). Reconciled into
@@ -245,7 +249,7 @@ jobs:
           username: deploy
           key: ${{ env.DEPLOY_SSH_KEY }}
           command_timeout: 10m
-          envs: DEPLOY_BRANCH,DEPLOY_SHA,SYSTEMD_UNIT,HEADSCALE_API_URL,HEADSCALE_PUBLIC_URL,HEADSCALE_API_KEY,SANDBOX_REGISTRY_REDIS_URL,DATABASE_URL,SECRETS_MASTER_KEY,ELIZA_AGENT_IMAGE,ELIZA_CLOUD_AGENT_BASE_DOMAIN
+          envs: DEPLOY_BRANCH,DEPLOY_SHA,SYSTEMD_UNIT,HEADSCALE_API_URL,HEADSCALE_PUBLIC_URL,HEADSCALE_API_KEY,CONTAINERS_SSH_KEY,SANDBOX_REGISTRY_REDIS_URL,DATABASE_URL,SECRETS_MASTER_KEY,ELIZA_AGENT_IMAGE,ELIZA_CLOUD_AGENT_BASE_DOMAIN
           script: |
             set -euo pipefail
             echo "=== Deploying eliza-provisioning-worker (branch: $DEPLOY_BRANCH sha: $DEPLOY_SHA) ==="
@@ -417,6 +421,7 @@ jobs:
               "HEADSCALE_API_URL=$HEADSCALE_API_URL" \
               "HEADSCALE_PUBLIC_URL=$HEADSCALE_PUBLIC_URL" \
               "HEADSCALE_API_KEY=$HEADSCALE_API_KEY" \
+              "CONTAINERS_SSH_KEY=$CONTAINERS_SSH_KEY" \
               "SANDBOX_REGISTRY_REDIS_URL=$SANDBOX_REGISTRY_REDIS_URL" \
               "DATABASE_URL=$DATABASE_URL" \
               "SECRETS_MASTER_KEY=$SECRETS_MASTER_KEY" \

--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -164,6 +164,10 @@ jobs:
       # image ref is auditable config) to roll the fleet pin via deploy;
       # leave it unset to preserve whatever is hand-set on the box.
       ELIZA_AGENT_IMAGE: ${{ vars.ELIZA_AGENT_IMAGE }}
+      # The edge Worker forwards the original per-agent host to this daemon.
+      # Keep the daemon's parser on the same environment-specific suffix or a
+      # staging host (`<uuid>.staging.elizacloud.ai`) is rejected as malformed.
+      ELIZA_CLOUD_AGENT_BASE_DOMAIN: ${{ needs.determine-env.outputs.environment == 'production' && 'elizacloud.ai' || 'staging.elizacloud.ai' }}
     steps:
       - name: Check deploy configuration
         id: deploy_config
@@ -241,7 +245,7 @@ jobs:
           username: deploy
           key: ${{ env.DEPLOY_SSH_KEY }}
           command_timeout: 10m
-          envs: DEPLOY_BRANCH,DEPLOY_SHA,SYSTEMD_UNIT,HEADSCALE_API_URL,HEADSCALE_PUBLIC_URL,HEADSCALE_API_KEY,SANDBOX_REGISTRY_REDIS_URL,DATABASE_URL,SECRETS_MASTER_KEY,ELIZA_AGENT_IMAGE
+          envs: DEPLOY_BRANCH,DEPLOY_SHA,SYSTEMD_UNIT,HEADSCALE_API_URL,HEADSCALE_PUBLIC_URL,HEADSCALE_API_KEY,SANDBOX_REGISTRY_REDIS_URL,DATABASE_URL,SECRETS_MASTER_KEY,ELIZA_AGENT_IMAGE,ELIZA_CLOUD_AGENT_BASE_DOMAIN
           script: |
             set -euo pipefail
             echo "=== Deploying eliza-provisioning-worker (branch: $DEPLOY_BRANCH sha: $DEPLOY_SHA) ==="
@@ -416,7 +420,8 @@ jobs:
               "SANDBOX_REGISTRY_REDIS_URL=$SANDBOX_REGISTRY_REDIS_URL" \
               "DATABASE_URL=$DATABASE_URL" \
               "SECRETS_MASTER_KEY=$SECRETS_MASTER_KEY" \
-              "ELIZA_AGENT_IMAGE=$ELIZA_AGENT_IMAGE"; do
+              "ELIZA_AGENT_IMAGE=$ELIZA_AGENT_IMAGE" \
+              "ELIZA_CLOUD_AGENT_BASE_DOMAIN=$ELIZA_CLOUD_AGENT_BASE_DOMAIN"; do
               key="${kv%%=*}"
               val="${kv#*=}"
               [ -n "$val" ] || continue
@@ -437,9 +442,15 @@ jobs:
           username: deploy
           key: ${{ env.DEPLOY_SSH_KEY }}
           command_timeout: 5m
-          envs: SYSTEMD_UNIT
+          envs: SYSTEMD_UNIT,ELIZA_CLOUD_AGENT_BASE_DOMAIN
           script: |
             set -euo pipefail
+            ENV_FILE=/opt/eliza/cloud/.env.local
+            ACTUAL_AGENT_BASE_DOMAIN=$(sudo awk -F= '$1=="ELIZA_CLOUD_AGENT_BASE_DOMAIN" { value=$2 } END { print value }' "$ENV_FILE")
+            if [ "$ACTUAL_AGENT_BASE_DOMAIN" != "$ELIZA_CLOUD_AGENT_BASE_DOMAIN" ]; then
+              echo "::error::Agent router base-domain drift: expected $ELIZA_CLOUD_AGENT_BASE_DOMAIN, found ${ACTUAL_AGENT_BASE_DOMAIN:-<missing>}."
+              exit 1
+            fi
             # The worker logs to journald via systemd's stdout/stderr capture.
             # Info-level logs are filtered unless VERBOSE_LOGGING=true, so we
             # rely on systemd's own signals: process is active AND no fatal

--- a/packages/scripts/cloud/admin/daemons/agent-router.test.ts
+++ b/packages/scripts/cloud/admin/daemons/agent-router.test.ts
@@ -326,6 +326,12 @@ describe("extractAgentIdFromHost", () => {
     expect(
       extractAgentIdFromHost(`${agentId}.elizacloud.ai:443`, "elizacloud.ai"),
     ).toBe(agentId);
+    expect(
+      extractAgentIdFromHost(
+        `${agentId}.staging.elizacloud.ai`,
+        "staging.elizacloud.ai",
+      ),
+    ).toBe(agentId);
   });
 
   it("rejects root, unrelated, and malformed hosts", () => {

--- a/packages/scripts/cloud/admin/daemons/provisioning-worker-env-reconcile.test.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker-env-reconcile.test.ts
@@ -24,6 +24,7 @@ const workflow = readFileSync(workflowPath, "utf8");
 const ENV_KEY = "SANDBOX_REGISTRY_REDIS_URL";
 const FIELD_ENCRYPTION_KEY = "SECRETS_MASTER_KEY";
 const BRIDGE_FALLBACK_KEY = "AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK";
+const AGENT_BASE_DOMAIN_KEY = "ELIZA_CLOUD_AGENT_BASE_DOMAIN";
 
 // The reconcile loop runs the workflow's VERBATIM bash, which uses GNU
 // `sed -i "/^KEY=/d"` (no backup-suffix argument). BSD/macOS `sed -i` parses
@@ -104,6 +105,25 @@ describe("deploy-eliza-provisioning-worker.yml SANDBOX_REGISTRY_REDIS_URL wiring
     expect(secretLoopIdx).toBeGreaterThan(-1);
     expect(lanePinIdx).toBeLessThan(scrubIdx);
     expect(scrubIdx).toBeLessThan(secretLoopIdx);
+  });
+
+  it("pins the agent router to the protected deployment environment", () => {
+    expect(workflow).toContain(
+      `${AGENT_BASE_DOMAIN_KEY}: \${{ needs.determine-env.outputs.environment == 'production' && 'elizacloud.ai' || 'staging.elizacloud.ai' }}`,
+    );
+    const deployEnvs = workflow
+      .split("\n")
+      .find(
+        (line) =>
+          line.trim().startsWith("envs:") && line.includes("DEPLOY_SHA"),
+      );
+    expect(deployEnvs).toContain(AGENT_BASE_DOMAIN_KEY);
+    expect(workflow).toContain(
+      `"${AGENT_BASE_DOMAIN_KEY}=$${AGENT_BASE_DOMAIN_KEY}"`,
+    );
+    expect(workflow).toContain(
+      "Agent router base-domain drift: expected $ELIZA_CLOUD_AGENT_BASE_DOMAIN",
+    );
   });
 });
 

--- a/packages/scripts/cloud/admin/daemons/provisioning-worker-env-reconcile.test.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker-env-reconcile.test.ts
@@ -25,6 +25,7 @@ const ENV_KEY = "SANDBOX_REGISTRY_REDIS_URL";
 const FIELD_ENCRYPTION_KEY = "SECRETS_MASTER_KEY";
 const BRIDGE_FALLBACK_KEY = "AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK";
 const AGENT_BASE_DOMAIN_KEY = "ELIZA_CLOUD_AGENT_BASE_DOMAIN";
+const CONTAINERS_SSH_KEY = "CONTAINERS_SSH_KEY";
 
 // The reconcile loop runs the workflow's VERBATIM bash, which uses GNU
 // `sed -i "/^KEY=/d"` (no backup-suffix argument). BSD/macOS `sed -i` parses
@@ -90,6 +91,22 @@ describe("deploy-eliza-provisioning-worker.yml SANDBOX_REGISTRY_REDIS_URL wiring
     expect(envsLine).toBeDefined();
     expect(workflow).toContain(
       `"${FIELD_ENCRYPTION_KEY}=$${FIELD_ENCRYPTION_KEY}"`,
+    );
+  });
+
+  it("reconciles the protected agent-node SSH key into the daemon environment", () => {
+    expect(workflow).toContain(
+      `${CONTAINERS_SSH_KEY}: \${{ secrets.${CONTAINERS_SSH_KEY} }}`,
+    );
+    const envsLine = workflow
+      .split("\n")
+      .find(
+        (line) =>
+          line.trim().startsWith("envs:") && line.includes(CONTAINERS_SSH_KEY),
+      );
+    expect(envsLine).toBeDefined();
+    expect(workflow).toContain(
+      `"${CONTAINERS_SSH_KEY}=$${CONTAINERS_SSH_KEY}"`,
     );
   });
 

--- a/packages/ui/src/api/client-cloud-agent-base.test.ts
+++ b/packages/ui/src/api/client-cloud-agent-base.test.ts
@@ -11,6 +11,8 @@ vi.mock("@capacitor/core", () => ({
 
 import {
   buildCloudSharedAgentApiBase,
+  buildDedicatedCloudAgentApiBase,
+  dedicatedCloudAgentIdFromBase,
   isCloudAgentsCollectionBase,
   isElizaCloudControlPlaneAgentlessBase,
 } from "../utils/cloud-agent-base";
@@ -137,6 +139,40 @@ describe("cloud-agent-base helpers", () => {
     expect(
       buildCloudSharedAgentApiBase("https://api.elizacloud.ai/", "abc"),
     ).toBe("https://api.elizacloud.ai/api/v1/eliza/agents/abc");
+  });
+
+  it("buildDedicatedCloudAgentApiBase preserves production as the default", () => {
+    expect(buildDedicatedCloudAgentApiBase("agent-123")).toBe(
+      "https://agent-123.elizacloud.ai",
+    );
+    expect(
+      buildDedicatedCloudAgentApiBase(
+        "agent-123",
+        "https://api.elizacloud.ai/api/v1",
+      ),
+    ).toBe("https://agent-123.elizacloud.ai");
+  });
+
+  it("buildDedicatedCloudAgentApiBase keeps staging agents on staging ingress", () => {
+    for (const cloudBase of [
+      "https://staging.elizacloud.ai",
+      "https://api-staging.elizacloud.ai/api/v1",
+      "https://app-staging.elizacloud.ai",
+      "https://existing.staging.elizacloud.ai",
+    ]) {
+      expect(buildDedicatedCloudAgentApiBase("agent-123", cloudBase)).toBe(
+        "https://agent-123.staging.elizacloud.ai",
+      );
+    }
+  });
+
+  it("dedicatedCloudAgentIdFromBase extracts production and staging ids", () => {
+    expect(
+      dedicatedCloudAgentIdFromBase("https://agent-123.elizacloud.ai"),
+    ).toBe("agent-123");
+    expect(
+      dedicatedCloudAgentIdFromBase("https://agent-123.staging.elizacloud.ai"),
+    ).toBe("agent-123");
   });
 
   it("isCloudAgentsCollectionBase flags blank/bare/collection bases", () => {

--- a/packages/ui/src/api/client-cloud-connect-mock-cloud.test.ts
+++ b/packages/ui/src/api/client-cloud-connect-mock-cloud.test.ts
@@ -74,6 +74,7 @@ type MockAgent = {
   pollsSinceResume: number;
   /** After running: how many dedicated-proxy calls still answer 202. */
   proxy202sRemaining: number;
+  executionTier: "shared" | "dedicated-always";
   /**
    * Proxy-readiness window (#15901): how many dedicated-proxy calls answer a
    * flat router 404 even though the control-plane record already says
@@ -107,6 +108,7 @@ function agentDto(agent: MockAgent) {
         : agent.webUiUrl,
     bridgeUrl: agent.bridgeUrl,
     errorMessage: agent.errorMessage ?? null,
+    executionTier: agent.executionTier,
     createdAt: "2026-07-01T00:00:00.000Z",
     updatedAt: "2026-07-01T00:00:00.000Z",
   };
@@ -425,6 +427,7 @@ describe("mock-cloud connect e2e — dedicated cold boot + shared chat bridge", 
       resumeRequested: false,
       pollsSinceResume: 0,
       proxy202sRemaining: 0,
+      executionTier: "dedicated-always",
       ...overrides,
     };
     state.agents.set(agent.id, agent);
@@ -583,6 +586,7 @@ describe("mock-cloud connect e2e — dedicated cold boot + shared chat bridge", 
       resumeRequested: false,
       pollsSinceResume: 0,
       proxy202sRemaining: 0,
+      executionTier: "shared",
     };
     state.agents.set(shared.id, shared);
 
@@ -647,6 +651,7 @@ describe("mock-cloud connect e2e — dedicated cold boot + shared chat bridge", 
       resumeRequested: false,
       pollsSinceResume: 0,
       proxy202sRemaining: 0,
+      executionTier: "dedicated-always",
     };
     state.agents.set(other.id, other);
 
@@ -680,6 +685,7 @@ describe("mock-cloud connect e2e — dedicated cold boot + shared chat bridge", 
       resumeRequested: false,
       pollsSinceResume: 0,
       proxy202sRemaining: 0,
+      executionTier: "shared",
     };
     state.agents.set(shared.id, shared);
     state.conversations.set("agent-shared:agent-shared", {
@@ -751,6 +757,7 @@ describe("mock-cloud connect e2e — dedicated cold boot + shared chat bridge", 
       resumeRequested: false,
       pollsSinceResume: 0,
       proxy202sRemaining: 0,
+      executionTier: "shared",
     };
     state.agents.set(shared.id, shared);
     seedDedicated({

--- a/packages/ui/src/api/client-cloud-direct-auth.test.ts
+++ b/packages/ui/src/api/client-cloud-direct-auth.test.ts
@@ -135,6 +135,38 @@ describe("ElizaClient direct Cloud auth on native", () => {
     );
   });
 
+  it("keeps a staging dedicated agent login on the staging auth host, not the production apex", async () => {
+    // Regression for the staging dedicated-ingress fix: a session whose agent
+    // base is `<uuid>.staging.elizacloud.ai` belongs to the STAGING tenant.
+    // Auth for it must ride the staging API/auth hosts — a hop to the
+    // production apex would mint a production session that can never see the
+    // staging agent.
+    capacitorMocks.post.mockResolvedValue({ status: 200, data: {} });
+
+    const client = new ElizaClient(
+      "https://0b5fca39-8d55-4c96-a1a3-000000000000.staging.elizacloud.ai",
+    );
+    const result = await client.cloudLoginDirect(
+      "https://staging.elizacloud.ai",
+    );
+
+    expect(capacitorMocks.post).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://api-staging.elizacloud.ai/api/auth/cli-session",
+      }),
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        ok: true,
+        apiBase: "https://api-staging.elizacloud.ai",
+        browserUrl: expect.stringMatching(
+          /^https:\/\/staging\.elizacloud\.ai\/auth\/cli-login\?session=/,
+        ),
+      }),
+    );
+    expectNoLocalPersistOrStatusProbe();
+  });
+
   it("polls native CLI sessions through the Cloud API host", async () => {
     capacitorMocks.get.mockResolvedValue({
       status: 200,

--- a/packages/ui/src/api/client-cloud-direct-auth.test.ts
+++ b/packages/ui/src/api/client-cloud-direct-auth.test.ts
@@ -234,6 +234,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
             agentName: "My Agent",
             status: "running",
             bridgeUrl: "https://agent-1.example.test",
+            executionTier: "dedicated-always",
           },
         ],
       },
@@ -259,6 +260,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
           agent_name: "My Agent",
           status: "running",
           bridge_url: "https://agent-1.example.test",
+          execution_tier: "dedicated-always",
         }),
       ],
     });

--- a/packages/ui/src/api/client-cloud-select-or-provision.test.ts
+++ b/packages/ui/src/api/client-cloud-select-or-provision.test.ts
@@ -209,6 +209,33 @@ describe("selectOrProvisionCloudAgent — never duplicate on a failed lookup", (
     expect(createCloudCompatAgent).not.toHaveBeenCalled();
   });
 
+  it("converts a staging shared-style agent URL to staging dedicated ingress", async () => {
+    const { client, getCloudCompatAgents, createCloudCompatAgent } =
+      fakeClient();
+    getCloudCompatAgents.mockResolvedValue({
+      success: true,
+      data: [
+        makeAgent({
+          agent_id: "agent-staging",
+          bridge_url: null,
+          web_ui_url:
+            "https://api-staging.elizacloud.ai/api/v1/eliza/agents/agent-staging",
+          webUiUrl:
+            "https://api-staging.elizacloud.ai/api/v1/eliza/agents/agent-staging",
+        }),
+      ],
+    });
+
+    const result = await client.selectOrProvisionCloudAgent({
+      ...BASE_OPTS,
+      cloudApiBase: "https://api-staging.elizacloud.ai/api/v1",
+    });
+
+    expect(result.created).toBe(false);
+    expect(result.apiBase).toBe("https://agent-staging.staging.elizacloud.ai");
+    expect(createCloudCompatAgent).not.toHaveBeenCalled();
+  });
+
   it("does NOT provision when the list fetch throws (transient/network error)", async () => {
     const { client, getCloudCompatAgents, createCloudCompatAgent } =
       fakeClient();

--- a/packages/ui/src/api/client-cloud-select-or-provision.test.ts
+++ b/packages/ui/src/api/client-cloud-select-or-provision.test.ts
@@ -44,6 +44,7 @@ function makeAgent(
     database_status: "ok",
     error_message: null,
     last_heartbeat_at: null,
+    execution_tier: "dedicated-always",
     ...overrides,
   };
 }
@@ -209,7 +210,7 @@ describe("selectOrProvisionCloudAgent — never duplicate on a failed lookup", (
     expect(createCloudCompatAgent).not.toHaveBeenCalled();
   });
 
-  it("converts a staging shared-style agent URL to staging dedicated ingress", async () => {
+  it("converts an adapter-shaped URL for a dedicated staging record to dedicated ingress", async () => {
     const { client, getCloudCompatAgents, createCloudCompatAgent } =
       fakeClient();
     getCloudCompatAgents.mockResolvedValue({
@@ -234,6 +235,88 @@ describe("selectOrProvisionCloudAgent — never duplicate on a failed lookup", (
     expect(result.created).toBe(false);
     expect(result.apiBase).toBe("https://agent-staging.staging.elizacloud.ai");
     expect(createCloudCompatAgent).not.toHaveBeenCalled();
+  });
+
+  it("keeps an explicit shared staging record on the shared adapter", async () => {
+    const { client, getCloudCompatAgents, createCloudCompatAgent } =
+      fakeClient();
+    getCloudCompatAgents.mockResolvedValue({
+      success: true,
+      data: [
+        makeAgent({
+          agent_id: "agent-shared",
+          bridge_url: null,
+          web_ui_url: null,
+          webUiUrl: null,
+          containerUrl: "",
+          execution_tier: "shared",
+        }),
+      ],
+    });
+
+    const result = await client.selectOrProvisionCloudAgent({
+      ...BASE_OPTS,
+      cloudApiBase: "https://api-staging.elizacloud.ai/api/v1",
+      preferSharedTier: true,
+    });
+
+    expect(result.created).toBe(false);
+    expect(result.executionTier).toBe("shared");
+    expect(result.apiBase).toBe(
+      "https://api-staging.elizacloud.ai/api/v1/eliza/agents/agent-shared",
+    );
+    expect(createCloudCompatAgent).not.toHaveBeenCalled();
+  });
+
+  it("force-creates a dedicated target instead of reusing an explicit shared bridge", async () => {
+    const {
+      client,
+      getCloudCompatAgents,
+      createCloudCompatAgent,
+      getCloudCompatAgent,
+    } = fakeClient();
+    getCloudCompatAgents.mockResolvedValue({
+      success: true,
+      data: [
+        makeAgent({
+          agent_id: "shared-bridge",
+          bridge_url: null,
+          web_ui_url: null,
+          webUiUrl: null,
+          containerUrl: "",
+          execution_tier: "shared",
+        }),
+      ],
+    });
+    createCloudCompatAgent.mockResolvedValue({
+      success: true,
+      data: {
+        agentId: "dedicated-target",
+        agentName: "Eliza",
+        jobId: "",
+        status: "running",
+        nodeId: null,
+        message: "",
+      },
+    });
+    getCloudCompatAgent.mockResolvedValue({
+      success: true,
+      data: makeAgent({
+        agent_id: "dedicated-target",
+        status: "running",
+        web_ui_url: "https://dedicated-target.elizacloud.ai",
+        webUiUrl: "https://dedicated-target.elizacloud.ai",
+      }),
+    });
+
+    const result = await client.selectOrProvisionCloudAgent(BASE_OPTS);
+
+    expect(createCloudCompatAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ forceCreate: true }),
+    );
+    expect(result.agentId).toBe("dedicated-target");
+    expect(result.apiBase).toBe("https://dedicated-target.elizacloud.ai");
+    expect(result.executionTier).toBe("dedicated-always");
   });
 
   it("does NOT provision when the list fetch throws (transient/network error)", async () => {

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -127,6 +127,8 @@ type DirectCloudAgent = {
   last_heartbeat_at?: string | null;
   agentConfig?: Record<string, unknown>;
   agent_config?: Record<string, unknown>;
+  executionTier?: string | null;
+  execution_tier?: string | null;
 };
 
 type DirectCloudJob = {
@@ -949,6 +951,10 @@ function toCloudCompatAgent(input: DirectCloudAgent): CloudCompatAgent {
       "unknown",
     error_message: input.errorMessage ?? input.error_message ?? null,
     last_heartbeat_at: input.lastHeartbeatAt ?? input.last_heartbeat_at ?? null,
+    execution_tier:
+      stringOrNull(input.executionTier) ??
+      stringOrNull(input.execution_tier) ??
+      null,
   };
 }
 
@@ -1534,6 +1540,7 @@ declare module "./client-base" {
        * Shared-runtime adapters continue to use the Steward session token.
        */
       requiresAgentPairing?: boolean;
+      executionTier?: string | null;
     }>;
     /**
      * Background shared→personal handoff for a freshly provisioned cloud agent:
@@ -3370,6 +3377,7 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
   const onProgress = options.onProgress;
   const resolvedCloudApiBase = resolveDirectCloudAuthApiBase(cloudApiBase);
   let forceCreateForTerminalAgents = false;
+  let forceCreatePastSharedAgents = false;
   // Ensure the direct-cloud requests below authenticate even on a cold boot,
   // where the resolved token may be empty (the caller always passes the session
   // token). Persist it through the canonical steward-session store so
@@ -3410,11 +3418,22 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
           "Couldn't reach Eliza Cloud to find your agents. Check your connection and try again.",
       );
     }
-    const chosen = pickPreferredCloudAgent(list.data, preferAgentId);
+    // Dedicated mode must not bind a temporary shared bridge as if it were a
+    // dedicated sandbox. The Cloud API exposes the authoritative tier; carry
+    // it through the compat model instead of guessing from URL presence. A
+    // shared-only organization needs forceCreate below so the backend reuse
+    // guard cannot hand the same bridge back to an always-on create request.
+    const eligibleAgents = preferSharedTier
+      ? list.data
+      : list.data.filter((agent) => agent.execution_tier !== "shared");
+    forceCreatePastSharedAgents =
+      !preferSharedTier &&
+      list.data.some((agent) => agent.execution_tier === "shared");
+    const chosen = pickPreferredCloudAgent(eligibleAgents, preferAgentId);
     forceCreateForTerminalAgents =
-      list.data.length > 0 &&
+      eligibleAgents.length > 0 &&
       !chosen &&
-      list.data.every(isTerminalFailedCloudAgent);
+      eligibleAgents.every(isTerminalFailedCloudAgent);
     if (chosen) {
       let agent = chosen;
       // A picked agent that is not `running` is a dedicated cold boot: shared
@@ -3441,7 +3460,9 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
         agent.bridge_url || agent.web_ui_url || agent.webUiUrl,
       );
       const useSharedAdapter = Boolean(
-        !hasDedicatedBase && (preferSharedTier || preferStewardAgentAdapter),
+        agent.execution_tier === "shared" ||
+          (!hasDedicatedBase &&
+            (preferSharedTier || preferStewardAgentAdapter)),
       );
       const apiBase = useSharedAdapter
         ? buildCloudSharedAgentApiBase(resolvedCloudApiBase, agent.agent_id)
@@ -3459,6 +3480,7 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
         bridgeUrl: agent.bridge_url,
         created: false,
         requiresAgentPairing: false,
+        executionTier: agent.execution_tier ?? null,
       };
     }
   }
@@ -3474,12 +3496,14 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
   // if that lookup fails or has no URL yet, fall back to the standard dedicated
   // subdomain for the known agent id.
   onProgress?.("creating", `Creating ${name}...`);
+  const mustForceCreate =
+    forceCreate ||
+    forceCreatePastSharedAgents ||
+    (forceCreateForTerminalAgents && !preferSharedTier);
   const created = await this.createCloudCompatAgent({
     agentName: name,
     ...(bio?.length ? { agentConfig: { bio } } : {}),
-    ...(forceCreate || (forceCreateForTerminalAgents && !preferSharedTier)
-      ? { forceCreate: true }
-      : {}),
+    ...(mustForceCreate ? { forceCreate: true } : {}),
     ...(preferSharedTier ? { preferSharedTier: true } : {}),
   });
   if (!created.success || !created.data.agentId) {
@@ -3494,7 +3518,9 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
     detailAgent?.bridge_url || detailAgent?.web_ui_url || detailAgent?.webUiUrl,
   );
   const useSharedAdapter = Boolean(
-    !detailHasDedicatedBase && (preferSharedTier || preferStewardAgentAdapter),
+    detailAgent?.execution_tier === "shared" ||
+      (!detailHasDedicatedBase &&
+        (preferSharedTier || preferStewardAgentAdapter)),
   );
   // A freshly-created dedicated agent's subdomain is populated immediately, but
   // its container takes ~30-120s to boot. When the caller wants a dedicated
@@ -3545,6 +3571,7 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
     // `true` so the pre-existing create UX is unchanged.
     created: created.created !== false,
     requiresAgentPairing: false,
+    executionTier: detailAgent?.execution_tier ?? null,
   };
 };
 

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -131,6 +131,11 @@ type DirectCloudAgent = {
   execution_tier?: string | null;
 };
 
+type CloudCompatAgentWithExecutionTier = CloudCompatAgent & {
+  /** Server-authoritative runtime placement. Older compat responses may omit it. */
+  execution_tier?: string | null;
+};
+
 type DirectCloudJob = {
   id?: string;
   jobId?: string;
@@ -907,7 +912,9 @@ function parseDirectCloudAgentCreateData(
   };
 }
 
-function toCloudCompatAgent(input: DirectCloudAgent): CloudCompatAgent {
+function toCloudCompatAgent(
+  input: DirectCloudAgent,
+): CloudCompatAgentWithExecutionTier {
   const id = stringOrNull(input.agentId) ?? requireString(input.id, "agent id");
   const agentName =
     stringOrNull(input.agentName) ?? stringOrNull(input.name) ?? id;
@@ -1220,7 +1227,7 @@ declare module "./client-base" {
     cloudDisconnect(): Promise<{ ok: boolean }>;
     getCloudCompatAgents(): Promise<{
       success: boolean;
-      data: CloudCompatAgent[];
+      data: CloudCompatAgentWithExecutionTier[];
       error?: string;
     }>;
     createCloudCompatAgent(opts: {
@@ -1274,7 +1281,7 @@ declare module "./client-base" {
     ): Promise<CloudCompatAgentProvisionResponse>;
     getCloudCompatAgent(agentId: string): Promise<{
       success: boolean;
-      data: CloudCompatAgent;
+      data: CloudCompatAgentWithExecutionTier;
     }>;
     getCloudCompatAgentManagedDiscord(agentId: string): Promise<{
       success: boolean;
@@ -3267,7 +3274,7 @@ export async function waitForCloudAgentRunning(
     timeoutMs?: number;
     onProgress?: (status: string, detail?: string) => void;
   },
-): Promise<CloudCompatAgent> {
+): Promise<CloudCompatAgentWithExecutionTier> {
   const { agentId, onProgress } = options;
   const pollIntervalMs = Math.max(
     50,
@@ -3334,11 +3341,11 @@ export async function waitForCloudAgentRunning(
  * deletion rows are unreusable.
  */
 function pickPreferredCloudAgent(
-  agents: CloudCompatAgent[],
+  agents: CloudCompatAgentWithExecutionTier[],
   preferAgentId?: string | null,
-): CloudCompatAgent | null {
+): CloudCompatAgentWithExecutionTier | null {
   if (!agents.length) return null;
-  const byNewest = (rows: CloudCompatAgent[]) =>
+  const byNewest = (rows: CloudCompatAgentWithExecutionTier[]) =>
     [...rows].sort((a, b) =>
       String(b.created_at).localeCompare(String(a.created_at)),
     );

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -3037,7 +3037,9 @@ function resolveDedicatedCloudAgentApiBase(args: {
 }): string {
   const resolved = resolveCloudAgentApiBase(args);
   if (!isDirectCloudSharedAgentBase(resolved)) return resolved;
-  return buildDedicatedCloudAgentApiBase(args.agentId) ?? resolved;
+  return (
+    buildDedicatedCloudAgentApiBase(args.agentId, args.cloudApiBase) ?? resolved
+  );
 }
 
 /**

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -3415,7 +3415,7 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
           // the error so the caller can retry rather than duplicate.
           return await this.getCloudCompatAgents().catch((cause) => ({
             success: false as const,
-            data: [] as CloudCompatAgent[],
+            data: [] as CloudCompatAgentWithExecutionTier[],
             error: cause instanceof Error ? cause.message : undefined,
           }));
         })();

--- a/packages/ui/src/api/client-types-cloud.ts
+++ b/packages/ui/src/api/client-types-cloud.ts
@@ -287,8 +287,6 @@ export interface CloudCompatAgent {
   database_status: string;
   error_message: string | null;
   last_heartbeat_at: string | null;
-  /** Server-authoritative runtime placement. Older compat responses may omit it. */
-  execution_tier?: string | null;
 }
 
 export interface CloudCompatAgentStatus {

--- a/packages/ui/src/api/client-types-cloud.ts
+++ b/packages/ui/src/api/client-types-cloud.ts
@@ -287,6 +287,8 @@ export interface CloudCompatAgent {
   database_status: string;
   error_message: string | null;
   last_heartbeat_at: string | null;
+  /** Server-authoritative runtime placement. Older compat responses may omit it. */
+  execution_tier?: string | null;
 }
 
 export interface CloudCompatAgentStatus {

--- a/packages/ui/src/state/startup-phase-restore.concurrency.test.ts
+++ b/packages/ui/src/state/startup-phase-restore.concurrency.test.ts
@@ -209,6 +209,57 @@ describe("cloud restore routes the client without waiting on the Steward refresh
     expect(sharedClient.setBaseUrl).toHaveBeenCalledWith(sharedApiBase);
     expect(sharedClient.setToken).toHaveBeenCalledWith("paired-token");
   });
+
+  it("repairs a staging shared adapter to staging dedicated ingress", async () => {
+    setBootConfig({
+      ...DEFAULT_BOOT_CONFIG,
+      cloudApiBase: "https://staging.elizacloud.ai",
+    });
+    const restored: PersistedActiveServer = {
+      id: "cloud:agent-staging",
+      kind: "cloud",
+      label: "Eliza Cloud",
+      apiBase:
+        "https://api-staging.elizacloud.ai/api/v1/eliza/agents/agent-staging",
+      accessToken: "paired-token",
+    };
+    const clientRef = { setBaseUrl: vi.fn(), setToken: vi.fn() };
+
+    await applyRestoredConnection({
+      restoredActiveServer: restored,
+      clientRef,
+    });
+
+    expect(clientRef.setBaseUrl).toHaveBeenCalledWith(
+      "https://agent-staging.staging.elizacloud.ai",
+    );
+    expect(clientRef.setToken).toHaveBeenCalledWith("paired-token");
+  });
+
+  it("repairs a previously persisted production ingress in the staging app", async () => {
+    setBootConfig({
+      ...DEFAULT_BOOT_CONFIG,
+      cloudApiBase: "https://staging.elizacloud.ai",
+    });
+    const restored: PersistedActiveServer = {
+      id: "cloud:agent-staging",
+      kind: "cloud",
+      label: "Eliza Cloud",
+      apiBase: "https://agent-staging.elizacloud.ai",
+      accessToken: "paired-token",
+    };
+    const clientRef = { setBaseUrl: vi.fn(), setToken: vi.fn() };
+
+    await applyRestoredConnection({
+      restoredActiveServer: restored,
+      clientRef,
+    });
+
+    expect(clientRef.setBaseUrl).toHaveBeenCalledWith(
+      "https://agent-staging.staging.elizacloud.ai",
+    );
+    expect(clientRef.setToken).toHaveBeenCalledWith("paired-token");
+  });
 });
 
 describe("desktop local restore shares one runtime-mode RPC", () => {

--- a/packages/ui/src/state/startup-phase-restore.concurrency.test.ts
+++ b/packages/ui/src/state/startup-phase-restore.concurrency.test.ts
@@ -257,9 +257,12 @@ describe("cloud restore routes the client without waiting on the Steward refresh
         }),
       }),
     );
-    expect(clientRef.setBaseUrl).toHaveBeenCalledWith(
-      "https://api-staging.elizacloud.ai/api/v1/eliza/agents/shared-agent",
-    );
+    await vi.waitFor(() => {
+      expect(clientRef.setBaseUrl).toHaveBeenLastCalledWith(
+        "https://api-staging.elizacloud.ai/api/v1/eliza/agents/shared-agent",
+      );
+      expect(clientRef.setToken).toHaveBeenLastCalledWith(stewardToken);
+    });
     expect(clientRef.setToken).toHaveBeenCalledWith(stewardToken);
   });
 

--- a/packages/ui/src/state/startup-phase-restore.concurrency.test.ts
+++ b/packages/ui/src/state/startup-phase-restore.concurrency.test.ts
@@ -1,19 +1,15 @@
 // @vitest-environment jsdom
 //
 // Boot parallelization of the restoring-session phase: (1) a cloud restore
-// derives the dedicated per-agent base synchronously from the persisted id —
-// no backfill network lookup — and routes the client while the Steward-token
-// refresh round-trip is still in flight (client mutations still land base →
-// token), and (2) a desktop local restore issues ONE runtime-mode RPC shared
-// by the agent-autostart gate and the embedded-local target reclassification.
+// derives a missing per-agent base synchronously from the persisted id and
+// routes the client while the Steward-token refresh round-trip is still in
+// flight (client mutations still land base → token), and (2) a desktop local
+// restore issues ONE runtime-mode RPC shared by the agent-autostart gate and
+// the embedded-local target reclassification.
 // Real restore module under test; only the network / desktop-bridge
 // boundaries are stubbed.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  clearPendingCloudHandoff,
-  savePendingCloudHandoff,
-} from "../cloud/handoff/pending-handoff-store";
 import {
   DEFAULT_BOOT_CONFIG,
   setBootConfig,
@@ -111,7 +107,6 @@ describe("cloud restore routes the client without waiting on the Steward refresh
 
   afterEach(() => {
     globalThis.fetch = realFetch;
-    clearPendingCloudHandoff();
     setBootConfig(DEFAULT_BOOT_CONFIG);
     localStorage.clear();
     vi.restoreAllMocks();
@@ -172,16 +167,9 @@ describe("cloud restore routes the client without waiting on the Steward refresh
     );
   });
 
-  it("repairs a pending shared adapter unless the host explicitly enables shared tier", async () => {
+  it("preserves a shared adapter regardless of the dedicated-create default", async () => {
     const sharedApiBase =
       "https://api.elizacloud.ai/api/v1/eliza/agents/shared-agent";
-    savePendingCloudHandoff({
-      sharedAgentId: "shared-agent",
-      dedicatedAgentId: "dedicated-agent",
-      sharedApiBase,
-      cloudApiBase: "https://elizacloud.ai",
-      startedAt: Date.now(),
-    });
     const restored: PersistedActiveServer = {
       id: "cloud:shared-agent",
       kind: "cloud",
@@ -195,9 +183,7 @@ describe("cloud restore routes the client without waiting on the Steward refresh
       restoredActiveServer: restored,
       clientRef: dedicatedClient,
     });
-    expect(dedicatedClient.setBaseUrl).toHaveBeenCalledWith(
-      "https://shared-agent.elizacloud.ai",
-    );
+    expect(dedicatedClient.setBaseUrl).toHaveBeenCalledWith(sharedApiBase);
     expect(dedicatedClient.setToken).toHaveBeenCalledWith("paired-token");
 
     setBootConfig({ ...DEFAULT_BOOT_CONFIG, preferSharedCloudTier: true });
@@ -210,7 +196,7 @@ describe("cloud restore routes the client without waiting on the Steward refresh
     expect(sharedClient.setToken).toHaveBeenCalledWith("paired-token");
   });
 
-  it("repairs a staging shared adapter to staging dedicated ingress", async () => {
+  it("keeps a staging shared adapter on the staging control plane", async () => {
     setBootConfig({
       ...DEFAULT_BOOT_CONFIG,
       cloudApiBase: "https://staging.elizacloud.ai",
@@ -231,9 +217,50 @@ describe("cloud restore routes the client without waiting on the Steward refresh
     });
 
     expect(clientRef.setBaseUrl).toHaveBeenCalledWith(
-      "https://agent-staging.staging.elizacloud.ai",
+      "https://api-staging.elizacloud.ai/api/v1/eliza/agents/agent-staging",
     );
     expect(clientRef.setToken).toHaveBeenCalledWith("paired-token");
+  });
+
+  it("repairs a legacy dedicated-looking staging base when the owner record is shared", async () => {
+    setBootConfig({
+      ...DEFAULT_BOOT_CONFIG,
+      cloudApiBase: "https://staging.elizacloud.ai",
+    });
+    const stewardToken = makeJwt(3600);
+    localStorage.setItem(STEWARD_TOKEN_KEY, stewardToken);
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        success: true,
+        data: { executionTier: "shared" },
+      }),
+    } as Response);
+    const clientRef = { setBaseUrl: vi.fn(), setToken: vi.fn() };
+
+    await applyRestoredConnection({
+      restoredActiveServer: {
+        id: "cloud:shared-agent",
+        kind: "cloud",
+        label: "Eliza Cloud",
+        apiBase: "https://shared-agent.elizacloud.ai",
+      },
+      clientRef,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api-staging.elizacloud.ai/api/v1/eliza/agents/shared-agent",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: `Bearer ${stewardToken}`,
+        }),
+      }),
+    );
+    expect(clientRef.setBaseUrl).toHaveBeenCalledWith(
+      "https://api-staging.elizacloud.ai/api/v1/eliza/agents/shared-agent",
+    );
+    expect(clientRef.setToken).toHaveBeenCalledWith(stewardToken);
   });
 
   it("repairs a previously persisted production ingress in the staging app", async () => {

--- a/packages/ui/src/state/startup-phase-restore.ts
+++ b/packages/ui/src/state/startup-phase-restore.ts
@@ -17,13 +17,13 @@ import {
   cloudTokenSecsRemaining,
   isDirectCloudSharedAgentBase,
   refreshCloudStewardSession,
+  resolveDirectCloudAuthApiBase,
 } from "../api/client-cloud";
 import {
   getBackendStartupTimeoutMs,
   invokeDesktopBridgeRequestWithTimeout,
   isElectrobunRuntime,
 } from "../bridge";
-import { loadPendingCloudHandoff } from "../cloud/handoff/pending-handoff-store";
 import { getBootConfig } from "../config/boot-config";
 import {
   ANDROID_LOCAL_AGENT_IPC_BASE,
@@ -46,6 +46,7 @@ import {
   isOnboardingReplayRequested,
 } from "../platform";
 import {
+  buildCloudSharedAgentApiBase,
   buildDedicatedCloudAgentApiBase,
   dedicatedCloudAgentIdFromBase,
   isDedicatedCloudAgentBase,
@@ -83,6 +84,8 @@ const STEWARD_RESTORE_REFRESH_AHEAD_SECS = 120;
  * and the api-client 401 self-heal remain the backstops).
  */
 const STEWARD_RESTORE_REFRESH_TIMEOUT_MS = 4_000;
+/** Bound the legacy runtime-tier repair lookup independently from startup. */
+const CLOUD_AGENT_TIER_PROBE_TIMEOUT_MS = 4_000;
 /** Steward refresh endpoint path (same-origin on web; `api.` host on native). */
 const STEWARD_REFRESH_PATH = "/api/auth/steward-refresh";
 /** Default direct Cloud site base used to derive the native refresh endpoint. */
@@ -101,43 +104,89 @@ function isDevUiPort(): boolean {
 }
 
 /**
- * Repair a restored cloud active-server whose apiBase is missing or is the
- * unusable agent-id-less collection URL (`.../api/v1/eliza/agents`). Dedicated
- * Cloud agents must restore to their own subdomain; the shared runtime adapter
- * answers "Not a shared-runtime agent" for those ids.
+ * Read the server-authoritative runtime tier for an older persisted dedicated
+ * base. A previous client inferred the tier from URL shape and could persist a
+ * temporary shared bridge id as `<id>.elizacloud.ai`; this lookup repairs that
+ * record without trusting another URL heuristic. Any inconclusive result
+ * leaves the saved base in place.
+ */
+async function fetchCloudAgentExecutionTier(
+  agentId: string,
+  stewardToken: string | null,
+): Promise<string | null> {
+  if (!stewardToken) return null;
+  const cloudApiBase = resolveDirectCloudAuthApiBase(
+    getBootConfig().cloudApiBase || RESTORE_DEFAULT_DIRECT_CLOUD_BASE_URL,
+  );
+  try {
+    const response = await fetch(
+      `${cloudApiBase}/api/v1/eliza/agents/${encodeURIComponent(agentId)}`,
+      {
+        headers: {
+          Accept: "application/json",
+          Authorization: `Bearer ${stewardToken}`,
+        },
+        signal: AbortSignal.timeout(CLOUD_AGENT_TIER_PROBE_TIMEOUT_MS),
+      },
+    );
+    if (!response.ok) return null;
+    const payload: unknown = await response.json();
+    if (typeof payload !== "object" || payload === null) return null;
+    const data = (payload as Record<string, unknown>).data;
+    if (typeof data !== "object" || data === null) return null;
+    const tier = (data as Record<string, unknown>).executionTier;
+    return typeof tier === "string" && tier.trim() ? tier.trim() : null;
+  } catch {
+    // error-policy:J4 this is a compatibility repair probe; the normal startup
+    // poll remains authoritative when the control plane is temporarily down.
+    return null;
+  }
+}
+
+/**
+ * Repair a restored managed-cloud target using the current environment and,
+ * for legacy dedicated-looking records, the server-authoritative runtime tier.
  */
 async function backfillCloudApiBase(
   active: PersistedActiveServer,
+  stewardToken: string | null,
 ): Promise<PersistedActiveServer> {
   if (active.kind !== "cloud") return active;
   const agentId = recoverCloudAgentId(active);
-  const pending = loadPendingCloudHandoff();
-  const isPendingSharedRuntime =
-    getBootConfig().preferSharedCloudTier === true &&
-    Boolean(pending && agentId === pending.sharedAgentId) &&
-    active.apiBase === pending?.sharedApiBase;
-  const dedicatedApiBase = agentId
-    ? buildDedicatedCloudAgentApiBase(
-        agentId,
-        getBootConfig().cloudApiBase || active.apiBase,
-      )
-    : null;
-  const shouldRepair =
+  if (!agentId) return active;
+  const cloudApiBase =
+    getBootConfig().cloudApiBase ||
+    active.apiBase ||
+    RESTORE_DEFAULT_DIRECT_CLOUD_BASE_URL;
+  const dedicatedApiBase = buildDedicatedCloudAgentApiBase(
+    agentId,
+    cloudApiBase,
+  );
+  if (!dedicatedApiBase) return active;
+  const sharedApiBase = buildCloudSharedAgentApiBase(
+    resolveDirectCloudAuthApiBase(cloudApiBase),
+    agentId,
+  );
+  const managedBase =
     !active.apiBase ||
     isElizaCloudControlPlaneAgentlessBase(active.apiBase) ||
-    (isDirectCloudSharedAgentBase(active.apiBase) && !isPendingSharedRuntime) ||
-    (isDedicatedCloudAgentBase(active.apiBase) &&
-      Boolean(dedicatedApiBase) &&
-      active.apiBase !== dedicatedApiBase);
-  // Custom per-agent hosts stay untouched; managed dedicated hosts must match
-  // the current Cloud environment.
-  if (!shouldRepair) return active;
+    isDirectCloudSharedAgentBase(active.apiBase) ||
+    isDedicatedCloudAgentBase(active.apiBase);
+  // Custom per-agent hosts are server-owned and must remain untouched.
+  if (!managedBase) return active;
 
-  if (!dedicatedApiBase) return active;
+  const executionTier = isDedicatedCloudAgentBase(active.apiBase)
+    ? await fetchCloudAgentExecutionTier(agentId, stewardToken)
+    : null;
+  const repairedApiBase =
+    executionTier === "shared" || isDirectCloudSharedAgentBase(active.apiBase)
+      ? sharedApiBase
+      : dedicatedApiBase;
+  if (active.apiBase === repairedApiBase) return active;
 
   const updated: PersistedActiveServer = {
     ...active,
-    apiBase: dedicatedApiBase,
+    apiBase: repairedApiBase,
   };
   savePersistedActiveServer(updated);
   return updated;
@@ -417,13 +466,17 @@ export async function applyRestoredConnection(args: {
   }
 
   if (restoredActiveServer.kind === "cloud") {
-    // The two restore fetches are independent, so they run concurrently: the
-    // Steward-token resolution reads only persisted browser state (the stored
-    // JWT / the .elizacloud.ai cookie) and the boot-config cloud base — never
-    // the backfilled apiBase — and its refresh POST goes through raw fetch,
-    // not the client singleton that backfill temporarily repoints. Client
-    // mutations still land in the original order (base, then token).
-    const backfillPromise = backfillCloudApiBase(restoredActiveServer);
+    // Base reconciliation and Steward refresh are independent and run
+    // concurrently. Reconciliation uses only a snapshot of the stored Steward
+    // token and never mutates the client; client mutations still land in the
+    // original order (base, then refreshed token).
+    // Never send an agent-local paired token to the Cloud control plane. The
+    // Steward session store is the only valid credential for this owner lookup.
+    const restoreProbeToken = readStoredStewardToken()?.trim() || null;
+    const backfillPromise = backfillCloudApiBase(
+      restoredActiveServer,
+      restoreProbeToken,
+    );
     const stewardTokenPromise = resolveRestoredStewardToken();
     // error-policy:J5 the rejection is observed at `await stewardTokenPromise`
     // below; this no-op handler only covers the window where backfill throws

--- a/packages/ui/src/state/startup-phase-restore.ts
+++ b/packages/ui/src/state/startup-phase-restore.ts
@@ -116,18 +116,29 @@ async function backfillCloudApiBase(
     getBootConfig().preferSharedCloudTier === true &&
     Boolean(pending && agentId === pending.sharedAgentId) &&
     active.apiBase === pending?.sharedApiBase;
+  const dedicatedApiBase = agentId
+    ? buildDedicatedCloudAgentApiBase(
+        agentId,
+        getBootConfig().cloudApiBase || active.apiBase,
+      )
+    : null;
   const shouldRepair =
     !active.apiBase ||
     isElizaCloudControlPlaneAgentlessBase(active.apiBase) ||
-    (isDirectCloudSharedAgentBase(active.apiBase) && !isPendingSharedRuntime);
-  // A concrete per-agent base is fine, including a dedicated subdomain.
+    (isDirectCloudSharedAgentBase(active.apiBase) && !isPendingSharedRuntime) ||
+    (isDedicatedCloudAgentBase(active.apiBase) &&
+      Boolean(dedicatedApiBase) &&
+      active.apiBase !== dedicatedApiBase);
+  // Custom per-agent hosts stay untouched; managed dedicated hosts must match
+  // the current Cloud environment.
   if (!shouldRepair) return active;
 
-  if (!agentId) return active;
-  const apiBase = buildDedicatedCloudAgentApiBase(agentId);
-  if (!apiBase) return active;
+  if (!dedicatedApiBase) return active;
 
-  const updated: PersistedActiveServer = { ...active, apiBase };
+  const updated: PersistedActiveServer = {
+    ...active,
+    apiBase: dedicatedApiBase,
+  };
   savePersistedActiveServer(updated);
   return updated;
 }

--- a/packages/ui/src/state/startup-phase-restore.ts
+++ b/packages/ui/src/state/startup-phase-restore.ts
@@ -84,8 +84,8 @@ const STEWARD_RESTORE_REFRESH_AHEAD_SECS = 120;
  * and the api-client 401 self-heal remain the backstops).
  */
 const STEWARD_RESTORE_REFRESH_TIMEOUT_MS = 4_000;
-/** Bound the legacy runtime-tier repair lookup independently from startup. */
-const CLOUD_AGENT_TIER_PROBE_TIMEOUT_MS = 4_000;
+/** Bound the non-blocking legacy runtime-tier repair lookup. */
+const CLOUD_AGENT_TIER_PROBE_TIMEOUT_MS = 12_000;
 /** Steward refresh endpoint path (same-origin on web; `api.` host on native). */
 const STEWARD_REFRESH_PATH = "/api/auth/steward-refresh";
 /** Default direct Cloud site base used to derive the native refresh endpoint. */
@@ -104,17 +104,17 @@ function isDevUiPort(): boolean {
 }
 
 /**
- * Read the server-authoritative runtime tier for an older persisted dedicated
- * base. A previous client inferred the tier from URL shape and could persist a
- * temporary shared bridge id as `<id>.elizacloud.ai`; this lookup repairs that
- * record without trusting another URL heuristic. Any inconclusive result
- * leaves the saved base in place.
+ * Repair an older persisted dedicated-looking base when the owner record says
+ * it is actually a temporary shared bridge. This runs off the startup critical
+ * path: an inconclusive lookup leaves the already-bound target untouched.
  */
-async function fetchCloudAgentExecutionTier(
-  agentId: string,
+async function reconcileLegacyDedicatedCloudApiBase(
+  active: PersistedActiveServer,
   stewardToken: string | null,
-): Promise<string | null> {
-  if (!stewardToken) return null;
+): Promise<PersistedActiveServer | null> {
+  if (!stewardToken || !isDedicatedCloudAgentBase(active.apiBase)) return null;
+  const agentId = recoverCloudAgentId(active);
+  if (!agentId) return null;
   const cloudApiBase = resolveDirectCloudAuthApiBase(
     getBootConfig().cloudApiBase || RESTORE_DEFAULT_DIRECT_CLOUD_BASE_URL,
   );
@@ -135,7 +135,11 @@ async function fetchCloudAgentExecutionTier(
     const data = (payload as Record<string, unknown>).data;
     if (typeof data !== "object" || data === null) return null;
     const tier = (data as Record<string, unknown>).executionTier;
-    return typeof tier === "string" && tier.trim() ? tier.trim() : null;
+    if (tier !== "shared") return null;
+    return {
+      ...active,
+      apiBase: buildCloudSharedAgentApiBase(cloudApiBase, agentId),
+    };
   } catch {
     // error-policy:J4 this is a compatibility repair probe; the normal startup
     // poll remains authoritative when the control plane is temporarily down.
@@ -147,10 +151,9 @@ async function fetchCloudAgentExecutionTier(
  * Repair a restored managed-cloud target using the current environment and,
  * for legacy dedicated-looking records, the server-authoritative runtime tier.
  */
-async function backfillCloudApiBase(
+function backfillCloudApiBase(
   active: PersistedActiveServer,
-  stewardToken: string | null,
-): Promise<PersistedActiveServer> {
+): PersistedActiveServer {
   if (active.kind !== "cloud") return active;
   const agentId = recoverCloudAgentId(active);
   if (!agentId) return active;
@@ -175,13 +178,9 @@ async function backfillCloudApiBase(
   // Custom per-agent hosts are server-owned and must remain untouched.
   if (!managedBase) return active;
 
-  const executionTier = isDedicatedCloudAgentBase(active.apiBase)
-    ? await fetchCloudAgentExecutionTier(agentId, stewardToken)
-    : null;
-  const repairedApiBase =
-    executionTier === "shared" || isDirectCloudSharedAgentBase(active.apiBase)
-      ? sharedApiBase
-      : dedicatedApiBase;
+  const repairedApiBase = isDirectCloudSharedAgentBase(active.apiBase)
+    ? sharedApiBase
+    : dedicatedApiBase;
   if (active.apiBase === repairedApiBase) return active;
 
   const updated: PersistedActiveServer = {
@@ -466,24 +465,20 @@ export async function applyRestoredConnection(args: {
   }
 
   if (restoredActiveServer.kind === "cloud") {
-    // Base reconciliation and Steward refresh are independent and run
-    // concurrently. Reconciliation uses only a snapshot of the stored Steward
-    // token and never mutates the client; client mutations still land in the
-    // original order (base, then refreshed token).
+    // Environment reconciliation is synchronous so the client is routed
+    // immediately. The slower legacy tier check and Steward refresh then run
+    // concurrently; neither blocks the initial base mutation.
     // Never send an agent-local paired token to the Cloud control plane. The
     // Steward session store is the only valid credential for this owner lookup.
     const restoreProbeToken = readStoredStewardToken()?.trim() || null;
-    const backfillPromise = backfillCloudApiBase(
-      restoredActiveServer,
-      restoreProbeToken,
-    );
-    const stewardTokenPromise = resolveRestoredStewardToken();
-    // error-policy:J5 the rejection is observed at `await stewardTokenPromise`
-    // below; this no-op handler only covers the window where backfill throws
-    // first and that await is never reached.
-    stewardTokenPromise.catch(() => {});
-    const resolved = await backfillPromise;
+    const resolved = backfillCloudApiBase(restoredActiveServer);
     clientRef.setBaseUrl(resolved.apiBase ?? null);
+    const tierRepairPromise = isDedicatedCloudAgentBase(
+      restoredActiveServer.apiBase,
+    )
+      ? reconcileLegacyDedicatedCloudApiBase(resolved, restoreProbeToken)
+      : Promise.resolve(null);
+    const stewardTokenPromise = resolveRestoredStewardToken();
     // Cloud = Steward everywhere (DECISIONS.md D3): prefer the live Steward
     // session token over the token captured at provision time (which may have
     // rotated since). If that stored JWT expired while the app was closed,
@@ -498,6 +493,22 @@ export async function applyRestoredConnection(args: {
         ? resolved.accessToken || stewardToken || null
         : stewardToken || resolved.accessToken || null,
     );
+    void tierRepairPromise.then((repaired) => {
+      if (!repaired || repaired.apiBase === resolved.apiBase) return;
+      const current = loadPersistedActiveServer();
+      // A user can switch agents while the compatibility probe is in flight.
+      // Never overwrite a newer selection; null is allowed for direct unit
+      // callers that did not seed persistence.
+      if (
+        current &&
+        (current.id !== resolved.id || current.apiBase !== resolved.apiBase)
+      ) {
+        return;
+      }
+      savePersistedActiveServer(repaired);
+      clientRef.setBaseUrl(repaired.apiBase ?? null);
+      clientRef.setToken(stewardToken || repaired.accessToken || null);
+    });
     return;
   }
 

--- a/packages/ui/src/utils/cloud-agent-base.ts
+++ b/packages/ui/src/utils/cloud-agent-base.ts
@@ -49,6 +49,14 @@ export function normalizeDirectCloudSharedAgentApiBase(value: string): string {
   return stripTrailingSlash(url.toString());
 }
 
+// Staging apex + API. Without these, `staging.elizacloud.ai` ends with
+// `.elizacloud.ai` and is misclassified as a per-agent subdomain.
+const STAGING_CONSOLE_HOSTS = new Set([
+  "staging.elizacloud.ai",
+  "api-staging.elizacloud.ai",
+  "app-staging.elizacloud.ai",
+]);
+
 /**
  * Eliza Cloud control-plane hostnames. The bare origin (and the
  * `/api/v1/eliza/agents` collection) on any of these is NOT a per-agent base —
@@ -61,14 +69,15 @@ export const ELIZA_CLOUD_CONTROL_PLANE_HOSTS = new Set([
   "www.elizacloud.ai",
   "dev.elizacloud.ai",
   "app.elizacloud.ai",
-  // Staging apex + API. Without these, `staging.elizacloud.ai` ends with
-  // `.elizacloud.ai` but isn't in the set, so isDedicatedCloudAgentBase
-  // mis-classifies the staging console as a per-agent subdomain (and the apex
-  // login redirect never fires on staging — so staging can't validate it).
-  "staging.elizacloud.ai",
-  "api-staging.elizacloud.ai",
-  "app-staging.elizacloud.ai",
+  ...STAGING_CONSOLE_HOSTS,
 ]);
+
+function isStagingCloudHostname(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  return (
+    STAGING_CONSOLE_HOSTS.has(host) || host.endsWith(".staging.elizacloud.ai")
+  );
+}
 
 /**
  * Build the shared-runtime REST adapter base for a known agent id:
@@ -86,18 +95,25 @@ export function buildCloudSharedAgentApiBase(
 
 /**
  * Build the dedicated Cloud agent REST base for the standard
- * `<agentId>.elizacloud.ai` ingress. Returns null when the id cannot be a
- * single DNS label; callers should then fall back to a server-reported URL
- * instead of producing a malformed host.
+ * `<agentId>.elizacloud.ai` production ingress or the environment-matched
+ * `<agentId>.staging.elizacloud.ai` staging ingress. Returns null when the id
+ * cannot be a single DNS label; callers should then fall back to a
+ * server-reported URL instead of producing a malformed host.
  */
 export function buildDedicatedCloudAgentApiBase(
   agentId: string | null | undefined,
+  cloudApiBase?: string | null,
 ): string | null {
   const label = agentId?.trim().toLowerCase() ?? "";
   if (!/^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(label)) {
     return null;
   }
-  return `https://${label}.elizacloud.ai`;
+  const cloudUrl = cloudApiBase ? normalizeHttpUrl(cloudApiBase.trim()) : null;
+  const suffix =
+    cloudUrl && isStagingCloudHostname(cloudUrl.hostname)
+      ? ".staging.elizacloud.ai"
+      : ".elizacloud.ai";
+  return `https://${label}${suffix}`;
 }
 
 /**
@@ -157,8 +173,9 @@ export function isDedicatedCloudAgentBase(
 
 /**
  * Extract the agent id from a dedicated cloud agent base
- * (`https://<agentId>.elizacloud.ai`) — the left-most subdomain label. Returns
- * null for any base that is not a dedicated cloud agent subdomain.
+ * (`https://<agentId>.elizacloud.ai` or its staging equivalent) — the
+ * left-most subdomain label. Returns null for any base that is not a dedicated
+ * cloud agent subdomain.
  */
 export function dedicatedCloudAgentIdFromBase(
   value: string | null | undefined,
@@ -167,7 +184,10 @@ export function dedicatedCloudAgentIdFromBase(
   const url = normalizeHttpUrl((value as string).trim());
   if (!url) return null;
   const host = url.hostname.toLowerCase();
-  const label = host.slice(0, host.length - ".elizacloud.ai".length);
+  const suffix = isStagingCloudHostname(host)
+    ? ".staging.elizacloud.ai"
+    : ".elizacloud.ai";
+  const label = host.slice(0, host.length - suffix.length);
   return label.includes(".") ? label.slice(label.lastIndexOf(".") + 1) : label;
 }
 
@@ -179,16 +199,6 @@ export const PROD_ELIZA_APP_ORIGIN = "https://app.elizacloud.ai";
  * `staging.elizacloud.ai`; its paired app is `app-staging.elizacloud.ai`
  * (a DIFFERENT tenant/session from prod). */
 export const STAGING_ELIZA_APP_ORIGIN = "https://app-staging.elizacloud.ai";
-
-/** Console hostnames that belong to the STAGING environment. Derived from the
- * same control-plane host knowledge used elsewhere (client-cloud.ts /
- * steward-url.ts): the staging console apex, its API origins, and the staging
- * app host itself all point back to the staging app. */
-const STAGING_CONSOLE_HOSTS = new Set([
-  "staging.elizacloud.ai",
-  "api-staging.elizacloud.ai",
-  "app-staging.elizacloud.ai",
-]);
 
 /**
  * Resolve the Eliza *app* origin (the create-agent / "Open Eliza app" target)


### PR DESCRIPTION
## Summary
- derive dedicated-agent ingress from the active Cloud environment instead of hardcoding production
- preserve the control plane's authoritative execution tier so dedicated onboarding never binds a shared-runtime bridge as a dedicated agent
- force a fresh dedicated create when an account only has shared agents, while keeping shared mode on the shared adapter
- repair legacy persisted cloud targets in a bounded background reconciliation without delaying startup
- reconcile the environment-specific agent domain and protected node SSH key into the provisioning control plane on deploy
- remove the duplicate Cartesia environment declaration that blocked the touched UI typecheck

## Root cause
Three independent assumptions combined into the staging failure:

1. The compatibility adapter discarded `executionTier`, so the UI inferred placement from URLs and could treat a shared-runtime bridge as a dedicated sandbox.
2. Dedicated URL fallback always used `<agent>.elizacloud.ai`, even when the active control plane was staging.
3. Staging's router domain and provisioning-node SSH credential had drifted from the protected deployment environment, producing unroutable agents and failed dedicated provisioning.

The fix keeps placement authoritative, scopes URL construction to the active Cloud environment, repairs only stale persisted targets, and makes the deployment reconcile the required runtime configuration.

## Validation
- `packages/ui` typecheck: pass
- focused cloud select/direct-auth/connect/restore suites: 88 tests pass across 5 files
- router and provisioning-workflow suites: 31 tests pass
- changed-file coverage gate: pass (`client-cloud.ts` 63.01%, `startup-phase-restore.ts` 56.96%, `cloud-agent-base.ts` 87.69%)
- `actionlint` and `git diff --check`: pass
- exact-SHA staging control-plane deploy: pass
- fresh staging dedicated agent: provisioned in about 20 seconds, `running`, bridge ready, no error
- authenticated dedicated API smoke: list `200`, create conversation `200`, send message `200`, assistant replied `OK`
- dedicated UI smoke through the local renderer and live staging runtime: launcher/composer rendered, 12 agent requests returned `200`, zero production requests, zero console errors
- legacy copied-profile recovery: stale target repaired to the staging shared adapter with zero production requests

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - no rendered UI surface changed; this PR changes routing, placement selection, session reconciliation, and deployment configuration.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - acceptance is captured by authenticated runtime and browser network assertions.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: router and protected deployment reconciliation are pinned by [agent-router.test.ts](https://github.com/elizaOS/eliza/blob/fix/staging-dedicated-agent-domain-20260712/packages/scripts/cloud/admin/daemons/agent-router.test.ts) and [provisioning-worker-env-reconcile.test.ts](https://github.com/elizaOS/eliza/blob/fix/staging-dedicated-agent-domain-20260712/packages/scripts/cloud/admin/daemons/provisioning-worker-env-reconcile.test.ts); live dedicated provisioning reached `running` with bridge ready and no error.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: environment-scoped selection and legacy-session recovery are pinned by [client-cloud-select-or-provision.test.ts](https://github.com/elizaOS/eliza/blob/fix/staging-dedicated-agent-domain-20260712/packages/ui/src/api/client-cloud-select-or-provision.test.ts) and [startup-phase-restore.concurrency.test.ts](https://github.com/elizaOS/eliza/blob/fix/staging-dedicated-agent-domain-20260712/packages/ui/src/state/startup-phase-restore.concurrency.test.ts); live UI smoke produced 12 successful staging-agent responses, zero production requests, and zero console errors.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no prompt, model, or agent-action path changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: staging host construction and extraction are asserted in [client-cloud-agent-base.test.ts](https://github.com/elizaOS/eliza/blob/fix/staging-dedicated-agent-domain-20260712/packages/ui/src/api/client-cloud-agent-base.test.ts), with runtime-tier behavior asserted in [client-cloud-direct-auth.test.ts](https://github.com/elizaOS/eliza/blob/fix/staging-dedicated-agent-domain-20260712/packages/ui/src/api/client-cloud-direct-auth.test.ts).
