### PR TITLE
fix(ui): repair App navigate-view wiring useAuthStatus mock drift

### DIFF
--- a/packages/ui/src/App.navigate-view-wiring.test.tsx
+++ b/packages/ui/src/App.navigate-view-wiring.test.tsx
@@ -254,6 +254,13 @@ vi.mock("./hooks/useAuthStatus", () => ({
   // Home widgets gate their loaders on this (#11084); the mounted App renders
   // them, so the mock must export it alongside useAuthStatus.
   useIsAuthenticated: () => authStatusMock.phase === "authenticated",
+  // notification-store reads auth state outside React to gate its boot probe and
+  // re-arm hydration once a session lands (initNotifications -> requestHydration,
+  // #16242); the mounted App runs that one-time boot effect, so the mock must
+  // export both seams. Auth phase is static in these tests, so the re-arm
+  // subscription never fires — returning a no-op unsubscribe is faithful.
+  isAuthenticatedNow: () => authStatusMock.phase === "authenticated",
+  subscribeAuthStatus: () => vi.fn(),
 }));
 
 vi.mock("./utils/cloud-agent-base", async (importOriginal) => {


### PR DESCRIPTION
# Relates to

Pre-existing `develop`-tip test failure in `packages/ui/src/App.navigate-view-wiring.test.tsx` (Tests workflow reported `13 tests | 1 failed`). No linked issue; the failure was surfaced by the CI Tests lane on `develop`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] The changed file is lint-clean (`biome check` on the file) and the affected suite is green; see **Known gaps** for why a repo-wide `verify` was not run.
- [x] A reviewer can confirm the change works without reading the code, from the before/after vitest output below.

# Sync with develop

- [x] Branched from and rebased onto the latest `origin/develop` (`96b443a614d`); zero conflicts.
- [x] Affected suite passes post-sync (13/13, stable across 9 reruns). See **Known gaps** re: repo-wide `verify`.

# Risks

Low. The change is confined to a single Vitest mock factory inside one `*.test.tsx` file. `vi.mock` is file-scoped, so no other test file or any production code is affected. No runtime/UI behavior changes.

# Background

## What does this PR do?

Repairs mock drift in `App.navigate-view-wiring.test.tsx`. The single failing test — **"keeps an unauthenticated shared Cloud app inside first-run onboarding"** — threw:

```
No "isAuthenticatedNow" export is defined on the "./hooks/useAuthStatus" mock.
```

`src/state/notifications/notification-store.ts` (added for #16242) imports `isAuthenticatedNow` **and** `subscribeAuthStatus` from `../../hooks/useAuthStatus` to gate and re-arm its boot hydration probe:

- `initNotifications()` (run-once, `if (initialized) return;`) → `requestHydration()` → `notificationProbesEnabled()` → **`isAuthenticatedNow()`**;
- in the unauthenticated branch, `requestHydration()` re-arms via **`subscribeAuthStatus(...)`**.

The mounted `<App />` fires `initNotifications` once inside the `notifications-boot` effect. Because it is run-once and that effect is not wrapped by an error boundary, **only the first-executed test** (which sets `phase = "unauthenticated"`) reaches those seams and throws — so exactly **1 of 13** fails while the other 12 short-circuit at the `initialized` guard.

The test's `vi.mock("./hooks/useAuthStatus", …)` factory only exported `useAuthStatus` + `useIsAuthenticated`. This PR adds the two missing non-React seams the module actually imports, mirroring the existing `useIsAuthenticated` pattern (both derive from `authStatusMock.phase`). Auth phase is static within these tests, so the re-arm subscription never fires — a no-op unsubscribe is faithful.

## What kind of change is this?

Bug fix (repairs a broken test; no production behavior change).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

```bash
cd packages/ui && bunx vitest run src/App.navigate-view-wiring.test.tsx
```

Before: `13 tests | 1 failed`. After: `13 tests | 13 passed`, stable across 9 reruns.

## Detailed testing steps

None beyond the command above — automated unit/component test coverage. The diff is test-only.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] `N/A - test-only change (packages/ui/src/App.navigate-view-wiring.test.tsx, a *.test.tsx non-surface file). No rendered UI surface changes; the evidence gate excludes *.test.tsx from surface-artifact requirements.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - test-only change; no UI surface modified (see above).`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - test-only change; no user-facing flow changed. Evidence is the before/after Vitest output below.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - no backend/server code path changed; this is a client-side Vitest mock fix.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no runtime frontend behavior changed; the change only adds missing exports to a test mock. Vitest run output attached below.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - no DB rows, memories, scheduled tasks, wallet/on-chain output, or generated files are produced by this change.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model changes.`

## Backend + frontend logs

`N/A - no backend or runtime frontend code changed.` The proof is the Vitest result below.

## Screenshots (before / after) + video walkthrough

`N/A - test-only change to a *.test.tsx file; no rendered UI surface is modified. The CI evidence gate classifies *.test.tsx as non-surface (scripts/check-pr-evidence.mjs, SURFACE_NON_VISUAL_RE).`

### Before / After (Vitest)

<details>
<summary>Before (clean origin/develop @ 96b443a614d) — 1 of 13 failing</summary>

```
FAIL  src/App.navigate-view-wiring.test.tsx > App navigate-view event wiring > keeps an unauthenticated shared Cloud app inside first-run onboarding
Error: [vitest] No "isAuthenticatedNow" export is defined on the "./hooks/useAuthStatus" mock. Did you forget to return it from "vi.mock"?
 ❯ notificationProbesEnabled src/state/notifications/notification-store.ts:96:5
 ❯ requestHydration src/state/notifications/notification-store.ts:473:8
 ❯ initNotifications src/state/notifications/notification-store.ts:535:8
 ❯ src/components/shell/notifications-boot.tsx:26:5

 Test Files  1 failed (1)
      Tests  1 failed | 12 passed (13)
```
</details>

<details>
<summary>After (this branch) — 13 of 13 passing, stable across 9 reruns</summary>

```
 ✓ App navigate-view event wiring > keeps an unauthenticated shared Cloud app inside first-run onboarding
 ✓ App navigate-view event wiring > routes view-manager events through the mounted App listener
 ✓ App navigate-view event wiring > routes a settings subview navigate to the settings tab (#9945)
 ✓ App navigate-view event wiring > passes settings navigate payloads into SettingsView for targeted permission priming
 ✓ App navigate-view event wiring > pins remote views and opens remote view windows through App wiring
 ✓ App navigate-view event wiring > renders a remote module route through DynamicViewLoader in the mounted App
 ✓ App navigate-view event wiring > routes frame-only sandboxed views through DynamicViewLoader with frameUrl
 ✓ App navigate-view event wiring > renders no global corner back button on app routes
 ✓ App navigate-view event wiring > lets a view explicitly share the Home/Launcher background
 ✓ App navigate-view event wiring > reports user desktop-tab clicks to the agent without a navigation echo
 ✓ App navigate-view event wiring > renders split-view events as a live dynamic view layout
 ✓ App navigate-view event wiring > renders registered documents bundles inside split-view when registry wins
 ✓ App navigate-view event wiring > keeps /views on the built-in Launcher instead of the remote manager bundle

 Test Files  1 passed (1)
      Tests  13 passed (13)
```

Stability (8 consecutive reruns after the definitive run): all `13 passed (13)`.
</details>

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT changes.`

## Known gaps / failures

- Repo-wide `bun run verify` (workspace typecheck + lint) was not run in full: it is an 8 GB-heap, whole-monorepo task unrelated to this one-line-scope test fix. Instead the changed file was validated directly — `biome check src/App.navigate-view-wiring.test.tsx` is clean, and the affected suite is green 13/13 across 9 reruns. The diff adds only two properties to an existing mock object, so it cannot affect the workspace typegraph.
- All Evidence Gate rows are `N/A` because the change is confined to a `*.test.tsx` file with no rendered UI surface; the CI evidence gate does not require surface artifacts for `*.test.*` diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
