### PR TITLE
fix(ci): fail closed when Hetzner reaper auth fails

### DIFF
--- a/packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-reaper.test.ts
+++ b/packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-reaper.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Fail-closed credential and cleanup contracts for the scheduled Hetzner E2E
+ * reaper, using the real client with only its HTTP boundary replaced.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { runHetznerE2eReaper } from "./hetzner-e2e-reaper";
+
+let originalFetch: typeof globalThis.fetch;
+let responseQueue: Response[];
+let requestedMethods: string[];
+let requestedUrls: string[];
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  responseQueue = [];
+  requestedMethods = [];
+  requestedUrls = [];
+  globalThis.fetch = mock(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      requestedMethods.push(init?.method ?? "GET");
+      requestedUrls.push(String(input));
+      const response = responseQueue.shift();
+      if (!response) {
+        throw new Error("No Hetzner response queued");
+      }
+      return response;
+    },
+  ) as typeof globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("Hetzner E2E reaper credential boundary", () => {
+  test("intentionally absent credentials remain a no-op", async () => {
+    await expect(runHetznerE2eReaper(undefined)).resolves.toBeUndefined();
+    expect(requestedMethods).toEqual([]);
+    expect(requestedUrls).toEqual([]);
+  });
+
+  test("a configured credential rejected by Hetzner fails the sweep", async () => {
+    responseQueue.push(
+      Response.json(
+        { error: { code: "unauthorized", message: "unauthorized" } },
+        { status: 401 },
+      ),
+    );
+
+    await expect(
+      runHetznerE2eReaper("rejected-ci-token"),
+    ).rejects.toMatchObject({
+      name: "HetznerCloudError",
+      code: "missing_token",
+      status: 401,
+    });
+    expect(requestedUrls).toHaveLength(1);
+    expect(requestedUrls[0]).toContain(
+      "/servers?label_selector=ci=true,workflow=hetzner-e2e",
+    );
+  });
+
+  test("a successful empty sweep remains a real success", async () => {
+    responseQueue.push(Response.json({ servers: [] }));
+
+    await expect(
+      runHetznerE2eReaper("valid-ci-token"),
+    ).resolves.toBeUndefined();
+    expect(requestedUrls).toHaveLength(1);
+  });
+
+  test("deletes a stale server through the real client", async () => {
+    responseQueue.push(
+      Response.json({
+        servers: [
+          {
+            id: 42,
+            name: "ci-hetzner-e2e-stale",
+            created: "2000-01-01T00:00:00.000Z",
+          },
+        ],
+      }),
+      new Response(null, { status: 204 }),
+    );
+
+    await expect(
+      runHetznerE2eReaper("valid-ci-token"),
+    ).resolves.toBeUndefined();
+    expect(requestedMethods).toEqual(["GET", "DELETE"]);
+    expect(requestedUrls[1]).toBe("https://api.hetzner.cloud/v1/servers/42");
+  });
+});

--- a/packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-reaper.test.ts
+++ b/packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-reaper.test.ts
@@ -90,4 +90,27 @@ describe("Hetzner E2E reaper credential boundary", () => {
     expect(requestedMethods).toEqual(["GET", "DELETE"]);
     expect(requestedUrls[1]).toBe("https://api.hetzner.cloud/v1/servers/42");
   });
+
+  test("continues the sweep but fails the process when any deletion fails", async () => {
+    responseQueue.push(
+      Response.json({
+        servers: [
+          { id: 42, name: "first", created: "2000-01-01T00:00:00.000Z" },
+          { id: 43, name: "second", created: "2000-01-01T00:00:00.000Z" },
+        ],
+      }),
+      Response.json(
+        { error: { code: "conflict", message: "server locked" } },
+        { status: 409 },
+      ),
+      new Response(null, { status: 204 }),
+    );
+
+    await expect(runHetznerE2eReaper("valid-ci-token")).rejects.toMatchObject({
+      name: "AggregateError",
+      message: "Hetzner E2E reaper failed to delete 1 stale server(s)",
+    });
+    expect(requestedMethods).toEqual(["GET", "DELETE", "DELETE"]);
+    expect(requestedUrls[2]).toBe("https://api.hetzner.cloud/v1/servers/43");
+  });
 });

--- a/packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-reaper.ts
+++ b/packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-reaper.ts
@@ -2,40 +2,26 @@
 /**
  * Sweep stale CI servers older than 60 minutes. Run on a schedule so a
  * crashed workflow can't leak servers indefinitely. Gracefully exits 0
- * when HCLOUD_TOKEN_CI is unset or rejected (so it doesn't spam-fail before
- * secrets are configured).
+ * when HCLOUD_TOKEN_CI is unset so the workflow can exist before its secret is
+ * configured. A configured token that Hetzner rejects must fail the sweep.
  */
 
-import {
-  HetznerCloudClient,
-  HetznerCloudError,
-} from "@elizaos/cloud-shared/lib/services/containers/hetzner-cloud-api";
+import { HetznerCloudClient } from "@elizaos/cloud-shared/lib/services/containers/hetzner-cloud-api";
 
 const MAX_AGE_MS = 60 * 60 * 1000;
 
-async function main(): Promise<void> {
-  const token = process.env.HCLOUD_TOKEN_CI;
+export async function runHetznerE2eReaper(
+  token: string | undefined,
+): Promise<void> {
   if (!token) {
     console.log("[hetzner-e2e-reaper] HCLOUD_TOKEN_CI not set; skipping");
     return;
   }
   const client = HetznerCloudClient.withToken(token);
-  let servers: Awaited<ReturnType<typeof client.listServers>>;
-  try {
-    servers = await client.listServers({
-      ci: "true",
-      workflow: "hetzner-e2e",
-    });
-  } catch (err) {
-    // error-policy:J4 Scheduled cleanup must not page on absent or revoked CI credentials.
-    if (err instanceof HetznerCloudError && err.code === "missing_token") {
-      console.warn(
-        "[hetzner-e2e-reaper] HCLOUD_TOKEN_CI rejected by Hetzner; skipping",
-      );
-      return;
-    }
-    throw err;
-  }
+  const servers = await client.listServers({
+    ci: "true",
+    workflow: "hetzner-e2e",
+  });
   const now = Date.now();
   let deleted = 0;
   for (const server of servers) {
@@ -62,4 +48,7 @@ async function main(): Promise<void> {
   );
 }
 
-await main();
+if (import.meta.main) {
+  // biome-ignore lint/suspicious/noUndeclaredEnvVars: GitHub Actions injects this standalone script secret; it is not a cached Turbo task input.
+  await runHetznerE2eReaper(Bun.env.HCLOUD_TOKEN_CI);
+}

--- a/packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-reaper.ts
+++ b/packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-reaper.ts
@@ -24,6 +24,7 @@ export async function runHetznerE2eReaper(
   });
   const now = Date.now();
   let deleted = 0;
+  const failures: Error[] = [];
   for (const server of servers) {
     const created = Date.parse(server.created);
     if (!Number.isFinite(created)) continue;
@@ -36,8 +37,13 @@ export async function runHetznerE2eReaper(
       await client.deleteServer(server.id);
       deleted++;
     } catch (err) {
-      // error-policy:J6 Best-effort cleanup keeps sweeping other stale servers.
+      // error-policy:J2 Preserve per-server context while completing the remaining sweep.
       const message = err instanceof Error ? err.message : String(err);
+      failures.push(
+        new Error(`Failed to delete Hetzner server ${server.id}: ${message}`, {
+          cause: err,
+        }),
+      );
       console.warn(
         `[hetzner-e2e-reaper] delete ${server.id} failed: ${message}`,
       );
@@ -46,6 +52,13 @@ export async function runHetznerE2eReaper(
   console.log(
     `[hetzner-e2e-reaper] swept ${deleted}/${servers.length} servers`,
   );
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures,
+      `Hetzner E2E reaper failed to delete ${failures.length} stale server(s)`,
+      { cause: failures[0] },
+    );
+  }
 }
 
 if (import.meta.main) {


### PR DESCRIPTION
## What changed

- Keep an absent HCLOUD_TOKEN_CI as an intentional no-op.
- Propagate Hetzner rejection of a configured token so the scheduled cleanup job fails visibly.
- Make the reaper import-safe and add real-client behavioral tests with only HTTP mocked.

## Root cause and impact

Scheduled run 29215514441 reported success even though Hetzner returned HTTP 401 and no orphan cleanup ran. The script treated the client missing_token classification as equivalent to an unconfigured secret even after a real authenticated request had been attempted.

A revoked or wrong CI project credential can no longer silently disable infrastructure cleanup. Repositories that have not configured the optional token still avoid noisy failures.

## Validation

- 4 focused tests passed.
- Changed-file coverage 86.84 percent.
- Biome clean.
- Error-policy ratchet clean.
- git diff --check clean.
- CLI smoke: absent token exits 0; rejected configured token exits 1 with typed HTTP 401 error.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - scheduled infrastructure cleanup fix; no rendered UI change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - scheduled infrastructure cleanup fix; no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing interaction changed.
<!-- evidence-row:backend-logs -->
- [x] Real Hetzner API + CLI exit evidence: https://github.com/elizaOS/eliza/releases/download/pr-evidence/16209-live-cli-smoke.json
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Sanitized process-status artifact (absent token exit 0; rejected configured token exit 1): https://github.com/elizaOS/eliza/releases/download/pr-evidence/16209-live-cli-smoke.json
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual change.

## Independent reviewer evidence

Manual review found that per-server deletion failures were still swallowed, allowing a partially failed cleanup to report success. The sweep now continues deleting remaining stale servers, aggregates each contextual failure, and exits nonzero afterward. Five focused tests pass, including partial failure. A live request using a deliberately invalid non-secret token reached `api.hetzner.cloud`, received the expected typed HTTP 401, and exited 1; the absent-token lane exited 0 without a request.
