### PR TITLE
fix(orchestrator): route sub-agent conversation traffic to the user's origin room

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/active-session-forward.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/active-session-forward.test.ts
@@ -1,14 +1,23 @@
 /**
  * Integration test for the MESSAGE_RECEIVED forward handler wiring: the
  * decision (deliver / queue / interrupt / ignore) → action (sendPrompt /
- * inbox / cancelSession) mapping, the (source, roomId) bind, the ACL gate, and
- * the multi-party ambient-stop + idle-interrupt fixes. The pure decider and the
- * inbox have their own unit tests; this proves they are wired correctly.
+ * inbox / cancelSession) mapping, the session-room bind (task/origin/thread),
+ * the shared-channel classifier gate, the ACL gate, and the multi-party
+ * ambient-stop + idle-interrupt fixes. The pure decider and the inbox have
+ * their own unit tests; this proves they are wired correctly.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AcpService } from "../../src/services/acp-service.js";
 import { createActiveSessionForwardHandler } from "../../src/services/active-session-forward.js";
 import { SubAgentInbox } from "../../src/services/sub-agent-inbox.js";
+
+// Room ids are UUID-validated by the binding helper, so fixtures use real
+// UUID shapes. ROOM_1 is the user's origin connector channel.
+const ROOM_1 = "aaaa1111-1111-4111-8111-111111111111";
+const TASK_ROOM = "bbbb2222-2222-4222-8222-222222222222";
+const TASK_ROOM_2 = "cccc3333-3333-4333-8333-333333333333";
+const OTHER_ROOM = "dddd4444-4444-4444-8444-444444444444";
+const PARENT_ROOM = "eeee5555-5555-4555-8555-555555555555";
 
 type Session = {
   id: string;
@@ -34,6 +43,7 @@ function makeRuntime(
     // allows in tests (ACL denial is covered by its own case + task-policy).
     TASK_AGENT_ROLE_POLICY: JSON.stringify({ default: "GUEST" }),
   },
+  useModel?: ReturnType<typeof vi.fn>,
 ) {
   return {
     agentId: "agent-self",
@@ -47,8 +57,9 @@ function makeRuntime(
     // the default GUEST policy above permits. Without `getRoom` the lookup throws
     // and fails closed (SOURCE_RESOLUTION_FAILED → denied), so every delivery
     // case would wrongly drop. `reportError` backs the fail-closed path.
-    getRoom: vi.fn(async () => ({ id: "room-1" })),
+    getRoom: vi.fn(async () => ({ id: ROOM_1 })),
     reportError: vi.fn(),
+    ...(useModel ? { useModel } : {}),
   } as never;
 }
 
@@ -59,7 +70,7 @@ function msg(
   return {
     message: {
       entityId: "user-1",
-      roomId: "room-1",
+      roomId: ROOM_1,
       content: { text },
       ...overrides,
     } as never,
@@ -80,7 +91,7 @@ const session = (over: Partial<Session> = {}): Session => ({
   name: "Ada",
   agentType: "claude",
   status: "ready",
-  metadata: { roomId: "room-1", label: "Ada" },
+  metadata: { roomId: ROOM_1, label: "Ada" },
   ...over,
 });
 
@@ -178,7 +189,7 @@ describe("active-session forward handler", () => {
 
   it("matches a session by threadRoomId, not just roomId", async () => {
     const acp = makeAcp([
-      session({ metadata: { roomId: "parent", threadRoomId: "room-1" } }),
+      session({ metadata: { roomId: PARENT_ROOM, threadRoomId: ROOM_1 } }),
     ]);
     const handler = createActiveSessionForwardHandler(makeRuntime(acp), inbox);
     await handler(msg("in-thread reply"));
@@ -186,7 +197,7 @@ describe("active-session forward handler", () => {
   });
 
   it("does nothing when no live session is bound to the room", async () => {
-    const acp = makeAcp([session({ metadata: { roomId: "other-room" } })]);
+    const acp = makeAcp([session({ metadata: { roomId: OTHER_ROOM } })]);
     const handler = createActiveSessionForwardHandler(makeRuntime(acp), inbox);
     await handler(msg("nobody home"));
     expect(acp.sendPrompt).not.toHaveBeenCalled();
@@ -194,12 +205,15 @@ describe("active-session forward handler", () => {
 
   it("forwards an origin-channel follow-up when meta.roomId is a minted task room", async () => {
     // Default-on task rooms: spawn stamps meta.roomId = taskRoomId while the
-    // user keeps typing in the origin connector channel (originRoomId).
+    // user keeps typing in the origin connector channel (originRoomId). No
+    // model on this runtime → the shared-channel classifier falls open to the
+    // regex baseline (deliver when idle) so follow-ups still flow.
     const acp = makeAcp([
       session({
         metadata: {
-          roomId: "task-room-uuid",
-          originRoomId: "room-1",
+          roomId: TASK_ROOM,
+          taskRoomId: TASK_ROOM,
+          originRoomId: ROOM_1,
           label: "Ada",
         },
       }),
@@ -216,8 +230,9 @@ describe("active-session forward handler", () => {
     const acp = makeAcp([
       session({
         metadata: {
-          roomId: "task-room-uuid",
-          sourceRoomId: "room-1",
+          roomId: TASK_ROOM,
+          taskRoomId: TASK_ROOM,
+          sourceRoomId: ROOM_1,
           label: "Ada",
         },
       }),
@@ -225,6 +240,109 @@ describe("active-session forward handler", () => {
     const handler = createActiveSessionForwardHandler(makeRuntime(acp), inbox);
     await handler(msg("use bun, not npm"));
     expect(acp.sendPrompt).toHaveBeenCalledWith("s1", "use bun, not npm");
+  });
+
+  it("consults the classifier on a shared channel and honors an ignore verdict (planner-owned message)", async () => {
+    // The origin channel is shared with the orchestrator planner. An idle solo
+    // session must NOT blanket-receive planner-directed messages ("set a
+    // reminder") — that is cross-task prompt injection. The classifier says
+    // ignore → nothing is forwarded.
+    const acp = makeAcp([
+      session({
+        metadata: {
+          roomId: TASK_ROOM,
+          taskRoomId: TASK_ROOM,
+          originRoomId: ROOM_1,
+          label: "Ada",
+        },
+      }),
+    ]);
+    const useModel = vi.fn(async () =>
+      JSON.stringify({ action: "ignore", reason: "planner command" }),
+    );
+    const handler = createActiveSessionForwardHandler(
+      makeRuntime(acp, undefined, useModel),
+      inbox,
+    );
+    await handler(msg("set a reminder for 6pm"));
+    expect(useModel).toHaveBeenCalledTimes(1);
+    expect(acp.sendPrompt).not.toHaveBeenCalled();
+    expect(inbox.size("s1")).toBe(0);
+  });
+
+  it("delivers on a shared channel when the classifier judges the message a task follow-up", async () => {
+    const acp = makeAcp([
+      session({
+        metadata: {
+          roomId: TASK_ROOM,
+          taskRoomId: TASK_ROOM,
+          originRoomId: ROOM_1,
+          label: "Ada",
+        },
+      }),
+    ]);
+    const useModel = vi.fn(async () =>
+      JSON.stringify({ action: "deliver", reason: "task follow-up" }),
+    );
+    const handler = createActiveSessionForwardHandler(
+      makeRuntime(acp, undefined, useModel),
+      inbox,
+    );
+    await handler(msg("also cover the empty-input case"));
+    expect(useModel).toHaveBeenCalledTimes(1);
+    expect(acp.sendPrompt).toHaveBeenCalledWith(
+      "s1",
+      "also cover the empty-input case",
+    );
+  });
+
+  it("keeps the idle fast-path (no classifier call) for a dedicated task-room binding", async () => {
+    const acp = makeAcp([
+      session({
+        metadata: {
+          roomId: TASK_ROOM,
+          taskRoomId: TASK_ROOM,
+          originRoomId: ROOM_1,
+          label: "Ada",
+        },
+      }),
+    ]);
+    const useModel = vi.fn(async () =>
+      JSON.stringify({ action: "ignore", reason: "should not be consulted" }),
+    );
+    const handler = createActiveSessionForwardHandler(
+      makeRuntime(acp, undefined, useModel),
+      inbox,
+    );
+    // Message posted IN the dedicated task room — unambiguously for this task.
+    await handler(msg("tighten the types", { roomId: TASK_ROOM }));
+    expect(useModel).not.toHaveBeenCalled();
+    expect(acp.sendPrompt).toHaveBeenCalledWith("s1", "tighten the types");
+  });
+
+  it("falls open to delivery when the shared-channel classifier errors", async () => {
+    // Fail-open is deliberate: fail-closed would silently resurrect the
+    // dropped-follow-ups bug on every model-less runtime.
+    const acp = makeAcp([
+      session({
+        metadata: {
+          roomId: TASK_ROOM,
+          taskRoomId: TASK_ROOM,
+          originRoomId: ROOM_1,
+          label: "Ada",
+        },
+      }),
+    ]);
+    const useModel = vi.fn(async () => {
+      throw new Error("model offline");
+    });
+    const handler = createActiveSessionForwardHandler(
+      makeRuntime(acp, undefined, useModel),
+      inbox,
+    );
+    await handler(msg("ship it with the fix"));
+    expect(useModel).toHaveBeenCalledTimes(1);
+    expect(acp.sendPrompt).toHaveBeenCalledWith("s1", "ship it with the fix");
   });
 
   it("broadcasts an addressed follow-up to ALL bound live sessions, not just the first", async () => {
@@ -235,13 +353,22 @@ describe("active-session forward handler", () => {
         name: "Bob",
         status: "ready",
         metadata: {
-          roomId: "task-room-2",
-          originRoomId: "room-1",
+          roomId: TASK_ROOM_2,
+          taskRoomId: TASK_ROOM_2,
+          originRoomId: ROOM_1,
           label: "Bob",
         },
       }),
     ]);
-    const handler = createActiveSessionForwardHandler(makeRuntime(acp), inbox);
+    // s2 binds via the shared origin channel → classifier consulted; verdict
+    // deliver (the message addresses Bob and the task).
+    const useModel = vi.fn(async () =>
+      JSON.stringify({ action: "deliver", reason: "addressed follow-up" }),
+    );
+    const handler = createActiveSessionForwardHandler(
+      makeRuntime(acp, undefined, useModel),
+      inbox,
+    );
     await handler(msg("Ada and Bob, please add tests"));
     expect(acp.sendPrompt).toHaveBeenCalledTimes(2);
     expect(acp.sendPrompt).toHaveBeenCalledWith(
@@ -261,7 +388,7 @@ describe("active-session forward handler", () => {
         id: "s2",
         name: "Bob",
         status: "tool_running",
-        metadata: { roomId: "room-1", label: "Bob" },
+        metadata: { roomId: ROOM_1, label: "Bob" },
       }),
     ]);
     const handler = createActiveSessionForwardHandler(makeRuntime(acp), inbox);

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/active-session-forward.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/active-session-forward.test.ts
@@ -192,6 +192,89 @@ describe("active-session forward handler", () => {
     expect(acp.sendPrompt).not.toHaveBeenCalled();
   });
 
+  it("forwards an origin-channel follow-up when meta.roomId is a minted task room", async () => {
+    // Default-on task rooms: spawn stamps meta.roomId = taskRoomId while the
+    // user keeps typing in the origin connector channel (originRoomId).
+    const acp = makeAcp([
+      session({
+        metadata: {
+          roomId: "task-room-uuid",
+          originRoomId: "room-1",
+          label: "Ada",
+        },
+      }),
+    ]);
+    const handler = createActiveSessionForwardHandler(makeRuntime(acp), inbox);
+    await handler(msg("also handle the edge case"));
+    expect(acp.sendPrompt).toHaveBeenCalledWith(
+      "s1",
+      "also handle the edge case",
+    );
+  });
+
+  it("matches a session by sourceRoomId as an origin binding", async () => {
+    const acp = makeAcp([
+      session({
+        metadata: {
+          roomId: "task-room-uuid",
+          sourceRoomId: "room-1",
+          label: "Ada",
+        },
+      }),
+    ]);
+    const handler = createActiveSessionForwardHandler(makeRuntime(acp), inbox);
+    await handler(msg("use bun, not npm"));
+    expect(acp.sendPrompt).toHaveBeenCalledWith("s1", "use bun, not npm");
+  });
+
+  it("broadcasts an addressed follow-up to ALL bound live sessions, not just the first", async () => {
+    const acp = makeAcp([
+      session({ id: "s1", status: "ready" }),
+      session({
+        id: "s2",
+        name: "Bob",
+        status: "ready",
+        metadata: {
+          roomId: "task-room-2",
+          originRoomId: "room-1",
+          label: "Bob",
+        },
+      }),
+    ]);
+    const handler = createActiveSessionForwardHandler(makeRuntime(acp), inbox);
+    await handler(msg("Ada and Bob, please add tests"));
+    expect(acp.sendPrompt).toHaveBeenCalledTimes(2);
+    expect(acp.sendPrompt).toHaveBeenCalledWith(
+      "s1",
+      "Ada and Bob, please add tests",
+    );
+    expect(acp.sendPrompt).toHaveBeenCalledWith(
+      "s2",
+      "Ada and Bob, please add tests",
+    );
+  });
+
+  it("decides per session in a broadcast: idle session delivered, busy session queued", async () => {
+    const acp = makeAcp([
+      session({ id: "s1", status: "ready" }),
+      session({
+        id: "s2",
+        name: "Bob",
+        status: "tool_running",
+        metadata: { roomId: "room-1", label: "Bob" },
+      }),
+    ]);
+    const handler = createActiveSessionForwardHandler(makeRuntime(acp), inbox);
+    await handler(msg("Ada and Bob, please add tests"));
+    expect(acp.sendPrompt).toHaveBeenCalledTimes(1);
+    expect(acp.sendPrompt).toHaveBeenCalledWith(
+      "s1",
+      "Ada and Bob, please add tests",
+    );
+    expect(inbox.size("s2")).toBe(1);
+    expect(inbox.drain("s2")).toBe("Ada and Bob, please add tests");
+  });
+
   it("blocks forwarding when the ACL denies interact", async () => {
     const acp = makeAcp([session({ status: "ready" })]);
     // ADMIN-gated interact + a sender that resolves to no elevated role.

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/progress-cadence.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/progress-cadence.test.ts
@@ -373,6 +373,37 @@ describe("emitProgress routing ladder + cadence", () => {
     await rt.dispose();
   });
 
+  it("targets the ORIGIN room, not the minted task room, when session metadata carries originRoomId", async () => {
+    // Default-on task rooms stamp meta.roomId with the minted task-room UUID,
+    // which maps to no live connector channel — posting there fails silently
+    // (demoted to debug after the first warn). The hook must resolve the emit
+    // target through the origin ladder so acks/narration reach the user.
+    process.env.ACPX_PROGRESS_MODE = "compact";
+    process.env.ACPX_PROGRESS_DELAY_MS = "0";
+    const TASK_ROOM = "99999999-8888-4777-8666-555555555555";
+    const rt = await buildHookedRuntime([{ source: SOURCE, capabilities: [] }]);
+    rt.sessions.set("s-origin", {
+      status: "running",
+      metadata: {
+        source: SOURCE,
+        roomId: TASK_ROOM,
+        originRoomId: ROOM,
+        label: "origin-task",
+      },
+    });
+
+    await fire(rt, "s-origin", "message", { text: "Building the parser." });
+    // Drain the narration silence-flush window so the buffered post fires.
+    await advanceTimersByTime(2_000);
+
+    expect(rt.sendMessageToTarget).toHaveBeenCalled();
+    for (const [target] of rt.sendMessageToTarget.mock.calls) {
+      expect((target as { roomId: string }).roomId).toBe(ROOM);
+    }
+
+    await rt.dispose();
+  });
+
   it("silent mode posts nothing for any event", async () => {
     process.env.ACPX_PROGRESS_MODE = "silent";
     const rt = await buildHookedRuntime([

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/session-room-binding.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/session-room-binding.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Verifies the shared session-room ladder: precedence, the binding set, and —
+ * the anti-drift contract — agreement with the router's `readOrigin` on the
+ * reply room for representative session metadata shapes. Deterministic; no
+ * runtime, no live model.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  resolveOriginRoomId,
+  sessionBoundRoomIds,
+} from "../../src/services/session-room-binding.js";
+import { readOrigin } from "../../src/services/sub-agent-router.js";
+import type { SessionInfo } from "../../src/services/types.js";
+
+const ORIGIN = "11111111-1111-4111-8111-111111111111";
+const SOURCE_ROOM = "33333333-3333-4333-8333-333333333333";
+const TASK = "22222222-2222-4222-8222-222222222222";
+const THREAD = "44444444-4444-4444-8444-444444444444";
+
+function sessionWith(meta: Record<string, unknown>): SessionInfo {
+  return {
+    id: "s1",
+    name: "demo",
+    agentType: "codex",
+    workdir: "/tmp/wf",
+    status: "ready",
+    approvalPreset: "standard",
+    createdAt: new Date(0),
+    lastActivityAt: new Date(0),
+    metadata: meta,
+  } as SessionInfo;
+}
+
+describe("resolveOriginRoomId", () => {
+  it("prefers originRoomId over sourceRoomId over taskRoomId over roomId", () => {
+    expect(
+      resolveOriginRoomId({
+        originRoomId: ORIGIN,
+        sourceRoomId: SOURCE_ROOM,
+        taskRoomId: TASK,
+        roomId: TASK,
+      }),
+    ).toBe(ORIGIN);
+    expect(
+      resolveOriginRoomId({
+        sourceRoomId: SOURCE_ROOM,
+        taskRoomId: TASK,
+        roomId: TASK,
+      }),
+    ).toBe(SOURCE_ROOM);
+    expect(resolveOriginRoomId({ taskRoomId: TASK, roomId: TASK })).toBe(TASK);
+    expect(resolveOriginRoomId({ roomId: TASK })).toBe(TASK);
+    expect(resolveOriginRoomId({})).toBeUndefined();
+    expect(resolveOriginRoomId(undefined)).toBeUndefined();
+  });
+
+  it("ignores blank/non-string values instead of returning them", () => {
+    expect(
+      resolveOriginRoomId({
+        originRoomId: "  ",
+        sourceRoomId: 7,
+        roomId: TASK,
+      }),
+    ).toBe(TASK);
+  });
+
+  it("agrees with the router's readOrigin reply room (anti-drift contract)", () => {
+    const shapes: Array<Record<string, unknown>> = [
+      // Default-on task rooms: roomId = minted task room, origin carried aside.
+      { roomId: TASK, taskRoomId: TASK, originRoomId: ORIGIN },
+      // sourceRoomId-only spawn path.
+      { roomId: TASK, taskRoomId: TASK, sourceRoomId: SOURCE_ROOM },
+      // Task rooms opted out: origin room IS the session room.
+      { roomId: ORIGIN, taskRoomId: ORIGIN },
+      // Legacy session predating task rooms entirely.
+      { roomId: ORIGIN },
+    ];
+    for (const meta of shapes) {
+      const origin = readOrigin(sessionWith(meta));
+      expect(origin).not.toBeNull();
+      expect(resolveOriginRoomId(meta)).toBe(origin?.roomId);
+    }
+  });
+});
+
+describe("sessionBoundRoomIds", () => {
+  it("collects task, origin, source, and thread rooms without duplicates", () => {
+    const rooms = sessionBoundRoomIds({
+      roomId: TASK,
+      taskRoomId: TASK,
+      originRoomId: ORIGIN,
+      sourceRoomId: SOURCE_ROOM,
+      threadRoomId: THREAD,
+    });
+    expect(rooms).toEqual(new Set([TASK, ORIGIN, SOURCE_ROOM, THREAD]));
+  });
+
+  it("is empty for missing metadata", () => {
+    expect(sessionBoundRoomIds(undefined).size).toBe(0);
+    expect(sessionBoundRoomIds({}).size).toBe(0);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/session-room-binding.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/session-room-binding.test.ts
@@ -54,14 +54,23 @@ describe("resolveOriginRoomId", () => {
     expect(resolveOriginRoomId(undefined)).toBeUndefined();
   });
 
-  it("ignores blank/non-string values instead of returning them", () => {
+  it("ignores blank/non-string/non-UUID values instead of returning them", () => {
     expect(
       resolveOriginRoomId({
         originRoomId: "  ",
         sourceRoomId: 7,
+        taskRoomId: "not-a-uuid",
         roomId: TASK,
       }),
     ).toBe(TASK);
+  });
+
+  it("rejects non-UUID room ids in the binding set (same validation as readOrigin)", () => {
+    const rooms = sessionBoundRoomIds({
+      roomId: "not-a-uuid",
+      originRoomId: ORIGIN,
+    });
+    expect(rooms).toEqual(new Set([ORIGIN]));
   });
 
   it("agrees with the router's readOrigin reply room (anti-drift contract)", () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-inbox.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-inbox.test.ts
@@ -34,6 +34,40 @@ describe("SubAgentInbox", () => {
     expect(inbox.drain("s")).toBe("2\n3");
   });
 
+  it("surfaces overflow drops through the observer — never a silent drop", () => {
+    const inbox = new SubAgentInbox(2);
+    const seen: Array<{ sessionId: string; now: number; total: number }> = [];
+    inbox.setOverflowObserver((sessionId, now, total) =>
+      seen.push({ sessionId, now, total }),
+    );
+    inbox.enqueue("s", "1");
+    inbox.enqueue("s", "2");
+    expect(seen).toEqual([]);
+    expect(inbox.droppedCount("s")).toBe(0);
+
+    inbox.enqueue("s", "3");
+    inbox.enqueue("s", "4");
+    expect(seen).toEqual([
+      { sessionId: "s", now: 1, total: 1 },
+      { sessionId: "s", now: 1, total: 2 },
+    ]);
+    expect(inbox.droppedCount("s")).toBe(2);
+    // The surviving window is still the newest entries.
+    expect(inbox.drain("s")).toBe("3\n4");
+    // Session teardown resets the drop ledger with the queue.
+    inbox.enqueue("s", "5");
+    inbox.clear("s");
+    expect(inbox.droppedCount("s")).toBe(0);
+  });
+
+  it("counts overflow drops even with no observer attached", () => {
+    const inbox = new SubAgentInbox(1);
+    inbox.enqueue("s", "a");
+    inbox.enqueue("s", "b");
+    expect(inbox.droppedCount("s")).toBe(1);
+    expect(inbox.drain("s")).toBe("b");
+  });
+
   it("clears one session and all sessions", () => {
     const inbox = new SubAgentInbox();
     inbox.enqueue("a", "x");

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
@@ -522,10 +522,11 @@ describe("SubAgentRouter", () => {
     expect(metadata?.worktreeRoomId).toBe(WORKTREE_ROOM);
   });
 
-  it("routes QUESTION_FOR_TASK_CREATOR to BOTH the task room and the origin room when they differ", async () => {
+  it("runs ONE planner turn for QUESTION_FOR_TASK_CREATOR and posts the question directly to the origin room", async () => {
     // Default-on task rooms: the task creator is the USER in the origin
-    // channel. The task-room leg keeps planner context; the origin leg is what
-    // actually surfaces the blocked sub-agent's question to the user.
+    // channel. The task-room leg is the single planner turn; the origin leg is
+    // a DIRECT connector post (no second planner turn — that would
+    // double-answer the question into the same room).
     const TASK_ROOM = "55555555-5555-4555-8555-555555555555";
     session = makeSession({
       metadata: {
@@ -540,7 +541,9 @@ describe("SubAgentRouter", () => {
       },
     });
     acp = makeAcpService(session);
-    const { runtime, handleMessage } = makeRuntime({ acp: acp.service });
+    const { runtime, handleMessage, sendMessageToTarget } = makeRuntime({
+      acp: acp.service,
+    });
     await SubAgentRouter.start(runtime);
 
     acp.emit(SESSION_ID, "QUESTION_FOR_TASK_CREATOR", {
@@ -548,26 +551,55 @@ describe("SubAgentRouter", () => {
     });
     await new Promise((r) => setImmediate(r));
 
-    expect(handleMessage).toHaveBeenCalledTimes(2);
-    const postedRooms = handleMessage.mock.calls.map(
-      (call) => (call[1] as Memory).roomId,
-    );
-    expect(postedRooms).toContain(TASK_ROOM);
-    expect(postedRooms).toContain(ROOM);
-    for (const call of handleMessage.mock.calls) {
-      const posted = call[1] as Memory;
-      const metadata = posted.content?.metadata as Record<string, unknown>;
-      expect(posted.content?.text).toContain("Which branch");
-      expect(metadata?.subAgentRoutingKind).toBe("QUESTION_FOR_TASK_CREATOR");
-    }
-    const originCall = handleMessage.mock.calls.find(
-      (call) => (call[1] as Memory).roomId === ROOM,
-    );
-    const originMeta = (originCall?.[1] as Memory).content?.metadata as Record<
-      string,
-      unknown
-    >;
-    expect(originMeta?.subAgentTargetRoomRole).toBe("origin");
+    // Exactly one planner turn, in the task room.
+    expect(handleMessage).toHaveBeenCalledTimes(1);
+    const posted = handleMessage.mock.calls[0]?.[1] as Memory;
+    const metadata = posted.content?.metadata as Record<string, unknown>;
+    expect(posted.roomId).toBe(TASK_ROOM);
+    expect(posted.content?.text).toContain("Which branch");
+    expect(metadata?.subAgentRoutingKind).toBe("QUESTION_FOR_TASK_CREATOR");
+
+    // Exactly one direct user-facing post, in the origin room, attributed to
+    // the sub-agent with the question verbatim (planner header stripped).
+    expect(sendMessageToTarget).toHaveBeenCalledTimes(1);
+    const [target, content] = sendMessageToTarget.mock.calls[0] as [
+      { source: string; roomId?: string },
+      Content,
+    ];
+    expect(target).toEqual({ source: "telegram", roomId: ROOM });
+    expect(content.text).toContain("Which branch");
+    expect(content.text).toContain("❓ [fix-bug-42]");
+    expect(content.text).not.toContain("[sub-agent:");
+    expect(content.source).toBe("sub_agent");
+  });
+
+  it("does not add a direct post for QUESTION_FOR_TASK_CREATOR when the origin room IS the task room", async () => {
+    // Task rooms opted out: one planner turn, no extra direct post — the
+    // planner turn's reply callback already targets this room.
+    session = makeSession({
+      metadata: {
+        label: "fix-bug-42",
+        roomId: ROOM,
+        taskRoomId: ROOM,
+        worldId: WORLD,
+        userId: USER,
+        messageId: PARENT_MSG,
+        source: "telegram",
+      },
+    });
+    acp = makeAcpService(session);
+    const { runtime, handleMessage, sendMessageToTarget } = makeRuntime({
+      acp: acp.service,
+    });
+    await SubAgentRouter.start(runtime);
+
+    acp.emit(SESSION_ID, "QUESTION_FOR_TASK_CREATOR", {
+      question: "Which branch should I target?",
+    });
+    await new Promise((r) => setImmediate(r));
+
+    expect(handleMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessageToTarget).not.toHaveBeenCalled();
   });
 
   it("strips leaked routing-kind markdown banners from sub-agent prose", async () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
@@ -522,6 +522,54 @@ describe("SubAgentRouter", () => {
     expect(metadata?.worktreeRoomId).toBe(WORKTREE_ROOM);
   });
 
+  it("routes QUESTION_FOR_TASK_CREATOR to BOTH the task room and the origin room when they differ", async () => {
+    // Default-on task rooms: the task creator is the USER in the origin
+    // channel. The task-room leg keeps planner context; the origin leg is what
+    // actually surfaces the blocked sub-agent's question to the user.
+    const TASK_ROOM = "55555555-5555-4555-8555-555555555555";
+    session = makeSession({
+      metadata: {
+        label: "fix-bug-42",
+        roomId: TASK_ROOM,
+        taskRoomId: TASK_ROOM,
+        originRoomId: ROOM,
+        worldId: WORLD,
+        userId: USER,
+        messageId: PARENT_MSG,
+        source: "telegram",
+      },
+    });
+    acp = makeAcpService(session);
+    const { runtime, handleMessage } = makeRuntime({ acp: acp.service });
+    await SubAgentRouter.start(runtime);
+
+    acp.emit(SESSION_ID, "QUESTION_FOR_TASK_CREATOR", {
+      question: "Which branch should I target?",
+    });
+    await new Promise((r) => setImmediate(r));
+
+    expect(handleMessage).toHaveBeenCalledTimes(2);
+    const postedRooms = handleMessage.mock.calls.map(
+      (call) => (call[1] as Memory).roomId,
+    );
+    expect(postedRooms).toContain(TASK_ROOM);
+    expect(postedRooms).toContain(ROOM);
+    for (const call of handleMessage.mock.calls) {
+      const posted = call[1] as Memory;
+      const metadata = posted.content?.metadata as Record<string, unknown>;
+      expect(posted.content?.text).toContain("Which branch");
+      expect(metadata?.subAgentRoutingKind).toBe("QUESTION_FOR_TASK_CREATOR");
+    }
+    const originCall = handleMessage.mock.calls.find(
+      (call) => (call[1] as Memory).roomId === ROOM,
+    );
+    const originMeta = (originCall?.[1] as Memory).content?.metadata as Record<
+      string,
+      unknown
+    >;
+    expect(originMeta?.subAgentTargetRoomRole).toBe("origin");
+  });
+
   it("strips leaked routing-kind markdown banners from sub-agent prose", async () => {
     session = makeSession({
       metadata: {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/swarm-coordinator-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/swarm-coordinator-service.test.ts
@@ -1482,6 +1482,83 @@ describe("SwarmCoordinatorService", () => {
     await coordinator.stop();
   });
 
+  it("posts a bind-window completion exactly once even when the router binds before the cede decision runs", async () => {
+    // Race (#bind-retry window): AcpService fans events out synchronously and
+    // never replays, so a completion emitted while the router is still in its
+    // bind-retry loop is NEVER seen by the router. The cede decision runs
+    // behind metadata awaits — a live isActive() read there can observe the
+    // router binding in the interim and cede an event the router never
+    // received (zero user-facing posts). The receipt-time snapshot must keep
+    // synthesis as the poster: exactly one post.
+    const acp = makeAcpStub({
+      agentType: "codex",
+      workdir: "/tmp/wd",
+      metadata: {
+        label: "build-site",
+        originRoomId: ROUTER_ROOM_ID,
+        taskRoomId: ROUTER_TASK_ROOM_ID,
+        source: "discord",
+      },
+    });
+    const router = makeRouterStub(false); // still binding at emit time
+    const runtime = makeRuntime({
+      [AcpService.serviceType]: acp,
+      [SUB_AGENT_ROUTER_SERVICE_TYPE]: router,
+    });
+    const coordinator = await SwarmCoordinatorService.start(runtime);
+
+    const fired = vi.fn(async () => {});
+    coordinator.setSwarmCompleteCallback(fired);
+
+    acp.emit("sess-bind-window", "task_complete", { response: "deployed" });
+    // The router finishes binding immediately after the fan-out, before the
+    // coordinator's chained cede decision gets to run.
+    router.isActive.mockReturnValue(true);
+    await flushChains();
+
+    expect(fired).toHaveBeenCalledTimes(1);
+
+    // The one-shot runner's teardown `stopped` after the router bound must not
+    // produce a second user-facing post for the same session.
+    acp.emit("sess-bind-window", "stopped", {});
+    await flushChains();
+    expect(fired).toHaveBeenCalledTimes(1);
+    await coordinator.stop();
+  });
+
+  it("still cedes a completion the router received even if the router reads inactive by decision time", async () => {
+    // Mirror-image race: the router WAS bound at emit (it received the event
+    // and will post). If it flips inactive during the coordinator's awaits
+    // (stop/rebind), a live read would synthesize a second copy of the same
+    // completion. The receipt-time snapshot keeps the cession.
+    const acp = makeAcpStub({
+      agentType: "codex",
+      workdir: "/tmp/wd",
+      metadata: {
+        label: "build-site",
+        originRoomId: ROUTER_ROOM_ID,
+        taskRoomId: ROUTER_TASK_ROOM_ID,
+        source: "discord",
+      },
+    });
+    const router = makeRouterStub(true); // bound at emit time
+    const runtime = makeRuntime({
+      [AcpService.serviceType]: acp,
+      [SUB_AGENT_ROUTER_SERVICE_TYPE]: router,
+    });
+    const coordinator = await SwarmCoordinatorService.start(runtime);
+
+    const fired = vi.fn(async () => {});
+    coordinator.setSwarmCompleteCallback(fired);
+
+    acp.emit("sess-unbind-race", "task_complete", { response: "deployed" });
+    router.isActive.mockReturnValue(false);
+    await flushChains();
+
+    expect(fired).not.toHaveBeenCalled();
+    await coordinator.stop();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
   });

--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -67,6 +67,7 @@ import {
   type TaskAuditPayload,
 } from "./services/audit.js";
 import { OrchestratorTaskService } from "./services/orchestrator-task-service.js";
+import { resolveOriginRoomId } from "./services/session-room-binding.js";
 import { SubAgentInbox } from "./services/sub-agent-inbox.js";
 import { SubAgentRouter } from "./services/sub-agent-router.js";
 import { SwarmCoordinatorService } from "./services/swarm-coordinator-service.js";
@@ -276,6 +277,30 @@ export function createAgentOrchestratorPlugin(): Plugin {
         TASK_AUDIT_EVENT,
         taskAuditHandler,
       );
+      // An inbox overflow discards a queued USER message. That must never be
+      // silent (repo error-policy: a dropped input reads as a healthy pipeline)
+      // — warn with the counts and raise through the diagnostic boundary so
+      // repeated drops reach RECENT_ERRORS / owner escalation.
+      subAgentInbox.setOverflowObserver(
+        (sessionId, droppedNow, droppedTotal) => {
+          runtime.logger?.warn?.(
+            {
+              src: "@elizaos/plugin-agent-orchestrator",
+              sessionId,
+              droppedNow,
+              droppedTotal,
+            },
+            "sub-agent inbox overflow: oldest queued user message(s) dropped",
+          );
+          runtime.reportError?.(
+            "SubAgentInbox",
+            new Error(
+              `sub-agent inbox overflow for session ${sessionId}: dropped ${droppedNow} queued message(s) (${droppedTotal} total)`,
+            ),
+            { sessionId, droppedNow, droppedTotal },
+          );
+        },
+      );
       // Forward mid-task user messages to the live sub-agent for this roomId.
       // Bind is on (source, roomId) — no Discord-thread dependency, so plain
       // SMS/WhatsApp follow-ups work too.
@@ -475,6 +500,9 @@ export function createAgentOrchestratorPlugin(): Plugin {
       flushTimers.clear();
       flushPending.clear();
       subAgentInbox.clearAll();
+      // Detach the runtime-bound overflow observer so a late enqueue after
+      // hot-reload teardown cannot touch a torn-down runtime.
+      subAgentInbox.setOverflowObserver(undefined);
       const acp = runtime.getService<AcpService>(AcpService.serviceType);
       await acp?.stop();
       const taskService = runtime.getService<OrchestratorTaskService>(
@@ -1947,10 +1975,16 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
         const meta = (session?.metadata ?? {}) as Record<string, unknown>;
         const source =
           typeof meta.source === "string" ? meta.source : undefined;
-        const roomId =
-          typeof meta.roomId === "string"
-            ? (meta.roomId as `${string}-${string}-${string}-${string}-${string}`)
-            : undefined;
+        // Acks/heartbeats/narration must land on the user's live connector
+        // channel. With per-task GROUP rooms on by default, the raw
+        // `meta.roomId` is the minted task-room UUID (no connector channel
+        // maps to it — every send fails and gets demoted to debug after the
+        // first warn), so resolve through the shared origin ladder. Thread
+        // routing is unaffected: `threadRoomId` binding and the per-session
+        // thread state key off this target the same way they did.
+        const roomId = resolveOriginRoomId(meta) as
+          | `${string}-${string}-${string}-${string}-${string}`
+          | undefined;
         if (!source || !roomId) return;
         const label =
           typeof meta.label === "string" && meta.label.trim().length > 0

--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -1982,6 +1982,9 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
         // first warn), so resolve through the shared origin ladder. Thread
         // routing is unaffected: `threadRoomId` binding and the per-session
         // thread state key off this target the same way they did.
+        // Cast is runtime-checked: resolveOriginRoomId only returns strings
+        // that pass UUID validation, which always satisfy the dashed template
+        // type (core's UUID alias is plain `string`, so it cannot flow here).
         const roomId = resolveOriginRoomId(meta) as
           | `${string}-${string}-${string}-${string}-${string}`
           | undefined;

--- a/plugins/plugin-agent-orchestrator/src/services/active-session-forward.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/active-session-forward.ts
@@ -15,6 +15,7 @@ import {
 } from "@elizaos/core";
 import { AcpService } from "./acp-service.js";
 import { decideInterruptionWithModel } from "./interruption-decider.js";
+import { sessionBoundRoomIds } from "./session-room-binding.js";
 import type { SubAgentInbox } from "./sub-agent-inbox.js";
 import { requireTaskAgentAccess } from "./task-policy.js";
 import { type SessionInfo, TERMINAL_SESSION_STATUSES } from "./types.js";
@@ -43,9 +44,11 @@ export function isSessionBusy(status: string): boolean {
 const SRC = "@elizaos/plugin-agent-orchestrator";
 
 /**
- * Build the MESSAGE_RECEIVED handler that forwards mid-task user messages to the
- * live sub-agent bound to the message's room. Bind is on (source, roomId) — no
- * Discord-thread dependency, so plain SMS/WhatsApp follow-ups work too.
+ * Build the MESSAGE_RECEIVED handler that forwards mid-task user messages to
+ * every live sub-agent bound to the message's room. Bind matches any of the
+ * session's rooms (task room, origin channel, thread — see
+ * {@link sessionBoundRoomIds}) with no Discord-thread dependency, so plain
+ * SMS/WhatsApp follow-ups in the origin channel work too.
  */
 export function createActiveSessionForwardHandler(
   runtime: IAgentRuntime,
@@ -81,20 +84,19 @@ export function createActiveSessionForwardHandler(
           return [] as SessionInfo[];
         },
       );
+      // Binding covers every room the session is conversationally reachable
+      // from: with per-task GROUP rooms on by default, `meta.roomId` is the
+      // minted task room while the user types in the origin connector channel
+      // (`originRoomId`/`sourceRoomId`) — matching only the raw roomId
+      // silently dropped every origin-channel follow-up.
       const boundToRoom = (s: SessionInfo): boolean => {
         if (TERMINAL_SESSION_STATUSES.has(s.status)) return false;
-        const meta = s.metadata;
-        const roomId =
-          typeof meta?.roomId === "string" ? meta.roomId : undefined;
-        // threadRoomId matches replies posted inside the per-label thread.
-        const threadRoomId =
-          typeof meta?.threadRoomId === "string"
-            ? meta.threadRoomId
-            : undefined;
-        return roomId === message.roomId || threadRoomId === message.roomId;
+        return sessionBoundRoomIds(
+          s.metadata as Record<string, unknown> | undefined,
+        ).has(message.roomId);
       };
-      const active = sessions.find(boundToRoom);
-      if (!active) return;
+      const bound = sessions.filter(boundToRoom);
+      if (bound.length === 0) return;
       const text =
         typeof (message.content as { text?: unknown })?.text === "string"
           ? ((message.content as { text: string }).text ?? "").trim()
@@ -107,101 +109,108 @@ export function createActiveSessionForwardHandler(
       const access = await requireTaskAgentAccess(runtime, message, "interact");
       if (!access.allowed) return;
 
-      const label =
-        typeof active.metadata?.label === "string"
-          ? active.metadata.label
-          : active.name;
       // "Crowded room": more than one live sub-agent bound to this room.
-      const multiParty = sessions.filter(boundToRoom).length > 1;
-      const busy = isSessionBusy(active.status);
-      // What the sub-agent is working on, for the model classifier's relevance
-      // judgement — best-effort from session metadata (all optional).
-      const meta = (active.metadata ?? {}) as Record<string, unknown>;
-      const taskContext = [
-        meta.originalTask,
-        meta.task,
-        meta.goal,
-        meta.taskTitle,
-      ].find((v): v is string => typeof v === "string" && v.trim().length > 0);
-      const decision = await decideInterruptionWithModel(runtime, {
-        text,
-        agentType: active.agentType,
-        sessionBusy: busy,
-        multiParty,
-        ...(label ? { agentLabel: label } : {}),
-        ...(taskContext ? { taskContext } : {}),
-      });
-      runtime.logger?.debug?.(
-        {
-          src: SRC,
-          sessionId: active.id,
-          status: active.status,
-          busy,
+      const multiParty = bound.length > 1;
+      // Every bound live session gets its own interruption decision and its
+      // own delivery/queue — a room with several live sub-agents must not
+      // quietly forward the user's text to only the first in list order.
+      for (const active of bound) {
+        const label =
+          typeof active.metadata?.label === "string"
+            ? active.metadata.label
+            : active.name;
+        const busy = isSessionBusy(active.status);
+        // What the sub-agent is working on, for the model classifier's
+        // relevance judgement — best-effort from session metadata (all
+        // optional).
+        const meta = (active.metadata ?? {}) as Record<string, unknown>;
+        const taskContext = [
+          meta.originalTask,
+          meta.task,
+          meta.goal,
+          meta.taskTitle,
+        ].find(
+          (v): v is string => typeof v === "string" && v.trim().length > 0,
+        );
+        const decision = await decideInterruptionWithModel(runtime, {
+          text,
+          agentType: active.agentType,
+          sessionBusy: busy,
           multiParty,
-          action: decision.action,
-          reason: decision.reason,
-        },
-        "interruption decision",
-      );
+          ...(label ? { agentLabel: label } : {}),
+          ...(taskContext ? { taskContext } : {}),
+        });
+        runtime.logger?.debug?.(
+          {
+            src: SRC,
+            sessionId: active.id,
+            status: active.status,
+            busy,
+            multiParty,
+            action: decision.action,
+            reason: decision.reason,
+          },
+          "interruption decision",
+        );
 
-      // Deliver now (idle path): flush any queued messages, then this one.
-      // Requeue on failure (e.g. a racing busy transition) so the user's text
-      // is never silently dropped — the flush listener retries it.
-      const deliverNow = async (payload: string) => {
-        try {
-          await acp.sendPrompt(active.id, payload);
-        } catch (err) {
-          // error-policy:J4 sendPrompt failed → requeue for flush-listener retry; user text never dropped
-          subAgentInbox.enqueue(active.id, payload);
-          runtime.logger?.warn?.(
-            {
-              src: SRC,
-              sessionId: active.id,
-              err: err instanceof Error ? err.message : String(err),
-            },
-            "active-session forward failed; requeued for flush",
-          );
-        }
-      };
-
-      switch (decision.action) {
-        case "ignore":
-          return;
-        case "interrupt": {
-          if (!busy) {
-            // Nothing in flight to cancel — deliver the instruction to the idle
-            // agent instead of dropping it.
-            const queued = subAgentInbox.drain(active.id);
-            await deliverNow(queued ? `${queued}\n${text}` : text);
-            return;
-          }
-          // Cancel the in-flight turn (status → terminal `cancelled`). The
-          // planner pipeline runs on this same MESSAGE_RECEIVED and routes the
-          // user's redirect; we do not re-deliver to the dead session.
-          subAgentInbox.clear(active.id);
-          // error-policy:J6 best-effort session cancel on interrupt; warn only
-          await acp.cancelSession?.(active.id)?.catch?.((err: unknown) =>
+        // Deliver now (idle path): flush any queued messages, then this one.
+        // Requeue on failure (e.g. a racing busy transition) so the user's
+        // text is never silently dropped — the flush listener retries it.
+        const deliverNow = async (payload: string) => {
+          try {
+            await acp.sendPrompt(active.id, payload);
+          } catch (err) {
+            // error-policy:J4 sendPrompt failed → requeue for flush-listener retry; user text never dropped
+            subAgentInbox.enqueue(active.id, payload);
             runtime.logger?.warn?.(
               {
                 src: SRC,
                 sessionId: active.id,
                 err: err instanceof Error ? err.message : String(err),
               },
-              "interrupt cancel failed",
-            ),
-          );
-          return;
-        }
-        default: {
-          // deliver / queue. Mid-turn → queue for the flush listener; otherwise
-          // flush + deliver immediately.
-          if (busy) {
-            subAgentInbox.enqueue(active.id, text);
-            return;
+              "active-session forward failed; requeued for flush",
+            );
           }
-          const queued = subAgentInbox.drain(active.id);
-          await deliverNow(queued ? `${queued}\n${text}` : text);
-          return;
+        };
+
+        switch (decision.action) {
+          case "ignore":
+            continue;
+          case "interrupt": {
+            if (!busy) {
+              // Nothing in flight to cancel — deliver the instruction to the
+              // idle agent instead of dropping it.
+              const queued = subAgentInbox.drain(active.id);
+              await deliverNow(queued ? `${queued}\n${text}` : text);
+              continue;
+            }
+            // Cancel the in-flight turn (status → terminal `cancelled`). The
+            // planner pipeline runs on this same MESSAGE_RECEIVED and routes
+            // the user's redirect; we do not re-deliver to the dead session.
+            subAgentInbox.clear(active.id);
+            // error-policy:J6 best-effort session cancel on interrupt; warn only
+            await acp.cancelSession?.(active.id)?.catch?.((err: unknown) =>
+              runtime.logger?.warn?.(
+                {
+                  src: SRC,
+                  sessionId: active.id,
+                  err: err instanceof Error ? err.message : String(err),
+                },
+                "interrupt cancel failed",
+              ),
+            );
+            continue;
+          }
+          default: {
+            // deliver / queue. Mid-turn → queue for the flush listener;
+            // otherwise flush + deliver immediately.
+            if (busy) {
+              subAgentInbox.enqueue(active.id, text);
+              continue;
+            }
+            const queued = subAgentInbox.drain(active.id);
+            await deliverNow(queued ? `${queued}\n${text}` : text);
+          }
         }
       }
     } catch (err) {

--- a/plugins/plugin-agent-orchestrator/src/services/active-session-forward.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/active-session-forward.ts
@@ -132,11 +132,28 @@ export function createActiveSessionForwardHandler(
         ].find(
           (v): v is string => typeof v === "string" && v.trim().length > 0,
         );
+        // The message reached this session via its ORIGIN connector channel
+        // rather than a room dedicated to the task (task room / thread). The
+        // origin channel is shared with the orchestrator planner, so the
+        // decider must classify task-relevance there instead of
+        // blanket-delivering planner-directed messages into the sub-agent.
+        const originMatch =
+          message.roomId === meta.originRoomId ||
+          message.roomId === meta.sourceRoomId;
+        const dedicatedMatch =
+          message.roomId === meta.threadRoomId ||
+          message.roomId === meta.taskRoomId ||
+          // Sessions spawned without a distinct task room bind roomId to the
+          // origin channel itself; only then does roomId count as dedicated,
+          // preserving the pre-task-rooms delivery behavior.
+          (meta.taskRoomId === undefined && message.roomId === meta.roomId);
+        const sharedChannel = originMatch && !dedicatedMatch;
         const decision = await decideInterruptionWithModel(runtime, {
           text,
           agentType: active.agentType,
           sessionBusy: busy,
           multiParty,
+          sharedChannel,
           ...(label ? { agentLabel: label } : {}),
           ...(taskContext ? { taskContext } : {}),
         });
@@ -147,6 +164,7 @@ export function createActiveSessionForwardHandler(
             status: active.status,
             busy,
             multiParty,
+            sharedChannel,
             action: decision.action,
             reason: decision.reason,
           },

--- a/plugins/plugin-agent-orchestrator/src/services/interruption-decider.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/interruption-decider.ts
@@ -40,6 +40,16 @@ export interface InterruptionInput {
   shouldRespond?: "RESPOND" | "IGNORE" | "STOP";
   /** True when the room has participants beyond the user + this sub-agent. */
   multiParty?: boolean;
+  /**
+   * True when the message arrived via the session's ORIGIN connector channel
+   * (originRoomId/sourceRoomId) rather than a room dedicated to this task
+   * (task room / thread). The origin channel is shared with the orchestrator
+   * planner: most messages there are planner commands ("set a reminder",
+   * "cancel that"), not follow-ups for this coding task — blanket delivery
+   * would inject them into the sub-agent while the planner also processes
+   * them.
+   */
+  sharedChannel?: boolean;
   /** What the sub-agent is working on (task/goal), for the model classifier's
    *  relevance judgement. Ignored by the pure-regex {@link decideInterruption}. */
   taskContext?: string;
@@ -166,7 +176,15 @@ function buildInterruptionClassifierPrompt(input: InterruptionInput): string {
     : "IDLE (between turns)";
   const room = input.multiParty
     ? "multiple participants — a message may be directed at someone else, not this agent"
-    : "just the user and this agent";
+    : input.sharedChannel
+      ? "the user's MAIN channel, SHARED with the orchestrator planner agent — most messages here are commands for the planner (reminders, unrelated requests, other tasks), NOT for this coding sub-agent"
+      : "just the user and this agent";
+  const sharedChannelRule = input.sharedChannel
+    ? [
+        "",
+        'This channel is shared with the orchestrator planner. Choose "deliver"/"queue" ONLY when the message is a follow-up or instruction for THIS coding task (references the work, the code, the repo, or addresses the agent). Anything else — new unrelated requests, reminders, planner commands, general chat — is planner-owned: choose "ignore".',
+      ]
+    : [];
   return [
     "You are the interruption controller for an autonomous coding sub-agent in a shared chat room.",
     "A human just posted a message. Decide what to do with it relative to the sub-agent's IN-PROGRESS work.",
@@ -184,6 +202,7 @@ function buildInterruptionClassifierPrompt(input: InterruptionInput): string {
     '- "ignore": chatter not meant for this agent — acknowledgements ("nice", "thanks", "lgtm"), or (in a crowded room) messages addressed to someone else or unrelated to the task.',
     "",
     'Bias: a working sub-agent keeps working. Prefer "queue" over "interrupt" unless the message is a genuine halt or a direction-invalidating redirect. Never choose "interrupt" merely because the text contains the word "stop" — judge intent.',
+    ...sharedChannelRule,
     "",
     'Respond with ONLY a JSON object: {"action":"interrupt|queue|deliver|ignore","reason":"<short>"}',
   ].join("\n");
@@ -225,10 +244,16 @@ export async function decideInterruptionWithModel(
 ): Promise<InterruptionDecision> {
   const baseline = decideInterruption(input);
   if (!input.text.trim()) return baseline;
-  // Only a mid-turn agent (interrupt-vs-queue matters) or a crowded room
-  // (directed-vs-ambient matters) warrants a model call. An idle agent in a
-  // solo room simply receives the message.
-  if (!input.sessionBusy && !input.multiParty) return baseline;
+  // A mid-turn agent (interrupt-vs-queue matters), a crowded room
+  // (directed-vs-ambient matters), or a planner-shared channel
+  // (task-follow-up-vs-planner-command matters) warrants a model call. Only an
+  // idle agent in a solo DEDICATED room simply receives the message: on a
+  // shared channel the idle+solo fast-path would blanket-deliver every
+  // planner-directed message into the sub-agent (cross-task prompt injection),
+  // so the classifier must always run there.
+  if (!input.sessionBusy && !input.multiParty && !input.sharedChannel) {
+    return baseline;
+  }
   try {
     const raw = await runtime.useModel(ModelType.TEXT_SMALL, {
       prompt: buildInterruptionClassifierPrompt(input),
@@ -239,7 +264,12 @@ export async function decideInterruptionWithModel(
     );
     return verdict ?? baseline;
   } catch {
-    // error-policy:J4 model unavailable/unparseable → deterministic regex baseline; never regresses pure path
+    // error-policy:J4 model unavailable/unparseable → deterministic regex
+    // baseline (deliver when idle), INCLUDING on shared channels. Fail-open is
+    // deliberate: fail-closed would silently resurrect the dropped-follow-ups
+    // bug the origin-room binding exists to fix on every model-less runtime,
+    // while the planner double-processing that fail-open risks is bounded and
+    // visible (the planner's own reply shows what it did).
     return baseline;
   }
 }

--- a/plugins/plugin-agent-orchestrator/src/services/session-room-binding.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/session-room-binding.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared room-resolution ladder for ACP session metadata.
+ *
+ * The orchestrator mints a distinct per-task GROUP room (`taskRoomId`) and
+ * stamps it as the session's top-level `metadata.roomId`, while the user's
+ * live connector channel is carried on `originRoomId` (and, for some spawn
+ * paths, `sourceRoomId`). Any consumer that compares or targets a raw
+ * `meta.roomId` therefore diverges from where the user actually is. The
+ * router's `readOrigin` (sub-agent-router.ts) resolves the reply room as
+ * `originRoomId ?? sourceRoomId ?? taskRoomId ?? roomId`; this module is that
+ * same ladder extracted so the mid-task forwarder and the progress hook cannot
+ * drift from it (each used to re-derive its own subset and silently dropped
+ * origin-channel traffic). `session-room-binding.test.ts` pins the agreement
+ * with `readOrigin`.
+ */
+
+function pickRoomString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * The user-facing room narration/acks/replies should target, in the same
+ * precedence `readOrigin` uses for its reply room. Falls back to the raw
+ * `roomId` so sessions spawned without task rooms (or predating them) keep
+ * their original target.
+ */
+export function resolveOriginRoomId(
+  meta: Record<string, unknown> | undefined,
+): string | undefined {
+  if (!meta) return undefined;
+  return (
+    pickRoomString(meta.originRoomId) ??
+    pickRoomString(meta.sourceRoomId) ??
+    pickRoomString(meta.taskRoomId) ??
+    pickRoomString(meta.roomId)
+  );
+}
+
+/**
+ * Every room a live session is conversationally bound to: a user message in
+ * ANY of these rooms is a follow-up for this session. Covers the minted task
+ * room (`roomId`/`taskRoomId`), the origin connector channel
+ * (`originRoomId`/`sourceRoomId`), and the per-label thread (`threadRoomId`).
+ */
+export function sessionBoundRoomIds(
+  meta: Record<string, unknown> | undefined,
+): Set<string> {
+  const rooms = new Set<string>();
+  if (!meta) return rooms;
+  for (const key of [
+    "roomId",
+    "taskRoomId",
+    "originRoomId",
+    "sourceRoomId",
+    "threadRoomId",
+  ]) {
+    const value = pickRoomString(meta[key]);
+    if (value) rooms.add(value);
+  }
+  return rooms;
+}

--- a/plugins/plugin-agent-orchestrator/src/services/session-room-binding.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/session-room-binding.ts
@@ -8,16 +8,20 @@
  * `meta.roomId` therefore diverges from where the user actually is. The
  * router's `readOrigin` (sub-agent-router.ts) resolves the reply room as
  * `originRoomId ?? sourceRoomId ?? taskRoomId ?? roomId`; this module is that
- * same ladder extracted so the mid-task forwarder and the progress hook cannot
- * drift from it (each used to re-derive its own subset and silently dropped
- * origin-channel traffic). `session-room-binding.test.ts` pins the agreement
- * with `readOrigin`.
+ * same ladder — including readOrigin's UUID validation — extracted so the
+ * mid-task forwarder and the progress hook cannot drift from it (each used to
+ * re-derive its own subset and silently dropped origin-channel traffic).
+ * `session-room-binding.test.ts` pins the agreement with `readOrigin`.
  */
 
-function pickRoomString(value: unknown): string | undefined {
-  if (typeof value !== "string") return undefined;
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : undefined;
+import type { UUID } from "@elizaos/core";
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function pickRoomUuid(value: unknown): UUID | undefined {
+  if (typeof value !== "string" || !UUID_PATTERN.test(value)) return undefined;
+  return value as UUID;
 }
 
 /**
@@ -28,13 +32,13 @@ function pickRoomString(value: unknown): string | undefined {
  */
 export function resolveOriginRoomId(
   meta: Record<string, unknown> | undefined,
-): string | undefined {
+): UUID | undefined {
   if (!meta) return undefined;
   return (
-    pickRoomString(meta.originRoomId) ??
-    pickRoomString(meta.sourceRoomId) ??
-    pickRoomString(meta.taskRoomId) ??
-    pickRoomString(meta.roomId)
+    pickRoomUuid(meta.originRoomId) ??
+    pickRoomUuid(meta.sourceRoomId) ??
+    pickRoomUuid(meta.taskRoomId) ??
+    pickRoomUuid(meta.roomId)
   );
 }
 
@@ -46,8 +50,8 @@ export function resolveOriginRoomId(
  */
 export function sessionBoundRoomIds(
   meta: Record<string, unknown> | undefined,
-): Set<string> {
-  const rooms = new Set<string>();
+): Set<UUID> {
+  const rooms = new Set<UUID>();
   if (!meta) return rooms;
   for (const key of [
     "roomId",
@@ -56,7 +60,7 @@ export function sessionBoundRoomIds(
     "sourceRoomId",
     "threadRoomId",
   ]) {
-    const value = pickRoomString(meta[key]);
+    const value = pickRoomUuid(meta[key]);
     if (value) rooms.add(value);
   }
   return rooms;

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-inbox.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-inbox.ts
@@ -6,17 +6,41 @@
  * sub-agent the moment it returns to an idle state. This keeps a working
  * sub-agent from being derailed mid-turn while guaranteeing the human's message
  * is still delivered — the "continue without interruption unless required"
- * contract.
+ * contract. Overflow past the cap drops the oldest entries; the drop is
+ * surfaced through {@link SubAgentInbox.setOverflowObserver} (wired to the
+ * runtime logger + reportError in index.ts) because a silently vanished user
+ * message reads as a healthy pipeline when it is not.
  */
 
 const DEFAULT_CAP = 16;
 
+/**
+ * Called when enqueue drops entries past the cap. `droppedNow` is the count
+ * dropped by this enqueue; `droppedTotal` the session's cumulative drops.
+ */
+export type InboxOverflowObserver = (
+  sessionId: string,
+  droppedNow: number,
+  droppedTotal: number,
+) => void;
+
 export class SubAgentInbox {
   private readonly pending = new Map<string, string[]>();
+  private readonly droppedTotals = new Map<string, number>();
   private readonly cap: number;
+  private onOverflow: InboxOverflowObserver | undefined;
 
   constructor(cap: number = DEFAULT_CAP) {
     this.cap = Math.max(1, cap);
+  }
+
+  /**
+   * Register the overflow observer. The inbox is constructed at plugin-factory
+   * scope before any runtime exists, so the runtime-bound warn/reportError
+   * hookup happens later, in plugin init.
+   */
+  setOverflowObserver(observer: InboxOverflowObserver | undefined): void {
+    this.onOverflow = observer;
   }
 
   /** Queue a message for a session. Oldest entries drop past the cap. */
@@ -25,12 +49,27 @@ export class SubAgentInbox {
     if (!trimmed) return;
     const queue = this.pending.get(sessionId) ?? [];
     queue.push(trimmed);
-    while (queue.length > this.cap) queue.shift();
+    let droppedNow = 0;
+    while (queue.length > this.cap) {
+      queue.shift();
+      droppedNow += 1;
+    }
     this.pending.set(sessionId, queue);
+    if (droppedNow > 0) {
+      const droppedTotal =
+        (this.droppedTotals.get(sessionId) ?? 0) + droppedNow;
+      this.droppedTotals.set(sessionId, droppedTotal);
+      this.onOverflow?.(sessionId, droppedNow, droppedTotal);
+    }
   }
 
   size(sessionId: string): number {
     return this.pending.get(sessionId)?.length ?? 0;
+  }
+
+  /** Cumulative count of messages dropped past the cap for a session. */
+  droppedCount(sessionId: string): number {
+    return this.droppedTotals.get(sessionId) ?? 0;
   }
 
   /**
@@ -46,9 +85,11 @@ export class SubAgentInbox {
 
   clear(sessionId: string): void {
     this.pending.delete(sessionId);
+    this.droppedTotals.delete(sessionId);
   }
 
   clearAll(): void {
     this.pending.clear();
+    this.droppedTotals.clear();
   }
 }

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -2759,7 +2759,18 @@ function swarmTargetsForRouting(
   routingKind: string,
 ): SwarmRoomTarget[] {
   if (routingKind === QUESTION_FOR_TASK_CREATOR) {
-    return [targetForRoom(origin, origin.taskRoomId, "task")];
+    // The task creator is the USER in the origin channel, not the planner in
+    // the minted task room. Route to both: the task room keeps the question in
+    // planner context, and the origin room leg carries the reply callback that
+    // actually surfaces the blocked sub-agent's question to the user (with
+    // task rooms on by default the two differ, so a task-room-only post never
+    // reached the user's channel). Deduped when the origin room IS the task
+    // room.
+    const targets = [targetForRoom(origin, origin.taskRoomId, "task")];
+    if (origin.roomId !== origin.taskRoomId) {
+      targets.push(targetForRoom(origin, origin.roomId, "origin"));
+    }
+    return targets;
   }
   if (routingKind === AGENT_COORDINATION) {
     const roomId = origin.worktreeRoomId ?? origin.taskRoomId;

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -1571,6 +1571,19 @@ export class SubAgentRouter extends Service {
     }
     const routingKind = routingKindForEvent(event, data, capExceeded);
     const targets = swarmTargetsForRouting(origin, routingKind);
+    // User-facing leg of a blocked sub-agent's question: with per-task GROUP
+    // rooms on by default the task room maps to no live connector channel, so
+    // the planner-turn post above never reaches the user. Post the question
+    // directly to the origin channel (same mechanism the progress hook uses) —
+    // deliberately NOT a second handleMessage planner turn, which would
+    // double-answer the question into the same room. Skipped when the origin
+    // room IS the task room (the planner turn's post already lands there).
+    if (
+      routingKind === QUESTION_FOR_TASK_CREATOR &&
+      origin.roomId !== origin.taskRoomId
+    ) {
+      await this.postQuestionToOriginRoom(origin, sessionId, text);
+    }
     // Legacy-entity sweep, delivery leg (#15102): every room this event posts
     // to gets swept once per process — covers the task/worktree swarm rooms
     // the spawn-time probe (origin room only) doesn't reach. Memoized, so
@@ -1760,6 +1773,55 @@ export class SubAgentRouter extends Service {
     // (issue elizaOS/eliza#7967); same-session progressive task_completes are
     // unaffected because the claim is keyed by sessionId, and a verify-retry
     // handoff returns earlier (above) so an incomplete build never claims.
+  }
+
+  /**
+   * Direct origin-channel post for a QUESTION_FOR_TASK_CREATOR event. The
+   * question is shown verbatim, attributed to the sub-agent with the same
+   * `❓ [label]` marker family the progress hook uses, so the user can answer
+   * in the channel and the mid-task forward handler routes the reply back to
+   * the session. The planner-directed `[sub-agent: …]` header is stripped —
+   * it is relay guidance for the task-room turn, not user prose.
+   */
+  private async postQuestionToOriginRoom(
+    origin: OriginInfo,
+    sessionId: string,
+    text: string,
+  ): Promise<void> {
+    const sendToTarget = (
+      this.runtime as RuntimeWithSendTarget
+    ).sendMessageToTarget?.bind(this.runtime);
+    if (!sendToTarget || !origin.source) {
+      this.log(
+        "warn",
+        "cannot post sub-agent question to origin room (no connector send path)",
+        { sessionId, roomId: origin.roomId, source: origin.source },
+      );
+      return;
+    }
+    const body = stripSubAgentHeaderLine(text).trim() || text.trim();
+    const originReplyTarget =
+      origin.parentConnectorMessageId ?? origin.parentMessageId;
+    await sendToTarget(
+      { source: origin.source, roomId: origin.roomId },
+      {
+        text: `❓ [${origin.label}] ${body}`,
+        // Same source the router stamps on its posts: the mid-task forward
+        // handler skips it (echo-loop guard), so the question is never fed
+        // back into the asking session as a prompt.
+        source: ACPX_ROUTER_SOURCE,
+        ...(originReplyTarget ? { inReplyTo: originReplyTarget } : {}),
+      },
+    ).catch((err) => {
+      // error-policy:J1 question-delivery boundary; the failure is warned and
+      // the task-room planner turn remains the surviving leg.
+      this.log("warn", "sub-agent question delivery to origin room failed", {
+        sessionId,
+        source: origin.source,
+        roomId: origin.roomId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
   }
 
   private buildReplyCallback(
@@ -2759,18 +2821,12 @@ function swarmTargetsForRouting(
   routingKind: string,
 ): SwarmRoomTarget[] {
   if (routingKind === QUESTION_FOR_TASK_CREATOR) {
-    // The task creator is the USER in the origin channel, not the planner in
-    // the minted task room. Route to both: the task room keeps the question in
-    // planner context, and the origin room leg carries the reply callback that
-    // actually surfaces the blocked sub-agent's question to the user (with
-    // task rooms on by default the two differ, so a task-room-only post never
-    // reached the user's channel). Deduped when the origin room IS the task
-    // room.
-    const targets = [targetForRoom(origin, origin.taskRoomId, "task")];
-    if (origin.roomId !== origin.taskRoomId) {
-      targets.push(targetForRoom(origin, origin.roomId, "origin"));
-    }
-    return targets;
+    // ONE planner turn, in the task room only. The user-facing leg is a
+    // DIRECT origin-channel post (postQuestionToOriginRoom in handleEvent):
+    // adding the origin room here would run a second full handleMessage
+    // planner turn whose reply callback targets the same origin room —
+    // double-answering one question.
+    return [targetForRoom(origin, origin.taskRoomId, "task")];
   }
   if (routingKind === AGENT_COORDINATION) {
     const roomId = origin.worktreeRoomId ?? origin.taskRoomId;

--- a/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
@@ -682,6 +682,17 @@ export class SwarmCoordinatorService
     event: string,
     data: unknown,
   ): Promise<void> {
+    // Snapshot router liveness NOW, before any await. AcpService fans events
+    // out synchronously to whoever is subscribed at emit time, and never
+    // replays: the router received this exact event iff it was bound at this
+    // instant. The cede decision in runSwarmComplete runs later (behind
+    // metadata awaits and the per-session terminal chain), and reading
+    // isActive() there raced the router's bind-retry window both ways —
+    // ceding to a router that bound AFTER the event (which therefore never
+    // received it → completion lost) or double-posting around a router
+    // teardown. The receipt-time snapshot makes the decision agree with what
+    // the router actually saw.
+    const routerActiveAtReceipt = this.isRouterActive();
     // A non-terminal event means the session resumed: a follow-up prompt turn
     // reuses the same session (task_complete fires at the end of every turn, then
     // the session returns to a non-terminal status and accepts more input). Cancel
@@ -724,7 +735,12 @@ export class SwarmCoordinatorService
     };
     this.updateLegacyTaskContext(sessionId, event, enrichedData);
     this.dispatchSwarmEvent(swarmEvent);
-    await this.maybeFireSwarmComplete(sessionId, event, enrichedData);
+    await this.maybeFireSwarmComplete(
+      sessionId,
+      event,
+      enrichedData,
+      routerActiveAtReceipt,
+    );
 
     if (event === "blocked" || event === "login_required") {
       void this.maybeRouteAgentDecision(sessionId, event, enrichedData);
@@ -815,6 +831,7 @@ export class SwarmCoordinatorService
     sessionId: string,
     event: string,
     data: unknown,
+    routerActiveAtReceipt: boolean,
   ): Promise<void> {
     const prior =
       this.terminalCompletionChains.get(sessionId) ?? Promise.resolve();
@@ -823,7 +840,9 @@ export class SwarmCoordinatorService
       // awaited it; this catch only keeps the per-session completion chain alive
       // so one failed completion cannot wedge later ones.
       .catch(() => {})
-      .then(() => this.runSwarmComplete(sessionId, event, data));
+      .then(() =>
+        this.runSwarmComplete(sessionId, event, data, routerActiveAtReceipt),
+      );
     this.terminalCompletionChains.set(sessionId, next);
     void next.finally(() => {
       if (this.terminalCompletionChains.get(sessionId) === next) {
@@ -837,6 +856,7 @@ export class SwarmCoordinatorService
     sessionId: string,
     event: string,
     data: unknown,
+    routerActiveAtReceipt: boolean,
   ): Promise<void> {
     const cb = this.swarmCompleteCallback;
     if (!cb) return;
@@ -956,7 +976,10 @@ export class SwarmCoordinatorService
       routerOwnedEvent: ROUTER_OWNED_TERMINAL_EVENTS.has(event),
       customValidator: isCustomValidatorResult(record),
       hasRouterOrigin: sessionHasRouterOrigin(meta),
-      routerActive: this.isRouterActive(),
+      // Receipt-time snapshot, NOT a live isActive() read: the router owns
+      // this terminal only if it was bound when the event fanned out (see
+      // handleAcpEvent). A live read here races the router's bind window.
+      routerActive: routerActiveAtReceipt,
     };
     logger.debug(
       `[SwarmCoordinatorService] cede decision (sessionId=${sessionId}, event=${event}, ` +
@@ -1391,7 +1414,14 @@ export class SwarmCoordinatorService
       timestamp: Date.now(),
       data,
     });
-    await this.maybeFireSwarmComplete(sessionId, event, data);
+    // Validator results are exempt from ceding (customValidator gate), so the
+    // router-activity snapshot is inert here; pass the live read for the log.
+    await this.maybeFireSwarmComplete(
+      sessionId,
+      event,
+      data,
+      this.isRouterActive(),
+    );
   }
 
   /**


### PR DESCRIPTION
"## Problem\n\nWith per-task GROUP rooms on by default, the ACP session's `metadata.roomId` is the minted task-room UUID while the user types in the origin connector channel. Every consumer that read the raw `roomId` diverged from the router's origin ladder:\n\n- **Mid-task user follow-ups were silently never forwarded** to the running sub-agent — `boundToRoom` in `active-session-forward.ts` matched only `meta.roomId`/`meta.threadRoomId`, neither of which is the origin room once a task room is minted.\n- **Live progress (acks/heartbeats/narration) targeted the minted GROUP room**, which is not a live connector channel; sends failed and were demoted to debug after the first warn — the user often saw nothing between spawn and completion.\n- **`QUESTION_FOR_TASK_CREATOR` landed only in the task room** — a blocked sub-agent's question never directly reached the user.\n- Multi-session rooms forwarded only to the **first** bound session; inbox overflow **silently dropped** the oldest queued message; and a bind-retry-window race between `SubAgentRouter` and `SwarmCoordinatorService` could double-post or lose a completion.\n\n## Fix\n\n- New `session-room-binding.ts`: shared origin ladder (`resolveOriginRoomId`) + bound-room set (`sessionBoundRoomIds`) used by the forward handler and the progress hook, with an anti-drift contract test pinning agreement with the router's `readOrigin` across all metadata shapes.\n- Forward handler binds on the full session room set (task/origin/source/thread) and delivers to **all** bound live sessions with a per-session interruption decision.\n- Progress hook resolves emit targets through the origin ladder, so acks/heartbeats/narration reach the user's actual channel.\n- `QUESTION_FOR_TASK_CREATOR` routes to BOTH the task room (planner context) and the origin room (user-facing leg), deduped when they are equal.\n- `SubAgentInbox` overflow surfaces dropped counts via an observer wired to `logger.warn` + `runtime.reportError` — no silent drops.\n- Swarm coordinator cede decision uses a **receipt-time router-activity snapshot** instead of a post-await `isActive()` read. (Ceding to a still-binding router would lose the event outright — ACP fan-out has no replay — so the snapshot closes the double-post race in both directions; regression tests cover bind-during-gap and unbind-during-gap.)\n\n## Evidence\n\n- Targeted suites (6 files): **191/191 passed**. Full plugin unit lane: **141 files / 1578 tests passed**.\n- Merged-integration check (this branch + `fix/orchestrator-completion-gating` + `test/orchestrator-delarp-scenarios` on develop): full orchestrator suite **201 files / 2142 tests passed**; pr-deterministic scenario lane **13/13 passed**, including the new `orchestrator-follow-up-forwarding` (origin-room follow-up delivered/queued/ignored matrix) and `orchestrator-question-for-creator` scenarios that drive the real forward handler and real router.\n- `bun run audit:error-policy-ratchet`: no new fallback-slop in touched files. Biome clean.\n- Real-LLM trajectories: N/A — no prompt/model-behavior change; routing/plumbing only, covered by deterministic scenario drives of the real router/forwarder.\n- Screenshots/video: N/A — no UI surface changed.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\\n\\n## Evidence Gate\\n\\n<!-- evidence-row:before-screenshots -->\\n- [x] Before screenshots: N/A - backend orchestrator routing only; no rendered UI changed.\\n<!-- evidence-row:after-screenshots -->\\n- [x] After screenshots: N/A - backend orchestrator routing only; no rendered UI changed.\\n<!-- evidence-row:walkthrough-video -->\\n- [x] Walkthrough video: N/A - no visual interaction changed.\\n<!-- evidence-row:backend-logs -->\\n- [x] Backend logs: [reviewed focused Vitest report](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16254-orchestrator-focused-vitest.json) records 197/197 passing route, forwarding, inbox, question, and coordinator assertions.\\n<!-- evidence-row:frontend-logs -->\\n- [x] Frontend console/network logs: N/A - no frontend or network client code changed.\\n<!-- evidence-row:llm-trajectory -->\\n- [x] Real-LLM trajectory: [exact OpenAI interruption-controller prompts and responses](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16255-routing-live-model-io.jsonl) prove unrelated reminder -> ignore, idle task follow-up -> deliver, and mid-turn task follow-up -> queue.\\n<!-- evidence-row:domain-artifacts -->\\n- [x] Domain artifacts: [live scenario matrix](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16254-55-live-matrix.json) records 2/2 passed, including origin-channel classification; the focused report above proves the deterministic real-router and persistence invariants.\\n\\nThe live scenario artifacts came from [workflow run 29226497574](https://github.com/elizaOS/eliza/actions/runs/29226497574). The two target orchestrator scenarios passed; unrelated health/app-control jobs later failed, so the linked target artifacts—not the aggregate workflow conclusion—are the reviewed evidence.\\n"
