### PR TITLE
feat: model configuration surfaces — settings panel + /model subcommands (stage 2)

### DIFF
--- a/packages/agent/src/api/chat-augmentation.test.ts
+++ b/packages/agent/src/api/chat-augmentation.test.ts
@@ -47,6 +47,24 @@ function makeRuntime(
 }
 
 describe("maybeAugmentChatMessageWithDocuments", () => {
+  it.each([
+    ["/help"],
+    ["/model show"],
+    ["!status"],
+  ])("never rewrites a command turn (%s) — the deterministic command path needs the verbatim text", async (text) => {
+    const message = makeMessage();
+    (message.content as { text: string }).text = text;
+    const documents = { searchDocuments: vi.fn() };
+    const runtime = makeRuntime(documents);
+
+    const result = await maybeAugmentChatMessageWithDocuments(runtime, message);
+
+    expect(result).toBe(message);
+    // The skip happens before any retrieval work — no embed/search cost.
+    expect(documents.searchDocuments).not.toHaveBeenCalled();
+    expect(runtime.useModel).not.toHaveBeenCalled();
+  });
+
   it("skips optional document context when lookup exceeds its budget", async () => {
     const message = makeMessage();
     const documents = {

--- a/packages/agent/src/api/chat-augmentation.ts
+++ b/packages/agent/src/api/chat-augmentation.ts
@@ -221,6 +221,18 @@ export async function maybeAugmentChatMessageWithDocuments(
   const userPrompt = extractCompatTextContent(message.content).trim();
   if (!userPrompt || !runtime.agentId) return message;
 
+  // A slash/`!` command is an instruction to the command layer, never a
+  // document question. Rewriting it into the contextual-documents envelope
+  // breaks the deterministic command path: the pre-LLM shortcut gate matches
+  // the ORIGINAL text, but the command action's validate() re-reads
+  // message.content.text — which by then holds the envelope, so validate
+  // silently fails and the turn falls through to LLM improvisation whenever
+  // the command happens to be embedding-similar to a stored document (e.g.
+  // "/help", "/model" on an agent with model-related docs).
+  if (userPrompt.startsWith("/") || userPrompt.startsWith("!")) {
+    return message;
+  }
+
   // Hosts that run with an empty-vector embedding handler — e.g. Capacitor mobile
   // where loading the bge GGUF on top of the chat GGUF would OOM the
   // process — get only zero-vector embeddings back. The retrieval branch

--- a/packages/agent/src/api/model-config-slash-command.test.ts
+++ b/packages/agent/src/api/model-config-slash-command.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Cross-seam integration of the `/model small|large|coding|show` slash
+ * handler (@elizaos/plugin-commands) against the REAL model-config route: a
+ * live node:http server dispatches to handleModelConfigRoutes with real
+ * json/readJsonBody transport helpers, and the command handler reaches it via
+ * its production loopback fetch (ELIZA_PORT). No stubbed fetch and no mocked
+ * route — this pins that the slash grammar, the route's validation contract,
+ * and the narrated replies cannot drift apart. Only the catalog, config
+ * store, and operation manager are injected (the route's designed seams).
+ */
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import type { IAgentRuntime, Memory } from "@elizaos/core";
+import { initForRuntime, resolveCommand } from "@elizaos/plugin-commands";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ElizaConfig } from "../config/config";
+import { buildModelCatalog } from "./model-catalog";
+import { handleModelConfigRoutes } from "./model-config-routes";
+
+const catalog = buildModelCatalog({
+  readFile: () => {
+    throw new Error("ENOENT");
+  },
+  env: {} as NodeJS.ProcessEnv,
+});
+
+function makeRuntime(): IAgentRuntime {
+  const cache = new Map<string, unknown>();
+  return {
+    agentId: "agent-model-config-e2e",
+    character: { name: "Eliza", settings: {} },
+    actions: [],
+    getSetting: () => null,
+    getCache: async (key: string) => cache.get(key),
+    setCache: async (key: string, value: unknown) => {
+      cache.set(key, value);
+      return true;
+    },
+    deleteCache: async (key: string) => cache.delete(key),
+  } as unknown as IAgentRuntime;
+}
+
+function msg(text: string): Memory {
+  return {
+    id: "00000000-0000-0000-0000-000000000012",
+    entityId: "00000000-0000-0000-0000-0000000000ad",
+    roomId: "room-model-config-e2e",
+    content: { text, source: "client_chat" },
+  } as unknown as Memory;
+}
+
+const OWNER = { isAuthorized: true, isElevated: true };
+
+interface Harness {
+  config: ElizaConfig;
+  processEnv: NodeJS.ProcessEnv;
+  saveElizaConfig: ReturnType<typeof vi.fn>;
+  managerStart: ReturnType<typeof vi.fn>;
+  runtime: IAgentRuntime;
+  close: () => Promise<void>;
+}
+
+const priorElizaPort = process.env.ELIZA_PORT;
+let activeHarness: Harness | null = null;
+
+async function startHarness(
+  opts: { config?: ElizaConfig; managerStart?: ReturnType<typeof vi.fn> } = {},
+): Promise<Harness> {
+  const config: ElizaConfig = opts.config ?? {};
+  const processEnv: NodeJS.ProcessEnv = {};
+  const saveElizaConfig = vi.fn();
+  const managerStart =
+    opts.managerStart ??
+    vi.fn(async (req: { prepare?: () => Promise<unknown> }) => {
+      await req.prepare?.();
+      return { kind: "accepted", operation: { id: "op-e2e" } };
+    });
+
+  const server = http.createServer((req, res) => {
+    void (async () => {
+      const handled = await handleModelConfigRoutes({
+        req,
+        res,
+        method: req.method ?? "GET",
+        pathname: new URL(req.url ?? "/", "http://127.0.0.1").pathname,
+        json: (r: http.ServerResponse, body: unknown, status = 200) => {
+          r.writeHead(status, { "Content-Type": "application/json" });
+          r.end(JSON.stringify(body));
+        },
+        readJsonBody: async (rq: http.IncomingMessage) => {
+          const chunks: Buffer[] = [];
+          for await (const chunk of rq) chunks.push(chunk as Buffer);
+          return JSON.parse(Buffer.concat(chunks).toString("utf-8"));
+        },
+        state: { config },
+        saveElizaConfig,
+        runtimeOperationManager: { start: managerStart },
+        catalog,
+        processEnv,
+      } as never);
+      if (!handled) {
+        res.writeHead(404);
+        res.end();
+      }
+    })();
+  });
+  await new Promise<void>((resolve) =>
+    server.listen(0, "127.0.0.1", () => resolve()),
+  );
+  // The slash handler resolves its loopback target from ELIZA_PORT — point it
+  // at this live route server, exactly like production points it at app-core.
+  process.env.ELIZA_PORT = String((server.address() as AddressInfo).port);
+
+  initForRuntime("agent-model-config-e2e");
+  const harness: Harness = {
+    config,
+    processEnv,
+    saveElizaConfig,
+    managerStart,
+    runtime: makeRuntime(),
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      ),
+  };
+  activeHarness = harness;
+  return harness;
+}
+
+afterEach(async () => {
+  await activeHarness?.close();
+  activeHarness = null;
+  if (priorElizaPort === undefined) delete process.env.ELIZA_PORT;
+  else process.env.ELIZA_PORT = priorElizaPort;
+});
+
+describe("/model slash handler ↔ real /api/models/config route", () => {
+  it("applies a coding write end-to-end: config seams written, restart-free reply", async () => {
+    const h = await startHarness();
+
+    const r = await resolveCommand(
+      h.runtime,
+      msg("/model coding codex gpt-5.6-terra xhigh"),
+      OWNER,
+    );
+
+    expect(r.handled).toBe(true);
+    expect(r.reply).toContain("gpt-5.6-terra");
+    expect(r.reply).toContain("no restart needed");
+    expect(h.saveElizaConfig).toHaveBeenCalledTimes(1);
+    const env = (h.config as { env?: Record<string, unknown> }).env ?? {};
+    expect(env.ELIZA_CODEX_MODEL_POWERFUL).toBe("gpt-5.6-terra");
+    expect(env.ELIZA_CODEX_EFFORT).toBe("xhigh");
+    expect(
+      (env.vars as Record<string, string>).ELIZA_CODEX_MODEL_POWERFUL,
+    ).toBe("gpt-5.6-terra");
+    expect(h.processEnv.ELIZA_CODEX_MODEL_POWERFUL).toBe("gpt-5.6-terra");
+    expect(h.managerStart).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the route's real codex-acp effort-pin 400 verbatim", async () => {
+    const h = await startHarness();
+
+    const r = await resolveCommand(
+      h.runtime,
+      msg("/model coding codex gpt-5.6-terra ultra"),
+      OWNER,
+    );
+
+    expect(r.reply).toContain("pinned codex-acp adapter");
+    expect(r.reply).toContain("low, medium, high, xhigh");
+    expect(h.saveElizaConfig).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the real ambiguous-provider 400, and the provider-qualified retry restarts", async () => {
+    const h = await startHarness();
+
+    const ambiguous = await resolveCommand(
+      h.runtime,
+      msg("/model large zai-glm-4.7"),
+      OWNER,
+    );
+    expect(ambiguous.reply).toContain("multiple providers");
+    expect(ambiguous.reply).toContain("cerebras");
+    expect(ambiguous.reply).toContain("elizacloud");
+
+    const qualified = await resolveCommand(
+      h.runtime,
+      msg("/model large cerebras/zai-glm-4.7 high"),
+      OWNER,
+    );
+    expect(qualified.reply).toContain("restarting the agent to apply");
+    expect(qualified.reply).toContain(
+      "OPENAI_REASONING_EFFORT is shared by the small and large chat targets",
+    );
+    expect(h.managerStart).toHaveBeenCalledTimes(1);
+    const env = (h.config as { env?: Record<string, unknown> }).env ?? {};
+    expect(env.OPENAI_LARGE_MODEL).toBe("zai-glm-4.7");
+    expect(env.OPENAI_REASONING_EFFORT).toBe("high");
+  });
+
+  it("surfaces the real 409 when the operation manager is busy", async () => {
+    const h = await startHarness({
+      managerStart: vi.fn(async () => ({
+        kind: "rejected-busy",
+        activeOperationId: "op-live",
+      })),
+    });
+
+    const r = await resolveCommand(
+      h.runtime,
+      msg("/model small cerebras/gemma-4-31b"),
+      OWNER,
+    );
+    expect(r.reply).toContain("already in progress");
+    expect(r.reply).toContain("op-live");
+    expect(h.saveElizaConfig).not.toHaveBeenCalled();
+  });
+
+  it("/model show renders the route's real effective config with sources", async () => {
+    const h = await startHarness({
+      config: {
+        env: {
+          OPENAI_LARGE_MODEL: "zai-glm-4.7",
+          vars: { ANTHROPIC_SMALL_MODEL: "claude-haiku-4-5-20251001" },
+        },
+      } as ElizaConfig,
+    });
+
+    const r = await resolveCommand(h.runtime, msg("/model show"), OWNER);
+
+    expect(r.reply).toContain("**small**");
+    expect(r.reply).toContain("**large**");
+    expect(r.reply).toContain("**coding**");
+    expect(r.reply).toContain("OPENAI_LARGE_MODEL = zai-glm-4.7 (config.env)");
+    expect(r.reply).toContain(
+      "ANTHROPIC_SMALL_MODEL = claude-haiku-4-5-20251001 (config.env.vars)",
+    );
+    // The route's designed codex default surfaces even with nothing written.
+    expect(r.reply).toContain("ELIZA_CODEX_MODEL_POWERFUL = ");
+    expect(r.reply).toContain("(default)");
+    expect(r.reply).toContain("OPENAI_SMALL_MODEL unset");
+  });
+});

--- a/packages/core/src/generated/action-docs.ts
+++ b/packages/core/src/generated/action-docs.ts
@@ -3370,13 +3370,44 @@ export const allActionsSpec = {
 			description: "Set or show current model",
 			parameters: [
 				{
-					name: "model",
-					description: "provider/model or alias",
+					name: "target",
+					description:
+						"small, large, coding, show, local, cloud — or a model for this room",
 					required: false,
 					schema: {
 						type: "string",
 					},
-					descriptionCompressed: "provider/model or alias",
+					descriptionCompressed:
+						"small, large, coding, show, local, cloud - or a model for this room",
+				},
+				{
+					name: "model",
+					description:
+						"model id — for coding, the backend (codex, claude, opencode, elizaos)",
+					required: false,
+					schema: {
+						type: "string",
+					},
+					descriptionCompressed:
+						"model id - for coding, the backend (codex, claude, opencode, elizaos)",
+				},
+				{
+					name: "effort",
+					description: "reasoning effort — for coding, the model id",
+					required: false,
+					schema: {
+						type: "string",
+					},
+					descriptionCompressed: "reasoning effort - for coding, the model id",
+				},
+				{
+					name: "coding-effort",
+					description: "reasoning effort (coding target)",
+					required: false,
+					schema: {
+						type: "string",
+					},
+					descriptionCompressed: "reasoning effort (coding target)",
 				},
 			],
 			similes: ["/model", "/m"],

--- a/packages/docs/action-catalog.md
+++ b/packages/docs/action-catalog.md
@@ -260,7 +260,10 @@ Set or show current model
 
 | Parameter | Required | Type | Description |
 | --- | --- | --- | --- |
-| `model` | no | string | provider/model or alias |
+| `target` | no | string | small, large, coding, show, local, cloud — or a model for this room |
+| `model` | no | string | model id — for coding, the backend (codex, claude, opencode, elizaos) |
+| `effort` | no | string | reasoning effort — for coding, the model id |
+| `coding-effort` | no | string | reasoning effort (coding target) |
 
 ### QUEUE_COMMAND
 

--- a/packages/prompts/specs/actions/plugins.generated.json
+++ b/packages/prompts/specs/actions/plugins.generated.json
@@ -51,8 +51,32 @@
       "description": "Set or show current model",
       "parameters": [
         {
+          "name": "target",
+          "description": "small, large, coding, show, local, cloud — or a model for this room",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
           "name": "model",
-          "description": "provider/model or alias",
+          "description": "model id — for coding, the backend (codex, claude, opencode, elizaos)",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "effort",
+          "description": "reasoning effort — for coding, the model id",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "coding-effort",
+          "description": "reasoning effort (coding target)",
           "required": false,
           "schema": {
             "type": "string"

--- a/packages/scripts/view-action-ratchet.registry.json
+++ b/packages/scripts/view-action-ratchet.registry.json
@@ -40,6 +40,10 @@
     "streamGoLive": { "action": "STREAM" },
     "streamGoOffline": { "action": "STREAM" },
     "switchProvider": { "action": "MODEL_SWITCH" },
+    "updateModelsConfig": {
+      "action": "MODEL_SWITCH",
+      "note": "per-role model/effort write (POST /api/models/config) from the settings Models panel — same chat twin as the provider switch"
+    },
     "updateCharacter": { "action": "CHARACTER" },
     "updateConfig": {
       "action": "SETTINGS",

--- a/packages/ui/src/api/client-agent-models-config.test.ts
+++ b/packages/ui/src/api/client-agent-models-config.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Unit coverage for the models-config client verbs: the catalog/config reads
+ * and the POST /api/models/config outcome normalization (applied / deduped /
+ * typed 400 / 409-busy / throw). Transport stubbed, no live agent.
+ */
+import { describe, expect, it, vi } from "vitest";
+import "./client-agent";
+import { ElizaClient } from "./client-base";
+import { ApiError } from "./client-types-core";
+
+function clientWithBody(body: unknown): {
+  client: ElizaClient;
+  fetchMock: ReturnType<typeof vi.fn>;
+} {
+  const client = new ElizaClient("http://agent.example:31337", "token");
+  const fetchMock = vi.fn(async () => body);
+  client.fetch = fetchMock as unknown as typeof client.fetch;
+  return { client, fetchMock };
+}
+
+describe("ElizaClient.getModelsCatalog", () => {
+  it("reads /api/models without a cache-busting refresh", async () => {
+    const { client, fetchMock } = clientWithBody({
+      providers: {},
+      catalog: { providers: {} },
+    });
+    const result = await client.getModelsCatalog();
+    expect(fetchMock).toHaveBeenCalledWith("/api/models");
+    expect(result.catalog).toEqual({ providers: {} });
+  });
+});
+
+describe("ElizaClient.getModelsConfig", () => {
+  it("reads /api/models/config", async () => {
+    const { client, fetchMock } = clientWithBody({
+      targets: { small: {}, large: {}, coding: {} },
+    });
+    const result = await client.getModelsConfig();
+    expect(fetchMock).toHaveBeenCalledWith("/api/models/config");
+    expect(result.targets).toBeDefined();
+  });
+});
+
+describe("ElizaClient.updateModelsConfig", () => {
+  it("posts with allowNonOk so designed 400/409 bodies survive", async () => {
+    const { client, fetchMock } = clientWithBody({
+      applied: true,
+      restart: false,
+      keys: ["ELIZA_CODEX_MODEL_POWERFUL"],
+    });
+    await client.updateModelsConfig({
+      target: "coding",
+      backend: "codex",
+      model: "gpt-5.6-terra",
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/models/config",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          target: "coding",
+          backend: "codex",
+          model: "gpt-5.6-terra",
+        }),
+      },
+      { allowNonOk: true },
+    );
+  });
+
+  it("normalizes an applied restart write", async () => {
+    const { client } = clientWithBody({
+      applied: true,
+      restart: true,
+      operationId: "op-1",
+      keys: ["OPENAI_SMALL_MODEL"],
+      conflictingServiceEnvKeys: ["OPENAI_SMALL_MODEL"],
+    });
+    const result = await client.updateModelsConfig({
+      target: "small",
+      provider: "cerebras",
+      model: "gemma-4-31b",
+    });
+    expect(result).toEqual({
+      kind: "applied",
+      restart: true,
+      operationId: "op-1",
+      keys: ["OPENAI_SMALL_MODEL"],
+      conflictingServiceEnvKeys: ["OPENAI_SMALL_MODEL"],
+    });
+  });
+
+  it("treats a deduped restart (applied:false) as an applied outcome", async () => {
+    const { client } = clientWithBody({
+      applied: false,
+      restart: true,
+      operationId: "op-2",
+      keys: ["ANTHROPIC_LARGE_MODEL"],
+      deduped: true,
+    });
+    const result = await client.updateModelsConfig({
+      target: "large",
+      provider: "claude-chat",
+      model: "claude-opus-4-8",
+    });
+    expect(result).toEqual({
+      kind: "applied",
+      restart: true,
+      operationId: "op-2",
+      keys: ["ANTHROPIC_LARGE_MODEL"],
+      deduped: true,
+    });
+  });
+
+  it("normalizes the typed 400 body into an invalid outcome with context", async () => {
+    const { client } = clientWithBody({
+      error: 'Effort "ultra" is valid for gpt-5.6-terra but not parseable',
+      code: "MODEL_CONFIG_INVALID",
+      context: {
+        model: "gpt-5.6-terra",
+        effort: "ultra",
+        supported: ["low", "medium", "high", "xhigh"],
+      },
+    });
+    const result = await client.updateModelsConfig({
+      target: "coding",
+      backend: "codex",
+      model: "gpt-5.6-terra",
+      effort: "ultra",
+    });
+    expect(result).toEqual({
+      kind: "invalid",
+      error: 'Effort "ultra" is valid for gpt-5.6-terra but not parseable',
+      supported: ["low", "medium", "high", "xhigh"],
+    });
+  });
+
+  it("normalizes the 409 body into a busy outcome", async () => {
+    const { client } = clientWithBody({
+      error: "A runtime operation is already in progress",
+      activeOperationId: "op-9",
+    });
+    const result = await client.updateModelsConfig({
+      target: "small",
+      provider: "cerebras",
+      model: "gemma-4-31b",
+    });
+    expect(result).toEqual({
+      kind: "busy",
+      error: "A runtime operation is already in progress",
+      activeOperationId: "op-9",
+    });
+  });
+
+  it("throws a typed ApiError on an unrecognized failure body", async () => {
+    const { client } = clientWithBody({ error: "Model config update failed" });
+    await expect(
+      client.updateModelsConfig({
+        target: "small",
+        provider: "cerebras",
+        model: "gemma-4-31b",
+      }),
+    ).rejects.toThrowError(ApiError);
+  });
+});

--- a/packages/ui/src/api/client-agent.ts
+++ b/packages/ui/src/api/client-agent.ts
@@ -86,6 +86,10 @@ import type {
   ListTrainingCollectionsResponse,
   LogsFilter,
   LogsResponse,
+  ModelCatalog,
+  ModelsConfigResponse,
+  ModelsConfigWriteRequest,
+  ModelsConfigWriteResult,
   OrchestratorAccountOverview,
   OrchestratorAccountReadiness,
   OrchestratorRoomRosterOverview,
@@ -786,7 +790,19 @@ declare module "./client-base" {
     fetchModels(
       provider: string,
       refresh?: boolean,
-    ): Promise<{ provider: string; models: ProviderModelRecord[] }>;
+    ): Promise<{
+      provider: string;
+      models: ProviderModelRecord[];
+      catalog: ModelCatalog;
+    }>;
+    getModelsCatalog(): Promise<{
+      providers: Record<string, ProviderModelRecord[]>;
+      catalog: ModelCatalog;
+    }>;
+    getModelsConfig(): Promise<ModelsConfigResponse>;
+    updateModelsConfig(
+      request: ModelsConfigWriteRequest,
+    ): Promise<ModelsConfigWriteResult>;
     getCorePlugins(): Promise<CorePluginsResponse>;
     toggleCorePlugin(
       npmName: string,
@@ -2873,6 +2889,85 @@ ElizaClient.prototype.fetchModels = async function (
   const params = new URLSearchParams({ provider });
   if (refresh) params.set("refresh", "true");
   return this.fetch(`/api/models?${params.toString()}`);
+};
+
+ElizaClient.prototype.getModelsCatalog = async function (this: ElizaClient) {
+  // Deliberately no refresh=true: the caller wants the validated
+  // provider→model→efforts catalog attached to every /api/models response,
+  // not a cache-busting refetch of every provider's model list.
+  return this.fetch("/api/models");
+};
+
+ElizaClient.prototype.getModelsConfig = async function (this: ElizaClient) {
+  return this.fetch("/api/models/config");
+};
+
+ElizaClient.prototype.updateModelsConfig = async function (
+  this: ElizaClient,
+  request,
+) {
+  // allowNonOk: the route's 400 (MODEL_CONFIG_INVALID + context payload) and
+  // 409 (operation busy) are designed outcomes the settings panel renders
+  // inline; the default non-OK path would collapse them into a bare ApiError
+  // message and drop the context. Shapes are validated field-by-field because
+  // the body is an untrusted transport boundary.
+  const body = await this.fetch<Record<string, unknown> | undefined>(
+    "/api/models/config",
+    { method: "POST", body: JSON.stringify(request) },
+    { allowNonOk: true },
+  );
+  if (
+    body &&
+    typeof body.applied === "boolean" &&
+    typeof body.restart === "boolean" &&
+    Array.isArray(body.keys)
+  ) {
+    return {
+      kind: "applied",
+      restart: body.restart,
+      keys: body.keys.filter((key): key is string => typeof key === "string"),
+      ...(typeof body.operationId === "string"
+        ? { operationId: body.operationId }
+        : {}),
+      ...(body.deduped === true ? { deduped: true } : {}),
+      ...(Array.isArray(body.conflictingServiceEnvKeys)
+        ? {
+            conflictingServiceEnvKeys: body.conflictingServiceEnvKeys.filter(
+              (key): key is string => typeof key === "string",
+            ),
+          }
+        : {}),
+    };
+  }
+  const error = body && typeof body.error === "string" ? body.error : undefined;
+  if (body && error !== undefined && body.code === "MODEL_CONFIG_INVALID") {
+    const context =
+      body.context && typeof body.context === "object"
+        ? (body.context as Record<string, unknown>)
+        : {};
+    const supported = Array.isArray(context.supported)
+      ? context.supported.filter(
+          (value): value is string => typeof value === "string",
+        )
+      : undefined;
+    return {
+      kind: "invalid",
+      error,
+      ...(supported !== undefined ? { supported } : {}),
+    };
+  }
+  if (
+    body &&
+    error !== undefined &&
+    typeof body.activeOperationId === "string"
+  ) {
+    return { kind: "busy", error, activeOperationId: body.activeOperationId };
+  }
+  throw new ApiError({
+    kind: "http",
+    path: "/api/models/config",
+    message: error ?? "Model config update failed",
+  });
 };
 
 ElizaClient.prototype.getCorePlugins = async function (this: ElizaClient) {

--- a/packages/ui/src/api/client-agent.ts
+++ b/packages/ui/src/api/client-agent.ts
@@ -2970,7 +2970,6 @@ ElizaClient.prototype.updateModelsConfig = async function (
   });
 };
 
->>>>>>> feat/settings-models-panel
 ElizaClient.prototype.getCorePlugins = async function (this: ElizaClient) {
   try {
     const viaRpc = await invokeLocalDesktopAgentRpc<CorePluginsResponse>(

--- a/packages/ui/src/api/client-agent.ts
+++ b/packages/ui/src/api/client-agent.ts
@@ -86,6 +86,7 @@ import type {
   ListTrainingCollectionsResponse,
   LogsFilter,
   LogsResponse,
+  ModelCatalogResponse,
   OrchestratorAccountOverview,
   OrchestratorAccountReadiness,
   OrchestratorRoomRosterOverview,
@@ -787,6 +788,7 @@ declare module "./client-base" {
       provider: string,
       refresh?: boolean,
     ): Promise<{ provider: string; models: ProviderModelRecord[] }>;
+    fetchModelCatalog(): Promise<ModelCatalogResponse>;
     getCorePlugins(): Promise<CorePluginsResponse>;
     toggleCorePlugin(
       npmName: string,
@@ -2873,6 +2875,12 @@ ElizaClient.prototype.fetchModels = async function (
   const params = new URLSearchParams({ provider });
   if (refresh) params.set("refresh", "true");
   return this.fetch(`/api/models?${params.toString()}`);
+};
+
+ElizaClient.prototype.fetchModelCatalog = async function (this: ElizaClient) {
+  // No ?refresh: the `catalog` field is rebuilt server-side on every request,
+  // so a cached provider read is enough for completion data.
+  return this.fetch("/api/models");
 };
 
 ElizaClient.prototype.getCorePlugins = async function (this: ElizaClient) {

--- a/packages/ui/src/api/client-types-core.ts
+++ b/packages/ui/src/api/client-types-core.ts
@@ -282,6 +282,31 @@ export interface ProviderModelRecord {
   category: ProviderModelCategory;
 }
 
+/**
+ * One selectable model in the `catalog` field of `GET /api/models` — the
+ * validated provider→model→efforts catalog `POST /api/models/config` checks
+ * writes against (packages/agent/src/api/model-catalog.ts).
+ */
+export interface ModelCatalogEntry {
+  id: string;
+  display: string;
+  /** Accepted reasoning-effort levels; empty = the model has no effort knob. */
+  efforts: string[];
+  defaultEffort?: string;
+  roles: Array<"small" | "large" | "coding">;
+  costHint?: string;
+  /** false = listed by the provider but not callable via the API tier. */
+  apiSupported?: boolean;
+}
+
+/** Provider→entries map inside the `catalog` field of `GET /api/models`. */
+export type ModelCatalogProviders = Record<string, ModelCatalogEntry[]>;
+
+/** The slice of the `GET /api/models` response the model completions consume. */
+export interface ModelCatalogResponse {
+  catalog: { providers: ModelCatalogProviders };
+}
+
 export interface AgentAutomationModeResponse {
   mode: AgentAutomationMode;
   options: AgentAutomationMode[];

--- a/packages/ui/src/api/client-types-core.ts
+++ b/packages/ui/src/api/client-types-core.ts
@@ -385,7 +385,6 @@ export type ModelsConfigWriteResult =
     }
   | { kind: "busy"; error: string; activeOperationId: string };
 
->>>>>>> feat/settings-models-panel
 export interface AgentAutomationModeResponse {
   mode: AgentAutomationMode;
   options: AgentAutomationMode[];

--- a/packages/ui/src/api/client-types-core.ts
+++ b/packages/ui/src/api/client-types-core.ts
@@ -282,6 +282,101 @@ export interface ProviderModelRecord {
   category: ProviderModelCategory;
 }
 
+/**
+ * One selectable model in the validated provider→model→efforts catalog that
+ * every `GET /api/models` response carries (`catalog` field). Mirrors
+ * `ModelCatalogEntry` in packages/agent/src/api/model-catalog.ts — the server
+ * validates `POST /api/models/config` writes against exactly this shape.
+ */
+export interface ModelCatalogEntry {
+  id: string;
+  display: string;
+  /** Accepted reasoning-effort levels; empty = the model has no effort knob. */
+  efforts: string[];
+  defaultEffort?: string;
+  roles: Array<"small" | "large" | "coding">;
+  costHint?: string;
+  /** false = listed by the provider but not callable via the API tier. */
+  apiSupported?: boolean;
+}
+
+export interface ModelCatalog {
+  providers: Record<string, ModelCatalogEntry[]>;
+}
+
+export type ModelsConfigTarget = "small" | "large" | "coding";
+
+/**
+ * Coding backend wire values accepted by `POST /api/models/config`. The
+ * in-house backend is spelled `eliza-code` on the wire (the server persists it
+ * as `ELIZA_DEFAULT_AGENT_TYPE=elizaos`).
+ */
+export type ModelsConfigCodingBackend =
+  | "codex"
+  | "claude"
+  | "opencode"
+  | "eliza-code";
+
+/** Which config seam won for a key reported by `GET /api/models/config`. */
+export type ModelsConfigSource =
+  | "config.env"
+  | "config.env.vars"
+  | "process.env"
+  | "default";
+
+export interface ModelsConfigEffectiveValue {
+  value: string;
+  source: ModelsConfigSource;
+}
+
+export interface ModelsConfigResponse {
+  targets: {
+    small: Record<string, ModelsConfigEffectiveValue | null>;
+    large: Record<string, ModelsConfigEffectiveValue | null>;
+    coding: Record<string, ModelsConfigEffectiveValue | null>;
+  };
+}
+
+export interface ModelsConfigWriteRequest {
+  target: ModelsConfigTarget;
+  /** Chat targets: cerebras | elizacloud | claude-chat. */
+  provider?: string;
+  /** Coding target only. */
+  backend?: ModelsConfigCodingBackend;
+  model: string;
+  effort?: string;
+  /** Persist this backend as ELIZA_DEFAULT_AGENT_TYPE alongside the write. */
+  defaultBackend?: ModelsConfigCodingBackend;
+}
+
+/**
+ * Normalized `POST /api/models/config` outcome. The route answers three
+ * designed shapes — 2xx applied/deduped, 400 `MODEL_CONFIG_INVALID`, 409
+ * operation-busy — which the client folds into one discriminated union so
+ * panels render each as a distinct state instead of losing the 400 context
+ * payload inside a generic ApiError message. Transport failures and 500s
+ * still throw.
+ */
+export type ModelsConfigWriteResult =
+  | {
+      kind: "applied";
+      /** True when the write requires (and already triggered) an agent restart. */
+      restart: boolean;
+      keys: string[];
+      operationId?: string;
+      /** True when an identical restart was already in flight and this write joined it. */
+      deduped?: boolean;
+      /** Keys whose process-env value came from outside the config (service env). */
+      conflictingServiceEnvKeys?: string[];
+    }
+  | {
+      kind: "invalid";
+      error: string;
+      /** Values the route would have accepted, when the failure names them. */
+      supported?: string[];
+    }
+  | { kind: "busy"; error: string; activeOperationId: string };
+
 export interface AgentAutomationModeResponse {
   mode: AgentAutomationMode;
   options: AgentAutomationMode[];

--- a/packages/ui/src/chat/model-choices.test.ts
+++ b/packages/ui/src/chat/model-choices.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Position-aware "models" completion grammar over a fixture catalog — pure
+ * functions, no React/DOM: per-subcommand values for /model, provider
+ * qualification of ambiguous chat ids, apiSupported filtering, effort
+ * resolution, caps, and the value→label map.
+ */
+
+import { describe, expect, it } from "vitest";
+import type {
+  ModelCatalogEntry,
+  ModelCatalogProviders,
+} from "../api/client-types-core";
+import {
+  buildModelChoiceLabels,
+  CODING_BACKEND_CHOICES,
+  resolveModelChoices,
+} from "./model-choices";
+import type { SlashArgChoiceContext } from "./slash-menu";
+
+const CATALOG: ModelCatalogProviders = {
+  codex: [
+    {
+      id: "gpt-5.6-terra",
+      display: "GPT-5.6-Terra",
+      efforts: ["low", "medium", "high", "xhigh", "max", "ultra"],
+      defaultEffort: "medium",
+      roles: ["coding"],
+      costHint: "highest cost/latency tier",
+    },
+    {
+      id: "gpt-5.5",
+      display: "GPT-5.5",
+      efforts: ["low", "medium", "high", "xhigh"],
+      defaultEffort: "medium",
+      roles: ["coding"],
+    },
+    {
+      id: "gpt-5.3-codex-spark",
+      display: "GPT-5.3-Codex-Spark",
+      efforts: ["low", "medium", "high", "xhigh"],
+      defaultEffort: "high",
+      roles: ["coding"],
+      apiSupported: false,
+    },
+  ],
+  "claude-chat": [
+    {
+      id: "claude-opus-4-8",
+      display: "Claude Opus 4.8",
+      efforts: ["low", "medium", "high", "xhigh", "max"],
+      roles: ["small", "large"],
+    },
+  ],
+  "claude-coding": [
+    {
+      id: "claude-opus-4-8",
+      display: "Claude Opus 4.8",
+      efforts: ["low", "medium", "high", "xhigh", "max"],
+      defaultEffort: "xhigh",
+      roles: ["coding"],
+    },
+  ],
+  cerebras: [
+    {
+      id: "gemma-4-31b",
+      display: "Gemma 4 31B",
+      efforts: ["low", "medium", "high"],
+      roles: ["small"],
+    },
+    {
+      id: "zai-glm-4.7",
+      display: "GLM-4.7",
+      efforts: ["low", "medium", "high"],
+      roles: ["small", "large"],
+    },
+  ],
+  elizacloud: [
+    {
+      id: "zai-glm-4.7",
+      display: "GLM-4.7",
+      efforts: ["low", "medium", "high"],
+      roles: ["small", "large"],
+    },
+    {
+      id: "openai/gpt-oss-120b",
+      display: "GPT-OSS 120B",
+      efforts: ["low", "medium", "high"],
+      roles: ["small", "large"],
+    },
+  ],
+};
+
+function ctx(
+  argIndex: number,
+  precedingTokens: string[] = [],
+  commandKey = "model",
+): SlashArgChoiceContext {
+  return { commandKey, argIndex, precedingTokens };
+}
+
+describe("resolveModelChoices", () => {
+  it("returns nothing without a catalog", () => {
+    expect(resolveModelChoices(null, ctx(1, ["small"]))).toEqual([]);
+  });
+
+  it("offers every callable model id without positional context", () => {
+    const all = resolveModelChoices(CATALOG, undefined);
+    expect(all).toEqual([
+      "gpt-5.6-terra",
+      "gpt-5.5",
+      "claude-opus-4-8",
+      "gemma-4-31b",
+      "zai-glm-4.7",
+      "openai/gpt-oss-120b",
+    ]);
+    // Same list for a non-/model command tagging the source, and for the
+    // bare-name per-room position of /model itself.
+    expect(resolveModelChoices(CATALOG, ctx(0, [], "other"))).toEqual(all);
+    expect(resolveModelChoices(CATALOG, ctx(0))).toEqual(all);
+  });
+
+  it("offers chat models per target, provider-qualifying ambiguous ids", () => {
+    expect(resolveModelChoices(CATALOG, ctx(1, ["small"]))).toEqual([
+      "claude-opus-4-8",
+      "gemma-4-31b",
+      "cerebras/zai-glm-4.7",
+      "elizacloud/zai-glm-4.7",
+      "openai/gpt-oss-120b",
+    ]);
+    // gemma is small-only; large drops it.
+    expect(resolveModelChoices(CATALOG, ctx(1, ["large"]))).toEqual([
+      "claude-opus-4-8",
+      "cerebras/zai-glm-4.7",
+      "elizacloud/zai-glm-4.7",
+      "openai/gpt-oss-120b",
+    ]);
+  });
+
+  it("offers the coding backends after /model coding", () => {
+    expect(resolveModelChoices(CATALOG, ctx(1, ["coding"]))).toEqual([
+      ...CODING_BACKEND_CHOICES,
+    ]);
+  });
+
+  it("offers nothing after show/local/cloud (no catalog-backed completions)", () => {
+    expect(resolveModelChoices(CATALOG, ctx(1, ["show"]))).toEqual([]);
+    expect(resolveModelChoices(CATALOG, ctx(1, ["local"]))).toEqual([]);
+    expect(resolveModelChoices(CATALOG, ctx(1, ["cloud"]))).toEqual([]);
+  });
+
+  it("offers a provider's models when the chat provider is spelled as its own token", () => {
+    expect(resolveModelChoices(CATALOG, ctx(2, ["small", "cerebras"]))).toEqual(
+      ["gemma-4-31b", "zai-glm-4.7"],
+    );
+  });
+
+  it("offers efforts for a chat model token (bare, qualified, or slashed id)", () => {
+    expect(
+      resolveModelChoices(CATALOG, ctx(2, ["large", "zai-glm-4.7"])),
+    ).toEqual(["low", "medium", "high"]);
+    expect(
+      resolveModelChoices(CATALOG, ctx(2, ["large", "elizacloud/zai-glm-4.7"])),
+    ).toEqual(["low", "medium", "high"]);
+    // "openai" is not a catalog provider, so the slashed id resolves as an id.
+    expect(
+      resolveModelChoices(CATALOG, ctx(2, ["large", "openai/gpt-oss-120b"])),
+    ).toEqual(["low", "medium", "high"]);
+    expect(
+      resolveModelChoices(CATALOG, ctx(2, ["large", "unknown-model"])),
+    ).toEqual([]);
+  });
+
+  it("offers a backend's models for /model coding, hiding apiSupported:false", () => {
+    expect(resolveModelChoices(CATALOG, ctx(2, ["coding", "codex"]))).toEqual([
+      "gpt-5.6-terra",
+      "gpt-5.5",
+    ]);
+    expect(resolveModelChoices(CATALOG, ctx(2, ["coding", "claude"]))).toEqual([
+      "claude-opus-4-8",
+    ]);
+    // Free-form backends have no catalog to complete from.
+    expect(
+      resolveModelChoices(CATALOG, ctx(2, ["coding", "opencode"])),
+    ).toEqual([]);
+    expect(resolveModelChoices(CATALOG, ctx(2, ["coding", "elizaos"]))).toEqual(
+      [],
+    );
+  });
+
+  it("offers efforts for the chosen coding model", () => {
+    expect(
+      resolveModelChoices(CATALOG, ctx(3, ["coding", "codex", "gpt-5.5"])),
+    ).toEqual(["low", "medium", "high", "xhigh"]);
+    expect(
+      resolveModelChoices(CATALOG, ctx(3, ["coding", "codex", "nope"])),
+    ).toEqual([]);
+  });
+
+  it("offers efforts for the provider-spelled chat shape at index 3", () => {
+    expect(
+      resolveModelChoices(
+        CATALOG,
+        ctx(3, ["small", "cerebras", "gemma-4-31b"]),
+      ),
+    ).toEqual(["low", "medium", "high"]);
+    // Without a provider token at index 1, index 2 was already the effort.
+    expect(
+      resolveModelChoices(CATALOG, ctx(3, ["small", "zai-glm-4.7", "low"])),
+    ).toEqual([]);
+  });
+
+  it("caps oversized lists", () => {
+    const entries: ModelCatalogEntry[] = Array.from({ length: 40 }, (_, i) => ({
+      id: `model-${i}`,
+      display: `Model ${i}`,
+      efforts: ["low"],
+      roles: ["coding"],
+    }));
+    const big: ModelCatalogProviders = { codex: entries };
+    expect(resolveModelChoices(big, ctx(2, ["coding", "codex"]))).toHaveLength(
+      25,
+    );
+  });
+});
+
+describe("buildModelChoiceLabels", () => {
+  it("labels catalog values with display names and providers", () => {
+    const labels = buildModelChoiceLabels(CATALOG);
+    expect(labels.get("zai-glm-4.7")).toBe("GLM-4.7");
+    expect(labels.get("cerebras/zai-glm-4.7")).toBe("GLM-4.7 · cerebras");
+    expect(labels.get("gpt-5.6-terra")).toBe(
+      "GPT-5.6-Terra — highest cost/latency tier",
+    );
+    expect(labels.get("openai/gpt-oss-120b")).toBe("GPT-OSS 120B");
+  });
+
+  it("labels the static target and backend tokens, with or without a catalog", () => {
+    for (const labels of [
+      buildModelChoiceLabels(CATALOG),
+      buildModelChoiceLabels(null),
+    ]) {
+      expect(labels.get("small")).toBe("small chat model (global)");
+      expect(labels.get("coding")).toBe("coding sub-agent model (global)");
+      expect(labels.get("show")).toBe("current model configuration");
+      expect(labels.get("codex")).toBe("Codex CLI");
+      expect(labels.get("elizaos")).toBe("elizaOS coder");
+    }
+  });
+});

--- a/packages/ui/src/chat/model-choices.ts
+++ b/packages/ui/src/chat/model-choices.ts
@@ -1,0 +1,288 @@
+/**
+ * Position-aware completion values for the "models" dynamic arg source, derived
+ * from the `catalog` field of `GET /api/models` (the same catalog
+ * `POST /api/models/config` validates writes against). Pure functions so the
+ * grammar can be unit-tested without React: `useSlashCommandController`
+ * pre-fetches the catalog into state and delegates here per keystroke.
+ *
+ * The `/model` grammar this mirrors (plugin-commands actions/model-config.ts):
+ *   /model <target|model>                      target ∈ small|large|coding|show|local|cloud
+ *   /model small|large [provider] <model> [effort]
+ *   /model coding <backend> <model> [effort]
+ * Values must be single whitespace-free tokens (the menu's completion rejoins
+ * tokens with spaces). A model served by more than one chat provider is offered
+ * as `provider/id` so picking it can never hit the route's ambiguous-provider
+ * 400; unique ids stay bare.
+ */
+
+import type {
+  ModelCatalogEntry,
+  ModelCatalogProviders,
+} from "../api/client-types-core";
+import type { SlashArgChoiceContext } from "./slash-menu";
+
+/** Keeps the arg menu scannable when a provider catalog grows. */
+const MAX_MODEL_CHOICES = 25;
+
+type ChatTarget = "small" | "large";
+
+/** Backend tokens `/model coding <backend>` accepts, in suggestion order. */
+export const CODING_BACKEND_CHOICES = [
+  "codex",
+  "claude",
+  "opencode",
+  "elizaos",
+] as const;
+
+// Catalog provider that carries each backend's model list; opencode/elizaos
+// take free-form model ids, so they get no completion source.
+const CODING_BACKEND_CATALOG_PROVIDER: Record<string, string> = {
+  codex: "codex",
+  claude: "claude-coding",
+};
+
+function isChatTarget(token: string | undefined): token is ChatTarget {
+  return token === "small" || token === "large";
+}
+
+function callable(entry: ModelCatalogEntry): boolean {
+  return entry.apiSupported !== false;
+}
+
+function cap(values: string[]): string[] {
+  return values.slice(0, MAX_MODEL_CHOICES);
+}
+
+function allModelIds(providers: ModelCatalogProviders): string[] {
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  for (const entries of Object.values(providers)) {
+    for (const entry of entries) {
+      if (!callable(entry) || seen.has(entry.id)) continue;
+      seen.add(entry.id);
+      ids.push(entry.id);
+    }
+  }
+  return ids;
+}
+
+function chatEntries(
+  providers: ModelCatalogProviders,
+  target: ChatTarget,
+): Array<{ provider: string; entry: ModelCatalogEntry }> {
+  const matches: Array<{ provider: string; entry: ModelCatalogEntry }> = [];
+  for (const [provider, entries] of Object.entries(providers)) {
+    for (const entry of entries) {
+      if (callable(entry) && entry.roles.includes(target)) {
+        matches.push({ provider, entry });
+      }
+    }
+  }
+  return matches;
+}
+
+/**
+ * Chat model values for a target: bare id when one provider serves it,
+ * `provider/id` per serving provider otherwise (deterministic writes — the
+ * config route 400s on an ambiguous bare id).
+ */
+function chatModelValues(
+  providers: ModelCatalogProviders,
+  target: ChatTarget,
+): string[] {
+  const matches = chatEntries(providers, target);
+  const providerCount = new Map<string, number>();
+  for (const { entry } of matches) {
+    providerCount.set(entry.id, (providerCount.get(entry.id) ?? 0) + 1);
+  }
+  const values: string[] = [];
+  const seen = new Set<string>();
+  for (const { provider, entry } of matches) {
+    const value =
+      (providerCount.get(entry.id) ?? 0) > 1
+        ? `${provider}/${entry.id}`
+        : entry.id;
+    if (seen.has(value)) continue;
+    seen.add(value);
+    values.push(value);
+  }
+  return values;
+}
+
+function providerModelIds(
+  providers: ModelCatalogProviders,
+  provider: string,
+  target?: ChatTarget,
+): string[] {
+  const entries = providers[provider] ?? [];
+  return entries
+    .filter(
+      (entry) => callable(entry) && (!target || entry.roles.includes(target)),
+    )
+    .map((entry) => entry.id);
+}
+
+/** Union of effort levels in first-seen order across the given entries. */
+function effortUnion(entries: ModelCatalogEntry[]): string[] {
+  const efforts: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of entries) {
+    for (const effort of entry.efforts) {
+      if (seen.has(effort)) continue;
+      seen.add(effort);
+      efforts.push(effort);
+    }
+  }
+  return efforts;
+}
+
+/**
+ * Entries a chat-target model token names: a `provider/id` value narrows to
+ * that provider; a bare id matches every chat provider serving it.
+ */
+function chatEntriesForToken(
+  providers: ModelCatalogProviders,
+  target: ChatTarget,
+  token: string,
+): ModelCatalogEntry[] {
+  const slash = token.indexOf("/");
+  const prefix = slash > 0 ? token.slice(0, slash).toLowerCase() : "";
+  if (prefix && providers[prefix]) {
+    const id = token.slice(slash + 1);
+    return (providers[prefix] ?? []).filter(
+      (entry) => entry.id === id && entry.roles.includes(target),
+    );
+  }
+  return chatEntries(providers, target)
+    .filter(({ entry }) => entry.id === token)
+    .map(({ entry }) => entry);
+}
+
+function isChatProviderToken(
+  providers: ModelCatalogProviders,
+  target: ChatTarget,
+  token: string | undefined,
+): boolean {
+  if (!token) return false;
+  const entries = providers[token.toLowerCase()];
+  return entries?.some((entry) => entry.roles.includes(target)) ?? false;
+}
+
+function codingModelIds(
+  providers: ModelCatalogProviders,
+  backendToken: string | undefined,
+): string[] {
+  const provider =
+    CODING_BACKEND_CATALOG_PROVIDER[backendToken?.toLowerCase() ?? ""];
+  return provider ? providerModelIds(providers, provider) : [];
+}
+
+function codingEfforts(
+  providers: ModelCatalogProviders,
+  backendToken: string | undefined,
+  modelToken: string | undefined,
+): string[] {
+  const provider =
+    CODING_BACKEND_CATALOG_PROVIDER[backendToken?.toLowerCase() ?? ""];
+  if (!provider || !modelToken) return [];
+  const entry = (providers[provider] ?? []).find((e) => e.id === modelToken);
+  return entry ? [...entry.efforts] : [];
+}
+
+/**
+ * Resolve the completion values for a "models"-sourced argument. Without a
+ * catalog there is nothing to offer; without positional context (a command
+ * other than `/model` tagging the source) every callable model id is offered.
+ */
+export function resolveModelChoices(
+  providers: ModelCatalogProviders | null,
+  context: SlashArgChoiceContext | undefined,
+): string[] {
+  if (!providers) return [];
+  if (context?.commandKey !== "model") {
+    return cap(allModelIds(providers));
+  }
+
+  const first = context.precedingTokens[0]?.toLowerCase();
+  switch (context.argIndex) {
+    case 0:
+      // The static target choices ride on the arg definition; the dynamic side
+      // offers model ids for the pre-existing bare-name per-room preference.
+      return cap(allModelIds(providers));
+
+    case 1: {
+      if (isChatTarget(first)) return cap(chatModelValues(providers, first));
+      if (first === "coding") return [...CODING_BACKEND_CHOICES];
+      return [];
+    }
+
+    case 2: {
+      const second = context.precedingTokens[1] ?? "";
+      if (isChatTarget(first)) {
+        if (isChatProviderToken(providers, first, second)) {
+          return cap(providerModelIds(providers, second.toLowerCase(), first));
+        }
+        return effortUnion(chatEntriesForToken(providers, first, second));
+      }
+      if (first === "coding") return cap(codingModelIds(providers, second));
+      return [];
+    }
+
+    case 3: {
+      const second = context.precedingTokens[1] ?? "";
+      const third = context.precedingTokens[2] ?? "";
+      if (isChatTarget(first)) {
+        if (!isChatProviderToken(providers, first, second)) return [];
+        return effortUnion(
+          (providers[second.toLowerCase()] ?? []).filter(
+            (entry) => entry.id === third && entry.roles.includes(first),
+          ),
+        );
+      }
+      if (first === "coding") return codingEfforts(providers, second, third);
+      return [];
+    }
+
+    default:
+      return [];
+  }
+}
+
+// Row labels for /model's static target/backend tokens; catalog-derived model
+// values get their display name (plus provider for qualified values).
+const STATIC_MODEL_CHOICE_LABELS: ReadonlyArray<[string, string]> = [
+  ["small", "small chat model (global)"],
+  ["large", "large chat model (global)"],
+  ["coding", "coding sub-agent model (global)"],
+  ["show", "current model configuration"],
+  ["local", "on-device inference"],
+  ["cloud", "Eliza Cloud inference"],
+  ["codex", "Codex CLI"],
+  ["claude", "Claude Code"],
+  ["opencode", "OpenCode"],
+  ["elizaos", "elizaOS coder"],
+];
+
+/**
+ * Value→label map for every choice {@link resolveModelChoices} can emit, so
+ * the menu can render a display name next to the raw completion token.
+ */
+export function buildModelChoiceLabels(
+  providers: ModelCatalogProviders | null,
+): Map<string, string> {
+  const labels = new Map<string, string>(STATIC_MODEL_CHOICE_LABELS);
+  if (!providers) return labels;
+  for (const [provider, entries] of Object.entries(providers)) {
+    for (const entry of entries) {
+      const hint = entry.costHint ? ` — ${entry.costHint}` : "";
+      if (!labels.has(entry.id)) {
+        labels.set(entry.id, `${entry.display}${hint}`);
+      }
+      labels.set(
+        `${provider}/${entry.id}`,
+        `${entry.display} · ${provider}${hint}`,
+      );
+    }
+  }
+  return labels;
+}

--- a/packages/ui/src/chat/slash-menu.ts
+++ b/packages/ui/src/chat/slash-menu.ts
@@ -236,6 +236,21 @@ export function activeArgIndex(
   return Math.min(idx, command.args.length - 1);
 }
 
+/**
+ * Where an argument completion is happening, threaded to dynamic choice
+ * resolvers so a source like "models" can return different values per
+ * subcommand position (e.g. `/model small <model>` vs `/model coding
+ * <backend> <model>`). Resolvers without positional needs ignore it.
+ */
+export interface SlashArgChoiceContext {
+  /** Key of the matched command whose argument is being completed. */
+  commandKey: string;
+  /** Index of the argument being completed (see {@link activeArgIndex}). */
+  argIndex: number;
+  /** Argument tokens committed before the one being completed. */
+  precedingTokens: string[];
+}
+
 /** Filter a set of resolved arg choices by the partial token being typed. */
 export function filterArgChoices(choices: string[], query: string): string[] {
   if (!query) return [...choices];

--- a/packages/ui/src/chat/useSlashCommandController.models.test.ts
+++ b/packages/ui/src/chat/useSlashCommandController.models.test.ts
@@ -1,0 +1,245 @@
+// @vitest-environment jsdom
+
+/**
+ * Model-catalog wiring for useSlashCommandController's "models" choice source:
+ * the catalog is fetched only when a loaded command declares a "models"
+ * dynamic arg, resolveChoices("models", ctx) answers per subcommand position
+ * once it lands, describeChoice labels the values, and a failed fetch degrades
+ * to no completions (logged, never a fake list) without polluting the command
+ * catalog's error state.
+ */
+
+import type { CustomActionDef } from "@elizaos/shared";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SlashCommandCatalogItem } from "../api/client-types-commands";
+import { ApiError, type ModelCatalogResponse } from "../api/client-types-core";
+
+const { listCommands, listCustomActions, fetchModelCatalog } = vi.hoisted(
+  () => ({
+    listCommands:
+      vi.fn<(surface?: string) => Promise<SlashCommandCatalogItem[]>>(),
+    listCustomActions: vi.fn<() => Promise<CustomActionDef[]>>(),
+    fetchModelCatalog: vi.fn<() => Promise<ModelCatalogResponse>>(),
+  }),
+);
+
+vi.mock("../api", () => ({
+  client: {
+    listCommands: (surface?: string) => listCommands(surface),
+    listCustomActions: () => listCustomActions(),
+    fetchModelCatalog: () => fetchModelCatalog(),
+  },
+}));
+vi.mock("../config/boot-config-react.hooks", () => ({
+  useBootConfig: (): { shortcutFlags?: { naturalLanguage?: boolean } } => ({}),
+}));
+vi.mock("../hooks/useAvailableViews", () => ({
+  useAvailableViews: (): { views: never[] } => ({ views: [] }),
+}));
+vi.mock("../state", () => ({
+  useAppSelectorShallow: <T>(
+    selector: (state: {
+      setTab: (tab: string) => void;
+      handleChatClear: () => Promise<void>;
+    }) => T,
+  ): T =>
+    selector({
+      setTab: () => {},
+      handleChatClear: async () => {},
+    }),
+}));
+
+import { useSlashCommandController } from "./useSlashCommandController";
+
+function cmd(
+  partial: Partial<SlashCommandCatalogItem> & { key: string },
+): SlashCommandCatalogItem {
+  return {
+    nativeName: partial.key,
+    description: "",
+    textAliases: [`/${partial.key}`],
+    scope: "both",
+    acceptsArgs: false,
+    args: [],
+    requiresAuth: false,
+    requiresElevated: false,
+    target: { kind: "agent" },
+    ...partial,
+    source: partial.source ?? "builtin",
+  };
+}
+
+const MODEL_COMMAND = cmd({
+  key: "model",
+  acceptsArgs: true,
+  args: [
+    {
+      name: "target",
+      description: "small, large, coding, show, local, cloud",
+      choices: ["small", "large", "coding", "show", "local", "cloud"],
+      dynamicChoices: "models",
+    },
+    { name: "model", description: "model id", dynamicChoices: "models" },
+  ],
+});
+
+const CATALOG_RESPONSE: ModelCatalogResponse = {
+  catalog: {
+    providers: {
+      codex: [
+        {
+          id: "gpt-5.5",
+          display: "GPT-5.5",
+          efforts: ["low", "medium", "high", "xhigh"],
+          roles: ["coding"],
+        },
+      ],
+      cerebras: [
+        {
+          id: "zai-glm-4.7",
+          display: "GLM-4.7",
+          efforts: ["low", "medium", "high"],
+          roles: ["small", "large"],
+        },
+      ],
+    },
+  },
+};
+
+function apiError(status: number, message: string): ApiError {
+  return new ApiError({
+    kind: "http",
+    path: "/api/models",
+    status,
+    message,
+  });
+}
+
+beforeEach(() => {
+  listCommands.mockReset();
+  listCustomActions.mockReset();
+  fetchModelCatalog.mockReset();
+  listCustomActions.mockResolvedValue([]);
+  window.localStorage.clear();
+});
+
+describe("useSlashCommandController — models choice source", () => {
+  it("fetches the catalog when a command declares a models arg and resolves per-position choices", async () => {
+    listCommands.mockResolvedValue([MODEL_COMMAND]);
+    fetchModelCatalog.mockResolvedValue(CATALOG_RESPONSE);
+
+    const { result } = renderHook(() => useSlashCommandController());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(fetchModelCatalog).toHaveBeenCalledTimes(1);
+    await waitFor(() =>
+      expect(
+        result.current.resolveChoices("models", {
+          commandKey: "model",
+          argIndex: 1,
+          precedingTokens: ["large"],
+        }),
+      ).toEqual(["zai-glm-4.7"]),
+    );
+    expect(
+      result.current.resolveChoices("models", {
+        commandKey: "model",
+        argIndex: 1,
+        precedingTokens: ["coding"],
+      }),
+    ).toEqual(["codex", "claude", "opencode", "elizaos"]);
+    expect(
+      result.current.resolveChoices("models", {
+        commandKey: "model",
+        argIndex: 2,
+        precedingTokens: ["coding", "codex"],
+      }),
+    ).toEqual(["gpt-5.5"]);
+  });
+
+  it("labels model values and /model target tokens via describeChoice", async () => {
+    listCommands.mockResolvedValue([MODEL_COMMAND]);
+    fetchModelCatalog.mockResolvedValue(CATALOG_RESPONSE);
+
+    const { result } = renderHook(() => useSlashCommandController());
+
+    await waitFor(() =>
+      expect(result.current.describeChoice("models", "zai-glm-4.7")).toBe(
+        "GLM-4.7",
+      ),
+    );
+    expect(result.current.describeChoice("models", "coding")).toBe(
+      "coding sub-agent model (global)",
+    );
+    // Non-models sources stay label-free.
+    expect(result.current.describeChoice("views", "zai-glm-4.7")).toBe("");
+  });
+
+  it("does not fetch the catalog when no command declares a models arg", async () => {
+    listCommands.mockResolvedValue([cmd({ key: "help" })]);
+
+    const { result } = renderHook(() => useSlashCommandController());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(fetchModelCatalog).not.toHaveBeenCalled();
+    expect(
+      result.current.resolveChoices("models", {
+        commandKey: "model",
+        argIndex: 1,
+        precedingTokens: ["large"],
+      }),
+    ).toEqual([]);
+  });
+
+  it("degrades to no completions on a failed catalog fetch, logged, without flagging the command catalog", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    listCommands.mockResolvedValue([MODEL_COMMAND]);
+    const failure = new Error("models route down");
+    fetchModelCatalog.mockRejectedValue(failure);
+
+    const { result } = renderHook(() => useSlashCommandController());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await waitFor(() =>
+      expect(consoleError).toHaveBeenCalledWith(
+        expect.stringContaining("model catalog"),
+        failure,
+      ),
+    );
+    expect(
+      result.current.resolveChoices("models", {
+        commandKey: "model",
+        argIndex: 1,
+        precedingTokens: ["large"],
+      }),
+    ).toEqual([]);
+    // The command catalog itself loaded fine — no false error state (#12784).
+    expect(result.current.error).toBe(false);
+    consoleError.mockRestore();
+  });
+
+  it("treats an unauthenticated catalog fetch as quietly unavailable (#14663)", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    listCommands.mockResolvedValue([MODEL_COMMAND]);
+    fetchModelCatalog.mockRejectedValue(apiError(401, "Unauthorized"));
+
+    const { result } = renderHook(() => useSlashCommandController());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(fetchModelCatalog).toHaveBeenCalledTimes(1);
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(
+      result.current.resolveChoices("models", {
+        commandKey: "model",
+        argIndex: 0,
+        precedingTokens: [],
+      }),
+    ).toEqual([]);
+    consoleError.mockRestore();
+  });
+});

--- a/packages/ui/src/chat/useSlashCommandController.ts
+++ b/packages/ui/src/chat/useSlashCommandController.ts
@@ -13,7 +13,10 @@ import type {
   CommandArgSource,
   SlashCommandCatalogItem,
 } from "../api/client-types-commands";
-import { isApiError } from "../api/client-types-core";
+import {
+  isApiError,
+  type ModelCatalogProviders,
+} from "../api/client-types-core";
 import {
   resolveSettingsSectionToken,
   SETTINGS_SECTION_SUGGESTIONS,
@@ -25,7 +28,11 @@ import type { Tab } from "../navigation";
 import { useAppSelectorShallow } from "../state";
 import { getElizaApiBase, getElizaApiToken } from "../utils/eliza-globals";
 import { loadSavedCustomCommands, normalizeSlashCommandName } from "./index";
-import { filterCommandsForSurface } from "./slash-menu";
+import { buildModelChoiceLabels, resolveModelChoices } from "./model-choices";
+import {
+  filterCommandsForSurface,
+  type SlashArgChoiceContext,
+} from "./slash-menu";
 
 /** The surface the dashboard chat composer renders on. */
 const GUI_SURFACE = "gui" as const;
@@ -126,8 +133,17 @@ export interface SlashCommandController {
   error: boolean;
   /** Whether natural-language navigate/client shortcuts may short-circuit send. */
   naturalShortcutsEnabled: boolean;
-  /** Resolve dynamic argument completions for a named source. */
-  resolveChoices: (source: CommandArgSource) => string[];
+  /**
+   * Resolve dynamic argument completions for a named source. `context` carries
+   * the completion position so positional sources (the "models" grammar) can
+   * return per-subcommand values; sources without positional needs ignore it.
+   */
+  resolveChoices: (
+    source: CommandArgSource,
+    context?: SlashArgChoiceContext,
+  ) => string[];
+  /** Display label for a resolved choice ("" when the value speaks for itself). */
+  describeChoice: (source: CommandArgSource, choice: string) => string;
   /** Map a user-typed settings token to a canonical section id. */
   resolveSection: (token: string) => string | undefined;
   /**
@@ -239,6 +255,8 @@ export function useSlashCommandController(
   >([]);
   const [loading, setLoading] = React.useState(true);
   const [loadError, setLoadError] = React.useState(false);
+  const [modelCatalog, setModelCatalog] =
+    React.useState<ModelCatalogProviders | null>(null);
 
   React.useEffect(() => {
     let cancelled = false;
@@ -289,6 +307,30 @@ export function useSlashCommandController(
           return [];
         });
       if (cancelled) return;
+      // The model catalog only matters when a command actually declares a
+      // "models" dynamic arg (a cold GET /api/models can fan out provider
+      // fetches server-side), and it must not delay the command menu — fetched
+      // in parallel, resolved into state whenever it lands.
+      if (
+        catalog.some((command) =>
+          command.args.some((arg) => arg.dynamicChoices === "models"),
+        )
+      ) {
+        void client
+          .fetchModelCatalog()
+          .then((models) => {
+            if (!cancelled) setModelCatalog(models.catalog.providers);
+          })
+          .catch((error: unknown) => {
+            // error-policy:J4 model completions degrade to none with the
+            // failure logged; an unauthenticated 401/403 is expected (#14663).
+            if (isExpectedCatalogAuthError(error)) return;
+            console.error(
+              "[useSlashCommandController] Failed to load the model catalog; model completions will be empty",
+              error,
+            );
+          });
+      }
       setServerCommands(catalog);
       const saved = loadSavedCustomCommands().map((c) =>
         savedCommandToCommand(c.name),
@@ -321,17 +363,29 @@ export function useSlashCommandController(
     bootConfig.shortcutFlags?.naturalLanguage === true;
 
   const resolveChoices = React.useCallback(
-    (source: CommandArgSource): string[] => {
+    (source: CommandArgSource, context?: SlashArgChoiceContext): string[] => {
       switch (source) {
         case "settings-sections":
           return SETTINGS_SECTION_SUGGESTIONS;
         case "views":
           return views.map((v) => v.id);
+        case "models":
+          return resolveModelChoices(modelCatalog, context);
         default:
           return [];
       }
     },
-    [views],
+    [views, modelCatalog],
+  );
+
+  const modelChoiceLabels = React.useMemo(
+    () => buildModelChoiceLabels(modelCatalog),
+    [modelCatalog],
+  );
+  const describeChoice = React.useCallback(
+    (source: CommandArgSource, choice: string): string =>
+      source === "models" ? (modelChoiceLabels.get(choice) ?? "") : "",
+    [modelChoiceLabels],
   );
 
   const navigateTab = React.useCallback(
@@ -391,6 +445,7 @@ export function useSlashCommandController(
       error: loadError,
       naturalShortcutsEnabled,
       resolveChoices,
+      describeChoice,
       resolveSection: resolveSettingsSectionToken,
       isAuthorized,
       isElevated,
@@ -406,6 +461,7 @@ export function useSlashCommandController(
       loadError,
       naturalShortcutsEnabled,
       resolveChoices,
+      describeChoice,
       isAuthorized,
       isElevated,
       navigateTab,

--- a/packages/ui/src/components/settings/ModelConfigurationPanel.stories.tsx
+++ b/packages/ui/src/components/settings/ModelConfigurationPanel.stories.tsx
@@ -1,0 +1,226 @@
+/**
+ * Storybook stories for the Settings → Models configuration panel, covering
+ * the catalog loading/empty/error states and the ready panel across resting,
+ * armed-restart-confirm, restarting, typed-400, and saved-coding states. Pure
+ * fixture props into the presentational view — no backend, no app context.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react";
+import type { ModelCatalogEntry } from "../../api/client-types-core";
+import { ModelConfigurationPanelView } from "./ModelConfigurationPanel";
+import { SettingsStack } from "./settings-layout";
+import type {
+  ModelConfigChatGroup,
+  ModelConfigCodingGroup,
+  ModelGroupSaveState,
+} from "./useModelConfiguration";
+
+const t = (key: string, vars?: Record<string, unknown>) => {
+  const template =
+    typeof vars?.defaultValue === "string" ? vars.defaultValue : key;
+  return template.replace(/\{\{(\w+)\}\}/g, (_match, name: string) =>
+    String(vars?.[name] ?? ""),
+  );
+};
+
+const noop = () => {};
+
+const CEREBRAS_ENTRIES: ModelCatalogEntry[] = [
+  {
+    id: "gemma-4-31b",
+    display: "Gemma 4 31B",
+    efforts: ["low", "medium", "high"],
+    roles: ["small"],
+  },
+  {
+    id: "zai-glm-4.7",
+    display: "GLM-4.7",
+    efforts: ["low", "medium", "high"],
+    roles: ["small", "large"],
+  },
+];
+
+const CODEX_ENTRIES: ModelCatalogEntry[] = [
+  {
+    id: "gpt-5.6-terra",
+    display: "GPT-5.6-Terra",
+    efforts: ["low", "medium", "high", "xhigh"],
+    defaultEffort: "medium",
+    roles: ["coding"],
+    costHint: "highest cost/latency tier",
+  },
+  {
+    id: "gpt-5.3-codex-spark",
+    display: "GPT-5.3-Codex-Spark",
+    efforts: ["low", "medium", "high", "xhigh"],
+    roles: ["coding"],
+    apiSupported: false,
+  },
+];
+
+function chatGroup(
+  target: "small" | "large",
+  save: ModelGroupSaveState,
+): ModelConfigChatGroup {
+  return {
+    target,
+    providerOptions: [
+      { value: "cerebras", label: "Cerebras" },
+      { value: "elizacloud", label: "Eliza Cloud" },
+      { value: "claude-chat", label: "Claude" },
+    ],
+    provider: "cerebras",
+    modelOptions: CEREBRAS_ENTRIES.filter((entry) =>
+      entry.roles.includes(target),
+    ),
+    model: target === "small" ? "gemma-4-31b" : "zai-glm-4.7",
+    effortOptions: ["low", "medium", "high"],
+    effort: "low",
+    selectedEntry:
+      CEREBRAS_ENTRIES.find(
+        (entry) =>
+          entry.id === (target === "small" ? "gemma-4-31b" : "zai-glm-4.7"),
+      ) ?? null,
+    configured:
+      target === "small"
+        ? { model: "gemma-4-31b", source: "process.env" }
+        : { model: "zai-glm-4.7", source: "config.env" },
+    sharedEffortKnob: true,
+    save,
+    setProvider: noop,
+    setModel: noop,
+    setEffort: noop,
+    requestSave: noop,
+    confirmSave: noop,
+    cancelSave: noop,
+  };
+}
+
+function codingGroup(save: ModelGroupSaveState): ModelConfigCodingGroup {
+  return {
+    backend: "codex",
+    backendOptions: [
+      { value: "codex", label: "Codex" },
+      { value: "claude", label: "Claude" },
+      { value: "opencode", label: "OpenCode" },
+      { value: "eliza-code", label: "elizaOS" },
+    ],
+    persistedDefaultBackend: "codex",
+    makeDefault: true,
+    freeFormModel: false,
+    modelOptions: CODEX_ENTRIES,
+    model: "gpt-5.6-terra",
+    effortOptions: ["low", "medium", "high", "xhigh"],
+    effort: "medium",
+    selectedEntry: CODEX_ENTRIES[0] ?? null,
+    configured: { model: "gpt-5.6-terra", source: "default" },
+    save,
+    setBackend: noop,
+    setModel: noop,
+    setEffort: noop,
+    setMakeDefault: noop,
+    saveNow: noop,
+  };
+}
+
+function readyState(overrides?: {
+  small?: ModelGroupSaveState;
+  large?: ModelGroupSaveState;
+  coding?: ModelGroupSaveState;
+}) {
+  return {
+    phase: "ready" as const,
+    small: chatGroup("small", overrides?.small ?? { phase: "idle" }),
+    large: chatGroup("large", overrides?.large ?? { phase: "idle" }),
+    coding: codingGroup(overrides?.coding ?? { phase: "idle" }),
+  };
+}
+
+const meta = {
+  title: "Settings/ModelConfigurationPanel",
+  component: ModelConfigurationPanelView,
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <div className="max-w-2xl p-4">
+        <SettingsStack>
+          <Story />
+        </SettingsStack>
+      </div>
+    ),
+  ],
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof ModelConfigurationPanelView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Catalog + config fetch in flight. */
+export const Loading: Story = {
+  args: { state: { phase: "loading" }, t },
+};
+
+/** Catalog fetch failed — designed error state with retry. */
+export const LoadError: Story = {
+  args: {
+    state: {
+      phase: "error",
+      message: "HTTP 502 from /api/models",
+      retry: noop,
+    },
+    t,
+  },
+};
+
+/** Runtime reported no configurable models — designed empty state. */
+export const EmptyCatalog: Story = {
+  args: { state: { phase: "empty", retry: noop }, t },
+};
+
+/** All three groups resting, prefilled from the effective config. */
+export const Ready: Story = {
+  args: { state: readyState(), t },
+};
+
+/** Chat save armed: the restart warning awaits explicit confirmation. */
+export const ConfirmRestart: Story = {
+  args: { state: readyState({ small: { phase: "confirm" } }), t },
+};
+
+/** Chat write accepted; polling runtime status until it is back. */
+export const Restarting: Story = {
+  args: {
+    state: readyState({
+      large: { phase: "restarting", operationId: "op-42" },
+    }),
+    t,
+  },
+};
+
+/** The route's typed 400 rendered inline with its supported values. */
+export const InvalidEffort: Story = {
+  args: {
+    state: readyState({
+      coding: {
+        phase: "error",
+        message:
+          'Effort "ultra" is valid for gpt-5.6-terra but not parseable by the pinned codex-acp adapter',
+        supported: ["low", "medium", "high", "xhigh"],
+      },
+    }),
+    t,
+  },
+};
+
+/** Coding write applied restart-free, with a service-env conflict warning. */
+export const SavedCoding: Story = {
+  args: {
+    state: readyState({
+      coding: {
+        phase: "saved",
+        conflictKeys: ["ELIZA_CODEX_MODEL_POWERFUL"],
+      },
+    }),
+    t,
+  },
+};

--- a/packages/ui/src/components/settings/ModelConfigurationPanel.test.tsx
+++ b/packages/ui/src/components/settings/ModelConfigurationPanel.test.tsx
@@ -1,0 +1,491 @@
+// @vitest-environment jsdom
+
+/**
+ * Covers the per-role model configuration panel: catalog-driven option
+ * filtering per provider/backend, the chat restart-confirm save flow (with
+ * the server-side restart poll — never a client restartAgent call), the
+ * restart-free coding save, and inline rendering of the route's typed 400 /
+ * 409 outcomes. jsdom render with the app store, API client, and agent
+ * surface mocked; selects are driven through their agent-surface onFill
+ * bindings (the production chat-control path).
+ */
+
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  ModelCatalog,
+  ModelsConfigResponse,
+} from "../../api/client-types-core";
+
+interface CapturedAgentElement {
+  id: string;
+  options?: string[];
+  onFill?: (value: string) => void;
+  onActivate?: () => void;
+}
+
+const { clientMock, agentElements } = vi.hoisted(() => ({
+  clientMock: {
+    getModelsCatalog: vi.fn(),
+    getModelsConfig: vi.fn(),
+    updateModelsConfig: vi.fn(),
+    getStatus: vi.fn(),
+    restartAgent: vi.fn(),
+  },
+  agentElements: new Map<
+    string,
+    {
+      options?: string[];
+      onFill?: (v: string) => void;
+      onActivate?: () => void;
+    }
+  >(),
+}));
+
+vi.mock("../../state", () => {
+  const t = (key: string, vars?: Record<string, unknown>) => {
+    const template =
+      typeof vars?.defaultValue === "string" ? vars.defaultValue : key;
+    return template.replace(/\{\{(\w+)\}\}/g, (_match, name: string) =>
+      String(vars?.[name] ?? ""),
+    );
+  };
+  return {
+    useAppSelector: (sel: (value: Record<string, unknown>) => unknown) =>
+      sel({ t }),
+    useAppSelectorShallow: (sel: (value: Record<string, unknown>) => unknown) =>
+      sel({ t }),
+  };
+});
+
+vi.mock("../../api", () => ({ client: clientMock }));
+
+vi.mock("../../agent-surface", () => ({
+  useAgentElement: (spec: CapturedAgentElement) => {
+    agentElements.set(spec.id, {
+      options: spec.options,
+      onFill: spec.onFill,
+      onActivate: spec.onActivate,
+    });
+    return { ref: undefined, agentProps: { "data-agent-id": spec.id } };
+  },
+}));
+
+import { ModelConfigurationPanel } from "./ModelConfigurationPanel";
+
+function fixtureCatalog(): ModelCatalog {
+  return {
+    providers: {
+      codex: [
+        {
+          id: "gpt-5.6-terra",
+          display: "GPT-5.6-Terra",
+          efforts: ["low", "medium", "high", "xhigh", "max", "ultra"],
+          defaultEffort: "medium",
+          roles: ["coding"],
+          costHint: "highest cost/latency tier",
+        },
+        {
+          id: "gpt-5.3-codex-spark",
+          display: "GPT-5.3-Codex-Spark",
+          efforts: ["low", "medium", "high", "xhigh"],
+          defaultEffort: "high",
+          roles: ["coding"],
+          apiSupported: false,
+        },
+      ],
+      "claude-chat": [
+        {
+          id: "claude-opus-4-8",
+          display: "Claude Opus 4.8",
+          efforts: ["low", "medium", "high", "xhigh", "max"],
+          roles: ["small", "large"],
+        },
+      ],
+      "claude-coding": [
+        {
+          id: "claude-opus-4-8",
+          display: "Claude Opus 4.8",
+          efforts: ["low", "medium", "high", "xhigh", "max"],
+          defaultEffort: "xhigh",
+          roles: ["coding"],
+        },
+      ],
+      cerebras: [
+        {
+          id: "gemma-4-31b",
+          display: "Gemma 4 31B",
+          efforts: ["low", "medium", "high"],
+          roles: ["small"],
+        },
+        {
+          id: "zai-glm-4.7",
+          display: "GLM-4.7",
+          efforts: ["low", "medium", "high"],
+          roles: ["small", "large"],
+        },
+        {
+          id: "plain-model",
+          display: "Plain Model",
+          efforts: [],
+          roles: ["small", "large"],
+        },
+      ],
+      elizacloud: [
+        {
+          id: "gpt-oss-120b",
+          display: "GPT-OSS 120B",
+          efforts: ["low", "medium", "high"],
+          roles: ["small", "large"],
+        },
+      ],
+    },
+  };
+}
+
+function fixtureConfig(): ModelsConfigResponse {
+  return {
+    targets: {
+      small: {
+        OPENAI_SMALL_MODEL: { value: "gemma-4-31b", source: "process.env" },
+        ANTHROPIC_SMALL_MODEL: null,
+        OPENAI_REASONING_EFFORT: { value: "low", source: "config.env" },
+        ANTHROPIC_EFFORT_SMALL: null,
+      },
+      large: {
+        OPENAI_LARGE_MODEL: { value: "zai-glm-4.7", source: "config.env" },
+        ANTHROPIC_LARGE_MODEL: null,
+        OPENAI_REASONING_EFFORT: { value: "low", source: "config.env" },
+        ANTHROPIC_EFFORT_LARGE: null,
+      },
+      coding: {
+        ELIZA_DEFAULT_AGENT_TYPE: { value: "codex", source: "config.env" },
+        ELIZA_CODEX_MODEL_POWERFUL: {
+          value: "gpt-5.6-terra",
+          source: "default",
+        },
+        ELIZA_CODEX_EFFORT: { value: "medium", source: "config.env" },
+        ELIZA_CLAUDE_MODEL_POWERFUL: null,
+        ELIZA_CLAUDE_EFFORT: null,
+        ELIZA_OPENCODE_MODEL_POWERFUL: {
+          value: "custom-oss-model",
+          source: "config.env",
+        },
+        ELIZA_ELIZAOS_MODEL_POWERFUL: null,
+      },
+    },
+  };
+}
+
+function fill(agentId: string, value: string) {
+  const element = agentElements.get(agentId);
+  if (!element?.onFill) throw new Error(`no onFill captured for ${agentId}`);
+  act(() => element.onFill?.(value));
+}
+
+function agentButton(agentId: string): HTMLButtonElement {
+  const node = document.querySelector(`button[data-agent-id="${agentId}"]`);
+  if (!node) throw new Error(`no button rendered for ${agentId}`);
+  return node as HTMLButtonElement;
+}
+
+async function renderReady() {
+  render(<ModelConfigurationPanel />);
+  await waitFor(() =>
+    expect(agentElements.has("models-small-provider")).toBe(true),
+  );
+}
+
+beforeEach(() => {
+  agentElements.clear();
+  clientMock.getModelsCatalog.mockReset();
+  clientMock.getModelsCatalog.mockResolvedValue({
+    providers: {},
+    catalog: fixtureCatalog(),
+  });
+  clientMock.getModelsConfig.mockReset();
+  clientMock.getModelsConfig.mockResolvedValue(fixtureConfig());
+  clientMock.updateModelsConfig.mockReset();
+  clientMock.getStatus.mockReset();
+  clientMock.getStatus.mockResolvedValue({ state: "running" });
+  clientMock.restartAgent.mockReset();
+});
+
+afterEach(() => cleanup());
+
+describe("catalog load states", () => {
+  it("renders a loading state while the catalog fetch is pending", async () => {
+    let resolveCatalog: (value: unknown) => void = () => {};
+    clientMock.getModelsCatalog.mockReturnValue(
+      new Promise((resolve) => {
+        resolveCatalog = resolve;
+      }),
+    );
+    render(<ModelConfigurationPanel />);
+    expect(screen.getByText("Loading model catalog…")).toBeTruthy();
+    await act(async () => {
+      resolveCatalog({ providers: {}, catalog: fixtureCatalog() });
+    });
+  });
+
+  it("renders the error state with retry when the fetch fails, and recovers", async () => {
+    clientMock.getModelsCatalog.mockRejectedValueOnce(
+      new Error("catalog unreachable"),
+    );
+    render(<ModelConfigurationPanel />);
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("catalog unreachable");
+
+    agentButton("models-retry").click();
+    await waitFor(() =>
+      expect(agentElements.has("models-small-provider")).toBe(true),
+    );
+  });
+
+  it("renders the designed empty state for an empty catalog", async () => {
+    clientMock.getModelsCatalog.mockResolvedValue({
+      providers: {},
+      catalog: { providers: { codex: [], cerebras: [] } },
+    });
+    render(<ModelConfigurationPanel />);
+    expect(
+      await screen.findByText(
+        "No configurable models were reported by the runtime.",
+      ),
+    ).toBeTruthy();
+  });
+});
+
+describe("prefill and option filtering", () => {
+  it("prefills groups from the effective config and surfaces the env source", async () => {
+    await renderReady();
+
+    expect(agentElements.get("models-small-provider")?.options).toEqual([
+      "cerebras",
+      "elizacloud",
+      "claude-chat",
+    ]);
+    // Small target: only cerebras entries whose roles include "small".
+    expect(agentElements.get("models-small-model")?.options).toEqual([
+      "gemma-4-31b",
+      "zai-glm-4.7",
+      "plain-model",
+    ]);
+    expect(screen.getByText("Set by environment")).toBeTruthy();
+    // Prefilled efforts come from the shared/openai knob.
+    expect(agentElements.get("models-small-effort")?.options).toEqual([
+      "low",
+      "medium",
+      "high",
+    ]);
+  });
+
+  it("re-filters model options when the provider changes", async () => {
+    await renderReady();
+
+    fill("models-small-provider", "claude-chat");
+    expect(agentElements.get("models-small-model")?.options).toEqual([
+      "claude-opus-4-8",
+    ]);
+    // No model selected yet → no effort row.
+    expect(
+      document.querySelector('[data-agent-id="models-small-effort"]'),
+    ).toBeNull();
+
+    fill("models-small-model", "claude-opus-4-8");
+    expect(agentElements.get("models-small-effort")?.options).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+    ]);
+  });
+
+  it("hides the effort control for models without an effort knob", async () => {
+    await renderReady();
+
+    fill("models-small-model", "plain-model");
+    expect(
+      document.querySelector('[data-agent-id="models-small-effort"]'),
+    ).toBeNull();
+  });
+
+  it("clamps codex efforts to the acp-parseable set and keeps the coding prefill", async () => {
+    await renderReady();
+
+    expect(agentElements.get("models-coding-model")?.options).toEqual([
+      "gpt-5.6-terra",
+      "gpt-5.3-codex-spark",
+    ]);
+    expect(agentElements.get("models-coding-effort")?.options).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+    ]);
+  });
+
+  it("keeps a configured opencode model visible even when not in the suggestion list", async () => {
+    await renderReady();
+
+    fill("models-coding-backend", "opencode");
+    expect(agentElements.get("models-coding-model")?.options).toEqual([
+      "custom-oss-model",
+      "gemma-4-31b",
+      "zai-glm-4.7",
+      "plain-model",
+    ]);
+    expect(
+      document.querySelector('[data-agent-id="models-coding-effort"]'),
+    ).toBeNull();
+  });
+
+  it("renders a free-form model input for the eliza-code backend", async () => {
+    await renderReady();
+
+    fill("models-coding-backend", "eliza-code");
+    const input = document.querySelector(
+      'input[data-agent-id="models-coding-model"]',
+    );
+    expect(input).toBeTruthy();
+  });
+});
+
+describe("chat save flow", () => {
+  it("requires an explicit restart confirmation before posting, then polls status", async () => {
+    clientMock.updateModelsConfig.mockResolvedValue({
+      kind: "applied",
+      restart: true,
+      operationId: "op-1",
+      keys: ["OPENAI_SMALL_MODEL", "OPENAI_REASONING_EFFORT"],
+    });
+    let resolveStatus: (value: unknown) => void = () => {};
+    clientMock.getStatus.mockReturnValue(
+      new Promise((resolve) => {
+        resolveStatus = resolve;
+      }),
+    );
+    await renderReady();
+
+    act(() => agentButton("models-small-save").click());
+    expect(screen.getByText("Restart to apply?")).toBeTruthy();
+    expect(clientMock.updateModelsConfig).not.toHaveBeenCalled();
+
+    act(() => agentButton("models-small-confirm-restart").click());
+    await waitFor(() =>
+      expect(clientMock.updateModelsConfig).toHaveBeenCalledWith({
+        target: "small",
+        provider: "cerebras",
+        model: "gemma-4-31b",
+        effort: "low",
+      }),
+    );
+
+    // The route restarts server-side; the panel polls status but must never
+    // trigger a second restart itself.
+    expect(await screen.findByText("Restarting agent…")).toBeTruthy();
+    expect(clientMock.restartAgent).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveStatus({ state: "running" });
+    });
+    expect(await screen.findByText("Saved")).toBeTruthy();
+    // Source notes refresh from the server after a successful write.
+    expect(clientMock.getModelsConfig).toHaveBeenCalledTimes(2);
+  });
+
+  it("cancels an armed restart confirmation without posting", async () => {
+    await renderReady();
+
+    act(() => agentButton("models-small-save").click());
+    act(() => agentButton("models-small-cancel").click());
+
+    expect(screen.queryByText("Restart to apply?")).toBeNull();
+    expect(clientMock.updateModelsConfig).not.toHaveBeenCalled();
+  });
+
+  it("renders the route's typed 400 inline with the supported values", async () => {
+    clientMock.updateModelsConfig.mockResolvedValue({
+      kind: "invalid",
+      error: 'Effort "ultra" is not supported by model "gemma-4-31b"',
+      supported: ["low", "medium", "high"],
+    });
+    await renderReady();
+
+    act(() => agentButton("models-small-save").click());
+    act(() => agentButton("models-small-confirm-restart").click());
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain('Effort "ultra" is not supported');
+    expect(alert.textContent).toContain("Supported: low, medium, high");
+  });
+
+  it("surfaces an in-flight runtime operation (409) inline", async () => {
+    clientMock.updateModelsConfig.mockResolvedValue({
+      kind: "busy",
+      error: "A runtime operation is already in progress",
+      activeOperationId: "op-9",
+    });
+    await renderReady();
+
+    act(() => agentButton("models-large-save").click());
+    act(() => agentButton("models-large-confirm-restart").click());
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain(
+      "A runtime operation is already in progress (operation op-9)",
+    );
+  });
+});
+
+describe("coding save flow", () => {
+  it("saves without confirmation or restart and shows the no-restart copy", async () => {
+    clientMock.updateModelsConfig.mockResolvedValue({
+      kind: "applied",
+      restart: false,
+      keys: ["ELIZA_CODEX_MODEL_POWERFUL", "ELIZA_CODEX_EFFORT"],
+    });
+    await renderReady();
+
+    act(() => agentButton("models-coding-save").click());
+    await waitFor(() =>
+      expect(clientMock.updateModelsConfig).toHaveBeenCalledWith({
+        target: "coding",
+        backend: "codex",
+        model: "gpt-5.6-terra",
+        effort: "medium",
+        // codex is the persisted ELIZA_DEFAULT_AGENT_TYPE, so the default
+        // switch is prefilled on.
+        defaultBackend: "codex",
+      }),
+    );
+
+    expect(
+      await screen.findByText("Saved — applies to the next coding task"),
+    ).toBeTruthy();
+    expect(clientMock.getStatus).not.toHaveBeenCalled();
+    expect(clientMock.restartAgent).not.toHaveBeenCalled();
+  });
+
+  it("posts the eliza-code wire value with a free-form model and no effort", async () => {
+    clientMock.updateModelsConfig.mockResolvedValue({
+      kind: "applied",
+      restart: false,
+      keys: ["ELIZA_ELIZAOS_MODEL_POWERFUL"],
+    });
+    await renderReady();
+
+    fill("models-coding-backend", "eliza-code");
+    fill("models-coding-model", "my-house-model");
+    act(() => agentButton("models-coding-save").click());
+
+    await waitFor(() =>
+      expect(clientMock.updateModelsConfig).toHaveBeenCalledWith({
+        target: "coding",
+        backend: "eliza-code",
+        model: "my-house-model",
+      }),
+    );
+  });
+});

--- a/packages/ui/src/components/settings/ModelConfigurationPanel.test.tsx
+++ b/packages/ui/src/components/settings/ModelConfigurationPanel.test.tsx
@@ -242,6 +242,20 @@ describe("catalog load states", () => {
     );
   });
 
+  it("renders a readable error for a runtime that predates the model-config API", async () => {
+    // An older runtime (or a shapeless stub) answers without the catalog /
+    // targets fields — the boundary guard must surface the designed error
+    // state, never a TypeError from draft resolution.
+    clientMock.getModelsCatalog.mockResolvedValue({});
+    clientMock.getModelsConfig.mockResolvedValue({});
+    render(<ModelConfigurationPanel />);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain(
+      "did not return a model catalog (/api/models)",
+    );
+  });
+
   it("renders the designed empty state for an empty catalog", async () => {
     clientMock.getModelsCatalog.mockResolvedValue({
       providers: {},

--- a/packages/ui/src/components/settings/ModelConfigurationPanel.tsx
+++ b/packages/ui/src/components/settings/ModelConfigurationPanel.tsx
@@ -1,0 +1,545 @@
+/**
+ * Per-role model configuration for Settings → Models & Providers: three
+ * groups (Small model, Large model, Coding sub-agent) driven by the validated
+ * catalog + effective config from `useModelConfiguration`. Chat groups arm an
+ * explicit restart confirmation before saving — their writes restart the
+ * agent server-side — while the coding group saves restart-free and says so.
+ *
+ * `ModelConfigurationPanel` (mounted by ProviderSwitcher) binds the hook;
+ * `ModelConfigurationPanelView` is the pure renderer, exported for stories
+ * and tests. All controls use the agent-addressable settings rows so the
+ * whole panel is drivable from chat.
+ */
+import { CheckCircle2, Loader2 } from "lucide-react";
+import { useAppSelector } from "../../state";
+import {
+  SettingsActionButton,
+  SettingsInputRow,
+  SettingsSegmentedRow,
+  SettingsSelectRow,
+  SettingsSwitchRow,
+} from "./settings-agent-rows";
+import { SettingsGroup, SettingsRow } from "./settings-layout";
+import {
+  type ConfiguredValue,
+  type ModelConfigChatGroup,
+  type ModelConfigCodingGroup,
+  type ModelConfigurationState,
+  type ModelGroupSaveState,
+  useModelConfiguration,
+} from "./useModelConfiguration";
+
+type Translator = (key: string, vars?: Record<string, unknown>) => string;
+
+function sourceNote(
+  configured: ConfiguredValue | null,
+  currentModel: string,
+  t: Translator,
+): string | null {
+  if (!configured || configured.model !== currentModel) return null;
+  if (configured.source === "process.env") {
+    return t("modelconfig.sourceEnvironment", {
+      defaultValue: "Set by environment",
+    });
+  }
+  if (configured.source === "default") {
+    return t("modelconfig.sourceDefault", {
+      defaultValue: "Built-in default",
+    });
+  }
+  return null;
+}
+
+function joinNotes(...notes: Array<string | null | undefined>): string | null {
+  const parts = notes.filter((note): note is string => Boolean(note));
+  return parts.length > 0 ? parts.join(" · ") : null;
+}
+
+function modelOptionLabel(entry: {
+  display: string;
+  costHint?: string;
+  apiSupported?: boolean;
+}) {
+  const suffixes = [
+    ...(entry.costHint ? [entry.costHint] : []),
+    ...(entry.apiSupported === false ? ["not API-callable"] : []),
+  ];
+  if (suffixes.length === 0) return entry.display;
+  return (
+    <span>
+      {entry.display}{" "}
+      <span className="text-muted">— {suffixes.join(", ")}</span>
+    </span>
+  );
+}
+
+function SaveErrorNotice({
+  save,
+  t,
+}: {
+  save: ModelGroupSaveState;
+  t: Translator;
+}) {
+  if (save.phase !== "error") return null;
+  return (
+    <div role="alert" className="py-1.5 text-xs leading-relaxed text-warn">
+      <span>{save.message}</span>
+      {save.supported !== undefined && save.supported.length > 0 ? (
+        <span className="block text-muted">
+          {t("modelconfig.supportedValues", {
+            defaultValue: "Supported: {{values}}",
+            values: save.supported.join(", "),
+          })}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+function SaveStatus({
+  save,
+  restartCopy,
+  t,
+}: {
+  save: ModelGroupSaveState;
+  restartCopy: boolean;
+  t: Translator;
+}) {
+  if (save.phase === "saving") {
+    return (
+      <span
+        role="status"
+        className="inline-flex items-center gap-1.5 text-xs text-muted"
+      >
+        <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+        {t("modelconfig.saving", { defaultValue: "Saving…" })}
+      </span>
+    );
+  }
+  if (save.phase === "restarting") {
+    return (
+      <span
+        role="status"
+        className="inline-flex items-center gap-1.5 text-xs text-muted"
+      >
+        <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+        {t("modelconfig.restarting", { defaultValue: "Restarting agent…" })}
+      </span>
+    );
+  }
+  if (save.phase === "saved") {
+    return (
+      <span
+        role="status"
+        className="inline-flex flex-col items-end gap-0.5 text-xs text-ok"
+      >
+        <span className="inline-flex items-center gap-1.5">
+          <CheckCircle2 className="h-3.5 w-3.5" aria-hidden />
+          {restartCopy
+            ? t("modelconfig.savedRestarted", { defaultValue: "Saved" })
+            : t("modelconfig.savedNoRestart", {
+                defaultValue: "Saved — applies to the next coding task",
+              })}
+        </span>
+        {save.conflictKeys !== undefined && save.conflictKeys.length > 0 ? (
+          <span className="text-muted">
+            {t("modelconfig.conflictingServiceEnv", {
+              defaultValue:
+                "Service env also sets {{keys}} — a full service restart may override this value.",
+              keys: save.conflictKeys.join(", "),
+            })}
+          </span>
+        ) : null}
+      </span>
+    );
+  }
+  return null;
+}
+
+function ChatModelGroup({
+  group,
+  title,
+  description,
+  t,
+}: {
+  group: ModelConfigChatGroup;
+  title: string;
+  description: string;
+  t: Translator;
+}) {
+  const { target, save } = group;
+  const note = sourceNote(group.configured, group.model, t);
+  const busy = save.phase === "saving" || save.phase === "restarting";
+
+  return (
+    <SettingsGroup title={title} description={description} bare>
+      <SettingsSelectRow
+        agentId={`models-${target}-provider`}
+        label={t("modelconfig.provider", { defaultValue: "Provider" })}
+        value={group.provider}
+        onValueChange={group.setProvider}
+        options={group.providerOptions}
+        placeholder={t("modelconfig.chooseProvider", {
+          defaultValue: "Choose a provider",
+        })}
+        disabled={busy}
+        triggerClassName="w-full"
+      />
+      <SettingsSelectRow
+        agentId={`models-${target}-model`}
+        label={t("modelconfig.model", { defaultValue: "Model" })}
+        description={joinNotes(note, group.selectedEntry?.costHint)}
+        value={group.model}
+        onValueChange={group.setModel}
+        options={group.modelOptions.map((entry) => ({
+          value: entry.id,
+          label: modelOptionLabel(entry),
+        }))}
+        placeholder={t("modelconfig.chooseModel", {
+          defaultValue: "Choose a model",
+        })}
+        disabled={busy || group.modelOptions.length === 0}
+        triggerClassName="w-full"
+      />
+      {group.effortOptions.length > 0 ? (
+        <SettingsSelectRow
+          agentId={`models-${target}-effort`}
+          label={t("modelconfig.effort", {
+            defaultValue: "Reasoning effort",
+          })}
+          description={
+            group.sharedEffortKnob
+              ? t("modelconfig.sharedEffortNote", {
+                  defaultValue:
+                    "One shared knob (OPENAI_REASONING_EFFORT) — also applies to the other chat model on this provider family.",
+                })
+              : undefined
+          }
+          value={group.effort}
+          onValueChange={group.setEffort}
+          options={group.effortOptions.map((effort) => ({
+            value: effort,
+            label: effort,
+          }))}
+          placeholder={t("modelconfig.chooseEffort", {
+            defaultValue: "Choose an effort",
+          })}
+          disabled={busy}
+          triggerClassName="w-full"
+        />
+      ) : null}
+      <SaveErrorNotice save={save} t={t} />
+      {save.phase === "confirm" ? (
+        <SettingsRow
+          label={t("modelconfig.restartConfirmTitle", {
+            defaultValue: "Restart to apply?",
+          })}
+          description={t("modelconfig.restartConfirmBody", {
+            defaultValue:
+              "Saving this change restarts the agent. Anything in progress is interrupted.",
+          })}
+          control={
+            <span className="flex items-center gap-2">
+              <SettingsActionButton
+                agentId={`models-${target}-cancel`}
+                type="button"
+                variant="outline"
+                className="h-9 rounded-md px-3 text-xs font-medium"
+                onClick={group.cancelSave}
+              >
+                {t("modelconfig.cancel", { defaultValue: "Cancel" })}
+              </SettingsActionButton>
+              <SettingsActionButton
+                agentId={`models-${target}-confirm-restart`}
+                type="button"
+                variant="default"
+                className="h-9 rounded-md px-3 text-xs font-medium"
+                onClick={group.confirmSave}
+              >
+                {t("modelconfig.confirmRestart", {
+                  defaultValue: "Restart & apply",
+                })}
+              </SettingsActionButton>
+            </span>
+          }
+        />
+      ) : (
+        <SettingsRow
+          label={t("modelconfig.applyChanges", {
+            defaultValue: "Apply changes",
+          })}
+          description={t("modelconfig.chatSaveNote", {
+            defaultValue: "Saving restarts the agent.",
+          })}
+          control={
+            <span className="flex items-center gap-2">
+              <SaveStatus save={save} restartCopy t={t} />
+              {!busy && save.phase !== "saved" ? (
+                <SettingsActionButton
+                  agentId={`models-${target}-save`}
+                  type="button"
+                  variant="outline"
+                  className="h-9 rounded-md px-3 text-xs font-medium"
+                  disabled={!group.model}
+                  onClick={group.requestSave}
+                >
+                  {t("modelconfig.save", { defaultValue: "Save" })}
+                </SettingsActionButton>
+              ) : null}
+            </span>
+          }
+        />
+      )}
+    </SettingsGroup>
+  );
+}
+
+function CodingModelGroup({
+  group,
+  t,
+}: {
+  group: ModelConfigCodingGroup;
+  t: Translator;
+}) {
+  const { save } = group;
+  const note = sourceNote(group.configured, group.model, t);
+  const busy = save.phase === "saving";
+
+  return (
+    <SettingsGroup
+      title={t("modelconfig.codingGroupTitle", {
+        defaultValue: "Coding sub-agent",
+      })}
+      description={t("modelconfig.codingGroupDescription", {
+        defaultValue:
+          "The model coding tasks are delegated to. Applies to the next coding task — no restart.",
+      })}
+      bare
+    >
+      <SettingsSegmentedRow
+        agentId="models-coding-backend"
+        label={t("modelconfig.codingBackend", { defaultValue: "Backend" })}
+        value={group.backend}
+        onValueChange={(value) => {
+          const option = group.backendOptions.find(
+            (candidate) => candidate.value === value,
+          );
+          if (option) group.setBackend(option.value);
+        }}
+        options={group.backendOptions.map((option) => ({
+          value: option.value,
+          label: option.label,
+        }))}
+        disabled={busy}
+      />
+      {group.freeFormModel ? (
+        <SettingsInputRow
+          agentId="models-coding-model"
+          label={t("modelconfig.model", { defaultValue: "Model" })}
+          description={joinNotes(
+            note,
+            t("modelconfig.freeFormModelNote", {
+              defaultValue:
+                "Free-form model id — the in-house backend has no fixed catalog.",
+            }),
+          )}
+          value={group.model}
+          onValueChange={group.setModel}
+          placeholder={t("modelconfig.freeFormModelPlaceholder", {
+            defaultValue: "Model id",
+          })}
+          disabled={busy}
+        />
+      ) : (
+        <SettingsSelectRow
+          agentId="models-coding-model"
+          label={t("modelconfig.model", { defaultValue: "Model" })}
+          description={joinNotes(note, group.selectedEntry?.costHint)}
+          value={group.model}
+          onValueChange={group.setModel}
+          options={group.modelOptions.map((entry) => ({
+            value: entry.id,
+            label: modelOptionLabel(entry),
+          }))}
+          placeholder={t("modelconfig.chooseModel", {
+            defaultValue: "Choose a model",
+          })}
+          disabled={busy || group.modelOptions.length === 0}
+          triggerClassName="w-full"
+        />
+      )}
+      {group.effortOptions.length > 0 ? (
+        <SettingsSelectRow
+          agentId="models-coding-effort"
+          label={t("modelconfig.effort", {
+            defaultValue: "Reasoning effort",
+          })}
+          description={group.selectedEntry?.costHint}
+          value={group.effort}
+          onValueChange={group.setEffort}
+          options={group.effortOptions.map((effort) => ({
+            value: effort,
+            label: effort,
+          }))}
+          placeholder={t("modelconfig.chooseEffort", {
+            defaultValue: "Choose an effort",
+          })}
+          disabled={busy}
+          triggerClassName="w-full"
+        />
+      ) : null}
+      <SettingsSwitchRow
+        agentId="models-coding-default"
+        label={t("modelconfig.defaultBackend", {
+          defaultValue: "Default coding backend",
+        })}
+        description={t("modelconfig.defaultBackendNote", {
+          defaultValue: "Use this backend for new coding tasks.",
+        })}
+        checked={group.makeDefault}
+        onCheckedChange={group.setMakeDefault}
+        disabled={busy}
+      />
+      <SaveErrorNotice save={save} t={t} />
+      <SettingsRow
+        label={t("modelconfig.applyChanges", {
+          defaultValue: "Apply changes",
+        })}
+        description={t("modelconfig.codingSaveNote", {
+          defaultValue: "Applies to the next coding task — no restart.",
+        })}
+        control={
+          <span className="flex items-center gap-2">
+            <SaveStatus save={save} restartCopy={false} t={t} />
+            {!busy && save.phase !== "saved" ? (
+              <SettingsActionButton
+                agentId="models-coding-save"
+                type="button"
+                variant="outline"
+                className="h-9 rounded-md px-3 text-xs font-medium"
+                disabled={!group.model.trim()}
+                onClick={group.saveNow}
+              >
+                {t("modelconfig.save", { defaultValue: "Save" })}
+              </SettingsActionButton>
+            ) : null}
+          </span>
+        }
+      />
+    </SettingsGroup>
+  );
+}
+
+export function ModelConfigurationPanelView({
+  state,
+  t,
+}: {
+  state: ModelConfigurationState;
+  t: Translator;
+}) {
+  if (state.phase === "loading") {
+    return (
+      <SettingsGroup
+        title={t("modelconfig.panelTitle", { defaultValue: "Models" })}
+        bare
+      >
+        <span
+          role="status"
+          className="inline-flex items-center gap-2 py-2 text-xs text-muted"
+          aria-label={t("modelconfig.loading", {
+            defaultValue: "Loading model catalog…",
+          })}
+        >
+          <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+          {t("modelconfig.loading", {
+            defaultValue: "Loading model catalog…",
+          })}
+        </span>
+      </SettingsGroup>
+    );
+  }
+  if (state.phase === "error") {
+    return (
+      <SettingsGroup
+        title={t("modelconfig.panelTitle", { defaultValue: "Models" })}
+        bare
+      >
+        <div role="alert" className="flex flex-col gap-2 py-2">
+          <span className="text-xs leading-relaxed text-warn">
+            {t("modelconfig.loadError", {
+              defaultValue: "Couldn't load the model catalog: {{message}}",
+              message: state.message,
+            })}
+          </span>
+          <SettingsActionButton
+            agentId="models-retry"
+            type="button"
+            variant="outline"
+            className="h-9 w-fit rounded-md px-3 text-xs font-medium"
+            onClick={state.retry}
+          >
+            {t("modelconfig.retry", { defaultValue: "Retry" })}
+          </SettingsActionButton>
+        </div>
+      </SettingsGroup>
+    );
+  }
+  if (state.phase === "empty") {
+    return (
+      <SettingsGroup
+        title={t("modelconfig.panelTitle", { defaultValue: "Models" })}
+        bare
+      >
+        <div className="flex flex-col gap-2 py-2">
+          <span className="text-xs leading-relaxed text-muted">
+            {t("modelconfig.emptyCatalog", {
+              defaultValue:
+                "No configurable models were reported by the runtime.",
+            })}
+          </span>
+          <SettingsActionButton
+            agentId="models-retry"
+            type="button"
+            variant="outline"
+            className="h-9 w-fit rounded-md px-3 text-xs font-medium"
+            onClick={state.retry}
+          >
+            {t("modelconfig.retry", { defaultValue: "Retry" })}
+          </SettingsActionButton>
+        </div>
+      </SettingsGroup>
+    );
+  }
+  return (
+    <>
+      <ChatModelGroup
+        group={state.small}
+        title={t("modelconfig.smallGroupTitle", {
+          defaultValue: "Small model",
+        })}
+        description={t("modelconfig.smallGroupDescription", {
+          defaultValue:
+            "Fast, cheap model for routing and lightweight replies.",
+        })}
+        t={t}
+      />
+      <ChatModelGroup
+        group={state.large}
+        title={t("modelconfig.largeGroupTitle", {
+          defaultValue: "Large model",
+        })}
+        description={t("modelconfig.largeGroupDescription", {
+          defaultValue: "Primary reasoning model for substantive replies.",
+        })}
+        t={t}
+      />
+      <CodingModelGroup group={state.coding} t={t} />
+    </>
+  );
+}
+
+export function ModelConfigurationPanel() {
+  const t = useAppSelector((s) => s.t);
+  const state = useModelConfiguration();
+  return <ModelConfigurationPanelView state={state} t={t} />;
+}

--- a/packages/ui/src/components/settings/ProviderSwitcher.tsx
+++ b/packages/ui/src/components/settings/ProviderSwitcher.tsx
@@ -19,6 +19,7 @@ import {
 import { useAppSelectorShallow } from "../../state";
 import { ProvidersList } from "../local-inference/ProvidersList";
 import { RoutingMatrix } from "../local-inference/RoutingMatrix";
+import { ModelConfigurationPanel } from "./ModelConfigurationPanel";
 import { ProviderCard } from "./ProviderCard";
 import {
   ApiKeyPanel,
@@ -298,6 +299,10 @@ export function ProviderSwitcher(props: ProviderSwitcherProps = {}) {
           ) : null}
         </SettingsGroup>
       ) : null}
+
+      {/* Per-role model configuration (small/large chat brains + coding
+          sub-agent), driven by the validated /api/models catalog. */}
+      <ModelConfigurationPanel />
 
       {/* Voice folds into this section for MVP (the standalone Voice tab is
           developer-only): speech is pinned to the bundled Kokoro TTS, so a

--- a/packages/ui/src/components/settings/useModelConfiguration.ts
+++ b/packages/ui/src/components/settings/useModelConfiguration.ts
@@ -1,0 +1,807 @@
+/**
+ * State + save logic for the per-role model configuration panel (Settings →
+ * Models & Providers): the small/large chat brains and the coding sub-agent.
+ *
+ * Loads the validated provider→model→efforts catalog (`GET /api/models`) and
+ * the effective config (`GET /api/models/config`) together, exposes one
+ * draft-state group per target, and persists each group through
+ * `POST /api/models/config`. Chat-target writes restart the agent server-side
+ * (RuntimeOperationManager), so the save flow arms an explicit confirm step
+ * first and then only *polls* runtime status until it is back — it must never
+ * call `restartAgent()` itself, which would double-restart. Coding-target
+ * writes are restart-free by contract (spawns re-read config env per spawn).
+ *
+ * Two wire quirks this hook owns so the view stays declarative: the in-house
+ * coding backend is spelled `eliza-code` on the wire (persisted as
+ * `ELIZA_DEFAULT_AGENT_TYPE=elizaos`), and codex efforts are clamped to the
+ * pinned codex-acp adapter's parseable set even though the catalog lists
+ * `max`/`ultra` for some models — offering those would be a guaranteed 400.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import { client } from "../../api";
+import type {
+  ModelCatalog,
+  ModelCatalogEntry,
+  ModelsConfigCodingBackend,
+  ModelsConfigEffectiveValue,
+  ModelsConfigResponse,
+  ModelsConfigSource,
+  ModelsConfigWriteRequest,
+} from "../../api/client-types-core";
+
+export type ChatTarget = "small" | "large";
+
+/** Chat providers the write route accepts, in prefill-resolution order. */
+const CHAT_PROVIDERS: ReadonlyArray<{ id: string; label: string }> = [
+  { id: "cerebras", label: "Cerebras" },
+  { id: "elizacloud", label: "Eliza Cloud" },
+  { id: "claude-chat", label: "Claude" },
+];
+
+/** Providers persisted through the shared OPENAI_* env-key family. */
+const OPENAI_FAMILY_PROVIDERS: ReadonlySet<string> = new Set([
+  "cerebras",
+  "elizacloud",
+]);
+
+export const CODING_BACKEND_OPTIONS: ReadonlyArray<{
+  value: ModelsConfigCodingBackend;
+  label: string;
+}> = [
+  { value: "codex", label: "Codex" },
+  { value: "claude", label: "Claude" },
+  { value: "opencode", label: "OpenCode" },
+  { value: "eliza-code", label: "elizaOS" },
+];
+
+// Mirrors CODEX_ACP_EFFORTS in packages/agent/src/api/model-config-routes.ts:
+// the pinned codex-acp adapter cannot parse max/ultra, so the route 400s them.
+// Widen together with the server set when the acp pin is bumped.
+const CODEX_PINNED_EFFORTS: ReadonlySet<string> = new Set([
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+]);
+
+const CODING_MODEL_KEYS: Record<ModelsConfigCodingBackend, string> = {
+  codex: "ELIZA_CODEX_MODEL_POWERFUL",
+  claude: "ELIZA_CLAUDE_MODEL_POWERFUL",
+  opencode: "ELIZA_OPENCODE_MODEL_POWERFUL",
+  "eliza-code": "ELIZA_ELIZAOS_MODEL_POWERFUL",
+};
+
+const CODING_EFFORT_KEYS: Partial<Record<ModelsConfigCodingBackend, string>> = {
+  codex: "ELIZA_CODEX_EFFORT",
+  claude: "ELIZA_CLAUDE_EFFORT",
+};
+
+const CODING_CATALOG_PROVIDERS: Partial<
+  Record<ModelsConfigCodingBackend, string>
+> = {
+  codex: "codex",
+  claude: "claude-coding",
+  opencode: "cerebras",
+};
+
+const SAVED_STATE_TTL_MS = 2500;
+const RESTART_POLL_INTERVAL_MS = 1000;
+const RESTART_MAX_WAIT_MS = 60_000;
+
+export interface ConfiguredValue {
+  model: string;
+  source: ModelsConfigSource;
+}
+
+export type ModelGroupSaveState =
+  | { phase: "idle" }
+  | { phase: "confirm" }
+  | { phase: "saving" }
+  | { phase: "restarting"; operationId?: string }
+  | { phase: "saved"; conflictKeys?: string[] }
+  | { phase: "error"; message: string; supported?: string[] };
+
+export interface ModelConfigChatGroup {
+  target: ChatTarget;
+  providerOptions: Array<{ value: string; label: string }>;
+  provider: string;
+  modelOptions: ModelCatalogEntry[];
+  model: string;
+  effortOptions: string[];
+  effort: string;
+  selectedEntry: ModelCatalogEntry | null;
+  configured: ConfiguredValue | null;
+  /** True when this target's effort persists via the shared OPENAI_REASONING_EFFORT knob. */
+  sharedEffortKnob: boolean;
+  save: ModelGroupSaveState;
+  setProvider: (provider: string) => void;
+  setModel: (model: string) => void;
+  setEffort: (effort: string) => void;
+  requestSave: () => void;
+  confirmSave: () => void;
+  cancelSave: () => void;
+}
+
+export interface ModelConfigCodingGroup {
+  backend: ModelsConfigCodingBackend;
+  backendOptions: ReadonlyArray<{
+    value: ModelsConfigCodingBackend;
+    label: string;
+  }>;
+  persistedDefaultBackend: ModelsConfigCodingBackend | null;
+  makeDefault: boolean;
+  /** eliza-code has no catalog slice; its model is a free-form string. */
+  freeFormModel: boolean;
+  modelOptions: ModelCatalogEntry[];
+  model: string;
+  effortOptions: string[];
+  effort: string;
+  selectedEntry: ModelCatalogEntry | null;
+  configured: ConfiguredValue | null;
+  save: ModelGroupSaveState;
+  setBackend: (backend: ModelsConfigCodingBackend) => void;
+  setModel: (model: string) => void;
+  setEffort: (effort: string) => void;
+  setMakeDefault: (makeDefault: boolean) => void;
+  saveNow: () => void;
+}
+
+export type ModelConfigurationState =
+  | { phase: "loading" }
+  | { phase: "error"; message: string; retry: () => void }
+  | { phase: "empty"; retry: () => void }
+  | {
+      phase: "ready";
+      small: ModelConfigChatGroup;
+      large: ModelConfigChatGroup;
+      coding: ModelConfigCodingGroup;
+    };
+
+interface ChatDraft {
+  provider: string;
+  model: string;
+  effort: string;
+  configured: ConfiguredValue | null;
+}
+
+interface CodingDraft {
+  model: string;
+  effort: string;
+  configured: ConfiguredValue | null;
+}
+
+interface ReadyData {
+  catalog: ModelCatalog;
+  config: ModelsConfigResponse;
+}
+
+type LoadState =
+  | { phase: "loading" }
+  | { phase: "error"; message: string }
+  | { phase: "ready"; data: ReadyData };
+
+function entriesForRole(
+  catalog: ModelCatalog,
+  provider: string,
+  role: "small" | "large" | "coding",
+): ModelCatalogEntry[] {
+  return (catalog.providers[provider] ?? []).filter((entry) =>
+    entry.roles.includes(role),
+  );
+}
+
+function effective(
+  config: ModelsConfigResponse,
+  target: keyof ModelsConfigResponse["targets"],
+  key: string,
+): ModelsConfigEffectiveValue | null {
+  return config.targets[target]?.[key] ?? null;
+}
+
+function chatModelKey(target: ChatTarget, family: "OPENAI" | "ANTHROPIC") {
+  return `${family}_${target.toUpperCase()}_MODEL`;
+}
+
+function chatEffortKey(target: ChatTarget, provider: string) {
+  return OPENAI_FAMILY_PROVIDERS.has(provider)
+    ? "OPENAI_REASONING_EFFORT"
+    : `ANTHROPIC_EFFORT_${target.toUpperCase()}`;
+}
+
+/**
+ * Resolve the chat group prefill from the effective config: match the
+ * persisted model id against the catalog (OPENAI-family value against
+ * cerebras then elizacloud — both persist through the same keys — then the
+ * ANTHROPIC value against claude-chat). An unmatched or absent value keeps
+ * the provider guess but leaves the model unselected so the UI never claims
+ * a configuration the catalog cannot confirm.
+ */
+function resolveChatDraft(
+  target: ChatTarget,
+  catalog: ModelCatalog,
+  config: ModelsConfigResponse,
+): ChatDraft {
+  const openaiModel = effective(config, target, chatModelKey(target, "OPENAI"));
+  const anthropicModel = effective(
+    config,
+    target,
+    chatModelKey(target, "ANTHROPIC"),
+  );
+
+  const candidates: Array<{
+    provider: string;
+    value: ModelsConfigEffectiveValue | null;
+  }> = [
+    { provider: "cerebras", value: openaiModel },
+    { provider: "elizacloud", value: openaiModel },
+    { provider: "claude-chat", value: anthropicModel },
+  ];
+  for (const candidate of candidates) {
+    if (!candidate.value) continue;
+    const entry = entriesForRole(catalog, candidate.provider, target).find(
+      (item) => item.id === candidate.value?.value,
+    );
+    if (!entry) continue;
+    const effortValue = effective(
+      config,
+      target,
+      chatEffortKey(target, candidate.provider),
+    )?.value;
+    return {
+      provider: candidate.provider,
+      model: entry.id,
+      effort:
+        effortValue !== undefined && entry.efforts.includes(effortValue)
+          ? effortValue
+          : "",
+      configured: {
+        model: candidate.value.value,
+        source: candidate.value.source,
+      },
+    };
+  }
+
+  const fallbackProvider =
+    CHAT_PROVIDERS.find(
+      (choice) => entriesForRole(catalog, choice.id, target).length > 0,
+    )?.id ?? "";
+  const unmatched = anthropicModel ?? openaiModel;
+  return {
+    provider: unmatched
+      ? anthropicModel
+        ? "claude-chat"
+        : fallbackProvider
+      : fallbackProvider,
+    model: "",
+    effort: "",
+    configured: unmatched
+      ? { model: unmatched.value, source: unmatched.source }
+      : null,
+  };
+}
+
+function parsePersistedDefaultBackend(
+  config: ModelsConfigResponse,
+): ModelsConfigCodingBackend | null {
+  const raw = effective(config, "coding", "ELIZA_DEFAULT_AGENT_TYPE")?.value;
+  if (raw === undefined) return null;
+  if (raw === "elizaos") return "eliza-code";
+  return CODING_BACKEND_OPTIONS.some((option) => option.value === raw)
+    ? (raw as ModelsConfigCodingBackend)
+    : null;
+}
+
+function resolveCodingDraft(
+  backend: ModelsConfigCodingBackend,
+  catalog: ModelCatalog,
+  config: ModelsConfigResponse,
+): CodingDraft {
+  const configured = effective(config, "coding", CODING_MODEL_KEYS[backend]);
+  const effortKey = CODING_EFFORT_KEYS[backend];
+  const effortValue = effortKey
+    ? effective(config, "coding", effortKey)?.value
+    : undefined;
+  const model = configured?.value ?? "";
+  const entry = codingModelOptions(backend, catalog, model).find(
+    (item) => item.id === model,
+  );
+  const effortOptions = entry ? codingEffortOptions(backend, entry) : [];
+  return {
+    model,
+    effort:
+      effortValue !== undefined && effortOptions.includes(effortValue)
+        ? effortValue
+        : "",
+    configured: configured
+      ? { model: configured.value, source: configured.source }
+      : null,
+  };
+}
+
+function codingModelOptions(
+  backend: ModelsConfigCodingBackend,
+  catalog: ModelCatalog,
+  configuredModel: string,
+): ModelCatalogEntry[] {
+  const provider = CODING_CATALOG_PROVIDERS[backend];
+  if (!provider) return [];
+  // No role filter here: the write route validates coding models against the
+  // whole provider slice, and opencode's cerebras suggestion list carries
+  // small/large roles only.
+  const options = catalog.providers[provider] ?? [];
+  // opencode's catalog slice is a suggestion, not the write-route's truth
+  // (the server accepts any model string for it) — keep a configured value
+  // visible even when it is not in the suggested list.
+  if (
+    backend === "opencode" &&
+    configuredModel &&
+    !options.some((entry) => entry.id === configuredModel)
+  ) {
+    return [
+      {
+        id: configuredModel,
+        display: configuredModel,
+        efforts: [],
+        roles: ["coding"],
+      },
+      ...options,
+    ];
+  }
+  return options;
+}
+
+function codingEffortOptions(
+  backend: ModelsConfigCodingBackend,
+  entry: ModelCatalogEntry,
+): string[] {
+  if (backend === "codex") {
+    return entry.efforts.filter((effort) => CODEX_PINNED_EFFORTS.has(effort));
+  }
+  if (backend === "claude") return entry.efforts;
+  return [];
+}
+
+function catalogIsEmpty(catalog: ModelCatalog): boolean {
+  return Object.values(catalog.providers).every(
+    (entries) => entries.length === 0,
+  );
+}
+
+function failureMessage(err: unknown): string {
+  return err instanceof Error && err.message.trim()
+    ? err.message
+    : "Request failed";
+}
+
+export function useModelConfiguration(): ModelConfigurationState {
+  const [load, setLoad] = useState<LoadState>({ phase: "loading" });
+  const [chatDrafts, setChatDrafts] = useState<Record<ChatTarget, ChatDraft>>({
+    small: { provider: "", model: "", effort: "", configured: null },
+    large: { provider: "", model: "", effort: "", configured: null },
+  });
+  const [codingBackend, setCodingBackend] =
+    useState<ModelsConfigCodingBackend>("codex");
+  const [codingDrafts, setCodingDrafts] = useState<
+    Record<ModelsConfigCodingBackend, CodingDraft>
+  >({
+    codex: { model: "", effort: "", configured: null },
+    claude: { model: "", effort: "", configured: null },
+    opencode: { model: "", effort: "", configured: null },
+    "eliza-code": { model: "", effort: "", configured: null },
+  });
+  const [persistedDefaultBackend, setPersistedDefaultBackend] =
+    useState<ModelsConfigCodingBackend | null>(null);
+  const [makeDefault, setMakeDefault] = useState(false);
+  const [saveStates, setSaveStates] = useState<
+    Record<"small" | "large" | "coding", ModelGroupSaveState>
+  >({
+    small: { phase: "idle" },
+    large: { phase: "idle" },
+    coding: { phase: "idle" },
+  });
+
+  const disposedRef = useRef(false);
+  useEffect(
+    () => () => {
+      disposedRef.current = true;
+    },
+    [],
+  );
+  // The catalog the drafts were resolved against, for post-save re-resolution
+  // of `configured` markers without threading it through every callback.
+  const catalogRef = useRef<ModelCatalog | null>(null);
+
+  const setSaveState = useCallback(
+    (group: "small" | "large" | "coding", next: ModelGroupSaveState) => {
+      if (disposedRef.current) return;
+      setSaveStates((prev) => ({ ...prev, [group]: next }));
+    },
+    [],
+  );
+
+  const initializeDrafts = useCallback((data: ReadyData) => {
+    setChatDrafts({
+      small: resolveChatDraft("small", data.catalog, data.config),
+      large: resolveChatDraft("large", data.catalog, data.config),
+    });
+    const defaultBackend = parsePersistedDefaultBackend(data.config);
+    setPersistedDefaultBackend(defaultBackend);
+    setCodingBackend(defaultBackend ?? "codex");
+    setMakeDefault(defaultBackend !== null);
+    setCodingDrafts({
+      codex: resolveCodingDraft("codex", data.catalog, data.config),
+      claude: resolveCodingDraft("claude", data.catalog, data.config),
+      opencode: resolveCodingDraft("opencode", data.catalog, data.config),
+      "eliza-code": resolveCodingDraft("eliza-code", data.catalog, data.config),
+    });
+  }, []);
+
+  const loadAll = useCallback(async () => {
+    setLoad({ phase: "loading" });
+    try {
+      const [models, config] = await Promise.all([
+        client.getModelsCatalog(),
+        client.getModelsConfig(),
+      ]);
+      if (disposedRef.current) return;
+      const data: ReadyData = { catalog: models.catalog, config };
+      catalogRef.current = models.catalog;
+      initializeDrafts(data);
+      setLoad({ phase: "ready", data });
+    } catch (err) {
+      // error-policy:J4 catalog/config fetch failure renders the panel's
+      // designed error state (with retry) instead of a healthy-empty panel.
+      if (disposedRef.current) return;
+      setLoad({ phase: "error", message: failureMessage(err) });
+    }
+  }, [initializeDrafts]);
+
+  useEffect(() => {
+    void loadAll();
+  }, [loadAll]);
+
+  /**
+   * Refresh the effective config after a successful write so source notes and
+   * the persisted default backend reflect what the server actually stored.
+   * Deliberately leaves the user's draft selections alone — only the
+   * `configured` markers are re-resolved.
+   */
+  const refreshConfig = useCallback(async () => {
+    const config = await client.getModelsConfig();
+    if (disposedRef.current) return;
+    setLoad((prev) =>
+      prev.phase === "ready"
+        ? { phase: "ready", data: { ...prev.data, config } }
+        : prev,
+    );
+    setPersistedDefaultBackend(parsePersistedDefaultBackend(config));
+    const catalog = catalogRef.current;
+    if (!catalog) return;
+    setChatDrafts((prev) => ({
+      small: {
+        ...prev.small,
+        configured: resolveChatDraft("small", catalog, config).configured,
+      },
+      large: {
+        ...prev.large,
+        configured: resolveChatDraft("large", catalog, config).configured,
+      },
+    }));
+    setCodingDrafts((prev) => ({
+      codex: {
+        ...prev.codex,
+        configured: resolveCodingDraft("codex", catalog, config).configured,
+      },
+      claude: {
+        ...prev.claude,
+        configured: resolveCodingDraft("claude", catalog, config).configured,
+      },
+      opencode: {
+        ...prev.opencode,
+        configured: resolveCodingDraft("opencode", catalog, config).configured,
+      },
+      "eliza-code": {
+        ...prev["eliza-code"],
+        configured: resolveCodingDraft("eliza-code", catalog, config)
+          .configured,
+      },
+    }));
+  }, []);
+
+  const waitForRuntimeRunning = useCallback(async () => {
+    const startedAt = Date.now();
+    for (;;) {
+      if (disposedRef.current) return;
+      try {
+        const status = await client.getStatus();
+        if (status.state === "running") return;
+      } catch {
+        // error-policy:J4 status is expected to fail while the agent is down
+        // mid-restart; the poll loop itself is the designed degrade.
+      }
+      if (Date.now() - startedAt >= RESTART_MAX_WAIT_MS) return;
+      await new Promise((resolve) =>
+        setTimeout(resolve, RESTART_POLL_INTERVAL_MS),
+      );
+    }
+  }, []);
+
+  const scheduleIdle = useCallback((group: "small" | "large" | "coding") => {
+    setTimeout(() => {
+      if (disposedRef.current) return;
+      setSaveStates((prev) =>
+        prev[group].phase === "saved"
+          ? { ...prev, [group]: { phase: "idle" } }
+          : prev,
+      );
+    }, SAVED_STATE_TTL_MS);
+  }, []);
+
+  const performSave = useCallback(
+    async (
+      group: "small" | "large" | "coding",
+      request: ModelsConfigWriteRequest,
+    ) => {
+      setSaveState(group, { phase: "saving" });
+      try {
+        const result = await client.updateModelsConfig(request);
+        if (disposedRef.current) return;
+        if (result.kind === "invalid") {
+          setSaveState(group, {
+            phase: "error",
+            message: result.error,
+            ...(result.supported !== undefined
+              ? { supported: result.supported }
+              : {}),
+          });
+          return;
+        }
+        if (result.kind === "busy") {
+          setSaveState(group, {
+            phase: "error",
+            message: `${result.error} (operation ${result.activeOperationId})`,
+          });
+          return;
+        }
+        if (result.restart) {
+          setSaveState(group, {
+            phase: "restarting",
+            ...(result.operationId !== undefined
+              ? { operationId: result.operationId }
+              : {}),
+          });
+          await waitForRuntimeRunning();
+          if (disposedRef.current) return;
+        }
+        await refreshConfig().catch(() => {
+          // error-policy:J4 the write itself succeeded; a failed source-note
+          // refresh must not repaint a successful save as an error.
+        });
+        if (disposedRef.current) return;
+        setSaveState(group, {
+          phase: "saved",
+          ...(result.conflictingServiceEnvKeys !== undefined
+            ? { conflictKeys: result.conflictingServiceEnvKeys }
+            : {}),
+        });
+        scheduleIdle(group);
+      } catch (err) {
+        // error-policy:J4 transport/server failure renders the group's
+        // designed inline error state; nothing is swallowed.
+        if (disposedRef.current) return;
+        setSaveState(group, { phase: "error", message: failureMessage(err) });
+      }
+    },
+    [refreshConfig, scheduleIdle, setSaveState, waitForRuntimeRunning],
+  );
+
+  const buildChatGroup = useCallback(
+    (target: ChatTarget, data: ReadyData): ModelConfigChatGroup => {
+      const draft = chatDrafts[target];
+      const providerOptions = CHAT_PROVIDERS.filter(
+        (choice) => entriesForRole(data.catalog, choice.id, target).length > 0,
+      ).map((choice) => ({ value: choice.id, label: choice.label }));
+      const modelOptions = draft.provider
+        ? entriesForRole(data.catalog, draft.provider, target)
+        : [];
+      const selectedEntry =
+        modelOptions.find((entry) => entry.id === draft.model) ?? null;
+      const effortOptions = selectedEntry ? selectedEntry.efforts : [];
+      const save = saveStates[target];
+
+      const setProvider = (provider: string) => {
+        setChatDrafts((prev) => ({
+          ...prev,
+          [target]: { ...prev[target], provider, model: "", effort: "" },
+        }));
+        setSaveState(target, { phase: "idle" });
+      };
+      const setModel = (model: string) => {
+        setChatDrafts((prev) => {
+          const entry = entriesForRole(
+            data.catalog,
+            prev[target].provider,
+            target,
+          ).find((item) => item.id === model);
+          const keepEffort =
+            entry?.efforts.includes(prev[target].effort) ?? false;
+          return {
+            ...prev,
+            [target]: {
+              ...prev[target],
+              model,
+              effort: keepEffort
+                ? prev[target].effort
+                : (entry?.defaultEffort ?? ""),
+            },
+          };
+        });
+        setSaveState(target, { phase: "idle" });
+      };
+      const setEffort = (effort: string) => {
+        setChatDrafts((prev) => ({
+          ...prev,
+          [target]: { ...prev[target], effort },
+        }));
+        setSaveState(target, { phase: "idle" });
+      };
+      const requestSave = () => {
+        if (!draft.model) return;
+        if (save.phase === "saving" || save.phase === "restarting") return;
+        setSaveState(target, { phase: "confirm" });
+      };
+      const confirmSave = () => {
+        if (save.phase !== "confirm") return;
+        void performSave(target, {
+          target,
+          provider: draft.provider,
+          model: draft.model,
+          ...(draft.effort ? { effort: draft.effort } : {}),
+        });
+      };
+      const cancelSave = () => {
+        if (save.phase !== "confirm") return;
+        setSaveState(target, { phase: "idle" });
+      };
+
+      return {
+        target,
+        providerOptions,
+        provider: draft.provider,
+        modelOptions,
+        model: draft.model,
+        effortOptions,
+        effort: draft.effort,
+        selectedEntry,
+        configured: draft.configured,
+        sharedEffortKnob: OPENAI_FAMILY_PROVIDERS.has(draft.provider),
+        save,
+        setProvider,
+        setModel,
+        setEffort,
+        requestSave,
+        confirmSave,
+        cancelSave,
+      };
+    },
+    [chatDrafts, performSave, saveStates, setSaveState],
+  );
+
+  const buildCodingGroup = useCallback(
+    (data: ReadyData): ModelConfigCodingGroup => {
+      const draft = codingDrafts[codingBackend];
+      const freeFormModel = codingBackend === "eliza-code";
+      const modelOptions = codingModelOptions(
+        codingBackend,
+        data.catalog,
+        draft.configured?.model ?? "",
+      );
+      const selectedEntry =
+        modelOptions.find((entry) => entry.id === draft.model) ?? null;
+      const effortOptions = selectedEntry
+        ? codingEffortOptions(codingBackend, selectedEntry)
+        : [];
+      const save = saveStates.coding;
+
+      const setBackend = (backend: ModelsConfigCodingBackend) => {
+        setCodingBackend(backend);
+        setMakeDefault(backend === persistedDefaultBackend);
+        setSaveState("coding", { phase: "idle" });
+      };
+      const setModel = (model: string) => {
+        setCodingDrafts((prev) => {
+          const entry = codingModelOptions(
+            codingBackend,
+            data.catalog,
+            prev[codingBackend].configured?.model ?? "",
+          ).find((item) => item.id === model);
+          const nextEfforts = entry
+            ? codingEffortOptions(codingBackend, entry)
+            : [];
+          const keepEffort = nextEfforts.includes(prev[codingBackend].effort);
+          const defaultEffort =
+            entry?.defaultEffort !== undefined &&
+            nextEfforts.includes(entry.defaultEffort)
+              ? entry.defaultEffort
+              : "";
+          return {
+            ...prev,
+            [codingBackend]: {
+              ...prev[codingBackend],
+              model,
+              effort: keepEffort ? prev[codingBackend].effort : defaultEffort,
+            },
+          };
+        });
+        setSaveState("coding", { phase: "idle" });
+      };
+      const setEffort = (effort: string) => {
+        setCodingDrafts((prev) => ({
+          ...prev,
+          [codingBackend]: { ...prev[codingBackend], effort },
+        }));
+        setSaveState("coding", { phase: "idle" });
+      };
+      const saveNow = () => {
+        if (!draft.model.trim()) return;
+        if (save.phase === "saving" || save.phase === "restarting") return;
+        void performSave("coding", {
+          target: "coding",
+          backend: codingBackend,
+          model: draft.model.trim(),
+          ...(draft.effort && CODING_EFFORT_KEYS[codingBackend]
+            ? { effort: draft.effort }
+            : {}),
+          ...(makeDefault ? { defaultBackend: codingBackend } : {}),
+        });
+      };
+
+      return {
+        backend: codingBackend,
+        backendOptions: CODING_BACKEND_OPTIONS,
+        persistedDefaultBackend,
+        makeDefault,
+        freeFormModel,
+        modelOptions,
+        model: draft.model,
+        effortOptions,
+        effort: draft.effort,
+        selectedEntry,
+        configured: draft.configured,
+        save,
+        setBackend,
+        setModel,
+        setEffort,
+        setMakeDefault,
+        saveNow,
+      };
+    },
+    [
+      codingBackend,
+      codingDrafts,
+      makeDefault,
+      performSave,
+      persistedDefaultBackend,
+      saveStates.coding,
+      setSaveState,
+    ],
+  );
+
+  if (load.phase === "loading") return { phase: "loading" };
+  if (load.phase === "error") {
+    return {
+      phase: "error",
+      message: load.message,
+      retry: () => void loadAll(),
+    };
+  }
+  if (catalogIsEmpty(load.data.catalog)) {
+    return { phase: "empty", retry: () => void loadAll() };
+  }
+  return {
+    phase: "ready",
+    small: buildChatGroup("small", load.data),
+    large: buildChatGroup("large", load.data),
+    coding: buildCodingGroup(load.data),
+  };
+}

--- a/packages/ui/src/components/settings/useModelConfiguration.ts
+++ b/packages/ui/src/components/settings/useModelConfiguration.ts
@@ -367,6 +367,45 @@ function catalogIsEmpty(catalog: ModelCatalog): boolean {
   );
 }
 
+/**
+ * Boundary guards for the two GET responses. The typed client casts JSON
+ * blindly, and a runtime predating the model-config API (or a test stub)
+ * answers with a shapeless body — that must surface as the panel's designed
+ * error state with a readable message, not a TypeError from deep inside
+ * draft resolution.
+ */
+function parseCatalogResponse(response: unknown): ModelCatalog {
+  if (response && typeof response === "object") {
+    const catalog = (response as { catalog?: unknown }).catalog;
+    if (catalog && typeof catalog === "object") {
+      const providers = (catalog as { providers?: unknown }).providers;
+      if (
+        providers &&
+        typeof providers === "object" &&
+        !Array.isArray(providers) &&
+        Object.values(providers).every((entries) => Array.isArray(entries))
+      ) {
+        return catalog as ModelCatalog;
+      }
+    }
+  }
+  throw new Error(
+    "the runtime did not return a model catalog (/api/models) — it may predate the model configuration API",
+  );
+}
+
+function parseConfigResponse(response: unknown): ModelsConfigResponse {
+  if (response && typeof response === "object") {
+    const targets = (response as { targets?: unknown }).targets;
+    if (targets && typeof targets === "object" && !Array.isArray(targets)) {
+      return response as ModelsConfigResponse;
+    }
+  }
+  throw new Error(
+    "the runtime did not return a model configuration (/api/models/config) — it may predate the model configuration API",
+  );
+}
+
 function failureMessage(err: unknown): string {
   return err instanceof Error && err.message.trim()
     ? err.message
@@ -439,13 +478,16 @@ export function useModelConfiguration(): ModelConfigurationState {
   const loadAll = useCallback(async () => {
     setLoad({ phase: "loading" });
     try {
-      const [models, config] = await Promise.all([
+      const [modelsResponse, configResponse] = await Promise.all([
         client.getModelsCatalog(),
         client.getModelsConfig(),
       ]);
       if (disposedRef.current) return;
-      const data: ReadyData = { catalog: models.catalog, config };
-      catalogRef.current = models.catalog;
+      const data: ReadyData = {
+        catalog: parseCatalogResponse(modelsResponse),
+        config: parseConfigResponse(configResponse),
+      };
+      catalogRef.current = data.catalog;
       initializeDrafts(data);
       setLoad({ phase: "ready", data });
     } catch (err) {
@@ -469,7 +511,7 @@ export function useModelConfiguration(): ModelConfigurationState {
   const refreshConfig = useCallback(async () => {
     let config: ModelsConfigResponse;
     try {
-      config = await client.getModelsConfig();
+      config = parseConfigResponse(await client.getModelsConfig());
     } catch {
       // error-policy:J4 the write itself already succeeded; a failed
       // source-note refresh must not repaint a successful save as an error.

--- a/packages/ui/src/components/settings/useModelConfiguration.ts
+++ b/packages/ui/src/components/settings/useModelConfiguration.ts
@@ -467,7 +467,15 @@ export function useModelConfiguration(): ModelConfigurationState {
    * `configured` markers are re-resolved.
    */
   const refreshConfig = useCallback(async () => {
-    const config = await client.getModelsConfig();
+    let config: ModelsConfigResponse;
+    try {
+      config = await client.getModelsConfig();
+    } catch {
+      // error-policy:J4 the write itself already succeeded; a failed
+      // source-note refresh must not repaint a successful save as an error.
+      // The markers simply stay as they were until the next full load.
+      return;
+    }
     if (disposedRef.current) return;
     setLoad((prev) =>
       prev.phase === "ready"
@@ -509,16 +517,21 @@ export function useModelConfiguration(): ModelConfigurationState {
   }, []);
 
   const waitForRuntimeRunning = useCallback(async () => {
+    const isRunning = async (): Promise<boolean> => {
+      try {
+        const status = await client.getStatus();
+        return status.state === "running";
+      } catch {
+        // error-policy:J4 status is expected to fail while the agent is down
+        // mid-restart; "unreachable" is the designed not-yet-running signal
+        // the poll loop keeps waiting on.
+        return false;
+      }
+    };
     const startedAt = Date.now();
     for (;;) {
       if (disposedRef.current) return;
-      try {
-        const status = await client.getStatus();
-        if (status.state === "running") return;
-      } catch {
-        // error-policy:J4 status is expected to fail while the agent is down
-        // mid-restart; the poll loop itself is the designed degrade.
-      }
+      if (await isRunning()) return;
       if (Date.now() - startedAt >= RESTART_MAX_WAIT_MS) return;
       await new Promise((resolve) =>
         setTimeout(resolve, RESTART_POLL_INTERVAL_MS),
@@ -573,10 +586,7 @@ export function useModelConfiguration(): ModelConfigurationState {
           await waitForRuntimeRunning();
           if (disposedRef.current) return;
         }
-        await refreshConfig().catch(() => {
-          // error-policy:J4 the write itself succeeded; a failed source-note
-          // refresh must not repaint a successful save as an error.
-        });
+        await refreshConfig();
         if (disposedRef.current) return;
         setSaveState(group, {
           phase: "saved",

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.slash.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.slash.test.tsx
@@ -129,6 +129,7 @@ function makeSlash(
     isAuthorized: true,
     isElevated: true,
     resolveChoices: () => [],
+    describeChoice: () => "",
     resolveSection: (t: string) =>
       ({ model: "ai-model", voice: "voice", connectors: "connectors" })[t],
     navigateTab: vi.fn(),

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.stories.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.stories.tsx
@@ -273,6 +273,7 @@ const SLASH_CONTROLLER: SlashCommandController = {
   isAuthorized: true,
   isElevated: true,
   resolveChoices: () => [],
+  describeChoice: () => "",
   resolveSection: (t: string) =>
     ({ model: "ai-model", voice: "voice", connectors: "connectors" })[t],
   navigateTab: () => {},

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -170,6 +170,7 @@ const EMPTY_SLASH_CONTROLLER: SlashCommandController = {
   isAuthorized: false,
   isElevated: false,
   resolveChoices: () => [],
+  describeChoice: () => "",
   resolveSection: () => undefined,
   navigateTab: () => {},
   navigateSettings: () => {},

--- a/packages/ui/src/components/shell/SlashCommandMenu.tsx
+++ b/packages/ui/src/components/shell/SlashCommandMenu.tsx
@@ -79,7 +79,13 @@ export function useSlashMenu(
     const arg = matched.args[argIndex];
     if (!arg) return null;
     const dynamic = arg.dynamicChoices
-      ? controller.resolveChoices(arg.dynamicChoices)
+      ? controller.resolveChoices(arg.dynamicChoices, {
+          commandKey: matched.key,
+          argIndex,
+          // The in-progress token (when not ending on a space) sits AT
+          // argIndex, so slicing to it yields only the committed tokens.
+          precedingTokens: parsed.argTokens.slice(0, argIndex),
+        })
       : [];
     const all = Array.from(new Set([...(arg.choices ?? []), ...dynamic]));
     if (all.length === 0) return null;
@@ -113,18 +119,20 @@ export function useSlashMenu(
       }));
     }
     if (mode === "arg" && argInfo) {
-      // The header already names the argument; choice rows stay clean (no
-      // repeated description on every row).
+      // The header already names the argument; the secondary is a per-choice
+      // display label (e.g. a model's display name) — never the arg
+      // description repeated on every row.
+      const source = argInfo.arg.dynamicChoices;
       return argInfo.choices.map((choice) => ({
         id: `arg:${choice}`,
         primary: choice,
-        secondary: "",
+        secondary: source ? controller.describeChoice(source, choice) : "",
         isCommand: false,
         hasArgs: false,
       }));
     }
     return [];
-  }, [mode, commandResults, argInfo]);
+  }, [mode, commandResults, argInfo, controller]);
 
   const [activeIndex, setActiveIndexState] = React.useState(0);
   // Reset the highlight whenever the visible set changes.

--- a/plugins/plugin-commands/__tests__/model-config-command.test.ts
+++ b/plugins/plugin-commands/__tests__/model-config-command.test.ts
@@ -1,0 +1,448 @@
+/**
+ * `/model small|large|coding|show` tests: token parsing, owner gating, the
+ * loopback POST/GET to /api/models/config through a stubbed fetch, verbatim
+ * 400/409 passthrough, and regression pins for the two pre-existing `/model`
+ * behaviors (local/cloud runtime switch, bare-name per-room preference).
+ */
+
+import type { IAgentRuntime, Memory } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveCommand } from "../src/actions";
+import { parseModelConfigArgs } from "../src/actions/model-config";
+import { initForRuntime } from "../src/registry";
+
+function makeRuntime(): IAgentRuntime {
+	const cache = new Map<string, unknown>();
+	return {
+		agentId: "agent-model-config",
+		character: { name: "Eliza", settings: {} },
+		actions: [],
+		getSetting: () => null,
+		getCache: async (key: string) => cache.get(key),
+		setCache: async (key: string, value: unknown) => {
+			cache.set(key, value);
+			return true;
+		},
+		deleteCache: async (key: string) => cache.delete(key),
+	} as unknown as IAgentRuntime;
+}
+
+function msg(text: string): Memory {
+	return {
+		id: "00000000-0000-0000-0000-000000000011",
+		entityId: "00000000-0000-0000-0000-0000000000ac",
+		roomId: "room-model-config",
+		content: { text, source: "client_chat" },
+	} as unknown as Memory;
+}
+
+const OWNER = { isAuthorized: true, isElevated: true };
+
+function parsedModel(rawArgs: string) {
+	return { key: "model", canonical: "/model", args: [], rawArgs };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+describe("parseModelConfigArgs", () => {
+	it("returns null for the pre-existing /model shapes (local/cloud, bare name, empty)", () => {
+		expect(parseModelConfigArgs(parsedModel("local"))).toBeNull();
+		expect(parseModelConfigArgs(parsedModel("cloud gemma-4-31b"))).toBeNull();
+		expect(parseModelConfigArgs(parsedModel("claude-opus"))).toBeNull();
+		expect(parseModelConfigArgs(parsedModel(""))).toBeNull();
+	});
+
+	it("parses show", () => {
+		expect(parseModelConfigArgs(parsedModel("show"))).toEqual({
+			kind: "show",
+		});
+		expect(parseModelConfigArgs(parsedModel("show extra"))).toMatchObject({
+			kind: "usage",
+		});
+	});
+
+	it("parses chat targets with optional provider and effort", () => {
+		expect(parseModelConfigArgs(parsedModel("small zai-glm-4.7"))).toEqual({
+			kind: "write",
+			body: { target: "small", model: "zai-glm-4.7" },
+		});
+		expect(
+			parseModelConfigArgs(parsedModel("large cerebras zai-glm-4.7 high")),
+		).toEqual({
+			kind: "write",
+			body: {
+				target: "large",
+				provider: "cerebras",
+				model: "zai-glm-4.7",
+				effort: "high",
+			},
+		});
+	});
+
+	it("splits a fused provider/model token only for a known chat provider", () => {
+		expect(
+			parseModelConfigArgs(parsedModel("large elizacloud/zai-glm-4.7")),
+		).toEqual({
+			kind: "write",
+			body: { target: "large", provider: "elizacloud", model: "zai-glm-4.7" },
+		});
+		// "openai" is not a chat provider — the slashed id stays a model id.
+		expect(
+			parseModelConfigArgs(parsedModel("large openai/gpt-oss-120b")),
+		).toEqual({
+			kind: "write",
+			body: { target: "large", model: "openai/gpt-oss-120b" },
+		});
+	});
+
+	it("parses coding targets and maps the elizaos alias to the API's eliza-code", () => {
+		expect(
+			parseModelConfigArgs(parsedModel("coding codex gpt-5.5 xhigh")),
+		).toEqual({
+			kind: "write",
+			body: {
+				target: "coding",
+				backend: "codex",
+				model: "gpt-5.5",
+				effort: "xhigh",
+			},
+		});
+		expect(parseModelConfigArgs(parsedModel("coding elizaos eliza-1"))).toEqual(
+			{
+				kind: "write",
+				body: { target: "coding", backend: "eliza-code", model: "eliza-1" },
+			},
+		);
+	});
+
+	it("returns usage errors for malformed config subcommands", () => {
+		expect(parseModelConfigArgs(parsedModel("small"))).toMatchObject({
+			kind: "usage",
+		});
+		expect(parseModelConfigArgs(parsedModel("coding"))).toMatchObject({
+			kind: "usage",
+		});
+		expect(
+			parseModelConfigArgs(parsedModel("coding gemini gpt")),
+		).toMatchObject({ kind: "usage" });
+		expect(parseModelConfigArgs(parsedModel("small a b c d"))).toMatchObject({
+			kind: "usage",
+		});
+		expect(
+			parseModelConfigArgs(parsedModel("coding codex gpt-5.5 high extra")),
+		).toMatchObject({ kind: "usage" });
+	});
+});
+
+describe("/model small|large|coding → POST /api/models/config", () => {
+	let runtime: IAgentRuntime;
+	beforeEach(() => {
+		initForRuntime("agent-model-config");
+		runtime = makeRuntime();
+	});
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("POSTs a chat write and narrates the restart", async () => {
+		const fetchMock = vi.fn(async () =>
+			jsonResponse({
+				applied: true,
+				restart: true,
+				operationId: "op-1",
+				keys: ["OPENAI_LARGE_MODEL"],
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const r = await resolveCommand(
+			runtime,
+			msg("/model large zai-glm-4.7"),
+			OWNER,
+		);
+		expect(r.handled).toBe(true);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(String(url)).toContain("/api/models/config");
+		expect((init as RequestInit).method).toBe("POST");
+		expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+			target: "large",
+			model: "zai-glm-4.7",
+		});
+		expect(r.reply).toContain("restarting the agent to apply");
+	});
+
+	it("POSTs provider + effort and surfaces the shared OPENAI_REASONING_EFFORT knob", async () => {
+		const fetchMock = vi.fn(async () =>
+			jsonResponse({
+				applied: true,
+				restart: true,
+				operationId: "op-2",
+				keys: ["OPENAI_SMALL_MODEL", "OPENAI_REASONING_EFFORT"],
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const r = await resolveCommand(
+			runtime,
+			msg("/model small cerebras gpt-oss-120b low"),
+			OWNER,
+		);
+		expect(
+			JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string),
+		).toEqual({
+			target: "small",
+			provider: "cerebras",
+			model: "gpt-oss-120b",
+			effort: "low",
+		});
+		expect(r.reply).toContain("restarting the agent to apply");
+		expect(r.reply).toContain(
+			"OPENAI_REASONING_EFFORT is shared by the small and large chat targets",
+		);
+	});
+
+	it("POSTs a coding write and narrates the restart-free apply", async () => {
+		const fetchMock = vi.fn(async () =>
+			jsonResponse({
+				applied: true,
+				restart: false,
+				keys: ["ELIZA_CODEX_MODEL_POWERFUL", "ELIZA_CODEX_EFFORT"],
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const r = await resolveCommand(
+			runtime,
+			msg("/model coding codex gpt-5.6-terra xhigh"),
+			OWNER,
+		);
+		expect(
+			JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string),
+		).toEqual({
+			target: "coding",
+			backend: "codex",
+			model: "gpt-5.6-terra",
+			effort: "xhigh",
+		});
+		expect(r.reply).toContain("no restart needed");
+		expect(r.reply).not.toContain("restarting the agent");
+	});
+
+	it("passes the route's 400 validation error through verbatim", async () => {
+		const error =
+			'Effort "ultra" is valid for gpt-5.6-terra but not parseable by the pinned codex-acp adapter (supported until the pin is bumped: low, medium, high, xhigh)';
+		const fetchMock = vi.fn(async () =>
+			jsonResponse({ error, code: "MODEL_CONFIG_INVALID", context: {} }, 400),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const r = await resolveCommand(
+			runtime,
+			msg("/model coding codex gpt-5.6-terra ultra"),
+			OWNER,
+		);
+		expect(r.handled).toBe(true);
+		expect(r.reply).toContain(error);
+	});
+
+	it("surfaces a 409 busy runtime operation", async () => {
+		const fetchMock = vi.fn(async () =>
+			jsonResponse(
+				{
+					error: "A runtime operation is already in progress",
+					activeOperationId: "op-busy",
+				},
+				409,
+			),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const r = await resolveCommand(
+			runtime,
+			msg("/model large zai-glm-4.7"),
+			OWNER,
+		);
+		expect(r.reply).toContain("already in progress");
+		expect(r.reply).toContain("op-busy");
+	});
+
+	it("warns when the write conflicts with service-environment keys", async () => {
+		const fetchMock = vi.fn(async () =>
+			jsonResponse({
+				applied: true,
+				restart: false,
+				keys: ["ELIZA_CLAUDE_MODEL_POWERFUL"],
+				conflictingServiceEnvKeys: ["ELIZA_CLAUDE_MODEL_POWERFUL"],
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const r = await resolveCommand(
+			runtime,
+			msg("/model coding claude claude-opus-4-8"),
+			OWNER,
+		);
+		expect(r.reply).toContain("ELIZA_CLAUDE_MODEL_POWERFUL");
+		expect(r.reply).toContain("service-environment");
+	});
+
+	it("refuses config writes without elevated permissions and never hits the route", async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+
+		// resolveCommand defaults are fail-closed (unauthorized, unelevated).
+		const r = await resolveCommand(runtime, msg("/model large zai-glm-4.7"));
+		expect(r.handled).toBe(true);
+		expect(r.reply).toBe("This command requires elevated permissions.");
+		expect(fetchMock).not.toHaveBeenCalled();
+
+		const authorizedOnly = await resolveCommand(
+			runtime,
+			msg("/model coding codex gpt-5.5"),
+			{ isAuthorized: true, isElevated: false },
+		);
+		expect(authorizedOnly.reply).toBe(
+			"This command requires elevated permissions.",
+		);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("gates usage errors of the config subcommands behind elevation too", async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+
+		const r = await resolveCommand(runtime, msg("/model small"));
+		expect(r.reply).toBe("This command requires elevated permissions.");
+
+		const usage = await resolveCommand(runtime, msg("/model small"), OWNER);
+		expect(usage.reply).toContain("Usage: /model small");
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+});
+
+describe("/model show → GET /api/models/config", () => {
+	let runtime: IAgentRuntime;
+	beforeEach(() => {
+		initForRuntime("agent-model-config");
+		runtime = makeRuntime();
+	});
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("formats the effective config with values, sources, and unset keys", async () => {
+		const fetchMock = vi.fn(async () =>
+			jsonResponse({
+				targets: {
+					small: {
+						OPENAI_SMALL_MODEL: { value: "gpt-oss-120b", source: "config.env" },
+						ANTHROPIC_SMALL_MODEL: null,
+					},
+					large: {
+						OPENAI_LARGE_MODEL: {
+							value: "zai-glm-4.7",
+							source: "process.env",
+						},
+					},
+					coding: {
+						ELIZA_CODEX_MODEL_POWERFUL: {
+							value: "gpt-5.6-terra",
+							source: "default",
+						},
+					},
+				},
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const r = await resolveCommand(runtime, msg("/model show"), {
+			isAuthorized: true,
+			isElevated: false,
+		});
+		expect(r.handled).toBe(true);
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(String(url)).toContain("/api/models/config");
+		expect((init as RequestInit).method).toBe("GET");
+		expect(r.reply).toContain("**small**");
+		expect(r.reply).toContain("OPENAI_SMALL_MODEL = gpt-oss-120b (config.env)");
+		expect(r.reply).toContain("ANTHROPIC_SMALL_MODEL unset");
+		expect(r.reply).toContain("OPENAI_LARGE_MODEL = zai-glm-4.7 (process.env)");
+		expect(r.reply).toContain(
+			"ELIZA_CODEX_MODEL_POWERFUL = gpt-5.6-terra (default)",
+		);
+	});
+
+	it("requires authorization and never hits the route when unauthorized", async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+
+		const r = await resolveCommand(runtime, msg("/model show"));
+		expect(r.reply).toBe("This command requires authorization.");
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("surfaces a route error", async () => {
+		const fetchMock = vi.fn(async () => jsonResponse({ error: "boom" }, 500));
+		vi.stubGlobal("fetch", fetchMock);
+
+		const r = await resolveCommand(runtime, msg("/model show"), OWNER);
+		expect(r.reply).toContain("boom");
+	});
+});
+
+describe("regression — pre-existing /model behaviors are untouched", () => {
+	let runtime: IAgentRuntime;
+	beforeEach(() => {
+		initForRuntime("agent-model-config");
+		runtime = makeRuntime();
+	});
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("/model local still hits the runtime-switch route, not the config route", async () => {
+		const fetchMock = vi.fn(async () =>
+			jsonResponse({
+				ok: true,
+				target: "local",
+				model: "eliza-1-4b",
+				displayName: "Eliza-1 4B",
+				status: "ready",
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const r = await resolveCommand(runtime, msg("/model local eliza-1-4b"));
+		expect(r.handled).toBe(true);
+		expect(String(fetchMock.mock.calls[0][0])).toContain(
+			"/api/runtime/model-switch",
+		);
+		expect(r.reply).toContain("Eliza-1 4B");
+	});
+
+	it("a bare /model <name> still sets the per-room preference without any route call", async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+
+		const r = await resolveCommand(runtime, msg("/model claude-opus"));
+		expect(r.handled).toBe(true);
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(r.reply).toMatch(/Model set to/);
+	});
+
+	it("a bare /model still reports the current per-room preference", async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+
+		const r = await resolveCommand(runtime, msg("/model"));
+		expect(r.handled).toBe(true);
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(r.reply).toMatch(/Model is/);
+	});
+});

--- a/plugins/plugin-commands/__tests__/model-config-command.test.ts
+++ b/plugins/plugin-commands/__tests__/model-config-command.test.ts
@@ -418,7 +418,11 @@ describe("regression — pre-existing /model behaviors are untouched", () => {
 		);
 		vi.stubGlobal("fetch", fetchMock);
 
-		const r = await resolveCommand(runtime, msg("/model local eliza-1-4b"));
+		const r = await resolveCommand(
+			runtime,
+			msg("/model local eliza-1-4b"),
+			OWNER,
+		);
 		expect(r.handled).toBe(true);
 		expect(String(fetchMock.mock.calls[0][0])).toContain(
 			"/api/runtime/model-switch",

--- a/plugins/plugin-commands/__tests__/model-switch-command.test.ts
+++ b/plugins/plugin-commands/__tests__/model-switch-command.test.ts
@@ -34,6 +34,10 @@ function msg(text: string): Memory {
 	} as unknown as Memory;
 }
 
+// The runtime switch mutates the global inference backend, so it is
+// owner-gated exactly like the /model config writes.
+const OWNER = { isAuthorized: true, isElevated: true };
+
 describe("parseModelSwitchArgs", () => {
 	it("parses local/cloud targets and an optional id", () => {
 		expect(
@@ -99,7 +103,7 @@ describe("/model local|cloud → shared runtime-switch route", () => {
 		);
 		vi.stubGlobal("fetch", fetchMock);
 
-		const r = await resolveCommand(runtime, msg("/model cloud"));
+		const r = await resolveCommand(runtime, msg("/model cloud"), OWNER);
 		expect(r.handled).toBe(true);
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 		const [url, init] = fetchMock.mock.calls[0];
@@ -127,7 +131,11 @@ describe("/model local|cloud → shared runtime-switch route", () => {
 		);
 		vi.stubGlobal("fetch", fetchMock);
 
-		const r = await resolveCommand(runtime, msg("/model local eliza-1-4b"));
+		const r = await resolveCommand(
+			runtime,
+			msg("/model local eliza-1-4b"),
+			OWNER,
+		);
 		expect(r.handled).toBe(true);
 		expect(
 			JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string),
@@ -145,9 +153,19 @@ describe("/model local|cloud → shared runtime-switch route", () => {
 		);
 		vi.stubGlobal("fetch", fetchMock);
 
-		const r = await resolveCommand(runtime, msg("/model local"));
+		const r = await resolveCommand(runtime, msg("/model local"), OWNER);
 		expect(r.handled).toBe(true);
 		expect(r.reply).toMatch(/no provider/);
+	});
+
+	it("refuses the runtime switch without elevated trust and never hits the route", async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+
+		const r = await resolveCommand(runtime, msg("/model cloud"));
+		expect(r.handled).toBe(true);
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(r.reply).toMatch(/elevated permissions/);
 	});
 
 	it("does NOT hit the route for a bare /model <name> (per-room preference)", async () => {

--- a/plugins/plugin-commands/src/actions/handlers.ts
+++ b/plugins/plugin-commands/src/actions/handlers.ts
@@ -34,6 +34,11 @@ import {
 	getCommandSettings,
 	setCommandSetting,
 } from "./command-settings";
+import {
+	parseModelConfigArgs,
+	runModelConfigShowViaRoute,
+	runModelConfigWriteViaRoute,
+} from "./model-config";
 
 /**
  * Commands whose effects are fully owned by this deterministic layer. Broader
@@ -363,6 +368,27 @@ export async function runCommand(
 		}
 
 		case "model": {
+			// `/model show|small|large|coding …` drives the validated global
+			// model-config route. `show` reads config so authorization suffices; the
+			// write subcommands mutate config.env for every room (and restart the
+			// agent for chat targets), so they are owner-only. Gated here per
+			// subcommand rather than via definition-level flags, which would also
+			// gate (and hide from the GUI menu) the pre-existing per-room and
+			// local/cloud behaviors below.
+			const configCommand = parseModelConfigArgs(parsed);
+			if (configCommand) {
+				if (configCommand.kind === "show") {
+					if (!context.isAuthorized) return authError();
+					return runModelConfigShowViaRoute();
+				}
+				if (!context.isElevated) {
+					return reply("This command requires elevated permissions.");
+				}
+				if (configCommand.kind === "usage") {
+					return reply(configCommand.error);
+				}
+				return runModelConfigWriteViaRoute(configCommand.body);
+			}
 			// `/model local|cloud [id]` is a runtime inference switch shared with
 			// the MODEL_SWITCH action; a bare model name stays a per-room setting.
 			const switchArgs = parseModelSwitchArgs(parsed);

--- a/plugins/plugin-commands/src/actions/handlers.ts
+++ b/plugins/plugin-commands/src/actions/handlers.ts
@@ -391,8 +391,13 @@ export async function runCommand(
 			}
 			// `/model local|cloud [id]` is a runtime inference switch shared with
 			// the MODEL_SWITCH action; a bare model name stays a per-room setting.
+			// The switch mutates the global inference backend — same blast radius
+			// as the config writes above, so it carries the same owner-only gate.
 			const switchArgs = parseModelSwitchArgs(parsed);
 			if (switchArgs) {
+				if (!context.isElevated) {
+					return reply("This command requires elevated permissions.");
+				}
 				return runModelSwitchViaRoute(switchArgs.target, switchArgs.model);
 			}
 			return setOptionCommand(runtime, roomId, parsed, OPTION_COMMANDS.model);

--- a/plugins/plugin-commands/src/actions/model-config.ts
+++ b/plugins/plugin-commands/src/actions/model-config.ts
@@ -1,0 +1,288 @@
+/**
+ * `/model small|large|coding|show` — the slash surface over the validated
+ * model-config API (`packages/agent/src/api/model-config-routes.ts`). The
+ * command handler never validates model/effort values itself: it parses the
+ * token shape, then drives the same loopback route every other client uses, so
+ * the catalog-backed 400s (which name the supported efforts) surface verbatim.
+ *
+ * Token grammar, chosen so it can never collide with the two pre-existing
+ * `/model` behaviors (`local|cloud [id]` runtime switch, bare-name per-room
+ * preference):
+ *   /model show
+ *   /model small|large [provider] <model> [effort]     provider ∈ chat providers,
+ *                                                      or fused as provider/model
+ *   /model coding <backend> <model> [effort]           backend ∈ coding backends
+ * Anything else returns null from the parser and falls through to the existing
+ * paths in handlers.ts.
+ */
+
+import { resolveServerOnlyPort } from "@elizaos/core";
+import type { CommandResult, ParsedCommand } from "../types";
+
+/** Chat providers accepted by POST /api/models/config for small/large. */
+const CHAT_PROVIDERS = ["cerebras", "elizacloud", "claude-chat"] as const;
+type ChatProvider = (typeof CHAT_PROVIDERS)[number];
+
+/** Coding backends accepted by POST /api/models/config for target "coding". */
+type CodingBackend = "codex" | "claude" | "opencode" | "eliza-code";
+
+// "elizaos" is the orchestrator's spelling of the in-house backend (and what
+// ELIZA_DEFAULT_AGENT_TYPE persists); the API literal is "eliza-code".
+const CODING_BACKEND_TOKENS: Record<string, CodingBackend> = {
+	codex: "codex",
+	claude: "claude",
+	opencode: "opencode",
+	"eliza-code": "eliza-code",
+	elizaos: "eliza-code",
+};
+
+export interface ModelConfigWriteBody {
+	target: "small" | "large" | "coding";
+	provider?: ChatProvider;
+	backend?: CodingBackend;
+	model: string;
+	effort?: string;
+}
+
+export type ModelConfigCommand =
+	| { kind: "show" }
+	| { kind: "write"; body: ModelConfigWriteBody }
+	| { kind: "usage"; error: string };
+
+function reply(text: string): CommandResult {
+	return { handled: true, reply: text, shouldContinue: false };
+}
+
+function isChatProvider(token: string): token is ChatProvider {
+	return (CHAT_PROVIDERS as readonly string[]).includes(token);
+}
+
+function chatUsage(target: "small" | "large"): string {
+	return `Usage: /model ${target} [provider] <model> [effort] — provider is one of ${CHAT_PROVIDERS.join(", ")} (needed only when the model is served by more than one).`;
+}
+
+const CODING_USAGE = `Usage: /model coding <backend> <model> [effort] — backend is one of ${Object.keys(CODING_BACKEND_TOKENS).join(", ")}.`;
+
+/**
+ * Parse a `/model` argument list into a model-config command. Returns null when
+ * the first token is not one of the config subcommands (`show`, `small`,
+ * `large`, `coding`), so the caller keeps the runtime-switch and per-room
+ * preference behaviors untouched.
+ */
+export function parseModelConfigArgs(
+	parsed: ParsedCommand,
+): ModelConfigCommand | null {
+	const tokens = (parsed.rawArgs?.trim() || parsed.args.join(" ").trim())
+		.split(/\s+/)
+		.filter(Boolean);
+	const first = tokens[0]?.toLowerCase();
+
+	if (first === "show") {
+		if (tokens.length > 1) {
+			return { kind: "usage", error: "Usage: /model show" };
+		}
+		return { kind: "show" };
+	}
+
+	if (first === "small" || first === "large") {
+		const rest = tokens.slice(1);
+		let provider: ChatProvider | undefined;
+		if (rest[0] && isChatProvider(rest[0].toLowerCase())) {
+			provider = rest.shift()?.toLowerCase() as ChatProvider;
+		}
+		let model = rest.shift();
+		if (model && provider === undefined) {
+			// Fused provider/model form ("cerebras/zai-glm-4.7") — split only when
+			// the prefix names a chat provider, so a slashed model id such as
+			// "openai/gpt-oss-120b" stays a model id.
+			const slash = model.indexOf("/");
+			const prefix = slash > 0 ? model.slice(0, slash).toLowerCase() : "";
+			if (isChatProvider(prefix)) {
+				provider = prefix;
+				model = model.slice(slash + 1);
+			}
+		}
+		if (!model) return { kind: "usage", error: chatUsage(first) };
+		const effort = rest.shift();
+		if (rest.length > 0) return { kind: "usage", error: chatUsage(first) };
+		return {
+			kind: "write",
+			body: {
+				target: first,
+				model,
+				...(provider ? { provider } : {}),
+				...(effort ? { effort } : {}),
+			},
+		};
+	}
+
+	if (first === "coding") {
+		const backendToken = tokens[1]?.toLowerCase();
+		if (!backendToken) return { kind: "usage", error: CODING_USAGE };
+		const backend = CODING_BACKEND_TOKENS[backendToken];
+		if (!backend) {
+			return {
+				kind: "usage",
+				error: `Unknown coding backend "${tokens[1]}". ${CODING_USAGE}`,
+			};
+		}
+		const model = tokens[2];
+		if (!model) return { kind: "usage", error: CODING_USAGE };
+		const effort = tokens[3];
+		if (tokens.length > 4) return { kind: "usage", error: CODING_USAGE };
+		return {
+			kind: "write",
+			body: {
+				target: "coding",
+				backend,
+				model,
+				...(effort ? { effort } : {}),
+			},
+		};
+	}
+
+	return null;
+}
+
+interface ModelConfigWriteResponse {
+	applied?: boolean;
+	restart?: boolean;
+	operationId?: string;
+	keys?: string[];
+	deduped?: boolean;
+	conflictingServiceEnvKeys?: string[];
+	error?: string;
+	activeOperationId?: string;
+}
+
+function describeWrite(body: ModelConfigWriteBody): string {
+	const effort = body.effort ? ` at ${body.effort} effort` : "";
+	if (body.target === "coding") {
+		return `Coding model for ${body.backend} set to ${body.model}${effort}`;
+	}
+	const provider = body.provider ? ` (${body.provider})` : "";
+	return `${body.target === "small" ? "Small" : "Large"} chat model set to ${body.model}${provider}${effort}`;
+}
+
+/**
+ * POST the validated model-config route with a parsed write. Success replies
+ * state whether a restart applies the change; a 400's message is passed through
+ * verbatim (the route's errors name the supported models/efforts/providers).
+ */
+export async function runModelConfigWriteViaRoute(
+	body: ModelConfigWriteBody,
+): Promise<CommandResult> {
+	const port = resolveServerOnlyPort(process.env);
+	let response: Response;
+	try {
+		response = await fetch(`http://127.0.0.1:${port}/api/models/config`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(body),
+			signal: AbortSignal.timeout(30_000),
+		});
+	} catch (err) {
+		return reply(
+			`Couldn't update the model config: ${err instanceof Error ? err.message : String(err)}.`,
+		);
+	}
+	// error-policy:J3 non-JSON/empty response body -> null; the caller reads
+	// response.ok / fields defensively, so an unparseable body is a handled shape.
+	const parsed = (await response
+		.json()
+		.catch(() => null)) as ModelConfigWriteResponse | null;
+	if (response.status === 409) {
+		const active = parsed?.activeOperationId
+			? ` (operation ${parsed.activeOperationId})`
+			: "";
+		return reply(
+			`Couldn't update the model config: a runtime operation is already in progress${active}. Try again once it finishes.`,
+		);
+	}
+	if (!response.ok || parsed?.applied !== true) {
+		return reply(
+			`Couldn't update the model config: ${
+				typeof parsed?.error === "string"
+					? parsed.error
+					: `route returned ${response.status}`
+			}`,
+		);
+	}
+
+	const lines = [
+		parsed.restart
+			? `${describeWrite(body)} — restarting the agent to apply.`
+			: `${describeWrite(body)} — applies to new coding sessions, no restart needed.`,
+	];
+	if (body.effort && parsed.keys?.includes("OPENAI_REASONING_EFFORT")) {
+		lines.push(
+			"Note: OPENAI_REASONING_EFFORT is shared by the small and large chat targets.",
+		);
+	}
+	if (parsed.conflictingServiceEnvKeys?.length) {
+		lines.push(
+			`Warning: ${parsed.conflictingServiceEnvKeys.join(", ")} also carried a service-environment value; a full service restart may restore it.`,
+		);
+	}
+	return reply(lines.join("\n"));
+}
+
+type EffectiveValue = {
+	value: string;
+	source: string;
+} | null;
+
+interface ModelConfigShowResponse {
+	targets?: Record<string, Record<string, EffectiveValue>>;
+	error?: string;
+}
+
+const SHOW_TARGET_ORDER = ["small", "large", "coding"] as const;
+
+/**
+ * GET the effective model config and format it as one reply: every key the
+ * config route owns, with the source that won (config.env / config.env.vars /
+ * process.env / default) or `unset`.
+ */
+export async function runModelConfigShowViaRoute(): Promise<CommandResult> {
+	const port = resolveServerOnlyPort(process.env);
+	let response: Response;
+	try {
+		response = await fetch(`http://127.0.0.1:${port}/api/models/config`, {
+			method: "GET",
+			signal: AbortSignal.timeout(30_000),
+		});
+	} catch (err) {
+		return reply(
+			`Couldn't read the model config: ${err instanceof Error ? err.message : String(err)}.`,
+		);
+	}
+	// error-policy:J3 non-JSON/empty response body -> null; handled as a route error.
+	const parsed = (await response
+		.json()
+		.catch(() => null)) as ModelConfigShowResponse | null;
+	if (!response.ok || !parsed?.targets) {
+		return reply(
+			`Couldn't read the model config: ${
+				typeof parsed?.error === "string"
+					? parsed.error
+					: `route returned ${response.status}`
+			}`,
+		);
+	}
+
+	const lines = ["Model configuration:"];
+	for (const target of SHOW_TARGET_ORDER) {
+		const keys = parsed.targets[target];
+		if (!keys) continue;
+		lines.push(`**${target}**`);
+		for (const [key, effective] of Object.entries(keys)) {
+			lines.push(
+				effective
+					? `  ${key} = ${effective.value} (${effective.source})`
+					: `  ${key} unset`,
+			);
+		}
+	}
+	return reply(lines.join("\n"));
+}

--- a/plugins/plugin-commands/src/registry.ts
+++ b/plugins/plugin-commands/src/registry.ts
@@ -166,8 +166,26 @@ export const DEFAULT_COMMANDS: ReadonlyArray<CommandDefinition> = [
 		acceptsArgs: true,
 		args: [
 			{
+				name: "target",
+				description:
+					"small, large, coding, show, local, cloud — or a model for this room",
+				choices: ["small", "large", "coding", "show", "local", "cloud"],
+				dynamicChoices: "models",
+			},
+			{
 				name: "model",
-				description: "provider/model or alias",
+				description:
+					"model id — for coding, the backend (codex, claude, opencode, elizaos)",
+				dynamicChoices: "models",
+			},
+			{
+				name: "effort",
+				description: "reasoning effort — for coding, the model id",
+				dynamicChoices: "models",
+			},
+			{
+				name: "coding-effort",
+				description: "reasoning effort (coding target)",
 				dynamicChoices: "models",
 			},
 		],


### PR DESCRIPTION
# Model configuration surfaces — Settings panel + /model subcommands (stage 2)

Builds the user surfaces on the stage-1 model-config API (#16164): a **Settings → Models & Providers panel** for the small / large / coding models with per-model effort dropdowns, and **`/model small|large|coding|show` slash subcommands** with catalog-backed completions. Plus two real bugs found by live-probing the result: an ungated global runtime switch, and document augmentation silently breaking every deterministic slash command in the GUI.

## What's in here

**Settings panel** (`packages/ui`, ai-model section):
- Three catalog-driven groups: Small / Large (provider → role-filtered model → per-model effort, prefilled from `GET /api/models/config` with source notes — "set by environment" etc., plus a shared-`OPENAI_REASONING_EFFORT` warning) and Coding sub-agent (codex/claude/opencode/eliza-code segmented backend, per-backend model list, codex efforts clamped to the pinned acp set, `costHint` + not-API-callable badges, default-backend switch).
- Chat saves arm an explicit **restart confirmation**, POST through a typed `updateModelsConfig` client verb (2xx/400/409 normalized into an applied/invalid/busy union), then poll status until running. Coding saves are restart-free ("applies to the next coding task").
- Typed 400s render inline with `context.supported`; 409 shows the active operation id; catalog load has distinct loading / designed-empty / error(+retry) states — a pre-stage-1 runtime yields a readable error, not a TypeError (visible in the settings-e2e screenshot below).
- All controls use the agent-addressable settings rows; `updateModelsConfig` registered in the view-action-ratchet registry.

**Slash commands** (`plugins/plugin-commands` + chat controller):
- `/model show` — current config with per-key source attribution (authorized).
- `/model small|large <model> [effort]`, `/model coding <backend> <model> [effort]` — validated writes through the same loopback route the panel uses; **owner-only**; chat writes announce the restart, coding writes say "no restart needed"; route 400s (incl. the codex-acp ultra/max pin gate) surface verbatim.
- Pre-existing `/model local|cloud` and bare per-room `/model <name>` behaviors preserved byte-identically (regression-pinned) — and `local|cloud` now carries the **same owner-only gate** (adversarial review found the global runtime switch had *no auth at all*; a connector guest could flip the inference backend).
- `dynamicChoices: "models"` in the chat composer no longer returns `[]` — completions come from the `/api/models` catalog, per-subcommand (chat providers' models vs coding backend models).

**Deterministic-command fix** (`packages/agent`) — found live, pre-existing:
- Document augmentation rewrote `message.content.text` into the contextual-documents envelope **before** the command action's `validate()` re-read it, so any slash command embedding-similar to stored docs (`/help`, `/model` on an agent with model docs) silently fell through to LLM improvisation. The pre-LLM gate matched the original text; validate saw the envelope. Command turns now skip augmentation before any retrieval work (they're instructions, not document questions). Live-proven: `/help`, `/model`, `/models` flipped from LLM-improvised to `Shortcut: cmd:*` deterministic replies.

## Evidence — live against the running agent

<details><summary>Deterministic slash battery (GUI chat route, before → after the augmentation fix)</summary>

```
BEFORE (thought field of the turn):
/help => LLM        /model show => LLM      /models => LLM      /whoami => Shortcut: cmd:whoami

AFTER:
/help       => Shortcut: cmd:help    (real command list)
/model show => Shortcut: cmd:model   ("Model configuration: **small** OPENAI_SMALL_MODEL = gemma-4-31b (config.env) ...")
/models     => Shortcut: cmd:models
/model      => Shortcut: cmd:model
```
</details>

<details><summary>Owner write + rejection through the slash path (live)</summary>

```
/model coding codex gpt-5.6-luna high
→ "Coding model for codex set to gpt-5.6-luna at high effort — applies to new coding sessions, no restart needed."
→ eliza.json: ELIZA_CODEX_MODEL_POWERFUL=gpt-5.6-luna, ELIZA_CODEX_EFFORT=high

/model coding codex gpt-5.6-terra xhigh   (restore)
→ persisted: gpt-5.6-terra xhigh

/model coding codex gpt-5.6-terra ultra
→ "Couldn't update the model config: Effort \"ultra\" is valid for gpt-5.6-terra but not parseable by the pinned codex-acp adapter (supported until the pin is bumped: low, medium, high, xhigh)"
```
</details>

<details><summary>Auth: fail-closed proven live</summary>

A non-owner (webhook user) sent `/model coding codex gpt-5.4 low` on Discord: the persisted config stayed untouched (`gpt-5.6-terra xhigh`). Note the message was *plain text* (webhooks cannot invoke native Discord slash commands); with a leading bot-mention the deterministic layer can't see the command and the planner **hallucinated a success reply** while the write path held — that planner-honesty gap + the mention-stripping gap are filed as a follow-up issue, they are not introduced here. The new `/model` subcommands also surface as real native Discord commands via the existing `catalog-commands` bridge (execute-time role gate applies).
</details>

**Settings e2e** (real-registry walkthrough, desktop+mobile): [ai-model section](https://github.com/elizaOS/eliza/releases/download/pr-evidence/stage2-ai-model-section.png) — shows the new Models group rendering its **designed error state** with Retry against a harness runtime that predates the API (three-state rule; not a silent empty). [Full walkthrough video (webm)](https://github.com/elizaOS/eliza/releases/download/pr-evidence/stage2-settings-walkthrough.webm). Populated-panel screenshot: N/A here — headless capture of the live authed dashboard wasn't reachable from this session; the panel's populated behavior is pinned by 16 component tests (choices filtered per model, POST payloads, 400 rendering, restart warning) and the live API proofs above; owner eyeball on the live dashboard is the remaining check.

## Tests
- `packages/ui`: settings + chat-controller + api targeted suites **83 files / 717 tests green**; typecheck ✓ (after #16168 fixed develop's cloud-shared duplicate identifier)
- `plugins/plugin-commands`: **108/108** (incl. new subcommand suite, auth gating both ways, local|cloud + per-room regression pins); typecheck ✓
- `packages/agent`: cross-seam integration of the slash handler against the real model-config route (5✓) + chat-augmentation **14/14** incl. the new never-rewrite-command-turns cases
- biome clean on all touched files
- Known develop-red (not this branch): `no-backdrop-blur-gate` fails on develop's own `ChatWidgetHarness.tsx` (#16151)

Two Fable worktree lanes + adversarial review (both verdicts: ship, zero blocking) + manual integration, live probing, and the two hardening fixes above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
