### PR TITLE
fix(core): honor Provider.cacheStable when rendering provider events

### DIFF
--- a/packages/core/src/runtime/__tests__/context-renderer.test.ts
+++ b/packages/core/src/runtime/__tests__/context-renderer.test.ts
@@ -175,4 +175,88 @@ describe("context renderer", () => {
 			{ content: "stable provider", stable: true },
 		]);
 	});
+
+	it("marks a provider event's segment stable per its cacheStable flag", () => {
+		const context: ContextObject = {
+			id: "ctx",
+			version: "v5",
+			events: [
+				{
+					id: "provider:STABLE_DOCTRINE",
+					type: "provider",
+					name: "STABLE_DOCTRINE",
+					text: "doctrine: ship velocity outranks deliberation",
+					cacheStable: true,
+				},
+				{
+					id: "provider:VOLATILE_FEED",
+					type: "provider",
+					name: "VOLATILE_FEED",
+					text: "feed: latest market snapshot",
+					cacheStable: false,
+				},
+				{
+					id: "provider:UNSET",
+					type: "provider",
+					name: "UNSET",
+					text: "unset: defaults to volatile",
+				},
+			],
+		};
+
+		const rendered = renderContextObject(context);
+
+		// The segment's `stable` flag now reflects the provider's declared
+		// cacheStable, so buildStageChatMessages can route the stable one into
+		// the cached system message. Unset defaults to volatile.
+		expect(
+			rendered.promptSegments.map((segment) => ({
+				id: segment.id,
+				stable: segment.stable,
+			})),
+		).toEqual([
+			{ id: "provider:STABLE_DOCTRINE", stable: true },
+			{ id: "provider:VOLATILE_FEED", stable: false },
+			{ id: "provider:UNSET", stable: false },
+		]);
+	});
+
+	it("buckets a stable provider event into the cached system message", () => {
+		const context: ContextObject = {
+			id: "ctx",
+			version: "v5",
+			events: [
+				{
+					id: "provider:STABLE_DOCTRINE",
+					type: "provider",
+					name: "STABLE_DOCTRINE",
+					text: "doctrine: ship velocity outranks deliberation",
+					cacheStable: true,
+				},
+				{
+					id: "provider:VOLATILE_FEED",
+					type: "provider",
+					name: "VOLATILE_FEED",
+					text: "feed: latest market snapshot",
+					cacheStable: false,
+				},
+			],
+		};
+
+		const messages = buildStageChatMessages({
+			contextSegments: renderContextObject(context).promptSegments,
+			stageLabel: "planner_stage",
+			instructions: "decide the next action",
+			dynamicBlocks: [],
+			stepMessages: [],
+		});
+
+		const system = messages.find((message) => message.role === "system");
+		const user = messages.find((message) => message.role === "user");
+		expect(system?.content).toContain(
+			"doctrine: ship velocity outranks deliberation",
+		);
+		expect(user?.content).toContain("feed: latest market snapshot");
+		expect(system?.content).not.toContain("feed: latest market snapshot");
+	});
 });

--- a/packages/core/src/runtime/context-renderer.ts
+++ b/packages/core/src/runtime/context-renderer.ts
@@ -308,7 +308,12 @@ function renderEvent(
 			id: event.id,
 			label: `provider:${event.name}`,
 			content,
-			stable: false,
+			// Honor the provider's declared cache stability (threaded through by
+			// appendStateProviderEvents). A stable provider's content belongs in
+			// the cached system message; leaving this hardcoded false forced
+			// every provider into the uncached user message in
+			// buildStageChatMessages (planner/evaluator stages).
+			stable: event.cacheStable === true,
 		});
 		return;
 	}

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -2129,11 +2129,21 @@ function appendStateProviderEvents(
 	events: ContextEvent[],
 	state: State,
 	excludedProviderNames?: readonly string[],
+	providerDefinitions?: readonly { name: string; cacheStable?: boolean }[],
 ): void {
 	const providers = state.data?.providers;
 	const excluded = excludedProviderNames
 		? new Set(excludedProviderNames.map((name) => name.toUpperCase()))
 		: null;
+	// Provider.cacheStable lives on the registered provider definition, not on
+	// composeState's per-call ProviderResult, so resolve it by name here and
+	// stamp it on the event for context-renderer.ts to read.
+	const cacheStableByName = new Map<string, boolean>();
+	for (const def of providerDefinitions ?? []) {
+		if (typeof def.cacheStable === "boolean") {
+			cacheStableByName.set(def.name.toUpperCase(), def.cacheStable);
+		}
+	}
 	if (!providers || typeof providers !== "object") {
 		const fallbackText =
 			typeof state.text === "string" ? state.text.trim() : "";
@@ -2177,15 +2187,17 @@ function appendStateProviderEvents(
 		if (!text) {
 			continue;
 		}
+		const resolvedName =
+			typeof provider.providerName === "string"
+				? provider.providerName
+				: providerName;
 		events.push({
 			id: `provider:${providerName}`,
 			type: "provider",
 			source: "composeState",
-			name:
-				typeof provider.providerName === "string"
-					? provider.providerName
-					: providerName,
+			name: resolvedName,
 			text,
+			cacheStable: cacheStableByName.get(resolvedName.toUpperCase()),
 		});
 	}
 }
@@ -2781,7 +2793,12 @@ async function createV5MessageContextObject(args: {
 			? ["RECENT_MESSAGES"]
 			: []),
 	];
-	appendStateProviderEvents(events, args.state, renderExclusions);
+	appendStateProviderEvents(
+		events,
+		args.state,
+		renderExclusions,
+		args.runtime.providers,
+	);
 
 	if (hasStructuredRecentMessagesProvider(args.state)) {
 		events.push({

--- a/packages/core/src/types/context-object.ts
+++ b/packages/core/src/types/context-object.ts
@@ -75,6 +75,14 @@ export interface ContextProviderEvent extends ContextEventBase {
 	text?: string;
 	values?: Record<string, JsonValue | undefined>;
 	data?: Record<string, unknown>;
+	/**
+	 * Mirrors the originating `Provider.cacheStable`. Read by
+	 * `context-renderer.ts`'s `renderEvent` to mark the rendered prompt segment
+	 * `stable`, so `buildStageChatMessages` (planner/evaluator stages) routes a
+	 * genuinely-stable provider's content into the cached system message rather
+	 * than the uncached user message.
+	 */
+	cacheStable?: boolean;
 }
 
 export interface ContextToolEvent extends ContextEventBase {


### PR DESCRIPTION
Fixes #16165.

## What

`Provider.cacheStable` is part of the `Provider` contract and is set by in-tree providers, but its value was never read when a provider's output was rendered into a prompt segment — so it had no effect on caching.

## Why

Three spots dropped the flag:
- `ContextProviderEvent` (`types/context-object.ts`) carried no `cacheStable` field.
- `appendStateProviderEvents` (`services/message.ts`) never copied it from the registered provider definition onto the event.
- `renderEvent`'s provider-event branch (`runtime/context-renderer.ts:311`) hardcoded `stable: false`.

On the planner/evaluator stages, `buildStageChatMessages` buckets segments by their `stable` flag — `stable → cached system message`, `dynamic → uncached user message`. With `stable` forced `false`, **every** rendered provider's content was routed into the uncached user message, so a provider that declares `cacheStable: true` still had its (genuinely stable) content repriced on every call.

This is not a hypothetical flag: it's part of the public `Provider` contract, and the **plugin-starter scaffold** (`packages/examples/_plugin`, the template every new plugin is generated from) sets `cacheStable: true` on its example `HELLO_WORLD_PROVIDER` — so the framework documents the flag as functional while silently ignoring it. `registryPluginsProvider` sets it too.

*(Core's `ACTIONS`/`PROVIDERS` providers also set `cacheStable: true` but are intentionally in `MODEL_CONTEXT_PROVIDER_EXCLUSIONS` — they're rendered as native tools, not text segments — so they're correctly unaffected by this change.)*

## Changes

- `types/context-object.ts`: add optional `cacheStable` to `ContextProviderEvent`.
- `services/message.ts`: `appendStateProviderEvents` resolves `cacheStable` by provider name from `runtime.providers` and stamps it on the event.
- `runtime/context-renderer.ts`: `renderEvent` marks the segment `stable` when `cacheStable === true`.
- Providers that don't set the flag keep the previous behavior (volatile).

## Testing

- `bun run --cwd packages/core test` — `context-renderer.test.ts` 6/6 pass (2 new: one asserts a provider event's segment inherits its `cacheStable`; one asserts a stable provider event lands in the system message and a volatile one in the user message via `buildStageChatMessages`).
- `bun run --cwd packages/core typecheck` — clean.

## Evidence

| Type | Status |
|---|---|
| Unit tests (deterministic, real renderer — no mocks) | 6/6 in `context-renderer.test.ts` |
| Real-LLM trajectory | N/A — pure prompt-assembly routing; the segment-bucketing is deterministic and unit-covered end to end (`renderContextObject` -> `buildStageChatMessages`). Happy to add a live scenario if a reviewer wants the on-wire `cache_control` delta. |
| Backend logs | N/A — no new runtime log path |
| UI screenshots / video | N/A — no UI surface |
| Native / per-platform capture | N/A — no native surface |
| Audio walkthrough | N/A — no voice surface |
| Domain artifacts | N/A — no DB / memory / on-chain writes |
