### PR TITLE
fix(ci): restore develop after voice and deterministic lane regressions

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -105,13 +105,9 @@ jobs:
             commands:
               - bun run --cwd packages/app-core test
               - bun run --cwd packages/elizaos test
-              # The tenant-db durable-placement-claimer suite is split out into
-              # its own bounded-retry step below (#15785): under Bun canary on
-              # Windows it intermittently trips a native `Illegal instruction`
-              # panic while driving PGlite (WASM). Ignore it in the whole-package
-              # run so that upstream-runtime flake cannot fail the shard; the rest
-              # of packages/cloud/shared still runs here unchanged.
-              - bun run --cwd packages/cloud/shared test --path-ignore-patterns "**/tenant-db-placement-claimer.test.ts"
+              # The package test runner owns the Windows-only tenant-db PGlite
+              # quarantine and bounded native-crash retry (#15785).
+              - bun run --cwd packages/cloud/shared test
           - lane: framework-packages
             commands:
               - bun run --cwd packages/scenario-runner test
@@ -209,32 +205,3 @@ jobs:
               exit $code
             }
           }
-
-      # #15785: The tenant-db durable-placement-claimer suite drives PGlite
-      # (WASM) and intermittently trips a native `Illegal instruction` panic
-      # under Bun canary on Windows. That is an upstream runtime flake, not a
-      # product regression (the test blob is byte-identical to a run that passed
-      # in 49ms hours earlier — do not bisect). It is ignored by the whole-package
-      # run above and re-run here in isolation with a small bounded retry so a
-      # single native panic is retried instead of failing the whole shard.
-      # Each attempt is logged; the suite still has to pass for the shard to pass.
-      - name: Retry-isolated tenant-db PGlite suite (Windows canary flake, #15785)
-        if: matrix.lane == 'app-and-cli'
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = "Continue"
-          $suite = "src/lib/services/tenant-db/tenant-db-placement-claimer.test.ts"
-          $maxAttempts = 3
-          for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
-            Write-Host "::group::tenant-db placement-claimer suite (attempt $attempt/$maxAttempts)"
-            bun run --cwd packages/cloud/shared test $suite
-            $code = $LASTEXITCODE
-            Write-Host "::endgroup::"
-            if ($code -eq 0) {
-              Write-Host "tenant-db placement-claimer suite passed on attempt $attempt/$maxAttempts."
-              exit 0
-            }
-            Write-Warning "tenant-db placement-claimer suite failed on attempt $attempt/$maxAttempts with exit code $code (Bun canary/PGlite native flake, #15785)."
-          }
-          Write-Error "tenant-db placement-claimer suite still failing after $maxAttempts attempts; not the expected transient flake."
-          exit 1

--- a/packages/agent/src/api/accounts-routes.ts
+++ b/packages/agent/src/api/accounts-routes.ts
@@ -76,7 +76,9 @@ const z = (zod as typeof zod & { z?: typeof zod }).z ?? zod;
 const execFileAsync = promisify(execFile);
 
 async function commandAvailable(command: string): Promise<boolean> {
-  for (const dir of (process.env.PATH ?? "").split(path.delimiter)) {
+  const executablePath = process.env.PATH;
+  if (!executablePath) return false;
+  for (const dir of executablePath.split(path.delimiter)) {
     if (!dir) continue;
     try {
       await access(path.join(dir, command));
@@ -107,10 +109,15 @@ async function ensureSubscriptionCli(
 }
 
 function requestUsesLocalRoot(req: RouteRequestContext["req"]): boolean {
+  const hostUrl =
+    typeof req.headers.host === "string" && req.headers.host.trim()
+      ? `http://${req.headers.host}`
+      : null;
   const raw =
     (typeof req.headers.origin === "string" && req.headers.origin) ||
     (typeof req.headers.referer === "string" && req.headers.referer) ||
-    `http://${req.headers.host ?? ""}`;
+    hostUrl;
+  if (!raw) return false;
   try {
     const host = new URL(raw).hostname;
     return host === "localhost" || host === "127.0.0.1" || host === "::1";

--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -444,6 +444,16 @@ function normalizeAndroidLocalDirectUserText(text: string): string {
 const ANDROID_LOCAL_HISTORY_LIMIT = 6;
 const ANDROID_LOCAL_HISTORY_TEXT_LIMIT = 700;
 
+function compareCreatedAtAscending(
+  left: { createdAt?: number },
+  right: { createdAt?: number },
+): number {
+  if (left.createdAt === right.createdAt) return 0;
+  if (left.createdAt === undefined) return -1;
+  if (right.createdAt === undefined) return 1;
+  return left.createdAt - right.createdAt;
+}
+
 async function buildAndroidLocalDirectChatPrompt(args: {
   runtime: AgentRuntime;
   message: ReturnType<typeof createMessageMemory>;
@@ -460,7 +470,7 @@ async function buildAndroidLocalDirectChatPrompt(args: {
     });
     history = recent
       .filter((memory) => memory.id !== args.message.id)
-      .sort((a, b) => (a.createdAt ?? 0) - (b.createdAt ?? 0))
+      .sort(compareCreatedAtAscending)
       .slice(-ANDROID_LOCAL_HISTORY_LIMIT)
       .flatMap((memory) => {
         const text = extractCompatTextContent(memory.content).trim();

--- a/packages/agent/src/api/commands-routes.real-server.test.ts
+++ b/packages/agent/src/api/commands-routes.real-server.test.ts
@@ -196,7 +196,7 @@ describe("GET /api/commands (real loopback server)", () => {
     expect(byKey.get("think")?.target.kind).toBe("agent");
   });
 
-  it("filters client-only commands off chat connectors but keeps navigation", async () => {
+  it("filters local client and navigation commands off chat connectors", async () => {
     const baseUrl = await startCommandsServer();
     const body = (await (
       await fetch(`${baseUrl}/api/commands?surface=discord`)
@@ -207,8 +207,8 @@ describe("GET /api/commands (real loopback server)", () => {
     // GUI-only client behaviors have no remote surface.
     expect(keys.has("clear")).toBe(false);
     expect(keys.has("fullscreen")).toBe(false);
-    // Navigation + agent commands remain available remotely.
-    expect(keys.has("settings")).toBe(true);
+    // In-app navigation is GUI-only; agent commands remain available remotely.
+    expect(keys.has("settings")).toBe(false);
     expect(keys.has("think")).toBe(true);
   });
 

--- a/packages/agent/src/api/commands-routes.test.ts
+++ b/packages/agent/src/api/commands-routes.test.ts
@@ -145,7 +145,7 @@ describe("handleCommandsRoutes", () => {
     expect(payload.surface).toBe("discord");
     const keys = new Set(payload.commands.map((c) => c.key));
     expect(keys.has("fullscreen")).toBe(false); // gui-only
-    expect(keys.has("settings")).toBe(true); // all-surface
+    expect(keys.has("settings")).toBe(false); // app navigation is GUI-only
   });
 
   it("ignores an invalid surface and serves the unscoped catalog", async () => {
@@ -192,13 +192,14 @@ describe("handleCommandsRoutes", () => {
       expect(keys.has("fullscreen")).toBe(true);
     });
 
-    it("excludes client-only commands on discord but keeps navigation", async () => {
+    it("excludes local client and navigation commands on discord", async () => {
       const payload = await fetchCatalog("?surface=discord");
       expect(payload.surface).toBe("discord");
       const keys = new Set(payload.commands.map((c) => c.key));
       expect(keys.has("clear")).toBe(false);
       expect(keys.has("fullscreen")).toBe(false);
-      expect(keys.has("settings")).toBe(true);
+      expect(keys.has("settings")).toBe(false);
+      expect(keys.has("think")).toBe(true);
     });
 
     it("excludes client-only commands on telegram too", async () => {
@@ -207,7 +208,8 @@ describe("handleCommandsRoutes", () => {
       const keys = new Set(payload.commands.map((c) => c.key));
       expect(keys.has("clear")).toBe(false);
       expect(keys.has("fullscreen")).toBe(false);
-      expect(keys.has("settings")).toBe(true);
+      expect(keys.has("settings")).toBe(false);
+      expect(keys.has("think")).toBe(true);
     });
   });
 

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -237,7 +237,8 @@ type BrowserWorkspaceTabKind = NonNullable<
 >;
 
 let agentSkillsApiPromise:
-  Promise<typeof import("@elizaos/plugin-agent-skills")> | undefined;
+  | Promise<typeof import("@elizaos/plugin-agent-skills")>
+  | undefined;
 function getAgentSkillsApi(): Promise<
   typeof import("@elizaos/plugin-agent-skills")
 > {
@@ -248,7 +249,8 @@ function getAgentSkillsApi(): Promise<
 }
 
 let appManagerApiPromise:
-  Promise<typeof import("@elizaos/plugin-app-manager")> | undefined;
+  | Promise<typeof import("@elizaos/plugin-app-manager")>
+  | undefined;
 function getAppManagerApi(): Promise<
   typeof import("@elizaos/plugin-app-manager")
 > {
@@ -259,7 +261,8 @@ function getAppManagerApi(): Promise<
 }
 
 let walletApiPromise:
-  Promise<typeof import("@elizaos/plugin-wallet")> | undefined;
+  | Promise<typeof import("@elizaos/plugin-wallet")>
+  | undefined;
 function getWalletApi(): Promise<typeof import("@elizaos/plugin-wallet")> {
   walletApiPromise ??= importOptionalPlugin<
     typeof import("@elizaos/plugin-wallet")
@@ -2110,9 +2113,13 @@ async function handleRequest(
       }
       return Boolean(
         localInferenceServerApi.handleLocalInferenceTtsRoute &&
-        (await localInferenceServerApi.handleLocalInferenceTtsRoute(req, res, {
-          current: state.runtime,
-        })),
+          (await localInferenceServerApi.handleLocalInferenceTtsRoute(
+            req,
+            res,
+            {
+              current: state.runtime,
+            },
+          )),
       );
     })())
   ) {
@@ -2608,8 +2615,9 @@ async function handleRequest(
       return;
     }
     try {
-      const { unloadPluginFromDirectory } =
-        await import("../runtime/load-plugin-from-directory.ts");
+      const { unloadPluginFromDirectory } = await import(
+        "../runtime/load-plugin-from-directory.ts"
+      );
       const result = await unloadPluginFromDirectory({
         runtime: state.runtime as Parameters<
           typeof unloadPluginFromDirectory
@@ -4398,8 +4406,9 @@ export async function startApiServer(opts?: {
 
         // Build destination registry — all configured destinations
         const _connectors = state.config.connectors ?? {};
-        const streaming = (state.config as Record<string, unknown>)
-          .streaming as Record<string, unknown> | undefined;
+        const streaming = (state.config as Record<string, unknown>).streaming as
+          | Record<string, unknown>
+          | undefined;
         const destinations = new Map<string, StreamRouteDestination>();
 
         try {
@@ -5276,7 +5285,8 @@ export async function startApiServer(opts?: {
           ? Object.fromEntries(Object.entries(dbAgent))
           : null;
       const saved = agentRecord?.character as
-        Record<string, unknown> | undefined;
+        | Record<string, unknown>
+        | undefined;
       if (!saved || typeof saved !== "object") return;
 
       const c = rt.character;

--- a/packages/agent/src/runtime/operations/repository.ts
+++ b/packages/agent/src/runtime/operations/repository.ts
@@ -95,7 +95,9 @@ async function readOperationFile(
   return parsed;
 }
 
-export class FilesystemRuntimeOperationRepository implements RuntimeOperationRepository {
+export class FilesystemRuntimeOperationRepository
+  implements RuntimeOperationRepository
+{
   private readonly dir: string;
   private readonly byId: Map<string, RuntimeOperation> = new Map();
   private readonly byIdempotencyKey: Map<string, string> = new Map();

--- a/packages/app-core/src/api/auth.ts
+++ b/packages/app-core/src/api/auth.ts
@@ -46,7 +46,8 @@ export {
 
 export interface CompatStateLike {
   current:
-    (EmbedSessionSecretRuntime & { adapter?: { db?: unknown } | null }) | null;
+    | (EmbedSessionSecretRuntime & { adapter?: { db?: unknown } | null })
+    | null;
 }
 
 /**

--- a/packages/app-core/src/services/account-pool.ts
+++ b/packages/app-core/src/services/account-pool.ts
@@ -29,15 +29,14 @@ import {
   getAccessToken as getAccountAccessToken,
   listProviderAccounts,
 } from "@elizaos/auth/credentials";
+import { fetchAnthropicOAuthProfile } from "@elizaos/auth/oauth-flow";
 import {
   ACCOUNT_CREDENTIAL_PROVIDER_IDS,
   DIRECT_ACCOUNT_PROVIDER_ENV,
   DIRECT_ACCOUNT_PROVIDER_IDS,
   type DirectAccountProvider,
   isSubscriptionProvider,
-  type SubscriptionProvider,
 } from "@elizaos/auth/types";
-import { fetchAnthropicOAuthProfile } from "@elizaos/auth/oauth-flow";
 import {
   type AnthropicAccountPoolBridge,
   logger,
@@ -726,8 +725,11 @@ function recordToLinked(
 function emailFromIdToken(idToken: string | undefined): string | undefined {
   if (!idToken) return undefined;
   try {
+    const segments = idToken.split(".");
+    const encodedPayload = segments.length === 3 ? segments[1] : undefined;
+    if (!encodedPayload) return undefined;
     const payload = JSON.parse(
-      Buffer.from(idToken.split(".")[1] ?? "", "base64url").toString("utf8"),
+      Buffer.from(encodedPayload, "base64url").toString("utf8"),
     ) as { email?: unknown };
     return typeof payload.email === "string" && payload.email.includes("@")
       ? payload.email

--- a/packages/app-core/src/services/claude-token-refresh.ts
+++ b/packages/app-core/src/services/claude-token-refresh.ts
@@ -68,7 +68,10 @@ export function resolveClaudeExpectedRunMs(
   if (!Number.isFinite(parsed) || parsed <= 0) {
     return DEFAULT_CLAUDE_EXPECTED_RUN_MS;
   }
-  return Math.min(Math.max(Math.floor(parsed), MIN_EXPECTED_RUN_MS), MAX_EXPECTED_RUN_MS);
+  return Math.min(
+    Math.max(Math.floor(parsed), MIN_EXPECTED_RUN_MS),
+    MAX_EXPECTED_RUN_MS,
+  );
 }
 
 /**
@@ -102,7 +105,7 @@ export function shouldProactivelyRefreshClaudeToken(args: {
 }
 
 export {
-  classifyAuthFailureReason,
   type CodingAuthFailureReason,
+  classifyAuthFailureReason,
   isTokenExpiryText,
 } from "@elizaos/auth/token-expiry";

--- a/packages/app-core/src/services/coding-account-bridge.ts
+++ b/packages/app-core/src/services/coding-account-bridge.ts
@@ -48,10 +48,6 @@ import {
   resolveStateDir,
   setCodingAgentSelectorBridge,
 } from "@elizaos/core";
-import {
-  claudeMinRemainingMs,
-  resolveClaudeExpectedRunMs,
-} from "./claude-token-refresh.js";
 import type { LinkedAccountProviderId } from "@elizaos/shared/contracts/service-routing";
 import {
   type AccountPool,
@@ -59,6 +55,10 @@ import {
   type Strategy,
   selectionForProvider,
 } from "./account-pool.js";
+import {
+  claudeMinRemainingMs,
+  resolveClaudeExpectedRunMs,
+} from "./claude-token-refresh.js";
 
 const VALID_CODING_STRATEGIES = new Set<Strategy>([
   "priority",

--- a/packages/app/test/core-view-interaction-coverage.test.ts
+++ b/packages/app/test/core-view-interaction-coverage.test.ts
@@ -106,9 +106,9 @@ const CORE_VIEW_INTERACTIONS: Readonly<Record<string, CoreViewInteraction>> = {
         proves:
           "Drives representative settings controls through real UI events and backend requests.",
         signals: [
-          "voice settings: the auto-learn toggle flips state",
+          "voice settings: the wake-word toggle flips state",
           "capabilities settings: the Wallet switch fires the real config write",
-          "backup & reset settings: Back Up opens its modal",
+          "backup settings: Back Up opens its modal",
         ],
       },
       {
@@ -179,7 +179,7 @@ const CORE_VIEW_INTERACTIONS: Readonly<Record<string, CoreViewInteraction>> = {
         spec: "packages/app/test/ui-smoke/transcript-realaudio.spec.ts",
         proves:
           "Runs the real-audio transcript browser path and verifies transcript UI output.",
-        signals: ["transcripts-view", "transcript", "real audio"],
+        signals: ["live-meeting-page", "transcript", "real audio"],
       },
       {
         spec: "packages/ui/src/components/transcripts/TranscriptsView.test.tsx",

--- a/packages/app/test/service-worker-cache-strategies.test.ts
+++ b/packages/app/test/service-worker-cache-strategies.test.ts
@@ -199,13 +199,18 @@ describe("service worker navigation preload", () => {
 
   it("purges unknown caches on activate but keeps known ones", async () => {
     const worker = loadServiceWorker({
-      preexistingCaches: ["stale-cache-v0", "elizaos-shell-v5"],
+      preexistingCaches: [
+        "stale-cache-v0",
+        "elizaos-shell-v5",
+        "elizaos-shell-v6",
+      ],
     });
     const event = makeActivateEvent();
     worker.dispatch("activate", event);
     await Promise.all(event._work);
     expect(worker.caches.has("stale-cache-v0")).toBe(false);
-    expect(worker.caches.has("elizaos-shell-v5")).toBe(true);
+    expect(worker.caches.has("elizaos-shell-v5")).toBe(false);
+    expect(worker.caches.has("elizaos-shell-v6")).toBe(true);
   });
 
   it("consumes the navigation preload response instead of issuing a second fetch", async () => {

--- a/packages/cloud/shared/src/lib/cache/redis-factory.ts
+++ b/packages/cloud/shared/src/lib/cache/redis-factory.ts
@@ -30,8 +30,10 @@ export interface RedisFactoryEnv {
   MOCK_REDIS?: string;
 }
 
-export function buildRedisClient(env?: RedisFactoryEnv): CompatibleRedis | null {
-  const e = env ?? (process.env as RedisFactoryEnv);
+export type RedisFactoryEnvSource = RedisFactoryEnv | NodeJS.ProcessEnv;
+
+export function buildRedisClient(env?: RedisFactoryEnvSource): CompatibleRedis | null {
+  const e = env ?? process.env;
 
   if (e.MOCK_REDIS === "1") {
     return new MockSocketRedis() as unknown as SocketRedis;
@@ -55,8 +57,8 @@ export function buildRedisClient(env?: RedisFactoryEnv): CompatibleRedis | null 
  * callers gate on the same condition the factory uses, instead of hard-coding
  * an Upstash-only `KV_REST_API_*` check that misses a TCP `REDIS_URL` deploy.
  */
-export function hasRedisConfig(env?: RedisFactoryEnv): boolean {
-  const e = env ?? (process.env as RedisFactoryEnv);
+export function hasRedisConfig(env?: RedisFactoryEnvSource): boolean {
+  const e = env ?? process.env;
   if (e.MOCK_REDIS === "1") return true;
   if (e.REDIS_URL) return true;
   const restUrl = e.KV_REST_API_URL || e.UPSTASH_REDIS_REST_URL;

--- a/packages/cloud/shared/src/lib/voice-session/config-consent-opus.test.ts
+++ b/packages/cloud/shared/src/lib/voice-session/config-consent-opus.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import * as realRedisFactory from "../cache/redis-factory";
 
 // Capture the REAL cloud-bindings surface so the stub keeps every export and can
 // be restored. The coverage lane runs all changed files in ONE bun process with
@@ -15,6 +16,7 @@ import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "b
 import * as realCloudBindings from "../runtime/cloud-bindings";
 
 const realCloudBindingsExports = { ...realCloudBindings };
+const realRedisFactoryExports = { ...realRedisFactory };
 
 const redisState = new Map<string, string>();
 const redisCalls: Array<{ op: string; key: string; value?: string; ex?: number }> = [];
@@ -46,6 +48,7 @@ mock.module("../runtime/cloud-bindings", () => ({
 }));
 
 afterAll(() => {
+  mock.module("../cache/redis-factory", () => realRedisFactoryExports);
   mock.module("../runtime/cloud-bindings", () => realCloudBindingsExports);
 });
 

--- a/packages/cloud/shared/src/lib/voice-session/consent-nonce.ts
+++ b/packages/cloud/shared/src/lib/voice-session/consent-nonce.ts
@@ -23,7 +23,6 @@ import {
   type CompatibleRedis,
   hasRedisConfig,
   isCloudflareWorkerRuntime,
-  type RedisFactoryEnv,
 } from "../cache/redis-factory";
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 
@@ -37,7 +36,7 @@ function getRedis(): CompatibleRedis | null {
   if (!isCloudflareWorkerRuntime() && cachedRedis) return cachedRedis;
   // On Workers, Redis credentials live on `c.env`, exposed via
   // getCloudAwareEnv(); passing process.env would miss them.
-  const client = buildRedisClient(getCloudAwareEnv() as unknown as RedisFactoryEnv);
+  const client = buildRedisClient(getCloudAwareEnv());
   if (client && !isCloudflareWorkerRuntime()) cachedRedis = client;
   return client;
 }
@@ -47,7 +46,7 @@ function consentKey(userId: string, nonce: string): string {
 }
 
 export function isConsentStoreConfigured(): boolean {
-  return hasRedisConfig(getCloudAwareEnv() as unknown as RedisFactoryEnv);
+  return hasRedisConfig(getCloudAwareEnv());
 }
 
 export interface IssuedConsentNonce {

--- a/packages/cloud/shared/src/lib/voice-session/jwt.ts
+++ b/packages/cloud/shared/src/lib/voice-session/jwt.ts
@@ -34,7 +34,6 @@ import {
   type CompatibleRedis,
   hasRedisConfig,
   isCloudflareWorkerRuntime,
-  type RedisFactoryEnv,
 } from "../cache/redis-factory";
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 import { logger } from "../utils/logger";
@@ -292,7 +291,7 @@ function getRedis(): CompatibleRedis | null {
   // On Workers, Redis credentials are on `c.env` (via getCloudAwareEnv), not
   // plain process.env, so the session directory + revocation store resolve in
   // production instead of silently reporting "not configured".
-  const client = buildRedisClient(getCloudAwareEnv() as unknown as RedisFactoryEnv);
+  const client = buildRedisClient(getCloudAwareEnv());
   if (client && !isCloudflareWorkerRuntime()) cachedRedis = client;
   return client;
 }
@@ -314,7 +313,7 @@ function revocationKey(jti: string): string {
  * durable across workers. When false, revocation relies on the short TTL only.
  */
 export function isVoiceSessionRevocationConfigured(): boolean {
-  return hasRedisConfig(getCloudAwareEnv() as unknown as RedisFactoryEnv);
+  return hasRedisConfig(getCloudAwareEnv());
 }
 
 /**

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -2139,9 +2139,11 @@ function appendStateProviderEvents(
 	// composeState's per-call ProviderResult, so resolve it by name here and
 	// stamp it on the event for context-renderer.ts to read.
 	const cacheStableByName = new Map<string, boolean>();
-	for (const def of providerDefinitions ?? []) {
-		if (typeof def.cacheStable === "boolean") {
-			cacheStableByName.set(def.name.toUpperCase(), def.cacheStable);
+	if (providerDefinitions) {
+		for (const def of providerDefinitions) {
+			if (typeof def.cacheStable === "boolean") {
+				cacheStableByName.set(def.name.toUpperCase(), def.cacheStable);
+			}
 		}
 	}
 	if (!providers || typeof providers !== "object") {

--- a/packages/homepage/tests/smoke.node.test.mjs
+++ b/packages/homepage/tests/smoke.node.test.mjs
@@ -14,6 +14,8 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const marketingPath = resolve(__dirname, "../src/pages/marketing.tsx");
 const globalStylesPath = resolve(__dirname, "../src/index.css");
+const viteConfigPath = resolve(__dirname, "../vite.config.ts");
+const tsconfigPath = resolve(__dirname, "../tsconfig.app.json");
 
 test("marketing.tsx exports a default function component", () => {
   const src = readFileSync(marketingPath, "utf8");
@@ -44,4 +46,15 @@ test("reduced-motion keeps functional loading indicators animated", () => {
     reducedMotionBlock,
     /animation-iteration-count:\s*infinite\s*!important/,
   );
+});
+
+test("clean builds resolve bare shared imports to language-only source", () => {
+  const viteConfig = readFileSync(viteConfigPath, "utf8");
+  const tsconfig = JSON.parse(readFileSync(tsconfigPath, "utf8"));
+
+  assert.match(viteConfig, /find:\s*"@elizaos\/shared"/);
+  assert.match(viteConfig, /\.\.\/shared\/src\/i18n\/language\.ts/);
+  assert.deepEqual(tsconfig.compilerOptions.paths["@elizaos/shared"], [
+    "../shared/src/i18n/language.ts",
+  ]);
 });

--- a/packages/homepage/tsconfig.app.json
+++ b/packages/homepage/tsconfig.app.json
@@ -21,6 +21,7 @@
     "esModuleInterop": true,
     "paths": {
       "@/*": ["./src/*"],
+      "@elizaos/shared": ["../shared/src/i18n/language.ts"],
       "@elizaos/shared/brand": ["../shared/src/brand/index.ts"],
       "@elizaos/ui/cloud-ui/components/icons": [
         "../ui/src/cloud-ui/components/icons.tsx"

--- a/packages/homepage/vite.config.ts
+++ b/packages/homepage/vite.config.ts
@@ -62,6 +62,15 @@ export default defineConfig({
         find: "@elizaos/shared/brand",
         replacement: path.resolve(__dirname, "../shared/src/brand/index.ts"),
       },
+      // Keep this bare-package alias after the brand subpath: Vite string
+      // aliases also match slash-prefixed subpaths. The source-aliased UI
+      // region helper imports only these dependency-free language primitives,
+      // so clean homepage builds neither require shared/dist nor bundle the
+      // full shared (and transitively core) barrel.
+      {
+        find: "@elizaos/shared",
+        replacement: path.resolve(__dirname, "../shared/src/i18n/language.ts"),
+      },
       // Icon-only subpath MUST come before the cloud-ui barrel alias —
       // the homepage onboarding pages import only icons here to avoid
       // pulling the full barrel (which drags in hast + framer-motion).

--- a/packages/scripts/__tests__/ci-path-gate.test.mjs
+++ b/packages/scripts/__tests__/ci-path-gate.test.mjs
@@ -7,7 +7,7 @@ import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { gitChangedFiles } from "./ci-path-gate.mjs";
+import { gitChangedFiles } from "../ci-path-gate.mjs";
 
 const repos = [];
 

--- a/packages/scripts/__tests__/test-cloud-run.test.mjs
+++ b/packages/scripts/__tests__/test-cloud-run.test.mjs
@@ -25,7 +25,7 @@ import {
   runBatches,
   walkTests,
   writeSyncAll,
-} from "./test-cloud-run.mjs";
+} from "../test-cloud-run.mjs";
 
 describe("walkTests", () => {
   it("finds .test. and .spec. files recursively and skips excluded dirs", () => {

--- a/packages/scripts/__tests__/windows-ci-workflow.test.ts
+++ b/packages/scripts/__tests__/windows-ci-workflow.test.ts
@@ -23,11 +23,7 @@ const EXPECTED_COMMANDS = [
   "bun run --cwd packages/shared test",
   "bun run --cwd packages/app-core test",
   "bun run --cwd packages/elizaos test",
-  // #15785: the tenant-db placement-claimer suite panics intermittently under
-  // Bun canary/PGlite on Windows, so the whole-package run skips it and a
-  // dedicated retry-isolated step (asserted below) re-runs it with a bounded
-  // retry. The exclusion is only sound while that step exists.
-  'bun run --cwd packages/cloud/shared test --path-ignore-patterns "**/tenant-db-placement-claimer.test.ts"',
+  "bun run --cwd packages/cloud/shared test",
   "bun run --cwd packages/scenario-runner test",
   "bun run --cwd packages/vault test",
   "bun run --cwd packages/security test",
@@ -69,26 +65,10 @@ describe("Windows CI workflow", () => {
     expect(new Set(commands).size).toBe(commands.length);
   });
 
-  test("still runs the tenant-db suite the whole-package run excludes", () => {
-    // Skipping a suite in the matrix without the isolated retry step would be
-    // silent coverage loss, not flake mitigation. Pin the step's own block —
-    // not the whole workflow — so repointing $suite at a different suite or
-    // moving the step off the lane that runs packages/cloud/shared cannot
-    // silently drop tenant-db coverage while these substrings survive elsewhere.
-    const stepName =
-      "Retry-isolated tenant-db PGlite suite (Windows canary flake, #15785)";
-    const stepStart = workflowText.indexOf(stepName);
-    expect(stepStart).toBeGreaterThan(-1);
-    const nextStep = workflowText.indexOf("- name:", stepStart);
-    const stepBlock = workflowText.slice(
-      stepStart,
-      nextStep === -1 ? undefined : nextStep,
-    );
-    expect(stepBlock).toContain("if: matrix.lane == 'app-and-cli'");
-    expect(stepBlock).toContain(
-      '$suite = "src/lib/services/tenant-db/tenant-db-placement-claimer.test.ts"',
-    );
-    expect(stepBlock).toContain(
+  test("delegates the Windows PGlite quarantine to the package runner", () => {
+    expect(workflowText).not.toContain("--path-ignore-patterns");
+    expect(workflowText).not.toContain("Retry-isolated tenant-db PGlite suite");
+    expect(workflowText).not.toContain(
       "bun run --cwd packages/cloud/shared test $suite",
     );
   });

--- a/packages/tools/voice-evidence-harness/src/cli.ts
+++ b/packages/tools/voice-evidence-harness/src/cli.ts
@@ -17,13 +17,16 @@
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-
+import { type ClientRunResult, runClient } from "./client.ts";
 import { Evidence, type StageName } from "./evidence.ts";
-import { parseWav, writeWav } from "./wav.ts";
-import { runClient } from "./client.ts";
-import { startReferenceServer, type DomainRow, type ProviderConfig } from "./reference/voice-session-server.ts";
-import { startRealTarget, type RealTargetHandle } from "./real/real-target.ts";
 import { assembleMp4, ensureFfmpeg } from "./mp4.ts";
+import { startRealTarget } from "./real/real-target.ts";
+import {
+  type DomainRow,
+  type ProviderConfig,
+  startReferenceServer,
+} from "./reference/voice-session-server.ts";
+import { parseWav, writeWav } from "./wav.ts";
 
 type Target = "reference" | "real";
 
@@ -44,23 +47,33 @@ interface ScenarioResult {
 function loadSecret(path: string, field: string): string {
   const raw = JSON.parse(readFileSync(path, "utf8"));
   const v = raw[field];
-  if (!v || typeof v !== "string") throw new Error(`secret ${path}.${field} missing`);
+  if (!v || typeof v !== "string")
+    throw new Error(`secret ${path}.${field} missing`);
   return v;
 }
 
 function providerConfig(): ProviderConfig {
-  const deepgramApiKey = loadSecret(join(homedir(), ".moltbot/secrets/deepgram.json"), "api_key");
-  const cartesiaApiKey = loadSecret(join(homedir(), ".moltbot/secrets/cartesia.json"), "api_key");
+  const deepgramApiKey = loadSecret(
+    join(homedir(), ".moltbot/secrets/deepgram.json"),
+    "api_key",
+  );
+  const cartesiaApiKey = loadSecret(
+    join(homedir(), ".moltbot/secrets/cartesia.json"),
+    "api_key",
+  );
   const llmApiKey = process.env.OPENROUTER_API_KEY;
-  if (!llmApiKey) throw new Error("OPENROUTER_API_KEY not set (harness LLM leg)");
+  if (!llmApiKey)
+    throw new Error("OPENROUTER_API_KEY not set (harness LLM leg)");
   return {
     deepgramApiKey,
     cartesiaApiKey,
     // public Cartesia voice ("Skylar - Friendly Guide"); documented in README
-    cartesiaVoiceId: process.env.CARTESIA_VOICE_ID ?? "db6b0ed5-d5d3-463d-ae85-518a07d3c2b4",
+    cartesiaVoiceId:
+      process.env.CARTESIA_VOICE_ID ?? "db6b0ed5-d5d3-463d-ae85-518a07d3c2b4",
     llm: {
       apiKey: llmApiKey,
-      model: process.env.HARNESS_LLM_MODEL ?? "meta-llama/llama-3.1-8b-instruct",
+      model:
+        process.env.HARNESS_LLM_MODEL ?? "meta-llama/llama-3.1-8b-instruct",
     },
   };
 }
@@ -79,8 +92,24 @@ const FIXTURES: Record<Scenario, string> = {
 
 // Required stages per scenario. Absent = FAIL (no missing-becomes-zero).
 const REQUIRED_STAGES: Record<Scenario, StageName[]> = {
-  baseline: ["mint", "ws_hello", "ready", "stt_final", "llm_first_text", "tts_first_frame", "tts_complete"],
-  bargein: ["mint", "ws_hello", "ready", "stt_final", "tts_first_frame", "interrupt_requested", "interrupt_to_silence"],
+  baseline: [
+    "mint",
+    "ws_hello",
+    "ready",
+    "stt_final",
+    "llm_first_text",
+    "tts_first_frame",
+    "tts_complete",
+  ],
+  bargein: [
+    "mint",
+    "ws_hello",
+    "ready",
+    "stt_final",
+    "tts_first_frame",
+    "interrupt_requested",
+    "interrupt_to_silence",
+  ],
   // error-auth intentionally does NOT require `ready`: a bad provider key must
   // prevent the session from reaching ready. It requires the auth handshake
   // stages plus a surfaced error (asserted separately in the gate below).
@@ -109,34 +138,43 @@ async function runScenario(
     bits: wav.bitsPerSample,
     pcmBytes: wav.pcm.byteLength,
   });
-  if (wav.sampleRate !== 16000 || wav.channels !== 1 || wav.bitsPerSample !== 16) {
-    reasons.push(`fixture not linear16 mono 16k (got ${wav.sampleRate}Hz/${wav.channels}ch/${wav.bitsPerSample}bit)`);
+  if (
+    wav.sampleRate !== 16000 ||
+    wav.channels !== 1 ||
+    wav.bitsPerSample !== 16
+  ) {
+    reasons.push(
+      `fixture not linear16 mono 16k (got ${wav.sampleRate}Hz/${wav.channels}ch/${wav.bitsPerSample}bit)`,
+    );
   }
   ev.writeArtifact("input.wav", wavBytes, "input audio (spoken fixture)");
 
   // domain-artifact capture
   const domainRows: DomainRow[] = [];
 
-  const faultInjection = scenario === "error-auth" ? "deepgram-auth-fail" : undefined;
+  const faultInjection =
+    scenario === "error-auth" ? "deepgram-auth-fail" : undefined;
 
   // Boot the target: either the harness §7 REFERENCE server, or the REAL
   // production Phase-1 voice-session server (mint route consent+jwt precondition
   // chain + attachVoiceWsHandler + VoiceSession + merged adapters), booted on a
   // node WS transport shim. Both expose the same {wsUrl, mint, stop} surface.
   let wsBase: string;
-  let mintFn: () => Promise<{ sessionId: string; token: string; expiresAt: string }>;
+  let mintFn: () => Promise<{
+    sessionId: string;
+    token: string;
+    expiresAt: string | number;
+  }>;
   let stopFn: () => void | Promise<void>;
-  let realHandle: RealTargetHandle | null = null;
-
   if (target === "real") {
-    realHandle = await startRealTarget({
+    const realTarget = await startRealTarget({
       providers,
       faultInjection,
       hooks: { log: (level, msg, data) => ev.log("server", level, msg, data) },
     });
-    wsBase = realHandle.wsUrl; // ends with `sessionId=`
-    mintFn = () => realHandle!.mint();
-    stopFn = () => realHandle!.stop();
+    wsBase = realTarget.wsUrl; // ends with `sessionId=`
+    mintFn = () => realTarget.mint();
+    stopFn = () => realTarget.stop();
     ev.log("harness", "info", "REAL voice server started", {
       wsUrl: wsBase,
       faultInjection: faultInjection ?? "none",
@@ -150,29 +188,43 @@ async function runScenario(
         onServerEmit: (kind, payload) => ev.wsEvent("s2c", kind, payload),
         onDomainRow: (row) => {
           domainRows.push(row);
-          ev.log("server", "info", `domain-row:${row.table}`, row as unknown as Record<string, unknown>);
+          ev.log("server", "info", `domain-row:${row.table}`, { ...row });
         },
       },
     });
     wsBase = server.wsUrl;
     mintFn = async () => server.mint("harness-agent", "harness-conversation");
     stopFn = () => server.stop();
-    ev.log("harness", "info", "reference server started", { wsUrl: server.wsUrl, faultInjection: faultInjection ?? "none" });
+    ev.log("harness", "info", "reference server started", {
+      wsUrl: server.wsUrl,
+      faultInjection: faultInjection ?? "none",
+    });
   }
 
   // §7.1 mint
   const minted = await mintFn();
   ev.mark("mint");
   ev.wsEvent("c2s", "json", { kind: "mint_request", target });
-  ev.wsEvent("s2c", "json", { kind: "mint_response", sessionId: minted.sessionId, expiresAt: minted.expiresAt, token: "<REDACTED>" });
-  ev.log("harness", "info", "minted session", { sessionId: minted.sessionId, target });
+  ev.wsEvent("s2c", "json", {
+    kind: "mint_response",
+    sessionId: minted.sessionId,
+    expiresAt: minted.expiresAt,
+    token: "<REDACTED>",
+  });
+  ev.log("harness", "info", "minted session", {
+    sessionId: minted.sessionId,
+    target,
+  });
 
   // The REAL server's WS url carries the sessionId as a query param (the
   // production ws/route.ts reads `?sessionId=`); the reference server's wsUrl is
   // already complete. Compose the final URL accordingly.
-  const connectUrl = target === "real" ? `${wsBase}${encodeURIComponent(minted.sessionId)}` : wsBase;
+  const connectUrl =
+    target === "real"
+      ? `${wsBase}${encodeURIComponent(minted.sessionId)}`
+      : wsBase;
 
-  let clientResult;
+  let clientResult: ClientRunResult;
   try {
     clientResult = await runClient({
       wsUrl: connectUrl,
@@ -230,20 +282,37 @@ async function runScenario(
       bitsPerSample: 16,
       audioFormat: 1,
     });
-    ev.writeArtifact("output-tts.wav", outWav, "TTS downlink audio (Cartesia Sonic, real)");
+    ev.writeArtifact(
+      "output-tts.wav",
+      outWav,
+      "TTS downlink audio (Cartesia Sonic, real)",
+    );
   } else if (scenario !== "error-auth") {
     reasons.push("no downlink TTS audio captured");
   }
 
   // ---- domain artifacts ----
-  ev.writeJsonArtifact("domain-rows.json", domainRows, "session + transcript rows the server produced");
+  ev.writeJsonArtifact(
+    "domain-rows.json",
+    domainRows,
+    "session + transcript rows the server produced",
+  );
   const sessionRows = domainRows.filter((r) => r.table === "voice_sessions");
-  const transcriptRows = domainRows.filter((r) => r.table === "voice_transcripts");
-  ev.log("harness", "info", "domain artifacts", { sessions: sessionRows.length, transcripts: transcriptRows.length });
+  const transcriptRows = domainRows.filter(
+    (r) => r.table === "voice_transcripts",
+  );
+  ev.log("harness", "info", "domain artifacts", {
+    sessions: sessionRows.length,
+    transcripts: transcriptRows.length,
+  });
 
   // ---- stage timing report ----
   const timing = ev.timingReport(REQUIRED_STAGES[scenario]);
-  ev.writeJsonArtifact("timing-report.json", timing, "stage timing report with explicit not_reached");
+  ev.writeJsonArtifact(
+    "timing-report.json",
+    timing,
+    "stage timing report with explicit not_reached",
+  );
 
   // ---- interrupt assertion (barge-in) ----
   const interruptAssertion = {
@@ -253,7 +322,11 @@ async function runScenario(
     assertion: "post-interrupt downlink frame count MUST be 0",
     pass: clientResult.postBargeInFrameCount === 0,
   };
-  ev.writeJsonArtifact("interrupt-assertion.json", interruptAssertion, "post-interrupt frame-count assertion");
+  ev.writeJsonArtifact(
+    "interrupt-assertion.json",
+    interruptAssertion,
+    "post-interrupt frame-count assertion",
+  );
 
   // ---- DoD gate ----
   if (timing.missing.length > 0) {
@@ -267,7 +340,9 @@ async function runScenario(
   if (scenario === "bargein") {
     if (!clientResult.sawInterrupted) reasons.push("interrupt never confirmed");
     if (clientResult.postBargeInFrameCount !== 0) {
-      reasons.push(`POST-INTERRUPT FRAMES LEAKED: ${clientResult.postBargeInFrameCount} (must be 0)`);
+      reasons.push(
+        `POST-INTERRUPT FRAMES LEAKED: ${clientResult.postBargeInFrameCount} (must be 0)`,
+      );
     }
   }
   if (scenario === "error-auth") {
@@ -280,11 +355,18 @@ async function runScenario(
     // `transport_error` (the live /v2/listen upgrade is rejected at auth →ws
     // close → adapter error). Both are the same DoD fact: a surfaced provider
     // auth/transport error, session never reaches ready-with-audio, no TTS.
-    const PROVIDER_ERROR_CODES = new Set(["stt_connect_timeout", "transport_error", "auth_failed"]);
+    const PROVIDER_ERROR_CODES = new Set([
+      "stt_connect_timeout",
+      "transport_error",
+      "auth_failed",
+    ]);
     const gotStt = clientResult.errors.some(
       (e) => e.code.startsWith("stt_") || PROVIDER_ERROR_CODES.has(e.code),
     );
-    if (!gotStt) reasons.push("error-path did not surface a provider/auth error (stt_*/transport_error)");
+    if (!gotStt)
+      reasons.push(
+        "error-path did not surface a provider/auth error (stt_*/transport_error)",
+      );
     // and it MUST NOT have produced TTS audio
     if (clientResult.downlinkFrameCount > 0) {
       reasons.push("error-path incorrectly produced TTS audio");
@@ -318,17 +400,40 @@ async function runScenario(
     });
     if (!mp4.ok) reasons.push(`mp4 assembly failed: ${mp4.error}`);
     else {
-      const mp4Bytes = new Uint8Array(readFileSync(join(evDir, "walkthrough.mp4")));
-      ev.writeArtifact("walkthrough.mp4", mp4Bytes, "input+output audio over timeline card (GitHub-inline MP4)");
+      const mp4Bytes = new Uint8Array(
+        readFileSync(join(evDir, "walkthrough.mp4")),
+      );
+      ev.writeArtifact(
+        "walkthrough.mp4",
+        mp4Bytes,
+        "input+output audio over timeline card (GitHub-inline MP4)",
+      );
     }
   }
 
   // ---- README index with SHA-256s ----
-  const readme = buildReadme(scenario, ev, timing, clientResult, { sessions: sessionRows.length, transcripts: transcriptRows.length }, minted.sessionId, target);
-  ev.writeArtifact("README.md", new TextEncoder().encode(readme), "evidence index");
+  const readme = buildReadme(
+    scenario,
+    ev,
+    timing,
+    clientResult,
+    { sessions: sessionRows.length, transcripts: transcriptRows.length },
+    minted.sessionId,
+    target,
+  );
+  ev.writeArtifact(
+    "README.md",
+    new TextEncoder().encode(readme),
+    "evidence index",
+  );
 
   const pass = reasons.length === 0;
-  ev.log("harness", pass ? "info" : "error", `scenario ${scenario} ${pass ? "PASS" : "FAIL"}`, { reasons });
+  ev.log(
+    "harness",
+    pass ? "info" : "error",
+    `scenario ${scenario} ${pass ? "PASS" : "FAIL"}`,
+    { reasons },
+  );
   return { scenario, pass, reasons, evidenceDir: evDir };
 }
 
@@ -348,17 +453,27 @@ function buildReadme(
   const lines: string[] = [];
   lines.push(`# Voice E2E evidence — ${scenario}`);
   lines.push("");
-  lines.push(`Generated ${new Date().toISOString()} by \`@elizaos/voice-evidence-harness\`.`);
+  lines.push(
+    `Generated ${new Date().toISOString()} by \`@elizaos/voice-evidence-harness\`.`,
+  );
   lines.push("");
-  lines.push(`Target: **${target === "real" ? "REAL Phase-1 voice-session server (production mint+jwt+ws-handler+VoiceSession)" : "harness §7 reference server"}**.`);
-  lines.push("Real providers: **Deepgram Flux (STT)** + **Cartesia Sonic 3.5 (TTS)**, LIVE keys.");
-  lines.push("LLM leg: real streaming LLM over OpenRouter standing in for Cerebras `gemma-4-31b` via the Eliza SSE bridge (see harness README §LLM-leg).");
+  lines.push(
+    `Target: **${target === "real" ? "REAL Phase-1 voice-session server (production mint+jwt+ws-handler+VoiceSession)" : "harness §7 reference server"}**.`,
+  );
+  lines.push(
+    "Real providers: **Deepgram Flux (STT)** + **Cartesia Sonic 3.5 (TTS)**, LIVE keys.",
+  );
+  lines.push(
+    "LLM leg: real streaming LLM over OpenRouter standing in for Cerebras `gemma-4-31b` via the Eliza SSE bridge (see harness README §LLM-leg).",
+  );
   lines.push(`Session: \`${sessionId}\``);
   lines.push("");
   lines.push("## Stage timings");
   lines.push("");
   for (const s of timing.stages) {
-    lines.push(`- \`${s.stage}\`: ${s.reached ? `${s.monoMs.toFixed(1)}ms` : `**not_reached** (${(s as { reason: string }).reason})`}`);
+    lines.push(
+      `- \`${s.stage}\`: ${s.reached ? `${s.monoMs.toFixed(1)}ms` : `**not_reached** (${(s as { reason: string }).reason})`}`,
+    );
   }
   lines.push("");
   lines.push("## Deltas");
@@ -369,7 +484,9 @@ function buildReadme(
   lines.push("");
   lines.push("## Interrupt assertion");
   lines.push("");
-  lines.push(`- post-interrupt downlink frames (client-observed): **${client.postBargeInFrameCount}** (MUST be 0)`);
+  lines.push(
+    `- post-interrupt downlink frames (client-observed): **${client.postBargeInFrameCount}** (MUST be 0)`,
+  );
   lines.push(`- interrupted event seen: ${client.sawInterrupted}`);
   lines.push("");
   lines.push("## Domain artifacts");
@@ -389,7 +506,9 @@ function buildReadme(
   lines.push("## How to reproduce");
   lines.push("");
   lines.push("```bash");
-  lines.push(`cd packages/tools/voice-evidence-harness && bun run src/cli.ts --scenario=${scenario} --target=${target}`);
+  lines.push(
+    `cd packages/tools/voice-evidence-harness && bun run src/cli.ts --scenario=${scenario} --target=${target}`,
+  );
   lines.push("```");
   lines.push("");
   return lines.join("\n");
@@ -397,18 +516,31 @@ function buildReadme(
 
 async function main() {
   const args = process.argv.slice(2);
-  const scenarioArg = (args.find((a) => a.startsWith("--scenario="))?.split("=")[1] ?? "all") as Scenario | "all";
-  const fixtureOverride = args.find((a) => a.startsWith("--fixture="))?.split("=")[1];
-  const target = ((args.find((a) => a.startsWith("--target="))?.split("=")[1]) ?? "reference") as Target;
+  const scenarioArg = (args
+    .find((a) => a.startsWith("--scenario="))
+    ?.split("=")[1] ?? "all") as Scenario | "all";
+  const fixtureOverride = args
+    .find((a) => a.startsWith("--fixture="))
+    ?.split("=")[1];
+  const target = (args.find((a) => a.startsWith("--target="))?.split("=")[1] ??
+    "reference") as Target;
   if (target !== "reference" && target !== "real") {
-    console.error(`invalid --target=${target} (expected "reference" or "real")`);
+    console.error(
+      `invalid --target=${target} (expected "reference" or "real")`,
+    );
     process.exit(2);
   }
 
   const stamp = new Date().toISOString().replace(/[:.]/g, "-");
-  const runDir = join(evidenceRoot(), target === "real" ? `${stamp}-real-server` : stamp);
+  const runDir = join(
+    evidenceRoot(),
+    target === "real" ? `${stamp}-real-server` : stamp,
+  );
 
-  const scenarios: Scenario[] = scenarioArg === "all" ? ["baseline", "bargein", "error-auth"] : [scenarioArg];
+  const scenarios: Scenario[] =
+    scenarioArg === "all"
+      ? ["baseline", "bargein", "error-auth"]
+      : [scenarioArg];
 
   // Keep-alive: the REAL target boots a node WS server whose inbound socket is
   // the process's last live handle. When that socket closes (session teardown),
@@ -420,7 +552,12 @@ async function main() {
   const results: ScenarioResult[] = [];
   for (const s of scenarios) {
     console.log(`\n########## ${s} (target=${target}) ##########`);
-    const r = await runScenario(s, runDir, target, s === scenarioArg ? fixtureOverride : undefined);
+    const r = await runScenario(
+      s,
+      runDir,
+      target,
+      s === scenarioArg ? fixtureOverride : undefined,
+    );
     results.push(r);
   }
   clearInterval(keepAlive);
@@ -434,7 +571,10 @@ async function main() {
     "",
     "| scenario | result | reasons |",
     "| --- | --- | --- |",
-    ...results.map((r) => `| ${r.scenario} | ${r.pass ? "PASS" : "**FAIL**"} | ${r.reasons.join("; ") || "-"} |`),
+    ...results.map(
+      (r) =>
+        `| ${r.scenario} | ${r.pass ? "PASS" : "**FAIL**"} | ${r.reasons.join("; ") || "-"} |`,
+    ),
     "",
   ];
   const { writeFileSync, mkdirSync } = await import("node:fs");
@@ -445,7 +585,9 @@ async function main() {
 
   const allPass = results.every((r) => r.pass);
   if (!allPass) {
-    console.error("\nEVIDENCE RUN FAILED — one or more scenarios did not meet DoD.");
+    console.error(
+      "\nEVIDENCE RUN FAILED — one or more scenarios did not meet DoD.",
+    );
     process.exit(1);
   }
   console.log("\nEVIDENCE RUN PASSED.");

--- a/packages/tools/voice-evidence-harness/src/client.ts
+++ b/packages/tools/voice-evidence-harness/src/client.ts
@@ -36,13 +36,51 @@ export interface ClientRunResult {
   firstSilenceAfterBargeInMonoMs: number | null;
 }
 
+interface HarnessWebSocket {
+  binaryType: string;
+  readonly readyState: number;
+  send(data: string | ArrayBufferLike | ArrayBufferView): void;
+  close(code?: number, reason?: string): void;
+  addEventListener(type: "open", listener: () => void): void;
+  addEventListener(
+    type: "message",
+    listener: (event: MessageEvent) => void,
+  ): void;
+  addEventListener(type: "error" | "close", listener: () => void): void;
+}
+
+function isHarnessWebSocket(value: unknown): value is HarnessWebSocket {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof Reflect.get(value, "binaryType") === "string" &&
+    typeof Reflect.get(value, "readyState") === "number" &&
+    typeof Reflect.get(value, "send") === "function" &&
+    typeof Reflect.get(value, "close") === "function" &&
+    typeof Reflect.get(value, "addEventListener") === "function"
+  );
+}
+
+function openHarnessWebSocket(url: string): HarnessWebSocket {
+  const ctor: unknown = globalThis.WebSocket;
+  if (typeof ctor !== "function") {
+    throw new Error("WebSocket is unavailable in this runtime");
+  }
+  const socket: unknown = Reflect.construct(ctor, [url]);
+  if (!isHarnessWebSocket(socket)) {
+    throw new Error(
+      "WebSocket runtime does not expose the required client API",
+    );
+  }
+  return socket;
+}
+
 export async function runClient(
   opts: ClientRunOptions,
 ): Promise<ClientRunResult> {
   const { evidence: ev } = opts;
-  const NativeWebSocket = WebSocket as unknown as new (u: string) => WebSocket;
-  const ws = new NativeWebSocket(opts.wsUrl);
-  (ws as unknown as { binaryType: string }).binaryType = "arraybuffer";
+  const ws = openHarnessWebSocket(opts.wsUrl);
+  ws.binaryType = "arraybuffer";
 
   const downlinkChunks: Uint8Array[] = [];
   const result: ClientRunResult = {

--- a/packages/tools/voice-evidence-harness/src/evidence.ts
+++ b/packages/tools/voice-evidence-harness/src/evidence.ts
@@ -54,27 +54,38 @@ export type StageRecord = StageMark | StageMiss;
 const REDACT_PATTERNS: Array<[RegExp, string]> = [
   [/Token\s+[A-Za-z0-9._-]{12,}/g, "Token <REDACTED>"],
   [/Bearer\s+[A-Za-z0-9._-]{12,}/g, "Bearer <REDACTED>"],
-  [/("?(?:api[_-]?key|apiKey|X-API-Key|Authorization|token|deepgramApiKey)"?\s*[:=]\s*")[^"]+(")/gi, '$1<REDACTED>$2'],
+  [
+    /("?(?:api[_-]?key|apiKey|X-API-Key|Authorization|token|deepgramApiKey)"?\s*[:=]\s*")[^"]+(")/gi,
+    "$1<REDACTED>$2",
+  ],
   [/sk-[A-Za-z0-9]{16,}/g, "sk-<REDACTED>"],
 ];
 
-export function redact<T>(value: T): T {
+export function redact(value: string): string;
+export function redact(value: Record<string, unknown>): Record<string, unknown>;
+export function redact(value: readonly unknown[]): unknown[];
+export function redact(value: unknown): unknown;
+export function redact(value: unknown): unknown {
   if (typeof value === "string") {
     let s = value;
     for (const [re, rep] of REDACT_PATTERNS) s = s.replace(re, rep);
-    return s as unknown as T;
+    return s;
   }
-  if (Array.isArray(value)) return value.map((v) => redact(v)) as unknown as T;
+  if (Array.isArray(value)) return value.map((item) => redact(item));
   if (value && typeof value === "object") {
     const out: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-      if (/(^|[_-])(key|token|authorization|secret)$/i.test(k) && typeof v === "string") {
-        out[k] = "<REDACTED>";
+    for (const key of Object.keys(value)) {
+      const item: unknown = Reflect.get(value, key);
+      if (
+        /(^|[_-])(key|token|authorization|secret)$/i.test(key) &&
+        typeof item === "string"
+      ) {
+        out[key] = "<REDACTED>";
       } else {
-        out[k] = redact(v);
+        out[key] = redact(item);
       }
     }
-    return out as unknown as T;
+    return out;
   }
   return value;
 }
@@ -87,7 +98,12 @@ export class Evidence {
   private readonly serverLogs: LogEntry[] = [];
   private readonly stages = new Map<StageName, StageRecord>();
   private readonly wsTranscript: Array<Record<string, unknown>> = [];
-  private readonly artifacts: Array<{ name: string; bytes: number; sha256: string; note?: string }> = [];
+  private readonly artifacts: Array<{
+    name: string;
+    bytes: number;
+    sha256: string;
+    note?: string;
+  }> = [];
 
   constructor(dir: string) {
     this.dir = dir;
@@ -99,7 +115,12 @@ export class Evidence {
     return performance.now() - this.startMono;
   }
 
-  log(side: Side, level: LogEntry["level"], msg: string, data?: Record<string, unknown>): void {
+  log(
+    side: Side,
+    level: LogEntry["level"],
+    msg: string,
+    data?: Record<string, unknown>,
+  ): void {
     const entry: LogEntry = {
       ts: new Date().toISOString(),
       monoMs: Number(this.now().toFixed(3)),
@@ -117,7 +138,11 @@ export class Evidence {
   }
 
   /** Record a WS control/audio event exactly as it crossed the wire (redacted). */
-  wsEvent(direction: "c2s" | "s2c", kind: "json" | "binary", payload: Record<string, unknown>): void {
+  wsEvent(
+    direction: "c2s" | "s2c",
+    kind: "json" | "binary",
+    payload: Record<string, unknown>,
+  ): void {
     this.wsTranscript.push({
       monoMs: Number(this.now().toFixed(3)),
       direction,
@@ -128,7 +153,11 @@ export class Evidence {
 
   mark(stage: StageName): void {
     if (this.stages.has(stage)) return; // first occurrence wins
-    this.stages.set(stage, { stage, monoMs: Number(this.now().toFixed(3)), reached: true });
+    this.stages.set(stage, {
+      stage,
+      monoMs: Number(this.now().toFixed(3)),
+      reached: true,
+    });
     this.log("harness", "info", `stage:${stage}`, { monoMs: this.now() });
   }
 
@@ -139,7 +168,7 @@ export class Evidence {
 
   stageMs(stage: StageName): number | null {
     const r = this.stages.get(stage);
-    return r && r.reached ? r.monoMs : null;
+    return r?.reached ? r.monoMs : null;
   }
 
   /** Delta between two reached stages, or null if either is missing. Never 0-for-missing. */
@@ -156,15 +185,27 @@ export class Evidence {
     writeFileSync(path, bytes);
     const sha256 = createHash("sha256").update(bytes).digest("hex");
     this.artifacts.push({ name, bytes: bytes.byteLength, sha256, note });
-    this.log("harness", "info", `artifact:${name}`, { bytes: bytes.byteLength, sha256 });
+    this.log("harness", "info", `artifact:${name}`, {
+      bytes: bytes.byteLength,
+      sha256,
+    });
     return sha256;
   }
 
   writeJsonArtifact(name: string, value: unknown, note?: string): string {
-    return this.writeArtifact(name, new TextEncoder().encode(JSON.stringify(value, null, 2) + "\n"), note);
+    return this.writeArtifact(
+      name,
+      new TextEncoder().encode(`${JSON.stringify(value, null, 2)}\n`),
+      note,
+    );
   }
 
-  get artifactIndex(): ReadonlyArray<{ name: string; bytes: number; sha256: string; note?: string }> {
+  get artifactIndex(): ReadonlyArray<{
+    name: string;
+    bytes: number;
+    sha256: string;
+    note?: string;
+  }> {
     return this.artifacts;
   }
 
@@ -174,10 +215,26 @@ export class Evidence {
 
   /** Flush per-side logs + transcript + timings to disk. */
   flushLogs(): void {
-    this.writeJsonArtifact("ws-transcript.json", this.wsTranscript, "full WS message transcript (tokens redacted)");
-    this.writeJsonArtifact("server.log.json", this.serverLogs, "server + provider structured logs");
-    this.writeJsonArtifact("client.log.json", this.clientLogs, "client-side event log");
-    this.writeJsonArtifact("all.log.json", this.logs, "combined structured log");
+    this.writeJsonArtifact(
+      "ws-transcript.json",
+      this.wsTranscript,
+      "full WS message transcript (tokens redacted)",
+    );
+    this.writeJsonArtifact(
+      "server.log.json",
+      this.serverLogs,
+      "server + provider structured logs",
+    );
+    this.writeJsonArtifact(
+      "client.log.json",
+      this.clientLogs,
+      "client-side event log",
+    );
+    this.writeJsonArtifact(
+      "all.log.json",
+      this.logs,
+      "combined structured log",
+    );
   }
 
   /**
@@ -192,17 +249,33 @@ export class Evidence {
     const stages: StageRecord[] = [];
     const missing: string[] = [];
     for (const s of requiredStages) {
-      const rec = this.stages.get(s) ?? { stage: s, reached: false as const, reason: "stage never fired" };
+      const rec = this.stages.get(s) ?? {
+        stage: s,
+        reached: false as const,
+        reason: "stage never fired",
+      };
       stages.push(rec);
       if (!rec.reached) missing.push(s);
     }
     const deltas: Record<string, number | null> = {
       "mint->ready": this.stageDelta("mint", "ready"),
       "ready->stt_final": this.stageDelta("ready", "stt_final"),
-      "stt_final->llm_first_text": this.stageDelta("stt_final", "llm_first_text"),
-      "llm_first_text->tts_first_frame": this.stageDelta("llm_first_text", "tts_first_frame"),
-      "stt_final->tts_first_frame": this.stageDelta("stt_final", "tts_first_frame"),
-      "tts_first_frame->tts_complete": this.stageDelta("tts_first_frame", "tts_complete"),
+      "stt_final->llm_first_text": this.stageDelta(
+        "stt_final",
+        "llm_first_text",
+      ),
+      "llm_first_text->tts_first_frame": this.stageDelta(
+        "llm_first_text",
+        "tts_first_frame",
+      ),
+      "stt_final->tts_first_frame": this.stageDelta(
+        "stt_final",
+        "tts_first_frame",
+      ),
+      "tts_first_frame->tts_complete": this.stageDelta(
+        "tts_first_frame",
+        "tts_complete",
+      ),
       "interrupt_requested->interrupt_to_silence": this.stageDelta(
         "interrupt_requested",
         "interrupt_to_silence",

--- a/packages/tools/voice-evidence-harness/src/reference/voice-session-server.integration.test.ts
+++ b/packages/tools/voice-evidence-harness/src/reference/voice-session-server.integration.test.ts
@@ -236,7 +236,7 @@ function connect(wsUrl: string): Promise<ClientRecorder> {
             });
           }),
         send: (obj) => ws.send(JSON.stringify(obj)),
-        sendBinary: (bytes) => ws.send(bytes),
+        sendBinary: (bytes) => ws.send(Uint8Array.from(bytes)),
         close: () => ws.close(),
       } as ClientRecorder);
   });

--- a/packages/tools/voice-evidence-harness/src/reference/voice-session-server.ts
+++ b/packages/tools/voice-evidence-harness/src/reference/voice-session-server.ts
@@ -20,7 +20,10 @@
  */
 
 import { createHmac, randomUUID } from "node:crypto";
-import type { ServerWebSocket } from "bun";
+import {
+  CartesiaSonicTtsAdapter,
+  type CartesiaSonicTtsStream,
+} from "@harness-adapters/cartesia-sonic-tts.ts";
 
 import {
   createDeepgramFluxRealtimeSession,
@@ -28,15 +31,12 @@ import {
   type DeepgramFluxRealtimeEvent,
   type DeepgramFluxRealtimeSession,
 } from "@harness-adapters/deepgram-flux.ts";
-import {
-  CartesiaSonicTtsAdapter,
-  type CartesiaSonicTtsStream,
-} from "@harness-adapters/cartesia-sonic-tts.ts";
+import type { ServerWebSocket } from "bun";
 
-import { makeDeepgramFactory, makeCartesiaFactory } from "../ws-factories.ts";
-import { streamLlmReply, type LlmStreamConfig } from "./llm-bridge.ts";
+import { makeCartesiaFactory, makeDeepgramFactory } from "../ws-factories.ts";
+import { type LlmStreamConfig, streamLlmReply } from "./llm-bridge.ts";
 
-const HARNESS_MINT_SECRET = "harness-only-not-production-" + randomUUID();
+const HARNESS_MINT_SECRET = `harness-only-not-production-${randomUUID()}`;
 const TOKEN_TTL_MS = 120_000;
 
 export interface ProviderConfig {
@@ -119,7 +119,7 @@ export function mintHarnessToken(
   const sig = createHmac("sha256", HARNESS_MINT_SECRET)
     .update(payload)
     .digest("base64url");
-  const token = Buffer.from(payload).toString("base64url") + "." + sig;
+  const token = `${Buffer.from(payload).toString("base64url")}.${sig}`;
   return { sessionId, token, expiresAt };
 }
 
@@ -190,7 +190,7 @@ export function startReferenceServer(opts: StartServerOptions): RunningServer {
     ws.send(bytes);
   };
 
-  const server = Bun.serve<WsData, undefined>({
+  const server = Bun.serve<WsData>({
     port,
     fetch(req, srv) {
       const url = new URL(req.url);
@@ -487,7 +487,6 @@ export function startReferenceServer(opts: StartServerOptions): RunningServer {
     // done, and mark the LAST phrase so we close the context exactly once via
     // that phrase's completion (never send an empty trailing phrase into an
     // already-completing context -> that races into "Context closed").
-    let firstPhrase = true;
     let sentenceBuf = "";
     let phrasesSent = 0;
     const sendPhraseSafe = (text: string, last: boolean) => {
@@ -496,7 +495,6 @@ export function startReferenceServer(opts: StartServerOptions): RunningServer {
         // `continue:false` on the final phrase tells Cartesia this context is
         // complete after synthesizing it -> yields onComplete, no empty finish.
         tts.sendPhrase({ text, continueContext: !last });
-        firstPhrase = false;
         phrasesSent++;
       } catch (ignoredError) {
         void ignoredError;
@@ -628,6 +626,10 @@ export function startReferenceServer(opts: StartServerOptions): RunningServer {
   }
 
   const actualPort = server.port;
+  if (typeof actualPort !== "number") {
+    server.stop(true);
+    throw new Error("voice reference server did not bind a TCP port");
+  }
   const wsUrl = `ws://127.0.0.1:${actualPort}/api/v1/voice/session/ws`;
   return {
     port: actualPort,

--- a/packages/tools/voice-evidence-harness/src/voice-evidence-harness.test.ts
+++ b/packages/tools/voice-evidence-harness/src/voice-evidence-harness.test.ts
@@ -285,8 +285,10 @@ describe("LLM bridge", () => {
         controller.close();
       },
     });
-    globalThis.fetch = (async () =>
-      new Response(stream, { status: 200 })) as typeof fetch;
+    globalThis.fetch = Object.assign(
+      async () => new Response(stream, { status: 200 }),
+      { preconnect: originalFetch.preconnect },
+    );
     const deltas: string[] = [];
     const first: number[] = [];
     const done: string[] = [];
@@ -308,8 +310,10 @@ describe("LLM bridge", () => {
     expect(done).toEqual(["Hi there"]);
 
     const errors: string[] = [];
-    globalThis.fetch = (async () =>
-      new Response("bad", { status: 503, statusText: "Nope" })) as typeof fetch;
+    globalThis.fetch = Object.assign(
+      async () => new Response("bad", { status: 503, statusText: "Nope" }),
+      { preconnect: originalFetch.preconnect },
+    );
     await llmBridge.streamLlmReply(
       "weather",
       { apiKey: "key", baseUrl: "https://llm.test" },
@@ -389,7 +393,8 @@ describe("client and reference-server contract helpers", () => {
         maxRunMs: 1000,
       });
       await new Promise((resolve) => setTimeout(resolve, 0));
-      const ws = FakeWebSocket.instances[0]!;
+      const ws = FakeWebSocket.instances[0];
+      if (!ws) throw new Error("voice client did not create a WebSocket");
       expect(JSON.parse(String(ws.sent[0]))).toMatchObject({
         t: "hello",
         token: "token",
@@ -473,8 +478,8 @@ describe("provider websocket factories", () => {
     expect(fakeWsInstances[1]?.options?.headers).toEqual({
       "X-API-Key": "cartesia",
     });
-    cartesia.binaryType = "arraybuffer";
-    expect(cartesia.binaryType).toBe("arraybuffer");
+    expect(Reflect.set(cartesia, "binaryType", "arraybuffer")).toBe(true);
+    expect(Reflect.get(cartesia, "binaryType")).toBe("arraybuffer");
   });
 });
 

--- a/packages/tools/voice-evidence-harness/src/ws-factories.ts
+++ b/packages/tools/voice-evidence-harness/src/ws-factories.ts
@@ -26,17 +26,17 @@
  * ------------------------------------------------------------------------
  */
 
-import WebSocketImpl from "ws";
-import type {
-  DeepgramFluxWebSocket,
-  DeepgramFluxWebSocketFactory,
-  DeepgramFluxTransportRequest,
-} from "@harness-adapters/deepgram-flux.ts";
 import type {
   CartesiaWebSocketFactory,
-  CartesiaWebSocketLike,
   CartesiaWebSocketFactoryOptions,
+  CartesiaWebSocketLike,
 } from "@harness-adapters/cartesia-sonic-tts.ts";
+import type {
+  DeepgramFluxTransportRequest,
+  DeepgramFluxWebSocket,
+  DeepgramFluxWebSocketFactory,
+} from "@harness-adapters/deepgram-flux.ts";
+import WebSocketImpl from "ws";
 
 export interface FactoryHooks {
   log?: (msg: string, data?: Record<string, unknown>) => void;
@@ -47,10 +47,15 @@ export interface FactoryHooks {
  * `addEventListener`. Wrap so the adapters' `addEventListener`/
  * `removeEventListener` DOM-shaped API works unchanged.
  */
-function wrapDom(socket: WebSocketImpl): DeepgramFluxWebSocket & CartesiaWebSocketLike {
-  const listenerMap = new WeakMap<(e: unknown) => void, (...a: unknown[]) => void>();
+type BridgeEventType = "open" | "message" | "error" | "close";
 
-  const toDomEvent = (type: string, ...args: unknown[]): unknown => {
+function wrapDom(socket: WebSocketImpl): unknown {
+  const listenerMap = new WeakMap<
+    (e: unknown) => void,
+    (...a: unknown[]) => void
+  >();
+
+  const toDomEvent = (type: BridgeEventType, ...args: unknown[]): unknown => {
     switch (type) {
       case "open":
         return { type: "open" };
@@ -64,24 +69,36 @@ function wrapDom(socket: WebSocketImpl): DeepgramFluxWebSocket & CartesiaWebSock
         let data: unknown = raw;
         if (typeof raw !== "string") {
           if (Buffer.isBuffer(raw)) data = raw.toString("utf8");
-          else if (raw instanceof ArrayBuffer) data = Buffer.from(raw).toString("utf8");
+          else if (raw instanceof ArrayBuffer)
+            data = Buffer.from(raw).toString("utf8");
           else if (ArrayBuffer.isView(raw))
-            data = Buffer.from(raw.buffer, raw.byteOffset, raw.byteLength).toString("utf8");
-          else if (Array.isArray(raw)) data = Buffer.concat(raw).toString("utf8");
+            data = Buffer.from(
+              raw.buffer,
+              raw.byteOffset,
+              raw.byteLength,
+            ).toString("utf8");
+          else if (Array.isArray(raw))
+            data = Buffer.concat(raw).toString("utf8");
         }
         return { type: "message", data };
       }
       case "error": {
-        const err = args[0] as Error;
-        return { type: "error", message: err?.message, error: err };
+        const error = args[0];
+        return {
+          type: "error",
+          message: error instanceof Error ? error.message : String(error),
+          error,
+        };
       }
       case "close": {
-        const code = args[0] as number;
+        const code = typeof args[0] === "number" ? args[0] : 1006;
         const reason = args[1];
         return {
           type: "close",
           code,
-          reason: Buffer.isBuffer(reason) ? reason.toString("utf8") : String(reason ?? ""),
+          reason: Buffer.isBuffer(reason)
+            ? reason.toString("utf8")
+            : String(reason ?? ""),
           wasClean: code === 1000,
         };
       }
@@ -96,51 +113,93 @@ function wrapDom(socket: WebSocketImpl): DeepgramFluxWebSocket & CartesiaWebSock
     },
     set binaryType(v: string) {
       // ws uses "nodebuffer" | "arraybuffer" | "fragments"
-      (socket as unknown as { binaryType: string }).binaryType =
-        v === "arraybuffer" ? "arraybuffer" : "nodebuffer";
+      socket.binaryType = v === "arraybuffer" ? "arraybuffer" : "nodebuffer";
     },
     get binaryType() {
-      return (socket as unknown as { binaryType: string }).binaryType;
+      return socket.binaryType;
     },
     send(data: string | ArrayBuffer | ArrayBufferView) {
-      socket.send(data as never);
+      if (typeof data === "string" || data instanceof ArrayBuffer) {
+        socket.send(data);
+        return;
+      }
+      socket.send(Buffer.from(data.buffer, data.byteOffset, data.byteLength));
     },
     close(code?: number, reason?: string) {
       socket.close(code, reason);
     },
-    addEventListener(type: string, listener: (e: unknown) => void) {
-      const handler = (...args: unknown[]) => listener(toDomEvent(type, ...args));
+    addEventListener(type: BridgeEventType, listener: (e: unknown) => void) {
+      const handler = (...args: unknown[]) =>
+        listener(toDomEvent(type, ...args));
       listenerMap.set(listener, handler);
-      socket.on(type, handler as never);
+      socket.on(type, handler);
     },
-    removeEventListener(type: string, listener: (e: unknown) => void) {
+    removeEventListener(type: BridgeEventType, listener: (e: unknown) => void) {
       const handler = listenerMap.get(listener);
-      if (handler) socket.off(type, handler as never);
+      if (handler) socket.off(type, handler);
     },
   };
-  return wrapped as unknown as DeepgramFluxWebSocket & CartesiaWebSocketLike;
+  return wrapped;
 }
 
-export function makeDeepgramFactory(hooks?: FactoryHooks): DeepgramFluxWebSocketFactory {
+function hasWebSocketBridgeShape(value: unknown): boolean {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof Reflect.get(value, "readyState") === "number" &&
+    typeof Reflect.get(value, "send") === "function" &&
+    typeof Reflect.get(value, "close") === "function" &&
+    typeof Reflect.get(value, "addEventListener") === "function" &&
+    typeof Reflect.get(value, "removeEventListener") === "function"
+  );
+}
+
+function isDeepgramSocket(value: unknown): value is DeepgramFluxWebSocket {
+  return hasWebSocketBridgeShape(value);
+}
+
+function isCartesiaSocket(value: unknown): value is CartesiaWebSocketLike {
+  return hasWebSocketBridgeShape(value);
+}
+
+export function makeDeepgramFactory(
+  hooks?: FactoryHooks,
+): DeepgramFluxWebSocketFactory {
   return (request: DeepgramFluxTransportRequest): DeepgramFluxWebSocket => {
     // Strip the unsupported `channels` param (see defect note above).
     const url = new URL(request.url);
     if (url.searchParams.has("channels")) {
       url.searchParams.delete("channels");
-      hooks?.log?.("deepgram-flux: stripped unsupported 'channels' query param (adapter defect #15950)", {
-        note: "Flux /v2/listen rejects channels; harness strips it to proceed",
-      });
+      hooks?.log?.(
+        "deepgram-flux: stripped unsupported 'channels' query param (adapter defect #15950)",
+        {
+          note: "Flux /v2/listen rejects channels; harness strips it to proceed",
+        },
+      );
     }
     const socket = new WebSocketImpl(url.toString(), {
       headers: request.headers,
     });
-    return wrapDom(socket);
+    const wrapped = wrapDom(socket);
+    if (!isDeepgramSocket(wrapped)) {
+      throw new Error("Deepgram WebSocket bridge is missing required methods");
+    }
+    return wrapped;
   };
 }
 
-export function makeCartesiaFactory(_hooks?: FactoryHooks): CartesiaWebSocketFactory {
-  return (url: string, options: CartesiaWebSocketFactoryOptions): CartesiaWebSocketLike => {
+export function makeCartesiaFactory(
+  _hooks?: FactoryHooks,
+): CartesiaWebSocketFactory {
+  return (
+    url: string,
+    options: CartesiaWebSocketFactoryOptions,
+  ): CartesiaWebSocketLike => {
     const socket = new WebSocketImpl(url, { headers: options.headers });
-    return wrapDom(socket);
+    const wrapped = wrapDom(socket);
+    if (!isCartesiaSocket(wrapped)) {
+      throw new Error("Cartesia WebSocket bridge is missing required methods");
+    }
+    return wrapped;
   };
 }

--- a/packages/tools/voice-evidence-harness/tsconfig.json
+++ b/packages/tools/voice-evidence-harness/tsconfig.json
@@ -10,8 +10,8 @@
     "skipLibCheck": true,
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
-    "baseUrl": ".",
     "paths": {
+      "@/lib/*": ["../../cloud/shared/src/lib/*"],
       "@harness-adapters/deepgram-flux.ts": [
         "../../cloud/api/v1/voice/stt/providers/deepgram-flux.ts"
       ],

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -77,7 +77,7 @@
     "audit:stories:update-baseline": "node test/story-gate/run-story-gate.mjs --update-baseline",
     "audit:stories:play": "node test/story-gate/play-coverage-gate.mjs",
     "audit:stories:play:update-baseline": "node test/story-gate/play-coverage-gate.mjs --update-baseline",
-    "build:dist:unlocked": "bun run clean && node ../scripts/ensure-tsc-nested-output-dir.mjs packages/ui && tsc --noCheck -p tsconfig.build.json && node ../scripts/flatten-tsc-package-output.mjs packages/ui && node ../scripts/copy-package-assets.mjs packages/ui src/styles src/cloud-ui/index.css && node ../scripts/prepare-package-dist.mjs packages/ui && node ../scripts/rewrite-dist-relative-imports-node-esm.mjs packages/ui && node ../scripts/verify-package-runtime-exports.mjs packages/ui",
+    "build:dist:unlocked": "bun run clean && node ../scripts/ensure-tsc-nested-output-dir.mjs packages/ui && tsc --noCheck -p tsconfig.build.json && node ../scripts/flatten-tsc-package-output.mjs packages/ui && node ../scripts/copy-package-assets.mjs packages/ui src/styles src/cloud-ui/index.css src/voice/worklets && node ../scripts/prepare-package-dist.mjs packages/ui && node ../scripts/rewrite-dist-relative-imports-node-esm.mjs packages/ui && node ../scripts/verify-package-runtime-exports.mjs packages/ui",
     "test:orchestrator-accounts-e2e": "bun run --cwd ../.. packages/ui/src/components/chat/widgets/__e2e__/run-orchestrator-accounts-e2e.mjs",
     "test:wallet-widget-e2e": "bun run --cwd ../.. packages/ui/src/components/chat/widgets/__e2e__/run-wallet-widget-e2e.mjs",
     "test:task-pipeline-e2e": "bun run --cwd ../.. packages/ui/src/components/chat/widgets/__e2e__/run-task-pipeline-e2e.mjs",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -54,7 +54,7 @@
     "test:activity-feedback-e2e": "bun run --cwd ../.. packages/ui/src/components/chat/__e2e__/run-activity-feedback-e2e.mjs",
     "test:background-e2e": "bun run --cwd ../.. packages/ui/src/components/pages/__e2e__/run-background-e2e.mjs",
     "test:chat-infinite-scroll-e2e": "bun run --cwd ../.. packages/ui/src/components/pages/__e2e__/run-chat-infinite-scroll-e2e.mjs",
-    "test:suggestions-e2e": "bun run --cwd ../.. packages/ui/src/components/pages/__e2e__/run-suggestions-e2e.mjs",
+    "test:suggestions-e2e": "bun --conditions=eliza-source run --cwd ../.. packages/ui/src/components/pages/__e2e__/run-suggestions-e2e.mjs",
     "test:launcher-e2e": "bun run --cwd ../.. packages/ui/src/components/pages/__e2e__/run-launcher-e2e.mjs",
     "test:connectors-e2e": "bun run --cwd ../.. packages/ui/src/components/pages/__e2e__/run-connectors-e2e.mjs",
     "test:view-lifecycle-e2e": "bun run --cwd ../.. packages/ui/src/components/views/__e2e__/run-view-lifecycle-e2e.mjs",

--- a/packages/ui/src/api/client-cloud-steward-token.test.ts
+++ b/packages/ui/src/api/client-cloud-steward-token.test.ts
@@ -125,9 +125,9 @@ describe("resolveDirectCloudWebBase / resolveDirectCloudAuthApiBase", () => {
   });
 
   it("maps a staging API host to the staging web host", () => {
-    expect(
-      resolveDirectCloudWebBase("https://api-staging.elizacloud.ai"),
-    ).toBe("https://staging.elizacloud.ai");
+    expect(resolveDirectCloudWebBase("https://api-staging.elizacloud.ai")).toBe(
+      "https://staging.elizacloud.ai",
+    );
   });
 
   it("passes through an unmapped host unchanged (trailing slash trimmed)", () => {

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -131,11 +131,6 @@ type DirectCloudAgent = {
   execution_tier?: string | null;
 };
 
-type CloudCompatAgentWithExecutionTier = CloudCompatAgent & {
-  /** Server-authoritative runtime placement. Older compat responses may omit it. */
-  execution_tier?: string | null;
-};
-
 type DirectCloudJob = {
   id?: string;
   jobId?: string;
@@ -912,9 +907,7 @@ function parseDirectCloudAgentCreateData(
   };
 }
 
-function toCloudCompatAgent(
-  input: DirectCloudAgent,
-): CloudCompatAgentWithExecutionTier {
+function toCloudCompatAgent(input: DirectCloudAgent): CloudCompatAgent {
   const id = stringOrNull(input.agentId) ?? requireString(input.id, "agent id");
   const agentName =
     stringOrNull(input.agentName) ?? stringOrNull(input.name) ?? id;
@@ -1227,7 +1220,7 @@ declare module "./client-base" {
     cloudDisconnect(): Promise<{ ok: boolean }>;
     getCloudCompatAgents(): Promise<{
       success: boolean;
-      data: CloudCompatAgentWithExecutionTier[];
+      data: CloudCompatAgent[];
       error?: string;
     }>;
     createCloudCompatAgent(opts: {
@@ -1281,7 +1274,7 @@ declare module "./client-base" {
     ): Promise<CloudCompatAgentProvisionResponse>;
     getCloudCompatAgent(agentId: string): Promise<{
       success: boolean;
-      data: CloudCompatAgentWithExecutionTier;
+      data: CloudCompatAgent;
     }>;
     getCloudCompatAgentManagedDiscord(agentId: string): Promise<{
       success: boolean;
@@ -3274,7 +3267,7 @@ export async function waitForCloudAgentRunning(
     timeoutMs?: number;
     onProgress?: (status: string, detail?: string) => void;
   },
-): Promise<CloudCompatAgentWithExecutionTier> {
+): Promise<CloudCompatAgent> {
   const { agentId, onProgress } = options;
   const pollIntervalMs = Math.max(
     50,
@@ -3341,11 +3334,11 @@ export async function waitForCloudAgentRunning(
  * deletion rows are unreusable.
  */
 function pickPreferredCloudAgent(
-  agents: CloudCompatAgentWithExecutionTier[],
+  agents: CloudCompatAgent[],
   preferAgentId?: string | null,
-): CloudCompatAgentWithExecutionTier | null {
+): CloudCompatAgent | null {
   if (!agents.length) return null;
-  const byNewest = (rows: CloudCompatAgentWithExecutionTier[]) =>
+  const byNewest = (rows: CloudCompatAgent[]) =>
     [...rows].sort((a, b) =>
       String(b.created_at).localeCompare(String(a.created_at)),
     );
@@ -3415,7 +3408,7 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
           // the error so the caller can retry rather than duplicate.
           return await this.getCloudCompatAgents().catch((cause) => ({
             success: false as const,
-            data: [] as CloudCompatAgentWithExecutionTier[],
+            data: [] as CloudCompatAgent[],
             error: cause instanceof Error ? cause.message : undefined,
           }));
         })();

--- a/packages/ui/src/components/chat/ChatWidgetHarness.tsx
+++ b/packages/ui/src/components/chat/ChatWidgetHarness.tsx
@@ -248,7 +248,7 @@ export function ChatWidgetHarness() {
             "max(var(--safe-area-top, 0px), env(safe-area-inset-top, 0px))",
         }}
       >
-        <header className="z-10 flex shrink-0 items-center gap-3 border-b border-border/60 bg-bg/70 px-4 py-3 backdrop-blur-2xl">
+        <header className="z-10 flex shrink-0 items-center gap-3 border-b border-border/60 bg-bg px-4 py-3">
           <div className="flex h-10 w-10 items-center justify-center rounded-full border border-white/15 bg-white/10 shadow-sm">
             <Sparkles className="h-4 w-4 text-accent" />
           </div>
@@ -295,7 +295,7 @@ export function ChatWidgetHarness() {
               />
             ))}
             {events.length > 0 ? (
-              <aside className="rounded-2xl border border-border/60 bg-surface/60 p-3 text-xs text-muted backdrop-blur-xl">
+              <aside className="rounded-2xl border border-border/60 bg-surface p-3 text-xs text-muted">
                 <div className="mb-1 font-medium text-txt">Interaction log</div>
                 {events.map((event) => (
                   <div key={event} className="truncate">
@@ -308,19 +308,19 @@ export function ChatWidgetHarness() {
         </section>
 
         <footer
-          className="shrink-0 border-t border-border/60 bg-bg/65 px-3 pt-3 backdrop-blur-2xl"
+          className="shrink-0 border-t border-border/60 bg-bg px-3 pt-3"
           style={{
             paddingBottom:
               "calc(max(var(--safe-area-bottom, 0px), env(safe-area-inset-bottom, 0px), var(--android-gesture-inset-bottom, 0px)) + 0.75rem)",
           }}
         >
-          <div className="mx-auto flex max-w-2xl items-end gap-2 rounded-[1.5rem] border border-white/15 bg-surface/75 p-2 shadow-lg backdrop-blur-2xl">
+          <div className="mx-auto flex max-w-2xl items-end gap-2 rounded-[1.5rem] border border-white/15 bg-surface p-2 shadow-lg">
             <Textarea
               value={draft}
               aria-label="Gallery message"
               placeholder="Type a local message…"
               rows={1}
-              className="min-h-11 flex-1 resize-none border-0 bg-transparent shadow-none focus-visible:ring-0"
+              className="min-h-11 flex-1 resize-none border-0 bg-transparent shadow-none"
               onChange={(event) => setDraft(event.target.value)}
               onKeyDown={(event) => {
                 if (event.key === "Enter" && !event.shiftKey) {

--- a/packages/ui/src/components/cockpit/CockpitNewSessionForm.test.tsx
+++ b/packages/ui/src/components/cockpit/CockpitNewSessionForm.test.tsx
@@ -116,6 +116,20 @@ describe("CockpitNewSessionForm", () => {
     expect(screen.getByTestId("cockpit-repo-input")).toBeTruthy();
   });
 
+  it("keeps optional labels and repo guidance at accessible contrast", () => {
+    render(<CockpitNewSessionForm onCreate={vi.fn()} />);
+
+    for (const optionalLabel of screen.getAllByText("(optional)")) {
+      expect(optionalLabel.className).toContain("text-muted");
+      expect(optionalLabel.className).not.toContain("text-muted/70");
+    }
+    const guidance = screen.getByText(
+      "Leave blank to run in a scratch workspace.",
+    );
+    expect(guidance.className).toContain("text-muted");
+    expect(guidance.className).not.toContain("text-muted/70");
+  });
+
   it("reflects a mode switch in the submitted policy", async () => {
     const user = userEvent.setup();
     const onCreate = vi.fn();

--- a/packages/ui/src/components/cockpit/CockpitNewSessionForm.tsx
+++ b/packages/ui/src/components/cockpit/CockpitNewSessionForm.tsx
@@ -121,7 +121,7 @@ export function CockpitNewSessionForm({
 
       <label htmlFor="cockpit-repo-input" className="flex flex-col gap-1.5">
         <span className="text-xs font-semibold text-muted">
-          Repo <span className="font-normal text-muted/70">(optional)</span>
+          Repo <span className="font-normal text-muted">(optional)</span>
         </span>
         <Input
           id="cockpit-repo-input"
@@ -142,7 +142,7 @@ export function CockpitNewSessionForm({
             ))}
           </datalist>
         ) : null}
-        <span className="text-[11px] text-muted/70">
+        <span className="text-[11px] text-muted">
           {repoSuggestionsUnavailable
             ? "Repo suggestions are unavailable. Enter a repo manually or leave blank for a scratch workspace."
             : "Leave blank to run in a scratch workspace."}
@@ -152,7 +152,7 @@ export function CockpitNewSessionForm({
       <label htmlFor="cockpit-workdir-input" className="flex flex-col gap-1.5">
         <span className="text-xs font-semibold text-muted">
           Working directory{" "}
-          <span className="font-normal text-muted/70">(optional)</span>
+          <span className="font-normal text-muted">(optional)</span>
         </span>
         <Input
           id="cockpit-workdir-input"

--- a/packages/ui/src/hooks/useVoiceChat.playback-grace.test.tsx
+++ b/packages/ui/src/hooks/useVoiceChat.playback-grace.test.tsx
@@ -114,44 +114,46 @@ function installMocks() {
   cloudTtsHardFailure = false;
   elevenlabsProxyStatus = 200;
   fetchedUrls.length = 0;
-  fetchWithCsrf.mockImplementation(async (input: unknown, init?: RequestInit) => {
-    const url = typeof input === "string" ? input : String(input);
-    fetchedUrls.push(url);
-    if (url.includes("/api/tts/cloud")) {
-      if (cloudTtsHardFailure) {
-        return new Response("internal error", { status: 500 });
+  fetchWithCsrf.mockImplementation(
+    async (input: unknown, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : String(input);
+      fetchedUrls.push(url);
+      if (url.includes("/api/tts/cloud")) {
+        if (cloudTtsHardFailure) {
+          return new Response("internal error", { status: 500 });
+        }
+        if (cloudTtsStatus !== 200) {
+          return new Response("blocked", { status: cloudTtsStatus });
+        }
+        return new Response(new Uint8Array([1, 2, 3, 4]).buffer, {
+          status: 200,
+          headers: { "content-type": "audio/wav" },
+        });
       }
-      if (cloudTtsStatus !== 200) {
-        return new Response("blocked", { status: cloudTtsStatus });
+      if (url.includes("/api/tts/elevenlabs")) {
+        if (elevenlabsProxyStatus !== 200) {
+          return new Response("unavailable", { status: elevenlabsProxyStatus });
+        }
+        return new Response(new Uint8Array([1, 2, 3, 4]).buffer, {
+          status: 200,
+          headers: { "content-type": "audio/mpeg" },
+        });
       }
-      return new Response(new Uint8Array([1, 2, 3, 4]).buffer, {
-        status: 200,
-        headers: { "content-type": "audio/wav" },
-      });
-    }
-    if (url.includes("/api/tts/elevenlabs")) {
-      if (elevenlabsProxyStatus !== 200) {
-        return new Response("unavailable", { status: elevenlabsProxyStatus });
+      if (url.includes("/api/tts/local-inference")) {
+        return new Response(new Uint8Array([1, 2, 3, 4]).buffer, {
+          status: 200,
+          headers: { "content-type": "audio/wav" },
+        });
       }
-      return new Response(new Uint8Array([1, 2, 3, 4]).buffer, {
-        status: 200,
-        headers: { "content-type": "audio/mpeg" },
-      });
-    }
-    if (url.includes("/api/tts/local-inference")) {
-      return new Response(new Uint8Array([1, 2, 3, 4]).buffer, {
-        status: 200,
-        headers: { "content-type": "audio/wav" },
-      });
-    }
-    if (url.includes("/api/voice/playback-frames")) {
-      playbackFrameBodies.push(
-        JSON.parse(String(init?.body)) as PlaybackFramesBody,
-      );
-      return new Response(null, { status: 204 });
-    }
-    return new Response("unexpected endpoint", { status: 404 });
-  });
+      if (url.includes("/api/voice/playback-frames")) {
+        playbackFrameBodies.push(
+          JSON.parse(String(init?.body)) as PlaybackFramesBody,
+        );
+        return new Response(null, { status: 204 });
+      }
+      return new Response("unexpected endpoint", { status: 404 });
+    },
+  );
   Object.defineProperty(globalThis, "AudioContext", {
     configurable: true,
     value: FakeAudioContext,
@@ -272,9 +274,9 @@ describe("useVoiceChat playback is decoupled from the visualizer worklet (#16102
     // Finishing playback stops the tap with reset so the far-end reference
     // stream is cleared for the next utterance.
     await waitFor(() => {
-      expect(
-        playbackFrameBodies.some((body) => body.reset === true),
-      ).toBe(true);
+      expect(playbackFrameBodies.some((body) => body.reset === true)).toBe(
+        true,
+      );
     });
   });
 
@@ -309,9 +311,9 @@ describe("useVoiceChat playback is decoupled from the visualizer worklet (#16102
       expect(result.current.isSpeaking).toBe(false);
     });
     await waitFor(() => {
-      expect(
-        playbackFrameBodies.some((body) => body.reset === true),
-      ).toBe(true);
+      expect(playbackFrameBodies.some((body) => body.reset === true)).toBe(
+        true,
+      );
     });
   });
 
@@ -341,9 +343,9 @@ describe("useVoiceChat playback is decoupled from the visualizer worklet (#16102
       expect(result.current.isSpeaking).toBe(false);
     });
     await waitFor(() => {
-      expect(
-        playbackFrameBodies.some((body) => body.reset === true),
-      ).toBe(true);
+      expect(playbackFrameBodies.some((body) => body.reset === true)).toBe(
+        true,
+      );
     });
   });
 
@@ -366,9 +368,9 @@ describe("useVoiceChat playback is decoupled from the visualizer worklet (#16102
     expect(fetchedUrls.some((url) => url.includes("/api/tts/cloud"))).toBe(
       true,
     );
-    expect(
-      fetchedUrls.some((url) => url.includes("/api/tts/elevenlabs")),
-    ).toBe(true);
+    expect(fetchedUrls.some((url) => url.includes("/api/tts/elevenlabs"))).toBe(
+      true,
+    );
 
     await act(async () => {
       createdSources[0]?.onended?.();
@@ -448,9 +450,7 @@ describe("useVoiceChat playback is decoupled from the visualizer worklet (#16102
     });
 
     act(() => {
-      result.current.speak(
-        "hello total failure, a phrase unique to this test",
-      );
+      result.current.speak("hello total failure, a phrase unique to this test");
     });
 
     await waitFor(() => {
@@ -480,7 +480,8 @@ describe("useVoiceChat playback is decoupled from the visualizer worklet (#16102
     await waitFor(() => expect(result.current.isSpeaking).toBe(false));
 
     const fetchCountAfterFirstSpeak = fetchedUrls.filter(
-      (url) => url.includes("/api/tts/cloud") || url.includes("/api/tts/elevenlabs"),
+      (url) =>
+        url.includes("/api/tts/cloud") || url.includes("/api/tts/elevenlabs"),
     ).length;
     expect(fetchCountAfterFirstSpeak).toBeGreaterThan(0);
 

--- a/packages/ui/src/state/persistence-cloud-active-server.test.ts
+++ b/packages/ui/src/state/persistence-cloud-active-server.test.ts
@@ -211,7 +211,7 @@ describe("Cloud active server persistence", () => {
     );
   });
 
-  it("repairs a stale shared-adapter cloud active server back to the dedicated runtime on restore", async () => {
+  it("preserves a shared adapter until server-authoritative tier selection", async () => {
     const server = createPersistedActiveServer({
       kind: "cloud",
       id: "cloud:agent-dedicated",
@@ -228,7 +228,8 @@ describe("Cloud active server persistence", () => {
       clientRef: { setBaseUrl, setToken },
     });
 
-    const expectedApiBase = "https://agent-dedicated.elizacloud.ai";
+    const expectedApiBase =
+      "https://api.elizacloud.ai/api/v1/eliza/agents/agent-dedicated";
     expect(setBaseUrl).toHaveBeenCalledWith(expectedApiBase);
     expect(setToken).toHaveBeenCalledWith("cloud-token");
     expect(loadPersistedActiveServer()).toEqual(

--- a/packages/ui/src/voice/__tests__/voice-session-client.test.ts
+++ b/packages/ui/src/voice/__tests__/voice-session-client.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   createVoiceSessionClient,
@@ -8,9 +8,14 @@ import {
 import {
   FakeMicAudioContext,
   FakePlaybackAudioContext,
+  FakeWebSocket,
   fakeGetUserMedia,
   makeWsFactory,
 } from "./voice-session-fakes";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 interface MintOverrides {
   token?: string;
@@ -25,7 +30,9 @@ function makeMintFetch(overrides: MintOverrides[] = []) {
   const calls: Array<Record<string, unknown>> = [];
   let n = 0;
   const fetch = async (_url: string, init?: RequestInit): Promise<Response> => {
-    const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+    const body = init?.body
+      ? (JSON.parse(String(init.body)) as Record<string, unknown>)
+      : {};
     calls.push(body);
     const o = overrides[n] ?? {};
     n += 1;
@@ -49,7 +56,10 @@ function makeMintFetch(overrides: MintOverrides[] = []) {
   return { fetch, calls };
 }
 
-function baseDeps(mintFetch: ReturnType<typeof makeMintFetch>, ws: ReturnType<typeof makeWsFactory>) {
+function baseDeps(
+  mintFetch: ReturnType<typeof makeMintFetch>,
+  ws: ReturnType<typeof makeWsFactory>,
+) {
   const marks: VoiceTraceMark[] = [];
   const errors: Error[] = [];
   let t = 0;
@@ -77,7 +87,77 @@ async function flush(): Promise<void> {
   await Promise.resolve();
 }
 
+function playbackScriptNodeOf(ctx: FakePlaybackAudioContext) {
+  const node = ctx.scriptNode;
+  if (!node) throw new Error("no playback script node created");
+  return node;
+}
+
 describe("voice-session client (real framing/state/barge-in/reconnect)", () => {
+  it("constructs and validates the native WebSocket when no factory is injected", async () => {
+    class NativeWebSocket extends FakeWebSocket {
+      static readonly instances: NativeWebSocket[] = [];
+
+      constructor(url: string) {
+        super(url);
+        NativeWebSocket.instances.push(this);
+      }
+    }
+    vi.stubGlobal("WebSocket", NativeWebSocket);
+    const mint = makeMintFetch();
+    const errors: Error[] = [];
+    const client = createVoiceSessionClient({
+      agentId: "11111111-1111-1111-1111-111111111111",
+      conversationId: "22222222-2222-2222-2222-222222222222",
+      consentNonce: "native-ws",
+      fetch: mint.fetch,
+      getUserMedia: fakeGetUserMedia(),
+      createMicAudioContext: () => new FakeMicAudioContext(16_000),
+      createPlaybackAudioContext: () => new FakePlaybackAudioContext(16_000),
+      onError: (error) => errors.push(error),
+    });
+
+    await client.start();
+    await flush();
+    const socket = NativeWebSocket.instances[0];
+    expect(socket?.url).toBe(
+      "wss://cloud/api/v1/voice/session/ws?sessionId=sess-1",
+    );
+    expect(socket?.binaryType).toBe("arraybuffer");
+    socket?.emitOpen();
+    expect(socket?.sentControls()[0]).toMatchObject({
+      t: "hello",
+      token: "tok-1",
+    });
+    expect(errors).toEqual([]);
+    await client.stop();
+  });
+
+  it("rejects a malformed native WebSocket runtime", async () => {
+    class InvalidWebSocket {}
+    vi.stubGlobal("WebSocket", InvalidWebSocket);
+    const mint = makeMintFetch();
+    const errors: Error[] = [];
+    const client = createVoiceSessionClient({
+      agentId: "11111111-1111-1111-1111-111111111111",
+      conversationId: "22222222-2222-2222-2222-222222222222",
+      consentNonce: "invalid-native-ws",
+      fetch: mint.fetch,
+      getUserMedia: fakeGetUserMedia(),
+      createMicAudioContext: () => new FakeMicAudioContext(16_000),
+      createPlaybackAudioContext: () => new FakePlaybackAudioContext(16_000),
+      onError: (error) => errors.push(error),
+    });
+
+    await client.start();
+    await flush();
+
+    expect(
+      errors.some((error) => /required voice API/.test(error.message)),
+    ).toBe(true);
+    await client.stop();
+  });
+
   it("enforces hello-first: the FIRST frame sent is a JSON hello carrying the token", async () => {
     const mint = makeMintFetch();
     const ws = makeWsFactory();
@@ -190,7 +270,7 @@ describe("voice-session client (real framing/state/barge-in/reconnect)", () => {
     // Optimistic state: speaking → listening pre-ack.
     expect(client.state.phase).toBe("listening");
     // Playback queue is empty already → a pull yields pure silence.
-    const outPreAck = pbCtx.scriptNode!.render(100);
+    const outPreAck = playbackScriptNodeOf(pbCtx).render(100);
     expect(outPreAck.every((v) => v === 0)).toBe(true);
     // barge_in control frame was sent to the server.
     expect(sock.sentControls().some((c) => c.t === "barge_in")).toBe(true);
@@ -366,7 +446,13 @@ describe("voice-session client (real framing/state/barge-in/reconnect)", () => {
     });
     await client.start();
     await flush();
-    expect(errors.some((e) => e instanceof VoiceSessionMintError && (e as VoiceSessionMintError).status === 404)).toBe(true);
+    expect(
+      errors.some(
+        (e) =>
+          e instanceof VoiceSessionMintError &&
+          (e as VoiceSessionMintError).status === 404,
+      ),
+    ).toBe(true);
     // No socket ever opened.
     expect(ws.sockets.length).toBe(0);
   });

--- a/packages/ui/src/voice/__tests__/voice-session-client.test.ts
+++ b/packages/ui/src/voice/__tests__/voice-session-client.test.ts
@@ -134,7 +134,14 @@ describe("voice-session client (real framing/state/barge-in/reconnect)", () => {
   });
 
   it("rejects a malformed native WebSocket runtime", async () => {
-    class InvalidWebSocket {}
+    class InvalidWebSocket {
+      static latest: InvalidWebSocket | null = null;
+      readonly close = vi.fn();
+
+      constructor() {
+        InvalidWebSocket.latest = this;
+      }
+    }
     vi.stubGlobal("WebSocket", InvalidWebSocket);
     const mint = makeMintFetch();
     const errors: Error[] = [];
@@ -155,6 +162,7 @@ describe("voice-session client (real framing/state/barge-in/reconnect)", () => {
     expect(
       errors.some((error) => /required voice API/.test(error.message)),
     ).toBe(true);
+    expect(InvalidWebSocket.latest?.close).toHaveBeenCalledTimes(1);
     await client.stop();
   });
 

--- a/packages/ui/src/voice/__tests__/voice-session-fakes.ts
+++ b/packages/ui/src/voice/__tests__/voice-session-fakes.ts
@@ -6,17 +6,19 @@
  * barge-in / reconnect / PCM code — never a stub of the thing under test.
  */
 
+import type { VoiceWebSocketLike } from "../voice-session-client";
 import type {
-  MicAudioContextLike,
   AudioNodeLike,
+  AudioWorkletNodeLike,
+  MicAudioContextLike,
   ScriptProcessorNodeLike,
 } from "../voice-session-mic-capture";
 import type {
   PlaybackAudioContextLike,
   PlaybackNodeLike,
   PlaybackScriptNodeLike,
+  PlaybackWorkletNodeLike,
 } from "../voice-session-playback";
-import type { VoiceWebSocketLike } from "../voice-session-client";
 
 // ── Fake WebSocket ─────────────────────────────────────────────────────
 
@@ -54,10 +56,19 @@ export class FakeWebSocket implements VoiceWebSocketLike {
   }
 
   addEventListener(type: "open", listener: () => void): void;
-  addEventListener(type: "message", listener: (e: { data: unknown }) => void): void;
-  addEventListener(type: "close", listener: (e: { code?: number; reason?: string }) => void): void;
+  addEventListener(
+    type: "message",
+    listener: (e: { data: unknown }) => void,
+  ): void;
+  addEventListener(
+    type: "close",
+    listener: (e: { code?: number; reason?: string }) => void,
+  ): void;
   addEventListener(type: "error", listener: () => void): void;
-  addEventListener(type: keyof Listeners, listener: (...args: never[]) => void): void {
+  addEventListener(
+    type: keyof Listeners,
+    listener: (...args: never[]) => void,
+  ): void {
     (this.listeners[type] as Array<(...a: never[]) => void>).push(listener);
   }
 
@@ -92,7 +103,9 @@ export class FakeWebSocket implements VoiceWebSocketLike {
   }
   /** Count of binary uplink frames sent. */
   sentAudioCount(): number {
-    return this.sent.filter((d) => d instanceof ArrayBuffer || ArrayBuffer.isView(d)).length;
+    return this.sent.filter(
+      (d) => d instanceof ArrayBuffer || ArrayBuffer.isView(d),
+    ).length;
   }
 }
 
@@ -117,16 +130,45 @@ export function makeWsFactory(): {
 // ── Fake node ──
 
 class FakeNode implements AudioNodeLike, PlaybackNodeLike {
-  connect(target: AudioNodeLike & PlaybackNodeLike): AudioNodeLike & PlaybackNodeLike {
+  connect(
+    target: AudioNodeLike & PlaybackNodeLike,
+  ): AudioNodeLike & PlaybackNodeLike {
     return target;
   }
   disconnect(): void {}
 }
 
+/** Shared constructor double installed as the browser AudioWorkletNode. */
+export class FakeVoiceAudioWorkletNode
+  extends FakeNode
+  implements AudioWorkletNodeLike, PlaybackWorkletNodeLike
+{
+  static readonly instances: FakeVoiceAudioWorkletNode[] = [];
+  readonly postedMessages: unknown[] = [];
+  readonly port = {
+    onmessage: null as ((event: { data: unknown }) => void) | null,
+    postMessage: (data: unknown): void => {
+      this.postedMessages.push(data);
+    },
+  };
+
+  constructor(
+    readonly context: unknown,
+    readonly processorName: string,
+  ) {
+    super();
+    FakeVoiceAudioWorkletNode.instances.push(this);
+  }
+
+  static reset(): void {
+    FakeVoiceAudioWorkletNode.instances.length = 0;
+  }
+}
+
 // ── Fake mic AudioContext (ScriptProcessor path — WebView 113) ─────────
 
 export class FakeMicAudioContext implements MicAudioContextLike {
-  state: "suspended" | "running" | "closed" = "suspended";
+  state: AudioContextState = "suspended";
   readonly destination = new FakeNode();
   scriptNode: FakeScriptProcessor | null = null;
   closed = false;
@@ -152,6 +194,16 @@ export class FakeMicAudioContext implements MicAudioContextLike {
   }
 }
 
+/** Fake mic context that selects the AudioWorklet path and records its URL. */
+export class FakeMicWorkletAudioContext extends FakeMicAudioContext {
+  readonly moduleUrls: string[] = [];
+  readonly audioWorklet = {
+    addModule: async (url: string): Promise<void> => {
+      this.moduleUrls.push(url);
+    },
+  };
+}
+
 class FakeScriptProcessor extends FakeNode implements ScriptProcessorNodeLike {
   onaudioprocess:
     | ((event: {
@@ -170,7 +222,7 @@ class FakeScriptProcessor extends FakeNode implements ScriptProcessorNodeLike {
 // ── Fake playback AudioContext (ScriptProcessor path) ──────────────────
 
 export class FakePlaybackAudioContext implements PlaybackAudioContextLike {
-  state: "suspended" | "running" | "closed" = "suspended";
+  state: AudioContextState = "suspended";
   readonly destination = new FakeNode();
   scriptNode: FakePlaybackScriptNode | null = null;
   closed = false;
@@ -189,7 +241,20 @@ export class FakePlaybackAudioContext implements PlaybackAudioContextLike {
   }
 }
 
-export class FakePlaybackScriptNode extends FakeNode implements PlaybackScriptNodeLike {
+/** Fake playback context that selects AudioWorklet and records its URL. */
+export class FakePlaybackWorkletAudioContext extends FakePlaybackAudioContext {
+  readonly moduleUrls: string[] = [];
+  readonly audioWorklet = {
+    addModule: async (url: string): Promise<void> => {
+      this.moduleUrls.push(url);
+    },
+  };
+}
+
+export class FakePlaybackScriptNode
+  extends FakeNode
+  implements PlaybackScriptNodeLike
+{
   onaudioprocess:
     | ((event: {
         outputBuffer: {
@@ -217,14 +282,18 @@ export class FakePlaybackScriptNode extends FakeNode implements PlaybackScriptNo
 
 // ── Fake getUserMedia ──────────────────────────────────────────────────
 
-export function fakeGetUserMedia(): (c: MediaStreamConstraints) => Promise<MediaStream> {
+export function fakeGetUserMedia(): (
+  c: MediaStreamConstraints,
+) => Promise<MediaStream> {
   return async () =>
     ({
       getTracks: () => [{ stop() {} }],
     }) as unknown as MediaStream;
 }
 
-export function deniedGetUserMedia(): (c: MediaStreamConstraints) => Promise<MediaStream> {
+export function deniedGetUserMedia(): (
+  c: MediaStreamConstraints,
+) => Promise<MediaStream> {
   return async () => {
     const err = new Error("denied");
     (err as { name?: string }).name = "NotAllowedError";

--- a/packages/ui/src/voice/__tests__/voice-session-mic-capture.test.ts
+++ b/packages/ui/src/voice/__tests__/voice-session-mic-capture.test.ts
@@ -77,6 +77,83 @@ describe("voice-session mic capture (ScriptProcessor fallback path — WebView 1
     await capture.stop();
   });
 
+  it("releases the mic graph when the static AudioWorklet module fails to load", async () => {
+    vi.stubGlobal("AudioWorkletNode", FakeVoiceAudioWorkletNode);
+    const ctx = new FakeMicWorkletAudioContext(16_000);
+    const disconnect = vi.fn();
+    ctx.createMediaStreamSource = () => ({
+      connect: vi.fn(),
+      disconnect,
+    });
+    Object.defineProperty(ctx, "audioWorklet", {
+      value: {
+        addModule: vi.fn(async () => {
+          throw new Error("worklet asset unavailable");
+        }),
+      },
+    });
+    const stopTrack = vi.fn();
+    const getUserMedia = async () =>
+      ({ getTracks: () => [{ stop: stopTrack }] }) as unknown as MediaStream;
+
+    await expect(
+      startVoiceMicCapture({
+        onFrame: () => {},
+        getUserMedia,
+        createAudioContext: () => ctx,
+        visibility: {
+          addListener() {},
+          removeListener() {},
+          isHidden: () => false,
+        },
+      }),
+    ).rejects.toMatchObject({
+      name: "VoiceMicCaptureError",
+      code: "start_failed",
+    });
+
+    expect(disconnect).toHaveBeenCalledTimes(1);
+    expect(stopTrack).toHaveBeenCalledTimes(1);
+    expect(ctx.closed).toBe(true);
+  });
+
+  it("stops the mic track when AudioContext construction fails", async () => {
+    const stopTrack = vi.fn();
+    const getUserMedia = async () =>
+      ({ getTracks: () => [{ stop: stopTrack }] }) as unknown as MediaStream;
+
+    await expect(
+      startVoiceMicCapture({
+        onFrame: () => {},
+        getUserMedia,
+        createAudioContext: () => {
+          throw new Error("AudioContext constructor failed");
+        },
+      }),
+    ).rejects.toMatchObject({ code: "start_failed" });
+    expect(stopTrack).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops the mic track and closes the context when source creation fails", async () => {
+    const stopTrack = vi.fn();
+    const getUserMedia = async () =>
+      ({ getTracks: () => [{ stop: stopTrack }] }) as unknown as MediaStream;
+    const ctx = new FakeMicAudioContext(16_000);
+    ctx.createMediaStreamSource = () => {
+      throw new Error("media source failed");
+    };
+
+    await expect(
+      startVoiceMicCapture({
+        onFrame: () => {},
+        getUserMedia,
+        createAudioContext: () => ctx,
+      }),
+    ).rejects.toMatchObject({ code: "start_failed" });
+    expect(stopTrack).toHaveBeenCalledTimes(1);
+    expect(ctx.closed).toBe(true);
+  });
+
   it("uses the ScriptProcessor backend when AudioWorklet is absent", async () => {
     const ctx = new FakeMicAudioContext(16_000);
     const frames: Uint8Array[] = [];

--- a/packages/ui/src/voice/__tests__/voice-session-mic-capture.test.ts
+++ b/packages/ui/src/voice/__tests__/voice-session-mic-capture.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { VOICE_SESSION_UPLINK_WORKLET_MODULE_URL } from "../audio-worklet-module-urls";
+import { resolveAudioWorkletModuleUrl } from "../audio-worklet-module-urls";
 import {
   startVoiceMicCapture,
   VoiceMicCaptureError,
@@ -69,7 +69,7 @@ describe("voice-session mic capture (ScriptProcessor fallback path — WebView 1
     });
 
     expect(capture.backend).toBe("audioworklet");
-    expect(ctx.moduleUrls).toEqual([VOICE_SESSION_UPLINK_WORKLET_MODULE_URL]);
+    expect(ctx.moduleUrls).toEqual([resolveAudioWorkletModuleUrl("uplink")]);
     expect(ctx.moduleUrls[0]).not.toMatch(/^(?:blob|data):/);
     expect(FakeVoiceAudioWorkletNode.instances[0]?.processorName).toBe(
       "eliza-voice-session-uplink",

--- a/packages/ui/src/voice/__tests__/voice-session-mic-capture.test.ts
+++ b/packages/ui/src/voice/__tests__/voice-session-mic-capture.test.ts
@@ -1,15 +1,18 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { VOICE_SESSION_UPLINK_WORKLET_MODULE_URL } from "../audio-worklet-module-urls";
 import {
   startVoiceMicCapture,
   VoiceMicCaptureError,
 } from "../voice-session-mic-capture";
-import {
-  FakeMicAudioContext,
-  fakeGetUserMedia,
-  deniedGetUserMedia,
-} from "./voice-session-fakes";
 import { int16BytesToFloatPcm } from "../voice-session-pcm";
+import {
+  deniedGetUserMedia,
+  FakeMicAudioContext,
+  FakeMicWorkletAudioContext,
+  FakeVoiceAudioWorkletNode,
+  fakeGetUserMedia,
+} from "./voice-session-fakes";
 
 /** Grab the fake ScriptProcessor once the graph is built. */
 function scriptNodeOf(ctx: FakeMicAudioContext) {
@@ -18,7 +21,62 @@ function scriptNodeOf(ctx: FakeMicAudioContext) {
   return node;
 }
 
+afterEach(() => {
+  vi.unstubAllGlobals();
+  FakeVoiceAudioWorkletNode.reset();
+});
+
 describe("voice-session mic capture (ScriptProcessor fallback path — WebView 113)", () => {
+  it("accepts and resumes an interrupted native AudioContext", async () => {
+    class NativeMicAudioContext extends FakeMicAudioContext {
+      static latest: NativeMicAudioContext | null = null;
+
+      constructor() {
+        super(16_000);
+        this.state = "interrupted";
+        NativeMicAudioContext.latest = this;
+      }
+    }
+    vi.stubGlobal("window", { AudioContext: NativeMicAudioContext });
+
+    const capture = await startVoiceMicCapture({
+      onFrame: () => {},
+      getUserMedia: fakeGetUserMedia(),
+      visibility: {
+        addListener() {},
+        removeListener() {},
+        isHidden: () => false,
+      },
+    });
+
+    expect(NativeMicAudioContext.latest?.state).toBe("running");
+    expect(capture.backend).toBe("scriptprocessor");
+    await capture.stop();
+  });
+
+  it("loads the uplink AudioWorklet from its static CSP-compatible URL", async () => {
+    vi.stubGlobal("AudioWorkletNode", FakeVoiceAudioWorkletNode);
+    const ctx = new FakeMicWorkletAudioContext(16_000);
+    const capture = await startVoiceMicCapture({
+      onFrame: () => {},
+      getUserMedia: fakeGetUserMedia(),
+      createAudioContext: () => ctx,
+      visibility: {
+        addListener() {},
+        removeListener() {},
+        isHidden: () => false,
+      },
+    });
+
+    expect(capture.backend).toBe("audioworklet");
+    expect(ctx.moduleUrls).toEqual([VOICE_SESSION_UPLINK_WORKLET_MODULE_URL]);
+    expect(ctx.moduleUrls[0]).not.toMatch(/^(?:blob|data):/);
+    expect(FakeVoiceAudioWorkletNode.instances[0]?.processorName).toBe(
+      "eliza-voice-session-uplink",
+    );
+    await capture.stop();
+  });
+
   it("uses the ScriptProcessor backend when AudioWorklet is absent", async () => {
     const ctx = new FakeMicAudioContext(16_000);
     const frames: Uint8Array[] = [];
@@ -27,7 +85,11 @@ describe("voice-session mic capture (ScriptProcessor fallback path — WebView 1
       frameMs: 100, // 1600 samples/frame @16k
       getUserMedia: fakeGetUserMedia(),
       createAudioContext: () => ctx,
-      visibility: { addListener() {}, removeListener() {}, isHidden: () => false },
+      visibility: {
+        addListener() {},
+        removeListener() {},
+        isHidden: () => false,
+      },
     });
     expect(capture.backend).toBe("scriptprocessor");
     expect(ctx.state).toBe("running"); // resumed on start
@@ -43,7 +105,11 @@ describe("voice-session mic capture (ScriptProcessor fallback path — WebView 1
       frameMs: 100, // 1600 samples → 3200 bytes/frame
       getUserMedia: fakeGetUserMedia(),
       createAudioContext: () => ctx,
-      visibility: { addListener() {}, removeListener() {}, isHidden: () => false },
+      visibility: {
+        addListener() {},
+        removeListener() {},
+        isHidden: () => false,
+      },
     });
     const node = scriptNodeOf(ctx);
     // Feed 4096 samples (one ScriptProcessor block). At 16k, no resample.
@@ -66,7 +132,11 @@ describe("voice-session mic capture (ScriptProcessor fallback path — WebView 1
       frameMs: 100,
       getUserMedia: fakeGetUserMedia(),
       createAudioContext: () => ctx,
-      visibility: { addListener() {}, removeListener() {}, isHidden: () => false },
+      visibility: {
+        addListener() {},
+        removeListener() {},
+        isHidden: () => false,
+      },
     });
     const node = scriptNodeOf(ctx);
     // 9600 samples @48k ≈ 3200 samples @16k → two 1600-sample frames.
@@ -134,7 +204,11 @@ describe("voice-session mic capture (ScriptProcessor fallback path — WebView 1
         onFrame: () => {},
         getUserMedia: deniedGetUserMedia(),
         createAudioContext: () => new FakeMicAudioContext(),
-        visibility: { addListener() {}, removeListener() {}, isHidden: () => false },
+        visibility: {
+          addListener() {},
+          removeListener() {},
+          isHidden: () => false,
+        },
       }),
     ).rejects.toMatchObject({
       name: "VoiceMicCaptureError",
@@ -145,13 +219,18 @@ describe("voice-session mic capture (ScriptProcessor fallback path — WebView 1
   it("fails loud when neither AudioWorklet nor ScriptProcessor exists", async () => {
     const ctx = new FakeMicAudioContext(16_000);
     // Strip the ScriptProcessor factory to simulate a bare host.
-    (ctx as { createScriptProcessor?: unknown }).createScriptProcessor = undefined;
+    (ctx as { createScriptProcessor?: unknown }).createScriptProcessor =
+      undefined;
     await expect(
       startVoiceMicCapture({
         onFrame: () => {},
         getUserMedia: fakeGetUserMedia(),
         createAudioContext: () => ctx,
-        visibility: { addListener() {}, removeListener() {}, isHidden: () => false },
+        visibility: {
+          addListener() {},
+          removeListener() {},
+          isHidden: () => false,
+        },
       }),
     ).rejects.toBeInstanceOf(VoiceMicCaptureError);
   });

--- a/packages/ui/src/voice/__tests__/voice-session-pcm.test.ts
+++ b/packages/ui/src/voice/__tests__/voice-session-pcm.test.ts
@@ -48,7 +48,9 @@ describe("voice-session-pcm Float32↔Int16 correctness (golden vectors)", () =>
   });
 
   it("round-trips Float32 → Int16 bytes → Float32 within one quantization step", () => {
-    const original = Float32Array.from([0, 0.25, -0.25, 0.9, -0.9, 0.001, -0.001]);
+    const original = Float32Array.from([
+      0, 0.25, -0.25, 0.9, -0.9, 0.001, -0.001,
+    ]);
     const decoded = int16BytesToFloatPcm(floatPcmToInt16Bytes(original));
     expect(decoded.length).toBe(original.length);
     for (let i = 0; i < original.length; i += 1) {

--- a/packages/ui/src/voice/__tests__/voice-session-playback.test.ts
+++ b/packages/ui/src/voice/__tests__/voice-session-playback.test.ts
@@ -1,17 +1,75 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { createVoiceSessionPlayback } from "../voice-session-playback";
-import { FakePlaybackAudioContext } from "./voice-session-fakes";
+import { VOICE_SESSION_DOWNLINK_WORKLET_MODULE_URL } from "../audio-worklet-module-urls";
 import { floatPcmToInt16Bytes } from "../voice-session-pcm";
+import { createVoiceSessionPlayback } from "../voice-session-playback";
+import {
+  FakePlaybackAudioContext,
+  FakePlaybackWorkletAudioContext,
+  FakeVoiceAudioWorkletNode,
+} from "./voice-session-fakes";
 
 function pcmFrame(value: number, samples: number): Uint8Array {
   return floatPcmToInt16Bytes(new Float32Array(samples).fill(value));
 }
 
+function scriptNodeOf(ctx: FakePlaybackAudioContext) {
+  const node = ctx.scriptNode;
+  if (!node) throw new Error("no playback script node created");
+  return node;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  FakeVoiceAudioWorkletNode.reset();
+});
+
 describe("voice-session streaming PCM playback sink (ScriptProcessor path)", () => {
+  it("accepts and unlocks an interrupted native AudioContext", async () => {
+    class NativePlaybackAudioContext extends FakePlaybackAudioContext {
+      static latest: NativePlaybackAudioContext | null = null;
+      static options: AudioContextOptions | undefined;
+
+      constructor(options?: AudioContextOptions) {
+        super(16_000);
+        this.state = "interrupted";
+        NativePlaybackAudioContext.latest = this;
+        NativePlaybackAudioContext.options = options;
+      }
+    }
+    vi.stubGlobal("window", { AudioContext: NativePlaybackAudioContext });
+
+    const playback = await createVoiceSessionPlayback();
+    expect(playback.unlocked).toBe(false);
+    await playback.unlock();
+
+    expect(NativePlaybackAudioContext.latest?.state).toBe("running");
+    expect(NativePlaybackAudioContext.options?.sampleRate).toBe(16_000);
+    expect(playback.backend).toBe("scriptprocessor");
+    await playback.stop();
+  });
+
+  it("loads the downlink AudioWorklet from its static CSP-compatible URL", async () => {
+    vi.stubGlobal("AudioWorkletNode", FakeVoiceAudioWorkletNode);
+    const ctx = new FakePlaybackWorkletAudioContext();
+    const playback = await createVoiceSessionPlayback({
+      createAudioContext: () => ctx,
+    });
+
+    expect(playback.backend).toBe("audioworklet");
+    expect(ctx.moduleUrls).toEqual([VOICE_SESSION_DOWNLINK_WORKLET_MODULE_URL]);
+    expect(ctx.moduleUrls[0]).not.toMatch(/^(?:blob|data):/);
+    expect(FakeVoiceAudioWorkletNode.instances[0]?.processorName).toBe(
+      "eliza-voice-session-downlink",
+    );
+    await playback.stop();
+  });
+
   it("uses the ScriptProcessor backend when AudioWorklet is absent", async () => {
     const ctx = new FakePlaybackAudioContext();
-    const pb = await createVoiceSessionPlayback({ createAudioContext: () => ctx });
+    const pb = await createVoiceSessionPlayback({
+      createAudioContext: () => ctx,
+    });
     expect(pb.backend).toBe("scriptprocessor");
     await pb.stop();
     expect(ctx.closed).toBe(true);
@@ -19,12 +77,14 @@ describe("voice-session streaming PCM playback sink (ScriptProcessor path)", () 
 
   it("streams enqueued frames out in ORDER as the engine pulls (no full-clip barrier)", async () => {
     const ctx = new FakePlaybackAudioContext();
-    const pb = await createVoiceSessionPlayback({ createAudioContext: () => ctx });
+    const pb = await createVoiceSessionPlayback({
+      createAudioContext: () => ctx,
+    });
     await pb.unlock(); // → running
     // Enqueue two distinguishable frames.
     pb.enqueue(pcmFrame(0.5, 4));
     pb.enqueue(pcmFrame(-0.5, 4));
-    const node = ctx.scriptNode!;
+    const node = scriptNodeOf(ctx);
     const out = node.render(8); // pull all 8 samples
     // First 4 ≈ 0.5, next 4 ≈ -0.5 → ordering preserved.
     for (let i = 0; i < 4; i += 1) expect(out[i]).toBeCloseTo(0.5, 2);
@@ -34,18 +94,22 @@ describe("voice-session streaming PCM playback sink (ScriptProcessor path)", () 
 
   it("flush() empties the queue IMMEDIATELY (barge-in) → subsequent pulls are silence", async () => {
     const ctx = new FakePlaybackAudioContext();
-    const pb = await createVoiceSessionPlayback({ createAudioContext: () => ctx });
+    const pb = await createVoiceSessionPlayback({
+      createAudioContext: () => ctx,
+    });
     await pb.unlock();
     pb.enqueue(pcmFrame(0.9, 100));
     pb.flush();
-    const out = ctx.scriptNode!.render(50);
+    const out = scriptNodeOf(ctx).render(50);
     expect(out.every((v) => v === 0)).toBe(true);
     await pb.stop();
   });
 
   it("buffers frames before unlock and drains them on the user-gesture unlock (nothing dropped)", async () => {
     const ctx = new FakePlaybackAudioContext();
-    const pb = await createVoiceSessionPlayback({ createAudioContext: () => ctx });
+    const pb = await createVoiceSessionPlayback({
+      createAudioContext: () => ctx,
+    });
     // Suspended: enqueue must NOT drop; needsUnlock flips true.
     pb.enqueue(pcmFrame(0.5, 4));
     expect(pb.unlocked).toBe(false);
@@ -55,7 +119,7 @@ describe("voice-session streaming PCM playback sink (ScriptProcessor path)", () 
     await pb.unlock();
     expect(pb.unlocked).toBe(true);
     expect(pb.needsUnlock).toBe(false);
-    const out = ctx.scriptNode!.render(4);
+    const out = scriptNodeOf(ctx).render(4);
     for (let i = 0; i < 4; i += 1) expect(out[i]).toBeCloseTo(0.5, 2);
     await pb.stop();
   });
@@ -70,7 +134,7 @@ describe("voice-session streaming PCM playback sink (ScriptProcessor path)", () 
     await pb.unlock();
     pb.enqueue(pcmFrame(0.5, 2));
     // Pull more than enqueued → transitions to empty → onDrained fires once.
-    ctx.scriptNode!.render(8);
+    scriptNodeOf(ctx).render(8);
     expect(onDrained).toHaveBeenCalledTimes(1);
     await pb.stop();
   });

--- a/packages/ui/src/voice/__tests__/voice-session-playback.test.ts
+++ b/packages/ui/src/voice/__tests__/voice-session-playback.test.ts
@@ -65,6 +65,23 @@ describe("voice-session streaming PCM playback sink (ScriptProcessor path)", () 
     await playback.stop();
   });
 
+  it("closes the context when the static AudioWorklet module fails to load", async () => {
+    vi.stubGlobal("AudioWorkletNode", FakeVoiceAudioWorkletNode);
+    const ctx = new FakePlaybackWorkletAudioContext();
+    Object.defineProperty(ctx, "audioWorklet", {
+      value: {
+        addModule: vi.fn(async () => {
+          throw new Error("worklet asset unavailable");
+        }),
+      },
+    });
+
+    await expect(
+      createVoiceSessionPlayback({ createAudioContext: () => ctx }),
+    ).rejects.toThrow("worklet asset unavailable");
+    expect(ctx.closed).toBe(true);
+  });
+
   it("uses the ScriptProcessor backend when AudioWorklet is absent", async () => {
     const ctx = new FakePlaybackAudioContext();
     const pb = await createVoiceSessionPlayback({

--- a/packages/ui/src/voice/__tests__/voice-session-playback.test.ts
+++ b/packages/ui/src/voice/__tests__/voice-session-playback.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { VOICE_SESSION_DOWNLINK_WORKLET_MODULE_URL } from "../audio-worklet-module-urls";
+import { resolveAudioWorkletModuleUrl } from "../audio-worklet-module-urls";
 import { floatPcmToInt16Bytes } from "../voice-session-pcm";
 import { createVoiceSessionPlayback } from "../voice-session-playback";
 import {
@@ -57,7 +57,7 @@ describe("voice-session streaming PCM playback sink (ScriptProcessor path)", () 
     });
 
     expect(playback.backend).toBe("audioworklet");
-    expect(ctx.moduleUrls).toEqual([VOICE_SESSION_DOWNLINK_WORKLET_MODULE_URL]);
+    expect(ctx.moduleUrls).toEqual([resolveAudioWorkletModuleUrl("downlink")]);
     expect(ctx.moduleUrls[0]).not.toMatch(/^(?:blob|data):/);
     expect(FakeVoiceAudioWorkletNode.instances[0]?.processorName).toBe(
       "eliza-voice-session-downlink",

--- a/packages/ui/src/voice/__tests__/voice-session-state.test.ts
+++ b/packages/ui/src/voice/__tests__/voice-session-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-
+import type { ServerControlFrame } from "../voice-session-protocol";
 import {
   applyClientAction,
   applyServerEvent,
@@ -9,7 +9,6 @@ import {
   toContinuousStatus,
   type VoiceSessionMachineState,
 } from "../voice-session-state";
-import type { ServerControlFrame } from "../voice-session-protocol";
 
 function fresh(): VoiceSessionMachineState {
   return { ...INITIAL_VOICE_SESSION_STATE };
@@ -20,9 +19,9 @@ describe("voice-session-state machine (§7.4)", () => {
     const connecting = applyClientAction(fresh(), { type: "client/connect" });
     expect(connecting.phase).toBe("connecting");
     // A second connect from a non-idle phase does nothing.
-    expect(applyClientAction(connecting, { type: "client/connect" }).phase).toBe(
-      "connecting",
-    );
+    expect(
+      applyClientAction(connecting, { type: "client/connect" }).phase,
+    ).toBe("connecting");
   });
 
   it("drives the full server lifecycle sequence in order", () => {
@@ -74,14 +73,22 @@ describe("voice-session-state machine (§7.4)", () => {
   });
 
   it("local barge-in from a non-speaking phase is a no-op", () => {
-    const s = applyServerEvent(fresh(), { t: "ready", sessionId: "x", traceId: "T" });
+    const s = applyServerEvent(fresh(), {
+      t: "ready",
+      sessionId: "x",
+      traceId: "T",
+    });
     expect(applyClientAction(s, { type: "client/local_barge_in" }).phase).toBe(
       "ready",
     );
   });
 
   it("stt_eager_eot updates trace but does not jump phase", () => {
-    let s = applyServerEvent(fresh(), { t: "stt_partial", text: "a", traceId: "T3" });
+    let s = applyServerEvent(fresh(), {
+      t: "stt_partial",
+      text: "a",
+      traceId: "T3",
+    });
     s = applyServerEvent(s, { t: "stt_eager_eot", traceId: "T3" });
     expect(s.phase).toBe("transcribing");
     expect(s.traceId).toBe("T3");
@@ -93,7 +100,10 @@ describe("voice-session-state machine (§7.4)", () => {
       code: "invalid_token",
       retryable: false,
     });
-    expect(fatal.lastError).toEqual({ code: "invalid_token", retryable: false });
+    expect(fatal.lastError).toEqual({
+      code: "invalid_token",
+      retryable: false,
+    });
     const retry = applyServerEvent(fresh(), {
       t: "error",
       code: "audio_too_large",
@@ -103,7 +113,10 @@ describe("voice-session-state machine (§7.4)", () => {
   });
 
   it("usage events carry trace but never change phase", () => {
-    const speaking = applyServerEvent(fresh(), { t: "speaking_start", traceId: "T4" });
+    const speaking = applyServerEvent(fresh(), {
+      t: "speaking_start",
+      traceId: "T4",
+    });
     const after = applyServerEvent(speaking, {
       t: "usage",
       sttMs: 10,
@@ -115,7 +128,11 @@ describe("voice-session-state machine (§7.4)", () => {
   });
 
   it("beginListening only advances from ready/complete", () => {
-    const ready = applyServerEvent(fresh(), { t: "ready", sessionId: "x", traceId: "T" });
+    const ready = applyServerEvent(fresh(), {
+      t: "ready",
+      sessionId: "x",
+      traceId: "T",
+    });
     expect(beginListening(ready).phase).toBe("listening");
     expect(beginListening(fresh()).phase).toBe("idle"); // idle stays idle
   });

--- a/packages/ui/src/voice/audio-worklet-module-urls.test.ts
+++ b/packages/ui/src/voice/audio-worklet-module-urls.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+  PLAYBACK_REFERENCE_TAP_WORKLET_MODULE_URL,
+  VOICE_SESSION_DOWNLINK_WORKLET_MODULE_URL,
+  VOICE_SESSION_UPLINK_WORKLET_MODULE_URL,
+} from "./audio-worklet-module-urls";
+
+const voiceDirectory = dirname(fileURLToPath(import.meta.url));
+const uiPackageJsonPath = resolve(voiceDirectory, "../../package.json");
+const moduleUrlSourcePath = resolve(
+  voiceDirectory,
+  "audio-worklet-module-urls.ts",
+);
+
+const modules = [
+  {
+    url: VOICE_SESSION_UPLINK_WORKLET_MODULE_URL,
+    fileName: "voice-session-uplink.js",
+    processorName: "eliza-voice-session-uplink",
+  },
+  {
+    url: VOICE_SESSION_DOWNLINK_WORKLET_MODULE_URL,
+    fileName: "voice-session-downlink.js",
+    processorName: "eliza-voice-session-downlink",
+  },
+  {
+    url: PLAYBACK_REFERENCE_TAP_WORKLET_MODULE_URL,
+    fileName: "playback-reference-tap.js",
+    processorName: "eliza-playback-reference-tap",
+  },
+] as const;
+
+describe("AudioWorklet module assets", () => {
+  it.each(modules)("uses a CSP-compatible URL for $processorName", ({
+    url,
+    fileName,
+  }) => {
+    expect(url).not.toMatch(/^(?:blob|data):/);
+    expect(new URL(url).pathname).toContain(`/worklets/${fileName}`);
+  });
+
+  it.each(modules)("ships the $processorName processor as a static module", ({
+    fileName,
+    processorName,
+  }) => {
+    const source = readFileSync(
+      resolve(voiceDirectory, "worklets", fileName),
+      "utf8",
+    );
+    expect(source).toContain(`registerProcessor("${processorName}"`);
+  });
+
+  it("prevents Vite from inlining worklets and copies them into package dist", () => {
+    const moduleUrlSource = readFileSync(moduleUrlSourcePath, "utf8");
+    const packageJson = JSON.parse(readFileSync(uiPackageJsonPath, "utf8")) as {
+      scripts: { "build:dist:unlocked": string };
+    };
+
+    expect(moduleUrlSource.match(/\.js\?no-inline"/g)).toHaveLength(
+      modules.length,
+    );
+    expect(packageJson.scripts["build:dist:unlocked"]).toContain(
+      "src/voice/worklets",
+    );
+  });
+});

--- a/packages/ui/src/voice/audio-worklet-module-urls.test.ts
+++ b/packages/ui/src/voice/audio-worklet-module-urls.test.ts
@@ -3,11 +3,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
-import {
-  PLAYBACK_REFERENCE_TAP_WORKLET_MODULE_URL,
-  VOICE_SESSION_DOWNLINK_WORKLET_MODULE_URL,
-  VOICE_SESSION_UPLINK_WORKLET_MODULE_URL,
-} from "./audio-worklet-module-urls";
+import { resolveAudioWorkletModuleUrl } from "./audio-worklet-module-urls";
 
 const voiceDirectory = dirname(fileURLToPath(import.meta.url));
 const uiPackageJsonPath = resolve(voiceDirectory, "../../package.json");
@@ -18,17 +14,17 @@ const moduleUrlSourcePath = resolve(
 
 const modules = [
   {
-    url: VOICE_SESSION_UPLINK_WORKLET_MODULE_URL,
+    url: resolveAudioWorkletModuleUrl("uplink"),
     fileName: "voice-session-uplink.js",
     processorName: "eliza-voice-session-uplink",
   },
   {
-    url: VOICE_SESSION_DOWNLINK_WORKLET_MODULE_URL,
+    url: resolveAudioWorkletModuleUrl("downlink"),
     fileName: "voice-session-downlink.js",
     processorName: "eliza-voice-session-downlink",
   },
   {
-    url: PLAYBACK_REFERENCE_TAP_WORKLET_MODULE_URL,
+    url: resolveAudioWorkletModuleUrl("playback-reference"),
     fileName: "playback-reference-tap.js",
     processorName: "eliza-playback-reference-tap",
   },

--- a/packages/ui/src/voice/audio-worklet-module-urls.ts
+++ b/packages/ui/src/voice/audio-worklet-module-urls.ts
@@ -7,17 +7,26 @@
  * beside the compiled voice modules for non-Vite consumers.
  */
 
-export const VOICE_SESSION_UPLINK_WORKLET_MODULE_URL = new URL(
-  "./worklets/voice-session-uplink.js?no-inline",
-  import.meta.url,
-).href;
-
-export const VOICE_SESSION_DOWNLINK_WORKLET_MODULE_URL = new URL(
-  "./worklets/voice-session-downlink.js?no-inline",
-  import.meta.url,
-).href;
-
-export const PLAYBACK_REFERENCE_TAP_WORKLET_MODULE_URL = new URL(
-  "./worklets/playback-reference-tap.js?no-inline",
-  import.meta.url,
-).href;
+// Resolve only when voice starts so non-ESM fixture bundles can import the UI
+// without evaluating their unsupported `import.meta.url` placeholder.
+export function resolveAudioWorkletModuleUrl(
+  kind: "uplink" | "downlink" | "playback-reference",
+): string {
+  switch (kind) {
+    case "uplink":
+      return new URL(
+        "./worklets/voice-session-uplink.js?no-inline",
+        import.meta.url,
+      ).href;
+    case "downlink":
+      return new URL(
+        "./worklets/voice-session-downlink.js?no-inline",
+        import.meta.url,
+      ).href;
+    case "playback-reference":
+      return new URL(
+        "./worklets/playback-reference-tap.js?no-inline",
+        import.meta.url,
+      ).href;
+  }
+}

--- a/packages/ui/src/voice/audio-worklet-module-urls.ts
+++ b/packages/ui/src/voice/audio-worklet-module-urls.ts
@@ -1,0 +1,23 @@
+/**
+ * Same-origin AudioWorklet entry points.
+ *
+ * `?no-inline` keeps Vite from converting these small modules to `data:` URLs;
+ * browser CSPs can therefore load them under the normal same-origin
+ * `script-src` policy. The package build copies the matching source directory
+ * beside the compiled voice modules for non-Vite consumers.
+ */
+
+export const VOICE_SESSION_UPLINK_WORKLET_MODULE_URL = new URL(
+  "./worklets/voice-session-uplink.js?no-inline",
+  import.meta.url,
+).href;
+
+export const VOICE_SESSION_DOWNLINK_WORKLET_MODULE_URL = new URL(
+  "./worklets/voice-session-downlink.js?no-inline",
+  import.meta.url,
+).href;
+
+export const PLAYBACK_REFERENCE_TAP_WORKLET_MODULE_URL = new URL(
+  "./worklets/playback-reference-tap.js?no-inline",
+  import.meta.url,
+).href;

--- a/packages/ui/src/voice/browser-audio-runtime.test.ts
+++ b/packages/ui/src/voice/browser-audio-runtime.test.ts
@@ -27,7 +27,14 @@ describe("browser audio runtime boundaries", () => {
   });
 
   it("uses webkitAudioContext and rejects a constructor result that fails validation", () => {
-    class WebkitAudioContext {}
+    class WebkitAudioContext {
+      static latest: WebkitAudioContext | null = null;
+      readonly close = vi.fn(async () => {});
+
+      constructor() {
+        WebkitAudioContext.latest = this;
+      }
+    }
     vi.stubGlobal("window", { webkitAudioContext: WebkitAudioContext });
 
     const context = constructBrowserAudioContext(
@@ -36,6 +43,7 @@ describe("browser audio runtime boundaries", () => {
     );
 
     expect(context).toBeNull();
+    expect(WebkitAudioContext.latest?.close).toHaveBeenCalledTimes(1);
   });
 
   it("constructs and validates the native AudioWorkletNode", () => {
@@ -68,7 +76,14 @@ describe("browser audio runtime boundaries", () => {
       ),
     ).toBeNull();
 
-    class InvalidAudioWorkletNode {}
+    class InvalidAudioWorkletNode {
+      static latest: InvalidAudioWorkletNode | null = null;
+      readonly disconnect = vi.fn();
+
+      constructor() {
+        InvalidAudioWorkletNode.latest = this;
+      }
+    }
     vi.stubGlobal("AudioWorkletNode", InvalidAudioWorkletNode);
     expect(
       constructBrowserAudioWorkletNode(
@@ -77,5 +92,6 @@ describe("browser audio runtime boundaries", () => {
         (_value): _value is { accepted: true } => false,
       ),
     ).toBeNull();
+    expect(InvalidAudioWorkletNode.latest?.disconnect).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/ui/src/voice/browser-audio-runtime.test.ts
+++ b/packages/ui/src/voice/browser-audio-runtime.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  constructBrowserAudioContext,
+  constructBrowserAudioWorkletNode,
+} from "./browser-audio-runtime";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("browser audio runtime boundaries", () => {
+  it("constructs the native AudioContext with arguments after validation", () => {
+    class NativeAudioContext {
+      constructor(readonly options: AudioContextOptions) {}
+    }
+    vi.stubGlobal("window", { AudioContext: NativeAudioContext });
+
+    const context = constructBrowserAudioContext(
+      [{ sampleRate: 16_000 }],
+      (value): value is NativeAudioContext =>
+        value instanceof NativeAudioContext,
+    );
+
+    expect(context).toBeInstanceOf(NativeAudioContext);
+    expect(context?.options.sampleRate).toBe(16_000);
+  });
+
+  it("uses webkitAudioContext and rejects a constructor result that fails validation", () => {
+    class WebkitAudioContext {}
+    vi.stubGlobal("window", { webkitAudioContext: WebkitAudioContext });
+
+    const context = constructBrowserAudioContext(
+      [],
+      (_value): _value is { accepted: true } => false,
+    );
+
+    expect(context).toBeNull();
+  });
+
+  it("constructs and validates the native AudioWorkletNode", () => {
+    const context = { sampleRate: 16_000 };
+    class NativeAudioWorkletNode {
+      constructor(
+        readonly receivedContext: object,
+        readonly name: string,
+      ) {}
+    }
+    vi.stubGlobal("AudioWorkletNode", NativeAudioWorkletNode);
+
+    const node = constructBrowserAudioWorkletNode(
+      context,
+      "eliza-test-worklet",
+      (value): value is NativeAudioWorkletNode =>
+        value instanceof NativeAudioWorkletNode,
+    );
+
+    expect(node?.receivedContext).toBe(context);
+    expect(node?.name).toBe("eliza-test-worklet");
+  });
+
+  it("returns null for unavailable or invalid AudioWorkletNode runtimes", () => {
+    expect(
+      constructBrowserAudioWorkletNode(
+        {},
+        "missing",
+        (value): value is unknown => value !== undefined,
+      ),
+    ).toBeNull();
+
+    class InvalidAudioWorkletNode {}
+    vi.stubGlobal("AudioWorkletNode", InvalidAudioWorkletNode);
+    expect(
+      constructBrowserAudioWorkletNode(
+        {},
+        "invalid",
+        (_value): _value is { accepted: true } => false,
+      ),
+    ).toBeNull();
+  });
+});

--- a/packages/ui/src/voice/browser-audio-runtime.ts
+++ b/packages/ui/src/voice/browser-audio-runtime.ts
@@ -6,6 +6,26 @@
 
 export type RuntimeValidator<T> = (value: unknown) => value is T;
 
+function invokeCleanupBestEffort(value: unknown, methodName: string): void {
+  if ((typeof value !== "object" && typeof value !== "function") || !value) {
+    return;
+  }
+  try {
+    const cleanup: unknown = Reflect.get(value, methodName);
+    if (typeof cleanup !== "function") return;
+    const result: unknown = Reflect.apply(cleanup, value, []);
+    if (result && typeof Reflect.get(Object(result), "then") === "function") {
+      void Promise.resolve(result).catch((ignoredError) => {
+        // error-policy:J6 Rejected native cleanup must not mask validation.
+        void ignoredError;
+      });
+    }
+  } catch (ignoredError) {
+    // error-policy:J6 Best-effort cleanup must not mask validation.
+    void ignoredError;
+  }
+}
+
 function browserAudioContextConstructor(): unknown {
   if (typeof window === "undefined") return undefined;
   return (
@@ -21,7 +41,9 @@ export function constructBrowserAudioContext<T>(
   const ctor = browserAudioContextConstructor();
   if (typeof ctor !== "function") return null;
   const context: unknown = Reflect.construct(ctor, Array.from(args));
-  return validate(context) ? context : null;
+  if (validate(context)) return context;
+  invokeCleanupBestEffort(context, "close");
+  return null;
 }
 
 export function constructBrowserAudioWorkletNode<T>(
@@ -32,5 +54,7 @@ export function constructBrowserAudioWorkletNode<T>(
   const ctor: unknown = globalThis.AudioWorkletNode;
   if (typeof ctor !== "function") return null;
   const node: unknown = Reflect.construct(ctor, [context, name]);
-  return validate(node) ? node : null;
+  if (validate(node)) return node;
+  invokeCleanupBestEffort(node, "disconnect");
+  return null;
 }

--- a/packages/ui/src/voice/browser-audio-runtime.ts
+++ b/packages/ui/src/voice/browser-audio-runtime.ts
@@ -1,0 +1,36 @@
+/**
+ * Constructs browser audio primitives behind runtime validators so embedded
+ * WebViews can expose vendor-prefixed or partial APIs without weakening the
+ * typed voice pipeline.
+ */
+
+export type RuntimeValidator<T> = (value: unknown) => value is T;
+
+function browserAudioContextConstructor(): unknown {
+  if (typeof window === "undefined") return undefined;
+  return (
+    Reflect.get(window, "AudioContext") ??
+    Reflect.get(window, "webkitAudioContext")
+  );
+}
+
+export function constructBrowserAudioContext<T>(
+  args: readonly unknown[],
+  validate: RuntimeValidator<T>,
+): T | null {
+  const ctor = browserAudioContextConstructor();
+  if (typeof ctor !== "function") return null;
+  const context: unknown = Reflect.construct(ctor, Array.from(args));
+  return validate(context) ? context : null;
+}
+
+export function constructBrowserAudioWorkletNode<T>(
+  context: object,
+  name: string,
+  validate: RuntimeValidator<T>,
+): T | null {
+  const ctor: unknown = globalThis.AudioWorkletNode;
+  if (typeof ctor !== "function") return null;
+  const node: unknown = Reflect.construct(ctor, [context, name]);
+  return validate(node) ? node : null;
+}

--- a/packages/ui/src/voice/index.ts
+++ b/packages/ui/src/voice/index.ts
@@ -91,65 +91,6 @@ export {
   type VoiceCaptureTranscriptSegment,
 } from "./voice-capture-factory";
 export {
-  createVoiceSessionClient,
-  VoiceSessionMintError,
-  type VoiceSessionClient,
-  type VoiceSessionClientOptions,
-  type VoiceTraceMark,
-  type VoiceWebSocketFactory,
-  type VoiceWebSocketLike,
-} from "./voice-session-client";
-export {
-  hasAudioWorkletSupport,
-  startVoiceMicCapture,
-  VoiceMicCaptureError,
-  type AudioNodeLike,
-  type MicAudioContextLike,
-  type VoiceMicCapture,
-  type VoiceMicCaptureOptions,
-} from "./voice-session-mic-capture";
-export {
-  createVoiceSessionPlayback,
-  hasPlaybackWorkletSupport,
-  type PlaybackAudioContextLike,
-  type VoiceSessionPlayback,
-  type VoiceSessionPlaybackOptions,
-} from "./voice-session-playback";
-export {
-  clampFloatSample,
-  downmixChannelsToMono,
-  floatPcmToInt16Bytes,
-  floatSampleToInt16,
-  int16BytesToFloatPcm,
-  int16SampleToFloat,
-  VOICE_PCM_SAMPLE_RATE,
-} from "./voice-session-pcm";
-export {
-  applyClientAction,
-  applyServerEvent,
-  beginListening,
-  INITIAL_VOICE_SESSION_STATE,
-  loopToListening,
-  toContinuousStatus,
-  type VoiceSessionClientAction,
-  type VoiceSessionMachineState,
-  type VoiceSessionPhase,
-} from "./voice-session-state";
-export {
-  DEFAULT_DOWNLINK_CODEC,
-  DEFAULT_UPLINK_CODEC,
-  encodeClientControl,
-  isUsableMintResponse,
-  negotiateCodec,
-  parseServerControl,
-  VOICE_SESSION_PROTOCOL_VERSION as VOICE_SESSION_CLIENT_PROTOCOL_VERSION,
-  VOICE_SESSION_SAMPLE_RATE,
-  type ClientControlFrame,
-  type ServerControlFrame as VoiceSessionServerControlFrame,
-  type VoiceSessionCodec,
-  type VoiceSessionMintResponse,
-} from "./voice-session-protocol";
-export {
   type DefaultVoiceProviderResult,
   type PickDefaultVoiceProviderInput,
   type PresetPlatform,
@@ -169,6 +110,65 @@ export {
   type VoiceSelfTestReport,
   type VoiceSelfTestStage,
 } from "./voice-selftest/voice-selftest-harness";
+export {
+  createVoiceSessionClient,
+  type VoiceSessionClient,
+  type VoiceSessionClientOptions,
+  VoiceSessionMintError,
+  type VoiceTraceMark,
+  type VoiceWebSocketFactory,
+  type VoiceWebSocketLike,
+} from "./voice-session-client";
+export {
+  type AudioNodeLike,
+  hasAudioWorkletSupport,
+  type MicAudioContextLike,
+  startVoiceMicCapture,
+  type VoiceMicCapture,
+  VoiceMicCaptureError,
+  type VoiceMicCaptureOptions,
+} from "./voice-session-mic-capture";
+export {
+  clampFloatSample,
+  downmixChannelsToMono,
+  floatPcmToInt16Bytes,
+  floatSampleToInt16,
+  int16BytesToFloatPcm,
+  int16SampleToFloat,
+  VOICE_PCM_SAMPLE_RATE,
+} from "./voice-session-pcm";
+export {
+  createVoiceSessionPlayback,
+  hasPlaybackWorkletSupport,
+  type PlaybackAudioContextLike,
+  type VoiceSessionPlayback,
+  type VoiceSessionPlaybackOptions,
+} from "./voice-session-playback";
+export {
+  type ClientControlFrame,
+  DEFAULT_DOWNLINK_CODEC,
+  DEFAULT_UPLINK_CODEC,
+  encodeClientControl,
+  isUsableMintResponse,
+  negotiateCodec,
+  parseServerControl,
+  type ServerControlFrame as VoiceSessionServerControlFrame,
+  VOICE_SESSION_PROTOCOL_VERSION as VOICE_SESSION_CLIENT_PROTOCOL_VERSION,
+  VOICE_SESSION_SAMPLE_RATE,
+  type VoiceSessionCodec,
+  type VoiceSessionMintResponse,
+} from "./voice-session-protocol";
+export {
+  applyClientAction,
+  applyServerEvent,
+  beginListening,
+  INITIAL_VOICE_SESSION_STATE,
+  loopToListening,
+  toContinuousStatus,
+  type VoiceSessionClientAction,
+  type VoiceSessionMachineState,
+  type VoiceSessionPhase,
+} from "./voice-session-state";
 export {
   DEFAULT_CONFIRM_WINDOW_MS,
   hasTrainedHead,

--- a/packages/ui/src/voice/playback-frame-pump.test.ts
+++ b/packages/ui/src/voice/playback-frame-pump.test.ts
@@ -181,7 +181,7 @@ describe("PlaybackFramePump", () => {
 });
 
 describe("resumeAudioContextForPlayback", () => {
-  it("returns true immediately for a context that is not suspended", async () => {
+  it("returns true immediately for a running context", async () => {
     const ctx = fakeAudioContext("running");
     await expect(resumeAudioContextForPlayback(ctx)).resolves.toBe(true);
     expect(ctx.resume).not.toHaveBeenCalled();
@@ -191,6 +191,18 @@ describe("resumeAudioContextForPlayback", () => {
     const ctx = fakeAudioContext("suspended");
     await expect(resumeAudioContextForPlayback(ctx)).resolves.toBe(true);
     expect(ctx.resume).toHaveBeenCalledTimes(1);
+  });
+
+  it("resumes an interrupted context and reports success", async () => {
+    const ctx = fakeAudioContext("interrupted");
+    await expect(resumeAudioContextForPlayback(ctx)).resolves.toBe(true);
+    expect(ctx.resume).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports a closed context as unavailable without calling resume", async () => {
+    const ctx = fakeAudioContext("closed");
+    await expect(resumeAudioContextForPlayback(ctx)).resolves.toBe(false);
+    expect(ctx.resume).not.toHaveBeenCalled();
   });
 
   it("times out and reports failure if resume() never settles", async () => {
@@ -225,6 +237,26 @@ describe("ensurePlaybackContextRunning", () => {
       ensurePlaybackContextRunning(ctx, "elevenlabs", onBlocked),
     ).resolves.toBeUndefined();
     expect(onBlocked).not.toHaveBeenCalled();
+  });
+
+  it("resumes an interrupted context and resolves once running", async () => {
+    const ctx = fakeAudioContext("interrupted");
+    const onBlocked = vi.fn();
+    await expect(
+      ensurePlaybackContextRunning(ctx, "elevenlabs", onBlocked),
+    ).resolves.toBeUndefined();
+    expect(ctx.resume).toHaveBeenCalledTimes(1);
+    expect(onBlocked).not.toHaveBeenCalled();
+  });
+
+  it("fails closed for a closed context without attempting resume", async () => {
+    const ctx = fakeAudioContext("closed");
+    const onBlocked = vi.fn();
+    await expect(
+      ensurePlaybackContextRunning(ctx, "eliza-cloud", onBlocked),
+    ).rejects.toThrow(/blocked/i);
+    expect(ctx.resume).not.toHaveBeenCalled();
+    expect(onBlocked).toHaveBeenCalledTimes(1);
   });
 
   it("fails closed with NotAllowedError and reports onBlocked when resume cannot unblock playback", async () => {

--- a/packages/ui/src/voice/playback-frame-pump.ts
+++ b/packages/ui/src/voice/playback-frame-pump.ts
@@ -11,6 +11,7 @@
 import { fetchWithCsrf } from "../api/csrf-client";
 import { resolveApiUrl } from "../utils";
 import { ttsDebug } from "../utils/tts-debug";
+import { PLAYBACK_REFERENCE_TAP_WORKLET_MODULE_URL } from "./audio-worklet-module-urls";
 import {
   markTtsPlaybackEnded,
   markTtsPlaybackStarted,
@@ -22,34 +23,6 @@ const FRAME_MS = 20;
 const MAX_BATCH_FRAMES = 49;
 const FLUSH_INTERVAL_MS = 250;
 const WORKLET_NAME = "eliza-playback-reference-tap";
-
-const WORKLET_SOURCE = `
-class ElizaPlaybackReferenceTap extends AudioWorkletProcessor {
-  process(inputs) {
-    const input = inputs[0] || [];
-    const first = input[0];
-    if (first && first.length > 0) {
-      const mono = new Float32Array(first.length);
-      const channels = Math.max(1, input.length);
-      for (let i = 0; i < first.length; i += 1) {
-        let sum = 0;
-        let count = 0;
-        for (let ch = 0; ch < channels; ch += 1) {
-          const channel = input[ch];
-          if (channel) {
-            sum += channel[i] || 0;
-            count += 1;
-          }
-        }
-        mono[i] = count > 0 ? sum / count : 0;
-      }
-      this.port.postMessage({ pcm: mono, sampleRate }, [mono.buffer]);
-    }
-    return true;
-  }
-}
-registerProcessor("${WORKLET_NAME}", ElizaPlaybackReferenceTap);
-`;
 
 type FetchLike = (url: string, init?: RequestInit) => Promise<Response>;
 
@@ -94,10 +67,7 @@ function getNowMs(): number {
 function hasAudioWorklet(ctx: AudioContext): boolean {
   return (
     typeof ctx.audioWorklet?.addModule === "function" &&
-    typeof AudioWorkletNode !== "undefined" &&
-    typeof Blob !== "undefined" &&
-    typeof URL !== "undefined" &&
-    typeof URL.createObjectURL === "function"
+    typeof AudioWorkletNode !== "undefined"
   );
 }
 
@@ -105,16 +75,9 @@ async function ensurePlaybackWorklet(ctx: AudioContext): Promise<void> {
   const existing = workletModules.get(ctx);
   if (existing) return existing;
 
-  const pending = (async () => {
-    const url = URL.createObjectURL(
-      new Blob([WORKLET_SOURCE], { type: "text/javascript" }),
-    );
-    try {
-      await ctx.audioWorklet.addModule(url);
-    } finally {
-      URL.revokeObjectURL(url);
-    }
-  })();
+  const pending = ctx.audioWorklet.addModule(
+    PLAYBACK_REFERENCE_TAP_WORKLET_MODULE_URL,
+  );
   workletModules.set(ctx, pending);
   return pending;
 }

--- a/packages/ui/src/voice/playback-frame-pump.ts
+++ b/packages/ui/src/voice/playback-frame-pump.ts
@@ -90,16 +90,21 @@ export function warmPlaybackWorklet(ctx: AudioContext): void {
   });
 }
 
+function isPlaybackContextRunning(ctx: AudioContext): boolean {
+  return ctx.state === "running";
+}
+
 /**
- * Resumes a suspended AudioContext with a timeout, so a `resume()` call that
- * never settles (observed on some mobile WebViews) cannot block playback
- * forever. Returns whether the context is running afterward.
+ * Resumes a suspended or interrupted AudioContext with a timeout, so a
+ * `resume()` call that never settles (observed on some mobile WebViews) cannot
+ * block playback forever. Returns whether the context is running afterward.
  */
 export async function resumeAudioContextForPlayback(
   ctx: AudioContext,
   timeoutMs = 1200,
 ): Promise<boolean> {
-  if (ctx.state !== "suspended") return true;
+  if (isPlaybackContextRunning(ctx)) return true;
+  if (ctx.state !== "suspended" && ctx.state !== "interrupted") return false;
 
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
   try {
@@ -112,7 +117,7 @@ export async function resumeAudioContextForPlayback(
         timeoutId = setTimeout(() => resolve(false), timeoutMs);
       }),
     ]);
-    return resumed && ctx.state !== "suspended";
+    return resumed && isPlaybackContextRunning(ctx);
   } finally {
     if (timeoutId) clearTimeout(timeoutId);
   }
@@ -130,7 +135,7 @@ export async function ensurePlaybackContextRunning(
   provider: string,
   onBlocked: () => void,
 ): Promise<void> {
-  if (ctx.state !== "suspended") return;
+  if (isPlaybackContextRunning(ctx)) return;
   const resumed = await resumeAudioContextForPlayback(ctx);
   if (resumed) return;
   ttsDebug("play:audio-context-blocked", { provider, state: ctx.state });

--- a/packages/ui/src/voice/playback-frame-pump.ts
+++ b/packages/ui/src/voice/playback-frame-pump.ts
@@ -11,7 +11,7 @@
 import { fetchWithCsrf } from "../api/csrf-client";
 import { resolveApiUrl } from "../utils";
 import { ttsDebug } from "../utils/tts-debug";
-import { PLAYBACK_REFERENCE_TAP_WORKLET_MODULE_URL } from "./audio-worklet-module-urls";
+import { resolveAudioWorkletModuleUrl } from "./audio-worklet-module-urls";
 import {
   markTtsPlaybackEnded,
   markTtsPlaybackStarted,
@@ -76,7 +76,7 @@ async function ensurePlaybackWorklet(ctx: AudioContext): Promise<void> {
   if (existing) return existing;
 
   const pending = ctx.audioWorklet.addModule(
-    PLAYBACK_REFERENCE_TAP_WORKLET_MODULE_URL,
+    resolveAudioWorkletModuleUrl("playback-reference"),
   );
   workletModules.set(ctx, pending);
   return pending;

--- a/packages/ui/src/voice/voice-session-client.ts
+++ b/packages/ui/src/voice/voice-session-client.ts
@@ -31,17 +31,31 @@
  * through fakes — not stubs of the client itself.
  */
 
+import type { VoiceContinuousStatus } from "./voice-chat-types";
+import {
+  type MicAudioContextLike,
+  startVoiceMicCapture,
+  type VoiceMicCapture,
+  VoiceMicCaptureError,
+} from "./voice-session-mic-capture";
 import {
   createVoiceSessionPlayback,
   type PlaybackAudioContextLike,
   type VoiceSessionPlayback,
 } from "./voice-session-playback";
 import {
-  startVoiceMicCapture,
-  VoiceMicCaptureError,
-  type MicAudioContextLike,
-  type VoiceMicCapture,
-} from "./voice-session-mic-capture";
+  DEFAULT_DOWNLINK_CODEC,
+  DEFAULT_UPLINK_CODEC,
+  encodeClientControl,
+  isUsableMintResponse,
+  negotiateCodec,
+  parseServerControl,
+  type ServerControlFrame,
+  VOICE_SESSION_PROTOCOL_VERSION,
+  VOICE_SESSION_SAMPLE_RATE,
+  type VoiceSessionCodec,
+  type VoiceSessionMintResponse,
+} from "./voice-session-protocol";
 import {
   applyClientAction,
   applyServerEvent,
@@ -51,20 +65,6 @@ import {
   toContinuousStatus,
   type VoiceSessionMachineState,
 } from "./voice-session-state";
-import {
-  DEFAULT_DOWNLINK_CODEC,
-  DEFAULT_UPLINK_CODEC,
-  encodeClientControl,
-  isUsableMintResponse,
-  negotiateCodec,
-  parseServerControl,
-  VOICE_SESSION_PROTOCOL_VERSION,
-  VOICE_SESSION_SAMPLE_RATE,
-  type ServerControlFrame,
-  type VoiceSessionCodec,
-  type VoiceSessionMintResponse,
-} from "./voice-session-protocol";
-import type { VoiceContinuousStatus } from "./voice-chat-types";
 
 /** Minimal WebSocket surface the client drives (native or fake). */
 export interface VoiceWebSocketLike {
@@ -81,6 +81,29 @@ export interface VoiceWebSocketLike {
     listener: (event: { code?: number; reason?: string }) => void,
   ): void;
   addEventListener(type: "error", listener: () => void): void;
+}
+
+function isVoiceWebSocketLike(value: unknown): value is VoiceWebSocketLike {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof Reflect.get(value, "binaryType") === "string" &&
+    typeof Reflect.get(value, "send") === "function" &&
+    typeof Reflect.get(value, "close") === "function" &&
+    typeof Reflect.get(value, "addEventListener") === "function"
+  );
+}
+
+function openNativeVoiceWebSocket(url: string): VoiceWebSocketLike {
+  const ctor: unknown = globalThis.WebSocket;
+  if (typeof ctor !== "function") {
+    throw new Error("WebSocket is unavailable in this runtime");
+  }
+  const socket: unknown = Reflect.construct(ctor, [url]);
+  if (!isVoiceWebSocketLike(socket)) {
+    throw new Error("WebSocket runtime does not expose the required voice API");
+  }
+  return socket;
 }
 
 export type VoiceWebSocketFactory = (url: string) => VoiceWebSocketLike;
@@ -175,12 +198,7 @@ export function createVoiceSessionClient(
     });
   const wsFactory =
     options.webSocketFactory ??
-    ((url: string) => {
-      const Ctor = WebSocket as unknown as new (
-        u: string,
-      ) => VoiceWebSocketLike;
-      return new Ctor(url);
-    });
+    ((url: string) => openNativeVoiceWebSocket(url));
   const preferredUplink = options.uplinkCodec ?? DEFAULT_UPLINK_CODEC;
   const preferredDownlink = options.downlinkCodec ?? DEFAULT_DOWNLINK_CODEC;
   const maxReconnects = options.maxReconnects ?? 2;

--- a/packages/ui/src/voice/voice-session-client.ts
+++ b/packages/ui/src/voice/voice-session-client.ts
@@ -94,6 +94,19 @@ function isVoiceWebSocketLike(value: unknown): value is VoiceWebSocketLike {
   );
 }
 
+function closeInvalidNativeWebSocket(socket: unknown): void {
+  if ((typeof socket !== "object" && typeof socket !== "function") || !socket) {
+    return;
+  }
+  try {
+    const close: unknown = Reflect.get(socket, "close");
+    if (typeof close === "function") Reflect.apply(close, socket, []);
+  } catch (ignoredError) {
+    // error-policy:J6 Best-effort cleanup must not mask the runtime shape error.
+    void ignoredError;
+  }
+}
+
 function openNativeVoiceWebSocket(url: string): VoiceWebSocketLike {
   const ctor: unknown = globalThis.WebSocket;
   if (typeof ctor !== "function") {
@@ -101,6 +114,7 @@ function openNativeVoiceWebSocket(url: string): VoiceWebSocketLike {
   }
   const socket: unknown = Reflect.construct(ctor, [url]);
   if (!isVoiceWebSocketLike(socket)) {
+    closeInvalidNativeWebSocket(socket);
     throw new Error("WebSocket runtime does not expose the required voice API");
   }
   return socket;

--- a/packages/ui/src/voice/voice-session-mic-capture.ts
+++ b/packages/ui/src/voice/voice-session-mic-capture.ts
@@ -23,7 +23,7 @@
  * code (no stub of the thing under test).
  */
 
-import { VOICE_SESSION_UPLINK_WORKLET_MODULE_URL } from "./audio-worklet-module-urls";
+import { resolveAudioWorkletModuleUrl } from "./audio-worklet-module-urls";
 import {
   constructBrowserAudioContext,
   constructBrowserAudioWorkletNode,
@@ -345,7 +345,7 @@ export async function startVoiceMicCapture(
   try {
     if (hasAudioWorkletSupport(ctx)) {
       backend = "audioworklet";
-      await ctx.audioWorklet.addModule(VOICE_SESSION_UPLINK_WORKLET_MODULE_URL);
+      await ctx.audioWorklet.addModule(resolveAudioWorkletModuleUrl("uplink"));
       const node = constructBrowserAudioWorkletNode(
         ctx,
         WORKLET_NAME,

--- a/packages/ui/src/voice/voice-session-mic-capture.ts
+++ b/packages/ui/src/voice/voice-session-mic-capture.ts
@@ -23,6 +23,7 @@
  * code (no stub of the thing under test).
  */
 
+import { VOICE_SESSION_UPLINK_WORKLET_MODULE_URL } from "./audio-worklet-module-urls";
 import {
   constructBrowserAudioContext,
   constructBrowserAudioWorkletNode,
@@ -51,7 +52,7 @@ export class VoiceMicCaptureError extends Error {
 /** Minimal AudioContext surface the capture drives (real or injected fake). */
 export interface MicAudioContextLike {
   readonly sampleRate: number;
-  readonly state: "suspended" | "running" | "closed";
+  readonly state: AudioContextState;
   createMediaStreamSource(stream: MediaStream): AudioNodeLike;
   createScriptProcessor?(
     bufferSize: number,
@@ -110,7 +111,10 @@ function isMicAudioContextLike(value: unknown): value is MicAudioContextLike {
   const state: unknown = Reflect.get(value, "state");
   return (
     typeof Reflect.get(value, "sampleRate") === "number" &&
-    (state === "suspended" || state === "running" || state === "closed") &&
+    (state === "suspended" ||
+      state === "interrupted" ||
+      state === "running" ||
+      state === "closed") &&
     isAudioNodeLike(Reflect.get(value, "destination")) &&
     typeof Reflect.get(value, "createMediaStreamSource") === "function" &&
     typeof Reflect.get(value, "resume") === "function" &&
@@ -153,42 +157,13 @@ export interface VoiceMicCaptureOptions {
 
 const WORKLET_NAME = "eliza-voice-session-uplink";
 
-// Inline worklet: downmix to mono, post Float32 frames to the main thread where
-// resample+Int16 framing happens (keeping the DSP in one tested place).
-const WORKLET_SOURCE = `
-class ElizaVoiceSessionUplink extends AudioWorkletProcessor {
-  process(inputs) {
-    const input = inputs[0];
-    if (!input || input.length === 0) return true;
-    const frames = input[0] ? input[0].length : 0;
-    if (frames === 0) return true;
-    const channels = input.length;
-    const mono = new Float32Array(frames);
-    for (let i = 0; i < frames; i += 1) {
-      let sum = 0;
-      for (let ch = 0; ch < channels; ch += 1) {
-        const c = input[ch];
-        sum += c ? (c[i] || 0) : 0;
-      }
-      mono[i] = sum / channels;
-    }
-    this.port.postMessage({ pcm: mono, sampleRate }, [mono.buffer]);
-    return true;
-  }
-}
-registerProcessor("${WORKLET_NAME}", ElizaVoiceSessionUplink);
-`;
-
 /** Runtime AudioWorklet availability probe — never assumed (WebView 113). */
 export function hasAudioWorkletSupport(
   ctx: MicAudioContextLike,
 ): ctx is WorkletCapableMicContext {
   return (
     typeof ctx.audioWorklet?.addModule === "function" &&
-    typeof globalThis.AudioWorkletNode !== "undefined" &&
-    typeof Blob !== "undefined" &&
-    typeof URL !== "undefined" &&
-    typeof URL.createObjectURL === "function"
+    typeof globalThis.AudioWorkletNode !== "undefined"
   );
 }
 
@@ -304,7 +279,7 @@ export async function startVoiceMicCapture(
   }
 
   const ctx = createAudioContext();
-  if (ctx.state === "suspended") {
+  if (ctx.state === "suspended" || ctx.state === "interrupted") {
     try {
       await ctx.resume();
     } catch (ignoredError) {
@@ -343,14 +318,7 @@ export async function startVoiceMicCapture(
 
   if (hasAudioWorkletSupport(ctx)) {
     backend = "audioworklet";
-    const url = URL.createObjectURL(
-      new Blob([WORKLET_SOURCE], { type: "text/javascript" }),
-    );
-    try {
-      await ctx.audioWorklet.addModule(url);
-    } finally {
-      URL.revokeObjectURL(url);
-    }
+    await ctx.audioWorklet.addModule(VOICE_SESSION_UPLINK_WORKLET_MODULE_URL);
     const node = constructBrowserAudioWorkletNode(
       ctx,
       WORKLET_NAME,

--- a/packages/ui/src/voice/voice-session-mic-capture.ts
+++ b/packages/ui/src/voice/voice-session-mic-capture.ts
@@ -278,17 +278,43 @@ export async function startVoiceMicCapture(
     throw new VoiceMicCaptureError("getUserMedia failed", "start_failed", err);
   }
 
-  const ctx = createAudioContext();
-  if (ctx.state === "suspended" || ctx.state === "interrupted") {
-    try {
-      await ctx.resume();
-    } catch (ignoredError) {
-      void ignoredError;
-      // best-effort; a running graph is confirmed by frame delivery.
+  let acquiredContext: MicAudioContextLike | null = null;
+  let acquiredSource: AudioNodeLike | null = null;
+  try {
+    acquiredContext = createAudioContext();
+    if (
+      acquiredContext.state === "suspended" ||
+      acquiredContext.state === "interrupted"
+    ) {
+      try {
+        await acquiredContext.resume();
+      } catch (ignoredError) {
+        void ignoredError;
+        // best-effort; a running graph is confirmed by frame delivery.
+      }
     }
+    acquiredSource = acquiredContext.createMediaStreamSource(stream);
+  } catch (error) {
+    acquiredSource?.disconnect();
+    for (const track of stream.getTracks()) track.stop();
+    await acquiredContext?.close().catch(() => {});
+    if (error instanceof VoiceMicCaptureError) throw error;
+    throw new VoiceMicCaptureError(
+      "microphone audio pipeline failed to start",
+      "start_failed",
+      error,
+    );
   }
-
-  const source = ctx.createMediaStreamSource(stream);
+  if (!acquiredContext || !acquiredSource) {
+    for (const track of stream.getTracks()) track.stop();
+    await acquiredContext?.close().catch(() => {});
+    throw new VoiceMicCaptureError(
+      "microphone audio pipeline failed to initialize",
+      "start_failed",
+    );
+  }
+  const ctx = acquiredContext;
+  const source = acquiredSource;
   const resampler = new StreamingResampler(ctx.sampleRate);
 
   let stopped = false;
@@ -316,49 +342,64 @@ export async function startVoiceMicCapture(
   let workletNode: AudioWorkletNodeLike | null = null;
   let scriptNode: ScriptProcessorNodeLike | null = null;
 
-  if (hasAudioWorkletSupport(ctx)) {
-    backend = "audioworklet";
-    await ctx.audioWorklet.addModule(VOICE_SESSION_UPLINK_WORKLET_MODULE_URL);
-    const node = constructBrowserAudioWorkletNode(
-      ctx,
-      WORKLET_NAME,
-      isAudioWorkletNodeLike,
-    );
-    if (!node) {
-      for (const track of stream.getTracks()) track.stop();
-      await ctx.close();
+  try {
+    if (hasAudioWorkletSupport(ctx)) {
+      backend = "audioworklet";
+      await ctx.audioWorklet.addModule(VOICE_SESSION_UPLINK_WORKLET_MODULE_URL);
+      const node = constructBrowserAudioWorkletNode(
+        ctx,
+        WORKLET_NAME,
+        isAudioWorkletNodeLike,
+      );
+      if (!node) {
+        throw new VoiceMicCaptureError(
+          "AudioWorkletNode unavailable",
+          "unsupported",
+        );
+      }
+      workletNode = node;
+      node.port.onmessage = (event) => {
+        const data = event.data as { pcm?: Float32Array } | undefined;
+        if (data?.pcm) emitResampled(data.pcm);
+      };
+      source.connect(node);
+      // Worklet needs a graph terminus to pull frames; connect to destination.
+      node.connect(ctx.destination);
+    } else if (typeof ctx.createScriptProcessor === "function") {
+      backend = "scriptprocessor";
+      // 4096-sample buffer is the WebView-113-safe choice (power of two, low
+      // dropout risk). Mono in, mono out.
+      scriptNode = ctx.createScriptProcessor(4096, 1, 1);
+      scriptNode.onaudioprocess = (event) => {
+        const channel = event.inputBuffer.getChannelData(0);
+        // Copy: the underlying buffer is reused by the engine after this callback.
+        emitResampled(channel.slice());
+      };
+      source.connect(scriptNode);
+      scriptNode.connect(ctx.destination);
+    } else {
       throw new VoiceMicCaptureError(
-        "AudioWorkletNode unavailable",
+        "no AudioWorklet or ScriptProcessor available",
         "unsupported",
       );
     }
-    workletNode = node;
-    node.port.onmessage = (event) => {
-      const data = event.data as { pcm?: Float32Array } | undefined;
-      if (data?.pcm) emitResampled(data.pcm);
-    };
-    source.connect(node);
-    // Worklet needs a graph terminus to pull frames; connect to destination.
-    node.connect(ctx.destination);
-  } else if (typeof ctx.createScriptProcessor === "function") {
-    backend = "scriptprocessor";
-    // 4096-sample buffer is the WebView-113-safe choice (power of two, low
-    // dropout risk). Mono in, mono out.
-    scriptNode = ctx.createScriptProcessor(4096, 1, 1);
-    scriptNode.onaudioprocess = (event) => {
-      const channel = event.inputBuffer.getChannelData(0);
-      // Copy: the underlying buffer is reused by the engine after this callback.
-      emitResampled(channel.slice());
-    };
-    source.connect(scriptNode);
-    scriptNode.connect(ctx.destination);
-  } else {
-    // Neither backend — release the mic and fail loud.
+  } catch (error) {
+    if (workletNode) {
+      workletNode.port.onmessage = null;
+      workletNode.disconnect();
+    }
+    if (scriptNode) {
+      scriptNode.onaudioprocess = null;
+      scriptNode.disconnect();
+    }
+    source.disconnect();
     for (const track of stream.getTracks()) track.stop();
     await ctx.close().catch(() => {});
+    if (error instanceof VoiceMicCaptureError) throw error;
     throw new VoiceMicCaptureError(
-      "no AudioWorklet or ScriptProcessor available",
-      "unsupported",
+      "microphone audio pipeline failed to start",
+      "start_failed",
+      error,
     );
   }
 

--- a/packages/ui/src/voice/voice-session-mic-capture.ts
+++ b/packages/ui/src/voice/voice-session-mic-capture.ts
@@ -24,6 +24,10 @@
  */
 
 import {
+  constructBrowserAudioContext,
+  constructBrowserAudioWorkletNode,
+} from "./browser-audio-runtime";
+import {
   floatPcmToInt16Bytes,
   VOICE_PCM_SAMPLE_RATE,
 } from "./voice-session-pcm";
@@ -80,6 +84,43 @@ export interface AudioWorkletNodeLike extends AudioNodeLike {
     postMessage(data: unknown): void;
   };
 }
+
+function isAudioNodeLike(value: unknown): value is AudioNodeLike {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof Reflect.get(value, "connect") === "function" &&
+    typeof Reflect.get(value, "disconnect") === "function"
+  );
+}
+
+function isAudioWorkletNodeLike(value: unknown): value is AudioWorkletNodeLike {
+  if (!isAudioNodeLike(value)) return false;
+  const port: unknown = Reflect.get(value, "port");
+  return (
+    typeof port === "object" &&
+    port !== null &&
+    "onmessage" in port &&
+    typeof Reflect.get(port, "postMessage") === "function"
+  );
+}
+
+function isMicAudioContextLike(value: unknown): value is MicAudioContextLike {
+  if (typeof value !== "object" || value === null) return false;
+  const state: unknown = Reflect.get(value, "state");
+  return (
+    typeof Reflect.get(value, "sampleRate") === "number" &&
+    (state === "suspended" || state === "running" || state === "closed") &&
+    isAudioNodeLike(Reflect.get(value, "destination")) &&
+    typeof Reflect.get(value, "createMediaStreamSource") === "function" &&
+    typeof Reflect.get(value, "resume") === "function" &&
+    typeof Reflect.get(value, "close") === "function"
+  );
+}
+
+type WorkletCapableMicContext = MicAudioContextLike & {
+  audioWorklet: { addModule(url: string): Promise<void> };
+};
 
 export interface VoiceMicCaptureOptions {
   /** Emitted for every framed Int16 PCM chunk (little-endian, 16 kHz mono). */
@@ -139,10 +180,12 @@ registerProcessor("${WORKLET_NAME}", ElizaVoiceSessionUplink);
 `;
 
 /** Runtime AudioWorklet availability probe — never assumed (WebView 113). */
-export function hasAudioWorkletSupport(ctx: MicAudioContextLike): boolean {
+export function hasAudioWorkletSupport(
+  ctx: MicAudioContextLike,
+): ctx is WorkletCapableMicContext {
   return (
     typeof ctx.audioWorklet?.addModule === "function" &&
-    typeof AudioWorkletNode !== "undefined" &&
+    typeof globalThis.AudioWorkletNode !== "undefined" &&
     typeof Blob !== "undefined" &&
     typeof URL !== "undefined" &&
     typeof URL.createObjectURL === "function"
@@ -223,26 +266,14 @@ export async function startVoiceMicCapture(
   const createAudioContext =
     options.createAudioContext ??
     (() => {
-      const Ctor =
-        typeof window !== "undefined"
-          ? ((
-              window as unknown as {
-                AudioContext?: new () => MicAudioContextLike;
-              }
-            ).AudioContext ??
-            (
-              window as unknown as {
-                webkitAudioContext?: new () => MicAudioContextLike;
-              }
-            ).webkitAudioContext)
-          : undefined;
-      if (!Ctor) {
+      const context = constructBrowserAudioContext([], isMicAudioContextLike);
+      if (!context) {
         throw new VoiceMicCaptureError(
           "AudioContext unavailable",
           "unsupported",
         );
       }
-      return new Ctor();
+      return context;
     });
 
   let stream: MediaStream;
@@ -316,23 +347,31 @@ export async function startVoiceMicCapture(
       new Blob([WORKLET_SOURCE], { type: "text/javascript" }),
     );
     try {
-      await ctx.audioWorklet!.addModule(url);
+      await ctx.audioWorklet.addModule(url);
     } finally {
       URL.revokeObjectURL(url);
     }
-    workletNode = new (
-      AudioWorkletNode as unknown as new (
-        c: MicAudioContextLike,
-        name: string,
-      ) => AudioWorkletNodeLike
-    )(ctx, WORKLET_NAME);
-    workletNode.port.onmessage = (event) => {
+    const node = constructBrowserAudioWorkletNode(
+      ctx,
+      WORKLET_NAME,
+      isAudioWorkletNodeLike,
+    );
+    if (!node) {
+      for (const track of stream.getTracks()) track.stop();
+      await ctx.close();
+      throw new VoiceMicCaptureError(
+        "AudioWorkletNode unavailable",
+        "unsupported",
+      );
+    }
+    workletNode = node;
+    node.port.onmessage = (event) => {
       const data = event.data as { pcm?: Float32Array } | undefined;
       if (data?.pcm) emitResampled(data.pcm);
     };
-    source.connect(workletNode as unknown as AudioNodeLike);
+    source.connect(node);
     // Worklet needs a graph terminus to pull frames; connect to destination.
-    (workletNode as unknown as AudioNodeLike).connect(ctx.destination);
+    node.connect(ctx.destination);
   } else if (typeof ctx.createScriptProcessor === "function") {
     backend = "scriptprocessor";
     // 4096-sample buffer is the WebView-113-safe choice (power of two, low

--- a/packages/ui/src/voice/voice-session-pcm.ts
+++ b/packages/ui/src/voice/voice-session-pcm.ts
@@ -57,7 +57,11 @@ export function floatPcmToInt16Bytes(pcm: Float32Array): Uint8Array {
   const out = new Uint8Array(pcm.length * 2);
   const view = new DataView(out.buffer);
   for (let i = 0; i < pcm.length; i += 1) {
-    view.setInt16(i * 2, floatSampleToInt16(pcm[i] ?? 0), /* littleEndian */ true);
+    view.setInt16(
+      i * 2,
+      floatSampleToInt16(pcm[i] ?? 0),
+      /* littleEndian */ true,
+    );
   }
   return out;
 }

--- a/packages/ui/src/voice/voice-session-playback.ts
+++ b/packages/ui/src/voice/voice-session-playback.ts
@@ -178,54 +178,67 @@ export async function createVoiceSessionPlayback(
   let jsReadOffset = 0;
   let jsHadAudio = false;
 
-  if (hasPlaybackWorkletSupport(ctx)) {
-    backend = "audioworklet";
-    await ctx.audioWorklet.addModule(VOICE_SESSION_DOWNLINK_WORKLET_MODULE_URL);
-    const node = constructBrowserAudioWorkletNode(
-      ctx,
-      PLAYBACK_WORKLET_NAME,
-      isPlaybackWorkletNodeLike,
-    );
-    if (!node) {
-      await ctx.close();
-      throw new Error("AudioWorkletNode unavailable for playback");
-    }
-    workletNode = node;
-    node.port.onmessage = (event) => {
-      const d = event.data as { type?: string } | undefined;
-      if (d?.type === "drained") options.onDrained?.();
-    };
-    node.connect(ctx.destination);
-  } else if (typeof ctx.createScriptProcessor === "function") {
-    backend = "scriptprocessor";
-    scriptNode = ctx.createScriptProcessor(4096, 1, 1);
-    scriptNode.onaudioprocess = (event) => {
-      const outBuf = event.outputBuffer;
-      const ch = outBuf.getChannelData(0);
-      for (let i = 0; i < ch.length; i += 1) {
-        while (jsQueue.length > 0 && jsReadOffset >= jsQueue[0].length) {
-          jsQueue.shift();
-          jsReadOffset = 0;
-        }
-        if (jsQueue.length === 0) {
-          ch[i] = 0;
-          if (jsHadAudio) {
-            jsHadAudio = false;
-            options.onDrained?.();
+  try {
+    if (hasPlaybackWorkletSupport(ctx)) {
+      backend = "audioworklet";
+      await ctx.audioWorklet.addModule(
+        VOICE_SESSION_DOWNLINK_WORKLET_MODULE_URL,
+      );
+      const node = constructBrowserAudioWorkletNode(
+        ctx,
+        PLAYBACK_WORKLET_NAME,
+        isPlaybackWorkletNodeLike,
+      );
+      if (!node) {
+        throw new Error("AudioWorkletNode unavailable for playback");
+      }
+      workletNode = node;
+      node.port.onmessage = (event) => {
+        const d = event.data as { type?: string } | undefined;
+        if (d?.type === "drained") options.onDrained?.();
+      };
+      node.connect(ctx.destination);
+    } else if (typeof ctx.createScriptProcessor === "function") {
+      backend = "scriptprocessor";
+      scriptNode = ctx.createScriptProcessor(4096, 1, 1);
+      scriptNode.onaudioprocess = (event) => {
+        const outBuf = event.outputBuffer;
+        const ch = outBuf.getChannelData(0);
+        for (let i = 0; i < ch.length; i += 1) {
+          while (jsQueue.length > 0 && jsReadOffset >= jsQueue[0].length) {
+            jsQueue.shift();
+            jsReadOffset = 0;
           }
-        } else {
-          ch[i] = jsQueue[0][jsReadOffset];
-          jsReadOffset += 1;
+          if (jsQueue.length === 0) {
+            ch[i] = 0;
+            if (jsHadAudio) {
+              jsHadAudio = false;
+              options.onDrained?.();
+            }
+          } else {
+            ch[i] = jsQueue[0][jsReadOffset];
+            jsReadOffset += 1;
+          }
         }
-      }
-      for (let c = 1; c < outBuf.numberOfChannels; c += 1) {
-        outBuf.getChannelData(c).set(ch);
-      }
-    };
-    scriptNode.connect(ctx.destination);
-  } else {
+        for (let c = 1; c < outBuf.numberOfChannels; c += 1) {
+          outBuf.getChannelData(c).set(ch);
+        }
+      };
+      scriptNode.connect(ctx.destination);
+    } else {
+      throw new Error("no AudioWorklet or ScriptProcessor for playback");
+    }
+  } catch (error) {
+    if (workletNode) {
+      workletNode.port.onmessage = null;
+      workletNode.disconnect();
+    }
+    if (scriptNode) {
+      scriptNode.onaudioprocess = null;
+      scriptNode.disconnect();
+    }
     await ctx.close().catch(() => {});
-    throw new Error("no AudioWorklet or ScriptProcessor for playback");
+    throw error;
   }
 
   const pushSamples = (samples: Float32Array): void => {

--- a/packages/ui/src/voice/voice-session-playback.ts
+++ b/packages/ui/src/voice/voice-session-playback.ts
@@ -20,6 +20,7 @@
  * Tests inject a fake AudioContext to drive the real queue/flush/unlock code.
  */
 
+import { VOICE_SESSION_DOWNLINK_WORKLET_MODULE_URL } from "./audio-worklet-module-urls";
 import {
   constructBrowserAudioContext,
   constructBrowserAudioWorkletNode,
@@ -31,7 +32,7 @@ import {
 
 export interface PlaybackAudioContextLike {
   readonly sampleRate: number;
-  readonly state: "suspended" | "running" | "closed";
+  readonly state: AudioContextState;
   audioWorklet?: { addModule(url: string): Promise<void> };
   createScriptProcessor?(
     bufferSize: number,
@@ -95,7 +96,10 @@ function isPlaybackAudioContextLike(
   const state: unknown = Reflect.get(value, "state");
   return (
     typeof Reflect.get(value, "sampleRate") === "number" &&
-    (state === "suspended" || state === "running" || state === "closed") &&
+    (state === "suspended" ||
+      state === "interrupted" ||
+      state === "running" ||
+      state === "closed") &&
     isPlaybackNodeLike(Reflect.get(value, "destination")) &&
     typeof Reflect.get(value, "resume") === "function" &&
     typeof Reflect.get(value, "close") === "function"
@@ -114,57 +118,12 @@ export interface VoiceSessionPlaybackOptions {
 
 const PLAYBACK_WORKLET_NAME = "eliza-voice-session-downlink";
 
-// The worklet owns a growable ring of Float32 samples; the main thread posts
-// PCM frames + a "flush" command. It pulls samples per render quantum, emitting
-// silence when starved (so playback never blocks) and posting "drained" when it
-// transitions from having audio to empty.
-const PLAYBACK_WORKLET_SOURCE = `
-class ElizaVoiceSessionDownlink extends AudioWorkletProcessor {
-  constructor() {
-    super();
-    this.queue = [];
-    this.readOffset = 0;
-    this.hadAudio = false;
-    this.port.onmessage = (e) => {
-      const d = e.data;
-      if (!d) return;
-      if (d.type === 'pcm' && d.pcm) { this.queue.push(d.pcm); this.hadAudio = true; }
-      else if (d.type === 'flush') { this.queue = []; this.readOffset = 0; }
-    };
-  }
-  process(_inputs, outputs) {
-    const out = outputs[0];
-    const ch = out[0];
-    if (!ch) return true;
-    for (let i = 0; i < ch.length; i += 1) {
-      while (this.queue.length > 0 && this.readOffset >= this.queue[0].length) {
-        this.queue.shift();
-        this.readOffset = 0;
-      }
-      if (this.queue.length === 0) {
-        ch[i] = 0;
-        if (this.hadAudio) { this.hadAudio = false; this.port.postMessage({ type: 'drained' }); }
-      } else {
-        ch[i] = this.queue[0][this.readOffset];
-        this.readOffset += 1;
-      }
-    }
-    for (let c = 1; c < out.length; c += 1) out[c].set(ch);
-    return true;
-  }
-}
-registerProcessor("${PLAYBACK_WORKLET_NAME}", ElizaVoiceSessionDownlink);
-`;
-
 export function hasPlaybackWorkletSupport(
   ctx: PlaybackAudioContextLike,
 ): ctx is WorkletCapablePlaybackContext {
   return (
     typeof ctx.audioWorklet?.addModule === "function" &&
-    typeof globalThis.AudioWorkletNode !== "undefined" &&
-    typeof Blob !== "undefined" &&
-    typeof URL !== "undefined" &&
-    typeof URL.createObjectURL === "function"
+    typeof globalThis.AudioWorkletNode !== "undefined"
   );
 }
 
@@ -221,14 +180,7 @@ export async function createVoiceSessionPlayback(
 
   if (hasPlaybackWorkletSupport(ctx)) {
     backend = "audioworklet";
-    const url = URL.createObjectURL(
-      new Blob([PLAYBACK_WORKLET_SOURCE], { type: "text/javascript" }),
-    );
-    try {
-      await ctx.audioWorklet.addModule(url);
-    } finally {
-      URL.revokeObjectURL(url);
-    }
+    await ctx.audioWorklet.addModule(VOICE_SESSION_DOWNLINK_WORKLET_MODULE_URL);
     const node = constructBrowserAudioWorkletNode(
       ctx,
       PLAYBACK_WORKLET_NAME,
@@ -331,7 +283,7 @@ export async function createVoiceSessionPlayback(
     },
     async unlock() {
       if (stopped) return;
-      if (ctx.state === "suspended") {
+      if (ctx.state === "suspended" || ctx.state === "interrupted") {
         await ctx.resume().catch(() => {});
       }
       if (isRunning()) {

--- a/packages/ui/src/voice/voice-session-playback.ts
+++ b/packages/ui/src/voice/voice-session-playback.ts
@@ -21,6 +21,10 @@
  */
 
 import {
+  constructBrowserAudioContext,
+  constructBrowserAudioWorkletNode,
+} from "./browser-audio-runtime";
+import {
   int16BytesToFloatPcm,
   VOICE_PCM_SAMPLE_RATE,
 } from "./voice-session-pcm";
@@ -61,6 +65,46 @@ export interface PlaybackWorkletNodeLike extends PlaybackNodeLike {
     postMessage(data: unknown, transfer?: Transferable[]): void;
   };
 }
+
+function isPlaybackNodeLike(value: unknown): value is PlaybackNodeLike {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof Reflect.get(value, "connect") === "function" &&
+    typeof Reflect.get(value, "disconnect") === "function"
+  );
+}
+
+function isPlaybackWorkletNodeLike(
+  value: unknown,
+): value is PlaybackWorkletNodeLike {
+  if (!isPlaybackNodeLike(value)) return false;
+  const port: unknown = Reflect.get(value, "port");
+  return (
+    typeof port === "object" &&
+    port !== null &&
+    "onmessage" in port &&
+    typeof Reflect.get(port, "postMessage") === "function"
+  );
+}
+
+function isPlaybackAudioContextLike(
+  value: unknown,
+): value is PlaybackAudioContextLike {
+  if (typeof value !== "object" || value === null) return false;
+  const state: unknown = Reflect.get(value, "state");
+  return (
+    typeof Reflect.get(value, "sampleRate") === "number" &&
+    (state === "suspended" || state === "running" || state === "closed") &&
+    isPlaybackNodeLike(Reflect.get(value, "destination")) &&
+    typeof Reflect.get(value, "resume") === "function" &&
+    typeof Reflect.get(value, "close") === "function"
+  );
+}
+
+type WorkletCapablePlaybackContext = PlaybackAudioContextLike & {
+  audioWorklet: { addModule(url: string): Promise<void> };
+};
 
 export interface VoiceSessionPlaybackOptions {
   createAudioContext?: () => PlaybackAudioContextLike;
@@ -114,10 +158,10 @@ registerProcessor("${PLAYBACK_WORKLET_NAME}", ElizaVoiceSessionDownlink);
 
 export function hasPlaybackWorkletSupport(
   ctx: PlaybackAudioContextLike,
-): boolean {
+): ctx is WorkletCapablePlaybackContext {
   return (
     typeof ctx.audioWorklet?.addModule === "function" &&
-    typeof AudioWorkletNode !== "undefined" &&
+    typeof globalThis.AudioWorkletNode !== "undefined" &&
     typeof Blob !== "undefined" &&
     typeof URL !== "undefined" &&
     typeof URL.createObjectURL === "function"
@@ -146,23 +190,16 @@ export async function createVoiceSessionPlayback(
   const createAudioContext =
     options.createAudioContext ??
     (() => {
-      const Ctor =
-        typeof window !== "undefined"
-          ? (window as unknown as {
-              AudioContext?: new (o?: { sampleRate?: number }) => PlaybackAudioContextLike;
-            }).AudioContext ??
-            (window as unknown as {
-              webkitAudioContext?: new (o?: {
-                sampleRate?: number;
-              }) => PlaybackAudioContextLike;
-            }).webkitAudioContext
-          : undefined;
-      if (!Ctor) throw new Error("AudioContext unavailable for playback");
+      const context = constructBrowserAudioContext(
+        [{ sampleRate: VOICE_PCM_SAMPLE_RATE }],
+        isPlaybackAudioContextLike,
+      );
+      if (!context) throw new Error("AudioContext unavailable for playback");
       // Request a 16 kHz context so the pcm16 downlink plays at native rate with
       // no resample; if the platform ignores it (Safari sometimes forces 44.1),
       // the ScriptProcessor/worklet plays the raw samples — a pitch shift the
       // caller can correct later, but correctness of framing/flush is unaffected.
-      return new Ctor({ sampleRate: VOICE_PCM_SAMPLE_RATE });
+      return context;
     });
 
   const ctx = createAudioContext();
@@ -188,19 +225,25 @@ export async function createVoiceSessionPlayback(
       new Blob([PLAYBACK_WORKLET_SOURCE], { type: "text/javascript" }),
     );
     try {
-      await ctx.audioWorklet!.addModule(url);
+      await ctx.audioWorklet.addModule(url);
     } finally {
       URL.revokeObjectURL(url);
     }
-    workletNode = new (AudioWorkletNode as unknown as new (
-      c: PlaybackAudioContextLike,
-      name: string,
-    ) => PlaybackWorkletNodeLike)(ctx, PLAYBACK_WORKLET_NAME);
-    workletNode.port.onmessage = (event) => {
+    const node = constructBrowserAudioWorkletNode(
+      ctx,
+      PLAYBACK_WORKLET_NAME,
+      isPlaybackWorkletNodeLike,
+    );
+    if (!node) {
+      await ctx.close();
+      throw new Error("AudioWorkletNode unavailable for playback");
+    }
+    workletNode = node;
+    node.port.onmessage = (event) => {
       const d = event.data as { type?: string } | undefined;
       if (d?.type === "drained") options.onDrained?.();
     };
-    (workletNode as unknown as PlaybackNodeLike).connect(ctx.destination);
+    node.connect(ctx.destination);
   } else if (typeof ctx.createScriptProcessor === "function") {
     backend = "scriptprocessor";
     scriptNode = ctx.createScriptProcessor(4096, 1, 1);

--- a/packages/ui/src/voice/voice-session-playback.ts
+++ b/packages/ui/src/voice/voice-session-playback.ts
@@ -20,7 +20,7 @@
  * Tests inject a fake AudioContext to drive the real queue/flush/unlock code.
  */
 
-import { VOICE_SESSION_DOWNLINK_WORKLET_MODULE_URL } from "./audio-worklet-module-urls";
+import { resolveAudioWorkletModuleUrl } from "./audio-worklet-module-urls";
 import {
   constructBrowserAudioContext,
   constructBrowserAudioWorkletNode,
@@ -182,7 +182,7 @@ export async function createVoiceSessionPlayback(
     if (hasPlaybackWorkletSupport(ctx)) {
       backend = "audioworklet";
       await ctx.audioWorklet.addModule(
-        VOICE_SESSION_DOWNLINK_WORKLET_MODULE_URL,
+        resolveAudioWorkletModuleUrl("downlink"),
       );
       const node = constructBrowserAudioWorkletNode(
         ctx,

--- a/packages/ui/src/voice/worklets/playback-reference-tap.js
+++ b/packages/ui/src/voice/worklets/playback-reference-tap.js
@@ -1,0 +1,32 @@
+// biome-ignore-all lint/correctness/noUndeclaredVariables: AudioWorklet globals are supplied by the worklet scope.
+
+class ElizaPlaybackReferenceTap extends AudioWorkletProcessor {
+  process(inputs) {
+    const input = inputs[0] || [];
+    const firstChannel = input[0];
+    if (firstChannel && firstChannel.length > 0) {
+      const mono = new Float32Array(firstChannel.length);
+      const channels = Math.max(1, input.length);
+      for (let i = 0; i < firstChannel.length; i += 1) {
+        let sum = 0;
+        let count = 0;
+        for (
+          let channelIndex = 0;
+          channelIndex < channels;
+          channelIndex += 1
+        ) {
+          const channel = input[channelIndex];
+          if (channel) {
+            sum += channel[i] || 0;
+            count += 1;
+          }
+        }
+        mono[i] = count > 0 ? sum / count : 0;
+      }
+      this.port.postMessage({ pcm: mono, sampleRate }, [mono.buffer]);
+    }
+    return true;
+  }
+}
+
+registerProcessor("eliza-playback-reference-tap", ElizaPlaybackReferenceTap);

--- a/packages/ui/src/voice/worklets/voice-session-downlink.js
+++ b/packages/ui/src/voice/worklets/voice-session-downlink.js
@@ -1,0 +1,52 @@
+// biome-ignore-all lint/correctness/noUndeclaredVariables: AudioWorklet globals are supplied by the worklet scope.
+
+class ElizaVoiceSessionDownlink extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this.queue = [];
+    this.readOffset = 0;
+    this.hadAudio = false;
+    this.port.onmessage = (event) => {
+      const data = event.data;
+      if (!data) return;
+      if (data.type === "pcm" && data.pcm) {
+        this.queue.push(data.pcm);
+        this.hadAudio = true;
+      } else if (data.type === "flush") {
+        this.queue = [];
+        this.readOffset = 0;
+      }
+    };
+  }
+
+  process(_inputs, outputs) {
+    const output = outputs[0];
+    const firstChannel = output[0];
+    if (!firstChannel) return true;
+    for (let i = 0; i < firstChannel.length; i += 1) {
+      while (
+        this.queue.length > 0 &&
+        this.readOffset >= this.queue[0].length
+      ) {
+        this.queue.shift();
+        this.readOffset = 0;
+      }
+      if (this.queue.length === 0) {
+        firstChannel[i] = 0;
+        if (this.hadAudio) {
+          this.hadAudio = false;
+          this.port.postMessage({ type: "drained" });
+        }
+      } else {
+        firstChannel[i] = this.queue[0][this.readOffset];
+        this.readOffset += 1;
+      }
+    }
+    for (let channelIndex = 1; channelIndex < output.length; channelIndex += 1) {
+      output[channelIndex].set(firstChannel);
+    }
+    return true;
+  }
+}
+
+registerProcessor("eliza-voice-session-downlink", ElizaVoiceSessionDownlink);

--- a/packages/ui/src/voice/worklets/voice-session-uplink.js
+++ b/packages/ui/src/voice/worklets/voice-session-uplink.js
@@ -1,0 +1,24 @@
+// biome-ignore-all lint/correctness/noUndeclaredVariables: AudioWorklet globals are supplied by the worklet scope.
+
+class ElizaVoiceSessionUplink extends AudioWorkletProcessor {
+  process(inputs) {
+    const input = inputs[0];
+    if (!input || input.length === 0) return true;
+    const frames = input[0] ? input[0].length : 0;
+    if (frames === 0) return true;
+    const channels = input.length;
+    const mono = new Float32Array(frames);
+    for (let i = 0; i < frames; i += 1) {
+      let sum = 0;
+      for (let channelIndex = 0; channelIndex < channels; channelIndex += 1) {
+        const channel = input[channelIndex];
+        sum += channel ? channel[i] || 0 : 0;
+      }
+      mono[i] = sum / channels;
+    }
+    this.port.postMessage({ pcm: mono, sampleRate }, [mono.buffer]);
+    return true;
+  }
+}
+
+registerProcessor("eliza-voice-session-uplink", ElizaVoiceSessionUplink);

--- a/packages/ui/test/story-gate/baseline/a11y-baseline.json
+++ b/packages/ui/test/story-gate/baseline/a11y-baseline.json
@@ -487,12 +487,6 @@
   "cockpit-cockpitmodepicker--experimental-armed": [
     "color-contrast"
   ],
-  "cockpit-cockpitnewsessionform--default": [
-    "color-contrast"
-  ],
-  "cockpit-cockpitnewsessionform--experimental-armed": [
-    "color-contrast"
-  ],
   "cockpit-cockpitview--empty": [
     "color-contrast"
   ],

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/account-failure-propagation.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/account-failure-propagation.test.ts
@@ -249,7 +249,9 @@ describe("coding account selection helpers", () => {
             healthy: 0,
           },
         ],
-        codex: [{ providerId: "openai-codex", total: 1, enabled: 1, healthy: 1 }],
+        codex: [
+          { providerId: "openai-codex", total: 1, enabled: 1, healthy: 1 },
+        ],
       }),
       select: vi.fn(async () => null),
       markRateLimited: vi.fn(async () => undefined),

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/model-chooser-contract.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/model-chooser-contract.test.ts
@@ -171,7 +171,13 @@ function clearBridge(): void {
 }
 
 function runtime(settings: Record<string, string | undefined> = {}) {
-  const values = { ELIZA_ACP_TRANSPORT: "native", ...settings };
+  const values = {
+    ELIZA_ACP_TRANSPORT: "native",
+    // NativeAcpClient is mocked in this contract suite; command provisioning is
+    // outside its scope and must not depend on workspace build artifacts.
+    ELIZA_ELIZAOS_ACP_COMMAND: "test-eliza-code-acp",
+    ...settings,
+  };
   return {
     logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     getSetting: vi.fn((key: string) => values[key]),

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/multi-account-spawn.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/multi-account-spawn.test.ts
@@ -140,7 +140,13 @@ function clearBridge() {
 }
 
 function runtime(settings: Record<string, string | undefined> = {}) {
-  const values = { ELIZA_ACP_TRANSPORT: "native", ...settings };
+  const values = {
+    ELIZA_ACP_TRANSPORT: "native",
+    // NativeAcpClient is mocked in this contract suite; command provisioning is
+    // outside its scope and must not depend on workspace build artifacts.
+    ELIZA_ELIZAOS_ACP_COMMAND: "test-eliza-code-acp",
+    ...settings,
+  };
   return {
     logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     getSetting: vi.fn((key: string) => values[key]),

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-admission-queue.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-admission-queue.test.ts
@@ -145,6 +145,9 @@ afterAll(() => {
 function acpRuntime(settings: Record<string, string | undefined> = {}) {
   const values: Record<string, string | undefined> = {
     ELIZA_ACP_TRANSPORT: undefined, // native
+    // NativeAcpClient is mocked in this queue suite; command provisioning is
+    // outside its scope and must not depend on workspace build artifacts.
+    ELIZA_ELIZAOS_ACP_COMMAND: "test-eliza-code-acp",
     ...settings,
   };
   return {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-concurrency-e2e.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-concurrency-e2e.test.ts
@@ -151,7 +151,12 @@ import { AcpService } from "../../src/services/acp-service.js";
 function runtime(settings: Record<string, string | undefined> = {}) {
   // ELIZA_ACP_TRANSPORT undefined selects the native transport (the fake client
   // mocked above), so spawns resolve to "ready" without the CLI proc-mock dance.
-  const values: Record<string, string | undefined> = { ...settings };
+  const values: Record<string, string | undefined> = {
+    // NativeAcpClient is mocked in this concurrency suite; command provisioning
+    // is outside its scope and must not depend on workspace build artifacts.
+    ELIZA_ELIZAOS_ACP_COMMAND: "test-eliza-code-acp",
+    ...settings,
+  };
   return {
     logger: {
       debug: vi.fn(),

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
@@ -13,11 +13,11 @@
  *  - cross-task status aggregation and bulk pause/resume.
  */
 
-import type { IAgentRuntime } from "@elizaos/core";
 import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import type { IAgentRuntime } from "@elizaos/core";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { OrchestratorTaskService } from "../../src/services/orchestrator-task-service.js";
 import { OrchestratorTaskStore } from "../../src/services/orchestrator-task-store.js";
@@ -1235,15 +1235,9 @@ describe("OrchestratorTaskService — event bridge session status", () => {
       await service.start();
       const task = await service.createTask(createInput());
       await store.updateTask(task.id, { boundWorkdir: repo });
-      const spawned = must(
-        await service.spawnAgentForTask(task.id),
-        "spawned",
-      );
+      const spawned = must(await service.spawnAgentForTask(task.id), "spawned");
       const sessionId = must(spawned.sessions[0], "session").sessionId;
-      const live = must(
-        acp.liveSessions.get(sessionId),
-        "live ACP session",
-      );
+      const live = must(acp.liveSessions.get(sessionId), "live ACP session");
       live.metadata = {
         lastChangeSet: {
           changedFiles: "src/foo.ts",
@@ -1413,7 +1407,8 @@ describe("OrchestratorTaskService — event bridge session status", () => {
         }),
         expect.objectContaining({
           eventType: "account_failover_resumed",
-          summary: "Resumed after a capacity/overload condition (work preserved)",
+          summary:
+            "Resumed after a capacity/overload condition (work preserved)",
         }),
       ]),
     );
@@ -1826,9 +1821,10 @@ describe("OrchestratorTaskService — aggregation and bulk controls", () => {
         },
       },
     });
-    (
-      service as unknown as { admissionQueue: string[] }
-    ).admissionQueue.push(task.id, "missing-task");
+    (service as unknown as { admissionQueue: string[] }).admissionQueue.push(
+      task.id,
+      "missing-task",
+    );
 
     await expect(service.getAdmissionSnapshot()).resolves.toEqual({
       queueDepth: 1,
@@ -1851,7 +1847,9 @@ describe("OrchestratorTaskService — aggregation and bulk controls", () => {
         writeAdmission: (taskId: string, value: null) => Promise<void>;
       }
     ).writeAdmission(task.id, null);
-    expect((await store.getTask(task.id))?.task.metadata?.admission).toBeUndefined();
+    expect(
+      (await store.getTask(task.id))?.task.metadata?.admission,
+    ).toBeUndefined();
 
     const noAcpService = makeService(undefined, {
       ELIZA_ACP_QUEUE_AGING_MS: "600000",

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/resume-context.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/resume-context.test.ts
@@ -20,9 +20,9 @@ import {
   buildResumePreamble,
   MAX_RESUME_CHANGED_FILES,
   MAX_RESUME_PROGRESS_CHARS,
-  readResumeContext,
   RESUME_CONTEXT_METADATA_KEY,
   type ResumeContext,
+  readResumeContext,
   resumeEventFields,
 } from "../../src/services/resume-context.js";
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router-failover-resume.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router-failover-resume.test.ts
@@ -32,13 +32,13 @@ vi.mock("../../src/services/config-env.js", () => ({
 // registered symbol the source's bridgeSlot() reads/writes.
 const BRIDGE_SYMBOL = Symbol.for("eliza.account-pool.coding-agent.v1");
 
+import { OrchestratorTaskService } from "../../src/services/orchestrator-task-service.js";
+import { OrchestratorTaskStore } from "../../src/services/orchestrator-task-store.js";
+import type { OrchestratorTaskSession } from "../../src/services/orchestrator-task-types.js";
 import {
   RESUME_CONTEXT_METADATA_KEY,
   readResumeContext,
 } from "../../src/services/resume-context.js";
-import { OrchestratorTaskService } from "../../src/services/orchestrator-task-service.js";
-import { OrchestratorTaskStore } from "../../src/services/orchestrator-task-store.js";
-import type { OrchestratorTaskSession } from "../../src/services/orchestrator-task-types.js";
 import { SubAgentRouter } from "../../src/services/sub-agent-router.js";
 import type { SessionInfo } from "../../src/services/types.js";
 

--- a/plugins/plugin-openrouter/utils/events.ts
+++ b/plugins/plugin-openrouter/utils/events.ts
@@ -51,7 +51,9 @@ export function extractCacheTokens(usage: AIUsage): {
   cacheCreation?: number;
 } {
   const cacheRead =
-    usage.cacheReadInputTokens ?? usage.cachedInputTokens ?? usage.inputTokenDetails?.cacheReadTokens;
+    usage.cacheReadInputTokens ??
+    usage.cachedInputTokens ??
+    usage.inputTokenDetails?.cacheReadTokens;
   const cacheCreation = usage.cacheCreationInputTokens ?? usage.inputTokenDetails?.cacheWriteTokens;
   return { cacheRead, cacheCreation };
 }

--- a/plugins/plugin-wallet/src/types/trade.ts
+++ b/plugins/plugin-wallet/src/types/trade.ts
@@ -9,7 +9,10 @@ import type { FailureCode } from "../actions/failure-codes.js";
 export type Venue = "hyperliquid" | "polymarket";
 
 export type TradeOutcomeClass =
-  "not_attempted" | "rejected" | "unknown" | "policy_denied";
+  | "not_attempted"
+  | "rejected"
+  | "unknown"
+  | "policy_denied";
 
 export type PolicyDenyReason =
   | "market-not-allowed"
@@ -100,7 +103,8 @@ export type PolymarketSubmitOrderRequest = {
 };
 
 export type SubmitOrderRequest =
-  HyperliquidSubmitOrderRequest | PolymarketSubmitOrderRequest;
+  | HyperliquidSubmitOrderRequest
+  | PolymarketSubmitOrderRequest;
 
 export interface CancelOrderRequest {
   readonly venue: Venue;


### PR DESCRIPTION
## Summary

Restores the current `develop` branch after deterministic regressions in realtime voice, UI fixtures, type-safety, Windows CI, and repository hygiene blocked unrelated work.

The repair keeps the existing security and quality boundaries intact: no CSP broadening, no type-safety baseline increases, no skipped product tests, and no production deployment.

Tracks #16167. Production ACP first-use locking remains the separately reviewed follow-up in #16169.

## What changed

- Replaces blob AudioWorklet module URLs with packaged same-origin assets.
- Validates native voice runtime handles and performs best-effort cleanup across every failed microphone, AudioContext, AudioWorkletNode, and WebSocket startup boundary.
- Handles interrupted/closed playback contexts explicitly.
- Restores the exact type-safety ratchet limits and TypeScript 7 compatibility.
- Repairs homepage workspace resolution, cockpit contrast, chat-harness policy violations, suggestions fixtures, and stale Agent/App/UI expectations.
- Keeps mocked ACP tests independent from missing production artifacts.
- Moves script helper tests into the normal `packages/scripts/__tests__` discovery surface.
- Removes the redundant workflow-level Windows PGlite retry; the existing package runner remains the single bounded native-crash retry owner.
- Restores repository-wide formatting and import-order gates.

## Validation

- `bun run format:check`: 240/240 tasks
- full non-writing `lint:check`: 228/228 tasks
- `bun run verify:cloud`: 84/84 tasks
  - Cloud API TypeScript 7 checks pass
  - production Worker dry-run passes (16,219.93 KiB raw / 3,624.95 KiB gzip)
- script inventory: 9/9
- Windows/quarantine/script-focused tests: 68/68
- focused changed-file tests: 187/187, plus 79 execution-tier and 19 persistence tests
- type-safety, error-policy, voice-policy, view-action, and test-realness audits pass
- 31 changed test files introduce 0 test-realness regressions
- independent final review: no high- or medium-severity findings

## Deployment and residual evidence

- Production is untouched and out of scope.
- The current base Worker deploy is green at `56bea592`.
- Final-head GitHub CI must prove Windows, WebKit, Story Gate, UI fixture, and Scenario behavior before this leaves draft.
- Hetzner E2E currently has an external credential blocker: `HCLOUD_TOKEN_CI` returns HTTP 401. This PR does not mask or misclassify it as a code regression.
- After merge, staging health must report the exact merge SHA before #16167 is closed and before chat latency PR #16156 is rebased.

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16173-before-screenshots.png)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16173-after-screenshots.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence/16173-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [ ] N/A - This UI evidence path is isolated in Storybook and does not invoke a live backend; backend behavior is covered by the linked passing unit and integration checks.

<!-- evidence-row:frontend-logs -->
- [x] [16173-frontend-console-network.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16173-frontend-console-network.log)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - This repair does not change a model, prompt, provider choice, or inference path.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - This repair does not create or mutate persistent domain records.

<!-- evidence-row:ocr-review -->
- [x] [16173-ocr-review.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16173-ocr-review.json)
