### PR TITLE
feat: add plugin-wallettriage to third-party registry

### DIFF
--- a/packages/registry/entries/third-party/plugin-wallettriage.json
+++ b/packages/registry/entries/third-party/plugin-wallettriage.json
@@ -1,0 +1,19 @@
+{
+  "package": "plugin-wallettriage",
+  "repository": "github:wallettriage/plugin-wallettriage",
+  "kind": "plugin",
+  "description": "Real-time wallet risk check for elizaOS agents — a CHECK_ADDRESS_RISK action that cross-references an address's active ERC20 approvals with a live exploit threat feed BEFORE the agent acts (risk score 0-100, revoke-first findings). Pay-per-query via x402 (~$0.01 USDC on Base); stateless, no API key. Built-in per-query spend cap.",
+  "homepage": "https://wallettriage.com",
+  "version": "0.1.0",
+  "tags": [
+    "security",
+    "wallet",
+    "risk",
+    "x402",
+    "base",
+    "usdc",
+    "approvals",
+    "exploit",
+    "micropayments"
+  ]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -935,6 +935,55 @@
       "registryKind": "plugin",
       "directory": null
     },
+    "plugin-wallettriage": {
+      "git": {
+        "repo": "wallettriage/plugin-wallettriage",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "plugin-wallettriage",
+        "v0": null,
+        "v1": null,
+        "v2": "0.1.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Real-time wallet risk check for elizaOS agents — a CHECK_ADDRESS_RISK action that cross-references an address's active ERC20 approvals with a live exploit threat feed BEFORE the agent acts (risk score 0-100, revoke-first findings). Pay-per-query via x402 (~$0.01 USDC on Base); stateless, no API key. Built-in per-query spend cap.",
+      "homepage": "https://wallettriage.com",
+      "topics": [
+        "security",
+        "wallet",
+        "risk",
+        "x402",
+        "base",
+        "usdc",
+        "approvals",
+        "exploit",
+        "micropayments"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
     "plugin-x402-alpha-data": {
       "git": {
         "repo": "sna4an/plugin-x402-alpha-data",


### PR DESCRIPTION
# Relates to

Third-party plugin registry submission (process introduced in #8173 —
registry moved in-repo to `packages/registry`). No issue/ticket; this adds
one community registry entry.

Definition of Done: full standard in [`[CONTRIBUTING.md](https://claude.ai/CONTRIBUTING.md)`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run --cwd packages/registry validate` and `generate` pass post-sync
      (registry-scoped verification; see Known gaps for full `bun run verify`).

# Risks

**Low.** Data-only change: one new JSON file under
`packages/registry/entries/third-party/` plus the regenerated
`generated-registry.json`. No runtime, core, or UI code is touched. Worst
case is a malformed entry, which `bun run --cwd packages/registry validate`
guards against (run clean).

# Background

## What does this PR do?

Adds `plugin-wallettriage` to the third-party plugin registry.

WalletTriage is a real-time wallet risk engine: the plugin ships a
`CHECK_ADDRESS_RISK` action that, given an EVM address in the message,
cross-references the address's active ERC20 approvals with a live exploit
threat feed and returns a risk score (0–100), risk level and worst-first
findings (what to revoke, USD at risk) — so an agent can triage a
counterparty (or its own wallet) BEFORE acting. Each query is paid via
x402 (~$0.01 USDC on Base) by a configurable low-balance session key;
stateless, no signup, no API key. Hardening: https enforced for remote
gateways, per-query payment cap (refuses inflated payment requirements),
strict address validation.

- npm: https://www.npmjs.com/package/plugin-wallettriage
- Code: https://github.com/wallettriage/plugin-wallettriage
- Service: https://wallettriage.com · OpenAPI: https://api.wallettriage.com/openapi.yaml

## What kind of change is this?

Features (non-breaking): adds one community registry entry (data only).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/registry/entries/third-party/plugin-wallettriage.json` — then
confirm `generated-registry.json` contains the derived entry and that
validation passes.

## Detailed testing steps

```bash
bun run --cwd packages/registry validate   # entry passes schema validation
bun run --cwd packages/registry generate   # generated-registry.json is reproducible (no diff)
```

Plugin functionality (outside this repo, evidence below):

```bash
npm i plugin-wallettriage   # or: add "plugin-wallettriage" to character plugins
# WALLETTRIAGE_PRIVATE_KEY=0x... (session wallet with USDC on Base)
# ask the agent: "Is 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 safe to interact with?"
```

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - data-only registry entry; no UI surface affected.`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - data-only registry entry; no UI surface affected.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no user-facing flow in this repo; plugin flow evidenced by CLI log below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: registry `validate`/`generate` output pasted below.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no frontend change.`
<!-- evidence-row:llm-trajectory -->
- [x] LLM trajectory: `N/A - no agent/action/provider/prompt/model change in this repo; the action lives in the external plugin package.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: real paid end-to-end run of the plugin action attached below (x402 settle on Base mainnet).

# Evidence Details

## Real LLM-call trajectory

`N/A - registry data only; no prompt/model/action code in this diff.`

## Backend + frontend logs

<details>
<summary>registry validate + generate (paste your real output here)</summary>

```
$ bun run --cwd packages/registry validate
<colar saída real>

$ bun run --cwd packages/registry generate
<colar saída real>
```

</details>

<details>
<summary>Plugin end-to-end run (direct handler invocation, real x402 payment on Base mainnet)</summary>

```
$ node scripts/smoke-test.mjs
validate: true

--- agent reply ---
WalletTriage: 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 on eth → risk 12/100 (LOW).
No actionable findings — no active approvals flagged by the live exploit feed.
-------------------

success: true
risk_score: 12 | level: low
```

(Query paid via x402 — USDC on Base mainnet — through the CDP facilitator;
the same gateway has settled paid queries in production since 2026-07-08.)

</details>

## Screenshots (before / after) + video walkthrough

### Before

`N/A - data-only registry entry; no UI change.`

### After

`N/A - data-only registry entry; no UI change.`

### Walkthrough video

`N/A - no UI flow; CLI evidence above.`

## Audio / voice walkthrough

`N/A - no voice/audio change.`

## Known gaps / failures

- Full monorepo `bun run verify` not run end-to-end on this machine
  (Windows; unrelated packages fail to build locally). The diff is scoped
  to `packages/registry` data files, which pass the package's own
  `validate`, `generate` and `test` — the only checks that exercise this
  change. CI runs the full suite regardless.

<!--
## Discord username
<seu_username> (se estiver no Discord ai16z)
-->