### PR TITLE
fix(models): bump anthropic/openai chat defaults to sonnet-5 and gpt-5.6 sol/luna

### DIFF
--- a/packages/agent/src/api/provider-switch-config.ts
+++ b/packages/agent/src/api/provider-switch-config.ts
@@ -419,15 +419,15 @@ const PROVIDER_DEFAULT_MODELS: Record<
 > = {
   anthropic: {
     smallKey: "ANTHROPIC_SMALL_MODEL",
-    smallVal: "claude-haiku-4-5-20251001",
+    smallVal: "claude-sonnet-5",
     largeKey: "ANTHROPIC_LARGE_MODEL",
     largeVal: "claude-opus-4-8",
   },
   openai: {
     smallKey: "OPENAI_SMALL_MODEL",
-    smallVal: "gpt-5.4-mini",
+    smallVal: "gpt-5.6-luna",
     largeKey: "OPENAI_LARGE_MODEL",
-    largeVal: "gpt-5.5",
+    largeVal: "gpt-5.6-sol",
   },
   google: {
     smallKey: "GOOGLE_SMALL_MODEL",

--- a/plugins/plugin-anthropic/AGENTS.md
+++ b/plugins/plugin-anthropic/AGENTS.md
@@ -13,9 +13,9 @@ The exported `Plugin` object (`anthropicPlugin`) registers these model handlers:
 | ModelType | Handler | Default model |
 |---|---|---|
 | `TEXT_NANO` | `handleTextNano` | falls back to `ANTHROPIC_SMALL_MODEL` |
-| `TEXT_SMALL` | `handleTextSmall` | `claude-haiku-4-5-20251001` |
+| `TEXT_SMALL` | `handleTextSmall` | `claude-sonnet-5` |
 | `TEXT_MEDIUM` | `handleTextMedium` | falls back to `ANTHROPIC_SMALL_MODEL` |
-| `TEXT_LARGE` | `handleTextLarge` | `claude-opus-4-7` |
+| `TEXT_LARGE` | `handleTextLarge` | `claude-opus-4-8` |
 | `TEXT_MEGA` | `handleTextMega` | falls back to `ANTHROPIC_LARGE_MODEL` |
 | `TEXT_REASONING_SMALL` | `handleReasoningSmall` | falls back to `ANTHROPIC_SMALL_MODEL` |
 | `TEXT_REASONING_LARGE` | `handleReasoningLarge` | falls back to `ANTHROPIC_LARGE_MODEL` |
@@ -82,8 +82,8 @@ All settings are read via `runtime.getSetting(key)` first, then `process.env[key
 | `ANTHROPIC_API_KEY` | Yes (or `CLAUDE_API_KEY` or OAuth) | — | Anthropic API key |
 | `CLAUDE_API_KEY` | Alt to above | — | Alias accepted by auto-enable and `getApiKeyOptional` |
 | `ANTHROPIC_AUTH_MODE` | No | `apikey` | Set to `claude-cli` (CLI mode via `claude -p`) or `oauth` |
-| `ANTHROPIC_SMALL_MODEL` / `SMALL_MODEL` | No | `claude-haiku-4-5-20251001` | Model for TEXT_SMALL, RESPONSE_HANDLER, IMAGE_DESCRIPTION |
-| `ANTHROPIC_LARGE_MODEL` / `LARGE_MODEL` | No | `claude-opus-4-7` | Model for TEXT_LARGE, ACTION_PLANNER |
+| `ANTHROPIC_SMALL_MODEL` / `SMALL_MODEL` | No | `claude-sonnet-5` | Model for TEXT_SMALL, RESPONSE_HANDLER, IMAGE_DESCRIPTION |
+| `ANTHROPIC_LARGE_MODEL` / `LARGE_MODEL` | No | `claude-opus-4-8` | Model for TEXT_LARGE, ACTION_PLANNER |
 | `ANTHROPIC_NANO_MODEL` / `NANO_MODEL` | No | falls back to small | Model for TEXT_NANO |
 | `ANTHROPIC_MEDIUM_MODEL` / `MEDIUM_MODEL` | No | falls back to small | Model for TEXT_MEDIUM |
 | `ANTHROPIC_MEGA_MODEL` / `MEGA_MODEL` | No | falls back to large | Model for TEXT_MEGA |

--- a/plugins/plugin-anthropic/CLAUDE.md
+++ b/plugins/plugin-anthropic/CLAUDE.md
@@ -13,9 +13,9 @@ The exported `Plugin` object (`anthropicPlugin`) registers these model handlers:
 | ModelType | Handler | Default model |
 |---|---|---|
 | `TEXT_NANO` | `handleTextNano` | falls back to `ANTHROPIC_SMALL_MODEL` |
-| `TEXT_SMALL` | `handleTextSmall` | `claude-haiku-4-5-20251001` |
+| `TEXT_SMALL` | `handleTextSmall` | `claude-sonnet-5` |
 | `TEXT_MEDIUM` | `handleTextMedium` | falls back to `ANTHROPIC_SMALL_MODEL` |
-| `TEXT_LARGE` | `handleTextLarge` | `claude-opus-4-7` |
+| `TEXT_LARGE` | `handleTextLarge` | `claude-opus-4-8` |
 | `TEXT_MEGA` | `handleTextMega` | falls back to `ANTHROPIC_LARGE_MODEL` |
 | `TEXT_REASONING_SMALL` | `handleReasoningSmall` | falls back to `ANTHROPIC_SMALL_MODEL` |
 | `TEXT_REASONING_LARGE` | `handleReasoningLarge` | falls back to `ANTHROPIC_LARGE_MODEL` |
@@ -82,8 +82,8 @@ All settings are read via `runtime.getSetting(key)` first, then `process.env[key
 | `ANTHROPIC_API_KEY` | Yes (or `CLAUDE_API_KEY` or OAuth) | — | Anthropic API key |
 | `CLAUDE_API_KEY` | Alt to above | — | Alias accepted by auto-enable and `getApiKeyOptional` |
 | `ANTHROPIC_AUTH_MODE` | No | `apikey` | Set to `claude-cli` (CLI mode via `claude -p`) or `oauth` |
-| `ANTHROPIC_SMALL_MODEL` / `SMALL_MODEL` | No | `claude-haiku-4-5-20251001` | Model for TEXT_SMALL, RESPONSE_HANDLER, IMAGE_DESCRIPTION |
-| `ANTHROPIC_LARGE_MODEL` / `LARGE_MODEL` | No | `claude-opus-4-7` | Model for TEXT_LARGE, ACTION_PLANNER |
+| `ANTHROPIC_SMALL_MODEL` / `SMALL_MODEL` | No | `claude-sonnet-5` | Model for TEXT_SMALL, RESPONSE_HANDLER, IMAGE_DESCRIPTION |
+| `ANTHROPIC_LARGE_MODEL` / `LARGE_MODEL` | No | `claude-opus-4-8` | Model for TEXT_LARGE, ACTION_PLANNER |
 | `ANTHROPIC_NANO_MODEL` / `NANO_MODEL` | No | falls back to small | Model for TEXT_NANO |
 | `ANTHROPIC_MEDIUM_MODEL` / `MEDIUM_MODEL` | No | falls back to small | Model for TEXT_MEDIUM |
 | `ANTHROPIC_MEGA_MODEL` / `MEGA_MODEL` | No | falls back to large | Model for TEXT_MEGA |

--- a/plugins/plugin-anthropic/__tests__/native-plumbing.shape.test.ts
+++ b/plugins/plugin-anthropic/__tests__/native-plumbing.shape.test.ts
@@ -572,7 +572,7 @@ describe("Anthropic model defaults", () => {
       getSetting: vi.fn(() => undefined),
     } as IAgentRuntime;
 
-    expect(getResponseHandlerModel(runtime)).toBe("claude-haiku-4-5-20251001");
+    expect(getResponseHandlerModel(runtime)).toBe("claude-sonnet-5");
     expect(getActionPlannerModel(runtime)).toBe("claude-opus-4-8");
 
     const overrideRuntime = {

--- a/plugins/plugin-anthropic/utils/config.ts
+++ b/plugins/plugin-anthropic/utils/config.ts
@@ -12,7 +12,7 @@ import { logger } from "@elizaos/core";
 import type { ModelName, ModelSize, ValidatedApiKey } from "../types";
 import { createModelName } from "../types";
 
-const DEFAULT_SMALL_MODEL = "claude-haiku-4-5-20251001";
+const DEFAULT_SMALL_MODEL = "claude-sonnet-5";
 const DEFAULT_LARGE_MODEL = "claude-opus-4-8";
 const DEFAULT_BASE_URL = "https://api.anthropic.com/v1";
 

--- a/plugins/plugin-openai/AGENTS.md
+++ b/plugins/plugin-openai/AGENTS.md
@@ -12,10 +12,10 @@ This plugin registers **model handlers only** (no actions, providers, services, 
 
 | `ModelType` | Default model | Handler |
 |---|---|---|
-| `TEXT_SMALL` | `gpt-5.4-mini` | `handleTextSmall` |
+| `TEXT_SMALL` | `gpt-5.6-luna` | `handleTextSmall` |
 | `TEXT_NANO` | falls back to small | `handleTextNano` |
 | `TEXT_MEDIUM` | falls back to small | `handleTextMedium` |
-| `TEXT_LARGE` | `gpt-5` | `handleTextLarge` |
+| `TEXT_LARGE` | `gpt-5.6-sol` | `handleTextLarge` |
 | `TEXT_MEGA` | falls back to large | `handleTextMega` |
 | `RESPONSE_HANDLER` | falls back to small | `handleResponseHandler` |
 | `ACTION_PLANNER` | falls back to medium | `handleActionPlanner` |
@@ -87,10 +87,10 @@ All settings are read via `getSetting(runtime, key)` (runtime config first, then
 | `CEREBRAS_API_KEY` | one-of | — | Auth when using Cerebras endpoint |
 | `EVOLINK_API_KEY` | one-of | — | Auth when using EvoLink endpoint |
 | `OPENAI_BASE_URL` | no | `https://api.openai.com/v1` | Override API endpoint |
-| `OPENAI_SMALL_MODEL` / `SMALL_MODEL` | no | `gpt-5.4-mini` | TEXT_SMALL model |
+| `OPENAI_SMALL_MODEL` / `SMALL_MODEL` | no | `gpt-5.6-luna` | TEXT_SMALL model |
 | `OPENAI_NANO_MODEL` / `NANO_MODEL` | no | falls back to small | TEXT_NANO model |
 | `OPENAI_MEDIUM_MODEL` / `MEDIUM_MODEL` | no | falls back to small | TEXT_MEDIUM model |
-| `OPENAI_LARGE_MODEL` / `LARGE_MODEL` | no | `gpt-5` | TEXT_LARGE model |
+| `OPENAI_LARGE_MODEL` / `LARGE_MODEL` | no | `gpt-5.6-sol` | TEXT_LARGE model |
 | `OPENAI_MEGA_MODEL` / `MEGA_MODEL` | no | falls back to large | TEXT_MEGA model |
 | `OPENAI_RESPONSE_HANDLER_MODEL` | no | falls back to small | RESPONSE_HANDLER model |
 | `OPENAI_ACTION_PLANNER_MODEL` | no | falls back to medium | ACTION_PLANNER model |

--- a/plugins/plugin-openai/CLAUDE.md
+++ b/plugins/plugin-openai/CLAUDE.md
@@ -12,10 +12,10 @@ This plugin registers **model handlers only** (no actions, providers, services, 
 
 | `ModelType` | Default model | Handler |
 |---|---|---|
-| `TEXT_SMALL` | `gpt-5.4-mini` | `handleTextSmall` |
+| `TEXT_SMALL` | `gpt-5.6-luna` | `handleTextSmall` |
 | `TEXT_NANO` | falls back to small | `handleTextNano` |
 | `TEXT_MEDIUM` | falls back to small | `handleTextMedium` |
-| `TEXT_LARGE` | `gpt-5` | `handleTextLarge` |
+| `TEXT_LARGE` | `gpt-5.6-sol` | `handleTextLarge` |
 | `TEXT_MEGA` | falls back to large | `handleTextMega` |
 | `RESPONSE_HANDLER` | falls back to small | `handleResponseHandler` |
 | `ACTION_PLANNER` | falls back to medium | `handleActionPlanner` |
@@ -87,10 +87,10 @@ All settings are read via `getSetting(runtime, key)` (runtime config first, then
 | `CEREBRAS_API_KEY` | one-of | — | Auth when using Cerebras endpoint |
 | `EVOLINK_API_KEY` | one-of | — | Auth when using EvoLink endpoint |
 | `OPENAI_BASE_URL` | no | `https://api.openai.com/v1` | Override API endpoint |
-| `OPENAI_SMALL_MODEL` / `SMALL_MODEL` | no | `gpt-5.4-mini` | TEXT_SMALL model |
+| `OPENAI_SMALL_MODEL` / `SMALL_MODEL` | no | `gpt-5.6-luna` | TEXT_SMALL model |
 | `OPENAI_NANO_MODEL` / `NANO_MODEL` | no | falls back to small | TEXT_NANO model |
 | `OPENAI_MEDIUM_MODEL` / `MEDIUM_MODEL` | no | falls back to small | TEXT_MEDIUM model |
-| `OPENAI_LARGE_MODEL` / `LARGE_MODEL` | no | `gpt-5` | TEXT_LARGE model |
+| `OPENAI_LARGE_MODEL` / `LARGE_MODEL` | no | `gpt-5.6-sol` | TEXT_LARGE model |
 | `OPENAI_MEGA_MODEL` / `MEGA_MODEL` | no | falls back to large | TEXT_MEGA model |
 | `OPENAI_RESPONSE_HANDLER_MODEL` | no | falls back to small | RESPONSE_HANDLER model |
 | `OPENAI_ACTION_PLANNER_MODEL` | no | falls back to medium | ACTION_PLANNER model |

--- a/plugins/plugin-openai/__tests__/cerebras-config.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/cerebras-config.shape.test.ts
@@ -244,7 +244,7 @@ describe("plugin-openai Cerebras config (pure)", () => {
     });
     expect(getBaseURL(runtime)).toBe("https://api.openai.com/v1");
     expect(getApiKey(runtime)).toBe("sk-openai-fake");
-    expect(getSmallModel(runtime)).toBe("gpt-5.4-mini");
+    expect(getSmallModel(runtime)).toBe("gpt-5.6-luna");
   });
 
   it("uses a deterministic local embedding fallback in Cerebras mode without an embedding endpoint", async () => {

--- a/plugins/plugin-openai/__tests__/native-plumbing.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/native-plumbing.shape.test.ts
@@ -536,14 +536,14 @@ describe("OpenAI native text plumbing", () => {
     });
   });
 
-  it("defaults small and response handler models to gpt-5.4-mini while preserving explicit overrides", async () => {
+  it("defaults small and response handler models to gpt-5.6-luna while preserving explicit overrides", async () => {
     const { getResponseHandlerModel, getSmallModel } = await import("../utils/config");
     const runtime = {
       getSetting: vi.fn(() => undefined),
     } as IAgentRuntime;
 
-    expect(getSmallModel(runtime)).toBe("gpt-5.4-mini");
-    expect(getResponseHandlerModel(runtime)).toBe("gpt-5.4-mini");
+    expect(getSmallModel(runtime)).toBe("gpt-5.6-luna");
+    expect(getResponseHandlerModel(runtime)).toBe("gpt-5.6-luna");
 
     const overrideRuntime = {
       getSetting: vi.fn((key: string) => {

--- a/plugins/plugin-openai/utils/config.ts
+++ b/plugins/plugin-openai/utils/config.ts
@@ -274,7 +274,7 @@ export function getSmallModel(runtime: IAgentRuntime): string {
     getCerebrasModel(runtime) ??
     getEvoLinkModel(runtime) ??
     getSetting(runtime, "SMALL_MODEL") ??
-    "gpt-5.4-mini"
+    "gpt-5.6-luna"
   );
 }
 
@@ -304,7 +304,7 @@ export function getLargeModel(runtime: IAgentRuntime): string {
     getCerebrasModel(runtime) ??
     getEvoLinkModel(runtime) ??
     getSetting(runtime, "LARGE_MODEL") ??
-    "gpt-5.5"
+    "gpt-5.6-sol"
   );
 }
 


### PR DESCRIPTION
## What

Per product direction, the chat-tier defaults move to the current model generation (follow-up to #16260, which moved the coding tiers):

- **plugin-anthropic**: small `claude-haiku-4-5-20251001` → `claude-sonnet-5` (large stays `claude-opus-4-8`). Sonnet-5 carries the low..high chat-effort knob haiku rejects, so the small tier gains effort control as a side effect.
- **plugin-openai**: small `gpt-5.4-mini` → `gpt-5.6-luna`, large `gpt-5.5` → `gpt-5.6-sol` — same generation as the codex coding defaults set in #16260.
- **provider-switch stamps** updated to match (they land in env keys that OVERRIDE plugin defaults for anyone who used the switch UI).
- Package docs (CLAUDE.md/AGENTS.md tables) synced, including the anthropic doc rows that still said `claude-opus-4-7` while the code default has been `claude-opus-4-8`.

Cerebras/EvoLink modes are untouched (their mode-specific defaults sit earlier in the fallback chains); only the plain-OpenAI and Anthropic tails change.

## Evidence rows

<!-- evidence-row:before-screenshots -->
- [x] N/A - constants + docs only; no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - same reason.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow; default resolution is covered by the shape tests below.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live deployment reads these defaults on the reference rig (it pins explicit models via config; cloud-proxy routing removes both plugins from chat duty). Default resolution is proven by the updated unit tests: https://github.com/elizaOS/eliza/blob/develop/plugins/plugin-openai/__tests__/native-plumbing.shape.test.ts
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser-surface change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt/behavior change; the default-model fallback chains are exercised by plugin-anthropic (64 passed) and plugin-openai (98 passed) suites, including the updated default assertions.
<!-- evidence-row:domain-artifacts -->
- [x] Test runs: plugin-anthropic 64 passed / plugin-openai 98 passed / provider-switch 26 passed; typecheck green on all three packages (https://github.com/elizaOS/eliza/actions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
