### PR TITLE
fix(cloud-ui): auto-redirect after provisioning + unbroken oauth loading logo

### DIFF
--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -375,7 +375,7 @@
     <div class="eliza-preboot-shell" role="status" aria-live="polite" aria-label="Loading Eliza">
       <div class="eliza-preboot-shell__content">
         <div class="eliza-preboot-shell__brand" aria-hidden="true">
-          <img class="eliza-preboot-shell__mark" src="./brand/logos/logo_white_nobg.svg" alt="" />
+          <img class="eliza-preboot-shell__mark" src="%BASE_URL%brand/logos/logo_white_nobg.svg" alt="" />
           <span class="eliza-preboot-shell__name">elizaOS</span>
         </div>
         <p class="eliza-preboot-shell__status">Booting up&hellip;</p>

--- a/packages/app/test/brand-surface.test.ts
+++ b/packages/app/test/brand-surface.test.ts
@@ -193,6 +193,32 @@ describe("brand surfaces", () => {
     expect(html).toContain("Booting up&hellip;");
   });
 
+  it("preboot logo uses a base-aware brand path so it resolves on deep web routes and native builds", () => {
+    // Regression: the preboot <img> used a hard RELATIVE `./brand/logos/...`
+    // path. The deployed web SPA (base "/") serves nested routes
+    // (/auth/callback, /app-auth/authorize) from the origin root, so a browser
+    // resolved `./brand/...` against the route directory
+    // (→ /auth/brand/logos/...). The Pages SPA catch-all returns index.html
+    // (text/html) for that miss, so the <img> loaded HTML instead of the SVG
+    // and rendered a broken-image icon on the OAuth loading screen.
+    //
+    // The fix uses Vite's `%BASE_URL%` token, which is base-aware: the web
+    // build (`ELIZA_WEB_ABSOLUTE_BASE=1` → base "/") emits `/brand/...`, so
+    // every route depth resolves to the origin root; native/desktop builds
+    // (base "./", Electrobun/Capacitor load assets relative to the HTML doc)
+    // keep `./brand/...` and resolve the bundled asset. A hard `/brand/...`
+    // would have regressed native by resolving outside the bundle, and a hard
+    // `./brand/...` regressed deep web routes — the token satisfies both.
+    const html = read("index.html");
+    expect(html).toMatch(
+      /class="eliza-preboot-shell__mark"\s+src="%BASE_URL%brand\/logos\/logo_white_nobg\.svg"/,
+    );
+    // Must NOT regress back to a hard relative path (breaks deep web routes).
+    expect(html).not.toMatch(
+      /class="eliza-preboot-shell__mark"\s+src="\.\/brand/,
+    );
+  });
+
   it("renderer root CSS keeps the pre-app surface on the launch black", () => {
     // Same persistence argument as index.html: html/body/#root in the
     // renderer CSS is the page background under the app, so its --launch-bg

--- a/packages/app/test/brand-surface.test.ts
+++ b/packages/app/test/brand-surface.test.ts
@@ -194,26 +194,12 @@ describe("brand surfaces", () => {
   });
 
   it("preboot logo uses a base-aware brand path so it resolves on deep web routes and native builds", () => {
-    // Regression: the preboot <img> used a hard RELATIVE `./brand/logos/...`
-    // path. The deployed web SPA (base "/") serves nested routes
-    // (/auth/callback, /app-auth/authorize) from the origin root, so a browser
-    // resolved `./brand/...` against the route directory
-    // (→ /auth/brand/logos/...). The Pages SPA catch-all returns index.html
-    // (text/html) for that miss, so the <img> loaded HTML instead of the SVG
-    // and rendered a broken-image icon on the OAuth loading screen.
-    //
-    // The fix uses Vite's `%BASE_URL%` token, which is base-aware: the web
-    // build (`ELIZA_WEB_ABSOLUTE_BASE=1` → base "/") emits `/brand/...`, so
-    // every route depth resolves to the origin root; native/desktop builds
-    // (base "./", Electrobun/Capacitor load assets relative to the HTML doc)
-    // keep `./brand/...` and resolve the bundled asset. A hard `/brand/...`
-    // would have regressed native by resolving outside the bundle, and a hard
-    // `./brand/...` regressed deep web routes — the token satisfies both.
+    // BASE_URL resolves from the origin in web builds and beside the document
+    // in packaged builds, preserving both deep SPA routes and bundled assets.
     const html = read("index.html");
     expect(html).toMatch(
       /class="eliza-preboot-shell__mark"\s+src="%BASE_URL%brand\/logos\/logo_white_nobg\.svg"/,
     );
-    // Must NOT regress back to a hard relative path (breaks deep web routes).
     expect(html).not.toMatch(
       /class="eliza-preboot-shell__mark"\s+src="\.\/brand/,
     );

--- a/packages/ui/src/cloud/shell/StewardProvider.test.tsx
+++ b/packages/ui/src/cloud/shell/StewardProvider.test.tsx
@@ -64,11 +64,7 @@ afterEach(() => {
   runtimeGate.release();
   cleanup();
   resolveBrowserStewardApiUrl.mockReturnValue("placeholder-steward-url");
-  try {
-    window.localStorage.clear();
-  } catch {
-    // jsdom storage is always available; ignore if a test disabled it.
-  }
+  window.localStorage.clear();
 });
 
 function renderAt(pathname: string) {
@@ -140,13 +136,8 @@ describe("StewardAuthProvider", () => {
     expect(screen.queryByRole("status")).toBeNull();
   });
 
-  // Regression: the post-OAuth `/join` provisioning landing was left on its
-  // loading spinner (and never redirected into the app) because the Steward
-  // runtime only mounted when a token already sat in localStorage. On the
-  // returning-user / cookie-session handback the token isn't stored yet, so the
-  // runtime never loaded, the session never resolved, and JoinPage stalled.
-  // `/join` must load the runtime even with NO stored token so provisioning +
-  // the post-provision redirect run.
+  // Cookie-backed OAuth handoffs reach /join before local token persistence,
+  // so the runtime must mount there to resolve the session.
   it("loads the Steward runtime on /join with no stored token so provisioning can redirect", async () => {
     resolveBrowserStewardApiUrl.mockReturnValue(
       "https://api.elizacloud.ai/steward",
@@ -163,16 +154,11 @@ describe("StewardAuthProvider", () => {
 
 describe("shouldLoadStewardRuntime", () => {
   afterEach(() => {
-    try {
-      window.localStorage.clear();
-    } catch {
-      // ignore
-    }
+    window.localStorage.clear();
   });
 
   it("loads the runtime for /join (and its subpaths) even with no stored token", () => {
-    // The gate receives `location.pathname` (query already split off by the
-    // router), so only the bare path forms are asserted here.
+    // The router has already removed the query before calling the gate.
     window.localStorage.clear();
     expect(shouldLoadStewardRuntime("/join")).toBe(true);
     expect(shouldLoadStewardRuntime("/join/")).toBe(true);

--- a/packages/ui/src/cloud/shell/StewardProvider.test.tsx
+++ b/packages/ui/src/cloud/shell/StewardProvider.test.tsx
@@ -55,12 +55,20 @@ vi.mock("./StewardProviderRuntime", () => ({
   },
 }));
 
-import { StewardAuthProvider } from "./StewardProvider";
+import {
+  StewardAuthProvider,
+  shouldLoadStewardRuntime,
+} from "./StewardProvider";
 
 afterEach(() => {
   runtimeGate.release();
   cleanup();
   resolveBrowserStewardApiUrl.mockReturnValue("placeholder-steward-url");
+  try {
+    window.localStorage.clear();
+  } catch {
+    // jsdom storage is always available; ignore if a test disabled it.
+  }
 });
 
 function renderAt(pathname: string) {
@@ -130,5 +138,70 @@ describe("StewardAuthProvider", () => {
     expect(await screen.findByTestId("steward-runtime")).toBeTruthy();
     expect(screen.getByTestId("protected-child")).toBeTruthy();
     expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  // Regression: the post-OAuth `/join` provisioning landing was left on its
+  // loading spinner (and never redirected into the app) because the Steward
+  // runtime only mounted when a token already sat in localStorage. On the
+  // returning-user / cookie-session handback the token isn't stored yet, so the
+  // runtime never loaded, the session never resolved, and JoinPage stalled.
+  // `/join` must load the runtime even with NO stored token so provisioning +
+  // the post-provision redirect run.
+  it("loads the Steward runtime on /join with no stored token so provisioning can redirect", async () => {
+    resolveBrowserStewardApiUrl.mockReturnValue(
+      "https://api.elizacloud.ai/steward",
+    );
+    window.localStorage.clear();
+
+    renderAt("/join");
+
+    expect(await screen.findByTestId("steward-runtime")).toBeTruthy();
+    expect(screen.getByTestId("protected-child")).toBeTruthy();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});
+
+describe("shouldLoadStewardRuntime", () => {
+  afterEach(() => {
+    try {
+      window.localStorage.clear();
+    } catch {
+      // ignore
+    }
+  });
+
+  it("loads the runtime for /join (and its subpaths) even with no stored token", () => {
+    // The gate receives `location.pathname` (query already split off by the
+    // router), so only the bare path forms are asserted here.
+    window.localStorage.clear();
+    expect(shouldLoadStewardRuntime("/join")).toBe(true);
+    expect(shouldLoadStewardRuntime("/join/")).toBe(true);
+    expect(shouldLoadStewardRuntime("/join/next")).toBe(true);
+  });
+
+  it("keeps loading the runtime for the existing auth routes with no stored token", () => {
+    window.localStorage.clear();
+    for (const path of [
+      "/login",
+      "/app-auth/authorize",
+      "/auth/callback/email",
+      "/dashboard",
+      "/payment/abc",
+    ]) {
+      expect(shouldLoadStewardRuntime(path)).toBe(true);
+    }
+  });
+
+  it("does not load the runtime for a non-auth route with no stored token", () => {
+    window.localStorage.clear();
+    expect(shouldLoadStewardRuntime("/docs")).toBe(false);
+    // A route that merely CONTAINS 'join' as a segment substring must not match.
+    expect(shouldLoadStewardRuntime("/rejoinder")).toBe(false);
+  });
+
+  it("loads the runtime for any route once a token is stored", () => {
+    window.localStorage.setItem("steward_session_token", "tkn");
+    expect(shouldLoadStewardRuntime("/docs")).toBe(true);
+    expect(shouldLoadStewardRuntime("/anything")).toBe(true);
   });
 });

--- a/packages/ui/src/cloud/shell/StewardProvider.tsx
+++ b/packages/ui/src/cloud/shell/StewardProvider.tsx
@@ -61,16 +61,8 @@ const STEWARD_RUNTIME_ROUTE_PATTERNS = [
   /^\/bsc(?:\/|$)/,
   /^\/dashboard(?:\/|$)/,
   /^\/login(?:\/|$)/,
-  // `/join` is the post-OAuth provisioning landing (JoinPage). Its own
-  // registration (cloud/join/register.ts) documents that it "needs the Steward
-  // runtime so the session resolves", but the route was missing here — so the
-  // runtime only mounted when a token already sat in localStorage. On the
-  // returning-user / cookie-session hand back from OAuth the token isn't yet
-  // stored, so `LocalStewardAuthContext` stayed null, `useJoinSessionAuth`
-  // never became authenticated, and JoinPage sat on the provisioning spinner
-  // (or bounced back to /login) instead of running the join flow and
-  // navigating into the app. Load the runtime for `/join` unconditionally so
-  // the session resolves and provisioning + the post-provision redirect fire.
+  // JoinPage needs the runtime before a token is persisted so its cookie-backed
+  // session can resolve, provision the account, and enter the application.
   /^\/join(?:\/|$)/,
   /^\/invite(?:\/|$)/,
   /^\/accept-invitation(?:\/|$)/,
@@ -81,11 +73,9 @@ const STEWARD_RUNTIME_ROUTE_PATTERNS = [
 ] as const;
 
 /**
- * Whether the heavy `@stwd/*` Steward runtime must mount for this route. Exported
- * for unit coverage: the `/join` provisioning landing depends on this returning
- * true even before a token is persisted, so the session resolves and JoinPage
- * can provision + redirect (regression guard for the post-OAuth stuck-loading
- * bug).
+ * Whether the heavy `@stwd/*` Steward runtime must mount for a route. Join
+ * requires it before token persistence because session resolution precedes
+ * provisioning.
  */
 export function shouldLoadStewardRuntime(pathname: string): boolean {
   if (readStoredToken()) return true;

--- a/packages/ui/src/cloud/shell/StewardProvider.tsx
+++ b/packages/ui/src/cloud/shell/StewardProvider.tsx
@@ -61,6 +61,17 @@ const STEWARD_RUNTIME_ROUTE_PATTERNS = [
   /^\/bsc(?:\/|$)/,
   /^\/dashboard(?:\/|$)/,
   /^\/login(?:\/|$)/,
+  // `/join` is the post-OAuth provisioning landing (JoinPage). Its own
+  // registration (cloud/join/register.ts) documents that it "needs the Steward
+  // runtime so the session resolves", but the route was missing here — so the
+  // runtime only mounted when a token already sat in localStorage. On the
+  // returning-user / cookie-session hand back from OAuth the token isn't yet
+  // stored, so `LocalStewardAuthContext` stayed null, `useJoinSessionAuth`
+  // never became authenticated, and JoinPage sat on the provisioning spinner
+  // (or bounced back to /login) instead of running the join flow and
+  // navigating into the app. Load the runtime for `/join` unconditionally so
+  // the session resolves and provisioning + the post-provision redirect fire.
+  /^\/join(?:\/|$)/,
   /^\/invite(?:\/|$)/,
   /^\/accept-invitation(?:\/|$)/,
   /^\/payment(?:\/|$)/,
@@ -69,7 +80,14 @@ const STEWARD_RUNTIME_ROUTE_PATTERNS = [
   /^\/ballot(?:\/|$)/,
 ] as const;
 
-function shouldLoadStewardRuntime(pathname: string): boolean {
+/**
+ * Whether the heavy `@stwd/*` Steward runtime must mount for this route. Exported
+ * for unit coverage: the `/join` provisioning landing depends on this returning
+ * true even before a token is persisted, so the session resolves and JoinPage
+ * can provision + redirect (regression guard for the post-OAuth stuck-loading
+ * bug).
+ */
+export function shouldLoadStewardRuntime(pathname: string): boolean {
   if (readStoredToken()) return true;
   return STEWARD_RUNTIME_ROUTE_PATTERNS.some((pattern) =>
     pattern.test(pathname),


### PR DESCRIPTION
## What & Why

Two REAL user-observed bugs on the Eliza Cloud OAuth loading/landing flow, seen by Shadow on staging (`app-staging.elizacloud.ai` / `staging.elizacloud.ai`) on 2026-07-11. Both fixed at root cause. **Navigation + asset only — no auth semantics changed.**

---

### BUG 1 — post-provision auto-redirect never fires (user stuck on the loading/provisioning screen)

**Root cause.** The post-OAuth `/join` provisioning landing (`JoinPage`) runs the join flow and then hard-navigates into the app:

```ts
// packages/ui/src/cloud/join/JoinPage.tsx
const result = await runJoinFlow({ ... });
setPhase("ready");
if (typeof window !== "undefined") {
  window.location.assign("/");
}
```

That only fires once `useJoinSessionAuth()` reports `authenticated`, which needs the Steward runtime to resolve the session. Its own registration says so:

```ts
// packages/ui/src/cloud/join/register.ts
// "it needs the Steward runtime so the session resolves"
```

But `/join` was **missing from `STEWARD_RUNTIME_ROUTE_PATTERNS`**:

```ts
// packages/ui/src/cloud/shell/StewardProvider.tsx  (before)
const STEWARD_RUNTIME_ROUTE_PATTERNS = [
  /^\/app-auth(?:\/|$)/, /^\/auth(?:\/|$)/, /^\/bsc(?:\/|$)/,
  /^\/dashboard(?:\/|$)/, /^\/login(?:\/|$)/, /^\/invite(?:\/|$)/,
  /^\/accept-invitation(?:\/|$)/, /^\/payment(?:\/|$)/,
  /^\/sensitive-requests(?:\/|$)/, /^\/approve(?:\/|$)/, /^\/ballot(?:\/|$)/,
] as const; // no /join

function shouldLoadStewardRuntime(pathname: string): boolean {
  if (readStoredToken()) return true;               // token-present short-circuit
  return STEWARD_RUNTIME_ROUTE_PATTERNS.some((p) => p.test(pathname));
}
```

So the runtime only mounted for `/join` when a token was **already** in `localStorage`. On the returning-user / cookie-session handback from OAuth the token isn't stored yet → `LocalStewardAuthContext` stays `null` → `useJoinSessionAuth` never becomes `authenticated` → `JoinPage` sits on the provisioning spinner (or `<Navigate to="/login?returnTo=/join">`) and the `window.location.assign("/")` never runs.

**Fix.** Add `/join` to the runtime patterns (matching the register.ts contract), and export `shouldLoadStewardRuntime` for coverage. File anchor: `packages/ui/src/cloud/shell/StewardProvider.tsx:58-79`.

---

### BUG 2 — Eliza logo renders broken on the OAuth loading screen

**Root cause.** The preboot shell logo used a hard **relative** path:

```html
<!-- packages/app/index.html:378 (before) -->
<img class="eliza-preboot-shell__mark" src="./brand/logos/logo_white_nobg.svg" alt="" />
```

The deployed web SPA (`ELIZA_WEB_ABSOLUTE_BASE=1` → base `"/"`) serves nested routes from the origin root, so the browser resolves `./brand/...` against the **route directory**, not root. On a deep OAuth route that becomes `/auth/brand/...` or `/app-auth/brand/...`, which the Pages SPA catch-all serves as `index.html`.

**Evidence (staging curls):**

```
/auth/brand/logos/logo_white_nobg.svg      → HTTP 200  text/html      ← wrong (SPA fallback)
/app-auth/brand/logos/logo_white_nobg.svg  → HTTP 200  text/html      ← wrong
/brand/logos/logo_white_nobg.svg           → HTTP 200  image/svg+xml  ← correct SVG
```

The `<img>` received HTML instead of an SVG → broken-image icon.

**Fix.** Use Vite's base-aware `%BASE_URL%` token (Vite's `htmlEnvHook` replaces `%ENV%` in `index.html`; `BASE_URL` = resolved `base`):

```html
<!-- packages/app/index.html:378 (after) -->
<img class="eliza-preboot-shell__mark" src="%BASE_URL%brand/logos/logo_white_nobg.svg" alt="" />
```

- Web build (`base: "/"`) → `/brand/logos/...` → resolves at every route depth.
- Native/desktop build (`base: "./"`, Electrobun/Capacitor load relative to the HTML doc) → `./brand/logos/...` → resolves the bundled asset.

A hard `/brand/...` would regress native (resolves outside the bundle); a hard `./brand/...` regressed deep web routes. The token satisfies both. (Addresses the codex `--uncommitted` P2 base-awareness note.)

---

## Tests

- **`packages/ui/src/cloud/shell/StewardProvider.test.tsx`** — new: `/join` loads the runtime with no stored token; `shouldLoadStewardRuntime` unit coverage (join + subpaths, existing auth routes, non-auth routes incl. `/rejoinder` substring guard, token-present short-circuit). **9/9 pass.**
- **`packages/app/test/brand-surface.test.ts`** — new: preboot logo uses base-aware `%BASE_URL%` and must not regress to a hard relative `./brand` path. **12/12 pass.**
- Existing `run-join-flow.test.ts` still green (8/8).

```
✓ src/cloud/shell/StewardProvider.test.tsx (9 tests)
✓ test/brand-surface.test.ts (12 tests)
✓ src/cloud/join/lib/run-join-flow.test.ts (8 tests)
```

Biome clean on all 4 changed files; tsgo shows no new errors in the changed files (pre-existing repo errors are in `core/src/cloud-routing.ts` and `api/client-cloud*`, untouched here).

## Scope

`packages/app/index.html`, `packages/ui/src/cloud/shell/StewardProvider.tsx` + 2 test files. No auth semantics touched — this is navigation gating + a base-aware asset path.

[sol-cloud]

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16176-before-broken-logo-auth-callback-desktop.png)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16176-after-logo-ok-auth-callback-desktop.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence/16176-walkthrough-before-after.mp4

<!-- evidence-row:backend-logs -->
- [x] [16176-backend-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16176-backend-logs.txt)

<!-- evidence-row:frontend-logs -->
- [x] [16176-frontend-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16176-frontend-logs.txt)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - UI navigation + static asset-path fix (StewardProvider route pattern + preboot logo src in index.html); no agent, model, prompt, provider, or action code is touched and no LLM participates in the OAuth loading flow

<!-- evidence-row:domain-artifacts -->
- [x] [16176-domain-artifacts.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16176-domain-artifacts.txt)

<!-- evidence-row:ocr-review -->
- [x] [16176-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16176-ocr-review.txt)
