### PR TITLE
fix(discord,commands): clamp slash descriptions so one long one can't drop all commands

### DIFF
--- a/plugins/plugin-commands/src/registry.ts
+++ b/plugins/plugin-commands/src/registry.ts
@@ -315,7 +315,7 @@ export const DEFAULT_COMMANDS: ReadonlyArray<CommandDefinition> = [
 			{
 				name: "value",
 				description:
-					"account (id, id prefix, label, or email) — for strategy: priority, round-robin, least-used, quota-aware",
+					"account by id, label, or email — or the strategy name for `strategy`",
 			},
 		],
 		// requiresAuth only, matching /model: reads are authorized-only, and the

--- a/plugins/plugin-discord/__tests__/slash-commands.test.ts
+++ b/plugins/plugin-discord/__tests__/slash-commands.test.ts
@@ -287,4 +287,24 @@ describe("builtin command surface (privileged plumbing hidden from pickers)", ()
 		expect(wireSetup.default_member_permissions).toBe("8");
 		expect(wireHelp.default_member_permissions).toBeUndefined();
 	});
+
+	it("clamps over-long command + option descriptions to Discord's 100-char limit", async () => {
+		// commands.set() is atomic — one over-limit description fails the WHOLE
+		// registration, dropping every command. The transform must clamp so a
+		// long catalog description can never strand the rest.
+		const { transformCommandToDiscordApi } = await import(
+			"../discord-commands"
+		);
+		const long = "x".repeat(140);
+		const wire = transformCommandToDiscordApi({
+			name: "probe",
+			description: long,
+			options: [{ name: "arg", type: 3, description: long }],
+		} as never) as unknown as {
+			description: string;
+			options?: Array<{ description: string }>;
+		};
+		expect(wire.description.length).toBeLessThanOrEqual(100);
+		expect(wire.options?.[0]?.description.length).toBeLessThanOrEqual(100);
+	});
 });

--- a/plugins/plugin-discord/discord-commands.ts
+++ b/plugins/plugin-discord/discord-commands.ts
@@ -42,6 +42,22 @@ const INTEGRATION_USER_INSTALL = 1;
  * OFF by default (`DISCORD_USER_INSTALL`), because registering user-install
  * commands against a guild-install-only app is rejected by the API.
  */
+/**
+ * Discord's hard limit on command and option description length. Exceeding it
+ * fails the WHOLE `commands.set()` call (it is atomic), so a single over-long
+ * description from the shared command catalog would silently drop EVERY command
+ * from the guild — the failure mode that stranded /accounts + /backend. Clamp
+ * defensively here, the single choke point before registration, so one bad
+ * description can never nuke the rest.
+ */
+const DISCORD_DESCRIPTION_MAX = 100;
+
+function clampDescription(description: string): string {
+	return description.length > DISCORD_DESCRIPTION_MAX
+		? `${description.slice(0, DISCORD_DESCRIPTION_MAX - 1)}…`
+		: description;
+}
+
 export function transformCommandToDiscordApi(
 	cmd: DiscordSlashCommand,
 	opts?: { userInstall?: boolean; guildScoped?: boolean },
@@ -52,8 +68,11 @@ export function transformCommandToDiscordApi(
 		default_member_permissions?: string;
 	} = {
 		name: cmd.name,
-		description: cmd.description,
-		options: cmd.options,
+		description: clampDescription(cmd.description),
+		options: cmd.options?.map((option) => ({
+			...option,
+			description: clampDescription(option.description),
+		})),
 	};
 
 	if (opts?.guildScoped) {


### PR DESCRIPTION
`/accounts` and `/backend` (#16198) registered in-process but never appeared on Discord. Root cause: the `/accounts` `value`-option description was **103 chars** and Discord's limit is **100** — and `commands.set()` is **atomic**, so one over-limit description fails the *entire* registration, leaving every command at the previous set (this is the same "one bad command strands all" fragility as the sync deadlock).

Two fixes:
- shorten the `/accounts` value-option description to under 100 chars
- **clamp** command + option descriptions to 100 in `transformCommandToDiscordApi` — the single choke point before `commands.set()` — so an over-long catalog description can never again drop the whole command set (a catalog author on any package shouldn't be able to nuke Discord registration with a long string)

Live-verified after the fix (registered set read back from Discord's API):
```
before: 30-command push kept failing → stuck at 28, no /accounts /backend
        error: 27.options[2].description[BASE_TYPE_BAD_LENGTH]: Must be between 1 and 100
after:  30 commands registered, /accounts + /backend present and admin-gated
```

Tests: plugin-discord 393✓ (+ clamp regression: 140-char command + option descriptions clamp to ≤100), typecheck both packages ✓, biome clean.

Screenshots/video: N/A — connector registration; the before/after registered-set dump is the domain artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)