### PR TITLE
fix(plugin-cli-inference): apply biome formatting

### DIFF
--- a/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
@@ -6,8 +6,8 @@
  * so no real model runs; the few real-binary cases are skipped unless
  * `claude`/`codex` resolve through the SOC2 allowlist on this box.
  */
-import type { ChatMessage, PluginAutoEnableContext } from "@elizaos/core";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ChatMessage, IAgentRuntime, PluginAutoEnableContext } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { shouldEnable } from "../auto-enable";
 import {
   buildModelMetadata,
@@ -18,6 +18,7 @@ import {
   cliInferencePlugin,
   LARGE_TIER_MODEL_TYPES,
   resolveCliBackend,
+  resolveSdkEffort,
 } from "../index";
 import {
   __setSpawnForTests as __setClaudeSpawn,
@@ -699,6 +700,70 @@ describe("reasoning effort (SDK effort option)", () => {
     await session.generate("hi");
     expect(captured && "effort" in captured).toBe(false);
     await session.dispose();
+  });
+});
+
+describe("resolveSdkEffort (per-tier effort env precedence)", () => {
+  // getSetting() falls back to process.env when the runtime returns undefined,
+  // so a stray ambient value would defeat the "unset" cases. Clear both keys and
+  // drive resolution purely off the fake runtime's settings map.
+  const prev = {
+    effort: process.env.ELIZA_CLI_CLAUDE_EFFORT,
+    planner: process.env.ELIZA_CLI_CLAUDE_PLANNER_EFFORT,
+  };
+  beforeEach(() => {
+    delete process.env.ELIZA_CLI_CLAUDE_EFFORT;
+    delete process.env.ELIZA_CLI_CLAUDE_PLANNER_EFFORT;
+  });
+  afterEach(() => {
+    if (prev.effort === undefined) delete process.env.ELIZA_CLI_CLAUDE_EFFORT;
+    else process.env.ELIZA_CLI_CLAUDE_EFFORT = prev.effort;
+    if (prev.planner === undefined) delete process.env.ELIZA_CLI_CLAUDE_PLANNER_EFFORT;
+    else process.env.ELIZA_CLI_CLAUDE_PLANNER_EFFORT = prev.planner;
+  });
+
+  const runtimeWith = (settings: Record<string, string>): IAgentRuntime =>
+    ({ getSetting: (key: string) => settings[key] }) as unknown as IAgentRuntime;
+
+  it("reply tier (router=false) reads ELIZA_CLI_CLAUDE_EFFORT", () => {
+    const runtime = runtimeWith({ ELIZA_CLI_CLAUDE_EFFORT: "high" });
+    expect(resolveSdkEffort(runtime, false)).toBe("high");
+  });
+
+  it("reply tier ignores the planner override even when it is set", () => {
+    const runtime = runtimeWith({
+      ELIZA_CLI_CLAUDE_EFFORT: "medium",
+      ELIZA_CLI_CLAUDE_PLANNER_EFFORT: "max",
+    });
+    expect(resolveSdkEffort(runtime, false)).toBe("medium");
+  });
+
+  it("planner tier (router=true) prefers ELIZA_CLI_CLAUDE_PLANNER_EFFORT", () => {
+    const runtime = runtimeWith({
+      ELIZA_CLI_CLAUDE_EFFORT: "low",
+      ELIZA_CLI_CLAUDE_PLANNER_EFFORT: "max",
+    });
+    expect(resolveSdkEffort(runtime, true)).toBe("max");
+  });
+
+  it("planner tier falls back to the shared ELIZA_CLI_CLAUDE_EFFORT when its own key is unset", () => {
+    const runtime = runtimeWith({ ELIZA_CLI_CLAUDE_EFFORT: "high" });
+    expect(resolveSdkEffort(runtime, true)).toBe("high");
+  });
+
+  it("returns undefined for both tiers when no effort is configured (SDK keeps its default)", () => {
+    const runtime = runtimeWith({});
+    expect(resolveSdkEffort(runtime, false)).toBeUndefined();
+    expect(resolveSdkEffort(runtime, true)).toBeUndefined();
+  });
+
+  it("passes an unrecognized level through unvalidated — validation is normalizeEffort's job at the session", () => {
+    // resolveSdkEffort only resolves precedence; the session's normalizeEffort
+    // (tested above) drops unknown levels. Keeping the two concerns split means a
+    // bad env never silently downgrades a valid per-tier override.
+    const runtime = runtimeWith({ ELIZA_CLI_CLAUDE_EFFORT: "ultra" });
+    expect(resolveSdkEffort(runtime, false)).toBe("ultra");
+    expect(normalizeEffort(resolveSdkEffort(runtime, false))).toBeNull();
   });
 });
 

--- a/plugins/plugin-cli-inference/index.ts
+++ b/plugins/plugin-cli-inference/index.ts
@@ -154,10 +154,7 @@ function claudeSessionKey(model: string, systemPrompt: string, router: boolean):
  * to the SDK default (high) when unset. Validation lives in the session
  * (normalizeEffort) so an unknown value is dropped, never forwarded.
  */
-function resolveSdkEffort(
-  runtime: IAgentRuntime,
-  router: boolean,
-): string | undefined {
+function resolveSdkEffort(runtime: IAgentRuntime, router: boolean): string | undefined {
   const shared = getSetting(runtime, "ELIZA_CLI_CLAUDE_EFFORT");
   if (router) {
     return getSetting(runtime, "ELIZA_CLI_CLAUDE_PLANNER_EFFORT") ?? shared;

--- a/plugins/plugin-cli-inference/index.ts
+++ b/plugins/plugin-cli-inference/index.ts
@@ -154,7 +154,7 @@ function claudeSessionKey(model: string, systemPrompt: string, router: boolean):
  * to the SDK default (high) when unset. Validation lives in the session
  * (normalizeEffort) so an unknown value is dropped, never forwarded.
  */
-function resolveSdkEffort(runtime: IAgentRuntime, router: boolean): string | undefined {
+export function resolveSdkEffort(runtime: IAgentRuntime, router: boolean): string | undefined {
   const shared = getSetting(runtime, "ELIZA_CLI_CLAUDE_EFFORT");
   if (router) {
     return getSetting(runtime, "ELIZA_CLI_CLAUDE_PLANNER_EFFORT") ?? shared;

--- a/plugins/plugin-cli-inference/src/claude-sdk-session.ts
+++ b/plugins/plugin-cli-inference/src/claude-sdk-session.ts
@@ -230,13 +230,7 @@ async function loadZod(): Promise<ZodModule> {
 }
 
 /** Effort levels the Agent SDK's `effort` option accepts (== `claude --effort`). */
-const VALID_EFFORT_LEVELS: ReadonlySet<string> = new Set([
-  "low",
-  "medium",
-  "high",
-  "xhigh",
-  "max",
-]);
+const VALID_EFFORT_LEVELS: ReadonlySet<string> = new Set(["low", "medium", "high", "xhigh", "max"]);
 
 /**
  * Validate a caller-supplied effort string. Unknown values are dropped (return


### PR DESCRIPTION
# Summary

The `develop` **Quality (Extended)** CI lane's *Format + Type Safety Ratchet → Run biome format check* step fails on exactly one package:

```
@elizaos/plugin-cli-inference#format:check  ->  exited (1)
```

Two files in `plugins/plugin-cli-inference/` drifted out of biome format:

- `plugins/plugin-cli-inference/index.ts` — `resolveSdkEffort(...)` signature was split across four lines; biome 2.5.1 collapses it to one line that fits the width limit.
- `plugins/plugin-cli-inference/src/claude-sdk-session.ts` — the `VALID_EFFORT_LEVELS` `Set([...])` literal was split one-element-per-line; biome collapses it to a single line.

This PR runs the package's own write-formatter (`bunx @biomejs/biome format --write .` via the repo-pinned biome **2.5.1**, from the `overrides` block in the root `package.json`) scoped to `plugins/plugin-cli-inference/` only. The format change is **whitespace-only** — no logic, no tokens, no behavior change.

After the fix, the repo-wide `bun run format:check -- --continue` reports **239 / 240 packages passing**, with `@elizaos/plugin-cli-inference#format:check` now green.

### Coverage gate (`coverage on changed files`)

Because the format change touched two source files, the `Require changed tests for changed source` ratchet (issue #9943) demanded a changed unit test. This PR adds one: it **exports `resolveSdkEffort`** (in `index.ts`) and adds a focused `describe("resolveSdkEffort (per-tier effort env precedence)")` block to the existing suite `__tests__/cli-inference.test.ts` that exercises the previously-untested per-tier effort precedence — the reply tier reads `ELIZA_CLI_CLAUDE_EFFORT` (and ignores the planner override), the planner tier prefers `ELIZA_CLI_CLAUDE_PLANNER_EFFORT` and falls back to the shared key, both tiers return `undefined` when unset, and an unknown level passes through unvalidated (validation stays in the session's `normalizeEffort`, which the suite already covers). This covers the previously-uncovered `router=true` branch, and the two changed files clear the 50%/file floor: `index.ts` **67.76%**, `src/claude-sdk-session.ts` **62.11%** (mean 64.94%, threshold 50%). Suite: **49 passed** (was 43).

> Note (out of scope): the one remaining repo-wide format failure is `@elizaos/ui#format:check` on `packages/ui/src/components/accounts/AccountManagementPanel.test.tsx`, unrelated develop drift introduced by #16314 (merged 2026-07-14). That is a different package (a surface `.tsx`) and belongs in its own PR; it is intentionally not bundled here to keep this diff a clean plugin-`.ts` format-only change.

# Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - formatting-only change to plugin TypeScript, no UI surface or model behavior`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - formatting-only change to plugin TypeScript, no UI surface or model behavior`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - formatting-only change to plugin TypeScript, no UI surface or model behavior`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - a plugin format + unit-test change has no server runtime path; the format:check, test, and coverage-gate transcripts below are the mechanical proof.`

<details>
<summary>format:check, unit test, and coverage-gate transcripts (biome 2.5.1, scoped to plugins/plugin-cli-inference)</summary>

```
# BEFORE — cd plugins/plugin-cli-inference && bun run format:check
index.ts format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  × Formatter would have printed the following content:
src/claude-sdk-session.ts format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  × Formatter would have printed the following content:
Checked 20 files in 8ms. No fixes applied.
Found 2 errors.
error: script "format:check" exited with code 1   # exit 1

# WRITE-FORMAT — bun run format  (scoped to plugins/plugin-cli-inference)
$ bunx @biomejs/biome format --write .
Formatted 20 files in 8ms. Fixed 2 files.

# AFTER — cd plugins/plugin-cli-inference && bun run format:check
$ bunx @biomejs/biome format .
Checked 20 files in 8ms. No fixes applied.   # exit 0

# REPO-WIDE — bun run format:check -- --continue
 Tasks:    239 successful, 240 total
Failed:    @elizaos/ui#format:check   # unrelated develop drift (#16314), out of scope

# UNIT TEST — bunx vitest run __tests__/cli-inference.test.ts
 Test Files  1 passed (1)
      Tests  49 passed (49)   # +6 new resolveSdkEffort precedence cases

# COVERAGE GATE — reproduced locally (node run-changed-vitest-coverage.mjs + coverage-gate.awk, threshold 50)
   67.76% plugins/plugin-cli-inference/index.ts
   62.11% plugins/plugin-cli-inference/src/claude-sdk-session.ts
changed files: 2, mean coverage: 64.94%, threshold: 50%
coverage gate OK
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - formatting-only change to plugin TypeScript, no UI surface or model behavior`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - formatting-only change to plugin TypeScript, no UI surface or model behavior`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - formatting-only change to plugin TypeScript, no UI surface or model behavior`

## Notes

- biome version is the repo-pinned **2.5.1** (`overrides["@biomejs/biome"]` in root `package.json`); not bumped.
- Diff is 3 `.ts` files under a plugin (2 whitespace-only, plus 1 test file + a one-keyword `export`), none a surface `.tsx`, so the surface-artifact screenshot sub-gate does not apply.
- The only non-format change is adding `export` to `resolveSdkEffort` so the new unit test can drive it directly; runtime model/agent behavior is unchanged, so the trajectory/screenshot rows remain N/A.
