### PR TITLE
fix(app): make view workflows reliable

### DIFF
--- a/packages/agent/src/api/__tests__/conversation-stream-sse-contract.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-stream-sse-contract.test.ts
@@ -297,6 +297,38 @@ function createChunkPlanMessageService(
   } satisfies NonNullable<AgentRuntime["messageService"]>;
 }
 
+function createViewShortcutMessageService(): NonNullable<
+  AgentRuntime["messageService"]
+> {
+  return {
+    async handleMessage() {
+      return {
+        didRespond: true,
+        responseContent: {
+          text: "Navigated to Settings.",
+          thought: "Shortcut: app-control:nl:view-navigation",
+        },
+        responseMessages: [],
+        actionResults: [
+          {
+            success: true,
+            text: "Navigated to Settings.",
+            values: { mode: "show", viewId: "settings", viewType: "gui" },
+            data: { actionName: "VIEWS" },
+          },
+        ],
+      };
+    },
+    shouldRespond: () => ({
+      shouldRespond: true,
+      skipEvaluation: true,
+      reason: "view-shortcut-stream-contract-test",
+    }),
+    deleteMessage: async () => undefined,
+    clearChannel: async () => undefined,
+  } satisfies NonNullable<AgentRuntime["messageService"]>;
+}
+
 function createState(
   messageServiceOverride?: NonNullable<AgentRuntime["messageService"]>,
 ): {
@@ -459,6 +491,29 @@ describe("conversation stream SSE contract (#10712)", () => {
       (payload) => payload.type === "status" && payload.kind === "streaming",
     );
     expect(streamingStatusIndex).toBeLessThan(firstTokenIndex);
+  });
+
+  it("carries a direct VIEWS shortcut result on the terminal done frame", async () => {
+    const { ctx, record } = createCtx(createViewShortcutMessageService());
+
+    await handleConversationRoutes(ctx);
+
+    const done = parseSsePayloads(record.writes).find(
+      (payload) => payload.type === "done",
+    );
+    expect(done).toMatchObject({
+      type: "done",
+      fullText: "Navigated to Settings.",
+      thought: "Shortcut: app-control:nl:view-navigation",
+      actionResults: [
+        {
+          actionName: "VIEWS",
+          success: true,
+          text: "Navigated to Settings.",
+          values: { mode: "show", viewId: "settings", viewType: "gui" },
+        },
+      ],
+    });
   });
 
   it("delivers a post-SSE-init failure as a structured SSE error frame, not an HTTP error", async () => {

--- a/packages/agent/src/api/__tests__/conversation-streaming.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-streaming.test.ts
@@ -763,6 +763,54 @@ describe("generateChatResponse token streaming", () => {
     ]);
   });
 
+  it("returns direct shortcut action results without relying on planner cache", async () => {
+    const message = createChatMessage("open settings");
+    const getActionResults = vi.fn(() => [
+      {
+        success: true,
+        text: "Unrelated cached result.",
+        data: { actionName: "WORKFLOW" },
+      },
+    ]);
+    const runtime = createRuntime({
+      getActionResults: getActionResults as AgentRuntime["getActionResults"],
+      messageService: {
+        ...createStreamingMessageService(["Navigated to Settings."]),
+        async handleMessage() {
+          return {
+            didRespond: true,
+            responseContent: { text: "Navigated to Settings." },
+            responseMessages: [],
+            actionResults: [
+              {
+                success: true,
+                text: "Navigated to Settings.",
+                values: { mode: "show", viewId: "settings", viewType: "gui" },
+                data: { actionName: "VIEWS" },
+              },
+            ],
+          };
+        },
+      },
+    });
+
+    const result = await generateChatResponse(
+      runtime,
+      message,
+      "Streaming Agent",
+      { timeoutDuration: 5_000 },
+    );
+
+    expect(result.actionResults).toEqual([
+      {
+        actionName: "VIEWS",
+        success: true,
+        text: "Navigated to Settings.",
+        values: { mode: "show", viewId: "settings", viewType: "gui" },
+      },
+    ]);
+  });
+
   it("streams cleaned snapshots from the Android local direct path", async () => {
     const chunks: string[] = [];
     const snapshots: string[] = [];

--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -1517,8 +1517,13 @@ function summarizeActionResultForClient(
 function summarizeRuntimeActionResults(
   runtime: AgentRuntime,
   messageId: UUID | undefined,
+  turnActionResults?: unknown[],
 ): ChatActionResultSummary[] {
-  return readRuntimeActionResults(runtime, messageId)
+  const actionResults =
+    turnActionResults && turnActionResults.length > 0
+      ? turnActionResults
+      : readRuntimeActionResults(runtime, messageId);
+  return actionResults
     .map(summarizeActionResultForClient)
     .filter((entry): entry is ChatActionResultSummary => Boolean(entry))
     .slice(-8);
@@ -3182,6 +3187,7 @@ export async function generateChatResponse(
     const actionResultSummaries = summarizeRuntimeActionResults(
       runtime,
       typeof message.id === "string" ? message.id : undefined,
+      result?.actionResults,
     );
 
     return {

--- a/packages/agent/src/api/model-config-routes.test.ts
+++ b/packages/agent/src/api/model-config-routes.test.ts
@@ -345,8 +345,6 @@ describe("POST /api/models/config coding writes", () => {
         target: "coding",
         backend: "codex",
         model: "gpt-5.6-terra",
-        // xhigh is the ceiling the pinned codex-acp adapter can parse; ultra
-        // is rejected at the route (see the pin-gate suite below).
         effort: "xhigh",
       });
     await handleModelConfigRoutes(ctx as never);
@@ -629,8 +627,8 @@ describe("route matching", () => {
   });
 });
 
-describe("codex-acp effort pin gate (review amendment)", () => {
-  it("rejects ultra on gpt-5.6-terra (model supports it; pinned acp cannot parse it)", async () => {
+describe("managed codex-acp effort contract", () => {
+  it("rejects ultra even when the selected model advertises it", async () => {
     const { ctx, json, saveElizaConfig } = makeHarness("POST", {
       target: "coding",
       backend: "codex",
@@ -640,7 +638,8 @@ describe("codex-acp effort pin gate (review amendment)", () => {
     await expect(handleModelConfigRoutes(ctx as never)).resolves.toBe(true);
     const { body, status } = responseOf(json);
     expect(status).toBe(400);
-    expect(String(body.error)).toContain("codex-acp");
+    expect(String(body.error)).toContain("managed codex-acp contract");
+    expect(String(body.error)).toContain("low, medium, high, xhigh");
     expect(saveElizaConfig).not.toHaveBeenCalled();
   });
 });

--- a/packages/agent/src/api/model-config-routes.ts
+++ b/packages/agent/src/api/model-config-routes.ts
@@ -166,9 +166,11 @@ function findEntry(
   return catalog.providers[provider]?.find((entry) => entry.id === model);
 }
 
-// Mirrors PINNED_CODEX_ACP_EFFORTS in app-core's coding-account-bridge.ts:
-// the effort values the pinned codex-acp adapter's config parser accepts.
-const CODEX_ACP_EFFORTS: ReadonlySet<string> = new Set([
+// Keep this aligned with MANAGED_CODEX_ACP_EFFORTS in app-core's
+// coding-account-bridge.ts. The model catalog may advertise newer effort
+// variants before the managed Codex ACP spawn path supports them end to end;
+// accepting one here would persist a selection the coding backend cannot honor.
+const MANAGED_CODEX_ACP_EFFORTS: ReadonlySet<string> = new Set([
   "low",
   "medium",
   "high",
@@ -406,21 +408,14 @@ function resolveCodingWrites(
     }
     if (body.effort !== undefined) {
       validateEffort(entry, body.effort);
-      // The catalog carries the MODEL's truth (sol/terra do support ultra),
-      // but the pinned @zed-industries/codex-acp@0.14.0 adapter cannot parse
-      // `max`/`ultra` in config.toml — the whole file would fail to parse and
-      // drop the model pin ChatGPT-account auth requires. The bridge
-      // (coding-account-bridge.ts, PINNED_CODEX_ACP_EFFORTS) would skip the
-      // write, so accepting the value here would be a silent no-op. Reject it
-      // loudly instead; widen BOTH sets together when the acp pin is bumped.
-      if (backend === "codex" && !CODEX_ACP_EFFORTS.has(body.effort)) {
+      if (backend === "codex" && !MANAGED_CODEX_ACP_EFFORTS.has(body.effort)) {
         throw invalid(
-          `Effort "${body.effort}" is valid for ${entry.id} but not parseable by the pinned codex-acp adapter (supported until the pin is bumped: ${[...CODEX_ACP_EFFORTS].join(", ")})`,
+          `Effort "${body.effort}" is valid for ${entry.id} but not supported by the managed codex-acp contract (supported: ${[...MANAGED_CODEX_ACP_EFFORTS].join(", ")})`,
           {
             model: entry.id,
             effort: body.effort,
-            supported: [...CODEX_ACP_EFFORTS],
-            reason: "codex-acp-pin",
+            supported: [...MANAGED_CODEX_ACP_EFFORTS],
+            reason: "codex-acp-contract",
           },
         );
       }

--- a/packages/agent/src/api/model-config-slash-command.test.ts
+++ b/packages/agent/src/api/model-config-slash-command.test.ts
@@ -158,7 +158,7 @@ describe("/model slash handler ↔ real /api/models/config route", () => {
     expect(h.managerStart).not.toHaveBeenCalled();
   });
 
-  it("surfaces the route's real codex-acp effort-pin 400 verbatim", async () => {
+  it("surfaces the managed codex-acp effort-contract 400 verbatim", async () => {
     const h = await startHarness();
 
     const r = await resolveCommand(
@@ -167,7 +167,7 @@ describe("/model slash handler ↔ real /api/models/config route", () => {
       OWNER,
     );
 
-    expect(r.reply).toContain("pinned codex-acp adapter");
+    expect(r.reply).toContain("managed codex-acp contract");
     expect(r.reply).toContain("low, medium, high, xhigh");
     expect(h.saveElizaConfig).not.toHaveBeenCalled();
   });

--- a/packages/agent/src/api/views-registry.package-resolution.test.ts
+++ b/packages/agent/src/api/views-registry.package-resolution.test.ts
@@ -12,6 +12,7 @@
 import type { Plugin } from "@elizaos/core";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  bindPluginPackageDirectory,
   listViews,
   pluginPackageNameCandidates,
   registerPluginViews,
@@ -100,5 +101,35 @@ describe("registerPluginViews packageName override", () => {
     expect(entry).toBeDefined();
     const pluginDir = (entry?.pluginDir ?? "").split("\\").join("/");
     expect(pluginDir).toContain("plugins/plugin-elizacloud");
+  });
+});
+
+describe("registerPluginViews directory binding", () => {
+  const PLUGIN_NAME = "generated-view-resolution-fixture";
+
+  afterEach(() => {
+    unregisterPluginViews(PLUGIN_NAME);
+  });
+
+  it("uses the directory bound to an imported plugin object", async () => {
+    const plugin: Plugin = {
+      name: PLUGIN_NAME,
+      description: "directory-loaded plugin fixture",
+      views: [
+        {
+          id: "generated-view-resolution-fixture",
+          label: "Generated fixture",
+          bundlePath: "dist/views/bundle.js",
+        },
+      ],
+    } as Plugin;
+    bindPluginPackageDirectory(plugin, "/tmp/generated-plugin-fixture");
+
+    await registerPluginViews(plugin);
+
+    const entry = listViews({ includeAllKinds: true }).find(
+      (view) => view.id === "generated-view-resolution-fixture",
+    );
+    expect(entry?.pluginDir).toBe("/tmp/generated-plugin-fixture");
   });
 });

--- a/packages/agent/src/api/views-registry.ts
+++ b/packages/agent/src/api/views-registry.ts
@@ -57,6 +57,20 @@ function viewRegistryKey(id: string, viewType: ViewType): string {
 /** Module-level registry storage. Keyed by view type + view id. */
 const registry = new Map<string, ViewRegistryEntry>();
 
+// Directory-loaded plugins are real module objects but are not installed npm
+// packages, so name-based resolution cannot recover their bundle root. Binding
+// the imported object keeps the directory attached through every lifecycle
+// wrapper without widening the shared Plugin or runtime method contracts.
+const boundPluginPackageDirectories = new WeakMap<Plugin, string>();
+
+/** Bind an imported plugin object to the package root that supplied it. */
+export function bindPluginPackageDirectory(
+  plugin: Plugin,
+  pluginDir: string,
+): void {
+  boundPluginPackageDirectories.set(plugin, path.resolve(pluginDir));
+}
+
 /** View ids already warned about for oversized bundles — warn once per process. */
 const warnedLargeBundles = new Set<string>();
 
@@ -295,6 +309,7 @@ export async function registerPluginViews(
   // the real package instead of failing on name-derived candidates.
   const resolvedDir =
     pluginDir ??
+    boundPluginPackageDirectories.get(plugin) ??
     (await resolvePluginPackageDir(plugin.packageName ?? plugin.name));
 
   const registered: ViewRegistryEntry[] = [];

--- a/packages/agent/src/runtime/load-plugin-from-directory.test.ts
+++ b/packages/agent/src/runtime/load-plugin-from-directory.test.ts
@@ -11,6 +11,11 @@ import path from "node:path";
 import { AgentRuntime } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  getBundleDiskPath,
+  getView,
+  unregisterPluginViews,
+} from "../api/views-registry.ts";
+import {
   _resetLoadedDirectoryPluginsForTests,
   getLoadedDirectoryPlugins,
   loadPluginFromDirectory,
@@ -26,6 +31,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   _resetLoadedDirectoryPluginsForTests();
+  unregisterPluginViews("view-dir-plugin");
   await fsp.rm(tmpDir, { recursive: true, force: true });
 });
 
@@ -63,6 +69,61 @@ async function scaffold(
     await fsp.writeFile(full, content);
   }
   return root;
+}
+
+function reloadableViewPluginSource(
+  version: string,
+  options: { bundlePath?: string; failInit?: boolean } = {},
+): string {
+  const bundlePath = options.bundlePath ?? "dist/views/bundle.js";
+  return `export default {
+  name: "view-dir-plugin",
+  description: "contributes an editable view",
+  ${options.failInit ? 'init: async () => { throw new Error("replacement init failed"); },' : ""}
+  actions: [{
+    name: "EDITABLE_VIEW_VERSION",
+    description: "reports the loaded edit version",
+    examples: [],
+    similes: [],
+    validate: async () => true,
+    handler: async () => ({ version: "${version}" }),
+  }],
+  views: [{
+    id: "dir-loaded-view",
+    label: "Dir Loaded ${version}",
+    path: "/dir-loaded",
+    bundlePath: "${bundlePath}",
+    componentExport: "DirLoadedView",
+  }],
+};\n`;
+}
+
+async function expectIncumbentViewPlugin(
+  runtime: AgentRuntime,
+  incumbentDirectory: string,
+): Promise<void> {
+  const realIncumbentDirectory = await fsp.realpath(incumbentDirectory);
+  expect(getView("dir-loaded-view")).toMatchObject({
+    label: "Dir Loaded v1",
+    pluginDir: realIncumbentDirectory,
+    available: true,
+  });
+  expect(
+    runtime.plugins.filter((plugin) => plugin.name === "view-dir-plugin"),
+  ).toHaveLength(1);
+  const actions = runtime.actions.filter(
+    (action) => action.name === "EDITABLE_VIEW_VERSION",
+  );
+  expect(actions).toHaveLength(1);
+  await expect(
+    actions[0]?.handler?.(runtime as never, {} as never, {} as never),
+  ).resolves.toEqual({ version: "v1" });
+  expect(getLoadedDirectoryPlugins()).toEqual([
+    expect.objectContaining({
+      pluginName: "view-dir-plugin",
+      directory: realIncumbentDirectory,
+    }),
+  ]);
 }
 
 describe("loadPluginFromDirectory", () => {
@@ -143,17 +204,269 @@ describe("loadPluginFromDirectory", () => {
   ],
 };
 `,
+        "dist/views/bundle.js":
+          "export function DirLoadedView(){ return 'directory build'; }\n",
       },
     );
 
     const runtime = new AgentRuntime({ logLevel: "fatal" });
     const loaded = await loadPluginFromDirectory({ runtime, directory: dir });
     expect(loaded.pluginName).toBe("view-dir-plugin");
+    const realDir = await fsp.realpath(dir);
 
-    // registerPlugin must not throw on a views-bearing plugin; the lifecycle
-    // wrapper registers the views. (View bundle resolution is exercised by the
-    // views-registry tests; here we only assert registration succeeds.)
+    const view = getView("dir-loaded-view");
+    expect(view).toMatchObject({
+      pluginName: "view-dir-plugin",
+      pluginDir: realDir,
+      available: true,
+    });
+    expect(getBundleDiskPath(view as NonNullable<typeof view>)).toBe(
+      path.join(realDir, "dist/views/bundle.js"),
+    );
+
     await unloadPluginFromDirectory({ runtime, pluginName: "view-dir-plugin" });
+    expect(getView("dir-loaded-view")).toBeUndefined();
+  });
+
+  it("reloads an edited directory plugin against the rebuilt view bundle", async () => {
+    const pluginSource = (version: string) => `export default {
+  name: "view-dir-plugin",
+  description: "contributes an editable view",
+  actions: [{
+    name: "EDITABLE_VIEW_VERSION",
+    description: "reports the loaded edit version",
+    examples: [],
+    similes: [],
+    validate: async () => true,
+    handler: async () => ({ version: "${version}" }),
+  }],
+  views: [{
+    id: "dir-loaded-view",
+    label: "Dir Loaded ${version}",
+    path: "/dir-loaded",
+    bundlePath: "dist/views/bundle.js",
+    componentExport: "DirLoadedView",
+  }],
+};\n`;
+    const dir = await scaffold(
+      "plugin-with-edited-view",
+      { name: "@local/plugin-with-edited-view", main: "dist/index.js" },
+      {
+        "dist/index.js": pluginSource("v1"),
+        "dist/views/bundle.js":
+          "export function DirLoadedView(){ return 'v1'; }\n",
+      },
+    );
+    const runtime = new AgentRuntime({ logLevel: "fatal" });
+    const realDir = await fsp.realpath(dir);
+
+    await loadPluginFromDirectory({ runtime, directory: dir });
+    const initial = getView("dir-loaded-view");
+    expect(initial?.label).toBe("Dir Loaded v1");
+    expect(initial?.available).toBe(true);
+    const initialAction = runtime.actions.find(
+      (action) => action.name === "EDITABLE_VIEW_VERSION",
+    );
+    await expect(
+      initialAction?.handler?.(runtime as never, {} as never, {} as never),
+    ).resolves.toEqual({ version: "v1" });
+
+    await fsp.writeFile(path.join(dir, "dist/index.js"), pluginSource("v2"));
+    await fsp.writeFile(
+      path.join(dir, "dist/views/bundle.js"),
+      "export function DirLoadedView(){ return 'v2'; }\n",
+    );
+    await loadPluginFromDirectory({ runtime, directory: dir });
+    const edited = getView("dir-loaded-view");
+    expect(edited).toMatchObject({
+      label: "Dir Loaded v2",
+      pluginDir: realDir,
+      available: true,
+    });
+    expect(edited?.bundleHash).not.toBe(initial?.bundleHash);
+    expect(getLoadedDirectoryPlugins()).toHaveLength(1);
+    expect(
+      runtime.plugins.filter((plugin) => plugin.name === "view-dir-plugin"),
+    ).toHaveLength(1);
+    const editedActions = runtime.actions.filter(
+      (action) => action.name === "EDITABLE_VIEW_VERSION",
+    );
+    expect(editedActions).toHaveLength(1);
+    await expect(
+      editedActions[0]?.handler?.(runtime as never, {} as never, {} as never),
+    ).resolves.toEqual({ version: "v2" });
+
+    await unloadPluginFromDirectory({ runtime, pluginName: "view-dir-plugin" });
+  });
+
+  it("preserves the working incumbent when a replacement view bundle is missing", async () => {
+    const incumbentDir = await scaffold(
+      "plugin-view-incumbent-missing-replacement",
+      { name: "@local/plugin-view-incumbent", main: "dist/index.js" },
+      {
+        "dist/index.js": reloadableViewPluginSource("v1"),
+        "dist/views/bundle.js":
+          "export function DirLoadedView(){ return 'v1'; }\n",
+      },
+    );
+    const replacementDir = await scaffold(
+      "plugin-view-replacement-missing-bundle",
+      { name: "@local/plugin-view-replacement", main: "dist/index.js" },
+      { "dist/index.js": reloadableViewPluginSource("v2") },
+    );
+    const runtime = new AgentRuntime({ logLevel: "fatal" });
+
+    await loadPluginFromDirectory({ runtime, directory: incumbentDir });
+    const incumbent = runtime.plugins.find(
+      (plugin) => plugin.name === "view-dir-plugin",
+    );
+
+    await expect(
+      loadPluginFromDirectory({ runtime, directory: replacementDir }),
+    ).rejects.toMatchObject({ code: "PLUGIN_DIRECTORY_VIEW_ASSET_MISSING" });
+    expect(
+      runtime.plugins.find((plugin) => plugin.name === "view-dir-plugin"),
+    ).toBe(incumbent);
+    await expectIncumbentViewPlugin(runtime, incumbentDir);
+  });
+
+  it("preserves the working incumbent when a replacement bundle path escapes its package", async () => {
+    const incumbentDir = await scaffold(
+      "plugin-view-incumbent-escaping-replacement",
+      { name: "@local/plugin-view-incumbent", main: "dist/index.js" },
+      {
+        "dist/index.js": reloadableViewPluginSource("v1"),
+        "dist/views/bundle.js":
+          "export function DirLoadedView(){ return 'v1'; }\n",
+      },
+    );
+    const replacementDir = await scaffold(
+      "plugin-view-replacement-escaping-bundle",
+      { name: "@local/plugin-view-replacement", main: "dist/index.js" },
+      {
+        "dist/index.js": reloadableViewPluginSource("v2", {
+          bundlePath: "../outside-view.js",
+        }),
+      },
+    );
+    await fsp.writeFile(
+      path.join(tmpDir, "outside-view.js"),
+      "export function DirLoadedView(){ return 'outside'; }\n",
+    );
+    const runtime = new AgentRuntime({ logLevel: "fatal" });
+
+    await loadPluginFromDirectory({ runtime, directory: incumbentDir });
+    const incumbent = runtime.plugins.find(
+      (plugin) => plugin.name === "view-dir-plugin",
+    );
+
+    await expect(
+      loadPluginFromDirectory({ runtime, directory: replacementDir }),
+    ).rejects.toMatchObject({ code: "PLUGIN_DIRECTORY_VIEW_ASSET_MISSING" });
+    expect(
+      runtime.plugins.find((plugin) => plugin.name === "view-dir-plugin"),
+    ).toBe(incumbent);
+    await expectIncumbentViewPlugin(runtime, incumbentDir);
+  });
+
+  it("preserves the working incumbent when the replacement module is malformed", async () => {
+    const incumbentDir = await scaffold(
+      "plugin-view-incumbent-malformed-module",
+      { name: "@local/plugin-view-incumbent", main: "dist/index.js" },
+      {
+        "dist/index.js": reloadableViewPluginSource("v1"),
+        "dist/views/bundle.js":
+          "export function DirLoadedView(){ return 'v1'; }\n",
+      },
+    );
+    const replacementDir = await scaffold(
+      "plugin-view-replacement-malformed-module",
+      { name: "@local/plugin-view-replacement", main: "dist/index.js" },
+      { "dist/index.js": "export default { name: ;" },
+    );
+    const runtime = new AgentRuntime({ logLevel: "fatal" });
+
+    await loadPluginFromDirectory({ runtime, directory: incumbentDir });
+    const incumbent = runtime.plugins.find(
+      (plugin) => plugin.name === "view-dir-plugin",
+    );
+
+    await expect(
+      loadPluginFromDirectory({ runtime, directory: replacementDir }),
+    ).rejects.toThrow();
+    expect(
+      runtime.plugins.find((plugin) => plugin.name === "view-dir-plugin"),
+    ).toBe(incumbent);
+    await expectIncumbentViewPlugin(runtime, incumbentDir);
+  });
+
+  it("restores the working incumbent when replacement lifecycle registration fails", async () => {
+    const incumbentDir = await scaffold(
+      "plugin-view-incumbent-failed-lifecycle",
+      { name: "@local/plugin-view-incumbent", main: "dist/index.js" },
+      {
+        "dist/index.js": reloadableViewPluginSource("v1"),
+        "dist/views/bundle.js":
+          "export function DirLoadedView(){ return 'v1'; }\n",
+      },
+    );
+    const replacementDir = await scaffold(
+      "plugin-view-replacement-failed-lifecycle",
+      { name: "@local/plugin-view-replacement", main: "dist/index.js" },
+      {
+        "dist/index.js": reloadableViewPluginSource("v2", {
+          failInit: true,
+        }),
+        "dist/views/bundle.js":
+          "export function DirLoadedView(){ return 'v2'; }\n",
+      },
+    );
+    const runtime = new AgentRuntime({ logLevel: "fatal" });
+
+    await loadPluginFromDirectory({ runtime, directory: incumbentDir });
+    const incumbent = runtime.plugins.find(
+      (plugin) => plugin.name === "view-dir-plugin",
+    );
+
+    await expect(
+      loadPluginFromDirectory({ runtime, directory: replacementDir }),
+    ).rejects.toMatchObject({
+      code: "PLUGIN_DIRECTORY_RELOAD_FAILED",
+      cause: expect.objectContaining({ message: "replacement init failed" }),
+    });
+    expect(
+      runtime.plugins.find((plugin) => plugin.name === "view-dir-plugin"),
+    ).toBe(incumbent);
+    await expectIncumbentViewPlugin(runtime, incumbentDir);
+  });
+
+  it("rejects a declared view whose build did not produce its bundle", async () => {
+    const dir = await scaffold(
+      "plugin-with-missing-view-build",
+      { name: "@local/plugin-with-missing-view-build", main: "dist/index.js" },
+      {
+        "dist/index.js": `export default {
+  name: "view-dir-plugin",
+  description: "declares an unbuilt view",
+  views: [{
+    id: "dir-loaded-view",
+    label: "Dir Loaded",
+    path: "/dir-loaded",
+    bundlePath: "dist/views/bundle.js",
+  }],
+};\n`,
+      },
+    );
+    const runtime = new AgentRuntime({ logLevel: "fatal" });
+
+    await expect(
+      loadPluginFromDirectory({ runtime, directory: dir }),
+    ).rejects.toMatchObject({ code: "PLUGIN_DIRECTORY_VIEW_ASSET_MISSING" });
+    expect(
+      runtime.plugins.some((plugin) => plugin.name === "view-dir-plugin"),
+    ).toBe(false);
+    expect(getView("dir-loaded-view")).toBeUndefined();
+    expect(getLoadedDirectoryPlugins()).toHaveLength(0);
   });
 
   it("throws a clear error when the directory has no built entry", async () => {

--- a/packages/agent/src/runtime/load-plugin-from-directory.ts
+++ b/packages/agent/src/runtime/load-plugin-from-directory.ts
@@ -9,10 +9,18 @@
  * `extractPlugin` module→Plugin resolver it reuses.
  */
 import { readFile, realpath } from "node:fs/promises";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import type { AgentRuntime, Plugin } from "@elizaos/core";
+import {
+  type AgentRuntime,
+  ElizaError,
+  getViewModalities,
+  type Plugin,
+} from "@elizaos/core";
+import { bindPluginPackageDirectory, getView } from "../api/views-registry.ts";
 import { extractPlugin } from "./load-plugin-from-vfs.ts";
+import { installRuntimePluginLifecycle } from "./plugin-lifecycle.ts";
 
 /**
  * Live-load a plugin from an on-disk directory into the running runtime.
@@ -49,6 +57,183 @@ export interface LoadedDirectoryPlugin {
 }
 
 const loadedPlugins = new Map<string, LoadedDirectoryPlugin>();
+let moduleImportNonce = 0;
+const requireFromAgent = createRequire(import.meta.url);
+
+function isContainedPath(directory: string, candidate: string): boolean {
+  const relative = path.relative(directory, candidate);
+  return (
+    relative !== "" &&
+    relative !== ".." &&
+    !relative.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relative)
+  );
+}
+
+function isUnavailableAssetError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const code = Reflect.get(error, "code");
+  return (
+    typeof code === "string" && ["ENOENT", "ENOTDIR", "EISDIR"].includes(code)
+  );
+}
+
+async function importFreshPluginModule(
+  diskPath: string,
+  directory: string,
+): Promise<Record<string, unknown>> {
+  if (process.versions.bun) {
+    // Bun currently keys ESM compilation by disk path even when import() gets a
+    // unique query string. Its interoperable require cache is invalidatable, so
+    // clear the package graph and reload through that API on Bun-based hosts.
+    for (const cachedPath of Object.keys(requireFromAgent.cache)) {
+      if (isContainedPath(directory, cachedPath)) {
+        delete requireFromAgent.cache[cachedPath];
+      }
+    }
+    return requireFromAgent(diskPath) as Record<string, unknown>;
+  }
+
+  const moduleUrl = `${pathToFileURL(diskPath).href}?t=${Date.now()}-${moduleImportNonce++}`;
+  return (await import(moduleUrl)) as Record<string, unknown>;
+}
+
+async function isUsableLocalViewAsset(
+  directory: string,
+  declaredPath: unknown,
+): Promise<boolean> {
+  if (typeof declaredPath !== "string" || declaredPath.trim().length === 0) {
+    return false;
+  }
+
+  const candidate = path.resolve(directory, declaredPath);
+  if (!isContainedPath(directory, candidate)) return false;
+
+  let realAsset: string;
+  try {
+    realAsset = await realpath(candidate);
+  } catch (error) {
+    // error-policy:J3 a missing or non-file replacement asset is an explicit
+    // invalid candidate; other I/O failures remain observable.
+    if (isUnavailableAssetError(error)) return false;
+    throw new ElizaError(
+      "loadPluginFromDirectory: failed to inspect a declared view asset",
+      {
+        code: "PLUGIN_DIRECTORY_VIEW_ASSET_INSPECTION_FAILED",
+        cause: error,
+        context: { directory, declaredPath },
+      },
+    );
+  }
+  if (!isContainedPath(directory, realAsset)) return false;
+
+  try {
+    return (await readFile(realAsset)).byteLength > 0;
+  } catch (error) {
+    // error-policy:J3 directories and paths that disappear during preflight are
+    // invalid candidates, while permission/device failures are surfaced.
+    if (isUnavailableAssetError(error)) return false;
+    throw new ElizaError(
+      "loadPluginFromDirectory: failed to read a declared view asset",
+      {
+        code: "PLUGIN_DIRECTORY_VIEW_ASSET_INSPECTION_FAILED",
+        cause: error,
+        context: { directory, declaredPath },
+      },
+    );
+  }
+}
+
+async function findUnavailableDeclaredViews(
+  plugin: Plugin,
+  directory: string,
+): Promise<string[]> {
+  const unavailableViews: string[] = [];
+  if (!plugin.views) return unavailableViews;
+  for (const view of plugin.views) {
+    const requiresFrameDocument =
+      view.surface?.isolation === "sandboxed-iframe";
+    const hasRemoteAsset = requiresFrameDocument
+      ? typeof view.frameUrl === "string" && view.frameUrl.trim().length > 0
+      : [view.bundleUrl, view.frameUrl].some(
+          (assetUrl) =>
+            typeof assetUrl === "string" && assetUrl.trim().length > 0,
+        );
+    const localAssetPaths = requiresFrameDocument
+      ? [view.framePath]
+      : [view.bundlePath, view.framePath];
+
+    let hasLocalAsset = false;
+    for (const assetPath of localAssetPaths) {
+      if (await isUsableLocalViewAsset(directory, assetPath)) {
+        hasLocalAsset = true;
+        break;
+      }
+    }
+    if (hasRemoteAsset || hasLocalAsset) continue;
+
+    unavailableViews.push(
+      ...getViewModalities(view).map((viewType) => `${viewType}:${view.id}`),
+    );
+  }
+  return unavailableViews;
+}
+
+function viewAssetError(
+  directory: string,
+  pluginName: string,
+  unavailableViews: string[],
+): ElizaError {
+  return new ElizaError(
+    `loadPluginFromDirectory: declared views are missing built assets (${unavailableViews.join(", ")})`,
+    {
+      code: "PLUGIN_DIRECTORY_VIEW_ASSET_MISSING",
+      context: { directory, pluginName, unavailableViews },
+    },
+  );
+}
+
+async function restoreIncumbentAfterFailedReload(
+  runtime: AgentRuntime,
+  incumbent: Plugin,
+  directory: string,
+  reloadError: unknown,
+): Promise<never> {
+  try {
+    await runtime.unloadPlugin(incumbent.name);
+    await runtime.registerPlugin(incumbent);
+  } catch (rollbackError) {
+    // error-policy:J2 retain both failure stages when lifecycle restoration
+    // itself fails, because the runtime can no longer promise either version.
+    throw new ElizaError(
+      `loadPluginFromDirectory: reload failed and incumbent plugin "${incumbent.name}" could not be restored`,
+      {
+        code: "PLUGIN_DIRECTORY_RELOAD_ROLLBACK_FAILED",
+        cause: rollbackError,
+        severity: "fatal",
+        context: {
+          directory,
+          pluginName: incumbent.name,
+          reloadError:
+            reloadError instanceof Error
+              ? reloadError.message
+              : String(reloadError),
+        },
+      },
+    );
+  }
+
+  // error-policy:J2 the replacement failure remains the cause after the
+  // supported lifecycle API has restored the last known-good plugin.
+  throw new ElizaError(
+    `loadPluginFromDirectory: reload failed; restored incumbent plugin "${incumbent.name}"`,
+    {
+      code: "PLUGIN_DIRECTORY_RELOAD_FAILED",
+      cause: reloadError,
+      context: { directory, pluginName: incumbent.name },
+    },
+  );
+}
 
 function asRelativeEntry(value: unknown): string | null {
   if (typeof value !== "string" || value.length === 0) return null;
@@ -154,6 +339,7 @@ export async function loadPluginFromDirectory(
   options: LoadPluginFromDirectoryOptions,
 ): Promise<{ pluginName: string; loaded: true }> {
   const { runtime, directory } = options;
+  installRuntimePluginLifecycle(runtime);
   if (typeof runtime.registerPlugin !== "function") {
     throw new Error(
       "loadPluginFromDirectory: runtime.registerPlugin is not available — ensure installRuntimePluginLifecycle has run",
@@ -161,9 +347,8 @@ export async function loadPluginFromDirectory(
   }
 
   const diskPath = await resolveEntryFile(directory, options.entry);
-  // `?t=` cache-busts Node's ESM loader so a rebuild reloads the module.
-  const moduleUrl = `${pathToFileURL(diskPath).href}?t=${Date.now()}`;
-  const mod = (await import(moduleUrl)) as Record<string, unknown>;
+  const realDirectory = await realpath(directory);
+  const mod = await importFreshPluginModule(diskPath, realDirectory);
 
   const plugin: Plugin | null = extractPlugin(mod);
   if (!plugin) {
@@ -172,11 +357,62 @@ export async function loadPluginFromDirectory(
     );
   }
 
-  await runtime.registerPlugin(plugin);
+  bindPluginPackageDirectory(plugin, realDirectory);
+  const unavailableDeclaredViews = await findUnavailableDeclaredViews(
+    plugin,
+    realDirectory,
+  );
+  if (unavailableDeclaredViews.length > 0) {
+    throw viewAssetError(realDirectory, plugin.name, unavailableDeclaredViews);
+  }
+
+  const incumbent = runtime.plugins.find(
+    (registered) => registered.name === plugin.name,
+  );
+  const findUnavailableRegisteredViews = (): string[] => {
+    if (!plugin.views) return [];
+    return plugin.views.flatMap((view) =>
+      getViewModalities(view).flatMap((viewType) => {
+        const entry = getView(view.id, { viewType });
+        return entry?.pluginName === plugin.name && entry.available
+          ? []
+          : [`${viewType}:${view.id}`];
+      }),
+    );
+  };
+
+  if (incumbent) {
+    try {
+      await runtime.reloadPlugin(plugin);
+      // The preflight protects the normal path. Re-check the registered entries
+      // to catch an asset that disappears between disk validation and lifecycle
+      // registration without committing a broken replacement.
+      const unavailableViews = findUnavailableRegisteredViews();
+      if (unavailableViews.length > 0) {
+        throw viewAssetError(realDirectory, plugin.name, unavailableViews);
+      }
+    } catch (error) {
+      // error-policy:J2 restore the last known-good lifecycle ownership, then
+      // rethrow with the replacement failure preserved as the cause.
+      return restoreIncumbentAfterFailedReload(
+        runtime,
+        incumbent,
+        realDirectory,
+        error,
+      );
+    }
+  } else {
+    await runtime.registerPlugin(plugin);
+    const unavailableViews = findUnavailableRegisteredViews();
+    if (unavailableViews.length > 0) {
+      await runtime.unloadPlugin(plugin.name);
+      throw viewAssetError(realDirectory, plugin.name, unavailableViews);
+    }
+  }
 
   loadedPlugins.set(plugin.name, {
     pluginName: plugin.name,
-    directory: await realpath(directory),
+    directory: realDirectory,
     diskPath,
     loadedAt: Date.now(),
   });

--- a/packages/app-core/scripts/playwright-ui-live-stack.ts
+++ b/packages/app-core/scripts/playwright-ui-live-stack.ts
@@ -765,54 +765,6 @@ async function waitForJsonPredicate<T>(
     : new Error(`Timed out waiting for ${url}`);
 }
 
-function createProcessLogSignal(matchText: string): {
-  observe: (chunk: Buffer | string) => void;
-  wait: (timeoutMs: number, label: string) => Promise<void>;
-} {
-  let matched = false;
-  let tail = "";
-  const waiters = new Set<() => void>();
-
-  return {
-    observe(chunk) {
-      if (matched) {
-        return;
-      }
-      const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
-      tail = `${tail}${text}`.slice(-Math.max(matchText.length * 2, 4096));
-      if (!tail.includes(matchText)) {
-        return;
-      }
-      matched = true;
-      tail = "";
-      for (const resolve of waiters) {
-        resolve();
-      }
-      waiters.clear();
-    },
-    async wait(timeoutMs, label) {
-      if (matched) {
-        return;
-      }
-      await new Promise<void>((resolve, reject) => {
-        const timeout = setTimeout(() => {
-          cleanup();
-          reject(new Error(`Timed out waiting for ${label}`));
-        }, timeoutMs);
-        const finish = () => {
-          cleanup();
-          resolve();
-        };
-        const cleanup = () => {
-          clearTimeout(timeout);
-          waiters.delete(finish);
-        };
-        waiters.add(finish);
-      });
-    },
-  };
-}
-
 async function ensureUiDistReady(): Promise<void> {
   const distIndex = path.join(APP_DIST_DIR, "index.html");
   let needsBuild = false;
@@ -1111,9 +1063,6 @@ async function startRealStack(): Promise<StartedStack> {
     await seedLiveStackConfig(stateDir);
     const uiDistDir = await snapshotUiDist(stateDir);
     const apiBase = `http://127.0.0.1:${API_PORT}`;
-    const deferredBootComplete = createProcessLogSignal(
-      "[eliza-boot] deferred:complete",
-    );
     apiChild = spawn(
       "node",
       [
@@ -1136,11 +1085,9 @@ async function startRealStack(): Promise<StartedStack> {
     );
 
     apiChild.stdout.on("data", (chunk) => {
-      deferredBootComplete.observe(chunk);
       process.stdout.write(`[ui-smoke][api] ${chunk}`);
     });
     apiChild.stderr.on("data", (chunk) => {
-      deferredBootComplete.observe(chunk);
       process.stdout.write(`[ui-smoke][api-err] ${chunk}`);
     });
 
@@ -1176,11 +1123,14 @@ async function startRealStack(): Promise<StartedStack> {
     );
     if (!skipAutoFirstRun) {
       // App-control and plugin views are deferred capabilities. Treat the live
-      // harness as ready only after those runtime plugins have had a chance to
-      // register; otherwise chat-driven view switching can race boot.
-      await deferredBootComplete.wait(
+      // harness as ready only after the runtime's structured boot state settles;
+      // logger filtering may legitimately suppress the human-readable marker.
+      await waitForJsonPredicate<{
+        deferredBoot?: { settled?: boolean };
+      }>(
+        `${apiBase}/api/health`,
+        (health) => health.deferredBoot?.settled === true,
         READY_TIMEOUT_MS,
-        "deferred runtime plugin registration",
       );
     }
 

--- a/packages/app-core/scripts/playwright-ui-smoke-api-stub.mjs
+++ b/packages/app-core/scripts/playwright-ui-smoke-api-stub.mjs
@@ -117,8 +117,7 @@ function smokeViewObject({
     capabilities: [
       {
         id: "get-state",
-        label: "Get state",
-        inputSchema: { type: "object" },
+        description: "Read the mounted view state.",
       },
     ],
     _smokePluginDirName: pluginDirName,

--- a/packages/app-core/scripts/smoke-view-bundle-provenance.test.ts
+++ b/packages/app-core/scripts/smoke-view-bundle-provenance.test.ts
@@ -1,9 +1,9 @@
 /**
  * End-to-end contract for the UI-smoke stub's view-bundle route: boots the real
  * stub server (no mocks) and asserts the provenance the stub actually emits over
- * HTTP. Proves that audit mode fails observably instead of fabricating a bundle
- * for a production-declared view, and that synthesized placeholders are marked
- * as such on the wire (issue #15791).
+ * HTTP. Proves that audit mode fails observably instead of fabricating a bundle,
+ * synthesized placeholders are marked on the wire, and registry fixtures match
+ * the production view-capability transport contract (issue #15791).
  */
 import { type ChildProcess, spawn } from "node:child_process";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
@@ -102,7 +102,41 @@ async function bundleRootWithWallet(): Promise<string> {
   return root;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 describe("smoke view bundle provenance over HTTP (#15791)", () => {
+  it("advertises canonical view capability objects", async () => {
+    const bundleRoot = await emptyBundleRoot();
+    const { child, port } = await bootStub({
+      ELIZA_UI_SMOKE_VIEW_BUNDLE_ROOT: bundleRoot,
+    });
+    running = child;
+
+    const response = await fetch(`http://127.0.0.1:${port}/api/views`);
+    expect(response.status).toBe(200);
+    const payload: unknown = await response.json();
+    if (!isRecord(payload) || !Array.isArray(payload.views)) {
+      throw new Error("smoke view registry must return a views array");
+    }
+
+    for (const view of payload.views) {
+      if (!isRecord(view) || !Array.isArray(view.capabilities)) {
+        throw new Error("each smoke view must advertise capabilities");
+      }
+      for (const capability of view.capabilities) {
+        if (!isRecord(capability)) {
+          throw new Error("view capabilities must be objects");
+        }
+        expect(capability.id).toEqual(expect.any(String));
+        expect(String(capability.id).trim()).not.toBe("");
+        expect(capability.description).toEqual(expect.any(String));
+        expect(String(capability.description).trim()).not.toBe("");
+      }
+    }
+  });
+
   it("audit mode returns an observable failure, never a fabricated bundle", async () => {
     const bundleRoot = await emptyBundleRoot();
     const { child, port } = await bootStub({

--- a/packages/app-core/src/services/coding-account-bridge.test.ts
+++ b/packages/app-core/src/services/coding-account-bridge.test.ts
@@ -403,10 +403,7 @@ describe("coding-account-bridge", () => {
     expect(cfg).not.toContain("[evil]");
   });
 
-  it("skips ultra/max: valid catalog values the pinned codex-acp cannot parse", async () => {
-    // Writing an effort variant the pinned adapter's serde enum lacks would
-    // fail the WHOLE config.toml parse and drop the model pin ChatGPT-account
-    // auth requires — so these are withheld, not written.
+  it("omits max and ultra outside the managed codex-acp effort contract", async () => {
     writeAccount("openai-codex", "cx-ultra", "cx-ultra-access", {
       organizationId: "a",
     });

--- a/packages/app-core/src/services/coding-account-bridge.ts
+++ b/packages/app-core/src/services/coding-account-bridge.ts
@@ -255,15 +255,12 @@ const CODEX_EFFORT_VALUES: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * The effort subset the pinned codex-acp adapter can deserialize. Its bundled
- * codex core's `ReasoningEffort` enum is `minimal|low|medium|high|xhigh`
- * (verified against the @zed-industries/codex-acp@0.14.0 binary's serde
- * variant table); an unknown variant fails the WHOLE config.toml parse, which
- * would also discard the `model` pin ChatGPT-account auth requires — far worse
- * than running at the default effort. `max`/`ultra` are valid catalog values
- * on newer Codex builds but are withheld here until the adapter pin moves.
+ * Effort values guaranteed by the managed Codex ACP contract across linked
+ * account spawns. The catalog recognizes newer variants for other consumers,
+ * but this bridge withholds them until the managed adapter path supports them
+ * end to end so a generated CODEX_HOME never advertises an unhonored setting.
  */
-const PINNED_CODEX_ACP_EFFORTS: ReadonlySet<string> = new Set([
+const MANAGED_CODEX_ACP_EFFORTS: ReadonlySet<string> = new Set([
   "low",
   "medium",
   "high",
@@ -322,8 +319,7 @@ async function materializeCodexHome(
   // account"). Write a MINIMAL config.toml — the model plus an optional
   // validated reasoning effort — reusing the operator's working model
   // (extracted from ~/.codex/config.toml) but NOT the rest of their config,
-  // which can carry fields the pinned codex-acp rejects (e.g. newer
-  // reasoning-effort variants; see PINNED_CODEX_ACP_EFFORTS). Falls back to a
+  // which can carry unrelated interactive-only settings. Falls back to a
   // compatible default.
   const targetConfig = path.join(dir, "config.toml");
   try {
@@ -368,11 +364,9 @@ async function materializeCodexHome(
         `[coding-account-bridge] ignoring invalid ELIZA_CODEX_EFFORT=${JSON.stringify(effort)} (expected low|medium|high|xhigh|max|ultra)`,
       );
       effort = undefined;
-    } else if (effort && !PINNED_CODEX_ACP_EFFORTS.has(effort)) {
-      // error-policy:J7 see PINNED_CODEX_ACP_EFFORTS — writing max/ultra would
-      // fail the pinned adapter's whole config.toml parse and drop the model pin.
+    } else if (effort && !MANAGED_CODEX_ACP_EFFORTS.has(effort)) {
       logger.warn(
-        `[coding-account-bridge] ELIZA_CODEX_EFFORT=${JSON.stringify(effort)} is not parseable by the pinned codex-acp (supported: low|medium|high|xhigh); omitting model_reasoning_effort so config.toml stays loadable`,
+        `[coding-account-bridge] ELIZA_CODEX_EFFORT=${JSON.stringify(effort)} is not supported by the managed codex-acp contract (supported: low|medium|high|xhigh); omitting model_reasoning_effort`,
       );
       effort = undefined;
     }

--- a/packages/app/test/ui-smoke/helpers.ts
+++ b/packages/app/test/ui-smoke/helpers.ts
@@ -388,6 +388,11 @@ async function expectNoFirstRunRedirect(page: Page): Promise<void> {
 }
 
 async function expectStartupSettled(page: Page): Promise<void> {
+  // DOMContentLoaded includes the static preboot shell. Its brand copy is not
+  // route readiness; wait until the renderer has taken ownership of #root.
+  await expect(page.locator(".eliza-preboot-shell")).toHaveCount(0, {
+    timeout: STARTUP_SETTLED_TIMEOUT_MS,
+  });
   await page
     .getByText(/Initializing agent|Connecting to backend/i)
     .waitFor({ state: "hidden", timeout: STARTUP_SETTLED_TIMEOUT_MS });

--- a/packages/app/test/ui-smoke/view-create-edit-live-e2e.spec.ts
+++ b/packages/app/test/ui-smoke/view-create-edit-live-e2e.spec.ts
@@ -1,0 +1,1453 @@
+/**
+ * Live create→render→edit→render proof for agent-built plugin views. The real
+ * planner, coding task, verifier, directory loader, registry, and renderer run.
+ */
+
+import { createHash } from "node:crypto";
+import {
+  lstat,
+  readdir,
+  readFile,
+  readlink,
+  realpath,
+  stat,
+} from "node:fs/promises";
+import { join, relative, resolve, sep } from "node:path";
+import {
+  expect,
+  type Locator,
+  type Page,
+  type TestInfo,
+  test,
+} from "@playwright/test";
+import {
+  installDefaultAppRoutes,
+  openAppPath,
+  seedAppStorage,
+} from "./helpers";
+
+const LIVE_STACK = process.env.ELIZA_UI_SMOKE_LIVE_STACK === "1";
+const LIVE_CREATE_EDIT = process.env.ELIZA_UI_SMOKE_VIEW_CREATE_EDIT === "1";
+const COMPOSER =
+  '[data-testid="chat-composer-textarea"], textarea[aria-label="message"]';
+const SEND =
+  '[data-testid="chat-composer-action"], button[aria-label="Send"], button[aria-label="Send message"]';
+
+interface TaskSummary {
+  id: string;
+  status: string;
+  workdir?: string | null;
+  createdAt?: string;
+  lastError?: string;
+  metadata?: Record<string, unknown>;
+}
+
+interface ViewSummary {
+  id: string;
+  label: string;
+  path?: string;
+  pluginName: string;
+  available: boolean;
+  bundleHash?: string;
+  bundleUrlVersioned?: string;
+  pluginDir?: string;
+}
+
+interface ConversationSummary {
+  id: string;
+  roomId: string;
+}
+
+interface ConversationMessage {
+  id?: string;
+  role?: string;
+  source?: string;
+  text?: string;
+}
+
+interface ConversationTranscript {
+  messages?: ConversationMessage[];
+}
+
+interface TrajectoryListItem {
+  id?: string;
+  trajectoryId?: string;
+  status?: string;
+}
+
+interface TrajectoryIndex {
+  trajectories?: TrajectoryListItem[];
+  total?: number;
+  offset?: number;
+  limit?: number;
+}
+
+interface PhaseTaskEvidence {
+  sessions: TaskSummary[];
+  sessionIds: string[];
+  taskIds: string[];
+}
+
+function validatorPluginName(
+  session: TaskSummary | undefined,
+): string | undefined {
+  const validator = session?.metadata?.validator;
+  if (!validator || typeof validator !== "object" || Array.isArray(validator)) {
+    return undefined;
+  }
+  const params = (validator as Record<string, unknown>).params;
+  if (!params || typeof params !== "object" || Array.isArray(params)) {
+    return undefined;
+  }
+  const pluginName = (params as Record<string, unknown>).pluginName;
+  return typeof pluginName === "string" && pluginName.length > 0
+    ? pluginName
+    : undefined;
+}
+
+interface OrchestratorTaskEvidence {
+  id?: string;
+  artifacts?: Array<{
+    artifactType?: string;
+    path?: string | null;
+    sessionId?: string | null;
+  }>;
+  events?: unknown[];
+}
+
+interface PhaseTrajectoryEvidence {
+  ids: string[];
+  details: Array<{ id: string; body: unknown }>;
+}
+
+interface RawTrajectoryDetail {
+  id: string;
+  body: unknown;
+}
+
+interface ProofManifest {
+  conversation?: ConversationSummary;
+  token?: string;
+  createdMarker?: string;
+  editedMarker?: string;
+  createSessionIds: string[];
+  editSessionIds: string[];
+  createTaskIds: string[];
+  editTaskIds: string[];
+  createTrajectoryIds: string[];
+  editTrajectoryIds: string[];
+  workdir?: string | null;
+  pluginDir?: string;
+  viewId?: string;
+  pluginName?: string;
+  createdHash?: string;
+  editedHash?: string;
+  createVerdictMessageId?: string;
+  editVerdictMessageId?: string;
+  completed: boolean;
+  evidenceErrors: string[];
+}
+
+const VERIFIED_LOADED_TEXT = "plugin built, verified, and loaded live";
+const PLUGIN_DOMAIN_MAX_ENTRIES = 1_000;
+const PLUGIN_DOMAIN_MAX_FILES = 500;
+const PLUGIN_DOMAIN_MAX_TOTAL_BYTES = 20 * 1024 * 1024;
+const PLUGIN_DOMAIN_MAX_FILE_BYTES = 5 * 1024 * 1024;
+const PLUGIN_DOMAIN_MAX_DEPTH = 12;
+const RAW_EVIDENCE_MAX_ENTRIES = 2_000;
+const RAW_EVIDENCE_MAX_FILES = 50;
+const RAW_EVIDENCE_MAX_TOTAL_BYTES = 30 * 1024 * 1024;
+const RAW_EVIDENCE_MAX_FILE_BYTES = 10 * 1024 * 1024;
+
+async function attachJson(
+  testInfo: TestInfo,
+  name: string,
+  value: unknown,
+): Promise<void> {
+  await testInfo.attach(name, {
+    body: Buffer.from(`${JSON.stringify(value, null, 2)}\n`),
+    contentType: "application/json",
+  });
+}
+
+function safeAttachmentToken(value: string): string {
+  return value.replace(/[^A-Za-z0-9._-]/gu, "_").slice(0, 160);
+}
+
+function sessionTaskId(session: TaskSummary): string | undefined {
+  const taskId = session.metadata?.taskId;
+  return typeof taskId === "string" && taskId.length > 0 ? taskId : undefined;
+}
+
+function referencedRawArtifactPaths(task: OrchestratorTaskEvidence): string[] {
+  const paths = new Set(
+    (task.artifacts ?? [])
+      .filter((artifact) => artifact.artifactType === "trajectory")
+      .map((artifact) => artifact.path)
+      .filter((path): path is string => Boolean(path)),
+  );
+  const visit = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      for (const item of value) visit(item);
+      return;
+    }
+    if (!value || typeof value !== "object") return;
+    for (const [key, child] of Object.entries(value)) {
+      if (
+        (key === "stdoutLogPath" || key === "trajectoryPath") &&
+        typeof child === "string" &&
+        child.length > 0
+      ) {
+        paths.add(child);
+      }
+      visit(child);
+    }
+  };
+  visit(task.events);
+  return [...paths].sort();
+}
+
+async function attachReferencedTaskArtifacts(
+  testInfo: TestInfo,
+  phase: "create" | "edit",
+  taskId: string,
+  task: OrchestratorTaskEvidence,
+): Promise<void> {
+  const manifest: Array<{
+    path: string;
+    bytes?: number;
+    sha256?: string;
+    attached: boolean;
+    reason?: string;
+  }> = [];
+  let attachedFiles = 0;
+  let totalBytes = 0;
+  for (const path of referencedRawArtifactPaths(task)) {
+    const info = await lstat(path).catch(() => null);
+    if (!info) {
+      manifest.push({ path, attached: false, reason: "missing" });
+      continue;
+    }
+    if (info.isSymbolicLink()) {
+      manifest.push({ path, attached: false, reason: "symlink" });
+      continue;
+    }
+    if (!info.isFile()) {
+      manifest.push({ path, attached: false, reason: "not a file" });
+      continue;
+    }
+    if (!/\.(?:json|ndjson|ndjson\.1)$/u.test(path)) {
+      manifest.push({
+        path,
+        bytes: info.size,
+        attached: false,
+        reason: "unsupported artifact type",
+      });
+      continue;
+    }
+    if (
+      info.size > RAW_EVIDENCE_MAX_FILE_BYTES ||
+      totalBytes + info.size > RAW_EVIDENCE_MAX_TOTAL_BYTES ||
+      attachedFiles >= RAW_EVIDENCE_MAX_FILES
+    ) {
+      manifest.push({
+        path,
+        bytes: info.size,
+        attached: false,
+        reason: "raw evidence attachment limit",
+      });
+      continue;
+    }
+    const body = await readFile(path);
+    const sha256 = createHash("sha256").update(body).digest("hex");
+    await testInfo.attach(
+      `${phase}-task-${safeAttachmentToken(taskId)}-raw-${safeAttachmentToken(path)}-${sha256.slice(0, 8)}`,
+      {
+        body,
+        contentType: path.includes("ndjson")
+          ? "application/x-ndjson"
+          : "application/json",
+      },
+    );
+    totalBytes += body.byteLength;
+    attachedFiles += 1;
+    manifest.push({
+      path,
+      bytes: body.byteLength,
+      sha256,
+      attached: true,
+    });
+  }
+  await attachJson(
+    testInfo,
+    `${phase}-task-${safeAttachmentToken(taskId)}-raw-artifacts-manifest.json`,
+    { taskId, attachedFiles, totalBytes, files: manifest },
+  );
+}
+
+async function attachPhaseTaskEvidence(
+  page: Page,
+  testInfo: TestInfo,
+  phase: "create" | "edit",
+  previousIds: Set<string>,
+): Promise<PhaseTaskEvidence> {
+  const listed = await listTasks(page);
+  const discovered = listed.filter((task) => !previousIds.has(task.id));
+  expect(
+    discovered.length,
+    `${phase} must create at least one coding-agent session`,
+  ).toBeGreaterThan(0);
+
+  const sessions: TaskSummary[] = [];
+  const outputs: string[] = [];
+  for (const discoveredSession of discovered) {
+    const taskId = discoveredSession.id;
+    const attachmentId = safeAttachmentToken(taskId);
+    const sessionResponse = await page.request.get(
+      `/api/coding-agents/${encodeURIComponent(taskId)}`,
+    );
+    const sessionBody = (await sessionResponse.json()) as TaskSummary;
+    await attachJson(testInfo, `${phase}-coding-session-${attachmentId}.json`, {
+      status: sessionResponse.status(),
+      body: sessionBody,
+    });
+    expect(sessionResponse.ok()).toBe(true);
+    sessions.push(sessionBody);
+
+    const outputResponse = await page.request.get(
+      `/api/coding-agents/${encodeURIComponent(taskId)}/output?lines=2000`,
+    );
+    const outputBody = (await outputResponse.json()) as {
+      sessionId?: string;
+      output?: string;
+    };
+    const output = outputBody.output ?? "";
+    await testInfo.attach(`${phase}-coding-output-${attachmentId}.txt`, {
+      body: Buffer.from(output),
+      contentType: "text/plain",
+    });
+    expect(outputResponse.ok()).toBe(true);
+    outputs.push(output);
+  }
+
+  const taskIds = [
+    ...new Set(
+      sessions
+        .map(sessionTaskId)
+        .filter((taskId): taskId is string => Boolean(taskId)),
+    ),
+  ];
+  for (const taskId of taskIds) {
+    const response = await page.request.get(
+      `/api/orchestrator/tasks/${encodeURIComponent(taskId)}`,
+    );
+    const body = (await response.json()) as OrchestratorTaskEvidence;
+    await attachJson(
+      testInfo,
+      `${phase}-orchestrator-task-${safeAttachmentToken(taskId)}.json`,
+      { status: response.status(), body },
+    );
+    expect(response.ok(), `${phase} orchestrator task must be readable`).toBe(
+      true,
+    );
+    await attachReferencedTaskArtifacts(testInfo, phase, taskId, body);
+  }
+
+  expect(
+    outputs.some((output) => output.includes("PLUGIN_CREATE_DONE")),
+    `${phase} session lineage must contain the structured plugin proof`,
+  ).toBe(true);
+  return {
+    sessions,
+    sessionIds: sessions.map((session) => session.id),
+    taskIds,
+  };
+}
+
+async function attachViewState(
+  page: Page,
+  testInfo: TestInfo,
+  phase: "created" | "edited",
+  viewId: string,
+): Promise<ViewSummary> {
+  const viewResponse = await page.request.get(
+    `/api/views/${encodeURIComponent(viewId)}`,
+  );
+  const view = (await viewResponse.json()) as ViewSummary;
+  await attachJson(testInfo, `${phase}-view.json`, {
+    status: viewResponse.status(),
+    body: view,
+  });
+  expect(viewResponse.ok()).toBe(true);
+  return view;
+}
+
+async function attachCurrentView(
+  page: Page,
+  testInfo: TestInfo,
+  phase: "created" | "edited",
+  expectedViewId: string,
+): Promise<void> {
+  const response = await page.request.get("/api/views/current");
+  const body = (await response.json()) as {
+    currentView?: { viewId?: string } | null;
+  };
+  await attachJson(testInfo, `${phase}-current-view.json`, {
+    status: response.status(),
+    body,
+  });
+  expect(response.ok()).toBe(true);
+  expect(body.currentView?.viewId).toBe(expectedViewId);
+}
+
+async function putViewInForegroundForRouting(
+  page: Page,
+  testInfo: TestInfo,
+  viewId: string,
+  viewPath: string,
+): Promise<void> {
+  const registeredView = (await listViews(page)).find(
+    (view) => view.id === viewId,
+  );
+  expect(registeredView?.available, `${viewId} must be available`).toBe(true);
+
+  // Use the same navigation report as a user-initiated switch. The edit that
+  // follows must honor its explicit target even while another view is current.
+  const response = await page.request.post(
+    `/api/views/${encodeURIComponent(viewId)}/navigate`,
+    {
+      data: { source: "user", path: viewPath },
+    },
+  );
+  const body = await response.json();
+  await attachJson(testInfo, "pre-edit-foreground-view.json", {
+    status: response.status(),
+    body,
+  });
+  expect(response.ok(), `foregrounding ${viewId} must succeed`).toBe(true);
+  await expect
+    .poll(async () => {
+      const currentResponse = await page.request.get("/api/views/current");
+      if (!currentResponse.ok()) return null;
+      const currentBody = (await currentResponse.json()) as {
+        currentView?: { viewId?: string } | null;
+      };
+      return currentBody.currentView?.viewId ?? null;
+    })
+    .toBe(viewId);
+}
+
+async function settleViewForScreenshot(page: Page): Promise<void> {
+  const overlay = page.getByTestId("continuous-chat-overlay");
+  await expect(overlay).toBeVisible({ timeout: 60_000 });
+  if ((await overlay.getAttribute("data-open")) === "true") {
+    await page.locator(COMPOSER).first().press("Escape");
+    await expect(overlay).not.toHaveAttribute("data-open", "true", {
+      timeout: 10_000,
+    });
+  }
+
+  // Task completion and first-run notices are useful during the workflow but
+  // must not cover the view pixels that reviewers are being asked to inspect.
+  const visibleDismissButtons = page.locator(
+    '[data-testid="notification-banner-dismiss"]:visible',
+  );
+  for (let count = 0; count < 20; count += 1) {
+    if ((await visibleDismissButtons.count()) === 0) break;
+    await visibleDismissButtons.first().click();
+    await page.waitForTimeout(100);
+  }
+
+  // Let the chat spring and banner exit transitions finish so the artifact is
+  // a stable frame rather than an intermediate animation state.
+  await page.waitForTimeout(600);
+  await expect(overlay).not.toHaveAttribute("data-open", "true");
+  await expect(visibleDismissButtons).toHaveCount(0);
+}
+
+async function scrollProofMarkerIntoView(
+  surface: Locator,
+  marker: string,
+): Promise<void> {
+  // The coding agent owns presentation, so the proof marker may be standalone,
+  // embedded in the intent, or repeated without changing its evidentiary value.
+  await surface.getByText(marker).first().scrollIntoViewIfNeeded();
+}
+
+async function attachBundle(
+  page: Page,
+  testInfo: TestInfo,
+  phase: "created" | "edited",
+  view: ViewSummary,
+): Promise<Buffer> {
+  const response = await page.request.get(
+    view.bundleUrlVersioned ??
+      `/api/views/${encodeURIComponent(view.id)}/bundle.js`,
+  );
+  const body = await response.body();
+  await testInfo.attach(`${phase}-bundle.js`, {
+    body,
+    contentType: "text/javascript",
+  });
+  await attachJson(testInfo, `${phase}-bundle-headers.json`, {
+    status: response.status(),
+    headers: response.headers(),
+    sha256: createHash("sha256").update(body).digest("hex"),
+    bytes: body.byteLength,
+  });
+  expect(response.ok(), `${phase} view bundle must be serviceable`).toBe(true);
+  return body;
+}
+
+async function attachPluginDomain(
+  testInfo: TestInfo,
+  phase: "created" | "edited",
+  pluginDir: string,
+  taskWorkdir: string,
+): Promise<void> {
+  // macOS exposes the same temporary directory through both /var and
+  // /private/var; canonical paths keep that alias from failing containment.
+  const [root, workdir] = await Promise.all([
+    realpath(resolve(pluginDir)),
+    realpath(resolve(taskWorkdir)),
+  ]);
+  expect(root === workdir || root.startsWith(`${workdir}${sep}`)).toBe(true);
+  const files: Array<{
+    path: string;
+    kind: "file" | "symlink";
+    bytes: number;
+    sha256?: string;
+    text?: string;
+    linkTarget?: string;
+    omitted?: "file-limit" | "file-too-large" | "total-byte-limit";
+  }> = [];
+  const omitted: string[] = [];
+  let entriesVisited = 0;
+  let totalBytesRead = 0;
+  let truncated = false;
+
+  const visit = async (path: string, depth: number): Promise<void> => {
+    if (
+      truncated ||
+      depth > PLUGIN_DOMAIN_MAX_DEPTH ||
+      entriesVisited >= PLUGIN_DOMAIN_MAX_ENTRIES
+    ) {
+      truncated = true;
+      return;
+    }
+    entriesVisited += 1;
+    const info = await lstat(path);
+    const rel = relative(root, path);
+    if (info.isSymbolicLink()) {
+      files.push({
+        path: rel,
+        kind: "symlink",
+        bytes: info.size,
+        linkTarget: await readlink(path),
+      });
+      return;
+    }
+    if (info.isDirectory()) {
+      for (const entry of (await readdir(path)).sort()) {
+        await visit(join(path, entry), depth + 1);
+        if (truncated) break;
+      }
+      return;
+    }
+    if (!info.isFile()) return;
+    if (files.length >= PLUGIN_DOMAIN_MAX_FILES) {
+      files.push({
+        path: rel,
+        kind: "file",
+        bytes: info.size,
+        omitted: "file-limit",
+      });
+      truncated = true;
+      return;
+    }
+    if (info.size > PLUGIN_DOMAIN_MAX_FILE_BYTES) {
+      files.push({
+        path: rel,
+        kind: "file",
+        bytes: info.size,
+        omitted: "file-too-large",
+      });
+      omitted.push(rel);
+      return;
+    }
+    if (totalBytesRead + info.size > PLUGIN_DOMAIN_MAX_TOTAL_BYTES) {
+      files.push({
+        path: rel,
+        kind: "file",
+        bytes: info.size,
+        omitted: "total-byte-limit",
+      });
+      omitted.push(rel);
+      truncated = true;
+      return;
+    }
+    const body = await readFile(path);
+    totalBytesRead += body.byteLength;
+    files.push({
+      path: rel,
+      kind: "file",
+      bytes: body.byteLength,
+      sha256: createHash("sha256").update(body).digest("hex"),
+      ...(/\.(?:json|tsx?|md|css|svg)$/u.test(rel) && body.byteLength <= 200_000
+        ? { text: body.toString("utf8") }
+        : {}),
+    });
+  };
+  for (const target of [
+    "package.json",
+    "tsconfig.json",
+    "tsconfig.build.json",
+    "vitest.config.ts",
+    "biome.json",
+    "src",
+    "tests",
+    "assets",
+    "dist/views/bundle.js",
+  ]) {
+    const path = join(root, target);
+    if (await lstat(path).catch(() => null)) await visit(path, 0);
+  }
+  await attachJson(testInfo, `${phase}-plugin-domain.json`, {
+    pluginDir: root,
+    taskWorkdir: workdir,
+    entriesVisited,
+    totalBytesRead,
+    truncated,
+    omitted,
+    files: files.sort((a, b) => a.path.localeCompare(b.path)),
+  });
+}
+
+async function readRawTrajectoryDetails(): Promise<RawTrajectoryDetail[]> {
+  const configuredDir = process.env.ELIZA_TRAJECTORY_DIR?.trim();
+  if (!configuredDir) return [];
+  const root = resolve(configuredDir);
+  const rootInfo = await stat(root).catch(() => null);
+  if (!rootInfo?.isDirectory()) return [];
+
+  const details: RawTrajectoryDetail[] = [];
+  for (const file of await listEvidenceFiles(root)) {
+    if (
+      !file.path.endsWith(".json") ||
+      file.bytes > RAW_EVIDENCE_MAX_FILE_BYTES
+    ) {
+      continue;
+    }
+    let trajectory: unknown;
+    try {
+      trajectory = JSON.parse(await readFile(file.path, "utf8"));
+    } catch {
+      // error-policy:J3 a recorder file still being replaced is explicitly
+      // unready; the next polling pass retries it instead of accepting it.
+      continue;
+    }
+    if (!trajectory || typeof trajectory !== "object") continue;
+    const record = trajectory as Record<string, unknown>;
+    const id = record.trajectoryId ?? record.id;
+    if (typeof id !== "string" || id.length === 0) continue;
+    details.push({
+      id,
+      body: {
+        source: "raw-trajectory-file",
+        path: relative(root, file.path),
+        trajectory,
+      },
+    });
+  }
+  return details;
+}
+
+async function trajectorySnapshot(page: Page): Promise<{
+  body: TrajectoryIndex;
+  ids: Set<string>;
+  rawDetails: RawTrajectoryDetail[];
+}> {
+  const response = await page.request.get("/api/trajectories?limit=500");
+  expect(response.ok(), "trajectory index must be available").toBe(true);
+  const body = (await response.json()) as TrajectoryIndex;
+  const rawDetails = await readRawTrajectoryDetails();
+  return {
+    body,
+    ids: new Set(
+      [
+        ...(body.trajectories ?? []).map(
+          (item) => item.id ?? item.trajectoryId,
+        ),
+        ...rawDetails.map((detail) => detail.id),
+      ].filter((id): id is string => Boolean(id)),
+    ),
+    rawDetails,
+  };
+}
+
+function trajectoryStatus(body: unknown): string | undefined {
+  if (!body || typeof body !== "object") return undefined;
+  const trajectory = (body as { trajectory?: unknown }).trajectory;
+  if (!trajectory || typeof trajectory !== "object") return undefined;
+  const status = (trajectory as { status?: unknown }).status;
+  return typeof status === "string" ? status : undefined;
+}
+
+async function waitForFinalizedCorrelatedTrajectories(
+  page: Page,
+  testInfo: TestInfo,
+  phase: "create" | "edit",
+  previousIds: Set<string>,
+  roomId: string,
+  phaseMarker: string,
+): Promise<PhaseTrajectoryEvidence> {
+  const deadline = Date.now() + 90_000;
+  let latestIndex: TrajectoryIndex = { trajectories: [] };
+  let latestDetails: Array<{ id: string; body: unknown }> = [];
+  while (Date.now() < deadline) {
+    const snapshot = await trajectorySnapshot(page);
+    latestIndex = snapshot.body;
+    const details: Array<{ id: string; body: unknown }> =
+      snapshot.rawDetails.filter((detail) => {
+        if (previousIds.has(detail.id)) return false;
+        const serialized = JSON.stringify(detail.body);
+        if (!serialized.includes(roomId) || !serialized.includes(phaseMarker)) {
+          return false;
+        }
+        const status = trajectoryStatus(detail.body);
+        return status === "finished" || status === "completed";
+      });
+    const candidateIds = (snapshot.body.trajectories ?? [])
+      .map((item) => item.id ?? item.trajectoryId)
+      .filter(
+        (id): id is string =>
+          typeof id === "string" && id.length > 0 && !previousIds.has(id),
+      );
+    for (const id of candidateIds) {
+      const response = await page.request.get(
+        `/api/trajectories/${encodeURIComponent(id)}`,
+      );
+      if (!response.ok()) continue;
+      const body = await response.json();
+      const serialized = JSON.stringify(body);
+      if (!serialized.includes(roomId)) continue;
+      const status = trajectoryStatus(body);
+      if (status === "active" || status === "running") continue;
+      details.push({ id, body });
+    }
+    latestDetails = details;
+    if (details.length > 0) {
+      await attachJson(
+        testInfo,
+        `${phase}-trajectories-index.json`,
+        latestIndex,
+      );
+      for (const detail of details) {
+        await attachJson(
+          testInfo,
+          `${phase}-trajectory-${safeAttachmentToken(detail.id)}.json`,
+          {
+            correlatedRoomId: roomId,
+            phaseMarkerPresent: JSON.stringify(detail.body).includes(
+              phaseMarker,
+            ),
+            body: detail.body,
+          },
+        );
+      }
+      return { ids: details.map((detail) => detail.id), details };
+    }
+    await page.waitForTimeout(1_000);
+  }
+
+  await attachJson(testInfo, `${phase}-trajectories-timeout.json`, {
+    roomId,
+    phaseMarker,
+    index: latestIndex,
+    details: latestDetails,
+  });
+  throw new Error(
+    `${phase} did not produce a finalized trajectory correlated to room ${roomId}`,
+  );
+}
+
+function verifiedLoadedMessages(
+  transcript: ConversationTranscript,
+): ConversationMessage[] {
+  return (transcript.messages ?? []).filter(
+    (message) =>
+      message.source === "verification-room-bridge" &&
+      message.text?.includes(VERIFIED_LOADED_TEXT),
+  );
+}
+
+async function fetchConversationTranscript(
+  page: Page,
+  conversationId: string,
+): Promise<ConversationTranscript> {
+  const response = await page.request.get(
+    `/api/conversations/${encodeURIComponent(conversationId)}/messages`,
+  );
+  expect(response.ok(), "conversation transcript must be available").toBe(true);
+  return (await response.json()) as ConversationTranscript;
+}
+
+async function waitForNewVerifiedLoadedVerdict(
+  page: Page,
+  testInfo: TestInfo,
+  phase: "create" | "edit",
+  conversationId: string,
+  previousVerdictIds: Set<string>,
+): Promise<{
+  transcript: ConversationTranscript;
+  verdict: ConversationMessage;
+  verdictIds: Set<string>;
+}> {
+  const deadline = Date.now() + 60_000;
+  let latest: ConversationTranscript = { messages: [] };
+  while (Date.now() < deadline) {
+    latest = await fetchConversationTranscript(page, conversationId);
+    const verdicts = verifiedLoadedMessages(latest);
+    const verdict = verdicts.find(
+      (message) => message.id && !previousVerdictIds.has(message.id),
+    );
+    if (verdict) {
+      await attachJson(testInfo, `${phase}-verification-verdict.json`, verdict);
+      return {
+        transcript: latest,
+        verdict,
+        verdictIds: new Set(
+          verdicts
+            .map((message) => message.id)
+            .filter((id): id is string => Boolean(id)),
+        ),
+      };
+    }
+    await page.waitForTimeout(1_000);
+  }
+  await attachJson(testInfo, `${phase}-verification-verdict-timeout.json`, {
+    expectedText: VERIFIED_LOADED_TEXT,
+    previousVerdictIds: [...previousVerdictIds],
+    transcript: latest,
+  });
+  throw new Error(
+    `${phase} did not persist a new verified-and-loaded verdict in the originating conversation`,
+  );
+}
+
+async function listEvidenceFiles(
+  root: string,
+): Promise<Array<{ path: string; bytes: number }>> {
+  const files: Array<{ path: string; bytes: number }> = [];
+  let entries = 0;
+  const visit = async (path: string, depth: number): Promise<void> => {
+    if (entries >= RAW_EVIDENCE_MAX_ENTRIES || depth > 12) return;
+    entries += 1;
+    const info = await lstat(path);
+    if (info.isSymbolicLink()) return;
+    if (info.isDirectory()) {
+      for (const entry of (await readdir(path)).sort()) {
+        await visit(join(path, entry), depth + 1);
+        if (entries >= RAW_EVIDENCE_MAX_ENTRIES) break;
+      }
+      return;
+    }
+    if (info.isFile()) {
+      files.push({ path, bytes: info.size });
+    }
+  };
+  await visit(root, 0);
+  return files;
+}
+
+async function attachRawTrajectoryEvidence(
+  testInfo: TestInfo,
+  proof: ProofManifest,
+): Promise<void> {
+  const configuredDir = process.env.ELIZA_TRAJECTORY_DIR?.trim();
+  if (!configuredDir) {
+    await attachJson(testInfo, "raw-trajectory-artifacts-unavailable.json", {
+      available: false,
+      reason:
+        "ELIZA_TRAJECTORY_DIR was not externalized; the live harness owns and removes its state-scoped trajectory directory",
+    });
+    return;
+  }
+  const root = resolve(configuredDir);
+  const rootInfo = await stat(root).catch(() => null);
+  if (!rootInfo?.isDirectory()) {
+    await attachJson(testInfo, "raw-trajectory-artifacts-unavailable.json", {
+      available: false,
+      configuredDir: root,
+      reason: "configured trajectory directory does not exist",
+    });
+    return;
+  }
+
+  const correlationTokens = [
+    proof.conversation?.roomId,
+    proof.token,
+    proof.createdMarker,
+    proof.editedMarker,
+  ].filter((value): value is string => Boolean(value));
+  const sessionIds = new Set([
+    ...proof.createSessionIds,
+    ...proof.editSessionIds,
+  ]);
+  const manifest: Array<{
+    path: string;
+    bytes: number;
+    sha256?: string;
+    attached: boolean;
+    reason?: string;
+  }> = [];
+  let attachedFiles = 0;
+  let totalBytes = 0;
+  for (const file of await listEvidenceFiles(root)) {
+    const rel = relative(root, file.path);
+    if (!/\.(?:json|ndjson|ndjson\.1)$/u.test(rel)) continue;
+    const sessionPathMatch = [...sessionIds].some((id) => rel.includes(id));
+    if (
+      file.bytes > RAW_EVIDENCE_MAX_FILE_BYTES ||
+      totalBytes + file.bytes > RAW_EVIDENCE_MAX_TOTAL_BYTES ||
+      attachedFiles >= RAW_EVIDENCE_MAX_FILES
+    ) {
+      manifest.push({
+        path: rel,
+        bytes: file.bytes,
+        attached: false,
+        reason: "raw evidence attachment limit",
+      });
+      continue;
+    }
+    const body = await readFile(file.path);
+    const correlated =
+      sessionPathMatch ||
+      correlationTokens.some((token) => body.includes(Buffer.from(token)));
+    if (!correlated) continue;
+    const sha256 = createHash("sha256").update(body).digest("hex");
+    await testInfo.attach(
+      `raw-${safeAttachmentToken(rel)}-${sha256.slice(0, 8)}`,
+      {
+        body,
+        contentType: rel.includes("ndjson")
+          ? "application/x-ndjson"
+          : "application/json",
+      },
+    );
+    totalBytes += body.byteLength;
+    attachedFiles += 1;
+    manifest.push({
+      path: rel,
+      bytes: body.byteLength,
+      sha256,
+      attached: true,
+    });
+  }
+  await attachJson(testInfo, "raw-trajectory-artifacts-manifest.json", {
+    available: true,
+    root,
+    attachedFiles,
+    totalBytes,
+    files: manifest,
+  });
+}
+
+async function sendChat(
+  page: Page,
+  text: string,
+  mayNavigate = false,
+): Promise<void> {
+  const composer = page.locator(COMPOSER).first();
+  const send = page.locator(SEND).first();
+  await expect(composer).toBeVisible({ timeout: 60_000 });
+  await composer.fill(text);
+  await expect(send).toBeEnabled();
+  await send.click();
+  if (mayNavigate) {
+    await expect
+      .poll(
+        async () =>
+          new URL(page.url()).pathname !== "/chat" ||
+          (await page
+            .locator('[data-testid="chat-message"][data-role="user"]')
+            .filter({ hasText: text })
+            .last()
+            .isVisible()
+            .catch(() => false)),
+        { timeout: 30_000 },
+      )
+      .toBe(true);
+    return;
+  }
+  await expect(composer).toHaveValue("", { timeout: 30_000 });
+}
+
+async function listTasks(page: Page): Promise<TaskSummary[]> {
+  const response = await page.request.get("/api/coding-agents");
+  expect(response.ok(), "coding-agent session list must be available").toBe(
+    true,
+  );
+  return (await response.json()) as TaskSummary[];
+}
+
+async function waitForNewTask(
+  page: Page,
+  previousIds: Set<string>,
+  createChoiceLabel?: string,
+): Promise<TaskSummary> {
+  const deadline = Date.now() + 15 * 60_000;
+  let latest: TaskSummary | undefined;
+  let choiceSubmitted = false;
+  while (Date.now() < deadline) {
+    const tasks = await listTasks(page);
+    latest = tasks.find((task) => !previousIds.has(task.id));
+    if (latest) return latest;
+    if (createChoiceLabel && !choiceSubmitted) {
+      const choice = page
+        .getByRole("button", {
+          name: createChoiceLabel,
+          exact: true,
+        })
+        .last();
+      if (await choice.isVisible().catch(() => false)) {
+        await choice.click();
+        choiceSubmitted = true;
+      }
+    }
+    await page.waitForTimeout(2_000);
+  }
+  throw new Error("VIEWS did not start a coding task within 15 minutes");
+}
+
+async function waitForTaskDone(
+  page: Page,
+  taskId: string,
+): Promise<TaskSummary> {
+  // Live coding agents may run package installation, all four verification
+  // commands, and an artifact review in one prompt. Keep this phase bound
+  // finite, but do not cancel a healthy real-model task at the old 15-minute
+  // threshold while it is still producing tool events.
+  const deadline = Date.now() + 25 * 60_000;
+  let status = "missing";
+  while (Date.now() < deadline) {
+    const response = await page.request.get(
+      `/api/coding-agents/${encodeURIComponent(taskId)}`,
+    );
+    if (response.ok()) {
+      const task = (await response.json()) as TaskSummary;
+      status = task.status;
+      if (["completed", "stopped"].includes(status)) return task;
+      if (["errored", "cancelled", "blocked"].includes(status)) {
+        throw new Error(
+          `coding task ${taskId} ended with status ${status}${task.lastError ? `: ${task.lastError}` : ""}`,
+        );
+      }
+    }
+    await page.waitForTimeout(3_000);
+  }
+  throw new Error(`coding task ${taskId} did not finish (last=${status})`);
+}
+
+async function listViews(page: Page): Promise<ViewSummary[]> {
+  const response = await page.request.get("/api/views");
+  expect(response.ok(), "view registry must be available").toBe(true);
+  const body = (await response.json()) as { views?: ViewSummary[] };
+  return body.views ?? [];
+}
+
+async function waitForView(
+  page: Page,
+  token: string,
+  previousHash?: string,
+): Promise<ViewSummary> {
+  const deadline = Date.now() + 3 * 60_000;
+  let candidate: ViewSummary | undefined;
+  while (Date.now() < deadline) {
+    candidate = (await listViews(page)).find((view) =>
+      `${view.id} ${view.label} ${view.pluginName}`
+        .toLowerCase()
+        .includes(token),
+    );
+    if (
+      candidate?.available &&
+      candidate.bundleHash &&
+      candidate.bundleHash !== previousHash
+    ) {
+      return candidate;
+    }
+    await page.waitForTimeout(2_000);
+  }
+  throw new Error(
+    `view ${token} never became available with a fresh bundle hash (${candidate ? JSON.stringify(candidate) : "not registered"})`,
+  );
+}
+
+async function activateConversation(page: Page): Promise<ConversationSummary> {
+  await seedAppStorage(page);
+  await openAppPath(page, "/chat");
+
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() =>
+          localStorage.getItem("eliza:chat:activeConversationId"),
+        ),
+      {
+        message: "chat must hydrate an active conversation before the proof",
+        timeout: 30_000,
+      },
+    )
+    .toBeTruthy();
+
+  const id = await page.evaluate(() =>
+    localStorage.getItem("eliza:chat:activeConversationId"),
+  );
+  const response = await page.request.get("/api/conversations");
+  expect(response.ok()).toBe(true);
+  const body = (await response.json()) as {
+    conversations?: ConversationSummary[];
+  };
+  const conversation = body.conversations?.find(
+    (candidate) => candidate.id === id,
+  );
+  if (!conversation) {
+    throw new Error("hydrated conversation did not resolve to its server room");
+  }
+  return conversation;
+}
+
+test.skip(
+  !LIVE_STACK || !LIVE_CREATE_EDIT,
+  "requires ELIZA_UI_SMOKE_LIVE_STACK=1 and ELIZA_UI_SMOKE_VIEW_CREATE_EDIT=1",
+);
+
+test("creates, renders, edits, and hot-reloads a real plugin view", async ({
+  page,
+}, testInfo) => {
+  test.setTimeout(60 * 60_000);
+  if (!process.env.ELIZA_TRAJECTORY_DIR?.trim()) {
+    throw new Error(
+      "live create/edit proof requires ELIZA_TRAJECTORY_DIR so room-correlated native trajectories survive stack teardown",
+    );
+  }
+  const proof: ProofManifest = {
+    createSessionIds: [],
+    editSessionIds: [],
+    createTaskIds: [],
+    editTaskIds: [],
+    createTrajectoryIds: [],
+    editTrajectoryIds: [],
+    completed: false,
+    evidenceErrors: [],
+  };
+
+  try {
+    await installDefaultAppRoutes(page);
+    const conversation = await activateConversation(page);
+    proof.conversation = conversation;
+    const trajectoriesBeforeCreate = await trajectorySnapshot(page);
+    await attachJson(testInfo, "views-before.json", {
+      views: await listViews(page),
+    });
+
+    const suffix = Date.now().toString(36).slice(-6);
+    const token = `proof-surface-${suffix}`;
+    const createdMarker = `VIEW_CREATED_${suffix.toUpperCase()}`;
+    const editedMarker = `VIEW_EDITED_${suffix.toUpperCase()}`;
+    proof.token = token;
+    proof.createdMarker = createdMarker;
+    proof.editedMarker = editedMarker;
+
+    const verdictIdsBeforeCreate = new Set(
+      verifiedLoadedMessages(
+        await fetchConversationTranscript(page, conversation.id),
+      )
+        .map((message) => message.id)
+        .filter((id): id is string => Boolean(id)),
+    );
+    const beforeCreate = new Set(
+      (await listTasks(page)).map((task) => task.id),
+    );
+    await sendChat(
+      page,
+      `Use the VIEWS tool with action=create and intent="${token} ${createdMarker} Proof Surface ${suffix}". Build a finished release GUI surface named ${token}. Its rendered page must visibly include the exact marker ${createdMarker} and a heading containing "Proof Surface". Include real tests and a compiled bundle. Do not merely explain the steps.`,
+    );
+    const createTask = await waitForNewTask(
+      page,
+      beforeCreate,
+      "Create a new view plugin",
+    );
+    proof.createSessionIds = [createTask.id];
+    await waitForTaskDone(page, createTask.id);
+
+    const createTaskEvidence = await attachPhaseTaskEvidence(
+      page,
+      testInfo,
+      "create",
+      beforeCreate,
+    );
+    proof.createSessionIds = createTaskEvidence.sessionIds;
+    proof.createTaskIds = createTaskEvidence.taskIds;
+    const createdSession =
+      createTaskEvidence.sessions.find(
+        (session) => session.id === createTask.id,
+      ) ?? createTaskEvidence.sessions[0];
+    const expectedPluginName = validatorPluginName(createdSession);
+    expect(
+      expectedPluginName,
+      "create session must identify its plugin",
+    ).toBeTruthy();
+    proof.workdir = createdSession?.workdir;
+    proof.pluginName = expectedPluginName;
+
+    const createVerdict = await waitForNewVerifiedLoadedVerdict(
+      page,
+      testInfo,
+      "create",
+      conversation.id,
+      verdictIdsBeforeCreate,
+    );
+    proof.createVerdictMessageId = createVerdict.verdict.id;
+
+    const createdViewSummary = await waitForView(
+      page,
+      expectedPluginName as string,
+    );
+    const createdView = await attachViewState(
+      page,
+      testInfo,
+      "created",
+      createdViewSummary.id,
+    );
+    expect(createdView.bundleUrlVersioned).toContain(createdView.bundleHash);
+    const createdBundle = await attachBundle(
+      page,
+      testInfo,
+      "created",
+      createdView,
+    );
+    expect(createdView.pluginDir).toBeTruthy();
+    expect(createdSession?.workdir).toBeTruthy();
+    proof.pluginDir = createdView.pluginDir;
+    proof.viewId = createdView.id;
+    proof.pluginName = createdView.pluginName;
+    proof.createdHash = createdView.bundleHash;
+    await attachPluginDomain(
+      testInfo,
+      "created",
+      createdView.pluginDir as string,
+      createdSession?.workdir as string,
+    );
+
+    await openAppPath(page, "/chat");
+    await sendChat(
+      page,
+      `Use the VIEWS tool with action=show and view=${createdView.id}. Open it now.`,
+      true,
+    );
+    const createdSurface = page.locator(
+      `[data-eliza-view-id="${createdView.id}"]`,
+    );
+    await expect(createdSurface).toContainText(createdMarker, {
+      timeout: 90_000,
+    });
+    await expect(
+      page.getByRole("heading", { name: /Proof Surface/iu }).first(),
+    ).toBeVisible();
+    await attachCurrentView(page, testInfo, "created", createdView.id);
+    await settleViewForScreenshot(page);
+    const createdDesktop = testInfo.outputPath("created-desktop.png");
+    await page.screenshot({
+      path: createdDesktop,
+      fullPage: true,
+    });
+    await testInfo.attach("created-desktop.png", {
+      path: createdDesktop,
+      contentType: "image/png",
+    });
+    await page.setViewportSize({ width: 390, height: 844 });
+    await settleViewForScreenshot(page);
+    const createdMobile = testInfo.outputPath("created-mobile.png");
+    await page.screenshot({
+      path: createdMobile,
+      fullPage: true,
+    });
+    await testInfo.attach("created-mobile.png", {
+      path: createdMobile,
+      contentType: "image/png",
+    });
+    await scrollProofMarkerIntoView(createdSurface, createdMarker);
+    await page.waitForTimeout(300);
+    const createdMobileProof = testInfo.outputPath("created-mobile-proof.png");
+    await page.screenshot({
+      path: createdMobileProof,
+      fullPage: true,
+    });
+    await testInfo.attach("created-mobile-proof.png", {
+      path: createdMobileProof,
+      contentType: "image/png",
+    });
+    await page.setViewportSize({ width: 1280, height: 720 });
+
+    const createTrajectories = await waitForFinalizedCorrelatedTrajectories(
+      page,
+      testInfo,
+      "create",
+      trajectoriesBeforeCreate.ids,
+      conversation.roomId,
+      createdMarker,
+    );
+    proof.createTrajectoryIds = createTrajectories.ids;
+    const trajectoriesBeforeEdit = await trajectorySnapshot(page);
+    const beforeEdit = new Set((await listTasks(page)).map((task) => task.id));
+    await openAppPath(page, "/chat");
+    await putViewInForegroundForRouting(page, testInfo, "cockpit", "/cockpit");
+    await sendChat(
+      page,
+      `Use the VIEWS tool with action=edit and view=${createdView.id}. Replace the visible marker ${createdMarker} with the exact marker ${editedMarker}; keep the rest of the view working, update its real test, run every verification command, and rebuild the bundle.`,
+    );
+    const editTask = await waitForNewTask(page, beforeEdit);
+    proof.editSessionIds = [editTask.id];
+    await waitForTaskDone(page, editTask.id);
+
+    const editTaskEvidence = await attachPhaseTaskEvidence(
+      page,
+      testInfo,
+      "edit",
+      beforeEdit,
+    );
+    proof.editSessionIds = editTaskEvidence.sessionIds;
+    proof.editTaskIds = editTaskEvidence.taskIds;
+    const editedSession =
+      editTaskEvidence.sessions.find((session) => session.id === editTask.id) ??
+      editTaskEvidence.sessions[0];
+    expect(editedSession?.workdir).toBeTruthy();
+    expect(editedSession?.workdir).toBe(createdSession?.workdir);
+
+    const editVerdict = await waitForNewVerifiedLoadedVerdict(
+      page,
+      testInfo,
+      "edit",
+      conversation.id,
+      createVerdict.verdictIds,
+    );
+    proof.editVerdictMessageId = editVerdict.verdict.id;
+
+    const editedViewSummary = await waitForView(
+      page,
+      createdView.pluginName,
+      createdView.bundleHash,
+    );
+    const editedView = await attachViewState(
+      page,
+      testInfo,
+      "edited",
+      editedViewSummary.id,
+    );
+    expect(editedView.id).toBe(createdView.id);
+    expect(editedView.pluginName).toBe(createdView.pluginName);
+    expect(editedView.pluginDir).toBeTruthy();
+    const editedBundle = await attachBundle(
+      page,
+      testInfo,
+      "edited",
+      editedView,
+    );
+    expect(editedBundle.equals(createdBundle)).toBe(false);
+    await attachPluginDomain(
+      testInfo,
+      "edited",
+      editedView.pluginDir as string,
+      editedSession?.workdir as string,
+    );
+    await openAppPath(page, "/chat");
+    await sendChat(
+      page,
+      `Use the VIEWS tool with action=show and view=${editedView.id}. Open the edited view now.`,
+      true,
+    );
+    const editedSurface = page.locator(
+      `[data-eliza-view-id="${editedView.id}"]`,
+    );
+    await expect(editedSurface).toContainText(editedMarker, {
+      timeout: 90_000,
+    });
+    // The original marker remains correctly preserved in the chat transcript;
+    // only the hot-reloaded view surface must stop rendering it.
+    await expect(editedSurface).not.toContainText(createdMarker);
+    await expect(
+      page.getByRole("heading", { name: /Proof Surface/iu }).first(),
+    ).toBeVisible();
+    await attachCurrentView(page, testInfo, "edited", editedView.id);
+    await settleViewForScreenshot(page);
+    const editedDesktop = testInfo.outputPath("edited-desktop.png");
+    await page.screenshot({
+      path: editedDesktop,
+      fullPage: true,
+    });
+    await testInfo.attach("edited-desktop.png", {
+      path: editedDesktop,
+      contentType: "image/png",
+    });
+    await page.setViewportSize({ width: 390, height: 844 });
+    await settleViewForScreenshot(page);
+    const editedMobile = testInfo.outputPath("edited-mobile.png");
+    await page.screenshot({
+      path: editedMobile,
+      fullPage: true,
+    });
+    await testInfo.attach("edited-mobile.png", {
+      path: editedMobile,
+      contentType: "image/png",
+    });
+    await scrollProofMarkerIntoView(editedSurface, editedMarker);
+    await page.waitForTimeout(300);
+    const editedMobileProof = testInfo.outputPath("edited-mobile-proof.png");
+    await page.screenshot({
+      path: editedMobileProof,
+      fullPage: true,
+    });
+    await testInfo.attach("edited-mobile-proof.png", {
+      path: editedMobileProof,
+      contentType: "image/png",
+    });
+
+    const editTrajectories = await waitForFinalizedCorrelatedTrajectories(
+      page,
+      testInfo,
+      "edit",
+      trajectoriesBeforeEdit.ids,
+      conversation.roomId,
+      editedMarker,
+    );
+    proof.editTrajectoryIds = editTrajectories.ids;
+    const transcript = await fetchConversationTranscript(page, conversation.id);
+    await attachJson(testInfo, "conversation-transcript.json", transcript);
+    expect(verifiedLoadedMessages(transcript).length).toBeGreaterThanOrEqual(2);
+
+    proof.pluginDir = editedView.pluginDir;
+    proof.viewId = editedView.id;
+    proof.pluginName = editedView.pluginName;
+    proof.editedHash = editedView.bundleHash;
+    proof.completed = true;
+  } finally {
+    // The live harness removes its state root as soon as the test process exits;
+    // copy any externalized raw evidence into Playwright attachments while every
+    // session and trajectory correlation key is still available.
+    try {
+      await attachRawTrajectoryEvidence(testInfo, proof);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      proof.evidenceErrors.push(`raw trajectory evidence: ${message}`);
+      await testInfo.attach("raw-trajectory-artifacts-error.txt", {
+        body: Buffer.from(`${message}\n`),
+        contentType: "text/plain",
+      });
+    }
+    await attachJson(testInfo, "live-proof-manifest.json", {
+      ...proof,
+      capturedAt: new Date().toISOString(),
+    });
+  }
+});

--- a/packages/app/test/ui-smoke/view-switching-chat-e2e.spec.ts
+++ b/packages/app/test/ui-smoke/view-switching-chat-e2e.spec.ts
@@ -1,55 +1,10 @@
-// End-to-end coverage for AGENT-DRIVEN VIEW SWITCHING: a chat command (ACTIVE
-// navigation) or an intent-only message (PASSIVE routing) makes the renderer
-// switch the active view.
-//
-// WHY THIS SPEC EXISTS (the gap it closes):
-// The existing coverage proves the two halves of the view-switch seam in
-// isolation but never the whole pipe end to end:
-//   * scenario-runner (deterministic-view-switching) drives the REAL VIEWS
-//     action but stops at the loopback navigate POST — it never renders a UI.
-//   * The UI unit tests (app-navigate-view*, App.navigate-view-wiring,
-//     startup-phase-hydrate.navigate-frame) synthesize the WS frame / DOM event
-//     directly against a mocked App — they never run the real renderer shell.
-// This spec joins them: it drives the REAL composer/send surface, then exercises
-// the REAL renderer wiring — `client.onWsEvent("shell:navigate:view")` →
-// `eliza:navigate:view` DOM event (startup-phase-hydrate.ts:431) →
-// `createNavigateViewHandler` (app-navigate-view.ts) → `ViewRouter` +
-// `useNavigationPathSync` (App.tsx) — and asserts the active view actually
-// changed (URL + on-view marker).
-//
-// TWO TIERS (one always-on, one opt-in), so the spec is meaningful in CI and
-// becomes a true black-box agent test when a provider key is present:
-//
-//   1. DETERMINISTIC tier (default lane — the keyless stub):
-//      The stub returns a deterministic chat fixture but does NOT emit a
-//      `shell:navigate:view` WS frame (see playwright-ui-smoke-api-stub.mjs
-//      classifyAssistantAction — it only encodes the intended target as JSON
-//      text). So we (a) send the real command through the composer to prove the
-//      command surface, then (b) deterministically deliver the EXACT
-//      `eliza:navigate:view` payload the renderer's WS handler emits for that
-//      command — the precise normalized event from startup-phase-hydrate.ts:431
-//      — and assert the renderer switched. This drives the entire renderer-side
-//      navigate pipeline against the live app shell, not a mock.
-//
-//   2. LIVE tier (ELIZA_UI_SMOKE_LIVE_STACK=1 + provider key):
-//      No synthetic dispatch. The real agent runs the VIEWS action, the backend
-//      route broadcasts `shell:navigate:view` over the WS, and we assert the
-//      renderer switched. This proves the full black-box chat → agent → VIEWS →
-//      broadcast → renderer seam.
-//
-// NAVIGATION CONTRACT NOTES (verified against source, load-bearing for asserts):
-//   * `/inbox`, `/calendar` are registered plugin views: tabFromPath() returns
-//     "views" and ViewRouter mounts the dynamic bundle whose heading is the view
-//     label ("Inbox" / "Calendar"). (navigation/index.ts:495, App.tsx
-//     findRemoteViewForRoute)
-//   * `/character/documents` maps to the built-in documents/knowledge subtab,
-//     which embeds DocumentsView inside CharacterEditor.
-//   * `/wallet` maps to the `inventory` tab (TAB_PATHS.inventory === "/wallet").
-//   * `/settings` maps to the `settings` tab (settings-shell).
-//   * `/task-coordinator` is the coding view (resolveIntentView maps app/feature
-//     intent there). The PASSIVE coding case is asserted by URL — the
-//     cross-mode-stable signal navigatePath() sets — to keep the deterministic
-//     and live tiers identical.
+/**
+ * Drives chat commands through view resolution and asserts both the resulting
+ * route and a marker from the mounted view. The keyless tier injects the
+ * renderer's normalized event; the live tier uses the real agent and VIEWS.
+ * A websocket-withheld lane requires terminal action-result recovery over HTTP,
+ * so a backend switch cannot masquerade as a renderer switch.
+ */
 
 import { expect, type Locator, type Page, test } from "@playwright/test";
 import {
@@ -59,6 +14,10 @@ import {
 } from "./helpers";
 
 const LIVE_STACK = process.env.ELIZA_UI_SMOKE_LIVE_STACK === "1";
+const BLOCK_WEBSOCKET = process.env.ELIZA_UI_SMOKE_BLOCK_WEBSOCKET === "1";
+const routedWebSocketCounts = new WeakMap<Page, number>();
+const blockedNavigateFrameCounts = new WeakMap<Page, number>();
+const currentViewReadCounts = new WeakMap<Page, number>();
 
 const CHAT_COMPOSER_SELECTOR =
   '[data-testid="chat-composer-textarea"], textarea[aria-label="message"]';
@@ -512,53 +471,111 @@ async function createAndActivateLiveConversationForCase(
   page: Page,
   testCase: ViewSwitchCase,
 ): Promise<void> {
-  if (!LIVE_STACK) return;
+  if (!LIVE_STACK) {
+    await openAppPath(page, "/chat");
+    return;
+  }
 
-  const response = await page.evaluate(
-    async (payload) => {
-      const createResponse = await fetch("/api/conversations", {
-        method: "POST",
-        credentials: "same-origin",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-      });
-      return {
-        ok: createResponse.ok,
-        status: createResponse.status,
-        text: await createResponse.text(),
-      };
-    },
-    {
-      title: `view-switch: ${testCase.view.id}`,
-    },
-  );
+  const response = await page.request.post("/api/conversations", {
+    data: { title: `view-switch: ${testCase.view.id}` },
+  });
+  const responseText = await response.text();
   expect(
-    response.ok,
-    `live runtime should create an isolated chat (status=${response.status}, body=${response.text.slice(0, 500)})`,
+    response.ok(),
+    `live runtime should create an isolated chat (status=${response.status()}, body=${responseText.slice(0, 500)})`,
   ).toBe(true);
-  const body = JSON.parse(response.text) as ApiConversationResponse;
+  const body = JSON.parse(responseText) as ApiConversationResponse;
   const conversationId = body.conversation?.id?.trim();
   expect(conversationId, "created live conversation id").toBeTruthy();
 
-  await page.evaluate((id) => {
-    localStorage.setItem("eliza:chat:activeConversationId", id);
-  }, conversationId);
+  // Seed before the first document load: the active-conversation key is shell
+  // state and the surface-realm guard correctly rejects raw writes after a view
+  // owns the host realm.
+  await seedAppStorage(page, {
+    "eliza:chat:activeConversationId": conversationId as string,
+  });
   await openAppPath(page, "/chat");
   await expect(chatComposer(page)).toBeVisible({ timeout: 60_000 });
+  // The global composer paints before conversation hydration finishes. Sending
+  // while its index is still -1 makes useChatSend create a different draft and
+  // turns this into a race against startup instead of a switching proof.
+  await expect(page.getByTestId("chat-sheet")).not.toHaveAttribute(
+    "data-conversation-index",
+    "-1",
+    { timeout: 60_000 },
+  );
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() =>
+          localStorage.getItem("eliza:chat:activeConversationId"),
+        ),
+      {
+        timeout: 60_000,
+        message: "the isolated live conversation should finish hydrating",
+      },
+    )
+    .toBe(conversationId);
 }
 
 test.beforeEach(async ({ page }) => {
   // Land on the chat surface in the full-shell mode so the composer is present
   // and the navigate handler runs against the real ViewRouter.
-  await seedAppStorage(page);
+  currentViewReadCounts.set(page, 0);
+  page.on("request", (request) => {
+    if (new URL(request.url()).pathname !== "/api/views/current") return;
+    const count = currentViewReadCounts.get(page);
+    if (count === undefined) {
+      throw new Error("Current-view request counter was not initialized");
+    }
+    currentViewReadCounts.set(page, count + 1);
+  });
+  if (BLOCK_WEBSOCKET) {
+    routedWebSocketCounts.set(page, 0);
+    blockedNavigateFrameCounts.set(page, 0);
+    await page.routeWebSocket(
+      (url) => url.pathname === "/ws",
+      (socket) => {
+        const count = routedWebSocketCounts.get(page);
+        if (count === undefined) {
+          throw new Error("Routed WebSocket counter was not initialized");
+        }
+        routedWebSocketCounts.set(page, count + 1);
+
+        const server = socket.connectToServer();
+        server.onMessage((message) => {
+          if (
+            typeof message === "string" &&
+            message.includes("shell:navigate:view")
+          ) {
+            const blockedCount = blockedNavigateFrameCounts.get(page);
+            if (blockedCount === undefined) {
+              throw new Error(
+                "Blocked navigate-frame counter was not initialized",
+              );
+            }
+            blockedNavigateFrameCounts.set(page, blockedCount + 1);
+            return;
+          }
+          // Preserve the rest of the socket lifecycle so this lane isolates the
+          // navigation handoff instead of changing unrelated shell readiness.
+          socket.send(message);
+        });
+      },
+    );
+  }
+  if (!LIVE_STACK) await seedAppStorage(page);
   await installDefaultAppRoutes(page);
 });
 
 for (const testCase of VIEW_SWITCH_CASES) {
-  test(testCase.name, async ({ page }) => {
+  test(testCase.name, async ({ page }, testInfo) => {
     await ensureLiveViewRegisteredForCase(page, testCase);
-    await openAppPath(page, "/chat");
     await createAndActivateLiveConversationForCase(page, testCase);
+    const currentViewReadsBeforeCommand = currentViewReadCounts.get(page);
+    if (currentViewReadsBeforeCommand === undefined) {
+      throw new Error("Current-view request counter was not initialized");
+    }
 
     // 1) Drive the real command surface: type + send the user's message.
     await sendChatCommand(page, testCase.command, testCase.expectedPath);
@@ -581,6 +598,46 @@ for (const testCase of VIEW_SWITCH_CASES) {
 
     // 3) Assert the renderer actually switched the active view.
     await assertViewSwitched(page, testCase);
+
+    if (LIVE_STACK && BLOCK_WEBSOCKET) {
+      const routedSockets = routedWebSocketCounts.get(page) ?? 0;
+      const blockedNavigateFrames = blockedNavigateFrameCounts.get(page) ?? 0;
+      const currentViewReadsAfterCommand = currentViewReadCounts.get(page) ?? 0;
+      expect(
+        routedSockets,
+        "the browser socket must be routed through the frame interceptor",
+      ).toBeGreaterThan(0);
+      expect(
+        blockedNavigateFrames,
+        "the backend navigate frame must be observed and withheld from the page",
+      ).toBeGreaterThan(0);
+      expect(
+        currentViewReadsAfterCommand,
+        "the streamed VIEWS result must recover canonical navigation over HTTP",
+      ).toBeGreaterThan(currentViewReadsBeforeCommand);
+      await testInfo.attach("websocket-withheld-proof.json", {
+        contentType: "application/json",
+        body: Buffer.from(
+          JSON.stringify(
+            {
+              command: testCase.command,
+              expectedPath: testCase.expectedPath,
+              finalUrl: page.url(),
+              routedSockets,
+              blockedNavigateFrames,
+              currentViewReadsBeforeCommand,
+              currentViewReadsAfterCommand,
+            },
+            null,
+            2,
+          ),
+        ),
+      });
+      await testInfo.attach("inbox-after-http-recovery.png", {
+        contentType: "image/png",
+        body: await page.screenshot({ fullPage: true }),
+      });
+    }
   });
 }
 

--- a/packages/app/test/ui-smoke/view-switching-local-llm-e2e.spec.ts
+++ b/packages/app/test/ui-smoke/view-switching-local-llm-e2e.spec.ts
@@ -1,21 +1,10 @@
-// LOCAL-MODEL view-switching e2e + HTML report.
-//
-// For each user utterance this drives the REAL chat composer, asks the REAL
-// LOCAL model (eliza-1 via the eliza llama.cpp fork's llama-server, schema-
-// constrained planner output, thinking disabled) what to do, then delivers the
-// model's decision to the REAL renderer navigate pipeline and screenshots both
-// the chat (text going through) and the resulting view. A wrong model choice
-// renders the WRONG view — so the report shows successes AND failures visually.
-//
-// Requires a running llama-server with an eliza-1 GGUF loaded:
-//   BC=plugins/plugin-local-inference/native/llama.cpp/build-cuda
-//   LD_LIBRARY_PATH="$BC/bin" "$BC/bin/llama-server" \
-//     -m /home/shaw/models/eliza-1-2b-128k.gguf --host 127.0.0.1 --port 8080 -ngl 99 -c 8192 --jinja
-// Run (reusing an already-built app server is far faster):
-//   ELIZA_UI_SMOKE_REUSE_SERVER=1 LLAMACPP_URL=http://127.0.0.1:8080 LOCAL_LLM_LABEL=eliza-1-2b \
-//     bun run --cwd packages/app test:e2e test/ui-smoke/view-switching-local-llm-e2e.spec.ts
-//
-// Output: packages/app/test/ui-smoke/output/view-switching-local/report.html
+/**
+ * Drives local-model view decisions through the real chat composer and
+ * renderer navigation pipeline, then writes an HTML report with chat and view
+ * screenshots. It requires an eliza-1 GGUF served by llama-server; an
+ * unreachable model or incorrect view decision fails after the report is
+ * written so every attempted utterance remains inspectable.
+ */
 import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -28,6 +17,7 @@ import {
 
 const LLAMACPP_URL = process.env.LLAMACPP_URL ?? "http://127.0.0.1:8080";
 const MODEL_LABEL = process.env.LOCAL_LLM_LABEL ?? "eliza-1 (local)";
+const LIVE_LOCAL_MODEL = process.env.ELIZA_UI_SMOKE_LOCAL_LLM_LIVE === "1";
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const OUT = path.join(HERE, "output", "view-switching-local");
 
@@ -198,6 +188,11 @@ interface CaseResult {
   viewImg: string;
 }
 
+test.skip(
+  !LIVE_LOCAL_MODEL,
+  "requires ELIZA_UI_SMOKE_LOCAL_LLM_LIVE=1 and a real llama-server",
+);
+
 test("view switching driven by the local model — capture + report", async ({
   page,
 }) => {
@@ -285,10 +280,13 @@ test("view switching driven by the local model — capture + report", async ({
   console.log(
     `\n[local-vs] ${MODEL_LABEL}: ${passed}/${results.length} correct → ${path.join(OUT, "report.html")}`,
   );
-  // The report is the artifact; the test itself passes as long as it ran the
-  // full matrix and captured every case (failures are EXPECTED + shown).
   expect(results.length).toBe(CASES.length);
   expect(results.every((r) => r.chatImg && r.viewImg)).toBe(true);
+  const failures = results.filter((result) => !result.success);
+  expect(
+    failures,
+    `local-model view switching failed ${failures.length}/${results.length} cases; inspect ${path.join(OUT, "report.html")}`,
+  ).toEqual([]);
 });
 
 function esc(s: string): string {

--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -1833,6 +1833,12 @@ describe("runV5MessageRuntimeStage1", () => {
 		]);
 		if (result.kind === "planned_reply") {
 			expect(result.result.responseContent?.text).toBe("Spawned coding agent.");
+			expect(result.result.actionResults).toEqual([
+				expect.objectContaining({
+					success: true,
+					data: expect.objectContaining({ actionName: "TASKS" }),
+				}),
+			]);
 		}
 	});
 

--- a/packages/core/src/__tests__/planner-happy-path.test.ts
+++ b/packages/core/src/__tests__/planner-happy-path.test.ts
@@ -200,6 +200,7 @@ function makeMockAction(opts: {
 		required?: boolean;
 		schema: { type: "string" | "number" | "boolean" | "object" | "array" };
 	}>;
+	suppressActionResultClipboard?: boolean;
 }): Action {
 	return {
 		name: opts.name,
@@ -211,6 +212,9 @@ function makeMockAction(opts: {
 		handler: opts.handler,
 		...(opts.subActions ? { subActions: opts.subActions } : {}),
 		...(opts.contexts ? { contexts: opts.contexts } : {}),
+		...(opts.suppressActionResultClipboard
+			? { suppressActionResultClipboard: true }
+			: {}),
 	} as Action;
 }
 
@@ -267,6 +271,7 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 				return {
 					success: true,
 					text: "found 3 results for 'eliza'",
+					values: { mode: "show", viewId: "inbox" },
 					data: {
 						actionName: "WEB_SEARCH",
 						results: [
@@ -337,6 +342,14 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 		expect(result.kind).toBe("planned_reply");
 		if (result.kind === "planned_reply") {
 			expect(result.result.responseContent?.text).toContain("eliza");
+			expect(result.result.actionResults).toMatchObject([
+				{
+					success: true,
+					text: "found 3 results for 'eliza'",
+					data: { actionName: "WEB_SEARCH" },
+					values: { mode: "show", viewId: "inbox" },
+				},
+			]);
 		}
 
 		// Three model calls fired: messageHandler + planner + evaluator
@@ -478,6 +491,163 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 		const evalStage = trajectory.stages.find((s) => s.kind === "evaluation");
 		expect(evalStage?.evaluation?.success).toBe(true);
 		expect(evalStage?.evaluation?.decision).toBe("FINISH");
+	});
+
+	it("keeps statically suppressed results out of planner, tool, and client surfaces", async () => {
+		const tunnelCredential = makeMockAction({
+			name: "TUNNEL_CREDENTIAL",
+			parameters: [],
+			suppressActionResultClipboard: true,
+			handler: async () => ({
+				success: true,
+				text: "Credential tunnel completed.",
+				values: { secret: "must-not-leak" },
+				data: {
+					credential: "must-not-leak",
+					values: { nestedSecret: "must-not-leak" },
+				},
+			}),
+		});
+		const runtime = makeRuntime({
+			actions: [tunnelCredential],
+			responses: [
+				{
+					expectModelType: ModelType.RESPONSE_HANDLER,
+					body: stage1Response({
+						contexts: ["general"],
+						candidateActionNames: ["TUNNEL_CREDENTIAL"],
+						thought: "Credential delivery requires the protected action.",
+					}),
+				},
+				{
+					expectModelType: ModelType.ACTION_PLANNER,
+					body: {
+						text: "Delivering the credential.",
+						toolCalls: [{ id: "call-1", name: "TUNNEL_CREDENTIAL", args: {} }],
+					},
+				},
+				{
+					expectModelType: ModelType.RESPONSE_HANDLER,
+					body: JSON.stringify({
+						success: true,
+						decision: "FINISH",
+						thought: "Credential delivery succeeded.",
+						messageToUser: "Credential tunnel completed.",
+					}),
+				},
+			],
+		});
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage("send the credential"),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+		});
+
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind === "planned_reply") {
+			expect(result.result.actionResults).toEqual([
+				{
+					success: true,
+					text: "Credential tunnel completed.",
+					data: { actionName: "TUNNEL_CREDENTIAL" },
+				},
+			]);
+			expect(result.result.state.data.actionResults).toEqual(
+				result.result.actionResults,
+			);
+			expect(JSON.stringify(result.result.actionResults)).not.toContain(
+				"must-not-leak",
+			);
+		}
+		expect(JSON.stringify(getCalls(runtime))).not.toContain("must-not-leak");
+		expect(
+			JSON.stringify(readRecordedTrajectories(String(AGENT_ID))),
+		).not.toContain("must-not-leak");
+	});
+
+	it("honors per-result suppression without changing safe outcome text", async () => {
+		const views = makeMockAction({
+			name: "VIEWS",
+			parameters: [],
+			handler: async () => ({
+				success: true,
+				text: "Started view edit task.",
+				userFacingText: "Started view edit task.",
+				verifiedUserFacing: true,
+				values: {
+					workdir: "/private/worktree/must-not-leak",
+					taskSessionId: "session-must-not-leak",
+				},
+				data: {
+					workdir: "/private/worktree/must-not-leak",
+					task: { sessionId: "session-must-not-leak" },
+					agents: [{ sessionId: "session-must-not-leak" }],
+					suppressActionResultClipboard: true,
+				},
+			}),
+		});
+		const runtime = makeRuntime({
+			actions: [views],
+			responses: [
+				{
+					expectModelType: ModelType.RESPONSE_HANDLER,
+					body: stage1Response({
+						contexts: ["general"],
+						candidateActionNames: ["VIEWS"],
+						thought: "The user asked to edit a view.",
+					}),
+				},
+				{
+					expectModelType: ModelType.ACTION_PLANNER,
+					body: {
+						text: "Starting the view edit.",
+						toolCalls: [{ id: "call-1", name: "VIEWS", args: {} }],
+					},
+				},
+				{
+					expectModelType: ModelType.RESPONSE_HANDLER,
+					body: JSON.stringify({
+						success: true,
+						decision: "FINISH",
+						thought: "The edit task started.",
+						messageToUser: "Started view edit task.",
+					}),
+				},
+			],
+		});
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage("edit my view"),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+		});
+
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind === "planned_reply") {
+			expect(result.result.actionResults).toEqual([
+				{
+					success: true,
+					text: "Started view edit task.",
+					userFacingText: "Started view edit task.",
+					verifiedUserFacing: true,
+					data: { actionName: "VIEWS" },
+				},
+			]);
+			expect(result.result.state.data.actionResults).toEqual(
+				result.result.actionResults,
+			);
+		}
+
+		const observableSurfaces = JSON.stringify({
+			modelCalls: getCalls(runtime),
+			trajectories: readRecordedTrajectories(String(AGENT_ID)),
+			result,
+		});
+		expect(observableSurfaces).not.toContain("must-not-leak");
+		expect(observableSurfaces).not.toContain("suppressActionResultClipboard");
 	});
 
 	it("blocks high-risk USER input before planner tools execute", async () => {

--- a/packages/core/src/runtime/__tests__/execute-planned-tool-call.test.ts
+++ b/packages/core/src/runtime/__tests__/execute-planned-tool-call.test.ts
@@ -727,6 +727,80 @@ describe("executePlannedToolCall", () => {
 		);
 	});
 
+	it("honors per-result suppression in action events and streaming tool results", async () => {
+		const emitEvent = vi.fn(async () => {});
+		const onToolResult = vi.fn();
+		const action = makeAction({
+			name: "VIEWS",
+			handler: async () => ({
+				success: false,
+				text: "View edit did not start.",
+				values: { workdir: "/private/must-not-leak" },
+				data: {
+					actionName: "VIEWS",
+					task: { sessionId: "must-not-leak" },
+					suppressActionResultClipboard: true,
+				},
+			}),
+		});
+		const runtime = makeRuntime([action], { emitEvent });
+
+		const result = await runWithStreamingContext(
+			{ onStreamChunk: vi.fn(), onToolResult },
+			() =>
+				executePlannedToolCall(
+					runtime,
+					{ message: makeMessage() },
+					{ name: "VIEWS", params: {} },
+				),
+		);
+
+		expect(result).toMatchObject({
+			success: false,
+			text: "View edit did not start.",
+			data: expect.objectContaining({
+				suppressActionResultClipboard: true,
+			}),
+		});
+		const emittedSurfaces = JSON.stringify({
+			events: emitEvent.mock.calls,
+			streaming: onToolResult.mock.calls,
+		});
+		expect(emittedSurfaces).not.toContain("must-not-leak");
+		expect(emitEvent).toHaveBeenNthCalledWith(
+			2,
+			EventType.ACTION_COMPLETED,
+			expect.objectContaining({
+				content: expect.objectContaining({
+					actionStatus: "failed",
+					actionResult: expect.objectContaining({
+						success: false,
+						text: "View edit did not start.",
+						data: {
+							actionName: "VIEWS",
+							suppressed: true,
+							reason: "sensitive_action_result",
+						},
+					}),
+				}),
+			}),
+		);
+		expect(onToolResult).toHaveBeenCalledWith(
+			expect.objectContaining({
+				status: "failed",
+				result: expect.objectContaining({
+					success: false,
+					text: "View edit did not start.",
+					data: {
+						actionName: "VIEWS",
+						suppressed: true,
+						reason: "sensitive_action_result",
+					},
+				}),
+			}),
+		);
+	});
+
 	it("emits failed ACTION_COMPLETED events with string errors for thrown handlers", async () => {
 		const emitEvent = vi.fn(async () => {});
 		const action = makeAction({

--- a/packages/core/src/runtime/execute-planned-tool-call.ts
+++ b/packages/core/src/runtime/execute-planned-tool-call.ts
@@ -114,6 +114,55 @@ function sensitiveActionResultMarker(
 	};
 }
 
+/**
+ * A result may opt out per invocation because multi-mode actions only return
+ * sensitive data for some operations. Static action metadata remains the
+ * stronger default for actions whose every result is sensitive.
+ */
+export function shouldSuppressActionResultClipboard(
+	action: Pick<Action, "suppressActionResultClipboard"> | undefined,
+	result: { data?: Readonly<Record<string, unknown>> },
+): boolean {
+	return (
+		action?.suppressActionResultClipboard === true ||
+		result.data?.suppressActionResultClipboard === true
+	);
+}
+
+/**
+ * Keep the outcome and intentional user-facing projections while removing the
+ * structured payload that must not enter planner prompts or client clipboards.
+ */
+export function projectActionResultForClipboard(
+	action: Pick<Action, "name" | "suppressActionResultClipboard"> | undefined,
+	result: ActionResult,
+	actionName = action?.name,
+): ActionResult {
+	if (!shouldSuppressActionResultClipboard(action, result)) {
+		return result;
+	}
+
+	const resultActionName =
+		typeof result.data?.actionName === "string"
+			? result.data.actionName
+			: undefined;
+	const safeActionName = actionName ?? resultActionName;
+	return {
+		success: result.success,
+		...(result.text !== undefined ? { text: result.text } : {}),
+		...(result.userFacingText !== undefined
+			? { userFacingText: result.userFacingText }
+			: {}),
+		...(result.verifiedUserFacing !== undefined
+			? { verifiedUserFacing: result.verifiedUserFacing }
+			: {}),
+		...(safeActionName ? { data: { actionName: safeActionName } } : {}),
+		...(result.continueChain !== undefined
+			? { continueChain: result.continueChain }
+			: {}),
+	};
+}
+
 function readMetadataString(message: Memory, key: string): string | undefined {
 	const metadata = isContentRecord(message.metadata) ? message.metadata : null;
 	const value = metadata?.[key];
@@ -372,6 +421,10 @@ export async function executePlannedToolCall(
 			error,
 		});
 	}
+	const suppressActionResult = shouldSuppressActionResultClipboard(
+		action,
+		resultForEvent,
+	);
 
 	if (typeof runtime.emitEvent === "function") {
 		await runtime
@@ -385,7 +438,7 @@ export async function executePlannedToolCall(
 					actions: [action.name],
 					actionStatus: resultForEvent.success ? "completed" : "failed",
 					actionResult: actionResultToContentRecord(resultForEvent, {
-						suppressData: action.suppressActionResultClipboard === true,
+						suppressData: suppressActionResult,
 					}),
 					source: executorCtx.message.content.source,
 					error:
@@ -408,7 +461,7 @@ export async function executePlannedToolCall(
 	}
 
 	return emitToolResult(toolCall, resultForEvent, {
-		suppressData: action.suppressActionResultClipboard === true,
+		suppressData: suppressActionResult,
 	});
 }
 

--- a/packages/core/src/runtime/sub-planner.ts
+++ b/packages/core/src/runtime/sub-planner.ts
@@ -20,6 +20,7 @@ import {
 	type ExecutePlannedToolCallContext,
 	type ExecutePlannedToolCallOptions,
 	executePlannedToolCall,
+	projectActionResultForClipboard,
 } from "./execute-planned-tool-call";
 import {
 	actionResultToPlannerToolResult,
@@ -291,7 +292,7 @@ export async function runSubPlanner(
 				};
 			}
 
-			const result = await execute(
+			const rawResult = await execute(
 				params.runtime,
 				subPlannerCtx,
 				{ ...toolCall, name: resolvedChildAction.name },
@@ -299,6 +300,11 @@ export async function runSubPlanner(
 					...(params.options ?? {}),
 					actions: childActions,
 				},
+			);
+			const result = projectActionResultForClipboard(
+				resolvedChildAction,
+				rawResult,
+				resolvedChildAction.name,
 			);
 			return actionResultToPlannerToolResult(result, {
 				summary: summarizeActionResultForPlanner(

--- a/packages/core/src/services/message.persistence.test.ts
+++ b/packages/core/src/services/message.persistence.test.ts
@@ -85,6 +85,7 @@ describe("DefaultMessageService message persistence", () => {
 		const result = await service.handleMessage(runtime, message);
 
 		expect(result.mode).toBe("none");
+		expect(result.actionResults).toBeUndefined();
 		expect(message.id).toBe(CREATED_MESSAGE_ID);
 		expect(message.content.text).toBe(wrapped);
 

--- a/packages/core/src/services/message.shortcut-gate.test.ts
+++ b/packages/core/src/services/message.shortcut-gate.test.ts
@@ -89,6 +89,16 @@ describe("runShortcutGate (#8791 pre-LLM gate)", () => {
 		expect(result).not.toBeNull();
 		expect(result?.kind).toBe("direct_reply");
 		expect(result?.result.responseContent.text).toBe("echoed: /echo hi");
+		expect(result?.result.actionResults).toEqual([
+			{
+				success: true,
+				text: "echoed: /echo hi",
+				data: { actionName: "ECHO_COMMAND" },
+			},
+		]);
+		expect(result?.result.state.data.actionResults).toEqual(
+			result?.result.actionResults,
+		);
 		expect(useModel).not.toHaveBeenCalled();
 		// #8792: a SLASH_COMMAND_INVOKED interaction event is emitted.
 		expect(emitEvent).toHaveBeenCalledTimes(1);
@@ -236,12 +246,89 @@ describe("runShortcutGate (#8791 pre-LLM gate)", () => {
 			senderRole: "OWNER",
 		});
 		expect(result?.kind).toBe("direct_reply");
+		expect(result?.result.actionResults).toMatchObject([
+			{ success: true, data: { actionName: "ECHO_COMMAND" } },
+		]);
+		expect(result?.result.responseContent.thought).toBe("Shortcut: nl:echo");
 		expect(seenOptions[0]).toEqual({ what: "hello there", mode: "simple" });
 		expect(useModel).not.toHaveBeenCalled();
 		const shortcutEvents = emitEvent.mock.calls.filter(
 			(c) => c[0] === EventType.SHORTCUT_FIRED,
 		);
 		expect(shortcutEvents).toHaveLength(1);
+	});
+
+	it("does not publish sensitive shortcut result data or values", async () => {
+		const sensitiveAction: Action = {
+			...echoAction(),
+			suppressActionResultClipboard: true,
+			handler: async (_rt, _message, _state, _options, callback) => {
+				await callback?.({ text: "Sensitive action completed." });
+				return {
+					success: true,
+					text: "Sensitive action completed.",
+					values: { secret: "must-not-leak" },
+					data: { credential: "must-not-leak" },
+				};
+			},
+		};
+		const { runtime } = makeRuntime({ actions: [sensitiveAction] });
+
+		const result = await runShortcutGate({
+			// biome-ignore lint/suspicious/noExplicitAny: minimal fake runtime
+			runtime: runtime as any,
+			message: msg("/echo secret"),
+			state: {} as State,
+			responseId,
+			senderRole: "OWNER",
+		});
+
+		expect(result?.result.actionResults).toEqual([
+			{
+				success: true,
+				text: "Sensitive action completed.",
+				data: { actionName: "ECHO_COMMAND" },
+			},
+		]);
+	});
+
+	it("honors dynamic shortcut suppression and preserves a failed outcome", async () => {
+		const sensitiveAction: Action = {
+			...echoAction(),
+			handler: async (_rt, _message, _state, _options, callback) => {
+				await callback?.({ text: "View edit did not start." });
+				return {
+					success: false,
+					text: "View edit did not start.",
+					userFacingText: "View edit did not start.",
+					values: { workdir: "/private/must-not-leak" },
+					data: {
+						task: { sessionId: "must-not-leak" },
+						suppressActionResultClipboard: true,
+					},
+				};
+			},
+		};
+		const { runtime } = makeRuntime({ actions: [sensitiveAction] });
+
+		const result = await runShortcutGate({
+			// biome-ignore lint/suspicious/noExplicitAny: minimal fake runtime
+			runtime: runtime as any,
+			message: msg("/echo edit view"),
+			state: {} as State,
+			responseId,
+			senderRole: "OWNER",
+		});
+
+		expect(result?.result.actionResults).toEqual([
+			{
+				success: false,
+				text: "View edit did not start.",
+				userFacingText: "View edit did not start.",
+				data: { actionName: "ECHO_COMMAND" },
+			},
+		]);
+		expect(JSON.stringify(result)).not.toContain("must-not-leak");
 	});
 
 	// #12087 Item 3: the shortcut path enforces the target action's declared

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -93,6 +93,8 @@ import {
 	type ExecutePlannedToolCallContext,
 	type ExecutePlannedToolCallOptions,
 	executePlannedToolCall,
+	projectActionResultForClipboard,
+	shouldSuppressActionResultClipboard,
 } from "../runtime/execute-planned-tool-call";
 import {
 	type FactsAndRelationshipsRunResult,
@@ -182,6 +184,7 @@ import type {
 	HandlerCallback,
 	MessageHandlerResult,
 	Provider,
+	ProviderValue,
 	StreamChunkCallback,
 } from "../types/components";
 import type { ContextEvent, ContextObject } from "../types/context-object";
@@ -1367,6 +1370,7 @@ type StrategyMode = "simple" | "actions" | "none";
 interface StrategyResult {
 	responseContent: Content | null;
 	responseMessages: Memory[];
+	actionResults?: ActionResult[];
 	state: State;
 	mode: StrategyMode;
 }
@@ -5780,11 +5784,16 @@ async function executeV5PlannedToolCall(
 		return subPlannerResultToPlannerToolResult(subResult);
 	}
 
-	const actionResult = await executePlannedToolCall(
+	const rawActionResult = await executePlannedToolCall(
 		args.runtime,
 		executorCtx,
 		toolCall,
 		{ ...(args.executorOptions ?? {}), actions: executionActions },
+	);
+	const actionResult = projectActionResultForClipboard(
+		action,
+		rawActionResult,
+		toolCall.name,
 	);
 	return actionResultToPlannerToolResult(actionResult, {
 		summary: summarizeActionResultForPlanner(
@@ -6060,26 +6069,85 @@ function collectActionsFromContext(context: ContextObject): Action[] {
 
 function collectPreviousActionResults(
 	trajectory: PlannerTrajectory,
+	actions: readonly Action[] = [],
 ): ActionResult[] {
+	const actionsByName = new Map<string, Action>();
+	for (const action of [
+		...collectActionsFromContext(trajectory.context),
+		...actions,
+	]) {
+		actionsByName.set(normalizeActionIdentifier(action.name), action);
+	}
 	const results: ActionResult[] = [];
 	for (const step of [...trajectory.archivedSteps, ...trajectory.steps]) {
 		if (!step.result || !step.toolCall) {
 			continue;
 		}
+		const actionName = step.toolCall.name;
+		const action = actionsByName.get(normalizeActionIdentifier(actionName));
+		if (shouldSuppressActionResultClipboard(action, step.result)) {
+			results.push({
+				success: step.result.success,
+				...(step.result.text !== undefined ? { text: step.result.text } : {}),
+				...(step.result.userFacingText !== undefined
+					? { userFacingText: step.result.userFacingText }
+					: {}),
+				...(step.result.verifiedUserFacing !== undefined
+					? { verifiedUserFacing: step.result.verifiedUserFacing }
+					: {}),
+				data: { actionName },
+				...(step.result.continueChain !== undefined
+					? { continueChain: step.result.continueChain }
+					: {}),
+			});
+			continue;
+		}
+		const plannerData = step.result.data;
+		const nestedValues = plannerData?.values;
+		const nestedValueEntries =
+			nestedValues !== null &&
+			typeof nestedValues === "object" &&
+			!Array.isArray(nestedValues)
+				? Object.entries(nestedValues)
+				: [];
+		const values =
+			nestedValueEntries.length > 0 &&
+			nestedValueEntries.every(
+				(entry): entry is [string, ProviderValue] =>
+					typeof entry[1] !== "function" && typeof entry[1] !== "symbol",
+			)
+				? Object.fromEntries(nestedValueEntries)
+				: undefined;
+		const actionData =
+			values && plannerData
+				? Object.fromEntries(
+						Object.entries(plannerData).filter(([key]) => key !== "values"),
+					)
+				: plannerData;
+		const error =
+			typeof step.result.error === "string"
+				? step.result.error
+				: step.result.error instanceof Error
+					? step.result.error.message
+					: undefined;
 		results.push({
 			success: step.result.success,
-			text: step.result.text,
+			...(step.result.text !== undefined ? { text: step.result.text } : {}),
+			...(step.result.userFacingText !== undefined
+				? { userFacingText: step.result.userFacingText }
+				: {}),
+			...(step.result.verifiedUserFacing !== undefined
+				? { verifiedUserFacing: step.result.verifiedUserFacing }
+				: {}),
 			data: {
-				actionName: step.toolCall.name,
-				...(step.result.data ?? {}),
+				actionName,
+				...actionData,
 			},
-			error:
-				typeof step.result.error === "string"
-					? step.result.error
-					: step.result.error instanceof Error
-						? step.result.error.message
-						: undefined,
-			continueChain: step.result.continueChain,
+			...(values ? { values } : {}),
+			...(error !== undefined ? { error } : {}),
+			...(step.result.continueChain !== undefined
+				? { continueChain: step.result.continueChain }
+				: {}),
 		});
 	}
 	return results;
@@ -6169,8 +6237,9 @@ export async function runShortcutGate(args: {
 	if (!valid) return null;
 
 	let captured: string | undefined;
+	let shortcutActionResult: ActionResult | undefined;
 	try {
-		await action.handler(
+		shortcutActionResult = await action.handler(
 			args.runtime,
 			args.message,
 			args.state,
@@ -6190,6 +6259,27 @@ export async function runShortcutGate(args: {
 		return null;
 	}
 	if (captured === undefined) return null;
+	let actionResult: ActionResult | undefined;
+	if (shortcutActionResult) {
+		if (shouldSuppressActionResultClipboard(action, shortcutActionResult)) {
+			actionResult = projectActionResultForClipboard(
+				action,
+				shortcutActionResult,
+				action.name,
+			);
+		} else {
+			actionResult = {
+				...shortcutActionResult,
+				data: {
+					...shortcutActionResult.data,
+					actionName: action.name,
+				},
+			};
+		}
+	}
+	const resultState = actionResult
+		? withActionResultsForPrompt(args.state, [actionResult])
+		: args.state;
 
 	// #8792: report the interaction so the proactive-comment decider can react.
 	void emitInteractionEvent(args.runtime, match, args.message);
@@ -6207,14 +6297,17 @@ export async function runShortcutGate(args: {
 				requiresTool: false,
 			},
 		},
-		result: createV5ReplyStrategyResult({
-			runtime: args.runtime,
-			message: args.message,
-			state: args.state,
-			responseId: args.responseId,
-			text: captured,
-			thought,
-		}),
+		result: {
+			...createV5ReplyStrategyResult({
+				runtime: args.runtime,
+				message: args.message,
+				state: resultState,
+				responseId: args.responseId,
+				text: captured,
+				thought,
+			}),
+			...(actionResult ? { actionResults: [actionResult] } : {}),
+		},
 	};
 }
 
@@ -7304,7 +7397,10 @@ export async function runV5MessageRuntimeStage1(args: {
 							state: plannerState,
 							selectedContexts,
 							senderRole,
-							previousResults: collectPreviousActionResults(ctx.trajectory),
+							previousResults: collectPreviousActionResults(
+								ctx.trajectory,
+								exposedPlannerActions,
+							),
 							...(recordingCallback ? { callback: recordingCallback } : {}),
 						}),
 						plannerRuntime,
@@ -7390,6 +7486,7 @@ export async function runV5MessageRuntimeStage1(args: {
 
 		const actionResults = collectPreviousActionResults(
 			plannerResult.trajectory,
+			exposedPlannerActions,
 		);
 		const finalPlannerState =
 			actionResults.length > 0
@@ -7482,21 +7579,25 @@ export async function runV5MessageRuntimeStage1(args: {
 			kind: "planned_reply",
 			messageHandler,
 			result: shouldSendPlannedText
-				? createV5ReplyStrategyResult({
-						...args,
-						state: finalPlannerState,
-						text: effectiveReplyText,
-						thought:
-							plannerResult.evaluator?.thought ??
-							plannerResult.trajectory.steps.at(-1)?.thought ??
-							messageHandler.thought,
-						agentVoiced: effectiveReplyIsModelVoice,
-					})
+				? {
+						...createV5ReplyStrategyResult({
+							...args,
+							state: finalPlannerState,
+							text: effectiveReplyText,
+							thought:
+								plannerResult.evaluator?.thought ??
+								plannerResult.trajectory.steps.at(-1)?.thought ??
+								messageHandler.thought,
+							agentVoiced: effectiveReplyIsModelVoice,
+						}),
+						...(actionResults.length > 0 ? { actionResults } : {}),
+					}
 				: {
 						responseContent: null,
 						responseMessages: [],
 						state: finalPlannerState,
 						mode: "none",
+						...(actionResults.length > 0 ? { actionResults } : {}),
 					},
 		};
 	} catch (err) {
@@ -10300,6 +10401,7 @@ export class DefaultMessageService implements IMessageService {
 
 		let responseContent: Content | null = null;
 		let responseMessages: Memory[] = [];
+		let actionResults: ActionResult[] | undefined;
 		let mode: StrategyMode = "none";
 		let simpleReplyDelivered = false;
 
@@ -10324,6 +10426,7 @@ export class DefaultMessageService implements IMessageService {
 					? [...earlyReplyMessages, ...result.responseMessages]
 					: result.responseMessages;
 			state = result.state;
+			actionResults = result.actionResults;
 			mode = result.mode;
 
 			// Race check before we send anything.
@@ -10686,6 +10789,7 @@ export class DefaultMessageService implements IMessageService {
 			didRespond,
 			responseContent,
 			responseMessages,
+			...(actionResults ? { actionResults } : {}),
 			state,
 			mode,
 		};

--- a/packages/core/src/types/message-service.ts
+++ b/packages/core/src/types/message-service.ts
@@ -4,6 +4,7 @@
  * shapes the message service returns. Consumed by the runtime message handler.
  */
 import type {
+	ActionResult,
 	AgentContext,
 	HandlerCallback,
 	StreamChunkCallback,
@@ -48,6 +49,8 @@ export interface MessageProcessingResult {
 	didRespond: boolean;
 	responseContent?: Content | null;
 	responseMessages: Memory[];
+	/** Results executed during this turn, preserved across planner/cache cleanup. */
+	actionResults?: ActionResult[];
 	state?: State;
 	mode?: MessageProcessingMode;
 	skipEvaluation?: boolean;

--- a/packages/elizaos/src/__tests__/min-plugin-build-contract.test.ts
+++ b/packages/elizaos/src/__tests__/min-plugin-build-contract.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Minimal plugin build-contract coverage for both checkout and packaged
+ * scaffolds, where runtime loading requires emitted JavaScript under dist.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+const templateDir = resolve(here, "../../templates/min-plugin");
+
+describe("min-plugin build contract", () => {
+  it("uses an emitting build config and requires the loadable build step", () => {
+    const packageJson = JSON.parse(
+      readFileSync(resolve(templateDir, "package.json"), "utf8"),
+    ) as {
+      scripts?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    const buildConfig = JSON.parse(
+      readFileSync(resolve(templateDir, "tsconfig.build.json"), "utf8"),
+    ) as { compilerOptions?: Record<string, unknown>; include?: string[] };
+    const scaffold = readFileSync(resolve(templateDir, "SCAFFOLD.md"), "utf8");
+
+    expect(packageJson.scripts?.build).toContain("tsconfig.build.json");
+    expect(packageJson.scripts?.lint).toBe("biome check src/");
+    expect(packageJson.scripts?.lint).not.toContain("||");
+    expect(packageJson.devDependencies?.["@biomejs/biome"]).toBe("2.5.1");
+    expect(buildConfig.compilerOptions).toMatchObject({
+      noEmit: false,
+      outDir: "dist",
+      rootDir: "src",
+    });
+    expect(buildConfig.include).toContain("src/**/*.tsx");
+    expect(scaffold).toContain("bun install");
+    expect(scaffold).toContain("bun run build");
+    expect(scaffold).toContain("bundlePath");
+  });
+});

--- a/packages/elizaos/templates/min-plugin/SCAFFOLD.md
+++ b/packages/elizaos/templates/min-plugin/SCAFFOLD.md
@@ -24,15 +24,22 @@ The default `infoProvider` is a smoke implementation. Add real actions, provider
 
 ## 4. Verify before signaling done
 
+Install the scaffold's declared dependencies once:
+
+```bash
+bun install
+```
+
 Run, in this order, from the plugin's package directory:
 
 ```bash
 bun run typecheck
 bun run lint
 bun run test
+bun run build
 ```
 
-All three must exit zero. If one fails, fix it. Do not silence errors with unsafe casts to `any`, `// @ts-ignore`, broad `try/catch`, or `?? defaultValue` patterns that hide missing data.
+All four must exit zero. If the plugin declares a view, the build must produce every declared `bundlePath` or `framePath` under `dist/`; a successful source-only compile is not a loadable view. If one command fails, fix it. Do not silence errors with unsafe casts to `any`, `// @ts-ignore`, broad `try/catch`, or `?? defaultValue` patterns that hide missing data.
 
 ## 5. Signal completion
 

--- a/packages/elizaos/templates/min-plugin/package.json
+++ b/packages/elizaos/templates/min-plugin/package.json
@@ -7,9 +7,9 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc --noCheck -p tsconfig.json",
+    "build": "tsc --noCheck -p tsconfig.build.json",
     "typecheck": "tsc --noEmit -p tsconfig.json",
-    "lint": "bunx @biomejs/biome check src/ || echo '[__PLUGIN_NAME__] lint ok (bunx @biomejs/biome not configured)'",
+    "lint": "biome check src/",
     "test": "vitest run --config ./vitest.config.ts"
   },
   "exports": {
@@ -28,6 +28,7 @@
     "@elizaos/core": "latest"
   },
   "devDependencies": {
+    "@biomejs/biome": "2.5.1",
     "@types/node": "^25.0.6",
     "typescript": "^6.0.3",
     "vitest": "^4.0.0"

--- a/packages/elizaos/templates/min-plugin/tsconfig.build.json
+++ b/packages/elizaos/templates/min-plugin/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": false,
+    "declaration": true,
+    "declarationMap": true,
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["tests", "dist"]
+}

--- a/packages/elizaos/templates/min-plugin/tsconfig.json
+++ b/packages/elizaos/templates/min-plugin/tsconfig.json
@@ -12,12 +12,7 @@
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "noEmit": true,
-    "types": ["node", "vitest/globals"],
-    "paths": {
-      "@elizaos/core": ["../../packages/core/src/index.node.ts"],
-      "@elizaos/logger": ["../../../logger/src/index.ts"],
-      "@elizaos/logger/*": ["../../../logger/src/*"]
-    }
+    "types": ["node", "vitest/globals"]
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"]
 }

--- a/packages/scenario-runner/test/scenarios/live-sub-agent-credential-request.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/live-sub-agent-credential-request.scenario.ts
@@ -467,7 +467,7 @@ function writeLiveAcpTrajectory(input: {
                 : endedAt - input.startedAt,
             model: {
               modelType: "external_acp_child",
-              modelName: "@zed-industries/codex-acp@0.14.0",
+              modelName: "@agentclientprotocol/codex-acp@1.1.2",
               provider: "openai-codex",
               messages: [
                 {

--- a/packages/ui/src/components/views/DynamicViewLoader.test.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.test.tsx
@@ -1,13 +1,13 @@
-// @vitest-environment jsdom
-//
-// DynamicViewLoader: the same-origin bundle-URL gate (the RCE guard), that the
-// test-only import hook is stripped from minified production builds, and the
-// runtime load/cache/error behavior. The origin gate and the production-strip
-// check compile the REAL DynamicViewLoader.tsx source with esbuild rather than
-// asserting against a mock.
+/**
+ * Exercises dynamic view origin enforcement, host externals, and runtime
+ * lifecycle behavior against the real loader implementation.
+ *
+ * @vitest-environment jsdom
+ */
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
+import { ElizaError } from "@elizaos/core";
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import { type ReactElement, useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -72,6 +72,7 @@ describe("isSameOriginBundleUrl (view-bundle origin gate)", () => {
     }
 
     expect(output.code).not.toContain("__ELIZA_DYNAMIC_VIEW_BUNDLE_IMPORT__");
+    expect(output.code).not.toMatch(/import\((["'])@elizaos\/core\1\)/u);
     expect(output.code).toContain("isSameOriginBundleUrl");
   });
 });
@@ -102,6 +103,19 @@ describe("host-external importer resolution (factory hostImport)", () => {
   it("still resolves a framework module from the trunk map", async () => {
     const react = await resolveHostExternal("react");
     expect(typeof react.useState).toBe("function");
+  });
+
+  it("exposes only the browser-safe core view contract", async () => {
+    const core = await resolveHostExternal("@elizaos/core");
+
+    expect(core).toEqual({ ElizaError });
+    expect(core.ElizaError).toBe(ElizaError);
+    expect(Object.isFrozen(core)).toBe(true);
+  });
+
+  it("provides the authenticated fetch helper to plugin view bundles", async () => {
+    const api = await resolveHostExternal("@elizaos/ui/api/csrf-client");
+    expect(typeof api.fetchWithCsrf).toBe("function");
   });
 
   it("throws for an unknown specifier that is neither framework nor registered", async () => {

--- a/packages/ui/src/components/views/DynamicViewLoader.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.tsx
@@ -20,6 +20,7 @@
  */
 
 import {
+  ElizaError,
   type ResolvedSurfaceManifest,
   resolveSurfaceManifest,
   type SurfaceManifest,
@@ -362,6 +363,18 @@ function importHostExternal(
   >;
 }
 
+// View bundles execute inside the host realm, so core exports must cross an
+// explicit browser-safe boundary instead of retaining the runtime namespace in
+// the initial app bundle. Additions belong here only when a real view consumes
+// them and their browser behavior is covered by the loader contract tests.
+const CORE_VIEW_COMPAT = Object.freeze({
+  ElizaError,
+}) satisfies Readonly<Record<"ElizaError", typeof ElizaError>>;
+
+async function importCoreViewCompat(): Promise<Record<string, unknown>> {
+  return CORE_VIEW_COMPAT;
+}
+
 const APP_CORE_VIEW_COMPAT: Record<string, unknown> = {
   client,
   resolveAppBranding,
@@ -513,8 +526,8 @@ async function importUiBridgeCompat(): Promise<Record<string, unknown>> {
 }
 
 // Framework + host modules the shell always provides to every view bundle:
-// react, three, `@elizaos/ui/*`, the `@elizaos/app-core` view compat surface,
-// `@elizaos/shared`, and the native capacitor bridges. This map is
+// react, three, `@elizaos/core`, `@elizaos/ui/*`, the `@elizaos/app-core` view
+// compat surface, `@elizaos/shared`, and the native capacitor bridges. This map is
 // FRAMEWORK-ONLY — it must never list a plugin-specific specifier. A plugin (or
 // a build-variant entrypoint) contributes its own specifiers through
 // `registerHostExternalImporter` so adding a host-external plugin never edits
@@ -523,6 +536,7 @@ const HOST_EXTERNAL_IMPORTERS: Record<string, HostExternalImporter> = {
   "@elizaos/app-core": importAppCoreViewCompat,
   "@elizaos/app-core/browser": importAppCoreViewCompat,
   "@elizaos/app-core/ui-compat": importAppCoreViewCompat,
+  "@elizaos/core": importCoreViewCompat,
   "@elizaos/capacitor-contacts": () =>
     importHostExternal("@elizaos/capacitor-contacts"),
   "@elizaos/capacitor-messages": () =>
@@ -538,6 +552,7 @@ const HOST_EXTERNAL_IMPORTERS: Record<string, HostExternalImporter> = {
   "@elizaos/ui/agent-surface": async () => AgentSurfaceHost,
   "@elizaos/ui/app-navigate-view": importUiAppNavigateViewCompat,
   "@elizaos/ui/api": () => import("../../api/index.ts"),
+  "@elizaos/ui/api/csrf-client": () => import("../../api/csrf-client.ts"),
   "@elizaos/ui/bridge": importUiBridgeCompat,
   "@elizaos/ui/components": importUiComponentsCompat,
   "@elizaos/ui/config": () => import("../../config/index.ts"),

--- a/packages/ui/src/hooks/useAvailableViews.test.tsx
+++ b/packages/ui/src/hooks/useAvailableViews.test.tsx
@@ -1,7 +1,12 @@
-// @vitest-environment jsdom
+/**
+ * Exercises the shared view catalog's fetch, refresh, error, and builtin-merge behavior.
+ * @vitest-environment jsdom
+ */
 
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { emitViewEvent } from "../views/view-event-bus";
+import { VIEW_EVENTS } from "../views/view-event-types";
 import { __resetResourceCache } from "./resource-cache";
 import {
   useAvailableViews,
@@ -107,7 +112,7 @@ describe("useAvailableViews", () => {
     expect(fetchWithCsrf).not.toHaveBeenCalled();
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(30_000);
+      await vi.advanceTimersByTimeAsync(5_000);
     });
 
     expect(fetchWithCsrf).not.toHaveBeenCalled();
@@ -139,6 +144,39 @@ describe("useAvailableViews", () => {
       headers: { "X-Eliza-Platform": "desktop" },
     });
     expect(fetchWithCsrf).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts the current view-capability transport contract", async () => {
+    fetchWithCsrf.mockResolvedValueOnce(
+      response(200, {
+        views: [
+          view("birdclaw", {
+            capabilities: [
+              {
+                id: "get-state",
+                description: "Read the mounted view state.",
+              },
+            ],
+          }),
+        ],
+      }),
+    );
+
+    const { result } = renderHook(() => useAvailableViews());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.views).toEqual([
+      expect.objectContaining({
+        id: "birdclaw",
+        capabilities: [
+          {
+            id: "get-state",
+            description: "Read the mounted view state.",
+          },
+        ],
+      }),
+    ]);
   });
 
   it("strips views declaring `nativeOs: true` off the AOSP fork", async () => {
@@ -239,14 +277,17 @@ describe("useAvailableViews", () => {
     ]);
   });
 
-  it("treats malformed payloads as empty lists", async () => {
+  it("surfaces malformed payloads instead of rendering a healthy empty list", async () => {
     fetchWithCsrf.mockResolvedValueOnce(response(200, { ok: true }));
 
     const { result } = renderHook(() => useAvailableViews());
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     expect(result.current.views).toEqual([]);
-    expect(result.current.error).toBeNull();
+    expect(result.current.error).toMatchObject({
+      name: "ElizaError",
+      code: "VIEW_REGISTRY_RESPONSE_INVALID",
+    });
   });
 
   it("adds built-in shell entries only for routable consumers", async () => {
@@ -353,7 +394,7 @@ describe("useAvailableViews", () => {
     expect(result.current.views[0]?.id).toBe("second");
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(30_000);
+      await vi.advanceTimersByTimeAsync(5_000);
     });
     await flushHookEffects();
     expect(result.current.views[0]?.id).toBe("third");
@@ -361,16 +402,66 @@ describe("useAvailableViews", () => {
 
     unmount();
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(60_000);
+      await vi.advanceTimersByTimeAsync(10_000);
     });
     expect(fetchWithCsrf).toHaveBeenCalledTimes(3);
+  });
+
+  it("refreshes the shared registry immediately after a plugin create/edit reload", async () => {
+    fetchWithCsrf
+      .mockResolvedValueOnce(
+        response(200, {
+          views: [
+            view("notes", {
+              bundleUrl: "/api/views/notes/bundle.js?v=before",
+            }),
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(
+        response(200, {
+          views: [
+            view("notes", {
+              bundleUrl: "/api/views/notes/bundle.js?v=after",
+            }),
+            view("new-dashboard"),
+          ],
+        }),
+      );
+
+    // App mounts one consumer for routing and another for desktop tabs. The
+    // plugin event must refresh their shared cache once, not race two reads.
+    const router = renderHook(() => useAvailableViews());
+    const tabs = renderHook(() => useAvailableViews());
+    await waitFor(() => expect(router.result.current.loading).toBe(false));
+    expect(fetchWithCsrf).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      emitViewEvent(
+        VIEW_EVENTS.PLUGIN_RELOADED,
+        { pluginName: "test-plugin" },
+        "agent",
+      );
+    });
+
+    await waitFor(() =>
+      expect(router.result.current.views).toEqual([
+        expect.objectContaining({
+          id: "notes",
+          bundleUrl: "/api/views/notes/bundle.js?v=after",
+        }),
+        expect.objectContaining({ id: "new-dashboard" }),
+      ]),
+    );
+    expect(tabs.result.current.views).toEqual(router.result.current.views);
+    expect(fetchWithCsrf).toHaveBeenCalledTimes(2);
   });
 
   it("runs only one background poll when the hook is mounted twice", async () => {
     vi.useFakeTimers();
     // Two simultaneous mounts (App.tsx mounts the hook in ViewRouter and again
     // in the shell). They share one cache key, so they must share one poll timer
-    // — a single 30s tick should issue exactly one registry fetch, not two.
+    // — a single 5s tick should issue exactly one registry fetch, not two.
     fetchWithCsrf.mockResolvedValue(response(200, { views: [] }));
 
     const first = renderHook(() => useAvailableViews());
@@ -381,7 +472,7 @@ describe("useAvailableViews", () => {
     expect(fetchWithCsrf).toHaveBeenCalledTimes(1);
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(30_000);
+      await vi.advanceTimersByTimeAsync(5_000);
     });
     await flushHookEffects();
 
@@ -391,7 +482,7 @@ describe("useAvailableViews", () => {
     // With one mount unmounted, the surviving mount keeps the single timer alive.
     first.unmount();
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(30_000);
+      await vi.advanceTimersByTimeAsync(5_000);
     });
     await flushHookEffects();
     expect(fetchWithCsrf).toHaveBeenCalledTimes(3);
@@ -399,7 +490,7 @@ describe("useAvailableViews", () => {
     // Last unmount tears the timer down — no further polling.
     second.unmount();
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(60_000);
+      await vi.advanceTimersByTimeAsync(10_000);
     });
     expect(fetchWithCsrf).toHaveBeenCalledTimes(3);
   });
@@ -417,7 +508,7 @@ describe("useAvailableViews", () => {
     expect(fetchWithCsrf).toHaveBeenCalledTimes(1);
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(30_000);
+      await vi.advanceTimersByTimeAsync(5_000);
     });
     await flushHookEffects();
     expect(fetchWithCsrf).toHaveBeenCalledTimes(1);

--- a/packages/ui/src/hooks/useAvailableViews.ts
+++ b/packages/ui/src/hooks/useAvailableViews.ts
@@ -2,15 +2,16 @@
  * Fetches the available views from `GET /api/views` — the primary data source
  * for Launcher, returning the `ViewRegistryEntry` list.
  *
- * Polls every 30s (the endpoint is a cheap in-memory registry list). An
- * unreachable endpoint degrades to an empty list so Launcher still renders.
+ * Polls every 5s (the endpoint is a cheap in-memory registry list). A missing
+ * registry is unavailable; transport and payload failures remain visible errors.
  */
 
-import type {
-  AppShellBackgroundPolicy,
-  SurfaceManifest,
-  ViewHeaderPolicy,
-  ViewKind,
+import {
+  type AppShellBackgroundPolicy,
+  ElizaError,
+  type SurfaceManifest,
+  type ViewHeaderPolicy,
+  type ViewKind,
 } from "@elizaos/core";
 import { useEffect, useMemo, useSyncExternalStore } from "react";
 import { client } from "../api";
@@ -32,6 +33,8 @@ import { getFrontendPlatform } from "../platform/platform-guards";
 import { useAppSelector } from "../state/app-store";
 import type { StartupPhaseValue } from "../state/startup-coordinator";
 import { isShellPaintable } from "../state/startup-coordinator";
+import { onViewEvent } from "../views/view-event-bus";
+import { VIEW_EVENTS } from "../views/view-event-types";
 import { startPolling } from "./resource-cache";
 import { useCachedResource } from "./useCachedResource";
 
@@ -150,7 +153,113 @@ interface UseAvailableViewsOptions {
   networkEnabled?: boolean;
 }
 
-const POLL_INTERVAL_MS = 30_000;
+// WebSocket-free Cloud/mobile runtimes cannot receive plugin_reloaded. Keep a
+// short visible-tab poll so a verified create/edit becomes routable promptly on
+// those transports; resource-cache owns one timer regardless of hook mounts.
+const POLL_INTERVAL_MS = 5_000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isOptionalString(value: unknown): boolean {
+  return value === undefined || typeof value === "string";
+}
+
+function isOptionalBoolean(value: unknown): boolean {
+  return value === undefined || typeof value === "boolean";
+}
+
+function isSurfaceManifest(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  return (
+    (value.background === undefined ||
+      value.background === "opaque" ||
+      value.background === "shared") &&
+    (value.header === undefined ||
+      value.header === "normal" ||
+      value.header === "fullscreen" ||
+      value.header === "modal" ||
+      value.header === "immersive") &&
+    (value.isolation === undefined ||
+      value.isolation === "in-process" ||
+      value.isolation === "sandboxed-iframe" ||
+      value.isolation === "native-webview" ||
+      value.isolation === "immersive") &&
+    (value.lifecycle === undefined ||
+      value.lifecycle === "ephemeral" ||
+      value.lifecycle === "retained") &&
+    (value.capabilities === undefined ||
+      (Array.isArray(value.capabilities) &&
+        value.capabilities.every(
+          (capability) =>
+            capability === "wallpaper" ||
+            capability === "background:apply" ||
+            capability === "navigate" ||
+            capability === "storage" ||
+            capability === "agent-surface",
+        )))
+  );
+}
+
+function isViewRegistryEntry(value: unknown): value is ViewRegistryEntry {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.id === "string" &&
+    value.id.trim().length > 0 &&
+    typeof value.label === "string" &&
+    value.label.trim().length > 0 &&
+    typeof value.available === "boolean" &&
+    typeof value.pluginName === "string" &&
+    value.pluginName.trim().length > 0 &&
+    (value.viewType === undefined ||
+      value.viewType === "gui" ||
+      value.viewType === "tui" ||
+      value.viewType === "xr") &&
+    isOptionalString(value.description) &&
+    isOptionalString(value.icon) &&
+    isOptionalString(value.path) &&
+    isOptionalString(value.bundleUrl) &&
+    isOptionalString(value.frameUrl) &&
+    isOptionalString(value.componentExport) &&
+    isOptionalString(value.heroImageUrl) &&
+    isOptionalString(value.group) &&
+    isOptionalBoolean(value.hasHeroImage) &&
+    isOptionalBoolean(value.developerOnly) &&
+    isOptionalBoolean(value.visibleInManager) &&
+    isOptionalBoolean(value.pinnable) &&
+    isOptionalBoolean(value.builtin) &&
+    isOptionalBoolean(value.desktopTabEnabled) &&
+    isOptionalBoolean(value.nativeOs) &&
+    (value.order === undefined ||
+      (typeof value.order === "number" && Number.isFinite(value.order))) &&
+    (value.tags === undefined ||
+      (Array.isArray(value.tags) &&
+        value.tags.every((tag) => typeof tag === "string"))) &&
+    (value.capabilities === undefined ||
+      (Array.isArray(value.capabilities) &&
+        value.capabilities.every(
+          (capability) =>
+            isRecord(capability) &&
+            typeof capability.id === "string" &&
+            typeof capability.description === "string",
+        ))) &&
+    (value.backgroundPolicy === undefined ||
+      value.backgroundPolicy === "opaque" ||
+      value.backgroundPolicy === "shared") &&
+    (value.headerPolicy === undefined ||
+      value.headerPolicy === "normal" ||
+      value.headerPolicy === "fullscreen" ||
+      value.headerPolicy === "modal" ||
+      value.headerPolicy === "immersive") &&
+    (value.viewKind === undefined ||
+      value.viewKind === "system" ||
+      value.viewKind === "release" ||
+      value.viewKind === "developer" ||
+      value.viewKind === "preview") &&
+    (value.surface === undefined || isSurfaceManifest(value.surface))
+  );
+}
 
 async function fetchViewList(): Promise<ViewRegistryEntry[]> {
   const platform = getFrontendPlatform();
@@ -158,29 +267,47 @@ async function fetchViewList(): Promise<ViewRegistryEntry[]> {
     headers: { "X-Eliza-Platform": platform },
   });
   if (!response.ok) {
-    throw new Error(`GET /api/views returned HTTP ${response.status}`);
+    throw new ElizaError(`GET /api/views returned HTTP ${response.status}`, {
+      code: "VIEW_REGISTRY_HTTP_FAILED",
+      context: { status: response.status },
+    });
   }
-  const data = (await response.json()) as unknown;
-  if (!data || typeof data !== "object" || !("views" in data)) {
-    return [];
+  let data: unknown;
+  try {
+    data = await response.json();
+  } catch (cause) {
+    // error-policy:J2 preserve the parser failure while identifying the registry boundary.
+    throw new ElizaError("GET /api/views returned malformed JSON", {
+      code: "VIEW_REGISTRY_RESPONSE_INVALID",
+      cause,
+      context: { status: response.status },
+    });
   }
-  const { views } = data as { views: unknown };
-  if (!Array.isArray(views)) return [];
-  return views as ViewRegistryEntry[];
+  if (!isRecord(data) || !Array.isArray(data.views)) {
+    throw new ElizaError("GET /api/views response must contain a views array", {
+      code: "VIEW_REGISTRY_RESPONSE_INVALID",
+      context: { status: response.status },
+    });
+  }
+  return data.views.map((view, index) => {
+    if (!isViewRegistryEntry(view)) {
+      throw new ElizaError(`GET /api/views entry ${index} is invalid`, {
+        code: "VIEW_REGISTRY_RESPONSE_INVALID",
+        context: { status: response.status, index },
+      });
+    }
+    return view;
+  });
 }
 
 /**
  * One-shot fetch of the `/api/views` registry for non-React consumers (the apps
  * catalog loaders) that need to overlay live plugin ViewDeclaration metadata
- * onto the internal-tool catalog. Returns an empty list if the endpoint is
- * unavailable — callers fall back to the static internal-tool declarations.
+ * onto the internal-tool catalog. Expected registry absence returns an empty
+ * list; other failures remain observable to each caller's UI boundary.
  */
 export async function fetchAvailableViews(): Promise<ViewRegistryEntry[]> {
-  try {
-    return await fetchViews();
-  } catch {
-    return [];
-  }
+  return fetchViews();
 }
 
 async function fetchViews(): Promise<ViewRegistryEntry[]> {
@@ -188,7 +315,15 @@ async function fetchViews(): Promise<ViewRegistryEntry[]> {
   try {
     guiViews = await fetchViewList();
   } catch (err) {
-    if (String(err).includes("404")) return [];
+    // error-policy:J4 a missing registry means this runtime does not expose
+    // plugin views; every other transport or payload failure reaches the UI.
+    if (
+      err instanceof ElizaError &&
+      err.code === "VIEW_REGISTRY_HTTP_FAILED" &&
+      err.context?.status === 404
+    ) {
+      return [];
+    }
     throw err;
   }
   const merged = new Map<string, ViewRegistryEntry>();
@@ -199,6 +334,52 @@ async function fetchViews(): Promise<ViewRegistryEntry[]> {
 }
 
 const VIEWS_CACHE_KEY = "views:available";
+
+// App mounts this hook in both the router and the desktop-tab catalog. A plugin
+// reload reaches both subscribers synchronously, but the registry must issue
+// one forced refresh: two forced reads can race and make the older response win
+// the user's first navigation after a create/edit operation.
+const pluginReloadRefreshers = new Set<() => Promise<void>>();
+let stopPluginReloadSubscription: (() => void) | null = null;
+let pluginReloadRefresh: Promise<void> | null = null;
+let pluginReloadRefreshQueued = false;
+
+function runPluginReloadRefresh(): void {
+  if (pluginReloadRefresh) {
+    pluginReloadRefreshQueued = true;
+    return;
+  }
+  const refresh = pluginReloadRefreshers.values().next().value;
+  if (!refresh) return;
+  pluginReloadRefreshQueued = false;
+  const pending = refresh().finally(() => {
+    if (pluginReloadRefresh !== pending) return;
+    pluginReloadRefresh = null;
+    // A second plugin can finish loading while the first registry read is in
+    // flight. Preserve one trailing read so that event cannot disappear behind
+    // the first request and leave the new view stale until the polling interval.
+    if (pluginReloadRefreshQueued) runPluginReloadRefresh();
+  });
+  pluginReloadRefresh = pending;
+}
+
+function subscribePluginReloadRefresh(
+  refresh: () => Promise<void>,
+): () => void {
+  pluginReloadRefreshers.add(refresh);
+  if (!stopPluginReloadSubscription) {
+    stopPluginReloadSubscription = onViewEvent(
+      VIEW_EVENTS.PLUGIN_RELOADED,
+      runPluginReloadRefresh,
+    );
+  }
+  return () => {
+    pluginReloadRefreshers.delete(refresh);
+    if (pluginReloadRefreshers.size > 0) return;
+    stopPluginReloadSubscription?.();
+    stopPluginReloadSubscription = null;
+  };
+}
 
 const EMPTY_VIEWS: ViewRegistryEntry[] = [];
 
@@ -415,6 +596,10 @@ export function useAvailableViews(
     if (!networkEnabled) return;
     return startPolling(VIEWS_CACHE_KEY, fetchViews, POLL_INTERVAL_MS);
   }, [networkEnabled]);
+  useEffect(() => {
+    if (!networkEnabled) return;
+    return subscribePluginReloadRefresh(refetch);
+  }, [networkEnabled, refetch]);
 
   // In-process plugin views (registered via registerAppShellPage) are merged in
   // so they appear in the manager even when the agent route filtered them out

--- a/packages/ui/src/state/startup-phase-hydrate.initial-tab.test.ts
+++ b/packages/ui/src/state/startup-phase-hydrate.initial-tab.test.ts
@@ -78,6 +78,7 @@ describe("runHydrating initial tab routing", () => {
     expect(deps.setTabRaw).not.toHaveBeenCalledWith("character-select");
     expect(deps.initialTabSetRef.current).toBe(true);
     expect(events).toContainEqual({ type: "HYDRATION_COMPLETE" });
+    expect(events.at(-1)?.type).toBe("HYDRATION_COMPLETE");
   });
 
   it("a deep-linked URL wins: no root landing, the named tab is applied", async () => {

--- a/packages/ui/src/state/startup-phase-hydrate.navigate-frame.test.ts
+++ b/packages/ui/src/state/startup-phase-hydrate.navigate-frame.test.ts
@@ -31,10 +31,15 @@ const clientMock = vi.hoisted(() => {
     string,
     Set<(data: Record<string, unknown>) => void>
   >();
+  const recoveredViews: string[] = [];
   return {
     connectWs: vi.fn(),
     disconnectWs: vi.fn(),
     getCodingAgentStatus: vi.fn(async () => ({ tasks: [] })),
+    recoverMissedCurrentView: vi.fn(async () => {
+      recoveredViews.push("current");
+    }),
+    recoveredViews,
     onWsEvent: vi.fn(
       (type: string, handler: (data: Record<string, unknown>) => void) => {
         if (!wsHandlers.has(type)) wsHandlers.set(type, new Set());
@@ -62,6 +67,9 @@ const clientMock = vi.hoisted(() => {
 });
 
 vi.mock("../api", () => ({ client: clientMock }));
+vi.mock("../view-action-handoff", () => ({
+  recoverMissedCurrentView: clientMock.recoverMissedCurrentView,
+}));
 vi.mock("../components/views/view-interact-registry", () => ({
   dispatchViewInteract: vi.fn(async () => {}),
 }));
@@ -101,6 +109,8 @@ describe("agent view-switch raw WS frame to DOM navigate event", () => {
     clientMock.connectWs.mockClear();
     clientMock.disconnectWs.mockClear();
     clientMock.onWsEvent.mockClear();
+    clientMock.recoverMissedCurrentView.mockClear();
+    clientMock.recoveredViews.length = 0;
     navHandler = vi.fn();
     window.addEventListener(NAVIGATE_VIEW_EVENT, navHandler);
     cleanup = bindReadyPhase({ current: makeDeps() });
@@ -114,6 +124,19 @@ describe("agent view-switch raw WS frame to DOM navigate event", () => {
   it("registers a shell:navigate:view handler on ready-phase start", () => {
     expect(clientMock.wsHandlers.has(SHELL_NAVIGATE_VIEW_WS_EVENT)).toBe(true);
     teardown();
+  });
+
+  it("reconciles the current view after reconnect and unbinds that recovery", async () => {
+    clientMock.deliverFrame(JSON.stringify({ type: "ws-reconnected" }));
+    await vi.waitFor(() => {
+      expect(clientMock.recoveredViews).toEqual(["current"]);
+    });
+
+    cleanup();
+    clientMock.deliverFrame(JSON.stringify({ type: "ws-reconnected" }));
+    await Promise.resolve();
+    expect(clientMock.recoveredViews).toEqual(["current"]);
+    window.removeEventListener(NAVIGATE_VIEW_EVENT, navHandler);
   });
 
   it("normalizes a full backend pin-tab frame carrying the type discriminator", () => {

--- a/packages/ui/src/state/startup-phase-hydrate.switch.test.ts
+++ b/packages/ui/src/state/startup-phase-hydrate.switch.test.ts
@@ -112,6 +112,7 @@ describe("bindReadyPhase shell:switch-agent handler", () => {
     );
 
     cleanup();
+    expect(clientMock.handlers.has("shell:switch-agent")).toBe(false);
   });
 
   it("applies a trusted local profile and reports success", () => {

--- a/packages/ui/src/state/startup-phase-hydrate.ts
+++ b/packages/ui/src/state/startup-phase-hydrate.ts
@@ -1,8 +1,7 @@
 /**
- * startup-phase-hydrate.ts
- *
- * Side-effect logic for the "hydrating" startup phase and the persistent
- * "ready" phase (WebSocket bindings, nav listener).
+ * Coordinates side effects for the hydrating and ready startup phases.
+ * It binds persistent transport, navigation, wallet, and recovery listeners
+ * after the shell can paint, then releases them when the phase is torn down.
  */
 
 import { MESSAGE_SOURCE_CLIENT_CHAT } from "@elizaos/core";
@@ -37,6 +36,7 @@ import {
   tabFromPath,
 } from "../navigation";
 import { isTransientOptionalFetchFailure } from "../utils";
+import { recoverMissedCurrentView } from "../view-action-handoff";
 import { emitViewEvent } from "../views/view-event-bus";
 import type { ActionTone } from "./action-notice";
 import {
@@ -388,6 +388,11 @@ export function bindReadyPhase(
       hydratePty();
       void depsRef.current?.loadWalletConfig();
       void depsRef.current?.pollCloudCredits();
+      void recoverMissedCurrentView().catch((error) => {
+        // error-policy:J5 the structured warning observes this fire-and-forget
+        // recovery rejection; the next lifecycle event retries it.
+        logger.warn({ error }, "[startup] current view recovery failed");
+      });
     }),
   );
   const unbindSysWarn = client.onWsEvent(

--- a/packages/ui/src/state/startup-phase-hydrate.view-interact.test.ts
+++ b/packages/ui/src/state/startup-phase-hydrate.view-interact.test.ts
@@ -129,6 +129,7 @@ describe("bindReadyPhase view interaction bridge", () => {
 
     cleanup();
     expect(clientMock.disconnectWs).toHaveBeenCalled();
+    expect(clientMock.handlers.has("view:interact")).toBe(false);
   }, 60_000);
 
   it("routes future headset view:interact websocket events through the view dispatcher", async () => {

--- a/packages/ui/src/state/startup-phase-hydrate.voice-control.test.ts
+++ b/packages/ui/src/state/startup-phase-hydrate.voice-control.test.ts
@@ -92,6 +92,7 @@ describe("bindReadyPhase voice-control agent-event bridge", () => {
     expect(event.detail).toEqual({ command: "start" });
 
     teardown(cleanup);
+    expect(clientMock.handlers.has("agent_event")).toBe(false);
   });
 
   it("re-dispatches a STOP_TRANSCRIPTION voice-control agent_event to the shell", () => {

--- a/packages/ui/src/state/useAppLifecycleEvents.test.tsx
+++ b/packages/ui/src/state/useAppLifecycleEvents.test.tsx
@@ -1,10 +1,20 @@
-// @vitest-environment jsdom
+/**
+ * Exercises pause/resume conversation synchronization and missed-view recovery
+ * against real hook timing with deterministic client boundaries.
+ *
+ * @vitest-environment jsdom
+ */
 
 import { cleanup, renderHook } from "@testing-library/react";
 import type { MutableRefObject } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ConversationMessage } from "../api";
-import { APP_PAUSE_EVENT, APP_RESUME_EVENT } from "../events";
+import {
+  APP_PAUSE_EVENT,
+  APP_RESUME_EVENT,
+  NAVIGATE_VIEW_EVENT,
+  type NavigateViewDetail,
+} from "../events";
 import type { LoadConversationMessagesResult } from "./internal";
 import {
   RESUME_DEBOUNCE_MS,
@@ -31,11 +41,27 @@ const mocks = vi.hoisted(() => ({
     fetch: vi.fn(async () => ({ ok: true })),
     getBaseUrl: vi.fn(() => "http://127.0.0.1:31337"),
   },
+  fetchCurrentView: vi.fn(
+    async () =>
+      new Response(JSON.stringify({ currentView: null, justSwitched: false }), {
+        status: 200,
+      }),
+  ),
 }));
 
 vi.mock("../api", () => ({
   client: mocks.client,
 }));
+
+vi.mock("../api/csrf-client", () => ({
+  fetchWithCsrf: mocks.fetchCurrentView,
+}));
+
+const observedNavigations: NavigateViewDetail[] = [];
+
+function recordNavigation(event: Event): void {
+  observedNavigations.push((event as CustomEvent<NavigateViewDetail>).detail);
+}
 
 function makeMessages(...ms: ConversationMessage[]): ConversationMessage[] {
   return ms;
@@ -106,6 +132,9 @@ describe("useAppLifecycleEvents", () => {
     mocks.client.resetConnection.mockClear();
     mocks.client.fetch.mockClear();
     mocks.client.getBaseUrl.mockReturnValue("http://127.0.0.1:31337");
+    mocks.fetchCurrentView.mockClear();
+    observedNavigations.length = 0;
+    window.addEventListener(NAVIGATE_VIEW_EVENT, recordNavigation);
     window.localStorage.clear();
   });
 
@@ -114,11 +143,27 @@ describe("useAppLifecycleEvents", () => {
     // pending debounce timer) so a leftover timer from this test can't fire
     // into the next one's freshly-cleared mocks.
     cleanup();
+    window.removeEventListener(NAVIGATE_VIEW_EVENT, recordNavigation);
     vi.clearAllTimers();
     vi.useRealTimers();
   });
 
-  it("on resume: forces WS reconnect + refetches the active conversation tail (D2)", () => {
+  it("on resume: reconnects, refetches the tail, and recovers missed navigation (D2)", async () => {
+    mocks.fetchCurrentView.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          currentView: {
+            viewId: "calendar",
+            viewPath: "/calendar",
+            viewLabel: "Calendar",
+            viewType: "gui",
+            source: "agent",
+          },
+          justSwitched: true,
+        }),
+        { status: 200 },
+      ),
+    );
     const { loadConversationMessages } = setup({ activeId: "conv-42" });
 
     dispatchResume();
@@ -126,11 +171,19 @@ describe("useAppLifecycleEvents", () => {
     expect(mocks.client.resetConnection).not.toHaveBeenCalled();
     expect(loadConversationMessages).not.toHaveBeenCalled();
 
-    vi.advanceTimersByTime(RESUME_DEBOUNCE_MS);
+    await vi.advanceTimersByTimeAsync(RESUME_DEBOUNCE_MS);
 
     expect(mocks.client.resetConnection).toHaveBeenCalledTimes(1);
     expect(loadConversationMessages).toHaveBeenCalledTimes(1);
     expect(loadConversationMessages).toHaveBeenCalledWith("conv-42");
+    expect(observedNavigations).toEqual([
+      {
+        viewId: "calendar",
+        viewPath: "/calendar",
+        viewLabel: "Calendar",
+        viewType: "gui",
+      },
+    ]);
   });
 
   it("debounces rapid fg/bg flips into a single reconnect + refetch", () => {
@@ -168,6 +221,7 @@ describe("useAppLifecycleEvents", () => {
 
     expect(mocks.client.resetConnection).not.toHaveBeenCalled();
     expect(loadConversationMessages).not.toHaveBeenCalled();
+    expect(observedNavigations).toEqual([]);
   });
 
   it("coalesces a visibilitychange resume + bfcache pageshow in the same tick into one run", () => {

--- a/packages/ui/src/state/useAppLifecycleEvents.ts
+++ b/packages/ui/src/state/useAppLifecycleEvents.ts
@@ -34,6 +34,7 @@ import { type ConversationMessage, client } from "../api";
 import { APP_PAUSE_EVENT, APP_RESUME_EVENT } from "../events";
 import { shellLocalStorage } from "../surface-realm-channel";
 import { isElizaCloudControlPlaneAgentlessBase } from "../utils/cloud-agent-base";
+import { recoverMissedCurrentView } from "../view-action-handoff";
 import type { LoadConversationMessagesResult } from "./internal";
 
 /** Storage key for the last-known active conversation id. */
@@ -207,6 +208,12 @@ export function useAppLifecycleEvents({
           // retry path for the websocket.
           logger.warn({ error }, "[AppLifecycle] resume reconnect failed");
         }
+
+        void recoverMissedCurrentView().catch((error) => {
+          // error-policy:J5 the structured warning observes this fire-and-forget
+          // recovery rejection; reconnect or the next resume retries it.
+          logger.warn({ error }, "[AppLifecycle] current view recovery failed");
+        });
 
         // Refetch the active conversation tail so agent messages emitted while
         // backgrounded appear. Dedicated-agent REST mode has no websocket

--- a/packages/ui/src/state/useChatSend.test.tsx
+++ b/packages/ui/src/state/useChatSend.test.tsx
@@ -1,11 +1,11 @@
-// @vitest-environment jsdom
-
 /**
  * Core coverage of the chat send lifecycle (`useChatSend`): Stop/abort
  * handling, 404 conversation-gone recovery, always-streaming delivery,
  * transient send-failure notices, and the cloud shared→dedicated handoff queue.
  * Real hook under jsdom with a fake API client — deterministic, no live model
  * or network.
+ *
+ * @vitest-environment jsdom
  */
 import { act, renderHook } from "@testing-library/react";
 import type { MutableRefObject } from "react";
@@ -22,7 +22,11 @@ import {
   __resetNetworkStatusForTests,
   StreamGenerationError,
 } from "../api/client-base";
-import { APP_RESUME_EVENT, CLOUD_HANDOFF_PHASE_EVENT } from "../events";
+import {
+  APP_RESUME_EVENT,
+  CLOUD_HANDOFF_PHASE_EVENT,
+  NAVIGATE_VIEW_EVENT,
+} from "../events";
 import type { LoadConversationMessagesResult } from "./internal";
 import {
   buildSendFailureNotice,
@@ -633,6 +637,118 @@ describe("useChatSend always streams (#9174)", () => {
     expect(deps.setChatFirstTokenReceived).toHaveBeenCalledWith(true);
     // The streaming callback actually received incremental tokens.
     expect(tokens).toEqual([["Hello", " world"]]);
+  });
+});
+
+describe("useChatSend VIEWS action handoff", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.client.getBaseUrl.mockReturnValue("");
+    mocks.client.renameConversation.mockResolvedValue(undefined);
+    window.history.replaceState(null, "", "/chat");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("opens the canonical current view from a completed stream without a WebSocket frame", async () => {
+    mocks.client.sendConversationMessageStream.mockResolvedValue({
+      text: "Opening Calendar.",
+      completed: true,
+      actionResults: [
+        {
+          actionName: "VIEWS",
+          success: true,
+          values: { mode: "show", viewId: "calendar" },
+        },
+      ],
+    });
+    const fetchMock = vi.fn(async () =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            currentView: {
+              viewId: "calendar",
+              viewPath: "/calendar",
+              viewLabel: "Calendar",
+              viewType: "gui",
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const navigations: CustomEvent[] = [];
+    const onNavigate = (event: Event) => navigations.push(event as CustomEvent);
+    window.addEventListener(NAVIGATE_VIEW_EVENT, onNavigate);
+    const deps = makeDeps({
+      activeConversationId: "conv-1",
+      conversations: [conversation("conv-1", "room-1")],
+    });
+    const { result } = renderHook(() => useChatSend(deps));
+
+    await act(async () => {
+      await result.current.sendChatText("open calendar", {
+        conversationId: "conv-1",
+      });
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/views/current",
+      expect.any(Object),
+    );
+    expect(navigations).toHaveLength(1);
+    expect(navigations[0]?.detail).toEqual({
+      viewId: "calendar",
+      viewPath: "/calendar",
+      viewLabel: "Calendar",
+      viewType: "gui",
+    });
+    expect(deps.setActionNotice).not.toHaveBeenCalled();
+    window.removeEventListener(NAVIGATE_VIEW_EVENT, onNavigate);
+  });
+
+  it("preserves the successful reply and surfaces a distinct current-view fetch failure", async () => {
+    mocks.client.sendConversationMessageStream.mockResolvedValue({
+      text: "Opening Calendar.",
+      completed: true,
+      actionResults: [
+        {
+          actionName: "VIEWS",
+          success: true,
+          values: { mode: "show", viewId: "calendar" },
+        },
+      ],
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("offline", { status: 503 })),
+    );
+    const deps = makeDeps({
+      activeConversationId: "conv-1",
+      conversations: [conversation("conv-1", "room-1")],
+    });
+    const { result } = renderHook(() => useChatSend(deps));
+
+    await act(async () => {
+      await result.current.sendChatText("open calendar", {
+        conversationId: "conv-1",
+      });
+    });
+
+    expect(deps.setActionNotice).toHaveBeenCalledWith(
+      expect.stringMatching(/couldn't open/i),
+      "error",
+      8_000,
+    );
+    expect(
+      deps.conversationMessagesRef.current.some(
+        (message) =>
+          message.role === "assistant" && message.text === "Opening Calendar.",
+      ),
+    ).toBe(true);
   });
 });
 

--- a/packages/ui/src/state/useChatSend.ts
+++ b/packages/ui/src/state/useChatSend.ts
@@ -11,6 +11,7 @@ import { asRecord } from "@elizaos/shared";
 import { type MutableRefObject, useCallback, useEffect, useRef } from "react";
 import type { Conversation, CustomActionDef } from "../api";
 import {
+  type ChatActionResultSummary,
   type ChatToolCallEvent,
   type ChatTurnStatus,
   type CodingAgentSession,
@@ -38,6 +39,10 @@ import {
   type CloudHandoffPhaseDetail,
 } from "../events";
 import { getWindowNavigationPath, type Tab } from "../navigation";
+import {
+  dispatchViewActionHandoff,
+  findViewActionHandoff,
+} from "../view-action-handoff";
 import type { ChatReplyTarget } from "./ChatComposerContext.hooks";
 import { clearChatDraft } from "./ChatComposerContext.hooks";
 import { isConversationRecord } from "./chat-conversation-guards";
@@ -55,6 +60,26 @@ import {
 // ── Types ────────────────────────────────────────────────────────────
 
 const CONTEXT_ROUTING_METADATA_KEY = "__responseContext";
+
+async function handoffCompletedViewAction(
+  actionResults: ChatActionResultSummary[] | undefined,
+  showFailure: (message: string) => void,
+): Promise<void> {
+  if (!findViewActionHandoff(actionResults)) return;
+  try {
+    await dispatchViewActionHandoff(actionResults);
+  } catch (err) {
+    // error-policy:J4 the chat turn succeeded, so preserve it while surfacing a
+    // distinct navigation failure instead of fabricating an opened view.
+    logger.warn(
+      { err },
+      "[useChatSend] completed VIEWS action could not reach the renderer",
+    );
+    showFailure(
+      "The agent chose a view, but the app couldn't open it. Try opening the view again.",
+    );
+  }
+}
 
 // Sentinel for the streaming buffer's `pendingStatus`: "no status update
 // parked", distinct from a parked `null` (an explicit clear-the-status commit).
@@ -1584,6 +1609,9 @@ export function useChatSend(deps: UseChatSendDeps) {
         if (chatSendQueueRef.current.length === 0) {
           setChatSending(false);
         }
+        await handoffCompletedViewAction(data.actionResults, (message) => {
+          setActionNotice(message, "error", 8_000);
+        });
 
         // Action callbacks can persist additional assistant turns that are not
         // mirrored by the optimistic streaming draft in local state.
@@ -1777,6 +1805,13 @@ export function useChatSend(deps: UseChatSendDeps) {
               // Same idempotency key across the whole logical turn, including
               // the 404 recreate-and-replay recovery.
               clientMessageId,
+            );
+
+            await handoffCompletedViewAction(
+              retryData.actionResults,
+              (message) => {
+                setActionNotice(message, "error", 8_000);
+              },
             );
 
             // Commit any throttle-parked token before the terminal modification.
@@ -2331,6 +2366,9 @@ export function useChatSend(deps: UseChatSendDeps) {
           // Commit any token parked by the throttle before the terminal
           // drop/complete/fail/interrupt — no streamed tokens may be lost.
           flushStreamingText();
+          await handoffCompletedViewAction(data.actionResults, (message) => {
+            setActionNotice(message, "error", 8_000);
+          });
 
           if (!data.text.trim()) {
             if (data.failureKind) {

--- a/packages/ui/src/view-action-handoff.test.ts
+++ b/packages/ui/src/view-action-handoff.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Transport-independent VIEWS action handoff tests, using real Response bodies
+ * and the shared navigate-event payload rather than a WebSocket fixture.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { ChatActionResultSummary } from "./api/client-types-chat";
+import {
+  dispatchViewActionHandoff,
+  findViewActionHandoff,
+  recoverMissedCurrentView,
+} from "./view-action-handoff";
+
+const showCalendar: ChatActionResultSummary = {
+  actionName: "VIEWS",
+  success: true,
+  values: { mode: "show", viewId: "calendar" },
+};
+
+function currentViewResponse(patch: Record<string, unknown> = {}): Response {
+  return new Response(
+    JSON.stringify({
+      currentView: {
+        viewId: "calendar",
+        viewPath: "/calendar",
+        viewLabel: "Calendar",
+        viewType: "gui",
+        source: "agent",
+        updatedAt: "2026-07-13T01:00:00.000Z",
+        ...patch,
+      },
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+describe("view action handoff", () => {
+  it("selects the latest successful show/open result only", () => {
+    expect(
+      findViewActionHandoff([
+        showCalendar,
+        {
+          actionName: "VIEWS",
+          success: false,
+          values: { mode: "show", viewId: "wallet" },
+        },
+        {
+          actionName: "WORKFLOW",
+          success: true,
+          values: { viewId: "ignored" },
+        },
+      ]),
+    ).toEqual({ viewId: "calendar" });
+  });
+
+  it("dispatches the canonical current view when WebSockets are unavailable", async () => {
+    const dispatch = vi.fn();
+
+    await expect(
+      dispatchViewActionHandoff([showCalendar], {
+        fetchCurrentView: async () => currentViewResponse(),
+        currentPath: () => "/chat",
+        dispatch,
+      }),
+    ).resolves.toBe(true);
+
+    expect(dispatch).toHaveBeenCalledWith({
+      viewId: "calendar",
+      viewPath: "/calendar",
+      viewLabel: "Calendar",
+      viewType: "gui",
+    });
+  });
+
+  it("does not duplicate history when the WebSocket already switched the route", async () => {
+    const dispatch = vi.fn();
+
+    await expect(
+      dispatchViewActionHandoff([showCalendar], {
+        fetchCurrentView: async () => currentViewResponse(),
+        currentPath: () => "/calendar",
+        dispatch,
+      }),
+    ).resolves.toBe(false);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("fails loudly when the action result and canonical current view disagree", async () => {
+    await expect(
+      dispatchViewActionHandoff([showCalendar], {
+        fetchCurrentView: async () => currentViewResponse({ viewId: "wallet" }),
+        currentPath: () => "/chat",
+        dispatch: vi.fn(),
+      }),
+    ).rejects.toThrow(/selected "calendar" but current view is "wallet"/);
+  });
+
+  it("recovers a fresh missed agent switch without replaying edge commands", async () => {
+    const dispatch = vi.fn();
+
+    await expect(
+      recoverMissedCurrentView({
+        fetchCurrentView: async () =>
+          currentViewResponse({
+            source: "agent",
+            action: "open-window",
+            placement: "right",
+            alwaysOnTop: true,
+          }),
+        currentPath: () => "/chat",
+        dispatch,
+      }),
+    ).resolves.toBe(false);
+
+    expect(dispatch).not.toHaveBeenCalled();
+
+    await expect(
+      recoverMissedCurrentView({
+        fetchCurrentView: async () =>
+          new Response(
+            JSON.stringify({
+              currentView: {
+                viewId: "calendar",
+                viewPath: "/calendar",
+                viewLabel: "Calendar",
+                viewType: "gui",
+                source: "agent",
+                action: "open-window",
+                placement: "right",
+                alwaysOnTop: true,
+              },
+              justSwitched: true,
+            }),
+            { status: 200 },
+          ),
+        currentPath: () => "/chat",
+        dispatch,
+      }),
+    ).resolves.toBe(true);
+    expect(dispatch).toHaveBeenLastCalledWith({
+      viewId: "calendar",
+      viewPath: "/calendar",
+      viewLabel: "Calendar",
+      viewType: "gui",
+    });
+  });
+
+  it("does not override user navigation that changes during recovery", async () => {
+    let path = "/chat";
+    const dispatch = vi.fn();
+
+    await expect(
+      recoverMissedCurrentView({
+        fetchCurrentView: async () => {
+          path = "/settings";
+          return new Response(
+            JSON.stringify({
+              currentView: {
+                viewId: "calendar",
+                viewPath: "/calendar",
+                viewLabel: "Calendar",
+                viewType: "gui",
+                source: "agent",
+              },
+              justSwitched: true,
+            }),
+            { status: 200 },
+          );
+        },
+        currentPath: () => path,
+        dispatch,
+      }),
+    ).resolves.toBe(false);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/view-action-handoff.ts
+++ b/packages/ui/src/view-action-handoff.ts
@@ -1,0 +1,241 @@
+/**
+ * Converts successful VIEWS action summaries from a completed chat turn into
+ * shell navigation. Chat streams exist on every runtime transport, so this is
+ * the reliable handoff when a platform intentionally runs without WebSockets.
+ */
+
+import { ElizaError } from "@elizaos/core";
+import type { ChatActionResultSummary } from "./api/client-types-chat";
+import { fetchWithCsrf } from "./api/csrf-client";
+import { dispatchNavigateViewEvent } from "./events";
+import { getWindowNavigationPath } from "./navigation";
+
+interface CurrentViewNavigation {
+  viewId: string;
+  viewPath: string | null;
+  viewLabel: string;
+  viewType: "gui" | "tui" | "xr";
+  action?: string;
+  views?: string[];
+  layout?: string;
+  placement?: string;
+  subview?: string;
+  alwaysOnTop?: boolean;
+  source?: "agent" | "user";
+}
+
+interface CurrentViewResponse {
+  currentView: CurrentViewNavigation | null;
+  justSwitched: boolean;
+}
+
+export interface ViewActionHandoff {
+  viewId: string;
+  subview?: string;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export function findViewActionHandoff(
+  actionResults: readonly ChatActionResultSummary[] | undefined,
+): ViewActionHandoff | null {
+  if (!Array.isArray(actionResults)) return null;
+  for (let index = actionResults.length - 1; index >= 0; index--) {
+    const result = actionResults[index];
+    if (
+      result?.success !== true ||
+      result.actionName?.toUpperCase() !== "VIEWS"
+    ) {
+      continue;
+    }
+    const mode = readString(result.values?.mode)?.toLowerCase();
+    const viewId = readString(result.values?.viewId);
+    if ((mode === "show" || mode === "open") && viewId) {
+      const subview = readString(result.values?.subview);
+      return { viewId, ...(subview ? { subview } : {}) };
+    }
+  }
+  return null;
+}
+
+function parseCurrentViewResponse(body: unknown): CurrentViewResponse {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw new ElizaError("Malformed /api/views/current response", {
+      code: "VIEW_HANDOFF_RESPONSE_INVALID",
+    });
+  }
+  const response = body as { currentView?: unknown; justSwitched?: unknown };
+  const currentView = response.currentView;
+  if (currentView === null) {
+    return { currentView: null, justSwitched: response.justSwitched === true };
+  }
+  if (
+    !currentView ||
+    typeof currentView !== "object" ||
+    Array.isArray(currentView)
+  ) {
+    throw new ElizaError("The VIEWS action completed without a current view", {
+      code: "VIEW_HANDOFF_CURRENT_VIEW_MISSING",
+    });
+  }
+  const record = currentView as Record<string, unknown>;
+  const viewId = readString(record.viewId);
+  const viewLabel = readString(record.viewLabel);
+  const viewType = record.viewType;
+  const viewPath = record.viewPath;
+  if (
+    !viewId ||
+    !viewLabel ||
+    (viewType !== "gui" && viewType !== "tui" && viewType !== "xr") ||
+    !(typeof viewPath === "string" || viewPath === null)
+  ) {
+    throw new ElizaError("Malformed current view navigation fields", {
+      code: "VIEW_HANDOFF_RESPONSE_INVALID",
+    });
+  }
+  return {
+    justSwitched: response.justSwitched === true,
+    currentView: {
+      viewId,
+      viewLabel,
+      viewType,
+      viewPath,
+      ...(readString(record.action)
+        ? { action: readString(record.action) }
+        : {}),
+      ...(Array.isArray(record.views)
+        ? {
+            views: record.views.filter(
+              (view): view is string => typeof view === "string",
+            ),
+          }
+        : {}),
+      ...(readString(record.layout)
+        ? { layout: readString(record.layout) }
+        : {}),
+      ...(readString(record.placement)
+        ? { placement: readString(record.placement) }
+        : {}),
+      ...(readString(record.subview)
+        ? { subview: readString(record.subview) }
+        : {}),
+      ...(record.alwaysOnTop === true ? { alwaysOnTop: true } : {}),
+      ...(record.source === "agent" || record.source === "user"
+        ? { source: record.source }
+        : {}),
+    },
+  };
+}
+
+async function fetchCurrentViewResponse(
+  fetchCurrentView?: () => Promise<Response>,
+): Promise<CurrentViewResponse> {
+  const response = await (fetchCurrentView?.() ??
+    fetchWithCsrf("/api/views/current"));
+  if (!response.ok) {
+    throw new ElizaError(
+      `GET /api/views/current returned HTTP ${response.status}`,
+      {
+        code: "VIEW_HANDOFF_CURRENT_VIEW_HTTP_FAILED",
+        context: { status: response.status },
+      },
+    );
+  }
+  return parseCurrentViewResponse(await response.json());
+}
+
+export async function dispatchViewActionHandoff(
+  actionResults: readonly ChatActionResultSummary[] | undefined,
+  dependencies: {
+    fetchCurrentView?: () => Promise<Response>;
+    dispatch?: typeof dispatchNavigateViewEvent;
+    currentPath?: () => string;
+  } = {},
+): Promise<boolean> {
+  const handoff = findViewActionHandoff(actionResults);
+  if (!handoff) return false;
+
+  const { currentView: current } = await fetchCurrentViewResponse(
+    dependencies.fetchCurrentView,
+  );
+  if (!current) {
+    throw new ElizaError("The VIEWS action completed without a current view", {
+      code: "VIEW_HANDOFF_CURRENT_VIEW_MISSING",
+    });
+  }
+  if (current.viewId !== handoff.viewId) {
+    throw new ElizaError(
+      `VIEWS action selected "${handoff.viewId}" but current view is "${current.viewId}"`,
+      {
+        code: "VIEW_HANDOFF_VIEW_MISMATCH",
+        context: {
+          actionViewId: handoff.viewId,
+          currentViewId: current.viewId,
+        },
+      },
+    );
+  }
+
+  const currentPath = dependencies.currentPath?.() ?? getWindowNavigationPath();
+  const targetPath = current.viewPath ?? `/apps/${current.viewId}`;
+  // A live WebSocket may already have delivered the same switch while the chat
+  // response was streaming. Avoid adding a duplicate browser-history entry;
+  // subviews still dispatch because their selected section is not encoded in
+  // every platform's URL.
+  if (currentPath === targetPath && !current.subview && !handoff.subview) {
+    return false;
+  }
+
+  const dispatch = dependencies.dispatch ?? dispatchNavigateViewEvent;
+  dispatch({
+    viewId: current.viewId,
+    ...(current.viewPath ? { viewPath: current.viewPath } : {}),
+    viewLabel: current.viewLabel,
+    viewType: current.viewType,
+    ...(current.action ? { action: current.action } : {}),
+    ...(current.views ? { views: current.views } : {}),
+    ...(current.layout ? { layout: current.layout } : {}),
+    ...(current.placement ? { placement: current.placement } : {}),
+    ...((current.subview ?? handoff.subview)
+      ? { subview: current.subview ?? handoff.subview }
+      : {}),
+    ...(current.alwaysOnTop ? { alwaysOnTop: true } : {}),
+  });
+  return true;
+}
+
+/** Recover one recent agent navigation that was missed while transport was down. */
+export async function recoverMissedCurrentView(
+  dependencies: {
+    fetchCurrentView?: () => Promise<Response>;
+    dispatch?: typeof dispatchNavigateViewEvent;
+    currentPath?: () => string;
+  } = {},
+): Promise<boolean> {
+  const readPath = dependencies.currentPath ?? getWindowNavigationPath;
+  const pathBeforeFetch = readPath();
+  const { currentView: current, justSwitched } = await fetchCurrentViewResponse(
+    dependencies.fetchCurrentView,
+  );
+  if (!current || !justSwitched || current.source !== "agent") return false;
+
+  // Explicit user navigation while the recovery fetch was in flight wins over
+  // process-global server state, which may be shared by several windows.
+  if (readPath() !== pathBeforeFetch) return false;
+  const targetPath = current.viewPath ?? `/apps/${current.viewId}`;
+  if (pathBeforeFetch === targetPath && !current.subview) return false;
+
+  const dispatch = dependencies.dispatch ?? dispatchNavigateViewEvent;
+  // Recovery replays destination state only. Edge commands such as pin/window
+  // or layout actions must never execute again on every resume/reconnect.
+  dispatch({
+    viewId: current.viewId,
+    ...(current.viewPath ? { viewPath: current.viewPath } : {}),
+    viewLabel: current.viewLabel,
+    viewType: current.viewType,
+    ...(current.subview ? { subview: current.subview } : {}),
+  });
+  return true;
+}

--- a/plugins/plugin-agent-orchestrator/AGENTS.md
+++ b/plugins/plugin-agent-orchestrator/AGENTS.md
@@ -267,10 +267,10 @@ README → "GitHub credentials".
 | `ELIZA_AGENT_SELECTION_STRATEGY` | `fixed` | Adapter selection policy: `fixed` or `dynamic` |
 | `ELIZA_ELIZAOS_ACP_COMMAND` | `eliza-code-acp` | Native elizaOS ACP command |
 | `ELIZA_PI_AGENT_ACP_COMMAND` | `pi-agent` | Native Pi Agent ACP command |
-| `ELIZA_CODEX_ACP_COMMAND` | `npx -y @zed-industries/codex-acp@0.14.0` | Native Codex ACP command |
-| `ELIZA_CODEX_ACP_SANDBOX_MODE` / `ELIZA_CODEX_SANDBOX_MODE` | unset | Optional Codex ACP `sandbox_mode` override: `read-only`, `workspace-write`, or `danger-full-access` |
+| `ELIZA_CODEX_ACP_COMMAND` | `npx -y @agentclientprotocol/codex-acp@1.1.2` | Native Codex ACP command. The manifest default and the legacy `@zed-industries` default select the isolated managed successor; any other custom command is executed verbatim. |
+| `ELIZA_CODEX_ACP_SANDBOX_MODE` / `ELIZA_CODEX_SANDBOX_MODE` | unset | Optional managed Codex ACP sandbox mode: `read-only`, `workspace-write`, or `danger-full-access`. The successor receives these as `INITIAL_AGENT_MODE`; custom commands are not rewritten. |
 | `ELIZA_CODEX_ACP_NO_LANDLOCK_SANDBOX_MODE` | `danger-full-access` | Codex ACP sandbox mode used when Linux Landlock is unavailable |
-| `ELIZA_CODEX_ACP_APPROVAL_POLICY` / `ELIZA_CODEX_APPROVAL_POLICY` | `never` for no-Landlock fallback, otherwise unset | Optional Codex ACP `approval_policy` override |
+| `ELIZA_CODEX_ACP_APPROVAL_POLICY` / `ELIZA_CODEX_APPROVAL_POLICY` | `never` for no-Landlock fallback, otherwise unset | Optional managed Codex ACP approval policy. Setting it requires an explicit sandbox mode; the successor supports the fixed pairs `read-only`/`on-request`, `workspace-write`/`on-request`, and `danger-full-access`/`never`. |
 | `ELIZA_CODEX_ACP_LANDLOCK` / `ELIZA_CODEX_LANDLOCK` | auto-detect | Force Landlock detection for containers/tests: `1`/`true` or `0`/`false` |
 | `ELIZA_CLAUDE_ACP_COMMAND` | `npx -y @agentclientprotocol/claude-agent-acp@0.34.0` | Native Claude ACP command |
 | `ELIZA_OPENCODE_ACP_COMMAND` | bundled shim or `opencode acp` | Native OpenCode ACP command |

--- a/plugins/plugin-agent-orchestrator/CLAUDE.md
+++ b/plugins/plugin-agent-orchestrator/CLAUDE.md
@@ -267,10 +267,10 @@ README → "GitHub credentials".
 | `ELIZA_AGENT_SELECTION_STRATEGY` | `fixed` | Adapter selection policy: `fixed` or `dynamic` |
 | `ELIZA_ELIZAOS_ACP_COMMAND` | `eliza-code-acp` | Native elizaOS ACP command |
 | `ELIZA_PI_AGENT_ACP_COMMAND` | `pi-agent` | Native Pi Agent ACP command |
-| `ELIZA_CODEX_ACP_COMMAND` | `npx -y @zed-industries/codex-acp@0.14.0` | Native Codex ACP command |
-| `ELIZA_CODEX_ACP_SANDBOX_MODE` / `ELIZA_CODEX_SANDBOX_MODE` | unset | Optional Codex ACP `sandbox_mode` override: `read-only`, `workspace-write`, or `danger-full-access` |
+| `ELIZA_CODEX_ACP_COMMAND` | `npx -y @agentclientprotocol/codex-acp@1.1.2` | Native Codex ACP command. The manifest default and the legacy `@zed-industries` default select the isolated managed successor; any other custom command is executed verbatim. |
+| `ELIZA_CODEX_ACP_SANDBOX_MODE` / `ELIZA_CODEX_SANDBOX_MODE` | unset | Optional managed Codex ACP sandbox mode: `read-only`, `workspace-write`, or `danger-full-access`. The successor receives these as `INITIAL_AGENT_MODE`; custom commands are not rewritten. |
 | `ELIZA_CODEX_ACP_NO_LANDLOCK_SANDBOX_MODE` | `danger-full-access` | Codex ACP sandbox mode used when Linux Landlock is unavailable |
-| `ELIZA_CODEX_ACP_APPROVAL_POLICY` / `ELIZA_CODEX_APPROVAL_POLICY` | `never` for no-Landlock fallback, otherwise unset | Optional Codex ACP `approval_policy` override |
+| `ELIZA_CODEX_ACP_APPROVAL_POLICY` / `ELIZA_CODEX_APPROVAL_POLICY` | `never` for no-Landlock fallback, otherwise unset | Optional managed Codex ACP approval policy. Setting it requires an explicit sandbox mode; the successor supports the fixed pairs `read-only`/`on-request`, `workspace-write`/`on-request`, and `danger-full-access`/`never`. |
 | `ELIZA_CODEX_ACP_LANDLOCK` / `ELIZA_CODEX_LANDLOCK` | auto-detect | Force Landlock detection for containers/tests: `1`/`true` or `0`/`false` |
 | `ELIZA_CLAUDE_ACP_COMMAND` | `npx -y @agentclientprotocol/claude-agent-acp@0.34.0` | Native Claude ACP command |
 | `ELIZA_OPENCODE_ACP_COMMAND` | bundled shim or `opencode acp` | Native OpenCode ACP command |

--- a/plugins/plugin-agent-orchestrator/README.md
+++ b/plugins/plugin-agent-orchestrator/README.md
@@ -31,7 +31,7 @@ export ELIZA_ACP_TRANSPORT=native
 export ELIZA_ACP_DEFAULT_AGENT=elizaos
 export ELIZA_ELIZAOS_ACP_COMMAND="eliza-code-acp"
 export ELIZA_PI_AGENT_ACP_COMMAND="pi-agent"
-export ELIZA_CODEX_ACP_COMMAND="npx -y @zed-industries/codex-acp@0.14.0"
+export ELIZA_CODEX_ACP_COMMAND="npx -y @agentclientprotocol/codex-acp@1.1.2"
 export ELIZA_CLAUDE_ACP_COMMAND="npx -y @agentclientprotocol/claude-agent-acp@0.34.0"
 ```
 
@@ -145,10 +145,10 @@ All configuration is via environment variables. Use `ELIZA_ACP_TRANSPORT=native`
 | `ELIZA_ACP_DEFAULT_AGENT` | `elizaos` | Default agent type. Primary choices: `elizaos`, `pi-agent`, `opencode`. |
 | `ELIZA_ELIZAOS_ACP_COMMAND` | `eliza-code-acp` | Native elizaOS ACP command. |
 | `ELIZA_PI_AGENT_ACP_COMMAND` | `pi-agent` | Native Pi Agent ACP command. |
-| `ELIZA_CODEX_ACP_COMMAND` | `npx -y @zed-industries/codex-acp@0.14.0` | Native Codex ACP command. |
-| `ELIZA_CODEX_ACP_SANDBOX_MODE` / `ELIZA_CODEX_SANDBOX_MODE` | unset | Optional Codex ACP `sandbox_mode` override: `read-only`, `workspace-write`, or `danger-full-access`. |
+| `ELIZA_CODEX_ACP_COMMAND` | `npx -y @agentclientprotocol/codex-acp@1.1.2` | Native Codex ACP command. The manifest default and the legacy `@zed-industries` default select the isolated managed successor; any other custom command is executed verbatim. |
+| `ELIZA_CODEX_ACP_SANDBOX_MODE` / `ELIZA_CODEX_SANDBOX_MODE` | unset | Optional managed Codex ACP sandbox mode: `read-only`, `workspace-write`, or `danger-full-access`. The successor receives these as `INITIAL_AGENT_MODE`; custom commands are not rewritten. |
 | `ELIZA_CODEX_ACP_NO_LANDLOCK_SANDBOX_MODE` | `danger-full-access` | Codex ACP sandbox mode used when Linux Landlock is unavailable. |
-| `ELIZA_CODEX_ACP_APPROVAL_POLICY` / `ELIZA_CODEX_APPROVAL_POLICY` | `never` for no-Landlock fallback, otherwise unset | Optional Codex ACP `approval_policy` override. |
+| `ELIZA_CODEX_ACP_APPROVAL_POLICY` / `ELIZA_CODEX_APPROVAL_POLICY` | `never` for no-Landlock fallback, otherwise unset | Optional managed Codex ACP approval policy. Setting it requires an explicit sandbox mode; the successor supports the fixed pairs `read-only`/`on-request`, `workspace-write`/`on-request`, and `danger-full-access`/`never`. |
 | `ELIZA_CODEX_ACP_LANDLOCK` / `ELIZA_CODEX_LANDLOCK` | auto-detect | Force Landlock detection for containers/tests: `1`/`true` or `0`/`false`. |
 | `ELIZA_CLAUDE_ACP_COMMAND` | `npx -y @agentclientprotocol/claude-agent-acp@0.34.0` | Native Claude ACP command. |
 | `ELIZA_OPENCODE_ACP_COMMAND` | bundled shim or `opencode acp` | Native OpenCode ACP command override. |
@@ -205,7 +205,7 @@ These live smokes ship with the repo:
 
 ```bash
 # Native AcpService against Codex ACP. No global acpx is required; the default
-# native Codex command is `npx -y @zed-industries/codex-acp@0.14.0`.
+# native Codex command is `npx -y @agentclientprotocol/codex-acp@1.1.2`.
 # Authenticate Codex first.
 bun run build
 RUN_LIVE_NATIVE_ACP=1 bun run test:e2e:native
@@ -222,7 +222,7 @@ RUN_LIVE_ACPX=1 ELIZA_ACP_TRANSPORT=cli bun run test -- __tests__/live/sub-agent
 ```
 
 `live-native-acp-smoke.mjs` exercises the default native path by spawning a
-real Codex ACP session through `npx -y @zed-industries/codex-acp@0.14.0`,
+real Codex ACP session through `npx -y @agentclientprotocol/codex-acp@1.1.2`,
 sending "what is 7 + 8?", and verifying `task_complete` fires with response
 `"15"`. The Vitest wrapper is skipped unless `RUN_LIVE_NATIVE_ACP=1` is set;
 when enabled, it requires `NATIVE ACP SMOKE PASSED`.

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts
@@ -170,7 +170,7 @@ describe("NativeAcpClient JSON-RPC lifecycle", () => {
     const events: unknown[] = [];
     const p = queueProc();
     const client = new NativeAcpClient({
-      command: "npx -y @zed-industries/codex-acp@0.14.0",
+      command: "npx -y @agentclientprotocol/codex-acp@1.1.2",
       cwd: "/tmp/native-acp",
       approvalPreset: "autonomous",
       terminal: false,
@@ -181,7 +181,7 @@ describe("NativeAcpClient JSON-RPC lifecycle", () => {
     await waitForWrites(p, 1);
     expect(spawnMock).toHaveBeenCalledWith(
       "npx",
-      ["-y", "@zed-industries/codex-acp@0.14.0"],
+      ["-y", "@agentclientprotocol/codex-acp@1.1.2"],
       expect.objectContaining({ cwd: "/tmp/native-acp" }),
     );
     expect(writeAt(p, 0)).toMatchObject({

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -776,7 +776,7 @@ describe("AcpService", () => {
     );
   });
 
-  it("adds configured Codex ACP sandbox settings to the native command", async () => {
+  it("preserves custom Codex ACP commands verbatim", async () => {
     const service = new AcpService(
       runtime({
         ELIZA_ACP_TRANSPORT: "native",
@@ -795,11 +795,14 @@ describe("AcpService", () => {
 
     expect(nativeClientMock.instances).toHaveLength(1);
     expect(nativeClientMock.instances[0]?.opts.command).toBe(
-      "codex-acp --stdio -c sandbox_mode=workspace-write -c approval_policy=never",
+      "codex-acp --stdio",
+    );
+    expect(nativeClientMock.instances[0]?.opts.env?.INITIAL_AGENT_MODE).toBe(
+      undefined,
     );
   });
 
-  it("honors generic Codex sandbox setting aliases", async () => {
+  it("does not reinterpret managed-setting aliases for custom commands", async () => {
     const service = new AcpService(
       runtime({
         ELIZA_ACP_TRANSPORT: "native",
@@ -818,14 +821,62 @@ describe("AcpService", () => {
 
     expect(nativeClientMock.instances).toHaveLength(1);
     expect(nativeClientMock.instances[0]?.opts.command).toBe(
-      "codex-acp --stdio -c sandbox_mode=read-only -c approval_policy=on-request",
+      "codex-acp --stdio",
     );
+    expect(nativeClientMock.instances[0]?.opts.env?.INITIAL_AGENT_MODE).toBe(
+      undefined,
+    );
+  });
+
+  it("passes managed Codex sandbox settings through INITIAL_AGENT_MODE", async () => {
+    const service = new AcpService(
+      runtime({
+        ELIZA_ACP_TRANSPORT: "native",
+        ELIZA_CODEX_ACP_SANDBOX_MODE: "workspace-write",
+        ELIZA_CODEX_ACP_APPROVAL_POLICY: "on-request",
+      }),
+    );
+    await service.start();
+
+    await service.spawnSession({
+      name: "managed-codex-sandbox",
+      agentType: "codex",
+      workdir: "/tmp/acp-test",
+    });
+
+    expect(nativeClientMock.instances).toHaveLength(1);
+    expect(nativeClientMock.instances[0]?.opts.command).toContain(
+      "--package=@agentclientprotocol/codex-acp@1.1.2",
+    );
+    expect(nativeClientMock.instances[0]?.opts.env?.INITIAL_AGENT_MODE).toBe(
+      "agent",
+    );
+  });
+
+  it("rejects approval-only configuration for managed Codex ACP", async () => {
+    const service = new AcpService(
+      runtime({
+        ELIZA_ACP_TRANSPORT: "native",
+        ELIZA_CODEX_ACP_APPROVAL_POLICY: "never",
+      }),
+    );
+    await service.start();
+
+    await expect(
+      service.spawnSession({
+        name: "managed-codex-approval-only",
+        agentType: "codex",
+        workdir: "/tmp/acp-test",
+      }),
+    ).rejects.toThrow(
+      "Managed Codex ACP approval policy requires an explicit sandbox mode",
+    );
+    expect(nativeClientMock.instances).toHaveLength(0);
   });
 
   it("starts Codex ACP with the no-Landlock fallback when the runtime probe is disabled", async () => {
     const rt = runtime({
       ELIZA_ACP_TRANSPORT: "native",
-      ELIZA_CODEX_ACP_COMMAND: "codex-acp --stdio",
       ELIZA_CODEX_ACP_LANDLOCK: "0",
     });
     const service = new AcpService(rt);
@@ -838,8 +889,11 @@ describe("AcpService", () => {
     });
 
     expect(nativeClientMock.instances).toHaveLength(1);
-    expect(nativeClientMock.instances[0]?.opts.command).toBe(
-      "codex-acp --stdio -c sandbox_mode=danger-full-access -c approval_policy=never",
+    expect(nativeClientMock.instances[0]?.opts.command).toContain(
+      "--package=@agentclientprotocol/codex-acp@1.1.2",
+    );
+    expect(nativeClientMock.instances[0]?.opts.env?.INITIAL_AGENT_MODE).toBe(
+      "agent-full-access",
     );
     const logger = (rt as { logger: { warn: ReturnType<typeof vi.fn> } })
       .logger;
@@ -857,7 +911,7 @@ describe("AcpService", () => {
     process.env.ELIZA_CODEX_ACP_LANDLOCK = "1";
     try {
       nativeClientMock.startImplementation = async (client) => {
-        if (!client.opts.command.includes("sandbox_mode=danger-full-access")) {
+        if (client.opts.env?.INITIAL_AGENT_MODE !== "agent-full-access") {
           throw new Error(
             "ACP agent exited with code 101: thread 'main' panicked: permission profiles requiring direct runtime enforcement are incompatible with --use-legacy-landlock",
           );
@@ -865,7 +919,6 @@ describe("AcpService", () => {
       };
       const rt = runtime({
         ELIZA_ACP_TRANSPORT: "native",
-        ELIZA_CODEX_ACP_COMMAND: "codex-acp --stdio",
       });
       const service = new AcpService(rt);
       await service.start();
@@ -878,11 +931,17 @@ describe("AcpService", () => {
 
       expect(result.status).toBe("ready");
       expect(nativeClientMock.instances).toHaveLength(2);
-      expect(nativeClientMock.instances[0]?.opts.command).toBe(
-        "codex-acp --stdio",
+      expect(nativeClientMock.instances[0]?.opts.command).toContain(
+        "--package=@agentclientprotocol/codex-acp@1.1.2",
+      );
+      expect(nativeClientMock.instances[0]?.opts.env?.INITIAL_AGENT_MODE).toBe(
+        undefined,
       );
       expect(nativeClientMock.instances[1]?.opts.command).toBe(
-        "codex-acp --stdio -c sandbox_mode=danger-full-access -c approval_policy=never",
+        nativeClientMock.instances[0]?.opts.command,
+      );
+      expect(nativeClientMock.instances[1]?.opts.env?.INITIAL_AGENT_MODE).toBe(
+        "agent-full-access",
       );
       const logger = (rt as { logger: { warn: ReturnType<typeof vi.fn> } })
         .logger;
@@ -900,6 +959,34 @@ describe("AcpService", () => {
         process.env.ELIZA_CODEX_ACP_LANDLOCK = previousOverride;
       }
     }
+  });
+
+  it("does not relax an explicit managed sandbox after a Landlock panic", async () => {
+    nativeClientMock.startImplementation = async () => {
+      throw new Error(
+        "ACP agent exited with code 101: thread 'main' panicked: permission profiles requiring direct runtime enforcement are incompatible with --use-legacy-landlock",
+      );
+    };
+    const service = new AcpService(
+      runtime({
+        ELIZA_ACP_TRANSPORT: "native",
+        ELIZA_CODEX_ACP_SANDBOX_MODE: "workspace-write",
+        ELIZA_CODEX_ACP_APPROVAL_POLICY: "on-request",
+      }),
+    );
+    await service.start();
+
+    await expect(
+      service.spawnSession({
+        name: "codex-explicit-landlock-failure",
+        agentType: "codex",
+        workdir: "/tmp/acp-test",
+      }),
+    ).rejects.toThrow("use-legacy-landlock");
+    expect(nativeClientMock.instances).toHaveLength(1);
+    expect(nativeClientMock.instances[0]?.opts.env?.INITIAL_AGENT_MODE).toBe(
+      "agent",
+    );
   });
 
   it("does not emit task_complete from the session creation command", async () => {
@@ -1261,6 +1348,43 @@ describe("AcpService", () => {
     );
   });
 
+  it("CLI sendPrompt leaves a truncated turn resumable instead of emitting task_complete", async () => {
+    const create = nextProc();
+    const service = new AcpService(runtime());
+    const events: string[] = [];
+    service.onSessionEvent((_sid, event) => events.push(event));
+    await service.start();
+    const spawned = service.spawnSession({
+      name: "cli-truncated",
+      agentType: "codex",
+      workdir: "/tmp/acp-test",
+    });
+    await waitForSpawn(create);
+    closeOk(create);
+    const { sessionId } = await spawned;
+    events.length = 0;
+
+    const prompt = nextProc();
+    const sent = service.sendPrompt(sessionId, "continue the task");
+    await waitForSpawn(prompt);
+    prompt.proc.stdout.emit(
+      "data",
+      Buffer.from(
+        `{"jsonrpc":"2.0","id":"req-truncated","result":{"stopReason":"max_tokens","content":[{"type":"text","text":"partial output"}]},"sessionId":"${sessionId}"}\n`,
+      ),
+    );
+    closeOk(prompt);
+
+    const result = await sent;
+    expect(result).toMatchObject({
+      stopReason: "max_tokens",
+      finalText: "partial output",
+    });
+    expect(events).not.toContain("task_complete");
+    expect(events).not.toContain("stopped");
+    expect((await service.getSession(sessionId))?.status).toBe("ready");
+  });
+
   it("flushes raw stdout before advertising stdoutLogPath on task_complete", async () => {
     const priorTrajDir = process.env.ELIZA_TRAJECTORY_DIR;
     const priorRecording = process.env.ELIZA_TRAJECTORY_RECORDING;
@@ -1353,6 +1477,45 @@ describe("AcpService", () => {
     expect(result.response).toBe("final answer");
     expect(result.finalText).toBe("final answer");
     expect(taskCompletePayloads[0]?.response).toBe("final answer");
+    expect((await service.getSession(sessionId))?.status).toBe("ready");
+  });
+
+  it.each([
+    "max_tokens",
+    "interrupted",
+  ])("native sendPrompt does not advertise an incomplete %s turn as task_complete", async (stopReason) => {
+    const service = new AcpService(runtime({ ELIZA_ACP_TRANSPORT: "native" }));
+    const events: string[] = [];
+    service.onSessionEvent((_sid, event) => events.push(event));
+    await service.start();
+    const { sessionId } = await service.spawnSession({
+      name: `native-${stopReason}`,
+      agentType: "codex",
+      workdir: "/tmp/acp-test",
+    });
+    events.length = 0;
+    const client = firstNativeClient();
+    client.prompt.mockImplementationOnce(async () => {
+      client.emit({
+        jsonrpc: "2.0",
+        id: "prompt",
+        sessionId: "protocol-session",
+        result: {
+          stopReason,
+          content: [{ type: "text", text: "partial output" }],
+        },
+      } as AcpJsonRpcMessage);
+      return { stopReason };
+    });
+
+    const result = await service.sendPrompt(sessionId, "continue the task");
+
+    expect(result).toMatchObject({
+      stopReason,
+      finalText: "partial output",
+    });
+    expect(events).not.toContain("task_complete");
+    expect(events).not.toContain("stopped");
     expect((await service.getSession(sessionId))?.status).toBe("ready");
   });
 
@@ -2242,6 +2405,33 @@ describe("AcpService.runHealthCheck state_lost guards", () => {
     expect(after?.status).toBe("ready");
   });
 
+  it("does NOT probe acpx state for an attached native mid-flight session", async () => {
+    const service = new AcpService(runtime({ ELIZA_ACP_TRANSPORT: undefined }));
+    await service.start();
+    const { sessionId } = await service.spawnSession({
+      name: "native-health-check",
+      agentType: "codex",
+      workdir: "/tmp/acp-test",
+    });
+    const store = Reflect.get(service, "store") as {
+      update: (id: string, patch: unknown) => Promise<void>;
+    };
+    const old = new Date(Date.now() - 10 * 60_000);
+    await store.update(sessionId, {
+      status: "running",
+      lastActivityAt: old,
+      acpxSessionId: "native_protocol_session_without_acpx_state",
+    });
+
+    await (
+      service as unknown as { runHealthCheck: () => Promise<void> }
+    ).runHealthCheck();
+
+    const after = await service.getSession(sessionId);
+    expect(after?.status).toBe("running");
+    await service.stop();
+  });
+
   it("still marks a genuinely mid-flight session errored when its state artifact is gone", async () => {
     const service = new AcpService(runtime());
     await service.start();
@@ -2257,6 +2447,37 @@ describe("AcpService.runHealthCheck state_lost guards", () => {
 
     const after = await service.getSession(id);
     expect(after?.status).toBe("errored");
+  });
+
+  it("reclaims latest-turn output when a retained terminal session is swept", async () => {
+    const service = new AcpService(runtime());
+    await service.start();
+    const store = Reflect.get(service, "store") as {
+      create: (s: unknown) => Promise<void>;
+    };
+    const id = "00000000-0000-0000-0000-0000000000a3";
+    const old = new Date(Date.now() - 48 * 60 * 60_000);
+    await store.create(
+      staleSession({
+        id,
+        status: "stopped",
+        createdAt: old,
+        lastActivityAt: old,
+        acpxSessionId: undefined,
+      }),
+    );
+    const turnOutputBuffers = Reflect.get(service, "turnOutputBuffers") as Map<
+      string,
+      string[]
+    >;
+    turnOutputBuffers.set(id, ["sensitive latest-turn output"]);
+
+    await (
+      service as unknown as { runHealthCheck: () => Promise<void> }
+    ).runHealthCheck();
+
+    expect(await service.getSession(id)).toBeUndefined();
+    expect(turnOutputBuffers.has(id)).toBe(false);
   });
 
   it("enforces ELIZA_ACP_MAX_SESSIONS atomically under concurrent spawns", async () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/archive-reopen-lifecycle.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/archive-reopen-lifecycle.test.ts
@@ -46,6 +46,10 @@ describe("TASKS archive/reopen lifecycle (#11028)", () => {
     );
     expect(svc.archiveTask).toHaveBeenCalledWith("t1");
     expect(result?.success).toBe(true);
+    expect(result?.data).toMatchObject({
+      taskId: "t1",
+      task: { task: { id: "t1", archived: true } },
+    });
   });
 
   it("reopens a task through the durable service", async () => {
@@ -59,6 +63,10 @@ describe("TASKS archive/reopen lifecycle (#11028)", () => {
     );
     expect(svc.reopenTask).toHaveBeenCalledWith("t1");
     expect(result?.success).toBe(true);
+    expect(result?.data).toMatchObject({
+      taskId: "t1",
+      task: { task: { id: "t1", archived: false } },
+    });
   });
 
   it("pauses a task via the control action (archive/reopen/pause all route to the service)", async () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/cancel-task.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/cancel-task.test.ts
@@ -18,21 +18,20 @@ const cancelOptions = { parameters: { action: "cancel" } };
 describe("TASKS:cancel", () => {
   it("cancels a session by id", async () => {
     const svc = serviceMock();
-    expect(
-      (
-        await cancelTaskAction.handler(
-          runtimeWith(svc),
-          memory({ sessionId: "abcdef123456" }),
-          state,
-          cancelOptions,
-          callback(),
-        )
-      )?.data,
-    ).toMatchObject({
+    const result = await cancelTaskAction.handler(
+      runtimeWith(svc),
+      memory({ sessionId: "abcdef123456" }),
+      state,
+      cancelOptions,
+      callback(),
+    );
+    expect(result?.success).toBe(true);
+    expect(result?.data).toMatchObject({
       sessionId: "abcdef123456",
       stoppedSessions: ["abcdef123456"],
       status: "canceled",
     });
+    expect(svc.cancelSession).toHaveBeenCalledWith("abcdef123456");
   });
   it("cancels all sessions when all=true", async () => {
     const svc = serviceMock();

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/codex-sandbox.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/codex-sandbox.test.ts
@@ -4,8 +4,6 @@
  */
 import { describe, expect, it } from "vitest";
 import {
-  appendCodexAcpSandboxConfig,
-  commandHasCodexSandboxConfig,
   detectLandlockAvailability,
   isCodexLandlockPanic,
   normalizeCodexSandboxMode,
@@ -62,28 +60,6 @@ describe("codex ACP sandbox helpers", () => {
         env: { ELIZA_CODEX_LANDLOCK: "true" },
       }),
     ).toBe("available");
-  });
-
-  it("appends sandbox config without duplicating existing command settings", () => {
-    expect(
-      appendCodexAcpSandboxConfig(
-        "codex-acp --stdio",
-        "danger-full-access",
-        "never",
-      ),
-    ).toBe(
-      "codex-acp --stdio -c sandbox_mode=danger-full-access -c approval_policy=never",
-    );
-    expect(
-      appendCodexAcpSandboxConfig(
-        "codex-acp -c sandbox_mode=read-only -c approval_policy=on-request",
-        "danger-full-access",
-        "never",
-      ),
-    ).toBe("codex-acp -c sandbox_mode=read-only -c approval_policy=on-request");
-    expect(commandHasCodexSandboxConfig("codex-acp -s workspace-write")).toBe(
-      true,
-    );
   });
 
   it("recognizes Codex Landlock panic text", () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/create-task.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/create-task.test.ts
@@ -132,6 +132,7 @@ describe("TASKS:create", () => {
       "task_complete",
       expect.objectContaining({ response: "done" }),
     );
+    expect(svc.stopSession).toHaveBeenCalledWith("abcdef123456");
   });
   it("handles missing service, auth error, generic failure", async () => {
     expect(

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/send-to-agent.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/send-to-agent.test.ts
@@ -17,17 +17,19 @@ import {
 describe("TASKS:send", () => {
   it("sends input via action=send", async () => {
     const svc = serviceMock();
-    expect(
-      (
-        await sendToAgentAction.handler(
-          runtimeWith(svc),
-          memory({ sessionId: "abcdef123456", input: "continue" }),
-          state,
-          { parameters: { action: "send" } },
-          callback(),
-        )
-      )?.data,
-    ).toMatchObject({ sessionId: "abcdef123456", input: "continue" });
+    const result = await sendToAgentAction.handler(
+      runtimeWith(svc),
+      memory({ sessionId: "abcdef123456", input: "continue" }),
+      state,
+      { parameters: { action: "send" } },
+      callback(),
+    );
+    expect(result?.success).toBe(true);
+    expect(result?.data).toMatchObject({
+      sessionId: "abcdef123456",
+      input: "continue",
+    });
+    expect(svc.sendToSession).toHaveBeenCalledWith("abcdef123456", "continue");
   });
 
   it("continues the originating sub-agent for routed task_complete follow-ups", async () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/smithers-task-executor.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/smithers-task-executor.test.ts
@@ -55,6 +55,10 @@ describe("detectTurnDone", () => {
     expect(detectTurnDone({ stopReason: "max_turn_requests" })).toBe(false);
     expect(detectTurnDone({ stopReason: "interrupted" })).toBe(false);
   });
+  it("treats cancelled and stopped turns as terminal failures", () => {
+    expect(detectTurnDone({ stopReason: "cancelled" })).toBe(false);
+    expect(detectTurnDone({ stopReason: "stopped" })).toBe(false);
+  });
 });
 
 describe("SmithersTaskExecutor", () => {
@@ -102,6 +106,22 @@ describe("SmithersTaskExecutor", () => {
     await expect(
       executor.runTurn({ taskId: "t", runId: "t", turn: 1, prompt: "P" }),
     ).rejects.toThrow("agent failed");
+  });
+
+  it.each([
+    "cancelled",
+    "stopped",
+  ])("throws when a turn is %s", async (stopReason) => {
+    const acp = new FakeAcp({ stopReason });
+    const executor = new SmithersTaskExecutor(acp);
+    await expect(
+      executor.runTurn({ taskId: "t", runId: "t", turn: 1, prompt: "P" }),
+    ).rejects.toMatchObject({
+      code:
+        stopReason === "cancelled"
+          ? "ACP_TASK_PROMPT_CANCELLED"
+          : "ACP_TASK_PROMPT_STOPPED",
+    });
   });
 
   it("uses injected approval/submit callbacks", async () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/smithers-task-integration.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/smithers-task-integration.test.ts
@@ -89,4 +89,41 @@ describe("runDurableTask", () => {
     },
     TIMEOUT,
   );
+
+  it(
+    "rejects a clean turn that completes without a response",
+    async () => {
+      const service: AcpTaskService = {
+        sendPrompt: async () => ({ stopReason: "end_turn" }),
+      };
+
+      await expect(
+        runDurableTask(service, uniqueSession(), "x", {}),
+      ).rejects.toMatchObject({
+        name: "ElizaError",
+        code: "SMITHERS_TASK_RESPONSE_MISSING",
+      });
+    },
+    TIMEOUT,
+  );
+
+  it(
+    "rejects a truncated run instead of emitting task completion",
+    async () => {
+      const service: AcpTaskService = {
+        sendPrompt: async () => ({
+          stopReason: "max_tokens",
+          finalText: "partial output",
+        }),
+      };
+
+      await expect(
+        runDurableTask(service, uniqueSession(), "x", {}),
+      ).rejects.toMatchObject({
+        name: "ElizaError",
+        code: "SMITHERS_TASK_INCOMPLETE",
+      });
+    },
+    TIMEOUT,
+  );
 });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/spawn-agent.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/spawn-agent.test.ts
@@ -24,6 +24,12 @@ describe("TASKS:spawn_agent", () => {
     ).not.toContain("lockWorkdir");
   });
 
+  it("does not expose keepAliveAfterComplete to planner-generated tool calls", () => {
+    expect(
+      spawnAgentAction.parameters?.map((param) => param.name),
+    ).not.toContain("keepAliveAfterComplete");
+  });
+
   it("validates with explicit payload and a service available", async () => {
     expect(
       await spawnAgentAction.validate(
@@ -108,6 +114,63 @@ describe("TASKS:spawn_agent", () => {
       metadata?: Record<string, unknown>;
     };
     expect(call.metadata?.originConnectorMessageId).toBe("1506941896755249255");
+  });
+
+  it("persists custom verification and retry policy on the ACP session", async () => {
+    const svc = serviceMock();
+    const workdir = process.cwd();
+    const validator = {
+      service: "app-verification",
+      method: "verifyPlugin",
+      params: { workdir, pluginName: "proof-view", profile: "full" },
+    };
+    await spawnAgentAction.handler(
+      runtimeWith(svc),
+      memory({ task: "build a plugin view", agentType: "codex" }),
+      state,
+      {
+        parameters: {
+          action: "spawn_agent",
+          workdir,
+          lockWorkdir: true,
+          validator,
+          maxRetries: 2,
+          onVerificationFail: "retry",
+        },
+      },
+      callback(),
+    );
+
+    const call = svc.spawnSession.mock.calls[0]?.[0] as {
+      metadata?: Record<string, unknown>;
+    };
+    expect(call.metadata).toMatchObject({
+      validator,
+      maxRetries: 2,
+      onVerificationFail: "retry",
+      keepAliveAfterComplete: true,
+    });
+  });
+
+  it("ignores a standalone keep-alive request without a validator owner", async () => {
+    const svc = serviceMock();
+    await spawnAgentAction.handler(
+      runtimeWith(svc),
+      memory({ task: "build a script", agentType: "codex" }),
+      state,
+      {
+        parameters: {
+          action: "spawn_agent",
+          keepAliveAfterComplete: true,
+        },
+      },
+      callback(),
+    );
+
+    const call = svc.spawnSession.mock.calls[0]?.[0] as {
+      metadata?: Record<string, unknown>;
+    };
+    expect(call.metadata?.keepAliveAfterComplete).toBe(false);
   });
 
   it("stamps deterministic deduped task/worktree swarm room metadata", async () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/stop-agent.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/stop-agent.test.ts
@@ -18,17 +18,19 @@ const stopOptions = { parameters: { action: "stop_agent" } };
 describe("TASKS:stop_agent", () => {
   it("stops a specific session", async () => {
     const svc = serviceMock();
-    expect(
-      (
-        await stopAgentAction.handler(
-          runtimeWith(svc),
-          memory({ sessionId: "abcdef123456" }),
-          state,
-          stopOptions,
-          callback(),
-        )
-      )?.data,
-    ).toMatchObject({ sessionId: "abcdef123456", agentType: "codex" });
+    const result = await stopAgentAction.handler(
+      runtimeWith(svc),
+      memory({ sessionId: "abcdef123456" }),
+      state,
+      stopOptions,
+      callback(),
+    );
+    expect(result?.success).toBe(true);
+    expect(result?.data).toMatchObject({
+      sessionId: "abcdef123456",
+      agentType: "codex",
+    });
+    expect(svc.stopSession).toHaveBeenCalledWith("abcdef123456");
   });
   it("stops all sessions when all=true", async () => {
     const svc = serviceMock();

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/swarm-coordinator-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/swarm-coordinator-service.test.ts
@@ -19,6 +19,7 @@ import type { IAgentRuntime } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AcpService } from "../../src/services/acp-service.ts";
 import {
+  extractStructuredCompletionProof,
   SWARM_COORDINATOR_SERVICE_TYPE,
   SwarmCoordinatorService,
   type SwarmEvent,
@@ -57,6 +58,7 @@ function makeAcpStub(session?: Record<string, unknown>) {
 function makeRuntime(services: Record<string, unknown>): IAgentRuntime {
   return {
     getService: vi.fn((key: string) => services[key] ?? null),
+    reportError: vi.fn(),
   } as unknown as IAgentRuntime;
 }
 
@@ -285,6 +287,365 @@ describe("SwarmCoordinatorService", () => {
     await coordinator.stop();
   });
 
+  it("passes the coding agent's structured plugin proof to verification", async () => {
+    const acp = makeAcpStub({
+      agentType: "codex",
+      workdir: "/tmp/plugin-view",
+      metadata: {
+        validator: {
+          service: "app-verification",
+          method: "verifyPlugin",
+          params: { pluginName: "proof-view" },
+        },
+      },
+    });
+    const verification = {
+      verifyPlugin: vi.fn(async () => ({ verdict: "pass", checks: [] })),
+    };
+    const coordinator = await SwarmCoordinatorService.start(
+      makeRuntime({
+        [AcpService.serviceType]: acp,
+        "app-verification": verification,
+      }),
+    );
+    const response =
+      'PLUGIN_CREATE_DONE {"pluginName":"proof-view","files":["src/index.ts"],"tests":{"passed":1,"failed":0},"lint":"ok","typecheck":"ok"}';
+
+    acp.emit("sess-plugin-proof", "task_complete", { response });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(verification.verifyPlugin).toHaveBeenCalledWith({
+      pluginName: "proof-view",
+      workdir: "/tmp/plugin-view",
+      structuredProof: {
+        kind: "PLUGIN_CREATE_DONE",
+        pluginName: "proof-view",
+        files: ["src/index.ts"],
+        tests: { passed: 1, failed: 0 },
+        lint: "ok",
+        typecheck: "ok",
+      },
+    });
+    await coordinator.stop();
+  });
+
+  it("recovers structured proof from captured session output", async () => {
+    const response =
+      'PLUGIN_CREATE_DONE {"pluginName":"proof-view","files":["src/index.ts"],"tests":{"passed":1,"failed":0},"lint":"ok","typecheck":"ok"}';
+    const acp = {
+      ...makeAcpStub({
+        agentType: "codex",
+        workdir: "/tmp/plugin-view",
+        metadata: {
+          validator: {
+            service: "app-verification",
+            method: "verifyPlugin",
+            params: { pluginName: "proof-view" },
+          },
+        },
+      }),
+      getSessionOutput: vi.fn(
+        () => 'PLUGIN_CREATE_DONE {"pluginName":"stale-proof"}',
+      ),
+      getSessionTurnOutput: vi.fn(() => response),
+    };
+    const verification = {
+      verifyPlugin: vi.fn(async () => ({ verdict: "pass", checks: [] })),
+    };
+    const coordinator = await SwarmCoordinatorService.start(
+      makeRuntime({
+        [AcpService.serviceType]: acp,
+        "app-verification": verification,
+      }),
+    );
+
+    acp.emit("sess-output-proof", "task_complete", {
+      response: "The plugin is ready.",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(acp.getSessionTurnOutput).toHaveBeenCalledWith(
+      "sess-output-proof",
+      2_000,
+    );
+    expect(acp.getSessionOutput).not.toHaveBeenCalled();
+    expect(verification.verifyPlugin).toHaveBeenCalledWith(
+      expect.objectContaining({
+        structuredProof: expect.objectContaining({
+          kind: "PLUGIN_CREATE_DONE",
+          pluginName: "proof-view",
+        }),
+      }),
+    );
+    await coordinator.stop();
+  });
+
+  it("uses the final structured claim when a transport captures earlier echoes", () => {
+    const proof =
+      'PLUGIN_CREATE_DONE {"pluginName":"one"}\nPLUGIN_CREATE_DONE {"pluginName":"two"}';
+    expect(extractStructuredCompletionProof(proof)).toEqual({
+      kind: "PLUGIN_CREATE_DONE",
+      pluginName: "two",
+    });
+  });
+
+  it("collapses identical proof echoes from tool and final-response channels", () => {
+    const proof = 'PLUGIN_CREATE_DONE {"pluginName":"proof-view"}';
+    expect(extractStructuredCompletionProof(`${proof}\n${proof}`)).toEqual({
+      kind: "PLUGIN_CREATE_DONE",
+      pluginName: "proof-view",
+    });
+  });
+
+  it("recovers a final proof concatenated directly after a tool-output wrapper", () => {
+    const captured =
+      '[/tool output]PLUGIN_CREATE_DONE {"pluginName":"proof-view","tests":{"passed":6,"failed":0}}';
+    expect(extractStructuredCompletionProof(captured)).toEqual({
+      kind: "PLUGIN_CREATE_DONE",
+      pluginName: "proof-view",
+      tests: { passed: 6, failed: 0 },
+    });
+  });
+
+  it("ignores an escaped schema echo before a valid final proof", () => {
+    const captured = [
+      'PLUGIN_CREATE_DONE {\\"pluginName\\":\\"<package-name>\\"}',
+      '[/tool output]PLUGIN_CREATE_DONE {"pluginName":"proof-view"}',
+    ].join("\n");
+    expect(extractStructuredCompletionProof(captured)).toEqual({
+      kind: "PLUGIN_CREATE_DONE",
+      pluginName: "proof-view",
+    });
+  });
+
+  it("retries failed plugin verification with bounded structured feedback", async () => {
+    const acp = {
+      ...makeAcpStub({
+        agentType: "codex",
+        workdir: "/tmp/plugin-view",
+        metadata: {
+          initialTask: "build the plugin view",
+          onVerificationFail: "retry",
+          maxRetries: 2,
+          retryCount: 0,
+          validator: {
+            service: "app-verification",
+            method: "verifyPlugin",
+            params: { pluginName: "proof-view" },
+          },
+        },
+      }),
+      updateSessionMetadata: vi.fn(async () => {}),
+      sendPrompt: vi.fn(async () => ({ stopReason: "end_turn" })),
+    };
+    const verification = {
+      verifyPlugin: vi.fn(async () => ({
+        verdict: "fail",
+        checks: [{ kind: "test", passed: false }],
+      })),
+    };
+    const coordinator = await SwarmCoordinatorService.start(
+      makeRuntime({
+        [AcpService.serviceType]: acp,
+        "app-verification": verification,
+      }),
+    );
+    const received: SwarmEvent[] = [];
+    coordinator.subscribe((event) => received.push(event));
+
+    acp.emit("sess-plugin-retry", "task_complete", {
+      response:
+        'PLUGIN_CREATE_DONE {"pluginName":"proof-view","files":["src/index.ts"],"tests":{"passed":1,"failed":0},"lint":"ok","typecheck":"ok"}',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(acp.updateSessionMetadata).toHaveBeenCalledWith(
+      "sess-plugin-retry",
+      { retryCount: 1 },
+    );
+    expect(acp.sendPrompt).toHaveBeenCalledWith(
+      "sess-plugin-retry",
+      expect.stringContaining("Verification failed (retry 1/2)"),
+    );
+    expect(acp.sendPrompt.mock.calls[0]?.[1]).toContain('"kind": "test"');
+    expect(received).toHaveLength(0);
+    await coordinator.stop();
+  });
+
+  it.each([
+    {
+      failure: "PromptResult.error",
+      terminal: { stopReason: "end_turn", error: "retry agent crashed" },
+      reportedMessage: "retry agent crashed",
+    },
+    {
+      failure: "stopReason error",
+      terminal: { stopReason: "error" },
+      reportedMessage: "ACP verification retry ended with stopReason error",
+    },
+  ])("escalates and closes the session when a verification retry resolves with $failure", async ({
+    terminal,
+    reportedMessage,
+  }) => {
+    const acp = {
+      ...makeAcpStub({
+        agentType: "codex",
+        workdir: "/tmp/plugin-view",
+        metadata: {
+          onVerificationFail: "retry",
+          maxRetries: 2,
+          retryCount: 0,
+          validator: {
+            service: "app-verification",
+            method: "verifyPlugin",
+            params: { pluginName: "proof-view" },
+          },
+        },
+      }),
+      updateSessionMetadata: vi.fn(async () => {}),
+      sendPrompt: vi.fn(async () => ({
+        sessionId: "sess-plugin-retry-error",
+        response: "",
+        finalText: "",
+        durationMs: 5,
+        exitCode: 1,
+        ...terminal,
+      })),
+      stopSession: vi.fn(async () => {}),
+    };
+    const verification = {
+      verifyPlugin: vi.fn(async () => ({
+        verdict: "fail",
+        checks: [{ kind: "test", passed: false }],
+      })),
+    };
+    const runtime = makeRuntime({
+      [AcpService.serviceType]: acp,
+      "app-verification": verification,
+    });
+    const coordinator = await SwarmCoordinatorService.start(runtime);
+    const received: SwarmEvent[] = [];
+    coordinator.subscribe((event) => received.push(event));
+
+    acp.emit("sess-plugin-retry-error", "task_complete", {
+      response:
+        'PLUGIN_CREATE_DONE {"pluginName":"proof-view","files":["src/index.ts"],"tests":{"passed":1,"failed":0},"lint":"ok","typecheck":"ok"}',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(acp.updateSessionMetadata).toHaveBeenCalledWith(
+      "sess-plugin-retry-error",
+      { retryCount: 1 },
+    );
+    expect(received).toHaveLength(1);
+    expect(received[0]).toMatchObject({
+      type: "escalation",
+      sessionId: "sess-plugin-retry-error",
+      data: {
+        summary: "App verification failed: test",
+        verification: { verdict: "fail" },
+      },
+    });
+    expect(runtime.reportError).toHaveBeenCalledWith(
+      "SwarmCoordinator.retryCustomValidator",
+      expect.objectContaining({
+        code: "ACP_VERIFICATION_RETRY_FAILED",
+        message: reportedMessage,
+      }),
+      {
+        sessionId: "sess-plugin-retry-error",
+        retry: 1,
+        maxRetries: 2,
+      },
+    );
+    expect(acp.stopSession).toHaveBeenCalledTimes(1);
+    expect(acp.stopSession).toHaveBeenCalledWith("sess-plugin-retry-error");
+    await coordinator.stop();
+  });
+
+  it("keeps the session alive through fail-retry-pass and stops after the final verdict", async () => {
+    const order: string[] = [];
+    const initialProof =
+      'PLUGIN_CREATE_DONE {"pluginName":"proof-view","files":["src/index.ts"],"tests":{"passed":1,"failed":0},"lint":"ok","typecheck":"ok"}';
+    const retriedProof =
+      'PLUGIN_CREATE_DONE {"pluginName":"proof-view","files":["src/index.ts","src/view.tsx"],"tests":{"passed":2,"failed":0},"lint":"ok","typecheck":"ok"}';
+    const session = {
+      agentType: "codex",
+      workdir: "/tmp/plugin-view",
+      metadata: {
+        onVerificationFail: "retry",
+        maxRetries: 2,
+        retryCount: 0,
+        validator: {
+          service: "app-verification",
+          method: "verifyPlugin",
+          params: { pluginName: "proof-view" },
+        },
+      },
+    };
+    const acp = {
+      ...makeAcpStub(session),
+      getSessionTurnOutput: vi.fn(async () => retriedProof),
+      updateSessionMetadata: vi.fn(async (_id: string, patch: object) => {
+        Object.assign(session.metadata, patch);
+      }),
+      sendPrompt: vi.fn(async () => {
+        order.push("retry-prompt");
+        acp.emit("sess-retry-pass", "task_complete", {
+          response: "Verification fixes are complete.",
+        });
+        return { stopReason: "end_turn" };
+      }),
+      stopSession: vi.fn(async () => {
+        order.push("stop");
+      }),
+    };
+    const verification = {
+      verifyPlugin: vi
+        .fn()
+        .mockImplementationOnce(async () => {
+          order.push("verify-fail");
+          return {
+            verdict: "fail",
+            checks: [{ kind: "test", passed: false }],
+          };
+        })
+        .mockImplementationOnce(async () => {
+          order.push("verify-pass");
+          return { verdict: "pass", checks: [] };
+        }),
+    };
+    const coordinator = await SwarmCoordinatorService.start(
+      makeRuntime({
+        [AcpService.serviceType]: acp,
+        "app-verification": verification,
+      }),
+    );
+    const received: SwarmEvent[] = [];
+    coordinator.subscribe((event) => received.push(event));
+
+    acp.emit("sess-retry-pass", "task_complete", { response: initialProof });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(verification.verifyPlugin).toHaveBeenCalledTimes(2);
+    expect(received).toHaveLength(1);
+    expect(received[0]).toMatchObject({
+      type: "task_complete",
+      data: {
+        summary: "App verification passed.",
+        verification: { verdict: "pass" },
+      },
+    });
+    expect(order).toEqual([
+      "verify-fail",
+      "retry-prompt",
+      "verify-pass",
+      "stop",
+    ]);
+    expect(acp.stopSession).toHaveBeenCalledTimes(1);
+    await coordinator.stop();
+  });
+
   it("fires swarm-complete synthesis after app-verification passes", async () => {
     const acp = makeAcpStub({
       agentType: "codex",
@@ -377,6 +738,71 @@ describe("SwarmCoordinatorService", () => {
       sessionId: "sess-missing-verifier",
       status: "escalation",
       label: "build-site",
+    });
+    await coordinator.stop();
+  });
+
+  it.each([
+    { label: "missing", method: undefined, rendered: "undefined" },
+    {
+      label: "unsupported",
+      method: "destroyEverything",
+      rendered: "destroyEverything",
+    },
+  ])("terminally escalates and closes a $label validator method", async ({
+    method,
+    rendered,
+  }) => {
+    const acp = {
+      ...makeAcpStub({
+        agentType: "codex",
+        workdir: "/tmp/wd",
+        metadata: {
+          label: "build-site",
+          validator: {
+            service: "app-verification",
+            method,
+            params: { appName: "demo-app" },
+          },
+        },
+      }),
+      stopSession: vi.fn(async () => undefined),
+    };
+    const runtime = makeRuntime({ [AcpService.serviceType]: acp });
+    const coordinator = await SwarmCoordinatorService.start(runtime);
+    const received: SwarmEvent[] = [];
+    coordinator.subscribe((event) => received.push(event));
+
+    acp.emit("sess-invalid-validator", "task_complete", {});
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toMatchObject({
+      type: "escalation",
+      sessionId: "sess-invalid-validator",
+      data: {
+        summary: `Unsupported app-verification validator method: ${rendered}`,
+        verification: {
+          source: "custom-validator",
+          validator: {
+            service: "app-verification",
+            method: rendered,
+          },
+          verdict: "fail",
+        },
+      },
+    });
+    expect(runtime.reportError).toHaveBeenCalledWith(
+      "SwarmCoordinator.runCustomValidatorAndDispatch",
+      expect.objectContaining({
+        code: "APP_VERIFICATION_VALIDATOR_METHOD_INVALID",
+      }),
+      { sessionId: "sess-invalid-validator", suppliedMethod: rendered },
+    );
+    expect(acp.stopSession).toHaveBeenCalledOnce();
+    expect(acp.stopSession).toHaveBeenCalledWith("sess-invalid-validator");
+    expect(coordinator.tasks.get("sess-invalid-validator")).toMatchObject({
+      status: "escalation",
     });
     await coordinator.stop();
   });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-control-structural.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-control-structural.test.ts
@@ -64,6 +64,10 @@ describe("TASKS:control structural action", () => {
     );
 
     expect(result?.success).toBe(true);
+    expect(result?.data).toMatchObject({
+      action: "stop",
+      sessionId: "abcdef123456",
+    });
     expect(svc.stopSession).toHaveBeenCalledWith("abcdef123456");
   });
 });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-history.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-history.test.ts
@@ -218,5 +218,6 @@ describe("TASKS:history", () => {
     expect(result?.text).not.toContain("session-b");
     expect(result?.text).not.toContain("session-c");
     expect(result?.data?.sessionIds).toEqual(["session-a"]);
+    expect(acpService.listSessions).toHaveBeenCalledTimes(1);
   });
 });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/tasks-create-validator-lifecycle.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/tasks-create-validator-lifecycle.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Direct TASKS create lifecycle tests use a real AgentRuntime with an
+ * in-memory adapter and a structural ACP service to pin validator ownership,
+ * terminal PromptResult handling, and event cardinality.
+ */
+
+import {
+  AgentRuntime,
+  createCharacter,
+  type IAgentRuntime,
+  InMemoryDatabaseAdapter,
+  type Memory,
+  Service,
+} from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AcpActionService } from "../../src/actions/common.ts";
+import { tasksAction } from "../../src/actions/tasks.ts";
+import type {
+  PromptResult,
+  SessionEventName,
+  SessionInfo,
+  SpawnOptions,
+  SpawnResult,
+} from "../../src/services/types.ts";
+
+const AGENT_ID = "00000000-0000-4000-8000-000000000001";
+const ROOM_ID = "11111111-1111-4111-8111-111111111111";
+const MESSAGE_ID = "22222222-2222-4222-8222-222222222222";
+
+type PromptResultFixture = {
+  stopReason: string;
+  response?: string;
+  finalText?: string;
+  error?: string;
+};
+
+const activeRuntimes: AgentRuntime[] = [];
+
+async function createHarness(
+  promptResult: PromptResultFixture = {
+    stopReason: "end_turn",
+    response: "done",
+    finalText: "done",
+  },
+  emitsPromptTerminalEvents = true,
+) {
+  const stopSession = vi.fn(
+    async (_sessionId: string, _force?: boolean) => undefined,
+  );
+  const emitSessionEvent = vi.fn(
+    (_sessionId: string, _event: SessionEventName, _data: unknown) => undefined,
+  );
+  const metadataBySession = new Map<string, Record<string, unknown>>();
+
+  class HarnessAcpService extends Service implements AcpActionService {
+    static serviceType = "ACP_SUBPROCESS_SERVICE";
+    capabilityDescription =
+      "Deterministic ACP boundary for TASKS lifecycle tests";
+    readonly emitsPromptTerminalEvents = emitsPromptTerminalEvents;
+    readonly resolveAgentType = vi.fn(async () => "codex");
+    readonly spawnSession = vi.fn(
+      async (opts: SpawnOptions): Promise<SpawnResult> => {
+        const metadata = opts.metadata ?? {};
+        metadataBySession.set("session-1", metadata);
+        return {
+          sessionId: "session-1",
+          id: "session-1",
+          name: "validator-view",
+          agentType: "codex",
+          workdir: "/tmp",
+          status: "ready",
+          metadata,
+        };
+      },
+    );
+    readonly sendPrompt = vi.fn(async (): Promise<PromptResult> => {
+      if (emitsPromptTerminalEvents && promptResult.stopReason === "end_turn") {
+        emitSessionEvent("session-1", "task_complete", {
+          response: promptResult.finalText ?? promptResult.response,
+        });
+      }
+      return {
+        sessionId: "session-1",
+        response: promptResult.response ?? "",
+        finalText: promptResult.finalText ?? "",
+        stopReason: promptResult.stopReason,
+        durationMs: 1,
+        ...(promptResult.error ? { error: promptResult.error } : {}),
+      };
+    });
+    readonly sendToSession = vi.fn(
+      async (_sessionId: string, _input: string): Promise<PromptResult> =>
+        this.sendPrompt(),
+    );
+    readonly sendKeysToSession = vi.fn(
+      async (_sessionId: string, _keys?: string) => undefined,
+    );
+    readonly stopSession = stopSession;
+    readonly emitSessionEvent = emitSessionEvent;
+    readonly getSession = vi.fn(
+      async (): Promise<SessionInfo> => ({
+        id: "session-1",
+        name: "validator-view",
+        agentType: "codex",
+        workdir: "/tmp",
+        status: "ready",
+        approvalPreset: "standard",
+        createdAt: new Date(0),
+        lastActivityAt: new Date(0),
+        metadata: metadataBySession.get("session-1"),
+      }),
+    );
+    readonly listSessions = vi.fn(async (): Promise<SessionInfo[]> => []);
+
+    static async start(runtime: IAgentRuntime): Promise<Service> {
+      return new HarnessAcpService(runtime);
+    }
+
+    async stop(): Promise<void> {}
+  }
+
+  const runtime = new AgentRuntime({
+    agentId: AGENT_ID,
+    character: createCharacter({ name: "Tester" }),
+    adapter: new InMemoryDatabaseAdapter(),
+    disableBasicCapabilities: true,
+    enableAutonomy: false,
+    logLevel: "fatal",
+  });
+  activeRuntimes.push(runtime);
+  runtime.setSetting("ELIZA_ORCHESTRATOR_TASK_ROOMS", "0");
+  await runtime.initialize({ skipMigrations: true });
+  await runtime.registerService(HarnessAcpService);
+  await runtime.getServiceLoadPromise(HarnessAcpService.serviceType);
+  const acp = runtime.getService<HarnessAcpService>(
+    HarnessAcpService.serviceType,
+  );
+  if (!acp) {
+    throw new Error("ACP harness service did not start");
+  }
+  const message = {
+    id: MESSAGE_ID,
+    agentId: AGENT_ID,
+    entityId: AGENT_ID,
+    roomId: ROOM_ID,
+    content: { text: "Create the proof view" },
+  } as Memory;
+  const invoke = (parameters: Record<string, unknown>) =>
+    tasksAction.handler(runtime, message, undefined, { parameters });
+  return {
+    acp,
+    emitSessionEvent,
+    invoke,
+    metadataBySession,
+    stopSession,
+  };
+}
+
+describe("TASKS create validator lifecycle", () => {
+  let previousSmithers: string | undefined;
+
+  beforeEach(() => {
+    previousSmithers = process.env.ELIZA_ORCHESTRATOR_SMITHERS;
+    process.env.ELIZA_ORCHESTRATOR_SMITHERS = "0";
+  });
+
+  afterEach(async () => {
+    if (previousSmithers === undefined) {
+      delete process.env.ELIZA_ORCHESTRATOR_SMITHERS;
+    } else {
+      process.env.ELIZA_ORCHESTRATOR_SMITHERS = previousSmithers;
+    }
+    for (const runtime of activeRuntimes.splice(0)) {
+      await runtime.stop();
+      await runtime.close();
+    }
+  });
+
+  it("derives keep-alive from the locked retrying validator contract", async () => {
+    const harness = await createHarness();
+    const result = await harness.invoke({
+      action: "create",
+      task: "Create the proof view",
+      workdir: "/tmp",
+      lockWorkdir: true,
+      validator: {
+        service: "app-verification",
+        method: "verifyPlugin",
+        params: { workdir: "/tmp", pluginName: "proof-view" },
+      },
+      maxRetries: 2,
+      onVerificationFail: "retry",
+    });
+
+    expect(result?.success).toBe(true);
+    expect(harness.emitSessionEvent).toHaveBeenCalledWith(
+      "session-1",
+      "task_complete",
+      expect.objectContaining({ response: "done" }),
+    );
+    expect(harness.stopSession).not.toHaveBeenCalled();
+    expect(harness.metadataBySession.get("session-1")).toMatchObject({
+      keepAliveAfterComplete: true,
+      validator: {
+        service: "app-verification",
+        method: "verifyPlugin",
+      },
+    });
+  });
+
+  it("ignores an independently supplied keep-alive flag", async () => {
+    const harness = await createHarness();
+    const result = await harness.invoke({
+      action: "create",
+      task: "Create an ordinary script",
+      workdir: "/tmp",
+      keepAliveAfterComplete: true,
+    });
+
+    expect(result?.success).toBe(true);
+    expect(harness.stopSession).toHaveBeenCalledOnce();
+    expect(harness.metadataBySession.get("session-1")).toMatchObject({
+      keepAliveAfterComplete: false,
+    });
+  });
+
+  it.each([
+    "cancelled",
+    "stopped",
+  ])("reports a %s PromptResult as failed instead of completed", async (stopReason) => {
+    const harness = await createHarness({ stopReason });
+    const result = await harness.invoke({
+      action: "create",
+      task: "Create the proof view",
+      workdir: "/tmp",
+    });
+
+    expect(result?.success).toBe(false);
+    expect(result?.data).toMatchObject({
+      agents: [expect.objectContaining({ status: "failed" })],
+    });
+    expect(
+      harness.emitSessionEvent.mock.calls.filter(
+        ([, event]) => event === "task_complete",
+      ),
+    ).toHaveLength(0);
+    expect(harness.stopSession).toHaveBeenCalledOnce();
+  });
+
+  it("bridges a legacy PromptResult error into exactly one error event", async () => {
+    const harness = await createHarness(
+      { stopReason: "error", error: "agent crashed" },
+      false,
+    );
+    const result = await harness.invoke({
+      action: "create",
+      task: "Create the proof view",
+      workdir: "/tmp",
+    });
+
+    expect(result?.success).toBe(false);
+    expect(
+      harness.emitSessionEvent.mock.calls.filter(
+        ([, event]) => event === "error",
+      ),
+    ).toEqual([
+      [
+        "session-1",
+        "error",
+        expect.objectContaining({ message: "agent crashed" }),
+      ],
+    ]);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/package.json
+++ b/plugins/plugin-agent-orchestrator/package.json
@@ -171,14 +171,14 @@
       },
       "ELIZA_CODEX_ACP_COMMAND": {
         "type": "string",
-        "description": "Native ACP command used for Codex sessions when ELIZA_ACP_TRANSPORT=native. Pin this in production to avoid implicit package upgrades.",
+        "description": "Native ACP command used for Codex sessions when ELIZA_ACP_TRANSPORT=native. The manifest default and legacy @zed-industries default select the isolated managed successor; any other custom command is executed verbatim.",
         "required": false,
-        "default": "npx -y @zed-industries/codex-acp@0.14.0",
+        "default": "npx -y @agentclientprotocol/codex-acp@1.1.2",
         "sensitive": false
       },
       "ELIZA_CODEX_ACP_SANDBOX_MODE": {
         "type": "string",
-        "description": "Optional Codex ACP sandbox_mode override. Accepted values: read-only, workspace-write, danger-full-access.",
+        "description": "Optional managed Codex ACP sandbox mode, passed through INITIAL_AGENT_MODE. Accepted values: read-only, workspace-write, danger-full-access. Custom commands are not rewritten.",
         "required": false,
         "sensitive": false
       },
@@ -197,7 +197,7 @@
       },
       "ELIZA_CODEX_ACP_APPROVAL_POLICY": {
         "type": "string",
-        "description": "Optional Codex ACP approval_policy override. The no-Landlock fallback defaults this to never when unset.",
+        "description": "Optional managed Codex ACP approval policy. Requires an explicit sandbox mode; fixed pairs are read-only/on-request, workspace-write/on-request, and danger-full-access/never. The no-Landlock fallback defaults to never.",
         "required": false,
         "sensitive": false
       },

--- a/plugins/plugin-agent-orchestrator/scripts/live-codex-spawn-e2e.ts
+++ b/plugins/plugin-agent-orchestrator/scripts/live-codex-spawn-e2e.ts
@@ -144,7 +144,7 @@ async function main() {
   acp.onSessionEvent((_sid, event, data) => events.push({ event, data }));
 
   log(
-    "Spawning REAL Codex sub-agent (npx @zed-industries/codex-acp; may take a minute)...",
+    "Spawning REAL Codex sub-agent (npx @agentclientprotocol/codex-acp; may take a minute)...",
   );
   const result = await acp.spawnSession({
     agentType: "codex",

--- a/plugins/plugin-agent-orchestrator/src/__tests__/codex-acp-command.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/codex-acp-command.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Codex ACP bootstrap command contract, including project-manifest isolation.
+ */
+
+import { describe, expect, it } from "vitest";
+import { splitCommandLine } from "../services/acp-native-transport.js";
+import {
+  defaultCodexAcpCommand,
+  resolveCodexAcpCommand,
+  resolveCodexAcpInitialAgentMode,
+} from "../services/acp-service.js";
+
+describe("defaultCodexAcpCommand", () => {
+  it("uses an isolated npm prefix even when the temp path contains spaces", () => {
+    const parsed = splitCommandLine(
+      defaultCodexAcpCommand("/tmp/eliza coding agent"),
+    );
+
+    expect(parsed).toEqual({
+      command: "npx",
+      args: [
+        "-y",
+        "--prefix",
+        "/tmp/eliza coding agent",
+        "--package=@agentclientprotocol/codex-acp@1.1.2",
+        "--",
+        "codex-acp",
+      ],
+    });
+  });
+
+  it("maps successor sandbox settings to its fixed ACP modes", () => {
+    expect(resolveCodexAcpInitialAgentMode("read-only", "on-request")).toBe(
+      "read-only",
+    );
+    expect(resolveCodexAcpInitialAgentMode("workspace-write")).toBe("agent");
+    expect(resolveCodexAcpInitialAgentMode("danger-full-access", "never")).toBe(
+      "agent-full-access",
+    );
+  });
+
+  it("rejects approval settings the successor mode cannot honor", () => {
+    expect(() =>
+      resolveCodexAcpInitialAgentMode("workspace-write", "never"),
+    ).toThrow("requires approval policy on-request");
+  });
+
+  it("removes command-breaking quotes and newlines from the temp path", () => {
+    const parsed = splitCommandLine(defaultCodexAcpCommand('/tmp/a"b\nc'));
+
+    expect(parsed.args[2]).toBe("/tmp/abc");
+  });
+
+  it("upgrades the plugin manifest default but preserves operator commands", () => {
+    const isolated = defaultCodexAcpCommand("/tmp/isolated");
+
+    expect(
+      resolveCodexAcpCommand(
+        "npx -y @zed-industries/codex-acp@0.14.0",
+        isolated,
+      ),
+    ).toBe(isolated);
+    expect(
+      resolveCodexAcpCommand(
+        "npx -y @agentclientprotocol/codex-acp@1.1.2",
+        isolated,
+      ),
+    ).toBe(isolated);
+    expect(
+      resolveCodexAcpCommand(
+        '  custom-codex-acp --mode "operator owned"  ',
+        isolated,
+      ),
+    ).toBe('  custom-codex-acp --mode "operator owned"  ');
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/actions/common.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/common.ts
@@ -28,6 +28,8 @@ import type {
 import { TERMINAL_SESSION_STATUSES } from "../services/types.js";
 
 export interface AcpActionService {
+  /** The service emits its own per-prompt terminal session event. */
+  readonly emitsPromptTerminalEvents?: boolean;
   defaultApprovalPreset?: ApprovalPreset;
   agentSelectionStrategy?: string;
   spawnSession(opts: SpawnOptions): Promise<SpawnResult>;

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -1,28 +1,7 @@
 /**
- * TASKS — single Pattern C parent action that subsumes the orchestrator's
- * task-agent lifecycle, workspace lifecycle, GitHub issue management, and
- * coding-task archive/reopen surface.
- *
- * Each sub-action is exposed as a simile of the parent and dispatched to a
- * per-action runner in this file.
- *
- * Actions:
- *   create               — CREATE_AGENT_TASK / START_CODING_TASK
- *   spawn_agent          — SPAWN_AGENT
- *   send                 — SEND_TO_AGENT
- *   stop_agent           — STOP_AGENT
- *   list_agents          — LIST_AGENTS
- *   cancel               — CANCEL_TASK
- *   history              — TASK_HISTORY
- *   control              — TASK_CONTROL (action: pause|resume|stop|continue|archive|reopen)
- *   share                — TASK_SHARE
- *   provision_workspace  — CREATE_WORKSPACE / PROVISION_WORKSPACE
- *   submit_workspace     — SUBMIT_WORKSPACE / FINALIZE_WORKSPACE
- *   manage_issues        — MANAGE_ISSUES (action: create|list|get|update|comment|close|reopen|add_labels)
- *   archive              — ARCHIVE_CODING_TASK
- *   reopen               — REOPEN_CODING_TASK
- *
- * @module actions/tasks
+ * Unified action surface for orchestrator task, agent, workspace, and issue operations.
+ * Simile actions normalize into a small operation vocabulary before their
+ * runners enforce access, routing, lifecycle, and session-event invariants.
  */
 
 import * as fs from "node:fs";
@@ -40,6 +19,7 @@ import type {
 import {
   ChannelType,
   logger as coreLogger,
+  ElizaError,
   MESSAGE_SOURCE_SUB_AGENT,
   stringToUuid,
 } from "@elizaos/core";
@@ -268,10 +248,52 @@ function additionalSessionMetadata(
   params: Record<string, unknown>,
   content: Record<string, unknown>,
 ): Record<string, unknown> {
+  const validator = objectValue(params.validator ?? content.validator);
+  const maxRetries = params.maxRetries ?? content.maxRetries;
+  const onVerificationFail =
+    typeof (params.onVerificationFail ?? content.onVerificationFail) ===
+    "string"
+      ? (params.onVerificationFail ?? content.onVerificationFail)
+      : undefined;
   return {
     ...(objectValue(content.metadata) ?? {}),
     ...(objectValue(params.metadata) ?? {}),
+    ...(validator ? { validator } : {}),
+    ...(typeof maxRetries === "number" && Number.isInteger(maxRetries)
+      ? { maxRetries }
+      : {}),
+    ...(onVerificationFail ? { onVerificationFail } : {}),
   };
+}
+
+/**
+ * Only the app-verification retry contract may retain a completed one-shot
+ * session. The model-facing boolean is deliberately ignored: a live session
+ * needs a concrete validator, a bounded retry budget, and a locked verifier
+ * workdir matching the task workdir so the coordinator has an owner that will
+ * either retry or close it.
+ */
+function hasVerifiedRetryLifecycle(
+  params: Record<string, unknown>,
+  content: Record<string, unknown>,
+  metadata: Record<string, unknown>,
+): boolean {
+  const validator = objectValue(metadata.validator);
+  const validatorParams = objectValue(validator?.params);
+  const taskWorkdir = pickString(params, content, "workdir");
+  const validatorWorkdir = plainString(validatorParams?.workdir);
+  const maxRetries = metadata.maxRetries;
+  return (
+    validator?.service === "app-verification" &&
+    (validator.method === "verifyApp" || validator.method === "verifyPlugin") &&
+    metadata.onVerificationFail === "retry" &&
+    typeof maxRetries === "number" &&
+    Number.isInteger(maxRetries) &&
+    maxRetries > 0 &&
+    pickBoolean(params, content, "lockWorkdir") === true &&
+    taskWorkdir !== undefined &&
+    validatorWorkdir === taskWorkdir
+  );
 }
 
 function inheritedResolvedWorkdirRoute(
@@ -586,37 +608,51 @@ function looksLikePersonalLifeOpsTask(text: string): boolean {
 // Durable variant of runPromptAndClose: drives the spawned session through the
 // Smithers engine (a persisted, crash-resumable run) instead of a single direct
 // prompt. Single-turn by default, so behaviour matches; enabled by default (see
-// shouldUseSmithersTaskRunner). Emits the same session events as runPromptAndClose.
+// shouldUseSmithersTaskRunner). Terminal events come from AcpService itself;
+// structural test doubles and older services are bridged here when needed.
 async function runPromptViaSmithers(
   service: ReturnType<typeof getAcpService> & {},
   session: SpawnResult,
   task: string,
   timeoutMs: number | undefined,
   model: string | undefined,
+  keepAliveAfterComplete: boolean,
 ): Promise<void> {
   const startedAt = Date.now();
+  let completed = false;
   try {
     const { lastResponse } = await runDurableTask(service, session, task, {
       timeoutMs,
       model,
     });
-    emitSessionEvent(service, session.sessionId, "task_complete", {
-      response: lastResponse ?? "",
-      durationMs: Date.now() - startedAt,
-    });
+    if (service.emitsPromptTerminalEvents !== true) {
+      emitSessionEvent(service, session.sessionId, "task_complete", {
+        response: lastResponse,
+        durationMs: Date.now() - startedAt,
+      });
+    }
+    completed = true;
   } catch (error) {
-    // error-policy:J2 emit an observable 'error' session event, then rethrow.
-    emitSessionEvent(service, session.sessionId, "error", {
-      message: failureMessage(error),
-    });
+    // error-policy:J1 action boundary translates a durable-run failure into the
+    // legacy session-event contract before propagating it to TASKS.
+    if (service.emitsPromptTerminalEvents !== true) {
+      emitSessionEvent(service, session.sessionId, "error", {
+        message: failureMessage(error),
+      });
+    }
     throw error;
   } finally {
-    try {
-      await service.stopSession(session.sessionId);
-    } finally {
-      emitSessionEvent(service, session.sessionId, "stopped", {
-        sessionId: session.sessionId,
-      });
+    // A custom validator owns the session after the successful terminal event
+    // so it can send a corrective prompt on the same ACP conversation. Error
+    // paths still close here because no validator completion can follow them.
+    if (!(completed && keepAliveAfterComplete)) {
+      try {
+        await service.stopSession(session.sessionId);
+      } finally {
+        emitSessionEvent(service, session.sessionId, "stopped", {
+          sessionId: session.sessionId,
+        });
+      }
     }
   }
 }
@@ -627,37 +663,69 @@ async function runPromptAndClose(
   task: string,
   timeoutMs: number | undefined,
   model: string | undefined,
+  keepAliveAfterComplete: boolean,
 ): Promise<void> {
   const startedAt = Date.now();
+  let completed = false;
   try {
     const result = service.sendPrompt
       ? await service.sendPrompt(session.sessionId, task, { timeoutMs, model })
       : await service.sendToSession(session.sessionId, task);
-    if (result.error || result.stopReason === "error") {
-      emitSessionEvent(service, session.sessionId, "error", {
-        message: result.error ?? "acpx prompt ended with stopReason error",
+    if (
+      result.error ||
+      result.stopReason === "error" ||
+      result.stopReason === "cancelled" ||
+      result.stopReason === "stopped"
+    ) {
+      const message =
+        result.error ??
+        (result.stopReason === "cancelled"
+          ? "ACP task prompt was cancelled"
+          : result.stopReason === "stopped"
+            ? "ACP task prompt was stopped"
+            : "ACP task prompt failed");
+      throw new ElizaError(message, {
+        code:
+          result.stopReason === "cancelled"
+            ? "ACP_TASK_PROMPT_CANCELLED"
+            : result.stopReason === "stopped"
+              ? "ACP_TASK_PROMPT_STOPPED"
+              : "ACP_TASK_PROMPT_FAILED",
+        context: {
+          sessionId: session.sessionId,
+          stopReason: result.stopReason,
+        },
+        severity: "ephemeral",
+      });
+    }
+    if (service.emitsPromptTerminalEvents !== true) {
+      emitSessionEvent(service, session.sessionId, "task_complete", {
+        response: result.finalText || result.response,
+        durationMs: result.durationMs || Date.now() - startedAt,
         stopReason: result.stopReason,
       });
-      throw new Error(result.error ?? "acpx prompt failed");
     }
-    emitSessionEvent(service, session.sessionId, "task_complete", {
-      response: result.finalText || result.response,
-      durationMs: result.durationMs || Date.now() - startedAt,
-      stopReason: result.stopReason,
-    });
+    completed = true;
   } catch (error) {
-    // error-policy:J2 emit an observable 'error' session event, then rethrow.
-    emitSessionEvent(service, session.sessionId, "error", {
-      message: failureMessage(error),
-    });
+    // error-policy:J1 action boundary translates one prompt failure into the
+    // legacy session-event contract before propagating it to TASKS. AcpService
+    // advertises structural terminal events and therefore bypasses this bridge.
+    if (service.emitsPromptTerminalEvents !== true) {
+      emitSessionEvent(service, session.sessionId, "error", {
+        message: failureMessage(error),
+      });
+    }
     throw error;
   } finally {
-    try {
-      await service.stopSession(session.sessionId);
-    } finally {
-      emitSessionEvent(service, session.sessionId, "stopped", {
-        sessionId: session.sessionId,
-      });
+    // See runPromptViaSmithers: validator retries need the same live session.
+    if (!(completed && keepAliveAfterComplete)) {
+      try {
+        await service.stopSession(session.sessionId);
+      } finally {
+        emitSessionEvent(service, session.sessionId, "stopped", {
+          sessionId: session.sessionId,
+        });
+      }
     }
   }
 }
@@ -721,6 +789,11 @@ async function runCreate(
   const timeoutMs = getTimeoutMs(params, content);
   const baseLabel = pickString(params, content, "label");
   const extraMetadata = additionalSessionMetadata(params, content);
+  const keepAliveAfterComplete = hasVerifiedRetryLifecycle(
+    params,
+    content,
+    extraMetadata,
+  );
   const originConnectorMessageId = connectorMessageIdFromMemory(
     message,
     content,
@@ -787,6 +860,7 @@ async function runCreate(
           source: content.source,
           workdirRouteId: route?.id,
           workdirRoute: route,
+          keepAliveAfterComplete,
         },
       });
       if (shouldUseSmithersTaskRunner()) {
@@ -796,6 +870,7 @@ async function runCreate(
           taskWithRouteHints,
           timeoutMs,
           model,
+          keepAliveAfterComplete,
         );
       } else {
         await runPromptAndClose(
@@ -804,6 +879,7 @@ async function runCreate(
           taskWithRouteHints,
           timeoutMs,
           model,
+          keepAliveAfterComplete,
         );
       }
       return { session, label, agentType, originalTask: taskWithRouteHints };
@@ -956,17 +1032,13 @@ async function runCreate(
     for (const [index, session] of sessions.entries()) {
       const hint = sessionAttachHints[index];
       try {
-        // Every session that resolved fulfilled above was driven through
-        // runPromptAndClose / runPromptViaSmithers, which stop it in their
-        // `finally` before we reach here. So the `SpawnResult.status` captured
-        // at spawn time is a stale `ready` snapshot — passing it would make
-        // attachSession falsely promote the task to `active` and count a
-        // finished single-turn session as live. Read the real post-run status
-        // from the service instead; a fulfilled outcome always means the
-        // session was stopped, so fall back to a terminal status if its record
-        // is already gone.
+        // The spawn snapshot can be stale after the prompt: ordinary sessions
+        // are stopped, while validator-owned sessions deliberately remain
+        // ready for a corrective turn. Read the real state so the task widget
+        // reflects whichever lifecycle owns the session.
         const refreshed = await service.getSession(session.sessionId);
-        const effectiveStatus = refreshed?.status ?? "stopped";
+        const effectiveStatus =
+          refreshed?.status ?? (keepAliveAfterComplete ? "ready" : "stopped");
         await taskService.attachSession(threadId, {
           sessionId: session.sessionId,
           agentType: session.agentType,
@@ -1176,12 +1248,12 @@ async function runSpawnAgent(
     const approvalPreset = parseApproval(
       pickString(params, content, "approvalPreset"),
     );
-    const keepAliveAfterComplete = pickBoolean(
+    const extraMetadata = additionalSessionMetadata(params, content);
+    const keepAliveAfterComplete = hasVerifiedRetryLifecycle(
       params,
       content,
-      "keepAliveAfterComplete",
+      extraMetadata,
     );
-    const extraMetadata = additionalSessionMetadata(params, content);
     // Structural only: the planner emits deferUserReply when the user asked for
     // no interim reply. No regex over the task text (the model judges intent).
     const deferUserReply =
@@ -3433,13 +3505,6 @@ export const tasksAction: Action & {
         type: "string" as const,
         enum: ["readonly", "standard", "permissive", "autonomous"],
       },
-    },
-    {
-      name: "keepAliveAfterComplete",
-      description:
-        "Keep session alive after completion for action=spawn_agent.",
-      required: false,
-      schema: { type: "boolean" as const },
     },
     {
       name: "deferUserReply",

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -35,6 +35,7 @@ import { homedir, tmpdir } from "node:os";
 import { basename, delimiter, dirname, join, resolve, sep } from "node:path";
 import {
   SUB_AGENT_CREDENTIAL_PARENT_CAPABILITY_SERVICE as CORE_SUB_AGENT_CREDENTIAL_PARENT_CAPABILITY_SERVICE,
+  ElizaError,
   type IAgentRuntime,
   Service,
 } from "@elizaos/core";
@@ -46,9 +47,7 @@ import {
 } from "./acp-provisioning.js";
 import { augmentTaskWithDeployGuidance } from "./app-deploy-guidance.js";
 import {
-  appendCodexAcpSandboxConfig,
   type CodexSandboxMode,
-  commandHasCodexSandboxConfig,
   detectLandlockAvailability,
   isCodexLandlockPanic,
   normalizeCodexApprovalPolicy,
@@ -189,8 +188,83 @@ const LEASE_REVOKE_EVENTS: ReadonlySet<SessionEventName> = new Set([
   "error",
   "cancelled",
 ]);
+
+function isIncompletePromptStopReason(stopReason: string | undefined): boolean {
+  const reason = (stopReason ?? "").toLowerCase();
+  return (
+    reason.includes("max") ||
+    reason.includes("length") ||
+    reason.includes("interrupt")
+  );
+}
+
 const DEFAULT_WORKDIR_ROOT = join(tmpdir(), "eliza-acp");
-const DEFAULT_CODEX_ACP_COMMAND = "npx -y @zed-industries/codex-acp@0.14.0";
+const SUCCESSOR_CODEX_ACP_PACKAGE = "@agentclientprotocol/codex-acp@1.1.2";
+const LEGACY_CODEX_ACP_COMMAND = "npx -y @zed-industries/codex-acp@0.14.0";
+const DECLARED_SUCCESSOR_CODEX_ACP_COMMAND = `npx -y ${SUCCESSOR_CODEX_ACP_PACKAGE}`;
+
+/**
+ * Bootstrap codex-acp outside the caller's project manifest. npm validates a
+ * working tree's direct-dependency/override pairs before `npx` starts its
+ * requested package, so an unrelated host manifest conflict can otherwise
+ * prevent every Codex session from reaching the ACP handshake. The explicit
+ * package selection and argument boundary keep npm's own flags separate from
+ * the adapter's Codex configuration flags.
+ */
+export function defaultCodexAcpCommand(tempRoot = tmpdir()): string {
+  const safeTempRoot = tempRoot.replace(/["\r\n]/gu, "");
+  return `npx -y --prefix "${safeTempRoot}" --package=${SUCCESSOR_CODEX_ACP_PACKAGE} -- codex-acp`;
+}
+
+const DEFAULT_CODEX_ACP_COMMAND = defaultCodexAcpCommand();
+
+export function resolveCodexAcpCommand(
+  configured: string | undefined,
+  fallback = DEFAULT_CODEX_ACP_COMMAND,
+): string {
+  if (!configured) return fallback;
+  const trimmed = configured.trim();
+  if (
+    !trimmed ||
+    trimmed === LEGACY_CODEX_ACP_COMMAND ||
+    trimmed === DECLARED_SUCCESSOR_CODEX_ACP_COMMAND
+  ) {
+    return fallback;
+  }
+  return configured;
+}
+
+type CodexAcpInitialAgentMode = "read-only" | "agent" | "agent-full-access";
+
+/**
+ * The maintained Codex ACP server exposes sandbox and approval as three fixed
+ * mode pairs. Rejecting an impossible pair keeps an operator setting from
+ * appearing to apply while the adapter silently chooses different semantics.
+ */
+export function resolveCodexAcpInitialAgentMode(
+  sandboxMode: CodexSandboxMode,
+  approvalPolicy?: string,
+): CodexAcpInitialAgentMode {
+  const mode =
+    sandboxMode === "read-only"
+      ? "read-only"
+      : sandboxMode === "workspace-write"
+        ? "agent"
+        : "agent-full-access";
+  const supportedApproval =
+    mode === "agent-full-access" ? "never" : "on-request";
+  if (approvalPolicy && approvalPolicy !== supportedApproval) {
+    throw new ElizaError(
+      `Codex ACP mode ${mode} requires approval policy ${supportedApproval}`,
+      {
+        code: "CODEX_ACP_MODE_CONFLICT",
+        context: { sandboxMode, approvalPolicy, supportedApproval },
+        severity: "fatal",
+      },
+    );
+  }
+  return mode;
+}
 const CODEX_NO_LANDLOCK_SANDBOX_MODE: CodexSandboxMode = "danger-full-access";
 const CODEX_NO_LANDLOCK_APPROVAL_POLICY = "never";
 /**
@@ -620,13 +694,15 @@ export function resolveInitialTaskPromptTimeoutMs(
   return explicitTimeoutMs ?? 0;
 }
 const DEFAULT_AGENTS: AgentType[] = ["elizaos", "codex", "claude", "opencode"];
-// Path segment the app-core coding-account bridge uses for per-account Codex
-// homes (`<stateDir>/auth/_codex-home/<accountId>`). buildEnv keys off this
-// marker to know a subscription account was selected and drop a forwarded
-// OPENAI_API_KEY that would otherwise override the per-account auth.json. Kept
-// in sync with coding-account-bridge.ts:codexHomeDir (cross-package, no shared
-// import — the orchestrator depends only on @elizaos/core).
+// Path segment for Codex homes whose auth.json carries a selected ChatGPT
+// subscription. The marker stays in sync with
+// coding-account-bridge.ts:codexHomeDir; ordinary CODEX_HOME paths may instead
+// be API-key homes and must never trigger subscription credential stripping.
 const CODEX_PER_ACCOUNT_HOME_MARKER = "_codex-home";
+
+function isCodexSubscriptionHome(home: string | undefined): boolean {
+  return Boolean(home?.includes(CODEX_PER_ACCOUNT_HOME_MARKER));
+}
 const DENY_ENV_PATTERNS = [
   /DISCORD.*TOKEN/i,
   /TELEGRAM.*TOKEN/i,
@@ -665,6 +741,8 @@ export const ACP_SUBPROCESS_SERVICE_TYPE =
 
 export class AcpService extends Service {
   static serviceType = ACP_SUBPROCESS_SERVICE_TYPE;
+  /** sendPrompt owns terminal event emission for both native and CLI transports. */
+  readonly emitsPromptTerminalEvents = true;
 
   // Process-wide registry of live AcpService instances. The SIGTERM/SIGINT
   // listener is registered exactly ONCE per Node process and fans out to
@@ -716,6 +794,10 @@ export class AcpService extends Service {
   private readonly nativeCancelledPromptSessionIds = new Set<string>();
   private readonly nativeStoppingSessionIds = new Set<string>();
   private readonly outputBuffers = new Map<string, string[]>();
+  // Full session output remains available for history, while custom validators
+  // need the exact latest prompt turn so a retry cannot re-consume an older
+  // completion proof from the same long-lived ACP session.
+  private readonly turnOutputBuffers = new Map<string, string[]>();
   // Sessions whose raw stdout has been teed to disk at least once. Drives the
   // `task_complete` stdoutLogPath reference: only sessions that actually wrote a
   // file get the path attached, so the task document never points at a
@@ -1383,6 +1465,13 @@ export class AcpService extends Service {
       if (Number.isFinite(lastActivityMs) && lastActivityMs > liveCutoffMs) {
         continue;
       }
+      // A native transport client is the live session state. Its protocol
+      // session id belongs to the adapter (Codex, Claude, etc.), not to acpx's
+      // on-disk session store, so probing that store would falsely declare a
+      // healthy long-running prompt lost whenever it pauses past the grace
+      // window. Detached CLI sessions have no attached client and still take
+      // the state-artifact recovery path below.
+      if (this.nativeClients.has(s.id)) continue;
       const { exists } = await this.acpxSessionStateStat(s.acpxSessionId);
       if (!exists) {
         // Descriptive status, NOT an imperative. The old text literally said
@@ -1439,6 +1528,7 @@ export class AcpService extends Service {
     }
     for (const id of swept) {
       this.outputBuffers.delete(id);
+      this.turnOutputBuffers.delete(id);
       this.changedPathsBySession.delete(id);
       this.nativeClients.delete(id);
       this.persistedStdoutSessions.delete(id);
@@ -1895,6 +1985,7 @@ export class AcpService extends Service {
       // onto the same native session. Teardown on the pre-prompt error paths;
       // sendNativePrompt's own finally clears it on the normal path.
       this.nativePromptSessionIds.add(sessionId);
+      this.turnOutputBuffers.set(sessionId, []);
       try {
         await this.store.updateStatus(sessionId, "busy");
         return await this.sendNativePrompt(session, text, opts, startedAt);
@@ -1905,6 +1996,7 @@ export class AcpService extends Service {
         throw err;
       }
     }
+    this.turnOutputBuffers.set(sessionId, []);
     await this.store.updateStatus(sessionId, "busy");
     const args = this.baseArgs({
       workdir: session.workdir,
@@ -2119,6 +2211,7 @@ export class AcpService extends Service {
     await this.removeOwnedGitIndex(session);
     await this.store.delete(sessionId);
     this.outputBuffers.delete(sessionId);
+    this.turnOutputBuffers.delete(sessionId);
     this.changedPathsBySession.delete(sessionId);
     this.persistedStdoutSessions.delete(sessionId);
     this.pendingStdoutWrites.delete(sessionId);
@@ -2359,6 +2452,11 @@ export class AcpService extends Service {
     return (this.outputBuffers.get(sessionId) ?? []).slice(-lines).join("");
   }
 
+  /** Output captured during the most recent prompt turn only. */
+  async getSessionTurnOutput(sessionId: string, lines = 200): Promise<string> {
+    return (this.turnOutputBuffers.get(sessionId) ?? []).slice(-lines).join("");
+  }
+
   private baseArgs(opts: {
     workdir: string;
     approvalPreset: ApprovalPreset;
@@ -2427,59 +2525,96 @@ export class AcpService extends Service {
     return mode ?? CODEX_NO_LANDLOCK_SANDBOX_MODE;
   }
 
-  private codexAgentCommand(): string {
-    const command =
-      this.setting("ELIZA_CODEX_ACP_COMMAND") ?? DEFAULT_CODEX_ACP_COMMAND;
-    const configuredSandboxMode = this.codexAcpSandboxMode();
-    if (configuredSandboxMode) {
-      return appendCodexAcpSandboxConfig(
-        command,
-        configuredSandboxMode,
-        this.codexAcpApprovalPolicy() ??
-          (configuredSandboxMode === "danger-full-access"
+  private validateManagedCodexAcpModeConfiguration(): void {
+    const sandboxMode = this.codexAcpSandboxMode();
+    const approvalPolicy = this.codexAcpApprovalPolicy();
+    if (!sandboxMode && approvalPolicy) {
+      throw new ElizaError(
+        "Managed Codex ACP approval policy requires an explicit sandbox mode",
+        {
+          code: "CODEX_ACP_MODE_CONFLICT",
+          context: { approvalPolicy },
+          severity: "fatal",
+        },
+      );
+    }
+    if (sandboxMode) {
+      resolveCodexAcpInitialAgentMode(
+        sandboxMode,
+        approvalPolicy ??
+          (sandboxMode === "danger-full-access"
             ? CODEX_NO_LANDLOCK_APPROVAL_POLICY
             : undefined),
       );
     }
-    if (commandHasCodexSandboxConfig(command)) return command;
-
-    const landlock = detectLandlockAvailability({
-      env: {
-        ELIZA_CODEX_ACP_LANDLOCK: this.setting("ELIZA_CODEX_ACP_LANDLOCK"),
-        ELIZA_CODEX_LANDLOCK: this.setting("ELIZA_CODEX_LANDLOCK"),
-      },
-    });
-    if (landlock !== "unavailable") return command;
-
-    this.log(
-      "warn",
-      "Landlock unavailable; starting Codex ACP with sandbox fallback",
-      {
-        sandboxMode: this.codexNoLandlockSandboxMode(),
-        approvalPolicy:
-          this.codexAcpApprovalPolicy() ?? CODEX_NO_LANDLOCK_APPROVAL_POLICY,
-      },
-    );
-    return appendCodexAcpSandboxConfig(
-      command,
-      this.codexNoLandlockSandboxMode(),
-      this.codexAcpApprovalPolicy() ?? CODEX_NO_LANDLOCK_APPROVAL_POLICY,
-    );
   }
 
-  private codexLandlockFallbackCommand(
+  private managedCodexAcpInitialAgentMode(
+    forceNoLandlockFallback = false,
+  ): CodexAcpInitialAgentMode | undefined {
+    this.validateManagedCodexAcpModeConfiguration();
+    const configuredSandboxMode = this.codexAcpSandboxMode();
+    const landlock =
+      configuredSandboxMode || forceNoLandlockFallback
+        ? undefined
+        : detectLandlockAvailability({
+            env: {
+              ELIZA_CODEX_ACP_LANDLOCK: this.setting(
+                "ELIZA_CODEX_ACP_LANDLOCK",
+              ),
+              ELIZA_CODEX_LANDLOCK: this.setting("ELIZA_CODEX_LANDLOCK"),
+            },
+          });
+    const sandboxMode = forceNoLandlockFallback
+      ? this.codexNoLandlockSandboxMode()
+      : (configuredSandboxMode ??
+        (landlock === "unavailable"
+          ? this.codexNoLandlockSandboxMode()
+          : undefined));
+    if (!sandboxMode) return undefined;
+    const approvalPolicy =
+      this.codexAcpApprovalPolicy() ??
+      (sandboxMode === "danger-full-access"
+        ? CODEX_NO_LANDLOCK_APPROVAL_POLICY
+        : undefined);
+    const mode = resolveCodexAcpInitialAgentMode(sandboxMode, approvalPolicy);
+    if (!configuredSandboxMode && landlock === "unavailable") {
+      this.log(
+        "warn",
+        "Codex ACP Landlock unavailable; starting with sandbox fallback",
+        {
+          sandboxMode,
+          approvalPolicy: mode === "agent-full-access" ? "never" : "on-request",
+        },
+      );
+    }
+    return mode;
+  }
+
+  private codexAgentCommand(): string {
+    const command = resolveCodexAcpCommand(
+      this.setting("ELIZA_CODEX_ACP_COMMAND"),
+    );
+    if (command === DEFAULT_CODEX_ACP_COMMAND) {
+      this.validateManagedCodexAcpModeConfiguration();
+    }
+    // Operator commands are opaque adapter boundaries. Mutating them with
+    // flags from a different codex-acp generation can silently change their
+    // argv contract, so only the declared legacy default is upgraded above.
+    return command;
+  }
+
+  private shouldRetryManagedCodexLandlock(
     agentType: AgentType,
     command: string,
     message: string,
-  ): string | undefined {
+  ): boolean {
     if ((normalizeTaskAgentAdapter(agentType) ?? agentType) !== "codex")
-      return undefined;
-    if (!isCodexLandlockPanic(message)) return undefined;
-    if (commandHasCodexSandboxConfig(command)) return undefined;
-    return appendCodexAcpSandboxConfig(
-      command,
-      this.codexAcpSandboxMode() ?? this.codexNoLandlockSandboxMode(),
-      this.codexAcpApprovalPolicy() ?? CODEX_NO_LANDLOCK_APPROVAL_POLICY,
+      return false;
+    return (
+      command === DEFAULT_CODEX_ACP_COMMAND &&
+      !this.codexAcpSandboxMode() &&
+      isCodexLandlockPanic(message)
     );
   }
 
@@ -2489,7 +2624,11 @@ export class AcpService extends Service {
     opts: SpawnOptions,
   ): Promise<SpawnResult> {
     const command = this.nativeAgentCommand(session.agentType);
-    const createClient = (clientCommand: string, stderr: string[]) =>
+    const createClient = (
+      clientCommand: string,
+      stderr: string[],
+      codexInitialAgentModeOverride?: CodexAcpInitialAgentMode,
+    ) =>
       new NativeAcpClient({
         command: clientCommand,
         cwd: session.workdir,
@@ -2502,6 +2641,7 @@ export class AcpService extends Service {
           opts.model,
           session.agentType,
           id,
+          codexInitialAgentModeOverride,
         ),
         // Auto-inherit the parent runtime's configured MCP servers (config
         // `mcp.servers`) so the sub-agent gets the same MCP tools. Undefined when
@@ -2571,25 +2711,26 @@ export class AcpService extends Service {
       // the failure happened before the set.
       this.nativeClients.delete(id);
       let message = stderr.join("").trim() || errorMessage(err);
-      const fallbackCommand = this.codexLandlockFallbackCommand(
+      const shouldRetryLandlock = this.shouldRetryManagedCodexLandlock(
         session.agentType,
         command,
         message,
       );
-      if (fallbackCommand) {
+      if (shouldRetryLandlock) {
+        const fallbackSandboxMode = this.codexNoLandlockSandboxMode();
+        const fallbackMode = this.managedCodexAcpInitialAgentMode(true);
         this.log(
           "warn",
           "Codex ACP Landlock unavailable; retrying with sandbox fallback",
           {
             sessionId: id,
-            sandboxMode: this.codexNoLandlockSandboxMode(),
+            sandboxMode: fallbackSandboxMode,
             approvalPolicy:
-              this.codexAcpApprovalPolicy() ??
-              CODEX_NO_LANDLOCK_APPROVAL_POLICY,
+              fallbackMode === "agent-full-access" ? "never" : "on-request",
           },
         );
         stderr = [];
-        client = createClient(fallbackCommand, stderr);
+        client = createClient(command, stderr, fallbackMode);
         try {
           return await attachClient(client);
         } catch (retryErr) {
@@ -3009,7 +3150,8 @@ export class AcpService extends Service {
           const cleanCompletion =
             !record.cancelled &&
             (code === 0 || code === null) &&
-            finalText.trim().length > 0;
+            finalText.trim().length > 0 &&
+            !isIncompletePromptStopReason(stopReason);
           if (record.cancelled) {
             this.emitSessionEvent(opts.sessionId, "cancelled", {
               sessionId: opts.sessionId,
@@ -3034,7 +3176,7 @@ export class AcpService extends Service {
               exitCode: code,
               ...this.stdoutLogRef(opts.sessionId),
             });
-          } else {
+          } else if (!isIncompletePromptStopReason(stopReason)) {
             this.emitSessionEvent(opts.sessionId, "stopped", {
               sessionId: opts.sessionId,
               response: finalText,
@@ -3364,14 +3506,10 @@ export class AcpService extends Service {
             sourceEventId: `${sessionId}:${startedAt}`,
           });
         }
-        // Treat any non-error terminal stopReason as a completion so
-        // downstream evaluators get a chance to summarize the work for
-        // the user. claude-agent-sdk emits a variety of stopReasons
-        // (`end_turn`, `max_tokens`, `interrupted`, `tool_use`, ...);
-        // limiting completion to `end_turn` silently dropped sessions
-        // that hit token limits, ran out of turns, or stopped for any
-        // other non-error reason — the sub-agent did real work (commits,
-        // edits, deploys) and the user got nothing back.
+        // Truncated and interrupted turns remain resumable input to the durable
+        // task loop. Advertising them as task_complete would let downstream
+        // stores and the user observe success before the loop continues or
+        // rejects the exhausted run.
         // A terminal stopReason of `error` does NOT mean the work was lost: the
         // sub-agent often wrote files, deployed, and printed a verified result
         // before its LAST step errored (a flaky post-build verify, a lint exit,
@@ -3384,18 +3522,32 @@ export class AcpService extends Service {
         if (deferPromptTerminalEvent) {
           return { finalText, stopReason };
         }
-        if (stopReason === "error" && !finalText?.trim()) {
-          this.emitSessionEvent(sessionId, "error", {
-            message: "acpx prompt ended with stopReason error",
-            stopReason,
-          });
-        } else {
-          this.emitSessionEvent(sessionId, "task_complete", {
-            response: finalText,
-            durationMs: Date.now() - startedAt,
-            stopReason,
-            ...this.stdoutLogRef(sessionId),
-          });
+        if (!isIncompletePromptStopReason(stopReason)) {
+          if (stopReason === "cancelled") {
+            this.emitSessionEvent(sessionId, "cancelled", {
+              response: finalText,
+              durationMs: Date.now() - startedAt,
+              stopReason,
+            });
+          } else if (stopReason === "stopped") {
+            this.emitSessionEvent(sessionId, "stopped", {
+              response: finalText,
+              durationMs: Date.now() - startedAt,
+              stopReason,
+            });
+          } else if (stopReason === "error" && !finalText?.trim()) {
+            this.emitSessionEvent(sessionId, "error", {
+              message: "acpx prompt ended with stopReason error",
+              stopReason,
+            });
+          } else {
+            this.emitSessionEvent(sessionId, "task_complete", {
+              response: finalText,
+              durationMs: Date.now() - startedAt,
+              stopReason,
+              ...this.stdoutLogRef(sessionId),
+            });
+          }
         }
       }
     }
@@ -3651,6 +3803,7 @@ export class AcpService extends Service {
     model?: string,
     agentType?: AgentType,
     childSessionId?: string,
+    codexInitialAgentModeOverride?: CodexAcpInitialAgentMode,
   ): NodeJS.ProcessEnv {
     // Deny-list-filtered, allowlisted, casing-canonicalized host env (see
     // forwardableSubAgentEnv / canonicalForwardedEnvKey — Bun on Windows reports
@@ -3710,6 +3863,15 @@ export class AcpService extends Service {
     if (childSessionId?.trim()) {
       env.PARALLAX_SESSION_ID = childSessionId.trim();
     }
+    if (
+      agentType === "codex" &&
+      resolveCodexAcpCommand(this.setting("ELIZA_CODEX_ACP_COMMAND")) ===
+        DEFAULT_CODEX_ACP_COMMAND
+    ) {
+      const initialAgentMode =
+        codexInitialAgentModeOverride ?? this.managedCodexAcpInitialAgentMode();
+      if (initialAgentMode) env.INITIAL_AGENT_MODE = initialAgentMode;
+    }
     if (agentType === "claude") {
       // Config-env (UI-saved, restart-free — falls back to process.env) effort
       // override for the spawned Claude Code CLI.
@@ -3758,10 +3920,9 @@ export class AcpService extends Service {
     if (
       agentType === "codex" &&
       typeof env.CODEX_HOME === "string" &&
-      env.CODEX_HOME.includes(CODEX_PER_ACCOUNT_HOME_MARKER)
+      isCodexSubscriptionHome(env.CODEX_HOME)
     ) {
-      // A specific Codex subscription account was selected: its ChatGPT-login
-      // auth.json lives in the injected per-account CODEX_HOME.
+      // A Codex ChatGPT subscription login lives in the injected CODEX_HOME.
       if (env.OPENAI_API_KEY) {
         // Codex treats a present env OPENAI_API_KEY as api-key mode, which
         // OVERRIDES that subscription login — silently defeating multi-account
@@ -3770,7 +3931,7 @@ export class AcpService extends Service {
         delete env.OPENAI_API_KEY;
         this.log(
           "debug",
-          "Dropped OPENAI_API_KEY for codex sub-agent in favor of selected per-account CODEX_HOME",
+          "Dropped OPENAI_API_KEY for codex sub-agent in favor of subscription CODEX_HOME",
         );
       }
       if (env.OPENAI_MODEL) {
@@ -4039,6 +4200,13 @@ export class AcpService extends Service {
     buffer.push(text);
     if (buffer.length > 2_000) buffer.splice(0, buffer.length - 2_000);
     this.outputBuffers.set(sessionId, buffer);
+    const turnBuffer = this.turnOutputBuffers.get(sessionId);
+    if (turnBuffer) {
+      turnBuffer.push(text);
+      if (turnBuffer.length > 2_000) {
+        turnBuffer.splice(0, turnBuffer.length - 2_000);
+      }
+    }
   }
 
   // Tool-call arg keys that carry a target file path / signal a write.

--- a/plugins/plugin-agent-orchestrator/src/services/codex-sandbox.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/codex-sandbox.ts
@@ -1,8 +1,7 @@
 /**
- * Codex ACP sandbox configuration: normalizes `sandbox_mode` / `approval_policy`
- * overrides and probes Linux Landlock availability so the orchestrator can hand
- * a spawned Codex agent a safe-but-workable filesystem sandbox, falling back to
- * `danger-full-access` where Landlock is unavailable.
+ * Normalizes managed Codex ACP sandbox settings and probes Linux Landlock
+ * availability so the orchestrator can select a supported successor mode,
+ * falling back to `danger-full-access` where Landlock is unavailable.
  */
 import { existsSync, readFileSync } from "node:fs";
 import { platform } from "node:os";
@@ -92,48 +91,6 @@ export function detectLandlockAvailability(
   }
 }
 
-export function commandHasCodexConfigKey(
-  command: string,
-  key: string,
-): boolean {
-  const args = splitCommandLineArgs(command);
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] !== "-c" && args[i] !== "--config") continue;
-    const value = args[i + 1]?.trim();
-    if (value?.startsWith(`${key}=`)) return true;
-  }
-  return false;
-}
-
-export function commandHasCodexSandboxConfig(command: string): boolean {
-  const args = splitCommandLineArgs(command);
-  return (
-    commandHasCodexConfigKey(command, "sandbox_mode") ||
-    args.includes("--dangerously-bypass-approvals-and-sandbox") ||
-    args.some(
-      (arg, index) =>
-        arg === "-s" &&
-        CODEX_SANDBOX_MODES.has(args[index + 1] as CodexSandboxMode),
-    )
-  );
-}
-
-export function appendCodexAcpSandboxConfig(
-  command: string,
-  sandboxMode: CodexSandboxMode,
-  approvalPolicy?: string,
-): string {
-  const args: string[] = [];
-  if (!commandHasCodexSandboxConfig(command)) {
-    args.push("-c", `sandbox_mode=${sandboxMode}`);
-  }
-  if (approvalPolicy && !commandHasCodexConfigKey(command, "approval_policy")) {
-    args.push("-c", `approval_policy=${approvalPolicy}`);
-  }
-  if (args.length === 0) return command.trim();
-  return [command.trim(), ...args].filter(Boolean).join(" ");
-}
-
 export function isCodexLandlockPanic(text: string): boolean {
   const normalized = text.toLowerCase();
   return (
@@ -144,11 +101,5 @@ export function isCodexLandlockPanic(text: string): boolean {
     (normalized.includes("panicked") ||
       normalized.includes("code 101") ||
       normalized.includes("exited with code 101"))
-  );
-}
-
-function splitCommandLineArgs(input: string): string[] {
-  return (input.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/gu) ?? []).map((part) =>
-    part.replace(/^(['"])(.*)\1$/u, "$2"),
   );
 }

--- a/plugins/plugin-agent-orchestrator/src/services/smithers-task-executor.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/smithers-task-executor.ts
@@ -5,6 +5,7 @@
  * coupling the runner to AcpService internals.
  */
 
+import { ElizaError } from "@elizaos/core";
 import type {
   TaskApprovalResult,
   TaskProvisionResult,
@@ -65,6 +66,9 @@ export function detectTurnDone(result: {
   if (result.error) return false;
   const reason = (result.stopReason ?? "").toLowerCase();
   if (
+    reason === "error" ||
+    reason === "cancelled" ||
+    reason === "stopped" ||
     reason.includes("max") ||
     reason.includes("length") ||
     reason.includes("interrupt")
@@ -131,8 +135,30 @@ export class SmithersTaskExecutor implements TaskStepExecutor {
         : (this.opts.continuePrompt ??
           "Continue working on the task. Reply when complete.");
     const result = await this.acp.sendPrompt(sessionId, prompt);
-    if (result.error) {
-      this.lastError = new Error(result.error);
+    const stopReason = (result.stopReason ?? "").toLowerCase();
+    if (
+      result.error ||
+      stopReason === "error" ||
+      stopReason === "cancelled" ||
+      stopReason === "stopped"
+    ) {
+      const message =
+        result.error ??
+        (stopReason === "cancelled"
+          ? "ACP task prompt was cancelled"
+          : stopReason === "stopped"
+            ? "ACP task prompt was stopped"
+            : "ACP task prompt failed");
+      this.lastError = new ElizaError(message, {
+        code:
+          stopReason === "cancelled"
+            ? "ACP_TASK_PROMPT_CANCELLED"
+            : stopReason === "stopped"
+              ? "ACP_TASK_PROMPT_STOPPED"
+              : "ACP_TASK_PROMPT_FAILED",
+        context: { sessionId, stopReason: result.stopReason },
+        severity: "ephemeral",
+      });
       throw this.lastError;
     }
     this.lastResponse =

--- a/plugins/plugin-agent-orchestrator/src/services/smithers-task-integration.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/smithers-task-integration.ts
@@ -5,10 +5,10 @@
  * path when Smithers is disabled.
  */
 
+import { ElizaError } from "@elizaos/core";
 import type { AcpLike } from "./smithers-task-executor";
 import { SmithersTaskExecutor } from "./smithers-task-executor";
 import { runTaskWithSmithers } from "./smithers-task-runner";
-import type { TaskRunStatus } from "./smithers-task-types";
 
 type PromptOut = {
   stopReason?: string;
@@ -87,8 +87,8 @@ export async function runDurableTask(
   task: string,
   opts: { timeoutMs?: number; model?: string; maxTurns?: number } = {},
 ): Promise<{
-  status: TaskRunStatus;
-  lastResponse: string | undefined;
+  status: "completed";
+  lastResponse: string;
   turns: number;
 }> {
   const executor = new SmithersTaskExecutor(
@@ -109,9 +109,31 @@ export async function runDurableTask(
   // A single-turn loop can swallow a turn throw via onMaxReached='return-last';
   // surface it so the host reports the failure (matching the direct path).
   if (executor.lastError) throw executor.lastError;
+  if (result.status !== "completed") {
+    throw new ElizaError("Durable task did not reach completion", {
+      code: "SMITHERS_TASK_INCOMPLETE",
+      context: {
+        sessionId: session.sessionId,
+        status: result.status,
+        turns: result.turns,
+      },
+      severity: "ephemeral",
+    });
+  }
+  const lastResponse = executor.lastResponse;
+  if (typeof lastResponse !== "string" || lastResponse.trim().length === 0) {
+    throw new ElizaError("Durable task completed without a response", {
+      code: "SMITHERS_TASK_RESPONSE_MISSING",
+      context: {
+        sessionId: session.sessionId,
+        status: result.status,
+        turns: result.turns,
+      },
+    });
+  }
   return {
-    status: result.status,
-    lastResponse: executor.lastResponse,
+    status: "completed",
+    lastResponse,
     turns: result.turns,
   };
 }

--- a/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
@@ -1,55 +1,7 @@
 /**
- * @module services/swarm-coordinator-service
- *
- * SWARM_COORDINATOR service: the discoverable runtime adapter that bridges the
- * orchestrator's `AcpService` session-event stream to the consumers that still
- * speak the legacy "swarm coordinator" interface.
- *
- * ## Why this exists
- *
- * The `plugin-acpx` + `plugin-agent-orchestrator` consolidation
- * (`dc1b89c2eb`) deleted `pty-service.ts` and `swarm-coordinator.ts`. The old
- * `PtyService.start()` constructed a `SwarmCoordinator`, started it, and
- * registered it on the runtime under `SWARM_COORDINATOR`. With those files
- * gone, NOTHING registers a `SWARM_COORDINATOR` service anymore — but three
- * consumers were never migrated and still discover it via
- * `runtime.getService("SWARM_COORDINATOR")` (or `PTY_SERVICE.coordinator`):
- *
- *   1. `packages/agent/src/api/coordinator-wiring.ts`
- *      (`wireCoordinatorBridgesWhenReady`) polls for the service for 90s and,
- *      when it never appears, logs
- *      `coordinator not available after 90s — coding agent features disabled`
- *      and leaves the chat / ws / event-routing / swarm-synthesis bridges
- *      unwired.
- *   2. `packages/agent/src/api/server-helpers-swarm.ts`
- *      (`getCoordinatorFromRuntime`, the `wireCodingAgent*Bridge` helpers)
- *      look up the same service and expect the
- *      `setChatCallback` / `setWsBroadcast` / `setAgentDecisionCallback` /
- *      `setSwarmCompleteCallback` / `getTaskThread` / `sourceRoomId` surface.
- *   3. `plugins/plugin-app-control/src/services/verification-room-bridge.ts`
- *      needs `subscribe(listener)` so it can post verification verdicts back
- *      into the originating chat room. Without it, it logs
- *      `SWARM_COORDINATOR service still has no subscribe() after 60 retries;
- *      bridge inactive.`
- *
- * This service restores the registration + the exact surface those consumers
- * depend on, implemented as a thin adapter over the post-consolidation
- * `AcpService` event bus (no resurrection of the deleted 2600-line coordinator
- * or its `TaskRegistry` / pty internals).
- *
- * ## Event mapping
- *
- * `AcpService.onSessionEvent(sessionId, eventName, data)` is re-shaped to the
- * legacy `SwarmEvent` (`{ type, sessionId, timestamp, data }`) and fanned out
- * to every `subscribe()` listener AND to the injected `setWsBroadcast`
- * callback. The chat / agent-decision / swarm-complete callbacks are stored and
- * invoked from the points where the orchestrator already has the matching data
- * (terminal session events trigger swarm-complete synthesis).
- *
- * The setters being present + returning a live coordinator is what makes
- * `wireChatBridge` / `wireWsBridge` / `wireEventRouting` / `wireSwarmSynthesis`
- * each return `true`, so `wireCoordinatorBridgesWhenReady` succeeds on boot
- * instead of timing out.
+ * Exposes ACP session events through the runtime's swarm-coordinator contract.
+ * API, chat, websocket, and verification consumers share this adapter so raw
+ * terminal events are withheld until routing and custom validation complete.
  */
 
 import type {
@@ -64,7 +16,12 @@ import type {
   SwarmEvent,
   SwarmEventListener,
 } from "@elizaos/core";
-import { logger, Service, SWARM_COORDINATOR_SERVICE_TYPE } from "@elizaos/core";
+import {
+  ElizaError,
+  logger,
+  Service,
+  SWARM_COORDINATOR_SERVICE_TYPE,
+} from "@elizaos/core";
 import { AcpService } from "./acp-service.js";
 import { OrchestratorTaskService } from "./orchestrator-task-service.js";
 import {
@@ -140,6 +97,55 @@ function readString(
   return typeof value === "string" && value.trim().length > 0
     ? value
     : undefined;
+}
+
+type StructuredCompletionProof = Record<string, unknown> & {
+  kind: "APP_CREATE_DONE" | "PLUGIN_CREATE_DONE";
+};
+
+function parseStructuredCompletionProof(
+  payload: string,
+  kind: StructuredCompletionProof["kind"],
+): StructuredCompletionProof | undefined {
+  try {
+    const parsed: unknown = JSON.parse(payload);
+    return isRecord(parsed) ? { ...parsed, kind } : undefined;
+  } catch {
+    // error-policy:J3 subprocess completion output is untrusted input;
+    // malformed schema echoes are an explicit invalid result so a later valid
+    // final claim in the same captured turn remains eligible for verification.
+    return undefined;
+  }
+}
+
+/**
+ * Completion claims are a line protocol so the verifier receives the agent's
+ * exact claim instead of inferring success from prose. ACP transports can echo
+ * one turn into both tool-output and final-response channels. The last valid
+ * claim is authoritative because it is the agent's final post-command state;
+ * the verifier still cross-checks every field against disk and command output.
+ */
+export function extractStructuredCompletionProof(
+  output: string | undefined,
+): StructuredCompletionProof | undefined {
+  if (!output) return undefined;
+  const proofs: StructuredCompletionProof[] = [];
+  for (const line of output.split(/\r?\n/gu)) {
+    const markerPattern = /(APP_CREATE_DONE|PLUGIN_CREATE_DONE)/gu;
+    for (const marker of line.matchAll(markerPattern)) {
+      const suffix = line.slice(marker.index).trim();
+      const match = suffix.match(
+        /^(APP_CREATE_DONE|PLUGIN_CREATE_DONE)\s+(\{.*\})$/u,
+      );
+      if (!match) continue;
+      const proof = parseStructuredCompletionProof(
+        match[2],
+        match[1] as StructuredCompletionProof["kind"],
+      );
+      if (proof) proofs.push(proof);
+    }
+  }
+  return proofs.at(-1);
 }
 
 // Same UUID shape the sub-agent-router's `pickUuid` gate accepts. Kept as a
@@ -594,7 +600,20 @@ export class SwarmCoordinatorService
       this.acpBindTimer = null;
     }
     this.unsubscribeAcp = acp.onSessionEvent((sessionId, event, data) => {
-      void this.handleAcpEvent(sessionId, String(event), data);
+      void this.handleAcpEvent(sessionId, String(event), data).catch((err) => {
+        // error-policy:J7 ACP event fan-out is asynchronous; report a rejected
+        // handler so it cannot become an unobserved rejection or silently stop
+        // verifier delivery.
+        logger.error(
+          `[SwarmCoordinator] ACP event handler failed: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+        this.runtime.reportError("SwarmCoordinator.handleAcpEvent", err, {
+          sessionId,
+          event: String(event),
+        });
+      });
     });
     this.acpBindStatus = "bound";
     this.acpBindReason = null;
@@ -1317,7 +1336,44 @@ export class SwarmCoordinatorService
       validator.method === "verifyApp" || validator.method === "verifyPlugin"
         ? validator.method
         : null;
-    if (!method) return;
+    if (!method) {
+      const suppliedMethod =
+        typeof validator.method === "string"
+          ? validator.method
+          : typeof validator.method;
+      const error = new ElizaError(
+        `Unsupported app-verification validator method: ${suppliedMethod}`,
+        {
+          code: "APP_VERIFICATION_VALIDATOR_METHOD_INVALID",
+          context: { sessionId, suppliedMethod },
+          severity: "fatal",
+        },
+      );
+      logger.warn(`[SwarmCoordinator] ${error.message}`);
+      this.runtime.reportError(
+        "SwarmCoordinator.runCustomValidatorAndDispatch",
+        error,
+        { sessionId, suppliedMethod },
+      );
+      try {
+        await this.dispatchCustomValidatorResult(sessionId, "escalation", {
+          ...enrichedData,
+          summary: error.message,
+          verification: {
+            source: "custom-validator",
+            validator: {
+              service: "app-verification",
+              method: suppliedMethod,
+            },
+            params: isRecord(validator.params) ? validator.params : {},
+            verdict: "fail",
+          },
+        });
+      } finally {
+        await this.stopCustomValidatorSession(sessionId);
+      }
+      return;
+    }
     const verificationService = this.runtime.getService?.("app-verification") as
       | {
           verifyApp?: (
@@ -1342,24 +1398,49 @@ export class SwarmCoordinatorService
           verdict: "fail",
         },
       });
+      await this.stopCustomValidatorSession(sessionId);
       return;
     }
-    const params = {
+    let params: Record<string, unknown> = {
       ...(isRecord(validator.params) ? validator.params : {}),
       ...(typeof enrichedData.workdir === "string"
         ? { workdir: enrichedData.workdir }
         : {}),
     };
     try {
+      let structuredProof = extractStructuredCompletionProof(
+        readString(enrichedData, "response") ??
+          readString(enrichedData, "finalText"),
+      );
+      if (!structuredProof) {
+        const acp = this.acp();
+        const capturedOutput = acp
+          ? typeof acp.getSessionTurnOutput === "function"
+            ? await acp.getSessionTurnOutput(sessionId, 2_000)
+            : typeof acp.getSessionOutput === "function"
+              ? await acp.getSessionOutput(sessionId, 2_000)
+              : undefined
+          : undefined;
+        structuredProof = extractStructuredCompletionProof(capturedOutput);
+      }
+      params = {
+        ...params,
+        ...(structuredProof ? { structuredProof } : {}),
+      };
       const result = await verify.call(verificationService, params);
       const verdict = result.verdict === "pass" ? "pass" : "fail";
       const checks = Array.isArray(result.checks) ? result.checks : [];
       const failed = checks
         .filter(
           (check): check is Record<string, unknown> =>
-            isRecord(check) && check.ok === false,
+            isRecord(check) && (check.passed === false || check.ok === false),
         )
-        .map((check) => readString(check, "label") ?? readString(check, "name"))
+        .map(
+          (check) =>
+            readString(check, "label") ??
+            readString(check, "name") ??
+            readString(check, "kind"),
+        )
         .filter((value): value is string => Boolean(value));
       const summary =
         verdict === "pass"
@@ -1367,6 +1448,12 @@ export class SwarmCoordinatorService
           : failed.length > 0
             ? `App verification failed: ${failed.join(", ")}`
             : "App verification failed.";
+      if (
+        verdict === "fail" &&
+        (await this.retryCustomValidator(sessionId, enrichedData, result))
+      ) {
+        return;
+      }
       await this.dispatchCustomValidatorResult(
         sessionId,
         verdict === "pass" ? "task_complete" : "escalation",
@@ -1382,6 +1469,7 @@ export class SwarmCoordinatorService
           },
         },
       );
+      await this.stopCustomValidatorSession(sessionId);
     } catch (err) {
       // error-policy:J1 boundary — translates a validator fault into a structured escalation result (verdict fail) dispatched below.
       logger.warn(
@@ -1399,6 +1487,95 @@ export class SwarmCoordinatorService
           verdict: "fail",
         },
       });
+      await this.stopCustomValidatorSession(sessionId);
+    }
+  }
+
+  private async stopCustomValidatorSession(sessionId: string): Promise<void> {
+    const acp = this.acp();
+    if (!acp || typeof acp.stopSession !== "function") return;
+    try {
+      await acp.stopSession(sessionId);
+    } catch (err) {
+      // error-policy:J6 the verifier verdict is already dispatched; teardown
+      // failure must not replace that durable pass/fail result.
+      logger.warn(
+        `[SwarmCoordinator] custom validator session close failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+
+  private async retryCustomValidator(
+    sessionId: string,
+    enrichedData: Record<string, unknown>,
+    result: Record<string, unknown>,
+  ): Promise<boolean> {
+    if (enrichedData.onVerificationFail !== "retry") return false;
+    const maxRetries =
+      typeof enrichedData.maxRetries === "number" &&
+      Number.isInteger(enrichedData.maxRetries) &&
+      enrichedData.maxRetries >= 0
+        ? enrichedData.maxRetries
+        : 0;
+    const retryCount =
+      typeof enrichedData.retryCount === "number" &&
+      Number.isInteger(enrichedData.retryCount) &&
+      enrichedData.retryCount >= 0
+        ? enrichedData.retryCount
+        : 0;
+    if (retryCount >= maxRetries) return false;
+
+    const acp = this.acp();
+    if (!acp || typeof acp.sendPrompt !== "function") return false;
+    const nextRetry = retryCount + 1;
+    const feedback = JSON.stringify(result, null, 2).slice(0, 12_000);
+    try {
+      if (typeof acp.updateSessionMetadata === "function") {
+        await acp.updateSessionMetadata(sessionId, { retryCount: nextRetry });
+        this.enrichmentMetadataCache.delete(sessionId);
+      }
+      const promptResult = await acp.sendPrompt(
+        sessionId,
+        [
+          `Verification failed (retry ${nextRetry}/${maxRetries}).`,
+          "Fix every reported issue in the existing workdir, rerun all requested verification commands, and emit exactly one fresh structured completion line only after they pass.",
+          "Verifier result:",
+          feedback,
+        ].join("\n\n"),
+      );
+      if (promptResult.error || promptResult.stopReason === "error") {
+        throw new ElizaError(
+          promptResult.error ??
+            "ACP verification retry ended with stopReason error",
+          {
+            code: "ACP_VERIFICATION_RETRY_FAILED",
+            context: {
+              sessionId,
+              retry: nextRetry,
+              maxRetries,
+              stopReason: promptResult.stopReason,
+            },
+            severity: "ephemeral",
+          },
+        );
+      }
+      return true;
+    } catch (err) {
+      // error-policy:J7 a retry transport failure must not hide the original
+      // verification failure; warn and let the caller dispatch escalation.
+      logger.warn(
+        `[SwarmCoordinator] custom validator retry failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      this.runtime.reportError("SwarmCoordinator.retryCustomValidator", err, {
+        sessionId,
+        retry: nextRetry,
+        maxRetries,
+      });
+      return false;
     }
   }
 

--- a/plugins/plugin-agent-orchestrator/tests/e2e/live-native-acp-smoke.mjs
+++ b/plugins/plugin-agent-orchestrator/tests/e2e/live-native-acp-smoke.mjs
@@ -25,7 +25,7 @@ const DEFAULT_CODEX_MODEL =
   process.env.LIVE_NATIVE_ACP_CODEX_MODEL ?? "gpt-5.5";
 const DEFAULT_CODEX_REASONING_EFFORT =
   process.env.LIVE_NATIVE_ACP_CODEX_REASONING_EFFORT ?? "low";
-const DEFAULT_CODEX_COMMAND = `npx -y @zed-industries/codex-acp@0.14.0 -c 'model="${DEFAULT_CODEX_MODEL}"' -c 'model_reasoning_effort="${DEFAULT_CODEX_REASONING_EFFORT}"'`;
+const DEFAULT_CODEX_COMMAND = "npx -y @agentclientprotocol/codex-acp@1.1.2";
 const GIT_IDENTITY_EVIDENCE =
   process.env.LIVE_NATIVE_ACP_GIT_IDENTITY_EVIDENCE === "1";
 const GIT_IDENTITY_PROMPT =

--- a/plugins/plugin-app-control/src/actions/app-create.ts
+++ b/plugins/plugin-app-control/src/actions/app-create.ts
@@ -1,21 +1,8 @@
 /**
- * @module plugin-app-control/actions/app-create
- *
- * create sub-mode of the unified APP action.
- *
- * Multi-turn flow:
- *  1. First turn — search installed apps for fuzzy matches against the
- *     user's intent. If matches exist, render a [CHOICE:...] block via
- *     callback and persist a workbench Task tagged "app-create-intent"
- *     keyed by roomId so the next turn can find it.
- *  2. Follow-up turn — when the user replies with `new` / `edit-N` /
- *     `cancel`, the dispatcher's validate sees the intent task + the
- *     keyword, the dispatcher routes back here, and we resolve the choice.
- *  3. Create-new path — extract a kebab-case name + display name via the
- *     LLM, copy the min-project template, then dispatch a coding agent via
- *     START_CODING_TASK with the AppVerificationService validator.
- *  4. Edit path — same dispatch, but workdir is the existing app's source
- *     directory.
+ * Implements the APP action's multi-turn create and edit workflow.
+ * Choice tasks keep ambiguous intent attached to the originating room; the
+ * selected path then delegates work in the target source directory and routes
+ * structured verification back to that same conversation.
  */
 
 import { promises as fs } from "node:fs";
@@ -418,7 +405,7 @@ async function dispatchCodingAgent({
 
 	const fakeMessage = {
 		entityId: runtime.agentId,
-		roomId: runtime.agentId,
+		roomId: originRoomId,
 		agentId: runtime.agentId,
 		content: { text: prompt },
 	} as Memory;
@@ -427,12 +414,16 @@ async function dispatchCodingAgent({
 		parameters: {
 			task: prompt,
 			label,
+			workdir,
+			lockWorkdir: true,
+			keepAliveAfterComplete: true,
 			approvalPreset: "permissive",
 			validator: {
 				service: "app-verification",
 				method: "verifyApp",
 				params: { workdir, appName, profile: "full" },
 			},
+			maxRetries: 2,
 			onVerificationFail: "retry",
 			metadata: {
 				// Carried into session metadata via start-coding-task.ts so the

--- a/plugins/plugin-app-control/src/actions/verified-plugin-task.test.ts
+++ b/plugins/plugin-app-control/src/actions/verified-plugin-task.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Coding-task handoff contract for plugin create and edit operations.
+ */
+
+import { describe, expect, it } from "vitest";
+import { buildVerifiedPluginTaskParameters } from "./verified-plugin-task";
+
+describe("buildVerifiedPluginTaskParameters", () => {
+	it("locks execution and verification to the plugin source directory", () => {
+		const parameters = buildVerifiedPluginTaskParameters({
+			task: "build the view",
+			label: "create-view:proof",
+			workdir: "/state/plugins/plugin-proof",
+			pluginName: "proof",
+			originRoomId: "room-1",
+		});
+
+		expect(parameters).toMatchObject({
+			workdir: "/state/plugins/plugin-proof",
+			lockWorkdir: true,
+			keepAliveAfterComplete: true,
+			validator: {
+				service: "app-verification",
+				method: "verifyPlugin",
+				params: {
+					workdir: "/state/plugins/plugin-proof",
+					pluginName: "proof",
+					profile: "full",
+				},
+			},
+		});
+	});
+});

--- a/plugins/plugin-app-control/src/actions/verified-plugin-task.ts
+++ b/plugins/plugin-app-control/src/actions/verified-plugin-task.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared coding-task parameters for plugin create and edit operations.
+ * Verification is the handoff that rebuilds and live-loads the finished plugin;
+ * omitting it leaves successful source edits invisible to the running app.
+ */
+
+import type { HandlerOptions } from "@elizaos/core";
+
+export function buildVerifiedPluginTaskParameters({
+	task,
+	label,
+	workdir,
+	pluginName,
+	originRoomId,
+}: {
+	task: string;
+	label: string;
+	workdir: string;
+	pluginName: string;
+	originRoomId: string;
+}): NonNullable<HandlerOptions["parameters"]> {
+	return {
+		task,
+		label,
+		workdir,
+		lockWorkdir: true,
+		keepAliveAfterComplete: true,
+		approvalPreset: "permissive",
+		validator: {
+			service: "app-verification",
+			method: "verifyPlugin",
+			params: { workdir, pluginName, profile: "full" },
+		},
+		maxRetries: 2,
+		onVerificationFail: "retry",
+		metadata: { originRoomId },
+	};
+}

--- a/plugins/plugin-app-control/src/actions/views-create-scaffold.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-create-scaffold.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Verifies that VIEWS create seeds a complete standalone GUI plugin contract.
+ */
+
+import {
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { seedGuiViewScaffold } from "./views-create-scaffold.js";
+
+const tempDirs: string[] = [];
+
+function scaffoldFixture(): string {
+	const workdir = mkdtempSync(path.join(os.tmpdir(), "view-scaffold-"));
+	tempDirs.push(workdir);
+	mkdirSync(path.join(workdir, "src/providers"), { recursive: true });
+	mkdirSync(path.join(workdir, "tests"), { recursive: true });
+	writeFileSync(
+		path.join(workdir, "package.json"),
+		JSON.stringify({
+			name: "@local/plugin-proof-surface",
+			scripts: {
+				build: "tsc --noCheck -p tsconfig.build.json",
+				test: "vitest run --config ./vitest.config.ts",
+			},
+			dependencies: { "@elizaos/core": "latest" },
+			devDependencies: { typescript: "^6.0.3", vitest: "^4.0.0" },
+		}),
+	);
+	writeFileSync(
+		path.join(workdir, "tsconfig.json"),
+		JSON.stringify({
+			compilerOptions: { strict: true },
+			include: ["src/**/*.ts", "tests/**/*.ts"],
+		}),
+	);
+	return workdir;
+}
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe("seedGuiViewScaffold", () => {
+	it("writes the registered view, React proof surface, real test, and browser build", async () => {
+		const workdir = scaffoldFixture();
+		const intent = "Show a signed audit ledger with a live refresh control";
+
+		await seedGuiViewScaffold({
+			workdir,
+			viewId: "proof-surface",
+			displayName: "Proof Surface",
+			intent,
+		});
+
+		const index = readFileSync(path.join(workdir, "src/index.ts"), "utf8");
+		expect(index).toContain("interface ViewEnabledPlugin extends Plugin");
+		expect(index).toContain('id: "proof-surface"');
+		expect(index).toContain('modalities: ["gui"]');
+		expect(index).toContain('viewKind: "release"');
+		expect(index).toContain('bundlePath: "dist/views/bundle.js"');
+		expect(index).toContain('componentExport: "PluginView"');
+		expect(index).toContain('heroImagePath: "assets/hero.svg"');
+
+		const component = readFileSync(
+			path.join(workdir, "src/views/PluginView.tsx"),
+			"utf8",
+		);
+		expect(component).toContain(
+			'VIEW_SCAFFOLD_MARKER = "eliza-view-scaffold:proof-surface"',
+		);
+		expect(component).toContain(`VIEW_INTENT = ${JSON.stringify(intent)}`);
+		expect(component).toContain("data-eliza-view-marker");
+		expect(component).toContain("export function PluginView()");
+
+		const testSource = readFileSync(
+			path.join(workdir, "tests/view-render.test.tsx"),
+			"utf8",
+		);
+		expect(testSource).toContain("renderToStaticMarkup(<PluginView />)");
+		expect(testSource).toContain("VIEW_SCAFFOLD_MARKER");
+		expect(testSource).toContain(
+			`expect(VIEW_INTENT).toBe(${JSON.stringify(intent)})`,
+		);
+
+		const viteConfig = readFileSync(
+			path.join(workdir, "vite.config.views.ts"),
+			"utf8",
+		);
+		expect(viteConfig).toContain(
+			'entry: path.resolve(process.cwd(), "src/views/view-bundle.ts")',
+		);
+		expect(viteConfig).toContain('outDir: "dist/views"');
+		expect(viteConfig).toContain('fileName: () => "bundle.js"');
+		expect(viteConfig).toContain('"react/jsx-runtime"');
+
+		const packageJson = JSON.parse(
+			readFileSync(path.join(workdir, "package.json"), "utf8"),
+		) as {
+			scripts: Record<string, string>;
+			dependencies: Record<string, string>;
+			devDependencies: Record<string, string>;
+		};
+		expect(packageJson.scripts.build).toContain(
+			"vite build --config vite.config.views.ts",
+		);
+		expect(packageJson.scripts["build:views"]).toBe(
+			"vite build --config vite.config.views.ts",
+		);
+		expect(packageJson.scripts.lint).toBe("biome check src/ tests/");
+		expect(packageJson.dependencies.react).toBe("^19.0.0");
+		expect(packageJson.dependencies["react-dom"]).toBe("^19.0.0");
+		expect(packageJson.devDependencies["@biomejs/biome"]).toBe("2.5.1");
+		expect(packageJson.devDependencies.vite).toBe("^8.0.0");
+
+		const tsconfig = JSON.parse(
+			readFileSync(path.join(workdir, "tsconfig.json"), "utf8"),
+		) as { compilerOptions: { jsx?: string }; include: string[] };
+		expect(tsconfig.compilerOptions.jsx).toBe("react-jsx");
+		expect(tsconfig.include).toContain("src/**/*.tsx");
+		expect(tsconfig.include).toContain("tests/**/*.tsx");
+	});
+});

--- a/plugins/plugin-app-control/src/actions/views-create-scaffold.ts
+++ b/plugins/plugin-app-control/src/actions/views-create-scaffold.ts
@@ -1,0 +1,437 @@
+/**
+ * Seeds the browser-loadable GUI baseline used by VIEWS create.
+ *
+ * The generic min-plugin template intentionally contains no UI dependencies or
+ * view declaration. This module turns that copied template into a complete,
+ * standalone view plugin before a coding agent begins the requested design.
+ */
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { ElizaError } from "@elizaos/core";
+
+export interface SeedGuiViewScaffoldInput {
+	workdir: string;
+	viewId: string;
+	displayName: string;
+	intent: string;
+}
+
+type JsonObject = Record<string, unknown>;
+
+function isJsonObject(value: unknown): value is JsonObject {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requireJsonObject(value: unknown, source: string): JsonObject {
+	if (!isJsonObject(value)) {
+		throw new ElizaError(`${source} must contain a JSON object`, {
+			code: "VIEW_SCAFFOLD_CONFIG_OBJECT_REQUIRED",
+			context: { source },
+		});
+	}
+	return value;
+}
+
+function objectField(
+	record: JsonObject,
+	key: string,
+	source: string,
+): JsonObject {
+	const value = record[key];
+	if (value === undefined) {
+		const created: JsonObject = {};
+		record[key] = created;
+		return created;
+	}
+	if (!isJsonObject(value)) {
+		throw new ElizaError(`${source}.${key} must be a JSON object`, {
+			code: "VIEW_SCAFFOLD_CONFIG_FIELD_INVALID",
+			context: { source, field: key, expected: "object" },
+		});
+	}
+	return value;
+}
+
+function requiredStringField(
+	record: JsonObject,
+	key: string,
+	source: string,
+): string {
+	const value = record[key];
+	if (typeof value !== "string" || value.trim().length === 0) {
+		throw new ElizaError(`${source}.${key} must be a non-empty string`, {
+			code: "VIEW_SCAFFOLD_CONFIG_FIELD_INVALID",
+			context: { source, field: key, expected: "non-empty string" },
+		});
+	}
+	return value;
+}
+
+function sourceString(value: string): string {
+	return JSON.stringify(value);
+}
+
+function pluginIndexSource({
+	packageName,
+	viewId,
+	displayName,
+	intent,
+}: {
+	packageName: string;
+	viewId: string;
+	displayName: string;
+	intent: string;
+}): string {
+	return `/**
+ * Runtime entrypoint for a standalone plugin-contributed GUI view.
+ *
+ * The local view shape keeps this scaffold compatible with installed core
+ * packages that predate Plugin.views while preserving the current runtime
+ * manifest exactly.
+ */
+
+import type { Plugin } from "@elizaos/core";
+import { infoProvider } from "./providers/info.js";
+
+interface StandaloneGuiView {
+  id: string;
+  label: string;
+  description: string;
+  icon: string;
+  path: string;
+  modalities: ["gui"];
+  viewKind: "release";
+  bundlePath: string;
+  componentExport: string;
+  heroImagePath: string;
+  visibleInManager: boolean;
+  desktopTabEnabled: boolean;
+}
+
+interface ViewEnabledPlugin extends Plugin {
+  views: StandaloneGuiView[];
+}
+
+const plugin: ViewEnabledPlugin = {
+  name: ${sourceString(packageName)},
+  description: ${sourceString(`${displayName} GUI view for: ${intent}`)},
+  providers: [infoProvider],
+  views: [
+    {
+      id: ${sourceString(viewId)},
+      label: ${sourceString(displayName)},
+      description: ${sourceString(intent)},
+      icon: "PanelTopOpen",
+      path: ${sourceString(`/${viewId}`)},
+      modalities: ["gui"],
+      viewKind: "release",
+      bundlePath: "dist/views/bundle.js",
+      componentExport: "PluginView",
+      heroImagePath: "assets/hero.svg",
+      visibleInManager: true,
+      desktopTabEnabled: true,
+    },
+  ],
+};
+
+export default plugin;
+export { infoProvider, plugin };
+`;
+}
+
+function componentSource({
+	viewId,
+	displayName,
+	intent,
+}: {
+	viewId: string;
+	displayName: string;
+	intent: string;
+}): string {
+	return `/**
+ * Browser component for the plugin's GUI view.
+ *
+ * The visible intent and stable marker give the coding agent and the live E2E
+ * verifier an unambiguous baseline to customize and prove after hot-loading.
+ */
+
+import type { CSSProperties } from "react";
+
+export const VIEW_ID = ${sourceString(viewId)};
+export const VIEW_LABEL = ${sourceString(displayName)};
+export const VIEW_INTENT = ${sourceString(intent)};
+export const VIEW_SCAFFOLD_MARKER = ${sourceString(`eliza-view-scaffold:${viewId}`)};
+
+const styles: Record<string, CSSProperties> = {
+  shell: {
+    alignItems: "center",
+    background: "#111111",
+    color: "#f5f5f4",
+    display: "flex",
+    justifyContent: "center",
+    minHeight: "100%",
+    padding: "clamp(24px, 6vw, 72px)",
+  },
+  panel: {
+    background: "#1c1917",
+    border: "1px solid #44403c",
+    borderRadius: 20,
+    boxShadow: "0 24px 70px rgba(0, 0, 0, 0.36)",
+    maxWidth: 760,
+    padding: "clamp(28px, 5vw, 56px)",
+    width: "100%",
+  },
+  eyebrow: {
+    color: "#fb923c",
+    fontSize: 13,
+    fontWeight: 700,
+    letterSpacing: "0.12em",
+    margin: "0 0 14px",
+    textTransform: "uppercase",
+  },
+  title: {
+    fontSize: "clamp(36px, 7vw, 68px)",
+    letterSpacing: "-0.04em",
+    lineHeight: 0.96,
+    margin: 0,
+  },
+  intent: {
+    color: "#d6d3d1",
+    fontSize: 18,
+    lineHeight: 1.65,
+    margin: "28px 0 0",
+  },
+  status: {
+    borderLeft: "3px solid #f97316",
+    color: "#a8a29e",
+    fontSize: 14,
+    lineHeight: 1.5,
+    marginTop: 36,
+    paddingLeft: 16,
+  },
+};
+
+export function PluginView() {
+  return (
+    <main
+      aria-labelledby="${viewId}-title"
+      data-eliza-view-id={VIEW_ID}
+      data-eliza-view-marker={VIEW_SCAFFOLD_MARKER}
+      style={styles.shell}
+    >
+      <section style={styles.panel}>
+        <p style={styles.eyebrow}>View scaffold ready</p>
+        <h1 id="${viewId}-title" style={styles.title}>
+          {VIEW_LABEL}
+        </h1>
+        <p style={styles.intent}>{VIEW_INTENT}</p>
+        <p role="status" style={styles.status}>
+          The Plugin.views manifest, React export, render test, and browser
+          bundle are connected. Build the requested experience from this
+          working surface.
+        </p>
+      </section>
+    </main>
+  );
+}
+
+export default PluginView;
+`;
+}
+
+function componentTestSource({
+	viewId,
+	intent,
+}: {
+	viewId: string;
+	intent: string;
+}): string {
+	return `/**
+ * Exercises the actual React view export through server rendering.
+ */
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import PluginView, {
+  VIEW_ID,
+  VIEW_INTENT,
+  VIEW_SCAFFOLD_MARKER,
+} from "../src/views/PluginView.js";
+
+describe("standalone GUI view", () => {
+  it("renders the registered identity, creation intent, and proof marker", () => {
+    const html = renderToStaticMarkup(<PluginView />);
+
+    expect(VIEW_ID).toBe(${sourceString(viewId)});
+    expect(VIEW_INTENT).toBe(${sourceString(intent)});
+    expect(html).toContain(\`data-eliza-view-id="\${VIEW_ID}"\`);
+    expect(html).toContain(VIEW_SCAFFOLD_MARKER);
+    expect(html).toContain("View scaffold ready");
+  });
+});
+`;
+}
+
+const VIEW_BUNDLE_SOURCE = `/**
+ * Browser-bundle entrypoint consumed by the Eliza view loader.
+ */
+
+export { default, PluginView } from "./PluginView.js";
+`;
+
+const VITE_CONFIG_SOURCE = `/**
+ * Produces one browser-loadable ES module for the plugin view registry.
+ */
+
+import path from "node:path";
+import { defineConfig } from "vite";
+
+const hostExternals = new Set([
+  "react",
+  "react/jsx-dev-runtime",
+  "react/jsx-runtime",
+]);
+
+export default defineConfig({
+  build: {
+    emptyOutDir: false,
+    outDir: "dist/views",
+    sourcemap: true,
+    lib: {
+      entry: path.resolve(process.cwd(), "src/views/view-bundle.ts"),
+      formats: ["es"],
+      fileName: () => "bundle.js",
+    },
+    rollupOptions: {
+      external: (id) =>
+        hostExternals.has(id) ||
+        [...hostExternals].some((external) => id.startsWith(\`\${external}/\`)),
+      output: {
+        exports: "named",
+        codeSplitting: false,
+      },
+    },
+  },
+  define: {
+    "import.meta.env.DEV": JSON.stringify(false),
+    "import.meta.env.PROD": JSON.stringify(true),
+    "import.meta.env.MODE": JSON.stringify("production"),
+    "import.meta.env.SSR": JSON.stringify(false),
+    "process.env.NODE_ENV": JSON.stringify("production"),
+  },
+});
+`;
+
+const VITEST_CONFIG_SOURCE = `/**
+ * Runs the standalone plugin's runtime and React rendering tests.
+ */
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.{ts,tsx}"],
+    exclude: ["dist/**", "**/node_modules/**"],
+    environment: "node",
+  },
+});
+`;
+
+/**
+ * Converts an already-copied min-plugin directory into a working GUI plugin.
+ */
+export async function seedGuiViewScaffold({
+	workdir,
+	viewId,
+	displayName,
+	intent,
+}: SeedGuiViewScaffoldInput): Promise<void> {
+	const packageJsonPath = path.join(workdir, "package.json");
+	const packageJson = requireJsonObject(
+		JSON.parse(await fs.readFile(packageJsonPath, "utf8")) as unknown,
+		"package.json",
+	);
+	const packageName = requiredStringField(packageJson, "name", "package.json");
+	const scripts = objectField(packageJson, "scripts", "package.json");
+	const dependencies = objectField(packageJson, "dependencies", "package.json");
+	const devDependencies = objectField(
+		packageJson,
+		"devDependencies",
+		"package.json",
+	);
+
+	scripts.build =
+		"tsc --noCheck -p tsconfig.build.json && vite build --config vite.config.views.ts";
+	scripts["build:views"] = "vite build --config vite.config.views.ts";
+	scripts.lint = "biome check src/ tests/";
+	dependencies.react = "^19.0.0";
+	dependencies["react-dom"] = "^19.0.0";
+	devDependencies["@biomejs/biome"] = "2.5.1";
+	devDependencies["@types/react"] = "^19.0.0";
+	devDependencies["@types/react-dom"] = "^19.0.0";
+	devDependencies.vite = "^8.0.0";
+
+	const tsconfigPath = path.join(workdir, "tsconfig.json");
+	const tsconfig = requireJsonObject(
+		JSON.parse(await fs.readFile(tsconfigPath, "utf8")) as unknown,
+		"tsconfig.json",
+	);
+	const compilerOptions = objectField(
+		tsconfig,
+		"compilerOptions",
+		"tsconfig.json",
+	);
+	compilerOptions.jsx = "react-jsx";
+	tsconfig.include = [
+		"src/**/*.ts",
+		"src/**/*.tsx",
+		"tests/**/*.ts",
+		"tests/**/*.tsx",
+	];
+
+	await fs.mkdir(path.join(workdir, "src/views"), { recursive: true });
+	await fs.mkdir(path.join(workdir, "tests"), { recursive: true });
+	await Promise.all([
+		fs.writeFile(
+			packageJsonPath,
+			`${JSON.stringify(packageJson, null, 2)}\n`,
+			"utf8",
+		),
+		fs.writeFile(
+			tsconfigPath,
+			`${JSON.stringify(tsconfig, null, 2)}\n`,
+			"utf8",
+		),
+		fs.writeFile(
+			path.join(workdir, "src/index.ts"),
+			pluginIndexSource({ packageName, viewId, displayName, intent }),
+			"utf8",
+		),
+		fs.writeFile(
+			path.join(workdir, "src/views/PluginView.tsx"),
+			componentSource({ viewId, displayName, intent }),
+			"utf8",
+		),
+		fs.writeFile(
+			path.join(workdir, "src/views/view-bundle.ts"),
+			VIEW_BUNDLE_SOURCE,
+			"utf8",
+		),
+		fs.writeFile(
+			path.join(workdir, "tests/view-render.test.tsx"),
+			componentTestSource({ viewId, intent }),
+			"utf8",
+		),
+		fs.writeFile(
+			path.join(workdir, "vite.config.views.ts"),
+			VITE_CONFIG_SOURCE,
+			"utf8",
+		),
+		fs.writeFile(
+			path.join(workdir, "vitest.config.ts"),
+			VITEST_CONFIG_SOURCE,
+			"utf8",
+		),
+	]);
+}

--- a/plugins/plugin-app-control/src/actions/views-create.packaged.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-create.packaged.test.ts
@@ -1,14 +1,5 @@
 /**
- * VIEWS create from a packaged install (no monorepo checkout at repoRoot).
- *
- * Before the scaffold-env fallbacks, this flow dead-ended with
- * "min-plugin template not found (tried: <repoRoot>/packages/...)" the moment
- * the agent ran outside an elizaOS checkout (packaged desktop install, wrong
- * cwd). These tests drive the real runViewsCreate handler end to end against
- * an empty repoRoot: the template must resolve from the installed `elizaos`
- * package, the plugin must land in <stateDir>/plugins, and missing
- * orchestrator/CLI prerequisites must answer with setup guidance BEFORE
- * anything is scaffolded.
+ * Exercises VIEWS create against packaged templates and state-directory plugin storage.
  */
 
 import {
@@ -24,7 +15,9 @@ import os from "node:os";
 import path from "node:path";
 import type { HandlerOptions, IAgentRuntime, Memory } from "@elizaos/core";
 import { afterEach, describe, expect, it } from "vitest";
+import type { ViewSummary } from "./views-client";
 import { runViewsCreate } from "./views-create";
+import { locatePluginSourceDir } from "./views-plugin-source";
 
 const AGENT_ID = "00000000-0000-0000-0000-000000000001";
 
@@ -123,6 +116,20 @@ function message(text: string): Memory {
 }
 
 describe("runViewsCreate from a packaged install", () => {
+	it("rejects registry plugin names that could escape the source roots", async () => {
+		await expect(
+			locatePluginSourceDir(tempDir("packaged-install-"), {
+				id: "escape",
+				label: "Escape",
+				pluginName: "@malicious/../../outside",
+				viewType: "gui",
+			} as ViewSummary),
+		).rejects.toMatchObject({
+			name: "ElizaError",
+			code: "VIEW_PLUGIN_NAME_INVALID",
+		});
+	});
+
 	it("scaffolds from the installed elizaos template into <stateDir>/plugins and dispatches", async () => {
 		const packagedRoot = tempDir("packaged-install-");
 		const stateDir = tempDir("state-");
@@ -151,6 +158,33 @@ describe("runViewsCreate from a packaged install", () => {
 		);
 		expect(pkg.name).not.toContain("__PLUGIN_NAME__");
 		expect(existsSync(path.join(workdir, "SCAFFOLD.md"))).toBe(true);
+		const index = readFileSync(path.join(workdir, "src/index.ts"), "utf8");
+		expect(index).toContain('bundlePath: "dist/views/bundle.js"');
+		expect(index).toContain('componentExport: "PluginView"');
+		expect(index).toContain('viewKind: "release"');
+		const component = readFileSync(
+			path.join(workdir, "src/views/PluginView.tsx"),
+			"utf8",
+		);
+		expect(component).toContain("VIEW_SCAFFOLD_MARKER");
+		expect(component).toContain("build me a crypto price ticker view");
+		expect(
+			readFileSync(path.join(workdir, "tests/view-render.test.tsx"), "utf8"),
+		).toContain("renderToStaticMarkup(<PluginView />)");
+		expect(
+			readFileSync(path.join(workdir, "vite.config.views.ts"), "utf8"),
+		).toContain('fileName: () => "bundle.js"');
+		expect(pkg.scripts.build).toContain(
+			"vite build --config vite.config.views.ts",
+		);
+		await expect(
+			locatePluginSourceDir(packagedRoot, {
+				id: "crypto-price-ticker",
+				label: "Crypto Price Ticker",
+				pluginName: pkg.name,
+				viewType: "gui",
+			} as ViewSummary),
+		).resolves.toBe(workdir);
 		// The coding agent was dispatched against that workdir.
 		expect(dispatched).toHaveLength(1);
 		expect(String(dispatched[0].task)).toContain(`sourceDir: ${workdir}`);

--- a/plugins/plugin-app-control/src/actions/views-create.ts
+++ b/plugins/plugin-app-control/src/actions/views-create.ts
@@ -1,16 +1,8 @@
 /**
- * @module plugin-app-control/actions/views-create
- *
- * create sub-mode of the VIEWS action.
- *
- * Multi-turn flow mirrors app-create.ts:
- *  1. First turn — search installed plugins for fuzzy matches against the
- *     user's intent. If matches exist, render a [CHOICE:...] block and
- *     persist a Task tagged "views-create-intent" keyed by roomId.
- *  2. Follow-up turn — user replies with `new` / `edit-N` / `cancel`.
- *  3. Create-new path — extract a kebab-case name, copy the min-plugin
- *     template, then dispatch a coding agent via START_CODING_TASK.
- *  4. Edit path — same dispatch, targeting the existing plugin's source dir.
+ * Implements the VIEWS action's multi-turn create and edit workflow.
+ * New GUI views start from a loadable plugin baseline; ambiguous matches are
+ * resolved in the originating room before a coding task edits, verifies,
+ * rebuilds, and reloads the selected local plugin.
  */
 
 import { promises as fs } from "node:fs";
@@ -31,7 +23,9 @@ import {
 	resolveScaffoldTemplateDir,
 	templateMissingGuidance,
 } from "./scaffold-env.js";
+import { buildVerifiedPluginTaskParameters } from "./verified-plugin-task.js";
 import type { ViewSummary } from "./views-client.js";
+import { seedGuiViewScaffold } from "./views-create-scaffold.js";
 import { writeViewHeroAsset } from "./views-hero.js";
 import { isRestrictedPlatform } from "./views-platform.js";
 import { locatePluginSourceDir } from "./views-plugin-source.js";
@@ -337,37 +331,21 @@ async function dispatchCodingAgent({
 
 	const fakeMessage = {
 		entityId: runtime.agentId,
-		roomId: runtime.agentId,
+		// TASKS deliberately trusts the handler message, rather than model-writable
+		// metadata, as the authoritative chat origin for completion routing.
+		roomId: originRoomId,
 		agentId: runtime.agentId,
 		content: { text: prompt },
 	} as Memory;
 
 	const handlerOptions: HandlerOptions = {
-		parameters: {
+		parameters: buildVerifiedPluginTaskParameters({
 			task: prompt,
 			label,
-			approvalPreset: "permissive",
-			// Verify the scaffolded/edited plugin once the coding agent finishes.
-			// Without this validator the orchestrator never runs verification and
-			// VerificationRoomBridgeService (which filters on
-			// validator.service === "app-verification") never posts a verdict back
-			// to the room — the user would see "Started …" and then silence.
-			validator: {
-				service: "app-verification",
-				method: "verifyPlugin",
-				// pluginName is what VerificationRoomBridgeService reads to resolve the
-				// target name for the verdict it posts back (decodeEvent reads
-				// params.pluginName for verifyPlugin); omitting it drops the verdict.
-				params: { workdir, pluginName, profile: "full" },
-			},
-			onVerificationFail: "retry",
-			metadata: {
-				// Carried into session metadata via start-coding-task.ts so the
-				// verification-room-bridge can post the verdict back to the
-				// originating chat room.
-				originRoomId,
-			},
-		},
+			workdir,
+			pluginName,
+			originRoomId,
+		}),
 	};
 
 	const result = await spawnWithTrajectoryLink(
@@ -440,17 +418,24 @@ export function buildCreatePrompt(
 		`intent: ${intent}`,
 		`sourceDir: ${workdir}`,
 		"workspaceRule: work in sourceDir, not the task agent scratch directory",
+		"deploymentScope: local runtime plugin only; do not publish or register a Cloud app, request parent-agent Cloud commands, or wait for a CDN URL",
 		"referenceDocs: read SCAFFOLD.md for layout and conventions",
-		"viewRequirement: add a Plugin.views entry with a compiled view bundle so the view appears in the Eliza view registry",
+		"viewScaffold: sourceDir already contains a working Plugin.views declaration, React component, render test, and Vite browser-bundle build; extend that baseline instead of replacing or reinventing its contracts",
+		"viewRequirement: preserve the seeded Plugin.views entry and compiled dist/views/bundle.js output so the view appears in the Eliza view registry",
+		"proofMarker: preserve VIEW_SCAFFOLD_MARKER and keep VIEW_INTENT represented in the rendered experience so live verification can identify the created view",
 		'viewKindRule: set the views entry viewKind explicitly using the four-kind contract: "release" for a finished user-facing view (the default), "preview" for an early/experimental view, or "developer" for dev tooling such as logs, inspectors, debuggers, editors, or diagnostics; never "system" (reserved for built-ins)',
 		"iconAsset: a branded assets/hero.svg is already seeded and is served as the view hero — keep it (or replace it with a real image at assets/hero.<ext>); do not delete it",
 		"implementation: edit and add files needed for the intent",
-		"verificationCommands[3]:",
+		"setupCommand: bun install",
+		"verificationCommands[4]:",
 		"  bun run typecheck",
 		"  bun run lint",
 		"  bun run test",
+		"  bun run build",
+		"completionFiles: list every changed file as a nonempty relative path array; replace the example path with the actual paths",
+		"completionTests: replace the example passed count with the exact count printed by the test command",
 		"completionRule: after all commands pass, emit exactly one completion line in this canonical schema",
-		`PLUGIN_CREATE_DONE {"pluginName":"${pluginName}","files":["src/index.ts"],"tests":{"passed":1,"failed":0},"lint":"ok","typecheck":"ok"}`,
+		`PLUGIN_CREATE_DONE {"pluginName":"${pluginName}","files":["<changed-relative-path>"],"tests":{"passed":<exact passed count>,"failed":0},"lint":"ok","typecheck":"ok"}`,
 	].join("\n");
 }
 
@@ -466,14 +451,18 @@ function buildEditPrompt(
 		`viewLabel: ${view.label}`,
 		`intent: ${intent}`,
 		`sourceDir: ${workdir}`,
+		"deploymentScope: local runtime plugin only; do not publish or register a Cloud app, request parent-agent Cloud commands, or wait for a CDN URL",
 		"referenceDocs: read SCAFFOLD.md or AGENTS.md if present, otherwise README.md",
 		"implementation: minimal requested change; no unrelated refactors",
-		"verificationCommands[3]:",
+		"verificationCommands[4]:",
 		"  bun run typecheck",
 		"  bun run lint",
 		"  bun run test",
+		"  bun run build",
+		"completionFiles: list every changed file as a nonempty relative path array; replace the example path with the actual paths",
+		"completionTests: replace the example passed count with the exact count printed by the test command",
 		"completionRule: after all commands pass, emit exactly one completion line in this canonical schema",
-		`PLUGIN_CREATE_DONE {"pluginName":"${view.pluginName}","files":[],"tests":{"passed":1,"failed":0},"lint":"ok","typecheck":"ok"}`,
+		`PLUGIN_CREATE_DONE {"pluginName":"${view.pluginName}","files":["<changed-relative-path>"],"tests":{"passed":<exact passed count>,"failed":0},"lint":"ok","typecheck":"ok"}`,
 	].join("\n");
 }
 
@@ -694,6 +683,12 @@ async function createNewViewPlugin({
 	await copyTemplate(templateSrc, workdir, {
 		[NAME_PLACEHOLDER]: name,
 		[DISPLAY_NAME_PLACEHOLDER]: displayName,
+	});
+	await seedGuiViewScaffold({
+		workdir,
+		viewId: name,
+		displayName,
+		intent,
 	});
 
 	// Seed a self-contained branded hero icon so the scaffolded view has an image

--- a/plugins/plugin-app-control/src/actions/views-edit.ts
+++ b/plugins/plugin-app-control/src/actions/views-edit.ts
@@ -1,15 +1,7 @@
 /**
- * @module plugin-app-control/actions/views-edit
- *
- * edit sub-mode of the VIEWS action.
- *
- * Resolves the target view by id/label/plugin, locates its source directory,
- * and dispatches a coding sub-agent (START_CODING_TASK) to perform the
- * requested edit. After the agent completes and emits PLUGIN_CREATE_DONE the
- * view registry picks up bundle changes automatically on the next request.
- *
- * Metadata-only edits (label, description, tags) require plugin config
- * changes, which are outside this coding sub-agent dispatch path.
+ * Delegates verified source edits for an explicitly selected registered view.
+ * The target resolves to local plugin source, stays locked to that worktree,
+ * and returns completion to the originating room after rebuild and reload.
  */
 
 import type {
@@ -22,6 +14,7 @@ import type {
 import { logger, spawnWithTrajectoryLink } from "@elizaos/core";
 import { readStringOption } from "../params.js";
 import { findAsyncCodingDelegationActionName } from "./scaffold-env.js";
+import { buildVerifiedPluginTaskParameters } from "./verified-plugin-task.js";
 import type { ViewSummary } from "./views-client.js";
 import { isRestrictedPlatform } from "./views-platform.js";
 import { locatePluginSourceDir } from "./views-plugin-source.js";
@@ -189,31 +182,38 @@ async function dispatchEditAgent({
 		`viewLabel: ${view.label}`,
 		`intent: ${intent}`,
 		`sourceDir: ${workdir}`,
+		"deploymentScope: local runtime plugin only; do not publish or register a Cloud app, request parent-agent Cloud commands, or wait for a CDN URL",
 		"referenceDocs: read SCAFFOLD.md or AGENTS.md if present, otherwise README.md",
 		"implementation: minimal requested change; no unrelated refactors",
-		"verificationCommands[3]:",
+		"verificationCommands[4]:",
 		"  bun run typecheck",
 		"  bun run lint",
 		"  bun run test",
+		"  bun run build",
+		"completionFiles: list every changed file as a nonempty relative path array; replace the example path with the actual paths",
+		"completionTests: replace the example passed count with the exact count printed by the test command",
 		"completionRule: after all commands pass, emit exactly one completion line in this canonical schema",
-		`PLUGIN_CREATE_DONE {"pluginName":"${view.pluginName}","files":[],"tests":{"passed":1,"failed":0},"lint":"ok","typecheck":"ok"}`,
+		`PLUGIN_CREATE_DONE {"pluginName":"${view.pluginName}","files":["<changed-relative-path>"],"tests":{"passed":<exact passed count>,"failed":0},"lint":"ok","typecheck":"ok"}`,
 	].join("\n");
 
 	const label = `edit-view:${view.id}`;
 	const fakeMessage = {
 		entityId: runtime.agentId,
-		roomId: runtime.agentId,
+		// TASKS deliberately trusts the handler message, rather than model-writable
+		// metadata, as the authoritative chat origin for completion routing.
+		roomId: originRoomId,
 		agentId: runtime.agentId,
 		content: { text: prompt },
 	} as Memory;
 
 	const handlerOptions: HandlerOptions = {
-		parameters: {
+		parameters: buildVerifiedPluginTaskParameters({
 			task: prompt,
 			label,
-			approvalPreset: "permissive",
-			metadata: { originRoomId },
-		},
+			workdir,
+			pluginName: view.pluginName,
+			originRoomId,
+		}),
 	};
 
 	const result = await spawnWithTrajectoryLink(

--- a/plugins/plugin-app-control/src/actions/views-icon.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-icon.test.ts
@@ -23,7 +23,13 @@ const coreMock = vi.hoisted(() => ({
 		error instanceof Error ? error.message : String(error),
 }));
 
-vi.mock("@elizaos/core", () => coreMock);
+vi.mock("@elizaos/core", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@elizaos/core")>();
+	return {
+		...coreMock,
+		resolveStateDir: actual.resolveStateDir,
+	};
+});
 
 import type { ViewSummary } from "./views-client.js";
 import {

--- a/plugins/plugin-app-control/src/actions/views-management.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-management.test.ts
@@ -59,6 +59,7 @@ vi.mock("@elizaos/core", async (importOriginal) => {
 		...coreMock,
 		findCodingDelegationActionName: actual.findCodingDelegationActionName,
 		getUserMessageText: actual.getUserMessageText,
+		resolveStateDir: actual.resolveStateDir,
 	};
 });
 
@@ -201,6 +202,17 @@ function createRepoFixture() {
 		path.join(templateDir, "src/index.ts"),
 		"export const name = '__PLUGIN_NAME__';\nexport const displayName = '__PLUGIN_DISPLAY_NAME__';\n",
 	);
+	writeFileSync(
+		path.join(templateDir, "tsconfig.json"),
+		JSON.stringify({
+			compilerOptions: {
+				strict: true,
+				module: "ESNext",
+				moduleResolution: "bundler",
+			},
+			include: ["src/**/*.ts", "tests/**/*.ts"],
+		}),
+	);
 	return {
 		repoRoot,
 		pluginsDir,
@@ -342,7 +354,16 @@ describe("view management actions", () => {
 			expect(
 				readFileSync(path.join(workdir, "src/index.ts"), "utf8"),
 			).toContain("Remote Ledger");
+			expect(
+				readFileSync(path.join(workdir, "src/index.ts"), "utf8"),
+			).toContain('bundlePath: "dist/views/bundle.js"');
+			expect(
+				readFileSync(path.join(workdir, "src/views/PluginView.tsx"), "utf8"),
+			).toContain("create a remote ledger dashboard view");
 			expect(codingHandler).toHaveBeenCalledTimes(1);
+			expect(codingHandler.mock.calls[0][1]).toMatchObject({
+				roomId: "room-1",
+			});
 			const handlerOptions = codingHandler.mock.calls[0][3] as {
 				parameters: Record<string, unknown>;
 			};
@@ -351,7 +372,17 @@ describe("view management actions", () => {
 				"task: build_eliza_plugin_with_view",
 			);
 			expect(handlerOptions.parameters.task).toContain(
+				"sourceDir already contains a working Plugin.views declaration",
+			);
+			expect(handlerOptions.parameters.task).toContain(
 				"completionRule: after all commands pass",
+			);
+			expect(handlerOptions.parameters.task).toContain("bun run build");
+			expect(handlerOptions.parameters.task).toContain(
+				'"files":["<changed-relative-path>"]',
+			);
+			expect(handlerOptions.parameters.task).toContain(
+				'"passed":<exact passed count>',
 			);
 			expect(handlerOptions.parameters.metadata).toMatchObject({
 				originRoomId: "room-1",
@@ -395,6 +426,9 @@ describe("view management actions", () => {
 				taskSessionId: "task-session-1",
 			});
 			expect(codingHandler).toHaveBeenCalledTimes(1);
+			expect(codingHandler.mock.calls[0][1]).toMatchObject({
+				roomId: "room-1",
+			});
 			const handlerOptions = codingHandler.mock.calls[0][3] as {
 				parameters: Record<string, unknown>;
 			};
@@ -405,6 +439,23 @@ describe("view management actions", () => {
 			expect(handlerOptions.parameters.task).toContain(
 				"rename the title to Remote Ledger Updated",
 			);
+			expect(handlerOptions.parameters.task).toContain("bun run build");
+			expect(handlerOptions.parameters.task).toContain(
+				'"files":["<changed-relative-path>"]',
+			);
+			expect(handlerOptions.parameters.task).toContain(
+				'"passed":<exact passed count>',
+			);
+			expect(handlerOptions.parameters.validator).toEqual({
+				service: "app-verification",
+				method: "verifyPlugin",
+				params: {
+					workdir: pluginDir,
+					pluginName: "@local/plugin-ledger",
+					profile: "full",
+				},
+			});
+			expect(handlerOptions.parameters.onVerificationFail).toBe("retry");
 			expect(handlerOptions.parameters.metadata).toMatchObject({
 				originRoomId: "room-1",
 				parentTrajectoryStepId: "parent-step-1",
@@ -1750,6 +1801,77 @@ describe("view management actions", () => {
 		}
 	});
 
+	it("keeps an explicit edit target isolated from current-view capabilities", async () => {
+		const repo = createRepoFixture();
+		try {
+			const pluginDir = path.join(repo.pluginsDir, "plugin-proof-surface");
+			mkdirSync(pluginDir, { recursive: true });
+			const { runtime, codingHandler } = createRuntime();
+			const client = {
+				listViews: vi.fn(async () => [
+					view({
+						id: "cockpit",
+						label: "Cockpit",
+						pluginName: "@elizaos/plugin-task-coordinator",
+						path: "/cockpit",
+						capabilities: [
+							{
+								id: "orchestrator-add-agent",
+								description: "Add an agent to the coding swarm.",
+							},
+						],
+					}),
+					view({
+						id: "proof-surface",
+						label: "Proof Surface",
+						pluginName: "@local/plugin-proof-surface",
+						path: "/proof-surface",
+						capabilities: [],
+					}),
+				]),
+				getCurrentView: vi.fn(async () => ({
+					viewId: "cockpit",
+					viewLabel: "Cockpit",
+					viewType: "gui" as const,
+					viewPath: "/cockpit",
+				})),
+			};
+			const action = createViewsAction({
+				client,
+				hasOwnerAccess: vi.fn(async () => true),
+				repoRoot: repo.repoRoot,
+			});
+
+			const result = await action.handler(
+				runtime as never,
+				message("add an agent") as never,
+				undefined,
+				{
+					parameters: {
+						action: "edit",
+						view: "proof-surface",
+						intent: "Replace marker VIEW_CREATED with VIEW_EDITED and rebuild.",
+					},
+				},
+				vi.fn(),
+			);
+
+			expect(result?.success).toBe(true);
+			expect(result?.values).toMatchObject({
+				mode: "edit",
+				viewId: "proof-surface",
+				workdir: pluginDir,
+			});
+			expect(codingHandler).toHaveBeenCalledTimes(1);
+			expect(globalThis.fetch).not.toHaveBeenCalledWith(
+				"http://127.0.0.1:3456/api/views/cockpit/interact",
+				expect.anything(),
+			);
+		} finally {
+			repo.cleanup();
+		}
+	});
+
 	it("routes explicit CLOSE_VIEW alias calls through non-destructive view close", async () => {
 		const { runtime } = createRuntime();
 		const callback = vi.fn();
@@ -3014,6 +3136,77 @@ describe("view management actions", () => {
 			subMode: "cancel",
 		});
 		expect(runtime.createTask).not.toHaveBeenCalled();
+	});
+
+	it("keeps an APP edit task in its chat room with bounded verification retries", async () => {
+		const repo = createRepoFixture();
+		try {
+			const pluginDir = path.join(repo.pluginsDir, "plugin-proof-app");
+			mkdirSync(pluginDir, { recursive: true });
+			const { runtime, codingHandler } = createRuntime();
+			const appClient = {
+				listInstalledApps: vi.fn(async () => [
+					{
+						name: "proof-app",
+						displayName: "Proof App",
+						pluginName: "@local/plugin-proof-app",
+						version: "1.0.0",
+						installedAt: "2026-07-13T00:00:00.000Z",
+					},
+				]),
+			};
+
+			const result = await runCreate({
+				runtime: runtime as never,
+				client: appClient as never,
+				message: message("Update the proof app", "origin-app-room") as never,
+				options: {
+					action: "create",
+					editTarget: "proof-app",
+					intent: "Replace the proof marker and rebuild.",
+				},
+				callback: vi.fn(),
+				repoRoot: repo.repoRoot,
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.values).toMatchObject({
+				mode: "create",
+				subMode: "edit",
+				name: "proof-app",
+				workdir: pluginDir,
+			});
+			expect(codingHandler).toHaveBeenCalledTimes(1);
+			expect(codingHandler.mock.calls[0][1]).toMatchObject({
+				roomId: "origin-app-room",
+			});
+			const handlerOptions = codingHandler.mock.calls[0][3] as {
+				parameters: Record<string, unknown>;
+			};
+			expect(handlerOptions.parameters.metadata).toMatchObject({
+				originRoomId: "origin-app-room",
+				parentTrajectoryStepId: "parent-step-1",
+				trajectoryLinkSource: "plugin-app-control:app-create",
+			});
+			expect(handlerOptions.parameters).toMatchObject({
+				workdir: pluginDir,
+				lockWorkdir: true,
+				keepAliveAfterComplete: true,
+				maxRetries: 2,
+				onVerificationFail: "retry",
+				validator: {
+					service: "app-verification",
+					method: "verifyApp",
+					params: {
+						workdir: pluginDir,
+						appName: "proof-app",
+						profile: "full",
+					},
+				},
+			});
+		} finally {
+			repo.cleanup();
+		}
 	});
 
 	it("returns create choice blocks as verified user-facing payloads", async () => {

--- a/plugins/plugin-app-control/src/actions/views-management.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-management.test.ts
@@ -3138,6 +3138,66 @@ describe("view management actions", () => {
 		expect(runtime.createTask).not.toHaveBeenCalled();
 	});
 
+	it("surfaces invalid APP create continuations without fabricating a dispatch", async () => {
+		const callback = vi.fn();
+		const appClient = { listInstalledApps: vi.fn(async () => []) };
+		const emptyRuntime = createRuntime().runtime;
+
+		const empty = await runCreate({
+			runtime: emptyRuntime as never,
+			client: appClient as never,
+			message: message("") as never,
+			callback,
+			repoRoot: "/tmp/no-app-create",
+		});
+		expect(empty).toMatchObject({
+			success: false,
+			text: "Tell me what app you want to build.",
+		});
+		expect(appClient.listInstalledApps).not.toHaveBeenCalled();
+
+		const missingTarget = await runCreate({
+			runtime: emptyRuntime as never,
+			client: appClient as never,
+			message: message("Update the missing app") as never,
+			options: { action: "create", editTarget: "missing" },
+			callback,
+			repoRoot: "/tmp/no-app-create",
+		});
+		expect(missingTarget).toMatchObject({
+			success: false,
+			text: 'Cannot find an installed app named "missing".',
+		});
+
+		const pendingTasks: RuntimeTask[] = [
+			{
+				id: "pending-app-create",
+				metadata: {
+					roomId: "room-1",
+					intent: "Update proof app",
+					intentCreatedAt: "2026-07-13T00:00:00.000Z",
+					choices: [{ key: "edit-1", label: "Edit proof app" }],
+				},
+			},
+		];
+		const pendingRuntime = createRuntime({ tasks: pendingTasks }).runtime;
+		const lostTarget = await runCreate({
+			runtime: pendingRuntime as never,
+			client: appClient as never,
+			message: message("edit-1") as never,
+			callback,
+			repoRoot: "/tmp/no-app-create",
+		});
+		expect(lostTarget).toMatchObject({
+			success: false,
+			text: 'I lost track of the edit target "edit-1". Please re-state your request.',
+		});
+		expect(pendingRuntime.deleteTask).toHaveBeenCalledWith(
+			"pending-app-create",
+		);
+		expect(emptyRuntime.actions[0]?.handler).not.toHaveBeenCalled();
+	});
+
 	it("keeps an APP edit task in its chat room with bounded verification retries", async () => {
 		const repo = createRepoFixture();
 		try {

--- a/plugins/plugin-app-control/src/actions/views-plugin-source.ts
+++ b/plugins/plugin-app-control/src/actions/views-plugin-source.ts
@@ -1,13 +1,12 @@
 /**
- * @module plugin-app-control/actions/views-plugin-source
- *
- * Resolve a view's on-disk plugin source directory from its registry summary.
- * Shared by the create, edit, and icon sub-handlers so plugin-path resolution
- * lives in one place.
+ * Resolves a registered view's owning plugin to editable local source.
+ * Checkout and packaged-install locations share this path so create, edit, and
+ * icon operations agree on where a plugin lives.
  */
 
-import { promises as fs } from "node:fs";
+import { existsSync, promises as fs } from "node:fs";
 import path from "node:path";
+import { ElizaError, resolveStateDir } from "@elizaos/core";
 import type { ViewSummary } from "./views-client.js";
 
 /** Where plugin sources live relative to the repo root, in lookup order. */
@@ -23,15 +22,35 @@ export async function locatePluginSourceDir(
 	view: ViewSummary,
 ): Promise<string | null> {
 	const pluginBasename = view.pluginName.replace(/^@[^/]+\//, "").trim();
-	const candidates = [
-		...PLUGIN_SOURCE_DIR_CANDIDATES.map((dir) =>
-			path.join(repoRoot, dir, pluginBasename),
-		),
-		path.join(repoRoot, "eliza", "apps", pluginBasename),
+	if (
+		pluginBasename.length === 0 ||
+		pluginBasename === "." ||
+		pluginBasename === ".." ||
+		pluginBasename.includes("/") ||
+		pluginBasename.includes("\\") ||
+		pluginBasename.includes("\0")
+	) {
+		throw new ElizaError("View plugin name is not a safe directory name", {
+			code: "VIEW_PLUGIN_NAME_INVALID",
+			context: { pluginName: view.pluginName },
+		});
+	}
+	const directoryBasenames = [
+		pluginBasename,
+		pluginBasename.startsWith("plugin-")
+			? pluginBasename.slice("plugin-".length)
+			: `plugin-${pluginBasename}`,
 	];
+	const candidates = directoryBasenames.flatMap((basename) => [
+		...PLUGIN_SOURCE_DIR_CANDIDATES.map((dir) =>
+			path.join(repoRoot, dir, basename),
+		),
+		path.join(repoRoot, "eliza", "apps", basename),
+		path.join(resolveStateDir(), "plugins", basename),
+	]);
 	for (const candidate of candidates) {
-		const stat = await fs.stat(candidate).catch(() => null);
-		if (stat?.isDirectory()) return candidate;
+		if (!existsSync(candidate)) continue;
+		if ((await fs.stat(candidate)).isDirectory()) return candidate;
 	}
 	return null;
 }

--- a/plugins/plugin-app-control/src/actions/views.ts
+++ b/plugins/plugin-app-control/src/actions/views.ts
@@ -1,11 +1,7 @@
 /**
- * @module plugin-app-control/actions/views
- *
- * Unified VIEWS action. Lets the Eliza agent list, open, search, manage,
- * create, edit, and delete UI views contributed by plugins via `Plugin.views`.
- *
- * Sub-modes dispatched from a single action keep the planner surface minimal
- * and the handler testable. Mirrors the APP action structure.
+ * Unified action for discovering, opening, managing, and authoring plugin-contributed views.
+ * Sub-modes share owner checks, view resolution, and client boundaries while
+ * keeping the planner surface to one action.
  */
 
 import path from "node:path";
@@ -942,7 +938,11 @@ function resolveViewCapability({
 		(MODES as readonly string[]).includes(explicitAction.trim().toLowerCase());
 	const actionToken = actionIsMode ? null : explicitAction;
 	const requestedView = resolveViewTarget(readViewTargetOption(options), views);
-	const currentView = views.find((view) => view.id === currentViewId) ?? null;
+	// A resolved planner target is authoritative. Foreground UI state is only a
+	// fallback for requests that do not identify a registered view.
+	const currentView = requestedView
+		? null
+		: (views.find((view) => view.id === currentViewId) ?? null);
 	const candidates = capabilityCandidates(views, viewType);
 
 	if (explicitCapability) {
@@ -968,6 +968,7 @@ function resolveViewCapability({
 	let best: { candidate: ResolvedViewCapability; score: number } | null = null;
 
 	for (const candidate of candidates) {
+		if (requestedView && candidate.view.id !== requestedView.id) continue;
 		const vTokens = viewTokens(candidate.view);
 		const cTokens = capabilityTokens(candidate.capability);
 		const capOperation = operationFamilyForCapability(candidate.capability);
@@ -2464,7 +2465,9 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 					}
 				}
 
-				logger.info(`[plugin-app-control] VIEWS mode=${effectiveMode}`);
+				logger.info(
+					`[plugin-app-control] VIEWS requestedMode=${mode} effectiveMode=${effectiveMode} action=${readStringOption(actionOptions, "action") ?? "inferred"} view=${readViewTargetOption(actionOptions) ?? "none"} resolvedCapability=${forcedResolvedCapability ? `${forcedResolvedCapability.view.id}:${forcedResolvedCapability.capability.id}` : "none"}`,
+				);
 
 				switch (effectiveMode) {
 					case "list":

--- a/plugins/plugin-app-control/src/components/ViewManagerSpatialView.tsx
+++ b/plugins/plugin-app-control/src/components/ViewManagerSpatialView.tsx
@@ -29,6 +29,7 @@ export interface ViewManagerSnapshot {
 	views: ViewEntry[];
 	loading?: boolean;
 	error?: string | null;
+	openingViewId?: string | null;
 }
 
 /** The surfaces this logical view can render on, ordered gui · xr · tui. */
@@ -79,11 +80,11 @@ export function ViewManagerSpatialView({
 			) : null}
 
 			<Divider label="views" />
-			{views.length === 0 ? (
+			{views.length === 0 && !snapshot.loading && !snapshot.error ? (
 				<Text tone="muted" align="center" style="caption">
 					None
 				</Text>
-			) : (
+			) : views.length > 0 ? (
 				<List gap={1}>
 					{views.slice(0, 12).map((view) => (
 						<HStack
@@ -126,14 +127,18 @@ export function ViewManagerSpatialView({
 								variant="ghost"
 								tone="default"
 								agent={`open:${view.id}`}
+								disabled={
+									snapshot.openingViewId !== null &&
+									snapshot.openingViewId !== undefined
+								}
 								onPress={() => onOpenView?.(view)}
 							>
-								Open
+								{snapshot.openingViewId === view.id ? "Opening…" : "Open"}
 							</Button>
 						</HStack>
 					))}
 				</List>
-			)}
+			) : null}
 		</Card>
 	);
 }

--- a/plugins/plugin-app-control/src/services/__tests__/app-verification.integration.test.ts
+++ b/plugins/plugin-app-control/src/services/__tests__/app-verification.integration.test.ts
@@ -1,16 +1,5 @@
 /**
- * @module plugin-app-control/services/__tests__/app-verification.integration
- *
- * Integration test for AppVerificationService.verifyApp against a real
- * temp project on disk that uses real `tsc` for typecheck. We do NOT rely
- * on a global eslint install — lint is wired to a local shim so the fast
- * profile (typecheck + lint) returns a pure typecheck verdict.
- *
- * The test is gated on `bun --version` succeeding because the verifier's
- * default packageManager detection picks bun when bun.lockb is present, and
- * we explicitly pass packageManager: "npm" to keep the surface narrow. We
- * still need npx to be available to run the local tsc; if npx + npm aren't
- * on PATH the test is skipped to keep CI portable.
+ * Exercises AppVerificationService against real temporary projects and local toolchain commands.
  */
 
 import { execFile } from "node:child_process";
@@ -64,6 +53,7 @@ export const broken: number = ({ hello: "world" } as Greeting).foo;
 
 const PASS_SHIM_JS = `process.stdout.write("lint ok\\n"); process.exit(0);\n`;
 const TEST_SHIM_JS = `process.stdout.write(" Tests  2 passed (2)\\n"); process.exit(0);\n`;
+const BUILD_SHIM_JS = `process.stdout.write("build ok\\n"); process.exit(0);\n`;
 
 function writeMinimalTsProject(workdir: string, source: string): void {
 	writeFileSync(path.join(workdir, "src.ts"), source, "utf8");
@@ -93,6 +83,8 @@ function writeMinimalTsProject(workdir: string, source: string): void {
 	writeFileSync(lintShim, PASS_SHIM_JS, "utf8");
 	const testShim = path.join(workdir, "test-shim.mjs");
 	writeFileSync(testShim, TEST_SHIM_JS, "utf8");
+	const buildShim = path.join(workdir, "build-shim.mjs");
+	writeFileSync(buildShim, BUILD_SHIM_JS, "utf8");
 
 	writeFileSync(
 		path.join(workdir, "package.json"),
@@ -109,6 +101,7 @@ function writeMinimalTsProject(workdir: string, source: string): void {
 						"npx --yes -p typescript@5.6.2 tsc --noEmit -p tsconfig.json",
 					lint: `node ${JSON.stringify(lintShim).slice(1, -1)}`,
 					test: `node ${JSON.stringify(testShim).slice(1, -1)}`,
+					build: `node ${JSON.stringify(buildShim).slice(1, -1)}`,
 				},
 			},
 			null,
@@ -155,6 +148,42 @@ describeIntegration("AppVerificationService.verifyApp (integration)", () => {
 	);
 
 	itIf(pkgManagerAvailable)(
+		"builds a verified plugin before reporting a pass",
+		async () => {
+			const workdir = mkdtempSync(path.join(tmpdir(), "verify-plugin-build-"));
+			writeMinimalTsProject(workdir, PASS_TS);
+
+			const result = await service.verifyPlugin({
+				workdir,
+				profile: "full",
+				runId: "int-plugin-build",
+				packageManager: "npm",
+				structuredProof: {
+					kind: "PLUGIN_CREATE_DONE",
+					pluginName: "verify-int-fixture",
+					files: ["src.ts"],
+					typecheck: "ok",
+					lint: "ok",
+					tests: { passed: 2, failed: 0 },
+				},
+			});
+
+			expect(result.verdict).toBe("pass");
+			expect(result.checks.map((check) => check.kind)).toEqual([
+				"typecheck",
+				"lint",
+				"test",
+				"build",
+				"structured-proof",
+			]);
+			expect(
+				result.checks.find((check) => check.kind === "build")?.passed,
+			).toBe(true);
+		},
+		120_000,
+	);
+
+	itIf(pkgManagerAvailable)(
 		"returns verdict=fail with non-empty diagnostics when TS has a type error",
 		async () => {
 			const workdir = mkdtempSync(path.join(tmpdir(), "verify-int-fail-"));
@@ -175,6 +204,7 @@ describeIntegration("AppVerificationService.verifyApp (integration)", () => {
 			expect(result.retryablePromptForChild.toLowerCase()).toContain(
 				"typecheck",
 			);
+			expect(result.retryablePromptForChild).toContain("bun run build");
 		},
 		120_000,
 	);

--- a/plugins/plugin-app-control/src/services/app-verification.ts
+++ b/plugins/plugin-app-control/src/services/app-verification.ts
@@ -1,14 +1,7 @@
 /**
- * @module plugin-app-control/services/app-verification
- * @description AppVerificationService — runs a structured verification
- * pipeline (typecheck / lint / test / build / launch / browser) against
- * an app workdir and returns a result the orchestrator can use to decide
- * pass / retry / escalate.
- *
- * Other agents wire this into the parent's APP_CREATE / PLUGIN_CREATE flow:
- * when a child coding agent claims completion, the parent calls
- * `verifyApp()` and either accepts the result, retries with the
- * `retryablePromptForChild` message, or escalates to the user.
+ * Verifies generated app and plugin workdirs through build, test, launch, and browser checks.
+ * The orchestrator consumes its structured verdict, diagnostics, artifacts,
+ * and corrective prompt before accepting or retrying a coding-agent result.
  */
 
 import { type ExecFileOptions, execFile } from "node:child_process";
@@ -161,7 +154,15 @@ function expandProfile(
 	projectKind: ProjectKind,
 ): VerificationCheck[] {
 	if (projectKind === "plugin") {
-		return [{ kind: "typecheck" }, { kind: "lint" }, { kind: "test" }];
+		// Plugin loading executes the compiled package entrypoint. A source-only
+		// pass would let create/edit verification succeed while load-from-directory
+		// either fails on a missing dist entry or reloads the previous build.
+		return [
+			{ kind: "typecheck" },
+			{ kind: "lint" },
+			{ kind: "test" },
+			{ kind: "build" },
+		];
 	}
 	if (profile === "fast" || profile === undefined) {
 		return [{ kind: "typecheck" }, { kind: "lint" }];
@@ -1079,7 +1080,7 @@ function buildRetryPrompt(
 	}
 	lines.push("");
 	lines.push(
-		"After fixing the issues, rerun `bun run typecheck`, `bun run lint`, and `bun run test`, then re-emit exactly one structured completion line:",
+		"After fixing the issues, rerun `bun run typecheck`, `bun run lint`, `bun run test`, and `bun run build`, then re-emit exactly one structured completion line:",
 	);
 	const nameField = proofKind === "APP_CREATE_DONE" ? "appName" : "pluginName";
 	lines.push(

--- a/plugins/plugin-app-control/src/shortcuts.test.ts
+++ b/plugins/plugin-app-control/src/shortcuts.test.ts
@@ -30,6 +30,7 @@ describe("viewNavigationShortcuts (#8791)", () => {
 			"hey can you open settings please",
 			"open app builder",
 			"check my messages",
+			"go to my email",
 			"what's on my calendar",
 			"abre ajustes",
 			"打开设置",
@@ -72,6 +73,3 @@ describe("viewNavigationShortcuts (#8791)", () => {
 		).toBeNull();
 	});
 });
-/**
- * Natural-language shortcut tests for direct view navigation commands.
- */

--- a/plugins/plugin-app-control/src/shortcuts.ts
+++ b/plugins/plugin-app-control/src/shortcuts.ts
@@ -9,7 +9,7 @@
 import type { ShortcutDefinition } from "@elizaos/core";
 
 const VIEW_TARGET_PATTERN =
-	"settings|calendar|agenda|schedule|inbox|messages|wallet|app builder|task coordinator|home|home screen|home page|home dashboard|dashboard|main screen|main page|main chat|chat";
+	"settings|calendar|agenda|schedule|inbox|messages|mailbox|mail|email|e-mail|emails|wallet|app builder|task coordinator|home|home screen|home page|home dashboard|dashboard|main screen|main page|main chat|chat";
 const NAVIGATION_VERB_PATTERN =
 	"open|show|go(?: back)?(?: to)?|back(?: to)?|return(?: to)?|switch to|take me to|pull up|bring up|check|view";
 

--- a/plugins/plugin-app-control/src/views/ViewManagerView.manifest.test.ts
+++ b/plugins/plugin-app-control/src/views/ViewManagerView.manifest.test.ts
@@ -54,18 +54,17 @@ describe("views-manager manifest", () => {
 		expect(views).toContain("list-views");
 	});
 
-	it("is the thin SpatialSurface wrapper around the single ViewManagerSpatialView", () => {
-		// The wrapper owns the live fetch and renders the one presentational
-		// spatial view inside a SpatialSurface — no hand-rolled rich-DOM chrome.
-		expect(viewSource).toContain("SpatialSurface");
+	it("keeps transport state thin and delegates rendering to ViewManagerSpatialView", () => {
+		// The shell owns SpatialSurface so plugin views share one host wrapper;
+		// this component owns only transport, navigation, and reload state.
+		expect(viewSource).not.toContain("<SpatialSurface");
 		expect(viewSource).toContain("ViewManagerSpatialView");
 		expect(viewSource).toContain("fetchViewEntries");
+		expect(viewSource).toContain("requestViewNavigation");
+		expect(viewSource).toContain("dispatchNavigateViewEvent");
 		// No hardcoded terminal-chrome colors leak back into the wrapper.
 		expect(viewSource).not.toContain("#7dd3fc");
 		expect(viewSource).not.toContain("#6c63ff");
 		expect(viewSource).not.toContain("rgba(");
 	});
 });
-/**
- * View manager manifest tests for exported view registrations and metadata.
- */

--- a/plugins/plugin-app-control/src/views/ViewManagerView.render.test.tsx
+++ b/plugins/plugin-app-control/src/views/ViewManagerView.render.test.tsx
@@ -1,13 +1,13 @@
 /**
- * Behavior tests for the consolidated ViewManagerView wrapper.
- *
- * The wrapper owns GET /api/views fetching and open-to-navigate handoff while
- * rendering the shared ViewManagerSpatialView inside a SpatialSurface.
- *
+ * Exercises ViewManagerView's fetch, state, and navigation boundaries with browser-style responses.
  * @vitest-environment jsdom
  */
 
-import { emitViewEvent, VIEW_EVENTS } from "@elizaos/ui/events";
+import {
+	emitViewEvent,
+	NAVIGATE_VIEW_EVENT,
+	VIEW_EVENTS,
+} from "@elizaos/ui/events";
 import {
 	act,
 	cleanup,
@@ -100,7 +100,10 @@ describe("ViewManagerView GUI wrapper", () => {
 		expect(calls[0].url).not.toContain("?viewType");
 	});
 
-	it("opens a view via POST navigate with NO ?viewType query string (gui distinction)", async () => {
+	it("uses the CSRF-aware POST then dispatches local navigation without a server echo", async () => {
+		vi.spyOn(document, "cookie", "get").mockReturnValue(
+			"eliza_csrf=view-manager-token",
+		);
 		const { calls } = stubFetch(({ url }) => {
 			if (url === "/api/views") return jsonResponse(guiViews);
 			if (url === "/api/views/wallet/navigate")
@@ -108,6 +111,10 @@ describe("ViewManagerView GUI wrapper", () => {
 			throw new Error(`Unexpected request: ${url}`);
 		});
 
+		const navigateEvents: CustomEvent[] = [];
+		const onNavigate = (event: Event) =>
+			navigateEvents.push(event as CustomEvent);
+		window.addEventListener(NAVIGATE_VIEW_EVENT, onNavigate);
 		const { container } = render(<ViewManagerView />);
 		await screen.findByText("Wallet");
 
@@ -127,9 +134,52 @@ describe("ViewManagerView GUI wrapper", () => {
 		expect(navCall?.url).toBe("/api/views/wallet/navigate");
 		expect(navCall?.url).not.toContain("?viewType");
 		expect(navCall?.init?.method).toBe("POST");
-		expect(navCall?.init?.body).toBe(
-			JSON.stringify({ path: "/wallet", viewType: undefined }),
+		expect(navCall?.init?.credentials).toBe("include");
+		expect(new Headers(navCall?.init?.headers).get("x-eliza-csrf")).toBe(
+			"view-manager-token",
 		);
+		expect(navCall?.init?.body).toBe(
+			JSON.stringify({
+				path: "/wallet",
+				viewType: undefined,
+				source: "user",
+			}),
+		);
+		expect(navigateEvents).toHaveLength(1);
+		expect(navigateEvents[0]?.detail).toMatchObject({
+			viewId: "wallet",
+			viewPath: "/wallet",
+			viewLabel: "Wallet",
+			viewType: "gui",
+		});
+		window.removeEventListener(NAVIGATE_VIEW_EVENT, onNavigate);
+	});
+
+	it("surfaces a failed open and does not dispatch local navigation", async () => {
+		const { calls } = stubFetch(({ url }) => {
+			if (url === "/api/views") return jsonResponse(guiViews);
+			if (url === "/api/views/wallet/navigate") {
+				return jsonResponse({ error: "offline" }, { status: 503 });
+			}
+			throw new Error(`Unexpected request: ${url}`);
+		});
+		const navigateEvents: CustomEvent[] = [];
+		const onNavigate = (event: Event) =>
+			navigateEvents.push(event as CustomEvent);
+		window.addEventListener(NAVIGATE_VIEW_EVENT, onNavigate);
+
+		const { container } = render(<ViewManagerView />);
+		await screen.findByText("Wallet");
+		fireEvent.click(
+			container.querySelector<HTMLButtonElement>(
+				'[data-agent-id="open:wallet"]',
+			) as HTMLButtonElement,
+		);
+
+		await screen.findByText("Could not open view: HTTP 503");
+		expect(calls.some((call) => call.url.endsWith("/navigate"))).toBe(true);
+		expect(navigateEvents).toHaveLength(0);
+		window.removeEventListener(NAVIGATE_VIEW_EVENT, onNavigate);
 	});
 
 	it("renders the empty state for an empty payload", async () => {
@@ -152,7 +202,20 @@ describe("ViewManagerView GUI wrapper", () => {
 		});
 
 		render(<ViewManagerView />);
-		await screen.findByText("HTTP 500");
+		await screen.findByText(/HTTP 500/);
+	});
+
+	it("renders malformed registry data as an error rather than a healthy empty state", async () => {
+		stubFetch(({ url }) => {
+			if (url === "/api/views") return jsonResponse({ status: "ready" });
+			throw new Error(`Unexpected request: ${url}`);
+		});
+
+		render(<ViewManagerView />);
+		await screen.findByText(
+			"GET /api/views response must contain a views array",
+		);
+		expect(screen.queryByText("None")).toBeNull();
 	});
 
 	it("shows 'loading' before the fetch resolves", async () => {

--- a/plugins/plugin-app-control/src/views/ViewManagerView.tsx
+++ b/plugins/plugin-app-control/src/views/ViewManagerView.tsx
@@ -1,23 +1,17 @@
 /**
- * ViewManagerView — the GUI data wrapper for the "views" surface (the
- * "views view"): the deduped manager that fetches GET /api/views and lists every
- * registered view (collapsed one row per logical id with modality chips and
- * per-view open/available state).
- *
- * It owns the live view list (fetch + loading/error state and the open→navigate
- * handoff) and renders the one presentational {@link ViewManagerSpatialView}
- * inside a {@link SpatialSurface}. The browser DOM surface ships today, while
- * the retained modality contract stays available for future adapters.
- *
- * Built as a standalone ES-module view bundle; loaded dynamically by the
- * frontend shell via `import("/api/views/views-manager/bundle.js")`. External
- * dependencies (react, @elizaos/ui) are provided by the shell host environment
- * and externalized from this bundle.
+ * Connects the registered-view catalog to its spatial manager surface.
+ * It owns fetch, loading, error, reload, and open-to-navigation state while the
+ * presentational component remains transport-agnostic. The shell loads this as
+ * a standalone ES module and supplies its external React and UI dependencies.
  */
 
 import { useAgentElement } from "@elizaos/ui/agent-surface";
 import { Button } from "@elizaos/ui/components/ui/button";
-import { useViewEvent, VIEW_EVENTS } from "@elizaos/ui/events";
+import {
+	dispatchNavigateViewEvent,
+	useViewEvent,
+	VIEW_EVENTS,
+} from "@elizaos/ui/events";
 import { useCallback, useEffect, useState } from "react";
 import {
 	type ViewManagerSnapshot,
@@ -36,6 +30,7 @@ export function ViewManagerView() {
 	const [views, setViews] = useState<ViewEntry[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
+	const [openingViewId, setOpeningViewId] = useState<string | null>(null);
 
 	const fetchViews = useCallback(async () => {
 		setLoading(true);
@@ -56,8 +51,27 @@ export function ViewManagerView() {
 		void fetchViews();
 	}, [fetchViews]);
 
-	const openView = useCallback((view: ViewEntry) => {
-		void requestViewNavigation(view);
+	const openView = useCallback(async (view: ViewEntry) => {
+		setOpeningViewId(view.id);
+		setError(null);
+		try {
+			// A user click navigates locally after the server records current-view
+			// state. This works on Cloud/mobile transports that intentionally have no
+			// WebSocket, and `source:user` prevents a duplicate server echo.
+			await requestViewNavigation(view, { source: "user" });
+			dispatchNavigateViewEvent({
+				viewId: view.id,
+				...(view.path ? { viewPath: view.path } : {}),
+				viewLabel: view.label,
+				viewType: view.viewType ?? "gui",
+			});
+		} catch (err) {
+			// error-policy:J4 the manager keeps the catalog visible and renders a
+			// distinct open failure instead of pretending navigation succeeded.
+			setError(err instanceof Error ? err.message : "Could not open view");
+		} finally {
+			setOpeningViewId(null);
+		}
 	}, []);
 
 	const refreshControl = useAgentElement<HTMLButtonElement>({
@@ -72,7 +86,12 @@ export function ViewManagerView() {
 		},
 	});
 
-	const snapshot: ViewManagerSnapshot = { views, loading, error };
+	const snapshot: ViewManagerSnapshot = {
+		views,
+		loading,
+		error,
+		openingViewId,
+	};
 
 	return (
 		<div className="flex flex-col gap-2">

--- a/plugins/plugin-app-control/src/views/viewManagerData.contract.test.ts
+++ b/plugins/plugin-app-control/src/views/viewManagerData.contract.test.ts
@@ -1,8 +1,5 @@
 /**
- * Contract tests for parsing the live GET /api/views payload shape.
- *
- * The fixture mirrors ViewRegistryEntry from packages/ui so fetchViewEntries is
- * exercised against the real DTO contract, not a trimmed stub.
+ * Exercises View Manager parsing against realistic live registry payloads and modality merges.
  */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -103,18 +100,24 @@ describe("fetchViewEntries contract (/api/views ViewRegistryEntry shape)", () =>
 		expect(fetchMock).toHaveBeenCalledOnce();
 	});
 
-	it("returns [] when the payload's views field is not an array", async () => {
+	it("rejects when the payload's views field is not an array", async () => {
 		vi.stubGlobal(
 			"fetch",
 			vi.fn(async () => jsonResponse({ views: null })),
 		);
-		await expect(fetchViewEntries()).resolves.toEqual([]);
+		await expect(fetchViewEntries()).rejects.toMatchObject({
+			name: "ElizaError",
+			code: "VIEW_MANAGER_LIST_RESPONSE_INVALID",
+		});
 
 		vi.stubGlobal(
 			"fetch",
 			vi.fn(async () => jsonResponse({})),
 		);
-		await expect(fetchViewEntries()).resolves.toEqual([]);
+		await expect(fetchViewEntries()).rejects.toMatchObject({
+			name: "ElizaError",
+			code: "VIEW_MANAGER_LIST_RESPONSE_INVALID",
+		});
 	});
 
 	it("throws 'HTTP <status>' on a non-ok response", async () => {

--- a/plugins/plugin-app-control/src/views/viewManagerData.interact.test.ts
+++ b/plugins/plugin-app-control/src/views/viewManagerData.interact.test.ts
@@ -71,6 +71,7 @@ describe("interact() happy paths", () => {
 			"/api/views/messages/navigate?viewType=gui",
 			expect.objectContaining({
 				method: "POST",
+				credentials: "include",
 				body: JSON.stringify({ path: "/messages", viewType: "gui" }),
 			}),
 		);
@@ -78,6 +79,19 @@ describe("interact() happy paths", () => {
 });
 
 describe("interact() error paths", () => {
+	it("rejects a malformed registry payload instead of fabricating an empty list", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => jsonResponse({ status: "ready" })),
+		);
+
+		await expect(interact("list-views")).rejects.toMatchObject({
+			name: "ElizaError",
+			code: "VIEW_MANAGER_LIST_RESPONSE_INVALID",
+			message: "GET /api/views response must contain a views array",
+		});
+	});
+
 	it("open-view rejects with 'viewId is required' when viewId is missing", async () => {
 		// No fetch should be needed before the guard fires; stub defensively.
 		vi.stubGlobal(

--- a/plugins/plugin-app-control/src/views/viewManagerData.ts
+++ b/plugins/plugin-app-control/src/views/viewManagerData.ts
@@ -1,10 +1,11 @@
 /**
- * Pure data layer for the View Manager bundle.
- *
- * Holds the view shape and the fetch/navigate/capability logic with no React or
- * `@elizaos/ui` imports, so it can be unit-tested in a plain Node environment
- * without dragging the shell-host UI dependency chain into the test runtime.
+ * React-free data layer for the View Manager bundle. Read requests use the
+ * browser fetch surface, while mutations go through the shell's authenticated
+ * API transport so cookie sessions and native hosts share one security path.
  */
+
+import { ElizaError } from "@elizaos/core";
+import { fetchWithCsrf } from "@elizaos/ui/api/csrf-client";
 
 /**
  * A surface a view renders on. Mirrors `ViewModality` in `@elizaos/core`; kept
@@ -14,6 +15,26 @@
 export type ViewModality = "gui" | "tui" | "xr";
 
 const MODALITY_ORDER: readonly ViewModality[] = ["gui", "xr", "tui"];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isViewModality(value: unknown): value is ViewModality {
+	return value === "gui" || value === "tui" || value === "xr";
+}
+
+function invalidViewListResponse(
+	message: string,
+	context: Record<string, unknown> = {},
+	options: { cause?: unknown } = {},
+): never {
+	throw new ElizaError(message, {
+		code: "VIEW_MANAGER_LIST_RESPONSE_INVALID",
+		context,
+		...(options.cause !== undefined ? { cause: options.cause } : {}),
+	});
+}
 
 /** Order + de-duplicate a modality list as gui, xr, tui (matches core). */
 function dedupeModalities(mods: readonly ViewModality[]): ViewModality[] {
@@ -69,7 +90,118 @@ export function collapseViewEntries(entries: ViewEntry[]): ViewEntry[] {
 		const base = isGui && !baseWasGui ? entry : existing;
 		byId.set(entry.id, { ...base, modalities: merged });
 	}
-	return order.map((id) => byId.get(id) as ViewEntry);
+	return order.map((id) => {
+		const entry = byId.get(id);
+		if (!entry) {
+			throw new ElizaError("Collapsed view entry is missing", {
+				code: "VIEW_MANAGER_COLLAPSE_INVARIANT_FAILED",
+				context: { viewId: id },
+			});
+		}
+		return entry;
+	});
+}
+
+function optionalString(
+	record: Record<string, unknown>,
+	key: string,
+	index: number,
+): string | undefined {
+	const value = record[key];
+	if (value === undefined) return undefined;
+	if (typeof value !== "string") {
+		return invalidViewListResponse(
+			`View entry ${index}.${key} must be a string`,
+			{ index, field: key },
+		);
+	}
+	return value;
+}
+
+function parseViewEntry(value: unknown, index: number): ViewEntry {
+	if (!isRecord(value)) {
+		return invalidViewListResponse(`View entry ${index} must be an object`, {
+			index,
+		});
+	}
+	const id = value.id;
+	const label = value.label;
+	const available = value.available;
+	const pluginName = value.pluginName;
+	if (typeof id !== "string" || id.trim().length === 0) {
+		return invalidViewListResponse(
+			`View entry ${index}.id must be a non-empty string`,
+			{ index, field: "id" },
+		);
+	}
+	if (typeof label !== "string" || label.trim().length === 0) {
+		return invalidViewListResponse(
+			`View entry ${index}.label must be a non-empty string`,
+			{ index, field: "label" },
+		);
+	}
+	if (typeof available !== "boolean") {
+		return invalidViewListResponse(
+			`View entry ${index}.available must be a boolean`,
+			{ index, field: "available" },
+		);
+	}
+	if (typeof pluginName !== "string" || pluginName.trim().length === 0) {
+		return invalidViewListResponse(
+			`View entry ${index}.pluginName must be a non-empty string`,
+			{ index, field: "pluginName" },
+		);
+	}
+
+	const viewType = value.viewType;
+	if (viewType !== undefined && !isViewModality(viewType)) {
+		return invalidViewListResponse(`View entry ${index}.viewType is invalid`, {
+			index,
+			field: "viewType",
+			value: viewType,
+		});
+	}
+	const rawModalities = value.modalities;
+	let modalities: ViewModality[] | undefined;
+	if (rawModalities !== undefined) {
+		if (!Array.isArray(rawModalities) || !rawModalities.every(isViewModality)) {
+			return invalidViewListResponse(
+				`View entry ${index}.modalities must contain valid modalities`,
+				{ index, field: "modalities" },
+			);
+		}
+		modalities = dedupeModalities(rawModalities);
+	}
+	const order = value.order;
+	if (
+		order !== undefined &&
+		(typeof order !== "number" || !Number.isFinite(order))
+	) {
+		return invalidViewListResponse(
+			`View entry ${index}.order must be a finite number`,
+			{ index, field: "order" },
+		);
+	}
+	const description = optionalString(value, "description", index);
+	const icon = optionalString(value, "icon", index);
+	const viewPath = optionalString(value, "path", index);
+	const bundleUrl = optionalString(value, "bundleUrl", index);
+	const heroImageUrl = optionalString(value, "heroImageUrl", index);
+
+	return {
+		id,
+		label,
+		available,
+		pluginName,
+		...(viewType ? { viewType } : {}),
+		...(modalities ? { modalities } : {}),
+		...(description !== undefined ? { description } : {}),
+		...(icon !== undefined ? { icon } : {}),
+		...(viewPath !== undefined ? { path: viewPath } : {}),
+		...(order !== undefined ? { order } : {}),
+		...(bundleUrl !== undefined ? { bundleUrl } : {}),
+		...(heroImageUrl !== undefined ? { heroImageUrl } : {}),
+	};
 }
 
 export async function fetchViewEntries(
@@ -77,24 +209,57 @@ export async function fetchViewEntries(
 ): Promise<ViewEntry[]> {
 	const qs = viewType ? `?viewType=${viewType}` : "";
 	const res = await fetch(`/api/views${qs}`);
-	if (!res.ok) throw new Error(`HTTP ${res.status}`);
-	const data = (await res.json()) as { views: ViewEntry[] };
-	return Array.isArray(data.views) ? data.views : [];
+	if (!res.ok) {
+		throw new ElizaError(`GET /api/views returned HTTP ${res.status}`, {
+			code: "VIEW_MANAGER_LIST_HTTP_FAILED",
+			context: { status: res.status, viewType },
+		});
+	}
+	let data: unknown;
+	try {
+		data = await res.json();
+	} catch (cause) {
+		// error-policy:J2 preserve the JSON parser failure while adding the API
+		// boundary and response status needed to diagnose a broken registry payload.
+		return invalidViewListResponse(
+			"GET /api/views returned malformed JSON",
+			{ status: res.status, viewType },
+			{ cause },
+		);
+	}
+	if (!isRecord(data) || !Array.isArray(data.views)) {
+		return invalidViewListResponse(
+			"GET /api/views response must contain a views array",
+			{ status: res.status, viewType },
+		);
+	}
+	return data.views.map(parseViewEntry);
 }
 
 export async function requestViewNavigation(
 	view: Pick<ViewEntry, "id" | "path" | "viewType">,
-) {
-	await fetch(
+	options: { source?: "agent" | "user" } = {},
+): Promise<void> {
+	const response = await fetchWithCsrf(
 		`/api/views/${encodeURIComponent(view.id)}/navigate${
 			view.viewType ? `?viewType=${view.viewType}` : ""
 		}`,
 		{
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({ path: view.path, viewType: view.viewType }),
+			body: JSON.stringify({
+				path: view.path,
+				viewType: view.viewType,
+				...(options.source ? { source: options.source } : {}),
+			}),
 		},
 	);
+	if (!response.ok) {
+		throw new ElizaError(`Could not open view: HTTP ${response.status}`, {
+			code: "VIEW_MANAGER_NAVIGATION_HTTP_FAILED",
+			context: { status: response.status, viewId: view.id },
+		});
+	}
 }
 
 export async function interact(
@@ -106,12 +271,25 @@ export async function interact(
 	}
 	if (capability === "open-view") {
 		const viewId = typeof params?.viewId === "string" ? params.viewId : null;
-		if (!viewId) throw new Error("viewId is required");
+		if (!viewId) {
+			throw new ElizaError("viewId is required", {
+				code: "VIEW_MANAGER_VIEW_ID_REQUIRED",
+				context: { capability },
+			});
+		}
 		const views = await fetchViewEntries();
 		const view = views.find((entry) => entry.id === viewId);
-		if (!view) throw new Error(`View "${viewId}" not found`);
+		if (!view) {
+			throw new ElizaError(`View "${viewId}" not found`, {
+				code: "VIEW_MANAGER_VIEW_NOT_FOUND",
+				context: { viewId },
+			});
+		}
 		await requestViewNavigation(view);
 		return { opened: true, viewId, viewType: view.viewType ?? "gui" };
 	}
-	throw new Error(`Unsupported capability "${capability}"`);
+	throw new ElizaError(`Unsupported capability "${capability}"`, {
+		code: "VIEW_MANAGER_CAPABILITY_UNSUPPORTED",
+		context: { capability },
+	});
 }

--- a/plugins/plugin-app-control/vite.config.views.ts
+++ b/plugins/plugin-app-control/vite.config.views.ts
@@ -16,4 +16,5 @@ export default createViewBundleConfig({
 	entry: "./src/views/app-control-view-bundle.ts",
 	outDir: "dist/views",
 	componentExport: "ViewManagerView",
+	additionalExternals: ["@elizaos/core"],
 });

--- a/plugins/plugin-app-control/vitest.config.ts
+++ b/plugins/plugin-app-control/vitest.config.ts
@@ -74,6 +74,10 @@ export default defineConfig({
 				replacement: path.join(uiSrc, "agent-surface/useAgentElement.ts"),
 			},
 			{
+				find: "@elizaos/ui/api/csrf-client",
+				replacement: path.join(uiSrc, "api/csrf-client.ts"),
+			},
+			{
 				find: "@elizaos/ui/events",
 				replacement: path.join(uiSrc, "events/index.ts"),
 			},
@@ -122,6 +126,10 @@ export default defineConfig({
 			// Use workspace source for @elizaos/shared and @elizaos/core so
 			// recently-added exports resolve at test time without requiring
 			// a fresh dist build of either package.
+			{
+				find: "@elizaos/shared/steward-session-client",
+				replacement: path.join(sharedSrc, "steward-session-client/index.ts"),
+			},
 			{
 				find: /^@elizaos\/shared\/(.*)\.js$/,
 				replacement: path.join(sharedSrc, "$1.ts"),

--- a/scripts/security/coverage-changed-files.self-test.mjs
+++ b/scripts/security/coverage-changed-files.self-test.mjs
@@ -183,6 +183,11 @@ try {
   );
   write(
     dir,
+    "packages/app-core/scripts/playwright-ui-live-stack.ts",
+    "export async function startLiveStack() {}\n",
+  );
+  write(
+    dir,
     "scripts/security/tool.self-test.mjs",
     "throw new Error('self-test only');\n",
   );
@@ -195,6 +200,11 @@ try {
     dir,
     "plugins/plugin-demo/vitest.config.ts",
     "export default { test: { include: ['scripts/**/*.test.mjs'] } };\n",
+  );
+  write(
+    dir,
+    "plugins/plugin-demo/vite.config.views.ts",
+    "export default { build: { outDir: 'dist/views' } };\n",
   );
   write(
     dir,
@@ -311,6 +321,11 @@ try {
       assert.ok(
         !out.files.includes("packages/app/scripts/walkthrough-e2e.mjs"),
       );
+      assert.ok(
+        !out.files.includes(
+          "packages/app-core/scripts/playwright-ui-live-stack.ts",
+        ),
+      );
     },
   );
 
@@ -329,10 +344,14 @@ try {
     );
   });
 
-  assertCase("vitest config changes are not LCOV-enforced source", () => {
+  assertCase("Vite config changes are not LCOV-enforced source", () => {
     assert.ok(
       !out.files.includes("plugins/plugin-demo/vitest.config.ts"),
       `vitest config leaked into changed source: ${out.files.join(",")}`,
+    );
+    assert.ok(
+      !out.files.includes("plugins/plugin-demo/vite.config.views.ts"),
+      `Vite config leaked into changed source: ${out.files.join(",")}`,
     );
   });
 

--- a/scripts/security/coverage-changed-files.sh
+++ b/scripts/security/coverage-changed-files.sh
@@ -46,7 +46,7 @@ changed_source() {
   {
     git diff --name-only --diff-filter=ACMRT "$MERGE_BASE" "$HEAD" -- \
       '*.ts' '*.tsx' '*.js' '*.jsx' '*.mjs' '*.cjs' '*.mts' '*.cts' \
-      | grep -vE '(^|/)(__tests__|__e2e__|test|tests|generated)/|([.-]e2e|[.]generated|[.]test|[.]spec|[.]stories)[.](ts|tsx|js|jsx|mjs|cjs|mts|cts)$|(^|/)vitest[.]config[.](ts|js|mts|mjs|cts|cjs)$' || true
+      | grep -vE '(^|/)(__tests__|__e2e__|test|tests|generated)/|([.-]e2e|[.]generated|[.]test|[.]spec|[.]stories)[.](ts|tsx|js|jsx|mjs|cjs|mts|cts)$|(^|/)(vite|vitest)[.]config([.][^.]+)?[.](ts|js|mts|mjs|cts|cjs)$|(^|/)scripts/playwright[^/]*[.](ts|js|mts|mjs|cts|cjs)$' || true
   } \
     | while IFS= read -r file; do
         [ -f "$file" ] || continue


### PR DESCRIPTION
# Relates to

Closes #16264.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`6e1763aed6be84a4ecb797c6cc24fe8f8ff3202b`).
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the change works without reading the code from the evidence attached below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Post-sync `bun run verify` passes at commit `70ff1aade0c65fb468045b617fb33e55df4a97d2` against base `6e1763aed6be84a4ecb797c6cc24fe8f8ff3202b`./

# Risks

Medium. This changes view navigation transport, reconnect reconciliation, public-response privacy filtering, and generated-view create/edit/reload behavior. Atomic plugin reload rollback, required error states, focused lifecycle coverage, live-model E2E runs, load-performance budgets, and responsive visual audits cover the affected paths.

# Background

## What does this PR do?

- Makes view switching work when WebSocket delivery is delayed or unavailable.
- Reconciles the active view after reconnect or resume.
- Prevents internal action results from leaking into public chat, streaming, and shortcut responses.
- Completes generated-view creation, validation, loading, editing, and atomic reload rollback.
- Makes view-registry and ACP task failures observable instead of presenting fabricated healthy states.
- Adds real lifecycle and live end-to-end coverage for the repaired workflows.

## What kind of change is this?

Bug fixes and reliability improvements.

# Documentation changes needed?

The generated-plugin scaffold contract and plugin-agent-orchestrator package guidance were updated with the new behavior. No additional user-facing documentation is required.

# Testing

## Where should a reviewer start?

Start with the two walkthrough videos: WebSocket-withheld switching and live-model view creation/editing. Then compare the exact-base desktop/mobile screenshots with the post-sync captures and inspect the live proof summary.

## Detailed testing steps

1. Send a view-navigation request while `NAVIGATE_VIEW` WebSocket frames are withheld.
2. Confirm the HTTP action response still navigates and active-view state reconciles after recovery.
3. Request a new view through the real live-model and coding-agent path.
4. Confirm the generated plugin is built, validated, registered, and rendered.
5. Edit that view and confirm its visible marker and bundle hash change.
6. Inspect the linked trajectory inputs/outputs, service receipts, network/state proof, and generated-view artifacts.

Validation completed:

- `bun install` after the final rebase.
- `bun run verify` — exit 0; all policy ratchets passed and 573/573 typecheck/lint tasks completed.
- UI lifecycle tests — 13/13 passed.
- Orchestrator lifecycle tests — 5/5 passed with a real `AgentRuntime` and in-memory adapter.
- `bun run audit:test-realness` — zero diff-scoped regressions.
- Live-model create/edit E2E — 1 passed in 10.3 minutes.
- WebSocket-withheld navigation recovery E2E — passed.
- Dynamic-view load-performance audit — every budget passed.
- Exact-base visual audit — 6/6 passed, computed `good=6`, manually reviewed.
- Post-sync visual audit — 6/6 passed, computed `good=6`, manually reviewed.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Exact-base (`04901b607c3`) full-page screenshots: [desktop chat](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-before-chat-desktop.jpg), [mobile chat](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-before-chat-mobile.jpg), [desktop launcher](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-before-launcher-desktop.jpg), [mobile launcher](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-before-launcher-mobile.jpg), [desktop Views Manager](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-before-manager-desktop.jpg), and [mobile Views Manager](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-before-manager-mobile.jpg).
<!-- evidence-row:after-screenshots -->
- [x] Pre-final-rebase (`37d7da24258`) full-page screenshots/: [desktop chat](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-after-chat-desktop.jpg), [mobile chat](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-after-chat-mobile.jpg), [desktop launcher](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-after-launcher-desktop.jpg), [mobile launcher](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-after-launcher-mobile.jpg), [desktop Views Manager](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-after-manager-desktop.jpg), and [mobile Views Manager](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-after-manager-mobile.jpg); the [OCR triage report](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-after-ocr-triage.json) records zero broken views and zero regressions.
<!-- evidence-row:walkthrough-video -->
- [x] Complete MP4 walkthroughs: [WebSocket-withheld switching and recovery](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-view-switch-recovery-walkthrough.mp4) and [live-model create/edit/reload](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-view-create-edit-walkthrough.mp4).
<!-- evidence-row:backend-logs -->
- [x] [Structured live service receipts](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-live-backend-service-receipts.json) and the [successful live E2E run log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-view-create-edit-test-log.txt) show build verification, live plugin loading, bundle serving, hash change, and completion.
<!-- evidence-row:frontend-logs -->
- [x] [Frontend/network recovery receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-view-switch-frontend-receipt.json) and [withheld-frame state proof](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-view-switch-network-proof.json) show the request, blocked WebSocket frame, HTTP-driven route change, reconciliation read, and clean console/network result.
<!-- evidence-row:llm-trajectory -->
- [x] [Reviewed live-model trajectory inputs, tool calls, outputs, and metrics](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-live-model-trajectories-reviewed.json) cover create, show, edit, and show-after-edit with four finished real trajectories and zero tool-call failures.
<!-- evidence-row:domain-artifacts -->
- [x] [Live proof manifest summary](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-live-proof-summary.json), [created bundle receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-created-bundle-headers.json), [edited bundle receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-edited-bundle-headers.json), [create verification verdict](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-create-verification-verdict.json), [edit verification verdict](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-edit-verification-verdict.json), [created marker proof](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-view-created-marker-proof.jpg), and [edited marker proof](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-view-edited-marker-proof.jpg) document the changed markers and bundle hashes.
<!-- evidence-row:ocr-review -->
- [x] OCR visual text review: [post-sync OCR report](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-after-ocr-triage.json), [exact-base OCR report](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-before-ocr-triage.json), and every linked screenshot were manually reviewed; both runs have zero broken views and zero regressions.

# Evidence Details

## Real LLM-call trajectory

The [privacy-safe reviewed trajectory artifact](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-live-model-trajectories-reviewed.json) preserves each user input, selected `VIEWS` tool input, model-visible output, latency/token metrics, and final decision. All four raw live trajectories were correlated to the create/edit run and manually reviewed through completion.

## Backend + frontend logs

- Backend/service: [live structured receipts](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-live-backend-service-receipts.json), [test log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-view-create-edit-test-log.txt), [create verdict](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-create-verification-verdict.json), [edit verdict](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-edit-verification-verdict.json).
- Frontend/network: [recovery receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-view-switch-frontend-receipt.json), [state proof](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-view-switch-network-proof.json), [recovered UI](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-view-switch-http-recovery.jpg).

The recovery run observed zero console errors, zero page errors, zero HTTP responses at or above 400, and no credential headers.

## Screenshots (before / after) + video walkthrough

All screenshots and both filmstrips/videos were opened and manually reviewed.

### Before — exact current `develop`

| Surface | Desktop | Mobile |
| --- | --- | --- |
| Chat | ![Before chat desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-before-chat-desktop.jpg) | ![Before chat mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-before-chat-mobile.jpg) |
| Launcher | ![Before launcher desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-before-launcher-desktop.jpg) | ![Before launcher mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-before-launcher-mobile.jpg) |
| Views Manager | ![Before Views Manager desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-before-manager-desktop.jpg) | ![Before Views Manager mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-before-manager-mobile.jpg) |

[Exact-base audit report](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-before-visual-report.json) · [provenance](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-before-visual-provenance.json)

### After — final rebased commit

| Surface | Desktop | Mobile |
| --- | --- | --- |
| Chat | ![After chat desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-after-chat-desktop.jpg) | ![After chat mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-after-chat-mobile.jpg) |
| Launcher | ![After launcher desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-after-launcher-desktop.jpg) | ![After launcher mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-after-launcher-mobile.jpg) |
| Views Manager | ![After Views Manager desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-after-manager-desktop.jpg) | ![After Views Manager mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-after-manager-mobile.jpg) |

[Post-sync audit report](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-after-visual-report.json) · [provenance](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-after-visual-provenance.json)

### Live generated-view artifacts

| Created view | Edited marker proof |
| --- | --- |
| ![Created view with VIEW_CREATED_JLW489 receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-view-created-marker-proof.jpg) | ![Edited view with VIEW_EDITED_JLW489 receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-view-edited-marker-proof.jpg) |

The [created desktop render](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-view-created-desktop.jpg) and [live create/edit filmstrip](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-view-create-edit-filmstrip.jpg) provide the surrounding rendered context; the receipt crops make the exact marker transition readable.

### Walkthrough video

- [WebSocket-withheld navigation recovery MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-view-switch-recovery-walkthrough.mp4) · [filmstrip](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-view-switch-recovery-filmstrip.jpg)
- [Live-model create/edit/reload MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-view-create-edit-walkthrough.mp4) · [filmstrip](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-view-create-edit-filmstrip.jpg)

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice behavior changed.

## Known gaps / failures

No implementation or verification failures remain. OCR marked four views `needs-eyeball` because those fixtures do not declare fixed text expectations; all six captures were manually reviewed, with zero broken views and zero OCR regressions. Raw browser traces and full raw trajectory payloads are intentionally not published because they contain local paths and private runtime context; the linked privacy-safe receipts preserve the relevant inputs, outputs, request/state transitions, and reviewed outcomes.

## Final exact-head verification (70ff1aade0c)

- Base: `6e1763aed6be84a4ecb797c6cc24fe8f8ff3202b`; head: `70ff1aade0c65fb468045b617fb33e55df4a97d2`.
- `bun run verify` passed: 573/573 Turbo tasks, all policy audits, zero test-realness regressions, and all 28 dist-path consumer configs.
- Changed-file coverage gate passed for all 33 production files: minimum 52.70%, mean 77.37%, required threshold 50%.
- Full app audit passed 246/246 scenarios: computed `broken=0`, `needs-work=0`, `good=227`, `needs-eyeball=17`; OCR found `broken=0`, `regressions=0`.
- Chat, Views launcher, and Views Manager were manually inspected at mobile portrait, mobile landscape, tablet portrait, and desktop. All 12 computed records are `good` with zero overflow, render-state, overlay-clearance, hover, or quality findings. Static captures do not establish keyboard, focus-order, or screen-reader behavior.
- Exact-head captures: [desktop chat](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-final-70ff1aa-chat-desktop.png), [mobile chat](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-final-70ff1aa-chat-mobile.png), [desktop launcher](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-final-70ff1aa-launcher-desktop.png), [mobile launcher](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-final-70ff1aa-launcher-mobile.png), [desktop Views Manager](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-final-70ff1aa-manager-desktop.png), and [mobile Views Manager](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-final-70ff1aa-manager-mobile.png).
- Exact-head computed artifacts: [visual report](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-final-70ff1aa-visual-report.json) and [OCR triage](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16292-final-70ff1aa-ocr-triage.json).