### PR TITLE
fix(ui): restore App auth-mock exports in surface fuzz tests

### DIFF
--- a/packages/ui/src/App.screen-background-fuzz.test.tsx
+++ b/packages/ui/src/App.screen-background-fuzz.test.tsx
@@ -161,6 +161,11 @@ vi.mock("./hooks/useAuthStatus", () => ({
   // the overlay throws mid-render and the mutation-isolation block below can't
   // settle the DOM to assert on. Authenticated => overlay stays out of the way.
   useIsAuthenticated: () => true,
+  // notification-store (#16242) reads these to gate + re-arm its boot hydration
+  // probe from the mounted App's notifications-boot effect; the mock must
+  // provide them or the probe throws mid-effect. Authenticated => probe on.
+  isAuthenticatedNow: () => true,
+  subscribeAuthStatus: () => vi.fn(),
 }));
 vi.mock("./hooks/useActivityEvents", () => ({
   useActivityEvents: () => ({ events: [], clearEvents: vi.fn() }),

--- a/packages/ui/src/App.surface-manifest-wallpaper.test.tsx
+++ b/packages/ui/src/App.surface-manifest-wallpaper.test.tsx
@@ -137,6 +137,11 @@ vi.mock("./hooks/useAuthStatus", () => ({
     refetch: vi.fn(),
   }),
   useIsAuthenticated: () => true,
+  // notification-store (#16242) reads these to gate + re-arm its boot hydration
+  // probe from the mounted App's notifications-boot effect; the mock must
+  // provide them or the probe throws mid-effect. Authenticated => probe on.
+  isAuthenticatedNow: () => true,
+  subscribeAuthStatus: () => vi.fn(),
 }));
 vi.mock("./hooks/useActivityEvents", () => ({
   useActivityEvents: () => ({ events: [], clearEvents: vi.fn() }),

--- a/packages/ui/src/App.surface-mutation-fuzz.test.tsx
+++ b/packages/ui/src/App.surface-mutation-fuzz.test.tsx
@@ -159,6 +159,11 @@ vi.mock("./hooks/useAuthStatus", () => ({
     refetch: vi.fn(),
   }),
   useIsAuthenticated: () => true,
+  // notification-store (#16242) reads these to gate + re-arm its boot hydration
+  // probe from the mounted App's notifications-boot effect; the mock must
+  // provide them or the probe throws mid-effect. Authenticated => probe on.
+  isAuthenticatedNow: () => true,
+  subscribeAuthStatus: () => vi.fn(),
 }));
 vi.mock("./hooks/useActivityEvents", () => ({
   useActivityEvents: () => ({ events: [], clearEvents: vi.fn() }),


### PR DESCRIPTION
## What & why

Part of the fix for the red **Client Tests** lane on `develop`, split out of #16367 so the test-only portion can merge immediately (it is exempt from the surface-artifact evidence gate).

`notification-store` (#16242) reads `isAuthenticatedNow` + `subscribeAuthStatus` from `useAuthStatus` inside the mounted App's `notifications-boot` effect. Three App fuzz tests `vi.mock("./hooks/useAuthStatus")` without those exports, so the boot probe threw mid-effect (unhandled rejection that fails the whole file). This is the same class as #16360 (which fixed `App.navigate-view-wiring`); these are the three remaining files.

Adds `isAuthenticatedNow: () => true` and `subscribeAuthStatus: () => vi.fn()` to the mock in:
- `App.surface-manifest-wallpaper.test.tsx`
- `App.surface-mutation-fuzz.test.tsx`
- `App.screen-background-fuzz.test.tsx`

## Verification

`bunx vitest run` (packages/ui) on the three files: **20 passed** (before: each failed on the current `develop` tip via the unhandled `isAuthenticatedNow` mock rejection).

## Evidence

Test-only change (only `*.test.tsx` files); no runtime or UI surface touched.

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - test-only change; only *.test.tsx mock fixtures touched`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - test-only change; only *.test.tsx mock fixtures touched`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - test-only change; nothing user-exercisable`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no production code path changed; test mock exports only`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs `N/A - no frontend change; vitest mock fixture only`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent/action/provider/prompt/model change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no domain artifacts produced; test mock fixture realignment only`.
