### PR TITLE
fix(cloud): route agent calls through the control-plane origin

### DIFF
--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -115,6 +115,9 @@ NEXT_PUBLIC_APP_URL = "https://elizacloud.ai"
 NEXT_PUBLIC_API_URL = "https://api.elizacloud.ai"
 ELIZA_CLOUD_URL = "https://elizacloud.ai"
 ELIZA_CLOUD_AGENT_BASE_DOMAIN = "elizacloud.ai"
+# Internal Worker-to-agent calls must target the control-plane origin directly;
+# same-zone fetches to a UUID host bypass its Worker route and hit wildcard DNS.
+AGENT_ROUTER_ORIGIN_HOST = "eliza-production-1.elizacloud.ai"
 WAIFU_SERVICE_ORG_ID = "d96d3fc8-cc07-40be-b81c-ba7a7b4e8028"
 WAIFU_SERVICE_USER_ID = "90101225-836f-4fa7-a69c-f70691dcf256"
 ELIZA_APP_URL = "https://eliza.app"

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-agent-router.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-agent-router.test.ts
@@ -111,6 +111,48 @@ describe("ElizaSandboxService Worker agent-router fetch", () => {
     });
   }
 
+  test("does not let request options replace the trusted agent identity or route", async () => {
+    enterWorkerRuntime();
+    const requests: Array<{ headers: Headers; redirect: RequestRedirect | undefined }> = [];
+    globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      requests.push({
+        headers: new Headers(init?.headers),
+        redirect: init?.redirect,
+      });
+      return Response.json({ ok: true });
+    });
+
+    await runWithCloudBindings(
+      {
+        ELIZA_CLOUD_AGENT_BASE_DOMAIN: "elizacloud.ai",
+        AGENT_ROUTER_ORIGIN_HOST: "eliza-production-1.elizacloud.ai",
+      },
+      () =>
+        service().fetchAgentApi(sandbox, "/api/agents", {
+          headers: {
+            Authorization: "Bearer attacker-token",
+            Host: "attacker.example",
+            "X-Api-Key": "attacker-token",
+            "X-Eliza-Token": "attacker-token",
+            "X-Forwarded-Host": "attacker.example",
+            "X-Forwarded-Proto": "http",
+          },
+          redirect: "follow",
+        }),
+    );
+
+    expect(requests).toHaveLength(1);
+    expect(Object.fromEntries(requests[0]!.headers.entries())).toEqual({
+      authorization: "Bearer agent-token",
+      "content-type": "application/json",
+      "x-api-key": "agent-token",
+      "x-eliza-token": "agent-token",
+      "x-forwarded-host": `${sandbox.id}.elizacloud.ai`,
+      "x-forwarded-proto": "https",
+    });
+    expect(requests[0]?.redirect).toBe("manual");
+  });
+
   test("fails closed before fetch when Worker routing configuration is missing or malformed", async () => {
     enterWorkerRuntime();
     const fetchMock = mock(async () => Response.json({ ok: true }));

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-agent-router.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-agent-router.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Verifies that Worker-side agent API calls stay on the configured control-plane
+ * origin while preserving the public agent identity and protecting its bearer
+ * credential. Non-Worker coverage locks the existing direct tailnet route.
+ */
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 
 import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
@@ -151,6 +156,23 @@ describe("ElizaSandboxService Worker agent-router fetch", () => {
       "x-forwarded-proto": "https",
     });
     expect(requests[0]?.redirect).toBe("manual");
+  });
+
+  test("fails closed before fetch when the agent credential is missing", async () => {
+    enterWorkerRuntime();
+    const fetchMock = mock(async () => Response.json({ ok: true }));
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      runWithCloudBindings(
+        {
+          ELIZA_CLOUD_AGENT_BASE_DOMAIN: "elizacloud.ai",
+          AGENT_ROUTER_ORIGIN_HOST: "eliza-production-1.elizacloud.ai",
+        },
+        () => service().fetchAgentApi({ ...sandbox, environment_vars: {} }, "/api/agents"),
+      ),
+    ).rejects.toThrow(`Agent proxy requires an API token for ${sandbox.id}`);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   test("fails closed before fetch when Worker routing configuration is missing or malformed", async () => {

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-agent-router.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-agent-router.test.ts
@@ -1,0 +1,343 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+
+import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
+import { runWithCloudBindings } from "../runtime/cloud-bindings";
+
+// Match the main sandbox suite's module identity; Bun treats query aliases as separate modules.
+const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+
+const originalFetch = globalThis.fetch;
+const originalWebSocketPair = Object.getOwnPropertyDescriptor(globalThis, "WebSocketPair");
+
+const sandbox = {
+  id: "e06bb509-6c52-4c33-a9f7-66addc43e8c8",
+  environment_vars: { ELIZA_API_TOKEN: "agent-token" },
+  bridge_url: "https://legacy-bridge.example",
+  health_url: "http://100.64.0.10:23816/api/health",
+  node_id: "node-1",
+  bridge_port: 18923,
+  web_ui_port: 23816,
+  headscale_ip: "100.64.0.10",
+  sandbox_id: "sandbox-e06bb509",
+};
+
+type AgentRecord = typeof sandbox;
+
+type AgentRouterHarness = {
+  fetchAgentApi(rec: AgentRecord, path: string, init?: RequestInit): Promise<Response>;
+  ensureRuntimeAgentStarted(rec: AgentRecord): Promise<{
+    id?: string;
+    name?: string;
+    status?: string;
+  } | null>;
+  pushState(
+    rec: AgentRecord,
+    state: { memories: unknown[]; config: Record<string, unknown>; workspaceFiles: object },
+  ): Promise<void>;
+};
+
+function service(): AgentRouterHarness {
+  return new ElizaSandboxService() as unknown as AgentRouterHarness;
+}
+
+function enterWorkerRuntime(): void {
+  Object.defineProperty(globalThis, "WebSocketPair", {
+    value: class WebSocketPair {},
+    configurable: true,
+  });
+}
+
+function enterNonWorkerRuntime(): void {
+  Reflect.deleteProperty(globalThis, "WebSocketPair");
+}
+
+function restoreWorkerRuntime(): void {
+  if (originalWebSocketPair) {
+    Object.defineProperty(globalThis, "WebSocketPair", originalWebSocketPair);
+    return;
+  }
+  Reflect.deleteProperty(globalThis, "WebSocketPair");
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  restoreWorkerRuntime();
+});
+
+describe("ElizaSandboxService Worker agent-router fetch", () => {
+  for (const deployment of [
+    {
+      name: "staging",
+      baseDomain: "staging.elizacloud.ai",
+      originHost: "eliza-staging-1.elizacloud.ai",
+    },
+    {
+      name: "production",
+      baseDomain: "elizacloud.ai",
+      originHost: "eliza-production-1.elizacloud.ai",
+    },
+  ]) {
+    test(`keeps ${deployment.name} API traffic on its configured router origin`, async () => {
+      enterWorkerRuntime();
+      const requests: Array<{ url: string; headers: Headers }> = [];
+      globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+        requests.push({
+          url: typeof input === "string" ? input : input.toString(),
+          headers: new Headers(init?.headers),
+        });
+        return Response.json({ ok: true });
+      });
+
+      await runWithCloudBindings(
+        {
+          ELIZA_CLOUD_AGENT_BASE_DOMAIN: deployment.baseDomain,
+          AGENT_ROUTER_ORIGIN_HOST: deployment.originHost,
+        },
+        () => service().fetchAgentApi(sandbox, "/api/agents?limit=20&state=ready"),
+      );
+
+      expect(requests).toHaveLength(1);
+      expect(requests[0]?.url).toBe(
+        `https://${deployment.originHost}/api/agents?limit=20&state=ready`,
+      );
+      expect(Object.fromEntries(requests[0]!.headers.entries())).toEqual({
+        authorization: "Bearer agent-token",
+        "content-type": "application/json",
+        "x-api-key": "agent-token",
+        "x-eliza-token": "agent-token",
+        "x-forwarded-host": `${sandbox.id}.${deployment.baseDomain}`,
+        "x-forwarded-proto": "https",
+      });
+    });
+  }
+
+  test("fails closed before fetch when Worker routing configuration is missing or malformed", async () => {
+    enterWorkerRuntime();
+    const fetchMock = mock(async () => Response.json({ ok: true }));
+    globalThis.fetch = fetchMock;
+
+    for (const bindings of [
+      {
+        ELIZA_CLOUD_AGENT_BASE_DOMAIN: "elizacloud.ai",
+        AGENT_ROUTER_ORIGIN_HOST: "",
+      },
+      {
+        ELIZA_CLOUD_AGENT_BASE_DOMAIN: "elizacloud.ai",
+        AGENT_ROUTER_ORIGIN_HOST: "http://eliza-production-1.elizacloud.ai",
+      },
+      {
+        ELIZA_CLOUD_AGENT_BASE_DOMAIN: "elizacloud.ai",
+        AGENT_ROUTER_ORIGIN_HOST: "https://eliza-production-1.elizacloud.ai/agent",
+      },
+      {
+        ELIZA_CLOUD_AGENT_BASE_DOMAIN: "elizacloud.ai",
+        AGENT_ROUTER_ORIGIN_HOST: "//eliza-production-1.elizacloud.ai",
+      },
+      {
+        ELIZA_CLOUD_AGENT_BASE_DOMAIN: "https://user@example.com",
+        AGENT_ROUTER_ORIGIN_HOST: "eliza-production-1.elizacloud.ai",
+      },
+    ]) {
+      await expect(
+        runWithCloudBindings(bindings, () =>
+          service().fetchAgentApi(sandbox, "/api/agents", { method: "GET" }),
+        ),
+      ).rejects.toThrow(/Worker agent routing requires a valid/);
+    }
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("keeps the runtime list/start/list lifecycle on one Worker router origin", async () => {
+    enterWorkerRuntime();
+    const requests: Array<{ url: string; method: string | undefined; headers: Headers }> = [];
+    let listCount = 0;
+    globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      requests.push({ url, method: init?.method, headers: new Headers(init?.headers) });
+      if (url.endsWith("/api/agents")) {
+        listCount += 1;
+        return Response.json({
+          agents: [
+            {
+              id: "runtime-agent-1",
+              name: "Cloud Agent",
+              status: listCount === 1 ? "inactive" : "active",
+            },
+          ],
+        });
+      }
+      return Response.json({ ok: true });
+    });
+
+    const started = await runWithCloudBindings(
+      {
+        ELIZA_CLOUD_AGENT_BASE_DOMAIN: "elizacloud.ai",
+        AGENT_ROUTER_ORIGIN_HOST: "eliza-production-1.elizacloud.ai",
+      },
+      () => service().ensureRuntimeAgentStarted(sandbox),
+    );
+
+    expect(started).toMatchObject({ id: "runtime-agent-1", status: "active" });
+    expect(requests.map(({ url, method }) => ({ url, method }))).toEqual([
+      {
+        url: "https://eliza-production-1.elizacloud.ai/api/agents",
+        method: "GET",
+      },
+      {
+        url: "https://eliza-production-1.elizacloud.ai/api/agents/runtime-agent-1/start",
+        method: "POST",
+      },
+      {
+        url: "https://eliza-production-1.elizacloud.ai/api/agents",
+        method: "GET",
+      },
+    ]);
+    for (const request of requests) {
+      expect(request.headers.get("x-forwarded-host")).toBe(`${sandbox.id}.elizacloud.ai`);
+      expect(request.headers.get("authorization")).toBe("Bearer agent-token");
+    }
+  });
+
+  test("routes record-based state restore through the same Worker origin", async () => {
+    enterWorkerRuntime();
+    const requests: Array<{ url: string; headers: Headers; body: BodyInit | null | undefined }> =
+      [];
+    globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      requests.push({
+        url: typeof input === "string" ? input : input.toString(),
+        headers: new Headers(init?.headers),
+        body: init?.body,
+      });
+      return Response.json({ ok: true });
+    });
+
+    await runWithCloudBindings(
+      {
+        ELIZA_CLOUD_AGENT_BASE_DOMAIN: "staging.elizacloud.ai",
+        AGENT_ROUTER_ORIGIN_HOST: "eliza-staging-1.elizacloud.ai",
+      },
+      () =>
+        service().pushState(sandbox, {
+          memories: [],
+          config: { restored: true },
+          workspaceFiles: {},
+        }),
+    );
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.url).toBe("https://eliza-staging-1.elizacloud.ai/api/restore");
+    expect(requests[0]?.headers.get("authorization")).toBe("Bearer agent-token");
+    expect(requests[0]?.headers.get("x-forwarded-host")).toBe(
+      `${sandbox.id}.staging.elizacloud.ai`,
+    );
+    expect(requests[0]?.body).toBe(
+      '{"memories":[],"config":{"restored":true},"workspaceFiles":{}}',
+    );
+  });
+
+  test("routes workflow, wallet, and LifeOps proxies through the same Worker origin", async () => {
+    enterWorkerRuntime();
+    const findRunningSandboxSpy = spyOn(
+      agentSandboxesRepository,
+      "findRunningSandbox",
+    ).mockResolvedValue(sandbox as never);
+    const requests: Array<{
+      url: string;
+      method: string | undefined;
+      headers: Headers;
+      body: BodyInit | null | undefined;
+    }> = [];
+    globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      requests.push({
+        url: typeof input === "string" ? input : input.toString(),
+        method: init?.method,
+        headers: new Headers(init?.headers),
+        body: init?.body,
+      });
+      return Response.json({ ok: true });
+    });
+
+    try {
+      await runWithCloudBindings(
+        {
+          ELIZA_CLOUD_AGENT_BASE_DOMAIN: "staging.elizacloud.ai",
+          AGENT_ROUTER_ORIGIN_HOST: "eliza-staging-1.elizacloud.ai",
+        },
+        async () => {
+          const sandboxService = new ElizaSandboxService();
+          await sandboxService.proxyWorkflowRequest(
+            sandbox.id,
+            "org-1",
+            "workflows",
+            "GET",
+            null,
+            "limit=2&drop=ignored",
+          );
+          await sandboxService.proxyWalletRequest(
+            sandbox.id,
+            "org-1",
+            "balances",
+            "GET",
+            null,
+            "limit=1&drop=ignored",
+          );
+          await sandboxService.proxyLifeOpsScheduleRequest(
+            sandbox.id,
+            "org-1",
+            "observations",
+            "POST",
+            '{"refresh":true}',
+            "timezone=UTC&drop=ignored",
+          );
+        },
+      );
+    } finally {
+      findRunningSandboxSpy.mockRestore();
+    }
+
+    expect(requests.map(({ url }) => url)).toEqual([
+      "https://eliza-staging-1.elizacloud.ai/api/workflow/workflows?limit=2",
+      "https://eliza-staging-1.elizacloud.ai/api/wallet/balances?limit=1",
+      "https://eliza-staging-1.elizacloud.ai/api/lifeops/schedule/observations?timezone=UTC",
+    ]);
+    for (const request of requests) {
+      expect(request.headers.get("authorization")).toBe("Bearer agent-token");
+      expect(request.headers.get("x-forwarded-host")).toBe(`${sandbox.id}.staging.elizacloud.ai`);
+      expect(request.headers.get("x-forwarded-proto")).toBe("https");
+    }
+    expect(requests[0]?.method).toBe("GET");
+    expect(requests[0]?.headers.get("accept")).toBe("application/json");
+    expect(requests[1]?.method).toBe("GET");
+    expect(requests[2]?.method).toBe("POST");
+    expect(requests[2]?.headers.get("accept")).toBe("application/json");
+    expect(requests[2]?.headers.get("content-type")).toBe("application/json");
+    expect(requests[2]?.body).toBe('{"refresh":true}');
+  });
+
+  test("keeps non-Worker API traffic on the existing direct runtime target", async () => {
+    enterNonWorkerRuntime();
+    const requests: Array<{ url: string; headers: Headers }> = [];
+    globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      requests.push({
+        url: typeof input === "string" ? input : input.toString(),
+        headers: new Headers(init?.headers),
+      });
+      return Response.json({ ok: true });
+    });
+
+    await runWithCloudBindings(
+      {
+        ELIZA_CLOUD_AGENT_BASE_DOMAIN: "staging.elizacloud.ai",
+        AGENT_ROUTER_ORIGIN_HOST: "eliza-staging-1.elizacloud.ai",
+      },
+      () => service().fetchAgentApi(sandbox, "/api/agents?limit=1", { method: "GET" }),
+    );
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.url).toBe("http://100.64.0.10:23816/api/agents?limit=1");
+    expect(requests[0]?.headers.get("authorization")).toBe("Bearer agent-token");
+    expect(requests[0]?.headers.has("x-forwarded-host")).toBe(false);
+    expect(requests[0]?.headers.has("x-forwarded-proto")).toBe(false);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-delta-sse.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-delta-sse.test.ts
@@ -10,11 +10,44 @@
  * implementations (the standalone bridge service and the duplicate on the host
  * service) must rebuild the full text. Real methods, no network.
  */
-import { describe, expect, test } from "bun:test";
-import { ElizaSandboxService } from "./eliza-sandbox";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { runWithCloudBindings } from "../runtime/cloud-bindings";
 import { ElizaSandboxBridgeService } from "./eliza-sandbox-bridge";
 
+// Match the main sandbox suite's module identity; Bun treats query aliases as separate modules.
+const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+
 type Normalizer = { normalizeBridgeSseResponse(response: Response): Response };
+
+type AgentApiFetcher = {
+  fetchAgentApi(
+    rec: {
+      id: string;
+      environment_vars: Record<string, string>;
+      bridge_url: string;
+      health_url: string;
+      node_id: string;
+      bridge_port: number;
+      web_ui_port: number;
+      headscale_ip: string;
+      sandbox_id: string;
+    },
+    path: string,
+    init?: RequestInit,
+  ): Promise<Response>;
+};
+
+const originalFetch = globalThis.fetch;
+const originalWebSocketPair = Object.getOwnPropertyDescriptor(globalThis, "WebSocketPair");
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalWebSocketPair) {
+    Object.defineProperty(globalThis, "WebSocketPair", originalWebSocketPair);
+  } else {
+    Reflect.deleteProperty(globalThis, "WebSocketPair");
+  }
+});
 
 function sseResponse(body: string): Response {
   return sseResponseChunks([body]);
@@ -149,3 +182,57 @@ for (const [label, make] of normalizers) {
     });
   });
 }
+
+test("Worker routing returns an upstream SSE response without cloning or buffering", async () => {
+  Object.defineProperty(globalThis, "WebSocketPair", {
+    value: class WebSocketPair {},
+    configurable: true,
+  });
+  const encoder = new TextEncoder();
+  const upstream = new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode("data: first\n\n"));
+        controller.enqueue(encoder.encode("data: second\n\n"));
+        controller.close();
+      },
+    }),
+    { headers: { "content-type": "text/event-stream" } },
+  );
+  let requestBody: BodyInit | null | undefined;
+  globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+    requestBody = init?.body;
+    return upstream;
+  });
+
+  const service = new ElizaSandboxService() as unknown as AgentApiFetcher;
+  const response = await runWithCloudBindings(
+    {
+      ELIZA_CLOUD_AGENT_BASE_DOMAIN: "elizacloud.ai",
+      AGENT_ROUTER_ORIGIN_HOST: "eliza-production-1.elizacloud.ai",
+    },
+    () =>
+      service.fetchAgentApi(
+        {
+          id: "e06bb509-6c52-4c33-a9f7-66addc43e8c8",
+          environment_vars: { ELIZA_API_TOKEN: "agent-token" },
+          bridge_url: "https://legacy-bridge.example",
+          health_url: "http://100.64.0.10:23816/api/health",
+          node_id: "node-1",
+          bridge_port: 18923,
+          web_ui_port: 23816,
+          headscale_ip: "100.64.0.10",
+          sandbox_id: "sandbox-e06bb509",
+        },
+        "/api/conversations/conversation-1/messages/stream",
+        {
+          method: "POST",
+          body: JSON.stringify({ text: "hello" }),
+        },
+      ),
+  );
+
+  expect(response).toBe(upstream);
+  expect(requestBody).toBe('{"text":"hello"}');
+  expect(await response.text()).toBe("data: first\n\ndata: second\n\n");
+});

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-failurekind.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-failurekind.test.ts
@@ -16,9 +16,11 @@
 import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import type { AgentSandbox } from "../../db/repositories/agent-sandboxes";
 import { logger } from "../utils/logger";
-import { ElizaSandboxService } from "./eliza-sandbox";
 import type { BridgeRequest, BridgeResponse } from "./eliza-sandbox-bridge";
 import { ElizaSandboxBridgeService } from "./eliza-sandbox-bridge";
+
+// Match the main sandbox suite's module identity; Bun treats query aliases as separate modules.
+const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
 
 type MessageSender = {
   bridgeMessageSend(rec: AgentSandbox, rpc: BridgeRequest): Promise<BridgeResponse>;
@@ -40,9 +42,15 @@ const rpc: BridgeRequest = {
   },
 };
 
-const endpointStubs = {
+const bridgeEndpointStubs = {
   getAgentApiEndpoint: async (_rec: unknown, path: string) => `http://sandbox.test${path}`,
   getAgentJsonHeaders: () => ({ "content-type": "application/json" }),
+  ensureRuntimeAgentStarted: async () => ({ id: "runtime-agent-1", name: "Smoke" }),
+};
+
+const hostEndpointStubs = {
+  fetchAgentApi: async (_rec: unknown, path: string, init?: RequestInit) =>
+    fetch(`http://sandbox.test${path}`, init),
   ensureRuntimeAgentStarted: async () => ({ id: "runtime-agent-1", name: "Smoke" }),
 };
 
@@ -51,14 +59,14 @@ const endpointStubs = {
 const senders: Array<[string, () => MessageSender]> = [
   [
     "ElizaSandboxBridgeService",
-    () => new ElizaSandboxBridgeService(endpointStubs as never) as unknown as MessageSender,
+    () => new ElizaSandboxBridgeService(bridgeEndpointStubs as never) as unknown as MessageSender,
   ],
   [
     "ElizaSandboxService",
     () => {
       const hostService = new ElizaSandboxService() as unknown as MessageSender &
         Record<string, unknown>;
-      Object.assign(hostService, endpointStubs);
+      Object.assign(hostService, hostEndpointStubs);
       return hostService;
     },
   ],
@@ -67,7 +75,7 @@ const senders: Array<[string, () => MessageSender]> = [
 function makeHostServiceSender(): MessageSender {
   const hostService = new ElizaSandboxService() as unknown as MessageSender &
     Record<string, unknown>;
-  Object.assign(hostService, endpointStubs);
+  Object.assign(hostService, hostEndpointStubs);
   return hostService;
 }
 

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-ssrf.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-ssrf.test.ts
@@ -14,9 +14,12 @@
  * The string branch is self-contained (no provider / DB), so this exercises the
  * real method directly.
  */
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 
-import { ElizaSandboxService } from "./eliza-sandbox";
+import { runWithCloudBindings } from "../runtime/cloud-bindings";
+
+// Match the main sandbox suite's module identity; Bun treats query aliases as separate modules.
+const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
 
 type BridgeEndpointResolver = {
   getSafeBridgeEndpoint(
@@ -25,6 +28,22 @@ type BridgeEndpointResolver = {
     options?: { trusted?: boolean },
   ): Promise<string>;
 };
+
+type AgentApiFetcher = {
+  fetchAgentApi(rec: Record<string, unknown>, path: string, init?: RequestInit): Promise<Response>;
+};
+
+const originalFetch = globalThis.fetch;
+const originalWebSocketPair = Object.getOwnPropertyDescriptor(globalThis, "WebSocketPair");
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalWebSocketPair) {
+    Object.defineProperty(globalThis, "WebSocketPair", originalWebSocketPair);
+  } else {
+    Reflect.deleteProperty(globalThis, "WebSocketPair");
+  }
+});
 
 function resolver(): BridgeEndpointResolver {
   return new ElizaSandboxService() as unknown as BridgeEndpointResolver;
@@ -55,5 +74,73 @@ describe("ElizaSandboxService bridge SSRF guard (untrusted string bridge URL)", 
         trusted: true,
       }),
     ).resolves.toBe("http://10.0.0.7:7000/api/restore");
+  });
+
+  test("rejects an absolute Worker API path before the agent token can leave", async () => {
+    Object.defineProperty(globalThis, "WebSocketPair", {
+      value: class WebSocketPair {},
+      configurable: true,
+    });
+    const fetchMock = mock(async () => Response.json({ ok: true }));
+    globalThis.fetch = fetchMock;
+    const service = new ElizaSandboxService() as unknown as AgentApiFetcher;
+
+    await expect(
+      runWithCloudBindings(
+        {
+          ELIZA_CLOUD_AGENT_BASE_DOMAIN: "elizacloud.ai",
+          AGENT_ROUTER_ORIGIN_HOST: "eliza-production-1.elizacloud.ai",
+        },
+        () =>
+          service.fetchAgentApi(
+            {
+              id: "e06bb509-6c52-4c33-a9f7-66addc43e8c8",
+              environment_vars: { ELIZA_API_TOKEN: "agent-token" },
+            },
+            "https://attacker.example/collect",
+          ),
+      ),
+    ).rejects.toThrow("Agent API path must be relative to the agent origin");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("never follows a redirect from the configured token recipient", async () => {
+    Object.defineProperty(globalThis, "WebSocketPair", {
+      value: class WebSocketPair {},
+      configurable: true,
+    });
+    const requests: Array<{ url: string; redirect: RequestRedirect | undefined }> = [];
+    globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      requests.push({
+        url: typeof input === "string" ? input : input.toString(),
+        redirect: init?.redirect,
+      });
+      return Response.redirect("https://attacker.example/collect", 302);
+    });
+    const service = new ElizaSandboxService() as unknown as AgentApiFetcher;
+
+    const response = await runWithCloudBindings(
+      {
+        ELIZA_CLOUD_AGENT_BASE_DOMAIN: "elizacloud.ai",
+        AGENT_ROUTER_ORIGIN_HOST: "eliza-production-1.elizacloud.ai",
+      },
+      () =>
+        service.fetchAgentApi(
+          {
+            id: "e06bb509-6c52-4c33-a9f7-66addc43e8c8",
+            environment_vars: { ELIZA_API_TOKEN: "agent-token" },
+          },
+          "/api/agents",
+          { redirect: "follow" },
+        ),
+    );
+
+    expect(response.status).toBe(302);
+    expect(requests).toEqual([
+      {
+        url: "https://eliza-production-1.elizacloud.ai/api/agents",
+        redirect: "manual",
+      },
+    ]);
   });
 });

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-dedicated-bootstrap.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-dedicated-bootstrap.test.ts
@@ -1,5 +1,5 @@
 // Exercises eliza sandbox dedicated bootstrap behavior with deterministic cloud-shared lib fixtures.
-import { afterAll, afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, mock, spyOn, test } from "bun:test";
 
 import type { AgentSandbox } from "../../db/repositories/agent-sandboxes";
 import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
@@ -18,10 +18,12 @@ import * as realRunSharedAgentTurnNs from "./shared-runtime/run-shared-agent-tur
  */
 
 // See eliza-sandbox-shared-billing.test.ts for why these process-global mocks
-// must be snapshot + restored in afterAll.
+// are installed in beforeAll and restored in afterAll.
 const realRunSharedAgentTurn = { ...realRunSharedAgentTurnNs };
 const realAiBilling = { ...realAiBillingNs };
 const realAiBillingRecords = { ...realAiBillingRecordsNs };
+const originalFetch = globalThis.fetch;
+const originalWebSocketPair = Object.getOwnPropertyDescriptor(globalThis, "WebSocketPair");
 
 const reconcileReservation = mock(async (actualCost: number) => ({
   reservedAmount: 0.002,
@@ -61,18 +63,7 @@ class MockInsufficientCreditsError extends Error {
   }
 }
 
-mock.module("./ai-billing", () => ({
-  reserveCredits,
-  billUsage,
-  recordUsageAnalytics,
-  estimateInputTokens,
-  InsufficientCreditsError: MockInsufficientCreditsError,
-}));
-
 const aiBillingRecord = mock(async () => ({ id: "ai-billing-1" }));
-mock.module("./ai-billing-records", () => ({
-  aiBillingRecordsService: { record: aiBillingRecord },
-}));
 
 const runSharedAgentTurn = mock(async () => ({
   reply: "bootstrap reply",
@@ -86,10 +77,22 @@ const runSharedAgentTurn = mock(async () => ({
 }));
 const resolveSharedAgentTurnModel = mock(() => "gpt-oss-120b");
 
-mock.module("./shared-runtime/run-shared-agent-turn", () => ({
-  runSharedAgentTurn,
-  resolveSharedAgentTurnModel,
-}));
+beforeAll(() => {
+  mock.module("./ai-billing", () => ({
+    reserveCredits,
+    billUsage,
+    recordUsageAnalytics,
+    estimateInputTokens,
+    InsufficientCreditsError: MockInsufficientCreditsError,
+  }));
+  mock.module("./ai-billing-records", () => ({
+    aiBillingRecordsService: { record: aiBillingRecord },
+  }));
+  mock.module("./shared-runtime/run-shared-agent-turn", () => ({
+    runSharedAgentTurn,
+    resolveSharedAgentTurnModel,
+  }));
+});
 
 afterAll(() => {
   mock.module("./shared-runtime/run-shared-agent-turn", () => realRunSharedAgentTurn);
@@ -145,7 +148,24 @@ function dedicatedSandbox(overrides: Partial<AgentSandbox> = {}): AgentSandbox {
   } as AgentSandbox;
 }
 
+function enterWorkerRuntime(): void {
+  Object.defineProperty(globalThis, "WebSocketPair", {
+    value: class WebSocketPair {},
+    configurable: true,
+  });
+}
+
+function restoreWorkerRuntime(): void {
+  if (originalWebSocketPair) {
+    Object.defineProperty(globalThis, "WebSocketPair", originalWebSocketPair);
+  } else {
+    Reflect.deleteProperty(globalThis, "WebSocketPair");
+  }
+}
+
 afterEach(() => {
+  globalThis.fetch = originalFetch;
+  restoreWorkerRuntime();
   reconcileReservation.mockClear();
   reserveCredits.mockClear();
   billUsage.mockClear();
@@ -223,6 +243,9 @@ describe("ElizaSandboxService bridge — dedicated bootstrap window", () => {
 
   test("a freshly-minted tier-upgrade migration target (pending + marker) gets the bootstrap window too (#15943)", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    enterWorkerRuntime();
+    const fetchMock = mock(async () => Response.json({ ok: true }));
+    globalThis.fetch = fetchMock;
     // Exactly the row the single-flight mint commits: dedicated-always, born
     // `pending` with its provision job, carrying the server-side reattach
     // marker and its own minted platform env. Users keep chatting against the
@@ -251,17 +274,24 @@ describe("ElizaSandboxService bridge — dedicated bootstrap window", () => {
     );
 
     try {
-      const response = await runWithCloudBindings({ CEREBRAS_API_KEY: "test-key" }, () =>
-        new ElizaSandboxService().bridge(sandbox.id, sandbox.organization_id, {
-          jsonrpc: "2.0",
-          id: "upgrade-boot-turn",
-          method: "message.send",
-          params: { text: "hello" },
-        }),
+      const response = await runWithCloudBindings(
+        {
+          CEREBRAS_API_KEY: "test-key",
+          ELIZA_CLOUD_AGENT_BASE_DOMAIN: "elizacloud.ai",
+          AGENT_ROUTER_ORIGIN_HOST: "eliza-production-1.elizacloud.ai",
+        },
+        () =>
+          new ElizaSandboxService().bridge(sandbox.id, sandbox.organization_id, {
+            jsonrpc: "2.0",
+            id: "upgrade-boot-turn",
+            method: "message.send",
+            params: { text: "hello" },
+          }),
       );
       expect(response.error).toBeUndefined();
       expect((response.result as { text?: string }).text).toBe("bootstrap reply");
       expect(runSharedAgentTurn).toHaveBeenCalledTimes(1);
+      expect(fetchMock).not.toHaveBeenCalled();
     } finally {
       findRunningSpy.mockRestore();
       findByIdSpy.mockRestore();

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-dedicated-bootstrap.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-dedicated-bootstrap.test.ts
@@ -1,4 +1,7 @@
-// Exercises eliza sandbox dedicated bootstrap behavior with deterministic cloud-shared lib fixtures.
+/**
+ * Covers dedicated-agent bootstrap routing through shared and container
+ * runtimes using deterministic repository and transport fixtures.
+ */
 import { afterAll, afterEach, beforeAll, describe, expect, mock, spyOn, test } from "bun:test";
 
 import type { AgentSandbox } from "../../db/repositories/agent-sandboxes";

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-shared-billing.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-shared-billing.test.ts
@@ -1,4 +1,7 @@
-// Exercises eliza sandbox shared billing behavior with deterministic cloud-shared lib fixtures.
+/**
+ * Covers shared-runtime reservation, settlement, and dedicated-routing billing
+ * boundaries using deterministic repository and provider fixtures.
+ */
 import { afterAll, afterEach, beforeAll, describe, expect, mock, spyOn, test } from "bun:test";
 
 import type { AgentSandbox } from "../../db/repositories/agent-sandboxes";

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-shared-billing.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-shared-billing.test.ts
@@ -1,5 +1,5 @@
 // Exercises eliza sandbox shared billing behavior with deterministic cloud-shared lib fixtures.
-import { afterAll, afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, mock, spyOn, test } from "bun:test";
 
 import type { AgentSandbox } from "../../db/repositories/agent-sandboxes";
 import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
@@ -11,17 +11,19 @@ import * as realRunSharedAgentTurnNs from "./shared-runtime/run-shared-agent-tur
 
 // Bun runs every cloud-shared test file in a single process, and `mock.module`
 // overrides are process-global with no built-in per-file teardown. The mocks
-// below replace `./shared-runtime/run-shared-agent-turn`, `./ai-billing`, and
-// `./ai-billing-records`; without an explicit restore they leak into later
-// files that import the real modules (e.g. `agent-tier.test.ts` picking up the
-// stub `runSharedAgentTurn` that always returns `degraded: false`), producing
+// installed in `beforeAll` replace `./shared-runtime/run-shared-agent-turn`,
+// `./ai-billing`, and `./ai-billing-records`; without an explicit restore they
+// leak into later files that import the real modules (e.g.
+// `agent-tier.test.ts` picking up the stub `runSharedAgentTurn` that always returns
+// `degraded: false`), producing
 // order-dependent failures. Snapshot the real exports into plain objects at
-// module-evaluation time (the `import *` namespaces above are hoisted before
-// the `mock.module` calls run, but they are live bindings, so the eager spread
-// is what captures the real exports) and re-install them in `afterAll`.
+// module-evaluation time. Install only when this suite starts, then re-install
+// the real exports in `afterAll`.
 const realRunSharedAgentTurn = { ...realRunSharedAgentTurnNs };
 const realAiBilling = { ...realAiBillingNs };
 const realAiBillingRecords = { ...realAiBillingRecordsNs };
+const originalFetch = globalThis.fetch;
+const originalWebSocketPair = Object.getOwnPropertyDescriptor(globalThis, "WebSocketPair");
 
 const reconcileReservation = mock(async (actualCost: number) => ({
   reservedAmount: 0.002,
@@ -83,21 +85,7 @@ class MockInsufficientCreditsError extends Error {
   }
 }
 
-mock.module("./ai-billing", () => ({
-  reserveCredits,
-  billUsage,
-  recordUsageAnalytics,
-  estimateInputTokens,
-  InsufficientCreditsError: MockInsufficientCreditsError,
-}));
-
 const aiBillingRecord = mock(async () => ({ id: "ai-billing-1" }));
-
-mock.module("./ai-billing-records", () => ({
-  aiBillingRecordsService: {
-    record: aiBillingRecord,
-  },
-}));
 
 const runSharedAgentTurn = mock(async () => ({
   reply: "metered reply",
@@ -116,10 +104,24 @@ const runSharedAgentTurn = mock(async () => ({
 
 const resolveSharedAgentTurnModel = mock(() => "gpt-oss-120b");
 
-mock.module("./shared-runtime/run-shared-agent-turn", () => ({
-  runSharedAgentTurn,
-  resolveSharedAgentTurnModel,
-}));
+beforeAll(() => {
+  mock.module("./ai-billing", () => ({
+    reserveCredits,
+    billUsage,
+    recordUsageAnalytics,
+    estimateInputTokens,
+    InsufficientCreditsError: MockInsufficientCreditsError,
+  }));
+  mock.module("./ai-billing-records", () => ({
+    aiBillingRecordsService: {
+      record: aiBillingRecord,
+    },
+  }));
+  mock.module("./shared-runtime/run-shared-agent-turn", () => ({
+    runSharedAgentTurn,
+    resolveSharedAgentTurnModel,
+  }));
+});
 
 afterAll(() => {
   mock.module("./shared-runtime/run-shared-agent-turn", () => realRunSharedAgentTurn);
@@ -174,7 +176,24 @@ function sharedSandbox(): AgentSandbox {
   };
 }
 
+function enterWorkerRuntime(): void {
+  Object.defineProperty(globalThis, "WebSocketPair", {
+    value: class WebSocketPair {},
+    configurable: true,
+  });
+}
+
+function restoreWorkerRuntime(): void {
+  if (originalWebSocketPair) {
+    Object.defineProperty(globalThis, "WebSocketPair", originalWebSocketPair);
+  } else {
+    Reflect.deleteProperty(globalThis, "WebSocketPair");
+  }
+}
+
 afterEach(() => {
+  globalThis.fetch = originalFetch;
+  restoreWorkerRuntime();
   reconcileReservation.mockClear();
   reserveCredits.mockClear();
   billUsage.mockClear();
@@ -186,6 +205,69 @@ afterEach(() => {
 });
 
 describe("ElizaSandboxService shared runtime billing", () => {
+  test("running dedicated turns use the Worker router origin and bypass shared billing", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    enterWorkerRuntime();
+    const sandbox = {
+      ...sharedSandbox(),
+      execution_tier: "dedicated-always",
+      bridge_url: "https://legacy-bridge.example",
+      health_url: "http://100.64.0.10:23816/api/health",
+      node_id: "node-1",
+      bridge_port: 18923,
+      web_ui_port: 23816,
+      headscale_ip: "100.64.0.10",
+      sandbox_id: "sandbox-e06bb509",
+      environment_vars: { ELIZA_API_TOKEN: "agent-token" },
+    } as AgentSandbox;
+    const findRunningSandboxSpy = spyOn(
+      agentSandboxesRepository,
+      "findRunningSandbox",
+    ).mockResolvedValue(sandbox);
+    const requests: Array<{ url: string; headers: Headers }> = [];
+    globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      requests.push({
+        url: typeof input === "string" ? input : input.toString(),
+        headers: new Headers(init?.headers),
+      });
+      return Response.json({
+        jsonrpc: "2.0",
+        id: "dedicated-turn",
+        result: { text: "dedicated reply" },
+      });
+    });
+
+    try {
+      const response = await runWithCloudBindings(
+        {
+          ELIZA_CLOUD_AGENT_BASE_DOMAIN: "elizacloud.ai",
+          AGENT_ROUTER_ORIGIN_HOST: "eliza-production-1.elizacloud.ai",
+        },
+        () =>
+          new ElizaSandboxService().bridge(sandbox.id, sandbox.organization_id, {
+            jsonrpc: "2.0",
+            id: "dedicated-turn",
+            method: "message.send",
+            params: { text: "hello" },
+          }),
+      );
+
+      expect(response.result).toMatchObject({
+        text: "dedicated reply",
+        transport: "native-jsonrpc",
+      });
+      expect(requests).toHaveLength(1);
+      expect(requests[0]?.url).toBe("https://eliza-production-1.elizacloud.ai/bridge");
+      expect(requests[0]?.headers.get("authorization")).toBe("Bearer agent-token");
+      expect(requests[0]?.headers.get("x-forwarded-host")).toBe(`${sandbox.id}.elizacloud.ai`);
+      expect(runSharedAgentTurn).not.toHaveBeenCalled();
+      expect(reserveCredits).not.toHaveBeenCalled();
+      expect(billUsage).not.toHaveBeenCalled();
+    } finally {
+      findRunningSandboxSpy.mockRestore();
+    }
+  });
+
   test("meters successful shared-runtime turns", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const sandbox = sharedSandbox();

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -1,4 +1,7 @@
-// Exercises eliza sandbox behavior with deterministic cloud-shared lib fixtures.
+/**
+ * Covers sandbox lifecycle, state transfer, recovery, and upgrade invariants
+ * using deterministic repository and provider fixtures.
+ */
 import {
   afterAll,
   afterEach,

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -405,7 +405,7 @@ describe("ElizaSandboxService bridge status", () => {
     globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = fetchUrl(input);
       requests.push({ url, headers: fetchHeaders(init?.headers) });
-      if (url === `https://${sandbox.id}.elizacloud.ai/api/agents`) {
+      if (url === "https://eliza-production-1.elizacloud.ai/api/agents") {
         return new Response("{}", { status: 404 });
       }
       if (url === "https://eliza-production-1.elizacloud.ai/") {
@@ -441,18 +441,30 @@ describe("ElizaSandboxService bridge status", () => {
         },
       });
       expect(requests).toHaveLength(2);
-      expect(requests[0]?.url.startsWith(`https://${sandbox.id}.elizacloud.ai`)).toBe(true);
-      expect(requests[1]).toEqual({
-        url: "https://eliza-production-1.elizacloud.ai/",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: "Bearer agent-token",
-          "X-Api-Key": "agent-token",
-          "X-Eliza-Token": "agent-token",
-          "x-forwarded-host": `${sandbox.id}.elizacloud.ai`,
-          "x-forwarded-proto": "https",
+      expect(requests).toEqual([
+        {
+          url: "https://eliza-production-1.elizacloud.ai/api/agents",
+          headers: {
+            authorization: "Bearer agent-token",
+            "content-type": "application/json",
+            "x-api-key": "agent-token",
+            "x-eliza-token": "agent-token",
+            "x-forwarded-host": `${sandbox.id}.elizacloud.ai`,
+            "x-forwarded-proto": "https",
+          },
         },
-      });
+        {
+          url: "https://eliza-production-1.elizacloud.ai/",
+          headers: {
+            authorization: "Bearer agent-token",
+            "content-type": "application/json",
+            "x-api-key": "agent-token",
+            "x-eliza-token": "agent-token",
+            "x-forwarded-host": `${sandbox.id}.elizacloud.ai`,
+            "x-forwarded-proto": "https",
+          },
+        },
+      ]);
     } finally {
       findRunningSandboxSpy.mockRestore();
     }

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -2090,6 +2090,8 @@ export class ElizaSandboxService {
     try {
       parsed = new URL(raw.includes("://") ? raw : `https://${raw}`);
     } catch {
+      // error-policy:J3 an unparsable routing binding is an explicit invalid
+      // configuration signal; it must never fall through to a token recipient.
       throw new AgentRouterConfigurationError(variable);
     }
 
@@ -2188,9 +2190,13 @@ export class ElizaSandboxService {
     target: AgentFetchTarget,
     init: RequestInit = {},
   ): Promise<Response> {
-    const headers = new Headers(this.getAgentJsonHeaders(rec));
-    new Headers(init.headers).forEach((value, name) => headers.set(name, value));
+    const headers = new Headers(init.headers);
     headers.delete("host");
+    headers.delete("x-forwarded-host");
+    headers.delete("x-forwarded-proto");
+    new Headers(this.getAgentJsonHeaders(rec)).forEach((value, name) =>
+      headers.set(name, value),
+    );
     if (target.forwardedHost) {
       headers.set("x-forwarded-host", target.forwardedHost);
       headers.set("x-forwarded-proto", "https");

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -515,6 +515,34 @@ type RuntimeAgentListResult = {
   agents: RuntimeAgentSummary[];
 };
 
+type AgentNetworkTarget = Pick<
+  AgentSandbox,
+  | "id"
+  | "bridge_url"
+  | "health_url"
+  | "node_id"
+  | "bridge_port"
+  | "web_ui_port"
+  | "headscale_ip"
+  | "sandbox_id"
+>;
+
+type AgentApiTarget = AgentNetworkTarget & Pick<AgentSandbox, "environment_vars">;
+
+type AgentFetchTarget = {
+  url: string;
+  forwardedHost?: string;
+};
+
+const AGENT_ID_RE = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
+
+class AgentRouterConfigurationError extends Error {
+  constructor(variable: "AGENT_ROUTER_ORIGIN_HOST" | "ELIZA_CLOUD_AGENT_BASE_DOMAIN") {
+    super(`Worker agent routing requires a valid ${variable}`);
+    this.name = "AgentRouterConfigurationError";
+  }
+}
+
 const DEFAULT_CENTRAL_SERVER_ID = "00000000-0000-0000-0000-000000000000";
 
 class BridgeRouteUnavailableError extends Error {
@@ -743,10 +771,8 @@ export class ElizaSandboxService {
       | "sandbox_id"
     >,
   ): Promise<RuntimeAgentListResult> {
-    const agentsEndpoint = await this.getAgentApiEndpoint(rec, "/api/agents");
-    const agentsRes = await fetch(agentsEndpoint, {
+    const agentsRes = await this.fetchAgentApi(rec, "/api/agents", {
       method: "GET",
-      headers: this.getAgentJsonHeaders(rec),
       signal: AbortSignal.timeout(10_000),
     });
     if (agentsRes.status === 404) {
@@ -851,15 +877,14 @@ export class ElizaSandboxService {
     >,
     runtimeAgentId: string,
   ): Promise<void> {
-    const startEndpoint = await this.getAgentApiEndpoint(
+    const startRes = await this.fetchAgentApi(
       rec,
       `/api/agents/${encodeURIComponent(runtimeAgentId)}/start`,
+      {
+        method: "POST",
+        signal: AbortSignal.timeout(60_000),
+      },
     );
-    const startRes = await fetch(startEndpoint, {
-      method: "POST",
-      headers: this.getAgentJsonHeaders(rec),
-      signal: AbortSignal.timeout(60_000),
-    });
     if (!startRes.ok) {
       throw new Error(`Runtime agent start returned HTTP ${startRes.status}`);
     }
@@ -883,7 +908,6 @@ export class ElizaSandboxService {
       | "user_id"
     >,
   ): Promise<string> {
-    const createEndpoint = await this.getAgentApiEndpoint(rec, "/api/agents");
     // Bootstrap secrets (OPENAI_API_KEY / ANTHROPIC_API_KEY / ...) are copied
     // out of environment_vars, which stores them encrypted at rest (#11332) —
     // materialize real values before building the bootstrap payload.
@@ -905,9 +929,8 @@ export class ElizaSandboxService {
       sessionKey: rec.id,
       env: bootstrapEnv,
     });
-    const createRes = await fetch(createEndpoint, {
+    const createRes = await this.fetchAgentApi(rec, "/api/agents", {
       method: "POST",
-      headers: this.getAgentJsonHeaders(rec),
       body: JSON.stringify({
         agent: this.buildRuntimeBootstrapAgent({ ...rec, environment_vars: pooledEnv }),
       }),
@@ -2039,12 +2062,6 @@ export class ElizaSandboxService {
     return this.normalizeConfiguredHostname(configured);
   }
 
-  private getConfiguredAgentRouterOriginHost(): string | null {
-    const configured = getCloudAwareEnv().AGENT_ROUTER_ORIGIN_HOST?.trim();
-    if (!configured) return null;
-    return this.normalizeConfiguredHostname(configured);
-  }
-
   private normalizeConfiguredHostname(hostname: string): string | null {
     const normalized = hostname
       .replace(/^https?:\/\//, "")
@@ -2054,30 +2071,105 @@ export class ElizaSandboxService {
     return normalized || null;
   }
 
-  private async getAgentApiEndpoint(
-    rec: Pick<
-      AgentSandbox,
-      | "id"
-      | "bridge_url"
-      | "health_url"
-      | "node_id"
-      | "bridge_port"
-      | "web_ui_port"
-      | "headscale_ip"
-      | "sandbox_id"
-    >,
-    path: string,
-  ): Promise<string> {
-    const isWorkerRuntime = this.isCloudflareWorkerRuntime();
-    const baseDomain = this.getConfiguredAgentBaseDomain();
-    if (isWorkerRuntime && baseDomain) {
-      const publicEndpoint = getElizaAgentPublicWebUiUrl(rec, { baseDomain, path });
-      if (publicEndpoint) return publicEndpoint;
+  /**
+   * Parse routing hosts more strictly than the display-URL helpers do. These
+   * values select the recipient of the agent's bearer token, so a malformed
+   * Worker binding must stop the request before fetch rather than fall back to
+   * the public UUID hostname (which same-zone routing sends to wildcard DNS)
+   * or a credential/path embedded in an otherwise hostname-only binding.
+   */
+  private getRequiredWorkerRoutingHost(
+    variable: "AGENT_ROUTER_ORIGIN_HOST" | "ELIZA_CLOUD_AGENT_BASE_DOMAIN",
+    value: string | undefined,
+    options: { allowPort: boolean },
+  ): string {
+    const raw = value?.trim();
+    if (!raw || raw.startsWith("//")) throw new AgentRouterConfigurationError(variable);
+
+    let parsed: URL;
+    try {
+      parsed = new URL(raw.includes("://") ? raw : `https://${raw}`);
+    } catch {
+      throw new AgentRouterConfigurationError(variable);
     }
+
+    const hostname = parsed.hostname.toLowerCase().replace(/\.+$/, "");
+    const validDnsName =
+      hostname.length > 0 &&
+      hostname.length <= 253 &&
+      hostname
+        .split(".")
+        .every(
+          (label) =>
+            label.length > 0 &&
+            label.length <= 63 &&
+            /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(label),
+        );
+    if (
+      parsed.protocol !== "https:" ||
+      parsed.username ||
+      parsed.password ||
+      parsed.pathname !== "/" ||
+      parsed.search ||
+      parsed.hash ||
+      !validDnsName ||
+      (!options.allowPort && parsed.port)
+    ) {
+      throw new AgentRouterConfigurationError(variable);
+    }
+
+    return parsed.port ? `${hostname}:${parsed.port}` : hostname;
+  }
+
+  private getWorkerAgentRouterFetchTarget(
+    rec: AgentNetworkTarget,
+    path: string,
+  ): AgentFetchTarget | null {
+    if (!this.isCloudflareWorkerRuntime()) return null;
+
+    const env = getCloudAwareEnv();
+    const originHost = this.getRequiredWorkerRoutingHost(
+      "AGENT_ROUTER_ORIGIN_HOST",
+      env.AGENT_ROUTER_ORIGIN_HOST,
+      { allowPort: true },
+    );
+    const baseDomain = this.getRequiredWorkerRoutingHost(
+      "ELIZA_CLOUD_AGENT_BASE_DOMAIN",
+      env.ELIZA_CLOUD_AGENT_BASE_DOMAIN,
+      { allowPort: false },
+    );
+    const agentId = rec.id.trim().toLowerCase();
+    if (!AGENT_ID_RE.test(agentId)) {
+      throw new Error("Worker agent routing requires a valid agent UUID");
+    }
+
+    const route = new URL(path, "https://agent-route.invalid/");
+    if (route.origin !== "https://agent-route.invalid") {
+      throw new Error("Agent API path must be relative to the agent origin");
+    }
+
+    const target = new URL(`https://${originHost}/`);
+    target.pathname = route.pathname;
+    target.search = route.search;
+    target.hash = route.hash;
+    return {
+      url: target.toString(),
+      forwardedHost: `${agentId}.${baseDomain}`,
+    };
+  }
+
+  private async getAgentApiFetchTarget(
+    rec: AgentNetworkTarget,
+    path: string,
+  ): Promise<AgentFetchTarget> {
+    const workerTarget = this.getWorkerAgentRouterFetchTarget(rec, path);
+    if (workerTarget) return workerTarget;
+
+    const baseDomain = this.getConfiguredAgentBaseDomain();
 
     const trustedWebBaseUrl = await this.getTrustedDockerWebBaseUrl(rec);
     if (trustedWebBaseUrl) {
-      return new URL(path, trustedWebBaseUrl).toString();
+      return { url: new URL(path, trustedWebBaseUrl).toString() };
     }
 
     if (baseDomain) {
@@ -2085,43 +2177,56 @@ export class ElizaSandboxService {
         baseDomain,
         path,
       });
-      if (publicEndpoint) return publicEndpoint;
+      if (publicEndpoint) return { url: publicEndpoint };
     }
 
-    return this.getSafeBridgeEndpoint(rec, path);
+    return { url: await this.getSafeBridgeEndpoint(rec, path) };
+  }
+
+  private async fetchAgentTarget(
+    rec: Pick<AgentSandbox, "id" | "environment_vars">,
+    target: AgentFetchTarget,
+    init: RequestInit = {},
+  ): Promise<Response> {
+    const headers = new Headers(this.getAgentJsonHeaders(rec));
+    new Headers(init.headers).forEach((value, name) => headers.set(name, value));
+    headers.delete("host");
+    if (target.forwardedHost) {
+      headers.set("x-forwarded-host", target.forwardedHost);
+      headers.set("x-forwarded-proto", "https");
+    }
+    // Fetch strips Authorization on a cross-origin redirect, but preserves
+    // custom auth headers such as X-Api-Key and X-Eliza-Token. Never let the
+    // configured control-plane origin redirect an agent token to another host.
+    return await fetch(target.url, { ...init, headers, redirect: "manual" });
+  }
+
+  private async fetchAgentApi(
+    rec: AgentApiTarget,
+    path: string,
+    init: RequestInit = {},
+  ): Promise<Response> {
+    const target = await this.getAgentApiFetchTarget(rec, path);
+    return await this.fetchAgentTarget(rec, target, init);
   }
 
   private async getAgentWebFetchTarget(
-    rec: Pick<
-      AgentSandbox,
-      | "id"
-      | "bridge_url"
-      | "health_url"
-      | "node_id"
-      | "bridge_port"
-      | "web_ui_port"
-      | "headscale_ip"
-      | "sandbox_id"
-    >,
+    rec: AgentNetworkTarget,
     path: string,
-  ): Promise<{ url: string; forwardedHost?: string }> {
-    const originHost = this.isCloudflareWorkerRuntime()
-      ? this.getConfiguredAgentRouterOriginHost()
-      : null;
-    if (originHost) {
-      const baseDomain = this.getConfiguredAgentBaseDomain();
-      const publicEndpoint = getElizaAgentPublicWebUiUrl(
-        rec,
-        baseDomain ? { baseDomain, path } : { path },
-      );
-      if (publicEndpoint) {
-        const agentHost = new URL(publicEndpoint).host;
-        const url = new URL(path, `https://${originHost}`).toString();
-        return { url, forwardedHost: agentHost };
-      }
-    }
+  ): Promise<AgentFetchTarget> {
+    const workerTarget = this.getWorkerAgentRouterFetchTarget(rec, path);
+    if (workerTarget) return workerTarget;
 
     return { url: await this.getAgentWebEndpoint(rec, path) };
+  }
+
+  private async fetchAgentWeb(
+    rec: AgentApiTarget,
+    path: string,
+    init: RequestInit = {},
+  ): Promise<Response> {
+    const target = await this.getAgentWebFetchTarget(rec, path);
+    return await this.fetchAgentTarget(rec, target, init);
   }
 
   private async getAgentWebEndpoint(
@@ -2718,15 +2823,8 @@ export class ElizaSandboxService {
       };
     }
 
-    const rootTarget = await this.getAgentWebFetchTarget(rec, "/");
-    const headers = this.getAgentJsonHeaders(rec);
-    if (rootTarget.forwardedHost) {
-      headers["x-forwarded-host"] = rootTarget.forwardedHost;
-      headers["x-forwarded-proto"] = "https";
-    }
-    const rootRes = await fetch(rootTarget.url, {
+    const rootRes = await this.fetchAgentWeb(rec, "/", {
       method: "GET",
-      headers,
       signal: AbortSignal.timeout(10_000),
     });
     if (!rootRes.ok) {
@@ -2861,10 +2959,8 @@ export class ElizaSandboxService {
     if (!rec.bridge_url) {
       throw new BridgeRouteUnavailableError("Sandbox has no bridge_url", 0);
     }
-    const url = await this.getAgentApiEndpoint(rec, "/bridge");
-    const res = await fetch(url, {
+    const res = await this.fetchAgentApi(rec, "/bridge", {
       method: "POST",
-      headers: this.getAgentJsonHeaders(rec),
       body: JSON.stringify({
         jsonrpc: "2.0",
         id: rpc.id ?? null,
@@ -2920,16 +3016,15 @@ export class ElizaSandboxService {
     params: Record<string, unknown>,
   ): Promise<BridgeResponse> {
     const conversationId = await this.createBridgeConversation(rec, params);
-    const messageEndpoint = await this.getAgentApiEndpoint(
+    const res = await this.fetchAgentApi(
       rec,
       `/api/conversations/${encodeURIComponent(conversationId)}/messages`,
+      {
+        method: "POST",
+        body: JSON.stringify(this.buildBridgeConversationMessageBody(params)),
+        signal: AbortSignal.timeout(60_000),
+      },
     );
-    const res = await fetch(messageEndpoint, {
-      method: "POST",
-      headers: this.getAgentJsonHeaders(rec),
-      body: JSON.stringify(this.buildBridgeConversationMessageBody(params)),
-      signal: AbortSignal.timeout(60_000),
-    });
     if (!res.ok) {
       return {
         jsonrpc: "2.0",
@@ -2968,16 +3063,15 @@ export class ElizaSandboxService {
     }
 
     const sessionId = await this.createBridgeMessagingSession(rec, runtimeAgent.id, params);
-    const messageEndpoint = await this.getAgentApiEndpoint(
+    const res = await this.fetchAgentApi(
       rec,
       `/api/messaging/sessions/${encodeURIComponent(sessionId)}/messages`,
+      {
+        method: "POST",
+        body: JSON.stringify(this.buildBridgeSessionMessageBody(params)),
+        signal: AbortSignal.timeout(60_000),
+      },
     );
-    const res = await fetch(messageEndpoint, {
-      method: "POST",
-      headers: this.getAgentJsonHeaders(rec),
-      body: JSON.stringify(this.buildBridgeSessionMessageBody(params)),
-      signal: AbortSignal.timeout(60_000),
-    });
     if (!res.ok) {
       return {
         jsonrpc: "2.0",
@@ -3017,16 +3111,15 @@ export class ElizaSandboxService {
     }
 
     const channelId = this.stableBridgeChannelId(runtimeAgent.id, params);
-    const messageEndpoint = await this.getAgentApiEndpoint(
+    const res = await this.fetchAgentApi(
       rec,
       `/api/messaging/central-channels/${encodeURIComponent(channelId)}/messages`,
+      {
+        method: "POST",
+        body: JSON.stringify(this.buildBridgeCentralChannelMessageBody(params, runtimeAgent.id)),
+        signal: AbortSignal.timeout(60_000),
+      },
     );
-    const res = await fetch(messageEndpoint, {
-      method: "POST",
-      headers: this.getAgentJsonHeaders(rec),
-      body: JSON.stringify(this.buildBridgeCentralChannelMessageBody(params, runtimeAgent.id)),
-      signal: AbortSignal.timeout(60_000),
-    });
     if (res.status === 404) {
       throw new BridgeRouteUnavailableError(
         "Central channel messaging API is unavailable",
@@ -3100,10 +3193,8 @@ export class ElizaSandboxService {
     rec: AgentSandbox,
     params: Record<string, unknown>,
   ): Promise<{ status: number; body: Record<string, unknown> }> {
-    const endpoint = await this.getAgentApiEndpoint(rec, "/v1/chat/completions");
-    const res = await fetch(endpoint, {
+    const res = await this.fetchAgentApi(rec, "/v1/chat/completions", {
       method: "POST",
-      headers: this.getAgentJsonHeaders(rec),
       body: JSON.stringify(this.buildBridgeOpenAiChatBody(params)),
       signal: AbortSignal.timeout(120_000),
     });
@@ -3157,10 +3248,8 @@ export class ElizaSandboxService {
       typeof params.source === "string" && params.source.trim() ? params.source : "cloud";
     const roomId =
       typeof params.roomId === "string" && params.roomId.trim() ? params.roomId : "default";
-    const endpoint = await this.getAgentApiEndpoint(rec, "/api/conversations");
-    const res = await fetch(endpoint, {
+    const res = await this.fetchAgentApi(rec, "/api/conversations", {
       method: "POST",
-      headers: this.getAgentJsonHeaders(rec),
       body: JSON.stringify({
         title: `${source}:${roomId}`.slice(0, 120),
         metadata: { scope: "general" },
@@ -3189,10 +3278,8 @@ export class ElizaSandboxService {
     runtimeAgentId: string,
     params: Record<string, unknown>,
   ): Promise<string> {
-    const endpoint = await this.getAgentApiEndpoint(rec, "/api/messaging/sessions");
-    const res = await fetch(endpoint, {
+    const res = await this.fetchAgentApi(rec, "/api/messaging/sessions", {
       method: "POST",
-      headers: this.getAgentJsonHeaders(rec),
       body: JSON.stringify({
         agentId: runtimeAgentId,
         userId: this.stableBridgeUserId(params),
@@ -3512,18 +3599,16 @@ export class ElizaSandboxService {
     sessionId: string,
     runtimeAgentId?: string,
   ): Promise<string | null> {
-    const endpoint = await this.getAgentApiEndpoint(
-      rec,
-      `/api/messaging/sessions/${encodeURIComponent(sessionId)}/messages?limit=20`,
-    );
-
     for (let attempt = 0; attempt < 24; attempt++) {
       if (attempt > 0) await new Promise((resolve) => setTimeout(resolve, 2_500));
-      const res = await fetch(endpoint, {
-        method: "GET",
-        headers: this.getAgentJsonHeaders(rec),
-        signal: AbortSignal.timeout(10_000),
-      });
+      const res = await this.fetchAgentApi(
+        rec,
+        `/api/messaging/sessions/${encodeURIComponent(sessionId)}/messages?limit=20`,
+        {
+          method: "GET",
+          signal: AbortSignal.timeout(10_000),
+        },
+      );
       if (!res.ok) return null;
       const body = await res.json().catch(() => ({}));
       const messages = this.getBridgeMessages(body);
@@ -3543,18 +3628,16 @@ export class ElizaSandboxService {
     channelId: string,
     runtimeAgentId?: string,
   ): Promise<string | null> {
-    const endpoint = await this.getAgentApiEndpoint(
-      rec,
-      `/api/messaging/central-channels/${encodeURIComponent(channelId)}/messages?limit=30`,
-    );
-
     for (let attempt = 0; attempt < 20; attempt++) {
       if (attempt > 0) await new Promise((resolve) => setTimeout(resolve, 2_500));
-      const res = await fetch(endpoint, {
-        method: "GET",
-        headers: this.getAgentJsonHeaders(rec),
-        signal: AbortSignal.timeout(10_000),
-      });
+      const res = await this.fetchAgentApi(
+        rec,
+        `/api/messaging/central-channels/${encodeURIComponent(channelId)}/messages?limit=30`,
+        {
+          method: "GET",
+          signal: AbortSignal.timeout(10_000),
+        },
+      );
       if (!res.ok) return null;
       const body = await res.json().catch(() => ({}));
       const messages = this.getBridgeMessages(body);
@@ -3689,31 +3772,9 @@ export class ElizaSandboxService {
 
     try {
       const fullPath = `/api/workflow/${workflowPath}${sanitizedQuery ? `?${sanitizedQuery}` : ""}`;
-      const envVars = rec.environment_vars as Record<string, string> | null;
-      const apiToken = envVars?.ELIZA_API_TOKEN;
-      if (!apiToken) {
-        logger.warn("[agent-sandbox] No ELIZA_API_TOKEN for workflow proxy", {
-          agentId,
-        });
-      }
-
-      const agentBaseDomain = process.env.ELIZA_CLOUD_AGENT_BASE_DOMAIN;
-      let endpoint: string;
-      if (agentBaseDomain) {
-        endpoint = `https://${agentId}.${agentBaseDomain}${fullPath}`;
-      } else if (rec.web_ui_port && rec.node_id) {
-        const bridgeUrl = new URL(rec.bridge_url);
-        endpoint = `${bridgeUrl.protocol}//${bridgeUrl.hostname}:${rec.web_ui_port}${fullPath}`;
-      } else {
-        endpoint = await this.getSafeBridgeEndpoint(rec, fullPath);
-      }
-
       const headers: Record<string, string> = { Accept: "application/json" };
       if (method !== "GET" && method !== "DELETE") {
         headers["Content-Type"] = "application/json";
-      }
-      if (apiToken) {
-        headers.Authorization = `Bearer ${apiToken}`;
       }
       const fetchOptions: RequestInit = {
         method,
@@ -3723,7 +3784,7 @@ export class ElizaSandboxService {
       if ((method === "POST" || method === "PUT") && body != null) {
         fetchOptions.body = body;
       }
-      return await fetch(endpoint, fetchOptions);
+      return await this.fetchAgentApi(rec, fullPath, fetchOptions);
     } catch (error) {
       logger.warn("[agent-sandbox] Workflow proxy request failed", {
         agentId,
@@ -3788,41 +3849,9 @@ export class ElizaSandboxService {
     try {
       const fullPath = `/api/wallet/${walletPath}${sanitizedQuery ? `?${sanitizedQuery}` : ""}`;
 
-      // Extract API token from environment_vars
-      const envVars = rec.environment_vars as Record<string, string> | null;
-      const apiToken = envVars?.ELIZA_API_TOKEN;
-      if (!apiToken) {
-        logger.warn("[agent-sandbox] No ELIZA_API_TOKEN for wallet proxy", {
-          agentId,
-        });
-      }
-
-      // Prefer the public domain over internal bridge IPs (only reachable
-      // from within the Hetzner network).
-      const agentBaseDomain = process.env.ELIZA_CLOUD_AGENT_BASE_DOMAIN;
-      let endpoint: string;
-      if (agentBaseDomain) {
-        // Public URL: https://{agentId}.{ELIZA_CLOUD_AGENT_BASE_DOMAIN}/api/wallet/...
-        endpoint = `https://${agentId}.${agentBaseDomain}${fullPath}`;
-      } else if (rec.web_ui_port && rec.node_id) {
-        // Internal fallback: http://{host}:{web_ui_port}/api/wallet/...
-        const bridgeUrl = new URL(rec.bridge_url);
-        endpoint = `${bridgeUrl.protocol}//${bridgeUrl.hostname}:${rec.web_ui_port}${fullPath}`;
-      } else {
-        endpoint = await this.getSafeBridgeEndpoint(rec, fullPath);
-      }
-
-      logger.info("[agent-sandbox] Wallet proxy endpoint", {
-        agentId,
-        endpoint: endpoint.replace(/Bearer.*/, "***"),
-      });
-
       const headers: Record<string, string> = {
         "Content-Type": "application/json",
       };
-      if (apiToken) {
-        headers.Authorization = `Bearer ${apiToken}`;
-      }
       const fetchOptions: RequestInit = {
         method,
         headers,
@@ -3831,7 +3860,7 @@ export class ElizaSandboxService {
       if (method === "POST" && body != null) {
         fetchOptions.body = body;
       }
-      return await fetch(endpoint, fetchOptions);
+      return await this.fetchAgentApi(rec, fullPath, fetchOptions);
     } catch (error) {
       logger.warn("[agent-sandbox] Wallet proxy request failed", {
         agentId,
@@ -3893,33 +3922,11 @@ export class ElizaSandboxService {
 
     try {
       const fullPath = `/api/lifeops/schedule/${schedulePath}${sanitizedQuery ? `?${sanitizedQuery}` : ""}`;
-      const envVars = rec.environment_vars as Record<string, string> | null;
-      const apiToken = envVars?.ELIZA_API_TOKEN;
-      if (!apiToken) {
-        logger.warn("[agent-sandbox] No ELIZA_API_TOKEN for schedule proxy", {
-          agentId,
-        });
-      }
-
-      const agentBaseDomain = process.env.ELIZA_CLOUD_AGENT_BASE_DOMAIN;
-      let endpoint: string;
-      if (agentBaseDomain) {
-        endpoint = `https://${agentId}.${agentBaseDomain}${fullPath}`;
-      } else if (rec.web_ui_port && rec.node_id) {
-        const bridgeUrl = new URL(rec.bridge_url);
-        endpoint = `${bridgeUrl.protocol}//${bridgeUrl.hostname}:${rec.web_ui_port}${fullPath}`;
-      } else {
-        endpoint = await this.getSafeBridgeEndpoint(rec, fullPath);
-      }
-
       const headers: Record<string, string> = {
         Accept: "application/json",
       };
       if (method === "POST") {
         headers["Content-Type"] = "application/json";
-      }
-      if (apiToken) {
-        headers.Authorization = `Bearer ${apiToken}`;
       }
       const fetchOptions: RequestInit = {
         method,
@@ -3929,7 +3936,7 @@ export class ElizaSandboxService {
       if (method === "POST" && body != null) {
         fetchOptions.body = body;
       }
-      return await fetch(endpoint, fetchOptions);
+      return await this.fetchAgentApi(rec, fullPath, fetchOptions);
     } catch (error) {
       logger.warn("[agent-sandbox] Schedule proxy request failed", {
         agentId,
@@ -3985,16 +3992,15 @@ export class ElizaSandboxService {
 
     try {
       const conversationId = await this.createBridgeConversation(rec, params);
-      const bridgeEndpoint = await this.getAgentApiEndpoint(
+      const res = await this.fetchAgentApi(
         rec,
         `/api/conversations/${encodeURIComponent(conversationId)}/messages/stream`,
+        {
+          method: "POST",
+          body: JSON.stringify(this.buildBridgeConversationMessageBody(params)),
+          signal: AbortSignal.timeout(120_000),
+        },
       );
-      const res = await fetch(bridgeEndpoint, {
-        method: "POST",
-        headers: this.getAgentJsonHeaders(rec),
-        body: JSON.stringify(this.buildBridgeConversationMessageBody(params)),
-        signal: AbortSignal.timeout(120_000),
-      });
       if (res.ok) return this.normalizeBridgeSseResponse(res);
       if (res.status !== 404) {
         logger.warn("[agent-sandbox] Bridge stream conversation request failed", {
@@ -6129,10 +6135,8 @@ export class ElizaSandboxService {
       throw new Error("Sandbox is not running");
     }
 
-    const snapshotEndpoint = await this.getAgentApiEndpoint(rec, "/api/snapshot");
-    const res = await fetch(snapshotEndpoint, {
+    const res = await this.fetchAgentApi(rec, "/api/snapshot", {
       method: "POST",
-      headers: this.getAgentJsonHeaders(rec),
       signal: AbortSignal.timeout(SNAPSHOT_FETCH_TIMEOUT_MS),
     });
     if (res.status === 404) {
@@ -6394,21 +6398,23 @@ export class ElizaSandboxService {
       authRec?: Pick<AgentSandbox, "id" | "environment_vars">;
     },
   ) {
-    const restoreEndpoint =
-      typeof sandboxOrBridgeUrl === "string"
-        ? await this.getSafeBridgeEndpoint(sandboxOrBridgeUrl, "/api/restore", options)
-        : await this.getAgentApiEndpoint(sandboxOrBridgeUrl, "/api/restore");
-    const res = await fetch(restoreEndpoint, {
+    const requestInit: RequestInit = {
       method: "POST",
-      headers:
-        typeof sandboxOrBridgeUrl === "string"
-          ? options?.authRec
-            ? this.getAgentJsonHeaders(options.authRec)
-            : { "Content-Type": "application/json" }
-          : this.getAgentJsonHeaders(sandboxOrBridgeUrl),
       body: JSON.stringify(state),
       signal: AbortSignal.timeout(SNAPSHOT_RESTORE_TIMEOUT_MS),
-    });
+    };
+    const res =
+      typeof sandboxOrBridgeUrl === "string"
+        ? await fetch(
+            await this.getSafeBridgeEndpoint(sandboxOrBridgeUrl, "/api/restore", options),
+            {
+              ...requestInit,
+              headers: options?.authRec
+                ? this.getAgentJsonHeaders(options.authRec)
+                : { "Content-Type": "application/json" },
+            },
+          )
+        : await this.fetchAgentApi(sandboxOrBridgeUrl, "/api/restore", requestInit);
     if (!res.ok) {
       // error-policy:J6 best-effort read of the restore error body to enrich
       // the error we throw next; a failed body read must not mask the status.

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -2194,9 +2194,11 @@ export class ElizaSandboxService {
     headers.delete("host");
     headers.delete("x-forwarded-host");
     headers.delete("x-forwarded-proto");
-    new Headers(this.getAgentJsonHeaders(rec)).forEach((value, name) =>
-      headers.set(name, value),
-    );
+    const trustedHeaders = new Headers(this.getAgentJsonHeaders(rec));
+    if (!trustedHeaders.has("authorization")) {
+      throw new Error(`Agent proxy requires an API token for ${rec.id}`);
+    }
+    trustedHeaders.forEach((value, name) => headers.set(name, value));
     if (target.forwardedHost) {
       headers.set("x-forwarded-host", target.forwardedHost);
       headers.set("x-forwarded-proto", "https");


### PR DESCRIPTION
Relates to #15347, #16194, #16079, and #16228.

## What changed

- routes every Cloudflare Worker-to-agent API, bridge, SSE, workflow, wallet, LifeOps, snapshot, and restore request through the configured control-plane origin
- carries the logical `<agent-id>.<agent-domain>` identity in trusted `X-Forwarded-Host` / `X-Forwarded-Proto` headers so the control-plane router selects the intended agent
- validates the control-plane host, base domain, agent UUID, and relative path before network I/O
- strips caller-controlled host, forwarding, and auth headers; restores the stored agent credential; and disables redirects so custom auth headers cannot follow a cross-origin redirect
- fails closed before fetch when routing configuration or the stored agent credential is missing
- preserves the existing direct tailnet/public routing behavior outside Cloudflare Workers
- declares the production default origin while retaining explicit staging and production environment bindings

## Why

The real managed-agent canary provisioned a healthy dedicated agent, but the nested same-zone Worker fetch to its UUID wildcard hostname failed at Cloudflare with HTTP 525 before nginx, the router, authentication, Headscale, or the model runtime received HTTP. Worker subrequests must target the fixed control-plane origin and pass the logical agent hostname separately.

## Validation

- exact head: `1a8277c542d5e90c58ec6ea61587f95036718a70`
- seven changed sandbox suites: 141 passed, 0 failed, 609 assertions
- `bun run --cwd packages/cloud/shared typecheck`
- `bun run --cwd packages/cloud/api typecheck` (includes production Worker bundle dry-run)
- explicit staging Wrangler dry-run confirms `AGENT_ROUTER_ORIGIN_HOST=eliza-staging-1.elizacloud.ai`
- production dry-run confirms `AGENT_ROUTER_ORIGIN_HOST=eliza-production-1.elizacloud.ai`
- Biome, `git diff --check`, and `bun run audit:error-policy-ratchet`

## Deployment and post-merge acceptance

The repository's canonical Cloud deployment guard intentionally rejects feature refs, so post-fix infrastructure evidence cannot be captured from this branch. After merge, deploy this exact change to staging through the canonical `develop` workflow, then run #16228's managed dedicated canary and require successful bridge, SSE, real model turn, exact cleanup, and deployed-commit provenance before production promotion.

## Risk

Medium: this centralizes all Worker-side dedicated-agent calls. Invalid configuration now fails closed instead of falling back to the broken wildcard route. No database migration or public API shape changes are included.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - backend-only Worker routing change with no rendered UI surface`.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - backend-only Worker routing change with no rendered UI surface`.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - the applicable end-to-end artifact is the managed dedicated-agent canary`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: [pre-fix real managed-agent canary](https://github.com/elizaOS/eliza/actions/runs/29225162447) and [artifact](https://github.com/elizaOS/eliza/actions/runs/29225162447/artifacts/8269503777) prove a healthy provision followed by edge-level bridge failure; post-fix staging canary is the explicit post-merge gate above.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code or browser request path changed`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: [the pre-fix canary artifact](https://github.com/elizaOS/eliza/actions/runs/29225162447/artifacts/8269503777) records zero model turns because transport failed before the runtime; a nonzero real turn is required from #16228 after the canonical staging deployment.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [the managed-agent artifact](https://github.com/elizaOS/eliza/actions/runs/29225162447/artifacts/8269503777) records the created agent, observed tier/mesh/readiness, and exact cleanup; no persistent schema or migration changes are made by this PR.
