### PR TITLE
fix(build): harden package dist inputs

### DIFF
--- a/packages/scripts/__tests__/copy-package-assets.test.ts
+++ b/packages/scripts/__tests__/copy-package-assets.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Verifies package asset assembly excludes generated caches while retaining
+ * the source assets needed by installed packages.
+ */
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { copyPackageAssets } from "../copy-package-assets.mjs";
+
+const temporaryDirectories: string[] = [];
+
+function writeFixture(root: string, relativePath: string, contents: string) {
+  const target = join(root, relativePath);
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, contents);
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("copy-package-assets", () => {
+  test("omits Python bytecode generated beside package sources", async () => {
+    const packageRoot = mkdtempSync(join(tmpdir(), "eliza-package-assets-"));
+    temporaryDirectories.push(packageRoot);
+    writeFixture(packageRoot, "packaging/python/module.py", "VALUE = 1\n");
+    writeFixture(
+      packageRoot,
+      "packaging/python/__pycache__/module.cpython-312.pyc",
+      "/source/checkout/module.py",
+    );
+    writeFixture(
+      packageRoot,
+      "packaging/python/legacy.pyc",
+      "/source/checkout/legacy.py",
+    );
+    writeFixture(
+      packageRoot,
+      "packaging/python/optimized.pyo",
+      "/source/checkout/optimized.py",
+    );
+    writeFixture(
+      packageRoot,
+      "packaging/python/elizaos_app.egg-info/PKG-INFO",
+      "generated package metadata\n",
+    );
+    writeFixture(
+      packageRoot,
+      "packaging/python/.pytest_cache/nodeids",
+      "generated test cache\n",
+    );
+    writeFixture(
+      packageRoot,
+      "packaging/python/.coverage.worker",
+      "generated coverage data\n",
+    );
+    for (const cacheDirectory of [
+      ".mypy_cache",
+      ".ruff_cache",
+      ".venv",
+      "ENV",
+      "env",
+      "venv",
+    ]) {
+      writeFixture(
+        packageRoot,
+        `packaging/python/${cacheDirectory}/generated-state`,
+        "generated local state\n",
+      );
+    }
+
+    await copyPackageAssets({
+      repositoryRoot: join(import.meta.dirname, "..", "..", ".."),
+      packageDirectory: packageRoot,
+      assetPaths: ["packaging"],
+    });
+
+    expect(
+      existsSync(join(packageRoot, "dist/packaging/python/module.py")),
+    ).toBe(true);
+    expect(
+      existsSync(join(packageRoot, "dist/packaging/python/__pycache__")),
+    ).toBe(false);
+    expect(
+      existsSync(join(packageRoot, "dist/packaging/python/legacy.pyc")),
+    ).toBe(false);
+    expect(
+      existsSync(join(packageRoot, "dist/packaging/python/optimized.pyo")),
+    ).toBe(false);
+    expect(
+      existsSync(
+        join(packageRoot, "dist/packaging/python/elizaos_app.egg-info"),
+      ),
+    ).toBe(false);
+    expect(
+      existsSync(join(packageRoot, "dist/packaging/python/.pytest_cache")),
+    ).toBe(false);
+    expect(
+      existsSync(join(packageRoot, "dist/packaging/python/.coverage.worker")),
+    ).toBe(false);
+    for (const cacheDirectory of [
+      ".mypy_cache",
+      ".ruff_cache",
+      ".venv",
+      "ENV",
+      "env",
+      "venv",
+    ]) {
+      expect(
+        existsSync(join(packageRoot, "dist/packaging/python", cacheDirectory)),
+      ).toBe(false);
+    }
+  });
+});

--- a/packages/scripts/__tests__/prepare-package-dist.test.ts
+++ b/packages/scripts/__tests__/prepare-package-dist.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Verifies publish manifests resolve dependency versions only from canonical
+ * workspace roots and reject ambiguous canonical package identities.
+ */
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  collectWorkspaceVersions,
+  preparePackageDist,
+} from "../prepare-package-dist.mjs";
+
+const temporaryDirectories: string[] = [];
+
+function temporaryRepository(): string {
+  const directory = mkdtempSync(join(tmpdir(), "eliza-package-dist-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function writeJson(root: string, relativePath: string, value: object): void {
+  const target = join(root, relativePath);
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("prepare-package-dist", () => {
+  test("ignores a stale nested manifest that repeats a workspace name", () => {
+    const root = temporaryRepository();
+    writeJson(root, "package.json", {
+      name: "workspace-fixture",
+      private: true,
+      workspaces: ["packages/*"],
+    });
+    writeJson(root, "packages/plugin-sql/package.json", {
+      name: "@elizaos/plugin-sql",
+      version: "2.0.3-beta.7",
+    });
+    writeJson(root, "packages/plugin-sql/src/package.json", {
+      name: "@elizaos/plugin-sql",
+      version: "2.0.0-beta.0",
+    });
+    writeJson(root, "packages/agent/package.json", {
+      name: "@elizaos/agent",
+      version: "2.0.3-beta.7",
+      private: true,
+      main: "./src/index.ts",
+      dependencies: { "@elizaos/plugin-sql": "workspace:*" },
+    });
+
+    const prepared = preparePackageDist({
+      repositoryRoot: root,
+      packageDirectory: "packages/agent",
+      optionalPluginFallbackVersions: new Map(),
+    });
+
+    expect(prepared.dependencies).toEqual({
+      "@elizaos/plugin-sql": "^2.0.3-beta.7",
+    });
+    const written = JSON.parse(
+      readFileSync(join(root, "packages/agent/dist/package.json"), "utf8"),
+    );
+    expect(written.dependencies).toEqual(prepared.dependencies);
+  });
+
+  test("rejects duplicate names selected by canonical workspace globs", () => {
+    const root = temporaryRepository();
+    writeJson(root, "package.json", {
+      name: "workspace-fixture",
+      private: true,
+      workspaces: ["packages/*"],
+    });
+    for (const directory of ["first", "second"]) {
+      writeJson(root, `packages/${directory}/package.json`, {
+        name: "@fixture/duplicate",
+        version: "1.0.0",
+      });
+    }
+
+    expect(() => collectWorkspaceVersions(root)).toThrow(
+      /Duplicate workspace package name @fixture\/duplicate/u,
+    );
+  });
+
+  test("honors negated workspace globs when resolving package identities", () => {
+    const root = temporaryRepository();
+    writeJson(root, "package.json", {
+      name: "workspace-fixture",
+      private: true,
+      workspaces: ["packages/*", "!packages/excluded"],
+    });
+    writeJson(root, "packages/canonical/package.json", {
+      name: "@fixture/canonical",
+      version: "1.2.3",
+    });
+    writeJson(root, "packages/excluded/package.json", {
+      name: "@fixture/canonical",
+      version: "9.9.9",
+    });
+
+    expect(collectWorkspaceVersions(root)).toEqual(
+      new Map([["@fixture/canonical", "1.2.3"]]),
+    );
+  });
+
+  test("surfaces malformed manifests selected by a workspace glob", () => {
+    const root = temporaryRepository();
+    writeJson(root, "package.json", {
+      name: "workspace-fixture",
+      private: true,
+      workspaces: ["packages/*"],
+    });
+    const manifestPath = join(root, "packages/broken/package.json");
+    mkdirSync(dirname(manifestPath), { recursive: true });
+    writeFileSync(manifestPath, "{ not-json }\n");
+
+    expect(() => collectWorkspaceVersions(root)).toThrow(
+      new RegExp(`Invalid JSON in ${manifestPath}`, "u"),
+    );
+  });
+});

--- a/packages/scripts/copy-package-assets.mjs
+++ b/packages/scripts/copy-package-assets.mjs
@@ -1,50 +1,49 @@
-// Drives repo automation copy package assets with explicit CLI and CI behavior.
+/** Copies publishable package assets while excluding generated local state. */
 import { spawnSync } from "node:child_process";
 import { cpSync, existsSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "../..");
 
-const [packageDirArg, ...assetPaths] = process.argv.slice(2);
-
-if (!packageDirArg || assetPaths.length === 0) {
-  console.error(
-    "usage: node packages/scripts/copy-package-assets.mjs <package-dir> <src-path> [<src-path> ...]",
-  );
-  process.exit(1);
-}
-
-const packageDir = path.resolve(repoRoot, packageDirArg);
-const distDir = path.join(packageDir, "dist");
-const cleanupHelperScript = path.join(
-  repoRoot,
-  "packages",
-  "scripts",
-  "rm-path-recursive.mjs",
-);
 const COPY_RETRY_ATTEMPTS = 3;
 const COPY_RETRY_DELAY_MS = 100;
 const EXCLUDED_ASSET_DIRS = new Set([
   ".gradle",
   ".kotlin",
+  ".mypy_cache",
+  ".pytest_cache",
+  ".ruff_cache",
   ".turbo",
+  ".venv",
+  "ENV",
+  "__pycache__",
   "artifacts",
   "build",
   "dist",
+  "env",
   "node_modules",
+  "venv",
 ]);
+const EXCLUDED_ASSET_EXTENSIONS = new Set([".pyc", ".pyo"]);
 
-function shouldCopyAsset(src) {
+export function shouldCopyAsset(packageDir, src) {
   const relative = path.relative(packageDir, src);
   if (!relative || relative.startsWith("..")) {
     return true;
   }
-  return !relative
-    .split(path.sep)
-    .some((segment) => EXCLUDED_ASSET_DIRS.has(segment));
+  const segments = relative.split(path.sep);
+  const leaf = segments.at(-1) ?? "";
+  return (
+    !segments.some(
+      (segment) =>
+        EXCLUDED_ASSET_DIRS.has(segment) || segment.endsWith(".egg-info"),
+    ) &&
+    !leaf.startsWith(".coverage") &&
+    !EXCLUDED_ASSET_EXTENSIONS.has(path.extname(leaf))
+  );
 }
 
 function shouldRetryCopy(error, sourcePath, attempt) {
@@ -57,12 +56,18 @@ function shouldRetryCopy(error, sourcePath, attempt) {
   );
 }
 
-function removePathRecursive(targetPath) {
+function removePathRecursive(repositoryRoot, targetPath) {
+  const cleanupHelperScript = path.join(
+    repositoryRoot,
+    "packages",
+    "scripts",
+    "rm-path-recursive.mjs",
+  );
   const completed = spawnSync(
     "node",
-    [cleanupHelperScript, path.relative(repoRoot, targetPath)],
+    [cleanupHelperScript, path.relative(repositoryRoot, targetPath)],
     {
-      cwd: repoRoot,
+      cwd: repositoryRoot,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
     },
@@ -81,17 +86,22 @@ function removePathRecursive(targetPath) {
   }
 }
 
-async function copyAssetWithRetry(sourcePath, targetPath) {
+async function copyAssetWithRetry({
+  repositoryRoot,
+  packageDir,
+  sourcePath,
+  targetPath,
+}) {
   let lastError;
   for (let attempt = 1; attempt <= COPY_RETRY_ATTEMPTS; attempt++) {
     try {
       if (existsSync(targetPath)) {
-        removePathRecursive(targetPath);
+        removePathRecursive(repositoryRoot, targetPath);
       }
       mkdirSync(path.dirname(targetPath), { recursive: true });
       cpSync(sourcePath, targetPath, {
         recursive: true,
-        filter: shouldCopyAsset,
+        filter: (src) => shouldCopyAsset(packageDir, src),
       });
       return;
     } catch (error) {
@@ -105,14 +115,57 @@ async function copyAssetWithRetry(sourcePath, targetPath) {
   throw lastError;
 }
 
-for (const assetPath of assetPaths) {
-  const sourcePath = path.join(packageDir, assetPath);
-  if (!existsSync(sourcePath)) {
-    console.error(`missing asset path: ${sourcePath}`);
-    process.exit(1);
+export async function copyPackageAssets({
+  repositoryRoot,
+  packageDirectory,
+  assetPaths,
+}) {
+  if (
+    !packageDirectory ||
+    !Array.isArray(assetPaths) ||
+    assetPaths.length === 0
+  ) {
+    throw new TypeError(
+      "usage: node packages/scripts/copy-package-assets.mjs <package-dir> <src-path> [<src-path> ...]",
+    );
   }
+  const packageDir = path.resolve(repositoryRoot, packageDirectory);
+  const distDir = path.join(packageDir, "dist");
 
-  const relativeTarget = assetPath.replace(/^src\//, "");
-  const targetPath = path.join(distDir, relativeTarget);
-  await copyAssetWithRetry(sourcePath, targetPath);
+  for (const assetPath of assetPaths) {
+    const sourcePath = path.join(packageDir, assetPath);
+    if (!existsSync(sourcePath)) {
+      throw new Error(`missing asset path: ${sourcePath}`);
+    }
+
+    const relativeTarget = assetPath.replace(/^src\//, "");
+    const targetPath = path.join(distDir, relativeTarget);
+    await copyAssetWithRetry({
+      repositoryRoot,
+      packageDir,
+      sourcePath,
+      targetPath,
+    });
+  }
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  try {
+    const [packageDirectory, ...assetPaths] = process.argv.slice(2);
+    await copyPackageAssets({
+      repositoryRoot: repoRoot,
+      packageDirectory,
+      assetPaths,
+    });
+  } catch (error) {
+    // error-policy:J1 the CLI boundary exposes invalid inputs or copy failures
+    // to the invoking build instead of leaving a partial package silently.
+    const message =
+      error instanceof Error ? (error.stack ?? error.message) : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  }
 }

--- a/packages/scripts/prepare-package-dist.mjs
+++ b/packages/scripts/prepare-package-dist.mjs
@@ -1,161 +1,118 @@
-// Drives repo automation prepare package dist with explicit CLI and CI behavior.
-import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+/**
+ * Produces the publishable manifest beside each compiled workspace package.
+ * Workspace dependency versions come from the shared canonical discovery seam,
+ * so nested tool manifests cannot impersonate a package.
+ */
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { resolveRegistryFallbackTags } from "./lib/script-metadata.mjs";
+import { listPackages } from "./lib/workspaces.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "../..");
 
-const [packageDirArg, ...restArgs] = process.argv.slice(2);
-
-if (!packageDirArg) {
-  console.error(
-    "usage: node packages/scripts/prepare-package-dist.mjs <package-dir> [--compiled-prefix=path] [--asset-prefix=path]",
-  );
-  process.exit(1);
-}
-
-const options = Object.fromEntries(
-  restArgs.map((arg) => {
-    const match = arg.match(/^--([^=]+)=(.*)$/);
-    if (!match) {
-      console.error(`invalid option: ${arg}`);
-      process.exit(1);
-    }
-    return [match[1], match[2]];
-  }),
-);
-
-const compiledPrefix = normalizePrefix(options["compiled-prefix"] ?? "");
-const assetPrefix = normalizePrefix(options["asset-prefix"] ?? "");
-const packageDir = path.resolve(repoRoot, packageDirArg);
-const packageJsonPath = path.join(packageDir, "package.json");
-const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
-const workspaceVersions = collectWorkspaceVersions(repoRoot);
-const skipLocalUpstreams = process.env.ELIZA_SKIP_LOCAL_UPSTREAMS === "1";
-// npm dist-tag to fall back to when an optional/independently-published plugin's
-// workspace: version cannot be resolved (ELIZA_SKIP_LOCAL_UPSTREAMS=1). Each
-// plugin declares `elizaos.scripts.publish.registryFallbackTag` in its own
-// package.json; resolved through the discovery seam so no plugin names live here.
-const OPTIONAL_PLUGIN_FALLBACK_VERSIONS = resolveRegistryFallbackTags({
-  repoRoot,
-});
-
-const publishManifest = {
-  ...packageJson,
-  main: packageJson.main
-    ? transformModulePath(packageJson.main, compiledPrefix)
-    : undefined,
-  module: packageJson.module
-    ? transformModulePath(packageJson.module, compiledPrefix)
-    : undefined,
-  types: transformTypesPath(getRootTypesEntry(packageJson), compiledPrefix),
-  bin: transformBin(packageJson.bin, compiledPrefix),
-  exports: transformExports(packageJson.exports, compiledPrefix, assetPrefix),
-  dependencies: rewriteWorkspaceDeps(
-    packageJson.dependencies,
-    workspaceVersions,
-  ),
-  peerDependencies: rewriteWorkspaceDeps(
-    packageJson.peerDependencies,
-    workspaceVersions,
-  ),
-  optionalDependencies: rewriteWorkspaceDeps(
-    packageJson.optionalDependencies,
-    workspaceVersions,
-  ),
-  publishConfig: {
-    ...(packageJson.publishConfig ?? {}),
-    access:
-      packageJson.publishConfig?.access ??
-      (String(packageJson.name).startsWith("@") ? "public" : undefined),
-  },
-};
-
-delete publishManifest.private;
-delete publishManifest.scripts;
-delete publishManifest.devDependencies;
-delete publishManifest.workspaces;
-delete publishManifest.files;
-
-if (!publishManifest.exports?.["./package.json"]) {
-  publishManifest.exports = {
-    ...publishManifest.exports,
-    "./package.json": "./package.json",
-  };
-}
-
-if (!publishManifest.publishConfig?.access) {
-  delete publishManifest.publishConfig;
-}
-
-const distDir = path.join(packageDir, "dist");
-mkdirSync(distDir, { recursive: true });
-writeFileSync(
-  path.join(distDir, "package.json"),
-  `${JSON.stringify(cleanUndefined(publishManifest), null, 2)}\n`,
-);
-
-function collectWorkspaceVersions(rootDir) {
-  const packageRoots = [
-    path.join(rootDir, "packages"),
-    path.join(rootDir, "plugins"),
-  ];
+export function collectWorkspaceVersions(rootDir) {
   const versions = new Map();
-
-  for (const packageRoot of packageRoots) {
-    walk(packageRoot, (entryPath) => {
-      if (path.basename(entryPath) !== "package.json") {
-        return;
-      }
-      let data;
-      try {
-        data = JSON.parse(readFileSync(entryPath, "utf8"));
-      } catch {
-        return;
-      }
-      if (typeof data.name === "string" && typeof data.version === "string") {
-        versions.set(data.name, data.version);
-      }
-    });
+  for (const { name, packageJson } of listPackages({ repoRoot: rootDir })) {
+    if (
+      typeof name === "string" &&
+      name.length > 0 &&
+      typeof packageJson.version === "string" &&
+      packageJson.version.length > 0
+    ) {
+      versions.set(name, packageJson.version);
+    }
   }
-
   return versions;
 }
 
-function walk(dirPath, visit) {
-  let entries;
-  try {
-    entries = readdirSync(dirPath, { withFileTypes: true });
-  } catch {
-    return;
+export function preparePackageDist({
+  repositoryRoot,
+  packageDirectory,
+  compiledPrefix = "",
+  assetPrefix = "",
+  skipLocalUpstreams = false,
+  optionalPluginFallbackVersions,
+}) {
+  const normalizedCompiledPrefix = normalizePrefix(compiledPrefix);
+  const normalizedAssetPrefix = normalizePrefix(assetPrefix);
+  const packageDir = path.resolve(repositoryRoot, packageDirectory);
+  const packageJsonPath = path.join(packageDir, "package.json");
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+  const workspaceVersions = collectWorkspaceVersions(repositoryRoot);
+  // Optional plugins declare their registry fallback tags in package metadata;
+  // callers may inject the map so fixtures exercise the same rewrite boundary.
+  const fallbackVersions =
+    optionalPluginFallbackVersions ??
+    resolveRegistryFallbackTags({ repoRoot: repositoryRoot });
+  const rewriteOptions = { skipLocalUpstreams, fallbackVersions };
+
+  const publishManifest = {
+    ...packageJson,
+    main: packageJson.main
+      ? transformModulePath(packageJson.main, normalizedCompiledPrefix)
+      : undefined,
+    module: packageJson.module
+      ? transformModulePath(packageJson.module, normalizedCompiledPrefix)
+      : undefined,
+    types: transformTypesPath(
+      getRootTypesEntry(packageJson),
+      normalizedCompiledPrefix,
+    ),
+    bin: transformBin(packageJson.bin, normalizedCompiledPrefix),
+    exports: transformExports(
+      packageJson.exports,
+      normalizedCompiledPrefix,
+      normalizedAssetPrefix,
+    ),
+    dependencies: rewriteWorkspaceDeps(
+      packageJson.dependencies,
+      workspaceVersions,
+      rewriteOptions,
+    ),
+    peerDependencies: rewriteWorkspaceDeps(
+      packageJson.peerDependencies,
+      workspaceVersions,
+      rewriteOptions,
+    ),
+    optionalDependencies: rewriteWorkspaceDeps(
+      packageJson.optionalDependencies,
+      workspaceVersions,
+      rewriteOptions,
+    ),
+    publishConfig: {
+      ...(packageJson.publishConfig ?? {}),
+      access:
+        packageJson.publishConfig?.access ??
+        (String(packageJson.name).startsWith("@") ? "public" : undefined),
+    },
+  };
+
+  delete publishManifest.private;
+  delete publishManifest.scripts;
+  delete publishManifest.devDependencies;
+  delete publishManifest.workspaces;
+  delete publishManifest.files;
+
+  if (!publishManifest.exports?.["./package.json"]) {
+    publishManifest.exports = {
+      ...publishManifest.exports,
+      "./package.json": "./package.json",
+    };
+  }
+  if (!publishManifest.publishConfig?.access) {
+    delete publishManifest.publishConfig;
   }
 
-  for (const entry of entries) {
-    const entryPath = path.join(dirPath, entry.name);
-    if (entry.isDirectory()) {
-      if (
-        [
-          "node_modules",
-          "dist",
-          ".git",
-          ".venv",
-          "venv",
-          "__pycache__",
-          "android",
-          "ios",
-          "external",
-          "output",
-        ].includes(entry.name)
-      ) {
-        continue;
-      }
-      walk(entryPath, visit);
-      continue;
-    }
-    visit(entryPath);
-  }
+  const cleanedManifest = cleanUndefined(publishManifest);
+  const distDir = path.join(packageDir, "dist");
+  mkdirSync(distDir, { recursive: true });
+  writeFileSync(
+    path.join(distDir, "package.json"),
+    `${JSON.stringify(cleanedManifest, null, 2)}\n`,
+  );
+  return cleanedManifest;
 }
 
 function normalizePrefix(prefix) {
@@ -183,7 +140,7 @@ function getRootTypesEntry(pkg) {
   return getRootEntry(pkg);
 }
 
-function rewriteWorkspaceDeps(section, versions) {
+function rewriteWorkspaceDeps(section, versions, options) {
   if (!section) {
     return undefined;
   }
@@ -193,8 +150,11 @@ function rewriteWorkspaceDeps(section, versions) {
     if (typeof version === "string" && version.startsWith("workspace:")) {
       const resolvedVersion = versions.get(name);
       if (!resolvedVersion) {
-        if (skipLocalUpstreams) {
-          const fallbackVersion = resolveWorkspaceFallbackVersion(name);
+        if (options.skipLocalUpstreams) {
+          const fallbackVersion = resolveWorkspaceFallbackVersion(
+            name,
+            options,
+          );
           if (fallbackVersion) {
             rewrittenEntries.push([name, fallbackVersion]);
           }
@@ -218,11 +178,11 @@ function rewriteWorkspaceDeps(section, versions) {
   return rewritten;
 }
 
-function resolveWorkspaceFallbackVersion(name) {
-  if (!skipLocalUpstreams) {
+function resolveWorkspaceFallbackVersion(name, options) {
+  if (!options.skipLocalUpstreams) {
     return null;
   }
-  return OPTIONAL_PLUGIN_FALLBACK_VERSIONS.get(name) ?? null;
+  return options.fallbackVersions.get(name) ?? null;
 }
 
 function normalizeWorkspaceVersion(spec, resolvedVersion) {
@@ -385,4 +345,43 @@ function cleanUndefined(value) {
     );
   }
   return value;
+}
+
+function main(argv = process.argv.slice(2)) {
+  const [packageDirectory, ...restArgs] = argv;
+  if (!packageDirectory) {
+    throw new TypeError(
+      "usage: node packages/scripts/prepare-package-dist.mjs <package-dir> [--compiled-prefix=path] [--asset-prefix=path]",
+    );
+  }
+  const options = Object.fromEntries(
+    restArgs.map((argument) => {
+      const match = argument.match(/^--([^=]+)=(.*)$/u);
+      if (!match) throw new TypeError(`invalid option: ${argument}`);
+      return [match[1], match[2]];
+    }),
+  );
+  preparePackageDist({
+    repositoryRoot: repoRoot,
+    packageDirectory,
+    compiledPrefix: options["compiled-prefix"] ?? "",
+    assetPrefix: options["asset-prefix"] ?? "",
+    skipLocalUpstreams: process.env.ELIZA_SKIP_LOCAL_UPSTREAMS === "1",
+  });
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  try {
+    main();
+  } catch (error) {
+    // error-policy:J1 the CLI boundary exposes invalid workspace or manifest
+    // state to the invoking build instead of emitting a partial dist manifest.
+    const message =
+      error instanceof Error ? (error.stack ?? error.message) : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  }
 }


### PR DESCRIPTION
# Relates to

Fixes #16343.

Follow-up to #12333 / #12631, which explicitly deferred this publishing edge case. Relates to #16268 / #16269; launcher smoke verification remains a separate scope.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto latest `origin/develop` (`0f8045c6744d6dd696a57ba0a053f9f2ee55355c`) with zero conflicts.
- [x] `bun install` and `bun run verify` ran after the final sync under Node 24.15.0.
- [x] A reviewer can confirm the change from the inline package artifacts and validation evidence below.

# Sync with develop

- [x] Rebased onto latest `origin/develop`; `git rev-list --left-right --count origin/develop...HEAD` is `0 1`.
- [x] `bun run verify` passes post-sync: 573/573 Turbo tasks succeeded and all preflight guards/ratchets passed.

# Risks

Medium. These scripts assemble publish output for many workspaces. The main risks are exposing a duplicate canonical package identity that traversal order previously hid, or excluding generated Python state a package accidentally depended on. Representative agent, app-core, and UI outputs were therefore built, packed, and inspected directly; ordinary Python sources remain present.

# Background

## What does this PR do?

It prevents local non-canonical state from contaminating package output:

- `prepare-package-dist` now resolves dependency versions through the repository's shared canonical workspace-discovery seam. Nested tool manifests cannot impersonate a workspace root, workspace negations remain authoritative, malformed selected manifests fail, and duplicate canonical names are rejected.
- `copy-package-assets` excludes Python bytecode, cache/type/lint/test state, virtual environments, coverage residue, and `*.egg-info` metadata while retaining source assets.

The CLI boundary still emits a non-zero build failure rather than a partial manifest. No package manifest, lockfile, workflow, runtime, UI, or generated packaging-runtime exclusion changed.

## What kind of change is this?

Bug fix (non-breaking build and publishing hardening).

# Documentation changes needed?

N/A - no user-facing command or configuration contract changed; the behavior is internal package assembly and is covered by executable tests.

# Testing

## Where should a reviewer start?

- `packages/scripts/__tests__/prepare-package-dist.test.ts`
- `packages/scripts/__tests__/copy-package-assets.test.ts`
- `packages/scripts/prepare-package-dist.mjs`
- `packages/scripts/copy-package-assets.mjs`

## Detailed testing steps

All post-sync commands used Node `v24.15.0` on `PATH`.

<details>
<summary>Focused, shared-seam, and full verification results</summary>

```text
Node 24 focused Vitest:
  2 files passed
  5 tests passed

Changed-file coverage gate:
  copy-package-assets.mjs: 57.14%
  prepare-package-dist.mjs: 55.47%
  mean: 56.31% (50% required) — passed

Bun shared workspace-discovery contract:
  20 passed
  0 failed
  23 assertions

bun run verify:
  573 successful / 573 total Turbo tasks
  238 cached
  28 dist-path consumer configurations passed
  build/typecheck model, Turbo dependency, TEE-secret, script-integrity,
  test-realness, and error-policy audits passed
  0 failed tasks

Static gates:
  Biome: 4 files checked, no fixes, exit 0
  error-policy ratchet: no new fallback-slop
  git diff --check: exit 0
  branch scope: exactly 4 intended paths
```

Commands:

```bash
PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" \
  node node_modules/vitest/vitest.mjs run \
  packages/scripts/__tests__/prepare-package-dist.test.ts \
  packages/scripts/__tests__/copy-package-assets.test.ts
bun test packages/scripts/__tests__/workspaces-lib.test.ts
bun run --cwd packages/agent build
bun run --cwd packages/agent pack:dry-run
bun run --cwd packages/app-core build
bun run --cwd packages/app-core pack:dry-run
bun run --cwd packages/ui build
bun run --cwd packages/ui pack:dry-run
bun run audit:error-policy-ratchet
bun run verify
```

</details>

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - no rendered UI source or visual surface changed.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - no rendered UI source or visual surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: N/A - this is non-interactive package-build tooling with no user flow.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no server runtime path changed; real package-build and pack transcripts are inline above.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend path changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, model, prompt, provider, action, or planner behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: https://github.com/elizaOS/eliza/pull/16346#domain-artifacts — generated publish manifests, dry-run tarball summaries, and residue scans are inline.

# Evidence Details

## Real LLM-call trajectory

N/A - this change does not touch agent or model behavior.

## Backend + frontend logs

N/A - no backend or frontend runtime path changed. The applicable build-path transcript is inline in **Testing**.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI or interactive user flow changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio path changed.

## Domain artifacts

Manually inspected canonical and emitted manifest values:

```text
canonical plugins/plugin-sql/package.json:   2.0.3-beta.7
nested plugins/plugin-sql/src/package.json:  2.0.0-beta.0
agent dist dependency emitted:               ^2.0.3-beta.7
```

Representative package dry-runs:

| Package | Files | Packed / unpacked | SHA |
| --- | ---: | ---: | --- |
| `@elizaos/agent` | 1,427 | 4.5 MB / 10.0 MB | `1cf7c89532f87d8a66e8ef56cd52f989d021c97a` |
| `@elizaos/app-core` | 1,657 | 27.3 MB / 35.1 MB | `04d98f17d88c188b566f699dcc0ee5a669bd6eb6` |
| `@elizaos/ui` | 4,814 | 5.8 MB / 21.2 MB | `2f42ba437a3a3b055259c0dd2f2e64a42f9e4a4a` |

A scan of all three generated `dist/` trees found no `__pycache__`, pytest/mypy/ruff cache, virtual-environment directory, `*.egg-info`, `.coverage*`, `*.pyc`, or `*.pyo` residue. Four required Python source files remain under `packages/app-core/dist/packaging/pypi/elizaos_app/`.

## Known gaps / failures

N/A - all applicable post-sync gates passed. Biome prints one non-failing warning for the existing `ELIZA_SKIP_LOCAL_UPSTREAMS` Turbo declaration gap; this PR relocates but does not introduce that environment-variable read. Cached `bun-ios-runtime` warnings and report-only test-realness findings are unrelated to this four-path diff.