### PR TITLE
fix(cloud): make Railway voice services reproducible

### DIFF
--- a/packages/cloud/services/voice-kokoro-tts/Dockerfile
+++ b/packages/cloud/services/voice-kokoro-tts/Dockerfile
@@ -19,6 +19,10 @@ ARG KOKORO_IMAGE=ghcr.io/remsky/kokoro-fastapi-cpu:v0.2.2
 
 FROM ${KOKORO_IMAGE}
 
+# Kokoro-FastAPI v0.2.2 exposes only /v1/audio/speech. Cloud-api's stable free
+# voice contract remains /api/tts, so the derived image owns that typed adapter.
+COPY --chown=appuser:appuser eliza_kokoro_compat.py /app/eliza_kokoro_compat.py
+
 # Railway replaces this default with its deployment-specific PORT. The upstream
 # entrypoint hard-codes 8880, so the command below must expand PORT at runtime or
 # Railway probes a different socket and rejects an otherwise-running deploy.
@@ -27,4 +31,4 @@ EXPOSE 8880
 
 # Preserve the upstream model-download behavior while binding Uvicorn to the
 # same runtime port Railway uses for health checks and public routing.
-CMD ["sh", "-c", "if [ \"$DOWNLOAD_MODEL\" = \"true\" ]; then python download_model.py --output api/src/models/v1_0; fi; exec uv run --extra \"$DEVICE\" python -m uvicorn api.src.main:app --host 0.0.0.0 --port \"$PORT\" --log-level debug"]
+CMD ["sh", "-c", "if [ \"$DOWNLOAD_MODEL\" = \"true\" ]; then python download_model.py --output api/src/models/v1_0; fi; exec uv run --extra \"$DEVICE\" python -m uvicorn eliza_kokoro_compat:app --host 0.0.0.0 --port \"$PORT\" --log-level debug"]

--- a/packages/cloud/services/voice-kokoro-tts/Dockerfile
+++ b/packages/cloud/services/voice-kokoro-tts/Dockerfile
@@ -21,6 +21,8 @@ FROM ${KOKORO_IMAGE}
 
 # Kokoro-FastAPI v0.2.2 exposes only /v1/audio/speech. Cloud-api's stable free
 # voice contract remains /api/tts, so the derived image owns that typed adapter.
+# Its complete-audio path omits the required voice during text chunking; the
+# streaming WAV path is the upstream-supported path that preserves the voice.
 COPY --chown=appuser:appuser eliza_kokoro_compat.py /app/eliza_kokoro_compat.py
 
 # Railway replaces this default with its deployment-specific PORT. The upstream

--- a/packages/cloud/services/voice-kokoro-tts/Dockerfile
+++ b/packages/cloud/services/voice-kokoro-tts/Dockerfile
@@ -19,7 +19,12 @@ ARG KOKORO_IMAGE=ghcr.io/remsky/kokoro-fastapi-cpu:v0.2.2
 
 FROM ${KOKORO_IMAGE}
 
-# Railway injects PORT; the upstream server reads it. Kept explicit so the
-# healthcheck URL in railway.toml and the EXPOSE line agree with the runtime.
+# Railway replaces this default with its deployment-specific PORT. The upstream
+# entrypoint hard-codes 8880, so the command below must expand PORT at runtime or
+# Railway probes a different socket and rejects an otherwise-running deploy.
 ENV PORT=8880
 EXPOSE 8880
+
+# Preserve the upstream model-download behavior while binding Uvicorn to the
+# same runtime port Railway uses for health checks and public routing.
+CMD ["sh", "-c", "if [ \"$DOWNLOAD_MODEL\" = \"true\" ]; then python download_model.py --output api/src/models/v1_0; fi; exec uv run --extra \"$DEVICE\" python -m uvicorn api.src.main:app --host 0.0.0.0 --port \"$PORT\" --log-level debug"]

--- a/packages/cloud/services/voice-kokoro-tts/README.md
+++ b/packages/cloud/services/voice-kokoro-tts/README.md
@@ -27,6 +27,10 @@ redeploy from this directory:
 railway up --service kokoro-tts       # from packages/cloud/services/voice-kokoro-tts
 ```
 
+Railway assigns a deployment-specific `PORT`; the image launcher binds Uvicorn
+to that value so `/health` is checked on the same socket that serves traffic.
+Do not restore the upstream launch command, which hard-codes port `8880`.
+
 After deploy, point cloud-api at it by setting `KOKORO_TTS_URL` (Worker env /
 `wrangler secret`) to the service's public URL, and set the same URL as the repo
 variable `ELIZA_VOICE_KOKORO_TTS_URL` so the scheduled contract lane targets the

--- a/packages/cloud/services/voice-kokoro-tts/README.md
+++ b/packages/cloud/services/voice-kokoro-tts/README.md
@@ -5,6 +5,10 @@ Self-hosted Kokoro TTS behind the cloud-api `/api/v1/voice/tts` route (the
 upstream [Kokoro-FastAPI](https://github.com/remsky/Kokoro-FastAPI) image; the
 weights ship in the image, so there are no secrets.
 
+Pinned Kokoro-FastAPI exposes `/v1/audio/speech`; `eliza_kokoro_compat.py`
+adapts the existing cloud-api `/api/tts` body to that typed upstream request.
+Keep this adapter until every deployed cloud-api caller uses the new contract.
+
 ## Contract (do not break — the live test asserts it)
 
 | Method | Path | Request | Response |

--- a/packages/cloud/services/voice-kokoro-tts/README.md
+++ b/packages/cloud/services/voice-kokoro-tts/README.md
@@ -28,7 +28,7 @@ The service is pinned in-repo (`Dockerfile` + `railway.toml`). To deploy or
 redeploy from this directory:
 
 ```bash
-railway up --service kokoro-tts       # from packages/cloud/services/voice-kokoro-tts
+railway up . --path-as-root --service kokoro-tts  # from packages/cloud/services/voice-kokoro-tts
 ```
 
 Railway assigns a deployment-specific `PORT`; the image launcher binds Uvicorn
@@ -43,6 +43,6 @@ live deploy (see `../voice-whisper-stt/README.md` for the shared lane wiring).
 Build a GPU variant on a GPU-backed plan by overriding the pinned image:
 
 ```bash
-railway up --service kokoro-tts \
+railway up . --path-as-root --service kokoro-tts \
   --build-arg KOKORO_IMAGE=ghcr.io/remsky/kokoro-fastapi-gpu:v0.2.2
 ```

--- a/packages/cloud/services/voice-kokoro-tts/eliza_kokoro_compat.py
+++ b/packages/cloud/services/voice-kokoro-tts/eliza_kokoro_compat.py
@@ -1,0 +1,38 @@
+"""Preserves the cloud voice contract on top of pinned Kokoro-FastAPI.
+
+Cloud-api sends the legacy ``POST /api/tts`` request shape. The pinned upstream
+only exposes OpenAI-compatible ``POST /v1/audio/speech``, so this module adds a
+thin typed adapter while leaving model loading and audio generation upstream.
+"""
+
+from fastapi import Request
+from pydantic import BaseModel, Field
+
+from api.src.main import app
+from api.src.routers.openai_compatible import create_speech
+from api.src.structures import OpenAISpeechRequest
+
+
+class CloudTTSRequest(BaseModel):
+    """Request body sent by the cloud-api free TTS route."""
+
+    text: str = Field(min_length=1)
+    voice: str = Field(min_length=1)
+    speed: float = Field(ge=0.25, le=4.0)
+
+
+@app.post("/api/tts")
+async def cloud_tts(payload: CloudTTSRequest, request: Request):
+    """Translate the stable cloud contract into Kokoro's pinned API shape."""
+
+    return await create_speech(
+        OpenAISpeechRequest(
+            model="kokoro",
+            input=payload.text,
+            voice=payload.voice,
+            response_format="wav",
+            speed=payload.speed,
+            stream=False,
+        ),
+        request,
+    )

--- a/packages/cloud/services/voice-kokoro-tts/eliza_kokoro_compat.py
+++ b/packages/cloud/services/voice-kokoro-tts/eliza_kokoro_compat.py
@@ -32,7 +32,7 @@ async def cloud_tts(payload: CloudTTSRequest, request: Request):
             voice=payload.voice,
             response_format="wav",
             speed=payload.speed,
-            stream=False,
+            stream=True,
         ),
         request,
     )

--- a/packages/cloud/services/voice-whisper-stt/Dockerfile
+++ b/packages/cloud/services/voice-whisper-stt/Dockerfile
@@ -31,7 +31,10 @@ FROM ${WHISPER_IMAGE}
 # packages/cloud/api/v1/voice/stt/whisper-model.ts.
 ENV WHISPER__MODEL=Systran/faster-whisper-small
 
-# Railway injects PORT; kept explicit so the railway.toml healthcheck and EXPOSE
-# agree with the runtime bind.
+# Railway replaces this default with its deployment-specific PORT. Speaches
+# normally reads UVICORN_PORT=8000 instead, so the command below must pass PORT
+# explicitly or Railway probes a different socket and rejects the deployment.
 ENV PORT=8000
 EXPOSE 8000
+
+CMD ["sh", "-c", "exec uvicorn --factory speaches.main:create_app --host 0.0.0.0 --port \"$PORT\""]

--- a/packages/cloud/services/voice-whisper-stt/Dockerfile
+++ b/packages/cloud/services/voice-whisper-stt/Dockerfile
@@ -12,8 +12,8 @@
 #   GET  /health       -> 200 (Railway healthcheck, see railway.toml)
 # The `model` id the route sends is resolveWhisperSttModel(WHISPER_STT_MODEL),
 # defaulting to the multilingual Systran/faster-whisper-small — Speaches lazily
-# downloads that CTranslate2 model on first use, so WHISPER__MODEL below warms it
-# at boot to keep the first live request from timing out.
+# downloads that CTranslate2 model only through its registry API, so the build
+# installs it before Railway can accept the service.
 #
 # Pin: Speaches publishes CPU/CUDA variants under ghcr.io/speaches-ai/speaches.
 # CPU is the Railway default (free tier has no GPU); override WHISPER_IMAGE at
@@ -26,10 +26,14 @@ ARG WHISPER_IMAGE=ghcr.io/speaches-ai/speaches:0.8.2-cpu
 
 FROM ${WHISPER_IMAGE}
 
-# Warm the default multilingual model at boot so the first transcription does not
-# eat a cold model download. Must track DEFAULT_WHISPER_STT_MODEL in
-# packages/cloud/api/v1/voice/stt/whisper-model.ts.
-ENV WHISPER__MODEL=Systran/faster-whisper-small
+# Railway accepts the service only after the image already contains the model.
+# Speaches 0.8.2 does not preload models from an environment variable, and its
+# generic /health endpoint cannot distinguish an empty registry from a usable
+# transcription service. Keep this default aligned with
+# DEFAULT_WHISPER_STT_MODEL in packages/cloud/api/v1/voice/stt/whisper-model.ts.
+ARG WHISPER_MODEL=Systran/faster-whisper-small
+ENV WHISPER_MODEL=${WHISPER_MODEL}
+RUN python -c 'import os; from speaches.executors.whisper.utils import model_registry; model_registry.download_model_files_if_not_exist(os.environ["WHISPER_MODEL"])'
 
 # Railway replaces this default with its deployment-specific PORT. Speaches
 # normally reads UVICORN_PORT=8000 instead, so the command below must pass PORT

--- a/packages/cloud/services/voice-whisper-stt/README.md
+++ b/packages/cloud/services/voice-whisper-stt/README.md
@@ -28,6 +28,10 @@ The service is pinned in-repo (`Dockerfile` + `railway.toml`):
 railway up --service whisper-stt      # from packages/cloud/services/voice-whisper-stt
 ```
 
+Railway assigns a deployment-specific `PORT`; the image launcher passes that
+value to Uvicorn explicitly so `/health` and public traffic use the same socket.
+Do not rely on Speaches' fixed `UVICORN_PORT=8000` image default.
+
 After deploy, set `WHISPER_STT_URL` (cloud-api Worker env / `wrangler secret`)
 to the public URL, optionally `WHISPER_STT_MODEL` to pin a different hosted
 model, and set the repo variable `ELIZA_VOICE_WHISPER_STT_URL` to the same URL.

--- a/packages/cloud/services/voice-whisper-stt/README.md
+++ b/packages/cloud/services/voice-whisper-stt/README.md
@@ -4,7 +4,8 @@ Self-hosted Whisper STT behind the cloud-api `/api/v1/voice/stt` route (the
 `WHISPER_STT_URL` branch — the free, unbilled default transcription path). It
 wraps the upstream [Speaches](https://github.com/speaches-ai/speaches) image
 (OpenAI-compatible, formerly faster-whisper-server); the CTranslate2 model is
-fetched from Hugging Face at boot, so there are no secrets.
+fetched from Hugging Face while the image is built, so there are no secrets and
+a healthy deployment already contains the model required by the route.
 
 ## Contract (do not break — the live test asserts it)
 
@@ -16,8 +17,8 @@ fetched from Hugging Face at boot, so there are no secrets.
 The `model` id is `resolveWhisperSttModel(WHISPER_STT_MODEL)`, defaulting to the
 multilingual `Systran/faster-whisper-small`
 (`packages/cloud/api/v1/voice/stt/whisper-model.ts`). The Dockerfile's
-`WHISPER__MODEL` warms that same model at boot — keep the two in sync. The exact
-request shape is asserted by
+`WHISPER_MODEL` build argument installs that same model — keep the two in sync.
+The exact request shape is asserted by
 `packages/cloud/api/__tests__/voice-kokoro-whisper-live.test.ts`.
 
 ## Deploy (owner action)
@@ -25,7 +26,7 @@ request shape is asserted by
 The service is pinned in-repo (`Dockerfile` + `railway.toml`):
 
 ```bash
-railway up --service whisper-stt      # from packages/cloud/services/voice-whisper-stt
+railway up . --path-as-root --service whisper-stt  # from packages/cloud/services/voice-whisper-stt
 ```
 
 Railway assigns a deployment-specific `PORT`; the image launcher passes that
@@ -39,7 +40,7 @@ model, and set the repo variable `ELIZA_VOICE_WHISPER_STT_URL` to the same URL.
 CUDA variant on a GPU-backed plan:
 
 ```bash
-railway up --service whisper-stt \
+railway up . --path-as-root --service whisper-stt \
   --build-arg WHISPER_IMAGE=ghcr.io/speaches-ai/speaches:0.8.2-cuda
 ```
 

--- a/packages/cloud/services/voice-whisper-stt/railway.toml
+++ b/packages/cloud/services/voice-whisper-stt/railway.toml
@@ -5,8 +5,8 @@
 # secrets required — cloud-api owns auth/billing upstream and the Docker image
 # contains the model required by the route.
 #
-# healthcheckTimeout is generous: the first boot downloads the CTranslate2 model
-# weights, so early /health probes can be slow on a cold deploy.
+# healthcheckTimeout is generous because cold containers must unpack the model
+# layer and initialize the API before Railway probes the serving socket.
 
 [build]
 builder = "DOCKERFILE"

--- a/packages/cloud/services/voice-whisper-stt/railway.toml
+++ b/packages/cloud/services/voice-whisper-stt/railway.toml
@@ -2,8 +2,8 @@
 #
 # Consumed by the cloud-api /api/v1/voice/stt route via the WHISPER_STT_URL env
 # var; serves POST /v1/audio/transcriptions (OpenAI-compatible) -> { text }. No
-# secrets required — cloud-api owns auth/billing upstream and the model is fetched
-# from Hugging Face at boot (WHISPER__MODEL in the Dockerfile).
+# secrets required — cloud-api owns auth/billing upstream and the Docker image
+# contains the model required by the route.
 #
 # healthcheckTimeout is generous: the first boot downloads the CTranslate2 model
 # weights, so early /health probes can be slow on a cold deploy.

--- a/packages/scripts/__tests__/voice-railway-service-defs.test.ts
+++ b/packages/scripts/__tests__/voice-railway-service-defs.test.ts
@@ -117,7 +117,7 @@ describe("Railway voice service definitions (#14374)", () => {
           expect(adapter).toContain('@app.post("/api/tts")');
           expect(adapter).toContain("OpenAISpeechRequest(");
           expect(adapter).toContain('response_format="wav"');
-          expect(adapter).toContain("stream=False");
+          expect(adapter).toContain("stream=True");
         });
       }
 

--- a/packages/scripts/__tests__/voice-railway-service-defs.test.ts
+++ b/packages/scripts/__tests__/voice-railway-service-defs.test.ts
@@ -91,6 +91,20 @@ describe("Railway voice service definitions (#14374)", () => {
         expect(typeof toml.deploy?.healthcheckTimeout).toBe("number");
       });
 
+      test("binds the server to Railway's runtime PORT", () => {
+        const dockerfile = read(`${svc.dir}/Dockerfile`);
+        const command = dockerfile.match(/^CMD\s+(.*)$/m)?.[1];
+
+        // Dockerfile ENV is only a local default: Railway replaces PORT for
+        // each deployment and probes that assigned value. Both upstream images
+        // otherwise bind fixed ports, which leaves the process running while
+        // every Railway health probe targets the wrong socket.
+        expect(dockerfile).toMatch(/^ENV PORT=\d+$/m);
+        expect(command).toBeDefined();
+        expect(command).toContain('"sh", "-c"');
+        expect(command).toContain('\\"$PORT\\"');
+      });
+
       test("documents the route contract and the owner deploy command", () => {
         expect(exists(`${svc.dir}/README.md`)).toBe(true);
         const readme = read(`${svc.dir}/README.md`);

--- a/packages/scripts/__tests__/voice-railway-service-defs.test.ts
+++ b/packages/scripts/__tests__/voice-railway-service-defs.test.ts
@@ -40,6 +40,7 @@ const SERVICES = [
     // is verified to exist on ghcr — a bad tag (`railway up` fails at FROM) is
     // caught here instead of only at deploy. Re-verify the manifest before bumping.
     imageTag: "ghcr.io/remsky/kokoro-fastapi-cpu:v0.2.2",
+    compatibilityModule: "eliza_kokoro_compat.py",
   },
   {
     dir: "packages/cloud/services/voice-whisper-stt",
@@ -49,6 +50,7 @@ const SERVICES = [
     // 0.8.2-cpu is a real ghcr manifest that still serves the transcription +
     // /health contract; the prior 0.6.5-cpu was a 404 (`railway up` died at FROM).
     imageTag: "ghcr.io/speaches-ai/speaches:0.8.2-cpu",
+    compatibilityModule: null,
   },
 ] as const;
 
@@ -104,6 +106,20 @@ describe("Railway voice service definitions (#14374)", () => {
         expect(command).toContain('"sh", "-c"');
         expect(command).toContain('\\"$PORT\\"');
       });
+
+      if (svc.compatibilityModule !== null) {
+        test("adapts the stable cloud route to the pinned upstream API", () => {
+          const dockerfile = read(`${svc.dir}/Dockerfile`);
+          const adapter = read(`${svc.dir}/${svc.compatibilityModule}`);
+
+          expect(dockerfile).toContain(svc.compatibilityModule);
+          expect(dockerfile).toContain("eliza_kokoro_compat:app");
+          expect(adapter).toContain('@app.post("/api/tts")');
+          expect(adapter).toContain("OpenAISpeechRequest(");
+          expect(adapter).toContain('response_format="wav"');
+          expect(adapter).toContain("stream=False");
+        });
+      }
 
       test("documents the route contract and the owner deploy command", () => {
         expect(exists(`${svc.dir}/README.md`)).toBe(true);

--- a/packages/scripts/__tests__/voice-railway-service-defs.test.ts
+++ b/packages/scripts/__tests__/voice-railway-service-defs.test.ts
@@ -34,7 +34,7 @@ const SERVICES = [
     // The route contract these files exist to serve; the strings must appear in
     // the README so the contract is legible without reading the route code.
     contractPath: "/api/tts",
-    deployCmd: "railway up --service kokoro-tts",
+    deployCmd: "railway up . --path-as-root --service kokoro-tts",
     urlVar: "ELIZA_VOICE_KOKORO_TTS_URL",
     // Exact `FROM` tag the Dockerfile ARG defaults to. Pinned to a manifest that
     // is verified to exist on ghcr — a bad tag (`railway up` fails at FROM) is
@@ -45,7 +45,7 @@ const SERVICES = [
   {
     dir: "packages/cloud/services/voice-whisper-stt",
     contractPath: "/v1/audio/transcriptions",
-    deployCmd: "railway up --service whisper-stt",
+    deployCmd: "railway up . --path-as-root --service whisper-stt",
     urlVar: "ELIZA_VOICE_WHISPER_STT_URL",
     // 0.8.2-cpu is a real ghcr manifest that still serves the transcription +
     // /health contract; the prior 0.6.5-cpu was a 404 (`railway up` died at FROM).
@@ -118,6 +118,19 @@ describe("Railway voice service definitions (#14374)", () => {
           expect(adapter).toContain("OpenAISpeechRequest(");
           expect(adapter).toContain('response_format="wav"');
           expect(adapter).toContain("stream=True");
+        });
+      }
+
+      if (svc.dir.endsWith("voice-whisper-stt")) {
+        test("installs the required multilingual model into the image", () => {
+          const dockerfile = read(`${svc.dir}/Dockerfile`);
+
+          expect(dockerfile).toContain(
+            "ARG WHISPER_MODEL=Systran/faster-whisper-small",
+          );
+          expect(dockerfile).toContain(
+            "model_registry.download_model_files_if_not_exist",
+          );
         });
       }
 


### PR DESCRIPTION
# Relates to

Fixes #14374.

- [x] Both pinned Railway services reproduce from committed definitions.
- [x] The production request shapes pass against fresh exact-head deployments.
- [x] The scheduled monitor fails on a deliberately broken URL and recovers green after restoration.
- [x] Required JPG and narrated MP4 evidence is attached inline and manually reviewed.

# Sync with develop

- PR head: `3ced248930b71e65cee89d9e9b5cb9a5dddb6dbf`
- Base and merge-base: `4f766c5b71f16f0a143e495b7fb19f09cd1e67f8`
- A final `git fetch origin develop` reports `HEAD...origin/develop = 5 0`; there are no base commits to rebase and no conflicts.
- Local and remote branch heads are identical.
- `bun run verify` passes at the exact PR head: 573/573 Turbo tasks plus all 28 dist-path consumer configs.

# Risks

Medium operational risk, bounded by pinned images and the live monitor. Whisper's multilingual model is now part of the immutable image, which increases its image size but prevents Railway's generic `/health` endpoint from accepting a container whose required model is absent. Kokoro remains on the pinned CPU image and exposes the existing cloud contract through a thin typed adapter.

The workflow also contains separate self-hosted acoustic jobs. Their missing GPU/voice provisioning is tracked by #9454 and does not weaken or gate the GitHub-hosted Railway contract job proved here.

# Background

## What does this PR do?

- Binds both upstream servers to Railway's runtime-assigned `PORT`, so the process, health probe, and public domain use the same socket.
- Preserves the cloud API's `POST /api/tts { text, voice, speed } -> audio/wav` contract over Kokoro-FastAPI v0.2.2's OpenAI endpoint.
- Uses Kokoro's working streaming WAV path; its pinned complete-audio path omits the required voice while chunking and returns HTTP 500.
- Installs `Systran/faster-whisper-small` into the Speaches image during build. Speaches 0.8.2 ignores the old `WHISPER__MODEL` preload assumption and otherwise returns 404 after a healthy deploy.
- Documents the monorepo-safe `railway up . --path-as-root` owner command.
- Expands mutation-sensitive service-definition tests for runtime ports, the compatibility route, baked model, pinned images, deploy docs, and monitor wiring.

## Root-cause progression proved against real Railway

1. Fresh `develop` deployments `46857e2f-3a65-4db4-8b00-03dccbae21be` (Kokoro) and `bbcc82cc-79d7-4e89-8ccf-dd01e0783077` (Whisper) failed Railway health because their inherited launchers listened on 8880/8000 instead of injected `PORT=8080`.
2. After repairing the socket, the real cloud route exposed Kokoro's missing `/api/tts` compatibility endpoint and then the pinned upstream non-streaming voice bug. The adapter now routes through the live-proved streaming WAV path.
3. The first real round trip then exposed Whisper's empty model registry: `/health` returned 200 while transcription returned `404 Model ... is not installed locally`. The build now installs the exact model before Railway can accept the image.

# Testing

## Fresh exact-head deployments

| Service | Deployment | Image digest | Manual finding |
| --- | --- | --- | --- |
| Kokoro | `fc17eda2-6199-4b3f-aae1-1edbf9f4ec08` | `sha256:7f20118883c4322b0e951020f28709e512ad8e3089de54ac3dbf87824883d62f` | `/health` 200; four reviewed `/api/tts` requests 200; generated valid RIFF/WAVE. |
| Whisper | `c968cde2-ec2d-4848-9a1e-dd15699d22ed` | `sha256:a8fcd7b1852c6c1e239fa5d6425100c1031d4354588e34aae2b884266d51cf0c` | `/v1/models` lists the multilingual model before use; model loads in 0.70s; three reviewed transcription requests 200. |

Both deployment messages contain exact head `3ced248930b`. The public domains target port 8080, and the repository variables point at those domains.

## Automated and local verification

- `bun test packages/scripts/__tests__/voice-railway-service-defs.test.ts`: 16 pass, 55 assertions.
- Exact production `ELIZA_VOICE_LIVE_RAILWAY=1 ... bun test packages/cloud/api/__tests__/voice-kokoro-whisper-live.test.ts`: 1 pass, 1 optional Spanish fixture skip, 0 fail, 100% coverage of the model resolver.
- [Intentional-red dispatch](https://github.com/elizaOS/eliza/actions/runs/29310564804/job/87013230022): `WHISPER_STT_URL=https://example.invalid` reached the job environment and failed with `ENOTFOUND example.invalid` (0 pass / 1 fail).
- [Recovery-green dispatch](https://github.com/elizaOS/eliza/actions/runs/29310613685/job/87013388679): restored production URL, 1 pass / 0 fail at the exact PR head.
- Biome on the changed TypeScript test, Python bytecode compilation for the adapter, Docker/Railway live builds, `git diff --check`, and the full `bun run verify`: pass.

<details>
<summary>Reviewed backend log receipts</summary>

```text
Kokoro: Uvicorn running on 0.0.0.0:8080
Kokoro: GET /health -> 200 OK
Kokoro: POST /api/tts -> 200 OK
Whisper: Uvicorn running on 0.0.0.0:8080
Whisper: GET /health -> 200 OK
Whisper: Model Systran/faster-whisper-small loaded in 0.70s
Whisper: POST /v1/audio/transcriptions -> 200 OK
```

Local reviewed-log SHA-256 values:

- Whisper build: `0c1a78cb2ebd94834a025a2e3c925a24c73b305c7eeffeeec67a9aa633001ca7`
- Whisper runtime: `13c5b4f0d13c74fcb1f04d1b74d9954bb5f4c6228ea4637f9097619bacac199f`
- Kokoro runtime: `928652318cb5e4f1320cceb8e43a60f565076eec8790b22fd021f0c012d0b46d`
- Intentional-red job: `4649ceb4c309471f74850af246ac306c96eb81a83f163b19f0f1445ed6fe5b5b`
- Recovery-green job: `39ad579552055bdb508c4fab7062f1ab0450105671d4cfebace2ce933cc73256`

</details>

## Manual artifact review

[Inline evidence comment](https://github.com/elizaOS/eliza/pull/16337#issuecomment-4966017621): two JPG job receipts plus the narrated WAV/spectrogram MP4.

- WAV: 247,948 bytes, RIFF/WAVE, 16-bit mono PCM at 24 kHz; SHA-256 `df78ac1e4ddbb56a4273ae77c8a64b7ebe341e9adb9279ad91be9192429d1bb1`.
- MP4: 510,336 bytes, H.264/AAC with fast-start metadata; SHA-256 `cfd3542feafadd67f7e26d49894137af2f03399229366c83412c35f9c75c14fa`.
- I opened the spectrogram and reviewed continuous voiced harmonics across the complete ~5-second sentence.
- The freshly deployed Whisper transcribed it as: “The Eliza OS Railway Voice Contract is healthy on the exact production commit.”

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] `N/A - service deployment/configuration only; no product UI pixels changed.`
<!-- evidence-row:after-screenshots -->
- [x] Scheduled monitor red/green JPGs are attached in the [inline evidence comment](https://github.com/elizaOS/eliza/pull/16337#issuecomment-4966017621).
<!-- evidence-row:walkthrough-video -->
- [x] Narrated WAV/spectrogram MP4 is attached in the [inline evidence comment](https://github.com/elizaOS/eliza/pull/16337#issuecomment-4966017621).
<!-- evidence-row:backend-logs -->
- [x] Fresh exact-head Railway deployment/runtime receipts are documented above; the selected contract jobs provide the intentional [red log](https://github.com/elizaOS/eliza/actions/runs/29310564804/job/87013230022) and recovered [green log](https://github.com/elizaOS/eliza/actions/runs/29310613685/job/87013388679).
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend console, network, request, or state path changed.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no LLM, prompt, action, provider, or planner behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts—exact image digests, WAV, transcript, spectrogram, MP4, inline JPGs, and scheduled red/green receipts—are attached in the [inline evidence comment](https://github.com/elizaOS/eliza/pull/16337#issuecomment-4966017621) and detailed above.

# Evidence Details

## Audio / voice walkthrough

The inline MP4 contains the actual freshly synthesized production audio, not a mock or silent fixture. Its associated WAV was submitted unchanged to the freshly deployed Whisper service, and the returned transcript is quoted above.

## Known gaps / truthful disclosures

- The optional Spanish test remains skipped because `ELIZA_VOICE_LIVE_SPANISH_AUDIO_URL` is not provisioned; multilingual model identity and its full advertised language registry are verified, while a licensed Spanish fixture remains a separate evidence input.
- The unrelated acoustic matrix is not fully provisioned on the self-hosted runner (#9454). This PR's production Railway contract runs on GitHub-hosted Linux and is independently green.
- Railway dashboard log links require project access, so durable reviewer-visible proof is also present in the GitHub job logs, exact deployment/image identifiers, inline media, and quoted structured receipts.