### PR TITLE
test: tolerate cloud audit auth navigation

### DIFF
--- a/packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts
@@ -488,23 +488,39 @@ test.describe("cloud-surfaces aesthetic audit (#10725/#11342)", () => {
   test("coverage matches the registered cloud routes", async ({ page }) => {
     await seedStewardToken(page);
     await installCloudApiStubs(page);
-    // The seeded session redirects /login asynchronously, which can destroy
-    // the evaluate context while the registry is being read.
     await page.goto("/dashboard/agents", { waitUntil: "domcontentloaded" });
-    const readRegistryPaths = () =>
-      page.evaluate(() => {
-        const store = (globalThis as unknown as Record<symbol, unknown>)[
-          Symbol.for("elizaos.ui.cloud-route-registry")
-        ] as { entries: Map<string, unknown> } | undefined;
-        return store ? [...store.entries.keys()] : [];
-      });
+    const readRegistryPaths = async () => {
+      try {
+        return await page.evaluate(() => {
+          const store = (globalThis as unknown as Record<symbol, unknown>)[
+            Symbol.for("elizaos.ui.cloud-route-registry")
+          ] as { entries: Map<string, unknown> } | undefined;
+          return store ? [...store.entries.keys()] : [];
+        });
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          error.message.includes("Execution context was destroyed")
+        ) {
+          return [];
+        }
+        throw error;
+      }
+    };
+    let registeredPaths = await readRegistryPaths();
     await expect
-      .poll(async () => (await readRegistryPaths()).length, {
-        message: "cloud-route registry populated by the running shell",
-        timeout: 30_000,
-      })
+      .poll(
+        async () => {
+          registeredPaths = await readRegistryPaths();
+          return registeredPaths.length;
+        },
+        {
+          message: "cloud-route registry populated by the running shell",
+          timeout: 30_000,
+        },
+      )
       .toBeGreaterThan(0);
-    const registered = new Set(await readRegistryPaths());
+    const registered = new Set(registeredPaths);
     const audited = new Set(CLOUD_AUDIT_CASES.map((c) => c.route));
     const unaudited = [...registered].filter((p) => !audited.has(p));
     expect(


### PR DESCRIPTION
## Summary

- treat only Playwright execution-context destruction during Steward auth navigation as transient
- retain all other cloud route-registry evaluation failures
- preserve the successfully read registry paths instead of evaluating a second time

## Verification

- strict cloud audit rendered 85/85 cloud desktop/mobile surfaces before this guard-only failure
- Prettier check
- `git diff --check`

No product runtime code changes.

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16173-before-screenshots.png)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16173-after-screenshots.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence/16173-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [x] https://github.com/elizaOS/eliza/actions/runs/29185231865

<!-- evidence-row:frontend-logs -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence/16173-frontend-console-network.log

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - Test-only navigation retry; no model execution change.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - Test-only navigation retry; no domain records.

<!-- evidence-row:ocr-review -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence/16173-ocr-review.json