### PR TITLE
fix(tests): realign Server-lane test expectations with merged behavior

### DIFF
--- a/packages/agent/src/api/notification-lazy-route.test.ts
+++ b/packages/agent/src/api/notification-lazy-route.test.ts
@@ -20,15 +20,17 @@ function makeContext(pathname: string, method = "GET") {
   const json = vi.fn();
   const error = vi.fn();
   const readJsonBody = vi.fn();
+  const setHeader = vi.fn();
   return {
     args: {
       req: { url: pathname } as http.IncomingMessage,
-      res: {} as http.ServerResponse,
+      res: { setHeader } as unknown as http.ServerResponse,
       method,
       pathname,
       url: new URL(pathname, "http://localhost"),
-      // No runtime → the notification handler serves an empty inbox for GET,
-      // which still proves the wrapper forwarded the request (returned true).
+      // No runtime → the notification handler fails closed with a retryable 503
+      // (it does not fabricate an empty inbox), which still proves the wrapper
+      // forwarded the request (returned true).
       state: { runtime: null },
       json,
       error,
@@ -52,10 +54,17 @@ describe("handleInboxAndCloudRelayRouteGroup (lazy wrapper guard)", () => {
       >[0],
     );
     expect(handled).toBe(true);
-    expect(json).toHaveBeenCalledWith(args.res, {
-      notifications: [],
-      unreadCount: 0,
-    });
+    // No runtime → the dispatch fails closed with a retryable 503 rather than
+    // fabricating an empty inbox; the wrapper still forwarded (handled === true).
+    expect(json).toHaveBeenCalledWith(
+      args.res,
+      {
+        error: "Notification service is still starting",
+        code: "NOTIFICATION_SERVICE_NOT_READY",
+        retryAfter: 1,
+      },
+      503,
+    );
   });
 
   it("forwards /api/notifications/push-tokens to the dispatch", async () => {

--- a/packages/scenario-runner/src/__tests__/deterministic-action-coverage.test.ts
+++ b/packages/scenario-runner/src/__tests__/deterministic-action-coverage.test.ts
@@ -86,7 +86,6 @@ const CORE_ACTION_SURFACE: Record<string, readonly string[]> = {
     "CONTEXT_COMMAND",
     "ELEVATED_COMMAND",
     "HELP_COMMAND",
-    "MODELS_COMMAND",
     "MODEL_COMMAND",
     "NEW_COMMAND",
     "QUEUE_COMMAND",
@@ -232,10 +231,9 @@ const KNOWN_UNCOVERED: readonly string[] = [
   "SMARTGLASSES_DISPLAY_TEXT",
   "SMARTGLASSES_MICROPHONE",
   "SMARTGLASSES_STATUS",
-  // plugin-commands slash-command actions (/help, /status, /models, /reset,
-  // /compact, /think, /model, /tts, …) are dispatched through the command
-  // palette, not the keyless scenario pipeline, so they have no deterministic
-  // scenario yet.
+  // plugin-commands slash-command actions (/help, /status, /reset, /compact,
+  // /think, /model, /tts, …) are dispatched through the command palette, not
+  // the keyless scenario pipeline, so they have no deterministic scenario yet.
   "ACCOUNTS_COMMAND",
   "BACKEND_COMMAND",
   "COMMANDS_COMMAND",
@@ -243,7 +241,6 @@ const KNOWN_UNCOVERED: readonly string[] = [
   "CONTEXT_COMMAND",
   "ELEVATED_COMMAND",
   "HELP_COMMAND",
-  "MODELS_COMMAND",
   "MODEL_COMMAND",
   "NEW_COMMAND",
   "QUEUE_COMMAND",

--- a/packages/scenario-runner/src/corpus-assertion-guard.test.ts
+++ b/packages/scenario-runner/src/corpus-assertion-guard.test.ts
@@ -363,13 +363,18 @@ const EXPECTED_PR_DETERMINISTIC_SCENARIO_IDS = [
   "nostr.search-posts",
   // Registered here retroactively: the scenario landed (#13778) without the
   // same-commit guard update this list requires, leaving the guard red.
+  // Orchestrator deterministic scenarios from the de-larp sweep (#16256),
+  // registered here retroactively for the same reason as the block above.
+  "orchestrator-completion-residuals",
   "orchestrator-concurrency-admission",
   "orchestrator-device-modality-reach",
   "orchestrator-evidence-bundle",
+  "orchestrator-follow-up-forwarding",
   "orchestrator-grilling-happy-path",
   "orchestrator-multi-project-failure-isolation",
   "orchestrator-multi-project-portfolio",
   "orchestrator-multi-task-supervisor",
+  "orchestrator-question-for-creator",
   "orchestrator-reflexion-respawn",
   "orchestrator-view-cloud-deploy",
   "orchestrator-watchdog-stall",

--- a/packages/test/harness/integration-config-core-subpath-alias.test.ts
+++ b/packages/test/harness/integration-config-core-subpath-alias.test.ts
@@ -84,14 +84,22 @@ describe("integration.config.ts @elizaos/core alias (#11047)", () => {
     ).toBe(true);
   });
 
-  it("leaves unknown @elizaos/core subpaths to package-exports resolution", () => {
-    // Prefix rewriting turned every unaliased subpath into an ENOTDIR path
-    // under the entry file. Unknown subpaths must instead fall through so
-    // Vite resolves them via packages/core's exports map.
+  it("source-aliases other @elizaos/core subpaths to a real sibling file, never ENOTDIR", () => {
+    // The lane's generic source alias maps every remaining `@elizaos/core/<x>`
+    // to its `src/<x>.ts` sibling — Vite's SSR resolver ignores the package's
+    // `eliza-source` export condition and would otherwise pick unbuilt dist.
+    // The #11047 guarantee still holds: the rewrite lands on a real FILE, never
+    // an ENOTDIR path nested under the core entry file. `@elizaos/core/roles`
+    // (a real export since #14904) is the representative subpath.
     const resolved = resolveThroughAliases(
       getIntegrationAliases(),
       "@elizaos/core/roles",
     );
-    expect(resolved).toBeUndefined();
+    expect(resolved, "@elizaos/core/roles must resolve").toBeDefined();
+    const target = resolved as string;
+    expect(
+      existsSync(target) && statSync(target).isFile(),
+      `@elizaos/core/roles resolved to "${target}", which is not a file (ENOTDIR, #11047)`,
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## What & why

Four Server-lane test files on `develop` carried expectations that concurrent merges invalidated, turning the **Tests** lane red (Server shard). Each fix realigns the test with the already-merged production behavior; **no production code changes**.

| Test file | Root cause (attributed) | Fix |
|---|---|---|
| `packages/agent/src/api/notification-lazy-route.test.ts` | #6c3b3b5 ("fail closed and recover unavailable inbox") changed the no-runtime `/api/notifications` path from a fabricated empty inbox to a retryable **503 + `Retry-After`**; this older test still asserted the empty inbox and passed a `res` mock without `setHeader`. | Give `res` a `setHeader`; assert the 503 `NOTIFICATION_SERVICE_NOT_READY` body. |
| `packages/scenario-runner/src/corpus-assertion-guard.test.ts` | #16256 added three `pr-deterministic` orchestrator scenarios not registered in `EXPECTED_PR_DETERMINISTIC_SCENARIO_IDS`. | Register `orchestrator-completion-residuals`, `orchestrator-follow-up-forwarding`, `orchestrator-question-for-creator`. |
| `packages/scenario-runner/src/__tests__/deterministic-action-coverage.test.ts` | #16246 dropped `/models`; `MODELS_COMMAND` no longer exists on `plugin-commands`, but the manifest still listed it. | Remove `MODELS_COMMAND` from both manifest lists. |
| `packages/test/harness/integration-config-core-subpath-alias.test.ts` | The lane's generic source alias `@elizaos/core/(.*) -> packages/core/src/$1.ts` now catches `@elizaos/core/roles` (a real export since #14904) -> a real file, so the "unknown subpath -> `undefined`" case is obsolete. | Assert the #11047 guarantee instead: resolves to a **real file**, never an ENOTDIR path. |

## Verification

All four pass locally (`bunx vitest run <file>` in each package). Before: each failed on the current `develop` tip; after: green.

## Evidence

Test-only change; no runtime/UI surface touched.

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - test-only change; no UI surface touched (only *.test.ts files)`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - test-only change; no UI surface touched (only *.test.ts files)`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - test-only change; nothing user-exercisable`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no production code path changed; test expectations only`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent/action/provider/prompt/model change; these are deterministic gate tests`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no domain artifacts produced; test expectation realignment only`.
