### PR TITLE
fix(ui): apply biome formatting to account panel test

### DIFF
--- a/packages/ui/src/components/accounts/AccountManagementPanel.test.tsx
+++ b/packages/ui/src/components/accounts/AccountManagementPanel.test.tsx
@@ -71,9 +71,7 @@ vi.mock("./AddAccountDialog", () => ({
     credentialRepairAccount?: { id: string } | null;
   }) =>
     open ? (
-      <div role="dialog">
-        add dialog {credentialRepairAccount?.id ?? "new"}
-      </div>
+      <div role="dialog">add dialog {credentialRepairAccount?.id ?? "new"}</div>
     ) : null,
 }));
 vi.mock("./RotationStrategyPicker", () => ({


### PR DESCRIPTION
# Summary

The `develop` **Quality (Extended)** CI lane's *Format + Type Safety Ratchet → Run biome format check* step fails on `@elizaos/ui#format:check`. One file drifted out of biome format:

- `packages/ui/src/components/accounts/AccountManagementPanel.test.tsx` — a `vi.mock` returns `<div role="dialog">…</div>` that was split across three lines; biome 2.5.1 collapses it onto a single line that fits the width limit.

The file landed unformatted via #16314 (merged 2026-07-14). This PR runs the package's own write-formatter (`bunx @biomejs/biome format --write src` via the repo-pinned biome **2.5.1**, from the `overrides` block in the root `package.json`) scoped to `packages/ui` only. Only this one file was failing (`Found 1 error`); the diff is **whitespace-only** — no logic, no tokens, no behavior change.

This is a follow-up to #16358 (which greened `@elizaos/plugin-cli-inference#format:check`). Together they take the repo-wide `bun run format:check` to **240 / 240 packages passing**.

This is a `.test.tsx` (a test file), so the surface-artifact screenshot sub-gate — which applies only to non-test `.tsx` surfaces — does not apply.

# Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - formatting-only change to a test file, no UI surface or model behavior`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - formatting-only change to a test file, no UI surface or model behavior`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - formatting-only change to a test file, no UI surface or model behavior`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: `N/A - whitespace-only test-file format change has no server runtime path; the before/after biome format:check transcript below is the mechanical proof.`

<details>
<summary>before/after <code>bun run format:check</code> (biome 2.5.1, scoped to packages/ui)</summary>

```
# BEFORE — cd packages/ui && bun run format:check
src/components/accounts/AccountManagementPanel.test.tsx format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  × Formatter would have printed the following content:
Checked 2716 files in 330ms. No fixes applied.
Found 1 error.
error: script "format:check" exited with code 1   # exit 1

# WRITE-FORMAT — cd packages/ui && bun run format
$ bunx @biomejs/biome format --write src
Formatted 2716 files in 313ms. Fixed 1 file.

# AFTER — cd packages/ui && bun run format:check
$ bunx @biomejs/biome format src
Checked 2716 files in 333ms. No fixes applied.   # exit 0
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - formatting-only change to a test file, no UI surface or model behavior`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - formatting-only change to a test file, no UI surface or model behavior`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - formatting-only change to a test file, no UI surface or model behavior`

## Notes

- biome version is the repo-pinned **2.5.1** (`overrides["@biomejs/biome"]` in root `package.json`); not bumped.
- Diff is one `.test.tsx` file (whitespace-only), so the surface-artifact screenshot sub-gate does not apply.
- Coverage: a pure-format diff changes no logic and does not alter coverage.
