### PR TITLE
test: remove tautological assertions

### DIFF
--- a/packages/agent/src/capacitor-bridge-shim-parity.test.ts
+++ b/packages/agent/src/capacitor-bridge-shim-parity.test.ts
@@ -15,7 +15,7 @@
  */
 
 import type { AgentRuntime } from "@elizaos/core";
-import { describe, expect, it } from "vitest";
+import { describe, expectTypeOf, it } from "vitest";
 import type {
   AndroidCoreRouteDeps,
   AndroidDispatchRoute,
@@ -34,84 +34,48 @@ type RealAgentRuntime = typeof import("./runtime/index.ts");
 type RealLocalInferenceRuntime =
   typeof import("../../../plugins/plugin-local-inference/src/runtime/index.ts");
 
-/**
- * Compile-time-only assignability probe: instantiating it with a `_From` that
- * does not extend `To` is a type error. The exported aliases below are the
- * actual assertions; they carry no runtime cost.
- */
-type AssertAssignable<To, _From extends To> = never;
-
-// ── @elizaos/agent (root) — Android bridge contract ─────────────────────────
-// `loadAgentModule` in android/bridge.ts casts the dynamic root import to the
-// same member types the agent-root shim declares.
-export type StartElizaParity = AssertAssignable<
-  ShimAgentRoot["startEliza"],
-  RealAgentRoot["startEliza"]
->;
-export type RootDispatchRouteParity = AssertAssignable<
-  ShimAgentRoot["dispatchRoute"],
-  RealAgentRoot["dispatchRoute"]
->;
-export type ConfigFileExistsParity = AssertAssignable<
-  ShimAgentRoot["configFileExists"],
-  RealAgentRoot["configFileExists"]
->;
-export type LoadElizaConfigParity = AssertAssignable<
-  ShimAgentRoot["loadElizaConfig"],
-  RealAgentRoot["loadElizaConfig"]
->;
-export type SaveElizaConfigParity = AssertAssignable<
-  ShimAgentRoot["saveElizaConfig"],
-  RealAgentRoot["saveElizaConfig"]
->;
-export type HasPersistedFirstRunStateParity = AssertAssignable<
-  ShimAgentRoot["hasPersistedFirstRunState"],
-  RealAgentRoot["hasPersistedFirstRunState"]
->;
-
-// The Android dispatch/core-route types are the bridge's own vocabulary for
-// the same members; pin the real exports against them directly too so a drift
-// in either the shim or the bridge contract is caught.
-export type AndroidDispatchParity = AssertAssignable<
-  AndroidDispatchRoute,
-  RealAgentApi["dispatchRoute"]
->;
-export type AndroidCoreRouteDepsParity = AssertAssignable<
-  AndroidCoreRouteDeps,
-  Pick<
-    RealAgentRoot,
-    | "configFileExists"
-    | "loadElizaConfig"
-    | "saveElizaConfig"
-    | "hasPersistedFirstRunState"
-  >
->;
-
-// ── @elizaos/agent/api — shared dispatchRoute contract ───────────────────────
-export type ApiDispatchRouteParity = AssertAssignable<
-  ShimAgentApi["dispatchRoute"],
-  RealAgentApi["dispatchRoute"]
->;
-
-// ── @elizaos/agent/runtime — iOS bridge contract ────────────────────────────
-export type BootElizaRuntimeParity = AssertAssignable<
-  ShimAgentRuntime["bootElizaRuntime"],
-  RealAgentRuntime["bootElizaRuntime"]
->;
-
-// ── @elizaos/plugin-local-inference/runtime — router install contract ───────
-// The android bridge invokes `installRouterHandler(runtime, {})` with the
-// booted AgentRuntime; the real export must keep accepting exactly that call.
-export type InstallRouterHandlerParity = AssertAssignable<
-  (runtime: AgentRuntime, options: Record<string, never>) => void,
-  RealLocalInferenceRuntime["installRouterHandler"]
->;
-
 describe("capacitor-bridge shim parity (#15850)", () => {
-  it("is enforced at compile time — this file failing to typecheck IS the signal", () => {
-    // The type aliases above are the assertions; tsgo/tsc rejects this file
-    // (and the agent typecheck lane fails) the moment a real export drifts
-    // from the bridge's shim contract.
-    expect(true).toBe(true);
+  it("keeps real bridge exports assignable to their shim contracts", () => {
+    expectTypeOf<RealAgentRoot["startEliza"]>().toMatchTypeOf<
+      ShimAgentRoot["startEliza"]
+    >();
+    expectTypeOf<RealAgentRoot["dispatchRoute"]>().toMatchTypeOf<
+      ShimAgentRoot["dispatchRoute"]
+    >();
+    expectTypeOf<RealAgentRoot["configFileExists"]>().toMatchTypeOf<
+      ShimAgentRoot["configFileExists"]
+    >();
+    expectTypeOf<RealAgentRoot["loadElizaConfig"]>().toMatchTypeOf<
+      ShimAgentRoot["loadElizaConfig"]
+    >();
+    expectTypeOf<RealAgentRoot["saveElizaConfig"]>().toMatchTypeOf<
+      ShimAgentRoot["saveElizaConfig"]
+    >();
+    expectTypeOf<RealAgentRoot["hasPersistedFirstRunState"]>().toMatchTypeOf<
+      ShimAgentRoot["hasPersistedFirstRunState"]
+    >();
+    expectTypeOf<
+      RealAgentApi["dispatchRoute"]
+    >().toMatchTypeOf<AndroidDispatchRoute>();
+    expectTypeOf<
+      Pick<
+        RealAgentRoot,
+        | "configFileExists"
+        | "loadElizaConfig"
+        | "saveElizaConfig"
+        | "hasPersistedFirstRunState"
+      >
+    >().toMatchTypeOf<AndroidCoreRouteDeps>();
+    expectTypeOf<RealAgentApi["dispatchRoute"]>().toMatchTypeOf<
+      ShimAgentApi["dispatchRoute"]
+    >();
+    expectTypeOf<RealAgentRuntime["bootElizaRuntime"]>().toMatchTypeOf<
+      ShimAgentRuntime["bootElizaRuntime"]
+    >();
+    expectTypeOf<
+      RealLocalInferenceRuntime["installRouterHandler"]
+    >().toMatchTypeOf<
+      (runtime: AgentRuntime, options: Record<string, never>) => void
+    >();
   });
 });

--- a/packages/core/src/__tests__/runtime-regression-lane.test.ts
+++ b/packages/core/src/__tests__/runtime-regression-lane.test.ts
@@ -4,7 +4,6 @@
  * a PR diff, so this lane keeps those changes attached to the existing behavioral
  * matrix until the runtime is fully decomposed into independently covered modules.
  */
-import { describe, expect, it } from "vitest";
 import "./compose-state-provider-hook.test";
 import "./compose-state-refresh-providers.test";
 import "./compose-state-role-gate.test";
@@ -28,9 +27,3 @@ import "../runtime/__tests__/model-stream-chunk-hooks.test";
 import "../runtime/__tests__/pii-swap-use-model.test";
 import "../runtime/__tests__/secret-swap-use-model.test";
 import "../runtime/__tests__/streaming-use-model.test";
-
-describe("AgentRuntime regression lane", () => {
-	it("loads the runtime behavioral matrix", () => {
-		expect(true).toBe(true);
-	});
-});

--- a/packages/elizaos/src/migrate/migrate.test.ts
+++ b/packages/elizaos/src/migrate/migrate.test.ts
@@ -12,7 +12,7 @@ import * as path from "node:path";
 // DEV-only dependency used solely to drive the migration archive through the
 // REAL importer, proving cross-package `.eliza-agent` format compatibility.
 import { importAgent } from "@elizaos/agent/services/agent-export";
-import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { migrateAgent } from "../commands/migrate-agent.js";
 import { buildElizaAgentArchive } from "./archive-format.js";
 import { assemblePayload } from "./archive-writer.js";
@@ -486,10 +486,7 @@ function buildSqliteFixtureHome(): string | null {
 describe("oc home-format variants (cross-version)", () => {
   const fixDir = (name: string) =>
     path.join(__dirname, "__tests__", "fixtures", name);
-  let sqliteHome: string | null = null;
-  beforeAll(() => {
-    sqliteHome = buildSqliteFixtureHome();
-  });
+  const sqliteHome = buildSqliteFixtureHome();
 
   it("reads legacy lowercase memory.md as curated memory (GAP A)", () => {
     const src = readOcAgentHome(fixDir("oc-home-legacymem"), "quill");
@@ -572,54 +569,52 @@ describe("oc home-format variants (cross-version)", () => {
     ).toBe("Nyx");
   });
 
-  it("detects sqlite memory + warns + never silently empty (GAP D)", () => {
-    if (!sqliteHome) {
-      // node:sqlite unavailable in this runtime: can't build the fixture, but
-      // the production DETECT+WARN-without-read path is still covered by the
-      // reader's own guard. Soft-skip the read assertions.
-      expect(true).toBe(true);
-      return;
-    }
-    const src = readOcAgentHome(sqliteHome, "scribe");
-    // Detection ALWAYS happens regardless of node:sqlite availability.
-    expect(src.sqliteStores.length).toBeGreaterThanOrEqual(1);
-    expect(src.sqliteStores.some((s) => s.name === "scribe")).toBe(true);
-    // A warning is ALWAYS present for a sqlite home (read-ok OR not-ported).
-    expect(src.warnings.length).toBeGreaterThanOrEqual(1);
-    expect(src.warnings.join(" ")).toMatch(/sqlite/i);
+  it.skipIf(!sqliteHome)(
+    "detects sqlite memory + warns + never silently empty (GAP D)",
+    () => {
+      if (!sqliteHome) throw new Error("sqlite fixture unavailable");
+      const src = readOcAgentHome(sqliteHome, "scribe");
+      // Detection ALWAYS happens regardless of node:sqlite availability.
+      expect(src.sqliteStores.length).toBeGreaterThanOrEqual(1);
+      expect(src.sqliteStores.some((s) => s.name === "scribe")).toBe(true);
+      // A warning is ALWAYS present for a sqlite home (read-ok OR not-ported).
+      expect(src.warnings.length).toBeGreaterThanOrEqual(1);
+      expect(src.warnings.join(" ")).toMatch(/sqlite/i);
 
-    if (src.sqliteUningested) {
-      // node:sqlite unavailable (older Node): DETECT + WARN, no silent empty.
-      expect(src.warnings.join(" ")).toMatch(/NOT ported|could NOT read/i);
-    } else {
-      // node:sqlite available: prose reconstructed from chunks.text.
-      expect(src.dailyLogs.length).toBe(1); // 2 chunks merged, dup dropped
-      const day = src.dailyLogs.find((d) => d.date === "2026-06-28");
-      expect(day).toBeDefined();
-      expect(day?.text).toContain("daily log chunk one");
-      expect(day?.text).toContain("daily log chunk two");
-      // dedup: chunk-two appears once despite the duplicate row.
-      expect(
-        (day?.text.match(/continuation of the same recent day/g) ?? []).length,
-      ).toBe(1);
-      // named memory recovered (scribe-thoughts.md).
-      expect(src.namedMemory.some((m) => m.key === "scribe-thoughts")).toBe(
-        true,
-      );
-      // awareness recovered from sqlite is promoted to CURRENT, not dropped.
-      expect(src.awareness).toContain("open thread");
-      expect(src.namedMemory.some((m) => m.key === "scribe-awareness")).toBe(
-        false,
-      );
-      const { counts } = tierMemories(src, {
-        memoryDays: 14,
-        agentId: "00000000-0000-0000-0000-00000000a000",
-        entityId: "00000000-0000-0000-0000-00000000e000",
-        roomId: "00000000-0000-0000-0000-00000000r000",
-      });
-      expect(counts.CURRENT).toBeGreaterThanOrEqual(1); // awareness seeded
-    }
-  });
+      if (src.sqliteUningested) {
+        // node:sqlite unavailable (older Node): DETECT + WARN, no silent empty.
+        expect(src.warnings.join(" ")).toMatch(/NOT ported|could NOT read/i);
+      } else {
+        // node:sqlite available: prose reconstructed from chunks.text.
+        expect(src.dailyLogs.length).toBe(1); // 2 chunks merged, dup dropped
+        const day = src.dailyLogs.find((d) => d.date === "2026-06-28");
+        expect(day).toBeDefined();
+        expect(day?.text).toContain("daily log chunk one");
+        expect(day?.text).toContain("daily log chunk two");
+        // dedup: chunk-two appears once despite the duplicate row.
+        expect(
+          (day?.text.match(/continuation of the same recent day/g) ?? [])
+            .length,
+        ).toBe(1);
+        // named memory recovered (scribe-thoughts.md).
+        expect(src.namedMemory.some((m) => m.key === "scribe-thoughts")).toBe(
+          true,
+        );
+        // awareness recovered from sqlite is promoted to CURRENT, not dropped.
+        expect(src.awareness).toContain("open thread");
+        expect(src.namedMemory.some((m) => m.key === "scribe-awareness")).toBe(
+          false,
+        );
+        const { counts } = tierMemories(src, {
+          memoryDays: 14,
+          agentId: "00000000-0000-0000-0000-00000000a000",
+          entityId: "00000000-0000-0000-0000-00000000e000",
+          roomId: "00000000-0000-0000-0000-00000000r000",
+        });
+        expect(counts.CURRENT).toBeGreaterThanOrEqual(1); // awareness seeded
+      }
+    },
+  );
 
   it("warns (does NOT silently succeed) on a persona-less device/builder home", () => {
     // A home with neither SOUL/IDENTITY nor any memory -> empty-home warning.

--- a/packages/elizaos/src/migrate/migrate.test.ts
+++ b/packages/elizaos/src/migrate/migrate.test.ts
@@ -337,6 +337,7 @@ describe("firewall keeps the personal memory corpus out of a portable archive", 
       from: FIXTURE,
       agentId: "tess",
       firewall,
+      memoryDays: 10_000,
     });
     const { payload } = assemblePayload({
       agentId: plan.ids.agentId,

--- a/plugins/plugin-computeruse/src/__tests__/cua-parity-input.real.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/cua-parity-input.real.test.ts
@@ -95,13 +95,7 @@ describe("cua parity input (real driver, Windows)", () => {
     "key_down/key_up press-hold round-trips (always releases)",
     async () => {
       await driverKeyDown("shift");
-      try {
-        // No throw is the contract; the held modifier has no observable side
-        // effect on its own here.
-        expect(true).toBe(true);
-      } finally {
-        await driverKeyUp("shift");
-      }
+      await driverKeyUp("shift");
     },
     20000,
   );

--- a/scripts/security/coverage-changed-files.self-test.mjs
+++ b/scripts/security/coverage-changed-files.self-test.mjs
@@ -213,6 +213,11 @@ try {
   );
   write(
     dir,
+    "packages/demo/src/driver.real.test.ts",
+    "import { test } from 'vitest';\ntest('real driver', () => {});\n",
+  );
+  write(
+    dir,
     "packages/test/cloud-e2e/tests/live-deploy.spec.ts",
     "import { test } from '../src/helpers/test-fixtures';\ntest('live', () => {});\n",
   );
@@ -273,6 +278,18 @@ try {
       );
     },
   );
+
+  assertCase("real-driver suites stay in their dedicated lane", () => {
+    const realSuite = "packages/demo/src/driver.real.test.ts";
+    assert.ok(
+      !out.bun_tests.includes(realSuite),
+      `real suite leaked into bun lane: ${out.bun_tests.join(",")}`,
+    );
+    assert.ok(
+      !out.vitest_tests.includes(realSuite),
+      `real suite leaked into vitest lane: ${out.vitest_tests.join(",")}`,
+    );
+  });
 
   assertCase("cloud Playwright specs stay in their dedicated lane", () => {
     const liveSpec = "packages/test/cloud-e2e/tests/live-deploy.spec.ts";

--- a/scripts/security/coverage-changed-files.sh
+++ b/scripts/security/coverage-changed-files.sh
@@ -35,7 +35,7 @@ fi
 # and pull in heavy harnesses that the changed-file coverage gate must not.
 is_excluded_test() {
   case "$1" in
-    *.e2e.test.*|*.live.test.*|packages/app/test/android/*.android.spec.*) return 0 ;;
+    *.e2e.test.*|*.live.test.*|*.real.test.*|*.real.e2e.test.*|packages/app/test/android/*.android.spec.*) return 0 ;;
     packages/test/cloud-e2e/tests/*.spec.*) return 0 ;;
     */test/e2e/*|test/e2e/*|*/e2e/*.test.*|e2e/*.test.*) return 0 ;;
   esac


### PR DESCRIPTION
Closes #16239

## What changed

- replaced the Capacitor bridge dummy runtime assertion with directional `expectTypeOf` contract checks
- removed the dummy assertion from the runtime regression aggregate while retaining its imported 201-test behavioral matrix
- makes unavailable `node:sqlite` capability an explicit conditional skip instead of a passing assertion
- validates real key down/up through the actual driver calls without an unconditional expectation
- keeps `*.real.test.*` hardware suites out of deterministic changed-file coverage, with a throwaway-Git regression test for the classifier

## Validation

- exact head: `f1de1fcfb4cafddce93cc09143d30be202ceabb2`
- focused runtime/agent/migration tests: 225 passed, 0 failed
- coverage classifier self-test: 15 cases passed; exact branch classification schedules the two deterministic Vitest files, the core Bun test, and the registered Node self-test while excluding the real-driver suite
- `bun run audit:test-realness`: no diff-scoped regressions and `tautologicalAssertion=0`
- Biome and `git diff --check`

The full agent command also began running its unrequested 329-file batch matrix and encountered an unrelated missing built registry artifact in batch 3. The intended focused agent file was then invoked directly through the package's Vitest wrapper and passed 1/1.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - test-only cleanup with no rendered UI surface`.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - test-only cleanup with no rendered UI surface`.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no user-facing visual flow changed`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - no production server path changed; focused test and audit outputs are the applicable proof`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend or network path changed`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, prompt, provider, or model behavior changed`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - no persisted data contract or production output changed`.
