### PR TITLE
Add @ophis/plugin-elizaos to the third-party registry

### DIFF
--- a/packages/registry/entries/third-party/ophis-plugin-elizaos.json
+++ b/packages/registry/entries/third-party/ophis-plugin-elizaos.json
@@ -1,0 +1,9 @@
+{
+  "package": "@ophis/plugin-elizaos",
+  "repository": "github:ophis-fi/ophis",
+  "kind": "plugin",
+  "description": "MEV-protected same-chain swaps via Ophis (CoW Protocol): the agent signs a GPv2 order with its own EVM key and it settles gaslessly in a batch auction (surplus returned, no sandwiching). Carries an integrator partner fee + optional referral rebate.",
+  "homepage": "https://docs.ophis.fi/ai-agents",
+  "version": "0.3.1",
+  "tags": ["defi", "swap", "dex", "cow-protocol", "mev-protection"]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -138,6 +138,51 @@
       "registryKind": "plugin",
       "directory": null
     },
+    "@ophis/plugin-elizaos": {
+      "git": {
+        "repo": "ophis-fi/ophis",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "@ophis/plugin-elizaos",
+        "v0": null,
+        "v1": null,
+        "v2": "0.3.1"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "MEV-protected same-chain swaps via Ophis (CoW Protocol): the agent signs a GPv2 order with its own EVM key and it settles gaslessly in a batch auction (surplus returned, no sandwiching). Carries an integrator partner fee + optional referral rebate.",
+      "homepage": "https://docs.ophis.fi/ai-agents",
+      "topics": [
+        "defi",
+        "swap",
+        "dex",
+        "cow-protocol",
+        "mev-protection"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
     "@seekdaseek/plugin-agentfeed": {
       "git": {
         "repo": "seekdaseek/plugin-agentfeed",


### PR DESCRIPTION
Adds **`@ophis/plugin-elizaos`** to the community (third-party) registry.

[Ophis](https://ophis.fi) is CoW-Protocol MEV-protected swap infrastructure. The plugin lets an elizaOS agent perform same-chain ERC-20 swaps: it signs a GPv2 order with the agent's own EVM key and the order settles gaslessly in a batch auction — uniform clearing price, surplus returned to the trader, no sandwiching.

- **Package**: `@ophis/plugin-elizaos@0.3.0` (published on npm, provenance-attested; `@ophis` scope, not the reserved `@elizaos`).
- **Repo**: https://github.com/ophis-fi/ophis (`packages/plugin-elizaos`), public.
- Provides a `swap` action (natural-language → MEV-protected swap) reusing the audited `@ophis/agent-swap` core.

Per the registry guide: added `entries/third-party/ophis-plugin-elizaos.json` and regenerated `generated-registry.json` (`bun run validate` → 24 entries validated; `bun run generate`). The diff to `generated-registry.json` is a pure addition (+45/-0).
