### PR TITLE
fix(ui): remove reintroduced design-gate violations on account/settings/notification/widget surfaces

### DIFF
--- a/packages/ui/src/components/accounts/AccountManagementPanel.test.tsx
+++ b/packages/ui/src/components/accounts/AccountManagementPanel.test.tsx
@@ -146,7 +146,16 @@ describe("AccountManagementPanel", () => {
     expect(screen.getByRole("dialog")).toBeTruthy();
     // Account operations live behind progressive disclosure: expand the
     // connected provider row to reveal its account cards + strategy picker.
-    fireEvent.click(screen.getByRole("button", { name: /OpenAI API/ }));
+    const providerToggle = screen.getByRole("button", { name: /OpenAI API/ });
+    // Product policy disables focus rings globally (styles.css); the provider
+    // row toggle must not carry Tailwind focus/ring utilities — guards the
+    // no-focus-ring-gate at the component level.
+    const toggleClass = providerToggle.getAttribute("class") ?? "";
+    expect(toggleClass).not.toMatch(
+      /(?:^|\s)(?:focus|focus-visible|focus-within):/,
+    );
+    expect(toggleClass).not.toMatch(/(?:^|\s)!?ring-/);
+    fireEvent.click(providerToggle);
     fireEvent.click(screen.getByRole("button", { name: "move First" }));
     await waitFor(() => expect(accounts.patch).toHaveBeenCalledTimes(2));
     fireEvent.click(screen.getByRole("button", { name: "test First" }));

--- a/packages/ui/src/components/accounts/AccountManagementPanel.tsx
+++ b/packages/ui/src/components/accounts/AccountManagementPanel.tsx
@@ -318,7 +318,7 @@ export function AccountManagementPanel({
           <button
             type="button"
             onClick={() => setShowAvailable((v) => !v)}
-            className="flex w-full items-center gap-1.5 text-left text-[11px] font-medium uppercase tracking-wider text-muted transition-colors hover:text-txt-strong focus:outline-none focus-visible:text-txt-strong"
+            className="flex w-full items-center gap-1.5 text-left text-[11px] font-medium uppercase tracking-wider text-muted transition-colors hover:text-txt-strong"
             aria-expanded={showAvailable}
           >
             <span

--- a/packages/ui/src/components/accounts/ProviderAccountRow.tsx
+++ b/packages/ui/src/components/accounts/ProviderAccountRow.tsx
@@ -214,7 +214,7 @@ export function ProviderAccountRow({
           disabled={!connected}
           aria-expanded={connected ? expanded : undefined}
           className={cn(
-            "flex min-w-0 flex-1 items-center gap-3 rounded-md text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/50",
+            "flex min-w-0 flex-1 items-center gap-3 rounded-md text-left",
             connected ? "cursor-pointer" : "cursor-default",
           )}
         >

--- a/packages/ui/src/components/accounts/ProviderPicker.test.tsx
+++ b/packages/ui/src/components/accounts/ProviderPicker.test.tsx
@@ -64,4 +64,21 @@ describe("ProviderPicker", () => {
     fireEvent.click(screen.getByRole("option", { name: /Anthropic API/ }));
     expect(onPick).toHaveBeenCalledWith("anthropic-api");
   });
+
+  // Product policy disables focus rings globally (styles.css); the search input
+  // and option rows must not carry Tailwind focus/ring utilities — guards the
+  // no-focus-ring-gate at the component level.
+  it("renders the search input and options free of focus/ring utilities", () => {
+    renderPicker();
+    fireEvent.change(searchInput(), { target: { value: "Anthropic API" } });
+    const targets = [
+      searchInput(),
+      screen.getByRole("option", { name: /Anthropic API/ }),
+    ];
+    for (const el of targets) {
+      const cls = el.getAttribute("class") ?? "";
+      expect(cls).not.toMatch(/(?:^|\s)(?:focus|focus-visible|focus-within):/);
+      expect(cls).not.toMatch(/(?:^|\s)!?ring-/);
+    }
+  });
 });

--- a/packages/ui/src/components/accounts/ProviderPicker.tsx
+++ b/packages/ui/src/components/accounts/ProviderPicker.tsx
@@ -132,7 +132,7 @@ export function ProviderPicker({ onPick }: ProviderPickerProps) {
           placeholder={t("accounts.add.search", {
             defaultValue: "Search providers",
           })}
-          className="h-9 w-full rounded-md border border-border/60 bg-bg-accent/40 pl-8 pr-3 text-sm text-txt-strong outline-none placeholder:text-muted focus:border-txt/30 focus:ring-2 focus:ring-accent/40"
+          className="h-9 w-full rounded-md border border-border/60 bg-bg-accent/40 pl-8 pr-3 text-sm text-txt-strong outline-none placeholder:text-muted"
           aria-label={t("accounts.add.search", {
             defaultValue: "Search providers",
           })}
@@ -175,7 +175,7 @@ export function ProviderPicker({ onPick }: ProviderPickerProps) {
                   onMouseMove={() => setActiveIndex(index)}
                   onClick={() => onPick(option.id)}
                   className={cn(
-                    "flex w-full items-center gap-3 rounded-md px-2 py-2 text-left transition-colors focus:outline-none",
+                    "flex w-full items-center gap-3 rounded-md px-2 py-2 text-left transition-colors",
                     active ? "bg-bg-accent" : "hover:bg-bg-accent/60",
                     option.unavailable && "opacity-60",
                   )}

--- a/packages/ui/src/components/chat/widgets/orchestrator-task-widget.test.tsx
+++ b/packages/ui/src/components/chat/widgets/orchestrator-task-widget.test.tsx
@@ -152,9 +152,14 @@ describe("OrchestratorTaskWidget", () => {
     mocks.getWidgets.mockRejectedValue(new Error("task store unavailable"));
     render(<OrchestratorTaskWidget {...props} />);
 
-    expect((await screen.findByRole("alert")).textContent).toContain(
-      "task store unavailable",
-    );
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("task store unavailable");
+    // #10708 (chromeless widgets): the error state is a danger-tinted strip —
+    // a radius + translucent fill, never the glass-card triad. It must NOT
+    // reintroduce a `border border-*` on the container.
+    const alertClass = alert.getAttribute("class") ?? "";
+    expect(alertClass).not.toMatch(/\bborder\s+border-/);
+    expect(alertClass).toMatch(/bg-danger/);
     expect(screen.queryByText("No orchestration tasks yet")).toBeNull();
 
     mocks.getWidgets.mockResolvedValue(populated);

--- a/packages/ui/src/components/chat/widgets/orchestrator-task-widget.tsx
+++ b/packages/ui/src/components/chat/widgets/orchestrator-task-widget.tsx
@@ -132,7 +132,7 @@ export function OrchestratorTaskWidgetView({
         </div>
       ) : error ? (
         <div
-          className="my-2 flex items-start gap-2 rounded-sm border border-danger/35 bg-danger/10 p-2 text-3xs text-danger"
+          className="my-2 flex items-start gap-2 rounded-sm bg-danger/10 p-2 text-3xs text-danger"
           role="alert"
         >
           <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />

--- a/packages/ui/src/components/settings/DesktopSettingsNavigation.test.tsx
+++ b/packages/ui/src/components/settings/DesktopSettingsNavigation.test.tsx
@@ -107,4 +107,28 @@ describe("DesktopSettingsNavigation", () => {
     fireEvent.keyDown(appearance, { key: "Enter" });
     expect(onSelect).toHaveBeenCalledWith("appearance");
   });
+
+  // Product policy disables focus rings globally (styles.css), so nav items must
+  // not carry Tailwind focus/ring utilities — guards the no-focus-ring-gate at
+  // the component level.
+  it("renders nav items free of focus/ring utilities", () => {
+    render(
+      <DesktopSettingsNavigation
+        grouped={grouped as never}
+        activeId="identity"
+        onSelect={vi.fn()}
+        onBack={vi.fn()}
+        settingsLabel="Settings"
+        label={resolveLabel}
+      />,
+    );
+    for (const id of ["identity", "ai-model", "appearance"]) {
+      const cls =
+        screen
+          .getByTestId(`desktop-settings-item-${id}`)
+          .getAttribute("class") ?? "";
+      expect(cls).not.toMatch(/(?:^|\s)(?:focus|focus-visible|focus-within):/);
+      expect(cls).not.toMatch(/(?:^|\s)!?ring-/);
+    }
+  });
 });

--- a/packages/ui/src/components/settings/DesktopSettingsNavigation.tsx
+++ b/packages/ui/src/components/settings/DesktopSettingsNavigation.tsx
@@ -112,7 +112,7 @@ export function DesktopSettingsNavigation({
                     }}
                     className={cn(
                       "group flex min-h-11 w-full items-center gap-2.5 rounded-md border border-transparent px-2 py-2 text-left text-sm transition-colors",
-                      "text-muted hover:bg-surface/70 hover:text-txt-strong focus-visible:border-accent/60",
+                      "text-muted hover:bg-surface/70 hover:text-txt-strong",
                       isActive &&
                         "bg-accent/10 font-medium text-txt-strong hover:bg-accent/12",
                     )}

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -534,8 +534,18 @@ describe("NotificationsHomeCenter", () => {
     expect(unavailable.textContent).toContain("Notifications unavailable");
     expect(unavailable.textContent).not.toContain("private transport detail");
 
+    const retry = screen.getByRole("button", { name: "Retry" });
+    // Product policy disables focus rings globally (styles.css); the retry
+    // button must not carry Tailwind focus/ring utilities — guards the
+    // no-focus-ring-gate at the component level.
+    const retryClass = retry.getAttribute("class") ?? "";
+    expect(retryClass).not.toMatch(
+      /(?:^|\s)(?:focus|focus-visible|focus-within):/,
+    );
+    expect(retryClass).not.toMatch(/(?:^|\s)!?ring-/);
+
     await act(async () => {
-      fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+      fireEvent.click(retry);
       await Promise.resolve();
     });
 

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -1258,7 +1258,7 @@ export function NotificationsHomeCenter({
           <button
             type="button"
             onClick={() => void retryNotificationHydration()}
-            className="flex h-11 shrink-0 items-center gap-1.5 rounded-xl bg-orange-500 px-3 text-xs font-semibold text-black transition-colors hover:bg-orange-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-400"
+            className="flex h-11 shrink-0 items-center gap-1.5 rounded-xl bg-orange-500 px-3 text-xs font-semibold text-black transition-colors hover:bg-orange-600"
           >
             <RefreshCw aria-hidden className="h-3.5 w-3.5" />
             Retry


### PR DESCRIPTION
## What & why

Restores two source-scanning **design-gates** that concurrent UI merges re-triggered on the red **Client Tests** lane, at the source (the gates scan `src/`), **preserving** the features that introduced them (multi-account manager #16204, settings rail #16354/#16363, orchestrator widget #16203).

> Scope: this PR is **only the 6 component `.tsx` design-gate fixes**. The three App auth-mock **test** fixes it originally also carried were split into the test-only PR **#16370**. Rebased onto current `origin/develop`; all 6 banned tokens still existed there, so **none were already fixed by another agent**.

- **`no-focus-ring-gate`** — #16204 and #16354/#16363 reintroduced banned Tailwind focus/ring utilities on `AccountManagementPanel`, `ProviderAccountRow`, `ProviderPicker`, `DesktopSettingsNavigation`, and the `NotificationsHomeCenter` retry button. Focus rings are **globally disabled by product policy** (`packages/ui/src/styles/styles.css`: `:where(:focus,:focus-visible,:focus-within){outline:none!important}`), so the removed ring/border-on-focus utilities **never painted at rest**.
- **`no-widget-chrome-gate` (#10708)** — #16203 gave the `orchestrator-task-widget` error state the glass-card triad (radius + border + translucent fill). Drop the **border** so it is a chromeless danger-tinted strip, matching the widget's own loading skeleton (`rounded-sm bg-*`, no border). The error affordance (icon + red text + retry) is unchanged.

## Verification

`bunx vitest run src/no-focus-ring-gate.test.ts src/no-widget-chrome-gate.test.ts` (packages/ui): **green** (both failed on develop before this change). A full `bun run --cwd packages/app audit:app` on this change: **244 views, 0 broken** (`ocr-triage.json`: verified 95 / broken 0 / needs-eyeball 149).

## Evidence

These 6 edits are **className-string-only with no at-rest visual delta** — focus rings are globally disabled by CSS, and the widget border only ever showed in the error state. So the before/after captures are **intentionally identical**; the artifacts prove the affected surfaces render healthy post-fix (no regression). Uploaded to the `pr-evidence-2` overflow release (the primary `pr-evidence` release is at GitHub's 1000-asset cap).

**Before (desktop / mobile)** — identical to after (no visual delta):

![before desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16367-before-desktop.jpg)
![before mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16367-before-mobile.jpg)

**After (desktop / mobile)** — className-only fix applied:

![after desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16367-after-desktop.jpg)
![after mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16367-after-mobile.jpg)

**Walkthrough:** [16367-walkthrough.mp4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16367-walkthrough.mp4) — a real Playwright recording (`E2E_RECORD=1` audit-app) walking the home shell, tasks, orchestrator (the fixed `orchestrator-task-widget`), and cockpit views rendering correctly post-fix, 0 broken.

**OCR:** [16367-ocr-triage.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16367-ocr-triage.json) — packaged-engine OCR triage over the audit captures: **0 broken**.

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots (desktop + mobile) — identical to after; className-only, no at-rest visual delta: ![before desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16367-before-desktop.jpg) ![before mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16367-before-mobile.jpg)
<!-- evidence-row:after-screenshots -->
- [x] After screenshots (desktop + mobile) — fix applied, surfaces render healthy: ![after desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16367-after-desktop.jpg) ![after mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16367-after-mobile.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video (real MP4, Playwright `E2E_RECORD=1`): https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16367-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - renderer-only className change; no backend code path touched`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs `N/A - no behavior change; className-only edits, verified by the design-gate vitest suites`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent/action/provider/prompt/model change`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — OCR triage over the audit captures (https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16367-ocr-triage.json): 244 views, 0 broken.
