### PR TITLE
test: ratchet internal mock runtimes and casts

### DIFF
--- a/packages/scripts/__tests__/test-realness-audit.test.ts
+++ b/packages/scripts/__tests__/test-realness-audit.test.ts
@@ -1,9 +1,10 @@
 // Exercises tests test realness audit.test automation behavior with deterministic script fixtures.
-import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, test } from "vitest";
 
 const audit = await import(
   new URL("../test-realness-audit.mjs", import.meta.url).href
@@ -171,6 +172,74 @@ describe("test-realness-audit", () => {
     );
   });
 
+  test("internal runtime mocks are diff-scoped migration debt", () => {
+    const root = makeRepo();
+    const relPath = "packages/sample/runtime.test.ts";
+    const baseFindings = audit.analyzeTestSource(
+      root,
+      relPath,
+      "import { test } from 'vitest';\ntest('real runtime', () => {});\n",
+    );
+    const currentFindings = audit.analyzeTestSource(
+      root,
+      relPath,
+      [
+        "import { createMockRuntime } from '../testing/mock-runtime';",
+        "import { test } from 'vitest';",
+        "test('synthetic runtime', () => {",
+        "  const runtime = createMockRuntime();",
+        "  void runtime;",
+        "});",
+      ].join("\n"),
+    );
+
+    expect(currentFindings).toContainEqual(
+      expect.objectContaining({
+        category: "internalRuntimeMock",
+        path: relPath,
+        line: 4,
+      }),
+    );
+    const regressions = audit.collectDiffScopedRegressions({
+      currentFindings,
+      baseFindings,
+      changedFiles: [relPath],
+    });
+    expect(audit.collectDiffScopedFailures(regressions)).toContain(
+      "internalRuntimeMock increased in touched test file packages/sample/runtime.test.ts: 1 current > 0 base",
+    );
+  });
+
+  test("partial objects cast to IAgentRuntime are diff-scoped migration debt", () => {
+    const root = makeRepo();
+    const relPath = "packages/sample/cast-runtime.test.ts";
+    const currentFindings = audit.analyzeTestSource(
+      root,
+      relPath,
+      [
+        "import type { IAgentRuntime } from '@elizaos/core';",
+        "const runtime = { agentId: 'fake' } as unknown as IAgentRuntime;",
+        "void runtime;",
+      ].join("\n"),
+    );
+
+    expect(currentFindings).toContainEqual(
+      expect.objectContaining({
+        category: "internalRuntimeCast",
+        path: relPath,
+        line: 2,
+      }),
+    );
+    const regressions = audit.collectDiffScopedRegressions({
+      currentFindings,
+      baseFindings: [],
+      changedFiles: [relPath],
+    });
+    expect(audit.collectDiffScopedFailures(regressions)).toContain(
+      "internalRuntimeCast increased in touched test file packages/sample/cast-runtime.test.ts: 1 current > 0 base",
+    );
+  });
+
   test("real-outcome assertions do not trigger the diff-scoped ratchet", () => {
     const root = makeRepo();
     const relPath = "packages/sample/real.test.ts";
@@ -208,18 +277,15 @@ describe("test-realness-audit", () => {
       "import { test } from 'vitest';\ntest('plain', () => {});\n",
     );
 
-    const result = Bun.spawnSync([
+    const result = spawnSync(
       "node",
-      SCRIPT_PATH,
-      "--repo-root",
-      root,
-      "--check",
-    ]);
+      [SCRIPT_PATH, "--repo-root", root, "--check"],
+      { encoding: "utf8" },
+    );
 
-    expect(result.exitCode).toBe(1);
-    const stderr = new TextDecoder().decode(result.stderr);
-    expect(stderr).toContain("diff-scoped ratchet could not run");
-    expect(stderr).toContain("Ensure CI fetches origin/develop");
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("diff-scoped ratchet could not run");
+    expect(result.stderr).toContain("Ensure CI fetches origin/develop");
   });
 
   test("comments do not register as focused tests", () => {
@@ -280,18 +346,20 @@ describe("test-realness-audit", () => {
     const baselinePath = path.join(root, "empty-baseline.json");
     fs.writeFileSync(baselinePath, "");
 
-    const result = Bun.spawnSync([
+    const result = spawnSync(
       "node",
-      SCRIPT_PATH,
-      "--repo-root",
-      root,
-      "--baseline",
-      baselinePath,
-      "--print-baseline",
-    ]);
+      [
+        SCRIPT_PATH,
+        "--repo-root",
+        root,
+        "--baseline",
+        baselinePath,
+        "--print-baseline",
+      ],
+      { encoding: "utf8" },
+    );
 
-    expect(result.exitCode).toBe(0);
-    const stdout = new TextDecoder().decode(result.stdout);
-    expect(JSON.parse(stdout).thresholds.focusedOnly).toBe(0);
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout).thresholds.focusedOnly).toBe(0);
   });
 });

--- a/packages/scripts/test-realness-audit.mjs
+++ b/packages/scripts/test-realness-audit.mjs
@@ -32,6 +32,12 @@
  *     not a mergeable-quality boundary.
  *   - tautologicalAssertion: same heuristic caveat — most hits are
  *     scaffolding inside otherwise-real tests.
+ *   - internalRuntimeMock: `createMockRuntime()` bypasses the real runtime
+ *     lifecycle and service/database architecture. Existing uses are migration
+ *     debt; touched test files may only reduce or preserve their count.
+ *   - internalRuntimeCast: completing a partial object with an `IAgentRuntime`
+ *     cast is the hand-written equivalent. Existing casts remain migration debt
+ *     but touched test files may not add more.
  *
  * The baseline file (test-realness-baseline.json) is a reference snapshot used
  * for delta reporting on the report-only categories; it does not gate. Use
@@ -80,6 +86,8 @@ export const CATEGORY_LABELS = Object.freeze({
   envConditionalSuite: "Env-gated conditional suite",
   tautologicalAssertion: "Tautological assertion",
   mockCallOnlyAssertion: "Mock-call-only assertion",
+  internalRuntimeMock: "Internal mock runtime",
+  internalRuntimeCast: "Partial object cast to IAgentRuntime",
 });
 
 const CHECKED_CATEGORIES = Object.keys(CATEGORY_LABELS);
@@ -95,6 +103,8 @@ export const ENFORCED_CATEGORIES = Object.freeze([
 ]);
 
 export const DIFF_SCOPED_CATEGORIES = Object.freeze([
+  "internalRuntimeCast",
+  "internalRuntimeMock",
   "mockCallOnlyAssertion",
   "tautologicalAssertion",
 ]);
@@ -402,6 +412,32 @@ export function analyzeTestSource(repoRoot, relativePath, sourceText) {
         lineNumber,
         detail:
           "Assertion proves a mock was invoked; pair it with the real outcome or artifact.",
+      });
+    }
+
+    if (/\bcreateMockRuntime\s*\(/u.test(line)) {
+      addRegexFinding({
+        findings,
+        category: "internalRuntimeMock",
+        repoRoot,
+        filePath,
+        sourceText,
+        lineNumber,
+        detail:
+          "createMockRuntime() bypasses AgentRuntime lifecycle and internal service/database integration.",
+      });
+    }
+
+    if (/\bas\s+(?:unknown\s+as\s+)?IAgentRuntime\b/u.test(line)) {
+      addRegexFinding({
+        findings,
+        category: "internalRuntimeCast",
+        repoRoot,
+        filePath,
+        sourceText,
+        lineNumber,
+        detail:
+          "IAgentRuntime cast can complete a partial object without exercising AgentRuntime architecture.",
       });
     }
   }


### PR DESCRIPTION
Closes #16226

## What changed

- added `internalRuntimeMock` and `internalRuntimeCast` to the test-realness inventory
- detects executable `createMockRuntime()` calls and `IAgentRuntime` completion casts after comments and strings are stripped
- includes both categories in the existing diff-scoped ratchet
- added deterministic coverage proving each pattern produces a touched-file regression

## Why

The repository currently has 139 `createMockRuntime()` calls and 978 `IAgentRuntime` cast findings in test files. Both patterns bypass real runtime lifecycle and internal service/database integration. Existing debt needs incremental migration without allowing new debt or a cast-based escape hatch.

## Validation

- audit self-tests: 11 passed
- full audit: 7,293 files scanned
- `node packages/scripts/test-realness-audit.mjs --check`
- Biome check passed

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - repository audit tooling with no rendered UI surface`.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - repository audit tooling with no rendered UI surface`.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - there is no user-facing visual flow`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - no runtime server path changed`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code or network request changed`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent action, provider, prompt, or model behavior changed`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - the machine-readable audit inventory is produced by the validated script`.