### PR TITLE
fix(ci): add fail-closed develop PR aggregate

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -69,6 +69,12 @@ the lightweight PR surface and remains independent of the exhaustive fleet:
   roll-ups inside the post-merge `test.yml` orchestrator. They report branch
   health after a develop push; they are not the pre-merge required context.
 
+The aggregate contract runs directly under Node in
+`packages/scripts/develop-pr-aggregate.self-test.mjs`; the changed-file gate
+loads the same assertions through
+`packages/scripts/develop-pr-aggregate.test.mjs` so the implementation also
+produces enforced per-file coverage.
+
 Two SPOF guards, enforced by `packages/scripts/ci-merge-gate-contract.mjs` (run
 in the `changes` job, #13617):
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -7,9 +7,11 @@ This directory contains GitHub Actions workflows for the elizaOS project (v2.0.0
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
 | `ci.yaml` | Push/PR to main | Main-specific CI - typecheck, tests, lint, build, dev startup |
-| `test.yml` | Push/PR to develop, manual, schedule | Broader develop tests plus required zero-key deterministic E2E; live jobs are separate |
-| `quality.yml` | Push/PR to main/develop, manual | Develop/main quality gates: format, type-safety ratchet, prompt-secret scan, UI determinism, lint |
-| `scenario-pr.yml` | PR to main/develop, manual | Secret-free deterministic scenario/browser E2E gate |
+| `develop-pr.yml` | PR to develop | Lightweight lint, typecheck, build, and deterministic lane-integrity checks |
+| `develop-pr-gate.yml` | PR target to develop, manual canaries | Stable fail-closed aggregate over the nine lightweight required contexts |
+| `test.yml` | Push to develop, manual, schedule | Broader post-merge develop tests; live jobs are separate |
+| `quality.yml` | PR to main, push main/develop, manual | Extended format, type-safety, homepage, secret, UI-determinism, and lint checks |
+| `scenario-pr.yml` | PR to main, push develop, manual/schedule | Secret-free deterministic scenario/browser E2E gate |
 | `scenario-matrix.yml` | Develop/manual opt-in | Real-service scenario matrix; not a PR gate |
 | `pr.yaml` | PR opened/edited | PR title validation |
 | `release.yaml` | Push to main, Release | NPM beta/production package releases |
@@ -49,10 +51,10 @@ Publishes TypeScript/JavaScript packages to NPM.
 
 ### Linux Runner Policy
 
-The heavy develop **test lanes** in `test.yml` run on the self-hosted
+The heavy post-merge develop **test lanes** in `test.yml` run on the self-hosted
 `self-hosted, hetzner-robot` pool (GitHub-hosted minutes are billing-frozen for
-this org, #13481). Everything the **merge gate** depends on to *reach a
-conclusion* stays GitHub-hosted so a drained fleet can never wedge develop:
+this org, #13481). Everything the pre-merge **Develop PR Gate** depends on is
+the lightweight PR surface and remains independent of the exhaustive fleet:
 
 - **Path classifiers** (`Classify changed paths`) across `test.yml`,
   `scenario-pr.yml`, `dev-smoke.yml`, `docker-ci-smoke.yml`,
@@ -60,9 +62,12 @@ conclusion* stays GitHub-hosted so a drained fleet can never wedge develop:
   `windows-desktop-preload-smoke.yml` run on `ubuntu-24.04`. They are git-diff +
   node scripts with no self-hosted needs; pinning them to the fleet (#8501) once
   left every downstream job queued indefinitely and gridlocked develop.
-- **`ci-ok`** (the merge queue's sole required context), its
-  `plugin-tests-status` roll-up, and the hosted **`merge-quality-gate`** all run
-  on `ubuntu-24.04`.
+- **`Develop PR Gate`** runs on `ubuntu-24.04` and only observes check metadata
+  from the nine lightweight component contexts. It never waits for post-merge,
+  scheduled, device, aesthetic, or exhaustive suites.
+- **`ci-ok`**, `plugin-tests-status`, and `merge-quality-gate` remain hosted
+  roll-ups inside the post-merge `test.yml` orchestrator. They report branch
+  health after a develop push; they are not the pre-merge required context.
 
 Two SPOF guards, enforced by `packages/scripts/ci-merge-gate-contract.mjs` (run
 in the `changes` job, #13617):
@@ -75,13 +80,12 @@ in the `changes` job, #13617):
    the whole workflow falls back to hosted — one flip unblocks the entire queue
    instead of per-PR admin-bypass. Keep the runner-agnostic step hardening (no
    `sudo`-only install/cleanup) so lanes run on either runner type.
-2. **Hosted quality parity.** `merge-quality-gate` runs the same lint /
+2. **Post-merge quality parity.** `merge-quality-gate` runs the same lint /
    `format:check` / repo-wide `typecheck` / gitleaks secret scan that guard
-   `main`, and `ci-ok` needs it — so a lint, type, format, or committed-secret
-   regression is refused by the merge queue on develop, not just on `main`. It
-   runs on `merge_group` + develop `push`. The lightweight `develop-pr.yml`
-   lint job also runs `format:check`, so formatting fails on the PR even when a
-   busy push wave supersedes post-merge quality runs (#15959).
+   `main`, and `ci-ok` needs it on develop `push`. The pre-merge
+   `develop-pr.yml` lint job runs `format:check`, and the stable aggregate waits
+   for that exact job, so formatting is refused before merge even when a busy
+   push wave supersedes post-merge quality runs (#15959).
 
 CodeQL is a separate exception: trusted push, scheduled, and manual CodeQL runs
 use `self-hosted, Linux, X64, hetzner-robot` because full JavaScript analysis is
@@ -181,10 +185,10 @@ Runs on PRs and pushes to main:
 - Dev startup + HMR propagation
 - Interop TypeScript tests (`packages/interop`)
 
-The broader `test.yml` orchestrator runs automatically on `develop` only to
-avoid duplicating the main-branch CI gate. Secret-free deterministic zero-key
-coverage for PRs to either protected branch is handled by `scenario-pr.yml`;
-`test.yml` keeps the broader develop push/PR, manual, and scheduled coverage.
+The broader `test.yml` orchestrator runs after pushes to `develop` to avoid
+duplicating the main-branch CI gate on every PR. The lightweight develop PR
+surface is owned by `develop-pr.yml` and aggregated by `develop-pr-gate.yml`;
+`test.yml` keeps the broader develop push, manual, and scheduled coverage.
 
 ### Live E2E
 

--- a/.github/workflows/develop-pr-gate.yml
+++ b/.github/workflows/develop-pr-gate.yml
@@ -1,0 +1,70 @@
+# Base-trusted aggregate for the lightweight develop pull-request gate. It
+# observes GitHub check metadata only: the privileged pull_request_target job
+# never checks out or executes pull-request code, receives no secrets, and has
+# read-only permissions. The stable job stays pending until every component is
+# terminal and fails for every outcome except success.
+name: Develop PR Gate
+
+on:
+  pull_request_target:
+    branches: [develop]
+    types: [opened, synchronize, reopened, ready_for_review, edited, labeled, unlabeled]
+  workflow_dispatch:
+    inputs:
+      canary:
+        description: Deterministic terminal-state canary (success is the only green outcome)
+        required: true
+        type: choice
+        options:
+          - success
+          - missing
+          - cancelled
+          - timed-out
+          - failed
+          - skipped
+          - pending-timeout
+
+concurrency:
+  group: develop-pr-gate-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+
+permissions:
+  contents: read
+  checks: read
+  actions: read
+  pull-requests: read
+
+jobs:
+  gate:
+    name: Develop PR Gate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    env:
+      AGGREGATE_EVENT_NAME: ${{ github.event_name }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+      PR_ACTION: ${{ github.event.action || '' }}
+      PR_UPDATED_AT: ${{ github.event.pull_request.updated_at || '' }}
+      POLL_TIMEOUT_SECONDS: "2400"
+      POLL_INTERVAL_SECONDS: "30"
+      CANARY_SCENARIO: ${{ github.event_name == 'workflow_dispatch' && inputs.canary || '' }}
+    steps:
+      - name: Check out the trusted aggregate implementation
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24.15.0"
+
+      - name: Verify the aggregate state machine and workflow contract
+        run: node packages/scripts/develop-pr-aggregate.self-test.mjs
+
+      - name: Evaluate required develop checks
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node packages/scripts/develop-pr-aggregate.mjs

--- a/.github/workflows/develop-pr.yml
+++ b/.github/workflows/develop-pr.yml
@@ -68,6 +68,12 @@ jobs:
             node "$self_test"
           done < scripts/security/coverage-node-self-tests.txt
 
+      # The aggregate itself is base-trusted and therefore cannot execute its
+      # new implementation on the PR that introduces a change. This required
+      # lane validates the proposed state machine and workflow contract first.
+      - name: Develop PR aggregate contract self-test
+        run: node packages/scripts/develop-pr-aggregate.self-test.mjs
+
       # View→action ratchet (#14369): every builtin-view on-screen mutation
       # must map to a registered agent action (chat twin), and the generated
       # action catalog must reflect the real registered surface. Dependency-free

--- a/packages/scripts/develop-pr-aggregate-workflow-contract.mjs
+++ b/packages/scripts/develop-pr-aggregate-workflow-contract.mjs
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+/**
+ * Static contract for the base-trusted develop pull-request aggregate.
+ * It binds the stable check name to a hosted, read-only workflow and verifies
+ * that every polled context still belongs to an always-emitted owner workflow
+ * with the activity types modeled by the aggregate state machine.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import {
+  AGGREGATE_TRIGGER_ACTIONS,
+  CANARY_SCENARIOS,
+  DEFAULT_PULL_REQUEST_ACTIONS,
+  REQUIRED_CHECKS,
+} from "./develop-pr-aggregate.mjs";
+
+const DEFAULT_REPO_ROOT = resolve(
+  fileURLToPath(new URL(".", import.meta.url)),
+  "..",
+  "..",
+);
+const AGGREGATE_WORKFLOW = ".github/workflows/develop-pr-gate.yml";
+export const TRUSTED_BASE_REF_LINE =
+  "ref: $" + "{{ github.event.pull_request.base.sha || github.sha }}";
+export const OBSERVED_HEAD_LINE =
+  "HEAD_SHA: $" + "{{ github.event.pull_request.head.sha || github.sha }}";
+export const DISPATCH_CANARY_LINE =
+  "CANARY_SCENARIO: $" +
+  "{{ github.event_name == 'workflow_dispatch' && inputs.canary || '' }}";
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function assert(condition, message) {
+  if (!condition) fail(message);
+}
+
+function assertIncludes(text, fragment, message) {
+  assert(text.includes(fragment), `${message}: missing ${fragment}`);
+}
+
+function assertEqual(actual, expected, message) {
+  const actualJson = JSON.stringify(actual);
+  const expectedJson = JSON.stringify(expected);
+  assert(
+    actualJson === expectedJson,
+    `${message}: expected ${expectedJson}, got ${actualJson}`,
+  );
+}
+
+function unquote(value) {
+  return value.trim().replace(/^(?:"([\s\S]*)"|'([\s\S]*)')$/, "$1$2");
+}
+
+function inlineList(block, key, fallback = null) {
+  const match = block.match(
+    new RegExp(`^\\s{4}${key}:\\s*\\[([^\\]]*)\\]\\s*$`, "m"),
+  );
+  if (!match) return fallback;
+  return match[1].split(",").map(unquote).filter(Boolean);
+}
+
+function eventBlock(text, eventName, workflowPath) {
+  const lines = text.split(/\r?\n/);
+  const onIndex = lines.indexOf("on:");
+  assert(onIndex >= 0, `${workflowPath}: missing on mapping`);
+  const eventIndex = lines.findIndex(
+    (line, index) => index > onIndex && line === `  ${eventName}:`,
+  );
+  assert(eventIndex >= 0, `${workflowPath}: missing on.${eventName}`);
+  const selected = [];
+  for (let index = eventIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (/^\S/.test(line) || /^ {2}\S/.test(line)) break;
+    selected.push(line);
+  }
+  return selected.join("\n");
+}
+
+function count(text, pattern) {
+  return Array.from(text.matchAll(pattern)).length;
+}
+
+export function validateAggregateWorkflow(workflow) {
+  assertIncludes(workflow, "name: Develop PR Gate", "workflow name");
+  assertIncludes(
+    workflow,
+    "  pull_request_target:",
+    "base-trusted pull-request trigger",
+  );
+  assert(
+    !/^ {2}pull_request:/m.test(workflow),
+    "aggregate must not run PR-controlled workflow code via pull_request",
+  );
+  const targetBlock = eventBlock(
+    workflow,
+    "pull_request_target",
+    AGGREGATE_WORKFLOW,
+  );
+  assertEqual(
+    inlineList(targetBlock, "branches"),
+    ["develop"],
+    "aggregate target branches",
+  );
+  assertEqual(
+    inlineList(targetBlock, "types"),
+    AGGREGATE_TRIGGER_ACTIONS,
+    "aggregate activity types",
+  );
+  assert(
+    !/^\s+(paths|paths-ignore):/m.test(targetBlock),
+    "aggregate trigger must always emit; paths filters are forbidden",
+  );
+  assertIncludes(workflow, "  workflow_dispatch:", "canary dispatch trigger");
+  for (const scenario of CANARY_SCENARIOS) {
+    assertIncludes(workflow, `          - ${scenario}`, `canary ${scenario}`);
+  }
+
+  assertIncludes(workflow, "  contents: read", "contents permission");
+  assertIncludes(workflow, "  checks: read", "checks permission");
+  assertIncludes(workflow, "  actions: read", "actions permission");
+  assertIncludes(workflow, "  pull-requests: read", "pull-request permission");
+  assert(
+    !/^\s+[a-z-]+:\s*write\s*$/m.test(workflow),
+    "aggregate token permissions must remain read-only",
+  );
+  assert(
+    !workflow.includes("${{ secrets."),
+    "aggregate must not receive repository or organization secrets",
+  );
+
+  assertIncludes(workflow, "    name: Develop PR Gate", "stable job name");
+  assertIncludes(workflow, "    runs-on: ubuntu-24.04", "hosted runner");
+  assertIncludes(workflow, "    timeout-minutes: 45", "bounded timeout");
+  assertEqual(
+    count(workflow, /uses:\s*actions\/checkout@/g),
+    1,
+    "aggregate checkout count",
+  );
+  assertIncludes(workflow, TRUSTED_BASE_REF_LINE, "trusted base checkout ref");
+  assertIncludes(
+    workflow,
+    "persist-credentials: false",
+    "checkout credential isolation",
+  );
+  assert(
+    !workflow.includes("allow-unsafe-pr-checkout"),
+    "aggregate may never opt into an untrusted pull-request checkout",
+  );
+  assertIncludes(workflow, OBSERVED_HEAD_LINE, "PR head observation target");
+  assertIncludes(
+    workflow,
+    "node packages/scripts/develop-pr-aggregate.self-test.mjs",
+    "deterministic state-machine self-test",
+  );
+  assertIncludes(
+    workflow,
+    "node packages/scripts/develop-pr-aggregate.mjs",
+    "aggregate runner",
+  );
+  assertIncludes(
+    workflow,
+    DISPATCH_CANARY_LINE,
+    "dispatch-only canary boundary",
+  );
+}
+
+function validateOwnerWorkflow(text, workflowPath, expectedActions) {
+  const block = eventBlock(text, "pull_request", workflowPath);
+  const branches = inlineList(block, "branches", []);
+  assert(
+    branches.length === 0 || branches.includes("develop"),
+    `${workflowPath}: pull_request trigger does not cover develop`,
+  );
+  assert(
+    !/^\s+(paths|paths-ignore):/m.test(block),
+    `${workflowPath}: required owner may not disappear behind a path filter`,
+  );
+  assertEqual(
+    inlineList(block, "types", DEFAULT_PULL_REQUEST_ACTIONS),
+    expectedActions,
+    `${workflowPath}: modeled pull_request activity types`,
+  );
+}
+
+export function runContract(repoRoot = DEFAULT_REPO_ROOT) {
+  const read = (relativePath) =>
+    readFileSync(resolve(repoRoot, relativePath), "utf8");
+  const aggregateWorkflow = read(AGGREGATE_WORKFLOW);
+  validateAggregateWorkflow(aggregateWorkflow);
+
+  const checksByWorkflow = Map.groupBy(
+    REQUIRED_CHECKS,
+    ({ workflowPath }) => workflowPath,
+  );
+  for (const [workflowPath, checks] of checksByWorkflow) {
+    const workflow = read(workflowPath);
+    const expectedActions = checks[0].triggerActions;
+    for (const check of checks) {
+      assertEqual(
+        check.triggerActions,
+        expectedActions,
+        `${workflowPath}: contexts disagree about owner activity types`,
+      );
+      const marker =
+        check.context === "lint" ||
+        check.context === "typecheck" ||
+        check.context === "build" ||
+        check.context === "check-pr-evidence" ||
+        check.context === "check-pr-title"
+          ? `  ${check.context}:`
+          : `name: ${check.context}`;
+      assertIncludes(
+        workflow,
+        marker,
+        `${workflowPath}: owner for ${check.context}`,
+      );
+    }
+    validateOwnerWorkflow(workflow, workflowPath, expectedActions);
+  }
+
+  const contexts = REQUIRED_CHECKS.map(({ context }) => context);
+  assertEqual(
+    new Set(contexts).size,
+    contexts.length,
+    "required context names must be unique",
+  );
+  assert(
+    !contexts.includes("Develop PR Gate"),
+    "aggregate must not require its own check context",
+  );
+  return { ok: true, contexts };
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  const result = runContract();
+  console.log(
+    `develop-pr aggregate workflow contract passed (${result.contexts.length} contexts)`,
+  );
+}

--- a/packages/scripts/develop-pr-aggregate.mjs
+++ b/packages/scripts/develop-pr-aggregate.mjs
@@ -1,0 +1,545 @@
+#!/usr/bin/env node
+/**
+ * Fail-closed state machine for the hosted develop pull-request aggregate.
+ * The base-trusted workflow supplies the PR head SHA, while this module binds
+ * each required check to its owning workflow and waits for one terminal result
+ * per context. Missing and non-success terminal states never become green.
+ */
+import { writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+export const GITHUB_ACTIONS_APP_ID = 15368;
+export const DEFAULT_PULL_REQUEST_ACTIONS = [
+  "opened",
+  "synchronize",
+  "reopened",
+];
+
+const DEVELOP_PR_ACTIONS = [
+  "opened",
+  "synchronize",
+  "reopened",
+  "ready_for_review",
+];
+const PR_METADATA_ACTIONS = [
+  "opened",
+  "edited",
+  "synchronize",
+  "reopened",
+  "ready_for_review",
+  "labeled",
+  "unlabeled",
+];
+const STALE_BASE_ACTIONS = [
+  "opened",
+  "synchronize",
+  "reopened",
+  "ready_for_review",
+  "labeled",
+  "unlabeled",
+];
+
+export const REQUIRED_CHECKS = Object.freeze([
+  {
+    context: "Test Integrity (lane coverage)",
+    workflowPath: ".github/workflows/develop-pr.yml",
+    triggerActions: DEVELOP_PR_ACTIONS,
+  },
+  {
+    context: "lint",
+    workflowPath: ".github/workflows/develop-pr.yml",
+    triggerActions: DEVELOP_PR_ACTIONS,
+  },
+  {
+    context: "typecheck",
+    workflowPath: ".github/workflows/develop-pr.yml",
+    triggerActions: DEVELOP_PR_ACTIONS,
+  },
+  {
+    context: "build",
+    workflowPath: ".github/workflows/develop-pr.yml",
+    triggerActions: DEVELOP_PR_ACTIONS,
+  },
+  {
+    context: "gitleaks",
+    workflowPath: ".github/workflows/gitleaks.yml",
+    triggerActions: DEFAULT_PULL_REQUEST_ACTIONS,
+  },
+  {
+    context: "coverage on changed files",
+    workflowPath: ".github/workflows/coverage-gate.yml",
+    triggerActions: DEFAULT_PULL_REQUEST_ACTIONS,
+  },
+  {
+    context: "check-pr-evidence",
+    workflowPath: ".github/workflows/pr.yaml",
+    triggerActions: PR_METADATA_ACTIONS,
+  },
+  {
+    context: "check-pr-title",
+    workflowPath: ".github/workflows/pr.yaml",
+    triggerActions: PR_METADATA_ACTIONS,
+  },
+  {
+    context: "stale-base guard",
+    workflowPath: ".github/workflows/stale-base-guard.yml",
+    triggerActions: STALE_BASE_ACTIONS,
+  },
+]);
+
+export const AGGREGATE_TRIGGER_ACTIONS = Object.freeze(
+  Array.from(
+    new Set(REQUIRED_CHECKS.flatMap(({ triggerActions }) => triggerActions)),
+  ),
+);
+
+export const CANARY_SCENARIOS = Object.freeze([
+  "success",
+  "missing",
+  "cancelled",
+  "timed-out",
+  "failed",
+  "skipped",
+  "pending-timeout",
+]);
+
+const SUCCESS_CONCLUSION = "success";
+const COMPLETED_STATUS = "completed";
+const API_VERSION = "2022-11-28";
+const PAGE_SIZE = 100;
+const MAX_PAGES = 10;
+const FRESHNESS_SKEW_MS = 10_000;
+const DEFAULT_TERMINAL_SETTLE_MS = 15_000;
+
+function parseTimestamp(value) {
+  if (typeof value !== "string" || value.length === 0) return null;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function latestById(runs) {
+  return runs.reduce(
+    (latest, run) =>
+      latest === null || Number(run.id) > Number(latest.id) ? run : latest,
+    null,
+  );
+}
+
+function detailForRun(run) {
+  return run.details_url || `check-run ${run.id}`;
+}
+
+function waitingResult(required, code, detail, run = null) {
+  return {
+    ...required,
+    state: "waiting",
+    code,
+    detail,
+    url: run?.details_url ?? null,
+  };
+}
+
+function failedResult(required, code, detail, run = null) {
+  return {
+    ...required,
+    state: "failed",
+    code,
+    detail,
+    url: run?.details_url ?? null,
+  };
+}
+
+/**
+ * Evaluates one API snapshot. Callers decide when the polling deadline has
+ * elapsed; before then, missing/queued/stale observations remain waiting.
+ */
+export function evaluateAggregate({
+  checkRuns,
+  headSha,
+  eventAction,
+  eventUpdatedAt,
+  nowMs,
+  deadlineReached = false,
+  terminalSettleMs = DEFAULT_TERMINAL_SETTLE_MS,
+}) {
+  const eventUpdatedMs = parseTimestamp(eventUpdatedAt);
+  const freshAfterMs =
+    eventUpdatedMs === null ? null : eventUpdatedMs - FRESHNESS_SKEW_MS;
+
+  const results = REQUIRED_CHECKS.map((required) => {
+    const candidates = checkRuns.filter(
+      (run) =>
+        run.name === required.context &&
+        Number(run.app_id) === GITHUB_ACTIONS_APP_ID &&
+        run.workflow_path === required.workflowPath &&
+        run.workflow_event === "pull_request" &&
+        run.workflow_head_sha === headSha,
+    );
+    const run = latestById(candidates);
+
+    if (run === null) {
+      const detail = `no GitHub Actions check run from ${required.workflowPath}`;
+      return deadlineReached
+        ? failedResult(required, "missing", detail)
+        : waitingResult(required, "missing", detail);
+    }
+
+    const freshRunRequired = required.triggerActions.includes(eventAction);
+    const startedMs = parseTimestamp(run.started_at);
+    if (
+      freshRunRequired &&
+      (freshAfterMs === null || startedMs === null || startedMs < freshAfterMs)
+    ) {
+      const detail = `latest owner run predates ${eventAction} event`;
+      return deadlineReached
+        ? failedResult(required, "stale-event-result", detail, run)
+        : waitingResult(required, "stale-event-result", detail, run);
+    }
+
+    if (run.status !== COMPLETED_STATUS) {
+      const detail = `${detailForRun(run)} is ${run.status || "unknown"}`;
+      return deadlineReached
+        ? failedResult(required, "pending-timeout", detail, run)
+        : waitingResult(required, "pending", detail, run);
+    }
+
+    if (run.conclusion === SUCCESS_CONCLUSION) {
+      return {
+        ...required,
+        state: "passed",
+        code: "success",
+        detail: `${detailForRun(run)} concluded success`,
+        url: run.details_url ?? null,
+      };
+    }
+
+    const completedMs = parseTimestamp(run.completed_at);
+    if (
+      !deadlineReached &&
+      completedMs !== null &&
+      nowMs - completedMs < terminalSettleMs
+    ) {
+      return waitingResult(
+        required,
+        "terminal-settling",
+        `${detailForRun(run)} concluded ${run.conclusion || "unknown"}; waiting briefly for a superseding rerun`,
+        run,
+      );
+    }
+
+    if (run.conclusion === "skipped") {
+      return failedResult(
+        required,
+        "skipped-forbidden",
+        `${detailForRun(run)} was skipped; required workflows must classify paths inside an always-emitted job`,
+        run,
+      );
+    }
+
+    return failedResult(
+      required,
+      `terminal-${run.conclusion || "unknown"}`,
+      `${detailForRun(run)} concluded ${run.conclusion || "unknown"}`,
+      run,
+    );
+  });
+
+  const failed = results.filter(({ state }) => state === "failed");
+  const waiting = results.filter(({ state }) => state === "waiting");
+  return {
+    verdict:
+      failed.length > 0
+        ? "failure"
+        : waiting.length > 0
+          ? "waiting"
+          : "success",
+    results,
+    counts: {
+      passed: results.length - failed.length - waiting.length,
+      waiting: waiting.length,
+      failed: failed.length,
+    },
+  };
+}
+
+function extractWorkflowRunId(detailsUrl) {
+  if (typeof detailsUrl !== "string") return null;
+  const match = detailsUrl.match(/\/actions\/runs\/(\d+)\/job\/\d+/);
+  return match ? Number(match[1]) : null;
+}
+
+function apiHeaders(token) {
+  return {
+    Accept: "application/vnd.github+json",
+    Authorization: `Bearer ${token}`,
+    "User-Agent": "elizaOS-develop-pr-aggregate",
+    "X-GitHub-Api-Version": API_VERSION,
+  };
+}
+
+async function requestJson(url, token) {
+  const response = await fetch(url, { headers: apiHeaders(token) });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `GitHub API ${response.status} for ${url}: ${body.slice(0, 500)}`,
+    );
+  }
+  return response.json();
+}
+
+export async function loadOwnedCheckRuns({
+  repository,
+  headSha,
+  token,
+  workflowRunCache = new Map(),
+}) {
+  const requiredNames = new Set(REQUIRED_CHECKS.map(({ context }) => context));
+  const rawRuns = [];
+
+  for (let page = 1; page <= MAX_PAGES; page += 1) {
+    const url =
+      `https://api.github.com/repos/${repository}/commits/${headSha}/check-runs` +
+      `?filter=all&per_page=${PAGE_SIZE}&page=${page}&app_id=${GITHUB_ACTIONS_APP_ID}`;
+    const payload = await requestJson(url, token);
+    const pageRuns = Array.isArray(payload.check_runs)
+      ? payload.check_runs
+      : [];
+    rawRuns.push(...pageRuns.filter(({ name }) => requiredNames.has(name)));
+    // total_count covers every Actions check on the commit, while rawRuns is
+    // intentionally narrowed to required names. Page fullness is therefore
+    // the reliable pagination boundary for this filtered in-memory set.
+    if (pageRuns.length < PAGE_SIZE) {
+      break;
+    }
+  }
+
+  const runIds = new Set(
+    rawRuns
+      .map(({ details_url: detailsUrl }) => extractWorkflowRunId(detailsUrl))
+      .filter((runId) => runId !== null),
+  );
+  for (const runId of runIds) {
+    if (workflowRunCache.has(runId)) continue;
+    const workflowRun = await requestJson(
+      `https://api.github.com/repos/${repository}/actions/runs/${runId}`,
+      token,
+    );
+    workflowRunCache.set(runId, {
+      path: workflowRun.path,
+      event: workflowRun.event,
+      headSha: workflowRun.head_sha,
+    });
+  }
+
+  return rawRuns.map((run) => {
+    const workflowRunId = extractWorkflowRunId(run.details_url);
+    const owner =
+      workflowRunId === null ? null : workflowRunCache.get(workflowRunId);
+    return {
+      ...run,
+      app_id: run.app?.id,
+      workflow_path: owner?.path ?? null,
+      workflow_event: owner?.event ?? null,
+      workflow_head_sha: owner?.headSha ?? null,
+    };
+  });
+}
+
+function escapeCell(value) {
+  return String(value).replaceAll("|", "\\|").replaceAll("\n", " ");
+}
+
+export function renderSummary(evaluation, { headSha, eventAction, attempt }) {
+  const lines = [
+    "### Develop PR Gate",
+    "",
+    `- Head SHA: \`${headSha}\``,
+    `- Pull-request action: \`${eventAction}\``,
+    `- Poll attempt: ${attempt}`,
+    `- Verdict: **${evaluation.verdict}**`,
+    `- Passed / waiting / failed: ${evaluation.counts.passed} / ${evaluation.counts.waiting} / ${evaluation.counts.failed}`,
+    "",
+    "| Required context | Owning workflow | State | Detail |",
+    "| --- | --- | --- | --- |",
+  ];
+  for (const result of evaluation.results) {
+    const detail = result.url
+      ? `[${escapeCell(result.detail)}](${result.url})`
+      : escapeCell(result.detail);
+    lines.push(
+      `| ${escapeCell(result.context)} | \`${escapeCell(result.workflowPath)}\` | ${result.state} | ${detail} |`,
+    );
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function writeSummary(summary) {
+  // biome-ignore lint/suspicious/noUndeclaredEnvVars: GitHub creates this per-job file outside Turbo's cache contract.
+  const path = process.env.GITHUB_STEP_SUMMARY;
+  if (path) writeFileSync(path, summary);
+}
+
+function positiveInteger(value, name, fallback) {
+  const resolved = value === undefined || value === "" ? fallback : value;
+  if (!/^\d+$/.test(String(resolved)) || Number(resolved) <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return Number(resolved);
+}
+
+function validateProductionEnvironment(env) {
+  if (env.AGGREGATE_EVENT_NAME !== "pull_request_target") {
+    throw new Error("production aggregate requires pull_request_target");
+  }
+  if (!/^\d+$/.test(env.PR_NUMBER ?? "")) {
+    throw new Error("PR_NUMBER must be a pull request number");
+  }
+  if (!/^[0-9a-f]{40}$/.test(env.HEAD_SHA ?? "")) {
+    throw new Error("HEAD_SHA must be a full commit SHA");
+  }
+  if (!/^[^/]+\/[^/]+$/.test(env.GITHUB_REPOSITORY ?? "")) {
+    throw new Error("GITHUB_REPOSITORY must be owner/repository");
+  }
+  if (!AGGREGATE_TRIGGER_ACTIONS.includes(env.PR_ACTION)) {
+    throw new Error(`unsupported pull-request action: ${env.PR_ACTION}`);
+  }
+  if (parseTimestamp(env.PR_UPDATED_AT) === null) {
+    throw new Error("PR_UPDATED_AT must be an ISO timestamp");
+  }
+  if (!env.GITHUB_TOKEN) throw new Error("GITHUB_TOKEN is required");
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function buildCanaryCheckRuns(scenario, nowMs) {
+  if (!CANARY_SCENARIOS.includes(scenario)) {
+    throw new Error(`unsupported canary scenario: ${scenario}`);
+  }
+  const startedAt = new Date(nowMs - 60_000).toISOString();
+  const completedAt = new Date(nowMs - 30_000).toISOString();
+  const runs = REQUIRED_CHECKS.map((required, index) => ({
+    id: 10_000 + index,
+    name: required.context,
+    app_id: GITHUB_ACTIONS_APP_ID,
+    workflow_path: required.workflowPath,
+    workflow_event: "pull_request",
+    workflow_head_sha: "a".repeat(40),
+    status: COMPLETED_STATUS,
+    conclusion: SUCCESS_CONCLUSION,
+    started_at: startedAt,
+    completed_at: completedAt,
+    details_url: `https://github.example/actions/runs/1/job/${10_000 + index}`,
+  }));
+  const targetIndex = runs.findIndex(({ name }) => name === "gitleaks");
+  if (scenario === "missing") runs.splice(targetIndex, 1);
+  if (scenario === "cancelled") runs[targetIndex].conclusion = "cancelled";
+  if (scenario === "timed-out") runs[targetIndex].conclusion = "timed_out";
+  if (scenario === "failed") runs[targetIndex].conclusion = "failure";
+  if (scenario === "skipped") runs[targetIndex].conclusion = "skipped";
+  if (scenario === "pending-timeout") {
+    runs[targetIndex].status = "in_progress";
+    runs[targetIndex].conclusion = null;
+    runs[targetIndex].completed_at = null;
+  }
+  return runs;
+}
+
+async function runCanary(scenario) {
+  const nowMs = Date.now();
+  const evaluation = evaluateAggregate({
+    checkRuns: buildCanaryCheckRuns(scenario, nowMs),
+    headSha: "a".repeat(40),
+    eventAction: "synchronize",
+    eventUpdatedAt: new Date(nowMs - 90_000).toISOString(),
+    nowMs,
+    deadlineReached: true,
+    terminalSettleMs: 0,
+  });
+  const summary = renderSummary(evaluation, {
+    headSha: "synthetic-canary",
+    eventAction: scenario,
+    attempt: 1,
+  });
+  writeSummary(summary);
+  console.log(summary);
+  return evaluation.verdict === "success" ? 0 : 1;
+}
+
+async function runProduction(env) {
+  validateProductionEnvironment(env);
+  const timeoutSeconds = positiveInteger(
+    env.POLL_TIMEOUT_SECONDS,
+    "POLL_TIMEOUT_SECONDS",
+    2_400,
+  );
+  const intervalSeconds = positiveInteger(
+    env.POLL_INTERVAL_SECONDS,
+    "POLL_INTERVAL_SECONDS",
+    30,
+  );
+  const deadlineMs = Date.now() + timeoutSeconds * 1_000;
+  const workflowRunCache = new Map();
+  let attempt = 1;
+
+  while (true) {
+    const nowMs = Date.now();
+    const checkRuns = await loadOwnedCheckRuns({
+      repository: env.GITHUB_REPOSITORY,
+      headSha: env.HEAD_SHA,
+      token: env.GITHUB_TOKEN,
+      workflowRunCache,
+    });
+    const deadlineReached = nowMs >= deadlineMs;
+    const evaluation = evaluateAggregate({
+      checkRuns,
+      headSha: env.HEAD_SHA,
+      eventAction: env.PR_ACTION,
+      eventUpdatedAt: env.PR_UPDATED_AT,
+      nowMs,
+      deadlineReached,
+    });
+    const summary = renderSummary(evaluation, {
+      headSha: env.HEAD_SHA,
+      eventAction: env.PR_ACTION,
+      attempt,
+    });
+    writeSummary(summary);
+    console.log(
+      `Develop PR Gate poll ${attempt}: passed=${evaluation.counts.passed} waiting=${evaluation.counts.waiting} failed=${evaluation.counts.failed}`,
+    );
+    for (const result of evaluation.results) {
+      console.log(
+        `${result.state.toUpperCase()} ${result.context}: ${result.detail}`,
+      );
+    }
+
+    if (evaluation.verdict === "success") return 0;
+    if (evaluation.verdict === "failure") return 1;
+
+    attempt += 1;
+    await sleep(
+      Math.min(intervalSeconds * 1_000, Math.max(1, deadlineMs - nowMs)),
+    );
+  }
+}
+
+export async function main(env = process.env) {
+  const canary = env.CANARY_SCENARIO;
+  if (canary) {
+    if (env.AGGREGATE_EVENT_NAME !== "workflow_dispatch") {
+      throw new Error("canary scenarios are restricted to workflow_dispatch");
+    }
+    return runCanary(canary);
+  }
+  return runProduction(env);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  process.exitCode = await main();
+}

--- a/packages/scripts/develop-pr-aggregate.self-test.mjs
+++ b/packages/scripts/develop-pr-aggregate.self-test.mjs
@@ -86,6 +86,26 @@ for (const [scenario, code] of [
   assert.equal(resultFor(evaluation, "gitleaks").code, code, scenario);
 }
 
+// Every remaining GitHub conclusion that is neither success nor skipped must
+// still fail closed through the generic terminal branch, so an unexpected or
+// future conclusion string can never be mistaken for a pass.
+for (const conclusion of [
+  "neutral",
+  "action_required",
+  "startup_failure",
+  "stale",
+]) {
+  const runs = successRuns();
+  runs.find(({ name }) => name === "gitleaks").conclusion = conclusion;
+  const evaluation = evaluate(runs, { deadlineReached: true });
+  assert.equal(evaluation.verdict, "failure", conclusion);
+  assert.equal(
+    resultFor(evaluation, "gitleaks").code,
+    `terminal-${conclusion}`,
+    conclusion,
+  );
+}
+
 const settlingRuns = buildCanaryCheckRuns("cancelled", NOW_MS);
 const cancelled = settlingRuns.find(({ name }) => name === "gitleaks");
 cancelled.completed_at = new Date(NOW_MS - 5_000).toISOString();

--- a/packages/scripts/develop-pr-aggregate.self-test.mjs
+++ b/packages/scripts/develop-pr-aggregate.self-test.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+/**
+ * Deterministic contract tests for the develop PR aggregate state machine and
+ * its base-trusted workflow. Synthetic check snapshots cover every terminal
+ * class without calling GitHub or waiting for real runner timeouts.
+ */
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import {
+  buildCanaryCheckRuns,
+  CANARY_SCENARIOS,
+  evaluateAggregate,
+  GITHUB_ACTIONS_APP_ID,
+  REQUIRED_CHECKS,
+  renderSummary,
+} from "./develop-pr-aggregate.mjs";
+import {
+  OBSERVED_HEAD_LINE,
+  runContract,
+  TRUSTED_BASE_REF_LINE,
+  validateAggregateWorkflow,
+} from "./develop-pr-aggregate-workflow-contract.mjs";
+
+const NOW_MS = Date.parse("2026-07-14T01:00:00Z");
+const HEAD_SHA = "a".repeat(40);
+const EVENT_UPDATED_AT = new Date(NOW_MS - 90_000).toISOString();
+
+function evaluate(checkRuns, overrides = {}) {
+  return evaluateAggregate({
+    checkRuns,
+    headSha: HEAD_SHA,
+    eventAction: "synchronize",
+    eventUpdatedAt: EVENT_UPDATED_AT,
+    nowMs: NOW_MS,
+    terminalSettleMs: 0,
+    ...overrides,
+  });
+}
+
+function successRuns() {
+  return buildCanaryCheckRuns("success", NOW_MS);
+}
+
+function resultFor(evaluation, context) {
+  const result = evaluation.results.find((entry) => entry.context === context);
+  assert(result, `missing result for ${context}`);
+  return result;
+}
+
+const allGreen = evaluate(successRuns());
+assert.equal(allGreen.verdict, "success");
+assert.deepEqual(allGreen.counts, { passed: 9, waiting: 0, failed: 0 });
+
+const missingBeforeDeadline = evaluate(buildCanaryCheckRuns("missing", NOW_MS));
+assert.equal(missingBeforeDeadline.verdict, "waiting");
+assert.equal(resultFor(missingBeforeDeadline, "gitleaks").code, "missing");
+const missingAtDeadline = evaluate(buildCanaryCheckRuns("missing", NOW_MS), {
+  deadlineReached: true,
+});
+assert.equal(missingAtDeadline.verdict, "failure");
+assert.equal(resultFor(missingAtDeadline, "gitleaks").code, "missing");
+
+const pendingBeforeDeadline = evaluate(
+  buildCanaryCheckRuns("pending-timeout", NOW_MS),
+);
+assert.equal(pendingBeforeDeadline.verdict, "waiting");
+assert.equal(resultFor(pendingBeforeDeadline, "gitleaks").code, "pending");
+const pendingAtDeadline = evaluate(
+  buildCanaryCheckRuns("pending-timeout", NOW_MS),
+  { deadlineReached: true },
+);
+assert.equal(pendingAtDeadline.verdict, "failure");
+assert.equal(resultFor(pendingAtDeadline, "gitleaks").code, "pending-timeout");
+
+for (const [scenario, code] of [
+  ["cancelled", "terminal-cancelled"],
+  ["timed-out", "terminal-timed_out"],
+  ["failed", "terminal-failure"],
+  ["skipped", "skipped-forbidden"],
+]) {
+  const evaluation = evaluate(buildCanaryCheckRuns(scenario, NOW_MS), {
+    deadlineReached: true,
+  });
+  assert.equal(evaluation.verdict, "failure", scenario);
+  assert.equal(resultFor(evaluation, "gitleaks").code, code, scenario);
+}
+
+const settlingRuns = buildCanaryCheckRuns("cancelled", NOW_MS);
+const cancelled = settlingRuns.find(({ name }) => name === "gitleaks");
+cancelled.completed_at = new Date(NOW_MS - 5_000).toISOString();
+const settling = evaluate(settlingRuns, { terminalSettleMs: 15_000 });
+assert.equal(settling.verdict, "waiting");
+assert.equal(resultFor(settling, "gitleaks").code, "terminal-settling");
+
+const rerunRuns = buildCanaryCheckRuns("failed", NOW_MS);
+const oldFailure = rerunRuns.find(({ name }) => name === "gitleaks");
+rerunRuns.push({
+  ...oldFailure,
+  id: Number(oldFailure.id) + 10_000,
+  conclusion: "success",
+});
+assert.equal(evaluate(rerunRuns).verdict, "success");
+
+const wrongOwnerRuns = successRuns();
+const wrongOwner = wrongOwnerRuns.find(({ name }) => name === "gitleaks");
+wrongOwner.workflow_path = ".github/workflows/untrusted.yml";
+const wrongOwnerEvaluation = evaluate(wrongOwnerRuns);
+assert.equal(wrongOwnerEvaluation.verdict, "waiting");
+assert.equal(resultFor(wrongOwnerEvaluation, "gitleaks").code, "missing");
+
+const wrongAppRuns = successRuns();
+wrongAppRuns.find(({ name }) => name === "gitleaks").app_id =
+  GITHUB_ACTIONS_APP_ID + 1;
+assert.equal(resultFor(evaluate(wrongAppRuns), "gitleaks").code, "missing");
+
+const editedRuns = successRuns();
+const editedStale = evaluate(editedRuns, {
+  eventAction: "edited",
+  eventUpdatedAt: new Date(NOW_MS - 10_000).toISOString(),
+});
+assert.equal(editedStale.verdict, "waiting");
+assert.equal(editedStale.counts.waiting, 2);
+assert.equal(resultFor(editedStale, "lint").state, "passed");
+for (const context of ["check-pr-evidence", "check-pr-title"]) {
+  const oldRun = editedRuns.find(({ name }) => name === context);
+  editedRuns.push({
+    ...oldRun,
+    id: Number(oldRun.id) + 20_000,
+    started_at: new Date(NOW_MS - 5_000).toISOString(),
+    completed_at: new Date(NOW_MS - 1_000).toISOString(),
+  });
+}
+assert.equal(
+  evaluate(editedRuns, {
+    eventAction: "edited",
+    eventUpdatedAt: new Date(NOW_MS - 10_000).toISOString(),
+  }).verdict,
+  "success",
+);
+
+const contexts = REQUIRED_CHECKS.map(({ context }) => context);
+assert.equal(new Set(contexts).size, contexts.length);
+assert(!contexts.includes("Develop PR Gate"));
+assert.deepEqual(CANARY_SCENARIOS, [
+  "success",
+  "missing",
+  "cancelled",
+  "timed-out",
+  "failed",
+  "skipped",
+  "pending-timeout",
+]);
+
+const summary = renderSummary(allGreen, {
+  headSha: HEAD_SHA,
+  eventAction: "synchronize",
+  attempt: 1,
+});
+assert.match(summary, /Verdict: \*\*success\*\*/);
+assert.match(summary, /coverage on changed files/);
+
+const workflowPath = fileURLToPath(
+  new URL("../../.github/workflows/develop-pr-gate.yml", import.meta.url),
+);
+const workflow = readFileSync(workflowPath, "utf8");
+validateAggregateWorkflow(workflow);
+assert.throws(
+  () =>
+    validateAggregateWorkflow(
+      workflow.replace("  pull_request_target:", "  pull_request:"),
+    ),
+  /pull_request_target|PR-controlled/,
+);
+assert.throws(
+  () =>
+    validateAggregateWorkflow(
+      workflow.replace("  checks: read", "  checks: write"),
+    ),
+  /checks permission|read-only/,
+);
+assert.throws(
+  () =>
+    validateAggregateWorkflow(
+      workflow.replace(
+        TRUSTED_BASE_REF_LINE,
+        OBSERVED_HEAD_LINE.replace("HEAD_SHA: ", "ref: "),
+      ),
+    ),
+  /trusted base checkout ref/,
+);
+assert.throws(
+  () =>
+    validateAggregateWorkflow(
+      workflow.replace(
+        "    types: [opened, synchronize, reopened, ready_for_review, edited, labeled, unlabeled]",
+        "    types: [opened, synchronize]",
+      ),
+    ),
+  /aggregate activity types/,
+);
+
+assert.deepEqual(runContract(), { ok: true, contexts });
+console.log("develop-pr aggregate self-test passed");

--- a/packages/scripts/develop-pr-aggregate.test.mjs
+++ b/packages/scripts/develop-pr-aggregate.test.mjs
@@ -1,0 +1,10 @@
+/**
+ * Bun coverage entrypoint for the deterministic develop PR aggregate contract.
+ * The same assertions run directly under Node in the bootstrap integrity lane;
+ * this wrapper lets the changed-file gate measure the implementation they load.
+ */
+import { test } from "bun:test";
+
+test("develop PR aggregate contract", async () => {
+  await import("./develop-pr-aggregate.self-test.mjs");
+});

--- a/scripts/security/coverage-node-self-tests.txt
+++ b/scripts/security/coverage-node-self-tests.txt
@@ -1,4 +1,5 @@
 packages/scripts/ci-path-gate.self-test.mjs
+packages/scripts/develop-pr-aggregate.self-test.mjs
 packages/scripts/test-cloud-run-flush.self-test.mjs
 scripts/security/coverage-changed-files.self-test.mjs
 scripts/security/coverage-gate.self-test.mjs


### PR DESCRIPTION
# Relates to

Closes #16217.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the state-machine behavior from the deterministic
      receipts and real GitHub check-run links below.

# Sync with develop

- [x] Exact head `e783661450cb8c259595ef6e841a67b3637513df` is based on
      `origin/develop` `4f766c5b71f16f0a143e495b7fb19f09cd1e67f8`; zero conflicts.
- [x] Full `bun run verify` passed after `bun install` (573/573 Turbo
      lint/typecheck tasks, all audits, and 28/28 dist-path consumers).

# Risks

Medium: this introduces the future stable merge-gate context. The aggregate is
base-trusted, read-only, hosted, bounded to 45 minutes, and never checks out PR
code. It binds every observed check to the GitHub Actions app, exact owning
workflow path, `pull_request` event, and current PR head SHA.

This PR does **not** mutate ruleset `18901247`. The existing nine no-bypass
required contexts remain authoritative throughout bootstrap and live canaries.

# Background

## What does this PR do?

Adds one always-emitted `Develop PR Gate` check for PRs targeting `develop`.
It polls the nine existing lightweight required contexts and passes only when
all nine have a current, owner-bound terminal `success`. Missing, stale,
pending past the poll budget, cancelled, timed out, failed, neutral, action
required, and skipped results fail closed. Owner workflows may classify
non-applicable work inside an always-emitted successful job; disappearing
behind a path filter is forbidden by the static workflow contract.

The workflow uses `pull_request_target` only as a trusted orchestration
boundary: it checks out `pull_request.base.sha`, has read-only permissions, has
no secrets, and observes check metadata for `pull_request.head.sha`. The new
self-test is also wired into the already-required `Test Integrity (lane
coverage)` job so this bootstrap PR validates the proposed implementation even
though a newly-added base-trusted workflow cannot execute until it exists on
the base branch.

The workflow README now distinguishes the lightweight pre-merge surface from
the exhaustive post-merge suites and the push-only `ci-ok` roll-up.

## What kind of change is this?

Bug fix / CI enforcement improvement.

# Documentation changes needed?

Updated `.github/workflows/README.md` with the current pre-merge and post-merge
ownership model.

# Testing

## Where should a reviewer start?

1. `packages/scripts/develop-pr-aggregate.self-test.mjs` — deterministic state
   transitions and trust-boundary tamper cases.
2. `.github/workflows/develop-pr-gate.yml` — stable hosted orchestration
   boundary.
3. `packages/scripts/develop-pr-aggregate-workflow-contract.mjs` — exact owner,
   trigger, path-filter, permissions, and checkout contracts.

## Detailed testing steps

```text
node packages/scripts/develop-pr-aggregate.self-test.mjs
  develop-pr aggregate self-test passed

node packages/scripts/develop-pr-aggregate-workflow-contract.mjs
  develop-pr aggregate workflow contract passed (9 contexts)

actionlint .github/workflows/develop-pr-gate.yml .github/workflows/develop-pr.yml
  exit 0

bunx @biomejs/biome check packages/scripts/develop-pr-aggregate.mjs \
  packages/scripts/develop-pr-aggregate-workflow-contract.mjs \
  packages/scripts/develop-pr-aggregate.self-test.mjs
  Checked 3 files. No fixes applied.

node packages/scripts/audit-scripts.mjs --json
  {"ok":true,"failures":[]}

git diff --check
  exit 0

bun install
  exit 0; 8859 packages installed

bun run verify
  exit 0; 573/573 uncached Turbo tasks and 28/28 dist-path consumers passed

bun test packages/scripts/develop-pr-aggregate.test.mjs --coverage
  1 pass; contract 97.54%, implementation 60.85%; enforced floor 50%
```

Deterministic terminal-state receipt at this exact head:

| Scenario | Expected aggregate | Observed |
| --- | --- | --- |
| all nine success | success | success / exit 0 |
| owner-bound context missing at deadline | failure | `missing` |
| context remains in progress at deadline | failure | `pending-timeout` |
| cancelled | failure | `terminal-cancelled` |
| timed out | failure | `terminal-timed_out` |
| failed | failure | `terminal-failure` |
| skipped/path-disappeared | failure | `skipped-forbidden` |
| wrong workflow path or wrong app | wait, then fail missing | observed |
| stale result after an event that reruns its owner | wait, then fail stale | observed |
| newer successful rerun supersedes an old failure | success | observed |

Real GitHub baseline canaries for the same nine source contexts are preserved
in #13306: [green #16321](https://github.com/elizaOS/eliza/pull/16321/checks)
reached 9/9 success, including the
[zero-file coverage job](https://github.com/elizaOS/eliza/actions/runs/29298277609/job/86976439814);
[red #16322](https://github.com/elizaOS/eliza/pull/16322) was blocked by the
[failed title job](https://github.com/elizaOS/eliza/actions/runs/29298342833/job/86976635515).

## Post-merge aggregate canaries and migration (required before ruleset mutation)

1. Dispatch `develop-pr-gate.yml` on `develop` once for each synthetic
   `success`, `missing`, `cancelled`, `timed-out`, `failed`, `skipped`, and
   `pending-timeout` scenario. Only `success` may conclude success.
2. Open aggregate-specific green and deliberately red PR canaries. Confirm the
   aggregate observes real owner checks and that the red source lane makes the
   aggregate red.
3. Add `Develop PR Gate` to ruleset `18901247` **alongside** the existing nine
   contexts. Confirm a PR is blocked while it is missing/pending and becomes
   mergeable only after both old and new gates pass.
4. Only after those receipts, replace the nine individual required contexts
   with the aggregate. At no point is the rule open or bypassable.

Rollback is the reverse, fail-closed sequence: restore the captured nine
individual contexts alongside the aggregate first, verify effective-rule
readback and a green PR, then remove the aggregate context. If the aggregate
is unhealthy, leave the old nine in force. Never delete/disable the ruleset;
its `bypass_actors: []`, PR, deletion, and non-fast-forward rules remain
unchanged.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered product or GitHub configuration UI changed; the before
      state is the API-backed nine-context ruleset receipt in #13306.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changed; workflow/check conclusions and ruleset API
      readback are the authoritative artifacts.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this is a CI metadata state machine; linked Actions runs and the
      deterministic scenario matrix are the reproducible walkthrough.
<!-- evidence-row:backend-logs -->
- [x] N/A - no elizaOS backend changed; GitHub Actions logs and API outcomes are
      the relevant transport-boundary logs and are linked above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime, request, or state changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Exact-head commit](https://github.com/elizaOS/eliza/commit/e783661450cb8c259595ef6e841a67b3637513df),
      [workflow/check baseline canaries](https://github.com/elizaOS/eliza/issues/13306#issuecomment-4964560078),
      and this PR's exact-head check runs are the domain artifacts.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM behavior changed.

## Backend + frontend logs

N/A - no application backend/frontend path changed. GitHub Actions is the
system boundary; exact runs are linked in Testing and will be reviewed on this
PR before readiness.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI changed.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

- The `pull_request_target` aggregate cannot execute on the PR that first adds
  it because the trusted base does not contain it. The existing required lane
  executes its complete self-test/contract on this PR; live aggregate dispatch
  and PR canaries happen after merge and before any ruleset mutation.
- A historical replay attempted after #16321/#16322 source branches were
  deleted returned GitHub API 422 because their head SHAs were no longer
  reachable refs. Their permanent Actions job URLs and ruleset results remain
  linked above; this is not a product or test failure.