### PR TITLE
fix(lifeops): surface active delegation contracts to the planner provider

### DIFF
--- a/plugins/plugin-personal-assistant/test/delegation-contracts.test.ts
+++ b/plugins/plugin-personal-assistant/test/delegation-contracts.test.ts
@@ -274,9 +274,16 @@ describe("delegation contract repository", () => {
     const { runtime } = runtimeResult;
     await LifeOpsRepository.bootstrapSchema(runtime);
     const repo = new LifeOpsRepository(runtime);
+    // The provider queries the active window against wall-clock `new Date()`
+    // (delegation-contracts.ts), so the fixture must straddle the current
+    // instant rather than an absolute date that silently expires.
+    const nowMs = Date.now();
     await repo.upsertDelegationContract(
       createLifeOpsDelegationContractRecord({
-        ...vendorContract(),
+        ...vendorContract({
+          createdAt: new Date(nowMs - 60 * 60 * 1000).toISOString(),
+          expiresAt: new Date(nowMs + 7 * 24 * 60 * 60 * 1000).toISOString(),
+        }),
         agentId: runtime.agentId,
         metadata: { sourceThread: "gmail:thread-vendor-1" },
       }),


### PR DESCRIPTION
# Relates to

Fixes a deterministic, pre-existing failure on `develop` in
`plugins/plugin-personal-assistant/test/delegation-contracts.test.ts`
(`> surfaces active contracts to the planner provider`). Not caused by a merge —
a time-bomb fixture whose hardcoded `expiresAt` (2026-07-13) simply lapsed.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`.
- [x] `bun install` was run; the delegation suites pass post-sync (see below).
- [x] A reviewer can confirm the change works without reading the code, from the
      before/after test output below.

# Sync with develop

- [x] Based on the current `origin/develop` tip; zero conflicts.
- [x] Delegation suites pass post-sync (full-repo `bun run verify` not run — this
      is a one-line test-fixture change with no production-code surface; see
      **Known gaps / failures**).

# Risks

Low. The change is confined to a single test fixture in one `it(...)` block. It
touches no production code and no other test. The evaluator and repository tests
that assert against fixed timestamps are deliberately left unchanged.

# Background

## What does this PR do?

Anchors the delegation-contract fixture in the *"surfaces active contracts to the
planner provider"* test to wall-clock `Date.now()` instead of an absolute
`expiresAt` of `2026-07-13T16:00:00.000Z`.

Root cause: the `delegationContracts` provider
(`src/providers/delegation-contracts.ts`) queries
`listDelegationContracts(..., { statuses: ["active"], activeAtIso: new Date().toISOString() })`.
`listDelegationContracts` (`src/lifeops/repository.ts`) filters the active window
with `created_at <= now AND expires_at >= now`. Once the fixture's `expiresAt`
(2026-07-13) passed, the filter *correctly* excluded the contract as expired, so
the provider returned its designed empty result and the assertion
`expect(result.text).toContain("Active delegation contracts:")` failed. The
sibling *"persists active thread contracts"* test passes because it queries with
an explicit in-window `activeAtIso: "2026-07-06T16:30:00.000Z"`, and the
evaluator tests pass because they inject an explicit `nowIso` — only the provider
test depends on wall-clock now.

The provider behavior is correct: surfacing an *expired* delegation contract to
the planner would be the real bug, and the active-window filter is exercised and
depended upon by the sibling repository test. So the fix belongs in the stale
fixture, not the implementation. The fixture now straddles the current instant
(`createdAt = now - 1h`, `expiresAt = now + 7d`), which durably exercises the
real wall-clock provider path and can never silently expire again.

## What kind of change is this?

Bug fixes (repairs a deterministic time-bomb test failure).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-personal-assistant/test/delegation-contracts.test.ts`, the
`surfaces active contracts to the planner provider` case.

## Detailed testing steps

```bash
cd plugins/plugin-personal-assistant
bunx vitest run test/delegation-contracts.test.ts --reporter=dot
```

Before this change: 5 passed, 1 failed. After: 6 passed. All three delegation
suites (`delegation-contracts`, `delegation-contracts-event`,
`delegation-contracts-inbound`) pass: 13/13.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend provider + test only, no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend provider + test only, no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend provider + test only, no rendered UI surface.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic repository/provider unit test; no long-lived service emits `[ClassName]` logs. The red-before / green-after `bunx vitest run` output is in the `<details>` block under "Backend + frontend logs".
<!-- evidence-row:frontend-logs -->
- [x] N/A - backend provider + test only, no rendered UI surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic provider unit test, no live-model behavior change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - test-fixture-only change; the delegation-contract DB row and the provider's rendered "Active delegation contracts:" text are asserted directly by the deterministic test shown below.

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic provider unit test, no live-model behavior change.

## Backend + frontend logs

Backend: the fix is a test-fixture change; there is no long-lived service to emit
`[ClassName]` logs. The deterministic `bunx vitest run` transition (red -> green)
is the evidence.

<details>
<summary>Before — bunx vitest run test/delegation-contracts.test.ts (fails)</summary>

```
FAIL  plugins/plugin-personal-assistant/test/delegation-contracts.test.ts > delegation contract repository > surfaces active contracts to the planner provider
AssertionError: expected '' to contain 'Active delegation contracts:'

- Expected
+ Received

- Active delegation contracts:

 ❯ plugins/plugin-personal-assistant/test/delegation-contracts.test.ts:295:25

 Test Files  1 failed (1)
      Tests  1 failed | 5 passed (6)
```
</details>

<details>
<summary>After — full delegation suite (passes)</summary>

```
bunx vitest run test/delegation-contracts.test.ts test/delegation-contracts-event.test.ts test/delegation-contracts-inbound.test.ts --reporter=dot

 Test Files  3 passed (3)
      Tests  13 passed (13)
```

```
bunx vitest run test/delegation-contracts.test.ts --reporter=dot

 Test Files  1 passed (1)
      Tests  6 passed (6)
```
</details>

Frontend: N/A - no rendered UI surface.

## Screenshots (before / after) + video walkthrough

### Before

N/A - backend provider + test only, no rendered UI surface.

### After

N/A - backend provider + test only, no rendered UI surface.

### Walkthrough video

N/A - backend provider + test only, no rendered UI surface.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT surface.

## Known gaps / failures

- Repo-wide `bun run verify` (typecheck + lint across the workspace) was not run:
  this is a one-line change to a single test fixture with no production-code
  surface, and a full-workspace verify is unrelated to it. The delegation test
  suites pass (13/13). `bun install` also produced unrelated working-tree churn
  (lockfile, generated manifests, app icons, homepage snapshots) that is NOT part
  of this PR — only the test file is committed.
