### PR TITLE
test(voice): keep CLI evidence runs out of the real user home

### DIFF
--- a/packages/tools/voice-evidence-harness/README.md
+++ b/packages/tools/voice-evidence-harness/README.md
@@ -71,6 +71,16 @@ The harness **exits non-zero** if any required stage/artifact is missing — the
 is NO path that turns absent data into a healthy zero (the 16011 closure cited
 exactly that).
 
+Two env overrides (both must be **absolute** paths; blank or relative values
+fail loudly) redirect the CLI's home-derived locations — tests use them to keep
+runs out of the real `~/.moltbot` tree, since reassigning `HOME` does not move
+Bun's `os.homedir()` (#16180):
+
+- `VOICE_EVIDENCE_ROOT` — where evidence runs are written (default
+  `~/.moltbot/projects/eliza-fleet/evidence/voice-e2e`).
+- `VOICE_EVIDENCE_SECRETS_DIR` — where `deepgram.json` / `cartesia.json` are
+  read (default `~/.moltbot/secrets`).
+
 ## Scenarios
 
 - **baseline** — full happy-path turn: mint → hello → ready → real STT final →

--- a/packages/tools/voice-evidence-harness/src/cli-run.test.ts
+++ b/packages/tools/voice-evidence-harness/src/cli-run.test.ts
@@ -1,18 +1,34 @@
 /**
- * Coverage for the harness CLI orchestration (main -> runScenario -> buildReadme).
- * The live seams (secret files, reference server, WS client, ffmpeg/MP4) are
- * faked; the REAL Evidence sink writes into a temp dir. A `--scenario=baseline`
- * run exercises the full evidence pipeline: fixture load, mint, client run with
- * all required stages marked, output-wav write, domain/timing/interrupt
- * artifacts, README build, and the top-level INDEX + pass path. The
- * process.exit + argv globals are saved/restored, and the mocks are restored in
- * afterAll so the non-isolated coverage lane's siblings are not poisoned.
+ * Coverage for the harness CLI orchestration (main -> runScenario -> buildReadme)
+ * plus the #16180 home-isolation contract. The live seams (reference server, WS
+ * client, ffmpeg/MP4, real target) are faked; the filesystem is REAL: secrets
+ * are real JSON files in a temp dir the CLI reads via VOICE_EVIDENCE_SECRETS_DIR,
+ * the fixture is the real committed WAV, and the REAL Evidence sink writes into
+ * the VOICE_EVIDENCE_ROOT temp dir. Every test asserts all produced artifacts
+ * stay below the mkdtemp root and that the real ~/.moltbot tree has zero delta
+ * (reassigning process.env.HOME is NOT sufficient under Bun — homedir() keeps
+ * returning the real account home, which is how the original leak happened).
+ * A subprocess leg runs the real, unmocked CLI to a loud failure and proves the
+ * failure path honors the seam too. The process.exit + argv globals are
+ * saved/restored, and the mocks are restored in afterAll so sibling suites in
+ * the same bun process are not poisoned.
  */
 
 import { afterAll, afterEach, beforeEach, expect, mock, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join, relative, sep } from "node:path";
+import { fileURLToPath } from "node:url";
 
 class ExitSignal extends Error {
   constructor(readonly code: number) {
@@ -20,46 +36,69 @@ class ExitSignal extends Error {
   }
 }
 
-import * as realFs from "node:fs";
 import * as realClient from "./client.ts";
 import * as realMp4 from "./mp4.ts";
+import { EVIDENCE_ROOT_ENV, SECRETS_DIR_ENV } from "./paths.ts";
 import * as realRealTarget from "./real/real-target.ts";
 import * as realServer from "./reference/voice-session-server.ts";
-import { writeWav } from "./wav.ts";
 
-const realFsExports = { ...realFs };
 const realClientExports = { ...realClient };
 const realServerExports = { ...realServer };
 const realRealTargetExports = { ...realRealTarget };
 const realMp4Exports = { ...realMp4 };
 
-// A valid linear16 mono 16k WAV the fixture reads resolve to.
-const fixtureWav = writeWav({
-  pcm: new Uint8Array(64),
-  sampleRate: 16000,
-  channels: 1,
-  bitsPerSample: 16,
-  audioFormat: 1,
-});
+const PKG_DIR = fileURLToPath(new URL("..", import.meta.url));
 
-// readFileSync: fake the two secret JSONs + any *.wav fixture; delegate the rest
-// (Evidence's own reads are writes, so this is safe).
-mock.module("node:fs", () => ({
-  ...realFsExports,
-  readFileSync: (p: unknown, ...rest: unknown[]) => {
-    const path = String(p);
-    if (path.endsWith("deepgram.json"))
-      return JSON.stringify({ api_key: "dg" });
-    if (path.endsWith("cartesia.json"))
-      return JSON.stringify({ api_key: "ct" });
-    if (path.endsWith(".wav")) return Buffer.from(fixtureWav);
-    if (path.endsWith("walkthrough.mp4")) return Buffer.from([0, 0, 0, 0]);
-    return (realFsExports.readFileSync as typeof realFs.readFileSync)(
-      p as string,
-      ...(rest as []),
+// The real account home, captured before any test touches process.env.HOME.
+// Bun's homedir() ignores a HOME reassignment, so this is what the pre-#16180
+// CLI actually wrote under — the no-delta assertions below guard exactly it.
+const REAL_HOME = homedir();
+const REAL_MOLTBOT = join(REAL_HOME, ".moltbot");
+
+/**
+ * Serialize a directory tree (names, kinds, sizes, mtimes) for before/after
+ * comparison. Any write anywhere below `root` — new file, new dir, touched
+ * mtime, changed size — changes the serialization. `<absent>` keeps a missing
+ * root (fresh CI account) distinguishable from an empty one.
+ */
+function snapshotTree(root: string): string {
+  if (!existsSync(root)) return "<absent>";
+  const lines: string[] = [];
+  const walk = (dir: string): void => {
+    const entries = readdirSync(dir, { withFileTypes: true }).sort((a, b) =>
+      a.name.localeCompare(b.name),
     );
-  },
-}));
+    for (const entry of entries) {
+      const p = join(dir, entry.name);
+      const st = lstatSync(p);
+      const kind = entry.isDirectory()
+        ? "dir"
+        : entry.isSymbolicLink()
+          ? "link"
+          : "file";
+      lines.push(
+        `${relative(root, p)} ${kind} size=${st.size} mtimeMs=${st.mtimeMs}`,
+      );
+      if (entry.isDirectory()) walk(p);
+    }
+  };
+  walk(root);
+  return lines.join("\n");
+}
+
+/** Absolute paths of every file below `root` (throws if root is missing). */
+function listFilesRecursive(root: string): string[] {
+  const files: string[] = [];
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const p = join(dir, entry.name);
+      if (entry.isDirectory()) walk(p);
+      else files.push(p);
+    }
+  };
+  walk(root);
+  return files;
+}
 
 // Reference server double: mint + a no-op stop. runScenario wires hooks but our
 // faked runClient marks the stages, so the server internals are not needed here.
@@ -93,11 +132,16 @@ const realTargetStub = () => ({
 });
 mock.module("./real/real-target.ts", realTargetStub);
 
-// MP4: report ffmpeg present + a successful assembly so the mp4 branch runs.
+// MP4: report ffmpeg present and write a real (fake-content) walkthrough.mp4 so
+// the CLI's read-back-and-index step exercises the real filesystem — this suite
+// deliberately mocks no fs API.
 const mp4Stub = () => ({
   ...realMp4Exports,
   ensureFfmpeg: () => ({ ok: true, version: "6.0", installHint: "hint" }),
-  assembleMp4: () => ({ ok: true }),
+  assembleMp4: (params: { dir: string; out: string }) => {
+    writeFileSync(join(params.dir, params.out), new Uint8Array([0, 0, 0, 0]));
+    return { ok: true };
+  },
 });
 mock.module("./mp4.ts", mp4Stub);
 
@@ -146,27 +190,57 @@ mock.module("./client.ts", clientStub);
 const originalArgv = process.argv;
 const originalHome = process.env.HOME;
 const originalOpenRouter = process.env.OPENROUTER_API_KEY;
-let tmpHome = "";
+const originalEvidenceRoot = process.env[EVIDENCE_ROOT_ENV];
+const originalSecretsDir = process.env[SECRETS_DIR_ENV];
+let tmpRoot = "";
+let evidenceOverrideRoot = "";
+let secretsOverrideDir = "";
+let realMoltbotBefore = "";
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
 
 beforeEach(() => {
   clientResultOverride = {};
   markStages = true;
-  tmpHome = mkdtempSync(join(tmpdir(), "cli-home-"));
-  process.env.HOME = tmpHome;
+  tmpRoot = mkdtempSync(join(tmpdir(), "voice-evidence-cli-"));
+  evidenceOverrideRoot = join(tmpRoot, "evidence");
+  secretsOverrideDir = join(tmpRoot, "secrets");
+  // REAL secret files in the override dir: the CLI's loadSecret() performs a
+  // genuine disk read through the seam (nothing intercepts readFileSync here).
+  mkdirSync(secretsOverrideDir, { recursive: true });
+  writeFileSync(
+    join(secretsOverrideDir, "deepgram.json"),
+    JSON.stringify({ api_key: "dg-test" }),
+  );
+  writeFileSync(
+    join(secretsOverrideDir, "cartesia.json"),
+    JSON.stringify({ api_key: "ct-test" }),
+  );
+  process.env[EVIDENCE_ROOT_ENV] = evidenceOverrideRoot;
+  process.env[SECRETS_DIR_ENV] = secretsOverrideDir;
+  // Reassigned for hygiene only: Bun's homedir() ignores it (#16180), which is
+  // why the two explicit overrides above are the actual isolation mechanism.
+  process.env.HOME = tmpRoot;
   process.env.OPENROUTER_API_KEY = "or-key";
+  realMoltbotBefore = snapshotTree(REAL_MOLTBOT);
 });
 
 afterEach(() => {
   process.argv = originalArgv;
-  if (originalHome === undefined) delete process.env.HOME;
-  else process.env.HOME = originalHome;
-  if (originalOpenRouter === undefined) delete process.env.OPENROUTER_API_KEY;
-  else process.env.OPENROUTER_API_KEY = originalOpenRouter;
-  if (tmpHome) rmSync(tmpHome, { recursive: true, force: true });
+  restoreEnv("HOME", originalHome);
+  restoreEnv("OPENROUTER_API_KEY", originalOpenRouter);
+  restoreEnv(EVIDENCE_ROOT_ENV, originalEvidenceRoot);
+  restoreEnv(SECRETS_DIR_ENV, originalSecretsDir);
+  // Safety net behind the per-test assertions: no test may leave a delta under
+  // the real ~/.moltbot tree.
+  expect(snapshotTree(REAL_MOLTBOT)).toBe(realMoltbotBefore);
+  if (tmpRoot) rmSync(tmpRoot, { recursive: true, force: true });
 });
 
 afterAll(() => {
-  mock.module("node:fs", () => realFsExports);
   mock.module("./client.ts", () => realClientExports);
   mock.module("./reference/voice-session-server.ts", () => realServerExports);
   mock.module("./real/real-target.ts", () => realRealTargetExports);
@@ -204,7 +278,7 @@ async function importCli(): Promise<Array<number | undefined>> {
   return localExits;
 }
 
-test("baseline reference scenario runs the full evidence pipeline end-to-end", async () => {
+test("baseline reference scenario runs the full evidence pipeline under the override root", async () => {
   // main() only runs once per test process (module is cached after the first
   // import), and we import cli.ts WITHOUT a query bust so coverage lands on
   // cli.ts. A baseline reference run drives the fullest single-scenario path:
@@ -219,4 +293,83 @@ test("baseline reference scenario runs the full evidence pipeline end-to-end", a
   const exits = await importCli();
   // The fully-faked baseline run meets its DoD -> no non-zero exit.
   expect(exits.every((c) => c === 0 || c === undefined)).toBe(true);
+
+  // Exactly one timestamped run dir, created under the override root.
+  const runDirs = readdirSync(evidenceOverrideRoot);
+  expect(runDirs).toHaveLength(1);
+  const runDir = join(evidenceOverrideRoot, runDirs[0]);
+  const indexMd = readFileSync(join(runDir, "INDEX.md"), "utf8");
+  expect(indexMd).toContain("| baseline | PASS |");
+
+  // Every artifact of the run sits below the mkdtemp root — nothing may escape
+  // toward the real home (#16180 acceptance criterion).
+  const artifacts = listFilesRecursive(evidenceOverrideRoot);
+  expect(artifacts.length).toBeGreaterThan(0);
+  for (const artifact of artifacts) {
+    expect(artifact.startsWith(tmpRoot + sep)).toBe(true);
+  }
+
+  // The complete per-scenario DoD artifact set landed in <run>/baseline/.
+  const produced = new Set(
+    artifacts.map((artifactPath) => relative(runDir, artifactPath)),
+  );
+  for (const expected of [
+    "INDEX.md",
+    "baseline/input.wav",
+    "baseline/output-tts.wav",
+    "baseline/domain-rows.json",
+    "baseline/timing-report.json",
+    "baseline/interrupt-assertion.json",
+    "baseline/ws-transcript.json",
+    "baseline/server.log.json",
+    "baseline/client.log.json",
+    "baseline/all.log.json",
+    "baseline/walkthrough.mp4",
+    "baseline/README.md",
+  ]) {
+    expect(produced.has(expected)).toBe(true);
+  }
+
+  // input.wav is the REAL committed fixture, read through the real fs.
+  const fixtureBytes = readFileSync(join(PKG_DIR, "fixtures/turn_weather.wav"));
+  const capturedInput = readFileSync(join(runDir, "baseline/input.wav"));
+  expect(capturedInput.equals(fixtureBytes)).toBe(true);
+
+  // The real ~/.moltbot tree is untouched by the passing run.
+  expect(snapshotTree(REAL_MOLTBOT)).toBe(realMoltbotBefore);
+});
+
+test("failing CLI subprocess (real, unmocked) keeps every write under the override root", () => {
+  // The real cli.ts, no module mocks: secrets resolve through
+  // VOICE_EVIDENCE_SECRETS_DIR (a genuine disk read of the temp JSONs proves
+  // the secrets seam), then the missing OPENROUTER_API_KEY fails the run
+  // loudly. The evidence dir is created before that failure, so this leg
+  // proves the FAILURE path also lands under the override root and leaves the
+  // real home untouched.
+  const childEnv: Record<string, string | undefined> = { ...process.env };
+  delete childEnv.OPENROUTER_API_KEY;
+  const res = spawnSync(
+    process.execPath,
+    ["run", "src/cli.ts", "--scenario=baseline", "--target=reference"],
+    { cwd: PKG_DIR, env: childEnv, encoding: "utf8", timeout: 120_000 },
+  );
+  expect(res.error).toBeUndefined();
+  expect(res.status).toBe(1);
+  expect(`${res.stdout}\n${res.stderr}`).toContain(
+    "OPENROUTER_API_KEY not set",
+  );
+
+  // The failure still produced its (partial) evidence tree under the override
+  // root: one timestamped run dir containing the baseline scenario dir.
+  const runDirs = readdirSync(evidenceOverrideRoot);
+  expect(runDirs).toHaveLength(1);
+  const scenarioDir = join(evidenceOverrideRoot, runDirs[0], "baseline");
+  expect(lstatSync(scenarioDir).isDirectory()).toBe(true);
+  for (const artifact of listFilesRecursive(evidenceOverrideRoot)) {
+    expect(artifact.startsWith(tmpRoot + sep)).toBe(true);
+  }
+
+  // No delta anywhere under the real ~/.moltbot tree — the default evidence
+  // root and the default secrets dir both live below it.
+  expect(snapshotTree(REAL_MOLTBOT)).toBe(realMoltbotBefore);
 });

--- a/packages/tools/voice-evidence-harness/src/cli.ts
+++ b/packages/tools/voice-evidence-harness/src/cli.ts
@@ -9,7 +9,10 @@
  *   1. starts the reference §7 server wired to the REAL merged adapters + LIVE keys,
  *   2. drives a real WS voice turn with a real spoken WAV fixture,
  *   3. captures EVERY DoD artifact into
- *      ~/.moltbot/projects/eliza-fleet/evidence/voice-e2e/<timestamp>/<scenario>/,
+ *      ~/.moltbot/projects/eliza-fleet/evidence/voice-e2e/<timestamp>/<scenario>/
+ *      (evidence root and secrets dir are overridable via VOICE_EVIDENCE_ROOT /
+ *      VOICE_EVIDENCE_SECRETS_DIR — see paths.ts; tests use those to keep runs
+ *      out of the real user home, #16180),
  *   4. asserts post-interrupt frame count == 0 (barge-in),
  *   5. FAILS LOUDLY (non-zero exit) if any required stage/artifact is missing.
  */
@@ -20,6 +23,7 @@ import { join } from "node:path";
 import { type ClientRunResult, runClient } from "./client.ts";
 import { Evidence, type StageName } from "./evidence.ts";
 import { assembleMp4, ensureFfmpeg } from "./mp4.ts";
+import { evidenceRoot, secretPath } from "./paths.ts";
 import { startRealTarget } from "./real/real-target.ts";
 import {
   type DomainRow,
@@ -31,9 +35,6 @@ import { parseWav, writeWav } from "./wav.ts";
 type Target = "reference" | "real";
 
 const HARNESS_DIR = new URL("..", import.meta.url).pathname;
-function evidenceRoot(): string {
-  return join(homedir(), ".moltbot/projects/eliza-fleet/evidence/voice-e2e");
-}
 
 type Scenario = "baseline" | "bargein" | "error-auth";
 
@@ -53,14 +54,8 @@ function loadSecret(path: string, field: string): string {
 }
 
 function providerConfig(): ProviderConfig {
-  const deepgramApiKey = loadSecret(
-    join(homedir(), ".moltbot/secrets/deepgram.json"),
-    "api_key",
-  );
-  const cartesiaApiKey = loadSecret(
-    join(homedir(), ".moltbot/secrets/cartesia.json"),
-    "api_key",
-  );
+  const deepgramApiKey = loadSecret(secretPath("deepgram"), "api_key");
+  const cartesiaApiKey = loadSecret(secretPath("cartesia"), "api_key");
   const llmApiKey = process.env.OPENROUTER_API_KEY;
   if (!llmApiKey)
     throw new Error("OPENROUTER_API_KEY not set (harness LLM leg)");

--- a/packages/tools/voice-evidence-harness/src/paths.test.ts
+++ b/packages/tools/voice-evidence-harness/src/paths.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Contract tests for the evidence-root/secrets-dir derivation seam (paths.ts):
+ * env overrides win without consulting the home lookup, blank/relative
+ * overrides fail loudly, and the defaults stay on the real-home ~/.moltbot
+ * layout. The identical contract is executed under Bun (this file's direct
+ * imports) and under Node type stripping (a spawned `node` subprocess importing
+ * the same module), because the #16180 leak was a runtime-behavior divergence
+ * (Bun's homedir() ignoring a HOME reassignment) that a single-runtime test
+ * could not observe.
+ */
+
+import { afterEach, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import {
+  DEFAULT_EVIDENCE_SUBPATH,
+  DEFAULT_SECRETS_SUBPATH,
+  EVIDENCE_ROOT_ENV,
+  evidenceRoot,
+  SECRETS_DIR_ENV,
+  secretPath,
+  secretsDir,
+} from "./paths.ts";
+
+const FAKE_HOME = "/fake-home";
+const fakeHome = () => FAKE_HOME;
+const forbiddenHome = (): string => {
+  throw new Error("home lookup consulted although an override is set");
+};
+
+const originalEvidenceRoot = process.env[EVIDENCE_ROOT_ENV];
+const originalSecretsDir = process.env[SECRETS_DIR_ENV];
+
+afterEach(() => {
+  if (originalEvidenceRoot === undefined) delete process.env[EVIDENCE_ROOT_ENV];
+  else process.env[EVIDENCE_ROOT_ENV] = originalEvidenceRoot;
+  if (originalSecretsDir === undefined) delete process.env[SECRETS_DIR_ENV];
+  else process.env[SECRETS_DIR_ENV] = originalSecretsDir;
+});
+
+test("evidence root: override wins and the home lookup is never consulted", () => {
+  expect(
+    evidenceRoot({ [EVIDENCE_ROOT_ENV]: "/override/evidence" }, forbiddenHome),
+  ).toBe("/override/evidence");
+  // surrounding whitespace is tolerated, the path itself is kept verbatim
+  expect(
+    evidenceRoot(
+      { [EVIDENCE_ROOT_ENV]: "  /override/evidence " },
+      forbiddenHome,
+    ),
+  ).toBe("/override/evidence");
+});
+
+test("evidence root: default stays on the ~/.moltbot layout", () => {
+  expect(evidenceRoot({}, fakeHome)).toBe(
+    join(FAKE_HOME, DEFAULT_EVIDENCE_SUBPATH),
+  );
+  // live default (no override, real home lookup) — the CLI's non-test path
+  expect(evidenceRoot({})).toBe(join(homedir(), DEFAULT_EVIDENCE_SUBPATH));
+});
+
+test("evidence root: default arguments read process.env", () => {
+  process.env[EVIDENCE_ROOT_ENV] = "/from-process-env/evidence";
+  expect(evidenceRoot()).toBe("/from-process-env/evidence");
+});
+
+test("secrets: override and default derivations", () => {
+  expect(
+    secretsDir({ [SECRETS_DIR_ENV]: "/override/secrets" }, forbiddenHome),
+  ).toBe("/override/secrets");
+  expect(secretsDir({}, fakeHome)).toBe(
+    join(FAKE_HOME, DEFAULT_SECRETS_SUBPATH),
+  );
+  expect(
+    secretPath(
+      "deepgram",
+      { [SECRETS_DIR_ENV]: "/override/secrets" },
+      forbiddenHome,
+    ),
+  ).toBe("/override/secrets/deepgram.json");
+  expect(secretPath("cartesia", {}, fakeHome)).toBe(
+    join(FAKE_HOME, DEFAULT_SECRETS_SUBPATH, "cartesia.json"),
+  );
+  process.env[SECRETS_DIR_ENV] = "/from-process-env/secrets";
+  expect(secretPath("deepgram")).toBe(
+    "/from-process-env/secrets/deepgram.json",
+  );
+});
+
+test("blank or relative overrides fail loudly instead of falling back to the real home", () => {
+  expect(() => evidenceRoot({ [EVIDENCE_ROOT_ENV]: "" }, fakeHome)).toThrow(
+    "set but blank",
+  );
+  expect(() => evidenceRoot({ [EVIDENCE_ROOT_ENV]: "   " }, fakeHome)).toThrow(
+    "set but blank",
+  );
+  expect(() =>
+    evidenceRoot({ [EVIDENCE_ROOT_ENV]: "relative/evidence" }, fakeHome),
+  ).toThrow("must be an absolute path");
+  expect(() => secretsDir({ [SECRETS_DIR_ENV]: "" }, fakeHome)).toThrow(
+    "set but blank",
+  );
+  expect(() =>
+    secretsDir({ [SECRETS_DIR_ENV]: "./secrets" }, fakeHome),
+  ).toThrow("must be an absolute path");
+});
+
+test("the same contract holds under the Node runtime (type-stripped subprocess)", () => {
+  const pathsUrl = new URL("./paths.ts", import.meta.url).href;
+  // The script mirrors the Bun-leg assertions above and prints its observations
+  // as JSON; the parent asserts equality so a divergence between runtimes (the
+  // #16180 failure mode) surfaces as a concrete value diff.
+  const nodeScript = [
+    `const m = await import(${JSON.stringify(pathsUrl)});`,
+    `const threw = (fn) => { try { fn(); return false; } catch { return true; } };`,
+    `const noHome = () => { throw new Error("home lookup consulted although an override is set"); };`,
+    `const out = {`,
+    `  overrideWins: m.evidenceRoot({ [m.EVIDENCE_ROOT_ENV]: "/node-override/evidence" }, noHome),`,
+    `  defaultUnderHome: m.evidenceRoot({}, () => "/node-fake-home"),`,
+    `  secretsOverride: m.secretPath("deepgram", { [m.SECRETS_DIR_ENV]: "/node-override/secrets" }, noHome),`,
+    `  secretsDefault: m.secretPath("cartesia", {}, () => "/node-fake-home"),`,
+    `  blankRootThrows: threw(() => m.evidenceRoot({ [m.EVIDENCE_ROOT_ENV]: "  " }, () => "/h")),`,
+    `  relativeRootThrows: threw(() => m.evidenceRoot({ [m.EVIDENCE_ROOT_ENV]: "relative/evidence" }, () => "/h")),`,
+    `  blankSecretsThrows: threw(() => m.secretsDir({ [m.SECRETS_DIR_ENV]: "" }, () => "/h")),`,
+    `  relativeSecretsThrows: threw(() => m.secretsDir({ [m.SECRETS_DIR_ENV]: "./secrets" }, () => "/h")),`,
+    `};`,
+    `process.stdout.write(JSON.stringify(out));`,
+  ].join("\n");
+  const res = spawnSync("node", ["--input-type=module", "--eval", nodeScript], {
+    encoding: "utf8",
+    timeout: 60_000,
+  });
+  expect(res.error).toBeUndefined();
+  if (res.status !== 0) {
+    throw new Error(`node leg failed (status ${res.status}): ${res.stderr}`);
+  }
+  const observed: unknown = JSON.parse(res.stdout);
+  expect(observed).toEqual({
+    overrideWins: "/node-override/evidence",
+    defaultUnderHome: join("/node-fake-home", DEFAULT_EVIDENCE_SUBPATH),
+    secretsOverride: "/node-override/secrets/deepgram.json",
+    secretsDefault: join(
+      "/node-fake-home",
+      DEFAULT_SECRETS_SUBPATH,
+      "cartesia.json",
+    ),
+    blankRootThrows: true,
+    relativeRootThrows: true,
+    blankSecretsThrows: true,
+    relativeSecretsThrows: true,
+  });
+});

--- a/packages/tools/voice-evidence-harness/src/paths.ts
+++ b/packages/tools/voice-evidence-harness/src/paths.ts
@@ -1,0 +1,84 @@
+/**
+ * Evidence-root and secrets-dir derivation seam for the harness CLI.
+ *
+ * The CLI used to join node:os.homedir() inline, and a test that only
+ * reassigned process.env.HOME still wrote evidence under the REAL ~/.moltbot
+ * tree because Bun's homedir() ignores a HOME reassignment (#16180). This
+ * module is the single injectable seam: explicit env overrides
+ * (VOICE_EVIDENCE_ROOT / VOICE_EVIDENCE_SECRETS_DIR) win, the live default
+ * stays the real-home ~/.moltbot layout, and both the env map and the home
+ * lookup are parameters so the contract is assertable as pure derivation.
+ *
+ * Runtime-neutral on purpose: only node:os / node:path and erasable-TS syntax,
+ * so the same file executes under Bun (bun:test) and under Node type stripping
+ * — paths.test.ts exercises both legs, because the #16180 leak was exactly a
+ * Bun-vs-Node runtime divergence a single-runtime test could not see.
+ */
+
+import { homedir } from "node:os";
+import { isAbsolute, join } from "node:path";
+
+/** Env var overriding where evidence runs are written (absolute path). */
+export const EVIDENCE_ROOT_ENV = "VOICE_EVIDENCE_ROOT";
+/** Env var overriding where provider secret JSONs are read (absolute path). */
+export const SECRETS_DIR_ENV = "VOICE_EVIDENCE_SECRETS_DIR";
+
+/** Live default evidence location, relative to the user home (see README). */
+export const DEFAULT_EVIDENCE_SUBPATH =
+  ".moltbot/projects/eliza-fleet/evidence/voice-e2e";
+/** Live default secrets location, relative to the user home (see README). */
+export const DEFAULT_SECRETS_SUBPATH = ".moltbot/secrets";
+
+/** Minimal read surface of process.env, injectable for pure derivation tests. */
+export interface PathEnv {
+  readonly [name: string]: string | undefined;
+}
+
+/**
+ * Read an override env var. A set-but-blank or relative value throws instead
+ * of silently falling back: this seam exists to keep test runs out of the real
+ * home, so a malformed override must never be able to redirect writes there.
+ */
+function overrideFrom(env: PathEnv, name: string): string | undefined {
+  const raw = env[name];
+  if (raw === undefined) return undefined;
+  const value = raw.trim();
+  if (value.length === 0) {
+    throw new Error(
+      `${name} is set but blank; unset it or provide an absolute path`,
+    );
+  }
+  if (!isAbsolute(value)) {
+    throw new Error(`${name} must be an absolute path (got "${value}")`);
+  }
+  return value;
+}
+
+/** Root directory evidence runs are written under. */
+export function evidenceRoot(
+  env: PathEnv = process.env,
+  home: () => string = homedir,
+): string {
+  const override = overrideFrom(env, EVIDENCE_ROOT_ENV);
+  if (override !== undefined) return override;
+  return join(home(), DEFAULT_EVIDENCE_SUBPATH);
+}
+
+/** Directory the provider secret JSONs are read from. */
+export function secretsDir(
+  env: PathEnv = process.env,
+  home: () => string = homedir,
+): string {
+  const override = overrideFrom(env, SECRETS_DIR_ENV);
+  if (override !== undefined) return override;
+  return join(home(), DEFAULT_SECRETS_SUBPATH);
+}
+
+/** Path of one provider's secret JSON (shape: `{"api_key": "..."}`). */
+export function secretPath(
+  provider: "deepgram" | "cartesia",
+  env: PathEnv = process.env,
+  home: () => string = homedir,
+): string {
+  return join(secretsDir(env, home), `${provider}.json`);
+}


### PR DESCRIPTION
Closes #16180

## Problem

`packages/tools/voice-evidence-harness/src/cli.ts` derived both the evidence root and the Deepgram/Cartesia secret paths from `node:os.homedir()` inline, and `cli-run.test.ts` only reassigned `process.env.HOME` — which Bun's `homedir()` ignores — so every test run wrote evidence under the **real** `~/.moltbot` tree. Reproduced on this machine before the fix: running the develop-side `cli-run.test.ts` leaked `~/.moltbot/projects/eliza-fleet/evidence/voice-e2e/2026-07-13T20-11-15-312Z/` (108-byte fake `input.wav`, 4-byte fake `walkthrough.mp4`) into the real home (see linked evidence). The leaked dirs were removed after capture, mirroring the issue's remediation.

## Change

- **`src/paths.ts` (new)** — single injectable derivation seam. `VOICE_EVIDENCE_ROOT` / `VOICE_EVIDENCE_SECRETS_DIR` env overrides win; a set-but-blank or relative override **throws** (a malformed override must never silently fall back to the real home); defaults preserve the exact live `~/.moltbot` layout and evidence naming. Runtime-neutral by design (only `node:os`/`node:path`, erasable TS) so the same file executes under Bun and Node type stripping.
- **`src/cli.ts`** — evidence root + secret paths now come from the seam; no other behavior change.
- **`src/cli-run.test.ts`** — rewritten to run against the **real filesystem** (the `node:fs` `mock.module` is gone): real committed fixture WAV, real secret JSONs read from the temp secrets dir through the seam. Asserts on the **pass path** (in-process baseline run) that the full DoD artifact set lands below the `mkdtemp` root, and on the **failure path** (a spawned, fully **unmocked** `bun src/cli.ts` subprocess failing loudly on a missing `OPENROUTER_API_KEY`) that the partial evidence tree also stays below the override root. Every test snapshots the real `~/.moltbot` tree (names, kinds, sizes, mtimes) before, and asserts **zero delta** after — in the test bodies and again in `afterEach` as a safety net.
- **`src/paths.test.ts` (new)** — derivation contract under **both runtimes**: Bun leg via direct imports (override wins without consulting the home lookup, defaults on the `~/.moltbot` layout incl. the live `homedir()` default, blank/relative overrides throw), plus a **Node** leg that runs the identical assertions in a type-stripped `node` subprocess and compares observations, so a Bun-vs-Node divergence (the #16180 failure mode) surfaces as a concrete value diff.
- **`README.md`** — documents the two overrides.

## Acceptance criteria mapping

| criterion | where |
| --- | --- |
| explicit injectable evidence root + test-safe secret seam | `src/paths.ts` (`VOICE_EVIDENCE_ROOT`, `VOICE_EVIDENCE_SECRETS_DIR`, injectable env/home params) |
| preserve current live default under the real user home | `DEFAULT_EVIDENCE_SUBPATH` / `DEFAULT_SECRETS_SUBPATH`; asserted in `paths.test.ts` ("default stays on the ~/.moltbot layout", incl. real `homedir()` leg) |
| every artifact below the test mkdtemp root on success and failure | `cli-run.test.ts` — pass path walks the produced tree and checks the full DoD artifact set + `startsWith(tmpRoot)`; failure path via real unmocked CLI subprocess |
| real `~/.moltbot` has no delta after the test | `snapshotTree()` before/after (names, kinds, sizes, mtimes) in both tests + `afterEach` safety net |
| exercised under both Node and Bun | `paths.test.ts` Node subprocess leg (type-stripped import of the same module) + all Bun legs; verified on node v25.2.1 locally, CI runs node 24.15 (type stripping default since 23.6) |
| live-provider behavior and evidence naming unchanged outside tests | overrides only read from env; defaults byte-identical; run-dir naming (`<stamp>[-real-server]/<scenario>`) untouched |

## Evidence rows

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - CLI test-harness path-derivation change; no rendered UI surface (web/desktop/mobile untouched).
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - CLI test-harness path-derivation change; no rendered UI surface (web/desktop/mobile untouched).
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no user-facing flow; the change is where a CLI evidence harness writes files, proven by logs + tree diffs below.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: dual-runtime test logs (CI-identical Bun isolated + shared lanes, Node subprocess leg, whole-package suite 39/39) plus a manual REAL unmocked `cli.ts` run with overrides failing loudly (exit 1) with every write under the override root: https://gist.github.com/lalalune/5cf22eac5f77b8dc6eabaaeaec57d020
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend surface; the harness is a terminal CLI.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent/action/provider/prompt/model behavior change; the harness's live provider legs (Deepgram/Cartesia/OpenRouter) are untouched — only path derivation changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the artifacts ARE the filesystem trees — (a) reproduced pre-fix leak into real `~/.moltbot` from the develop-side test run, (b) post-fix override evidence tree, (c) full recursive `~/.moltbot` before/after listing (names, kinds, sizes, mtimes) with **NO DELTA**, (d) coverage-gate replica output (paths.ts 100%, cli.ts 83.81%, threshold 50): https://gist.github.com/lalalune/5cf22eac5f77b8dc6eabaaeaec57d020

## Verification

- `bun test` package suite: **39 pass / 0 fail** across all 5 files in one process (mock-restoration interplay covered).
- CI-identical coverage lanes: isolated `cli-run.test.ts` 2 pass, shared `paths.test.ts` 6 pass; awk gate: **paths.ts 100%, cli.ts 83.81%** (threshold 50) — gate OK.
- Package `bun run typecheck` (tsgo): clean.
- `bun run audit:error-policy-ratchet`: `no new fallback-slop in touched files` (cli.ts emptyCatch 0->0, serverConsole 0->0; paths.ts 0->0).
- `bun run verify` PASS (ran on pre-rebase head e44e6e3; branch then rebased onto fafa288dcd4 — change is isolated to `packages/tools/voice-evidence-harness`, and all package-scoped checks re-ran green on the final head; log tail in gist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)