### PR TITLE
fix(notifications): fail closed and recover unavailable inbox

### DIFF
--- a/packages/agent/src/api/notification-routes.test.ts
+++ b/packages/agent/src/api/notification-routes.test.ts
@@ -38,6 +38,7 @@ async function makeRuntimeWithService(): Promise<{
     baseRuntime,
   )) as NotificationService;
   const runtime = {
+    reportError: vi.fn(),
     getService: (t: string) =>
       t === ServiceType.NOTIFICATION
         ? service
@@ -283,6 +284,7 @@ describe("handleNotificationRoute", () => {
   it("GET serves an explicitly disabled inbox when support is unregistered", async () => {
     const helpers = makeHelpers();
     const emptyRuntime = {
+      reportError: vi.fn(),
       getService: () => null,
       hasService: () => false,
       getServiceRegistrationStatus: () => "unknown",
@@ -309,6 +311,7 @@ describe("handleNotificationRoute", () => {
   ] as const)("returns typed retryable 503 while the service is %s", async (status) => {
     const helpers = makeHelpers();
     const startingRuntime = {
+      reportError: vi.fn(),
       getService: () => null,
       hasService: () => true,
       getServiceRegistrationStatus: () => status,
@@ -341,6 +344,7 @@ describe("handleNotificationRoute", () => {
       .mockRejectedValue(new Error("private adapter failure"));
     const failedRuntime = {
       agentId: "00000000-0000-0000-0000-0000000000bb",
+      reportError: vi.fn(),
       getService: () => null,
       hasService: () => true,
       getServiceRegistrationStatus: () => "failed",
@@ -373,6 +377,7 @@ describe("handleNotificationRoute", () => {
   it("returns a typed disabled error for mutations when support is unregistered", async () => {
     const helpers = makeHelpers();
     const emptyRuntime = {
+      reportError: vi.fn(),
       getService: () => null,
       hasService: () => false,
       getServiceRegistrationStatus: () => "unknown",

--- a/packages/agent/src/api/notification-routes.test.ts
+++ b/packages/agent/src/api/notification-routes.test.ts
@@ -6,7 +6,10 @@
  * the service-absent empty-inbox and 503 fallbacks.
  */
 import type http from "node:http";
-import type { IAgentRuntime } from "@elizaos/core";
+import type {
+  IAgentRuntime,
+  NotificationServiceLifecycleRuntime,
+} from "@elizaos/core";
 import { NotificationService, ServiceType } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -15,7 +18,7 @@ import {
 } from "./notification-routes";
 
 async function makeRuntimeWithService(): Promise<{
-  runtime: { getService: (t: string) => unknown };
+  runtime: NotificationServiceLifecycleRuntime;
   service: NotificationService;
 }> {
   const cache = new Map<string, unknown>();
@@ -41,6 +44,9 @@ async function makeRuntimeWithService(): Promise<{
         : t === ServiceType.AGENT_EVENT
           ? bus
           : null,
+    hasService: (t: string) => t === ServiceType.NOTIFICATION,
+    getServiceRegistrationStatus: () => "registered" as const,
+    getServiceLoadPromise: async () => service,
   };
   return { runtime, service };
 }
@@ -53,13 +59,15 @@ function makeHelpers() {
 }
 
 const req = (url: string) => ({ url }) as http.IncomingMessage;
-const res = {} as http.ServerResponse;
+const setHeader = vi.fn();
+const res = { setHeader } as unknown as http.ServerResponse;
 
 describe("handleNotificationRoute", () => {
-  let runtime: { getService: (t: string) => unknown };
+  let runtime: NotificationServiceLifecycleRuntime;
   let service: NotificationService;
 
   beforeEach(async () => {
+    setHeader.mockReset();
     ({ runtime, service } = await makeRuntimeWithService());
   });
 
@@ -94,6 +102,10 @@ describe("handleNotificationRoute", () => {
     };
     expect(payload.notifications).toHaveLength(1);
     expect(payload.unreadCount).toBe(1);
+    expect(
+      (helpers.json.mock.calls[0][1] as { serviceStatus: string })
+        .serviceStatus,
+    ).toBe("ready");
   });
 
   it("GET honors unreadOnly + category + limit filters", async () => {
@@ -268,9 +280,14 @@ describe("handleNotificationRoute", () => {
     }
   });
 
-  it("GET serves an empty inbox when the service is not registered", async () => {
+  it("GET serves an explicitly disabled inbox when support is unregistered", async () => {
     const helpers = makeHelpers();
-    const emptyRuntime = { getService: () => null };
+    const emptyRuntime = {
+      getService: () => null,
+      hasService: () => false,
+      getServiceRegistrationStatus: () => "unknown",
+      getServiceLoadPromise: async () => service,
+    } satisfies NotificationServiceLifecycleRuntime;
     await handleNotificationRoute(
       req("/api/notifications"),
       res,
@@ -282,12 +299,85 @@ describe("handleNotificationRoute", () => {
     expect(helpers.json).toHaveBeenCalledWith(res, {
       notifications: [],
       unreadCount: 0,
+      serviceStatus: "disabled",
     });
   });
 
-  it("returns 503 for mutations when the service is not registered", async () => {
+  it.each([
+    "pending",
+    "registering",
+  ] as const)("returns typed retryable 503 while the service is %s", async (status) => {
     const helpers = makeHelpers();
-    const emptyRuntime = { getService: () => null };
+    const startingRuntime = {
+      getService: () => null,
+      hasService: () => true,
+      getServiceRegistrationStatus: () => status,
+      getServiceLoadPromise: async () => service,
+    } satisfies NotificationServiceLifecycleRuntime;
+    await handleNotificationRoute(
+      req("/api/notifications"),
+      res,
+      "/api/notifications",
+      "GET",
+      { runtime: startingRuntime },
+      helpers,
+    );
+    expect(setHeader).toHaveBeenCalledWith("Retry-After", "1");
+    expect(helpers.json).toHaveBeenCalledWith(
+      res,
+      {
+        error: "Notification service is still starting",
+        code: "NOTIFICATION_SERVICE_NOT_READY",
+        retryAfter: 1,
+      },
+      503,
+    );
+  });
+
+  it("returns typed 503 and starts one recovery for a failed service", async () => {
+    const helpers = makeHelpers();
+    const getServiceLoadPromise = vi
+      .fn()
+      .mockRejectedValue(new Error("private adapter failure"));
+    const failedRuntime = {
+      agentId: "00000000-0000-0000-0000-0000000000bb",
+      getService: () => null,
+      hasService: () => true,
+      getServiceRegistrationStatus: () => "failed",
+      getServiceLoadPromise,
+    } satisfies NotificationServiceLifecycleRuntime;
+    await handleNotificationRoute(
+      req("/api/notifications"),
+      res,
+      "/api/notifications",
+      "GET",
+      { runtime: failedRuntime },
+      helpers,
+    );
+    expect(setHeader).toHaveBeenCalledWith("Retry-After", "1");
+    expect(helpers.json).toHaveBeenCalledWith(
+      res,
+      {
+        error: "Notification inbox is temporarily unavailable",
+        code: "NOTIFICATION_SERVICE_FAILED",
+        retryAfter: 1,
+      },
+      503,
+    );
+    expect(JSON.stringify(helpers.json.mock.calls[0][1])).not.toContain(
+      "private adapter failure",
+    );
+    expect(getServiceLoadPromise).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns a typed disabled error for mutations when support is unregistered", async () => {
+    const helpers = makeHelpers();
+    const emptyRuntime = {
+      getService: () => null,
+      hasService: () => false,
+      getServiceRegistrationStatus: () => "unknown",
+      getServiceLoadPromise: async () => service,
+    } satisfies NotificationServiceLifecycleRuntime;
     await handleNotificationRoute(
       req("/api/notifications"),
       res,
@@ -296,6 +386,13 @@ describe("handleNotificationRoute", () => {
       { runtime: emptyRuntime },
       helpers,
     );
-    expect(helpers.error).toHaveBeenCalledWith(res, expect.any(String), 503);
+    expect(helpers.json).toHaveBeenCalledWith(
+      res,
+      {
+        error: "Notification service is disabled",
+        code: "NOTIFICATION_SERVICE_DISABLED",
+      },
+      503,
+    );
   });
 });

--- a/packages/agent/src/api/notification-routes.ts
+++ b/packages/agent/src/api/notification-routes.ts
@@ -39,13 +39,16 @@ import type {
   NotificationCategory,
   NotificationInput,
   NotificationPriority,
+  NotificationServiceLifecycleRuntime,
   RouteHelpers,
 } from "@elizaos/core";
 import { NotificationService, ServiceType } from "@elizaos/core";
 
 export interface NotificationRouteState {
-  runtime: { getService: (type: string) => unknown } | null;
+  runtime: NotificationServiceLifecycleRuntime | null;
 }
+
+const NOTIFICATION_RETRY_AFTER_SECONDS = 1;
 
 const CATEGORIES: NotificationCategory[] = [
   "reminder",
@@ -134,6 +137,77 @@ function getService(state: NotificationRouteState): NotificationService | null {
   return svc instanceof NotificationService ? svc : null;
 }
 
+function respondServiceUnavailable(
+  res: http.ServerResponse,
+  state: NotificationRouteState,
+  method: string,
+  pathname: string,
+  helpers: RouteHelpers,
+): boolean {
+  const runtime = state.runtime;
+  if (!runtime) {
+    res.setHeader("Retry-After", String(NOTIFICATION_RETRY_AFTER_SECONDS));
+    helpers.json(
+      res,
+      {
+        error: "Notification service is still starting",
+        code: "NOTIFICATION_SERVICE_NOT_READY",
+        retryAfter: NOTIFICATION_RETRY_AFTER_SECONDS,
+      },
+      503,
+    );
+    return true;
+  }
+
+  const availability = NotificationService.getAvailability(runtime);
+  if (availability === "disabled") {
+    if (method === "GET" && pathname === "/api/notifications") {
+      helpers.json(res, {
+        notifications: [],
+        unreadCount: 0,
+        serviceStatus: "disabled",
+      });
+      return true;
+    }
+    helpers.json(
+      res,
+      {
+        error: "Notification service is disabled",
+        code: "NOTIFICATION_SERVICE_DISABLED",
+      },
+      503,
+    );
+    return true;
+  }
+
+  if (availability === "failed") {
+    const recovery = NotificationService.requestRecovery(runtime);
+    res.setHeader("Retry-After", String(recovery.retryAfterSeconds));
+    helpers.json(
+      res,
+      {
+        error: "Notification inbox is temporarily unavailable",
+        code: "NOTIFICATION_SERVICE_FAILED",
+        retryAfter: recovery.retryAfterSeconds,
+      },
+      503,
+    );
+    return true;
+  }
+
+  res.setHeader("Retry-After", String(NOTIFICATION_RETRY_AFTER_SECONDS));
+  helpers.json(
+    res,
+    {
+      error: "Notification service is still starting",
+      code: "NOTIFICATION_SERVICE_NOT_READY",
+      retryAfter: NOTIFICATION_RETRY_AFTER_SECONDS,
+    },
+    503,
+  );
+  return true;
+}
+
 function parseLimit(raw: string | null): number | undefined {
   if (!raw) return undefined;
   const parsed = Number.parseInt(raw, 10);
@@ -206,15 +280,7 @@ export async function handleNotificationRoute(
 
   const service = getService(state);
   if (!service) {
-    // The runtime is up but the notification service isn't registered yet
-    // (very early boot). Serve an empty inbox rather than 500 so the UI
-    // degrades gracefully and retries.
-    if (method === "GET" && pathname === "/api/notifications") {
-      helpers.json(res, { notifications: [], unreadCount: 0 });
-      return true;
-    }
-    helpers.error(res, "notification service not ready", 503);
-    return true;
+    return respondServiceUnavailable(res, state, method, pathname, helpers);
   }
 
   // ── GET /api/notifications ────────────────────────────────────────
@@ -228,6 +294,7 @@ export async function handleNotificationRoute(
     helpers.json(res, {
       notifications,
       unreadCount: service.getUnreadCount(),
+      serviceStatus: "ready",
     });
     return true;
   }

--- a/packages/core/src/services/notification.test.ts
+++ b/packages/core/src/services/notification.test.ts
@@ -237,6 +237,18 @@ describe("NotificationService", () => {
 				unavailable.runtime.getServiceLoadPromise(ServiceType.NOTIFICATION),
 			).rejects.toThrow("failed to start");
 			await Promise.resolve();
+			expect(unavailable.runtime.getRecentReportedErrors()).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						scope: "NotificationService.recovery",
+						message: "Service notification not found or failed to start",
+						context: expect.objectContaining({
+							attempt: 1,
+							retryAfterSeconds: 1,
+						}),
+					}),
+				]),
+			);
 
 			const deferred = Array.from({ length: 10 }, () =>
 				NotificationService.requestRecovery(unavailable.runtime),

--- a/packages/core/src/services/notification.test.ts
+++ b/packages/core/src/services/notification.test.ts
@@ -148,6 +148,111 @@ describe("NotificationService", () => {
 		}
 	});
 
+	it("recovers persisted history after a transient hydration failure", async () => {
+		class TransientCacheAdapter extends InMemoryDatabaseAdapter {
+			readAttempts = 0;
+
+			override async getCaches<T>(keys: string[]): Promise<Map<string, T>> {
+				this.readAttempts += 1;
+				if (this.readAttempts === 1) {
+					throw new Error("notification cache temporarily unavailable");
+				}
+				return super.getCaches<T>(keys);
+			}
+		}
+
+		const adapter = new TransientCacheAdapter();
+		const transient = await createRuntime([NotificationService], adapter);
+		try {
+			await expect(
+				transient.runtime.getServiceLoadPromise(ServiceType.NOTIFICATION),
+			).rejects.toThrow("Service notification not found or failed to start");
+			expect(
+				transient.runtime.getServiceRegistrationStatus(
+					ServiceType.NOTIFICATION,
+				),
+			).toBe("failed");
+
+			const persisted = {
+				id: "00000000-0000-0000-0000-0000000000cc",
+				title: "Recovered history",
+				category: "general",
+				priority: "normal",
+				source: "test",
+				createdAt: Date.now(),
+				readAt: null,
+			} as AgentNotification;
+			await transient.runtime.setCache(
+				`notifications:${transient.runtime.agentId}`,
+				[persisted],
+			);
+
+			const attempts = Array.from({ length: 8 }, () =>
+				NotificationService.requestRecovery(transient.runtime),
+			);
+			expect(
+				attempts.filter((attempt) => attempt.state === "started"),
+			).toHaveLength(1);
+			expect(
+				attempts.filter((attempt) => attempt.state === "in-flight"),
+			).toHaveLength(7);
+
+			const recovered = (await transient.runtime.getServiceLoadPromise(
+				ServiceType.NOTIFICATION,
+			)) as NotificationService;
+			expect(adapter.readAttempts).toBe(2);
+			expect(
+				recovered.list().map((notification) => notification.title),
+			).toEqual(["Recovered history"]);
+			expect(
+				transient.runtime.getServiceRegistrationStatus(
+					ServiceType.NOTIFICATION,
+				),
+			).toBe("registered");
+		} finally {
+			await transient.cleanup();
+		}
+	});
+
+	it("backs off repeated recovery requests after a persistent failure", async () => {
+		class UnavailableCacheAdapter extends InMemoryDatabaseAdapter {
+			readAttempts = 0;
+
+			override async getCaches<T>(_keys: string[]): Promise<Map<string, T>> {
+				this.readAttempts += 1;
+				throw new Error("notification cache unavailable");
+			}
+		}
+
+		const adapter = new UnavailableCacheAdapter();
+		const unavailable = await createRuntime([NotificationService], adapter);
+		try {
+			await expect(
+				unavailable.runtime.getServiceLoadPromise(ServiceType.NOTIFICATION),
+			).rejects.toThrow("failed to start");
+			expect(
+				NotificationService.requestRecovery(unavailable.runtime).state,
+			).toBe("started");
+			await expect(
+				unavailable.runtime.getServiceLoadPromise(ServiceType.NOTIFICATION),
+			).rejects.toThrow("failed to start");
+			await Promise.resolve();
+
+			const deferred = Array.from({ length: 10 }, () =>
+				NotificationService.requestRecovery(unavailable.runtime),
+			);
+			expect(deferred.every((attempt) => attempt.state === "backoff")).toBe(
+				true,
+			);
+			expect(deferred.every((attempt) => attempt.retryAfterSeconds === 1)).toBe(
+				true,
+			);
+			expect(adapter.readAttempts).toBe(2);
+		} finally {
+			await unavailable.cleanup();
+		}
+	});
+
 	it("collapses notifications sharing a groupKey", async () => {
 		await service.notify({ title: "Reminder 1", groupKey: "task:abc" });
 		await service.notify({ title: "Reminder 2", groupKey: "task:abc" });

--- a/packages/core/src/services/notification.ts
+++ b/packages/core/src/services/notification.ts
@@ -57,6 +57,11 @@ export interface NotificationServiceRecovery {
 /** Runtime lifecycle surface required by notification transports. */
 export interface NotificationServiceLifecycleRuntime {
 	readonly agentId?: string;
+	reportError(
+		scope: string,
+		error: unknown,
+		context?: Record<string, unknown>,
+	): void;
 	getService(serviceType: string): unknown;
 	hasService(serviceType: string): boolean;
 	getServiceRegistrationStatus(
@@ -245,6 +250,10 @@ export class NotificationService extends Service {
 				const delayMs = recoveryDelayMs(failures);
 				recovery.failures = failures;
 				recovery.nextAttemptAt = Date.now() + delayMs;
+				runtime.reportError("NotificationService.recovery", error, {
+					attempt,
+					retryAfterSeconds: retryAfterSeconds(delayMs),
+				});
 				logger.warn(
 					{
 						src: "service:notification",

--- a/packages/core/src/services/notification.ts
+++ b/packages/core/src/services/notification.ts
@@ -39,6 +39,82 @@ import { Service, ServiceType } from "../types/service.ts";
 /** Max notifications retained per agent in the inbox (oldest evicted). */
 const MAX_NOTIFICATIONS = 300;
 
+const RECOVERY_BASE_DELAY_MS = 1_000;
+const RECOVERY_MAX_DELAY_MS = 30_000;
+
+export type NotificationServiceAvailability =
+	| "disabled"
+	| "pending"
+	| "registering"
+	| "failed"
+	| "registered";
+
+export interface NotificationServiceRecovery {
+	state: "started" | "in-flight" | "backoff" | "unavailable";
+	retryAfterSeconds: number;
+}
+
+/** Runtime lifecycle surface required by notification transports. */
+export interface NotificationServiceLifecycleRuntime {
+	readonly agentId?: string;
+	getService(serviceType: string): unknown;
+	hasService(serviceType: string): boolean;
+	getServiceRegistrationStatus(
+		serviceType: string,
+	): "pending" | "registering" | "registered" | "failed" | "unknown";
+	getServiceLoadPromise(serviceType: string): Promise<Service>;
+}
+
+interface NotificationRecoveryState {
+	failures: number;
+	nextAttemptAt: number;
+	inFlight: Promise<NotificationService | null> | null;
+}
+
+const recoveryByRuntime = new WeakMap<
+	NotificationServiceLifecycleRuntime,
+	NotificationRecoveryState
+>();
+const availabilityByRuntime = new WeakMap<
+	NotificationServiceLifecycleRuntime,
+	NotificationServiceAvailability
+>();
+
+function retryAfterSeconds(delayMs: number): number {
+	return Math.max(1, Math.ceil(delayMs / 1_000));
+}
+
+function recoveryDelayMs(failures: number): number {
+	return Math.min(
+		RECOVERY_MAX_DELAY_MS,
+		RECOVERY_BASE_DELAY_MS * 2 ** Math.max(0, failures - 1),
+	);
+}
+
+function recordAvailability(
+	runtime: NotificationServiceLifecycleRuntime,
+	availability: NotificationServiceAvailability,
+): NotificationServiceAvailability {
+	if (availabilityByRuntime.get(runtime) === availability) return availability;
+	availabilityByRuntime.set(runtime, availability);
+	const context = {
+		src: "service:notification",
+		agentId: runtime.agentId,
+		availability,
+	};
+	if (availability === "failed") {
+		logger.warn(
+			context,
+			"NotificationService unavailable after startup failure",
+		);
+	} else if (availability === "disabled") {
+		logger.info(context, "NotificationService intentionally disabled");
+	} else {
+		logger.debug(context, "NotificationService availability changed");
+	}
+	return availability;
+}
+
 /**
  * True once a notification's explicit `expiresAt` (unix ms) has passed. Only
  * caller-set expiry is honored — there is no per-category default retention.
@@ -81,6 +157,120 @@ export class NotificationService extends Service {
 	/** Resolved cache key (scoped per agent). */
 	private get cacheKey(): string {
 		return `notifications:${this.runtime.agentId}`;
+	}
+
+	/**
+	 * Resolve the runtime lifecycle state without treating a failed instance as
+	 * an intentionally empty inbox. A registered class with no live instance is
+	 * fail-closed even if the runtime reports an inconsistent `registered` state.
+	 */
+	static getAvailability(
+		runtime: NotificationServiceLifecycleRuntime,
+	): NotificationServiceAvailability {
+		const service = runtime.getService(ServiceType.NOTIFICATION);
+		if (service instanceof NotificationService) {
+			recoveryByRuntime.delete(runtime);
+			return recordAvailability(runtime, "registered");
+		}
+		if (!runtime.hasService(ServiceType.NOTIFICATION)) {
+			return recordAvailability(runtime, "disabled");
+		}
+		const status = runtime.getServiceRegistrationStatus(
+			ServiceType.NOTIFICATION,
+		);
+		if (status === "pending" || status === "registering") {
+			return recordAvailability(runtime, status);
+		}
+		if (status === "failed" || status === "registered") {
+			return recordAvailability(runtime, "failed");
+		}
+		return recordAvailability(runtime, "pending");
+	}
+
+	/**
+	 * Start one background recovery attempt after a failed hydration. The
+	 * runtime already deduplicates concurrent service starts; this coordinator
+	 * adds a bounded cooldown so repeated HTTP and Android requests cannot turn
+	 * a persistent adapter outage into a retry stampede.
+	 */
+	static requestRecovery(
+		runtime: NotificationServiceLifecycleRuntime,
+	): NotificationServiceRecovery {
+		const existing = recoveryByRuntime.get(runtime);
+		if (existing?.inFlight) {
+			return { state: "in-flight", retryAfterSeconds: 1 };
+		}
+		if (NotificationService.getAvailability(runtime) !== "failed") {
+			return { state: "unavailable", retryAfterSeconds: 1 };
+		}
+
+		const now = Date.now();
+		if (existing && existing.nextAttemptAt > now) {
+			return {
+				state: "backoff",
+				retryAfterSeconds: retryAfterSeconds(existing.nextAttemptAt - now),
+			};
+		}
+
+		const recovery: NotificationRecoveryState = existing ?? {
+			failures: 0,
+			nextAttemptAt: 0,
+			inFlight: null,
+		};
+		const attempt = recovery.failures + 1;
+		const inFlight = runtime
+			.getServiceLoadPromise(ServiceType.NOTIFICATION)
+			.then((service) => {
+				if (!(service instanceof NotificationService)) {
+					throw new Error(
+						"Recovered notification service has an unexpected implementation",
+					);
+				}
+				recoveryByRuntime.delete(runtime);
+				recordAvailability(runtime, "registered");
+				logger.info(
+					{
+						src: "service:notification",
+						agentId: runtime.agentId,
+						attempt,
+					},
+					"NotificationService recovery succeeded",
+				);
+				return service;
+			})
+			// error-policy:J7 service recovery telemetry must not turn a handled
+			// background retry failure into an unhandled rejection.
+			.catch((error: unknown) => {
+				const failures = recovery.failures + 1;
+				const delayMs = recoveryDelayMs(failures);
+				recovery.failures = failures;
+				recovery.nextAttemptAt = Date.now() + delayMs;
+				logger.warn(
+					{
+						src: "service:notification",
+						agentId: runtime.agentId,
+						attempt,
+						retryAfterSeconds: retryAfterSeconds(delayMs),
+						error: error instanceof Error ? error.message : String(error),
+					},
+					"NotificationService recovery failed; backing off",
+				);
+				return null;
+			})
+			.finally(() => {
+				recovery.inFlight = null;
+			});
+		recovery.inFlight = inFlight;
+		recoveryByRuntime.set(runtime, recovery);
+		logger.info(
+			{
+				src: "service:notification",
+				agentId: runtime.agentId,
+				attempt,
+			},
+			"NotificationService recovery started",
+		);
+		return { state: "started", retryAfterSeconds: 1 };
 	}
 
 	static async start(runtime: IAgentRuntime): Promise<Service> {

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -654,6 +654,10 @@ export interface IAgentRuntime extends IDatabaseAdapter<object> {
 
 	hasService(serviceType: ServiceTypeName | string): boolean;
 
+	getServiceRegistrationStatus(
+		serviceType: ServiceTypeName | string,
+	): "pending" | "registering" | "registered" | "failed" | "unknown";
+
 	/**
 	 * Get the messaging adapter if the current database adapter supports it
 	 *

--- a/packages/ui/src/api/client-notifications.test.ts
+++ b/packages/ui/src/api/client-notifications.test.ts
@@ -1,13 +1,29 @@
 /**
- * Unit coverage for the notification client verbs — focused on the push-token
- * register/unregister calls that are the only client trigger for the server's
- * `/api/notifications/push-tokens` routes. Transport stubbed; no live agent.
+ * Unit coverage for notification client contracts, including the explicit
+ * disabled-inbox response and push-token verbs. Transport stubbed; no live
+ * agent.
  */
 import { describe, expect, it, vi } from "vitest";
 import { ElizaClient } from "./client-base";
 import "./client-notifications";
 
 describe("ElizaClient push-token verbs", () => {
+  it("preserves the explicit disabled inbox status from the list response", async () => {
+    const client = new ElizaClient("http://agent.example:31337", "token");
+    const response = {
+      notifications: [],
+      unreadCount: 0,
+      serviceStatus: "disabled" as const,
+    };
+    const fetch = vi.fn(async () => response);
+    client.fetch = fetch as typeof client.fetch;
+
+    await expect(client.listNotifications({ limit: 100 })).resolves.toEqual(
+      response,
+    );
+    expect(fetch).toHaveBeenCalledWith("/api/notifications?limit=100");
+  });
+
   it("POSTs the platform + token to /api/notifications/push-tokens", async () => {
     const client = new ElizaClient("http://agent.example:31337", "token");
     const fetch = vi.fn(async () => ({ ok: true }));

--- a/packages/ui/src/api/client-notifications.ts
+++ b/packages/ui/src/api/client-notifications.ts
@@ -15,6 +15,7 @@ import { ElizaClient } from "./client-base";
 export interface NotificationListResponse {
   notifications: AgentNotification[];
   unreadCount: number;
+  serviceStatus?: "ready" | "disabled";
 }
 
 export interface ListNotificationsOptions {

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -45,6 +45,7 @@ import {
   __ingestNotificationForTests,
   __resetNotificationStoreForTests,
   __setHydratedForTests,
+  __setHydrationFailureForTests,
 } from "../../state/notifications/notification-store";
 import {
   dampenPull,
@@ -522,6 +523,24 @@ describe("NotificationsHomeCenter", () => {
   it("renders nothing while the empty inbox is still hydrating", () => {
     const { container } = render(<NotificationsHomeCenter />);
     expect(container.firstChild).toBeNull();
+  });
+
+  it("renders terminal hydration failure with a working retry", async () => {
+    __setHydrationFailureForTests("private transport detail");
+    render(<NotificationsHomeCenter />);
+
+    const unavailable = screen.getByTestId("notifications-unavailable");
+    expect(unavailable.getAttribute("role")).toBe("alert");
+    expect(unavailable.textContent).toContain("Notifications unavailable");
+    expect(unavailable.textContent).not.toContain("private transport detail");
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByTestId("notifications-unavailable")).toBeNull();
+    expect(screen.queryByTestId("notifications-empty")).not.toBeNull();
   });
 
   it("reveals a subtle empty status through the normal pull gesture", () => {

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -6,6 +6,8 @@
  * fades in Apple-style when the first notification arrives. Once hydration has
  * established that the inbox is empty, pulling its quiet gesture band reveals a
  * restrained "No Notifications" status instead of producing a blank shade. The
+ * terminal load-failure state is a visible unavailable card with a manual retry,
+ * so a broken persistence path never masquerades as loading or an empty inbox. The
  * inbox container has no
  * card chrome of its own; each notification is a liquid-glass card. Groups
  * carry NO headers or dividers — the physical gap between card clusters is the
@@ -44,7 +46,7 @@
  * row.
  */
 import type { AgentNotification } from "@elizaos/core";
-import { ChevronDown, ChevronUp } from "lucide-react";
+import { ChevronDown, ChevronUp, RefreshCw } from "lucide-react";
 import { motion } from "motion/react";
 import {
   type RefObject,
@@ -64,6 +66,7 @@ import {
   clearNotifications,
   removeNotification,
   removeNotifications,
+  retryNotificationHydration,
   useNotifications,
 } from "../../state/notifications/notification-store";
 import {
@@ -378,10 +381,10 @@ export function __setNotificationsHomeCenterRenderObserverForTests(
 }
 
 /**
- * The notification inbox. Before hydration it renders nothing; a hydrated empty
- * inbox keeps only a visually quiet gesture band so a pull can reveal the empty
- * state. Mounted inline on the home column (HomeScreen), directly beneath the
- * time/weather header — the same layer as the widgets.
+ * The notification inbox. Loading, hydrated-empty, and terminal-error states
+ * remain visually distinct; the error state offers an explicit retry. Mounted
+ * inline on the home column (HomeScreen), directly beneath the time/weather
+ * header — the same layer as the widgets.
  */
 export function NotificationsHomeCenter({
   emptyGestureTargetRef,
@@ -393,7 +396,7 @@ export function NotificationsHomeCenter({
   emptyGestureTargetRef?: RefObject<HTMLElement | null>;
 } = {}): React.JSX.Element | null {
   notificationsHomeCenterRenderObserverForTests?.();
-  const { notifications, hydrated } = useNotifications();
+  const { notifications, hydrated, hydrationStatus } = useNotifications();
   // Shade mode: rested (interrupt-tier triage) vs expanded (full inbox).
   // Producer groups stay stacked until individually fanned out.
   const [shadeExpanded, setShadeExpanded] = useState(false);
@@ -1229,6 +1232,41 @@ export function NotificationsHomeCenter({
   // Do not flash an empty result while the initial request is still in flight.
   // Once hydrated, keep the transparent pull target mounted so an empty shade
   // can communicate its state instead of ignoring the gesture.
+  if (hydrationStatus === "failed") {
+    return (
+      <section
+        aria-label="Notifications"
+        data-testid="home-notification-center"
+        className="relative flex min-h-20 flex-none items-center px-1.5 py-1 text-white"
+      >
+        <style>{NOTIF_SCROLL_CSS}</style>
+        <LiquidGlassRefractionDefs />
+        <div
+          role="alert"
+          data-testid="notifications-unavailable"
+          className="eliza-notif-glass flex w-full items-center justify-between gap-3 rounded-2xl border border-orange-500/30 px-4 py-3"
+        >
+          <div className="min-w-0">
+            <p className="text-sm font-semibold text-white">
+              Notifications unavailable
+            </p>
+            <p className="mt-0.5 text-xs leading-snug text-white/60">
+              Your notification history could not be loaded. New alerts may
+              still arrive.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => void retryNotificationHydration()}
+            className="flex h-11 shrink-0 items-center gap-1.5 rounded-xl bg-orange-500 px-3 text-xs font-semibold text-black transition-colors hover:bg-orange-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-400"
+          >
+            <RefreshCw aria-hidden className="h-3.5 w-3.5" />
+            Retry
+          </button>
+        </div>
+      </section>
+    );
+  }
   if (!surfaceReady) return null;
 
   const pullPx = pullPxRef.current;

--- a/packages/ui/src/state/notifications/notification-store.test.ts
+++ b/packages/ui/src/state/notifications/notification-store.test.ts
@@ -7,6 +7,7 @@
  */
 import type { AgentNotification } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "../../api/client-types-core";
 
 const listNotifications = vi.fn();
 const markNotificationReadApi = vi.fn();
@@ -105,7 +106,7 @@ describe("notification-store", () => {
       count: 0,
       notifications: [],
     });
-    onWsEvent.mockReset();
+    onWsEvent.mockReset().mockReturnValue(() => {});
     // Defaults model the plain web platform: no desktop bridge (null), no
     // Capacitor channel ("none"), web Notification unavailable (false).
     invokeDesktopBridgeRequest.mockReset().mockResolvedValue(null);
@@ -121,6 +122,7 @@ describe("notification-store", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -260,10 +262,111 @@ describe("notification-store", () => {
     });
     initNotifications();
     initNotifications(); // idempotent
-    expect(onWsEvent).toHaveBeenCalledTimes(1);
+    expect(onWsEvent).toHaveBeenCalledTimes(2);
     expect(onWsEvent.mock.calls[0][0]).toBe("agent_event");
+    expect(onWsEvent.mock.calls[1][0]).toBe("ws-reconnected");
     expect(listNotifications).toHaveBeenCalledTimes(1);
     await Promise.resolve();
+  });
+
+  it("honors Retry-After, preserves live WS rows, and merges recovered history once", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const live = makeNotification({ id: "live", title: "From WS" });
+    const persisted = makeNotification({
+      id: "persisted",
+      title: "Persisted history",
+      createdAt: live.createdAt - 1,
+    });
+    listNotifications
+      .mockRejectedValueOnce(
+        new ApiError({
+          kind: "http",
+          path: "/api/notifications",
+          status: 503,
+          code: "NOTIFICATION_SERVICE_NOT_READY",
+          retryAfter: 2,
+          message: "Notification service is still starting",
+        }),
+      )
+      .mockResolvedValueOnce({
+        notifications: [live, persisted],
+        unreadCount: 2,
+        serviceStatus: "ready",
+      });
+
+    initNotifications();
+    const handler = onWsEvent.mock.calls[0][1] as (
+      data: Record<string, unknown>,
+    ) => void;
+    handler({
+      stream: "notification",
+      payload: { notification: live, unreadCount: 1 },
+    });
+    await flushDelivery();
+
+    expect(listNotifications).toHaveBeenCalledTimes(1);
+    expect(__getStateForTests()).toMatchObject({
+      notifications: [live],
+      hydrationStatus: "retrying",
+      hydrationAttempts: 1,
+    });
+    await vi.advanceTimersByTimeAsync(1_999);
+    expect(listNotifications).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    await flushDelivery();
+
+    const recovered = __getStateForTests();
+    expect(recovered.hydrationStatus).toBe("ready");
+    expect(recovered.hydrationError).toBeNull();
+    expect(
+      recovered.notifications.map((notification) => notification.id),
+    ).toEqual(["live", "persisted"]);
+    expect(recovered.unreadCount).toBe(2);
+    expect(listNotifications).toHaveBeenCalledTimes(2);
+    expect(onWsEvent).toHaveBeenCalledTimes(2);
+    expect(pushNotificationBanner).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops after the bounded hydrate retry budget and exposes terminal failure", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    listNotifications.mockRejectedValue(new Error("transport unavailable"));
+
+    initNotifications();
+    await flushDelivery();
+    for (let attempt = 1; attempt < 5; attempt += 1) {
+      await vi.runOnlyPendingTimersAsync();
+      await flushDelivery();
+    }
+
+    expect(listNotifications).toHaveBeenCalledTimes(5);
+    expect(vi.getTimerCount()).toBe(0);
+    expect(onWsEvent).toHaveBeenCalledTimes(2);
+    expect(__getStateForTests()).toMatchObject({
+      hydrated: false,
+      hydrationStatus: "failed",
+      hydrationAttempts: 5,
+      hydrationError: "transport unavailable",
+    });
+
+    listNotifications.mockResolvedValueOnce({
+      notifications: [makeNotification({ id: "after-reconnect" })],
+      unreadCount: 1,
+      serviceStatus: "ready",
+    });
+    const reconnectHandler = onWsEvent.mock.calls.find(
+      ([event]) => event === "ws-reconnected",
+    )?.[1] as () => void;
+    reconnectHandler();
+    await flushDelivery();
+    expect(listNotifications).toHaveBeenCalledTimes(6);
+    expect(__getStateForTests()).toMatchObject({
+      hydrated: true,
+      hydrationStatus: "ready",
+      hydrationAttempts: 1,
+      hydrationError: null,
+    });
   });
 
   it("WS handler ignores non-notification streams", async () => {

--- a/packages/ui/src/state/notifications/notification-store.ts
+++ b/packages/ui/src/state/notifications/notification-store.ts
@@ -16,11 +16,13 @@ import {
 import { logger } from "@elizaos/logger";
 import { useSyncExternalStore } from "react";
 import { client } from "../../api/client";
+import { isApiError } from "../../api/client-types-core";
 import { invokeDesktopBridgeRequest } from "../../bridge/electrobun-rpc";
 import {
   showNativeNotification,
   showWebNotification,
 } from "../../bridge/native-notifications";
+import { APP_RESUME_EVENT } from "../../events";
 import { pushNotificationBanner } from "./notification-banner-store";
 
 /**
@@ -41,17 +43,38 @@ export interface NotificationState {
   notifications: AgentNotification[];
   unreadCount: number;
   hydrated: boolean;
+  hydrationStatus:
+    | "idle"
+    | "loading"
+    | "retrying"
+    | "ready"
+    | "disabled"
+    | "failed";
+  hydrationAttempts: number;
+  hydrationError: string | null;
 }
 
 let state: NotificationState = {
   notifications: [],
   unreadCount: 0,
   hydrated: false,
+  hydrationStatus: "idle",
+  hydrationAttempts: 0,
+  hydrationError: null,
 };
 
 const listeners = new Set<() => void>();
 const ephemeralNotificationIds = new Set<string>();
 let initialized = false;
+const HYDRATION_MAX_ATTEMPTS = 5;
+const HYDRATION_BASE_DELAY_MS = 500;
+const HYDRATION_MAX_DELAY_MS = 30_000;
+const HYDRATION_JITTER_RATIO = 0.2;
+let hydrationInFlight: Promise<void> | null = null;
+let hydrationRetryTimer: ReturnType<typeof setTimeout> | null = null;
+let hydrationGeneration = 0;
+let liveEventRevision = 0;
+const notificationCleanups: Array<() => void> = [];
 
 function emit(): void {
   for (const listener of listeners) listener();
@@ -299,38 +322,176 @@ function handleWsAgentEvent(data: Record<string, unknown>): void {
   const unreadCount =
     typeof payload?.unreadCount === "number" ? payload.unreadCount : undefined;
   const deliverUpdate = payload?.type !== "notification_update";
+  liveEventRevision += 1;
   ingest(notification, unreadCount, { deliver: deliverUpdate });
 }
 
-async function hydrate(): Promise<void> {
+function mergeHydratedNotifications(
+  persisted: AgentNotification[],
+): AgentNotification[] {
+  const combined = [...state.notifications, ...persisted].sort(
+    (a, b) => b.createdAt - a.createdAt,
+  );
+  const seenIds = new Set<string>();
+  const seenGroups = new Set<string>();
+  const merged: AgentNotification[] = [];
+  for (const notification of combined) {
+    if (seenIds.has(notification.id)) continue;
+    if (notification.groupKey && seenGroups.has(notification.groupKey))
+      continue;
+    seenIds.add(notification.id);
+    if (notification.groupKey) seenGroups.add(notification.groupKey);
+    merged.push(notification);
+    if (merged.length === 300) break;
+  }
+  return merged;
+}
+
+function isRetryableHydrationError(error: unknown): boolean {
+  if (!isApiError(error)) return true;
+  if (error.kind === "network" || error.kind === "timeout") return true;
+  return (
+    error.status === 408 ||
+    error.status === 429 ||
+    (typeof error.status === "number" && error.status >= 500)
+  );
+}
+
+function hydrationRetryDelayMs(error: unknown, attempt: number): number {
+  const exponential = Math.min(
+    HYDRATION_MAX_DELAY_MS,
+    HYDRATION_BASE_DELAY_MS * 2 ** Math.max(0, attempt - 1),
+  );
+  const jitter = exponential * HYDRATION_JITTER_RATIO * (Math.random() * 2 - 1);
+  const jittered = Math.max(0, Math.round(exponential + jitter));
+  const advertised =
+    isApiError(error) && typeof error.retryAfter === "number"
+      ? error.retryAfter * 1_000
+      : 0;
+  return Math.min(HYDRATION_MAX_DELAY_MS, Math.max(jittered, advertised));
+}
+
+function hydrationErrorMessage(error: unknown): string {
+  return error instanceof Error
+    ? error.message
+    : "Notification inbox hydration failed";
+}
+
+async function runHydrationAttempt(generation: number): Promise<void> {
+  const attempt = state.hydrationAttempts + 1;
+  const liveRevisionAtStart = liveEventRevision;
+  setState({
+    hydrated: false,
+    hydrationStatus: attempt === 1 ? "loading" : "retrying",
+    hydrationAttempts: attempt,
+  });
   try {
     const res = await client.listNotifications({ limit: 100 });
+    if (generation !== hydrationGeneration) return;
+    if (hydrationRetryTimer) {
+      clearTimeout(hydrationRetryTimer);
+      hydrationRetryTimer = null;
+    }
+    const notifications = mergeHydratedNotifications(res.notifications);
+    const hydrationStatus =
+      res.serviceStatus === "disabled" ? "disabled" : "ready";
     setState({
-      notifications: res.notifications,
-      unreadCount: res.unreadCount,
+      notifications,
+      unreadCount:
+        liveEventRevision === liveRevisionAtStart
+          ? res.unreadCount
+          : state.unreadCount,
       hydrated: true,
+      hydrationStatus,
+      hydrationError: null,
     });
+    if (attempt > 1) {
+      logger.info(
+        { attempt, hydrationStatus },
+        "[notification-store] inbox hydration recovered",
+      );
+    }
   } catch (err) {
-    // error-policy:J1 transport boundary: the inbox HTTP hydrate failed
-    // (endpoint not ready at early boot, or a real 5xx/network fault). Surface
-    // it — a silent swallow here is the banned "not loaded reads as empty".
-    // Recovery is designed: mark hydrated so the surface renders (not a
-    // perpetual spinner) and the live WS stream, subscribed independently in
-    // initNotifications, still populates the inbox from the next event on.
+    // error-policy:J1 transport boundary — bounded background retries keep the
+    // live subscription active while surfacing terminal failure in store state.
+    if (generation !== hydrationGeneration) return;
+    const message = hydrationErrorMessage(err);
+    const retryable =
+      isRetryableHydrationError(err) && attempt < HYDRATION_MAX_ATTEMPTS;
+    if (!retryable) {
+      logger.error(
+        { err, attempt, retryable: isRetryableHydrationError(err) },
+        "[notification-store] inbox hydration terminal failure",
+      );
+      setState({
+        hydrated: false,
+        hydrationStatus: "failed",
+        hydrationError: message,
+      });
+      return;
+    }
+
+    const delayMs = hydrationRetryDelayMs(err, attempt);
     logger.warn(
-      { err },
-      "[notification-store] inbox hydrate failed; live WS stream will populate",
+      { err, attempt, delayMs },
+      "[notification-store] inbox hydration failed; retry scheduled",
     );
-    setState({ hydrated: true });
+    setState({
+      hydrationStatus: "retrying",
+      hydrationError: message,
+    });
+    hydrationRetryTimer = setTimeout(() => {
+      hydrationRetryTimer = null;
+      void requestHydration();
+    }, delayMs);
   }
+}
+
+function requestHydration(): Promise<void> {
+  if (hydrationInFlight) return hydrationInFlight;
+  if (state.hydrationStatus === "failed") return Promise.resolve();
+  const generation = hydrationGeneration;
+  const run = runHydrationAttempt(generation);
+  let tracked: Promise<void>;
+  tracked = run.finally(() => {
+    if (hydrationInFlight === tracked) hydrationInFlight = null;
+  });
+  hydrationInFlight = tracked;
+  return tracked;
+}
+
+function retryTerminalHydration(): void {
+  if (state.hydrationStatus !== "failed") return;
+  setState({
+    hydrated: false,
+    hydrationStatus: "idle",
+    hydrationAttempts: 0,
+    hydrationError: null,
+  });
+  void requestHydration();
 }
 
 /** Idempotent boot: hydrate the inbox and subscribe to live notifications. */
 export function initNotifications(): void {
   if (initialized) return;
   initialized = true;
-  void hydrate();
-  client.onWsEvent("agent_event", handleWsAgentEvent);
+  notificationCleanups.push(
+    client.onWsEvent("agent_event", handleWsAgentEvent),
+    client.onWsEvent("ws-reconnected", retryTerminalHydration),
+  );
+  if (typeof window !== "undefined") {
+    window.addEventListener("online", retryTerminalHydration);
+    notificationCleanups.push(() =>
+      window.removeEventListener("online", retryTerminalHydration),
+    );
+  }
+  if (typeof document !== "undefined") {
+    document.addEventListener(APP_RESUME_EVENT, retryTerminalHydration);
+    notificationCleanups.push(() =>
+      document.removeEventListener(APP_RESUME_EVENT, retryTerminalHydration),
+    );
+  }
+  void requestHydration();
 }
 
 let devSeedAttempted = false;
@@ -347,7 +508,10 @@ export async function seedDevNotificationsIfEmpty(): Promise<void> {
   if (devSeedAttempted) return;
   devSeedAttempted = true;
   // Hydrate first so we only seed a genuinely-empty inbox, never over real rows.
-  if (!state.hydrated) await hydrate();
+  if (!state.hydrated) await requestHydration();
+  if (state.hydrationStatus !== "ready" || state.hydrationError !== null) {
+    return;
+  }
   if (state.notifications.length > 0) return;
   try {
     const res = await client.seedDevNotifications();
@@ -474,7 +638,20 @@ export function useNotifications(): NotificationState {
 
 /** Test-only reset hook. */
 export function __resetNotificationStoreForTests(): void {
-  state = { notifications: [], unreadCount: 0, hydrated: false };
+  for (const cleanup of notificationCleanups.splice(0)) cleanup();
+  hydrationGeneration += 1;
+  if (hydrationRetryTimer) clearTimeout(hydrationRetryTimer);
+  hydrationRetryTimer = null;
+  hydrationInFlight = null;
+  liveEventRevision = 0;
+  state = {
+    notifications: [],
+    unreadCount: 0,
+    hydrated: false,
+    hydrationStatus: "idle",
+    hydrationAttempts: 0,
+    hydrationError: null,
+  };
   initialized = false;
   devSeedAttempted = false;
   ephemeralNotificationIds.clear();

--- a/packages/ui/src/state/notifications/notification-store.ts
+++ b/packages/ui/src/state/notifications/notification-store.ts
@@ -460,15 +460,16 @@ function requestHydration(): Promise<void> {
   return tracked;
 }
 
-function retryTerminalHydration(): void {
-  if (state.hydrationStatus !== "failed") return;
+/** Retry a terminal inbox load after a user or lifecycle recovery signal. */
+export function retryNotificationHydration(): Promise<void> {
+  if (state.hydrationStatus !== "failed") return Promise.resolve();
   setState({
     hydrated: false,
     hydrationStatus: "idle",
     hydrationAttempts: 0,
     hydrationError: null,
   });
-  void requestHydration();
+  return requestHydration();
 }
 
 /** Idempotent boot: hydrate the inbox and subscribe to live notifications. */
@@ -477,18 +478,22 @@ export function initNotifications(): void {
   initialized = true;
   notificationCleanups.push(
     client.onWsEvent("agent_event", handleWsAgentEvent),
-    client.onWsEvent("ws-reconnected", retryTerminalHydration),
+    client.onWsEvent("ws-reconnected", () => {
+      void retryNotificationHydration();
+    }),
   );
   if (typeof window !== "undefined") {
-    window.addEventListener("online", retryTerminalHydration);
+    const retryOnline = () => void retryNotificationHydration();
+    window.addEventListener("online", retryOnline);
     notificationCleanups.push(() =>
-      window.removeEventListener("online", retryTerminalHydration),
+      window.removeEventListener("online", retryOnline),
     );
   }
   if (typeof document !== "undefined") {
-    document.addEventListener(APP_RESUME_EVENT, retryTerminalHydration);
+    const retryOnResume = () => void retryNotificationHydration();
+    document.addEventListener(APP_RESUME_EVENT, retryOnResume);
     notificationCleanups.push(() =>
-      document.removeEventListener(APP_RESUME_EVENT, retryTerminalHydration),
+      document.removeEventListener(APP_RESUME_EVENT, retryOnResume),
     );
   }
   void requestHydration();
@@ -678,6 +683,16 @@ export function __ingestEphemeralNotificationForTests(
 /** Test-only: drive the hydration flag to exercise the not-loaded vs empty UI. */
 export function __setHydratedForTests(value: boolean): void {
   setState({ hydrated: value });
+}
+
+/** Test-only terminal state used to verify the designed unavailable surface. */
+export function __setHydrationFailureForTests(message: string): void {
+  setState({
+    hydrated: false,
+    hydrationStatus: "failed",
+    hydrationAttempts: HYDRATION_MAX_ATTEMPTS,
+    hydrationError: message,
+  });
 }
 
 /** Test-only snapshot of the live store state (the WS-validation path asserts the

--- a/plugins/plugin-capacitor-bridge/src/android/dispatch.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/android/dispatch.test.ts
@@ -6,7 +6,15 @@
  * streaming sink lifecycle without booting a runtime or device.
  */
 
-import type { IAgentRuntime, RouteHandlerResult } from "@elizaos/core";
+import type { IAgentRuntime, Plugin, RouteHandlerResult } from "@elizaos/core";
+import {
+	AgentRuntime,
+	createCharacter,
+	InMemoryDatabaseAdapter,
+	NotificationService,
+	type Service,
+	ServiceType,
+} from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import type { StdioBridgeStreamSink } from "../shared/stdio-bridge.ts";
 import {
@@ -18,6 +26,33 @@ import {
 } from "./dispatch.ts";
 
 const runtime = {} as IAgentRuntime;
+
+async function createNotificationRuntime(
+	services: NonNullable<Plugin["services"]> = [],
+	adapter: InMemoryDatabaseAdapter = new InMemoryDatabaseAdapter(),
+): Promise<{ runtime: AgentRuntime; cleanup: () => Promise<void> }> {
+	const runtime = new AgentRuntime({
+		character: createCharacter({ name: "AndroidNotificationDispatchTest" }),
+		adapter,
+		logLevel: "fatal",
+		enableAutonomy: false,
+	});
+	await runtime.initialize();
+	if (services.length > 0) {
+		await runtime.registerPlugin({
+			name: "android-notification-dispatch-test",
+			description: "Real notification lifecycle for Android dispatch coverage",
+			services,
+		});
+	}
+	return {
+		runtime,
+		cleanup: async () => {
+			await runtime.stop();
+			await runtime.close();
+		},
+	};
+}
 
 /** A dispatchRoute that returns a fixed buffered result for the matched path. */
 function fixedRoute(result: RouteHandlerResult | null): {
@@ -280,6 +315,7 @@ describe("dispatchBufferedRequest", () => {
 		expect(JSON.parse(list.body)).toEqual({
 			notifications: seeded,
 			unreadCount: 1,
+			serviceStatus: "ready",
 		});
 		// Served inline — the plugin dispatcher was never consulted.
 		expect(calls).toHaveLength(0);
@@ -311,20 +347,147 @@ describe("dispatchBufferedRequest", () => {
 		void push;
 	});
 
-	it("serves an empty inbox when the notification service is not up yet", async () => {
-		const noSvcRuntime = {
-			getService: () => null,
-		} as unknown as IAgentRuntime;
-		const { route } = fixedRoute(null);
-		const res = await dispatchBufferedRequest(noSvcRuntime, route, {
-			method: "GET",
-			path: "/api/notifications",
+	it("serves an explicitly disabled inbox when notification support is unregistered", async () => {
+		const disabled = await createNotificationRuntime();
+		try {
+			const { route } = fixedRoute(null);
+			const res = await dispatchBufferedRequest(disabled.runtime, route, {
+				method: "GET",
+				path: "/api/notifications",
+			});
+			expect(res.status).toBe(200);
+			expect(JSON.parse(res.body)).toEqual({
+				notifications: [],
+				unreadCount: 0,
+				serviceStatus: "disabled",
+			});
+		} finally {
+			await disabled.cleanup();
+		}
+	});
+
+	it("returns typed retryable 503 while the notification service is pending", async () => {
+		const pending = await createNotificationRuntime([NotificationService]);
+		try {
+			const { route } = fixedRoute(null);
+			const res = await dispatchBufferedRequest(pending.runtime, route, {
+				method: "GET",
+				path: "/api/notifications",
+			});
+			expect(res.status).toBe(503);
+			expect(res.headers["retry-after"]).toBe("1");
+			expect(JSON.parse(res.body)).toEqual({
+				error: "Notification service is still starting",
+				code: "NOTIFICATION_SERVICE_NOT_READY",
+				retryAfter: 1,
+			});
+		} finally {
+			await pending.cleanup();
+		}
+	});
+
+	it("returns typed retryable 503 while the notification service is registering", async () => {
+		let releaseStart = () => {};
+		const startGate = new Promise<void>((resolve) => {
+			releaseStart = resolve;
 		});
-		expect(res.status).toBe(200);
-		expect(JSON.parse(res.body)).toEqual({
-			notifications: [],
-			unreadCount: 0,
-		});
+		class SlowNotificationService extends NotificationService {
+			static override serviceType = ServiceType.NOTIFICATION;
+
+			static override async start(runtime: IAgentRuntime): Promise<Service> {
+				await startGate;
+				return NotificationService.start(runtime);
+			}
+		}
+		const registering = await createNotificationRuntime([
+			SlowNotificationService,
+		]);
+		const loading = registering.runtime.getServiceLoadPromise(
+			ServiceType.NOTIFICATION,
+		);
+		try {
+			expect(
+				registering.runtime.getServiceRegistrationStatus(
+					ServiceType.NOTIFICATION,
+				),
+			).toBe("registering");
+			const { route } = fixedRoute(null);
+			const res = await dispatchBufferedRequest(registering.runtime, route, {
+				method: "GET",
+				path: "/api/notifications",
+			});
+			expect(res.status).toBe(503);
+			expect(res.headers["retry-after"]).toBe("1");
+			expect(JSON.parse(res.body).code).toBe("NOTIFICATION_SERVICE_NOT_READY");
+		} finally {
+			releaseStart();
+			await loading;
+			await registering.cleanup();
+		}
+	});
+
+	it("recovers a failed service once and then serves its persisted rows", async () => {
+		class TransientCacheAdapter extends InMemoryDatabaseAdapter {
+			readAttempts = 0;
+
+			override async getCaches<T>(keys: string[]): Promise<Map<string, T>> {
+				this.readAttempts += 1;
+				if (this.readAttempts === 1) throw new Error("cache temporarily down");
+				return super.getCaches<T>(keys);
+			}
+		}
+		const adapter = new TransientCacheAdapter();
+		const failedRuntime = await createNotificationRuntime(
+			[NotificationService],
+			adapter,
+		);
+		try {
+			await expect(
+				failedRuntime.runtime.getServiceLoadPromise(ServiceType.NOTIFICATION),
+			).rejects.toThrow("failed to start");
+			await failedRuntime.runtime.setCache(
+				`notifications:${failedRuntime.runtime.agentId}`,
+				[
+					{
+						id: "00000000-0000-0000-0000-0000000000dd",
+						title: "Recovered Android history",
+						category: "general",
+						priority: "normal",
+						source: "test",
+						createdAt: Date.now(),
+						readAt: null,
+					},
+				],
+			);
+			const { route } = fixedRoute(null);
+			const failed = await dispatchBufferedRequest(
+				failedRuntime.runtime,
+				route,
+				{
+					method: "GET",
+					path: "/api/notifications",
+				},
+			);
+			expect(failed.status).toBe(503);
+			expect(JSON.parse(failed.body).code).toBe("NOTIFICATION_SERVICE_FAILED");
+
+			await failedRuntime.runtime.getServiceLoadPromise(
+				ServiceType.NOTIFICATION,
+			);
+			const available = await dispatchBufferedRequest(
+				failedRuntime.runtime,
+				route,
+				{ method: "GET", path: "/api/notifications" },
+			);
+			expect(available.status).toBe(200);
+			expect(JSON.parse(available.body)).toMatchObject({
+				serviceStatus: "ready",
+				notifications: [{ title: "Recovered Android history" }],
+			});
+			expect(adapter.readAttempts).toBe(2);
+		} finally {
+			await failedRuntime.cleanup();
+		}
 	});
 });
 

--- a/plugins/plugin-capacitor-bridge/src/android/dispatch.ts
+++ b/plugins/plugin-capacitor-bridge/src/android/dispatch.ts
@@ -24,7 +24,7 @@ import type {
 	IAgentRuntime,
 	RouteHandlerResult,
 } from "@elizaos/core";
-import { ServiceType } from "@elizaos/core";
+import { NotificationService, ServiceType } from "@elizaos/core";
 import type { StdioBridgeStreamSink } from "../shared/stdio-bridge.ts";
 
 /** In-process route dispatcher (from `@elizaos/agent/api`). */
@@ -137,12 +137,19 @@ function statusText(status: number): string {
 	return STATUS_TEXT[status] ?? "";
 }
 
-function jsonResponse(status: number, body: unknown): AndroidBufferedResponse {
+function jsonResponse(
+	status: number,
+	body: unknown,
+	headers: Record<string, string> = {},
+): AndroidBufferedResponse {
 	const text = JSON.stringify(body);
 	return {
 		status,
 		statusText: statusText(status),
-		headers: { "content-type": "application/json; charset=utf-8" },
+		headers: {
+			"content-type": "application/json; charset=utf-8",
+			...headers,
+		},
 		body: text,
 		bodyBase64: Buffer.from(text, "utf8").toString("base64"),
 		bodyEncoding: "base64",
@@ -227,13 +234,41 @@ async function directAndroidNotificationRoute(
 
 	const service = runtime.getService(ServiceType.NOTIFICATION);
 	if (!isAndroidNotifier(service)) {
-		// The service isn't up yet (very early boot). Serve an empty inbox on
-		// GET so the widget shows its empty state instead of erroring; fail the
-		// mutations loudly.
-		if (method === "GET" && pathname === "/api/notifications") {
-			return jsonResponse(200, { notifications: [], unreadCount: 0 });
+		const availability = NotificationService.getAvailability(runtime);
+		if (availability === "disabled") {
+			if (method === "GET" && pathname === "/api/notifications") {
+				return jsonResponse(200, {
+					notifications: [],
+					unreadCount: 0,
+					serviceStatus: "disabled",
+				});
+			}
+			return jsonResponse(503, {
+				error: "Notification service is disabled",
+				code: "NOTIFICATION_SERVICE_DISABLED",
+			});
 		}
-		return jsonResponse(503, { error: "notification service not ready" });
+		if (availability === "failed") {
+			const recovery = NotificationService.requestRecovery(runtime);
+			return jsonResponse(
+				503,
+				{
+					error: "Notification inbox is temporarily unavailable",
+					code: "NOTIFICATION_SERVICE_FAILED",
+					retryAfter: recovery.retryAfterSeconds,
+				},
+				{ "retry-after": String(recovery.retryAfterSeconds) },
+			);
+		}
+		return jsonResponse(
+			503,
+			{
+				error: "Notification service is still starting",
+				code: "NOTIFICATION_SERVICE_NOT_READY",
+				retryAfter: 1,
+			},
+			{ "retry-after": "1" },
+		);
 	}
 
 	if (method === "GET" && pathname === "/api/notifications") {
@@ -253,6 +288,7 @@ async function directAndroidNotificationRoute(
 		return jsonResponse(200, {
 			notifications,
 			unreadCount: service.getUnreadCount(),
+			serviceStatus: "ready",
 		});
 	}
 


### PR DESCRIPTION
# Summary

Notification hydration now fails closed and recovers observably. A terminal inbox failure renders a distinct error card with Retry, background recovery reports through `runtime.reportError`, and a successful retry restores the persisted notification state.

# What changed

- Extends the notification lifecycle runtime contract with `reportError` and reports every J7 recovery failure with scope, attempt, and retry delay.
- Exposes an explicit hydration retry operation used by lifecycle callbacks and the UI.
- Renders loading, error, empty, and recovered inbox states distinctly; the error card does not leak raw backend details.
- Adds component and lifecycle coverage for terminal failure, owner-visible reporting, retry, and recovery.

# Validation

- Exact rebased head: `eb756ba77be78d782c3168bba40c22286dace516`.
- UI Vitest: 3 files / 113 tests passed.
- Bun server/core/Android bridge focused tests passed.
- Core, UI, and Capacitor bridge typechecks passed.
- App audit: 246/246 Playwright cases passed; 227 good, 17 needs-eyeball, 0 needs-work, 0 broken.
- OCR triage: 244 views, 0 broken, 0 new regressions.
- PostgreSQL 17 outage/recovery: HTTP 503 while unavailable, `NotificationService.recovery` recorded in the runtime error ring, then HTTP 200 after recovery with the original persisted row.
- Real Vite browser against the real backend: desktop/mobile loading → error → Retry → recovered notification; no page errors.
- Exact-head Android cloud-debug APK built successfully, was installed on a clean Android 34 emulator, and its on-device SHA-256 matched the local APK (`0dfd19d876fd…`). The renderer stamp records commit `eb756ba77be78d782c3168bba40c22286dace516`, cloud runtime mode, Android target, and build `cce0a035ce81…`. A fresh install correctly stops at cloud sign-in, so the authenticated notification transition is proven by the real browser capture rather than misrepresented as an authenticated device flow.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: [desktop terminal-failure state](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16258-error-desktop.jpg) and [mobile terminal-failure state](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16258-error-mobile.jpg).
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: [desktop recovered notification](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16258-recovered-desktop.jpg), [mobile recovered notification](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16258-recovered-mobile.jpg), and [desktop Retry hover](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16258-error-desktop-hover.jpg).
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: [desktop outage/recovery MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16258-notification-recovery-desktop.mp4), [mobile outage/recovery MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16258-notification-recovery-mobile.mp4), [reviewed contact sheet](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16258-desktop-contact-sheet.jpg), and [exact-head Android recording](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16258-exact-head-android.mp4).
<!-- evidence-row:backend-logs -->
- [x] Backend logs: [structured outage/recovery log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16258-live-ui-backend.log) and [focused PostgreSQL lifecycle log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16258-live-postgres-backend.log) show failed DB operations, the `NotificationService.recovery` report, backoff, and successful recovery.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: [browser event trace](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16258-frontend-console-network.json) records repeated notification 503s followed by desktop/mobile 200s with no page errors; [exact-head Android logcat](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16258-exact-head-android-logcat.txt) contains no fatal app exception.
<!-- evidence-row:ocr-review -->
- [x] OCR visual text review: [exact-head OCR triage](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16258-exact-head-ocr-triage.json) reports 0 broken views and 0 new regressions; [aesthetic report](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16258-exact-head-aesthetic-report.json) and [head manifest](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16258-exact-head-manifest.json) bind the result to the rebased head.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A — notification persistence, lifecycle diagnostics, and UI state rendering changed; no prompt, model, action, provider, or evaluator behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [PostgreSQL recovery trace and persisted row](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16258-live-postgres-recovery.json), [exact-head Android installed-build screenshot](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16258-exact-head-android-installed.jpg), [renderer build stamp](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16258-exact-head-renderer-build.json), and [Android accessibility tree](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16258-exact-head-android-window.xml).

# Manual review

The desktop/mobile error and recovered captures were opened and inspected. The error card is visually distinct, readable, unclipped, and uses orange only as the action accent; the mobile Retry target is at least 44 px. The contact sheet confirms the state transition. The exact-head audit and OCR reports were inspected and contain no broken/needs-work verdicts or new OCR regressions. The exact-head Android screenshot, renderer stamp, hierarchy, recording, and logcat were also opened/reviewed; they identify the expected current app and sign-in boundary without claiming an authenticated session.

# Risk

Medium. This changes a cross-layer failure path. The implementation fails closed, reports repeated systemic failures to the agent/owner channel, and restores state only after the real durable store is healthy.
