### PR TITLE
feat(anthropic): effort-driven adaptive thinking + live-probed model gates (stage 3)

### DIFF
--- a/packages/agent/src/api/model-catalog.test.ts
+++ b/packages/agent/src/api/model-catalog.test.ts
@@ -191,7 +191,6 @@ describe("claude chat/coding effort gates", () => {
         "claude-opus-4-6",
         "claude-sonnet-5",
         "claude-sonnet-4-6",
-        "claude-haiku-4-5-20251001",
       ]) {
         expect(entry(catalog, provider, id).efforts).toEqual([
           "low",
@@ -200,6 +199,12 @@ describe("claude chat/coding effort gates", () => {
         ]);
       }
     }
+    // Live-probed 2026-07-12: haiku rejects the chat-API effort parameter
+    // entirely; only the coding CLI's separate effort env applies to it.
+    expect(entry(catalog, "claude-chat", "claude-haiku-4-5-20251001").efforts).toEqual([]);
+    expect(
+      entry(catalog, "claude-coding", "claude-haiku-4-5-20251001").efforts,
+    ).toEqual(["low", "medium", "high"]);
   });
 
   it("assigns chat models small+large and coding models coding", () => {

--- a/packages/agent/src/api/model-catalog.ts
+++ b/packages/agent/src/api/model-catalog.ts
@@ -106,9 +106,17 @@ const CODEX_STATIC_ENTRIES: ModelCatalogEntry[] = [
   },
 ];
 
-// Anthropic effort gate: xhigh/max only on opus >= 4.7 and fable-5; haiku
-// caps at high; sonnets cap at high.
-const CLAUDE_MODELS: Array<{ id: string; display: string; full: boolean }> = [
+// Anthropic effort gate: xhigh/max only on opus >= 4.7 and fable-5; sonnets
+// cap at high. Haiku takes NO chat-API effort at all — live-probed 2026-07-12,
+// the Messages API answers "This model does not support the effort parameter"
+// (and rejects adaptive thinking); the coding CLI's CLAUDE_CODE_EFFORT_LEVEL
+// is a separate mechanism and keeps its low..high range there.
+const CLAUDE_MODELS: Array<{
+  id: string;
+  display: string;
+  full: boolean;
+  chatEffort?: false;
+}> = [
   { id: "claude-fable-5", display: "Claude Fable 5", full: true },
   { id: "claude-opus-4-8", display: "Claude Opus 4.8", full: true },
   { id: "claude-opus-4-7", display: "Claude Opus 4.7", full: true },
@@ -119,6 +127,7 @@ const CLAUDE_MODELS: Array<{ id: string; display: string; full: boolean }> = [
     id: "claude-haiku-4-5-20251001",
     display: "Claude Haiku 4.5",
     full: false,
+    chatEffort: false,
   },
 ];
 
@@ -131,7 +140,7 @@ function claudeEfforts(full: boolean): string[] {
 const CLAUDE_CHAT_ENTRIES: ModelCatalogEntry[] = CLAUDE_MODELS.map((m) => ({
   id: m.id,
   display: m.display,
-  efforts: claudeEfforts(m.full),
+  efforts: m.chatEffort === false ? [] : claudeEfforts(m.full),
   roles: ["small", "large"],
 }));
 

--- a/packages/agent/src/api/model-config-routes.test.ts
+++ b/packages/agent/src/api/model-config-routes.test.ts
@@ -84,18 +84,18 @@ describe("POST /api/models/config validation", () => {
     expect(saveElizaConfig).not.toHaveBeenCalled();
   });
 
-  it("rejects xhigh on haiku via claude-chat", async () => {
+  it("rejects any effort on haiku via claude-chat (no chat effort knob)", async () => {
     const { ctx, json } = makeHarness("POST", {
       target: "small",
       provider: "claude-chat",
       model: "claude-haiku-4-5-20251001",
-      effort: "xhigh",
+      effort: "high",
     });
     await handleModelConfigRoutes(ctx as never);
     const { body, status } = responseOf(json);
     expect(status).toBe(400);
     expect(body.code).toBe("MODEL_CONFIG_INVALID");
-    expect(String(body.error)).toContain("xhigh");
+    expect(String(body.error)).toContain("no effort control");
   });
 
   // gemma carries a live-proven low/medium/high knob (2026-07-12 probe), so
@@ -221,10 +221,11 @@ describe("POST /api/models/config chat writes", () => {
   });
 
   it("writes ANTHROPIC keys (model + per-target effort) for claude-chat", async () => {
+    // sonnet-5, not haiku: haiku carries no chat effort knob (live-probed).
     const { ctx, config, processEnv } = makeHarness("POST", {
       target: "small",
       provider: "claude-chat",
-      model: "claude-haiku-4-5-20251001",
+      model: "claude-sonnet-5",
       effort: "high",
     });
     await handleModelConfigRoutes(ctx as never);
@@ -232,7 +233,7 @@ describe("POST /api/models/config chat writes", () => {
       string,
       unknown
     >;
-    expect(env.ANTHROPIC_SMALL_MODEL).toBe("claude-haiku-4-5-20251001");
+    expect(env.ANTHROPIC_SMALL_MODEL).toBe("claude-sonnet-5");
     expect(env.ANTHROPIC_EFFORT_SMALL).toBe("high");
     expect(processEnv.ANTHROPIC_EFFORT_SMALL).toBe("high");
   });

--- a/plugins/plugin-anthropic/AGENTS.md
+++ b/plugins/plugin-anthropic/AGENTS.md
@@ -97,6 +97,9 @@ All settings are read via `runtime.getSetting(key)` first, then `process.env[key
 | `ANTHROPIC_COT_BUDGET` | No | `0` | Chain-of-thought token budget (both sizes) |
 | `ANTHROPIC_COT_BUDGET_SMALL` | No | — | CoT budget for small-size models |
 | `ANTHROPIC_COT_BUDGET_LARGE` | No | — | CoT budget for large-size models |
+| `ANTHROPIC_EFFORT` | No | — | Reasoning effort (`low`\|`medium`\|`high`\|`xhigh`\|`max`) sent as adaptive thinking + `output_config.effort`; wins over the CoT budget. xhigh/max clamp to high below opus 4.7/fable-5; haiku ignores it (model rejects the parameter) |
+| `ANTHROPIC_EFFORT_SMALL` | No | — | Effort for small-size models (what `POST /api/models/config` persists) |
+| `ANTHROPIC_EFFORT_LARGE` | No | — | Effort for large-size models |
 | `ANTHROPIC_PROMPT_CACHE_TTL` | No | `5m` | Prompt cache TTL: `"5m"` or `"1h"` |
 | `ANTHROPIC_TEMPERATURE_LOCKED_MODELS` | No | — | Comma-separated model ids that only accept `temperature=1`, applied on top of the built-in `opus-4` name check |
 | `ANTHROPIC_MAX_OUTPUT_TOKENS` | No | — | Output-token cap override: a bare number and/or comma-separated `model-id:tokens` pairs; unlisted models keep the built-in caps |

--- a/plugins/plugin-anthropic/CLAUDE.md
+++ b/plugins/plugin-anthropic/CLAUDE.md
@@ -97,6 +97,9 @@ All settings are read via `runtime.getSetting(key)` first, then `process.env[key
 | `ANTHROPIC_COT_BUDGET` | No | `0` | Chain-of-thought token budget (both sizes) |
 | `ANTHROPIC_COT_BUDGET_SMALL` | No | — | CoT budget for small-size models |
 | `ANTHROPIC_COT_BUDGET_LARGE` | No | — | CoT budget for large-size models |
+| `ANTHROPIC_EFFORT` | No | — | Reasoning effort (`low`\|`medium`\|`high`\|`xhigh`\|`max`) sent as adaptive thinking + `output_config.effort`; wins over the CoT budget. xhigh/max clamp to high below opus 4.7/fable-5; haiku ignores it (model rejects the parameter) |
+| `ANTHROPIC_EFFORT_SMALL` | No | — | Effort for small-size models (what `POST /api/models/config` persists) |
+| `ANTHROPIC_EFFORT_LARGE` | No | — | Effort for large-size models |
 | `ANTHROPIC_PROMPT_CACHE_TTL` | No | `5m` | Prompt cache TTL: `"5m"` or `"1h"` |
 | `ANTHROPIC_TEMPERATURE_LOCKED_MODELS` | No | — | Comma-separated model ids that only accept `temperature=1`, applied on top of the built-in `opus-4` name check |
 | `ANTHROPIC_MAX_OUTPUT_TOKENS` | No | — | Output-token cap override: a bare number and/or comma-separated `model-id:tokens` pairs; unlisted models keep the built-in caps |

--- a/plugins/plugin-anthropic/__tests__/effort-thinking.shape.test.ts
+++ b/plugins/plugin-anthropic/__tests__/effort-thinking.shape.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Shape tests for the effort/thinking provider options: ANTHROPIC_EFFORT(_SMALL/
+ * _LARGE) becomes adaptive thinking + the AI SDK `effort` option, per-model
+ * ceilings clamp xhigh/max on models that reject them, the legacy fixed CoT
+ * budget survives (and loses to effort), invalid values are dropped, and
+ * thinking-active requests carry temperature=1 with topP removed. Drives the
+ * real handlers against a mocked AI SDK — no live API.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+function createRuntime(settings: Record<string, string>) {
+  return {
+    character: { name: "Claude Agent", system: "system prompt" },
+    emitEvent: vi.fn(),
+    getSetting: vi.fn((key: string) => settings[key]),
+  } as unknown as IAgentRuntime;
+}
+
+function mockAiSdk() {
+  const generateText = vi.fn(async () => ({
+    text: "ok",
+    finishReason: "stop",
+    usage: { inputTokens: 5, outputTokens: 2 },
+  }));
+  vi.doMock("ai", () => ({ generateText, streamText: vi.fn() }));
+  vi.doMock("../providers/anthropic", () => ({
+    createAnthropicClientWithTopPSupport: () => (modelName: string) => ({
+      modelId: modelName,
+    }),
+  }));
+  return generateText;
+}
+
+function anthropicOptionsOf(generateText: ReturnType<typeof vi.fn>) {
+  const call = generateText.mock.calls[0]?.[0] as
+    | {
+        providerOptions?: { anthropic?: Record<string, unknown> };
+        temperature?: number;
+        topP?: number;
+      }
+    | undefined;
+  if (!call) throw new Error("generateText was not called");
+  return {
+    anthropic: call.providerOptions?.anthropic,
+    temperature: call.temperature,
+    topP: call.topP,
+  };
+}
+
+afterEach(() => {
+  vi.doUnmock("ai");
+  vi.doUnmock("../providers/anthropic");
+  vi.clearAllMocks();
+  vi.resetModules();
+});
+
+describe("Anthropic effort/thinking provider options", () => {
+  it("sends adaptive thinking + effort from ANTHROPIC_EFFORT_LARGE and forces temperature=1", async () => {
+    const generateText = mockAiSdk();
+    const { handleTextLarge } = await import("../models/text");
+    await handleTextLarge(
+      createRuntime({
+        ANTHROPIC_API_KEY: "test-key",
+        ANTHROPIC_LARGE_MODEL: "claude-opus-4-8",
+        ANTHROPIC_EFFORT_LARGE: "xhigh",
+      }),
+      { prompt: "hi", temperature: 0.7 } as never
+    );
+    const { anthropic, temperature } = anthropicOptionsOf(generateText);
+    expect(anthropic?.thinking).toEqual({ type: "adaptive" });
+    expect(anthropic?.effort).toBe("xhigh");
+    expect(temperature).toBe(1);
+  }, 60_000);
+
+  it("falls back to the shared ANTHROPIC_EFFORT and normalizes case", async () => {
+    const generateText = mockAiSdk();
+    const { handleTextSmall } = await import("../models/text");
+    await handleTextSmall(
+      createRuntime({
+        ANTHROPIC_API_KEY: "test-key",
+        ANTHROPIC_SMALL_MODEL: "claude-sonnet-5",
+        ANTHROPIC_EFFORT: "Medium",
+      }),
+      { prompt: "hi" } as never
+    );
+    const { anthropic } = anthropicOptionsOf(generateText);
+    expect(anthropic?.effort).toBe("medium");
+    expect(anthropic?.thinking).toEqual({ type: "adaptive" });
+  }, 60_000);
+
+  it("clamps xhigh to high on models without the extended tiers (sonnet)", async () => {
+    const generateText = mockAiSdk();
+    const { handleTextSmall } = await import("../models/text");
+    await handleTextSmall(
+      createRuntime({
+        ANTHROPIC_API_KEY: "test-key",
+        ANTHROPIC_SMALL_MODEL: "claude-sonnet-4-6",
+        ANTHROPIC_EFFORT_SMALL: "xhigh",
+      }),
+      { prompt: "hi" } as never
+    );
+    const { anthropic } = anthropicOptionsOf(generateText);
+    expect(anthropic?.effort).toBe("high");
+  }, 60_000);
+
+  // Live-probed 2026-07-12: haiku-4-5 rejects the effort parameter outright
+  // ("This model does not support the effort parameter"), so a configured
+  // effort must never reach the wire for it.
+  it("never sends effort for haiku (model rejects the parameter)", async () => {
+    const generateText = mockAiSdk();
+    const { handleTextSmall } = await import("../models/text");
+    await handleTextSmall(
+      createRuntime({
+        ANTHROPIC_API_KEY: "test-key",
+        ANTHROPIC_SMALL_MODEL: "claude-haiku-4-5-20251001",
+        ANTHROPIC_EFFORT_SMALL: "high",
+      }),
+      { prompt: "hi" } as never
+    );
+    const { anthropic } = anthropicOptionsOf(generateText);
+    expect(anthropic?.effort).toBeUndefined();
+    expect(anthropic?.thinking).toBeUndefined();
+  }, 60_000);
+
+  it("falls back to the CoT budget on haiku when both are configured", async () => {
+    const generateText = mockAiSdk();
+    const { handleTextSmall } = await import("../models/text");
+    await handleTextSmall(
+      createRuntime({
+        ANTHROPIC_API_KEY: "test-key",
+        ANTHROPIC_SMALL_MODEL: "claude-haiku-4-5-20251001",
+        ANTHROPIC_EFFORT_SMALL: "high",
+        ANTHROPIC_COT_BUDGET_SMALL: "1024",
+      }),
+      { prompt: "hi" } as never
+    );
+    const { anthropic } = anthropicOptionsOf(generateText);
+    expect(anthropic?.effort).toBeUndefined();
+    expect(anthropic?.thinking).toEqual({ type: "enabled", budgetTokens: 1024 });
+  }, 60_000);
+
+  it("keeps max on fable-5", async () => {
+    const generateText = mockAiSdk();
+    const { handleTextLarge } = await import("../models/text");
+    await handleTextLarge(
+      createRuntime({
+        ANTHROPIC_API_KEY: "test-key",
+        ANTHROPIC_LARGE_MODEL: "claude-fable-5",
+        ANTHROPIC_EFFORT_LARGE: "max",
+      }),
+      { prompt: "hi" } as never
+    );
+    const { anthropic } = anthropicOptionsOf(generateText);
+    expect(anthropic?.effort).toBe("max");
+  }, 60_000);
+
+  it("ignores an invalid effort value and sends no thinking block", async () => {
+    const generateText = mockAiSdk();
+    const { handleTextLarge } = await import("../models/text");
+    await handleTextLarge(
+      createRuntime({
+        ANTHROPIC_API_KEY: "test-key",
+        ANTHROPIC_LARGE_MODEL: "claude-sonnet-5",
+        ANTHROPIC_EFFORT_LARGE: "turbo",
+      }),
+      { prompt: "hi" } as never
+    );
+    const { anthropic, temperature } = anthropicOptionsOf(generateText);
+    expect(anthropic?.effort).toBeUndefined();
+    expect(anthropic?.thinking).toBeUndefined();
+    expect(temperature).toBe(0.7);
+  }, 60_000);
+
+  it("keeps the legacy fixed CoT budget shape when no effort is configured", async () => {
+    const generateText = mockAiSdk();
+    const { handleTextLarge } = await import("../models/text");
+    await handleTextLarge(
+      createRuntime({
+        ANTHROPIC_API_KEY: "test-key",
+        ANTHROPIC_LARGE_MODEL: "claude-sonnet-5",
+        ANTHROPIC_COT_BUDGET: "2048",
+      }),
+      { prompt: "hi", temperature: 0.5 } as never
+    );
+    const { anthropic, temperature } = anthropicOptionsOf(generateText);
+    expect(anthropic?.thinking).toEqual({ type: "enabled", budgetTokens: 2048 });
+    expect(anthropic?.effort).toBeUndefined();
+    // Thinking-active requests only accept temperature=1.
+    expect(temperature).toBe(1);
+  }, 60_000);
+
+  it("prefers effort over a configured CoT budget when both are set", async () => {
+    const generateText = mockAiSdk();
+    const { handleTextLarge } = await import("../models/text");
+    await handleTextLarge(
+      createRuntime({
+        ANTHROPIC_API_KEY: "test-key",
+        ANTHROPIC_LARGE_MODEL: "claude-opus-4-8",
+        ANTHROPIC_COT_BUDGET: "2048",
+        ANTHROPIC_EFFORT_LARGE: "high",
+      }),
+      { prompt: "hi" } as never
+    );
+    const { anthropic } = anthropicOptionsOf(generateText);
+    expect(anthropic?.thinking).toEqual({ type: "adaptive" });
+    expect(anthropic?.effort).toBe("high");
+  }, 60_000);
+
+  it("drops topP when thinking is active", async () => {
+    const generateText = mockAiSdk();
+    const { handleTextLarge } = await import("../models/text");
+    await handleTextLarge(
+      createRuntime({
+        ANTHROPIC_API_KEY: "test-key",
+        ANTHROPIC_LARGE_MODEL: "claude-sonnet-5",
+        ANTHROPIC_EFFORT_LARGE: "low",
+      }),
+      { prompt: "hi", topP: 0.9 } as never
+    );
+    const { anthropic, topP } = anthropicOptionsOf(generateText);
+    expect(anthropic?.effort).toBe("low");
+    expect(topP).toBeUndefined();
+  }, 60_000);
+});

--- a/plugins/plugin-anthropic/models/text.ts
+++ b/plugins/plugin-anthropic/models/text.ts
@@ -44,7 +44,9 @@ import { createAnthropicClientWithTopPSupport } from "../providers/anthropic";
 import { createModelName, type ModelName, type ModelSize } from "../types";
 import { generateViaCli, streamViaCli } from "../utils/claude-cli";
 import {
+  type AnthropicEffort,
   getActionPlannerModel,
+  getAnthropicEffort,
   getAuthMode,
   getCoTBudget,
   getExperimentalTelemetry,
@@ -78,11 +80,18 @@ interface ProviderOptions {
 
 interface AnthropicProviderOptions {
   [key: string]: ProviderOptionValue | undefined;
-  readonly thinking?: {
-    [key: string]: ProviderOptionValue | undefined;
-    readonly type: "enabled";
-    readonly budgetTokens: number;
-  };
+  readonly thinking?:
+    | {
+        [key: string]: ProviderOptionValue | undefined;
+        readonly type: "enabled";
+        readonly budgetTokens: number;
+      }
+    | {
+        [key: string]: ProviderOptionValue | undefined;
+        readonly type: "adaptive";
+      };
+  /** output_config.effort on the wire; see getAnthropicEffort. */
+  readonly effort?: AnthropicEffort;
   readonly cacheControl?: {
     [key: string]: ProviderOptionValue | undefined;
     readonly type: "ephemeral";
@@ -396,6 +405,46 @@ function toAnthropicTextParams(params: GenerateTextParams): GenerateTextParamsWi
 
 function isOpus4Model(modelName: ModelName): boolean {
   return modelName.toLowerCase().includes("opus-4");
+}
+
+/**
+ * Whether a model accepts the effort parameter (output_config.effort) at all.
+ * Live-probed 2026-07-12: haiku-4-5 rejects both `effort` ("This model does
+ * not support the effort parameter") and adaptive thinking, so sending the
+ * knob 400s every request. Claude-3-era models predate the parameter. Mirrors
+ * the server-side model catalog (packages/agent/src/api/model-catalog.ts).
+ */
+function supportsEffortParameter(modelName: ModelName): boolean {
+  const name = modelName.toLowerCase();
+  return !name.includes("haiku") && !name.includes("claude-3");
+}
+
+/**
+ * Whether a model accepts the xhigh/max effort tiers. Mirrors the server-side
+ * model catalog (packages/agent/src/api/model-catalog.ts): fable-5 and
+ * opus >= 4.7 take the full range; everything else caps at high — sending
+ * higher 400s the request.
+ */
+function supportsExtendedEffort(modelName: ModelName): boolean {
+  const name = modelName.toLowerCase();
+  if (name.includes("fable-5")) return true;
+  const opus = name.match(/opus-4-(\d+)/);
+  return opus !== null && Number(opus[1]) >= 7;
+}
+
+/**
+ * Clamp a configured effort to what the resolved model accepts. Clamping (to
+ * "high") rather than dropping keeps the operator's intent — they asked for
+ * maximum reasoning; the model's ceiling is the closest legal request.
+ */
+function clampEffortForModel(effort: AnthropicEffort, modelName: ModelName): AnthropicEffort {
+  if ((effort === "xhigh" || effort === "max") && !supportsExtendedEffort(modelName)) {
+    logger.warn(
+      `[Anthropic] effort "${effort}" is not supported by ${modelName}; clamping to "high"`
+    );
+    return "high";
+  }
+  return effort;
 }
 
 function buildUserContent(params: GenerateTextParamsWithProviderOptions): UserContent {
@@ -891,7 +940,8 @@ function resolveTextParams(
   runtime: IAgentRuntime,
   params: GenerateTextParamsWithProviderOptions,
   modelName: ModelName,
-  cotBudget: number
+  cotBudget: number,
+  effort?: AnthropicEffort
 ): ResolvedTextParams {
   const prompt = params.prompt ?? "";
   const stopSequences = params.stopSequences ?? [];
@@ -958,16 +1008,50 @@ function resolveTextParams(
       }
     : {};
 
+  // Effort (the modern knob — maps to the API's output_config.effort, paired
+  // with adaptive thinking) wins over the legacy fixed CoT budget when both
+  // are configured; the budget shape stays for existing ANTHROPIC_COT_BUDGET
+  // operators. A model without the effort parameter falls back to the budget
+  // path (or nothing) — sending the knob anyway would 400 every request.
+  let clampedEffort = effort !== undefined ? clampEffortForModel(effort, modelName) : undefined;
+  if (clampedEffort !== undefined && !supportsEffortParameter(modelName)) {
+    logger.warn(
+      `[Anthropic] effort is configured but ${modelName} does not support the effort parameter; ignoring it for this model`
+    );
+    clampedEffort = undefined;
+  }
   const providerOptions: ProviderOptions =
-    cotBudget > 0
+    clampedEffort !== undefined
       ? {
           ...baseProviderOptions,
           anthropic: {
             ...(baseProviderOptions.anthropic ?? {}),
-            thinking: { type: "enabled", budgetTokens: cotBudget },
+            thinking: { type: "adaptive" },
+            effort: clampedEffort,
           },
         }
-      : baseProviderOptions;
+      : cotBudget > 0
+        ? {
+            ...baseProviderOptions,
+            anthropic: {
+              ...(baseProviderOptions.anthropic ?? {}),
+              thinking: { type: "enabled", budgetTokens: cotBudget },
+            },
+          }
+        : baseProviderOptions;
+
+  // Thinking-enabled requests only accept temperature=1 and reject topP — the
+  // API 400s otherwise. The opus-4 lock above covers those models regardless
+  // of thinking; this covers thinking on everything else.
+  if (clampedEffort !== undefined || cotBudget > 0) {
+    if (temperature !== undefined && temperature !== 1) {
+      temperature = 1;
+    }
+    if (topP !== undefined) {
+      logger.warn("[Anthropic] dropping topP: not accepted alongside extended thinking");
+      topP = undefined;
+    }
+  }
 
   return {
     prompt,
@@ -995,7 +1079,8 @@ async function generateTextWithModel(
     fallback: buildCanonicalSystemPrompt({ character: runtime.character }),
   });
   const cotBudget = getCoTBudget(runtime, modelSize);
-  const resolved = resolveTextParams(runtime, paramsWithAttachments, modelName, cotBudget);
+  const effort = getAnthropicEffort(runtime, modelSize);
+  const resolved = resolveTextParams(runtime, paramsWithAttachments, modelName, cotBudget, effort);
 
   if (getAuthMode(runtime) === "cli") {
     if (shouldReturnNativeResult) {

--- a/plugins/plugin-anthropic/utils/config.ts
+++ b/plugins/plugin-anthropic/utils/config.ts
@@ -8,6 +8,7 @@
  * max-output-token override parsers documented in this package's CLAUDE.md.
  */
 import type { IAgentRuntime } from "@elizaos/core";
+import { logger } from "@elizaos/core";
 import type { ModelName, ModelSize, ValidatedApiKey } from "../types";
 import { createModelName } from "../types";
 
@@ -145,6 +146,44 @@ export function getExperimentalTelemetry(runtime: IAgentRuntime): boolean {
     return false;
   }
   return setting.toLowerCase() === "true";
+}
+
+/** Effort levels the Anthropic API's `output_config.effort` accepts (the AI
+ * SDK's `effort` provider option maps onto it). Per-model ceilings — xhigh/max
+ * only on opus >= 4.7 / fable-5, haiku capped at high — are enforced at the
+ * call site in models/text.ts, which knows the resolved model id. */
+const ANTHROPIC_EFFORT_LEVELS = ["low", "medium", "high", "xhigh", "max"] as const;
+export type AnthropicEffort = (typeof ANTHROPIC_EFFORT_LEVELS)[number];
+
+function isAnthropicEffort(value: string): value is AnthropicEffort {
+  return (ANTHROPIC_EFFORT_LEVELS as readonly string[]).includes(value);
+}
+
+/**
+ * The operator-configured reasoning effort for a model size, from
+ * ANTHROPIC_EFFORT_SMALL / ANTHROPIC_EFFORT_LARGE (what POST /api/models/config
+ * persists for claude chat targets) with ANTHROPIC_EFFORT as the shared
+ * fallback. An unrecognized value is ignored with a warning rather than sent —
+ * the API would 400 the whole request.
+ */
+export function getAnthropicEffort(
+  runtime: IAgentRuntime,
+  modelSize: ModelSize
+): AnthropicEffort | undefined {
+  const specificKey = modelSize === "small" ? "ANTHROPIC_EFFORT_SMALL" : "ANTHROPIC_EFFORT_LARGE";
+  const raw = getRawSetting(runtime, specificKey) ?? getRawSetting(runtime, "ANTHROPIC_EFFORT");
+  if (raw === undefined) return undefined;
+  const normalized = raw.trim().toLowerCase();
+  if (!normalized) return undefined;
+  if (!isAnthropicEffort(normalized)) {
+    logger.warn(
+      `[Anthropic] ignoring invalid effort ${JSON.stringify(raw)} (expected ${ANTHROPIC_EFFORT_LEVELS.join(
+        "|"
+      )})`
+    );
+    return undefined;
+  }
+  return normalized;
 }
 
 export function getCoTBudget(runtime: IAgentRuntime, modelSize: ModelSize): number {


### PR DESCRIPTION
# Anthropic effort-driven adaptive thinking + live-probed model gates (stage 3)

Completes the model-configuration arc (#16164 → #16171): the `ANTHROPIC_EFFORT(_SMALL/_LARGE)` keys that `POST /api/models/config` persists for claude chat targets now actually control the model's reasoning, replacing the plugin's only knob — a fixed `{type:"enabled", budgetTokens}` chain-of-thought budget that nothing in the config surface set.

## What changed

**`plugins/plugin-anthropic`**:
- `getAnthropicEffort(runtime, size)` reads `ANTHROPIC_EFFORT_SMALL` / `ANTHROPIC_EFFORT_LARGE` → shared `ANTHROPIC_EFFORT`, validated against `low|medium|high|xhigh|max` (invalid values warn and are ignored — the API would 400 the whole request).
- A configured effort sends `thinking: {type:"adaptive"}` + the AI SDK `effort` provider option (`output_config.effort` on the wire) and **wins over** the legacy CoT budget; `ANTHROPIC_COT_BUDGET*` keeps its exact shape for existing operators.
- **Per-model gates from live probes against the real Messages API** (all on a real subscription token, request bodies captured via fetch interception):
  - `haiku-4-5` rejects both the effort parameter (`"This model does not support the effort parameter"`) **and** adaptive thinking (`"adaptive thinking is not supported on this model"`) — a configured effort is ignored for it with a warning, falling back to the budget path when set.
  - `xhigh`/`max` clamp to `high` below opus 4.7 / fable-5 (matching the catalog's tiers).
  - Thinking-active requests (effort **or** budget) force `temperature=1` and drop `topP` — API constraints; the budget path previously latently 400'd on non-opus models with a caller temperature.

**`packages/agent` model catalog correction** (stage-1 ground-truth fix): haiku's **chat** entry now exposes no effort knob (`efforts: []` — `POST /api/models/config` rejects effort on it with the designed "exposes no effort control" 400); its **coding** entry keeps `low..high` (the Claude Code CLI's `CLAUDE_CODE_EFFORT_LEVEL` is a separate mechanism).

## Evidence — live wire captures (fetch-intercepted request bodies, real API)

<details><summary>Effort reaches the wire as adaptive thinking + output_config.effort</summary>

```
WIRE: {"model":"claude-haiku-4-5-20251001","thinking":{"type":"adaptive"},"output_config":{"effort":"low"}}
STATUS: 400  → "adaptive thinking is not supported on this model"     (pre-gate probe that produced the correction)
```
The SDK provider maps `effort` → `output_config.effort` exactly as expected — and the live API told us haiku takes neither knob.
</details>

<details><summary>Raw shape probes per model (the ground truth for the gates)</summary>

```
haiku  output_config.effort only  => 400 "This model does not support the effort parameter."
haiku  adaptive + effort          => 400 "adaptive thinking is not supported on this model"
sonnet-5 / opus-4-8 probes        => 429 (both subscription accounts' windows were hot — acceptance
                                     unverifiable at probe time; shapes match the documented API and
                                     a rejection would surface loudly per fail-fast policy)
```
</details>

<details><summary>Corrected behavior, live (haiku + configured effort → clean request, 200)</summary>

```
[Anthropic] effort is configured but claude-haiku-4-5-20251001 does not support the effort parameter; ignoring it for this model
WIRE: {"model":"claude-haiku-4-5-20251001","temperature":0.7}     ← no thinking, no output_config
STATUS: 200
reply: OK
```
</details>

## Tests
- `plugin-anthropic`: new `effort-thinking.shape.test.ts` (10 cases: adaptive+effort emission, shared-key fallback + case-normalization, xhigh→high clamp, fable-5 max kept, invalid dropped, budget back-compat, effort-beats-budget, haiku never-sends + budget fallback, temperature=1 forcing, topP drop) — full plugin suite 64✓; typecheck ✓
- `packages/agent`: catalog + config-route suites updated to the live-proven haiku truth, 41✓; typecheck ✓ (after #16174 fixed develop's `CloudCompatAgent` type break)
- biome clean; plugin CLAUDE.md/AGENTS.md env-var tables updated

Screenshots/video: N/A — model-provider wiring, no UI surface; the live wire captures + API replies above are the domain artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
