### PR TITLE
chore: ignore AppleDouble sidecars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1582,3 +1582,6 @@ packages/ui/src/components/shell/__e2e__/output-fused-wake-integration/
 packages/ui/src/testing/__e2e__/output-widget-cert/
 # Home locale e2e output (screenshots — regenerate via test:home-locale-e2e)
 packages/ui/src/components/shell/__e2e__/output-home-locale/
+
+# Dataset allowlists above must not re-include macOS resource-fork sidecars.
+**/._*

--- a/packages/cloud/shared/.gitignore
+++ b/packages/cloud/shared/.gitignore
@@ -113,3 +113,6 @@ TRIAGE_NOTES.md
 .env.local.bak-*
 .wrangler
 .wrangler-dry-run
+
+# Log allowlists above must not re-include macOS resource-fork sidecars.
+**/._*

--- a/packages/native/bun-runtime/.gitignore
+++ b/packages/native/bun-runtime/.gitignore
@@ -3,3 +3,5 @@ artifacts/*
 !artifacts/ElizaBunEngine.xcframework/**
 build/
 vendor/
+# The xcframework re-include admits every descendant; reject macOS resource-fork sidecars.
+**/._*

--- a/packages/tools/voice-evidence-harness/.gitignore
+++ b/packages/tools/voice-evidence-harness/.gitignore
@@ -6,3 +6,5 @@ node_modules/
 # fixtures are required to run it and are committed on purpose (provenance in
 # fixtures/PROVENANCE.md). Re-include them here.
 !fixtures/*.wav
+# The fixtures/*.wav re-include must not admit macOS resource-fork sidecars (._*.wav).
+**/._*

--- a/packages/training/.gitignore
+++ b/packages/training/.gitignore
@@ -53,3 +53,5 @@ curriculum_state.json
 scripts/synth/scenarios/*.jsonl
 # DFlash drafter distillation job outputs (see scripts/dflash/jobs/).
 runs/
+# Dataset allowlists must not admit macOS resource-fork sidecars.
+**/._*

--- a/plugins/plugin-local-inference/native/verify/asr_bench_fixtures/.gitignore
+++ b/plugins/plugin-local-inference/native/verify/asr_bench_fixtures/.gitignore
@@ -1,1 +1,3 @@
 !**/*.wav
+# The *.wav re-include must not admit macOS resource-fork sidecars (._*.wav).
+**/._*


### PR DESCRIPTION
# Relates to

Closes #16340

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install --frozen-lockfile` and `bun run verify` passed after sync.
- [x] A reviewer can confirm the ignore behavior from the rule-provenance transcript below.

# Sync with develop

- [x] Rebased onto `origin/develop` at `0f8045c6744`; zero conflicts.
- [x] `bun run verify` passes post-sync: 573/573 Turbo tasks plus all follow-on repository audits.

# Risks

Low. The terminal `**/._*` rules ignore macOS AppleDouble resource-fork sidecars repository-wide and after the training subtree's broad allowlists. Files whose actual names intentionally begin `._` can no longer be committed, which is the intended repository policy.

# Background

## What does this PR do?

Adds a terminal AppleDouble rejection to the root ignore policy and repeats it after `packages/training/.gitignore` allowlist negations. The subtree rule is necessary because a descendant ignore file's later negation can override an ancestor rule.

No dataset or generated artifact is modified or deleted.

## What kind of change is this?

Repository hygiene improvement.

# Documentation changes needed?

No user-facing documentation changes are needed; the durable rationale is adjacent to each ignore rule.

# Testing

## Where should a reviewer start?

Run the exact commands below from the repository root. Each representative path must resolve to the terminal AppleDouble rule, and the diff must remain clean.

```bash
git diff --check origin/develop...HEAD
git check-ignore -v --no-index \
  packages/benchmarks/example/._artifact \
  packages/training/data/final-eliza1-smoke/._train.jsonl \
  packages/training/data/voice/example/._audio.wav
```

Validated after the final rebase:

- `bun install --frozen-lockfile` — pass.
- `bun run verify` — pass, 573/573 Turbo tasks and all follow-on audits.
- `git diff --check origin/develop...HEAD` — pass.
- `git check-ignore -v --no-index ...` — all three paths resolve to the intended terminal rules.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - ignore-policy-only change has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - ignore-policy-only change has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - there is no interactive or visual flow to record.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no backend process or request path changes.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend source or network behavior changes.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the representative rule-provenance transcript below satisfies the acceptance plan in [#16340](https://github.com/elizaOS/eliza/issues/16340).

# Evidence Details

## Ignore-rule provenance

Manually reviewed output:

```text
.gitignore:1587:**/._*  packages/benchmarks/example/._artifact
packages/training/.gitignore:57:**/._*  packages/training/data/final-eliza1-smoke/._train.jsonl
packages/training/.gitignore:57:**/._*  packages/training/data/voice/example/._audio.wav
```

The first path proves repository-wide rejection. The latter two prove that the training subtree's terminal rule wins after its dataset allowlists.

## Real LLM-call trajectory

N/A - no agent/model/action/provider/prompt behavior changes.

## Backend + frontend logs

N/A - Git ignore evaluation is a local repository operation, not a running backend or frontend path.

## Screenshots + walkthrough video

N/A - no rendered surface or user flow changes.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT behavior changes.

## Known gaps / failures

None. Repository-wide verification and the targeted rule-provenance checks pass after the final sync.
