### PR TITLE
perf(cloud): coalesce concurrent cold pricing-catalog reads (#16162)

### DIFF
--- a/packages/cloud/shared/src/lib/services/ai-pricing/cache.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/cache.test.ts
@@ -92,19 +92,16 @@ test("persisted: concurrent cold misses for the same key coalesce onto one read 
   __clearPersistedPricingCache();
   const row = { model: "m" } as unknown as AiPricingEntry;
   let calls = 0;
-  let release!: (v: AiPricingEntry[]) => void;
-  const gate = new Promise<AiPricingEntry[]>((resolve) => {
-    release = resolve;
-  });
+  const gate = Promise.withResolvers<AiPricingEntry[]>();
   const loader = (): Promise<AiPricingEntry[]> => {
     calls++;
-    return gate; // stays pending until released — both callers reach in-flight
+    return gate.promise;
   };
 
   // Both fired before either resolves — the hot-path shape lookup.ts produces.
   const p1 = getCachedPersistedEntries("cc", loader);
   const p2 = getCachedPersistedEntries("cc", loader);
-  release([row]);
+  gate.resolve([row]);
 
   expect(await p1).toEqual([row]);
   expect(await p2).toEqual([row]);
@@ -117,20 +114,42 @@ test("external: concurrent cold misses for the same key coalesce onto one read (
     provider: "p",
   } as unknown as PreparedPricingEntry;
   let calls = 0;
-  let release!: (v: PreparedPricingEntry[]) => void;
-  const gate = new Promise<PreparedPricingEntry[]>((resolve) => {
-    release = resolve;
-  });
+  const gate = Promise.withResolvers<PreparedPricingEntry[]>();
   const loader = (): Promise<PreparedPricingEntry[]> => {
     calls++;
-    return gate;
+    return gate.promise;
   };
 
   const p1 = getCachedExternalEntries("cc:ext", loader);
   const p2 = getCachedExternalEntries("cc:ext", loader);
-  release([entry]);
+  gate.resolve([entry]);
 
   expect(await p1).toEqual([entry]);
   expect(await p2).toEqual([entry]);
   expect(calls).toBe(1);
+});
+
+test("persisted: concurrent rejection is shared and a later request retries", async () => {
+  __clearPersistedPricingCache();
+  const gate = Promise.withResolvers<AiPricingEntry[]>();
+  let calls = 0;
+  const loader = (): Promise<AiPricingEntry[]> => {
+    calls++;
+    return gate.promise;
+  };
+
+  const first = getCachedPersistedEntries("reject", loader);
+  const concurrent = getCachedPersistedEntries("reject", loader);
+  const settled = Promise.allSettled([first, concurrent]);
+  gate.reject(new Error("db transient"));
+
+  const results = await settled;
+  expect(results.map((result) => result.status)).toEqual(["rejected", "rejected"]);
+  for (const result of results) {
+    if (result.status !== "rejected") throw new Error("expected rejection");
+    if (!(result.reason instanceof Error)) throw new Error("expected Error reason");
+    expect(result.reason.message).toBe("db transient");
+  }
+  expect(calls).toBe(1);
+  await expect(getCachedPersistedEntries("reject", async () => [])).resolves.toEqual([]);
 });

--- a/packages/cloud/shared/src/lib/services/ai-pricing/cache.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/cache.test.ts
@@ -34,7 +34,10 @@ test("negative-caches a failing loader — subsequent lookups skip the re-fetch"
 
 test("caches a successful loader result — loader runs once", async () => {
   let calls = 0;
-  const entry = { model: "m", provider: "p" } as unknown as PreparedPricingEntry;
+  const entry = {
+    model: "m",
+    provider: "p",
+  } as unknown as PreparedPricingEntry;
   const loader = async (): Promise<PreparedPricingEntry[]> => {
     calls++;
     return [entry];
@@ -48,7 +51,10 @@ test("caches a successful loader result — loader runs once", async () => {
 test("persisted: caches a successful DB read — loader runs once within TTL", async () => {
   __clearPersistedPricingCache();
   let calls = 0;
-  const row = { model: "gpt-oss-120b", provider: "cerebras" } as unknown as AiPricingEntry;
+  const row = {
+    model: "gpt-oss-120b",
+    provider: "cerebras",
+  } as unknown as AiPricingEntry;
   const loader = async (): Promise<AiPricingEntry[]> => {
     calls++;
     return [row];
@@ -80,4 +86,51 @@ test("persisted: distinct keys cache independently (no cross-key bleed)", async 
   expect(await getCachedPersistedEntries("kb", async () => [b])).toEqual([b]);
   // 'ka' stays cached as [a] even though this loader would return [b].
   expect(await getCachedPersistedEntries("ka", async () => [b])).toEqual([a]);
+});
+
+test("persisted: concurrent cold misses for the same key coalesce onto one read (#16162)", async () => {
+  __clearPersistedPricingCache();
+  const row = { model: "m" } as unknown as AiPricingEntry;
+  let calls = 0;
+  let release!: (v: AiPricingEntry[]) => void;
+  const gate = new Promise<AiPricingEntry[]>((resolve) => {
+    release = resolve;
+  });
+  const loader = (): Promise<AiPricingEntry[]> => {
+    calls++;
+    return gate; // stays pending until released — both callers reach in-flight
+  };
+
+  // Both fired before either resolves — the hot-path shape lookup.ts produces.
+  const p1 = getCachedPersistedEntries("cc", loader);
+  const p2 = getCachedPersistedEntries("cc", loader);
+  release([row]);
+
+  expect(await p1).toEqual([row]);
+  expect(await p2).toEqual([row]);
+  expect(calls).toBe(1); // one shared read, not two duplicate DB round-trips
+});
+
+test("external: concurrent cold misses for the same key coalesce onto one read (#16162)", async () => {
+  const entry = {
+    model: "m",
+    provider: "p",
+  } as unknown as PreparedPricingEntry;
+  let calls = 0;
+  let release!: (v: PreparedPricingEntry[]) => void;
+  const gate = new Promise<PreparedPricingEntry[]>((resolve) => {
+    release = resolve;
+  });
+  const loader = (): Promise<PreparedPricingEntry[]> => {
+    calls++;
+    return gate;
+  };
+
+  const p1 = getCachedExternalEntries("cc:ext", loader);
+  const p2 = getCachedExternalEntries("cc:ext", loader);
+  release([entry]);
+
+  expect(await p1).toEqual([entry]);
+  expect(await p2).toEqual([entry]);
+  expect(calls).toBe(1);
 });

--- a/packages/cloud/shared/src/lib/services/ai-pricing/cache.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/cache.ts
@@ -7,7 +7,36 @@ import {
   type PreparedPricingEntry,
 } from "./types";
 
+/**
+ * Share one in-flight loader across concurrent cold misses for the same key,
+ * then forget it once it settles. `lookup.ts` resolves independent input and
+ * output rates concurrently, so on a fresh isolate both can miss the completed-
+ * value cache and issue two identical reads for the same key before either is
+ * cached (#16162). The promise is dropped on BOTH fulfillment and rejection, so
+ * a failed load never poisons a later retry and the in-flight map stays bounded
+ * by completion.
+ */
+function coalesce<T>(
+  inFlight: Map<string, Promise<T>>,
+  key: string,
+  run: () => Promise<T>,
+): Promise<T> {
+  const existing = inFlight.get(key);
+  if (existing) return existing;
+  const started = run();
+  inFlight.set(key, started);
+  // Drop the entry once it settles, either way. Attach the cleanup as a settled
+  // handler (not `.finally().catch()`) so it never creates a second, unhandled
+  // rejected chain — the caller awaiting `started` still sees the real error.
+  const cleanup = () => {
+    if (inFlight.get(key) === started) inFlight.delete(key);
+  };
+  started.then(cleanup, cleanup);
+  return started;
+}
+
 const externalCatalogCache = new Map<string, ExternalCacheValue>();
+const externalCatalogInFlight = new Map<string, Promise<PreparedPricingEntry[]>>();
 
 function evictExpiredCacheEntries(): void {
   const now = Date.now();
@@ -27,30 +56,32 @@ export async function getCachedExternalEntries(
     return cached.entries;
   }
 
-  // Evict expired entries before adding new ones to prevent unbounded growth
-  evictExpiredCacheEntries();
+  return coalesce(externalCatalogInFlight, cacheKey, async () => {
+    // Evict expired entries before adding new ones to prevent unbounded growth
+    evictExpiredCacheEntries();
 
-  let entries: PreparedPricingEntry[];
-  try {
-    entries = await loader();
-  } catch (error) {
-    // Negative-cache the failure (shorter TTL) so a dead/erroring upstream — e.g.
-    // Cerebras retiring its public catalog endpoint (permanent 404) — is NOT
-    // re-fetched on every hot-path pricing lookup. The first failure per TTL
-    // still propagates so the caller logs + degrades to seed/cached pricing
-    // exactly as today; subsequent lookups hit this cached empty result and
-    // skip the (variably slow) network round-trip entirely.
+    let entries: PreparedPricingEntry[];
+    try {
+      entries = await loader();
+    } catch (error) {
+      // Negative-cache the failure (shorter TTL) so a dead/erroring upstream — e.g.
+      // Cerebras retiring its public catalog endpoint (permanent 404) — is NOT
+      // re-fetched on every hot-path pricing lookup. The first failure per TTL
+      // still propagates so the caller logs + degrades to seed/cached pricing
+      // exactly as today; subsequent lookups hit this cached empty result and
+      // skip the (variably slow) network round-trip entirely.
+      externalCatalogCache.set(cacheKey, {
+        entries: [],
+        expiresAt: Date.now() + NEGATIVE_EXTERNAL_CACHE_TTL_MS,
+      });
+      throw error;
+    }
     externalCatalogCache.set(cacheKey, {
-      entries: [],
-      expiresAt: Date.now() + NEGATIVE_EXTERNAL_CACHE_TTL_MS,
+      entries,
+      expiresAt: Date.now() + EXTERNAL_CACHE_TTL_MS,
     });
-    throw error;
-  }
-  externalCatalogCache.set(cacheKey, {
-    entries,
-    expiresAt: Date.now() + EXTERNAL_CACHE_TTL_MS,
+    return entries;
   });
-  return entries;
 }
 
 // ── Persisted (DB) active-pricing read cache ────────────────────────────────
@@ -67,6 +98,7 @@ export async function getCachedExternalEntries(
 const PERSISTED_PRICING_CACHE_TTL_MS = 60 * 1000;
 
 const persistedPricingCache = new Map<string, { entries: AiPricingEntry[]; expiresAt: number }>();
+const persistedPricingInFlight = new Map<string, Promise<AiPricingEntry[]>>();
 
 function evictExpiredPersistedEntries(): void {
   const now = Date.now();
@@ -86,18 +118,23 @@ export async function getCachedPersistedEntries(
     return cached.entries;
   }
 
-  evictExpiredPersistedEntries();
-  // Do NOT cache a failure: a DB read error is transient (unlike a permanently
-  // dead external catalog), so let the next request retry against the DB.
-  const entries = await loader();
-  persistedPricingCache.set(cacheKey, {
-    entries,
-    expiresAt: Date.now() + PERSISTED_PRICING_CACHE_TTL_MS,
+  return coalesce(persistedPricingInFlight, cacheKey, async () => {
+    evictExpiredPersistedEntries();
+    // Do NOT cache a failure: a DB read error is transient (unlike a permanently
+    // dead external catalog), so let the next request retry against the DB. The
+    // in-flight entry is dropped on rejection too (see `coalesce`), so a failed
+    // read never blocks the next request's retry.
+    const entries = await loader();
+    persistedPricingCache.set(cacheKey, {
+      entries,
+      expiresAt: Date.now() + PERSISTED_PRICING_CACHE_TTL_MS,
+    });
+    return entries;
   });
-  return entries;
 }
 
 /** Test hook: reset the persisted-pricing cache between tests. */
 export function __clearPersistedPricingCache(): void {
   persistedPricingCache.clear();
+  persistedPricingInFlight.clear();
 }

--- a/packages/cloud/shared/src/lib/services/ai-pricing/cache.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/cache.ts
@@ -1,4 +1,4 @@
-// Coordinates cloud service cache behavior behind route handlers.
+/** Coalesces and briefly caches canonical pricing reads on the inference billing hot path. */
 import type { AiPricingEntry } from "../../../db/schemas/ai-pricing";
 import {
   EXTERNAL_CACHE_TTL_MS,
@@ -7,15 +7,7 @@ import {
   type PreparedPricingEntry,
 } from "./types";
 
-/**
- * Share one in-flight loader across concurrent cold misses for the same key,
- * then forget it once it settles. `lookup.ts` resolves independent input and
- * output rates concurrently, so on a fresh isolate both can miss the completed-
- * value cache and issue two identical reads for the same key before either is
- * cached (#16162). The promise is dropped on BOTH fulfillment and rejection, so
- * a failed load never poisons a later retry and the in-flight map stays bounded
- * by completion.
- */
+/** Input and output rates resolve concurrently, so cold reads share one promise per canonical key. */
 function coalesce<T>(
   inFlight: Map<string, Promise<T>>,
   key: string,


### PR DESCRIPTION
Fixes #16162.

## Why

`ai-pricing/lookup.ts` resolves the input and output rates concurrently (#16156). On a fresh isolate both sides can miss the completed-value cache and reach the same canonical provider/model/rate read before either result is cached — **two identical external-catalog / DB fetches for one key**. `cache.ts` kept the completed-value TTL cache but retained **no in-flight promise**, so nothing coalesced the concurrent cold misses.

Not a billing-correctness bug (prices still fail closed + are validated) — a duplicate-I/O / cold-latency opportunity, and the persisted read runs on **every** inference in the synchronous credit-reserve.

## What

A small key-scoped single-flight (`coalesce`) shared by both cache layers (external catalog + persisted DB):

- concurrent cold misses for the same key await **one** in-flight loader;
- the in-flight promise is dropped on **both fulfillment and rejection**, so a failed load never poisons a later retry and the map is bounded by completion (attached as a settled `then(cleanup, cleanup)` handler so it never spawns a second unhandled rejected chain);
- the completed-value TTL cache, external-404 negative-cache, DB-errors-not-cached, and fail-closed validation are all **unchanged** (only cold misses reach the coalescer; a cache hit still returns immediately).

## Testing

`bun test ai-pricing/cache.test.ts` — **7 pass**, incl. two new regressions: two concurrent cold misses for the same key invoke the loader **once** (persisted + external). The existing negative-cache / DB-error-retry / cross-key-independence tests still hold (the sequential retry test already covers drop-on-reject: a second call after a failure re-runs the loader).

`typecheck` clean, biome clean.

# Evidence Gate

Backend-only change in `packages/cloud/shared` (two in-memory Maps + a helper) — no UI, agent/model path, or live-service run. Behaviour is proven by the deterministic unit tests above.

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only change; no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only change; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; covered by deterministic unit tests.
<!-- evidence-row:backend-logs -->
- [x] Concurrency/rejection execution proof: https://github.com/elizaOS/eliza/releases/download/pr-evidence/16216-single-flight-proof.json
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or API surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change (pricing-cache I/O only).
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no durable domain state; in-flight map settlement proof: https://github.com/elizaOS/eliza/releases/download/pr-evidence/16216-single-flight-proof.json

## Known gaps / failures

Evidence rows are `N/A` — a pure in-memory concurrency change has no UI/LLM/domain artifacts; the unit tests are the authoritative evidence.

[stan-cloud]