### PR TITLE
fix(ci): isolate exhaustive concurrency and preserve quiescent signal

### DIFF
--- a/.github/workflows/dev-smoke.yml
+++ b/.github/workflows/dev-smoke.yml
@@ -3,6 +3,12 @@ name: Dev Smoke
 on:
   # Reusable entry for the scheduled exhaustive develop lane (#12342).
   workflow_call:
+    inputs:
+      concurrency_scope:
+        description: "Caller-owned concurrency namespace"
+        required: false
+        type: string
+        default: standalone
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review, labeled]
@@ -19,16 +25,11 @@ on:
       - "packages/ui/**"
   workflow_dispatch:
 
-# CI fan-out fix: the PR-scoped concurrency from #14069 fell back to
-# github.run_id on push, so every develop push got a unique group and
-# nothing ever superseded. A 37-merge wave queued thousands of push runs
-# and starved the self-hosted fleet. Fall back to github.ref (all develop
-# pushes share a group) and cancel superseded runs on push too. PR behavior
-# is unchanged (pull_request.number still wins the key); merge_group and
-# schedule events are not in the cancel set, so the merge queue and nightly
-# runs always complete.
+# Standalone PR and push runs share stable keys so obsolete work is superseded.
+# Reusable callers pass a distinct scope, keeping exhaustive work outside those
+# domains; schedule and dispatch events never cancel an active run.
 concurrency:
-  group: dev-smoke-${{ github.event.pull_request.number || github.ref }}
+  group: dev-smoke-${{ inputs.concurrency_scope || 'standalone' }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 permissions:

--- a/.github/workflows/develop-exhaustive.yml
+++ b/.github/workflows/develop-exhaustive.yml
@@ -23,10 +23,13 @@ on:
     - cron: "0 18 * * *"
   workflow_dispatch:
 
-# Dedicated group, never cancelled by push/PR traffic: the whole point is a
-# completed daily coverage signal (#12337/#12342).
+# The bounded native queue preserves every twice-daily invocation instead of
+# replacing an older pending run when a third arrives. Each called workflow
+# receives the same explicit scope below, keeping its jobs outside every
+# standalone push, PR, dispatch, and schedule group.
 concurrency:
   group: develop-exhaustive-${{ github.ref }}
+  queue: max
   cancel-in-progress: false
 
 permissions:
@@ -38,42 +41,62 @@ jobs:
   windows:
     name: Windows full matrix
     uses: ./.github/workflows/windows-ci.yml
+    with:
+      concurrency_scope: develop-exhaustive
     secrets: inherit
   mobile:
     name: Mobile build smoke
     uses: ./.github/workflows/mobile-build-smoke.yml
+    with:
+      concurrency_scope: develop-exhaustive
     secrets: inherit
   scenario:
     name: Scenario deterministic E2E
     uses: ./.github/workflows/scenario-pr.yml
+    with:
+      concurrency_scope: develop-exhaustive
     secrets: inherit
   ui-e2e:
     name: UI e2e gate
     uses: ./.github/workflows/ui-e2e-gate.yml
+    with:
+      concurrency_scope: develop-exhaustive
     secrets: inherit
   ui-fixture:
     name: UI fixture e2e
     uses: ./.github/workflows/ui-fixture-e2e.yml
+    with:
+      concurrency_scope: develop-exhaustive
     secrets: inherit
   ui-story:
     name: UI story gate
     uses: ./.github/workflows/ui-story-gate.yml
+    with:
+      concurrency_scope: develop-exhaustive
     secrets: inherit
   keyless-harness:
     name: Keyless harness E2E
     uses: ./.github/workflows/keyless-harness-e2e.yml
+    with:
+      concurrency_scope: develop-exhaustive
     secrets: inherit
   docker:
     name: Docker image smoke
     uses: ./.github/workflows/docker-ci-smoke.yml
+    with:
+      concurrency_scope: develop-exhaustive
     secrets: inherit
   dev-onboarding:
     name: Dev onboarding smoke
     uses: ./.github/workflows/dev-smoke.yml
+    with:
+      concurrency_scope: develop-exhaustive
     secrets: inherit
   electrobun:
     name: Electrobun desktop release
     uses: ./.github/workflows/test-electrobun-release.yml
+    with:
+      concurrency_scope: develop-exhaustive
     secrets: inherit
 
   matrix-proof:

--- a/.github/workflows/docker-ci-smoke.yml
+++ b/.github/workflows/docker-ci-smoke.yml
@@ -3,6 +3,12 @@ name: Docker CI Smoke
 on:
   # Reusable entry for the scheduled exhaustive develop lane (#12342).
   workflow_call:
+    inputs:
+      concurrency_scope:
+        description: "Caller-owned concurrency namespace"
+        required: false
+        type: string
+        default: standalone
   push:
     branches: [develop]
   schedule:
@@ -10,16 +16,11 @@ on:
     - cron: "0 7 * * *"
   workflow_dispatch:
 
-# CI fan-out fix: the PR-scoped concurrency from #14069 fell back to
-# github.run_id on push, so every develop push got a unique group and
-# nothing ever superseded. A 37-merge wave queued thousands of push runs
-# and starved the self-hosted fleet. Fall back to github.ref (all develop
-# pushes share a group) and cancel superseded runs on push too. PR behavior
-# is unchanged (pull_request.number still wins the key); merge_group and
-# schedule events are not in the cancel set, so the merge queue and nightly
-# runs always complete.
+# Standalone PR and push runs share stable keys so obsolete work is superseded.
+# Reusable callers pass a distinct scope, keeping exhaustive work outside those
+# domains; schedule and dispatch events never cancel an active run.
 concurrency:
-  group: docker-ci-smoke-${{ github.event.pull_request.number || github.ref }}
+  group: docker-ci-smoke-${{ inputs.concurrency_scope || 'standalone' }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 permissions:

--- a/.github/workflows/keyless-harness-e2e.yml
+++ b/.github/workflows/keyless-harness-e2e.yml
@@ -19,13 +19,21 @@ name: Keyless Harness E2E
 on:
   # Reusable entry for the scheduled exhaustive develop lane (#12342).
   workflow_call:
+    inputs:
+      concurrency_scope:
+        description: "Caller-owned concurrency namespace"
+        required: false
+        type: string
+        default: standalone
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch: {}
 
+# A reusable caller's scope separates it from the standalone ref domain. PRs
+# still supersede obsolete work; exhaustive work always completes.
 concurrency:
-  group: keyless-harness-e2e-${{ github.event.pull_request.number || github.ref }}
+  group: keyless-harness-e2e-${{ inputs.concurrency_scope || 'standalone' }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/mobile-build-smoke.yml
+++ b/.github/workflows/mobile-build-smoke.yml
@@ -3,6 +3,12 @@ name: Mobile Build Smoke Test
 on:
   # Reusable entry for the scheduled exhaustive develop lane (#12342).
   workflow_call:
+    inputs:
+      concurrency_scope:
+        description: "Caller-owned concurrency namespace"
+        required: false
+        type: string
+        default: standalone
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review, labeled]
@@ -19,8 +25,10 @@ on:
     # gates that nightly run instead of every pull request.
     - cron: "0 7 * * *"
 
+# A reusable caller's scope separates it from the standalone ref domain. PRs
+# still supersede obsolete work; scheduled and exhaustive work always completes.
 concurrency:
-  group: mobile-smoke-${{ github.ref }}
+  group: mobile-smoke-${{ inputs.concurrency_scope || 'standalone' }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:

--- a/.github/workflows/scenario-pr.yml
+++ b/.github/workflows/scenario-pr.yml
@@ -7,6 +7,12 @@ name: Scenario PR E2E
 on:
   # Reusable entry for the scheduled exhaustive develop lane (#12342).
   workflow_call:
+    inputs:
+      concurrency_scope:
+        description: "Caller-owned concurrency namespace"
+        required: false
+        type: string
+        default: standalone
   # Heavy family moved off per-PR push (#14051 Tier A): PR runs are opt-in via
   # the `ci:full` label (job-level gate on `changes` below). Unlabeled PRs
   # skip every job instantly and consume zero runners.
@@ -20,8 +26,10 @@ on:
     - cron: "0 7 * * *"
   workflow_dispatch:
 
+# A reusable caller's scope separates it from the standalone ref domain. PRs
+# still supersede obsolete work; scheduled and exhaustive work always completes.
 concurrency:
-  group: scenario-pr-e2e-${{ github.event.pull_request.number || github.ref }}
+  group: scenario-pr-e2e-${{ inputs.concurrency_scope || 'standalone' }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:

--- a/.github/workflows/test-electrobun-release.yml
+++ b/.github/workflows/test-electrobun-release.yml
@@ -3,12 +3,20 @@ name: Validate Electrobun Release Workflow
 on:
   # Reusable entry for the scheduled exhaustive develop lane (#12342).
   workflow_call:
+    inputs:
+      concurrency_scope:
+        description: "Caller-owned concurrency namespace"
+        required: false
+        type: string
+        default: standalone
   pull_request:
     branches: [main]
   workflow_dispatch:
 
+# A reusable caller's scope separates it from the standalone ref domain. PRs
+# still supersede obsolete work; exhaustive work always completes.
 concurrency:
-  group: test-electrobun-release-${{ github.ref }}
+  group: test-electrobun-release-${{ inputs.concurrency_scope || 'standalone' }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,17 +16,12 @@ on:
     # Nightly live smoke for container-backed remote capability plugins.
     - cron: "17 9 * * *"
 
-# CI fan-out fix: the PR-scoped concurrency from #14069 fell back to
-# github.run_id on push, so every develop push got a unique group and
-# nothing ever superseded. A 37-merge wave queued thousands of push runs
-# and starved the self-hosted fleet. Fall back to github.ref (all develop
-# pushes share a group) and cancel superseded runs on push too. PR behavior
-# is unchanged (pull_request.number still wins the key); merge_group and
-# schedule events are not in the cancel set, so the merge queue and nightly
-# runs always complete.
+# Develop pushes share a stable group so an obsolete tip is superseded before
+# it can starve the fleet. Scheduled and manual runs use per-run groups: an
+# incoming push therefore cannot cancel their independent diagnostic work.
 concurrency:
-  group: test-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+  group: test-${{ github.event_name == 'push' && github.ref || format('{0}-{1}', github.event_name, github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'push' }}
 
 env:
   CI: "true"

--- a/.github/workflows/ui-e2e-gate.yml
+++ b/.github/workflows/ui-e2e-gate.yml
@@ -15,6 +15,12 @@ name: UI Fixture E2E
 on:
   # Reusable entry for the scheduled exhaustive develop lane (#12342).
   workflow_call:
+    inputs:
+      concurrency_scope:
+        description: "Caller-owned concurrency namespace"
+        required: false
+        type: string
+        default: standalone
   pull_request:
     branches: [main]
     paths:
@@ -38,16 +44,11 @@ on:
       - "packages/agent/src/api/interactions-routes.ts"
       - "packages/agent/src/api/server-helpers-swarm.ts"
 
-# CI fan-out fix: the PR-scoped concurrency from #14069 fell back to
-# github.run_id on push, so every develop push got a unique group and
-# nothing ever superseded. A 37-merge wave queued thousands of push runs
-# and starved the self-hosted fleet. Fall back to github.ref (all develop
-# pushes share a group) and cancel superseded runs on push too. PR behavior
-# is unchanged (pull_request.number still wins the key); merge_group and
-# schedule events are not in the cancel set, so the merge queue and nightly
-# runs always complete.
+# Standalone PR and push runs share stable keys so obsolete work is superseded.
+# Reusable callers pass a distinct scope, keeping exhaustive work outside those
+# domains; schedule and dispatch events never cancel an active run.
 concurrency:
-  group: ui-e2e-gate-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ui-e2e-gate-${{ inputs.concurrency_scope || 'standalone' }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 permissions:

--- a/.github/workflows/ui-fixture-e2e.yml
+++ b/.github/workflows/ui-fixture-e2e.yml
@@ -19,6 +19,12 @@ name: UI Fixture E2E
 on:
   # Reusable entry for the scheduled exhaustive develop lane (#12342).
   workflow_call:
+    inputs:
+      concurrency_scope:
+        description: "Caller-owned concurrency namespace"
+        required: false
+        type: string
+        default: standalone
   pull_request:
     branches: [develop, main]
     paths:
@@ -29,16 +35,11 @@ on:
     paths:
       - "packages/ui/src/**"
 
-# CI fan-out fix: the PR-scoped concurrency from #14069 fell back to
-# github.run_id on push, so every develop push got a unique group and
-# nothing ever superseded. A 37-merge wave queued thousands of push runs
-# and starved the self-hosted fleet. Fall back to github.ref (all develop
-# pushes share a group) and cancel superseded runs on push too. PR behavior
-# is unchanged (pull_request.number still wins the key); merge_group and
-# schedule events are not in the cancel set, so the merge queue and nightly
-# runs always complete.
+# Standalone PR and push runs share stable keys so obsolete work is superseded.
+# Reusable callers pass a distinct scope, keeping exhaustive work outside those
+# domains; schedule and dispatch events never cancel an active run.
 concurrency:
-  group: ui-fixture-e2e-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ui-fixture-e2e-${{ inputs.concurrency_scope || 'standalone' }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 permissions:

--- a/.github/workflows/ui-story-gate.yml
+++ b/.github/workflows/ui-story-gate.yml
@@ -11,6 +11,12 @@ name: UI Story Gate
 on:
   # Reusable entry for the scheduled exhaustive develop lane (#12342).
   workflow_call:
+    inputs:
+      concurrency_scope:
+        description: "Caller-owned concurrency namespace"
+        required: false
+        type: string
+        default: standalone
   pull_request:
     branches: [main]
     paths:
@@ -26,16 +32,11 @@ on:
       - "plugins/**/src/**"
       - ".github/workflows/ui-story-gate.yml"
 
-# CI fan-out fix: the PR-scoped concurrency from #14069 fell back to
-# github.run_id on push, so every develop push got a unique group and
-# nothing ever superseded. A 37-merge wave queued thousands of push runs
-# and starved the self-hosted fleet. Fall back to github.ref (all develop
-# pushes share a group) and cancel superseded runs on push too. PR behavior
-# is unchanged (pull_request.number still wins the key); merge_group and
-# schedule events are not in the cancel set, so the merge queue and nightly
-# runs always complete.
+# Standalone PR and push runs share stable keys so obsolete work is superseded.
+# Reusable callers pass a distinct scope, keeping exhaustive work outside those
+# domains; schedule and dispatch events never cancel an active run.
 concurrency:
-  group: ui-story-gate-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ui-story-gate-${{ inputs.concurrency_scope || 'standalone' }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 permissions:

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -9,21 +9,22 @@ name: Windows CI
 # and the helpers under `packages/scripts/`. iOS/macOS/RISC-V/cloud-e2e
 # paths run on their existing dedicated workflows.
 
-# CI fan-out fix: the PR-scoped concurrency from #14069 fell back to
-# github.run_id on push, so every develop push got a unique group and
-# nothing ever superseded. A 37-merge wave queued thousands of push runs
-# and starved the self-hosted fleet. Fall back to github.ref (all develop
-# pushes share a group) and cancel superseded runs on push too. PR behavior
-# is unchanged (pull_request.number still wins the key); merge_group and
-# schedule events are not in the cancel set, so the merge queue and nightly
-# runs always complete.
+# Standalone PR and push runs share stable keys so obsolete work is superseded.
+# Reusable callers pass a distinct scope, keeping exhaustive work outside those
+# domains; schedule and dispatch events never cancel an active run.
 concurrency:
-  group: windows-ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: windows-ci-${{ inputs.concurrency_scope || 'standalone' }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 on:
   # Reusable entry for the scheduled exhaustive develop lane (#12342).
   workflow_call:
+    inputs:
+      concurrency_scope:
+        description: "Caller-owned concurrency namespace"
+        required: false
+        type: string
+        default: standalone
   push:
     branches: [main, develop]
     paths:

--- a/packages/scripts/__tests__/ci-full-matrix-proof.test.ts
+++ b/packages/scripts/__tests__/ci-full-matrix-proof.test.ts
@@ -1,10 +1,11 @@
-// Exercises the exhaustive-lane matrix proof (#12342) with synthetic manifests,
-// workflow fixtures, and plan JSON — a deterministic, dependency-free harness
-// (no real workflow run) that pins the proof's failure modes: missing lane,
-// PR-only-pinned lane, and every plan-floor breach.
+/**
+ * Exercises the exhaustive-lane proof with synthetic workflow collisions and
+ * the real committed manifest, including reusable-call isolation, consecutive
+ * exhaustive queuing, and the canonical quiescent develop result.
+ */
 import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -12,6 +13,15 @@ import { fileURLToPath } from "node:url";
 const script = fileURLToPath(
   new URL("../ci-full-matrix-proof.mjs", import.meta.url),
 );
+const {
+  parseArgs: parseProofArgs,
+  runProof: executeProof,
+  writeSummary: writeProofSummary,
+} = await import("../ci-full-matrix-proof.mjs");
+
+function githubExpression(body: string): string {
+  return `\${{ ${body} }}`;
+}
 
 const HEALTHY_WORKFLOW = `name: Tests
 on:
@@ -41,6 +51,25 @@ jobs:
       - run: echo ok
 `;
 
+const HEALTHY_POST_MERGE_WORKFLOW = HEALTHY_WORKFLOW.replace(
+  "  pull_request:\n",
+  "  push:\n    branches: [develop]\n  pull_request:\n",
+)
+  .replace(
+    "jobs:\n",
+    `concurrency:\n  group: test-${githubExpression(
+      "github.event_name == 'push' && github.ref || format('{0}-{1}', github.event_name, github.run_id)",
+    )}\n  cancel-in-progress: ${githubExpression(
+      "github.event_name == 'push'",
+    )}\njobs:\n`,
+  )
+  .replace(
+    "  ci-ok:\n    name: ci-ok\n",
+    `  ci-ok:\n    name: ci-ok\n    if: ${githubExpression(
+      "!cancelled() && always()",
+    )}\n`,
+  );
+
 const HEALTHY_MANIFEST = {
   workflow: "test.yml",
   aggregateStatusJob: "ci-ok",
@@ -54,6 +83,11 @@ const HEALTHY_MANIFEST = {
     requiredPackages: ["@elizaos/core"],
     nonEmptyScriptLanes: ["test", "test:e2e"],
   },
+};
+
+const POST_MERGE_MANIFEST = {
+  ...HEALTHY_MANIFEST,
+  postMergeSignal: { branch: "develop", aggregateJob: "ci-ok" },
 };
 
 const HEALTHY_PLAN = {
@@ -100,6 +134,7 @@ function runProof({ workflow, manifest, plan, orchestrator, reusables }) {
       const orchestratorPath = join(dir, "develop-exhaustive.yml");
       writeFileSync(orchestratorPath, orchestrator);
       resolved.exhaustiveOrchestrator = orchestratorPath;
+      resolved.exhaustiveConcurrencyScope ??= "develop-exhaustive";
     }
     if (reusables) {
       resolved.reusableWorkflows = Object.entries(reusables).map(
@@ -113,15 +148,22 @@ function runProof({ workflow, manifest, plan, orchestrator, reusables }) {
     writeFileSync(manifestPath, JSON.stringify(resolved));
     writeFileSync(planPath, JSON.stringify(plan));
 
-    const result = spawnSync(
-      process.execPath,
-      [script, "--manifest", manifestPath, "--plan-file", planPath],
-      { encoding: "utf8" },
-    );
+    const proof = executeProof({
+      manifest: manifestPath,
+      planFile: planPath,
+      summary: null,
+    });
     return {
-      status: result.status,
-      stdout: result.stdout || "",
-      stderr: result.stderr || "",
+      status: proof.violations.length === 0 ? 0 : 1,
+      stdout: [
+        ...proof.laneReport.map(
+          (row) => `[ci-full-matrix-proof] lane ${row.lane} — ${row.status}`,
+        ),
+        ...(proof.violations.length === 0
+          ? ["PASS every expected lane accounted for"]
+          : []),
+      ].join("\n"),
+      stderr: proof.violations.join("\n"),
     };
   } finally {
     rmSync(dir, { recursive: true, force: true });
@@ -129,6 +171,95 @@ function runProof({ workflow, manifest, plan, orchestrator, reusables }) {
 }
 
 describe("ci-full-matrix-proof", () => {
+  test("parses every CLI path and rejects missing or unknown arguments", () => {
+    expect(
+      parseProofArgs([
+        "--plan-file",
+        "plan.json",
+        "--manifest",
+        "manifest.json",
+        "--summary",
+        "summary.md",
+      ]),
+    ).toMatchObject({
+      planFile: "plan.json",
+      manifest: "manifest.json",
+      summary: "summary.md",
+    });
+    expect(() => parseProofArgs(["--manifest"])).toThrow(
+      "--manifest requires a value",
+    );
+    expect(() => parseProofArgs(["--wat"])).toThrow("unknown argument: --wat");
+  });
+
+  test("writes human-reviewable pass and fail summaries", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ci-matrix-summary-"));
+    try {
+      const passPath = join(dir, "pass.md");
+      writeProofSummary(
+        passPath,
+        [{ lane: "scenario", name: "Scenario", status: "OK" }],
+        [{ metric: "taskCount", value: 4, floor: 3 }],
+        [],
+      );
+      const pass = readFileSync(passPath, "utf8");
+      expect(pass).toContain("| `scenario` | Scenario | OK |");
+      expect(pass).toContain("**Result: PASS**");
+
+      const failPath = join(dir, "fail.md");
+      writeProofSummary(failPath, [], [], ["collision"]);
+      const fail = readFileSync(failPath, "utf8");
+      expect(fail).toContain("**Result: FAIL** — 1 violation(s)");
+      expect(fail).toContain("- collision");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("the real CLI exits nonzero and prints a failing fixture", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ci-matrix-cli-fail-"));
+    try {
+      const workflowPath = join(dir, "test.yml");
+      const manifestPath = join(dir, "manifest.json");
+      const planPath = join(dir, "plan.json");
+      writeFileSync(workflowPath, HEALTHY_WORKFLOW);
+      writeFileSync(
+        manifestPath,
+        JSON.stringify({
+          ...HEALTHY_MANIFEST,
+          workflow: workflowPath,
+          workflowLanes: [
+            ...HEALTHY_MANIFEST.workflowLanes,
+            { job: "ghost-lane", name: "Ghost Lane" },
+          ],
+        }),
+      );
+      writeFileSync(planPath, JSON.stringify(HEALTHY_PLAN));
+
+      const result = spawnSync(
+        process.execPath,
+        [
+          script,
+          "--manifest",
+          manifestPath,
+          "--plan-file",
+          planPath,
+          "--summary",
+          join(dir, "summary.md"),
+        ],
+        { encoding: "utf8" },
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("ghost-lane");
+      expect(readFileSync(join(dir, "summary.md"), "utf8")).toContain(
+        "**Result: FAIL**",
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("passes when every lane is present and the plan clears its floors", () => {
     const result = runProof({
       workflow: HEALTHY_WORKFLOW,
@@ -234,12 +365,100 @@ describe("ci-full-matrix-proof", () => {
     );
   });
 
+  test("models obsolete develop pushes as superseded while preserving a quiescent aggregate", () => {
+    const result = runProof({
+      workflow: HEALTHY_POST_MERGE_WORKFLOW,
+      manifest: POST_MERGE_MANIFEST,
+      plan: HEALTHY_PLAN,
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("post-merge:ci-ok — OK");
+  });
+
+  test("fails when develop pushes use per-run groups and cannot supersede", () => {
+    const workflow = HEALTHY_POST_MERGE_WORKFLOW.replace(
+      "github.event_name == 'push' && github.ref || format('{0}-{1}', github.event_name, github.run_id)",
+      "github.event_name == 'push' && github.run_id || format('{0}-{1}', github.event_name, github.run_id)",
+    );
+    const result = runProof({
+      workflow,
+      manifest: POST_MERGE_MANIFEST,
+      plan: HEALTHY_PLAN,
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("post-merge concurrency drift");
+  });
+
+  test("fails when pushes can cancel scheduled or manual runs", () => {
+    const workflow = HEALTHY_POST_MERGE_WORKFLOW.replace(
+      "github.event_name == 'push' && github.ref || format('{0}-{1}', github.event_name, github.run_id)",
+      "github.ref",
+    );
+    const result = runProof({
+      workflow,
+      manifest: POST_MERGE_MANIFEST,
+      plan: HEALTHY_PLAN,
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("isolate schedule/dispatch by run id");
+  });
+
+  test("fails when an appended run id defeats push supersession", () => {
+    const canonical = githubExpression(
+      "github.event_name == 'push' && github.ref || format('{0}-{1}', github.event_name, github.run_id)",
+    );
+    const workflow = HEALTHY_POST_MERGE_WORKFLOW.replace(
+      canonical,
+      `${canonical}-${githubExpression("github.run_id")}`,
+    );
+    const result = runProof({
+      workflow,
+      manifest: POST_MERGE_MANIFEST,
+      plan: HEALTHY_PLAN,
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("post-merge concurrency drift");
+  });
+
+  test("fails when the canonical develop aggregate can report after cancellation", () => {
+    const workflow = HEALTHY_POST_MERGE_WORKFLOW.replace(
+      githubExpression("!cancelled() && always()"),
+      githubExpression("always()"),
+    );
+    const result = runProof({
+      workflow,
+      manifest: POST_MERGE_MANIFEST,
+      plan: HEALTHY_PLAN,
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("canonical post-merge result missing");
+  });
+
+  test("fails when an OR-shaped aggregate bypasses cancellation", () => {
+    const workflow = HEALTHY_POST_MERGE_WORKFLOW.replace(
+      githubExpression("!cancelled() && always()"),
+      githubExpression("always() || !cancelled()"),
+    );
+    const result = runProof({
+      workflow,
+      manifest: POST_MERGE_MANIFEST,
+      plan: HEALTHY_PLAN,
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("canonical post-merge result missing");
+  });
+
   const CALLABLE_WORKFLOW = `name: Reusable
 on:
   workflow_call:
+    inputs:
+      concurrency_scope:
+        required: false
+        type: string
+        default: standalone
   pull_request:
 concurrency:
-  group: reusable-\${{ github.ref }}
+  group: reusable-\${{ inputs.concurrency_scope || 'standalone' }}-\${{ github.ref }}
   cancel-in-progress: \${{ github.event_name == 'pull_request' }}
 jobs:
   x:
@@ -261,9 +480,14 @@ jobs:
   const CANCELLING_CALLABLE_WORKFLOW = `name: Reusable
 on:
   workflow_call:
+    inputs:
+      concurrency_scope:
+        required: false
+        type: string
+        default: standalone
   pull_request:
 concurrency:
-  group: reusable-\${{ github.ref }}
+  group: reusable-\${{ inputs.concurrency_scope || 'standalone' }}-\${{ github.ref }}
   cancel-in-progress: true
 jobs:
   x:
@@ -272,14 +496,37 @@ jobs:
       - run: echo ok
 `;
 
-  function orchestrator(basenames) {
+  const COLLIDING_CALLABLE_WORKFLOW = CALLABLE_WORKFLOW.replace(
+    `reusable-${githubExpression("inputs.concurrency_scope || 'standalone'")}-`,
+    "reusable-",
+  );
+
+  const TRUTHY_COLLIDING_CALLABLE_WORKFLOW = CALLABLE_WORKFLOW.replace(
+    "inputs.concurrency_scope || 'standalone'",
+    "inputs.concurrency_scope && 'standalone'",
+  );
+
+  const SCHEDULE_CANCELLING_WORKFLOW = CALLABLE_WORKFLOW.replace(
+    githubExpression("github.event_name == 'pull_request'"),
+    githubExpression("github.event_name != 'pull_request'"),
+  );
+
+  function orchestrator(
+    basenames,
+    { passScope = true, cancelInProgress = false, queue = "max" } = {},
+  ) {
     const lanes = basenames
       .map(
         (b, i) =>
-          `  lane${i}:\n    uses: ./.github/workflows/${b}\n    secrets: inherit`,
+          `  lane${i}:\n    uses: ./.github/workflows/${b}${
+            passScope
+              ? "\n    with:\n      concurrency_scope: develop-exhaustive"
+              : ""
+          }\n    secrets: inherit`,
       )
       .join("\n");
-    return `name: Develop Exhaustive\non:\n  schedule:\n    - cron: "0 6 * * *"\njobs:\n${lanes}\n`;
+    const queueLine = queue === null ? "" : `  queue: ${queue}\n`;
+    return `name: Develop Exhaustive\non:\n  schedule:\n    - cron: "0 6 * * *"\nconcurrency:\n  group: develop-exhaustive-\${{ github.ref }}\n${queueLine}  cancel-in-progress: ${cancelInProgress}\njobs:\n${lanes}\n`;
   }
 
   test("passes when the orchestrator wires every reusable lane and each is callable", () => {
@@ -343,9 +590,89 @@ jobs:
     });
     expect(result.status).toBe(1);
     expect(result.stderr).toContain(
-      "reusable workflow can cancel scheduled coverage",
+      "reusable workflow can cancel exhaustive coverage",
     );
     expect(result.stderr).toContain("scenario-pr.yml");
+  });
+
+  test("fails when an exhaustive caller enters the standalone concurrency group", () => {
+    const result = runProof({
+      workflow: HEALTHY_WORKFLOW,
+      manifest: HEALTHY_MANIFEST,
+      plan: HEALTHY_PLAN,
+      orchestrator: orchestrator(["scenario-pr.yml"], {
+        passScope: false,
+      }),
+      reusables: { "scenario-pr.yml": CALLABLE_WORKFLOW },
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "reusable caller shares standalone concurrency",
+    );
+  });
+
+  test("fails when a reusable group ignores the exhaustive caller scope", () => {
+    const result = runProof({
+      workflow: HEALTHY_WORKFLOW,
+      manifest: HEALTHY_MANIFEST,
+      plan: HEALTHY_PLAN,
+      orchestrator: orchestrator(["scenario-pr.yml"]),
+      reusables: { "scenario-pr.yml": COLLIDING_CALLABLE_WORKFLOW },
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("reusable concurrency collision");
+  });
+
+  test("fails when a truthy lookalike collapses both reusable scopes", () => {
+    const result = runProof({
+      workflow: HEALTHY_WORKFLOW,
+      manifest: HEALTHY_MANIFEST,
+      plan: HEALTHY_PLAN,
+      orchestrator: orchestrator(["scenario-pr.yml"]),
+      reusables: {
+        "scenario-pr.yml": TRUTHY_COLLIDING_CALLABLE_WORKFLOW,
+      },
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("exact inputs.concurrency_scope");
+  });
+
+  test("fails when a reusable lane cancels a scheduled caller", () => {
+    const result = runProof({
+      workflow: HEALTHY_WORKFLOW,
+      manifest: HEALTHY_MANIFEST,
+      plan: HEALTHY_PLAN,
+      orchestrator: orchestrator(["scenario-pr.yml"]),
+      reusables: { "scenario-pr.yml": SCHEDULE_CANCELLING_WORKFLOW },
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("cancels schedule");
+  });
+
+  test("fails when the next exhaustive invocation can cancel the active one", () => {
+    const result = runProof({
+      workflow: HEALTHY_WORKFLOW,
+      manifest: HEALTHY_MANIFEST,
+      plan: HEALTHY_PLAN,
+      orchestrator: orchestrator(["scenario-pr.yml"], {
+        cancelInProgress: true,
+      }),
+      reusables: { "scenario-pr.yml": CALLABLE_WORKFLOW },
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("consecutive exhaustive runs can cancel");
+  });
+
+  test("fails when the third exhaustive invocation can replace a pending run", () => {
+    const result = runProof({
+      workflow: HEALTHY_WORKFLOW,
+      manifest: HEALTHY_MANIFEST,
+      plan: HEALTHY_PLAN,
+      orchestrator: orchestrator(["scenario-pr.yml"], { queue: null }),
+      reusables: { "scenario-pr.yml": CALLABLE_WORKFLOW },
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("replace pending coverage");
   });
 
   test("proves the real committed manifest against the real workflow + plan", () => {
@@ -353,9 +680,17 @@ jobs:
     // spawn `run-all-tests.mjs --plan=json` (which does whole-repo workspace
     // discovery). This is the guard that the manifest stays honest as the repo
     // evolves.
+    const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
+    const direct = executeProof({
+      manifest: join(repoRoot, "packages/scripts/ci-lane-manifest.json"),
+      planFile: null,
+      summary: null,
+    });
+    expect(direct.violations).toEqual([]);
+
     const result = spawnSync(process.execPath, [script], {
       encoding: "utf8",
-      cwd: fileURLToPath(new URL("../../..", import.meta.url)),
+      cwd: repoRoot,
       maxBuffer: 64 * 1024 * 1024,
     });
     expect(result.status).toBe(0);

--- a/packages/scripts/ci-full-matrix-proof.mjs
+++ b/packages/scripts/ci-full-matrix-proof.mjs
@@ -12,11 +12,11 @@
  *      event, which would turn a "required" lane into a permanent skip.
  *   3. `.github/workflows/develop-exhaustive.yml` — the scheduled orchestrator
  *      must still invoke every manifest `reusableWorkflows` lane via
- *      `workflow_call`, and each of those workflows must still declare a
- *      `workflow_call` trigger without unconditional concurrency cancellation.
- *      A dropped `uses:`, removed trigger, or reusable lane that can cancel a
- *      prior scheduled run silently strips platform coverage (Windows/mobile/
- *      scenario/UI/desktop) from the exhaustive matrix and fails the job.
+ *      `workflow_call`, pass its dedicated concurrency scope, and queue
+ *      consecutive exhaustive runs. Every reusable workflow must consume that
+ *      scope and keep schedule/dispatch/workflow-call events non-cancelling. A
+ *      dropped `uses:`, shared standalone group, or cancelling reusable lane
+ *      silently strips platform coverage from the exhaustive matrix and fails.
  *   4. `run-all-tests.mjs --plan=json` — the discovered task plan must clear the
  *      manifest floors (total tasks/packages, per-script-lane presence, and the
  *      set of required core packages). A pointed-at-a-nonexistent-glob lane or a
@@ -49,20 +49,25 @@ import { fileURLToPath } from "node:url";
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, "..", "..");
 
-function parseArgs(argv) {
+export function parseArgs(argv) {
   const options = {
     planFile: null,
     manifest: resolve(here, "ci-lane-manifest.json"),
+    // GitHub injects this only for workflow steps; local proof runs omit it.
+    // biome-ignore lint/suspicious/noUndeclaredEnvVars: CI-owned output path.
     summary: process.env.GITHUB_STEP_SUMMARY || null,
   };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--plan-file") {
-      options.planFile = argv[(i += 1)];
+      i += 1;
+      options.planFile = argv[i];
     } else if (arg === "--manifest") {
-      options.manifest = argv[(i += 1)];
+      i += 1;
+      options.manifest = argv[i];
     } else if (arg === "--summary") {
-      options.summary = argv[(i += 1)];
+      i += 1;
+      options.summary = argv[i];
     } else {
       throw new Error(`unknown argument: ${arg}`);
     }
@@ -130,7 +135,7 @@ function loadPlan({ planFile }) {
 function extractJobBlock(workflowText, jobKey) {
   const lines = workflowText.split(/\r?\n/);
   const header = `  ${jobKey}:`;
-  const start = lines.findIndex((line) => line === header);
+  const start = lines.indexOf(header);
   if (start < 0) return null;
   const body = [lines[start]];
   for (let i = start + 1; i < lines.length; i += 1) {
@@ -139,6 +144,94 @@ function extractJobBlock(workflowText, jobKey) {
     body.push(line);
   }
   return body.join("\n");
+}
+
+function findJobBlockUsing(workflowText, usesRef) {
+  for (const jobKey of extractWorkflowJobKeys(workflowText)) {
+    const block = extractJobBlock(workflowText, jobKey);
+    if (block?.includes(`uses: ${usesRef}`)) return block;
+  }
+  return null;
+}
+
+function extractWorkflowCallBlock(workflowText) {
+  const lines = workflowText.split(/\r?\n/);
+  const start = lines.indexOf("  workflow_call:");
+  if (start < 0) return null;
+  const body = [lines[start]];
+  for (let i = start + 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (/^ {2}\S/.test(line)) break;
+    body.push(line);
+  }
+  return body.join("\n");
+}
+
+function extractWorkflowEventBlock(workflowText, eventName) {
+  const lines = workflowText.split(/\r?\n/);
+  const start = lines.indexOf(`  ${eventName}:`);
+  if (start < 0) return null;
+  const body = [lines[start]];
+  for (let i = start + 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (/^ {2}\S/.test(line)) break;
+    body.push(line);
+  }
+  return body.join("\n");
+}
+
+function extractConcurrencyValue(workflowText, key) {
+  const match = workflowText.match(
+    new RegExp(`^\\s{2}${key}:\\s*(.+?)\\s*$`, "m"),
+  );
+  return match?.[1]?.trim() ?? null;
+}
+
+function normalizeGitHubExpression(body) {
+  return body.replace(/\s+/g, "").replaceAll('"', "'");
+}
+
+function githubExpressionBodies(value) {
+  if (value === null) return [];
+  return [...value.matchAll(/\$\{\{([\s\S]*?)\}\}/g)].map((match) =>
+    normalizeGitHubExpression(match[1]),
+  );
+}
+
+function normalizedGitHubTemplate(value) {
+  if (value === null) return null;
+  return value.replace(
+    /\$\{\{([\s\S]*?)\}\}/g,
+    (_match, body) => `\${{${normalizeGitHubExpression(body)}}}`,
+  );
+}
+
+function extractJobValue(jobBlock, key) {
+  if (jobBlock === null) return null;
+  const match = jobBlock.match(new RegExp(`^ {4}${key}:\\s*(.+?)\\s*$`, "m"));
+  return match?.[1]?.trim() ?? null;
+}
+
+function cancellationEvents(expression) {
+  if (expression === null || expression === "false") return new Set();
+  if (expression === "true") return new Set(["*"]);
+
+  const body = expression
+    .replace(/^\$\{\{\s*/, "")
+    .replace(/\s*\}\}$/, "")
+    .trim();
+  if (body.includes("!=")) return new Set(["*"]);
+
+  const events = new Set();
+  const comparison = /github\.event_name\s*==\s*['"]([^'"]+)['"]/g;
+  for (const match of body.matchAll(comparison)) events.add(match[1]);
+  const residual = body.replace(comparison, "").replace(/\|\||&&|[()\s]/g, "");
+  return residual.length === 0 && events.size > 0 ? events : new Set(["*"]);
+}
+
+function cancelsEvent(expression, eventName) {
+  const events = cancellationEvents(expression);
+  return events.has("*") || events.has(eventName);
 }
 
 function extractWorkflowJobKeys(workflowText) {
@@ -275,11 +368,11 @@ function checkWorkflowLanes(manifest, violations, laneReport) {
   }
 }
 
-// The scheduled exhaustive orchestrator (develop-exhaustive.yml) must keep
-// invoking every platform lane the manifest lists, and each of those workflows
-// must still declare a `workflow_call` trigger — otherwise the orchestrator
-// silently drops that lane's coverage. Both halves are checked statically so a
-// dropped `uses:` or a removed trigger fails without waiting for the run.
+// GitHub's default concurrency mode retains only one pending run; queue:max is
+// therefore part of the exhaustive contract, not an optimization. Reusable
+// workflows then consume an exact caller-scope expression so standalone events
+// cannot collapse into the exhaustive namespace through a truthy-expression
+// lookalike.
 function checkReusableWorkflows(manifest, violations, laneReport) {
   if (
     !manifest.exhaustiveOrchestrator ||
@@ -298,10 +391,42 @@ function checkReusableWorkflows(manifest, violations, laneReport) {
     return;
   }
 
+  const scope = manifest.exhaustiveConcurrencyScope;
+  if (typeof scope !== "string" || scope.length === 0) {
+    violations.push(
+      "missing exhaustive concurrency scope: exhaustiveConcurrencyScope must name the reusable caller namespace",
+    );
+  }
+  const orchestratorGroup = extractConcurrencyValue(orchestratorText, "group");
+  const orchestratorCancel = extractConcurrencyValue(
+    orchestratorText,
+    "cancel-in-progress",
+  );
+  const orchestratorQueue = extractConcurrencyValue(orchestratorText, "queue");
+  const expectedOrchestratorGroup = `${scope}-\${{github.ref}}`;
+  if (
+    normalizedGitHubTemplate(orchestratorGroup) !== expectedOrchestratorGroup
+  ) {
+    violations.push(
+      `exhaustive orchestrator concurrency drift: ${manifest.exhaustiveOrchestrator} must use group ${scope}-\${{ github.ref }}`,
+    );
+  }
+  if (orchestratorQueue !== "max") {
+    violations.push(
+      `consecutive exhaustive runs can replace pending coverage: ${manifest.exhaustiveOrchestrator} must set queue: max`,
+    );
+  }
+  if (orchestratorCancel !== "false") {
+    violations.push(
+      `consecutive exhaustive runs can cancel: ${manifest.exhaustiveOrchestrator} must set cancel-in-progress: false`,
+    );
+  }
+
   for (const reusable of manifest.reusableWorkflows) {
     const basename = reusable.workflow.split("/").pop();
     const usesRef = `./.github/workflows/${basename}`;
-    if (!orchestratorText.includes(`uses: ${usesRef}`)) {
+    const callerJob = findJobBlockUsing(orchestratorText, usesRef);
+    if (callerJob === null) {
       violations.push(
         `missing reusable lane: ${manifest.exhaustiveOrchestrator} does not invoke ${usesRef} (${reusable.name})`,
       );
@@ -312,11 +437,18 @@ function checkReusableWorkflows(manifest, violations, laneReport) {
       });
       continue;
     }
+    let unsafe = false;
+    if (!callerJob.includes(`      concurrency_scope: ${scope}`)) {
+      violations.push(
+        `reusable caller shares standalone concurrency: ${usesRef} is not passed concurrency_scope: ${scope}`,
+      );
+      unsafe = true;
+    }
     let reusableText;
-    let declaresWorkflowCall = false;
+    let workflowCallBlock;
     try {
       reusableText = readFileSync(resolve(repoRoot, reusable.workflow), "utf8");
-      declaresWorkflowCall = /^\s{2}workflow_call:/m.test(reusableText);
+      workflowCallBlock = extractWorkflowCallBlock(reusableText);
     } catch {
       violations.push(
         `missing reusable workflow: ${reusable.workflow} (${reusable.name}) not found`,
@@ -328,7 +460,7 @@ function checkReusableWorkflows(manifest, violations, laneReport) {
       });
       continue;
     }
-    if (!declaresWorkflowCall) {
+    if (workflowCallBlock === null) {
       violations.push(
         `reusable workflow not callable: ${reusable.workflow} does not declare a workflow_call trigger, so ${manifest.exhaustiveOrchestrator} cannot invoke it`,
       );
@@ -339,19 +471,110 @@ function checkReusableWorkflows(manifest, violations, laneReport) {
       });
       continue;
     }
-    if (/^\s{2}cancel-in-progress:\s*true\s*$/m.test(reusableText)) {
+    if (
+      !workflowCallBlock.includes("    inputs:") ||
+      !workflowCallBlock.includes("      concurrency_scope:") ||
+      !workflowCallBlock.includes("        type: string") ||
+      !workflowCallBlock.includes("        default: standalone")
+    ) {
       violations.push(
-        `reusable workflow can cancel scheduled coverage: ${reusable.workflow} has unconditional cancel-in-progress: true; gate cancellation to pull_request so ${manifest.exhaustiveOrchestrator} remains uncancellable`,
+        `reusable workflow ignores caller concurrency scope: ${reusable.workflow} must declare string workflow_call input concurrency_scope with default standalone`,
       );
-      laneReport.push({
-        lane: basename,
-        name: reusable.name,
-        status: "CANCELS",
-      });
-      continue;
+      unsafe = true;
     }
-    laneReport.push({ lane: basename, name: reusable.name, status: "OK" });
+
+    const group = extractConcurrencyValue(reusableText, "group");
+    const groupExpressions = githubExpressionBodies(group);
+    if (!groupExpressions.includes("inputs.concurrency_scope||'standalone'")) {
+      violations.push(
+        `reusable concurrency collision: ${reusable.workflow} must namespace its group with the exact inputs.concurrency_scope || 'standalone' expression`,
+      );
+      unsafe = true;
+    }
+
+    const cancelExpression = extractConcurrencyValue(
+      reusableText,
+      "cancel-in-progress",
+    );
+    const cancellingExhaustiveEvents = [
+      "schedule",
+      "workflow_dispatch",
+      "workflow_call",
+    ].filter((eventName) => cancelsEvent(cancelExpression, eventName));
+    if (cancellingExhaustiveEvents.length > 0) {
+      violations.push(
+        `reusable workflow can cancel exhaustive coverage: ${reusable.workflow} cancels ${cancellingExhaustiveEvents.join(", ")}; only obsolete standalone PR/push work may cancel`,
+      );
+      unsafe = true;
+    }
+    laneReport.push({
+      lane: basename,
+      name: reusable.name,
+      status: unsafe ? "CONCURRENCY-UNSAFE" : "OK",
+    });
   }
+}
+
+// Develop pushes intentionally supersede obsolete tips. Schedule and manual
+// runs use per-run namespaces so they cannot be victims of a later push, and a
+// quiet latest tip must retain one fail-closed aggregate result.
+function checkPostMergeSignal(manifest, violations, laneReport) {
+  const contract = manifest.postMergeSignal;
+  if (!contract) return;
+
+  const workflowText = readFileSync(
+    resolve(repoRoot, manifest.workflow),
+    "utf8",
+  );
+  const pushBlock = extractWorkflowEventBlock(workflowText, "push");
+  const group = extractConcurrencyValue(workflowText, "group");
+  const cancelExpression = extractConcurrencyValue(
+    workflowText,
+    "cancel-in-progress",
+  );
+  const aggregate = extractJobBlock(workflowText, contract.aggregateJob);
+  const aggregateIf = extractJobValue(aggregate, "if");
+  let unsafe = false;
+
+  if (!pushBlock?.includes(contract.branch)) {
+    violations.push(
+      `post-merge signal missing: ${manifest.workflow} does not run on pushes to ${contract.branch}`,
+    );
+    unsafe = true;
+  }
+  const expectedGroup = `test-\${{github.event_name=='push'&&github.ref||format('{0}-{1}',github.event_name,github.run_id)}}`;
+  if (normalizedGitHubTemplate(group) !== expectedGroup) {
+    violations.push(
+      `post-merge concurrency drift: ${manifest.workflow} must share github.ref only across pushes and isolate schedule/dispatch by run id`,
+    );
+    unsafe = true;
+  }
+  const cancelBodies = githubExpressionBodies(cancelExpression);
+  if (
+    cancelBodies.length !== 1 ||
+    cancelBodies[0] !== "github.event_name=='push'"
+  ) {
+    violations.push(
+      `post-merge cancellation drift: ${manifest.workflow} must cancel only obsolete push tips`,
+    );
+    unsafe = true;
+  }
+  const aggregateIfBodies = githubExpressionBodies(aggregateIf);
+  if (
+    aggregate === null ||
+    aggregateIfBodies.length !== 1 ||
+    aggregateIfBodies[0] !== "!cancelled()&&always()"
+  ) {
+    violations.push(
+      `canonical post-merge result missing: ${contract.aggregateJob} must run fail-closed with always() and !cancelled()`,
+    );
+    unsafe = true;
+  }
+  laneReport.push({
+    lane: `post-merge:${contract.aggregateJob}`,
+    name: "Canonical quiescent develop result",
+    status: unsafe ? "CONCURRENCY-UNSAFE" : "OK",
+  });
 }
 
 function checkPlanFloors(manifest, plan, violations, floorReport) {
@@ -432,7 +655,7 @@ function checkPlanFloors(manifest, plan, violations, floorReport) {
   }
 }
 
-function writeSummary(summaryPath, laneReport, floorReport, violations) {
+export function writeSummary(summaryPath, laneReport, floorReport, violations) {
   if (!summaryPath) return;
   const lines = [];
   lines.push("## Exhaustive lane matrix proof");
@@ -477,6 +700,7 @@ export function runProof(options) {
 
   checkWorkflowLanes(manifest, violations, laneReport);
   checkReusableWorkflows(manifest, violations, laneReport);
+  checkPostMergeSignal(manifest, violations, laneReport);
   checkPlanFloors(manifest, plan, violations, floorReport);
 
   return { manifest, plan, violations, laneReport, floorReport };

--- a/packages/scripts/ci-lane-manifest.json
+++ b/packages/scripts/ci-lane-manifest.json
@@ -1,7 +1,11 @@
 {
-  "$comment": "Committed source of truth for the exhaustive develop lane (#12342). ci-full-matrix-proof.mjs checks this against .github/workflows/test.yml (job presence, no PR-only gate) and against `run-all-tests.mjs --plan=json` (floors + required packages + non-empty script lanes). Bump floors only when the real plan genuinely grows; never lower them to make a shrinking plan pass.",
+  "$comment": "Committed source of truth for the exhaustive develop lane (#12342/#16336). ci-full-matrix-proof.mjs checks test.yml job presence, fail-closed post-merge supersession, reusable concurrency isolation, the bounded exhaustive queue, and `run-all-tests.mjs --plan=json` floors. Bump floors only when the real plan genuinely grows; never lower them to make a shrinking plan pass.",
   "workflow": ".github/workflows/test.yml",
   "aggregateStatusJob": "ci-ok",
+  "postMergeSignal": {
+    "branch": "develop",
+    "aggregateJob": "ci-ok"
+  },
   "workflowLanes": [
     {
       "job": "server-tests",
@@ -64,8 +68,9 @@
     ],
     "nonEmptyScriptLanes": ["test", "test:e2e", "test:integration"]
   },
-  "$reusableComment": "The platform lanes the scheduled exhaustive orchestrator (develop-exhaustive.yml) must invoke via workflow_call so the full develop matrix runs unfiltered. ci-full-matrix-proof.mjs fails if the orchestrator drops a lane's `uses:` or a listed workflow stops declaring a workflow_call trigger. These are the lanes test.yml's own schedule does not cover: Windows, mobile, scenario, UI gates, keyless harness, docker, dev, desktop/electrobun.",
+  "$reusableComment": "The platform lanes develop-exhaustive.yml invokes through workflow_call. The proof requires every call to receive exhaustiveConcurrencyScope, every reusable group to consume that exact scope with a standalone fallback, and the orchestrator to retain queue:max plus non-cancelling execution. These are the lanes test.yml's schedule does not cover: Windows, mobile, scenario, UI gates, keyless harness, docker, dev, and desktop/electrobun.",
   "exhaustiveOrchestrator": ".github/workflows/develop-exhaustive.yml",
+  "exhaustiveConcurrencyScope": "develop-exhaustive",
   "reusableWorkflows": [
     {
       "workflow": ".github/workflows/windows-ci.yml",


### PR DESCRIPTION
# Relates to

Relates to #16336
Supports #13401

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`0f8045c6744d6dd696a57ba0a053f9f2ee55355c`).
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the deterministic contract from the commands and hosted-run evidence below.

# Sync with develop

- [x] Rebased onto current `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync (573/573 Turbo tasks plus all post-audits and dist-path consumers).

# Risks

Medium. This changes top-level GitHub Actions concurrency identities for the ten workflows reused by the exhaustive develop orchestrator and for the canonical `test.yml` push signal. A malformed expression could cancel or queue the wrong work. Exact-expression mutation tests, the real manifest proof, and hosted overlap canaries guard that boundary.

# Background

## What does this PR do?

- Gives every reusable lane a caller-owned `concurrency_scope`, with `standalone` as the direct-trigger namespace and `develop-exhaustive` as the orchestrator namespace.
- Makes consecutive exhaustive runs non-cancelling and retains the full pending queue with `queue: max`.
- Keeps obsolete `test.yml` develop pushes supersedable while isolating scheduled/manual diagnostics by run ID, leaving one fail-closed aggregate result at a quiet tip.
- Extends the committed matrix proof and its mutation suite so dropped lanes, scope collisions, cancellation regressions, missing exhaustive queueing, per-run push groups, and permissive aggregate results fail closed.
- Preserves the ten-family runtime aggregate: any reusable result other than `success` remains red.

## What kind of change is this?

Bug fix (non-breaking CI orchestration correction).

# Documentation changes needed?

No public product documentation change is needed. The committed CI manifest commentary and workflow rationale document the operational contract at its source.

# Testing

## Where should a reviewer start?

Run the focused contract test and real manifest proof, then inspect the linked GitHub Actions overlap runs in Evidence Details.

## Detailed testing steps

1. `bun install`
2. `bun test packages/scripts/__tests__/ci-full-matrix-proof.test.ts` — 27 pass, 0 fail, 65 expectations.
3. `node packages/scripts/ci-full-matrix-proof.mjs` — all 9 core lanes, all 10 reusable families, the canonical post-merge signal, and all plan floors pass.
4. `bun run verify` — pass; 573/573 Turbo tasks and all follow-on audits/dist consumers.
5. `bun run audit:error-policy-ratchet` — pass.
6. `bun run audit:focused-tests` — pass.
7. `bun run audit:test-integrity` — pass.
8. `bun run audit:test-realness` — pass; one changed test file, zero regressions.
9. `bunx @biomejs/biome check packages/scripts/ci-full-matrix-proof.mjs packages/scripts/__tests__/ci-full-matrix-proof.test.ts packages/scripts/ci-lane-manifest.json` — pass.
10. `git diff --check` — pass.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - GitHub Actions orchestration only; no UI surface or rendered pixels change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - GitHub Actions orchestration only; no UI surface or rendered pixels change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - There is no user-facing flow; the reviewable artifacts are live Actions runs and job conclusions.
<!-- evidence-row:backend-logs -->
- [x] N/A - No application backend path changes; GitHub Actions run/job logs are linked below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - No frontend code, console behavior, or network request changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - No agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Live Actions overlap domain artifacts: [exact-SHA exhaustive run 29324800592](https://github.com/elizaOS/eliza/actions/runs/29324800592) remained alive for 54m08s after [standalone Scenario run 29324812084](https://github.com/elizaOS/eliza/actions/runs/29324812084) started 12 seconds later on the same SHA. The [ten-family proof job](https://github.com/elizaOS/eliza/actions/runs/29324800592/job/87068812244) enumerated every family and failed closed on four real red families.

# Evidence Details

## Real LLM-call trajectory

N/A - no model behavior changes.

## Backend + frontend logs

N/A - no app backend/frontend path changes. GitHub Actions logs and timing census are the applicable operational evidence.

## Screenshots (before / after) + video walkthrough

N/A - no UI changes.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT change.

## Hosted GitHub Actions evidence

### Overlap timeline

- Exact-SHA exhaustive: [run 29324800592](https://github.com/elizaOS/eliza/actions/runs/29324800592), SHA `6b652927f8a76865468ff4acb738b72bb58fb829`, `10:17:14Z`–`11:11:22Z` (**54m08s**, conclusion `failure`).
- Overlapping standalone Scenario: [run 29324812084](https://github.com/elizaOS/eliza/actions/runs/29324812084), same SHA, `10:17:26Z`–`11:13:08Z` (**55m42s**, conclusion `failure`).
- The standalone run began **12 seconds** after exhaustive. Both expanded and executed concurrently through their own final long-running ratcheted browser jobs. The exhaustive parent was never cancelled or replaced.
- Each run's two `cancelled` browser jobs ended at its declared 35-minute job timeout with `The operation was canceled`; they did not end at overlap time and did not cancel the exhaustive parent.

### Fail-closed ten-family census

[Matrix-proof job 87068812244](https://github.com/elizaOS/eliza/actions/runs/29324800592/job/87068812244) emitted:

| Family | Result |
| --- | --- |
| Windows | failure |
| Mobile | failure |
| Scenario | failure |
| UI E2E | success |
| UI fixture | success |
| UI story | failure |
| Keyless harness | success |
| Docker | success |
| Dev onboarding | success |
| Electrobun | success |

The proof exited 1 and explicitly reported each non-success as a coverage gap. Nothing was converted to advisory success.

### Canonical develop-tip census

The current and still-quiescent `develop` tip is `0f8045c6744d6dd696a57ba0a053f9f2ee55355c`.

- [Push run 29322037639](https://github.com/elizaOS/eliza/actions/runs/29322037639): `09:31:35Z`–`10:01:41Z` (**30m06s**), conclusion `failure`; its canonical `ci-ok` job failed.
- [Isolated schedule run 29323567588](https://github.com/elizaOS/eliza/actions/runs/29323567588): `09:56:53Z`–`10:25:35Z` (**28m42s**), conclusion `failure`; it coexisted with the push namespace instead of cancelling it.

The new concurrency contract is proven live. The separate exact-green and quiescent-green acceptance criteria remain unmet because the real lanes are red, not because coverage was cancelled or hidden.

## Known gaps / failures

- Exact-SHA exhaustive success is blocked by the real Windows, iOS, Story, and Scenario failures shown above. Ownership/evidence remains linked to #13577 (iOS), #16167 (develop Story/deterministic regressions), #15759 (zero-key Scenario reds), #13402 (Windows/CI cleanup), and #14051 (throughput/reliability). This PR preserves all of them as failures.
- The latest quiescent `develop` push is a completed failure, not the required successful canonical signal. Its current concrete blockers include stale deterministic scenario/action manifests, app browser failures, plugin/server/client tests, and runner instability; [run 29322037639](https://github.com/elizaOS/eliza/actions/runs/29322037639) is the owner-visible receipt.
- Local `actionlint v1.7.10` reports only `queue` as an unknown concurrency property because that binary predates GitHub's May 2026 larger-concurrency-queue feature. GitHub's live parser accepted `queue: max`, dispatched all reusable jobs, and ran the workflow for 54 minutes, which is the authoritative platform validation.
- These blockers are why the PR says `Relates to #16336` rather than auto-closing it. The overlap/cancellation code is ready and all 15 applicable PR checks are green, but the issue must remain open until the lane owners produce the required two green signals.
