### PR TITLE
fix(ui): pin desktop settings rail outside the content scroll container

### DIFF
--- a/packages/ui/src/components/pages/SettingsView.test.tsx
+++ b/packages/ui/src/components/pages/SettingsView.test.tsx
@@ -358,12 +358,15 @@ describe("SettingsView", () => {
   }
 
   it("renders a persistent rail and default work area on a desktop viewport", () => {
-    const restore = mockMatchMedia((query) =>
-      query.includes("min-width: 1024px"),
-    );
+    const restore = mockMatchMedia((query) => query.includes("min-width:"));
     try {
       render(<SettingsView />);
-      expect(screen.getByTestId("desktop-settings-navigation")).toBeTruthy();
+      const navigation = screen.getByTestId("desktop-settings-navigation");
+      expect(navigation).toBeTruthy();
+      expect(screen.getByTestId("desktop-settings-fixed-pane")).toBeTruthy();
+      // The fixed pane is a sibling of WorkspaceLayout's scrolling <main>, not
+      // a sticky child that disappears as the section content scrolls.
+      expect(navigation.closest("main")).toBeNull();
       expect(screen.getByTestId("desktop-settings-work-area")).toBeTruthy();
       expect(screen.getByTestId("stub-identity")).toBeTruthy();
       expect(
@@ -388,6 +391,9 @@ describe("SettingsView", () => {
       expect(hubRow("identity")).toBeTruthy();
       expect(screen.queryByTestId("stub-identity")).toBeNull();
       expect(screen.getAllByTestId("view-header")).toHaveLength(1);
+      expect(
+        screen.queryByTestId("page-layout-mobile-sidebar-trigger"),
+      ).toBeNull();
     } finally {
       restore();
     }

--- a/packages/ui/src/components/pages/SettingsView.tsx
+++ b/packages/ui/src/components/pages/SettingsView.tsx
@@ -306,12 +306,24 @@ export function SettingsView({
     : settingsTitle;
   const onBack = activeSectionDef ? backToHub : navigateBackToLauncher;
   const backLabel = activeSectionDef ? "Back to Settings" : "Back to launcher";
+  const desktopSidebar = isDesktop ? (
+    <DesktopSettingsNavigation
+      grouped={grouped}
+      activeId={desktopSectionDef?.id ?? null}
+      onSelect={openSection}
+      onBack={navigateBackToLauncher}
+      settingsLabel={settingsTitle}
+      label={(labelKey, fallback) => t(labelKey, { defaultValue: fallback })}
+    />
+  ) : null;
 
   return (
     <ShellViewAgentSurface viewId="settings">
       <ContentLayout
         inModal={inModal}
         contentClassName={isDesktop ? "px-0 pt-0" : "max-sm:pt-1"}
+        sidebar={desktopSidebar}
+        sidebarCollapsible={false}
       >
         <div
           data-testid="settings-shell"
@@ -333,19 +345,6 @@ export function SettingsView({
               />
             ))}
           </div>
-
-          {isDesktop ? (
-            <DesktopSettingsNavigation
-              grouped={grouped}
-              activeId={desktopSectionDef?.id ?? null}
-              onSelect={openSection}
-              onBack={navigateBackToLauncher}
-              settingsLabel={settingsTitle}
-              label={(labelKey, fallback) =>
-                t(labelKey, { defaultValue: fallback })
-              }
-            />
-          ) : null}
 
           <div className="min-w-0 flex-1 pb-32">
             {isDesktop ? (

--- a/packages/ui/src/components/settings/DesktopSettingsNavigation.tsx
+++ b/packages/ui/src/components/settings/DesktopSettingsNavigation.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useRef } from "react";
 
 import { cn } from "../../lib/utils";
+import { Sidebar } from "../composites/sidebar";
 import { ViewBackButton } from "../shared/ViewHeader";
 import {
   type GroupedSettingsSections,
@@ -51,90 +52,97 @@ export function DesktopSettingsNavigation({
   };
 
   return (
-    <nav
-      aria-label="Settings sections"
-      data-testid="desktop-settings-navigation"
-      className="sticky top-0 flex h-fit w-60 shrink-0 flex-col gap-6 border-r border-border/60 px-3 py-6"
+    <Sidebar
+      testId="desktop-settings-fixed-pane"
+      collapsible={false}
+      className="!m-0 !h-full !w-60 !min-w-60 !rounded-none !border-0 !bg-transparent !shadow-none"
+      bodyClassName="overflow-y-auto"
     >
-      <div className="flex items-start gap-1 px-1">
-        <ViewBackButton
-          onBack={onBack}
-          label="Back to launcher"
-          className="mt-0.5 shrink-0"
-        />
-        <div className="min-w-0 pt-1">
-          <p className="text-sm font-semibold tracking-tight text-txt-strong">
-            {settingsLabel}
-          </p>
-          <p className="mt-1 text-xs leading-relaxed text-muted">
-            Agent, app, and privacy controls
-          </p>
+      <nav
+        aria-label="Settings sections"
+        data-testid="desktop-settings-navigation"
+        className="flex min-h-full w-60 shrink-0 flex-col gap-6 border-r border-border/60 px-3 py-6"
+      >
+        <div className="flex items-start gap-1 px-1">
+          <ViewBackButton
+            onBack={onBack}
+            label="Back to launcher"
+            className="mt-0.5 shrink-0"
+          />
+          <div className="min-w-0 pt-1">
+            <p className="text-sm font-semibold tracking-tight text-txt-strong">
+              {settingsLabel}
+            </p>
+            <p className="mt-1 text-xs leading-relaxed text-muted">
+              Agent, app, and privacy controls
+            </p>
+          </div>
         </div>
-      </div>
 
-      {grouped.map(({ group, label: groupLabel, items }) => (
-        <section key={group} data-testid={`desktop-settings-group-${group}`}>
-          <h2 className="mb-1 px-2 text-2xs font-medium uppercase tracking-wide text-muted/70">
-            {groupLabel}
-          </h2>
-          <div className="flex flex-col gap-0.5">
-            {items.map((section) => {
-              const Icon = section.icon;
-              const sectionLabel = label(section.label, section.defaultLabel);
-              const isActive = section.id === activeId;
+        {grouped.map(({ group, label: groupLabel, items }) => (
+          <section key={group} data-testid={`desktop-settings-group-${group}`}>
+            <h2 className="mb-1 px-2 text-2xs font-medium uppercase tracking-wide text-muted/70">
+              {groupLabel}
+            </h2>
+            <div className="flex flex-col gap-0.5">
+              {items.map((section) => {
+                const Icon = section.icon;
+                const sectionLabel = label(section.label, section.defaultLabel);
+                const isActive = section.id === activeId;
 
-              return (
-                <button
-                  key={section.id}
-                  ref={(node) => setItemRef(section.id, node)}
-                  type="button"
-                  data-testid={`desktop-settings-item-${section.id}`}
-                  aria-current={isActive ? "page" : undefined}
-                  onClick={() => onSelect(section.id)}
-                  onKeyDown={(event) => {
-                    if (event.key === "ArrowDown") {
-                      event.preventDefault();
-                      focusRelativeItem(section.id, 1);
-                    } else if (event.key === "ArrowUp") {
-                      event.preventDefault();
-                      focusRelativeItem(section.id, -1);
-                    } else if (event.key === "Enter") {
-                      event.preventDefault();
-                      onSelect(section.id);
-                    }
-                  }}
-                  className={cn(
-                    "group flex min-h-11 w-full items-center gap-2.5 rounded-md border border-transparent px-2 py-2 text-left text-sm transition-colors",
-                    "text-muted hover:bg-surface/70 hover:text-txt-strong focus-visible:border-accent/60",
-                    isActive &&
-                      "bg-accent/10 font-medium text-txt-strong hover:bg-accent/12",
-                  )}
-                >
-                  <span
-                    aria-hidden
+                return (
+                  <button
+                    key={section.id}
+                    ref={(node) => setItemRef(section.id, node)}
+                    type="button"
+                    data-testid={`desktop-settings-item-${section.id}`}
+                    aria-current={isActive ? "page" : undefined}
+                    onClick={() => onSelect(section.id)}
+                    onKeyDown={(event) => {
+                      if (event.key === "ArrowDown") {
+                        event.preventDefault();
+                        focusRelativeItem(section.id, 1);
+                      } else if (event.key === "ArrowUp") {
+                        event.preventDefault();
+                        focusRelativeItem(section.id, -1);
+                      } else if (event.key === "Enter") {
+                        event.preventDefault();
+                        onSelect(section.id);
+                      }
+                    }}
                     className={cn(
-                      "flex size-6 shrink-0 items-center justify-center rounded-md",
-                      SECTION_HUE_MEDALLION_CLASS[section.hue],
-                      !isActive && "opacity-80 group-hover:opacity-100",
+                      "group flex min-h-11 w-full items-center gap-2.5 rounded-md border border-transparent px-2 py-2 text-left text-sm transition-colors",
+                      "text-muted hover:bg-surface/70 hover:text-txt-strong focus-visible:border-accent/60",
+                      isActive &&
+                        "bg-accent/10 font-medium text-txt-strong hover:bg-accent/12",
                     )}
                   >
-                    <Icon className="size-3.5" />
-                  </span>
-                  <span className="min-w-0 flex-1 truncate">
-                    {sectionLabel}
-                  </span>
-                  {isActive ? (
                     <span
                       aria-hidden
-                      className="size-1.5 shrink-0 rounded-full bg-accent"
-                    />
-                  ) : null}
-                </button>
-              );
-            })}
-          </div>
-        </section>
-      ))}
-    </nav>
+                      className={cn(
+                        "flex size-6 shrink-0 items-center justify-center rounded-md",
+                        SECTION_HUE_MEDALLION_CLASS[section.hue],
+                        !isActive && "opacity-80 group-hover:opacity-100",
+                      )}
+                    >
+                      <Icon className="size-3.5" />
+                    </span>
+                    <span className="min-w-0 flex-1 truncate">
+                      {sectionLabel}
+                    </span>
+                    {isActive ? (
+                      <span
+                        aria-hidden
+                        className="size-1.5 shrink-0 rounded-full bg-accent"
+                      />
+                    ) : null}
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+        ))}
+      </nav>
+    </Sidebar>
   );
 }

--- a/packages/ui/src/layouts/content-layout/content-layout.tsx
+++ b/packages/ui/src/layouts/content-layout/content-layout.tsx
@@ -5,7 +5,8 @@
  * content header inside the scrollable column for single-pane pages.
  */
 
-import type { ReactNode } from "react";
+import type { ReactElement, ReactNode } from "react";
+import type { SidebarProps } from "../../components/composites/sidebar";
 import { cn } from "../../lib/utils";
 import { WorkspaceLayout } from "../workspace-layout";
 
@@ -20,6 +21,10 @@ export interface ContentLayoutProps {
   className?: string;
   /** Additional classes on the inner content wrapper. */
   contentClassName?: string;
+  /** Optional desktop workspace sidebar, forwarded to WorkspaceLayout. */
+  sidebar?: ReactElement<SidebarProps> | null;
+  /** Whether the forwarded sidebar can collapse on desktop. */
+  sidebarCollapsible?: boolean;
 }
 
 export function ContentLayout({
@@ -28,6 +33,8 @@ export function ContentLayout({
   inModal,
   className,
   contentClassName,
+  sidebar,
+  sidebarCollapsible,
 }: ContentLayoutProps) {
   return (
     <WorkspaceLayout
@@ -36,6 +43,8 @@ export function ContentLayout({
       contentHeader={contentHeader}
       contentPadding={!inModal}
       headerPlacement="inside"
+      sidebar={sidebar}
+      sidebarCollapsible={sidebarCollapsible}
     >
       {children}
     </WorkspaceLayout>


### PR DESCRIPTION
## Summary

- route the desktop settings navigation through `ContentLayout` / `WorkspaceLayout`'s sidebar slot, placing it beside rather than inside the scrollable `<main>`
- give the fixed-width rail its own vertical overflow while preserving its border, keyboard navigation, and 15rem width
- keep the existing settings hub on viewports below 1024px, without registering a mobile drawer
- add a regression assertion that the desktop navigation is not descended from the scrolling `<main>`

## Evidence

| Viewport | State | Evidence |
|---|---|---|
| 1440x1000 | Models & Providers, content scroll container forced long and scrolled 1078px; rail remains visible at `y=0` | ![Pinned desktop settings rail while content is scrolled](https://github.com/0xSolace/eliza/releases/download/evidence-settings-rail-pinned-20260714/models-providers-scrolled-1440x1000.png) |

Playwright geometry receipt:

```text
scroll main: { scrollHeight: 2424, clientHeight: 1000, scrollTop: 1078 }
rail box:    { x: 0, y: 0, width: 240, height: 1000 }
```

## Verification

```text
$ bun run --cwd packages/ui test src/components/settings/DesktopSettingsNavigation.test.tsx src/components/pages/SettingsView.test.tsx
Test Files  2 passed (2)
Tests       28 passed (28)
Duration    12.40s

$ bun run --cwd packages/ui typecheck
$ tsc --noEmit
(exit 0)

$ bunx @biomejs/biome check <4 changed files>
Checked 4 files in 20ms. No fixes applied.

$ bun run --cwd packages/ui test:settings-e2e
Desktop 1440x1000: grouped rail, switching, active state, back navigation verified
Mobile 390x844: hub -> subview -> back, no desktop rail verified
Settings e2e complete. Screenshots written to .../output-settings
```

Codex review (`gpt-5.5`): no findings.

[sol-orch]

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/0xSolace/eliza/releases/download/evidence-settings-rail-pinned-20260714/16363-before-rail-scrolls-away-1440x1000.png)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/0xSolace/eliza/releases/download/evidence-settings-rail-pinned-20260714/16363-after-rail-pinned-1440x1000.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/0xSolace/eliza/releases/download/evidence-settings-rail-pinned-20260714/16363-settings-rail-pinned-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [ ] N/A - UI-only layout change; no backend request or server path fires.

<!-- evidence-row:frontend-logs -->
- [x] [16363-frontend-logs.txt](https://github.com/0xSolace/eliza/releases/download/evidence-settings-rail-pinned-20260714/16363-frontend-logs.txt)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No agent, model, prompt, provider, or action behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - Layout-only UI fix produces no database, wallet, memory, or device artifact.

<!-- evidence-row:ocr-review -->
- [x] [16363-ocr-review.txt](https://github.com/0xSolace/eliza/releases/download/evidence-settings-rail-pinned-20260714/16363-ocr-review.txt)
