### PR TITLE
fix(runtime): surface fresh-boot service failures

### DIFF
--- a/packages/agent/src/api/health-routes.services.test.ts
+++ b/packages/agent/src/api/health-routes.services.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Drives service readiness through the real AgentRuntime and health route,
+ * distinguishing boot-critical failures from optional degradation.
+ */
+
+import type http from "node:http";
+import {
+  AgentRuntime,
+  createCharacter,
+  InMemoryDatabaseAdapter,
+  Service,
+} from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  type HealthRouteContext,
+  handleHealthRoutes,
+} from "./health-routes.ts";
+
+const OPTIONAL_TYPE = "health_route_optional_failure";
+const CRITICAL_TYPE = "health_route_critical_failure";
+
+class OptionalFailureService extends Service {
+  static override readonly serviceType = OPTIONAL_TYPE;
+  override capabilityDescription =
+    "Optional failure used by health integration.";
+  static override async start(): Promise<OptionalFailureService> {
+    throw new Error("optional startup failure");
+  }
+  override async stop(): Promise<void> {}
+}
+
+class CriticalFailureService extends Service {
+  static override readonly serviceType = CRITICAL_TYPE;
+  static override readonly bootCritical = true;
+  override capabilityDescription =
+    "Critical failure used by health integration.";
+  static override async start(): Promise<CriticalFailureService> {
+    throw new Error("critical startup failure");
+  }
+  override async stop(): Promise<void> {}
+}
+
+describe("service health route", () => {
+  const runtimes: AgentRuntime[] = [];
+
+  afterEach(async () => {
+    for (const runtime of runtimes.splice(0)) {
+      await runtime.stop();
+      await runtime.close();
+    }
+  });
+
+  async function failingRuntime(
+    service: typeof OptionalFailureService | typeof CriticalFailureService,
+  ): Promise<AgentRuntime> {
+    const runtime = new AgentRuntime({
+      character: createCharacter({ name: "HealthRouteServiceFailure" }),
+      adapter: new InMemoryDatabaseAdapter(),
+      logLevel: "fatal",
+    });
+    runtimes.push(runtime);
+    await runtime.initialize();
+    await runtime.registerPlugin({
+      name: "health-route-service-failure-plugin",
+      description: "Registers a failing health-route integration service.",
+      services: [service],
+    });
+    await expect(
+      runtime.getServiceLoadPromise(service.serviceType),
+    ).rejects.toMatchObject({ code: "SERVICE_START_FAILED" });
+    return runtime;
+  }
+
+  async function requestHealth(runtime: AgentRuntime) {
+    const res = {} as http.ServerResponse;
+    const json = vi.fn<HealthRouteContext["json"]>();
+    await handleHealthRoutes({
+      req: {} as http.IncomingMessage,
+      res,
+      method: "GET",
+      pathname: "/api/health",
+      url: new URL("http://localhost/api/health"),
+      state: {
+        runtime,
+        config: {},
+        agentState: "running",
+        agentName: "HealthRouteServiceFailure",
+        model: undefined,
+        startedAt: Date.now(),
+        startup: { phase: "ready", attempt: 1 },
+        plugins: [],
+        pendingRestartReasons: [],
+        connectorHealthMonitor: null,
+      },
+      json,
+      error: vi.fn<HealthRouteContext["error"]>(),
+    });
+    return { json, res };
+  }
+
+  it("reports an optional service failure as ready but degraded", async () => {
+    const runtime = await failingRuntime(OptionalFailureService);
+    const { json, res } = await requestHealth(runtime);
+    expect(json).toHaveBeenCalledWith(
+      res,
+      expect.objectContaining({
+        ready: true,
+        services: expect.objectContaining({
+          status: "degraded",
+          failed: 1,
+          failures: [
+            expect.objectContaining({
+              serviceType: OPTIONAL_TYPE,
+              serviceClass: "OptionalFailureService",
+              critical: false,
+              message: "optional startup failure",
+            }),
+          ],
+        }),
+      }),
+      200,
+    );
+  });
+
+  it("returns 503 when a boot-critical service fails", async () => {
+    const runtime = await failingRuntime(CriticalFailureService);
+    const { json, res } = await requestHealth(runtime);
+    expect(json).toHaveBeenCalledWith(
+      res,
+      expect.objectContaining({
+        ready: false,
+        services: expect.objectContaining({
+          status: "failed",
+          failed: 1,
+          failures: [
+            expect.objectContaining({
+              serviceType: CRITICAL_TYPE,
+              serviceClass: "CriticalFailureService",
+              critical: true,
+              message: "critical startup failure",
+            }),
+          ],
+        }),
+      }),
+      503,
+    );
+  });
+});

--- a/packages/agent/src/api/health-routes.ts
+++ b/packages/agent/src/api/health-routes.ts
@@ -471,6 +471,110 @@ export function computeCanRespond(
   }
 }
 
+export interface ServiceHealthFailure {
+  serviceType: string;
+  serviceClass: string;
+  plugin?: string;
+  critical: boolean;
+  code: string;
+  message: string;
+}
+
+export type ServiceHealthSummary =
+  | {
+      status: "unavailable";
+      registered: null;
+      pending: null;
+      failed: null;
+      failures: null;
+    }
+  | {
+      status: "healthy" | "loading" | "degraded" | "starting" | "failed";
+      registered: number;
+      pending: number;
+      failed: number;
+      failures: ServiceHealthFailure[];
+    };
+
+/**
+ * Readiness only waits for explicitly boot-critical implementations. Optional
+ * services remain visible as loading/degraded so a connector or feature
+ * failure cannot trap the process in a supervisor restart loop.
+ */
+export function summarizeServiceHealth(
+  runtime: AgentRuntime | null,
+): ServiceHealthSummary {
+  if (!runtime) {
+    return {
+      status: "unavailable",
+      registered: null,
+      pending: null,
+      failed: null,
+      failures: null,
+    };
+  }
+  if (typeof runtime.getServiceHealth !== "function") {
+    return {
+      status: "unavailable",
+      registered: null,
+      pending: null,
+      failed: null,
+      failures: null,
+    };
+  }
+
+  let registered = 0;
+  let pending = 0;
+  let failed = 0;
+  let criticalPending = 0;
+  const failures: ServiceHealthFailure[] = [];
+
+  for (const health of Object.values(runtime.getServiceHealth())) {
+    for (const implementation of health.implementations) {
+      if (implementation.status === "registered") {
+        registered += 1;
+      } else if (
+        implementation.status === "pending" ||
+        implementation.status === "registering"
+      ) {
+        pending += 1;
+        if (implementation.critical) criticalPending += 1;
+      } else if (implementation.status === "failed") {
+        if (!implementation.error) {
+          throw new Error(
+            `Failed service ${implementation.serviceType}/${implementation.serviceClass} has no diagnostic`,
+          );
+        }
+        failed += 1;
+        failures.push({
+          serviceType: implementation.serviceType,
+          serviceClass: implementation.serviceClass,
+          ...(implementation.plugin ? { plugin: implementation.plugin } : {}),
+          critical: implementation.critical,
+          code: implementation.error.code,
+          message: implementation.error.message,
+        });
+      }
+    }
+  }
+  failures.sort((a, b) =>
+    `${a.serviceType}\u0000${a.plugin ?? ""}\u0000${a.serviceClass}`.localeCompare(
+      `${b.serviceType}\u0000${b.plugin ?? ""}\u0000${b.serviceClass}`,
+    ),
+  );
+
+  const status = failures.some((failure) => failure.critical)
+    ? "failed"
+    : criticalPending > 0
+      ? "starting"
+      : failures.length > 0
+        ? "degraded"
+        : pending > 0
+          ? "loading"
+          : "healthy";
+  return { status, registered, pending, failed, failures };
+}
+
 /**
  * Handle health / status / runtime introspection routes.
  * Returns `true` if the request was handled.
@@ -562,6 +666,7 @@ export async function handleHealthRoutes(
       ? runtime.plugins.length
       : state.plugins.filter((p) => p.enabled || p.isActive).length;
     const failedPluginCount = state.plugins.filter((p) => p.loadError).length;
+    const services = summarizeServiceHealth(runtime);
 
     let coordinatorStatus: "ok" | "not_wired" = "not_wired";
     try {
@@ -588,10 +693,16 @@ export async function handleHealthRoutes(
     }
 
     const databaseLiveness = await probeRuntimeDatabaseLiveness(runtime);
+    const serviceReadinessFailed =
+      services.status === "failed" || services.status === "starting";
+    const agentProcessReady =
+      state.agentState === "running" || state.agentState === "paused";
     const ready =
-      state.agentState !== "starting" &&
-      state.agentState !== "restarting" &&
-      !databaseLiveness.terminal;
+      runtime !== null &&
+      agentProcessReady &&
+      !databaseLiveness.terminal &&
+      !serviceReadinessFailed;
+    const terminal = databaseLiveness.terminal || services.status === "failed";
 
     json(
       res,
@@ -611,6 +722,7 @@ export async function handleHealthRoutes(
           loaded: loadedPluginCount,
           failed: failedPluginCount,
         },
+        services,
         coordinator: coordinatorStatus,
         connectors,
         uptime,
@@ -621,7 +733,7 @@ export async function handleHealthRoutes(
         // before hitting feature routes right after boot instead of sleeping.
         deferredBoot: getDeferredBootStatus(),
       },
-      databaseLiveness.terminal ? 503 : 200,
+      terminal ? 503 : 200,
     );
     return true;
   }

--- a/packages/core/src/plugin-lifecycle.ts
+++ b/packages/core/src/plugin-lifecycle.ts
@@ -81,6 +81,15 @@ type RuntimeServiceRegistrationStatus =
 	| "registered"
 	| "failed";
 
+type RuntimeServiceImplementationHealth = {
+	serviceType: string;
+	serviceClass: string;
+	plugin?: string;
+	critical: boolean;
+	status: RuntimeServiceRegistrationStatus;
+	error?: { code: string; message: string };
+};
+
 type RuntimeServicePromiseHandler = {
 	resolve: (service: Service) => void;
 	reject: (error: Error) => void;
@@ -100,6 +109,7 @@ type RuntimeModelHandlerRecord = {
 type RuntimePluginRegistrationCapture = {
 	ownership: PluginOwnership;
 	adapterBefore: IAgentRuntime["adapter"] | null | undefined;
+	serviceCountsBefore: Map<ServiceTypeName, number>;
 };
 
 type RuntimePluginServiceStartCapture = {
@@ -135,6 +145,12 @@ type RuntimePrivateState = {
 		ServiceTypeName,
 		RuntimeServiceRegistrationStatus
 	>;
+	serviceImplementationHealth: Map<
+		RuntimeServiceClass,
+		RuntimeServiceImplementationHealth
+	>;
+	serviceInstancesByClass: Map<RuntimeServiceClass, Service>;
+	servicePluginNames: WeakMap<RuntimeServiceClass, string>;
 	sendHandlers: Map<string, RuntimeSendHandler>;
 	models: Map<string, RuntimeModelHandlerRecord[]>;
 	_runServiceStart?: (
@@ -519,6 +535,33 @@ function pushUniqueService(
 	items.push(next);
 }
 
+function trackRegisteredServiceClasses(
+	privateState: RuntimePrivateState,
+	capture: RuntimePluginRegistrationCapture,
+): void {
+	for (const [serviceType, classes] of privateState.serviceTypes) {
+		const before = capture.serviceCountsBefore.get(serviceType) ?? 0;
+		for (const serviceClass of classes.slice(before)) {
+			serviceClassOwners.set(serviceClass, capture.ownership.pluginName);
+			privateState.servicePluginNames.set(
+				serviceClass,
+				capture.ownership.pluginName,
+			);
+			const health = privateState.serviceImplementationHealth.get(serviceClass);
+			if (health) {
+				privateState.serviceImplementationHealth.set(serviceClass, {
+					...health,
+					plugin: capture.ownership.pluginName,
+				});
+			}
+			pushUniqueService(capture.ownership.services, {
+				serviceType,
+				serviceClass,
+			});
+		}
+	}
+}
+
 function createEmptyOwnership(plugin: Plugin): PluginOwnership {
 	return {
 		pluginName: plugin.name,
@@ -581,20 +624,19 @@ async function stopOwnedServices(
 		}
 
 		const ownedClassSet = new Set(ownedClasses);
-		const removalIndices: number[] = [];
-		currentClasses.forEach((serviceClass, index) => {
-			if (ownedClassSet.has(serviceClass)) {
-				removalIndices.push(index);
-			}
-		});
-
 		const instances = runtime.services.get(key) ?? [];
-		for (const removalIndex of [...removalIndices].sort((a, b) => b - a)) {
-			const instance = instances[removalIndex];
+		for (const ownedClass of ownedClasses) {
+			const instance = privateState.serviceInstancesByClass.get(ownedClass);
 			if (instance && typeof instance.stop === "function") {
 				await instance.stop();
 			}
-			instances.splice(removalIndex, 1);
+			if (instance) {
+				const instanceIndex = instances.indexOf(instance);
+				if (instanceIndex >= 0) {
+					instances.splice(instanceIndex, 1);
+				}
+			}
+			privateState.serviceInstancesByClass.delete(ownedClass);
 		}
 
 		for (const ownedClass of ownedClasses) {
@@ -602,6 +644,8 @@ async function stopOwnedServices(
 				await ownedClass.stopRuntime(runtime);
 			}
 			serviceClassOwners.delete(ownedClass);
+			privateState.serviceImplementationHealth.delete(ownedClass);
+			privateState.servicePluginNames.delete(ownedClass);
 		}
 
 		const remainingClasses = currentClasses.filter(
@@ -1013,6 +1057,18 @@ export function installRuntimePluginLifecycle(runtime: IAgentRuntime): void {
 		const nextClasses = privateState.serviceTypes.get(serviceType) ?? [];
 		for (const registeredClass of nextClasses.slice(serviceTypesBefore)) {
 			serviceClassOwners.set(registeredClass, capture.ownership.pluginName);
+			privateState.servicePluginNames.set(
+				registeredClass,
+				capture.ownership.pluginName,
+			);
+			const health =
+				privateState.serviceImplementationHealth.get(registeredClass);
+			if (health) {
+				privateState.serviceImplementationHealth.set(registeredClass, {
+					...health,
+					plugin: capture.ownership.pluginName,
+				});
+			}
 			pushUniqueService(capture.ownership.services, {
 				serviceType,
 				serviceClass: registeredClass,
@@ -1073,12 +1129,19 @@ export function installRuntimePluginLifecycle(runtime: IAgentRuntime): void {
 		const capture: RuntimePluginRegistrationCapture = {
 			ownership: createEmptyOwnership(plugin),
 			adapterBefore: runtimeWithLifecycle.adapter,
+			serviceCountsBefore: new Map(
+				Array.from(privateState.serviceTypes, ([serviceType, classes]) => [
+					serviceType,
+					classes.length,
+				]),
+			),
 		};
 
 		try {
 			await pluginRegistrationContext.run(capture, async () => {
 				await originalRegisterPlugin(plugin);
 			});
+			trackRegisteredServiceClasses(privateState, capture);
 			trackRoutesAndPluginRef(
 				runtimeWithLifecycle,
 				capture.ownership,
@@ -1104,6 +1167,7 @@ export function installRuntimePluginLifecycle(runtime: IAgentRuntime): void {
 				);
 			}
 		} catch (error) {
+			trackRegisteredServiceClasses(privateState, capture);
 			trackRoutesAndPluginRef(
 				runtimeWithLifecycle,
 				capture.ownership,

--- a/packages/core/src/runtime-service-start-failure.test.ts
+++ b/packages/core/src/runtime-service-start-failure.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Exercises AgentRuntime service startup, rollback, ownership, and per-class
+ * health against the real in-memory adapter.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { createCharacter } from "./character.ts";
+import { InMemoryDatabaseAdapter } from "./database/inMemoryAdapter.ts";
+import { AgentRuntime } from "./runtime.ts";
+import type { IAgentRuntime } from "./types/runtime.ts";
+import { Service } from "./types/service.ts";
+
+const FAILURE_TYPE = "integration_failure_service";
+const MULTI_TYPE = "multi_implementation_service";
+const FINALIZATION_TYPE = "finalization_failure_service";
+let finalizationStopCalls = 0;
+let workingStopCalls = 0;
+
+class FailingService extends Service {
+	static override readonly serviceType = FAILURE_TYPE;
+	override capabilityDescription = "Fails deterministically during startup.";
+	static override async start(): Promise<FailingService> {
+		throw new Error("fresh boot dependency is unavailable");
+	}
+	override async stop(): Promise<void> {}
+}
+
+class FailingMultipleService extends Service {
+	static override readonly serviceType = MULTI_TYPE;
+	static override readonly allowsMultiple = true;
+	override capabilityDescription = "The unavailable implementation.";
+	static override async start(): Promise<FailingMultipleService> {
+		throw new Error("first implementation unavailable");
+	}
+	override async stop(): Promise<void> {}
+}
+
+class WorkingMultipleService extends Service {
+	static override readonly serviceType = MULTI_TYPE;
+	static override readonly allowsMultiple = true;
+	override capabilityDescription = "The available implementation.";
+	static override async start(
+		runtime: IAgentRuntime,
+	): Promise<WorkingMultipleService> {
+		return new WorkingMultipleService(runtime);
+	}
+	override async stop(): Promise<void> {
+		workingStopCalls += 1;
+	}
+}
+
+class LaterWorkingMultipleService extends Service {
+	static override readonly serviceType = MULTI_TYPE;
+	static override readonly allowsMultiple = true;
+	override capabilityDescription =
+		"A late, independently started implementation.";
+	static override async start(
+		runtime: IAgentRuntime,
+	): Promise<LaterWorkingMultipleService> {
+		return new LaterWorkingMultipleService(runtime);
+	}
+	override async stop(): Promise<void> {}
+}
+
+class FinalizationFailingService extends Service {
+	static override readonly serviceType = FINALIZATION_TYPE;
+	override capabilityDescription = "Fails while registering send handlers.";
+	static override async start(
+		runtime: IAgentRuntime,
+	): Promise<FinalizationFailingService> {
+		return new FinalizationFailingService(runtime);
+	}
+	static override registerSendHandlers(runtime: IAgentRuntime): void {
+		runtime.registerSendHandler("partial-finalization", async () => undefined);
+		throw new Error("send-handler finalization failed");
+	}
+	override async stop(): Promise<void> {
+		finalizationStopCalls += 1;
+	}
+}
+
+describe("AgentRuntime service startup observability", () => {
+	const runtimes: AgentRuntime[] = [];
+
+	afterEach(async () => {
+		for (const runtime of runtimes.splice(0)) {
+			await runtime.stop();
+			await runtime.close();
+		}
+	});
+
+	function runtime(name: string): AgentRuntime {
+		const instance = new AgentRuntime({
+			character: createCharacter({ name }),
+			adapter: new InMemoryDatabaseAdapter(),
+			logLevel: "fatal",
+		});
+		runtimes.push(instance);
+		return instance;
+	}
+
+	it("reports a typed, plugin-attributed failure", async () => {
+		const instance = runtime("ServiceFailureIntegration");
+		await instance.initialize();
+		await instance.registerPlugin({
+			name: "service-failure-integration-plugin",
+			description: "Registers a service whose real start method fails.",
+			services: [FailingService],
+		});
+
+		await expect(
+			instance.getServiceLoadPromise(FAILURE_TYPE),
+		).rejects.toMatchObject({
+			code: "SERVICE_START_FAILED",
+			message: "fresh boot dependency is unavailable",
+		});
+		expect(instance.getServiceHealth()[FAILURE_TYPE]).toMatchObject({
+			status: "failed",
+			instances: 0,
+			implementations: [
+				{
+					serviceClass: "FailingService",
+					plugin: "service-failure-integration-plugin",
+					status: "failed",
+					error: {
+						code: "SERVICE_START_FAILED",
+						message: "fresh boot dependency is unavailable",
+					},
+				},
+			],
+		});
+		expect(instance.getRecentReportedErrors()).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					scope: "AgentRuntime.serviceStart",
+					context: expect.objectContaining({
+						plugin: "service-failure-integration-plugin",
+						serviceType: FAILURE_TYPE,
+						serviceClass: "FailingService",
+					}),
+				}),
+			]),
+		);
+	});
+
+	it("retains a failed sibling when another implementation succeeds", async () => {
+		const instance = runtime("MultiServiceIntegration");
+		await instance.initialize();
+		await instance.registerPlugin({
+			name: "multi-service-integration-plugin",
+			description: "Registers unavailable and available implementations.",
+			services: [FailingMultipleService, WorkingMultipleService],
+		});
+
+		await expect(
+			instance.getServiceLoadPromise(MULTI_TYPE),
+		).resolves.toBeInstanceOf(WorkingMultipleService);
+		expect(instance.getServiceRegistrationStatus(MULTI_TYPE)).toBe(
+			"registered",
+		);
+		expect(instance.getServiceHealth()[MULTI_TYPE]).toMatchObject({
+			status: "degraded",
+			instances: 1,
+			implementations: expect.arrayContaining([
+				expect.objectContaining({
+					serviceClass: "FailingMultipleService",
+					status: "failed",
+				}),
+				expect.objectContaining({
+					serviceClass: "WorkingMultipleService",
+					status: "registered",
+				}),
+			]),
+		});
+	});
+
+	it("starts a late implementation even when the type already has an instance", async () => {
+		const instance = runtime("LateMultiServiceIntegration");
+		await instance.initialize();
+		await instance.registerPlugin({
+			name: "first-multi-service-plugin",
+			description: "Registers the first implementation.",
+			services: [WorkingMultipleService],
+		});
+		await expect(
+			instance.getServiceLoadPromise(MULTI_TYPE),
+		).resolves.toBeInstanceOf(WorkingMultipleService);
+
+		await instance.registerPlugin({
+			name: "later-multi-service-plugin",
+			description: "Registers the later implementation.",
+			services: [LaterWorkingMultipleService],
+		});
+		await expect(
+			instance.getServiceLoadPromise(MULTI_TYPE),
+		).resolves.toBeInstanceOf(WorkingMultipleService);
+		expect(instance.getServicesByType(MULTI_TYPE)).toHaveLength(2);
+		expect(instance.getServiceHealth()[MULTI_TYPE]).toMatchObject({
+			status: "registered",
+			instances: 2,
+		});
+	});
+
+	it("unloading a failed implementation does not stop a healthy sibling", async () => {
+		workingStopCalls = 0;
+		const instance = runtime("MultiServiceUnloadIntegration");
+		await instance.initialize();
+		await instance.registerPlugin({
+			name: "failing-multi-service-plugin",
+			description: "Registers the unavailable implementation.",
+			services: [FailingMultipleService],
+		});
+		await expect(
+			instance.getServiceLoadPromise(MULTI_TYPE),
+		).rejects.toMatchObject({ code: "SERVICE_START_FAILED" });
+		await instance.registerPlugin({
+			name: "working-multi-service-plugin",
+			description: "Registers the available implementation.",
+			services: [WorkingMultipleService],
+		});
+		await expect(
+			instance.getServiceLoadPromise(MULTI_TYPE),
+		).resolves.toBeInstanceOf(WorkingMultipleService);
+
+		await instance.unloadPlugin("failing-multi-service-plugin");
+		expect(workingStopCalls).toBe(0);
+		expect(instance.getService(MULTI_TYPE)).toBeInstanceOf(
+			WorkingMultipleService,
+		);
+		expect(instance.getServiceHealth()[MULTI_TYPE]).toMatchObject({
+			status: "registered",
+			instances: 1,
+			implementations: [
+				expect.objectContaining({
+					serviceClass: "WorkingMultipleService",
+					status: "registered",
+				}),
+			],
+		});
+	});
+
+	it("rolls back a service whose send-handler finalization fails", async () => {
+		finalizationStopCalls = 0;
+		let originalSendCalls = 0;
+		const instance = runtime("ServiceFinalizationIntegration");
+		await instance.initialize();
+		instance.registerSendHandler("partial-finalization", async () => {
+			originalSendCalls += 1;
+			return undefined;
+		});
+		await instance.registerPlugin({
+			name: "service-finalization-integration-plugin",
+			description: "Registers a service with a failing finalization hook.",
+			services: [FinalizationFailingService],
+		});
+
+		await expect(
+			instance.getServiceLoadPromise(FINALIZATION_TYPE),
+		).rejects.toMatchObject({
+			code: "SERVICE_START_FAILED",
+			message: "send-handler finalization failed",
+		});
+		expect(instance.getService(FINALIZATION_TYPE)).toBeNull();
+		await instance.sendMessageToTarget(
+			{ source: "partial-finalization" },
+			{ text: "restored handler", agentVoiced: true },
+		);
+		expect(originalSendCalls).toBe(1);
+		expect(finalizationStopCalls).toBe(1);
+	});
+});

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -241,7 +241,10 @@ import {
 	type SendHandlerFunction,
 	type Service,
 	type ServiceClass,
+	type ServiceImplementationHealth,
+	type ServiceRegistrationStatus,
 	ServiceType,
+	type ServiceTypeHealth,
 	type ServiceTypeName,
 	type SetConnectorAccountCredentialRefParams,
 	type State,
@@ -651,6 +654,10 @@ type ServicePromiseHandler = {
 	resolve: ServiceResolver;
 	reject: ServiceRejecter;
 };
+
+type ServiceStartOutcome =
+	| { service: Service; error?: never }
+	| { service: null; error?: ElizaError };
 
 function isTextStreamResult(
 	value: JsonValue | object,
@@ -1122,8 +1129,17 @@ export class AgentRuntime implements IAgentRuntime {
 	private startingServices = new Map<string, Promise<Service | null>>();
 	private serviceRegistrationStatus = new Map<
 		ServiceTypeName,
-		"pending" | "registering" | "registered" | "failed"
+		ServiceRegistrationStatus
 	>(); // status tracking
+	/** Per-class state prevents one healthy implementation from hiding a sibling failure. */
+	private serviceImplementationHealth = new Map<
+		ServiceClass,
+		ServiceImplementationHealth
+	>();
+	private serviceInstancesByClass = new Map<ServiceClass, Service>();
+	/** Service startup happens after plugin registration, so ownership must survive that boundary. */
+	private servicePluginNames = new WeakMap<ServiceClass, string>();
+	private reportedServiceStartFailures = new WeakSet<ElizaError>();
 	public initPromise: Promise<void>;
 	private initResolver:
 		| ((value?: void | PromiseLike<void>) => void)
@@ -2225,6 +2241,18 @@ export class AgentRuntime implements IAgentRuntime {
 					this._createServiceResolver(serviceType);
 				}
 				this.serviceRegistrationStatus.set(serviceType, "pending");
+				this.servicePluginNames.set(
+					service,
+					pluginToRegister.packageName ?? pluginToRegister.name,
+				);
+				this.serviceImplementationHealth.set(service, {
+					serviceType,
+					serviceClass:
+						(service as { name?: string }).name || "AnonymousService",
+					plugin: pluginToRegister.packageName ?? pluginToRegister.name,
+					critical: service.bootCritical === true,
+					status: "pending",
+				});
 				if (!this.serviceTypes.has(serviceType)) {
 					this.serviceTypes.set(serviceType, []);
 				}
@@ -2244,17 +2272,19 @@ export class AgentRuntime implements IAgentRuntime {
 				// Fire-and-forget: cannot await here because _runServiceStart
 				// awaits initPromise which resolves after initialize() completes
 				// (after all registerPlugin calls finish). Awaiting would deadlock.
+				// error-policy:J1 the detached startup boundary reports dispatcher
+				// failures not already reported by the service boundary.
 				this._ensureServiceStarted(serviceType).catch((err) => {
-					this.logger.error(
-						{
-							src: "agent",
-							agentId: this.agentId,
-							plugin: pluginToRegister.name,
-							serviceType,
-							error: err instanceof Error ? err.message : String(err),
-						},
-						"Service start failed",
-					);
+					if (
+						err instanceof ElizaError &&
+						this.reportedServiceStartFailures.has(err)
+					) {
+						return;
+					}
+					this.reportError("AgentRuntime.serviceStartDispatch", err, {
+						plugin: pluginToRegister.name,
+						serviceType,
+					});
 				});
 			}
 		}
@@ -2435,6 +2465,7 @@ export class AgentRuntime implements IAgentRuntime {
 		this.servicePromises.clear();
 		this.servicePromiseHandlers.clear();
 		this.startingServices.clear();
+		this.serviceInstancesByClass.clear();
 	}
 
 	private async _stopServiceInstance(
@@ -4793,10 +4824,15 @@ export class AgentRuntime implements IAgentRuntime {
 		if (!this.isNativeFeatureServiceEnabled(serviceType)) return null;
 		const key = this.resolveServiceTypeAlias(serviceType) as ServiceTypeName;
 		const instances = this.services.get(key);
-		if (instances && instances.length > 0) {
+		const classes = this.serviceTypes.get(key);
+		const hasPendingImplementation = classes?.some(
+			(serviceClass) =>
+				this.serviceImplementationHealth.get(serviceClass)?.status ===
+				"pending",
+		);
+		if (instances && instances.length > 0 && !hasPendingImplementation) {
 			return instances[0];
 		}
-		const classes = this.serviceTypes.get(key);
 		if (!classes || classes.length === 0) {
 			return null;
 		}
@@ -4805,10 +4841,30 @@ export class AgentRuntime implements IAgentRuntime {
 			// Start ALL registered service classes for this type, not just the first.
 			// This supports multiple services of the same type (e.g. multiple wallet services).
 			inFlight = (async () => {
-				let first: Service | null = null;
-				for (const cls of classes) {
-					const result = await this._runServiceStart(key, serviceType, cls);
-					if (result && !first) first = result;
+				let first: Service | null = this.services.get(key)?.[0] ?? null;
+				let lastError: ElizaError | undefined;
+				for (;;) {
+					const pendingClasses = classes.filter(
+						(serviceClass) =>
+							this.serviceImplementationHealth.get(serviceClass)?.status ===
+							"pending",
+					);
+					if (pendingClasses.length === 0) break;
+					for (const cls of pendingClasses) {
+						const outcome = await this._runServiceStart(key, serviceType, cls);
+						if (outcome.service && !first) first = outcome.service;
+						if (outcome.error) lastError = outcome.error;
+					}
+				}
+				this.refreshServiceRegistrationStatus(key);
+				if (!first && lastError) {
+					const handler = this.servicePromiseHandlers.get(serviceType);
+					if (handler) {
+						handler.reject(lastError);
+						this.servicePromiseHandlers.delete(serviceType);
+						this.servicePromises.delete(serviceType);
+					}
+					throw lastError;
 				}
 				return first;
 			})();
@@ -4821,31 +4877,135 @@ export class AgentRuntime implements IAgentRuntime {
 		}
 	}
 
+	private updateServiceImplementationHealth(
+		serviceDef: ServiceClass,
+		key: ServiceTypeName,
+		status: ServiceRegistrationStatus,
+		error?: ElizaError,
+	): void {
+		const current = this.serviceImplementationHealth.get(serviceDef);
+		this.serviceImplementationHealth.set(serviceDef, {
+			serviceType: String(key),
+			serviceClass:
+				current?.serviceClass ??
+				(serviceDef as { name?: string }).name ??
+				"AnonymousService",
+			plugin: current?.plugin ?? this.servicePluginNames.get(serviceDef),
+			critical: current?.critical ?? serviceDef.bootCritical === true,
+			status,
+			...(error
+				? {
+						error: {
+							code: error.code,
+							message: error.message,
+						},
+					}
+				: {}),
+		});
+	}
+
+	private refreshServiceRegistrationStatus(key: ServiceTypeName): void {
+		const classes = this.serviceTypes.get(key) ?? [];
+		const statuses = classes
+			.map(
+				(serviceClass) =>
+					this.serviceImplementationHealth.get(serviceClass)?.status,
+			)
+			.filter((status): status is ServiceRegistrationStatus => Boolean(status));
+		if (statuses.includes("registering")) {
+			this.serviceRegistrationStatus.set(key, "registering");
+		} else if (statuses.includes("pending")) {
+			this.serviceRegistrationStatus.set(key, "pending");
+		} else if (statuses.includes("registered")) {
+			this.serviceRegistrationStatus.set(key, "registered");
+		} else if (statuses.includes("failed")) {
+			this.serviceRegistrationStatus.set(key, "failed");
+		} else {
+			this.serviceRegistrationStatus.delete(key);
+		}
+	}
+
+	private recordServiceStartFailure(
+		key: ServiceTypeName,
+		requestedServiceType: string,
+		serviceDef: ServiceClass,
+		error: unknown,
+	): ElizaError {
+		const serviceClass =
+			(serviceDef as { name?: string }).name || "AnonymousService";
+		const plugin = this.servicePluginNames.get(serviceDef);
+		const context = {
+			agentId: this.agentId,
+			serviceType: String(key),
+			requestedServiceType,
+			serviceClass,
+			...(plugin ? { plugin } : {}),
+		};
+		const structured =
+			error instanceof ElizaError
+				? error
+				: new ElizaError(
+						error instanceof Error
+							? error.message
+							: `Service ${String(key)} failed to start`,
+						{
+							code: "SERVICE_START_FAILED",
+							cause: error,
+							context,
+						},
+					);
+		this.updateServiceImplementationHealth(
+			serviceDef,
+			key,
+			"failed",
+			structured,
+		);
+		this.refreshServiceRegistrationStatus(key);
+		this.reportedServiceStartFailures.add(structured);
+		this.reportError("AgentRuntime.serviceStart", structured, context);
+		return structured;
+	}
+
 	/** Runs one service start; used by _ensureServiceStarted with startingServices dedupe. */
 	private async _runServiceStart(
 		key: ServiceTypeName,
 		serviceType: string,
 		serviceDef: ServiceClass,
-	): Promise<Service | null> {
-		this.serviceRegistrationStatus.set(key, "registering");
+	): Promise<ServiceStartOutcome> {
+		this.updateServiceImplementationHealth(serviceDef, key, "registering");
+		this.refreshServiceRegistrationStatus(key);
 		await this.initPromise;
 		if (typeof serviceDef.start !== "function") {
-			this.logger.error(
-				{ src: "agent", agentId: this.agentId, serviceType },
-				"Service class has no static start method",
+			const error = this.recordServiceStartFailure(
+				key,
+				serviceType,
+				serviceDef,
+				new ElizaError("Service class has no static start method", {
+					code: "SERVICE_START_METHOD_MISSING",
+				}),
 			);
-			this.serviceRegistrationStatus.set(key, "failed");
-			return null;
+			return { service: null, error };
 		}
+		let serviceInstance: Service | null = null;
+		let sendHandlersBefore: Map<string, SendHandlerFunction> | null = null;
+		let messageConnectorsBefore: Map<string, MessageConnector> | null = null;
 		try {
 			if (this.stopped) {
-				this.serviceRegistrationStatus.set(key, "failed");
-				return null;
+				this.serviceImplementationHealth.delete(serviceDef);
+				this.refreshServiceRegistrationStatus(key);
+				return { service: null };
 			}
-			const serviceInstance = await serviceDef.start(this);
+			serviceInstance = await serviceDef.start(this);
 			if (!serviceInstance) {
-				this.serviceRegistrationStatus.set(key, "failed");
-				return null;
+				const error = this.recordServiceStartFailure(
+					key,
+					serviceType,
+					serviceDef,
+					new ElizaError("Service start returned no instance", {
+						code: "SERVICE_START_RETURNED_NO_INSTANCE",
+					}),
+				);
+				return { service: null, error };
 			}
 			if (this.stopped) {
 				await this._stopServiceInstance(
@@ -4853,8 +5013,14 @@ export class AgentRuntime implements IAgentRuntime {
 					serviceInstance,
 					"late service start after runtime stop",
 				);
-				this.serviceRegistrationStatus.set(key, "failed");
-				return null;
+				this.serviceImplementationHealth.delete(serviceDef);
+				this.refreshServiceRegistrationStatus(key);
+				return { service: null };
+			}
+			if (serviceDef.registerSendHandlers) {
+				sendHandlersBefore = new Map(this.sendHandlers);
+				messageConnectorsBefore = new Map(this.messageConnectors);
+				serviceDef.registerSendHandlers(this, serviceInstance);
 			}
 			if (!this.services.has(key)) {
 				this.services.set(key, []);
@@ -4863,30 +5029,48 @@ export class AgentRuntime implements IAgentRuntime {
 			if (serviceList) {
 				serviceList.push(serviceInstance);
 			}
+			this.serviceInstancesByClass.set(serviceDef, serviceInstance);
+			this.updateServiceImplementationHealth(serviceDef, key, "registered");
+			this.refreshServiceRegistrationStatus(key);
 			const handler = this.servicePromiseHandlers.get(serviceType);
 			if (handler) {
 				handler.resolve(serviceInstance);
 				this.servicePromiseHandlers.delete(serviceType);
 			}
-			if (serviceDef.registerSendHandlers) {
-				serviceDef.registerSendHandlers(this, serviceInstance);
-			}
-			this.serviceRegistrationStatus.set(key, "registered");
-			return serviceInstance;
+			return { service: serviceInstance };
 		} catch (error) {
-			this.reportError("AgentRuntime.serviceStart", error, {
-				serviceType,
-			});
-			const handler = this.servicePromiseHandlers.get(serviceType);
-			if (handler) {
-				handler.reject(
-					error instanceof Error ? error : new Error(String(error)),
-				);
-				this.servicePromiseHandlers.delete(serviceType);
-				this.servicePromises.delete(serviceType);
+			// error-policy:J1 each implementation is an independent lifecycle
+			// boundary; preserve sibling startup while recording this failure.
+			if (serviceInstance) {
+				const published = this.services.get(key);
+				const publishedIndex = published?.indexOf(serviceInstance) ?? -1;
+				if (published && publishedIndex >= 0) {
+					published.splice(publishedIndex, 1);
+				}
+				this.serviceInstancesByClass.delete(serviceDef);
 			}
-			this.serviceRegistrationStatus.set(key, "failed");
-			return null;
+			if (sendHandlersBefore) {
+				this.sendHandlers = sendHandlersBefore;
+			}
+			if (messageConnectorsBefore) {
+				this.messageConnectors = messageConnectorsBefore;
+			}
+			if (serviceInstance) {
+				await this._stopServiceInstance(
+					key,
+					serviceInstance,
+					"service start finalization failed",
+				);
+			}
+			return {
+				service: null,
+				error: this.recordServiceStartFailure(
+					key,
+					serviceType,
+					serviceDef,
+					error,
+				),
+			};
 		}
 	}
 
@@ -4984,41 +5168,42 @@ export class AgentRuntime implements IAgentRuntime {
 	 * Get service health information
 	 * @returns Object containing service health status
 	 */
-	getServiceHealth(): Record<
-		string,
-		{
-			status: "pending" | "registering" | "registered" | "failed" | "unknown";
-			instances: number;
-			hasPromise: boolean;
-		}
-	> {
-		const health: Record<
-			string,
-			{
-				status: "pending" | "registering" | "registered" | "failed" | "unknown";
-				instances: number;
-				hasPromise: boolean;
-			}
-		> = {};
+	getServiceHealth(): Record<string, ServiceTypeHealth> {
+		const health: Record<string, ServiceTypeHealth> = {};
 
-		// Check all registered services
-		for (const [serviceType, instances] of this.services) {
+		const serviceTypes = new Set<string>([
+			...this.serviceTypes.keys(),
+			...this.services.keys(),
+			...this.serviceRegistrationStatus.keys(),
+		]);
+		for (const serviceType of serviceTypes) {
+			const implementations = Array.from(
+				this.serviceImplementationHealth.values(),
+			).filter((entry) => entry.serviceType === serviceType);
+			const statuses = implementations.map((entry) => entry.status);
+			const instances =
+				this.services.get(serviceType as ServiceTypeName)?.length ?? 0;
+			const status =
+				statuses.includes("failed") && statuses.includes("registered")
+					? "degraded"
+					: statuses.includes("failed")
+						? "failed"
+						: statuses.includes("registering")
+							? "registering"
+							: statuses.includes("pending")
+								? "pending"
+								: statuses.includes("registered")
+									? "registered"
+									: "unknown";
 			health[serviceType] = {
-				status: this.getServiceRegistrationStatus(serviceType),
-				instances: instances.length,
+				status,
+				instances,
 				hasPromise: this.servicePromises.has(serviceType),
+				implementations: implementations.map((entry) => ({
+					...entry,
+					...(entry.error ? { error: { ...entry.error } } : {}),
+				})),
 			};
-		}
-
-		// Check services that have registration status but no instances yet
-		for (const [serviceType, status] of this.serviceRegistrationStatus) {
-			if (!health[serviceType]) {
-				health[serviceType] = {
-					status,
-					instances: 0,
-					hasPromise: this.servicePromises.has(serviceType),
-				};
-			}
 		}
 
 		return health;
@@ -5041,6 +5226,13 @@ export class AgentRuntime implements IAgentRuntime {
 		);
 
 		this.serviceRegistrationStatus.set(serviceType, "pending");
+		this.serviceImplementationHealth.set(serviceDef, {
+			serviceType,
+			serviceClass:
+				(serviceDef as { name?: string }).name || "AnonymousService",
+			critical: serviceDef.bootCritical === true,
+			status: "pending",
+		});
 		if (!this.servicePromises.has(serviceType)) {
 			this._createServiceResolver(serviceType);
 		}

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -42,6 +42,8 @@ export interface ServiceClass {
 	serviceType: string;
 	/** True when multiple implementations may intentionally share this service type. */
 	allowsMultiple?: boolean;
+	/** A failed implementation prevents process readiness instead of reporting degraded health. */
+	bootCritical?: boolean;
 	/** Factory method to create and start the service */
 	start(runtime: IAgentRuntime): Promise<Service>;
 	/** Stop service for a runtime - optional as not all services implement this */

--- a/packages/core/src/types/service.ts
+++ b/packages/core/src/types/service.ts
@@ -64,6 +64,31 @@ export interface ServiceTypeRegistry {
  */
 export type ServiceTypeName = ServiceTypeRegistry[keyof ServiceTypeRegistry];
 
+export type ServiceRegistrationStatus =
+	| "pending"
+	| "registering"
+	| "registered"
+	| "failed";
+
+export interface ServiceImplementationHealth {
+	serviceType: string;
+	serviceClass: string;
+	plugin?: string;
+	critical: boolean;
+	status: ServiceRegistrationStatus;
+	error?: {
+		code: string;
+		message: string;
+	};
+}
+
+export interface ServiceTypeHealth {
+	status: ServiceRegistrationStatus | "degraded" | "unknown";
+	instances: number;
+	hasPromise: boolean;
+	implementations: ServiceImplementationHealth[];
+}
+
 /**
  * Helper type to extract service type values from the registry
  */
@@ -84,6 +109,7 @@ export type TypedServiceClass<T extends ServiceTypeName> = {
 	new (runtime?: IAgentRuntime): Service;
 	serviceType: T;
 	allowsMultiple?: boolean;
+	bootCritical?: boolean;
 	start(runtime: IAgentRuntime): Promise<Service>;
 };
 
@@ -186,6 +212,9 @@ export abstract class Service {
 
 	/** True when multiple implementations may intentionally share this service type. */
 	static allowsMultiple?: boolean;
+
+	/** A failed implementation prevents process readiness instead of reporting degraded health. */
+	static bootCritical?: boolean;
 
 	/** Service name */
 	abstract capabilityDescription: string;


### PR DESCRIPTION
# Relates to

Fixes #16309

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This draft targets `develop` and is rebased onto the latest fetched `origin/develop`.
- [x] `bun run install:light` and `bun run verify` passed after sync.
- [ ] Attach and manually review the final isolated fresh-boot logs and domain state before marking ready.

# Sync with develop

- [x] Rebased onto `origin/develop` at `b6f1f4ffcb2bc5652f74978208701132a4b28d68`; zero conflicts.
- [x] Commit under review: `d2b07d22499b56bfebfa4ef745323fd21cec42eb`.
- [x] Post-sync `bun run verify` passed: 573/573 Turbo tasks plus every follow-on repository audit.

# Background

A clean boot could report settled health after service startup failed. The failure was logged and converted to `null`, late plugin schema work could race service startup, and scheduling seeded tasks before its runner was registered. Those independent paths made broken initialization look healthy.

This change makes boot state transactional and observable:

- Service startup failures are typed, reported with plugin/service context, and retained in structured boot health.
- Handler and service registration roll back when startup/finalization fails.
- Late plugin registration serializes schema work before starting dependent services.
- Scheduling registers its runner structurally before the seed service runs.
- Personal-assistant scheduling contributions use the shared scheduling service boundary.
- Health and readiness distinguish pending, successful, and failed service initialization.

# Risks

Medium-high. This changes core plugin/service lifecycle ordering and intentionally turns formerly hidden initialization failures into unhealthy readiness. The added rollback and real PGlite integration coverage protect the affected paths, but final packaged fresh-state boot logs remain an explicit draft gate.

# Testing

A reviewer can start with:

```bash
bun test   packages/core/src/runtime-service-start-failure.test.ts   packages/agent/src/api/health-routes.services.test.ts   packages/agent/src/runtime/late-plugin-schema.test.ts   plugins/plugin-scheduling/src/plugin.test.ts
```

Validated locally:

- Focused runtime, health, real-PGlite late-schema, and scheduling tests: 54 passed.
- Additional real-PGlite late-plugin schema rerun: 2 passed.
- Agent, core, scheduling, and personal-assistant scoped typechecks: passed.
- Full repository build: passed.
- Error-policy ratchet: passed.
- Post-rebase `bun run verify`: passed, 573/573 Turbo tasks and all repository audits.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - headless runtime initialization; no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - headless runtime initialization; no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no user-visible screen or interaction flow.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs: pending final isolated packaged fresh-state boot capture and manual review before ready-for-review.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend path changes.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no model, prompt, provider, action, or planner behavior changes.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: real PGlite schema/registry/health outcomes are asserted by integration tests; attach the final isolated boot health payload and database/service evidence before ready-for-review.

# Known gaps

This remains a draft until the exact-head packaged-runtime fresh boot is captured and its structured logs, health payload, schema state, and scheduling registry state are manually reviewed and attached inline. No publishing or registry mutation is performed by this PR.
