### PR TITLE
feat(accounts): account-pool lease broker with lease attribution

### DIFF
--- a/packages/agent/src/api/accounts-routes.ts
+++ b/packages/agent/src/api/accounts-routes.ts
@@ -797,9 +797,6 @@ async function handleListAllAccounts(
           lastLeaseAt:
             broker.accounts[brokerAccountKey(providerId, cfg.id)]
               ?.lastLeaseAt ?? null,
-          lastSelectedAt:
-            broker.accounts[brokerAccountKey(providerId, cfg.id)]
-              ?.lastLeaseAt ?? null,
           servedLastRequest: lastSelection?.accountId === cfg.id,
         },
       })),

--- a/packages/agent/src/api/accounts-routes.ts
+++ b/packages/agent/src/api/accounts-routes.ts
@@ -60,6 +60,7 @@ import {
   isUnavailableSubscriptionProvider,
   type SubscriptionProvider,
 } from "@elizaos/auth/types";
+import type { AccountPoolBrokerSnapshot } from "@elizaos/core";
 import { ElizaError, logger } from "@elizaos/core";
 import type { RouteRequestContext } from "@elizaos/shared";
 import {
@@ -160,6 +161,20 @@ async function getPool(): Promise<PoolFacade> {
     cachedPool = getAgentHostBridge().getDefaultAccountPool() as PoolFacade;
   }
   return cachedPool;
+}
+
+function brokerAccountKey(
+  providerId: LinkedAccountProviderId,
+  accountId: string,
+): string {
+  return `${providerId}:${accountId}`;
+}
+
+function brokerSnapshot(): AccountPoolBrokerSnapshot {
+  const getter = getAgentHostBridge().getAccountPoolBrokerSnapshot;
+  return typeof getter === "function"
+    ? getter()
+    : { accounts: {}, providers: {} };
 }
 
 /** Test-only: drop the cached pool reference between tests. */
@@ -738,6 +753,7 @@ async function handleListAllAccounts(
 ): Promise<boolean> {
   const { res, json } = ctx;
   const pool = await getPool();
+  const broker = brokerSnapshot();
   const providers = SUPPORTED_PROVIDER_IDS.map((providerId) => {
     const linkedConfigs = pool
       .list(providerId)
@@ -752,6 +768,21 @@ async function handleListAllAccounts(
     // so the UI can label the active row without re-deriving policy. Guarded
     // because older host bridges may not implement selectionState.
     const selection = pool.selectionState?.(providerId, strategy);
+    const providerBroker = broker.providers[providerId];
+    const lastSelection = providerBroker?.lastSelection
+      ? {
+          accountId: providerBroker.lastSelection.accountId,
+          atMs: providerBroker.lastSelection.atMs,
+        }
+      : null;
+    const recentFailovers = (providerBroker?.recentFailovers ?? []).map(
+      (failover) => ({
+        fromAccountId: failover.fromAccountId,
+        toAccountId: failover.toAccountId,
+        atMs: failover.atMs,
+        cause: failover.cause.reason,
+      }),
+    );
     return {
       providerId,
       strategy,
@@ -759,8 +790,24 @@ async function handleListAllAccounts(
       accounts: linkedConfigs.map((cfg) => ({
         ...cfg,
         hasCredential: onDiskSet.has(cfg.id),
+        observability: {
+          activeLeaseCount:
+            broker.accounts[brokerAccountKey(providerId, cfg.id)]
+              ?.activeLeaseCount ?? 0,
+          lastLeaseAt:
+            broker.accounts[brokerAccountKey(providerId, cfg.id)]
+              ?.lastLeaseAt ?? null,
+          lastSelectedAt:
+            broker.accounts[brokerAccountKey(providerId, cfg.id)]
+              ?.lastLeaseAt ?? null,
+          servedLastRequest: lastSelection?.accountId === cfg.id,
+        },
       })),
       ...(selection ? { selection } : {}),
+      observability: {
+        lastSelection,
+        recentFailovers,
+      },
     };
   });
   json(res, { providers });

--- a/packages/agent/src/runtime/host-bridge.test.ts
+++ b/packages/agent/src/runtime/host-bridge.test.ts
@@ -59,6 +59,8 @@ describe("agent host bridge (downward injection seam)", () => {
       runVaultBootstrap: () => Promise.resolve({ migrated: 3, failed: [] }),
       sharedVault: defaultAgentHostBridge.sharedVault,
       getDefaultAccountPool: () => pool,
+      getAccountPoolBrokerSnapshot:
+        defaultAgentHostBridge.getAccountPoolBrokerSnapshot,
       applyAccountPoolApiCredentials: () => undefined,
       startAccountPoolKeepAlive: () => {
         keepAliveStarted = true;

--- a/packages/agent/src/runtime/host-bridge.ts
+++ b/packages/agent/src/runtime/host-bridge.ts
@@ -24,6 +24,10 @@ import type {
   ServerResponse as HttpServerResponse,
 } from "node:http";
 import type { AgentRuntime } from "@elizaos/core";
+import {
+  type AccountPoolBrokerSnapshot,
+  emptyAccountPoolBrokerSnapshot,
+} from "@elizaos/core";
 import type { resolveServiceRoutingInConfig } from "@elizaos/shared";
 import type { Vault } from "@elizaos/vault";
 
@@ -51,6 +55,7 @@ export interface AgentHostBridge {
   runVaultBootstrap(): Promise<{ migrated: number; failed: unknown[] }>;
   sharedVault(): Vault;
   getDefaultAccountPool(): unknown;
+  getAccountPoolBrokerSnapshot(): AccountPoolBrokerSnapshot;
   applyAccountPoolApiCredentials(
     options: AccountPoolCredentialsOptions,
   ): Promise<void> | void;
@@ -104,6 +109,7 @@ export const defaultAgentHostBridge: AgentHostBridge = {
   runVaultBootstrap: () => Promise.resolve({ migrated: 0, failed: [] }),
   sharedVault: () => noopVault,
   getDefaultAccountPool: () => null,
+  getAccountPoolBrokerSnapshot: emptyAccountPoolBrokerSnapshot,
   applyAccountPoolApiCredentials: () => undefined,
   startAccountPoolKeepAlive: () => undefined,
   getBuildVariant: defaultBuildVariant,

--- a/packages/agent/test/api/accounts-routes.test.ts
+++ b/packages/agent/test/api/accounts-routes.test.ts
@@ -486,7 +486,6 @@ describe("accounts routes provider-scoped account resolution", () => {
           observability: {
             activeLeaseCount: number;
             lastLeaseAt: number | null;
-            lastSelectedAt: number | null;
             servedLastRequest: boolean;
           };
         }>;
@@ -513,7 +512,6 @@ describe("accounts routes provider-scoped account resolution", () => {
         observability: {
           activeLeaseCount: 0,
           lastLeaseAt: null,
-          lastSelectedAt: null,
           servedLastRequest: false,
         },
       }),
@@ -522,7 +520,6 @@ describe("accounts routes provider-scoped account resolution", () => {
         observability: {
           activeLeaseCount: 2,
           lastLeaseAt: 1234,
-          lastSelectedAt: 1234,
           servedLastRequest: true,
         },
       }),

--- a/packages/agent/test/api/accounts-routes.test.ts
+++ b/packages/agent/test/api/accounts-routes.test.ts
@@ -26,6 +26,7 @@ const poolMock = {
   upsert: vi.fn(),
   deleteMetadata: vi.fn(),
   refreshUsage: vi.fn(),
+  selectionState: vi.fn(),
 };
 
 vi.mock("@elizaos/auth/account-storage", () => ({
@@ -403,6 +404,150 @@ describe("accounts routes provider-scoped account resolution", () => {
     expect(openai?.accounts.every((account) => account.hasCredential)).toBe(
       true,
     );
+  });
+
+  it("adds sanitized broker observability to the accounts response", async () => {
+    const personal = linkedAccount("openai-codex", {
+      id: "personal",
+      label: "Personal",
+      priority: 0,
+    });
+    const work = linkedAccount("openai-codex", {
+      id: "work",
+      label: "Work",
+      priority: 1,
+    });
+    poolMock.list.mockImplementation((providerId?: string) => {
+      return providerId === "openai-codex" ? [personal, work] : [];
+    });
+    poolMock.selectionState.mockReturnValue({
+      activeAccountId: "work",
+      reason: "least-used",
+    });
+    setAgentHostBridge({
+      ...defaultAgentHostBridge,
+      getDefaultAccountPool: () => poolMock,
+      getAccountPoolBrokerSnapshot: () => ({
+        accounts: {
+          "openai-codex:work": {
+            activeLeaseCount: 2,
+            lastLeaseAt: 1234,
+            lastLease: {
+              leaseId: "opaque-lease",
+              atMs: 1234,
+              sessionKeyHash: "fixture-session-hash",
+              model: "gpt-5.6-terra",
+            },
+            lastReportedStatus: {
+              atMs: 1250,
+              ok: false,
+              category: "rate_limit",
+              reason: "http_429",
+              httpStatus: 429,
+            },
+          },
+        },
+        providers: {
+          "openai-codex": {
+            lastSelection: {
+              accountId: "work",
+              atMs: 1234,
+              reason: "least-used",
+            },
+            recentFailovers: [
+              {
+                atMs: 1234,
+                providerId: "openai-codex",
+                sessionKeyHash: "fixture-session-hash",
+                fromAccountId: "personal",
+                toAccountId: "work",
+                cause: { category: "rate_limit", reason: "http_429" },
+              },
+            ],
+          },
+        },
+      }),
+    });
+    _resetAccountsRoutesPoolCache();
+    const ctx = createContext({ method: "GET", pathname: "/api/accounts" });
+
+    const handled = await handleAccountsRoutes(ctx);
+
+    expect(handled).toBe(true);
+    const response = ctx.body as {
+      providers: Array<{
+        providerId: string;
+        observability: {
+          lastSelection: { accountId: string; atMs: number } | null;
+          recentFailovers: unknown[];
+        };
+        accounts: Array<{
+          id: string;
+          observability: {
+            activeLeaseCount: number;
+            lastLeaseAt: number | null;
+            lastSelectedAt: number | null;
+            servedLastRequest: boolean;
+          };
+        }>;
+      }>;
+    };
+    const codex = response.providers.find(
+      (entry) => entry.providerId === "openai-codex",
+    );
+    expect(codex?.observability.lastSelection).toEqual({
+      accountId: "work",
+      atMs: 1234,
+    });
+    expect(codex?.observability.recentFailovers).toEqual([
+      {
+        fromAccountId: "personal",
+        toAccountId: "work",
+        atMs: 1234,
+        cause: "http_429",
+      },
+    ]);
+    expect(codex?.accounts).toEqual([
+      expect.objectContaining({
+        id: "personal",
+        observability: {
+          activeLeaseCount: 0,
+          lastLeaseAt: null,
+          lastSelectedAt: null,
+          servedLastRequest: false,
+        },
+      }),
+      expect.objectContaining({
+        id: "work",
+        observability: {
+          activeLeaseCount: 2,
+          lastLeaseAt: 1234,
+          lastSelectedAt: 1234,
+          servedLastRequest: true,
+        },
+      }),
+    ]);
+    expect(JSON.stringify(codex)).not.toContain("raw-session");
+    expect(JSON.stringify(codex)).not.toContain("refresh");
+    expect(JSON.stringify(codex)).not.toContain("accessToken");
+  });
+
+  it("rejects malformed OAuth code and cancellation requests", async () => {
+    const submit = createContext({
+      method: "POST",
+      pathname: "/api/accounts/anthropic-subscription/oauth/submit-code",
+      body: {},
+    });
+    expect(await handleAccountsRoutes(submit)).toBe(true);
+    expect(submit.status).toBe(400);
+
+    const cancel = createContext({
+      method: "POST",
+      pathname: "/api/accounts/anthropic-subscription/oauth/cancel",
+      body: {},
+    });
+    expect(await handleAccountsRoutes(cancel)).toBe(true);
+    expect(cancel.status).toBe(400);
   });
 
   it("rejects external or unavailable subscription providers as imported API keys", async () => {

--- a/packages/app-core/src/api/account-pool-broker-routes.test.ts
+++ b/packages/app-core/src/api/account-pool-broker-routes.test.ts
@@ -1,0 +1,404 @@
+/**
+ * Focused coverage for the localhost-only account-pool broker HTTP surface.
+ * Tests use real temp account-storage records and the default AccountPool
+ * singleton, while provider calls are avoided by storing far-future access
+ * tokens that do not require refresh.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import * as http from "node:http";
+import { Socket } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { saveAccount } from "@elizaos/auth/account-storage";
+import type { AccountCredentialProvider } from "@elizaos/auth/types";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  __resetDefaultAccountPoolForTests,
+  getDefaultAccountPool,
+} from "../services/account-pool.js";
+import {
+  __resetAccountPoolBrokerRoutesForTests,
+  handleAccountPoolBrokerRoute,
+} from "./account-pool-broker-routes.js";
+
+interface FakeRes {
+  res: http.ServerResponse;
+  body(): unknown;
+  header(name: string): string | number | readonly string[] | undefined;
+  status(): number;
+}
+
+const SECRET = "test-broker-fixture-test-broker-fixture-test";
+const FAR_FUTURE = Date.now() + 10 * 365 * 24 * 60 * 60 * 1000;
+
+let home: string;
+let prevHome: string | undefined;
+let prevStateDir: string | undefined;
+let prevEnabled: string | undefined;
+let prevSecret: string | undefined;
+let prevTtl: string | undefined;
+
+function fakeRes(): FakeRes {
+  let bodyText = "";
+  const headers = new Map<string, string | number | readonly string[]>();
+  const req = new http.IncomingMessage(new Socket());
+  const res = new http.ServerResponse(req);
+  res.statusCode = 200;
+  res.setHeader = ((
+    name: string,
+    value: string | number | readonly string[],
+  ) => {
+    headers.set(name.toLowerCase(), Array.isArray(value) ? [...value] : value);
+    return res;
+  }) as typeof res.setHeader;
+  res.end = ((chunk?: string | Buffer) => {
+    if (typeof chunk === "string") bodyText += chunk;
+    else if (chunk) bodyText += chunk.toString("utf8");
+    return res;
+  }) as typeof res.end;
+  return {
+    res,
+    body() {
+      return bodyText.length > 0 ? JSON.parse(bodyText) : null;
+    },
+    header(name: string) {
+      return headers.get(name.toLowerCase());
+    },
+    status() {
+      return res.statusCode;
+    },
+  };
+}
+
+function fakeReq(
+  pathname: string,
+  options: {
+    method?: string;
+    auth?: string;
+    body?: Record<string, unknown>;
+    remoteAddress?: string;
+  } = {},
+): http.IncomingMessage {
+  const req = new http.IncomingMessage(new Socket());
+  req.method = options.method ?? "POST";
+  req.url = pathname;
+  req.headers = { host: "127.0.0.1:18792" };
+  if (options.auth !== undefined) req.headers.authorization = options.auth;
+  if (options.body !== undefined) {
+    (req as { body?: unknown }).body = options.body;
+  }
+  Object.defineProperty(req.socket, "remoteAddress", {
+    value: options.remoteAddress ?? "127.0.0.1",
+    configurable: true,
+  });
+  return req;
+}
+
+function writeAccount(
+  providerId: AccountCredentialProvider,
+  id: string,
+  access: string,
+  extra: { organizationId?: string } = {},
+): void {
+  saveAccount({
+    id,
+    providerId,
+    label: id,
+    source: "oauth",
+    credentials: {
+      access,
+      refresh: `${access}-refresh`,
+      expires: FAR_FUTURE,
+    },
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...extra,
+  });
+}
+
+async function postBroker(
+  pathSuffix: string,
+  body: Record<string, unknown>,
+): Promise<FakeRes> {
+  const res = fakeRes();
+  await handleAccountPoolBrokerRoute(
+    fakeReq(`/internal/account-pool/v1/${pathSuffix}`, {
+      auth: `Bearer ${SECRET}`,
+      body,
+    }),
+    res.res,
+  );
+  return res;
+}
+
+async function lease(
+  body: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const res = await postBroker("lease", body);
+  expect(res.status()).toBe(200);
+  return res.body() as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  prevHome = process.env.ELIZA_HOME;
+  prevStateDir = process.env.ELIZA_STATE_DIR;
+  prevEnabled = process.env.ELIZA_ACCOUNT_POOL_BROKER_ENABLED;
+  prevSecret = process.env.ELIZA_ACCOUNT_POOL_BROKER_SECRET;
+  prevTtl = process.env.ELIZA_ACCOUNT_POOL_BROKER_LEASE_TTL_MS;
+  home = mkdtempSync(path.join(tmpdir(), "account-pool-broker-"));
+  process.env.ELIZA_HOME = home;
+  process.env.ELIZA_STATE_DIR = home;
+  process.env.ELIZA_ACCOUNT_POOL_BROKER_ENABLED = "1";
+  process.env.ELIZA_ACCOUNT_POOL_BROKER_SECRET = SECRET;
+  delete process.env.ELIZA_ACCOUNT_POOL_BROKER_LEASE_TTL_MS;
+  __resetDefaultAccountPoolForTests();
+  __resetAccountPoolBrokerRoutesForTests();
+});
+
+afterEach(() => {
+  __resetAccountPoolBrokerRoutesForTests();
+  __resetDefaultAccountPoolForTests();
+  if (prevHome === undefined) delete process.env.ELIZA_HOME;
+  else process.env.ELIZA_HOME = prevHome;
+  if (prevStateDir === undefined) delete process.env.ELIZA_STATE_DIR;
+  else process.env.ELIZA_STATE_DIR = prevStateDir;
+  if (prevEnabled === undefined)
+    delete process.env.ELIZA_ACCOUNT_POOL_BROKER_ENABLED;
+  else process.env.ELIZA_ACCOUNT_POOL_BROKER_ENABLED = prevEnabled;
+  if (prevSecret === undefined)
+    delete process.env.ELIZA_ACCOUNT_POOL_BROKER_SECRET;
+  else process.env.ELIZA_ACCOUNT_POOL_BROKER_SECRET = prevSecret;
+  if (prevTtl === undefined)
+    delete process.env.ELIZA_ACCOUNT_POOL_BROKER_LEASE_TTL_MS;
+  else process.env.ELIZA_ACCOUNT_POOL_BROKER_LEASE_TTL_MS = prevTtl;
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("account-pool broker route auth", () => {
+  it("is absent unless explicitly enabled with a strong bearer secret", async () => {
+    delete process.env.ELIZA_ACCOUNT_POOL_BROKER_ENABLED;
+    const res = fakeRes();
+    const handled = await handleAccountPoolBrokerRoute(
+      fakeReq("/internal/account-pool/v1/health", {
+        method: "GET",
+        auth: `Bearer ${SECRET}`,
+      }),
+      res.res,
+    );
+    expect(handled).toBe(false);
+
+    process.env.ELIZA_ACCOUNT_POOL_BROKER_ENABLED = "1";
+    process.env.ELIZA_ACCOUNT_POOL_BROKER_SECRET = "short";
+    const weak = fakeRes();
+    expect(
+      await handleAccountPoolBrokerRoute(
+        fakeReq("/internal/account-pool/v1/health", {
+          method: "GET",
+          auth: "Bearer short",
+        }),
+        weak.res,
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects non-loopback callers before serving the broker", async () => {
+    const res = fakeRes();
+    const handled = await handleAccountPoolBrokerRoute(
+      fakeReq("/internal/account-pool/v1/health", {
+        method: "GET",
+        auth: `Bearer ${SECRET}`,
+        remoteAddress: "10.0.0.8",
+      }),
+      res.res,
+    );
+    expect(handled).toBe(true);
+    expect(res.status()).toBe(403);
+    expect(res.header("Cache-Control")).toBe("no-store");
+    expect(res.body()).toEqual({ ok: false, error: "loopback_only" });
+  });
+
+  it("requires bearer auth and never echoes the secret in errors", async () => {
+    const res = fakeRes();
+    await handleAccountPoolBrokerRoute(
+      fakeReq("/internal/account-pool/v1/health", {
+        method: "GET",
+        auth: "Bearer wrong-secret",
+      }),
+      res.res,
+    );
+    expect(res.status()).toBe(401);
+    expect(JSON.stringify(res.body())).not.toContain(SECRET);
+    expect(res.header("Cache-Control")).toBe("no-store");
+  });
+});
+
+describe("account-pool broker lease flow", () => {
+  it("leases an access token, omits refresh tokens, and returns no-store", async () => {
+    writeAccount("anthropic-subscription", "primary", "sk-ant-oat-primary");
+    const res = await postBroker("lease", {
+      providerId: "anthropic-subscription",
+      sessionKey: "openclaw:s1",
+      strategy: "priority",
+      exclude: [],
+    });
+    expect(res.status()).toBe(200);
+    expect(res.header("Cache-Control")).toBe("no-store");
+    const body = res.body() as Record<string, unknown>;
+    expect(body.accountId).toBe("primary");
+    expect(body.accessToken).toBe("sk-ant-oat-primary");
+    expect(JSON.stringify(body)).not.toContain("refresh");
+  });
+
+  it("keeps explicit session affinity until exclusion forces a switch", async () => {
+    writeAccount("anthropic-subscription", "primary", "token-primary");
+    writeAccount("anthropic-subscription", "spare", "token-spare");
+    const pool = getDefaultAccountPool();
+    const spare = pool.get("spare", "anthropic-subscription");
+    if (!spare) throw new Error("missing spare");
+    await pool.upsert({
+      ...spare,
+      priority: 1,
+      usage: { sessionPct: 0, refreshedAt: Date.now() },
+    });
+    const primary = pool.get("primary", "anthropic-subscription");
+    if (!primary) throw new Error("missing primary");
+    await pool.upsert({
+      ...primary,
+      priority: 0,
+      usage: { sessionPct: 99, refreshedAt: Date.now() },
+    });
+
+    const first = await lease({
+      providerId: "anthropic-subscription",
+      sessionKey: "openclaw:same-session",
+      strategy: "priority",
+    });
+    const pinned = await lease({
+      providerId: "anthropic-subscription",
+      sessionKey: "openclaw:same-session",
+      strategy: "least-used",
+    });
+    const switched = await lease({
+      providerId: "anthropic-subscription",
+      sessionKey: "openclaw:same-session",
+      strategy: "least-used",
+      exclude: ["primary"],
+    });
+
+    expect(first.accountId).toBe("primary");
+    expect(pinned.accountId).toBe("primary");
+    expect(switched.accountId).toBe("spare");
+  });
+
+  it("returns the ChatGPT account id for Codex leases without exposing refresh tokens", async () => {
+    writeAccount("openai-codex", "codex", "codex-access", {
+      organizationId: "acct_123",
+    });
+    const body = await lease({
+      providerId: "openai-codex",
+      sessionKey: "openclaw:codex",
+      strategy: "priority",
+    });
+    expect(body.accountId).toBe("codex");
+    expect(body.chatgptAccountId).toBe("acct_123");
+    expect(body.accessToken).toBe("codex-access");
+    expect(JSON.stringify(body)).not.toContain("codex-access-refresh");
+  });
+});
+
+describe("account-pool broker report/release flow", () => {
+  it("classifies success, rate-limit, auth failure, and transient failures", async () => {
+    writeAccount("anthropic-subscription", "ok", "token-ok");
+    writeAccount("anthropic-subscription", "limited", "token-limited");
+    writeAccount("anthropic-subscription", "revoked", "token-revoked");
+    writeAccount("anthropic-subscription", "outage", "token-outage");
+
+    const success = await lease({
+      providerId: "anthropic-subscription",
+      sessionKey: "success",
+      strategy: "priority",
+      exclude: ["limited", "revoked", "outage"],
+    });
+    await postBroker("report", {
+      leaseId: success.leaseId,
+      ok: true,
+      httpStatus: 200,
+      tokens: 42,
+      latencyMs: 12,
+    });
+    expect(
+      getDefaultAccountPool().get("ok", "anthropic-subscription")?.health,
+    ).toBe("ok");
+
+    const limited = await lease({
+      providerId: "anthropic-subscription",
+      sessionKey: "limited",
+      strategy: "priority",
+      exclude: ["ok", "revoked", "outage"],
+    });
+    await postBroker("report", {
+      leaseId: limited.leaseId,
+      ok: false,
+      httpStatus: 429,
+      errorCode: "rate_limit_exceeded",
+      retryAfterMs: 120_000,
+    });
+    expect(
+      getDefaultAccountPool().get("limited", "anthropic-subscription")?.health,
+    ).toBe("rate-limited");
+
+    const revoked = await lease({
+      providerId: "anthropic-subscription",
+      sessionKey: "revoked",
+      strategy: "priority",
+      exclude: ["ok", "limited", "outage"],
+    });
+    await postBroker("report", {
+      leaseId: revoked.leaseId,
+      ok: false,
+      httpStatus: 401,
+      errorCode: "invalid_grant",
+    });
+    expect(
+      getDefaultAccountPool().get("revoked", "anthropic-subscription")?.health,
+    ).toBe("needs-reauth");
+
+    const outage = await lease({
+      providerId: "anthropic-subscription",
+      sessionKey: "outage",
+      strategy: "priority",
+      exclude: ["ok", "limited", "revoked"],
+    });
+    await postBroker("report", {
+      leaseId: outage.leaseId,
+      ok: false,
+      httpStatus: 503,
+      errorCode: "provider_overload",
+    });
+    expect(
+      getDefaultAccountPool().get("outage", "anthropic-subscription")?.health,
+    ).toBe("ok");
+  });
+
+  it("release expires a lease for later reports", async () => {
+    writeAccount("anthropic-subscription", "primary", "token-primary");
+    const leased = await lease({
+      providerId: "anthropic-subscription",
+      sessionKey: "release-me",
+      strategy: "priority",
+    });
+    const released = await postBroker("release", {
+      leaseId: leased.leaseId,
+    });
+    expect(released.status()).toBe(200);
+    expect(released.body()).toEqual({ ok: true, released: true });
+
+    const report = await postBroker("report", {
+      leaseId: leased.leaseId,
+      ok: true,
+      httpStatus: 200,
+    });
+    expect(report.status()).toBe(404);
+    expect(report.body()).toEqual({ ok: false, error: "unknown_lease" });
+  });
+});

--- a/packages/app-core/src/api/account-pool-broker-routes.ts
+++ b/packages/app-core/src/api/account-pool-broker-routes.ts
@@ -1,0 +1,169 @@
+/**
+ * HTTP mount for the internal account-pool broker. This surface is intentionally
+ * absent unless explicitly enabled by env and is only valid for loopback peers
+ * presenting the broker bearer secret; the public chat/message routes never
+ * pass through this handler.
+ */
+import type http from "node:http";
+import { isLoopbackRemoteAddress } from "@elizaos/shared";
+import {
+  AccountPoolBroker,
+  parseBrokerLeaseRequest,
+  parseBrokerReleaseRequest,
+  parseBrokerReportRequest,
+} from "../services/account-pool-broker.js";
+import { readCompatJsonBody } from "./compat-route-shared.js";
+import { sendJson } from "./response.js";
+
+const ROUTE_PREFIX = "/internal/account-pool/v1";
+const MIN_BROKER_SECRET_LENGTH = 32;
+
+let brokerSingleton: AccountPoolBroker | null = null;
+
+export function __resetAccountPoolBrokerRoutesForTests(): void {
+  brokerSingleton = null;
+}
+
+function brokerEnabled(): boolean {
+  const enabled =
+    process.env.ELIZA_ACCOUNT_POOL_BROKER_ENABLED?.trim().toLowerCase();
+  if (
+    enabled !== "1" &&
+    enabled !== "true" &&
+    enabled !== "yes" &&
+    enabled !== "on"
+  ) {
+    return false;
+  }
+  return brokerSecret() !== null;
+}
+
+function brokerSecret(): string | null {
+  const secret = process.env.ELIZA_ACCOUNT_POOL_BROKER_SECRET?.trim();
+  return secret && secret.length >= MIN_BROKER_SECRET_LENGTH ? secret : null;
+}
+
+function readBearer(req: http.IncomingMessage): string | null {
+  const header = req.headers.authorization;
+  const raw = Array.isArray(header) ? header[0] : header;
+  if (typeof raw !== "string") return null;
+  if (!raw.toLowerCase().startsWith("bearer ")) return null;
+  return raw.slice(7).trim();
+}
+
+function safeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+function broker(): AccountPoolBroker {
+  brokerSingleton ??= new AccountPoolBroker();
+  return brokerSingleton;
+}
+
+function sendBrokerJson(
+  res: http.ServerResponse,
+  status: number,
+  body: unknown,
+): void {
+  res.setHeader("Cache-Control", "no-store");
+  sendJson(res, status, body);
+}
+
+function methodAllowed(
+  method: string,
+  expected: "GET" | "POST",
+  res: http.ServerResponse,
+): boolean {
+  if (method === expected) return true;
+  sendBrokerJson(res, 405, { ok: false, error: "method_not_allowed" });
+  return false;
+}
+
+export async function handleAccountPoolBrokerRoute(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+): Promise<boolean> {
+  const method = (req.method ?? "GET").toUpperCase();
+  const url = new URL(req.url ?? "/", "http://localhost");
+  if (!url.pathname.startsWith(ROUTE_PREFIX)) return false;
+  if (!brokerEnabled()) return false;
+
+  res.setHeader("Cache-Control", "no-store");
+
+  if (!isLoopbackRemoteAddress(req.socket.remoteAddress)) {
+    sendBrokerJson(res, 403, { ok: false, error: "loopback_only" });
+    return true;
+  }
+
+  const expected = brokerSecret();
+  const presented = readBearer(req);
+  if (!expected || !presented || !safeEqual(presented, expected)) {
+    sendBrokerJson(res, 401, { ok: false, error: "unauthorized" });
+    return true;
+  }
+
+  if (url.pathname === `${ROUTE_PREFIX}/health`) {
+    if (!methodAllowed(method, "GET", res)) return true;
+    sendBrokerJson(res, 200, broker().health());
+    return true;
+  }
+
+  if (url.pathname === `${ROUTE_PREFIX}/lease`) {
+    if (!methodAllowed(method, "POST", res)) return true;
+    const body = await readCompatJsonBody(req, res);
+    if (body === null) return true;
+    const parsed = parseBrokerLeaseRequest(body);
+    if (!parsed) {
+      sendBrokerJson(res, 400, { ok: false, error: "invalid_lease_request" });
+      return true;
+    }
+    try {
+      const lease = await broker().lease(parsed);
+      if (!lease) {
+        sendBrokerJson(res, 503, { ok: false, error: "no_account_available" });
+        return true;
+      }
+      sendBrokerJson(res, 200, lease);
+    } catch {
+      // error-policy:J1 HTTP boundary translation: token resolution failures
+      // become a structured unavailable response without exposing secrets.
+      sendBrokerJson(res, 503, { ok: false, error: "token_unavailable" });
+    }
+    return true;
+  }
+
+  if (url.pathname === `${ROUTE_PREFIX}/report`) {
+    if (!methodAllowed(method, "POST", res)) return true;
+    const body = await readCompatJsonBody(req, res);
+    if (body === null) return true;
+    const parsed = parseBrokerReportRequest(body);
+    if (!parsed) {
+      sendBrokerJson(res, 400, { ok: false, error: "invalid_report_request" });
+      return true;
+    }
+    const result = await broker().report(parsed);
+    sendBrokerJson(res, result.ok ? 200 : 404, result);
+    return true;
+  }
+
+  if (url.pathname === `${ROUTE_PREFIX}/release`) {
+    if (!methodAllowed(method, "POST", res)) return true;
+    const body = await readCompatJsonBody(req, res);
+    if (body === null) return true;
+    const parsed = parseBrokerReleaseRequest(body);
+    if (!parsed) {
+      sendBrokerJson(res, 400, { ok: false, error: "invalid_release_request" });
+      return true;
+    }
+    sendBrokerJson(res, 200, broker().release(parsed));
+    return true;
+  }
+
+  sendBrokerJson(res, 404, { ok: false, error: "not_found" });
+  return true;
+}

--- a/packages/app-core/src/api/account-pool-broker-routes.ts
+++ b/packages/app-core/src/api/account-pool-broker-routes.ts
@@ -5,6 +5,7 @@
  * pass through this handler.
  */
 import type http from "node:http";
+import type { AccountPoolBrokerSnapshot } from "@elizaos/core";
 import { isLoopbackRemoteAddress } from "@elizaos/shared";
 import {
   AccountPoolBroker,
@@ -63,6 +64,10 @@ function safeEqual(a: string, b: string): boolean {
 function broker(): AccountPoolBroker {
   brokerSingleton ??= new AccountPoolBroker();
   return brokerSingleton;
+}
+
+export function getAccountPoolBrokerSnapshot(): AccountPoolBrokerSnapshot {
+  return brokerSingleton?.snapshot() ?? { accounts: {}, providers: {} };
 }
 
 function sendBrokerJson(

--- a/packages/app-core/src/api/account-pool-broker-routes.ts
+++ b/packages/app-core/src/api/account-pool-broker-routes.ts
@@ -4,6 +4,7 @@
  * presenting the broker bearer secret; the public chat/message routes never
  * pass through this handler.
  */
+import crypto from "node:crypto";
 import type http from "node:http";
 import type { AccountPoolBrokerSnapshot } from "@elizaos/core";
 import { isLoopbackRemoteAddress } from "@elizaos/shared";
@@ -52,13 +53,13 @@ function readBearer(req: http.IncomingMessage): string | null {
   return raw.slice(7).trim();
 }
 
+// Compare fixed-length SHA-256 digests so neither content nor secret length
+// leaks through timing.
 function safeEqual(a: string, b: string): boolean {
-  if (a.length !== b.length) return false;
-  let diff = 0;
-  for (let i = 0; i < a.length; i++) {
-    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
-  }
-  return diff === 0;
+  return crypto.timingSafeEqual(
+    crypto.createHash("sha256").update(a).digest(),
+    crypto.createHash("sha256").update(b).digest(),
+  );
 }
 
 function broker(): AccountPoolBroker {

--- a/packages/app-core/src/api/internal-routes.test.ts
+++ b/packages/app-core/src/api/internal-routes.test.ts
@@ -374,6 +374,39 @@ describe("getDeviceSecret", () => {
     }
   });
 
+  it("delegates account-pool broker routes before wake handling", async () => {
+    const previousEnabled = process.env.ELIZA_ACCOUNT_POOL_BROKER_ENABLED;
+    const previousSecret = process.env.ELIZA_ACCOUNT_POOL_BROKER_SECRET;
+    process.env.ELIZA_ACCOUNT_POOL_BROKER_ENABLED = "1";
+    process.env.ELIZA_ACCOUNT_POOL_BROKER_SECRET =
+      "test-broker-secret-at-least-thirty-two-chars";
+    try {
+      const response = fakeRes();
+      const handled = await handleInternalWakeRoute(
+        fakeReq("/internal/account-pool/v1/health", {
+          method: "GET",
+          auth: "Bearer test-broker-secret-at-least-thirty-two-chars",
+        }),
+        response.res,
+        {
+          current: null,
+          pendingAgentName: null,
+          pendingRestartReasons: [],
+        },
+      );
+      expect(handled).toBe(true);
+      expect(response.status()).toBe(200);
+      expect(response.body()).toMatchObject({ ok: true });
+    } finally {
+      if (previousEnabled === undefined)
+        delete process.env.ELIZA_ACCOUNT_POOL_BROKER_ENABLED;
+      else process.env.ELIZA_ACCOUNT_POOL_BROKER_ENABLED = previousEnabled;
+      if (previousSecret === undefined)
+        delete process.env.ELIZA_ACCOUNT_POOL_BROKER_SECRET;
+      else process.env.ELIZA_ACCOUNT_POOL_BROKER_SECRET = previousSecret;
+    }
+  });
+
   it("persists generated secrets across cache resets", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-device-secret-"));
     const filePath = path.join(dir, "state", "internal", "device-secret");

--- a/packages/app-core/src/api/internal-routes.ts
+++ b/packages/app-core/src/api/internal-routes.ts
@@ -20,6 +20,7 @@ import fs from "node:fs";
 import type http from "node:http";
 import path from "node:path";
 import { resolveStateDir, type Service, ServiceType } from "@elizaos/core";
+import { handleAccountPoolBrokerRoute } from "./account-pool-broker-routes";
 import type { CompatRuntimeState } from "./compat-route-shared";
 import { readCompatJsonBody } from "./compat-route-shared";
 import { sendJson } from "./response";
@@ -208,6 +209,8 @@ export async function handleInternalWakeRoute(
   res: http.ServerResponse,
   state: CompatRuntimeState,
 ): Promise<boolean> {
+  if (await handleAccountPoolBrokerRoute(req, res)) return true;
+
   const method = (req.method ?? "GET").toUpperCase();
   const url = new URL(req.url ?? "/", "http://localhost");
 

--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -149,7 +149,6 @@ import {
   sqlLiteral,
 } from "@elizaos/shared/utils/sql-compat";
 import { buildCharacterFromConfig } from "../runtime/build-character-from-config";
-import { handleAccountPoolBrokerRoute } from "./account-pool-broker-routes";
 import { handleAuthBootstrapRoutes } from "./auth-bootstrap-routes";
 import { handleAuthPairingCompatRoutes } from "./auth-pairing-routes";
 import { handleAuthSessionRoutes } from "./auth-session-routes";
@@ -841,12 +840,6 @@ const COMPAT_ROUTE_CHAIN: readonly CompatRouteChainEntry[] = [
     id: "background-tasks",
     handler: ({ req, res, state }) =>
       handleBackgroundTasksRoute(req, res, state),
-  },
-  {
-    // Localhost-only raw account-pool lease broker. It is disabled unless
-    // explicitly env-enabled and bearer-secret configured.
-    id: "account-pool-broker",
-    handler: ({ req, res }) => handleAccountPoolBrokerRoute(req, res),
   },
   {
     // Internal wake route called by Capacitor BackgroundRunner JSContexts on

--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -149,6 +149,7 @@ import {
   sqlLiteral,
 } from "@elizaos/shared/utils/sql-compat";
 import { buildCharacterFromConfig } from "../runtime/build-character-from-config";
+import { handleAccountPoolBrokerRoute } from "./account-pool-broker-routes";
 import { handleAuthBootstrapRoutes } from "./auth-bootstrap-routes";
 import { handleAuthPairingCompatRoutes } from "./auth-pairing-routes";
 import { handleAuthSessionRoutes } from "./auth-session-routes";
@@ -840,6 +841,12 @@ const COMPAT_ROUTE_CHAIN: readonly CompatRouteChainEntry[] = [
     id: "background-tasks",
     handler: ({ req, res, state }) =>
       handleBackgroundTasksRoute(req, res, state),
+  },
+  {
+    // Localhost-only raw account-pool lease broker. It is disabled unless
+    // explicitly env-enabled and bearer-secret configured.
+    id: "account-pool-broker",
+    handler: ({ req, res }) => handleAccountPoolBrokerRoute(req, res),
   },
   {
     // Internal wake route called by Capacitor BackgroundRunner JSContexts on

--- a/packages/app-core/src/runtime/install-agent-host-bridge.test.ts
+++ b/packages/app-core/src/runtime/install-agent-host-bridge.test.ts
@@ -29,6 +29,7 @@ describe("installAgentHostBridge", () => {
     expect(bridge).not.toBe(defaultAgentHostBridge);
     expect(typeof bridge.runVaultBootstrap).toBe("function");
     expect(typeof bridge.getDefaultAccountPool).toBe("function");
+    expect(typeof bridge.getAccountPoolBrokerSnapshot).toBe("function");
     expect(typeof bridge.sharedVault).toBe("function");
     expect(typeof bridge.getBuildVariant).toBe("function");
     expect(typeof bridge.handleCloudPairRoute).toBe("function");

--- a/packages/app-core/src/runtime/install-agent-host-bridge.ts
+++ b/packages/app-core/src/runtime/install-agent-host-bridge.ts
@@ -18,6 +18,7 @@ import {
   setAgentHostBridge,
 } from "@elizaos/agent/runtime/host-bridge";
 import { getBuildVariant, isStoreBuild } from "@elizaos/core";
+import { getAccountPoolBrokerSnapshot } from "../api/account-pool-broker-routes";
 import { resolveAuthorizedRouteRole } from "../api/auth";
 import { handleCloudPairRoute } from "../api/cloud-pair-route";
 import {
@@ -41,6 +42,7 @@ export function installAgentHostBridge(): void {
     runVaultBootstrap,
     sharedVault,
     getDefaultAccountPool,
+    getAccountPoolBrokerSnapshot,
     applyAccountPoolApiCredentials: (options) =>
       applyAccountPoolApiCredentials(options),
     startAccountPoolKeepAlive: () => startAccountPoolKeepAlive(),

--- a/packages/app-core/src/services/account-pool-broker.test.ts
+++ b/packages/app-core/src/services/account-pool-broker.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Unit tests for broker lease lifetime behavior that is awkward to exercise
+ * through HTTP without sleeping. A minimal fake AccountPool drives the broker
+ * while a deterministic clock advances past the bounded TTL.
+ */
+import type { LinkedAccountConfig } from "@elizaos/shared";
+import { describe, expect, it, vi } from "vitest";
+import type { AccountPool } from "./account-pool.js";
+import { AccountPoolBroker } from "./account-pool-broker.js";
+
+function account(
+  overrides: Partial<LinkedAccountConfig> = {},
+): LinkedAccountConfig {
+  return {
+    id: "primary",
+    providerId: "anthropic-subscription",
+    label: "primary",
+    source: "oauth",
+    enabled: true,
+    priority: 0,
+    createdAt: 1,
+    health: "ok",
+    ...overrides,
+  };
+}
+
+describe("AccountPoolBroker TTL", () => {
+  it("expires leases and reports them as expired instead of mutating accounts", async () => {
+    let now = 1_000;
+    const recordCall = vi.fn(async () => {});
+    const pool = {
+      select: vi.fn(async () => account()),
+      recordCall,
+      markHealthy: vi.fn(async () => {}),
+      markRateLimited: vi.fn(async () => {}),
+      markNeedsReauth: vi.fn(async () => {}),
+      list: vi.fn(() => [account()]),
+    } as unknown as AccountPool;
+    const broker = new AccountPoolBroker({
+      pool,
+      now: () => now,
+      leaseTtlMs: 1_000,
+      idGenerator: () => "lease-1",
+      tokenResolver: async () => ({
+        accessToken: "access",
+        accessExpiresAt: 10_000,
+      }),
+    });
+
+    const lease = await broker.lease({
+      providerId: "anthropic-subscription",
+      sessionKey: "session",
+      strategy: "priority",
+    });
+    expect(lease?.leaseId).toBe("lease-1");
+    now = 2_001;
+
+    await expect(
+      broker.report({ leaseId: "lease-1", ok: true, httpStatus: 200 }),
+    ).resolves.toEqual({ ok: false, error: "expired_lease" });
+    expect(recordCall).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app-core/src/services/account-pool-broker.test.ts
+++ b/packages/app-core/src/services/account-pool-broker.test.ts
@@ -61,3 +61,232 @@ describe("AccountPoolBroker TTL", () => {
     expect(recordCall).not.toHaveBeenCalled();
   });
 });
+
+describe("AccountPoolBroker observability", () => {
+  it("attributes leases with hashed session keys and updates model from reports", async () => {
+    let now = 10_000;
+    const pool = {
+      select: vi.fn(async () => account({ id: "primary" })),
+      recordCall: vi.fn(async () => {}),
+      markHealthy: vi.fn(async () => {}),
+      markRateLimited: vi.fn(async () => {}),
+      markNeedsReauth: vi.fn(async () => {}),
+      list: vi.fn(() => [account({ id: "primary" })]),
+    } as unknown as AccountPool;
+    const broker = new AccountPoolBroker({
+      pool,
+      now: () => now,
+      idGenerator: () => "lease-primary",
+      tokenResolver: async () => ({
+        accessToken: "access",
+        accessExpiresAt: 20_000,
+      }),
+    });
+
+    const lease = await broker.lease({
+      providerId: "anthropic-subscription",
+      sessionKey: "raw-session-key",
+      strategy: "least-used",
+    });
+    expect(lease?.leaseId).toBe("lease-primary");
+    now += 5;
+    await broker.report({
+      leaseId: "lease-primary",
+      ok: true,
+      httpStatus: 200,
+      model: "claude-fable-5",
+    });
+
+    const snapshot = broker.snapshot();
+    const observed = snapshot.accounts["anthropic-subscription:primary"];
+    expect(observed).toMatchObject({
+      activeLeaseCount: 1,
+      lastLeaseAt: 10_000,
+      lastReportedStatus: {
+        ok: true,
+        category: "ok",
+        reason: "ok",
+        model: "claude-fable-5",
+      },
+    });
+    expect(observed?.lastLease).toMatchObject({
+      leaseId: "lease-primary",
+      atMs: 10_000,
+      model: "claude-fable-5",
+    });
+    expect(observed?.lastLease?.sessionKeyHash).toMatch(/^[a-f0-9]{12}$/);
+    expect(observed?.lastLease?.sessionKeyHash).not.toContain("raw-session");
+    expect(snapshot.providers["anthropic-subscription"]?.lastSelection).toEqual(
+      {
+        accountId: "primary",
+        atMs: 10_000,
+        reason: "least-used",
+      },
+    );
+  });
+
+  it("records failover only for a different account within sixty seconds", async () => {
+    let now = 1_000;
+    let nextAccountId = "a";
+    let leaseIndex = 0;
+    const pool = {
+      select: vi.fn(async () => account({ id: nextAccountId })),
+      recordCall: vi.fn(async () => {}),
+      markHealthy: vi.fn(async () => {}),
+      markRateLimited: vi.fn(async () => {}),
+      markNeedsReauth: vi.fn(async () => {}),
+      list: vi.fn(() => [account({ id: "a" }), account({ id: "b" })]),
+    } as unknown as AccountPool;
+    const broker = new AccountPoolBroker({
+      pool,
+      now: () => now,
+      idGenerator: () => `lease-${++leaseIndex}`,
+      tokenResolver: async () => ({
+        accessToken: "access",
+        accessExpiresAt: 100_000,
+      }),
+    });
+
+    const first = await broker.lease({
+      providerId: "anthropic-subscription",
+      sessionKey: "same-session",
+    });
+    await broker.report({
+      leaseId: first?.leaseId ?? "",
+      ok: false,
+      httpStatus: 429,
+      errorCode: "quota exceeded for user@example.com token sk-secret",
+      model: "claude-fable-5",
+    });
+    nextAccountId = "a";
+    now += 1_000;
+    await broker.lease({
+      providerId: "anthropic-subscription",
+      sessionKey: "same-session",
+    });
+    expect(
+      broker.snapshot().providers["anthropic-subscription"]?.recentFailovers,
+    ).toEqual([]);
+
+    const recovered = await broker.lease({
+      providerId: "anthropic-subscription",
+      sessionKey: "recovered-session",
+    });
+    await broker.report({
+      leaseId: recovered?.leaseId ?? "",
+      ok: false,
+      httpStatus: 500,
+    });
+    await broker.report({ leaseId: recovered?.leaseId ?? "", ok: true });
+    broker.release({ leaseId: recovered?.leaseId ?? "" });
+    nextAccountId = "b";
+    now += 1_000;
+    await broker.lease({
+      providerId: "anthropic-subscription",
+      sessionKey: "recovered-session",
+    });
+    expect(
+      broker.snapshot().providers["anthropic-subscription"]?.recentFailovers,
+    ).toEqual([]);
+
+    const second = await broker.lease({
+      providerId: "anthropic-subscription",
+      sessionKey: "same-session-2",
+    });
+    await broker.report({
+      leaseId: second?.leaseId ?? "",
+      ok: false,
+      httpStatus: 500,
+      errorCode: "upstream_timeout",
+    });
+    nextAccountId = "b";
+    now += 60_001;
+    await broker.lease({
+      providerId: "anthropic-subscription",
+      sessionKey: "same-session-2",
+    });
+    expect(
+      broker.snapshot().providers["anthropic-subscription"]?.recentFailovers,
+    ).toEqual([]);
+
+    nextAccountId = "a";
+    const third = await broker.lease({
+      providerId: "anthropic-subscription",
+      sessionKey: "same-session-3",
+    });
+    await broker.report({
+      leaseId: third?.leaseId ?? "",
+      ok: false,
+      httpStatus: 401,
+      errorCode: "refresh token revoked for user@example.com",
+    });
+    nextAccountId = "b";
+    now += 59_999;
+    await broker.lease({
+      providerId: "anthropic-subscription",
+      sessionKey: "same-session-3",
+    });
+
+    const failovers =
+      broker.snapshot().providers["anthropic-subscription"]?.recentFailovers ??
+      [];
+    expect(failovers).toHaveLength(1);
+    expect(failovers[0]).toMatchObject({
+      fromAccountId: "a",
+      toAccountId: "b",
+      cause: { category: "auth", reason: "http_401" },
+    });
+    expect(JSON.stringify(failovers[0])).not.toContain("user@example.com");
+    expect(JSON.stringify(failovers[0])).not.toContain("sk-secret");
+  });
+
+  it("caps recent failovers at ten per provider", async () => {
+    let now = 1_000;
+    let nextAccountId = "a";
+    let leaseIndex = 0;
+    const pool = {
+      select: vi.fn(async () => account({ id: nextAccountId })),
+      recordCall: vi.fn(async () => {}),
+      markHealthy: vi.fn(async () => {}),
+      markRateLimited: vi.fn(async () => {}),
+      markNeedsReauth: vi.fn(async () => {}),
+      list: vi.fn(() => [account({ id: "a" }), account({ id: "b" })]),
+    } as unknown as AccountPool;
+    const broker = new AccountPoolBroker({
+      pool,
+      now: () => now,
+      idGenerator: () => `lease-${++leaseIndex}`,
+      tokenResolver: async () => ({
+        accessToken: "access",
+        accessExpiresAt: 100_000,
+      }),
+    });
+
+    for (let i = 0; i < 12; i++) {
+      nextAccountId = "a";
+      const leased = await broker.lease({
+        providerId: "anthropic-subscription",
+        sessionKey: `session-${i}`,
+      });
+      await broker.report({
+        leaseId: leased?.leaseId ?? "",
+        ok: false,
+        httpStatus: 503,
+      });
+      nextAccountId = "b";
+      now += 1_000;
+      await broker.lease({
+        providerId: "anthropic-subscription",
+        sessionKey: `session-${i}`,
+      });
+      now += 1_000;
+    }
+
+    const failovers =
+      broker.snapshot().providers["anthropic-subscription"]?.recentFailovers ??
+      [];
+    expect(failovers).toHaveLength(10);
+    expect(failovers[0]?.atMs).toBe(6_000);
+    expect(failovers[9]?.atMs).toBe(24_000);
+  });
+});

--- a/packages/app-core/src/services/account-pool-broker.ts
+++ b/packages/app-core/src/services/account-pool-broker.ts
@@ -450,20 +450,19 @@ export class AccountPoolBroker {
       return { ok: false, error: "expired_lease" };
     }
     const reportAt = this.now();
-    if (report.model) {
-      lease.model = report.model;
-      const state = this.ensureAccountObservability(
-        lease.providerId,
-        lease.accountId,
-      );
-      if (state.lastLease?.leaseId === lease.leaseId) {
-        state.lastLease = { ...state.lastLease, model: report.model };
-      }
-    }
     const observability = this.ensureAccountObservability(
       lease.providerId,
       lease.accountId,
     );
+    if (report.model) {
+      lease.model = report.model;
+      if (observability.lastLease?.leaseId === lease.leaseId) {
+        observability.lastLease = {
+          ...observability.lastLease,
+          model: report.model,
+        };
+      }
+    }
     const successPredatesFailure =
       report.ok &&
       observability.lastFailureAtMs !== null &&

--- a/packages/app-core/src/services/account-pool-broker.ts
+++ b/packages/app-core/src/services/account-pool-broker.ts
@@ -4,9 +4,16 @@
  * mutation to the canonical AccountPool and credential store; callers receive
  * short-lived access tokens but never refresh tokens or display identities.
  */
-import { randomBytes } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import { getAccessToken } from "@elizaos/auth/credentials";
 import { logger } from "@elizaos/core";
+import type {
+  AccountPoolBrokerAccountSnapshot,
+  AccountPoolBrokerFailoverSnapshot,
+  AccountPoolBrokerLastReportedStatus,
+  AccountPoolBrokerProviderSnapshot,
+  AccountPoolBrokerSnapshot,
+} from "@elizaos/core";
 import type { LinkedAccountUsage } from "@elizaos/shared/contracts/service-routing";
 import { isLinkedAccountProviderId } from "@elizaos/shared/contracts/service-routing";
 import {
@@ -29,6 +36,8 @@ const DEFAULT_LEASE_TTL_MS = 5 * 60_000;
 const MAX_LEASE_TTL_MS = 15 * 60_000;
 const MAX_RETRY_AFTER_MS = 60 * 60_000;
 const DEFAULT_RATE_LIMIT_MS = 60_000;
+const FAILOVER_WINDOW_MS = 60_000;
+const MAX_RECENT_FAILOVERS = 10;
 
 export interface AccountPoolBrokerLeaseRequest {
   providerId: PoolProviderId;
@@ -68,7 +77,25 @@ interface LeaseEntry {
   providerId: PoolProviderId;
   accountId: string;
   sessionKey: string;
+  sessionKeyHash: string;
+  atMs: number;
   expiresAt: number;
+  model?: string;
+}
+
+interface AccountObservabilityState {
+  lastLease: AccountPoolBrokerAccountSnapshot["lastLease"];
+  lastReportedStatus: AccountPoolBrokerLastReportedStatus | null;
+  lastFailureAtMs: number | null;
+}
+
+interface PendingFailoverSignal {
+  providerId: PoolProviderId;
+  accountId: string;
+  sessionKeyHash: string;
+  atMs: number;
+  cause: AccountPoolBrokerFailoverSnapshot["cause"];
+  model?: string;
 }
 
 export interface AccountPoolBrokerDeps {
@@ -171,6 +198,24 @@ function makeLeaseId(): string {
   return randomBytes(32).toString("base64url");
 }
 
+function hashSessionKey(sessionKey: string): string {
+  return createHash("sha256").update(sessionKey).digest("hex").slice(0, 12);
+}
+
+function observabilityAccountKey(
+  providerId: PoolProviderId,
+  accountId: string,
+): string {
+  return `${providerId}:${accountId}`;
+}
+
+function pendingFailoverKey(
+  providerId: PoolProviderId,
+  sessionKeyHash: string,
+): string {
+  return `${providerId}:${sessionKeyHash}`;
+}
+
 function retryUntilMs(now: number, retryAfterMs: number | undefined): number {
   if (
     typeof retryAfterMs !== "number" ||
@@ -203,6 +248,62 @@ function reportIsTransient(report: AccountPoolBrokerReportRequest): boolean {
   return /\b(timeout|timed.?out|overload|unavailable|reset|network)\b/i.test(
     report.errorCode ?? "",
   );
+}
+
+function normalizeReportCause(
+  report: AccountPoolBrokerReportRequest,
+): AccountPoolBrokerFailoverSnapshot["cause"] | null {
+  // Keep this precedence aligned with report(), which applies rate-limit
+  // health before auth when a provider response ambiguously matches both.
+  if (reportIsRateLimit(report)) {
+    return {
+      category: "rate_limit",
+      reason: report.httpStatus === 429 ? "http_429" : "rate_limit",
+    };
+  }
+  if (reportIsAuthFailure(report)) {
+    return {
+      category: "auth",
+      reason:
+        report.httpStatus === 401
+          ? "http_401"
+          : report.httpStatus === 403
+            ? "http_403"
+            : "auth_failed",
+    };
+  }
+  if (reportIsTransient(report)) {
+    const status = report.httpStatus;
+    return {
+      category: "transient",
+      reason:
+        typeof status === "number" && status >= 500 && status <= 599
+          ? "http_5xx"
+          : /\b(timeout|timed.?out)\b/i.test(report.errorCode ?? "")
+            ? "timeout"
+            : /\b(network|reset)\b/i.test(report.errorCode ?? "")
+              ? "network"
+              : "transient_error",
+    };
+  }
+  return null;
+}
+
+function lastReportedStatusFromReport(
+  report: AccountPoolBrokerReportRequest,
+  atMs: number,
+): AccountPoolBrokerLastReportedStatus {
+  const failoverCause = normalizeReportCause(report);
+  return {
+    atMs,
+    ok: report.ok,
+    category: report.ok ? "ok" : (failoverCause?.category ?? "other"),
+    reason: report.ok ? "ok" : (failoverCause?.reason ?? "error"),
+    ...(typeof report.httpStatus === "number"
+      ? { httpStatus: report.httpStatus }
+      : {}),
+    ...(report.model ? { model: report.model } : {}),
+  };
 }
 
 export async function resolveBrokerAccessToken(
@@ -247,6 +348,22 @@ export class AccountPoolBroker {
   private readonly leaseTtlMs: number;
   private readonly byLeaseId = new Map<string, LeaseEntry>();
   private readonly bySessionKey = new Map<string, string>();
+  private readonly accountObservability = new Map<
+    string,
+    AccountObservabilityState
+  >();
+  private readonly lastSelectionByProvider = new Map<
+    PoolProviderId,
+    NonNullable<AccountPoolBrokerProviderSnapshot["lastSelection"]>
+  >();
+  private readonly recentFailoversByProvider = new Map<
+    PoolProviderId,
+    AccountPoolBrokerFailoverSnapshot[]
+  >();
+  private readonly pendingFailoversBySession = new Map<
+    string,
+    PendingFailoverSignal
+  >();
 
   constructor(deps: AccountPoolBrokerDeps = {}) {
     this.pool = deps.pool ?? getDefaultAccountPool();
@@ -269,7 +386,9 @@ export class AccountPoolBroker {
     const account =
       pinned &&
       pinned.providerId === request.providerId &&
-      !exclude.has(pinned.accountId)
+      !exclude.has(pinned.accountId) &&
+      (!configured.accountIds ||
+        configured.accountIds.includes(pinned.accountId))
         ? await this.pool.select({
             providerId: request.providerId,
             sessionKey: request.sessionKey,
@@ -291,15 +410,19 @@ export class AccountPoolBroker {
     const token = await this.tokenResolver(request.providerId, selected.id);
     const leaseId = this.idGenerator();
     const leaseExpiresAt = now + this.leaseTtlMs;
+    const sessionKeyHash = hashSessionKey(request.sessionKey);
     const lease: LeaseEntry = {
       leaseId,
       providerId: request.providerId,
       accountId: selected.id,
       sessionKey: request.sessionKey,
+      sessionKeyHash,
+      atMs: now,
       expiresAt: leaseExpiresAt,
     };
     this.byLeaseId.set(leaseId, lease);
     this.bySessionKey.set(request.sessionKey, leaseId);
+    this.observeLease(lease, request.strategy ?? configured.strategy);
 
     return {
       leaseId,
@@ -326,6 +449,32 @@ export class AccountPoolBroker {
       this.deleteLease(lease);
       return { ok: false, error: "expired_lease" };
     }
+    const reportAt = this.now();
+    if (report.model) {
+      lease.model = report.model;
+      const state = this.ensureAccountObservability(
+        lease.providerId,
+        lease.accountId,
+      );
+      if (state.lastLease?.leaseId === lease.leaseId) {
+        state.lastLease = { ...state.lastLease, model: report.model };
+      }
+    }
+    const observability = this.ensureAccountObservability(
+      lease.providerId,
+      lease.accountId,
+    );
+    const successPredatesFailure =
+      report.ok &&
+      observability.lastFailureAtMs !== null &&
+      lease.atMs <= observability.lastFailureAtMs;
+    if (!successPredatesFailure) {
+      observability.lastReportedStatus = lastReportedStatusFromReport(
+        report,
+        reportAt,
+      );
+    }
+    if (!report.ok) observability.lastFailureAtMs = reportAt;
 
     await this.pool.recordCall(
       lease.accountId,
@@ -342,10 +491,35 @@ export class AccountPoolBroker {
     );
 
     if (report.ok) {
-      await this.pool.markHealthy(lease.accountId, {
-        providerId: lease.providerId,
-      });
+      const pendingKey = pendingFailoverKey(
+        lease.providerId,
+        lease.sessionKeyHash,
+      );
+      const pending = this.pendingFailoversBySession.get(pendingKey);
+      if (pending?.accountId === lease.accountId) {
+        this.pendingFailoversBySession.delete(pendingKey);
+      }
+      if (!successPredatesFailure) {
+        await this.pool.markHealthy(lease.accountId, {
+          providerId: lease.providerId,
+        });
+      }
       return { ok: true };
+    }
+
+    const failoverCause = normalizeReportCause(report);
+    if (failoverCause) {
+      this.pendingFailoversBySession.set(
+        pendingFailoverKey(lease.providerId, lease.sessionKeyHash),
+        {
+          providerId: lease.providerId,
+          accountId: lease.accountId,
+          sessionKeyHash: lease.sessionKeyHash,
+          atMs: reportAt,
+          cause: failoverCause,
+          ...(report.model ? { model: report.model } : {}),
+        },
+      );
     }
 
     if (reportIsRateLimit(report)) {
@@ -394,11 +568,21 @@ export class AccountPoolBroker {
       total: number;
       enabled: number;
       selectable: number;
+      lastSelection: AccountPoolBrokerProviderSnapshot["lastSelection"];
     }>;
     activeLeases: number;
+    accounts: Record<
+      string,
+      {
+        activeLeaseCount: number;
+        lastLeaseAt: number | null;
+        lastReportedStatus: AccountPoolBrokerLastReportedStatus | null;
+      }
+    >;
   } {
     this.pruneExpired();
     const now = this.now();
+    const snapshot = this.snapshot();
     const providers = new Set<PoolProviderId>(
       this.pool.list().map((account) => account.providerId),
     );
@@ -406,12 +590,23 @@ export class AccountPoolBroker {
       ok: true,
       enabled: true,
       activeLeases: this.byLeaseId.size,
+      accounts: Object.fromEntries(
+        Object.entries(snapshot.accounts).map(([accountId, account]) => [
+          accountId,
+          {
+            activeLeaseCount: account.activeLeaseCount,
+            lastLeaseAt: account.lastLeaseAt,
+            lastReportedStatus: account.lastReportedStatus,
+          },
+        ]),
+      ),
       providers: [...providers].sort().map((providerId) => {
         const accounts = this.pool.list(providerId);
         return {
           providerId,
           total: accounts.length,
           enabled: accounts.filter((account) => account.enabled).length,
+          lastSelection: this.lastSelectionByProvider.get(providerId) ?? null,
           selectable: accounts.filter(
             (account) =>
               account.enabled &&
@@ -423,6 +618,115 @@ export class AccountPoolBroker {
         };
       }),
     };
+  }
+
+  snapshot(): AccountPoolBrokerSnapshot {
+    this.pruneExpired();
+    const activeCounts = new Map<string, number>();
+    for (const lease of this.byLeaseId.values()) {
+      const key = observabilityAccountKey(lease.providerId, lease.accountId);
+      activeCounts.set(key, (activeCounts.get(key) ?? 0) + 1);
+    }
+
+    const accounts: AccountPoolBrokerSnapshot["accounts"] = {};
+    for (const account of this.pool.list()) {
+      const key = observabilityAccountKey(account.providerId, account.id);
+      const state = this.accountObservability.get(key);
+      accounts[key] = {
+        activeLeaseCount: activeCounts.get(key) ?? 0,
+        lastLease: state?.lastLease ?? null,
+        lastLeaseAt: state?.lastLease?.atMs ?? null,
+        lastReportedStatus: state?.lastReportedStatus ?? null,
+      };
+    }
+    for (const [key, state] of this.accountObservability) {
+      accounts[key] ??= {
+        activeLeaseCount: activeCounts.get(key) ?? 0,
+        lastLease: state.lastLease,
+        lastLeaseAt: state.lastLease?.atMs ?? null,
+        lastReportedStatus: state.lastReportedStatus,
+      };
+    }
+
+    const providerIds = new Set<PoolProviderId>([
+      ...this.pool.list().map((account) => account.providerId),
+      ...this.lastSelectionByProvider.keys(),
+      ...this.recentFailoversByProvider.keys(),
+    ]);
+    const providers: AccountPoolBrokerSnapshot["providers"] = {};
+    for (const providerId of providerIds) {
+      providers[providerId] = {
+        lastSelection: this.lastSelectionByProvider.get(providerId) ?? null,
+        recentFailovers: [
+          ...(this.recentFailoversByProvider.get(providerId) ?? []),
+        ],
+      };
+    }
+    return { accounts, providers };
+  }
+
+  private observeLease(lease: LeaseEntry, reason: string | undefined): void {
+    const state = this.ensureAccountObservability(
+      lease.providerId,
+      lease.accountId,
+    );
+    state.lastLease = {
+      leaseId: lease.leaseId,
+      atMs: lease.atMs,
+      sessionKeyHash: lease.sessionKeyHash,
+      ...(lease.model ? { model: lease.model } : {}),
+    };
+    this.lastSelectionByProvider.set(lease.providerId, {
+      accountId: lease.accountId,
+      atMs: lease.atMs,
+      reason: reason ?? "priority",
+    });
+
+    const pendingKey = pendingFailoverKey(
+      lease.providerId,
+      lease.sessionKeyHash,
+    );
+    const pending = this.pendingFailoversBySession.get(pendingKey);
+    if (!pending) return;
+    this.pendingFailoversBySession.delete(pendingKey);
+    if (
+      pending.accountId === lease.accountId ||
+      lease.atMs - pending.atMs > FAILOVER_WINDOW_MS
+    ) {
+      return;
+    }
+    const failover: AccountPoolBrokerFailoverSnapshot = {
+      atMs: lease.atMs,
+      providerId: lease.providerId,
+      sessionKeyHash: lease.sessionKeyHash,
+      fromAccountId: pending.accountId,
+      toAccountId: lease.accountId,
+      cause: pending.cause,
+      ...(pending.model ? { model: pending.model } : {}),
+    };
+    const recent = this.recentFailoversByProvider.get(lease.providerId) ?? [];
+    recent.push(failover);
+    this.recentFailoversByProvider.set(
+      lease.providerId,
+      recent.slice(-MAX_RECENT_FAILOVERS),
+    );
+  }
+
+  private ensureAccountObservability(
+    providerId: PoolProviderId,
+    accountId: string,
+  ): AccountObservabilityState {
+    const key = observabilityAccountKey(providerId, accountId);
+    let state = this.accountObservability.get(key);
+    if (!state) {
+      state = {
+        lastLease: null,
+        lastReportedStatus: null,
+        lastFailureAtMs: null,
+      };
+      this.accountObservability.set(key, state);
+    }
+    return state;
   }
 
   private resolveSessionPin(sessionKey: string): LeaseEntry | null {
@@ -448,6 +752,11 @@ export class AccountPoolBroker {
     const now = this.now();
     for (const lease of this.byLeaseId.values()) {
       if (lease.expiresAt <= now) this.deleteLease(lease);
+    }
+    for (const [sessionKey, pending] of this.pendingFailoversBySession) {
+      if (now - pending.atMs > FAILOVER_WINDOW_MS) {
+        this.pendingFailoversBySession.delete(sessionKey);
+      }
     }
   }
 }

--- a/packages/app-core/src/services/account-pool-broker.ts
+++ b/packages/app-core/src/services/account-pool-broker.ts
@@ -1,0 +1,453 @@
+/**
+ * Localhost-only account-pool lease broker for same-host compatibility shims.
+ * It delegates selection, token resolution, usage accounting, and health
+ * mutation to the canonical AccountPool and credential store; callers receive
+ * short-lived access tokens but never refresh tokens or display identities.
+ */
+import { randomBytes } from "node:crypto";
+import { getAccessToken } from "@elizaos/auth/credentials";
+import { logger } from "@elizaos/core";
+import type { LinkedAccountUsage } from "@elizaos/shared/contracts/service-routing";
+import { isLinkedAccountProviderId } from "@elizaos/shared/contracts/service-routing";
+import {
+  type AccountPool,
+  getDefaultAccountPool,
+  type PoolProviderId,
+  type Strategy,
+  selectionForProvider,
+} from "./account-pool.js";
+import {
+  claudeMinRemainingMs,
+  resolveClaudeExpectedRunMs,
+} from "./claude-token-refresh.js";
+import {
+  adoptRotatedCodexTokens,
+  isAuthFailure,
+} from "./coding-account-bridge.js";
+
+const DEFAULT_LEASE_TTL_MS = 5 * 60_000;
+const MAX_LEASE_TTL_MS = 15 * 60_000;
+const MAX_RETRY_AFTER_MS = 60 * 60_000;
+const DEFAULT_RATE_LIMIT_MS = 60_000;
+
+export interface AccountPoolBrokerLeaseRequest {
+  providerId: PoolProviderId;
+  sessionKey: string;
+  strategy?: Strategy;
+  exclude?: string[];
+}
+
+export interface AccountPoolBrokerReportRequest {
+  leaseId: string;
+  ok: boolean;
+  httpStatus?: number;
+  errorCode?: string;
+  retryAfterMs?: number;
+  tokens?: number;
+  latencyMs?: number;
+  model?: string;
+}
+
+export interface AccountPoolBrokerReleaseRequest {
+  leaseId: string;
+}
+
+export interface AccountPoolBrokerLeaseResponse {
+  leaseId: string;
+  providerId: PoolProviderId;
+  accountId: string;
+  accessToken: string;
+  accessExpiresAt: number;
+  leaseExpiresAt: number;
+  usage?: LinkedAccountUsage;
+  chatgptAccountId?: string;
+}
+
+interface LeaseEntry {
+  leaseId: string;
+  providerId: PoolProviderId;
+  accountId: string;
+  sessionKey: string;
+  expiresAt: number;
+}
+
+export interface AccountPoolBrokerDeps {
+  pool?: AccountPool;
+  now?: () => number;
+  tokenResolver?: typeof resolveBrokerAccessToken;
+  idGenerator?: () => string;
+  leaseTtlMs?: number;
+}
+
+function normalizeLeaseTtlMs(value: number | undefined): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return DEFAULT_LEASE_TTL_MS;
+  }
+  return Math.min(Math.max(1_000, value), MAX_LEASE_TTL_MS);
+}
+
+function readLeaseTtlFromEnv(): number {
+  const raw = process.env.ELIZA_ACCOUNT_POOL_BROKER_LEASE_TTL_MS;
+  if (!raw) return DEFAULT_LEASE_TTL_MS;
+  return normalizeLeaseTtlMs(Number(raw));
+}
+
+function isStrategy(value: unknown): value is Strategy {
+  return (
+    value === "priority" ||
+    value === "round-robin" ||
+    value === "least-used" ||
+    value === "quota-aware" ||
+    value === "reset-soonest"
+  );
+}
+
+function parseStringArray(value: unknown): string[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) return undefined;
+  if (!value.every((item) => typeof item === "string")) return undefined;
+  const out = value.map((item) => (item as string).trim()).filter(Boolean);
+  return out;
+}
+
+export function parseBrokerLeaseRequest(
+  body: Record<string, unknown>,
+): AccountPoolBrokerLeaseRequest | null {
+  const providerId = body.providerId;
+  const sessionKey = body.sessionKey;
+  if (!isLinkedAccountProviderId(providerId)) return null;
+  if (typeof sessionKey !== "string" || !sessionKey.trim()) return null;
+  const strategy = body.strategy;
+  if (strategy !== undefined && !isStrategy(strategy)) return null;
+  const exclude = parseStringArray(body.exclude);
+  if (body.exclude !== undefined && exclude === undefined) return null;
+  return {
+    providerId,
+    sessionKey: sessionKey.trim(),
+    ...(strategy ? { strategy } : {}),
+    ...(exclude ? { exclude } : {}),
+  };
+}
+
+export function parseBrokerReportRequest(
+  body: Record<string, unknown>,
+): AccountPoolBrokerReportRequest | null {
+  if (typeof body.leaseId !== "string" || !body.leaseId.trim()) return null;
+  if (typeof body.ok !== "boolean") return null;
+  const out: AccountPoolBrokerReportRequest = {
+    leaseId: body.leaseId.trim(),
+    ok: body.ok,
+  };
+  for (const key of [
+    "httpStatus",
+    "retryAfterMs",
+    "tokens",
+    "latencyMs",
+  ] as const) {
+    const value = body[key];
+    if (value === undefined) continue;
+    if (typeof value !== "number" || !Number.isFinite(value)) return null;
+    out[key] = value;
+  }
+  for (const key of ["errorCode", "model"] as const) {
+    const value = body[key];
+    if (value === undefined) continue;
+    if (typeof value !== "string") return null;
+    const trimmed = value.trim();
+    if (trimmed) out[key] = trimmed.slice(0, 128);
+  }
+  return out;
+}
+
+export function parseBrokerReleaseRequest(
+  body: Record<string, unknown>,
+): AccountPoolBrokerReleaseRequest | null {
+  return typeof body.leaseId === "string" && body.leaseId.trim()
+    ? { leaseId: body.leaseId.trim() }
+    : null;
+}
+
+function makeLeaseId(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+function retryUntilMs(now: number, retryAfterMs: number | undefined): number {
+  if (
+    typeof retryAfterMs !== "number" ||
+    !Number.isFinite(retryAfterMs) ||
+    retryAfterMs <= 0
+  ) {
+    return now + DEFAULT_RATE_LIMIT_MS;
+  }
+  return now + Math.min(retryAfterMs, MAX_RETRY_AFTER_MS);
+}
+
+function reportIsAuthFailure(report: AccountPoolBrokerReportRequest): boolean {
+  if (report.httpStatus === 401 || report.httpStatus === 403) return true;
+  return report.errorCode ? isAuthFailure(report.errorCode) : false;
+}
+
+function reportIsRateLimit(report: AccountPoolBrokerReportRequest): boolean {
+  if (report.httpStatus === 429) return true;
+  return /rate.?limit|quota|subscription/i.test(report.errorCode ?? "");
+}
+
+function reportIsTransient(report: AccountPoolBrokerReportRequest): boolean {
+  if (
+    typeof report.httpStatus === "number" &&
+    report.httpStatus >= 500 &&
+    report.httpStatus <= 599
+  ) {
+    return true;
+  }
+  return /\b(timeout|timed.?out|overload|unavailable|reset|network)\b/i.test(
+    report.errorCode ?? "",
+  );
+}
+
+export async function resolveBrokerAccessToken(
+  providerId: PoolProviderId,
+  accountId: string,
+): Promise<{ accessToken: string; accessExpiresAt: number }> {
+  if (providerId === "openai-codex") {
+    try {
+      await adoptRotatedCodexTokens(accountId);
+    } catch (err) {
+      // error-policy:J7 Codex token adoption is a repair step before canonical
+      // token resolution; getAccessToken below remains the observed boundary.
+      logger.warn(
+        `[AccountPoolBroker] Codex token adoption failed for account ${accountId}: ${String(err)}`,
+      );
+    }
+  }
+  const opts =
+    providerId === "anthropic-subscription"
+      ? {
+          minRemainingMs: claudeMinRemainingMs(
+            resolveClaudeExpectedRunMs((key) => process.env[key]),
+          ),
+          outcome: true as const,
+        }
+      : { outcome: true as const };
+  const outcome = await getAccessToken(providerId, accountId, opts);
+  if (!outcome.ok) {
+    throw new Error(`token_resolve_failed:${outcome.kind}`);
+  }
+  return {
+    accessToken: outcome.accessToken,
+    accessExpiresAt: outcome.expiresAt,
+  };
+}
+
+export class AccountPoolBroker {
+  private readonly pool: AccountPool;
+  private readonly now: () => number;
+  private readonly tokenResolver: typeof resolveBrokerAccessToken;
+  private readonly idGenerator: () => string;
+  private readonly leaseTtlMs: number;
+  private readonly byLeaseId = new Map<string, LeaseEntry>();
+  private readonly bySessionKey = new Map<string, string>();
+
+  constructor(deps: AccountPoolBrokerDeps = {}) {
+    this.pool = deps.pool ?? getDefaultAccountPool();
+    this.now = deps.now ?? Date.now;
+    this.tokenResolver = deps.tokenResolver ?? resolveBrokerAccessToken;
+    this.idGenerator = deps.idGenerator ?? makeLeaseId;
+    this.leaseTtlMs = normalizeLeaseTtlMs(
+      deps.leaseTtlMs ?? readLeaseTtlFromEnv(),
+    );
+  }
+
+  async lease(
+    request: AccountPoolBrokerLeaseRequest,
+  ): Promise<AccountPoolBrokerLeaseResponse | null> {
+    this.pruneExpired();
+    const now = this.now();
+    const exclude = new Set(request.exclude ?? []);
+    const pinned = this.resolveSessionPin(request.sessionKey);
+    const configured = selectionForProvider(request.providerId);
+    const account =
+      pinned &&
+      pinned.providerId === request.providerId &&
+      !exclude.has(pinned.accountId)
+        ? await this.pool.select({
+            providerId: request.providerId,
+            sessionKey: request.sessionKey,
+            strategy: request.strategy ?? configured.strategy,
+            accountIds: [pinned.accountId],
+          })
+        : null;
+    const selected =
+      account ??
+      (await this.pool.select({
+        providerId: request.providerId,
+        sessionKey: request.sessionKey,
+        strategy: request.strategy ?? configured.strategy,
+        ...(configured.accountIds ? { accountIds: configured.accountIds } : {}),
+        exclude: request.exclude,
+      }));
+    if (!selected) return null;
+
+    const token = await this.tokenResolver(request.providerId, selected.id);
+    const leaseId = this.idGenerator();
+    const leaseExpiresAt = now + this.leaseTtlMs;
+    const lease: LeaseEntry = {
+      leaseId,
+      providerId: request.providerId,
+      accountId: selected.id,
+      sessionKey: request.sessionKey,
+      expiresAt: leaseExpiresAt,
+    };
+    this.byLeaseId.set(leaseId, lease);
+    this.bySessionKey.set(request.sessionKey, leaseId);
+
+    return {
+      leaseId,
+      providerId: request.providerId,
+      accountId: selected.id,
+      accessToken: token.accessToken,
+      accessExpiresAt: token.accessExpiresAt,
+      leaseExpiresAt,
+      ...(selected.usage ? { usage: selected.usage } : {}),
+      ...(request.providerId === "openai-codex" && selected.organizationId
+        ? { chatgptAccountId: selected.organizationId }
+        : {}),
+    };
+  }
+
+  async report(
+    report: AccountPoolBrokerReportRequest,
+  ): Promise<
+    { ok: true } | { ok: false; error: "unknown_lease" | "expired_lease" }
+  > {
+    const lease = this.byLeaseId.get(report.leaseId);
+    if (!lease) return { ok: false, error: "unknown_lease" };
+    if (lease.expiresAt <= this.now()) {
+      this.deleteLease(lease);
+      return { ok: false, error: "expired_lease" };
+    }
+
+    await this.pool.recordCall(
+      lease.accountId,
+      {
+        ok: report.ok,
+        ...(report.tokens !== undefined ? { tokens: report.tokens } : {}),
+        ...(report.latencyMs !== undefined
+          ? { latencyMs: report.latencyMs }
+          : {}),
+        ...(report.errorCode ? { errorCode: report.errorCode } : {}),
+        ...(report.model ? { model: report.model } : {}),
+      },
+      { providerId: lease.providerId },
+    );
+
+    if (report.ok) {
+      await this.pool.markHealthy(lease.accountId, {
+        providerId: lease.providerId,
+      });
+      return { ok: true };
+    }
+
+    if (reportIsRateLimit(report)) {
+      await this.pool.markRateLimited(
+        lease.accountId,
+        retryUntilMs(this.now(), report.retryAfterMs),
+        report.errorCode ?? "rate_limited",
+        { providerId: lease.providerId },
+      );
+      this.deleteLease(lease);
+      return { ok: true };
+    }
+
+    if (reportIsAuthFailure(report)) {
+      await this.pool.markNeedsReauth(
+        lease.accountId,
+        report.errorCode ?? "auth_failed",
+        { providerId: lease.providerId },
+      );
+      this.deleteLease(lease);
+      return { ok: true };
+    }
+
+    if (reportIsTransient(report)) {
+      return { ok: true };
+    }
+
+    return { ok: true };
+  }
+
+  release(request: AccountPoolBrokerReleaseRequest): {
+    ok: true;
+    released: boolean;
+  } {
+    const lease = this.byLeaseId.get(request.leaseId);
+    if (!lease) return { ok: true, released: false };
+    this.deleteLease(lease);
+    return { ok: true, released: true };
+  }
+
+  health(): {
+    ok: true;
+    enabled: true;
+    providers: Array<{
+      providerId: PoolProviderId;
+      total: number;
+      enabled: number;
+      selectable: number;
+    }>;
+    activeLeases: number;
+  } {
+    this.pruneExpired();
+    const now = this.now();
+    const providers = new Set<PoolProviderId>(
+      this.pool.list().map((account) => account.providerId),
+    );
+    return {
+      ok: true,
+      enabled: true,
+      activeLeases: this.byLeaseId.size,
+      providers: [...providers].sort().map((providerId) => {
+        const accounts = this.pool.list(providerId);
+        return {
+          providerId,
+          total: accounts.length,
+          enabled: accounts.filter((account) => account.enabled).length,
+          selectable: accounts.filter(
+            (account) =>
+              account.enabled &&
+              (account.health === "ok" ||
+                (account.health === "rate-limited" &&
+                  typeof account.healthDetail?.until === "number" &&
+                  account.healthDetail.until < now)),
+          ).length,
+        };
+      }),
+    };
+  }
+
+  private resolveSessionPin(sessionKey: string): LeaseEntry | null {
+    const leaseId = this.bySessionKey.get(sessionKey);
+    if (!leaseId) return null;
+    const lease = this.byLeaseId.get(leaseId);
+    if (!lease || lease.expiresAt <= this.now()) {
+      if (lease) this.deleteLease(lease);
+      else this.bySessionKey.delete(sessionKey);
+      return null;
+    }
+    return lease;
+  }
+
+  private deleteLease(lease: LeaseEntry): void {
+    this.byLeaseId.delete(lease.leaseId);
+    if (this.bySessionKey.get(lease.sessionKey) === lease.leaseId) {
+      this.bySessionKey.delete(lease.sessionKey);
+    }
+  }
+
+  private pruneExpired(): void {
+    const now = this.now();
+    for (const lease of this.byLeaseId.values()) {
+      if (lease.expiresAt <= now) this.deleteLease(lease);
+    }
+  }
+}

--- a/packages/core/src/account-pool-bridge.ts
+++ b/packages/core/src/account-pool-bridge.ts
@@ -196,3 +196,61 @@ export function setCodingAgentSelectorBridge(
 		delete slot[CODING_AGENT_SELECTOR_BRIDGE_SYMBOL];
 	}
 }
+
+/* ---------------------- Account-pool broker snapshot --------------------- */
+
+export interface AccountPoolBrokerLastLease {
+	leaseId: string;
+	atMs: number;
+	sessionKeyHash: string;
+	model?: string;
+}
+
+export interface AccountPoolBrokerLastReportedStatus {
+	atMs: number;
+	ok: boolean;
+	category: "ok" | "auth" | "rate_limit" | "transient" | "other";
+	reason: string;
+	httpStatus?: number;
+	model?: string;
+}
+
+export interface AccountPoolBrokerAccountSnapshot {
+	activeLeaseCount: number;
+	lastLease: AccountPoolBrokerLastLease | null;
+	lastLeaseAt: number | null;
+	lastReportedStatus: AccountPoolBrokerLastReportedStatus | null;
+}
+
+export interface AccountPoolBrokerProviderLastSelection {
+	accountId: string;
+	atMs: number;
+	reason: string;
+}
+
+export interface AccountPoolBrokerFailoverSnapshot {
+	atMs: number;
+	providerId: string;
+	sessionKeyHash: string;
+	fromAccountId: string;
+	toAccountId: string;
+	cause: {
+		category: "auth" | "rate_limit" | "transient";
+		reason: string;
+	};
+	model?: string;
+}
+
+export interface AccountPoolBrokerProviderSnapshot {
+	lastSelection: AccountPoolBrokerProviderLastSelection | null;
+	recentFailovers: AccountPoolBrokerFailoverSnapshot[];
+}
+
+export interface AccountPoolBrokerSnapshot {
+	accounts: Record<string, AccountPoolBrokerAccountSnapshot>;
+	providers: Record<string, AccountPoolBrokerProviderSnapshot>;
+}
+
+export function emptyAccountPoolBrokerSnapshot(): AccountPoolBrokerSnapshot {
+	return { accounts: {}, providers: {} };
+}


### PR DESCRIPTION
## Summary

- ships the localhost-only, bearer-gated account-pool lease broker because the prerequisite broker branch was not present on `develop`
- attributes each lease with an opaque id, timestamp, model, and SHA-256 session-key prefix while keeping raw session keys and credentials out of observability responses
- exposes active lease counts, last lease/report status, provider last-selection state, and a bounded ten-entry failover history through broker health and `/api/accounts`
- derives failovers only when a 401/403, 429/quota, or transient report is followed by a different-account lease for the same provider/session within 60 seconds
- preserves configured account pins, avoids stale parallel successes clearing newer failure state, and leaves UI labels/selection semantics unchanged

## Testing

- `bunx vitest run src/services/account-pool-broker.test.ts src/api/account-pool-broker-routes.test.ts src/api/internal-routes.test.ts src/runtime/install-agent-host-bridge.test.ts` in `packages/app-core` (30 passed)
- `bunx vitest run test/api/accounts-routes.test.ts src/runtime/host-bridge.test.ts` in `packages/agent` (22 passed)
- `bun run typecheck` in `packages/app-core`, `packages/agent`, and `packages/core`
- focused Biome checks and `git diff --check`
- changed-source coverage gate: 71.21% mean, 52.67% minimum, threshold 50%
- Codex review run before push; report-cause precedence, provider-scoped pending failovers, concurrent-success health clearing, configured pin drift, and test fixture findings were fixed

<!-- pr-evidence:start -->
## PR Evidence

### Logs and validation

| Artifact | Receipt |
|---|---|
| Backend behavior | [Focused Vitest receipt](https://github.com/0xSolace/eliza/releases/download/pr-account-lease-observability-evidence-v1/backend-tests.log) |
| Validation | [Final validation receipt](https://github.com/0xSolace/eliza/releases/download/pr-account-lease-observability-evidence-v1/final-validation.log) |
| Coverage | [Changed-source coverage gate receipt](https://github.com/0xSolace/eliza/releases/download/pr-account-lease-observability-evidence-v1/coverage-gate.log) |

### Manual checks

- [x] Broker endpoints remain disabled by default, loopback-only, bearer-gated, and `Cache-Control: no-store`.
- [x] New snapshots expose no refresh token, access token, email, or raw session key.
- [x] Same-account retries and failovers outside 60 seconds do not create events; history is capped at ten.
- [x] No UI components or user-visible labels changed.
<!-- pr-evidence:end -->

## Evidence rows

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only API and in-memory observability change; no rendered UI changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only API and in-memory observability change; no rendered UI changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - deterministic backend route and broker behavior covered by focused tests

<!-- evidence-row:backend-logs -->
- [x] [backend-tests.log](https://github.com/0xSolace/eliza/releases/download/pr-account-lease-observability-evidence-v1/backend-tests.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic account routing and observability logic; no LLM-driven behavior changed

<!-- evidence-row:domain-artifacts -->
- [x] [coverage-gate.log](https://github.com/0xSolace/eliza/releases/download/pr-account-lease-observability-evidence-v1/coverage-gate.log)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered UI or screenshots in this backend-only PR


## Scope notes

- Leases are **non-exclusive**: the broker attributes usage and observes lease lifecycles but does not lock an account to a single holder; concurrent leases on the same account are expected.
- The broker endpoints have no in-repo consumer yet — the first consumer lands in PR #16399 (pending).
