### PR TITLE
fix(agent,ui): catalog-only fast path + pin chat models to the active provider

### DIFF
--- a/packages/agent/src/api/models-routes.test.ts
+++ b/packages/agent/src/api/models-routes.test.ts
@@ -64,6 +64,18 @@ describe("handleModelsRoutes catalog field", () => {
     });
   });
 
+  it("serves catalogOnly without touching any provider fetcher", async () => {
+    const { ctx, json } = makeCtx("/api/models?catalogOnly=1");
+    await expect(handleModelsRoutes(ctx as never)).resolves.toBe(true);
+    expect(json).toHaveBeenCalledWith(ctx.res, {
+      providers: {},
+      catalog: fakeCatalog,
+    });
+    // The whole point: no provider fan-out (it takes tens of seconds cold).
+    expect(ctx.getOrFetchAllProviders).not.toHaveBeenCalled();
+    expect(ctx.getOrFetchProvider).not.toHaveBeenCalled();
+  });
+
   it("declines non-matching routes", async () => {
     const { ctx } = makeCtx("/api/models");
     ctx.pathname = "/api/models/config";

--- a/packages/agent/src/api/models-routes.ts
+++ b/packages/agent/src/api/models-routes.ts
@@ -57,6 +57,16 @@ export async function handleModelsRoutes(
   // at call time so a refreshed server catalog shows up without a restart.
   const catalog = (ctx.buildCatalog ?? buildModelCatalog)();
 
+  // Catalog consumers (the settings model panel, slash-command completions)
+  // only need the validated catalog — local static tables + one file read.
+  // The all-providers fan-out below hits every provider's live model-list API
+  // and takes tens of seconds on a cold cache, which blows the UI client's
+  // 10s fetch budget and renders as a failed options load.
+  if (url.searchParams.get("catalogOnly") === "1") {
+    json(res, { providers: {}, catalog });
+    return true;
+  }
+
   if (specificProvider) {
     if (force) {
       try {

--- a/packages/ui/src/api/client-agent-models-config.test.ts
+++ b/packages/ui/src/api/client-agent-models-config.test.ts
@@ -19,13 +19,15 @@ function clientWithBody(body: unknown): {
 }
 
 describe("ElizaClient.getModelsCatalog", () => {
-  it("reads /api/models without a cache-busting refresh", async () => {
+  it("reads the catalog-only fast path (no provider fan-out)", async () => {
     const { client, fetchMock } = clientWithBody({
       providers: {},
       catalog: { providers: {} },
     });
     const result = await client.getModelsCatalog();
-    expect(fetchMock).toHaveBeenCalledWith("/api/models");
+    // catalogOnly skips the server's all-providers model-list fan-out, which
+    // exceeds the client's 10s fetch budget on a cold cache.
+    expect(fetchMock).toHaveBeenCalledWith("/api/models?catalogOnly=1");
     expect(result.catalog).toEqual({ providers: {} });
   });
 });

--- a/packages/ui/src/api/client-agent.ts
+++ b/packages/ui/src/api/client-agent.ts
@@ -2892,10 +2892,11 @@ ElizaClient.prototype.fetchModels = async function (
 };
 
 ElizaClient.prototype.getModelsCatalog = async function (this: ElizaClient) {
-  // Deliberately no refresh=true: the caller wants the validated
-  // provider→model→efforts catalog attached to every /api/models response,
-  // not a cache-busting refetch of every provider's model list.
-  return this.fetch("/api/models");
+  // catalogOnly skips the server's all-providers model-list fan-out, which
+  // takes tens of seconds on a cold cache — far past the client's 10s fetch
+  // budget. Catalog consumers (settings panel, slash completions) only need
+  // the validated catalog, which is local static tables + one file read.
+  return this.fetch("/api/models?catalogOnly=1");
 };
 
 ElizaClient.prototype.getModelsConfig = async function (this: ElizaClient) {

--- a/packages/ui/src/components/settings/ModelConfigurationPanel.test.tsx
+++ b/packages/ui/src/components/settings/ModelConfigurationPanel.test.tsx
@@ -366,6 +366,69 @@ describe("prefill and option filtering", () => {
   });
 });
 
+describe("active-provider scoping", () => {
+  it("pins the chat provider to the active intelligence selection and scopes models to it", async () => {
+    render(<ModelConfigurationPanel activeChatProvider="elizacloud" />);
+    await waitFor(() =>
+      expect(agentElements.has("models-small-model")).toBe(true),
+    );
+
+    // No free provider dropdown — the provider follows the active selection.
+    expect(agentElements.has("models-small-provider")).toBe(false);
+    expect(
+      document.querySelector('[data-agent-id="models-small-provider"]'),
+    ).toBeNull();
+    expect(
+      screen.getAllByText(/follows your active provider/i).length,
+    ).toBeGreaterThan(0);
+
+    // Model options come from the pinned provider's slice only.
+    const options = agentElements.get("models-small-model")?.options ?? [];
+    for (const id of options) {
+      expect(
+        fixtureCatalog().providers.elizacloud?.some((m) => m.id === id),
+      ).toBe(true);
+    }
+  });
+
+  it("keeps the free provider choice when no active provider maps to the catalog", async () => {
+    render(<ModelConfigurationPanel />);
+    await waitFor(() =>
+      expect(agentElements.has("models-small-provider")).toBe(true),
+    );
+    expect(agentElements.has("models-small-provider")).toBe(true);
+  });
+
+  it("saves against the pinned provider", async () => {
+    clientMock.updateModelsConfig.mockResolvedValue({
+      kind: "applied",
+      restart: true,
+      keys: ["OPENAI_SMALL_MODEL"],
+      operationId: "op-1",
+    });
+    render(<ModelConfigurationPanel activeChatProvider="cerebras" />);
+    await waitFor(() =>
+      expect(agentElements.has("models-small-model")).toBe(true),
+    );
+    fill("models-small-model", "gemma-4-31b");
+    act(() => agentButton("models-small-save").click());
+    await waitFor(() =>
+      expect(agentElements.has("models-small-confirm-restart")).toBe(true),
+    );
+    act(() => agentButton("models-small-confirm-restart").click());
+    await waitFor(() =>
+      expect(clientMock.updateModelsConfig).toHaveBeenCalled(),
+    );
+    expect(clientMock.updateModelsConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: "small",
+        provider: "cerebras",
+        model: "gemma-4-31b",
+      }),
+    );
+  });
+});
+
 describe("chat save flow", () => {
   it("requires an explicit restart confirmation before posting, then polls status", async () => {
     clientMock.updateModelsConfig.mockResolvedValue({

--- a/packages/ui/src/components/settings/ModelConfigurationPanel.tsx
+++ b/packages/ui/src/components/settings/ModelConfigurationPanel.tsx
@@ -173,18 +173,38 @@ function ChatModelGroup({
 
   return (
     <SettingsGroup title={title} description={description} bare>
-      <SettingsSelectRow
-        agentId={`models-${target}-provider`}
-        label={t("modelconfig.provider", { defaultValue: "Provider" })}
-        value={group.provider}
-        onValueChange={group.setProvider}
-        options={group.providerOptions}
-        placeholder={t("modelconfig.chooseProvider", {
-          defaultValue: "Choose a provider",
-        })}
-        disabled={busy}
-        triggerClassName="w-full"
-      />
+      {group.providerLocked ? (
+        // The provider follows the active intelligence selection above; a free
+        // dropdown here would let models be picked from a provider the runtime
+        // isn't routing chat through (dead keys, confusing pairings).
+        <div className="flex items-center justify-between gap-3 py-1.5 text-sm">
+          <span className="text-muted">
+            {t("modelconfig.provider", { defaultValue: "Provider" })}
+          </span>
+          <span>
+            {group.providerOptions.find((o) => o.value === group.provider)
+              ?.label ?? group.provider}{" "}
+            <span className="text-muted">
+              {t("modelconfig.providerFollowsActive", {
+                defaultValue: "(follows your active provider)",
+              })}
+            </span>
+          </span>
+        </div>
+      ) : (
+        <SettingsSelectRow
+          agentId={`models-${target}-provider`}
+          label={t("modelconfig.provider", { defaultValue: "Provider" })}
+          value={group.provider}
+          onValueChange={group.setProvider}
+          options={group.providerOptions}
+          placeholder={t("modelconfig.chooseProvider", {
+            defaultValue: "Choose a provider",
+          })}
+          disabled={busy}
+          triggerClassName="w-full"
+        />
+      )}
       <SettingsSelectRow
         agentId={`models-${target}-model`}
         label={t("modelconfig.model", { defaultValue: "Model" })}
@@ -538,8 +558,14 @@ export function ModelConfigurationPanelView({
   );
 }
 
-export function ModelConfigurationPanel() {
+export function ModelConfigurationPanel({
+  activeChatProvider,
+}: {
+  /** Catalog chat provider implied by the active intelligence selection;
+   * pins the small/large provider so models track what actually routes chat. */
+  activeChatProvider?: string;
+}) {
   const t = useAppSelector((s) => s.t);
-  const state = useModelConfiguration();
+  const state = useModelConfiguration({ activeChatProvider });
   return <ModelConfigurationPanelView state={state} t={t} />;
 }

--- a/packages/ui/src/components/settings/ProviderSwitcher.tsx
+++ b/packages/ui/src/components/settings/ProviderSwitcher.tsx
@@ -131,6 +131,19 @@ export function ProviderSwitcher(props: ProviderSwitcherProps = {}) {
     [providerEntries],
   );
 
+  // Pin the model-configuration panel's chat provider to the active
+  // intelligence selection when it unambiguously maps to a catalog provider.
+  // Subscription selections don't route chat and other BYOK providers have no
+  // curated catalog slice — those keep the free per-target choice.
+  const activeChatCatalogProvider =
+    resolvedSelectedId === "__cloud__"
+      ? "elizacloud"
+      : resolvedSelectedId === "cerebras"
+        ? "cerebras"
+        : resolvedSelectedId === "anthropic"
+          ? "claude-chat"
+          : undefined;
+
   const selectedPanelProvider = useMemo(() => {
     if (
       visibleProviderPanelId === "__cloud__" ||
@@ -302,7 +315,7 @@ export function ProviderSwitcher(props: ProviderSwitcherProps = {}) {
 
       {/* Per-role model configuration (small/large chat brains + coding
           sub-agent), driven by the validated /api/models catalog. */}
-      <ModelConfigurationPanel />
+      <ModelConfigurationPanel activeChatProvider={activeChatCatalogProvider} />
 
       {/* Voice folds into this section for MVP (the standalone Voice tab is
           developer-only): speech is pinned to the bundled Kokoro TTS, so a

--- a/packages/ui/src/components/settings/useModelConfiguration.ts
+++ b/packages/ui/src/components/settings/useModelConfiguration.ts
@@ -105,6 +105,10 @@ export interface ModelConfigChatGroup {
   target: ChatTarget;
   providerOptions: Array<{ value: string; label: string }>;
   provider: string;
+  /** True when the provider is pinned to the active intelligence selection —
+   * the panel renders a static label instead of a free provider dropdown so
+   * chat models can never be picked from an inactive provider. */
+  providerLocked: boolean;
   modelOptions: ModelCatalogEntry[];
   model: string;
   effortOptions: string[];
@@ -412,7 +416,18 @@ function failureMessage(err: unknown): string {
     : "Request failed";
 }
 
-export function useModelConfiguration(): ModelConfigurationState {
+export interface UseModelConfigurationOptions {
+  /** Catalog chat provider implied by the ACTIVE intelligence selection
+   * ("elizacloud" | "cerebras" | "claude-chat"). When set, the small/large
+   * groups are pinned to it; when undefined (no unambiguous active provider)
+   * the free per-target provider choice remains. */
+  activeChatProvider?: string;
+}
+
+export function useModelConfiguration(
+  options: UseModelConfigurationOptions = {},
+): ModelConfigurationState {
+  const activeChatProvider = options.activeChatProvider;
   const [load, setLoad] = useState<LoadState>({ phase: "loading" });
   const [chatDrafts, setChatDrafts] = useState<Record<ChatTarget, ChatDraft>>({
     small: { provider: "", model: "", effort: "", configured: null },
@@ -650,11 +665,21 @@ export function useModelConfiguration(): ModelConfigurationState {
   const buildChatGroup = useCallback(
     (target: ChatTarget, data: ReadyData): ModelConfigChatGroup => {
       const draft = chatDrafts[target];
+      // An unambiguous active intelligence selection pins the provider: models
+      // from an inactive provider would persist keys the runtime never reads.
+      const providerLocked =
+        activeChatProvider !== undefined &&
+        CHAT_PROVIDERS.some((choice) => choice.id === activeChatProvider);
+      const effectiveProvider = providerLocked
+        ? (activeChatProvider as string)
+        : draft.provider;
       const providerOptions = CHAT_PROVIDERS.filter(
-        (choice) => entriesForRole(data.catalog, choice.id, target).length > 0,
+        (choice) =>
+          (!providerLocked || choice.id === activeChatProvider) &&
+          entriesForRole(data.catalog, choice.id, target).length > 0,
       ).map((choice) => ({ value: choice.id, label: choice.label }));
-      const modelOptions = draft.provider
-        ? entriesForRole(data.catalog, draft.provider, target)
+      const modelOptions = effectiveProvider
+        ? entriesForRole(data.catalog, effectiveProvider, target)
         : [];
       const selectedEntry =
         modelOptions.find((entry) => entry.id === draft.model) ?? null;
@@ -672,7 +697,9 @@ export function useModelConfiguration(): ModelConfigurationState {
         setChatDrafts((prev) => {
           const entry = entriesForRole(
             data.catalog,
-            prev[target].provider,
+            providerLocked
+              ? (activeChatProvider as string)
+              : prev[target].provider,
             target,
           ).find((item) => item.id === model);
           const keepEffort =
@@ -706,7 +733,7 @@ export function useModelConfiguration(): ModelConfigurationState {
         if (save.phase !== "confirm") return;
         void performSave(target, {
           target,
-          provider: draft.provider,
+          provider: effectiveProvider,
           model: draft.model,
           ...(draft.effort ? { effort: draft.effort } : {}),
         });
@@ -719,14 +746,15 @@ export function useModelConfiguration(): ModelConfigurationState {
       return {
         target,
         providerOptions,
-        provider: draft.provider,
+        provider: effectiveProvider,
+        providerLocked,
         modelOptions,
         model: draft.model,
         effortOptions,
         effort: draft.effort,
         selectedEntry,
         configured: draft.configured,
-        sharedEffortKnob: OPENAI_FAMILY_PROVIDERS.has(draft.provider),
+        sharedEffortKnob: OPENAI_FAMILY_PROVIDERS.has(effectiveProvider),
         save,
         setProvider,
         setModel,
@@ -736,7 +764,7 @@ export function useModelConfiguration(): ModelConfigurationState {
         cancelSave,
       };
     },
-    [chatDrafts, performSave, saveStates, setSaveState],
+    [activeChatProvider, chatDrafts, performSave, saveStates, setSaveState],
   );
 
   const buildCodingGroup = useCallback(


### PR DESCRIPTION
Two live-reported defects in the #16171 model-configuration panel:

**1. "Loading options failed" on the model dropdown.** `GET /api/models` fans out to every provider's live model-list API — measured **22.7s on a cold cache** against the running agent, past the UI client's 10s fetch budget, so the catalog consumers always saw a failed load. The catalog itself is local static tables + one file read. New `?catalogOnly=1` skips the fan-out entirely; `getModelsCatalog` (settings panel + slash completions) uses it.

Live proof (cold cache, provider cache files deleted first):
```
$ time curl "…/api/models?catalogOnly=1"     → status=200 in 0.037s   (was 22.7s)
  providers: {}  catalog: codex/claude-chat/claude-coding/cerebras/elizacloud ✓
```

**2. Free provider mixing.** The small/large provider dropdown offered every catalog provider regardless of what routes chat — models could be picked from an inactive provider (e.g. Claude chat models while the brain runs Cerebras), persisting keys the runtime never reads. The panel now pins the chat provider to the **active intelligence selection** when it unambiguously maps to a catalog provider (Eliza Cloud → `elizacloud`, Cerebras → `cerebras`, Anthropic → `claude-chat`), rendering a static "follows your active provider" label instead of the dropdown, with model options scoped to that provider's slice. Ambiguous states (subscription-only selections — they don't route chat — and other BYOK providers) keep the free choice rather than locking the panel out. Coding stays backend-scoped as before (codex → codex models, claude → claude models).

**Tests**: models-routes 4✓ (incl. catalogOnly-never-touches-fetchers), panel 19✓ (3 new: pinned provider hides the dropdown + scopes options, free choice preserved without a mapping, save carries the pinned provider), client verbs 13✓; ui + agent typecheck ✓; biome clean.

Screenshots/video: N/A — the latency fix is proven by the timed curl above; the scoping behavior is pinned by the component tests and owner-eyeballed on the live dashboard post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)