### PR TITLE
fix(loadperf): measure network bytes without service worker cache

### DIFF
--- a/packages/benchmarks/loadperf/frontend-kpi.mjs
+++ b/packages/benchmarks/loadperf/frontend-kpi.mjs
@@ -275,7 +275,10 @@ export async function runFrontendKpi({
   let browser = null;
   try {
     browser = await playwright.chromium.launch({ args: ["--no-sandbox"] });
-    const context = await browser.newContext();
+    const context = await browser.newContext({
+      // Keep Resource Timing scoped to network responses instead of decoded service-worker cache bodies.
+      serviceWorkers: "block",
+    });
     await context.addInitScript(OBSERVER_INIT);
     const page = await context.newPage();
     await page.goto(target, { waitUntil: "load", timeout: 60_000 });

--- a/packages/benchmarks/loadperf/frontend-kpi.test.mjs
+++ b/packages/benchmarks/loadperf/frontend-kpi.test.mjs
@@ -132,6 +132,7 @@ describe("frontend KPI budgets", () => {
   it("runs the browser measurement path and records a passing result", async () => {
     const recorded = [];
     let browserClosed = false;
+    let contextOptions;
     const metrics = {
       fcpMs: 0,
       lcpMs: 0,
@@ -155,7 +156,10 @@ describe("frontend KPI budgets", () => {
     const playwright = {
       chromium: {
         launch: async () => ({
-          newContext: async () => context,
+          newContext: async (options) => {
+            contextOptions = options;
+            return context;
+          },
           close: async () => {
             browserClosed = true;
           },
@@ -176,6 +180,7 @@ describe("frontend KPI budgets", () => {
 
     expect(exitCode).toBe(0);
     expect(browserClosed).toBe(true);
+    expect(contextOptions).toEqual({ serviceWorkers: "block" });
     expect(recorded).toEqual([
       {
         name: "frontend",


### PR DESCRIPTION
## Summary

- block service workers in the frontend KPI browser context
- keep Resource Timing measurements scoped to CDN-like HTTP responses
- assert the browser context option in the benchmark unit test

## Why

Once the app service worker claimed the page, Resource Timing reported decoded Cache API response sizes as `encodedBodySize`, inflating the transfer KPI from the real ~3.22 MB wire size to ~9.7 MB.

## Verification

- `bunx vitest run packages/benchmarks/loadperf/frontend-kpi.test.mjs` (6/6)
- `bunx prettier --check packages/benchmarks/loadperf/frontend-kpi.mjs packages/benchmarks/loadperf/frontend-kpi.test.mjs`
- live staging benchmark: 3,222,549 JS bytes; all KPI budgets pass
- `git diff --check`

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Benchmark instrumentation only; no rendered UI changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - Benchmark instrumentation only; no rendered UI changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - No interaction flow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - No backend behavior changed.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - Live staging benchmark passed all five KPI budgets with 3,222,549 transferred JS bytes.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No model inference path changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - No persistent domain records changed.

<!-- evidence-row:ocr-review -->
- [ ] N/A - No rendered UI changed.