### PR TITLE
fix(cloud): drop duplicated CARTESIA_API_KEY declaration

### DIFF
--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -133,8 +133,6 @@ export interface Bindings {
   CEREBRAS_API_KEY?: string;
   /** Deepgram Flux realtime STT key (server-held; NEVER returned to clients). */
   DEEPGRAM_API_KEY?: string;
-  /** Cartesia Sonic realtime TTS key (server-held; NEVER returned to clients). */
-  CARTESIA_API_KEY?: string;
   /** BYOK OpenRouter key — the backup for models we have no native key for. */
   OPENROUTER_API_KEY?: string;
   OPENROUTER_BASE_URL?: string;


### PR DESCRIPTION
TS2300 `Duplicate identifier 'CARTESIA_API_KEY'` in `packages/cloud/shared/src/types/cloud-worker-env.ts` since #16030 declared the key twice (voice section + AI-providers section). Breaks `bun run --cwd packages/ui typecheck` (and any package referencing cloud/shared) on current develop.

One-line removal of the second declaration, keeping the voice-section one that carries the behavioral doc. `bun run --cwd packages/cloud/shared typecheck` green after.

Screenshots/video: N/A — type-only fix, no behavior or UI surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)