### PR TITLE
feat(ui): persistent desktop settings navigation rail

### DIFF
--- a/packages/ui/src/components/pages/SettingsView.test.tsx
+++ b/packages/ui/src/components/pages/SettingsView.test.tsx
@@ -1,11 +1,9 @@
 // @vitest-environment jsdom
 
 // Renders the real SettingsView against mocked state + stub sections to cover
-// the uniform layout: ONE shared ViewHeader + the iOS-style grouped hub list
-// (no desktop `w-60` rail, no horizontal tab strip, no responsive branch),
-// hub → subview navigation (hub row → section body → back to hub), the
-// initialSection prop, and per-section error boundaries (isolate a throwing
-// section, recover on retry). jsdom; sections and state barrel are stubbed.
+// the mobile hub → subview flow, the persistent desktop workspace, breakpoint
+// switching, initialSection, and per-section error boundaries. jsdom; sections
+// and state barrel are stubbed.
 
 import {
   cleanup,
@@ -217,12 +215,10 @@ describe("SettingsView", () => {
     expect(screen.queryByTestId("stub-runtime")).toBeNull();
   });
 
-  it("renders exactly ONE header and NO desktop w-60 rail", () => {
-    const { container } = render(<SettingsView />);
-    // Uniform top bar: a single shared header, never two stacked.
+  it("renders exactly one header in the mobile hub", () => {
+    render(<SettingsView />);
     expect(screen.getAllByTestId("view-header")).toHaveLength(1);
-    // The old persistent desktop rail (`nav.w-60`) is gone in every layout.
-    expect(container.querySelector("nav.w-60")).toBeNull();
+    expect(screen.queryByTestId("desktop-settings-navigation")).toBeNull();
   });
 
   it("groups the hub rows by Agent / System under the header", () => {
@@ -341,11 +337,7 @@ describe("SettingsView", () => {
     }
   });
 
-  // ── #13590: form-factor independence ──────────────────────────────────────
-  //
-  // The uniform layout has NO responsive branch (the desktop rail + mobile-hub
-  // split is gone). The same header + folded nav render regardless of viewport,
-  // so a mocked matchMedia must NOT change what is shown.
+  // ── Responsive settings workspace ─────────────────────────────────────────
 
   /** Mock matchMedia so each query resolves by the supplied predicate. */
   function mockMatchMedia(matches: (query: string) => boolean) {
@@ -365,21 +357,31 @@ describe("SettingsView", () => {
     };
   }
 
-  it("renders the same hub list on a wide (desktop) viewport", () => {
-    const restore = mockMatchMedia(() => true);
+  it("renders a persistent rail and default work area on a desktop viewport", () => {
+    const restore = mockMatchMedia((query) =>
+      query.includes("min-width: 1024px"),
+    );
     try {
       render(<SettingsView />);
-      // No auto-selected pane, no rail — the same grouped hub as on mobile.
-      expect(hubRow("identity")).toBeTruthy();
-      expect(hubRow("runtime")).toBeTruthy();
-      expect(screen.queryByTestId("stub-identity")).toBeNull();
-      expect(screen.getAllByTestId("view-header")).toHaveLength(1);
+      expect(screen.getByTestId("desktop-settings-navigation")).toBeTruthy();
+      expect(screen.getByTestId("desktop-settings-work-area")).toBeTruthy();
+      expect(screen.getByTestId("stub-identity")).toBeTruthy();
+      expect(
+        screen
+          .getByTestId("desktop-settings-item-identity")
+          .getAttribute("aria-current"),
+      ).toBe("page");
+      expect(screen.queryByTestId("settings-hub-list")).toBeNull();
+      expect(screen.queryByTestId("view-header")).toBeNull();
+      expect(
+        screen.getByRole("button", { name: "Back to launcher" }),
+      ).toBeTruthy();
     } finally {
       restore();
     }
   });
 
-  it("renders the same hub list on a narrow (mobile) viewport", () => {
+  it("keeps the current hub list on a narrow mobile viewport", () => {
     const restore = mockMatchMedia(() => false);
     try {
       render(<SettingsView />);

--- a/packages/ui/src/components/pages/SettingsView.tsx
+++ b/packages/ui/src/components/pages/SettingsView.tsx
@@ -1,14 +1,8 @@
 /**
- * The Settings view (`/settings`): an iOS/Android-style hub → subview
- * settings surface with ONE uniform top bar in every layout (#13590). A shared
- * `ViewHeader` (icon-only back, centered title) sits above either the hub — a
- * grouped row list (`SettingsHubList`) that IS the main screen — or the open
- * section's body as a full-width subview.
- *
- * - Hub (no section open): header title = "Settings", back → launcher; the
- *   grouped row list picks a section.
- * - Section open: header title = section label, back → hub; only the section
- *   body renders (no persistent nav chrome).
+ * The Settings view (`/settings`) adapts its information architecture to the
+ * available workspace. At 1024px and wider it renders a persistent grouped
+ * settings rail beside the active section. On narrower screens it preserves the
+ * existing iOS/Android-style hub → subview flow and shared back header.
  *
  * Section content is lazy-loaded and gated by `isViewVisible`; `initialSection`
  * deep-links a specific section. Also reusable in modal form (`inModal`).
@@ -17,11 +11,14 @@ import { isViewVisible } from "@elizaos/core";
 import { isPermissionId, type PermissionId } from "@elizaos/shared";
 import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { useAgentElement } from "../../agent-surface";
+import { useMediaQuery } from "../../hooks/useMediaQuery";
 import { ContentLayout } from "../../layouts/content-layout";
+import { cn } from "../../lib/utils";
 import { isAndroidCloudBuild } from "../../platform/android-runtime";
 import { useAppSelectorShallow } from "../../state";
 import { useEnabledViewKinds } from "../../state/useViewKinds";
 import { PermissionPrimingModal } from "../permissions/PermissionPrimingModal";
+import { DesktopSettingsNavigation } from "../settings/DesktopSettingsNavigation";
 import { SettingsHubList } from "../settings/SettingsHubList";
 import {
   type GroupedSettingsSections,
@@ -211,6 +208,7 @@ export function SettingsView({
     walletEnabled: s.walletEnabled,
   }));
   const enabledKinds = useEnabledViewKinds();
+  const isDesktop = useMediaQuery("(min-width: 1024px)");
   const [activeSection, setActiveSection] = useState<string | null>(
     () => initialSection ?? readSettingsHashSection(),
   );
@@ -294,25 +292,34 @@ export function SettingsView({
       ) ??
       null)
     : null;
+  // A desktop workspace always has useful content beside its persistent rail.
+  // This presentational default does not write a hash, so the mobile root still
+  // opens on the exact same hub when the viewport becomes narrow.
+  const desktopSectionDef = activeSectionDef ?? visibleSections[0] ?? null;
+  const displayedSectionDef = isDesktop ? desktopSectionDef : activeSectionDef;
 
-  // Uniform top bar: a hub shows "Settings" with a launcher back; an open
-  // section shows its label with a back to the hub. One header, both states.
+  // Mobile keeps the uniform top bar: the hub shows "Settings" and a section
+  // shows its title with a back action. Desktop uses an in-pane title instead.
+  const settingsTitle = t("nav.settings", { defaultValue: "Settings" });
   const headerTitle = activeSectionDef
     ? settingsSectionTitle(activeSectionDef, t)
-    : t("nav.settings", { defaultValue: "Settings" });
+    : settingsTitle;
   const onBack = activeSectionDef ? backToHub : navigateBackToLauncher;
   const backLabel = activeSectionDef ? "Back to Settings" : "Back to launcher";
 
   return (
     <ShellViewAgentSurface viewId="settings">
-      <ContentLayout inModal={inModal} contentClassName="max-sm:pt-1">
-        <div data-testid="settings-shell" className="flex w-full flex-col">
-          <ViewHeader
-            title={headerTitle}
-            onBack={onBack}
-            backLabel={backLabel}
-            className="px-0"
-          />
+      <ContentLayout
+        inModal={inModal}
+        contentClassName={isDesktop ? "px-0 pt-0" : "max-sm:pt-1"}
+      >
+        <div
+          data-testid="settings-shell"
+          className={cn(
+            "flex min-h-full w-full",
+            isDesktop ? "flex-row" : "flex-col",
+          )}
+        >
           {/* Agent-surface anchors: the agent addresses every section by
               `section-<id>` regardless of which one is shown. */}
           <div className="hidden">
@@ -321,25 +328,67 @@ export function SettingsView({
                 key={section.id}
                 section={section}
                 label={settingsSectionLabel(section, t)}
-                active={section.id === activeSection}
+                active={section.id === displayedSectionDef?.id}
                 onSelect={openSection}
               />
             ))}
           </div>
+
+          {isDesktop ? (
+            <DesktopSettingsNavigation
+              grouped={grouped}
+              activeId={desktopSectionDef?.id ?? null}
+              onSelect={openSection}
+              onBack={navigateBackToLauncher}
+              settingsLabel={settingsTitle}
+              label={(labelKey, fallback) =>
+                t(labelKey, { defaultValue: fallback })
+              }
+            />
+          ) : null}
+
           <div className="min-w-0 flex-1 pb-32">
-            {activeSectionDef ? (
-              <SettingsSectionContent section={activeSectionDef} t={t} />
+            {isDesktop ? (
+              <main
+                data-testid="desktop-settings-work-area"
+                className="mx-auto w-full max-w-[90rem] px-6 pb-10 pt-6 xl:px-8 xl:pt-8"
+              >
+                {desktopSectionDef ? (
+                  <>
+                    <header className="mb-8 border-b border-border/60 pb-5">
+                      <p className="text-xs font-medium text-muted">
+                        {settingsTitle}
+                      </p>
+                      <h1 className="mt-1 text-xl font-semibold tracking-tight text-txt-strong">
+                        {settingsSectionTitle(desktopSectionDef, t)}
+                      </h1>
+                    </header>
+                    <SettingsSectionContent section={desktopSectionDef} t={t} />
+                  </>
+                ) : null}
+              </main>
             ) : (
-              /* The hub IS the main screen: an iOS-style grouped row list.
-                 Tapping a row swaps in the section subview; the shared header
-                 back returns here. */
-              <SettingsHubList
-                grouped={grouped}
-                onSelect={openSection}
-                label={(labelKey, fallback) =>
-                  t(labelKey, { defaultValue: fallback })
-                }
-              />
+              <>
+                <ViewHeader
+                  title={headerTitle}
+                  onBack={onBack}
+                  backLabel={backLabel}
+                  className="px-0"
+                />
+                {activeSectionDef ? (
+                  <SettingsSectionContent section={activeSectionDef} t={t} />
+                ) : (
+                  /* The hub IS the mobile main screen. Tapping a row swaps in
+                     the section subview; the shared header returns here. */
+                  <SettingsHubList
+                    grouped={grouped}
+                    onSelect={openSection}
+                    label={(labelKey, fallback) =>
+                      t(labelKey, { defaultValue: fallback })
+                    }
+                  />
+                )}
+              </>
             )}
           </div>
           {primePermission ? (

--- a/packages/ui/src/components/pages/__e2e__/run-settings-e2e.mjs
+++ b/packages/ui/src/components/pages/__e2e__/run-settings-e2e.mjs
@@ -194,60 +194,67 @@ const pageErrors = [];
 p.on("pageerror", (e) => pageErrors.push(String(e)));
 
 await p.goto(url, { waitUntil: "domcontentloaded" });
-await p.waitForSelector('[data-testid="settings-hub-list"]');
+await p.waitForSelector('[data-testid="desktop-settings-navigation"]');
 
-// ── 1. Hub structure ─────────────────────────────────────────────────────────
-const hubText = await p
-  .locator('[data-testid="settings-hub-list"]')
+// ── 1. Persistent desktop rail structure ────────────────────────────────────
+const railText = await p
+  .locator('[data-testid="desktop-settings-navigation"]')
   .textContent();
 for (const group of ["Agent", "App", "Privacy & Security", "Cloud"]) {
-  assert(hubText.includes(group), `hub shows the "${group}" group label`);
+  assert(railText.includes(group), `rail shows the "${group}" group label`);
 }
 for (const id of VISIBLE_SECTIONS) {
   assert(
-    (await p.locator(`[data-testid="settings-hub-row-${id}"]`).count()) === 1,
-    `hub lists the "${id}" row`,
+    (await p.locator(`[data-testid="desktop-settings-item-${id}"]`).count()) ===
+      1,
+    `rail lists the "${id}" item`,
   );
 }
 for (const id of HIDDEN_SECTIONS) {
   assert(
-    (await p.locator(`[data-testid="settings-hub-row-${id}"]`).count()) === 0,
-    `hub hides the "${id}" row (Developer Mode off)`,
+    (await p.locator(`[data-testid="desktop-settings-item-${id}"]`).count()) ===
+      0,
+    `rail hides the "${id}" item (Developer Mode off)`,
   );
 }
 assert(
-  (await p.locator('[data-testid="settings-section-nav"]').count()) === 0,
-  "the old horizontal scroll-strip nav is gone",
+  (await p.locator('[data-testid="settings-hub-list"]').count()) === 0,
+  "desktop replaces the mobile hub with the persistent rail",
 );
-await snap(p, "01-hub-desktop");
+await snap(p, "01-rail-desktop");
 
-// ── 2. Every visible row opens its subview; back returns to the hub ─────────
+// ── 2. Every visible rail item switches content in place ────────────────────
 let shotIndex = 2;
 for (const id of VISIBLE_SECTIONS) {
-  await p.locator(`[data-testid="settings-hub-row-${id}"]`).click();
-  await p.waitForSelector('[data-testid="settings-hub-list"]', {
-    state: "detached",
-  });
-  // The section body region is mounted under the retitled header.
+  const item = p.locator(`[data-testid="desktop-settings-item-${id}"]`);
+  await item.click();
   assert(
     (await p.locator(`[id="${id}"]`).count()) === 1,
-    `row "${id}" opens its section subview`,
+    `rail item "${id}" opens its section content`,
   );
-  // Let lazy bodies settle into their loaded/empty/error state before shooting.
+  assert(
+    (await item.getAttribute("aria-current")) === "page",
+    `rail item "${id}" retains the active state`,
+  );
+  assert(
+    (await p.locator('[data-testid="desktop-settings-navigation"]').count()) ===
+      1,
+    `rail remains mounted while "${id}" is open`,
+  );
   await p.waitForTimeout(450);
   await snap(p, `${String(shotIndex).padStart(2, "0")}-section-${id}`);
   shotIndex += 1;
-  await p.getByRole("button", { name: "Back to Settings" }).click();
-  await p.waitForSelector('[data-testid="settings-hub-list"]');
 }
-assert(true, "walked every visible section and returned to the hub each time");
+assert(true, "walked every visible desktop section with the rail retained");
 
 // ── 3. Hash deep-link opens a section directly ───────────────────────────────
 await p.goto(`${url}#appearance`, { waitUntil: "domcontentloaded" });
 await p.waitForSelector("#appearance");
 assert(
-  (await p.locator('[data-testid="settings-hub-list"]').count()) === 0,
-  "#appearance deep-link opens the Appearance subview directly",
+  (await p
+    .locator('[data-testid="desktop-settings-item-appearance"]')
+    .getAttribute("aria-current")) === "page",
+  "#appearance deep-link activates Appearance in the persistent rail",
 );
 await snap(p, `${String(shotIndex).padStart(2, "0")}-deeplink-appearance`);
 shotIndex += 1;

--- a/packages/ui/src/components/settings/DesktopSettingsNavigation.test.tsx
+++ b/packages/ui/src/components/settings/DesktopSettingsNavigation.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { Settings } from "lucide-react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DesktopSettingsNavigation } from "./DesktopSettingsNavigation";
+
+const grouped = [
+  {
+    group: "agent",
+    label: "Agent",
+    items: [
+      {
+        id: "identity",
+        label: "identity.label",
+        defaultLabel: "Basics",
+        icon: Settings,
+        hue: "slate" as const,
+      },
+      {
+        id: "ai-model",
+        label: "models.label",
+        defaultLabel: "Models & Providers",
+        icon: Settings,
+        hue: "accent" as const,
+      },
+    ],
+  },
+  {
+    group: "system",
+    label: "System",
+    items: [
+      {
+        id: "appearance",
+        label: "appearance.label",
+        defaultLabel: "Appearance",
+        icon: Settings,
+        hue: "rose" as const,
+      },
+    ],
+  },
+];
+
+const resolveLabel = (_key: string, fallback: string) => fallback;
+
+afterEach(() => document.body.replaceChildren());
+
+describe("DesktopSettingsNavigation", () => {
+  it("renders grouped sections and marks the active item", () => {
+    render(
+      <DesktopSettingsNavigation
+        grouped={grouped as never}
+        activeId="ai-model"
+        onSelect={vi.fn()}
+        onBack={vi.fn()}
+        settingsLabel="Settings"
+        label={resolveLabel}
+      />,
+    );
+
+    expect(screen.getByText("Agent")).toBeTruthy();
+    expect(screen.getByText("System")).toBeTruthy();
+    expect(screen.getByText("Models & Providers")).toBeTruthy();
+    expect(
+      screen
+        .getByTestId("desktop-settings-item-ai-model")
+        .getAttribute("aria-current"),
+    ).toBe("page");
+    expect(
+      screen
+        .getByTestId("desktop-settings-item-identity")
+        .getAttribute("aria-current"),
+    ).toBeNull();
+  });
+
+  it("moves focus with arrow keys across groups and activates with Enter", () => {
+    const onSelect = vi.fn();
+    render(
+      <DesktopSettingsNavigation
+        grouped={grouped as never}
+        activeId="identity"
+        onSelect={onSelect}
+        onBack={vi.fn()}
+        settingsLabel="Settings"
+        label={resolveLabel}
+      />,
+    );
+
+    const identity = screen.getByTestId("desktop-settings-item-identity");
+    const models = screen.getByTestId("desktop-settings-item-ai-model");
+    const appearance = screen.getByTestId("desktop-settings-item-appearance");
+
+    identity.focus();
+    fireEvent.keyDown(identity, { key: "ArrowDown" });
+    expect(document.activeElement).toBe(models);
+
+    fireEvent.keyDown(models, { key: "ArrowDown" });
+    expect(document.activeElement).toBe(appearance);
+
+    fireEvent.keyDown(appearance, { key: "ArrowDown" });
+    expect(document.activeElement).toBe(identity);
+
+    fireEvent.keyDown(identity, { key: "ArrowUp" });
+    expect(document.activeElement).toBe(appearance);
+
+    fireEvent.keyDown(appearance, { key: "Enter" });
+    expect(onSelect).toHaveBeenCalledWith("appearance");
+  });
+});

--- a/packages/ui/src/components/settings/DesktopSettingsNavigation.tsx
+++ b/packages/ui/src/components/settings/DesktopSettingsNavigation.tsx
@@ -1,0 +1,140 @@
+import { useCallback, useRef } from "react";
+
+import { cn } from "../../lib/utils";
+import { ViewBackButton } from "../shared/ViewHeader";
+import {
+  type GroupedSettingsSections,
+  SECTION_HUE_MEDALLION_CLASS,
+} from "./settings-sections";
+
+interface DesktopSettingsNavigationProps {
+  grouped: GroupedSettingsSections;
+  activeId: string | null;
+  onSelect: (id: string) => void;
+  onBack: () => void;
+  settingsLabel: string;
+  label: (labelKey: string, fallback: string) => string;
+}
+
+/**
+ * Persistent navigation for the desktop settings workspace. Arrow keys move
+ * focus through the complete rail while Enter/Space activates the focused
+ * destination. Mobile continues to use SettingsHubList instead.
+ */
+export function DesktopSettingsNavigation({
+  grouped,
+  activeId,
+  onSelect,
+  onBack,
+  settingsLabel,
+  label,
+}: DesktopSettingsNavigationProps): React.JSX.Element {
+  const itemRefs = useRef(new Map<string, HTMLButtonElement>());
+  const sectionIds = grouped.flatMap(({ items }) =>
+    items.map((section) => section.id),
+  );
+
+  const setItemRef = useCallback(
+    (id: string, node: HTMLButtonElement | null) => {
+      if (node) itemRefs.current.set(id, node);
+      else itemRefs.current.delete(id);
+    },
+    [],
+  );
+
+  const focusRelativeItem = (currentId: string, offset: number) => {
+    const currentIndex = sectionIds.indexOf(currentId);
+    if (currentIndex < 0 || sectionIds.length === 0) return;
+    const nextIndex =
+      (currentIndex + offset + sectionIds.length) % sectionIds.length;
+    itemRefs.current.get(sectionIds[nextIndex])?.focus();
+  };
+
+  return (
+    <nav
+      aria-label="Settings sections"
+      data-testid="desktop-settings-navigation"
+      className="sticky top-0 flex h-fit w-60 shrink-0 flex-col gap-6 border-r border-border/60 px-3 py-6"
+    >
+      <div className="flex items-start gap-1 px-1">
+        <ViewBackButton
+          onBack={onBack}
+          label="Back to launcher"
+          className="mt-0.5 shrink-0"
+        />
+        <div className="min-w-0 pt-1">
+          <p className="text-sm font-semibold tracking-tight text-txt-strong">
+            {settingsLabel}
+          </p>
+          <p className="mt-1 text-xs leading-relaxed text-muted">
+            Agent, app, and privacy controls
+          </p>
+        </div>
+      </div>
+
+      {grouped.map(({ group, label: groupLabel, items }) => (
+        <section key={group} data-testid={`desktop-settings-group-${group}`}>
+          <h2 className="mb-1 px-2 text-2xs font-medium uppercase tracking-wide text-muted/70">
+            {groupLabel}
+          </h2>
+          <div className="flex flex-col gap-0.5">
+            {items.map((section) => {
+              const Icon = section.icon;
+              const sectionLabel = label(section.label, section.defaultLabel);
+              const isActive = section.id === activeId;
+
+              return (
+                <button
+                  key={section.id}
+                  ref={(node) => setItemRef(section.id, node)}
+                  type="button"
+                  data-testid={`desktop-settings-item-${section.id}`}
+                  aria-current={isActive ? "page" : undefined}
+                  onClick={() => onSelect(section.id)}
+                  onKeyDown={(event) => {
+                    if (event.key === "ArrowDown") {
+                      event.preventDefault();
+                      focusRelativeItem(section.id, 1);
+                    } else if (event.key === "ArrowUp") {
+                      event.preventDefault();
+                      focusRelativeItem(section.id, -1);
+                    } else if (event.key === "Enter") {
+                      event.preventDefault();
+                      onSelect(section.id);
+                    }
+                  }}
+                  className={cn(
+                    "group flex min-h-11 w-full items-center gap-2.5 rounded-md border border-transparent px-2 py-2 text-left text-sm transition-colors",
+                    "text-muted hover:bg-surface/70 hover:text-txt-strong focus-visible:border-accent/60",
+                    isActive &&
+                      "bg-accent/10 font-medium text-txt-strong hover:bg-accent/12",
+                  )}
+                >
+                  <span
+                    aria-hidden
+                    className={cn(
+                      "flex size-6 shrink-0 items-center justify-center rounded-md",
+                      SECTION_HUE_MEDALLION_CLASS[section.hue],
+                      !isActive && "opacity-80 group-hover:opacity-100",
+                    )}
+                  >
+                    <Icon className="size-3.5" />
+                  </span>
+                  <span className="min-w-0 flex-1 truncate">
+                    {sectionLabel}
+                  </span>
+                  {isActive ? (
+                    <span
+                      aria-hidden
+                      className="size-1.5 shrink-0 rounded-full bg-accent"
+                    />
+                  ) : null}
+                </button>
+              );
+            })}
+          </div>
+        </section>
+      ))}
+    </nav>
+  );
+}


### PR DESCRIPTION
## Motivation

The desktop UI dossier identified three linked causes behind Settings feeling like a stretched phone UI:

1. Desktop mode changed mechanics, not composition. Settings remained one wide vertical column.
2. Opening a section replaced navigation instead of preserving place awareness.
3. The grouped mobile list was serving as the desktop information architecture instead of a touch-specific presentation.

This PR implements the dossier's independent P0.1 slice only. Desktop Settings now has a persistent grouped navigation rail and real work area. The existing mobile hub and drill-in flow remains unchanged below 1024px.

## What changed

- Added a 240px grouped desktop settings rail sourced from `settings-sections.ts`.
- Kept the active section highlighted while switching content in place.
- Added Arrow Up/Down focus movement, Enter activation, persistent visible focus treatment, 44px targets, and the launcher back affordance.
- Added a desktop content work area with 24px/32px responsive padding and a localized breadcrumb/title.
- Preserved the current mobile grouped hub, section drill-in, loading/error boundaries, hashes, and agent-surface anchors.
- Added focused Vitest coverage for rail rendering, active state, breakpoint behavior, and keyboard navigation.

## Before / after

### Settings root, 1280x800

Before:

![Before settings root](https://github.com/0xSolace/eliza/releases/download/pr-settings-rail-evidence-v1/before-settings-root-1280x800.png)

After:

![After settings root](https://github.com/0xSolace/eliza/releases/download/pr-settings-rail-evidence-v1/settings-root-1280x800.png)


### Models & Providers, 1440x1000

Before:

![Before Models and Providers](https://github.com/0xSolace/eliza/releases/download/pr-settings-rail-evidence-v1/before-models-providers-1440x1000.png)

After:

![After Models and Providers](https://github.com/0xSolace/eliza/releases/download/pr-settings-rail-evidence-v1/models-providers-1440x1000.png)


### Mobile no-regression, 390x844

![Mobile settings hub](https://github.com/0xSolace/eliza/releases/download/pr-settings-rail-evidence-v1/settings-root-390x844.png)


### Walkthrough and validation artifacts


Additional screenshots: [1440x1000 root](https://github.com/0xSolace/eliza/releases/download/pr-settings-rail-evidence-v1/settings-root-1440x1000.png), [1280x800 Models & Providers](https://github.com/0xSolace/eliza/releases/download/pr-settings-rail-evidence-v1/models-providers-1280x800.png), [390x844 Models & Providers](https://github.com/0xSolace/eliza/releases/download/pr-settings-rail-evidence-v1/models-providers-390x844.png).

## Evidence gate

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/0xSolace/eliza/releases/download/pr-settings-rail-evidence-v1/before-settings-root-1280x800.png)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/0xSolace/eliza/releases/download/pr-settings-rail-evidence-v1/settings-root-1280x800.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/0xSolace/eliza/releases/download/pr-settings-rail-evidence-v1/settings-rail-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [ ] N/A - presentation-only UI shell; no backend behavior changed

<!-- evidence-row:frontend-logs -->
- [x] [frontend-console.log](https://github.com/0xSolace/eliza/releases/download/pr-settings-rail-evidence-v1/frontend-console.log)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic settings navigation; no LLM-driven behavior changed

<!-- evidence-row:domain-artifacts -->
- [x] [validation.log](https://github.com/0xSolace/eliza/releases/download/pr-settings-rail-evidence-v1/validation.log)

<!-- evidence-row:ocr-review -->
- [x] OCR visual text review: [ocr-review.txt](https://github.com/0xSolace/eliza/releases/download/pr-settings-rail-evidence-v1/ocr-review.txt)

## Acceptance criteria

- [x] Desktop at 1440 shows the full rail and a work area wider than 880px.
- [x] Desktop at 1280 shows the full rail and useful Models & Providers content without horizontal overflow.
- [x] Main content begins after the 240px rail plus desktop gutter.
- [x] Selecting Models & Providers retains the rail and active highlight.
- [x] Arrow Up/Down moves focus; Enter activates; focus remains in the persistent rail across section transitions.
- [x] Mobile at 390 preserves the current grouped hub, chevrons, drill-in, and back behavior.
- [x] Loading, error, empty, hash, and agent-surface behavior remains intact.
- [x] Dark theme uses existing tokens only; no new dependency or hardcoded hex color.
- [x] Diff is limited to `SettingsView`, the new rail component, and focused tests. No account, chat, overlay, Vite, HTML, or lockfile changes.

## Validation

- `14/14` focused Vitest tests passed.
- Focused changed-surface coverage: 86.48% statements, 78.94% branches, 84.21% functions, 89.79% lines.
- `packages/ui` typecheck passed.
- `packages/ui` lint passed with repository baseline warnings only.
- Biome and `git diff --check` passed.
- Codex review completed; findings fixed for launcher navigation, 44px targets, and localized desktop chrome.

[sol-orch]
