### PR TITLE
fix(connectors): bypass mention-prefixed commands and owner-gate model switch

### DIFF
--- a/packages/core/src/runtime/shortcut-registry.test.ts
+++ b/packages/core/src/runtime/shortcut-registry.test.ts
@@ -13,6 +13,7 @@ import {
 	matchShortcut,
 	normalizeForMatch,
 	ShortcutRegistry,
+	stripLeadingMentionForShortcut,
 } from "./shortcut-registry";
 
 const settingsExplicit: ShortcutDefinition = {
@@ -103,6 +104,48 @@ describe("matchShortcut — explicit tier (always-on)", () => {
 			priority: 5,
 		};
 		expect(matchShortcut([a, b], "/x")?.shortcut.id).toBe("b");
+	});
+
+	// #16172 gap 1: a leading connector-native mention must not defeat the
+	// deterministic explicit shortcut (strict-mention Discord requires `<@bot>`).
+	it("matches an explicit alias behind a leading <@id> mention", () => {
+		expect(matchShortcut(defs, "<@123> /settings")?.shortcut.id).toBe(
+			"cmd:settings",
+		);
+	});
+	it("matches an explicit alias behind a leading <@!id> nickname mention", () => {
+		expect(matchShortcut(defs, "<@!123> /set billing")?.shortcut.id).toBe(
+			"cmd:settings",
+		);
+	});
+	it("matches a mention-prefixed alias even when natural is disabled", () => {
+		expect(
+			matchShortcut(defs, "<@123> /settings", { allowNatural: false })
+				?.shortcut.id,
+		).toBe("cmd:settings");
+	});
+	it("does not strip a mention that is part of an argument", () => {
+		// `/settings <@123>` still matches /settings (the mention is an arg), and
+		// the leading-mention strip must not corrupt it into a non-match.
+		expect(matchShortcut(defs, "/settings <@123>")?.shortcut.id).toBe(
+			"cmd:settings",
+		);
+	});
+});
+
+describe("stripLeadingMentionForShortcut (#16172)", () => {
+	it("strips a leading <@id> and its whitespace", () => {
+		expect(stripLeadingMentionForShortcut("<@123> /model show")).toBe(
+			"/model show",
+		);
+	});
+	it("strips a leading <@!id> nickname mention", () => {
+		expect(stripLeadingMentionForShortcut("<@!42> /help")).toBe("/help");
+	});
+	it("leaves an inner mention untouched", () => {
+		expect(stripLeadingMentionForShortcut("/model <@123>")).toBe(
+			"/model <@123>",
+		);
 	});
 });
 

--- a/packages/core/src/runtime/shortcut-registry.ts
+++ b/packages/core/src/runtime/shortcut-registry.ts
@@ -97,20 +97,12 @@ function patternRegex(pattern: ShortcutPattern): RegExp | null {
 	return null;
 }
 
-/**
- * A single leading connector-native user mention (`<@id>` / `<@!id>`) plus its
- * trailing whitespace. Stripped before explicit slash/`!` alias matching so a
- * mention-prefixed command (`<@bot> /model show`, which strict-mention Discord
- * servers require) fires the SAME deterministic shortcut as a bare `/model
- * show` instead of falling through to the planner (issue #16172, gap 1).
- */
+/** A single leading Discord user mention and its separator. */
 const LEADING_RAW_MENTION = /^<@!?\d+>\s*/;
 
 /**
- * Remove a single leading connector-native bot mention so the pre-LLM explicit
- * shortcut gate sees the raw command. Only the id form (`<@id>` / `<@!id>`) is
- * handled here — it is connector-neutral and needs no display name; textual
- * `@name` mentions are stripped upstream by the command parser.
+ * Expose the command behind a connector-native mention to the deterministic
+ * shortcut gate. Inner mentions remain arguments.
  */
 export function stripLeadingMentionForShortcut(text: string): string {
 	return text.replace(LEADING_RAW_MENTION, "");
@@ -159,10 +151,8 @@ export function matchShortcut(
 	text: string,
 	context: ShortcutMatchContext = {},
 ): ShortcutMatch | null {
-	// Strip a leading connector-native mention so `<@bot> /cmd` matches the same
-	// explicit shortcut as `/cmd` (issue #16172). Only the explicit tier needs
-	// this pre-strip; the natural tier already dissolves mentions via
-	// `normalizeForMatch` (which drops non-alphanumeric tokens).
+	// The natural tier already dissolves mentions during normalization; only the
+	// exact explicit tier needs this connector-wire normalization.
 	const raw = stripLeadingMentionForShortcut(text.trim()).trim().toLowerCase();
 	if (!raw) return null;
 

--- a/packages/core/src/runtime/shortcut-registry.ts
+++ b/packages/core/src/runtime/shortcut-registry.ts
@@ -97,6 +97,25 @@ function patternRegex(pattern: ShortcutPattern): RegExp | null {
 	return null;
 }
 
+/**
+ * A single leading connector-native user mention (`<@id>` / `<@!id>`) plus its
+ * trailing whitespace. Stripped before explicit slash/`!` alias matching so a
+ * mention-prefixed command (`<@bot> /model show`, which strict-mention Discord
+ * servers require) fires the SAME deterministic shortcut as a bare `/model
+ * show` instead of falling through to the planner (issue #16172, gap 1).
+ */
+const LEADING_RAW_MENTION = /^<@!?\d+>\s*/;
+
+/**
+ * Remove a single leading connector-native bot mention so the pre-LLM explicit
+ * shortcut gate sees the raw command. Only the id form (`<@id>` / `<@!id>`) is
+ * handled here — it is connector-neutral and needs no display name; textual
+ * `@name` mentions are stripped upstream by the command parser.
+ */
+export function stripLeadingMentionForShortcut(text: string): string {
+	return text.replace(LEADING_RAW_MENTION, "");
+}
+
 function aliasMatches(raw: string, alias: string): boolean {
 	const a = alias.toLowerCase();
 	if (raw === a) return true;
@@ -140,7 +159,11 @@ export function matchShortcut(
 	text: string,
 	context: ShortcutMatchContext = {},
 ): ShortcutMatch | null {
-	const raw = text.trim().toLowerCase();
+	// Strip a leading connector-native mention so `<@bot> /cmd` matches the same
+	// explicit shortcut as `/cmd` (issue #16172). Only the explicit tier needs
+	// this pre-strip; the natural tier already dissolves mentions via
+	// `normalizeForMatch` (which drops non-alphanumeric tokens).
+	const raw = stripLeadingMentionForShortcut(text.trim()).trim().toLowerCase();
 	if (!raw) return null;
 
 	// ── Tier 1: explicit (slash/`!`) — unambiguous, always eligible ──────────

--- a/plugins/plugin-app-control/src/actions/model-switch.test.ts
+++ b/plugins/plugin-app-control/src/actions/model-switch.test.ts
@@ -4,7 +4,14 @@
  * The route's real HTTP behavior is covered in packages/agent.
  */
 
-import type { HandlerCallback, IAgentRuntime, Memory } from "@elizaos/core";
+import type {
+	HandlerCallback,
+	IAgentRuntime,
+	Memory,
+	RoleGate,
+	RoleGateRole,
+} from "@elizaos/core";
+import { satisfiesRoleGate } from "@elizaos/core";
 import { DEFAULT_ELIZA_CLOUD_TEXT_MODEL } from "@elizaos/shared";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -122,9 +129,13 @@ describe("MODEL_SWITCH handler", () => {
 		expect(await a.validate(runtime, message("hi"))).toBe(false);
 	});
 
-	it("declares USER role gate and required target param", () => {
+	it("declares an OWNER role gate and required target param", () => {
+		// #16172 gap 3: MODEL_SWITCH flips the GLOBAL inference backend, so it must
+		// be OWNER-gated (matching the owner-only `/model local|cloud` slash write
+		// and the sibling AGENT_SWITCH action). A planner-routed guest message must
+		// not reach this action ungated.
 		const { action: a } = action({ ok: true });
-		expect(a.roleGate).toEqual({ minRole: "USER" });
+		expect(a.roleGate).toEqual({ minRole: "OWNER" });
 		const target = a.parameters?.find((p) => p.name === "target");
 		expect(target?.required).toBe(true);
 		expect(target?.schema).toMatchObject({ enum: ["local", "cloud"] });
@@ -212,5 +223,39 @@ describe("MODEL_SWITCH handler", () => {
 		);
 		expect(result?.success).toBe(false);
 		expect(texts[0]).toMatch(/ECONNREFUSED/);
+	});
+});
+
+/**
+ * #16172 gap 3 regression: MODEL_SWITCH performs a GLOBAL runtime inference
+ * switch, so the planner-routed action-invocation path must be OWNER-gated.
+ * Before the fix the action declared `roleGate: { minRole: "USER" }`, so a
+ * guest whose (possibly mention-prefixed) message slipped past the
+ * deterministic command layer and reached the planner could invoke a global
+ * backend switch. The runtime enforces the DECLARED gate through the shared
+ * `satisfiesRoleGate` chokepoint (used by both the shortcut gate and the
+ * planned-tool-call executor), so proving the declared gate rejects non-owner
+ * roles proves the ungated planner path is closed.
+ */
+describe("MODEL_SWITCH role gate (planner path) — #16172 gap 3", () => {
+	const gate = createModelSwitchAction().roleGate as RoleGate | undefined;
+
+	const passes = (role: RoleGateRole) => satisfiesRoleGate([role], gate);
+
+	it("declares an OWNER floor", () => {
+		expect(gate).toEqual({ minRole: "OWNER" });
+	});
+
+	it("rejects a guest/user reaching the action via the planner", () => {
+		expect(passes("USER" as RoleGateRole)).toBe(false);
+		expect(passes("MEMBER" as RoleGateRole)).toBe(false);
+	});
+
+	it("rejects an ADMIN (a global inference switch is owner-only)", () => {
+		expect(passes("ADMIN" as RoleGateRole)).toBe(false);
+	});
+
+	it("allows an OWNER", () => {
+		expect(passes("OWNER" as RoleGateRole)).toBe(true);
 	});
 });

--- a/plugins/plugin-app-control/src/actions/model-switch.ts
+++ b/plugins/plugin-app-control/src/actions/model-switch.ts
@@ -190,7 +190,16 @@ export function createModelSwitchAction(
 		name: "MODEL_SWITCH",
 		contexts: ["general", "settings"],
 		contextGate: { anyOf: ["general", "settings"] },
-		roleGate: { minRole: "USER" },
+		// OWNER-gated (issue #16172, gap 3): flipping local↔cloud inference is a
+		// GLOBAL runtime backend switch (it drives the same loopback
+		// /api/runtime/model-switch route the owner-only `/model local|cloud` slash
+		// command uses — see plugins/plugin-commands handlers.ts). When the planner
+		// routes a (possibly guest) message here — e.g. a mention-prefixed
+		// `<@bot> /model cloud` that slipped past the deterministic layer — the
+		// action must NOT execute a global switch for a non-owner. This matches the
+		// sibling AGENT_SWITCH gate and is enforced by the shared actionGateFailure
+		// chokepoint the shortcut gate + planned-tool-call executor both consult.
+		roleGate: { minRole: "OWNER" },
 		similes: [
 			"SWITCH_MODEL",
 			"USE_LOCAL_MODEL",

--- a/plugins/plugin-app-control/src/actions/model-switch.ts
+++ b/plugins/plugin-app-control/src/actions/model-switch.ts
@@ -190,15 +190,8 @@ export function createModelSwitchAction(
 		name: "MODEL_SWITCH",
 		contexts: ["general", "settings"],
 		contextGate: { anyOf: ["general", "settings"] },
-		// OWNER-gated (issue #16172, gap 3): flipping local↔cloud inference is a
-		// GLOBAL runtime backend switch (it drives the same loopback
-		// /api/runtime/model-switch route the owner-only `/model local|cloud` slash
-		// command uses — see plugins/plugin-commands handlers.ts). When the planner
-		// routes a (possibly guest) message here — e.g. a mention-prefixed
-		// `<@bot> /model cloud` that slipped past the deterministic layer — the
-		// action must NOT execute a global switch for a non-owner. This matches the
-		// sibling AGENT_SWITCH gate and is enforced by the shared actionGateFailure
-		// chokepoint the shortcut gate + planned-tool-call executor both consult.
+		// This mutates the global inference backend, matching the sibling
+		// AGENT_SWITCH owner boundary regardless of planner or shortcut routing.
 		roleGate: { minRole: "OWNER" },
 		similes: [
 			"SWITCH_MODEL",

--- a/plugins/plugin-commands/__tests__/parser.test.ts
+++ b/plugins/plugin-commands/__tests__/parser.test.ts
@@ -3,7 +3,13 @@
  * stripping, colon separators) and `parseCommand` token/argument extraction.
  */
 import { describe, expect, it } from "vitest";
-import { normalizeCommandBody, parseCommand } from "../src/parser.ts";
+import {
+	detectCommand,
+	hasCommand,
+	normalizeCommandBody,
+	parseCommand,
+	stripLeadingBotMention,
+} from "../src/parser.ts";
 import type { CommandDefinition } from "../src/types.ts";
 
 /**
@@ -35,6 +41,78 @@ describe("normalizeCommandBody", () => {
 
 	it("leaves a plain command body untouched", () => {
 		expect(normalizeCommandBody("/help me now")).toBe("/help me now");
+	});
+
+	// #16172 gap 1: a leading connector-native mention (`<@id>` / `<@!id>`) must
+	// be stripped by the id form alone, with no known display name.
+	it("strips a leading Discord raw mention (<@id>)", () => {
+		expect(normalizeCommandBody("<@123456789> /status")).toBe("/status");
+	});
+
+	it("strips the legacy nickname raw mention (<@!id>)", () => {
+		expect(normalizeCommandBody("<@!123456789> /model show")).toBe(
+			"/model show",
+		);
+	});
+});
+
+describe("stripLeadingBotMention (#16172)", () => {
+	it("strips a leading <@id> and its separating whitespace", () => {
+		expect(stripLeadingBotMention("<@123> /model show")).toBe("/model show");
+	});
+
+	it("strips a leading <@!id> nickname mention", () => {
+		expect(stripLeadingBotMention("<@!987654321> /help")).toBe("/help");
+	});
+
+	it("strips a mention followed by a newline before the command", () => {
+		expect(stripLeadingBotMention("<@123>\n/status")).toBe("/status");
+	});
+
+	it("leaves a mention that is NOT at the very start untouched", () => {
+		// a mention inside an argument must survive verbatim
+		expect(stripLeadingBotMention("/model <@123>")).toBe("/model <@123>");
+	});
+
+	it("leaves plain command text untouched", () => {
+		expect(stripLeadingBotMention("/model show")).toBe("/model show");
+	});
+});
+
+describe("hasCommand / detectCommand — mention-prefixed commands (#16172)", () => {
+	// The default registry (fallback store) is pre-seeded with the built-in
+	// commands, so `/model` / `/help` resolve without initForRuntime.
+	it("detects a bare slash command (baseline)", () => {
+		expect(hasCommand("/model show")).toBe(true);
+		expect(detectCommand("/model show").isCommand).toBe(true);
+	});
+
+	it("detects a command behind a leading <@id> mention + space", () => {
+		expect(hasCommand("<@123> /model show")).toBe(true);
+		const d = detectCommand("<@123> /model show");
+		expect(d.isCommand).toBe(true);
+		expect(d.command?.key).toBe("model");
+	});
+
+	it("detects a command behind a leading <@!id> nickname mention", () => {
+		expect(hasCommand("<@!123> /help")).toBe(true);
+		expect(detectCommand("<@!123> /help").command?.key).toBe("help");
+	});
+
+	it("detects a command when a newline separates the mention", () => {
+		expect(hasCommand("<@123>\n/model show")).toBe(true);
+		expect(detectCommand("<@123>\n/model show").command?.key).toBe("model");
+	});
+
+	it("preserves the command args after mention stripping", () => {
+		const d = detectCommand("<@123> /model cloud");
+		expect(d.command?.key).toBe("model");
+		expect(d.command?.rawArgs).toBe("cloud");
+	});
+
+	it("does not treat a mention with no command as a command", () => {
+		expect(hasCommand("<@123> hello there")).toBe(false);
+		expect(detectCommand("<@123> hello there").isCommand).toBe(false);
 	});
 });
 

--- a/plugins/plugin-commands/src/parser.ts
+++ b/plugins/plugin-commands/src/parser.ts
@@ -12,30 +12,13 @@ import type {
 const escapeRegExp = (value: string) =>
 	value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
-/**
- * A leading bot mention followed by optional whitespace/newlines. Matches the
- * connector-native raw mention forms so command detection sees the same text
- * regardless of whether the server requires an explicit mention:
- *   - Discord user mention `<@123>` / `<@!123>` (the `!` is the legacy nickname form)
- *   - Discord role/channel-style angle mentions are intentionally NOT stripped
- *     (only user mentions prefix a command); a bare `@name` textual mention is
- *     handled separately by {@link normalizeCommandBody} with the known name.
- *
- * Only a SINGLE leading mention is stripped, and only when it sits at the very
- * start — so `/model <@123>` (a mention inside an argument) is untouched.
- */
+/** A single leading Discord user mention; role and channel forms do not match. */
 const LEADING_RAW_MENTION = /^<@!?\d+>\s*/;
 
 /**
- * Strip a leading connector-native bot mention (`<@id>` / `<@!id>`) plus the
- * whitespace/newline that separates it from the command, so a mention-prefixed
- * command (`<@bot> /model show`, common on strict-mention Discord servers)
- * matches the deterministic command layer exactly like a bare `/model show`.
- *
- * Text-form `@name` mentions are left to {@link normalizeCommandBody} (which
- * needs the bot's display name); this handles the id form every connector emits
- * in `content.text` before command detection runs, so no connector-specific
- * pre-normalization is required for the raw mention to be defeated.
+ * Remove the connector-native bot prefix so strict-mention messages reach the
+ * deterministic command layer. Textual names require the separate known-name
+ * normalization, and inner mentions remain command arguments.
  */
 export function stripLeadingBotMention(text: string): string {
 	return text.replace(LEADING_RAW_MENTION, "");
@@ -218,9 +201,7 @@ export function normalizeCommandBody(
 ): string {
 	let normalized = text.trim();
 
-	// Remove a leading connector-native mention (`<@id>` / `<@!id>`) first — the
-	// id form every connector emits in content.text, independent of any known
-	// display name.
+	// Raw connector IDs do not require a configured display name.
 	normalized = stripLeadingBotMention(normalized).trim();
 
 	// Remove textual bot mention prefix (e.g., "@bot /status" -> "/status")

--- a/plugins/plugin-commands/src/parser.ts
+++ b/plugins/plugin-commands/src/parser.ts
@@ -13,11 +13,40 @@ const escapeRegExp = (value: string) =>
 	value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
 /**
+ * A leading bot mention followed by optional whitespace/newlines. Matches the
+ * connector-native raw mention forms so command detection sees the same text
+ * regardless of whether the server requires an explicit mention:
+ *   - Discord user mention `<@123>` / `<@!123>` (the `!` is the legacy nickname form)
+ *   - Discord role/channel-style angle mentions are intentionally NOT stripped
+ *     (only user mentions prefix a command); a bare `@name` textual mention is
+ *     handled separately by {@link normalizeCommandBody} with the known name.
+ *
+ * Only a SINGLE leading mention is stripped, and only when it sits at the very
+ * start — so `/model <@123>` (a mention inside an argument) is untouched.
+ */
+const LEADING_RAW_MENTION = /^<@!?\d+>\s*/;
+
+/**
+ * Strip a leading connector-native bot mention (`<@id>` / `<@!id>`) plus the
+ * whitespace/newline that separates it from the command, so a mention-prefixed
+ * command (`<@bot> /model show`, common on strict-mention Discord servers)
+ * matches the deterministic command layer exactly like a bare `/model show`.
+ *
+ * Text-form `@name` mentions are left to {@link normalizeCommandBody} (which
+ * needs the bot's display name); this handles the id form every connector emits
+ * in `content.text` before command detection runs, so no connector-specific
+ * pre-normalization is required for the raw mention to be defeated.
+ */
+export function stripLeadingBotMention(text: string): string {
+	return text.replace(LEADING_RAW_MENTION, "");
+}
+
+/**
  * Check if text contains a command
  */
 export function hasCommand(text: string): boolean {
 	if (!text) return false;
-	const trimmed = text.trim();
+	const trimmed = stripLeadingBotMention(text.trim()).trim();
 	if (!trimmed.startsWith("/") && !trimmed.startsWith("!")) return false;
 	return Boolean(startsWithCommand(trimmed));
 }
@@ -30,7 +59,7 @@ export function detectCommand(text: string): CommandDetectionResult {
 		return { isCommand: false };
 	}
 
-	const trimmed = text.trim();
+	const trimmed = stripLeadingBotMention(text.trim()).trim();
 
 	// Quick check for command prefix
 	if (!trimmed.startsWith("/") && !trimmed.startsWith("!")) {
@@ -189,7 +218,12 @@ export function normalizeCommandBody(
 ): string {
 	let normalized = text.trim();
 
-	// Remove bot mention prefix (e.g., "@bot /status" -> "/status")
+	// Remove a leading connector-native mention (`<@id>` / `<@!id>`) first — the
+	// id form every connector emits in content.text, independent of any known
+	// display name.
+	normalized = stripLeadingBotMention(normalized).trim();
+
+	// Remove textual bot mention prefix (e.g., "@bot /status" -> "/status")
 	if (botMention) {
 		const mentionPattern = new RegExp(`^@${escapeRegExp(botMention)}\\s*`, "i");
 		normalized = normalized.replace(mentionPattern, "");


### PR DESCRIPTION
## Summary

Fixes #16172 — three stacked gaps on the plain-text connector command path that let a **leading bot-mention bypass the deterministic command layer**, after which the planner improvised (hallucinated success) and could reach the **ungated MODEL_SWITCH action**.

On strict-mention Discord servers a command arrives as `<@bot> /model show` with the mention still in `content.text`. The deterministic layer (`hasCommand`/`detectCommand` and the pre-LLM explicit shortcut gate) only matched text starting with `/`, so the mention-prefixed command fell through to the planner.

## The three gaps (issue framing) → fixes

**Gap 1 — mention prefix defeats detection.** Strip a leading connector-native mention (`<@id>` / `<@!id>`) before command detection:
- `plugins/plugin-commands` parser: new `stripLeadingBotMention()`, applied in `hasCommand`, `detectCommand`, and `normalizeCommandBody`.
- core explicit-shortcut matcher: new `stripLeadingMentionForShortcut()`, applied at the top of `matchShortcut` (explicit tier only; the natural tier already dissolves mentions via `normalizeForMatch`).
- Only a **single leading** mention is stripped — an inner mention like `/model <@123>` is untouched.

**Gap 2 — planner improvises / hallucinated success.** With detection restored, a mention-prefixed command now resolves deterministically **before** the planner, closing the fabricated-"Switched…"-success path (same class as #7923/#7945).

**Gap 3 — MODEL_SWITCH has no role gate.** `MODEL_SWITCH` now declares `roleGate: { minRole: "OWNER" }` (was `USER`). Flipping local↔cloud is a **global** runtime inference switch that drives the same loopback `/api/runtime/model-switch` route the owner-only `/model local|cloud` slash write uses — and matches the sibling `AGENT_SWITCH` gate. Enforced by the shared `actionGateFailure` chokepoint that both the shortcut gate and the planned-tool-call executor consult, so a planner-routed non-owner message can no longer invoke it.

## Files

- `plugins/plugin-commands/src/parser.ts` — mention-strip in detection path
- `packages/core/src/runtime/shortcut-registry.ts` — mention-strip in explicit shortcut matcher
- `plugins/plugin-app-control/src/actions/model-switch.ts` — OWNER gate

## Tests (new / updated)

- **parser** (`plugin-commands/__tests__/parser.test.ts`): mention-prefixed detection — plain, `<@!id>` nickname, newline separator; arg preservation; non-command mention; inner-mention safety; `normalizeCommandBody` raw-mention forms.
- **shortcut-registry** (`packages/core/.../shortcut-registry.test.ts`): explicit alias behind a leading mention (incl. `allowNatural:false`), inner-mention safety, `stripLeadingMentionForShortcut`.
- **model-switch** (`plugin-app-control/.../model-switch.test.ts`): OWNER-gate regression via `satisfiesRoleGate` — USER/MEMBER/ADMIN rejected, OWNER allowed; declared-gate assertion updated USER→OWNER.

### Evidence (touched test files green)

```
plugin-commands  __tests__/parser.test.ts + command-actions.test.ts   43 passed
core             src/runtime/shortcut-registry.test.ts                27 passed
core             message.shortcut-gate.test.ts + action-gate.test.ts  21 passed
app-control      model-switch.test.ts                                 22 passed
app-control      settings-routing.test.ts + agent-switch.test.ts      18 passed
```

### Coverage on changed files (>= 50% required)

```
parser.ts             83.83% lines
shortcut-registry.ts  99.03% lines
model-switch.ts       80.88% lines
```

Typecheck clean on all three touched files (`tsc --noEmit`).

🌞 [sol-cloud]

### PR evidence rows
<!-- evidence-row:before-screenshots -->
- [x] N/A - connector command-routing and authorization logic only; no rendered UI changed. Covered by focused connector and app-control tests listed above.

<!-- evidence-row:after-screenshots -->
- [x] N/A - connector command-routing and authorization logic only; no rendered UI changed. Covered by focused connector and app-control tests listed above.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - connector command-routing and authorization logic only; no rendered UI changed. Covered by focused connector and app-control tests listed above.

<!-- evidence-row:backend-logs -->
- [x] [16189-connector-command-routing.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16189-connector-command-routing.log)

<!-- evidence-row:frontend-logs -->
- [x] N/A - connector command-routing and authorization logic only; no rendered UI changed. Covered by focused connector and app-control tests listed above.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - connector command-routing and authorization logic only; no rendered UI changed. Covered by focused connector and app-control tests listed above.

<!-- evidence-row:domain-artifacts -->
- [x] [16189-model-switch-role-gate.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16189-model-switch-role-gate.json)


