### PR TITLE
fix(ui): add execution_tier to CloudCompatAgent

### DIFF
--- a/packages/ui/src/api/client-types-cloud.ts
+++ b/packages/ui/src/api/client-types-cloud.ts
@@ -287,6 +287,9 @@ export interface CloudCompatAgent {
   database_status: string;
   error_message: string | null;
   last_heartbeat_at: string | null;
+  /** Authoritative Cloud execution tier ("shared" | "dedicated"); the
+   * dedicated-mode agent picker filters shared bridges on it. */
+  execution_tier?: string | null;
 }
 
 export interface CloudCompatAgentStatus {


### PR DESCRIPTION
TS2339 `Property 'execution_tier' does not exist on type 'CloudCompatAgent'` at `packages/ui/src/api/client-cloud.ts:3435/3438` on current develop — #16163's dedicated-mode agent filter reads the field and the compat mapper already populates it; only the interface missed it. Breaks `bun run --cwd packages/ui typecheck` (and packages/agent, which references ui).

One additive optional field. `packages/ui` typecheck green after.

Screenshots/video: N/A — type-only fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)