### PR TITLE
feat: model configuration API — catalog, validated config routes, spawn wiring (stage 1)

### DIFF
--- a/packages/agent/src/api/index.ts
+++ b/packages/agent/src/api/index.ts
@@ -56,6 +56,7 @@ export * from "./early-logs.ts";
 export * from "./memory-bounds.ts";
 export * from "./memory-routes.ts";
 export * from "./model-catalog.ts";
+export * from "./model-config-routes.ts";
 export * from "./models-routes.ts";
 export * from "./parse-action-block.ts";
 export * from "./permission-request-prompt.ts";

--- a/packages/agent/src/api/index.ts
+++ b/packages/agent/src/api/index.ts
@@ -55,6 +55,7 @@ export * from "./documents-service-loader.ts";
 export * from "./early-logs.ts";
 export * from "./memory-bounds.ts";
 export * from "./memory-routes.ts";
+export * from "./model-catalog.ts";
 export * from "./models-routes.ts";
 export * from "./parse-action-block.ts";
 export * from "./permission-request-prompt.ts";

--- a/packages/agent/src/api/model-catalog.test.ts
+++ b/packages/agent/src/api/model-catalog.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Unit tests for the provider→model catalog: static-table ground truth (spark
+ * API flag, per-model effort gates, role assignment), live Codex cache parse +
+ * merge semantics, and the designed static fallback on a corrupt/absent cache.
+ * Deterministic — filesystem reads are injected, no live provider is touched.
+ */
+import { describe, expect, it } from "vitest";
+import { buildModelCatalog, CODING_MODEL_DEFAULTS } from "./model-catalog";
+
+const NO_CACHE = {
+  readFile: () => {
+    throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+  },
+  env: {} as NodeJS.ProcessEnv,
+};
+
+function entry(
+  providerEntries: ReturnType<typeof buildModelCatalog>,
+  provider: string,
+  id: string,
+) {
+  const found = providerEntries.providers[provider]?.find((m) => m.id === id);
+  if (!found) throw new Error(`missing ${provider}/${id}`);
+  return found;
+}
+
+describe("static codex catalog (fallback table)", () => {
+  const catalog = buildModelCatalog(NO_CACHE);
+
+  it("marks gpt-5.3-codex-spark as not API-supported", () => {
+    const spark = entry(catalog, "codex", "gpt-5.3-codex-spark");
+    expect(spark.apiSupported).toBe(false);
+    expect(spark.defaultEffort).toBe("high");
+  });
+
+  it("gives terra ultra (with cost hint) but not luna", () => {
+    const terra = entry(catalog, "codex", "gpt-5.6-terra");
+    const luna = entry(catalog, "codex", "gpt-5.6-luna");
+    expect(terra.efforts).toContain("ultra");
+    expect(terra.costHint).toBe("highest cost/latency tier");
+    expect(luna.efforts).not.toContain("ultra");
+    expect(luna.costHint).toBeUndefined();
+    expect(luna.efforts).toEqual(["low", "medium", "high", "xhigh", "max"]);
+  });
+
+  it("defaults every non-spark codex model to medium effort", () => {
+    for (const m of catalog.providers.codex) {
+      if (m.id === "gpt-5.3-codex-spark") continue;
+      expect(m.defaultEffort).toBe("medium");
+    }
+  });
+
+  it("exposes the user-approved codex coding default model", () => {
+    expect(CODING_MODEL_DEFAULTS.codex).toBe("gpt-5.6-terra");
+    expect(catalog.providers.codex.some((m) => m.id === "gpt-5.6-terra")).toBe(
+      true,
+    );
+  });
+});
+
+describe("codex models_cache.json parse + merge", () => {
+  const cache = JSON.stringify({
+    models: [
+      {
+        slug: "gpt-5.7-nova",
+        display_name: "GPT-5.7-Nova",
+        default_reasoning_level: "medium",
+        supported_reasoning_levels: [
+          { effort: "low" },
+          { effort: "medium" },
+          { effort: "ultra" },
+        ],
+        visibility: "list",
+        supported_in_api: true,
+      },
+      {
+        // Server view of an existing static model wins over the static row.
+        slug: "gpt-5.5",
+        display_name: "GPT-5.5 (server)",
+        default_reasoning_level: "high",
+        supported_reasoning_levels: [{ effort: "low" }, { effort: "high" }],
+        visibility: "list",
+        supported_in_api: true,
+      },
+      {
+        slug: "codex-auto-review",
+        display_name: "Codex Auto Review",
+        default_reasoning_level: "medium",
+        supported_reasoning_levels: [{ effort: "medium" }],
+        visibility: "hide",
+        supported_in_api: true,
+      },
+    ],
+  });
+
+  const catalog = buildModelCatalog({
+    readFile: (p) => {
+      expect(p.endsWith("models_cache.json")).toBe(true);
+      return cache;
+    },
+    env: { CODEX_HOME: "/fake/codex-home" } as NodeJS.ProcessEnv,
+  });
+
+  it("adds server-only models with parsed efforts, default, and ultra cost hint", () => {
+    const nova = entry(catalog, "codex", "gpt-5.7-nova");
+    expect(nova.display).toBe("GPT-5.7-Nova");
+    expect(nova.efforts).toEqual(["low", "medium", "ultra"]);
+    expect(nova.defaultEffort).toBe("medium");
+    expect(nova.costHint).toBe("highest cost/latency tier");
+    expect(nova.roles).toEqual(["coding"]);
+  });
+
+  it("lets the server catalog win for models it lists", () => {
+    const gpt55 = entry(catalog, "codex", "gpt-5.5");
+    expect(gpt55.display).toBe("GPT-5.5 (server)");
+    expect(gpt55.efforts).toEqual(["low", "high"]);
+    expect(gpt55.defaultEffort).toBe("high");
+  });
+
+  it("excludes entries the server marks hidden", () => {
+    expect(
+      catalog.providers.codex.some((m) => m.id === "codex-auto-review"),
+    ).toBe(false);
+  });
+
+  it("retains static models the server cache omits (spark keeps its flag)", () => {
+    const spark = entry(catalog, "codex", "gpt-5.3-codex-spark");
+    expect(spark.apiSupported).toBe(false);
+    expect(catalog.providers.codex.some((m) => m.id === "gpt-5.6-terra")).toBe(
+      true,
+    );
+  });
+
+  it("resolves the cache path from CODEX_HOME", () => {
+    let seen = "";
+    buildModelCatalog({
+      readFile: (p) => {
+        seen = p;
+        return cache;
+      },
+      env: { CODEX_HOME: "/opt/codex" } as NodeJS.ProcessEnv,
+    });
+    expect(seen).toBe("/opt/codex/models_cache.json");
+  });
+});
+
+describe("codex cache failure fallback", () => {
+  it.each([
+    ["unparseable JSON", "{nope"],
+    ["missing models array", JSON.stringify({ fetched_at: "now" })],
+    ["no usable entries", JSON.stringify({ models: [{ slug: "" }] })],
+  ])("falls back to the static table on %s", (_label, raw) => {
+    const catalog = buildModelCatalog({
+      readFile: () => raw,
+      env: {} as NodeJS.ProcessEnv,
+    });
+    const ids = catalog.providers.codex.map((m) => m.id);
+    expect(ids).toEqual([
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+      "gpt-5.6-luna",
+      "gpt-5.5",
+      "gpt-5.4",
+      "gpt-5.4-mini",
+      "gpt-5.3-codex-spark",
+    ]);
+  });
+
+  it("falls back when the cache file cannot be read", () => {
+    const catalog = buildModelCatalog(NO_CACHE);
+    expect(catalog.providers.codex).toHaveLength(7);
+  });
+});
+
+describe("claude chat/coding effort gates", () => {
+  const catalog = buildModelCatalog(NO_CACHE);
+
+  it("grants xhigh+ only to opus >= 4.7 and fable-5", () => {
+    for (const provider of ["claude-chat", "claude-coding"]) {
+      const full = ["claude-fable-5", "claude-opus-4-8", "claude-opus-4-7"];
+      for (const id of full) {
+        expect(entry(catalog, provider, id).efforts).toEqual([
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max",
+        ]);
+      }
+      for (const id of [
+        "claude-opus-4-6",
+        "claude-sonnet-5",
+        "claude-sonnet-4-6",
+        "claude-haiku-4-5-20251001",
+      ]) {
+        expect(entry(catalog, provider, id).efforts).toEqual([
+          "low",
+          "medium",
+          "high",
+        ]);
+      }
+    }
+  });
+
+  it("assigns chat models small+large and coding models coding", () => {
+    for (const m of catalog.providers["claude-chat"]) {
+      expect(m.roles).toEqual(["small", "large"]);
+    }
+    for (const m of catalog.providers["claude-coding"]) {
+      expect(m.roles).toEqual(["coding"]);
+    }
+  });
+});
+
+describe("cerebras + elizacloud", () => {
+  const catalog = buildModelCatalog(NO_CACHE);
+
+  it("exposes no effort knob for gemma or zai-glm-4.7", () => {
+    expect(entry(catalog, "cerebras", "gemma-4-31b").efforts).toEqual([]);
+    expect(entry(catalog, "cerebras", "zai-glm-4.7").efforts).toEqual([]);
+    expect(entry(catalog, "elizacloud", "zai-glm-4.7").efforts).toEqual([]);
+  });
+
+  it("keeps gpt-oss reasoning_effort at low/medium/high", () => {
+    expect(entry(catalog, "cerebras", "gpt-oss-120b").efforts).toEqual([
+      "low",
+      "medium",
+      "high",
+    ]);
+    expect(entry(catalog, "elizacloud", "openai/gpt-oss-120b").efforts).toEqual(
+      ["low", "medium", "high"],
+    );
+  });
+
+  it("assigns gemma small-only on cerebras and the curated cloud trio small+large", () => {
+    expect(entry(catalog, "cerebras", "gemma-4-31b").roles).toEqual(["small"]);
+    expect(entry(catalog, "cerebras", "zai-glm-4.7").roles).toEqual([
+      "small",
+      "large",
+    ]);
+    for (const m of catalog.providers.elizacloud) {
+      expect(m.roles).toEqual(["small", "large"]);
+    }
+    expect(catalog.providers.elizacloud.map((m) => m.id)).toEqual([
+      "gpt-oss-120b",
+      "openai/gpt-oss-120b",
+      "zai-glm-4.7",
+      "gemma-4-31b",
+    ]);
+  });
+
+  it("returns fresh copies so callers cannot mutate the static tables", () => {
+    const first = buildModelCatalog(NO_CACHE);
+    first.providers.cerebras[0]?.efforts.push("bogus");
+    first.providers.cerebras[0]?.roles.push("large");
+    const second = buildModelCatalog(NO_CACHE);
+    expect(entry(second, "cerebras", "gemma-4-31b").efforts).toEqual([]);
+    expect(entry(second, "cerebras", "gemma-4-31b").roles).toEqual(["small"]);
+  });
+});

--- a/packages/agent/src/api/model-catalog.test.ts
+++ b/packages/agent/src/api/model-catalog.test.ts
@@ -215,10 +215,24 @@ describe("claude chat/coding effort gates", () => {
 describe("cerebras + elizacloud", () => {
   const catalog = buildModelCatalog(NO_CACHE);
 
-  it("exposes no effort knob for gemma or zai-glm-4.7", () => {
-    expect(entry(catalog, "cerebras", "gemma-4-31b").efforts).toEqual([]);
-    expect(entry(catalog, "cerebras", "zai-glm-4.7").efforts).toEqual([]);
-    expect(entry(catalog, "elizacloud", "zai-glm-4.7").efforts).toEqual([]);
+  // reasoning_effort was live-probed 2026-07-12: gemma and zai-glm-4.7 both
+  // modulate their emitted reasoning low->high, so they carry the knob too.
+  it("exposes the low/medium/high effort knob on gemma and zai-glm-4.7", () => {
+    expect(entry(catalog, "cerebras", "gemma-4-31b").efforts).toEqual([
+      "low",
+      "medium",
+      "high",
+    ]);
+    expect(entry(catalog, "cerebras", "zai-glm-4.7").efforts).toEqual([
+      "low",
+      "medium",
+      "high",
+    ]);
+    expect(entry(catalog, "elizacloud", "zai-glm-4.7").efforts).toEqual([
+      "low",
+      "medium",
+      "high",
+    ]);
   });
 
   it("keeps gpt-oss reasoning_effort at low/medium/high", () => {
@@ -254,7 +268,11 @@ describe("cerebras + elizacloud", () => {
     first.providers.cerebras[0]?.efforts.push("bogus");
     first.providers.cerebras[0]?.roles.push("large");
     const second = buildModelCatalog(NO_CACHE);
-    expect(entry(second, "cerebras", "gemma-4-31b").efforts).toEqual([]);
+    expect(entry(second, "cerebras", "gemma-4-31b").efforts).toEqual([
+      "low",
+      "medium",
+      "high",
+    ]);
     expect(entry(second, "cerebras", "gemma-4-31b").roles).toEqual(["small"]);
   });
 });

--- a/packages/agent/src/api/model-catalog.ts
+++ b/packages/agent/src/api/model-catalog.ts
@@ -145,17 +145,21 @@ const CLAUDE_CODING_ENTRIES: ModelCatalogEntry[] = CLAUDE_MODELS.map((m) => ({
   roles: ["coding"],
 }));
 
+// All three Cerebras-served models are reasoning models: `reasoning_effort`
+// was live-probed 2026-07-12 and modulates the emitted reasoning on each
+// (glm 90->1337 reasoning chars low->high; gemma 663->1133), so every entry
+// carries the knob — not just gpt-oss.
 const CEREBRAS_ENTRIES: ModelCatalogEntry[] = [
   {
     id: "gemma-4-31b",
     display: "Gemma 4 31B",
-    efforts: [],
+    efforts: ["low", "medium", "high"],
     roles: ["small"],
   },
   {
     id: "zai-glm-4.7",
     display: "GLM-4.7",
-    efforts: [],
+    efforts: ["low", "medium", "high"],
     roles: ["small", "large"],
   },
   {
@@ -185,13 +189,13 @@ const ELIZACLOUD_ENTRIES: ModelCatalogEntry[] = [
   {
     id: "zai-glm-4.7",
     display: "GLM-4.7",
-    efforts: [],
+    efforts: ["low", "medium", "high"],
     roles: ["small", "large"],
   },
   {
     id: "gemma-4-31b",
     display: "Gemma 4 31B",
-    efforts: [],
+    efforts: ["low", "medium", "high"],
     roles: ["small", "large"],
   },
 ];

--- a/packages/agent/src/api/model-catalog.ts
+++ b/packages/agent/src/api/model-catalog.ts
@@ -1,0 +1,344 @@
+/**
+ * Provider→model catalog powering user-configurable model selection: which
+ * models each provider serves, which reasoning-effort levels each model
+ * accepts, and which runtime roles (small / large chat brain, coding
+ * sub-agent) a model may fill. `GET /api/models` attaches the catalog to its
+ * response and `POST /api/models/config` (model-config-routes.ts) validates
+ * every write against it — Codex in particular silently accepts invalid
+ * `model_reasoning_effort` values, so this catalog is the only enforcement
+ * seam.
+ *
+ * Codex entries are live-merged from `$CODEX_HOME/models_cache.json` (the
+ * Codex CLI's cached server catalog) at call time, with the verified static
+ * table below as the designed fallback when the cache is absent or corrupt.
+ * Every other provider's list is static, verified ground truth: Anthropic
+ * chat/coding model ids and effort gates, the Cerebras trio (zai-glm-4.7
+ * exposes NO effort — its reasoning knob is unverified), and the Eliza Cloud
+ * curated trio. Filesystem access is injectable so tests run hermetically.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { logger } from "@elizaos/core";
+
+export interface ModelCatalogEntry {
+  id: string;
+  display: string;
+  /** Accepted reasoning-effort levels; empty = the model has no effort knob. */
+  efforts: string[];
+  defaultEffort?: string;
+  roles: Array<"small" | "large" | "coding">;
+  costHint?: string;
+  /** false = listed by the provider but not callable via the API tier. */
+  apiSupported?: boolean;
+}
+
+export interface ModelCatalog {
+  providers: Record<string, ModelCatalogEntry[]>;
+}
+
+/**
+ * User-approved default coding model per backend. Mirrors
+ * `TASK_AGENT_DEFAULT_MODEL_PREFS` in
+ * plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts —
+ * keep the two in sync when the product default moves.
+ */
+export const CODING_MODEL_DEFAULTS: Readonly<Record<string, string>> = {
+  codex: "gpt-5.6-terra",
+};
+
+// The ultra tier trades cost and latency for maximum reasoning + delegation;
+// surfaced so clients can warn before a user pins it as their default.
+const ULTRA_COST_HINT = "highest cost/latency tier";
+
+const CODEX_STATIC_ENTRIES: ModelCatalogEntry[] = [
+  {
+    id: "gpt-5.6-sol",
+    display: "GPT-5.6-Sol",
+    efforts: ["low", "medium", "high", "xhigh", "max", "ultra"],
+    defaultEffort: "medium",
+    roles: ["coding"],
+    costHint: ULTRA_COST_HINT,
+  },
+  {
+    id: "gpt-5.6-terra",
+    display: "GPT-5.6-Terra",
+    efforts: ["low", "medium", "high", "xhigh", "max", "ultra"],
+    defaultEffort: "medium",
+    roles: ["coding"],
+    costHint: ULTRA_COST_HINT,
+  },
+  {
+    id: "gpt-5.6-luna",
+    display: "GPT-5.6-Luna",
+    efforts: ["low", "medium", "high", "xhigh", "max"],
+    defaultEffort: "medium",
+    roles: ["coding"],
+  },
+  {
+    id: "gpt-5.5",
+    display: "GPT-5.5",
+    efforts: ["low", "medium", "high", "xhigh"],
+    defaultEffort: "medium",
+    roles: ["coding"],
+  },
+  {
+    id: "gpt-5.4",
+    display: "GPT-5.4",
+    efforts: ["low", "medium", "high", "xhigh"],
+    defaultEffort: "medium",
+    roles: ["coding"],
+  },
+  {
+    id: "gpt-5.4-mini",
+    display: "GPT-5.4-Mini",
+    efforts: ["low", "medium", "high", "xhigh"],
+    defaultEffort: "medium",
+    roles: ["coding"],
+  },
+  {
+    id: "gpt-5.3-codex-spark",
+    display: "GPT-5.3-Codex-Spark",
+    efforts: ["low", "medium", "high", "xhigh"],
+    defaultEffort: "high",
+    roles: ["coding"],
+    apiSupported: false,
+  },
+];
+
+// Anthropic effort gate: xhigh/max only on opus >= 4.7 and fable-5; haiku
+// caps at high; sonnets cap at high.
+const CLAUDE_MODELS: Array<{ id: string; display: string; full: boolean }> = [
+  { id: "claude-fable-5", display: "Claude Fable 5", full: true },
+  { id: "claude-opus-4-8", display: "Claude Opus 4.8", full: true },
+  { id: "claude-opus-4-7", display: "Claude Opus 4.7", full: true },
+  { id: "claude-opus-4-6", display: "Claude Opus 4.6", full: false },
+  { id: "claude-sonnet-5", display: "Claude Sonnet 5", full: false },
+  { id: "claude-sonnet-4-6", display: "Claude Sonnet 4.6", full: false },
+  {
+    id: "claude-haiku-4-5-20251001",
+    display: "Claude Haiku 4.5",
+    full: false,
+  },
+];
+
+function claudeEfforts(full: boolean): string[] {
+  return full
+    ? ["low", "medium", "high", "xhigh", "max"]
+    : ["low", "medium", "high"];
+}
+
+const CLAUDE_CHAT_ENTRIES: ModelCatalogEntry[] = CLAUDE_MODELS.map((m) => ({
+  id: m.id,
+  display: m.display,
+  efforts: claudeEfforts(m.full),
+  roles: ["small", "large"],
+}));
+
+// Claude Code CLI defaults to xhigh (CLAUDE_CODE_EFFORT_LEVEL); models whose
+// effort ceiling is high get no default rather than a fabricated one.
+const CLAUDE_CODING_ENTRIES: ModelCatalogEntry[] = CLAUDE_MODELS.map((m) => ({
+  id: m.id,
+  display: m.display,
+  efforts: claudeEfforts(m.full),
+  ...(m.full ? { defaultEffort: "xhigh" } : {}),
+  roles: ["coding"],
+}));
+
+const CEREBRAS_ENTRIES: ModelCatalogEntry[] = [
+  {
+    id: "gemma-4-31b",
+    display: "Gemma 4 31B",
+    efforts: [],
+    roles: ["small"],
+  },
+  {
+    id: "zai-glm-4.7",
+    display: "GLM-4.7",
+    efforts: [],
+    roles: ["small", "large"],
+  },
+  {
+    id: "gpt-oss-120b",
+    display: "GPT-OSS 120B",
+    efforts: ["low", "medium", "high"],
+    roles: ["small", "large"],
+  },
+];
+
+// Curated per product decision: exactly the Cerebras trio as served by Eliza
+// Cloud (plus the `openai/` alias the cloud router also accepts) — nothing
+// else until the cloud catalog is opened up.
+const ELIZACLOUD_ENTRIES: ModelCatalogEntry[] = [
+  {
+    id: "gpt-oss-120b",
+    display: "GPT-OSS 120B",
+    efforts: ["low", "medium", "high"],
+    roles: ["small", "large"],
+  },
+  {
+    id: "openai/gpt-oss-120b",
+    display: "GPT-OSS 120B",
+    efforts: ["low", "medium", "high"],
+    roles: ["small", "large"],
+  },
+  {
+    id: "zai-glm-4.7",
+    display: "GLM-4.7",
+    efforts: [],
+    roles: ["small", "large"],
+  },
+  {
+    id: "gemma-4-31b",
+    display: "Gemma 4 31B",
+    efforts: [],
+    roles: ["small", "large"],
+  },
+];
+
+export interface BuildModelCatalogOptions {
+  /** Injectable file read for tests; defaults to fs.readFileSync utf-8. */
+  readFile?: (filePath: string) => string;
+  /** Injectable env for tests; defaults to process.env (CODEX_HOME lookup). */
+  env?: NodeJS.ProcessEnv;
+}
+
+const EFFORT_LEVELS = new Set([
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+  "ultra",
+]);
+const HIDDEN_VISIBILITIES = new Set(["hide", "hidden", "internal"]);
+
+function clone(entry: ModelCatalogEntry): ModelCatalogEntry {
+  return { ...entry, efforts: [...entry.efforts], roles: [...entry.roles] };
+}
+
+/**
+ * Parse the Codex CLI's `models_cache.json` into catalog entries. Throws on a
+ * malformed document (the caller falls back to the static table); individual
+ * entries that lack a usable slug/effort list are skipped, and entries the
+ * server marks hidden/internal are excluded from the user-facing catalog.
+ */
+function parseCodexModelsCache(raw: string): ModelCatalogEntry[] {
+  const doc = JSON.parse(raw) as { models?: unknown };
+  if (!Array.isArray(doc.models)) {
+    throw new Error("models_cache.json has no models array");
+  }
+  const entries: ModelCatalogEntry[] = [];
+  for (const item of doc.models) {
+    if (!item || typeof item !== "object") continue;
+    const m = item as {
+      slug?: unknown;
+      display_name?: unknown;
+      default_reasoning_level?: unknown;
+      supported_reasoning_levels?: unknown;
+      visibility?: unknown;
+      supported_in_api?: unknown;
+    };
+    if (typeof m.slug !== "string" || !m.slug.trim()) continue;
+    if (
+      typeof m.visibility === "string" &&
+      HIDDEN_VISIBILITIES.has(m.visibility.toLowerCase())
+    ) {
+      continue;
+    }
+    const efforts = Array.isArray(m.supported_reasoning_levels)
+      ? m.supported_reasoning_levels
+          .map((level) =>
+            level && typeof level === "object"
+              ? (level as { effort?: unknown }).effort
+              : undefined,
+          )
+          .filter(
+            (effort): effort is string =>
+              typeof effort === "string" && EFFORT_LEVELS.has(effort),
+          )
+      : [];
+    if (efforts.length === 0) continue;
+    const defaultEffort =
+      typeof m.default_reasoning_level === "string" &&
+      efforts.includes(m.default_reasoning_level)
+        ? m.default_reasoning_level
+        : undefined;
+    entries.push({
+      id: m.slug,
+      display:
+        typeof m.display_name === "string" && m.display_name.trim()
+          ? m.display_name
+          : m.slug,
+      efforts,
+      ...(defaultEffort ? { defaultEffort } : {}),
+      roles: ["coding"],
+      ...(efforts.includes("ultra") ? { costHint: ULTRA_COST_HINT } : {}),
+      ...(m.supported_in_api === false ? { apiSupported: false } : {}),
+    });
+  }
+  if (entries.length === 0) {
+    throw new Error("models_cache.json contained no usable model entries");
+  }
+  return entries;
+}
+
+// Log the fallback once per process — the catalog is rebuilt per request and
+// a missing cache on a box without the Codex CLI is a permanent condition.
+let codexCacheFallbackLogged = false;
+
+function buildCodexEntries(
+  opts: BuildModelCatalogOptions,
+): ModelCatalogEntry[] {
+  const env = opts.env ?? process.env;
+  const readFile =
+    opts.readFile ?? ((filePath: string) => fs.readFileSync(filePath, "utf-8"));
+  const codexHome = env.CODEX_HOME?.trim()
+    ? env.CODEX_HOME.trim()
+    : path.join(os.homedir(), ".codex");
+  const cachePath = path.join(codexHome, "models_cache.json");
+
+  let cacheEntries: ModelCatalogEntry[];
+  try {
+    cacheEntries = parseCodexModelsCache(readFile(cachePath));
+  } catch (err) {
+    // error-policy:J4 the live Codex server catalog is an optional enrichment;
+    // an absent or corrupt cache degrades to the verified static table by
+    // design (this catalog must exist on boxes without the Codex CLI).
+    if (!codexCacheFallbackLogged) {
+      codexCacheFallbackLogged = true;
+      logger.debug(
+        `[ModelCatalog] codex models_cache.json unavailable at ${cachePath}; serving static codex catalog: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    return CODEX_STATIC_ENTRIES.map(clone);
+  }
+
+  // Merge: the server catalog wins per model id; statically-known models the
+  // cache omits are retained so a partial server catalog never shrinks the
+  // verified baseline (spark stays listed with apiSupported:false).
+  const merged = new Map<string, ModelCatalogEntry>(
+    CODEX_STATIC_ENTRIES.map((entry) => [entry.id, clone(entry)]),
+  );
+  for (const entry of cacheEntries) merged.set(entry.id, entry);
+  return [...merged.values()];
+}
+
+/**
+ * Build the full provider→model catalog. Pure given its injected reads: the
+ * only I/O is the Codex cache lookup, and callers get fresh copies so cached
+ * static tables can never be mutated through a response object.
+ */
+export function buildModelCatalog(
+  opts: BuildModelCatalogOptions = {},
+): ModelCatalog {
+  return {
+    providers: {
+      codex: buildCodexEntries(opts),
+      "claude-chat": CLAUDE_CHAT_ENTRIES.map(clone),
+      "claude-coding": CLAUDE_CODING_ENTRIES.map(clone),
+      cerebras: CEREBRAS_ENTRIES.map(clone),
+      elizacloud: ELIZACLOUD_ENTRIES.map(clone),
+    },
+  };
+}

--- a/packages/agent/src/api/model-config-routes.test.ts
+++ b/packages/agent/src/api/model-config-routes.test.ts
@@ -1,0 +1,419 @@
+/**
+ * Unit tests for GET/POST /api/models/config: catalog-backed validation
+ * rejections, the dual-seam config write (config.env + config.env.vars +
+ * process.env), restart semantics per target (chat restarts via the operation
+ * manager, coding does not), external-env conflict reporting, and the GET
+ * resolution order. Deterministic — catalog, process env, save, and the
+ * operation manager are injected; no live runtime or filesystem is touched.
+ */
+import type http from "node:http";
+import { describe, expect, it, vi } from "vitest";
+import type { ElizaConfig } from "../config/config";
+import { buildModelCatalog } from "./model-catalog";
+import { handleModelConfigRoutes } from "./model-config-routes";
+
+const catalog = buildModelCatalog({
+  readFile: () => {
+    throw new Error("ENOENT");
+  },
+  env: {} as NodeJS.ProcessEnv,
+});
+
+interface HarnessOptions {
+  config?: ElizaConfig;
+  processEnv?: NodeJS.ProcessEnv;
+  managerStart?: ReturnType<typeof vi.fn>;
+}
+
+function makeHarness(
+  method: string,
+  body: Record<string, unknown> | null,
+  opts: HarnessOptions = {},
+) {
+  const config: ElizaConfig = opts.config ?? {};
+  const processEnv: NodeJS.ProcessEnv = opts.processEnv ?? {};
+  const json = vi.fn();
+  const saveElizaConfig = vi.fn();
+  const managerStart =
+    opts.managerStart ??
+    vi.fn(async (req: { prepare?: () => Promise<unknown> }) => {
+      await req.prepare?.();
+      return {
+        kind: "accepted",
+        operation: { id: "op-1" },
+      };
+    });
+  const ctx = {
+    req: {} as http.IncomingMessage,
+    res: {} as http.ServerResponse,
+    method,
+    pathname: "/api/models/config",
+    json,
+    readJsonBody: vi.fn(async () => body),
+    state: { config },
+    saveElizaConfig,
+    runtimeOperationManager: { start: managerStart } as never,
+    catalog,
+    processEnv,
+  };
+  return { ctx, json, saveElizaConfig, managerStart, config, processEnv };
+}
+
+function responseOf(json: ReturnType<typeof vi.fn>) {
+  const call = json.mock.calls[0];
+  if (!call) throw new Error("json was not called");
+  return {
+    body: call[1] as Record<string, unknown>,
+    status: call[2] as number | undefined,
+  };
+}
+
+describe("POST /api/models/config validation", () => {
+  it("rejects ultra on gpt-5.6-luna", async () => {
+    const { ctx, json, saveElizaConfig } = makeHarness("POST", {
+      target: "coding",
+      backend: "codex",
+      model: "gpt-5.6-luna",
+      effort: "ultra",
+    });
+    await expect(handleModelConfigRoutes(ctx as never)).resolves.toBe(true);
+    const { body, status } = responseOf(json);
+    expect(status).toBe(400);
+    expect(body.code).toBe("MODEL_CONFIG_INVALID");
+    expect(String(body.error)).toContain("ultra");
+    expect(saveElizaConfig).not.toHaveBeenCalled();
+  });
+
+  it("rejects xhigh on haiku via claude-chat", async () => {
+    const { ctx, json } = makeHarness("POST", {
+      target: "small",
+      provider: "claude-chat",
+      model: "claude-haiku-4-5-20251001",
+      effort: "xhigh",
+    });
+    await handleModelConfigRoutes(ctx as never);
+    const { body, status } = responseOf(json);
+    expect(status).toBe(400);
+    expect(body.code).toBe("MODEL_CONFIG_INVALID");
+    expect(String(body.error)).toContain("xhigh");
+  });
+
+  it("rejects effort on gemma (model with no effort knob)", async () => {
+    const { ctx, json } = makeHarness("POST", {
+      target: "small",
+      provider: "cerebras",
+      model: "gemma-4-31b",
+      effort: "low",
+    });
+    await handleModelConfigRoutes(ctx as never);
+    const { body, status } = responseOf(json);
+    expect(status).toBe(400);
+    expect(String(body.error)).toContain("no effort control");
+  });
+
+  it("rejects an unknown model for the provider", async () => {
+    const { ctx, json } = makeHarness("POST", {
+      target: "large",
+      provider: "cerebras",
+      model: "made-up-model",
+    });
+    await handleModelConfigRoutes(ctx as never);
+    const { body, status } = responseOf(json);
+    expect(status).toBe(400);
+    expect(String(body.error)).toContain("Unknown model");
+  });
+
+  it("rejects a chat target carrying a coding backend (target/backend mismatch)", async () => {
+    const { ctx, json } = makeHarness("POST", {
+      target: "large",
+      backend: "codex",
+      model: "gpt-5.6-terra",
+    });
+    await handleModelConfigRoutes(ctx as never);
+    const { body, status } = responseOf(json);
+    expect(status).toBe(400);
+    expect(String(body.error)).toContain("coding-target field");
+  });
+
+  it("rejects target coding without a backend", async () => {
+    const { ctx, json } = makeHarness("POST", {
+      target: "coding",
+      model: "gpt-5.6-terra",
+    });
+    await handleModelConfigRoutes(ctx as never);
+    const { status, body } = responseOf(json);
+    expect(status).toBe(400);
+    expect(String(body.error)).toContain("requires backend");
+  });
+
+  it("rejects a gemma large write (role mismatch on cerebras)", async () => {
+    const { ctx, json } = makeHarness("POST", {
+      target: "large",
+      provider: "cerebras",
+      model: "gemma-4-31b",
+    });
+    await handleModelConfigRoutes(ctx as never);
+    const { status, body } = responseOf(json);
+    expect(status).toBe(400);
+    expect(String(body.error)).toContain("not offered");
+  });
+
+  it("rejects an ambiguous model when provider is omitted", async () => {
+    const { ctx, json } = makeHarness("POST", {
+      target: "large",
+      model: "gpt-oss-120b",
+    });
+    await handleModelConfigRoutes(ctx as never);
+    const { status, body } = responseOf(json);
+    expect(status).toBe(400);
+    expect(String(body.error)).toContain("multiple providers");
+  });
+
+  it("rejects effort on backends without an effort seam", async () => {
+    const { ctx, json } = makeHarness("POST", {
+      target: "coding",
+      backend: "opencode",
+      model: "cerebras/gpt-oss-120b",
+      effort: "high",
+    });
+    await handleModelConfigRoutes(ctx as never);
+    const { status, body } = responseOf(json);
+    expect(status).toBe(400);
+    expect(String(body.error)).toContain("no effort control");
+  });
+});
+
+describe("POST /api/models/config chat writes", () => {
+  it("writes both config seams + process.env and requests a restart", async () => {
+    const { ctx, json, saveElizaConfig, managerStart, config, processEnv } =
+      makeHarness("POST", {
+        target: "large",
+        provider: "cerebras",
+        model: "gpt-oss-120b",
+        effort: "high",
+      });
+    await handleModelConfigRoutes(ctx as never);
+
+    const env = (config as Record<string, unknown>).env as Record<
+      string,
+      unknown
+    > & { vars: Record<string, string> };
+    expect(env.OPENAI_LARGE_MODEL).toBe("gpt-oss-120b");
+    expect(env.vars.OPENAI_LARGE_MODEL).toBe("gpt-oss-120b");
+    expect(processEnv.OPENAI_LARGE_MODEL).toBe("gpt-oss-120b");
+    expect(env.OPENAI_REASONING_EFFORT).toBe("high");
+    expect(env.vars.OPENAI_REASONING_EFFORT).toBe("high");
+    expect(processEnv.OPENAI_REASONING_EFFORT).toBe("high");
+    expect(saveElizaConfig).toHaveBeenCalledWith(config);
+    expect(managerStart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        intent: expect.objectContaining({ kind: "restart" }),
+      }),
+    );
+    const { body } = responseOf(json);
+    expect(body).toMatchObject({
+      applied: true,
+      restart: true,
+      operationId: "op-1",
+    });
+  });
+
+  it("writes ANTHROPIC keys (model + per-target effort) for claude-chat", async () => {
+    const { ctx, config, processEnv } = makeHarness("POST", {
+      target: "small",
+      provider: "claude-chat",
+      model: "claude-haiku-4-5-20251001",
+      effort: "high",
+    });
+    await handleModelConfigRoutes(ctx as never);
+    const env = (config as Record<string, unknown>).env as Record<
+      string,
+      unknown
+    >;
+    expect(env.ANTHROPIC_SMALL_MODEL).toBe("claude-haiku-4-5-20251001");
+    expect(env.ANTHROPIC_EFFORT_SMALL).toBe("high");
+    expect(processEnv.ANTHROPIC_EFFORT_SMALL).toBe("high");
+  });
+
+  it("returns 409 without writing when the runtime is busy", async () => {
+    const managerStart = vi.fn(async () => ({
+      kind: "rejected-busy",
+      activeOperationId: "op-active",
+    }));
+    const { ctx, json, saveElizaConfig, config } = makeHarness(
+      "POST",
+      { target: "large", provider: "elizacloud", model: "zai-glm-4.7" },
+      { managerStart },
+    );
+    await handleModelConfigRoutes(ctx as never);
+    const { status, body } = responseOf(json);
+    expect(status).toBe(409);
+    expect(body.activeOperationId).toBe("op-active");
+    expect(saveElizaConfig).not.toHaveBeenCalled();
+    expect((config as Record<string, unknown>).env).toBeUndefined();
+  });
+
+  it("reports keys whose prior process.env value came from outside the config", async () => {
+    const { ctx, json } = makeHarness(
+      "POST",
+      { target: "large", provider: "cerebras", model: "zai-glm-4.7" },
+      {
+        // service.env-style value: present in process.env, absent from config.
+        processEnv: { OPENAI_LARGE_MODEL: "llama-x-from-service-env" },
+      },
+    );
+    await handleModelConfigRoutes(ctx as never);
+    const { body } = responseOf(json);
+    expect(body.conflictingServiceEnvKeys).toEqual(["OPENAI_LARGE_MODEL"]);
+  });
+
+  it("does not flag a conflict when process.env just mirrors the old config value", async () => {
+    const { ctx, json } = makeHarness(
+      "POST",
+      { target: "large", provider: "cerebras", model: "zai-glm-4.7" },
+      {
+        config: {
+          env: { vars: { OPENAI_LARGE_MODEL: "gpt-oss-120b" } },
+        } as ElizaConfig,
+        processEnv: { OPENAI_LARGE_MODEL: "gpt-oss-120b" },
+      },
+    );
+    await handleModelConfigRoutes(ctx as never);
+    const { body } = responseOf(json);
+    expect(body.conflictingServiceEnvKeys).toBeUndefined();
+  });
+});
+
+describe("POST /api/models/config coding writes", () => {
+  it("writes codex model + effort without a restart", async () => {
+    const { ctx, json, saveElizaConfig, managerStart, config, processEnv } =
+      makeHarness("POST", {
+        target: "coding",
+        backend: "codex",
+        model: "gpt-5.6-terra",
+        effort: "ultra",
+      });
+    await handleModelConfigRoutes(ctx as never);
+
+    const env = (config as Record<string, unknown>).env as Record<
+      string,
+      unknown
+    > & { vars: Record<string, string> };
+    expect(env.ELIZA_CODEX_MODEL_POWERFUL).toBe("gpt-5.6-terra");
+    expect(env.vars.ELIZA_CODEX_MODEL_POWERFUL).toBe("gpt-5.6-terra");
+    expect(processEnv.ELIZA_CODEX_MODEL_POWERFUL).toBe("gpt-5.6-terra");
+    expect(env.ELIZA_CODEX_EFFORT).toBe("ultra");
+    expect(saveElizaConfig).toHaveBeenCalledWith(config);
+    expect(managerStart).not.toHaveBeenCalled();
+    const { body } = responseOf(json);
+    expect(body).toMatchObject({ applied: true, restart: false });
+  });
+
+  it("accepts a free-form opencode model and a defaultBackend switch", async () => {
+    const { ctx, config } = makeHarness("POST", {
+      target: "coding",
+      backend: "opencode",
+      model: "cerebras/gpt-oss-120b",
+      defaultBackend: "opencode",
+    });
+    await handleModelConfigRoutes(ctx as never);
+    const env = (config as Record<string, unknown>).env as Record<
+      string,
+      unknown
+    >;
+    expect(env.ELIZA_OPENCODE_MODEL_POWERFUL).toBe("cerebras/gpt-oss-120b");
+    expect(env.ELIZA_DEFAULT_AGENT_TYPE).toBe("opencode");
+  });
+
+  it("persists defaultBackend eliza-code under the orchestrator's elizaos spelling", async () => {
+    const { ctx, config } = makeHarness("POST", {
+      target: "coding",
+      backend: "eliza-code",
+      model: "eliza-local",
+      defaultBackend: "eliza-code",
+    });
+    await handleModelConfigRoutes(ctx as never);
+    const env = (config as Record<string, unknown>).env as Record<
+      string,
+      unknown
+    >;
+    expect(env.ELIZA_ELIZAOS_MODEL_POWERFUL).toBe("eliza-local");
+    expect(env.ELIZA_DEFAULT_AGENT_TYPE).toBe("elizaos");
+  });
+
+  it("validates claude coding models against the claude-coding catalog", async () => {
+    const { ctx, json } = makeHarness("POST", {
+      target: "coding",
+      backend: "claude",
+      model: "claude-nonexistent-9",
+    });
+    await handleModelConfigRoutes(ctx as never);
+    const { status } = responseOf(json);
+    expect(status).toBe(400);
+  });
+});
+
+describe("GET /api/models/config resolution order", () => {
+  it("reports which source won per key: config.env > config.env.vars > process.env", async () => {
+    const { ctx, json } = makeHarness("GET", null, {
+      config: {
+        env: {
+          OPENAI_LARGE_MODEL: "direct-model",
+          vars: {
+            OPENAI_LARGE_MODEL: "vars-model",
+            OPENAI_SMALL_MODEL: "vars-small",
+          },
+        },
+      } as ElizaConfig,
+      processEnv: {
+        OPENAI_SMALL_MODEL: "proc-small",
+        ELIZA_CLAUDE_MODEL_POWERFUL: "claude-opus-4-7",
+      },
+    });
+    await handleModelConfigRoutes(ctx as never);
+    const { body } = responseOf(json);
+    const targets = body.targets as Record<
+      string,
+      Record<string, { value: string; source: string } | null>
+    >;
+    expect(targets.large?.OPENAI_LARGE_MODEL).toEqual({
+      value: "direct-model",
+      source: "config.env",
+    });
+    expect(targets.small?.OPENAI_SMALL_MODEL).toEqual({
+      value: "vars-small",
+      source: "config.env.vars",
+    });
+    expect(targets.coding?.ELIZA_CLAUDE_MODEL_POWERFUL).toEqual({
+      value: "claude-opus-4-7",
+      source: "process.env",
+    });
+    expect(targets.small?.ANTHROPIC_SMALL_MODEL).toBeNull();
+  });
+
+  it("falls back to the user-approved codex coding default when unset", async () => {
+    const { ctx, json } = makeHarness("GET", null);
+    await handleModelConfigRoutes(ctx as never);
+    const { body } = responseOf(json);
+    const targets = body.targets as Record<
+      string,
+      Record<string, { value: string; source: string } | null>
+    >;
+    expect(targets.coding?.ELIZA_CODEX_MODEL_POWERFUL).toEqual({
+      value: "gpt-5.6-terra",
+      source: "default",
+    });
+  });
+});
+
+describe("route matching", () => {
+  it("declines other paths and methods", async () => {
+    const { ctx } = makeHarness("PUT", { target: "large", model: "x" });
+    await expect(handleModelConfigRoutes(ctx as never)).resolves.toBe(false);
+    const other = makeHarness("GET", null);
+    other.ctx.pathname = "/api/models";
+    await expect(handleModelConfigRoutes(other.ctx as never)).resolves.toBe(
+      false,
+    );
+  });
+});

--- a/packages/agent/src/api/model-config-routes.test.ts
+++ b/packages/agent/src/api/model-config-routes.test.ts
@@ -98,17 +98,19 @@ describe("POST /api/models/config validation", () => {
     expect(String(body.error)).toContain("xhigh");
   });
 
-  it("rejects effort on gemma (model with no effort knob)", async () => {
+  // gemma carries a live-proven low/medium/high knob (2026-07-12 probe), so
+  // effort validation on it rejects values outside that list, not all effort.
+  it("rejects an effort outside gemma's supported list", async () => {
     const { ctx, json } = makeHarness("POST", {
       target: "small",
       provider: "cerebras",
       model: "gemma-4-31b",
-      effort: "low",
+      effort: "xhigh",
     });
     await handleModelConfigRoutes(ctx as never);
     const { body, status } = responseOf(json);
     expect(status).toBe(400);
-    expect(String(body.error)).toContain("no effort control");
+    expect(String(body.error)).toContain("not supported by model");
   });
 
   it("rejects an unknown model for the provider", async () => {
@@ -291,7 +293,9 @@ describe("POST /api/models/config coding writes", () => {
         target: "coding",
         backend: "codex",
         model: "gpt-5.6-terra",
-        effort: "ultra",
+        // xhigh is the ceiling the pinned codex-acp adapter can parse; ultra
+        // is rejected at the route (see the pin-gate suite below).
+        effort: "xhigh",
       });
     await handleModelConfigRoutes(ctx as never);
 
@@ -302,7 +306,7 @@ describe("POST /api/models/config coding writes", () => {
     expect(env.ELIZA_CODEX_MODEL_POWERFUL).toBe("gpt-5.6-terra");
     expect(env.vars.ELIZA_CODEX_MODEL_POWERFUL).toBe("gpt-5.6-terra");
     expect(processEnv.ELIZA_CODEX_MODEL_POWERFUL).toBe("gpt-5.6-terra");
-    expect(env.ELIZA_CODEX_EFFORT).toBe("ultra");
+    expect(env.ELIZA_CODEX_EFFORT).toBe("xhigh");
     expect(saveElizaConfig).toHaveBeenCalledWith(config);
     expect(managerStart).not.toHaveBeenCalled();
     const { body } = responseOf(json);
@@ -415,5 +419,21 @@ describe("route matching", () => {
     await expect(handleModelConfigRoutes(other.ctx as never)).resolves.toBe(
       false,
     );
+  });
+});
+
+describe("codex-acp effort pin gate (review amendment)", () => {
+  it("rejects ultra on gpt-5.6-terra (model supports it; pinned acp cannot parse it)", async () => {
+    const { ctx, json, saveElizaConfig } = makeHarness("POST", {
+      target: "coding",
+      backend: "codex",
+      model: "gpt-5.6-terra",
+      effort: "ultra",
+    });
+    await expect(handleModelConfigRoutes(ctx as never)).resolves.toBe(true);
+    const { body, status } = responseOf(json);
+    expect(status).toBe(400);
+    expect(String(body.error)).toContain("codex-acp");
+    expect(saveElizaConfig).not.toHaveBeenCalled();
   });
 });

--- a/packages/agent/src/api/model-config-routes.ts
+++ b/packages/agent/src/api/model-config-routes.ts
@@ -1,0 +1,569 @@
+/**
+ * Validated read/write surface for user-configurable models behind the
+ * authenticated control API. `POST /api/models/config` checks every request
+ * against the provider→model→efforts catalog (model-catalog.ts) before
+ * touching config — Codex silently accepts an invalid
+ * `model_reasoning_effort`, so this route is the enforcement seam — then
+ * persists the selection to all three config seams at once:
+ * `config.env.vars[KEY]`, `config.env[KEY]` (the section the orchestrator's
+ * `readConfigEnvKey` re-reads per spawn), and `process.env[KEY]`.
+ *
+ * Chat-brain targets (small/large) require a runtime restart for the model
+ * plugin to pick up the new ids, driven through the same idempotent
+ * RuntimeOperationManager the provider-switch route uses — the config write
+ * happens inside the operation's prepare step so a busy runtime rejects
+ * without a half-applied config. Coding targets return without restart:
+ * sub-agent spawns re-read the config env on every spawn. When a touched key
+ * already carried a different process-env value that the config did not put
+ * there (systemd service.env, shell export), the response lists it in
+ * `conflictingServiceEnvKeys` as an honest warning — a full service restart
+ * may resurrect the external value.
+ *
+ * `GET /api/models/config` reports the current effective value for every key
+ * this route owns, with the source that won (`config.env` → `config.env.vars`
+ * → `process.env`, mirroring the orchestrator's direct-section-first read).
+ */
+import {
+  ElizaError,
+  logger,
+  type RouteHelpers,
+  type RouteRequestMeta,
+} from "@elizaos/core";
+import type { ElizaConfig } from "../config/config.ts";
+import type { RuntimeOperationManager } from "../runtime/operations/index.ts";
+import {
+  buildModelCatalog,
+  CODING_MODEL_DEFAULTS,
+  type ModelCatalog,
+  type ModelCatalogEntry,
+} from "./model-catalog.ts";
+
+export type ModelConfigTarget = "small" | "large" | "coding";
+export type CodingBackend = "codex" | "claude" | "opencode" | "eliza-code";
+
+export interface ModelConfigWriteBody {
+  target: ModelConfigTarget;
+  provider?: string;
+  backend?: CodingBackend;
+  model: string;
+  effort?: string;
+  /** Optional coding-backend switch, persisted as ELIZA_DEFAULT_AGENT_TYPE. */
+  defaultBackend?: CodingBackend;
+}
+
+export interface ModelConfigRouteContext
+  extends RouteRequestMeta,
+    Pick<RouteHelpers, "json" | "readJsonBody"> {
+  state: { config: ElizaConfig };
+  saveElizaConfig: (config: ElizaConfig) => void;
+  runtimeOperationManager: RuntimeOperationManager;
+  /** Injectable catalog for tests; defaults to the live buildModelCatalog(). */
+  catalog?: ModelCatalog;
+  /** Injectable process env for tests; defaults to process.env. */
+  processEnv?: NodeJS.ProcessEnv;
+}
+
+const TARGETS = new Set<ModelConfigTarget>(["small", "large", "coding"]);
+const CODING_BACKENDS = new Set<CodingBackend>([
+  "codex",
+  "claude",
+  "opencode",
+  "eliza-code",
+]);
+
+// Chat providers → the env-var family the corresponding model plugin reads.
+// cerebras and elizacloud both serve through the OpenAI-compatible plugin.
+const CHAT_PROVIDER_KEY_FAMILY: Record<string, "OPENAI" | "ANTHROPIC"> = {
+  cerebras: "OPENAI",
+  elizacloud: "OPENAI",
+  "claude-chat": "ANTHROPIC",
+};
+
+interface CodingBackendSeam {
+  modelKey: string;
+  /** null = the backend has no effort seam; sending effort is a 400. */
+  effortKey: string | null;
+  /** Catalog provider to validate against; null = free-form model string. */
+  catalogProvider: string | null;
+}
+
+// Model keys are the `powerful` slots of TASK_AGENT_MODEL_PREF_SETTING_KEYS
+// (plugin-agent-orchestrator/src/services/task-agent-frameworks.ts) — the keys
+// spawns actually read. The effort keys are persisted now; the CLI adapters
+// grow their consumers in a follow-on wiring change.
+const CODING_BACKEND_SEAMS: Record<CodingBackend, CodingBackendSeam> = {
+  codex: {
+    modelKey: "ELIZA_CODEX_MODEL_POWERFUL",
+    effortKey: "ELIZA_CODEX_EFFORT",
+    catalogProvider: "codex",
+  },
+  claude: {
+    modelKey: "ELIZA_CLAUDE_MODEL_POWERFUL",
+    effortKey: "ELIZA_CLAUDE_EFFORT",
+    catalogProvider: "claude-coding",
+  },
+  opencode: {
+    modelKey: "ELIZA_OPENCODE_MODEL_POWERFUL",
+    effortKey: null,
+    catalogProvider: null,
+  },
+  "eliza-code": {
+    modelKey: "ELIZA_ELIZAOS_MODEL_POWERFUL",
+    effortKey: null,
+    catalogProvider: null,
+  },
+};
+
+// The orchestrator's KNOWN_ADAPTER_TYPES spells the in-house backend
+// "elizaos"; persisting the API's "eliza-code" literal would be silently
+// dropped by its adapter normalization.
+const DEFAULT_BACKEND_PERSISTED_VALUE: Record<CodingBackend, string> = {
+  codex: "codex",
+  claude: "claude",
+  opencode: "opencode",
+  "eliza-code": "elizaos",
+};
+
+function invalid(
+  message: string,
+  context: Record<string, unknown>,
+): ElizaError {
+  return new ElizaError(message, {
+    code: "MODEL_CONFIG_INVALID",
+    context,
+    severity: "ephemeral",
+  });
+}
+
+function findEntry(
+  catalog: ModelCatalog,
+  provider: string,
+  model: string,
+): ModelCatalogEntry | undefined {
+  return catalog.providers[provider]?.find((entry) => entry.id === model);
+}
+
+function validateEffort(entry: ModelCatalogEntry, effort: string): void {
+  if (entry.efforts.length === 0) {
+    throw invalid(`Model "${entry.id}" exposes no effort control`, {
+      model: entry.id,
+      effort,
+    });
+  }
+  if (!entry.efforts.includes(effort)) {
+    throw invalid(
+      `Effort "${effort}" is not supported by model "${entry.id}" (supported: ${entry.efforts.join(", ")})`,
+      { model: entry.id, effort, supported: entry.efforts },
+    );
+  }
+}
+
+function ensureEnvSections(config: ElizaConfig): {
+  direct: Record<string, unknown>;
+  vars: Record<string, string>;
+} {
+  const record = config as Record<string, unknown>;
+  if (
+    !record.env ||
+    typeof record.env !== "object" ||
+    Array.isArray(record.env)
+  ) {
+    record.env = {};
+  }
+  const direct = record.env as Record<string, unknown>;
+  if (
+    !direct.vars ||
+    typeof direct.vars !== "object" ||
+    Array.isArray(direct.vars)
+  ) {
+    direct.vars = {};
+  }
+  return { direct, vars: direct.vars as Record<string, string> };
+}
+
+function readConfigEnvString(
+  config: ElizaConfig,
+  key: string,
+): { value: string; source: "config.env" | "config.env.vars" } | null {
+  const env = (config as Record<string, unknown>).env;
+  if (!env || typeof env !== "object" || Array.isArray(env)) return null;
+  const direct = (env as Record<string, unknown>)[key];
+  if (typeof direct === "string" && direct.trim()) {
+    return { value: direct, source: "config.env" };
+  }
+  const vars = (env as Record<string, unknown>).vars;
+  if (vars && typeof vars === "object" && !Array.isArray(vars)) {
+    const nested = (vars as Record<string, unknown>)[key];
+    if (typeof nested === "string" && nested.trim()) {
+      return { value: nested, source: "config.env.vars" };
+    }
+  }
+  return null;
+}
+
+/**
+ * Write one key to all three seams. Returns true when process.env already
+ * carried a different value that the config did not put there — i.e. it came
+ * from an external source (systemd service.env, shell export) that a full
+ * service restart may re-apply over this save.
+ */
+function writeModelEnvKey(
+  config: ElizaConfig,
+  processEnv: NodeJS.ProcessEnv,
+  key: string,
+  value: string,
+): boolean {
+  const priorProcess = processEnv[key];
+  const priorConfig = readConfigEnvString(config, key)?.value;
+  const { direct, vars } = ensureEnvSections(config);
+  direct[key] = value;
+  vars[key] = value;
+  processEnv[key] = value;
+  return (
+    typeof priorProcess === "string" &&
+    priorProcess !== value &&
+    priorProcess !== priorConfig
+  );
+}
+
+interface ResolvedWrite {
+  key: string;
+  value: string;
+}
+
+function resolveChatWrites(
+  catalog: ModelCatalog,
+  body: ModelConfigWriteBody,
+): ResolvedWrite[] {
+  if (body.backend !== undefined) {
+    throw invalid(
+      `backend is a coding-target field; target "${body.target}" selects a chat provider`,
+      { target: body.target, backend: body.backend },
+    );
+  }
+
+  let provider = body.provider;
+  if (provider !== undefined && !(provider in CHAT_PROVIDER_KEY_FAMILY)) {
+    throw invalid(
+      `Unknown chat provider "${provider}" (expected one of: ${Object.keys(CHAT_PROVIDER_KEY_FAMILY).join(", ")})`,
+      { provider },
+    );
+  }
+  if (provider === undefined) {
+    const matches = Object.keys(CHAT_PROVIDER_KEY_FAMILY).filter((candidate) =>
+      findEntry(catalog, candidate, body.model)?.roles.includes(
+        body.target as "small" | "large",
+      ),
+    );
+    if (matches.length === 0) {
+      throw invalid(
+        `Unknown model "${body.model}" for target "${body.target}"`,
+        { model: body.model, target: body.target },
+      );
+    }
+    if (matches.length > 1) {
+      throw invalid(
+        `Model "${body.model}" is served by multiple providers (${matches.join(", ")}); specify provider`,
+        { model: body.model, providers: matches },
+      );
+    }
+    provider = matches[0] as string;
+  }
+
+  const entry = findEntry(catalog, provider, body.model);
+  if (!entry) {
+    throw invalid(`Unknown model "${body.model}" for provider "${provider}"`, {
+      model: body.model,
+      provider,
+    });
+  }
+  if (!entry.roles.includes(body.target as "small" | "large")) {
+    throw invalid(
+      `Model "${body.model}" is not offered for the "${body.target}" role on provider "${provider}"`,
+      { model: body.model, provider, target: body.target, roles: entry.roles },
+    );
+  }
+
+  const family = CHAT_PROVIDER_KEY_FAMILY[provider] as "OPENAI" | "ANTHROPIC";
+  const targetUpper = body.target.toUpperCase();
+  const writes: ResolvedWrite[] = [
+    { key: `${family}_${targetUpper}_MODEL`, value: body.model },
+  ];
+  if (body.effort !== undefined) {
+    validateEffort(entry, body.effort);
+    writes.push(
+      family === "ANTHROPIC"
+        ? { key: `ANTHROPIC_EFFORT_${targetUpper}`, value: body.effort }
+        : { key: "OPENAI_REASONING_EFFORT", value: body.effort },
+    );
+  }
+  return writes;
+}
+
+function resolveCodingWrites(
+  catalog: ModelCatalog,
+  body: ModelConfigWriteBody,
+): ResolvedWrite[] {
+  const backend = body.backend;
+  if (backend === undefined || !CODING_BACKENDS.has(backend)) {
+    throw invalid(
+      `target "coding" requires backend (one of: ${[...CODING_BACKENDS].join(", ")})`,
+      { backend: backend ?? null },
+    );
+  }
+  const seam = CODING_BACKEND_SEAMS[backend];
+  if (body.provider !== undefined && body.provider !== seam.catalogProvider) {
+    throw invalid(
+      `provider "${body.provider}" does not match coding backend "${backend}"`,
+      { provider: body.provider, backend },
+    );
+  }
+
+  if (seam.catalogProvider) {
+    const entry = findEntry(catalog, seam.catalogProvider, body.model);
+    if (!entry) {
+      throw invalid(`Unknown model "${body.model}" for backend "${backend}"`, {
+        model: body.model,
+        backend,
+        provider: seam.catalogProvider,
+      });
+    }
+    if (body.effort !== undefined) validateEffort(entry, body.effort);
+  } else if (body.effort !== undefined) {
+    throw invalid(`backend "${backend}" has no effort control`, {
+      backend,
+      effort: body.effort,
+    });
+  }
+
+  const writes: ResolvedWrite[] = [{ key: seam.modelKey, value: body.model }];
+  if (body.effort !== undefined && seam.effortKey) {
+    writes.push({ key: seam.effortKey, value: body.effort });
+  }
+  if (body.defaultBackend !== undefined) {
+    if (!CODING_BACKENDS.has(body.defaultBackend)) {
+      throw invalid(`Unknown defaultBackend "${body.defaultBackend}"`, {
+        defaultBackend: body.defaultBackend,
+      });
+    }
+    writes.push({
+      key: "ELIZA_DEFAULT_AGENT_TYPE",
+      value: DEFAULT_BACKEND_PERSISTED_VALUE[body.defaultBackend],
+    });
+  }
+  return writes;
+}
+
+function parseWriteBody(raw: Record<string, unknown>): ModelConfigWriteBody {
+  const target = raw.target;
+  if (typeof target !== "string" || !TARGETS.has(target as ModelConfigTarget)) {
+    throw invalid(`target must be one of: ${[...TARGETS].join(", ")}`, {
+      target: target ?? null,
+    });
+  }
+  const model = raw.model;
+  if (typeof model !== "string" || !model.trim()) {
+    throw invalid("model must be a non-empty string", { model: model ?? null });
+  }
+  const optionalString = (field: string): string | undefined => {
+    const value = raw[field];
+    if (value === undefined) return undefined;
+    if (typeof value !== "string" || !value.trim()) {
+      throw invalid(`${field} must be a non-empty string when provided`, {
+        [field]: value,
+      });
+    }
+    return value.trim();
+  };
+  const backend = optionalString("backend");
+  if (backend !== undefined && !CODING_BACKENDS.has(backend as CodingBackend)) {
+    throw invalid(
+      `Unknown backend "${backend}" (expected one of: ${[...CODING_BACKENDS].join(", ")})`,
+      { backend },
+    );
+  }
+  const defaultBackend = optionalString("defaultBackend");
+  if (
+    defaultBackend !== undefined &&
+    !CODING_BACKENDS.has(defaultBackend as CodingBackend)
+  ) {
+    throw invalid(
+      `Unknown defaultBackend "${defaultBackend}" (expected one of: ${[...CODING_BACKENDS].join(", ")})`,
+      { defaultBackend },
+    );
+  }
+  return {
+    target: target as ModelConfigTarget,
+    model: model.trim(),
+    provider: optionalString("provider"),
+    backend: backend as CodingBackend | undefined,
+    effort: optionalString("effort"),
+    defaultBackend: defaultBackend as CodingBackend | undefined,
+  };
+}
+
+type EffectiveValue = {
+  value: string;
+  source: "config.env" | "config.env.vars" | "process.env" | "default";
+} | null;
+
+function resolveEffective(
+  config: ElizaConfig,
+  processEnv: NodeJS.ProcessEnv,
+  key: string,
+): EffectiveValue {
+  const fromConfig = readConfigEnvString(config, key);
+  if (fromConfig) return fromConfig;
+  const fromProcess = processEnv[key];
+  if (typeof fromProcess === "string" && fromProcess.trim()) {
+    return { value: fromProcess, source: "process.env" };
+  }
+  return null;
+}
+
+function buildEffectiveConfig(
+  config: ElizaConfig,
+  processEnv: NodeJS.ProcessEnv,
+): Record<string, Record<string, EffectiveValue>> {
+  const resolve = (key: string): EffectiveValue =>
+    resolveEffective(config, processEnv, key);
+  const chatKeys = (target: "SMALL" | "LARGE") => ({
+    [`OPENAI_${target}_MODEL`]: resolve(`OPENAI_${target}_MODEL`),
+    [`ANTHROPIC_${target}_MODEL`]: resolve(`ANTHROPIC_${target}_MODEL`),
+    OPENAI_REASONING_EFFORT: resolve("OPENAI_REASONING_EFFORT"),
+    [`ANTHROPIC_EFFORT_${target}`]: resolve(`ANTHROPIC_EFFORT_${target}`),
+  });
+  const codexDefault = CODING_MODEL_DEFAULTS.codex;
+  return {
+    small: chatKeys("SMALL"),
+    large: chatKeys("LARGE"),
+    coding: {
+      ELIZA_DEFAULT_AGENT_TYPE: resolve("ELIZA_DEFAULT_AGENT_TYPE"),
+      ELIZA_CODEX_MODEL_POWERFUL:
+        resolve("ELIZA_CODEX_MODEL_POWERFUL") ??
+        (codexDefault ? { value: codexDefault, source: "default" } : null),
+      ELIZA_CODEX_EFFORT: resolve("ELIZA_CODEX_EFFORT"),
+      ELIZA_CLAUDE_MODEL_POWERFUL: resolve("ELIZA_CLAUDE_MODEL_POWERFUL"),
+      ELIZA_CLAUDE_EFFORT: resolve("ELIZA_CLAUDE_EFFORT"),
+      ELIZA_OPENCODE_MODEL_POWERFUL: resolve("ELIZA_OPENCODE_MODEL_POWERFUL"),
+      ELIZA_ELIZAOS_MODEL_POWERFUL: resolve("ELIZA_ELIZAOS_MODEL_POWERFUL"),
+    },
+  };
+}
+
+/**
+ * Handle `GET`/`POST /api/models/config`. Returns true when the request was
+ * handled.
+ */
+export async function handleModelConfigRoutes(
+  ctx: ModelConfigRouteContext,
+): Promise<boolean> {
+  const { req, res, method, pathname, state, json, readJsonBody } = ctx;
+  if (pathname !== "/api/models/config") return false;
+  const processEnv = ctx.processEnv ?? process.env;
+
+  if (method === "GET") {
+    json(res, { targets: buildEffectiveConfig(state.config, processEnv) });
+    return true;
+  }
+
+  if (method !== "POST") return false;
+
+  const raw = await readJsonBody<Record<string, unknown>>(req, res);
+  if (raw === null) return true;
+
+  try {
+    const body = parseWriteBody(raw);
+    const catalog = ctx.catalog ?? buildModelCatalog();
+
+    if (body.target === "coding") {
+      const writes = resolveCodingWrites(catalog, body);
+      const conflicts: string[] = [];
+      for (const write of writes) {
+        if (
+          writeModelEnvKey(state.config, processEnv, write.key, write.value)
+        ) {
+          conflicts.push(write.key);
+        }
+      }
+      ctx.saveElizaConfig(state.config);
+      logger.info(
+        `[ModelConfigRoutes] coding model config applied: ${writes.map((w) => `${w.key}=${w.value}`).join(" ")}`,
+      );
+      // No restart: the orchestrator re-reads the config env section on every
+      // sub-agent spawn (readConfigEnvKey), so the write is live immediately.
+      json(res, {
+        applied: true,
+        restart: false,
+        keys: writes.map((w) => w.key),
+        ...(conflicts.length > 0
+          ? { conflictingServiceEnvKeys: conflicts }
+          : {}),
+      });
+      return true;
+    }
+
+    const writes = resolveChatWrites(catalog, body);
+    const conflicts: string[] = [];
+    const outcome = await ctx.runtimeOperationManager.start({
+      intent: {
+        kind: "restart",
+        reason: `model-config: ${body.target} model set to ${body.model}`,
+      },
+      // Writing inside prepare keeps the config change atomic with operation
+      // acceptance: a rejected-busy outcome leaves the config untouched.
+      prepare: async () => {
+        for (const write of writes) {
+          if (
+            writeModelEnvKey(state.config, processEnv, write.key, write.value)
+          ) {
+            conflicts.push(write.key);
+          }
+        }
+        ctx.saveElizaConfig(state.config);
+        return undefined;
+      },
+    });
+
+    if (outcome.kind === "rejected-busy") {
+      json(
+        res,
+        {
+          error: "A runtime operation is already in progress",
+          activeOperationId: outcome.activeOperationId,
+        },
+        409,
+      );
+      return true;
+    }
+
+    logger.info(
+      `[ModelConfigRoutes] ${body.target} model config applied: ${writes.map((w) => `${w.key}=${w.value}`).join(" ")} op=${outcome.operation.id}`,
+    );
+    json(res, {
+      applied: outcome.kind === "accepted",
+      restart: true,
+      operationId: outcome.operation.id,
+      keys: writes.map((w) => w.key),
+      ...(outcome.kind === "deduped" ? { deduped: true } : {}),
+      ...(conflicts.length > 0 ? { conflictingServiceEnvKeys: conflicts } : {}),
+    });
+    return true;
+  } catch (err) {
+    // error-policy:J1 route transport boundary — translate the typed
+    // validation failure into a structured 400 and anything else into a 500.
+    if (err instanceof ElizaError) {
+      json(
+        res,
+        { error: err.message, code: err.code, context: err.context },
+        400,
+      );
+      return true;
+    }
+    logger.error(
+      `[ModelConfigRoutes] model config write failed: ${err instanceof Error ? err.stack : String(err)}`,
+    );
+    json(res, { error: "Model config update failed" }, 500);
+    return true;
+  }
+}

--- a/packages/agent/src/api/model-config-routes.ts
+++ b/packages/agent/src/api/model-config-routes.ts
@@ -143,6 +143,15 @@ function findEntry(
   return catalog.providers[provider]?.find((entry) => entry.id === model);
 }
 
+// Mirrors PINNED_CODEX_ACP_EFFORTS in app-core's coding-account-bridge.ts:
+// the effort values the pinned codex-acp adapter's config parser accepts.
+const CODEX_ACP_EFFORTS: ReadonlySet<string> = new Set([
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+]);
+
 function validateEffort(entry: ModelCatalogEntry, effort: string): void {
   if (entry.efforts.length === 0) {
     throw invalid(`Model "${entry.id}" exposes no effort control`, {
@@ -328,7 +337,27 @@ function resolveCodingWrites(
         provider: seam.catalogProvider,
       });
     }
-    if (body.effort !== undefined) validateEffort(entry, body.effort);
+    if (body.effort !== undefined) {
+      validateEffort(entry, body.effort);
+      // The catalog carries the MODEL's truth (sol/terra do support ultra),
+      // but the pinned @zed-industries/codex-acp@0.14.0 adapter cannot parse
+      // `max`/`ultra` in config.toml — the whole file would fail to parse and
+      // drop the model pin ChatGPT-account auth requires. The bridge
+      // (coding-account-bridge.ts, PINNED_CODEX_ACP_EFFORTS) would skip the
+      // write, so accepting the value here would be a silent no-op. Reject it
+      // loudly instead; widen BOTH sets together when the acp pin is bumped.
+      if (backend === "codex" && !CODEX_ACP_EFFORTS.has(body.effort)) {
+        throw invalid(
+          `Effort "${body.effort}" is valid for ${entry.id} but not parseable by the pinned codex-acp adapter (supported until the pin is bumped: ${[...CODEX_ACP_EFFORTS].join(", ")})`,
+          {
+            model: entry.id,
+            effort: body.effort,
+            supported: [...CODEX_ACP_EFFORTS],
+            reason: "codex-acp-pin",
+          },
+        );
+      }
+    }
   } else if (body.effort !== undefined) {
     throw invalid(`backend "${backend}" has no effort control`, {
       backend,

--- a/packages/agent/src/api/models-routes.test.ts
+++ b/packages/agent/src/api/models-routes.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Unit tests for GET /api/models: both response shapes (all-providers and
+ * ?provider=) carry the additive `catalog` field alongside the unchanged
+ * provider-cache payload. Deterministic — cache fetchers and the catalog
+ * builder are injected.
+ */
+import type http from "node:http";
+import { describe, expect, it, vi } from "vitest";
+import type { ModelCatalog } from "./model-catalog";
+import { handleModelsRoutes } from "./models-routes";
+
+const fakeCatalog: ModelCatalog = {
+  providers: {
+    codex: [
+      {
+        id: "gpt-5.6-terra",
+        display: "GPT-5.6-Terra",
+        efforts: ["low"],
+        roles: ["coding"],
+      },
+    ],
+  },
+};
+
+function makeCtx(urlPath: string) {
+  const json = vi.fn();
+  const ctx = {
+    req: {} as http.IncomingMessage,
+    res: {} as http.ServerResponse,
+    method: "GET",
+    pathname: "/api/models",
+    url: new URL(`http://localhost${urlPath}`),
+    json,
+    providerCachePath: (provider: string) => `/tmp/${provider}.json`,
+    getOrFetchProvider: vi.fn(async () => [{ id: "m1" }]),
+    getOrFetchAllProviders: vi.fn(async () => ({ openai: [{ id: "m1" }] })),
+    resolveModelsCacheDir: () => "/tmp",
+    pathExists: () => false,
+    readDir: () => [],
+    unlinkFile: () => {},
+    joinPath: (a: string, b: string) => `${a}/${b}`,
+    buildCatalog: () => fakeCatalog,
+  };
+  return { ctx, json };
+}
+
+describe("handleModelsRoutes catalog field", () => {
+  it("attaches the catalog to the all-providers response", async () => {
+    const { ctx, json } = makeCtx("/api/models");
+    await expect(handleModelsRoutes(ctx as never)).resolves.toBe(true);
+    expect(json).toHaveBeenCalledWith(ctx.res, {
+      providers: { openai: [{ id: "m1" }] },
+      catalog: fakeCatalog,
+    });
+  });
+
+  it("attaches the catalog to the single-provider response", async () => {
+    const { ctx, json } = makeCtx("/api/models?provider=openai");
+    await expect(handleModelsRoutes(ctx as never)).resolves.toBe(true);
+    expect(json).toHaveBeenCalledWith(ctx.res, {
+      provider: "openai",
+      models: [{ id: "m1" }],
+      catalog: fakeCatalog,
+    });
+  });
+
+  it("declines non-matching routes", async () => {
+    const { ctx } = makeCtx("/api/models");
+    ctx.pathname = "/api/models/config";
+    await expect(handleModelsRoutes(ctx as never)).resolves.toBe(false);
+  });
+});

--- a/packages/agent/src/api/models-routes.ts
+++ b/packages/agent/src/api/models-routes.ts
@@ -3,10 +3,14 @@
  * control-API auth gate. Returns provider model lists from an on-disk cache:
  * `?provider=` narrows to one provider, `?refresh=true` busts the cache (a
  * single provider's file, or every cached `.json` for an all-providers fetch)
- * before refetching. Filesystem and fetch access are injected through the
- * route context so the handler stays transport-agnostic and unit-testable.
+ * before refetching. Every response additionally carries a `catalog` field —
+ * the validated provider→model→efforts catalog (model-catalog.ts) that
+ * `POST /api/models/config` writes are checked against. Filesystem and fetch
+ * access are injected through the route context so the handler stays
+ * transport-agnostic and unit-testable.
  */
 import type { RouteHelpers, RouteRequestMeta } from "@elizaos/core";
+import { buildModelCatalog, type ModelCatalog } from "./model-catalog.ts";
 
 export interface ModelsRouteContext
   extends RouteRequestMeta,
@@ -22,6 +26,8 @@ export interface ModelsRouteContext
   readDir: (targetPath: string) => string[];
   unlinkFile: (targetPath: string) => void;
   joinPath: (left: string, right: string) => string;
+  /** Injectable catalog builder for tests; defaults to buildModelCatalog. */
+  buildCatalog?: () => ModelCatalog;
 }
 
 export async function handleModelsRoutes(
@@ -47,6 +53,9 @@ export async function handleModelsRoutes(
 
   const force = url.searchParams.get("refresh") === "true";
   const specificProvider = url.searchParams.get("provider");
+  // Built per request: the codex slice re-reads the CLI's models_cache.json
+  // at call time so a refreshed server catalog shows up without a restart.
+  const catalog = (ctx.buildCatalog ?? buildModelCatalog)();
 
   if (specificProvider) {
     if (force) {
@@ -57,7 +66,7 @@ export async function handleModelsRoutes(
       }
     }
     const models = await getOrFetchProvider(specificProvider, force);
-    json(res, { provider: specificProvider, models });
+    json(res, { provider: specificProvider, models, catalog });
     return true;
   }
 
@@ -75,6 +84,6 @@ export async function handleModelsRoutes(
   }
 
   const all = await getOrFetchAllProviders(force);
-  json(res, { providers: all });
+  json(res, { providers: all, catalog });
   return true;
 }

--- a/packages/agent/src/api/server-lazy-routes.ts
+++ b/packages/agent/src/api/server-lazy-routes.ts
@@ -463,6 +463,17 @@ export async function handleModelsRoutes(
   return (await import("./models-routes.ts")).handleModelsRoutes(...args);
 }
 
+type ModelConfigRoutesModule = typeof import("./model-config-routes.ts");
+export async function handleModelConfigRoutes(
+  ...args: Parameters<ModelConfigRoutesModule["handleModelConfigRoutes"]>
+): ReturnType<ModelConfigRoutesModule["handleModelConfigRoutes"]> {
+  const ctx = routeContext(args);
+  if (ctx?.pathname !== "/api/models/config") return false;
+  return (await import("./model-config-routes.ts")).handleModelConfigRoutes(
+    ...args,
+  );
+}
+
 type MusicPlayerFallbackModule =
   typeof import("./music-player-route-fallback.ts");
 export async function tryHandleMusicPlayerStatusFallbackLazy(

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -441,6 +441,7 @@ import {
   handleMemoryRoutes,
   handleMiscRoutes,
   handleMobileOptionalRoutes,
+  handleModelConfigRoutes,
   handleModelsRoutes,
   handlePermissionRoutes,
   handlePermissionsExtraRoutes,
@@ -2508,6 +2509,29 @@ async function handleRequest(
     })
   ) {
     return;
+  }
+
+  // Gate on the exact path before building the context so the runtime
+  // operation manager is not instantiated on unrelated requests.
+  if (pathname === "/api/models/config") {
+    if (
+      await handleModelConfigRoutes({
+        req,
+        res,
+        method,
+        pathname,
+        json,
+        readJsonBody,
+        state: { config: state.config },
+        saveElizaConfig,
+        runtimeOperationManager: getOrCreateRuntimeOperationManager(
+          state,
+          restartRuntime,
+        ),
+      })
+    ) {
+      return;
+    }
   }
 
   if (

--- a/packages/app-core/src/services/coding-account-bridge.test.ts
+++ b/packages/app-core/src/services/coding-account-bridge.test.ts
@@ -28,6 +28,7 @@ let home: string;
 let prevHome: string | undefined;
 let prevStateDir: string | undefined;
 let prevCodexModel: string | undefined;
+let prevCodexEffort: string | undefined;
 let prevCodingStrategy: string | undefined;
 
 function writeAccount(
@@ -99,6 +100,8 @@ beforeEach(() => {
   prevHome = process.env.ELIZA_HOME;
   prevStateDir = process.env.ELIZA_STATE_DIR;
   prevCodexModel = process.env.ELIZA_CODEX_MODEL;
+  prevCodexEffort = process.env.ELIZA_CODEX_EFFORT;
+  delete process.env.ELIZA_CODEX_EFFORT;
   prevCodingStrategy = process.env.ELIZA_CODING_ACCOUNT_STRATEGY;
   delete process.env.ELIZA_CODING_ACCOUNT_STRATEGY;
   home = mkdtempSync(path.join(tmpdir(), "coding-acct-"));
@@ -118,6 +121,8 @@ afterEach(() => {
   else process.env.ELIZA_STATE_DIR = prevStateDir;
   if (prevCodexModel === undefined) delete process.env.ELIZA_CODEX_MODEL;
   else process.env.ELIZA_CODEX_MODEL = prevCodexModel;
+  if (prevCodexEffort === undefined) delete process.env.ELIZA_CODEX_EFFORT;
+  else process.env.ELIZA_CODEX_EFFORT = prevCodexEffort;
   if (prevCodingStrategy === undefined) {
     delete process.env.ELIZA_CODING_ACCOUNT_STRATEGY;
   } else {
@@ -247,6 +252,86 @@ describe("coding-account-bridge", () => {
     // Clean single model line, no injected table/keys.
     expect(cfg).toMatch(/^model = "[\w.:/-]+"\n$/);
     expect(cfg).not.toContain("[evil]");
+  });
+
+  it("falls back to gpt-5.6-terra when no model is configured anywhere", async () => {
+    writeAccount("openai-codex", "cx-fb", "cx-fb-access", {
+      organizationId: "a",
+    });
+    // Isolate os.homedir() so a real ~/.codex/config.toml on the test machine
+    // can't supply the operator-model fallback and mask the compiled default.
+    const prevOsHome = process.env.HOME;
+    process.env.HOME = home;
+    try {
+      const sel = await (
+        getDefaultAccountPool() && getCodingAgentSelectorBridge()
+      )?.select("codex");
+      const cfg = readFileSync(
+        path.join(sel?.envPatch.CODEX_HOME as string, "config.toml"),
+        "utf-8",
+      );
+      expect(cfg).toBe('model = "gpt-5.6-terra"\n');
+    } finally {
+      if (prevOsHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevOsHome;
+    }
+  });
+
+  it("writes model_reasoning_effort for a valid ELIZA_CODEX_EFFORT", async () => {
+    writeAccount("openai-codex", "cx-eff", "cx-eff-access", {
+      organizationId: "a",
+    });
+    process.env.ELIZA_CODEX_MODEL = "gpt-5.6-terra";
+    process.env.ELIZA_CODEX_EFFORT = "xhigh";
+    const sel = await (
+      getDefaultAccountPool() && getCodingAgentSelectorBridge()
+    )?.select("codex");
+    const cfg = readFileSync(
+      path.join(sel?.envPatch.CODEX_HOME as string, "config.toml"),
+      "utf-8",
+    );
+    expect(cfg).toContain('model = "gpt-5.6-terra"');
+    expect(cfg).toContain('model_reasoning_effort = "xhigh"');
+  });
+
+  it("skips the effort line for an invalid ELIZA_CODEX_EFFORT (keeps the model pin)", async () => {
+    writeAccount("openai-codex", "cx-bad", "cx-bad-access", {
+      organizationId: "a",
+    });
+    process.env.ELIZA_CODEX_MODEL = "gpt-5.6-terra";
+    process.env.ELIZA_CODEX_EFFORT = 'banana"\n[evil]\nx = "1';
+    const sel = await (
+      getDefaultAccountPool() && getCodingAgentSelectorBridge()
+    )?.select("codex");
+    const cfg = readFileSync(
+      path.join(sel?.envPatch.CODEX_HOME as string, "config.toml"),
+      "utf-8",
+    );
+    expect(cfg).toBe('model = "gpt-5.6-terra"\n');
+    expect(cfg).not.toContain("model_reasoning_effort");
+    expect(cfg).not.toContain("[evil]");
+  });
+
+  it("skips ultra/max: valid catalog values the pinned codex-acp cannot parse", async () => {
+    // Writing an effort variant the pinned adapter's serde enum lacks would
+    // fail the WHOLE config.toml parse and drop the model pin ChatGPT-account
+    // auth requires — so these are withheld, not written.
+    writeAccount("openai-codex", "cx-ultra", "cx-ultra-access", {
+      organizationId: "a",
+    });
+    process.env.ELIZA_CODEX_MODEL = "gpt-5.6-sol";
+    for (const effort of ["ultra", "max"]) {
+      process.env.ELIZA_CODEX_EFFORT = effort;
+      __resetDefaultAccountPoolForTests();
+      const sel = await (
+        getDefaultAccountPool() && getCodingAgentSelectorBridge()
+      )?.select("codex");
+      const cfg = readFileSync(
+        path.join(sel?.envPatch.CODEX_HOME as string, "config.toml"),
+        "utf-8",
+      );
+      expect(cfg).toBe('model = "gpt-5.6-sol"\n');
+    }
   });
 
   it("rotates opencode across least-used cerebras-api accounts → CEREBRAS_API_KEY", async () => {

--- a/packages/app-core/src/services/coding-account-bridge.test.ts
+++ b/packages/app-core/src/services/coding-account-bridge.test.ts
@@ -6,7 +6,13 @@
  * CEREBRAS_API_KEY), usage attribution, and rate-limit skipping. Runs against a
  * real temp ELIZA_HOME / ELIZA_STATE_DIR and real account storage — no mocked pool.
  */
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { saveAccount } from "@elizaos/auth/account-storage";
@@ -252,6 +258,67 @@ describe("coding-account-bridge", () => {
     // Clean single model line, no injected table/keys.
     expect(cfg).toMatch(/^model = "[\w.:/-]+"\n$/);
     expect(cfg).not.toContain("[evil]");
+  });
+
+  it("prefers the app-configured ELIZA_CODEX_MODEL_POWERFUL over the machine config", async () => {
+    writeAccount("openai-codex", "cx-pow", "cx-pow-access", {
+      organizationId: "a",
+    });
+    const prevOsHome = process.env.HOME;
+    const prevPowerful = process.env.ELIZA_CODEX_MODEL_POWERFUL;
+    // Isolated HOME carrying a machine ~/.codex/config.toml — without the
+    // POWERFUL read this operator config silently won on every spawn.
+    process.env.HOME = home;
+    mkdirSync(path.join(home, ".codex"), { recursive: true });
+    writeFileSync(
+      path.join(home, ".codex", "config.toml"),
+      'model = "gpt-5.5"\n',
+    );
+    delete process.env.ELIZA_CODEX_MODEL;
+    process.env.ELIZA_CODEX_MODEL_POWERFUL = "gpt-5.6-terra";
+    try {
+      const sel = await (
+        getDefaultAccountPool() && getCodingAgentSelectorBridge()
+      )?.select("codex");
+      const cfg = readFileSync(
+        path.join(sel?.envPatch.CODEX_HOME as string, "config.toml"),
+        "utf-8",
+      );
+      expect(cfg).toContain('model = "gpt-5.6-terra"');
+    } finally {
+      if (prevOsHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevOsHome;
+      if (prevPowerful === undefined) {
+        delete process.env.ELIZA_CODEX_MODEL_POWERFUL;
+      } else {
+        process.env.ELIZA_CODEX_MODEL_POWERFUL = prevPowerful;
+      }
+    }
+  });
+
+  it("lets an explicit ELIZA_CODEX_MODEL pin beat the app-configured model", async () => {
+    writeAccount("openai-codex", "cx-pin", "cx-pin-access", {
+      organizationId: "a",
+    });
+    const prevPowerful = process.env.ELIZA_CODEX_MODEL_POWERFUL;
+    process.env.ELIZA_CODEX_MODEL = "gpt-5.5";
+    process.env.ELIZA_CODEX_MODEL_POWERFUL = "gpt-5.6-terra";
+    try {
+      const sel = await (
+        getDefaultAccountPool() && getCodingAgentSelectorBridge()
+      )?.select("codex");
+      const cfg = readFileSync(
+        path.join(sel?.envPatch.CODEX_HOME as string, "config.toml"),
+        "utf-8",
+      );
+      expect(cfg).toContain('model = "gpt-5.5"');
+    } finally {
+      if (prevPowerful === undefined) {
+        delete process.env.ELIZA_CODEX_MODEL_POWERFUL;
+      } else {
+        process.env.ELIZA_CODEX_MODEL_POWERFUL = prevPowerful;
+      }
+    }
   });
 
   it("falls back to gpt-5.6-terra when no model is configured anywhere", async () => {

--- a/packages/app-core/src/services/coding-account-bridge.ts
+++ b/packages/app-core/src/services/coding-account-bridge.ts
@@ -241,6 +241,36 @@ export async function adoptRotatedCodexTokens(
 }
 
 /**
+ * Reasoning-effort values the Codex model catalog knows. Codex itself silently
+ * accepts an invalid `model_reasoning_effort`, so validation is on us: an
+ * unknown operator value is warned about and dropped, never interpolated.
+ */
+const CODEX_EFFORT_VALUES: ReadonlySet<string> = new Set([
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+  "ultra",
+]);
+
+/**
+ * The effort subset the pinned codex-acp adapter can deserialize. Its bundled
+ * codex core's `ReasoningEffort` enum is `minimal|low|medium|high|xhigh`
+ * (verified against the @zed-industries/codex-acp@0.14.0 binary's serde
+ * variant table); an unknown variant fails the WHOLE config.toml parse, which
+ * would also discard the `model` pin ChatGPT-account auth requires — far worse
+ * than running at the default effort. `max`/`ultra` are valid catalog values
+ * on newer Codex builds but are withheld here until the adapter pin moves.
+ */
+const PINNED_CODEX_ACP_EFFORTS: ReadonlySet<string> = new Set([
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+]);
+
+/**
  * Materialize a per-account `CODEX_HOME` so Codex authenticates as the selected
  * account instead of the machine's single `~/.codex` login. Writes the
  * ChatGPT-login `auth.json` shape Codex reads; the account_id is the OAuth
@@ -279,10 +309,12 @@ function materializeCodexHome(accountId: string, accessToken: string): string {
   // Codex reads its model from CODEX_HOME/config.toml; with none, codex-acp
   // falls back to a built-in default (e.g. gpt-5.3-codex) that ChatGPT-account
   // auth rejects ("model is not supported when using Codex with a ChatGPT
-  // account"). Write a MINIMAL config.toml with just the model — reusing the
-  // operator's working model (extracted from ~/.codex/config.toml) but NOT the
-  // rest of their config, which can carry fields the pinned codex-acp rejects
-  // (e.g. newer reasoning-effort variants). Falls back to a compatible default.
+  // account"). Write a MINIMAL config.toml — the model plus an optional
+  // validated reasoning effort — reusing the operator's working model
+  // (extracted from ~/.codex/config.toml) but NOT the rest of their config,
+  // which can carry fields the pinned codex-acp rejects (e.g. newer
+  // reasoning-effort variants; see PINNED_CODEX_ACP_EFFORTS). Falls back to a
+  // compatible default.
   const targetConfig = path.join(dir, "config.toml");
   try {
     let model = process.env.ELIZA_CODEX_MODEL?.trim();
@@ -307,9 +339,29 @@ function materializeCodexHome(accountId: string, accessToken: string): string {
         if (m?.[1]) model = m[1];
       }
     }
-    writeFileSync(targetConfig, `model = "${model || "gpt-5.1-codex"}"\n`, {
-      mode: 0o600,
-    });
+    let effort = process.env.ELIZA_CODEX_EFFORT?.trim().toLowerCase();
+    if (effort && !CODEX_EFFORT_VALUES.has(effort)) {
+      // error-policy:J7 an invalid operator effort must not poison the spawn —
+      // warn and omit the line; the model pin below still ships.
+      logger.warn(
+        `[coding-account-bridge] ignoring invalid ELIZA_CODEX_EFFORT=${JSON.stringify(effort)} (expected low|medium|high|xhigh|max|ultra)`,
+      );
+      effort = undefined;
+    } else if (effort && !PINNED_CODEX_ACP_EFFORTS.has(effort)) {
+      // error-policy:J7 see PINNED_CODEX_ACP_EFFORTS — writing max/ultra would
+      // fail the pinned adapter's whole config.toml parse and drop the model pin.
+      logger.warn(
+        `[coding-account-bridge] ELIZA_CODEX_EFFORT=${JSON.stringify(effort)} is not parseable by the pinned codex-acp (supported: low|medium|high|xhigh); omitting model_reasoning_effort so config.toml stays loadable`,
+      );
+      effort = undefined;
+    }
+    writeFileSync(
+      targetConfig,
+      `model = "${model || "gpt-5.6-terra"}"\n${
+        effort ? `model_reasoning_effort = "${effort}"\n` : ""
+      }`,
+      { mode: 0o600 },
+    );
   } catch (err) {
     logger.warn(
       `[coding-account-bridge] could not materialize codex config.toml: ${String(err)}`,

--- a/packages/app-core/src/services/coding-account-bridge.ts
+++ b/packages/app-core/src/services/coding-account-bridge.ts
@@ -317,15 +317,26 @@ function materializeCodexHome(accountId: string, accessToken: string): string {
   // compatible default.
   const targetConfig = path.join(dir, "config.toml");
   try {
-    let model = process.env.ELIZA_CODEX_MODEL?.trim();
-    // Validate the operator-supplied model: it is interpolated into TOML, so a
-    // stray quote/newline would break out of the string (corrupt config) — and
-    // a model name is a conservative token anyway. Reject anything else.
-    if (model && !/^[\w.:/-]+$/.test(model)) {
-      logger.warn(
-        `[coding-account-bridge] ignoring malformed ELIZA_CODEX_MODEL=${JSON.stringify(model)}`,
-      );
-      model = undefined;
+    // Resolution order: explicit env pin > app-configured model (what
+    // POST /api/models/config writes for the codex coding target) > the
+    // operator's machine config > the compatible default. Without the
+    // POWERFUL read here, the app-configured model was a dead-end key — the
+    // machine ~/.codex/config.toml silently won on every spawn.
+    let model: string | undefined;
+    for (const key of ["ELIZA_CODEX_MODEL", "ELIZA_CODEX_MODEL_POWERFUL"]) {
+      const candidate = process.env[key]?.trim();
+      if (!candidate) continue;
+      // Validate the operator-supplied model: it is interpolated into TOML, so
+      // a stray quote/newline would break out of the string (corrupt config) —
+      // and a model name is a conservative token anyway. Reject anything else.
+      if (!/^[\w.:/-]+$/.test(candidate)) {
+        logger.warn(
+          `[coding-account-bridge] ignoring malformed ${key}=${JSON.stringify(candidate)}`,
+        );
+        continue;
+      }
+      model = candidate;
+      break;
     }
     if (!model) {
       const machineConfig = path.join(os.homedir(), ".codex", "config.toml");
@@ -460,9 +471,7 @@ function makeBridge(pool: AccountPool): CodingAgentSelectorBridge {
           providerId === "anthropic-subscription"
             ? {
                 minRemainingMs: claudeMinRemainingMs(
-                  resolveClaudeExpectedRunMs(
-                    (key) => process.env[key],
-                  ),
+                  resolveClaudeExpectedRunMs((key) => process.env[key]),
                 ),
               }
             : undefined;

--- a/packages/app-core/test/helpers/live-provider.ts
+++ b/packages/app-core/test/helpers/live-provider.ts
@@ -464,7 +464,7 @@ function selectCliProvider(): LiveProviderConfig | null {
   const isCodex = backend.startsWith("codex");
   const model = isCodex
     ? getTrimmedEnv("ELIZA_CLI_CODEX_MODEL") || "gpt-5.5"
-    : getTrimmedEnv("ELIZA_CLI_CLAUDE_MODEL") || "claude-opus-4-7";
+    : getTrimmedEnv("ELIZA_CLI_CLAUDE_MODEL") || "claude-opus-4-8";
 
   const env: Record<string, string> = { ELIZA_CHAT_VIA_CLI: backend };
   for (const envVar of CLI_PASSTHROUGH_ENV_VARS) {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/multi-account-spawn.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/multi-account-spawn.test.ts
@@ -452,3 +452,71 @@ describe("claude effort env (ELIZA_CLAUDE_EFFORT → CLAUDE_CODE_EFFORT_LEVEL)",
     expect(env.CLAUDE_CODE_EFFORT_LEVEL).toBeUndefined();
   });
 });
+
+// Same buildEnv surface again: the app-configured claude coding model
+// (ELIZA_CLAUDE_MODEL_POWERFUL, written by POST /api/models/config) must reach
+// the spawned Claude Code CLI as ANTHROPIC_MODEL when the spawn carries no
+// explicit model — before this fallback the key was write-only.
+describe("claude model env (ELIZA_CLAUDE_MODEL_POWERFUL → ANTHROPIC_MODEL)", () => {
+  let tempDir: string;
+  let prevConfigPath: string | undefined;
+  let prevAnthropicModel: string | undefined;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "acp-model-"));
+    prevConfigPath = process.env.ELIZA_CONFIG_PATH;
+    prevAnthropicModel = process.env.ANTHROPIC_MODEL;
+    // A host-level ANTHROPIC_MODEL would forward via the allowlist and mask
+    // the config-driven assertion below.
+    delete process.env.ANTHROPIC_MODEL;
+  });
+
+  afterEach(() => {
+    if (prevConfigPath === undefined) delete process.env.ELIZA_CONFIG_PATH;
+    else process.env.ELIZA_CONFIG_PATH = prevConfigPath;
+    if (prevAnthropicModel === undefined) delete process.env.ANTHROPIC_MODEL;
+    else process.env.ANTHROPIC_MODEL = prevAnthropicModel;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function writeConfig(env: Record<string, string>): void {
+    const file = path.join(tempDir, "eliza.json");
+    fs.writeFileSync(file, JSON.stringify({ env }));
+    process.env.ELIZA_CONFIG_PATH = file;
+  }
+
+  async function spawnAndGetEnv(
+    agentType: string,
+    model?: string,
+  ): Promise<NodeJS.ProcessEnv> {
+    const service = new AcpService(runtime());
+    await service.start();
+    await service.spawnSession({
+      name: `${agentType}-model`,
+      agentType: agentType as never,
+      workdir: "/tmp/acp-test",
+      ...(model ? { model } : {}),
+    });
+    const env = firstNativeClient().opts.env ?? {};
+    await service.stop();
+    return env;
+  }
+
+  it("sets ANTHROPIC_MODEL from a freshly-saved config value (no restart)", async () => {
+    writeConfig({ ELIZA_CLAUDE_MODEL_POWERFUL: "claude-opus-4-8" });
+    const env = await spawnAndGetEnv("claude");
+    expect(env.ANTHROPIC_MODEL).toBe("claude-opus-4-8");
+  });
+
+  it("lets an explicit per-spawn model beat the configured one", async () => {
+    writeConfig({ ELIZA_CLAUDE_MODEL_POWERFUL: "claude-opus-4-8" });
+    const env = await spawnAndGetEnv("claude", "claude-sonnet-5");
+    expect(env.ANTHROPIC_MODEL).toBe("claude-sonnet-5");
+  });
+
+  it("does not set ANTHROPIC_MODEL for non-claude agent types", async () => {
+    writeConfig({ ELIZA_CLAUDE_MODEL_POWERFUL: "claude-opus-4-8" });
+    const env = await spawnAndGetEnv("codex");
+    expect(env.ANTHROPIC_MODEL).toBeUndefined();
+  });
+});

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/multi-account-spawn.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/multi-account-spawn.test.ts
@@ -4,6 +4,9 @@
  * with single-account fallback when the bridge is absent.
  */
 
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { CODING_AGENT_SELECTOR_BRIDGE_SYMBOL } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
@@ -374,5 +377,78 @@ describe("multi-account coding-agent spawn", () => {
       nativeClientMock.instances[1]?.opts.env?.CLAUDE_CODE_OAUTH_TOKEN,
     ).toBe("sk-ant-oat-acc-b");
     await service.stop();
+  });
+});
+
+// Same spawn-env surface (buildEnv), different knob: the config-env
+// ELIZA_CLAUDE_EFFORT → CLAUDE_CODE_EFFORT_LEVEL plumbing for the Claude Code
+// CLI. Uses a real temp config file behind ELIZA_CONFIG_PATH to prove a
+// freshly-saved UI value applies on the next spawn without a restart.
+describe("claude effort env (ELIZA_CLAUDE_EFFORT → CLAUDE_CODE_EFFORT_LEVEL)", () => {
+  let tempDir: string;
+  let prevConfigPath: string | undefined;
+  let prevEffort: string | undefined;
+  let prevEffortLevel: string | undefined;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "acp-effort-"));
+    prevConfigPath = process.env.ELIZA_CONFIG_PATH;
+    prevEffort = process.env.ELIZA_CLAUDE_EFFORT;
+    prevEffortLevel = process.env.CLAUDE_CODE_EFFORT_LEVEL;
+    delete process.env.ELIZA_CLAUDE_EFFORT;
+    // A host-level effort would forward via the allowlist and mask the
+    // config-driven assertion below.
+    delete process.env.CLAUDE_CODE_EFFORT_LEVEL;
+  });
+
+  afterEach(() => {
+    if (prevConfigPath === undefined) delete process.env.ELIZA_CONFIG_PATH;
+    else process.env.ELIZA_CONFIG_PATH = prevConfigPath;
+    if (prevEffort === undefined) delete process.env.ELIZA_CLAUDE_EFFORT;
+    else process.env.ELIZA_CLAUDE_EFFORT = prevEffort;
+    if (prevEffortLevel === undefined) {
+      delete process.env.CLAUDE_CODE_EFFORT_LEVEL;
+    } else {
+      process.env.CLAUDE_CODE_EFFORT_LEVEL = prevEffortLevel;
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function writeConfig(env: Record<string, string>): void {
+    const file = path.join(tempDir, "eliza.json");
+    fs.writeFileSync(file, JSON.stringify({ env }));
+    process.env.ELIZA_CONFIG_PATH = file;
+  }
+
+  async function spawnAndGetEnv(agentType: string): Promise<NodeJS.ProcessEnv> {
+    const service = new AcpService(runtime());
+    await service.start();
+    await service.spawnSession({
+      name: `${agentType}-effort`,
+      agentType: agentType as never,
+      workdir: "/tmp/acp-test",
+    });
+    const env = firstNativeClient().opts.env ?? {};
+    await service.stop();
+    return env;
+  }
+
+  it("sets CLAUDE_CODE_EFFORT_LEVEL from a freshly-saved config value (no restart)", async () => {
+    // Mixed case proves the value is normalized before the CLI sees it.
+    writeConfig({ ELIZA_CLAUDE_EFFORT: "Max" });
+    const env = await spawnAndGetEnv("claude");
+    expect(env.CLAUDE_CODE_EFFORT_LEVEL).toBe("max");
+  });
+
+  it("skips an invalid effort — the spawn proceeds and the CLI keeps its default", async () => {
+    writeConfig({ ELIZA_CLAUDE_EFFORT: "turbo" });
+    const env = await spawnAndGetEnv("claude");
+    expect(env.CLAUDE_CODE_EFFORT_LEVEL).toBeUndefined();
+  });
+
+  it("does not set the effort env for non-claude agent types", async () => {
+    writeConfig({ ELIZA_CLAUDE_EFFORT: "max" });
+    const env = await spawnAndGetEnv("codex");
+    expect(env.CLAUDE_CODE_EFFORT_LEVEL).toBeUndefined();
   });
 });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/should-forward-env.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/should-forward-env.test.ts
@@ -29,6 +29,7 @@ describe("shouldForwardEnv", () => {
     expect(shouldForwardEnv("ANTHROPIC_API_KEY")).toBe(true);
     expect(shouldForwardEnv("OPENAI_API_KEY")).toBe(true);
     expect(shouldForwardEnv("CEREBRAS_BASE_URL")).toBe(true);
+    expect(shouldForwardEnv("CLAUDE_CODE_EFFORT_LEVEL")).toBe(true);
     expect(shouldForwardEnv("PATH")).toBe(true);
   });
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-agent-frameworks.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-agent-frameworks.test.ts
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearTaskAgentFrameworkStateCache,
   getTaskAgentFrameworkState,
+  getTaskAgentModelPrefs,
   type TaskAgentFrameworkProbe,
 } from "../../src/services/task-agent-frameworks.js";
 
@@ -238,5 +239,66 @@ describe("getTaskAgentFrameworkState", () => {
       preflightState.frameworks.find((item) => item.id === "codex")
         ?.installCommand,
     ).toBe("preflight-codex-install");
+  });
+});
+
+// Model prefs must honor a freshly-saved config-file value on the NEXT spawn:
+// runtime.getSetting snapshots character settings at boot, so config-env is
+// checked first (matching how the codex/opencode prefs already behave).
+describe("getTaskAgentModelPrefs", () => {
+  const PREF_ENV_KEYS = [
+    "ELIZA_CONFIG_PATH",
+    "ELIZA_CLAUDE_MODEL_POWERFUL",
+    "ELIZA_CLAUDE_MODEL_FAST",
+  ] as const;
+  const savedPrefEnv = new Map<string, string | undefined>();
+  let prefTempHome: string;
+
+  beforeEach(() => {
+    for (const key of PREF_ENV_KEYS) {
+      savedPrefEnv.set(key, process.env[key]);
+      delete process.env[key];
+    }
+    prefTempHome = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-modelprefs-"));
+    process.env.ELIZA_CONFIG_PATH = path.join(
+      prefTempHome,
+      "missing-eliza.json",
+    );
+  });
+
+  afterEach(() => {
+    for (const key of PREF_ENV_KEYS) {
+      const value = savedPrefEnv.get(key);
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    savedPrefEnv.clear();
+    fs.rmSync(prefTempHome, { recursive: true, force: true });
+  });
+
+  it("defaults the claude powerful model to claude-opus-4-8", () => {
+    const prefs = getTaskAgentModelPrefs(runtime(), "claude");
+    expect(prefs?.powerful).toBe("claude-opus-4-8");
+  });
+
+  it("resolves a freshly-saved config value without restart (config beats the stale runtime snapshot)", () => {
+    const configPath = path.join(prefTempHome, "eliza.json");
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        env: { ELIZA_CLAUDE_MODEL_POWERFUL: "claude-sonnet-5" },
+      }),
+    );
+    process.env.ELIZA_CONFIG_PATH = configPath;
+    // The runtime still holds the boot-time value — the config file must win.
+    const stale = runtime({ ELIZA_CLAUDE_MODEL_POWERFUL: "claude-opus-4-7" });
+    expect(getTaskAgentModelPrefs(stale, "claude")?.powerful).toBe(
+      "claude-sonnet-5",
+    );
+    // Without the config entry, the runtime setting is the fallback.
+    fs.writeFileSync(configPath, JSON.stringify({ env: {} }));
+    expect(getTaskAgentModelPrefs(stale, "claude")?.powerful).toBe(
+      "claude-opus-4-7",
+    );
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -3719,6 +3719,15 @@ export class AcpService extends Service {
       env.OPENAI_MODEL = model;
       if (agentType === "claude") env.ANTHROPIC_MODEL = model;
       if (agentType === "opencode") env.OPENCODE_MODEL = model;
+    } else if (agentType === "claude") {
+      // No per-spawn model: fall back to the app-configured claude coding
+      // model (what POST /api/models/config writes). Config-env read, so a
+      // UI/API save applies to the next spawn with no restart. Without this
+      // the key was write-only — no spawn path ever consumed it.
+      const configured = readConfigEnvKey(
+        "ELIZA_CLAUDE_MODEL_POWERFUL",
+      )?.trim();
+      if (configured) env.ANTHROPIC_MODEL = configured;
     }
     if (childSessionId?.trim()) {
       env.PARALLAX_SESSION_ID = childSessionId.trim();
@@ -3968,7 +3977,9 @@ export class AcpService extends Service {
   private authFailureFields(
     text: string,
     agentType?: AgentType,
-  ): { failureKind: "auth"; authReason?: "token_expired" } | Record<string, never> {
+  ):
+    | { failureKind: "auth"; authReason?: "token_expired" }
+    | Record<string, never> {
     // Explicit token-expiry phrasing ("token expired", "session expired", …) is
     // auth-shaped too, but `isAuthText` only matches 401/unauthorized/
     // authenticate/login/api key/invalid_grant — NOT a bare "expired" — so a run

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -189,6 +189,19 @@ const DEFAULT_WORKDIR_ROOT = join(tmpdir(), "eliza-acp");
 const DEFAULT_CODEX_ACP_COMMAND = "npx -y @zed-industries/codex-acp@0.14.0";
 const CODEX_NO_LANDLOCK_SANDBOX_MODE: CodexSandboxMode = "danger-full-access";
 const CODEX_NO_LANDLOCK_APPROVAL_POLICY = "never";
+/**
+ * Effort levels the Claude Code CLI honors via CLAUDE_CODE_EFFORT_LEVEL (its
+ * own default is xhigh). The CLI does not validate the env var, so buildEnv
+ * gates the config-env ELIZA_CLAUDE_EFFORT value against this set and skips
+ * anything else instead of forwarding a value the CLI would misread.
+ */
+const CLAUDE_CODE_EFFORT_LEVELS: ReadonlySet<string> = new Set([
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+]);
 
 /**
  * Resolve the absolute workdir for a spawned session. When `isolate` is true,
@@ -3710,6 +3723,25 @@ export class AcpService extends Service {
     if (childSessionId?.trim()) {
       env.PARALLAX_SESSION_ID = childSessionId.trim();
     }
+    if (agentType === "claude") {
+      // Config-env (UI-saved, restart-free — falls back to process.env) effort
+      // override for the spawned Claude Code CLI.
+      const effort = readConfigEnvKey("ELIZA_CLAUDE_EFFORT")
+        ?.trim()
+        .toLowerCase();
+      if (effort) {
+        if (CLAUDE_CODE_EFFORT_LEVELS.has(effort)) {
+          env.CLAUDE_CODE_EFFORT_LEVEL = effort;
+        } else {
+          // error-policy:J7 a bad operator effort must not fail the spawn —
+          // warn and leave the CLI on its own default.
+          this.log("warn", "ignoring invalid ELIZA_CLAUDE_EFFORT", {
+            value: effort,
+            expected: [...CLAUDE_CODE_EFFORT_LEVELS],
+          });
+        }
+      }
+    }
     if (agentType === "claude" && env.CLAUDE_CODE_OAUTH_TOKEN) {
       // A specific subscription account was selected for this sub-agent. Claude
       // Code prefers ANTHROPIC_API_KEY over CLAUDE_CODE_OAUTH_TOKEN, so drop any
@@ -4324,6 +4356,9 @@ export function shouldForwardEnv(
       "OPENAI_MODEL",
       "ANTHROPIC_MODEL",
       "OPENCODE_MODEL",
+      // Claude Code CLI reasoning-effort knob; buildEnv also sets it from the
+      // validated config-env ELIZA_CLAUDE_EFFORT for claude spawns.
+      "CLAUDE_CODE_EFFORT_LEVEL",
       "OPENCODE_DISABLE_AUTOUPDATE",
       "OPENCODE_DISABLE_TERMINAL_TITLE",
       "CODEX_HOME",

--- a/plugins/plugin-agent-orchestrator/src/services/opencode-config.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/opencode-config.ts
@@ -188,7 +188,7 @@ export function buildOpencodeSpawnConfig(
       OPENCODE_OPENAI_COMPATIBLE_NPM,
       ELIZA_CLOUD_OPENAI_BASE,
       cloudKey,
-      powerful || "claude-opus-4-7",
+      powerful || "claude-opus-4-8",
       fast || "claude-haiku-4-5",
     );
   }

--- a/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
@@ -285,7 +285,9 @@ export const TASK_AGENT_DEFAULT_MODEL_PREFS: Record<
   elizaos: {},
   "pi-agent": {},
   claude: { powerful: "claude-opus-4-7" },
-  codex: { powerful: "gpt-5.5", fast: "gpt-5.4-mini" },
+  // The codex powerful default mirrors CODING_MODEL_DEFAULTS in
+  // packages/agent/src/api/model-catalog.ts — keep the two in sync.
+  codex: { powerful: "gpt-5.6-terra", fast: "gpt-5.4-mini" },
   opencode: {},
 };
 

--- a/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
@@ -284,7 +284,7 @@ export const TASK_AGENT_DEFAULT_MODEL_PREFS: Record<
 > = {
   elizaos: {},
   "pi-agent": {},
-  claude: { powerful: "claude-opus-4-7" },
+  claude: { powerful: "claude-opus-4-8" },
   // The codex powerful default mirrors CODING_MODEL_DEFAULTS in
   // packages/agent/src/api/model-catalog.ts — keep the two in sync.
   codex: { powerful: "gpt-5.6-terra", fast: "gpt-5.4-mini" },

--- a/plugins/plugin-anthropic/__tests__/native-plumbing.shape.test.ts
+++ b/plugins/plugin-anthropic/__tests__/native-plumbing.shape.test.ts
@@ -573,7 +573,7 @@ describe("Anthropic model defaults", () => {
     } as IAgentRuntime;
 
     expect(getResponseHandlerModel(runtime)).toBe("claude-haiku-4-5-20251001");
-    expect(getActionPlannerModel(runtime)).toBe("claude-opus-4-7");
+    expect(getActionPlannerModel(runtime)).toBe("claude-opus-4-8");
 
     const overrideRuntime = {
       getSetting: vi.fn((key: string) => {

--- a/plugins/plugin-anthropic/package.json
+++ b/plugins/plugin-anthropic/package.json
@@ -108,7 +108,7 @@
         "type": "string",
         "description": "Override the default Anthropic large model identifier used by the plugin",
         "required": false,
-        "default": "claude-opus-4-7",
+        "default": "claude-opus-4-8",
         "sensitive": false
       },
       "ANTHROPIC_EXPERIMENTAL_TELEMETRY": {

--- a/plugins/plugin-anthropic/registry-entry.json
+++ b/plugins/plugin-anthropic/registry-entry.json
@@ -35,7 +35,7 @@
       "type": "string",
       "required": false,
       "sensitive": false,
-      "default": "claude-opus-4-7",
+      "default": "claude-opus-4-8",
       "label": "Large Model",
       "help": "Override the default Anthropic large model identifier used by the plugin",
       "placeholder": "e.g., gpt-4o, claude-sonnet-4-20250514",

--- a/plugins/plugin-anthropic/utils/config.ts
+++ b/plugins/plugin-anthropic/utils/config.ts
@@ -12,7 +12,7 @@ import type { ModelName, ModelSize, ValidatedApiKey } from "../types";
 import { createModelName } from "../types";
 
 const DEFAULT_SMALL_MODEL = "claude-haiku-4-5-20251001";
-const DEFAULT_LARGE_MODEL = "claude-opus-4-7";
+const DEFAULT_LARGE_MODEL = "claude-opus-4-8";
 const DEFAULT_BASE_URL = "https://api.anthropic.com/v1";
 
 export function isBrowser(): boolean {


### PR DESCRIPTION
# Model configuration API — catalog + validated config routes + spawn wiring (stage 1)

Lets an operator set the **small / large / coding sub-agent** models (and per-model reasoning effort) through one validated API, with the config actually reaching the running system: chat-brain writes restart the runtime through the operation manager; coding writes apply to the **next spawn with no restart**.

## What's in here

**`GET /api/models` → `catalog`** (additive field) — provider→model catalog with per-model effort lists, defaults, roles, and cost hints:
- **codex**: static table for gpt-5.6-sol/terra/luna, gpt-5.5/5.4/5.4-mini, spark (`apiSupported:false`), live-merged with the operator's `$CODEX_HOME/models_cache.json` (server view wins per id; corrupt/absent cache degrades to the static table — error-policy:J4)
- **claude chat/coding**: fable-5 + opus-4-8/4-7/4-6 + sonnet + haiku with per-model effort gates (xhigh/max only where the API accepts them)
- **cerebras / elizacloud**: gemma-4-31b, zai-glm-4.7, gpt-oss-120b — all three carry the `low/medium/high` `reasoning_effort` knob (**live-probed 2026-07-12**: glm modulates 90→1337 reasoning chars low→high, gemma 663→1133)

**`GET/POST /api/models/config`** — validated writes + source-attributed reads:
- POST validates target/backend/provider/model/role/effort against the catalog and writes the dual config seam (`config.env` + `config.env.vars` + `process.env`)
- chat targets request a runtime restart via the operation manager; coding targets return `restart:false`
- GET reports every key with its resolution source (`config.env` / `process.env` / `default`)
- **codex-acp pin gate**: `max`/`ultra` are valid for gpt-5.6-terra per the live catalog, but the pinned `@zed-industries/codex-acp@0.14.0` config parser cannot parse them — writing them would fail the whole `config.toml` parse and drop the model pin. The route rejects them with a typed 400 naming the pin; the bridge carries a matching two-tier guard.

**Spawn wiring (the part that makes the keys real):**
- `coding-account-bridge`: per-account `CODEX_HOME/config.toml` now resolves model as explicit `ELIZA_CODEX_MODEL` pin > app-configured `ELIZA_CODEX_MODEL_POWERFUL` > operator machine config > `gpt-5.6-terra` default, and writes a validated `model_reasoning_effort` from `ELIZA_CODEX_EFFORT`. Before this the app-configured key was **write-only** — the machine `~/.codex/config.toml` silently won every spawn (caught by the live spawn proof below).
- `acp-service.buildEnv`: claude spawns read config-env `ELIZA_CLAUDE_EFFORT` → `CLAUDE_CODE_EFFORT_LEVEL` (validated) and fall back to `ELIZA_CLAUDE_MODEL_POWERFUL` → `ANTHROPIC_MODEL` when the spawn carries no explicit model. Both are config-env reads: a UI/API save applies to the next spawn without restart.
- coding defaults: codex powerful `gpt-5.6-terra` (mirrored in `CODING_MODEL_DEFAULTS`), claude powerful `claude-opus-4-8`; plugin-anthropic default bumped opus-4-7 → opus-4-8.

## Evidence — all live against the running agent (not mocks)

<details><summary>Catalog + source-attributed GET (live)</summary>

```
$ GET /api/models → catalog
providers: ['codex', 'claude-chat', 'claude-coding', 'cerebras', 'elizacloud']
codex ids: ['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna', 'gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.3-codex-spark']   # live models_cache.json merge
terra: {'efforts': ['low','medium','high','xhigh','max','ultra'], 'defaultEffort': 'medium', 'costHint': 'highest cost/latency tier'}
cerebras: [('gemma-4-31b', ['low','medium','high']), ('zai-glm-4.7', ['low','medium','high']), ('gpt-oss-120b', ['low','medium','high'])]

$ GET /api/models/config (after write + restart — values survive with correct source)
ELIZA_CODEX_MODEL_POWERFUL {'value': 'gpt-5.6-terra', 'source': 'config.env'}
ELIZA_CODEX_EFFORT         {'value': 'xhigh',         'source': 'config.env'}
```
</details>

<details><summary>Validation rejections (live, typed 400s)</summary>

```
$ POST {"target":"coding","backend":"codex","model":"gpt-5.6-terra","effort":"ultra"}
{"error":"Effort \"ultra\" is valid for gpt-5.6-terra but not parseable by the pinned codex-acp adapter (supported until the pin is bumped: low, medium, high, xhigh)",
 "code":"MODEL_CONFIG_INVALID","context":{"model":"gpt-5.6-terra","effort":"ultra","supported":["low","medium","high","xhigh"],"reason":"codex-acp-pin"}}

$ POST {"target":"small","provider":"cerebras","model":"gemma-4-31b","effort":"xhigh"}
{"error":"Effort \"xhigh\" is not supported by model \"gemma-4-31b\" (supported: low, medium, high)","code":"MODEL_CONFIG_INVALID",...}
```
</details>

<details><summary>Codex spawn proof — config reaches the generated per-account config.toml</summary>

```
$ POST {"target":"coding","backend":"codex","model":"gpt-5.6-terra","effort":"xhigh"}
{"applied":true,"restart":false,"keys":["ELIZA_CODEX_MODEL_POWERFUL","ELIZA_CODEX_EFFORT"]}

$ POST /api/coding-agents/spawn {"agentType":"codex",...} @ 01:22:34
$ cat ~/.milady/auth/_codex-home/codex2/config.toml   (regenerated 01:22:34)
model = "gpt-5.6-terra"
model_reasoning_effort = "xhigh"
```
(First iteration of this proof caught the write-only-key bug: config.toml said `gpt-5.5` from the machine config. Fixed in the bridge, re-proven above.)
</details>

<details><summary>Claude spawn proof — child process env (read from /proc while running)</summary>

```
$ POST {"target":"coding","backend":"claude","model":"claude-opus-4-8","effort":"max"}
{"applied":true,"restart":false,"keys":["ELIZA_CLAUDE_MODEL_POWERFUL","ELIZA_CLAUDE_EFFORT"]}

$ POST /api/coding-agents/spawn {"agentType":"claude",...}; read spawned claude-agent-acp env:
ANTHROPIC_MODEL=claude-opus-4-8
CLAUDE_CODE_EFFORT_LEVEL=max
```
</details>

<details><summary>Chat-target restart semantics + live brain probe</summary>

```
$ POST {"target":"small","provider":"cerebras","model":"gemma-4-31b","effort":"low"}
{"applied":true,"restart":true,"operationId":"ce4ff11e-...","keys":["OPENAI_SMALL_MODEL","OPENAI_REASONING_EFFORT"]}
→ runtime restarted itself via the operation manager (health: restarted, uptime=18s)

Live Discord probe after migrating the chat-brain pins to config.env:
trajectory tj-ef7b9e9e46bcd7: user "quick check: what is 17+25?" → replyText "17 + 25 = 42" (clean simple route)
```
</details>

<details><summary>Cerebras reasoning_effort live probes (ground truth for the catalog)</summary>

Probed 2026-07-12 against api.cerebras.ai with `reasoning_effort` low/medium/high:
- zai-glm-4.7: reasoning length 90 → 594 → 1337 chars (low→medium→high)
- gemma-4-31b: 663 → 941 → 1133
- gpt-oss-120b: modulates as documented
All three carry the knob in the catalog; effort values outside low/medium/high are rejected.
</details>

## Tests

- `packages/agent`: model-catalog 20✓, model-config-routes 21✓, models-routes 3✓ (44 total), typecheck ✓
- `packages/app-core`: coding-account-bridge 23✓ (incl. new POWERFUL-beats-machine-config and env-pin-beats-POWERFUL cases), typecheck ✓
- `plugin-agent-orchestrator`: multi-account-spawn 12✓ (incl. new `ELIZA_CLAUDE_MODEL_POWERFUL → ANTHROPIC_MODEL` suite), should-forward-env ✓, task-agent-frameworks ✓, typecheck ✓
- biome clean on all touched files

Screenshots / video: **N/A — stage 1 is API-only** (no UI surface in this PR; the Settings-panel + slash-command stage builds on these routes and will carry the rendered proof).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
