### PR TITLE
fix(ci): always emit required coverage context

### DIFF
--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -7,7 +7,9 @@ name: coverage-gate
 # classifier strips TypeScript-only syntax before excluding modules with no
 # runtime code; declarations and deleted files are not targets. LCOV LF:0 never
 # proves type-only status. Source covered only by e2e/live lanes still needs a
-# focused unit test in this gate. Docs-only PRs do not spend coverage time.
+# focused unit test in this gate. Docs-only PRs run only the dependency-free
+# classifier so this required context always reaches a terminal success without
+# spending workspace-install or test time.
 # Standalone Node self-tests are excluded only when listed in the manifest that
 # the Develop PR Test Integrity job executes on every PR.
 # A test-only PR (changed tests, no changed source) executes its changed tests —
@@ -25,10 +27,6 @@ name: coverage-gate
 on:
   pull_request:
     branches: [develop, main]
-    paths:
-      - "packages/**"
-      - "plugins/**"
-      - "apps/**"
 
 # cancel superseded in-flight runs for the same PR to free hosted-runner
 # capacity. only cancels pull_request runs; push runs on protected branches


### PR DESCRIPTION
# Relates to

Fixes the missing-context prerequisite in #16217 and unblocks the exact no-bypass branch-protection restoration in #13306.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the change works from the workflow diff, `actionlint`, full verification, and the live PR check rollup.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync.

# Risks

Low. Docs/config-only PRs now start the coverage workflow and spend only checkout, Node setup, and the dependency-free changed-file classifier. Source/test PR behavior and the enforced coverage floor are unchanged.

# Background

## What does this PR do?

It removes the workflow-level path filter from `coverage-gate.yml`. The job already classifies changed files before any Bun workspace setup and all expensive steps are conditional, so an unrelated PR exits green cheaply while still emitting the exact `coverage on changed files` context that branch rules require.

Without this, GitHub leaves a required context permanently pending whenever the workflow is skipped by path filters, trapping otherwise valid docs/config-only PRs.

## What kind of change is this?

Bug fix to the CI/branch-protection contract.

# Documentation changes needed?

No separate docs change. The workflow's policy comment now records why the context must always emit.

# Testing

## Where should a reviewer start?

`.github/workflows/coverage-gate.yml`

## Detailed testing steps

- `actionlint .github/workflows/coverage-gate.yml` — pass.
- `git diff --check` — pass.
- `bun install` — pass.
- `bun run verify` — pass (573 Turbo lint/typecheck tasks plus repository ratchets/audits and dist-path checks).
- Live proof: this PR changes only `.github/workflows/coverage-gate.yml`, outside the old `packages/**`, `plugins/**`, and `apps/**` filters; its check rollup must nevertheless contain a successful `coverage on changed files` run.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - CI workflow trigger behavior has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - CI workflow trigger behavior has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: N/A - the behavior is a GitHub Actions check-run, captured directly in the PR rollup.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no application backend executes; GitHub Actions job logs are linked from the live check rollup.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend code or request path changes.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the [live `coverage on changed files` check-run](https://github.com/elizaOS/eliza/actions/runs/29297460313/job/86973979261) is the authoritative CI artifact proving the context now exists for an otherwise path-filtered diff.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changes.

## Backend + frontend logs

N/A - no application runtime changes. GitHub Actions logs are available from the PR check rollup.

## Screenshots (before / after) + video walkthrough

N/A - repository CI workflow behavior only.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT changes.

## Known gaps / failures

None. The post-install artifact sync and repository lint command generated local uncommitted build/artifact outputs in the isolated worktree; none are part of this one-file commit or PR diff.