### PR TITLE
fix(app): avoid protected API probes during fresh onboarding

### DIFF
--- a/packages/ui/src/chat/useSlashCommandController.catalog.test.ts
+++ b/packages/ui/src/chat/useSlashCommandController.catalog.test.ts
@@ -15,7 +15,7 @@
 
 import type { CustomActionDef } from "@elizaos/shared";
 import { renderHook, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   CommandSurface,
   SlashCommandCatalogItem,
@@ -53,6 +53,10 @@ vi.mock("../state", () => ({
     }),
 }));
 
+import {
+  __resetAuthStatusForTests,
+  __setAuthStatusForTests,
+} from "../hooks/useAuthStatus";
 import { useSlashCommandController } from "./useSlashCommandController";
 
 function cmd(
@@ -268,5 +272,70 @@ describe("useSlashCommandController — catalog load (#11112)", () => {
     expect(result.current.commands).toEqual([]);
     expect(result.current.error).toBe(true);
     consoleError.mockRestore();
+  });
+});
+
+describe("useSlashCommandController — protected-probe gate (#16242)", () => {
+  const originalLocation = Object.getOwnPropertyDescriptor(window, "location");
+
+  function setOrigin(url: string): void {
+    const u = new URL(url);
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        href: u.href,
+        origin: u.origin,
+        protocol: u.protocol,
+        host: u.host,
+        hostname: u.hostname,
+        port: u.port,
+        pathname: u.pathname,
+        search: u.search,
+        hash: u.hash,
+        assign: () => {},
+        replace: () => {},
+        reload: () => {},
+        toString: () => u.href,
+      },
+    });
+  }
+
+  beforeEach(() => {
+    listCommands.mockReset().mockResolvedValue([]);
+    listCustomActions.mockReset().mockResolvedValue([]);
+    __resetAuthStatusForTests();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    __resetAuthStatusForTests();
+    if (originalLocation) {
+      Object.defineProperty(window, "location", originalLocation);
+    }
+  });
+
+  it("does not fetch commands/custom-actions on the unauthenticated Cloud origin, then fetches after sign-in", async () => {
+    setOrigin("https://app.elizacloud.ai/");
+    const { result } = renderHook(() => useSlashCommandController());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(listCommands).not.toHaveBeenCalled();
+    expect(listCustomActions).not.toHaveBeenCalled();
+
+    __setAuthStatusForTests({
+      phase: "authenticated",
+      identity: { id: "u-1", displayName: "Owner", kind: "owner" },
+      session: { id: "s-1", kind: "browser", expiresAt: null },
+      access: {
+        mode: "session",
+        passwordConfigured: true,
+        ownerConfigured: true,
+        role: "OWNER",
+      },
+    });
+    await waitFor(() => {
+      expect(listCommands).toHaveBeenCalledWith(GUI);
+      expect(listCustomActions).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/ui/src/chat/useSlashCommandController.ts
+++ b/packages/ui/src/chat/useSlashCommandController.ts
@@ -24,6 +24,7 @@ import {
 import { useBootConfig } from "../config/boot-config-react.hooks";
 import { COMMAND_PALETTE_EVENT, dispatchNavigateViewEvent } from "../events";
 import { useAvailableViews } from "../hooks/useAvailableViews";
+import { useProtectedAgentProbesEnabled } from "../hooks/useProtectedAgentProbesEnabled";
 import type { Tab } from "../navigation";
 import { useAppSelectorShallow } from "../state";
 import { getElizaApiBase, getElizaApiToken } from "../utils/eliza-globals";
@@ -257,8 +258,21 @@ export function useSlashCommandController(
   const [loadError, setLoadError] = React.useState(false);
   const [modelCatalog, setModelCatalog] =
     React.useState<ModelCatalogProviders | null>(null);
+  // The catalog load hits the protected GET /api/commands + /api/custom-actions;
+  // hold it until probes are allowed so fresh Cloud onboarding fires no 401
+  // (#16242). Re-runs to populate the menu once the gate opens post-sign-in.
+  const probesEnabled = useProtectedAgentProbesEnabled();
 
   React.useEffect(() => {
+    if (!probesEnabled) {
+      // No session yet on the shared Cloud app — present a resolved-empty
+      // catalog (not a perpetual spinner) and skip the protected fetches.
+      setServerCommands([]);
+      setCustomCommands([]);
+      setLoadError(false);
+      setLoading(false);
+      return;
+    }
     let cancelled = false;
     setLoading(true);
     setLoadError(false);
@@ -345,7 +359,7 @@ export function useSlashCommandController(
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [probesEnabled]);
 
   const commands = React.useMemo(
     // Server catalog wins over custom/saved on alias collisions; then gate by

--- a/packages/ui/src/components/chat/widgets/__e2e__/run-wallet-widget-e2e.mjs
+++ b/packages/ui/src/components/chat/widgets/__e2e__/run-wallet-widget-e2e.mjs
@@ -81,7 +81,12 @@ export const client = {
 `,
 );
 const authStub = join(outDir, "auth-stub.ts");
-await writeFile(authStub, `export function useIsAuthenticated() { return true; }\n`);
+await writeFile(
+  authStub,
+  `export function useIsAuthenticated() { return true; }\n` +
+    `export function isAuthenticatedNow() { return true; }\n` +
+    `export function subscribeAuthStatus() { return () => {}; }\n`,
+);
 const navStub = join(outDir, "nav-stub.ts");
 await writeFile(
   navStub,

--- a/packages/ui/src/components/shell/__e2e__/home-screen-fixture.auth-stub.ts
+++ b/packages/ui/src/components/shell/__e2e__/home-screen-fixture.auth-stub.ts
@@ -30,6 +30,23 @@ export function useIsAuthenticated(): boolean {
   return true;
 }
 
+/**
+ * Non-hook auth reads the notification store consults from its module seam
+ * (#16242). The fixture is a resolved authenticated snapshot with no
+ * transitions, so `isAuthenticatedNow()` is always true and the store hydrates
+ * without ever re-arming on `subscribeAuthStatus` — but both exports must exist
+ * here or the aliased e2e bundle fails to resolve the store's imports.
+ */
+export function isAuthenticatedNow(): boolean {
+  return true;
+}
+
+export function subscribeAuthStatus(
+  _listener: (state: typeof AUTHENTICATED_STATE) => void,
+): () => void {
+  return () => {};
+}
+
 export function useAuthStatus(): {
   state: typeof AUTHENTICATED_STATE;
   refetch: () => void;

--- a/packages/ui/src/components/shell/__e2e__/run-home-locale-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-home-locale-e2e.mjs
@@ -81,7 +81,12 @@ const stubWeatherDeps = {
     b.onLoad(
       { filter: /^surface-realm-channel-stub$/, namespace: "home-locale-stub" },
       () => ({
-        contents: "export const shellLocalStorage = window.localStorage;",
+        // `runAsPrivilegedShell` is pulled in once the auth-status gate
+        // (#16242) reaches this bundle via csrf-client → ios-local-agent-kernel;
+        // stub it as a direct passthrough (no realm boundary in the fixture).
+        contents:
+          "export const shellLocalStorage = window.localStorage;\n" +
+          "export const runAsPrivilegedShell = (fn) => fn();",
         loader: "js",
       }),
     );

--- a/packages/ui/src/hooks/useAuthStatus.prime.test.tsx
+++ b/packages/ui/src/hooks/useAuthStatus.prime.test.tsx
@@ -11,7 +11,10 @@ import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   __resetAuthStatusForTests,
+  __setAuthStatusForTests,
+  isAuthenticatedNow,
   primeAuthStatusProbe,
+  subscribeAuthStatus,
   useAuthStatus,
 } from "./useAuthStatus";
 
@@ -166,5 +169,41 @@ describe("primeAuthStatusProbe + activation reuse", () => {
       expect(result.current.state.phase).toBe("authenticated"),
     );
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("isAuthenticatedNow + subscribeAuthStatus (non-hook seam, #16242)", () => {
+  beforeEach(() => {
+    __resetAuthStatusForTests();
+  });
+  afterEach(() => {
+    __resetAuthStatusForTests();
+  });
+
+  it("reads the shared snapshot without a probe and notifies subscribers on publish", () => {
+    expect(isAuthenticatedNow()).toBe(false);
+    const seen: string[] = [];
+    const unsub = subscribeAuthStatus((state) => seen.push(state.phase));
+
+    __setAuthStatusForTests({
+      phase: "authenticated",
+      identity: { id: "u", displayName: "Owner", kind: "owner" },
+      session: { id: "s", kind: "browser", expiresAt: null },
+      access: {
+        mode: "session",
+        passwordConfigured: true,
+        ownerConfigured: true,
+        role: "OWNER",
+      },
+    });
+    expect(isAuthenticatedNow()).toBe(true);
+    expect(seen).toContain("authenticated");
+
+    unsub();
+    __setAuthStatusForTests({ phase: "unauthenticated" });
+    // After unsubscribe the listener stops receiving updates; the snapshot read
+    // still reflects the latest published state.
+    expect(isAuthenticatedNow()).toBe(false);
+    expect(seen).not.toContain("unauthenticated");
   });
 });

--- a/packages/ui/src/hooks/useAuthStatus.ts
+++ b/packages/ui/src/hooks/useAuthStatus.ts
@@ -218,6 +218,31 @@ export function useIsAuthenticated(): boolean {
 }
 
 /**
+ * Non-hook read of the shared auth snapshot's authenticated state, for module
+ * seams (stores/services) that gate on auth without a React context — e.g. the
+ * notification store holding its protected hydrate until a session exists
+ * (#16242). Mirrors {@link useIsAuthenticated} without subscribing.
+ */
+export function isAuthenticatedNow(): boolean {
+  return authStatusSnapshot.phase === "authenticated";
+}
+
+/**
+ * Subscribe to auth-status changes outside React (companion to
+ * {@link isAuthenticatedNow}). The listener fires on every publish with the new
+ * snapshot; returns an unsubscribe. Lets a module seam re-arm work it deferred
+ * while unauthenticated the moment a session lands.
+ */
+export function subscribeAuthStatus(
+  listener: (state: AuthStatusState) => void,
+): () => void {
+  authStatusSubscribers.add(listener);
+  return () => {
+    authStatusSubscribers.delete(listener);
+  };
+}
+
+/**
  * Test/story seam for the #11084 auth gate: publish a synthetic status into the
  * shared snapshot (and to subscribers) so `useIsAuthenticated`-gated loaders
  * run without a live `/api/auth/me` probe. Harness-only — the jsdom story

--- a/packages/ui/src/hooks/useProtectedAgentProbesEnabled.test.tsx
+++ b/packages/ui/src/hooks/useProtectedAgentProbesEnabled.test.tsx
@@ -1,0 +1,250 @@
+// @vitest-environment jsdom
+
+/**
+ * Regression guard for #16242: a fresh, unauthenticated visit to the shared
+ * Eliza Cloud web app must issue ZERO protected agent probes before sign-in
+ * (each 401s and Chromium logs it as a console error). Two layers are proven
+ * against the REAL hooks + gate — not a mock of the gate:
+ *
+ *   - the pure gate decisions (`protectedAgentProbesEnabled`,
+ *     `shouldProbeExistingLocalInstall`) that govern every gated call site, and
+ *   - real hook behavior for the protected `GET /api/runtime/mode` and the
+ *     `GET /api/commands` + `/api/custom-actions` catalog fetches — asserted by
+ *     spying on the actual network functions the hooks call.
+ *
+ * The gate stays inert off the Cloud origin (localhost/self-hosted/desktop),
+ * so probes fire there exactly as before.
+ */
+
+import { act, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../api/runtime-mode-client", () => ({
+  fetchRuntimeModeSnapshot: vi.fn().mockResolvedValue(null),
+}));
+
+const { listCommands, listCustomActions, getModelsCatalog } = vi.hoisted(
+  () => ({
+    listCommands: vi.fn(),
+    listCustomActions: vi.fn(),
+    getModelsCatalog: vi.fn(),
+  }),
+);
+
+vi.mock("../api", () => ({
+  client: {
+    listCommands: (surface?: string) => listCommands(surface),
+    listCustomActions: () => listCustomActions(),
+    getModelsCatalog: () => getModelsCatalog(),
+  },
+}));
+vi.mock("../config/boot-config-react.hooks", () => ({
+  useBootConfig: (): Record<string, never> => ({}),
+}));
+vi.mock("../hooks/useAvailableViews", () => ({
+  useAvailableViews: (): { views: never[] } => ({ views: [] }),
+}));
+vi.mock("../state", () => ({
+  useAppSelectorShallow: <T,>(
+    selector: (state: {
+      setTab: (tab: string) => void;
+      handleChatClear: () => Promise<void>;
+    }) => T,
+  ): T => selector({ setTab: () => {}, handleChatClear: async () => {} }),
+}));
+
+import { fetchRuntimeModeSnapshot } from "../api/runtime-mode-client";
+import { useSlashCommandController } from "../chat/useSlashCommandController";
+import { shouldProbeExistingLocalInstall } from "../state/first-run-bootstrap";
+import {
+  __resetAuthStatusForTests,
+  __setAuthStatusForTests,
+} from "./useAuthStatus";
+import {
+  protectedAgentProbesEnabled,
+  useProtectedAgentProbesEnabled,
+} from "./useProtectedAgentProbesEnabled";
+import {
+  __resetRuntimeModeCacheForTests,
+  useRuntimeMode,
+} from "./useRuntimeMode";
+
+const CLOUD_APP_ORIGIN = "https://app.elizacloud.ai";
+const runtimeModeMock = vi.mocked(fetchRuntimeModeSnapshot);
+const originalLocationDescriptor = Object.getOwnPropertyDescriptor(
+  window,
+  "location",
+);
+
+function setLocation(url: string): void {
+  const u = new URL(url);
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: {
+      href: u.href,
+      origin: u.origin,
+      protocol: u.protocol,
+      host: u.host,
+      hostname: u.hostname,
+      port: u.port,
+      pathname: u.pathname,
+      search: u.search,
+      hash: u.hash,
+      assign: () => {},
+      replace: () => {},
+      reload: () => {},
+      toString: () => u.href,
+    },
+  });
+}
+
+function authenticate(): void {
+  __setAuthStatusForTests({
+    phase: "authenticated",
+    identity: { id: "u-1", displayName: "Owner", kind: "owner" },
+    session: { id: "s-1", kind: "browser", expiresAt: null },
+    access: {
+      mode: "session",
+      passwordConfigured: true,
+      ownerConfigured: true,
+      role: "OWNER",
+    },
+  });
+}
+
+function GateProbe(props: { onValue: (enabled: boolean) => void }): null {
+  props.onValue(useProtectedAgentProbesEnabled());
+  return null;
+}
+
+function RuntimeModeProbe(): null {
+  useRuntimeMode();
+  return null;
+}
+
+function SlashProbe(): null {
+  useSlashCommandController();
+  return null;
+}
+
+beforeEach(() => {
+  __resetAuthStatusForTests();
+  __resetRuntimeModeCacheForTests();
+  runtimeModeMock.mockClear().mockResolvedValue(null);
+  listCommands.mockReset().mockResolvedValue([]);
+  listCustomActions.mockReset().mockResolvedValue([]);
+  getModelsCatalog
+    .mockReset()
+    .mockResolvedValue({ catalog: { providers: {} } });
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  __resetAuthStatusForTests();
+  __resetRuntimeModeCacheForTests();
+  if (originalLocationDescriptor) {
+    Object.defineProperty(window, "location", originalLocationDescriptor);
+  }
+});
+
+describe("protectedAgentProbesEnabled (pure gate — #16242)", () => {
+  it("blocks probes only on a bare, unauthenticated Cloud control-plane origin", () => {
+    expect(protectedAgentProbesEnabled(false, CLOUD_APP_ORIGIN)).toBe(false);
+    expect(protectedAgentProbesEnabled(false, "https://elizacloud.ai")).toBe(
+      false,
+    );
+    // A session flips the gate open even on the Cloud origin.
+    expect(protectedAgentProbesEnabled(true, CLOUD_APP_ORIGIN)).toBe(true);
+    // Self-hosted / local / desktop origins never require cloud auth.
+    expect(protectedAgentProbesEnabled(false, "http://localhost:2138")).toBe(
+      true,
+    );
+    expect(
+      protectedAgentProbesEnabled(false, "https://agent.example.com"),
+    ).toBe(true);
+    expect(protectedAgentProbesEnabled(false, null)).toBe(true);
+  });
+});
+
+describe("shouldProbeExistingLocalInstall (startup restore — #16242)", () => {
+  it("skips the first-run/status + config probe on a Cloud control-plane origin", () => {
+    expect(shouldProbeExistingLocalInstall(CLOUD_APP_ORIGIN)).toBe(false);
+    expect(shouldProbeExistingLocalInstall("https://elizacloud.ai")).toBe(
+      false,
+    );
+    expect(shouldProbeExistingLocalInstall("http://localhost:2138")).toBe(true);
+    expect(shouldProbeExistingLocalInstall("https://agent.example.com")).toBe(
+      true,
+    );
+    expect(shouldProbeExistingLocalInstall(null)).toBe(true);
+  });
+});
+
+describe("useProtectedAgentProbesEnabled (live hook)", () => {
+  it("is false on the unauthenticated Cloud origin and true once authenticated", async () => {
+    setLocation(`${CLOUD_APP_ORIGIN}/`);
+    const seen: boolean[] = [];
+    render(<GateProbe onValue={(v) => seen.push(v)} />);
+    expect(seen.at(-1)).toBe(false);
+
+    act(() => {
+      authenticate();
+    });
+    await waitFor(() => expect(seen.at(-1)).toBe(true));
+  });
+
+  it("is true on a localhost origin regardless of auth", () => {
+    setLocation("http://localhost:2138/");
+    const seen: boolean[] = [];
+    render(<GateProbe onValue={(v) => seen.push(v)} />);
+    expect(seen.at(-1)).toBe(true);
+  });
+});
+
+describe("useRuntimeMode — GET /api/runtime/mode gated (#16242)", () => {
+  it("does not probe on the fresh unauthenticated Cloud origin, then probes after sign-in", async () => {
+    setLocation(`${CLOUD_APP_ORIGIN}/`);
+    render(<RuntimeModeProbe />);
+    // Give any (incorrectly ungated) mount effect a chance to fire.
+    await Promise.resolve();
+    expect(runtimeModeMock).not.toHaveBeenCalled();
+
+    act(() => {
+      authenticate();
+    });
+    await waitFor(() => expect(runtimeModeMock).toHaveBeenCalledTimes(1));
+  });
+
+  it("probes on mount on a non-Cloud origin (unchanged behavior)", async () => {
+    setLocation("http://localhost:2138/");
+    render(<RuntimeModeProbe />);
+    await waitFor(() => expect(runtimeModeMock).toHaveBeenCalledTimes(1));
+  });
+});
+
+describe("useSlashCommandController — command catalog gated (#16242)", () => {
+  it("does not fetch commands/custom-actions on the unauthenticated Cloud origin, then fetches after sign-in", async () => {
+    setLocation(`${CLOUD_APP_ORIGIN}/`);
+    render(<SlashProbe />);
+    await Promise.resolve();
+    expect(listCommands).not.toHaveBeenCalled();
+    expect(listCustomActions).not.toHaveBeenCalled();
+
+    act(() => {
+      authenticate();
+    });
+    await waitFor(() => {
+      expect(listCommands).toHaveBeenCalledTimes(1);
+      expect(listCustomActions).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("fetches the catalog on mount on a non-Cloud origin (unchanged behavior)", async () => {
+    setLocation("http://localhost:2138/");
+    render(<SlashProbe />);
+    await waitFor(() => {
+      expect(listCommands).toHaveBeenCalledWith("gui");
+      expect(listCustomActions).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/ui/src/hooks/useProtectedAgentProbesEnabled.ts
+++ b/packages/ui/src/hooks/useProtectedAgentProbesEnabled.ts
@@ -1,0 +1,40 @@
+/**
+ * Gate for shell data loaders that hit protected (auth-required) agent API
+ * routes on mount.
+ *
+ * The one origin where the shell must NOT probe those routes before a session
+ * exists is the shared Eliza Cloud web app (`app.elizacloud.ai` and the other
+ * control-plane hosts): its same-origin `/api/*` is the managed cloud endpoint,
+ * so every protected GET fired during fresh onboarding 401s and Chromium logs
+ * each as a console error — the first-run noise of #16242. The in-chat first-run
+ * conductor owns Cloud sign-in there; once a session exists the probes resume.
+ *
+ * Everywhere else (localhost, desktop/mobile local agents, self-hosted remotes)
+ * the same-origin agent needs no cloud auth, so probes fire immediately — no
+ * auth round-trip is inserted into those hot paths. Consumers:
+ * `notifications-boot`, `useWeather`, `useRuntimeMode`, `useSlashCommandController`.
+ */
+
+import { isElizaCloudControlPlaneAgentlessBase } from "../utils/cloud-agent-base";
+import { useIsAuthenticated } from "./useAuthStatus";
+
+/**
+ * Pure decision behind {@link useProtectedAgentProbesEnabled}: probes are
+ * allowed once authenticated, or on any origin that is not a bare Eliza Cloud
+ * control-plane host (where the same-origin agent needs no cloud session).
+ */
+export function protectedAgentProbesEnabled(
+  authenticated: boolean,
+  origin: string | null | undefined,
+): boolean {
+  if (authenticated) return true;
+  return !isElizaCloudControlPlaneAgentlessBase(origin ?? "");
+}
+
+export function useProtectedAgentProbesEnabled(): boolean {
+  const authenticated = useIsAuthenticated();
+  return protectedAgentProbesEnabled(
+    authenticated,
+    typeof window !== "undefined" ? window.location.origin : null,
+  );
+}

--- a/packages/ui/src/hooks/useRuntimeMode.ts
+++ b/packages/ui/src/hooks/useRuntimeMode.ts
@@ -24,6 +24,7 @@ import {
   type RuntimeMode,
   type RuntimeModeSnapshot,
 } from "../api/runtime-mode-client";
+import { useProtectedAgentProbesEnabled } from "./useProtectedAgentProbesEnabled";
 
 export type UseRuntimeModeState =
   | { phase: "loading" }
@@ -79,6 +80,10 @@ export function __resetRuntimeModeCacheForTests(): void {
 export function useRuntimeMode(): UseRuntimeModeResult {
   const [state, setState] = useState<UseRuntimeModeState>(snapshot);
   const mountedRef = useRef(true);
+  // GET /api/runtime/mode is protected; hold the first fetch until probes are
+  // allowed so fresh Cloud onboarding fires no 401 (#16242). Cached at module
+  // scope, so it runs at most once per session regardless of consumer count.
+  const probesEnabled = useProtectedAgentProbesEnabled();
 
   const refetch = useCallback(() => {
     if (!mountedRef.current) return;
@@ -89,12 +94,15 @@ export function useRuntimeMode(): UseRuntimeModeResult {
     mountedRef.current = true;
     subscribers.add(setState);
     setState(snapshot);
-    if (snapshot.phase === "loading") void refresh();
     return () => {
       mountedRef.current = false;
       subscribers.delete(setState);
     };
   }, []);
+
+  useEffect(() => {
+    if (probesEnabled && snapshot.phase === "loading") void refresh();
+  }, [probesEnabled]);
 
   const mode = state.phase === "ready" ? state.snapshot.mode : null;
   return {

--- a/packages/ui/src/hooks/useWeather.test.ts
+++ b/packages/ui/src/hooks/useWeather.test.ts
@@ -3,6 +3,10 @@
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  __resetAuthStatusForTests,
+  __setAuthStatusForTests,
+} from "./useAuthStatus";
+import {
   describeWeatherCode,
   prefers24HourClock,
   temperatureUnitForLocale,
@@ -360,5 +364,78 @@ describe("useWeather", () => {
       .at(-1);
     expect(preciseUrl).toContain("latitude=37.7");
     expect(preciseUrl).toMatch(/temperature_unit=(celsius|fahrenheit)/);
+  });
+});
+
+describe("useWeather — protected-probe gate (#16242)", () => {
+  const originalLocation = Object.getOwnPropertyDescriptor(window, "location");
+
+  function setOrigin(url: string): void {
+    const u = new URL(url);
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        href: u.href,
+        origin: u.origin,
+        protocol: u.protocol,
+        host: u.host,
+        hostname: u.hostname,
+        port: u.port,
+        pathname: u.pathname,
+        search: u.search,
+        hash: u.hash,
+        assign: () => {},
+        replace: () => {},
+        reload: () => {},
+        toString: () => u.href,
+      },
+    });
+  }
+
+  afterEach(() => {
+    __resetAuthStatusForTests();
+    if (originalLocation) {
+      Object.defineProperty(window, "location", originalLocation);
+    }
+  });
+
+  it("does not hit /api/location/approximate on the unauthenticated Cloud origin", async () => {
+    setOrigin("https://app.elizacloud.ai/");
+    __resetAuthStatusForTests();
+    const { calls } = installFetchRouter();
+    denyGeolocation();
+
+    const { result } = renderHook(() => useWeather());
+    // Let any (incorrectly ungated) revalidate settle.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(calls.some((u) => u.includes("/api/location/approximate"))).toBe(
+      false,
+    );
+    expect(result.current.status).toBe("loading");
+  });
+
+  it("resolves conditions once authenticated on the Cloud origin", async () => {
+    setOrigin("https://app.elizacloud.ai/");
+    __setAuthStatusForTests({
+      phase: "authenticated",
+      identity: { id: "u-1", displayName: "Owner", kind: "owner" },
+      session: { id: "s-1", kind: "browser", expiresAt: null },
+      access: {
+        mode: "session",
+        passwordConfigured: true,
+        ownerConfigured: true,
+        role: "OWNER",
+      },
+    });
+    const { calls } = installFetchRouter();
+    denyGeolocation();
+
+    const { result } = renderHook(() => useWeather());
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    expect(calls.some((u) => u.includes("/api/location/approximate"))).toBe(
+      true,
+    );
   });
 });

--- a/packages/ui/src/hooks/useWeather.ts
+++ b/packages/ui/src/hooks/useWeather.ts
@@ -9,6 +9,7 @@ import * as React from "react";
 import { client } from "../api/client";
 import { shellLocalStorage } from "../surface-realm-channel";
 import { useIntervalWhenDocumentVisible } from "./useDocumentVisibility";
+import { useProtectedAgentProbesEnabled } from "./useProtectedAgentProbesEnabled";
 
 /**
  * Current-conditions weather for the home dashboard's weather widget.
@@ -378,6 +379,11 @@ export function useWeather(): WeatherState {
     };
   }, []);
 
+  // The approximate-location leg hits the protected GET /api/location/approximate;
+  // hold it until probes are allowed so fresh Cloud onboarding fires no 401
+  // (#16242). Re-runs to load real conditions once the gate opens post-sign-in.
+  const probesEnabled = useProtectedAgentProbesEnabled();
+
   const applyUnavailable = React.useCallback(() => {
     if (!mountedRef.current) return;
     // Only fall to "unavailable" when we have nothing cached to show.
@@ -408,13 +414,15 @@ export function useWeather(): WeatherState {
   }, []);
 
   React.useEffect(() => {
+    if (!probesEnabled) return;
     void revalidate();
-  }, [revalidate]);
+  }, [revalidate, probesEnabled]);
 
   // Revalidate while the home stays open — a long-lived session no longer shows
   // a frozen temperature — but only when the document is visible (no background
   // polling) and only past the TTL (revalidate is cache-first).
   useIntervalWhenDocumentVisible(() => {
+    if (!probesEnabled) return;
     void revalidate();
   }, WEATHER_TTL_MS);
 

--- a/packages/ui/src/state/first-run-bootstrap.test.ts
+++ b/packages/ui/src/state/first-run-bootstrap.test.ts
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+
+/**
+ * Existing-install boot probe (`first-run-bootstrap`): detection of a returning
+ * local/self-hosted install and the #16242 gate that skips the probe on a bare
+ * Eliza Cloud control-plane origin (where the same-origin API is auth-gated and
+ * would only 401). Drives the real functions with a fake probe client — no
+ * network — and stubs `window.location.origin` to exercise the origin gate.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  detectExistingFirstRunConnection,
+  type ExistingFirstRunProbeClient,
+  shouldProbeExistingLocalInstall,
+} from "./first-run-bootstrap";
+
+const originalLocation = Object.getOwnPropertyDescriptor(window, "location");
+
+function setOrigin(url: string): void {
+  const u = new URL(url);
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: {
+      href: u.href,
+      origin: u.origin,
+      protocol: u.protocol,
+      host: u.host,
+      hostname: u.hostname,
+      port: u.port,
+      pathname: u.pathname,
+      search: u.search,
+      hash: u.hash,
+      assign: () => {},
+      replace: () => {},
+      reload: () => {},
+      toString: () => u.href,
+    },
+  });
+}
+
+function makeClient(
+  overrides: Partial<ExistingFirstRunProbeClient> = {},
+): ExistingFirstRunProbeClient {
+  return {
+    apiAvailable: true,
+    getFirstRunStatus: vi.fn(async () => ({ complete: false })),
+    getConfig: vi.fn(async () => ({})),
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  if (originalLocation) {
+    Object.defineProperty(window, "location", originalLocation);
+  }
+});
+
+describe("shouldProbeExistingLocalInstall (#16242)", () => {
+  it("is false only on a bare Cloud control-plane origin", () => {
+    expect(shouldProbeExistingLocalInstall("https://app.elizacloud.ai")).toBe(
+      false,
+    );
+    expect(shouldProbeExistingLocalInstall("https://elizacloud.ai")).toBe(
+      false,
+    );
+    expect(shouldProbeExistingLocalInstall("http://localhost:2138")).toBe(true);
+    expect(shouldProbeExistingLocalInstall("https://agent.example.com")).toBe(
+      true,
+    );
+    expect(shouldProbeExistingLocalInstall(null)).toBe(true);
+    expect(shouldProbeExistingLocalInstall(undefined)).toBe(true);
+  });
+});
+
+describe("detectExistingFirstRunConnection", () => {
+  beforeEach(() => {
+    setOrigin("http://localhost:2138/");
+  });
+
+  it("returns null and never probes when the API is unavailable", async () => {
+    const client = makeClient({ apiAvailable: false });
+    const result = await detectExistingFirstRunConnection({
+      client,
+      timeoutMs: 1000,
+    });
+    expect(result).toBeNull();
+    expect(client.getFirstRunStatus).not.toHaveBeenCalled();
+  });
+
+  it("skips the probe on a Cloud control-plane origin (#16242)", async () => {
+    setOrigin("https://app.elizacloud.ai/");
+    const client = makeClient();
+    const result = await detectExistingFirstRunConnection({
+      client,
+      timeoutMs: 1000,
+    });
+    expect(result).toBeNull();
+    // The gate returns before any protected probe is issued.
+    expect(client.getFirstRunStatus).not.toHaveBeenCalled();
+    expect(client.getConfig).not.toHaveBeenCalled();
+  });
+
+  it("detects a completed backend install from first-run status", async () => {
+    const client = makeClient({
+      getFirstRunStatus: vi.fn(async () => ({ complete: true })),
+    });
+    const result = await detectExistingFirstRunConnection({
+      client,
+      timeoutMs: 1000,
+    });
+    expect(result).toMatchObject({ detectedExistingInstall: true });
+    expect(result?.activeServer.kind).toBe("local");
+    expect(client.getConfig).not.toHaveBeenCalled();
+  });
+
+  it("detects an existing install from persisted config when first-run is incomplete", async () => {
+    const client = makeClient({
+      getFirstRunStatus: vi.fn(async () => ({ complete: false })),
+      getConfig: vi.fn(async () => ({ meta: { firstRunComplete: true } })),
+    });
+    const result = await detectExistingFirstRunConnection({
+      client,
+      timeoutMs: 1000,
+    });
+    expect(result).toMatchObject({ detectedExistingInstall: true });
+    expect(client.getConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null when no install is detected (incomplete + empty config)", async () => {
+    const client = makeClient({
+      getFirstRunStatus: vi.fn(async () => ({ complete: false })),
+      getConfig: vi.fn(async () => ({})),
+    });
+    const result = await detectExistingFirstRunConnection({
+      client,
+      timeoutMs: 1000,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the status probe throws (agent unreachable)", async () => {
+    const client = makeClient({
+      getFirstRunStatus: vi.fn(async () => {
+        throw new Error("unreachable");
+      }),
+    });
+    const result = await detectExistingFirstRunConnection({
+      client,
+      timeoutMs: 1000,
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/packages/ui/src/state/first-run-bootstrap.ts
+++ b/packages/ui/src/state/first-run-bootstrap.ts
@@ -3,6 +3,7 @@
  * first-run config and resolves the initial active-server record so a returning
  * user skips re-onboarding. Reads via the injected probe client.
  */
+import { isElizaCloudControlPlaneAgentlessBase } from "../utils/cloud-agent-base";
 import { asRecord, readString } from "./config-readers";
 import {
   createPersistedActiveServer,
@@ -54,11 +55,39 @@ function hasPersistedExistingInstallConfig(
   );
 }
 
+/**
+ * Whether the boot-time existing-install probe (GET /api/first-run/status +
+ * /api/config) should run for `origin`. The probe detects a returning
+ * local/self-hosted install so the user skips re-onboarding. On a bare Eliza
+ * Cloud control-plane origin (app.elizacloud.ai, elizacloud.ai, …) the
+ * same-origin API is the managed cloud endpoint: it requires auth and hosts no
+ * unauthenticated local install to detect, so probing it only yields 401
+ * console noise during fresh onboarding (#16242). Skip it there — the in-chat
+ * first-run conductor owns Cloud sign-in.
+ */
+export function shouldProbeExistingLocalInstall(
+  origin: string | null | undefined,
+): boolean {
+  return !isElizaCloudControlPlaneAgentlessBase(origin ?? "");
+}
+
+function currentOrigin(): string | null {
+  return typeof window !== "undefined" ? window.location.origin : null;
+}
+
 export async function detectExistingFirstRunConnection(args: {
   client: ExistingFirstRunProbeClient;
   timeoutMs: number;
 }): Promise<ExistingFirstRunProbeResult | null> {
   if (!args.client.apiAvailable) {
+    return null;
+  }
+
+  // Skip the probe on a bare Cloud control-plane origin: the same-origin API is
+  // auth-gated, so first-run/status + config only 401 during fresh onboarding
+  // (#16242). Gated here rather than at the restore call site so every caller
+  // inherits it and the guard is testable in isolation.
+  if (!shouldProbeExistingLocalInstall(currentOrigin())) {
     return null;
   }
 

--- a/packages/ui/src/state/notifications/notification-store.test.ts
+++ b/packages/ui/src/state/notifications/notification-store.test.ts
@@ -53,6 +53,10 @@ vi.mock("./notification-banner-store", () => ({
 }));
 
 import {
+  __resetAuthStatusForTests,
+  __setAuthStatusForTests,
+} from "../../hooks/useAuthStatus";
+import {
   __getStateForTests,
   __ingestEphemeralNotificationForTests,
   __ingestNotificationForTests,
@@ -711,5 +715,77 @@ describe("notification-store", () => {
       await expect(seedDevNotificationsIfEmpty()).resolves.toBeUndefined();
       expect(__getStateForTests().notifications).toHaveLength(0);
     });
+  });
+});
+
+describe("notification-store — protected hydrate gate (#16242)", () => {
+  const originalLocation = Object.getOwnPropertyDescriptor(window, "location");
+
+  function setOrigin(url: string): void {
+    const u = new URL(url);
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        href: u.href,
+        origin: u.origin,
+        protocol: u.protocol,
+        host: u.host,
+        hostname: u.hostname,
+        port: u.port,
+        pathname: u.pathname,
+        search: u.search,
+        hash: u.hash,
+        assign: () => {},
+        replace: () => {},
+        reload: () => {},
+        toString: () => u.href,
+      },
+    });
+  }
+
+  beforeEach(() => {
+    __resetNotificationStoreForTests();
+    __resetAuthStatusForTests();
+    listNotifications
+      .mockReset()
+      .mockResolvedValue({ notifications: [], unreadCount: 0 });
+    onWsEvent.mockReset().mockReturnValue(() => {});
+    invokeDesktopBridgeRequest.mockReset().mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    __resetNotificationStoreForTests();
+    __resetAuthStatusForTests();
+    if (originalLocation) {
+      Object.defineProperty(window, "location", originalLocation);
+    }
+  });
+
+  it("holds GET /api/notifications on the unauthenticated Cloud origin, then hydrates after sign-in", async () => {
+    setOrigin("https://app.elizacloud.ai/");
+    initNotifications();
+    // WS subscriptions still wire up; only the protected hydrate is held.
+    await Promise.resolve();
+    expect(listNotifications).not.toHaveBeenCalled();
+    expect(onWsEvent).toHaveBeenCalled();
+
+    __setAuthStatusForTests({
+      phase: "authenticated",
+      identity: { id: "u-1", displayName: "Owner", kind: "owner" },
+      session: { id: "s-1", kind: "browser", expiresAt: null },
+      access: {
+        mode: "session",
+        passwordConfigured: true,
+        ownerConfigured: true,
+        role: "OWNER",
+      },
+    });
+    await vi.waitFor(() => expect(listNotifications).toHaveBeenCalledTimes(1));
+  });
+
+  it("hydrates on mount on a non-Cloud origin regardless of auth (unchanged)", async () => {
+    setOrigin("http://localhost:2138/");
+    initNotifications();
+    await vi.waitFor(() => expect(listNotifications).toHaveBeenCalledTimes(1));
   });
 });

--- a/packages/ui/src/state/notifications/notification-store.ts
+++ b/packages/ui/src/state/notifications/notification-store.ts
@@ -23,6 +23,11 @@ import {
   showWebNotification,
 } from "../../bridge/native-notifications";
 import { APP_RESUME_EVENT } from "../../events";
+import {
+  isAuthenticatedNow,
+  subscribeAuthStatus,
+} from "../../hooks/useAuthStatus";
+import { protectedAgentProbesEnabled } from "../../hooks/useProtectedAgentProbesEnabled";
 import { pushNotificationBanner } from "./notification-banner-store";
 
 /**
@@ -75,6 +80,23 @@ let hydrationRetryTimer: ReturnType<typeof setTimeout> | null = null;
 let hydrationGeneration = 0;
 let liveEventRevision = 0;
 const notificationCleanups: Array<() => void> = [];
+// One-shot re-arm: on a fresh, unauthenticated shared Cloud app there is no
+// session yet, so the protected GET /api/notifications hydrate is held to avoid
+// a 401 (#16242). This unsubscribe is set while waiting for a session and
+// cleared once hydration is re-triggered post-sign-in.
+let hydrationAuthRearmUnsub: (() => void) | null = null;
+
+/**
+ * Whether the inbox hydrate may hit the protected `GET /api/notifications` now.
+ * Same origin-aware gate the React shell hooks use, read without a hook so the
+ * store can consult it from its module-scope hydrate path.
+ */
+function notificationProbesEnabled(): boolean {
+  return protectedAgentProbesEnabled(
+    isAuthenticatedNow(),
+    typeof window !== "undefined" ? window.location.origin : null,
+  );
+}
 
 function emit(): void {
   for (const listener of listeners) listener();
@@ -448,6 +470,20 @@ async function runHydrationAttempt(generation: number): Promise<void> {
 }
 
 function requestHydration(): Promise<void> {
+  if (!notificationProbesEnabled()) {
+    // No session yet on the shared Cloud app — skip the protected fetch (it
+    // would 401 and Chromium logs the console error) and re-arm once, so the
+    // inbox hydrates the moment a session lands post-sign-in (#16242).
+    if (!hydrationAuthRearmUnsub) {
+      hydrationAuthRearmUnsub = subscribeAuthStatus(() => {
+        if (!notificationProbesEnabled()) return;
+        hydrationAuthRearmUnsub?.();
+        hydrationAuthRearmUnsub = null;
+        void requestHydration();
+      });
+    }
+    return Promise.resolve();
+  }
   if (hydrationInFlight) return hydrationInFlight;
   if (state.hydrationStatus === "failed") return Promise.resolve();
   const generation = hydrationGeneration;
@@ -648,6 +684,8 @@ export function __resetNotificationStoreForTests(): void {
   if (hydrationRetryTimer) clearTimeout(hydrationRetryTimer);
   hydrationRetryTimer = null;
   hydrationInFlight = null;
+  hydrationAuthRearmUnsub?.();
+  hydrationAuthRearmUnsub = null;
   liveEventRevision = 0;
   state = {
     notifications: [],


### PR DESCRIPTION
## Summary

Fixes #16242. A fresh, unauthenticated production browser context on the shared Eliza Cloud web app (`app.elizacloud.ai`) renders onboarding but probes **protected** agent endpoints **before** Cloud sign-in. Each returns `401` and Chromium logs it as a console error — the noisy first-run logs users report.

Protected probes that fired before auth (all 401):

| Endpoint | Fired from |
| --- | --- |
| `GET /api/first-run/status` | existing-install boot probe |
| `GET /api/config` | existing-install boot probe |
| `GET /api/notifications?limit=100` | notification store hydrate |
| `GET /api/runtime/mode` | `useRuntimeMode` |
| `GET /api/commands?surface=gui` | slash-command catalog |
| `GET /api/custom-actions` | slash-command catalog |
| `GET /api/location/approximate` | weather home widget |

## Root cause

The dashboard is kept **warm-but-hidden** during onboarding, so its shell-boot hooks/widgets mount and fetch on mount unconditionally. Separately, the boot **existing-install** probe (`detectExistingFirstRunConnection` → `GET /api/first-run/status` + `/api/config`) runs even when the same-origin API is the auth-gated Eliza Cloud control plane — where there is no unauthenticated local install to detect. `/api/auth/me` is the one probe that degrades gracefully (not in the list); it's the designated auth check.

## The fix

One origin-aware gate, reusing the exact predicate the app already uses for `isAgentlessCloudOrigin` (`isElizaCloudControlPlaneAgentlessBase`) plus the established `useIsAuthenticated()` (#11084 doctrine: "shell data loaders must not start until [authenticated]"):

```
probesEnabled = authenticated || !isElizaCloudControlPlaneAgentlessBase(window.location.origin)
```

- **New `useProtectedAgentProbesEnabled()`** gates the React shell hooks: `useWeather`, `useRuntimeMode`, `useSlashCommandController`.
- **`detectExistingFirstRunConnection`** gates itself via the new pure `shouldProbeExistingLocalInstall(origin)` — it returns `null` (no probe) on a bare Cloud control-plane origin.
- **The notification store** hydrate is gated at its own `.ts` module seam (`requestHydration`) using the same gate read via new non-hook `isAuthenticatedNow()` / `subscribeAuthStatus()`, with a **one-shot re-arm** so the inbox hydrates the moment a session lands after sign-in.

The gate is **inert everywhere except a bare, unauthenticated Cloud control-plane origin**. Local / self-hosted / desktop / remote agents (no cloud auth wall, so no 401) and authenticated Cloud sessions probe exactly as before, and the probes **resume the moment a session exists** after sign-in (effects re-run / the store re-arms). No global suppression — genuine failures still surface (`Do not suppress genuine failures globally`).

### Endpoints now gated
`/api/first-run/status`, `/api/config`, `/api/notifications`, `/api/runtime/mode`, `/api/commands`, `/api/custom-actions`, `/api/location/approximate`.

## Acceptance mapping
- Fresh desktop + mobile contexts still show cloud-only onboarding — onboarding untouched; only probes are gated. ✅
- Eliza Cloud auth popup / Google → `accounts.google.com` via Steward — unchanged. ✅
- No protected agent request before authentication — all 7 gated to 0 on the fresh Cloud origin. ✅
- Existing authenticated hydration unchanged — after sign-in `authenticated` flips true and every probe fires / the store re-arms. ✅

## Tests

The gate proof is co-located in each touched module's suite (weather, slash catalog, notification store, first-run bootstrap, auth-status seam) plus a dedicated `useProtectedAgentProbesEnabled.test.tsx` — asserting on the **actual** network functions the hooks/store call, not a mock of the gate.

<details><summary>coverage gate (enforced, ≥50% per changed source file)</summary>

```
   86.21% packages/ui/src/hooks/useRuntimeMode.ts
   81.82% packages/ui/src/hooks/useWeather.ts
   78.95% packages/ui/src/hooks/useAuthStatus.ts
  100.00% packages/ui/src/hooks/useProtectedAgentProbesEnabled.ts
   81.58% packages/ui/src/state/first-run-bootstrap.ts
   63.39% packages/ui/src/chat/useSlashCommandController.ts
   95.85% packages/ui/src/state/notifications/notification-store.ts

changed files: 7, mean coverage: 83.97%, threshold: 50%
coverage gate OK
```

Regression sweeps (all green): src/state + src/hooks + src/chat (152 files / 1322 tests). bunx biome check clean; tsgo adds no new errors in touched files.

</details>

## How to verify
Open `https://app.elizacloud.ai/` in a fresh browser context (no cookies/localStorage), wait for onboarding, and inspect Network/Console before authenticating: **zero** protected `401`s. Sign in → every listed endpoint hydrates normally.

## Evidence

This is a **frontend behavior-only** change with **no rendered-UI delta**: the gated hooks/components render nothing new and the home widgets stay hidden during onboarding. The observable behavior — "zero protected `401`s before auth, normal hydration after" — is proven by the real unit tests above (asserting on the actual network functions the hooks/store call), not by pixels. All touched files are `.ts`/tests, so there is no UI surface to screenshot.

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots `N/A - no rendered-UI delta; the change gates which network requests fire, not any pixels (all touched files are .ts/tests, no component render output changes).`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots `N/A - no rendered-UI delta; see before-screenshots.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video `N/A - no visual flow; the behavior is "zero protected 401s before auth", proven by the unit tests above rather than a screen recording.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs `N/A - UI-only change; no server/backend code touched (all files under packages/ui/src).`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs `N/A - the request/response change (protected probes suppressed pre-auth, then fired post-auth) is asserted directly against the network functions in the unit tests above; a live Cloud console capture is not reproducible in the worktree.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory `N/A - no agent/action/provider/prompt/model change; this only gates client-side fetches.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts `N/A - no DB rows, memories, scheduled tasks, wallet/on-chain output, or generated files are produced or changed by this fetch-gating fix.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
