### PR TITLE
fix(accounts): reconcile failed usage probes before reauthentication

### DIFF
--- a/packages/auth/src/codex-usage.test.ts
+++ b/packages/auth/src/codex-usage.test.ts
@@ -100,6 +100,26 @@ describe("fetchCodexUsage — success parsing", () => {
     expect(usage).toEqual({ planType: "plus" });
   });
 
+  it.each([
+    [
+      "primary",
+      { primary_window: null, secondary_window: { used_percent: 25 } },
+    ],
+    [
+      "secondary",
+      { primary_window: { used_percent: 88 }, secondary_window: null },
+    ],
+  ])("treats a null %s window exactly like an absent optional window", async (name, rateLimit) => {
+    const usage = await fetchCodexUsage(
+      "tok",
+      "a",
+      fetchReturning(jsonResponse({ rate_limit: rateLimit })),
+    );
+    expect(usage).toEqual(
+      name === "primary" ? { weeklyPct: 25 } : { sessionPct: 88 },
+    );
+  });
+
   it("sends bearer + account id + codex-cli UA; omits the account header when absent", async () => {
     const seen: Array<Record<string, string>> = [];
     const spy = (async (_url: string | URL | Request, init?: RequestInit) => {
@@ -116,22 +136,23 @@ describe("fetchCodexUsage — success parsing", () => {
 });
 
 describe("fetchCodexUsage — typed failures (never fabricated data)", () => {
-  it.each([[401], [429], [503]])(
-    "throws a typed http_error carrying status %s in context and message",
-    async (status) => {
-      const err = await fetchCodexUsage(
-        "tok",
-        "a",
-        fetchReturning(new Response("denied", { status })),
-      ).catch((e: unknown) => e);
-      expect(err).toBeInstanceOf(ElizaError);
-      const typed = err as ElizaError;
-      expect(typed.code).toBe("codex_usage.http_error");
-      expect(typed.context?.status).toBe(status);
-      // Callers (rate-limit regexes, dashboards) read the status from the message.
-      expect(typed.message).toContain(String(status));
-    },
-  );
+  it.each([
+    [401],
+    [429],
+    [503],
+  ])("throws a typed http_error carrying status %s in context and message", async (status) => {
+    const err = await fetchCodexUsage(
+      "tok",
+      "a",
+      fetchReturning(new Response("denied", { status })),
+    ).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ElizaError);
+    const typed = err as ElizaError;
+    expect(typed.code).toBe("codex_usage.http_error");
+    expect(typed.context?.status).toBe(status);
+    // Callers (rate-limit regexes, dashboards) read the status from the message.
+    expect(typed.message).toContain(String(status));
+  });
 
   it("throws a typed request_failed on transport errors, preserving the cause", async () => {
     const boom = new TypeError("network down");
@@ -165,7 +186,10 @@ describe("fetchCodexUsage — typed failures (never fabricated data)", () => {
     ["array body", "[1,2]"],
     ["non-object rate_limit", '{"rate_limit": 5}'],
     ["non-object primary window", '{"rate_limit":{"primary_window": 7}}'],
+    ["string primary window", '{"rate_limit":{"primary_window":"none"}}'],
+    ["array primary window", '{"rate_limit":{"primary_window":[]}}'],
     ["non-object secondary window", '{"rate_limit":{"secondary_window": []}}'],
+    ["string secondary window", '{"rate_limit":{"secondary_window":"none"}}'],
   ])("throws a typed invalid_shape for %s", async (_name, body) => {
     const err = await fetchCodexUsage(
       "tok",

--- a/packages/auth/src/codex-usage.ts
+++ b/packages/auth/src/codex-usage.ts
@@ -132,20 +132,25 @@ export async function fetchCodexUsage(
   const secondary = isRecord(rateLimit)
     ? rateLimit.secondary_window
     : undefined;
-  if (primary !== undefined && !isRecord(primary)) {
+  // OpenAI uses null for a window that does not apply to the account. Treat
+  // that the same as an omitted optional window, while retaining strict shape
+  // validation for every other present value.
+  if (primary !== undefined && primary !== null && !isRecord(primary)) {
     throw new ElizaError("Codex usage primary window was invalid", {
       code: "codex_usage.invalid_shape",
       severity: "fatal",
     });
   }
-  if (secondary !== undefined && !isRecord(secondary)) {
+  if (secondary !== undefined && secondary !== null && !isRecord(secondary)) {
     throw new ElizaError("Codex usage secondary window was invalid", {
       code: "codex_usage.invalid_shape",
       severity: "fatal",
     });
   }
 
-  const sessionPct = clampPct(isRecord(primary) ? primary.used_percent : undefined);
+  const sessionPct = clampPct(
+    isRecord(primary) ? primary.used_percent : undefined,
+  );
   const weeklyPct = clampPct(
     isRecord(secondary) ? secondary.used_percent : undefined,
   );

--- a/packages/ui/src/hooks/useAccounts.test.tsx
+++ b/packages/ui/src/hooks/useAccounts.test.tsx
@@ -236,6 +236,41 @@ describe("useAccounts", () => {
     );
   });
 
+  it("drops a rejected poll invalidated by a newer mutation instead of setting a stale error", async () => {
+    let rejectStalePoll: ((err: Error) => void) | undefined;
+    const stalePoll = new Promise<AccountsListResponse>((_resolve, reject) => {
+      rejectStalePoll = reject;
+    });
+    client.listAccounts
+      .mockResolvedValueOnce(initial)
+      .mockImplementationOnce(() => stalePoll);
+    const notices = vi.fn();
+    const { result } = renderHook(() =>
+      useAccounts({ pollMs: 0, setActionNotice: notices }),
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // Leave a poll in flight, invalidate it with a mutation, then fail it.
+    let pending: Promise<void> | undefined;
+    act(() => {
+      pending = result.current.refresh();
+    });
+    await act(() =>
+      result.current.patch("openai-api", "primary", { label: "Renamed" }),
+    );
+    await act(async () => {
+      rejectStalePoll?.(new Error("transport down"));
+      await pending;
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(notices).not.toHaveBeenCalledWith(
+      "Failed to load accounts: transport down",
+      "error",
+      6000,
+    );
+  });
+
   it("surfaces a rejected strategy save before rethrowing it", async () => {
     client.patchProviderStrategy.mockRejectedValueOnce(
       new Error("config write failed"),

--- a/packages/ui/src/hooks/useAccounts.test.tsx
+++ b/packages/ui/src/hooks/useAccounts.test.tsx
@@ -4,7 +4,14 @@
  */
 // @vitest-environment jsdom
 
-import { act, renderHook, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const client = vi.hoisted(() => ({
@@ -18,11 +25,19 @@ const client = vi.hoisted(() => ({
 }));
 
 vi.mock("../api", () => ({ client }));
+vi.mock("../state", () => ({
+  useAppSelector: (
+    selector: (state: {
+      t: (key: string, vars?: Record<string, unknown>) => string;
+    }) => unknown,
+  ) => selector({ t: (key, vars) => String(vars?.defaultValue ?? key) }),
+}));
 vi.mock("./useDocumentVisibility", () => ({
   useIntervalWhenDocumentVisible: () => undefined,
 }));
 
 import type { AccountsListResponse } from "../api/client-agent";
+import { AccountCard } from "../components/accounts/AccountCard";
 import { useAccounts } from "./useAccounts";
 
 const initial: AccountsListResponse = {
@@ -122,6 +137,103 @@ describe("useAccounts", () => {
       "Failed to load accounts: transport down",
     );
     expect(notices).toHaveBeenCalled();
+  });
+
+  it("reconciles a failed probe so the card immediately exposes reauthentication", async () => {
+    const staleAccount = {
+      ...primaryAccount,
+      id: "codex-account",
+      providerId: "openai-codex" as const,
+      source: "oauth" as const,
+      health: "rate-limited" as const,
+    };
+    const stale: AccountsListResponse = {
+      providers: [
+        {
+          providerId: "openai-codex",
+          strategy: "priority",
+          accounts: [staleAccount],
+        },
+      ],
+    };
+    const staleProvider = stale.providers[0];
+    if (!staleProvider) throw new Error("Stale account fixture is incomplete");
+    const terminal: AccountsListResponse = {
+      providers: [
+        {
+          ...staleProvider,
+          accounts: [
+            {
+              ...staleAccount,
+              health: "needs-reauth",
+              healthDetail: {
+                lastError: "Codex usage secondary window was invalid",
+              },
+            },
+          ],
+        },
+      ],
+    };
+    let resolveStalePoll: ((value: AccountsListResponse) => void) | undefined;
+    const stalePoll = new Promise<AccountsListResponse>((resolve) => {
+      resolveStalePoll = resolve;
+    });
+    client.listAccounts
+      .mockResolvedValueOnce(stale)
+      .mockImplementationOnce(() => stalePoll)
+      .mockResolvedValueOnce(terminal);
+    client.refreshAccountUsage.mockRejectedValueOnce(
+      new Error("Codex usage secondary window was invalid"),
+    );
+    const notices = vi.fn();
+
+    function Harness() {
+      const accounts = useAccounts({ pollMs: 0, setActionNotice: notices });
+      const account = accounts.data?.providers[0]?.accounts[0];
+      if (!account) return <div>loading</div>;
+      return (
+        <>
+          <button type="button" onClick={() => void accounts.refresh()}>
+            Poll
+          </button>
+          <AccountCard
+            account={account}
+            isFirst
+            isLast
+            saving={false}
+            onPatch={vi.fn()}
+            onMoveUp={vi.fn()}
+            onMoveDown={vi.fn()}
+            onTest={vi.fn()}
+            onRefreshUsage={() =>
+              accounts
+                .refreshUsage("openai-codex", "codex-account")
+                .catch(() => undefined)
+            }
+            onDelete={vi.fn()}
+            onReauthenticate={vi.fn()}
+          />
+        </>
+      );
+    }
+
+    render(<Harness />);
+    await screen.findByText("Rate-limited");
+    expect(screen.queryByRole("button", { name: "Reauthenticate" })).toBeNull();
+    // Leave a stale regular list poll in flight while the probe fails.
+    fireEvent.click(screen.getByRole("button", { name: "Poll" }));
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+
+    await screen.findByText("Needs reauth");
+    expect(screen.getByRole("button", { name: "Reauthenticate" })).toBeTruthy();
+    await act(async () => resolveStalePoll?.(stale));
+    expect(screen.getByText("Needs reauth")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Reauthenticate" })).toBeTruthy();
+    expect(notices).toHaveBeenCalledWith(
+      "Failed to refresh usage: Codex usage secondary window was invalid",
+      "error",
+      6000,
+    );
   });
 
   it("surfaces a rejected strategy save before rethrowing it", async () => {

--- a/packages/ui/src/hooks/useAccounts.ts
+++ b/packages/ui/src/hooks/useAccounts.ts
@@ -149,7 +149,12 @@ export function useAccounts(opts: UseAccountsOptions = {}): UseAccountsResult {
       setData(next);
       setError(null);
     } catch (err) {
-      if (!mountedRef.current || listRequestIdRef.current !== requestId) return;
+      if (
+        !mountedRef.current ||
+        listRequestIdRef.current !== requestId ||
+        stateVersionRef.current !== stateVersion
+      )
+        return;
       setError(describeError("Failed to load accounts", err));
       notify("Failed to load accounts", err);
     } finally {
@@ -334,7 +339,10 @@ export function useAccounts(opts: UseAccountsOptions = {}): UseAccountsResult {
           // error-policy:J7 diagnostics-must-not-kill-the-loop. Preserve and
           // rethrow the primary usage failure; the regular list poll retries
           // reconciliation without replacing the actionable probe notice.
-          void reconcileError;
+          console.warn(
+            "[useAccounts] post-probe reconciliation failed",
+            reconcileError,
+          );
         }
         throw err;
       } finally {

--- a/packages/ui/src/hooks/useAccounts.ts
+++ b/packages/ui/src/hooks/useAccounts.ts
@@ -330,10 +330,11 @@ export function useAccounts(opts: UseAccountsOptions = {}): UseAccountsResult {
             setData((prev) => replaceAccount(prev, providerId, authoritative));
             setError(null);
           }
-        } catch {
+        } catch (reconcileError) {
           // error-policy:J7 diagnostics-must-not-kill-the-loop. Preserve and
           // rethrow the primary usage failure; the regular list poll retries
           // reconciliation without replacing the actionable probe notice.
+          void reconcileError;
         }
         throw err;
       } finally {

--- a/packages/ui/src/hooks/useAccounts.ts
+++ b/packages/ui/src/hooks/useAccounts.ts
@@ -109,8 +109,24 @@ export function useAccounts(opts: UseAccountsOptions = {}): UseAccountsResult {
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState<Set<string>>(() => new Set<string>());
   const mountedRef = useRef(true);
+  // Failed probes can mutate server-side health before rejecting. Track each
+  // account independently so stale responses cannot overwrite a newer change
+  // to the same account without dropping unrelated concurrent refreshes.
+  const accountVersionRef = useRef(new Map<string, number>());
+  const stateVersionRef = useRef(0);
+  const listRequestIdRef = useRef(0);
   const dataRef = useRef(data);
   dataRef.current = data;
+
+  const nextAccountVersion = useCallback(
+    (providerId: LinkedAccountProviderId, accountId: string) => {
+      const key = `${providerId}:${accountId}`;
+      const version = (accountVersionRef.current.get(key) ?? 0) + 1;
+      accountVersionRef.current.set(key, version);
+      return { key, version };
+    },
+    [],
+  );
 
   const notify = useCallback(
     (prefix: string, err: unknown) => {
@@ -120,13 +136,20 @@ export function useAccounts(opts: UseAccountsOptions = {}): UseAccountsResult {
   );
 
   const refresh = useCallback(async () => {
+    const requestId = ++listRequestIdRef.current;
+    const stateVersion = stateVersionRef.current;
     try {
       const next = await client.listAccounts();
-      if (!mountedRef.current) return;
+      if (
+        !mountedRef.current ||
+        listRequestIdRef.current !== requestId ||
+        stateVersionRef.current !== stateVersion
+      )
+        return;
       setData(next);
       setError(null);
     } catch (err) {
-      if (!mountedRef.current) return;
+      if (!mountedRef.current || listRequestIdRef.current !== requestId) return;
       setError(describeError("Failed to load accounts", err));
       notify("Failed to load accounts", err);
     } finally {
@@ -145,6 +168,7 @@ export function useAccounts(opts: UseAccountsOptions = {}): UseAccountsResult {
 
   const createApiKey = useCallback<UseAccountsResult["createApiKey"]>(
     async (providerId, body) => {
+      stateVersionRef.current += 1;
       const key = `create:${providerId}`;
       markSaving(key, true);
       try {
@@ -175,6 +199,8 @@ export function useAccounts(opts: UseAccountsOptions = {}): UseAccountsResult {
 
   const patch = useCallback<UseAccountsResult["patch"]>(
     async (providerId, accountId, body) => {
+      stateVersionRef.current += 1;
+      const request = nextAccountVersion(providerId, accountId);
       markSaving(accountId, true);
       const previous = dataRef.current;
       // Optimistic update for safe fields.
@@ -194,23 +220,32 @@ export function useAccounts(opts: UseAccountsOptions = {}): UseAccountsResult {
       });
       try {
         const updated = await client.patchAccount(providerId, accountId, body);
-        setData((prev) => replaceAccount(prev, providerId, updated));
+        if (accountVersionRef.current.get(request.key) === request.version) {
+          stateVersionRef.current += 1;
+          setData((prev) => replaceAccount(prev, providerId, updated));
+        }
       } catch (err) {
-        setData(previous);
+        if (accountVersionRef.current.get(request.key) === request.version) {
+          stateVersionRef.current += 1;
+          setData(previous);
+        }
         notify("Failed to update account", err);
         throw err;
       } finally {
         markSaving(accountId, false);
       }
     },
-    [markSaving, notify],
+    [markSaving, nextAccountVersion, notify],
   );
 
   const remove = useCallback<UseAccountsResult["remove"]>(
     async (providerId, accountId) => {
+      stateVersionRef.current += 1;
+      nextAccountVersion(providerId, accountId);
       markSaving(accountId, true);
       try {
         await client.deleteAccount(providerId, accountId);
+        stateVersionRef.current += 1;
         setData((prev) => {
           if (!prev) return prev;
           return {
@@ -231,7 +266,7 @@ export function useAccounts(opts: UseAccountsOptions = {}): UseAccountsResult {
         markSaving(accountId, false);
       }
     },
-    [markSaving, notify],
+    [markSaving, nextAccountVersion, notify],
   );
 
   const test = useCallback<UseAccountsResult["test"]>(
@@ -269,23 +304,48 @@ export function useAccounts(opts: UseAccountsOptions = {}): UseAccountsResult {
 
   const refreshUsage = useCallback<UseAccountsResult["refreshUsage"]>(
     async (providerId, accountId) => {
+      stateVersionRef.current += 1;
+      const request = nextAccountVersion(providerId, accountId);
       markSaving(`usage:${accountId}`, true);
       try {
         const result: AccountRefreshUsageResult =
           await client.refreshAccountUsage(providerId, accountId);
-        setData((prev) => replaceAccount(prev, providerId, result.account));
+        if (accountVersionRef.current.get(request.key) === request.version) {
+          stateVersionRef.current += 1;
+          setData((prev) => replaceAccount(prev, providerId, result.account));
+        }
       } catch (err) {
         notify("Failed to refresh usage", err);
+        try {
+          const reconciled = await client.listAccounts();
+          const authoritative = reconciled.providers
+            .find((provider) => provider.providerId === providerId)
+            ?.accounts.find((account) => account.id === accountId);
+          if (
+            mountedRef.current &&
+            authoritative &&
+            accountVersionRef.current.get(request.key) === request.version
+          ) {
+            stateVersionRef.current += 1;
+            setData((prev) => replaceAccount(prev, providerId, authoritative));
+            setError(null);
+          }
+        } catch {
+          // error-policy:J7 diagnostics-must-not-kill-the-loop. Preserve and
+          // rethrow the primary usage failure; the regular list poll retries
+          // reconciliation without replacing the actionable probe notice.
+        }
         throw err;
       } finally {
         markSaving(`usage:${accountId}`, false);
       }
     },
-    [markSaving, notify],
+    [markSaving, nextAccountVersion, notify],
   );
 
   const setStrategy = useCallback<UseAccountsResult["setStrategy"]>(
     async (providerId, strategy) => {
+      stateVersionRef.current += 1;
       const key = `strategy:${providerId}`;
       markSaving(key, true);
       const previous = dataRef.current;
@@ -299,7 +359,9 @@ export function useAccounts(opts: UseAccountsOptions = {}): UseAccountsResult {
       });
       try {
         await client.patchProviderStrategy(providerId, { strategy });
+        stateVersionRef.current += 1;
       } catch (err) {
+        stateVersionRef.current += 1;
         setData(previous);
         notify("Failed to update rotation strategy", err);
         throw err;


### PR DESCRIPTION
## Summary

- accept `null` Codex primary/secondary usage windows as absent optional windows while keeping arrays, strings, and malformed records invalid
- reconcile the affected account from `/api/accounts` after a failed usage probe, preserving the original error toast and rejection
- guard account/list responses so stale concurrent polls or mutations cannot hide a newer terminal health transition
- cover the live `RATE-LIMITED` to `NEEDS-REAUTH` card transition and immediate Reauthenticate action

## Root cause

The dogfood response shape had `rate_limit.secondary_window: null`. The parser treated every present non-record value as invalid, even though OpenAI uses JSON null for an absent optional window. The failed backend probe persisted terminal `needs-reauth`, but `useAccounts.refreshUsage` only replaced local state on success. Its catch reported the parser error without reconciling `/api/accounts`, so the stale card remained `rate-limited` and AccountCard's terminal-only Reauthenticate action stayed hidden.

Only the focused null shape is represented in the test fixture. No token, user identifier, or raw provider response is logged or included here.

## Evidence

| Check | Result |
| --- | --- |
| Codex parser tests | 21 passed, including null primary/secondary and strict array/string rejection |
| UI focused tests | 22 passed across `useAccounts`, `AccountList`, and `AddAccountDialog` |
| Failed-probe UI behavior | RATE-LIMITED becomes NEEDS-REAUTH, Reauthenticate appears, original error notice remains |
| Concurrent stale poll | delayed stale `/api/accounts` result cannot overwrite reconciled terminal health |
| Replacement flow | existing `AccountList` and `AddAccountDialog` tests verify scoped credential repair and `replaceAccountId` submission |
| Formatting | Biome clean on all four changed files; `git diff --check` clean |
| Codex review | completed; race and error-policy findings addressed |

## Risk

Auth parsing and account-health UI state are touched. Do not auto-merge.

[sol-orch]


# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - state-reconciliation fix only; no visual component or styling changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - the existing account card enters its already-supported NEEDS-REAUTH state; no new visual surface was introduced.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic hook and account-list tests cover the failed-probe transition without using live credentials.
<!-- evidence-row:backend-logs -->
- [x] N/A - parser behavior is covered by credential-safe deterministic tests; raw provider responses are intentionally excluded.
<!-- evidence-row:frontend-logs -->
- [x] N/A - focused tests assert the original error notice remains while reconciled terminal health becomes visible.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no token, user identifier, or raw provider response may be attached; strict parser and UI state assertions are the safe verification surface.
