### PR TITLE
fix(auth): reconcile Codex token rotations atomically

### DIFF
--- a/packages/app-core/src/services/account-pool.ts
+++ b/packages/app-core/src/services/account-pool.ts
@@ -1074,7 +1074,7 @@ export async function sweepAccountPoolKeepAlive(): Promise<AccountPoolKeepAliveR
       // refresh below burns on the consumed token and this sweep marks a
       // perfectly recoverable account needs-reauth.
       if (providerId === "openai-codex") {
-        await adoptRotatedCodexTokens(record.id).catch(() => false);
+        await adoptRotatedCodexTokens(record.id);
       }
       const token = await getAccountAccessToken(providerId, record.id);
       if (!token) {
@@ -1148,7 +1148,9 @@ export function startAccountPoolKeepAlive(
     keepAliveRunning = true;
     void sweepAccountPoolKeepAlive()
       .catch((err) => {
-        logger.debug(`[AccountPool] keep-alive sweep failed: ${String(err)}`);
+        // error-policy:J1 timer boundary observes rejected sweeps; the next
+        // interval retries without translating credential failure to health.
+        logger.error(`[AccountPool] keep-alive sweep failed: ${String(err)}`);
       })
       .finally(() => {
         keepAliveRunning = false;

--- a/packages/app-core/src/services/coding-account-bridge.test.ts
+++ b/packages/app-core/src/services/coding-account-bridge.test.ts
@@ -3,8 +3,9 @@
  * and its auth-failure triage (isAuthFailure): least-used vs priority vs config-
  * vs env-driven selection, per-agent env patches (CLAUDE_CODE_OAUTH_TOKEN, a
  * materialized CODEX_HOME/auth.json + config.toml with a TOML-injection guard,
- * CEREBRAS_API_KEY), usage attribution, and rate-limit skipping. Runs against a
- * real temp ELIZA_HOME / ELIZA_STATE_DIR and real account storage — no mocked pool.
+ * active-generation discovery, CEREBRAS_API_KEY), usage attribution, and rate-
+ * limit skipping. Runs against a real temp ELIZA_HOME / ELIZA_STATE_DIR and real
+ * account storage — no mocked pool.
  */
 import {
   mkdirSync,
@@ -15,7 +16,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { saveAccount } from "@elizaos/auth/account-storage";
+import { loadAccount, saveAccount } from "@elizaos/auth/account-storage";
 import type { AccountCredentialProvider } from "@elizaos/auth/types";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -226,17 +227,35 @@ describe("coding-account-bridge", () => {
       organizationId: "acct_123",
       idToken: "codex-id-token-1",
     });
+    const canonical = loadAccount("openai-codex", "codex-1");
+    if (!canonical) throw new Error("expected canonical Codex account");
     const bridge = getDefaultAccountPool() && getCodingAgentSelectorBridge();
     const sel = await bridge?.select("codex");
     expect(sel?.providerId).toBe("openai-codex");
     const codexHome = sel?.envPatch.CODEX_HOME;
     expect(codexHome).toBeTruthy();
+    const accountHome = path.join(home, "auth", "_codex-home", "codex-1");
+    const activeHome = readFileSync(
+      path.join(accountHome, "active-home"),
+      "utf-8",
+    ).trim();
+    expect(path.resolve(accountHome, activeHome)).toBe(
+      path.resolve(codexHome as string),
+    );
+    const [generationDir, generationName] = activeHome.split(path.sep);
+    expect(generationDir).toBe("generations");
+    expect(generationName).toMatch(/^[a-f0-9]{24}$/);
     const authJson = JSON.parse(
       readFileSync(path.join(codexHome as string, "auth.json"), "utf-8"),
     );
     expect(authJson.tokens.access_token).toBe("codex-access-1");
     expect(authJson.tokens.account_id).toBe("acct_123");
     expect(authJson.auth_mode).toBe("chatgpt");
+    // The timestamp identifies the source credential generation. Selection
+    // must not stamp "now" and make a stale materialization look newer.
+    expect(authJson.last_refresh).toBe(
+      new Date(canonical.updatedAt).toISOString(),
+    );
     // id_token must be present or codex-acp fails "Authentication required".
     expect(authJson.tokens.id_token).toBe("codex-id-token-1");
     // A minimal config.toml with a model — without it codex-acp falls back to a
@@ -468,6 +487,9 @@ describe("coding-account-bridge", () => {
     ) as { tokens?: { refresh_token?: string } };
     expect(authOnDisk.tokens?.refresh_token).toBe(
       "cx-rot-access-refresh-ROTATED",
+    );
+    expect(readFileSync(path.join(codexHome, "active-home"), "utf-8")).toBe(
+      ".\n",
     );
   });
 

--- a/packages/app-core/src/services/coding-account-bridge.ts
+++ b/packages/app-core/src/services/coding-account-bridge.ts
@@ -23,11 +23,22 @@
  * `applySubscriptionCredentialsLocal` does.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { createHash, randomUUID } from "node:crypto";
+import {
+  existsSync,
+  linkSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  type Stats,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { loadAccount } from "@elizaos/auth/account-storage";
-import { writeJsonAtomicSync } from "@elizaos/auth/atomic-json";
 import {
   type AccessTokenOutcome,
   getAccessToken,
@@ -44,6 +55,7 @@ import {
 import {
   type CodingAgentSelectorBridge,
   type CodingProviderAvailability,
+  ElizaError,
   logger,
   resolveStateDir,
   setCodingAgentSelectorBridge,
@@ -140,6 +152,17 @@ function codexHomeDir(accountId: string): string {
   );
 }
 
+function codexGenerationDir(accountId: string, refreshToken: string): string {
+  const generation = createHash("sha256")
+    .update(refreshToken)
+    .digest("hex")
+    .slice(0, 24);
+  return path.join(codexHomeDir(accountId), "generations", generation);
+}
+
+const CODEX_ACTIVE_HOME_FILE = "active-home";
+const CODEX_GENERATION_NAME_PATTERN = /^[a-f0-9]{24}$/;
+
 /** Decode the `exp` claim (epoch ms) from a JWT access token, or null. */
 function jwtExpiryMs(accessToken: string): number | null {
   const parts = accessToken.split(".");
@@ -158,14 +181,386 @@ function jwtExpiryMs(accessToken: string): number | null {
   }
 }
 
-/** Shape of the ChatGPT-mode `auth.json` a Codex CLI maintains in CODEX_HOME. */
+/** Credential fields read from a ChatGPT-mode Codex `auth.json`. */
 interface MaterializedCodexAuthJson {
-  tokens?: {
-    access_token?: string;
-    refresh_token?: string;
+  tokens: {
+    access_token: string;
+    refresh_token: string;
     id_token?: string;
+    account_id?: string;
   };
   last_refresh?: string;
+}
+
+interface MaterializedCodexAuthCandidate {
+  authPath: string;
+  homeDir: string;
+  auth: MaterializedCodexAuthJson;
+  lastRefreshMs: number | null;
+}
+
+type CodexAuthParseResult =
+  | { ok: true; value: MaterializedCodexAuthJson }
+  | { ok: false; error: Error };
+
+const CODEX_AUTH_STABLE_READ_ATTEMPTS = 20;
+const CODEX_AUTH_STABLE_READ_DELAY_MS = 10;
+
+function parseMaterializedCodexAuth(
+  raw: string,
+  authPath: string,
+): CodexAuthParseResult {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch (cause) {
+    // error-policy:J3 auth.json is maintained by an external process; malformed
+    // JSON is an explicit invalid read so the stable-reader can retry or fail.
+    return {
+      ok: false,
+      error: new ElizaError(`Codex auth file is malformed: ${authPath}`, {
+        code: "CODEX_AUTH_FILE_INVALID",
+        cause,
+        context: { authPath },
+        severity: "fatal",
+      }),
+    };
+  }
+  if (typeof value !== "object" || value === null) {
+    return {
+      ok: false,
+      error: new ElizaError(
+        `Codex auth file has the wrong shape: ${authPath}`,
+        {
+          code: "CODEX_AUTH_FILE_INVALID",
+          context: { authPath },
+          severity: "fatal",
+        },
+      ),
+    };
+  }
+  const tokens = Reflect.get(value, "tokens");
+  if (typeof tokens !== "object" || tokens === null) {
+    return {
+      ok: false,
+      error: new ElizaError(
+        `Codex auth file is missing its token pair: ${authPath}`,
+        {
+          code: "CODEX_AUTH_FILE_INVALID",
+          context: { authPath },
+          severity: "fatal",
+        },
+      ),
+    };
+  }
+  const accessToken = Reflect.get(tokens, "access_token");
+  const refreshToken = Reflect.get(tokens, "refresh_token");
+  const idToken = Reflect.get(tokens, "id_token");
+  const lastRefresh = Reflect.get(value, "last_refresh");
+  if (
+    typeof accessToken !== "string" ||
+    accessToken.length === 0 ||
+    typeof refreshToken !== "string" ||
+    refreshToken.length === 0 ||
+    (idToken !== undefined && typeof idToken !== "string") ||
+    (lastRefresh !== undefined && typeof lastRefresh !== "string")
+  ) {
+    return {
+      ok: false,
+      error: new ElizaError(
+        `Codex auth file contains an invalid token generation: ${authPath}`,
+        {
+          code: "CODEX_AUTH_FILE_INVALID",
+          context: { authPath },
+          severity: "fatal",
+        },
+      ),
+    };
+  }
+  return {
+    ok: true,
+    value: {
+      tokens: {
+        access_token: accessToken,
+        refresh_token: refreshToken,
+        ...(idToken ? { id_token: idToken } : {}),
+      },
+      ...(lastRefresh ? { last_refresh: lastRefresh } : {}),
+    },
+  };
+}
+
+function sameFileGeneration(left: Stats, right: Stats): boolean {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.size === right.size &&
+    left.mtimeMs === right.mtimeMs &&
+    left.ctimeMs === right.ctimeMs
+  );
+}
+
+async function readStableCodexAuth(
+  homeDir: string,
+): Promise<MaterializedCodexAuthCandidate> {
+  const authPath = path.join(homeDir, "auth.json");
+  let lastInvalid: Error | undefined;
+  for (let attempt = 0; attempt < CODEX_AUTH_STABLE_READ_ATTEMPTS; attempt++) {
+    const before = statSync(authPath);
+    const raw = readFileSync(authPath, "utf-8");
+    const after = statSync(authPath);
+    const parsed = parseMaterializedCodexAuth(raw, authPath);
+    if (sameFileGeneration(before, after) && parsed.ok) {
+      const rawLastRefresh = parsed.value.last_refresh;
+      const parsedLastRefresh = rawLastRefresh
+        ? Date.parse(rawLastRefresh)
+        : Number.NaN;
+      return {
+        authPath,
+        homeDir,
+        auth: parsed.value,
+        lastRefreshMs: Number.isFinite(parsedLastRefresh)
+          ? parsedLastRefresh
+          : null,
+      };
+    }
+    if (!parsed.ok) lastInvalid = parsed.error;
+    await new Promise<void>((resolve) =>
+      setTimeout(resolve, CODEX_AUTH_STABLE_READ_DELAY_MS),
+    );
+  }
+  throw new ElizaError(
+    `Codex auth file did not reach a valid stable generation: ${authPath}`,
+    {
+      code: "CODEX_AUTH_FILE_UNSTABLE",
+      ...(lastInvalid ? { cause: lastInvalid } : {}),
+      context: { authPath },
+      severity: "fatal",
+    },
+  );
+}
+
+function listCodexHomeCandidates(accountId: string): string[] {
+  const accountHome = codexHomeDir(accountId);
+  const homes: string[] = [];
+  if (existsSync(path.join(accountHome, "auth.json"))) homes.push(accountHome);
+  const generationsDir = path.join(accountHome, "generations");
+  if (!existsSync(generationsDir)) return homes;
+  for (const entry of readdirSync(generationsDir, { withFileTypes: true })) {
+    if (
+      entry.isDirectory() &&
+      CODEX_GENERATION_NAME_PATTERN.test(entry.name) &&
+      existsSync(path.join(generationsDir, entry.name, "auth.json"))
+    ) {
+      homes.push(path.join(generationsDir, entry.name));
+    }
+  }
+  return homes;
+}
+
+function publishJsonExclusive(filePath: string, value: unknown): void {
+  const tmpPath = `${filePath}.tmp-${process.pid}-${randomUUID()}`;
+  try {
+    writeFileSync(tmpPath, JSON.stringify(value, null, 2), {
+      encoding: "utf-8",
+      mode: 0o600,
+      flag: "wx",
+    });
+    // A hard-link is an atomic no-replace publish. Unlike rename(), it cannot
+    // overwrite a generation an external runtime has already handed to Codex.
+    linkSync(tmpPath, filePath);
+  } catch (cause) {
+    // error-policy:J2 the credential-file boundary adds the target path while
+    // preserving the filesystem failure; callers must fail the selection.
+    throw new ElizaError(
+      `Could not publish Codex auth generation: ${filePath}`,
+      {
+        code: "CODEX_AUTH_GENERATION_PUBLISH_FAILED",
+        cause,
+        context: { filePath },
+        severity: "fatal",
+      },
+    );
+  } finally {
+    rmSync(tmpPath, { force: true });
+  }
+}
+
+function canonicalCodexAuth(
+  accountId: string,
+  record: NonNullable<ReturnType<typeof loadAccount>>,
+): MaterializedCodexAuthJson & Record<string, unknown> {
+  const { access, refresh, idToken } = record.credentials;
+  if (!access || !refresh) {
+    throw new ElizaError(
+      `openai-codex account "${accountId}" is missing a complete token pair`,
+      {
+        code: "CODEX_CANONICAL_CREDENTIAL_MISSING",
+        context: { accountId },
+        severity: "fatal",
+      },
+    );
+  }
+  return {
+    auth_mode: "chatgpt",
+    OPENAI_API_KEY: null,
+    tokens: {
+      ...(idToken ? { id_token: idToken } : {}),
+      access_token: access,
+      refresh_token: refresh,
+      ...(record.organizationId ? { account_id: record.organizationId } : {}),
+    },
+    // This is the canonical record's observed write time, not materialization
+    // time. Re-materialization therefore cannot masquerade as a newer OAuth
+    // generation and eclipse a concurrent Codex rotation.
+    last_refresh: new Date(record.updatedAt).toISOString(),
+  };
+}
+
+async function createCanonicalCodexHome(
+  accountId: string,
+  record: NonNullable<ReturnType<typeof loadAccount>>,
+): Promise<MaterializedCodexAuthCandidate> {
+  const refreshToken = record.credentials.refresh;
+  if (!refreshToken) {
+    throw new ElizaError(
+      `openai-codex account "${accountId}" is missing a refresh token`,
+      {
+        code: "CODEX_CANONICAL_CREDENTIAL_MISSING",
+        context: { accountId },
+        severity: "fatal",
+      },
+    );
+  }
+  const homeDir = codexGenerationDir(accountId, refreshToken);
+  mkdirSync(homeDir, { recursive: true, mode: 0o700 });
+  const authPath = path.join(homeDir, "auth.json");
+  if (!existsSync(authPath)) {
+    publishJsonExclusive(authPath, canonicalCodexAuth(accountId, record));
+  }
+  const candidate = await readStableCodexAuth(homeDir);
+  if (candidate.auth.tokens.refresh_token !== refreshToken) {
+    throw new ElizaError(
+      `Codex auth generation does not match its canonical generation: ${authPath}`,
+      {
+        code: "CODEX_AUTH_GENERATION_MISMATCH",
+        context: { accountId, authPath },
+        severity: "fatal",
+      },
+    );
+  }
+  return candidate;
+}
+
+interface CodexReconciliation {
+  adopted: boolean;
+  candidate: MaterializedCodexAuthCandidate | null;
+  record: NonNullable<ReturnType<typeof loadAccount>>;
+}
+
+async function reconcileCodexTokensLocked(
+  accountId: string,
+): Promise<CodexReconciliation> {
+  const record = loadAccount("openai-codex", accountId);
+  if (!record) {
+    throw new ElizaError(`openai-codex account "${accountId}" is missing`, {
+      code: "CODEX_CANONICAL_CREDENTIAL_MISSING",
+      context: { accountId },
+      severity: "fatal",
+    });
+  }
+  const candidates: MaterializedCodexAuthCandidate[] = [];
+  for (const homeDir of listCodexHomeCandidates(accountId)) {
+    candidates.push(await readStableCodexAuth(homeDir));
+  }
+  const matching = candidates.filter(
+    (candidate) =>
+      candidate.auth.tokens.refresh_token === record.credentials.refresh,
+  );
+  const divergent = candidates.filter(
+    (candidate) =>
+      candidate.auth.tokens.refresh_token !== record.credentials.refresh,
+  );
+  for (const candidate of divergent) {
+    if (candidate.lastRefreshMs === null) {
+      throw new ElizaError(
+        `Codex auth generation cannot be ordered safely: ${candidate.authPath}`,
+        {
+          code: "CODEX_AUTH_GENERATION_AMBIGUOUS",
+          context: { accountId, authPath: candidate.authPath },
+          severity: "fatal",
+        },
+      );
+    }
+  }
+  const newer = divergent
+    .filter(
+      (candidate) =>
+        candidate.lastRefreshMs !== null &&
+        candidate.lastRefreshMs > record.updatedAt,
+    )
+    .sort(
+      (left, right) =>
+        (right.lastRefreshMs ?? Number.NEGATIVE_INFINITY) -
+        (left.lastRefreshMs ?? Number.NEGATIVE_INFINITY),
+    );
+  const newest = newer[0];
+  const equallyNew = newest
+    ? newer.find(
+        (candidate) =>
+          candidate !== newest &&
+          candidate.lastRefreshMs === newest.lastRefreshMs &&
+          candidate.auth.tokens.refresh_token !==
+            newest.auth.tokens.refresh_token,
+      )
+    : undefined;
+  if (newest && equallyNew) {
+    throw new ElizaError(
+      `Codex auth generations have an ambiguous refresh order for account "${accountId}"`,
+      {
+        code: "CODEX_AUTH_GENERATION_AMBIGUOUS",
+        context: {
+          accountId,
+          authPaths: [newest.authPath, equallyNew.authPath],
+        },
+        severity: "fatal",
+      },
+    );
+  }
+  if (newest) {
+    const tokens = newest.auth.tokens;
+    saveCredentials(
+      "openai-codex",
+      {
+        access: tokens.access_token,
+        refresh: tokens.refresh_token,
+        expires: jwtExpiryMs(tokens.access_token) ?? Date.now(),
+        ...(tokens.id_token ? { idToken: tokens.id_token } : {}),
+      },
+      accountId,
+    );
+    const adoptedRecord = loadAccount("openai-codex", accountId);
+    if (!adoptedRecord) {
+      throw new ElizaError(
+        `Adopted Codex credentials could not be reloaded for account "${accountId}"`,
+        {
+          code: "CODEX_CANONICAL_CREDENTIAL_MISSING",
+          context: { accountId },
+          severity: "fatal",
+        },
+      );
+    }
+    logger.info(
+      `[coding-account-bridge] adopted rotated Codex tokens from CODEX_HOME for account "${accountId}" (CLI self-refresh)`,
+    );
+    return { adopted: true, candidate: newest, record: adoptedRecord };
+  }
+  const candidate = matching.sort(
+    (left, right) =>
+      (right.lastRefreshMs ?? Number.NEGATIVE_INFINITY) -
+      (left.lastRefreshMs ?? Number.NEGATIVE_INFINITY),
+  )[0];
+  return { adopted: false, candidate: candidate ?? null, record };
 }
 
 /**
@@ -187,56 +582,9 @@ interface MaterializedCodexAuthJson {
 export async function adoptRotatedCodexTokens(
   accountId: string,
 ): Promise<boolean> {
-  const authPath = path.join(codexHomeDir(accountId), "auth.json");
-  if (!existsSync(authPath)) return false;
   return accountRefreshMutex.acquire(`openai-codex:${accountId}`, async () => {
-    let parsed: MaterializedCodexAuthJson;
-    try {
-      parsed = JSON.parse(
-        readFileSync(authPath, "utf-8"),
-      ) as MaterializedCodexAuthJson;
-    } catch {
-      // error-policy:J3 externally-maintained auth.json — an unreadable/malformed
-      // file means "no usable credential", handled as a false refresh result.
-      return false;
-    }
-    const tokens = parsed?.tokens;
-    if (!tokens?.access_token || !tokens.refresh_token) return false;
-    const record = loadAccount("openai-codex", accountId);
-    if (!record) return false;
-    // Same refresh token → the CLI never rotated; nothing to adopt.
-    if (tokens.refresh_token === record.credentials.refresh) return false;
-    // Only adopt when the CLI's copy is NEWER than the canonical record. An
-    // older materialized copy (e.g. the account was re-linked via OAuth after
-    // that session ran) would clobber a fresh login with dead tokens.
-    const materializedAt =
-      typeof parsed.last_refresh === "string"
-        ? Date.parse(parsed.last_refresh)
-        : Number.NaN;
-    if (
-      !Number.isFinite(materializedAt) ||
-      materializedAt <= record.updatedAt
-    ) {
-      return false;
-    }
-    // Prefer the access token's own exp claim; an undecodable token is saved
-    // as already-expired so the next getAccessToken refreshes it immediately
-    // (with the adopted, still-valid refresh token).
-    const expires = jwtExpiryMs(tokens.access_token) ?? Date.now();
-    saveCredentials(
-      "openai-codex",
-      {
-        access: tokens.access_token,
-        refresh: tokens.refresh_token,
-        expires,
-        ...(tokens.id_token ? { idToken: tokens.id_token } : {}),
-      },
-      accountId,
-    );
-    logger.info(
-      `[coding-account-bridge] adopted rotated Codex tokens from CODEX_HOME for account "${accountId}" (CLI self-refresh)`,
-    );
-    return true;
+    const reconciled = await reconcileCodexTokensLocked(accountId);
+    return reconciled.adopted;
   });
 }
 
@@ -267,52 +615,7 @@ const MANAGED_CODEX_ACP_EFFORTS: ReadonlySet<string> = new Set([
   "xhigh",
 ]);
 
-/**
- * Materialize a per-account `CODEX_HOME` so Codex authenticates as the selected
- * account instead of the machine's single `~/.codex` login. Writes the
- * ChatGPT-login `auth.json` shape Codex reads; the account_id is the OAuth
- * account id baked into the credential record (`organizationId`).
- */
-async function materializeCodexHome(
-  accountId: string,
-  accessToken: string,
-): Promise<string> {
-  const dir = codexHomeDir(accountId);
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true, mode: 0o700 });
-  }
-  // Codex refresh tokens are one-time credentials. A session may rotate the
-  // pair after selection but before materialization, so adoption is repeated
-  // under the account mutex immediately before writing. Any adoption failure
-  // must abort the write; continuing could destroy the only valid token pair.
-  await adoptRotatedCodexTokens(accountId);
-  const record = loadAccount("openai-codex", accountId);
-  const refreshToken = record?.credentials.refresh;
-  if (!refreshToken) {
-    throw new Error(
-      `openai-codex account "${accountId}" is missing a refresh token`,
-    );
-  }
-  const chatgptAccountId = record?.organizationId;
-  // Codex's chatgpt-mode auth loader requires `tokens.id_token`; omitting it
-  // fails with "Authentication required" even when access_token is valid (an
-  // expired id_token is tolerated — Codex refreshes — but it must be present).
-  const idToken = record?.credentials.idToken;
-  const authJson = {
-    auth_mode: "chatgpt",
-    OPENAI_API_KEY: null as string | null,
-    tokens: {
-      ...(idToken ? { id_token: idToken } : {}),
-      // Access and refresh tokens are a generation pair; never combine a
-      // caller-cached access token with a newly adopted refresh token.
-      access_token: record?.credentials.access ?? accessToken,
-      refresh_token: refreshToken,
-      ...(chatgptAccountId ? { account_id: chatgptAccountId } : {}),
-    },
-    last_refresh: new Date().toISOString(),
-  };
-  writeJsonAtomicSync(path.join(dir, "auth.json"), authJson);
-
+function resolveCodexConfig(): string {
   // Codex reads its model from CODEX_HOME/config.toml; with none, codex-acp
   // falls back to a built-in default (e.g. gpt-5.3-codex) that ChatGPT-account
   // auth rejects ("model is not supported when using Codex with a ChatGPT
@@ -321,83 +624,164 @@ async function materializeCodexHome(
   // (extracted from ~/.codex/config.toml) but NOT the rest of their config,
   // which can carry unrelated interactive-only settings. Falls back to a
   // compatible default.
-  const targetConfig = path.join(dir, "config.toml");
-  try {
-    // Resolution order: explicit env pin > app-configured model (what
-    // POST /api/models/config writes for the codex coding target) > the
-    // operator's machine config > the compatible default. Without the
-    // POWERFUL read here, the app-configured model was a dead-end key — the
-    // machine ~/.codex/config.toml silently won on every spawn.
-    let model: string | undefined;
-    for (const key of ["ELIZA_CODEX_MODEL", "ELIZA_CODEX_MODEL_POWERFUL"]) {
-      const candidate = process.env[key]?.trim();
-      if (!candidate) continue;
-      // Validate the operator-supplied model: it is interpolated into TOML, so
-      // a stray quote/newline would break out of the string (corrupt config) —
-      // and a model name is a conservative token anyway. Reject anything else.
-      if (!/^[\w.:/-]+$/.test(candidate)) {
-        logger.warn(
-          `[coding-account-bridge] ignoring malformed ${key}=${JSON.stringify(candidate)}`,
-        );
-        continue;
-      }
-      model = candidate;
-      break;
-    }
-    if (!model) {
-      const machineConfig = path.join(os.homedir(), ".codex", "config.toml");
-      if (existsSync(machineConfig)) {
-        // Accept both double- and single-quoted TOML strings (both are valid +
-        // common); the captured value can't contain the quote char so it's
-        // safe to re-emit double-quoted.
-        const m = readFileSync(machineConfig, "utf-8").match(
-          /^\s*model\s*=\s*["']([^"']+)["']/m,
-        );
-        if (m?.[1]) model = m[1];
-      }
-    }
-    let effort = process.env.ELIZA_CODEX_EFFORT?.trim().toLowerCase();
-    if (effort && !CODEX_EFFORT_VALUES.has(effort)) {
-      // error-policy:J7 an invalid operator effort must not poison the spawn —
-      // warn and omit the line; the model pin below still ships.
+  // Resolution order: explicit env pin > app-configured model (what
+  // POST /api/models/config writes for the codex coding target) > the
+  // operator's machine config > the compatible default. Without the POWERFUL
+  // read here, the app-configured model is a dead-end key.
+  let model: string | undefined;
+  for (const key of ["ELIZA_CODEX_MODEL", "ELIZA_CODEX_MODEL_POWERFUL"]) {
+    const candidate = process.env[key]?.trim();
+    if (!candidate) continue;
+    // A model is interpolated into TOML, so reject characters that could break
+    // out of the string rather than trying to escape a broader grammar here.
+    if (!/^[\w.:/-]+$/.test(candidate)) {
       logger.warn(
-        `[coding-account-bridge] ignoring invalid ELIZA_CODEX_EFFORT=${JSON.stringify(effort)} (expected low|medium|high|xhigh|max|ultra)`,
+        `[coding-account-bridge] ignoring malformed ${key}=${JSON.stringify(candidate)}`,
       );
-      effort = undefined;
-    } else if (effort && !MANAGED_CODEX_ACP_EFFORTS.has(effort)) {
-      logger.warn(
-        `[coding-account-bridge] ELIZA_CODEX_EFFORT=${JSON.stringify(effort)} is not supported by the managed codex-acp contract (supported: low|medium|high|xhigh); omitting model_reasoning_effort`,
-      );
-      effort = undefined;
+      continue;
     }
-    // The file store makes every rotated pair observable to the pool. The
-    // adapter's `auto` mode can select a process-local or unavailable keyring
-    // on headless hosts, which is incompatible with durable pool adoption.
-    writeFileSync(
-      targetConfig,
-      `model = "${model || "gpt-5.6-sol"}"\ncli_auth_credentials_store = "file"\n${
-        effort ? `model_reasoning_effort = "${effort}"\n` : ""
-      }`,
-      { mode: 0o600 },
-    );
-  } catch (err) {
-    logger.warn(
-      `[coding-account-bridge] could not materialize codex config.toml: ${String(err)}`,
-    );
+    model = candidate;
+    break;
   }
-  return dir;
+  if (!model) {
+    const machineConfig = path.join(os.homedir(), ".codex", "config.toml");
+    if (existsSync(machineConfig)) {
+      // Accept both double- and single-quoted TOML strings. The captured value
+      // cannot contain its delimiter, so re-emitting double-quoted is safe.
+      const match = readFileSync(machineConfig, "utf-8").match(
+        /^\s*model\s*=\s*["']([^"']+)["']/m,
+      );
+      if (match?.[1]) model = match[1];
+    }
+  }
+  let effort = process.env.ELIZA_CODEX_EFFORT?.trim().toLowerCase();
+  if (effort && !CODEX_EFFORT_VALUES.has(effort)) {
+    // error-policy:J7 invalid operator input is omitted so the required model
+    // and credential-store pins remain usable and the rejection is observable.
+    logger.warn(
+      `[coding-account-bridge] ignoring invalid ELIZA_CODEX_EFFORT=${JSON.stringify(effort)} (expected low|medium|high|xhigh|max|ultra)`,
+    );
+    effort = undefined;
+  } else if (effort && !MANAGED_CODEX_ACP_EFFORTS.has(effort)) {
+    // error-policy:J7 see MANAGED_CODEX_ACP_EFFORTS — writing max/ultra would
+    // fail the adapter's whole config parse and discard both safety pins.
+    logger.warn(
+      `[coding-account-bridge] ELIZA_CODEX_EFFORT=${JSON.stringify(effort)} is not supported by the managed codex-acp contract (supported: low|medium|high|xhigh); omitting model_reasoning_effort so config.toml stays loadable`,
+    );
+    effort = undefined;
+  }
+  return `model = "${model || "gpt-5.6-sol"}"\ncli_auth_credentials_store = "file"\n${
+    effort ? `model_reasoning_effort = "${effort}"\n` : ""
+  }`;
+}
+
+function materializeRequiredTextFile(
+  targetPath: string,
+  contents: string,
+  errorCode:
+    | "CODEX_CONFIG_MATERIALIZATION_FAILED"
+    | "CODEX_ACTIVE_HOME_MATERIALIZATION_FAILED",
+  description: string,
+): void {
+  const tmpPath = `${targetPath}.tmp-${process.pid}-${randomUUID()}`;
+  try {
+    if (
+      existsSync(targetPath) &&
+      readFileSync(targetPath, "utf-8") === contents
+    ) {
+      return;
+    }
+    writeFileSync(tmpPath, contents, {
+      encoding: "utf-8",
+      mode: 0o600,
+      flag: "wx",
+    });
+    renameSync(tmpPath, targetPath);
+    if (readFileSync(targetPath, "utf-8") !== contents) {
+      throw new ElizaError(
+        `Codex ${description} verification failed after materialization: ${targetPath}`,
+        {
+          code: errorCode,
+          context: { targetPath },
+          severity: "fatal",
+        },
+      );
+    }
+  } catch (cause) {
+    // error-policy:J2 both config and active-home publication are part of the
+    // auth-safety boundary, so the spawn must not proceed on filesystem error.
+    throw new ElizaError(
+      `Could not materialize required Codex ${description}: ${targetPath}`,
+      {
+        code: errorCode,
+        cause,
+        context: { targetPath },
+        severity: "fatal",
+      },
+    );
+  } finally {
+    rmSync(tmpPath, { force: true });
+  }
+}
+
+function materializeRequiredCodexConfig(homeDir: string): void {
+  materializeRequiredTextFile(
+    path.join(homeDir, "config.toml"),
+    resolveCodexConfig(),
+    "CODEX_CONFIG_MATERIALIZATION_FAILED",
+    "config",
+  );
+}
+
+function publishActiveCodexHome(accountId: string, homeDir: string): void {
+  const accountHome = codexHomeDir(accountId);
+  const relativeHome = path.relative(accountHome, homeDir);
+  if (
+    relativeHome.startsWith(`..${path.sep}`) ||
+    relativeHome === ".." ||
+    path.isAbsolute(relativeHome)
+  ) {
+    throw new ElizaError(`Codex home is outside its account root: ${homeDir}`, {
+      code: "CODEX_ACTIVE_HOME_MATERIALIZATION_FAILED",
+      context: { accountId, homeDir },
+      severity: "fatal",
+    });
+  }
+  // The benchmark harness cannot infer which historical token generation is
+  // canonical without reading secrets, so publish a non-secret relative path.
+  materializeRequiredTextFile(
+    path.join(accountHome, CODEX_ACTIVE_HOME_FILE),
+    `${relativeHome || "."}\n`,
+    "CODEX_ACTIVE_HOME_MATERIALIZATION_FAILED",
+    "active-home pointer",
+  );
+}
+
+/**
+ * Reconcile a Codex-owned token generation and return a safe `CODEX_HOME`.
+ * Existing auth files are immutable from the bridge's perspective: Codex may
+ * be refreshing one in another process, so only Codex writes an already-
+ * published generation. A newer canonical login gets a new generation path.
+ */
+async function materializeCodexHome(accountId: string): Promise<string> {
+  return accountRefreshMutex.acquire(`openai-codex:${accountId}`, async () => {
+    const reconciled = await reconcileCodexTokensLocked(accountId);
+    const candidate =
+      reconciled.candidate ??
+      (await createCanonicalCodexHome(accountId, reconciled.record));
+    materializeRequiredCodexConfig(candidate.homeDir);
+    publishActiveCodexHome(accountId, candidate.homeDir);
+    return candidate.homeDir;
+  });
 }
 
 async function buildEnvPatch(
   providerId: LinkedAccountProviderId,
-  accountId: string,
   accessToken: string,
 ): Promise<Record<string, string>> {
   switch (providerId) {
     case "anthropic-subscription":
       return { CLAUDE_CODE_OAUTH_TOKEN: accessToken };
-    case "openai-codex":
-      return { CODEX_HOME: await materializeCodexHome(accountId, accessToken) };
     default: {
       // Direct API providers (e.g. cerebras-api → CEREBRAS_API_KEY for opencode)
       // inject under their canonical env key; run-main.ts normalizes aliases
@@ -462,80 +846,77 @@ function makeBridge(pool: AccountPool): CodingAgentSelectorBridge {
           ...(opts?.accountIds ? { accountIds: opts.accountIds } : {}),
         });
         if (!account) continue;
-        // A prior Codex session may have rotated the one-time refresh token
-        // inside its CODEX_HOME; heal the canonical record BEFORE resolving a
-        // token or the refresh below burns on the consumed token.
+        let envPatch: Record<string, string>;
         if (providerId === "openai-codex") {
-          await adoptRotatedCodexTokens(account.id).catch(() => false);
-        }
-        // Claude coding spawns get a BARE `CLAUDE_CODE_OAUTH_TOKEN` the
-        // third-party claude-agent-acp adapter reads ONCE and cannot refresh, so a
-        // long run outlives a short-TTL token (recon gap #3). Proactively widen
-        // the refresh window for anthropic-subscription so the injected token
-        // survives the expected run duration. Codex self-refreshes into its
-        // CODEX_HOME, so it keeps the default buffer.
-        const resolveOpts =
-          providerId === "anthropic-subscription"
-            ? {
-                minRemainingMs: claudeMinRemainingMs(
-                  resolveClaudeExpectedRunMs((key) => process.env[key]),
-                ),
-              }
-            : undefined;
-        let accessToken: string | null = null;
-        let resolveOutcome: AccessTokenOutcome | undefined;
-        let resolveError: unknown;
-        try {
-          resolveOutcome = await getAccessToken(providerId, account.id, {
-            ...resolveOpts,
-            outcome: true,
-          });
-          accessToken = resolveOutcome.ok ? resolveOutcome.accessToken : null;
-          // A widened Claude resolve is only a freshness preference. The
-          // default-buffer retry preserves a still-valid token when refresh is
-          // transiently unavailable or the vendor minted a shorter-lived token.
-          if (
-            accessToken === null &&
-            resolveOpts &&
-            resolveOutcome &&
-            !resolveOutcome.ok &&
-            resolveOutcome.kind !== "auth"
-          ) {
-            const stillValid = await getAccessToken(providerId, account.id, {
+          // CODEX_HOME is the refresh authority for a running Codex process.
+          // Reconcile and select its immutable generation before any canonical
+          // refresh can present an already-consumed one-time token.
+          envPatch = { CODEX_HOME: await materializeCodexHome(account.id) };
+        } else {
+          // Claude coding spawns get a bare token the third-party adapter reads
+          // once and cannot refresh, so widen the freshness window to the
+          // expected run duration before injecting it.
+          const resolveOpts =
+            providerId === "anthropic-subscription"
+              ? {
+                  minRemainingMs: claudeMinRemainingMs(
+                    resolveClaudeExpectedRunMs((key) => process.env[key]),
+                  ),
+                }
+              : undefined;
+          let accessToken: string | null = null;
+          let resolveOutcome: AccessTokenOutcome | undefined;
+          let resolveError: unknown;
+          try {
+            resolveOutcome = await getAccessToken(providerId, account.id, {
+              ...resolveOpts,
               outcome: true,
             });
-            resolveOutcome = stillValid;
-            if (stillValid.ok) {
-              logger.info(
-                `[coding-account-bridge] proactive refresh for ${providerId}/${account.id} did not yield a fresh token; using the still-valid shorter-TTL token (a long run may hit the typed expiry signal)`,
-              );
-              accessToken = stillValid.accessToken;
+            accessToken = resolveOutcome.ok ? resolveOutcome.accessToken : null;
+            // A widened Claude resolve is only a freshness preference. The
+            // default-buffer retry preserves a still-valid shorter-lived token
+            // when proactive refresh is transiently unavailable.
+            if (
+              accessToken === null &&
+              resolveOpts &&
+              resolveOutcome &&
+              !resolveOutcome.ok &&
+              resolveOutcome.kind !== "auth"
+            ) {
+              const stillValid = await getAccessToken(providerId, account.id, {
+                outcome: true,
+              });
+              resolveOutcome = stillValid;
+              if (stillValid.ok) {
+                logger.info(
+                  `[coding-account-bridge] proactive refresh for ${providerId}/${account.id} did not yield a fresh token; using the still-valid shorter-TTL token (a long run may hit the typed expiry signal)`,
+                );
+                accessToken = stillValid.accessToken;
+              }
             }
-          }
-        } catch (err) {
-          resolveError = err;
-          logger.warn(
-            `[coding-account-bridge] token resolve failed for ${providerId}/${account.id}: ${String(err)}`,
-          );
-        }
-        if (!accessToken) {
-          // Only flag for re-auth on a genuine auth failure; a transient
-          // network/5xx blip must not pull a healthy account out of rotation.
-          if (accessTokenFailureIsAuth(resolveOutcome, resolveError)) {
-            await pool.markNeedsReauth(
-              account.id,
-              "No valid credential / token refresh failed",
-              { providerId },
+          } catch (err) {
+            resolveError = err;
+            logger.warn(
+              `[coding-account-bridge] token resolve failed for ${providerId}/${account.id}: ${String(err)}`,
             );
           }
-          continue;
+          if (!accessToken) {
+            // Only flag for re-auth on a genuine auth failure; a transient
+            // network/5xx blip must not pull a healthy account out of rotation.
+            if (accessTokenFailureIsAuth(resolveOutcome, resolveError)) {
+              await pool.markNeedsReauth(
+                account.id,
+                "No valid credential / token refresh failed",
+                { providerId },
+              );
+            }
+            continue;
+          }
+          envPatch = await buildEnvPatch(providerId, accessToken);
+          if (Object.keys(envPatch).length === 0) {
+            continue;
+          }
         }
-        const envPatch = await buildEnvPatch(
-          providerId,
-          account.id,
-          accessToken,
-        );
-        if (Object.keys(envPatch).length === 0) continue;
         const source: "oauth" | "api-key" = isSubscriptionProvider(providerId)
           ? "oauth"
           : "api-key";
@@ -571,7 +952,7 @@ function makeBridge(pool: AccountPool): CodingAgentSelectorBridge {
       // Session-level auth failures can come from an injected token aging out.
       // Verify the stored credential before evicting the account from rotation.
       if (providerId === "openai-codex") {
-        await adoptRotatedCodexTokens(accountId).catch(() => false);
+        await adoptRotatedCodexTokens(accountId);
       }
       try {
         const tokenOutcome = await getAccessToken(providerId, accountId, {
@@ -633,7 +1014,7 @@ function makeBridge(pool: AccountPool): CodingAgentSelectorBridge {
       // mid-run — heal the canonical record before the next sweep refreshes
       // against the consumed one.
       if (providerId === "openai-codex") {
-        await adoptRotatedCodexTokens(accountId).catch(() => false);
+        await adoptRotatedCodexTokens(accountId);
       }
       return pool.recordCall(accountId, result, { providerId });
     },

--- a/packages/app-core/src/services/multi-account-refresh-failover.test.ts
+++ b/packages/app-core/src/services/multi-account-refresh-failover.test.ts
@@ -15,16 +15,28 @@
  * credential store, real AccountPool, real bridge — no in-memory stubs.
  */
 
-import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { spawn } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { loadAccount, saveAccount } from "@elizaos/auth/account-storage";
 import { writeJsonAtomicSync } from "@elizaos/auth/atomic-json";
 import type { AccountCredentialProvider } from "@elizaos/auth/types";
+import { logger } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   __resetDefaultAccountPoolForTests,
   getDefaultAccountPool,
+  startAccountPoolKeepAlive,
+  stopAccountPoolKeepAliveForTests,
+  sweepAccountPoolKeepAlive,
 } from "./account-pool.js";
 import {
   adoptRotatedCodexTokens,
@@ -84,6 +96,65 @@ function writeMaterializedCodexAuth(
     OPENAI_API_KEY: null,
     tokens,
     last_refresh: new Date(lastRefreshMs).toISOString(),
+  });
+}
+
+async function waitForFile(filePath: string): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (!existsSync(filePath)) {
+    if (Date.now() >= deadline) {
+      throw new Error(`timed out waiting for external writer: ${filePath}`);
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+function startExternalCodexFileRotation(
+  authPath: string,
+  signalPath: string,
+  payload: string,
+): Promise<void> {
+  const script = `
+const fs = require("node:fs");
+const authPath = process.argv[1];
+const signalPath = process.argv[2];
+const payload = process.argv[3];
+const midpoint = Math.floor(payload.length / 2);
+const fd = fs.openSync(authPath, "w", 0o600);
+fs.writeSync(fd, payload.slice(0, midpoint));
+fs.fsyncSync(fd);
+fs.writeFileSync(signalPath, "writer-open");
+setTimeout(() => {
+  fs.writeSync(fd, payload.slice(midpoint));
+  fs.fsyncSync(fd);
+  fs.closeSync(fd);
+}, 75);
+`;
+  const child = spawn(
+    process.execPath,
+    ["-e", script, authPath, signalPath, payload],
+    {
+      stdio: ["ignore", "ignore", "pipe"],
+    },
+  );
+  let stderr = "";
+  child.stderr.setEncoding("utf-8");
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+  return new Promise<void>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(
+        new Error(
+          `external Codex writer exited code=${String(code)} signal=${String(signal)}: ${stderr}`,
+        ),
+      );
+    });
   });
 }
 
@@ -181,13 +252,105 @@ describe("adoptRotatedCodexTokens (CLI self-refresh sync-back)", () => {
     expect(record?.credentials.refresh).toBe("rt-fresh-login");
   });
 
-  it("no-ops when there is no materialized CODEX_HOME or it is corrupt", async () => {
+  it("no-ops when there is no materialized CODEX_HOME", async () => {
     writeAccount("openai-codex", "codex-work", {
       access: "a",
       refresh: "r",
       expires: Date.now() + HOUR_MS,
     });
     expect(await adoptRotatedCodexTokens("codex-work")).toBe(false);
+  });
+
+  it("fails closed before canonical refresh when the only Codex file generation is unreadable", async () => {
+    const fetchSpy = vi.fn(async () => {
+      throw new Error("getAccessToken must not run after adoption failure");
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+    writeAccount("openai-codex", "codex-work", {
+      access: "expired-access",
+      refresh: "rt-consumed",
+      expires: Date.now() - HOUR_MS,
+    });
+    const codexHome = path.join(home, "auth", "_codex-home", "codex-work");
+    mkdirSync(codexHome, { recursive: true, mode: 0o700 });
+    writeFileSync(path.join(codexHome, "auth.json"), '{"tokens":');
+
+    getDefaultAccountPool();
+    const bridge = getCodingAgentSelectorBridge();
+    await expect(bridge?.select("codex")).rejects.toMatchObject({
+      code: "CODEX_AUTH_FILE_UNSTABLE",
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps the background sweep from resolving a canonical token after adoption fails", async () => {
+    const fetchSpy = vi.fn(async () => {
+      throw new Error("getAccessToken must not run after adoption failure");
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+    writeAccount("openai-codex", "codex-work", {
+      access: "expired-access",
+      refresh: "rt-consumed",
+      expires: Date.now() - HOUR_MS,
+    });
+    const codexHome = path.join(home, "auth", "_codex-home", "codex-work");
+    mkdirSync(codexHome, { recursive: true, mode: 0o700 });
+    writeFileSync(path.join(codexHome, "auth.json"), '{"tokens":');
+
+    await expect(sweepAccountPoolKeepAlive()).rejects.toMatchObject({
+      code: "CODEX_AUTH_FILE_UNSTABLE",
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("heals a flagged direct-API account after its stored credential resolves", async () => {
+    writeAccount("anthropic-api", "direct-work", {
+      access: "sk-ant-valid",
+      refresh: "",
+      expires: Number.MAX_SAFE_INTEGER,
+    });
+    const pool = getDefaultAccountPool();
+    await pool.markInvalid("direct-work", "earlier transient failure", {
+      providerId: "anthropic-api",
+    });
+    expect(pool.get("direct-work", "anthropic-api")?.health).toBe("invalid");
+
+    await expect(sweepAccountPoolKeepAlive()).resolves.toEqual({
+      checked: 1,
+      refreshed: 0,
+      failed: 0,
+    });
+    expect(pool.get("direct-work", "anthropic-api")?.health).toBe("ok");
+  });
+
+  it("observes an adoption failure at the keep-alive timer boundary", async () => {
+    writeAccount("openai-codex", "codex-work", {
+      access: "expired-access",
+      refresh: "rt-consumed",
+      expires: Date.now() - HOUR_MS,
+    });
+    const codexHome = path.join(home, "auth", "_codex-home", "codex-work");
+    mkdirSync(codexHome, { recursive: true, mode: 0o700 });
+    writeFileSync(path.join(codexHome, "auth.json"), '{"tokens":');
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+    try {
+      startAccountPoolKeepAlive(60_000);
+      await vi.waitFor(
+        () => {
+          expect(errorSpy).toHaveBeenCalledWith(
+            expect.stringContaining("[AccountPool] keep-alive sweep failed:"),
+          );
+        },
+        { timeout: 3_000, interval: 10 },
+      );
+      expect(
+        getDefaultAccountPool().get("codex-work", "openai-codex")?.health,
+      ).not.toBe("needs-reauth");
+    } finally {
+      stopAccountPoolKeepAliveForTests();
+      errorSpy.mockRestore();
+    }
   });
 
   it("bridge.select heals the canonical record BEFORE resolving, so a CLI-rotated account still spawns", async () => {
@@ -238,6 +401,116 @@ describe("adoptRotatedCodexTokens (CLI self-refresh sync-back)", () => {
     expect(loadAccount("openai-codex", "codex-work")?.credentials.refresh).toBe(
       "rt-rotated",
     );
+  });
+
+  it("preserves and adopts a real external writer's rotated generation across concurrent selections", async () => {
+    writeAccount(
+      "openai-codex",
+      "codex-work",
+      {
+        access: fakeJwt(Date.now() + HOUR_MS),
+        refresh: "rt-initial",
+        expires: Date.now() + HOUR_MS,
+        idToken: "id-initial",
+      },
+      { organizationId: "acct_W" },
+    );
+    getDefaultAccountPool();
+    const bridge = getCodingAgentSelectorBridge();
+    const initial = await bridge?.select("codex");
+    const selectedHome = initial?.envPatch.CODEX_HOME;
+    expect(selectedHome).toBeTruthy();
+    const canonicalBefore = loadAccount("openai-codex", "codex-work");
+    expect(canonicalBefore).toBeTruthy();
+    const rotationAt = new Date(
+      Math.max(Date.now(), canonicalBefore?.updatedAt ?? 0) + 1_000,
+    ).toISOString();
+    const rotatedAccess = fakeJwt(Date.now() + 3 * HOUR_MS);
+    const rotatedPayload = JSON.stringify({
+      auth_mode: "chatgpt",
+      OPENAI_API_KEY: null,
+      tokens: {
+        access_token: rotatedAccess,
+        refresh_token: "rt-external-rotated",
+        id_token: "id-external-rotated",
+        account_id: "acct_W",
+      },
+      last_refresh: rotationAt,
+    });
+    const authPath = path.join(selectedHome as string, "auth.json");
+    const signalPath = path.join(home, "external-writer-open");
+    const externalWriter = startExternalCodexFileRotation(
+      authPath,
+      signalPath,
+      rotatedPayload,
+    );
+    await waitForFile(signalPath);
+
+    const [first, second] = await Promise.all([
+      bridge?.select("codex"),
+      bridge?.select("codex"),
+    ]);
+    await externalWriter;
+
+    expect(first?.envPatch.CODEX_HOME).toBe(selectedHome);
+    expect(second?.envPatch.CODEX_HOME).toBe(selectedHome);
+    // The bridge never rewrites a published auth generation, so the exact
+    // external-process bytes and its real last_refresh survive materialization.
+    expect(readFileSync(authPath, "utf-8")).toBe(rotatedPayload);
+    const authAfter = JSON.parse(readFileSync(authPath, "utf-8")) as {
+      last_refresh?: string;
+      tokens?: { refresh_token?: string };
+    };
+    expect(authAfter.last_refresh).toBe(rotationAt);
+    expect(authAfter.tokens?.refresh_token).toBe("rt-external-rotated");
+    const canonicalAfter = loadAccount("openai-codex", "codex-work");
+    expect(canonicalAfter?.credentials.access).toBe(rotatedAccess);
+    expect(canonicalAfter?.credentials.refresh).toBe("rt-external-rotated");
+    expect(canonicalAfter?.credentials.idToken).toBe("id-external-rotated");
+  });
+
+  it("fails closed when the required file-store config cannot be replaced", async () => {
+    writeAccount("openai-codex", "codex-work", {
+      access: fakeJwt(Date.now() + HOUR_MS),
+      refresh: "rt-config",
+      expires: Date.now() + HOUR_MS,
+    });
+    getDefaultAccountPool();
+    const bridge = getCodingAgentSelectorBridge();
+    const initial = await bridge?.select("codex");
+    const selectedHome = initial?.envPatch.CODEX_HOME;
+    expect(selectedHome).toBeTruthy();
+    const configPath = path.join(selectedHome as string, "config.toml");
+    rmSync(configPath);
+    mkdirSync(configPath);
+
+    await expect(bridge?.select("codex")).rejects.toMatchObject({
+      code: "CODEX_CONFIG_MATERIALIZATION_FAILED",
+    });
+  });
+
+  it("fails closed when the active Codex home cannot be published", async () => {
+    writeAccount("openai-codex", "codex-work", {
+      access: fakeJwt(Date.now() + HOUR_MS),
+      refresh: "rt-pointer",
+      expires: Date.now() + HOUR_MS,
+    });
+    getDefaultAccountPool();
+    const bridge = getCodingAgentSelectorBridge();
+    await bridge?.select("codex");
+    const pointerPath = path.join(
+      home,
+      "auth",
+      "_codex-home",
+      "codex-work",
+      "active-home",
+    );
+    rmSync(pointerPath);
+    mkdirSync(pointerPath);
+
+    await expect(bridge?.select("codex")).rejects.toMatchObject({
+      code: "CODEX_ACTIVE_HOME_MATERIALIZATION_FAILED",
+    });
   });
 });
 

--- a/packages/benchmarks/codex-adapter/AGENTS.md
+++ b/packages/benchmarks/codex-adapter/AGENTS.md
@@ -7,11 +7,11 @@ against the **Codex CLI** agent, authenticated per OpenAI-Codex account
 registered as a standalone benchmark — it wraps other benchmarks.
 
 Each turn spawns a one-shot `codex exec` subprocess authenticated **as** a
-selected account by pointing `CODEX_HOME` at that account's materialized home
-(`<stateDir>/auth/_codex-home/<accountId>/`, written by the TS runtime's
-`coding-account-bridge.ts`). The orchestrator process imports no Codex/Node
-dependency — it only needs the `codex` binary (or `CODEX_BIN`) and at least one
-materialized home.
+selected account by pointing `CODEX_HOME` at the credential generation named by
+`<stateDir>/auth/_codex-home/<accountId>/active-home` (written atomically by the
+TS runtime's `coding-account-bridge.ts`). The orchestrator process imports no
+Codex/Node dependency — it only needs the `codex` binary (or `CODEX_BIN`) and at
+least one materialized home.
 
 ## Layout
 
@@ -30,6 +30,9 @@ materialized home.
 
 - **`--accounts`**: integer `N` = first `N` accounts; `a,b` = exactly those ids;
   omitted = all. Turns round-robin: turn `i` → `accounts[i % len]`.
+- Discovery fails loudly when an `active-home` pointer is malformed, escapes
+  its account root, or names a missing generation; a missing pointer or `.`
+  selects the legacy account-root layout.
 - The client **never fabricates a response** — a missing binary, an
   unauthenticated account (`auth.json` absent), or a nonzero `codex exec` raises.
 - A live gpt-5.5 run needs real authenticated Codex homes + entitlement; the

--- a/packages/benchmarks/codex-adapter/CLAUDE.md
+++ b/packages/benchmarks/codex-adapter/CLAUDE.md
@@ -7,11 +7,11 @@ against the **Codex CLI** agent, authenticated per OpenAI-Codex account
 registered as a standalone benchmark — it wraps other benchmarks.
 
 Each turn spawns a one-shot `codex exec` subprocess authenticated **as** a
-selected account by pointing `CODEX_HOME` at that account's materialized home
-(`<stateDir>/auth/_codex-home/<accountId>/`, written by the TS runtime's
-`coding-account-bridge.ts`). The orchestrator process imports no Codex/Node
-dependency — it only needs the `codex` binary (or `CODEX_BIN`) and at least one
-materialized home.
+selected account by pointing `CODEX_HOME` at the credential generation named by
+`<stateDir>/auth/_codex-home/<accountId>/active-home` (written atomically by the
+TS runtime's `coding-account-bridge.ts`). The orchestrator process imports no
+Codex/Node dependency — it only needs the `codex` binary (or `CODEX_BIN`) and at
+least one materialized home.
 
 ## Layout
 
@@ -30,6 +30,9 @@ materialized home.
 
 - **`--accounts`**: integer `N` = first `N` accounts; `a,b` = exactly those ids;
   omitted = all. Turns round-robin: turn `i` → `accounts[i % len]`.
+- Discovery fails loudly when an `active-home` pointer is malformed, escapes
+  its account root, or names a missing generation; a missing pointer or `.`
+  selects the legacy account-root layout.
 - The client **never fabricates a response** — a missing binary, an
   unauthenticated account (`auth.json` absent), or a nonzero `codex exec` raises.
 - A live gpt-5.5 run needs real authenticated Codex homes + entitlement; the

--- a/packages/benchmarks/codex-adapter/README.md
+++ b/packages/benchmarks/codex-adapter/README.md
@@ -21,14 +21,19 @@ single `~/.codex` login. The layout (written by
 
 ```
 <stateDir>/auth/_codex-home/<accountId>/
-    auth.json      # chatgpt-mode tokens
-    config.toml    # pinned model (gpt-5.5)
+    active-home                         # relative, non-secret pointer
+    generations/<refresh-token-hash>/
+        auth.json                       # chatgpt-mode tokens
+        config.toml                     # pinned model (gpt-5.5)
 ```
 
 where `<stateDir>` is `$ELIZA_HOME` (or the resolved per-user state dir,
 default `~/.local/state/eliza`). This adapter's `codex_adapter.accounts`
-enumerates those homes and round-robins turns across the selected set — it does
-**no** OAuth and no network; materializing the homes is the TS runtime's job.
+enumerates account roots, validates each atomically-published `active-home`, and
+round-robins turns across the selected set. It does **no** OAuth and no network;
+materializing the generations is the TS runtime's job. Account roots created
+before generation isolation remain discoverable when the pointer is absent or
+contains `.`.
 
 ## `--accounts` semantics
 

--- a/packages/benchmarks/codex-adapter/codex_adapter/accounts.py
+++ b/packages/benchmarks/codex-adapter/codex_adapter/accounts.py
@@ -1,14 +1,15 @@
 """Multi-account CODEX_HOME selection for the Codex benchmark harness (#10193/#10199).
 
-The elizaOS runtime materializes one ``CODEX_HOME`` directory per authenticated
+The elizaOS runtime materializes a credential generation for each authenticated
 OpenAI-Codex account so a spawned ``codex`` subprocess authenticates AS that
 account instead of the machine's single ``~/.codex`` login. The TS side
-(``packages/app-core/src/services/coding-account-bridge.ts``) writes each home
-at::
+(``packages/app-core/src/services/coding-account-bridge.ts``) writes::
 
     <stateDir>/auth/_codex-home/<accountId>/
-        auth.json      # chatgpt-mode tokens
-        config.toml    # pinned model
+        active-home                         # relative, non-secret pointer
+        generations/<refresh-token-hash>/
+            auth.json                       # chatgpt-mode tokens
+            config.toml                     # pinned model
 
 where ``<stateDir>`` is ``$ELIZA_HOME`` (or the resolved per-user state dir,
 default ``~/.local/state/eliza``). This module is the **offline-testable**
@@ -23,8 +24,13 @@ credential-gated on those homes already existing.
 from __future__ import annotations
 
 import os
+import re
 from dataclasses import dataclass
 from pathlib import Path
+
+
+ACTIVE_HOME_FILE = "active-home"
+GENERATION_NAME = re.compile(r"^[a-f0-9]{24}$")
 
 
 def default_state_dir() -> Path:
@@ -46,6 +52,59 @@ def codex_homes_root(state_dir: Path | None = None) -> Path:
     """The directory containing one subdir per authenticated Codex account."""
     root = state_dir if state_dir is not None else default_state_dir()
     return root / "auth" / "_codex-home"
+
+
+def _active_codex_home(account_root: Path) -> Path:
+    """Resolve the generation the runtime published for one account.
+
+    Homes created before generation isolation remain valid at the account root,
+    represented by no pointer or ``.``. Any other pointer is a strict protocol
+    boundary: only ``generations/<24 lowercase hex>`` is accepted, and broken
+    or escaping targets fail instead of silently selecting stale credentials.
+    """
+    pointer_path = account_root / ACTIVE_HOME_FILE
+    if not os.path.lexists(pointer_path):
+        return account_root
+    try:
+        relative_text = pointer_path.read_text(encoding="utf-8").strip()
+    except OSError as cause:
+        # error-policy:J2 active-home is an on-disk protocol boundary; retain
+        # the filesystem cause while naming the account state that is invalid.
+        raise ValueError(
+            f"cannot read Codex active-home pointer: {pointer_path}"
+        ) from cause
+
+    if relative_text == ".":
+        return account_root.resolve()
+
+    relative = Path(relative_text)
+    if (
+        relative.is_absolute()
+        or len(relative.parts) != 2
+        or relative.parts[0] != "generations"
+        or GENERATION_NAME.fullmatch(relative.parts[1]) is None
+    ):
+        raise ValueError(
+            f"invalid Codex active-home pointer {pointer_path}: {relative_text!r}"
+        )
+
+    account_root_resolved = account_root.resolve()
+    try:
+        active_home = (account_root / relative).resolve()
+    except (OSError, RuntimeError) as cause:
+        # error-policy:J2 symlink and filesystem resolution failures identify
+        # the corrupt pointer without hiding the underlying OS error.
+        raise ValueError(
+            f"cannot resolve Codex active-home pointer: {pointer_path}"
+        ) from cause
+    if (
+        not active_home.is_relative_to(account_root_resolved)
+        or not active_home.is_dir()
+    ):
+        raise ValueError(
+            f"Codex active-home pointer target is unavailable: {pointer_path} -> {active_home}"
+        )
+    return active_home
 
 
 @dataclass(frozen=True)
@@ -75,7 +134,7 @@ def discover_codex_accounts(state_dir: Path | None = None) -> list[CodexAccount]
     if not root.is_dir():
         return []
     accounts = [
-        CodexAccount(account_id=child.name, codex_home=child)
+        CodexAccount(account_id=child.name, codex_home=_active_codex_home(child))
         for child in sorted(root.iterdir(), key=lambda p: p.name)
         if child.is_dir()
     ]
@@ -132,7 +191,9 @@ def select_codex_accounts(
     accounts are materialized at all. The runner surfaces this as a loud failure
     on a live run rather than proceeding with a half-satisfied account set.
     """
-    accounts = discovered if discovered is not None else discover_codex_accounts(state_dir)
+    accounts = (
+        discovered if discovered is not None else discover_codex_accounts(state_dir)
+    )
     count, explicit_ids = _parse_accounts_spec(spec)
 
     if not accounts:
@@ -140,7 +201,7 @@ def select_codex_accounts(
             "no Codex accounts materialized under "
             f"{codex_homes_root(state_dir)}. Authenticate at least one "
             "OpenAI-Codex account so the runtime writes its CODEX_HOME "
-            "(auth/_codex-home/<accountId>/auth.json)."
+            "(auth/_codex-home/<accountId>/active-home)."
         )
 
     by_id = {account.account_id: account for account in accounts}

--- a/packages/benchmarks/codex-adapter/tests/test_accounts.py
+++ b/packages/benchmarks/codex-adapter/tests/test_accounts.py
@@ -2,7 +2,7 @@
 
 These exercise the account discovery / --accounts parsing / round-robin
 iteration logic without any live model call. Homes are faked on a tmp dir in the
-same layout the TS runtime materializes: ``<state>/auth/_codex-home/<id>/auth.json``.
+legacy and generation-isolated layouts the TS runtime supports.
 """
 
 from __future__ import annotations
@@ -30,6 +30,18 @@ def _materialize(state_dir, *account_ids, authenticated=True):
     return root
 
 
+def _materialize_generation(state_dir, account_id, authenticated=True):
+    root = state_dir / "auth" / "_codex-home" / account_id
+    generation = root / "generations" / ("a" * 24)
+    generation.mkdir(parents=True, exist_ok=True)
+    if authenticated:
+        (generation / "auth.json").write_text(
+            '{"auth_mode":"chatgpt"}', encoding="utf-8"
+        )
+    (root / "active-home").write_text(f"generations/{'a' * 24}\n", encoding="utf-8")
+    return generation
+
+
 def test_default_state_dir_prefers_eliza_home(monkeypatch, tmp_path):
     monkeypatch.setenv("ELIZA_HOME", str(tmp_path / "home"))
     assert default_state_dir() == tmp_path / "home"
@@ -54,6 +66,40 @@ def test_discover_sorted_accounts(tmp_path):
     accounts = discover_codex_accounts(tmp_path)
     assert [a.account_id for a in accounts] == ["acct-a", "acct-b", "acct-c"]
     assert all(a.is_authenticated for a in accounts)
+
+
+def test_discover_resolves_published_generation(tmp_path):
+    generation = _materialize_generation(tmp_path, "acct-a")
+    accounts = discover_codex_accounts(tmp_path)
+    assert [account.account_id for account in accounts] == ["acct-a"]
+    assert accounts[0].codex_home == generation.resolve()
+    assert accounts[0].is_authenticated
+
+
+@pytest.mark.parametrize(
+    "pointer",
+    ["", "../escape", "generations/not-a-generation", "/tmp/escape"],
+)
+def test_discover_rejects_invalid_active_home_pointer(tmp_path, pointer):
+    root = _materialize(tmp_path, "acct-a") / "acct-a"
+    (root / "active-home").write_text(f"{pointer}\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="invalid Codex active-home pointer"):
+        discover_codex_accounts(tmp_path)
+
+
+def test_discover_accepts_explicit_legacy_active_home(tmp_path):
+    root = _materialize(tmp_path, "acct-a") / "acct-a"
+    (root / "active-home").write_text(".\n", encoding="utf-8")
+    accounts = discover_codex_accounts(tmp_path)
+    assert accounts[0].codex_home == root.resolve()
+    assert accounts[0].is_authenticated
+
+
+def test_discover_rejects_missing_active_generation(tmp_path):
+    root = _materialize(tmp_path, "acct-a") / "acct-a"
+    (root / "active-home").write_text(f"generations/{'b' * 24}\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="target is unavailable"):
+        discover_codex_accounts(tmp_path)
 
 
 def test_is_authenticated_false_without_auth_json(tmp_path):

--- a/packages/benchmarks/docs/HITL_MULTI_CODEX_RUNBOOK.md
+++ b/packages/benchmarks/docs/HITL_MULTI_CODEX_RUNBOOK.md
@@ -18,8 +18,10 @@ single `~/.codex` login. Each home lives at:
 
 ```
 <stateDir>/auth/_codex-home/<accountId>/
-    auth.json      # chatgpt-mode tokens (written by coding-account-bridge.ts)
-    config.toml    # pinned model
+    active-home                         # relative, non-secret pointer
+    generations/<refresh-token-hash>/
+        auth.json                       # chatgpt-mode tokens
+        config.toml                     # pinned model
 ```
 
 `<stateDir>` = `$ELIZA_HOME` (or the resolved per-user state dir, default
@@ -31,7 +33,7 @@ Verify what is materialized:
 
 ```bash
 ls "${ELIZA_HOME:-$HOME/.local/state/eliza}/auth/_codex-home/"
-# one directory per accountId, each containing auth.json
+# one directory per accountId, each pointing at an active generation
 ```
 
 ## 2. Preconditions


### PR DESCRIPTION
## What

Corrective follow-up to the prematurely merged #16293. This closes #16300 by making the Codex one-time refresh-token path fail closed from selection through the periodic account sweep.

- Codex selection reconciles every materialized token generation under the account refresh mutex before any canonical token resolution. Adoption failure propagates; neither `select()` nor the keep-alive sweep can fall through to `getAccessToken` with the consumed token.
- A published `auth.json` is thereafter Codex-owned. The bridge creates a refresh-token-addressed generation with atomic no-replace publication and never overwrites an existing generation, so an external Codex truncate/write cannot lose the only valid rotated pair in an adoption/write gap.
- Stable stat/read/stat retries cover the real truncate-then-write behavior of the external Codex process. Divergent generations require a real parseable `last_refresh`; ambiguous order fails instead of guessing.
- Initial materialization uses the canonical record's observable `updatedAt`, not materialization time, so it cannot invent a fresher OAuth generation.
- `config.toml` and the non-secret `active-home` pointer are atomically replaced and verified. Failure to pin `cli_auth_credentials_store = "file"` aborts the spawn.
- The benchmark adapter follows the validated active generation while preserving the pre-generation account-root layout.

## Correctness boundary

The in-process account mutex serializes reconciliation, canonical persistence, config publication, and selection. An external Codex process cannot honor that mutex, so the bridge removes the conflicting write entirely: after the initial no-replace publish, only Codex writes that generation. A later OAuth login gets a different generation path; reconciliation scans both without clobbering either.

## Verification

Exact head: `e8e16ff5df33aaeecd57c3450c606e684b84e674`, rebased onto `origin/develop` `d993ca4bd140a207310a09b5c918e6a9b6c27b4f`. The rebase absorbed develop's behavior-neutral `PINNED_CODEX_ACP_EFFORTS`->`MANAGED_CODEX_ACP_EFFORTS` rename (from #98d31e159f6) into resolveCodexConfig; the 26 codex-rotation-bridge tests were re-verified green on this head. The linked evidence artifacts below were captured on the pre-rebase head 22682d9 and remain representative because the rotation logic they exercise is unchanged.

- `bun run --cwd packages/app-core test --run src/services/coding-account-bridge.test.ts src/services/multi-account-refresh-failover.test.ts` — 46/46 passed. This includes a real child process that opens the shared auth file with truncation, writes half, fsyncs, pauses while two selectors race, then completes the rotation; exact external bytes survive and the canonical record adopts the rotated pair.
- Changed-file coverage gate — `account-pool.ts` 56.23%, `coding-account-bridge.ts` 89.39%, mean 72.81%; all exceed the 50% per-file threshold.

- `python3 -m pytest packages/benchmarks/codex-adapter/tests -v` — 39/39 passed.
- `bun run --cwd packages/app-core typecheck` — passed.
- changed-file Biome, Black, and Ruff — passed.
- `bun run audit:error-policy-ratchet` — passed; 2 production files checked, no new fallback slop.
- `bun run verify` — passed; 573/573 graph tasks, all audits, zero changed-test realness regressions, and 28/28 dist-path consumer configs.
- `bun run build` — passed before the final rebase (175/175); the exact-head verify rebuilt and typechecked app-core and its dependency graph.

## Evidence rows

<!-- evidence-row:before-screenshots -->
- [x] N/A - server-side credential-file coordination; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - server-side credential-file coordination; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; the external-process interleaving is captured by the exact-head test artifact below.
<!-- evidence-row:backend-logs -->
- [x] [16308-22682d9ddd4d-codex-rotation-tests.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16308-22682d9ddd4d-codex-rotation-tests.json)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser or client execution path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, provider, evaluator, or generated response behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [16308-22682d9ddd4d-codex-rotation-domain.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence/16308-22682d9ddd4d-codex-rotation-domain.json)
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshot evidence or UI text to OCR-review.

Closes #16300





