### PR TITLE
test(workflow): replace embedded fake runtime

### DIFF
--- a/plugins/plugin-workflow/__tests__/integration/dispatch-workflow-step-e2e.test.ts
+++ b/plugins/plugin-workflow/__tests__/integration/dispatch-workflow-step-e2e.test.ts
@@ -42,7 +42,6 @@ import {
 import type { EmbeddedWorkflowService } from '../../src/services/embedded-workflow-service';
 import {
   registerWorkflowDispatchService,
-  WORKFLOW_DISPATCH_SERVICE_TYPE,
   type WorkflowDispatchResult,
 } from '../../src/services/workflow-dispatch';
 import { type EmbeddedHarness, makeEmbeddedHarness } from './embedded-harness';
@@ -228,21 +227,26 @@ describe('dispatch_workflow step e2e (LifeOps registry -> WORKFLOW_DISPATCH -> e
   });
 
   test('(c) missing WORKFLOW_DISPATCH service yields a structured failure and no execution', async () => {
-    const workflowId = await createDispatchableWorkflow(h.workflow, 'Nested orphan');
-    h.services.delete(WORKFLOW_DISPATCH_SERVICE_TYPE);
+    const missing = await makeEmbeddedHarness('dispatch-step-missing-service-agent');
+    try {
+      const registry = createWorkflowStepRegistry();
+      registerDefaultWorkflowStepPack(registry);
+      registerWorkflowStepRegistry(missing.runtime, registry);
+      const workflowId = await createDispatchableWorkflow(missing.workflow, 'Nested orphan');
 
-    const result = (await executeStepViaRegistry(
-      h,
-      { kind: 'dispatch_workflow', workflowId },
-      makeStepArgs()
-    )) as { ok: boolean; error?: string };
+      const result = (await executeStepViaRegistry(
+        missing,
+        { kind: 'dispatch_workflow', workflowId },
+        makeStepArgs()
+      )) as { ok: boolean; error?: string };
 
-    expect(result.ok).toBe(false);
-    expect(result.error).toBe('WORKFLOW_DISPATCH service not registered');
-    const { data: executions } = await h.workflow.listExecutions({
-      workflowId,
-    });
-    expect(executions).toHaveLength(0);
+      expect(result.ok).toBe(false);
+      expect(result.error).toBe('WORKFLOW_DISPATCH service not registered');
+      const { data: executions } = await missing.workflow.listExecutions({ workflowId });
+      expect(executions).toHaveLength(0);
+    } finally {
+      await missing.close();
+    }
   });
 
   test('(d) unknown workflowId is a structured failure from the real dispatch, not a throw', async () => {

--- a/plugins/plugin-workflow/__tests__/integration/embedded-harness.ts
+++ b/plugins/plugin-workflow/__tests__/integration/embedded-harness.ts
@@ -1,22 +1,14 @@
 /**
- * Shared PGlite-backed runtime harness for workflow integration e2e suites.
- *
- * Mirrors the harness pattern established in trigger-dispatch-e2e.test.ts: a
- * runtime whose DB is a real PGlite instance and whose services registry is a
- * real map, with the REAL EmbeddedWorkflowService started against it. The only
- * test double is the runtime's task STORE (an in-memory map — same as
- * workflow-task-worker.test.ts). Callers register whatever additional real
- * services their suite drives (WORKFLOW_DISPATCH, WorkflowService, …) on the
- * exposed `services` map.
+ * Shared PGlite-backed AgentRuntime harness for workflow integration suites.
+ * Core tasks and services use the real runtime; only external systems are absent.
  */
-
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { PGlite } from '@electric-sql/pglite';
-import type { IAgentRuntime, Task, TaskWorker, UUID } from '@elizaos/core';
-import { stringToUuid } from '@elizaos/core';
+import { AgentRuntime, createCharacter, stringToUuid } from '@elizaos/core';
 import { drizzle } from 'drizzle-orm/pglite';
+import { InMemoryDatabaseAdapter } from '../../../../packages/core/src/database/inMemoryAdapter.ts';
 import * as dbSchema from '../../src/db/schema';
 import {
   EMBEDDED_WORKFLOW_SERVICE_TYPE,
@@ -24,84 +16,47 @@ import {
 } from '../../src/services/embedded-workflow-service';
 
 export interface EmbeddedHarness {
-  runtime: IAgentRuntime;
-  agentId: UUID;
-  tasks: Map<UUID, Task>;
-  /** The runtime's real service registry, exposed so suites can register the
-   * additional real services they exercise. */
-  services: Map<string, unknown[]>;
+  runtime: AgentRuntime;
   workflow: EmbeddedWorkflowService;
   close: () => Promise<void>;
 }
 
 export async function makeEmbeddedHarness(agentSeed: string): Promise<EmbeddedHarness> {
-  const agentId = stringToUuid(agentSeed);
   const dir = await mkdtemp(join(tmpdir(), 'workflow-e2e-'));
   const client = new PGlite({ dataDir: join(dir, 'pglite') });
   const db = drizzle(client, { schema: dbSchema });
+  const adapter = new InMemoryDatabaseAdapter();
+  Reflect.set(adapter, 'db', db);
+  const runtime = Object.assign(
+    new AgentRuntime({
+      character: createCharacter({
+        id: stringToUuid(agentSeed),
+        name: `WorkflowIntegrationAgent-${agentSeed}`,
+        settings: { WORKFLOW_SEED_DEFAULTS: 'false' },
+      }),
+      adapter,
+      logLevel: 'fatal',
+      enableAutonomy: false,
+    }),
+    { serverless: true }
+  );
 
-  const tasks = new Map<UUID, Task>();
-  const workers = new Map<string, TaskWorker>();
-  const services = new Map<string, unknown[]>();
-  let nextId = 1;
-
-  const runtime = {
-    agentId,
-    character: { settings: {} },
-    db,
-    serverless: true, // no scheduler loop; suites drive execution explicitly
-    logger: {
-      debug: () => {},
-      info: () => {},
-      warn: () => {},
-      error: () => {},
-    },
-    services,
-    // Suppress the default health-check workflow seed: these harnesses verify
-    // run/dispatch mechanics against explicitly-created workflows, and the
-    // auto-seeded default (which also runs once and arms a schedule on start)
-    // is orthogonal pollution here — it would otherwise leave a stray execution
-    // row and trigger task. The seed path is covered by the embedded service's
-    // own unit suite.
-    getSetting: (key: string) => (key === 'WORKFLOW_SEED_DEFAULTS' ? 'false' : null),
-    getService: (type: string) => {
-      const entries = services.get(type);
-      return entries && entries.length > 0 ? entries[0] : null;
-    },
-    registerTaskWorker: (worker: TaskWorker) => {
-      workers.set(worker.name, worker);
-    },
-    getTaskWorker: (name: string) => workers.get(name),
-    createTask: async (task: Task) => {
-      const id = (task.id ?? stringToUuid(`${agentSeed}-task-${nextId++}`)) as UUID;
-      tasks.set(id, { ...task, id, agentId });
-      return id;
-    },
-    getTask: async (id: UUID) => tasks.get(id) ?? null,
-    getTasks: async (params: { tags?: string[] }) => {
-      const wanted = params?.tags ?? [];
-      return [...tasks.values()].filter((t) => wanted.every((tag) => t.tags?.includes(tag)));
-    },
-    getTasksByName: async (name: string) => [...tasks.values()].filter((t) => t.name === name),
-    updateTask: async (id: UUID, patch: Partial<Task>) => {
-      const existing = tasks.get(id);
-      if (existing) tasks.set(id, { ...existing, ...patch });
-    },
-    deleteTask: async (id: UUID) => {
-      tasks.delete(id);
-    },
-  } as unknown as IAgentRuntime;
-
-  const workflow = await EmbeddedWorkflowService.start(runtime);
-  services.set(EMBEDDED_WORKFLOW_SERVICE_TYPE, [workflow]);
+  await runtime.initialize();
+  await runtime.registerPlugin({
+    name: 'workflow-embedded-integration-harness',
+    description: 'Real embedded workflow service for integration coverage',
+    services: [EmbeddedWorkflowService],
+  });
+  const workflow = (await runtime.getServiceLoadPromise(
+    EMBEDDED_WORKFLOW_SERVICE_TYPE
+  )) as EmbeddedWorkflowService;
 
   return {
     runtime,
-    agentId,
-    tasks,
-    services,
     workflow,
     async close() {
+      await runtime.stop();
+      await runtime.close();
       await client.close();
       await rm(dir, { recursive: true, force: true });
     },

--- a/plugins/plugin-workflow/__tests__/integration/workflow-action-run-e2e.test.ts
+++ b/plugins/plugin-workflow/__tests__/integration/workflow-action-run-e2e.test.ts
@@ -40,10 +40,12 @@ interface ActionHarness extends EmbeddedHarness {
 
 async function makeActionHarness(): Promise<ActionHarness> {
   const h = await makeEmbeddedHarness('workflow-action-run-agent');
-  // The REAL service the action resolves — started keylessly the same way the
-  // plugin's service lifecycle does; it adopts the registered embedded engine.
-  const service = await WorkflowService.start(h.runtime);
-  h.services.set(WORKFLOW_SERVICE_TYPE, [service]);
+  await h.runtime.registerPlugin({
+    name: 'workflow-action-integration-harness',
+    description: 'Real WorkflowService for action integration coverage',
+    services: [WorkflowService],
+  });
+  const service = (await h.runtime.getServiceLoadPromise(WORKFLOW_SERVICE_TYPE)) as WorkflowService;
   return { ...h, service };
 }
 
@@ -103,7 +105,6 @@ describe('WORKFLOW action run op e2e (real WorkflowService + embedded engine, ke
   });
 
   afterEach(async () => {
-    await h.service.stop();
     await h.close();
   });
 
@@ -194,7 +195,11 @@ describe('WORKFLOW action run op e2e (real WorkflowService + embedded engine, ke
   test('(e) validate() reflects real service registration', async () => {
     if (!workflowAction.validate) throw new Error('workflow action missing validate');
     expect(await workflowAction.validate(h.runtime, message, undefined)).toBe(true);
-    h.services.delete(WORKFLOW_SERVICE_TYPE);
-    expect(await workflowAction.validate(h.runtime, message, undefined)).toBe(false);
+    const unregistered = await makeEmbeddedHarness('workflow-action-unregistered-agent');
+    try {
+      expect(await workflowAction.validate(unregistered.runtime, message, undefined)).toBe(false);
+    } finally {
+      await unregistered.close();
+    }
   });
 });


### PR DESCRIPTION
Closes #16236

## What changed

- replaced the object-literal `IAgentRuntime` with real `AgentRuntime` and `InMemoryDatabaseAdapter`
- retains real PGLite/Drizzle workflow persistence by attaching it through the adapter database boundary
- removed fake task storage, fake task-worker registry, and exposed fake service registry
- registers embedded and facade workflow services through real plugin lifecycle and lazy loading
- tests missing services with separate real runtimes where those services were never registered
- lets runtime shutdown own service cleanup instead of stopping services twice

## Why

The previous integration harness bypassed the exact internal runtime, task, database, and service architecture these E2E suites claimed to validate.

## Validation

- focused consuming E2E suites: 10 passed
- plugin typecheck passed
- plugin Biome check passed
- complete plugin-workflow suite: 379 passed, 0 failed, 1,160 assertions
- test-realness audit passed

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - integration harness change with no rendered UI surface`.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - integration harness change with no rendered UI surface`.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - there is no user-facing visual flow`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - no server route changed; runtime/service/task execution is directly exercised by the E2E suites`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code or network request changed`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - deterministic keyless workflows are exercised and no model behavior changed`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - real workflow execution rows, trigger data, and idempotency records are asserted directly in PGLite`.