### PR TITLE
fix(mobile): stop cloud-hybrid cold-launch re-onboarding — error-classified boot retry (#16065)

### DIFF
--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
@@ -3841,29 +3841,49 @@ public class ElizaAgentService extends Service {
     public static boolean shouldAutoStart(Context context) {
         String mode = readRuntimeMode(context);
         long totalMemBytes = readDeviceTotalMemBytes(context);
-        boolean deviceAllowsLocalAgent = DeviceRamTierPolicy.allowsLocalAgent(totalMemBytes);
         boolean start = shouldAutoStartForRuntimeMode(
-            isBrandedDevice(), mode, deviceAllowsLocalAgent);
+            isBrandedDevice(), mode, totalMemBytes);
         String trimmed = mode == null ? null : mode.trim();
-        if (!start && "local".equals(trimmed) && !deviceAllowsLocalAgent) {
-            // Fail loud (#14390): a persisted local choice on a device below the
-            // RAM floor is refused, not silently attempted-and-wedged. The
+        if (!start
+                && isOnDeviceAgentRuntimeMode(trimmed)
+                && !allowsAgentStartForRuntimeMode(trimmed, totalMemBytes)) {
+            // Fail loud (#14390, #15577): a persisted on-device runtime choice —
+            // "local" OR "cloud-hybrid" — on a device below its matching RAM
+            // floor is refused, not silently attempted-and-wedged. Refusing BOTH
+            // symmetrically is what keeps the renderer from waiting out the 45s
+            // existing-install probe for an agent this gate will never start; the
             // renderer heals the stale mode back to onboarding at boot
             // (device-ram-tier.ts enforceDeviceRamPolicyOnPersistedRuntimeMode).
-            Log.w(TAG, "refusing to auto-start the on-device agent: persisted local"
-                + " runtime mode on a device below the "
-                + DeviceRamTierPolicy.LOCAL_AGENT_MIN_MARKETED_RAM_GB
-                + " GB RAM floor (marketed "
+            int requiredRamGb = "cloud-hybrid".equals(trimmed)
+                ? DeviceRamTierPolicy.HYBRID_AGENT_MIN_MARKETED_RAM_GB
+                : DeviceRamTierPolicy.LOCAL_AGENT_MIN_MARKETED_RAM_GB;
+            Log.w(TAG, "refusing to auto-start the on-device agent: persisted "
+                + trimmed + " runtime mode on a device below the "
+                + requiredRamGb + " GB RAM floor (marketed "
                 + DeviceRamTierPolicy.marketedRamGb(totalMemBytes) + " GB)");
         }
         return start;
     }
 
     static boolean shouldAutoStartForRuntimeMode(
-            boolean brandedDevice, String mode, boolean deviceAllowsLocalAgent) {
+            boolean brandedDevice, String mode, long totalMemBytes) {
         if (brandedDevice) return true;
         String trimmed = mode == null ? null : mode.trim();
-        return "local".equals(trimmed) && deviceAllowsLocalAgent;
+        // A committed on-device runtime — "local" (on-device inference + agent)
+        // or "cloud-hybrid" (cloud inference, but the on-device agent still owns
+        // chat, plugins, the voice bridge, and device control) — auto-starts the
+        // bundled agent on cold launch once it clears its matching RAM floor: the
+        // 4 GB hybrid floor for cloud-hybrid, the 8 GB local floor otherwise
+        // (#15577). A fresh install (mode == null) and every external/pure-cloud
+        // choice never auto-start one — onboarding, then the renderer, own that.
+        return isOnDeviceAgentRuntimeMode(trimmed)
+            && allowsAgentStartForRuntimeMode(trimmed, totalMemBytes);
+    }
+
+    /** The persisted runtime modes that run the bundled on-device agent process. */
+    static boolean isOnDeviceAgentRuntimeMode(String mode) {
+        String trimmed = mode == null ? null : mode.trim();
+        return "local".equals(trimmed) || "cloud-hybrid".equals(trimmed);
     }
 
     /**

--- a/packages/app-core/platforms/android/app/src/test/java/ai/elizaos/app/ElizaAgentAutostartPolicyTest.java
+++ b/packages/app-core/platforms/android/app/src/test/java/ai/elizaos/app/ElizaAgentAutostartPolicyTest.java
@@ -10,63 +10,91 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 /**
- * JVM unit tests for the stock-Android local-agent autostart policy (#14390).
- * Only two things may auto-start the bundled agent: a branded device (the
- * device IS the agent) or an explicit onboarding "local" choice on a device
- * that clears the RAM-tier floor. A fresh install (no persisted mode) never
- * auto-starts — onboarding owns the decision and the renderer starts the
- * service on demand through the Agent Capacitor plugin — and a persisted
- * "local" on a RAM-blocked device is refused instead of wedging boot.
+ * JVM unit tests for the stock-Android on-device-agent autostart policy (#14390,
+ * #15577). Three things may auto-start the bundled agent: a branded device (the
+ * device IS the agent); an explicit "local" choice on a device that clears the
+ * 8 GB local floor; or an explicit "cloud-hybrid" choice on a device that clears
+ * the lower 4 GB hybrid floor (cloud inference, but the on-device agent still
+ * owns chat, plugins, the voice bridge, and device control). A fresh install (no
+ * persisted mode) never auto-starts — onboarding owns the decision and the
+ * renderer starts the service on demand through the Agent Capacitor plugin — and
+ * a persisted on-device mode the device can no longer honor is refused instead
+ * of wedging boot.
  */
 public class ElizaAgentAutostartPolicyTest {
 
-    private static final boolean RAM_OK = true;
-    private static final boolean RAM_BLOCKED = false;
+    // Marketed sizes recovered by DeviceRamTierPolicy (round raw totalMem UP to
+    // the next whole GiB): a 6 GB LP3 phone clears the 4 GB hybrid floor but not
+    // the 8 GB local floor, which is the exact case cloud-hybrid must handle.
+    private static final long RAM_12GB = 12L * (1L << 30);
+    private static final long RAM_6GB = 6L * (1L << 30);
+    private static final long RAM_3GB = 3L * (1L << 30);
 
     @Test
     public void brandedDevicesAlwaysStartTheBundledAgent() {
-        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, null, RAM_OK));
-        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, null, RAM_BLOCKED));
-        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, "cloud", RAM_OK));
-        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, "remote-mac", RAM_BLOCKED));
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, null, RAM_12GB));
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, null, RAM_3GB));
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, "cloud", RAM_12GB));
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, "remote-mac", RAM_3GB));
     }
 
     @Test
     public void stockFreshInstallNeverAutoStarts() {
         // The runtime decision belongs to onboarding: with no persisted mode the
         // renderer must land in first-run, then start the service explicitly
-        // once the user commits to the local runtime.
-        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, null, RAM_OK));
-        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "", RAM_OK));
-        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "   ", RAM_OK));
-        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, null, RAM_BLOCKED));
+        // once the user commits to a runtime — even on a device that clears both
+        // RAM floors.
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, null, RAM_12GB));
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "", RAM_12GB));
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "   ", RAM_12GB));
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, null, RAM_3GB));
     }
 
     @Test
-    public void stockCloudModesStayCloudFirst() {
-        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "cloud", RAM_OK));
-        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "cloud-hybrid", RAM_OK));
+    public void stockPureCloudStaysCloudFirst() {
+        // Pure cloud runs no on-device agent, regardless of RAM headroom.
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "cloud", RAM_12GB));
+    }
+
+    @Test
+    public void stockCloudHybridStartsTheBundledAgentWhenHybridRamAllows() {
+        // cloud-hybrid needs the on-device agent and clears the lower 4 GB
+        // hybrid floor — so a 6 GB LP3 (hybrid-OK, local-blocked) auto-starts,
+        // and a phone below the hybrid floor does not.
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "cloud-hybrid", RAM_6GB));
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(false, " cloud-hybrid ", RAM_6GB));
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "cloud-hybrid", RAM_3GB));
     }
 
     @Test
     public void stockExternalModesDoNotStartTheBundledAgent() {
-        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "remote-mac", RAM_OK));
-        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "tunnel-to-mobile", RAM_OK));
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "remote-mac", RAM_12GB));
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "tunnel-to-mobile", RAM_12GB));
     }
 
     @Test
     public void stockLocalModeStartsTheBundledAgentWhenRamAllows() {
-        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "local", RAM_OK));
-        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(false, " local ", RAM_OK));
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "local", RAM_12GB));
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(false, " local ", RAM_12GB));
     }
 
     @Test
     public void stockLocalModeIsRefusedBelowTheRamFloor() {
         // A persisted "local" survives reinstalls via Capacitor Preferences, so
         // a low-RAM device can carry one it can no longer honor — refusing here
-        // is what keeps a 4 GB phone from wedging boot for the 180 s budget.
-        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "local", RAM_BLOCKED));
-        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, " local ", RAM_BLOCKED));
+        // is what keeps a 6 GB phone from wedging boot for the 180 s budget even
+        // though it clears the lower hybrid floor.
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "local", RAM_6GB));
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, " local ", RAM_6GB));
+    }
+
+    @Test
+    public void onDeviceAgentRuntimeModePredicateCoversLocalAndCloudHybridOnly() {
+        assertTrue(ElizaAgentService.isOnDeviceAgentRuntimeMode("local"));
+        assertTrue(ElizaAgentService.isOnDeviceAgentRuntimeMode(" cloud-hybrid "));
+        assertFalse(ElizaAgentService.isOnDeviceAgentRuntimeMode("cloud"));
+        assertFalse(ElizaAgentService.isOnDeviceAgentRuntimeMode("remote-mac"));
+        assertFalse(ElizaAgentService.isOnDeviceAgentRuntimeMode(null));
     }
 
     @Test

--- a/packages/ui/src/first-run/mobile-runtime-mode.test.ts
+++ b/packages/ui/src/first-run/mobile-runtime-mode.test.ts
@@ -8,9 +8,21 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  IOS_LOCAL_AGENT_IPC_BASE,
+  isCommittedOnDeviceMobileRuntimeMode,
+  isElizaCloudRuntimeLocked,
+  isMobileLocalAgentIpcBase,
+  isMobileLocalAgentIpcUrl,
+  isMobileLocalAgentUrl,
+  MOBILE_LOCAL_AGENT_API_BASE,
+  MOBILE_LOCAL_AGENT_IPC_BASE,
   MOBILE_RUNTIME_MODE_STORAGE_KEY,
+  mobileLocalAgentPathFromUrl,
+  mobileRuntimeModeForServerTarget,
+  normalizeMobileRuntimeMode,
   persistMobileRuntimeMode,
   persistMobileRuntimeModeForServerTarget,
+  readPersistedMobileRuntimeMode,
 } from "./mobile-runtime-mode";
 
 const { capacitorState, preferencesRemoveMock, preferencesSetMock } =
@@ -102,5 +114,152 @@ describe("persistMobileRuntimeMode (single write path)", () => {
         key: MOBILE_RUNTIME_MODE_STORAGE_KEY,
       });
     });
+  });
+});
+
+describe("isMobileLocalAgentIpcUrl", () => {
+  it("matches the IPC base and its path/query variants", () => {
+    expect(isMobileLocalAgentIpcUrl(MOBILE_LOCAL_AGENT_IPC_BASE)).toBe(true);
+    expect(
+      isMobileLocalAgentIpcUrl(`${MOBILE_LOCAL_AGENT_IPC_BASE}/api/status`),
+    ).toBe(true);
+    expect(
+      isMobileLocalAgentIpcUrl(`${MOBILE_LOCAL_AGENT_IPC_BASE}?foo=1`),
+    ).toBe(true);
+    // Chromium WebView reshapes the authority into a `//ipc/...` pathname.
+    expect(
+      isMobileLocalAgentIpcUrl(new URL(`${MOBILE_LOCAL_AGENT_IPC_BASE}/api`)),
+    ).toBe(true);
+  });
+
+  it("rejects empty, loopback-http, and unparseable values", () => {
+    expect(isMobileLocalAgentIpcUrl(null)).toBe(false);
+    expect(isMobileLocalAgentIpcUrl("   ")).toBe(false);
+    expect(isMobileLocalAgentIpcUrl(MOBILE_LOCAL_AGENT_API_BASE)).toBe(false);
+    expect(isMobileLocalAgentIpcUrl("https://example.test")).toBe(false);
+    expect(isMobileLocalAgentIpcUrl("::not a url::")).toBe(false);
+  });
+});
+
+describe("isMobileLocalAgentIpcBase", () => {
+  it("matches the IPC base with or without a trailing slash", () => {
+    expect(isMobileLocalAgentIpcBase(MOBILE_LOCAL_AGENT_IPC_BASE)).toBe(true);
+    expect(isMobileLocalAgentIpcBase(`${MOBILE_LOCAL_AGENT_IPC_BASE}/`)).toBe(
+      true,
+    );
+  });
+  it("rejects a null/absent base and unrelated hosts", () => {
+    expect(isMobileLocalAgentIpcBase(null)).toBe(false);
+    expect(isMobileLocalAgentIpcBase("https://api.elizacloud.ai")).toBe(false);
+  });
+});
+
+describe("mobileLocalAgentPathFromUrl", () => {
+  it("extracts the request path from IPC and loopback-http forms", () => {
+    expect(mobileLocalAgentPathFromUrl(MOBILE_LOCAL_AGENT_IPC_BASE)).toBe("/");
+    expect(
+      mobileLocalAgentPathFromUrl(`${MOBILE_LOCAL_AGENT_IPC_BASE}/api/health`),
+    ).toBe("/api/health");
+    expect(
+      mobileLocalAgentPathFromUrl(`${MOBILE_LOCAL_AGENT_IPC_BASE}?x=1`),
+    ).toBe("/?x=1");
+    expect(
+      mobileLocalAgentPathFromUrl(`${MOBILE_LOCAL_AGENT_API_BASE}/api/status`),
+    ).toBe("/api/status");
+  });
+  it("returns null for absent, unparseable, and non-local URLs", () => {
+    expect(mobileLocalAgentPathFromUrl(null)).toBeNull();
+    expect(mobileLocalAgentPathFromUrl("   ")).toBeNull();
+    expect(mobileLocalAgentPathFromUrl("::nope::")).toBeNull();
+    expect(mobileLocalAgentPathFromUrl("https://example.test/api")).toBeNull();
+  });
+});
+
+describe("isMobileLocalAgentUrl", () => {
+  it("accepts the IPC identity and the loopback-http implementation base", () => {
+    expect(isMobileLocalAgentUrl(IOS_LOCAL_AGENT_IPC_BASE)).toBe(true);
+    expect(isMobileLocalAgentUrl(`${MOBILE_LOCAL_AGENT_API_BASE}/api`)).toBe(
+      true,
+    );
+  });
+  it("rejects remote hosts and junk", () => {
+    expect(isMobileLocalAgentUrl(null)).toBe(false);
+    expect(isMobileLocalAgentUrl("https://example.test")).toBe(false);
+    expect(isMobileLocalAgentUrl("::bad::")).toBe(false);
+  });
+});
+
+describe("normalizeMobileRuntimeMode", () => {
+  it("passes through every known mode (trimming) and rejects the rest", () => {
+    for (const mode of [
+      "remote-mac",
+      "cloud",
+      "cloud-hybrid",
+      "local",
+      "tunnel-to-mobile",
+    ] as const) {
+      expect(normalizeMobileRuntimeMode(mode)).toBe(mode);
+      expect(normalizeMobileRuntimeMode(` ${mode} `)).toBe(mode);
+    }
+    expect(normalizeMobileRuntimeMode(null)).toBeNull();
+    expect(normalizeMobileRuntimeMode("")).toBeNull();
+    expect(normalizeMobileRuntimeMode("external")).toBeNull();
+  });
+});
+
+describe("mobileRuntimeModeForServerTarget", () => {
+  it("maps first-run server targets to their runtime mode", () => {
+    expect(mobileRuntimeModeForServerTarget("remote")).toBe("remote-mac");
+    expect(mobileRuntimeModeForServerTarget("elizacloud")).toBe("cloud");
+    expect(mobileRuntimeModeForServerTarget("elizacloud-hybrid")).toBe(
+      "cloud-hybrid",
+    );
+    expect(mobileRuntimeModeForServerTarget("local")).toBe("local");
+  });
+});
+
+describe("isCommittedOnDeviceMobileRuntimeMode", () => {
+  it("is true only for the on-device-agent modes (local + cloud-hybrid)", () => {
+    expect(isCommittedOnDeviceMobileRuntimeMode("local")).toBe(true);
+    expect(isCommittedOnDeviceMobileRuntimeMode("cloud-hybrid")).toBe(true);
+    expect(isCommittedOnDeviceMobileRuntimeMode("cloud")).toBe(false);
+    expect(isCommittedOnDeviceMobileRuntimeMode("remote-mac")).toBe(false);
+    expect(isCommittedOnDeviceMobileRuntimeMode("tunnel-to-mobile")).toBe(
+      false,
+    );
+    expect(isCommittedOnDeviceMobileRuntimeMode(null)).toBe(false);
+  });
+});
+
+describe("read + isElizaCloudRuntimeLocked", () => {
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("reads null when nothing (or garbage) is persisted", () => {
+    expect(readPersistedMobileRuntimeMode()).toBeNull();
+    window.localStorage.setItem(MOBILE_RUNTIME_MODE_STORAGE_KEY, "external");
+    expect(readPersistedMobileRuntimeMode()).toBeNull();
+  });
+
+  it("reads the persisted mode back", () => {
+    window.localStorage.setItem(
+      MOBILE_RUNTIME_MODE_STORAGE_KEY,
+      "cloud-hybrid",
+    );
+    expect(readPersistedMobileRuntimeMode()).toBe("cloud-hybrid");
+  });
+
+  it("locks the Eliza Cloud runtime for cloud + cloud-hybrid, not local/none", () => {
+    expect(isElizaCloudRuntimeLocked()).toBe(false);
+    window.localStorage.setItem(MOBILE_RUNTIME_MODE_STORAGE_KEY, "cloud");
+    expect(isElizaCloudRuntimeLocked()).toBe(true);
+    window.localStorage.setItem(
+      MOBILE_RUNTIME_MODE_STORAGE_KEY,
+      "cloud-hybrid",
+    );
+    expect(isElizaCloudRuntimeLocked()).toBe(true);
+    window.localStorage.setItem(MOBILE_RUNTIME_MODE_STORAGE_KEY, "local");
+    expect(isElizaCloudRuntimeLocked()).toBe(false);
   });
 });

--- a/packages/ui/src/first-run/mobile-runtime-mode.ts
+++ b/packages/ui/src/first-run/mobile-runtime-mode.ts
@@ -209,6 +209,23 @@ export function isElizaCloudRuntimeLocked(): boolean {
   return mode === "cloud" || mode === "cloud-hybrid";
 }
 
+/**
+ * The mobile runtime modes that commit to the bundled on-device agent process:
+ * `local` (on-device inference + agent) and `cloud-hybrid` (cloud inference,
+ * but the on-device agent still owns chat, plugins, the voice bridge, and
+ * device control). Both persist the on-device active-server record and both
+ * expect the native service to bring the agent up on cold launch. The restore
+ * path therefore keeps their record and waits out the ~30s native boot rather
+ * than re-onboarding; `cloud`, `remote-mac`, and `tunnel-to-mobile` never run a
+ * bundled agent. Single source of that truth for
+ * `reconcileMobileRestoredActiveServer` and the existing-install probe gate.
+ */
+export function isCommittedOnDeviceMobileRuntimeMode(
+  mode: MobileRuntimeMode | null,
+): boolean {
+  return mode === "local" || mode === "cloud-hybrid";
+}
+
 async function persistNativeMobileRuntimeMode(
   mode: MobileRuntimeMode | null,
 ): Promise<void> {

--- a/packages/ui/src/state/first-run-bootstrap.test.ts
+++ b/packages/ui/src/state/first-run-bootstrap.test.ts
@@ -1,0 +1,228 @@
+// @vitest-environment jsdom
+
+/**
+ * Existing-install probe on cold boot: the wait-for-boot retry that stops a
+ * committed on-device runtime (mobile `local`/`cloud-hybrid`) from re-onboarding
+ * while its ~30s native boot is still in flight (#16065), and the error
+ * classification that keeps a genuine agent fault from being masked as
+ * first-run. Drives the real {@link detectExistingFirstRunConnection} against an
+ * injected probe client (real `ApiError` shapes, controllable timing) — nothing
+ * about the function under test is mocked. Fake timers so the 45s/1s waits are
+ * deterministic.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError, type ApiErrorKind } from "../api/client-types-core";
+import {
+  detectExistingFirstRunConnection,
+  type ExistingFirstRunProbeClient,
+  isBootingAgentProbeError,
+} from "./first-run-bootstrap";
+
+const PROBE_PATH = "/api/first-run/status";
+
+function apiError(kind: ApiErrorKind, status?: number): ApiError {
+  return new ApiError({
+    kind,
+    status,
+    path: PROBE_PATH,
+    message: status ? `HTTP ${status}` : kind,
+  });
+}
+
+/**
+ * A probe client whose `getFirstRunStatus` plays a scripted sequence of
+ * outcomes — each entry is either a thrown error (transport/HTTP failure) or a
+ * resolved status — so a cold boot's "unreachable, unreachable, …, ready" can
+ * be reproduced exactly. `getConfig` resolves empty unless overridden.
+ */
+function scriptedClient(
+  outcomes: Array<{ throw: unknown } | { status: { complete: boolean } }>,
+  config: Record<string, unknown> | null = null,
+): ExistingFirstRunProbeClient & { calls: () => number } {
+  let call = 0;
+  return {
+    apiAvailable: true,
+    calls: () => call,
+    getFirstRunStatus: () => {
+      const outcome = outcomes[Math.min(call, outcomes.length - 1)];
+      call += 1;
+      if ("throw" in outcome) return Promise.reject(outcome.throw);
+      return Promise.resolve(outcome.status);
+    },
+    getConfig: () => Promise.resolve(config),
+  };
+}
+
+describe("isBootingAgentProbeError", () => {
+  it("classifies transport-level and gateway-unavailable failures as still-booting", () => {
+    expect(isBootingAgentProbeError(apiError("network"))).toBe(true);
+    expect(isBootingAgentProbeError(apiError("timeout"))).toBe(true);
+    // Native iOS/Android transports answer a not-yet-ready kernel with 503;
+    // 502/504 are the same gateway-unavailable band.
+    expect(isBootingAgentProbeError(apiError("http", 502))).toBe(true);
+    expect(isBootingAgentProbeError(apiError("http", 503))).toBe(true);
+    expect(isBootingAgentProbeError(apiError("http", 504))).toBe(true);
+  });
+
+  it("classifies an agent that ANSWERED with an error as a genuine fault", () => {
+    expect(isBootingAgentProbeError(apiError("http", 401))).toBe(false);
+    expect(isBootingAgentProbeError(apiError("http", 403))).toBe(false);
+    expect(isBootingAgentProbeError(apiError("http", 404))).toBe(false);
+    expect(isBootingAgentProbeError(apiError("http", 500))).toBe(false);
+    expect(isBootingAgentProbeError(apiError("parse"))).toBe(false);
+  });
+
+  it("treats an unrecognized (non-ApiError) throw as genuine, never as booting", () => {
+    expect(isBootingAgentProbeError(new Error("boom"))).toBe(false);
+    expect(isBootingAgentProbeError("boom")).toBe(false);
+    expect(isBootingAgentProbeError(null)).toBe(false);
+  });
+});
+
+describe("detectExistingFirstRunConnection — wait-for-boot retry", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("retries a still-booting agent and restores once it finally answers (no re-onboard)", async () => {
+    // Three unreachable probes (the on-device agent binding its socket), then a
+    // completed first-run — the returning user is restored, not re-onboarded.
+    const client = scriptedClient([
+      { throw: apiError("network") },
+      { throw: apiError("http", 503) },
+      { throw: apiError("timeout") },
+      { status: { complete: true } },
+    ]);
+
+    const promise = detectExistingFirstRunConnection({
+      client,
+      timeoutMs: 45_000,
+      waitForBootingAgent: true,
+    });
+
+    // Each retry waits 1s; drive four attempts.
+    await vi.advanceTimersByTimeAsync(4_000);
+    const result = await promise;
+
+    expect(result).toEqual({
+      activeServer: expect.objectContaining({ kind: "local" }),
+      detectedExistingInstall: true,
+    });
+    expect(client.calls()).toBe(4);
+  });
+
+  it("returns null (onboard) when the agent never boots within the timeout", async () => {
+    const client = scriptedClient([{ throw: apiError("network") }]);
+
+    const promise = detectExistingFirstRunConnection({
+      client,
+      timeoutMs: 45_000,
+      waitForBootingAgent: true,
+    });
+
+    await vi.advanceTimersByTimeAsync(46_000);
+    expect(await promise).toBeNull();
+  });
+
+  it("stops probing once the outer timeout settles the race (cancellation)", async () => {
+    const client = scriptedClient([{ throw: apiError("network") }]);
+
+    const promise = detectExistingFirstRunConnection({
+      client,
+      timeoutMs: 10_000,
+      waitForBootingAgent: true,
+    });
+
+    await vi.advanceTimersByTimeAsync(11_000);
+    expect(await promise).toBeNull();
+    const callsAtTimeout = client.calls();
+
+    // Long after the race settled, the retry loop must not keep firing probes.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(client.calls()).toBe(callsAtTimeout);
+  });
+
+  it("SURFACES a genuine agent fault (auth) instead of retrying it into first-run", async () => {
+    const client = scriptedClient([{ throw: apiError("http", 401) }]);
+
+    await expect(
+      detectExistingFirstRunConnection({
+        client,
+        timeoutMs: 45_000,
+        waitForBootingAgent: true,
+      }),
+    ).rejects.toMatchObject({ kind: "http", status: 401 });
+    // One shot — a genuine fault is not retried across the boot window.
+    expect(client.calls()).toBe(1);
+  });
+
+  it("SURFACES a malformed-response (parse) fault rather than masking it", async () => {
+    const client = scriptedClient([{ throw: apiError("parse") }]);
+
+    await expect(
+      detectExistingFirstRunConnection({
+        client,
+        timeoutMs: 45_000,
+        waitForBootingAgent: true,
+      }),
+    ).rejects.toMatchObject({ kind: "parse" });
+  });
+});
+
+describe("detectExistingFirstRunConnection — fresh-install single shot", () => {
+  it("does not wait: any failure resolves to null immediately (fast onboarding)", async () => {
+    // Even an auth error is "no install here" for a fresh install — the single
+    // shot never throws and never retries, so onboarding is instant.
+    const client = scriptedClient([{ throw: apiError("http", 401) }]);
+
+    const result = await detectExistingFirstRunConnection({
+      client,
+      timeoutMs: 3_500,
+      // waitForBootingAgent omitted → fresh-install path
+    });
+
+    expect(result).toBeNull();
+    expect(client.calls()).toBe(1);
+  });
+
+  it("restores immediately when a fresh probe finds a completed first-run", async () => {
+    const client = scriptedClient([{ status: { complete: true } }]);
+
+    const result = await detectExistingFirstRunConnection({
+      client,
+      timeoutMs: 3_500,
+    });
+
+    expect(result).toEqual({
+      activeServer: expect.objectContaining({ kind: "local" }),
+      detectedExistingInstall: true,
+    });
+  });
+
+  it("detects an existing install from persisted config when first-run is incomplete", async () => {
+    const client = scriptedClient([{ status: { complete: false } }], {
+      meta: { firstRunComplete: true },
+    });
+
+    const result = await detectExistingFirstRunConnection({
+      client,
+      timeoutMs: 3_500,
+    });
+
+    expect(result).toMatchObject({ detectedExistingInstall: true });
+  });
+
+  it("returns null without probing when the API is unavailable", async () => {
+    const client = scriptedClient([{ status: { complete: true } }]);
+    const result = await detectExistingFirstRunConnection({
+      client: { ...client, apiAvailable: false },
+      timeoutMs: 3_500,
+      waitForBootingAgent: true,
+    });
+    expect(result).toBeNull();
+    expect(client.calls()).toBe(0);
+  });
+});

--- a/packages/ui/src/state/first-run-bootstrap.ts
+++ b/packages/ui/src/state/first-run-bootstrap.ts
@@ -4,6 +4,7 @@
  * user skips re-onboarding. Reads via the injected probe client.
  */
 import { asRecord, readString } from "./config-readers";
+import { asApiLikeError } from "./parsers";
 import {
   createPersistedActiveServer,
   type PersistedActiveServer,
@@ -54,9 +55,78 @@ function hasPersistedExistingInstallConfig(
   );
 }
 
+/** Delay between existing-install probes while waiting for a booting agent. */
+const BOOTING_AGENT_RETRY_MS = 1_000;
+
+/**
+ * True when an existing-install probe failure means "the committed on-device
+ * agent is still coming up", so the wait-for-boot loop should keep retrying
+ * rather than surface it.
+ *
+ * A booting on-device agent reports "not up yet" only two ways: a
+ * transport-level failure (the loopback/IPC socket refuses the connection or
+ * the request times out — `kind` `network`/`timeout`) or a structured
+ * `502`/`503`/`504` heartbeat (the iOS/Android native transports answer a
+ * not-yet-ready kernel with a `503`; the same gateway-unavailable band the
+ * backend poll treats as transient in `startup-phase-poll.ts`). Every other
+ * outcome means the agent ANSWERED — an auth `401/403`, a real `500`, a `404`,
+ * or a `parse` failure on malformed JSON — which is a genuine fault the caller
+ * must see, never a reason to re-onboard a set-up user. An unrecognized
+ * (non-`ApiError`) throw is treated as genuine for the same reason: masking an
+ * unknown failure as "still booting" is exactly the sludge this guards against.
+ */
+export function isBootingAgentProbeError(err: unknown): boolean {
+  const api = asApiLikeError(err);
+  if (!api) return false;
+  if (api.kind === "network" || api.kind === "timeout") return true;
+  return api.status === 502 || api.status === 503 || api.status === 504;
+}
+
+/**
+ * Interpret an agent that ANSWERED the first-run status probe. A completed
+ * first-run — or a partial one whose persisted config already carries an
+ * existing install — restores the local active server; anything else means the
+ * agent is up but genuinely un-onboarded, so first-run proceeds normally.
+ */
+async function interpretAnsweredFirstRunStatus(
+  client: ExistingFirstRunProbeClient,
+  status: { complete: boolean },
+): Promise<ExistingFirstRunProbeResult | null> {
+  if (status.complete) {
+    return {
+      activeServer: LOCAL_ACTIVE_SERVER,
+      detectedExistingInstall: true,
+    } satisfies ExistingFirstRunProbeResult;
+  }
+
+  // error-policy:J4 same probe semantics — no readable config means "no
+  // existing install detected", so onboarding proceeds.
+  const config = await client.getConfig().catch(() => null);
+  if (!hasPersistedExistingInstallConfig(config)) {
+    return null;
+  }
+
+  return {
+    activeServer: LOCAL_ACTIVE_SERVER,
+    detectedExistingInstall: true,
+  } satisfies ExistingFirstRunProbeResult;
+}
+
 export async function detectExistingFirstRunConnection(args: {
   client: ExistingFirstRunProbeClient;
   timeoutMs: number;
+  /**
+   * Set when a committed on-device runtime (mobile `local` / `cloud-hybrid`)
+   * is persisted, so the native service IS bringing the bundled agent up. That
+   * cold boot takes ~30s on a low-power phone — far longer than the single-shot
+   * probe — so a still-booting agent must be waited out, not read as "no
+   * install". When set, an unreachable probe (see {@link isBootingAgentProbeError})
+   * is retried until the agent answers or the outer timeout fires; a genuine
+   * probe fault (auth/5xx/malformed) is rethrown for the caller to surface. A
+   * fresh install leaves this unset and keeps the fast single-shot: any failure
+   * there legitimately means "not installed", and re-onboarding is correct.
+   */
+  waitForBootingAgent?: boolean;
 }): Promise<ExistingFirstRunProbeResult | null> {
   if (!args.client.apiAvailable) {
     return null;
@@ -64,36 +134,41 @@ export async function detectExistingFirstRunConnection(args: {
 
   const timeoutToken = Symbol("first-run-bootstrap-timeout");
   let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  let timedOut = false;
+  const probe = async (): Promise<ExistingFirstRunProbeResult | null> => {
+    for (;;) {
+      if (timedOut) return null;
+
+      let status: { complete: boolean } | null;
+      try {
+        status = await args.client.getFirstRunStatus();
+      } catch (err) {
+        if (!args.waitForBootingAgent) {
+          // error-policy:J4 fresh-install probe — an unreachable agent means
+          // "no existing install detected" and first-run proceeds normally.
+          return null;
+        }
+        // The committed on-device agent is still booting only when the probe
+        // never reached a live agent; a genuine fault is surfaced, not retried
+        // into first-run.
+        if (!isBootingAgentProbeError(err)) throw err;
+        if (timedOut) return null;
+        await new Promise((resolve) =>
+          setTimeout(resolve, BOOTING_AGENT_RETRY_MS),
+        );
+        continue;
+      }
+
+      return interpretAnsweredFirstRunStatus(args.client, status);
+    }
+  };
   const result = await Promise.race([
-    (async () => {
-      // error-policy:J4 existing-install probe — an unreachable agent means
-      // "no existing install detected" and first-run proceeds normally
-      const status = await args.client.getFirstRunStatus().catch(() => null);
-      if (!status) {
-        return null;
-      }
-
-      if (status.complete) {
-        return {
-          activeServer: LOCAL_ACTIVE_SERVER,
-          detectedExistingInstall: true,
-        } satisfies ExistingFirstRunProbeResult;
-      }
-
-      // error-policy:J4 same probe semantics — no readable config means "no
-      // existing install detected"
-      const config = await args.client.getConfig().catch(() => null);
-      if (!hasPersistedExistingInstallConfig(config)) {
-        return null;
-      }
-
-      return {
-        activeServer: LOCAL_ACTIVE_SERVER,
-        detectedExistingInstall: true,
-      } satisfies ExistingFirstRunProbeResult;
-    })(),
+    probe(),
     new Promise<typeof timeoutToken>((resolve) => {
-      timeoutId = setTimeout(() => resolve(timeoutToken), args.timeoutMs);
+      timeoutId = setTimeout(() => {
+        timedOut = true;
+        resolve(timeoutToken);
+      }, args.timeoutMs);
     }),
   ]);
   if (timeoutId !== null) {

--- a/packages/ui/src/state/persistence-cloud-active-server.test.ts
+++ b/packages/ui/src/state/persistence-cloud-active-server.test.ts
@@ -315,6 +315,69 @@ describe("Cloud active server persistence", () => {
     });
   });
 
+  it("keeps the on-device agent record under cloud-hybrid (#16065 LP3 re-onboarded every cold launch)", () => {
+    // cloud-hybrid = on-device agent chat + cloud inference, so the persisted
+    // on-device record is valid. Rejecting it here (returning null) cleared the
+    // record + reset first-run on every cold launch, bouncing a returning hybrid
+    // user into onboarding while the still-booting agent (~30s on the LP3) was
+    // unreachable. `undefined` = keep the record as-is.
+    const server = {
+      id: "local:android",
+      kind: "remote" as const,
+      label: "On-device agent",
+      apiBase: "eliza-local-agent://ipc",
+    };
+    expect(
+      reconcileMobileRestoredActiveServer({
+        platform: "android",
+        mobileRuntimeMode: "cloud-hybrid",
+        server,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("keeps the on-device agent record under local (the committed on-device sibling of cloud-hybrid)", () => {
+    const server = {
+      id: "local:mobile",
+      kind: "remote" as const,
+      label: "On-device agent",
+      apiBase: "eliza-local-agent://ipc",
+    };
+    expect(
+      reconcileMobileRestoredActiveServer({
+        platform: "ios",
+        mobileRuntimeMode: "local",
+        server,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("drops the on-device agent record for a non-agent mode (pure cloud never runs a bundled agent)", () => {
+    // A persisted on-device record with a mode that runs NO bundled agent
+    // (`cloud`, `remote-mac`, `tunnel-to-mobile`) is genuinely stale — return
+    // null so restore clears it and lets the user re-onboard to the chosen mode.
+    const server = {
+      id: "local:android",
+      kind: "remote" as const,
+      label: "On-device agent",
+      apiBase: "eliza-local-agent://ipc",
+    };
+    expect(
+      reconcileMobileRestoredActiveServer({
+        platform: "android",
+        mobileRuntimeMode: "cloud",
+        server,
+      }),
+    ).toBeNull();
+    expect(
+      reconcileMobileRestoredActiveServer({
+        platform: "android",
+        mobileRuntimeMode: "remote-mac",
+        server,
+      }),
+    ).toBeNull();
+  });
+
   it("logs a warning instead of silently swallowing a failed active-server persist", () => {
     const server = createPersistedActiveServer({
       id: "cloud:agent-warn",

--- a/packages/ui/src/state/startup-phase-restore.mobile-probe.test.ts
+++ b/packages/ui/src/state/startup-phase-restore.mobile-probe.test.ts
@@ -1,0 +1,270 @@
+// @vitest-environment jsdom
+//
+// Mobile committed-runtime restore: `runRestoringSession` must wait out the
+// on-device agent's ~30s cold boot instead of re-onboarding a returning
+// cloud-hybrid user (#16065), and must NOT convert a genuine probe fault into
+// first-run. Drives the real restore module with only the platform flag, the
+// desktop bridge, and the existing-install probe stubbed — the probe-wiring and
+// the J1 surface-don't-onboard boundary under test are real.
+
+import { logger } from "@elizaos/logger";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "../api/client-types-core";
+import {
+  DEFAULT_BOOT_CONFIG,
+  setBootConfig,
+} from "../config/boot-config-store";
+import { MOBILE_RUNTIME_MODE_STORAGE_KEY } from "../first-run/mobile-runtime-mode";
+import type { ExistingFirstRunProbeResult } from "./first-run-bootstrap";
+import {
+  clearPersistedActiveServer,
+  loadPersistedActiveServer,
+  savePersistedActiveServer,
+} from "./persistence";
+import type { StartupEvent } from "./startup-coordinator";
+import {
+  type RestoringSessionDeps,
+  runRestoringSession,
+} from "./startup-phase-restore";
+
+const bridgeMock = vi.hoisted(() => ({
+  getBackendStartupTimeoutMs: vi.fn(() => 180_000),
+  invokeDesktopBridgeRequestWithTimeout: vi.fn(async () => ({
+    status: "timeout" as const,
+  })),
+  isElectrobunRuntime: vi.fn(() => false),
+  scanProviderCredentials: vi.fn(async () => []),
+}));
+
+const probeMock = vi.hoisted(() => ({
+  detectExistingFirstRunConnection: vi.fn(
+    async (): Promise<ExistingFirstRunProbeResult | null> => null,
+  ),
+}));
+
+vi.mock("../bridge", () => bridgeMock);
+vi.mock("./first-run-bootstrap", () => probeMock);
+// Force the Android native mobile platform; keep every other platform helper
+// real so the restore path behaves exactly as it does on-device.
+vi.mock("../platform", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../platform")>();
+  return { ...actual, isAndroid: true, isIOS: false };
+});
+
+const LOCAL_PROBE_RESULT: ExistingFirstRunProbeResult = {
+  activeServer: { id: "local", kind: "local", label: "Local Agent" },
+  detectedExistingInstall: true,
+};
+
+function makeDeps(): RestoringSessionDeps {
+  return {
+    setStartupError: vi.fn(),
+    setAuthRequired: vi.fn(),
+    setConnected: vi.fn(),
+    setFirstRunOptions: vi.fn(),
+    setFirstRunComplete: vi.fn(),
+    setFirstRunLoading: vi.fn(),
+    firstRunCompletionCommittedRef: { current: false },
+    uiLanguage: "en",
+  };
+}
+
+async function drive(dispatch: (event: StartupEvent) => void): Promise<void> {
+  await runRestoringSession(
+    makeDeps(),
+    dispatch,
+    { current: null },
+    { current: false },
+  );
+}
+
+describe("runRestoringSession — mobile committed-runtime existing-install probe", () => {
+  const realFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    localStorage.clear();
+    clearPersistedActiveServer();
+    setBootConfig(DEFAULT_BOOT_CONFIG);
+    vi.clearAllMocks();
+    bridgeMock.isElectrobunRuntime.mockReturnValue(false);
+    bridgeMock.getBackendStartupTimeoutMs.mockReturnValue(180_000);
+    probeMock.detectExistingFirstRunConnection.mockResolvedValue(null);
+    // primeAuthStatusProbe fires fire-and-forget; a 503 is discarded by design.
+    globalThis.fetch = vi.fn(
+      async () =>
+        ({
+          ok: false,
+          status: 503,
+          json: async () => ({}),
+        }) as unknown as Response,
+    ) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    localStorage.clear();
+    clearPersistedActiveServer();
+    setBootConfig(DEFAULT_BOOT_CONFIG);
+    vi.restoreAllMocks();
+  });
+
+  it("probes with wait-for-boot (45s) for a committed cloud-hybrid runtime and restores the on-device agent", async () => {
+    localStorage.setItem(MOBILE_RUNTIME_MODE_STORAGE_KEY, "cloud-hybrid");
+    probeMock.detectExistingFirstRunConnection.mockResolvedValue(
+      LOCAL_PROBE_RESULT,
+    );
+    const dispatch = vi.fn();
+
+    await drive(dispatch);
+
+    // The still-booting on-device agent is waited out, not read as "no install".
+    expect(probeMock.detectExistingFirstRunConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ waitForBootingAgent: true, timeoutMs: 45_000 }),
+    );
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "SESSION_RESTORED" }),
+    );
+    expect(dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "NO_SESSION" }),
+    );
+  });
+
+  it("SURFACES a genuine probe fault as a restored install (no re-onboard) instead of onboarding", async () => {
+    localStorage.setItem(MOBILE_RUNTIME_MODE_STORAGE_KEY, "cloud-hybrid");
+    // The committed agent booted but answered with an auth error — a genuine
+    // fault the probe rethrows. The J1 boundary must route to restore so the
+    // real error surfaces in polling-backend, never re-onboard the set-up user.
+    probeMock.detectExistingFirstRunConnection.mockRejectedValue(
+      new ApiError({
+        kind: "http",
+        status: 401,
+        path: "/api/first-run/status",
+        message: "unauthorized",
+      }),
+    );
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+    const dispatch = vi.fn();
+
+    await drive(dispatch);
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("existing-install probe failed"),
+    );
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "SESSION_RESTORED" }),
+    );
+    expect(dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "NO_SESSION" }),
+    );
+  });
+
+  it("keeps the fast single-shot (no wait) for a fresh install and onboards", async () => {
+    // No committed mode persisted → fresh install: the probe is a fast
+    // single-shot (no boot wait), and a null result routes to onboarding.
+    probeMock.detectExistingFirstRunConnection.mockResolvedValue(null);
+    const dispatch = vi.fn();
+
+    await drive(dispatch);
+
+    expect(probeMock.detectExistingFirstRunConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ waitForBootingAgent: false, timeoutMs: 3_500 }),
+    );
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "NO_SESSION" }),
+    );
+  });
+
+  it("does not wait for a persisted cloud (non-agent) runtime — no bundled agent to boot", async () => {
+    localStorage.setItem(MOBILE_RUNTIME_MODE_STORAGE_KEY, "cloud");
+    const dispatch = vi.fn();
+
+    await drive(dispatch);
+
+    // `cloud` runs no on-device agent, so the probe stays a fast single-shot.
+    expect(probeMock.detectExistingFirstRunConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ waitForBootingAgent: false }),
+    );
+  });
+
+  it("restores a persisted on-device record under cloud-hybrid without probing (normalized to the IPC identity)", async () => {
+    localStorage.setItem(MOBILE_RUNTIME_MODE_STORAGE_KEY, "cloud-hybrid");
+    // A committed on-device record IS persisted, so restore skips the probe and
+    // reconciles the legacy `kind:"local"` record to the Android IPC identity.
+    savePersistedActiveServer({
+      id: "local",
+      kind: "local",
+      label: "Local Agent",
+    });
+    const dispatch = vi.fn();
+
+    await drive(dispatch);
+
+    expect(probeMock.detectExistingFirstRunConnection).not.toHaveBeenCalled();
+    expect(loadPersistedActiveServer()).toEqual(
+      expect.objectContaining({ apiBase: "eliza-local-agent://ipc" }),
+    );
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "SESSION_RESTORED" }),
+    );
+  });
+
+  it("drops a persisted on-device record + re-onboards when the mode is no longer an on-device runtime", async () => {
+    // A stale on-device record with a mode switched to `cloud` must be cleared
+    // (reconcile → null) and the user routed back to onboarding.
+    localStorage.setItem(MOBILE_RUNTIME_MODE_STORAGE_KEY, "cloud");
+    savePersistedActiveServer({
+      id: "local:android",
+      kind: "remote",
+      label: "On-device agent",
+      apiBase: "eliza-local-agent://ipc",
+    });
+    const dispatch = vi.fn();
+
+    await drive(dispatch);
+
+    expect(loadPersistedActiveServer()).toBeNull();
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "NO_SESSION" }),
+    );
+  });
+
+  it("honors a one-shot force-fresh directive: clears the record and re-onboards without probing", async () => {
+    localStorage.setItem("elizaos:first-run:force-fresh", "1");
+    savePersistedActiveServer({
+      id: "local:android",
+      kind: "remote",
+      label: "On-device agent",
+      apiBase: "eliza-local-agent://ipc",
+    });
+    const dispatch = vi.fn();
+
+    await drive(dispatch);
+
+    expect(probeMock.detectExistingFirstRunConnection).not.toHaveBeenCalled();
+    expect(loadPersistedActiveServer()).toBeNull();
+    // The directive is consumed (one-shot), so the NEXT launch is normal.
+    expect(localStorage.getItem("elizaos:first-run:force-fresh")).toBeNull();
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "NO_SESSION" }),
+    );
+  });
+
+  it("re-onboards an unrestorable cloud record (id carries a path, no apiBase to recover from)", async () => {
+    // A persisted cloud record whose id is not a recoverable `cloud:<agentId>`
+    // and that has no apiBase cannot be restored; the reconcile/canRestore gates
+    // clear it and the user re-onboards rather than booting a dead session.
+    savePersistedActiveServer({
+      id: "cloud:tenant/agent",
+      kind: "cloud",
+      label: "Eliza Cloud",
+    });
+    const dispatch = vi.fn();
+
+    await drive(dispatch);
+
+    expect(loadPersistedActiveServer()).toBeNull();
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "NO_SESSION" }),
+    );
+  });
+});

--- a/packages/ui/src/state/startup-phase-restore.ts
+++ b/packages/ui/src/state/startup-phase-restore.ts
@@ -30,6 +30,7 @@ import {
   ANDROID_LOCAL_AGENT_LABEL,
   ANDROID_LOCAL_AGENT_SERVER_ID,
   IOS_LOCAL_AGENT_IPC_BASE,
+  isCommittedOnDeviceMobileRuntimeMode,
   isMobileLocalAgentUrl,
   MOBILE_LOCAL_AGENT_LABEL,
   MOBILE_LOCAL_AGENT_SERVER_ID,
@@ -53,7 +54,10 @@ import {
   isElizaCloudControlPlaneAgentlessBase,
 } from "../utils/cloud-agent-base";
 import { getElizaApiBase } from "../utils/eliza-globals";
-import { detectExistingFirstRunConnection } from "./first-run-bootstrap";
+import {
+  detectExistingFirstRunConnection,
+  type ExistingFirstRunProbeResult,
+} from "./first-run-bootstrap";
 import {
   clearPersistedActiveServer,
   hydratePersistedFirstRunCompleteFromNativeStore,
@@ -265,7 +269,16 @@ export function reconcileMobileRestoredActiveServer(args: {
 }): PersistedActiveServer | null | undefined {
   const { server, mobileRuntimeMode, platform } = args;
   const mobileLocal = isMobileLocalActiveServer(server);
-  if (mobileLocal && mobileRuntimeMode !== "local") {
+  // The on-device agent is the chat target for BOTH committed on-device modes
+  // — `local` (on-device inference) and `cloud-hybrid` (cloud inference, but
+  // the on-device agent still owns chat, plugins, the voice bridge, and device
+  // control) — and first-run-finish persists the on-device active-server record
+  // for either. Only reject the record when the persisted mode does NOT run a
+  // bundled agent (`cloud`/`remote-mac`/`tunnel-to-mobile`): rejecting it for
+  // `cloud-hybrid` cleared the record + reset first-run on every cold launch,
+  // bouncing a returning hybrid user into onboarding while the ~30s-booting
+  // agent was still unreachable.
+  if (mobileLocal && !isCommittedOnDeviceMobileRuntimeMode(mobileRuntimeMode)) {
     return null;
   }
 
@@ -690,15 +703,47 @@ export async function runRestoringSession(
   // Probe the API when there is evidence of a prior install, or when no
   // persisted server exists (covers headless/VPS setups where config was
   // set via files without going through UI firstRun).
-  const probed =
-    !forceFreshFirstRun && !persistedActiveServer && !isDevUiPort()
-      ? await detectExistingFirstRunConnection({
-          client,
-          timeoutMs: isDesktop
-            ? Math.min(getBackendStartupTimeoutMs(), 30_000)
+  //
+  // A committed mobile on-device runtime (`local`/`cloud-hybrid`) means the
+  // native service is bringing the bundled agent up right now; its ~30s cold
+  // boot on a low-power phone outlasts the 3.5s single-shot probe, so wait for
+  // it (up to 45s) instead of dropping the returning user back into first-run
+  // every cold launch. A fresh install (no committed mode) keeps the fast
+  // single-shot.
+  const committedMobileOnDeviceMode =
+    (isAndroid || isIOS) &&
+    isCommittedOnDeviceMobileRuntimeMode(readPersistedMobileRuntimeMode());
+  const shouldProbeExistingInstall =
+    !forceFreshFirstRun && !persistedActiveServer && !isDevUiPort();
+  let probed: ExistingFirstRunProbeResult | null = null;
+  if (shouldProbeExistingInstall) {
+    try {
+      probed = await detectExistingFirstRunConnection({
+        client,
+        timeoutMs: isDesktop
+          ? Math.min(getBackendStartupTimeoutMs(), 30_000)
+          : committedMobileOnDeviceMode
+            ? Math.min(getBackendStartupTimeoutMs(), 45_000)
             : Math.min(getBackendStartupTimeoutMs(), 3_500),
-        })
-      : null;
+        waitForBootingAgent: committedMobileOnDeviceMode,
+      });
+    } catch (err) {
+      // error-policy:J1 existing-install probe boundary. The probe only throws
+      // in wait-for-boot mode, and only for a GENUINE fault — the committed
+      // on-device agent answered with auth/5xx/malformed, not a still-booting
+      // heartbeat. The install exists, so re-onboarding would both lose the
+      // user's setup and mask the fault: instead route to restore as a detected
+      // install and let the polling-backend phase surface the real error
+      // through its designed timeout/error states.
+      logger.error(
+        `[startup-phase-restore] existing-install probe failed for a committed on-device runtime: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      probed = {
+        activeServer: mobileLocalActiveServer(isAndroid ? "android" : "ios"),
+        detectedExistingInstall: true,
+      };
+    }
+  }
   if (cancelled.current) return;
 
   let restoredActiveServer =


### PR DESCRIPTION
Fixes #16065. Reworks the closed #15998 per the reviewer's requests (error-classified retry + committed tests + a clean touched suite).

## Root cause

A committed `cloud-hybrid` mobile runtime re-onboarded on **every** cold launch, via two independent mechanisms:

1. **Persisted-record path** — `reconcileMobileRestoredActiveServer` (`packages/ui/src/state/startup-phase-restore.ts`) accepted the on-device active-server record only for mode `"local"`. For `cloud-hybrid` it returned `null`, which cleared the record + reset `firstRunComplete` on every boot — bouncing a returning hybrid user into onboarding.
2. **Probe path** — when no active server was persisted (e.g. a WebView-storage wipe, #11506), `detectExistingFirstRunConnection` (`packages/ui/src/state/first-run-bootstrap.ts`) gave up after a fixed **3.5s** single-shot, while the on-device agent takes **~30s** to boot. It read the still-booting agent as "no install" → onboarding.

## What the reviewer rejected on #15998 (and this reworks)

The #15998 retry swallowed **every** probe failure as "still booting" and, after up to 45s, converted it into first-run — so an auth `401`, a real `5xx`, or malformed JSON became onboarding instead of surfacing. J4 can't turn arbitrary failures into an "unavailable" result. The reviewer also required committed retry-loop tests, a symmetric Android below-floor diagnostic for cloud-hybrid, and a clean touched suite.

## The fix

- **reconcile** — accept the on-device record for **both** committed on-device modes (`local` + `cloud-hybrid`) through one shared predicate `isCommittedOnDeviceMobileRuntimeMode` (`packages/ui/src/first-run/mobile-runtime-mode.ts`); non-agent modes (`cloud`/`remote-mac`/`tunnel-to-mobile`) are still dropped as stale.
- **error-classified retry** — `detectExistingFirstRunConnection` gains `waitForBootingAgent`. It keeps retrying **only** while the agent is still booting, classified by the new exported `isBootingAgentProbeError`, which reuses the exact transient band `startup-phase-poll.ts` already trusts: `ApiError` kind `network`/`timeout`, or HTTP `502`/`503`/`504` (the iOS/Android native transports answer a not-yet-ready kernel with a structured `503`). Any **genuine** fault — auth `401/403`, a real `500`, `parse` on malformed JSON, or an unrecognized throw — is **rethrown**, never retried into first-run. The fresh-install single-shot is unchanged (instant onboarding).
- **restore boundary (J1)** — the probe call site catches a rethrown genuine fault and, because the committed install exists, routes to restore-as-detected-install so the **polling-backend phase surfaces the real error** through its designed timeout/error states, instead of masking it as onboarding.
- **Android** — `shouldAutoStart` now pre-warms the bundled agent at boot for `cloud-hybrid` (4 GB hybrid floor) as well as `local` (8 GB), reusing the existing `allowsAgentStartForRuntimeMode`; the fail-loud below-floor diagnostic now covers **both** modes symmetrically, so a below-floor cloud-hybrid is refused observably rather than leaving the renderer to wait out the 45s probe.

## Tests — real functions, injected transports (nothing under test is mocked)

- `packages/ui/src/state/first-run-bootstrap.test.ts` (new, 12 tests): classifier table (transient vs genuine vs unknown); repeated-unreachable → eventual success (no re-onboard); timeout termination → onboard; cancellation stops probing after the race settles; genuine `401`/`parse` faults **surfaced (thrown)**, not retried; fresh-install single-shot never waits and even an auth error resolves instantly.
- `packages/ui/src/state/persistence-cloud-active-server.test.ts` (+3): cloud-hybrid and local on-device records kept; non-agent modes (`cloud`/`remote-mac`) still dropped.
- `packages/app-core/.../ElizaAgentAutostartPolicyTest.java`: cloud-hybrid autostarts at the 4 GB floor, local at 8 GB, below-floor refused, fresh install never; `isOnDeviceAgentRuntimeMode` predicate.

<details>
<summary>Renderer test output (34 passed)</summary>

```
$ vitest run src/state/first-run-bootstrap.test.ts src/state/persistence-cloud-active-server.test.ts
 Test Files  2 passed (2)
      Tests  34 passed (34)

# consumer regression sweep (startup-phase-restore / poll / coordinator / first-run-conductor / cloud-shell)
 Test Files  6 passed (6)
      Tests  141 passed (141)
```
</details>

- `biome check` clean on all changed TS files (pinned 2.5.3).
- `tsgo --noEmit` on `packages/ui`: 0 errors in touched files (the 4 repo-wide errors are pre-existing and in untouched files — ContinuousChatOverlay, message-scroller, BLE, opus-decoder).
- The Android JVM lane (`ElizaAgentAutostartPolicyTest`) runs in CI; it couldn't be exercised in this local (non-gradle) environment.

## How to verify

1. On a phone in **cloud-hybrid** mode, force-stop and cold-launch repeatedly → the app restores straight to chat; no onboarding flash while the ~30s agent boots (previously re-onboarded every launch).
2. Fresh install → still lands in onboarding immediately (fast single-shot preserved).
3. A cloud-hybrid agent that boots but answers `401`/`500`/garbage → the polling-backend error/timeout state is shown, not onboarding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Evidence

<!-- evidence-row:before-screenshots -->
`N/A - no rendered UI surface changed. This is logic/state/hook/core code; any touched .tsx are test files, and plugins/ paths sit outside the surface-artifact gate. No user-visible pixels change.`
<!-- evidence-row:after-screenshots -->
`N/A - no rendered UI surface changed (see above).`
<!-- evidence-row:walkthrough-video -->
`N/A - non-visual behavior change; the deterministic unit tests documented above drive the real code path end to end.`
<!-- evidence-row:backend-logs -->
`N/A - no separate server run captured; the real code path is proven by the unit tests documented above (they drive the actual executor / hook / state code, not mocks of the thing under test). Full affected suites pass + Biome clean + typecheck clean on touched files.`
<!-- evidence-row:frontend-logs -->
`N/A - no new console/network surface beyond what the unit/hook tests above assert directly on the real request/stream/routing behavior.`
<!-- evidence-row:llm-trajectory -->
`N/A - deterministic change; tests use a deterministic model proxy and assert channel/routing/state behavior, not model output quality. No live-model behavior change.`
<!-- evidence-row:domain-artifacts -->
`N/A - this change produces no DB rows / files / wallet / on-chain output; the domain artifact is the test assertion itself (see the test list above).`
