### PR TITLE
fix(cloud): make CLI auth token retrieval single-use

### DIFF
--- a/packages/cloud/api/auth/cli-session/[sessionId]/route.single-use.integration.test.ts
+++ b/packages/cloud/api/auth/cli-session/[sessionId]/route.single-use.integration.test.ts
@@ -15,8 +15,10 @@ import {
 } from "bun:test";
 import { Hono } from "hono";
 
-process.env.DATABASE_URL = "pglite://memory";
-process.env.TEST_DATABASE_URL = "pglite://memory";
+const databaseUrl =
+  process.env.CLI_AUTH_POSTGRES_URL?.trim() || "pglite://memory";
+process.env.DATABASE_URL = databaseUrl;
+process.env.TEST_DATABASE_URL = databaseUrl;
 process.env.NODE_ENV ||= "test";
 
 const USER_ID = "11111111-1111-4111-8111-111111111111";
@@ -68,6 +70,7 @@ let closeDb:
   | typeof import("../../../../shared/src/db/client").closeDatabaseConnectionsForTests
   | undefined;
 let cliAuthSessionsRepository: typeof import("../../../../shared/src/db/repositories/cli-auth-sessions").cliAuthSessionsRepository;
+let apiKeysRepository: typeof import("../../../../shared/src/db/repositories/api-keys").apiKeysRepository;
 let cliAuthSessionsService: typeof import("../../../../shared/src/lib/services/cli-auth-sessions").cliAuthSessionsService;
 let pollApp: Hono;
 let legacyPollApp: Hono;
@@ -94,6 +97,9 @@ beforeAll(async () => {
 
   ({ cliAuthSessionsRepository } = await import(
     "../../../../shared/src/db/repositories/cli-auth-sessions"
+  ));
+  ({ apiKeysRepository } = await import(
+    "../../../../shared/src/db/repositories/api-keys"
   ));
   ({ cliAuthSessionsService } = await import(
     "../../../../shared/src/lib/services/cli-auth-sessions"
@@ -305,8 +311,10 @@ describe("CLI session single-use plaintext retrieval with real persistence", () 
     const response = await pollApp.request(
       `/api/auth/cli-session/${sessionId}`,
     );
-    expect(response.status).toBe(200);
-    expect(await response.json()).not.toHaveProperty("apiKey");
+    expect(response.status).toBe(500);
+    expect(await response.json()).toMatchObject({
+      error: "Failed to get session status",
+    });
     expect(decryptCalls).toBe(0);
     expect(await readSession(sessionId)).toMatchObject({
       status: "authenticated",
@@ -314,19 +322,56 @@ describe("CLI session single-use plaintext retrieval with real persistence", () 
     });
   });
 
-  test("the legacy poll route does not expire a session when encrypted key lookup is incomplete", async () => {
+  test("incomplete encrypted key material is an observable integrity failure", async () => {
     const sessionId = "missing-key-material";
     await seedAuthenticatedSession(sessionId, { completeEncryptedKey: false });
 
     const response = await legacyPollApp.request(
       `/api/eliza-app/cli-auth/poll?session_id=${sessionId}`,
     );
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(500);
     expect(await response.json()).toMatchObject({
-      status: "authenticated",
-      token: null,
+      success: false,
+      error: "Failed to poll session",
     });
     expect(decryptCalls).toBe(0);
+    expect(await readSession(sessionId)).toMatchObject({
+      status: "authenticated",
+      consumed_at: null,
+    });
+  });
+
+  test("a real API-key regeneration update invalidates a decrypted candidate before claim", async () => {
+    const sessionId = "regenerated-during-decrypt";
+    await seedAuthenticatedSession(sessionId);
+
+    let signalDecryptStarted: (() => void) | undefined;
+    const decryptStarted = new Promise<void>((resolve) => {
+      signalDecryptStarted = resolve;
+    });
+    let releaseDecrypt: (() => void) | undefined;
+    const decryptReleased = new Promise<void>((resolve) => {
+      releaseDecrypt = resolve;
+    });
+    decryptHook = async () => {
+      signalDecryptStarted?.();
+      await decryptReleased;
+    };
+
+    const pendingResponse = pollApp.request(
+      `/api/auth/cli-session/${sessionId}`,
+    );
+    await within(decryptStarted, "regeneration rendezvous");
+    await apiKeysRepository.update(API_KEY_ID, {
+      key_hash: "regenerated-hash",
+      key_prefix: "eliza_regenerated",
+      key_ciphertext: "regenerated-ciphertext",
+    });
+    releaseDecrypt?.();
+
+    const response = await pendingResponse;
+    expect(response.status).toBe(200);
+    expect(await response.json()).not.toHaveProperty("apiKey");
     expect(await readSession(sessionId)).toMatchObject({
       status: "authenticated",
       consumed_at: null,

--- a/packages/cloud/api/auth/cli-session/[sessionId]/route.single-use.integration.test.ts
+++ b/packages/cloud/api/auth/cli-session/[sessionId]/route.single-use.integration.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Real-persistence regression coverage for the single-use CLI key reveal.
+ *
+ * The HTTP route, service, repositories, Drizzle queries, and PGlite database
+ * are real. Only the external KMS decrypt boundary and logger are controlled.
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import { Hono } from "hono";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+const USER_ID = "11111111-1111-4111-8111-111111111111";
+const OTHER_USER_ID = "44444444-4444-4444-8444-444444444444";
+const ORG_ID = "22222222-2222-4222-8222-222222222222";
+const API_KEY_ID = "33333333-3333-4333-8333-333333333333";
+const PLAINTEXT = "eliza_single_winner_plaintext";
+
+let decryptMode: "success" | "failure" = "success";
+let decryptCalls = 0;
+let concurrentDecryptGate: Promise<void> | null = null;
+let releaseConcurrentDecrypts: (() => void) | null = null;
+let decryptHook: (() => Promise<void>) | null = null;
+
+// Bun module mocks are process-wide across test files. Preserve the real
+// encryption export so this reveal-only decrypt seam cannot poison the CLI
+// completion integration tests when both files share a test process.
+const { encryptApiKey } = await import(
+  "../../../../shared/src/db/crypto/api-keys"
+);
+
+mock.module("../../../../shared/src/db/crypto/api-keys", () => ({
+  decryptApiKey: async () => {
+    decryptCalls += 1;
+    if (decryptMode === "failure") {
+      throw new Error("controlled KMS failure");
+    }
+
+    await decryptHook?.();
+
+    if (concurrentDecryptGate) {
+      if (decryptCalls === 2) {
+        releaseConcurrentDecrypts?.();
+      }
+      await within(concurrentDecryptGate, "concurrent decrypt rendezvous");
+    }
+
+    return PLAINTEXT;
+  },
+  encryptApiKey,
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { debug() {}, info() {}, warn() {}, error() {} },
+}));
+
+let dbWrite: typeof import("../../../../shared/src/db/client").dbWrite;
+let closeDb:
+  | typeof import("../../../../shared/src/db/client").closeDatabaseConnectionsForTests
+  | undefined;
+let cliAuthSessionsRepository: typeof import("../../../../shared/src/db/repositories/cli-auth-sessions").cliAuthSessionsRepository;
+let cliAuthSessionsService: typeof import("../../../../shared/src/lib/services/cli-auth-sessions").cliAuthSessionsService;
+let pollApp: Hono;
+let legacyPollApp: Hono;
+
+beforeAll(async () => {
+  ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import(
+    "../../../../shared/src/db/client"
+  ));
+  await dbWrite.execute(`CREATE TABLE api_keys (
+    id uuid PRIMARY KEY, name text NOT NULL, description text, key_hash text NOT NULL UNIQUE,
+    key_prefix text NOT NULL, key_ciphertext text, key_nonce text, key_auth_tag text,
+    key_kms_key_id text, key_kms_key_version integer, organization_id uuid NOT NULL,
+    user_id uuid NOT NULL, rate_limit integer NOT NULL DEFAULT 1000,
+    is_active boolean NOT NULL DEFAULT true, usage_count integer NOT NULL DEFAULT 0,
+    expires_at timestamp, last_used_at timestamp, created_at timestamp NOT NULL DEFAULT now(),
+    updated_at timestamp NOT NULL DEFAULT now(), deleted_at timestamp
+  )`);
+  await dbWrite.execute(`CREATE TABLE cli_auth_sessions (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(), session_id text NOT NULL UNIQUE,
+    user_id uuid, api_key_id uuid, consumed_at timestamp, status text NOT NULL DEFAULT 'pending',
+    expires_at timestamp NOT NULL, authenticated_at timestamp,
+    created_at timestamp NOT NULL DEFAULT now(), updated_at timestamp NOT NULL DEFAULT now()
+  )`);
+
+  ({ cliAuthSessionsRepository } = await import(
+    "../../../../shared/src/db/repositories/cli-auth-sessions"
+  ));
+  ({ cliAuthSessionsService } = await import(
+    "../../../../shared/src/lib/services/cli-auth-sessions"
+  ));
+
+  const pollRoute = await import("./route");
+  pollApp = new Hono();
+  pollApp.route("/api/auth/cli-session/:sessionId", pollRoute.default);
+
+  const legacyPollRoute = await import(
+    "../../../eliza-app/cli-auth/poll/route"
+  );
+  legacyPollApp = new Hono();
+  legacyPollApp.route("/api/eliza-app/cli-auth/poll", legacyPollRoute.default);
+}, 60_000);
+
+afterAll(async () => {
+  await closeDb?.();
+});
+
+beforeEach(async () => {
+  decryptMode = "success";
+  decryptCalls = 0;
+  concurrentDecryptGate = null;
+  releaseConcurrentDecrypts = null;
+  decryptHook = null;
+  await dbWrite.execute("DELETE FROM cli_auth_sessions");
+  await dbWrite.execute("DELETE FROM api_keys");
+});
+
+async function seedAuthenticatedSession(
+  sessionId: string,
+  options: {
+    completeEncryptedKey?: boolean;
+    sessionUserId?: string;
+  } = {},
+): Promise<void> {
+  const completeEncryptedKey = options.completeEncryptedKey ?? true;
+  const sessionUserId = options.sessionUserId ?? USER_ID;
+  await dbWrite.execute(`INSERT INTO api_keys
+    (id, name, key_hash, key_prefix, key_ciphertext, key_nonce, key_auth_tag,
+      key_kms_key_id, key_kms_key_version, organization_id, user_id)
+    VALUES ('${API_KEY_ID}', 'CLI key', 'hash', 'eliza_single',
+      ${completeEncryptedKey ? "'ciphertext'" : "NULL"}, 'nonce', 'auth-tag',
+      'kms-key', 1, '${ORG_ID}', '${USER_ID}')`);
+  await dbWrite.execute(`INSERT INTO cli_auth_sessions
+    (session_id, user_id, api_key_id, status, expires_at, authenticated_at)
+    VALUES ('${sessionId}', '${sessionUserId}', '${API_KEY_ID}', 'authenticated',
+      now() + interval '10 minutes', now())`);
+}
+
+async function readSession(
+  sessionId: string,
+): Promise<Record<string, unknown>> {
+  const result = await dbWrite.execute(
+    `SELECT status, consumed_at FROM cli_auth_sessions WHERE session_id = '${sessionId}'`,
+  );
+  return result.rows[0] as Record<string, unknown>;
+}
+
+async function within<T>(promise: Promise<T>, label: string): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error(`${label} timed out`)),
+          5_000,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+describe("CLI session single-use plaintext retrieval with real persistence", () => {
+  test("the session lifecycle still uses the real repository guards", async () => {
+    const sessionId = "lifecycle";
+    const created = await cliAuthSessionsService.createSession(sessionId);
+    expect(created).toMatchObject({ session_id: sessionId, status: "pending" });
+    expect(await cliAuthSessionsService.getSession(sessionId)).toMatchObject({
+      session_id: sessionId,
+    });
+    expect(
+      await cliAuthSessionsService.getActiveSession(sessionId),
+    ).toMatchObject({
+      status: "pending",
+    });
+
+    const authenticated = await cliAuthSessionsRepository.markAuthenticated(
+      sessionId,
+      USER_ID,
+      API_KEY_ID,
+    );
+    expect(authenticated).toMatchObject({
+      status: "authenticated",
+      user_id: USER_ID,
+      api_key_id: API_KEY_ID,
+    });
+
+    await cliAuthSessionsRepository.markExpired(sessionId);
+    expect(await cliAuthSessionsService.getSession(sessionId)).toMatchObject({
+      status: "expired",
+    });
+    await cliAuthSessionsRepository.update(sessionId, {
+      expires_at: new Date(Date.now() - 1_000),
+    });
+    await cliAuthSessionsService.cleanupExpiredSessions();
+    expect(await cliAuthSessionsService.getSession(sessionId)).toBeNull();
+  });
+
+  test("two concurrent poll routes decrypt the candidate but exactly one returns plaintext", async () => {
+    const sessionId = "concurrent-poll";
+    await seedAuthenticatedSession(sessionId);
+
+    concurrentDecryptGate = new Promise<void>((resolve) => {
+      releaseConcurrentDecrypts = resolve;
+    });
+
+    const [first, second] = await Promise.all([
+      pollApp.request(`/api/auth/cli-session/${sessionId}`),
+      pollApp.request(`/api/auth/cli-session/${sessionId}`),
+    ]);
+    const payloads = (await Promise.all([
+      first.json(),
+      second.json(),
+    ])) as Array<Record<string, unknown>>;
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(decryptCalls).toBe(2);
+    expect(
+      payloads.filter((payload) => payload.apiKey === PLAINTEXT),
+    ).toHaveLength(1);
+    expect(payloads.filter((payload) => !("apiKey" in payload))).toHaveLength(
+      1,
+    );
+    expect(await readSession(sessionId)).toMatchObject({
+      status: "authenticated",
+      consumed_at: expect.any(String),
+    });
+  });
+
+  test("a decrypt failure does not consume the session and a retry can win", async () => {
+    const sessionId = "decrypt-retry";
+    await seedAuthenticatedSession(sessionId);
+    decryptMode = "failure";
+
+    const failed = await pollApp.request(`/api/auth/cli-session/${sessionId}`);
+    expect(failed.status).toBe(500);
+    expect(await readSession(sessionId)).toMatchObject({
+      status: "authenticated",
+      consumed_at: null,
+    });
+
+    decryptMode = "success";
+    const retried = await pollApp.request(`/api/auth/cli-session/${sessionId}`);
+    expect(retried.status).toBe(200);
+    expect(await retried.json()).toMatchObject({ apiKey: PLAINTEXT });
+    expect(await readSession(sessionId)).toMatchObject({
+      status: "authenticated",
+      consumed_at: expect.any(String),
+    });
+  });
+
+  test("a stale candidate cannot consume a session whose owner changes during decrypt", async () => {
+    const sessionId = "stale-candidate";
+    await seedAuthenticatedSession(sessionId);
+
+    let signalDecryptStarted: (() => void) | undefined;
+    const decryptStarted = new Promise<void>((resolve) => {
+      signalDecryptStarted = resolve;
+    });
+    let releaseDecrypt: (() => void) | undefined;
+    const decryptReleased = new Promise<void>((resolve) => {
+      releaseDecrypt = resolve;
+    });
+    decryptHook = async () => {
+      signalDecryptStarted?.();
+      await decryptReleased;
+    };
+
+    const pendingResponse = pollApp.request(
+      `/api/auth/cli-session/${sessionId}`,
+    );
+    await within(decryptStarted, "decrypt rendezvous");
+    await dbWrite.execute(
+      `UPDATE cli_auth_sessions SET user_id = '${OTHER_USER_ID}' WHERE session_id = '${sessionId}'`,
+    );
+    releaseDecrypt?.();
+
+    const response = await pendingResponse;
+    expect(response.status).toBe(200);
+    expect(await response.json()).not.toHaveProperty("apiKey");
+    expect(await readSession(sessionId)).toMatchObject({
+      status: "authenticated",
+      consumed_at: null,
+    });
+  });
+
+  test("a session/API-key owner mismatch is rejected before decrypt", async () => {
+    const sessionId = "mismatched-owner";
+    await seedAuthenticatedSession(sessionId, {
+      sessionUserId: OTHER_USER_ID,
+    });
+
+    const response = await pollApp.request(
+      `/api/auth/cli-session/${sessionId}`,
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).not.toHaveProperty("apiKey");
+    expect(decryptCalls).toBe(0);
+    expect(await readSession(sessionId)).toMatchObject({
+      status: "authenticated",
+      consumed_at: null,
+    });
+  });
+
+  test("the legacy poll route does not expire a session when encrypted key lookup is incomplete", async () => {
+    const sessionId = "missing-key-material";
+    await seedAuthenticatedSession(sessionId, { completeEncryptedKey: false });
+
+    const response = await legacyPollApp.request(
+      `/api/eliza-app/cli-auth/poll?session_id=${sessionId}`,
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      status: "authenticated",
+      token: null,
+    });
+    expect(decryptCalls).toBe(0);
+    expect(await readSession(sessionId)).toMatchObject({
+      status: "authenticated",
+      consumed_at: null,
+    });
+  });
+});

--- a/packages/cloud/api/auth/cli-session/[sessionId]/route.ts
+++ b/packages/cloud/api/auth/cli-session/[sessionId]/route.ts
@@ -39,10 +39,20 @@ app.get("/", async (c) => {
     if (session.status === "authenticated") {
       const apiKeyData =
         await cliAuthSessionsService.getAndClearApiKey(sessionId);
-      if (!apiKeyData) {
+      if (apiKeyData.status === "unavailable") {
+        if (
+          apiKeyData.reason === "consumed" ||
+          apiKeyData.reason === "claim-lost"
+        ) {
+          return c.json(
+            { status: "authenticated", message: "API key already retrieved" },
+            200,
+            corsHeaders,
+          );
+        }
         return c.json(
-          { status: "authenticated", message: "API key already retrieved" },
-          200,
+          { error: `API key unavailable: ${apiKeyData.reason}` },
+          apiKeyData.reason === "not-found" ? 404 : 410,
           corsHeaders,
         );
       }

--- a/packages/cloud/api/eliza-app/cli-auth/poll/route.ts
+++ b/packages/cloud/api/eliza-app/cli-auth/poll/route.ts
@@ -43,10 +43,15 @@ app.get("/", async (c) => {
       );
       const retrieved =
         await cliAuthSessionsService.getAndClearApiKey(sessionId);
-      await db
-        .update(cliAuthSessions)
-        .set({ status: "expired" })
-        .where(eq(cliAuthSessions.session_id, sessionId));
+      // Preserve the legacy terminal status only after this poll actually won
+      // the reveal claim. A missing key or failed decrypt must leave the
+      // authenticated session retryable instead of expiring it permanently.
+      if (retrieved) {
+        await db
+          .update(cliAuthSessions)
+          .set({ status: "expired" })
+          .where(eq(cliAuthSessions.session_id, sessionId));
+      }
       return c.json({
         success: true,
         status: "authenticated",

--- a/packages/cloud/api/eliza-app/cli-auth/poll/route.ts
+++ b/packages/cloud/api/eliza-app/cli-auth/poll/route.ts
@@ -46,7 +46,7 @@ app.get("/", async (c) => {
       // Preserve the legacy terminal status only after this poll actually won
       // the reveal claim. A missing key or failed decrypt must leave the
       // authenticated session retryable instead of expiring it permanently.
-      if (retrieved) {
+      if (retrieved.status === "revealed") {
         await db
           .update(cliAuthSessions)
           .set({ status: "expired" })
@@ -54,8 +54,12 @@ app.get("/", async (c) => {
       }
       return c.json({
         success: true,
-        status: "authenticated",
-        token: retrieved?.apiKey ?? null,
+        status:
+          retrieved.status === "unavailable" &&
+          (retrieved.reason === "expired" || retrieved.reason === "revoked")
+            ? "expired"
+            : "authenticated",
+        token: retrieved.status === "revealed" ? retrieved.apiKey : null,
       });
     }
 

--- a/packages/cloud/api/v1/cli-auth/[session]/token/route.test.ts
+++ b/packages/cloud/api/v1/cli-auth/[session]/token/route.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Legacy CLI token retrieval is exercised through its real Hono route while
+ * the durable session service is isolated to cover every HTTP boundary state.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+type Session = {
+  consumed_at: Date | null;
+  expires_at: Date;
+  status: "pending" | "authenticated" | "expired";
+};
+
+const getSession = mock(
+  async (_sessionId: string): Promise<Session | null> => ({
+    consumed_at: null,
+    expires_at: new Date(Date.now() + 60_000),
+    status: "authenticated",
+  }),
+);
+
+const getAndClearApiKey = mock(async (_sessionId: string) => ({
+  status: "claimed" as const,
+  apiKey: "eliz_legacy_single_use",
+  keyPrefix: "eliz_leg",
+  expiresAt: new Date("2026-08-01T00:00:00.000Z"),
+}));
+
+const loggerError = mock(() => undefined);
+
+mock.module("@/lib/services/cli-auth-sessions", () => ({
+  cliAuthSessionsService: { getAndClearApiKey, getSession },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { error: loggerError },
+}));
+
+const { default: tokenRoute } = await import("./route");
+
+const app = new Hono();
+app.route("/api/v1/cli-auth/:session/token", tokenRoute);
+
+function poll(session = "session-1", origin?: string) {
+  return app.fetch(
+    new Request(`https://api.example.test/api/v1/cli-auth/${session}/token`, {
+      headers: origin ? { origin } : undefined,
+    }),
+  );
+}
+
+describe("GET /api/v1/cli-auth/:session/token", () => {
+  beforeEach(() => {
+    getSession.mockReset();
+    getAndClearApiKey.mockReset();
+    loggerError.mockClear();
+    getSession.mockResolvedValue({
+      consumed_at: null,
+      expires_at: new Date(Date.now() + 60_000),
+      status: "authenticated",
+    });
+    getAndClearApiKey.mockResolvedValue({
+      status: "claimed",
+      apiKey: "eliz_legacy_single_use",
+      keyPrefix: "eliz_leg",
+      expiresAt: new Date("2026-08-01T00:00:00.000Z"),
+    });
+  });
+
+  test("reveals a claimed key once and preserves CORS", async () => {
+    const response = await poll("session-1", "http://localhost:5173");
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("access-control-allow-origin")).toBe(
+      "http://localhost:5173",
+    );
+    await expect(response.json()).resolves.toEqual({
+      apiKey: "eliz_legacy_single_use",
+      keyPrefix: "eliz_leg",
+      expiresAt: "2026-08-01T00:00:00.000Z",
+    });
+    expect(getAndClearApiKey).toHaveBeenCalledWith("session-1");
+  });
+
+  test("returns explicit non-secret states before a session is claimable", async () => {
+    getSession.mockResolvedValueOnce(null);
+    expect((await poll()).status).toBe(404);
+
+    getSession.mockResolvedValueOnce({
+      consumed_at: new Date(),
+      expires_at: new Date(Date.now() + 60_000),
+      status: "authenticated",
+    });
+    expect((await poll()).status).toBe(410);
+
+    getSession.mockResolvedValueOnce({
+      consumed_at: null,
+      expires_at: new Date(Date.now() - 1),
+      status: "authenticated",
+    });
+    expect((await poll()).status).toBe(410);
+
+    getSession.mockResolvedValueOnce({
+      consumed_at: null,
+      expires_at: new Date(Date.now() + 60_000),
+      status: "pending",
+    });
+    const pending = await poll();
+    expect(pending.status).toBe(202);
+    await expect(pending.json()).resolves.toEqual({ status: "pending" });
+    expect(getAndClearApiKey).not.toHaveBeenCalled();
+  });
+
+  test("keeps losing claim outcomes plaintext-free", async () => {
+    getAndClearApiKey.mockResolvedValueOnce({
+      status: "unavailable",
+      reason: "already-consumed",
+    });
+
+    const response = await poll();
+    expect(response.status).toBe(410);
+    const body = await response.json();
+    expect(body).toEqual({ error: "Token unavailable: already-consumed" });
+    expect(JSON.stringify(body)).not.toContain("eliz_");
+  });
+
+  test("translates service failures without exposing their details", async () => {
+    getAndClearApiKey.mockRejectedValueOnce(new Error("kms ciphertext leaked"));
+
+    const response = await poll();
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: "Failed to retrieve CLI token",
+    });
+    expect(loggerError).toHaveBeenCalledTimes(1);
+  });
+
+  test("answers preflight without touching persistence", async () => {
+    const response = await app.fetch(
+      new Request("https://api.example.test/api/v1/cli-auth/session-1/token", {
+        method: "OPTIONS",
+        headers: { origin: "http://localhost:5173" },
+      }),
+    );
+
+    expect(response.status).toBe(204);
+    expect(getSession).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/cli-auth/[session]/token/route.test.ts
+++ b/packages/cloud/api/v1/cli-auth/[session]/token/route.test.ts
@@ -12,6 +12,18 @@ type Session = {
   status: "pending" | "authenticated" | "expired";
 };
 
+type ClaimResult =
+  | {
+      status: "claimed";
+      apiKey: string;
+      keyPrefix: string;
+      expiresAt: Date;
+    }
+  | {
+      status: "unavailable";
+      reason: "already-consumed";
+    };
+
 const getSession = mock(
   async (_sessionId: string): Promise<Session | null> => ({
     consumed_at: null,
@@ -20,12 +32,14 @@ const getSession = mock(
   }),
 );
 
-const getAndClearApiKey = mock(async (_sessionId: string) => ({
-  status: "claimed" as const,
-  apiKey: "eliz_legacy_single_use",
-  keyPrefix: "eliz_leg",
-  expiresAt: new Date("2026-08-01T00:00:00.000Z"),
-}));
+const getAndClearApiKey = mock(
+  async (_sessionId: string): Promise<ClaimResult> => ({
+    status: "claimed",
+    apiKey: "eliz_legacy_single_use",
+    keyPrefix: "eliz_leg",
+    expiresAt: new Date("2026-08-01T00:00:00.000Z"),
+  }),
+);
 
 const loggerError = mock(() => undefined);
 

--- a/packages/cloud/api/v1/cli-auth/[session]/token/route.ts
+++ b/packages/cloud/api/v1/cli-auth/[session]/token/route.ts
@@ -22,6 +22,7 @@ app.options("/", (c) => {
 
 app.get("/", async (c) => {
   const corsHeaders = getCorsHeaders(c.req.header("origin") ?? null);
+  // error-policy:J1 The HTTP boundary translates integrity and dependency failures without disclosing key material.
   try {
     const sessionId = c.req.param("session");
     if (!sessionId) {

--- a/packages/cloud/api/v1/cli-auth/[session]/token/route.ts
+++ b/packages/cloud/api/v1/cli-auth/[session]/token/route.ts
@@ -44,8 +44,12 @@ app.get("/", async (c) => {
 
     const apiKeyData =
       await cliAuthSessionsService.getAndClearApiKey(sessionId);
-    if (!apiKeyData) {
-      return c.json({ error: "Token unavailable" }, 410, corsHeaders);
+    if (apiKeyData.status === "unavailable") {
+      return c.json(
+        { error: `Token unavailable: ${apiKeyData.reason}` },
+        apiKeyData.reason === "not-found" ? 404 : 410,
+        corsHeaders,
+      );
     }
 
     return c.json(

--- a/packages/cloud/shared/src/db/repositories/cli-auth-sessions.ts
+++ b/packages/cloud/shared/src/db/repositories/cli-auth-sessions.ts
@@ -1,6 +1,7 @@
 // Persists cli auth sessions records for cloud services through the shared DB boundary.
-import { and, eq, gt, lt } from "drizzle-orm";
+import { and, eq, gt, isNotNull, isNull, lt } from "drizzle-orm";
 import { dbRead, dbWrite } from "../helpers";
+import { type ApiKey, apiKeys } from "../schemas/api-keys";
 import {
   type CliAuthSession,
   cliAuthSessions,
@@ -8,6 +9,11 @@ import {
 } from "../schemas/cli-auth-sessions";
 
 export type { CliAuthSession, NewCliAuthSession };
+
+export interface CliAuthApiKeyRevealCandidate {
+  session: CliAuthSession;
+  apiKey: ApiKey;
+}
 
 /**
  * Repository for CLI authentication session database operations.
@@ -47,6 +53,37 @@ export class CliAuthSessionsRepository {
   // ============================================================================
   // WRITE OPERATIONS (use primary)
   // ============================================================================
+
+  /**
+   * Loads an eligible reveal candidate from the primary database.
+   *
+   * CLI completion writes the session and API-key row on the primary, then the
+   * CLI polls immediately. A replica read here can observe a false miss or an
+   * older session state, so the complete candidate is read consistently in one
+   * joined query before the external KMS decrypt.
+   */
+  async findApiKeyRevealCandidate(
+    sessionId: string,
+  ): Promise<CliAuthApiKeyRevealCandidate | undefined> {
+    const now = new Date();
+    const [candidate] = await dbWrite
+      .select({ session: cliAuthSessions, apiKey: apiKeys })
+      .from(cliAuthSessions)
+      .innerJoin(apiKeys, eq(cliAuthSessions.api_key_id, apiKeys.id))
+      .where(
+        and(
+          eq(cliAuthSessions.session_id, sessionId),
+          eq(cliAuthSessions.status, "authenticated"),
+          isNotNull(cliAuthSessions.user_id),
+          eq(apiKeys.user_id, cliAuthSessions.user_id),
+          gt(cliAuthSessions.expires_at, now),
+          isNull(cliAuthSessions.consumed_at),
+        ),
+      )
+      .limit(1);
+
+    return candidate;
+  }
 
   /**
    * Creates a new CLI auth session.
@@ -99,18 +136,38 @@ export class CliAuthSessionsRepository {
   }
 
   /**
-   * Marks a session's API key as consumed (single-use token flow, D-6).
-   * The actual decrypted plaintext is returned directly by the route
-   * handler from the encrypted api_keys row — it is never persisted here.
+   * Atomically claims a session's single-use plaintext reveal (D-6).
+   *
+   * Every eligibility condition used before decryption is repeated on the
+   * primary write. Concurrent pollers may both do the read/decrypt work, but
+   * only the update winner receives the plaintext. Matching the expected key
+   * and owner also prevents a stale read from consuming a changed session.
    */
-  async markConsumed(sessionId: string): Promise<void> {
-    await dbWrite
+  async claimConsumed(
+    sessionId: string,
+    expectedApiKeyId: string,
+    expectedUserId: string,
+  ): Promise<CliAuthSession | undefined> {
+    const consumedAt = new Date();
+    const [claimed] = await dbWrite
       .update(cliAuthSessions)
       .set({
-        consumed_at: new Date(),
-        updated_at: new Date(),
+        consumed_at: consumedAt,
+        updated_at: consumedAt,
       })
-      .where(eq(cliAuthSessions.session_id, sessionId));
+      .where(
+        and(
+          eq(cliAuthSessions.session_id, sessionId),
+          eq(cliAuthSessions.status, "authenticated"),
+          eq(cliAuthSessions.api_key_id, expectedApiKeyId),
+          eq(cliAuthSessions.user_id, expectedUserId),
+          gt(cliAuthSessions.expires_at, consumedAt),
+          isNull(cliAuthSessions.consumed_at),
+        ),
+      )
+      .returning();
+
+    return claimed;
   }
 
   /**

--- a/packages/cloud/shared/src/db/repositories/cli-auth-sessions.ts
+++ b/packages/cloud/shared/src/db/repositories/cli-auth-sessions.ts
@@ -1,5 +1,5 @@
-// Persists cli auth sessions records for cloud services through the shared DB boundary.
-import { and, eq, gt, isNotNull, isNull, lt } from "drizzle-orm";
+/** Persists CLI auth sessions through primary-safe reveal and lifecycle operations. */
+import { and, eq, exists, gt, isNull, lt, or } from "drizzle-orm";
 import { dbRead, dbWrite } from "../helpers";
 import { type ApiKey, apiKeys } from "../schemas/api-keys";
 import {
@@ -10,9 +10,9 @@ import {
 
 export type { CliAuthSession, NewCliAuthSession };
 
-export interface CliAuthApiKeyRevealCandidate {
+export interface CliAuthApiKeyRevealState {
   session: CliAuthSession;
-  apiKey: ApiKey;
+  apiKey: ApiKey | null;
 }
 
 /**
@@ -55,34 +55,24 @@ export class CliAuthSessionsRepository {
   // ============================================================================
 
   /**
-   * Loads an eligible reveal candidate from the primary database.
+   * Loads the durable reveal state from the primary database.
    *
    * CLI completion writes the session and API-key row on the primary, then the
    * CLI polls immediately. A replica read here can observe a false miss or an
    * older session state, so the complete candidate is read consistently in one
-   * joined query before the external KMS decrypt.
+   * left-joined query before the external KMS decrypt. The left join preserves
+   * a broken API-key reference so the service can report an integrity failure
+   * instead of misclassifying it as an already-consumed session.
    */
-  async findApiKeyRevealCandidate(
-    sessionId: string,
-  ): Promise<CliAuthApiKeyRevealCandidate | undefined> {
-    const now = new Date();
-    const [candidate] = await dbWrite
+  async findApiKeyRevealState(sessionId: string): Promise<CliAuthApiKeyRevealState | undefined> {
+    const [state] = await dbWrite
       .select({ session: cliAuthSessions, apiKey: apiKeys })
       .from(cliAuthSessions)
-      .innerJoin(apiKeys, eq(cliAuthSessions.api_key_id, apiKeys.id))
-      .where(
-        and(
-          eq(cliAuthSessions.session_id, sessionId),
-          eq(cliAuthSessions.status, "authenticated"),
-          isNotNull(cliAuthSessions.user_id),
-          eq(apiKeys.user_id, cliAuthSessions.user_id),
-          gt(cliAuthSessions.expires_at, now),
-          isNull(cliAuthSessions.consumed_at),
-        ),
-      )
+      .leftJoin(apiKeys, eq(cliAuthSessions.api_key_id, apiKeys.id))
+      .where(eq(cliAuthSessions.session_id, sessionId))
       .limit(1);
 
-    return candidate;
+    return state;
   }
 
   /**
@@ -143,11 +133,13 @@ export class CliAuthSessionsRepository {
    * only the update winner receives the plaintext. Matching the expected key
    * and owner also prevents a stale read from consuming a changed session.
    */
-  async claimConsumed(
-    sessionId: string,
-    expectedApiKeyId: string,
-    expectedUserId: string,
-  ): Promise<CliAuthSession | undefined> {
+  async claimConsumed(input: {
+    sessionId: string;
+    apiKeyId: string;
+    userId: string;
+    organizationId: string;
+    keyHash: string;
+  }): Promise<CliAuthSession | undefined> {
     const consumedAt = new Date();
     const [claimed] = await dbWrite
       .update(cliAuthSessions)
@@ -157,12 +149,28 @@ export class CliAuthSessionsRepository {
       })
       .where(
         and(
-          eq(cliAuthSessions.session_id, sessionId),
+          eq(cliAuthSessions.session_id, input.sessionId),
           eq(cliAuthSessions.status, "authenticated"),
-          eq(cliAuthSessions.api_key_id, expectedApiKeyId),
-          eq(cliAuthSessions.user_id, expectedUserId),
+          eq(cliAuthSessions.api_key_id, input.apiKeyId),
+          eq(cliAuthSessions.user_id, input.userId),
           gt(cliAuthSessions.expires_at, consumedAt),
           isNull(cliAuthSessions.consumed_at),
+          exists(
+            dbWrite
+              .select({ id: apiKeys.id })
+              .from(apiKeys)
+              .where(
+                and(
+                  eq(apiKeys.id, input.apiKeyId),
+                  eq(apiKeys.user_id, input.userId),
+                  eq(apiKeys.organization_id, input.organizationId),
+                  eq(apiKeys.key_hash, input.keyHash),
+                  eq(apiKeys.is_active, true),
+                  isNull(apiKeys.deleted_at),
+                  or(isNull(apiKeys.expires_at), gt(apiKeys.expires_at, consumedAt)),
+                ),
+              ),
+          ),
         ),
       )
       .returning();

--- a/packages/cloud/shared/src/lib/services/cli-auth-sessions.idempotent-complete.test.ts
+++ b/packages/cloud/shared/src/lib/services/cli-auth-sessions.idempotent-complete.test.ts
@@ -233,6 +233,38 @@ describe("cliAuthSessionsService.completeAuthentication idempotency", () => {
   });
 });
 
+describe("cliAuthSessionsService single-use reveal preconditions", () => {
+  test("returns no plaintext when the primary has no eligible candidate", async () => {
+    track(
+      spyOn(cliAuthSessionsRepository, "findApiKeyRevealCandidate").mockResolvedValue(undefined),
+    );
+    const claim = track(spyOn(cliAuthSessionsRepository, "claimConsumed"));
+
+    await expect(cliAuthSessionsService.getAndClearApiKey(SESSION_ID)).resolves.toBeNull();
+    expect(claim).not.toHaveBeenCalled();
+  });
+
+  test("keeps an incomplete encrypted-key candidate unconsumed", async () => {
+    track(
+      spyOn(cliAuthSessionsRepository, "findApiKeyRevealCandidate").mockResolvedValue({
+        session: authenticatedSession(USER_ID),
+        apiKey: {
+          id: API_KEY_ID,
+          key_ciphertext: null,
+          key_nonce: "nonce",
+          key_auth_tag: "auth-tag",
+          key_kms_key_id: "kms-key",
+          key_kms_key_version: 1,
+        } as never,
+      }),
+    );
+    const claim = track(spyOn(cliAuthSessionsRepository, "claimConsumed"));
+
+    await expect(cliAuthSessionsService.getAndClearApiKey(SESSION_ID)).resolves.toBeNull();
+    expect(claim).not.toHaveBeenCalled();
+  });
+});
+
 describe("cliAuthSessionsService lifecycle", () => {
   test("creates a pending session with a ten-minute expiry", async () => {
     const create = track(

--- a/packages/cloud/shared/src/lib/services/cli-auth-sessions.idempotent-complete.test.ts
+++ b/packages/cloud/shared/src/lib/services/cli-auth-sessions.idempotent-complete.test.ts
@@ -234,33 +234,42 @@ describe("cliAuthSessionsService.completeAuthentication idempotency", () => {
 });
 
 describe("cliAuthSessionsService single-use reveal preconditions", () => {
-  test("returns no plaintext when the primary has no eligible candidate", async () => {
-    track(
-      spyOn(cliAuthSessionsRepository, "findApiKeyRevealCandidate").mockResolvedValue(undefined),
-    );
+  test("returns an explicit not-found result when the primary has no session", async () => {
+    track(spyOn(cliAuthSessionsRepository, "findApiKeyRevealState").mockResolvedValue(undefined));
     const claim = track(spyOn(cliAuthSessionsRepository, "claimConsumed"));
 
-    await expect(cliAuthSessionsService.getAndClearApiKey(SESSION_ID)).resolves.toBeNull();
+    await expect(cliAuthSessionsService.getAndClearApiKey(SESSION_ID)).resolves.toEqual({
+      status: "unavailable",
+      reason: "not-found",
+    });
     expect(claim).not.toHaveBeenCalled();
   });
 
-  test("keeps an incomplete encrypted-key candidate unconsumed", async () => {
+  test("reports incomplete encrypted key material as an integrity failure", async () => {
     track(
-      spyOn(cliAuthSessionsRepository, "findApiKeyRevealCandidate").mockResolvedValue({
+      spyOn(cliAuthSessionsRepository, "findApiKeyRevealState").mockResolvedValue({
         session: authenticatedSession(USER_ID),
         apiKey: {
           id: API_KEY_ID,
+          user_id: USER_ID,
+          organization_id: ORG_ID,
+          key_hash: "hash",
           key_ciphertext: null,
           key_nonce: "nonce",
           key_auth_tag: "auth-tag",
           key_kms_key_id: "kms-key",
           key_kms_key_version: 1,
+          is_active: true,
+          deleted_at: null,
+          expires_at: null,
         } as never,
       }),
     );
     const claim = track(spyOn(cliAuthSessionsRepository, "claimConsumed"));
 
-    await expect(cliAuthSessionsService.getAndClearApiKey(SESSION_ID)).resolves.toBeNull();
+    await expect(cliAuthSessionsService.getAndClearApiKey(SESSION_ID)).rejects.toMatchObject({
+      code: "CLI_AUTH_SESSION_INTEGRITY",
+    });
     expect(claim).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/shared/src/lib/services/cli-auth-sessions.ts
+++ b/packages/cloud/shared/src/lib/services/cli-auth-sessions.ts
@@ -178,9 +178,10 @@ export class CliAuthSessionsService {
   /**
    * Single-use plaintext retrieval (D-6).
    *
-   * Returns the decrypted plaintext API key for an authenticated session
-   * exactly once. The session is marked `consumed_at` in the same call,
-   * after which further attempts return null.
+   * Returns the decrypted plaintext API key for an authenticated session at
+   * most once. One concurrent caller can win the `consumed_at` claim; if its
+   * response is lost after that claim, the credential is intentionally not
+   * replayable and the caller must create a new CLI auth session.
    *
    * The plaintext is decrypted in-memory from the encrypted api_keys row
    * and never persisted on the cli_auth_sessions row.
@@ -190,20 +191,15 @@ export class CliAuthSessionsService {
     keyPrefix: string;
     expiresAt: Date | null;
   } | null> {
-    const session = await this.getActiveSession(sessionId);
-
-    if (
-      !session ||
-      session.status !== "authenticated" ||
-      !session.api_key_id ||
-      session.consumed_at
-    ) {
+    const candidate = await cliAuthSessionsRepository.findApiKeyRevealCandidate(sessionId);
+    if (!candidate) {
       return null;
     }
 
-    const apiKeyRecord = await apiKeysRepository.findById(session.api_key_id);
+    const { apiKey: apiKeyRecord, session } = candidate;
     if (
-      !apiKeyRecord ||
+      !session.api_key_id ||
+      !session.user_id ||
       !apiKeyRecord.key_ciphertext ||
       !apiKeyRecord.key_nonce ||
       !apiKeyRecord.key_auth_tag ||
@@ -221,7 +217,18 @@ export class CliAuthSessionsService {
       kms_key_version: apiKeyRecord.key_kms_key_version,
     });
 
-    await cliAuthSessionsRepository.markConsumed(sessionId);
+    // Decryption deliberately happens before the primary-DB claim. A missing
+    // key or KMS failure therefore leaves the session retryable. The claim is
+    // one conditional UPDATE, so concurrent pollers have exactly one winner
+    // without holding an external KMS call open inside a DB transaction.
+    const claimed = await cliAuthSessionsRepository.claimConsumed(
+      sessionId,
+      session.api_key_id,
+      session.user_id,
+    );
+    if (!claimed) {
+      return null;
+    }
 
     return {
       apiKey: plaintext,

--- a/packages/cloud/shared/src/lib/services/cli-auth-sessions.ts
+++ b/packages/cloud/shared/src/lib/services/cli-auth-sessions.ts
@@ -4,7 +4,7 @@
 
 import { ElizaError } from "@elizaos/core";
 import { decryptApiKey } from "../../db/crypto/api-keys";
-import { apiKeysRepository, cliAuthSessionsRepository } from "../../db/repositories";
+import { cliAuthSessionsRepository } from "../../db/repositories";
 import type { ApiKey } from "../../db/schemas/api-keys";
 import type { CliAuthSession } from "../../db/schemas/cli-auth-sessions";
 import { cliAuthSessionCompletionService } from "./cli-auth-session-completion";
@@ -13,6 +13,26 @@ import { cliAuthSessionCompletionService } from "./cli-auth-session-completion";
  * Session expiry time in minutes.
  */
 const SESSION_EXPIRY_MINUTES = 10; // Sessions expire after 10 minutes
+
+export type CliAuthApiKeyRevealResult =
+  | {
+      status: "revealed";
+      apiKey: string;
+      keyPrefix: string;
+      expiresAt: Date | null;
+    }
+  | {
+      status: "unavailable";
+      reason: "not-found" | "not-authenticated" | "expired" | "consumed" | "revoked" | "claim-lost";
+    };
+
+function revealIntegrityError(sessionId: string, defect: string): ElizaError {
+  return new ElizaError("CLI auth session cannot reveal its API key", {
+    code: "CLI_AUTH_SESSION_INTEGRITY",
+    context: { sessionId, defect },
+    severity: "fatal",
+  });
+}
 
 /**
  * Service for CLI authentication flow and session management.
@@ -186,27 +206,49 @@ export class CliAuthSessionsService {
    * The plaintext is decrypted in-memory from the encrypted api_keys row
    * and never persisted on the cli_auth_sessions row.
    */
-  async getAndClearApiKey(sessionId: string): Promise<{
-    apiKey: string;
-    keyPrefix: string;
-    expiresAt: Date | null;
-  } | null> {
-    const candidate = await cliAuthSessionsRepository.findApiKeyRevealCandidate(sessionId);
-    if (!candidate) {
-      return null;
+  async getAndClearApiKey(sessionId: string): Promise<CliAuthApiKeyRevealResult> {
+    const state = await cliAuthSessionsRepository.findApiKeyRevealState(sessionId);
+    if (!state) {
+      return { status: "unavailable", reason: "not-found" };
     }
 
-    const { apiKey: apiKeyRecord, session } = candidate;
+    const { apiKey: apiKeyRecord, session } = state;
+    if (session.status !== "authenticated") {
+      return { status: "unavailable", reason: "not-authenticated" };
+    }
+    if (session.expires_at <= new Date()) {
+      return { status: "unavailable", reason: "expired" };
+    }
+    if (session.consumed_at) {
+      return { status: "unavailable", reason: "consumed" };
+    }
+    if (!session.api_key_id) {
+      throw revealIntegrityError(sessionId, "missing_api_key_id");
+    }
+    if (!session.user_id) {
+      throw revealIntegrityError(sessionId, "missing_user_id");
+    }
+    if (!apiKeyRecord) {
+      throw revealIntegrityError(sessionId, "missing_api_key_row");
+    }
+    if (apiKeyRecord.user_id !== session.user_id) {
+      throw revealIntegrityError(sessionId, "api_key_owner_mismatch");
+    }
     if (
-      !session.api_key_id ||
-      !session.user_id ||
+      !apiKeyRecord.is_active ||
+      apiKeyRecord.deleted_at ||
+      (apiKeyRecord.expires_at && apiKeyRecord.expires_at <= new Date())
+    ) {
+      return { status: "unavailable", reason: "revoked" };
+    }
+    if (
       !apiKeyRecord.key_ciphertext ||
       !apiKeyRecord.key_nonce ||
       !apiKeyRecord.key_auth_tag ||
       !apiKeyRecord.key_kms_key_id ||
       apiKeyRecord.key_kms_key_version == null
     ) {
-      return null;
+      throw revealIntegrityError(sessionId, "incomplete_encrypted_key");
     }
 
     const plaintext = await decryptApiKey(apiKeyRecord.id, {
@@ -221,16 +263,19 @@ export class CliAuthSessionsService {
     // key or KMS failure therefore leaves the session retryable. The claim is
     // one conditional UPDATE, so concurrent pollers have exactly one winner
     // without holding an external KMS call open inside a DB transaction.
-    const claimed = await cliAuthSessionsRepository.claimConsumed(
+    const claimed = await cliAuthSessionsRepository.claimConsumed({
       sessionId,
-      session.api_key_id,
-      session.user_id,
-    );
+      apiKeyId: session.api_key_id,
+      userId: session.user_id,
+      organizationId: apiKeyRecord.organization_id,
+      keyHash: apiKeyRecord.key_hash,
+    });
     if (!claimed) {
-      return null;
+      return { status: "unavailable", reason: "claim-lost" };
     }
 
     return {
+      status: "revealed",
       apiKey: plaintext,
       keyPrefix: apiKeyRecord.key_prefix,
       expiresAt: apiKeyRecord.expires_at,


### PR DESCRIPTION
Closes #16253.

## What changed

- Atomically claims a CLI key reveal so concurrent pollers have exactly one plaintext winner.
- Returns typed reveal outcomes instead of conflating an expected losing poll with missing or corrupt durable state.
- Throws `CLI_AUTH_SESSION_INTEGRITY` for missing references, owner mismatches, and incomplete encrypted key material.
- Revalidates key ID, user, organization, active/deleted/expiry state, and key hash inside the consume update.
- Rejects a candidate invalidated by the real API-key update writer during KMS decryption.
- Keeps expected losing callers plaintext-free and leaves KMS failures retryable.
- Covers the legacy `/api/v1/cli-auth/:session/token` boundary so every changed production source participates in the enforced coverage gate.

The browser completion endpoint returns only `keyPrefix`; plaintext is disclosed only by the single-use CLI poll boundary.

## Verification

- Live Worker flow on the exact runtime implementation: real SIWE EIP-4361 auth, API-key middleware, persistent PGlite, local KMS, completion, two concurrent polls, and replay.
  - [Request/response trace](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16259-live-worker-trace.json)
  - [Structured backend route log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16259-live-worker-backend.log)
  - [DB/KMS artifact](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16259-live-worker-db.json)
- PGlite route/service/repository suites: **33/33 pass**, including the newly covered legacy route's success, pending, missing, expired, consumed, losing-claim, failure-translation, and preflight states.
- PostgreSQL 17 single-use route suite: **7/7 pass, 31 assertions**.
  - [JUnit report](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16259-postgres-junit.xml)
  - [Regeneration-race DB artifact](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16259-postgres-db.csv)
- PostgreSQL repository coverage: **99.07% lines**; focused legacy route coverage: **98.15% lines**.
- Cloud shared typecheck: **pass**.
- Cloud API typecheck and production Worker dry-run: **pass**.
- Biome and diff integrity: **pass**.

I manually reviewed every linked artifact. The live trace shows one concurrent poll with `apiKeyPresent=true`, one with `false`, and replay 410. Its winner SHA-256 equals the durable `api_keys.key_hash`; the DB row also proves owner equality, ciphertext at rest, local-KMS key identity/version, and `consumed=true`. The PostgreSQL race artifact shows the stale candidate stayed unconsumed while the regenerated hash won. The final commit adds only route coverage and a required boundary-policy comment, so the captured runtime implementation is unchanged.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend authentication persistence only; no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend authentication persistence only; no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual flow changes.
<!-- evidence-row:backend-logs -->
- [x] [Exact-runtime live Worker structured log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16259-live-worker-backend.log) and [request/response trace](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16259-live-worker-trace.json).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser contract changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] [Live DB/KMS proof](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16259-live-worker-db.json), [PostgreSQL race artifact](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16259-postgres-db.csv), and [PostgreSQL JUnit report](https://github.com/elizaOS/eliza/releases/download/pr-evidence/pr16259-postgres-junit.xml).

## Known gaps / failures

None. The flow has been exercised through the real local Worker/auth/KMS boundary and PostgreSQL 17; fresh GitHub Develop, Cloud, security, and coverage lanes are required before merge.