### PR TITLE
fix(commands): stop offering opencode in backend lists and pickers

### DIFF
--- a/plugins/plugin-commands/__tests__/accounts-backend-command.test.ts
+++ b/plugins/plugin-commands/__tests__/accounts-backend-command.test.ts
@@ -557,7 +557,7 @@ describe("/backend", () => {
 		expect(call?.url).toContain("/api/models/config");
 		expect(call?.method).toBe("GET");
 		expect(r.reply).toContain("Default coding backend: opencode (config.env)");
-		expect(r.reply).toContain("codex, claude, opencode, eliza");
+		expect(r.reply).toContain("codex, claude, eliza");
 	});
 
 	it("bare /backend reports the unset state", async () => {

--- a/plugins/plugin-commands/src/actions/model-config.ts
+++ b/plugins/plugin-commands/src/actions/model-config.ts
@@ -40,14 +40,14 @@ export const CODING_BACKEND_TOKENS: Record<string, CodingBackend> = {
 };
 
 /**
- * One user-facing name per backend, for display strings. The token map above
- * is the INPUT surface (aliases welcome); dumping its keys at the user showed
- * the same backend three times.
+ * One user-facing name per OFFERED backend, for display strings. The token
+ * map above is the INPUT surface (aliases welcome — including "opencode",
+ * which stays switchable by name but is deliberately not offered in lists
+ * and pickers; owner decision, 2026-07-13).
  */
 export const CODING_BACKEND_DISPLAY: readonly string[] = [
 	"codex",
 	"claude",
-	"opencode",
 	"eliza",
 ];
 

--- a/plugins/plugin-commands/src/registry.ts
+++ b/plugins/plugin-commands/src/registry.ts
@@ -183,7 +183,7 @@ export const DEFAULT_COMMANDS: ReadonlyArray<CommandDefinition> = [
 			{
 				name: "model",
 				description:
-					"model id — for coding, the backend (codex, claude, opencode, eliza)",
+					"model id — for coding, the backend (codex, claude, eliza)",
 				dynamicChoices: "models",
 			},
 			{
@@ -338,7 +338,7 @@ export const DEFAULT_COMMANDS: ReadonlyArray<CommandDefinition> = [
 			{
 				name: "backend",
 				description: "default coding backend for new tasks",
-				choices: ["codex", "claude", "opencode", "eliza"],
+				choices: ["codex", "claude", "eliza"],
 			},
 		],
 		// requiresAuth only (see /accounts): the bare read is authorized-only,


### PR DESCRIPTION
Owner decision: the offered coding backends are **codex, claude, eliza**. `opencode` stays fully functional as an input alias (`/backend opencode` still switches) and its config keys are untouched — the in-house eliza backend inherits `ELIZA_OPENCODE_*` provider config as its fallback — it is just no longer advertised in `/backend`, the usage strings, or the native pickers.

Live-verified: `/backend` → "Available: codex, claude, eliza." Tests: plugin-commands 134✓ (display assertion updated), discord native sweep 59✓ (picks up the trimmed choices automatically), typecheck ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)