### PR TITLE
fix(plugin-openai): add auditable Cerebras provider evidence

### DIFF
--- a/.github/workflows/develop-live.yml
+++ b/.github/workflows/develop-live.yml
@@ -126,6 +126,7 @@ jobs:
           inputs.filter != 'anthropic-thinking-receipt'
         env:
           RUNNER_TEMP_LOG: ${{ runner.temp }}/develop-live-sweep.log
+          LIVE_EVIDENCE_ROOT: ${{ runner.temp }}/develop-live-evidence
           TEST_FILTER: ${{ inputs.filter }}
         run: |
           set -o pipefail
@@ -133,7 +134,11 @@ jobs:
           if [ -n "${TEST_FILTER:-}" ]; then
             filter_args+=(--filter="$TEST_FILTER")
           fi
-          node packages/scripts/run-all-tests.mjs --all --no-cloud "${filter_args[@]}" 2>&1 | tee "$RUNNER_TEMP_LOG"
+          node packages/scripts/run-live-test-with-artifacts.mjs \
+            --label "develop-live-${TEST_FILTER:-all}" \
+            --report-root "$LIVE_EVIDENCE_ROOT" \
+            -- node packages/scripts/run-all-tests.mjs --all --no-cloud "${filter_args[@]}" \
+            2>&1 | tee "$RUNNER_TEMP_LOG"
 
       - name: Cloud unit suite
         if: >-
@@ -190,4 +195,12 @@ jobs:
         with:
           name: develop-live-sweep-log
           path: ${{ runner.temp }}/develop-live-sweep.log
+          if-no-files-found: ignore
+
+      - name: Upload structured live evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: develop-live-evidence
+          path: ${{ runner.temp }}/develop-live-evidence
           if-no-files-found: ignore

--- a/packages/scripts/__tests__/real-live-suites.test.ts
+++ b/packages/scripts/__tests__/real-live-suites.test.ts
@@ -143,6 +143,24 @@ describe("real/live guarded-suite manifest (#9310 §E)", () => {
     });
   });
 
+  test("Cerebras wire evidence is credentialed and uploaded as a structured artifact", () => {
+    expect(
+      manifest.find(
+        (entry) =>
+          entry.file ===
+          "plugins/plugin-openai/__tests__/cerebras-evidence.live.test.ts",
+      ),
+    ).toMatchObject({ requires: ["CEREBRAS_API_KEY"] });
+
+    const workflow = fs.readFileSync(
+      path.join(repoRoot, ".github/workflows/develop-live.yml"),
+      "utf8",
+    );
+    expect(workflow).toContain("run-live-test-with-artifacts.mjs");
+    expect(workflow).toContain("name: develop-live-evidence");
+    expect(workflow).toContain("runner.temp }}/develop-live-evidence");
+  });
+
   test("computer-use service actuation is isolated behind a per-command acknowledgment", () => {
     const entry = manifest.find(
       (candidate) =>

--- a/packages/scripts/lib/real-live-suites.mjs
+++ b/packages/scripts/lib/real-live-suites.mjs
@@ -242,6 +242,12 @@ export const GUARDED_REAL_LIVE_SUITES = [
     requires: ["CEREBRAS_API_KEY"],
   },
   {
+    file: "plugins/plugin-openai/__tests__/cerebras-evidence.live.test.ts",
+    requires: ["CEREBRAS_API_KEY"],
+    notes:
+      "credential-redacted raw request/response/SSE, trajectory, tool, structured-output, and provider/transport error evidence",
+  },
+  {
     file: "plugins/plugin-openai/__tests__/openai-drift.real.test.ts",
     requires: ["OPENAI_API_KEY"],
     notes: "also runs nightly in external-api-live-drift.yml",

--- a/plugins/plugin-openai/__tests__/cerebras-evidence.live.test.ts
+++ b/plugins/plugin-openai/__tests__/cerebras-evidence.live.test.ts
@@ -1,0 +1,695 @@
+/**
+ * Captures credential-redacted wire and trajectory evidence from real Cerebras
+ * calls, including success surfaces and provider/transport failures.
+ */
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type IAgentRuntime, logger, ModelType, runWithTrajectoryContext } from "@elizaos/core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  buildLiveHarness,
+  type LiveAgentHarness,
+} from "../../../packages/app-core/test/helpers/live-agent-test";
+import {
+  type CapturedWireCall,
+  type CerebrasWireCapture,
+  serializeCerebrasProviderError,
+  startCerebrasWireCapture,
+  writeCerebrasEvidenceArtifacts,
+} from "./helpers/cerebras-wire-capture";
+
+const PUBLIC_MODELS_URL = "https://api.cerebras.ai/public/v1/models";
+const CEREBRAS_KEY = process.env.CEREBRAS_API_KEY?.trim() ?? "";
+const HAS_CEREBRAS_KEY = CEREBRAS_KEY.length > 0;
+const INVALID_CEREBRAS_KEY = "csk-invalid-evidence-key";
+const MISSING_MODEL = "cerebras-evidence-model-does-not-exist";
+const OVERSIZED_TOKEN_COUNT = 140_000;
+
+interface TextUsage {
+  promptTokens?: number;
+  completionTokens?: number;
+  totalTokens?: number;
+  reasoningTokens?: number;
+}
+
+interface TextResult {
+  text: string;
+  finishReason?: string;
+  usage?: TextUsage;
+  toolCalls?: unknown[];
+  providerMetadata?: unknown;
+}
+
+interface StreamResult {
+  textStream: AsyncIterable<string>;
+  text: PromiseLike<string>;
+  usage: PromiseLike<TextUsage | undefined>;
+  finishReason: PromiseLike<string | undefined>;
+}
+
+const receipts: Array<Record<string, unknown>> = [];
+const trajectories: Array<Record<string, unknown>> = [];
+let providerCatalog: unknown;
+let capture: CerebrasWireCapture | null = null;
+let harness: LiveAgentHarness | null = null;
+
+const previousEnvironment = {
+  ELIZA_PROVIDER: process.env.ELIZA_PROVIDER,
+  OPENAI_BASE_URL: process.env.OPENAI_BASE_URL,
+};
+
+if (!HAS_CEREBRAS_KEY) {
+  const reason = "missing CEREBRAS_API_KEY (required for raw-wire evidence)";
+  process.env.SKIP_REASON ||= reason;
+  logger.warn(`[OpenAICerebrasEvidence] ${reason}`);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  if ((typeof value !== "object" && typeof value !== "function") || value === null) return false;
+  return typeof (value as { then?: unknown }).then === "function";
+}
+
+function requireHarness(): LiveAgentHarness {
+  if (!harness) throw new Error("[OpenAICerebrasEvidence] Harness is not initialized.");
+  return harness;
+}
+
+function requireTextResult(value: unknown): TextResult {
+  if (!isRecord(value) || typeof value.text !== "string") {
+    throw new Error(
+      `[OpenAICerebrasEvidence] Expected native text result: ${JSON.stringify(value)}`
+    );
+  }
+  const usage = isRecord(value.usage)
+    ? {
+        promptTokens:
+          typeof value.usage.promptTokens === "number" ? value.usage.promptTokens : undefined,
+        completionTokens:
+          typeof value.usage.completionTokens === "number"
+            ? value.usage.completionTokens
+            : undefined,
+        totalTokens:
+          typeof value.usage.totalTokens === "number" ? value.usage.totalTokens : undefined,
+        reasoningTokens:
+          typeof value.usage.reasoningTokens === "number" ? value.usage.reasoningTokens : undefined,
+      }
+    : undefined;
+  return {
+    text: value.text,
+    ...(typeof value.finishReason === "string" ? { finishReason: value.finishReason } : {}),
+    ...(usage ? { usage } : {}),
+    ...(Array.isArray(value.toolCalls) ? { toolCalls: value.toolCalls } : {}),
+    ...(value.providerMetadata !== undefined ? { providerMetadata: value.providerMetadata } : {}),
+  };
+}
+
+function requireStreamResult(value: unknown): StreamResult {
+  if (
+    !isRecord(value) ||
+    !value.textStream ||
+    typeof (value.textStream as { [Symbol.asyncIterator]?: unknown })[Symbol.asyncIterator] !==
+      "function" ||
+    !isPromiseLike(value.text) ||
+    !isPromiseLike(value.usage) ||
+    !isPromiseLike(value.finishReason)
+  ) {
+    throw new Error("[OpenAICerebrasEvidence] Expected native streaming result.");
+  }
+  return value as unknown as StreamResult;
+}
+
+function requireJsonRequest(call: CapturedWireCall): Record<string, unknown> {
+  const parsed = call.request?.parsedBody;
+  if (parsed?.kind !== "json" || !isRecord(parsed.value)) {
+    throw new Error(
+      `[OpenAICerebrasEvidence] Wire call ${call.id} did not contain a JSON request.`
+    );
+  }
+  return parsed.value;
+}
+
+function attachTrajectoryCapture(runtime: IAgentRuntime): void {
+  const trajectoryLogger = {
+    isEnabled: () => true,
+    logLlmCall: (params: Record<string, unknown>) => {
+      trajectories.push(params);
+    },
+  };
+  const originalByType = runtime.getServicesByType.bind(runtime);
+  runtime.getServicesByType = ((type: string) => {
+    if (type === "trajectories") return [trajectoryLogger];
+    return originalByType(type);
+  }) as typeof runtime.getServicesByType;
+  const originalByName = runtime.getService.bind(runtime);
+  runtime.getService = ((name: string) => {
+    if (name === "trajectories") return trajectoryLogger;
+    return originalByName(name);
+  }) as typeof runtime.getService;
+}
+
+async function waitForWireCallsToSettle(startIndex: number): Promise<CapturedWireCall[]> {
+  const deadline = Date.now() + 5_000;
+  for (;;) {
+    const calls = capture?.calls.slice(startIndex) ?? [];
+    if (calls.length > 0 && calls.every((call) => call.completedAt)) return calls;
+    if (Date.now() >= deadline) {
+      throw new Error("[OpenAICerebrasEvidence] Wire call did not settle before artifact capture.");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+async function waitForWireRequest(startIndex: number): Promise<CapturedWireCall> {
+  const deadline = Date.now() + 5_000;
+  for (;;) {
+    const call = capture?.calls[startIndex];
+    if (call?.request) return call;
+    if (Date.now() >= deadline) {
+      throw new Error("[OpenAICerebrasEvidence] Provider request did not reach the wire proxy.");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+async function runCaptured<T>(
+  name: string,
+  stepId: string,
+  operation: () => Promise<T>
+): Promise<{ result: T; wireCalls: CapturedWireCall[] }> {
+  if (!capture) throw new Error("[OpenAICerebrasEvidence] Wire capture is not initialized.");
+  const startIndex = capture.calls.length;
+  const result = await runWithTrajectoryContext({ trajectoryStepId: stepId }, operation);
+  const wireCalls = await waitForWireCallsToSettle(startIndex);
+  expect(wireCalls, `${name} should make one provider request`).toHaveLength(1);
+  return { result, wireCalls };
+}
+
+async function runCapturedError(
+  name: string,
+  operation: () => Promise<unknown>
+): Promise<{
+  error: ReturnType<typeof serializeCerebrasProviderError>;
+  wireCalls: CapturedWireCall[];
+}> {
+  if (!capture) throw new Error("[OpenAICerebrasEvidence] Wire capture is not initialized.");
+  const startIndex = capture.calls.length;
+  let thrown: unknown;
+  try {
+    await operation();
+  } catch (error) {
+    // error-policy:J1 boundary translation — the live test converts the thrown
+    // provider failure into a typed receipt and still asserts the wire status.
+    thrown = error;
+  }
+  if (thrown === undefined) {
+    throw new Error(`[OpenAICerebrasEvidence] ${name} unexpectedly succeeded.`);
+  }
+  const wireCalls = await waitForWireCallsToSettle(startIndex);
+  expect(wireCalls, `${name} should make one provider request`).toHaveLength(1);
+  return { error: serializeCerebrasProviderError(thrown), wireCalls };
+}
+
+function catalogModel(modelId: string): Record<string, unknown> {
+  if (!isRecord(providerCatalog) || !Array.isArray(providerCatalog.data)) {
+    throw new Error("[OpenAICerebrasEvidence] Public model catalog has an invalid shape.");
+  }
+  const model = providerCatalog.data.find(
+    (candidate) => isRecord(candidate) && candidate.id === modelId
+  );
+  if (!isRecord(model)) {
+    throw new Error(`[OpenAICerebrasEvidence] ${modelId} is absent from the public model catalog.`);
+  }
+  return model;
+}
+
+function calculatedCost(modelId: string, usage: TextUsage | undefined): Record<string, unknown> {
+  const model = catalogModel(modelId);
+  if (!isRecord(model.pricing)) {
+    throw new Error(`[OpenAICerebrasEvidence] ${modelId} has no public pricing record.`);
+  }
+  const promptRate = Number(model.pricing.prompt);
+  const completionRate = Number(model.pricing.completion);
+  if (!Number.isFinite(promptRate) || !Number.isFinite(completionRate)) {
+    throw new Error(`[OpenAICerebrasEvidence] ${modelId} pricing is not numeric.`);
+  }
+  const promptTokens = usage?.promptTokens;
+  const completionTokens = usage?.completionTokens;
+  if (typeof promptTokens !== "number" || typeof completionTokens !== "number") {
+    throw new Error(`[OpenAICerebrasEvidence] ${modelId} usage is incomplete.`);
+  }
+  return {
+    currency: "USD",
+    source: PUBLIC_MODELS_URL,
+    promptRatePerToken: promptRate,
+    completionRatePerToken: completionRate,
+    calculatedAmount: promptTokens * promptRate + completionTokens * completionRate,
+    providerReportedAmount: null,
+    providerReportedAmountReason: "The chat response exposes usage but no billed-cost field.",
+  };
+}
+
+function observedLatencyMs(wireCalls: readonly CapturedWireCall[]): number {
+  const durationMs = wireCalls[0]?.durationMs;
+  if (typeof durationMs !== "number") {
+    throw new Error("[OpenAICerebrasEvidence] Wire latency was not finalized.");
+  }
+  return durationMs;
+}
+
+function restoreEnvironment(): void {
+  for (const [name, value] of Object.entries(previousEnvironment)) {
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+}
+
+describe.skipIf(!HAS_CEREBRAS_KEY)("plugin-openai Cerebras evidence", () => {
+  beforeAll(async () => {
+    capture = await startCerebrasWireCapture();
+    process.env.ELIZA_PROVIDER = "cerebras";
+    process.env.OPENAI_BASE_URL = capture.baseUrl;
+    harness = await buildLiveHarness({
+      provider: "cerebras",
+      requiredEnv: ["CEREBRAS_API_KEY"],
+    });
+    attachTrajectoryCapture(harness.runtime);
+
+    const catalogResponse = await fetch(PUBLIC_MODELS_URL);
+    expect(catalogResponse.status).toBe(200);
+    providerCatalog = (await catalogResponse.json()) as unknown;
+    for (const modelId of ["gpt-oss-120b", "zai-glm-4.7"]) {
+      const model = catalogModel(modelId);
+      expect(model.capabilities).toEqual(
+        expect.objectContaining({
+          streaming: true,
+          structured_outputs: true,
+          tools: true,
+          reasoning: true,
+        })
+      );
+    }
+  }, 120_000);
+
+  afterAll(async () => {
+    const teardownFailures: unknown[] = [];
+    try {
+      if (harness) {
+        const [result] = await Promise.allSettled([harness.close()]);
+        if (result.status === "rejected") teardownFailures.push(result.reason);
+        harness = null;
+      }
+      if (capture) {
+        const [result] = await Promise.allSettled([capture.close()]);
+        if (result.status === "rejected") teardownFailures.push(result.reason);
+        const artifactDirectory =
+          process.env.ELIZA_LIVE_TEST_ARTIFACT_DIR?.trim() ||
+          join(tmpdir(), `eliza-cerebras-evidence-${process.pid}`);
+        const rateLimitCallIds = capture.calls
+          .filter((call) => call.response?.status === 429)
+          .map((call) => call.id);
+        const paths = await writeCerebrasEvidenceArtifacts({
+          artifactDirectory,
+          ...(process.env.ELIZA_LIVE_TEST_LLM_CALLS_JSONL?.trim()
+            ? { trajectoryPath: process.env.ELIZA_LIVE_TEST_LLM_CALLS_JSONL.trim() }
+            : {}),
+          calls: capture.calls,
+          trajectories,
+          receipts: [
+            ...receipts,
+            rateLimitCallIds.length > 0
+              ? {
+                  name: "rate-limit-429",
+                  status: "observed",
+                  wireCallIds: rateLimitCallIds,
+                }
+              : {
+                  name: "rate-limit-429",
+                  status: "not-exercised",
+                  reason:
+                    "Cerebras exposes no deterministic 429 trigger; the evidence lane does not manufacture provider output or intentionally exhaust shared quota.",
+                },
+          ],
+          providerCatalog,
+          secrets: [CEREBRAS_KEY, INVALID_CEREBRAS_KEY],
+          metadata: {
+            issue: 16298,
+            supersedesPullRequestEvidence: 16299,
+            headSha: process.env.GITHUB_SHA ?? "local",
+            githubRunId: process.env.GITHUB_RUN_ID ?? "local",
+            upstreamBaseUrl: "https://api.cerebras.ai/v1",
+          },
+        });
+        logger.info(paths, "[OpenAICerebrasEvidence] Wrote reviewed-artifact inputs");
+        capture = null;
+      }
+    } finally {
+      restoreEnvironment();
+    }
+    if (teardownFailures.length > 0) {
+      throw new AggregateError(teardownFailures, "Cerebras evidence teardown failed.");
+    }
+  }, 120_000);
+
+  it("captures the gpt-oss reasoning floor on the actual request", async () => {
+    const runtime = requireHarness().runtime;
+    const { result: rawResult, wireCalls } = await runCaptured(
+      "gpt-oss reasoning floor",
+      "cerebras-evidence-reasoning-floor",
+      () =>
+        runtime.useModel(ModelType.TEXT_LARGE, {
+          model: "gpt-oss-120b",
+          messages: [{ role: "user", content: "Respond with exactly READY and nothing else." }],
+          maxTokens: 160,
+        })
+    );
+    const result = requireTextResult(rawResult);
+    expect(result.text.trim().toUpperCase()).toContain("READY");
+    expect(result.finishReason).toBe("stop");
+    expect(result.usage?.promptTokens).toBeGreaterThan(0);
+    expect(result.usage?.completionTokens).toBeGreaterThan(0);
+    const request = requireJsonRequest(wireCalls[0]);
+    expect(request).toMatchObject({ model: "gpt-oss-120b", reasoning_effort: "low" });
+    expect(wireCalls[0].response?.status).toBe(200);
+
+    receipts.push({
+      name: "gpt-oss-reasoning-floor",
+      status: "passed",
+      wireCallIds: wireCalls.map((call) => call.id),
+      result,
+      latencyMs: observedLatencyMs(wireCalls),
+      cost: calculatedCost("gpt-oss-120b", result.usage),
+    });
+  }, 120_000);
+
+  it("captures GLM thinking-off and the raw SSE stream", async () => {
+    const runtime = requireHarness().runtime;
+    const parsedChunks: string[] = [];
+    const { result: rawStream, wireCalls } = await runCaptured(
+      "GLM streaming thinking-off",
+      "cerebras-evidence-glm-stream",
+      async () => {
+        const stream = requireStreamResult(
+          await runtime.useModel(ModelType.TEXT_LARGE, {
+            model: "zai-glm-4.7",
+            messages: [{ role: "user", content: "Reply with exactly PONG and no punctuation." }],
+            maxTokens: 160,
+            stream: true,
+            providerOptions: { eliza: { thinking: "off" } },
+            onStreamChunk: (chunk: string) => {
+              parsedChunks.push(chunk);
+            },
+          })
+        );
+        const iterated: string[] = [];
+        for await (const chunk of stream.textStream) iterated.push(chunk);
+        return {
+          text: await stream.text,
+          usage: await stream.usage,
+          finishReason: await stream.finishReason,
+          iterated,
+        };
+      }
+    );
+    expect(rawStream.text.trim().toUpperCase()).toContain("PONG");
+    expect(rawStream.finishReason).toBe("stop");
+    expect(rawStream.usage?.reasoningTokens ?? 0).toBe(0);
+    expect(rawStream.iterated.join("")).toBe(rawStream.text);
+    expect(parsedChunks.join("")).toBe(rawStream.text);
+    const request = requireJsonRequest(wireCalls[0]);
+    expect(request).toMatchObject({
+      model: "zai-glm-4.7",
+      stream: true,
+      reasoning_effort: "none",
+    });
+    expect(wireCalls[0].response?.headers).toContainEqual(
+      expect.objectContaining({
+        name: "content-type",
+        value: expect.stringContaining("text/event-stream"),
+      })
+    );
+    expect(wireCalls[0].response?.chunks.length).toBeGreaterThan(0);
+    expect(wireCalls[0].response?.body?.utf8).toContain("data:");
+    expect(wireCalls[0].response?.body?.utf8).toContain("[DONE]");
+
+    receipts.push({
+      name: "glm-thinking-off-stream",
+      status: "passed",
+      wireCallIds: wireCalls.map((call) => call.id),
+      result: rawStream,
+      parsedChunks,
+      latencyMs: observedLatencyMs(wireCalls),
+      cost: calculatedCost("zai-glm-4.7", rawStream.usage),
+    });
+  }, 120_000);
+
+  it("captures a real Cerebras tool call through plugin normalization", async () => {
+    const runtime = requireHarness().runtime;
+    const { result: rawResult, wireCalls } = await runCaptured(
+      "tool call",
+      "cerebras-evidence-tool",
+      () =>
+        runtime.useModel(ModelType.TEXT_LARGE, {
+          model: "gpt-oss-120b",
+          messages: [
+            { role: "system", content: "Call the requested tool; do not answer in prose." },
+            {
+              role: "user",
+              content: "Call RECORD_EVIDENCE with verdict verified and count 2.",
+            },
+          ],
+          tools: [
+            {
+              name: "RECORD_EVIDENCE",
+              description: "Record the evidence verdict.",
+              parameters: {
+                type: "object",
+                properties: {
+                  verdict: { type: "string", enum: ["verified"] },
+                  count: { type: "number" },
+                },
+                required: ["verdict", "count"],
+                additionalProperties: false,
+              },
+            },
+          ],
+          toolChoice: { type: "tool", name: "RECORD_EVIDENCE" },
+          maxTokens: 160,
+        })
+    );
+    const result = requireTextResult(rawResult);
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls?.[0]).toMatchObject({
+      toolName: "RECORD_EVIDENCE",
+      input: { verdict: "verified", count: 2 },
+    });
+    const request = requireJsonRequest(wireCalls[0]);
+    expect(request.tools).toEqual(expect.any(Array));
+    expect(request.tool_choice).toEqual(expect.objectContaining({ type: "function" }));
+    expect(wireCalls[0].response?.body?.utf8).toContain("tool_calls");
+
+    receipts.push({
+      name: "tool-call",
+      status: "passed",
+      wireCallIds: wireCalls.map((call) => call.id),
+      result,
+      latencyMs: observedLatencyMs(wireCalls),
+      cost: calculatedCost("gpt-oss-120b", result.usage),
+    });
+  }, 120_000);
+
+  it("captures and parses real Cerebras JSON-mode structured output", async () => {
+    const runtime = requireHarness().runtime;
+    const responseSchema = {
+      type: "object",
+      properties: {
+        verdict: { type: "string", enum: ["verified"] },
+        count: { type: "number" },
+      },
+      required: ["verdict", "count"],
+      additionalProperties: false,
+    };
+    const { result: rawResult, wireCalls } = await runCaptured(
+      "structured output",
+      "cerebras-evidence-structured-output",
+      () =>
+        runtime.useModel(ModelType.TEXT_LARGE, {
+          model: "gpt-oss-120b",
+          messages: [
+            {
+              role: "user",
+              content: 'Return only JSON with verdict "verified" and count 2.',
+            },
+          ],
+          responseSchema,
+          responseFormat: { type: "json_object" },
+          maxTokens: 160,
+        })
+    );
+    const result = requireTextResult(rawResult);
+    const parsed = JSON.parse(result.text) as unknown;
+    expect(parsed).toEqual({ verdict: "verified", count: 2 });
+    const request = requireJsonRequest(wireCalls[0]);
+    expect(request.response_format).toEqual({ type: "json_object" });
+    expect(wireCalls[0].response?.status).toBe(200);
+
+    receipts.push({
+      name: "structured-output",
+      status: "passed",
+      wireCallIds: wireCalls.map((call) => call.id),
+      responseSchema,
+      parsed,
+      result,
+      latencyMs: observedLatencyMs(wireCalls),
+      cost: calculatedCost("gpt-oss-120b", result.usage),
+    });
+  }, 120_000);
+
+  it("captures the real authentication failure without retaining the bad Authorization header", async () => {
+    const runtime = requireHarness().runtime;
+    runtime.setSetting("CEREBRAS_API_KEY", INVALID_CEREBRAS_KEY, true);
+    let evidence: Awaited<ReturnType<typeof runCapturedError>>;
+    try {
+      evidence = await runCapturedError("bad key", () =>
+        runtime.useModel(ModelType.TEXT_LARGE, {
+          model: "gpt-oss-120b",
+          prompt: "Authentication failure evidence.",
+          maxTokens: 8,
+        })
+      );
+    } finally {
+      runtime.setSetting("CEREBRAS_API_KEY", CEREBRAS_KEY, true);
+    }
+    expect(evidence.error.statusCode).toBe(401);
+    expect(evidence.wireCalls[0].response?.status).toBe(401);
+    expect(evidence.wireCalls[0].request?.headers).toContainEqual({
+      name: "authorization",
+      value: "[REDACTED]",
+    });
+    receipts.push({
+      name: "bad-key",
+      status: "passed",
+      wireCallIds: evidence.wireCalls.map((call) => call.id),
+      error: evidence.error,
+    });
+  }, 120_000);
+
+  it("captures the provider model-not-found response", async () => {
+    const runtime = requireHarness().runtime;
+    const evidence = await runCapturedError("model not found", () =>
+      runtime.useModel(ModelType.TEXT_LARGE, {
+        model: MISSING_MODEL,
+        prompt: "Model-not-found evidence.",
+        maxTokens: 8,
+      })
+    );
+    expect(evidence.error.statusCode).toBe(404);
+    expect(evidence.wireCalls[0].response?.status).toBe(404);
+    expect(requireJsonRequest(evidence.wireCalls[0]).model).toBe(MISSING_MODEL);
+    receipts.push({
+      name: "model-not-found",
+      status: "passed",
+      wireCallIds: evidence.wireCalls.map((call) => call.id),
+      error: evidence.error,
+    });
+  }, 120_000);
+
+  it("captures the provider context-limit response using the published limit", async () => {
+    const runtime = requireHarness().runtime;
+    const model = catalogModel("gpt-oss-120b");
+    expect(model.limits).toEqual(expect.objectContaining({ max_context_length: 131_072 }));
+    const oversizedPrompt = "x ".repeat(OVERSIZED_TOKEN_COUNT);
+    const evidence = await runCapturedError("oversized context", () =>
+      runtime.useModel(ModelType.TEXT_LARGE, {
+        model: "gpt-oss-120b",
+        prompt: oversizedPrompt,
+        maxTokens: 8,
+      })
+    );
+    expect(evidence.error.statusCode).toBe(400);
+    expect(evidence.wireCalls[0].response?.status).toBe(400);
+    const request = requireJsonRequest(evidence.wireCalls[0]);
+    expect(JSON.stringify(request).length).toBeGreaterThan(OVERSIZED_TOKEN_COUNT);
+    receipts.push({
+      name: "oversized-context",
+      status: "passed",
+      wireCallIds: evidence.wireCalls.map((call) => call.id),
+      publishedMaxContextTokens: 131_072,
+      repeatedPromptTokens: OVERSIZED_TOKEN_COUNT,
+      error: evidence.error,
+    });
+  }, 120_000);
+
+  it("aborts an in-flight provider request through the caller signal", async () => {
+    const runtime = requireHarness().runtime;
+    if (!capture) throw new Error("[OpenAICerebrasEvidence] Capture is not initialized.");
+    const startIndex = capture.calls.length;
+    const abortController = new AbortController();
+    const evidence = await runCapturedError("caller abort", async () => {
+      const pending = runtime.useModel(ModelType.TEXT_LARGE, {
+        model: "gpt-oss-120b",
+        prompt: "Caller-abort evidence; generate a detailed explanation of model serving.",
+        maxTokens: 160,
+        signal: abortController.signal,
+      });
+      // error-policy:J1 boundary translation — attach an observer immediately,
+      // then rethrow the provider error after the wire proxy confirms receipt.
+      const observed = pending.then(
+        (value) => ({ status: "fulfilled", value }) as const,
+        (error: unknown) => ({ status: "rejected", error }) as const
+      );
+      await waitForWireRequest(startIndex);
+      abortController.abort(new DOMException("Evidence caller aborted the request.", "AbortError"));
+      const outcome = await observed;
+      if (outcome.status === "rejected") throw outcome.error;
+      return outcome.value;
+    });
+    expect(evidence.error.message.toLowerCase()).toMatch(/abort|timeout|terminated/);
+    expect(evidence.wireCalls[0].transport.outcome).toMatch(/client-aborted|proxy-error/);
+    receipts.push({
+      name: "caller-abort",
+      status: "passed",
+      wireCallIds: evidence.wireCalls.map((call) => call.id),
+      abortedAfterProxyReceivedRequest: true,
+      error: evidence.error,
+      transport: evidence.wireCalls[0].transport,
+    });
+  }, 120_000);
+
+  it("surfaces a mid-stream transport disconnect after a real upstream chunk", async () => {
+    const runtime = requireHarness().runtime;
+    if (!capture) throw new Error("[OpenAICerebrasEvidence] Capture is not initialized.");
+    capture.armFault({ kind: "disconnect-after-first-response-chunk" });
+    const evidence = await runCapturedError("mid-stream disconnect", async () => {
+      const stream = requireStreamResult(
+        await runtime.useModel(ModelType.TEXT_LARGE, {
+          model: "gpt-oss-120b",
+          prompt: "Stream the words ALPHA BETA GAMMA slowly.",
+          maxTokens: 64,
+          stream: true,
+        })
+      );
+      for await (const _chunk of stream.textStream) {
+        // The proxy severs the connection before forwarding the captured chunk.
+      }
+    });
+    expect(evidence.wireCalls[0].fault).toEqual({
+      kind: "disconnect-after-first-response-chunk",
+      triggered: true,
+    });
+    expect(evidence.wireCalls[0].transport.outcome).toBe("injected-disconnect");
+    expect(evidence.wireCalls[0].response?.chunks).toHaveLength(1);
+    expect(evidence.error.message.length).toBeGreaterThan(0);
+    receipts.push({
+      name: "mid-stream-disconnect",
+      status: "passed",
+      wireCallIds: evidence.wireCalls.map((call) => call.id),
+      error: evidence.error,
+      capturedUpstreamChunk: evidence.wireCalls[0].response?.chunks[0],
+    });
+  }, 120_000);
+});

--- a/plugins/plugin-openai/__tests__/cerebras-evidence.live.test.ts
+++ b/plugins/plugin-openai/__tests__/cerebras-evidence.live.test.ts
@@ -191,7 +191,8 @@ async function runCaptured<T>(
 
 async function runCapturedError(
   name: string,
-  operation: () => Promise<unknown>
+  operation: () => Promise<unknown>,
+  options: { minimumWireCalls?: number } = {}
 ): Promise<{
   error: ReturnType<typeof serializeCerebrasProviderError>;
   wireCalls: CapturedWireCall[];
@@ -210,7 +211,13 @@ async function runCapturedError(
     throw new Error(`[OpenAICerebrasEvidence] ${name} unexpectedly succeeded.`);
   }
   const wireCalls = await waitForWireCallsToSettle(startIndex);
-  expect(wireCalls, `${name} should make one provider request`).toHaveLength(1);
+  if (options.minimumWireCalls === undefined) {
+    expect(wireCalls, `${name} should make one provider request`).toHaveLength(1);
+  } else {
+    expect(wireCalls.length, `${name} should exercise provider retries`).toBeGreaterThanOrEqual(
+      options.minimumWireCalls
+    );
+  }
   return { error: serializeCerebrasProviderError(thrown), wireCalls };
 }
 
@@ -388,7 +395,6 @@ describe.skipIf(!HAS_CEREBRAS_KEY)("plugin-openai Cerebras evidence", () => {
 
   it("captures GLM thinking-off and the raw SSE stream", async () => {
     const runtime = requireHarness().runtime;
-    const parsedChunks: string[] = [];
     const { result: rawStream, wireCalls } = await runCaptured(
       "GLM streaming thinking-off",
       "cerebras-evidence-glm-stream",
@@ -400,9 +406,6 @@ describe.skipIf(!HAS_CEREBRAS_KEY)("plugin-openai Cerebras evidence", () => {
             maxTokens: 160,
             stream: true,
             providerOptions: { eliza: { thinking: "off" } },
-            onStreamChunk: (chunk: string) => {
-              parsedChunks.push(chunk);
-            },
           })
         );
         const iterated: string[] = [];
@@ -419,7 +422,6 @@ describe.skipIf(!HAS_CEREBRAS_KEY)("plugin-openai Cerebras evidence", () => {
     expect(rawStream.finishReason).toBe("stop");
     expect(rawStream.usage?.reasoningTokens ?? 0).toBe(0);
     expect(rawStream.iterated.join("")).toBe(rawStream.text);
-    expect(parsedChunks.join("")).toBe(rawStream.text);
     const request = requireJsonRequest(wireCalls[0]);
     expect(request).toMatchObject({
       model: "zai-glm-4.7",
@@ -441,7 +443,7 @@ describe.skipIf(!HAS_CEREBRAS_KEY)("plugin-openai Cerebras evidence", () => {
       status: "passed",
       wireCallIds: wireCalls.map((call) => call.id),
       result: rawStream,
-      parsedChunks,
+      parsedChunks: rawStream.iterated,
       latencyMs: observedLatencyMs(wireCalls),
       cost: calculatedCost("zai-glm-4.7", rawStream.usage),
     });
@@ -663,33 +665,43 @@ describe.skipIf(!HAS_CEREBRAS_KEY)("plugin-openai Cerebras evidence", () => {
   it("surfaces a mid-stream transport disconnect after a real upstream chunk", async () => {
     const runtime = requireHarness().runtime;
     if (!capture) throw new Error("[OpenAICerebrasEvidence] Capture is not initialized.");
-    capture.armFault({ kind: "disconnect-after-first-response-chunk" });
-    const evidence = await runCapturedError("mid-stream disconnect", async () => {
-      const stream = requireStreamResult(
-        await runtime.useModel(ModelType.TEXT_LARGE, {
-          model: "gpt-oss-120b",
-          prompt: "Stream the words ALPHA BETA GAMMA slowly.",
-          maxTokens: 64,
-          stream: true,
-        })
-      );
-      for await (const _chunk of stream.textStream) {
-        // The proxy severs the connection before forwarding the captured chunk.
-      }
-    });
-    expect(evidence.wireCalls[0].fault).toEqual({
-      kind: "disconnect-after-first-response-chunk",
-      triggered: true,
-    });
-    expect(evidence.wireCalls[0].transport.outcome).toBe("injected-disconnect");
-    expect(evidence.wireCalls[0].response?.chunks).toHaveLength(1);
+    // The SDK has a bounded internal retry budget. Faulting more attempts than
+    // that budget proves terminal truncation instead of accidentally proving
+    // its transparent retry path.
+    capture.armFault({ kind: "disconnect-after-first-response-chunk", attempts: 8 });
+    const evidence = await runCapturedError(
+      "mid-stream disconnect",
+      async () => {
+        const stream = requireStreamResult(
+          await runtime.useModel(ModelType.TEXT_LARGE, {
+            model: "gpt-oss-120b",
+            prompt: "Stream the words ALPHA BETA GAMMA slowly.",
+            maxTokens: 64,
+            stream: true,
+          })
+        );
+        for await (const _chunk of stream.textStream) {
+          // The proxy severs every retry before forwarding the captured chunk.
+        }
+        await Promise.all([stream.text, stream.usage, stream.finishReason]);
+      },
+      { minimumWireCalls: 2 }
+    );
+    for (const wireCall of evidence.wireCalls) {
+      expect(wireCall.fault).toEqual({
+        kind: "disconnect-after-first-response-chunk",
+        triggered: true,
+      });
+      expect(wireCall.transport.outcome).toBe("injected-disconnect");
+      expect(wireCall.response?.chunks).toHaveLength(1);
+    }
     expect(evidence.error.message.length).toBeGreaterThan(0);
     receipts.push({
       name: "mid-stream-disconnect",
       status: "passed",
       wireCallIds: evidence.wireCalls.map((call) => call.id),
       error: evidence.error,
-      capturedUpstreamChunk: evidence.wireCalls[0].response?.chunks[0],
+      capturedUpstreamChunks: evidence.wireCalls.map((call) => call.response?.chunks[0]),
     });
   }, 120_000);
 });

--- a/plugins/plugin-openai/__tests__/cerebras-wire-capture.test.ts
+++ b/plugins/plugin-openai/__tests__/cerebras-wire-capture.test.ts
@@ -147,4 +147,42 @@ describe("Cerebras wire evidence", () => {
     expect(capture.calls[0].response?.chunks.length).toBeGreaterThanOrEqual(2);
     expect(capture.calls[0].response?.body?.utf8).toBe(body);
   });
+
+  it("applies a disconnect fault across the requested number of attempts", async () => {
+    const fixture = await startFixtureServer((_request, response) => {
+      response.setHeader("content-type", "text/event-stream");
+      response.write('data: {"choices":[{"delta":{"content":"A"}}]}\n\n');
+      response.end("data: [DONE]\n\n");
+    });
+    cleanups.push(fixture.close);
+    const capture = await startCerebrasWireCapture(fixture.baseUrl);
+    cleanups.push(capture.close);
+    capture.armFault({ kind: "disconnect-after-first-response-chunk", attempts: 2 });
+
+    const consume = async () => {
+      const response = await fetch(`${capture.baseUrl}/chat/completions`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ stream: true }),
+      });
+      return response.text();
+    };
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const [outcome] = await Promise.allSettled([consume()]);
+      if (outcome.status === "fulfilled") expect(outcome.value).not.toContain("[DONE]");
+      else expect(outcome.reason).toBeInstanceOf(Error);
+    }
+    await expect(consume()).resolves.toContain("[DONE]");
+
+    expect(capture.calls.slice(0, 2)).toHaveLength(2);
+    for (const call of capture.calls.slice(0, 2)) {
+      expect(call.fault).toEqual({
+        kind: "disconnect-after-first-response-chunk",
+        triggered: true,
+      });
+      expect(call.transport.outcome).toBe("injected-disconnect");
+      expect(call.response?.chunks).toHaveLength(1);
+    }
+    expect(capture.calls[2].transport.outcome).toBe("complete");
+  });
 });

--- a/plugins/plugin-openai/__tests__/cerebras-wire-capture.test.ts
+++ b/plugins/plugin-openai/__tests__/cerebras-wire-capture.test.ts
@@ -1,0 +1,150 @@
+/** Verifies that live-wire evidence preserves transport bytes while credentials stay out of artifacts. */
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  startCerebrasWireCapture,
+  writeCerebrasEvidenceArtifacts,
+} from "./helpers/cerebras-wire-capture";
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  await Promise.all(
+    cleanups
+      .splice(0)
+      .reverse()
+      .map((cleanup) => cleanup())
+  );
+});
+
+function startFixtureServer(
+  handler: (request: IncomingMessage, response: ServerResponse) => void
+): Promise<{ baseUrl: string; close: () => Promise<void> }> {
+  const server = createServer(handler);
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("fixture server did not bind a TCP port"));
+        return;
+      }
+      resolve({
+        baseUrl: `http://127.0.0.1:${address.port}`,
+        close: () =>
+          new Promise<void>((closeResolve, closeReject) => {
+            server.close((error) => {
+              if (error) closeReject(error);
+              else closeResolve();
+            });
+          }),
+      });
+    });
+  });
+}
+
+describe("Cerebras wire evidence", () => {
+  it("forwards authorization but records only a redacted header and exact body bytes", async () => {
+    const secret = "csk-unit-secret";
+    let upstreamAuthorization: string | undefined;
+    const fixture = await startFixtureServer(async (request, response) => {
+      upstreamAuthorization = request.headers.authorization;
+      for await (const _chunk of request) {
+        // Drain the real request before responding so the fixture exercises forwarding.
+      }
+      response.setHeader("content-type", "application/json");
+      response.end(
+        JSON.stringify({ id: "completion-1", choices: [{ message: { content: "ok" } }] })
+      );
+    });
+    cleanups.push(fixture.close);
+    const capture = await startCerebrasWireCapture(fixture.baseUrl);
+    cleanups.push(capture.close);
+
+    const requestBody = JSON.stringify({
+      model: "gpt-oss-120b",
+      messages: [{ role: "user", content: "hi" }],
+    });
+    const response = await fetch(`${capture.baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${secret}`,
+        "content-type": "application/json",
+      },
+      body: requestBody,
+    });
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ id: "completion-1" });
+
+    expect(upstreamAuthorization).toBe(`Bearer ${secret}`);
+    expect(capture.calls).toHaveLength(1);
+    const [call] = capture.calls;
+    expect(call.request?.body.utf8).toBe(requestBody);
+    expect(call.request?.headers).toContainEqual({ name: "authorization", value: "[REDACTED]" });
+    expect(call.response?.body?.utf8).toContain('"completion-1"');
+    expect(call.transport.outcome).toBe("complete");
+  });
+
+  it("writes redacted wire JSON and append-only trajectory JSONL", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "cerebras-evidence-"));
+    cleanups.push(() => rm(directory, { recursive: true, force: true }));
+    const secret = "csk-artifact-secret";
+
+    const paths = await writeCerebrasEvidenceArtifacts({
+      artifactDirectory: directory,
+      calls: [],
+      trajectories: [
+        {
+          provider: "cerebras",
+          model: "gpt-oss-120b",
+          response: `safe response accidentally followed by ${secret}`,
+        },
+      ],
+      receipts: [{ authorization: `Bearer ${secret}` }],
+      secrets: [secret],
+      metadata: { headSha: "unit-head" },
+    });
+
+    const [wire, trajectory] = await Promise.all([
+      readFile(paths.wirePath, "utf8"),
+      readFile(paths.trajectoryPath, "utf8"),
+    ]);
+    expect(wire).not.toContain(secret);
+    expect(trajectory).not.toContain(secret);
+    expect(wire).toContain("[REDACTED]");
+    expect(trajectory).toContain("[REDACTED]");
+    expect(JSON.parse(trajectory.trim())).toMatchObject({
+      provider: "cerebras",
+      model: "gpt-oss-120b",
+    });
+  });
+
+  it("captures upstream SSE chunks without coalescing their evidence records", async () => {
+    const fixture = await startFixtureServer((_request, response) => {
+      response.setHeader("content-type", "text/event-stream");
+      response.write('data: {"choices":[{"delta":{"content":"A"}}]}\n\n');
+      setTimeout(() => {
+        response.end("data: [DONE]\n\n");
+      }, 10);
+    });
+    cleanups.push(fixture.close);
+    const capture = await startCerebrasWireCapture(fixture.baseUrl);
+    cleanups.push(capture.close);
+
+    const response = await fetch(`${capture.baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ stream: true }),
+    });
+    const body = await response.text();
+
+    expect(body).toContain('"content":"A"');
+    expect(body).toContain("[DONE]");
+    expect(capture.calls[0].response?.chunks.length).toBeGreaterThanOrEqual(2);
+    expect(capture.calls[0].response?.body?.utf8).toBe(body);
+  });
+});

--- a/plugins/plugin-openai/__tests__/helpers/cerebras-wire-capture.ts
+++ b/plugins/plugin-openai/__tests__/helpers/cerebras-wire-capture.ts
@@ -14,7 +14,10 @@ const SENSITIVE_HEADER =
 const HOP_BY_HOP_HEADER =
   /^(?:connection|content-length|content-encoding|host|keep-alive|proxy-authenticate|proxy-authorization|te|trailer|transfer-encoding|upgrade)$/i;
 
-export type WireFault = { kind: "disconnect-after-first-response-chunk" };
+export type WireFault = {
+  kind: "disconnect-after-first-response-chunk";
+  attempts?: number;
+};
 
 export interface WireHeader {
   name: string;
@@ -42,7 +45,7 @@ export interface CapturedWireCall {
   startedAt: string;
   completedAt?: string;
   durationMs?: number;
-  fault?: WireFault & { triggered: boolean };
+  fault?: { kind: WireFault["kind"]; triggered: boolean };
   request?: {
     method: string;
     upstreamUrl: string;
@@ -217,7 +220,7 @@ export async function startCerebrasWireCapture(
   upstreamBaseUrl = UPSTREAM_BASE_URL
 ): Promise<CerebrasWireCapture> {
   const calls: CapturedWireCall[] = [];
-  let nextFault: WireFault | undefined;
+  let faultPlan: { kind: WireFault["kind"]; remainingAttempts: number } | undefined;
 
   const server = createServer((request, response) => {
     const startedAtMs = Date.now();
@@ -226,9 +229,12 @@ export async function startCerebrasWireCapture(
       startedAt: new Date(startedAtMs).toISOString(),
       transport: { outcome: "pending" },
     };
-    const fault = nextFault;
-    nextFault = undefined;
-    if (fault) call.fault = { ...fault, triggered: false };
+    const fault = faultPlan;
+    if (fault) {
+      call.fault = { kind: fault.kind, triggered: false };
+      fault.remainingAttempts--;
+      if (fault.remainingAttempts === 0) faultPlan = undefined;
+    }
     calls.push(call);
 
     const handleRequest = async () => {
@@ -343,10 +349,14 @@ export async function startCerebrasWireCapture(
     baseUrl: `http://127.0.0.1:${port}/v1`,
     calls,
     armFault(fault) {
-      if (nextFault) {
+      if (faultPlan) {
         throw new Error("[CerebrasWireCapture] A wire fault is already armed.");
       }
-      nextFault = fault;
+      const attempts = fault.attempts ?? 1;
+      if (!Number.isSafeInteger(attempts) || attempts < 1) {
+        throw new Error("[CerebrasWireCapture] Fault attempts must be a positive integer.");
+      }
+      faultPlan = { kind: fault.kind, remainingAttempts: attempts };
     },
     close: () => closeServer(server),
   };

--- a/plugins/plugin-openai/__tests__/helpers/cerebras-wire-capture.ts
+++ b/plugins/plugin-openai/__tests__/helpers/cerebras-wire-capture.ts
@@ -1,0 +1,413 @@
+/**
+ * Loopback forwarding proxy for live Cerebras evidence. It preserves request and
+ * response bytes while removing credentials before any artifact reaches disk.
+ */
+import { createHash, randomUUID } from "node:crypto";
+import { appendFile, mkdir, writeFile } from "node:fs/promises";
+import { createServer, type IncomingHttpHeaders, type Server } from "node:http";
+import { dirname, join } from "node:path";
+
+const UPSTREAM_BASE_URL = "https://api.cerebras.ai";
+const REDACTED = "[REDACTED]";
+const SENSITIVE_HEADER =
+  /^(?:authorization|proxy-authorization|cookie|set-cookie|x-api-key|api-key)$/i;
+const HOP_BY_HOP_HEADER =
+  /^(?:connection|content-length|content-encoding|host|keep-alive|proxy-authenticate|proxy-authorization|te|trailer|transfer-encoding|upgrade)$/i;
+
+export type WireFault = { kind: "disconnect-after-first-response-chunk" };
+
+export interface WireHeader {
+  name: string;
+  value: string;
+}
+
+export interface WireBytes {
+  byteLength: number;
+  sha256: string;
+  base64: string;
+  utf8: string;
+}
+
+export interface WireChunk extends WireBytes {
+  index: number;
+}
+
+export type ParsedJsonEvidence =
+  | { kind: "json"; value: unknown }
+  | { kind: "not-json" }
+  | { kind: "invalid-json"; error: string };
+
+export interface CapturedWireCall {
+  id: string;
+  startedAt: string;
+  completedAt?: string;
+  durationMs?: number;
+  fault?: WireFault & { triggered: boolean };
+  request?: {
+    method: string;
+    upstreamUrl: string;
+    headers: WireHeader[];
+    body: WireBytes;
+    parsedBody: ParsedJsonEvidence;
+  };
+  response?: {
+    status: number;
+    statusText: string;
+    headers: WireHeader[];
+    headersAt: string;
+    body?: WireBytes;
+    chunks: WireChunk[];
+    parsedBody?: ParsedJsonEvidence;
+  };
+  transport: {
+    outcome: "pending" | "complete" | "client-aborted" | "injected-disconnect" | "proxy-error";
+    error?: SerializedError;
+  };
+}
+
+export interface SerializedError {
+  name: string;
+  message: string;
+  statusCode?: number;
+  code?: string;
+  data?: unknown;
+}
+
+export interface CerebrasWireCapture {
+  readonly baseUrl: string;
+  readonly calls: CapturedWireCall[];
+  armFault(fault: WireFault): void;
+  close(): Promise<void>;
+}
+
+export interface CerebrasEvidenceArtifactInput {
+  artifactDirectory: string;
+  trajectoryPath?: string;
+  calls: readonly CapturedWireCall[];
+  trajectories: readonly Record<string, unknown>[];
+  receipts: readonly Record<string, unknown>[];
+  providerCatalog?: unknown;
+  secrets: readonly string[];
+  metadata: Record<string, unknown>;
+}
+
+function sha256(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function encodeBytes(bytes: Uint8Array): WireBytes {
+  const buffer = Buffer.from(bytes);
+  return {
+    byteLength: buffer.byteLength,
+    sha256: sha256(buffer),
+    base64: buffer.toString("base64"),
+    utf8: buffer.toString("utf8"),
+  };
+}
+
+function parseJsonEvidence(bytes: Uint8Array, contentType: string | undefined): ParsedJsonEvidence {
+  if (!contentType?.toLowerCase().includes("json")) {
+    return { kind: "not-json" };
+  }
+  try {
+    return { kind: "json", value: JSON.parse(Buffer.from(bytes).toString("utf8")) as unknown };
+  } catch (error) {
+    // error-policy:J3 untrusted-input sanitizing — raw provider bytes remain in
+    // the artifact and malformed JSON is an explicit invalid result.
+    return {
+      kind: "invalid-json",
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function incomingHeaderEntries(headers: IncomingHttpHeaders): WireHeader[] {
+  return Object.entries(headers).flatMap(([name, rawValue]) => {
+    const values = Array.isArray(rawValue) ? rawValue : rawValue === undefined ? [] : [rawValue];
+    return values.map((value) => ({
+      name,
+      value: SENSITIVE_HEADER.test(name) ? REDACTED : value,
+    }));
+  });
+}
+
+function responseHeaderEntries(headers: Headers): WireHeader[] {
+  return [...headers.entries()].map(([name, value]) => ({
+    name,
+    value: SENSITIVE_HEADER.test(name) ? REDACTED : value,
+  }));
+}
+
+function forwardingHeaders(headers: IncomingHttpHeaders): Headers {
+  const forwarded = new Headers();
+  for (const [name, rawValue] of Object.entries(headers)) {
+    if (HOP_BY_HOP_HEADER.test(name) || rawValue === undefined) continue;
+    forwarded.set(name, Array.isArray(rawValue) ? rawValue.join(", ") : rawValue);
+  }
+  // Fetch transparently decodes compressed bodies. Asking for identity keeps
+  // the captured bytes identical to those delivered to the AI SDK client.
+  forwarded.set("accept-encoding", "identity");
+  return forwarded;
+}
+
+function applyResponseHeaders(target: import("node:http").ServerResponse, headers: Headers): void {
+  for (const [name, value] of headers.entries()) {
+    if (HOP_BY_HOP_HEADER.test(name) || SENSITIVE_HEADER.test(name)) continue;
+    target.setHeader(name, value);
+  }
+}
+
+async function readRequestBody(request: import("node:http").IncomingMessage): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+function serializeError(error: unknown): SerializedError {
+  if (!(error instanceof Error)) {
+    return { name: "NonError", message: String(error) };
+  }
+  const candidate = error as Error & {
+    statusCode?: unknown;
+    code?: unknown;
+    data?: unknown;
+  };
+  return {
+    name: error.name,
+    message: error.message,
+    ...(typeof candidate.statusCode === "number" ? { statusCode: candidate.statusCode } : {}),
+    ...(typeof candidate.code === "string" ? { code: candidate.code } : {}),
+    ...(candidate.data !== undefined ? { data: candidate.data } : {}),
+  };
+}
+
+function startServer(server: Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const onError = (error: Error) => {
+      server.off("listening", onListening);
+      reject(error);
+    };
+    const onListening = () => {
+      server.off("error", onError);
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("[CerebrasWireCapture] Loopback proxy did not bind a TCP port."));
+        return;
+      }
+      resolve(address.port);
+    };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen(0, "127.0.0.1");
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+export async function startCerebrasWireCapture(
+  upstreamBaseUrl = UPSTREAM_BASE_URL
+): Promise<CerebrasWireCapture> {
+  const calls: CapturedWireCall[] = [];
+  let nextFault: WireFault | undefined;
+
+  const server = createServer((request, response) => {
+    const startedAtMs = Date.now();
+    const call: CapturedWireCall = {
+      id: randomUUID(),
+      startedAt: new Date(startedAtMs).toISOString(),
+      transport: { outcome: "pending" },
+    };
+    const fault = nextFault;
+    nextFault = undefined;
+    if (fault) call.fault = { ...fault, triggered: false };
+    calls.push(call);
+
+    const handleRequest = async () => {
+      const body = await readRequestBody(request);
+      const upstreamUrl = new URL(request.url ?? "/", upstreamBaseUrl).toString();
+      const contentType = Array.isArray(request.headers["content-type"])
+        ? request.headers["content-type"][0]
+        : request.headers["content-type"];
+      call.request = {
+        method: request.method ?? "GET",
+        upstreamUrl,
+        headers: incomingHeaderEntries(request.headers),
+        body: encodeBytes(body),
+        parsedBody: parseJsonEvidence(body, contentType),
+      };
+
+      const abortController = new AbortController();
+      let clientAborted = false;
+      request.once("aborted", () => {
+        clientAborted = true;
+        abortController.abort(new Error("Cerebras evidence client aborted the request."));
+      });
+      response.once("close", () => {
+        if (!response.writableEnded && call.transport.outcome !== "injected-disconnect") {
+          clientAborted = true;
+          abortController.abort(new Error("Cerebras evidence client closed before completion."));
+        }
+      });
+
+      const upstreamResponse = await fetch(upstreamUrl, {
+        method: request.method,
+        headers: forwardingHeaders(request.headers),
+        body: body.byteLength > 0 ? new Uint8Array(body) : undefined,
+        redirect: "manual",
+        signal: abortController.signal,
+      });
+      const headersAt = new Date().toISOString();
+      call.response = {
+        status: upstreamResponse.status,
+        statusText: upstreamResponse.statusText,
+        headers: responseHeaderEntries(upstreamResponse.headers),
+        headersAt,
+        chunks: [],
+      };
+
+      response.statusCode = upstreamResponse.status;
+      response.statusMessage = upstreamResponse.statusText;
+      applyResponseHeaders(response, upstreamResponse.headers);
+
+      const responseChunks: Buffer[] = [];
+      if (upstreamResponse.body) {
+        const reader = upstreamResponse.body.getReader();
+        for (;;) {
+          const part = await reader.read();
+          if (part.done) break;
+          const chunk = Buffer.from(part.value);
+          responseChunks.push(chunk);
+          call.response.chunks.push({
+            index: call.response.chunks.length,
+            ...encodeBytes(chunk),
+          });
+
+          if (call.fault?.kind === "disconnect-after-first-response-chunk") {
+            call.fault.triggered = true;
+            call.transport.outcome = "injected-disconnect";
+            abortController.abort(new Error("Injected disconnect after first upstream chunk."));
+            response.destroy();
+            break;
+          }
+          response.write(chunk);
+        }
+      }
+
+      const fullResponse = Buffer.concat(responseChunks);
+      call.response.body = encodeBytes(fullResponse);
+      call.response.parsedBody = parseJsonEvidence(
+        fullResponse,
+        upstreamResponse.headers.get("content-type") ?? undefined
+      );
+      if (!response.destroyed) response.end();
+      if (call.transport.outcome === "pending") {
+        call.transport.outcome = clientAborted ? "client-aborted" : "complete";
+      }
+    };
+
+    handleRequest()
+      .catch((error) => {
+        // error-policy:J1 boundary translation — the loopback HTTP boundary
+        // records the transport failure and returns an explicit 502 when the
+        // client is still connected; live assertions observe the same failure.
+        call.transport = {
+          outcome: response.destroyed ? "client-aborted" : "proxy-error",
+          error: serializeError(error),
+        };
+        if (!response.headersSent && !response.destroyed) {
+          response.statusCode = 502;
+          response.setHeader("content-type", "application/json");
+          response.end(JSON.stringify({ error: "cerebras evidence proxy upstream failure" }));
+        } else if (!response.destroyed) {
+          response.destroy(error instanceof Error ? error : new Error(String(error)));
+        }
+      })
+      .finally(() => {
+        const completedAtMs = Date.now();
+        call.completedAt = new Date(completedAtMs).toISOString();
+        call.durationMs = completedAtMs - startedAtMs;
+      });
+  });
+
+  const port = await startServer(server);
+  return {
+    baseUrl: `http://127.0.0.1:${port}/v1`,
+    calls,
+    armFault(fault) {
+      if (nextFault) {
+        throw new Error("[CerebrasWireCapture] A wire fault is already armed.");
+      }
+      nextFault = fault;
+    },
+    close: () => closeServer(server),
+  };
+}
+
+function jsonStringifyEvidence(value: unknown): string {
+  return JSON.stringify(
+    value,
+    (_key, nested) => {
+      if (typeof nested === "bigint") return nested.toString();
+      if (typeof nested === "function") return undefined;
+      return nested;
+    },
+    2
+  );
+}
+
+function redactSecrets(serialized: string, secrets: readonly string[]): string {
+  let redacted = serialized;
+  for (const secret of secrets.filter((value) => value.length > 0)) {
+    redacted = redacted.replaceAll(secret, REDACTED);
+    redacted = redacted.replaceAll(Buffer.from(secret).toString("base64"), REDACTED);
+  }
+  return redacted;
+}
+
+export async function writeCerebrasEvidenceArtifacts(
+  input: CerebrasEvidenceArtifactInput
+): Promise<{ wirePath: string; trajectoryPath: string }> {
+  await mkdir(input.artifactDirectory, { recursive: true });
+  const wirePath = join(input.artifactDirectory, "cerebras-wire-evidence.json");
+  const trajectoryPath =
+    input.trajectoryPath ?? join(input.artifactDirectory, "cerebras-trajectory.jsonl");
+  const payload = {
+    schema: "eliza_cerebras_wire_evidence_v1",
+    generatedAt: new Date().toISOString(),
+    metadata: input.metadata,
+    providerCatalog: input.providerCatalog,
+    receipts: input.receipts,
+    trajectories: input.trajectories,
+    calls: input.calls,
+  };
+  const serialized = `${redactSecrets(jsonStringifyEvidence(payload), input.secrets)}\n`;
+  await mkdir(dirname(wirePath), { recursive: true });
+  await writeFile(wirePath, serialized, "utf8");
+
+  const trajectoryLines = input.trajectories.map((trajectory, index) => {
+    const record = {
+      timestamp: new Date().toISOString(),
+      callId: `cerebras-trajectory-${index + 1}`,
+      ...trajectory,
+    };
+    return redactSecrets(JSON.stringify(record), input.secrets);
+  });
+  if (trajectoryLines.length > 0) {
+    await mkdir(dirname(trajectoryPath), { recursive: true });
+    await appendFile(trajectoryPath, `${trajectoryLines.join("\n")}\n`, "utf8");
+  }
+  return { wirePath, trajectoryPath };
+}
+
+export function serializeCerebrasProviderError(error: unknown): SerializedError {
+  return serializeError(error);
+}

--- a/plugins/plugin-openai/__tests__/native-plumbing.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/native-plumbing.shape.test.ts
@@ -69,6 +69,13 @@ vi.mock("ai", () => ({
       parsePartialOutput: async () => undefined,
       createElementStreamTransform: () => undefined,
     }),
+    json: () => ({
+      name: "json",
+      responseFormat: Promise.resolve({ type: "json" }),
+      parseCompleteOutput: async ({ text }: { text: string }) => JSON.parse(text),
+      parsePartialOutput: async () => undefined,
+      createElementStreamTransform: () => undefined,
+    }),
   },
 }));
 
@@ -499,7 +506,7 @@ describe("OpenAI native text plumbing", () => {
     }).rejects.toThrow("stream provider failed");
   });
 
-  it("maps string responseFormat json_object into the AI SDK responseFormat", async () => {
+  it("maps string responseFormat json_object into the AI SDK JSON output contract", async () => {
     aiMocks.generateText.mockResolvedValue({
       text: "{}",
       finishReason: "stop",
@@ -513,7 +520,37 @@ describe("OpenAI native text plumbing", () => {
     } as never);
 
     const call = aiMocks.generateText.mock.calls[0][0] as Record<string, unknown>;
-    expect(call.responseFormat).toEqual({ type: "json" });
+    expect(call).not.toHaveProperty("responseFormat");
+    await expect(
+      (call.output as { responseFormat: Promise<unknown> }).responseFormat
+    ).resolves.toEqual({ type: "json" });
+  });
+
+  it("keeps Cerebras JSON mode schema-free at the provider boundary", async () => {
+    vi.stubEnv("ELIZA_PROVIDER", "cerebras");
+    vi.stubEnv("CEREBRAS_API_KEY", "test-cerebras-key");
+    aiMocks.generateText.mockResolvedValue({
+      text: '{"answer":"ok"}',
+      finishReason: "stop",
+      usage: { inputTokens: 3, outputTokens: 3 },
+    });
+
+    const { handleTextSmall } = await import("../models/text");
+    await handleTextSmall(createRuntime(), {
+      prompt: "json",
+      responseFormat: { type: "json_object" },
+      responseSchema: {
+        type: "object",
+        properties: { answer: { type: "string" } },
+        required: ["answer"],
+      },
+    } as never);
+
+    const call = aiMocks.generateText.mock.calls[0][0] as Record<string, unknown>;
+    expect((call.output as { name: string }).name).toBe("json");
+    await expect(
+      (call.output as { responseFormat: Promise<unknown> }).responseFormat
+    ).resolves.toEqual({ type: "json" });
   });
 
   it("marks unconsumed streaming companion promises as handled", async () => {

--- a/plugins/plugin-openai/__tests__/native-plumbing.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/native-plumbing.shape.test.ts
@@ -333,6 +333,46 @@ describe("OpenAI native text plumbing", () => {
     expect(onStreamChunk).toHaveBeenNthCalledWith(2, "lo");
   });
 
+  it.each([
+    { stream: false, mock: aiMocks.generateText },
+    { stream: true, mock: aiMocks.streamText },
+  ])("forwards the caller abort signal to the $stream transport", async ({ stream, mock }) => {
+    const signal = new AbortController().signal;
+    if (stream) {
+      mock.mockResolvedValue({
+        textStream: (async function* textStream() {
+          yield "ok";
+        })(),
+        text: Promise.resolve("ok"),
+        toolCalls: Promise.resolve([]),
+        finishReason: Promise.resolve("stop"),
+        usage: Promise.resolve({ inputTokens: 1, outputTokens: 1 }),
+      });
+    } else {
+      mock.mockResolvedValue({
+        text: "ok",
+        toolCalls: [],
+        finishReason: "stop",
+        usage: { inputTokens: 1, outputTokens: 1 },
+      });
+    }
+
+    const { handleTextSmall } = await import("../models/text");
+    const result = await handleTextSmall(createRuntime(), {
+      prompt: "abortable request",
+      stream,
+      signal,
+    } as never);
+    if (stream) {
+      for await (const _chunk of (result as { textStream: AsyncIterable<string> }).textStream) {
+        // Consumption finalizes streaming telemetry; the assertion is on the SDK call below.
+      }
+    }
+
+    const call = mock.mock.calls[0][0] as Record<string, unknown>;
+    expect(call.abortSignal).toBe(signal);
+  });
+
   it("emits usage and records the completed live-stream response after consumption", async () => {
     const trajectoryCalls: CapturedLlmCall[] = [];
     const toolCalls = [{ toolName: "lookup", input: { q: "x" } }];

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -1589,6 +1589,7 @@ async function generateTextByModelType(
     ...promptOrMessages,
     system: systemPrompt,
     allowSystemInMessages: true,
+    ...(params.signal ? { abortSignal: params.signal } : {}),
     // Omit the cap when the caller opted out (direct-channel Stage-1) so the
     // model's own max applies — a hardcoded value 400s when it exceeds the
     // model's limit. Other callers keep the 8192 default.

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -88,7 +88,11 @@ interface GenerateTextParamsWithOpenAIOptions
   };
 }
 
-type NativeOutput = NonNullable<Parameters<typeof generateText<ToolSet>>[0]["output"]>;
+type NativeTextOutput = NonNullable<Parameters<typeof generateText<ToolSet>>[0]["output"]>;
+type NativeOutput =
+  | NativeTextOutput
+  | ReturnType<typeof Output.json>
+  | ReturnType<typeof Output.object>;
 type NativeGenerateTextParams = Parameters<typeof generateText<ToolSet, NativeOutput>>[0];
 type NativeStreamTextParams = Parameters<typeof streamText<ToolSet, NativeOutput>>[0];
 type NativePrompt =
@@ -1559,14 +1563,10 @@ async function generateTextByModelType(
       : userContent
         ? { messages: [{ role: "user" as const, content: userContent }] }
         : { prompt: promptText };
-  // elizaOS callers pass `responseFormat: { type: "json_object" | "text" }`
-  // (see `GenerateTextParams` in @elizaos/core). The AI SDK's equivalent
-  // is `responseFormat: { type: "json" }` (which translates to
-  // `response_format: { type: "json_object" }` at the OpenAI wire layer).
-  // Translate the shape so the param actually reaches the API call —
-  // before this, callers asking for json_object were silently ignored
-  // and Cerebras returned plain text, dropping us into the simple-reply
-  // fallback every turn.
+  // AI SDK v6 derives the provider-level response format from its `output`
+  // contract; a similarly named top-level setting is ignored by generateText.
+  // Cerebras accepts JSON mode but not the SDK's JSON Schema wire payload, so
+  // its unstructured JSON output deliberately carries no schema.
   const callerResponseFormat = (paramsWithAttachments as { responseFormat?: unknown })
     .responseFormat;
   const responseFormatType =
@@ -1577,11 +1577,11 @@ async function generateTextByModelType(
           "type" in callerResponseFormat
         ? (callerResponseFormat as { type: string }).type
         : undefined;
-  const wireResponseFormat: { type: "json" } | { type: "text" } | undefined =
-    responseFormatType === "json_object"
-      ? { type: "json" }
-      : responseFormatType === "text"
-        ? { type: "text" }
+  const requestedOutput: NativeOutput | undefined =
+    paramsWithAttachments.responseSchema && !cerebrasMode
+      ? buildStructuredOutput(paramsWithAttachments.responseSchema)
+      : responseFormatType === "json_object"
+        ? Output.json()
         : undefined;
 
   const generateParams: NativeTextParams = {
@@ -1597,15 +1597,7 @@ async function generateTextByModelType(
     experimental_telemetry: telemetryConfig,
     ...(normalizedTools ? { tools: normalizedTools } : {}),
     ...(normalizedToolChoice ? { toolChoice: normalizedToolChoice } : {}),
-    // Cerebras's OpenAI-compatible endpoint does not accept the
-    // `response_format: { type: "json_schema", ... }` payload that the AI SDK
-    // emits when `output: Output.object(...)` is set. Fall back to relying on
-    // `responseFormat: { type: "json_object" }` (already passed by callers)
-    // plus the schema embedded in the prompt body.
-    ...(paramsWithAttachments.responseSchema && !isCerebrasMode(runtime)
-      ? { output: buildStructuredOutput(paramsWithAttachments.responseSchema) }
-      : {}),
-    ...(wireResponseFormat ? { responseFormat: wireResponseFormat } : {}),
+    ...(requestedOutput ? { output: requestedOutput } : {}),
     ...(providerOptions ? { providerOptions: providerOptions as NativeProviderOptions } : {}),
   };
 


### PR DESCRIPTION
# Relates to

Closes #16298.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run against the synced head.
- [x] A reviewer can confirm the change works without reading the code from the exact-head run and immutable artifacts below.

# Sync with develop

- [x] Rebasing onto `origin/develop` reported the branch up to date with zero conflicts.
- [x] Post-install `bun run verify` passed: 573/573 tasks, all 28 dist-path consumers, and zero diff-scoped test-realness regressions.

# Risks

**Medium.** The production change maps JSON object requests to the AI SDK v6 `Output.json()` contract so `response_format` actually reaches OpenAI-compatible providers; non-Cerebras schema output remains schema-backed while Cerebras uses its supported schema-free JSON mode. The evidence proxy records raw request/response bytes, so its credential and cookie redaction is security-sensitive. Unit tests exercise split headers/bodies, binary integrity, signal forwarding, and bounded fault injection, and the uploaded exact-head artifact was scanned manually for credentials.

# Background

## What does this PR do?

It closes the proof gaps left by #16299 with a reproducible Cerebras evidence lane:

- preserves redacted raw request, response, and SSE chunk bytes with length and SHA-256 receipts;
- records real LLM trajectories for reasoning, exact GLM streaming, forced tool use, and structured JSON output;
- proves real 401, 404, 400 context-limit, caller-abort, and terminal mid-stream disconnect behavior;
- registers the credentialed suite in the real/live manifest and uploads evidence even when a later carrier step fails;
- fixes AI SDK v6 structured-output plumbing so the intended `response_format: {"type":"json_object"}` is present on the actual Cerebras wire;
- applies the disconnect fault to every bounded SDK retry so the error-path test cannot recover into false green.

The first exact run failed three assertions and is retained as a regression receipt: https://github.com/elizaOS/eliza/actions/runs/29303733035. The repaired exact-head run passes the scoped provider lane: https://github.com/elizaOS/eliza/actions/runs/29305529434.

## What kind of change is this?

Bug fix plus live evidence/test infrastructure.

# Documentation changes needed?

No public documentation change is needed. The workflow, live-suite manifest, artifact schema, and tests document the operator and reviewer path.

# Testing

## Where should a reviewer start?

Start with the final issue receipt, which links the exact head, artifact IDs/digests, and manual review:
https://github.com/elizaOS/eliza/issues/16298#issuecomment-4965480530

Then inspect:

1. artifact `8300392399` (`develop-live-evidence`) from the final run;
2. `report.json` and the included `index.html` viewer;
3. `cerebras-wire-evidence.json` for the raw-wire receipts;
4. `llm-calls.jsonl` and `trajectory.jsonl` for the four real model calls.

## Detailed testing steps

- `bun install` — 4,913 installs checked, no dependency changes.
- `bun run verify` — 573/573 tasks passed; 28/28 dist consumers passed.
- Focused shape/helper tests — 23/23 passed.
- Full keyless plugin suite — 122 passed, 3 skipped.
- Live-suite manifest tests — 13/13 passed.
- `actionlint .github/workflows/develop-live.yml` — passed.
- Error-policy, secret-leak, and test-integrity audits — passed.
- Exact credentialed wrapper — 14 test files passed / 1 skipped; 138 tests passed / 7 skipped; exit 0.

Final exact head: `8130e179272aca49df1779a5bd1b06dd9a7c8243`.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - provider/runtime/workflow-only change; no UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - provider/runtime/workflow-only change; no UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no frontend user flow; the artifact viewer and raw receipts are the review surface.
<!-- evidence-row:backend-logs -->
- [x] Backend/live-test logs are in [artifact 8300392399](https://github.com/elizaOS/eliza/actions/runs/29305529434/artifacts/8300392399) and [artifact 8300392178](https://github.com/elizaOS/eliza/actions/runs/29305529434/artifacts/8300392178).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser state changes.
<!-- evidence-row:llm-trajectory -->
- [x] Four real Cerebras LLM trajectories are in `llm-calls.jsonl`, `trajectory.jsonl`, and the viewer in [artifact 8300392399](https://github.com/elizaOS/eliza/actions/runs/29305529434/artifacts/8300392399).
<!-- evidence-row:domain-artifacts -->
- [x] The raw-wire domain artifact is `cerebras-wire-evidence.json` in [artifact 8300392399](https://github.com/elizaOS/eliza/actions/runs/29305529434/artifacts/8300392399).

# Evidence Details

## Real LLM-call trajectory

Final run: https://github.com/elizaOS/eliza/actions/runs/29305529434

- Evidence artifact: https://github.com/elizaOS/eliza/actions/runs/29305529434/artifacts/8300392399
- Artifact digest: `sha256:603cd15d214790deb9de04b03e660fdce9d37a9950d65f1abe4ccc3be980f5c9`
- Sweep-log artifact: https://github.com/elizaOS/eliza/actions/runs/29305529434/artifacts/8300392178
- Sweep digest: `sha256:53be8388612a044f1e8483b5d532d0977a05467b27d5c60859e32a3de6be8ac1`

The artifact contains four real LLM calls: `gpt-oss-120b` reasoning, exact `zai-glm-4.7` SSE with thinking disabled, a forced `RECORD_EVIDENCE` tool call, and JSON-mode structured output. The recorded outputs are `READY`, `PONG`, `{"verdict":"verified","count":2}` tool input, and the same parsed structured object.

## Backend + frontend logs

Backend: `stdout.log`, `stderr.log`, and `develop-live-sweep.log` are linked above. The scoped wrapper records `[eliza-test] PASS @elizaos/plugin-openai`, exit 0, and artifact creation.

Frontend: N/A - no frontend code or state path is changed.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface is changed.

### Before

N/A - no UI surface is changed.

### After

N/A - no UI surface is changed.

### Walkthrough video

N/A - no frontend flow exists. The self-contained HTML run viewer is included in the evidence artifact.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT path is changed.

## Known gaps / failures

- **429 is explicitly not exercised.** Cerebras exposes no deterministic 429 trigger; the suite does not fabricate a provider response or intentionally exhaust shared quota. The artifact records this row as `not-exercised`, never passed.
- **Overall workflow carrier is red after provider acceptance passed.** The later, separate Cloud unit suite fails at `packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts:514`: a test DB double lacks `db.execute`, producing “Sandbox bridge is unreachable.” This branch changes no Cloud source file. The scoped provider step passed before that failure and both artifact uploads passed afterward.
- **Screenshots/video/frontend/audio are N/A** because this is a provider/runtime/workflow-only change.

## Manual artifact review

I downloaded both final-run ZIPs and verified their SHA-256 values match GitHub's digests. I opened `report.json`, the HTML viewer/data, stdout/stderr, both JSONL files, the raw-wire JSON, and the sweep log. All 42 byte receipts reproduced their recorded byte lengths, SHA-256 values, and UTF-8 views. Authorization and set-cookie values are `[REDACTED]`; no Cerebras-key or bearer-credential pattern occurs in the extracted bundles. All nine exercised receipts passed, all three SDK retry attempts ended in injected disconnect after one real upstream chunk, and the 429 row remains explicitly `not-exercised`.