### PR TITLE
fix(ci): make LifeOps live validation evidence fail closed

### DIFF
--- a/.github/workflows/lifeops-live-validation-11632.yml
+++ b/.github/workflows/lifeops-live-validation-11632.yml
@@ -15,12 +15,19 @@ on:
 permissions:
   contents: read
 
+env:
+  BUN_VERSION: "canary"
+  NODE_VERSION: "24.15.0"
+
 jobs:
   collect:
     runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    timeout-minutes: 45
     env:
+      CI: "true"
       ELIZA_SKIP_ARTIFACT_SYNC: "1"
       ELIZA_LIVE_TEST: "1"
+      LIFEOPS_EVIDENCE_DIR: ${{ github.workspace }}/reports/lifeops-live-validation/11632-status
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
@@ -53,26 +60,41 @@ jobs:
       PAYPAL_CLIENT_ID: ${{ secrets.PAYPAL_CLIENT_ID }}
       PAYPAL_CLIENT_SECRET: ${{ secrets.PAYPAL_CLIENT_SECRET }}
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: oven-sh/setup-bun@v2
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          bun-version: latest
+          submodules: false
+          show-progress: false
 
-      - name: Install
-        run: bun run install:light
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          node-version: ${{ env.NODE_VERSION }}
+          install-command: bun install --ignore-scripts --no-frozen-lockfile
+          install-native-deps: "false"
+          install-protoc: "false"
+          setup-python: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      - name: Prepare evidence directory
+        run: |
+          set -euo pipefail
+          rm -rf "$LIFEOPS_EVIDENCE_DIR"
+          mkdir -p "$LIFEOPS_EVIDENCE_DIR/pre" "$LIFEOPS_EVIDENCE_DIR/post"
 
       - name: Collect pre-run status
-        run: node scripts/lifeops/collect-11632-live-validation-status.mjs
+        run: >-
+          node scripts/lifeops/collect-11632-live-validation-status.mjs
+          --out "$LIFEOPS_EVIDENCE_DIR/pre/status.json"
 
       - name: Run OWNER/AGENT matrix
         if: ${{ inputs.run_keyless_matrix }}
         env:
           LIFEOPS_PERMISSION_MATRIX: "1"
-          LIFEOPS_EVIDENCE_DIR: ${{ runner.temp }}/evidence/8833-lifeops-live-validation/11632-status
         run: |
-          set -o pipefail
-          mkdir -p "$LIFEOPS_EVIDENCE_DIR"
+          set -euo pipefail
           bunx vitest run \
             --config packages/test/vitest/integration.config.ts \
             plugins/plugin-personal-assistant/test/owner-agent-permission-matrix.integration.test.ts \
@@ -82,10 +104,8 @@ jobs:
         if: ${{ inputs.run_live_connectors }}
         env:
           TEST_LANE: post-merge
-          LIFEOPS_EVIDENCE_DIR: ${{ runner.temp }}/evidence/8833-lifeops-live-validation/11632-status
         run: |
-          set -o pipefail
-          mkdir -p "$LIFEOPS_EVIDENCE_DIR"
+          set -euo pipefail
           bun run --cwd plugins/plugin-google test \
             2>&1 | tee "$LIFEOPS_EVIDENCE_DIR/plugin-google-live.txt"
 
@@ -93,20 +113,29 @@ jobs:
         if: ${{ inputs.run_live_connectors }}
         env:
           TEST_LANE: post-merge
-          LIFEOPS_EVIDENCE_DIR: ${{ runner.temp }}/evidence/8833-lifeops-live-validation/11632-status
         run: |
-          set -o pipefail
-          mkdir -p "$LIFEOPS_EVIDENCE_DIR"
+          set -euo pipefail
           bun run --cwd plugins/plugin-x test \
             2>&1 | tee "$LIFEOPS_EVIDENCE_DIR/plugin-x-live.txt"
 
       - name: Collect post-run status
         if: always()
-        run: node scripts/lifeops/collect-11632-live-validation-status.mjs
+        run: >-
+          node scripts/lifeops/collect-11632-live-validation-status.mjs
+          --out "$LIFEOPS_EVIDENCE_DIR/post/status.json"
+
+      - name: Validate evidence contract
+        if: always()
+        env:
+          RUN_KEYLESS_MATRIX: ${{ inputs.run_keyless_matrix }}
+          RUN_LIVE_CONNECTORS: ${{ inputs.run_live_connectors }}
+        run: node scripts/lifeops/validate-11632-evidence.mjs
 
       - name: Upload status artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: lifeops-11632-live-validation-status
-          path: ${{ runner.temp }}/evidence/8833-lifeops-live-validation/11632-status/
+          name: lifeops-11632-live-validation-status-${{ github.sha }}
+          path: reports/lifeops-live-validation/11632-status/
+          if-no-files-found: error
+          retention-days: 14

--- a/packages/scripts/__tests__/lifeops-live-validation-workflow.test.ts
+++ b/packages/scripts/__tests__/lifeops-live-validation-workflow.test.ts
@@ -4,7 +4,6 @@
  * shell contract GitHub runs rejects missing permission-matrix results.
  */
 import { describe, expect, test } from "bun:test";
-import { spawnSync } from "node:child_process";
 import {
   mkdirSync,
   mkdtempSync,
@@ -14,7 +13,13 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import {
+  applyDeviceReadiness,
+  buildStatus,
+  groupStatus,
+  renderMarkdown,
+} from "../../../scripts/lifeops/collect-11632-live-validation-status.mjs";
+import { validate11632EvidenceFromEnv } from "../../../scripts/lifeops/validate-11632-evidence.mjs";
 
 const repoRoot = new URL("../../../", import.meta.url);
 const workflowText = readFileSync(
@@ -44,7 +49,6 @@ interface Workflow {
 
 const workflow = Bun.YAML.parse(workflowText) as Workflow;
 const job = workflow.jobs?.collect;
-const repoRootPath = fileURLToPath(repoRoot);
 
 function namedStep(name: string): WorkflowStep {
   const step = job?.steps?.find((candidate) => candidate.name === name);
@@ -74,25 +78,33 @@ function seedStatusArtifact(root: string, matrixLog: string): void {
 
 function runEvidenceValidation(
   root: string,
-  options: { requestedConnectors?: boolean } = {},
+  options: {
+    requestedMatrix?: boolean;
+    requestedConnectors?: boolean;
+    runKeylessMatrix?: string;
+    runLiveConnectors?: string;
+  } = {},
 ) {
-  return spawnSync(
-    "bash",
-    ["-c", namedStep("Validate evidence contract").run ?? ""],
-    {
-      cwd: repoRootPath,
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        LIFEOPS_EVIDENCE_DIR: root,
-        RUN_KEYLESS_MATRIX: "true",
-        RUN_LIVE_CONNECTORS: String(options.requestedConnectors ?? false),
-        GITHUB_SHA: "0123456789abcdef",
-        GITHUB_RUN_ID: "1234",
-        GITHUB_RUN_ATTEMPT: "1",
-      },
-    },
-  );
+  try {
+    const manifest = validate11632EvidenceFromEnv({
+      LIFEOPS_EVIDENCE_DIR: root,
+      RUN_KEYLESS_MATRIX:
+        options.runKeylessMatrix ?? String(options.requestedMatrix ?? true),
+      RUN_LIVE_CONNECTORS:
+        options.runLiveConnectors ??
+        String(options.requestedConnectors ?? false),
+      GITHUB_SHA: "0123456789abcdef",
+      GITHUB_RUN_ID: "1234",
+      GITHUB_RUN_ATTEMPT: "1",
+    });
+    return { status: 0, stderr: "", manifest };
+  } catch (error) {
+    return {
+      status: 1,
+      stderr: error instanceof Error ? error.message : String(error),
+      manifest: null,
+    };
+  }
 }
 
 describe("#11632 LifeOps live-validation workflow", () => {
@@ -202,5 +214,176 @@ describe("#11632 LifeOps live-validation workflow", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
+  });
+
+  test("accepts requested connector logs only when both executed without skips", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "lifeops-11632-workflow-"));
+    try {
+      seedStatusArtifact(
+        root,
+        "Test Files  1 passed (1)\nTests  20 passed (20)\n",
+      );
+      for (const filename of ["plugin-google-live.txt", "plugin-x-live.txt"]) {
+        writeFileSync(
+          path.join(root, filename),
+          "Test Files  1 passed (1)\nTests  4 passed (4)\n",
+        );
+      }
+
+      const result = runEvidenceValidation(root, {
+        requestedConnectors: true,
+      });
+      expect(result.status).toBe(0);
+      expect(result.manifest?.proof.connectors).toEqual({
+        "plugin-google-live.txt": expect.objectContaining({ passed: 4 }),
+        "plugin-x-live.txt": expect.objectContaining({ passed: 4 }),
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects status snapshots that claim the wrong issue or closeable verdict", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "lifeops-11632-workflow-"));
+    try {
+      seedStatusArtifact(
+        root,
+        "Test Files  1 passed (1)\nTests  20 passed (20)\n",
+      );
+      writeFileSync(
+        path.join(root, "post/status.json"),
+        `${JSON.stringify({
+          issue: 999,
+          generatedAt: "2026-07-14T00:00:01.000Z",
+          verdict: { closeable: true },
+        })}\n`,
+      );
+
+      const result = runEvidenceValidation(root);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("wrong issue or fabricated");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects malformed workflow booleans before reading an artifact", () => {
+    const result = runEvidenceValidation("unused", {
+      runKeylessMatrix: "yes",
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "RUN_KEYLESS_MATRIX must be exactly true or false",
+    );
+  });
+
+  test("collector distinguishes required-all, required-any, optional, and blank env", () => {
+    const names = ["LIFEOPS_TEST_ALL", "LIFEOPS_TEST_ANY", "LIFEOPS_TEST_OPT"];
+    const previous = Object.fromEntries(
+      names.map((name) => [name, process.env[name]]),
+    );
+    try {
+      process.env.LIFEOPS_TEST_ALL = "present";
+      process.env.LIFEOPS_TEST_ANY = "   ";
+      process.env.LIFEOPS_TEST_OPT = "optional";
+      const blocked = groupStatus({
+        id: "fixture",
+        label: "Fixture",
+        requiredAll: ["LIFEOPS_TEST_ALL"],
+        requiredAny: ["LIFEOPS_TEST_ANY"],
+        optional: ["LIFEOPS_TEST_OPT"],
+      });
+      expect(blocked.readyForOperatorRun).toBe(false);
+      expect(blocked.present).toEqual(["LIFEOPS_TEST_ALL", "LIFEOPS_TEST_OPT"]);
+      expect(blocked.missingRequiredAll).toEqual([]);
+      expect(blocked.missingRequiredAny).toEqual(["LIFEOPS_TEST_ANY"]);
+
+      process.env.LIFEOPS_TEST_ANY = "ready";
+      expect(
+        groupStatus({
+          id: "fixture",
+          label: "Fixture",
+          requiredAll: ["LIFEOPS_TEST_ALL"],
+          requiredAny: ["LIFEOPS_TEST_ANY"],
+        }).readyForOperatorRun,
+      ).toBe(true);
+    } finally {
+      for (const name of names) {
+        const value = previous[name];
+        if (value === undefined) delete process.env[name];
+        else process.env[name] = value;
+      }
+    }
+  });
+
+  test("collector requires the configured Android serial to be online", () => {
+    const online = [
+      {
+        id: "native_android",
+        readyForOperatorRun: true,
+        missingRequiredAny: [],
+      },
+    ];
+    // biome-ignore lint/suspicious/noUndeclaredEnvVars: isolated fixture restores the operator-only device selector before returning.
+    const previous = process.env.ANDROID_SERIAL;
+    process.env.ANDROID_SERIAL = "device-123";
+    try {
+      applyDeviceReadiness(online, {
+        adb: {
+          summary: "List of devices attached\ndevice-123 device product:test",
+        },
+      });
+      expect(online[0]).toMatchObject({
+        readyForOperatorRun: true,
+        deviceReady: true,
+      });
+
+      const offline = [
+        {
+          id: "native_android",
+          readyForOperatorRun: true,
+          missingRequiredAny: [],
+        },
+      ];
+      applyDeviceReadiness(offline, {
+        adb: { summary: "device-123 offline" },
+      });
+      expect(offline[0]?.readyForOperatorRun).toBe(false);
+      expect(offline[0]?.missingRequiredAny).toContain(
+        "online adb device device-123",
+      );
+    } finally {
+      // biome-ignore lint/suspicious/noUndeclaredEnvVars: isolated fixture restores the operator-only device selector before returning.
+      if (previous === undefined) delete process.env.ANDROID_SERIAL;
+      else process.env.ANDROID_SERIAL = previous;
+    }
+  });
+
+  test("collector builds and renders the complete fail-closed status ledger", () => {
+    const status = buildStatus();
+    expect(status.issue).toBe(11632);
+    expect(status.verdict.closeable).toBe(false);
+    expect(status.envGroups).toHaveLength(13);
+    expect(status.existingEvidence).toHaveLength(14);
+    expect(status.nextCommands).toContain(
+      "bun run --cwd packages/app capture:android-emu",
+    );
+
+    const markdown = renderMarkdown({
+      ...status,
+      envGroups: [
+        {
+          ...status.envGroups[0],
+          label: "Model | live",
+        },
+      ],
+      devices: {
+        ...status.devices,
+        adb: { ...status.devices.adb, summary: "line one\nline two" },
+      },
+    });
+    expect(markdown).toContain("Model \\| live");
+    expect(markdown).toContain("line one<br>line two");
+    expect(markdown).toContain("Verdict: **not closeable**");
   });
 });

--- a/packages/scripts/__tests__/lifeops-live-validation-workflow.test.ts
+++ b/packages/scripts/__tests__/lifeops-live-validation-workflow.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Locks the #11632 manual validation lane to a clean-checkout source graph and
+ * a fail-closed evidence artifact. The executable fixture proves that the same
+ * shell contract GitHub runs rejects missing permission-matrix results.
+ */
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = new URL("../../../", import.meta.url);
+const workflowText = readFileSync(
+  new URL(".github/workflows/lifeops-live-validation-11632.yml", repoRoot),
+  "utf8",
+);
+const integrationConfig = readFileSync(
+  new URL("packages/test/vitest/integration.config.ts", repoRoot),
+  "utf8",
+);
+
+interface WorkflowStep {
+  name?: string;
+  uses?: string;
+  run?: string;
+  with?: Record<string, string | number>;
+}
+
+interface WorkflowJob {
+  env?: Record<string, string>;
+  steps?: WorkflowStep[];
+}
+
+interface Workflow {
+  jobs?: Record<string, WorkflowJob>;
+}
+
+const workflow = Bun.YAML.parse(workflowText) as Workflow;
+const job = workflow.jobs?.collect;
+const repoRootPath = fileURLToPath(repoRoot);
+
+function namedStep(name: string): WorkflowStep {
+  const step = job?.steps?.find((candidate) => candidate.name === name);
+  if (!step) throw new Error(`Missing #11632 workflow step: ${name}`);
+  return step;
+}
+
+function seedStatusArtifact(root: string, matrixLog: string): void {
+  for (const phase of ["pre", "post"]) {
+    const directory = path.join(root, phase);
+    mkdirSync(directory, { recursive: true });
+    writeFileSync(path.join(directory, "README.md"), `${phase} status\n`);
+    writeFileSync(
+      path.join(directory, "status.json"),
+      `${JSON.stringify({
+        issue: 11632,
+        generatedAt: `2026-07-14T00:00:0${phase === "pre" ? "0" : "1"}.000Z`,
+        verdict: { closeable: false },
+      })}\n`,
+    );
+  }
+  writeFileSync(
+    path.join(root, "owner-agent-permission-matrix.txt"),
+    matrixLog,
+  );
+}
+
+function runEvidenceValidation(
+  root: string,
+  options: { requestedConnectors?: boolean } = {},
+) {
+  return spawnSync(
+    "bash",
+    ["-c", namedStep("Validate evidence contract").run ?? ""],
+    {
+      cwd: repoRootPath,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        LIFEOPS_EVIDENCE_DIR: root,
+        RUN_KEYLESS_MATRIX: "true",
+        RUN_LIVE_CONNECTORS: String(options.requestedConnectors ?? false),
+        GITHUB_SHA: "0123456789abcdef",
+        GITHUB_RUN_ID: "1234",
+        GITHUB_RUN_ATTEMPT: "1",
+      },
+    },
+  );
+}
+
+describe("#11632 LifeOps live-validation workflow", () => {
+  test("resolves clean-checkout cloud imports from source before collection", () => {
+    expect(integrationConfig).toContain("find: /^@elizaos\\/cloud-routing$/");
+    expect(integrationConfig).toContain(
+      '"packages",\n  "cloud",\n  "routing",',
+    );
+    expect(integrationConfig).toContain(
+      "find: /^@elizaos\\/plugin-elizacloud$/",
+    );
+    expect(integrationConfig).toContain('"index.node.ts"');
+    expect(integrationConfig).toContain('conditions: ["eliza-source"]');
+    expect(integrationConfig).toContain(
+      "...buildHarnessSourceAliases(elizaWorkspaceRoot)",
+    );
+  });
+
+  test("uploads the same report tree populated by both status collectors", () => {
+    expect(job?.env?.LIFEOPS_EVIDENCE_DIR).toContain(
+      "reports/lifeops-live-validation/11632-status",
+    );
+    expect(namedStep("Collect pre-run status").run).toContain(
+      '"$LIFEOPS_EVIDENCE_DIR/pre/status.json"',
+    );
+    expect(namedStep("Collect post-run status").run).toContain(
+      '"$LIFEOPS_EVIDENCE_DIR/post/status.json"',
+    );
+    expect(namedStep("Validate evidence contract").run).toBe(
+      "node scripts/lifeops/validate-11632-evidence.mjs",
+    );
+    expect(namedStep("Upload status artifact").with?.path).toBe(
+      "reports/lifeops-live-validation/11632-status/",
+    );
+    expect(
+      namedStep("Upload status artifact").with?.["if-no-files-found"],
+    ).toBe("error");
+  });
+
+  test("accepts a complete 20-pass fixture and emits a hash manifest", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "lifeops-11632-workflow-"));
+    try {
+      seedStatusArtifact(
+        root,
+        "Test Files  1 passed (1)\nTests  20 passed (20)\n",
+      );
+
+      const result = runEvidenceValidation(root);
+      expect(result.status).toBe(0);
+      const manifest = JSON.parse(
+        readFileSync(path.join(root, "artifact-manifest.json"), "utf8"),
+      ) as {
+        schema: string;
+        commit: string;
+        artifacts: Array<{ bytes: number; sha256: string }>;
+      };
+      expect(manifest.schema).toBe("eliza_lifeops_11632_evidence_v1");
+      expect(manifest.commit).toBe("0123456789abcdef");
+      expect(manifest.artifacts).toHaveLength(5);
+      expect(manifest.artifacts.every((artifact) => artifact.bytes > 0)).toBe(
+        true,
+      );
+      expect(
+        manifest.artifacts.every((artifact) =>
+          /^[a-f0-9]{64}$/.test(artifact.sha256),
+        ),
+      ).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects an empty or non-passing matrix artifact", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "lifeops-11632-workflow-"));
+    try {
+      seedStatusArtifact(root, "");
+
+      const result = runEvidenceValidation(root);
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toMatch(
+        /Evidence artifact is empty|does not prove exactly 20 passing tests/,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects requested connector logs with skipped tests", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "lifeops-11632-workflow-"));
+    try {
+      seedStatusArtifact(
+        root,
+        "Test Files  1 passed (1)\nTests  20 passed (20)\n",
+      );
+      for (const filename of ["plugin-google-live.txt", "plugin-x-live.txt"]) {
+        writeFileSync(
+          path.join(root, filename),
+          "Test Files  1 passed (1)\nTests  4 passed | 1 skipped (5)\n",
+        );
+      }
+
+      const result = runEvidenceValidation(root, {
+        requestedConnectors: true,
+      });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("is not skip-free live proof");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/test/vitest/integration.config.ts
+++ b/packages/test/vitest/integration.config.ts
@@ -9,6 +9,7 @@ import {
   getSharedSourceRoot,
   getUiSourceRoot,
 } from "../eliza-package-paths";
+import { buildHarnessSourceAliases } from "../harness/source-aliases";
 import { repoRoot } from "./repo-root";
 import {
   getAgentSourceAliases,
@@ -119,6 +120,35 @@ const appManagerAliases: ModuleAlias[] = existsSync(appManagerSource)
       },
     ]
   : [];
+// Core is source-aliased in this lane and re-exports the cloud-routing package.
+// Clean CI checkouts do not build that package first, so resolving its default
+// dist export would abort collection before any integration test can run.
+const cloudRoutingSource = path.join(
+  elizaWorkspaceRoot,
+  "packages",
+  "cloud",
+  "routing",
+  "src",
+  "index.ts",
+);
+// The agent barrel keeps Cloud route handlers lazy, but Vite still resolves
+// the literal dynamic import during transform. Point it at the Node source
+// entry (and its SDK dependency at source) so an unused lazy route cannot make
+// an unrelated integration suite depend on prebuilt plugin artifacts.
+const cloudSdkSource = path.join(
+  elizaWorkspaceRoot,
+  "packages",
+  "cloud",
+  "sdk",
+  "src",
+  "index.ts",
+);
+const elizaCloudSourceRoot = path.join(
+  elizaWorkspaceRoot,
+  "plugins",
+  "plugin-elizacloud",
+  "src",
+);
 // Include/exclude globs are cwd-relative, but the eliza workspace sits at
 // `eliza/` in the nested eliza layout and at the repo root in a flat eliza
 // checkout (#11047). Derive the prefix instead of hardcoding `eliza/` so the
@@ -147,6 +177,35 @@ const integrationResolveAlias: ModuleAlias[] = [
   ...discordSubpathAliases,
   ...appControlSubpathAliases,
   ...appManagerAliases,
+  {
+    find: /^@elizaos\/cloud-routing$/,
+    replacement: cloudRoutingSource,
+  },
+  {
+    find: /^@elizaos\/cloud-sdk$/,
+    replacement: cloudSdkSource,
+  },
+  {
+    find: /^@elizaos\/plugin-elizacloud$/,
+    replacement: path.join(elizaCloudSourceRoot, "index.node.ts"),
+  },
+  {
+    find: /^@elizaos\/plugin-elizacloud\/(.+)$/,
+    replacement: `${elizaCloudSourceRoot.split(path.sep).join("/")}/$1`,
+  },
+  {
+    // The generic source alias maps subpaths to sibling `.ts` files; `kms` is
+    // an index directory, so preserve the package's explicit export shape.
+    find: /^@elizaos\/security\/kms$/,
+    replacement: path.join(
+      elizaWorkspaceRoot,
+      "packages",
+      "security",
+      "src",
+      "kms",
+      "index.ts",
+    ),
+  },
   ...(elizaCoreEntry
     ? [
         // Subpath aliases must precede the bare specifier. A bare-string
@@ -175,6 +234,10 @@ const integrationResolveAlias: ModuleAlias[] = [
     "plugin-shopify",
   ]),
   ...getSharedSourceAliases(sharedSourceRoot),
+  // Vite's SSR resolver does not consistently select custom export
+  // conditions, so source-alias the remaining workspace leaves after the
+  // specialized entry points above. This keeps clean CI independent of dist.
+  ...buildHarnessSourceAliases(elizaWorkspaceRoot),
   ...getOptionalInstalledPackageAliases(repoRoot, [
     {
       find: "@elizaos/plugin-signal",
@@ -223,6 +286,10 @@ const integrationResolveAlias: ModuleAlias[] = [
 
 export default defineConfig({
   resolve: {
+    // Prefer the workspace TypeScript branches in resolver paths that honor
+    // custom export conditions. The explicit and comprehensive aliases above
+    // cover Vite SSR paths that do not apply this condition consistently.
+    conditions: ["eliza-source"],
     alias: integrationResolveAlias,
   },
   test: {

--- a/scripts/lifeops/collect-11632-live-validation-status.mjs
+++ b/scripts/lifeops/collect-11632-live-validation-status.mjs
@@ -223,7 +223,7 @@ function adbHasOnlineSerial(adbSummary, serial) {
   });
 }
 
-function applyDeviceReadiness(envGroups, devices) {
+export function applyDeviceReadiness(envGroups, devices) {
   const androidGroup = envGroups.find((group) => group.id === "native_android");
   if (!androidGroup?.readyForOperatorRun) return;
 
@@ -265,7 +265,7 @@ export function liveConnectorRowsProven(existingEvidence) {
   });
 }
 
-function buildStatus() {
+export function buildStatus() {
   const envGroups = CONNECTOR_GROUPS.map(groupStatus);
   const existingEvidence = [
     fileStatus(`${LIFEOPS_REPORT_ROOT}/README.md`),
@@ -360,7 +360,7 @@ function buildStatus() {
   };
 }
 
-function renderMarkdown(status) {
+export function renderMarkdown(status) {
   const cell = (value) =>
     String(value || "n/a")
       .replaceAll("|", "\\|")

--- a/scripts/lifeops/collect-11632-live-validation-status.mjs
+++ b/scripts/lifeops/collect-11632-live-validation-status.mjs
@@ -19,6 +19,10 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { applyLayeredEnvToProcess } from "./env-layers.mjs";
+import {
+  isLiveVitestProof,
+  parseVitestCounts,
+} from "./validate-11632-evidence.mjs";
 
 const ROOT = resolve(new URL("../..", import.meta.url).pathname);
 const DEFAULT_OUT = join(
@@ -26,6 +30,10 @@ const DEFAULT_OUT = join(
   "reports/lifeops-live-validation/11632-status/status.json",
 );
 const LIFEOPS_REPORT_ROOT = "reports/lifeops-live-validation";
+const REQUIRED_LIVE_EVIDENCE_PATHS = [
+  `${LIFEOPS_REPORT_ROOT}/11632-status/plugin-google-live.txt`,
+  `${LIFEOPS_REPORT_ROOT}/11632-status/plugin-x-live.txt`,
+];
 
 export const CONNECTOR_GROUPS = [
   {
@@ -245,7 +253,16 @@ function parseEvidenceLog(path, patterns) {
     path,
     exists: true,
     matched: patterns.filter((pattern) => pattern.test(text)).map(String),
+    vitestCounts: parseVitestCounts(text),
   };
+}
+
+/** Require a real, skip-free Vitest result for every live connector row. */
+export function liveConnectorRowsProven(existingEvidence) {
+  return REQUIRED_LIVE_EVIDENCE_PATHS.every((path) => {
+    const entry = existingEvidence.find((candidate) => candidate.path === path);
+    return Boolean(entry?.exists && isLiveVitestProof(entry.vitestCounts));
+  });
 }
 
 function buildStatus() {
@@ -316,12 +333,7 @@ function buildStatus() {
     (group) => group.readyForOperatorRun,
   );
   const blockedGroups = envGroups.filter((group) => !group.readyForOperatorRun);
-  const liveRowsProven = existingEvidence.some(
-    (entry) =>
-      entry.exists &&
-      (entry.path?.includes("plugin-google-live") ||
-        entry.path?.includes("plugin-x-live")),
-  );
+  const liveRowsProven = liveConnectorRowsProven(existingEvidence);
 
   return {
     issue: 11632,

--- a/scripts/lifeops/collect-11632-live-validation-status.test.mjs
+++ b/scripts/lifeops/collect-11632-live-validation-status.test.mjs
@@ -1,0 +1,54 @@
+/**
+ * Verifies that #11632 status can only claim live connector evidence when both
+ * required Vitest logs contain executed, skip-free test summaries.
+ */
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { liveConnectorRowsProven } from "./collect-11632-live-validation-status.mjs";
+
+const GOOGLE_PATH =
+  "reports/lifeops-live-validation/11632-status/plugin-google-live.txt";
+const X_PATH = "reports/lifeops-live-validation/11632-status/plugin-x-live.txt";
+
+function evidence(path, { passed = 1, failed = 0, skipped = 0 } = {}) {
+  return {
+    path,
+    exists: true,
+    vitestCounts: {
+      passed,
+      failed,
+      skipped,
+      summaryLines: ["Tests summary"],
+    },
+  };
+}
+
+describe("#11632 live connector proof", () => {
+  it("requires both connector rows", () => {
+    assert.equal(liveConnectorRowsProven([evidence(GOOGLE_PATH)]), false);
+  });
+
+  it("accepts two executed, skip-free connector rows", () => {
+    assert.equal(
+      liveConnectorRowsProven([evidence(GOOGLE_PATH), evidence(X_PATH)]),
+      true,
+    );
+  });
+
+  it("rejects failures and skips", () => {
+    assert.equal(
+      liveConnectorRowsProven([
+        evidence(GOOGLE_PATH),
+        evidence(X_PATH, { skipped: 1 }),
+      ]),
+      false,
+    );
+    assert.equal(
+      liveConnectorRowsProven([
+        evidence(GOOGLE_PATH, { failed: 1 }),
+        evidence(X_PATH),
+      ]),
+      false,
+    );
+  });
+});

--- a/scripts/lifeops/validate-11632-evidence.mjs
+++ b/scripts/lifeops/validate-11632-evidence.mjs
@@ -176,29 +176,29 @@ export function validate11632Evidence({
   return manifest;
 }
 
+/** Validate the workflow contract directly from an Actions-style environment. */
+export function validate11632EvidenceFromEnv(env) {
+  return validate11632Evidence({
+    root: env.LIFEOPS_EVIDENCE_DIR,
+    requestedMatrix: requiredBoolean(
+      "RUN_KEYLESS_MATRIX",
+      env.RUN_KEYLESS_MATRIX,
+    ),
+    requestedConnectors: requiredBoolean(
+      "RUN_LIVE_CONNECTORS",
+      env.RUN_LIVE_CONNECTORS,
+    ),
+    commit: env.GITHUB_SHA,
+    runId: env.GITHUB_RUN_ID,
+    runAttempt: env.GITHUB_RUN_ATTEMPT,
+  });
+}
+
 const IS_MAIN =
   import.meta.main || process.argv[1] === fileURLToPath(import.meta.url);
 
 if (IS_MAIN) {
-  const {
-    LIFEOPS_EVIDENCE_DIR,
-    RUN_KEYLESS_MATRIX,
-    RUN_LIVE_CONNECTORS,
-    GITHUB_SHA,
-    GITHUB_RUN_ID,
-    GITHUB_RUN_ATTEMPT,
-  } = process.env;
-  const manifest = validate11632Evidence({
-    root: LIFEOPS_EVIDENCE_DIR,
-    requestedMatrix: requiredBoolean("RUN_KEYLESS_MATRIX", RUN_KEYLESS_MATRIX),
-    requestedConnectors: requiredBoolean(
-      "RUN_LIVE_CONNECTORS",
-      RUN_LIVE_CONNECTORS,
-    ),
-    commit: GITHUB_SHA,
-    runId: GITHUB_RUN_ID,
-    runAttempt: GITHUB_RUN_ATTEMPT,
-  });
+  const manifest = validate11632EvidenceFromEnv(process.env);
   console.log(
     `[11632-evidence] validated ${manifest.artifacts.length} artifact(s) for ${manifest.commit}`,
   );

--- a/scripts/lifeops/validate-11632-evidence.mjs
+++ b/scripts/lifeops/validate-11632-evidence.mjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+/**
+ * Validates and inventories the #11632 LifeOps workflow artifact. Both status
+ * snapshots, every requested live lane, exact-run provenance, and every byte
+ * included in the upload must be present before a hash manifest is written.
+ */
+import { createHash } from "node:crypto";
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+function requiredText(name, value) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${name} is required`);
+  }
+  return value.trim();
+}
+
+function requiredBoolean(name, value) {
+  if (value === "true") return true;
+  if (value === "false") return false;
+  throw new Error(`${name} must be exactly true or false`);
+}
+
+function stripAnsi(text) {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: Vitest colors its summary in TTY-backed Actions logs.
+  return text.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+/** Parse all Vitest `Tests` summary lines from one captured lane. */
+export function parseVitestCounts(logText) {
+  const counts = { passed: 0, failed: 0, skipped: 0 };
+  const summaryLines =
+    stripAnsi(logText).match(/^[ \t]*Tests[ \t]+[^\n]*$/gm) ?? [];
+  for (const line of summaryLines) {
+    for (const key of Object.keys(counts)) {
+      const match = new RegExp(`(\\d+)\\s+${key}`).exec(line);
+      if (match) counts[key] += Number(match[1]);
+    }
+  }
+  return { ...counts, summaryLines: summaryLines.map((line) => line.trim()) };
+}
+
+/** A live lane is proof only when tests ran and none failed or skipped. */
+export function isLiveVitestProof(counts) {
+  return (
+    counts.summaryLines.length > 0 &&
+    counts.passed > 0 &&
+    counts.failed === 0 &&
+    counts.skipped === 0
+  );
+}
+
+function readNonempty(root, relativePath) {
+  const absolute = path.join(root, relativePath);
+  const bytes = readFileSync(absolute);
+  if (bytes.length === 0) {
+    throw new Error(`Evidence artifact is empty: ${relativePath}`);
+  }
+  return { absolute, bytes };
+}
+
+function readStatus(root, relativePath) {
+  const { bytes } = readNonempty(root, relativePath);
+  const status = JSON.parse(bytes.toString("utf8"));
+  if (status.issue !== 11632 || status.verdict?.closeable !== false) {
+    throw new Error(
+      `${relativePath} has the wrong issue or fabricated a closeable verdict`,
+    );
+  }
+  return status;
+}
+
+function listFiles(root) {
+  const files = [];
+  const visit = (directory) => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const absolute = path.join(directory, entry.name);
+      if (entry.isDirectory()) visit(absolute);
+      else if (entry.isFile() && entry.name !== "artifact-manifest.json") {
+        files.push(absolute);
+      }
+    }
+  };
+  visit(root);
+  return files.sort();
+}
+
+/** Validate the artifact tree and write its exact-byte manifest. */
+export function validate11632Evidence({
+  root,
+  requestedMatrix,
+  requestedConnectors,
+  commit,
+  runId,
+  runAttempt,
+}) {
+  const evidenceRoot = path.resolve(requiredText("root", root));
+  const provenance = {
+    commit: requiredText("commit", commit),
+    runId: requiredText("runId", runId),
+    runAttempt: requiredText("runAttempt", runAttempt),
+  };
+
+  for (const relativePath of ["pre/README.md", "post/README.md"]) {
+    readNonempty(evidenceRoot, relativePath);
+  }
+  const preStatus = readStatus(evidenceRoot, "pre/status.json");
+  const postStatus = readStatus(evidenceRoot, "post/status.json");
+
+  let matrixCounts = null;
+  if (requestedMatrix) {
+    const matrix = readNonempty(
+      evidenceRoot,
+      "owner-agent-permission-matrix.txt",
+    ).bytes.toString("utf8");
+    matrixCounts = parseVitestCounts(matrix);
+    if (
+      matrixCounts.passed !== 20 ||
+      matrixCounts.failed !== 0 ||
+      matrixCounts.skipped !== 0
+    ) {
+      throw new Error(
+        "OWNER/AGENT matrix artifact does not prove exactly 20 passing tests",
+      );
+    }
+  }
+
+  const connectorCounts = {};
+  for (const filename of requestedConnectors
+    ? ["plugin-google-live.txt", "plugin-x-live.txt"]
+    : []) {
+    const log = readNonempty(evidenceRoot, filename).bytes.toString("utf8");
+    const counts = parseVitestCounts(log);
+    if (!isLiveVitestProof(counts)) {
+      throw new Error(
+        `Requested connector artifact is not skip-free live proof: ${filename}`,
+      );
+    }
+    connectorCounts[filename] = counts;
+  }
+
+  const artifacts = listFiles(evidenceRoot).map((absolute) => {
+    const bytes = readFileSync(absolute);
+    if (bytes.length === 0) {
+      throw new Error(
+        `Evidence artifact is empty: ${path.relative(evidenceRoot, absolute)}`,
+      );
+    }
+    return {
+      path: path.relative(evidenceRoot, absolute).split(path.sep).join("/"),
+      bytes: bytes.length,
+      sha256: createHash("sha256").update(bytes).digest("hex"),
+    };
+  });
+
+  const manifest = {
+    schema: "eliza_lifeops_11632_evidence_v1",
+    issue: 11632,
+    ...provenance,
+    requestedMatrix,
+    requestedConnectors,
+    proof: {
+      matrix: matrixCounts,
+      connectors: connectorCounts,
+      preGeneratedAt: preStatus.generatedAt,
+      postGeneratedAt: postStatus.generatedAt,
+      closeable: false,
+    },
+    artifacts,
+  };
+  writeFileSync(
+    path.join(evidenceRoot, "artifact-manifest.json"),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+  return manifest;
+}
+
+const IS_MAIN =
+  import.meta.main || process.argv[1] === fileURLToPath(import.meta.url);
+
+if (IS_MAIN) {
+  const {
+    LIFEOPS_EVIDENCE_DIR,
+    RUN_KEYLESS_MATRIX,
+    RUN_LIVE_CONNECTORS,
+    GITHUB_SHA,
+    GITHUB_RUN_ID,
+    GITHUB_RUN_ATTEMPT,
+  } = process.env;
+  const manifest = validate11632Evidence({
+    root: LIFEOPS_EVIDENCE_DIR,
+    requestedMatrix: requiredBoolean("RUN_KEYLESS_MATRIX", RUN_KEYLESS_MATRIX),
+    requestedConnectors: requiredBoolean(
+      "RUN_LIVE_CONNECTORS",
+      RUN_LIVE_CONNECTORS,
+    ),
+    commit: GITHUB_SHA,
+    runId: GITHUB_RUN_ID,
+    runAttempt: GITHUB_RUN_ATTEMPT,
+  });
+  console.log(
+    `[11632-evidence] validated ${manifest.artifacts.length} artifact(s) for ${manifest.commit}`,
+  );
+}


### PR DESCRIPTION
## Summary

Repairs the agent-resolvable validation-harness residual in #11632 without claiming that credentialed connector or physical-device rows are complete.

- resolves monorepo sources in the integration Vitest config so the OWNER/AGENT matrix actually collects on a clean runner
- sends pre-run status, matrix output, optional connector output, and post-run status into one clean artifact root
- validates every promised artifact before upload and writes a SHA-256 manifest
- parses real Vitest terminal summaries instead of treating any non-empty file as proof
- exposes the collector/validator contracts to direct regression tests, including missing/truncated output and manifest integrity failures
- pins workflow actions and checks out the exact triggering ref

This intentionally does not close #11632. OWNER/AGENT connector accounts, health/finance sandboxes, and physical iOS/Android evidence remain human-provisioned rows.

## Verification

Exact head: `0657888d72d1dc3b4e7d50806f1ddc440cd3b335`

- `bun run verify`: 573/573 Turbo tasks; all follow-on audits passed; 28/28 dist consumers
- `actionlint .github/workflows/lifeops-live-validation-11632.yml`
- Biome check on every edited source/workflow file
- Node collector contract suite: 3/3
- Bun workflow/validator contract suite: 11/11
- changed-file coverage: collector 90.11%, validator 92.68%
- [exact-head workflow run 29306015739](https://github.com/elizaOS/eliza/actions/runs/29306015739): 20/20 real PGLite OWNER/AGENT integration cases; evidence validation and upload passed

## Evidence gate

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots: N/A - workflow, validation script, configuration, and test-only change with no rendered UI surface.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots: N/A - workflow, validation script, configuration, and test-only change with no rendered UI surface.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: N/A - no interactive or rendered user flow changes.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: [exact-head workflow run with the real matrix log](https://github.com/elizaOS/eliza/actions/runs/29306015739).

<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs: N/A - no frontend request, state, or rendering path changes.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - no agent action, provider, prompt, planner, or model behavior changes.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [artifact 8300266608 containing pre/post status JSON and Markdown, matrix log, and SHA-256 manifest](https://github.com/elizaOS/eliza/actions/runs/29306015739).

## Manual artifact review

I downloaded the exact-head artifact through the Actions API and opened all six files. Raw ZIP SHA-256: `217fceaeac82174ec5e9da37dfc1143e6fc75f5eda6ef9cf62399aad7538c919`.

The manifest identifies commit `0657888d72d1dc3b4e7d50806f1ddc440cd3b335` and run `29306015739`; all five listed artifact byte counts and SHA-256 values were independently recomputed. The matrix log reports 20 passed, 0 failed, 0 skipped. Pre/post status both report `closeable: false`: the model group is ready, while Google, Discord, Telegram, Slack, Signal, WhatsApp, X, Twilio, health, finance, iOS/macOS native, and Android native groups remain explicitly blocked instead of reading as healthy-empty.

Ref #11632
