### PR TITLE
fix(commands): render /model show as operator slots, not raw env keys

### DIFF
--- a/plugins/plugin-commands/__tests__/model-config-command.test.ts
+++ b/plugins/plugin-commands/__tests__/model-config-command.test.ts
@@ -336,7 +336,7 @@ describe("/model show → GET /api/models/config", () => {
 		vi.unstubAllGlobals();
 	});
 
-	it("formats the effective config with values, sources, and unset keys", async () => {
+	it("formats the effective config as operator-readable slots, not raw env keys", async () => {
 		const fetchMock = vi.fn(async () =>
 			jsonResponse({
 				targets: {
@@ -369,13 +369,14 @@ describe("/model show → GET /api/models/config", () => {
 		const [url, init] = fetchMock.mock.calls[0];
 		expect(String(url)).toContain("/api/models/config");
 		expect((init as RequestInit).method).toBe("GET");
-		expect(r.reply).toContain("**small**");
-		expect(r.reply).toContain("OPENAI_SMALL_MODEL = gpt-oss-120b (config.env)");
-		expect(r.reply).toContain("ANTHROPIC_SMALL_MODEL unset");
-		expect(r.reply).toContain("OPENAI_LARGE_MODEL = zai-glm-4.7 (process.env)");
-		expect(r.reply).toContain(
-			"ELIZA_CODEX_MODEL_POWERFUL = gpt-5.6-terra (default)",
-		);
+		// Human slots with friendly source labels — the raw persistence keys
+		// (ELIZA_*_MODEL_POWERFUL, …) must never reach the operator.
+		expect(r.reply).toContain("small: gpt-oss-120b (app config)");
+		expect(r.reply).toContain("large: zai-glm-4.7 (environment)");
+		expect(r.reply).toContain("codex: gpt-5.6-terra (default)");
+		expect(r.reply).toContain("eliza: uses the runtime's own chat models");
+		expect(r.reply).not.toContain("MODEL_POWERFUL");
+		expect(r.reply).not.toContain("unset");
 	});
 
 	it("requires authorization and never hits the route when unauthorized", async () => {

--- a/plugins/plugin-commands/src/actions/model-config.ts
+++ b/plugins/plugin-commands/src/actions/model-config.ts
@@ -263,13 +263,108 @@ interface ModelConfigShowResponse {
 	error?: string;
 }
 
-const SHOW_TARGET_ORDER = ["small", "large", "coding"] as const;
-
 /**
  * GET the effective model config and format it as one reply: every key the
  * config route owns, with the source that won (config.env / config.env.vars /
  * process.env / default) or `unset`.
  */
+/** Where a value came from, in operator words instead of seam names. */
+function sourceLabel(source: string): string {
+	if (source === "config.env" || source === "config.env.vars") {
+		return "app config";
+	}
+	if (source === "process.env") return "environment";
+	return source;
+}
+
+type ShowTargets = NonNullable<ModelConfigShowResponse["targets"]>;
+type Effective = { value: string; source: string } | null | undefined;
+
+function chatLine(
+	label: string,
+	keys: Record<string, Effective> | undefined,
+	modelKeys: string[],
+	effortKeys: string[],
+): string | null {
+	if (!keys) return null;
+	const model = modelKeys
+		.map((k) => keys[k])
+		.find((v): v is { value: string; source: string } => Boolean(v));
+	if (!model) return `${label}: not set`;
+	const effort = effortKeys
+		.map((k) => keys[k])
+		.find((v): v is { value: string; source: string } => Boolean(v));
+	const effortPart = effort ? ` — effort ${effort.value}` : "";
+	return `${label}: ${model.value}${effortPart} (${sourceLabel(model.source)})`;
+}
+
+/**
+ * Render the raw per-key config the route reports as an operator-readable
+ * summary. The env keys (ELIZA_CODEX_MODEL_POWERFUL, …) are persistence
+ * details — dumping them read as "wtf is model powerful"; the operator wants
+ * model + effort + where it came from, per slot.
+ */
+export function renderModelConfigShow(targets: ShowTargets): string {
+	const lines = ["Model configuration:"];
+	const small = chatLine(
+		"small",
+		targets.small,
+		["OPENAI_SMALL_MODEL", "ANTHROPIC_SMALL_MODEL"],
+		["OPENAI_REASONING_EFFORT", "ANTHROPIC_EFFORT_SMALL"],
+	);
+	const large = chatLine(
+		"large",
+		targets.large,
+		["OPENAI_LARGE_MODEL", "ANTHROPIC_LARGE_MODEL"],
+		["OPENAI_REASONING_EFFORT", "ANTHROPIC_EFFORT_LARGE"],
+	);
+	if (small) lines.push(small);
+	if (large) lines.push(large);
+
+	const coding = targets.coding;
+	if (coding) {
+		const def = coding.ELIZA_DEFAULT_AGENT_TYPE;
+		lines.push(
+			def
+				? `coding — default backend: ${displayCodingBackend(def.value)} (${sourceLabel(def.source)})`
+				: "coding — default backend: not set (the orchestrator picks per task)",
+		);
+		const backends: Array<{
+			label: string;
+			modelKey: string;
+			effortKey?: string;
+		}> = [
+			{
+				label: "codex",
+				modelKey: "ELIZA_CODEX_MODEL_POWERFUL",
+				effortKey: "ELIZA_CODEX_EFFORT",
+			},
+			{
+				label: "claude",
+				modelKey: "ELIZA_CLAUDE_MODEL_POWERFUL",
+				effortKey: "ELIZA_CLAUDE_EFFORT",
+			},
+			{ label: "opencode", modelKey: "ELIZA_OPENCODE_MODEL_POWERFUL" },
+			{ label: "eliza", modelKey: "ELIZA_ELIZAOS_MODEL_POWERFUL" },
+		];
+		for (const b of backends) {
+			const model = coding[b.modelKey];
+			if (!model) {
+				if (b.label === "eliza") {
+					lines.push("  eliza: uses the runtime's own chat models");
+				}
+				continue;
+			}
+			const effort = b.effortKey ? coding[b.effortKey] : undefined;
+			const effortPart = effort ? ` @ ${effort.value}` : "";
+			lines.push(
+				`  ${b.label}: ${model.value}${effortPart} (${sourceLabel(model.source)})`,
+			);
+		}
+	}
+	return lines.join("\n");
+}
+
 export async function runModelConfigShowViaRoute(): Promise<CommandResult> {
 	const port = resolveServerOnlyPort(process.env);
 	let response: Response;
@@ -297,18 +392,5 @@ export async function runModelConfigShowViaRoute(): Promise<CommandResult> {
 		);
 	}
 
-	const lines = ["Model configuration:"];
-	for (const target of SHOW_TARGET_ORDER) {
-		const keys = parsed.targets[target];
-		if (!keys) continue;
-		lines.push(`**${target}**`);
-		for (const [key, effective] of Object.entries(keys)) {
-			lines.push(
-				effective
-					? `  ${key} = ${effective.value} (${effective.source})`
-					: `  ${key} unset`,
-			);
-		}
-	}
-	return reply(lines.join("\n"));
+	return reply(renderModelConfigShow(parsed.targets));
 }


### PR DESCRIPTION
Owner-reported slop (verbatim: *"wtf is model powerful???"*): `/model show` dumped the persistence layer at the user — `ELIZA_CODEX_MODEL_POWERFUL = gpt-5.6-terra (config.env)`, `ANTHROPIC_SMALL_MODEL unset`, and so on. The env keys are seam details ("powerful" is the orchestrator's coding-model tier name); the operator wants model + effort + where it came from.

Before → after, live on the running agent:
```
**small**                                        Model configuration:
  OPENAI_SMALL_MODEL = gemma-4-31b (config.env)  small: gemma-4-31b — effort low (app config)
  ANTHROPIC_SMALL_MODEL unset                    large: zai-glm-4.7 — effort low (app config)
  OPENAI_REASONING_EFFORT = low (config.env)     coding — default backend: eliza (app config)
  …                                                codex: gpt-5.6-terra @ xhigh (app config)
**coding**                                         claude: claude-opus-4-8 @ high (app config)
  ELIZA_DEFAULT_AGENT_TYPE = elizaos (config.env)  opencode: zai-glm-4.7 (app config)
  ELIZA_CODEX_MODEL_POWERFUL = gpt-5.6-terra …     eliza: uses the runtime's own chat models
```

Friendly source labels (config.env → "app config", process.env → "environment"), unset families skipped, backend display names (a persisted `elizaos` renders as `eliza`), and the in-house backend explained in words. The keys themselves are unchanged — they just never reach the operator.

Tests: plugin-commands 134✓ (show-format test rewritten to pin the human view and assert `MODEL_POWERFUL`/`unset` never appear); typecheck ✓; biome ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)