### PR TITLE
fix(ci): align cloud deploy triggers

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -43,6 +43,7 @@ on:
       - "packages/cloud/sdk/**"
       - "packages/scripts/cloud/**"
       - "packages/app/**"
+      - "packages/app-core/**"
       - "packages/ui/**"
       - ".github/workflows/cloud-cf-deploy.yml"
   pull_request:
@@ -54,6 +55,7 @@ on:
       - "packages/cloud/sdk/**"
       - "packages/scripts/cloud/**"
       - "packages/app/**"
+      - "packages/app-core/**"
       - "packages/ui/**"
       - ".github/workflows/cloud-cf-deploy.yml"
   workflow_dispatch:
@@ -148,10 +150,8 @@ jobs:
     # migrate is a light `bun install` + `db:cloud:migrate`, not the heavy
     # working-tree materialization that motivated keeping deploys off-hosted.
     runs-on: ${{ fromJSON(vars.CLOUD_CF_MIGRATE_RUNNER_JSON || '["ubuntu-latest"]') }}
-    # Job-level concurrency groups are repo-wide, so this serializes against
-    # cloud-deploy-backend's migrate-db too: overlapping triggers (a develop
-    # push fires both workflows) can never run the migrator concurrently
-    # against the same database.
+    # Job-level concurrency groups are repo-wide, so this also serializes
+    # against an explicitly dispatched legacy cloud-deploy-backend migration.
     concurrency:
       group: cloud-db-migrate-${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging' }}
       cancel-in-progress: false

--- a/.github/workflows/cloud-deploy-backend.yml
+++ b/.github/workflows/cloud-deploy-backend.yml
@@ -1,16 +1,13 @@
 name: Cloud Deploy Backend
 
 # Source: cloud/.github/workflows/deploy-backend.yml in the original elizaOS/cloud repo.
+#
+# This is a manual-only legacy operations workflow. Canonical Cloudflare
+# Worker/Pages releases and their database migrations are owned by
+# cloud-cf-deploy.yml; dispatch this workflow only for an explicit standalone
+# migration or legacy VPS deployment.
 
 on:
-  push:
-    branches: [develop, main]
-    paths:
-      - '.github/workflows/cloud-deploy-backend.yml'
-      - 'packages/cloud/api/**'
-      - 'packages/cloud/shared/**'
-      - 'packages/cloud/services/**'
-      - 'packages/cloud/sdk/**'
   workflow_dispatch:
     inputs:
       environment:
@@ -49,25 +46,16 @@ jobs:
       - name: Set environment
         id: env
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "environment=${{ github.event.inputs.environment }}" >> $GITHUB_OUTPUT
-            echo "branch=${{ github.event.inputs.environment == 'production' && 'main' || 'develop' }}" >> $GITHUB_OUTPUT
-          elif [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            echo "environment=production" >> $GITHUB_OUTPUT
-            echo "branch=main" >> $GITHUB_OUTPUT
-          else
-            echo "environment=staging" >> $GITHUB_OUTPUT
-            echo "branch=develop" >> $GITHUB_OUTPUT
-          fi
+          echo "environment=${{ github.event.inputs.environment }}" >> $GITHUB_OUTPUT
+          echo "branch=${{ github.event.inputs.environment == 'production' && 'main' || 'develop' }}" >> $GITHUB_OUTPUT
 
   migrate-db:
     name: Run Database Migrations
     runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     needs: determine-env
-    # Job-level concurrency groups are repo-wide: this serializes against the
-    # migrate-db gate in cloud-cf-deploy.yml (#11208) so overlapping triggers
-    # (a develop push fires both workflows) never run the migrator
-    # concurrently against the same database.
+    # Job-level concurrency groups are repo-wide: this serializes an explicit
+    # legacy migration against the canonical migrate-db gate in
+    # cloud-cf-deploy.yml (#11208).
     concurrency:
       group: cloud-db-migrate-${{ needs.determine-env.outputs.environment }}
       cancel-in-progress: false

--- a/packages/scripts/__tests__/cloud-deploy-workflow-contract.test.ts
+++ b/packages/scripts/__tests__/cloud-deploy-workflow-contract.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const repoRoot = new URL("../../../", import.meta.url);
+
+interface WorkflowTrigger {
+  branches?: string[];
+  paths?: string[];
+  inputs?: Record<string, unknown>;
+}
+
+interface WorkflowJob {
+  if?: string;
+}
+
+interface Workflow {
+  on?: Record<string, WorkflowTrigger>;
+  jobs?: Record<string, WorkflowJob>;
+}
+
+function readWorkflow(name: string): Workflow {
+  const source = readFileSync(
+    new URL(`.github/workflows/${name}`, repoRoot),
+    "utf8",
+  );
+  return Bun.YAML.parse(source) as Workflow;
+}
+
+const canonical = readWorkflow("cloud-cf-deploy.yml");
+const legacy = readWorkflow("cloud-deploy-backend.yml");
+
+describe("Cloud deployment workflow trigger contract", () => {
+  test("canonical push and pull-request deploys cover app-core changes", () => {
+    const push = canonical.on?.push;
+    const pullRequest = canonical.on?.pull_request;
+
+    expect(push?.branches).toEqual(["main", "develop"]);
+    expect(pullRequest?.branches).toEqual(["main", "develop"]);
+    expect(push?.paths).toContain("packages/app/**");
+    expect(push?.paths).toContain("packages/app-core/**");
+    expect(pullRequest?.paths).toContain("packages/app/**");
+    expect(pullRequest?.paths).toContain("packages/app-core/**");
+  });
+
+  test("legacy backend deploys are manual-only and retain migration/VPS controls", () => {
+    expect(Object.keys(legacy.on ?? {}).sort()).toEqual(["workflow_dispatch"]);
+
+    const dispatch = legacy.on?.workflow_dispatch;
+    expect(dispatch?.inputs).toHaveProperty("environment");
+    expect(dispatch?.inputs).toHaveProperty("deploy_legacy_vps");
+    expect(legacy.jobs).toHaveProperty("migrate-db");
+    expect(legacy.jobs).toHaveProperty("deploy");
+    expect(legacy.jobs?.deploy?.if).toContain("inputs.deploy_legacy_vps");
+  });
+});


### PR DESCRIPTION
## What changed

- Include packages/app-core changes in canonical Cloudflare Worker/Pages push and PR triggers.
- Make the superseded Cloud Deploy Backend workflow manual-only while preserving explicit migrations and optional legacy VPS deploys.
- Add parsed-YAML contracts for both trigger boundaries.

## Root cause and impact

The app imports @elizaos/app-core, but app-core runtime changes did not trigger a Cloud Pages rebuild. Separately, both the canonical Cloudflare workflow and the legacy backend workflow auto-ran migrations for the same Cloud changes; production run 29187621231 remained waiting after the canonical deployment already succeeded.

Future app-core runtime changes now rebuild the deployed app, and normal develop/main pushes have one canonical migration/deploy owner. Manual legacy recovery remains available.

## Validation

- Focused workflow contract: 2 tests, 12 assertions.
- Biome clean.
- Actionlint clean for both workflows.
- git diff --check clean.
- Rebased exactly onto 66d2850f8ad04510239ad8758d1705ad6f5db57b with equivalent range-diff.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI workflow trigger fix; no rendered UI change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - CI workflow trigger fix; no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing interaction changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - parsed workflow contracts and Actionlint cover the changed automation.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain data or artifacts changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual change.
