### PR TITLE
fix(notifications): fail closed at the route boundary, not a fake empty inbox

### DIFF
--- a/packages/agent/src/api/notification-routes.test.ts
+++ b/packages/agent/src/api/notification-routes.test.ts
@@ -12,6 +12,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   DEV_SEED_NOTIFICATIONS,
   handleNotificationRoute,
+  type ServiceRegistrationStatus,
 } from "./notification-routes";
 
 async function makeRuntimeWithService(): Promise<{
@@ -297,5 +298,93 @@ describe("handleNotificationRoute", () => {
       helpers,
     );
     expect(helpers.error).toHaveBeenCalledWith(res, expect.any(String), 503);
+  });
+
+  // #16223: the service instance being absent is NOT health. A still-starting or
+  // FAILED notification service must never be reported as a healthy empty inbox.
+  const runtimeWithStatus = (status: ServiceRegistrationStatus) => ({
+    getService: () => null,
+    getServiceRegistrationStatus: () => status,
+  });
+  const resWithHeaders = () =>
+    ({ setHeader: vi.fn() }) as unknown as http.ServerResponse;
+
+  it("GET returns a typed 503 (never empty) when the service FAILED to start", async () => {
+    const helpers = makeHelpers();
+    const failedRes = resWithHeaders();
+    await handleNotificationRoute(
+      req("/api/notifications"),
+      failedRes,
+      "/api/notifications",
+      "GET",
+      { runtime: runtimeWithStatus("failed") },
+      helpers,
+    );
+    expect(helpers.json).not.toHaveBeenCalled();
+    expect(helpers.error).toHaveBeenCalledWith(
+      failedRes,
+      "NOTIFICATION_SERVICE_FAILED",
+      503,
+    );
+  });
+
+  it.each<ServiceRegistrationStatus>([
+    "pending",
+    "registering",
+  ])("GET returns 503 + Retry-After (never empty) while the service is %s", async (status) => {
+    const helpers = makeHelpers();
+    const startingRes = resWithHeaders();
+    await handleNotificationRoute(
+      req("/api/notifications"),
+      startingRes,
+      "/api/notifications",
+      "GET",
+      { runtime: runtimeWithStatus(status) },
+      helpers,
+    );
+    expect(helpers.json).not.toHaveBeenCalled();
+    expect(startingRes.setHeader).toHaveBeenCalledWith("Retry-After", "1");
+    expect(helpers.error).toHaveBeenCalledWith(
+      startingRes,
+      expect.any(String),
+      503,
+    );
+  });
+
+  it("GET serves an explicit empty inbox only when the subsystem is disabled (unknown)", async () => {
+    const helpers = makeHelpers();
+    const unknownRes = resWithHeaders();
+    await handleNotificationRoute(
+      req("/api/notifications"),
+      unknownRes,
+      "/api/notifications",
+      "GET",
+      { runtime: runtimeWithStatus("unknown") },
+      helpers,
+    );
+    expect(helpers.json).toHaveBeenCalledWith(unknownRes, {
+      notifications: [],
+      unreadCount: 0,
+    });
+    expect(unknownRes.setHeader).not.toHaveBeenCalled();
+  });
+
+  it("mutations get a typed 503 when the service FAILED (no Retry-After)", async () => {
+    const helpers = makeHelpers();
+    const failedRes = resWithHeaders();
+    await handleNotificationRoute(
+      req("/api/notifications"),
+      failedRes,
+      "/api/notifications",
+      "POST",
+      { runtime: runtimeWithStatus("failed") },
+      helpers,
+    );
+    expect(helpers.error).toHaveBeenCalledWith(
+      failedRes,
+      "NOTIFICATION_SERVICE_FAILED",
+      503,
+    );
+    expect(failedRes.setHeader).not.toHaveBeenCalled();
   });
 });

--- a/packages/agent/src/api/notification-routes.ts
+++ b/packages/agent/src/api/notification-routes.ts
@@ -43,8 +43,22 @@ import type {
 } from "@elizaos/core";
 import { NotificationService, ServiceType } from "@elizaos/core";
 
+export type ServiceRegistrationStatus =
+  | "pending"
+  | "registering"
+  | "registered"
+  | "failed"
+  | "unknown";
+
 export interface NotificationRouteState {
-  runtime: { getService: (type: string) => unknown } | null;
+  runtime: {
+    getService: (type: string) => unknown;
+    // Optional so headless/partial runtimes still satisfy the type; the real
+    // AgentRuntime always implements it (mirrors the runtimeLike pattern in
+    // plugin route handlers). Lets the route tell a still-starting or FAILED
+    // notification service apart from an intentionally-absent one (#16223).
+    getServiceRegistrationStatus?: (type: string) => ServiceRegistrationStatus;
+  } | null;
 }
 
 const CATEGORIES: NotificationCategory[] = [
@@ -206,12 +220,34 @@ export async function handleNotificationRoute(
 
   const service = getService(state);
   if (!service) {
-    // The runtime is up but the notification service isn't registered yet
-    // (very early boot). Serve an empty inbox rather than 500 so the UI
-    // degrades gracefully and retries.
-    if (method === "GET" && pathname === "/api/notifications") {
+    // The service instance is absent — but absence is NOT health. Consult the
+    // registration status so a service that is still starting or has FAILED to
+    // read its durable inbox is never masked as a healthy empty inbox (#16223).
+    const status =
+      state.runtime?.getServiceRegistrationStatus?.(ServiceType.NOTIFICATION) ??
+      "unknown";
+    // The one case that may report an empty inbox: a genuinely absent subsystem
+    // (native feature disabled / headless), identified positively from status —
+    // not inferred from a missing instance.
+    if (
+      status === "unknown" &&
+      method === "GET" &&
+      pathname === "/api/notifications"
+    ) {
       helpers.json(res, { notifications: [], unreadCount: 0 });
       return true;
+    }
+    if (status === "failed") {
+      // Persistence could not be read; a typed 503 (no adapter/secret detail)
+      // rather than a fabricated empty success.
+      helpers.error(res, "NOTIFICATION_SERVICE_FAILED", 503);
+      return true;
+    }
+    // pending | registering | registered-without-instance are transient — ask
+    // the client to back off and retry instead of caching an empty history.
+    // "unknown" (disabled/headless) on a mutation is not transient: no retry.
+    if (status !== "unknown") {
+      res.setHeader("Retry-After", "1");
     }
     helpers.error(res, "notification service not ready", 503);
     return true;

--- a/plugins/plugin-capacitor-bridge/src/android/dispatch.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/android/dispatch.test.ts
@@ -434,3 +434,61 @@ describe("dispatchStreamingRequest", () => {
 		expect(events[0]).toMatchObject({ kind: "response", status: 404 });
 	});
 });
+
+// #16223: parity with the HTTP route — an absent notification service instance
+// is NOT health. A still-starting or FAILED service must not be masked as a
+// healthy empty inbox on the Android UDS route.
+describe("Android notification route fail-closed (#16223)", () => {
+	const notifRuntime = (status: string) =>
+		({
+			getService: () => null,
+			getServiceRegistrationStatus: () => status,
+		}) as unknown as IAgentRuntime;
+	const notifRoute = fixedRoute(null).route;
+
+	it("GET returns a typed 503 (never empty) when the service FAILED", async () => {
+		const res = await dispatchBufferedRequest(
+			notifRuntime("failed"),
+			notifRoute,
+			{
+				method: "GET",
+				path: "/api/notifications",
+			},
+		);
+		expect(res.status).toBe(503);
+		expect(JSON.parse(res.body)).toEqual({
+			error: "NOTIFICATION_SERVICE_FAILED",
+		});
+	});
+
+	it.each([
+		"pending",
+		"registering",
+	])("GET returns 503 + retry-after (never empty) while the service is %s", async (status) => {
+		const res = await dispatchBufferedRequest(
+			notifRuntime(status),
+			notifRoute,
+			{
+				method: "GET",
+				path: "/api/notifications",
+			},
+		);
+		expect(res.status).toBe(503);
+		expect(res.headers["retry-after"]).toBe("1");
+		expect(JSON.parse(res.body)).not.toHaveProperty("notifications");
+	});
+
+	it("GET serves an explicit empty inbox only when the subsystem is disabled (unknown)", async () => {
+		const res = await dispatchBufferedRequest(
+			notifRuntime("unknown"),
+			notifRoute,
+			{
+				method: "GET",
+				path: "/api/notifications",
+			},
+		);
+		expect(res.status).toBe(200);
+		expect(JSON.parse(res.body)).toEqual({ notifications: [], unreadCount: 0 });
+		expect(res.headers["retry-after"]).toBeUndefined();
+	});
+});

--- a/plugins/plugin-capacitor-bridge/src/android/dispatch.ts
+++ b/plugins/plugin-capacitor-bridge/src/android/dispatch.ts
@@ -137,16 +137,48 @@ function statusText(status: number): string {
 	return STATUS_TEXT[status] ?? "";
 }
 
-function jsonResponse(status: number, body: unknown): AndroidBufferedResponse {
+function jsonResponse(
+	status: number,
+	body: unknown,
+	extraHeaders?: Record<string, string>,
+): AndroidBufferedResponse {
 	const text = JSON.stringify(body);
 	return {
 		status,
 		statusText: statusText(status),
-		headers: { "content-type": "application/json; charset=utf-8" },
+		headers: {
+			"content-type": "application/json; charset=utf-8",
+			...extraHeaders,
+		},
 		body: text,
 		bodyBase64: Buffer.from(text, "utf8").toString("base64"),
 		bodyEncoding: "base64",
 	};
+}
+
+type ServiceRegistrationStatus =
+	| "pending"
+	| "registering"
+	| "registered"
+	| "failed"
+	| "unknown";
+
+// The concrete AgentRuntime exposes service registration status, but it is not
+// on the IAgentRuntime interface — read it defensively (the runtimeLike pattern
+// used by plugin route handlers) so a still-starting or FAILED notification
+// service can be told apart from an intentionally-absent one (#16223).
+function serviceRegistrationStatus(
+	runtime: IAgentRuntime,
+	serviceType: string,
+): ServiceRegistrationStatus {
+	const getter = (
+		runtime as {
+			getServiceRegistrationStatus?: (t: string) => ServiceRegistrationStatus;
+		}
+	).getServiceRegistrationStatus;
+	return typeof getter === "function"
+		? getter.call(runtime, serviceType)
+		: "unknown";
 }
 
 function runtimeAgentName(runtime: IAgentRuntime): string {
@@ -227,13 +259,29 @@ async function directAndroidNotificationRoute(
 
 	const service = runtime.getService(ServiceType.NOTIFICATION);
 	if (!isAndroidNotifier(service)) {
-		// The service isn't up yet (very early boot). Serve an empty inbox on
-		// GET so the widget shows its empty state instead of erroring; fail the
-		// mutations loudly.
-		if (method === "GET" && pathname === "/api/notifications") {
+		// Absence is not health. Consult the registration status so a still-
+		// starting or FAILED notification service is not masked as a healthy
+		// empty inbox (#16223) — parity with the HTTP route.
+		const status = serviceRegistrationStatus(runtime, ServiceType.NOTIFICATION);
+		// Only a genuinely absent subsystem (native feature disabled / headless)
+		// may show the empty widget state — identified positively from status.
+		if (
+			status === "unknown" &&
+			method === "GET" &&
+			pathname === "/api/notifications"
+		) {
 			return jsonResponse(200, { notifications: [], unreadCount: 0 });
 		}
-		return jsonResponse(503, { error: "notification service not ready" });
+		if (status === "failed") {
+			// Persistence could not be read; never a fabricated empty success.
+			return jsonResponse(503, { error: "NOTIFICATION_SERVICE_FAILED" });
+		}
+		// pending | registering | registered-without-instance are transient.
+		return jsonResponse(
+			503,
+			{ error: "notification service not ready" },
+			status === "unknown" ? undefined : { "retry-after": "1" },
+		);
 	}
 
 	if (method === "GET" && pathname === "/api/notifications") {


### PR DESCRIPTION
# Relates to

Refs #16223 (route-boundary portion — see scope below)

- [x] Targets `develop`, rebased on latest `origin/develop`, zero conflicts.
- [x] A reviewer can confirm the change from the evidence below without reading the code.

# Risks

Low. Two route handlers stop reporting an absent notification-service instance as a healthy empty inbox. Behaviour only changes when the service is **not** a live registered instance; the registered happy path is untouched. A runtime that doesn't expose the status getter falls back to the previous empty-inbox behaviour, so partial/headless runtimes are unaffected.

# Background

## What does this PR do?

After #16207 made `NotificationService.start()` fail closed on an unreadable durable inbox, `AgentRuntime._runServiceStart()` marks the service `failed` and leaves **no instance**. Both notification routes returned HTTP 200 `{notifications:[],unreadCount:0}` whenever `runtime.getService(NOTIFICATION)` was absent — so they converted that failure back into a *healthy empty inbox*, masking lost/at-risk persistence. The HTTP comment even claimed the UI "degrades gracefully and retries" when it did not.

This consults the runtime's existing `getServiceRegistrationStatus` (read defensively — it lives on the concrete `AgentRuntime`, not `IAgentRuntime`, mirroring the `runtimeLike` pattern already used by plugin route handlers) instead of inferring health from a missing instance:

- `failed` → typed 503 `NOTIFICATION_SERVICE_FAILED` (no adapter/secret detail), never an empty success;
- `pending` / `registering` / registered-without-instance → 503 + `Retry-After` so the client backs off instead of caching an empty history;
- `unknown` (native feature disabled / headless) → the explicit no-inbox contract: 200 empty on GET, positively identified from status.

Applied identically to the HTTP route (`packages/agent/src/api/notification-routes.ts`) and the Android UDS route (`plugins/plugin-capacitor-bridge/src/android/dispatch.ts`).

## Scope

This is the **route-boundary** portion of #16223 (items 1–5, 8, 9). The UI hydrate-retry (item 6) and single-flight runtime recovery (item 7) are larger and left as explicit follow-ups rather than half-done here — the issue stays open (`Refs`, not `Closes`).

## What kind of change is this?

Bug fix (non-breaking; data-integrity / fail-closed correctness).

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

The `if (!service)` branch in both route files. Pinned by the new status-driven cases in `notification-routes.test.ts` and `dispatch.test.ts`.

## Detailed testing steps

None — route-level unit tests cover the matrix.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] `N/A - server-side route handlers in packages/agent + plugins/plugin-capacitor-bridge; no rendered UI surface (verified: surfaceFiles=[]).`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - server-side route handlers; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; HTTP/UDS status-code contract fix.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - no deployed backend to log; the code paths are asserted by the route-level unit runs under Evidence Details (real NotificationService / mounted dispatch).`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend change in this scoped PR (UI hydrate-retry is a flagged follow-up).`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/model/provider behaviour; a notification route status-code change.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - no DB rows/memories/files produced; the change only selects HTTP status + Retry-After from service registration state.`

# Evidence Details

## Backend + frontend logs

<details><summary>HTTP route unit run — status-driven fail-closed (18/18 pass)</summary>

```
handleNotificationRoute
  ✓ GET returns a typed 503 (never empty) when the service FAILED to start
  ✓ GET returns 503 + Retry-After (never empty) while the service is pending
  ✓ GET returns 503 + Retry-After (never empty) while the service is registering
  ✓ GET serves an explicit empty inbox only when the subsystem is disabled (unknown)
  ✓ mutations get a typed 503 when the service FAILED (no Retry-After)
  … 13 pre-existing cases (list/create/read/delete/seed/filters + backward-compat fallbacks)

 18 passed (18)
```

</details>

<details><summary>Android UDS route unit run — parity (20/20 pass)</summary>

```
Android notification route fail-closed (#16223)
  ✓ GET returns a typed 503 (never empty) when the service FAILED
  ✓ GET returns 503 + retry-after (never empty) while the service is pending
  ✓ GET returns 503 + retry-after (never empty) while the service is registering
  ✓ GET serves an explicit empty inbox only when the subsystem is disabled (unknown)
  … 16 pre-existing dispatch cases

 20 passed (20)
```

</details>

Typecheck: my 4 files are clean (`tsgo --noEmit`; the package's other errors are pre-existing cross-package graph issues in wallet/scheduling/contracts, untouched here). Biome clean. Whole-file coverage from the changed tests: `notification-routes.ts` 97.4%, `dispatch.ts` 83.2% — both above the changed-file gate.

[stan-cloud]
