### PR TITLE
fix(ci): preserve committed homepage baselines

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -70,6 +70,10 @@ jobs:
 
       - name: Setup workspace dependencies
         uses: ./.github/actions/setup-bun-workspace
+        env:
+          # The legacy fixture bundle contains stale visual baselines; homepage
+          # tests must use the expectations committed with the checked-out SHA.
+          ELIZA_SKIP_ARTIFACT_SYNC: "1"
         with:
           bun-version: ${{ env.BUN_VERSION }}
           install-command: bun install --ignore-scripts --no-frozen-lockfile


### PR DESCRIPTION
## Summary

- skip the legacy large-fixture artifact sync only in the homepage Quality job
- preserve the visual baselines from the checked-out commit during CI setup
- keep the rest of repository postinstall enabled

## Root cause

The legacy artifact bundle contains stale copies of three tracked mobile homepage baselines. Repository postinstall extracted those copies over the checked-out SHA, so CI compared current rendering against mutated expectations. Restoring the committed files makes all three tests pass under `CI=true`; no product or baseline change is needed.

## Verification

- `actionlint .github/workflows/quality.yml`
- `ELIZA_SKIP_ARTIFACT_SYNC=1 bun packages/scripts/sync-artifacts.mjs`
- 44 workflow/script contract tests passed
- affected mobile Playwright visuals passed 3/3 under `CI=true`
- `git diff --check`

<!-- evidence-row:before-screenshots -->
- [ ] N/A - This PR changes CI setup only and does not alter rendering.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - This PR changes CI setup only and does not alter rendering.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - This PR changes CI setup only; there is no user workflow to record.

<!-- evidence-row:backend-logs -->
- [ ] N/A - This PR does not change backend behavior.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - This PR does not change frontend behavior.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - This PR does not change a model, prompt, provider, or inference path.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - This PR does not create or mutate persistent domain records.

<!-- evidence-row:ocr-review -->
- [ ] N/A - This PR has no visual delta or screenshots.