### PR TITLE
fix(accounts): reset credential health after successful oauth replacement

### DIFF
--- a/packages/app-core/src/services/account-pool.ts
+++ b/packages/app-core/src/services/account-pool.ts
@@ -1106,9 +1106,9 @@ export async function sweepAccountPoolKeepAlive(): Promise<AccountPoolKeepAliveR
       } catch (err) {
         result.failed += 1;
         const message = err instanceof Error ? err.message : String(err);
-        if (/401|403|invalid|unauthor/i.test(message)) {
+        if (/\b(?:HTTP\s*)?(?:401|403)\b|unauthoriz/i.test(message)) {
           await pool.markNeedsReauth(record.id, message, { providerId });
-        } else if (/429|rate.?limit/i.test(message)) {
+        } else if (/\b(?:HTTP\s*)?429\b|rate.?limit/i.test(message)) {
           await pool.markRateLimited(
             record.id,
             Date.now() + DEFAULT_RATE_LIMIT_BACKOFF_MS,
@@ -1116,8 +1116,16 @@ export async function sweepAccountPoolKeepAlive(): Promise<AccountPoolKeepAliveR
             { providerId },
           );
         } else {
-          await pool.markInvalid(record.id, message, { providerId });
+          logger.warn(
+            `[AccountPool] usage refresh failed for ${providerId}/${record.id} without proving credential failure: ${message}`,
+          );
         }
+        // Usage parsing, transport, and provider-shape failures do not prove
+        // the credential is bad. Keep the current health so a successfully
+        // replaced credential cannot be permanently evicted merely because
+        // an optional usage endpoint changed shape. Explicit authentication
+        // failures above remain terminal; token-resolution failures are
+        // handled before this probe.
       }
     }
   }

--- a/packages/app-core/src/services/multi-account-refresh-failover.test.ts
+++ b/packages/app-core/src/services/multi-account-refresh-failover.test.ts
@@ -340,6 +340,34 @@ describe("adoptRotatedCodexTokens (CLI self-refresh sync-back)", () => {
     expect(pool.get("codex-work", "openai-codex")?.health).toBe("ok");
   });
 
+  it.each([
+    [401, "needs-reauth"],
+    [429, "rate-limited"],
+  ] as const)("classifies an HTTP %i usage rejection as %s", async (status, expectedHealth) => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("rejected", { status })),
+    );
+    writeAccount(
+      "openai-codex",
+      "codex-work",
+      {
+        access: fakeJwt(Date.now() + HOUR_MS),
+        refresh: "rt-valid",
+        expires: Date.now() + HOUR_MS,
+      },
+      { organizationId: "org-work" },
+    );
+
+    const pool = getDefaultAccountPool();
+    await expect(sweepAccountPoolKeepAlive()).resolves.toEqual({
+      checked: 1,
+      refreshed: 0,
+      failed: 1,
+    });
+    expect(pool.get("codex-work", "openai-codex")?.health).toBe(expectedHealth);
+  });
+
   it("heals a flagged direct-API account after its stored credential resolves", async () => {
     writeAccount("anthropic-api", "direct-work", {
       access: "sk-ant-valid",

--- a/packages/app-core/src/services/multi-account-refresh-failover.test.ts
+++ b/packages/app-core/src/services/multi-account-refresh-failover.test.ts
@@ -303,6 +303,43 @@ describe("adoptRotatedCodexTokens (CLI self-refresh sync-back)", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  it("does not brick a healthy Codex credential when usage parsing fails", async () => {
+    const fetchSpy = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            rate_limit: {
+              primary_window: { used_percent: 10 },
+              secondary_window: "unexpected-provider-shape",
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+    writeAccount(
+      "openai-codex",
+      "codex-work",
+      {
+        access: fakeJwt(Date.now() + HOUR_MS),
+        refresh: "rt-valid",
+        expires: Date.now() + HOUR_MS,
+      },
+      { organizationId: "org-work" },
+    );
+
+    const pool = getDefaultAccountPool();
+    expect(pool.get("codex-work", "openai-codex")?.health).toBe("ok");
+
+    await expect(sweepAccountPoolKeepAlive()).resolves.toEqual({
+      checked: 1,
+      refreshed: 0,
+      failed: 1,
+    });
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(pool.get("codex-work", "openai-codex")?.health).toBe("ok");
+  });
+
   it("heals a flagged direct-API account after its stored credential resolves", async () => {
     writeAccount("anthropic-api", "direct-work", {
       access: "sk-ant-valid",


### PR DESCRIPTION
## Summary

- stop usage parser, response-shape, and transport failures from terminally invalidating an otherwise valid subscription credential
- retain terminal `needs-reauth` transitions for explicit HTTP 401/403 failures
- retain temporary rate-limit transitions for HTTP 429 failures
- log non-auth probe failures while preserving current credential health

## Dogfood evidence

- OAuth replacement persisted new credentials in-place: the account record `updatedAt` and access-token expiry moved to the completed reauth time while its stable `createdAt` and account id were intentionally preserved.
- A credential-safe live probe returned HTTP 200 from `wham/usage`; response shape had `rate_limit.secondary_window: null`.
- Current parser rejected that valid optional-null response as `codex_usage.invalid_shape`.
- Keep-alive then matched the word `invalid` in that parser message and incorrectly changed the account to terminal `needs-reauth`.
- The OAuth replacement route already strips terminal health metadata and explicitly writes `health: ok`; its focused replacement test continues to pass.

Parser null-handling and UI reconcile are intentionally excluded here because the parallel `sol-reauth-livefix` lane owns them. This PR fixes the independent health-state regression so future provider-shape or transport failures cannot brick a freshly replaced credential.

## Verification

- `bun x vitest run packages/app-core/src/services/multi-account-refresh-failover.test.ts` (17 passed)
- `bun x vitest run packages/agent/src/api/accounts-routes.test.ts` (8 passed)
- Codex review: clean after addressing its observability finding
- live dogfood after the parser hotfix + supported `POST /api/accounts/openai-codex/:id/refresh-usage`: `health=ok`, account selected, usage populated

Auth surface, intentionally not auto-merged.

[sol-orch]


# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend credential-health logic only; no visual surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend credential-health logic only; no visual surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused deterministic tests exercise OAuth replacement and non-auth probe failure handling without exposing live credentials.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - credential-safe test assertions are the relevant domain artifact; raw OAuth credentials and provider responses are intentionally excluded.
