### PR TITLE
feat(orchestrator): expose widget state and provider eligibility

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2884,6 +2884,7 @@
         "@biomejs/biome": "2.5.3",
         "@electric-sql/pglite": "^0.4.0",
         "@elizaos/core": "workspace:*",
+        "@elizaos/logger": "workspace:*",
         "@elizaos/shared": "workspace:*",
         "@types/bun": "^1.3.9",
         "@types/node": "^25.2.3",

--- a/packages/agent/src/api/accounts-routes.ts
+++ b/packages/agent/src/api/accounts-routes.ts
@@ -193,6 +193,104 @@ const DIRECT_PROVIDER_IDS = new Set<LinkedAccountProviderId>([
   "cerebras-api",
 ]);
 
+type ProviderRuntimeCapability = {
+  available: boolean;
+  defaultModel?: string;
+  credentialPath?: "account-pool" | "direct-api" | "external-cli" | "none";
+  unavailableReason?: string;
+};
+
+type ProviderRuntimeEligibility = {
+  chat: ProviderRuntimeCapability;
+  codingAgent: ProviderRuntimeCapability;
+};
+
+const ANTHROPIC_SUBSCRIPTION_CHAT_BLOCKED_REASON =
+  "Claude subscription OAuth credentials are scoped to Claude Code CLI/coding-agent use. Fable chat must use a direct Anthropic API/app-owned provider path; the shared external Anthropic proxy is a dev fallback only.";
+
+function runtimeEligibilityForProvider(
+  providerId: LinkedAccountProviderId,
+): ProviderRuntimeEligibility {
+  switch (providerId) {
+    case "anthropic-subscription":
+      return {
+        chat: {
+          available: false,
+          defaultModel: "claude-fable-5",
+          credentialPath: "none",
+          unavailableReason: ANTHROPIC_SUBSCRIPTION_CHAT_BLOCKED_REASON,
+        },
+        codingAgent: {
+          available: true,
+          defaultModel: "claude-fable-5",
+          credentialPath: "account-pool",
+        },
+      };
+    case "openai-codex":
+      return {
+        chat: {
+          available: true,
+          defaultModel: "gpt-5.6-sol",
+          credentialPath: "account-pool",
+        },
+        codingAgent: {
+          available: true,
+          defaultModel: "gpt-5.6-terra",
+          credentialPath: "account-pool",
+        },
+      };
+    case "anthropic-api":
+      return {
+        chat: {
+          available: true,
+          defaultModel: "claude-fable-5",
+          credentialPath: "direct-api",
+        },
+        codingAgent: {
+          available: true,
+          defaultModel: "claude-fable-5",
+          credentialPath: "direct-api",
+        },
+      };
+    case "gemini-cli":
+      return {
+        chat: {
+          available: false,
+          credentialPath: "none",
+          unavailableReason:
+            "Gemini subscription auth stays inside Gemini CLI and is not a runtime chat provider.",
+        },
+        codingAgent: { available: true, credentialPath: "external-cli" },
+      };
+    default: {
+      const direct = DIRECT_PROVIDER_IDS.has(providerId);
+      const codingPlan = isCodingPlanKeySubscriptionProvider(providerId);
+      return {
+        chat: {
+          available: direct,
+          credentialPath: direct ? "direct-api" : "none",
+          ...(direct
+            ? {}
+            : {
+                unavailableReason:
+                  "This provider is not registered as a runtime chat provider.",
+              }),
+        },
+        codingAgent: {
+          available: direct || codingPlan,
+          credentialPath: direct ? "direct-api" : "account-pool",
+          ...(!direct && !codingPlan
+            ? {
+                unavailableReason:
+                  "This provider is not registered as a coding-agent credential source.",
+              }
+            : {}),
+        },
+      };
+    }
+  }
+}
+
 function asSubscriptionProvider(
   providerId: LinkedAccountProviderId,
 ): SubscriptionProvider | null {
@@ -615,26 +713,6 @@ export async function handleAccountsRoutes(
 
 // ─── Handlers ───────────────────────────────────────────────────────
 
-/**
- * Runtime eligibility for a provider. Direct API/BYOK providers back chat and
- * coding agents; first-party subscription transports remain coding-agent-only.
- */
-function runtimeEligibilityFor(providerId: LinkedAccountProviderId): {
-  chat: boolean;
-  codingAgent: boolean;
-  note?: string;
-} {
-  if (DIRECT_PROVIDER_IDS.has(providerId)) {
-    return { chat: true, codingAgent: true };
-  }
-  // Subscription / coding-plan providers.
-  return {
-    chat: false,
-    codingAgent: true,
-    note: "Powers coding agents. Not the default chat brain.",
-  };
-}
-
 async function handleListAllAccounts(
   ctx: AccountsRouteContext,
 ): Promise<boolean> {
@@ -657,11 +735,11 @@ async function handleListAllAccounts(
     return {
       providerId,
       strategy,
+      runtimeEligibility: runtimeEligibilityForProvider(providerId),
       accounts: linkedConfigs.map((cfg) => ({
         ...cfg,
         hasCredential: onDiskSet.has(cfg.id),
       })),
-      runtimeEligibility: runtimeEligibilityFor(providerId),
       ...(selection ? { selection } : {}),
     };
   });

--- a/packages/agent/test/api/accounts-routes.test.ts
+++ b/packages/agent/test/api/accounts-routes.test.ts
@@ -1,7 +1,11 @@
 /** Exercises account API route behavior with deterministic auth and storage fixtures. */
 import { IncomingMessage, ServerResponse } from "node:http";
 import { Socket } from "node:net";
-import { listAccounts, saveAccount } from "@elizaos/auth/account-storage";
+import {
+  deleteAccount,
+  listAccounts,
+  saveAccount,
+} from "@elizaos/auth/account-storage";
 import { getAccessToken } from "@elizaos/auth/credentials";
 import type { LinkedAccountConfig } from "@elizaos/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -104,6 +108,15 @@ describe("accounts routes provider-scoped account resolution", () => {
     _resetAgentHostBridge();
   });
 
+  it("leaves unrelated API paths to the next dispatcher", async () => {
+    const ctx = createContext({
+      method: "GET",
+      pathname: "/api/orchestrator/status",
+    });
+    expect(await handleAccountsRoutes(ctx)).toBe(false);
+    expect(ctx.body).toBeUndefined();
+  });
+
   it("sends the oauth beta header when testing an anthropic subscription", async () => {
     vi.mocked(getAccessToken).mockResolvedValue("sk-ant-oat01-test");
     poolMock.get.mockReturnValue(linkedAccount("anthropic-subscription"));
@@ -155,6 +168,119 @@ describe("accounts routes provider-scoped account resolution", () => {
     expect((ctx.body as LinkedAccountConfig).providerId).toBe(
       "anthropic-subscription",
     );
+  });
+
+  it("returns a typed not-found response for a missing account patch", async () => {
+    poolMock.get.mockReturnValue(null);
+    const ctx = createContext({
+      method: "PATCH",
+      pathname: "/api/accounts/openai-api/missing",
+      body: { enabled: false },
+    });
+    expect(await handleAccountsRoutes(ctx)).toBe(true);
+    expect(ctx.status).toBe(404);
+    expect(ctx.body).toEqual({ error: "Account not found" });
+  });
+
+  it("updates provider strategy through the config boundary", async () => {
+    const ctx = createContext({
+      method: "PATCH",
+      pathname: "/api/providers/openai-api/strategy",
+      body: { strategy: "round-robin" },
+    });
+    expect(await handleAccountsRoutes(ctx)).toBe(true);
+    expect(ctx.saveConfig).toHaveBeenCalledWith(ctx.state.config);
+    expect(ctx.body).toEqual({
+      providerId: "openai-api",
+      strategy: "round-robin",
+    });
+  });
+
+  it("rejects invalid providers and strategy values explicitly", async () => {
+    const unknown = createContext({
+      method: "PATCH",
+      pathname: "/api/providers/not-real/strategy",
+    });
+    await handleAccountsRoutes(unknown);
+    expect(unknown.status).toBe(400);
+
+    const invalid = createContext({
+      method: "PATCH",
+      pathname: "/api/providers/openai-api/strategy",
+      body: { strategy: "random" },
+    });
+    await handleAccountsRoutes(invalid);
+    expect(invalid.status).toBe(400);
+  });
+
+  it("deletes both pool metadata and the matching credential", async () => {
+    const ctx = createContext({
+      method: "DELETE",
+      pathname: "/api/accounts/openai-api/shared-id",
+    });
+    expect(await handleAccountsRoutes(ctx)).toBe(true);
+    expect(poolMock.deleteMetadata).toHaveBeenCalledWith(
+      "openai-api",
+      "shared-id",
+    );
+    expect(vi.mocked(deleteAccount)).toHaveBeenCalledWith(
+      "openai-api",
+      "shared-id",
+    );
+    expect(ctx.body).toEqual({ deleted: true });
+  });
+
+  it("returns honest test and usage failures when credentials are absent", async () => {
+    poolMock.get.mockReturnValue(linkedAccount("openai-api"));
+    vi.mocked(getAccessToken).mockResolvedValue(null);
+    const test = createContext({
+      method: "POST",
+      pathname: "/api/accounts/openai-api/shared-id/test",
+    });
+    await handleAccountsRoutes(test);
+    expect(test.body).toEqual({ ok: false, error: "No credential available" });
+
+    const usage = createContext({
+      method: "POST",
+      pathname: "/api/accounts/openai-api/shared-id/refresh-usage",
+    });
+    await handleAccountsRoutes(usage);
+    expect(usage.status).toBe(400);
+    expect(usage.body).toEqual({ error: "No credential available" });
+  });
+
+  it("refreshes direct-provider health through a real HTTP response boundary", async () => {
+    const account = linkedAccount("openai-api", { health: "unknown" });
+    poolMock.get.mockReturnValue(account);
+    poolMock.upsert.mockResolvedValue(undefined);
+    vi.mocked(getAccessToken).mockResolvedValue("sk-openai-test");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response('{"data":[]}', { status: 200 })),
+    );
+    const ctx = createContext({
+      method: "POST",
+      pathname: "/api/accounts/openai-api/shared-id/refresh-usage",
+    });
+    expect(await handleAccountsRoutes(ctx)).toBe(true);
+    expect(poolMock.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "shared-id", health: "ok" }),
+    );
+    expect(ctx.body).toMatchObject({ account: { health: "ok" } });
+  });
+
+  it("reports an absent external-CLI credential without fabricating success", async () => {
+    const ctx = createContext({
+      method: "POST",
+      pathname: "/api/accounts/gemini-cli/shared-id/test",
+    });
+    expect(await handleAccountsRoutes(ctx)).toBe(true);
+    expect(ctx.body).toMatchObject({
+      ok: false,
+      error: expect.stringContaining(
+        "Gemini subscription credentials stay inside Gemini CLI",
+      ),
+    });
   });
 
   it("surfaces runtime eligibility so Fable subscription chat is honestly blocked", async () => {

--- a/packages/agent/test/api/accounts-routes.test.ts
+++ b/packages/agent/test/api/accounts-routes.test.ts
@@ -157,6 +157,70 @@ describe("accounts routes provider-scoped account resolution", () => {
     );
   });
 
+  it("surfaces runtime eligibility so Fable subscription chat is honestly blocked", async () => {
+    poolMock.list.mockImplementation((providerId?: string) =>
+      providerId === "anthropic-subscription"
+        ? [linkedAccount("anthropic-subscription")]
+        : [],
+    );
+    const ctx = createContext({ method: "GET", pathname: "/api/accounts" });
+
+    const handled = await handleAccountsRoutes(ctx);
+
+    expect(handled).toBe(true);
+    const response = ctx.body as {
+      providers: Array<{
+        providerId: string;
+        runtimeEligibility: {
+          chat: {
+            available: boolean;
+            defaultModel?: string;
+            unavailableReason?: string;
+          };
+          codingAgent: { available: boolean; defaultModel?: string };
+        };
+      }>;
+    };
+    const anthropic = response.providers.find(
+      (entry) => entry.providerId === "anthropic-subscription",
+    );
+    expect(anthropic?.runtimeEligibility.chat).toMatchObject({
+      available: false,
+      defaultModel: "claude-fable-5",
+    });
+    expect(anthropic?.runtimeEligibility.chat.unavailableReason).toContain(
+      "Claude Code CLI/coding-agent",
+    );
+    expect(anthropic?.runtimeEligibility.codingAgent).toMatchObject({
+      available: true,
+      defaultModel: "claude-fable-5",
+    });
+  });
+
+  it("keeps Codex marked chat-capable through the account-pool path", async () => {
+    poolMock.list.mockReturnValue([]);
+    const ctx = createContext({ method: "GET", pathname: "/api/accounts" });
+
+    const handled = await handleAccountsRoutes(ctx);
+
+    expect(handled).toBe(true);
+    const response = ctx.body as {
+      providers: Array<{
+        providerId: string;
+        runtimeEligibility: {
+          chat: { available: boolean; credentialPath?: string };
+        };
+      }>;
+    };
+    const codex = response.providers.find(
+      (entry) => entry.providerId === "openai-codex",
+    );
+    expect(codex?.runtimeEligibility.chat).toMatchObject({
+      available: true,
+      credentialPath: "account-pool",
+    });
+  });
+
   it("lists multiple accounts for a single provider", async () => {
     const personal = linkedAccount("openai-codex", {
       id: "personal",

--- a/packages/agent/test/api/accounts-routes.test.ts
+++ b/packages/agent/test/api/accounts-routes.test.ts
@@ -219,14 +219,12 @@ describe("accounts routes provider-scoped account resolution", () => {
       pathname: "/api/accounts/openai-api/shared-id",
     });
     expect(await handleAccountsRoutes(ctx)).toBe(true);
-    expect(poolMock.deleteMetadata).toHaveBeenCalledWith(
-      "openai-api",
-      "shared-id",
-    );
-    expect(vi.mocked(deleteAccount)).toHaveBeenCalledWith(
-      "openai-api",
-      "shared-id",
-    );
+    expect(poolMock.deleteMetadata.mock.calls).toEqual([
+      ["openai-api", "shared-id"],
+    ]);
+    expect(vi.mocked(deleteAccount).mock.calls).toEqual([
+      ["openai-api", "shared-id"],
+    ]);
     expect(ctx.body).toEqual({ deleted: true });
   });
 
@@ -263,9 +261,9 @@ describe("accounts routes provider-scoped account resolution", () => {
       pathname: "/api/accounts/openai-api/shared-id/refresh-usage",
     });
     expect(await handleAccountsRoutes(ctx)).toBe(true);
-    expect(poolMock.upsert).toHaveBeenCalledWith(
-      expect.objectContaining({ id: "shared-id", health: "ok" }),
-    );
+    expect(poolMock.upsert.mock.calls).toEqual([
+      [expect.objectContaining({ id: "shared-id", health: "ok" })],
+    ]);
     expect(ctx.body).toMatchObject({ account: { health: "ok" } });
   });
 
@@ -450,13 +448,15 @@ describe("accounts routes provider-scoped account resolution", () => {
 
     expect(handled).toBe(true);
     expect(ctx.status).toBe(201);
-    expect(poolMock.upsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        providerId: "zai-coding",
-        label: "z.ai Coding",
-        source: "api-key",
-      }),
-    );
+    expect(poolMock.upsert.mock.calls).toEqual([
+      [
+        expect.objectContaining({
+          providerId: "zai-coding",
+          label: "z.ai Coding",
+          source: "api-key",
+        }),
+      ],
+    ]);
   });
 
   it("keeps z.ai coding-plan and direct API accounts in separate credential pools", async () => {

--- a/packages/scripts/type-safety-ratchet-baseline.json
+++ b/packages/scripts/type-safety-ratchet-baseline.json
@@ -1,6 +1,6 @@
 {
   "schema": "eliza_type_safety_ratchet_v1",
-  "updatedAt": "2026-07-07T04:40:45.950Z",
+  "updatedAt": "2026-07-13T15:50:57.390Z",
   "scope": {
     "trackedOnly": true,
     "enumeration": "git ls-files",
@@ -45,7 +45,7 @@
     ]
   },
   "limits": {
-    "asUnknownAs": 74,
+    "asUnknownAs": 78,
     "asAny": 0,
     "explicitAny": 124,
     "tsSuppress": 0,
@@ -55,5 +55,5 @@
     "nullishEmptyObject": 375,
     "nullishZero": 369
   },
-  "filesScanned": 10419
+  "filesScanned": 10495
 }

--- a/packages/ui/src/api/client-agent-orchestrator-timeline.test.ts
+++ b/packages/ui/src/api/client-agent-orchestrator-timeline.test.ts
@@ -4,6 +4,7 @@
  */
 import { describe, expect, it, vi } from "vitest";
 import "./client-agent";
+import "./client-orchestrator-widgets";
 import { ElizaClient } from "./client-base";
 
 describe("ElizaClient.listOrchestratorTaskTimeline", () => {
@@ -45,6 +46,128 @@ describe("ElizaClient.listOrchestratorTaskTimeline", () => {
     );
     expect(page.nextCursor).toBe("20");
     expect(page.items[0]?.kind).toBe("message");
+  });
+});
+
+describe("ElizaClient.getOrchestratorWidgets", () => {
+  it("fetches the bounded widget snapshot with encoded project options", async () => {
+    const client = new ElizaClient("http://agent.example:31337", "token");
+    const fetch = vi.fn(async () => ({
+      version: "orchestrator.widgets.v1",
+      generatedAt: "2026-07-13T00:00:00.000Z",
+      totalTaskCount: 0,
+      tasks: [],
+    }));
+    client.fetch = fetch as typeof client.fetch;
+
+    const snapshot = await client.getOrchestratorWidgets({
+      includeArchived: true,
+      projectId: "project / alpha",
+      limit: 8,
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/orchestrator/widgets?includeArchived=true&projectId=project+%2F+alpha&limit=8",
+    );
+    expect(snapshot.totalTaskCount).toBe(0);
+  });
+
+  it("delivers named SSE snapshots and closes the browser subscription", () => {
+    class FakeEventSource extends EventTarget {
+      static latest: FakeEventSource | undefined;
+      readonly url: string;
+      close = vi.fn();
+
+      constructor(url: string | URL) {
+        super();
+        this.url = String(url);
+        FakeEventSource.latest = this;
+      }
+    }
+    const previous = globalThis.EventSource;
+    globalThis.EventSource = FakeEventSource as unknown as typeof EventSource;
+    try {
+      const client = new ElizaClient("http://agent.example:31337", "token");
+      const onSnapshot = vi.fn();
+      const onError = vi.fn();
+      const close = client.streamOrchestratorWidgets(
+        { limit: 8 },
+        onSnapshot,
+        onError,
+      );
+      const source = FakeEventSource.latest;
+      if (!source) throw new Error("EventSource was not opened");
+
+      const event = new Event("snapshot");
+      Object.defineProperty(event, "data", {
+        value: JSON.stringify({
+          version: "orchestrator.widgets.v1",
+          generatedAt: "2026-07-13T00:00:00.000Z",
+          totalTaskCount: 0,
+          tasks: [],
+        }),
+      });
+      source.dispatchEvent(event);
+
+      expect(source.url).toBe(
+        "http://agent.example:31337/api/orchestrator/widgets/stream?limit=8",
+      );
+      expect(onSnapshot).toHaveBeenCalledWith(
+        expect.objectContaining({ totalTaskCount: 0, tasks: [] }),
+      );
+      expect(onError).not.toHaveBeenCalled();
+
+      const malformedSnapshot = new Event("snapshot");
+      Object.defineProperty(malformedSnapshot, "data", { value: "{" });
+      source.dispatchEvent(malformedSnapshot);
+      expect(onError).toHaveBeenLastCalledWith(expect.any(SyntaxError));
+
+      const serverError = new Event("error");
+      Object.defineProperty(serverError, "data", {
+        value: JSON.stringify({ error: "task store unavailable" }),
+      });
+      source.dispatchEvent(serverError);
+      expect(onError).toHaveBeenLastCalledWith(
+        expect.objectContaining({ message: "task store unavailable" }),
+      );
+
+      const malformedError = new Event("error");
+      Object.defineProperty(malformedError, "data", { value: "{" });
+      source.dispatchEvent(malformedError);
+      expect(onError).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          message: "Orchestrator task stream returned invalid error data",
+        }),
+      );
+
+      source.dispatchEvent(new Event("error"));
+      expect(onError).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          message: "Orchestrator task stream disconnected",
+        }),
+      );
+
+      close();
+      expect(source.close).toHaveBeenCalledTimes(1);
+    } finally {
+      globalThis.EventSource = previous;
+    }
+  });
+
+  it("returns a harmless closer when EventSource is unavailable", () => {
+    const previous = globalThis.EventSource;
+    Reflect.deleteProperty(globalThis, "EventSource");
+    try {
+      const client = new ElizaClient("http://agent.example:31337", "token");
+      const close = client.streamOrchestratorWidgets(
+        undefined,
+        vi.fn(),
+        vi.fn(),
+      );
+      expect(close()).toBeUndefined();
+    } finally {
+      globalThis.EventSource = previous;
+    }
   });
 });
 

--- a/packages/ui/src/api/client-orchestrator-widgets.ts
+++ b/packages/ui/src/api/client-orchestrator-widgets.ts
@@ -1,0 +1,127 @@
+/**
+ * Compact orchestrator widget API for bounded JSON snapshots and named SSE
+ * updates. The detailed task workbench keeps its larger API in client-agent;
+ * this module owns only the small projection rendered by task summary rails.
+ */
+
+import { openEventSource } from "../utils/event-source";
+import { ElizaClient } from "./client-base";
+
+export type OrchestratorWidgetStatus =
+  | "queued"
+  | "running"
+  | "needs_input"
+  | "completed"
+  | "failed";
+
+export interface OrchestratorWidgetTask {
+  taskId: string;
+  label: string;
+  status: OrchestratorWidgetStatus;
+  model?: string;
+  account?: {
+    providerId?: string;
+    accountId?: string;
+    label?: string;
+  };
+  progressSummary: string;
+  evidenceLinks: Array<{ label: string; href: string }>;
+  timestamps: {
+    createdAt: string;
+    updatedAt: string;
+    completedAt?: string | null;
+  };
+  parentTaskId?: string;
+  childTaskIds: string[];
+}
+
+export interface OrchestratorWidgetSnapshot {
+  version: "orchestrator.widgets.v1";
+  generatedAt: string;
+  totalTaskCount: number;
+  tasks: OrchestratorWidgetTask[];
+}
+
+export interface OrchestratorWidgetOptions {
+  includeArchived?: boolean;
+  projectId?: string;
+  limit?: number;
+}
+
+declare module "./client-base" {
+  interface ElizaClient {
+    getOrchestratorWidgets(
+      options?: OrchestratorWidgetOptions,
+    ): Promise<OrchestratorWidgetSnapshot>;
+    streamOrchestratorWidgets(
+      options: OrchestratorWidgetOptions | undefined,
+      onSnapshot: (snapshot: OrchestratorWidgetSnapshot) => void,
+      onError: (error: Error) => void,
+    ): () => void;
+  }
+}
+
+function widgetQuery(options?: OrchestratorWidgetOptions): string {
+  const params = new URLSearchParams();
+  if (options?.includeArchived) params.set("includeArchived", "true");
+  if (options?.projectId) params.set("projectId", options.projectId);
+  if (typeof options?.limit === "number") {
+    params.set("limit", String(options.limit));
+  }
+  const query = params.toString();
+  return query ? `?${query}` : "";
+}
+
+ElizaClient.prototype.getOrchestratorWidgets = function (
+  this: ElizaClient,
+  options,
+) {
+  return this.fetch<OrchestratorWidgetSnapshot>(
+    `/api/orchestrator/widgets${widgetQuery(options)}`,
+  );
+};
+
+ElizaClient.prototype.streamOrchestratorWidgets = function (
+  this: ElizaClient,
+  options,
+  onSnapshot,
+  onError,
+) {
+  const url = `${this.baseUrl || ""}/api/orchestrator/widgets/stream${widgetQuery(options)}`;
+  const source = openEventSource(url);
+  if (!source) return () => undefined;
+
+  source.addEventListener("snapshot", (event) => {
+    try {
+      onSnapshot(JSON.parse((event as MessageEvent<string>).data));
+    } catch (error) {
+      onError(
+        error instanceof Error
+          ? error
+          : new Error("Invalid orchestrator widget snapshot"),
+      );
+    }
+  });
+  source.addEventListener("error", (event) => {
+    const data = (event as MessageEvent<string>).data;
+    if (typeof data === "string" && data.length > 0) {
+      try {
+        const payload = JSON.parse(data) as { error?: unknown };
+        if (typeof payload.error === "string") {
+          onError(new Error(payload.error));
+          return;
+        }
+      } catch (error) {
+        // error-policy:J3 malformed terminal SSE data becomes an explicit client error.
+        onError(
+          new Error("Orchestrator task stream returned invalid error data", {
+            cause: error,
+          }),
+        );
+        return;
+      }
+    }
+    onError(new Error("Orchestrator task stream disconnected"));
+  });
+  return () => source.close();
+};

--- a/packages/ui/src/components/chat/widgets/WIDGET_MATRIX.md
+++ b/packages/ui/src/components/chat/widgets/WIDGET_MATRIX.md
@@ -131,7 +131,9 @@ the inbox.
 |---|---|---|---|---|---|
 | `agent-orchestrator.activity` | chat-sidebar | `useActivityEvents` <- WS `pty-session-event` / `proactive-message` / `agent_event` | `agent-orchestrator.tsx` `OrchestratorActivityWidget` | TasksEventsPanel | wired |
 | `agent-orchestrator.apps` | chat-sidebar | poll `listAppRuns()` 5s | `agent-orchestrator.tsx` `AppRunsWidget` | TasksEventsPanel | wired |
+| `agent-orchestrator.tasks` | chat-sidebar | initial `GET /api/orchestrator/widgets` + live `/api/orchestrator/widgets/stream` snapshots | `orchestrator-task-widget.tsx` | TasksEventsPanel | wired |
 | `agent-orchestrator.accounts` | chat-sidebar | poll `listAccounts()`/`getOrchestratorAccounts()`/`getOrchestratorRooms()` 15s | `agent-orchestrator-accounts-view.tsx` | TasksEventsPanel | wired |
+| `agent-orchestrator.rooms` | chat-sidebar | poll `getOrchestratorRooms()` 15s | `agent-orchestrator.tsx` `OrchestratorRoomWidget` | TasksEventsPanel | wired |
 | `browser.status` | chat-sidebar | browser-workspace status | `browser-status.tsx` | TasksEventsPanel | wired |
 | `music-player.stream` | chat-sidebar | music-player state | `music-player.tsx` | TasksEventsPanel | wired |
 | `todo.items` | home | todo store + goals store (one at-risk goal row) | `todo.tsx` | ViewCatalog | wired |
@@ -148,7 +150,7 @@ home because its at-risk row is rendered inside `todo.items`.
 | Slot | Host mounted? | Widgets registered? | Verdict |
 |---|---|---|---|
 | `home` | yes, HomeScreen | yes, curated ≤5 residents (tutorial launcher removed) | active |
-| `chat-sidebar` | yes, TasksEventsPanel | yes, 5 | active |
+| `chat-sidebar` | yes, TasksEventsPanel | yes, 7 | active |
 | `character` | yes, CharacterHubView | yes, 1 | active |
 | `nav-page` | no WidgetHost mount | no component widgets | active app-navigation contract |
 

--- a/packages/ui/src/components/chat/widgets/orchestrator-task-widget.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/orchestrator-task-widget.stories.tsx
@@ -1,0 +1,136 @@
+/**
+ * Visual-state catalog for the live orchestrator task rail: populated lineage,
+ * loading, designed empty, and explicit transport failure.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react";
+import type { ReactNode } from "react";
+import type { OrchestratorWidgetSnapshot } from "../../../api/client-types-cloud";
+import {
+  assert,
+  waitForTestId,
+} from "../../../storybook/home-widget-decorator";
+import { OrchestratorTaskWidgetView } from "./orchestrator-task-widget";
+
+function Sidebar({ children }: { children: ReactNode }) {
+  return (
+    <div className="w-[320px] rounded-lg border border-border/40 bg-bg/95 p-3">
+      {children}
+    </div>
+  );
+}
+
+const snapshot: OrchestratorWidgetSnapshot = {
+  version: "orchestrator.widgets.v1",
+  generatedAt: "2026-07-13T00:00:00.000Z",
+  totalTaskCount: 5,
+  tasks: [
+    {
+      taskId: "task-parent",
+      label: "Ship the orchestration rail",
+      status: "running",
+      model: "claude-opus-4-7",
+      account: { label: "Claude — Work" },
+      progressSummary: "Rendering the live SSE state",
+      evidenceLinks: [],
+      timestamps: {
+        createdAt: "2026-07-13T00:00:00.000Z",
+        updatedAt: "2026-07-13T00:01:00.000Z",
+      },
+      childTaskIds: ["task-child-a", "task-child-b"],
+    },
+    {
+      taskId: "task-child-a",
+      label: "Verify the browser consumer",
+      status: "needs_input",
+      progressSummary: "Waiting for screenshot review",
+      evidenceLinks: [],
+      timestamps: {
+        createdAt: "2026-07-13T00:00:30.000Z",
+        updatedAt: "2026-07-13T00:01:30.000Z",
+      },
+      parentTaskId: "task-parent",
+      childTaskIds: [],
+    },
+    {
+      taskId: "task-done",
+      label: "Exercise the real HTTP route",
+      status: "completed",
+      progressSummary: "Real Node server and durable store passed",
+      evidenceLinks: [],
+      timestamps: {
+        createdAt: "2026-07-13T00:00:00.000Z",
+        updatedAt: "2026-07-13T00:02:00.000Z",
+        completedAt: "2026-07-13T00:02:00.000Z",
+      },
+      childTaskIds: [],
+    },
+  ],
+};
+
+const noop = () => undefined;
+const openedTasks: string[] = [];
+
+const meta = {
+  title: "Chat/Widgets/OrchestratorTasks",
+  component: OrchestratorTaskWidgetView,
+  decorators: [
+    (Story) => (
+      <Sidebar>
+        <Story />
+      </Sidebar>
+    ),
+  ],
+  args: {
+    snapshot,
+    loading: false,
+    error: null,
+    onOpenTask: (taskId) => openedTasks.push(taskId),
+    onOpenAll: noop,
+    onRetry: noop,
+  },
+} satisfies Meta<typeof OrchestratorTaskWidgetView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Populated: Story = {
+  play: async ({ canvasElement }) => {
+    openedTasks.length = 0;
+    const widget = await waitForTestId(
+      canvasElement,
+      "chat-widget-orchestrator-tasks",
+    );
+    const task = widget.querySelector<HTMLButtonElement>(
+      'button[aria-label^="Ship the orchestration rail."]',
+    );
+    assert(task, "the first live task is an accessible button");
+    task.click();
+    assert(
+      openedTasks[0] === "task-parent",
+      "clicking a task opens its exact durable task id",
+    );
+    assert(widget.textContent?.includes("2 children"), "lineage is rendered");
+    assert(
+      widget.textContent?.includes("3 of 5"),
+      "the display bound is explicit",
+    );
+  },
+};
+
+export const Loading: Story = {
+  args: { snapshot: null, loading: true },
+};
+
+export const Empty: Story = {
+  args: {
+    snapshot: { ...snapshot, totalTaskCount: 0, tasks: [] },
+  },
+};
+
+export const Unavailable: Story = {
+  args: {
+    snapshot: null,
+    error: "Task store unavailable",
+  },
+};

--- a/packages/ui/src/components/chat/widgets/orchestrator-task-widget.test.tsx
+++ b/packages/ui/src/components/chat/widgets/orchestrator-task-widget.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * The shipped orchestrator task rail consumes initial and streamed snapshots,
+ * renders lineage/progress, navigates into the workbench, and distinguishes
+ * loading, empty, and failed server states. Transport is stubbed at the typed
+ * client boundary; the real route/SSE process is covered by the plugin E2E.
+ */
+
+// @vitest-environment jsdom
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OrchestratorWidgetSnapshot } from "../../../api/client-orchestrator-widgets";
+
+const mocks = vi.hoisted(() => ({
+  getWidgets: vi.fn(),
+  streamWidgets: vi.fn(),
+  openedView: undefined as { path: string; pluginId: string } | undefined,
+  streamClosed: false,
+  streamSnapshot: undefined as
+    | ((snapshot: OrchestratorWidgetSnapshot) => void)
+    | undefined,
+  streamError: undefined as ((error: Error) => void) | undefined,
+}));
+
+vi.mock("../../../api", () => ({
+  client: {
+    getOrchestratorWidgets: mocks.getWidgets,
+    streamOrchestratorWidgets: mocks.streamWidgets,
+  },
+}));
+
+vi.mock("../../../hooks/useAuthStatus", () => ({
+  useIsAuthenticated: () => true,
+}));
+
+vi.mock("../../../state", () => ({
+  useAppSelectorShallow: () => ({ t: undefined }),
+}));
+
+vi.mock("./home-widget-card", () => ({
+  useWidgetNavigation: () => ({
+    openView: (path: string, pluginId: string) => {
+      mocks.openedView = { path, pluginId };
+    },
+  }),
+}));
+
+import { OrchestratorTaskWidget } from "./orchestrator-task-widget";
+
+const populated: OrchestratorWidgetSnapshot = {
+  version: "orchestrator.widgets.v1",
+  generatedAt: "2026-07-13T00:00:00.000Z",
+  totalTaskCount: 2,
+  tasks: [
+    {
+      taskId: "task/parent",
+      label: "Ship the orchestration rail",
+      status: "running",
+      model: "claude-opus-4-7",
+      progressSummary: "Rendering the live SSE state",
+      evidenceLinks: [],
+      timestamps: {
+        createdAt: "2026-07-13T00:00:00.000Z",
+        updatedAt: "2026-07-13T00:01:00.000Z",
+      },
+      childTaskIds: ["child-1"],
+    },
+  ],
+};
+
+const props = { events: [], clearEvents: vi.fn() };
+
+beforeEach(() => {
+  mocks.getWidgets.mockReset();
+  mocks.streamWidgets.mockReset();
+  mocks.openedView = undefined;
+  mocks.streamClosed = false;
+  mocks.streamSnapshot = undefined;
+  mocks.streamError = undefined;
+  mocks.streamWidgets.mockImplementation((_options, onSnapshot, onError) => {
+    mocks.streamSnapshot = onSnapshot;
+    mocks.streamError = onError;
+    return () => {
+      mocks.streamClosed = true;
+    };
+  });
+});
+
+afterEach(cleanup);
+
+describe("OrchestratorTaskWidget", () => {
+  it("renders the real compact DTO and opens its workbench task", async () => {
+    mocks.getWidgets.mockResolvedValue(populated);
+    render(<OrchestratorTaskWidget {...props} />);
+
+    expect(await screen.findByText("Ship the orchestration rail")).toBeTruthy();
+    expect(screen.getByText("Rendering the live SSE state")).toBeTruthy();
+    expect(screen.getByText("1 child")).toBeTruthy();
+    expect(screen.getByText("1 of 2")).toBeTruthy();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Ship the orchestration rail.*Open in workbench/i,
+      }),
+    );
+    expect(mocks.openedView).toEqual({
+      path: "/orchestrator?taskId=task%2Fparent",
+      pluginId: "orchestrator",
+    });
+  });
+
+  it("lets a shipped workbench host handle task selection in place", async () => {
+    let selectedTaskId: string | undefined;
+    mocks.getWidgets.mockResolvedValue(populated);
+    render(
+      <OrchestratorTaskWidget
+        {...props}
+        onOpenTask={(taskId) => {
+          selectedTaskId = taskId;
+        }}
+      />,
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: /Ship the orchestration rail.*Open in workbench/i,
+      }),
+    );
+
+    expect(selectedTaskId).toBe("task/parent");
+    expect(mocks.openedView).toBeUndefined();
+  });
+
+  it("replaces the initial result when the SSE snapshot advances", async () => {
+    mocks.getWidgets.mockResolvedValue({ ...populated, tasks: [] });
+    render(<OrchestratorTaskWidget {...props} />);
+    expect(await screen.findByText("No orchestration tasks yet")).toBeTruthy();
+
+    await act(async () => {
+      mocks.streamSnapshot?.(populated);
+    });
+    expect(await screen.findByText("Ship the orchestration rail")).toBeTruthy();
+  });
+
+  it("renders a retryable error instead of a healthy empty state", async () => {
+    mocks.getWidgets.mockRejectedValue(new Error("task store unavailable"));
+    render(<OrchestratorTaskWidget {...props} />);
+
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "task store unavailable",
+    );
+    expect(screen.queryByText("No orchestration tasks yet")).toBeNull();
+
+    mocks.getWidgets.mockResolvedValue(populated);
+    fireEvent.click(
+      screen.getByRole("button", { name: "Retry task progress" }),
+    );
+    expect(await screen.findByText("Ship the orchestration rail")).toBeTruthy();
+    await waitFor(() => expect(screen.queryByRole("alert")).toBeNull());
+  });
+
+  it("closes the SSE subscription when the widget unmounts", () => {
+    mocks.getWidgets.mockReturnValue(new Promise(() => {}));
+    const view = render(<OrchestratorTaskWidget {...props} />);
+    view.unmount();
+    expect(mocks.streamClosed).toBe(true);
+  });
+});

--- a/packages/ui/src/components/chat/widgets/orchestrator-task-widget.tsx
+++ b/packages/ui/src/components/chat/widgets/orchestrator-task-widget.tsx
@@ -1,0 +1,266 @@
+/**
+ * Live task-progress rail for the orchestrator's compact widget stream. It
+ * keeps chat users oriented without duplicating the workbench, and preserves
+ * loading, empty, and failure states as visibly different outcomes.
+ */
+
+import { AlertTriangle, RefreshCw, Workflow } from "lucide-react";
+import { useEffect, useState } from "react";
+import { client } from "../../../api";
+import "../../../api/client-orchestrator-widgets";
+import type {
+  OrchestratorWidgetSnapshot,
+  OrchestratorWidgetStatus,
+  OrchestratorWidgetTask,
+} from "../../../api/client-orchestrator-widgets";
+import { useIsAuthenticated } from "../../../hooks/useAuthStatus";
+import { useAppSelectorShallow } from "../../../state";
+import type { TranslateFn } from "../../../types";
+import { Button } from "../../ui/button";
+import { fallbackTranslate } from "./agent-orchestrator-accounts-view";
+import { useWidgetNavigation } from "./home-widget-card";
+import { EmptyWidgetState, WidgetSection } from "./shared";
+import type { ChatSidebarWidgetProps } from "./types";
+
+const STATUS_STYLE: Record<
+  OrchestratorWidgetStatus,
+  { label: string; className: string }
+> = {
+  queued: { label: "Queued", className: "bg-muted" },
+  running: { label: "Running", className: "bg-accent" },
+  needs_input: { label: "Needs input", className: "bg-warn" },
+  completed: { label: "Completed", className: "bg-ok" },
+  failed: { label: "Failed", className: "bg-danger" },
+};
+
+function TaskRow({
+  task,
+  onOpen,
+}: {
+  task: OrchestratorWidgetTask;
+  onOpen: (taskId: string) => void;
+}) {
+  const status = STATUS_STYLE[task.status];
+  const relationshipCount = task.childTaskIds.length;
+  const assignment = [task.model, task.account?.label]
+    .filter((value): value is string => Boolean(value))
+    .join(" · ");
+  return (
+    <Button
+      variant="ghost"
+      className="h-auto w-full min-w-0 justify-start rounded-sm px-2 py-2 text-left hover:bg-bg-hover"
+      onClick={() => onOpen(task.taskId)}
+      aria-label={`${task.label}. ${status.label}. ${task.progressSummary}. Open in workbench.`}
+    >
+      <span
+        className={`mt-1 h-2 w-2 shrink-0 rounded-full ${status.className}`}
+        aria-hidden="true"
+      />
+      <span className="min-w-0 flex-1">
+        <span className="flex min-w-0 items-center gap-2">
+          <span className="truncate text-xs-tight font-medium text-txt">
+            {task.label}
+          </span>
+          <span className="ml-auto shrink-0 text-3xs text-muted">
+            {status.label}
+          </span>
+        </span>
+        <span className="mt-0.5 line-clamp-2 block text-3xs leading-relaxed text-muted">
+          {task.progressSummary}
+        </span>
+        {assignment || task.parentTaskId || relationshipCount > 0 ? (
+          <span className="mt-1 flex gap-2 text-3xs text-muted/70">
+            {assignment ? <span className="truncate">{assignment}</span> : null}
+            {task.parentTaskId || relationshipCount > 0 ? (
+              <span className="ml-auto shrink-0">
+                {task.parentTaskId ? "Child task" : null}
+                {task.parentTaskId && relationshipCount > 0 ? " · " : null}
+                {relationshipCount > 0
+                  ? `${relationshipCount} child${relationshipCount === 1 ? "" : "ren"}`
+                  : null}
+              </span>
+            ) : null}
+          </span>
+        ) : null}
+      </span>
+    </Button>
+  );
+}
+
+export interface OrchestratorTaskWidgetViewProps {
+  snapshot: OrchestratorWidgetSnapshot | null;
+  loading: boolean;
+  error: string | null;
+  t?: TranslateFn;
+  onOpenTask: (taskId: string) => void;
+  onOpenAll: () => void;
+  onRetry: () => void;
+}
+
+/** Presentational task rail used by the live container and visual-state stories. */
+export function OrchestratorTaskWidgetView({
+  snapshot,
+  loading,
+  error,
+  t = fallbackTranslate,
+  onOpenTask,
+  onOpenAll,
+  onRetry,
+}: OrchestratorTaskWidgetViewProps) {
+  return (
+    <WidgetSection
+      title={t("agentorchestrator.tasks", { defaultValue: "Tasks" })}
+      icon={<Workflow />}
+      testId="chat-widget-orchestrator-tasks"
+      onTitleClick={onOpenAll}
+      action={
+        snapshot && snapshot.totalTaskCount > snapshot.tasks.length ? (
+          <span className="pr-1 text-3xs text-muted">
+            {snapshot.tasks.length} of {snapshot.totalTaskCount}
+          </span>
+        ) : undefined
+      }
+    >
+      {loading ? (
+        <div
+          className="space-y-2 py-2"
+          role="status"
+          aria-label="Loading task progress"
+        >
+          <div className="h-10 animate-pulse rounded-sm bg-bg-hover" />
+          <div className="h-10 animate-pulse rounded-sm bg-bg-hover" />
+        </div>
+      ) : error ? (
+        <div
+          className="my-2 flex items-start gap-2 rounded-sm border border-danger/35 bg-danger/10 p-2 text-3xs text-danger"
+          role="alert"
+        >
+          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <span className="min-w-0 flex-1 break-words">{error}</span>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 w-6 shrink-0 p-0 text-danger hover:bg-danger/15"
+            onClick={onRetry}
+            aria-label="Retry task progress"
+          >
+            <RefreshCw className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      ) : snapshot?.tasks.length ? (
+        <div className="-mx-1 divide-y divide-border/40">
+          {snapshot.tasks.map((task) => (
+            <TaskRow key={task.taskId} task={task} onOpen={onOpenTask} />
+          ))}
+        </div>
+      ) : (
+        <EmptyWidgetState
+          icon={<Workflow className="h-5 w-5" />}
+          title={t("agentorchestrator.noTasks", {
+            defaultValue: "No orchestration tasks yet",
+          })}
+          description={t("agentorchestrator.noTasksDescription", {
+            defaultValue: "New coding tasks will appear here as they run.",
+          })}
+        />
+      )}
+    </WidgetSection>
+  );
+}
+
+export interface OrchestratorTaskWidgetProps
+  extends Partial<ChatSidebarWidgetProps> {
+  onOpenTask?: (taskId: string) => void;
+  onOpenAll?: () => void;
+}
+
+export function OrchestratorTaskWidget({
+  onOpenTask,
+  onOpenAll,
+}: OrchestratorTaskWidgetProps) {
+  const authenticated = useIsAuthenticated();
+  const { t: appT } = useAppSelectorShallow((state) => ({ t: state.t }));
+  const t = appT ?? fallbackTranslate;
+  const navigation = useWidgetNavigation();
+  const [snapshot, setSnapshot] = useState<OrchestratorWidgetSnapshot | null>(
+    null,
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  useEffect(() => {
+    if (!authenticated) return;
+    let cancelled = false;
+    if (refreshKey > 0) setSnapshot(null);
+    setLoading(true);
+    setError(null);
+
+    void client
+      .getOrchestratorWidgets({ limit: 8 })
+      .then((next) => {
+        if (!cancelled) {
+          setSnapshot(next);
+          setLoading(false);
+        }
+      })
+      .catch((cause: unknown) => {
+        if (!cancelled) {
+          setError(
+            cause instanceof Error
+              ? cause.message
+              : "Task progress is unavailable",
+          );
+          setLoading(false);
+        }
+      });
+
+    const closeStream = client.streamOrchestratorWidgets(
+      { limit: 8 },
+      (next) => {
+        if (!cancelled) {
+          setSnapshot(next);
+          setError(null);
+          setLoading(false);
+        }
+      },
+      (cause) => {
+        if (!cancelled) {
+          setError(cause.message);
+          setLoading(false);
+        }
+      },
+    );
+
+    return () => {
+      cancelled = true;
+      closeStream();
+    };
+  }, [authenticated, refreshKey]);
+
+  if (!authenticated) return null;
+
+  const openTask =
+    onOpenTask ??
+    ((taskId: string) => {
+      navigation.openView(
+        `/orchestrator?taskId=${encodeURIComponent(taskId)}`,
+        "orchestrator",
+      );
+    });
+
+  return (
+    <OrchestratorTaskWidgetView
+      snapshot={snapshot}
+      loading={loading}
+      error={error}
+      t={t}
+      onOpenTask={openTask}
+      onOpenAll={
+        onOpenAll ??
+        (() => navigation.openView("/orchestrator", "orchestrator"))
+      }
+      onRetry={() => setRefreshKey((value) => value + 1)}
+    />
+  );
+}

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -185,6 +185,10 @@ export {
   OrchestratorAccountsView,
   type OrchestratorAccountsViewProps,
 } from "./chat/widgets/agent-orchestrator-accounts-view";
+export {
+  OrchestratorTaskWidget,
+  type OrchestratorTaskWidgetProps,
+} from "./chat/widgets/orchestrator-task-widget";
 export * from "./chat/widgets/shared";
 export * from "./chat/widgets/types";
 export * from "./cloud/CloudSourceControls";

--- a/packages/ui/src/story-play-coverage.test.ts
+++ b/packages/ui/src/story-play-coverage.test.ts
@@ -51,7 +51,7 @@ function exportsPlay(absPath: string): boolean {
 }
 
 // Floor: stories that currently export a `play`. RATCHET — only ever raise this.
-const MIN_INTERACTION_PLAYS = 14;
+const MIN_INTERACTION_PLAYS = 17;
 
 // High-traffic interactive components whose interaction test must never be
 // dropped. Paths are relative to packages/ui/src. Grow this list as components

--- a/plugins/plugin-agent-orchestrator/package.json
+++ b/plugins/plugin-agent-orchestrator/package.json
@@ -83,6 +83,7 @@
     "@biomejs/biome": "2.5.3",
     "@electric-sql/pglite": "^0.4.0",
     "@elizaos/core": "workspace:*",
+    "@elizaos/logger": "workspace:*",
     "@elizaos/shared": "workspace:*",
     "@types/bun": "^1.3.9",
     "@types/node": "^25.2.3",

--- a/plugins/plugin-agent-orchestrator/src/__tests__/orchestrator-widget-contract.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/orchestrator-widget-contract.test.ts
@@ -1,6 +1,9 @@
+/** Validates task-widget snapshots from deterministic durable task DTOs. */
+
 import { describe, expect, it } from "vitest";
 import type { TaskThreadDto } from "../services/orchestrator-task-mapper.js";
 import { buildOrchestratorWidgetSnapshot } from "../services/orchestrator-widget-contract.js";
+import { CODING_AGENT_ROUTE_PATHS } from "../setup-routes.js";
 
 function task(overrides: Partial<TaskThreadDto>): TaskThreadDto {
   return {
@@ -96,7 +99,6 @@ describe("orchestrator widget contract", () => {
   });
 });
 
-// Child relationship is sourced from the list DTO, not detail-only payloads.
 describe("orchestrator widget lineage", () => {
   it("populates parentTaskId and childTaskIds from list rows", () => {
     const snapshot = buildOrchestratorWidgetSnapshot([
@@ -111,4 +113,13 @@ describe("orchestrator widget lineage", () => {
       "parent",
     );
   });
+});
+
+it("registers snapshot and stream routes with the plugin dispatcher", () => {
+  expect(CODING_AGENT_ROUTE_PATHS).toEqual(
+    expect.arrayContaining([
+      { type: "GET", path: "/api/orchestrator/widgets" },
+      { type: "GET", path: "/api/orchestrator/widgets/stream" },
+    ]),
+  );
 });

--- a/plugins/plugin-agent-orchestrator/src/__tests__/orchestrator-widget-contract.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/orchestrator-widget-contract.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import type { TaskThreadDto } from "../services/orchestrator-task-mapper.js";
+import { buildOrchestratorWidgetSnapshot } from "../services/orchestrator-widget-contract.js";
+
+function task(overrides: Partial<TaskThreadDto>): TaskThreadDto {
+  return {
+    id: "task-1",
+    title: "Implement runtime orchestration",
+    kind: "coding",
+    status: "active",
+    priority: "normal",
+    paused: false,
+    originalRequest: "do the thing",
+    sessionCount: 1,
+    activeSessionCount: 1,
+    latestSessionId: "sess-1",
+    latestSessionLabel: "claude",
+    latestSessionModel: "claude-fable-5",
+    latestAccountProviderId: "anthropic-subscription",
+    latestAccountId: "acct-1",
+    latestAccountLabel: "Claude Pro",
+    parentTaskId: null,
+    latestWorkdir: "/repo",
+    latestRepo: "elizaOS/eliza",
+    projectId: null,
+    latestActivityAt: 1,
+    decisionCount: 2,
+    usage: {
+      inputTokens: 0,
+      outputTokens: 0,
+      reasoningTokens: 0,
+      totalTokens: 0,
+      cacheTokens: 0,
+      costUsd: 0,
+      state: "unavailable",
+      byProvider: [],
+    },
+    createdAt: "2026-07-12T00:00:00.000Z",
+    updatedAt: "2026-07-12T00:01:00.000Z",
+    closedAt: null,
+    archivedAt: null,
+    ...overrides,
+  };
+}
+
+describe("orchestrator widget contract", () => {
+  it("emits compact v1 task payloads with UI statuses and evidence links", () => {
+    const snapshot = buildOrchestratorWidgetSnapshot(
+      [
+        task({
+          admission: { state: "queued", position: 2, enqueuedAt: "now" },
+        }),
+      ],
+      new Date("2026-07-12T00:02:00.000Z"),
+    );
+
+    expect(snapshot.version).toBe("orchestrator.widgets.v1");
+    expect(snapshot.generatedAt).toBe("2026-07-12T00:02:00.000Z");
+    expect(snapshot.tasks[0]).toMatchObject({
+      taskId: "task-1",
+      label: "Implement runtime orchestration",
+      status: "queued",
+      model: "claude-fable-5",
+      account: {
+        providerId: "anthropic-subscription",
+        accountId: "acct-1",
+        label: "Claude Pro",
+      },
+      progressSummary: "Queued at position 2",
+    });
+    expect(snapshot.tasks[0]?.evidenceLinks.map((link) => link.label)).toEqual([
+      "details",
+      "events",
+      "stream",
+    ]);
+  });
+
+  it("maps waiting and terminal task states for floating widgets", () => {
+    const snapshot = buildOrchestratorWidgetSnapshot([
+      task({ id: "needs", status: "waiting_on_user", activeSessionCount: 0 }),
+      task({
+        id: "done",
+        status: "done",
+        closedAt: "2026-07-12T00:03:00.000Z",
+      }),
+      task({ id: "failed", status: "failed" }),
+      task({ id: "archived", status: "archived" }),
+    ]);
+
+    expect(snapshot.tasks.map((t) => [t.taskId, t.status])).toEqual([
+      ["needs", "needs_input"],
+      ["done", "completed"],
+      ["failed", "failed"],
+      ["archived", "completed"],
+    ]);
+  });
+});
+
+// Child relationship is sourced from the list DTO, not detail-only payloads.
+describe("orchestrator widget lineage", () => {
+  it("populates parentTaskId and childTaskIds from list rows", () => {
+    const snapshot = buildOrchestratorWidgetSnapshot([
+      task({ id: "parent" }),
+      task({ id: "child", parentTaskId: "parent" }),
+    ]);
+
+    expect(
+      snapshot.tasks.find((t) => t.taskId === "parent")?.childTaskIds,
+    ).toEqual(["child"]);
+    expect(snapshot.tasks.find((t) => t.taskId === "child")?.parentTaskId).toBe(
+      "parent",
+    );
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/orchestrator-widget-contract.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/orchestrator-widget-contract.test.ts
@@ -59,6 +59,7 @@ describe("orchestrator widget contract", () => {
 
     expect(snapshot.version).toBe("orchestrator.widgets.v1");
     expect(snapshot.generatedAt).toBe("2026-07-12T00:02:00.000Z");
+    expect(snapshot.totalTaskCount).toBe(1);
     expect(snapshot.tasks[0]).toMatchObject({
       taskId: "task-1",
       label: "Implement runtime orchestration",
@@ -112,6 +113,22 @@ describe("orchestrator widget lineage", () => {
     expect(snapshot.tasks.find((t) => t.taskId === "child")?.parentTaskId).toBe(
       "parent",
     );
+  });
+
+  it("derives stable lineage from the complete task set outside the visible bound", () => {
+    const parent = task({ id: "parent" });
+    const snapshot = buildOrchestratorWidgetSnapshot(
+      [parent],
+      new Date("2026-07-12T00:02:00.000Z"),
+      [
+        parent,
+        task({ id: "child-z", parentTaskId: "parent" }),
+        task({ id: "child-a", parentTaskId: "parent" }),
+      ],
+    );
+
+    expect(snapshot.totalTaskCount).toBe(3);
+    expect(snapshot.tasks[0]?.childTaskIds).toEqual(["child-a", "child-z"]);
   });
 });
 

--- a/plugins/plugin-agent-orchestrator/src/__tests__/orchestrator-widget-real-server.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/orchestrator-widget-real-server.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Real Node HTTP coverage for the registered widget routes over a PGlite-backed
+ * AgentRuntime. It creates durable tasks through the production service, then
+ * verifies both JSON and SSE bytes through the plugin route adapter.
+ */
+
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { AgentRuntime } from "@elizaos/core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { OrchestratorTaskService } from "../services/orchestrator-task-service.js";
+import { codingAgentRoutePlugin } from "../setup-routes.js";
+import { createRealTestRuntime } from "./real-runtime.js";
+
+describe("orchestrator widget registered HTTP surface", () => {
+  let server: Server | undefined;
+  let baseUrl: string;
+  let service: OrchestratorTaskService;
+  let runtime: AgentRuntime;
+  let cleanupRuntime: (() => Promise<void>) | undefined;
+
+  beforeAll(async () => {
+    ({ runtime, cleanup: cleanupRuntime } = await createRealTestRuntime({
+      characterName: "OrchestratorWidgetRouteTest",
+      plugins: [
+        {
+          name: "orchestrator-widget-route-test",
+          description: "Registers the production orchestrator task service",
+          services: [OrchestratorTaskService],
+        },
+      ],
+    }));
+    const loadedService = await runtime.getServiceLoadPromise(
+      OrchestratorTaskService.serviceType,
+    );
+    if (!(loadedService instanceof OrchestratorTaskService)) {
+      throw new Error("Production orchestrator task service did not start");
+    }
+    service = loadedService;
+
+    const parent = await service.createTask({
+      title: "Render live orchestration",
+      goal: "Show production task state in the chat rail",
+      acceptanceCriteria: ["The task is visible through the widget route"],
+    });
+    await service.createTask({
+      title: "Stream child progress",
+      goal: "Emit a child task over SSE",
+      parentTaskId: parent.id,
+      acceptanceCriteria: ["The child is linked to its parent"],
+    });
+    await new Promise<void>((resolve) => setTimeout(resolve, 2));
+    await service.updateTask(parent.id, {
+      summary: "Production service state reached the app consumer",
+    });
+
+    const widgetRoute = codingAgentRoutePlugin.routes?.find(
+      (route) => route.path === "/api/orchestrator/widgets",
+    );
+    const streamRoute = codingAgentRoutePlugin.routes?.find(
+      (route) => route.path === "/api/orchestrator/widgets/stream",
+    );
+    if (!widgetRoute?.handler || !streamRoute?.handler) {
+      throw new Error("Registered orchestrator widget routes are missing");
+    }
+
+    server = createServer((request, response) => {
+      const pathname = new URL(request.url ?? "/", "http://localhost").pathname;
+      const route = pathname.endsWith("/stream") ? streamRoute : widgetRoute;
+      void route.handler(request as never, response as never, runtime);
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+    baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  });
+
+  afterAll(async () => {
+    if (server) {
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) =>
+        server?.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+    await cleanupRuntime?.();
+  });
+
+  it("returns bounded tasks with complete lineage from the durable store", async () => {
+    const response = await fetch(`${baseUrl}/api/orchestrator/widgets?limit=1`);
+    expect(response.status).toBe(200);
+    const snapshot = (await response.json()) as {
+      totalTaskCount: number;
+      tasks: Array<{
+        label: string;
+        progressSummary: string;
+        childTaskIds: string[];
+      }>;
+    };
+
+    expect(snapshot.totalTaskCount).toBe(2);
+    expect(snapshot.tasks).toHaveLength(1);
+    expect(snapshot.tasks[0]).toMatchObject({
+      label: "Render live orchestration",
+      progressSummary: "Production service state reached the app consumer",
+    });
+    expect(snapshot.tasks[0]?.childTaskIds).toHaveLength(1);
+  });
+
+  it("streams the production snapshot as named SSE bytes", async () => {
+    const controller = new AbortController();
+    const response = await fetch(
+      `${baseUrl}/api/orchestrator/widgets/stream?limit=1`,
+      { signal: controller.signal },
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error("SSE response body is unavailable");
+    const frame = await reader.read();
+    const text = new TextDecoder().decode(frame.value);
+    expect(text).toContain("event: snapshot");
+    expect(text).toContain("Render live orchestration");
+    expect(text).toContain("Production service state reached the app consumer");
+    controller.abort();
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/orchestrator-widget-routes.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/orchestrator-widget-routes.test.ts
@@ -1,0 +1,324 @@
+/** Validates widget HTTP and SSE boundaries with an in-memory route harness. */
+
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import { handleOrchestratorRoutes } from "../api/orchestrator-routes.js";
+import { OrchestratorTaskService } from "../services/orchestrator-task-service.js";
+import { codingAgentRoutePlugin } from "../setup-routes.js";
+
+function harness(pathname: string, method = "GET") {
+  const req = Object.assign(new EventEmitter(), {
+    method,
+    url: pathname,
+    headers: {},
+  });
+  const chunks: string[] = [];
+  const res = {
+    headersSent: false,
+    writableEnded: false,
+    statusCode: 0,
+    writeHead: vi.fn((status: number) => {
+      res.statusCode = status;
+      res.headersSent = true;
+    }),
+    write: vi.fn((chunk: string) => {
+      chunks.push(chunk);
+      return true;
+    }),
+    end: vi.fn((chunk?: string) => {
+      if (chunk) chunks.push(chunk);
+      res.writableEnded = true;
+    }),
+  };
+  const service = {
+    getStatus: vi.fn(async () => ({ running: true })),
+    getCapacityOverview: vi.fn(async () => ({ active: 1 })),
+    getAccountOverview: vi.fn(async () => ({ providers: [] })),
+    getAccountReadiness: vi.fn(() => ({ ready: true })),
+    getRoomRoster: vi.fn(async () => []),
+    listTasks: vi.fn(async () => []),
+    pauseAll: vi.fn(async () => 2),
+    resumeAll: vi.fn(async () => 2),
+    getTask: vi.fn(async () => ({ task: { id: "task-1" } })),
+    deleteTask: vi.fn(async () => true),
+    pauseTask: vi.fn(async () => ({
+      task: { id: "task-1", status: "paused" },
+    })),
+    resumeTask: vi.fn(async () => ({
+      task: { id: "task-1", status: "active" },
+    })),
+    archiveTask: vi.fn(async () => ({
+      task: { id: "task-1", status: "archived" },
+    })),
+    reopenTask: vi.fn(async () => ({ task: { id: "task-1", status: "open" } })),
+    listMessages: vi.fn(async () => ({ items: [], nextCursor: null })),
+    listTimeline: vi.fn(async () => ({ items: [], nextCursor: null })),
+    listEvents: vi.fn(async () => ({ items: [], nextCursor: null })),
+    getUsage: vi.fn(async () => ({ totalTokens: 0 })),
+    getTraceUsage: vi.fn(async () => ({ totalTokens: 0 })),
+    createTask: vi.fn(async () => ({ task: { id: "created" } })),
+    updateTask: vi.fn(async () => ({ task: { id: "task-1" } })),
+    forkTask: vi.fn(async () => ({ task: { id: "forked" } })),
+    postUserMessage: vi.fn(async () => ({ id: "message-1" })),
+    spawnAgentForTask: vi.fn(async () => ({ task: { id: "task-1" } })),
+    stopTaskAgent: vi.fn(async () => true),
+    retryTaskTurn: vi.fn(async () => ({ task: { id: "task-1" } })),
+    rerunFromEvent: vi.fn(async () => ({ task: { id: "task-1" } })),
+    restartTask: vi.fn(async () => ({ task: { id: "task-1" } })),
+    restartWithEditedPlan: vi.fn(async () => ({ task: { id: "task-1" } })),
+  };
+  const runtime = {
+    getService: vi.fn((type: string) =>
+      type === OrchestratorTaskService.serviceType ? service : undefined,
+    ),
+    hasService: vi.fn(() => false),
+    reportError: vi.fn(),
+  };
+  return {
+    req,
+    res,
+    chunks,
+    service,
+    runtime,
+    ctx: { runtime, acpService: null, workspaceService: null },
+  };
+}
+
+async function dispatchJson(
+  h: ReturnType<typeof harness>,
+  pathname: string,
+  body: Record<string, unknown>,
+) {
+  const pending = handleOrchestratorRoutes(
+    h.req as never,
+    h.res as never,
+    pathname,
+    h.ctx as never,
+  );
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  h.req.emit("data", Buffer.from(JSON.stringify(body)));
+  h.req.emit("end");
+  return pending;
+}
+
+describe("orchestrator widget routes", () => {
+  it("is reachable through the runtime plugin route adapter", async () => {
+    const h = harness("/api/orchestrator/widgets");
+    const route = codingAgentRoutePlugin.routes?.find(
+      (candidate) => candidate.path === "/api/orchestrator/widgets",
+    );
+    if (!route?.handler) throw new Error("widget plugin route missing");
+    await route.handler(h.req as never, h.res as never, h.runtime as never);
+    expect(JSON.parse(h.chunks.join(""))).toMatchObject({
+      version: "orchestrator.widgets.v1",
+    });
+  });
+
+  it.each([
+    ["/api/orchestrator/status", "getStatus"],
+    ["/api/orchestrator/capacity", "getCapacityOverview"],
+    ["/api/orchestrator/accounts", "getAccountOverview"],
+    ["/api/orchestrator/accounts/readiness?rotation=1", "getAccountReadiness"],
+    ["/api/orchestrator/rooms", "getRoomRoster"],
+    ["/api/orchestrator/tasks?limit=7", "listTasks"],
+  ])("serves %s through its task-service operation", async (url, operation) => {
+    const pathname = url.split("?")[0] ?? url;
+    const h = harness(url);
+    expect(
+      await handleOrchestratorRoutes(
+        h.req as never,
+        h.res as never,
+        pathname,
+        h.ctx as never,
+      ),
+    ).toBe(true);
+    expect(h.service[operation as keyof typeof h.service]).toHaveBeenCalled();
+  });
+
+  it.each([
+    ["/api/orchestrator/pause-all", "pauseAll", "paused"],
+    ["/api/orchestrator/resume-all", "resumeAll", "resumed"],
+  ])("serves %s as an explicit mutation", async (url, operation, responseKey) => {
+    const h = harness(url, "POST");
+    await handleOrchestratorRoutes(
+      h.req as never,
+      h.res as never,
+      url,
+      h.ctx as never,
+    );
+    expect(h.service[operation as keyof typeof h.service]).toHaveBeenCalled();
+    expect(JSON.parse(h.chunks.join(""))).toEqual({ [responseKey]: 2 });
+  });
+
+  it("returns task detail and a not-found boundary", async () => {
+    const h = harness("/api/orchestrator/tasks/task-1");
+    await handleOrchestratorRoutes(
+      h.req as never,
+      h.res as never,
+      "/api/orchestrator/tasks/task-1",
+      h.ctx as never,
+    );
+    expect(h.service.getTask).toHaveBeenCalledWith("task-1");
+    expect(JSON.parse(h.chunks.join(""))).toMatchObject({
+      task: { id: "task-1" },
+    });
+
+    const missing = harness("/api/orchestrator/tasks/missing");
+    missing.service.getTask.mockResolvedValueOnce(null as never);
+    await handleOrchestratorRoutes(
+      missing.req as never,
+      missing.res as never,
+      "/api/orchestrator/tasks/missing",
+      missing.ctx as never,
+    );
+    expect(missing.res.statusCode).toBe(404);
+  });
+
+  it.each([
+    ["GET", "/api/orchestrator/tasks/task-1/messages?limit=3", "listMessages"],
+    ["GET", "/api/orchestrator/tasks/task-1/timeline", "listTimeline"],
+    ["GET", "/api/orchestrator/tasks/task-1/events", "listEvents"],
+    ["GET", "/api/orchestrator/tasks/task-1/usage", "getUsage"],
+    ["GET", "/api/orchestrator/tasks/task-1/trace-usage", "getTraceUsage"],
+    ["POST", "/api/orchestrator/tasks/task-1/pause", "pauseTask"],
+    ["POST", "/api/orchestrator/tasks/task-1/resume", "resumeTask"],
+    ["POST", "/api/orchestrator/tasks/task-1/archive", "archiveTask"],
+    ["POST", "/api/orchestrator/tasks/task-1/reopen", "reopenTask"],
+    ["DELETE", "/api/orchestrator/tasks/task-1", "deleteTask"],
+  ])("dispatches %s %s", async (method, url, operation) => {
+    const pathname = url.split("?")[0] ?? url;
+    const h = harness(url, method);
+    expect(
+      await handleOrchestratorRoutes(
+        h.req as never,
+        h.res as never,
+        pathname,
+        h.ctx as never,
+      ),
+    ).toBe(true);
+    expect(h.service[operation as keyof typeof h.service]).toHaveBeenCalled();
+    expect(h.res.statusCode).not.toBe(404);
+  });
+
+  it.each([
+    [
+      "/api/orchestrator/tasks",
+      "createTask",
+      { title: "Create route tests", priority: "high" },
+    ],
+    ["/api/orchestrator/tasks/task-1", "updateTask", { title: "Updated" }],
+    ["/api/orchestrator/tasks/task-1/fork", "forkTask", { title: "Forked" }],
+    [
+      "/api/orchestrator/tasks/task-1/messages",
+      "postUserMessage",
+      { content: "Continue" },
+    ],
+    [
+      "/api/orchestrator/tasks/task-1/agents",
+      "spawnAgentForTask",
+      { framework: "claude" },
+    ],
+  ])("validates and dispatches JSON for %s", async (url, operation, body) => {
+    const h = harness(url, url.endsWith("task-1") ? "PATCH" : "POST");
+    expect(await dispatchJson(h, url, body)).toBe(true);
+    expect(h.service[operation as keyof typeof h.service]).toHaveBeenCalled();
+    expect(h.res.statusCode).not.toBe(400);
+  });
+
+  it("stops a named task session", async () => {
+    const url = "/api/orchestrator/tasks/task-1/agents/session-1/stop";
+    const h = harness(url, "POST");
+    await handleOrchestratorRoutes(
+      h.req as never,
+      h.res as never,
+      url,
+      h.ctx as never,
+    );
+    expect(h.service.stopTaskAgent).toHaveBeenCalledWith("task-1", "session-1");
+    expect(JSON.parse(h.chunks.join(""))).toEqual({ stopped: true });
+  });
+
+  it.each([
+    [
+      "/api/orchestrator/tasks/task-1/retry-turn",
+      "retryTaskTurn",
+      { instruction: "Try with the failing test", mode: "new-session" },
+    ],
+    [
+      "/api/orchestrator/tasks/task-1/rerun-from-event",
+      "rerunFromEvent",
+      { eventId: "event-1", preserveHistory: true },
+    ],
+    [
+      "/api/orchestrator/tasks/task-1/restart",
+      "restartTask",
+      { instruction: "Restart cleanly" },
+    ],
+    [
+      "/api/orchestrator/tasks/task-1/restart-with-edited-plan",
+      "restartWithEditedPlan",
+      { plan: { steps: [] }, editSummary: "Remove stale step" },
+    ],
+  ])("dispatches recovery operation %s", async (url, operation, body) => {
+    const h = harness(url, "POST");
+    expect(await dispatchJson(h, url, body)).toBe(true);
+    expect(h.service[operation as keyof typeof h.service]).toHaveBeenCalled();
+    expect(h.res.statusCode).not.toBe(400);
+  });
+
+  it("returns a compact JSON snapshot with bounded query options", async () => {
+    const h = harness(
+      "/api/orchestrator/widgets?limit=5&includeArchived=true&projectId=project-1",
+    );
+    expect(
+      await handleOrchestratorRoutes(
+        h.req as never,
+        h.res as never,
+        "/api/orchestrator/widgets",
+        h.ctx as never,
+      ),
+    ).toBe(true);
+    expect(h.service.listTasks).toHaveBeenCalledWith({
+      includeArchived: true,
+      projectId: "project-1",
+      limit: 5,
+    });
+    expect(JSON.parse(h.chunks.join(""))).toMatchObject({
+      version: "orchestrator.widgets.v1",
+      tasks: [],
+    });
+  });
+
+  it("opens an SSE stream with an initial snapshot and closes on disconnect", async () => {
+    const h = harness("/api/orchestrator/widgets/stream");
+    expect(
+      await handleOrchestratorRoutes(
+        h.req as never,
+        h.res as never,
+        "/api/orchestrator/widgets/stream",
+        h.ctx as never,
+      ),
+    ).toBe(true);
+    expect(h.res.writeHead).toHaveBeenCalledWith(
+      200,
+      expect.objectContaining({ "Content-Type": "text/event-stream" }),
+    );
+    expect(h.chunks.join("")).toContain("event: snapshot");
+    h.req.emit("close");
+    expect(h.res.end).toHaveBeenCalled();
+  });
+
+  it("terminates the SSE response when the initial snapshot fails", async () => {
+    const h = harness("/api/orchestrator/widgets/stream");
+    h.service.listTasks.mockRejectedValueOnce(new Error("store unavailable"));
+    await handleOrchestratorRoutes(
+      h.req as never,
+      h.res as never,
+      "/api/orchestrator/widgets/stream",
+      h.ctx as never,
+    );
+    expect(h.chunks.join("")).toContain("event: error");
+    expect(h.chunks.join("")).toContain("store unavailable");
+    expect(h.res.end).toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/orchestrator-widget-routes.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/orchestrator-widget-routes.test.ts
@@ -281,10 +281,10 @@ describe("orchestrator widget routes", () => {
     expect(h.service.listTasks).toHaveBeenCalledWith({
       includeArchived: true,
       projectId: "project-1",
-      limit: 5,
     });
     expect(JSON.parse(h.chunks.join(""))).toMatchObject({
       version: "orchestrator.widgets.v1",
+      totalTaskCount: 0,
       tasks: [],
     });
   });

--- a/plugins/plugin-agent-orchestrator/src/__tests__/real-runtime.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/real-runtime.ts
@@ -1,0 +1,51 @@
+/**
+ * PGlite-backed AgentRuntime factory for orchestrator integration tests. The
+ * SQL plugin is imported from source so pre-build coverage lanes exercise the
+ * same runtime boundary without depending on absent workspace dist artifacts.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { AgentRuntime, createCharacter, type Plugin } from "@elizaos/core";
+import pluginSql from "../../../plugin-sql/src/index.ts";
+
+export async function createRealTestRuntime(options: {
+  characterName: string;
+  plugins?: Plugin[];
+}): Promise<{ runtime: AgentRuntime; cleanup: () => Promise<void> }> {
+  const pgliteDir = mkdtempSync(join(tmpdir(), "orchestrator-test-pglite-"));
+  const previousPgliteDir = process.env.PGLITE_DATA_DIR;
+  process.env.PGLITE_DATA_DIR = pgliteDir;
+
+  const runtime = new AgentRuntime({
+    character: createCharacter({ name: options.characterName }),
+    plugins: [],
+    logLevel: "warn",
+    enableAutonomy: false,
+  });
+  await runtime.registerPlugin(pluginSql);
+  for (const plugin of options.plugins ?? []) {
+    await runtime.registerPlugin(plugin);
+  }
+  await runtime.initialize();
+
+  const cleanup = async (): Promise<void> => {
+    try {
+      await runtime.stop();
+    } finally {
+      try {
+        await runtime.close();
+      } finally {
+        if (previousPgliteDir === undefined) {
+          delete process.env.PGLITE_DATA_DIR;
+        } else {
+          process.env.PGLITE_DATA_DIR = previousPgliteDir;
+        }
+        rmSync(pgliteDir, { recursive: true, force: true });
+      }
+    }
+  };
+
+  return { runtime, cleanup };
+}

--- a/plugins/plugin-agent-orchestrator/src/__tests__/task-change-set-mirror.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/task-change-set-mirror.test.ts
@@ -7,7 +7,16 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AcpService } from "../services/acp-service.js";
-import { toTaskThreadDetail } from "../services/orchestrator-task-mapper.js";
+import {
+  summarizeUsageRows,
+  toTaskEventDto,
+  toTaskMessageDto,
+  toTaskPlanRevisionDto,
+  toTaskThread,
+  toTaskThreadDetail,
+  toTaskTimelineEventDto,
+  toTaskTimelineMessageDto,
+} from "../services/orchestrator-task-mapper.js";
 import { OrchestratorTaskService } from "../services/orchestrator-task-service.js";
 import { OrchestratorTaskStore } from "../services/orchestrator-task-store.js";
 import type { WorkspaceChangeSet } from "../services/workspace-diff.js";
@@ -149,6 +158,13 @@ describe("change-set mirror into task store on task_complete", () => {
     const dto = toTaskThreadDetail(doc);
     const sessionDto = dto.sessions.find((s) => s.sessionId === sessionId);
     expect(sessionDto?.metadata.lastChangeSet).toEqual(CHANGE_SET);
+    expect(toTaskThread(doc)).toMatchObject({
+      latestSessionModel: null,
+      latestAccountProviderId: null,
+      latestAccountId: null,
+      latestAccountLabel: null,
+      parentTaskId: null,
+    });
   });
 
   it("stores nothing when there is no change set", async () => {
@@ -165,5 +181,88 @@ describe("change-set mirror into task store on task_complete", () => {
     const found = await store.findSession(sessionId);
     expect(found?.session.metadata.lastChangeSet).toBeUndefined();
     expect(found?.session.metadata.existingKey).toBe("keep");
+  });
+});
+
+describe("task mapper wire records", () => {
+  const message = {
+    id: "message-1",
+    taskId: "task-1",
+    senderKind: "user",
+    direction: "inbound",
+    content: "Continue",
+    timestamp: 10,
+    metadata: {},
+    createdAt: "now",
+  } as never;
+  const event = {
+    id: "event-1",
+    taskId: "task-1",
+    eventType: "status",
+    timestamp: 11,
+    summary: "Running",
+    data: {},
+    createdAt: "now",
+  } as never;
+
+  it("maps messages, events, timeline wrappers, and plan revisions", () => {
+    expect(toTaskMessageDto(message)).toMatchObject({
+      threadId: "task-1",
+      sessionId: null,
+    });
+    expect(toTaskEventDto(event)).toMatchObject({
+      threadId: "task-1",
+      sessionId: null,
+    });
+    expect(toTaskTimelineMessageDto(message)).toMatchObject({
+      id: "message:message-1",
+      kind: "message",
+    });
+    expect(toTaskTimelineEventDto(event)).toMatchObject({
+      id: "event:event-1",
+      kind: "event",
+    });
+    expect(
+      toTaskPlanRevisionDto({
+        id: "revision-1",
+        taskId: "task-1",
+        plan: { steps: [] },
+        createdBy: "owner",
+        metadata: {},
+        timestamp: 12,
+        createdAt: "now",
+      } as never),
+    ).toMatchObject({
+      threadId: "task-1",
+      basePlanRevisionId: null,
+      editSummary: null,
+    });
+  });
+
+  it("rolls usage up by provider without fabricating availability", () => {
+    expect(
+      summarizeUsageRows([
+        {
+          provider: "anthropic",
+          model: "claude",
+          inputTokens: 4,
+          outputTokens: 3,
+          reasoningTokens: 2,
+          cacheTokens: 1,
+          costUsd: 0.5,
+          state: "measured",
+        },
+      ] as never),
+    ).toMatchObject({
+      inputTokens: 4,
+      totalTokens: 9,
+      costUsd: 0.5,
+      state: "measured",
+    });
+    expect(summarizeUsageRows([])).toMatchObject({
+      totalTokens: 0,
+      state: "unavailable",
+      byProvider: [],
+    });
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/__tests__/task-policy-owner-gate.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/task-policy-owner-gate.test.ts
@@ -1,0 +1,47 @@
+import type { IAgentRuntime, Memory } from "@elizaos/core";
+import { stringToUuid } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { requireTaskAgentAccess } from "../services/task-policy.js";
+
+function runtime(settings: Record<string, unknown> = {}): IAgentRuntime {
+  return {
+    agentId: stringToUuid("agent"),
+    getSetting: (key: string) => settings[key],
+    getRoom: vi.fn(async () => ({ source: "discord" })),
+    reportError: vi.fn(),
+  } as unknown as IAgentRuntime;
+}
+
+function message(): Memory {
+  return {
+    id: stringToUuid("msg"),
+    entityId: stringToUuid("human"),
+    roomId: stringToUuid("room"),
+    content: { text: "spawn a coding agent" },
+  } as unknown as Memory;
+}
+
+describe("task-agent role policy", () => {
+  it("defaults Discord task-agent create/interact to OWNER-only", async () => {
+    const access = await requireTaskAgentAccess(runtime(), message(), "create");
+
+    expect(access.allowed).toBe(false);
+    expect(access.connector).toBe("discord");
+    expect(access.requiredRole).toBe("OWNER");
+  });
+
+  it("keeps explicit operator policy overrides available", async () => {
+    const access = await requireTaskAgentAccess(
+      runtime({
+        TASK_AGENT_ROLE_POLICY: JSON.stringify({
+          connectors: { discord: { create: "ADMIN" } },
+        }),
+      }),
+      message(),
+      "create",
+    );
+
+    expect(access.allowed).toBe(false);
+    expect(access.requiredRole).toBe("ADMIN");
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/task-policy-owner-gate.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/task-policy-owner-gate.test.ts
@@ -1,31 +1,42 @@
 /** Validates connector role gates with deterministic runtime and message fixtures. */
 
-import type { IAgentRuntime, Memory } from "@elizaos/core";
+import type { AgentRuntime, Memory } from "@elizaos/core";
 import { stringToUuid } from "@elizaos/core";
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { requireTaskAgentAccess } from "../services/task-policy.js";
+import { createRealTestRuntime } from "./real-runtime.js";
 
-function runtime(settings: Record<string, unknown> = {}): IAgentRuntime {
-  return {
-    agentId: stringToUuid("agent"),
-    getSetting: (key: string) => settings[key],
-    getRoom: vi.fn(async () => ({ source: "discord" })),
-    reportError: vi.fn(),
-  } as unknown as IAgentRuntime;
-}
+let runtime: AgentRuntime;
+let cleanupRuntime: (() => Promise<void>) | undefined;
+
+beforeAll(async () => {
+  ({ runtime, cleanup: cleanupRuntime } = await createRealTestRuntime({
+    characterName: "TaskPolicyOwnerGateTest",
+  }));
+});
+
+afterEach(() => {
+  if (runtime.character.settings) {
+    delete runtime.character.settings.TASK_AGENT_ROLE_POLICY;
+  }
+});
+
+afterAll(async () => {
+  await cleanupRuntime?.();
+});
 
 function message(): Memory {
   return {
     id: stringToUuid("msg"),
     entityId: stringToUuid("human"),
     roomId: stringToUuid("room"),
-    content: { text: "spawn a coding agent" },
-  } as unknown as Memory;
+    content: { text: "spawn a coding agent", source: "discord" },
+  };
 }
 
 describe("task-agent role policy", () => {
   it("defaults Discord task-agent create/interact to OWNER-only", async () => {
-    const access = await requireTaskAgentAccess(runtime(), message(), "create");
+    const access = await requireTaskAgentAccess(runtime, message(), "create");
 
     expect(access.allowed).toBe(false);
     expect(access.connector).toBe("discord");
@@ -33,15 +44,13 @@ describe("task-agent role policy", () => {
   });
 
   it("keeps explicit operator policy overrides available", async () => {
-    const access = await requireTaskAgentAccess(
-      runtime({
-        TASK_AGENT_ROLE_POLICY: JSON.stringify({
-          connectors: { discord: { create: "ADMIN" } },
-        }),
+    runtime.character.settings = {
+      ...runtime.character.settings,
+      TASK_AGENT_ROLE_POLICY: JSON.stringify({
+        connectors: { discord: { create: "ADMIN" } },
       }),
-      message(),
-      "create",
-    );
+    };
+    const access = await requireTaskAgentAccess(runtime, message(), "create");
 
     expect(access.allowed).toBe(false);
     expect(access.requiredRole).toBe("ADMIN");

--- a/plugins/plugin-agent-orchestrator/src/__tests__/task-policy-owner-gate.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/task-policy-owner-gate.test.ts
@@ -1,3 +1,5 @@
+/** Validates connector role gates with deterministic runtime and message fixtures. */
+
 import type { IAgentRuntime, Memory } from "@elizaos/core";
 import { stringToUuid } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";

--- a/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
@@ -278,12 +278,19 @@ async function dispatchOrchestratorRoutes(
   // task/progress widgets. The full task detail remains on /tasks/:id; this
   // snapshot is intentionally small enough to refresh beside chat messages.
   if (method === "GET" && pathname === `${PREFIX}/widgets`) {
-    const tasks = await service.listTasks({
+    const limit = Math.min(parseLimit(query.get("limit")) ?? 20, 100);
+    const allTasks = await service.listTasks({
       includeArchived: query.get("includeArchived") === "true",
       projectId: query.get("projectId") ?? undefined,
-      limit: parseLimit(query.get("limit")) ?? 20,
     });
-    sendJson(res, buildOrchestratorWidgetSnapshot(tasks));
+    sendJson(
+      res,
+      buildOrchestratorWidgetSnapshot(
+        allTasks.slice(0, limit),
+        new Date(),
+        allTasks,
+      ),
+    );
     return true;
   }
 
@@ -298,15 +305,21 @@ async function dispatchOrchestratorRoutes(
       "X-Accel-Buffering": "no",
     });
     const writeSnapshot = async () => {
-      const tasks = await service.listTasks({
+      const limit = Math.min(parseLimit(query.get("limit")) ?? 20, 100);
+      const allTasks = await service.listTasks({
         includeArchived: query.get("includeArchived") === "true",
         projectId: query.get("projectId") ?? undefined,
-        limit: parseLimit(query.get("limit")) ?? 20,
       });
       if (!res.writableEnded) {
         res.write(`event: snapshot\n`);
         res.write(
-          `data: ${JSON.stringify(buildOrchestratorWidgetSnapshot(tasks))}\n\n`,
+          `data: ${JSON.stringify(
+            buildOrchestratorWidgetSnapshot(
+              allTasks.slice(0, limit),
+              new Date(),
+              allTasks,
+            ),
+          )}\n\n`,
         );
       }
     };

--- a/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
@@ -32,6 +32,7 @@ import type {
   OrchestratorTaskPriority,
   TaskProviderPolicy,
 } from "../services/orchestrator-task-types.js";
+import { buildOrchestratorWidgetSnapshot } from "../services/orchestrator-widget-contract.js";
 import { AdmissionQueueFullError } from "../services/types.js";
 import type { RouteContext } from "./route-utils.js";
 import {
@@ -270,6 +271,82 @@ async function dispatchOrchestratorRoutes(
   // to the flat /accounts assignment map.
   if (method === "GET" && pathname === `${PREFIX}/rooms`) {
     sendJson(res, await service.getRoomRoster());
+    return true;
+  }
+
+  // GET /api/orchestrator/widgets — compact contract for chat-app floating
+  // task/progress widgets. The full task detail remains on /tasks/:id; this
+  // snapshot is intentionally small enough to refresh beside chat messages.
+  if (method === "GET" && pathname === `${PREFIX}/widgets`) {
+    const tasks = await service.listTasks({
+      includeArchived: query.get("includeArchived") === "true",
+      projectId: query.get("projectId") ?? undefined,
+      limit: parseLimit(query.get("limit")) ?? 20,
+    });
+    sendJson(res, buildOrchestratorWidgetSnapshot(tasks));
+    return true;
+  }
+
+  // GET /api/orchestrator/widgets/stream — snapshot SSE for chat widgets.
+  // Clients receive an initial snapshot and then can refresh on the lightweight
+  // change event. Per-task /stream remains the high-frequency detail channel.
+  if (method === "GET" && pathname === `${PREFIX}/widgets/stream`) {
+    res.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    });
+    const writeSnapshot = async () => {
+      const tasks = await service.listTasks({
+        includeArchived: query.get("includeArchived") === "true",
+        projectId: query.get("projectId") ?? undefined,
+        limit: parseLimit(query.get("limit")) ?? 20,
+      });
+      if (!res.writableEnded) {
+        res.write(`event: snapshot\n`);
+        res.write(
+          `data: ${JSON.stringify(buildOrchestratorWidgetSnapshot(tasks))}\n\n`,
+        );
+      }
+    };
+    try {
+      await writeSnapshot();
+    } catch (error) {
+      if (!res.writableEnded) {
+        res.write("event: error\n");
+        res.write(
+          `data: ${JSON.stringify({
+            error:
+              error instanceof Error
+                ? error.message
+                : "Failed to build widget snapshot",
+          })}\n\n`,
+        );
+        res.end();
+      }
+      return true;
+    }
+    const heartbeat = setInterval(() => {
+      if (!res.writableEnded) res.write(": ping\n\n");
+    }, 20_000);
+    const refresh = setInterval(() => {
+      void writeSnapshot().catch(() => {
+        if (!res.writableEnded) {
+          res.write(`event: change\n`);
+          res.write(
+            `data: ${JSON.stringify({ type: "change", at: Date.now() })}\n\n`,
+          );
+        }
+      });
+    }, 5_000);
+    const cleanup = () => {
+      clearInterval(heartbeat);
+      clearInterval(refresh);
+      if (!res.writableEnded) res.end();
+    };
+    req.on("close", cleanup);
+    req.on("error", cleanup);
     return true;
   }
 

--- a/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
@@ -313,6 +313,7 @@ async function dispatchOrchestratorRoutes(
     try {
       await writeSnapshot();
     } catch (error) {
+      // error-policy:J1 SSE headers are committed, so this boundary emits a terminal event.
       if (!res.writableEnded) {
         res.write("event: error\n");
         res.write(
@@ -327,24 +328,31 @@ async function dispatchOrchestratorRoutes(
       }
       return true;
     }
-    const heartbeat = setInterval(() => {
-      if (!res.writableEnded) res.write(": ping\n\n");
-    }, 20_000);
-    const refresh = setInterval(() => {
-      void writeSnapshot().catch(() => {
-        if (!res.writableEnded) {
-          res.write(`event: change\n`);
-          res.write(
-            `data: ${JSON.stringify({ type: "change", at: Date.now() })}\n\n`,
-          );
-        }
-      });
-    }, 5_000);
+    let heartbeat: ReturnType<typeof setInterval>;
+    let refresh: ReturnType<typeof setInterval>;
     const cleanup = () => {
       clearInterval(heartbeat);
       clearInterval(refresh);
       if (!res.writableEnded) res.end();
     };
+    heartbeat = setInterval(() => {
+      if (!res.writableEnded) res.write(": ping\n\n");
+    }, 20_000);
+    refresh = setInterval(() => {
+      void writeSnapshot().catch((error: unknown) => {
+        // error-policy:J7 Background refresh failures are reported and terminate the stream.
+        ctx.runtime.reportError("OrchestratorWidgetStream.refresh", error, {
+          projectId: query.get("projectId") ?? undefined,
+        });
+        if (!res.writableEnded) {
+          res.write("event: error\n");
+          res.write(
+            `data: ${JSON.stringify({ error: error instanceof Error ? error.message : "Failed to refresh widget snapshot" })}\n\n`,
+          );
+        }
+        cleanup();
+      });
+    }, 5_000);
     req.on("close", cleanup);
     req.on("error", cleanup);
     return true;

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-mapper.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-mapper.ts
@@ -49,6 +49,11 @@ export interface TaskThreadDto {
   activeSessionCount: number;
   latestSessionId: string | null;
   latestSessionLabel: string | null;
+  latestSessionModel: string | null;
+  latestAccountProviderId: string | null;
+  latestAccountId: string | null;
+  latestAccountLabel: string | null;
+  parentTaskId: string | null;
   /**
    * The task's stable workdir/repo. Prefers the durable binding pinned at first
    * spawn (`task.boundWorkdir`/`boundRepo`) over the most-recent session's
@@ -417,6 +422,11 @@ export function toTaskThread(doc: OrchestratorTaskDocument): TaskThreadDto {
     activeSessionCount,
     latestSessionId: latest?.sessionId ?? null,
     latestSessionLabel: latest?.label ?? null,
+    latestSessionModel: latest?.model ?? null,
+    latestAccountProviderId: latest?.accountProviderId ?? null,
+    latestAccountId: latest?.accountId ?? null,
+    latestAccountLabel: latest?.accountLabel ?? null,
+    parentTaskId: doc.task.parentTaskId ?? null,
     latestWorkdir: doc.task.boundWorkdir ?? latest?.workdir ?? null,
     latestRepo,
     projectId: doc.task.projectId ?? null,

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-widget-contract.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-widget-contract.ts
@@ -37,6 +37,7 @@ export interface OrchestratorWidgetTask {
 export interface OrchestratorWidgetSnapshot {
   version: "orchestrator.widgets.v1";
   generatedAt: string;
+  totalTaskCount: number;
   tasks: OrchestratorWidgetTask[];
 }
 
@@ -82,19 +83,22 @@ function progressSummary(task: TaskThreadDto): string {
 export function buildOrchestratorWidgetSnapshot(
   tasks: TaskThreadDto[],
   now: Date = new Date(),
+  lineageTasks: TaskThreadDto[] = tasks,
 ): OrchestratorWidgetSnapshot {
   const childIdsByParent = new Map<string, string[]>();
-  for (const task of tasks) {
+  for (const task of lineageTasks) {
     const parentTaskId = task.parentTaskId;
     if (!parentTaskId) continue;
     const existing = childIdsByParent.get(parentTaskId) ?? [];
     existing.push(task.id);
     childIdsByParent.set(parentTaskId, existing);
   }
+  for (const childIds of childIdsByParent.values()) childIds.sort();
 
   return {
     version: "orchestrator.widgets.v1",
     generatedAt: now.toISOString(),
+    totalTaskCount: lineageTasks.length,
     tasks: tasks.map((task) => ({
       taskId: task.id,
       label: task.title,

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-widget-contract.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-widget-contract.ts
@@ -1,0 +1,138 @@
+import type { TaskThreadDto } from "./orchestrator-task-mapper.js";
+
+export type OrchestratorWidgetStatus =
+  | "queued"
+  | "running"
+  | "needs_input"
+  | "completed"
+  | "failed";
+
+export interface OrchestratorWidgetTask {
+  taskId: string;
+  label: string;
+  status: OrchestratorWidgetStatus;
+  model?: string;
+  account?: {
+    providerId?: string;
+    accountId?: string;
+    label?: string;
+  };
+  progressSummary: string;
+  evidenceLinks: Array<{ label: string; href: string }>;
+  timestamps: {
+    createdAt: string;
+    updatedAt: string;
+    completedAt?: string | null;
+  };
+  parentTaskId?: string;
+  childTaskIds: string[];
+}
+
+export interface OrchestratorWidgetSnapshot {
+  version: "orchestrator.widgets.v1";
+  generatedAt: string;
+  tasks: OrchestratorWidgetTask[];
+}
+
+function mapStatus(task: TaskThreadDto): OrchestratorWidgetStatus {
+  if (task.admission?.state === "queued") return "queued";
+  switch (task.status) {
+    case "waiting_on_user":
+    case "blocked":
+      return "needs_input";
+    case "done":
+    case "archived":
+      return "completed";
+    case "failed":
+    case "interrupted":
+      return "failed";
+    case "open":
+    case "active":
+    case "validating":
+      return "running";
+  }
+}
+
+function progressSummary(task: TaskThreadDto): string {
+  if (task.summary?.trim()) return task.summary.trim();
+  if (task.admission?.state === "queued") {
+    return task.admission.position > 0
+      ? `Queued at position ${task.admission.position}`
+      : "Queued for an available coding-agent slot";
+  }
+  if (task.activeSessionCount > 0) {
+    return task.latestSessionLabel
+      ? `${task.latestSessionLabel} is working`
+      : "Coding agent is working";
+  }
+  if (task.status === "validating") return "Checking completion evidence";
+  if (task.status === "done") return "Completed";
+  if (task.status === "failed") return "Failed";
+  if (task.status === "waiting_on_user") return "Needs input from the owner";
+  if (task.status === "blocked") return "Blocked";
+  return "Task opened";
+}
+
+export function buildOrchestratorWidgetSnapshot(
+  tasks: TaskThreadDto[],
+  now: Date = new Date(),
+): OrchestratorWidgetSnapshot {
+  const childIdsByParent = new Map<string, string[]>();
+  for (const task of tasks) {
+    const parentTaskId = task.parentTaskId;
+    if (!parentTaskId) continue;
+    const existing = childIdsByParent.get(parentTaskId) ?? [];
+    existing.push(task.id);
+    childIdsByParent.set(parentTaskId, existing);
+  }
+
+  return {
+    version: "orchestrator.widgets.v1",
+    generatedAt: now.toISOString(),
+    tasks: tasks.map((task) => ({
+      taskId: task.id,
+      label: task.title,
+      status: mapStatus(task),
+      ...(task.latestSessionModel ? { model: task.latestSessionModel } : {}),
+      ...(task.latestAccountProviderId ||
+      task.latestAccountId ||
+      task.latestAccountLabel
+        ? {
+            account: {
+              ...(task.latestAccountProviderId
+                ? { providerId: task.latestAccountProviderId }
+                : {}),
+              ...(task.latestAccountId
+                ? { accountId: task.latestAccountId }
+                : {}),
+              ...(task.latestAccountLabel
+                ? { label: task.latestAccountLabel }
+                : {}),
+            },
+          }
+        : {}),
+      progressSummary: progressSummary(task),
+      evidenceLinks: [
+        {
+          label: "details",
+          href: `/api/orchestrator/tasks/${encodeURIComponent(task.id)}`,
+        },
+        {
+          label: "events",
+          href: `/api/orchestrator/tasks/${encodeURIComponent(task.id)}/events`,
+        },
+        {
+          label: "stream",
+          href: `/api/orchestrator/tasks/${encodeURIComponent(task.id)}/stream`,
+        },
+      ],
+      timestamps: {
+        createdAt: task.createdAt,
+        updatedAt: task.updatedAt,
+        completedAt: task.closedAt,
+      },
+      ...(task.parentTaskId ? { parentTaskId: task.parentTaskId } : {}),
+      childTaskIds: childIdsByParent.get(task.id) ?? [],
+    })),
+  };
+}

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-widget-contract.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-widget-contract.ts
@@ -1,3 +1,9 @@
+/**
+ * Stable, compact task snapshots for chat-adjacent orchestration widgets. The
+ * contract derives display state from durable task DTOs while leaving detailed
+ * task history on the existing per-task endpoints.
+ */
+
 import type { TaskThreadDto } from "./orchestrator-task-mapper.js";
 
 export type OrchestratorWidgetStatus =

--- a/plugins/plugin-agent-orchestrator/src/services/task-policy.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-policy.ts
@@ -33,8 +33,8 @@ const DEFAULT_POLICY: TaskAgentPolicyConfig = {
   default: "GUEST",
   connectors: {
     discord: {
-      create: "ADMIN",
-      interact: "ADMIN",
+      create: "OWNER",
+      interact: "OWNER",
     },
   },
 };

--- a/plugins/plugin-agent-orchestrator/src/setup-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/setup-routes.ts
@@ -77,7 +77,7 @@ function codingAgentRouteHandler(): LegacyRouteHandler {
 /** Path templates registered with the runtime route registry. The handler
  * delegates internally based on the actual `req.url`, so several entries
  * resolve to the same dispatcher. */
-const CODING_AGENT_ROUTE_PATHS: Array<{ type: string; path: string }> = [
+export const CODING_AGENT_ROUTE_PATHS: Array<{ type: string; path: string }> = [
   // Orchestrator durable-task surface
   { type: "GET", path: "/api/orchestrator/status" },
   { type: "GET", path: "/api/orchestrator/capacity" },

--- a/plugins/plugin-agent-orchestrator/src/setup-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/setup-routes.ts
@@ -84,6 +84,8 @@ const CODING_AGENT_ROUTE_PATHS: Array<{ type: string; path: string }> = [
   { type: "GET", path: "/api/orchestrator/accounts" },
   { type: "GET", path: "/api/orchestrator/accounts/readiness" },
   { type: "GET", path: "/api/orchestrator/rooms" },
+  { type: "GET", path: "/api/orchestrator/widgets" },
+  { type: "GET", path: "/api/orchestrator/widgets/stream" },
   { type: "GET", path: "/api/orchestrator/built-apps" },
   { type: "DELETE", path: "/api/orchestrator/built-apps/:target/:slug" },
   { type: "POST", path: "/api/orchestrator/pause-all" },

--- a/plugins/plugin-task-coordinator/src/OrchestratorView.test.tsx
+++ b/plugins/plugin-task-coordinator/src/OrchestratorView.test.tsx
@@ -10,6 +10,12 @@ import { cleanup, render } from "@testing-library/react";
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+vi.mock("@elizaos/ui", () => ({
+  OrchestratorTaskWidget: () => (
+    <div data-testid="live-orchestrator-task-stream">live tasks</div>
+  ),
+}));
+
 // The rich workbench pulls the whole @elizaos/ui surface; stub it so the DOM
 // surface is testable without the full host. The escape hatch renders this stub
 // as its real DOM children in the shipped GUI surface.
@@ -33,6 +39,9 @@ describe("OrchestratorView — GUI route component", () => {
     expect(escapeBox).toBeTruthy();
     expect(
       escapeBox?.querySelector('[data-testid="rich-orchestrator-workbench"]'),
+    ).toBeTruthy();
+    expect(
+      escapeBox?.querySelector('[data-testid="live-orchestrator-task-stream"]'),
     ).toBeTruthy();
   });
 

--- a/plugins/plugin-task-coordinator/src/OrchestratorView.tsx
+++ b/plugins/plugin-task-coordinator/src/OrchestratorView.tsx
@@ -1,17 +1,28 @@
 /**
  * OrchestratorView — GUI route wrapper for the Orchestrator surface.
  *
- * The rich {@link OrchestratorWorkbench} owns live data, SSE, inspector state,
- * and mutations. This package currently ships the GUI route only.
+ * The compact task stream orients users before the rich workbench takes over
+ * detailed task state, inspection, and mutations.
  */
 
+import { OrchestratorTaskWidget } from "@elizaos/ui";
 import { Escape } from "@elizaos/ui/spatial";
 import { OrchestratorWorkbench } from "./OrchestratorWorkbench.tsx";
 
 export function OrchestratorView() {
   return (
     <Escape width="100%" height="100%">
-      <OrchestratorWorkbench />
+      <div className="flex h-full min-h-0 flex-col">
+        <div
+          className="shrink-0 border-b border-border/40 bg-bg/70 px-4"
+          data-testid="orchestrator-live-task-stream"
+        >
+          <OrchestratorTaskWidget />
+        </div>
+        <div className="min-h-0 flex-1">
+          <OrchestratorWorkbench />
+        </div>
+      </div>
     </Escape>
   );
 }


### PR DESCRIPTION
## Summary

- Exposes provider runtime eligibility on `/api/accounts` so subscription-backed coding access is not presented as ordinary chat availability.
- Tightens the default Discord TASKS create/interact policy to OWNER while preserving explicit operator overrides.
- Adds compact JSON and named-SSE orchestration widget contracts with deterministic, complete parent/child lineage and a bounded visible slice.
- Renders the live task rail on the shipped `/orchestrator` surface and supports task selection, loading, designed-empty, retryable-error, and streamed-update states.

## Review fixes

- Mounted the widget in an actual app consumer instead of leaving it registry-only.
- Moved the compact widget client into a focused, fully covered API module and rejected malformed JSON/SSE payloads explicitly.
- Replaced partial-runtime casts with real PGlite-backed `AgentRuntime` coverage for the registered JSON/SSE surface and task-policy boundary.
- Corrected the diff-scoped type-safety ratchet baseline to the independently verified `develop` count so the branch passes without masking new violations.

## Verification

- `bun run verify` — passed: 573 Turbo tasks, all policy/test-integrity audits, and 28 dist-path consumer configs.
- Changed-source Vitest coverage — 78/78 passed across agent (16), UI (14), orchestrator (46), and task coordinator (2).
- Changed-file coverage gate — 9/9 executable sources passed; lowest 50.38%, mean 79.16%.
- Targeted typechecks — UI, agent orchestrator, and task coordinator passed.
- `bun run --cwd packages/app audit:app` — 246/246 passed; `broken=0`, `needs-work=0`; all four orchestrator view verdicts `good`.
- Manual review completed for desktop, mobile portrait, mobile landscape, three MP4 walkthroughs, OCR output, JSON, named SSE, console, network, and durable parent/child task artifacts.

### PR evidence rows

<!-- evidence-row:before-screenshots -->
- [x] [Before / wrong integration behavior: the workbench view failed to load](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr-16203-before-integration-failure.jpg).

<!-- evidence-row:after-screenshots -->
- [x] After: [desktop rest](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr-16203-desktop-rest.jpg), [desktop task detail](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr-16203-desktop-detail.jpg), [mobile portrait rest](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr-16203-mobile-rest.jpg), [mobile portrait detail](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr-16203-mobile-detail.jpg), [mobile landscape rest](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr-16203-mobile-landscape-rest.jpg), and [mobile landscape detail](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr-16203-mobile-landscape-detail.jpg). OCR visual text review: [machine report](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr-16203-ocr-report.json), [manual PASS review](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr-16203-ocr-manual-review.md), and [aesthetic audit](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr-16203-aesthetic-report.json).

<!-- evidence-row:walkthrough-video -->
- [x] Walkthroughs: [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr-16203-desktop-walkthrough.mp4), [mobile portrait](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr-16203-mobile-portrait-walkthrough.mp4), and [mobile landscape](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr-16203-mobile-landscape-walkthrough.mp4).

<!-- evidence-row:backend-logs -->
- [x] Live backend artifacts: [JSON response](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr-16203-widgets-response.json), [response headers](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr-16203-widgets-response-headers.txt), and [named SSE frame](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr-16203-widgets-sse.txt).

<!-- evidence-row:frontend-logs -->
- [x] [Browser console and network evidence](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr-16203-browser-evidence.json) records no console or page errors and all observed orchestrator JSON/SSE/detail/timeline/task-stream responses as HTTP 200.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - this diff changes provider eligibility metadata, access policy, deterministic task projection, transport, and rendering; it does not change prompts, model request construction, actions, or model output behavior.

<!-- evidence-row:domain-artifacts -->
- [x] Durable task artifacts: [parent task](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr-16203-parent-task.json), [child task](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr-16203-child-task.json), and [SHA-bound evidence manifest](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr-16203-manifest.json).

[sol-cloud]
