### PR TITLE
test(commands): align Discord scenario with GUI-only navigation

### DIFF
--- a/packages/scenario-runner/test/scenarios/deterministic-slash-commands.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-slash-commands.scenario.ts
@@ -26,7 +26,7 @@ import { handleCommandsRoutes } from "../../../agent/src/api/commands-routes.ts"
  *     source of truth (every command present, none invented),
  *   - each `target.kind` carries the correct effect (agent → message pipeline,
  *     navigate → a concrete in-app route, client → a known local-client behavior), and
- *   - chat connectors (Discord) drop GUI-only client commands but keep navigation.
+ *   - chat connectors (Discord) drop GUI-only navigation/client commands but keep agent commands.
  */
 
 type ScenarioRoute = {
@@ -192,7 +192,7 @@ function expectGuiCatalog(status: number, body: unknown): string | undefined {
   return undefined;
 }
 
-/** Chat connectors drop GUI-only client commands but keep navigation + agent. */
+/** Chat connectors drop GUI-only navigation/client commands but keep agent commands. */
 function expectDiscordCatalog(
   status: number,
   body: unknown,
@@ -202,12 +202,14 @@ function expectDiscordCatalog(
   if (payload.surface !== "discord") {
     return `expected surface=discord, saw ${JSON.stringify(payload.surface)}`;
   }
-  const keys = new Set(payload.commands.map((c) => c.key));
-  if (keys.has("clear") || keys.has("fullscreen")) {
-    return "GUI-only client commands leaked onto the Discord surface";
+  const nonAgentCommand = payload.commands.find(
+    (command) => command.target.kind !== "agent",
+  );
+  if (nonAgentCommand) {
+    return `GUI-only ${nonAgentCommand.target.kind} command ${nonAgentCommand.key} leaked onto the Discord surface`;
   }
-  if (!keys.has("settings") || !keys.has("think")) {
-    return "navigation/agent commands missing from the Discord surface";
+  if (commandByKey(payload, "think")?.target.kind !== "agent") {
+    return "agent command /think is missing from the Discord surface";
   }
   return undefined;
 }


### PR DESCRIPTION
## Summary

- align the deterministic Discord slash-command scenario with the command catalog's GUI-only navigation contract
- reject any non-agent command on the Discord surface
- keep a representative assertion that the agent command `/think` remains available

## Root cause

PR #16154 intentionally made in-app navigation commands GUI-only to declutter Discord, but the deterministic scenario still required `/settings` on Discord. Exact-head Tests therefore reported 37 passing scenarios and one stale assertion failure.

## Verification

- targeted real-loopback deterministic scenario: 1 passed, 0 failed
- `bunx prettier --check packages/scenario-runner/test/scenarios/deterministic-slash-commands.scenario.ts`
- `git diff --check`

Failure artifact: exact-head Tests run 29183604279, `tests-zero-key-e2e-report`.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Test-only contract correction; no rendered UI changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - Test-only contract correction; no rendered UI changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - No interaction flow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - No backend behavior changed.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - No frontend behavior changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - The deterministic scenario made no live model calls.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - No persistent domain records changed.

<!-- evidence-row:ocr-review -->
- [ ] N/A - No rendered UI changed.