### PR TITLE
fix(cloud): harden telemetry and cancellation evidence

### DIFF
--- a/packages/cloud/shared/src/lib/observability/http-telemetry-hono.test.ts
+++ b/packages/cloud/shared/src/lib/observability/http-telemetry-hono.test.ts
@@ -9,7 +9,7 @@
 import { describe, expect, it } from "bun:test";
 import { Hono } from "hono";
 import { ELIZA_TRACE_ID_HEADER } from "./http-telemetry";
-import { httpTelemetryMiddleware } from "./http-telemetry-hono";
+import { httpTelemetryMiddleware, shouldDecorateHttpTelemetryStatus } from "./http-telemetry-hono";
 
 function immutableHeadersResponse(body: string, init: ResponseInit): Response {
   const response = new Response(body, init);
@@ -25,6 +25,11 @@ function immutableHeadersResponse(body: string, init: ResponseInit): Response {
 }
 
 describe("httpTelemetryMiddleware", () => {
+  it("bypasses status-101 upgrades whose workerd socket cannot survive rewrapping", () => {
+    expect(shouldDecorateHttpTelemetryStatus(101)).toBe(false);
+    expect(shouldDecorateHttpTelemetryStatus(200)).toBe(true);
+  });
+
   it("stamps trace id + Server-Timing on a mutable handler response", async () => {
     const app = new Hono();
     app.use("*", httpTelemetryMiddleware());

--- a/packages/cloud/shared/src/lib/observability/http-telemetry-hono.ts
+++ b/packages/cloud/shared/src/lib/observability/http-telemetry-hono.ts
@@ -20,12 +20,21 @@ import {
 
 type TraceEnv = { Variables: { traceId: string } };
 
+/** WebSocket upgrades carry a workerd-only socket extension that rewrapping drops. */
+export function shouldDecorateHttpTelemetryStatus(status: number): boolean {
+  return status !== 101;
+}
+
 export function httpTelemetryMiddleware(): MiddlewareHandler<TraceEnv> {
   return async (c, next) => {
     const traceId = resolveElizaTraceId(c.req.raw.headers);
     const startedAt = performance.now();
     c.set("traceId", traceId);
     await next();
+    // A status-101 Response carries workerd's non-standard `webSocket` field.
+    // Standard Response reconstruction cannot preserve it, so the upgrade must
+    // leave this middleware byte-for-byte rather than risk dropping the socket.
+    if (!shouldDecorateHttpTelemetryStatus(c.res.status)) return;
     const metrics: ServerTimingMetric[] = [
       {
         name: "cloud_worker",

--- a/packages/cloud/shared/src/lib/observability/http-telemetry.test.ts
+++ b/packages/cloud/shared/src/lib/observability/http-telemetry.test.ts
@@ -1,5 +1,6 @@
 /** Validates application trace correlation and standards-based HTTP timing headers. */
 import { describe, expect, test } from "bun:test";
+import { ElizaError } from "@elizaos/core";
 
 import {
   appendServerTiming,
@@ -20,6 +21,13 @@ describe("HTTP telemetry", () => {
       [ELIZA_TRACE_ID_HEADER]: "123E4567-E89B-42D3-A456-426614174000",
     });
     expect(resolveElizaTraceId(headers)).toBe("123e4567-e89b-42d3-a456-426614174000");
+  });
+
+  test("preserves UUIDv7 trace ids", () => {
+    const headers = new Headers({
+      [ELIZA_TRACE_ID_HEADER]: "01890F47-6C4A-7B2D-8F31-123456789ABC",
+    });
+    expect(resolveElizaTraceId(headers)).toBe("01890f47-6c4a-7b2d-8f31-123456789abc");
   });
 
   test("uses the W3C trace id when the application header is absent", () => {
@@ -45,11 +53,46 @@ describe("HTTP telemetry", () => {
     "bad value\n",
     "customer-email@example.com",
     "turn_12345678",
+    "00000000000000000000000000000000",
   ])("rejects caller-chosen trace text %s and generates a UUID", (traceId) => {
     const headers = new Headers({ [ELIZA_TRACE_ID_HEADER]: traceId });
     expect(resolveElizaTraceId(headers)).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
     );
+  });
+
+  test.each([
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    Number.NEGATIVE_INFINITY,
+    -0.01,
+  ])("rejects invalid gateway timing %s instead of fabricating zero", (invalidDuration) => {
+    let thrown: unknown;
+    try {
+      snapshotGatewayPreforwardTiming({
+        totalMs: invalidDuration,
+        authMs: 1,
+        middleMs: 1,
+        reserveMs: 1,
+        setupMs: 1,
+      });
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(ElizaError);
+    expect((thrown as ElizaError).code).toBe("HTTP_TELEMETRY_INVALID_DURATION");
+    expect((thrown as ElizaError).context).toEqual({
+      field: "totalMs",
+      value: String(invalidDuration),
+    });
+  });
+
+  test("rejects invalid standalone Server-Timing metrics before writing headers", () => {
+    const headers = new Headers({ "Server-Timing": "provider;dur=3" });
+    expect(() =>
+      appendServerTiming(headers, [{ name: "cloud_worker", durationMs: Number.NaN }]),
+    ).toThrow("HTTP telemetry duration is invalid");
+    expect(headers.get("Server-Timing")).toBe("provider;dur=3");
   });
 
   test("appends inner and outer Server-Timing without overwriting", () => {

--- a/packages/cloud/shared/src/lib/observability/http-telemetry.ts
+++ b/packages/cloud/shared/src/lib/observability/http-telemetry.ts
@@ -6,12 +6,14 @@
  * provider and dedicated-agent propagation is tracked separately.
  */
 
+import { ElizaError } from "@elizaos/core";
+
 export const ELIZA_TRACE_ID_HEADER = "X-Eliza-Trace-Id";
 export const ELIZA_PREFORWARD_HEADER = "X-Eliza-Preforward-Ms";
 export const ELIZA_TELEMETRY_HEADER = "X-Eliza-Telemetry";
 
 const OPAQUE_TRACE_ID =
-  /^(?:[0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/i;
+  /^(?:[0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/i;
 const W3C_TRACEPARENT_V00 = /^00-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$/;
 const ZERO_TRACE_ID = "0".repeat(32);
 const ZERO_PARENT_ID = "0".repeat(16);
@@ -39,7 +41,9 @@ export interface GatewayHandoffTelemetry {
 /** Resolve an opaque correlation id without retaining caller-chosen text. */
 export function resolveElizaTraceId(headers: Headers): string {
   const supplied = headers.get(ELIZA_TRACE_ID_HEADER)?.trim();
-  if (supplied && OPAQUE_TRACE_ID.test(supplied)) return supplied.toLowerCase();
+  if (supplied && OPAQUE_TRACE_ID.test(supplied) && supplied.toLowerCase() !== ZERO_TRACE_ID) {
+    return supplied.toLowerCase();
+  }
 
   const traceparent = headers.get("traceparent")?.trim();
   const match = traceparent?.match(W3C_TRACEPARENT_V00);
@@ -53,8 +57,14 @@ function sanitizeToken(value: string): string {
   return value.replace(/[^A-Za-z0-9_.-]/g, "_").slice(0, 64) || "unknown";
 }
 
-function finiteDuration(value: number): number {
-  if (!Number.isFinite(value) || value < 0) return 0;
+function finiteDuration(value: number, field: string): number {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new ElizaError("HTTP telemetry duration is invalid", {
+      code: "HTTP_TELEMETRY_INVALID_DURATION",
+      severity: "fatal",
+      context: { field, value: String(value) },
+    });
+  }
   return Math.round(value * 100) / 100;
 }
 
@@ -63,11 +73,11 @@ export function snapshotGatewayPreforwardTiming(
   timing: GatewayPreforwardTiming,
 ): GatewayPreforwardTiming {
   return Object.freeze({
-    totalMs: finiteDuration(timing.totalMs),
-    authMs: finiteDuration(timing.authMs),
-    middleMs: finiteDuration(timing.middleMs),
-    reserveMs: finiteDuration(timing.reserveMs),
-    setupMs: finiteDuration(timing.setupMs),
+    totalMs: finiteDuration(timing.totalMs, "totalMs"),
+    authMs: finiteDuration(timing.authMs, "authMs"),
+    middleMs: finiteDuration(timing.middleMs, "middleMs"),
+    reserveMs: finiteDuration(timing.reserveMs, "reserveMs"),
+    setupMs: finiteDuration(timing.setupMs, "setupMs"),
   });
 }
 
@@ -99,7 +109,7 @@ export function bindGatewayHandoffTelemetry<TInput, TOutput>(
 export function appendServerTiming(headers: Headers, metrics: readonly ServerTimingMetric[]): void {
   const encoded = metrics.map((metric) => {
     const name = sanitizeToken(metric.name);
-    const duration = finiteDuration(metric.durationMs);
+    const duration = finiteDuration(metric.durationMs, `Server-Timing:${name}`);
     const description = metric.description ? `;desc="${sanitizeToken(metric.description)}"` : "";
     return `${name};dur=${duration}${description}`;
   });


### PR DESCRIPTION
Fixes #16281

Corrects the post-merge review findings from #16098:

- fail fast on invalid telemetry durations instead of fabricating zero
- accept UUIDv7 and reject the all-zero direct trace ID
- bypass status-101 WebSocket upgrades without reconstructing the Response
- replace curated evidence with immutable, PR-prefixed raw Worker events and billing-domain proof

Exact-head staging evidence: https://github.com/elizaOS/eliza/pull/16282#issuecomment-4961522622

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - backend-only telemetry validation and middleware behavior; no rendered UI changed.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - backend-only telemetry validation and middleware behavior; no rendered UI changed.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no user-facing visual flow changed; the live client-close flow is represented by raw Worker and billing artifacts.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: [raw canceled Worker event](https://github.com/user-attachments/files/29979615/16282-canceled-worker-event.json)

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend code or browser UI path changed.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changed; the live inference request was used only to prove transport cancellation and billing.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [joined reservation, settlement, usage, AI billing record, and balance proof](https://github.com/user-attachments/files/29979616/16282-cancellation-billing-proof.json)
