### PR TITLE
fix(discord): break the slash-command sync deadlock + carry the admin gate

### DIFF
--- a/plugins/plugin-discord/__tests__/slash-command-registration-scope.test.ts
+++ b/plugins/plugin-discord/__tests__/slash-command-registration-scope.test.ts
@@ -64,6 +64,25 @@ function makeService() {
 }
 
 describe("Discord slash-command registration scopes", () => {
+	// Regression (#deadlock): the account ready promise resolves only AFTER
+	// onReady returns, but onReady itself awaits this registration — waiting on
+	// the promise from that path hung forever and no command set ever reached
+	// Discord (live: registered commands frozen at a 2-day-old snapshot). With
+	// a ready client the push must proceed without touching the promise.
+	it("pushes commands while the ready promise is still pending when the client is already ready", async () => {
+		const { globalAndGuildSet, service } = makeService();
+		const state = service.requireAccountState() as unknown as {
+			clientReadyPromise: Promise<void>;
+			client: { isReady?: () => boolean };
+		};
+		state.clientReadyPromise = new Promise<void>(() => {}); // never resolves
+		state.client.isReady = () => true;
+
+		await service.registerSlashCommands([command("global")]);
+
+		expect(globalAndGuildSet).toHaveBeenCalled();
+	});
+
 	it("keeps global commands out of guild scope while retaining guild-only and targeted commands", async () => {
 		const { globalAndGuildSet, service, targetedCreate } = makeService();
 

--- a/plugins/plugin-discord/slash-command-registration.ts
+++ b/plugins/plugin-discord/slash-command-registration.ts
@@ -37,7 +37,16 @@ export async function registerDiscordSlashCommands(
 	accountId?: string | null,
 ): Promise<void> {
 	const state = host.requireAccountState(accountId);
-	await state.clientReadyPromise;
+	// The account's ready promise resolves only AFTER onReady returns (#15855
+	// sequencing) — but onReady itself awaits the DISCORD_REGISTER_COMMANDS
+	// emission that lands here, so awaiting the promise from that path
+	// deadlocks silently and no command set ever reaches Discord's API. The
+	// actual precondition is a ready client; only wait when it isn't ready yet.
+	if (
+		!(typeof state.client?.isReady === "function" && state.client.isReady())
+	) {
+		await state.clientReadyPromise;
+	}
 
 	const client = state.client;
 	const clientApplication = client?.application;

--- a/plugins/plugin-discord/slash-commands.ts
+++ b/plugins/plugin-discord/slash-commands.ts
@@ -747,6 +747,12 @@ function toDiscordSlashCommand(command: SlashCommand): DiscordSlashCommand {
 		name: command.name,
 		description: command.description,
 		options,
+		// Without this the admin gate (default_member_permissions) configured on
+		// a built-in never reaches transformCommandToDiscordApi — every gated
+		// command registered as usable by everyone.
+		...(command.requiredPermissions != null
+			? { requiredPermissions: command.requiredPermissions }
+			: {}),
 	};
 }
 


### PR DESCRIPTION
Reading the live registered command set back from Discord's API (with command-id snowflakes decoded to timestamps) showed the last successful push was **two days old across ~15 bot restarts** — every cleanup since (#16154's nav declutter + admin gating, #16171's /model subcommands) never reached Discord.

**Bug 1 — circular wait.** `registerDiscordSlashCommands` awaited the account's `clientReadyPromise` unconditionally, but since #15855 that promise resolves only **after** `onReady` returns — and `onReady` itself awaits the `DISCORD_REGISTER_COMMANDS` emission that lands in this function. Deadlock with no timeout and no log line; instrumentation showed the handler firing and then nothing. Fix: the actual precondition is a ready client — await the promise only when `client.isReady()` is false. (A pre-extraction version of this fix existed on an unmerged local branch from Jul 10, which explains the two-day-old snapshot: it was live-tested once, then the checkout moved back to develop.)

**Bug 2 — dropped admin gate.** `toDiscordSlashCommand` projected built-ins into the registration payload without `requiredPermissions`, so #16154's `default_member_permissions` gates on `/settings` `/setup` `/app` `/transcribe` never reached the API even when a push happened.

**Live-verified end to end** (registered set read back from Discord's API after restart):
```
before: 44 commands, lastEdit=2026-07-10T23:16 on every entry, nav commands present, zero gated
after:  30 commands, fresh push — nav commands gone, /app /settings /setup /transcribe [admin-gated],
        /model carrying the current target/model/effort/coding-effort options
```

Tests: new regression in `slash-command-registration-scope.test.ts` (never-resolving ready promise + ready client → push still happens); full plugin suite 391✓; typecheck ✓; biome clean.

Screenshots/video: N/A — connector registration; the before/after registered-set dump above is the domain artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)