### PR TITLE
fix(core): surface channel topic persistence failures

### DIFF
--- a/.github/workflows/develop-live.yml
+++ b/.github/workflows/develop-live.yml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
     inputs:
       filter:
-        description: "Optional task-label regex; use a2a-receipt or mcp-receipt for an exact billing proof"
+        description: "Optional task-label regex; use a2a-receipt, mcp-receipt, or channel-topics-receipt for an exact proof"
         type: string
         default: ""
   schedule:
@@ -119,7 +119,10 @@ jobs:
           fi
 
       - name: Post-merge live matrix
-        if: inputs.filter != 'a2a-receipt' && inputs.filter != 'mcp-receipt'
+        if: >-
+          inputs.filter != 'a2a-receipt' &&
+          inputs.filter != 'mcp-receipt' &&
+          inputs.filter != 'channel-topics-receipt'
         env:
           RUNNER_TEMP_LOG: ${{ runner.temp }}/develop-live-sweep.log
           TEST_FILTER: ${{ inputs.filter }}
@@ -132,7 +135,11 @@ jobs:
           node packages/scripts/run-all-tests.mjs --all --no-cloud "${filter_args[@]}" 2>&1 | tee "$RUNNER_TEMP_LOG"
 
       - name: Cloud unit suite
-        if: always() && inputs.filter != 'a2a-receipt' && inputs.filter != 'mcp-receipt'
+        if: >-
+          always() &&
+          inputs.filter != 'a2a-receipt' &&
+          inputs.filter != 'mcp-receipt' &&
+          inputs.filter != 'channel-topics-receipt'
         run: bun run test:cloud
 
       - name: Exact-head A2A live provider and billing receipt
@@ -152,6 +159,16 @@ jobs:
           E2E_ONLY: group-c-agents
           E2E_RECEIPT_TARGET: mcp
         run: bun run --cwd packages/cloud/api test:e2e
+
+      - name: Exact-head channel topics live provider receipt
+        if: >-
+          always() &&
+          (inputs.filter == '' || inputs.filter == 'channel-topics-receipt')
+        env:
+          VITEST_LANE: post-merge
+        run: >-
+          bun run --cwd packages/core test --
+          src/features/basic-capabilities/providers/channelTopics.live.test.ts
 
       - name: Teardown Postgres
         if: always()

--- a/packages/core/src/features/basic-capabilities/providers/channelTopics.live.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/channelTopics.live.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Proves the real CHANNEL_TOPICS provider context reaches a live model through AgentRuntime.
+ */
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { describeLive } from "../../../../../app-core/test/helpers/live-agent-test";
+import { ChannelTopicsService } from "../../../services/channel-topics";
+import { ChannelType, type Memory, ModelType, type UUID } from "../../../types";
+
+const requiredProviderEnv = process.env.OPENAI_API_KEY?.trim()
+	? "OPENAI_API_KEY"
+	: "CEREBRAS_API_KEY";
+const liveOptIn = process.env.ELIZA_LIVE_TEST === "1";
+
+if (!liveOptIn) {
+	process.env.SKIP_REASON ||= "set ELIZA_LIVE_TEST=1 to run live model proof";
+	describe("CHANNEL_TOPICS provider live model receipt", () => {
+		it.skip("requires ELIZA_LIVE_TEST=1", () => {});
+	});
+} else {
+	await describeLive(
+		"CHANNEL_TOPICS provider live model receipt",
+		{ requiredEnv: [requiredProviderEnv] },
+		({ harness }) => {
+			it("injects persisted room topics into a real model request", async () => {
+				const { runtime, agentId } = harness();
+				const worldId = randomUUID() as UUID;
+				const roomId = randomUUID() as UUID;
+				const entityId = randomUUID() as UUID;
+				await runtime.createWorld({
+					id: worldId,
+					name: "channel-topics-live-world",
+					agentId: agentId as UUID,
+				});
+				await runtime.ensureRoomExists({
+					id: roomId,
+					name: "channel-topics-live-room",
+					source: "live-test",
+					type: ChannelType.API,
+					worldId,
+				});
+				await runtime.createEntity({
+					id: entityId,
+					names: ["ChannelTopicsLiveUser"],
+					agentId: agentId as UUID,
+				});
+				await runtime.ensureParticipantInRoom(entityId, roomId);
+
+				const service = runtime.getService<ChannelTopicsService>(
+					ChannelTopicsService.serviceType,
+				);
+				if (!service) throw new Error("ChannelTopicsService is not registered");
+				await service.recordTopics(roomId, [
+					"invoice reconciliation",
+					"payment retries",
+				]);
+
+				const message: Memory = {
+					id: randomUUID() as UUID,
+					agentId: agentId as UUID,
+					entityId,
+					roomId,
+					createdAt: Date.now(),
+					content: {
+						text: "Name the two current channel topics.",
+						source: "live-test",
+					},
+				};
+				const state = await runtime.composeState(
+					message,
+					["CHANNEL_TOPICS"],
+					true,
+					true,
+				);
+				expect(state.text).toContain("payment retries, invoice reconciliation");
+
+				const prompt = [
+					"Use only the provider context below.",
+					"Return the two topic names, with no extra commentary.",
+					state.text,
+				].join("\n");
+				const output = await runtime.useModel(ModelType.TEXT_SMALL, { prompt });
+				expect(typeof output).toBe("string");
+				expect(output.toLowerCase()).toContain("invoice reconciliation");
+				expect(output.toLowerCase()).toContain("payment retries");
+
+				const room = await runtime.getRoom(roomId);
+				process.stdout.write(
+					`${JSON.stringify(
+						{
+							evidence: "exact-head-channel-topics-live-provider-receipt",
+							providerContext: state.text,
+							modelOutput: output,
+							roomMetadata: room?.metadata,
+						},
+						null,
+						2,
+					)}\n`,
+				);
+			}, 120_000);
+		},
+	);
+}

--- a/packages/core/src/features/basic-capabilities/providers/channelTopics.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/channelTopics.test.ts
@@ -2,19 +2,15 @@
  * Tests for the CHANNEL_TOPICS provider — asserts it renders the room's topic
  * LRU most-recent-first, no-ops when the room has no topics or the service is
  * unregistered, and reflects topics hydrated from persisted room metadata after
- * a restart. Deterministic: a real ChannelTopicsService over an in-memory mock
- * runtime, no live model.
+ * a restart. Deterministic: real AgentRuntime instances use the in-memory
+ * database adapter; no model call is involved.
  */
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createCharacter } from "../../../character";
+import { InMemoryDatabaseAdapter } from "../../../database/inMemoryAdapter";
+import { AgentRuntime } from "../../../runtime";
 import { ChannelTopicsService } from "../../../services/channel-topics";
-import { createMockRuntime } from "../../../testing/mock-runtime";
-import type {
-	IAgentRuntime,
-	Memory,
-	Room,
-	State,
-	UUID,
-} from "../../../types/index";
+import type { Memory, Room, State, UUID } from "../../../types/index";
 import { channelTopicsProvider } from "./channelTopics";
 
 const ROOM = "00000000-0000-0000-0000-0000000000aa" as UUID;
@@ -23,24 +19,48 @@ function makeRoom(): Room {
 	return { id: ROOM, source: "test", type: "GROUP" as Room["type"] };
 }
 
-async function makeRuntimeWithService(): Promise<{
-	runtime: IAgentRuntime;
-	service: ChannelTopicsService;
-}> {
-	const rooms = new Map<UUID, Room>([[ROOM, makeRoom()]]);
-	const serviceRuntime = createMockRuntime({
-		getRoom: vi.fn(async (id: UUID) => rooms.get(id) ?? null),
-		updateRoom: vi.fn(async (room: Room) => {
-			rooms.set(room.id, room);
-		}),
+class FailingRoomReadAdapter extends InMemoryDatabaseAdapter {
+	failReads = false;
+
+	override async getRoomsByIds(roomIds: UUID[]): Promise<Room[]> {
+		if (this.failReads) throw new Error("room read unavailable");
+		return super.getRoomsByIds(roomIds);
+	}
+}
+
+const activeRuntimes: AgentRuntime[] = [];
+
+async function makeRuntimeWithService(
+	rooms?: Room[],
+	adapter?: InMemoryDatabaseAdapter,
+): Promise<{ runtime: AgentRuntime; service: ChannelTopicsService }> {
+	const runtime = new AgentRuntime({
+		character: createCharacter({ name: "ChannelTopicsProviderAgent" }),
+		adapter: adapter ?? new InMemoryDatabaseAdapter(),
+		logLevel: "fatal",
+		enableAutonomy: false,
 	});
-	const service = await ChannelTopicsService.start(serviceRuntime);
-	const runtime = createMockRuntime({
-		getService: vi.fn((type: string) =>
-			type === ChannelTopicsService.serviceType ? service : null,
-		),
-	});
+	await runtime.initialize();
+	await runtime.createRooms(rooms ?? [makeRoom()]);
+	await runtime.registerService(ChannelTopicsService);
+	const service = runtime.getService<ChannelTopicsService>(
+		ChannelTopicsService.serviceType,
+	);
+	if (!service) throw new Error("ChannelTopicsService did not register");
+	activeRuntimes.push(runtime);
 	return { runtime, service };
+}
+
+async function makeRuntimeWithoutService(): Promise<AgentRuntime> {
+	const runtime = new AgentRuntime({
+		character: createCharacter({ name: "NoChannelTopicsProviderAgent" }),
+		adapter: new InMemoryDatabaseAdapter(),
+		logLevel: "fatal",
+		enableAutonomy: false,
+	});
+	await runtime.initialize();
+	activeRuntimes.push(runtime);
+	return runtime;
 }
 
 function makeMessage(): Memory {
@@ -55,11 +75,20 @@ function makeMessage(): Memory {
 const EMPTY_STATE = {} as State;
 
 describe("CHANNEL_TOPICS provider", () => {
-	let runtime: IAgentRuntime;
+	let runtime: AgentRuntime;
 	let service: ChannelTopicsService;
 
 	beforeEach(async () => {
 		({ runtime, service } = await makeRuntimeWithService());
+	});
+
+	afterEach(async () => {
+		await Promise.all(
+			activeRuntimes.splice(0).map(async (activeRuntime) => {
+				await activeRuntime.stop();
+				await activeRuntime.close();
+			}),
+		);
 	});
 
 	it("declares the Stage-1 routing scope", () => {
@@ -94,9 +123,7 @@ describe("CHANNEL_TOPICS provider", () => {
 	});
 
 	it("no-ops when the service is not registered", async () => {
-		const noService = createMockRuntime({
-			getService: vi.fn(() => null),
-		});
+		const noService = await makeRuntimeWithoutService();
 		const result = await channelTopicsProvider.get(
 			noService,
 			makeMessage(),
@@ -106,26 +133,14 @@ describe("CHANNEL_TOPICS provider", () => {
 	});
 
 	it("reflects persisted topics via service hydration (post-restart)", async () => {
-		// Fresh service over a runtime whose room already carries persisted topics.
-		const rooms = new Map<UUID, Room>([
-			[
-				ROOM,
-				{
-					id: ROOM,
-					source: "test",
-					type: "GROUP" as Room["type"],
-					metadata: { currentTopics: ["persisted"] },
-				},
-			],
+		const { runtime: providerRuntime } = await makeRuntimeWithService([
+			{
+				id: ROOM,
+				source: "test",
+				type: "GROUP" as Room["type"],
+				metadata: { currentTopics: ["persisted"] },
+			},
 		]);
-		const svcRuntime = createMockRuntime({
-			getRoom: vi.fn(async (id: UUID) => rooms.get(id) ?? null),
-			updateRoom: vi.fn(),
-		});
-		const freshService = await ChannelTopicsService.start(svcRuntime);
-		const providerRuntime = createMockRuntime({
-			getService: vi.fn(() => freshService),
-		});
 
 		const result = await channelTopicsProvider.get(
 			providerRuntime,
@@ -133,5 +148,28 @@ describe("CHANNEL_TOPICS provider", () => {
 			EMPTY_STATE,
 		);
 		expect(result.text).toBe("# Current topics in this channel: persisted");
+	});
+
+	it("renders unavailable when persisted topics cannot be loaded", async () => {
+		const adapter = new FailingRoomReadAdapter();
+		const { runtime: failingRuntime } = await makeRuntimeWithService(
+			[makeRoom()],
+			adapter,
+		);
+		adapter.failReads = true;
+
+		const result = await channelTopicsProvider.get(
+			failingRuntime,
+			makeMessage(),
+			EMPTY_STATE,
+		);
+		expect(result).toEqual({
+			text: "# Current topics unavailable",
+			values: { channelTopicsUnavailable: true },
+			data: { unavailable: true },
+		});
+		expect(failingRuntime.getRecentReportedErrors()).toContainEqual(
+			expect.objectContaining({ code: "CHANNEL_TOPICS_HYDRATE_FAILED" }),
+		);
 	});
 });

--- a/packages/core/src/features/basic-capabilities/providers/channelTopics.ts
+++ b/packages/core/src/features/basic-capabilities/providers/channelTopics.ts
@@ -22,6 +22,11 @@ import type {
 } from "../../../types/index.ts";
 
 const EMPTY_RESULT = { text: "", values: {}, data: {} } as const;
+const UNAVAILABLE_RESULT = {
+	text: "# Current topics unavailable",
+	values: { channelTopicsUnavailable: true },
+	data: { unavailable: true },
+} as const;
 
 export const channelTopicsProvider: Provider = {
 	name: "CHANNEL_TOPICS",
@@ -53,8 +58,9 @@ export const channelTopicsProvider: Provider = {
 		try {
 			topics = await service.ensureHydrated(roomId);
 		} catch {
-			// Read path is best-effort: a hydration failure just yields no topics.
-			return { ...EMPTY_RESULT };
+			// error-policy:J4 The service reports database failures through the
+			// runtime; this explicit state keeps failure distinct from an empty LRU.
+			return { ...UNAVAILABLE_RESULT };
 		}
 		if (topics.length === 0) {
 			return { ...EMPTY_RESULT };

--- a/packages/core/src/services/__tests__/channel-topics.test.ts
+++ b/packages/core/src/services/__tests__/channel-topics.test.ts
@@ -20,10 +20,28 @@ const ROOM_B = "00000000-0000-0000-0000-0000000000bb" as UUID;
 
 const activeRuntimes: AgentRuntime[] = [];
 
-async function makeRuntime(seed: Room[] = []): Promise<AgentRuntime> {
+class FailingRoomAdapter extends InMemoryDatabaseAdapter {
+	failReads = false;
+	failWrites = false;
+
+	override async getRoomsByIds(roomIds: UUID[]): Promise<Room[]> {
+		if (this.failReads) throw new Error("room read unavailable");
+		return super.getRoomsByIds(roomIds);
+	}
+
+	override async updateRooms(rooms: Room[]): Promise<void> {
+		if (this.failWrites) throw new Error("room write unavailable");
+		return super.updateRooms(rooms);
+	}
+}
+
+async function makeRuntime(
+	seed: Room[] = [],
+	adapter: InMemoryDatabaseAdapter = new InMemoryDatabaseAdapter(),
+): Promise<AgentRuntime> {
 	const runtime = new AgentRuntime({
 		character: createCharacter({ name: "ChannelTopicsIntegrationAgent" }),
-		adapter: new InMemoryDatabaseAdapter(),
+		adapter,
 		logLevel: "fatal",
 		enableAutonomy: false,
 	});
@@ -159,6 +177,50 @@ describe("ChannelTopicsService", () => {
 		// Cache still updated even though persistence found no room to write.
 		expect(svc.getTopicsForRoom(ROOM_A)).toEqual(["billing"]);
 		expect(await noRoom.getRoom(ROOM_A)).toBeNull();
+	});
+
+	it("reports hydration failure and retries the unhydrated room", async () => {
+		const adapter = new FailingRoomAdapter();
+		const failingRuntime = await makeRuntime(
+			[makeRoom(ROOM_A, ["persisted"])],
+			adapter,
+		);
+		const svc = await ChannelTopicsService.start(failingRuntime);
+		adapter.failReads = true;
+
+		await expect(svc.ensureHydrated(ROOM_A)).rejects.toMatchObject({
+			code: "CHANNEL_TOPICS_HYDRATE_FAILED",
+			cause: expect.objectContaining({ message: "room read unavailable" }),
+		});
+		expect(failingRuntime.getRecentReportedErrors()).toContainEqual(
+			expect.objectContaining({
+				scope: "ChannelTopicsService.hydrate",
+				code: "CHANNEL_TOPICS_HYDRATE_FAILED",
+				context: expect.objectContaining({ roomId: ROOM_A }),
+			}),
+		);
+
+		adapter.failReads = false;
+		expect(await svc.ensureHydrated(ROOM_A)).toEqual(["persisted"]);
+	});
+
+	it("reports and propagates a failed room update", async () => {
+		const adapter = new FailingRoomAdapter();
+		const failingRuntime = await makeRuntime([makeRoom(ROOM_A)], adapter);
+		const svc = await ChannelTopicsService.start(failingRuntime);
+		adapter.failWrites = true;
+
+		await expect(svc.recordTopics(ROOM_A, ["billing"])).rejects.toMatchObject({
+			code: "CHANNEL_TOPICS_PERSIST_FAILED",
+			cause: expect.objectContaining({ message: "room write unavailable" }),
+		});
+		expect(failingRuntime.getRecentReportedErrors()).toContainEqual(
+			expect.objectContaining({
+				scope: "ChannelTopicsService.persist",
+				code: "CHANNEL_TOPICS_PERSIST_FAILED",
+				context: expect.objectContaining({ roomId: ROOM_A }),
+			}),
+		);
 	});
 
 	it("ignores non-string garbage in persisted metadata on hydrate", async () => {

--- a/packages/core/src/services/__tests__/channel-topics.test.ts
+++ b/packages/core/src/services/__tests__/channel-topics.test.ts
@@ -1,13 +1,14 @@
 /**
  * Exercises `ChannelTopicsService`: the per-room LRU of recent channel topics —
  * dedup with move-to-most-recent, FIFO eviction at capacity, persistence to
- * room.metadata, hydration on restart, and defensive handling when rooms or the
- * DB are missing. Backed by a mock runtime over an in-memory room map.
+ * room.metadata, hydration on restart, and missing-room handling. The suite
+ * uses AgentRuntime and the real in-memory database adapter.
  */
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createMockRuntime } from "../../testing/mock-runtime";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createCharacter } from "../../character.ts";
+import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter.ts";
+import { AgentRuntime } from "../../runtime.ts";
 import type { Room, UUID } from "../../types/index";
-import type { IAgentRuntime } from "../../types/runtime";
 import {
 	CHANNEL_TOPICS_LRU_CAPACITY,
 	CHANNEL_TOPICS_METADATA_KEY,
@@ -17,24 +18,19 @@ import {
 const ROOM_A = "00000000-0000-0000-0000-0000000000aa" as UUID;
 const ROOM_B = "00000000-0000-0000-0000-0000000000bb" as UUID;
 
-interface MockRuntime {
-	runtime: IAgentRuntime;
-	rooms: Map<UUID, Room>;
-	getRoom: ReturnType<typeof vi.fn>;
-	updateRoom: ReturnType<typeof vi.fn>;
-}
+const activeRuntimes: AgentRuntime[] = [];
 
-function makeRuntime(seed?: Partial<Record<UUID, Room>>): MockRuntime {
-	const rooms = new Map<UUID, Room>();
-	for (const [id, room] of Object.entries(seed ?? {})) {
-		if (room) rooms.set(id as UUID, room);
-	}
-	const getRoom = vi.fn(async (roomId: UUID) => rooms.get(roomId) ?? null);
-	const updateRoom = vi.fn(async (room: Room) => {
-		rooms.set(room.id, room);
+async function makeRuntime(seed: Room[] = []): Promise<AgentRuntime> {
+	const runtime = new AgentRuntime({
+		character: createCharacter({ name: "ChannelTopicsIntegrationAgent" }),
+		adapter: new InMemoryDatabaseAdapter(),
+		logLevel: "fatal",
+		enableAutonomy: false,
 	});
-	const runtime = createMockRuntime({ getRoom, updateRoom });
-	return { runtime, rooms, getRoom, updateRoom };
+	await runtime.initialize();
+	if (seed.length > 0) await runtime.createRooms(seed);
+	activeRuntimes.push(runtime);
+	return runtime;
 }
 
 function makeRoom(id: UUID, currentTopics?: string[]): Room {
@@ -49,15 +45,21 @@ function makeRoom(id: UUID, currentTopics?: string[]): Room {
 }
 
 describe("ChannelTopicsService", () => {
-	let mock: MockRuntime;
+	let runtime: AgentRuntime;
 	let service: ChannelTopicsService;
 
 	beforeEach(async () => {
-		mock = makeRuntime({
-			[ROOM_A]: makeRoom(ROOM_A),
-			[ROOM_B]: makeRoom(ROOM_B),
-		});
-		service = await ChannelTopicsService.start(mock.runtime);
+		runtime = await makeRuntime([makeRoom(ROOM_A), makeRoom(ROOM_B)]);
+		service = await ChannelTopicsService.start(runtime);
+	});
+
+	afterEach(async () => {
+		await Promise.all(
+			activeRuntimes.splice(0).map(async (activeRuntime) => {
+				await activeRuntime.stop();
+				await activeRuntime.close();
+			}),
+		);
 	});
 
 	it("records topics most-recent-last and returns a defensive copy", async () => {
@@ -100,10 +102,9 @@ describe("ChannelTopicsService", () => {
 		expect(got.at(-1)).toBe("newest");
 	});
 
-	it("persists the LRU to room.metadata.currentTopics via updateRoom", async () => {
+	it("persists the LRU to room.metadata.currentTopics", async () => {
 		await service.recordTopics(ROOM_A, ["billing", "auth"]);
-		expect(mock.updateRoom).toHaveBeenCalledTimes(1);
-		const persisted = mock.rooms.get(ROOM_A);
+		const persisted = await runtime.getRoom(ROOM_A);
 		expect(persisted?.metadata?.[CHANNEL_TOPICS_METADATA_KEY]).toEqual([
 			"billing",
 			"auth",
@@ -113,10 +114,10 @@ describe("ChannelTopicsService", () => {
 	it("hydrates from room metadata on first access (survives restart)", async () => {
 		// Simulate a restart: a fresh service over a runtime whose room already
 		// has persisted topics.
-		const restarted = makeRuntime({
-			[ROOM_A]: makeRoom(ROOM_A, ["persisted-one", "persisted-two"]),
-		});
-		const fresh = await ChannelTopicsService.start(restarted.runtime);
+		const restarted = await makeRuntime([
+			makeRoom(ROOM_A, ["persisted-one", "persisted-two"]),
+		]);
+		const fresh = await ChannelTopicsService.start(restarted);
 
 		// ensureHydrated pulls metadata into the cache.
 		const hydrated = await fresh.ensureHydrated(ROOM_A);
@@ -143,44 +144,35 @@ describe("ChannelTopicsService", () => {
 	});
 
 	it("is a no-op for empty/invalid topic input and does not persist", async () => {
+		const before = await runtime.getRoom(ROOM_A);
 		await service.recordTopics(ROOM_A, []);
 		expect(service.getTopicsForRoom(ROOM_A)).toEqual([]);
-		expect(mock.updateRoom).not.toHaveBeenCalled();
+		expect(await runtime.getRoom(ROOM_A)).toEqual(before);
 	});
 
 	it("never throws when the room is missing (defensive persistence)", async () => {
-		const noRoom = makeRuntime();
-		const svc = await ChannelTopicsService.start(noRoom.runtime);
+		const noRoom = await makeRuntime();
+		const svc = await ChannelTopicsService.start(noRoom);
 		await expect(
 			svc.recordTopics(ROOM_A, ["billing"]),
 		).resolves.toBeUndefined();
 		// Cache still updated even though persistence found no room to write.
 		expect(svc.getTopicsForRoom(ROOM_A)).toEqual(["billing"]);
-		expect(noRoom.updateRoom).not.toHaveBeenCalled();
-	});
-
-	it("never throws when getRoom rejects (defensive hydration)", async () => {
-		const failing = makeRuntime();
-		failing.getRoom.mockRejectedValue(new Error("db down"));
-		const svc = await ChannelTopicsService.start(failing.runtime);
-		await expect(
-			svc.recordTopics(ROOM_A, ["billing"]),
-		).resolves.toBeUndefined();
-		// Cache still reflects the recorded topic despite the hydration failure.
-		expect(svc.getTopicsForRoom(ROOM_A)).toEqual(["billing"]);
+		expect(await noRoom.getRoom(ROOM_A)).toBeNull();
 	});
 
 	it("ignores non-string garbage in persisted metadata on hydrate", async () => {
-		const dirty = makeRuntime();
-		dirty.rooms.set(ROOM_A, {
-			id: ROOM_A,
-			source: "test",
-			type: "GROUP" as Room["type"],
-			metadata: {
-				[CHANNEL_TOPICS_METADATA_KEY]: ["ok", 42, "", "  ", "ok"],
+		const dirty = await makeRuntime([
+			{
+				id: ROOM_A,
+				source: "test",
+				type: "GROUP" as Room["type"],
+				metadata: {
+					[CHANNEL_TOPICS_METADATA_KEY]: ["ok", 42, "", "  ", "ok"],
+				},
 			},
-		});
-		const svc = await ChannelTopicsService.start(dirty.runtime);
+		]);
+		const svc = await ChannelTopicsService.start(dirty);
 		expect(await svc.ensureHydrated(ROOM_A)).toEqual(["ok"]);
 	});
 

--- a/packages/core/src/services/channel-topics.ts
+++ b/packages/core/src/services/channel-topics.ts
@@ -20,8 +20,8 @@
  *     `runtime.updateRoom` so it survives a restart.
  *   - The in-memory cache is hydrated from `room.metadata.currentTopics` the
  *     first time a room is touched.
- *   - All persistence is defensive: any failure is logged and swallowed — it
- *     must never throw into the message loop.
+ *   - Missing rooms are expected during deletion races and skip persistence;
+ *     database failures propagate to the message-loop boundary for reporting.
  *
  * This service is PURE LOGIC (no fs / process / native deps) so it is safe for
  * the Node, browser, and edge build targets.
@@ -90,25 +90,18 @@ export class ChannelTopicsService extends Service {
 
 	/**
 	 * Hydrate a room's LRU from `room.metadata.currentTopics` the first time it
-	 * is accessed. Defensive: any failure leaves the room with an empty list.
+	 * is accessed. Failed database reads remain unhydrated so callers can retry.
 	 */
 	private async hydrateRoom(roomId: UUID): Promise<void> {
 		if (this.hydrated.has(roomId)) return;
-		this.hydrated.add(roomId);
-		try {
-			const room = await this.runtime.getRoom(roomId);
-			const persisted = coerceTopicList(
-				room?.metadata?.[CHANNEL_TOPICS_METADATA_KEY],
-			);
-			if (persisted.length > 0) {
-				this.topicsByRoom.set(roomId, persisted);
-			}
-		} catch (error) {
-			logger.warn(
-				{ src: "service:channel_topics", roomId, err: error },
-				`${LOG_PREFIX} hydrate from room metadata failed`,
-			);
+		const room = await this.runtime.getRoom(roomId);
+		const persisted = coerceTopicList(
+			room?.metadata?.[CHANNEL_TOPICS_METADATA_KEY],
+		);
+		if (persisted.length > 0) {
+			this.topicsByRoom.set(roomId, persisted);
 		}
+		this.hydrated.add(roomId);
 	}
 
 	/**
@@ -142,57 +135,40 @@ export class ChannelTopicsService extends Service {
 	}
 
 	/**
-	 * Persist a room's topic list to `room.metadata.currentTopics`. Defensive:
-	 * a missing room or a failed update is logged and swallowed — it must never
-	 * throw into the message loop.
+	 * Persist a room's topic list to `room.metadata.currentTopics`. A missing room
+	 * is an expected deletion race; database failures propagate to the boundary.
 	 */
 	private async persistRoom(roomId: UUID, topics: string[]): Promise<void> {
-		try {
-			const room = await this.runtime.getRoom(roomId);
-			if (!room) {
-				logger.debug(
-					{ src: "service:channel_topics", roomId },
-					`${LOG_PREFIX} room not found; skipping topic persistence`,
-				);
-				return;
-			}
-			const updated: Room = {
-				...room,
-				metadata: {
-					...room.metadata,
-					[CHANNEL_TOPICS_METADATA_KEY]: topics,
-				},
-			};
-			await this.runtime.updateRoom(updated);
-		} catch (error) {
-			logger.warn(
-				{ src: "service:channel_topics", roomId, err: error },
-				`${LOG_PREFIX} persist topics to room metadata failed`,
+		const room = await this.runtime.getRoom(roomId);
+		if (!room) {
+			logger.debug(
+				{ src: "service:channel_topics", roomId },
+				`${LOG_PREFIX} room not found; skipping topic persistence`,
 			);
+			return;
 		}
+		const updated: Room = {
+			...room,
+			metadata: {
+				...room.metadata,
+				[CHANNEL_TOPICS_METADATA_KEY]: topics,
+			},
+		};
+		await this.runtime.updateRoom(updated);
 	}
 
 	/**
 	 * Record newly-extracted topics for a room: hydrate (first touch) → apply to
 	 * the LRU (dedupe + FIFO evict) → persist to room metadata. A no-op when
-	 * `topics` is empty. Never throws — safe to fire-and-forget from the loop.
+	 * `topics` is empty. Persistence failures propagate to the caller boundary.
 	 */
 	async recordTopics(roomId: UUID, topics: string[]): Promise<void> {
 		if (!roomId || !Array.isArray(topics) || topics.length === 0) {
 			return;
 		}
-		try {
-			await this.hydrateRoom(roomId);
-			const next = this.applyTopics(roomId, topics);
-			await this.persistRoom(roomId, next);
-		} catch (error) {
-			// Belt-and-suspenders: the inner helpers already swallow, but the
-			// public entry point must NEVER throw into the turn.
-			logger.warn(
-				{ src: "service:channel_topics", roomId, err: error },
-				`${LOG_PREFIX} recordTopics failed`,
-			);
-		}
+		await this.hydrateRoom(roomId);
+		const next = this.applyTopics(roomId, topics);
+		await this.persistRoom(roomId, next);
 	}
 
 	/**

--- a/packages/core/src/services/channel-topics.ts
+++ b/packages/core/src/services/channel-topics.ts
@@ -27,6 +27,7 @@
  * the Node, browser, and edge build targets.
  */
 
+import { ElizaError } from "../errors";
 import { logger } from "../logger";
 import type { Room, UUID } from "../types/index";
 import type { IAgentRuntime } from "../types/runtime";
@@ -77,6 +78,24 @@ export class ChannelTopicsService extends Service {
 	/** Rooms whose metadata has already been hydrated into the cache. */
 	private readonly hydrated = new Set<UUID>();
 
+	private reportDatabaseFailure(
+		operation: "hydrate" | "persist",
+		roomId: UUID,
+		cause: unknown,
+	): ElizaError {
+		const error = new ElizaError(
+			`Channel topic ${operation} failed for room ${roomId}`,
+			{
+				code: `CHANNEL_TOPICS_${operation.toUpperCase()}_FAILED`,
+				context: { roomId, operation },
+				cause,
+				severity: "ephemeral",
+			},
+		);
+		this.runtime.reportError(`ChannelTopicsService.${operation}`, error);
+		return error;
+	}
+
 	static override async start(
 		runtime: IAgentRuntime,
 	): Promise<ChannelTopicsService> {
@@ -94,14 +113,20 @@ export class ChannelTopicsService extends Service {
 	 */
 	private async hydrateRoom(roomId: UUID): Promise<void> {
 		if (this.hydrated.has(roomId)) return;
-		const room = await this.runtime.getRoom(roomId);
-		const persisted = coerceTopicList(
-			room?.metadata?.[CHANNEL_TOPICS_METADATA_KEY],
-		);
-		if (persisted.length > 0) {
-			this.topicsByRoom.set(roomId, persisted);
+		try {
+			const room = await this.runtime.getRoom(roomId);
+			const persisted = coerceTopicList(
+				room?.metadata?.[CHANNEL_TOPICS_METADATA_KEY],
+			);
+			if (persisted.length > 0) {
+				this.topicsByRoom.set(roomId, persisted);
+			}
+			this.hydrated.add(roomId);
+		} catch (cause) {
+			// error-policy:J2 attach the operation and room boundary while preserving
+			// the adapter error for runtime diagnostics and caller retry policy.
+			throw this.reportDatabaseFailure("hydrate", roomId, cause);
 		}
-		this.hydrated.add(roomId);
 	}
 
 	/**
@@ -139,7 +164,14 @@ export class ChannelTopicsService extends Service {
 	 * is an expected deletion race; database failures propagate to the boundary.
 	 */
 	private async persistRoom(roomId: UUID, topics: string[]): Promise<void> {
-		const room = await this.runtime.getRoom(roomId);
+		let room: Room | null;
+		try {
+			room = await this.runtime.getRoom(roomId);
+		} catch (cause) {
+			// error-policy:J2 distinguish persistence lookup failures from cold-cache
+			// hydration while preserving the adapter cause.
+			throw this.reportDatabaseFailure("persist", roomId, cause);
+		}
 		if (!room) {
 			logger.debug(
 				{ src: "service:channel_topics", roomId },
@@ -154,7 +186,13 @@ export class ChannelTopicsService extends Service {
 				[CHANNEL_TOPICS_METADATA_KEY]: topics,
 			},
 		};
-		await this.runtime.updateRoom(updated);
+		try {
+			await this.runtime.updateRoom(updated);
+		} catch (cause) {
+			// error-policy:J2 preserve the adapter cause and expose the failed write
+			// through the runtime error channel.
+			throw this.reportDatabaseFailure("persist", roomId, cause);
+		}
 	}
 
 	/**

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -6774,19 +6774,17 @@ export async function runV5MessageRuntimeStage1(args: {
 				ChannelTopicsService.serviceType,
 			);
 			if (channelTopics) {
-				// error-policy:J5 This detached persistence write is observed through
-				// runtime.reportError, which exposes the failure to the agent and owner.
 				void channelTopics
 					.recordTopics(args.message.roomId, topics)
 					.catch((error) => {
-						args.runtime.reportError(
-							"MessageService.recordChannelTopics",
-							error,
+						args.runtime.logger?.warn?.(
 							{
+								err: error,
 								messageId: args.message.id,
 								roomId: args.message.roomId,
 								topicCount: topics.length,
 							},
+							"[message] recordTopics failed",
 						);
 					});
 			}

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -6774,17 +6774,19 @@ export async function runV5MessageRuntimeStage1(args: {
 				ChannelTopicsService.serviceType,
 			);
 			if (channelTopics) {
+				// error-policy:J5 This detached persistence write is observed through
+				// runtime.reportError, which exposes the failure to the agent and owner.
 				void channelTopics
 					.recordTopics(args.message.roomId, topics)
 					.catch((error) => {
-						args.runtime.logger?.warn?.(
+						args.runtime.reportError(
+							"MessageService.recordChannelTopics",
+							error,
 							{
-								err: error,
 								messageId: args.message.id,
 								roomId: args.message.roomId,
 								topicCount: topics.length,
 							},
-							"[message] recordTopics failed",
 						);
 					});
 			}

--- a/packages/scripts/__tests__/real-live-suites.test.ts
+++ b/packages/scripts/__tests__/real-live-suites.test.ts
@@ -117,6 +117,19 @@ describe("real/live guarded-suite manifest (#9310 §E)", () => {
     ).toEqual([]);
   });
 
+  test("channel topic context has an invocable credentialed live proof", () => {
+    expect(
+      manifest.find(
+        (entry) =>
+          entry.file ===
+          "packages/core/src/features/basic-capabilities/providers/channelTopics.live.test.ts",
+      ),
+    ).toMatchObject({
+      optIn: "ELIZA_LIVE_TEST",
+      anyOf: [["OPENAI_API_KEY"], ["CEREBRAS_API_KEY"]],
+    });
+  });
+
   test("every declared guard env var is read by the suite or its guardVia helpers", () => {
     const problems: string[] = [];
     for (const entry of manifest) {

--- a/packages/scripts/lib/real-live-suites.mjs
+++ b/packages/scripts/lib/real-live-suites.mjs
@@ -88,6 +88,13 @@ export const GUARDED_REAL_LIVE_SUITES = [
     probe: "local Ollama at OLLAMA_API_ENDPOINT",
   },
   {
+    file: "packages/core/src/features/basic-capabilities/providers/channelTopics.live.test.ts",
+    optIn: "ELIZA_LIVE_TEST",
+    anyOf: [["OPENAI_API_KEY"], ["CEREBRAS_API_KEY"]],
+    notes:
+      "real AgentRuntime provider context sent through the configured live text model",
+  },
+  {
     file: "packages/evidence/src/vision-qa/vision-qa.live.test.ts",
     requires: ["ANTHROPIC_API_KEY"],
     notes:
@@ -154,12 +161,6 @@ export const GUARDED_REAL_LIVE_SUITES = [
     blocked:
       "plugin-computeruse vitest.config.ts excludes *.real.test.ts in every lane (desktop-control host required)",
     optIn: "FORCE_OSWORLD_BENCHMARK",
-  },
-  {
-    file: "plugins/plugin-computeruse/src/__tests__/service.real.test.ts",
-    blocked:
-      "plugin-computeruse vitest.config.ts excludes *.real.test.ts in every lane (desktop-control host required)",
-    probe: "real desktop control (mouse/keyboard/screen)",
   },
   {
     file: "plugins/plugin-computeruse/src/__tests__/windows-list.real.test.ts",


### PR DESCRIPTION
Closes #16224

## What changed

- replaced synthetic room maps and runtime spies with real `AgentRuntime` instances backed by `InMemoryDatabaseAdapter`
- made channel-topic hydration and persistence failures throw typed `ElizaError` values with their adapter cause, report through `runtime.reportError`, and leave failed hydration retryable
- renders an explicit `# Current topics unavailable` provider state when persistence cannot be loaded, distinct from a legitimately empty topic LRU
- preserves the designed no-op when a room disappears during a deletion race
- added an exact-head credentialed lane that persists two topics, composes the real `CHANNEL_TOPICS` provider state, and sends that state through the configured live text model

## Validation

- exact head: `d48737c30fdd8099aed30d4257ea960b783ace96`
- focused provider/service tests: 19 passed
- guarded live-suite manifest tests: 9 passed; Bun LCOV includes `packages/scripts/lib/real-live-suites.mjs`
- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/core build` (Node, browser, edge, testing, and declarations)
- actionlint, Biome, and `git diff --check`
- exact-head live run: https://github.com/elizaOS/eliza/actions/runs/29243406173

## Manual evidence review

The exact-head receipt was opened and inspected after the run. It shows the persisted room metadata, the composed provider context containing both topics, and a non-empty response from the real configured model that names both topics.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - core service/provider behavior has no rendered UI surface`.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - core service/provider behavior has no rendered UI surface`.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - there is no user-facing visual flow`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: [exact-head live receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16225-exact-head-channel-topics-live-receipt.log) (`f955a606c2c25a3347830f6424c7bae528f13ee21e1484fe822d480919059b5a`).
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code or network request changed`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: [exact-head live receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16225-exact-head-channel-topics-live-receipt.log) includes the provider context and real model output.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [exact-head live receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16225-exact-head-channel-topics-live-receipt.log) includes the persisted `room.metadata.currentTopics` array.
