### PR TITLE
test(discord): native-interaction sweep over the full catalog command surface

### DIFF
--- a/plugins/plugin-discord/__tests__/catalog-commands.test.ts
+++ b/plugins/plugin-discord/__tests__/catalog-commands.test.ts
@@ -4,7 +4,7 @@
  */
 import type { Content, IAgentRuntime, Memory } from "@elizaos/core";
 import { getConnectorCommands } from "@elizaos/plugin-commands";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PermissionFlagsBits } from "discord.js";
 
 // The connector bridge gates auth via the agent role model (`hasRoleAccess`).
@@ -45,6 +45,7 @@ function makeRuntime(overrides: Partial<IAgentRuntime> = {}): IAgentRuntime {
 			cache.set(key, value);
 			return true;
 		}),
+		deleteCache: vi.fn(async (key: string) => cache.delete(key)),
 		getSetting: vi.fn(() => undefined),
 		character: { name: "TestAgent" },
 		logger: {
@@ -495,4 +496,107 @@ describe("registerCatalogSlashCommands", () => {
 			cleanup();
 		}
 	});
+});
+
+/**
+ * Full native-picker simulation sweep (#16172 follow-through): every catalog
+ * command on the discord surface is executed through a synthetic
+ * ChatInputCommandInteraction — the same execute path a real picker invocation
+ * takes (sender auth -> connector gate -> deterministic resolve or pipeline
+ * dispatch) — and must reply without throwing. Deterministic commands hit a
+ * canned loopback router instead of the live API; pipeline commands hit a
+ * mocked messageService. This is the owner-side "fire every command" check
+ * that cannot be driven from outside Discord (bots cannot invoke application
+ * commands), productized so rot in ANY command is caught in CI.
+ */
+describe("native interaction sweep — full catalog surface", () => {
+	/** Canned loopback API for the deterministic command handlers. */
+	function stubLoopbackFetch(): ReturnType<typeof vi.fn> {
+		const json = (body: unknown) =>
+			new Response(JSON.stringify(body), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+			const url = String(input);
+			if (url.includes("/api/models/config")) {
+				return json({ targets: { small: {}, large: {}, coding: {} } });
+			}
+			if (url.includes("/api/models")) {
+				return json({ providers: {}, catalog: { providers: {} } });
+			}
+			if (url.includes("/api/accounts")) {
+				return json({ providers: [] });
+			}
+			if (url.includes("/api/runtime/model-switch")) {
+				return json({ ok: true, target: "cloud", model: "m", status: "ready" });
+			}
+			return json({ ok: true });
+		});
+		vi.stubGlobal("fetch", fetchMock);
+		return fetchMock;
+	}
+
+	function makePipelineRuntime() {
+		const handleMessage = vi.fn(
+			async (
+				_runtime: IAgentRuntime,
+				_message: Memory,
+				callback: (content: Content) => Promise<Memory[]>,
+			) => {
+				await callback({ text: "pipeline reply" } as Content);
+				return { handled: true };
+			},
+		);
+		return makeRuntime({
+			messageService: { handleMessage } as never,
+		});
+	}
+
+	function repliedOnce(interaction: MockInteraction): boolean {
+		return (
+			interaction.reply.mock.calls.length > 0 ||
+			interaction.editReply.mock.calls.length > 0
+		);
+	}
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	const surface = getConnectorCommands("discord");
+
+	for (const command of surface) {
+		it(`/${command.name} (owner, bare) replies without throwing`, async () => {
+			hasRoleAccess.mockResolvedValue(true);
+			stubLoopbackFetch();
+			const interaction = makeInteraction();
+			const mapped = mapCatalogCommand(command);
+			await mapped.execute(interaction as never, makePipelineRuntime());
+			expect(repliedOnce(interaction)).toBe(true);
+		});
+	}
+
+	for (const command of surface.filter((c) => c.requiresAuth)) {
+		it(`/${command.name} (guest) refuses and never reaches a backend`, async () => {
+			hasRoleAccess.mockResolvedValue(false);
+			const fetchMock = stubLoopbackFetch();
+			const interaction = makeInteraction();
+			const runtime = makePipelineRuntime();
+			const mapped = mapCatalogCommand(command);
+			await mapped.execute(interaction as never, runtime);
+			expect(interaction.reply).toHaveBeenCalledTimes(1);
+			const arg = interaction.reply.mock.calls[0][0] as {
+				content: string;
+				ephemeral: boolean;
+			};
+			expect(arg.ephemeral).toBe(true);
+			expect(arg.content).toMatch(/authorization|elevated/);
+			expect(fetchMock).not.toHaveBeenCalled();
+			expect(
+				(runtime.messageService as { handleMessage: ReturnType<typeof vi.fn> })
+					.handleMessage,
+			).not.toHaveBeenCalled();
+		});
+	}
 });


### PR DESCRIPTION
Bots cannot invoke Discord application commands, so until now the native picker path (sender auth → connector gate → deterministic resolve or pipeline dispatch) could only be exercised by a human clicking every command — which is how the `/model show` verification happened, and why command rot ("stub reading settings that never existed") kept slipping through.

This sweep **simulates the native invocation for every catalog command on the discord surface**, twice each:

- **owner, bare invocation** — the mapped `execute` runs against a synthetic `ChatInputCommandInteraction`, a canned loopback router (models/config/accounts/model-switch endpoints), and a mocked message pipeline; it must produce a reply without throwing
- **guest** — every `requiresAuth` command must refuse with an ephemeral reply and **never** reach `fetch` or the pipeline (fail-closed pinned per command)

That's 38 generated cases on top of the existing suite (59 total in the file; full plugin suite 435✓). The first run already earned its keep: it flagged the `/reset` + `/new` paths needing `deleteCache` on the runtime surface — exactly the depth-of-execution this class of test is for. New commands added to the catalog get swept automatically with zero test-writing.

Screenshots/video: N/A — CI test harness; the sweep itself is the artifact (it replaces the manual click-every-command pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)