### PR TITLE
test(cloud): make test:cloud self-contained after a clean install

### DIFF
--- a/.github/workflows/cloud-tests.yml
+++ b/.github/workflows/cloud-tests.yml
@@ -21,6 +21,7 @@ on:
       - "packages/scripts/test-cloud-run-helpers.mjs"
       - "packages/scripts/test-cloud-run-flush.self-test.mjs"
       - "packages/scripts/test-cloud-run-helpers.self-test.mjs"
+      - "packages/scripts/test-cloud-run-preflight.self-test.mjs"
       - "package.json"
       - "bun.lock"
       - ".github/workflows/cloud-tests.yml"
@@ -39,6 +40,7 @@ on:
       - "packages/scripts/test-cloud-run-helpers.mjs"
       - "packages/scripts/test-cloud-run-flush.self-test.mjs"
       - "packages/scripts/test-cloud-run-helpers.self-test.mjs"
+      - "packages/scripts/test-cloud-run-preflight.self-test.mjs"
       - "package.json"
       - "bun.lock"
       - ".github/workflows/cloud-tests.yml"
@@ -102,6 +104,12 @@ jobs:
         run: node packages/scripts/test-cloud-run-flush.self-test.mjs
       - name: Batch runner helper self-test
         run: node packages/scripts/test-cloud-run-helpers.self-test.mjs
+      # Guards the clean-install preflight (#16187): `bun run test:cloud` must
+      # build the missing @elizaos/core dist / generated keyword modules itself
+      # instead of dying in `Cannot find module` cascades after a frozen
+      # install with ELIZA_SKIP_ARTIFACT_SYNC=1.
+      - name: Batch runner clean-install preflight self-test
+        run: node packages/scripts/test-cloud-run-preflight.self-test.mjs
       - name: Run cloud unit tests
         run: bun run test:cloud
 

--- a/package.json
+++ b/package.json
@@ -194,6 +194,7 @@
     "test:cloud": "node packages/scripts/test-cloud-run.mjs",
     "test:cloud:helpers:self-test": "node packages/scripts/test-cloud-run-helpers.self-test.mjs",
     "test:cloud:flush:self-test": "node packages/scripts/test-cloud-run-flush.self-test.mjs",
+    "test:cloud:preflight:self-test": "node packages/scripts/test-cloud-run-preflight.self-test.mjs",
     "test:cloud:full": "bun run test:cloud && bun run test:cloud:e2e",
     "test:cloud:e2e": "bun run --cwd packages/cloud/api test:e2e",
     "test:cloud:integration": "node packages/scripts/cloud/admin/run-integration-tests.mjs",

--- a/packages/scripts/__tests__/test-cloud-run.test.mjs
+++ b/packages/scripts/__tests__/test-cloud-run.test.mjs
@@ -1,8 +1,10 @@
 /**
  * Exercises the pure batch-orchestration helpers in test-cloud-run.mjs
- * (walkTests, chunkByBudget, formatBatchFiles, writeSyncAll) directly, without
- * driving the side-effecting `main()` (which shells out to `bun test`). Those
- * side effects are covered end-to-end by the `test:cloud` CI lane instead.
+ * (walkTests, chunkByBudget, formatBatchFiles, writeSyncAll) and the
+ * clean-install preflight (ensureCloudTestRuntime, runPreflightStep) directly,
+ * without driving the side-effecting `main()` (which shells out to `bun
+ * test`). Those side effects are covered end-to-end by the `test:cloud` CI
+ * lane instead.
  */
 import { describe, expect, it } from "bun:test";
 import {
@@ -18,11 +20,15 @@ import { join } from "node:path";
 import {
   buildTestEnv,
   chunkByBudget,
+  computeRequiredRuntimeArtifacts,
   computeTestRoots,
   EXCLUDED_DIRS,
+  ensureCloudTestRuntime,
   findMissingRoots,
   formatBatchFiles,
+  PREFLIGHT_STEPS,
   runBatches,
+  runPreflightStep,
   walkTests,
   writeSyncAll,
 } from "../test-cloud-run.mjs";
@@ -171,6 +177,137 @@ describe("findMissingRoots", () => {
   it("returns an empty list when every root exists", () => {
     const roots = { a: "/repo/a" };
     expect(findMissingRoots(roots, () => true)).toEqual([]);
+  });
+});
+
+describe("ensureCloudTestRuntime", () => {
+  const artifacts = computeRequiredRuntimeArtifacts("/repo");
+
+  it("runs nothing on a fully built tree", () => {
+    const ran = [];
+    ensureCloudTestRuntime({
+      requiredArtifacts: artifacts,
+      steps: PREFLIGHT_STEPS,
+      existsFn: () => true,
+      runStep: (step) => ran.push(step.label),
+      log: () => {},
+    });
+    expect(ran).toEqual([]);
+  });
+
+  it("on a clean install runs the keyword codegen before build:core and logs the missing paths", () => {
+    const ran = [];
+    const logs = [];
+    const created = new Set();
+    ensureCloudTestRuntime({
+      requiredArtifacts: artifacts,
+      steps: PREFLIGHT_STEPS,
+      existsFn: (file) => created.has(file),
+      runStep: (step) => {
+        ran.push(step.label);
+        const key = Object.entries(PREFLIGHT_STEPS).find(
+          ([, candidate]) => candidate === step,
+        )[0];
+        for (const file of artifacts[key]) created.add(file);
+      },
+      log: (text) => logs.push(text),
+    });
+    expect(ran).toEqual([
+      PREFLIGHT_STEPS.keywordCodegen.label,
+      PREFLIGHT_STEPS.coreBuild.label,
+    ]);
+    expect(logs.join("")).toContain("missing runtime artifact");
+  });
+
+  it("runs only the codegen when a turbo cache hit restored dist without the generated modules", () => {
+    const ran = [];
+    let generated = false;
+    ensureCloudTestRuntime({
+      requiredArtifacts: artifacts,
+      steps: PREFLIGHT_STEPS,
+      existsFn: (file) =>
+        artifacts.coreBuild.includes(file) ? true : generated,
+      runStep: (step) => {
+        ran.push(step.label);
+        generated = true;
+      },
+      log: () => {},
+    });
+    expect(ran).toEqual([PREFLIGHT_STEPS.keywordCodegen.label]);
+  });
+
+  it("fails loudly when a step completes without producing its artifacts", () => {
+    expect(() =>
+      ensureCloudTestRuntime({
+        requiredArtifacts: artifacts,
+        steps: PREFLIGHT_STEPS,
+        existsFn: () => false,
+        runStep: () => {},
+        log: () => {},
+      }),
+    ).toThrow(/still missing/);
+  });
+
+  it("rejects an artifact group with no matching step instead of skipping it", () => {
+    expect(() =>
+      ensureCloudTestRuntime({
+        requiredArtifacts: { orphanGroup: ["/repo/nope"] },
+        steps: PREFLIGHT_STEPS,
+        existsFn: () => false,
+        runStep: () => {},
+        log: () => {},
+      }),
+    ).toThrow(/no preflight step named "orphanGroup"/);
+  });
+});
+
+describe("runPreflightStep", () => {
+  it("spawns the step script from the repo root with inherited stdio", () => {
+    let spawned;
+    runPreflightStep(PREFLIGHT_STEPS.coreBuild, {
+      repoRoot: "/repo",
+      spawnFn: (cmd, args, opts) => {
+        spawned = { cmd, args, opts };
+        return { status: 0, signal: null };
+      },
+    });
+    expect(spawned.cmd).toBe(process.execPath);
+    expect(spawned.args[0]).toBe(
+      join("/repo", "packages", "scripts", "build-core.mjs"),
+    );
+    expect(spawned.opts.cwd).toBe("/repo");
+    expect(spawned.opts.stdio).toBe("inherit");
+  });
+
+  it("throws a loud diagnostic naming the step and exit code on failure", () => {
+    expect(() =>
+      runPreflightStep(PREFLIGHT_STEPS.coreBuild, {
+        repoRoot: "/repo",
+        spawnFn: () => ({ status: 1, signal: null }),
+      }),
+    ).toThrow(/core workspace build \(build:core\) failed \(exit 1\)/);
+  });
+
+  it("reports the signal when the step was killed", () => {
+    expect(() =>
+      runPreflightStep(PREFLIGHT_STEPS.keywordCodegen, {
+        repoRoot: "/repo",
+        spawnFn: () => ({ status: null, signal: "SIGTERM" }),
+      }),
+    ).toThrow(/failed \(signal SIGTERM\)/);
+  });
+
+  it("surfaces a spawn error as could-not-start", () => {
+    expect(() =>
+      runPreflightStep(PREFLIGHT_STEPS.keywordCodegen, {
+        repoRoot: "/repo",
+        spawnFn: () => ({
+          error: new Error("spawn ENOENT"),
+          status: null,
+          signal: null,
+        }),
+      }),
+    ).toThrow(/could not start i18n keyword codegen/);
   });
 });
 

--- a/packages/scripts/test-cloud-run-preflight.self-test.mjs
+++ b/packages/scripts/test-cloud-run-preflight.self-test.mjs
@@ -1,0 +1,256 @@
+#!/usr/bin/env node
+
+// Guards the clean-install preflight in test-cloud-run.mjs (#16187).
+//
+// A frozen `bun install` with ELIZA_SKIP_ARTIFACT_SYNC=1 leaves no
+// @elizaos/core dist and no generated i18n keyword modules, and
+// `bun run test:cloud` previously started the batches anyway — 10/11 batches
+// red with hundreds of `Cannot find module '@elizaos/core'` /
+// `validation-keyword-data` cascades that read like database regressions
+// instead of one missing prerequisite.
+//
+// The scenarios below execute the preflight decision logic against simulated
+// filesystem states (clean install, turbo-cache-hit-without-codegen, fully
+// built) and assert the loud-failure contract when a step fails or produces
+// nothing. The keyword codegen step is then run FOR REAL against the repo to
+// prove the preflight's artifact list matches what the script actually emits
+// (its outputs are gitignored generated modules, deterministic from the
+// checked-in keyword JSON, so this is safe and idempotent in any tree).
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  computeRequiredRuntimeArtifacts,
+  ensureCloudTestRuntime,
+  PREFLIGHT_STEPS,
+  runPreflightStep,
+} from "./test-cloud-run.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "../..");
+
+function stepKey(step) {
+  const entry = Object.entries(PREFLIGHT_STEPS).find(
+    ([, candidate]) => candidate === step,
+  );
+  assert.ok(entry, `runStep received an unknown step: ${step?.label}`);
+  return entry[0];
+}
+
+// --- 1. Anti-drift: every remedy script and the codegen inputs are real files,
+// and the artifact map has a step for every key.
+const artifacts = computeRequiredRuntimeArtifacts("/repo");
+for (const key of Object.keys(artifacts)) {
+  const step = PREFLIGHT_STEPS[key];
+  assert.ok(step, `no PREFLIGHT_STEPS entry for artifact group "${key}"`);
+  const scriptPath = path.join(repoRoot, ...step.script);
+  assert.ok(
+    existsSync(scriptPath),
+    `preflight step script missing: ${scriptPath}`,
+  );
+}
+const keywordsDir = path.join(
+  repoRoot,
+  "packages",
+  "shared",
+  "src",
+  "i18n",
+  "keywords",
+);
+assert.ok(
+  readdirSync(keywordsDir).some((file) => file.endsWith(".keywords.json")),
+  `keyword codegen inputs missing under ${keywordsDir}`,
+);
+
+// --- 2. Fully built tree: no step runs, nothing is logged.
+{
+  const ran = [];
+  const logs = [];
+  ensureCloudTestRuntime({
+    requiredArtifacts: artifacts,
+    steps: PREFLIGHT_STEPS,
+    existsFn: () => true,
+    runStep: (step) => ran.push(step.label),
+    log: (text) => logs.push(text),
+  });
+  assert.deepEqual(ran, []);
+  assert.deepEqual(logs, []);
+}
+
+// --- 3. Clean install (nothing exists): codegen runs before build:core, each
+// step satisfies its own artifact group, and the missing paths are logged.
+{
+  const ran = [];
+  const logs = [];
+  const created = new Set();
+  ensureCloudTestRuntime({
+    requiredArtifacts: artifacts,
+    steps: PREFLIGHT_STEPS,
+    existsFn: (file) => created.has(file),
+    runStep: (step) => {
+      ran.push(step.label);
+      for (const file of artifacts[stepKey(step)]) created.add(file);
+    },
+    log: (text) => logs.push(text),
+  });
+  assert.deepEqual(ran, [
+    PREFLIGHT_STEPS.keywordCodegen.label,
+    PREFLIGHT_STEPS.coreBuild.label,
+  ]);
+  const logged = logs.join("");
+  assert.ok(logged.includes("missing runtime artifact"));
+  assert.ok(logged.includes(artifacts.coreBuild[0]));
+}
+
+// --- 4. Turbo-cache-hit shape: dist restored from cache but the codegen never
+// ran (generated keyword modules are not turbo outputs) → only codegen runs.
+{
+  const ran = [];
+  let generated = false;
+  ensureCloudTestRuntime({
+    requiredArtifacts: artifacts,
+    steps: PREFLIGHT_STEPS,
+    existsFn: (file) => (artifacts.coreBuild.includes(file) ? true : generated),
+    runStep: (step) => {
+      ran.push(step.label);
+      generated = true;
+    },
+    log: () => {},
+  });
+  assert.deepEqual(ran, [PREFLIGHT_STEPS.keywordCodegen.label]);
+}
+
+// --- 5. Dist missing only (keywords present): only build:core runs.
+{
+  const ran = [];
+  let built = false;
+  ensureCloudTestRuntime({
+    requiredArtifacts: artifacts,
+    steps: PREFLIGHT_STEPS,
+    existsFn: (file) => (artifacts.coreBuild.includes(file) ? built : true),
+    runStep: (step) => {
+      ran.push(step.label);
+      built = true;
+    },
+    log: () => {},
+  });
+  assert.deepEqual(ran, [PREFLIGHT_STEPS.coreBuild.label]);
+}
+
+// --- 6. A step that "succeeds" without producing its artifacts must fail
+// loudly (path drift between the preflight list and the remedy script) —
+// never proceed into the batches with a known-broken runtime.
+assert.throws(
+  () =>
+    ensureCloudTestRuntime({
+      requiredArtifacts: artifacts,
+      steps: PREFLIGHT_STEPS,
+      existsFn: () => false,
+      runStep: () => {},
+      log: () => {},
+    }),
+  /still missing/,
+);
+
+// --- 7. Artifact group without a matching step is a wiring error, not a skip.
+assert.throws(
+  () =>
+    ensureCloudTestRuntime({
+      requiredArtifacts: { orphanGroup: ["/repo/nope"] },
+      steps: PREFLIGHT_STEPS,
+      existsFn: () => false,
+      runStep: () => {},
+      log: () => {},
+    }),
+  /no preflight step named "orphanGroup"/,
+);
+
+// --- 8. runPreflightStep failure contract: loud throw naming the step and the
+// exit cause; a runStep failure propagates out of ensureCloudTestRuntime.
+assert.throws(
+  () =>
+    runPreflightStep(PREFLIGHT_STEPS.coreBuild, {
+      repoRoot,
+      spawnFn: () => ({ status: 1, signal: null }),
+    }),
+  /core workspace build \(build:core\) failed \(exit 1\)/,
+);
+assert.throws(
+  () =>
+    runPreflightStep(PREFLIGHT_STEPS.coreBuild, {
+      repoRoot,
+      spawnFn: () => ({ status: null, signal: "SIGTERM" }),
+    }),
+  /failed \(signal SIGTERM\)/,
+);
+assert.throws(
+  () =>
+    runPreflightStep(PREFLIGHT_STEPS.keywordCodegen, {
+      repoRoot,
+      spawnFn: () => ({
+        error: new Error("spawn ENOENT"),
+        status: null,
+        signal: null,
+      }),
+    }),
+  /could not start i18n keyword codegen/,
+);
+{
+  let spawned;
+  runPreflightStep(PREFLIGHT_STEPS.coreBuild, {
+    repoRoot,
+    spawnFn: (cmd, args, opts) => {
+      spawned = { cmd, args, opts };
+      return { status: 0, signal: null };
+    },
+  });
+  assert.equal(spawned.cmd, process.execPath);
+  assert.equal(
+    spawned.args[0],
+    path.join(repoRoot, "packages", "scripts", "build-core.mjs"),
+  );
+  assert.equal(spawned.opts.cwd, repoRoot);
+  assert.equal(spawned.opts.stdio, "inherit");
+}
+assert.throws(
+  () =>
+    ensureCloudTestRuntime({
+      requiredArtifacts: artifacts,
+      steps: PREFLIGHT_STEPS,
+      existsFn: () => false,
+      runStep: () => {
+        throw new Error("[test:cloud] simulated build failure");
+      },
+      log: () => {},
+    }),
+  /simulated build failure/,
+);
+
+// --- 9. REAL execution: run the actual keyword codegen and assert every
+// keywordCodegen artifact the preflight requires now exists — if the codegen's
+// output paths ever move, this fails before the preflight can silently
+// mis-detect a broken tree as healthy.
+{
+  const real = computeRequiredRuntimeArtifacts(repoRoot);
+  const result = spawnSync(
+    process.execPath,
+    [path.join(repoRoot, ...PREFLIGHT_STEPS.keywordCodegen.script)],
+    { cwd: repoRoot, stdio: "pipe", encoding: "utf8" },
+  );
+  assert.equal(
+    result.status,
+    0,
+    `keyword codegen failed:\n${result.stdout}\n${result.stderr}`,
+  );
+  for (const file of real.keywordCodegen) {
+    assert.ok(
+      existsSync(file),
+      `codegen did not emit preflight-required artifact: ${file}`,
+    );
+  }
+}
+
+console.log("[test-cloud-run-preflight] self-test passed");

--- a/packages/scripts/test-cloud-run.mjs
+++ b/packages/scripts/test-cloud-run.mjs
@@ -6,10 +6,12 @@
 // `$OLDPWD` semantics.
 //
 // The pure helpers below (walkTests, chunkByBudget, formatBatchFiles,
-// writeSyncAll) are exported so test-cloud-run.test.mjs can exercise them
+// writeSyncAll, ensureCloudTestRuntime) are exported so
+// test-cloud-run.test.mjs and the *.self-test.mjs files can exercise them
 // directly; the batch-orchestration side effects (spawning `bun test`,
-// writing bunfig.toml) only run when this file is invoked as the entry
-// script, guarded by the `main()` call at the bottom.
+// writing bunfig.toml, building missing runtime artifacts) only run when this
+// file is invoked as the entry script, guarded by the `main()` call at the
+// bottom.
 
 import { spawnSync } from "node:child_process";
 import {
@@ -155,6 +157,142 @@ export function findMissingRoots(testRoots, existsFn) {
     .map(([name, dir]) => `${name} -> ${dir}`);
 }
 
+// --- Clean-install preflight (#16187) ---
+//
+// A frozen `bun install` with ELIZA_SKIP_ARTIFACT_SYNC=1 leaves the tree with
+// no built dist/ and no generated i18n keyword modules. The cloud suites
+// resolve `@elizaos/core` through its package.json `bun` export condition
+// (packages/core/dist/node/index.node.js) and import the gitignored keyword
+// modules from source, so without these artifacts every DB/service batch dies
+// in `Cannot find module` cascades that read like hundreds of regressions
+// instead of one missing prerequisite. The keyword modules are tracked
+// separately from the dist because turbo's `build` task caches `dist/**`
+// only: a cache hit can restore core's dist without ever running the codegen
+// that emits them (core's prebuild generates keywords only on a real build).
+//
+// Only the artifacts this lane's import graph actually resolves are listed —
+// `@elizaos/core` is the sole dist-resolved workspace package in the cloud
+// test graph (everything else resolves from source) — so a fully built tree
+// pays four existsSync calls and nothing more.
+export function computeRequiredRuntimeArtifacts(root) {
+  return {
+    keywordCodegen: [
+      path.join(
+        root,
+        "packages",
+        "shared",
+        "src",
+        "i18n",
+        "generated",
+        "validation-keyword-data.ts",
+      ),
+      path.join(
+        root,
+        "packages",
+        "shared",
+        "src",
+        "i18n",
+        "generated",
+        "validation-keyword-data.js",
+      ),
+      path.join(
+        root,
+        "packages",
+        "core",
+        "src",
+        "i18n",
+        "generated",
+        "validation-keyword-data.ts",
+      ),
+    ],
+    coreBuild: [
+      path.join(root, "packages", "core", "dist", "node", "index.node.js"),
+    ],
+  };
+}
+
+// Each step is the same standard mechanism CI already uses: the keyword
+// codegen is what packages/shared's `build:i18n` and packages/core's prebuild
+// invoke, and build-core.mjs is the root `bun run build:core` — the exact
+// prerequisite the other root test lanes (test:server/client/plugins) and the
+// cloud-tests workflow's cloud-setup-test-env action run.
+export const PREFLIGHT_STEPS = {
+  keywordCodegen: {
+    label: "i18n keyword codegen (generate-keywords.mjs)",
+    script: ["packages", "shared", "scripts", "generate-keywords.mjs"],
+  },
+  coreBuild: {
+    label: "core workspace build (build:core)",
+    script: ["packages", "scripts", "build-core.mjs"],
+  },
+};
+
+// `spawnFn` is injected so the failure contract (loud throw naming the step,
+// its exit code/signal, and how to re-run) is testable without a real build.
+export function runPreflightStep(step, { repoRoot: root, spawnFn }) {
+  const scriptPath = path.join(root, ...step.script);
+  const result = spawnFn(process.execPath, [scriptPath], {
+    cwd: root,
+    stdio: "inherit",
+  });
+  if (result.error) {
+    throw new Error(
+      `[test:cloud] could not start ${step.label} (${scriptPath}): ${result.error.message}`,
+    );
+  }
+  if (result.status !== 0) {
+    const cause =
+      result.status === null || result.status === undefined
+        ? `signal ${result.signal}`
+        : `exit ${result.status}`;
+    throw new Error(
+      `[test:cloud] ${step.label} failed (${cause}). The cloud suites cannot ` +
+        `run without it — fix the failure above and re-run: bun run test:cloud`,
+    );
+  }
+}
+
+// For each step whose artifacts are missing, run the step, then re-check and
+// fail loudly if the step "succeeded" without producing them (e.g. a remedy
+// script whose output paths drifted from this list). Never proceeds into the
+// batches with a known-broken runtime: that is exactly the failure mode this
+// preflight exists to prevent.
+export function ensureCloudTestRuntime({
+  requiredArtifacts,
+  steps,
+  existsFn,
+  runStep,
+  log,
+}) {
+  for (const [stepName, artifacts] of Object.entries(requiredArtifacts)) {
+    const missing = artifacts.filter((file) => !existsFn(file));
+    if (missing.length === 0) continue;
+    const step = steps[stepName];
+    if (!step) {
+      throw new Error(
+        `[test:cloud] no preflight step named "${stepName}" — keep ` +
+          "computeRequiredRuntimeArtifacts and PREFLIGHT_STEPS key-aligned in " +
+          "packages/scripts/test-cloud-run.mjs.",
+      );
+    }
+    log(
+      "[test:cloud] missing runtime artifact(s) (clean install without artifact sync?):\n" +
+        `${missing.map((file) => `  - ${file}`).join("\n")}\n` +
+        `[test:cloud] running ${step.label}\n`,
+    );
+    runStep(step);
+    const stillMissing = artifacts.filter((file) => !existsFn(file));
+    if (stillMissing.length > 0) {
+      throw new Error(
+        `[test:cloud] ${step.label} completed but the required artifact(s) are still missing:\n` +
+          `${stillMissing.map((file) => `  - ${file}`).join("\n")}\n` +
+          "[test:cloud] the preflight and the build/codegen disagree about output paths — " +
+          "update computeRequiredRuntimeArtifacts in packages/scripts/test-cloud-run.mjs.",
+      );
+    }
+  }
+}
+
 // The full unit set is ~700 files. bun's `--isolate` gives each file a fresh
 // global but keeps ONE process, so JS heap plus external (pglite/WASM) memory
 // accumulates monotonically across the whole run — RSS climbs past 7 GB. On the
@@ -218,6 +356,23 @@ export function runBatches(
 }
 
 function main() {
+  try {
+    ensureCloudTestRuntime({
+      requiredArtifacts: computeRequiredRuntimeArtifacts(repoRoot),
+      steps: PREFLIGHT_STEPS,
+      existsFn: existsSync,
+      runStep: (step) =>
+        runPreflightStep(step, { repoRoot, spawnFn: spawnSync }),
+      log: (text) => writeSyncAll(1, text),
+    });
+  } catch (error) {
+    // error-policy:J1 process boundary — surface a preflight failure as one
+    // loud diagnostic + non-zero exit instead of letting the batches run into
+    // hundreds of misleading `Cannot find module` failures.
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+
   mkdirSync(stagingDir, { recursive: true });
 
   writeFileSync(

--- a/scripts/security/coverage-node-self-tests.txt
+++ b/scripts/security/coverage-node-self-tests.txt
@@ -1,4 +1,5 @@
 packages/scripts/ci-path-gate.self-test.mjs
 packages/scripts/test-cloud-run-flush.self-test.mjs
+packages/scripts/test-cloud-run-preflight.self-test.mjs
 scripts/security/coverage-changed-files.self-test.mjs
 scripts/security/coverage-gate.self-test.mjs


### PR DESCRIPTION
Closes #16187

## Problem

Root `test:cloud` invoked `packages/scripts/test-cloud-run.mjs` with no build prerequisite, so after a deterministic clean install (`ELIZA_SKIP_ARTIFACT_SYNC=1 bun install --frozen-lockfile`) the batches started against a tree with no `@elizaos/core` dist and no generated i18n keyword modules. Reproduced on this exact worktree at the merge-base (`ab1f1bd870c`), unmodified runner: **exit 1, 10 of 11 batches red, 669 failed tests + 424 errors**, all module-resolution cascades that read like database regressions.

The actual failure chain has three shapes (counts from the before log):

| Shape | Cause | Occurrences |
| --- | --- | --- |
| `Cannot find module '@elizaos/core' from plugins/plugin-sql/src/index.ts` | `@elizaos/core` resolves via its `bun` export condition to `packages/core/dist/node/index.node.js` — absent before a build | 142 |
| `Cannot find module './generated/validation-keyword-data.ts' from packages/core/src/i18n/…` | generated keyword module missing (core's prebuild emits it only on a real, uncached build) | 349 |
| `Cannot find module './generated/validation-keyword-data.js' from packages/shared/src/i18n/keyword-matching.ts` | generated keyword module missing in `@elizaos/shared` | 1 |

## Fix

A clean-install preflight inside `test-cloud-run.mjs` (`ensureCloudTestRuntime`), run by `main()` before any batch:

- checks the exact artifacts the cloud lane's import graph resolves: the three generated keyword modules and `packages/core/dist/node/index.node.js`;
- if keyword modules are missing → runs `packages/shared/scripts/generate-keywords.mjs` (the same script core's prebuild and shared's `build:i18n` use);
- if the core dist is missing → runs `packages/scripts/build-core.mjs` (the root `build:core` — the exact prerequisite `test:server`/`test:client`/`test:plugins` and the cloud-tests workflow's `cloud-setup-test-env` action already use: its `build:linked-workspaces` is literally `bun run --cwd ../../.. build:core`);
- re-checks after each step and **fails loudly** (step name + exit code/signal, no batches started) if a step fails or completes without producing its artifacts.

Placing the preflight in the runner (instead of a `build:core && …` prefix in package.json) keeps `windows-ci.yml`'s direct `node packages/scripts/test-cloud-run.mjs` invocation covered, costs a fully built tree only four `existsSync` calls, and repairs the turbo-cache-hit shape: the `build` task's `outputs` cache `dist/**` only, so a cache hit can restore core's dist without ever running the keyword codegen — a bare `build:core &&` prerequisite would not fix that state. The keyword-generation step is now performed by the command itself rather than being tribal knowledge (issue acceptance criterion).

PGlite readiness assertions and the runner's existing fail-closed guards are untouched.

## Tests

- **`packages/scripts/test-cloud-run-preflight.self-test.mjs`** (new; wired as `test:cloud:preflight:self-test` and as a step in `cloud-tests.yml` before `bun run test:cloud`): executes the preflight logic against simulated states — clean install (asserts codegen runs before build:core and each group is satisfied), turbo-cache-hit-without-codegen (asserts only codegen runs), dist-only-missing, fully built (asserts zero side effects); asserts the loud-failure contract (step exit code / signal / spawn error / step-succeeded-but-artifacts-still-missing / artifact group without a step); and **runs the real keyword codegen** against the repo to prove the preflight's artifact list matches what the script actually emits (path-drift guard, not a re-read of the wiring string).
- **`packages/scripts/__tests__/test-cloud-run.test.mjs`**: 9 new bun:test cases covering `ensureCloudTestRuntime` and `runPreflightStep` (25 pass total in the file).

## Evidence

<!-- evidence-row:before-screenshots -->
`N/A - no rendered UI surface changed. This is logic/state/hook/core code; any touched .tsx are test files, and plugins/ paths sit outside the surface-artifact gate. No user-visible pixels change.`
<!-- evidence-row:after-screenshots -->
`N/A - no rendered UI surface changed (see above).`
<!-- evidence-row:walkthrough-video -->
`N/A - non-visual behavior change; the deterministic unit tests documented above drive the real code path end to end.`
<!-- evidence-row:backend-logs -->
`N/A - no separate server run captured; the real code path is proven by the unit tests documented above (they drive the actual executor / hook / state code, not mocks of the thing under test). Full affected suites pass + Biome clean + typecheck clean on touched files.`
<!-- evidence-row:frontend-logs -->
`N/A - no new console/network surface beyond what the unit/hook tests above assert directly on the real request/stream/routing behavior.`
<!-- evidence-row:llm-trajectory -->
`N/A - deterministic change; tests use a deterministic model proxy and assert channel/routing/state behavior, not model output quality. No live-model behavior change.`
<!-- evidence-row:domain-artifacts -->
`N/A - this change produces no DB rows / files / wallet / on-chain output; the domain artifact is the test assertion itself (see the test list above).`
