### PR TITLE
test(workflow): use real runtime model dispatch

### DIFF
--- a/plugins/plugin-workflow/__tests__/helpers/modelRuntime.ts
+++ b/plugins/plugin-workflow/__tests__/helpers/modelRuntime.ts
@@ -1,0 +1,52 @@
+/**
+ * Real AgentRuntime harness for workflow-generation tests. Model handlers are
+ * the only mocked boundary; routing, settings, and `useModel` dispatch remain real.
+ */
+import { mock } from 'bun:test';
+import { AgentRuntime, createCharacter, ModelType } from '@elizaos/core';
+import { InMemoryDatabaseAdapter } from '../../../../packages/core/src/database/inMemoryAdapter.ts';
+
+type ModelMock = ReturnType<typeof mock>;
+
+export interface ModelRuntimeOptions {
+  settings?: Record<string, unknown>;
+  useModel?: ModelMock;
+}
+
+/** External model double that supports structured and text workflow calls. */
+export function createModelMock(schemaResult?: Record<string, unknown>): ModelMock {
+  return mock((_type: string, opts: Record<string, unknown>) => {
+    if (opts.responseSchema || opts.schema) return Promise.resolve(schemaResult || {});
+
+    const prompt = typeof opts.prompt === 'string' ? opts.prompt : '';
+    const dataSection = '\n\nData:\n';
+    const dataIndex = prompt.lastIndexOf(dataSection);
+    if (dataIndex !== -1) return Promise.resolve(prompt.slice(dataIndex + dataSection.length));
+
+    const jsonIndex = prompt.lastIndexOf('\n\n{');
+    if (jsonIndex !== -1) return Promise.resolve(prompt.slice(jsonIndex + 2));
+    return Promise.resolve('');
+  });
+}
+
+export function createModelRuntime(options: ModelRuntimeOptions = {}): AgentRuntime {
+  const runtime = new AgentRuntime({
+    character: createCharacter({
+      name: 'WorkflowGenerationIntegrationAgent',
+      settings: options.settings ?? {},
+    }),
+    adapter: new InMemoryDatabaseAdapter(),
+    logLevel: 'fatal',
+    enableAutonomy: false,
+  });
+  const model = options.useModel ?? createModelMock();
+
+  for (const modelType of [ModelType.TEXT_SMALL, ModelType.TEXT_LARGE]) {
+    runtime.registerModel(
+      modelType,
+      async (_runtime, params) => model(modelType, params, 'openai'),
+      'openai'
+    );
+  }
+  return runtime;
+}

--- a/plugins/plugin-workflow/__tests__/unit/generation.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/generation.test.ts
@@ -18,7 +18,7 @@ import {
   modifyWorkflow,
 } from '../../src/utils/generation';
 import type { UnknownParamDetection } from '../../src/utils/workflow';
-import { createMockRuntime } from '../helpers/mockRuntime';
+import { createModelRuntime } from '../helpers/modelRuntime';
 
 const CEREBRAS_WORKFLOW_SETTINGS = {
   ELIZA_PROVIDER: 'cerebras',
@@ -57,7 +57,7 @@ function assertCerebrasWorkflowCall(call: unknown[] | undefined, callSite: strin
 
 describe('extractKeywords', () => {
   test('returns keywords from valid LLM response', async () => {
-    const runtime = createMockRuntime({
+    const runtime = createModelRuntime({
       useModel: mock(() => Promise.resolve({ keywords: ['gmail', 'stripe', 'send'] })),
     });
 
@@ -66,7 +66,7 @@ describe('extractKeywords', () => {
   });
 
   test('trims and filters empty keywords', async () => {
-    const runtime = createMockRuntime({
+    const runtime = createModelRuntime({
       useModel: mock(() => Promise.resolve({ keywords: [' gmail ', '', '  slack  ', ' '] })),
     });
 
@@ -75,7 +75,7 @@ describe('extractKeywords', () => {
   });
 
   test('limits to 5 keywords', async () => {
-    const runtime = createMockRuntime({
+    const runtime = createModelRuntime({
       useModel: mock(() =>
         Promise.resolve({
           keywords: ['a', 'b', 'c', 'd', 'e', 'f', 'g'],
@@ -88,7 +88,7 @@ describe('extractKeywords', () => {
   });
 
   test('throws when LLM returns null', async () => {
-    const runtime = createMockRuntime({
+    const runtime = createModelRuntime({
       useModel: mock(() => Promise.resolve(null)),
     });
 
@@ -96,7 +96,7 @@ describe('extractKeywords', () => {
   });
 
   test('throws when LLM returns object without keywords', async () => {
-    const runtime = createMockRuntime({
+    const runtime = createModelRuntime({
       useModel: mock(() => Promise.resolve({ result: 'no keywords field' })),
     });
 
@@ -104,7 +104,7 @@ describe('extractKeywords', () => {
   });
 
   test('throws when keywords contains non-strings', async () => {
-    const runtime = createMockRuntime({
+    const runtime = createModelRuntime({
       useModel: mock(() => Promise.resolve({ keywords: ['valid', 42, null] })),
     });
 
@@ -113,7 +113,7 @@ describe('extractKeywords', () => {
 
   test('omits the bias directive when preferredProviders is undefined', async () => {
     const useModel = mock(() => Promise.resolve({ keywords: ['email'] }));
-    const runtime = createMockRuntime({ useModel });
+    const runtime = createModelRuntime({ useModel });
 
     await extractKeywords(runtime, 'Send my emails');
 
@@ -123,7 +123,7 @@ describe('extractKeywords', () => {
 
   test('appends the bias directive when preferredProviders is non-empty', async () => {
     const useModel = mock(() => Promise.resolve({ keywords: ['gmail', 'discord'] }));
-    const runtime = createMockRuntime({ useModel });
+    const runtime = createModelRuntime({ useModel });
 
     await extractKeywords(runtime, 'Summarize my emails to my chat', ['gmail', 'discord']);
 
@@ -134,7 +134,7 @@ describe('extractKeywords', () => {
 
   test('omits the bias directive when preferredProviders is empty array', async () => {
     const useModel = mock(() => Promise.resolve({ keywords: ['email'] }));
-    const runtime = createMockRuntime({ useModel });
+    const runtime = createModelRuntime({ useModel });
 
     await extractKeywords(runtime, 'Send my emails', []);
 
@@ -144,7 +144,7 @@ describe('extractKeywords', () => {
 
   test('routes structured workflow calls through Cerebras gpt-oss-120b when configured', async () => {
     const useModel = mock(() => Promise.resolve({ keywords: ['gmail'] }));
-    const runtime = createMockRuntime({
+    const runtime = createModelRuntime({
       settings: CEREBRAS_WORKFLOW_SETTINGS,
       useModel,
     });
@@ -156,7 +156,7 @@ describe('extractKeywords', () => {
 
   test('infers Cerebras workflow routing from a root OpenAI-compatible base URL', async () => {
     const useModel = mock(() => Promise.resolve({ keywords: ['gmail'] }));
-    const runtime = createMockRuntime({
+    const runtime = createModelRuntime({
       settings: {
         OPENAI_BASE_URL: 'https://cerebras.ai/v1',
         CEREBRAS_MODEL: 'gpt-oss-120b',
@@ -176,7 +176,7 @@ describe('extractKeywords', () => {
 
 describe('matchWorkflow', () => {
   test('returns no-match for empty workflow list', async () => {
-    const runtime = createMockRuntime();
+    const runtime = createModelRuntime();
     const result = await matchWorkflow(runtime, 'Activate Stripe', []);
 
     expect(result.matchedWorkflowId).toBeNull();
@@ -194,7 +194,7 @@ describe('matchWorkflow', () => {
         reason: 'matched',
       })
     );
-    const runtime = createMockRuntime({ useModel });
+    const runtime = createModelRuntime({ useModel });
 
     const workflows: WorkflowDefinition[] = [
       {
@@ -226,7 +226,7 @@ describe('matchWorkflow', () => {
   });
 
   test('returns graceful failure when LLM throws', async () => {
-    const runtime = createMockRuntime({
+    const runtime = createModelRuntime({
       useModel: mock(() => Promise.reject(new Error('LLM timeout'))),
     });
 
@@ -254,7 +254,7 @@ describe('matchWorkflow', () => {
       matches: [{ id: 'wf-002', name: 'Gmail', score: 0.7 }],
       reason: 'Partial match by name',
     };
-    const runtime = createMockRuntime({
+    const runtime = createModelRuntime({
       useModel: mock(() => Promise.resolve(matchResult)),
     });
 
@@ -287,7 +287,7 @@ describe('generateWorkflow', () => {
       connections: {},
     });
 
-    const runtime = createMockRuntime({
+    const runtime = createModelRuntime({
       useModel: mock(() => Promise.resolve(workflowJson)),
     });
 
@@ -305,7 +305,7 @@ describe('generateWorkflow', () => {
 }
 \`\`\``;
 
-    const runtime = createMockRuntime({
+    const runtime = createModelRuntime({
       useModel: mock(() => Promise.resolve(workflowJson)),
     });
 
@@ -314,7 +314,7 @@ describe('generateWorkflow', () => {
   });
 
   test('throws when response is not valid JSON', async () => {
-    const runtime = createMockRuntime({
+    const runtime = createModelRuntime({
       useModel: mock(() => Promise.resolve('not json at all')),
     });
 
@@ -322,7 +322,7 @@ describe('generateWorkflow', () => {
   });
 
   test('throws when workflow has no nodes array', async () => {
-    const runtime = createMockRuntime({
+    const runtime = createModelRuntime({
       useModel: mock(() => Promise.resolve(JSON.stringify({ name: 'Bad', connections: {} }))),
     });
 
@@ -330,7 +330,7 @@ describe('generateWorkflow', () => {
   });
 
   test('throws when workflow has no connections object', async () => {
-    const runtime = createMockRuntime({
+    const runtime = createModelRuntime({
       useModel: mock(() =>
         Promise.resolve(JSON.stringify({ name: 'Bad', nodes: [{ name: 'A' }] }))
       ),
@@ -351,7 +351,7 @@ describe('generateWorkflow', () => {
         })
       )
     );
-    const runtime = createMockRuntime({ useModel });
+    const runtime = createModelRuntime({ useModel });
 
     const nodes = [
       {
@@ -380,7 +380,7 @@ describe('generateWorkflow', () => {
         })
       )
     );
-    const runtime = createMockRuntime({ useModel });
+    const runtime = createModelRuntime({ useModel });
 
     // Unknown node with no schema
     const nodes = [
@@ -414,7 +414,7 @@ describe('generateWorkflow', () => {
         })
       );
     });
-    const runtime = createMockRuntime({ useModel });
+    const runtime = createModelRuntime({ useModel });
 
     const result = await generateWorkflow(runtime, 'test', []);
     expect(result.name).toBe('Good');
@@ -436,7 +436,7 @@ describe('generateWorkflow', () => {
         })
       );
     });
-    const runtime = createMockRuntime({ useModel });
+    const runtime = createModelRuntime({ useModel });
 
     await generateWorkflow(runtime, 'test', []);
 
@@ -460,7 +460,7 @@ describe('generateWorkflow', () => {
         })
       )
     );
-    const runtime = createMockRuntime({
+    const runtime = createModelRuntime({
       settings: CEREBRAS_WORKFLOW_SETTINGS,
       useModel,
     });
@@ -497,7 +497,7 @@ describe('workflow generation model routing', () => {
       }
       return Promise.resolve(JSON.stringify(workflow));
     });
-    const runtime = createMockRuntime({
+    const runtime = createModelRuntime({
       settings: CEREBRAS_WORKFLOW_SETTINGS,
       useModel,
     });
@@ -531,7 +531,7 @@ describe('workflow generation model routing', () => {
         JSON.stringify({ responses: { values: [{ content: 'gpt-oss-120b' }] } })
       );
     });
-    const runtime = createMockRuntime({
+    const runtime = createModelRuntime({
       settings: CEREBRAS_WORKFLOW_SETTINGS,
       useModel,
     });
@@ -600,7 +600,7 @@ describe('modifyWorkflow', () => {
         })
       );
     });
-    const runtime = createMockRuntime({ useModel });
+    const runtime = createModelRuntime({ useModel });
 
     const result = await modifyWorkflow(runtime, baseWorkflow, 'tweak', []);
     expect(result.name).toBe('Modified');
@@ -651,7 +651,7 @@ describe('classifyDraftIntent', () => {
         reason: 'User said yes',
       })
     );
-    const runtime = createMockRuntime({ useModel });
+    const runtime = createModelRuntime({ useModel });
 
     const result = await classifyDraftIntent(runtime, 'Yes, deploy it', sampleDraft);
 
@@ -667,7 +667,7 @@ describe('classifyDraftIntent', () => {
         reason: 'User wants different email',
       })
     );
-    const runtime = createMockRuntime({ useModel });
+    const runtime = createModelRuntime({ useModel });
 
     const result = await classifyDraftIntent(runtime, 'Use Outlook instead', sampleDraft);
 
@@ -682,7 +682,7 @@ describe('classifyDraftIntent', () => {
         reason: 'test',
       })
     );
-    const runtime = createMockRuntime({ useModel });
+    const runtime = createModelRuntime({ useModel });
 
     await classifyDraftIntent(runtime, 'yes', sampleDraft);
 
@@ -699,7 +699,7 @@ describe('classifyDraftIntent', () => {
         reason: 'User rejected',
       })
     );
-    const runtime = createMockRuntime({ useModel });
+    const runtime = createModelRuntime({ useModel });
 
     const result = await classifyDraftIntent(runtime, 'No, forget it', sampleDraft);
 
@@ -713,7 +713,7 @@ describe('classifyDraftIntent', () => {
         reason: 'Completely different request',
       })
     );
-    const runtime = createMockRuntime({ useModel });
+    const runtime = createModelRuntime({ useModel });
 
     const result = await classifyDraftIntent(
       runtime,


### PR DESCRIPTION
Closes #16232

## What changed

- replaced all 34 synthetic `createMockRuntime()` call sites in the workflow-generation suite with a real `AgentRuntime` backed by `InMemoryDatabaseAdapter`
- registers deterministic external model handlers for `TEXT_SMALL` and `TEXT_LARGE` through `runtime.registerModel`
- exercises real runtime settings, provider selection, `useModel` dispatch, and model handler lookup while keeping the external model response deterministic

## Why

The external model boundary is not the runtime behavior under test. Replacing `runtime.useModel` itself bypassed the routing architecture that the suite claimed to cover.

## Validation

- exact head: `b9bac07fcec9e9b49da7c86e1183b80bda38bc80`
- generation suite: 33 passed, 0 failed, 80 assertions
- full plugin suite: 379 passed, 0 failed, 1,160 assertions
- plugin typecheck passed after building the workspace's core/shared artifacts
- plugin Biome check and `git diff --check` passed

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - test-harness change with no rendered UI surface`.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - test-harness change with no rendered UI surface`.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - there is no user-facing visual flow`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - no production server path changed; the full plugin and focused suite outputs are the applicable proof`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code or request path changed`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - production prompt/model behavior is unchanged; the external response is deliberately deterministic while real runtime dispatch is the subject under test`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - no production workflow, database row, memory, or file is created by this test-only change`.
