### PR TITLE
test(workflow): run routes on real services

### DIFF
--- a/plugins/plugin-workflow/__tests__/helpers/routeHarness.ts
+++ b/plugins/plugin-workflow/__tests__/helpers/routeHarness.ts
@@ -1,0 +1,39 @@
+/** Shared in-memory HTTP transport harness for invoking workflow Route handlers. */
+import type { RouteRequest, RouteResponse } from '@elizaos/core';
+
+export function createRouteRequest(overrides?: Partial<RouteRequest>): RouteRequest {
+  return {
+    body: undefined,
+    params: {},
+    query: {},
+    headers: {},
+    method: 'GET',
+    ...overrides,
+  };
+}
+
+export function createRouteResponse(): {
+  response: RouteResponse;
+  result: () => { status: number; body: unknown };
+} {
+  let status = 200;
+  let body: unknown;
+  const response: RouteResponse = {
+    status(code: number) {
+      status = code;
+      return response;
+    },
+    json(data: unknown) {
+      body = data;
+      return response;
+    },
+    send(data: unknown) {
+      body = data;
+      return response;
+    },
+    end() {
+      return response;
+    },
+  };
+  return { response, result: () => ({ status, body }) };
+}

--- a/plugins/plugin-workflow/__tests__/unit/routes/executions.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/routes/executions.test.ts
@@ -1,123 +1,141 @@
-/** Unit tests for the execution query route handlers against a mocked WorkflowService (deterministic). */
-import { describe, expect, mock, test } from 'bun:test';
-import type { RouteRequest, RouteResponse } from '@elizaos/core';
+/** Execution query routes over real workflow services and persisted execution rows. */
+import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from 'bun:test';
 import { executionRoutes } from '../../../src/routes/executions';
-import { createExecution } from '../../fixtures/workflows';
-import { createMockRuntime } from '../../helpers/mockRuntime';
-import { createMockService } from '../../helpers/mockService';
+import { WORKFLOW_SERVICE_TYPE, WorkflowService } from '../../../src/services/workflow-service';
+import { createRouteRequest, createRouteResponse } from '../../helpers/routeHarness';
+import { type EmbeddedHarness, makeEmbeddedHarness } from '../../integration/embedded-harness';
 
-function createRouteRequest(overrides?: Partial<RouteRequest>): RouteRequest {
-  return {
-    body: undefined,
-    params: {},
-    query: {},
-    headers: {},
-    method: 'GET',
-    ...overrides,
-  };
-}
-
-function createRouteResponse(): {
-  res: RouteResponse;
-  getResult: () => { status: number; body: unknown };
-} {
-  let status = 200;
-  let body: unknown;
-  const res: RouteResponse = {
-    status(code: number) {
-      status = code;
-      return res;
-    },
-    json(data: unknown) {
-      body = data;
-      return res;
-    },
-    send(data: unknown) {
-      body = data;
-      return res;
-    },
-    end() {
-      return res;
-    },
-  };
-  return { res, getResult: () => ({ status, body }) };
-}
-
-// Routes: [0]=GET /executions, [1]=GET /executions/:id
 const listHandler = executionRoutes[0].handler;
 const getHandler = executionRoutes[1].handler;
 if (!listHandler || !getHandler) throw new Error('expected execution route handlers');
 
-function runtimeWithService(serviceOverrides?: Record<string, unknown>) {
-  const service = createMockService(serviceOverrides);
-  return {
-    runtime: createMockRuntime({ services: { workflow: service } }),
-    service,
-  };
+setDefaultTimeout(60_000);
+
+let harness: EmbeddedHarness;
+let firstWorkflowId: string;
+let firstExecutionId: string;
+
+async function createAndExecute(
+  name: string
+): Promise<{ workflowId: string; executionId: string }> {
+  const workflow = await harness.workflow.createWorkflow({
+    name,
+    nodes: [
+      {
+        id: 'trigger',
+        name: 'Manual Trigger',
+        type: 'workflows-nodes-base.manualTrigger',
+        typeVersion: 1,
+        position: [0, 0],
+        parameters: {},
+      },
+      {
+        id: 'set',
+        name: 'Set',
+        type: 'workflows-nodes-base.set',
+        typeVersion: 3.4,
+        position: [200, 0],
+        parameters: { assignments: { assignments: [] } },
+      },
+    ],
+    connections: {
+      'Manual Trigger': { main: [[{ node: 'Set', type: 'main', index: 0 }]] },
+    },
+  });
+  const execution = await harness.workflow.executeWorkflow(workflow.id, {
+    mode: 'manual',
+    triggerData: { suite: 'execution-routes' },
+  });
+  return { workflowId: workflow.id, executionId: execution.id };
 }
 
+beforeAll(async () => {
+  harness = await makeEmbeddedHarness('execution-route-runtime');
+  await harness.runtime.registerPlugin({
+    name: 'execution-route-workflow-facade',
+    description: 'Real workflow facade for execution route coverage',
+    services: [WorkflowService],
+  });
+  const loadedService = await harness.runtime.getServiceLoadPromise(WORKFLOW_SERVICE_TYPE);
+  if (!(loadedService instanceof WorkflowService)) {
+    throw new Error('expected real WorkflowService');
+  }
+  const first = await createAndExecute('First execution route workflow');
+  firstWorkflowId = first.workflowId;
+  firstExecutionId = first.executionId;
+  await createAndExecute('Second execution route workflow');
+});
+
+afterAll(async () => {
+  await harness.close();
+});
+
 describe('GET /executions', () => {
-  test('returns list of executions', async () => {
-    const { runtime } = runtimeWithService();
-    const req = createRouteRequest();
-    const { res, getResult } = createRouteResponse();
+  test('returns persisted executions', async () => {
+    const { response, result } = createRouteResponse();
+    await listHandler(createRouteRequest(), response, harness.runtime);
 
-    await listHandler(req, res, runtime);
-
-    const { body } = getResult();
-    const data = body as { success: boolean; data: Array<{ id: string }> };
-    expect(data.success).toBe(true);
-    expect(data.data.length).toBe(2);
-    expect(data.data[0].id).toBe('exec-001');
+    const body = result().body as {
+      success: boolean;
+      data: Array<{ id: string; status: string }>;
+    };
+    expect(body.success).toBe(true);
+    expect(body.data).toHaveLength(2);
+    expect(body.data.map((execution) => execution.id)).toContain(firstExecutionId);
+    expect(body.data.every((execution) => execution.status === 'success')).toBe(true);
   });
 
-  test('passes filter params to service', async () => {
-    const listMock = mock(() =>
-      Promise.resolve({ data: [createExecution()], nextCursor: 'cur-1' })
+  test('applies workflow and limit filters in the real query path', async () => {
+    const { response, result } = createRouteResponse();
+    await listHandler(
+      createRouteRequest({
+        query: { workflowId: firstWorkflowId, status: 'success', limit: '1' },
+      }),
+      response,
+      harness.runtime
     );
-    const { runtime } = runtimeWithService({ listExecutions: listMock });
-    const req = createRouteRequest({
-      query: { workflowId: 'wf-001', status: 'error', limit: '5' },
-    });
-    const { res, getResult } = createRouteResponse();
 
-    await listHandler(req, res, runtime);
-
-    const callArgs = listMock.mock.calls[0][0] as {
-      workflowId?: string;
-      status?: string;
-      limit?: number;
+    const body = result().body as {
+      success: boolean;
+      data: Array<{ id: string; workflowId: string }>;
     };
-    expect(callArgs.workflowId).toBe('wf-001');
-    expect(callArgs.status).toBe('error');
-    expect(callArgs.limit).toBe(5);
-
-    const { body } = getResult();
-    expect((body as { nextCursor: string }).nextCursor).toBe('cur-1');
+    expect(body.success).toBe(true);
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0]).toMatchObject({
+      id: firstExecutionId,
+      workflowId: firstWorkflowId,
+    });
   });
 });
 
 describe('GET /executions/:id', () => {
-  test('returns execution detail', async () => {
-    const { runtime } = runtimeWithService();
-    const req = createRouteRequest({ params: { id: 'exec-001' } });
-    const { res, getResult } = createRouteResponse();
+  test('returns persisted execution detail', async () => {
+    const { response, result } = createRouteResponse();
+    await getHandler(
+      createRouteRequest({ params: { id: firstExecutionId } }),
+      response,
+      harness.runtime
+    );
 
-    await getHandler(req, res, runtime);
-
-    const { body } = getResult();
-    const data = body as { success: boolean; data: { id: string } };
-    expect(data.success).toBe(true);
-    expect(data.data.id).toBe('exec-001');
+    const body = result().body as {
+      success: boolean;
+      data: { id: string; workflowId: string; status: string };
+    };
+    expect(body.success).toBe(true);
+    expect(body.data).toMatchObject({
+      id: firstExecutionId,
+      workflowId: firstWorkflowId,
+      status: 'success',
+    });
   });
 
-  test('returns 400 when id is missing', async () => {
-    const { runtime } = runtimeWithService();
-    const req = createRouteRequest({ params: {} });
-    const { res, getResult } = createRouteResponse();
+  test('returns 400 when id is missing without touching the service', async () => {
+    const { response, result } = createRouteResponse();
+    await getHandler(createRouteRequest({ params: {} }), response, harness.runtime);
 
-    await getHandler(req, res, runtime);
-
-    expect(getResult().status).toBe(400);
+    expect(result()).toEqual({
+      status: 400,
+      body: { success: false, error: 'execution_id_required' },
+    });
   });
 });

--- a/plugins/plugin-workflow/__tests__/unit/routes/executions.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/routes/executions.test.ts
@@ -106,6 +106,20 @@ describe('GET /executions', () => {
       workflowId: firstWorkflowId,
     });
   });
+
+  test('uses the designed default for an invalid limit', async () => {
+    const { response, result } = createRouteResponse();
+    await listHandler(
+      createRouteRequest({ query: { limit: 'not-a-number' } }),
+      response,
+      harness.runtime
+    );
+
+    const outcome = result();
+    expect(outcome.status).toBe(200);
+    expect(outcome.body).toMatchObject({ success: true });
+    expect((outcome.body as { data: unknown[] }).data).toHaveLength(2);
+  });
 });
 
 describe('GET /executions/:id', () => {
@@ -136,6 +150,20 @@ describe('GET /executions/:id', () => {
     expect(result()).toEqual({
       status: 400,
       body: { success: false, error: 'execution_id_required' },
+    });
+  });
+
+  test('returns a structured failure for an unknown execution', async () => {
+    const { response, result } = createRouteResponse();
+    await getHandler(
+      createRouteRequest({ params: { id: 'missing-execution' } }),
+      response,
+      harness.runtime
+    );
+
+    expect(result()).toMatchObject({
+      status: 500,
+      body: { success: false, error: 'failed_to_fetch_execution' },
     });
   });
 });

--- a/plugins/plugin-workflow/__tests__/unit/routes/nodes.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/routes/nodes.test.ts
@@ -1,45 +1,8 @@
-/** Unit tests for the node-catalog route handlers over the bundled catalog (deterministic). */
-import { describe, expect, test } from 'bun:test';
-import type { RouteRequest, RouteResponse } from '@elizaos/core';
+/** Node-catalog route coverage through the registered embedded runtime catalog. */
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { nodeRoutes } from '../../../src/routes/nodes';
-import { createMockRuntime } from '../../helpers/mockRuntime';
-
-function createRouteRequest(overrides?: Partial<RouteRequest>): RouteRequest {
-  return {
-    body: undefined,
-    params: {},
-    query: {},
-    headers: {},
-    method: 'GET',
-    ...overrides,
-  };
-}
-
-function createRouteResponse(): {
-  res: RouteResponse;
-  getResult: () => { status: number; body: unknown };
-} {
-  let status = 200;
-  let body: unknown;
-  const res: RouteResponse = {
-    status(code: number) {
-      status = code;
-      return res;
-    },
-    json(data: unknown) {
-      body = data;
-      return res;
-    },
-    send(data: unknown) {
-      body = data;
-      return res;
-    },
-    end() {
-      return res;
-    },
-  };
-  return { res, getResult: () => ({ status, body }) };
-}
+import { createRouteRequest, createRouteResponse } from '../../helpers/routeHarness';
+import { type EmbeddedHarness, makeEmbeddedHarness } from '../../integration/embedded-harness';
 
 // Routes: [0] = /nodes/available, [1] = /nodes/:type, [2] = /nodes
 const availableHandler = nodeRoutes[0].handler;
@@ -49,25 +12,33 @@ if (!availableHandler || !getNodeHandler || !searchHandler) {
   throw new Error('expected node route handlers');
 }
 
-const runtime = createMockRuntime();
+let harness: EmbeddedHarness;
+
+beforeAll(async () => {
+  harness = await makeEmbeddedHarness('node-route-runtime');
+});
+
+afterAll(async () => {
+  await harness.close();
+});
 
 describe('GET /nodes', () => {
   test('returns 400 when q parameter is missing', async () => {
     const req = createRouteRequest({ query: {} });
-    const { res, getResult } = createRouteResponse();
+    const { response, result } = createRouteResponse();
 
-    await searchHandler(req, res, runtime);
+    await searchHandler(req, response, harness.runtime);
 
-    expect(getResult().status).toBe(400);
+    expect(result().status).toBe(400);
   });
 
   test('returns search results for supported HTTP keyword', async () => {
     const req = createRouteRequest({ query: { q: 'http' } });
-    const { res, getResult } = createRouteResponse();
+    const { response, result } = createRouteResponse();
 
-    await searchHandler(req, res, runtime);
+    await searchHandler(req, response, harness.runtime);
 
-    const { status, body } = getResult();
+    const { status, body } = result();
     expect(status).toBe(200);
     const data = body as {
       success: boolean;
@@ -83,21 +54,21 @@ describe('GET /nodes', () => {
 
   test('respects limit parameter', async () => {
     const req = createRouteRequest({ query: { q: 'send', limit: '3' } });
-    const { res, getResult } = createRouteResponse();
+    const { response, result } = createRouteResponse();
 
-    await searchHandler(req, res, runtime);
+    await searchHandler(req, response, harness.runtime);
 
-    const data = getResult().body as { data: unknown[] };
+    const data = result().body as { data: unknown[] };
     expect(data.data.length).toBeLessThanOrEqual(3);
   });
 
   test('handles comma-separated keywords', async () => {
     const req = createRouteRequest({ query: { q: 'http,set' } });
-    const { res, getResult } = createRouteResponse();
+    const { response, result } = createRouteResponse();
 
-    await searchHandler(req, res, runtime);
+    await searchHandler(req, response, harness.runtime);
 
-    const data = getResult().body as { success: boolean; data: unknown[] };
+    const data = result().body as { success: boolean; data: unknown[] };
     expect(data.success).toBe(true);
     expect(data.data.length).toBeGreaterThan(0);
   });
@@ -108,11 +79,11 @@ describe('GET /nodes/:type', () => {
     const req = createRouteRequest({
       params: { type: 'workflows-nodes-base.httpRequest' },
     });
-    const { res, getResult } = createRouteResponse();
+    const { response, result } = createRouteResponse();
 
-    await getNodeHandler(req, res, runtime);
+    await getNodeHandler(req, response, harness.runtime);
 
-    const { status, body } = getResult();
+    const { status, body } = result();
     expect(status).toBe(200);
     const data = body as {
       success: boolean;
@@ -127,31 +98,31 @@ describe('GET /nodes/:type', () => {
     const req = createRouteRequest({
       params: { type: 'workflows-nodes-base.nonexistentNode12345' },
     });
-    const { res, getResult } = createRouteResponse();
+    const { response, result } = createRouteResponse();
 
-    await getNodeHandler(req, res, runtime);
+    await getNodeHandler(req, response, harness.runtime);
 
-    expect(getResult().status).toBe(404);
+    expect(result().status).toBe(404);
   });
 
   test('returns 400 when type param is missing', async () => {
     const req = createRouteRequest({ params: {} });
-    const { res, getResult } = createRouteResponse();
+    const { response, result } = createRouteResponse();
 
-    await getNodeHandler(req, res, runtime);
+    await getNodeHandler(req, response, harness.runtime);
 
-    expect(getResult().status).toBe(400);
+    expect(result().status).toBe(400);
   });
 });
 
 describe('GET /nodes/available', () => {
   test('returns categorized nodes without credential bridge', async () => {
     const req = createRouteRequest();
-    const { res, getResult } = createRouteResponse();
+    const { response, result } = createRouteResponse();
 
-    await availableHandler(req, res, runtime);
+    await availableHandler(req, response, harness.runtime);
 
-    const { status, body } = getResult();
+    const { status, body } = result();
     expect(status).toBe(200);
     const data = body as {
       success: boolean;
@@ -168,36 +139,5 @@ describe('GET /nodes/available', () => {
     const first = data.data.utility[0] as Record<string, unknown>;
     expect(first.score).toBeUndefined();
     expect(first.matchReason).toBeUndefined();
-  });
-
-  test('credential bridge path keeps utility-only embedded catalog available', async () => {
-    const runtimeWithBridge = createMockRuntime({
-      services: {
-        workflow_credential_provider: {
-          resolve: () => Promise.resolve(null),
-          checkCredentialTypes: (types: string[]) => ({
-            supported: types,
-            unsupported: [],
-          }),
-        },
-      },
-    });
-
-    const req = createRouteRequest();
-    const { res, getResult } = createRouteResponse();
-
-    await availableHandler(req, res, runtimeWithBridge);
-
-    const { body } = getResult();
-    const data = body as {
-      data: {
-        supported: Array<{ name: string }>;
-        unsupported: Array<{ name: string; missingCredential?: string }>;
-        utility: unknown[];
-      };
-    };
-    expect(data.data.supported.length).toBeGreaterThan(0);
-    expect(data.data.unsupported).toEqual([]);
-    expect(data.data.utility.length).toBeGreaterThan(0);
   });
 });

--- a/plugins/plugin-workflow/__tests__/unit/routes/validation.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/routes/validation.test.ts
@@ -1,64 +1,35 @@
-/** Unit tests for the workflow-validation route handler over fixture workflows (deterministic). */
-import { describe, expect, test } from 'bun:test';
-import type { RouteRequest, RouteResponse } from '@elizaos/core';
+/** Validation route coverage through a real AgentRuntime and the production validator. */
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { validationRoutes } from '../../../src/routes/validation';
 import {
   createInvalidWorkflow_duplicateNames,
   createInvalidWorkflow_noNodes,
   createValidWorkflow,
 } from '../../fixtures/workflows';
-import { createMockRuntime } from '../../helpers/mockRuntime';
-
-function createRouteRequest(body: unknown): RouteRequest {
-  return {
-    body,
-    params: {},
-    query: {},
-    headers: {},
-    method: 'POST',
-    path: '/workflows/validate',
-  };
-}
-
-function createRouteResponse(): {
-  res: RouteResponse;
-  getResult: () => { status: number; body: unknown };
-} {
-  let status = 200;
-  let body: unknown;
-  const res: RouteResponse = {
-    status(code: number) {
-      status = code;
-      return res;
-    },
-    json(data: unknown) {
-      body = data;
-      return res;
-    },
-    send(data: unknown) {
-      body = data;
-      return res;
-    },
-    end() {
-      return res;
-    },
-  };
-  return { res, getResult: () => ({ status, body }) };
-}
+import { createRouteRequest, createRouteResponse } from '../../helpers/routeHarness';
+import { type EmbeddedHarness, makeEmbeddedHarness } from '../../integration/embedded-harness';
 
 const handler = validationRoutes[0].handler;
 if (!handler) throw new Error('expected validation route handler');
-const runtime = createMockRuntime();
+let harness: EmbeddedHarness;
+
+beforeAll(async () => {
+  harness = await makeEmbeddedHarness('validation-route-runtime');
+});
+
+afterAll(async () => {
+  await harness.close();
+});
 
 describe('POST /workflows/validate', () => {
   test('returns valid for a correct workflow', async () => {
     const workflow = createValidWorkflow();
-    const req = createRouteRequest(workflow);
-    const { res, getResult } = createRouteResponse();
+    const req = createRouteRequest({ body: workflow, method: 'POST' });
+    const { response, result } = createRouteResponse();
 
-    await handler(req, res, runtime);
+    await handler(req, response, harness.runtime);
 
-    const { status, body } = getResult();
+    const { status, body } = result();
     expect(status).toBe(200);
     const data = body as {
       valid: boolean;
@@ -71,12 +42,12 @@ describe('POST /workflows/validate', () => {
 
   test('returns errors for workflow with no nodes', async () => {
     const workflow = createInvalidWorkflow_noNodes();
-    const req = createRouteRequest(workflow);
-    const { res, getResult } = createRouteResponse();
+    const req = createRouteRequest({ body: workflow, method: 'POST' });
+    const { response, result } = createRouteResponse();
 
-    await handler(req, res, runtime);
+    await handler(req, response, harness.runtime);
 
-    const { status, body } = getResult();
+    const { status, body } = result();
     expect(status).toBe(200);
     const data = body as { valid: boolean; errors: string[] };
     expect(data.valid).toBe(false);
@@ -85,35 +56,35 @@ describe('POST /workflows/validate', () => {
 
   test('returns errors for workflow with duplicate node names', async () => {
     const workflow = createInvalidWorkflow_duplicateNames();
-    const req = createRouteRequest(workflow);
-    const { res, getResult } = createRouteResponse();
+    const req = createRouteRequest({ body: workflow, method: 'POST' });
+    const { response, result } = createRouteResponse();
 
-    await handler(req, res, runtime);
+    await handler(req, response, harness.runtime);
 
-    const { body } = getResult();
+    const { body } = result();
     const data = body as { valid: boolean; errors: string[] };
     expect(data.valid).toBe(false);
     expect(data.errors.some((e) => e.toLowerCase().includes('duplicate'))).toBe(true);
   });
 
   test('returns 400 when body has no nodes', async () => {
-    const req = createRouteRequest({ connections: {} });
-    const { res, getResult } = createRouteResponse();
+    const req = createRouteRequest({ body: { connections: {} }, method: 'POST' });
+    const { response, result } = createRouteResponse();
 
-    await handler(req, res, runtime);
+    await handler(req, response, harness.runtime);
 
-    const { status, body } = getResult();
+    const { status, body } = result();
     expect(status).toBe(400);
     expect((body as { success: boolean }).success).toBe(false);
   });
 
   test('returns 400 when body has no connections', async () => {
-    const req = createRouteRequest({ nodes: [] });
-    const { res, getResult } = createRouteResponse();
+    const req = createRouteRequest({ body: { nodes: [] }, method: 'POST' });
+    const { response, result } = createRouteResponse();
 
-    await handler(req, res, runtime);
+    await handler(req, response, harness.runtime);
 
-    const { status } = getResult();
+    const { status } = result();
     expect(status).toBe(400);
   });
 });


### PR DESCRIPTION
Closes #16247

## Outcome

Replaces workflow route test doubles with initialized `AgentRuntime` instances, registered embedded catalogs, real `WorkflowService`, real Smithers executions, and PGlite persistence. Route implementation behavior is unchanged.

## What changed

- Deduplicated three request/response capture copies into one typed route harness.
- Invokes node-catalog and validation handlers with initialized real runtimes and the registered embedded catalog.
- Replaced fabricated execution-service results with two real two-node Smithers executions persisted in PGlite.
- Verifies execution list/detail, workflow/status/limit filters, invalid-limit defaulting, missing IDs, and unknown execution failures through the real service boundary.
- Removed the always-supported fake credential-provider case, which represented no actual connector API.
- Removed all fake runtime/service factories from the three suites.

## Validation

- Node and validation routes: **13 passed**.
- Execution routes: **6 passed** after two real two-node executions.
- `bun run --cwd plugins/plugin-workflow typecheck`: passed.
- Focused Biome and `git diff --check`: passed.
- `bun run audit:test-realness`: passed with zero diff-scoped regressions across the full stacked change.
- GitHub build, lint, typecheck, integrity, coverage, and security gates are required at the final rebased head.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - route integration test cleanup with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no frontend pixels changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing visual flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no deployed backend implementation changed; focused service/execution/route logs were manually reviewed during local validation.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or network client path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent prompt, model, or generated-content behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - ephemeral PGlite execution rows are asserted directly; no production domain artifact is emitted.
