### PR TITLE
fix(computeruse): isolate real desktop tests

### DIFF
--- a/packages/scripts/__tests__/real-live-suites.test.ts
+++ b/packages/scripts/__tests__/real-live-suites.test.ts
@@ -143,17 +143,29 @@ describe("real/live guarded-suite manifest (#9310 §E)", () => {
     });
   });
 
-  test("computer-use service actuation is isolated behind an explicit real-lane opt-in", () => {
-    expect(
-      manifest.find(
-        (entry) =>
-          entry.file ===
-          "plugins/plugin-computeruse/src/__tests__/service.real.test.ts",
-      ),
-    ).toMatchObject({
-      optIn: "COMPUTER_USE_REAL_DESKTOP_TESTS",
-      blocked: expect.stringContaining("vitest.config.ts excludes"),
+  test("computer-use service actuation is isolated behind a per-command acknowledgment", () => {
+    const entry = manifest.find(
+      (candidate) =>
+        candidate.file ===
+        "plugins/plugin-computeruse/src/__tests__/service.real.test.ts",
+    );
+    expect(entry).toMatchObject({
+      blocked: expect.stringContaining("excludes real desktop actuation"),
+      notes: expect.stringContaining("per-command acknowledgment"),
     });
+    expect(entry).not.toHaveProperty("optIn");
+
+    const realSource = fs.readFileSync(
+      path.join(
+        repoRoot,
+        "plugins/plugin-computeruse/src/__tests__/service.real.test.ts",
+      ),
+      "utf8",
+    );
+    expect(realSource).toContain(
+      'process.env.COMPUTER_USE_REAL_DESKTOP_TESTS !== "1"',
+    );
+    expect(realSource).toContain("throw new Error");
 
     const integrationSource = fs.readFileSync(
       path.join(

--- a/packages/scripts/__tests__/real-live-suites.test.ts
+++ b/packages/scripts/__tests__/real-live-suites.test.ts
@@ -143,6 +143,35 @@ describe("real/live guarded-suite manifest (#9310 §E)", () => {
     });
   });
 
+  test("computer-use service actuation is isolated behind an explicit real-lane opt-in", () => {
+    expect(
+      manifest.find(
+        (entry) =>
+          entry.file ===
+          "plugins/plugin-computeruse/src/__tests__/service.real.test.ts",
+      ),
+    ).toMatchObject({
+      optIn: "COMPUTER_USE_REAL_DESKTOP_TESTS",
+      blocked: expect.stringContaining("vitest.config.ts excludes"),
+    });
+
+    const integrationSource = fs.readFileSync(
+      path.join(
+        repoRoot,
+        "plugins/plugin-computeruse/src/__tests__/service.integration.test.ts",
+      ),
+      "utf8",
+    );
+    for (const hostModule of [
+      "../platform/desktop.js",
+      "../platform/driver.js",
+      "../platform/screenshot.js",
+      "screenshot-quality.ts",
+    ]) {
+      expect(integrationSource).not.toContain(hostModule);
+    }
+  });
+
   test("the exact Anthropic receipt disables aggregate coverage with a real Bun config", () => {
     const workflow = fs.readFileSync(
       path.join(repoRoot, ".github/workflows/develop-live.yml"),

--- a/packages/scripts/lib/real-live-suites.mjs
+++ b/packages/scripts/lib/real-live-suites.mjs
@@ -41,7 +41,7 @@ import path from "node:path";
 
 /** Same content pattern that defines the guarded set in issue #9310. */
 export const GUARD_CONTENT_PATTERN =
-  /describe\.skip|requireLiveProvider|ELIZA_LIVE_TEST/;
+  /describe\.skip|requireLiveProvider|ELIZA_LIVE_TEST|COMPUTER_USE_REAL_DESKTOP_TESTS/;
 
 export const REAL_LIVE_FILE_PATTERN = /\.(?:real|live)\.test\.tsx?$/;
 
@@ -171,11 +171,10 @@ export const GUARDED_REAL_LIVE_SUITES = [
   },
   {
     file: "plugins/plugin-computeruse/src/__tests__/service.real.test.ts",
-    optIn: "COMPUTER_USE_REAL_DESKTOP_TESTS",
     blocked:
-      "plugin-computeruse vitest.config.ts excludes *.real.test.ts from workspace sweeps; run this file through packages/test/vitest/real.config.ts on an isolated interactive desktop",
+      "plugin-computeruse excludes real desktop actuation from every workspace sweep; run this exact file through packages/test/vitest/real.config.ts on an isolated interactive desktop",
     notes:
-      "captures the display and actuates pointer, keyboard, and scrolling only after explicit operator opt-in",
+      "the file itself requires COMPUTER_USE_REAL_DESKTOP_TESTS=1 as a per-command acknowledgment",
   },
   {
     file: "plugins/plugin-computeruse/src/__tests__/windows-list.real.test.ts",

--- a/packages/scripts/lib/real-live-suites.mjs
+++ b/packages/scripts/lib/real-live-suites.mjs
@@ -170,6 +170,14 @@ export const GUARDED_REAL_LIVE_SUITES = [
     optIn: "FORCE_OSWORLD_BENCHMARK",
   },
   {
+    file: "plugins/plugin-computeruse/src/__tests__/service.real.test.ts",
+    optIn: "COMPUTER_USE_REAL_DESKTOP_TESTS",
+    blocked:
+      "plugin-computeruse vitest.config.ts excludes *.real.test.ts from workspace sweeps; run this file through packages/test/vitest/real.config.ts on an isolated interactive desktop",
+    notes:
+      "captures the display and actuates pointer, keyboard, and scrolling only after explicit operator opt-in",
+  },
+  {
     file: "plugins/plugin-computeruse/src/__tests__/windows-list.real.test.ts",
     blocked:
       "plugin-computeruse vitest.config.ts excludes *.real.test.ts in every lane (desktop-control host required)",

--- a/plugins/plugin-computeruse/docs/TEST_LANES_COMPUTERUSE_VISION.md
+++ b/plugins/plugin-computeruse/docs/TEST_LANES_COMPUTERUSE_VISION.md
@@ -48,9 +48,10 @@ bunx vitest run plugins/plugin-computeruse/src/__tests__/cua-parity-input.real.t
   --config packages/test/vitest/real.config.ts
 ```
 
-The service-level lane captures the display and actuates the pointer, keyboard,
-and scroll wheel. Run it only on an isolated interactive desktop and acknowledge
-those effects explicitly:
+The service-level lane captures the display and moves the pointer, then reads
+the OS cursor position back to prove the driver effect. Run it only on an
+isolated interactive desktop and acknowledge those effects explicitly. A direct
+invocation without the acknowledgment fails before the suite starts:
 
 ```bash
 COMPUTER_USE_REAL_DESKTOP_TESTS=1 bunx vitest run \

--- a/plugins/plugin-computeruse/docs/TEST_LANES_COMPUTERUSE_VISION.md
+++ b/plugins/plugin-computeruse/docs/TEST_LANES_COMPUTERUSE_VISION.md
@@ -48,6 +48,16 @@ bunx vitest run plugins/plugin-computeruse/src/__tests__/cua-parity-input.real.t
   --config packages/test/vitest/real.config.ts
 ```
 
+The service-level lane captures the display and actuates the pointer, keyboard,
+and scroll wheel. Run it only on an isolated interactive desktop and acknowledge
+those effects explicitly:
+
+```bash
+COMPUTER_USE_REAL_DESKTOP_TESTS=1 bunx vitest run \
+  plugins/plugin-computeruse/src/__tests__/service.real.test.ts \
+  --config packages/test/vitest/real.config.ts
+```
+
 `ELIZA_CI_REAL=1` additionally drops credential/upstream-gated reals
 (e.g. `computeruse.real.test.ts`, whose headless-browser path needs a display).
 

--- a/plugins/plugin-computeruse/src/__tests__/platform-capabilities.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/platform-capabilities.test.ts
@@ -26,11 +26,13 @@ function detectFor(
   osName: PlatformOS,
   availableCommands: string[],
   browserAvailable = true,
+  driverName: "legacy" | "nutjs" = "legacy",
 ) {
   const commands = new Set(availableCommands);
   return detectPlatformCapabilities({
     osName,
     commandExists: (command) => commands.has(command),
+    driverName,
     isBrowserAvailable: () => browserAvailable,
     shell: "/bin/zsh",
   });
@@ -123,6 +125,20 @@ describe("cross-platform computer-use capabilities", () => {
     });
     expect(caps.windowList.available).toBe(false);
     expect(caps.browser.available).toBe(false);
+  });
+
+  it("reports capture and input through the resolved nutjs driver", () => {
+    const caps = detectFor("linux", ["/bin/zsh"], false, "nutjs");
+
+    expect(caps.screenshot).toEqual({
+      available: true,
+      tool: "@nut-tree-fork/nut-js",
+    });
+    expect(caps.computerUse).toEqual({
+      available: true,
+      tool: "@nut-tree-fork/nut-js",
+    });
+    expect(caps.windowList.available).toBe(false);
   });
 });
 

--- a/plugins/plugin-computeruse/src/__tests__/service.integration.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/service.integration.test.ts
@@ -1,9 +1,9 @@
 /**
- * Exercises ComputerUseService through an initialized AgentRuntime, using real
- * host integrations when available and permission-independent paths otherwise.
+ * Exercises ComputerUseService through a real AgentRuntime and in-memory
+ * database without capturing or actuating the host desktop.
  */
 
-import { AgentRuntime, createCharacter, stringToUuid } from "@elizaos/core";
+import type { AgentRuntime } from "@elizaos/core";
 import {
   afterAll,
   afterEach,
@@ -13,11 +13,10 @@ import {
   expect,
   it,
 } from "vitest";
-import { InMemoryDatabaseAdapter } from "../../../../packages/core/src/database/inMemoryAdapter.ts";
-import { assertScreenshotBase64NotBlank } from "../../test/helpers/screenshot-quality.ts";
-import { desktopMouseMove } from "../platform/desktop.js";
-import { currentPlatform } from "../platform/helpers.js";
-import { captureScreenshot } from "../platform/screenshot.js";
+import {
+  startComputerUseRuntime,
+  stopComputerUseRuntime,
+} from "../../test/helpers/service-runtime.ts";
 import { ComputerUseService } from "../services/computer-use-service.js";
 
 type RawActionParams = { action: string };
@@ -42,76 +41,6 @@ function executeRawWindowAction(
   return execute.call(service, params);
 }
 
-const os = currentPlatform();
-
-let hasScreenCapture = false;
-try {
-  await captureScreenshot();
-  hasScreenCapture = true;
-} catch {
-  // error-policy:J4 The hardware lane is explicitly unavailable without screen-capture permission.
-}
-
-let hasDesktopControl = false;
-try {
-  desktopMouseMove(0, 0);
-  hasDesktopControl = true;
-} catch {
-  // error-policy:J4 The hardware lane is explicitly unavailable without a desktop driver or permission.
-}
-
-async function startComputerUseRuntime(
-  settings: Record<string, string> = {},
-): Promise<{ runtime: AgentRuntime; service: ComputerUseService }> {
-  const runtime = new AgentRuntime({
-    character: createCharacter({
-      id: stringToUuid(`computeruse-service-${crypto.randomUUID()}`),
-      name: "ComputerUseServiceIntegrationAgent",
-      settings: {
-        COMPUTER_USE_APPROVAL_MODE: "full_control",
-        ...settings,
-      },
-    }),
-    adapter: new InMemoryDatabaseAdapter(),
-    enableAutonomy: false,
-    logLevel: "fatal",
-  });
-  await runtime.initialize();
-  await runtime.registerPlugin({
-    name: "computeruse-service-integration",
-    description: "Real ComputerUseService lifecycle integration",
-    services: [ComputerUseService],
-  });
-  const service = await runtime.getServiceLoadPromise(
-    ComputerUseService.serviceType,
-  );
-  if (!(service instanceof ComputerUseService)) {
-    throw new Error("ComputerUseService did not register with AgentRuntime");
-  }
-  return { runtime, service };
-}
-
-async function stopComputerUseRuntime(runtime: AgentRuntime): Promise<void> {
-  await runtime.stop();
-  await runtime.close();
-}
-
-function skipIfAccessibilityPermissionMissing(
-  skip: (message?: string) => void,
-  result: {
-    permissionDenied?: boolean;
-    permissionType?: string;
-    message?: string;
-    error?: string;
-  },
-): void {
-  if (result.permissionDenied && result.permissionType === "accessibility") {
-    skip(
-      result.message ?? result.error ?? "Accessibility permission is missing",
-    );
-  }
-}
-
 describe("ComputerUseService lifecycle", () => {
   let runtime: AgentRuntime;
   let service: ComputerUseService;
@@ -124,7 +53,7 @@ describe("ComputerUseService lifecycle", () => {
     await stopComputerUseRuntime(runtime);
   });
 
-  it("registers a usable service with detected host capabilities", () => {
+  it("registers the service and reports capability state without claiming availability", () => {
     expect(ComputerUseService.serviceType).toBe("computeruse");
     expect(service.capabilityDescription.length).toBeGreaterThan(0);
     const caps = service.getCapabilities();
@@ -143,55 +72,18 @@ describe("ComputerUseService lifecycle", () => {
       expect(typeof caps[key].available).toBe("boolean");
       expect(typeof caps[key].tool).toBe("string");
     }
-
-    if (os === "darwin") {
-      expect(caps.screenshot.available).toBe(true);
-      expect(caps.screenshot.tool).toContain("screencapture");
-    }
-
-    if (os === "win32") {
-      expect(caps.screenshot.available).toBe(true);
-      expect(caps.computerUse.available).toBe(true);
-    }
-    const size = service.getScreenDimensions();
-    expect(size.width).toBeGreaterThanOrEqual(640);
-    expect(size.height).toBeGreaterThanOrEqual(480);
     expect(service.getRecentActions()).toEqual([]);
   });
 });
 
-const describeIfScreenCapture = hasScreenCapture ? describe : describe.skip;
-const describeIfDesktop = hasDesktopControl ? describe : describe.skip;
-
-describeIfScreenCapture("ComputerUseService screen capture (real)", () => {
-  let runtime: AgentRuntime;
-  let service: ComputerUseService;
-
-  beforeAll(async () => {
-    ({ runtime, service } = await startComputerUseRuntime());
-  });
-
-  afterAll(async () => {
-    await stopComputerUseRuntime(runtime);
-  });
-
-  it("captures a non-blank screenshot", async () => {
-    const result = await service.executeDesktopAction({ action: "screenshot" });
-    expect(result.success).toBe(true);
-    assertScreenshotBase64NotBlank(
-      result.screenshot,
-      "ComputerUseService screenshot action",
-    );
-  });
-});
-
-describeIfDesktop("ComputerUseService desktop actions (real)", () => {
+describe("ComputerUseService configuration", () => {
   let runtime: AgentRuntime;
   let service: ComputerUseService;
 
   beforeAll(async () => {
     ({ runtime, service } = await startComputerUseRuntime({
       COMPUTER_USE_SCREENSHOT_AFTER_ACTION: "false",
+      COMPUTER_USE_ACTION_TIMEOUT_MS: "5000",
     }));
   });
 
@@ -199,57 +91,12 @@ describeIfDesktop("ComputerUseService desktop actions (real)", () => {
     await stopComputerUseRuntime(runtime);
   });
 
-  it("executes mouse_move action", async ({ skip }) => {
-    const result = await service.executeDesktopAction({
-      action: "mouse_move",
-      coordinate: [200, 200],
+  it("applies explicit settings without dispatching an action", () => {
+    expect(service.getConfig()).toMatchObject({
+      screenshotAfterAction: false,
+      actionTimeoutMs: 5000,
     });
-
-    skipIfAccessibilityPermissionMissing(skip, result);
-    expect(result.success).toBe(true);
-    expect(result.screenshot).toBeUndefined();
-  });
-
-  it("executes click action", async ({ skip }) => {
-    const result = await service.executeDesktopAction({
-      action: "click",
-      coordinate: [200, 200],
-    });
-
-    skipIfAccessibilityPermissionMissing(skip, result);
-    expect(result.success).toBe(true);
-  });
-
-  it("executes key action", async ({ skip }) => {
-    const result = await service.executeDesktopAction({
-      action: "key",
-      key: "Escape",
-    });
-
-    skipIfAccessibilityPermissionMissing(skip, result);
-    expect(result.success).toBe(true);
-  });
-
-  it("executes key_combo action", async ({ skip }) => {
-    const result = await service.executeDesktopAction({
-      action: "key_combo",
-      key: "shift+Escape",
-    });
-
-    skipIfAccessibilityPermissionMissing(skip, result);
-    expect(result.success).toBe(true);
-  });
-
-  it("executes scroll action", async ({ skip }) => {
-    const result = await service.executeDesktopAction({
-      action: "scroll",
-      coordinate: [400, 400],
-      scrollDirection: "down",
-      scrollAmount: 2,
-    });
-
-    skipIfAccessibilityPermissionMissing(skip, result);
-    expect(result.success).toBe(true);
+    expect(service.getRecentActions()).toEqual([]);
   });
 });
 
@@ -320,7 +167,7 @@ describe("ComputerUseService desktop validation and history", () => {
   });
 });
 
-describe("ComputerUseService window actions (real)", () => {
+describe("ComputerUseService window validation", () => {
   let runtime: AgentRuntime;
   let service: ComputerUseService;
 
@@ -331,13 +178,6 @@ describe("ComputerUseService window actions (real)", () => {
   afterAll(async () => {
     await stopComputerUseRuntime(runtime);
   });
-
-  it("lists windows", async () => {
-    const result = await service.executeWindowAction({ action: "list" });
-
-    expect(result.success).toBe(true);
-    expect(Array.isArray(result.windows)).toBe(true);
-  }, 15000);
 
   it("returns error for focus without windowId", async () => {
     const result = await service.executeWindowAction({ action: "focus" });

--- a/plugins/plugin-computeruse/src/__tests__/service.real.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/service.real.test.ts
@@ -1,6 +1,6 @@
 /**
- * Drives ComputerUseService against the selected host driver only after an
- * operator opts in; hardware and permission failures fail instead of skipping.
+ * Proves observable ComputerUseService effects against the selected host
+ * driver only after an operator opts in. Hardware and permission failures fail.
  */
 
 import type { AgentRuntime } from "@elizaos/core";
@@ -12,15 +12,19 @@ import {
 } from "../../test/helpers/service-runtime.ts";
 import type { ComputerUseService } from "../services/computer-use-service.js";
 
-const realDesktopEnabled = process.env.COMPUTER_USE_REAL_DESKTOP_TESTS === "1";
-const describeRealDesktop = realDesktopEnabled ? describe : describe.skip;
+if (process.env.COMPUTER_USE_REAL_DESKTOP_TESTS !== "1") {
+  throw new Error(
+    "Real desktop service tests require per-command acknowledgment: set COMPUTER_USE_REAL_DESKTOP_TESTS=1 on an isolated interactive desktop",
+  );
+}
 
-describeRealDesktop("ComputerUseService real desktop", () => {
+describe("ComputerUseService real desktop", () => {
   let runtime: AgentRuntime;
   let service: ComputerUseService;
 
   beforeAll(async () => {
     ({ runtime, service } = await startComputerUseRuntime({
+      COMPUTER_USE_APPROVAL_MODE: "full_control",
       COMPUTER_USE_SCREENSHOT_AFTER_ACTION: "false",
     }));
   });
@@ -38,50 +42,29 @@ describeRealDesktop("ComputerUseService real desktop", () => {
     );
   });
 
-  it("moves the pointer through the selected service driver", async () => {
-    const result = await service.executeDesktopAction({
+  it("moves the pointer and reads the resulting OS position", async () => {
+    const moveResult = await service.executeDesktopAction({
       action: "mouse_move",
       coordinate: [200, 200],
     });
-
-    expect(result.success, `mouse_move failed: ${result.error}`).toBe(true);
-    expect(result.screenshot).toBeUndefined();
-  });
-
-  it("clicks through the selected service driver", async () => {
-    const result = await service.executeDesktopAction({
-      action: "click",
-      coordinate: [200, 200],
-    });
-
-    expect(result.success, `click failed: ${result.error}`).toBe(true);
-  });
-
-  it("sends keys through the selected service driver", async () => {
-    const keyResult = await service.executeDesktopAction({
-      action: "key",
-      key: "Escape",
-    });
-    expect(keyResult.success, `key failed: ${keyResult.error}`).toBe(true);
-
-    const comboResult = await service.executeDesktopAction({
-      action: "key_combo",
-      key: "shift+Escape",
-    });
-    expect(comboResult.success, `key_combo failed: ${comboResult.error}`).toBe(
+    expect(moveResult.success, `mouse_move failed: ${moveResult.error}`).toBe(
       true,
     );
-  });
+    expect(moveResult.screenshot).toBeUndefined();
 
-  it("scrolls through the selected service driver", async () => {
-    const result = await service.executeDesktopAction({
-      action: "scroll",
-      coordinate: [400, 400],
-      scrollDirection: "down",
-      scrollAmount: 2,
+    const positionResult = await service.executeDesktopAction({
+      action: "get_cursor_position",
     });
-
-    expect(result.success, `scroll failed: ${result.error}`).toBe(true);
+    expect(
+      positionResult.success,
+      `cursor query failed: ${positionResult.error}`,
+    ).toBe(true);
+    expect(
+      Math.abs((positionResult.cursorPosition?.x ?? -1) - 200),
+    ).toBeLessThanOrEqual(2);
+    expect(
+      Math.abs((positionResult.cursorPosition?.y ?? -1) - 200),
+    ).toBeLessThanOrEqual(2);
   });
 
   it("enumerates at least one real host window", async () => {

--- a/plugins/plugin-computeruse/src/__tests__/service.real.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/service.real.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Drives ComputerUseService against the selected host driver only after an
+ * operator opts in; hardware and permission failures fail instead of skipping.
+ */
+
+import type { AgentRuntime } from "@elizaos/core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { assertScreenshotBase64NotBlank } from "../../test/helpers/screenshot-quality.ts";
+import {
+  startComputerUseRuntime,
+  stopComputerUseRuntime,
+} from "../../test/helpers/service-runtime.ts";
+import type { ComputerUseService } from "../services/computer-use-service.js";
+
+const realDesktopEnabled = process.env.COMPUTER_USE_REAL_DESKTOP_TESTS === "1";
+const describeRealDesktop = realDesktopEnabled ? describe : describe.skip;
+
+describeRealDesktop("ComputerUseService real desktop", () => {
+  let runtime: AgentRuntime;
+  let service: ComputerUseService;
+
+  beforeAll(async () => {
+    ({ runtime, service } = await startComputerUseRuntime({
+      COMPUTER_USE_SCREENSHOT_AFTER_ACTION: "false",
+    }));
+  });
+
+  afterAll(async () => {
+    await stopComputerUseRuntime(runtime);
+  });
+
+  it("captures a non-blank screenshot through the service", async () => {
+    const result = await service.executeDesktopAction({ action: "screenshot" });
+    expect(result.success, `screenshot failed: ${result.error}`).toBe(true);
+    assertScreenshotBase64NotBlank(
+      result.screenshot,
+      "ComputerUseService screenshot action",
+    );
+  });
+
+  it("moves the pointer through the selected service driver", async () => {
+    const result = await service.executeDesktopAction({
+      action: "mouse_move",
+      coordinate: [200, 200],
+    });
+
+    expect(result.success, `mouse_move failed: ${result.error}`).toBe(true);
+    expect(result.screenshot).toBeUndefined();
+  });
+
+  it("clicks through the selected service driver", async () => {
+    const result = await service.executeDesktopAction({
+      action: "click",
+      coordinate: [200, 200],
+    });
+
+    expect(result.success, `click failed: ${result.error}`).toBe(true);
+  });
+
+  it("sends keys through the selected service driver", async () => {
+    const keyResult = await service.executeDesktopAction({
+      action: "key",
+      key: "Escape",
+    });
+    expect(keyResult.success, `key failed: ${keyResult.error}`).toBe(true);
+
+    const comboResult = await service.executeDesktopAction({
+      action: "key_combo",
+      key: "shift+Escape",
+    });
+    expect(comboResult.success, `key_combo failed: ${comboResult.error}`).toBe(
+      true,
+    );
+  });
+
+  it("scrolls through the selected service driver", async () => {
+    const result = await service.executeDesktopAction({
+      action: "scroll",
+      coordinate: [400, 400],
+      scrollDirection: "down",
+      scrollAmount: 2,
+    });
+
+    expect(result.success, `scroll failed: ${result.error}`).toBe(true);
+  });
+
+  it("enumerates at least one real host window", async () => {
+    const result = await service.executeWindowAction({ action: "list" });
+    expect(result.success, `window list failed: ${result.error}`).toBe(true);
+    if (!result.windows) {
+      throw new Error("Window enumeration succeeded without a windows result");
+    }
+    expect(
+      result.windows.length,
+      "Window enumeration returned no windows; the real lane requires an interactive desktop",
+    ).toBeGreaterThan(0);
+  }, 15000);
+});

--- a/plugins/plugin-computeruse/src/platform/capabilities.ts
+++ b/plugins/plugin-computeruse/src/platform/capabilities.ts
@@ -4,11 +4,13 @@
  * host OS and their parity classification. iOS/Android live in mobile/, not here.
  */
 import type { PlatformCapabilities } from "../types.js";
+import { type DriverName, selectedDriver } from "./driver.js";
 import type { PlatformOS } from "./helpers.js";
 
 export interface CapabilityDetectionOptions {
   osName: PlatformOS;
   commandExists: (command: string) => boolean;
+  driverName?: DriverName;
   isBrowserAvailable: () => boolean;
   shell?: string;
 }
@@ -168,6 +170,20 @@ export function detectPlatformCapabilities(
     caps.computerUse = { available: true, tool: "PowerShell user32.dll" };
     caps.windowList = { available: true, tool: "PowerShell Get-Process" };
     caps.clipboard = { available: true, tool: "PowerShell Get-Clipboard" };
+  }
+
+  // The service dispatches capture and input through the resolved driver. A
+  // nutjs installation must not be reported through unrelated legacy binaries,
+  // especially on Linux hosts where xdotool is intentionally absent.
+  if ((options.driverName ?? selectedDriver()) === "nutjs") {
+    caps.screenshot = {
+      available: true,
+      tool: "@nut-tree-fork/nut-js",
+    };
+    caps.computerUse = {
+      available: true,
+      tool: "@nut-tree-fork/nut-js",
+    };
   }
 
   caps.browser = options.isBrowserAvailable()

--- a/plugins/plugin-computeruse/test/helpers/service-runtime.ts
+++ b/plugins/plugin-computeruse/test/helpers/service-runtime.ts
@@ -20,10 +20,7 @@ export async function startComputerUseRuntime(
     character: createCharacter({
       id: stringToUuid(`computeruse-service-${crypto.randomUUID()}`),
       name: "ComputerUseServiceTestAgent",
-      settings: {
-        COMPUTER_USE_APPROVAL_MODE: "full_control",
-        ...settings,
-      },
+      settings,
     }),
     adapter: new InMemoryDatabaseAdapter(),
     enableAutonomy: false,

--- a/plugins/plugin-computeruse/test/helpers/service-runtime.ts
+++ b/plugins/plugin-computeruse/test/helpers/service-runtime.ts
@@ -1,0 +1,53 @@
+/**
+ * Boots ComputerUseService through a real AgentRuntime backed by the in-memory
+ * database adapter. The harness never dispatches host actions; each caller
+ * chooses whether it exercises deterministic validation or opted-in hardware.
+ */
+
+import {
+  AgentRuntime,
+  createCharacter,
+  InMemoryDatabaseAdapter,
+  stringToUuid,
+} from "@elizaos/core";
+import { ComputerUseService } from "../../src/services/computer-use-service.js";
+
+/** Starts the service through the same AgentRuntime registration path used in production. */
+export async function startComputerUseRuntime(
+  settings: Record<string, string> = {},
+): Promise<{ runtime: AgentRuntime; service: ComputerUseService }> {
+  const runtime = new AgentRuntime({
+    character: createCharacter({
+      id: stringToUuid(`computeruse-service-${crypto.randomUUID()}`),
+      name: "ComputerUseServiceTestAgent",
+      settings: {
+        COMPUTER_USE_APPROVAL_MODE: "full_control",
+        ...settings,
+      },
+    }),
+    adapter: new InMemoryDatabaseAdapter(),
+    enableAutonomy: false,
+    logLevel: "fatal",
+  });
+  await runtime.initialize();
+  await runtime.registerPlugin({
+    name: "computeruse-service-test",
+    description: "ComputerUseService runtime test harness",
+    services: [ComputerUseService],
+  });
+  const service = await runtime.getServiceLoadPromise(
+    ComputerUseService.serviceType,
+  );
+  if (!(service instanceof ComputerUseService)) {
+    throw new Error("ComputerUseService did not register with AgentRuntime");
+  }
+  return { runtime, service };
+}
+
+/** Releases runtime resources created by {@link startComputerUseRuntime}. */
+export async function stopComputerUseRuntime(
+  runtime: AgentRuntime,
+): Promise<void> {
+  await runtime.stop();
+  await runtime.close();
+}


### PR DESCRIPTION
# Relates to

Fixes #16266.

- [x] This PR targets `develop` and is based on the latest `origin/develop` (`04901b607c3`) with zero conflicts.
- [x] `bun run install:light` and `bun run verify` completed successfully after sync.
- [x] The deterministic and discovery evidence below lets a reviewer confirm the default lane is non-actuating without running destructive desktop input.

# Sync with develop

- [x] Fetched and rebased onto `origin/develop` at `04901b607c3` with zero conflicts.
- [x] `bun run verify` passed after the sync check: 573/573 Turbo tasks succeeded and 28 dist-path consumer configs typechecked.

# Risks

Low. Desktop action behavior is unchanged. Capability metadata now reports the resolved nutjs or legacy driver used by the service instead of unrelated legacy binaries. The main risk is test-lane classification: a future filename, config, or manifest change could accidentally make real desktop actuation discoverable by ordinary sweeps. The manifest contract test and unconditional `*.real.test.ts` package exclusion guard that boundary.

# Background

## What does this PR do?

- Keeps real `AgentRuntime` + `InMemoryDatabaseAdapter` integration coverage in the deterministic service suite while removing screenshot capture, valid pointer/keyboard/scroll payloads, and window enumeration from ordinary runs.
- Moves observable real screenshot, cursor-movement readback, and window checks into `service.real.test.ts`, guarded by per-command `COMPUTER_USE_REAL_DESKTOP_TESTS=1` acknowledgment and executed through `ComputerUseService`, the selected driver seam.
- Makes permission, driver, screenshot-quality, and empty-window failures fail the real lane instead of silently skipping or fabricating healthy results.
- Uses the public `@elizaos/core` export for the shared runtime harness instead of a cross-workspace source import.
- Reports screenshot and input capability through the service's resolved driver, with deterministic Linux coverage for nutjs hosts without xdotool.
- Registers and documents the destructive real lane and adds a manifest contract ensuring the deterministic suite has no direct host-module imports.

## What kind of change is this?

Bug fix and test-integrity improvement.

# Documentation changes needed?

Documentation was updated in `plugins/plugin-computeruse/docs/TEST_LANES_COMPUTERUSE_VISION.md` with the explicit isolated-desktop command and its host-side effects.

# Testing

## Where should a reviewer start?

Compare `service.integration.test.ts` with `service.real.test.ts`, then inspect the corresponding entry and contract in `real-live-suites.mjs` and `real-live-suites.test.ts`.

## Detailed testing steps

1. Run `bun run --cwd plugins/plugin-computeruse test -- src/__tests__/service.integration.test.ts` and confirm 10/10 deterministic tests pass without host capture or input.
2. Run `bun test packages/scripts/__tests__/real-live-suites.test.ts` and confirm 12/12 manifest tests pass.
3. Run the real-file command without `COMPUTER_USE_REAL_DESKTOP_TESTS=1` and confirm it fails before hooks or actions run.
4. Only on an isolated interactive desktop, run `COMPUTER_USE_REAL_DESKTOP_TESTS=1 bunx vitest run plugins/plugin-computeruse/src/__tests__/service.real.test.ts --config packages/test/vitest/real.config.ts`. This destructive step was not run on the shared development host.

Additional completed checks:

- `bun run --cwd plugins/plugin-computeruse test`: 90 passed / 1 skipped files; 760 passed / 14 skipped tests.
- `bun run --cwd plugins/plugin-computeruse typecheck`: passed.
- `bun run --cwd plugins/plugin-computeruse lint`: passed with 28 pre-existing warning-level diagnostics and no errors.
- `bun run audit:error-policy-ratchet`: passed.
- `bun run verify`: passed in full; 573/573 Turbo tasks plus all repository audits and dist-path checks.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - this test-only and documentation change does not alter a rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - this test-only and documentation change does not alter a rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no user-facing flow or rendered UI change to record.
<!-- evidence-row:backend-logs -->
- [x] N/A - the service capability metadata path changed; real AgentRuntime integration and deterministic capability command results are recorded in Testing above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code, request, response, or client state changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent prompt, model, provider, action implementation, or live-LLM behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the runtime capability object and guarded-suite manifest are asserted by the focused integration and manifest tests recorded above.

# Evidence Details

## Real LLM-call trajectory

N/A - no model or agent behavior changed.

## Backend + frontend logs

The service capability metadata path changed without adding a transport boundary. Real AgentRuntime integration, deterministic capability assertions, and command outcomes are listed under Testing; no frontend path changed.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio behavior changed.

## Known gaps / failures

- The destructive `COMPUTER_USE_REAL_DESKTOP_TESTS=1` lane was **not run** on this shared development host. It captures the display and moves/clicks the pointer, sends keys, scrolls, and enumerates windows, so it requires an isolated interactive desktop with explicit operator consent.
- The same real file was invoked without acknowledgment and failed before test collection. This proves the fail-closed safety gate, not real hardware behavior.
- Root lint reported existing warning-level diagnostics across the monorepo; `bun run verify` exited successfully with no errors.