### PR TITLE
fix(local-inference): recover complete staged downloads

### DIFF
--- a/plugins/plugin-local-inference/src/services/downloader.test.ts
+++ b/plugins/plugin-local-inference/src/services/downloader.test.ts
@@ -1,6 +1,7 @@
-/** Exercises the curated Eliza-1 `Downloader`: disk preflight, gated-repo handling, and registry writes on completion, against a real temp state dir with a fake HardwareProbe. No network. */
+/** Exercises the curated Eliza-1 `Downloader` against real temp state, including a local HTTP range server for restart recovery; other network and hardware boundaries stay controlled. */
 import { createHash } from "node:crypto";
 import fs from "node:fs";
+import { createServer } from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -246,6 +247,12 @@ function installRangeAwareFetchFixture(files: Map<string, string>): {
 				const match = /^bytes=(\d+)-$/.exec(range);
 				const start = match?.[1] ? Number.parseInt(match[1], 10) : 0;
 				const buf = Buffer.from(body);
+				if (start >= buf.length) {
+					return new Response("range not satisfiable", {
+						status: 416,
+						headers: { "content-range": `bytes */${buf.length}` },
+					});
+				}
 				const tail = buf.subarray(start);
 				return new Response(tail, {
 					status: 206,
@@ -262,6 +269,63 @@ function installRangeAwareFetchFixture(files: Map<string, string>): {
 		},
 	) as unknown as typeof fetch;
 	return { rangeRequests };
+}
+
+async function startRangeServer(files: Map<string, string>): Promise<{
+	baseUrl: string;
+	requests: Map<string, string[]>;
+	close: () => Promise<void>;
+}> {
+	const requests = new Map<string, string[]>();
+	const server = createServer((request, response) => {
+		const remotePath = remotePathOf(
+			new URL(request.url ?? "/", "http://127.0.0.1"),
+		);
+		const body = files.get(remotePath);
+		if (body === undefined) {
+			response.writeHead(404).end(`missing ${remotePath}`);
+			return;
+		}
+		const range = request.headers.range;
+		const seen = requests.get(remotePath) ?? [];
+		seen.push(range ?? "full");
+		requests.set(remotePath, seen);
+		const bytes = Buffer.from(body);
+		const match = range ? /^bytes=(\d+)-$/.exec(range) : null;
+		const start = match?.[1] ? Number.parseInt(match[1], 10) : 0;
+		if (range && start >= bytes.length) {
+			response
+				.writeHead(416, { "content-range": `bytes */${bytes.length}` })
+				.end("range not satisfiable");
+			return;
+		}
+		const payload = range ? bytes.subarray(start) : bytes;
+		response.writeHead(range ? 206 : 200, {
+			"content-length": payload.length,
+			...(range
+				? {
+						"content-range": `bytes ${start}-${bytes.length - 1}/${bytes.length}`,
+					}
+				: {}),
+		});
+		response.end(payload);
+	});
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", resolve);
+	});
+	const address = server.address();
+	if (!address || typeof address === "string") {
+		throw new Error("range server did not bind a TCP port");
+	}
+	return {
+		baseUrl: `http://127.0.0.1:${address.port}`,
+		requests,
+		close: () =>
+			new Promise<void>((resolve, reject) => {
+				server.close((error) => (error ? reject(error) : resolve()));
+			}),
+	};
 }
 
 /** Standard 2b bundle content set for stale-content robustness tests. */
@@ -1380,6 +1444,46 @@ describe("local inference downloader stale-content robustness", () => {
 		).toBe(freshBundleBytes.text);
 		const main = readOwnedRegistryModels().find((m) => m.id === model.id);
 		expect(main?.sha256).toBe(sha256(freshBundleBytes.text));
+	});
+
+	it("commits a complete .part after restart without requesting a range past EOF", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-download-test-"));
+		process.env.ELIZA_STATE_DIR = root;
+		const model = findCatalogModel("eliza-1-2b");
+		if (!model) throw new Error("missing test catalog model");
+		const server = await startRangeServer(freshBundleFixtureFiles());
+		process.env.ELIZA_HF_BASE_URL = server.baseUrl;
+
+		const textPart = eliza1StagingPartPath(root, "text/eliza-1-2b-128k.gguf");
+		fs.mkdirSync(path.dirname(textPart), { recursive: true });
+		fs.writeFileSync(textPart, freshBundleBytes.text);
+		fs.writeFileSync(`${textPart}.expected`, sha256(freshBundleBytes.text));
+
+		try {
+			const downloader = new Downloader({
+				probeDeviceCaps: async () => cpuOnlyCaps,
+			});
+			const completed = waitForTerminal(downloader, model.id);
+			await downloader.start(model.id);
+			const job = await completed;
+
+			expect(job.state).toBe("completed");
+			expect(
+				server.requests.get(
+					eliza1BundleRemotePath("text/eliza-1-2b-128k.gguf"),
+				),
+			).toBeUndefined();
+			expect(
+				fs.readFileSync(
+					eliza1BundleFinalPath(root, "text/eliza-1-2b-128k.gguf"),
+					"utf8",
+				),
+			).toBe(freshBundleBytes.text);
+			expect(fs.existsSync(textPart)).toBe(false);
+			expect(fs.existsSync(`${textPart}.expected`)).toBe(false);
+		} finally {
+			await server.close();
+		}
 	});
 
 	it("re-fetches from scratch when a completed transfer fails the sha gate (stale edge)", async () => {

--- a/plugins/plugin-local-inference/src/services/downloader.ts
+++ b/plugins/plugin-local-inference/src/services/downloader.ts
@@ -535,6 +535,23 @@ async function resumableStartByte(
 	return 0;
 }
 
+async function promoteCompletePartial(
+	stagingPath: string,
+	finalPath: string,
+	expectedSha256: string,
+	sizeBytes: number,
+): Promise<DownloadedFile | null> {
+	const sha256 = await hashFile(stagingPath);
+	if (sha256 !== expectedSha256) return null;
+	await fsp.rename(stagingPath, finalPath);
+	await fsp
+		// error-policy:J6 best-effort removal after the verified artifact is committed;
+		// a stale sidecar cannot invalidate or replace the final sha-pinned file.
+		.rm(stagingMetaPath(stagingPath), { force: true })
+		.catch(() => undefined);
+	return { path: finalPath, sizeBytes, sha256 };
+}
+
 export class Downloader {
 	private readonly active = new Map<string, ActiveJob>();
 	private readonly terminal = new Map<string, DownloadJob>();
@@ -1530,6 +1547,18 @@ export class Downloader {
 				let startByte = 0;
 				if (expectedSha256) {
 					startByte = await resumableStartByte(stagingPath, expectedSha256);
+					if (startByte > 0) {
+						const completed = await promoteCompletePartial(
+							stagingPath,
+							finalPath,
+							expectedSha256,
+							startByte,
+						);
+						if (completed) {
+							record.job.received = baseBytes + completed.sizeBytes;
+							return completed;
+						}
+					}
 					// Stamp the partial with the content hash it is being fetched
 					// against so a later resume can tell whether the .part still
 					// belongs to THIS content version.


### PR DESCRIPTION
# Relates to

Closes #16201.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync.

# Risks

Low. On restart, resumable SHA-pinned downloads now hash an existing `.part` once before making a network request. Incomplete or mismatched partials continue through the existing Range-resume path unchanged. The tradeoff is one local read of an existing partial after restart.

# Background

## What does this PR do?

If the process stopped after writing the final byte but before renaming the staged file, the next run sent `Range: bytes=<file-size>-`. A conforming server answered `416 Range Not Satisfiable`, so a fully downloaded multi-GB model remained stuck in `.part` forever.

This change verifies a resumed `.part` against the manifest SHA-256 before opening the network request. When it already matches, the downloader atomically promotes it to the final path and removes the stale `.expected` sidecar. Non-matching partials retain the existing resume behavior.

The regression test uses a real local TCP HTTP server with `206`/`416` range semantics and proves that a complete staged text artifact is committed without any request for that artifact.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

My changes do not require project documentation changes. This restores the documented resumable-download behavior without changing setup, public APIs, or operator workflows.

# Testing

## Where should a reviewer start?

`plugins/plugin-local-inference/src/services/downloader.test.ts`, test: `commits a complete .part after restart without requesting a range past EOF`.

## Detailed testing steps

1. Seed a complete `.part` and matching `.expected` SHA sidecar in a temporary Eliza state directory.
2. Start the downloader against the test's real local range-aware HTTP server.
3. Verify the job completes, the final file is byte-identical, `.part` and `.expected` are removed, and the server saw no request for the already-complete artifact.

Validation run:

```text
RED (before implementation)
Error: HTTP 416 from model hub for elizaos/eliza-1/text/eliza-1-2b-128k.gguf

GREEN
downloader.test.ts: 27 passed
plugin-local-inference suite: 253 files passed; 2577 tests passed; 20 skipped
changed-source coverage: downloader.ts 83.85% (required: 50%)
bun run verify: 573 successful, 573 total
error-policy-ratchet: no new fallback-slop in touched files
```

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - headless downloader persistence path; no rendered UI change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - headless downloader persistence path; no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no frontend user flow changed.
<!-- evidence-row:backend-logs -->
- [x] Real loopback TCP range-server proof: https://github.com/elizaOS/eliza/releases/download/pr-evidence/16202-downloader-restart-proof.json
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, state, or rendering changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt, inference, provider, or model-output behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Real temporary-filesystem promotion proof (final bytes verified; `.part` and sidecar removed): https://github.com/elizaOS/eliza/releases/download/pr-evidence/16202-downloader-restart-proof.json
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual change.

# Evidence Details

The focused suite passed 28 tests after rebasing onto current `develop`; package typecheck, Biome, and the error-policy ratchet also passed. The regression drives a real loopback TCP server with conforming 206/416 range behavior and a real temporary state directory. I manually reviewed the transcript and filesystem assertions: the complete SHA-pinned staged artifact was promoted without any HTTP request for that file, and both staging files were removed.

A live multi-gigabyte model download is N/A because the defect is entirely at the HTTP range/filesystem commit boundary exercised here; no model is loaded or invoked.