### PR TITLE
fix(commands): accept the reset-soonest account strategy in /accounts

### DIFF
--- a/plugins/plugin-commands/__tests__/accounts-backend-command.test.ts
+++ b/plugins/plugin-commands/__tests__/accounts-backend-command.test.ts
@@ -146,6 +146,18 @@ describe("parseAccountsArgs", () => {
 				key: "accounts",
 				canonical: "/accounts",
 				args: [],
+				rawArgs: "strategy claude reset-soonest",
+			}),
+		).toEqual({
+			kind: "strategy",
+			provider: "anthropic-subscription",
+			strategy: "reset-soonest",
+		});
+		expect(
+			parseAccountsArgs({
+				key: "accounts",
+				canonical: "/accounts",
+				args: [],
 				rawArgs: "refresh cerebras",
 			}),
 		).toEqual({ kind: "refresh", provider: "cerebras-api" });
@@ -398,25 +410,28 @@ describe("/accounts writes", () => {
 		);
 	});
 
-	it("strategy PATCHes the provider strategy route with the exact body", async () => {
+	it("reset-soonest PATCHes the provider strategy route with the exact body", async () => {
 		const fetchMock = vi.fn(async () =>
-			jsonResponse({ providerId: "cerebras-api", strategy: "least-used" }),
+			jsonResponse({
+				providerId: "anthropic-subscription",
+				strategy: "reset-soonest",
+			}),
 		);
 		vi.stubGlobal("fetch", fetchMock);
 
 		const r = await resolveCommand(
 			runtime,
-			msg("/accounts strategy cerebras least-used"),
+			msg("/accounts strategy claude reset-soonest"),
 			OWNER,
 		);
 		const [call] = recordedCalls(fetchMock);
 		expect(call?.method).toBe("PATCH");
 		expect(new URL(call?.url ?? "").pathname).toBe(
-			"/api/providers/cerebras-api/strategy",
+			"/api/providers/anthropic-subscription/strategy",
 		);
-		expect(call?.body).toEqual({ strategy: "least-used" });
+		expect(call?.body).toEqual({ strategy: "reset-soonest" });
 		expect(r.reply).toBe(
-			"Account strategy for cerebras-api set to least-used.",
+			"Account strategy for anthropic-subscription set to reset-soonest.",
 		);
 	});
 

--- a/plugins/plugin-commands/src/actions/accounts.ts
+++ b/plugins/plugin-commands/src/actions/accounts.ts
@@ -7,7 +7,7 @@
  * Token grammar (bare `/accounts` renders the per-provider report):
  *   /accounts
  *   /accounts use|enable|disable <provider> <account>
- *   /accounts strategy <provider> <priority|round-robin|least-used|quota-aware>
+ *   /accounts strategy <provider> <priority|round-robin|least-used|quota-aware|reset-soonest>
  *   /accounts refresh <provider> [account]
  *
  * `<provider>` accepts the wire ids plus the short aliases claude/codex/
@@ -25,6 +25,7 @@ export const ACCOUNT_STRATEGIES = [
 	"round-robin",
 	"least-used",
 	"quota-aware",
+	"reset-soonest",
 ] as const;
 type AccountStrategy = (typeof ACCOUNT_STRATEGIES)[number];
 


### PR DESCRIPTION
## What

#16204 added the `reset-soonest` account-selection strategy to the contracts and the PATCH route, but the `/accounts strategy` command's client-side gate (`ACCOUNT_STRATEGIES`) still rejected the token before the request could reach route validation — the settings UI could set the new strategy while the chat command 400'd locally. One-value addition + usage-doc line.

## Evidence rows

<!-- evidence-row:before-screenshots -->
- [x] N/A - text-command gate; no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - same reason.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - one-token grammar change; covered by the command suite.
<!-- evidence-row:backend-logs -->
- [x] N/A - no server change; the route already accepts the value (accounts-routes.ts:349, #16204).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser-surface change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic command path, no model involvement.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - this deterministic command grammar change creates no persistent domain artifact; the exact PATCH route and body are verified by the focused 26/26 command-path suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)