### PR TITLE
fix(cloud): unify MCP chat reserved and provider output ceilings

### DIFF
--- a/.github/workflows/develop-live.yml
+++ b/.github/workflows/develop-live.yml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
     inputs:
       filter:
-        description: "Optional task-label regex; use a2a-receipt for only the exact A2A proof"
+        description: "Optional task-label regex; use a2a-receipt or mcp-receipt for an exact billing proof"
         type: string
         default: ""
   schedule:
@@ -119,7 +119,7 @@ jobs:
           fi
 
       - name: Post-merge live matrix
-        if: inputs.filter != 'a2a-receipt'
+        if: inputs.filter != 'a2a-receipt' && inputs.filter != 'mcp-receipt'
         env:
           RUNNER_TEMP_LOG: ${{ runner.temp }}/develop-live-sweep.log
           TEST_FILTER: ${{ inputs.filter }}
@@ -132,7 +132,7 @@ jobs:
           node packages/scripts/run-all-tests.mjs --all --no-cloud "${filter_args[@]}" 2>&1 | tee "$RUNNER_TEMP_LOG"
 
       - name: Cloud unit suite
-        if: always() && inputs.filter != 'a2a-receipt'
+        if: always() && inputs.filter != 'a2a-receipt' && inputs.filter != 'mcp-receipt'
         run: bun run test:cloud
 
       - name: Exact-head A2A live provider and billing receipt
@@ -141,6 +141,16 @@ jobs:
           (inputs.filter == '' || inputs.filter == 'cloud-api' || inputs.filter == 'a2a-receipt')
         env:
           E2E_ONLY: group-c-agents
+          E2E_RECEIPT_TARGET: a2a
+        run: bun run --cwd packages/cloud/api test:e2e
+
+      - name: Exact-head MCP live provider and billing receipt
+        if: >-
+          always() &&
+          (inputs.filter == '' || inputs.filter == 'cloud-api' || inputs.filter == 'mcp-receipt')
+        env:
+          E2E_ONLY: group-c-agents
+          E2E_RECEIPT_TARGET: mcp
         run: bun run --cwd packages/cloud/api test:e2e
 
       - name: Teardown Postgres

--- a/packages/cloud/api/__tests__/agent-mcp-billing.test.ts
+++ b/packages/cloud/api/__tests__/agent-mcp-billing.test.ts
@@ -15,9 +15,9 @@ import * as workersHonoAuthActual from "@/lib/auth/workers-hono-auth";
 const ORG_ID = "00000000-0000-4000-8000-0000000000aa";
 const USER_ID = "00000000-0000-4000-8000-0000000000bb";
 
-const languageModel = mock((model: string) => ({ model }));
-mock.module("@ai-sdk/gateway", () => ({
-  gateway: { languageModel },
+const getLanguageModel = mock((model: string) => ({ model }));
+mock.module("@/lib/providers/language-model", () => ({
+  getLanguageModel,
 }));
 
 const streamText = mock();
@@ -156,7 +156,7 @@ async function callChat() {
 }
 
 beforeEach(() => {
-  languageModel.mockClear();
+  getLanguageModel.mockClear();
   streamText.mockReset();
   resolveAnthropicThinkingBudgetTokens.mockReset();
   resolveAnthropicThinkingBudgetTokens.mockReturnValue(null);
@@ -268,8 +268,8 @@ describe("Agent MCP billing", () => {
   // recordCreatorEarnings throws, the pre-fix code let it reach the outer catch,
   // which ran the NON-idempotent reconcile(0) — double-refunding the WHOLE
   // reservation (free inference + a net credit grant) and returning an error.
-  // The fix swallows the earnings error so reconcile fires exactly once and the
-  // already-correct settlement response is returned.
+  // The degraded response carries an explicit warning, so reconcile fires
+  // exactly once without presenting the accounting path as fully healthy.
   test("post-settlement earnings failure does not double-refund the reservation", async () => {
     const reconcile = makeReservation({ adjustmentType: "none" });
     recordCreatorEarnings.mockRejectedValue(
@@ -278,7 +278,10 @@ describe("Agent MCP billing", () => {
 
     const response = await callChat();
     const body = (await response.json()) as {
-      result?: { content: Array<{ type: string; text: string }> };
+      result?: {
+        content: Array<{ type: string; text: string }>;
+        _meta?: { warnings?: Array<{ code: string; message: string }> };
+      };
       error?: { code: number; message: string };
     };
 
@@ -294,6 +297,12 @@ describe("Agent MCP billing", () => {
     expect(recordCreatorEarnings).toHaveBeenCalledTimes(1);
     expect(body.error).toBeUndefined();
     expect(body.result?.content?.[0]?.text).toBe("hello from model");
+    expect(body.result?._meta?.warnings).toEqual([
+      {
+        code: "CREATOR_EARNINGS_UNAVAILABLE",
+        message: "Creator earnings could not be recorded",
+      },
+    ]);
   });
 
   test("get_info returns agent metadata without billing", async () => {
@@ -343,6 +352,28 @@ describe("Agent MCP billing", () => {
     expect(body.error?.message).toContain("Insufficient credits");
     // Reserve-before-provider: a failed admission performs no inference.
     expect(streamText).not.toHaveBeenCalled();
+  });
+
+  test("missing provider usage fails and refunds instead of fabricating zero metering", async () => {
+    const reconcile = makeReservation({ adjustmentType: "refund" });
+    streamText.mockResolvedValue({
+      textStream: textStream("unmetered output"),
+      usage: Promise.resolve({
+        inputTokens: undefined,
+        outputTokens: undefined,
+        totalTokens: undefined,
+      }),
+    });
+
+    const response = await callChat();
+    const body = (await response.json()) as {
+      error?: { code: number; message: string };
+    };
+
+    expect(body.error?.code).toBe(-32000);
+    expect(reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcile).toHaveBeenCalledWith(0);
+    expect(recordCreatorEarnings).not.toHaveBeenCalled();
   });
 
   test("a provider error refunds the reservation and returns -32000", async () => {

--- a/packages/cloud/api/__tests__/agent-mcp-billing.test.ts
+++ b/packages/cloud/api/__tests__/agent-mcp-billing.test.ts
@@ -216,9 +216,8 @@ describe("Agent MCP billing", () => {
   });
 
   // #16148: the reserved output ceiling and the provider-facing cap must be one
-  // immutable value for every resolved thinking budget — the acceptance table.
-  // Previously reserve used `4096 + budget` while the provider got
-  // `max(4096, budget) + 4096` (and no cap with thinking off).
+  // immutable value for every resolved thinking budget. The table covers both
+  // the finite no-thinking floor and admitted thinking budgets.
   test.each([
     [null, 4096, 0],
     [1024, 5120, 1024],
@@ -230,6 +229,9 @@ describe("Agent MCP billing", () => {
 
     const response = await callChat();
     expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      result?: { _meta?: { admittedOutputTokens?: number } };
+    };
 
     // Reserved with this exact ceiling (3rd arg to estimateRequestCost)...
     expect(estimateRequestCost.mock.calls[0]?.[2]).toBe(expectedCap);
@@ -239,6 +241,7 @@ describe("Agent MCP billing", () => {
     expect(streamText.mock.calls[0]?.[0]?.maxOutputTokens).toBe(
       estimateRequestCost.mock.calls[0]?.[2],
     );
+    expect(body.result?._meta?.admittedOutputTokens).toBe(expectedCap);
     // Provider thinking policy uses the already-resolved effective budget
     // (`effectiveThinkingBudget ?? 0`), not a recomputed value.
     expect(mergeAnthropicCotProviderOptions.mock.calls[0]?.[2]).toBe(
@@ -263,13 +266,8 @@ describe("Agent MCP billing", () => {
     expect(recordCreatorEarnings).not.toHaveBeenCalled();
   });
 
-  // Regression for #10266: a post-settlement earnings failure must NOT trigger a
-  // second reconcile. The consumer is settled with reconcile(actualTotal); if
-  // recordCreatorEarnings throws, the pre-fix code let it reach the outer catch,
-  // which ran the NON-idempotent reconcile(0) — double-refunding the WHOLE
-  // reservation (free inference + a net credit grant) and returning an error.
-  // The degraded response carries an explicit warning, so reconcile fires
-  // exactly once without presenting the accounting path as fully healthy.
+  // The consumer settlement is non-idempotent: a later creator-accounting
+  // failure must remain visible without entering the outer refund boundary.
   test("post-settlement earnings failure does not double-refund the reservation", async () => {
     const reconcile = makeReservation({ adjustmentType: "none" });
     recordCreatorEarnings.mockRejectedValue(
@@ -350,17 +348,28 @@ describe("Agent MCP billing", () => {
     expect(streamText).not.toHaveBeenCalled();
   });
 
-  test("chat with an empty message is rejected before billing", async () => {
+  test.each([
+    ["missing message", { model: "gpt-5-mini" }],
+    ["blank message", { message: "   ", model: "gpt-5-mini" }],
+    ["non-string message", { message: 42, model: "gpt-5-mini" }],
+    ["blank model", { message: "hello", model: "" }],
+  ])("chat with %s is rejected before billing", async (_case, args) => {
     const response = await handleToolCall(
       makeContext() as never,
       makeCharacter(),
-      { name: "chat", arguments: { model: "gpt-5-mini" } },
+      { name: "chat", arguments: args },
       "rpc-1",
       { id: USER_ID, organization_id: ORG_ID },
     );
-    const body = (await response.json()) as { error?: { code: number } };
+    const body = (await response.json()) as {
+      error?: { code: number; message: string };
+    };
 
-    expect(body.error?.code).toBe(-32602);
+    expect(response.status).toBe(400);
+    expect(body.error).toEqual({
+      code: -32602,
+      message: "valid chat arguments are required",
+    });
     expect(reserve).not.toHaveBeenCalled();
     expect(streamText).not.toHaveBeenCalled();
   });

--- a/packages/cloud/api/__tests__/agent-mcp-billing.test.ts
+++ b/packages/cloud/api/__tests__/agent-mcp-billing.test.ts
@@ -34,11 +34,22 @@ mock.module("@/lib/pricing", () => ({
   getProviderFromModel,
 }));
 
+// Settable so a test can drive the admitted thinking budget through the route
+// (#16148). The resolver's own clamping is unit-tested elsewhere; here it stands
+// in for "whatever budget the route resolved to".
+const resolveAnthropicThinkingBudgetTokens = mock((): number | null => null);
+const mergeAnthropicCotProviderOptions = mock(
+  (
+    _model: string,
+    _env: unknown,
+    _budget?: number,
+  ): Record<string, unknown> => ({}),
+);
 mock.module("@/lib/providers/anthropic-thinking", () => ({
   getAnthropicCotEnv: () => ({}),
-  mergeAnthropicCotProviderOptions: () => ({}),
+  mergeAnthropicCotProviderOptions,
   parseThinkingBudgetFromCharacterSettings: () => null,
-  resolveAnthropicThinkingBudgetTokens: () => null,
+  resolveAnthropicThinkingBudgetTokens,
 }));
 
 const recordCreatorEarnings = mock();
@@ -147,6 +158,10 @@ async function callChat() {
 beforeEach(() => {
   languageModel.mockClear();
   streamText.mockReset();
+  resolveAnthropicThinkingBudgetTokens.mockReset();
+  resolveAnthropicThinkingBudgetTokens.mockReturnValue(null);
+  mergeAnthropicCotProviderOptions.mockReset();
+  mergeAnthropicCotProviderOptions.mockReturnValue({});
   estimateRequestCost.mockReset();
   calculateCost.mockReset();
   getProviderFromModel.mockClear();
@@ -200,6 +215,37 @@ describe("Agent MCP billing", () => {
     );
   });
 
+  // #16148: the reserved output ceiling and the provider-facing cap must be one
+  // immutable value for every resolved thinking budget — the acceptance table.
+  // Previously reserve used `4096 + budget` while the provider got
+  // `max(4096, budget) + 4096` (and no cap with thinking off).
+  test.each([
+    [null, 4096, 0],
+    [1024, 5120, 1024],
+    [4096, 8192, 4096],
+    [8000, 12096, 8000],
+  ] as const)("reserves and caps the provider at one ceiling (budget=%p → cap=%p)", async (budget, expectedCap, expectedProviderBudget) => {
+    makeReservation({ adjustmentType: "none" });
+    resolveAnthropicThinkingBudgetTokens.mockReturnValue(budget);
+
+    const response = await callChat();
+    expect(response.status).toBe(200);
+
+    // Reserved with this exact ceiling (3rd arg to estimateRequestCost)...
+    expect(estimateRequestCost.mock.calls[0]?.[2]).toBe(expectedCap);
+    // ...and the provider is capped at the identical value — always sent.
+    expect(streamText).toHaveBeenCalledTimes(1);
+    expect(streamText.mock.calls[0]?.[0]?.maxOutputTokens).toBe(expectedCap);
+    expect(streamText.mock.calls[0]?.[0]?.maxOutputTokens).toBe(
+      estimateRequestCost.mock.calls[0]?.[2],
+    );
+    // Provider thinking policy uses the already-resolved effective budget
+    // (`effectiveThinkingBudget ?? 0`), not a recomputed value.
+    expect(mergeAnthropicCotProviderOptions.mock.calls[0]?.[2]).toBe(
+      expectedProviderBudget,
+    );
+  });
+
   test("does not record creator earnings when final overage is uncollected", async () => {
     makeReservation({ adjustmentType: "uncollected_overage" });
     calculateCost.mockResolvedValue({ totalCost: 0.02 });
@@ -248,5 +294,70 @@ describe("Agent MCP billing", () => {
     expect(recordCreatorEarnings).toHaveBeenCalledTimes(1);
     expect(body.error).toBeUndefined();
     expect(body.result?.content?.[0]?.text).toBe("hello from model");
+  });
+
+  test("get_info returns agent metadata without billing", async () => {
+    const response = await handleToolCall(
+      makeContext() as never,
+      makeCharacter(),
+      { name: "get_info", arguments: {} },
+      "rpc-1",
+      { id: USER_ID, organization_id: ORG_ID },
+    );
+    const body = (await response.json()) as {
+      result?: { content: Array<{ type: string; text: string }> };
+    };
+
+    expect(response.status).toBe(200);
+    const info = JSON.parse(body.result?.content?.[0]?.text ?? "{}");
+    expect(info).toMatchObject({ name: "Markup Agent", monetization: true });
+    // Metadata-only: no reservation, no provider call.
+    expect(reserve).not.toHaveBeenCalled();
+    expect(streamText).not.toHaveBeenCalled();
+  });
+
+  test("chat with an empty message is rejected before billing", async () => {
+    const response = await handleToolCall(
+      makeContext() as never,
+      makeCharacter(),
+      { name: "chat", arguments: { model: "gpt-5-mini" } },
+      "rpc-1",
+      { id: USER_ID, organization_id: ORG_ID },
+    );
+    const body = (await response.json()) as { error?: { code: number } };
+
+    expect(body.error?.code).toBe(-32602);
+    expect(reserve).not.toHaveBeenCalled();
+    expect(streamText).not.toHaveBeenCalled();
+  });
+
+  test("insufficient credits at reservation returns -32003 and never calls the provider", async () => {
+    reserve.mockRejectedValue(new InsufficientCreditsError(0.5, 0.1));
+
+    const response = await callChat();
+    const body = (await response.json()) as {
+      error?: { code: number; message: string };
+    };
+
+    expect(body.error?.code).toBe(-32003);
+    expect(body.error?.message).toContain("Insufficient credits");
+    // Reserve-before-provider: a failed admission performs no inference.
+    expect(streamText).not.toHaveBeenCalled();
+  });
+
+  test("a provider error refunds the reservation and returns -32000", async () => {
+    const reconcile = makeReservation({ adjustmentType: "none" });
+    streamText.mockRejectedValue(new Error("provider unavailable"));
+
+    const response = await callChat();
+    const body = (await response.json()) as {
+      error?: { code: number; message: string };
+    };
+
+    expect(body.error?.code).toBe(-32000);
+    expect(body.error?.message).toBe("provider unavailable");
+    // The whole reservation is refunded (reconcile(0)); no creator earnings.
+    expect(reconcile).toHaveBeenCalledWith(0);
+    expect(recordCreatorEarnings).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/__tests__/agent-mcp-billing.test.ts
+++ b/packages/cloud/api/__tests__/agent-mcp-billing.test.ts
@@ -292,8 +292,8 @@ describe("Agent MCP billing", () => {
     expect(reconcile).toHaveBeenCalledTimes(1);
     expect(reconcile.mock.calls[0]?.[0]).toBeCloseTo(0.06, 12);
 
-    // The earnings step was attempted (and failed) — but the request still
-    // returns the successful settlement, never the -32000 outer-catch error.
+    // Settlement remains successful, while the warning makes the failed
+    // secondary accounting write observable to the caller.
     expect(recordCreatorEarnings).toHaveBeenCalledTimes(1);
     expect(body.error).toBeUndefined();
     expect(body.result?.content?.[0]?.text).toBe("hello from model");
@@ -321,6 +321,31 @@ describe("Agent MCP billing", () => {
     const info = JSON.parse(body.result?.content?.[0]?.text ?? "{}");
     expect(info).toMatchObject({ name: "Markup Agent", monetization: true });
     // Metadata-only: no reservation, no provider call.
+    expect(reserve).not.toHaveBeenCalled();
+    expect(streamText).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ["missing tool name", {}],
+    ["blank tool name", { name: "" }],
+    ["non-object arguments", { name: "chat", arguments: "invalid" }],
+  ])("rejects %s before billing", async (_case, params) => {
+    const response = await handleToolCall(
+      makeContext() as never,
+      makeCharacter(),
+      params,
+      "rpc-1",
+      { id: USER_ID, organization_id: ORG_ID },
+    );
+    const body = (await response.json()) as {
+      error?: { code: number; message: string };
+    };
+
+    expect(response.status).toBe(400);
+    expect(body.error).toEqual({
+      code: -32602,
+      message: "valid tool call params are required",
+    });
     expect(reserve).not.toHaveBeenCalled();
     expect(streamText).not.toHaveBeenCalled();
   });

--- a/packages/cloud/api/agents/[id]/mcp/route.ts
+++ b/packages/cloud/api/agents/[id]/mcp/route.ts
@@ -55,6 +55,11 @@ const ProviderUsageSchema = z.object({
   totalTokens: z.number().int().nonnegative(),
 });
 
+const ToolCallParamsSchema = z.object({
+  name: z.string().trim().min(1),
+  arguments: z.record(z.string(), z.unknown()).default({}),
+});
+
 const app = new Hono<AppEnv>();
 
 function getAnthropicCotEnv(env: AppEnv["Bindings"]): AnthropicCotEnv {
@@ -260,10 +265,18 @@ export async function handleToolCall(
   rpcId: string | number,
   authUser: { id: string; organization_id: string },
 ): Promise<Response> {
-  const { name, arguments: args } = params as {
-    name: string;
-    arguments: Record<string, unknown>;
-  };
+  const parsedParams = ToolCallParamsSchema.safeParse(params);
+  if (!parsedParams.success) {
+    return c.json(
+      {
+        jsonrpc: "2.0",
+        error: { code: -32602, message: "valid tool call params are required" },
+        id: rpcId,
+      },
+      400,
+    );
+  }
+  const { name, arguments: args } = parsedParams.data;
 
   if (name === "get_info") {
     const bioText = Array.isArray(character.bio)
@@ -423,12 +436,10 @@ export async function handleToolCall(
         | { code: "CREATOR_EARNINGS_UNAVAILABLE"; message: string }
         | undefined;
       if (character.monetization_enabled && actualCreatorMarkup > 0) {
-        // Earnings recording is a NON-CRITICAL post-settlement step. The consumer
-        // was already settled above (reconcile(actualTotal)); if this throws it
-        // must NOT propagate to the outer catch, whose reconcile(0) is
-        // non-idempotent and would refund the WHOLE reservation a second time →
-        // free inference + a net credit grant (and the creator may already be
-        // credited). Log and swallow, matching processUsage's documented intent.
+        // Settlement is non-idempotent: a secondary accounting failure cannot
+        // reach the outer refund boundary after reconcile(actualTotal), because
+        // reconcile(0) would issue a second adjustment. The warning below keeps
+        // that degraded outcome visible without corrupting consumer billing.
         try {
           await agentMonetizationService.recordCreatorEarnings({
             agentId: character.id,

--- a/packages/cloud/api/agents/[id]/mcp/route.ts
+++ b/packages/cloud/api/agents/[id]/mcp/route.ts
@@ -351,20 +351,23 @@ export async function handleToolCall(
       throw error;
     }
 
-    const maxOutputTokens = effectiveThinkingBudget
-      ? Math.max(DEFAULT_MIN_OUTPUT_TOKENS, effectiveThinkingBudget) +
-        DEFAULT_MIN_OUTPUT_TOKENS
-      : undefined;
-
     try {
       const result = await streamText({
         model: gateway.languageModel(model),
         messages,
-        ...(maxOutputTokens && { maxOutputTokens }),
+        // Cap the provider at the EXACT ceiling billing reserved above
+        // (`estimatedOutputTokens`), not a second, larger formula (#16148).
+        // Always sent — including the no-thinking 4096 floor — so final usage
+        // cannot outrun the admitted reservation.
+        maxOutputTokens: estimatedOutputTokens,
         ...mergeAnthropicCotProviderOptions(
           model,
           envForThinking,
-          agentThinkingBudget,
+          // Feed the already-resolved effective budget, not the raw character
+          // setting. Idempotent: a positive budget re-resolves to itself and
+          // `0` re-resolves to off, so the provider's thinking policy is exactly
+          // what was priced — never a recomputed, divergent value (#16148).
+          effectiveThinkingBudget ?? 0,
         ),
       });
 

--- a/packages/cloud/api/agents/[id]/mcp/route.ts
+++ b/packages/cloud/api/agents/[id]/mcp/route.ts
@@ -4,11 +4,10 @@
  * GET → MCP server metadata + tool catalog.
  * POST → JSON-RPC dispatch (`initialize`, `tools/list`, `tools/call`, `ping`).
  *
- * The `chat` tool reserves credits, calls the model via the configured
- * provider (BitRouter), then reconciles. Returns plain JSON, not SSE.
+ * The `chat` tool reserves credits, resolves the configured model provider,
+ * then reconciles actual usage. Returns plain JSON, not SSE.
  */
 
-import { gateway } from "@ai-sdk/gateway";
 import { calculateCreditMarkup } from "@elizaos/cloud-shared/billing";
 import { streamText } from "ai";
 import { Hono } from "hono";
@@ -30,6 +29,7 @@ import {
   parseThinkingBudgetFromCharacterSettings,
   resolveAnthropicThinkingBudgetTokens,
 } from "@/lib/providers/anthropic-thinking";
+import { getLanguageModel } from "@/lib/providers/language-model";
 import { agentMonetizationService } from "@/lib/services/agent-monetization";
 import { charactersService } from "@/lib/services/characters/characters";
 import type { CreditReservation } from "@/lib/services/credits";
@@ -47,6 +47,12 @@ const MCPRequestSchema = z.object({
   method: z.string(),
   params: z.record(z.string(), z.unknown()).optional(),
   id: z.union([z.string(), z.number()]),
+});
+
+const ProviderUsageSchema = z.object({
+  inputTokens: z.number().int().nonnegative(),
+  outputTokens: z.number().int().nonnegative(),
+  totalTokens: z.number().int().nonnegative(),
 });
 
 const app = new Hono<AppEnv>();
@@ -168,6 +174,8 @@ app.post("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
   try {
     user = await requireUserOrApiKeyWithOrg(c);
   } catch {
+    // error-policy:J1 the public JSON-RPC boundary translates authentication
+    // failures without exposing session or API-key internals.
     return c.json(
       {
         jsonrpc: "2.0",
@@ -338,6 +346,8 @@ export async function handleToolCall(
         description: `Agent MCP: ${character.name} (${model})`,
       });
     } catch (error) {
+      // error-policy:J1 the route boundary translates the expected credit
+      // refusal and lets unexpected reservation failures reach the owner path.
       if (error instanceof InsufficientCreditsError) {
         return c.json({
           jsonrpc: "2.0",
@@ -353,7 +363,7 @@ export async function handleToolCall(
 
     try {
       const result = await streamText({
-        model: gateway.languageModel(model),
+        model: getLanguageModel(model),
         messages,
         // Cap the provider at the EXACT ceiling billing reserved above
         // (`estimatedOutputTokens`), not a second, larger formula (#16148).
@@ -376,13 +386,13 @@ export async function handleToolCall(
         fullText += delta;
       }
 
-      const usage = await result.usage;
+      const usage = ProviderUsageSchema.parse(await result.usage);
 
       const { totalCost: actualBaseCost } = await calculateCost(
         model,
         provider,
-        usage?.inputTokens || 0,
-        usage?.outputTokens || 0,
+        usage.inputTokens,
+        usage.outputTokens,
       );
       const { markupCredits: actualCreatorMarkup, totalCredits: actualTotal } =
         calculateCreditMarkup({
@@ -409,6 +419,9 @@ export async function handleToolCall(
         });
       }
 
+      let creatorEarningsWarning:
+        | { code: "CREATOR_EARNINGS_UNAVAILABLE"; message: string }
+        | undefined;
       if (character.monetization_enabled && actualCreatorMarkup > 0) {
         // Earnings recording is a NON-CRITICAL post-settlement step. The consumer
         // was already settled above (reconcile(actualTotal)); if this throws it
@@ -424,7 +437,7 @@ export async function handleToolCall(
             earnings: actualCreatorMarkup,
             consumerOrgId: authUser.organization_id,
             model,
-            tokens: (usage?.inputTokens || 0) + (usage?.outputTokens || 0),
+            tokens: usage.totalTokens,
             protocol: "mcp",
           });
           logger.info(
@@ -436,6 +449,9 @@ export async function handleToolCall(
             },
           );
         } catch (earningsError) {
+          // error-policy:J4 inference is already purchased and settled, so the
+          // response degrades explicitly with a machine-readable warning while
+          // the structured error log raises the accounting failure to operators.
           logger.error(
             "[Agent MCP] Failed to record creator earnings (settlement already applied — not rolling back)",
             {
@@ -447,6 +463,10 @@ export async function handleToolCall(
                   : String(earningsError),
             },
           );
+          creatorEarningsWarning = {
+            code: "CREATOR_EARNINGS_UNAVAILABLE",
+            message: "Creator earnings could not be recorded",
+          };
         }
       }
 
@@ -461,14 +481,19 @@ export async function handleToolCall(
               total: actualTotal,
             },
             usage: {
-              inputTokens: usage?.inputTokens || 0,
-              outputTokens: usage?.outputTokens || 0,
+              inputTokens: usage.inputTokens,
+              outputTokens: usage.outputTokens,
             },
+            ...(creatorEarningsWarning
+              ? { warnings: [creatorEarningsWarning] }
+              : {}),
           },
         },
         id: rpcId,
       });
     } catch (error) {
+      // error-policy:J1 the JSON-RPC boundary refunds a failed generation and
+      // returns a structured failure instead of partial model output.
       await reservation.reconcile(0);
       logger.error("[Agent MCP] Error generating response", {
         error: error instanceof Error ? error.message : "Unknown error",

--- a/packages/cloud/api/agents/[id]/mcp/route.ts
+++ b/packages/cloud/api/agents/[id]/mcp/route.ts
@@ -60,6 +60,11 @@ const ToolCallParamsSchema = z.object({
   arguments: z.record(z.string(), z.unknown()).default({}),
 });
 
+const ChatArgumentsSchema = z.object({
+  message: z.string().trim().min(1),
+  model: z.string().trim().min(1).default("gpt-5-mini"),
+});
+
 const app = new Hono<AppEnv>();
 
 function getAnthropicCotEnv(env: AppEnv["Bindings"]): AnthropicCotEnv {
@@ -302,17 +307,18 @@ export async function handleToolCall(
   }
 
   if (name === "chat") {
-    const { message, model = "gpt-5-mini" } = args as {
-      message: string;
-      model?: string;
-    };
-    if (!message) {
-      return c.json({
-        jsonrpc: "2.0",
-        error: { code: -32602, message: "message required" },
-        id: rpcId,
-      });
+    const parsedArguments = ChatArgumentsSchema.safeParse(args);
+    if (!parsedArguments.success) {
+      return c.json(
+        {
+          jsonrpc: "2.0",
+          error: { code: -32602, message: "valid chat arguments are required" },
+          id: rpcId,
+        },
+        400,
+      );
     }
+    const { message, model } = parsedArguments.data;
 
     const bioText = Array.isArray(character.bio)
       ? character.bio.join("\n")
@@ -375,6 +381,12 @@ export async function handleToolCall(
     }
 
     try {
+      logger.info("[Agent MCP] Invoking configured provider", {
+        agentId: character.id,
+        model,
+        maxOutputTokens: estimatedOutputTokens,
+        thinkingBudgetTokens: effectiveThinkingBudget,
+      });
       const result = await streamText({
         model: getLanguageModel(model),
         messages,
@@ -486,6 +498,7 @@ export async function handleToolCall(
         result: {
           content: [{ type: "text", text: fullText }],
           _meta: {
+            admittedOutputTokens: estimatedOutputTokens,
             cost: {
               base: actualBaseCost,
               markup: actualCreatorMarkup,

--- a/packages/cloud/api/test/e2e/group-c-agents.test.ts
+++ b/packages/cloud/api/test/e2e/group-c-agents.test.ts
@@ -37,6 +37,7 @@ import {
 } from "./_helpers/api";
 
 const UNOWNED_AGENT_ID = "00000000-0000-4000-8000-000000000000";
+const MCP_LIVE_ADMITTED_OUTPUT_TOKENS = 4096;
 
 const serverReachable = await isServerReachable();
 const hasTestApiKey = Boolean(process.env.TEST_API_KEY?.trim());
@@ -45,6 +46,7 @@ const hasLiveProvider = Boolean(
     process.env.OPENROUTER_API_KEY?.trim() ||
     process.env.AI_GATEWAY_API_KEY?.trim(),
 );
+const receiptTarget = process.env.E2E_RECEIPT_TARGET?.trim();
 if (!serverReachable) {
   console.warn(
     `[group-c-agents] ${getBaseUrl()} did not respond to /api/health. ` +
@@ -61,8 +63,8 @@ if (!hasTestApiKey) {
 if (!hasLiveProvider) {
   console.warn(
     "[group-c-agents] OPENAI_API_KEY, OPENROUTER_API_KEY, and " +
-      "AI_GATEWAY_API_KEY are not set; the exact-head A2A " +
-      "provider/billing receipt test will SKIP.",
+      "AI_GATEWAY_API_KEY are not set; exact-head A2A and MCP " +
+      "provider/billing receipt tests will SKIP.",
   );
 }
 
@@ -80,6 +82,7 @@ async function seedOwnedCharacter(input: {
   settings?: Record<string, unknown>;
   isPublic?: boolean;
   a2aEnabled?: boolean;
+  mcpEnabled?: boolean;
 }): Promise<void> {
   const databaseUrl = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
   if (!databaseUrl) {
@@ -111,6 +114,7 @@ async function seedOwnedCharacter(input: {
          is_template,
          is_public,
          a2a_enabled,
+         mcp_enabled,
          source,
          view_count,
          interaction_count,
@@ -135,6 +139,7 @@ async function seedOwnedCharacter(input: {
          false,
          $9,
          $10,
+         $11,
          'cloud',
          3,
          2,
@@ -156,6 +161,9 @@ async function seedOwnedCharacter(input: {
         }),
         input.isPublic ?? false,
         input.a2aEnabled ?? false,
+        // Match the schema default for normal fixtures while allowing access-
+        // control cases to seed an explicitly disabled MCP agent.
+        input.mcpEnabled ?? true,
       ],
     );
   } finally {
@@ -327,7 +335,7 @@ describeE2E("/api/agents/:id/a2a", () => {
     });
   });
 
-  test.skipIf(!hasLiveProvider)(
+  test.skipIf(!hasLiveProvider || receiptTarget === "mcp")(
     "live provider stays within the admitted ceiling and settles the real credit hold",
     async () => {
       const userId = process.env.TEST_USER_ID;
@@ -434,6 +442,139 @@ describeE2E("/api/agents/:id/a2a", () => {
         `${JSON.stringify(
           {
             evidence: "exact-head-a2a-live-provider-billing-receipt",
+            agent: { id: agentId, name: agentName },
+            httpStatus: response.status,
+            providerReceipt: receipt.result,
+            databaseSettlement: settlement,
+          },
+          null,
+          2,
+        )}\n`,
+      );
+    },
+    120_000,
+  );
+});
+
+// -------------------------------------------------------------------------
+// /api/agents/:id/mcp — live provider + credit settlement receipt
+// -------------------------------------------------------------------------
+describeE2E("/api/agents/:id/mcp", () => {
+  test.skipIf(!hasLiveProvider || receiptTarget === "a2a")(
+    "live provider stays within the admitted ceiling and settles the real credit hold",
+    async () => {
+      const userId = process.env.TEST_USER_ID;
+      const organizationId = process.env.TEST_ORGANIZATION_ID;
+      const databaseUrl =
+        process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+      if (!userId || !organizationId || !databaseUrl) {
+        throw new Error(
+          "TEST_USER_ID, TEST_ORGANIZATION_ID, and the e2e database URL are required",
+        );
+      }
+
+      const agentId = crypto.randomUUID();
+      const agentName = `MCP live ceiling ${crypto.randomUUID()}`;
+      await seedOwnedCharacter({
+        id: agentId,
+        organizationId,
+        userId,
+        name: agentName,
+        isPublic: true,
+        mcpEnabled: true,
+      });
+      createdCharacterIds.push(agentId);
+
+      const response = await api.post(
+        `/api/agents/${agentId}/mcp`,
+        {
+          jsonrpc: "2.0",
+          method: "tools/call",
+          id: "mcp-live-ceiling",
+          params: {
+            name: "chat",
+            arguments: {
+              message: "Confirm this live MCP request in one short sentence.",
+              model: "gpt-5-mini",
+            },
+          },
+        },
+        { headers: bearerHeaders() },
+      );
+      const rawBody = await response.text();
+      expect(response.status, rawBody).toBe(200);
+      const receipt = z
+        .object({
+          jsonrpc: z.literal("2.0"),
+          id: z.literal("mcp-live-ceiling"),
+          result: z.object({
+            content: z
+              .array(z.object({ type: z.literal("text"), text: z.string() }))
+              .min(1),
+            _meta: z.object({
+              admittedOutputTokens: z.literal(MCP_LIVE_ADMITTED_OUTPUT_TOKENS),
+              usage: z.object({
+                inputTokens: z.number().int().nonnegative(),
+                outputTokens: z
+                  .number()
+                  .int()
+                  .positive()
+                  .max(MCP_LIVE_ADMITTED_OUTPUT_TOKENS),
+              }),
+              cost: z.object({
+                base: z.number().nonnegative(),
+                markup: z.number().nonnegative(),
+                total: z.number().positive(),
+              }),
+            }),
+          }),
+        })
+        .parse(JSON.parse(rawBody));
+      expect(receipt.result.content.some((part) => part.text.length > 0)).toBe(
+        true,
+      );
+
+      const client = new Client({ connectionString: databaseUrl });
+      await client.connect();
+      let settlement: {
+        amount: string;
+        description: string | null;
+        settled_at: Date | null;
+        metadata: Record<string, unknown>;
+      };
+      try {
+        const result = await client.query<{
+          amount: string;
+          description: string | null;
+          settled_at: Date | null;
+          metadata: Record<string, unknown>;
+        }>(
+          `SELECT amount, description, settled_at, metadata
+             FROM credit_transactions
+            WHERE organization_id = $1
+              AND description = $2
+            ORDER BY created_at DESC
+            LIMIT 1`,
+          [organizationId, `Agent MCP: ${agentName} (gpt-5-mini) (reserved)`],
+        );
+        const row = result.rows[0];
+        if (!row) throw new Error("MCP reservation row was not persisted");
+        settlement = row;
+      } finally {
+        await client.end();
+      }
+
+      expect(settlement.settled_at).toBeInstanceOf(Date);
+      expect(Number(settlement.amount)).toBeLessThan(0);
+      expect(settlement.metadata.type).toBe("reservation");
+      expect(settlement.metadata.settlement_marker).toBe(
+        "credit_reservation_v1",
+      );
+
+      process.stdout.write(
+        `${JSON.stringify(
+          {
+            evidence: "exact-head-mcp-live-provider-billing-receipt",
             agent: { id: agentId, name: agentName },
             httpStatus: response.status,
             providerReceipt: receipt.result,


### PR DESCRIPTION
# Relates to

Closes #16148

- [x] Targets `develop` and is rebased on the latest `origin/develop`.
- [x] A reviewer can confirm the change from the evidence below without reading the code.

# Risks

The affected surface is the public per-agent MCP `chat` tool. Valid requests retain reserve-before-provider and exactly-once reconciliation. Invalid JSON-RPC tool/chat arguments now reject before billing, incomplete provider usage fails closed and refunds, and a post-settlement creator-accounting failure returns a machine-readable warning instead of entering the non-idempotent refund boundary.

# Background

## What does this PR do?

The MCP route previously priced one output ceiling but authorized a different—or absent—provider ceiling. It now derives one admitted value, `4096 + effective thinking budget`, and sends it unchanged to both reservation pricing and `streamText.maxOutputTokens`. Provider selection goes through the configured shared resolver rather than a hardwired gateway.

The route requires valid nested tool/chat arguments and complete non-negative provider metering. Missing usage can no longer appear as zero cost. Creator-earnings failure after consumer settlement is surfaced through `warnings` and structured logs without issuing a second refund.

The exact reviewed head is `992a273cfb7cfcdc421a2791dd999797b543050d`.

## What kind of change is this?

Bug fix (non-breaking for valid requests).

# Documentation changes needed?

No public API documentation changes are required.

# Testing

## Where should a reviewer start?

`packages/cloud/api/agents/[id]/mcp/route.ts` contains the shared ceiling, configured provider resolution, strict request/metering validation, and structured invocation cap log. `packages/cloud/api/__tests__/agent-mcp-billing.test.ts` covers the route boundaries. `packages/cloud/api/test/e2e/group-c-agents.test.ts` produces the real provider/HTTP/Postgres receipt.

## Detailed testing results

- 18 focused MCP billing tests passed: all cap rows, malformed tool/chat inputs, missing usage, insufficient credits, provider failure, uncollected overage, and post-settlement earnings warning.
- 5 shared resolver tests passed on the exact base: character override, deploy default, operator cap for both sources, explicit zero, and unsupported provider/model families.
- Group C passed against the real mounted Worker and PGlite: 85 pass, 2 credential-gated live receipts skipped locally.
- Full workspace build passed: 175/175 tasks plus 26/26 view-bundle guard.
- Cloud API typecheck and production Wrangler dry-run passed.
- Exact-head GitHub live lane called the configured real provider through the mounted HTTP route and inspected the settled Postgres reservation row.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] `N/A - backend-only MCP billing route; no UI pixels changed.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - backend-only MCP billing route; no UI pixels changed.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no frontend or native interaction exists for this server route.`
<!-- evidence-row:backend-logs -->
- [x] [Exact-head live provider and billing receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16234-exact-head-mcp-live-receipt.log) records the runtime-admitted cap, mounted HTTP status, provider output and usage, costs, and settled database row from head `992a273`.
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend code or browser request path changed.`
<!-- evidence-row:llm-trajectory -->
- [x] [Exact-head live provider and billing receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16234-exact-head-mcp-live-receipt.log) contains the real MCP input, model output, configured-provider cap, and provider token usage. `N/A - scenario-runner`: this is an authenticated cloud MCP billing transport, so the mounted-route receipt exercises the affected reservation/provider/settlement path that a runtime scenario does not.
<!-- evidence-row:domain-artifacts -->
- [x] [Exact-head live provider and billing receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16234-exact-head-mcp-live-receipt.log) includes the negative `credit_transactions` reservation row, settlement timestamp, and settlement marker read back from Postgres after the request.

# Evidence Details

The exact-head receipt is emitted only after asserting HTTP 200, a response `_meta.admittedOutputTokens` value of 4096 from the same runtime variable passed to `streamText`, non-empty provider output, positive output usage at or below that ceiling, positive settled cost, and a negative settled reservation transaction with the expected MCP description. The workflow is credential-gated and fails rather than substituting a mock provider or fabricated usage.

[stan-cloud]
