### PR TITLE
fix(core): stop action-internal model calls from leaking into the visible chat stream (#16230)

### DIFF
--- a/packages/core/src/__tests__/message-regression-lane.test.ts
+++ b/packages/core/src/__tests__/message-regression-lane.test.ts
@@ -1,0 +1,22 @@
+/**
+ * Composes the message-service regression suites for changes to the monolithic
+ * DefaultMessageService module (`services/message.ts`). The changed-file
+ * coverage gate runs only tests present in a PR diff, so this lane keeps such
+ * changes attached to the existing behavioral matrix until the message service
+ * is decomposed into independently covered modules — the mirror of
+ * `runtime-regression-lane.test.ts` for the other core monolith.
+ *
+ * Added for #16230 (scoping the visible chat stream to the top-level reply):
+ * `message.shortcut-gate.test` exercises the shortcut path's streaming-
+ * suppression wrap; the surrounding turn/voice suites supply the rest of the
+ * line coverage the gate's per-file floor requires. Only suites that share one
+ * process cleanly are composed here — suites that write trajectory to disk or
+ * install leaky module-level mocks (stress-compaction, credit-exhaustion,
+ * attachment SSRF) stay in their own isolated files.
+ */
+import "../services/message.mute-drop.test";
+import "../services/message.shortcut-gate.test";
+import "../services/message.voice-gate.test";
+import "./message-answer-clobber-rescue.test";
+import "./message-failure-reply.test";
+import "./planner-happy-path.test";

--- a/packages/core/src/__tests__/runtime-regression-lane.test.ts
+++ b/packages/core/src/__tests__/runtime-regression-lane.test.ts
@@ -25,5 +25,6 @@ import "../runtime/__tests__/model-provider-failover.test";
 import "../runtime/__tests__/model-registrations.test";
 import "../runtime/__tests__/model-stream-chunk-hooks.test";
 import "../runtime/__tests__/pii-swap-use-model.test";
+import "../runtime/__tests__/run-actions-by-mode.test";
 import "../runtime/__tests__/secret-swap-use-model.test";
 import "../runtime/__tests__/streaming-use-model.test";

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -132,6 +132,7 @@ import {
 	getStreamingContext,
 	runInsideModelStreamChunkDelivery,
 	runWithStreamingContext,
+	runWithSuppressedModelStream,
 } from "./streaming-context";
 import {
 	getTrajectoryContext,
@@ -3698,13 +3699,15 @@ export class AgentRuntime implements IAgentRuntime {
 				await runWithActionRoutingContext(
 					{ actionName: action.name, modelClass: action.modelClass },
 					() =>
-						action.handler(
-							this,
-							message,
-							composedState,
-							{ mode },
-							actionCallback,
-							options?.responses,
+						runWithSuppressedModelStream(() =>
+							action.handler(
+								this,
+								message,
+								composedState,
+								{ mode },
+								actionCallback,
+								options?.responses,
+							),
 						),
 				);
 			} catch (err) {

--- a/packages/core/src/runtime/__tests__/action-streaming-suppression.test.ts
+++ b/packages/core/src/runtime/__tests__/action-streaming-suppression.test.ts
@@ -1,0 +1,172 @@
+/**
+ * An action's *internal* `runtime.useModel` calls must NOT stream into the
+ * turn's visible reply channel (#16230). The visible token stream is scoped to
+ * the top-level RESPONSE_HANDLER generation; an action delivers its own output
+ * through the HandlerCallback, and any model call it makes to produce that
+ * output (e.g. the conversation compactor's ledger extraction) is an
+ * implementation detail the user must never see. `executePlannedToolCall`
+ * enforces this by running the handler inside `runWithSuppressedModelStream`,
+ * which shadows the chat-SSE `onStreamChunk` with a no-op while keeping the
+ * abort signal and structured hooks.
+ *
+ * The positive controls prove the negative assertions are not vacuous: the same
+ * emission DOES reach the sink when it happens at the top level (outside the
+ * suppression seam).
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+	getStreamingContext,
+	runWithStreamingContext,
+	runWithSuppressedModelStream,
+} from "../../streaming-context";
+import type { Action, IAgentRuntime, Memory } from "../../types";
+import { ModelType } from "../../types/model";
+import { executePlannedToolCall } from "../execute-planned-tool-call";
+
+const LEDGER_JSON = '```json\n{ "state": { "facts": ["internal fact"] } }\n```';
+const CLEAN_SUMMARY = "Compacted 8 older message(s); preserved the latest 4.";
+
+function makeMessage(): Memory {
+	return {
+		id: "message-id",
+		entityId: "entity-id",
+		roomId: "room-id",
+		content: { text: "/compact" },
+	} as Memory;
+}
+
+/**
+ * An action that mirrors COMPACT_CONVERSATION: it makes an internal TEXT_LARGE
+ * call whose stubbed handler streams intermediate ledger JSON into whatever
+ * streaming context is active, then delivers its designed reply through the
+ * HandlerCallback.
+ */
+function makeCompactorLikeAction(): Action {
+	return {
+		name: "COMPACT_CONVERSATION",
+		description: "Compact the conversation",
+		validate: async () => true,
+		handler: async (runtime, _message, _state, _options, callback) => {
+			// Internal model call: streaming happens inside useModel, which reads
+			// the ambient streaming context. This is the leak vector.
+			await runtime.useModel(ModelType.TEXT_LARGE, {
+				prompt: "extract the conversation ledger",
+			});
+			// The action's actual, user-visible reply.
+			await callback?.({ text: CLEAN_SUMMARY });
+			return { success: true, text: CLEAN_SUMMARY };
+		},
+	} as Action;
+}
+
+function makeRuntime(action: Action): IAgentRuntime {
+	return {
+		actions: [action],
+		logger: { debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+		// A STREAMING TEXT_LARGE model: it pushes the intermediate ledger into
+		// whatever streaming context is active during the call.
+		useModel: vi.fn(async () => {
+			const active = getStreamingContext();
+			await active?.onStreamChunk?.(LEDGER_JSON, undefined, LEDGER_JSON);
+			return LEDGER_JSON;
+		}),
+	} as unknown as IAgentRuntime;
+}
+
+describe("action streaming suppression (#16230)", () => {
+	it("keeps an action's internal useModel tokens off the visible reply stream, delivering only the callback reply", async () => {
+		const visibleSink = vi.fn();
+		const callbackReplies: string[] = [];
+		const action = makeCompactorLikeAction();
+		const runtime = makeRuntime(action);
+
+		const result = await runWithStreamingContext(
+			{
+				messageId: "msg-1",
+				onStreamChunk: async (chunk: string) => {
+					visibleSink(chunk);
+				},
+			} as never,
+			() =>
+				executePlannedToolCall(
+					runtime,
+					{
+						message: makeMessage(),
+						callback: async (content) => {
+							if (typeof content?.text === "string") {
+								callbackReplies.push(content.text);
+							}
+							return [];
+						},
+					},
+					{ name: "COMPACT_CONVERSATION", params: {} },
+				),
+		);
+
+		// The internal model call ran inside the active streaming context...
+		expect(runtime.useModel).toHaveBeenCalledTimes(1);
+		// ...but its intermediate ledger JSON was swallowed by the suppression
+		// seam — it must NEVER surface as a visible token.
+		expect(visibleSink).not.toHaveBeenCalled();
+		// The designed reply reaches the client through the HandlerCallback.
+		expect(callbackReplies).toEqual([CLEAN_SUMMARY]);
+		expect(result.success).toBe(true);
+		expect(result.text).toBe(CLEAN_SUMMARY);
+	});
+
+	it("positive control: the same internal emission DOES reach the sink at the top level (outside the action seam)", async () => {
+		const visibleSink = vi.fn();
+		const runtime = makeRuntime(makeCompactorLikeAction());
+
+		await runWithStreamingContext(
+			{
+				messageId: "msg-2",
+				onStreamChunk: async (chunk: string) => {
+					visibleSink(chunk);
+				},
+			} as never,
+			// Calling the streaming model directly at the top level — the way the
+			// RESPONSE_HANDLER reply generation does — is exactly what SHOULD stream.
+			() => runtime.useModel(ModelType.TEXT_LARGE, { prompt: "reply" }),
+		);
+
+		expect(visibleSink).toHaveBeenCalledWith(LEDGER_JSON);
+	});
+
+	it("runWithSuppressedModelStream is a pass-through when no streaming context is active", async () => {
+		const ran = vi.fn();
+		await runWithSuppressedModelStream(async () => {
+			expect(getStreamingContext()).toBeUndefined();
+			ran();
+		});
+		expect(ran).toHaveBeenCalledTimes(1);
+	});
+
+	it("runWithSuppressedModelStream preserves the abort signal and structured hooks while detaching onStreamChunk", async () => {
+		const abortSignal = new AbortController().signal;
+		const onToolResult = vi.fn(async () => undefined);
+		const visibleSink = vi.fn();
+
+		await runWithStreamingContext(
+			{
+				messageId: "msg-3",
+				abortSignal,
+				onStreamChunk: async (chunk: string) => {
+					visibleSink(chunk);
+				},
+				onToolResult,
+			} as never,
+			() =>
+				runWithSuppressedModelStream(async () => {
+					const inner = getStreamingContext();
+					// onStreamChunk is detached...
+					await inner?.onStreamChunk?.(LEDGER_JSON, undefined, LEDGER_JSON);
+					// ...but the abort signal and structured hooks are intact.
+					expect(inner?.abortSignal).toBe(abortSignal);
+					expect(inner?.onToolResult).toBe(onToolResult);
+				}),
+		);
+
+		expect(visibleSink).not.toHaveBeenCalled();
+	});
+});

--- a/packages/core/src/runtime/__tests__/run-actions-by-mode.test.ts
+++ b/packages/core/src/runtime/__tests__/run-actions-by-mode.test.ts
@@ -8,6 +8,10 @@ import { beforeAll, describe, expect, it, vi } from "vitest";
 import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
 import { AgentRuntime } from "../../runtime";
 import {
+	getStreamingContext,
+	runWithStreamingContext,
+} from "../../streaming-context";
+import {
 	type Action,
 	ActionMode,
 	type Character,
@@ -203,6 +207,63 @@ describe("runActionsByMode", () => {
 			{ text: "raw hook output" },
 			"HOOK_STATUS",
 		);
+	});
+
+	// #16230: runActionsByMode wraps each hook handler in
+	// runWithSuppressedModelStream, so a hook action's INTERNAL model call cannot
+	// stream into the turn's visible reply channel. The visible stream is scoped
+	// to the top-level response generation; hooks speak through their callback.
+	it("keeps a hook action's internal useModel output off the visible stream (#16230)", async () => {
+		const LEDGER = '```json\n{"state":{"facts":["internal"]}}\n```';
+		const visibleSink = vi.fn();
+		runtime.actions.length = 0;
+		runtime.actions.push({
+			name: "INTERNAL_MODELER",
+			description: "hook that calls the model internally",
+			mode: ActionMode.ALWAYS_AFTER,
+			examples: [],
+			validate: async () => true,
+			handler: async (rt) => {
+				await rt.useModel("TEXT_LARGE" as never, { prompt: "extract ledger" });
+				return { success: true };
+			},
+		} as Action);
+		// A streaming model: it pushes intermediate output into whatever streaming
+		// context is active during the call. The wrap makes that context's
+		// onStreamChunk a no-op for the duration of the handler.
+		const originalUseModel = runtime.useModel;
+		runtime.useModel = (async () => {
+			const active = getStreamingContext();
+			await active?.onStreamChunk?.(LEDGER, undefined, LEDGER);
+			return LEDGER;
+		}) as typeof runtime.useModel;
+		try {
+			await runWithStreamingContext(
+				{
+					messageId: "m",
+					onStreamChunk: async (chunk: string) => {
+						visibleSink(chunk);
+					},
+				} as never,
+				() => runtime.runActionsByMode("ALWAYS_AFTER", makeMessage()),
+			);
+			expect(visibleSink).not.toHaveBeenCalled();
+
+			// Positive control: the same emission at the top level (outside the hook
+			// seam) DOES reach the sink — the negative assertion is not vacuous.
+			await runWithStreamingContext(
+				{
+					messageId: "m",
+					onStreamChunk: async (chunk: string) => {
+						visibleSink(chunk);
+					},
+				} as never,
+				() => runtime.useModel("TEXT_LARGE" as never, { prompt: "reply" }),
+			);
+			expect(visibleSink).toHaveBeenCalledWith(LEDGER);
+		} finally {
+			runtime.useModel = originalUseModel;
+		}
 	});
 
 	it("HOOK_MODES export covers all 9 hook positions", () => {

--- a/packages/core/src/runtime/execute-planned-tool-call.ts
+++ b/packages/core/src/runtime/execute-planned-tool-call.ts
@@ -8,7 +8,11 @@
 import { validateToolArgs } from "../actions/validate-tool-args";
 import { evaluateConnectorAccountPolicies } from "../connectors/account-manager";
 import { checkSenderRole } from "../roles";
-import { emitStreamingHook, getStreamingContext } from "../streaming-context";
+import {
+	emitStreamingHook,
+	getStreamingContext,
+	runWithSuppressedModelStream,
+} from "../streaming-context";
 import {
 	getTrajectoryContext,
 	runWithTrajectoryContext,
@@ -403,13 +407,15 @@ export async function executePlannedToolCall(
 					{ actionName: action.name, modelClass: action.modelClass },
 					() =>
 						withActionStep(runtime, action.name, () =>
-							action.handler(
-								runtime,
-								executorCtx.message,
-								executorCtx.state,
-								handlerOptions,
-								actionCallback,
-								executorCtx.responses,
+							runWithSuppressedModelStream(() =>
+								action.handler(
+									runtime,
+									executorCtx.message,
+									executorCtx.state,
+									handlerOptions,
+									actionCallback,
+									executorCtx.responses,
+								),
 							),
 						),
 				);

--- a/packages/core/src/services/message.shortcut-gate.test.ts
+++ b/packages/core/src/services/message.shortcut-gate.test.ts
@@ -7,6 +7,10 @@
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ShortcutRegistry } from "../runtime/shortcut-registry";
+import {
+	getStreamingContext,
+	runWithStreamingContext,
+} from "../streaming-context";
 import type { Action } from "../types/components";
 import { EventType } from "../types/events";
 import type { Memory, State, UUID } from "../types/index";
@@ -360,6 +364,85 @@ describe("runShortcutGate (#8791 pre-LLM gate)", () => {
 		expect(result).toBeNull();
 		expect(handler).not.toHaveBeenCalled();
 		expect(useModel).not.toHaveBeenCalled();
+	});
+
+	// #16230: a shortcut action's INTERNAL model call (e.g. the /compact
+	// compactor's ledger extraction) must not stream into the turn's visible
+	// reply. runShortcutGate runs the handler inside runWithSuppressedModelStream,
+	// so intermediate model output never reaches the chat SSE sink; the designed
+	// reply reaches the client through the captured callback text.
+	it("keeps a shortcut action's internal model output off the visible stream, surfacing only the reply (#16230)", async () => {
+		const LEDGER = '```json\n{"state":{"facts":["internal fact"]}}\n```';
+		const SUMMARY = "Compacted 8 older message(s); preserved the latest 4.";
+		const visibleSink = vi.fn();
+
+		const registry = new ShortcutRegistry();
+		registry.register({
+			id: "cmd:compact",
+			kind: "explicit",
+			aliases: ["/compact"],
+			target: { kind: "action", name: "COMPACT_CONVERSATION" },
+		});
+		const compactAction: Action = {
+			name: "COMPACT_CONVERSATION",
+			description: "compact the conversation",
+			validate: async () => true,
+			handler: async (rt, _message, _state, _options, callback) => {
+				// Internal model call: streaming happens inside useModel, which reads
+				// the active streaming context — the leak vector.
+				await rt.useModel("TEXT_LARGE" as never, {
+					prompt: "extract the conversation ledger",
+				});
+				// The action's actual, user-visible reply.
+				if (callback) await callback({ text: SUMMARY });
+				return { success: true, text: SUMMARY };
+			},
+		};
+		const runtime = {
+			agentId: "00000000-0000-0000-0000-0000000000a1" as UUID,
+			actions: [compactAction],
+			shortcutRegistry: registry,
+			emitEvent: vi.fn(async () => undefined),
+			// A streaming model that pushes intermediate ledger JSON into whatever
+			// streaming context is active during the call.
+			useModel: async () => {
+				const active = getStreamingContext();
+				await active?.onStreamChunk?.(LEDGER, undefined, LEDGER);
+				return LEDGER;
+			},
+			logger: { debug: () => {}, warn: () => {} },
+		};
+
+		const result = await runWithStreamingContext(
+			{
+				messageId: "00000000-0000-0000-0000-0000000000f1" as UUID,
+				onStreamChunk: async (chunk: string) => {
+					visibleSink(chunk);
+				},
+			} as never,
+			() =>
+				runShortcutGate({
+					// biome-ignore lint/suspicious/noExplicitAny: minimal fake runtime
+					runtime: runtime as any,
+					message: msg("/compact"),
+					state: {} as State,
+					responseId,
+					senderRole: "OWNER",
+				}),
+		);
+
+		// The internal ledger JSON never surfaced as a visible token...
+		expect(visibleSink).not.toHaveBeenCalled();
+		// ...and the designed summary is the reply.
+		expect(result?.kind).toBe("direct_reply");
+		expect(result?.result.responseContent.text).toBe(SUMMARY);
+		expect(result?.result.actionResults).toMatchObject([
+			{
+				success: true,
+				text: SUMMARY,
+				data: { actionName: "COMPACT_CONVERSATION" },
+			},
+		]);
 	});
 
 	it("allows an OWNER to trigger the same OWNER-gated shortcut action", async () => {

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -171,6 +171,7 @@ import {
 	getModelStreamChunkDeliveryDepth,
 	getStreamingContext,
 	runWithStreamingContext,
+	runWithSuppressedModelStream,
 	type StreamingContext,
 } from "../streaming-context";
 import {
@@ -6239,17 +6240,24 @@ export async function runShortcutGate(args: {
 	let captured: string | undefined;
 	let shortcutActionResult: ActionResult | undefined;
 	try {
-		shortcutActionResult = await action.handler(
-			args.runtime,
-			args.message,
-			args.state,
-			{ ...target.parameters, ...match.parameters, mode: "simple" },
-			async (content) => {
-				if (typeof content?.text === "string" && content.text) {
-					captured = content.text;
-				}
-				return [];
-			},
+		// The shortcut action runs its handler here, outside the planned-tool-call
+		// executor. Detach the visible token stream so an action's *internal*
+		// `runtime.useModel` calls (e.g. the compactor's ledger extraction) do not
+		// masquerade as the reply (#16230); the designed reply reaches the client
+		// through `captured` below, not the raw model stream.
+		shortcutActionResult = await runWithSuppressedModelStream(() =>
+			action.handler(
+				args.runtime,
+				args.message,
+				args.state,
+				{ ...target.parameters, ...match.parameters, mode: "simple" },
+				async (content) => {
+					if (typeof content?.text === "string" && content.text) {
+						captured = content.text;
+					}
+					return [];
+				},
+			),
 		);
 	} catch (err) {
 		args.runtime.logger?.warn?.(

--- a/packages/core/src/streaming-context.ts
+++ b/packages/core/src/streaming-context.ts
@@ -168,6 +168,39 @@ export function runWithStreamingContext<T>(
 	return getOrCreateContextManager().run(context, fn);
 }
 
+/** A `StreamChunkCallback` that discards every chunk. */
+const discardStreamChunk: StreamChunkCallback = async () => undefined;
+
+/**
+ * Run `fn` with the ambient visible-token stream detached.
+ *
+ * Any `useModel` call inside still inherits the active streaming context's
+ * abort signal and structured tool/evaluation hooks, but its raw tokens no
+ * longer reach the turn's visible reply channel — `onStreamChunk` becomes a
+ * no-op. This is the seam that keeps an action handler's *internal* model
+ * calls off the user-visible reply (#16230): only the top-level response
+ * generation streams raw tokens, while an action delivers its own output
+ * through the HandlerCallback. The visible stream would otherwise surface an
+ * action's intermediate model output — e.g. the conversation compactor's
+ * rendered-ledger JSON masquerading as the `/compact` reply. An action that
+ * genuinely wants to stream can still opt in with an explicit `onStreamChunk`
+ * in its `useModel` params, which `useModel` honors independently of the
+ * ambient context. The planner and evaluator model calls apply the same
+ * override inline.
+ *
+ * A straight pass-through (no added scope) when no streaming context is active.
+ */
+export function runWithSuppressedModelStream<T>(fn: () => T): T {
+	const active = getStreamingContext();
+	if (!active) {
+		return fn();
+	}
+	return runWithStreamingContext(
+		{ ...active, onStreamChunk: discardStreamChunk },
+		fn,
+	);
+}
+
 /**
  * Get the currently active streaming context.
  * Called by useModel to check if automatic streaming should be enabled.


### PR DESCRIPTION
Fixes #16230

## Root cause

The GUI chat SSE route (`POST /api/conversations/:id/messages/stream`) streams a turn's model tokens through a single ambient streaming context — `onStreamChunk` on an AsyncLocalStorage `StreamingContext` (`packages/core/src/streaming-context.ts`). Every `runtime.useModel` call made anywhere inside `processMessage` reads that context and streams into the visible reply channel (`packages/core/src/runtime.ts:5573-5606`).

Only the **top-level** reply generation should reach that channel. The visible reply is produced by the Stage-1 `RESPONSE_HANDLER` call (`packages/core/src/services/message.ts:6628`, `streamStructured: true`), which runs *before* actions. An action delivers its own output through the `HandlerCallback` — not through raw model streaming. But an action's **internal** `useModel` calls run inside the same ambient context, so their intermediate output streamed straight into the visible reply.

`/compact` is the reported trigger: the deterministic command layer fires `COMPACT_CONVERSATION`, whose compactor makes an internal `TEXT_LARGE` call (`buildActionCompactorModelCall`, `packages/agent/src/actions/compact-conversation.ts:95` — plain `runtime.useModel("TEXT_LARGE", { system, prompt })`, no explicit `onStreamChunk`). That call's raw rendered-ledger JSON streamed as the visible reply and **claimed the stream source first**, so the action's actual summary ("Compacted N older message(s); preserved the latest M.") — delivered later via the callback — was discarded (`generateChatResponse` only chunks the resolved reply `if (!streamedText && resolvedText)`, `packages/agent/src/api/chat-routes.ts:2743`). Any action making internal model calls on the GUI stream path had the same exposure.

## The fix (channel scoping, not text filtering)

New `runWithSuppressedModelStream(fn)` in `streaming-context.ts`: runs `fn` with the ambient `onStreamChunk` detached (replaced with a no-op) while **keeping the abort signal and structured tool/evaluation hooks intact**. This is the same suppression the planner loop and evaluator already apply to their own model calls (`planner-loop.ts:1621`, `evaluator.ts:117`) — now generalized for action handlers.

It is wired around **every** action-handler invocation, so the fix is generic — it excludes *any* action's internal model calls, not just compact:

- `runtime/execute-planned-tool-call.ts:406` — the planned-tool-call executor (all planner-dispatched actions)
- `runtime.ts:3701` — `runActionsByMode` (`ALWAYS_*` / `CONTEXT_*` hook + evaluator actions)
- `services/message.ts:6242` — the shortcut/command path (the `/compact` repro)

Nested sub-action handlers inherit the suppression via AsyncLocalStorage, so a single wrap at each top-level dispatch site covers the whole call tree. The top-level `RESPONSE_HANDLER` reply generation is untouched — it runs outside any action seam, so the user-visible reply still streams token-by-token. An action that genuinely wants to stream can still opt in with an explicit `onStreamChunk` in its `useModel` params, which `useModel` honors independently of the ambient context.

## How to verify

1. In a conversation with enough history, send `/compact` through the GUI chat.
2. **Before:** the visible streamed reply was the compactor's internal ```json { "state": { "facts": [...] } }``` ledger.
3. **After:** the visible reply is the designed summary ("Compacted N older message(s); preserved the latest M."); the internal ledger JSON never appears on the wire.

## Tests

New `packages/core/src/runtime/__tests__/action-streaming-suppression.test.ts` drives the **real** `executePlannedToolCall` seam (no mock of the code under test): an action whose stubbed `TEXT_LARGE` model streams intermediate ledger JSON into the active streaming context, with a real chat-SSE sink attached. Asserts the sink never receives the internal tokens while the `HandlerCallback` delivers the clean reply. Positive controls prove the negative assertions are non-vacuous (the same emission DOES stream when made at the top level) and that the abort signal + structured hooks survive the suppression.

<details><summary>Test output</summary>

```
 ✓ action streaming suppression (#16230) > keeps an action's internal useModel tokens off the visible reply stream, delivering only the callback reply
 ✓ action streaming suppression (#16230) > positive control: the same internal emission DOES reach the sink at the top level (outside the action seam)
 ✓ action streaming suppression (#16230) > runWithSuppressedModelStream is a pass-through when no streaming context is active
 ✓ action streaming suppression (#16230) > runWithSuppressedModelStream preserves the abort signal and structured hooks while detaching onStreamChunk

 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Regression set (streaming + action execution), all green:
```
execute-planned-tool-call.test.ts, planner-streaming-suppression.test.ts,
streaming-use-model.test.ts, guarded-stream-use-model.test.ts,
streaming-context-events.test.ts, streaming-runtime-hooks.test.ts,
run-actions-by-mode.test.ts, action-model-routing-integration.test.ts,
action-handler-callsite-audit.test.ts, shortcut-registry.test.ts,
plugin-shortcut-lifecycle.test.ts, planner-happy-path.test.ts,
message-runtime-stage1.test.ts, stress-compaction.test.ts,
message-answer-clobber-rescue.test.ts
```
</details>

Verification: `bunx tsgo --noEmit -p ./tsconfig.json` (packages/core) — 0 errors. `bunx biome check` on all changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Evidence

<!-- evidence-row:before-screenshots -->
`N/A - no rendered UI surface changed. This is logic/state/hook/core code; any touched .tsx are test files, and plugins/ paths sit outside the surface-artifact gate. No user-visible pixels change.`
<!-- evidence-row:after-screenshots -->
`N/A - no rendered UI surface changed (see above).`
<!-- evidence-row:walkthrough-video -->
`N/A - non-visual behavior change; the deterministic unit tests documented above drive the real code path end to end.`
<!-- evidence-row:backend-logs -->
`N/A - no separate server run captured; the real code path is proven by the unit tests documented above (they drive the actual executor / hook / state code, not mocks of the thing under test). Full affected suites pass + Biome clean + typecheck clean on touched files.`
<!-- evidence-row:frontend-logs -->
`N/A - no new console/network surface beyond what the unit/hook tests above assert directly on the real request/stream/routing behavior.`
<!-- evidence-row:llm-trajectory -->
`N/A - deterministic change; tests use a deterministic model proxy and assert channel/routing/state behavior, not model output quality. No live-model behavior change.`
<!-- evidence-row:domain-artifacts -->
`N/A - this change produces no DB rows / files / wallet / on-chain output; the domain artifact is the test assertion itself (see the test list above).`
