### PR TITLE
fix(commands,discord): declutter the native slash picker + close the auth-flag gap

### DIFF
--- a/plugins/plugin-commands/__tests__/command-actions.test.ts
+++ b/plugins/plugin-commands/__tests__/command-actions.test.ts
@@ -148,13 +148,15 @@ describe("runCommand / resolveCommand — deterministic handlers (#8790)", () =>
 	});
 
 	it("rejects invalid option values deterministically", async () => {
-		const r = await resolveCommand(runtime, msg("/think enormous"));
+		const r = await resolveCommand(runtime, msg("/think enormous"), {
+			isAuthorized: true,
+		});
 		expect(r.handled).toBe(true);
 		expect(r.reply).toContain("Invalid thinking value");
 	});
 
 	it("deterministically handles lifecycle commands (reset/new/compact)", async () => {
-		await resolveCommand(runtime, msg("/think high"));
+		await resolveCommand(runtime, msg("/think high"), { isAuthorized: true });
 		const reset = await resolveCommand(runtime, msg("/reset"), {
 			isAuthorized: true,
 		});
@@ -164,7 +166,9 @@ describe("runCommand / resolveCommand — deterministic handlers (#8790)", () =>
 		expect(await getCommandSettings(runtime, "room-1")).toEqual({});
 
 		await resolveCommand(runtime, msg("/model gpt-5"));
-		const next = await resolveCommand(runtime, msg("/new"));
+		const next = await resolveCommand(runtime, msg("/new"), {
+			isAuthorized: true,
+		});
 		expect(next.handled).toBe(true);
 		expect(next.reply).toBe(
 			"Started a new conversation context for this room.",

--- a/plugins/plugin-commands/__tests__/model-config-command.test.ts
+++ b/plugins/plugin-commands/__tests__/model-config-command.test.ts
@@ -299,7 +299,7 @@ describe("/model small|large|coding → POST /api/models/config", () => {
 		// resolveCommand defaults are fail-closed (unauthorized, unelevated).
 		const r = await resolveCommand(runtime, msg("/model large zai-glm-4.7"));
 		expect(r.handled).toBe(true);
-		expect(r.reply).toBe("This command requires elevated permissions.");
+		expect(r.reply).toMatch(/requires (authorization|elevated permissions)/);
 		expect(fetchMock).not.toHaveBeenCalled();
 
 		const authorizedOnly = await resolveCommand(
@@ -318,7 +318,7 @@ describe("/model small|large|coding → POST /api/models/config", () => {
 		vi.stubGlobal("fetch", fetchMock);
 
 		const r = await resolveCommand(runtime, msg("/model small"));
-		expect(r.reply).toBe("This command requires elevated permissions.");
+		expect(r.reply).toMatch(/requires (authorization|elevated permissions)/);
 
 		const usage = await resolveCommand(runtime, msg("/model small"), OWNER);
 		expect(usage.reply).toContain("Usage: /model small");
@@ -434,7 +434,7 @@ describe("regression — pre-existing /model behaviors are untouched", () => {
 		const fetchMock = vi.fn();
 		vi.stubGlobal("fetch", fetchMock);
 
-		const r = await resolveCommand(runtime, msg("/model claude-opus"));
+		const r = await resolveCommand(runtime, msg("/model claude-opus"), OWNER);
 		expect(r.handled).toBe(true);
 		expect(fetchMock).not.toHaveBeenCalled();
 		expect(r.reply).toMatch(/Model set to/);
@@ -444,7 +444,7 @@ describe("regression — pre-existing /model behaviors are untouched", () => {
 		const fetchMock = vi.fn();
 		vi.stubGlobal("fetch", fetchMock);
 
-		const r = await resolveCommand(runtime, msg("/model"));
+		const r = await resolveCommand(runtime, msg("/model"), OWNER);
 		expect(r.handled).toBe(true);
 		expect(fetchMock).not.toHaveBeenCalled();
 		expect(r.reply).toMatch(/Model is/);

--- a/plugins/plugin-commands/__tests__/model-switch-command.test.ts
+++ b/plugins/plugin-commands/__tests__/model-switch-command.test.ts
@@ -165,14 +165,16 @@ describe("/model local|cloud → shared runtime-switch route", () => {
 		const r = await resolveCommand(runtime, msg("/model cloud"));
 		expect(r.handled).toBe(true);
 		expect(fetchMock).not.toHaveBeenCalled();
-		expect(r.reply).toMatch(/elevated permissions/);
+		// The definition-level requiresAuth gate fires first for untrusted
+		// senders; elevated is re-checked for authorized-but-not-owner ones.
+		expect(r.reply).toMatch(/authorization|elevated permissions/);
 	});
 
 	it("does NOT hit the route for a bare /model <name> (per-room preference)", async () => {
 		const fetchMock = vi.fn();
 		vi.stubGlobal("fetch", fetchMock);
 
-		const r = await resolveCommand(runtime, msg("/model claude-opus"));
+		const r = await resolveCommand(runtime, msg("/model claude-opus"), OWNER);
 		expect(r.handled).toBe(true);
 		expect(fetchMock).not.toHaveBeenCalled();
 		expect(r.reply).toMatch(/Model set to/);

--- a/plugins/plugin-commands/src/actions/handlers.ts
+++ b/plugins/plugin-commands/src/actions/handlers.ts
@@ -369,12 +369,11 @@ export async function runCommand(
 
 		case "model": {
 			// `/model show|small|large|coding …` drives the validated global
-			// model-config route. `show` reads config so authorization suffices; the
-			// write subcommands mutate config.env for every room (and restart the
-			// agent for chat targets), so they are owner-only. Gated here per
-			// subcommand rather than via definition-level flags, which would also
-			// gate (and hide from the GUI menu) the pre-existing per-room and
-			// local/cloud behaviors below.
+			// model-config route. The definition now carries requiresAuth (the
+			// whole command is operator-facing — connector pickers gate it), and
+			// the write subcommands are additionally owner-only here because they
+			// mutate config.env for every room (and restart the agent for chat
+			// targets).
 			const configCommand = parseModelConfigArgs(parsed);
 			if (configCommand) {
 				if (configCommand.kind === "show") {

--- a/plugins/plugin-commands/src/connector-catalog.ts
+++ b/plugins/plugin-commands/src/connector-catalog.ts
@@ -53,6 +53,14 @@ export interface ConnectorCommand {
 	 * views is the active surface. Omitted = globally available.
 	 */
 	views?: string[];
+	/**
+	 * Auth flags from the definition, so connector bridges can gate the NATIVE
+	 * picker (e.g. Discord default_member_permissions) instead of showing a
+	 * command that execute-time trust will refuse anyway (#16154 deferral).
+	 * Execution is still re-checked server-side — these are presentation gates.
+	 */
+	requiresAuth: boolean;
+	requiresElevated: boolean;
 }
 
 const KNOWN_SURFACES: ReadonlySet<string> = new Set([
@@ -145,6 +153,8 @@ function toConnectorCommand(command: CommandDefinition): ConnectorCommand {
 		...(command.views && command.views.length > 0
 			? { views: command.views }
 			: {}),
+		requiresAuth: command.requiresAuth ?? false,
+		requiresElevated: command.requiresElevated ?? false,
 	};
 }
 

--- a/plugins/plugin-commands/src/registry.ts
+++ b/plugins/plugin-commands/src/registry.ts
@@ -29,6 +29,9 @@ export const DEFAULT_COMMANDS: ReadonlyArray<CommandDefinition> = [
 		scope: "both",
 		category: "status",
 		acceptsArgs: false,
+		// In-app only: on chat connectors it duplicates /help in the native
+		// picker; the text alias still resolves everywhere.
+		surfaces: ["gui"],
 	},
 	{
 		key: "status",
@@ -48,6 +51,7 @@ export const DEFAULT_COMMANDS: ReadonlyArray<CommandDefinition> = [
 		category: "status",
 		acceptsArgs: true,
 		args: [{ name: "mode", description: "Output mode (list, detail, json)" }],
+		requiresAuth: true,
 	},
 	{
 		key: "whoami",
@@ -97,6 +101,7 @@ export const DEFAULT_COMMANDS: ReadonlyArray<CommandDefinition> = [
 		scope: "both",
 		category: "session",
 		acceptsArgs: false,
+		requiresAuth: true,
 	},
 	{
 		key: "compact",
@@ -124,6 +129,7 @@ export const DEFAULT_COMMANDS: ReadonlyArray<CommandDefinition> = [
 		args: [
 			{ name: "level", description: "off, minimal, low, medium, high, xhigh" },
 		],
+		requiresAuth: true,
 	},
 	{
 		key: "verbose",
@@ -134,6 +140,7 @@ export const DEFAULT_COMMANDS: ReadonlyArray<CommandDefinition> = [
 		category: "options",
 		acceptsArgs: true,
 		args: [{ name: "level", description: "off, on, full" }],
+		requiresAuth: true,
 	},
 	{
 		key: "reasoning",
@@ -144,6 +151,7 @@ export const DEFAULT_COMMANDS: ReadonlyArray<CommandDefinition> = [
 		category: "options",
 		acceptsArgs: true,
 		args: [{ name: "level", description: "off, on, stream" }],
+		requiresAuth: true,
 	},
 	{
 		key: "elevated",
@@ -189,6 +197,7 @@ export const DEFAULT_COMMANDS: ReadonlyArray<CommandDefinition> = [
 				dynamicChoices: "models",
 			},
 		],
+		requiresAuth: true,
 	},
 	{
 		key: "models",
@@ -198,6 +207,7 @@ export const DEFAULT_COMMANDS: ReadonlyArray<CommandDefinition> = [
 		scope: "both",
 		category: "options",
 		acceptsArgs: false,
+		requiresAuth: true,
 	},
 	{
 		key: "usage",
@@ -207,6 +217,7 @@ export const DEFAULT_COMMANDS: ReadonlyArray<CommandDefinition> = [
 		scope: "both",
 		category: "options",
 		acceptsArgs: false,
+		requiresAuth: true,
 	},
 	{
 		key: "queue",
@@ -222,6 +233,7 @@ export const DEFAULT_COMMANDS: ReadonlyArray<CommandDefinition> = [
 				description: "steer, followup, collect, interrupt, or options",
 			},
 		],
+		requiresAuth: true,
 	},
 
 	// Management commands
@@ -306,6 +318,7 @@ export const DEFAULT_COMMANDS: ReadonlyArray<CommandDefinition> = [
 				description: "on, off, status, provider, limit, audio",
 			},
 		],
+		requiresAuth: true,
 	},
 	{
 		key: "transcribe",

--- a/plugins/plugin-discord/__tests__/catalog-commands.test.ts
+++ b/plugins/plugin-discord/__tests__/catalog-commands.test.ts
@@ -5,6 +5,7 @@
 import type { Content, IAgentRuntime, Memory } from "@elizaos/core";
 import { getConnectorCommands } from "@elizaos/plugin-commands";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PermissionFlagsBits } from "discord.js";
 
 // The connector bridge gates auth via the agent role model (`hasRoleAccess`).
 // Mock it so each test controls the sender's resolved trust level without
@@ -121,6 +122,8 @@ describe("catalog → DiscordSlashCommand mapping", () => {
 					choices: Array.from({ length: 30 }, (_, i) => `token-${i}`),
 				},
 			],
+			requiresAuth: false,
+			requiresElevated: false,
 		});
 		const section = mapped.options?.find((o) => o.name === "section");
 		expect(section).toBeDefined();
@@ -136,6 +139,40 @@ describe("catalog → DiscordSlashCommand mapping", () => {
 	it("omits options for argless commands", () => {
 		const whoami = findCatalog("whoami");
 		expect(whoami.options).toBeUndefined();
+	});
+
+	it("gates the native picker on catalog auth flags", () => {
+		// elevated -> Administrator, auth -> ManageGuild, open -> ungated. Discord
+		// still hides these in the guild picker; server-side trust re-checks.
+		const elevated = mapCatalogCommand({
+			name: "op",
+			description: "op",
+			target: { kind: "agent" },
+			options: [],
+			requiresAuth: true,
+			requiresElevated: true,
+		});
+		expect(elevated.requiredPermissions).toBe(
+			PermissionFlagsBits.Administrator,
+		);
+		const authed = mapCatalogCommand({
+			name: "auth",
+			description: "auth",
+			target: { kind: "agent" },
+			options: [],
+			requiresAuth: true,
+			requiresElevated: false,
+		});
+		expect(authed.requiredPermissions).toBe(PermissionFlagsBits.ManageGuild);
+		const open = mapCatalogCommand({
+			name: "open",
+			description: "open",
+			target: { kind: "agent" },
+			options: [],
+			requiresAuth: false,
+			requiresElevated: false,
+		});
+		expect(open.requiredPermissions).toBeUndefined();
 	});
 });
 

--- a/plugins/plugin-discord/__tests__/slash-commands.test.ts
+++ b/plugins/plugin-discord/__tests__/slash-commands.test.ts
@@ -257,7 +257,10 @@ describe("builtin command surface (privileged plumbing hidden from pickers)", ()
 				`${name} must carry requiredPermissions`,
 			).toBeTruthy();
 		}
-		for (const name of ["help", "status", "search", "clear"]) {
+		// /clear was removed: it only explained that clearing isn't wired up,
+		// which /help already covers — placebo commands don't earn picker space.
+		expect(commands.get("clear")).toBeUndefined();
+		for (const name of ["help", "status", "search"]) {
 			expect(
 				commands.get(name)?.requiredPermissions,
 				`${name} must stay visible to everyone`,

--- a/plugins/plugin-discord/catalog-commands.ts
+++ b/plugins/plugin-discord/catalog-commands.ts
@@ -55,6 +55,7 @@ import {
 	resolveSettingsSection,
 } from "@elizaos/plugin-commands";
 import type { ChatInputCommandInteraction } from "discord.js";
+import { PermissionFlagsBits } from "discord.js";
 import { safeInteractionCall } from "./native-commands";
 import {
 	addCommand,
@@ -420,10 +421,21 @@ function mapOption(
 /** Map one catalog command onto an in-process `SlashCommand`. */
 export function mapCatalogCommand(command: ConnectorCommand): SlashCommand {
 	const options = command.options.map(mapOption);
+	// Gate the NATIVE picker on the catalog's auth flags (the #16154 deferral):
+	// elevated commands register admin-only, auth-required ones ManageGuild.
+	// Discord's default_member_permissions only hides them in guild pickers —
+	// server-side trust still re-checks on every execution (runCommand), and
+	// paired DM users are unaffected (member permissions are guild-scoped).
+	const requiredPermissions = command.requiresElevated
+		? PermissionFlagsBits.Administrator
+		: command.requiresAuth
+			? PermissionFlagsBits.ManageGuild
+			: undefined;
 	return {
 		name: command.name,
 		description: command.description,
 		...(options.length > 0 ? { options } : {}),
+		...(requiredPermissions !== undefined ? { requiredPermissions } : {}),
 		execute: buildExecute(command),
 	};
 }

--- a/plugins/plugin-discord/slash-commands.ts
+++ b/plugins/plugin-discord/slash-commands.ts
@@ -202,20 +202,6 @@ const searchCommand: SlashCommand = {
 	},
 };
 
-const clearCommand: SlashCommand = {
-	name: "clear",
-	description: "Explain how context clearing works in this channel",
-	ephemeral: true,
-	requiredRole: "USER",
-	async execute(interaction) {
-		await interaction.reply({
-			content:
-				"Context clearing is not wired up for Discord yet. I can search recent messages with `/search`, but I won't pretend existing memory was deleted.",
-			ephemeral: true,
-		});
-	},
-};
-
 const settingsCommand: SlashCommand = {
 	name: "settings",
 	description: "View the current Discord bot settings",
@@ -721,7 +707,6 @@ function registerBuiltins(): void {
 		helpCommand,
 		statusCommand,
 		searchCommand,
-		clearCommand,
 		settingsCommand,
 		setupCommand,
 		appCommand,


### PR DESCRIPTION
The Discord slash picker showed 30 commands with only 4 gated — including operator-only tools (model config, queue mode, session reset) any server member could see and fire. Cleanup:

- **Removed `/clear`** — its whole handler just replied "context clearing isn't wired up on Discord", which `/help` already covers. Placebo commands don't earn picker space.
- **`/commands` is now in-app-only** — on a chat connector it's a strict duplicate of `/help` in the native list. Text alias still resolves everywhere.
- **Closed the #16154 deferral**: `ConnectorCommand` now carries `requiresAuth`/`requiresElevated`, so connector bridges gate the **native picker** (Discord: `requiresElevated → Administrator`, `requiresAuth → ManageGuild`). Execution is still re-checked server-side, and DM/paired users are unaffected (member permissions are guild-scoped).
- **Flagged the operator-facing agent commands** `requiresAuth` (context/new/compact/think/verbose/reasoning/queue/tts/model/models/usage) so they stop showing to normal members and refuse at execute time. `/model` keeps its per-subcommand owner gate on writes.

Telegram already gates these at execute time via `gateConnectorCommandByName` (no BotFather permission model), so no picker change there.

**Live-verified** (registered set read back from Discord's API after restart):
```
before: 30 commands, 4 gated
after:  28 commands, /clear + /commands gone, 21 operator commands admin/ManageGuild-gated
open to everyone: /ask /help /status /whoami /stop /search /eliza-pair
```

Tests: plugin-commands 108✓ (auth-gate assertions updated for the new definition-level gating), plugin-discord 391✓ (+ new picker-gating mapping test, /clear-removed assertion), both typecheck ✓, biome clean.

Screenshots/video: N/A — connector command registration; the before/after registered-set dump is the domain artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)