### PR TITLE
fix(ci): classify agent operator command actions

### DIFF
--- a/packages/scenario-runner/src/__tests__/deterministic-action-coverage.test.ts
+++ b/packages/scenario-runner/src/__tests__/deterministic-action-coverage.test.ts
@@ -79,6 +79,8 @@ const CORE_ACTION_SURFACE: Record<string, readonly string[]> = {
   ],
   "@elizaos/plugin-coding-tools": ["FILE", "SHELL", "WORKTREE"],
   "@elizaos/plugin-commands": [
+    "ACCOUNTS_COMMAND",
+    "BACKEND_COMMAND",
     "COMMANDS_COMMAND",
     "COMPACT_COMMAND",
     "CONTEXT_COMMAND",
@@ -234,6 +236,8 @@ const KNOWN_UNCOVERED: readonly string[] = [
   // /compact, /think, /model, /tts, …) are dispatched through the command
   // palette, not the keyless scenario pipeline, so they have no deterministic
   // scenario yet.
+  "ACCOUNTS_COMMAND",
+  "BACKEND_COMMAND",
   "COMMANDS_COMMAND",
   "COMPACT_COMMAND",
   "CONTEXT_COMMAND",


### PR DESCRIPTION
## Summary

- Add the /accounts and /backend actions to the imported plugin-commands surface manifest.
- Classify both command-palette actions in the existing known-uncovered baseline.

## Root cause and impact

PR #16198 added ACCOUNTS_COMMAND and BACKEND_COMMAND, but the deterministic action coverage contract was not updated. The manifest drift assertion failed and cascaded through Server Tests, Scenario PR E2E preflight, and Windows framework tests.

This restores the action-surface contract without fabricating keyless scenario coverage for operator slash commands that are dispatched through the command palette.

## Validation

- Scenario-runner focused suite: 74 passed.
- Independent full deterministic-action-coverage file: 17 passed.
- Biome clean.
- git diff --check clean.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - deterministic test manifest only; no rendered UI change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - deterministic test manifest only; no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing interaction changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused scenario-runner contract tests are the executable evidence.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain data or artifacts changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual change.