### PR TITLE
fix(audit): distinguish unreadable OCR from blank pixels

### DIFF
--- a/packages/app/scripts/OCR_TRIAGE.md
+++ b/packages/app/scripts/OCR_TRIAGE.md
@@ -14,6 +14,23 @@ and cross-checks the result against the DOM verdict already in `report.json`.
 The OCR engine is installed by the normal workspace `bun install`; if it is
 missing or cannot initialize, the gate fails instead of skipping the check.
 
+OCR silence is not proof of blank pixels. The shared evidence primitive first
+runs whole-page OCR and retains its transcript and mean confidence. A weak pass
+(fewer than two words or below 45% confidence) gets one deterministic retry:
+the image is enlarged up to 3×/2400 px, converted to normalized grayscale,
+sharpened, thresholded at 225, and read with sparse-text segmentation. The raw
+transcript/confidence for both attempts and the selected mode are written to the
+triage report. Separately, downsampled pixel analysis proves blank frames only
+when they have no opaque samples or a single quantized color. Low-confidence OCR
+on a visually populated frame is `needs-eyeball`, never “pixels are blank.”
+
+This split is load-bearing for icon-heavy mobile launchers (#16327). On the
+390×844 reproduction, default packaged Tesseract returned only `oY)` at 40%
+confidence. The high-contrast sparse pass recovered 49 words at 72% confidence,
+including the launcher labels, while pixel analysis measured 210 color buckets
+and a 33.7% dominant-color ratio. A slug exemption would also hide a truly blank
+launcher; the evidence-driven split keeps that failure armed.
+
 ## What it produces
 
 - **Verifications** — a view whose pixels contain every label it's supposed to
@@ -29,8 +46,8 @@ missing or cannot initialize, the gate fails instead of skipping the check.
 
 | File | Role |
 |------|------|
-| `scripts/mvp-visual-verify/ocr.mjs` | Shared OCR engine resolver. Prefers packaged `tesseract.js`, with an explicit system `tesseract` fallback for debugging. |
-| `test/ui-smoke/ocr-content-rules.ts` | Pure, dependency-free verdict rules (blank / dev-string / placeholder / expectation). Unit-tested; no OCR engine, no `page`, no fs. |
+| `scripts/mvp-visual-verify/ocr.mjs` | Shared OCR engine and pixel-diagnostic exports. Prefers packaged `tesseract.js`, with an explicit system `tesseract` fallback for debugging. |
+| `test/ui-smoke/ocr-content-rules.ts` | Pure, dependency-free verdict rules (proven blank / inconclusive OCR / dev-string / placeholder / expectation). Unit-tested; no OCR engine, no `page`, no fs. |
 | `test/ui-smoke/ocr-view-expectations.ts` | Per-builtin-view expectation manifest (required/forbidden on-screen labels), seeded from the real OCR of a healthy capture. |
 | `test/ui-smoke/ocr-triage-baseline.json` | `slug::viewport` of pixel-broken renders already tracked by an issue. Ratchet posture: known debt is reported but non-gating; a NEW pixel-broken render fails the gate. |
 | `scripts/ocr-triage.ts` | CLI: OCRs a capture dir, applies the rules, cross-checks `report.json`, writes `ocr-triage.json`, exits non-zero on a new regression. |

--- a/packages/app/scripts/lib/visual-qa.test.ts
+++ b/packages/app/scripts/lib/visual-qa.test.ts
@@ -1,14 +1,19 @@
-// Unit tests for the visual-QA analyzer: colour fractions, dominant palette,
-// change-metric, and the pure expectation evaluator, all on synthetic
-// sharp-generated fixtures so they run deterministically in CI without a real
-// screenshot. OCR must remain packaged: the analyzer may prefer a system
-// tesseract binary, but the repo dependency fallback is part of the contract.
-import { mkdtempSync, readFileSync } from "node:fs";
+/**
+ * Exercises the visual-QA analyzer with real Sharp pixels and packaged OCR.
+ * Deterministic generated frames cover palette, diff, and blank-proof boundaries;
+ * the installed Tesseract dependency remains part of the end-to-end contract.
+ */
+import { afterAll, describe, expect, it } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  comparePixels,
+  summarizeDiff,
+} from "@elizaos/evidence/visual-primitives";
 import sharp from "sharp";
-import { afterAll, describe, expect, it } from "vitest";
+import { analyzeImageFile } from "../mvp-visual-verify/ocr.mjs";
 import {
   analyzeScreenshot,
   changeMetric,
@@ -40,7 +45,68 @@ const solid = async (name: string, r: number, g: number, b: number) => {
 };
 
 afterAll(() => {
-  // best-effort temp cleanup; leaving fixtures on failure aids debugging
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("pixel blank proof", () => {
+  it("distinguishes a one-color frame from visible multicolor pixels", async () => {
+    const blank = await analyzeImageFile(
+      await solid("pixel-blank.png", 208, 216, 216),
+    );
+    expect(blank.pixelBlank).toBe(true);
+    expect(blank.pixelBlankReasons).toEqual(["screenshot is one color"]);
+
+    const visiblePath = join(dir, "pixel-visible.png");
+    await sharp(Buffer.from([0, 0, 0, 255, 255, 255]), {
+      raw: { width: 2, height: 1, channels: 3 },
+    })
+      .png()
+      .toFile(visiblePath);
+    const visible = await analyzeImageFile(visiblePath);
+    expect(visible.colorBuckets).toBe(2);
+    expect(visible.pixelBlank).toBe(false);
+    expect(visible.pixelBlankReasons).toEqual([]);
+  });
+});
+
+describe("pixel comparison diagnostics", () => {
+  it("counts visible channel changes and emits an inspectable highlight", () => {
+    const baseline = Buffer.from([10, 20, 30, 255, 40, 50, 60, 255]);
+    const current = Buffer.from([10, 20, 30, 255, 250, 0, 250, 255]);
+    const comparison = comparePixels(current, baseline, 2, 1, {
+      threshold: 30,
+      buildHighlight: true,
+    });
+
+    expect(comparison.changedPixels).toBe(1);
+    expect(comparison.totalPixels).toBe(2);
+    expect(comparison.sumAbsDelta).toBe(450);
+    expect(comparison.highlight).toEqual(
+      Buffer.from([27, 27, 27, 255, 255, 0, 255, 255]),
+    );
+    expect(summarizeDiff({ ...comparison, resized: false })).toEqual({
+      changedPixels: 1,
+      totalPixels: 2,
+      changedRatio: 0.5,
+      changedPercent: 50,
+      meanAbsDelta: 75,
+      resized: false,
+    });
+  });
+
+  it("rejects dimensions and summaries that cannot represent real pixels", () => {
+    expect(() => comparePixels(Buffer.alloc(4), Buffer.alloc(4), 2, 1)).toThrow(
+      "buffers too small",
+    );
+    expect(() =>
+      summarizeDiff({
+        changedPixels: 0,
+        totalPixels: 0,
+        sumAbsDelta: 0,
+        resized: false,
+      }),
+    ).toThrow("totalPixels must be > 0");
+  });
 });
 
 describe("colorFractions", () => {

--- a/packages/app/scripts/mvp-visual-verify/ocr.mjs
+++ b/packages/app/scripts/mvp-visual-verify/ocr.mjs
@@ -1,10 +1,12 @@
 /**
- * Compatibility exports for MVP screenshot OCR. Engine resolution, packaged
- * tesseract workers, explicit unavailable results, and cleanup live in the
- * shared evidence primitive module so OCR failure semantics stay consistent.
+ * Compatibility exports for MVP screenshot OCR and its independent pixel
+ * diagnostics. Engine resolution, preprocessing, explicit unavailable results,
+ * and cleanup live in the shared evidence primitive module so failure semantics
+ * stay consistent.
  */
 
 export {
+  analyzeImageFile,
   closeOcrEngines,
   ocrImage,
   resetTesseractProbe,

--- a/packages/app/scripts/ocr-real-engine.test.ts
+++ b/packages/app/scripts/ocr-real-engine.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Exercises packaged Tesseract and pixel diagnostics against a real launcher capture plus adversarial generated frames.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import sharp from "sharp";
+import {
+  evaluateOcrContent,
+  type OcrResult,
+} from "../test/ui-smoke/ocr-content-rules";
+import {
+  closeOcrEngines,
+  ocrImage,
+  resetTesseractProbe,
+} from "./mvp-visual-verify/ocr.mjs";
+import { runOcrTriage } from "./ocr-triage";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const LAUNCHER_CAPTURE = resolve(
+  HERE,
+  "mvp-visual-verify/baseline/mobile-portrait/builtin-rolodex.png",
+);
+const dir = mkdtempSync(join(tmpdir(), "ocr-real-engine-"));
+const previousEngine = process.env.ELIZA_MVP_OCR_ENGINE;
+
+function contentResult(
+  result: Awaited<ReturnType<typeof ocrImage>>,
+): OcrResult {
+  if (!result.available) {
+    return {
+      ok: false,
+      text: "",
+      lines: [],
+      words: 0,
+      meanConfidence: 0,
+      reason: result.reason,
+    };
+  }
+  return {
+    ok: true,
+    text: result.text,
+    lines: result.text.split("\n").filter(Boolean),
+    words: result.words,
+    meanConfidence: result.meanConfidence,
+    pixelBlank: result.pixelBlank,
+    pixelBlankReasons: result.pixelBlankReasons,
+    selectedMode: result.selectedMode,
+    attempts: result.attempts,
+  };
+}
+
+beforeAll(() => {
+  process.env.ELIZA_MVP_OCR_ENGINE = "packaged";
+  resetTesseractProbe();
+});
+
+afterAll(async () => {
+  await closeOcrEngines();
+  resetTesseractProbe();
+  if (previousEngine === undefined) delete process.env.ELIZA_MVP_OCR_ENGINE;
+  else process.env.ELIZA_MVP_OCR_ENGINE = previousEngine;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("real OCR blank-vs-unreadable classification", () => {
+  it("does not call a populated mobile launcher blank when the first OCR pass is weak", async () => {
+    const auditDir = join(dir, "launcher-audit");
+    const viewportDir = join(auditDir, "mobile-portrait");
+    mkdirSync(viewportDir, { recursive: true });
+    copyFileSync(LAUNCHER_CAPTURE, join(viewportDir, "builtin-rolodex.png"));
+    writeFileSync(
+      join(auditDir, "report.json"),
+      JSON.stringify([
+        {
+          slug: "builtin-rolodex",
+          viewport: "mobile-portrait",
+          viewType: "gui",
+          verdict: "good",
+        },
+      ]),
+    );
+
+    const triage = await runOcrTriage([
+      "--audit-dir",
+      auditDir,
+      "--out",
+      join(auditDir, "ocr-triage.json"),
+    ]);
+    const entry = triage.entries[0];
+    if (!entry) throw new Error("expected launcher triage entry");
+    const attempts = entry.attempts;
+    if (!attempts) throw new Error("expected retained OCR attempts");
+
+    expect(attempts[0]).toMatchObject({
+      mode: "auto",
+      ok: true,
+    });
+    expect(attempts[0].meanConfidence).toBeLessThan(0.45);
+    expect(attempts).toHaveLength(2);
+    expect(attempts[1]).toMatchObject({
+      mode: "sparse-high-contrast",
+      ok: true,
+    });
+    expect(entry.selectedMode).toBe("sparse-high-contrast");
+    expect(entry.text).toMatch(/Ask Eliza/i);
+    expect(entry.pixelBlank).toBe(false);
+    expect(entry.ocrVerdict).toBe("needs-eyeball");
+    expect(entry.regression).toBe(false);
+    expect(entry.reasons.join(" ")).not.toMatch(/pixels are blank/i);
+  }, 90_000);
+
+  it("still breaks a genuinely solid frame after both real OCR passes", async () => {
+    const path = join(dir, "solid.png");
+    await sharp({
+      create: {
+        width: 390,
+        height: 844,
+        channels: 4,
+        background: { r: 208, g: 216, b: 216, alpha: 1 },
+      },
+    })
+      .png()
+      .toFile(path);
+
+    const result = await ocrImage(path, { timeoutMs: 60_000 });
+    if (!result.available) throw new Error(result.reason);
+    expect(result.pixelBlank).toBe(true);
+
+    const finding = evaluateOcrContent({ ocr: contentResult(result) });
+    expect(finding.blankPixels).toBe(true);
+    expect(finding.ocrInconclusive).toBe(false);
+    expect(finding.verdict).toBe("broken");
+    expect(finding.reasons.join(" ")).toMatch(/one color/);
+  }, 90_000);
+
+  it("routes a nonblank textless gradient to review instead of fabricating blank pixels", async () => {
+    const width = 390;
+    const height = 844;
+    const pixels = Buffer.alloc(width * height * 3);
+    for (let y = 0; y < height; y += 1) {
+      for (let x = 0; x < width; x += 1) {
+        const value = 72 + Math.floor((156 * x) / (width - 1));
+        const offset = (y * width + x) * 3;
+        pixels[offset] = value;
+        pixels[offset + 1] = value;
+        pixels[offset + 2] = value;
+      }
+    }
+    const path = join(dir, "gradient.png");
+    await sharp(pixels, { raw: { width, height, channels: 3 } })
+      .png()
+      .toFile(path);
+
+    const result = await ocrImage(path, { timeoutMs: 60_000 });
+    if (!result.available) throw new Error(result.reason);
+    expect(result.pixelBlank).toBe(false);
+
+    const finding = evaluateOcrContent({ ocr: contentResult(result) });
+    expect(finding.blankPixels).toBe(false);
+    expect(finding.ocrInconclusive).toBe(true);
+    expect(finding.verdict).toBe("needs-eyeball");
+    expect(finding.reasons.join(" ")).toMatch(/OCR inconclusive/);
+  }, 90_000);
+
+  it("keeps near-solid quality warnings distinct from proof of a blank frame", async () => {
+    const width = 120;
+    const height = 120;
+    const pixels = Buffer.alloc(width * height * 3, 255);
+    pixels[0] = 16;
+    pixels[1] = 16;
+    pixels[2] = 16;
+    const path = join(dir, "near-solid.png");
+    await sharp(pixels, { raw: { width, height, channels: 3 } })
+      .png()
+      .toFile(path);
+
+    const result = await ocrImage(path, { timeoutMs: 60_000 });
+    if (!result.available) throw new Error(result.reason);
+    expect(result.imageAnalysis.issues).toContain(
+      "screenshot is effectively one color",
+    );
+    expect(result.imageAnalysis.issues).toContain(
+      "screenshot is near-solid black/white",
+    );
+    expect(result.pixelBlank).toBe(false);
+
+    const finding = evaluateOcrContent({ ocr: contentResult(result) });
+    expect(finding.blankPixels).toBe(false);
+    expect(finding.verdict).toBe("needs-eyeball");
+  }, 90_000);
+});

--- a/packages/app/scripts/ocr-triage.ts
+++ b/packages/app/scripts/ocr-triage.ts
@@ -41,6 +41,7 @@ import {
   validateOcrRecordPaths,
 } from "./lib/audit-capture-manifest";
 import {
+  analyzeImageFile,
   closeOcrEngines,
   ocrImage,
   resolveOcrEngine,
@@ -56,12 +57,6 @@ const BLANK_EXEMPT_SLUGS = new Set<string>([
   ...OVERLAY_NATIVE_OR_CANVAS_SLUGS,
   "builtin-background",
   "plugin-focus-gui",
-  // Legacy alias route that resolves to the launcher-grid fallback (see
-  // launcher-curation.ts and the ocr-view-expectations.ts trailer). The grid's
-  // white-on-gradient icon labels sit right at the engine's blank word floor
-  // (1–2 garbled words across runs), so without the exemption the same healthy
-  // render flaps between needs-eyeball and blank-broken run to run.
-  "builtin-rolodex",
 ]);
 
 export interface ReportEntry {
@@ -97,6 +92,8 @@ function parseOcrRecord(value: unknown, index: number): OcrRecord {
     !Number.isFinite(value.words) ||
     typeof value.meanConfidence !== "number" ||
     !Number.isFinite(value.meanConfidence) ||
+    value.meanConfidence < 0 ||
+    value.meanConfidence > 1 ||
     (value.reason !== undefined && typeof value.reason !== "string")
   ) {
     throw new Error(`Invalid OCR input record at line ${index + 1}`);
@@ -122,6 +119,12 @@ export interface TriageEntry {
   /** DOM audit passed (good/needs-eyeball) but the pixels are broken — the caught bug. */
   regression: boolean;
   text: string;
+  words: number;
+  meanConfidence: number;
+  selectedMode: string | null;
+  attempts: OcrResult["attempts"];
+  pixelBlank: boolean;
+  pixelBlankReasons: string[];
 }
 
 export interface TriageSummary {
@@ -181,7 +184,11 @@ async function runPackagedOcr(paths: string[]): Promise<OcrRecord[]> {
       text: result.text,
       lines: result.text.split("\n").filter(Boolean),
       words: result.words,
-      meanConfidence: 1,
+      meanConfidence: result.meanConfidence,
+      pixelBlank: result.pixelBlank,
+      pixelBlankReasons: result.pixelBlankReasons,
+      selectedMode: result.selectedMode,
+      attempts: result.attempts,
     });
   }
   return out;
@@ -276,16 +283,43 @@ export async function runOcrTriage(argv: string[]): Promise<TriageResult> {
   const reportByKey = new Map<string, ReportEntry>();
   for (const r of report) reportByKey.set(`${r.slug}::${r.viewport}`, r);
 
-  const ocr: OcrRecord[] = args.ocr
+  const rawOcr: OcrRecord[] = args.ocr
     ? readFileSync(args.ocr, "utf8")
         .split("\n")
         .filter((l) => l.trim())
         .map((line, index) => parseOcrRecord(JSON.parse(line), index))
     : await runPackagedOcr(manifest.map((entry) => entry.path));
-  validateOcrRecordPaths(ocr, manifest, auditDir);
+  validateOcrRecordPaths(rawOcr, manifest, auditDir);
+  const shotsByKey = new Map(manifest.map((shot) => [shot.key, shot]));
+  const ocr: OcrRecord[] = await Promise.all(
+    rawOcr.map(async (record) => {
+      if (record.pixelBlank !== undefined) {
+        if (!record.pixelBlankReasons) {
+          throw new Error(
+            `OCR record ${record.path} has a pixel verdict without its diagnostics`,
+          );
+        }
+        return record;
+      }
+      const key = `${slugOf(record.path)}::${viewportOf(record.path)}`;
+      const shot = shotsByKey.get(key);
+      if (!shot) {
+        throw new Error(`OCR record ${key} has no authorized shot`);
+      }
+      const analysis = await analyzeImageFile(shot.path);
+      return {
+        ...record,
+        pixelBlank: analysis.pixelBlank,
+        pixelBlankReasons: analysis.pixelBlankReasons,
+      };
+    }),
+  );
 
   const entries: TriageEntry[] = [];
   for (const rec of ocr) {
+    if (rec.pixelBlank === undefined || !rec.pixelBlankReasons) {
+      throw new Error(`OCR record ${rec.path} has no pixel diagnostics`);
+    }
     const slug = slugOf(rec.path);
     const viewport = viewportOf(rec.path);
     const rep = reportByKey.get(`${slug}::${viewport}`) ?? null;
@@ -307,6 +341,12 @@ export async function runOcrTriage(argv: string[]): Promise<TriageResult> {
       reasons: finding.reasons,
       regression: domPassed && finding.verdict === "broken",
       text: rec.text,
+      words: rec.words,
+      meanConfidence: rec.meanConfidence,
+      selectedMode: rec.selectedMode ?? null,
+      attempts: rec.attempts,
+      pixelBlank: rec.pixelBlank,
+      pixelBlankReasons: rec.pixelBlankReasons,
     });
   }
 

--- a/packages/app/test/audit/ocr-content-rules.test.ts
+++ b/packages/app/test/audit/ocr-content-rules.test.ts
@@ -77,9 +77,43 @@ describe("evaluateOcrContent", () => {
   });
 
   it("catches a blank paint on a non-exempt view (the DOM-metric blind spot)", () => {
-    const f = evaluateOcrContent({ ocr: ocr("+", { words: 1 }) });
+    const f = evaluateOcrContent({
+      ocr: ocr("+", {
+        words: 1,
+        pixelBlank: true,
+        pixelBlankReasons: ["screenshot is one color"],
+      }),
+    });
     expect(f.blankPixels).toBe(true);
+    expect(f.ocrInconclusive).toBe(false);
     expect(f.verdict).toBe("broken");
+    expect(f.reasons).toContain("pixels are blank — screenshot is one color");
+  });
+
+  it("keeps an unreadable nonblank frame distinct from a proven blank render", () => {
+    const f = evaluateOcrContent({
+      ocr: ocr("oY)", {
+        words: 1,
+        meanConfidence: 0.4,
+        pixelBlank: false,
+      }),
+    });
+    expect(f.blankPixels).toBe(false);
+    expect(f.ocrInconclusive).toBe(true);
+    expect(f.verdict).toBe("needs-eyeball");
+    expect(f.reasons.join(" ")).toMatch(/OCR inconclusive.*not blank/);
+  });
+
+  it("does not fabricate a missing-label defect from low-confidence OCR", () => {
+    const f = evaluateOcrContent({
+      ocr: ocr("glyph noise", {
+        meanConfidence: 0.2,
+        pixelBlank: false,
+      }),
+      expectation: { requireAll: ["Ask Eliza"] },
+    });
+    expect(f.missingRequired).toHaveLength(0);
+    expect(f.verdict).toBe("needs-eyeball");
   });
 
   it("exempts TUI/canvas surfaces from the blank floor", () => {

--- a/packages/app/test/audit/ocr-triage-provenance.test.ts
+++ b/packages/app/test/audit/ocr-triage-provenance.test.ts
@@ -12,6 +12,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import sharp from "sharp";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { resolveAuditAppOutput } from "../../scripts/lib/audit-output.mjs";
 import {
@@ -39,18 +40,18 @@ if (appDirCandidates.length !== 1) {
 const [APP_DIR] = appDirCandidates;
 const CLI = join(APP_DIR, "scripts", "ocr-triage.ts");
 
-/** Minimal valid 1×1 PNG — enough for `existsSync`; the CLI OCR comes from ndjson. */
-const PNG_1x1 = Buffer.from(
-  "89504e470d0a1a0a0000000d494844520000000100000001080600000" +
-    "01f15c4890000000d49444154789c62000100000500010d0a2db40000" +
-    "000049454e44ae426082",
+/** Multicolor pixels keep provenance fixtures outside the proven-blank path. */
+const PNG_2x2 = Buffer.from(
+  "89504e470d0a1a0a0000000d494844520000000200000002080600000" +
+    "072b60d240000000970485973000003e8000003e801b57b526b000000" +
+    "1349444154789c63f8cfc0f01f0c1918fe83010049c809f71463329d" +
+    "0000000049454e44ae426082",
   "hex",
 );
-
 function shot(dir: string, viewport: string, slug: string): void {
   const vp = join(dir, viewport);
   mkdirSync(vp, { recursive: true });
-  writeFileSync(join(vp, `${slug}.png`), PNG_1x1);
+  writeFileSync(join(vp, `${slug}.png`), PNG_2x2);
 }
 
 function ocrLine(viewport: string, slug: string, text: string): string {
@@ -295,6 +296,44 @@ describe("ocr-triage CLI (end-to-end provenance)", () => {
     ).toThrow(/builtin-chat::desktop-landscape points to/);
   });
 
+  it("binds pixel diagnostics by screenshot path when OCR records arrive out of order", async () => {
+    for (const r of CURRENT_ROWS) shot(dir, r.viewport, r.slug);
+    await sharp({
+      create: {
+        width: 2,
+        height: 2,
+        channels: 4,
+        background: { r: 208, g: 216, b: 216, alpha: 1 },
+      },
+    })
+      .png()
+      .toFile(join(dir, "desktop-landscape", "builtin-chat.png"));
+    writeFileSync(join(dir, "report.json"), JSON.stringify(CURRENT_ROWS));
+    writeFileSync(
+      join(dir, "ocr.ndjson"),
+      [
+        ocrLine("desktop-landscape", "builtin-phone", "Phone dialer keypad"),
+        ocrLine("desktop-landscape", "builtin-chat", "Chat messages composer"),
+      ].join("\n"),
+    );
+
+    const result = await runOcrTriage([
+      "--audit-dir",
+      dir,
+      "--ocr",
+      join(dir, "ocr.ndjson"),
+      "--out",
+      join(dir, "ocr-triage.json"),
+    ]);
+    const chat = result.entries.find((entry) => entry.slug === "builtin-chat");
+    const phone = result.entries.find(
+      (entry) => entry.slug === "builtin-phone",
+    );
+    if (!chat || !phone) throw new Error("expected current audit entries");
+    expect(chat.pixelBlank).toBe(true);
+    expect(phone.pixelBlank).toBe(false);
+  });
+
   it("exits non-zero when imported OCR contains a stale record", async () => {
     for (const r of CURRENT_ROWS) shot(dir, r.viewport, r.slug);
     writeFileSync(join(dir, "report.json"), JSON.stringify(CURRENT_ROWS));
@@ -394,7 +433,7 @@ describe("audit runner cleanup", () => {
   it("resets stale artifacts once before Playwright owns the run", () => {
     const stale = join(dir, "mobile-portrait", "plugin-retired-gui.png");
     mkdirSync(join(dir, "mobile-portrait"));
-    writeFileSync(stale, PNG_1x1);
+    writeFileSync(stale, PNG_2x2);
 
     const output = execFileSync(
       process.execPath,

--- a/packages/app/test/ui-smoke/ocr-content-rules.ts
+++ b/packages/app/test/ui-smoke/ocr-content-rules.ts
@@ -1,8 +1,7 @@
 /**
- * Pixel-truth content rules for the all-views audit: given the text Apple Vision
- * OCR'd out of a captured view screenshot, decide whether the pixels a user
- * actually sees are healthy, and whether they match what the view is supposed to
- * show.
+ * Pixel-truth content rules for the all-views audit: given OCR plus independent
+ * pixel diagnostics from a captured view screenshot, decide whether the pixels
+ * a user actually sees are healthy and match what the view is supposed to show.
  *
  * This closes the gap the DOM-derived metrics in `aesthetic-audit-rules.ts` can't
  * see. `readableChars` counts text in the DOM tree; it says nothing about what
@@ -14,7 +13,7 @@
  *
  * Kept dependency-free (no OCR engine, no `page`, no fs) so it unit-tests as pure
  * functions, mirroring how `aesthetic-audit-rules.ts` was extracted from its
- * Playwright spec. The CLI (`ocr-triage.mjs`) and, in CI, the audit spec, supply
+ * Playwright spec. The CLI (`ocr-triage.ts`) and, in CI, the audit spec, supply
  * the OCR and consume the verdict.
  */
 
@@ -27,6 +26,24 @@ export interface OcrResult {
   /** Mean OCR confidence, 0..1 when the engine reports it. */
   meanConfidence: number;
   /** Present when OCR could not read the screenshot because the image or engine failed. */
+  reason?: string;
+  /** Independent pixel analysis found no opaque samples or one quantized color. */
+  pixelBlank?: boolean;
+  /** Inspectable evidence behind `pixelBlank`; OCR silence alone never populates this. */
+  pixelBlankReasons?: string[];
+  /** OCR preprocessing/segmentation path selected by the engine. */
+  selectedMode?: string;
+  /** Raw transcripts and confidences retained when the engine made multiple attempts. */
+  attempts?: OcrAttempt[];
+}
+
+export interface OcrAttempt {
+  mode: string;
+  ok: boolean;
+  text: string;
+  words: number;
+  chars: number;
+  meanConfidence: number;
   reason?: string;
 }
 
@@ -46,8 +63,10 @@ export type OcrVerdict = "verified" | "needs-eyeball" | "broken";
 
 export interface OcrContentFinding {
   verdict: OcrVerdict;
-  /** ok && the pixels carry essentially no readable text, on a view that should show some. */
+  /** Independent image analysis proved the pixels are effectively blank. */
   blankPixels: boolean;
+  /** OCR could not read the frame reliably, but the frame was not proven blank. */
+  ocrInconclusive: boolean;
   /** Developer-only strings that must never reach a user (see {@link DEVELOPER_LEAK_PATTERNS}). */
   errorLeaks: string[];
   /** Scaffolding text left in the render (lorem, TODO, unresolved template tokens). */
@@ -117,11 +136,12 @@ export function detectPlaceholderLeaks(text: string): string[] {
 }
 
 /**
- * Minimum words of OCR'd text below which a non-exempt view is considered to
- * have painted nothing. A single glyph (a lone "+" FAB, a spinner) clears no bar;
- * two real words is the floor for "this view showed the user something".
+ * Minimum words for a transcript to support content assertions. A single glyph
+ * (a lone "+" FAB, a spinner) cannot prove what the view rendered, so a shorter
+ * transcript is inconclusive; it never proves the underlying pixels are blank.
  */
-export const BLANK_PIXEL_WORD_FLOOR = 2;
+export const OCR_RELIABLE_WORD_FLOOR = 2;
+export const OCR_RELIABLE_CONFIDENCE_FLOOR = 0.45;
 
 export interface EvaluateArgs {
   ocr: OcrResult;
@@ -141,26 +161,34 @@ export function evaluateOcrContent({
     return {
       verdict: "broken",
       blankPixels: false,
+      ocrInconclusive: false,
       errorLeaks: [],
       placeholderLeaks: [],
       missingRequired: [],
       forbiddenPresent: [],
       reasons: [
         ocr.reason
-          ? `OCR failed: ${ocr.reason}`
-          : "screenshot failed to decode",
+          ? `OCR diagnostics error: ${ocr.reason}`
+          : "OCR diagnostics error: screenshot failed to decode",
       ],
     };
   }
 
   const hay = normalize(ocr.text);
-  const errorLeaks = detectErrorLeaks(ocr.text);
-  const placeholderLeaks = detectPlaceholderLeaks(ocr.text);
-  const blankPixels = !exemptFromBlank && ocr.words < BLANK_PIXEL_WORD_FLOOR;
+  const blankPixels = !exemptFromBlank && ocr.pixelBlank === true;
+  const ocrInconclusive =
+    !exemptFromBlank &&
+    !blankPixels &&
+    (ocr.words < OCR_RELIABLE_WORD_FLOOR ||
+      ocr.meanConfidence < OCR_RELIABLE_CONFIDENCE_FLOOR);
+  const errorLeaks = ocrInconclusive ? [] : detectErrorLeaks(ocr.text);
+  const placeholderLeaks = ocrInconclusive
+    ? []
+    : detectPlaceholderLeaks(ocr.text);
 
   const missingRequired: string[] = [];
   const forbiddenPresent: string[] = [];
-  if (expectation) {
+  if (expectation && !ocrInconclusive && !blankPixels) {
     for (const label of expectation.requireAll ?? []) {
       if (!hay.includes(normalize(label))) missingRequired.push(label);
     }
@@ -177,8 +205,18 @@ export function evaluateOcrContent({
     }
   }
 
-  if (blankPixels)
-    reasons.push("pixels are blank — view painted no readable text");
+  if (blankPixels) {
+    const evidence = ocr.pixelBlankReasons?.join(", ");
+    reasons.push(
+      evidence
+        ? `pixels are blank — ${evidence}`
+        : "pixels are blank — independent pixel analysis found no rendered content",
+    );
+  } else if (ocrInconclusive) {
+    reasons.push(
+      `OCR inconclusive — ${ocr.words} word(s), ${(ocr.meanConfidence * 100).toFixed(1)}% mean confidence; pixels were not blank`,
+    );
+  }
   if (errorLeaks.length)
     reasons.push(`developer string on screen: ${errorLeaks.join(", ")}`);
   if (missingRequired.length)
@@ -198,7 +236,11 @@ export function evaluateOcrContent({
   let verdict: OcrVerdict;
   if (blankPixels || errorLeaks.length > 0 || missingRequired.length > 0) {
     verdict = "broken";
-  } else if (placeholderLeaks.length > 0 || forbiddenPresent.length > 0) {
+  } else if (
+    ocrInconclusive ||
+    placeholderLeaks.length > 0 ||
+    forbiddenPresent.length > 0
+  ) {
     verdict = "needs-eyeball";
   } else if (
     expectation &&
@@ -216,6 +258,7 @@ export function evaluateOcrContent({
   return {
     verdict,
     blankPixels,
+    ocrInconclusive,
     errorLeaks,
     placeholderLeaks,
     missingRequired,

--- a/packages/evidence/src/visual-primitives.mjs
+++ b/packages/evidence/src/visual-primitives.mjs
@@ -23,6 +23,14 @@ export const DEFAULT_OVERFLOW_TOLERANCE_PX = 2;
 
 const TESSERACT_JS_PACKAGE = "tesseract.js";
 const TESSERACT_JS_CACHE_DIR = path.join(tmpdir(), "elizaos-tesseract-cache");
+export const DEFAULT_OCR_CONFIDENCE_FLOOR = 0.45;
+const OCR_FALLBACK_MAX_WIDTH = 2400;
+const OCR_FALLBACK_SCALE = 3;
+const OCR_FALLBACK_THRESHOLD = 225;
+const PROVEN_BLANK_IMAGE_ISSUES = new Set([
+  "screenshot has no sampled pixels",
+  "screenshot is one color",
+]);
 
 /** @type {{ path: string | null } | null} */
 let systemTesseractProbe = null;
@@ -559,35 +567,88 @@ export function resetTesseractProbe() {
   packagedWorkers = new Map();
 }
 
-/** OCR a single PNG, or report an explicit unavailable result. */
+/**
+ * OCR a single PNG, or report an explicit unavailable result.
+ *
+ * Whole-page segmentation is the cheap first pass. When that pass is weak, a
+ * bounded high-contrast upscale plus sparse-text segmentation gets one second
+ * chance; this is particularly important for mobile screenshots whose labels
+ * are only a dozen source pixels tall. The selected transcript, confidence,
+ * every attempted transcript, and independent pixel-blank diagnostics remain
+ * in the result so downstream gates never infer "blank" from OCR silence.
+ */
 export async function ocrImage(pngPath, opts = {}) {
   const engine = await resolveOcrEngine();
   if (!engine.available) return { available: false, reason: engine.reason };
   const lang = opts.lang ?? "eng";
   const timeoutMs = opts.timeoutMs ?? 30_000;
-  const text =
-    engine.kind === "packaged"
-      ? await runPackagedTesseract(pngPath, lang, timeoutMs).catch((err) => ({
-          error: err instanceof Error ? err.message : String(err),
-        }))
-      : await runSystemTesseract(engine.bin, pngPath, lang, timeoutMs).catch(
-          (err) => ({
-            error: err instanceof Error ? err.message : String(err),
-          }),
-        );
-  if (typeof text !== "string") {
+  const confidenceFloor = opts.confidenceFloor ?? DEFAULT_OCR_CONFIDENCE_FLOOR;
+  const [primaryOutcome, imageOutcome] = await Promise.allSettled([
+    recognizeWithEngine(engine, pngPath, lang, timeoutMs, "auto"),
+    analyzeImageFile(pngPath),
+  ]);
+  if (primaryOutcome.status === "rejected") {
     return {
       available: false,
-      reason: `${engine.label} failed: ${text.error.slice(0, 200)}`,
+      reason: `${engine.label} failed: ${errorMessage(primaryOutcome.reason).slice(0, 200)}`,
     };
   }
-  const normalized = normalizeOcrText(text);
+  if (imageOutcome.status === "rejected") {
+    return {
+      available: false,
+      reason: `pixel diagnostics failed: ${errorMessage(imageOutcome.reason).slice(0, 200)}`,
+    };
+  }
+  const primaryRecognition = primaryOutcome.value;
+  const imageAnalysis = imageOutcome.value;
+
+  const attempts = [buildOcrAttempt("auto", primaryRecognition)];
+  if (!isReliableOcrAttempt(attempts[0], confidenceFloor)) {
+    const fallbackRecognition = await buildHighContrastOcrInput(pngPath)
+      .then((fallbackInput) =>
+        recognizeWithEngine(
+          engine,
+          fallbackInput,
+          lang,
+          timeoutMs,
+          "sparse-high-contrast",
+        ),
+      )
+      .catch((err) => {
+        // error-policy:J1 OCR primitive boundary — a failed fallback is retained
+        // as a diagnostic while the successful primary pass remains inspectable.
+        return { error: err instanceof Error ? err.message : String(err) };
+      });
+    if ("error" in fallbackRecognition) {
+      attempts.push({
+        mode: "sparse-high-contrast",
+        ok: false,
+        reason: fallbackRecognition.error,
+        text: "",
+        words: 0,
+        chars: 0,
+        meanConfidence: 0,
+      });
+    } else {
+      attempts.push(
+        buildOcrAttempt("sparse-high-contrast", fallbackRecognition),
+      );
+    }
+  }
+
+  const selected = selectOcrAttempt(attempts, confidenceFloor);
   return {
     available: true,
-    text: normalized,
-    words: normalized ? normalized.split(/\s+/).filter(Boolean).length : 0,
-    chars: normalized.replace(/\s+/g, "").length,
+    text: selected.text,
+    words: selected.words,
+    chars: selected.chars,
+    meanConfidence: selected.meanConfidence,
     engine: engine.label,
+    selectedMode: selected.mode,
+    attempts,
+    pixelBlank: imageAnalysis.pixelBlank,
+    pixelBlankReasons: imageAnalysis.pixelBlankReasons,
+    imageAnalysis,
   };
 }
 
@@ -686,6 +747,9 @@ export async function analyzeImageFile(filePath) {
   ) {
     issues.push("blue accent candidate exceeds orange pixels");
   }
+  const pixelBlankReasons = issues.filter((issue) =>
+    PROVEN_BLANK_IMAGE_ISSUES.has(issue),
+  );
 
   return {
     width: info.width,
@@ -699,6 +763,8 @@ export async function analyzeImageFile(filePath) {
     redRatio: sampledPixels === 0 ? 0 : redPixels / sampledPixels,
     averageLuminance,
     issues,
+    pixelBlank: pixelBlankReasons.length > 0,
+    pixelBlankReasons,
   };
 }
 
@@ -727,17 +793,35 @@ function containsForbidden(haystack, token) {
   return haystack.includes(needle);
 }
 
-function runSystemTesseract(bin, pngPath, lang, timeoutMs) {
+async function recognizeWithEngine(engine, input, lang, timeoutMs, mode) {
+  return engine.kind === "packaged"
+    ? runPackagedTesseract(input, lang, timeoutMs, mode)
+    : runSystemTesseract(engine.bin, input, lang, timeoutMs, mode);
+}
+
+function runSystemTesseract(bin, input, lang, timeoutMs, mode) {
   return new Promise((resolve, reject) => {
-    const child = spawn(bin, [pngPath, "stdout", "-l", lang], {
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    const readsStdin = Buffer.isBuffer(input);
+    const inputArg = readsStdin ? "stdin" : input;
+    const pageSegMode = mode === "sparse-high-contrast" ? "11" : "3";
+    const child = spawn(
+      bin,
+      [inputArg, "stdout", "-l", lang, "--psm", pageSegMode, "tsv"],
+      {
+        stdio: [readsStdin ? "pipe" : "ignore", "pipe", "pipe"],
+      },
+    );
+    if (readsStdin) {
+      child.stdin.end(input);
+    }
     let stdout = "";
     let stderr = "";
     const timer = setTimeout(() => {
       child.kill("SIGKILL");
       reject(
-        new Error(`tesseract timed out after ${timeoutMs}ms on ${pngPath}`),
+        new Error(
+          `tesseract timed out after ${timeoutMs}ms on ${readsStdin ? mode : input}`,
+        ),
       );
     }, timeoutMs);
     child.stdout.on("data", (d) => {
@@ -752,10 +836,46 @@ function runSystemTesseract(bin, pngPath, lang, timeoutMs) {
     });
     child.on("close", (code) => {
       clearTimeout(timer);
-      if (code === 0) resolve(stdout);
+      if (code === 0) resolve(parseSystemTesseractTsv(stdout));
       else reject(new Error(`tesseract exited ${code}: ${stderr.trim()}`));
     });
   });
+}
+
+function parseSystemTesseractTsv(tsv) {
+  const rows = String(tsv).split(/\r?\n/);
+  if (!rows[0]?.startsWith("level\tpage_num\t")) {
+    throw new Error("system tesseract returned an invalid TSV header");
+  }
+  const lines = new Map();
+  let confidenceTotal = 0;
+  let confidenceCount = 0;
+  for (const row of rows.slice(1)) {
+    if (!row) continue;
+    const columns = row.split("\t");
+    if (columns.length < 12 || columns[0] !== "5") continue;
+    const text = columns.slice(11).join("\t").trim();
+    if (!text) continue;
+    const confidence = Number(columns[10]);
+    if (!Number.isFinite(confidence)) {
+      throw new Error("system tesseract returned a non-numeric confidence");
+    }
+    const key = columns.slice(1, 5).join(":");
+    const current = lines.get(key);
+    if (current) current.push(text);
+    else lines.set(key, [text]);
+    if (confidence >= 0) {
+      confidenceTotal += confidence;
+      confidenceCount += 1;
+    }
+  }
+  return {
+    text: [...lines.values()].map((words) => words.join(" ")).join("\n"),
+    meanConfidence:
+      confidenceCount === 0
+        ? 0
+        : Math.min(1, Math.max(0, confidenceTotal / confidenceCount / 100)),
+  };
 }
 
 async function loadPackagedTesseract() {
@@ -765,18 +885,30 @@ async function loadPackagedTesseract() {
   return packagedTesseractProbe;
 }
 
-async function runPackagedTesseract(pngPath, lang, timeoutMs) {
-  const worker = await getPackagedWorker(lang, timeoutMs);
+async function runPackagedTesseract(input, lang, timeoutMs, mode) {
+  const worker = await getPackagedWorker(lang, timeoutMs, mode);
   const result = await withTimeout(
-    worker.recognize(pngPath),
+    worker.recognize(input),
     timeoutMs,
-    `tesseract.js timed out after ${timeoutMs}ms on ${pngPath}`,
+    `tesseract.js timed out after ${timeoutMs}ms during ${mode}`,
   );
-  return result?.data?.text ?? "";
+  if (
+    !result?.data ||
+    typeof result.data.text !== "string" ||
+    typeof result.data.confidence !== "number" ||
+    !Number.isFinite(result.data.confidence)
+  ) {
+    throw new Error("tesseract.js returned no transcript confidence");
+  }
+  return {
+    text: result.data.text,
+    meanConfidence: Math.min(1, Math.max(0, result.data.confidence / 100)),
+  };
 }
 
-async function getPackagedWorker(lang, timeoutMs) {
-  const existing = packagedWorkers.get(lang);
+async function getPackagedWorker(lang, timeoutMs, mode) {
+  const workerKey = `${lang}:${mode}`;
+  const existing = packagedWorkers.get(workerKey);
   if (existing) return existing;
   const workerPromise = (async () => {
     const tesseract = await loadPackagedTesseract();
@@ -784,14 +916,99 @@ async function getPackagedWorker(lang, timeoutMs) {
       throw new Error("tesseract.js createWorker export is unavailable");
     }
     mkdirSync(TESSERACT_JS_CACHE_DIR, { recursive: true });
-    return withTimeout(
+    const worker = await withTimeout(
       tesseract.createWorker(lang, 1, { cachePath: TESSERACT_JS_CACHE_DIR }),
       timeoutMs,
       `tesseract.js worker initialization timed out after ${timeoutMs}ms`,
     );
+    if (mode === "sparse-high-contrast") {
+      if (!tesseract.PSM?.SPARSE_TEXT) {
+        await worker.terminate();
+        throw new Error("tesseract.js sparse-text segmentation is unavailable");
+      }
+      await withTimeout(
+        worker.setParameters({
+          tessedit_pageseg_mode: tesseract.PSM.SPARSE_TEXT,
+        }),
+        timeoutMs,
+        `tesseract.js sparse-text configuration timed out after ${timeoutMs}ms`,
+      );
+    }
+    return worker;
   })();
-  packagedWorkers.set(lang, workerPromise);
-  return workerPromise;
+  const trackedWorkerPromise = workerPromise.then(
+    (worker) => worker,
+    (error) => {
+      packagedWorkers.delete(workerKey);
+      throw error;
+    },
+  );
+  packagedWorkers.set(workerKey, trackedWorkerPromise);
+  return trackedWorkerPromise;
+}
+
+async function buildHighContrastOcrInput(pngPath) {
+  const metadata = await sharp(pngPath).metadata();
+  if (!metadata.width || metadata.width <= 0) {
+    throw new Error("OCR image has no positive pixel width");
+  }
+  const width = Math.min(
+    OCR_FALLBACK_MAX_WIDTH,
+    metadata.width * OCR_FALLBACK_SCALE,
+  );
+  return sharp(pngPath)
+    .resize({ width, kernel: sharp.kernel.lanczos3 })
+    .grayscale()
+    .normalize()
+    .sharpen()
+    .threshold(OCR_FALLBACK_THRESHOLD)
+    .png()
+    .toBuffer();
+}
+
+function buildOcrAttempt(mode, recognition) {
+  const text = normalizeOcrText(recognition.text);
+  return {
+    mode,
+    ok: true,
+    text,
+    words: text ? text.split(/\s+/).filter(Boolean).length : 0,
+    chars: text.replace(/\s+/g, "").length,
+    meanConfidence: recognition.meanConfidence,
+  };
+}
+
+function isReliableOcrAttempt(attempt, confidenceFloor) {
+  return (
+    attempt.ok &&
+    attempt.words >= 2 &&
+    attempt.meanConfidence >= confidenceFloor
+  );
+}
+
+function selectOcrAttempt(attempts, confidenceFloor) {
+  const successful = attempts.filter((attempt) => attempt.ok);
+  if (successful.length === 0) {
+    throw new Error("OCR produced no successful attempt");
+  }
+  return successful.reduce((best, candidate) => {
+    const bestReliable = isReliableOcrAttempt(best, confidenceFloor);
+    const candidateReliable = isReliableOcrAttempt(candidate, confidenceFloor);
+    if (candidateReliable !== bestReliable) {
+      return candidateReliable ? candidate : best;
+    }
+    const bestScore =
+      best.meanConfidence * Math.log2(Math.max(2, best.words + 1));
+    const candidateScore =
+      candidate.meanConfidence * Math.log2(Math.max(2, candidate.words + 1));
+    if (candidateScore !== bestScore) {
+      return candidateScore > bestScore ? candidate : best;
+    }
+    if (candidate.words !== best.words) {
+      return candidate.words > best.words ? candidate : best;
+    }
+    return candidate.chars > best.chars ? candidate : best;
+  });
 }
 
 function withTimeout(promise, ms, message) {
@@ -805,10 +1022,17 @@ function withTimeout(promise, ms, message) {
 }
 
 function normalizeOcrText(text) {
-  return String(text ?? "")
+  if (typeof text !== "string") {
+    throw new Error("OCR transcript must be a string");
+  }
+  return text
     .replace(/\r/g, "")
     .replace(/[ \t]+/g, " ")
     .trim();
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
 }
 
 async function fileExists(p) {


### PR DESCRIPTION
# Relates to

Fixes #16327. Residual split from #15912.

Definition of Done: full standard in [`CONTRIBUTING.md`](https://github.com/elizaOS/eliza/blob/develop/CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased onto `origin/develop` `4f766c5b71f16f0a143e495b7fb19f09cd1e67f8`; zero conflicts.
- [x] `bun run verify` passes post-sync: [complete log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-root-verify.log).

# Risks

**Medium.** The classifier and OCR primitive are shared by every app-audit screenshot. A weak whole-page read now incurs one bounded high-contrast/sparse-text retry, which adds OCR work only below the two-word/45% reliability floor. True solid/transparent blank frames still fail from independent pixel evidence. Low-confidence nonblank frames remain visible as `needs-eyeball`; they are not promoted to healthy.

# Background

## What does this PR do?

The old rule inferred “pixels are blank” from a short OCR transcript. On the exact 390×844 issue capture (`sha256:392331bd…eff4`), whole-page packaged Tesseract saw one word, `oY)`, at 40% confidence even though 22 labeled launcher icons and the Ask Eliza bar were visibly rendered.

This change separates the signals:

- pixel analysis alone can prove blank pixels (no samples or one quantized color);
- weak OCR gets one deterministic retry: up to 3×/2400 px, normalized grayscale, sharpen, threshold 225, sparse-text segmentation;
- selected mode, raw attempt transcripts, word/character counts, and mean confidence remain in `ocr-triage.json`;
- weak OCR on nonblank pixels becomes `needs-eyeball`; OCR/image diagnostics failures remain explicit errors;
- imported OCR is enriched from the report-authorized screenshot path, never record order;
- a real packaged-Tesseract test covers a launcher capture, a genuinely solid frame, a nonblank unreadable gradient, and a near-solid warning frame.

Measured on the exact issue image, the retry recovered 49 words at 72% confidence (including Settings, Wallet, Tasks, Automations, and other launcher labels). Independent analysis measured 210 color buckets and a 33.7% dominant-color ratio, so the corrected verdict is `needs-eyeball`, `pixelBlank=false`, `regression=false`—never fabricated `verified`.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

The OCR triage documentation is updated with the measured cause, retry configuration, confidence floor, retained diagnostics, and exact reproduction result.

# Testing

## Where should a reviewer start?

1. Open the wrong capture and report first in **Evidence Details**.
2. Compare the exact-capture corrected diagnostics, especially the `auto` and `sparse-high-contrast` attempts.
3. Open the after screenshots and MP4.
4. Inspect the five-pass determinism manifest and the complete 244-row audit/OCR reports.
5. Review `packages/evidence/src/visual-primitives.mjs`, then `packages/app/test/ui-smoke/ocr-content-rules.ts` and `packages/app/scripts/ocr-real-engine.test.ts`.

## Detailed testing steps

```bash
bun test packages/app/scripts/ocr-real-engine.test.ts
bun test packages/app/scripts/lib/visual-qa.test.ts
bun test packages/app/test/audit/ocr-content-rules.test.ts \
  packages/app/test/audit/ocr-triage-provenance.test.ts
bun run --cwd packages/app test
bun run --cwd packages/evidence test
bun run --cwd packages/evidence typecheck
bun run audit:error-policy-ratchet
bun run --cwd packages/app audit:app
bun run verify
```

Results:

- real packaged OCR: 4 passed, 0 failed ([log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-real-ocr-test.log));
- verdict/provenance boundaries: 44 passed, 0 failed ([log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-focused-ocr-tests.log));
- exact changed-file coverage gate: `ocr-triage.ts` 53.99% and `visual-primitives.mjs` 53.56%, both above the 50% per-file floor ([CI run](https://github.com/elizaOS/eliza/actions/runs/29305441879), [final-head validation](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-final-head-validation.json));
- app on the final head: 500 Bun + 562 Vitest passed, 0 failed ([original complete log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-app-test.log), [final-head validation](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-final-head-validation.json));
- evidence: 427 passed, 2 skipped, 0 failed ([log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-evidence-test.log));
- evidence typecheck and error-policy ratchet pass ([typecheck](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-evidence-typecheck.log), [ratchet](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-error-policy-ratchet.log));
- root verify: 573/573 Turbo tasks plus all 28 dist-path consumer configs pass on the final head ([original complete log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-root-verify.log), [final-head validation](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-final-head-validation.json)).

### Repeated app audit

All target rows had DOM `good`, OCR `needs-eyeball`, `pixelBlank=false`, and `regression=false`. Passes 1–6 had identical word counts/confidences: mobile portrait 27/68%, mobile landscape 15/79%, desktop 30/77%, iPad 33/81%. A seventh exact-final-head pass preserved every count and verdict; mobile portrait confidence varied within the real engine from 68% to 70% while the other three confidences and screenshots remained exact.

| Pass | Scope | Playwright | OCR | Target result | Screenshot proof |
| --- | --- | ---: | ---: | --- | --- |
| 1 | Full app audit | 246/246 | 244 rows; 96 verified, 148 needs-eye, 0 broken/regressions | 4/4 good + nonblank | canonical hashes |
| 2 | Rolodex, all viewports | 4/4 | 4/4 needs-eye | identical | byte-identical |
| 3 | Rolodex, all viewports | 4/4 | 4/4 needs-eye | identical | byte-identical |
| 4 | Rolodex, all viewports | 4/4 | 4/4 needs-eye | identical | byte-identical |
| 5 | Rolodex, all viewports, recorded | 4/4 | 4/4 needs-eye | identical | 3 byte-identical; recorded iPad max channel delta 2, no visible/verdict change |
| 6 | Extra non-recorded stability check | 4/4 | 4/4 needs-eye | identical | byte-identical to passes 1–4 |
| 7 | Exact final head after coverage-test commit | 4/4 | 4/4 needs-eye, 0 regressions | identical verdicts | 3 byte-identical; mobile portrait manually reviewed, max channel delta 6 |

[Five byte-identical pass manifest plus recorded-pass variance](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-five-pass-determinism.json). Every listed screenshot and report was opened and reviewed manually.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-before-mobile-portrait.jpg) and [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-before-desktop-landscape.jpg) screenshots, plus the [wrong OCR report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-before-ocr-triage.json), are linked first below.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are linked for [mobile portrait](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-after-mobile-portrait.jpg), [mobile landscape](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-after-mobile-landscape.jpg), [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-after-desktop-landscape.jpg), and [iPad](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-after-ipad-portrait.jpg).
<!-- evidence-row:walkthrough-video -->
- [x] A [real Playwright MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-walkthrough.mp4) covering all four viewport capture flows is linked below.
<!-- evidence-row:backend-logs -->
- [x] N/A — this changes offline audit/OCR tooling, not a backend/runtime request path; no production backend behavior fires.
<!-- evidence-row:frontend-logs -->
- [x] [Mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-frontend-trace-mobile-portrait.zip) and [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-frontend-trace-desktop-landscape.zip) Playwright traces retain console, network, DOM snapshots, and screenshots; the [reviewed summary](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-frontend-log-summary.json) is linked below.
<!-- evidence-row:llm-trajectory -->
- [x] N/A — no agent, action, provider, prompt, model, or LLM behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] [Exact-capture corrected OCR JSON](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-corrected-exact-capture.json), [full 244-row OCR report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-full-ocr-triage.json), [determinism manifest](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-five-pass-determinism.json), [final-head validation](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-final-head-validation.json), and [asset manifest](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-asset-manifest.json) are linked below.

# Evidence Details

## Before — wrong result first

Exact historical run 29063969087, aesthetic artifact 8216843748, image digest `392331bd92be12b4d74508c2d0cc706774ca12b256d3227acade55807ff7eff4`:

![Before mobile portrait: populated launcher falsely classified blank](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-before-mobile-portrait.jpg)

![Before desktop landscape](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-before-desktop-landscape.jpg)

[Complete wrong OCR report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-before-ocr-triage.json)

```json
{
  "slug": "builtin-rolodex",
  "viewport": "mobile-portrait",
  "domVerdict": "good",
  "ocrVerdict": "broken",
  "reasons": ["pixels are blank — view painted no readable text"],
  "regression": true,
  "text": "oY)"
}
```

## Exact-capture diagnostics after the fix

![Deterministic high-contrast preprocessing of the exact wrong capture](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-diagnostic-high-contrast.jpg)

- [Direct engine result: both attempts, confidence, pixel analysis, finding](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-corrected-exact-capture.json)
- [Full triage result for the same authorized capture](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-corrected-exact-triage.json)

## After

![After mobile portrait](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-after-mobile-portrait.jpg)

![After mobile landscape](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-after-mobile-landscape.jpg)

![After desktop landscape](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-after-desktop-landscape.jpg)

![After iPad portrait](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-after-ipad-portrait.jpg)

## Walkthrough video

- [MP4 — four real Playwright capture sequences (31.8 seconds)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-walkthrough.mp4)
- [Manually reviewed final-frame contact sheet](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-walkthrough-contact-sheet.jpg)

The video was decoded end to end after conversion; early boot and final-render keyframes were opened manually.

## Backend + frontend logs

Backend: **N/A —** the changed code is the local screenshot/OCR verifier. It sends no production backend request and changes no server/runtime behavior.

Frontend evidence:

- [Reviewed trace summary](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-frontend-log-summary.json): mobile and desktop each reached startup `phase=ready`, mounted `rolodex` active, recorded 0 console errors, 0 page errors, and 0 HTTP 4xx/5xx responses.
- [Mobile portrait Playwright trace](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-frontend-trace-mobile-portrait.zip)
- [Desktop landscape Playwright trace](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-frontend-trace-desktop-landscape.zip)
- [Full app-audit log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-full-audit.log)
- [Recorded focused-audit log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-recorded-audit.log)

## Real LLM-call trajectory

N/A — no agent/action/provider/prompt/model behavior changes.

## Domain artifacts

- [Full 244-row DOM report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-full-audit-report.json)
- [Full 244-row OCR report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-full-ocr-triage.json)
- [Recorded four-row DOM report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-recorded-audit-report.json)
- [Recorded four-row OCR report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-recorded-ocr-triage.json)
- [Five-pass determinism manifest](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-five-pass-determinism.json)
- [Exact-final-head four-row DOM report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-final-head-audit-report.json)
- [Exact-final-head four-row OCR report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-final-head-ocr-triage.json)
- [Exact-final-head validation, test counts, coverage, hashes, and manual-review record](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-final-head-validation.json)
- [Uploaded asset SHA-256/size/direct-URL manifest](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16327-asset-manifest.json)

The original 30-asset manifest and the three additive final-head artifacts were checked against their local byte size and SHA-256; every direct URL returned HTTP 200. The existing `pr-evidence` release was preserved after reaching GitHub's 1,000-asset limit; these artifacts live in its non-destructive continuation, `pr-evidence-2`.

## Audio / voice walkthrough

N/A — no voice, transcript, TTS, STT, or audio behavior changes.

## Known gaps / failures

- A standalone `bun run --cwd packages/app typecheck` was initially invoked before its workspace build closure existed and reported missing generated `dist` declarations from dependent packages. The canonical root `bun run verify` built the Turbo dependency closure and passed `@elizaos/app:typecheck` plus all 28 dist-path consumers; this was an invocation-order issue, not a source failure.
- The full audit reports eight existing 1-second hover-probe timeouts on untouched Transcripts and Messages controls (four viewports each). Computed verdicts remain `broken=0`, `needs-work=0`; all seven focused Rolodex passes have `hover-probe-failures=0`.
- The recorded iPad PNG differs from non-recorded runs by at most 2/255 in 44,671 of 3,870,400 decoded channels. It was manually compared with no visible difference; OCR text/count/confidence and every verdict field are identical. Five non-recorded passes are byte-identical in every viewport.
- Native-device, backend, audio, and real-LLM evidence are N/A for this offline audit-classifier change for the concrete reasons above.
