### PR TITLE
ci(chat): bind live latency artifacts to the workflow checkout SHA

### DIFF
--- a/.github/workflows/chat-latency-live.yml
+++ b/.github/workflows/chat-latency-live.yml
@@ -3,6 +3,18 @@ name: Chat Latency Live
 # Manual, privacy-safe comparison of Cerebras direct and the Eliza Cloud model
 # gateway from the same GitHub-hosted runner. Production is never automatic:
 # selecting it binds the job to the protected production environment.
+#
+# Dispatch sequence for exact artifacts (checkout SHA == deployed SHA, #16185):
+#   1. Merge to develop; Cloud CF Deploy ships that exact commit and
+#      /api/health serves it as `commit`.
+#   2. Confirm refs/heads/develop still equals the served deployment SHA.
+#   3. Dispatch this workflow on ref develop with expected_gateway_sha set to
+#      that commit. GITHUB_SHA of the dispatched run is the head of the
+#      dispatch ref, so the live job's bind step fails before any paid request
+#      unless the checkout equals expected_gateway_sha; the served SHA is then
+#      re-verified before and after the benchmark. If develop advanced past
+#      the deployment, redeploy (or wait for CF Deploy) instead of bypassing —
+#      there is intentionally no feature-branch or stale-checkout escape hatch.
 on:
   pull_request:
     branches: [develop, main]
@@ -81,6 +93,31 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: "24.15.0"
+
+      # Fails closed before any network or paid request: the artifact must be
+      # intrinsically tied to one source revision, so the checkout that supplies
+      # scripts and config has to be the same commit the gateway serves.
+      - name: Bind checkout to the requested gateway SHA
+        env:
+          EXPECTED_GATEWAY_SHA: ${{ inputs.expected_gateway_sha }}
+        run: |
+          node --input-type=module - <<'NODE'
+          const expected = process.env.EXPECTED_GATEWAY_SHA ?? "";
+          const checkout = process.env.GITHUB_SHA ?? "";
+          if (!/^[a-f0-9]{40}$/.test(expected)) {
+            throw new Error("expected_gateway_sha must be a 40-character lowercase commit");
+          }
+          if (checkout !== expected) {
+            throw new Error(
+              "Checkout " +
+                (checkout || "<missing>") +
+                " does not match expected_gateway_sha " +
+                expected +
+                "; dispatch from develop at the exact deployed commit (see the dispatch sequence at the top of this workflow).",
+            );
+          }
+          console.log("Checkout " + checkout + " matches the requested gateway deployment");
+          NODE
 
       - name: Verify the exact deployed gateway SHA
         env:
@@ -195,8 +232,14 @@ jobs:
           const summaries = summarizeLatencyRecords(records);
           console.log("### Paired chat latency: direct + gateway / ${{ inputs.environment }}");
           console.log("");
+          // Both provenance SHAs are emitted so the summary alone shows the
+          // checkout-SHA == deployed-SHA invariant the bind step enforces. The
+          // gateway value is the requested SHA; the verify/reverify steps prove
+          // /api/health served exactly it before and after the benchmark.
+          console.log("Checkout: " + (process.env.GITHUB_SHA ?? "unknown"));
+          console.log("");
           console.log(
-            "Gateway deployment: " +
+            "Gateway deployment (requested, health-verified before/after): " +
               (process.env.ELIZA_GATEWAY_DEPLOY_SHA ?? "unknown"),
           );
           console.log("");

--- a/packages/scripts/__tests__/chat-latency-workflow.test.ts
+++ b/packages/scripts/__tests__/chat-latency-workflow.test.ts
@@ -7,6 +7,32 @@ const workflow = readFileSync(
   "utf8",
 );
 
+function extractEmbeddedNode(stepName: string): string {
+  const nodeBody = extractRun(stepName).match(
+    /<<'NODE'\n(?<node>[\s\S]*?)\nNODE(?:\n|$)/,
+  )?.groups?.node;
+  if (!nodeBody) {
+    throw new Error(`Missing embedded Node program for ${stepName}`);
+  }
+  return nodeBody;
+}
+
+// Executes the bind step's embedded program exactly as the runner does
+// (`node --input-type=module -` with the heredoc on stdin), with a fully
+// controlled environment so match/mismatch outcomes are deterministic.
+function runBindProgram(env: Record<string, string>): {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+} {
+  const result = spawnSync(process.execPath, ["--input-type=module", "-"], {
+    input: extractEmbeddedNode("Bind checkout to the requested gateway SHA"),
+    encoding: "utf8",
+    env,
+  });
+  return { status: result.status, stdout: result.stdout, stderr: result.stderr };
+}
+
 function extractRun(stepName: string): string {
   const escaped = stepName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const body = workflow.match(
@@ -109,8 +135,76 @@ describe("chat latency live workflow", () => {
     expect(workflow).toContain("cold/warm/post-idle");
   });
 
+  describe("checkout binding to the requested gateway SHA (#16185)", () => {
+    const shaA = "a".repeat(40);
+    const shaB = "b".repeat(40);
+
+    test("orders the bind step inside the live job before the health check and paid probe", () => {
+      const liveIndex = workflow.indexOf("\n  live:");
+      const bindIndex = workflow.indexOf(
+        "- name: Bind checkout to the requested gateway SHA",
+      );
+      const verifyIndex = workflow.indexOf(
+        "- name: Verify the exact deployed gateway SHA",
+      );
+      const probeIndex = workflow.indexOf(
+        "- name: Probe Gemma and GLM reasoning modes on one runner",
+      );
+      expect(liveIndex).toBeGreaterThan(-1);
+      expect(bindIndex).toBeGreaterThan(liveIndex);
+      expect(bindIndex).toBeLessThan(verifyIndex);
+      expect(verifyIndex).toBeLessThan(probeIndex);
+    });
+
+    test("passes when the checkout equals expected_gateway_sha", () => {
+      const result = runBindProgram({
+        EXPECTED_GATEWAY_SHA: shaA,
+        GITHUB_SHA: shaA,
+      });
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain(
+        "matches the requested gateway deployment",
+      );
+    });
+
+    test("fails on a checkout/deployment mismatch before any benchmark command", () => {
+      const result = runBindProgram({
+        EXPECTED_GATEWAY_SHA: shaA,
+        GITHUB_SHA: shaB,
+      });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("does not match expected_gateway_sha");
+    });
+
+    test("fails when the checkout SHA is missing entirely", () => {
+      const result = runBindProgram({ EXPECTED_GATEWAY_SHA: shaA });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("does not match expected_gateway_sha");
+    });
+
+    test("keeps the 40-character validation on expected_gateway_sha", () => {
+      const result = runBindProgram({
+        EXPECTED_GATEWAY_SHA: "deadbeef",
+        GITHUB_SHA: shaA,
+      });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("40-character lowercase commit");
+    });
+
+    test("documents the dispatch sequence and emits both SHAs in the summary", () => {
+      expect(workflow).toContain("Dispatch sequence for exact artifacts");
+      expect(workflow).toContain("checkout SHA == deployed SHA");
+      const summary = extractRun("Add privacy-safe timing table to summary");
+      expect(summary).toContain(
+        '"Checkout: " + (process.env.GITHUB_SHA ?? "unknown")',
+      );
+      expect(summary).toContain("process.env.ELIZA_GATEWAY_DEPLOY_SHA");
+    });
+  });
+
   test("keeps every live shell and embedded Node program syntactically valid", () => {
     const steps = [
+      "Bind checkout to the requested gateway SHA",
       "Verify the exact deployed gateway SHA",
       "Probe Gemma and GLM reasoning modes on one runner",
       "Reverify the exact deployed gateway SHA",


### PR DESCRIPTION
Closes #16185

## Problem

`.github/workflows/chat-latency-live.yml` verified the served `/api/health` commit against `inputs.expected_gateway_sha` before and after the paired benchmark, but never asserted that the workflow checkout itself (`GITHUB_SHA`) was that same commit. If `develop` advanced between an exact staging deployment and workflow dispatch, the artifact could combine scripts/config from a newer checkout with a gateway deployment at the requested older SHA — and every served-SHA check would still pass.

## Change

- **New fail-closed bind step** (`Bind checkout to the requested gateway SHA`) in the `live` job, placed immediately after Node setup — before the health check and before any paid request. It re-validates `/^[a-f0-9]{40}$/` on `expected_gateway_sha` and requires `GITHUB_SHA === expected_gateway_sha`, with a clear remediation message on mismatch. The step lives only in the dispatch-gated `live` job (`if: github.event_name == 'workflow_dispatch'`); the `pull_request` contract job is untouched.
- **Both provenance SHAs in the privacy-safe summary**: the timing-table step now prints `Checkout: $GITHUB_SHA` alongside the gateway deployment SHA (labeled as requested + health-verified before/after, since the summary runs on `always()` and must not overclaim if the reverify step failed). (The JSONL artifact already stamps both per record via `ciContext()` in `packages/scripts/cloud/chat-latency.mjs` — `ci.sha` and `ci.gatewayDeploySha` — no script change needed.)
- **Documented dispatch sequence** in the workflow header: deploy exact `develop` commit → confirm `refs/heads/develop` still equals the served SHA → dispatch on `develop` with that SHA; explicitly states there is no feature-branch or stale-checkout escape hatch (canonical-ref guards preserved, no deploy bypass added).
- **Contract test extended** (`packages/scripts/__tests__/chat-latency-workflow.test.ts`): executes the embedded bind program exactly as the runner does (`node --input-type=module -` with the extracted heredoc on stdin, fully controlled env) for match / mismatch / missing-`GITHUB_SHA` / malformed-SHA cases, proves the bind step is ordered inside the `live` job before the health check and the benchmark command, asserts the summary emits both SHAs, and adds the bind step to the shell + embedded-Node syntax validation sweep.

## Acceptance criteria mapping

- Fail before any paid request unless `github.sha == inputs.expected_gateway_sha` → bind step, ordered before `Verify the exact deployed gateway SHA` and the probe; ordering statically asserted in the contract test.
- Keep the 40-char validation and before/after served-health checks → bind step re-validates the 40-char shape; `Verify`/`Reverify the exact deployed gateway SHA` steps unchanged (existing tests still assert them).
- Emit both checkout and served SHAs in the privacy-safe summary/artifact → summary prints both; artifact records already stamp `ci.sha` + `ci.gatewayDeploySha`.
- Static workflow contract proving a mismatch fails before the benchmark → `fails on a checkout/deployment mismatch before any benchmark command` + ordering test.
- Preserve canonical-ref guards; no feature-branch deploy bypass → no guard touched; header comment states the invariant and forbids bypass.
- Document the exact merged-`develop` dispatch sequence → workflow header comment block; presence asserted by test.

## Evidence

**Contract test run (13 pass / 0 fail, 71 assertions — 6 new #16185 tests):**

```
bun test packages/scripts/__tests__/chat-latency-workflow.test.ts
 13 pass
 0 fail
 71 expect() calls
Ran 13 tests across 1 file.

checkout binding to the requested gateway SHA (#16185)
  ✓ orders the bind step inside the live job before the health check and paid probe
  ✓ passes when the checkout equals expected_gateway_sha
  ✓ fails on a checkout/deployment mismatch before any benchmark command
  ✓ fails when the checkout SHA is missing entirely
  ✓ keeps the 40-character validation on expected_gateway_sha
  ✓ documents the dispatch sequence and emits both SHAs in the summary
```

**Direct execution of the extracted bind program (exact runner invocation):**

```
--- match case ---
$ EXPECTED_GATEWAY_SHA=aaaa…(40) GITHUB_SHA=aaaa…(40) node --input-type=module - < bind-program.mjs
Checkout aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa matches the requested gateway deployment
exit=0

--- mismatch case ---
$ EXPECTED_GATEWAY_SHA=aaaa…(40) GITHUB_SHA=bbbb…(40) node --input-type=module - < bind-program.mjs
Error: Checkout bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb does not match expected_gateway_sha
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; dispatch from develop at the exact deployed commit
(see the dispatch sequence at the top of this workflow).
exit=1
```

**Workflow YAML validity + live-job step order (parsed with `yaml`):**

```
YAML OK; live steps: Checkout exact requested ref | Setup Node.js |
Bind checkout to the requested gateway SHA | Verify the exact deployed gateway SHA |
Probe Gemma and GLM reasoning modes on one runner | Reverify the exact deployed gateway SHA |
Add privacy-safe timing table to summary | Upload exact-SHA latency evidence | Enforce probe result
```

**Contract-job commands (what the `contract` job runs on this PR):**

```
node --check packages/scripts/cloud/chat-latency.mjs   → OK
node --test packages/scripts/cloud/chat-latency.test.mjs → 17 pass / 0 fail
```

**Verify:** `bun run verify` (typecheck + lint) green on the rebased branch; `bun run audit:error-policy-ratchet` → `no new fallback-slop in touched files` (0 changed production source files).

- Live `workflow_dispatch` run: `N/A - requires staging environment secrets (CEREBRAS_API_KEY / ELIZACLOUD_API_KEY) and a paid benchmark run; issue acceptance criteria are satisfied by the static workflow contract proof above. The dispatch-only bind step is additionally exercised end-to-end by the direct execution of the extracted program with runner-identical env/invocation.`
- Video walkthrough / screenshots: `N/A - CI workflow + test change; no user-facing UI surface.`
- Real-LLM trajectories: `N/A - no agent/action/provider/prompt/model behavior change.`
- Frontend console/network logs: `N/A - no frontend change.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Evidence rows

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - CI workflow + static contract test change; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - CI workflow + static contract test change; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - CI workflow + static contract test change; no user-facing flow to walk through.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: contract-test run (13 pass / 0 fail, 71 assertions) incl. direct execution of the extracted bind program (match exit 0 / mismatch exit 1): https://gist.github.com/lalalune/1a5678af393df6aedb22b68e768d96d3
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend surface; change is a GitHub Actions job step + contract tests.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent/action/prompt/model behavior change; the guarded job benchmarks latency but this change only binds its checkout SHA.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the workflow contract itself is the artifact - bind-step ordering and match/mismatch/malformed exit codes proven by the linked test log (see Backend logs row); live workflow_dispatch N/A - requires staging environment secrets (CEREBRAS_API_KEY/ELIZACLOUD_API_KEY) and a paid run; acceptance criteria accept the static contract proof.
