### PR TITLE
fix(orchestrator): reconcile client contract and policy tests

### DIFF
--- a/packages/ui/src/api/client-agent-coding-agent-status.test.ts
+++ b/packages/ui/src/api/client-agent-coding-agent-status.test.ts
@@ -24,6 +24,11 @@ function thread(overrides: Partial<CodingAgentTaskThread> = {}) {
     latestRepo: null,
     projectId: null,
     latestActivityAt: Date.now(),
+    latestSessionModel: null,
+    latestAccountProviderId: null,
+    latestAccountId: null,
+    latestAccountLabel: null,
+    parentTaskId: null,
     decisionCount: 0,
     usage: {
       inputTokens: 0,

--- a/packages/ui/src/api/client-types-cloud.ts
+++ b/packages/ui/src/api/client-types-cloud.ts
@@ -957,6 +957,15 @@ export interface CodingAgentTaskThread {
    * detail (#13776). */
   projectId: string | null;
   latestActivityAt: number | null;
+  /** Model + account provenance of the latest session, surfaced on the summary
+   * so widgets can show which model/account a task runs under without fetching
+   * its detail (#16203). */
+  latestSessionModel: string | null;
+  latestAccountProviderId: string | null;
+  latestAccountId: string | null;
+  latestAccountLabel: string | null;
+  /** Fork lineage: the task this one was forked from (null = root task). */
+  parentTaskId: string | null;
   decisionCount: number;
   usage: CodingAgentTaskUsageSummary;
   createdAt: string;

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-mapper-contract.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-mapper-contract.test.ts
@@ -225,6 +225,11 @@ const clientThreadReference: CodingAgentTaskThread = {
   latestRepo: "owner/repo",
   projectId: "project-1",
   latestActivityAt: 1,
+  latestSessionModel: "claude-opus-4-7",
+  latestAccountProviderId: "anthropic",
+  latestAccountId: "acct-1",
+  latestAccountLabel: "Personal Max",
+  parentTaskId: "parent-1",
   decisionCount: 1,
   usage: {
     inputTokens: 0,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-policy.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-policy.test.ts
@@ -38,28 +38,28 @@ const COLD_CORE_IMPORT_TIMEOUT_MS = 30_000;
 
 describe("requireTaskAgentAccess — policy merge", () => {
   it(
-    "keeps the built-in Discord ADMIN gate when only another connector is overridden",
+    "keeps the built-in Discord OWNER gate when only another connector is overridden",
     async () => {
       const result = await requireTaskAgentAccess(
         runtimeWith({ connectors: { slack: "ADMIN" } }),
         discordMessage,
         "create",
       );
-      // Discord still requires ADMIN despite the slack-only override.
-      expect(result.requiredRole).toBe("ADMIN");
+      // Discord still requires OWNER despite the slack-only override (#16203).
+      expect(result.requiredRole).toBe("OWNER");
     },
     COLD_CORE_IMPORT_TIMEOUT_MS,
   );
 
   it(
-    "still requires Discord ADMIN under the default policy (no override)",
+    "still requires Discord OWNER under the default policy (no override)",
     async () => {
       const result = await requireTaskAgentAccess(
         runtimeWith(undefined),
         discordMessage,
         "interact",
       );
-      expect(result.requiredRole).toBe("ADMIN");
+      expect(result.requiredRole).toBe("OWNER");
     },
     COLD_CORE_IMPORT_TIMEOUT_MS,
   );

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-policy.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-policy.test.ts
@@ -45,7 +45,6 @@ describe("requireTaskAgentAccess — policy merge", () => {
         discordMessage,
         "create",
       );
-      // Discord still requires OWNER despite the slack-only override (#16203).
       expect(result.requiredRole).toBe("OWNER");
     },
     COLD_CORE_IMPORT_TIMEOUT_MS,


### PR DESCRIPTION
## Problem

#16203 (widget state / provider eligibility) shipped with a red test.yml: it widened the orchestrator thread DTO with `latestSessionModel` / `latestAccountProviderId` / `latestAccountId` / `latestAccountLabel` / `parentTaskId` and intentionally moved the built-in Discord task-agent gate from ADMIN to OWNER, but did not update:
- the DTO ↔ client contract pins (`orchestrator-task-mapper-contract.test.ts` — thread/detail key sets),
- the client `CodingAgentTaskThread` type (the server now emits fields the client type doesn't declare — exactly the drift the contract test exists to catch),
- the two `task-policy.test.ts` policy-merge assertions still pinned to ADMIN.

Develop's orchestrator suite is red on 4 tests as a result.

## Fix

- Add the five fields to the client `CodingAgentTaskThread` (required, `string | null`, mirroring the server DTO which always emits them via `?? null`), with provenance comments.
- Extend the contract-test reference objects so the key pins match again.
- Align the two policy assertions (and their names/comments) with the intentional OWNER gate.
- Default the new fields in the one UI test helper that builds threads.

## Evidence rows

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - type/test reconciliation only; no rendered UI change (no .tsx/.css touched — only client-types-cloud.ts and test files)`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - same reason; nothing renders differently`.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no user-exercisable flow changed`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - no runtime code path changed; the change is a client type + test pins. Proof is the previously-red suites now passing (below)`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend runtime behavior changed`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model change`.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - this client-type and test-pin reconciliation creates no persistent domain artifact; the four previously failing contract/policy tests now pass.

# Evidence Details

```
bun x vitest run --root plugins/plugin-agent-orchestrator __tests__/unit/task-policy.test.ts __tests__/unit/orchestrator-task-mapper-contract.test.ts
 Test Files  2 passed (2)
      Tests  9 passed (9)

packages/ui typecheck: 0 errors
packages/ui affected suites (client-agent-coding-agent-status, task-widget):
 Test Files  2 passed (2)
      Tests  16 passed (16)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)