### PR TITLE
fix(ui): remove chat sheet crossfade single-frame flash flake

### DIFF
--- a/packages/ui/src/components/shell/__e2e__/run-chat-sheet-frame-glitch-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-sheet-frame-glitch-e2e.mjs
@@ -47,6 +47,7 @@ import {
   stubElizaCore,
   stubNodeBuiltins,
 } from "../../../testing/e2e-runner/esbuild-stubs.ts";
+import { detectFlashes } from "../../../testing/frame-glitch-detect.ts";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(here, "..", "..", "..", "..", "..", "..");
@@ -375,36 +376,28 @@ for (let i = 0; i < imgs.length - 1; i += 1) {
   pairDiff.push(diffCount(imgs[i], imgs[i + 1]));
 }
 
-// Detector 1 — single-frame flash.
-const FLASH_RATIO = 0.4; // neighbours must agree ≥2.5× closer than to frame k
-const NOISE = Math.max(40, 0.0002 * imgs[0].width * imgs[0].height); // ~px floor
-function neighbourDiff(k) {
-  // diff(frame k-1, frame k+1)
-  const d = diffCount(imgs[k - 1], imgs[k + 1]);
-  return d.n;
-}
-// A single-frame flash is only meaningful DURING the animation — a frame showing
-// the wrong state mid-morph, a large-diff outlier. Once the spring has settled
-// the UI is static and any 1-frame diff is sub-pixel/caret noise, not a glitch.
-// Gate on activity (in/out diff a real fraction of the peak movement) so the
-// static tail can't produce false positives.
-const ACTIVE_FRACTION = 0.25;
-function detectFlashes(diffSeq) {
-  const peak = Math.max(...diffSeq.map((d) => d.n), 1);
-  const hits = [];
-  for (let k = 1; k < imgs.length - 1; k += 1) {
-    const a = diffSeq[k - 1].n; // diff(k-1,k)
-    const b = diffSeq[k].n; // diff(k,k+1)
-    if (a < NOISE || b < NOISE) continue;
-    if (Math.max(a, b) < ACTIVE_FRACTION * peak) continue; // static tail → skip
-    const c = neighbourDiff(k); // diff(k-1,k+1)
-    if (c < FLASH_RATIO * Math.min(a, b)) {
-      hits.push({ frame: k, in: a, out: b, neighbours: c });
-    }
-  }
-  return hits;
-}
-const flashes = detectFlashes(pairDiff);
+// Detector 1 — single-frame flash (shift-tolerant; see frame-glitch-detect.ts).
+// FLASH_RATIO: neighbours must agree ≥2.5× closer with each other than either
+// does with frame k. NOISE: per-pair floor below which a change is sub-pixel/
+// caret noise. ACTIVE_FRACTION: only frames whose change is ≥25% of the burst's
+// peak motion are candidates, so the settled tail can't flash. maxShift aligns
+// away the ≤1px whole-frame scroll jog (the bottom-anchored transcript tracking
+// the open-spring's pixel settle) that a naive diff misreads as a ~17k-px flash.
+const DETECTOR_OPTIONS = {
+  maxShift: 1,
+  noise: Math.max(40, 0.0002 * imgs[0].width * imgs[0].height),
+  activeFraction: 0.25,
+  flashRatio: 0.4,
+};
+// pixelmatch over the common box, wrapped as the detector's PixelDiff. The
+// detector aligns the crops itself, so equal dims are guaranteed here.
+const pixelDiff = (a, b, w, h) => pixelmatch(a, b, null, w, h, { threshold: 0.1 });
+const rgbaFrames = imgs.map((p) => ({
+  width: p.width,
+  height: p.height,
+  data: p.data,
+}));
+const flashes = detectFlashes(rgbaFrames, pixelDiff, DETECTOR_OPTIONS);
 if (CANARY) {
   console.log(
     `  canary seed burst: ${flashes.length} product-frame candidate(s) (informational; product gate ran in the preceding step)`,
@@ -451,22 +444,16 @@ if (CANARY) {
       bad.data[idx + 3] = 255;
     }
   }
-  const cImgs = imgs.slice();
-  cImgs[k] = bad;
-  const cDiff = [];
-  for (let i = 0; i < cImgs.length - 1; i += 1)
-    cDiff.push(diffCount(cImgs[i], cImgs[i + 1]));
-  const cNeighbour = (kk) => diffCount(cImgs[kk - 1], cImgs[kk + 1]).n;
-  const cPeak = Math.max(...cDiff.map((d) => d.n), 1);
-  let canaryFlash = false;
-  for (let kk = 1; kk < cImgs.length - 1; kk += 1) {
-    const a = cDiff[kk - 1].n;
-    const b = cDiff[kk].n;
-    if (a < NOISE || b < NOISE) continue;
-    if (Math.max(a, b) < ACTIVE_FRACTION * cPeak) continue;
-    if (cNeighbour(kk) < FLASH_RATIO * Math.min(a, b)) canaryFlash = true;
-  }
-  assert(canaryFlash, "canary: flash detector FIRES on the injected bad frame");
+  // Route the injected frame through the SAME shipped detector so the canary
+  // guards the shift-tolerant metric itself: a solid block is genuine content,
+  // not a translation, so no alignment can hide it.
+  const canaryFrames = rgbaFrames.slice();
+  canaryFrames[k] = { width: bad.width, height: bad.height, data: bad.data };
+  const canaryFlashes = detectFlashes(canaryFrames, pixelDiff, DETECTOR_OPTIONS);
+  assert(
+    canaryFlashes.length > 0,
+    "canary: flash detector FIRES on the injected bad frame",
+  );
 
   // (b) Two-pills detector: inject a sample where both bars are fully visible.
   const canarySamples = [...samples, { t: 0, pill: 1, grabber: 1, state: "X" }];

--- a/packages/ui/src/testing/frame-glitch-detect.test.ts
+++ b/packages/ui/src/testing/frame-glitch-detect.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Proves the chat-sheet frame-glitch detector both ways: it must NOT flag a
+ * whole-frame sub-pixel scroll jog (the transcript tracking the open-spring's
+ * pixel settle — the ~50%-flaky false positive this metric fixes) yet must
+ * still flag a genuine one-frame wrong state. Synthetic RGBA frames + a trivial
+ * exact-pixel comparator, so the verdict math is exercised in isolation.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  detectFlashes,
+  type FlashDetectorOptions,
+  type PixelDiff,
+  type RgbaFrame,
+  shiftTolerantDiff,
+} from "./frame-glitch-detect";
+
+const W = 60;
+const H = 60;
+
+// Count pixels whose RGB differs at all — the detector is comparator-agnostic,
+// so an exact-equality count stands in for the harness's pixelmatch.
+const exactDiff: PixelDiff = (a, b, w, h) => {
+  let n = 0;
+  for (let i = 0; i < w * h; i += 1) {
+    const o = i * 4;
+    if (a[o] !== b[o] || a[o + 1] !== b[o + 1] || a[o + 2] !== b[o + 2]) n += 1;
+  }
+  return n;
+};
+
+// A texture whose colour depends only on the row, so shifting `shiftY` is an
+// exact vertical translation: a 1px jog changes every row under a naive diff
+// but aligns to zero under a 1px shift — exactly the transcript-scroll jog.
+function rowTexture(shiftY: number): RgbaFrame {
+  const data = new Uint8Array(W * H * 4);
+  for (let y = 0; y < H; y += 1) {
+    const v = ((y - shiftY) * 37) & 0xff;
+    for (let x = 0; x < W; x += 1) {
+      const o = (y * W + x) * 4;
+      data[o] = v;
+      data[o + 1] = (v * 3) & 0xff;
+      data[o + 2] = (v * 7) & 0xff;
+      data[o + 3] = 255;
+    }
+  }
+  return { width: W, height: H, data };
+}
+
+// The row texture with a solid opaque block painted in — a genuine content
+// change no small translation can undo (a mispainted morph / "two pills" frame).
+function withBlock(base: RgbaFrame): RgbaFrame {
+  const data = new Uint8Array(base.data);
+  for (let y = 15; y < 45; y += 1) {
+    for (let x = 15; x < 45; x += 1) {
+      const o = (y * W + x) * 4;
+      data[o] = 255;
+      data[o + 1] = 0;
+      data[o + 2] = 255;
+      data[o + 3] = 255;
+    }
+  }
+  return { width: W, height: H, data };
+}
+
+const OPTS: FlashDetectorOptions = {
+  maxShift: 1,
+  noise: 50,
+  activeFraction: 0.25,
+  flashRatio: 0.4,
+};
+
+describe("shiftTolerantDiff", () => {
+  it("aligns away a whole-frame 1px scroll jog to zero", () => {
+    const a = rowTexture(0);
+    const b = rowTexture(1);
+    // A 1px translation lights up (almost) every pixel under a naive diff...
+    expect(exactDiff(a.data, b.data, W, H)).toBeGreaterThan(W * (H - 1));
+    // ...but shift-tolerant alignment collapses it to zero.
+    expect(shiftTolerantDiff(a, b, exactDiff, 1)).toBe(0);
+  });
+
+  it("preserves a genuine localized content change", () => {
+    const base = rowTexture(0);
+    const blocked = withBlock(base);
+    // No 1px translation can hide the 30x30 block.
+    expect(shiftTolerantDiff(base, blocked, exactDiff, 1)).toBeGreaterThan(800);
+  });
+});
+
+describe("detectFlashes", () => {
+  it("does NOT flag a one-frame sub-pixel scroll jog (the flaky false positive)", () => {
+    const frames = [rowTexture(0), rowTexture(1), rowTexture(0)];
+    // The naive detector (maxShift 0) DOES fire on the jog — this is the bug the
+    // shift-tolerant metric fixes, asserted so the fix stays load-bearing.
+    expect(
+      detectFlashes(frames, exactDiff, { ...OPTS, maxShift: 0 }),
+    ).toHaveLength(1);
+    // Shift-tolerant: the jog aligns away, no flash.
+    expect(detectFlashes(frames, exactDiff, OPTS)).toHaveLength(0);
+  });
+
+  it("still flags a genuine one-frame wrong state", () => {
+    const base = rowTexture(0);
+    const frames = [base, withBlock(base), base];
+    const flashes = detectFlashes(frames, exactDiff, OPTS);
+    expect(flashes).toHaveLength(1);
+    expect(flashes[0].frame).toBe(1);
+    expect(flashes[0].neighbours).toBeLessThan(flashes[0].in);
+  });
+
+  it("does not flag a monotonic multi-frame drift as a one-frame flash", () => {
+    // A steady 1px-per-frame scroll is real motion, not an outlier: the two
+    // neighbours do NOT agree, so it is never a single-frame flash.
+    const frames = [rowTexture(0), rowTexture(1), rowTexture(2), rowTexture(3)];
+    expect(
+      detectFlashes(frames, exactDiff, { ...OPTS, maxShift: 0 }),
+    ).toHaveLength(0);
+    expect(detectFlashes(frames, exactDiff, OPTS)).toHaveLength(0);
+  });
+
+  it("ignores frames whose motion is below the active-fraction gate", () => {
+    // A tiny wobble that never approaches the burst's peak motion is settled-tail
+    // noise, not a flash, even if its neighbours agree.
+    const big = withBlock(rowTexture(0));
+    const frames = [
+      rowTexture(0),
+      big, // a real, large flash → sets the peak
+      rowTexture(0),
+      rowTexture(0),
+      rowTexture(0),
+    ];
+    const flashes = detectFlashes(frames, exactDiff, OPTS);
+    // Only the large block frame flashes; the flat tail contributes nothing.
+    expect(flashes.map((f) => f.frame)).toEqual([1]);
+  });
+});

--- a/packages/ui/src/testing/frame-glitch-detect.ts
+++ b/packages/ui/src/testing/frame-glitch-detect.ts
@@ -1,0 +1,159 @@
+/**
+ * Transient single-frame-flash detector for the chat-sheet frame-burst e2e —
+ * the shift-tolerant diff metric plus the one-frame outlier rule, split out of
+ * the Playwright harness (`run-chat-sheet-frame-glitch-e2e.mjs`) so the
+ * detection math is provable in isolation (`frame-glitch-detect.test.ts`),
+ * mirroring the `scroll-cert` split: a pure verdict function the harness feeds
+ * real captured frames into.
+ *
+ * WHY shift-tolerant. The chat sheet opens on a spring; the transcript is
+ * bottom-anchored, so as the panel height settles by whole pixels the entire
+ * thread tracks it and jogs ≤1px per captured frame. A naive per-pixel diff
+ * counts that whole-frame 1px jog as ~17k changed pixels — every glyph edge —
+ * even though the frames are perceptually identical. When the jog reverses
+ * within one captured frame (the spring's sub-pixel overshoot, or a dropped
+ * screencast frame), that frame differs hard from BOTH neighbours while the
+ * neighbours agree, so the outlier rule fired a false "single-frame flash" on
+ * ~50% of runs at a wandering frame index — on byte-identical code, before and
+ * after any given merge. Aligning away a small integer translation before
+ * counting collapses that jog to ~0 while leaving genuine content change (a
+ * mispainted morph frame, the "two pills" bar, an injected wrong state) fully
+ * visible, so the detector keeps its teeth (the harness `--canary` still fires)
+ * without flaking on sub-pixel scroll.
+ */
+
+/** A decoded RGBA frame: `data` is row-major RGBA, `width * height * 4` bytes. */
+export interface RgbaFrame {
+  readonly width: number;
+  readonly height: number;
+  readonly data: Uint8Array;
+}
+
+/**
+ * Counts "changed" pixels between two equal-dimension RGBA buffers. The harness
+ * injects a `pixelmatch`-backed comparator; tests inject a trivial one — the
+ * detector logic is comparator-agnostic.
+ */
+export type PixelDiff = (
+  a: Uint8Array,
+  b: Uint8Array,
+  width: number,
+  height: number,
+) => number;
+
+export interface Flash {
+  readonly frame: number;
+  /** Shift-tolerant change into frame k (diff of k-1 → k). */
+  readonly in: number;
+  /** Shift-tolerant change out of frame k (diff of k → k+1). */
+  readonly out: number;
+  /** Shift-tolerant change across frame k (diff of k-1 → k+1). */
+  readonly neighbours: number;
+}
+
+export interface FlashDetectorOptions {
+  /** Per-axis integer translation aligned away before counting (px). */
+  readonly maxShift: number;
+  /** Per-pair floor below which a change is sub-pixel/caret noise, not motion. */
+  readonly noise: number;
+  /**
+   * A frame is a flash candidate only while its in/out change is at least this
+   * fraction of the burst's peak motion — the settled tail cannot flash.
+   */
+  readonly activeFraction: number;
+  /**
+   * Flag frame k when its neighbours agree at least this much closer with each
+   * other than either does with k (`diff(k-1,k+1) < flashRatio * min(in,out)`).
+   */
+  readonly flashRatio: number;
+}
+
+/** Copies a `w`×`h` RGBA sub-rectangle out of `frame` at (`x0`,`y0`). */
+function cropRgba(
+  frame: RgbaFrame,
+  x0: number,
+  y0: number,
+  w: number,
+  h: number,
+): Uint8Array {
+  const out = new Uint8Array(w * h * 4);
+  const rowBytes = w * 4;
+  const srcStride = frame.width * 4;
+  for (let y = 0; y < h; y += 1) {
+    const srcStart = (y0 + y) * srcStride + x0 * 4;
+    out.set(frame.data.subarray(srcStart, srcStart + rowBytes), y * rowBytes);
+  }
+  return out;
+}
+
+/**
+ * Minimum `diff` over integer translations of one frame relative to the other
+ * within ±`maxShift` on each axis. A whole-frame scroll jog of ≤maxShift px
+ * aligns to ~0; a genuine wrong-state frame — not a translation — does not.
+ *
+ * The unshifted overlap is tried first and short-circuits on a zero count, so
+ * the settled tail (identical consecutive frames) costs one comparison and only
+ * the handful of genuinely-moving frames pay for the full search.
+ */
+export function shiftTolerantDiff(
+  a: RgbaFrame,
+  b: RgbaFrame,
+  diff: PixelDiff,
+  maxShift: number,
+): number {
+  const commonW = Math.min(a.width, b.width);
+  const commonH = Math.min(a.height, b.height);
+  let best = Number.POSITIVE_INFINITY;
+  // (0,0) first so aligned frames early-out before the ring is searched.
+  for (let radius = 0; radius <= maxShift; radius += 1) {
+    for (let dy = -radius; dy <= radius; dy += 1) {
+      for (let dx = -radius; dx <= radius; dx += 1) {
+        if (Math.max(Math.abs(dx), Math.abs(dy)) !== radius) continue;
+        const w = commonW - Math.abs(dx);
+        const h = commonH - Math.abs(dy);
+        const aCrop = cropRgba(a, dx > 0 ? dx : 0, dy > 0 ? dy : 0, w, h);
+        const bCrop = cropRgba(b, dx < 0 ? -dx : 0, dy < 0 ? -dy : 0, w, h);
+        const n = diff(aCrop, bCrop, w, h);
+        if (n < best) best = n;
+        if (best === 0) return 0;
+      }
+    }
+  }
+  return best;
+}
+
+/**
+ * Flags frames that show a wrong state for exactly one frame mid-animation: a
+ * large shift-tolerant change into AND out of frame k while its two neighbours
+ * agree closely with each other. Uses shift-tolerant change throughout so a
+ * whole-frame sub-pixel scroll jog is not mistaken for a flash.
+ */
+export function detectFlashes(
+  frames: readonly RgbaFrame[],
+  diff: PixelDiff,
+  options: FlashDetectorOptions,
+): Flash[] {
+  const { maxShift, noise, activeFraction, flashRatio } = options;
+  const step: number[] = [];
+  for (let i = 0; i < frames.length - 1; i += 1) {
+    step.push(shiftTolerantDiff(frames[i], frames[i + 1], diff, maxShift));
+  }
+  const peak = Math.max(...step, 1);
+  const hits: Flash[] = [];
+  for (let k = 1; k < frames.length - 1; k += 1) {
+    const into = step[k - 1];
+    const outOf = step[k];
+    if (into < noise || outOf < noise) continue;
+    if (Math.max(into, outOf) < activeFraction * peak) continue;
+    const across = shiftTolerantDiff(
+      frames[k - 1],
+      frames[k + 1],
+      diff,
+      maxShift,
+    );
+    if (across < flashRatio * Math.min(into, outOf)) {
+      hits.push({ frame: k, in: into, out: outOf, neighbours: across });
+    }
+  }
+  return hits;
+}


### PR DESCRIPTION
## What

Removes the false **single-frame flash** that the "Chat shell gestures" lane's
`Frame-glitch (transient) e2e` step flagged intermittently. The fix is in the
**detector**, not the animation — the chat sheet renders identically before and
after.

## Root cause (a flaky detector, not a #16314 regression)

The step was bisected to #16314, but that attribution is spurious:

- #16314 touches only `accounts/*`, `auth/oauth-flow`, and `agent/accounts-routes` —
  **none** are in the frame-glitch fixture's render tree (`ContinuousChatOverlay`
  + `MockAppProvider` + `GlassStyles`, with `@elizaos/core` stubbed).
- `ContinuousChatOverlay.tsx` and the whole `__e2e__/` harness are **byte-identical**
  between the pre-#16314 commit and develop tip (`git diff` is empty).
- The step fails on **~50% of runs at a wandering frame index on byte-identical
  code** — including on the pre-#16314 commit (3/6 fail) and on develop tip
  (4/6 fail). It runs on **push to `develop`** (post-merge), so a ~50%-flaky
  detector reddens after arbitrary merges and gets misattributed by run-history
  bisect.

**Why it flashed:** the sheet opens on a spring; the transcript is bottom-anchored,
so as the panel height settles by whole pixels the entire thread tracks it and
jogs ≤1px per captured frame. The harness's **naive per-pixel diff** counted that
whole-frame 1px jog as ~17k changed pixels (every glyph edge) even though the
frames are perceptually identical — the per-frame diff overlay lights up the
*entire* transcript, not the handle. When the jog reverses within one captured
frame (the spring's sub-pixel overshoot, or a dropped screencast frame), that
frame differs hard from **both** neighbours while the neighbours agree → a false
"single-frame flash". The pill↔grabber crossfade itself is clean the whole time
(two-pills overlap `0.000`).

## Fix

Measure genuine **content change**, not sub-pixel scroll translation. The
detection math is extracted into a pure, unit-provable module
(`packages/ui/src/testing/frame-glitch-detect.ts`, mirroring the `scroll-cert`
split) that aligns away a ≤1px integer translation before counting. A real
wrong-state flash (a mispainted morph frame, the "two pills" bar, the injected
`--canary` block) is **not** a translation, so it still counts full and the
canary self-test still fires. Thresholds (`noise`, `activeFraction`, `flashRatio`)
are unchanged — only the diff metric is shift-tolerant now.

`frame-glitch-detect.test.ts` proves the detector both ways: a 1px whole-frame
jog the naive metric flags is **not** flagged shift-tolerant, and a genuine
one-frame block **is**.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - No rendered-UI change: the chat sheet animation is byte-identical before and after this PR (only the e2e detector's frame-diff metric changed). The meaningful "before" is the flaky detector verdict — see Backend logs.
<!-- evidence-row:after-screenshots -->
- [x] N/A - No rendered-UI change (see above); the fix is to the test harness's frame-diff metric, not to any component — chat sheet pixels are unchanged.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - The "flow" is the automated frame-glitch e2e; the harness records the open transition to transition.gif in the chat-shell-gesture-artifacts CI artifact. The pass/fail verdict is the evidence — see Backend logs.
<!-- evidence-row:backend-logs -->
- [x] Before (flaky, 4/6 FAIL) then after (6/6 PASS) + canary, from [run-chat-sheet-frame-glitch-e2e.mjs](packages/ui/src/components/shell/__e2e__/run-chat-sheet-frame-glitch-e2e.mjs); full output under Evidence Details.
<!-- evidence-row:frontend-logs -->
- [x] N/A - No app frontend/network: the isolated esbuild fixture stubs @elizaos/core; the harness asserts "no page errors (0)" on every run (shown in Backend logs).
<!-- evidence-row:llm-trajectory -->
- [x] N/A - No agent/action/provider/prompt/model change; this is a test-harness detector-metric fix.
<!-- evidence-row:domain-artifacts -->
- [x] New unit proof [frame-glitch-detect.test.ts](packages/ui/src/testing/frame-glitch-detect.test.ts) (detector proven both ways) plus the harness evidence bundle (summary.json, frame PNGs, transition.gif) uploaded as the chat-shell-gesture-artifacts CI artifact.

# Evidence Details

### Backend logs — detector verdict, before vs after (same code path, no retries)

<details>
<summary>BEFORE — develop tip (875673a), naive per-pixel diff — 4/6 FAIL</summary>

```
run 1: no single-frame flashes (found 0)
run 2: no single-frame flashes (found 1: [{"frame":24,"in":17246,"out":16116,"neighbours":1098}])
run 3: no single-frame flashes (found 0)
run 4: no single-frame flashes (found 1: [{"frame":23,"in":17257,"out":16116,"neighbours":1056}])
run 5: no single-frame flashes (found 4: frames 18,19,20,23 — in~17k, out~16k, neighbours~1.1-1.7k)
run 6: no single-frame flashes (found 3: frames 18,19,20 — same signature)
```

Same magnitude every time (in~17k, out~16k, neighbours~1k), wandering frame
index — the signature of a whole-transcript 1px jog, not a wrong-state frame.
Pre-#16314 commit (0f8045c) is identical: 3/6 FAIL, same magnitudes.
</details>

<details>
<summary>AFTER — this PR (shift-tolerant diff) — 6/6 PASS + canary fires</summary>

```
### 6 real runs
run 1..6: OK  no single-frame flashes (found 0)

### canary self-test (must still fire on an injected wrong state)
OK  canary: flash detector FIRES on the injected bad frame
OK  canary: two-pills detector FIRES on the injected both-visible sample
```

22/22 real runs green across the full session (was ~50%), under both node and
bun; every run reports "no page errors (0)" and "worst two-pills overlap 0.000".
</details>

### Unit proof (`bun run --cwd packages/ui vitest run src/testing/frame-glitch-detect.test.ts`)

<details>
<summary>6/6 pass — detector proven both ways</summary>

```
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

- shiftTolerantDiff aligns a whole-frame 1px jog to 0, preserves a localized block.
- detectFlashes does NOT flag the 1px jog (while the naive maxShift:0 detector
  DOES — asserted, so the fix stays load-bearing), still flags a genuine
  one-frame block, ignores monotonic drift and sub-active wobble.
</details>

Fixes the transient false positive tracked with the #9142 Part-2 harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
