### PR TITLE
fix(cloud): harden WebSocket telemetry boundary

### DIFF
--- a/packages/cloud/api/test/e2e/group-d-ai-media.test.ts
+++ b/packages/cloud/api/test/e2e/group-d-ai-media.test.ts
@@ -1,10 +1,11 @@
 /**
  * Group D — AI / inference / media routes.
  *
- * Covers five mounted routes from the Hono Worker:
+ * Covers mounted routes from the Hono Worker:
  *
  *   /api/elevenlabs/stt      — protected legacy alias for /api/v1/voice/stt.
  *   /api/elevenlabs/tts      — protected legacy alias for /api/v1/voice/tts.
+ *   /api/v1/voice/session/ws — public realtime voice WebSocket upgrade.
  *   /api/v1/responses        — protected Responses API compatibility route
  *                              backed by /api/v1/chat/completions.
  *   /api/v1/generate-image   — protected image generation route.
@@ -15,32 +16,36 @@
  *   /api/og                  — public; returns a Worker-native SVG image.
  *   /api/openapi.json        — public; returns the OpenAPI 3.1 spec as JSON.
  *
- * Each route gets:
- *   - Auth gate assertion (always runnable).
- *   - Happy-path reachability assertions avoid real provider calls by using
- *     inputs that validate auth and fail deterministically before upstream I/O.
- *   - Validation assertion for malformed bodies or unsupported methods.
+ * Authenticated HTTP routes get auth-gate coverage, and HTTP reachability
+ * checks avoid provider calls with inputs that fail deterministically before
+ * upstream I/O. The WebSocket check drives the complete upgrade and protocol
+ * close over a real local socket.
  *
- * Skip behavior: with REQUIRE_E2E_SERVER=0 and no reachable Worker (or no
- * bootstrapped TEST_API_KEY) every test in this file reports as a counted,
- * named `skip` — never a silent pass. The /api/v1/responses happy path is
- * split into a keyless-deterministic variant (503, never 501) and a
- * live-inference variant (200 + full response shape) keyed on provider-key
- * availability.
+ * Skip behavior: with REQUIRE_E2E_SERVER=0, protected route suites report
+ * counted, named skips when the Worker or bootstrapped TEST_API_KEY is absent.
+ * The public WebSocket suite requires a reachable local Worker with
+ * VOICE_REALTIME_WS_ENABLED=true. The /api/v1/responses happy path is split
+ * into a keyless-deterministic variant (503, never 501) and a live-inference
+ * variant (200 + full response shape) keyed on provider-key availability.
  */
 
 import { describe, expect, test } from "bun:test";
+import { createHash, randomBytes } from "node:crypto";
+import { connect as connectTcp } from "node:net";
+import { connect as connectTls } from "node:tls";
 
 import {
   api,
   bearerHeaders,
   getBaseUrl,
+  isLocalTarget,
   isServerReachable,
   url,
 } from "./_helpers/api";
 
 const serverReachable = await isServerReachable();
 const hasTestApiKey = Boolean(process.env.TEST_API_KEY?.trim());
+const voiceRealtimeWsEnabled = process.env.VOICE_REALTIME_WS_ENABLED === "true";
 if (!serverReachable) {
   console.warn(
     `[group-d-ai-media] ${getBaseUrl()} did not respond to /api/health. ` +
@@ -51,12 +56,15 @@ if (!serverReachable) {
 if (!hasTestApiKey) {
   console.warn(
     "[group-d-ai-media] TEST_API_KEY is not set; the preload could not " +
-      "bootstrap a test API key. Tests will SKIP.",
+      "bootstrap a test API key. Protected route tests will SKIP.",
   );
 }
 
 // Loud, counted skip instead of a silent pass when the Worker/key is absent.
 const describeE2E = describe.skipIf(!serverReachable || !hasTestApiKey);
+const describeLocalWorker = describe.skipIf(
+  !serverReachable || !isLocalTarget() || !voiceRealtimeWsEnabled,
+);
 
 // Live-inference split: the local lane shares this process env with wrangler
 // dev, so a provider key here means the Worker can really forward. A remote
@@ -70,6 +78,221 @@ const liveInferenceAvailable = Boolean(
 function bearerOnlyHeaders(): Record<string, string> {
   const { Authorization } = bearerHeaders();
   return { Authorization };
+}
+
+interface VoiceWebSocketProbe {
+  opened: boolean;
+  statusCode: number | undefined;
+  headers: Record<string, string>;
+  serverFrame: unknown;
+  closeCode: number;
+  closeReason: string;
+}
+
+const VOICE_WS_ORIGIN = "https://localhost";
+
+function maskedWebSocketFrame(opcode: number, payload: Uint8Array): Buffer {
+  if (payload.byteLength > 125) {
+    throw new Error("voice WebSocket probe only supports control-sized frames");
+  }
+  const mask = randomBytes(4);
+  const frame = Buffer.alloc(2 + mask.byteLength + payload.byteLength);
+  frame[0] = 0x80 | opcode;
+  frame[1] = 0x80 | payload.byteLength;
+  mask.copy(frame, 2);
+  for (let index = 0; index < payload.byteLength; index += 1) {
+    frame[6 + index] = payload[index] ^ mask[index % mask.byteLength];
+  }
+  return frame;
+}
+
+function probeBinaryFirstVoiceWebSocket(): Promise<VoiceWebSocketProbe> {
+  const endpoint = new URL("/api/v1/voice/session/ws", getBaseUrl());
+  endpoint.searchParams.set("sessionId", "e2e-status-101");
+  const websocketKey = randomBytes(16).toString("base64");
+  const expectedAccept = createHash("sha1")
+    .update(`${websocketKey}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
+    .digest("base64");
+
+  return new Promise((resolve, reject) => {
+    const port = Number(
+      endpoint.port || (endpoint.protocol === "https:" ? 443 : 80),
+    );
+    const socket =
+      endpoint.protocol === "https:"
+        ? connectTls({
+            host: endpoint.hostname,
+            port,
+            rejectUnauthorized: false,
+          })
+        : connectTcp({ host: endpoint.hostname, port });
+    const connectEvent =
+      endpoint.protocol === "https:" ? "secureConnect" : "connect";
+    let opened = false;
+    let statusCode: number | undefined;
+    const headers: Record<string, string> = {};
+    let serverFrame: unknown;
+    let closeResult: VoiceWebSocketProbe | undefined;
+    let handshakeComplete = false;
+    let buffered = Buffer.alloc(0);
+    let settled = false;
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      reject(new Error("voice WebSocket probe timed out"));
+    }, 30_000);
+
+    const fail = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      socket.destroy();
+      reject(error);
+    };
+
+    const readFrames = () => {
+      while (buffered.byteLength >= 2) {
+        const opcode = buffered[0] & 0x0f;
+        const masked = (buffered[1] & 0x80) !== 0;
+        let payloadLength = buffered[1] & 0x7f;
+        let offset = 2;
+        if (payloadLength === 126) {
+          if (buffered.byteLength < 4) return;
+          payloadLength = buffered.readUInt16BE(2);
+          offset = 4;
+        } else if (payloadLength === 127) {
+          if (buffered.byteLength < 10) return;
+          const extendedLength = buffered.readBigUInt64BE(2);
+          if (extendedLength > BigInt(Number.MAX_SAFE_INTEGER)) {
+            fail(new Error("voice WebSocket returned an oversized frame"));
+            return;
+          }
+          payloadLength = Number(extendedLength);
+          offset = 10;
+        }
+        if (masked) {
+          fail(new Error("voice WebSocket server returned a masked frame"));
+          return;
+        }
+        if (buffered.byteLength < offset + payloadLength) return;
+        const payload = buffered.subarray(offset, offset + payloadLength);
+        buffered = buffered.subarray(offset + payloadLength);
+
+        if (opcode === 0x1) {
+          try {
+            serverFrame = JSON.parse(payload.toString("utf8"));
+          } catch (error) {
+            fail(error instanceof Error ? error : new Error(String(error)));
+            return;
+          }
+        } else if (opcode === 0x2) {
+          fail(
+            new Error("voice WebSocket returned an unexpected binary frame"),
+          );
+          return;
+        } else if (opcode === 0x8) {
+          if (payload.byteLength < 2) {
+            fail(
+              new Error(
+                "voice WebSocket returned a close frame without a code",
+              ),
+            );
+            return;
+          }
+          if (closeResult) return;
+          closeResult = {
+            opened,
+            statusCode,
+            headers,
+            serverFrame,
+            closeCode: payload.readUInt16BE(0),
+            closeReason: payload.subarray(2).toString("utf8"),
+          };
+          socket.write(maskedWebSocketFrame(0x8, payload));
+          return;
+        }
+      }
+    };
+
+    // The wire handshake is intentional: Bun's WebSocket client does not expose
+    // upgrade response headers, which are the contract under regression here.
+    socket.once(connectEvent, () => {
+      socket.write(
+        `GET ${endpoint.pathname}${endpoint.search} HTTP/1.1\r\n` +
+          `Host: ${endpoint.host}\r\n` +
+          "Upgrade: websocket\r\n" +
+          "Connection: Upgrade\r\n" +
+          `Sec-WebSocket-Key: ${websocketKey}\r\n` +
+          "Sec-WebSocket-Version: 13\r\n" +
+          `Origin: ${VOICE_WS_ORIGIN}\r\n\r\n`,
+      );
+    });
+    socket.on("data", (chunk: Buffer) => {
+      buffered = Buffer.concat([buffered, chunk]);
+      if (!handshakeComplete) {
+        const boundary = buffered.indexOf("\r\n\r\n");
+        if (boundary === -1) return;
+        const handshake = buffered.subarray(0, boundary).toString("latin1");
+        buffered = buffered.subarray(boundary + 4);
+        const [statusLine, ...headerLines] = handshake.split("\r\n");
+        const statusMatch = /^HTTP\/1\.[01] (\d{3})(?: |$)/.exec(statusLine);
+        if (!statusMatch) {
+          fail(
+            new Error(
+              `voice WebSocket returned an invalid status line: ${statusLine}`,
+            ),
+          );
+          return;
+        }
+        statusCode = Number(statusMatch[1]);
+        for (const line of headerLines) {
+          const separator = line.indexOf(":");
+          if (separator <= 0) continue;
+          const name = line.slice(0, separator).trim().toLowerCase();
+          const value = line.slice(separator + 1).trim();
+          headers[name] = headers[name] ? `${headers[name]}, ${value}` : value;
+        }
+        if (statusCode !== 101) {
+          fail(
+            new Error(`voice WebSocket upgrade returned HTTP ${statusCode}`),
+          );
+          return;
+        }
+        const connectionTokens = headers.connection
+          ?.split(",")
+          .map((token) => token.trim().toLowerCase());
+        if (
+          headers.upgrade?.toLowerCase() !== "websocket" ||
+          !connectionTokens?.includes("upgrade") ||
+          headers["sec-websocket-accept"] !== expectedAccept
+        ) {
+          fail(
+            new Error("voice WebSocket returned an invalid RFC6455 handshake"),
+          );
+          return;
+        }
+        handshakeComplete = true;
+        opened = true;
+        socket.write(maskedWebSocketFrame(0x2, new Uint8Array([1])));
+      }
+      readFrames();
+    });
+    socket.once("error", fail);
+    socket.once("close", () => {
+      if (settled) return;
+      if (!closeResult) {
+        fail(
+          new Error("voice WebSocket transport closed without a close frame"),
+        );
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      resolve(closeResult);
+    });
+  });
 }
 
 describeE2E("Group D — /api/elevenlabs/stt", () => {
@@ -125,6 +348,36 @@ describeE2E("Group D — /api/elevenlabs/tts", () => {
       { headers: bearerHeaders() },
     );
     expect(res.status).toBe(400);
+  });
+});
+
+describeLocalWorker("Group D — /api/v1/voice/session/ws", () => {
+  test("pinned workerd preserves a connected 101 upgrade through the real middleware chain", async () => {
+    const probe = await probeBinaryFirstVoiceWebSocket();
+
+    expect(probe.opened).toBe(true);
+    expect(probe.statusCode).toBe(101);
+    expect(probe.headers["access-control-allow-origin"]).toBe(VOICE_WS_ORIGIN);
+    expect(probe.headers["access-control-allow-credentials"]).toBe("true");
+    expect(probe.headers["x-content-type-options"]).toBe("nosniff");
+    const requestId = probe.headers["x-request-id"];
+    if (typeof requestId !== "string") {
+      throw new Error("status-101 handshake omitted X-Request-Id");
+    }
+    expect(requestId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+
+    expect(probe.headers["x-eliza-trace-id"]).toBeUndefined();
+    expect(probe.headers["server-timing"]).toBeUndefined();
+    expect(probe.headers["timing-allow-origin"]).toBeUndefined();
+    expect(probe.serverFrame).toEqual({
+      t: "error",
+      code: "hello_required",
+      retryable: false,
+    });
+    expect(probe.closeCode).toBe(1008);
+    expect(probe.closeReason).toBe("first frame must be a JSON hello");
   });
 });
 

--- a/packages/cloud/api/test/e2e/run-e2e-batches.mjs
+++ b/packages/cloud/api/test/e2e/run-e2e-batches.mjs
@@ -72,6 +72,19 @@ const e2eEnv = {
   NODE_ENV: process.env.NODE_ENV || "test",
   CLOUD_E2E: process.env.CLOUD_E2E || "1",
   ELIZA_KMS_BACKEND: process.env.ELIZA_KMS_BACKEND || "memory",
+  // Keep the real voice upgrade route reachable in the pinned-Workerd lane.
+  // Binary-first coverage closes before token verification, so these inert
+  // values never open an outbound provider connection.
+  VOICE_REALTIME_WS_ENABLED: process.env.VOICE_REALTIME_WS_ENABLED || "true",
+  DEEPGRAM_API_KEY: process.env.DEEPGRAM_API_KEY || "e2e-inert-deepgram",
+  CARTESIA_API_KEY: process.env.CARTESIA_API_KEY || "e2e-inert-cartesia",
+  VOICE_REALTIME_CARTESIA_VOICE_ID:
+    process.env.VOICE_REALTIME_CARTESIA_VOICE_ID || "e2e-inert-voice",
+  VOICE_REALTIME_ELIZA_ENDPOINT:
+    process.env.VOICE_REALTIME_ELIZA_ENDPOINT ||
+    "https://voice-e2e.invalid/sse",
+  VOICE_REALTIME_ELIZA_AUTHORIZATION:
+    process.env.VOICE_REALTIME_ELIZA_AUTHORIZATION || "Bearer e2e-inert",
 };
 
 async function isHealthy() {

--- a/packages/cloud/api/v1/voice/session/__tests__/ws-route-upgrade.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-route-upgrade.test.ts
@@ -132,6 +132,7 @@ const baseEnv = {
 
 class FakeServerSocket {
   accepted = false;
+  binaryType: "blob" | "arraybuffer" = "blob";
   accept() {
     this.accepted = true;
   }
@@ -210,6 +211,7 @@ describe("voice-session ws upgrade (happy path)", () => {
     expect(attachCalls.length).toBe(1);
     const server = attachCalls[0].server as FakeServerSocket;
     expect(server.accepted).toBe(true);
+    expect(server.binaryType).toBe("arraybuffer");
   });
 
   test("prefers the durable usage store when Redis is eval-capable", async () => {

--- a/packages/cloud/api/v1/voice/session/ws/route.ts
+++ b/packages/cloud/api/v1/voice/session/ws/route.ts
@@ -124,8 +124,12 @@ app.get("/", (c) => {
   const client = pair[0] as unknown;
   const server = pair[1] as unknown as {
     accept(): void;
+    binaryType: "blob" | "arraybuffer";
   } & ServerWebSocketLike;
 
+  // The shared handler is synchronous, so normalize Workerd's binary messages
+  // at the platform boundary instead of allowing Blob audio into JSON parsing.
+  server.binaryType = "arraybuffer";
   server.accept();
 
   const usageLimits = resolveVoiceUsageLimits(env);

--- a/packages/cloud/shared/.env.example
+++ b/packages/cloud/shared/.env.example
@@ -166,6 +166,15 @@ ELEVENLABS_API_KEY=sk_your_elevenlabs_key_here
 # ELEVENLABS_VOICE_USE_SPEAKER_BOOST=true
 # ELEVENLABS_OUTPUT_FORMAT=mp3_44100_128
 
+# Realtime voice session WebSocket. Provider credentials and bridge settings
+# are required only when the route is enabled.
+VOICE_REALTIME_WS_ENABLED=false
+DEEPGRAM_API_KEY=your_deepgram_api_key_here
+CARTESIA_API_KEY=your_cartesia_api_key_here
+VOICE_REALTIME_CARTESIA_VOICE_ID=your_cartesia_voice_id_here
+VOICE_REALTIME_ELIZA_ENDPOINT=https://voice.example.com/sse
+VOICE_REALTIME_ELIZA_AUTHORIZATION=replace_with_strong_random_secret
+
 # ============================================================================
 # STORAGE
 # ============================================================================

--- a/packages/cloud/shared/src/lib/observability/http-telemetry-hono.test.ts
+++ b/packages/cloud/shared/src/lib/observability/http-telemetry-hono.test.ts
@@ -25,7 +25,7 @@ function immutableHeadersResponse(body: string, init: ResponseInit): Response {
 }
 
 describe("httpTelemetryMiddleware", () => {
-  it("bypasses status-101 upgrades whose workerd socket cannot survive rewrapping", () => {
+  it("keeps status-101 upgrades outside telemetry's standard-field-only fallback", () => {
     expect(shouldDecorateHttpTelemetryStatus(101)).toBe(false);
     expect(shouldDecorateHttpTelemetryStatus(200)).toBe(true);
   });

--- a/packages/cloud/shared/src/lib/observability/http-telemetry-hono.ts
+++ b/packages/cloud/shared/src/lib/observability/http-telemetry-hono.ts
@@ -6,9 +6,9 @@
  *
  * Responses returned straight from `fetch()` in workerd carry immutable
  * headers — mutating them throws a TypeError and would 500 an otherwise
- * healthy proxied response. When that happens the middleware re-wraps the
- * response (`new Response(body, response)`) without buffering the body, so
- * streaming passthrough routes stay zero-copy and still get telemetry headers.
+ * healthy proxied response. When that happens the middleware re-wraps the body
+ * with copied standard response fields, so streaming passthrough routes stay
+ * zero-copy and still get telemetry headers.
  */
 
 import type { MiddlewareHandler } from "hono";
@@ -20,7 +20,7 @@ import {
 
 type TraceEnv = { Variables: { traceId: string } };
 
-/** WebSocket upgrades carry a workerd-only socket extension that rewrapping drops. */
+/** Keep status-101 responses outside telemetry's standard-field-only fallback. */
 export function shouldDecorateHttpTelemetryStatus(status: number): boolean {
   return status !== 101;
 }
@@ -31,9 +31,9 @@ export function httpTelemetryMiddleware(): MiddlewareHandler<TraceEnv> {
     const startedAt = performance.now();
     c.set("traceId", traceId);
     await next();
-    // A status-101 Response carries workerd's non-standard `webSocket` field.
-    // Standard Response reconstruction cannot preserve it, so the upgrade must
-    // leave this middleware byte-for-byte rather than risk dropping the socket.
+    // Hono preserves Workerd's `webSocket` extension when it passes the complete
+    // response as ResponseInit. The TypeError fallback below copies only standard
+    // fields, so telemetry must not risk routing an upgrade through that fallback.
     if (!shouldDecorateHttpTelemetryStatus(c.res.status)) return;
     const metrics: ServerTimingMetric[] = [
       {

--- a/packages/cloud/shared/src/lib/observability/http-telemetry.test.ts
+++ b/packages/cloud/shared/src/lib/observability/http-telemetry.test.ts
@@ -65,6 +65,7 @@ describe("HTTP telemetry", () => {
     Number.NaN,
     Number.POSITIVE_INFINITY,
     Number.NEGATIVE_INFINITY,
+    Number.MAX_VALUE,
     -0.01,
   ])("rejects invalid gateway timing %s instead of fabricating zero", (invalidDuration) => {
     let thrown: unknown;
@@ -87,12 +88,16 @@ describe("HTTP telemetry", () => {
     });
   });
 
-  test("rejects invalid standalone Server-Timing metrics before writing headers", () => {
+  test.each([
+    Number.NaN,
+    Number.MAX_VALUE,
+  ])("rejects invalid standalone Server-Timing metric %s before writing headers", (invalidDuration) => {
     const headers = new Headers({ "Server-Timing": "provider;dur=3" });
     expect(() =>
-      appendServerTiming(headers, [{ name: "cloud_worker", durationMs: Number.NaN }]),
+      appendServerTiming(headers, [{ name: "cloud_worker", durationMs: invalidDuration }]),
     ).toThrow("HTTP telemetry duration is invalid");
     expect(headers.get("Server-Timing")).toBe("provider;dur=3");
+    expect(headers.get("Server-Timing")).not.toContain("Infinity");
   });
 
   test("appends inner and outer Server-Timing without overwriting", () => {

--- a/packages/cloud/shared/src/lib/observability/http-telemetry.ts
+++ b/packages/cloud/shared/src/lib/observability/http-telemetry.ts
@@ -58,14 +58,15 @@ function sanitizeToken(value: string): string {
 }
 
 function finiteDuration(value: number, field: string): number {
-  if (!Number.isFinite(value) || value < 0) {
+  const rounded = Math.round(value * 100) / 100;
+  if (!Number.isFinite(value) || value < 0 || !Number.isFinite(rounded)) {
     throw new ElizaError("HTTP telemetry duration is invalid", {
       code: "HTTP_TELEMETRY_INVALID_DURATION",
       severity: "fatal",
       context: { field, value: String(value) },
     });
   }
-  return Math.round(value * 100) / 100;
+  return rounded;
 }
 
 /** Normalize once so structured logs and both response formats agree exactly. */


### PR DESCRIPTION
# Relates to

Relates to #16281

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      (`42838644ed2c871916a1151db145825a1234497d`) with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; both passed.
- [x] A reviewer can confirm the change works without reading the code from the
      real pinned-Workerd log and protocol artifacts below.

# Sync with develop

- [x] Rebased onto `origin/develop` at `42838644ed2c871916a1151db145825a1234497d`; zero conflicts.
- [x] `bun run verify` passes post-sync: 573/573 Turbo tasks, all policy audits,
      zero diff-scoped test-realness regressions, and 28/28 dist-path consumer
      configs.

# Risks

Low. The production changes reject telemetry durations that become non-finite
after two-decimal rounding and normalize Cloudflare WebSocket binary messages to
`ArrayBuffer`. The main compatibility risk is at the Worker WebSocket boundary;
the real middleware chain is covered against the repository-pinned Workerd.

# Background

## What does this PR do?

- Rejects finite gateway timings whose rounded representation overflows to
  `Infinity`, preserving existing `Server-Timing` content instead of emitting an
  invalid metric.
- Keeps the Hono status-101 fallback documentation aligned with the actual
  Workerd extension behavior without changing middleware order or CORS policy.
- Registers the realtime voice settings in the Cloud env example and supplies inert values through the E2E harness.
- Adds a production-faithful raw RFC 6455 E2E through the real voice WebSocket
  route, including handshake headers, middleware headers, error payload, close
  code/reason, and transport closure.
- Sets the accepted Workerd server socket to `binaryType = "arraybuffer"` so a
  binary-first client reaches the intended `hello_required` protocol boundary.

## What kind of change is this?

Bug fix (non-breaking) plus regression coverage.

# Documentation changes needed?

Yes. The Cloud shared environment example now documents the realtime voice
settings needed by local and deployed Workers; the middleware's inline contract
documentation was also corrected.

# Testing

## Where should a reviewer start?

Run the pinned-Workerd test in
`packages/cloud/api/test/e2e/group-d-ai-media.test.ts`, then inspect the
overflow cases in
`packages/cloud/shared/src/lib/observability/http-telemetry.test.ts`.

## Detailed testing steps

1. `bun install`
2. `E2E_ONLY=group-d-ai-media bun run --cwd packages/cloud/api test:e2e -- --test-name-pattern 'pinned workerd preserves a connected 101 upgrade'`
3. `bun test packages/cloud/shared/src/lib/observability/http-telemetry.test.ts packages/cloud/shared/src/lib/observability/http-telemetry-hono.test.ts packages/cloud/api/v1/voice/session/__tests__/ws-route-upgrade.test.ts`
4. `bun run verify`

Additional completed coverage:

- Focused unit suites: 34 pass, 0 fail.
- Full unfiltered Group D: 26 pass, 1 expected mutually exclusive
  live-provider/keyless skip, 0 fail.
- Disabled realtime-route configuration: the focused WebSocket test reports one
  counted skip and zero failures; the default Cloud integration lane does not
  mount this opt-in route.
- Cloud shared typecheck and Cloud API TypeScript build: pass.
- Error-policy and view-action ratchets: pass.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - this backend-only diff has no rendered
      UI surface.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - this backend-only diff has no rendered
      UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: N/A - there is no frontend or interactive UI flow; the
      real wire-level exchange is captured below.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: [inline pinned-Workerd log](#backend--frontend-logs) for the narrow local status-101 correction; this is not the issue-wide staging Worker-log proof.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend code or browser state is
      involved.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model
      behavior changes; the tested connection closes before provider/model use.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [inline telemetry and protocol artifacts](#domain-artifacts) for the narrow corrections in this PR; exact-head staging cancellation and billing artifacts remain missing.

# Evidence Details

## Real LLM-call trajectory

N/A - this change is confined to HTTP telemetry serialization and the
pre-provider WebSocket protocol boundary.

## Backend + frontend logs

Backend, real local Worker with Wrangler 4.100.0 and repository-pinned Workerd
1.20260611.1:

<details>
<summary>Pinned-Workerd WebSocket proof</summary>

```text
<-- GET /api/v1/voice/session/ws?sessionId=e2e-status-101
--> GET /api/v1/voice/session/ws?sessionId=e2e-status-101 101 10ms
[wrangler:info] GET /api/v1/voice/session/ws 101 Switching Protocols (1808ms)
(pass) Group D — /api/v1/voice/session/ws > pinned workerd preserves a connected 101 upgrade through the real middleware chain

1 pass
26 filtered out
0 fail
12 expect() calls
[api-e2e] PASS test/e2e/group-d-ai-media.test.ts
```

The test verifies `Upgrade`, the `Connection` token, the keyed RFC 6455
`Sec-WebSocket-Accept`, reflected credentialed CORS, `nosniff`, a UUID request
ID, and absence of HTTP telemetry headers on status 101. It then sends a masked
binary frame, parses the exact `hello_required` error, observes close 1008 with
the expected reason, replies with a masked close, and waits for transport EOF.

</details>

Frontend: N/A - no frontend request/state path changed.

## Screenshots (before / after) + video walkthrough

### Before

N/A - no UI surface.

### After

N/A - no UI surface.

### Walkthrough video

N/A - no UI flow; the complete real wire exchange is represented by the E2E
log and assertions above.

## Audio / voice walkthrough

N/A - although the endpoint is named `voice`, this fix covers only status-101
upgrade handling and a deliberately rejected pre-hello one-byte binary frame.
No STT, TTS, transcript, or audio round-trip behavior changes.

## Domain artifacts

Telemetry overflow probe after the fix:

```json
{"snapshotRejected":true,"appendRejected":true,"serverTiming":"provider;dur=3","containsInfinity":false}
```

WebSocket protocol artifact asserted over the real connection:

```json
{"t":"error","code":"hello_required","retryable":false}
```

The server then closes with RFC 6455 code `1008` and the expected
`hello_required` reason; the client acknowledges the close and observes actual
transport termination.

## Known gaps / failures

Issue #16281 remains open. Exact head `b4c9ce38e0b76450ce0e52ba3ed00d026f93f01c` has not been deployed to staging, so this PR does not yet have the issue-required raw sanitized Worker event independently correlated with raw response headers, or the real post-byte cancellation settlement/reconciliation, usage/balance, and billing/audit artifacts. Those artifacts also need immutable `pr16301-*` release-asset names, hashes, and manual-review notes.

The earlier cancellation evidence is bound to ancestor `9f6277f7fdda160cacdb87d0d859f82917eac570` and Worker version `c87d5cf1-d08b-4597-a054-af62360e259c`; it cannot prove the exact corrective head. The prior files are GitHub user attachments named `16282-*`, not `pr16301-*` release assets. This PR therefore relates to, but does not close, #16281.

Within the narrower correction proved here, the single skip in the full Group D run is the suite designed, mutually-exclusive live-provider/keyless variant; the deterministic keyless variant ran. The default Cloud integration configuration also produces a counted skip for this opt-in WebSocket suite; the enabled pinned-Workerd lane above runs the real route. UI, frontend, LLM, and audio evidence are N/A for the concrete reasons recorded above.