### PR TITLE
feat(ui): multi-account manager with reauthenticate flow [draft]

### DIFF
--- a/packages/agent/src/api/accounts-routes.test.ts
+++ b/packages/agent/src/api/accounts-routes.test.ts
@@ -10,11 +10,18 @@ const fakes = vi.hoisted(() => ({
   poolAccounts: [] as Array<Record<string, unknown>>,
   deleteAccount: vi.fn(),
   getAccessToken: vi.fn(async () => "access-token"),
-  probeDirectApiKey: vi.fn(async () => ({
-    ok: true,
-    status: 200,
-    latencyMs: 4,
-  })),
+  probeDirectApiKey: vi.fn(
+    async (): Promise<{
+      ok: boolean;
+      status: number;
+      latencyMs: number;
+      error?: string;
+    }> => ({
+      ok: true,
+      status: 200,
+      latencyMs: 4,
+    }),
+  ),
   saveAccount: vi.fn(),
   submitFlowCode: vi.fn(() => true),
   cancelFlow: vi.fn(() => true),
@@ -208,14 +215,20 @@ describe("accounts routes", () => {
     ).toMatchObject({
       strategy: "priority",
       accounts: [{ id: "account-1", hasCredential: true }],
-      runtimeEligibility: { chat: true, codingAgent: true },
+      runtimeEligibility: {
+        chat: { available: true, credentialPath: "direct-api" },
+        codingAgent: { available: true, credentialPath: "direct-api" },
+      },
     });
     expect(
       response.providers.find(
         (item) => item.providerId === "anthropic-subscription",
       ),
     ).toMatchObject({
-      runtimeEligibility: { chat: false, codingAgent: true },
+      runtimeEligibility: {
+        chat: { available: false, credentialPath: "none" },
+        codingAgent: { available: true, credentialPath: "account-pool" },
+      },
     });
   });
 
@@ -274,6 +287,187 @@ describe("accounts routes", () => {
     await handleAccountsRoutes(deleted.ctx);
     expect(fakes.deleteAccount).toHaveBeenCalledWith("openai-api", "account-1");
     expect(deleted.jsonCalls[0]?.body).toEqual({ deleted: true });
+  });
+
+  it("verifies and replaces an API credential in place without duplicating the account", async () => {
+    const target = {
+      ...linkedAccount,
+      health: "invalid",
+      healthDetail: { lastError: "credential rejected" },
+    };
+    fakes.poolAccounts = [target];
+    fakes.accounts = [
+      {
+        id: "account-1",
+        providerId: "openai-api",
+        label: "Primary",
+        source: "api-key",
+        credentials: { access: "old-secret" },
+        createdAt: 1,
+      },
+    ];
+    const replaced = makeContext("POST", "/api/accounts/openai-api", {
+      source: "api-key",
+      label: "Primary",
+      apiKey: "new-secret-value",
+      replaceAccountId: "account-1",
+    });
+    await handleAccountsRoutes(replaced.ctx);
+
+    expect(fakes.probeDirectApiKey).toHaveBeenCalledWith(
+      "openai-api",
+      "new-secret-value",
+    );
+    expect(fakes.saveAccount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "account-1",
+        label: "Primary",
+        credentials: expect.objectContaining({ access: "new-secret-value" }),
+      }),
+    );
+    expect(replaced.jsonCalls[0]).toMatchObject({
+      status: 200,
+      body: { id: "account-1", health: "ok" },
+    });
+    expect(replaced.jsonCalls[0]?.body).not.toHaveProperty("healthDetail");
+    expect(fakes.poolAccounts).toHaveLength(1);
+  });
+
+  it("leaves an API credential unchanged when its replacement cannot be verified", async () => {
+    fakes.poolAccounts = [{ ...linkedAccount, health: "invalid" }];
+    fakes.accounts = [
+      {
+        id: "account-1",
+        providerId: "openai-api",
+        label: "Primary",
+        credentials: { access: "old-secret" },
+      },
+    ];
+    fakes.probeDirectApiKey.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      latencyMs: 4,
+      error: "credential rejected",
+    });
+    const replaced = makeContext("POST", "/api/accounts/openai-api", {
+      source: "api-key",
+      label: "Primary",
+      apiKey: "bad-secret-value",
+      replaceAccountId: "account-1",
+    });
+    await handleAccountsRoutes(replaced.ctx);
+
+    expect(replaced.errorCalls).toEqual([
+      { message: "credential rejected", status: 400 },
+    ]);
+    expect(fakes.saveAccount).not.toHaveBeenCalled();
+    expect(fakes.poolAccounts[0]).toMatchObject({ health: "invalid" });
+  });
+
+  it("binds OAuth replacement to an existing same-provider account", async () => {
+    const target = {
+      id: "codex-work",
+      providerId: "openai-codex",
+      label: "Work Codex",
+      source: "oauth",
+      enabled: true,
+      priority: 3,
+      createdAt: 10,
+      health: "needs-reauth",
+      healthDetail: { lastError: "expired" },
+    };
+    fakes.poolAccounts = [target];
+    fakes.accounts = [{ ...target, credentials: { access: "old" } }];
+    const started = makeContext(
+      "POST",
+      "/api/accounts/openai-codex/oauth/start",
+      {
+        label: "Work Codex",
+        mode: "auto",
+        replaceAccountId: "codex-work",
+      },
+    );
+    await handleAccountsRoutes(started.ctx);
+
+    expect(fakes.startFlow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "codex-work",
+        replaceAccountId: "codex-work",
+      }),
+    );
+    const startCalls = fakes.startFlow.mock.calls as unknown as Array<
+      [
+        {
+          onAccountSaved: (record: Record<string, unknown>) => Promise<void>;
+        },
+      ]
+    >;
+    const options = startCalls[0]?.[0];
+    expect(options).toBeDefined();
+    await options?.onAccountSaved({
+      id: "codex-work",
+      providerId: "openai-codex",
+      label: "Work Codex",
+      source: "oauth",
+      createdAt: 10,
+      updatedAt: 20,
+    });
+    expect(fakes.poolAccounts).toHaveLength(1);
+    expect(fakes.poolAccounts[0]).toMatchObject({
+      id: "codex-work",
+      priority: 3,
+      health: "ok",
+    });
+  });
+
+  it("fails closed when an OAuth replacement target is missing or belongs to another provider", async () => {
+    const missing = makeContext(
+      "POST",
+      "/api/accounts/openai-codex/oauth/start",
+      { label: "Missing", replaceAccountId: "gone" },
+    );
+    await handleAccountsRoutes(missing.ctx);
+    expect(missing.errorCalls).toEqual([
+      { message: "Replacement account not found", status: 404 },
+    ]);
+
+    fakes.poolAccounts = [
+      { ...linkedAccount, id: "wrong-provider", providerId: "openai-api" },
+    ];
+    const mismatch = makeContext(
+      "POST",
+      "/api/accounts/openai-codex/oauth/start",
+      { label: "Wrong", replaceAccountId: "wrong-provider" },
+    );
+    await handleAccountsRoutes(mismatch.ctx);
+    expect(mismatch.errorCalls).toEqual([
+      {
+        message: "Replacement account belongs to a different provider",
+        status: 400,
+      },
+    ]);
+    expect(fakes.startFlow).not.toHaveBeenCalled();
+  });
+
+  it("keeps terminal credential health terminal during usage refresh", async () => {
+    fakes.poolAccounts = [
+      {
+        ...linkedAccount,
+        health: "needs-reauth",
+        healthDetail: { lastError: "refresh token revoked", lastChecked: 1 },
+      },
+    ];
+    const refreshed = makeContext(
+      "POST",
+      "/api/accounts/openai-api/account-1/refresh-usage",
+    );
+    await handleAccountsRoutes(refreshed.ctx);
+    expect(refreshed.jsonCalls[0]?.body).toMatchObject({
+      account: {
+        health: "needs-reauth",
+        healthDetail: { lastError: "refresh token revoked", lastChecked: 1 },
+      },
+    });
   });
 
   it("starts and controls OAuth flows and validates the status stream", async () => {

--- a/packages/agent/src/api/accounts-routes.ts
+++ b/packages/agent/src/api/accounts-routes.ts
@@ -309,11 +309,13 @@ const apiKeyAccountSchema = z.object({
   source: z.literal("api-key"),
   label: z.string().trim().min(1).max(120),
   apiKey: z.string().min(8).max(2048),
+  replaceAccountId: z.string().trim().min(1).max(200).optional(),
 });
 
 const oauthStartSchema = z.object({
   label: z.string().trim().min(1).max(120),
   mode: z.enum(["auto", "localhost", "device"]).optional(),
+  replaceAccountId: z.string().trim().min(1).max(200).optional(),
 });
 
 const oauthSubmitCodeSchema = z.object({
@@ -613,6 +615,24 @@ function healthForProbeStatus(status: number): LinkedAccountConfig["health"] {
   return "invalid";
 }
 
+function retainsTerminalCredentialHealth(
+  account: LinkedAccountConfig,
+): boolean {
+  return account.health === "needs-reauth" || account.health === "invalid";
+}
+
+function preserveTerminalCredentialHealth(
+  current: LinkedAccountConfig,
+  next: LinkedAccountConfig,
+): LinkedAccountConfig {
+  if (!retainsTerminalCredentialHealth(current)) return next;
+  return {
+    ...next,
+    health: current.health,
+    ...(current.healthDetail ? { healthDetail: current.healthDetail } : {}),
+  };
+}
+
 // ─── Route handler ──────────────────────────────────────────────────
 
 export interface AccountsRouteContext extends RouteRequestContext {
@@ -784,14 +804,63 @@ async function handleCreateApiKeyAccount(
   // the new account at the next default index, which would offset
   // `nextPriorityFromPool` by one.
   const pool = await getPool();
-  const priority = nextPriorityFromPool(pool, providerId);
+  const replaceAccountId = parsed.data.replaceAccountId;
+  const replacementTarget = replaceAccountId
+    ? pool.get(replaceAccountId, providerId)
+    : null;
+  if (replaceAccountId && !replacementTarget) {
+    const belongsToAnotherProvider = pool
+      .list()
+      .some(
+        (account) =>
+          account.id === replaceAccountId && account.providerId !== providerId,
+      );
+    error(
+      res,
+      belongsToAnotherProvider
+        ? "Replacement account belongs to a different provider"
+        : "Replacement account not found",
+      belongsToAnotherProvider ? 400 : 404,
+    );
+    return true;
+  }
+  const previousRecord = replaceAccountId
+    ? loadAccount(accountProvider, replaceAccountId)
+    : null;
+  if (replaceAccountId && !previousRecord) {
+    error(res, "Replacement account credential not found", 404);
+    return true;
+  }
 
-  const id = nodeCrypto.randomUUID();
+  if (replaceAccountId) {
+    const probe =
+      accountProvider in DIRECT_ACCOUNT_PROVIDER_ENV
+        ? await probeDirectApiKey(
+            accountProvider as DirectAccountProvider,
+            parsed.data.apiKey,
+          )
+        : isCodingPlanKeySubscriptionProvider(accountProvider)
+          ? await probeCodingPlanKey(accountProvider, parsed.data.apiKey)
+          : null;
+    if (!probe?.ok) {
+      error(
+        res,
+        probe?.error ?? "Replacement credential could not be verified",
+        400,
+      );
+      return true;
+    }
+  }
+
+  const priority = replacementTarget
+    ? replacementTarget.priority
+    : nextPriorityFromPool(pool, providerId);
+  const id = replaceAccountId ?? nodeCrypto.randomUUID();
   const now = Date.now();
   const record: AccountCredentialRecord = {
     id,
     providerId: accountProvider,
-    label: parsed.data.label,
+    label: replacementTarget?.label ?? parsed.data.label,
     source: "api-key",
     credentials: {
       access: parsed.data.apiKey,
@@ -799,10 +868,43 @@ async function handleCreateApiKeyAccount(
       // Sentinel: api-key creds never expire.
       expires: Number.MAX_SAFE_INTEGER,
     },
-    createdAt: now,
+    createdAt: previousRecord?.createdAt ?? now,
     updatedAt: now,
+    ...(previousRecord?.lastUsedAt
+      ? { lastUsedAt: previousRecord.lastUsedAt }
+      : {}),
   };
+  const stableReplacementTarget = replacementTarget
+    ? (({ healthDetail: _healthDetail, usage: _usage, ...stable }) => stable)(
+        replacementTarget,
+      )
+    : null;
+  const linkedConfig = stableReplacementTarget
+    ? {
+        ...stableReplacementTarget,
+        ...buildLinkedAccountConfigFromRecord(record, priority),
+        enabled: stableReplacementTarget.enabled,
+        priority,
+        createdAt: stableReplacementTarget.createdAt,
+        health: "ok" as const,
+      }
+    : buildLinkedAccountConfigFromRecord(record, priority);
   saveAccount(record);
+  try {
+    await pool.upsert(linkedConfig);
+  } catch (cause) {
+    if (previousRecord && replacementTarget) {
+      saveAccount(previousRecord);
+      await pool.upsert(replacementTarget);
+    } else {
+      deleteAccount(accountProvider, record.id);
+    }
+    throw new ElizaError("Account credential adoption failed", {
+      code: "accounts.credential_adoption_failed",
+      severity: "fatal",
+      cause,
+    });
+  }
 
   const envKey =
     accountProvider in DIRECT_ACCOUNT_PROVIDER_ENV
@@ -815,10 +917,7 @@ async function handleCreateApiKeyAccount(
     }
   }
 
-  const linkedConfig = buildLinkedAccountConfigFromRecord(record, priority);
-  await pool.upsert(linkedConfig);
-
-  json(res, linkedConfig, 201);
+  json(res, linkedConfig, replacementTarget ? 200 : 201);
   return true;
 }
 
@@ -847,10 +946,11 @@ async function handleOAuthRoutes(
   const action = rest[0];
 
   if (action === "start" && method === "POST") {
-    const body = await readJsonBody<{ label?: string; mode?: string }>(
-      req,
-      res,
-    );
+    const body = await readJsonBody<{
+      label?: string;
+      mode?: string;
+      replaceAccountId?: string;
+    }>(req, res);
     if (!body) return true;
     const parsed = oauthStartSchema.safeParse(body);
     if (!parsed.success) {
@@ -866,10 +966,61 @@ async function handleOAuthRoutes(
     // the post-save hook is monotonic regardless of concurrency since
     // the on-disk credential file appears strictly before the hook
     // fires.
-    const accountId = nodeCrypto.randomUUID();
     const pool = await getPool();
+    const replaceAccountId = parsed.data.replaceAccountId;
+    const replacementTarget = replaceAccountId
+      ? pool.get(replaceAccountId, providerId)
+      : null;
+    if (replaceAccountId && !replacementTarget) {
+      const belongsToAnotherProvider = pool
+        .list()
+        .some(
+          (account) =>
+            account.id === replaceAccountId &&
+            account.providerId !== providerId,
+        );
+      error(
+        res,
+        belongsToAnotherProvider
+          ? "Replacement account belongs to a different provider"
+          : "Replacement account not found",
+        belongsToAnotherProvider ? 400 : 404,
+      );
+      return true;
+    }
+    if (replaceAccountId && !loadAccount(subscription, replaceAccountId)) {
+      error(res, "Replacement account credential not found", 404);
+      return true;
+    }
 
+    const accountId = replaceAccountId ?? nodeCrypto.randomUUID();
+    let replacementMetadataBeforeAdoption: LinkedAccountConfig | null = null;
     const onAccountSaved = async (record: AccountCredentialRecord) => {
+      if (replacementTarget) {
+        const liveTarget = pool.get(replacementTarget.id, providerId);
+        if (!liveTarget) {
+          throw new Error("Replacement account metadata no longer exists");
+        }
+        replacementMetadataBeforeAdoption = liveTarget;
+        const canonical = buildLinkedAccountConfigFromRecord(
+          record,
+          liveTarget.priority,
+        );
+        const {
+          healthDetail: _healthDetail,
+          usage: _usage,
+          ...stableTarget
+        } = liveTarget;
+        await pool.upsert({
+          ...stableTarget,
+          ...canonical,
+          enabled: liveTarget.enabled,
+          priority: liveTarget.priority,
+          createdAt: liveTarget.createdAt,
+          health: "ok",
+        });
+        return;
+      }
       // Exclude the just-saved record from the priority calc — its
       // credential file already exists on disk so `pool.list` would
       // include it at a default priority (createdAt-sorted index),
@@ -898,7 +1049,17 @@ async function handleOAuthRoutes(
       handle = await startFlow({
         label: parsed.data.label,
         accountId,
+        ...(replaceAccountId ? { replaceAccountId } : {}),
         onAccountSaved,
+        ...(replacementTarget
+          ? {
+              onReplacementRollback: async () => {
+                if (replacementMetadataBeforeAdoption) {
+                  await pool.upsert(replacementMetadataBeforeAdoption);
+                }
+              },
+            }
+          : {}),
         ...(subscription === "openai-codex"
           ? {
               headless:
@@ -1173,7 +1334,7 @@ async function handleRefreshUsage(
 
   if (direct) {
     const probe = await probeDirectApiKey(direct, accessToken);
-    const next: LinkedAccountConfig = {
+    const next = preserveTerminalCredentialHealth(linked, {
       ...linked,
       health: probe.ok ? "ok" : healthForProbeStatus(probe.status),
       healthDetail: {
@@ -1186,7 +1347,7 @@ async function handleRefreshUsage(
         ...(linked.usage ?? {}),
         refreshedAt: Date.now(),
       },
-    };
+    });
     await pool.upsert(next);
     json(res, { account: next, probe, source: "direct-probe" });
     return true;
@@ -1194,7 +1355,7 @@ async function handleRefreshUsage(
 
   if (subscription && isCodingPlanKeySubscriptionProvider(subscription)) {
     const probe = await probeCodingPlanKey(subscription, accessToken);
-    const next: LinkedAccountConfig = {
+    const next = preserveTerminalCredentialHealth(linked, {
       ...linked,
       health: probe.ok ? "ok" : healthForProbeStatus(probe.status),
       healthDetail: {
@@ -1207,7 +1368,7 @@ async function handleRefreshUsage(
         ...(linked.usage ?? {}),
         refreshedAt: Date.now(),
       },
-    };
+    });
     await pool.upsert(next);
     json(res, { account: next, probe, source: "coding-plan-probe" });
     return true;
@@ -1236,7 +1397,9 @@ async function handleRefreshUsage(
     });
     const refreshed = pool.get(accountId, providerId);
     if (refreshed) {
-      json(res, { account: refreshed, source: "pool" });
+      const canonical = preserveTerminalCredentialHealth(linked, refreshed);
+      if (canonical !== refreshed) await pool.upsert(canonical);
+      json(res, { account: canonical, source: "pool" });
       return true;
     }
   } catch (err) {
@@ -1254,7 +1417,7 @@ async function handleRefreshUsage(
             error: `Usage refresh not supported for ${providerId}`,
             latencyMs: 0,
           };
-  const next: LinkedAccountConfig = {
+  const next = preserveTerminalCredentialHealth(linked, {
     ...linked,
     ...(probe.usage ? { usage: probe.usage } : {}),
     health: probe.ok ? "ok" : "rate-limited",
@@ -1264,7 +1427,7 @@ async function handleRefreshUsage(
           lastChecked: Date.now(),
           ...(probe.error ? { lastError: probe.error } : {}),
         },
-  };
+  });
   await pool.upsert(next);
   json(res, { account: next, probe, source: "inline-probe" });
   return true;

--- a/packages/auth/src/oauth-flow.test.ts
+++ b/packages/auth/src/oauth-flow.test.ts
@@ -12,12 +12,13 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { listAccounts, loadAccount } from "./account-storage";
+import { listAccounts, loadAccount, saveAccount } from "./account-storage";
 import {
   _resetFlowRegistry,
   type FlowState,
   fetchAnthropicOAuthProfile,
   startCodexOAuthFlow,
+  submitFlowCode,
   submitProviderFlowCode,
   subscribeFlow,
 } from "./oauth-flow";
@@ -313,6 +314,202 @@ describe("oauth-flow FlowState broadcast", () => {
       loadAccount("openai-codex", firstAccount.id)?.credentials.refresh,
     ).toBe("updated-refresh");
     expect(loadAccount("openai-codex", "reserved-id-2")).toBeNull();
+  });
+
+  it("replaces a same-provider credential in place after identity validation", async () => {
+    useTempElizaHome();
+    const identity = "stable-codex-account-id";
+    const email = "person@example.com";
+    saveAccount({
+      id: "target-account",
+      providerId: "openai-codex",
+      label: "Work Codex",
+      source: "oauth",
+      credentials: { access: "old-access", refresh: "old-refresh", expires: 1 },
+      createdAt: 10,
+      updatedAt: 11,
+      organizationId: identity,
+      email,
+    });
+    const vendor = stubCodexLogin();
+    const handle = await startCodexOAuthFlow({
+      label: "ignored replacement label",
+      accountId: "target-account",
+      replaceAccountId: "target-account",
+    });
+    const frames: FlowState[] = [];
+    subscribeFlow(handle.sessionId, (state) => frames.push(state));
+    vendor.resolveCredentials({
+      access: jwt({
+        "https://api.openai.com/auth": { chatgpt_account_id: identity },
+      }),
+      refresh: "new-refresh",
+      expires: Date.now() + 60_000,
+      idToken: jwt({ email }),
+    });
+
+    const { account } = await handle.completion;
+    expect(account).toMatchObject({
+      id: "target-account",
+      label: "Work Codex",
+      createdAt: 10,
+      organizationId: identity,
+      email,
+    });
+    expect(account.credentials.refresh).toBe("new-refresh");
+    expect(listAccounts("openai-codex")).toHaveLength(1);
+    expect(frames[0]).toMatchObject({ replaceAccountId: "target-account" });
+  });
+
+  it("fails closed on replacement identity mismatch and leaves the old credential intact", async () => {
+    useTempElizaHome();
+    saveAccount({
+      id: "target-account",
+      providerId: "openai-codex",
+      label: "Work Codex",
+      source: "oauth",
+      credentials: { access: "old-access", refresh: "old-refresh", expires: 1 },
+      createdAt: 10,
+      updatedAt: 11,
+      organizationId: "expected-identity",
+      email: "expected@example.com",
+    });
+    const vendor = stubCodexLogin();
+    const handle = await startCodexOAuthFlow({
+      label: "Work Codex",
+      replaceAccountId: "target-account",
+    });
+    vendor.resolveCredentials({
+      access: jwt({
+        "https://api.openai.com/auth": { chatgpt_account_id: "other-identity" },
+      }),
+      refresh: "new-refresh",
+      expires: Date.now() + 60_000,
+      idToken: jwt({ email: "other@example.com" }),
+    });
+
+    await expect(handle.completion).rejects.toMatchObject({
+      code: "oauth_flow.replacement_identity_mismatch",
+    });
+    expect(
+      loadAccount("openai-codex", "target-account")?.credentials,
+    ).toMatchObject({
+      access: "old-access",
+      refresh: "old-refresh",
+    });
+  });
+
+  it("leaves the old replacement credential intact when OAuth exchange fails", async () => {
+    useTempElizaHome();
+    saveAccount({
+      id: "target-account",
+      providerId: "openai-codex",
+      label: "Work Codex",
+      source: "oauth",
+      credentials: { access: "old-access", refresh: "old-refresh", expires: 1 },
+      createdAt: 10,
+      updatedAt: 11,
+    });
+    let rejectCredentials!: (error: Error) => void;
+    vi.mocked(startCodexLogin).mockResolvedValue({
+      authUrl: "https://auth.openai.com/authorize?fake",
+      state: "fake-state",
+      submitCode: () => undefined,
+      credentials: new Promise<OAuthCredentials>((_resolve, reject) => {
+        rejectCredentials = reject;
+      }),
+      close: () => undefined,
+    });
+    const handle = await startCodexOAuthFlow({
+      label: "Work Codex",
+      replaceAccountId: "target-account",
+    });
+    rejectCredentials(new Error("provider denied login"));
+
+    await expect(handle.completion).rejects.toThrow("provider denied login");
+    expect(
+      loadAccount("openai-codex", "target-account")?.credentials,
+    ).toMatchObject({
+      access: "old-access",
+      refresh: "old-refresh",
+    });
+  });
+
+  it("rolls back the credential when host adoption fails", async () => {
+    useTempElizaHome();
+    const identity = "stable-codex-account-id";
+    const email = "person@example.com";
+    saveAccount({
+      id: "target-account",
+      providerId: "openai-codex",
+      label: "Work Codex",
+      source: "oauth",
+      credentials: { access: "old-access", refresh: "old-refresh", expires: 1 },
+      createdAt: 10,
+      updatedAt: 11,
+      organizationId: identity,
+      email,
+    });
+    const vendor = stubCodexLogin();
+    const rollback = vi.fn();
+    const handle = await startCodexOAuthFlow({
+      label: "Work Codex",
+      replaceAccountId: "target-account",
+      onAccountSaved: async () => {
+        throw new Error("pool write failed");
+      },
+      onReplacementRollback: rollback,
+    });
+    vendor.resolveCredentials({
+      access: jwt({
+        "https://api.openai.com/auth": { chatgpt_account_id: identity },
+      }),
+      refresh: "new-refresh",
+      expires: Date.now() + 60_000,
+      idToken: jwt({ email }),
+    });
+
+    await expect(handle.completion).rejects.toMatchObject({
+      code: "oauth_flow.replacement_adoption_failed",
+    });
+    expect(rollback).toHaveBeenCalledOnce();
+    expect(
+      loadAccount("openai-codex", "target-account")?.credentials.refresh,
+    ).toBe("old-refresh");
+  });
+
+  it("rejects a stale replacement target and submits duplicate callbacks only once", async () => {
+    useTempElizaHome();
+    let submitted = 0;
+    let resolveCredentials!: (credentials: OAuthCredentials) => void;
+    vi.mocked(startCodexLogin).mockResolvedValue({
+      authUrl: "https://auth.openai.com/authorize?state=fake",
+      state: "fake",
+      submitCode: () => {
+        submitted += 1;
+      },
+      credentials: new Promise<OAuthCredentials>((resolve) => {
+        resolveCredentials = resolve;
+      }),
+      close: () => undefined,
+    });
+    const handle = await startCodexOAuthFlow({
+      label: "Missing",
+      replaceAccountId: "deleted-account",
+    });
+    expect(submitFlowCode(handle.sessionId, "same-code")).toBe(true);
+    expect(submitFlowCode(handle.sessionId, "same-code")).toBe(true);
+    expect(submitFlowCode(handle.sessionId, "different-code")).toBe(false);
+    expect(submitted).toBe(1);
+    resolveCredentials({
+      access: ACCESS_TOKEN,
+      refresh: REFRESH_TOKEN,
+      expires: Date.now() + 60_000,
+    });
+    await expect(handle.completion).rejects.toMatchObject({
+      code: "oauth_flow.replacement_target_missing",
+    });
+    expect(listAccounts("openai-codex")).toHaveLength(0);
   });
 
   it("emits an account-free error state when the exchange fails", async () => {

--- a/packages/auth/src/oauth-flow.ts
+++ b/packages/auth/src/oauth-flow.ts
@@ -23,6 +23,7 @@ import { ElizaError, logger } from "@elizaos/core";
 import {
   type AccountCredentialRecord,
   listAccounts,
+  loadAccount,
   saveAccount,
 } from "./account-storage.ts";
 import { startCodexDeviceLogin } from "./codex-device.ts";
@@ -59,6 +60,8 @@ export interface FlowState {
   authUrl?: string;
   /** Whether the client must offer a callback URL/code input. */
   needsCodeSubmission: boolean;
+  /** Existing account selected by the initiating request for atomic replacement. */
+  replaceAccountId?: string;
   account?: FlowAccountSummary;
   error?: string;
   startedAt: number;
@@ -119,40 +122,98 @@ function resolveAccountId(opts: { accountId?: string }): string {
   return opts.accountId?.trim() || crypto.randomUUID();
 }
 
-/**
- * Build an `AccountCredentialRecord` and persist it via `saveAccount`.
- * Returns the canonical record (with `createdAt`/`updatedAt` filled).
- */
-function persistAccount(args: {
+function normalizeIdentity(value: string | undefined): string | undefined {
+  const normalized = value?.trim().toLowerCase();
+  return normalized || undefined;
+}
+
+function assertReplacementIdentity(
+  existing: AccountCredentialRecord,
+  incoming: {
+    organizationId?: string;
+    providerAccountId?: string;
+    email?: string;
+  },
+): void {
+  const comparisons = [
+    ["organization", existing.organizationId, incoming.organizationId],
+    ["user", existing.userId, incoming.providerAccountId],
+    [
+      "email",
+      normalizeIdentity(existing.email),
+      normalizeIdentity(incoming.email),
+    ],
+  ] as const;
+  for (const [field, expected, actual] of comparisons) {
+    if (!expected) continue;
+    if (!actual || expected !== actual) {
+      throw new ElizaError(
+        `OAuth replacement ${field} identity does not match`,
+        {
+          code: "oauth_flow.replacement_identity_mismatch",
+          severity: "fatal",
+          context: { field },
+        },
+      );
+    }
+  }
+}
+
+/** Build the canonical account record without mutating credential storage. */
+function buildAccountRecord(args: {
   providerId: SubscriptionProvider;
   accountId: string;
+  replaceAccountId?: string;
   label: string;
   access: string;
   refresh: string;
   expires: number;
   idToken?: string;
   organizationId?: string;
+  providerAccountId?: string;
   email?: string;
-}): AccountCredentialRecord {
+}): { record: AccountCredentialRecord; previous?: AccountCredentialRecord } {
   const now = Date.now();
-  const normalizedEmail = args.email?.trim().toLowerCase();
-  const existing = listAccounts(args.providerId).find((account) => {
-    if (args.organizationId && account.organizationId === args.organizationId) {
-      return true;
-    }
-    return Boolean(
-      normalizedEmail &&
-        account.email?.trim().toLowerCase() === normalizedEmail,
-    );
-  });
+  const normalizedEmail = normalizeIdentity(args.email);
+  const replacement = args.replaceAccountId
+    ? loadAccount(args.providerId, args.replaceAccountId)
+    : null;
+  if (args.replaceAccountId && !replacement) {
+    throw new ElizaError("OAuth replacement account no longer exists", {
+      code: "oauth_flow.replacement_target_missing",
+      severity: "fatal",
+      context: {
+        providerId: args.providerId,
+        accountId: args.replaceAccountId,
+      },
+    });
+  }
+  if (replacement) {
+    assertReplacementIdentity(replacement, {
+      organizationId: args.organizationId,
+      providerAccountId: args.providerAccountId,
+      email: args.email,
+    });
+  }
+  const deduplicated = replacement
+    ? null
+    : listAccounts(args.providerId).find((account) => {
+        if (
+          args.organizationId &&
+          account.organizationId === args.organizationId
+        ) {
+          return true;
+        }
+        return Boolean(
+          normalizedEmail &&
+            normalizeIdentity(account.email) === normalizedEmail,
+        );
+      });
+  const existing = replacement ?? deduplicated;
   const record: AccountCredentialRecord = {
-    // OAuth starts before the provider identity is known, so callers commonly
-    // reserve a fresh UUID for every attempt. Once we have a stable provider
-    // identity, update its existing credential record instead of creating a
-    // duplicate account on every relink.
     id: existing?.id ?? args.accountId,
     providerId: args.providerId,
-    label: args.label,
+    label: replacement?.label ?? args.email ?? args.label,
     source: "oauth",
     credentials: {
       access: args.access,
@@ -163,17 +224,22 @@ function persistAccount(args: {
     createdAt: existing?.createdAt ?? now,
     updatedAt: now,
     ...(existing?.lastUsedAt ? { lastUsedAt: existing.lastUsedAt } : {}),
-    ...(existing?.userId ? { userId: existing.userId } : {}),
+    ...(args.providerAccountId
+      ? { userId: args.providerAccountId }
+      : existing?.userId
+        ? { userId: existing.userId }
+        : {}),
     ...(args.organizationId ? { organizationId: args.organizationId } : {}),
     ...(args.email ? { email: args.email } : {}),
   };
-  saveAccount(record);
-  return record;
+  return { record, ...(replacement ? { previous: replacement } : {}) };
 }
 
 interface StartOptions {
   label: string;
   accountId?: string;
+  /** Existing same-provider account to replace only after OAuth succeeds. */
+  replaceAccountId?: string;
   /** Remote/headless clients use Codex device auth instead of loopback PKCE. */
   headless?: boolean;
   /**
@@ -182,6 +248,10 @@ interface StartOptions {
    * `eliza.json`. Failures here propagate as flow `error`.
    */
   onAccountSaved?: (account: AccountCredentialRecord) => void | Promise<void>;
+  /** Restores host metadata if replacement adoption fails after a pool write. */
+  onReplacementRollback?: (
+    account: AccountCredentialRecord,
+  ) => void | Promise<void>;
 }
 
 // Anthropic.
@@ -305,6 +375,9 @@ async function startGenericFlow(args: {
     status: "pending",
     authUrl: vendor.authUrl,
     needsCodeSubmission,
+    ...(opts.replaceAccountId
+      ? { replaceAccountId: opts.replaceAccountId }
+      : {}),
     startedAt,
   };
 
@@ -376,19 +449,36 @@ async function startGenericFlow(args: {
         if (codexAccountId) organizationId = codexAccountId;
         email = extractJwtEmail(creds.idToken);
       }
-      const record = persistAccount({
+      const { record, previous } = buildAccountRecord({
         providerId,
         accountId: providerAccountId ?? accountId,
+        ...(opts.replaceAccountId
+          ? { replaceAccountId: opts.replaceAccountId }
+          : {}),
         label: email ?? opts.label,
         access: creds.access,
         refresh: creds.refresh,
         expires: creds.expires,
         ...(creds.idToken ? { idToken: creds.idToken } : {}),
         ...(organizationId ? { organizationId } : {}),
+        ...(providerAccountId ? { providerAccountId } : {}),
         ...(email ? { email } : {}),
       });
-      if (opts.onAccountSaved) {
-        await opts.onAccountSaved(record);
+      saveAccount(record);
+      try {
+        if (opts.onAccountSaved) {
+          await opts.onAccountSaved(record);
+        }
+      } catch (cause) {
+        if (previous) {
+          saveAccount(previous);
+          await opts.onReplacementRollback?.(previous);
+        }
+        throw new ElizaError("OAuth credential adoption failed", {
+          code: "oauth_flow.replacement_adoption_failed",
+          severity: "fatal",
+          cause,
+        });
       }
       // The broadcast state must never carry the tokens — every SSE
       // subscriber receives it verbatim; only the in-process completion
@@ -404,6 +494,7 @@ async function startGenericFlow(args: {
     }
   })();
 
+  let submittedCode: string | null = null;
   const handle: OAuthFlowHandle = {
     sessionId,
     authUrl: vendor.authUrl,
@@ -411,6 +502,11 @@ async function startGenericFlow(args: {
     needsCodeSubmission,
     completion,
     submitCode: (code: string) => {
+      if (submittedCode === code) return;
+      if (submittedCode !== null) {
+        throw new Error("OAuth callback code was already submitted");
+      }
+      submittedCode = code;
       vendor.submitCode(code);
     },
     cancel: (reason = "Cancelled") => {
@@ -476,8 +572,12 @@ export function submitFlowCode(sessionId: string, code: string): boolean {
   if (!entry) return false;
   if (entry.state.status !== "pending") return false;
   if (!entry.state.needsCodeSubmission) return false;
-  entry.handle.submitCode(code);
-  return true;
+  try {
+    entry.handle.submitCode(code);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/packages/ui/src/api/client-agent-accounts.test.ts
+++ b/packages/ui/src/api/client-agent-accounts.test.ts
@@ -1,0 +1,76 @@
+/** Verifies multi-account replacement payloads at the real client transport boundary. */
+import { describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "./client";
+
+describe("ElizaClient account replacement transport", () => {
+  it("sends explicit API-key and OAuth replacement targets", async () => {
+    const request = vi.fn(
+      async (input: RequestInfo | URL, _init?: RequestInit) => {
+        const url = String(input);
+        const body = url.endsWith("/oauth/start")
+          ? {
+              sessionId: "repair-session",
+              authUrl: "https://provider.example/authorize",
+              needsCodeSubmission: true,
+            }
+          : {
+              id: "account-1",
+              providerId: "openai-api",
+              label: "Primary",
+              source: "api-key",
+              enabled: true,
+              priority: 0,
+              createdAt: 1,
+              health: "ok",
+            };
+        return new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      },
+    );
+    const client = new ElizaClient("http://agent.example:31337", "token");
+    client.setRequestTransport({ request });
+
+    const apiKeyReplacement = {
+      label: "Primary",
+      apiKey: "replacement-secret",
+      replaceAccountId: "account-1",
+    };
+    const oauthReplacement = {
+      label: "Work Codex",
+      mode: "device" as const,
+      replaceAccountId: "codex-work",
+    };
+    await client.createApiKeyAccount("openai-api", apiKeyReplacement);
+    await client.startAccountOAuth("openai-codex", oauthReplacement);
+
+    expect(request).toHaveBeenNthCalledWith(
+      1,
+      "http://agent.example:31337/api/accounts/openai-api",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          source: "api-key",
+          label: "Primary",
+          apiKey: "replacement-secret",
+          replaceAccountId: "account-1",
+        }),
+      }),
+      expect.objectContaining({ timeoutMs: 10_000 }),
+    );
+    expect(request).toHaveBeenNthCalledWith(
+      2,
+      "http://agent.example:31337/api/accounts/openai-codex/oauth/start",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          label: "Work Codex",
+          mode: "device",
+          replaceAccountId: "codex-work",
+        }),
+      }),
+      expect.objectContaining({ timeoutMs: 10_000 }),
+    );
+  });
+});

--- a/packages/ui/src/components/accounts/AccountCard.test.tsx
+++ b/packages/ui/src/components/accounts/AccountCard.test.tsx
@@ -1,0 +1,92 @@
+/** Focused account-row coverage for health treatment and credential repair. */
+
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AccountWithCredentialFlag } from "../../api/client-agent";
+import { AccountCard } from "./AccountCard";
+
+vi.mock("../../state", () => ({
+  useAppSelector: (
+    selector: (state: {
+      t: (key: string, vars?: Record<string, unknown>) => string;
+    }) => unknown,
+  ) => selector({ t: (key, vars) => String(vars?.defaultValue ?? key) }),
+}));
+
+const baseAccount: AccountWithCredentialFlag = {
+  id: "account-primary",
+  providerId: "openai-codex",
+  label: "Production Codex",
+  source: "oauth",
+  enabled: true,
+  priority: 0,
+  createdAt: Date.now() - 86_400_000,
+  lastUsedAt: Date.now() - 60_000,
+  health: "ok",
+  hasCredential: true,
+};
+
+function renderAccount(
+  account: AccountWithCredentialFlag,
+  onReauthenticate = vi.fn(),
+) {
+  render(
+    <AccountCard
+      account={account}
+      isFirst
+      isLast
+      saving={false}
+      onPatch={vi.fn().mockResolvedValue(undefined)}
+      onMoveUp={vi.fn().mockResolvedValue(undefined)}
+      onMoveDown={vi.fn().mockResolvedValue(undefined)}
+      onTest={vi.fn().mockResolvedValue(undefined)}
+      onRefreshUsage={vi.fn().mockResolvedValue(undefined)}
+      onDelete={vi.fn().mockResolvedValue(undefined)}
+      onReauthenticate={onReauthenticate}
+    />,
+  );
+  return onReauthenticate;
+}
+
+describe("AccountCard health and repair actions", () => {
+  afterEach(cleanup);
+
+  it("prominently renders needs-reauth reason and dispatches reauthentication", () => {
+    const onReauthenticate = renderAccount({
+      ...baseAccount,
+      health: "needs-reauth",
+      healthDetail: { lastError: "Refresh token expired" },
+    });
+
+    expect(screen.getByText("Needs reauth")).toBeTruthy();
+    expect(screen.getByText("Refresh token expired")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Reauthenticate" }));
+    expect(onReauthenticate).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses replacement language for invalid API credentials", () => {
+    const onReauthenticate = renderAccount({
+      ...baseAccount,
+      providerId: "openai-api",
+      source: "api-key",
+      health: "invalid",
+    });
+
+    expect(screen.getByText("Invalid credential")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Replace credential" }));
+    expect(onReauthenticate).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps rate limits distinct from credential failures", () => {
+    renderAccount({
+      ...baseAccount,
+      health: "rate-limited",
+      healthDetail: { until: Date.now() + 3_600_000 },
+    });
+
+    expect(screen.getByText(/Rate-limited/)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Reauthenticate" })).toBeNull();
+  });
+});

--- a/packages/ui/src/components/accounts/AccountCard.tsx
+++ b/packages/ui/src/components/accounts/AccountCard.tsx
@@ -8,7 +8,7 @@
  * dialog for delete.
  */
 
-import { ChevronDown, ChevronUp, Trash2 } from "lucide-react";
+import { ChevronDown, ChevronUp, KeyRound, Trash2 } from "lucide-react";
 import type { AccountWithCredentialFlag } from "../../api/client-agent";
 import { useModalState } from "../../hooks/useModalState";
 import { cn } from "../../lib/utils";
@@ -41,6 +41,8 @@ export interface AccountCardProps {
   onTest: () => Promise<void>;
   onRefreshUsage: () => Promise<void>;
   onDelete: () => Promise<void>;
+  /** Opens the provider credential flow for this unhealthy account. */
+  onReauthenticate?: () => void;
   testBusy?: boolean;
   refreshBusy?: boolean;
 }
@@ -177,6 +179,7 @@ export function AccountCard({
   onTest,
   onRefreshUsage,
   onDelete,
+  onReauthenticate,
   testBusy = false,
   refreshBusy = false,
 }: AccountCardProps) {
@@ -196,6 +199,9 @@ export function AccountCard({
     account.providerId === "zai-coding" || account.providerId === "kimi-coding";
   const usage = account.usage;
   const lastUsed = formatRelativeTime(account.lastUsedAt);
+  const requiresCredentialRepair =
+    account.health === "needs-reauth" || account.health === "invalid";
+  const healthReason = account.healthDetail?.lastError?.trim();
 
   return (
     <div
@@ -293,6 +299,25 @@ export function AccountCard({
             />
             {t("accounts.enabled", { defaultValue: "Enabled" })}
           </div>
+          {requiresCredentialRepair && onReauthenticate ? (
+            <Button
+              type="button"
+              variant="default"
+              size="sm"
+              disabled={saving}
+              onClick={onReauthenticate}
+              className="h-7 gap-1.5 px-2 text-xs"
+            >
+              <KeyRound className="h-3.5 w-3.5" aria-hidden />
+              {account.source === "oauth"
+                ? t("accounts.reauthenticate", {
+                    defaultValue: "Reauthenticate",
+                  })
+                : t("accounts.replaceCredential", {
+                    defaultValue: "Replace credential",
+                  })}
+            </Button>
+          ) : null}
           <Button
             type="button"
             variant="outline"
@@ -368,6 +393,14 @@ export function AccountCard({
             })}
           </span>
         )}
+        {requiresCredentialRepair && healthReason ? (
+          <span
+            className="min-w-0 truncate text-[10px] text-destructive"
+            title={healthReason}
+          >
+            {healthReason}
+          </span>
+        ) : null}
         {!account.hasCredential ? (
           <span
             className="text-[10px] text-warn"

--- a/packages/ui/src/components/accounts/AccountList.test.tsx
+++ b/packages/ui/src/components/accounts/AccountList.test.tsx
@@ -1,0 +1,275 @@
+/**
+ * Focused AccountList coverage: credential-repair dialog wiring (repair state
+ * set on reauthenticate, cleared on plain add and on close), priority-swap
+ * move semantics with rollback, and the persisted-OAuth dialog restore.
+ */
+
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AccountList } from "./AccountList";
+import { readSubscriptionOAuth } from "./subscription-oauth-state";
+
+const accounts = vi.hoisted(() => ({
+  data: {
+    providers: [
+      {
+        providerId: "openai-api",
+        strategy: "priority",
+        accounts: [
+          {
+            id: "second",
+            label: "Second",
+            priority: 2,
+            enabled: true,
+            health: "needs-reauth",
+          },
+          {
+            id: "first",
+            label: "First",
+            priority: 1,
+            enabled: true,
+            health: "ok",
+          },
+        ],
+      },
+    ],
+  },
+  loading: false,
+  error: null,
+  patch: vi.fn().mockResolvedValue(undefined),
+  refresh: vi.fn().mockResolvedValue(undefined),
+  refreshUsage: vi.fn().mockResolvedValue(undefined),
+  remove: vi.fn().mockResolvedValue(undefined),
+  saving: new Set<string>(),
+  setStrategy: vi.fn().mockResolvedValue(undefined),
+  test: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../hooks/useAccounts", () => ({ useAccounts: () => accounts }));
+vi.mock("../../state", () => ({
+  useAppSelector: (
+    selector: (state: {
+      t: (key: string, vars?: Record<string, unknown>) => string;
+    }) => unknown,
+  ) => selector({ t: (key, vars) => String(vars?.defaultValue ?? key) }),
+}));
+vi.mock("./subscription-oauth-state", () => ({
+  readSubscriptionOAuth: vi.fn(() => null),
+}));
+vi.mock("./RotationStrategyPicker", () => ({
+  RotationStrategyPicker: ({
+    onChange,
+  }: {
+    onChange: (value: string) => void;
+  }) => (
+    <button type="button" onClick={() => onChange("round-robin")}>
+      change strategy
+    </button>
+  ),
+}));
+vi.mock("./AccountCard", () => ({
+  AccountCard: ({
+    account,
+    onMoveUp,
+    onMoveDown,
+    onTest,
+    onRefreshUsage,
+    onDelete,
+    onReauthenticate,
+  }: {
+    account: { label: string };
+    onMoveUp: () => Promise<void>;
+    onMoveDown: () => Promise<void>;
+    onTest: () => Promise<void>;
+    onRefreshUsage: () => Promise<void>;
+    onDelete: () => Promise<void>;
+    onReauthenticate: () => void;
+  }) => (
+    <div>
+      <span>card {account.label}</span>
+      <button
+        type="button"
+        onClick={() => {
+          void onMoveUp().catch(() => {});
+        }}
+      >
+        up {account.label}
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          void onMoveDown().catch(() => {});
+        }}
+      >
+        down {account.label}
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          void onTest();
+        }}
+      >
+        test {account.label}
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          void onRefreshUsage();
+        }}
+      >
+        refresh {account.label}
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          void onDelete();
+        }}
+      >
+        delete {account.label}
+      </button>
+      <button type="button" onClick={onReauthenticate}>
+        reauthenticate {account.label}
+      </button>
+    </div>
+  ),
+}));
+vi.mock("./AddAccountDialog", () => ({
+  AddAccountDialog: ({
+    open,
+    credentialRepairAccount,
+    onClose,
+  }: {
+    open: boolean;
+    credentialRepairAccount?: { id: string } | null;
+    onClose: () => void;
+  }) =>
+    open ? (
+      <div role="dialog">
+        add dialog {credentialRepairAccount?.id ?? "new"}
+        <button type="button" onClick={onClose}>
+          close dialog
+        </button>
+      </div>
+    ) : null,
+}));
+
+const mockedReadSubscriptionOAuth = vi.mocked(readSubscriptionOAuth);
+
+describe("AccountList", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    mockedReadSubscriptionOAuth.mockReturnValue(null);
+    accounts.loading = false;
+    accounts.patch.mockResolvedValue(undefined);
+  });
+
+  it("shows the loading indicator before the first account list arrives", () => {
+    accounts.loading = true;
+    const data = accounts.data;
+    // biome-ignore lint/suspicious/noExplicitAny: test toggles the hook's data shape
+    (accounts as any).data = null;
+    render(<AccountList providerId="openai-api" />);
+    expect(screen.getByText("Loading accounts…")).toBeTruthy();
+    // biome-ignore lint/suspicious/noExplicitAny: restore
+    (accounts as any).data = data;
+  });
+
+  it("renders the empty state when the provider has no accounts", () => {
+    render(<AccountList providerId="anthropic-api" />);
+    expect(
+      screen.getByText(
+        "No accounts yet — add one to start using this provider.",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("targets the repair dialog at the reauthenticated account and clears it for plain adds", () => {
+    render(<AccountList providerId="openai-api" />);
+    // Reauthenticate opens the dialog scoped to that unhealthy account.
+    fireEvent.click(
+      screen.getByRole("button", { name: "reauthenticate Second" }),
+    );
+    expect(screen.getByRole("dialog").textContent).toContain("second");
+    // Closing clears the repair target...
+    fireEvent.click(screen.getByRole("button", { name: "close dialog" }));
+    expect(screen.queryByRole("dialog")).toBeNull();
+    // ...so a plain "Add account" afterwards is NOT a repair (regression
+    // guard: stale repair state must not leak into an unrelated add).
+    fireEvent.click(screen.getByRole("button", { name: "Add account" }));
+    expect(screen.getByRole("dialog").textContent).toContain("new");
+  });
+
+  it("resets a previous repair target when Add account is clicked directly", () => {
+    render(<AccountList providerId="openai-api" />);
+    fireEvent.click(
+      screen.getByRole("button", { name: "reauthenticate Second" }),
+    );
+    expect(screen.getByRole("dialog").textContent).toContain("second");
+    fireEvent.click(screen.getByRole("button", { name: "Add account" }));
+    expect(screen.getByRole("dialog").textContent).toContain("new");
+  });
+
+  it("swaps priorities with the neighbour via two patches", async () => {
+    render(<AccountList providerId="openai-api" />);
+    fireEvent.click(screen.getByRole("button", { name: "down First" }));
+    await waitFor(() => expect(accounts.patch).toHaveBeenCalledTimes(2));
+    expect(accounts.patch).toHaveBeenNthCalledWith(1, "openai-api", "first", {
+      priority: 2,
+    });
+    expect(accounts.patch).toHaveBeenNthCalledWith(2, "openai-api", "second", {
+      priority: 1,
+    });
+  });
+
+  it("ignores moves past the list boundary", async () => {
+    render(<AccountList providerId="openai-api" />);
+    fireEvent.click(screen.getByRole("button", { name: "up First" }));
+    fireEvent.click(screen.getByRole("button", { name: "down Second" }));
+    await waitFor(() => expect(accounts.patch).not.toHaveBeenCalled());
+  });
+
+  it("rolls the first patch back when the neighbour patch fails", async () => {
+    accounts.patch
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce(undefined);
+    render(<AccountList providerId="openai-api" />);
+    fireEvent.click(screen.getByRole("button", { name: "down First" }));
+    await waitFor(() => expect(accounts.patch).toHaveBeenCalledTimes(3));
+    expect(accounts.patch).toHaveBeenNthCalledWith(3, "openai-api", "first", {
+      priority: 1,
+    });
+    expect(accounts.refresh).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a server refresh when the rollback also fails", async () => {
+    accounts.patch
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockRejectedValueOnce(new Error("rollback boom"));
+    render(<AccountList providerId="openai-api" />);
+    fireEvent.click(screen.getByRole("button", { name: "down First" }));
+    await waitFor(() => expect(accounts.refresh).toHaveBeenCalledTimes(1));
+  });
+
+  it("reopens the add dialog when a persisted OAuth session resurfaces on focus", () => {
+    render(<AccountList providerId="openai-api" />);
+    expect(screen.queryByRole("dialog")).toBeNull();
+    mockedReadSubscriptionOAuth.mockReturnValue({
+      providerId: "openai-api",
+      sessionId: "session-1",
+      // biome-ignore lint/suspicious/noExplicitAny: minimal persisted-session shape for the restore branch
+    } as any);
+    fireEvent(window, new Event("focus"));
+    expect(screen.getByRole("dialog")).toBeTruthy();
+  });
+});

--- a/packages/ui/src/components/accounts/AccountList.tsx
+++ b/packages/ui/src/components/accounts/AccountList.tsx
@@ -30,6 +30,8 @@ export function AccountList({ providerId }: AccountListProps) {
   const [addDialogOpen, setAddDialogOpen] = useState(
     () => readSubscriptionOAuth(providerId) !== null,
   );
+  const [credentialRepairAccount, setCredentialRepairAccount] =
+    useState<AccountWithCredentialFlag | null>(null);
 
   useEffect(() => {
     const restorePendingDialog = () => {
@@ -130,7 +132,10 @@ export function AccountList({ providerId }: AccountListProps) {
             type="button"
             variant="default"
             size="sm"
-            onClick={() => setAddDialogOpen(true)}
+            onClick={() => {
+              setCredentialRepairAccount(null);
+              setAddDialogOpen(true);
+            }}
             className="h-8 gap-1 px-2.5 text-xs"
           >
             <Plus className="h-3.5 w-3.5" aria-hidden />
@@ -167,6 +172,10 @@ export function AccountList({ providerId }: AccountListProps) {
                 accounts.refreshUsage(providerId, account.id)
               }
               onDelete={() => accounts.remove(providerId, account.id)}
+              onReauthenticate={() => {
+                setCredentialRepairAccount(account);
+                setAddDialogOpen(true);
+              }}
             />
           ))}
         </div>
@@ -175,7 +184,11 @@ export function AccountList({ providerId }: AccountListProps) {
       <AddAccountDialog
         open={addDialogOpen}
         providerId={providerId}
-        onClose={() => setAddDialogOpen(false)}
+        credentialRepairAccount={credentialRepairAccount}
+        onClose={() => {
+          setAddDialogOpen(false);
+          setCredentialRepairAccount(null);
+        }}
         onCreated={() => {
           // useAccounts already injects the new entry on success, so
           // there's nothing to do here. Refresh anyway in case the

--- a/packages/ui/src/components/accounts/AccountManagementPanel.test.tsx
+++ b/packages/ui/src/components/accounts/AccountManagementPanel.test.tsx
@@ -49,6 +49,9 @@ const accounts = vi.hoisted(() => ({
 }));
 
 vi.mock("../../hooks/useAccounts", () => ({ useAccounts: () => accounts }));
+vi.mock("../../providers", () => ({
+  SUBSCRIPTION_PROVIDER_SELECTIONS: [],
+}));
 vi.mock("../../state", () => ({
   useAppSelector: (
     selector: (state: {
@@ -59,14 +62,20 @@ vi.mock("../../state", () => ({
 vi.mock("./subscription-oauth-state", () => ({
   readSubscriptionOAuth: vi.fn(() => null),
 }));
-vi.mock("./AddAccountDialog", async (original) => {
-  const actual = await original<typeof import("./AddAccountDialog")>();
-  return {
-    ...actual,
-    AddAccountDialog: ({ open }: { open: boolean }) =>
-      open ? <div role="dialog">add dialog</div> : null,
-  };
-});
+vi.mock("./AddAccountDialog", () => ({
+  AddAccountDialog: ({
+    open,
+    credentialRepairAccount,
+  }: {
+    open: boolean;
+    credentialRepairAccount?: { id: string } | null;
+  }) =>
+    open ? (
+      <div role="dialog">
+        add dialog {credentialRepairAccount?.id ?? "new"}
+      </div>
+    ) : null,
+}));
 vi.mock("./RotationStrategyPicker", () => ({
   RotationStrategyPicker: ({
     onChange,
@@ -85,12 +94,14 @@ vi.mock("./AccountCard", () => ({
     onTest,
     onRefreshUsage,
     onDelete,
+    onReauthenticate,
   }: {
     account: { label: string };
     onMoveDown: () => void;
     onTest: () => void;
     onRefreshUsage: () => void;
     onDelete: () => void;
+    onReauthenticate: () => void;
   }) => (
     <div>
       <span>{account.label}</span>
@@ -105,6 +116,9 @@ vi.mock("./AccountCard", () => ({
       </button>
       <button type="button" onClick={onDelete}>
         delete {account.label}
+      </button>
+      <button type="button" onClick={onReauthenticate}>
+        reauthenticate {account.label}
       </button>
     </div>
   ),
@@ -148,5 +162,9 @@ describe("AccountManagementPanel", () => {
       "openai-api",
       "round-robin",
     );
+    fireEvent.click(
+      screen.getByRole("button", { name: "reauthenticate Second" }),
+    );
+    expect(screen.getByRole("dialog").textContent).toContain("second");
   });
 });

--- a/packages/ui/src/components/accounts/AccountManagementPanel.tsx
+++ b/packages/ui/src/components/accounts/AccountManagementPanel.tsx
@@ -72,6 +72,8 @@ export function AccountManagementPanel({
   const [addDialogOpen, setAddDialogOpen] = useState(() =>
     Boolean(pendingProviderId),
   );
+  const [credentialRepairAccount, setCredentialRepairAccount] =
+    useState<AccountWithCredentialFlag | null>(null);
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
   const [showAvailable, setShowAvailable] = useState(false);
 
@@ -119,9 +121,22 @@ export function AccountManagementPanel({
   }, []);
 
   const openAdd = useCallback((providerId?: LinkedAccountProviderId) => {
+    setCredentialRepairAccount(null);
     setPendingProviderId(providerId);
     setAddDialogOpen(true);
   }, []);
+
+  const openCredentialRepair = useCallback(
+    (
+      providerId: LinkedAccountProviderId,
+      account: AccountWithCredentialFlag,
+    ) => {
+      setCredentialRepairAccount(account);
+      setPendingProviderId(providerId);
+      setAddDialogOpen(true);
+    },
+    [],
+  );
 
   const handleMove = useCallback(
     async (
@@ -181,6 +196,7 @@ export function AccountManagementPanel({
     onSelectChatProvider,
     onSelectSubscription,
     onAdd: openAdd,
+    onReauthenticate: openCredentialRepair,
   };
 
   // ── Loading skeleton (structural, matches the row layout) ──
@@ -344,9 +360,11 @@ export function AccountManagementPanel({
       <AddAccountDialog
         open={addDialogOpen}
         providerId={pendingProviderId}
+        credentialRepairAccount={credentialRepairAccount}
         onClose={() => {
           setAddDialogOpen(false);
           setPendingProviderId(undefined);
+          setCredentialRepairAccount(null);
         }}
         onCreated={() => {
           void accounts.refresh();

--- a/packages/ui/src/components/accounts/AddAccountDialog.component.test.tsx
+++ b/packages/ui/src/components/accounts/AddAccountDialog.component.test.tsx
@@ -226,7 +226,12 @@ describe("AddAccountDialog", () => {
     expect(screen.queryByRole("button", { name: /Log in/ })).toBeNull();
   });
 
-  it("explains the server replacement gap before repairing an OAuth account", () => {
+  it("starts an explicit in-place OAuth replacement without an editable duplicate label", async () => {
+    api.startAccountOAuth.mockResolvedValue({
+      sessionId: "repair-session",
+      authUrl: "https://login.test",
+      needsCodeSubmission: true,
+    });
     render(
       <AddAccountDialog
         open
@@ -243,12 +248,86 @@ describe("AddAccountDialog", () => {
     );
 
     expect(screen.getByText("Reauthenticate Work Claude")).toBeTruthy();
-    expect(
-      screen.getByText(/creates a fresh account in the same pool/),
-    ).toBeTruthy();
-    expect(
+    expect(screen.getByText(/updated in place/)).toBeTruthy();
+    expect(screen.queryByLabelText("Account name")).toBeNull();
+    fireEvent.click(
       screen.getByRole("button", { name: "Log in and paste a code" }),
-    ).toBeTruthy();
+    );
+    await waitFor(() =>
+      expect(api.startAccountOAuth).toHaveBeenCalledWith(
+        "anthropic-subscription",
+        expect.objectContaining({
+          label: "Work Claude",
+          replaceAccountId: "expired-account",
+        }),
+      ),
+    );
+  });
+
+  it("submits an API-key repair as an in-place replacement", async () => {
+    render(
+      <AddAccountDialog
+        open
+        providerId="zai-coding"
+        credentialRepairAccount={{
+          id: "invalid-plan",
+          label: "Work plan",
+          source: "api-key",
+          health: "invalid",
+        }}
+        onClose={vi.fn()}
+        onCreated={vi.fn()}
+      />,
+    );
+    expect(screen.queryByLabelText("Account name")).toBeNull();
+    fireEvent.change(screen.getByLabelText("Coding-plan key"), {
+      target: { value: "replacement-secret" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save replacement" }));
+    await waitFor(() =>
+      expect(api.createApiKeyAccount).toHaveBeenCalledWith("zai-coding", {
+        label: "Work plan",
+        apiKey: "replacement-secret",
+        replaceAccountId: "invalid-plan",
+      }),
+    );
+  });
+
+  it("resets repair form state when the account id changes despite the same label", () => {
+    const props = {
+      open: true,
+      providerId: "zai-coding" as const,
+      onClose: vi.fn(),
+      onCreated: vi.fn(),
+    };
+    const { rerender } = render(
+      <AddAccountDialog
+        {...props}
+        credentialRepairAccount={{
+          id: "first-invalid",
+          label: "Shared label",
+          source: "api-key",
+          health: "invalid",
+        }}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText("Coding-plan key"), {
+      target: { value: "first-secret-value" },
+    });
+    rerender(
+      <AddAccountDialog
+        {...props}
+        credentialRepairAccount={{
+          id: "second-invalid",
+          label: "Shared label",
+          source: "api-key",
+          health: "invalid",
+        }}
+      />,
+    );
+    expect(
+      (screen.getByLabelText("Coding-plan key") as HTMLInputElement).value,
+    ).toBe("");
   });
 
   it("submits an OAuth callback code and reports terminal stream errors", async () => {

--- a/packages/ui/src/components/accounts/AddAccountDialog.component.test.tsx
+++ b/packages/ui/src/components/accounts/AddAccountDialog.component.test.tsx
@@ -226,6 +226,31 @@ describe("AddAccountDialog", () => {
     expect(screen.queryByRole("button", { name: /Log in/ })).toBeNull();
   });
 
+  it("explains the server replacement gap before repairing an OAuth account", () => {
+    render(
+      <AddAccountDialog
+        open
+        providerId="anthropic-subscription"
+        credentialRepairAccount={{
+          id: "expired-account",
+          label: "Work Claude",
+          source: "oauth",
+          health: "needs-reauth",
+        }}
+        onClose={vi.fn()}
+        onCreated={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Reauthenticate Work Claude")).toBeTruthy();
+    expect(
+      screen.getByText(/creates a fresh account in the same pool/),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Log in and paste a code" }),
+    ).toBeTruthy();
+  });
+
   it("submits an OAuth callback code and reports terminal stream errors", async () => {
     api.startAccountOAuth.mockResolvedValue({
       sessionId: "session-code",

--- a/packages/ui/src/components/accounts/AddAccountDialog.tsx
+++ b/packages/ui/src/components/accounts/AddAccountDialog.tsx
@@ -46,11 +46,7 @@ interface AddAccountDialogProps {
   open: boolean;
   /** Optional initial provider. When omitted, the dialog starts with the consolidated provider picker. */
   providerId?: LinkedAccountProviderId;
-  /**
-   * Unhealthy account that launched this flow. The current OAuth contract
-   * cannot replace an existing id, so repair creates a fresh account in the
-   * same provider pool. The dialog makes that limitation explicit.
-   */
+  /** Unhealthy account whose credential is replaced in place after verification. */
   credentialRepairAccount?: Pick<
     LinkedAccountConfig,
     "id" | "label" | "source" | "health"
@@ -77,7 +73,11 @@ interface SseFlowState {
 }
 
 type SubscriptionAddMode =
-  "oauth" | "api-key" | "external-cli" | "unavailable" | "none";
+  | "oauth"
+  | "api-key"
+  | "external-cli"
+  | "unavailable"
+  | "none";
 
 // The static provider catalog + its types now live in their own module so
 // presentational pieces can import them without a circular dependency on this
@@ -252,8 +252,11 @@ export function AddAccountDialog({
         : "provider-select",
     );
     setLabel(
-      credentialRepairAccount?.label ??
-        (activeProviderId ? defaultOAuthLabel(activeProviderId) : ""),
+      credentialRepairAccount?.id
+        ? credentialRepairAccount.label
+        : activeProviderId
+          ? defaultOAuthLabel(activeProviderId)
+          : "",
     );
     setApiKey("");
     setOauthCode("");
@@ -262,7 +265,12 @@ export function AddAccountDialog({
     setDeviceCode(null);
     setDeviceCodeCopied(false);
     setOauthUrl(null);
-  }, [closeEventSource, activeProviderId, credentialRepairAccount?.label]);
+  }, [
+    closeEventSource,
+    activeProviderId,
+    credentialRepairAccount?.id,
+    credentialRepairAccount?.label,
+  ]);
 
   const copyDeviceCode = useCallback(async (code: string) => {
     try {
@@ -430,6 +438,9 @@ export function AddAccountDialog({
         const flow = await client.startAccountOAuth(activeProviderId, {
           label: label.trim(),
           mode,
+          ...(credentialRepairAccount
+            ? { replaceAccountId: credentialRepairAccount.id }
+            : {}),
         });
         sessionIdRef.current = flow.sessionId;
         restoredSessionRef.current = flow.sessionId;
@@ -472,7 +483,14 @@ export function AddAccountDialog({
         }
       }
     },
-    [label, activeProviderId, subscribeToFlow, subscriptionAddMode, t],
+    [
+      label,
+      activeProviderId,
+      credentialRepairAccount,
+      subscribeToFlow,
+      subscriptionAddMode,
+      t,
+    ],
   );
 
   const submitOAuthCode = useCallback(
@@ -521,6 +539,9 @@ export function AddAccountDialog({
         const account = await client.createApiKeyAccount(activeProviderId, {
           label: trimmedLabel,
           apiKey: trimmedKey,
+          ...(credentialRepairAccount
+            ? { replaceAccountId: credentialRepairAccount.id }
+            : {}),
         });
         onCreated(account);
         onClose();
@@ -536,7 +557,15 @@ export function AddAccountDialog({
         setStep("error");
       }
     },
-    [apiKey, label, onClose, onCreated, activeProviderId, t],
+    [
+      apiKey,
+      label,
+      onClose,
+      onCreated,
+      activeProviderId,
+      credentialRepairAccount,
+      t,
+    ],
   );
 
   const handleClose = useCallback(() => {
@@ -574,20 +603,35 @@ export function AddAccountDialog({
       providerId ? initialStepForProvider(providerId) : "provider-select",
     );
     setLabel(
-      credentialRepairAccount?.label ??
-        (providerId ? defaultOAuthLabel(providerId) : ""),
+      credentialRepairAccount?.id
+        ? credentialRepairAccount.label
+        : providerId
+          ? defaultOAuthLabel(providerId)
+          : "",
     );
-  }, [open, providerId, credentialRepairAccount?.label]);
+    setApiKey("");
+    setOauthCode("");
+    setErrorMessage(null);
+    setSessionId(null);
+    setDeviceCode(null);
+    setDeviceCodeCopied(false);
+    setOauthUrl(null);
+  }, [
+    open,
+    providerId,
+    credentialRepairAccount?.id,
+    credentialRepairAccount?.label,
+  ]);
 
   const dialogDescription = credentialRepairAccount
     ? credentialRepairAccount.source === "oauth"
       ? t("accounts.reauthenticate.description", {
           defaultValue:
-            "Sign in again with this provider. Until the server supports replacing credentials by account id, this creates a fresh account in the same pool; remove the expired entry after sign-in succeeds.",
+            "Sign in again with the same provider. Your current credential stays active until the new sign-in succeeds, then this account is updated in place.",
         })
       : t("accounts.replaceCredential.description", {
           defaultValue:
-            "Enter a new credential for this provider. This creates a fresh account in the same pool; remove the invalid entry after the new credential is verified.",
+            "Enter a new credential for the same provider. The current credential stays unchanged until the replacement is verified and saved.",
         })
     : !activeProviderId
       ? t("accounts.add.chooseDescription", {
@@ -718,7 +762,9 @@ export function AddAccountDialog({
         {step === "choose" ? (
           <div className="grid gap-3 py-2">
             <p className="text-xs text-muted">
-              The connected account's email address will be used as its name.
+              {credentialRepairAccount
+                ? `${credentialRepairAccount.label} keeps its name, priority, and position in the account pool.`
+                : "The connected account's email address will be used as its name."}
             </p>
             <Button
               type="button"
@@ -892,7 +938,14 @@ export function AddAccountDialog({
 
         {step === "apikey" || step === "apikey-submitting" ? (
           <form onSubmit={submitApiKey} className="grid gap-3 py-2">
-            {labelInput}
+            {credentialRepairAccount ? (
+              <div className="rounded-sm border border-border/50 bg-bg-accent/50 px-3 py-2 text-xs text-muted">
+                Replacing the credential for {credentialRepairAccount.label}.
+                The account name and pool position will not change.
+              </div>
+            ) : (
+              labelInput
+            )}
             <div className="grid gap-1.5">
               <Label htmlFor="add-account-apikey">{apiKeyLabel}</Label>
               <Input

--- a/packages/ui/src/components/accounts/AddAccountDialog.tsx
+++ b/packages/ui/src/components/accounts/AddAccountDialog.tsx
@@ -46,6 +46,15 @@ interface AddAccountDialogProps {
   open: boolean;
   /** Optional initial provider. When omitted, the dialog starts with the consolidated provider picker. */
   providerId?: LinkedAccountProviderId;
+  /**
+   * Unhealthy account that launched this flow. The current OAuth contract
+   * cannot replace an existing id, so repair creates a fresh account in the
+   * same provider pool. The dialog makes that limitation explicit.
+   */
+  credentialRepairAccount?: Pick<
+    LinkedAccountConfig,
+    "id" | "label" | "source" | "health"
+  > | null;
   onClose: () => void;
   onCreated: (account: LinkedAccountConfig) => void;
 }
@@ -68,11 +77,7 @@ interface SseFlowState {
 }
 
 type SubscriptionAddMode =
-  | "oauth"
-  | "api-key"
-  | "external-cli"
-  | "unavailable"
-  | "none";
+  "oauth" | "api-key" | "external-cli" | "unavailable" | "none";
 
 // The static provider catalog + its types now live in their own module so
 // presentational pieces can import them without a circular dependency on this
@@ -180,6 +185,7 @@ function providerDisplayName(
 export function AddAccountDialog({
   open,
   providerId,
+  credentialRepairAccount = null,
   onClose,
   onCreated,
 }: AddAccountDialogProps) {
@@ -196,8 +202,10 @@ export function AddAccountDialog({
       ? initialStepForProvider(activeProviderId)
       : "provider-select",
   );
-  const [label, setLabel] = useState(() =>
-    activeProviderId ? defaultOAuthLabel(activeProviderId) : "",
+  const [label, setLabel] = useState(
+    () =>
+      credentialRepairAccount?.label ??
+      (activeProviderId ? defaultOAuthLabel(activeProviderId) : ""),
   );
   const [apiKey, setApiKey] = useState("");
   const [oauthCode, setOauthCode] = useState("");
@@ -243,7 +251,10 @@ export function AddAccountDialog({
         ? initialStepForProvider(activeProviderId)
         : "provider-select",
     );
-    setLabel(activeProviderId ? defaultOAuthLabel(activeProviderId) : "");
+    setLabel(
+      credentialRepairAccount?.label ??
+        (activeProviderId ? defaultOAuthLabel(activeProviderId) : ""),
+    );
     setApiKey("");
     setOauthCode("");
     setErrorMessage(null);
@@ -251,7 +262,7 @@ export function AddAccountDialog({
     setDeviceCode(null);
     setDeviceCodeCopied(false);
     setOauthUrl(null);
-  }, [closeEventSource, activeProviderId]);
+  }, [closeEventSource, activeProviderId, credentialRepairAccount?.label]);
 
   const copyDeviceCode = useCallback(async (code: string) => {
     try {
@@ -562,38 +573,51 @@ export function AddAccountDialog({
     setStep(
       providerId ? initialStepForProvider(providerId) : "provider-select",
     );
-    setLabel(providerId ? defaultOAuthLabel(providerId) : "");
-  }, [open, providerId]);
+    setLabel(
+      credentialRepairAccount?.label ??
+        (providerId ? defaultOAuthLabel(providerId) : ""),
+    );
+  }, [open, providerId, credentialRepairAccount?.label]);
 
-  const dialogDescription = !activeProviderId
-    ? t("accounts.add.chooseDescription", {
-        defaultValue:
-          "Choose the provider you want to connect. Chat providers use API keys; coding subscriptions use first-party login or dedicated plan credentials.",
-      })
-    : subscriptionAddMode === "oauth"
-      ? t("accounts.add.subscriptionDescription", {
+  const dialogDescription = credentialRepairAccount
+    ? credentialRepairAccount.source === "oauth"
+      ? t("accounts.reauthenticate.description", {
           defaultValue:
-            "Sign in with the provider's first-party coding account flow to add another account to the rotation pool.",
+            "Sign in again with this provider. Until the server supports replacing credentials by account id, this creates a fresh account in the same pool; remove the expired entry after sign-in succeeds.",
         })
-      : subscriptionAddMode === "api-key"
-        ? t("accounts.add.codingPlanDescription", {
+      : t("accounts.replaceCredential.description", {
+          defaultValue:
+            "Enter a new credential for this provider. This creates a fresh account in the same pool; remove the invalid entry after the new credential is verified.",
+        })
+    : !activeProviderId
+      ? t("accounts.add.chooseDescription", {
+          defaultValue:
+            "Choose the provider you want to connect. Chat providers use API keys; coding subscriptions use first-party login or dedicated plan credentials.",
+        })
+      : subscriptionAddMode === "oauth"
+        ? t("accounts.add.subscriptionDescription", {
             defaultValue:
-              "Paste a coding-plan credential for the provider's dedicated coding endpoint. It will not be used as a general API key.",
+              "Sign in with the provider's first-party coding account flow to add another account to the rotation pool.",
           })
-        : subscriptionAddMode === "external-cli"
-          ? t("accounts.add.externalCliDescription", {
+        : subscriptionAddMode === "api-key"
+          ? t("accounts.add.codingPlanDescription", {
               defaultValue:
-                "This subscription is managed by the provider's CLI. The app does not import or replay CLI tokens.",
+                "Paste a coding-plan credential for the provider's dedicated coding endpoint. It will not be used as a general API key.",
             })
-          : subscriptionAddMode === "unavailable"
-            ? t("accounts.add.unavailableDescription", {
+          : subscriptionAddMode === "external-cli"
+            ? t("accounts.add.externalCliDescription", {
                 defaultValue:
-                  "This provider does not expose a safe first-party coding subscription surface for linking here.",
+                  "This subscription is managed by the provider's CLI. The app does not import or replay CLI tokens.",
               })
-            : t("accounts.add.apiDescription", {
-                defaultValue:
-                  "Paste your API key. The key is stored locally with mode 0600.",
-              });
+            : subscriptionAddMode === "unavailable"
+              ? t("accounts.add.unavailableDescription", {
+                  defaultValue:
+                    "This provider does not expose a safe first-party coding subscription surface for linking here.",
+                })
+              : t("accounts.add.apiDescription", {
+                  defaultValue:
+                    "Paste your API key. The key is stored locally with mode 0600.",
+                });
 
   const apiKeyLabel =
     subscriptionAddMode === "api-key"
@@ -666,10 +690,20 @@ export function AddAccountDialog({
         <DialogHeader>
           <DialogTitle>
             {activeProviderId
-              ? t("accounts.add.title", {
-                  defaultValue: `Add ${providerDisplayName(activeProviderId, t)} account`,
-                  provider: providerDisplayName(activeProviderId, t),
-                })
+              ? credentialRepairAccount
+                ? credentialRepairAccount.source === "oauth"
+                  ? t("accounts.reauthenticate.title", {
+                      defaultValue: `Reauthenticate ${credentialRepairAccount.label}`,
+                      account: credentialRepairAccount.label,
+                    })
+                  : t("accounts.replaceCredential.title", {
+                      defaultValue: `Replace credential for ${credentialRepairAccount.label}`,
+                      account: credentialRepairAccount.label,
+                    })
+                : t("accounts.add.title", {
+                    defaultValue: `Add ${providerDisplayName(activeProviderId, t)} account`,
+                    provider: providerDisplayName(activeProviderId, t),
+                  })
               : t("accounts.add.chooseTitle", {
                   defaultValue: "Add a provider account",
                 })}
@@ -881,6 +915,10 @@ export function AddAccountDialog({
             >
               {step === "apikey-submitting" ? (
                 <Spinner className="h-3 w-3" />
+              ) : credentialRepairAccount ? (
+                t("accounts.replaceCredential.save", {
+                  defaultValue: "Save replacement",
+                })
               ) : (
                 t("accounts.add.save", { defaultValue: "Add account" })
               )}

--- a/packages/ui/src/components/accounts/ProviderAccountRow.tsx
+++ b/packages/ui/src/components/accounts/ProviderAccountRow.tsx
@@ -52,6 +52,10 @@ interface ProviderAccountRowProps {
     providerId: SubscriptionProviderSelectionId,
   ) => Promise<void> | void;
   onAdd: (providerId: LinkedAccountProviderId) => void;
+  onReauthenticate?: (
+    providerId: LinkedAccountProviderId,
+    account: AccountWithCredentialFlag,
+  ) => void;
   saving: Set<string>;
   onPatch: (
     providerId: LinkedAccountProviderId,
@@ -155,6 +159,7 @@ export function ProviderAccountRow({
   onSelectChatProvider,
   onSelectSubscription,
   onAdd,
+  onReauthenticate,
   saving,
   onPatch,
   onMove,
@@ -401,6 +406,11 @@ export function ProviderAccountRow({
                   onTest={() => onTest(option.id, account.id)}
                   onRefreshUsage={() => onRefreshUsage(option.id, account.id)}
                   onDelete={() => onDelete(option.id, account.id)}
+                  onReauthenticate={
+                    onReauthenticate
+                      ? () => onReauthenticate(option.id, account)
+                      : undefined
+                  }
                 />
               </div>
             ))}


### PR DESCRIPTION
## Summary

- adds account health, usage, pool status, selection-state, and credential-repair actions to the Models & Providers surface
- repairs OAuth and API-key credentials in place through an explicit `replaceAccountId` contract
- stores the OAuth replacement target in server-owned flow state, validates provider and identity before adoption, and rolls back credentials/metadata if adoption fails
- keeps `needs-reauth` and `invalid` terminal during usage refresh until canonical credential replacement succeeds
- removes the ambiguous duplicate-label repair path and preserves the account name, priority, enabled state, and pool position

## Testing

- `bun run --cwd packages/auth test -- oauth-flow.test.ts` (19 passed)
- `bunx vitest run --config packages/agent/vitest.config.ts packages/agent/src/api/accounts-routes.test.ts` (10 passed)
- `bun run --cwd packages/ui test -- src/api/client-agent-accounts.test.ts src/components/accounts/AccountCard.test.tsx src/components/accounts/AccountManagementPanel.test.tsx src/components/accounts/AddAccountDialog.component.test.tsx` (26 passed)
- `bun run --cwd packages/auth typecheck`
- `bun run --cwd packages/agent typecheck`
- `bun run --cwd packages/ui typecheck`
- focused Biome check and `git diff --check`
- changed-source coverage gate: 79.92% mean, 65.22% minimum, threshold 50%
- Codex review run before push; the stale `healthDetail` finding was fixed and regression-tested

<!-- pr-evidence:start -->
## PR Evidence

### Screenshots

| Before | After |
|---|---|
| [Desktop: stale repair flow created a second account](https://github.com/0xSolace/eliza/releases/download/pr-16314-evidence-v1/before-desktop-repair-dialog.jpg) | [Desktop: explicit in-place replacement](https://github.com/0xSolace/eliza/releases/download/pr-16314-evidence-v1/after-desktop-repair-dialog.jpg) |
| [Mobile before](https://github.com/0xSolace/eliza/releases/download/pr-16314-evidence-v1/before-mobile-repair-dialog.jpg) | [Mobile after](https://github.com/0xSolace/eliza/releases/download/pr-16314-evidence-v1/after-mobile-repair-dialog.jpg) |

### Video

- [Rendered repair walkthrough (MP4)](https://github.com/0xSolace/eliza/releases/download/pr-16314-evidence-v1/walkthrough.mp4)

### Logs and validation

| Artifact | Receipt |
|---|---|
| Frontend logs | [Network log showing the initiating `replaceAccountId` payload and successful server-owned flow session](https://github.com/0xSolace/eliza/releases/download/pr-16314-evidence-v1/frontend-network.log) |
| Backend logs | [Focused auth and account-route test log](https://github.com/0xSolace/eliza/releases/download/pr-16314-evidence-v1/backend-tests.log) |
| Validation | [Final focused tests, three package typechecks, Biome, and diff check](https://github.com/0xSolace/eliza/releases/download/pr-16314-evidence-v1/final-validation.log) |
| Coverage | [Changed-source coverage gate receipt](https://github.com/0xSolace/eliza/releases/download/pr-16314-evidence-v1/coverage-gate.log) |
| OCR/layout review | [Desktop/mobile evidence text and dimensions](https://github.com/0xSolace/eliza/releases/download/pr-16314-evidence-v1/ocr-review.txt) |

### Manual checks

- [x] Before and after capture the same unhealthy Anthropic account in the Models & Providers UI.
- [x] Desktop and 390x844 mobile layouts were rendered from the branch UI in an isolated sandbox.
- [x] Repair no longer exposes an editable stale label or instructs the user to delete an ambiguous duplicate.
- [x] OAuth initiation sends `replaceAccountId`; callback adoption reads the target from server-owned flow state rather than callback query input.
- [x] Same-provider success, provider mismatch, missing target, failed OAuth preservation, adoption rollback, duplicate callback idempotency, terminal-health preservation, action rendering, and id-keyed form reset are covered.
- [x] No production credentials or user data appear in the artifacts.
<!-- pr-evidence:end -->

## Evidence rows

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/0xSolace/eliza/releases/download/pr-16314-evidence-v1/before-desktop-repair-dialog.jpg)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/0xSolace/eliza/releases/download/pr-16314-evidence-v1/after-desktop-repair-dialog.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/0xSolace/eliza/releases/download/pr-16314-evidence-v1/walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [x] [backend-tests.log](https://github.com/0xSolace/eliza/releases/download/pr-16314-evidence-v1/backend-tests.log)

<!-- evidence-row:frontend-logs -->
- [x] [frontend-network.log](https://github.com/0xSolace/eliza/releases/download/pr-16314-evidence-v1/frontend-network.log)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic account/credential management flows; no LLM-driven behavior changed in this PR

<!-- evidence-row:domain-artifacts -->
- [x] [coverage-gate.log](https://github.com/0xSolace/eliza/releases/download/pr-16314-evidence-v1/coverage-gate.log)

<!-- evidence-row:ocr-review -->
- [x] OCR visual text review: [ocr-review.txt](https://github.com/0xSolace/eliza/releases/download/pr-16314-evidence-v1/ocr-review.txt)
