### PR TITLE
fix(commands): one user-facing name per coding backend

### DIFF
--- a/plugins/plugin-commands/__tests__/accounts-backend-command.test.ts
+++ b/plugins/plugin-commands/__tests__/accounts-backend-command.test.ts
@@ -557,7 +557,7 @@ describe("/backend", () => {
 		expect(call?.url).toContain("/api/models/config");
 		expect(call?.method).toBe("GET");
 		expect(r.reply).toContain("Default coding backend: opencode (config.env)");
-		expect(r.reply).toContain("codex, claude, opencode, eliza-code");
+		expect(r.reply).toContain("codex, claude, opencode, eliza");
 	});
 
 	it("bare /backend reports the unset state", async () => {

--- a/plugins/plugin-commands/src/actions/backend.ts
+++ b/plugins/plugin-commands/src/actions/backend.ts
@@ -10,14 +10,19 @@
 
 import { resolveServerOnlyPort } from "@elizaos/core";
 import type { CommandResult, ParsedCommand } from "../types";
-import { CODING_BACKEND_TOKENS, type CodingBackend } from "./model-config";
+import {
+	CODING_BACKEND_DISPLAY,
+	CODING_BACKEND_TOKENS,
+	type CodingBackend,
+	displayCodingBackend,
+} from "./model-config";
 
 export type BackendCommand =
 	| { kind: "show" }
 	| { kind: "write"; backend: CodingBackend }
 	| { kind: "usage"; error: string };
 
-const BACKEND_TOKEN_LIST = Object.keys(CODING_BACKEND_TOKENS).join(", ");
+const BACKEND_TOKEN_LIST = CODING_BACKEND_DISPLAY.join(", ");
 
 const BACKEND_USAGE = `Usage: /backend [backend] — backend is one of ${BACKEND_TOKEN_LIST}.`;
 
@@ -81,7 +86,7 @@ export async function runBackendShowViaRoute(): Promise<CommandResult> {
 	}
 	const effective = parsed.targets.coding?.ELIZA_DEFAULT_AGENT_TYPE ?? null;
 	const current = effective
-		? `${effective.value} (${effective.source})`
+		? `${displayCodingBackend(effective.value)} (${effective.source})`
 		: "not set — the orchestrator picks per task";
 	return reply(
 		[

--- a/plugins/plugin-commands/src/actions/model-config.ts
+++ b/plugins/plugin-commands/src/actions/model-config.ts
@@ -27,15 +27,34 @@ type ChatProvider = (typeof CHAT_PROVIDERS)[number];
 export type CodingBackend = "codex" | "claude" | "opencode" | "eliza-code";
 
 // "elizaos" is the orchestrator's spelling of the in-house backend (and what
-// ELIZA_DEFAULT_AGENT_TYPE persists); the API literal is "eliza-code". Shared
-// with `/backend` (backend.ts) so both commands accept the same tokens.
+// ELIZA_DEFAULT_AGENT_TYPE persists); the API literal is "eliza-code" and the
+// user-facing name is "eliza". Shared with `/backend` (backend.ts) so both
+// commands accept the same tokens.
 export const CODING_BACKEND_TOKENS: Record<string, CodingBackend> = {
 	codex: "codex",
 	claude: "claude",
 	opencode: "opencode",
+	eliza: "eliza-code",
 	"eliza-code": "eliza-code",
 	elizaos: "eliza-code",
 };
+
+/**
+ * One user-facing name per backend, for display strings. The token map above
+ * is the INPUT surface (aliases welcome); dumping its keys at the user showed
+ * the same backend three times.
+ */
+export const CODING_BACKEND_DISPLAY: readonly string[] = [
+	"codex",
+	"claude",
+	"opencode",
+	"eliza",
+];
+
+/** Map a persisted wire value (e.g. "elizaos") to its user-facing name. */
+export function displayCodingBackend(value: string): string {
+	return value === "elizaos" || value === "eliza-code" ? "eliza" : value;
+}
 
 export interface ModelConfigWriteBody {
 	target: "small" | "large" | "coding";
@@ -65,7 +84,7 @@ function chatUsage(target: "small" | "large"): string {
 	return `Usage: /model ${target} [provider] <model> [effort] — provider is one of ${CHAT_PROVIDERS.join(", ")} (needed only when the model is served by more than one).`;
 }
 
-const CODING_USAGE = `Usage: /model coding <backend> <model> [effort] — backend is one of ${Object.keys(CODING_BACKEND_TOKENS).join(", ")}.`;
+const CODING_USAGE = `Usage: /model coding <backend> <model> [effort] — backend is one of ${CODING_BACKEND_DISPLAY.join(", ")}.`;
 
 /**
  * Parse a `/model` argument list into a model-config command. Returns null when
@@ -163,9 +182,9 @@ function describeWrite(body: ModelConfigWriteBody): string {
 	const effort = body.effort ? ` at ${body.effort} effort` : "";
 	if (body.target === "coding") {
 		if (body.model === undefined) {
-			return `Default coding backend set to ${body.defaultBackend}`;
+			return `Default coding backend set to ${displayCodingBackend(body.defaultBackend ?? "")}`;
 		}
-		return `Coding model for ${body.backend} set to ${body.model}${effort}`;
+		return `Coding model for ${displayCodingBackend(body.backend ?? "")} set to ${body.model}${effort}`;
 	}
 	const provider = body.provider ? ` (${body.provider})` : "";
 	return `${body.target === "small" ? "Small" : "Large"} chat model set to ${body.model}${provider}${effort}`;

--- a/plugins/plugin-commands/src/registry.ts
+++ b/plugins/plugin-commands/src/registry.ts
@@ -183,7 +183,7 @@ export const DEFAULT_COMMANDS: ReadonlyArray<CommandDefinition> = [
 			{
 				name: "model",
 				description:
-					"model id — for coding, the backend (codex, claude, opencode, elizaos)",
+					"model id — for coding, the backend (codex, claude, opencode, eliza)",
 				dynamicChoices: "models",
 			},
 			{
@@ -338,7 +338,7 @@ export const DEFAULT_COMMANDS: ReadonlyArray<CommandDefinition> = [
 			{
 				name: "backend",
 				description: "default coding backend for new tasks",
-				choices: ["codex", "claude", "opencode", "eliza-code"],
+				choices: ["codex", "claude", "opencode", "eliza"],
 			},
 		],
 		// requiresAuth only (see /accounts): the bare read is authorized-only,


### PR DESCRIPTION
Owner-reported slop: `/backend` listed **"codex, claude, opencode, eliza-code, elizaos"** — five tokens for four backends, because the display strings dumped the raw INPUT-alias map (`eliza-code` and `elizaos` are both spellings of the in-house backend).

Display now uses **one friendly name per backend** — `codex, claude, opencode, eliza` — everywhere the user sees backends: the `/backend` available list, both usage strings, the native Discord picker choices, the write confirmations, and the current-value read (a persisted `elizaos` renders as `eliza (config.env)`). Input stays generous: `eliza` / `eliza-code` / `elizaos` all accepted; the wire/persisted value is unchanged.

Live-verified on the running bot:
```
/backend        → "Default coding backend: eliza (config.env)
                   Available: codex, claude, opencode, eliza. Switch with /backend <backend>."
/backend eliza  → "Default coding backend set to eliza — applies to new coding sessions, no restart needed."
                   (persisted wire value: elizaos ✓)
```

Tests: plugin-commands 134✓ (display assertion updated), plugin-discord command suites 72✓ (native sweep picks up the new picker choices automatically), typecheck ✓, biome ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - command/Discord copy only; no application visual layout changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - command/Discord copy only; no application visual layout changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - focused backend naming change; live command transcript is recorded above.
<!-- evidence-row:backend-logs -->
- [x] N/A - command behavior was verified by focused tests and the live transcript recorded above; no server/backend deployment changed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser or application frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or agent reasoning behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain data or persistence schema changed; the existing `elizaos` wire value is intentionally preserved.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered application UI changed.
