### PR TITLE
fix(cloud): route Opus 4.7/4.8 to adaptive thinking, not a manual budget

### DIFF
--- a/.github/workflows/develop-live.yml
+++ b/.github/workflows/develop-live.yml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
     inputs:
       filter:
-        description: "Optional task-label regex; use a2a-receipt, mcp-receipt, or channel-topics-receipt for an exact proof"
+        description: "Optional task-label regex; use a2a-receipt, mcp-receipt, channel-topics-receipt, or anthropic-thinking-receipt for an exact proof"
         type: string
         default: ""
   schedule:
@@ -122,7 +122,8 @@ jobs:
         if: >-
           inputs.filter != 'a2a-receipt' &&
           inputs.filter != 'mcp-receipt' &&
-          inputs.filter != 'channel-topics-receipt'
+          inputs.filter != 'channel-topics-receipt' &&
+          inputs.filter != 'anthropic-thinking-receipt'
         env:
           RUNNER_TEMP_LOG: ${{ runner.temp }}/develop-live-sweep.log
           TEST_FILTER: ${{ inputs.filter }}
@@ -139,7 +140,8 @@ jobs:
           always() &&
           inputs.filter != 'a2a-receipt' &&
           inputs.filter != 'mcp-receipt' &&
-          inputs.filter != 'channel-topics-receipt'
+          inputs.filter != 'channel-topics-receipt' &&
+          inputs.filter != 'anthropic-thinking-receipt'
         run: bun run test:cloud
 
       - name: Exact-head A2A live provider and billing receipt
@@ -169,6 +171,14 @@ jobs:
         run: >-
           bun run --cwd packages/core test --
           src/features/basic-capabilities/providers/channelTopics.live.test.ts
+
+      - name: Exact-head Anthropic adaptive thinking receipt
+        if: >-
+          always() &&
+          (inputs.filter == '' || inputs.filter == 'anthropic-thinking-receipt')
+        run: >-
+          bun test
+          packages/cloud/shared/src/lib/providers/anthropic-thinking.live.test.ts
 
       - name: Teardown Postgres
         if: always()

--- a/.github/workflows/develop-live.yml
+++ b/.github/workflows/develop-live.yml
@@ -177,7 +177,7 @@ jobs:
           always() &&
           (inputs.filter == '' || inputs.filter == 'anthropic-thinking-receipt')
         run: >-
-          BUN_TEST_COVERAGE=0 bun test
+          bun --config=bunfig.live.toml test
           packages/cloud/shared/src/lib/providers/anthropic-thinking.live.test.ts
 
       - name: Teardown Postgres

--- a/.github/workflows/develop-live.yml
+++ b/.github/workflows/develop-live.yml
@@ -177,7 +177,7 @@ jobs:
           always() &&
           (inputs.filter == '' || inputs.filter == 'anthropic-thinking-receipt')
         run: >-
-          bun test
+          BUN_TEST_COVERAGE=0 bun test
           packages/cloud/shared/src/lib/providers/anthropic-thinking.live.test.ts
 
       - name: Teardown Postgres

--- a/bunfig.live.toml
+++ b/bunfig.live.toml
@@ -1,0 +1,7 @@
+# One-shot credentialed live receipts need bounded test timeouts without the
+# repository-wide coverage collector. Coverage belongs to deterministic CI;
+# loading every imported module after a real API call adds minutes of work and
+# can fail an otherwise valid receipt on unrelated aggregate thresholds.
+[test]
+timeout = 120000
+coverage = false

--- a/packages/cloud/shared/src/lib/providers/anthropic-thinking.adaptive.test.ts
+++ b/packages/cloud/shared/src/lib/providers/anthropic-thinking.adaptive.test.ts
@@ -30,6 +30,7 @@ describe("Anthropic adaptive thinking (Opus 4.7/4.8) — #16149", () => {
     "claude-opus-4-7",
     "claude-opus-4.7",
     "anthropic/claude-opus-4-7",
+    "anthropic/claude-opus-4-7-20260701",
     "anthropic/claude-opus-4.8",
     "claude-opus-4-8",
   ];
@@ -55,6 +56,12 @@ describe("Anthropic adaptive thinking (Opus 4.7/4.8) — #16149", () => {
       expect(usesAdaptiveThinking(id)).toBe(false);
       expect(supportsExtendedThinking(id)).toBe(true);
       expect(thinkingOf(id)).toEqual({ type: "enabled", budgetTokens: 5000 });
+    }
+  });
+
+  test("does not classify later or malformed model versions as Opus 4.7/4.8", () => {
+    for (const id of ["claude-opus-4-70", "claude-opus-4.80", "claude-opus-4-8preview"]) {
+      expect(usesAdaptiveThinking(id)).toBe(false);
     }
   });
 

--- a/packages/cloud/shared/src/lib/providers/anthropic-thinking.adaptive.test.ts
+++ b/packages/cloud/shared/src/lib/providers/anthropic-thinking.adaptive.test.ts
@@ -67,8 +67,14 @@ describe("Anthropic adaptive thinking (Opus 4.7/4.8) — #16149", () => {
     }
   });
 
-  test("does not classify later or malformed model versions as Opus 4.7/4.8", () => {
-    for (const id of ["claude-opus-4-70", "claude-opus-4.80", "claude-opus-4-8preview"]) {
+  test("does not classify later, malformed, or lookalike model IDs as Opus 4.7/4.8", () => {
+    for (const id of [
+      "claude-opus-4-70",
+      "claude-opus-4.80",
+      "claude-opus-4-8preview",
+      "not-claude-opus-4-7",
+      "openai/not-claude-opus-4-8",
+    ]) {
       expect(usesAdaptiveThinking(id)).toBe(false);
     }
   });

--- a/packages/cloud/shared/src/lib/providers/anthropic-thinking.adaptive.test.ts
+++ b/packages/cloud/shared/src/lib/providers/anthropic-thinking.adaptive.test.ts
@@ -22,6 +22,12 @@ function thinkingOf(modelId: string): Record<string, unknown> | undefined {
   return anthropic?.thinking;
 }
 
+function openRouterReasoningOf(modelId: string): Record<string, unknown> | undefined {
+  const result = anthropicThinkingProviderOptions(modelId, ENV);
+  if (!("providerOptions" in result)) return undefined;
+  return result.providerOptions.openai;
+}
+
 describe("Anthropic adaptive thinking (Opus 4.7/4.8) — #16149", () => {
   // Bare, dot, hyphen, and provider-prefixed alias forms. (Model IDs are
   // lowercase by convention — `getProviderFromModel` is case-sensitive upstream,
@@ -43,6 +49,7 @@ describe("Anthropic adaptive thinking (Opus 4.7/4.8) — #16149", () => {
       // Adaptive models reject a manual budget — assert neither casing leaks in.
       expect(JSON.stringify(thinking)).not.toContain("budgetTokens");
       expect(JSON.stringify(thinking)).not.toContain("budget_tokens");
+      expect(openRouterReasoningOf(id)).toEqual({ reasoningEffort: "high" });
     });
   }
 
@@ -56,6 +63,7 @@ describe("Anthropic adaptive thinking (Opus 4.7/4.8) — #16149", () => {
       expect(usesAdaptiveThinking(id)).toBe(false);
       expect(supportsExtendedThinking(id)).toBe(true);
       expect(thinkingOf(id)).toEqual({ type: "enabled", budgetTokens: 5000 });
+      expect(openRouterReasoningOf(id)).toBeUndefined();
     }
   });
 

--- a/packages/cloud/shared/src/lib/providers/anthropic-thinking.adaptive.test.ts
+++ b/packages/cloud/shared/src/lib/providers/anthropic-thinking.adaptive.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Opus 4.7/4.8 use ADAPTIVE extended thinking; the shared helper must emit
+ * `thinking: { type: "adaptive" }` (no `budgetTokens`) for them instead of the
+ * manual `enabled + budgetTokens` that the provider 400s on, while manual-budget
+ * models keep their existing shape (#16149).
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  anthropicThinkingProviderOptions,
+  supportsExtendedThinking,
+  usesAdaptiveThinking,
+} from "./anthropic-thinking";
+
+const ENV = { ANTHROPIC_COT_BUDGET: "5000" };
+
+function thinkingOf(modelId: string): Record<string, unknown> | undefined {
+  const result = anthropicThinkingProviderOptions(modelId, ENV);
+  if (!("providerOptions" in result)) return undefined;
+  const anthropic = result.providerOptions.anthropic as
+    | { thinking?: Record<string, unknown> }
+    | undefined;
+  return anthropic?.thinking;
+}
+
+describe("Anthropic adaptive thinking (Opus 4.7/4.8) — #16149", () => {
+  // Bare, dot, hyphen, and provider-prefixed alias forms. (Model IDs are
+  // lowercase by convention — `getProviderFromModel` is case-sensitive upstream,
+  // so casing is out of scope for the adaptive-vs-manual routing this fixes.)
+  const adaptiveAliases = [
+    "claude-opus-4-7",
+    "claude-opus-4.7",
+    "anthropic/claude-opus-4-7",
+    "anthropic/claude-opus-4.8",
+    "claude-opus-4-8",
+  ];
+
+  for (const id of adaptiveAliases) {
+    test(`${id} → adaptive thinking, never a manual budget`, () => {
+      expect(usesAdaptiveThinking(id)).toBe(true);
+      const thinking = thinkingOf(id);
+      expect(thinking).toEqual({ type: "adaptive" });
+      // Adaptive models reject a manual budget — assert neither casing leaks in.
+      expect(JSON.stringify(thinking)).not.toContain("budgetTokens");
+      expect(JSON.stringify(thinking)).not.toContain("budget_tokens");
+    });
+  }
+
+  test("manual-budget models keep enabled + budgetTokens", () => {
+    for (const id of [
+      "claude-opus-4-5",
+      "claude-opus-4.6",
+      "claude-sonnet-4-6",
+      "anthropic/claude-sonnet-4",
+    ]) {
+      expect(usesAdaptiveThinking(id)).toBe(false);
+      expect(supportsExtendedThinking(id)).toBe(true);
+      expect(thinkingOf(id)).toEqual({ type: "enabled", budgetTokens: 5000 });
+    }
+  });
+
+  test("unsupported models emit no thinking options", () => {
+    for (const id of ["claude-3-5-haiku", "claude-instant-1", "claude-2"]) {
+      expect(supportsExtendedThinking(id)).toBe(false);
+      expect(anthropicThinkingProviderOptions(id, ENV)).toEqual({});
+    }
+  });
+
+  test("a zero or absent budget disables thinking even for an adaptive model", () => {
+    // Explicit 0 budget → off (the gate is unchanged for adaptive models).
+    expect(anthropicThinkingProviderOptions("claude-opus-4-7", ENV, 0)).toEqual({});
+    // No env budget configured → off.
+    expect(anthropicThinkingProviderOptions("claude-opus-4-7", {})).toEqual({});
+  });
+});

--- a/packages/cloud/shared/src/lib/providers/anthropic-thinking.live.test.ts
+++ b/packages/cloud/shared/src/lib/providers/anthropic-thinking.live.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Sends one real Opus 4.7 request through the cloud resolver and records the serialized adaptive-thinking request with the live response.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { generateText } from "ai";
+import { mergeAnthropicCotProviderOptions } from "./anthropic-thinking";
+import { getLanguageModel } from "./language-model";
+
+const LIVE_MODEL = "anthropic/claude-opus-4-7";
+const liveEnabled =
+  process.env.ELIZA_LIVE_TEST === "1" && Boolean(process.env.ANTHROPIC_API_KEY?.trim());
+
+describe.skipIf(!liveEnabled)("adaptive thinking live Anthropic trajectory", () => {
+  test("sends adaptive thinking without a manual budget and returns a live response", async () => {
+    const result = await generateText({
+      model: getLanguageModel(LIVE_MODEL),
+      prompt:
+        "Reply with ADAPTIVE_OK followed by one short sentence explaining why two even integers sum to an even integer.",
+      maxOutputTokens: 4_096,
+      maxRetries: 0,
+      ...mergeAnthropicCotProviderOptions(LIVE_MODEL, {
+        ANTHROPIC_COT_BUDGET: "2048",
+      }),
+    });
+
+    const requestBody = result.request.body as Record<string, unknown>;
+    expect(requestBody.thinking).toEqual({ type: "adaptive" });
+    expect(JSON.stringify(requestBody)).not.toContain("budget_tokens");
+    expect(result.text).toContain("ADAPTIVE_OK");
+
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          evidence: "live-anthropic-adaptive-thinking-trajectory",
+          model: LIVE_MODEL,
+          request: requestBody,
+          response: {
+            text: result.text,
+            finishReason: result.finishReason,
+            usage: result.usage,
+            providerMetadata: result.providerMetadata,
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+  }, 120_000);
+});

--- a/packages/cloud/shared/src/lib/providers/anthropic-thinking.live.test.ts
+++ b/packages/cloud/shared/src/lib/providers/anthropic-thinking.live.test.ts
@@ -1,5 +1,8 @@
 /**
- * Sends one real Opus 4.7 request through the cloud resolver and records the serialized adaptive-thinking request with the live response.
+ * Sends one real Opus 4.7 request through the cloud resolver's OpenRouter
+ * fallback and records the serialized adaptive-thinking request with the live
+ * response. This route remains independently runnable when the native
+ * Anthropic account is unavailable.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -9,30 +12,38 @@ import { getLanguageModel } from "./language-model";
 
 const LIVE_MODEL = "anthropic/claude-opus-4-7";
 const liveEnabled =
-  process.env.ELIZA_LIVE_TEST === "1" && Boolean(process.env.ANTHROPIC_API_KEY?.trim());
+  process.env.ELIZA_LIVE_TEST === "1" && Boolean(process.env.OPENROUTER_API_KEY?.trim());
 
-describe.skipIf(!liveEnabled)("adaptive thinking live Anthropic trajectory", () => {
+describe.skipIf(!liveEnabled)("adaptive thinking live OpenRouter trajectory", () => {
   test("sends adaptive thinking without a manual budget and returns a live response", async () => {
-    const result = await generateText({
-      model: getLanguageModel(LIVE_MODEL),
-      prompt:
-        "Reply with ADAPTIVE_OK followed by one short sentence explaining why two even integers sum to an even integer.",
-      maxOutputTokens: 4_096,
-      maxRetries: 0,
-      ...mergeAnthropicCotProviderOptions(LIVE_MODEL, {
-        ANTHROPIC_COT_BUDGET: "2048",
-      }),
-    });
+    const nativeKey = process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    let result;
+    try {
+      result = await generateText({
+        model: getLanguageModel(LIVE_MODEL),
+        prompt:
+          "Reply with ADAPTIVE_OK followed by one short sentence explaining why two even integers sum to an even integer.",
+        maxOutputTokens: 4_096,
+        maxRetries: 0,
+        ...mergeAnthropicCotProviderOptions(LIVE_MODEL, {
+          ANTHROPIC_COT_BUDGET: "2048",
+        }),
+      });
+    } finally {
+      if (nativeKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+      else process.env.ANTHROPIC_API_KEY = nativeKey;
+    }
 
     const requestBody = result.request.body as Record<string, unknown>;
-    expect(requestBody.thinking).toEqual({ type: "adaptive" });
+    expect(requestBody.reasoning_effort).toBe("high");
     expect(JSON.stringify(requestBody)).not.toContain("budget_tokens");
     expect(result.text).toContain("ADAPTIVE_OK");
 
     process.stdout.write(
       `${JSON.stringify(
         {
-          evidence: "live-anthropic-adaptive-thinking-trajectory",
+          evidence: "live-anthropic-adaptive-thinking-openrouter-trajectory",
           model: LIVE_MODEL,
           request: requestBody,
           response: {

--- a/packages/cloud/shared/src/lib/providers/anthropic-thinking.resolver-boundary.test.ts
+++ b/packages/cloud/shared/src/lib/providers/anthropic-thinking.resolver-boundary.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Exercises adaptive-thinking serialization through the real cloud resolver and AI SDK provider clients.
+ * HTTP is intercepted only after each client has built the exact upstream request body.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { generateText } from "ai";
+import { mergeAnthropicCotProviderOptions } from "./anthropic-thinking";
+import { getLanguageModel } from "./language-model";
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const PROVIDER_ENV_KEYS = [
+  "ANTHROPIC_API_KEY",
+  "OPENROUTER_API_KEY",
+  "AI_GATEWAY_API_KEY",
+] as const;
+const ORIGINAL_PROVIDER_ENV = Object.fromEntries(
+  PROVIDER_ENV_KEYS.map((key) => [key, process.env[key]]),
+);
+
+type CapturedRequest = { url: string; body: Record<string, unknown> };
+let captured: CapturedRequest[] = [];
+let failNativeForFallback = false;
+
+function configureProviders(input: {
+  anthropic?: boolean;
+  openRouter?: boolean;
+  gateway?: boolean;
+}) {
+  for (const key of PROVIDER_ENV_KEYS) delete process.env[key];
+  if (input.anthropic) process.env.ANTHROPIC_API_KEY = "test-anthropic-key";
+  if (input.openRouter) process.env.OPENROUTER_API_KEY = "test-openrouter-key";
+  if (input.gateway) process.env.AI_GATEWAY_API_KEY = "test-gateway-key";
+}
+
+async function captureDispatch(model: string): Promise<CapturedRequest[]> {
+  captured = [];
+  await expect(
+    generateText({
+      model: getLanguageModel(model),
+      prompt: "Confirm adaptive thinking request serialization.",
+      maxOutputTokens: 8_000,
+      maxRetries: 0,
+      ...mergeAnthropicCotProviderOptions(model, {
+        ANTHROPIC_COT_BUDGET: "4096",
+      }),
+    }),
+  ).rejects.toBeDefined();
+  return captured;
+}
+
+function anthropicThinking(body: Record<string, unknown>): Record<string, unknown> | undefined {
+  return body.thinking as Record<string, unknown> | undefined;
+}
+
+function gatewayProviderOptions(body: Record<string, unknown>) {
+  return body.providerOptions as
+    | {
+        anthropic?: { thinking?: Record<string, unknown> };
+        openai?: Record<string, unknown>;
+      }
+    | undefined;
+}
+
+beforeAll(() => {
+  process.env.OPENROUTER_BASE_URL = "https://openrouter.test/v1";
+  process.env.AI_GATEWAY_BASE_URL = "https://gateway.test/v1/ai";
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    captured.push({ url, body });
+    const status = failNativeForFallback && url.includes("api.anthropic.com") ? 503 : 418;
+    return Response.json({ error: { message: "request captured" } }, { status });
+  }) as typeof fetch;
+});
+
+afterAll(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  delete process.env.OPENROUTER_BASE_URL;
+  delete process.env.AI_GATEWAY_BASE_URL;
+  for (const key of PROVIDER_ENV_KEYS) {
+    const value = ORIGINAL_PROVIDER_ENV[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe("adaptive thinking resolver/request boundary", () => {
+  for (const model of ["anthropic/claude-opus-4-7", "anthropic/claude-opus-4.8"]) {
+    test(`native Anthropic serializes adaptive without a manual budget for ${model}`, async () => {
+      configureProviders({ anthropic: true });
+      const requests = await captureDispatch(model);
+
+      expect(requests).toHaveLength(1);
+      expect(requests[0]?.url).toBe("https://api.anthropic.com/v1/messages");
+      expect(anthropicThinking(requests[0]?.body ?? {})).toEqual({ type: "adaptive" });
+      expect(JSON.stringify(requests[0]?.body)).not.toContain("budget_tokens");
+    });
+
+    test(`OpenRouter serializes normalized adaptive reasoning for ${model}`, async () => {
+      configureProviders({ openRouter: true });
+      const requests = await captureDispatch(model);
+
+      expect(requests).toHaveLength(1);
+      expect(requests[0]?.url).toBe("https://openrouter.test/v1/chat/completions");
+      expect(requests[0]?.body.reasoning_effort).toBe("high");
+      expect(JSON.stringify(requests[0]?.body)).not.toContain("budget_tokens");
+    });
+
+    test(`Vercel gateway preserves both provider-specific adaptive signals for ${model}`, async () => {
+      configureProviders({ gateway: true });
+      const requests = await captureDispatch(model);
+
+      expect(requests).toHaveLength(1);
+      expect(requests[0]?.url).toBe("https://gateway.test/v1/ai/language-model");
+      const options = gatewayProviderOptions(requests[0]?.body ?? {});
+      expect(options?.anthropic?.thinking).toEqual({ type: "adaptive" });
+      expect(options?.openai).toEqual({ reasoningEffort: "high" });
+      expect(JSON.stringify(requests[0]?.body)).not.toContain("budgetTokens");
+    });
+  }
+
+  test("a retryable native failure keeps adaptive thinking on the OpenRouter fallback", async () => {
+    configureProviders({ anthropic: true, openRouter: true });
+    failNativeForFallback = true;
+    try {
+      const requests = await captureDispatch("anthropic/claude-opus-4.7");
+      expect(requests.map(({ url }) => url)).toEqual([
+        "https://api.anthropic.com/v1/messages",
+        "https://openrouter.test/v1/chat/completions",
+      ]);
+      expect(anthropicThinking(requests[0]?.body ?? {})).toEqual({ type: "adaptive" });
+      expect(requests[1]?.body.reasoning_effort).toBe("high");
+      expect(JSON.stringify(requests)).not.toContain("budget_tokens");
+    } finally {
+      failNativeForFallback = false;
+    }
+  });
+});

--- a/packages/cloud/shared/src/lib/providers/anthropic-thinking.ts
+++ b/packages/cloud/shared/src/lib/providers/anthropic-thinking.ts
@@ -42,6 +42,26 @@ export function supportsExtendedThinking(modelId: string): boolean {
   return EXTENDED_THINKING_MODEL_PATTERNS.some((pattern) => pattern.test(normalizedId));
 }
 
+/**
+ * Opus models that use ADAPTIVE extended thinking (`thinking: { type: "adaptive" }`,
+ * the provider chooses depth) rather than a manual `enabled + budgetTokens`.
+ * Sending a manual budget to these produces the provider 400 this fixes (#16149).
+ * Dot and hyphen aliases + provider prefixes are covered (no `^` anchor).
+ */
+const ADAPTIVE_THINKING_MODEL_PATTERNS = [
+  /claude-opus-4[.-]7/, // Claude Opus 4.7
+  /claude-opus-4[.-]8/, // Claude Opus 4.8
+];
+
+/**
+ * Whether the model uses ADAPTIVE extended thinking (vs a manual token budget).
+ * Adaptive models are a subset of {@link supportsExtendedThinking}.
+ */
+export function usesAdaptiveThinking(modelId: string): boolean {
+  const normalizedId = modelId.toLowerCase();
+  return ADAPTIVE_THINKING_MODEL_PATTERNS.some((pattern) => pattern.test(normalizedId));
+}
+
 const ENV_KEY = "ANTHROPIC_COT_BUDGET";
 const ENV_MAX_KEY = "ANTHROPIC_COT_BUDGET_MAX";
 
@@ -173,6 +193,14 @@ const anthropicThinkingOptions = (budgetTokens: number): AnthropicProviderOption
   thinking: { type: "enabled", budgetTokens },
 });
 
+// Adaptive models let the provider choose thinking depth and reject a manual
+// `budgetTokens` (#16149). A configured numeric budget still gates thinking
+// on/off (see `anthropicThinkingProviderOptions`) but is NOT forwarded as a
+// token cap; `effort` control is intentionally left to a follow-up per the issue.
+const anthropicAdaptiveThinkingOptions = (): AnthropicProviderOptions => ({
+  thinking: { type: "adaptive" },
+});
+
 /**
  * AI SDK provider options fragment when budget is active and model is Anthropic.
  *
@@ -188,7 +216,15 @@ export function anthropicThinkingProviderOptions(
   if (budget === null) {
     return {};
   }
-  const anthropic = anthropicThinkingOptions(budget) as CloudJsonObject;
+  // The resolved budget already gated thinking on/off (and 0 → off). Adaptive
+  // models (Opus 4.7/4.8) must NOT receive the manual `budgetTokens` — the
+  // provider 400s on it — so emit the adaptive shape; the numeric budget stays a
+  // gate, not a forwarded cap (#16149). Manual-budget models are unchanged.
+  const anthropic = (
+    usesAdaptiveThinking(modelId)
+      ? anthropicAdaptiveThinkingOptions()
+      : anthropicThinkingOptions(budget)
+  ) as CloudJsonObject;
   return {
     providerOptions: {
       anthropic,

--- a/packages/cloud/shared/src/lib/providers/anthropic-thinking.ts
+++ b/packages/cloud/shared/src/lib/providers/anthropic-thinking.ts
@@ -46,11 +46,12 @@ export function supportsExtendedThinking(modelId: string): boolean {
  * Opus models that use ADAPTIVE extended thinking (`thinking: { type: "adaptive" }`,
  * the provider chooses depth) rather than a manual `enabled + budgetTokens`.
  * Sending a manual budget to these produces the provider 400 this fixes (#16149).
- * Dot and hyphen aliases + provider prefixes are covered (no `^` anchor).
+ * Dot and hyphen aliases are accepted either bare or after a provider prefix;
+ * the leading boundary prevents unrelated lookalike model IDs from opting in.
  */
 const ADAPTIVE_THINKING_MODEL_PATTERNS = [
-  /claude-opus-4[.-]7(?:$|-)/, // Claude Opus 4.7 and dated aliases
-  /claude-opus-4[.-]8(?:$|-)/, // Claude Opus 4.8 and dated aliases
+  /(?:^|\/)claude-opus-4[.-]7(?:$|-)/, // Claude Opus 4.7 and dated aliases
+  /(?:^|\/)claude-opus-4[.-]8(?:$|-)/, // Claude Opus 4.8 and dated aliases
 ];
 
 /**

--- a/packages/cloud/shared/src/lib/providers/anthropic-thinking.ts
+++ b/packages/cloud/shared/src/lib/providers/anthropic-thinking.ts
@@ -49,8 +49,8 @@ export function supportsExtendedThinking(modelId: string): boolean {
  * Dot and hyphen aliases + provider prefixes are covered (no `^` anchor).
  */
 const ADAPTIVE_THINKING_MODEL_PATTERNS = [
-  /claude-opus-4[.-]7/, // Claude Opus 4.7
-  /claude-opus-4[.-]8/, // Claude Opus 4.8
+  /claude-opus-4[.-]7(?:$|-)/, // Claude Opus 4.7 and dated aliases
+  /claude-opus-4[.-]8(?:$|-)/, // Claude Opus 4.8 and dated aliases
 ];
 
 /**

--- a/packages/cloud/shared/src/lib/providers/anthropic-thinking.ts
+++ b/packages/cloud/shared/src/lib/providers/anthropic-thinking.ts
@@ -195,10 +195,17 @@ const anthropicThinkingOptions = (budgetTokens: number): AnthropicProviderOption
 
 // Adaptive models let the provider choose thinking depth and reject a manual
 // `budgetTokens` (#16149). A configured numeric budget still gates thinking
-// on/off (see `anthropicThinkingProviderOptions`) but is NOT forwarded as a
-// token cap; `effort` control is intentionally left to a follow-up per the issue.
+// on/off but is not forwarded as a token cap.
 const anthropicAdaptiveThinkingOptions = (): AnthropicProviderOptions => ({
   thinking: { type: "adaptive" },
+});
+
+// The cloud resolver may serve an Anthropic model through OpenRouter's
+// OpenAI-compatible client. That client ignores the `anthropic` namespace, so
+// the equivalent normalized signal must travel in its own provider namespace.
+// OpenRouter maps `reasoning_effort` to adaptive thinking for Opus 4.7+.
+const openRouterAdaptiveThinkingOptions = (): CloudJsonObject => ({
+  reasoningEffort: "high",
 });
 
 /**
@@ -220,14 +227,14 @@ export function anthropicThinkingProviderOptions(
   // models (Opus 4.7/4.8) must NOT receive the manual `budgetTokens` — the
   // provider 400s on it — so emit the adaptive shape; the numeric budget stays a
   // gate, not a forwarded cap (#16149). Manual-budget models are unchanged.
+  const adaptive = usesAdaptiveThinking(modelId);
   const anthropic = (
-    usesAdaptiveThinking(modelId)
-      ? anthropicAdaptiveThinkingOptions()
-      : anthropicThinkingOptions(budget)
+    adaptive ? anthropicAdaptiveThinkingOptions() : anthropicThinkingOptions(budget)
   ) as CloudJsonObject;
   return {
     providerOptions: {
       anthropic,
+      ...(adaptive ? { openai: openRouterAdaptiveThinkingOptions() } : {}),
     },
   };
 }

--- a/packages/scripts/__tests__/real-live-suites.test.ts
+++ b/packages/scripts/__tests__/real-live-suites.test.ts
@@ -130,6 +130,19 @@ describe("real/live guarded-suite manifest (#9310 §E)", () => {
     });
   });
 
+  test("adaptive Anthropic thinking has an invocable credentialed live proof", () => {
+    expect(
+      manifest.find(
+        (entry) =>
+          entry.file ===
+          "packages/cloud/shared/src/lib/providers/anthropic-thinking.live.test.ts",
+      ),
+    ).toMatchObject({
+      optIn: "ELIZA_LIVE_TEST",
+      requires: ["ANTHROPIC_API_KEY"],
+    });
+  });
+
   test("every declared guard env var is read by the suite or its guardVia helpers", () => {
     const problems: string[] = [];
     for (const entry of manifest) {

--- a/packages/scripts/__tests__/real-live-suites.test.ts
+++ b/packages/scripts/__tests__/real-live-suites.test.ts
@@ -143,6 +143,22 @@ describe("real/live guarded-suite manifest (#9310 §E)", () => {
     });
   });
 
+  test("the exact Anthropic receipt disables aggregate coverage with a real Bun config", () => {
+    const workflow = fs.readFileSync(
+      path.join(repoRoot, ".github/workflows/develop-live.yml"),
+      "utf8",
+    );
+    const liveConfig = fs.readFileSync(
+      path.join(repoRoot, "bunfig.live.toml"),
+      "utf8",
+    );
+    expect(workflow).toMatch(
+      /bun --config=bunfig[.]live[.]toml test\s+packages\/cloud\/shared\/src\/lib\/providers\/anthropic-thinking[.]live[.]test[.]ts/,
+    );
+    expect(liveConfig).toMatch(/\[test\][\s\S]*coverage\s*=\s*false/);
+    expect(liveConfig).toMatch(/timeout\s*=\s*120000/);
+  });
+
   test("every declared guard env var is read by the suite or its guardVia helpers", () => {
     const problems: string[] = [];
     for (const entry of manifest) {

--- a/packages/scripts/lib/real-live-suites.mjs
+++ b/packages/scripts/lib/real-live-suites.mjs
@@ -59,6 +59,13 @@ const DISCOVERY_SKIP_DIRS = new Set([
 
 export const GUARDED_REAL_LIVE_SUITES = [
   {
+    file: "packages/cloud/shared/src/lib/providers/anthropic-thinking.live.test.ts",
+    requires: ["ANTHROPIC_API_KEY"],
+    optIn: "ELIZA_LIVE_TEST",
+    notes:
+      "exact cloud resolver request/response trajectory proving Opus 4.7 adaptive thinking reaches Anthropic without budget_tokens",
+  },
+  {
     file: "packages/agent/src/services/push/push-delivery.real.test.ts",
     anyOf: [["ELIZA_APNS_KEY_ID"], ["ELIZA_FCM_SERVICE_ACCOUNT"]],
     guardVia: [


### PR DESCRIPTION
# Relates to

Closes #16149

## Outcome

Opus 4.7 and 4.8 now use provider-managed adaptive thinking across native Anthropic, OpenRouter, and Vercel AI Gateway resolution. The serialized request never sends a manual thinking token budget for those models. Opus through 4.6 and Sonnet 4 retain their existing `enabled + budgetTokens` behavior, and a zero/absent configured budget still disables thinking.

The accepted aliases are deliberately bounded: bare, dot, hyphen, and provider-prefixed Opus 4.7/4.8 identifiers resolve as adaptive; near-matches and later unknown versions do not silently enter the adaptive path.

## Verification

- Adaptive serialization matrix: 10/10 passed, covering Opus 4.7/4.8 aliases, negative near-matches, manual-budget models, unsupported models, and disabled thinking.
- Real resolver/request boundary: 7/7 passed across native Anthropic, OpenRouter fallback, and Vercel AI Gateway provider shapes.
- Live-suite manifest contract: 11/11 passed (22 assertions), including the dedicated no-coverage Bun config and exact workflow invocation.
- Exact verified head: `e4000e4a3620610b07b8541451546d8a5b6a7ecd`.
- Exact live run: [Develop Live Sweep 29254037295](https://github.com/elizaOS/eliza/actions/runs/29254037295), successful.

### Manually reviewed live trajectory

The exact-head workflow sent a real request through the production OpenRouter fallback for `anthropic/claude-opus-4-7`:

```json
{
  "model": "anthropic/claude-opus-4-7",
  "max_tokens": 4096,
  "reasoning_effort": "high",
  "manual_budget_present": false
}
```

The live model returned:

> ADAPTIVE_OK. Two even integers can be written as 2a and 2b, and their sum 2a + 2b = 2(a + b) is divisible by 2, hence even.

Finish reason was `stop`; usage was 50 input, 64 output, 114 total tokens. The run asserted `reasoning_effort: high`, absence of `budget_tokens`, and the live `ADAPTIVE_OK` response (1 pass, 0 failures).

The native Anthropic credential independently reached `https://api.anthropic.com/v1/messages` with model `claude-opus-4-7` and was rejected by Anthropic for insufficient account credit (`invalid_request_error`, request `req_011CcyzVRu3ixWy8dXN3Fowo`), rather than request-shape validation. The production OpenRouter fallback then proved the successful live path.

Permanent reviewed receipt: [pr-16220-anthropic-adaptive-thinking-evidence.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr-16220-anthropic-adaptive-thinking-evidence.json)  
SHA-256: `3ae919a8331e9d746511d47c1eb953f9d5e9868fd4f97fddc38a99f684195b98`

## Evidence gate

<!-- evidence-row:before-screenshots -->
- [x] N/A — backend-only provider request shaping; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A — backend-only provider request shaping; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A — no interactive user-facing flow; the live request/response trajectory is the reviewable behavior.
<!-- evidence-row:backend-logs -->
- [x] Exact-head backend/test logs are preserved in [run 29254037295](https://github.com/elizaOS/eliza/actions/runs/29254037295), including the serialized request, response, usage, assertions, and successful no-coverage execution.
<!-- evidence-row:frontend-logs -->
- [x] N/A — no frontend involvement.
<!-- evidence-row:llm-trajectory -->
- [x] [Real live Opus 4.7 request/response trajectory JSON](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr-16220-anthropic-adaptive-thinking-evidence.json), produced at exact head by [run 29254037295](https://github.com/elizaOS/eliza/actions/runs/29254037295) and manually reviewed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A — this change shapes provider requests and creates no DB rows, memories, files, or other durable domain records.

## Risk

Low and bounded to the shared Anthropic thinking-options helper plus its live receipt lane. Manual-budget models retain their prior request shape. The live lane uses `bunfig.live.toml` so the one real-provider receipt does not accidentally invoke the repository-wide coverage collector; ordinary test coverage configuration is unchanged.

No acceptance gaps or follow-ups remain for #16149.
