### PR TITLE
fix(cloud): make CLI auth completion atomic

### DIFF
--- a/packages/cloud/api/auth/cli-session/[sessionId]/complete/route.integration.test.ts
+++ b/packages/cloud/api/auth/cli-session/[sessionId]/complete/route.integration.test.ts
@@ -1,4 +1,4 @@
-/** Drives CLI-session re-completion through the real route, service, repositories, and PGlite; only the authenticated request identity and logger are controlled. */
+/** Drives CLI-session re-completion through the real route, service, DB transaction, KMS boundary, and PGlite; auth/logger are controlled, and the race test barriers the real primary read. */
 import {
   afterAll,
   beforeAll,
@@ -6,6 +6,7 @@ import {
   describe,
   expect,
   mock,
+  spyOn,
   test,
 } from "bun:test";
 import { Hono } from "hono";
@@ -19,10 +20,18 @@ const OTHER_USER_ID = "22222222-2222-4222-8222-222222222222";
 const ORG_ID = "33333333-3333-4333-8333-333333333333";
 const API_KEY_ID = "44444444-4444-4444-8444-444444444444";
 
+interface CompleteResponseBody {
+  alreadyAuthenticated: boolean;
+  apiKey: string | null;
+  keyPrefix: string | null;
+}
+
 let currentUserId = USER_ID;
 mock.module("@/lib/auth/workers-hono-auth", () => ({
-  requireUserWithOrg: async () => ({
-    id: currentUserId,
+  requireUserWithOrg: async (context: {
+    req: { header: (name: string) => string | undefined };
+  }) => ({
+    id: context.req.header("x-test-user-id") ?? currentUserId,
     organization_id: ORG_ID,
   }),
 }));
@@ -31,6 +40,7 @@ mock.module("@/lib/utils/logger", () => ({
 }));
 
 let dbWrite: typeof import("../../../../../shared/src/db/client").dbWrite;
+let cliAuthSessionCompletionService: typeof import("../../../../../shared/src/lib/services/cli-auth-session-completion").cliAuthSessionCompletionService;
 let closeDb:
   | typeof import("../../../../../shared/src/db/client").closeDatabaseConnectionsForTests
   | undefined;
@@ -39,6 +49,9 @@ let app: Hono;
 beforeAll(async () => {
   ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import(
     "../../../../../shared/src/db/client"
+  ));
+  ({ cliAuthSessionCompletionService } = await import(
+    "../../../../../shared/src/lib/services/cli-auth-session-completion"
   ));
   await dbWrite.execute(`CREATE TABLE api_keys (
     id uuid PRIMARY KEY, name text NOT NULL, description text, key_hash text NOT NULL UNIQUE,
@@ -84,10 +97,59 @@ async function seedSession(
       now() + interval '10 minutes', now())`);
 }
 
-async function complete(sessionId: string): Promise<Response> {
+async function seedPendingSession(sessionId: string): Promise<void> {
+  await dbWrite.execute(`INSERT INTO cli_auth_sessions
+    (session_id, status, expires_at)
+    VALUES ('${sessionId}', 'pending', now() + interval '10 minutes')`);
+}
+
+async function complete(
+  sessionId: string,
+  userId = currentUserId,
+): Promise<Response> {
   return app.request(`/api/auth/cli-session/${sessionId}/complete`, {
     method: "POST",
+    headers: { "x-test-user-id": userId },
   });
+}
+
+async function afterConcurrentPendingReads<T>(
+  run: () => Promise<T>,
+): Promise<{ result: T; reads: number }> {
+  const findActive = cliAuthSessionCompletionService.findActive.bind(
+    cliAuthSessionCompletionService,
+  );
+  let reads = 0;
+  let releaseReads: () => void = () => {};
+  const bothRead = new Promise<void>((resolve) => {
+    releaseReads = resolve;
+  });
+  let barrierTimer: ReturnType<typeof setTimeout> | undefined;
+  const barrierTimeout = new Promise<never>((_, reject) => {
+    barrierTimer = setTimeout(
+      () => reject(new Error("Timed out waiting for concurrent primary reads")),
+      5_000,
+    );
+  });
+  const readGate = Promise.race([bothRead, barrierTimeout]);
+  const readBarrier = spyOn(
+    cliAuthSessionCompletionService,
+    "findActive",
+  ).mockImplementation(async (sessionId) => {
+    const session = await findActive(sessionId);
+    reads += 1;
+    if (reads === 2) releaseReads();
+    await readGate;
+    return session;
+  });
+
+  try {
+    const result = await run();
+    return { result, reads };
+  } finally {
+    if (barrierTimer) clearTimeout(barrierTimer);
+    readBarrier.mockRestore();
+  }
 }
 
 describe("CLI session completion with real persistence", () => {
@@ -105,6 +167,91 @@ describe("CLI session completion with real persistence", () => {
       "SELECT count(*)::int AS count FROM api_keys",
     );
     expect(count.rows[0]).toMatchObject({ count: 1 });
+  });
+
+  test("concurrent completions atomically mint exactly one API key", async () => {
+    await seedPendingSession("concurrent");
+
+    // Wrap the real primary read with a barrier so both requests have observed
+    // the same pending row before either can attempt the conditional claim.
+    // This forces the race deterministically instead of relying on scheduler
+    // timing while preserving the real route/service/DB/KMS path.
+    const {
+      result: [first, second],
+      reads,
+    } = await afterConcurrentPendingReads(() =>
+      Promise.all([complete("concurrent"), complete("concurrent")]),
+    );
+    expect(reads).toBe(2);
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+
+    const bodies = (await Promise.all([
+      first.json(),
+      second.json(),
+    ])) as CompleteResponseBody[];
+    expect(bodies.map((body) => body.alreadyAuthenticated).sort()).toEqual([
+      false,
+      true,
+    ]);
+    const winner = bodies.find((body) => !body.alreadyAuthenticated);
+    const retry = bodies.find((body) => body.alreadyAuthenticated);
+    expect(winner?.apiKey).toStartWith("eliza_");
+    expect(retry?.apiKey).toBeNull();
+    expect(retry?.keyPrefix).toBe(winner?.keyPrefix);
+
+    const keys = await dbWrite.execute(
+      "SELECT id, is_active FROM api_keys ORDER BY created_at, id",
+    );
+    // beforeEach seeds one existing key; the two racing calls add exactly one.
+    expect(keys.rows).toHaveLength(2);
+    expect(keys.rows.every((row) => row.is_active === true)).toBe(true);
+
+    const session = await dbWrite.execute(
+      "SELECT status, user_id, api_key_id FROM cli_auth_sessions WHERE session_id = 'concurrent'",
+    );
+    expect(session.rows[0]).toMatchObject({
+      status: "authenticated",
+      user_id: USER_ID,
+    });
+    expect(
+      keys.rows.some((row) => row.id === session.rows[0]?.api_key_id),
+    ).toBe(true);
+  });
+
+  test("concurrent different-user completions persist only the winner's key", async () => {
+    await seedPendingSession("cross-user-race");
+
+    const { result: responses, reads } = await afterConcurrentPendingReads(() =>
+      Promise.all([
+        complete("cross-user-race", USER_ID),
+        complete("cross-user-race", OTHER_USER_ID),
+      ]),
+    );
+
+    expect(reads).toBe(2);
+    expect(responses.map((response) => response.status).sort()).toEqual([
+      200, 400,
+    ]);
+    const winnerIndex = responses.findIndex(
+      (response) => response.status === 200,
+    );
+    const winnerId = winnerIndex === 0 ? USER_ID : OTHER_USER_ID;
+    expect(JSON.stringify(await responses[1 - winnerIndex]?.json())).toContain(
+      "Session already authenticated or expired",
+    );
+
+    const keys = await dbWrite.execute(
+      `SELECT id, user_id FROM api_keys WHERE id <> '${API_KEY_ID}'`,
+    );
+    expect(keys.rows).toEqual([expect.objectContaining({ user_id: winnerId })]);
+    const session = await dbWrite.execute(
+      "SELECT user_id, api_key_id FROM cli_auth_sessions WHERE session_id = 'cross-user-race'",
+    );
+    expect(session.rows[0]).toMatchObject({
+      user_id: winnerId,
+      api_key_id: keys.rows[0]?.id,
+    });
   });
 
   test.each([

--- a/packages/cloud/api/auth/cli-session/[sessionId]/complete/route.integration.test.ts
+++ b/packages/cloud/api/auth/cli-session/[sessionId]/complete/route.integration.test.ts
@@ -32,7 +32,7 @@ interface CompleteResponseBody {
 
 let currentUserId = USER_ID;
 mock.module("@/lib/auth/workers-hono-auth", () => ({
-  requireUserWithOrg: async (context: {
+  requireUserOrApiKeyWithOrg: async (context: {
     req: { header: (name: string) => string | undefined };
   }) => ({
     id: context.req.header("x-test-user-id") ?? currentUserId,

--- a/packages/cloud/api/auth/cli-session/[sessionId]/complete/route.integration.test.ts
+++ b/packages/cloud/api/auth/cli-session/[sessionId]/complete/route.integration.test.ts
@@ -1,4 +1,7 @@
-/** Drives CLI-session re-completion through the real route, service, DB transaction, KMS boundary, and PGlite; auth/logger are controlled, and the race test barriers the real primary read. */
+/**
+ * Drives CLI-session completion through the real route, transaction, and KMS
+ * boundary against PGlite by default and PostgreSQL when configured.
+ */
 import {
   afterAll,
   beforeAll,
@@ -11,8 +14,10 @@ import {
 } from "bun:test";
 import { Hono } from "hono";
 
-process.env.DATABASE_URL = "pglite://memory";
-process.env.TEST_DATABASE_URL = "pglite://memory";
+const databaseUrl =
+  process.env.CLI_AUTH_POSTGRES_URL?.trim() || "pglite://memory";
+process.env.DATABASE_URL = databaseUrl;
+process.env.TEST_DATABASE_URL = databaseUrl;
 process.env.NODE_ENV ||= "test";
 
 const USER_ID = "11111111-1111-4111-8111-111111111111";
@@ -22,8 +27,7 @@ const API_KEY_ID = "44444444-4444-4444-8444-444444444444";
 
 interface CompleteResponseBody {
   alreadyAuthenticated: boolean;
-  apiKey: string | null;
-  keyPrefix: string | null;
+  keyPrefix: string;
 }
 
 let currentUserId = USER_ID;
@@ -41,6 +45,7 @@ mock.module("@/lib/utils/logger", () => ({
 
 let dbWrite: typeof import("../../../../../shared/src/db/client").dbWrite;
 let cliAuthSessionCompletionService: typeof import("../../../../../shared/src/lib/services/cli-auth-session-completion").cliAuthSessionCompletionService;
+let apiKeysService: typeof import("../../../../../shared/src/lib/services/api-keys").apiKeysService;
 let closeDb:
   | typeof import("../../../../../shared/src/db/client").closeDatabaseConnectionsForTests
   | undefined;
@@ -52,6 +57,9 @@ beforeAll(async () => {
   ));
   ({ cliAuthSessionCompletionService } = await import(
     "../../../../../shared/src/lib/services/cli-auth-session-completion"
+  ));
+  ({ apiKeysService } = await import(
+    "../../../../../shared/src/lib/services/api-keys"
   ));
   await dbWrite.execute(`CREATE TABLE api_keys (
     id uuid PRIMARY KEY, name text NOT NULL, description text, key_hash text NOT NULL UNIQUE,
@@ -160,7 +168,6 @@ describe("CLI session completion with real persistence", () => {
     expect(await response.json()).toMatchObject({
       success: true,
       alreadyAuthenticated: true,
-      apiKey: null,
       keyPrefix: "eliza_cli",
     });
     const count = await dbWrite.execute(
@@ -196,9 +203,8 @@ describe("CLI session completion with real persistence", () => {
     ]);
     const winner = bodies.find((body) => !body.alreadyAuthenticated);
     const retry = bodies.find((body) => body.alreadyAuthenticated);
-    expect(winner?.apiKey).toStartWith("eliza_");
-    expect(retry?.apiKey).toBeNull();
     expect(retry?.keyPrefix).toBe(winner?.keyPrefix);
+    expect(bodies.every((body) => !("apiKey" in body))).toBe(true);
 
     const keys = await dbWrite.execute(
       "SELECT id, is_active FROM api_keys ORDER BY created_at, id",
@@ -264,6 +270,57 @@ describe("CLI session completion with real persistence", () => {
     expect(JSON.stringify(await response.json())).toContain(
       "Session already authenticated or expired",
     );
+  });
+
+  test("rolls back the session claim when API-key insertion fails", async () => {
+    await seedPendingSession("insert-failure");
+    const generate = spyOn(apiKeysService, "generateApiKey").mockReturnValue({
+      key: "eliza_duplicate_plaintext",
+      hash: "hash",
+      prefix: "eliza_duplicate",
+    });
+
+    try {
+      const response = await complete("insert-failure");
+      expect(response.status).toBe(500);
+    } finally {
+      generate.mockRestore();
+    }
+
+    const session = await dbWrite.execute(
+      "SELECT status, user_id, api_key_id, authenticated_at FROM cli_auth_sessions WHERE session_id = 'insert-failure'",
+    );
+    expect(session.rows[0]).toMatchObject({
+      status: "pending",
+      user_id: null,
+      api_key_id: null,
+      authenticated_at: null,
+    });
+    const keys = await dbWrite.execute(
+      "SELECT count(*)::int AS count FROM api_keys",
+    );
+    expect(keys.rows[0]).toMatchObject({ count: 1 });
+  });
+
+  test.each([
+    [
+      "missing-key-reference",
+      "UPDATE cli_auth_sessions SET api_key_id = NULL WHERE session_id = 'missing-key-reference'",
+    ],
+    ["missing-key-row", `DELETE FROM api_keys WHERE id = '${API_KEY_ID}'`],
+    [
+      "mismatched-key-owner",
+      `UPDATE api_keys SET user_id = '${OTHER_USER_ID}' WHERE id = '${API_KEY_ID}'`,
+    ],
+  ])("fails closed for authenticated session integrity defect: %s", async (sessionId, mutation) => {
+    await seedSession(sessionId, USER_ID);
+    await dbWrite.execute(mutation);
+
+    const response = await complete(sessionId);
+    expect(response.status).toBe(500);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.success).not.toBe(true);
+    expect(JSON.stringify(body)).not.toContain("eliza_cli");
   });
 
   test("rejects a missing session", async () => {

--- a/packages/cloud/api/auth/cli-session/[sessionId]/complete/route.ts
+++ b/packages/cloud/api/auth/cli-session/[sessionId]/complete/route.ts
@@ -33,7 +33,6 @@ app.post("/", async (c) => {
 
     return c.json({
       success: true,
-      apiKey: result.apiKey,
       keyPrefix: result.keyPrefix,
       expiresAt: result.expiresAt,
       // Idempotent completion: true when this call found the session already

--- a/packages/cloud/api/auth/cli-session/[sessionId]/complete/route.ts
+++ b/packages/cloud/api/auth/cli-session/[sessionId]/complete/route.ts
@@ -1,7 +1,8 @@
 /**
  * POST /api/auth/cli-session/[sessionId]/complete
- * Complete CLI authentication for a session. Called by the web UI after
- * the user logs in.
+ * Completes a pending CLI login after an authenticated user approves it in
+ * the web UI. Session and API-key authentication share the same ownership
+ * checks so headless clients can exercise the production boundary too.
  */
 
 import { Hono } from "hono";
@@ -9,7 +10,7 @@ import {
   failureResponse,
   ValidationError,
 } from "@/lib/api/cloud-worker-errors";
-import { requireUserWithOrg } from "@/lib/auth/workers-hono-auth";
+import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { cliAuthSessionsService } from "@/lib/services/cli-auth-sessions";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -23,7 +24,7 @@ app.post("/", async (c) => {
       return c.json({ error: "Session ID is required" }, 400);
     }
 
-    const user = await requireUserWithOrg(c);
+    const user = await requireUserOrApiKeyWithOrg(c);
 
     const result = await cliAuthSessionsService.completeAuthentication(
       sessionId,

--- a/packages/cloud/shared/src/lib/services/cli-auth-session-completion.ts
+++ b/packages/cloud/shared/src/lib/services/cli-auth-session-completion.ts
@@ -1,0 +1,142 @@
+/** Primary-consistent, single-winner persistence for CLI login completion. */
+
+import crypto from "crypto";
+import { and, eq, gt } from "drizzle-orm";
+import { dbWrite } from "../../db/client";
+import { encryptApiKey } from "../../db/crypto/api-keys";
+import { type ApiKey, apiKeys, type NewApiKey } from "../../db/schemas/api-keys";
+import { type CliAuthSession, cliAuthSessions } from "../../db/schemas/cli-auth-sessions";
+import { apiKeysService } from "./api-keys";
+
+interface CompletionState {
+  session: CliAuthSession;
+  apiKey: ApiKey | undefined;
+}
+
+type ClaimResult =
+  | {
+      claimed: true;
+      session: CliAuthSession;
+      apiKey: ApiKey;
+      plainKey: string;
+    }
+  | {
+      claimed: false;
+      session: CliAuthSession | undefined;
+      apiKey: ApiKey | undefined;
+    };
+
+/**
+ * Keeps the CLI-session transition and its API-key insert in one focused
+ * consistency boundary. Key encryption happens before the transaction so KMS
+ * I/O never holds a database transaction open; a losing candidate remains only
+ * in memory and is never persisted.
+ */
+export class CliAuthSessionCompletionService {
+  async findActive(sessionId: string): Promise<CompletionState | undefined> {
+    const now = new Date();
+    const [session] = await dbWrite
+      .select()
+      .from(cliAuthSessions)
+      .where(and(eq(cliAuthSessions.session_id, sessionId), gt(cliAuthSessions.expires_at, now)))
+      .limit(1);
+
+    if (!session) return undefined;
+
+    const [apiKey] = session.api_key_id
+      ? await dbWrite.select().from(apiKeys).where(eq(apiKeys.id, session.api_key_id)).limit(1)
+      : [];
+    return { session, apiKey };
+  }
+
+  async claimPending(params: {
+    sessionId: string;
+    userId: string;
+    organizationId: string;
+  }): Promise<ClaimResult> {
+    const { apiKey, plainKey } = await this.prepareApiKey(params.userId, params.organizationId);
+    const now = new Date();
+
+    return await dbWrite.transaction(async (tx) => {
+      const [claimedSession] = await tx
+        .update(cliAuthSessions)
+        .set({
+          status: "authenticated",
+          user_id: params.userId,
+          api_key_id: apiKey.id,
+          authenticated_at: now,
+          updated_at: now,
+        })
+        .where(
+          and(
+            eq(cliAuthSessions.session_id, params.sessionId),
+            eq(cliAuthSessions.status, "pending"),
+            gt(cliAuthSessions.expires_at, now),
+          ),
+        )
+        .returning();
+
+      if (!claimedSession) {
+        const [currentSession] = await tx
+          .select()
+          .from(cliAuthSessions)
+          .where(eq(cliAuthSessions.session_id, params.sessionId))
+          .limit(1);
+        const [currentApiKey] = currentSession?.api_key_id
+          ? await tx
+              .select()
+              .from(apiKeys)
+              .where(eq(apiKeys.id, currentSession.api_key_id))
+              .limit(1)
+          : [];
+        return {
+          claimed: false,
+          session: currentSession,
+          apiKey: currentApiKey,
+        };
+      }
+
+      const [createdKey] = await tx.insert(apiKeys).values(apiKey).returning();
+      if (!createdKey) throw new Error("Failed to create CLI API key");
+
+      return {
+        claimed: true,
+        session: claimedSession,
+        apiKey: createdKey,
+        plainKey,
+      };
+    });
+  }
+
+  private async prepareApiKey(
+    userId: string,
+    organizationId: string,
+  ): Promise<{ apiKey: NewApiKey; plainKey: string }> {
+    const { key, hash, prefix } = apiKeysService.generateApiKey();
+    const id = crypto.randomUUID();
+    const encrypted = await encryptApiKey(organizationId, id, key);
+
+    return {
+      apiKey: {
+        id,
+        name: `CLI Login - ${new Date().toISOString()}`,
+        description: "Generated via CLI login command",
+        organization_id: organizationId,
+        user_id: userId,
+        rate_limit: 1000,
+        is_active: true,
+        expires_at: null,
+        key_hash: hash,
+        key_prefix: prefix,
+        key_ciphertext: encrypted.ciphertext,
+        key_nonce: encrypted.nonce,
+        key_auth_tag: encrypted.auth_tag,
+        key_kms_key_id: encrypted.kms_key_id,
+        key_kms_key_version: encrypted.kms_key_version,
+      },
+      plainKey: key,
+    };
+  }
+}
+
+export const cliAuthSessionCompletionService = new CliAuthSessionCompletionService();

--- a/packages/cloud/shared/src/lib/services/cli-auth-session-completion.ts
+++ b/packages/cloud/shared/src/lib/services/cli-auth-session-completion.ts
@@ -18,7 +18,6 @@ type ClaimResult =
       claimed: true;
       session: CliAuthSession;
       apiKey: ApiKey;
-      plainKey: string;
     }
   | {
       claimed: false;
@@ -54,7 +53,7 @@ export class CliAuthSessionCompletionService {
     userId: string;
     organizationId: string;
   }): Promise<ClaimResult> {
-    const { apiKey, plainKey } = await this.prepareApiKey(params.userId, params.organizationId);
+    const { apiKey } = await this.prepareApiKey(params.userId, params.organizationId);
     const now = new Date();
 
     return await dbWrite.transaction(async (tx) => {
@@ -103,7 +102,6 @@ export class CliAuthSessionCompletionService {
         claimed: true,
         session: claimedSession,
         apiKey: createdKey,
-        plainKey,
       };
     });
   }
@@ -111,7 +109,7 @@ export class CliAuthSessionCompletionService {
   private async prepareApiKey(
     userId: string,
     organizationId: string,
-  ): Promise<{ apiKey: NewApiKey; plainKey: string }> {
+  ): Promise<{ apiKey: NewApiKey }> {
     const { key, hash, prefix } = apiKeysService.generateApiKey();
     const id = crypto.randomUUID();
     const encrypted = await encryptApiKey(organizationId, id, key);
@@ -134,7 +132,6 @@ export class CliAuthSessionCompletionService {
         key_kms_key_id: encrypted.kms_key_id,
         key_kms_key_version: encrypted.kms_key_version,
       },
-      plainKey: key,
     };
   }
 }

--- a/packages/cloud/shared/src/lib/services/cli-auth-sessions.idempotent-complete.test.ts
+++ b/packages/cloud/shared/src/lib/services/cli-auth-sessions.idempotent-complete.test.ts
@@ -25,15 +25,15 @@
  *  - authenticated by a DIFFERENT user -> still rejected (no session leak)
  *  - expired / null session -> still the clear error
  *
- * Only the two repository singletons + apiKeysService the service imports are
- * doubled; the service logic under test is real.
+ * Only the completion boundary and lifecycle repositories are doubled; the
+ * CLI-auth service logic under test is real.
  */
 
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 
-import { apiKeysRepository, cliAuthSessionsRepository } from "../../db/repositories";
+import { cliAuthSessionsRepository } from "../../db/repositories";
 import type { CliAuthSession } from "../../db/schemas/cli-auth-sessions";
-import { apiKeysService } from "./api-keys";
+import { cliAuthSessionCompletionService } from "./cli-auth-session-completion";
 import { cliAuthSessionsService } from "./cli-auth-sessions";
 
 const SESSION_ID = "sess-idem-1";
@@ -73,6 +73,15 @@ function authenticatedSession(userId: string | null): CliAuthSession {
   } as CliAuthSession;
 }
 
+function completionState(session: CliAuthSession, keyPrefix?: string) {
+  return {
+    session,
+    apiKey: keyPrefix
+      ? ({ id: API_KEY_ID, key_prefix: keyPrefix, expires_at: null } as never)
+      : undefined,
+  };
+}
+
 const spies: Array<{ mockRestore: () => void }> = [];
 function track<T extends { mockRestore: () => void }>(s: T): T {
   spies.push(s);
@@ -90,10 +99,14 @@ afterEach(() => {
 describe("cliAuthSessionsService.completeAuthentication idempotency", () => {
   test("pending session mints a key and reports alreadyAuthenticated=false (negative control)", async () => {
     track(
-      spyOn(cliAuthSessionsRepository, "findActiveBySessionId").mockResolvedValue(pendingSession()),
+      spyOn(cliAuthSessionCompletionService, "findActive").mockResolvedValue(
+        completionState(pendingSession()),
+      ),
     );
     const createSpy = track(
-      spyOn(apiKeysService, "create").mockResolvedValue({
+      spyOn(cliAuthSessionCompletionService, "claimPending").mockResolvedValue({
+        claimed: true,
+        session: authenticatedSession(USER_ID),
         apiKey: {
           id: API_KEY_ID,
           key_prefix: "ek_live_pre",
@@ -102,12 +115,6 @@ describe("cliAuthSessionsService.completeAuthentication idempotency", () => {
         plainKey: "ek_live_plaintext_secret",
       } as never),
     );
-    track(
-      spyOn(cliAuthSessionsRepository, "markAuthenticated").mockResolvedValue(
-        authenticatedSession(USER_ID),
-      ),
-    );
-
     const result = await cliAuthSessionsService.completeAuthentication(SESSION_ID, USER_ID, ORG_ID);
 
     expect(createSpy).toHaveBeenCalledTimes(1);
@@ -116,21 +123,39 @@ describe("cliAuthSessionsService.completeAuthentication idempotency", () => {
     expect(result.keyPrefix).toBe("ek_live_pre");
   });
 
-  test("re-completing an already-authenticated session by the SAME user is idempotent — success, no second key minted", async () => {
+  test("a same-user loser resolves the winning key metadata from the primary claim", async () => {
     track(
-      spyOn(cliAuthSessionsRepository, "findActiveBySessionId").mockResolvedValue(
-        authenticatedSession(USER_ID),
+      spyOn(cliAuthSessionCompletionService, "findActive").mockResolvedValue(
+        completionState(pendingSession()),
       ),
     );
-    const createSpy = track(spyOn(apiKeysService, "create"));
-    const markSpy = track(spyOn(cliAuthSessionsRepository, "markAuthenticated"));
     track(
-      spyOn(apiKeysRepository, "findById").mockResolvedValue({
-        id: API_KEY_ID,
-        key_prefix: "ek_live_pre",
-        expires_at: null,
-      } as never),
+      spyOn(cliAuthSessionCompletionService, "claimPending").mockResolvedValue({
+        claimed: false,
+        session: authenticatedSession(USER_ID),
+        apiKey: {
+          id: API_KEY_ID,
+          key_prefix: "ek_live_pre",
+          expires_at: null,
+        } as never,
+      }),
     );
+    const result = await cliAuthSessionsService.completeAuthentication(SESSION_ID, USER_ID, ORG_ID);
+
+    expect(result).toMatchObject({
+      alreadyAuthenticated: true,
+      apiKey: null,
+      keyPrefix: "ek_live_pre",
+    });
+  });
+
+  test("re-completing an already-authenticated session by the SAME user is idempotent — success, no second key minted", async () => {
+    track(
+      spyOn(cliAuthSessionCompletionService, "findActive").mockResolvedValue(
+        completionState(authenticatedSession(USER_ID), "ek_live_pre"),
+      ),
+    );
+    const createSpy = track(spyOn(cliAuthSessionCompletionService, "claimPending"));
 
     const result = await cliAuthSessionsService.completeAuthentication(SESSION_ID, USER_ID, ORG_ID);
 
@@ -140,16 +165,14 @@ describe("cliAuthSessionsService.completeAuthentication idempotency", () => {
     // Plaintext is never re-derivable (D-6) — the browser only needs keyPrefix.
     expect(result.apiKey).toBeNull();
     expect(createSpy).not.toHaveBeenCalled();
-    expect(markSpy).not.toHaveBeenCalled();
   });
 
   test("re-completing when the api_keys row is gone still succeeds with a null keyPrefix", async () => {
     track(
-      spyOn(cliAuthSessionsRepository, "findActiveBySessionId").mockResolvedValue(
-        authenticatedSession(USER_ID),
+      spyOn(cliAuthSessionCompletionService, "findActive").mockResolvedValue(
+        completionState(authenticatedSession(USER_ID)),
       ),
     );
-    track(spyOn(apiKeysRepository, "findById").mockResolvedValue(undefined as never));
 
     const result = await cliAuthSessionsService.completeAuthentication(SESSION_ID, USER_ID, ORG_ID);
 
@@ -160,8 +183,12 @@ describe("cliAuthSessionsService.completeAuthentication idempotency", () => {
   test("rejects an authenticated legacy session whose owner cannot be proven", async () => {
     const session = authenticatedSession(null);
     session.api_key_id = null;
-    track(spyOn(cliAuthSessionsRepository, "findActiveBySessionId").mockResolvedValue(session));
-    const createSpy = track(spyOn(apiKeysService, "create"));
+    track(
+      spyOn(cliAuthSessionCompletionService, "findActive").mockResolvedValue(
+        completionState(session),
+      ),
+    );
+    const createSpy = track(spyOn(cliAuthSessionCompletionService, "claimPending"));
 
     await expect(
       cliAuthSessionsService.completeAuthentication(SESSION_ID, USER_ID, ORG_ID),
@@ -171,8 +198,8 @@ describe("cliAuthSessionsService.completeAuthentication idempotency", () => {
 
   test("does NOT leak a session authenticated by a DIFFERENT user", async () => {
     track(
-      spyOn(cliAuthSessionsRepository, "findActiveBySessionId").mockResolvedValue(
-        authenticatedSession(OTHER_USER_ID),
+      spyOn(cliAuthSessionCompletionService, "findActive").mockResolvedValue(
+        completionState(authenticatedSession(OTHER_USER_ID), "ek_live_pre"),
       ),
     );
 
@@ -184,7 +211,11 @@ describe("cliAuthSessionsService.completeAuthentication idempotency", () => {
   test("rejects any other non-pending terminal state", async () => {
     const session = pendingSession();
     session.status = "expired";
-    track(spyOn(cliAuthSessionsRepository, "findActiveBySessionId").mockResolvedValue(session));
+    track(
+      spyOn(cliAuthSessionCompletionService, "findActive").mockResolvedValue(
+        completionState(session),
+      ),
+    );
 
     await expect(
       cliAuthSessionsService.completeAuthentication(SESSION_ID, USER_ID, ORG_ID),
@@ -192,11 +223,7 @@ describe("cliAuthSessionsService.completeAuthentication idempotency", () => {
   });
 
   test("a missing/expired session still throws the clear error", async () => {
-    track(
-      spyOn(cliAuthSessionsRepository, "findActiveBySessionId").mockResolvedValue(
-        undefined as never,
-      ),
-    );
+    track(spyOn(cliAuthSessionCompletionService, "findActive").mockResolvedValue(undefined));
 
     await expect(
       cliAuthSessionsService.completeAuthentication(SESSION_ID, USER_ID, ORG_ID),

--- a/packages/cloud/shared/src/lib/services/cli-auth-sessions.idempotent-complete.test.ts
+++ b/packages/cloud/shared/src/lib/services/cli-auth-sessions.idempotent-complete.test.ts
@@ -77,7 +77,13 @@ function completionState(session: CliAuthSession, keyPrefix?: string) {
   return {
     session,
     apiKey: keyPrefix
-      ? ({ id: API_KEY_ID, key_prefix: keyPrefix, expires_at: null } as never)
+      ? ({
+          id: API_KEY_ID,
+          key_prefix: keyPrefix,
+          expires_at: null,
+          user_id: USER_ID,
+          organization_id: ORG_ID,
+        } as never)
       : undefined,
   };
 }
@@ -112,14 +118,12 @@ describe("cliAuthSessionsService.completeAuthentication idempotency", () => {
           key_prefix: "ek_live_pre",
           expires_at: null,
         } as never,
-        plainKey: "ek_live_plaintext_secret",
       } as never),
     );
     const result = await cliAuthSessionsService.completeAuthentication(SESSION_ID, USER_ID, ORG_ID);
 
     expect(createSpy).toHaveBeenCalledTimes(1);
     expect(result.alreadyAuthenticated).toBe(false);
-    expect(result.apiKey).toBe("ek_live_plaintext_secret");
     expect(result.keyPrefix).toBe("ek_live_pre");
   });
 
@@ -137,6 +141,8 @@ describe("cliAuthSessionsService.completeAuthentication idempotency", () => {
           id: API_KEY_ID,
           key_prefix: "ek_live_pre",
           expires_at: null,
+          user_id: USER_ID,
+          organization_id: ORG_ID,
         } as never,
       }),
     );
@@ -144,7 +150,6 @@ describe("cliAuthSessionsService.completeAuthentication idempotency", () => {
 
     expect(result).toMatchObject({
       alreadyAuthenticated: true,
-      apiKey: null,
       keyPrefix: "ek_live_pre",
     });
   });
@@ -162,22 +167,19 @@ describe("cliAuthSessionsService.completeAuthentication idempotency", () => {
     // The crux of the regression fix: NO error thrown, and NO duplicate key.
     expect(result.alreadyAuthenticated).toBe(true);
     expect(result.keyPrefix).toBe("ek_live_pre");
-    // Plaintext is never re-derivable (D-6) — the browser only needs keyPrefix.
-    expect(result.apiKey).toBeNull();
     expect(createSpy).not.toHaveBeenCalled();
   });
 
-  test("re-completing when the api_keys row is gone still succeeds with a null keyPrefix", async () => {
+  test("fails fast when an authenticated session references no API-key row", async () => {
     track(
       spyOn(cliAuthSessionCompletionService, "findActive").mockResolvedValue(
         completionState(authenticatedSession(USER_ID)),
       ),
     );
 
-    const result = await cliAuthSessionsService.completeAuthentication(SESSION_ID, USER_ID, ORG_ID);
-
-    expect(result.alreadyAuthenticated).toBe(true);
-    expect(result.keyPrefix).toBeNull();
+    await expect(
+      cliAuthSessionsService.completeAuthentication(SESSION_ID, USER_ID, ORG_ID),
+    ).rejects.toMatchObject({ code: "CLI_AUTH_SESSION_INTEGRITY" });
   });
 
   test("rejects an authenticated legacy session whose owner cannot be proven", async () => {

--- a/packages/cloud/shared/src/lib/services/cli-auth-sessions.ts
+++ b/packages/cloud/shared/src/lib/services/cli-auth-sessions.ts
@@ -4,8 +4,9 @@
 
 import { decryptApiKey } from "../../db/crypto/api-keys";
 import { apiKeysRepository, cliAuthSessionsRepository } from "../../db/repositories";
+import type { ApiKey } from "../../db/schemas/api-keys";
 import type { CliAuthSession } from "../../db/schemas/cli-auth-sessions";
-import { apiKeysService } from "./api-keys";
+import { cliAuthSessionCompletionService } from "./cli-auth-session-completion";
 
 /**
  * Session expiry time in minutes.
@@ -16,6 +17,41 @@ const SESSION_EXPIRY_MINUTES = 10; // Sessions expire after 10 minutes
  * Service for CLI authentication flow and session management.
  */
 export class CliAuthSessionsService {
+  private async alreadyAuthenticatedResult(
+    session: CliAuthSession,
+    userId: string,
+    primaryApiKey: ApiKey | null,
+  ): Promise<{
+    session: CliAuthSession;
+    apiKey: null;
+    keyPrefix: string | null;
+    expiresAt: Date | null;
+    alreadyAuthenticated: true;
+  }> {
+    if (!session.user_id || session.user_id !== userId) {
+      throw new Error("Session already authenticated or expired");
+    }
+
+    let keyPrefix: string | null = null;
+    let expiresAt: Date | null = null;
+    if (session.api_key_id) {
+      if (primaryApiKey) {
+        keyPrefix = primaryApiKey.key_prefix;
+        expiresAt = primaryApiKey.expires_at ?? null;
+      }
+    }
+
+    return {
+      session,
+      // Plaintext is never re-derivable (D-6); the CLI reads it via the
+      // single-use poll endpoint. The browser only consumes `keyPrefix`.
+      apiKey: null,
+      keyPrefix,
+      expiresAt,
+      alreadyAuthenticated: true,
+    };
+  }
+
   /**
    * Create a new CLI authentication session
    */
@@ -68,8 +104,11 @@ export class CliAuthSessionsService {
     expiresAt: Date | null;
     alreadyAuthenticated: boolean;
   }> {
-    // Check if session exists and is still valid
-    const session = await this.getActiveSession(sessionId);
+    // Completion is a consistency-sensitive state transition. A replica miss
+    // immediately after session creation must not turn a valid login into an
+    // "expired" error, so establish the initial state on the primary.
+    const state = await cliAuthSessionCompletionService.findActive(sessionId);
+    const session = state?.session;
 
     if (!session) {
       throw new Error("Invalid or expired session");
@@ -78,29 +117,7 @@ export class CliAuthSessionsService {
     // Browser retries are safe only when ownership is positively established;
     // a legacy row without an owner cannot prove that the caller completed it.
     if (session.status === "authenticated") {
-      if (!session.user_id || session.user_id !== userId) {
-        throw new Error("Session already authenticated or expired");
-      }
-
-      let keyPrefix: string | null = null;
-      let expiresAt: Date | null = null;
-      if (session.api_key_id) {
-        const existingKey = await apiKeysRepository.findById(session.api_key_id);
-        if (existingKey) {
-          keyPrefix = existingKey.key_prefix;
-          expiresAt = existingKey.expires_at ?? null;
-        }
-      }
-
-      return {
-        session,
-        // Plaintext is never re-derivable (D-6); the CLI reads it via the
-        // single-use poll endpoint. The browser only consumes `keyPrefix`.
-        apiKey: null,
-        keyPrefix,
-        expiresAt,
-        alreadyAuthenticated: true,
-      };
+      return await this.alreadyAuthenticatedResult(session, userId, state.apiKey ?? null);
     }
 
     if (session.status !== "pending") {
@@ -108,33 +125,30 @@ export class CliAuthSessionsService {
       throw new Error("Session already authenticated or expired");
     }
 
-    // Generate API key for CLI usage
-    const { apiKey, plainKey } = await apiKeysService.create({
-      name: `CLI Login - ${new Date().toISOString()}`,
-      description: "Generated via CLI login command",
-      organization_id: organizationId,
-      user_id: userId,
-      rate_limit: 1000,
-      is_active: true,
-      expires_at: null, // Never expires by default
-    });
-
-    // Update session with authentication details (no plaintext stored — D-6).
-    const updatedSession = await cliAuthSessionsRepository.markAuthenticated(
+    const claim = await cliAuthSessionCompletionService.claimPending({
       sessionId,
       userId,
-      apiKey.id,
-    );
+      organizationId,
+    });
 
-    if (!updatedSession) {
-      throw new Error("Failed to update session");
+    if (!claim.claimed) {
+      // Read from the same primary transaction that lost the conditional
+      // update. This avoids a read-replica lag window after another request
+      // wins the claim.
+      if (claim.session?.status === "authenticated") {
+        return await this.alreadyAuthenticatedResult(claim.session, userId, claim.apiKey ?? null);
+      }
+      if (!claim.session || claim.session.expires_at <= new Date()) {
+        throw new Error("Invalid or expired session");
+      }
+      throw new Error("Session already authenticated or expired");
     }
 
     return {
-      session: updatedSession,
-      apiKey: plainKey,
-      keyPrefix: apiKey.key_prefix,
-      expiresAt: apiKey.expires_at,
+      session: claim.session,
+      apiKey: claim.plainKey,
+      keyPrefix: claim.apiKey.key_prefix,
+      expiresAt: claim.apiKey.expires_at,
       alreadyAuthenticated: false,
     };
   }

--- a/packages/cloud/shared/src/lib/services/cli-auth-sessions.ts
+++ b/packages/cloud/shared/src/lib/services/cli-auth-sessions.ts
@@ -2,6 +2,7 @@
  * Service for managing CLI authentication sessions.
  */
 
+import { ElizaError } from "@elizaos/core";
 import { decryptApiKey } from "../../db/crypto/api-keys";
 import { apiKeysRepository, cliAuthSessionsRepository } from "../../db/repositories";
 import type { ApiKey } from "../../db/schemas/api-keys";
@@ -20,11 +21,11 @@ export class CliAuthSessionsService {
   private async alreadyAuthenticatedResult(
     session: CliAuthSession,
     userId: string,
+    organizationId: string,
     primaryApiKey: ApiKey | null,
   ): Promise<{
     session: CliAuthSession;
-    apiKey: null;
-    keyPrefix: string | null;
+    keyPrefix: string;
     expiresAt: Date | null;
     alreadyAuthenticated: true;
   }> {
@@ -32,22 +33,35 @@ export class CliAuthSessionsService {
       throw new Error("Session already authenticated or expired");
     }
 
-    let keyPrefix: string | null = null;
-    let expiresAt: Date | null = null;
-    if (session.api_key_id) {
-      if (primaryApiKey) {
-        keyPrefix = primaryApiKey.key_prefix;
-        expiresAt = primaryApiKey.expires_at ?? null;
-      }
+    if (!session.api_key_id) {
+      throw new ElizaError("Authenticated CLI session has no API key reference", {
+        code: "CLI_AUTH_SESSION_INTEGRITY",
+        context: { sessionId: session.session_id, defect: "missing_api_key_id" },
+        severity: "fatal",
+      });
+    }
+    if (!primaryApiKey) {
+      throw new ElizaError("Authenticated CLI session references a missing API key", {
+        code: "CLI_AUTH_SESSION_INTEGRITY",
+        context: { sessionId: session.session_id, defect: "missing_api_key_row" },
+        severity: "fatal",
+      });
+    }
+    if (primaryApiKey.user_id !== userId || primaryApiKey.organization_id !== organizationId) {
+      throw new ElizaError(
+        "Authenticated CLI session references an API key with different ownership",
+        {
+          code: "CLI_AUTH_SESSION_INTEGRITY",
+          context: { sessionId: session.session_id, defect: "api_key_owner_mismatch" },
+          severity: "fatal",
+        },
+      );
     }
 
     return {
       session,
-      // Plaintext is never re-derivable (D-6); the CLI reads it via the
-      // single-use poll endpoint. The browser only consumes `keyPrefix`.
-      apiKey: null,
-      keyPrefix,
-      expiresAt,
+      keyPrefix: primaryApiKey.key_prefix,
+      expiresAt: primaryApiKey.expires_at ?? null,
       alreadyAuthenticated: true,
     };
   }
@@ -99,8 +113,7 @@ export class CliAuthSessionsService {
     organizationId: string,
   ): Promise<{
     session: CliAuthSession;
-    apiKey: string | null;
-    keyPrefix: string | null;
+    keyPrefix: string;
     expiresAt: Date | null;
     alreadyAuthenticated: boolean;
   }> {
@@ -117,7 +130,12 @@ export class CliAuthSessionsService {
     // Browser retries are safe only when ownership is positively established;
     // a legacy row without an owner cannot prove that the caller completed it.
     if (session.status === "authenticated") {
-      return await this.alreadyAuthenticatedResult(session, userId, state.apiKey ?? null);
+      return await this.alreadyAuthenticatedResult(
+        session,
+        userId,
+        organizationId,
+        state.apiKey ?? null,
+      );
     }
 
     if (session.status !== "pending") {
@@ -136,7 +154,12 @@ export class CliAuthSessionsService {
       // update. This avoids a read-replica lag window after another request
       // wins the claim.
       if (claim.session?.status === "authenticated") {
-        return await this.alreadyAuthenticatedResult(claim.session, userId, claim.apiKey ?? null);
+        return await this.alreadyAuthenticatedResult(
+          claim.session,
+          userId,
+          organizationId,
+          claim.apiKey ?? null,
+        );
       }
       if (!claim.session || claim.session.expires_at <= new Date()) {
         throw new Error("Invalid or expired session");
@@ -146,7 +169,6 @@ export class CliAuthSessionsService {
 
     return {
       session: claim.session,
-      apiKey: claim.plainKey,
       keyPrefix: claim.apiKey.key_prefix,
       expiresAt: claim.apiKey.expires_at,
       alreadyAuthenticated: false,


### PR DESCRIPTION
"Closes #16240.\n\n## What changed\n\n- moves the CLI-login completion state transition onto the primary database;\n- conditionally claims only an unexpired `pending` session;\n- keeps the winning `pending -> authenticated` update and API-key insert in one transaction;\n- leaves every losing key candidate memory-only, so concurrent completion cannot create a live orphaned credential;\n- resolves a concurrent winner from the same primary transaction;\n- preserves same-user retry success without returning plaintext again and generic cross-user rejection.\n\n## Why\n\nThe merged sequential-idempotency fix still allowed two simultaneous browser completions to both observe `pending`, mint two never-expiring API keys, and leave one unreferenced. This makes that claim atomic.\n\n## Evidence\n\n- deterministic same-user and different-user PGlite races force both real route requests to observe `pending` before claiming;\n- focused route/service suite: **17/17 pass**;\n- changed-file coverage: **76.53% mean** (new completion boundary **100%**, touched session service **53.06%**; gate is 50%);\n- Cloud shared + API TypeScript 7 checks: **pass**;\n- production Worker dry-run: **pass**;\n- Biome and diff integrity: **pass**;\n- independent auth/security review: **SHIP**, no correctness or security blocker.\n\n## Scope note\n\nThe separate pre-existing concurrent poll/single-use retrieval race is tracked in #16253. This PR does not hide or conflate it with the atomic mint fix.\n\n## Final reviewer validation\\n\\n- Real PostgreSQL 17 route suite: 10/10 passed, including deterministic same-user/different-user races, rollback, and integrity failures.\\n- PGlite/service suites: 21/21 focused tests passed.\\n- Cloud API and shared typechecks passed; production Worker dry-run, Biome, diff integrity, type-safety, test-realness, and error-policy audits passed.\\n- Real local cloud stack: two genuine EIP-4361 SIWE tenants exercised create, owner approval, cross-tenant denial, idempotent owner retry, one-time token retrieval, and replay rejection.\\n- Completion responses contain metadata only; plaintext appears solely at the one-time poll boundary and is redacted from evidence.\\n- Persisted DB evidence proves the consumed session and encrypted API-key row share the authenticated owner and organization.\\n\\n## Evidence Gate\\n\\n<!-- evidence-row:before-screenshots -->\\n- [x] Before screenshots: N/A - backend authentication transaction; no rendered UI changed.\\n<!-- evidence-row:after-screenshots -->\\n- [x] After screenshots: N/A - backend authentication transaction; no rendered UI changed.\\n<!-- evidence-row:walkthrough-video -->\\n- [x] Walkthrough video: N/A - no visual flow changed.\\n<!-- evidence-row:backend-logs -->\\n- [x] Backend logs: [redacted real SIWE/API-key request log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16257-live-auth-backend.log) and [real PostgreSQL 17 route run](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16257-postgres-route-rebased.log).\\n<!-- evidence-row:frontend-logs -->\\n- [x] Frontend console/network logs: N/A - no frontend code changed; the exact HTTP statuses and response bodies are captured in the live boundary artifact.\\n<!-- evidence-row:llm-trajectory -->\\n- [x] Real-LLM trajectory: N/A - no prompts, models, actions, providers, or evaluators changed.\\n<!-- evidence-row:domain-artifacts -->\\n- [x] Domain artifacts: [redacted live-auth trace](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16257-live-auth-trace.json) proves create=201, owner=200, other tenant=400, retry=200, first poll=200, replay=410; [DB artifact](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16257-live-auth-db.json) proves ownership, encryption-at-rest, and consumption without exposing secret columns.\\n\\n## Known gaps / failures\\n\\nNone. Evidence was manually inspected; private keys, SIWE signatures, API-key hashes/ciphertext, authorization headers, and plaintext CLI keys are excluded.\\n"
