### PR TITLE
fix(ci): fail closed when app live cloud key is missing

### DIFF
--- a/.github/workflows/app-live-e2e.yml
+++ b/.github/workflows/app-live-e2e.yml
@@ -50,7 +50,6 @@ env:
   OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
   GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
   XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
-  ELIZAOS_CLOUD_API_KEY: ${{ secrets.ELIZAOS_CLOUD_API_KEY }}
 
 jobs:
   # Real LOCAL chat turn through the live stack: a real app-core runtime + a real
@@ -203,18 +202,35 @@ jobs:
   # Real CLOUD login + provisioning + chat through the app UI against real Eliza
   # Cloud. cloud-live.spec.ts mocks nothing; ELIZA_UI_SMOKE_CLOUD_LIVE=1 leaves
   # first-run open so the spec drives cloud onboarding, and ELIZAOS_CLOUD_API_KEY
-  # authenticates. Skips cleanly if the key is absent.
+  # authenticates. The secret-gated job fails before setup when neither accepted
+  # repository secret is configured; the spec remains safely skippable outside
+  # this workflow so keyless PR lanes cannot spend Cloud credits.
   cloud-live:
     name: cloud login + provision + chat (real Eliza Cloud)
     runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 45
     env:
       ELIZA_UI_SMOKE_CLOUD_LIVE: "1"
+      # Prefer the variable named for the runtime contract, but retain the
+      # repository's established ELIZACLOUD_API_KEY as the canonical fallback.
+      ELIZAOS_CLOUD_API_KEY: ${{ secrets.ELIZAOS_CLOUD_API_KEY || secrets.ELIZACLOUD_API_KEY }}
       PGLITE_WASM_MODE: node
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           submodules: false
+
+      - name: Require real Cloud credential
+        shell: bash
+        run: |
+          set -euo pipefail
+          cloud_key_without_whitespace="${ELIZAOS_CLOUD_API_KEY:-}"
+          cloud_key_without_whitespace="${cloud_key_without_whitespace//[[:space:]]/}"
+          if [[ -z "$cloud_key_without_whitespace" ]]; then
+            echo "::error::App Live E2E requires ELIZAOS_CLOUD_API_KEY or ELIZACLOUD_API_KEY; refusing a green-by-skip Cloud job."
+            exit 1
+          fi
+          unset cloud_key_without_whitespace
 
       - name: Free disk space for browser smoke
         run: |

--- a/packages/app-core/test/helpers/live-child-env.test.ts
+++ b/packages/app-core/test/helpers/live-child-env.test.ts
@@ -1,0 +1,50 @@
+/** Exercises credential isolation for child processes used by live app-core tests. */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createLiveRuntimeChildEnv } from "./live-child-env.ts";
+
+describe("createLiveRuntimeChildEnv", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("blanks an ambient Cloud key when isolating a different live provider", () => {
+    vi.stubEnv("ELIZA_UI_SMOKE_CLOUD_LIVE", "");
+    vi.stubEnv("ELIZAOS_CLOUD_API_KEY", "ambient-cloud-key");
+
+    const childEnv = createLiveRuntimeChildEnv({
+      OPENAI_API_KEY: "selected-provider-key",
+      ELIZA_STATE_DIR: undefined,
+    });
+
+    expect(childEnv.OPENAI_API_KEY).toBe("selected-provider-key");
+    expect(childEnv.ELIZAOS_CLOUD_API_KEY).toBe("");
+  });
+
+  it("preserves the ambient Cloud key only in Cloud-live mode", () => {
+    vi.stubEnv("ELIZA_UI_SMOKE_CLOUD_LIVE", "1");
+    vi.stubEnv("ELIZAOS_CLOUD_API_KEY", "cloud-live-key");
+
+    const childEnv = createLiveRuntimeChildEnv({
+      OPENAI_API_KEY: "selected-provider-key",
+      ELIZA_STATE_DIR: undefined,
+    });
+
+    expect(childEnv.OPENAI_API_KEY).toBe("selected-provider-key");
+    expect(childEnv.ELIZAOS_CLOUD_API_KEY).toBe("cloud-live-key");
+  });
+
+  it.each([
+    ["missing", undefined],
+    ["whitespace-only", " \t\n"],
+  ])("does not preserve a %s Cloud key in Cloud-live mode", (_, cloudKey) => {
+    vi.stubEnv("ELIZA_UI_SMOKE_CLOUD_LIVE", "1");
+    vi.stubEnv("ELIZAOS_CLOUD_API_KEY", cloudKey);
+
+    const childEnv = createLiveRuntimeChildEnv({
+      OPENAI_API_KEY: "selected-provider-key",
+      ELIZA_STATE_DIR: undefined,
+    });
+
+    expect(childEnv.ELIZAOS_CLOUD_API_KEY).toBe("");
+  });
+});

--- a/packages/app-core/test/helpers/live-child-env.ts
+++ b/packages/app-core/test/helpers/live-child-env.ts
@@ -6,14 +6,14 @@ import {
   LIVE_PROVIDER_ENV_KEYS,
 } from "./live-provider.ts";
 
-function hasHostsOverride(value: string | undefined): value is string {
+function hasNonWhitespaceValue(value: string | undefined): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
 
 function ensureSelfControlTestHostsPath(env: NodeJS.ProcessEnv): string | null {
   const configuredPath =
     env.WEBSITE_BLOCKER_HOSTS_FILE_PATH ?? env.SELFCONTROL_HOSTS_FILE_PATH;
-  if (hasHostsOverride(configuredPath)) {
+  if (hasNonWhitespaceValue(configuredPath)) {
     return configuredPath;
   }
 
@@ -33,6 +33,10 @@ function ensureSelfControlTestHostsPath(env: NodeJS.ProcessEnv): string | null {
 export function createLiveRuntimeChildEnv(
   overrides: Record<string, string | undefined>,
 ): NodeJS.ProcessEnv {
+  const ambientCloudApiKey = process.env.ELIZAOS_CLOUD_API_KEY;
+  const preserveAmbientCloudApiKey =
+    process.env.ELIZA_UI_SMOKE_CLOUD_LIVE === "1" &&
+    hasNonWhitespaceValue(ambientCloudApiKey);
   const liveProviderOverrides = Object.fromEntries(
     Object.entries(overrides).filter(
       ([key, value]) => value !== undefined && LIVE_PROVIDER_ENV_KEYS.has(key),
@@ -44,6 +48,13 @@ export function createLiveRuntimeChildEnv(
           env: liveProviderOverrides as Record<string, string>,
         })
       : { ...process.env };
+
+  // Provider isolation deliberately blanks every unselected credential. The
+  // app Cloud-live lane is the sole exception: its onboarding runtime needs the
+  // workflow-validated Cloud bearer in addition to the selected model provider.
+  if (preserveAmbientCloudApiKey) {
+    env.ELIZAOS_CLOUD_API_KEY = ambientCloudApiKey;
+  }
 
   for (const key of Object.keys(env)) {
     if (key === "VITEST" || key.startsWith("VITEST_")) {

--- a/packages/scripts/__tests__/app-live-e2e-workflow.test.ts
+++ b/packages/scripts/__tests__/app-live-e2e-workflow.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Fail-closed contract for the real Eliza Cloud job in app-live-e2e.yml.
+ *
+ * The Playwright spec intentionally remains self-skipping in keyless contexts
+ * so PR lanes cannot spend Cloud credits. The secret-gated workflow job must
+ * therefore reject a missing credential before setup/build/test work; otherwise
+ * Playwright reports the only test as skipped and the declared live job is green.
+ */
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const repoRoot = new URL("../../../", import.meta.url);
+
+function read(path: string): string {
+  return readFileSync(new URL(path, repoRoot), "utf8");
+}
+
+interface WorkflowStep {
+  name?: string;
+  uses?: string;
+  run?: string;
+}
+
+interface WorkflowJob {
+  env?: Record<string, string>;
+  steps?: WorkflowStep[];
+}
+
+interface Workflow {
+  on?: Record<string, unknown>;
+  jobs?: Record<string, WorkflowJob>;
+}
+
+const workflow = Bun.YAML.parse(
+  read(".github/workflows/app-live-e2e.yml"),
+) as Workflow;
+const cloudJob = workflow.jobs?.["cloud-live"];
+
+function namedStep(name: string): WorkflowStep {
+  const step = cloudJob?.steps?.find((candidate) => candidate.name === name);
+  if (!step) {
+    throw new Error(`Missing cloud-live workflow step: ${name}`);
+  }
+  return step;
+}
+
+describe("App Live E2E real Cloud job (#14357, #16194)", () => {
+  test("maps the runtime key to the established repository-secret fallback", () => {
+    expect(cloudJob?.env?.ELIZAOS_CLOUD_API_KEY).toBe(
+      "${{ secrets.ELIZAOS_CLOUD_API_KEY || secrets.ELIZACLOUD_API_KEY }}",
+    );
+  });
+
+  test("fails on a missing key before setup, build, or Playwright can skip", () => {
+    const steps = cloudJob?.steps ?? [];
+    const preflightIndex = steps.findIndex(
+      (step) => step.name === "Require real Cloud credential",
+    );
+    const firstExpensiveStepIndex = steps.findIndex(
+      (step) => step.name === "Free disk space for browser smoke",
+    );
+    const testIndex = steps.findIndex(
+      (step) => step.name === "Run real cloud login + provision + chat",
+    );
+
+    expect(preflightIndex).toBeGreaterThanOrEqual(0);
+    expect(firstExpensiveStepIndex).toBeGreaterThan(preflightIndex);
+    expect(testIndex).toBeGreaterThan(preflightIndex);
+
+    const run = namedStep("Require real Cloud credential").run;
+    expect(run).toBeDefined();
+
+    const missing = spawnSync("bash", ["-c", run ?? ""], {
+      encoding: "utf8",
+      env: { ...process.env, ELIZAOS_CLOUD_API_KEY: "" },
+    });
+    expect(missing.status).toBe(1);
+    expect(missing.stdout).toContain("refusing a green-by-skip Cloud job");
+
+    const whitespaceOnly = spawnSync("bash", ["-c", run ?? ""], {
+      encoding: "utf8",
+      env: { ...process.env, ELIZAOS_CLOUD_API_KEY: " \t\n" },
+    });
+    expect(whitespaceOnly.status).toBe(1);
+
+    const configured = spawnSync("bash", ["-c", run ?? ""], {
+      encoding: "utf8",
+      env: { ...process.env, ELIZAOS_CLOUD_API_KEY: "contract-test-key" },
+    });
+    expect(configured.status).toBe(0);
+  });
+
+  test("keeps the live spec keyless-safe and out of pull-request workflows", () => {
+    const spec = read("packages/app/test/ui-smoke/cloud-live.spec.ts");
+
+    expect(workflow.on?.pull_request).toBeUndefined();
+    expect(spec).toContain(
+      "const HAS_CLOUD_KEY = Boolean(process.env.ELIZAOS_CLOUD_API_KEY?.trim())",
+    );
+    expect(spec).toContain("test.skip(\n    !HAS_CLOUD_KEY,");
+  });
+});

--- a/packages/scripts/__tests__/app-live-e2e-workflow.test.ts
+++ b/packages/scripts/__tests__/app-live-e2e-workflow.test.ts
@@ -48,7 +48,7 @@ function namedStep(name: string): WorkflowStep {
 describe("App Live E2E real Cloud job (#14357, #16194)", () => {
   test("maps the runtime key to the established repository-secret fallback", () => {
     expect(cloudJob?.env?.ELIZAOS_CLOUD_API_KEY).toBe(
-      "${{ secrets.ELIZAOS_CLOUD_API_KEY || secrets.ELIZACLOUD_API_KEY }}",
+      "$" + "{{ secrets.ELIZAOS_CLOUD_API_KEY || secrets.ELIZACLOUD_API_KEY }}",
     );
   });
 


### PR DESCRIPTION
# Relates to

- Addresses #14357's green-by-skip credential bug.
- Implements the App Live credential/fail-closed acceptance item in #16194.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` at push time (`6c460be204e298faf544fc8534a471e478153dba`) with zero conflicts.
- [x] Locked `bun install`, the canonical focused tests, and the declared Turbo app-core typecheck graph were run after sync. Full repository `bun run verify` remains delegated to PR CI.
- [x] A reviewer can confirm the missing-key behavior from the deterministic contract test, which executes the workflow preflight with empty, whitespace-only, and populated environments.

# Sync with develop

- [x] Rebased onto `6c460be204e298faf544fc8534a471e478153dba`, the latest `origin/develop` immediately before the force-with-lease push; zero conflicts.
- [x] The relevant app-core test and full declared app-core Turbo typecheck dependency graph pass. Full repository `bun run verify` remains delegated to PR CI.

# Risks

Low. The change affects only the secret-gated `cloud-live` job and the importable live-child environment helper for that explicit mode. It scopes the Cloud key to that job, retains the preferred `ELIZAOS_CLOUD_API_KEY`, and falls back to the repository's established `ELIZACLOUD_API_KEY`. A missing key now fails before runner cleanup, dependency setup, builds, or Playwright. Provider isolation continues to blank ambient Cloud credentials in every non-Cloud live lane; only exact `ELIZA_UI_SMOKE_CLOUD_LIVE=1` with a non-whitespace key restores it to the runtime child. Keyless PR behavior is unchanged.

# Background

## What does this PR do?

Recent `App Live E2E` runs declared the real Cloud job green while Playwright reported its only test skipped. The workflow exported only `secrets.ELIZAOS_CLOUD_API_KEY`; the repository's live Cloud lanes use `secrets.ELIZACLOUD_API_KEY`. Because `cloud-live.spec.ts` correctly self-skips in keyless contexts, the empty workflow variable turned a missing credential into a vacuous green result.

This PR:

- maps the runtime variable to `${{ secrets.ELIZAOS_CLOUD_API_KEY || secrets.ELIZACLOUD_API_KEY }}` inside the `cloud-live` job;
- adds an explicit missing-key preflight immediately after checkout and before expensive work;
- forwards that validated key through provider isolation to the runtime child only when `ELIZA_UI_SMOKE_CLOUD_LIVE=1`;
- updates the stale comment that claimed the declared real Cloud job could skip cleanly;
- adds a behavioral child-environment regression proving ambient Cloud keys remain blank by default but explicit overrides survive isolation;
- adds a deterministic workflow contract that verifies the fallback, executes the preflight with empty/whitespace/configured keys, checks its ordering and child forwarding, and preserves the keyless-safe spec contract.

## What kind of change is this?

Bug fix (non-breaking CI correctness fix).

# Documentation changes needed?

No standalone documentation change is needed. The stale inline workflow documentation is corrected with the implementation.

# Testing

## Where should a reviewer start?

Start with `.github/workflows/app-live-e2e.yml` at the `cloud-live` job, then review `packages/app-core/test/helpers/live-child-env.ts`, `packages/app-core/test/helpers/live-child-env.test.ts`, and `packages/scripts/__tests__/app-live-e2e-workflow.test.ts`.

## Detailed testing steps

- `ELIZA_SKIP_ARTIFACT_SYNC=1 bun install --frozen-lockfile` — passed.
- `node packages/scripts/run-changed-vitest-coverage.mjs packages/app-core/test/helpers/live-child-env.test.ts` — canonical changed-Vitest coverage lane passed, 1 file / 4 tests.
- `COVERAGE_GATE_ENFORCE=1 awk -v changed='packages/app-core/test/helpers/live-child-env.ts' -v threshold=50 -f scripts/security/coverage-gate.awk coverage/vitest/lcov.info` — passed at 75.76% line coverage.
- `bun test packages/scripts/__tests__/app-live-e2e-workflow.test.ts packages/scripts/__tests__/real-live-suites.test.ts` — 11 passed.
- `bun test packages/app/test/ui-smoke-coverage.test.ts` — 6 passed.
- `bunx turbo run typecheck --filter=@elizaos/app-core` — 80/80 prerequisite build and typecheck tasks passed.
- `actionlint .github/workflows/app-live-e2e.yml` — passed.
- `bun -e '<parse app-live-e2e.yml with Bun.YAML and require cloud-live>'` — passed.
- `bun x biome check packages/app-core/test/helpers/live-child-env.ts packages/app-core/test/helpers/live-child-env.test.ts packages/scripts/__tests__/app-live-e2e-workflow.test.ts` — passed.
- `git diff --check` / `git diff --cached --check` — passed.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - workflow-only CI fix; no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - workflow-only CI fix; no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - workflow-only CI fix; no user-facing flow changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - no production backend changed; deterministic shell and child-environment tests prove the CI runtime path.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain data or artifacts changed.

# Evidence Details

## Real LLM-call trajectory

N/A - this PR fixes live-test credential plumbing only. A fresh secret-backed live run remains required before #14357 can close.

## Backend + frontend logs

N/A - no production backend or frontend runtime change.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice change.

## Known gaps / failures

- A fresh secret-backed `App Live E2E` run is intentionally not claimed here. This PR prevents the known missing-key green-by-skip outcome; #14357 still requires an actual real login, provision, non-stub chat response, and reviewed artifacts before closure.
- Before the locked install and generated i18n fixture existed in this fresh worktree, exploratory direct test commands could not resolve workspace dependencies / `validation-keyword-data.ts`. After running the repository setup and generator, the canonical app-core Vitest command passed twice.
- A bare app-core typecheck without its declared Turbo prerequisite graph reported unresolved unbuilt workspace packages. The canonical `turbo run typecheck --filter=@elizaos/app-core` lane then built those prerequisites and passed all 80 tasks.
- Full repository `bun run verify` was not run locally; PR CI remains the broad repository gate.
