### PR TITLE
fix(cloud): cap A2A chat provider at the admitted output ceiling

### DIFF
--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -115,7 +115,7 @@ jobs:
           process_isolated_tests=()
           for test_file in "${changed_tests[@]}"; do
             case "$test_file" in
-              packages/cloud/api/v1/voice/session/__tests__/harness-real-server.test.ts|packages/tools/voice-evidence-harness/src/cli-run.test.ts)
+              packages/cloud/api/__tests__/agent-a2a-billing.test.ts|packages/cloud/api/v1/voice/session/__tests__/harness-real-server.test.ts|packages/tools/voice-evidence-harness/src/cli-run.test.ts)
                 process_isolated_tests+=("$test_file")
                 ;;
               *) shared_tests+=("$test_file") ;;

--- a/.github/workflows/develop-live.yml
+++ b/.github/workflows/develop-live.yml
@@ -47,6 +47,7 @@ jobs:
       CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      AI_GATEWAY_API_KEY: ${{ secrets.AI_GATEWAY_API_KEY }}
       GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
       GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
@@ -132,6 +133,10 @@ jobs:
       - name: Cloud unit suite
         if: always()
         run: bun run test:cloud
+
+      - name: Exact-head A2A live gateway and billing receipt
+        if: always()
+        run: bun run --cwd packages/cloud/api test:e2e group-c-agents.test.ts
 
       - name: Teardown Postgres
         if: always()

--- a/.github/workflows/develop-live.yml
+++ b/.github/workflows/develop-live.yml
@@ -134,9 +134,11 @@ jobs:
         if: always()
         run: bun run test:cloud
 
-      - name: Exact-head A2A live gateway and billing receipt
+      - name: Exact-head A2A live provider and billing receipt
         if: always()
-        run: bun run --cwd packages/cloud/api test:e2e group-c-agents.test.ts
+        env:
+          E2E_ONLY: group-c-agents
+        run: bun run --cwd packages/cloud/api test:e2e
 
       - name: Teardown Postgres
         if: always()

--- a/.github/workflows/develop-live.yml
+++ b/.github/workflows/develop-live.yml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
     inputs:
       filter:
-        description: "Optional --filter regex over task labels (default: whole matrix)"
+        description: "Optional task-label regex; use a2a-receipt for only the exact A2A proof"
         type: string
         default: ""
   schedule:
@@ -119,6 +119,7 @@ jobs:
           fi
 
       - name: Post-merge live matrix
+        if: inputs.filter != 'a2a-receipt'
         env:
           RUNNER_TEMP_LOG: ${{ runner.temp }}/develop-live-sweep.log
           TEST_FILTER: ${{ inputs.filter }}
@@ -131,11 +132,13 @@ jobs:
           node packages/scripts/run-all-tests.mjs --all --no-cloud "${filter_args[@]}" 2>&1 | tee "$RUNNER_TEMP_LOG"
 
       - name: Cloud unit suite
-        if: always()
+        if: always() && inputs.filter != 'a2a-receipt'
         run: bun run test:cloud
 
       - name: Exact-head A2A live provider and billing receipt
-        if: always()
+        if: >-
+          always() &&
+          (inputs.filter == '' || inputs.filter == 'cloud-api' || inputs.filter == 'a2a-receipt')
         env:
           E2E_ONLY: group-c-agents
         run: bun run --cwd packages/cloud/api test:e2e

--- a/packages/cloud/api/__tests__/agent-a2a-billing.test.ts
+++ b/packages/cloud/api/__tests__/agent-a2a-billing.test.ts
@@ -25,9 +25,9 @@ import * as workersHonoAuthActual from "@/lib/auth/workers-hono-auth";
 const ORG_ID = "00000000-0000-4000-8000-0000000000aa";
 const USER_ID = "00000000-0000-4000-8000-0000000000bb";
 
-const languageModel = mock((model: string) => ({ model }));
-mock.module("@ai-sdk/gateway", () => ({
-  gateway: { languageModel },
+const getLanguageModel = mock((model: string) => ({ model }));
+mock.module("@/lib/providers/language-model", () => ({
+  getLanguageModel,
 }));
 
 const streamText = mock();
@@ -173,7 +173,7 @@ function callChat(model = "gpt-5-mini") {
 }
 
 beforeEach(() => {
-  languageModel.mockClear();
+  getLanguageModel.mockClear();
   streamText.mockReset();
   resolveAnthropicThinkingBudgetTokens.mockReset();
   resolveAnthropicThinkingBudgetTokens.mockReturnValue(null);

--- a/packages/cloud/api/__tests__/agent-a2a-billing.test.ts
+++ b/packages/cloud/api/__tests__/agent-a2a-billing.test.ts
@@ -7,8 +7,8 @@
  * try. recordCreatorEarnings can throw on a transient DB error; the pre-fix code
  * let it reach the outer catch, which ran the NON-idempotent reconcile(0) —
  * double-refunding the WHOLE reservation (free inference + a net credit grant)
- * and returning a -32000 error. The fix swallows the earnings error so reconcile
- * fires exactly once and the already-correct settlement response is returned.
+ * and returning a -32000 error. The degraded response now preserves the model
+ * result with an explicit warning and reconciles exactly once.
  *
  * `handleChat` is module-private, so we drive it through the exported Hono app's
  * POST handler (method "chat"), mounted under `/agents/:id/a2a` so the `:id`
@@ -266,6 +266,32 @@ describe("Agent A2A billing", () => {
     expect(body.error?.message).toContain("Insufficient credits");
     expect(streamText).not.toHaveBeenCalled();
     expect(recordCreatorEarnings).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ["missing messages", {}],
+    ["non-array messages", { messages: "hello" }],
+    ["unsupported role", { messages: [{ role: "tool", content: "hello" }] }],
+    ["empty content", { messages: [{ role: "user", content: "" }] }],
+  ])("rejects invalid chat params before billing: %s", async (_label, params) => {
+    const response = await app.request("/agents/agent-1/a2a", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "chat",
+        params,
+        id: "invalid-rpc",
+      }),
+    });
+    const body = (await response.json()) as {
+      error?: { code: number; message: string };
+    };
+
+    expect(response.status).toBe(400);
+    expect(body.error?.code).toBe(-32602);
+    expect(reserve).not.toHaveBeenCalled();
+    expect(streamText).not.toHaveBeenCalled();
   });
 
   test("missing provider usage fails and refunds instead of fabricating zero metering", async () => {

--- a/packages/cloud/api/__tests__/agent-a2a-billing.test.ts
+++ b/packages/cloud/api/__tests__/agent-a2a-billing.test.ts
@@ -268,6 +268,28 @@ describe("Agent A2A billing", () => {
     expect(recordCreatorEarnings).not.toHaveBeenCalled();
   });
 
+  test("missing provider usage fails and refunds instead of fabricating zero metering", async () => {
+    const reconcile = makeReservation({ adjustmentType: "refund" });
+    streamText.mockResolvedValue({
+      textStream: textStream("unmetered output"),
+      usage: Promise.resolve({
+        inputTokens: undefined,
+        outputTokens: undefined,
+        totalTokens: undefined,
+      }),
+    });
+
+    const response = await callChat();
+    const body = (await response.json()) as {
+      error?: { code: number; message: string };
+    };
+
+    expect(body.error?.code).toBe(-32000);
+    expect(reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcile).toHaveBeenCalledWith(0);
+    expect(recordCreatorEarnings).not.toHaveBeenCalled();
+  });
+
   // Regression for #10266 (A2A side).
   test("post-settlement earnings failure does not double-refund the reservation", async () => {
     const reconcile = makeReservation({ adjustmentType: "none" });
@@ -277,7 +299,10 @@ describe("Agent A2A billing", () => {
 
     const response = await callChat();
     const body = (await response.json()) as {
-      result?: { content: string };
+      result?: {
+        content: string;
+        warnings?: Array<{ code: string; message: string }>;
+      };
       error?: { code: number; message: string };
     };
 
@@ -293,5 +318,11 @@ describe("Agent A2A billing", () => {
     expect(recordCreatorEarnings).toHaveBeenCalledTimes(1);
     expect(body.error).toBeUndefined();
     expect(body.result?.content).toBe("hello from model");
+    expect(body.result?.warnings).toEqual([
+      {
+        code: "CREATOR_EARNINGS_UNAVAILABLE",
+        message: "Creator earnings could not be recorded",
+      },
+    ]);
   });
 });

--- a/packages/cloud/api/__tests__/agent-a2a-billing.test.ts
+++ b/packages/cloud/api/__tests__/agent-a2a-billing.test.ts
@@ -44,11 +44,18 @@ mock.module("@/lib/pricing", () => ({
   getProviderFromModel,
 }));
 
+// Settable so a test can drive a non-null admitted thinking budget through the
+// mounted route (#16147). The resolver's own clamping is unit-tested elsewhere;
+// here it stands in for "whatever budget the route resolved to".
+const resolveAnthropicThinkingBudgetTokens = mock((): number | null => null);
+const mergeAnthropicCotProviderOptions = mock(
+  (): Record<string, unknown> => ({}),
+);
 mock.module("@/lib/providers/anthropic-thinking", () => ({
   getAnthropicCotEnv: () => ({}),
-  mergeAnthropicCotProviderOptions: () => ({}),
+  mergeAnthropicCotProviderOptions,
   parseThinkingBudgetFromCharacterSettings: () => null,
-  resolveAnthropicThinkingBudgetTokens: () => null,
+  resolveAnthropicThinkingBudgetTokens,
 }));
 
 const recordCreatorEarnings = mock();
@@ -166,6 +173,10 @@ function callChat() {
 beforeEach(() => {
   languageModel.mockClear();
   streamText.mockReset();
+  resolveAnthropicThinkingBudgetTokens.mockReset();
+  resolveAnthropicThinkingBudgetTokens.mockReturnValue(null);
+  mergeAnthropicCotProviderOptions.mockReset();
+  mergeAnthropicCotProviderOptions.mockReturnValue({});
   estimateRequestCost.mockReset();
   calculateCost.mockReset();
   getProviderFromModel.mockClear();
@@ -215,6 +226,32 @@ describe("Agent A2A billing", () => {
     );
     expect(body.error).toBeUndefined();
     expect(body.result?.content).toBe("hello from model");
+  });
+
+  // #16147: the output ceiling used to price/reserve must be the exact value
+  // capped on the provider call, for every resolved thinking budget including
+  // none. The resolver's clamping (char override / env default /
+  // ANTHROPIC_COT_BUDGET_MAX) is unit-tested separately; here we prove the route
+  // forwards whatever it resolved to BOTH sinks identically.
+  test.each([
+    [null, undefined],
+    [1024, 1524],
+    [8000, 8500],
+  ] as const)("prices and caps the provider at one admitted ceiling (budget=%p)", async (budget, expectedCap) => {
+    makeReservation({ adjustmentType: "none" });
+    resolveAnthropicThinkingBudgetTokens.mockReturnValue(budget);
+
+    const response = await callChat();
+    expect(response.status).toBe(200);
+
+    // Reserved with this exact ceiling (3rd arg to estimateRequestCost)...
+    expect(estimateRequestCost.mock.calls[0]?.[2]).toBe(expectedCap);
+    // ...and the provider is capped at the identical value — never omitted.
+    expect(streamText).toHaveBeenCalledTimes(1);
+    expect(streamText.mock.calls[0]?.[0]?.maxOutputTokens).toBe(expectedCap);
+    expect(streamText.mock.calls[0]?.[0]?.maxOutputTokens).toBe(
+      estimateRequestCost.mock.calls[0]?.[2],
+    );
   });
 
   // Regression for #10266 (A2A side).

--- a/packages/cloud/api/__tests__/agent-a2a-billing.test.ts
+++ b/packages/cloud/api/__tests__/agent-a2a-billing.test.ts
@@ -37,7 +37,9 @@ mock.module("ai", () => ({
 
 const estimateRequestCost = mock();
 const calculateCost = mock();
-const getProviderFromModel = mock(() => "openai");
+const getProviderFromModel = mock((model: string) =>
+  model.startsWith("anthropic/") ? "anthropic" : "openai",
+);
 mock.module("@/lib/pricing", () => ({
   calculateCost,
   estimateRequestCost,
@@ -45,7 +47,7 @@ mock.module("@/lib/pricing", () => ({
 }));
 
 // Settable so a test can drive a non-null admitted thinking budget through the
-// mounted route (#16147). The resolver's own clamping is unit-tested elsewhere;
+// mounted route (#16147). Resolver precedence and clamping have their own tests;
 // here it stands in for "whatever budget the route resolved to".
 const resolveAnthropicThinkingBudgetTokens = mock((): number | null => null);
 const mergeAnthropicCotProviderOptions = mock(
@@ -149,7 +151,7 @@ function makeReservation(reconcileResult: {
   return reconcile;
 }
 
-function callChat() {
+function callChat(model = "gpt-5-mini") {
   return app.request(
     "/agents/agent-1/a2a",
     {
@@ -159,7 +161,7 @@ function callChat() {
         jsonrpc: "2.0",
         method: "chat",
         params: {
-          model: "gpt-5-mini",
+          model,
           messages: [{ role: "user", content: "hello" }],
         },
         id: "rpc-1",
@@ -230,18 +232,16 @@ describe("Agent A2A billing", () => {
 
   // #16147: the output ceiling used to price/reserve must be the exact value
   // capped on the provider call, for every resolved thinking budget including
-  // none. The resolver's clamping (char override / env default /
-  // ANTHROPIC_COT_BUDGET_MAX) is unit-tested separately; here we prove the route
-  // forwards whatever it resolved to BOTH sinks identically.
+  // none. Here we prove the route forwards the resolved value to both sinks.
   test.each([
-    [null, undefined],
+    [null, 500],
     [1024, 1524],
     [8000, 8500],
   ] as const)("prices and caps the provider at one admitted ceiling (budget=%p)", async (budget, expectedCap) => {
     makeReservation({ adjustmentType: "none" });
     resolveAnthropicThinkingBudgetTokens.mockReturnValue(budget);
 
-    const response = await callChat();
+    const response = await callChat("anthropic/claude-opus-4-5");
     expect(response.status).toBe(200);
 
     // Reserved with this exact ceiling (3rd arg to estimateRequestCost)...
@@ -252,6 +252,20 @@ describe("Agent A2A billing", () => {
     expect(streamText.mock.calls[0]?.[0]?.maxOutputTokens).toBe(
       estimateRequestCost.mock.calls[0]?.[2],
     );
+  });
+
+  test("insufficient credits stop the request before provider dispatch", async () => {
+    reserve.mockRejectedValue(new InsufficientCreditsError(0.5, 0.1));
+
+    const response = await callChat("anthropic/claude-opus-4-5");
+    const body = (await response.json()) as {
+      error?: { code: number; message: string };
+    };
+
+    expect(body.error?.code).toBe(-32003);
+    expect(body.error?.message).toContain("Insufficient credits");
+    expect(streamText).not.toHaveBeenCalled();
+    expect(recordCreatorEarnings).not.toHaveBeenCalled();
   });
 
   // Regression for #10266 (A2A side).

--- a/packages/cloud/api/agents/[id]/a2a/route.ts
+++ b/packages/cloud/api/agents/[id]/a2a/route.ts
@@ -9,7 +9,6 @@
  * the full text before responding rather than streaming back.
  */
 
-import { gateway } from "@ai-sdk/gateway";
 import { calculateCreditMarkup } from "@elizaos/cloud-shared/billing";
 import { streamText } from "ai";
 import { Hono } from "hono";
@@ -33,6 +32,7 @@ import {
   parseThinkingBudgetFromCharacterSettings,
   resolveAnthropicThinkingBudgetTokens,
 } from "@/lib/providers/anthropic-thinking";
+import { getLanguageModel } from "@/lib/providers/language-model";
 import { agentMonetizationService } from "@/lib/services/agent-monetization";
 import { charactersService } from "@/lib/services/characters/characters";
 import type { CreditReservation } from "@/lib/services/credits";
@@ -324,7 +324,7 @@ async function handleChat(
 
   try {
     const result = await streamText({
-      model: gateway.languageModel(model),
+      model: getLanguageModel(model),
       messages: fullMessages,
       // Cap the provider at the exact ceiling billing reserved above, so final
       // usage cannot outrun the admitted reservation (#16147). Omitting it let

--- a/packages/cloud/api/agents/[id]/a2a/route.ts
+++ b/packages/cloud/api/agents/[id]/a2a/route.ts
@@ -52,6 +52,12 @@ const JsonRpcRequestSchema = z.object({
   id: z.union([z.string(), z.number()]),
 });
 
+const ProviderUsageSchema = z.object({
+  inputTokens: z.number().int().nonnegative(),
+  outputTokens: z.number().int().nonnegative(),
+  totalTokens: z.number().int().nonnegative(),
+});
+
 export function generateAgentCard(character: UserCharacter, baseUrl: string) {
   const bioText = Array.isArray(character.bio)
     ? character.bio.join("\n")
@@ -193,6 +199,8 @@ app.post("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
   try {
     user = await requireUserOrApiKeyWithOrg(c);
   } catch {
+    // error-policy:J1 the public JSON-RPC boundary translates authentication
+    // failures without exposing session or API-key internals.
     return c.json(
       {
         jsonrpc: "2.0",
@@ -309,6 +317,8 @@ async function handleChat(
       description: `Agent: ${character.name} (${model})`,
     });
   } catch (error) {
+    // error-policy:J1 the route boundary translates the expected credit
+    // refusal and lets unexpected reservation failures reach the owner path.
     if (error instanceof InsufficientCreditsError) {
       return c.json({
         jsonrpc: "2.0",
@@ -342,12 +352,12 @@ async function handleChat(
       fullText += delta;
     }
 
-    const usage = await result.usage;
+    const usage = ProviderUsageSchema.parse(await result.usage);
     const { totalCost: actualBaseCost } = await calculateCost(
       model,
       provider,
-      usage?.inputTokens || 0,
-      usage?.outputTokens || 0,
+      usage.inputTokens,
+      usage.outputTokens,
     );
     const { markupCredits: actualCreatorMarkup, totalCredits: actualTotal } =
       calculateCreditMarkup({
@@ -374,6 +384,9 @@ async function handleChat(
       });
     }
 
+    let creatorEarningsWarning:
+      | { code: "CREATOR_EARNINGS_UNAVAILABLE"; message: string }
+      | undefined;
     if (character.monetization_enabled && actualCreatorMarkup > 0) {
       // Earnings recording is a NON-CRITICAL post-settlement step. The consumer
       // was already settled above (reconcile(actualTotal)); if this throws it
@@ -388,7 +401,7 @@ async function handleChat(
           earnings: actualCreatorMarkup,
           consumerOrgId: authUser.organization_id,
           model,
-          tokens: usage?.totalTokens,
+          tokens: usage.totalTokens,
           protocol: "a2a",
         });
         logger.info(
@@ -400,6 +413,9 @@ async function handleChat(
           },
         );
       } catch (earningsError) {
+        // error-policy:J4 inference is already purchased and settled, so the
+        // response degrades explicitly with a machine-readable warning while
+        // the structured error log raises the accounting failure to operators.
         logger.error(
           "[Agent A2A] Failed to record creator earnings (settlement already applied — not rolling back)",
           {
@@ -411,6 +427,10 @@ async function handleChat(
                 : String(earningsError),
           },
         );
+        creatorEarningsWarning = {
+          code: "CREATOR_EARNINGS_UNAVAILABLE",
+          message: "Creator earnings could not be recorded",
+        };
       }
     }
 
@@ -420,19 +440,24 @@ async function handleChat(
         content: fullText,
         model,
         usage: {
-          prompt_tokens: usage?.inputTokens || 0,
-          completion_tokens: usage?.outputTokens || 0,
-          total_tokens: usage?.totalTokens || 0,
+          prompt_tokens: usage.inputTokens,
+          completion_tokens: usage.outputTokens,
+          total_tokens: usage.totalTokens,
         },
         cost: {
           base: actualBaseCost,
           markup: actualCreatorMarkup,
           total: actualTotal,
         },
+        ...(creatorEarningsWarning
+          ? { warnings: [creatorEarningsWarning] }
+          : {}),
       },
       id: rpcId,
     });
   } catch (error) {
+    // error-policy:J1 the JSON-RPC boundary refunds a failed generation and
+    // returns a redacted structured failure instead of partial model output.
     await reservation.reconcile(0);
     logger.error("[Agent A2A] Error generating response", {
       error: error instanceof Error ? error.message : "Unknown error",

--- a/packages/cloud/api/agents/[id]/a2a/route.ts
+++ b/packages/cloud/api/agents/[id]/a2a/route.ts
@@ -58,6 +58,18 @@ const ProviderUsageSchema = z.object({
   totalTokens: z.number().int().nonnegative(),
 });
 
+const A2AChatParamsSchema = z.object({
+  model: z.string().trim().min(1).default("gpt-5-mini"),
+  messages: z
+    .array(
+      z.object({
+        role: z.enum(["user", "assistant", "system"]),
+        content: z.string().min(1),
+      }),
+    )
+    .min(1),
+});
+
 export function generateAgentCard(character: UserCharacter, baseUrl: string) {
   const bioText = Array.isArray(character.bio)
     ? character.bio.join("\n")
@@ -257,18 +269,18 @@ async function handleChat(
   rpcId: string | number,
   authUser: { id: string; organization_id: string },
 ): Promise<Response> {
-  const { model = "gpt-5-mini", messages } = params as {
-    model?: string;
-    messages: Array<{ role: string; content: string }>;
-  };
-
-  if (!messages?.length) {
-    return c.json({
-      jsonrpc: "2.0",
-      error: { code: -32602, message: "messages required" },
-      id: rpcId,
-    });
+  const parsedParams = A2AChatParamsSchema.safeParse(params);
+  if (!parsedParams.success) {
+    return c.json(
+      {
+        jsonrpc: "2.0",
+        error: { code: -32602, message: "valid messages are required" },
+        id: rpcId,
+      },
+      400,
+    );
   }
+  const { model, messages } = parsedParams.data;
 
   const bioText = Array.isArray(character.bio)
     ? character.bio.join("\n")
@@ -278,10 +290,7 @@ async function handleChat(
 
   const fullMessages = [
     { role: "system" as const, content: systemPrompt },
-    ...messages.map((m) => ({
-      role: m.role as "user" | "assistant" | "system",
-      content: m.content,
-    })),
+    ...messages,
   ];
 
   const provider = getProviderFromModel(model);

--- a/packages/cloud/api/agents/[id]/a2a/route.ts
+++ b/packages/cloud/api/agents/[id]/a2a/route.ts
@@ -43,6 +43,8 @@ import {
 import { logger } from "@/lib/utils/logger";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
+const A2A_TEXT_OUTPUT_TOKENS = 500;
+
 const JsonRpcRequestSchema = z.object({
   jsonrpc: z.literal("2.0"),
   method: z.string(),
@@ -285,7 +287,7 @@ async function handleChat(
     agentThinkingBudget,
   );
   const maxOutputTokens =
-    effectiveThinkingBudget != null ? 500 + effectiveThinkingBudget : undefined;
+    A2A_TEXT_OUTPUT_TOKENS + (effectiveThinkingBudget ?? 0);
   const baseCost = await estimateRequestCost(
     model,
     fullMessages,

--- a/packages/cloud/api/agents/[id]/a2a/route.ts
+++ b/packages/cloud/api/agents/[id]/a2a/route.ts
@@ -324,6 +324,10 @@ async function handleChat(
     const result = await streamText({
       model: gateway.languageModel(model),
       messages: fullMessages,
+      // Cap the provider at the exact ceiling billing reserved above, so final
+      // usage cannot outrun the admitted reservation (#16147). Omitting it let
+      // the provider bill more output than was priced upfront.
+      maxOutputTokens,
       ...mergeAnthropicCotProviderOptions(
         model,
         envForThinking,

--- a/packages/cloud/api/test/e2e/group-c-agents.test.ts
+++ b/packages/cloud/api/test/e2e/group-c-agents.test.ts
@@ -40,7 +40,11 @@ const UNOWNED_AGENT_ID = "00000000-0000-4000-8000-000000000000";
 
 const serverReachable = await isServerReachable();
 const hasTestApiKey = Boolean(process.env.TEST_API_KEY?.trim());
-const hasLiveGateway = Boolean(process.env.AI_GATEWAY_API_KEY?.trim());
+const hasLiveProvider = Boolean(
+  process.env.OPENAI_API_KEY?.trim() ||
+    process.env.OPENROUTER_API_KEY?.trim() ||
+    process.env.AI_GATEWAY_API_KEY?.trim(),
+);
 if (!serverReachable) {
   console.warn(
     `[group-c-agents] ${getBaseUrl()} did not respond to /api/health. ` +
@@ -54,9 +58,10 @@ if (!hasTestApiKey) {
       "bootstrap a test API key. Tests will SKIP.",
   );
 }
-if (!hasLiveGateway) {
+if (!hasLiveProvider) {
   console.warn(
-    "[group-c-agents] AI_GATEWAY_API_KEY is not set; the exact-head A2A " +
+    "[group-c-agents] OPENAI_API_KEY, OPENROUTER_API_KEY, and " +
+      "AI_GATEWAY_API_KEY are not set; the exact-head A2A " +
       "provider/billing receipt test will SKIP.",
   );
 }
@@ -287,8 +292,8 @@ describeE2E("/api/agents/:id/a2a", () => {
     expect(res.status).toBe(404);
   });
 
-  test.skipIf(!hasLiveGateway)(
-    "live gateway stays within the admitted ceiling and settles the real credit hold",
+  test.skipIf(!hasLiveProvider)(
+    "live provider stays within the admitted ceiling and settles the real credit hold",
     async () => {
       const userId = process.env.TEST_USER_ID;
       const organizationId = process.env.TEST_ORGANIZATION_ID;
@@ -392,7 +397,7 @@ describeE2E("/api/agents/:id/a2a", () => {
       process.stdout.write(
         `${JSON.stringify(
           {
-            evidence: "exact-head-a2a-live-gateway-billing-receipt",
+            evidence: "exact-head-a2a-live-provider-billing-receipt",
             agent: { id: agentId, name: agentName },
             httpStatus: response.status,
             providerReceipt: receipt.result,

--- a/packages/cloud/api/test/e2e/group-c-agents.test.ts
+++ b/packages/cloud/api/test/e2e/group-c-agents.test.ts
@@ -25,6 +25,7 @@
 
 import { afterAll, describe, expect, test } from "bun:test";
 import { Client } from "pg";
+import { z } from "zod";
 
 import {
   api,
@@ -39,6 +40,7 @@ const UNOWNED_AGENT_ID = "00000000-0000-4000-8000-000000000000";
 
 const serverReachable = await isServerReachable();
 const hasTestApiKey = Boolean(process.env.TEST_API_KEY?.trim());
+const hasLiveGateway = Boolean(process.env.AI_GATEWAY_API_KEY?.trim());
 if (!serverReachable) {
   console.warn(
     `[group-c-agents] ${getBaseUrl()} did not respond to /api/health. ` +
@@ -50,6 +52,12 @@ if (!hasTestApiKey) {
   console.warn(
     "[group-c-agents] TEST_API_KEY is not set; the preload could not " +
       "bootstrap a test API key. Tests will SKIP.",
+  );
+}
+if (!hasLiveGateway) {
+  console.warn(
+    "[group-c-agents] AI_GATEWAY_API_KEY is not set; the exact-head A2A " +
+      "provider/billing receipt test will SKIP.",
   );
 }
 
@@ -65,6 +73,7 @@ async function seedOwnedCharacter(input: {
   name: string;
   plugins?: string[];
   settings?: Record<string, unknown>;
+  isPublic?: boolean;
 }): Promise<void> {
   const databaseUrl = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
   if (!databaseUrl) {
@@ -116,7 +125,7 @@ async function seedOwnedCharacter(input: {
          '{}'::jsonb,
          '{}'::jsonb,
          $8::jsonb,
-         false,
+         $9,
          false,
          'cloud',
          3,
@@ -135,8 +144,9 @@ async function seedOwnedCharacter(input: {
           name: input.name,
           bio: ["E2E character for stats coverage"],
           system: "Test character",
-          isPublic: false,
+          isPublic: input.isPublic ?? false,
         }),
+        input.isPublic ?? false,
       ],
     );
   } finally {
@@ -276,6 +286,125 @@ describeE2E("/api/agents/:id/a2a", () => {
     });
     expect(res.status).toBe(404);
   });
+
+  test.skipIf(!hasLiveGateway)(
+    "live gateway stays within the admitted ceiling and settles the real credit hold",
+    async () => {
+      const userId = process.env.TEST_USER_ID;
+      const organizationId = process.env.TEST_ORGANIZATION_ID;
+      const databaseUrl =
+        process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+      if (!userId || !organizationId || !databaseUrl) {
+        throw new Error(
+          "TEST_USER_ID, TEST_ORGANIZATION_ID, and the e2e database URL are required",
+        );
+      }
+
+      const agentId = crypto.randomUUID();
+      const agentName = `A2A live ceiling ${crypto.randomUUID()}`;
+      await seedOwnedCharacter({
+        id: agentId,
+        organizationId,
+        userId,
+        name: agentName,
+        isPublic: true,
+      });
+      createdCharacterIds.push(agentId);
+
+      const response = await api.post(
+        `/api/agents/${agentId}/a2a`,
+        {
+          jsonrpc: "2.0",
+          method: "chat",
+          id: "a2a-live-ceiling",
+          params: {
+            model: "gpt-5-mini",
+            messages: [
+              {
+                role: "user",
+                content: "Confirm this live A2A request in one short sentence.",
+              },
+            ],
+          },
+        },
+        { headers: bearerHeaders() },
+      );
+      const rawBody = await response.text();
+      expect(response.status, rawBody).toBe(200);
+      const receipt = z
+        .object({
+          jsonrpc: z.literal("2.0"),
+          id: z.literal("a2a-live-ceiling"),
+          result: z.object({
+            content: z.string().min(1),
+            model: z.literal("gpt-5-mini"),
+            usage: z.object({
+              prompt_tokens: z.number().int().nonnegative(),
+              completion_tokens: z.number().int().positive().max(500),
+              total_tokens: z.number().int().positive(),
+            }),
+            cost: z.object({
+              base: z.number().nonnegative(),
+              markup: z.number().nonnegative(),
+              total: z.number().positive(),
+            }),
+          }),
+        })
+        .parse(JSON.parse(rawBody));
+
+      const client = new Client({ connectionString: databaseUrl });
+      await client.connect();
+      let settlement: {
+        amount: string;
+        description: string | null;
+        settled_at: Date | null;
+        metadata: Record<string, unknown>;
+      };
+      try {
+        const result = await client.query<{
+          amount: string;
+          description: string | null;
+          settled_at: Date | null;
+          metadata: Record<string, unknown>;
+        }>(
+          `SELECT amount, description, settled_at, metadata
+             FROM credit_transactions
+            WHERE organization_id = $1
+              AND description = $2
+            ORDER BY created_at DESC
+            LIMIT 1`,
+          [organizationId, `Agent: ${agentName} (gpt-5-mini) (reserved)`],
+        );
+        const row = result.rows[0];
+        if (!row) throw new Error("A2A reservation row was not persisted");
+        settlement = row;
+      } finally {
+        await client.end();
+      }
+
+      expect(settlement.settled_at).toBeInstanceOf(Date);
+      expect(Number(settlement.amount)).toBeLessThan(0);
+      expect(settlement.metadata.type).toBe("reservation");
+      expect(settlement.metadata.settlement_marker).toBe(
+        "credit_reservation_v1",
+      );
+
+      process.stdout.write(
+        `${JSON.stringify(
+          {
+            evidence: "exact-head-a2a-live-gateway-billing-receipt",
+            agent: { id: agentId, name: agentName },
+            httpStatus: response.status,
+            providerReceipt: receipt.result,
+            databaseSettlement: settlement,
+          },
+          null,
+          2,
+        )}\n`,
+      );
+    },
+    120_000,
+  );
 });
 
 // -------------------------------------------------------------------------

--- a/packages/cloud/api/test/e2e/group-c-agents.test.ts
+++ b/packages/cloud/api/test/e2e/group-c-agents.test.ts
@@ -79,6 +79,7 @@ async function seedOwnedCharacter(input: {
   plugins?: string[];
   settings?: Record<string, unknown>;
   isPublic?: boolean;
+  a2aEnabled?: boolean;
 }): Promise<void> {
   const databaseUrl = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
   if (!databaseUrl) {
@@ -109,6 +110,7 @@ async function seedOwnedCharacter(input: {
          character_data,
          is_template,
          is_public,
+         a2a_enabled,
          source,
          view_count,
          interaction_count,
@@ -130,8 +132,9 @@ async function seedOwnedCharacter(input: {
          '{}'::jsonb,
          '{}'::jsonb,
          $8::jsonb,
-         $9,
          false,
+         $9,
+         $10,
          'cloud',
          3,
          2,
@@ -152,6 +155,7 @@ async function seedOwnedCharacter(input: {
           isPublic: input.isPublic ?? false,
         }),
         input.isPublic ?? false,
+        input.a2aEnabled ?? false,
       ],
     );
   } finally {
@@ -292,6 +296,37 @@ describeE2E("/api/agents/:id/a2a", () => {
     expect(res.status).toBe(404);
   });
 
+  test("GET returns the public card for an A2A-enabled seeded agent", async () => {
+    const userId = process.env.TEST_USER_ID;
+    const organizationId = process.env.TEST_ORGANIZATION_ID;
+    if (!userId || !organizationId) {
+      throw new Error("TEST_USER_ID and TEST_ORGANIZATION_ID are required");
+    }
+
+    const agentId = crypto.randomUUID();
+    const agentName = `A2A public card ${crypto.randomUUID()}`;
+    await seedOwnedCharacter({
+      id: agentId,
+      organizationId,
+      userId,
+      name: agentName,
+      isPublic: true,
+      a2aEnabled: true,
+    });
+    createdCharacterIds.push(agentId);
+
+    const response = await api.get(`/api/agents/${agentId}/a2a`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      name: agentName,
+      capabilities: { streaming: true },
+      authentication: {
+        schemes: [{ scheme: "bearer" }],
+      },
+      pricing: { currency: "USD" },
+    });
+  });
+
   test.skipIf(!hasLiveProvider)(
     "live provider stays within the admitted ceiling and settles the real credit hold",
     async () => {
@@ -313,6 +348,7 @@ describeE2E("/api/agents/:id/a2a", () => {
         userId,
         name: agentName,
         isPublic: true,
+        a2aEnabled: true,
       });
       createdCharacterIds.push(agentId);
 

--- a/packages/cloud/shared/src/lib/providers/anthropic-thinking.test.ts
+++ b/packages/cloud/shared/src/lib/providers/anthropic-thinking.test.ts
@@ -1,0 +1,67 @@
+/** Verifies owner and deploy policy resolution for Anthropic thinking budgets at the shared cloud boundary. */
+import { describe, expect, test } from "bun:test";
+import {
+  parseThinkingBudgetFromCharacterSettings,
+  resolveAnthropicThinkingBudgetTokens,
+} from "./anthropic-thinking";
+
+describe("Anthropic thinking budget resolution", () => {
+  test("uses the character override before the deploy default", () => {
+    const characterBudget = parseThinkingBudgetFromCharacterSettings({
+      anthropicThinkingBudgetTokens: 1_200,
+    });
+
+    expect(
+      resolveAnthropicThinkingBudgetTokens(
+        "anthropic/claude-opus-4-5",
+        { ANTHROPIC_COT_BUDGET: "1800" },
+        characterBudget,
+      ),
+    ).toBe(1_200);
+  });
+
+  test("uses the uncapped deploy default when the character omits a budget", () => {
+    expect(
+      resolveAnthropicThinkingBudgetTokens("anthropic/claude-opus-4-5", {
+        ANTHROPIC_COT_BUDGET: "1600",
+      }),
+    ).toBe(1_600);
+  });
+
+  test("clamps both character and environment budgets to the operator cap", () => {
+    expect(
+      resolveAnthropicThinkingBudgetTokens("anthropic/claude-opus-4-5", {
+        ANTHROPIC_COT_BUDGET: "3000",
+        ANTHROPIC_COT_BUDGET_MAX: "2048",
+      }),
+    ).toBe(2_048);
+    expect(
+      resolveAnthropicThinkingBudgetTokens(
+        "anthropic/claude-opus-4-5",
+        { ANTHROPIC_COT_BUDGET_MAX: "2048" },
+        4_096,
+      ),
+    ).toBe(2_048);
+  });
+
+  test("lets an explicit zero disable the deploy default", () => {
+    expect(
+      resolveAnthropicThinkingBudgetTokens(
+        "anthropic/claude-opus-4-5",
+        { ANTHROPIC_COT_BUDGET: "1600" },
+        0,
+      ),
+    ).toBeNull();
+  });
+
+  test("disables thinking for unsupported providers and model families", () => {
+    expect(
+      resolveAnthropicThinkingBudgetTokens("openai/gpt-5", { ANTHROPIC_COT_BUDGET: "900" }),
+    ).toBeNull();
+    expect(
+      resolveAnthropicThinkingBudgetTokens("anthropic/claude-3-opus", {
+        ANTHROPIC_COT_BUDGET: "900",
+      }),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
# Relates to

Closes #16147

- [x] Targets `develop` and is rebased on the latest `origin/develop`.
- [x] A reviewer can confirm the change from the evidence below without reading the code.

# Risks

The affected surface is the public per-agent A2A chat route. The change deliberately fails closed when request input or provider metering is invalid: malformed chat messages are rejected before reservation, and an unmetered provider response is refunded and returned as an error. Creator-earnings failures occur after consumer settlement, so they remain a successful inference with a machine-readable warning and structured operator log rather than triggering a corrupting second refund.

# Background

## What does this PR do?

The A2A route previously priced a 500-token no-thinking allowance but passed no finite provider cap. It now derives one admitted ceiling—`500 + effective thinking budget`—and sends that same numeric value to both reservation pricing and `streamText`. Provider resolution goes through the configured shared resolver rather than a hardwired gateway.

The route also validates JSON-RPC chat messages before billing and requires complete, non-negative provider usage before settlement. Missing usage can no longer masquerade as zero metering. Post-settlement creator-accounting failure is observable through `warnings` without invoking the non-idempotent refund boundary again.

The exact reviewed head is `58197098d0847636bdf3988e176cb70c1ac9c182`.

## What kind of change is this?

Bug fix (non-breaking for valid requests).

# Documentation changes needed?

No public API documentation changes are required.

# Testing

## Where should a reviewer start?

`packages/cloud/api/agents/[id]/a2a/route.ts` contains the shared admitted cap, configured provider resolution, request validation, metering validation, and explicit settlement warning. `packages/cloud/api/__tests__/agent-a2a-billing.test.ts` covers those boundaries through the mounted route. `packages/cloud/api/test/e2e/group-c-agents.test.ts` produces the real provider/HTTP/Postgres receipt.

## Detailed testing results

- 11 focused mounted-route tests passed, including no-thinking `500`, thinking-budget caps, malformed inputs, missing-usage refund, insufficient credits, provider failure, and post-settlement earnings warning.
- Cloud API typecheck passed.
- Production Wrangler dry-run passed.
- Group C passed locally against PGlite: 85 pass, 1 credential-gated live case skipped.
- Exact-head GitHub live lane called the real configured model provider through the mounted HTTP route and inspected the settled Postgres reservation row.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] `N/A - backend-only A2A billing route; no UI pixels changed.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - backend-only A2A billing route; no UI pixels changed.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no frontend or native interaction exists for this server route.`
<!-- evidence-row:backend-logs -->
- [x] [Exact-head live provider and billing receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16229-exact-head-a2a-live-receipt.log) records the mounted HTTP status, provider output and usage, costs, and settled database row from head `5819709`.
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend code or browser request path changed.`
<!-- evidence-row:llm-trajectory -->
- [x] [Exact-head live provider and billing receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16229-exact-head-a2a-live-receipt.log) contains the real route input, model output, and provider token usage. `N/A - scenario-runner`: this is an authenticated cloud billing transport, so the direct mounted-route receipt exercises the affected reservation/provider/settlement path that a runtime scenario does not.
<!-- evidence-row:domain-artifacts -->
- [x] [Exact-head live provider and billing receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16229-exact-head-a2a-live-receipt.log) includes the negative `credit_transactions` reservation row, settlement timestamp, and settlement marker read back from Postgres after the request.

# Evidence Details

The exact-head receipt is emitted only after asserting HTTP 200, non-empty provider output, positive input/output usage, output usage at or below the 500-token admitted cap, positive settled cost, and a negative settled reservation transaction with the expected A2A description. The workflow is credential-gated and fails rather than substituting a mock provider or fabricated usage.

[stan-cloud]
