### PR TITLE
ci: stabilize promotion startup and cloud audit gates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -226,6 +226,9 @@ jobs:
       - name: Build packages
         run: bun run build
 
+      - name: Remove source-adjacent build output
+        run: bun run clean:stale-js
+
       - name: Install Playwright Chromium
         run: bunx playwright install --with-deps chromium
 

--- a/packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts
@@ -488,7 +488,9 @@ test.describe("cloud-surfaces aesthetic audit (#10725/#11342)", () => {
   test("coverage matches the registered cloud routes", async ({ page }) => {
     await seedStewardToken(page);
     await installCloudApiStubs(page);
-    await page.goto("/login", { waitUntil: "domcontentloaded" });
+    // The seeded session redirects /login asynchronously, which can destroy
+    // the evaluate context while the registry is being read.
+    await page.goto("/dashboard/agents", { waitUntil: "domcontentloaded" });
     const readRegistryPaths = () =>
       page.evaluate(() => {
         const store = (globalThis as unknown as Record<symbol, unknown>)[


### PR DESCRIPTION
## Summary

- remove source-adjacent JavaScript emitted by the workspace build before source-mode dev startup
- read the cloud route registry from an authenticated route instead of racing the seeded-session redirect away from `/login`

## Verification

- `actionlint .github/workflows/ci.yaml`
- `node --test packages/scripts/stale-js-shadow-guard.test.mjs` (5/5)
- Prettier check for both changed files
- `git diff --check`

These are narrow CI reliability fixes discovered by the verified develop-to-main promotion. No product runtime code changes.

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16173-before-screenshots.png)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16173-after-screenshots.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence/16173-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [x] https://github.com/elizaOS/eliza/actions/runs/29184368098

<!-- evidence-row:frontend-logs -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence/16173-frontend-console-network.log

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - This CI-only change does not alter prompts or model execution.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - This CI-only change does not create or mutate domain records.

<!-- evidence-row:ocr-review -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence/16173-ocr-review.json