### PR TITLE
fix(voice): route forced-cloud TTS directly to the configured cloud worker

### DIFF
--- a/packages/ui/src/hooks/useVoiceChat.forced-cloud-tts.test.tsx
+++ b/packages/ui/src/hooks/useVoiceChat.forced-cloud-tts.test.tsx
@@ -5,11 +5,16 @@
  * is `eliza-cloud`, a dedicated/on-device agent must NOT relay TTS through its
  * own `/api/tts/cloud` proxy (an extra phone-side download + base64 IPC
  * re-marshal) when a cloud session bearer + configured cloud origin are present:
- * it POSTs straight to the cloud worker's `/api/v1/voice/tts`. With no cloud
- * auth the on-device proxy path is preserved. Drives the real hook + real
- * processQueue against a mocked HTTP layer and audio graph.
+ * it POSTs straight to the cloud worker's `/api/v1/voice/tts` with a CORS-safe
+ * bare fetch (Authorization + Content-Type only, no cookies, no csrf mirror).
+ * Any direct failure (network reject or non-2xx) degrades to the on-device
+ * proxy, which authenticates server-side. With no cloud auth the proxy path is
+ * preserved. Drives the real hook + real processQueue against mocked HTTP
+ * layers (bare `fetch` for the direct worker, `fetchWithCsrf` for the proxy)
+ * and a fake audio graph.
  */
 
+import { logger } from "@elizaos/logger";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -22,9 +27,24 @@ import {
   DEFAULT_BOOT_CONFIG,
   setBootConfig,
 } from "../config/boot-config-store";
-import { useVoiceChat } from "./useVoiceChat";
+import { describeTtsFetchTargetForDebug } from "../voice/voice-chat-types";
+import {
+  __resetDirectCloudTtsFallbackWarnings,
+  useVoiceChat,
+} from "./useVoiceChat";
 
 const CLOUD_JWT = "header.payload.signature";
+const DIRECT_TTS_URL = "https://elizacloud.ai/api/v1/voice/tts";
+
+interface FakeSource {
+  buffer: unknown;
+  connect: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+  start: ReturnType<typeof vi.fn>;
+  onended: (() => void) | null;
+}
+
+const createdSources: FakeSource[] = [];
 
 class FakeAudioContext {
   state = "running";
@@ -43,13 +63,21 @@ class FakeAudioContext {
     connect: vi.fn(),
     disconnect: vi.fn(),
   }));
-  createBufferSource = vi.fn(() => ({
-    buffer: null,
-    connect: vi.fn(),
-    disconnect: vi.fn(),
-    start: vi.fn(),
-    onended: null,
-  }));
+  createBufferSource = vi.fn((): FakeSource => {
+    const source: FakeSource = {
+      buffer: null,
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      // Auto-finish shortly after start so the playback promise resolves and
+      // the speak() path runs to completion in fallback assertions.
+      start: vi.fn(() => {
+        setTimeout(() => source.onended?.(), 0);
+      }),
+      onended: null,
+    };
+    createdSources.push(source);
+    return source;
+  });
   decodeAudioData = vi.fn(async () => ({
     duration: 0.04,
     sampleRate: 16_000,
@@ -60,23 +88,51 @@ class FakeAudioContext {
   close = vi.fn(async () => {});
 }
 
-const fetchedUrls: string[] = [];
-const fetchedInits: (RequestInit | undefined)[] = [];
+/** Proxy-path capture (fetchWithCsrf). */
+const proxyUrls: string[] = [];
+const proxyInits: (RequestInit | undefined)[] = [];
+/** Direct-path capture (bare global fetch). */
+const directFetch = vi.fn();
+const directUrls: string[] = [];
+const directInits: (RequestInit | undefined)[] = [];
+
+function audioResponse(): Response {
+  return new Response(new Uint8Array([1, 2, 3, 4]).buffer, {
+    status: 200,
+    headers: { "content-type": "audio/wav" },
+  });
+}
 
 function installMocks() {
   fetchWithCsrf.mockReset();
-  fetchedUrls.length = 0;
-  fetchedInits.length = 0;
+  directFetch.mockReset();
+  proxyUrls.length = 0;
+  proxyInits.length = 0;
+  directUrls.length = 0;
+  directInits.length = 0;
+  createdSources.length = 0;
   fetchWithCsrf.mockImplementation(
     async (input: unknown, init?: RequestInit) => {
-      fetchedUrls.push(typeof input === "string" ? input : String(input));
-      fetchedInits.push(init);
-      return new Response(new Uint8Array([1, 2, 3, 4]).buffer, {
-        status: 200,
-        headers: { "content-type": "audio/wav" },
-      });
+      proxyUrls.push(typeof input === "string" ? input : String(input));
+      proxyInits.push(init);
+      return audioResponse();
     },
   );
+  directFetch.mockImplementation(async (input: unknown, init?: RequestInit) => {
+    directUrls.push(typeof input === "string" ? input : String(input));
+    directInits.push(init);
+    return audioResponse();
+  });
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    writable: true,
+    value: directFetch,
+  });
+  Object.defineProperty(window, "fetch", {
+    configurable: true,
+    writable: true,
+    value: directFetch,
+  });
   Object.defineProperty(globalThis, "AudioContext", {
     configurable: true,
     value: FakeAudioContext,
@@ -91,15 +147,25 @@ function installMocks() {
   window.cancelAnimationFrame = vi.fn((id: number) => clearTimeout(id));
 }
 
-function authHeaderOf(init: RequestInit | undefined): string | undefined {
-  const headers = (init?.headers ?? {}) as Record<string, string>;
-  return headers.Authorization;
+function headersOf(init: RequestInit | undefined): Record<string, string> {
+  return (init?.headers ?? {}) as Record<string, string>;
+}
+
+function renderForcedCloud() {
+  return renderHook(() =>
+    useVoiceChat({
+      onTranscript: vi.fn(),
+      voiceConfig: { provider: "eliza-cloud" },
+      cloudConnected: true,
+    }),
+  );
 }
 
 describe("useVoiceChat forced-cloud TTS routing (#16116)", () => {
   beforeEach(() => {
     installMocks();
     localStorage.clear();
+    __resetDirectCloudTtsFallbackWarnings();
     setBootConfig({ branding: {}, cloudApiBase: "https://elizacloud.ai" });
   });
   afterEach(() => {
@@ -113,33 +179,69 @@ describe("useVoiceChat forced-cloud TTS routing (#16116)", () => {
     // A live cloud session bearer is present (canonical Steward JWT).
     localStorage.setItem("steward_session_token", CLOUD_JWT);
 
-    const { result } = renderHook(() =>
-      useVoiceChat({
-        onTranscript: vi.fn(),
-        voiceConfig: { provider: "eliza-cloud" },
-        cloudConnected: true,
-      }),
-    );
+    const { result } = renderForcedCloud();
 
     act(() => {
       result.current.speak("hello from the cloud worker");
     });
 
     await waitFor(() => {
-      expect(fetchWithCsrf).toHaveBeenCalled();
+      expect(directFetch).toHaveBeenCalled();
     });
 
-    const ttsCall = fetchedUrls.findIndex((url) =>
+    const ttsCall = directUrls.findIndex((url) =>
       url.includes("/api/v1/voice/tts"),
     );
     expect(ttsCall).toBeGreaterThanOrEqual(0);
     // Direct to the configured cloud worker origin — NOT the on-device proxy.
-    expect(fetchedUrls[ttsCall]).toBe("https://elizacloud.ai/api/v1/voice/tts");
-    expect(fetchedUrls.some((url) => url.includes("/api/tts/cloud"))).toBe(
-      false,
-    );
+    expect(directUrls[ttsCall]).toBe(DIRECT_TTS_URL);
+    expect(proxyUrls.some((url) => url.includes("/api/tts/cloud"))).toBe(false);
     // Carries the cloud session bearer.
-    expect(authHeaderOf(fetchedInits[ttsCall])).toBe(`Bearer ${CLOUD_JWT}`);
+    expect(headersOf(directInits[ttsCall]).Authorization).toBe(
+      `Bearer ${CLOUD_JWT}`,
+    );
+  });
+
+  it("keeps the direct fetch CORS-safe: bare fetch, Authorization + Content-Type only, no cookies", async () => {
+    localStorage.setItem("steward_session_token", CLOUD_JWT);
+    // A csrf cookie exists (browser dashboard session) — it must NOT be
+    // mirrored into the direct cross-origin request.
+    // biome-ignore lint/suspicious/noDocumentCookie: jsdom test seeds the raw cookie the csrf client reads
+    document.cookie = "eliza_csrf=csrf-token-value";
+
+    const { result } = renderForcedCloud();
+
+    act(() => {
+      result.current.speak("cors safe please");
+    });
+
+    await waitFor(() => {
+      expect(directFetch).toHaveBeenCalled();
+    });
+
+    const ttsCall = directUrls.findIndex((url) =>
+      url.includes("/api/v1/voice/tts"),
+    );
+    expect(ttsCall).toBeGreaterThanOrEqual(0);
+    const init = directInits[ttsCall];
+    // Not fetchWithCsrf: no csrf mirror, no cookie credentials — the cloud
+    // worker answers ACAO:* which browsers reject with credentialed requests,
+    // and `x-eliza-csrf` is not in the worker's CORS allow-list. Both header
+    // names sent here ARE in CORS_ALLOW_HEADER_NAMES
+    // (packages/cloud/shared/src/lib/cors-constants.ts).
+    expect(init?.credentials).toBeUndefined();
+    const headers = headersOf(init);
+    expect(Object.keys(headers).sort()).toEqual([
+      "Authorization",
+      "Content-Type",
+    ]);
+    // Body carries the same `{ text }` contract as the proxy path (the worker
+    // treats an omitted voiceId as "unpinned", matching the proxy default).
+    expect(JSON.parse(String(init?.body))).toEqual({
+      text: "cors safe please",
+    });
+    // And the proxy transport was never used for the TTS call.
+    expect(proxyUrls.some((url) => url.includes("/api/tts/cloud"))).toBe(false);
   });
 
   it("honors a staging cloud origin from boot config (not hardcoded production)", async () => {
@@ -149,41 +251,26 @@ describe("useVoiceChat forced-cloud TTS routing (#16116)", () => {
       cloudApiBase: "https://staging.elizacloud.ai",
     });
 
-    const { result } = renderHook(() =>
-      useVoiceChat({
-        onTranscript: vi.fn(),
-        voiceConfig: { provider: "eliza-cloud" },
-        cloudConnected: true,
-      }),
-    );
+    const { result } = renderForcedCloud();
 
     act(() => {
       result.current.speak("staging please");
     });
 
     await waitFor(() => {
-      expect(fetchWithCsrf).toHaveBeenCalled();
+      expect(directFetch).toHaveBeenCalled();
     });
 
     expect(
-      fetchedUrls.some(
+      directUrls.some(
         (url) => url === "https://staging.elizacloud.ai/api/v1/voice/tts",
       ),
-    ).toBe(true);
-    expect(
-      fetchedUrls.some((url) => url.includes("elizacloud.ai/api/v1/voice/tts")),
     ).toBe(true);
   });
 
   it("preserves the on-device /api/tts/cloud proxy when no cloud session token exists", async () => {
     // No steward token in localStorage → no cloud bearer → proxy preserved.
-    const { result } = renderHook(() =>
-      useVoiceChat({
-        onTranscript: vi.fn(),
-        voiceConfig: { provider: "eliza-cloud" },
-        cloudConnected: true,
-      }),
-    );
+    const { result } = renderForcedCloud();
 
     act(() => {
       result.current.speak("no cloud auth here");
@@ -193,11 +280,128 @@ describe("useVoiceChat forced-cloud TTS routing (#16116)", () => {
       expect(fetchWithCsrf).toHaveBeenCalled();
     });
 
-    expect(fetchedUrls.some((url) => url.includes("/api/tts/cloud"))).toBe(
-      true,
-    );
-    expect(fetchedUrls.some((url) => url.includes("/api/v1/voice/tts"))).toBe(
+    expect(proxyUrls.some((url) => url.includes("/api/tts/cloud"))).toBe(true);
+    expect(directUrls.some((url) => url.includes("/api/v1/voice/tts"))).toBe(
       false,
+    );
+  });
+
+  it("falls back to the on-device proxy when the direct fetch rejects (network/preflight)", async () => {
+    localStorage.setItem("steward_session_token", CLOUD_JWT);
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    directFetch.mockImplementation(async (input: unknown) => {
+      directUrls.push(typeof input === "string" ? input : String(input));
+      throw new TypeError("Failed to fetch");
+    });
+
+    const { result } = renderForcedCloud();
+
+    act(() => {
+      result.current.speak("degrade gracefully");
+    });
+
+    // Both legs fired: direct first, then the proxy fallback.
+    await waitFor(() => {
+      expect(proxyUrls.some((url) => url.includes("/api/tts/cloud"))).toBe(
+        true,
+      );
+    });
+    expect(directUrls.filter((u) => u.includes("/api/v1/voice/tts"))).toEqual([
+      DIRECT_TTS_URL,
+    ]);
+    // The proxy audio actually played (decode → source.start), so the degrade
+    // is invisible to the user.
+    await waitFor(() => {
+      expect(createdSources[0]?.start).toHaveBeenCalledWith(0);
+    });
+    await waitFor(() => {
+      expect(result.current.isSpeaking).toBe(false);
+    });
+    expect(result.current.ttsError ?? null).toBeNull();
+    // Warned once, naming the real direct target.
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0]?.[0])).toContain(DIRECT_TTS_URL);
+  });
+
+  it("falls back to the on-device proxy on a direct non-2xx and warns only once across segments", async () => {
+    localStorage.setItem("steward_session_token", CLOUD_JWT);
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    directFetch.mockImplementation(async (input: unknown) => {
+      directUrls.push(typeof input === "string" ? input : String(input));
+      return new Response("expired session", { status: 401 });
+    });
+
+    const { result } = renderForcedCloud();
+
+    act(() => {
+      result.current.speak("first failing segment");
+    });
+    await waitFor(() => {
+      expect(
+        proxyUrls.filter((url) => url.includes("/api/tts/cloud")).length,
+      ).toBe(1);
+    });
+    await waitFor(() => {
+      expect(result.current.isSpeaking).toBe(false);
+    });
+
+    act(() => {
+      result.current.speak("second failing segment");
+    });
+    await waitFor(() => {
+      expect(
+        proxyUrls.filter((url) => url.includes("/api/tts/cloud")).length,
+      ).toBe(2);
+    });
+
+    // Direct was attempted for each segment (no sticky disable), the proxy
+    // rescued both, and the warn fired exactly once for the target.
+    expect(
+      directUrls.filter((u) => u.includes("/api/v1/voice/tts")).length,
+    ).toBe(2);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0]?.[0])).toContain(DIRECT_TTS_URL);
+    expect(result.current.ttsError ?? null).toBeNull();
+  });
+
+  it("surfaces a real TTS error (no silent healthy state) when direct AND proxy both fail", async () => {
+    localStorage.setItem("steward_session_token", CLOUD_JWT);
+    vi.spyOn(logger, "warn").mockImplementation(() => {});
+    directFetch.mockImplementation(async (input: unknown) => {
+      directUrls.push(typeof input === "string" ? input : String(input));
+      return new Response("boom", { status: 500 });
+    });
+    fetchWithCsrf.mockImplementation(async (input: unknown) => {
+      proxyUrls.push(typeof input === "string" ? input : String(input));
+      return new Response("proxy down", { status: 502 });
+    });
+
+    const { result } = renderForcedCloud();
+
+    act(() => {
+      result.current.speak("everything is broken");
+    });
+
+    await waitFor(() => {
+      expect(result.current.ttsError).not.toBeNull();
+    });
+    expect(result.current.ttsError?.engine).toBe("eliza-cloud");
+    // The surfaced failure is the PROXY's (the last real target) — the direct
+    // status was consumed by the designed degrade.
+    expect(result.current.ttsError?.message).toContain("502");
+  });
+
+  it("describes the actual fetch target in debug output (direct worker vs proxy)", () => {
+    // F4: the http-error debug line must name the target that actually served
+    // the response, not always the proxy.
+    expect(describeTtsFetchTargetForDebug(DIRECT_TTS_URL)).toBe(
+      "https://elizacloud.ai (absolute)",
+    );
+    expect(
+      describeTtsFetchTargetForDebug("http://127.0.0.1:2138/api/tts/cloud"),
+    ).toBe("http://127.0.0.1:2138 (absolute)");
+    expect(describeTtsFetchTargetForDebug("/api/tts/cloud")).toContain(
+      "relative URL",
     );
   });
 });

--- a/packages/ui/src/hooks/useVoiceChat.forced-cloud-tts.test.tsx
+++ b/packages/ui/src/hooks/useVoiceChat.forced-cloud-tts.test.tsx
@@ -1,0 +1,203 @@
+// @vitest-environment jsdom
+
+/**
+ * Forced-cloud TTS direct-worker routing (#16116). When the configured provider
+ * is `eliza-cloud`, a dedicated/on-device agent must NOT relay TTS through its
+ * own `/api/tts/cloud` proxy (an extra phone-side download + base64 IPC
+ * re-marshal) when a cloud session bearer + configured cloud origin are present:
+ * it POSTs straight to the cloud worker's `/api/v1/voice/tts`. With no cloud
+ * auth the on-device proxy path is preserved. Drives the real hook + real
+ * processQueue against a mocked HTTP layer and audio graph.
+ */
+
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchWithCsrf = vi.fn();
+vi.mock("../api/csrf-client", () => ({
+  fetchWithCsrf: (...args: unknown[]) => fetchWithCsrf(...args),
+}));
+
+import {
+  DEFAULT_BOOT_CONFIG,
+  setBootConfig,
+} from "../config/boot-config-store";
+import { useVoiceChat } from "./useVoiceChat";
+
+const CLOUD_JWT = "header.payload.signature";
+
+class FakeAudioContext {
+  state = "running";
+  destination = {};
+  audioWorklet = { addModule: vi.fn(async () => {}) };
+  resume = vi.fn(async () => {});
+  createAnalyser = vi.fn(() => ({
+    fftSize: 2048,
+    smoothingTimeConstant: 0.8,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    getFloatTimeDomainData: vi.fn((data: Float32Array) => data.fill(0)),
+  }));
+  createGain = vi.fn(() => ({
+    gain: { value: 1 },
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  }));
+  createBufferSource = vi.fn(() => ({
+    buffer: null,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    start: vi.fn(),
+    onended: null,
+  }));
+  decodeAudioData = vi.fn(async () => ({
+    duration: 0.04,
+    sampleRate: 16_000,
+    length: 640,
+    numberOfChannels: 1,
+    getChannelData: () => new Float32Array(640).fill(0.25),
+  }));
+  close = vi.fn(async () => {});
+}
+
+const fetchedUrls: string[] = [];
+const fetchedInits: (RequestInit | undefined)[] = [];
+
+function installMocks() {
+  fetchWithCsrf.mockReset();
+  fetchedUrls.length = 0;
+  fetchedInits.length = 0;
+  fetchWithCsrf.mockImplementation(
+    async (input: unknown, init?: RequestInit) => {
+      fetchedUrls.push(typeof input === "string" ? input : String(input));
+      fetchedInits.push(init);
+      return new Response(new Uint8Array([1, 2, 3, 4]).buffer, {
+        status: 200,
+        headers: { "content-type": "audio/wav" },
+      });
+    },
+  );
+  Object.defineProperty(globalThis, "AudioContext", {
+    configurable: true,
+    value: FakeAudioContext,
+  });
+  Object.defineProperty(window, "AudioContext", {
+    configurable: true,
+    value: FakeAudioContext,
+  });
+  window.requestAnimationFrame = vi.fn((cb: FrameRequestCallback) =>
+    window.setTimeout(() => cb(performance.now()), 16),
+  ) as typeof window.requestAnimationFrame;
+  window.cancelAnimationFrame = vi.fn((id: number) => clearTimeout(id));
+}
+
+function authHeaderOf(init: RequestInit | undefined): string | undefined {
+  const headers = (init?.headers ?? {}) as Record<string, string>;
+  return headers.Authorization;
+}
+
+describe("useVoiceChat forced-cloud TTS routing (#16116)", () => {
+  beforeEach(() => {
+    installMocks();
+    localStorage.clear();
+    setBootConfig({ branding: {}, cloudApiBase: "https://elizacloud.ai" });
+  });
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+    setBootConfig(DEFAULT_BOOT_CONFIG);
+    vi.restoreAllMocks();
+  });
+
+  it("POSTs directly to the cloud worker with the cloud bearer, bypassing /api/tts/cloud", async () => {
+    // A live cloud session bearer is present (canonical Steward JWT).
+    localStorage.setItem("steward_session_token", CLOUD_JWT);
+
+    const { result } = renderHook(() =>
+      useVoiceChat({
+        onTranscript: vi.fn(),
+        voiceConfig: { provider: "eliza-cloud" },
+        cloudConnected: true,
+      }),
+    );
+
+    act(() => {
+      result.current.speak("hello from the cloud worker");
+    });
+
+    await waitFor(() => {
+      expect(fetchWithCsrf).toHaveBeenCalled();
+    });
+
+    const ttsCall = fetchedUrls.findIndex((url) =>
+      url.includes("/api/v1/voice/tts"),
+    );
+    expect(ttsCall).toBeGreaterThanOrEqual(0);
+    // Direct to the configured cloud worker origin — NOT the on-device proxy.
+    expect(fetchedUrls[ttsCall]).toBe("https://elizacloud.ai/api/v1/voice/tts");
+    expect(fetchedUrls.some((url) => url.includes("/api/tts/cloud"))).toBe(
+      false,
+    );
+    // Carries the cloud session bearer.
+    expect(authHeaderOf(fetchedInits[ttsCall])).toBe(`Bearer ${CLOUD_JWT}`);
+  });
+
+  it("honors a staging cloud origin from boot config (not hardcoded production)", async () => {
+    localStorage.setItem("steward_session_token", CLOUD_JWT);
+    setBootConfig({
+      branding: {},
+      cloudApiBase: "https://staging.elizacloud.ai",
+    });
+
+    const { result } = renderHook(() =>
+      useVoiceChat({
+        onTranscript: vi.fn(),
+        voiceConfig: { provider: "eliza-cloud" },
+        cloudConnected: true,
+      }),
+    );
+
+    act(() => {
+      result.current.speak("staging please");
+    });
+
+    await waitFor(() => {
+      expect(fetchWithCsrf).toHaveBeenCalled();
+    });
+
+    expect(
+      fetchedUrls.some(
+        (url) => url === "https://staging.elizacloud.ai/api/v1/voice/tts",
+      ),
+    ).toBe(true);
+    expect(
+      fetchedUrls.some((url) => url.includes("elizacloud.ai/api/v1/voice/tts")),
+    ).toBe(true);
+  });
+
+  it("preserves the on-device /api/tts/cloud proxy when no cloud session token exists", async () => {
+    // No steward token in localStorage → no cloud bearer → proxy preserved.
+    const { result } = renderHook(() =>
+      useVoiceChat({
+        onTranscript: vi.fn(),
+        voiceConfig: { provider: "eliza-cloud" },
+        cloudConnected: true,
+      }),
+    );
+
+    act(() => {
+      result.current.speak("no cloud auth here");
+    });
+
+    await waitFor(() => {
+      expect(fetchWithCsrf).toHaveBeenCalled();
+    });
+
+    expect(fetchedUrls.some((url) => url.includes("/api/tts/cloud"))).toBe(
+      true,
+    );
+    expect(fetchedUrls.some((url) => url.includes("/api/v1/voice/tts"))).toBe(
+      false,
+    );
+  });
+});

--- a/packages/ui/src/hooks/useVoiceChat.ts
+++ b/packages/ui/src/hooks/useVoiceChat.ts
@@ -13,6 +13,7 @@
 
 import type { PluginListenerHandle } from "@capacitor/core";
 import { Capacitor } from "@capacitor/core";
+import { logger } from "@elizaos/logger";
 import {
   useCallback,
   useEffect,
@@ -90,6 +91,7 @@ import {
   DEFAULT_ELEVEN_MODEL,
   DEFAULT_ELEVEN_VOICE,
   describeTtsCloudFetchTargetForDebug,
+  describeTtsFetchTargetForDebug,
   getSpeechRecognitionCtor,
   globalAudioCache,
   isAbortError,
@@ -168,6 +170,32 @@ const MIC_RECONNECT_PULSE_MS = 1500;
 const CAPTURE_PAUSE_GRACE_MS = 1500;
 
 // ── Internal helpers ─────────────────────────────────────────────────
+
+/**
+ * Direct-cloud targets whose failure has already been logged at warn. Streamed
+ * replies fire one TTS request per clip segment, so an unreachable worker
+ * would otherwise warn once per sentence; the first failure per target warns,
+ * the rest trace through ELIZA_TTS_DEBUG only.
+ */
+const warnedDirectCloudTtsTargets = new Set<string>();
+
+/** Test hook: reset the warn-once dedupe between cases. */
+export function __resetDirectCloudTtsFallbackWarnings(): void {
+  warnedDirectCloudTtsTargets.clear();
+}
+
+function warnDirectCloudTtsFallback(target: string, error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  ttsDebug("useVoiceChat:eliza-cloud-direct-fallback", {
+    ttsTarget: target,
+    message,
+  });
+  if (warnedDirectCloudTtsTargets.has(target)) return;
+  warnedDirectCloudTtsTargets.add(target);
+  logger.warn(
+    `[useVoiceChat] Direct cloud TTS to ${target} failed (${message}); falling back to the on-device /api/tts/cloud proxy`,
+  );
+}
 
 function shouldPreferNativeTalkMode(): boolean {
   if (typeof window === "undefined") return false;
@@ -1861,9 +1889,14 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
           );
         }, CLOUD_TTS_TIMEOUT_MS);
         let res: Response;
+        // The URL the final `res` actually came from — the http-error debug log
+        // below must name the real target (direct worker vs proxy), not assume
+        // the proxy.
+        let fetchedTtsUrl: string;
         try {
           const apiToken = getElizaApiToken()?.trim() ?? "";
           const dbg = task.debugUtteranceContext;
+          const proxyUrl = resolveApiUrl("/api/tts/cloud");
           // Forced-cloud TTS routing (#15395 shared-tier + #16116 direct-cloud).
           // `speakElizaCloud` only runs when the configured provider is
           // `eliza-cloud`, so this IS the forced-cloud path:
@@ -1877,43 +1910,99 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
           // Same `{ text }` body, same audio-bytes response — only the URL and
           // bearer change.
           const route = resolveForcedCloudTtsRoute({
-            proxyUrl: resolveApiUrl("/api/tts/cloud"),
+            proxyUrl,
             proxyBearer: apiToken || null,
             sharedRuntimeOrigin: currentSharedRuntimeVoiceOrigin(),
             configuredCloudOrigin: configuredCloudVoiceOrigin(),
             cloudSessionToken: getCloudAuthToken(),
           });
+          // Debug-only correlation headers. Proxy/shared paths only: they are
+          // not in the cloud worker's CORS allow-list, so sending them on the
+          // direct cross-origin POST would fail the browser preflight.
+          const debugHeaders: Record<string, string> =
+            isTtsDebugEnabled() && dbg
+              ? {
+                  "x-elizaos-tts-message-id": encodeURIComponent(dbg.messageId),
+                  "x-elizaos-tts-clip-segment": encodeURIComponent(
+                    task.segment,
+                  ),
+                  "x-elizaos-tts-full-preview": encodeURIComponent(
+                    dbg.fullAssistTextPreview,
+                  ),
+                }
+              : {};
+          const fetchViaProxy = (url: string, bearer: string | null) =>
+            fetchWithCsrf(url, {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                Accept: "audio/wav, audio/mpeg, audio/*;q=0.9",
+                ...(bearer ? { Authorization: `Bearer ${bearer}` } : {}),
+                ...debugHeaders,
+              },
+              body: JSON.stringify({ text }),
+              signal: controller.signal,
+            });
           if (route.via === "direct-cloud") {
             ttsDebug("useVoiceChat:eliza-cloud-direct-worker", {
               ttsTarget: route.url,
               hadBearer: Boolean(route.bearer),
             });
+            fetchedTtsUrl = route.url;
+            try {
+              // CORS-safe bare fetch for the cross-origin cloud worker POST:
+              // Bearer auth needs no cookies, so no `credentials: "include"`
+              // (the worker answers `Access-Control-Allow-Origin: *`, which a
+              // browser rejects when combined with credentials), and no
+              // `fetchWithCsrf` (it mirrors the csrf cookie into
+              // `x-eliza-csrf`, which is not in the worker's allow-list and
+              // would fail the preflight). Authorization + Content-Type are
+              // both in `CORS_ALLOW_HEADER_NAMES`
+              // (packages/cloud/shared/src/lib/cors-constants.ts), so the
+              // preflight passes.
+              const directRes = await fetch(route.url, {
+                method: "POST",
+                headers: {
+                  "Content-Type": "application/json",
+                  ...(route.bearer
+                    ? { Authorization: `Bearer ${route.bearer}` }
+                    : {}),
+                },
+                body: JSON.stringify({
+                  text,
+                  ...(route.voiceId ? { voiceId: route.voiceId } : {}),
+                  ...(route.modelId ? { modelId: route.modelId } : {}),
+                }),
+                signal: controller.signal,
+              });
+              if (!directRes.ok) {
+                const preview = await directRes.text().catch(() => "");
+                throw new Error(
+                  `direct cloud TTS ${directRes.status}: ${preview.slice(0, 120)}`,
+                );
+              }
+              res = directRes;
+            } catch (error) {
+              // A caller abort (barge-in / stop / the shared timeout) is not a
+              // direct-target failure — surfacing it keeps cancel semantics;
+              // retrying via the proxy would speak a cancelled clip.
+              if (controller.signal.aborted) {
+                throw error;
+              }
+              // error-policy:J4 designed degrade — the direct cloud worker
+              // failed (expired renderer bearer → 401, CORS preflight, network);
+              // the on-device proxy authenticates server-side with the agent's
+              // cloud API key, so TTS keeps working exactly as before #16116.
+              // The fallback targets `proxyUrl` directly and can never re-enter
+              // this direct branch.
+              warnDirectCloudTtsFallback(route.url, error);
+              fetchedTtsUrl = proxyUrl;
+              res = await fetchViaProxy(proxyUrl, apiToken || null);
+            }
+          } else {
+            fetchedTtsUrl = route.url;
+            res = await fetchViaProxy(route.url, route.bearer);
           }
-          res = await fetchWithCsrf(route.url, {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              Accept: "audio/wav, audio/mpeg, audio/*;q=0.9",
-              ...(route.bearer
-                ? { Authorization: `Bearer ${route.bearer}` }
-                : {}),
-              ...(isTtsDebugEnabled() && dbg
-                ? {
-                    "x-elizaos-tts-message-id": encodeURIComponent(
-                      dbg.messageId,
-                    ),
-                    "x-elizaos-tts-clip-segment": encodeURIComponent(
-                      task.segment,
-                    ),
-                    "x-elizaos-tts-full-preview": encodeURIComponent(
-                      dbg.fullAssistTextPreview,
-                    ),
-                  }
-                : {}),
-            },
-            body: JSON.stringify({ text }),
-            signal: controller.signal,
-          });
         } finally {
           clearTimeout(timeoutId);
           if (activeFetchAbortRef.current === controller) {
@@ -1925,7 +2014,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
           const body = await res.text().catch(() => "");
           ttsDebug("useVoiceChat:eliza-cloud-http-error", {
             status: res.status,
-            ttsTarget: describeTtsCloudFetchTargetForDebug(),
+            ttsTarget: describeTtsFetchTargetForDebug(fetchedTtsUrl),
             hadBearer: Boolean(getElizaApiToken()?.trim()),
             bodyPreview: body.slice(0, 120),
           });

--- a/packages/ui/src/hooks/useVoiceChat.ts
+++ b/packages/ui/src/hooks/useVoiceChat.ts
@@ -22,6 +22,7 @@ import {
   useState,
 } from "react";
 import type { VoiceConfig } from "../api/client";
+import { getCloudAuthToken } from "../api/client-cloud";
 import { fetchWithCsrf } from "../api/csrf-client";
 import {
   getElectrobunRendererRpc,
@@ -64,8 +65,9 @@ import {
   warmPlaybackWorklet,
 } from "../voice/playback-frame-pump";
 import {
+  configuredCloudVoiceOrigin,
   currentSharedRuntimeVoiceOrigin,
-  sharedRuntimeTtsUrl,
+  resolveForcedCloudTtsRoute,
 } from "../voice/shared-runtime-voice";
 import {
   collapseWhitespace,
@@ -1862,22 +1864,39 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
         try {
           const apiToken = getElizaApiToken()?.trim() ?? "";
           const dbg = task.debugUtteranceContext;
-          // Shared-tier fallback (#15395): a shared-runtime agent has no
-          // `/api/tts/cloud` container route (404s), so target the cloud API
-          // worker's provider-agnostic v1 TTS route instead. Same `{ text }`
-          // JSON body, same audio-bytes response — no adaptation needed beyond
-          // the URL. Dedicated-tier agents keep `/api/tts/cloud` unchanged
-          // (sharedTtsOrigin is null for them).
-          const sharedTtsOrigin = currentSharedRuntimeVoiceOrigin();
-          const ttsTarget = sharedTtsOrigin
-            ? sharedRuntimeTtsUrl(sharedTtsOrigin)
-            : resolveApiUrl("/api/tts/cloud");
-          res = await fetchWithCsrf(ttsTarget, {
+          // Forced-cloud TTS routing (#15395 shared-tier + #16116 direct-cloud).
+          // `speakElizaCloud` only runs when the configured provider is
+          // `eliza-cloud`, so this IS the forced-cloud path:
+          //  - shared-runtime agents (no container) target the worker's
+          //    provider-agnostic v1 voice route off their active base;
+          //  - a dedicated/on-device agent with a cloud session bearer +
+          //    configured cloud origin POSTs straight to that same v1 route,
+          //    skipping its own `/api/tts/cloud` proxy (the extra phone-side
+          //    download + base64 IPC re-marshal, #16116);
+          //  - otherwise the on-device `/api/tts/cloud` proxy is preserved.
+          // Same `{ text }` body, same audio-bytes response — only the URL and
+          // bearer change.
+          const route = resolveForcedCloudTtsRoute({
+            proxyUrl: resolveApiUrl("/api/tts/cloud"),
+            proxyBearer: apiToken || null,
+            sharedRuntimeOrigin: currentSharedRuntimeVoiceOrigin(),
+            configuredCloudOrigin: configuredCloudVoiceOrigin(),
+            cloudSessionToken: getCloudAuthToken(),
+          });
+          if (route.via === "direct-cloud") {
+            ttsDebug("useVoiceChat:eliza-cloud-direct-worker", {
+              ttsTarget: route.url,
+              hadBearer: Boolean(route.bearer),
+            });
+          }
+          res = await fetchWithCsrf(route.url, {
             method: "POST",
             headers: {
               "Content-Type": "application/json",
               Accept: "audio/wav, audio/mpeg, audio/*;q=0.9",
-              ...(apiToken ? { Authorization: `Bearer ${apiToken}` } : {}),
+              ...(route.bearer
+                ? { Authorization: `Bearer ${route.bearer}` }
+                : {}),
               ...(isTtsDebugEnabled() && dbg
                 ? {
                     "x-elizaos-tts-message-id": encodeURIComponent(

--- a/packages/ui/src/hooks/useVoiceChat.tts-playback.test.tsx
+++ b/packages/ui/src/hooks/useVoiceChat.tts-playback.test.tsx
@@ -1,0 +1,328 @@
+// @vitest-environment jsdom
+
+/**
+ * useVoiceChat end-to-end TTS playback across every configured provider. Drives
+ * the real hook + real processQueue + real PlaybackFramePump against a fake Web
+ * Audio graph whose buffer source auto-fires `onended`, so each provider runs
+ * its full synth → decode → play → teardown path (not just the request). Covers
+ * eliza-cloud, local-inference, ElevenLabs (server-proxy), and browser
+ * SpeechSynthesis, plus streamed assistant speech and stop/cancel. Complements
+ * the routing unit tests (`useVoiceChat.forced-cloud-tts`, `shared-runtime-voice`).
+ */
+
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchWithCsrf = vi.fn();
+vi.mock("../api/csrf-client", () => ({
+  fetchWithCsrf: (...args: unknown[]) => fetchWithCsrf(...args),
+}));
+
+import { globalAudioCache } from "../voice/voice-chat-types";
+import { useVoiceChat } from "./useVoiceChat";
+
+interface FakeSource {
+  buffer: unknown;
+  connect: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+  start: ReturnType<typeof vi.fn>;
+  onended: (() => void) | null;
+}
+
+const createdSources: FakeSource[] = [];
+
+class FakeAudioWorkletNode {
+  port: { onmessage: ((event: MessageEvent) => void) | null } = {
+    onmessage: null,
+  };
+  connect = vi.fn();
+  disconnect = vi.fn();
+}
+
+class FakeAudioContext {
+  state = "running";
+  destination = {};
+  audioWorklet = { addModule: vi.fn(async () => {}) };
+  resume = vi.fn(async () => {});
+  createAnalyser = vi.fn(() => ({
+    fftSize: 2048,
+    smoothingTimeConstant: 0.8,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    getFloatTimeDomainData: vi.fn((data: Float32Array) => data.fill(0)),
+  }));
+  createGain = vi.fn(() => ({
+    gain: { value: 1 },
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  }));
+  createBufferSource = vi.fn((): FakeSource => {
+    const source: FakeSource = {
+      buffer: null,
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      // Auto-finish shortly after start so the playback promise resolves and
+      // the full teardown path (disconnect + timer clear) runs.
+      start: vi.fn(() => {
+        setTimeout(() => source.onended?.(), 0);
+      }),
+      onended: null,
+    };
+    createdSources.push(source);
+    return source;
+  });
+  decodeAudioData = vi.fn(async () => ({
+    duration: 0.04,
+    sampleRate: 16_000,
+    length: 640,
+    numberOfChannels: 1,
+    getChannelData: () => new Float32Array(640).fill(0.25),
+  }));
+  close = vi.fn(async () => {});
+}
+
+class FakeUtterance extends EventTarget {
+  text: string;
+  lang = "";
+  rate = 1;
+  pitch = 1;
+  voice: SpeechSynthesisVoice | null = null;
+  onstart: (() => void) | null = null;
+  onend: (() => void) | null = null;
+  onerror: ((event: SpeechSynthesisErrorEvent) => void) | null = null;
+  constructor(text: string) {
+    super();
+    this.text = text;
+  }
+}
+
+const speechSynthesisMock = {
+  speaking: false,
+  pending: false,
+  spoken: [] as FakeUtterance[],
+  cancel: vi.fn(),
+  getVoices: vi.fn(() => []),
+  speak: vi.fn((u: FakeUtterance) => {
+    speechSynthesisMock.spoken.push(u);
+    u.onstart?.();
+    u.onend?.();
+  }),
+};
+
+const fetchedUrls: string[] = [];
+
+function installMocks() {
+  fetchWithCsrf.mockReset();
+  fetchedUrls.length = 0;
+  createdSources.length = 0;
+  speechSynthesisMock.spoken = [];
+  speechSynthesisMock.speak.mockClear();
+  speechSynthesisMock.cancel.mockClear();
+  globalAudioCache.clear();
+  fetchWithCsrf.mockImplementation(async (input: unknown) => {
+    const url = typeof input === "string" ? input : String(input);
+    fetchedUrls.push(url);
+    if (url.includes("/api/voice/playback-frames")) {
+      return new Response(null, { status: 204 });
+    }
+    // Every TTS endpoint (cloud proxy, direct worker, local-inference,
+    // elevenlabs proxy) returns a decodable audio payload.
+    return new Response(new Uint8Array([1, 2, 3, 4]).buffer, {
+      status: 200,
+      headers: { "content-type": "audio/wav" },
+    });
+  });
+  Object.defineProperty(globalThis, "AudioContext", {
+    configurable: true,
+    value: FakeAudioContext,
+  });
+  Object.defineProperty(window, "AudioContext", {
+    configurable: true,
+    value: FakeAudioContext,
+  });
+  Object.defineProperty(globalThis, "AudioWorkletNode", {
+    configurable: true,
+    value: FakeAudioWorkletNode,
+  });
+  Object.defineProperty(window, "speechSynthesis", {
+    configurable: true,
+    value: speechSynthesisMock,
+  });
+  Object.defineProperty(window, "SpeechSynthesisUtterance", {
+    configurable: true,
+    value: FakeUtterance,
+  });
+  Object.defineProperty(globalThis, "SpeechSynthesisUtterance", {
+    configurable: true,
+    value: FakeUtterance,
+  });
+  if (typeof URL.createObjectURL !== "function") {
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: vi.fn(() => "blob:playback-worklet"),
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: vi.fn(),
+    });
+  }
+  window.requestAnimationFrame = vi.fn((cb: FrameRequestCallback) =>
+    window.setTimeout(() => cb(performance.now()), 16),
+  ) as typeof window.requestAnimationFrame;
+  window.cancelAnimationFrame = vi.fn((id: number) => clearTimeout(id));
+}
+
+type VoiceConfigArg = Parameters<typeof useVoiceChat>[0]["voiceConfig"];
+
+function renderVoiceChat(voiceConfig: VoiceConfigArg) {
+  return renderHook(() =>
+    useVoiceChat({ onTranscript: vi.fn(), voiceConfig, cloudConnected: true }),
+  );
+}
+
+describe("useVoiceChat TTS playback across providers", () => {
+  beforeEach(() => {
+    installMocks();
+    localStorage.clear();
+  });
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("plays an Eliza Cloud reply end to end (fetch → decode → play → finish)", async () => {
+    const { result } = renderVoiceChat({ provider: "eliza-cloud" });
+
+    act(() => {
+      result.current.speak("cloud reply one");
+    });
+
+    await waitFor(() => {
+      expect(createdSources.length).toBeGreaterThan(0);
+      expect(createdSources[0]?.start).toHaveBeenCalledWith(0);
+    });
+    await waitFor(() => {
+      expect(result.current.isSpeaking).toBe(false);
+    });
+    expect(result.current.ttsError ?? null).toBeNull();
+    expect(
+      fetchedUrls.some(
+        (url) => url.includes("/tts/") || url.includes("/voice/tts"),
+      ),
+    ).toBe(true);
+    // Cloud Kokoro is not the browser engine — no SpeechSynthesis swap.
+    expect(speechSynthesisMock.speak).not.toHaveBeenCalled();
+  });
+
+  it("plays a local-inference reply end to end", async () => {
+    const { result } = renderVoiceChat({ provider: "local-inference" });
+
+    act(() => {
+      result.current.speak("local inference reply");
+    });
+
+    await waitFor(() => {
+      expect(
+        fetchedUrls.some((url) => url.includes("/api/tts/local-inference")),
+      ).toBe(true);
+    });
+    await waitFor(() => {
+      expect(result.current.isSpeaking).toBe(false);
+    });
+    expect(result.current.ttsError ?? null).toBeNull();
+    expect(createdSources[0]?.start).toHaveBeenCalledWith(0);
+  });
+
+  it("plays an ElevenLabs reply via the server proxy (no browser key)", async () => {
+    const { result } = renderVoiceChat({
+      provider: "elevenlabs",
+      elevenlabs: { voiceId: "voice-x", modelId: "model-x" },
+    });
+
+    act(() => {
+      result.current.speak("elevenlabs reply");
+    });
+
+    await waitFor(() => {
+      expect(fetchedUrls.some((url) => url.includes("/api/tts/cloud"))).toBe(
+        true,
+      );
+    });
+    await waitFor(() => {
+      expect(result.current.isSpeaking).toBe(false);
+    });
+    expect(result.current.ttsError ?? null).toBeNull();
+    expect(createdSources[0]?.start).toHaveBeenCalledWith(0);
+  });
+
+  it("speaks via the browser when the browser is the configured engine (edge)", async () => {
+    const { result } = renderVoiceChat({ provider: "edge" });
+
+    act(() => {
+      result.current.speak("browser reply");
+    });
+
+    await waitFor(() => {
+      expect(speechSynthesisMock.speak).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(result.current.isSpeaking).toBe(false);
+    });
+    expect(result.current.ttsError ?? null).toBeNull();
+    // Configured browser voice: no server TTS fetch.
+    expect(fetchedUrls.some((url) => url.includes("/api/tts/"))).toBe(false);
+  });
+
+  it("streams assistant speech: an early clip flushes, then the final promotes", async () => {
+    const { result } = renderVoiceChat({ provider: "eliza-cloud" });
+
+    // First streamed chunk over the first-flush threshold queues a clip after
+    // the debounce; the final promotes the remainder.
+    act(() => {
+      result.current.queueAssistantSpeech(
+        "msg-stream-1",
+        "This is the first streamed sentence of the reply.",
+        false,
+      );
+    });
+
+    await waitFor(() => {
+      expect(createdSources.length).toBeGreaterThan(0);
+    });
+
+    act(() => {
+      result.current.queueAssistantSpeech(
+        "msg-stream-1",
+        "This is the first streamed sentence of the reply. And here is the rest of it.",
+        true,
+      );
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSpeaking).toBe(false);
+    });
+    expect(result.current.ttsError ?? null).toBeNull();
+  });
+
+  it("stopSpeaking cancels playback and clears the speaking state", async () => {
+    const { result } = renderVoiceChat({ provider: "eliza-cloud" });
+
+    act(() => {
+      result.current.speak("first utterance");
+      result.current.speak("second utterance", { append: true });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSpeaking).toBe(true);
+    });
+
+    act(() => {
+      result.current.stopSpeaking();
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSpeaking).toBe(false);
+    });
+  });
+});

--- a/packages/ui/src/hooks/useVoiceChat.tts-playback.test.tsx
+++ b/packages/ui/src/hooks/useVoiceChat.tts-playback.test.tsx
@@ -10,6 +10,7 @@
  * the routing unit tests (`useVoiceChat.forced-cloud-tts`, `shared-runtime-voice`).
  */
 
+import { logger } from "@elizaos/logger";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -19,7 +20,10 @@ vi.mock("../api/csrf-client", () => ({
 }));
 
 import { globalAudioCache } from "../voice/voice-chat-types";
-import { useVoiceChat } from "./useVoiceChat";
+import {
+  __resetDirectCloudTtsFallbackWarnings,
+  useVoiceChat,
+} from "./useVoiceChat";
 
 interface FakeSource {
   buffer: unknown;
@@ -181,13 +185,25 @@ function renderVoiceChat(voiceConfig: VoiceConfigArg) {
 }
 
 describe("useVoiceChat TTS playback across providers", () => {
+  const originalFetch = globalThis.fetch;
   beforeEach(() => {
     installMocks();
     localStorage.clear();
+    __resetDirectCloudTtsFallbackWarnings();
   });
   afterEach(() => {
     cleanup();
     localStorage.clear();
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      writable: true,
+      value: originalFetch,
+    });
+    Object.defineProperty(window, "fetch", {
+      configurable: true,
+      writable: true,
+      value: originalFetch,
+    });
     vi.restoreAllMocks();
   });
 
@@ -303,6 +319,50 @@ describe("useVoiceChat TTS playback across providers", () => {
       expect(result.current.isSpeaking).toBe(false);
     });
     expect(result.current.ttsError ?? null).toBeNull();
+  });
+
+  it("degrades a failed direct-cloud fetch to the proxy and still plays audio end to end", async () => {
+    // A cloud session bearer + the default cloud origin select the direct
+    // worker path; the direct bare fetch dies (network / preflight) and the
+    // designed degrade must play the same clip through the on-device proxy.
+    localStorage.setItem("steward_session_token", "header.payload.signature");
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    const directFetch = vi.fn(async () => {
+      throw new TypeError("Failed to fetch");
+    });
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      writable: true,
+      value: directFetch,
+    });
+    Object.defineProperty(window, "fetch", {
+      configurable: true,
+      writable: true,
+      value: directFetch,
+    });
+
+    const { result } = renderVoiceChat({ provider: "eliza-cloud" });
+
+    act(() => {
+      result.current.speak("fallback reply");
+    });
+
+    // Both legs fired: the direct worker attempt, then the proxy rescue.
+    await waitFor(() => {
+      expect(directFetch).toHaveBeenCalled();
+      expect(fetchedUrls.some((url) => url.includes("/api/tts/cloud"))).toBe(
+        true,
+      );
+    });
+    // The proxy audio decoded and played to completion — user hears the reply.
+    await waitFor(() => {
+      expect(createdSources[0]?.start).toHaveBeenCalledWith(0);
+    });
+    await waitFor(() => {
+      expect(result.current.isSpeaking).toBe(false);
+    });
+    expect(result.current.ttsError ?? null).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 
   it("stopSpeaking cancels playback and clears the speaking state", async () => {

--- a/packages/ui/src/voice/shared-runtime-voice.test.ts
+++ b/packages/ui/src/voice/shared-runtime-voice.test.ts
@@ -14,12 +14,18 @@ vi.mock("../utils/eliza-globals", () => ({
   getElizaApiBase: vi.fn<() => string | undefined>(),
 }));
 
+import {
+  DEFAULT_BOOT_CONFIG,
+  setBootConfig,
+} from "../config/boot-config-store";
 import { getElizaApiBase } from "../utils/eliza-globals";
 import {
   buildSharedRuntimeSttBody,
+  configuredCloudVoiceOrigin,
   currentSharedRuntimeVoiceOrigin,
   isVoiceTargetResolvableForActiveAgent,
   parseSharedRuntimeSttResponse,
+  resolveForcedCloudTtsRoute,
   sharedRuntimeSttUrl,
   sharedRuntimeTtsUrl,
   sharedRuntimeVoiceOrigin,
@@ -29,6 +35,7 @@ const getElizaApiBaseMock = vi.mocked(getElizaApiBase);
 
 afterEach(() => {
   vi.clearAllMocks();
+  setBootConfig(DEFAULT_BOOT_CONFIG);
 });
 
 describe("sharedRuntimeVoiceOrigin (shared-base detection)", () => {
@@ -94,6 +101,119 @@ describe("v1 route URL builders", () => {
     expect(sharedRuntimeSttUrl("https://api.elizacloud.ai/")).toBe(
       "https://api.elizacloud.ai/api/v1/voice/stt",
     );
+  });
+});
+
+describe("configuredCloudVoiceOrigin (boot-config cloud worker origin, #16116)", () => {
+  it("returns the boot-config cloud origin (default production)", () => {
+    setBootConfig({ branding: {}, cloudApiBase: "https://elizacloud.ai" });
+    expect(configuredCloudVoiceOrigin()).toBe("https://elizacloud.ai");
+  });
+
+  it("honors a staging/custom origin (not hardcoded to production)", () => {
+    setBootConfig({
+      branding: {},
+      cloudApiBase: "https://staging.elizacloud.ai",
+    });
+    expect(configuredCloudVoiceOrigin()).toBe("https://staging.elizacloud.ai");
+  });
+
+  it("strips a trailing /api/v1 and trailing slashes", () => {
+    setBootConfig({
+      branding: {},
+      cloudApiBase: "https://api.example.dev/api/v1/",
+    });
+    expect(configuredCloudVoiceOrigin()).toBe("https://api.example.dev");
+  });
+
+  it("returns null for a blank or non-https cloud base", () => {
+    setBootConfig({ branding: {}, cloudApiBase: "   " });
+    expect(configuredCloudVoiceOrigin()).toBeNull();
+    setBootConfig({ branding: {}, cloudApiBase: "ftp://nope.example" });
+    expect(configuredCloudVoiceOrigin()).toBeNull();
+  });
+});
+
+describe("resolveForcedCloudTtsRoute (#16116 direct-cloud routing)", () => {
+  const PROXY = "http://127.0.0.1:31337/api/tts/cloud";
+
+  it("routes forced-cloud DIRECTLY to the cloud worker with the cloud bearer", () => {
+    const route = resolveForcedCloudTtsRoute({
+      proxyUrl: PROXY,
+      proxyBearer: "on-device-agent-token",
+      sharedRuntimeOrigin: null,
+      configuredCloudOrigin: "https://elizacloud.ai",
+      cloudSessionToken: "cloud-steward-jwt",
+    });
+    expect(route.via).toBe("direct-cloud");
+    expect(route.url).toBe("https://elizacloud.ai/api/v1/voice/tts");
+    // NOT the on-device proxy — that is the whole point of the fix.
+    expect(route.url).not.toContain("/api/tts/cloud");
+    // Carries the CLOUD session bearer, not the on-device agent token.
+    expect(route.bearer).toBe("cloud-steward-jwt");
+  });
+
+  it("targets the configured staging origin (no hardcoded production)", () => {
+    const route = resolveForcedCloudTtsRoute({
+      proxyUrl: PROXY,
+      proxyBearer: null,
+      sharedRuntimeOrigin: null,
+      configuredCloudOrigin: "https://staging.elizacloud.ai",
+      cloudSessionToken: "jwt",
+    });
+    expect(route.url).toBe("https://staging.elizacloud.ai/api/v1/voice/tts");
+  });
+
+  it("preserves the on-device proxy when no cloud session token is available", () => {
+    const route = resolveForcedCloudTtsRoute({
+      proxyUrl: PROXY,
+      proxyBearer: "on-device-agent-token",
+      sharedRuntimeOrigin: null,
+      configuredCloudOrigin: "https://elizacloud.ai",
+      cloudSessionToken: null,
+    });
+    expect(route.via).toBe("on-device-proxy");
+    expect(route.url).toBe(PROXY);
+    expect(route.bearer).toBe("on-device-agent-token");
+  });
+
+  it("preserves the on-device proxy when no configured cloud origin is available", () => {
+    const route = resolveForcedCloudTtsRoute({
+      proxyUrl: PROXY,
+      proxyBearer: "on-device-agent-token",
+      sharedRuntimeOrigin: null,
+      configuredCloudOrigin: null,
+      cloudSessionToken: "jwt",
+    });
+    expect(route.via).toBe("on-device-proxy");
+    expect(route.url).toBe(PROXY);
+  });
+
+  it("treats a blank cloud session token as unavailable (proxy preserved)", () => {
+    const route = resolveForcedCloudTtsRoute({
+      proxyUrl: PROXY,
+      proxyBearer: "on-device-agent-token",
+      sharedRuntimeOrigin: null,
+      configuredCloudOrigin: "https://elizacloud.ai",
+      cloudSessionToken: "   ",
+    });
+    expect(route.via).toBe("on-device-proxy");
+    expect(route.url).toBe(PROXY);
+  });
+
+  it("leaves the shared-runtime path unchanged (targets the active base, #15395)", () => {
+    const route = resolveForcedCloudTtsRoute({
+      proxyUrl: PROXY,
+      proxyBearer: "active-base-token",
+      sharedRuntimeOrigin: "https://api.elizacloud.ai",
+      configuredCloudOrigin: "https://elizacloud.ai",
+      cloudSessionToken: "cloud-steward-jwt",
+    });
+    expect(route.via).toBe("shared-runtime");
+    expect(route.url).toBe("https://api.elizacloud.ai/api/v1/voice/tts");
+    // Shared-tier keeps its active-base token; it is not re-authed to the
+    // steward bearer here.
+    expect(route.bearer).toBe("active-base-token");
   });
 });
 

--- a/packages/ui/src/voice/shared-runtime-voice.test.ts
+++ b/packages/ui/src/voice/shared-runtime-voice.test.ts
@@ -201,6 +201,49 @@ describe("resolveForcedCloudTtsRoute (#16116 direct-cloud routing)", () => {
     expect(route.url).toBe(PROXY);
   });
 
+  it("omits voiceId/modelId from the direct route when the caller knows none (worker default = proxy default)", () => {
+    // The proxy injects LEGACY_DEFAULT_ELEVENLABS_VOICE_ID, which the worker's
+    // provider selection treats as "unpinned" — identical to omitting voiceId,
+    // so a bare direct body keeps voice parity in the default setup.
+    const route = resolveForcedCloudTtsRoute({
+      proxyUrl: PROXY,
+      proxyBearer: null,
+      sharedRuntimeOrigin: null,
+      configuredCloudOrigin: "https://elizacloud.ai",
+      cloudSessionToken: "jwt",
+    });
+    expect(route.via).toBe("direct-cloud");
+    expect(route.voiceId).toBeUndefined();
+    expect(route.modelId).toBeUndefined();
+  });
+
+  it("carries a caller-known voice/model pin into the direct route (parity seam)", () => {
+    const route = resolveForcedCloudTtsRoute({
+      proxyUrl: PROXY,
+      proxyBearer: null,
+      sharedRuntimeOrigin: null,
+      configuredCloudOrigin: "https://elizacloud.ai",
+      cloudSessionToken: "jwt",
+      voiceId: "  custom-voice-id  ",
+      modelId: "eleven_flash_v2_5",
+    });
+    expect(route.via).toBe("direct-cloud");
+    expect(route.voiceId).toBe("custom-voice-id");
+    expect(route.modelId).toBe("eleven_flash_v2_5");
+    // Blank pins are treated as absent, never sent as empty strings.
+    const blank = resolveForcedCloudTtsRoute({
+      proxyUrl: PROXY,
+      proxyBearer: null,
+      sharedRuntimeOrigin: null,
+      configuredCloudOrigin: "https://elizacloud.ai",
+      cloudSessionToken: "jwt",
+      voiceId: "   ",
+      modelId: null,
+    });
+    expect(blank.voiceId).toBeUndefined();
+    expect(blank.modelId).toBeUndefined();
+  });
+
   it("leaves the shared-runtime path unchanged (targets the active base, #15395)", () => {
     const route = resolveForcedCloudTtsRoute({
       proxyUrl: PROXY,

--- a/packages/ui/src/voice/shared-runtime-voice.ts
+++ b/packages/ui/src/voice/shared-runtime-voice.ts
@@ -23,6 +23,7 @@
  * container.
  */
 
+import { getBootConfig } from "../config/boot-config-store";
 import { normalizeDirectCloudSharedAgentApiBase } from "../utils/cloud-agent-base";
 import { getElizaApiBase } from "../utils/eliza-globals";
 
@@ -98,9 +99,96 @@ export function isVoiceTargetResolvableForActiveAgent(): boolean {
   return /^https?:\/\//i.test(sharedOrigin);
 }
 
-/** Build the shared-tier TTS URL (`<origin>/api/v1/voice/tts`). */
+/** Build the cloud-worker v1 TTS URL (`<origin>/api/v1/voice/tts`). */
 export function sharedRuntimeTtsUrl(origin: string): string {
   return `${origin.replace(/\/+$/, "")}/api/v1/voice/tts`;
+}
+
+/**
+ * Resolve the configured Eliza Cloud worker origin from boot config, for
+ * forced-cloud voice that must bypass the on-device proxy (#16116).
+ *
+ * Boot config carries the cloud SITE base (`cloudApiBase`, e.g.
+ * `https://elizacloud.ai`, or a staging/custom origin). The provider-agnostic
+ * v1 voice routes hang off the bare origin, so we strip a trailing `/api/v1`
+ * (some hosts pass the API base with the version path) and any trailing
+ * slashes. Returns `null` when boot config has no usable https origin — the
+ * caller then keeps the on-device proxy path. Reading from boot config (not a
+ * hardcoded production URL) keeps staging/custom cloud environments correct.
+ */
+export function configuredCloudVoiceOrigin(): string | null {
+  const raw = getBootConfig().cloudApiBase?.trim();
+  if (!raw) return null;
+  const origin = raw
+    .replace(/\/+$/, "")
+    .replace(/\/api\/v1$/i, "")
+    .replace(/\/+$/, "");
+  return /^https?:\/\//i.test(origin) ? origin : null;
+}
+
+/** How a forced-cloud TTS request was routed (drives the request + debug). */
+export interface ForcedCloudTtsRoute {
+  /** Absolute TTS endpoint to POST `{ text }` to. */
+  url: string;
+  /** Bearer to send, or `null` to omit the `Authorization` header. */
+  bearer: string | null;
+  /** Which target was chosen — observability + regression assertions. */
+  via: "shared-runtime" | "direct-cloud" | "on-device-proxy";
+}
+
+/**
+ * Decide where forced-cloud (`provider === "eliza-cloud"`) TTS should POST and
+ * which bearer to carry.
+ *
+ * A dedicated/on-device agent otherwise relays TTS through its own
+ * `/api/tts/cloud` proxy — an extra audio download through the phone-side event
+ * loop plus a base64 IPC re-marshal (~5–6 s/reply on constrained devices, #16116)
+ * even though the cloud worker completes in 1–2 s. When a cloud session bearer
+ * and a configured cloud origin are both available, POST straight to the cloud
+ * worker's v1 voice route instead. Shared-runtime agents (no container) already
+ * resolve directly to that route off their active base and are left unchanged
+ * (#15395). With no cloud auth/config, the on-device proxy path is preserved.
+ *
+ * Pure so the routing decision is unit-testable without a network or DOM.
+ */
+export function resolveForcedCloudTtsRoute(input: {
+  /** On-device proxy target, `resolveApiUrl("/api/tts/cloud")`. */
+  proxyUrl: string;
+  /** Bearer used for the shared-runtime + proxy paths (active-base token). */
+  proxyBearer: string | null;
+  /** `currentSharedRuntimeVoiceOrigin()` — non-null only for shared-tier bases. */
+  sharedRuntimeOrigin: string | null;
+  /** `configuredCloudVoiceOrigin()` — the boot-config cloud worker origin. */
+  configuredCloudOrigin: string | null;
+  /** `getCloudAuthToken()` — the canonical Steward cloud session bearer. */
+  cloudSessionToken: string | null;
+}): ForcedCloudTtsRoute {
+  const {
+    proxyUrl,
+    proxyBearer,
+    sharedRuntimeOrigin,
+    configuredCloudOrigin,
+    cloudSessionToken,
+  } = input;
+
+  if (sharedRuntimeOrigin) {
+    return {
+      url: sharedRuntimeTtsUrl(sharedRuntimeOrigin),
+      bearer: proxyBearer,
+      via: "shared-runtime",
+    };
+  }
+
+  const token = cloudSessionToken?.trim();
+  if (token && configuredCloudOrigin) {
+    return {
+      url: sharedRuntimeTtsUrl(configuredCloudOrigin),
+      bearer: token,
+      via: "direct-cloud",
+    };
+  }
+
+  return { url: proxyUrl, bearer: proxyBearer, via: "on-device-proxy" };
 }
 
 /** Build the shared-tier STT URL (`<origin>/api/v1/voice/stt`). */

--- a/packages/ui/src/voice/shared-runtime-voice.ts
+++ b/packages/ui/src/voice/shared-runtime-voice.ts
@@ -134,6 +134,9 @@ export interface ForcedCloudTtsRoute {
   bearer: string | null;
   /** Which target was chosen — observability + regression assertions. */
   via: "shared-runtime" | "direct-cloud" | "on-device-proxy";
+  /** Voice/model to carry in the direct request body (parity with a caller-known pin). */
+  voiceId?: string;
+  modelId?: string;
 }
 
 /**
@@ -149,6 +152,21 @@ export interface ForcedCloudTtsRoute {
  * resolve directly to that route off their active base and are left unchanged
  * (#15395). With no cloud auth/config, the on-device proxy path is preserved.
  *
+ * Voice/model parity with the proxy: in the default (unpinned) setup the direct
+ * `{ text }` body and the proxy produce the SAME voice — the proxy injects
+ * `LEGACY_DEFAULT_ELEVENLABS_VOICE_ID`, which the worker's provider selection
+ * (`packages/cloud/api/v1/voice/tts/provider-selection.ts`) explicitly treats
+ * as "caller did not pin a voice", identical to an omitted `voiceId`. The
+ * residual gap is a server-side `ELIZAOS_CLOUD_TTS_VOICE` / `_MODEL` env pin:
+ * those env vars live only in the agent-server process and are exposed through
+ * no renderer channel (not boot config, not `VoiceConfig`, not `getConfig()`),
+ * so the client cannot detect a pin to route around it. When the caller DOES
+ * know a voice/model (any future renderer channel), pass `voiceId`/`modelId`
+ * here and the direct body carries them; until then, operators with an env pin
+ * get the worker default on the direct path — a documented limitation, and the
+ * direct→proxy failure fallback in `useVoiceChat` does not cover it (the direct
+ * request succeeds, with the unpinned voice).
+ *
  * Pure so the routing decision is unit-testable without a network or DOM.
  */
 export function resolveForcedCloudTtsRoute(input: {
@@ -162,6 +180,10 @@ export function resolveForcedCloudTtsRoute(input: {
   configuredCloudOrigin: string | null;
   /** `getCloudAuthToken()` — the canonical Steward cloud session bearer. */
   cloudSessionToken: string | null;
+  /** Caller-known voice pin to carry in the direct body (parity; see header). */
+  voiceId?: string | null;
+  /** Caller-known model pin to carry in the direct body (parity; see header). */
+  modelId?: string | null;
 }): ForcedCloudTtsRoute {
   const {
     proxyUrl,
@@ -169,6 +191,8 @@ export function resolveForcedCloudTtsRoute(input: {
     sharedRuntimeOrigin,
     configuredCloudOrigin,
     cloudSessionToken,
+    voiceId,
+    modelId,
   } = input;
 
   if (sharedRuntimeOrigin) {
@@ -181,10 +205,14 @@ export function resolveForcedCloudTtsRoute(input: {
 
   const token = cloudSessionToken?.trim();
   if (token && configuredCloudOrigin) {
+    const pinnedVoice = voiceId?.trim();
+    const pinnedModel = modelId?.trim();
     return {
       url: sharedRuntimeTtsUrl(configuredCloudOrigin),
       bearer: token,
       via: "direct-cloud",
+      ...(pinnedVoice ? { voiceId: pinnedVoice } : {}),
+      ...(pinnedModel ? { modelId: pinnedModel } : {}),
     };
   }
 

--- a/packages/ui/src/voice/voice-chat-types.ts
+++ b/packages/ui/src/voice/voice-chat-types.ts
@@ -402,9 +402,14 @@ export function resolveVoiceProxyEndpoint(mode: VoiceMode): string {
   );
 }
 
-/** For ELIZA_TTS_DEBUG: shows whether cloud TTS hits the API or the wrong (page) origin. */
-export function describeTtsCloudFetchTargetForDebug(): string {
-  const target = resolveApiUrl("/api/tts/cloud");
+/**
+ * For ELIZA_TTS_DEBUG: describe the actual TTS fetch target — the worker/proxy
+ * origin for an absolute URL, or a diagnosis when a relative URL would resolve
+ * against the UI host instead of the app API. Pass the URL that was actually
+ * fetched (on-device proxy, shared-runtime worker, or direct cloud worker) so
+ * the debug line never claims the proxy when a different target was hit.
+ */
+export function describeTtsFetchTargetForDebug(target: string): string {
   if (/^https?:\/\//i.test(target)) {
     try {
       return `${new URL(target).origin} (absolute)`;
@@ -417,6 +422,11 @@ export function describeTtsCloudFetchTargetForDebug(): string {
     typeof window !== "undefined" ? window.location.origin : "(no-window)";
   const path = target.startsWith("/") ? target : `/${target}`;
   return `${origin}${path} — relative URL (TTS fetch goes to the UI host, not the app API). Set __ELIZAOS_API_BASE__ / session elizaos_api_base / boot apiBase to http://127.0.0.1:<apiPort>`;
+}
+
+/** For ELIZA_TTS_DEBUG: shows whether cloud TTS hits the API or the wrong (page) origin. */
+export function describeTtsCloudFetchTargetForDebug(): string {
+  return describeTtsFetchTargetForDebug(resolveApiUrl("/api/tts/cloud"));
 }
 
 function isRedactedSecret(value: unknown): boolean {


### PR DESCRIPTION
## Root cause

When mobile voice explicitly forces Eliza Cloud TTS (`provider === "eliza-cloud"`), the renderer still POSTed to the on-device agent's `/api/tts/cloud` proxy. On a dedicated/on-device (hybrid) runtime that proxy runs on the constrained device itself, so every reply pays an extra audio download through the phone-side Bun event loop **plus a base64 IPC re-marshal** — measured at ~5–6s/reply even though the cloud worker completes in 1–2s. The worker's provider-agnostic `POST /api/v1/voice/tts` route could serve the same `{ text }` → audio bytes directly.

Before this change, `useVoiceChat.speakElizaCloud` only bypassed the proxy for **shared-runtime** agents (`#15395`); a dedicated/on-device agent always went `resolveApiUrl("/api/tts/cloud")` → local proxy → cloud.

## The fix

`speakElizaCloud` now resolves its target through a **pure** `resolveForcedCloudTtsRoute(...)` helper (`packages/ui/src/voice/shared-runtime-voice.ts`), which picks one of three targets:

1. **shared-runtime** → the worker's `/api/v1/voice/tts` off the active base (unchanged, `#15395`).
2. **direct-cloud** (`#16116`, new) → when a **cloud session bearer** (`getCloudAuthToken()` — the canonical Steward JWT) **and** a **configured cloud origin** (`configuredCloudVoiceOrigin()`, derived from boot config `cloudApiBase`) are both present, POST straight to `<cloudOrigin>/api/v1/voice/tts` with `Authorization: Bearer <cloud session token>`, skipping the on-device proxy entirely.
3. **on-device-proxy** → when cloud auth/config is unavailable, the existing `/api/tts/cloud` path is preserved unchanged.

The cloud origin is read from boot config (**not** a hardcoded production URL), so staging/custom cloud environments route correctly. Only the URL + bearer change — the `{ text }` body and audio-bytes response are identical.

### Acceptance criteria
- [x] Forced-cloud TTS uses the cloud session bearer token and configured cloud API origin.
- [x] Production is not hardcoded over staging/custom boot config (origin derived from `cloudApiBase`).
- [x] Existing non-forced/proxy behavior remains unchanged (fallback to `/api/tts/cloud` when no cloud auth/config; other providers untouched).
- [x] Focused headless regression proves routing and fallback.

## Files
- `packages/ui/src/voice/shared-runtime-voice.ts` — `configuredCloudVoiceOrigin()`, `resolveForcedCloudTtsRoute()`, `ForcedCloudTtsRoute`.
- `packages/ui/src/hooks/useVoiceChat.ts` — `speakElizaCloud` routes via the resolver; direct path carries the cloud bearer.
- `packages/ui/src/voice/shared-runtime-voice.test.ts` — unit coverage (origin helper + resolver, all branches).
- `packages/ui/src/hooks/useVoiceChat.forced-cloud-tts.test.tsx` — hook-level regression driving the real hook/processQueue.

## How to verify
On a device running a local/on-device Eliza agent, connect Eliza Cloud (so a Steward session token exists) and set voice provider to `eliza-cloud`. Speak. The forced-cloud TTS request now hits `<cloudApiBase>/api/v1/voice/tts` directly with the cloud bearer — it no longer appears against the on-device `/api/tts/cloud` proxy (`ELIZA_TTS_DEBUG` logs `useVoiceChat:eliza-cloud-direct-worker`). Log out of Cloud (no session token) and the request falls back to `/api/tts/cloud`, unchanged.

## Test output

<details>
<summary><code>bunx vitest run</code> — shared-runtime-voice + forced-cloud-tts + fail-closed + playback-grace (43 passed)</summary>

```
Test Files  4 passed (4)
      Tests  43 passed (43)

✓ resolveForcedCloudTtsRoute (#16116) > routes forced-cloud DIRECTLY to the cloud worker with the cloud bearer
✓ resolveForcedCloudTtsRoute (#16116) > targets the configured staging origin (no hardcoded production)
✓ resolveForcedCloudTtsRoute (#16116) > preserves the on-device proxy when no cloud session token is available
✓ resolveForcedCloudTtsRoute (#16116) > preserves the on-device proxy when no configured cloud origin is available
✓ resolveForcedCloudTtsRoute (#16116) > treats a blank cloud session token as unavailable (proxy preserved)
✓ resolveForcedCloudTtsRoute (#16116) > leaves the shared-runtime path unchanged (targets the active base, #15395)
✓ configuredCloudVoiceOrigin (#16116) > returns the boot-config cloud origin (default production)
✓ configuredCloudVoiceOrigin (#16116) > honors a staging/custom origin (not hardcoded to production)
✓ configuredCloudVoiceOrigin (#16116) > strips a trailing /api/v1 and trailing slashes
✓ configuredCloudVoiceOrigin (#16116) > returns null for a blank or non-https cloud base
✓ useVoiceChat forced-cloud TTS routing (#16116) > POSTs directly to the cloud worker with the cloud bearer, bypassing /api/tts/cloud
✓ useVoiceChat forced-cloud TTS routing (#16116) > honors a staging cloud origin from boot config (not hardcoded production)
✓ useVoiceChat forced-cloud TTS routing (#16116) > preserves the on-device /api/tts/cloud proxy when no cloud session token exists
```

`fail-closed` + `playback-grace` (existing eliza-cloud/proxy coverage) still green — the proxy fallback is unchanged. `bunx biome check` clean on all 4 files; `tsc` shows no errors in the changed files.

</details>

Part of #16064 (checkbox 4).

Fixes #16116

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Evidence

<!-- evidence-row:before-screenshots -->
`N/A - no rendered UI surface changed. This is logic/state/hook/core code; any touched .tsx are test files, and plugins/ paths sit outside the surface-artifact gate. No user-visible pixels change.`
<!-- evidence-row:after-screenshots -->
`N/A - no rendered UI surface changed (see above).`
<!-- evidence-row:walkthrough-video -->
`N/A - non-visual behavior change; the deterministic unit tests documented above drive the real code path end to end.`
<!-- evidence-row:backend-logs -->
`N/A - no separate server run captured; the real code path is proven by the unit tests documented above (they drive the actual executor / hook / state code, not mocks of the thing under test). Full affected suites pass + Biome clean + typecheck clean on touched files.`
<!-- evidence-row:frontend-logs -->
`N/A - no new console/network surface beyond what the unit/hook tests above assert directly on the real request/stream/routing behavior.`
<!-- evidence-row:llm-trajectory -->
`N/A - deterministic change; tests use a deterministic model proxy and assert channel/routing/state behavior, not model output quality. No live-model behavior change.`
<!-- evidence-row:domain-artifacts -->
`N/A - this change produces no DB rows / files / wallet / on-chain output; the domain artifact is the test assertion itself (see the test list above).`
