### PR TITLE
fix(commands): drop /models, name the live endpoint in /model show

### DIFF
--- a/plugins/plugin-commands/__tests__/command-actions.test.ts
+++ b/plugins/plugin-commands/__tests__/command-actions.test.ts
@@ -338,7 +338,6 @@ describe("command shortcuts ↔ actions linkage (#8790 × #8791)", () => {
 			"cmd:help:/help->HELP_COMMAND",
 			"cmd:model:/m->MODEL_COMMAND",
 			"cmd:model:/model->MODEL_COMMAND",
-			"cmd:models:/models->MODELS_COMMAND",
 			"cmd:new:/new->NEW_COMMAND",
 			"cmd:queue:/q->QUEUE_COMMAND",
 			"cmd:queue:/queue->QUEUE_COMMAND",

--- a/plugins/plugin-commands/__tests__/model-config-command.test.ts
+++ b/plugins/plugin-commands/__tests__/model-config-command.test.ts
@@ -371,8 +371,8 @@ describe("/model show → GET /api/models/config", () => {
 		expect((init as RequestInit).method).toBe("GET");
 		// Human slots with friendly source labels — the raw persistence keys
 		// (ELIZA_*_MODEL_POWERFUL, …) must never reach the operator.
-		expect(r.reply).toContain("small: gpt-oss-120b (app config)");
-		expect(r.reply).toContain("large: zai-glm-4.7 (environment)");
+		expect(r.reply).toContain("small: gpt-oss-120b (app config, via api.openai.com)");
+		expect(r.reply).toContain("large: zai-glm-4.7 (environment, via api.openai.com)");
 		expect(r.reply).toContain("codex: gpt-5.6-terra (default)");
 		expect(r.reply).toContain("eliza: uses the runtime's own chat models");
 		expect(r.reply).not.toContain("MODEL_POWERFUL");

--- a/plugins/plugin-commands/src/actions/handlers.ts
+++ b/plugins/plugin-commands/src/actions/handlers.ts
@@ -62,7 +62,6 @@ export const DETERMINISTIC_COMMAND_KEYS: readonly string[] = [
 	"reset",
 	"new",
 	"compact",
-	"models",
 	"usage",
 	"think",
 	"verbose",
@@ -110,6 +109,18 @@ const OPTION_COMMANDS = {
 
 function reply(text: string): CommandResult {
 	return { handled: true, reply: text, shouldContinue: false };
+}
+
+/** Bare hostname of a base URL setting, or undefined when unset/unparsable. */
+function hostOf(value: unknown): string | undefined {
+	if (typeof value !== "string" || !value.trim()) return undefined;
+	try {
+		return new URL(value.trim()).hostname;
+	} catch {
+		// error-policy:J3 an unparsable operator-supplied URL degrades to "no
+		// endpoint shown" rather than a broken show line.
+		return undefined;
+	}
 }
 
 function authError(): CommandResult {
@@ -360,9 +371,6 @@ export async function runCommand(
 			return reply(lines.join("\n"));
 		}
 
-		case "models":
-			return reply(`Current model: ${resolveModelLabel(runtime)}`);
-
 		case "usage": {
 			const usage = await runtime.getCache<{
 				promptTokens?: number;
@@ -388,7 +396,16 @@ export async function runCommand(
 			if (configCommand) {
 				if (configCommand.kind === "show") {
 					if (!context.isAuthorized) return authError();
-					return runModelConfigShowViaRoute();
+					// Names what ACTUALLY serves each family, not just the config:
+					// the OPENAI_* family can point anywhere OpenAI-compatible
+					// (Cerebras, Eliza Cloud, ...) via OPENAI_BASE_URL.
+					return runModelConfigShowViaRoute({
+						openai:
+							hostOf(runtime.getSetting("OPENAI_BASE_URL")) ?? "api.openai.com",
+						anthropic:
+							hostOf(runtime.getSetting("ANTHROPIC_BASE_URL")) ??
+							"api.anthropic.com",
+					});
 				}
 				if (!context.isElevated) {
 					return reply("This command requires elevated permissions.");

--- a/plugins/plugin-commands/src/actions/model-config.ts
+++ b/plugins/plugin-commands/src/actions/model-config.ts
@@ -280,22 +280,40 @@ function sourceLabel(source: string): string {
 type ShowTargets = NonNullable<ModelConfigShowResponse["targets"]>;
 type Effective = { value: string; source: string } | null | undefined;
 
+/** Live serving endpoints, so the show names what ACTUALLY answers. */
+export interface ActiveChatEndpoints {
+	/** Host serving the OPENAI_* family (e.g. api.cerebras.ai). */
+	openai?: string;
+	/** Host serving the ANTHROPIC_* family. */
+	anthropic?: string;
+}
+
 function chatLine(
 	label: string,
 	keys: Record<string, Effective> | undefined,
 	modelKeys: string[],
 	effortKeys: string[],
+	endpoints?: ActiveChatEndpoints,
 ): string | null {
 	if (!keys) return null;
-	const model = modelKeys
-		.map((k) => keys[k])
-		.find((v): v is { value: string; source: string } => Boolean(v));
+	let model: { value: string; source: string } | undefined;
+	let family: "openai" | "anthropic" | undefined;
+	for (const k of modelKeys) {
+		const v = keys[k];
+		if (v) {
+			model = v;
+			family = k.startsWith("ANTHROPIC") ? "anthropic" : "openai";
+			break;
+		}
+	}
 	if (!model) return `${label}: not set`;
 	const effort = effortKeys
 		.map((k) => keys[k])
 		.find((v): v is { value: string; source: string } => Boolean(v));
 	const effortPart = effort ? ` — effort ${effort.value}` : "";
-	return `${label}: ${model.value}${effortPart} (${sourceLabel(model.source)})`;
+	const host = family ? endpoints?.[family] : undefined;
+	const viaPart = host ? `, via ${host}` : "";
+	return `${label}: ${model.value}${effortPart} (${sourceLabel(model.source)}${viaPart})`;
 }
 
 /**
@@ -304,19 +322,24 @@ function chatLine(
  * details — dumping them read as "wtf is model powerful"; the operator wants
  * model + effort + where it came from, per slot.
  */
-export function renderModelConfigShow(targets: ShowTargets): string {
+export function renderModelConfigShow(
+	targets: ShowTargets,
+	endpoints?: ActiveChatEndpoints,
+): string {
 	const lines = ["Model configuration:"];
 	const small = chatLine(
 		"small",
 		targets.small,
 		["OPENAI_SMALL_MODEL", "ANTHROPIC_SMALL_MODEL"],
 		["OPENAI_REASONING_EFFORT", "ANTHROPIC_EFFORT_SMALL"],
+		endpoints,
 	);
 	const large = chatLine(
 		"large",
 		targets.large,
 		["OPENAI_LARGE_MODEL", "ANTHROPIC_LARGE_MODEL"],
 		["OPENAI_REASONING_EFFORT", "ANTHROPIC_EFFORT_LARGE"],
+		endpoints,
 	);
 	if (small) lines.push(small);
 	if (large) lines.push(large);
@@ -365,7 +388,9 @@ export function renderModelConfigShow(targets: ShowTargets): string {
 	return lines.join("\n");
 }
 
-export async function runModelConfigShowViaRoute(): Promise<CommandResult> {
+export async function runModelConfigShowViaRoute(
+	endpoints?: ActiveChatEndpoints,
+): Promise<CommandResult> {
 	const port = resolveServerOnlyPort(process.env);
 	let response: Response;
 	try {
@@ -392,5 +417,5 @@ export async function runModelConfigShowViaRoute(): Promise<CommandResult> {
 		);
 	}
 
-	return reply(renderModelConfigShow(parsed.targets));
+	return reply(renderModelConfigShow(parsed.targets, endpoints));
 }

--- a/plugins/plugin-commands/src/registry.ts
+++ b/plugins/plugin-commands/src/registry.ts
@@ -200,16 +200,6 @@ export const DEFAULT_COMMANDS: ReadonlyArray<CommandDefinition> = [
 		requiresAuth: true,
 	},
 	{
-		key: "models",
-		nativeName: "models",
-		description: "List available models",
-		textAliases: ["/models"],
-		scope: "both",
-		category: "options",
-		acceptsArgs: false,
-		requiresAuth: true,
-	},
-	{
 		key: "usage",
 		nativeName: "usage",
 		description: "Show token usage",


### PR DESCRIPTION
Two owner-directed cleanups on the command surface:

**Drop `/models`.** It had shrunk to a one-line duplicate of `/model show` ("Current model: X"). Removed from the registry, the deterministic keys, and the coverage matrix — pickers everywhere drop it on the next registration push (live-verified: Discord now serves 29 commands, `/models` gone).

**Name the live endpoint in `/model show`.** The `OPENAI_*` family can point anywhere OpenAI-compatible (Cerebras, Eliza Cloud, …) via `OPENAI_BASE_URL`, so the model id alone doesn't tell the operator who's actually answering. The chat lines now carry it, live output:

```
Model configuration:
small: gemma-4-31b — effort low (app config, via api.cerebras.ai)
large: zai-glm-4.7 — effort low (app config, via api.cerebras.ai)
coding — default backend: eliza (app config)
  codex: gpt-5.6-terra @ xhigh (app config)
  claude: claude-opus-4-8 @ high (app config)
  ...
```

Hosts resolve from `OPENAI_BASE_URL` / `ANTHROPIC_BASE_URL` at show time (unparsable URL degrades to no suffix rather than a broken line).

Tests: plugin-commands 147✓ (show assertions pin the `via` suffix; coverage matrix updated), discord catalog sweep 57✓ (auto-adapted to the removal), typecheck ✓, biome ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)