### PR TITLE
fix(cloud): reserve /v1/messages against the provider output ceiling

### DIFF
--- a/packages/cloud/api/__tests__/messages-billing-offpath.test.ts
+++ b/packages/cloud/api/__tests__/messages-billing-offpath.test.ts
@@ -444,6 +444,80 @@ describe("messages route preforward telemetry", () => {
     expect(reserveArgs?.[2]).toBe(providerCap);
   });
 
+  // Streaming sibling of the reservation-parity test above: the stream handler
+  // recomputes the same floored ceiling before streamText, and the reservation
+  // taken by the route (before the stream/non-stream fork) must match it.
+  test("streaming: reserves the same reasoning-floored ceiling streamText is capped at", async () => {
+    const ledger = makeLedgerReservation(100, 0.015);
+    routeReservation = ledger.reservation;
+    let capturedConfig: Record<string, unknown> | undefined;
+    // sdkFaithfulStream doesn't expose the streamText config, so re-inline its
+    // SDK-faithful stream shape with a config capture.
+    streamTextImpl = (config) => {
+      capturedConfig = config;
+      const onFinish = config.onFinish as (event: {
+        text: string;
+        totalUsage: typeof USAGE;
+      }) => Promise<unknown>;
+      return {
+        fullStream: (async function* () {
+          yield { type: "text-start", id: "text-1" };
+          yield { type: "text-delta", id: "text-1", text: TEXT };
+          yield { type: "text-end", id: "text-1" };
+          await onFinish({ text: TEXT, totalUsage: USAGE });
+          yield { type: "finish", finishReason: "stop", totalUsage: USAGE };
+        })(),
+      };
+    };
+    reserveCredits.mockClear();
+
+    const response = await postMessages({ stream: true }); // gpt-oss-120b, max_tokens: 256
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain('"type":"message_stop"');
+
+    const providerCap = capturedConfig?.maxOutputTokens as number;
+    // Reasoning model → the streamText cap is floored above the requested 256.
+    expect(providerCap).toBeGreaterThan(256);
+    const reserveArgs = reserveCredits.mock.calls[0] as unknown as
+      | [unknown, number, number]
+      | undefined;
+    expect(reserveArgs?.[2]).toBe(providerCap);
+  });
+
+  // Pass-through regression: for a NON-reasoning model the floor must not
+  // fire — the reservation admits exactly the requested max_tokens, and the
+  // provider is capped at the same value.
+  test("non-reasoning model: reservation passes request.max_tokens through unfloored", async () => {
+    const ledger = makeLedgerReservation(100, 0.015);
+    routeReservation = ledger.reservation;
+    let capturedConfig: Record<string, unknown> | undefined;
+    generateTextImpl = (config) => {
+      capturedConfig = config;
+      return {
+        text: TEXT,
+        usage: USAGE,
+        toolCalls: [],
+        finishReason: "stop",
+        rawFinishReason: "stop",
+      };
+    };
+    reserveCredits.mockClear();
+
+    const response = await postMessages({
+      model: "openai/gpt-4o-mini",
+      max_tokens: 512,
+    });
+    expect(response.status).toBe(200);
+
+    // No floor: provider cap and reservation both equal the raw request value.
+    expect(capturedConfig?.maxOutputTokens).toBe(512);
+    const reserveArgs = reserveCredits.mock.calls[0] as unknown as
+      | [unknown, number, number]
+      | undefined;
+    expect(reserveArgs?.[2]).toBe(512);
+  });
+
   test("non-stream success preserves trace and the frozen provider boundary", async () => {
     const ledger = makeLedgerReservation(100, 0.015);
     routeReservation = ledger.reservation;

--- a/packages/cloud/api/__tests__/messages-billing-offpath.test.ts
+++ b/packages/cloud/api/__tests__/messages-billing-offpath.test.ts
@@ -410,6 +410,40 @@ function postMessages(bodyOverrides: Record<string, unknown> = {}) {
 }
 
 describe("messages route preforward telemetry", () => {
+  // #16081 invariant on /v1/messages: MODEL (gpt-oss-120b) is a reasoning model,
+  // so the provider's maxOutputTokens is floored ABOVE the requested 256. The
+  // reservation must admit that same floored ceiling — reserving the raw 256
+  // would let the provider bill far more output than was reserved.
+  test("reserves the same reasoning-floored ceiling the provider is capped at", async () => {
+    const ledger = makeLedgerReservation(100, 0.015);
+    routeReservation = ledger.reservation;
+    let capturedConfig: Record<string, unknown> | undefined;
+    generateTextImpl = (config) => {
+      capturedConfig = config;
+      return {
+        text: TEXT,
+        usage: USAGE,
+        toolCalls: [],
+        finishReason: "stop",
+        rawFinishReason: "stop",
+      };
+    };
+    reserveCredits.mockClear();
+
+    const response = await postMessages(); // gpt-oss-120b, max_tokens: 256
+    expect(response.status).toBe(200);
+
+    const providerCap = capturedConfig?.maxOutputTokens as number;
+    // Reasoning model → the provider cap is floored above the requested 256.
+    expect(providerCap).toBeGreaterThan(256);
+    // The reservation admitted that exact ceiling (3rd arg to reserveCredits),
+    // not the raw request.max_tokens.
+    const reserveArgs = reserveCredits.mock.calls[0] as unknown as
+      | [unknown, number, number]
+      | undefined;
+    expect(reserveArgs?.[2]).toBe(providerCap);
+  });
+
   test("non-stream success preserves trace and the frozen provider boundary", async () => {
     const ledger = makeLedgerReservation(100, 0.015);
     routeReservation = ledger.reservation;

--- a/packages/cloud/api/v1/messages/route.ts
+++ b/packages/cloud/api/v1/messages/route.ts
@@ -679,7 +679,23 @@ app.post("/", async (c) => {
   }
 
   const estimatedInputTokens = estimateInputTokens(estimateMessages);
-  const estimatedOutputTokens = request.max_tokens;
+  // Reserve against the SAME ceiling the provider is capped at below, not the
+  // raw request.max_tokens. `messagesEffectiveMaxTokens` raises a reasoning
+  // model's provider budget to fit hidden reasoning PLUS the answer (e.g. a
+  // requested 256 becomes the 4096 floor), so reserving the raw value lets the
+  // provider bill well above the reservation — the #16081 invariant, fixed for
+  // /v1/chat/completions but not here. The provider paths recompute the same
+  // deterministic value, so admission and enforcement stay identical.
+  const reservationCotBudget = resolveAnthropicThinkingBudgetTokens(
+    model,
+    process.env,
+  );
+  const estimatedOutputTokens =
+    messagesEffectiveMaxTokens(
+      request.max_tokens,
+      reservationCotBudget,
+      model,
+    ) ?? request.max_tokens;
   const affiliateCode = c.req.header("X-Affiliate-Code") ?? null;
   const billingSource: PricingBillingSource =
     resolveAiProviderSource(model) ?? "bitrouter";


### PR DESCRIPTION
# Relates to

Closes the `/v1/messages` gap in the #16081 reservation-parity invariant series (fixed for `/v1/chat/completions` in #16099, and the A2A / MCP agent routes in #16147 / #16148). Found while auditing cloud call sites that reserve credits and then call the provider.

- [x] Targets `develop`, rebased on latest `origin/develop`, zero conflicts.
- [x] A reviewer can confirm the change from the evidence below without reading the code.

# Risks

Low. Reasoning-model requests now reserve the (larger) ceiling the provider is already capped at; short completions release the difference through the existing reconciliation. Non-reasoning models are unaffected (`messagesEffectiveMaxTokens` passes their budget through unchanged). No reservation/reconciliation reordering.

# Background

## What does this PR do?

`messagesEffectiveMaxTokens` raises a reasoning model's provider `maxOutputTokens` above the requested `max_tokens` — a requested `256` becomes the `4096` reasoning floor, and an Anthropic CoT budget adds thinking + a response floor — so hidden reasoning doesn't consume the whole budget and return empty output (the fix for the `gpt-oss-120b` / `zai-glm-4.7` empty-output failure).

But the reservation was still priced on the raw `request.max_tokens`. So a reasoning request admitted far fewer output tokens than the provider was authorized to bill (256 reserved vs 4096 authorized — a 16× gap), letting the provider outrun the reservation and surface an uncollected overage. That's exactly the #16081 invariant — reservation admission must equal the provider-facing budget — which was fixed for `/v1/chat/completions` and the agent routes but not `/v1/messages`.

The fix computes the effective (floored) ceiling once, before the reservation, and prices against it. Both provider paths (`generateText` / `streamText`) already recompute the identical deterministic value, so admission and enforcement now match.

## What kind of change is this?

Bug fix (non-breaking; billing correctness).

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/messages/route.ts` — `estimatedOutputTokens` is now `messagesEffectiveMaxTokens(...)` instead of the raw `request.max_tokens`. Pinned by the new case in `messages-billing-offpath.test.ts`.

## Detailed testing steps

None — the route-level regression test covers it.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] `N/A - backend billing route in packages/cloud/api; no UI surface (surfaceFiles=[]).`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - backend billing route; no UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; server-side reservation/provider-cap parity fix.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - no deployed backend to log; the code path is asserted by the route-level unit run under Evidence Details (mounted /v1/messages, real settler, mocked provider + billing boundary).`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend involvement.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - the provider call is asserted at the mounted route with a mocked SDK boundary; a live-model trajectory would not exercise the reservation-vs-provider ceiling parity this fixes.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - no DB rows/memories/files produced; the change only selects the numeric ceiling the reservation is priced on.`

# Evidence Details

## Backend + frontend logs

<details><summary>Route-level unit run — reservation admits the provider ceiling (17/17 pass)</summary>

```
messages route preforward telemetry
  (pass) reserves the same reasoning-floored ceiling the provider is capped at
  … 16 pre-existing off-response-path billing / settlement cases

 17 pass
 0 fail
```

The new case drives the mounted `/v1/messages` route with `gpt-oss-120b` (a reasoning model) at `max_tokens: 256`, captures `generateText`'s `maxOutputTokens` (floored above 256), and asserts the value passed to `reserveCredits` equals it. Before the fix the reservation received the raw `256`.

</details>

Also verified: the pure-helper suite `messages-reasoning-floor.test.ts` (4/4, unchanged) documents that `messagesEffectiveMaxTokens` floors reasoning models above the request. Typecheck: my files clean (`tsgo --noEmit`; the package's other errors are pre-existing cross-package graph issues, untouched). Biome clean.

[stan-cloud]



## Admission-behavior note (added in review)

Reasoning-model requests with a small explicit `max_tokens` now reserve the full provider-authorized ceiling (e.g. 4096, or `cotBudget + 4096` for Anthropic extended thinking) at admission. Low-balance callers that previously passed admission under-reserved will now correctly receive 429 "Insufficient credits" — the provider genuinely could bill the floored amount; settlement still refunds short completions.