### PR TITLE
fix(core): honor roomIds in countMemories — room counts were table-wide

### DIFF
--- a/packages/core/src/runtime-count-memories.test.ts
+++ b/packages/core/src/runtime-count-memories.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Contract test for `AgentRuntime.countMemories`: the object form must forward
+ * BOTH the `roomIds` param (the IAgentRuntime/adapter spelling every typed
+ * caller uses) and the legacy `roomId` singular to the adapter. The
+ * implementation previously read only `roomId`, silently dropping
+ * interface-correct `roomIds` scoping — /reset reported the TABLE-WIDE count
+ * ("cleared 31126 message(s)") for a 40-message room, and the compact action's
+ * boundary math ran against the whole agent history.
+ */
+
+import { describe, expect, it } from "vitest";
+import { AgentRuntime } from "./runtime";
+import type { Character, IDatabaseAdapter, UUID } from "./types";
+
+const ROOM = "cccccccc-0000-0000-0000-000000000001" as UUID;
+
+function runtimeWithRecordingAdapter() {
+	const runtime = new AgentRuntime({
+		character: { name: "count-memories-test" } as Character,
+	});
+	const calls: Array<Record<string, unknown>> = [];
+	runtime.registerDatabaseAdapter({
+		countMemories: async (params: Record<string, unknown>) => {
+			calls.push(params);
+			return 7;
+		},
+	} as unknown as IDatabaseAdapter);
+	return { runtime, calls };
+}
+
+describe("AgentRuntime.countMemories room scoping", () => {
+	it("forwards roomIds (the adapter/interface spelling) to the adapter", async () => {
+		const { runtime, calls } = runtimeWithRecordingAdapter();
+		await runtime.countMemories({
+			roomIds: [ROOM],
+			tableName: "messages",
+			unique: false,
+		});
+		expect(calls[0]?.roomIds).toEqual([ROOM]);
+	});
+
+	it("forwards the legacy singular roomId as a one-element roomIds", async () => {
+		const { runtime, calls } = runtimeWithRecordingAdapter();
+		await runtime.countMemories({ roomId: ROOM, tableName: "messages" });
+		expect(calls[0]?.roomIds).toEqual([ROOM]);
+	});
+
+	it("forwards the bare-UUID form scoped to that room", async () => {
+		const { runtime, calls } = runtimeWithRecordingAdapter();
+		await runtime.countMemories(ROOM);
+		expect(calls[0]?.roomIds).toEqual([ROOM]);
+	});
+
+	it("leaves roomIds undefined (table-wide) only when no room scope was given", async () => {
+		const { runtime, calls } = runtimeWithRecordingAdapter();
+		await runtime.countMemories({ tableName: "messages" });
+		expect(calls[0]?.roomIds).toBeUndefined();
+	});
+});

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -9448,6 +9448,12 @@ ${section_end}`;
 			| UUID
 			| {
 					roomId?: UUID;
+					/** The IAgentRuntime/adapter param form. The implementation
+					 * previously read only `roomId` and silently dropped this,
+					 * turning interface-correct room-scoped counts into TABLE-WIDE
+					 * ones (/reset reported "cleared 31k message(s)" for a
+					 * 40-message room). */
+					roomIds?: UUID[];
 					unique?: boolean;
 					tableName?: string;
 					entityId?: UUID;
@@ -9465,7 +9471,9 @@ ${section_end}`;
 			});
 		}
 		return this.adapter.countMemories({
-			roomIds: roomIdOrParams.roomId ? [roomIdOrParams.roomId] : undefined,
+			roomIds:
+				roomIdOrParams.roomIds ??
+				(roomIdOrParams.roomId ? [roomIdOrParams.roomId] : undefined),
 			unique: roomIdOrParams.unique,
 			tableName: roomIdOrParams.tableName ?? "messages",
 			entityId: roomIdOrParams.entityId,


### PR DESCRIPTION
Found by battery-testing `/reset` through the GUI chat route: it replied **"Reset this room: cleared command settings and 31126 message(s)"** for a ~40-message scratch room. The delete was correctly room-scoped (global count 31,126 → 31,077 — only the room's ~49 rows went); **the count lied**.

Root cause is interface/implementation drift: `IAgentRuntime`/adapter declare `countMemories({ roomIds?: UUID[] … })` and every typed caller uses that spelling (plugin-commands' `/reset`/`/new` report, the compact action's boundary math) — but the runtime implementation only read the legacy `roomId` singular and **silently dropped `roomIds`**, so interface-correct room-scoped counts came back table-wide. TypeScript blessed the callers because they matched the interface; the implementation was the bug. Same silent-drop family as the `getMemories`-ignored-`limit` keystone from the prod-readiness audit.

Fix: forward `roomIds` through (keeping `roomId` and the bare-UUID form working), and pin all four scoping shapes with a recording-adapter contract test.

Live-verified after fix (see below in thread): `/reset` on a fresh scratch room reports the true small count.

Tests: new `runtime-count-memories.test.ts` 4✓; core typecheck ✓; plugin-commands typecheck ✓; biome clean. Downstream side-effect: the compact action's `completeMessageWindow` math is now computed against the actual room instead of the entire agent history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)