### PR TITLE
fix(ui): smooth notification shade motion

### DIFF
--- a/packages/ui/src/components/shell/HomeScreen.test.tsx
+++ b/packages/ui/src/components/shell/HomeScreen.test.tsx
@@ -263,9 +263,32 @@ describe("HomeScreen", () => {
       touches: [{ clientX: 202, clientY: 300 }],
     });
     fireEvent.touchEnd(home, { touches: [] });
-    act(() => vi.advanceTimersByTime(300));
+    act(() => vi.advanceTimersByTime(500));
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
     expect(screen.getByTestId("notifications-empty").style.opacity).toBe("0");
+  });
+
+  it("reveals the empty state from a mouse pull on the lower home background", () => {
+    __setHydratedForTests(true);
+    render(<HomeScreen onOpenTile={vi.fn()} />);
+    const home = screen.getByTestId("home-screen");
+    const list = screen.getByTestId("home-notification-list");
+    const pointer = {
+      isPrimary: true,
+      pointerId: 7,
+      pointerType: "mouse",
+      clientX: 200,
+    } as const;
+
+    fireEvent.pointerDown(home, { ...pointer, clientY: 620 });
+    fireEvent.pointerMove(home, { ...pointer, clientY: 760 });
+    fireEvent.pointerUp(home, { ...pointer, clientY: 760 });
+    fireEvent.click(home);
+
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+    expect(screen.getByTestId("notifications-empty").textContent).toBe(
+      "No Notifications",
+    );
   });
 
   it("reveals and closes the empty state from a trackpad swipe on the home background", () => {
@@ -289,28 +312,87 @@ describe("HomeScreen", () => {
     act(() => vi.advanceTimersByTime(500));
     fireEvent.wheel(home, { deltaY: PULL_COMMIT_PX + 10 });
     fireEvent.wheel(home, { deltaY: PULL_COMMIT_PX + 10 });
-    act(() => vi.advanceTimersByTime(300));
+    act(() => vi.advanceTimersByTime(500));
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
     expect(screen.getByTestId("notifications-empty").style.opacity).toBe("0");
   });
 
-  it("does not steal an empty-inbox gesture that begins on a home control", () => {
+  it("turns a vertical mouse drag on a lower home control into a pull without firing its click", () => {
+    __setHydratedForTests(true);
+    const onOpenTile = vi.fn();
+    render(<HomeScreen onOpenTile={onOpenTile} showNativeOsTiles />);
+    const tile = screen.getByTestId("home-tile-camera");
+    const list = screen.getByTestId("home-notification-list");
+    const pointer = {
+      isPrimary: true,
+      pointerId: 8,
+      pointerType: "mouse",
+      clientX: 200,
+    } as const;
+
+    fireEvent.pointerDown(tile, { ...pointer, clientY: 620 });
+    fireEvent.pointerMove(tile, { ...pointer, clientY: 760 });
+    fireEvent.pointerUp(tile, { ...pointer, clientY: 760 });
+    fireEvent.click(tile);
+
+    expect(onOpenTile).not.toHaveBeenCalled();
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+  });
+
+  it("yields a horizontal mouse drag on a lower home control without opening the shade", () => {
+    __setHydratedForTests(true);
+    render(<HomeScreen onOpenTile={vi.fn()} showNativeOsTiles />);
+    const tile = screen.getByTestId("home-tile-camera");
+    const list = screen.getByTestId("home-notification-list");
+    const pointer = {
+      isPrimary: true,
+      pointerId: 9,
+      pointerType: "mouse",
+      clientY: 620,
+    } as const;
+
+    fireEvent.pointerDown(tile, { ...pointer, clientX: 260 });
+    fireEvent.pointerMove(tile, {
+      ...pointer,
+      clientX: 120,
+      clientY: 624,
+    });
+    fireEvent.pointerUp(tile, {
+      ...pointer,
+      clientX: 120,
+      clientY: 624,
+    });
+
+    expect(list.getAttribute("data-shade-mode")).toBe("rested");
+    expect(screen.getByTestId("notifications-empty").style.opacity).toBe("0");
+  });
+
+  it("turns a vertical touch drag begun on a lower home control into a pull", () => {
     __setHydratedForTests(true);
     render(<HomeScreen onOpenTile={vi.fn()} showNativeOsTiles />);
     const tile = screen.getByTestId("home-tile-camera");
     const list = screen.getByTestId("home-notification-list");
 
     fireEvent.touchStart(tile, {
-      touches: [{ clientX: 200, clientY: 300 }],
+      touches: [{ clientX: 200, clientY: 620 }],
     });
     fireEvent.touchMove(tile, {
-      touches: [{ clientX: 202, clientY: 440 }],
+      touches: [{ clientX: 202, clientY: 760 }],
     });
     fireEvent.touchEnd(tile, { touches: [] });
+
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+  });
+
+  it("lets an empty-inbox trackpad pull begin on a lower home control", () => {
+    __setHydratedForTests(true);
+    render(<HomeScreen onOpenTile={vi.fn()} showNativeOsTiles />);
+    const tile = screen.getByTestId("home-tile-camera");
+    const list = screen.getByTestId("home-notification-list");
+
     fireEvent.wheel(tile, { deltaY: -(PULL_COMMIT_PX + 10) });
 
-    expect(list.getAttribute("data-shade-mode")).toBe("rested");
-    expect(screen.getByTestId("notifications-empty").style.opacity).toBe("0");
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
   });
 
   it("tapping an inline row follows its safe deep link directly", () => {

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.render-count.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.render-count.test.tsx
@@ -114,6 +114,9 @@ function expandShade(): void {
   fireEvent.wheel(screen.getByTestId("home-notification-list"), {
     deltaY: -(PULL_COMMIT_PX + 10),
   });
+  act(() => {
+    vi.advanceTimersByTime(400);
+  });
 }
 
 describe("NotificationsHomeCenter render count (#14559)", () => {
@@ -218,6 +221,9 @@ describe("NotificationsHomeCenter render count (#14559)", () => {
     });
     // A peek tap fans the producer stack and enters the expanded shade.
     fireEvent.click(screen.getAllByTestId("notification-stack-peek")[0]);
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
     expect(screen.getAllByTestId("notification-row")).toHaveLength(30);
     expect(rowRenders).toBeGreaterThanOrEqual(30);
 

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -2513,6 +2513,35 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(screen.getByTestId("notifications-count").style.opacity).toBe("0");
   });
 
+  it("keeps preview Collapse inert and ignores its deep-pull release click", () => {
+    seedTriage();
+    render(<NotificationsHomeCenter />);
+    const list = screen.getByTestId("home-notification-list");
+
+    fireEvent.touchStart(list, {
+      touches: [{ identifier: 15, clientX: 180, clientY: 120 }],
+    });
+    fireEvent.touchMove(list, {
+      touches: [{ identifier: 15, clientX: 180, clientY: 620 }],
+    });
+    const collapseFooter = screen.getByTestId("notifications-collapse-footer");
+    expect(collapseFooter.getAttribute("aria-hidden")).toBe("true");
+
+    act(() => vi.advanceTimersByTime(700));
+    fireEvent.touchEnd(list, {
+      touches: [],
+      changedTouches: [{ identifier: 15, clientX: 180, clientY: 620 }],
+    });
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+    expect(collapseFooter.getAttribute("aria-hidden")).toBeNull();
+
+    fireEvent.click(screen.getByTestId("notifications-collapse"));
+    expect(list.hasAttribute("data-shade-settling")).toBe(false);
+
+    fireEvent.click(screen.getByTestId("notifications-collapse"));
+    expect(list.hasAttribute("data-shade-settling")).toBe(true);
+  });
+
   it("keeps an owned touch pull after preview scroll anchoring", () => {
     seedTriage();
     render(<NotificationsHomeCenter />);

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -2666,6 +2666,43 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
   });
 
+  it("keeps a deep lower-surface touch pull open through its synthetic release click", () => {
+    seedTriage();
+    const surfaceRef = { current: null as HTMLElement | null };
+    render(
+      <div
+        ref={(node) => {
+          surfaceRef.current = node;
+        }}
+        data-testid="home-gesture-surface"
+      >
+        <NotificationsHomeCenter emptyGestureTargetRef={surfaceRef} />
+      </div>,
+    );
+    const surface = screen.getByTestId("home-gesture-surface");
+    const list = screen.getByTestId("home-notification-list");
+
+    fireEvent.touchStart(surface, {
+      touches: [{ identifier: 14, clientX: 180, clientY: 220 }],
+    });
+    fireEvent.touchMove(surface, {
+      touches: [{ identifier: 14, clientX: 180, clientY: 620 }],
+    });
+    // A slow hold must not let the release-click guard expire before touchend.
+    act(() => vi.advanceTimersByTime(700));
+    fireEvent.touchEnd(surface, {
+      touches: [],
+      changedTouches: [{ identifier: 14, clientX: 180, clientY: 620 }],
+    });
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+
+    fireEvent.click(surface, { clientY: 620 });
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+
+    fireEvent.click(surface, { clientY: 620 });
+    expect(list.hasAttribute("data-shade-settling")).toBe(true);
+  });
+
   it("a continuous drag that scrolls the expanded list back to the top does NOT collapse (re-base at the crossing)", () => {
     seedTriage();
     render(<NotificationsHomeCenter />);

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -893,6 +893,7 @@ describe("NotificationsHomeCenter", () => {
     expandShade();
     const clear = screen.getByTestId("notifications-clear-all");
     expect(clear.parentElement?.className).not.toContain("sticky");
+    expect(clear.parentElement?.className).toContain("px-2");
     expect(clear.parentElement).toBe(
       screen.getByTestId("home-notification-list").firstElementChild,
     );
@@ -921,6 +922,11 @@ describe("NotificationsHomeCenter", () => {
     expect(css).toContain(".eliza-notif-glass");
     expect(css).toContain("backdrop-filter");
     expect(css).toContain("box-shadow");
+    const focusedGlassRule = css.match(
+      /\.eliza-notif-glass:focus-within\s*\{([^}]*)\}/,
+    )?.[1];
+    expect(focusedGlassRule).toContain("box-shadow:");
+    expect(focusedGlassRule).toContain("!important");
     expect(css).toContain(".eliza-notif-row-inner[data-swipe-dragging]");
     expect(surface.getAttribute("data-swipe-dragging")).toBeNull();
   });
@@ -1157,6 +1163,7 @@ describe("NotificationsHomeCenter (Z-stacked groups)", () => {
     fireEvent.click(openingPeek, { detail: 0 });
     expect(screen.getAllByTestId("notification-row")).toHaveLength(3);
     const enteringControls = screen.getByTestId("notification-stack-controls");
+    expect(enteringControls.className).toContain("px-2");
     const groupContent = document.querySelector(
       "[data-notification-group-content]",
     ) as HTMLElement;

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -2203,6 +2203,15 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       pointerType: "mouse",
       pointerId: 108,
       clientX: 10,
+      clientY: 80,
+    });
+    // Establish the React drag state before the deep move. Subsequent frames
+    // update the runway imperatively, which is the real-browser path that can
+    // otherwise leave stale padding behind on release.
+    fireEvent.pointerMove(list, {
+      pointerType: "mouse",
+      pointerId: 108,
+      clientX: 10,
       clientY: 142,
     });
     act(() => vi.advanceTimersByTime(20));
@@ -2241,7 +2250,7 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
     expect(list.hasAttribute("data-shade-dragging")).toBe(false);
     expect(list.style.getPropertyValue("--eliza-notif-pull-overshoot")).toBe(
-      "0px",
+      "",
     );
   });
 

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -5,7 +5,7 @@
 // Pins the shade spec: priority-only triage, liquid-glass Z-stacked groups
 // with no headers/dividers, DIRECTIONAL pull/wheel expand-collapse (down
 // expands, up collapses — never a toggle, so trailing trackpad momentum can't
-// snap the shade back shut), a passive notification total, direct-tap
+// snap the shade back shut), an interactive notification total, direct-tap
 // activation, and swipe-to-dismiss.
 
 import {
@@ -57,9 +57,66 @@ import {
   notificationPullRevealProgress,
   orderDashboardNotifications,
   PULL_COMMIT_PX,
+  STACK_FOLD_SETTLE_MS,
 } from "./NotificationsHomeCenter";
+import {
+  notificationGroupContainerOffset,
+  PULL_TRAVEL_PX,
+} from "./notification-shade-presentation";
 
 let seq = 0;
+let restoreMatchMediaForTest: (() => void) | null = null;
+
+function installReducedMotionController(initialMatches = false): {
+  setMatches: (matches: boolean) => void;
+} {
+  const originalDescriptor = Object.getOwnPropertyDescriptor(
+    window,
+    "matchMedia",
+  );
+  const listeners = new Set<(event: MediaQueryListEvent) => void>();
+  let matches = initialMatches;
+  const media = "(prefers-reduced-motion: reduce)";
+  const mediaQuery = {
+    get matches() {
+      return matches;
+    },
+    media,
+    onchange: null,
+    addEventListener: (
+      _type: string,
+      listener: (event: MediaQueryListEvent) => void,
+    ) => listeners.add(listener),
+    removeEventListener: (
+      _type: string,
+      listener: (event: MediaQueryListEvent) => void,
+    ) => listeners.delete(listener),
+    addListener: (listener: (event: MediaQueryListEvent) => void) =>
+      listeners.add(listener),
+    removeListener: (listener: (event: MediaQueryListEvent) => void) =>
+      listeners.delete(listener),
+  } as unknown as MediaQueryList;
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: () => mediaQuery,
+  });
+  restoreMatchMediaForTest = () => {
+    if (originalDescriptor) {
+      Object.defineProperty(window, "matchMedia", originalDescriptor);
+    } else {
+      Reflect.deleteProperty(window, "matchMedia");
+    }
+    restoreMatchMediaForTest = null;
+  };
+  return {
+    setMatches: (nextMatches: boolean) => {
+      matches = nextMatches;
+      const event = { matches, media } as MediaQueryListEvent;
+      for (const listener of listeners) listener(event);
+    },
+  };
+}
+
 function makeNotification(
   overrides: Partial<AgentNotification> = {},
 ): AgentNotification {
@@ -82,6 +139,7 @@ function makeNotification(
 function expandShade(): HTMLElement {
   const list = screen.getByTestId("home-notification-list");
   fireEvent.wheel(list, { deltaY: -(PULL_COMMIT_PX + 10) });
+  act(() => vi.advanceTimersByTime(40));
   return list;
 }
 
@@ -94,7 +152,11 @@ function collapseShade(): HTMLElement {
 }
 
 function finishShadeCollapse(): void {
-  act(() => vi.advanceTimersByTime(250));
+  act(() => vi.advanceTimersByTime(400));
+}
+
+function finishStackFold(): void {
+  act(() => vi.advanceTimersByTime(STACK_FOLD_SETTLE_MS + 40));
 }
 
 function setOverflowingListGeometry(list: HTMLElement): void {
@@ -123,6 +185,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  restoreMatchMediaForTest?.();
   vi.clearAllTimers();
   vi.useRealTimers();
   __resetNotificationStoreForTests();
@@ -309,12 +372,27 @@ describe("interrupt priority projection", () => {
     expect(navigateDeepLink).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByTestId("notification-stack-collapse"));
-    finishShadeCollapse();
+    expect(screen.getAllByTestId("notification-row")).toHaveLength(2);
+    expect(
+      document.querySelector("[data-notification-stack-closing]"),
+    ).toBeTruthy();
+    expect(list.hasAttribute("data-shade-settling")).toBe(true);
+    act(() => vi.advanceTimersByTime(STACK_FOLD_SETTLE_MS - 1));
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+    expect(
+      document.querySelector("[data-notification-stack-closing]"),
+    ).toBeTruthy();
+    act(() => vi.advanceTimersByTime(1));
+    expect(
+      document.querySelector("[data-notification-stack-closing]"),
+    ).toBeTruthy();
+    act(() => vi.advanceTimersByTime(40));
     expect(
       screen
         .getByTestId("home-notification-list")
         .getAttribute("data-shade-mode"),
     ).toBe("rested");
+    expect(list.hasAttribute("data-shade-settling")).toBe(false);
     expect(screen.getAllByTestId("notification-row")).toHaveLength(1);
     expect(screen.queryByTestId("notification-stack-controls")).toBeNull();
 
@@ -460,6 +538,8 @@ describe("interrupt priority projection", () => {
       clientY: 70,
     });
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
+    expect(screen.getAllByTestId("notification-row")).toHaveLength(6);
+    act(() => vi.advanceTimersByTime(340));
     expect(screen.queryAllByTestId("notification-row")).toHaveLength(0);
   });
 });
@@ -499,23 +579,26 @@ describe("notification producer grouping", () => {
 });
 
 describe("dampenPull", () => {
-  it("has a slop dead zone, applies deliberate resistance, and clamps", () => {
+  it("tracks directly between detents and resists only after the endpoint", () => {
     expect(dampenPull(0)).toBe(0);
     expect(dampenPull(8)).toBe(0); // inside the dead zone
-    expect(dampenPull(48)).toBe(20); // (48-8) × 0.5
-    expect(dampenPull(104)).toBe(PULL_COMMIT_PX);
-    expect(dampenPull(10_000)).toBe(88); // clamped rubber band
+    expect(dampenPull(48)).toBe(40);
+    expect(dampenPull(52)).toBe(PULL_COMMIT_PX);
+    expect(dampenPull(96)).toBe(PULL_TRAVEL_PX);
+    expect(dampenPull(124)).toBeCloseTo(97.8);
   });
 });
 
 describe("notificationPullRevealProgress", () => {
-  it("tracks pull travel, staggers later groups, and finishes by commit", () => {
+  it("tracks full detent travel while staggering later groups", () => {
     expect(notificationPullRevealProgress(0, 0)).toBe(0);
-    expect(notificationPullRevealProgress(PULL_COMMIT_PX / 2, 0)).toBe(0.5);
-    expect(notificationPullRevealProgress(PULL_COMMIT_PX / 2, 2)).toBeLessThan(
+    expect(notificationPullRevealProgress(PULL_TRAVEL_PX / 2, 0)).toBe(0.5);
+    expect(
+      notificationPullRevealProgress(PULL_TRAVEL_PX / 2, 2),
+    ).toBeLessThan(
       0.5,
     );
-    expect(notificationPullRevealProgress(PULL_COMMIT_PX, 4)).toBe(1);
+    expect(notificationPullRevealProgress(PULL_TRAVEL_PX, 4)).toBe(1);
   });
 });
 
@@ -977,7 +1060,10 @@ describe("NotificationsHomeCenter (Z-stacked groups)", () => {
       // Peeks are TAPPABLE (tap fans the stack) and remain crisp.
       expect(peek.tagName).toBe("BUTTON");
       expect(peek.style.filter).toBe("");
-      expect(peek.style.bottom).toBe("24px");
+      expect(peek.className).toContain("inset-0");
+      expect(peek.closest("[data-notif-row]")).toBe(
+        rows[0]?.closest("[data-notif-row]"),
+      );
     }
     // Deeper cards sit lower in Z and protrude further.
     expect(Number(peeks[0].style.zIndex)).toBeGreaterThan(
@@ -1064,8 +1150,37 @@ describe("NotificationsHomeCenter (Z-stacked groups)", () => {
     expect(screen.getAllByTestId("notification-row")).toHaveLength(1);
     expect(screen.getByTestId("notification-stack")).toBeTruthy();
     // Tapping the peeked card below the top one fans the stack out.
-    fireEvent.click(screen.getAllByTestId("notification-stack-peek")[0]);
+    const openingPeek = screen.getAllByTestId("notification-stack-peek")[0];
+    openingPeek.focus();
+    fireEvent.click(openingPeek, { detail: 0 });
     expect(screen.getAllByTestId("notification-row")).toHaveLength(3);
+    const enteringControls = screen.getByTestId("notification-stack-controls");
+    const groupContent = document.querySelector(
+      "[data-notification-group-content]",
+    ) as HTMLElement;
+    const closingPeeks = Array.from(
+      document.querySelectorAll<HTMLElement>("[data-notification-stack-peek]"),
+    );
+    expect(enteringControls.style.height).toBe("0px");
+    expect(enteringControls.style.opacity).toBe("0");
+    expect(groupContent.style.paddingBottom).toBe("24px");
+    expect(closingPeeks).toHaveLength(2);
+    expect(closingPeeks.every((peek) => peek.style.opacity === "1")).toBe(true);
+    const enteringRows = screen
+      .getAllByTestId("notification-row")
+      .slice(1)
+      .map((row) => row.closest("[data-notif-row]") as HTMLElement);
+    expect(enteringRows.every((row) => row.style.opacity === "0")).toBe(true);
+
+    act(() => vi.advanceTimersByTime(40));
+    expect(enteringControls.style.height).toBe("36px");
+    expect(enteringControls.style.opacity).toBe("1");
+    expect(enteringRows.every((row) => row.style.opacity === "1")).toBe(true);
+    expect(groupContent.style.paddingBottom).toBe("16px");
+    expect(closingPeeks.every((peek) => peek.style.opacity === "0")).toBe(true);
+    expect(document.activeElement).toBe(
+      screen.getByTestId("notification-stack-collapse"),
+    );
     expect(screen.queryByTestId("notification-stack")).toBeNull();
     expect(screen.queryByTestId("notification-stack-peek")).toBeNull();
     // Priority order inside the fanned group: urgent first.
@@ -1089,10 +1204,41 @@ describe("NotificationsHomeCenter (Z-stacked groups)", () => {
       ) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(screen.queryByTestId("notifications-collapse")).toBeNull();
-    fireEvent.click(screen.getByTestId("notification-stack-collapse"));
+    fireEvent.click(screen.getByTestId("notification-stack-collapse"), {
+      detail: 0,
+    });
+    expect(screen.getAllByTestId("notification-row")).toHaveLength(3);
+    expect(enteringControls.style.height).toBe("0px");
+    expect(enteringControls.style.opacity).toBe("0");
+    expect(groupContent.style.paddingBottom).toBe("24px");
+    expect(closingPeeks.every((peek) => peek.style.opacity === "1")).toBe(true);
+    expect(enteringControls.getAttribute("aria-hidden")).toBe("true");
+    expect(enteringControls.hasAttribute("inert")).toBe(true);
+    expect(
+      closingPeeks.every(
+        (peek) =>
+          peek.getAttribute("aria-hidden") === "true" &&
+          peek.getAttribute("tabindex") === "-1" &&
+          peek.hasAttribute("disabled"),
+      ),
+    ).toBe(true);
+    expect(
+      screen
+        .getByTestId("notification-stack-collapse")
+        .hasAttribute("disabled"),
+    ).toBe(true);
+    expect(document.activeElement).toBe(
+      screen.getAllByTestId("notification-row")[0],
+    );
+    act(() => vi.advanceTimersByTime(STACK_FOLD_SETTLE_MS - 1));
+    expect(screen.getAllByTestId("notification-row")).toHaveLength(3);
+    act(() => vi.advanceTimersByTime(1));
+    expect(screen.getAllByTestId("notification-row")).toHaveLength(3);
+    act(() => vi.advanceTimersByTime(40));
     expect(screen.getAllByTestId("notification-row")).toHaveLength(1);
     expect(screen.getByTestId("notification-stack")).toBeTruthy();
     expect(screen.queryByTestId("notification-stack-collapse")).toBeNull();
+    expect(document.activeElement).toBe(screen.getByTestId("notification-row"));
     expect(screen.getByTestId("notifications-collapse").textContent).toContain(
       "Collapse",
     );
@@ -1123,6 +1269,106 @@ describe("NotificationsHomeCenter (Z-stacked groups)", () => {
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
     expect(screen.getAllByTestId("notification-row")).toHaveLength(3);
     expect(screen.queryByTestId("notification-stack-peek")).toBeNull();
+  });
+
+  it("does not let an older fold auto-close a stack opened during its settle", () => {
+    __ingestNotificationForTests(
+      makeNotification({ title: "A older", source: "calendar" }),
+    );
+    __ingestNotificationForTests(
+      makeNotification({ title: "A newest", source: "calendar" }),
+    );
+    __ingestNotificationForTests(
+      makeNotification({ title: "B older", source: "mail" }),
+    );
+    __ingestNotificationForTests(
+      makeNotification({ title: "B newest", source: "mail" }),
+    );
+    render(<NotificationsHomeCenter />);
+    const groupA = screen
+      .getByText("A newest")
+      .closest<HTMLElement>("[data-notification-group]");
+    const groupB = screen
+      .getByText("B newest")
+      .closest<HTMLElement>("[data-notification-group]");
+    expect(groupA).toBeTruthy();
+    expect(groupB).toBeTruthy();
+
+    fireEvent.click(
+      groupA?.querySelector<HTMLElement>(
+        '[data-testid="notification-row"]',
+      ) as HTMLElement,
+    );
+    act(() => vi.advanceTimersByTime(40));
+    fireEvent.click(
+      groupA?.querySelector<HTMLElement>(
+        '[data-testid="notification-stack-collapse"]',
+      ) as HTMLElement,
+    );
+    fireEvent.click(
+      groupB?.querySelector<HTMLElement>(
+        '[data-testid="notification-row"]',
+      ) as HTMLElement,
+    );
+    act(() => vi.advanceTimersByTime(40));
+    expect(screen.getAllByTestId("notification-stack-controls")).toHaveLength(
+      2,
+    );
+
+    finishStackFold();
+    expect(screen.getAllByTestId("notification-stack-controls")).toHaveLength(
+      1,
+    );
+    expect(
+      groupB?.querySelector('[data-testid="notification-stack-controls"]'),
+    ).toBeTruthy();
+    expect(
+      screen
+        .getByTestId("home-notification-list")
+        .getAttribute("data-shade-mode"),
+    ).toBe("expanded");
+    finishShadeCollapse();
+    expect(
+      screen
+        .getByTestId("home-notification-list")
+        .getAttribute("data-shade-mode"),
+    ).toBe("expanded");
+  });
+
+  it("finishes an in-flight fold immediately when reduced motion turns on", () => {
+    const motionPreference = installReducedMotionController();
+    __ingestNotificationForTests(makeNotification({ title: "A" }));
+    __ingestNotificationForTests(makeNotification({ title: "B" }));
+    __ingestNotificationForTests(makeNotification({ title: "C" }));
+    render(<NotificationsHomeCenter />);
+    expandShade();
+    fireEvent.click(screen.getAllByTestId("notification-stack-peek")[0]);
+    act(() => vi.advanceTimersByTime(40));
+    fireEvent.click(screen.getByTestId("notification-stack-collapse"));
+    expect(
+      document.querySelector("[data-notification-stack-closing]"),
+    ).toBeTruthy();
+    expect(screen.getAllByTestId("notification-row")).toHaveLength(3);
+
+    act(() => motionPreference.setMatches(true));
+    expect(
+      document.querySelector("[data-notification-stack-closing]"),
+    ).toBeNull();
+    expect(screen.queryByTestId("notification-stack-controls")).toBeNull();
+    expect(screen.getAllByTestId("notification-row")).toHaveLength(1);
+    expect(
+      screen
+        .getByTestId("home-notification-list")
+        .getAttribute("data-shade-mode"),
+    ).toBe("expanded");
+
+    act(() => vi.advanceTimersByTime(STACK_FOLD_SETTLE_MS + 250));
+    expect(screen.getAllByTestId("notification-row")).toHaveLength(1);
+    expect(
+      screen
+        .getByTestId("home-notification-list")
+        .getAttribute("data-shade-mode"),
+    ).toBe("expanded");
   });
 
   it("requires X then Clear before removing only that producer stack", () => {
@@ -1321,7 +1567,8 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(list.className).toContain("pb-2");
     expect(list.className).toContain("scroll-fade");
     expect(list.className).toContain("scroll-fade-b-[1.5rem]");
-    fireEvent.click(collapse);
+    collapse.focus();
+    fireEvent.click(collapse, { detail: 0 });
     // The total crossfades in while expanded rows settle, so release does not
     // leave an empty beat before the rested count appears.
     expect(screen.getByTestId("notifications-count").style.opacity).toBe("1");
@@ -1332,11 +1579,22 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       priorityRow.closest<HTMLElement>("[data-notification-group]")?.style
         .opacity,
     ).not.toBe("0");
+    expect(document.activeElement).toBe(
+      screen.getByTestId("notifications-count-button"),
+    );
+    expect(
+      screen
+        .getByTestId("notifications-count-button")
+        .getAttribute("aria-expanded"),
+    ).toBe("false");
     expect(screen.getByTestId("notifications-collapse")).toBeTruthy();
     finishShadeCollapse();
     expect(screen.queryByTestId("notifications-collapse")).toBeNull();
     expect(screen.getByTestId("notification-row")).toBe(priorityRow);
     expect(screen.getByTestId("notifications-count").style.opacity).toBe("1");
+    expect(document.activeElement).toBe(
+      screen.getByTestId("notifications-count-button"),
+    );
   });
 
   it("opens from the notification total without treating a pointer drag as a click", () => {
@@ -1373,6 +1631,33 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     fireEvent.click(countButton);
 
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
+  });
+
+  it("animates groups that mount when the notification total opens the shade", () => {
+    __ingestNotificationForTests(
+      makeNotification({ priority: "normal", title: "Quiet thing" }),
+    );
+    render(<NotificationsHomeCenter />);
+
+    const countButton = screen.getByTestId("notifications-count-button");
+    countButton.focus();
+    fireEvent.click(countButton, { detail: 0 });
+    const groupContent = document.querySelector(
+      "[data-notification-group-content]",
+    ) as HTMLElement;
+    expect(groupContent.style.opacity).toBe("0");
+    expect(groupContent.style.transform).toContain("-8px");
+    expect(
+      screen.getByTestId("notifications-collapse-footer").style.opacity,
+    ).toBe("0");
+
+    act(() => vi.advanceTimersByTime(40));
+    expect(groupContent.style.opacity).toBe("1");
+    expect(groupContent.style.transform).toContain("0px");
+    expect(
+      screen.getByTestId("notifications-collapse-footer").style.opacity,
+    ).toBe("1");
+    expect(document.activeElement).toBe(screen.getByTestId("notification-row"));
   });
 
   it("keeps the priority row mounted while an outside tap fades quiet groups", () => {
@@ -1496,23 +1781,50 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       pointerType: "mouse",
       pointerId: 83,
       clientX: 12,
-      clientY: 92,
+      clientY: 116,
     });
 
-    const filesOpacity = Number.parseFloat(filesGroup?.style.opacity ?? "1");
-    const agentOpacity = Number.parseFloat(agentGroup?.style.opacity ?? "1");
+    let filesOpacity = Number.parseFloat(filesGroup?.style.opacity ?? "1");
+    let agentOpacity = Number.parseFloat(agentGroup?.style.opacity ?? "1");
     expect(filesOpacity).toBeGreaterThan(0);
     expect(filesOpacity).toBeLessThan(1);
     expect(agentOpacity).toBeLessThan(filesOpacity);
-    const countOpacity = Number.parseFloat(
+    let countOpacity = Number.parseFloat(
       screen.getByTestId("notifications-count").style.opacity,
     );
-    const collapseOpacity = Number.parseFloat(
+    let collapseOpacity = Number.parseFloat(
       screen.getByTestId("notifications-collapse-footer").style.opacity,
     );
     expect(countOpacity).toBeGreaterThan(0);
     expect(countOpacity).toBeLessThan(1);
-    expect(collapseOpacity).toBeCloseTo(1 - countOpacity);
+    expect(collapseOpacity).toBeGreaterThan(0);
+    expect(collapseOpacity).toBeLessThan(1);
+    expect(countOpacity).toBeLessThan(filesOpacity);
+    expect(screen.getByTestId("notifications-count").style.clipPath).toBe("");
+
+    fireEvent.pointerMove(list, {
+      pointerType: "mouse",
+      pointerId: 83,
+      clientX: 12,
+      clientY: 92,
+    });
+    act(() => vi.advanceTimersByTime(20));
+    filesOpacity = Number.parseFloat(filesGroup?.style.opacity ?? "1");
+    agentOpacity = Number.parseFloat(agentGroup?.style.opacity ?? "1");
+    countOpacity = Number.parseFloat(
+      screen.getByTestId("notifications-count").style.opacity,
+    );
+    collapseOpacity = Number.parseFloat(
+      screen.getByTestId("notifications-collapse-footer").style.opacity,
+    );
+    expect(filesOpacity).toBeGreaterThan(0);
+    expect(filesOpacity).toBeLessThan(1);
+    expect(agentOpacity).toBeGreaterThan(0);
+    expect(agentOpacity).toBeLessThan(filesOpacity);
+    expect(countOpacity).toBeGreaterThan(0);
+    expect(countOpacity).toBeLessThan(1);
+    expect(collapseOpacity).toBeGreaterThan(0);
+    expect(collapseOpacity).toBeLessThan(1);
 
     fireEvent.pointerMove(list, {
       pointerType: "mouse",
@@ -1520,6 +1832,7 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       clientX: 12,
       clientY: 160,
     });
+    act(() => vi.advanceTimersByTime(20));
     expect(filesGroup?.style.opacity).toBe("1");
     expect(agentGroup?.style.opacity).toBe("1");
     expect(screen.getByTestId("notifications-count").style.opacity).toBe("0");
@@ -1733,15 +2046,6 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     );
     expect(countOpacity).toBeGreaterThan(0);
     expect(countOpacity).toBeLessThan(1);
-    const clear = screen.getByTestId("notifications-clear-all");
-    const clearReveal = clear.closest("li") as HTMLElement;
-    expect(Number.parseFloat(clearReveal.style.opacity)).toBeGreaterThan(0);
-    expect(Number.parseFloat(clearReveal.style.opacity)).toBeLessThan(1);
-    const collapseReveal = Number.parseFloat(
-      screen.getByTestId("notifications-collapse-footer").style.opacity,
-    );
-    expect(collapseReveal).toBeGreaterThan(0);
-    expect(collapseReveal).toBeLessThan(1);
     const revealedGroups = list.querySelectorAll(
       ":scope > [data-notification-pull-reveal]",
     );
@@ -1751,10 +2055,65 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       expect(opacity).toBeGreaterThan(0);
       expect(opacity).toBeLessThan(1);
     }
+
+    fireEvent.pointerMove(list, {
+      pointerType: "mouse",
+      pointerId: 10,
+      clientX: 10,
+      clientY: 80,
+    });
+    act(() => vi.advanceTimersByTime(20));
+    expect(
+      Number.parseFloat(
+        screen.getByTestId("notifications-count").style.opacity,
+      ),
+    ).toBeGreaterThan(0);
+    const expectedCountOffset = notificationGroupContainerOffset(
+      dampenPull(70),
+      false,
+      false,
+    );
+    expect(screen.getByTestId("notifications-count").style.transform).toBe(
+      `translate3d(0, ${expectedCountOffset}px, 0)`,
+    );
+    const clear = screen.getByTestId("notifications-clear-all");
+    const clearReveal = clear.closest("li") as HTMLElement;
+    expect(Number.parseFloat(clearReveal.style.opacity)).toBeGreaterThan(0);
+    expect(Number.parseFloat(clearReveal.style.opacity)).toBeLessThan(1);
+    const collapseReveal = Number.parseFloat(
+      screen.getByTestId("notifications-collapse-footer").style.opacity,
+    );
+    expect(collapseReveal).toBeGreaterThan(0);
+    expect(collapseReveal).toBeLessThan(1);
+    for (const group of revealedGroups) {
+      const opacity = Number.parseFloat((group as HTMLElement).style.opacity);
+      expect(opacity).toBeGreaterThan(0);
+      expect(opacity).toBeLessThan(1);
+    }
   });
 
   it("a short pull springs back without toggling", () => {
-    seedTriage();
+    __ingestNotificationForTests(
+      makeNotification({
+        priority: "urgent",
+        source: "mail",
+        title: "Urgent mail",
+      }),
+    );
+    __ingestNotificationForTests(
+      makeNotification({
+        priority: "normal",
+        source: "files",
+        title: "Files updated",
+      }),
+    );
+    __ingestNotificationForTests(
+      makeNotification({
+        priority: "low",
+        source: "agent",
+        title: "Agent summary",
+      }),
+    );
     render(<NotificationsHomeCenter />);
     const list = screen.getByTestId("home-notification-list");
     fireEvent.pointerDown(list, {
@@ -1770,6 +2129,12 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       clientX: 10,
       clientY: 40, // 30px raw → dampened 11px < commit
     });
+    const previewGroups = Array.from(
+      list.querySelectorAll<HTMLElement>("[data-notification-pull-reveal]"),
+    );
+    expect(previewGroups).toHaveLength(2);
+    expect(screen.getByTestId("notifications-clear-all")).toBeTruthy();
+    expect(screen.getByTestId("notifications-collapse")).toBeTruthy();
     fireEvent.pointerUp(list, {
       pointerType: "mouse",
       pointerId: 9,
@@ -1777,8 +2142,182 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       clientY: 40,
     });
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
+    const center = screen.getByTestId("home-notification-center");
+    expect(center.hasAttribute("data-notification-shade-cancelling")).toBe(
+      true,
+    );
+    expect(list.getAttribute("data-shade-preview")).toBe("expanding");
+    expect(
+      previewGroups.every(
+        (group) =>
+          group.isConnected &&
+          group.classList.contains("eliza-notif-shade-transition") &&
+          group.style.opacity === "0",
+      ),
+    ).toBe(true);
+    expect(screen.getByTestId("notifications-clear-all")).toBeTruthy();
+    expect(screen.getByTestId("notifications-collapse")).toBeTruthy();
+    act(() => vi.advanceTimersByTime(100));
+    expect(previewGroups.every((group) => group.isConnected)).toBe(true);
+    expect(screen.getByTestId("notifications-clear-all")).toBeTruthy();
+    expect(screen.getByTestId("notifications-collapse")).toBeTruthy();
+    act(() => vi.advanceTimersByTime(239));
+    expect(center.hasAttribute("data-notification-shade-cancelling")).toBe(
+      true,
+    );
+    expect(previewGroups.every((group) => group.isConnected)).toBe(true);
+    act(() => vi.advanceTimersByTime(1));
+    expect(center.hasAttribute("data-notification-shade-cancelling")).toBe(
+      false,
+    );
+    expect(previewGroups.every((group) => !group.isConnected)).toBe(true);
+    expect(screen.queryByTestId("notifications-clear-all")).toBeNull();
+    expect(screen.queryByTestId("notifications-collapse")).toBeNull();
     expect(screen.queryAllByTestId("notification-row")).toHaveLength(1);
-    expect(screen.getAllByTestId("notification-stack-peek")).toHaveLength(2);
+  });
+
+  it("keeps the same preview nodes mounted when an active pull crosses zero", () => {
+    __ingestNotificationForTests(
+      makeNotification({ priority: "urgent", source: "mail" }),
+    );
+    __ingestNotificationForTests(
+      makeNotification({ priority: "normal", source: "files" }),
+    );
+    render(<NotificationsHomeCenter />);
+    const list = screen.getByTestId("home-notification-list");
+    fireEvent.pointerDown(list, {
+      pointerType: "mouse",
+      isPrimary: true,
+      pointerId: 109,
+      clientX: 10,
+      clientY: 10,
+    });
+    fireEvent.pointerMove(list, {
+      pointerType: "mouse",
+      pointerId: 109,
+      clientX: 10,
+      clientY: 80,
+    });
+    const preview = list.querySelector<HTMLElement>(
+      "[data-notification-pull-reveal]",
+    );
+    expect(preview).toBeTruthy();
+
+    fireEvent.pointerMove(list, {
+      pointerType: "mouse",
+      pointerId: 109,
+      clientX: 10,
+      clientY: 10,
+    });
+    act(() => vi.advanceTimersByTime(20));
+    expect(list.getAttribute("data-shade-dragging")).not.toBeNull();
+    expect(list.querySelector("[data-notification-pull-reveal]")).toBe(preview);
+    expect(preview?.style.opacity).toBe("0");
+
+    fireEvent.pointerMove(list, {
+      pointerType: "mouse",
+      pointerId: 109,
+      clientX: 10,
+      clientY: 80,
+    });
+    act(() => vi.advanceTimersByTime(20));
+    expect(list.querySelector("[data-notification-pull-reveal]")).toBe(preview);
+    expect(Number.parseFloat(preview?.style.opacity ?? "0")).toBeGreaterThan(0);
+
+    fireEvent.pointerUp(list, {
+      pointerType: "mouse",
+      pointerId: 109,
+      clientX: 10,
+      clientY: 80,
+    });
+    expect(preview?.isConnected).toBe(true);
+    act(() => vi.advanceTimersByTime(340));
+    expect(preview?.isConnected).toBe(false);
+  });
+
+  it("clears a cancelled-pull settle before starting a committed collapse", () => {
+    seedTriage();
+    render(<NotificationsHomeCenter />);
+    const list = expandShade();
+    fireEvent.pointerDown(list, {
+      pointerType: "mouse",
+      isPrimary: true,
+      pointerId: 110,
+      clientX: 10,
+      clientY: 160,
+    });
+    fireEvent.pointerMove(list, {
+      pointerType: "mouse",
+      pointerId: 110,
+      clientX: 10,
+      clientY: 130,
+    });
+    fireEvent.pointerUp(list, {
+      pointerType: "mouse",
+      pointerId: 110,
+      clientX: 10,
+      clientY: 130,
+    });
+    const center = screen.getByTestId("home-notification-center");
+    expect(center.hasAttribute("data-notification-shade-cancelling")).toBe(
+      true,
+    );
+
+    act(() => vi.advanceTimersByTime(100));
+    fireEvent.click(screen.getByTestId("notifications-collapse"));
+    expect(center.hasAttribute("data-notification-shade-cancelling")).toBe(
+      false,
+    );
+    act(() => vi.advanceTimersByTime(219));
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+    act(() => vi.advanceTimersByTime(1));
+    expect(list.getAttribute("data-shade-mode")).toBe("rested");
+  });
+
+  it("clears a cancelled-pull settle before a stack opens", () => {
+    __ingestNotificationForTests(
+      makeNotification({ priority: "urgent", source: "calendar" }),
+    );
+    __ingestNotificationForTests(
+      makeNotification({ priority: "normal", source: "calendar" }),
+    );
+    render(<NotificationsHomeCenter />);
+    const list = screen.getByTestId("home-notification-list");
+    fireEvent.pointerDown(list, {
+      pointerType: "mouse",
+      isPrimary: true,
+      pointerId: 111,
+      clientX: 10,
+      clientY: 10,
+    });
+    fireEvent.pointerMove(list, {
+      pointerType: "mouse",
+      pointerId: 111,
+      clientX: 10,
+      clientY: 40,
+    });
+    fireEvent.pointerUp(list, {
+      pointerType: "mouse",
+      pointerId: 111,
+      clientX: 10,
+      clientY: 40,
+    });
+    const center = screen.getByTestId("home-notification-center");
+    expect(center.hasAttribute("data-notification-shade-cancelling")).toBe(
+      true,
+    );
+
+    // The list consumes the first post-drag synthetic click. The next click is
+    // the intentional activation and must start on its own transition clock.
+    fireEvent.click(screen.getByTestId("notification-row"));
+    fireEvent.click(screen.getByTestId("notification-row"));
+    expect(center.hasAttribute("data-notification-shade-cancelling")).toBe(
+      false,
+    );
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+    expect(screen.getByTestId("notification-stack-controls")).toBeTruthy();
+    act(() => vi.advanceTimersByTime(340));
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
   });
 
   it("a touch pull-down expands the shade (native non-passive listener path)", () => {
@@ -1827,11 +2366,32 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
   });
 
   it("trackpad fingers-down (wheel deltaY < 0) at the top expands the rested shade", () => {
-    seedTriage();
+    __ingestNotificationForTests(
+      makeNotification({
+        priority: "urgent",
+        source: "urgent-source",
+        title: "Urgent thing",
+      }),
+    );
+    __ingestNotificationForTests(
+      makeNotification({
+        priority: "normal",
+        source: "normal-source",
+        title: "Normal thing",
+      }),
+    );
     render(<NotificationsHomeCenter />);
     const list = screen.getByTestId("home-notification-list");
     fireEvent.wheel(list, { deltaY: -(PULL_COMMIT_PX + 10) });
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+    const quietGroup = screen
+      .getByText("Normal thing")
+      .closest("[data-notification-group-content]") as HTMLElement;
+    expect(quietGroup.style.opacity).toBe("0");
+    expect(quietGroup.style.transform).toContain("-8px");
+    act(() => vi.advanceTimersByTime(40));
+    expect(quietGroup.style.opacity).toBe("1");
+    expect(quietGroup.style.transform).toContain("0px");
   });
 
   it("the wheel gesture is DIRECTIONAL: trailing same-direction momentum never collapses what it just expanded", () => {
@@ -1970,6 +2530,136 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
 
     finishShadeCollapse();
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
+  });
+
+  it("an upward mouse drag on the empty notification region collapses the shade", () => {
+    seedTriage();
+    render(<NotificationsHomeCenter />);
+    const list = expandShade();
+    const center = screen.getByTestId("home-notification-center");
+
+    fireEvent.pointerDown(center, {
+      pointerType: "mouse",
+      isPrimary: true,
+      pointerId: 41,
+      clientX: 150,
+      clientY: 420,
+    });
+    fireEvent.pointerMove(center, {
+      pointerType: "mouse",
+      pointerId: 41,
+      clientX: 152,
+      clientY: 280,
+    });
+    fireEvent.pointerUp(center, {
+      pointerType: "mouse",
+      pointerId: 41,
+      clientX: 152,
+      clientY: 280,
+    });
+
+    finishShadeCollapse();
+    expect(list.getAttribute("data-shade-mode")).toBe("rested");
+  });
+
+  it("ignores empty-region drags while the shade close is settling", () => {
+    seedTriage();
+    render(<NotificationsHomeCenter />);
+    const list = expandShade();
+    const center = screen.getByTestId("home-notification-center");
+    fireEvent.click(screen.getByTestId("notifications-collapse"));
+    expect(list.hasAttribute("data-shade-settling")).toBe(true);
+
+    // Neither an aborted nudge nor a commit-distance swipe may start a second
+    // transition while the committed close owns the presentation clock.
+    fireEvent.pointerDown(center, {
+      pointerType: "mouse",
+      isPrimary: true,
+      pointerId: 42,
+      clientX: 150,
+      clientY: 420,
+    });
+    fireEvent.pointerMove(center, {
+      pointerType: "mouse",
+      pointerId: 42,
+      clientX: 150,
+      clientY: 390,
+    });
+    fireEvent.pointerUp(center, {
+      pointerType: "mouse",
+      pointerId: 42,
+      clientX: 150,
+      clientY: 390,
+    });
+    expect(center.hasAttribute("data-notification-shade-cancelling")).toBe(
+      false,
+    );
+
+    fireEvent.pointerDown(center, {
+      pointerType: "mouse",
+      isPrimary: true,
+      pointerId: 43,
+      clientX: 150,
+      clientY: 420,
+    });
+    fireEvent.pointerMove(center, {
+      pointerType: "mouse",
+      pointerId: 43,
+      clientX: 150,
+      clientY: 280,
+    });
+    fireEvent.pointerUp(center, {
+      pointerType: "mouse",
+      pointerId: 43,
+      clientX: 150,
+      clientY: 280,
+    });
+    expect(list.hasAttribute("data-shade-dragging")).toBe(false);
+    expect(center.hasAttribute("data-notification-shade-cancelling")).toBe(
+      false,
+    );
+
+    act(() => vi.advanceTimersByTime(219));
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+    act(() => vi.advanceTimersByTime(1));
+    expect(list.getAttribute("data-shade-mode")).toBe("rested");
+    expect(list.hasAttribute("data-shade-dragging")).toBe(false);
+  });
+
+  it("ignores empty-region touch swipes while the shade close is settling", () => {
+    seedTriage();
+    const surfaceRef = { current: null as HTMLElement | null };
+    render(
+      <div
+        ref={(node) => {
+          surfaceRef.current = node;
+        }}
+      >
+        <NotificationsHomeCenter emptyGestureTargetRef={surfaceRef} />
+      </div>,
+    );
+    const list = expandShade();
+    const center = screen.getByTestId("home-notification-center");
+    fireEvent.click(screen.getByTestId("notifications-collapse"));
+    expect(list.hasAttribute("data-shade-settling")).toBe(true);
+
+    fireEvent.touchStart(center, {
+      touches: [{ clientX: 150, clientY: 420 }],
+    });
+    fireEvent.touchMove(center, {
+      touches: [{ clientX: 150, clientY: 280 }],
+    });
+    expect(list.hasAttribute("data-shade-dragging")).toBe(false);
+    fireEvent.touchEnd(center, { touches: [] });
+    expect(center.hasAttribute("data-notification-shade-cancelling")).toBe(
+      false,
+    );
+
+    act(() => vi.advanceTimersByTime(219));
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+    act(() => vi.advanceTimersByTime(1));
+    expect(list.getAttribute("data-shade-mode")).toBe("rested");
+    expect(list.hasAttribute("data-shade-dragging")).toBe(false);
   });
 
   it("a bottom-edge touch drag closes an overflowing expanded shade", () => {

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -1892,8 +1892,15 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     render(<NotificationsHomeCenter />);
     const priorityRow = screen.getByTestId("notification-row");
     fireEvent.click(priorityRow);
+    act(() => vi.advanceTimersByTime(40));
     const controls = screen.getByTestId("notification-stack-controls");
     const quietRow = screen.getByText("Calendar summary").closest("li");
+    const stackRows = document.querySelector(
+      "[data-notification-stack-rows]",
+    ) as HTMLElement;
+    const sourceCount = screen.getByTestId("notification-source-count");
+    expect(stackRows.style.rowGap).toBe("6px");
+    expect(sourceCount.style.opacity).toBe("0");
 
     fireEvent.click(document.body);
 
@@ -1904,6 +1911,8 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(controls.style.height).toBe("0px");
     expect(quietRow?.style.opacity).toBe("0");
     expect(quietRow?.style.gridTemplateRows).toBe("0fr");
+    expect(stackRows.style.rowGap).toBe("0px");
+    expect(sourceCount.style.opacity).toBe("1");
     finishShadeCollapse();
     expect(screen.getByTestId("notification-row")).toBe(priorityRow);
     expect(screen.queryByTestId("notification-stack-controls")).toBeNull();

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -359,7 +359,7 @@ describe("interrupt priority projection", () => {
       value: 240,
       writable: true,
     });
-    fireEvent.click(screen.getByTestId("notification-row"));
+    fireEvent.click(screen.getByTestId("notification-row"), { detail: 1 });
 
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
     expect(list.scrollTop).toBe(0);
@@ -433,7 +433,7 @@ describe("interrupt priority projection", () => {
       touches: [{ clientX: 12, clientY: 40 }],
     });
     fireEvent.touchEnd(list, { touches: [] });
-    fireEvent.click(screen.getByTestId("notification-row"));
+    fireEvent.click(screen.getByTestId("notification-row"), { detail: 1 });
 
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
     expect(screen.queryByTestId("notification-stack-controls")).toBeNull();
@@ -1662,9 +1662,12 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       clientX: 10,
       clientY: 30,
     });
-    fireEvent.click(countButton);
+    fireEvent.click(countButton, { detail: 1 });
 
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
+
+    fireEvent.click(countButton, { detail: 0 });
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
   });
 
   it("animates groups that mount when the notification total opens the shade", () => {
@@ -2327,7 +2330,7 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(previewGroups.every((group) => group.isConnected)).toBe(true);
     expect(screen.getByTestId("notifications-clear-all")).toBeTruthy();
     expect(screen.getByTestId("notifications-collapse")).toBeTruthy();
-    act(() => vi.advanceTimersByTime(393));
+    act(() => vi.advanceTimersByTime(273));
     expect(center.hasAttribute("data-notification-shade-cancelling")).toBe(
       true,
     );
@@ -2443,7 +2446,7 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(center.hasAttribute("data-notification-shade-cancelling")).toBe(
       false,
     );
-    act(() => vi.advanceTimersByTime(459));
+    act(() => vi.advanceTimersByTime(219));
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
     act(() => vi.advanceTimersByTime(1));
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
@@ -2484,8 +2487,8 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
 
     // The list consumes the first post-drag synthetic click. The next click is
     // the intentional activation and must start on its own transition clock.
-    fireEvent.click(screen.getByTestId("notification-row"));
-    fireEvent.click(screen.getByTestId("notification-row"));
+    fireEvent.click(screen.getByTestId("notification-row"), { detail: 1 });
+    fireEvent.click(screen.getByTestId("notification-row"), { detail: 1 });
     expect(center.hasAttribute("data-notification-shade-cancelling")).toBe(
       false,
     );
@@ -2535,10 +2538,14 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
     expect(collapseFooter.getAttribute("aria-hidden")).toBeNull();
 
-    fireEvent.click(screen.getByTestId("notifications-collapse"));
+    fireEvent.click(screen.getByTestId("notifications-collapse"), {
+      detail: 1,
+    });
     expect(list.hasAttribute("data-shade-settling")).toBe(false);
 
-    fireEvent.click(screen.getByTestId("notifications-collapse"));
+    fireEvent.click(screen.getByTestId("notifications-collapse"), {
+      detail: 1,
+    });
     expect(list.hasAttribute("data-shade-settling")).toBe(true);
   });
 
@@ -2725,10 +2732,10 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     });
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
 
-    fireEvent.click(surface, { clientY: 620 });
+    fireEvent.click(surface, { clientY: 620, detail: 1 });
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
 
-    fireEvent.click(surface, { clientY: 620 });
+    fireEvent.click(surface, { clientY: 620, detail: 1 });
     expect(list.hasAttribute("data-shade-settling")).toBe(true);
   });
 
@@ -3046,7 +3053,7 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       false,
     );
 
-    act(() => vi.advanceTimersByTime(459));
+    act(() => vi.advanceTimersByTime(219));
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
     act(() => vi.advanceTimersByTime(1));
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
@@ -3082,7 +3089,7 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       false,
     );
 
-    act(() => vi.advanceTimersByTime(459));
+    act(() => vi.advanceTimersByTime(219));
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
     act(() => vi.advanceTimersByTime(1));
     expect(list.getAttribute("data-shade-mode")).toBe("rested");

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -1149,6 +1149,8 @@ describe("NotificationsHomeCenter (Z-stacked groups)", () => {
     expandShade();
     expect(screen.getAllByTestId("notification-row")).toHaveLength(1);
     expect(screen.getByTestId("notification-stack")).toBeTruthy();
+    const collapseFooter = screen.getByTestId("notifications-collapse-footer");
+    expect(collapseFooter.style.opacity).toBe("1");
     // Tapping the peeked card below the top one fans the stack out.
     const openingPeek = screen.getAllByTestId("notification-stack-peek")[0];
     openingPeek.focus();
@@ -1203,10 +1205,21 @@ describe("NotificationsHomeCenter (Z-stacked groups)", () => {
         screen.getAllByTestId("notification-row")[0],
       ) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
-    expect(screen.queryByTestId("notifications-collapse")).toBeNull();
+    expect(screen.getByTestId("notifications-collapse-footer")).toBe(
+      collapseFooter,
+    );
+    expect(collapseFooter.style.opacity).toBe("0");
+    expect(collapseFooter.getAttribute("aria-hidden")).toBe("true");
+    expect(collapseFooter.hasAttribute("inert")).toBe(true);
     fireEvent.click(screen.getByTestId("notification-stack-collapse"), {
       detail: 0,
     });
+    expect(screen.getByTestId("notifications-collapse-footer")).toBe(
+      collapseFooter,
+    );
+    expect(collapseFooter.style.opacity).toBe("1");
+    expect(collapseFooter.getAttribute("aria-hidden")).toBe("true");
+    expect(collapseFooter.hasAttribute("inert")).toBe(true);
     expect(screen.getAllByTestId("notification-row")).toHaveLength(3);
     expect(enteringControls.style.height).toBe("0px");
     expect(enteringControls.style.opacity).toBe("0");
@@ -1239,6 +1252,12 @@ describe("NotificationsHomeCenter (Z-stacked groups)", () => {
     expect(screen.getByTestId("notification-stack")).toBeTruthy();
     expect(screen.queryByTestId("notification-stack-collapse")).toBeNull();
     expect(document.activeElement).toBe(screen.getByTestId("notification-row"));
+    expect(screen.getByTestId("notifications-collapse-footer")).toBe(
+      collapseFooter,
+    );
+    expect(collapseFooter.style.opacity).toBe("1");
+    expect(collapseFooter.getAttribute("aria-hidden")).toBeNull();
+    expect(collapseFooter.hasAttribute("inert")).toBe(false);
     expect(screen.getByTestId("notifications-collapse").textContent).toContain(
       "Collapse",
     );
@@ -2560,6 +2579,39 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
 
     finishShadeCollapse();
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
+  });
+
+  it("collapses a fanned shade from empty space below its cards", () => {
+    seedTriage();
+    render(<NotificationsHomeCenter />);
+    const list = expandShade();
+    fireEvent.click(screen.getAllByTestId("notification-stack-peek")[0]);
+    act(() => vi.advanceTimersByTime(40));
+    const center = screen.getByTestId("home-notification-center");
+    const group = center.querySelector(
+      "[data-notification-group]",
+    ) as HTMLElement;
+    vi.spyOn(group, "getBoundingClientRect").mockReturnValue({
+      x: 20,
+      y: 100,
+      top: 100,
+      right: 300,
+      bottom: 300,
+      left: 20,
+      width: 280,
+      height: 200,
+      toJSON: () => ({}),
+    });
+
+    fireEvent.click(center, { clientY: 240 });
+    expect(list.hasAttribute("data-shade-settling")).toBe(false);
+    expect(screen.getByTestId("notification-stack-controls")).toBeTruthy();
+
+    fireEvent.click(center, { clientY: 360 });
+    expect(list.hasAttribute("data-shade-settling")).toBe(true);
+    finishShadeCollapse();
+    expect(list.getAttribute("data-shade-mode")).toBe("rested");
+    expect(screen.queryByTestId("notification-stack-controls")).toBeNull();
   });
 
   it("ignores empty-region drags while the shade close is settling", () => {

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -281,7 +281,7 @@ describe("interrupt priority projection", () => {
       "4",
     );
     expect(screen.getByTestId("notification-stack").style.paddingBottom).toBe(
-      "24px",
+      "16px",
     );
 
     fireEvent.pointerDown(list, {
@@ -295,7 +295,7 @@ describe("interrupt priority projection", () => {
       pointerType: "mouse",
       pointerId: 31,
       clientX: 10,
-      clientY: 78,
+      clientY: 40,
     });
 
     expect(screen.getByTestId("notification-row")).toBe(topRow);
@@ -308,13 +308,13 @@ describe("interrupt priority projection", () => {
     const previewTail = Number.parseFloat(
       screen.getByTestId("notification-stack").style.paddingBottom,
     );
-    expect(previewTail).toBe(24);
+    expect(previewTail).toBe(16);
 
     fireEvent.pointerUp(list, {
       pointerType: "mouse",
       pointerId: 31,
       clientX: 10,
-      clientY: 78,
+      clientY: 40,
     });
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
     expect(screen.getAllByTestId("notification-stack-peek")).toHaveLength(2);
@@ -322,7 +322,7 @@ describe("interrupt priority projection", () => {
     expandShade();
     expect(screen.getAllByTestId("notification-stack-peek")).toHaveLength(2);
     expect(screen.getByTestId("notification-stack").style.paddingBottom).toBe(
-      "24px",
+      "16px",
     );
     collapseShade();
     expect(screen.getAllByTestId("notification-stack-peek")).toHaveLength(2);
@@ -348,7 +348,7 @@ describe("interrupt priority projection", () => {
     expect(screen.getAllByTestId("notification-row")).toHaveLength(1);
     expect(screen.getAllByTestId("notification-stack-peek")).toHaveLength(1);
     expect(screen.getByTestId("notification-stack").style.paddingBottom).toBe(
-      "17px",
+      "9px",
     );
     expect(screen.getByTestId("notification-source-count").textContent).toBe(
       "2",
@@ -430,7 +430,7 @@ describe("interrupt priority projection", () => {
       touches: [{ clientX: 10, clientY: 10 }],
     });
     fireEvent.touchMove(list, {
-      touches: [{ clientX: 12, clientY: 75 }],
+      touches: [{ clientX: 12, clientY: 40 }],
     });
     fireEvent.touchEnd(list, { touches: [] });
     fireEvent.click(screen.getByTestId("notification-row"));
@@ -528,7 +528,7 @@ describe("interrupt priority projection", () => {
       pointerType: "mouse",
       pointerId: 32,
       clientX: 10,
-      clientY: 70,
+      clientY: 40,
     });
     expect(screen.getAllByTestId("notification-row")).toHaveLength(6);
 
@@ -536,7 +536,7 @@ describe("interrupt priority projection", () => {
       pointerType: "mouse",
       pointerId: 32,
       clientX: 10,
-      clientY: 70,
+      clientY: 40,
     });
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
     expect(screen.getAllByTestId("notification-row")).toHaveLength(6);
@@ -1087,7 +1087,7 @@ describe("NotificationsHomeCenter (Z-stacked groups)", () => {
     expect(peeks[1].style.opacity).toBe("1");
     expect(peeks[0].style.transform).toBe("translateY(7px) scale(0.985)");
     expect(peeks[1].style.transform).toBe("translateY(14px) scale(0.97)");
-    expect(stack.style.paddingBottom).toBe("24px");
+    expect(stack.style.paddingBottom).toBe("16px");
     // The producer tile is vertically centered and carries the stack total.
     const sourceIcon = screen.getByTestId("notification-source-icon");
     expect(sourceIcon.className).toContain("h-10");
@@ -1180,7 +1180,7 @@ describe("NotificationsHomeCenter (Z-stacked groups)", () => {
     );
     expect(enteringControls.style.height).toBe("0px");
     expect(enteringControls.style.opacity).toBe("0");
-    expect(groupContent.style.paddingBottom).toBe("24px");
+    expect(groupContent.style.paddingBottom).toBe("16px");
     expect(closingPeeks).toHaveLength(2);
     expect(closingPeeks.every((peek) => peek.style.opacity === "1")).toBe(true);
     const enteringRows = screen
@@ -1238,7 +1238,7 @@ describe("NotificationsHomeCenter (Z-stacked groups)", () => {
     expect(screen.getAllByTestId("notification-row")).toHaveLength(3);
     expect(enteringControls.style.height).toBe("0px");
     expect(enteringControls.style.opacity).toBe("0");
-    expect(groupContent.style.paddingBottom).toBe("24px");
+    expect(groupContent.style.paddingBottom).toBe("16px");
     expect(closingPeeks.every((peek) => peek.style.opacity === "1")).toBe(true);
     expect(enteringControls.getAttribute("aria-hidden")).toBe("true");
     expect(enteringControls.hasAttribute("inert")).toBe(true);
@@ -1598,7 +1598,7 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(collapseFooter.className).toContain("shrink-0");
     expect(collapseFooter.className).not.toContain("absolute");
     expect(list.className).toContain("flex-[0_1_auto]");
-    expect(list.className).toContain("pb-2");
+    expect(list.className).toContain("pb-1");
     expect(list.className).toContain("scroll-fade");
     expect(list.className).toContain("scroll-fade-b-[1.5rem]");
     collapse.focus();
@@ -1767,6 +1767,8 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       clientY: 20,
     });
     expect(list.getAttribute("data-shade-dragging")).toBeNull();
+    expect(list.hasAttribute("data-shade-settling")).toBe(true);
+    finishShadeCollapse();
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
     expect(screen.getByTestId("notification-row")).toBe(priorityRow);
   });
@@ -2046,6 +2048,49 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(screen.getAllByTestId("notification-stack-peek")).toHaveLength(2);
   });
 
+  it("keeps an owned pull open when preview insertion changes scrollTop", () => {
+    seedTriage();
+    render(<NotificationsHomeCenter />);
+    const list = screen.getByTestId("home-notification-list");
+    Object.defineProperty(list, "scrollTop", {
+      configurable: true,
+      value: 0,
+      writable: true,
+    });
+
+    fireEvent.pointerDown(list, {
+      pointerType: "mouse",
+      isPrimary: true,
+      pointerId: 109,
+      clientX: 10,
+      clientY: 10,
+    });
+    fireEvent.pointerMove(list, {
+      pointerType: "mouse",
+      pointerId: 109,
+      clientX: 10,
+      clientY: 70,
+    });
+    expect(list.getAttribute("data-shade-preview")).toBe("expanding");
+
+    list.scrollTop = 36;
+    fireEvent.pointerMove(list, {
+      pointerType: "mouse",
+      pointerId: 109,
+      clientX: 10,
+      clientY: 170,
+    });
+    expect(list.scrollTop).toBe(0);
+    fireEvent.pointerUp(list, {
+      pointerType: "mouse",
+      pointerId: 109,
+      clientX: 10,
+      clientY: 170,
+    });
+
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+  });
+
   it("reveals hidden notification groups continuously before release", () => {
     __ingestNotificationForTests(
       makeNotification({
@@ -2174,10 +2219,30 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     const collapse = screen.getByTestId("notifications-collapse-footer");
 
     expect(list.style.transform).toBe("");
+    expect(list.style.getPropertyValue("--eliza-notif-pull-overshoot")).toBe(
+      `${overpull}px`,
+    );
+    expect(list.getAttribute("data-shade-preview")).toBe("expanding");
+    expect(list.hasAttribute("data-shade-dragging")).toBe(true);
+    expect(list.parentElement?.querySelector("style")?.textContent).toContain(
+      ".eliza-notif-scroll[data-shade-preview][data-shade-dragging]",
+    );
     expect(groupContent?.style.transform).toBe(expectedTransform);
     expect(clearSlot?.style.transform).toBe(expectedTransform);
     expect(count.style.transform).toBe(expectedTransform);
-    expect(collapse.style.transform).toBe(`translateY(${overpull}px)`);
+    expect(collapse.style.transform).toBe("translateY(0px)");
+
+    fireEvent.pointerUp(list, {
+      pointerType: "mouse",
+      pointerId: 108,
+      clientX: 10,
+      clientY: 142,
+    });
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+    expect(list.hasAttribute("data-shade-dragging")).toBe(false);
+    expect(list.style.getPropertyValue("--eliza-notif-pull-overshoot")).toBe(
+      "0px",
+    );
   });
 
   it("a short pull springs back without toggling", () => {
@@ -2369,7 +2434,7 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(center.hasAttribute("data-notification-shade-cancelling")).toBe(
       false,
     );
-    act(() => vi.advanceTimersByTime(219));
+    act(() => vi.advanceTimersByTime(459));
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
     act(() => vi.advanceTimersByTime(1));
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
@@ -2437,6 +2502,159 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(screen.getAllByTestId("notification-row")).toHaveLength(1);
     expect(screen.getAllByTestId("notification-stack-peek")).toHaveLength(2);
     expect(screen.getByTestId("notifications-count").style.opacity).toBe("0");
+  });
+
+  it("keeps an owned touch pull after preview scroll anchoring", () => {
+    seedTriage();
+    render(<NotificationsHomeCenter />);
+    const list = screen.getByTestId("home-notification-list");
+    Object.defineProperty(list, "scrollTop", {
+      configurable: true,
+      value: 0,
+      writable: true,
+    });
+
+    fireEvent.touchStart(list, {
+      touches: [{ identifier: 7, clientX: 10, clientY: 10 }],
+    });
+    fireEvent.touchMove(list, {
+      touches: [{ identifier: 7, clientX: 10, clientY: 70 }],
+    });
+    list.scrollTop = 36;
+    fireEvent.touchMove(list, {
+      touches: [{ identifier: 7, clientX: 10, clientY: 170 }],
+    });
+    expect(list.scrollTop).toBe(0);
+    fireEvent.touchEnd(list, { touches: [] });
+
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+  });
+
+  it("retains a native pull when a notification arrives mid-gesture", () => {
+    seedTriage();
+    render(<NotificationsHomeCenter />);
+    const list = screen.getByTestId("home-notification-list");
+
+    fireEvent.touchStart(list, {
+      touches: [{ identifier: 11, clientX: 10, clientY: 10 }],
+    });
+    fireEvent.touchMove(list, {
+      touches: [{ identifier: 11, clientX: 10, clientY: 70 }],
+    });
+    __ingestNotificationForTests(
+      makeNotification({ priority: "low", source: "live-arrival" }),
+    );
+    fireEvent.touchMove(list, {
+      touches: [{ identifier: 11, clientX: 10, clientY: 170 }],
+    });
+    fireEvent.touchEnd(list, { touches: [] });
+
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+  });
+
+  it("keeps a lower-surface mouse pull after the surface scrollTop shifts", () => {
+    seedTriage();
+    const surfaceRef = { current: null as HTMLElement | null };
+    render(
+      <div
+        ref={(node) => {
+          surfaceRef.current = node;
+        }}
+        data-testid="home-gesture-surface"
+      >
+        <NotificationsHomeCenter emptyGestureTargetRef={surfaceRef} />
+      </div>,
+    );
+    const surface = screen.getByTestId("home-gesture-surface");
+    const list = screen.getByTestId("home-notification-list");
+    Object.defineProperty(surface, "scrollTop", {
+      configurable: true,
+      value: 0,
+      writable: true,
+    });
+
+    fireEvent.pointerDown(surface, {
+      pointerType: "mouse",
+      isPrimary: true,
+      pointerId: 12,
+      clientX: 180,
+      clientY: 300,
+    });
+    fireEvent.pointerMove(surface, {
+      pointerType: "mouse",
+      pointerId: 12,
+      clientX: 180,
+      clientY: 360,
+    });
+    surface.scrollTop = 36;
+    fireEvent.pointerMove(surface, {
+      pointerType: "mouse",
+      pointerId: 12,
+      clientX: 180,
+      clientY: 460,
+    });
+    expect(surface.scrollTop).toBe(0);
+    fireEvent.pointerUp(surface, {
+      pointerType: "mouse",
+      pointerId: 12,
+      clientX: 180,
+      clientY: 460,
+    });
+
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+  });
+
+  it("rebases lower-surface touch travel at the top and retains ownership", () => {
+    seedTriage();
+    const surfaceRef = { current: null as HTMLElement | null };
+    render(
+      <div
+        ref={(node) => {
+          surfaceRef.current = node;
+        }}
+        data-testid="home-gesture-surface"
+      >
+        <NotificationsHomeCenter emptyGestureTargetRef={surfaceRef} />
+      </div>,
+    );
+    const surface = screen.getByTestId("home-gesture-surface");
+    const list = screen.getByTestId("home-notification-list");
+    Object.defineProperty(surface, "scrollTop", {
+      configurable: true,
+      value: 120,
+      writable: true,
+    });
+
+    fireEvent.touchStart(surface, {
+      touches: [{ identifier: 8, clientX: 180, clientY: 200 }],
+    });
+    fireEvent.touchMove(surface, {
+      touches: [{ identifier: 8, clientX: 180, clientY: 300 }],
+    });
+    surface.scrollTop = 0;
+    fireEvent.touchMove(surface, {
+      touches: [{ identifier: 8, clientX: 180, clientY: 400 }],
+    });
+    fireEvent.touchMove(surface, {
+      touches: [{ identifier: 8, clientX: 180, clientY: 430 }],
+    });
+    fireEvent.touchEnd(surface, { touches: [] });
+    expect(list.getAttribute("data-shade-mode")).toBe("rested");
+
+    fireEvent.touchStart(surface, {
+      touches: [{ identifier: 9, clientX: 180, clientY: 300 }],
+    });
+    fireEvent.touchMove(surface, {
+      touches: [{ identifier: 9, clientX: 180, clientY: 380 }],
+    });
+    surface.scrollTop = 24;
+    fireEvent.touchMove(surface, {
+      touches: [{ identifier: 9, clientX: 180, clientY: 470 }],
+    });
+    expect(surface.scrollTop).toBe(0);
+    fireEvent.touchEnd(surface, { touches: [] });
+
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
   });
 
   it("a continuous drag that scrolls the expanded list back to the top does NOT collapse (re-base at the crossing)", () => {
@@ -2753,7 +2971,7 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       false,
     );
 
-    act(() => vi.advanceTimersByTime(219));
+    act(() => vi.advanceTimersByTime(459));
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
     act(() => vi.advanceTimersByTime(1));
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
@@ -2789,7 +3007,7 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       false,
     );
 
-    act(() => vi.advanceTimersByTime(219));
+    act(() => vi.advanceTimersByTime(459));
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
     act(() => vi.advanceTimersByTime(1));
     expect(list.getAttribute("data-shade-mode")).toBe("rested");

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -61,6 +61,7 @@ import {
 } from "./NotificationsHomeCenter";
 import {
   notificationGroupContainerOffset,
+  notificationPullOvershootOffset,
   PULL_TRAVEL_PX,
 } from "./notification-shade-presentation";
 
@@ -152,7 +153,7 @@ function collapseShade(): HTMLElement {
 }
 
 function finishShadeCollapse(): void {
-  act(() => vi.advanceTimersByTime(400));
+  act(() => vi.advanceTimersByTime(500));
 }
 
 function finishStackFold(): void {
@@ -539,7 +540,7 @@ describe("interrupt priority projection", () => {
     });
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
     expect(screen.getAllByTestId("notification-row")).toHaveLength(6);
-    act(() => vi.advanceTimersByTime(340));
+    act(() => vi.advanceTimersByTime(500));
     expect(screen.queryAllByTestId("notification-row")).toHaveLength(0);
   });
 });
@@ -587,15 +588,21 @@ describe("dampenPull", () => {
     expect(dampenPull(96)).toBe(PULL_TRAVEL_PX);
     expect(dampenPull(124)).toBeCloseTo(97.8);
   });
+
+  it("preserves resisted travel as signed visual overshoot", () => {
+    const overpull = dampenPull(124);
+
+    expect(notificationPullOvershootOffset(PULL_TRAVEL_PX)).toBe(0);
+    expect(notificationPullOvershootOffset(overpull)).toBeCloseTo(9.8);
+    expect(notificationPullOvershootOffset(-overpull)).toBeCloseTo(-9.8);
+  });
 });
 
 describe("notificationPullRevealProgress", () => {
   it("tracks full detent travel while staggering later groups", () => {
     expect(notificationPullRevealProgress(0, 0)).toBe(0);
     expect(notificationPullRevealProgress(PULL_TRAVEL_PX / 2, 0)).toBe(0.5);
-    expect(
-      notificationPullRevealProgress(PULL_TRAVEL_PX / 2, 2),
-    ).toBeLessThan(
+    expect(notificationPullRevealProgress(PULL_TRAVEL_PX / 2, 2)).toBeLessThan(
       0.5,
     );
     expect(notificationPullRevealProgress(PULL_TRAVEL_PX, 4)).toBe(1);
@@ -679,8 +686,9 @@ describe("NotificationsHomeCenter", () => {
       clientX: 10,
       clientY: 300,
     });
+    act(() => vi.advanceTimersByTime(16));
     expect(empty.style.opacity).toBe(restingEmptyStyle.opacity);
-    expect(empty.style.transform).toBe(restingEmptyStyle.transform);
+    expect(empty.style.transform).not.toBe(restingEmptyStyle.transform);
     expect(list.style.transform).toBe("");
     fireEvent.pointerUp(list, {
       pointerType: "mouse",
@@ -691,7 +699,7 @@ describe("NotificationsHomeCenter", () => {
 
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
     expect(screen.getByTestId("notifications-empty").style.opacity).toBe("1");
-    expect(empty.style.transform).toBe(restingEmptyStyle.transform);
+    expect(empty.style.transform).toBe("translate3d(0, 0px, 0)");
     expect(screen.queryByTestId("notifications-collapse")).toBeNull();
 
     fireEvent.click(document.body);
@@ -2086,7 +2094,10 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     );
     expect(revealedGroups).toHaveLength(2);
     for (const group of revealedGroups) {
-      const opacity = Number.parseFloat((group as HTMLElement).style.opacity);
+      const content = group.querySelector<HTMLElement>(
+        "[data-notification-group-content]",
+      );
+      const opacity = Number.parseFloat(content?.style.opacity ?? "");
       expect(opacity).toBeGreaterThan(0);
       expect(opacity).toBeLessThan(1);
     }
@@ -2121,10 +2132,52 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(collapseReveal).toBeGreaterThan(0);
     expect(collapseReveal).toBeLessThan(1);
     for (const group of revealedGroups) {
-      const opacity = Number.parseFloat((group as HTMLElement).style.opacity);
+      const content = group.querySelector<HTMLElement>(
+        "[data-notification-group-content]",
+      );
+      const opacity = Number.parseFloat(content?.style.opacity ?? "");
       expect(opacity).toBeGreaterThan(0);
       expect(opacity).toBeLessThan(1);
     }
+  });
+
+  it("keeps resisted overpull on stable shade contents without translating the scroller", () => {
+    __ingestNotificationForTests(
+      makeNotification({ priority: "normal", source: "files" }),
+    );
+    render(<NotificationsHomeCenter />);
+    const list = screen.getByTestId("home-notification-list");
+    fireEvent.pointerDown(list, {
+      pointerType: "mouse",
+      isPrimary: true,
+      pointerId: 108,
+      clientX: 10,
+      clientY: 10,
+    });
+    fireEvent.pointerMove(list, {
+      pointerType: "mouse",
+      pointerId: 108,
+      clientX: 10,
+      clientY: 142,
+    });
+    act(() => vi.advanceTimersByTime(20));
+
+    const overpull = notificationPullOvershootOffset(dampenPull(132));
+    const expectedTransform = `translate3d(0, ${overpull}px, 0)`;
+    const groupContent = list.querySelector<HTMLElement>(
+      "[data-notification-group-content]",
+    );
+    const clearSlot = list.querySelector<HTMLElement>(
+      "[data-notification-clear-slot]",
+    );
+    const count = screen.getByTestId("notifications-count");
+    const collapse = screen.getByTestId("notifications-collapse-footer");
+
+    expect(list.style.transform).toBe("");
+    expect(groupContent?.style.transform).toBe(expectedTransform);
+    expect(clearSlot?.style.transform).toBe(expectedTransform);
+    expect(count.style.transform).toBe(expectedTransform);
+    expect(collapse.style.transform).toBe(`translateY(${overpull}px)`);
   });
 
   it("a short pull springs back without toggling", () => {
@@ -2183,12 +2236,16 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     );
     expect(list.getAttribute("data-shade-preview")).toBe("expanding");
     expect(
-      previewGroups.every(
-        (group) =>
+      previewGroups.every((group) => {
+        const content = group.querySelector<HTMLElement>(
+          "[data-notification-group-content]",
+        );
+        return (
           group.isConnected &&
-          group.classList.contains("eliza-notif-shade-transition") &&
-          group.style.opacity === "0",
-      ),
+          content?.classList.contains("eliza-notif-shade-transition") &&
+          content.style.opacity === "0"
+        );
+      }),
     ).toBe(true);
     expect(screen.getByTestId("notifications-clear-all")).toBeTruthy();
     expect(screen.getByTestId("notifications-collapse")).toBeTruthy();
@@ -2196,7 +2253,7 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(previewGroups.every((group) => group.isConnected)).toBe(true);
     expect(screen.getByTestId("notifications-clear-all")).toBeTruthy();
     expect(screen.getByTestId("notifications-collapse")).toBeTruthy();
-    act(() => vi.advanceTimersByTime(239));
+    act(() => vi.advanceTimersByTime(393));
     expect(center.hasAttribute("data-notification-shade-cancelling")).toBe(
       true,
     );
@@ -2211,7 +2268,7 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(screen.queryAllByTestId("notification-row")).toHaveLength(1);
   });
 
-  it("keeps the same preview nodes mounted when an active pull crosses zero", () => {
+  it("keeps the same preview nodes mounted through zero and a committed settle", () => {
     __ingestNotificationForTests(
       makeNotification({ priority: "urgent", source: "mail" }),
     );
@@ -2237,6 +2294,10 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       "[data-notification-pull-reveal]",
     );
     expect(preview).toBeTruthy();
+    const previewContent = preview?.querySelector<HTMLElement>(
+      "[data-notification-group-content]",
+    );
+    expect(previewContent).toBeTruthy();
 
     fireEvent.pointerMove(list, {
       pointerType: "mouse",
@@ -2247,7 +2308,7 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     act(() => vi.advanceTimersByTime(20));
     expect(list.getAttribute("data-shade-dragging")).not.toBeNull();
     expect(list.querySelector("[data-notification-pull-reveal]")).toBe(preview);
-    expect(preview?.style.opacity).toBe("0");
+    expect(previewContent?.style.opacity).toBe("0");
 
     fireEvent.pointerMove(list, {
       pointerType: "mouse",
@@ -2257,7 +2318,9 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     });
     act(() => vi.advanceTimersByTime(20));
     expect(list.querySelector("[data-notification-pull-reveal]")).toBe(preview);
-    expect(Number.parseFloat(preview?.style.opacity ?? "0")).toBeGreaterThan(0);
+    expect(
+      Number.parseFloat(previewContent?.style.opacity ?? "0"),
+    ).toBeGreaterThan(0);
 
     fireEvent.pointerUp(list, {
       pointerType: "mouse",
@@ -2265,9 +2328,12 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       clientX: 10,
       clientY: 80,
     });
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
     expect(preview?.isConnected).toBe(true);
-    act(() => vi.advanceTimersByTime(340));
-    expect(preview?.isConnected).toBe(false);
+    expect(preview?.hasAttribute("data-notification-pull-reveal")).toBe(false);
+    expect(previewContent?.style.opacity).toBe("1");
+    act(() => vi.advanceTimersByTime(460));
+    expect(preview?.isConnected).toBe(true);
   });
 
   it("clears a cancelled-pull settle before starting a committed collapse", () => {
@@ -2351,7 +2417,7 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     );
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
     expect(screen.getByTestId("notification-stack-controls")).toBeTruthy();
-    act(() => vi.advanceTimersByTime(340));
+    act(() => vi.advanceTimersByTime(460));
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
   });
 

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -214,14 +214,17 @@ const STACK_PEEK_OFFSET_PX = 7;
 const STACK_BOTTOM_CLEARANCE_PX = 2;
 
 const CLEAR_CONFIRM_TIMEOUT_MS = 5_000;
-const SHADE_SETTLE_MS = 460;
+const SHADE_SETTLE_MS = 220;
 const SHADE_MIN_SETTLE_MS = 320;
 const SHADE_MAX_SETTLE_MS = 600;
 const SHADE_MIN_SETTLE_SPEED_PX_PER_MS = 0.15;
 const SHADE_EASING = "cubic-bezier(0.25,0.1,0.25,1)";
 /** Ignore trackpad rebound while the committed shade settle is running. */
 const WHEEL_COMMIT_LOCK_MS = SHADE_SETTLE_MS;
-const PULL_CANCEL_SETTLE_MS = SHADE_SETTLE_MS;
+// A cancelled direct-manipulation gesture needs a softer return than a
+// command-driven open/close so the surface does not appear to snap away from
+// the finger at release.
+const PULL_CANCEL_SETTLE_MS = 340;
 const SHADE_MIN_FLICK_DISTANCE_PX = 22;
 const SHADE_FLICK_VELOCITY_PX_PER_MS = 0.45;
 const SHADE_MIN_VELOCITY_SAMPLE_MS = 16;
@@ -1371,14 +1374,16 @@ export function NotificationsHomeCenter({
       });
     const targetPullPx = shouldCommit ? Math.sign(px) * PULL_TRAVEL_PX : 0;
     const remainingDistancePx = Math.abs(targetPullPx - px);
-    const settleMs = getVelocityAwareSettleDuration({
-      velocityPxPerMs: releaseVelocity,
-      remainingDistancePx,
-      fallbackDurationMs: PULL_CANCEL_SETTLE_MS,
-      minimumDurationMs: SHADE_MIN_SETTLE_MS,
-      maximumDurationMs: SHADE_MAX_SETTLE_MS,
-      minimumSpeedPxPerMs: SHADE_MIN_SETTLE_SPEED_PX_PER_MS,
-    });
+    const settleMs = shouldCommit
+      ? getVelocityAwareSettleDuration({
+          velocityPxPerMs: releaseVelocity,
+          remainingDistancePx,
+          fallbackDurationMs: PULL_CANCEL_SETTLE_MS,
+          minimumDurationMs: SHADE_MIN_SETTLE_MS,
+          maximumDurationMs: SHADE_MAX_SETTLE_MS,
+          minimumSpeedPxPerMs: SHADE_MIN_SETTLE_SPEED_PX_PER_MS,
+        })
+      : PULL_CANCEL_SETTLE_MS;
 
     if (px !== 0) flushPullPresentation();
     setShadeSettleDuration(settleMs);
@@ -2384,6 +2389,9 @@ export function NotificationsHomeCenter({
       window.clearTimeout(suppressNotificationClickTimer.current);
       suppressNotificationClickTimer.current = null;
     }
+    // Keyboard activation has no pointer-release click to suppress. Clearing
+    // the stale guard still prevents it from leaking into the next real tap.
+    if (e.detail === 0) return;
     e.preventDefault();
     e.stopPropagation();
   };

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -839,18 +839,14 @@ export function NotificationsHomeCenter({
     // first scrolled the list up to its top doesn't arrive already maxed.
     anchorY: number | null;
   } | null>(null);
-  const emptyPointerPull = useRef<{
-    id: number;
-    startX: number;
-    startY: number;
-    axis: "none" | "x" | "y";
-  } | null>(null);
   // A touch drag can end in `pointercancel` before the row sees enough pointer
   // movement to suppress the browser's synthetic click. The list owns the
   // vertical shade gesture, so it also blocks that one immediate follow-up
   // click; the next intentional tap remains available.
   const suppressNotificationClick = useRef(false);
   const suppressNotificationClickTimer = useRef<number | null>(null);
+  const suppressBackgroundClick = useRef(false);
+  const suppressBackgroundClickTimer = useRef<number | null>(null);
   // Wheel accumulation toward a shade commit: one direction at a time; a
   // direction flip abandons the previous run.
   const wheelPull = useRef<{ dir: 1 | -1; px: number }>({ dir: 1, px: 0 });
@@ -1248,6 +1244,10 @@ export function NotificationsHomeCenter({
   useEffect(() => {
     if (!shadeExpanded) return;
     const collapseOnOutsideClick = (event: MouseEvent) => {
+      // A background drag may end over a tile that synthesizes a click. The
+      // drag already decided the shade state; do not reinterpret that release
+      // as a separate outside-tap collapse before the surface can consume it.
+      if (suppressBackgroundClick.current) return;
       const target = event.target;
       const center = centerRef.current;
       if (target instanceof Node && center && !center.contains(target)) {
@@ -1328,6 +1328,20 @@ export function NotificationsHomeCenter({
     setShade,
     setShadeSettleDuration,
   ]);
+
+  const abortPointerPull = useCallback(() => {
+    const px = pullPxRef.current;
+    if (px !== 0) {
+      flushPullPresentation();
+      if (!reduceMotion) {
+        beginPullCancellation(
+          px > 0 ? "expand" : "collapse",
+          PULL_CANCEL_SETTLE_MS,
+        );
+      }
+    }
+    setPullPx(0);
+  }, [beginPullCancellation, flushPullPresentation, reduceMotion, setPullPx]);
 
   // Shared wheel accumulator for both the list and, while empty, the wider
   // home background. Returns whether the shade consumed this delta so the
@@ -1422,12 +1436,7 @@ export function NotificationsHomeCenter({
     };
     const onTouchStart = (e: TouchEvent) => {
       const t = e.touches[0];
-      const target = e.target;
-      if (
-        e.touches.length !== 1 ||
-        !t ||
-        (usesEmptyBackground && isInteractiveGestureTarget(target))
-      ) {
+      if (e.touches.length !== 1 || !t) {
         abortTouchPull();
         return;
       }
@@ -1572,7 +1581,6 @@ export function NotificationsHomeCenter({
       // surface. The home listener only fills the otherwise dead background.
       if (
         !usesEmptyBackground ||
-        isInteractiveGestureTarget(target) ||
         (target instanceof Node && list.contains(target))
       ) {
         return;
@@ -1844,6 +1852,124 @@ export function NotificationsHomeCenter({
     shadeExpanded,
   ]);
 
+  useEffect(() => {
+    const surface = emptyGestureTargetRef?.current ?? centerRef.current;
+    const list = scrollRef.current;
+    if (!surface || !list || !surfaceReady) return;
+
+    let gesture: {
+      id: number;
+      startX: number;
+      startY: number;
+      axis: "none" | "x" | "y";
+    } | null = null;
+    const armClickSuppression = () => {
+      suppressBackgroundClick.current = true;
+      if (suppressBackgroundClickTimer.current !== null) {
+        window.clearTimeout(suppressBackgroundClickTimer.current);
+      }
+      suppressBackgroundClickTimer.current = window.setTimeout(() => {
+        suppressBackgroundClick.current = false;
+        suppressBackgroundClickTimer.current = null;
+      }, 500);
+    };
+    const onClick = (event: MouseEvent) => {
+      if (!suppressBackgroundClick.current) return;
+      suppressBackgroundClick.current = false;
+      if (suppressBackgroundClickTimer.current !== null) {
+        window.clearTimeout(suppressBackgroundClickTimer.current);
+        suppressBackgroundClickTimer.current = null;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+    };
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (
+        event.pointerType !== "mouse" ||
+        !event.isPrimary ||
+        (target instanceof Node && list.contains(target))
+      ) {
+        return;
+      }
+      const { canExpand, canCollapse } = shadeGestureRef.current;
+      if (!canExpand && !canCollapse) return;
+      gesture = {
+        id: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+        axis: "none",
+      };
+    };
+    const onPointerMove = (event: PointerEvent) => {
+      const current = gesture;
+      if (!current || current.id !== event.pointerId) return;
+      const dx = event.clientX - current.startX;
+      const dy = event.clientY - current.startY;
+      if (
+        current.axis === "none" &&
+        (Math.abs(dx) > PULL_SLOP_PX || Math.abs(dy) > PULL_SLOP_PX)
+      ) {
+        current.axis = Math.abs(dx) > Math.abs(dy) ? "x" : "y";
+        if (current.axis === "x") {
+          gesture = null;
+          return;
+        }
+        surface.setPointerCapture?.(event.pointerId);
+        armClickSuppression();
+      }
+      if (current.axis !== "y") return;
+      event.preventDefault();
+      const { canExpand, canCollapse } = shadeGestureRef.current;
+      if (dy > 0 && canExpand && surface.scrollTop <= 0) {
+        setPullPx(dy > PULL_SLOP_PX ? dampenPull(dy) : 0, dy <= PULL_SLOP_PX);
+      } else if (dy < 0 && canCollapse) {
+        setPullPx(
+          dy < -PULL_SLOP_PX ? -dampenPull(-dy) : 0,
+          dy >= -PULL_SLOP_PX,
+        );
+      } else if (pullPxRef.current !== 0) {
+        setPullPx(0, true);
+      }
+    };
+    const onPointerEnd = (event: PointerEvent) => {
+      const current = gesture;
+      if (!current || current.id !== event.pointerId) return;
+      onPointerMove(event);
+      if (!gesture) return;
+      if (current.axis === "y") {
+        armClickSuppression();
+      }
+      gesture = null;
+      commitPull();
+    };
+    const onPointerCancel = (event: PointerEvent) => {
+      if (gesture?.id !== event.pointerId) return;
+      gesture = null;
+      abortPointerPull();
+    };
+
+    surface.addEventListener("pointerdown", onPointerDown);
+    surface.addEventListener("pointermove", onPointerMove, { passive: false });
+    surface.addEventListener("pointerup", onPointerEnd);
+    surface.addEventListener("pointercancel", onPointerCancel);
+    surface.addEventListener("click", onClick, true);
+    return () => {
+      surface.removeEventListener("pointerdown", onPointerDown);
+      surface.removeEventListener("pointermove", onPointerMove);
+      surface.removeEventListener("pointerup", onPointerEnd);
+      surface.removeEventListener("pointercancel", onPointerCancel);
+      surface.removeEventListener("click", onClick, true);
+    };
+  }, [
+    abortPointerPull,
+    commitPull,
+    emptyGestureTargetRef,
+    setPullPx,
+    surfaceReady,
+  ]);
+
   // Clear timers that may outlive a single gesture.
   useEffect(
     () => () => {
@@ -1858,6 +1984,9 @@ export function NotificationsHomeCenter({
       stackFoldTimers.current.clear();
       if (suppressNotificationClickTimer.current !== null) {
         window.clearTimeout(suppressNotificationClickTimer.current);
+      }
+      if (suppressBackgroundClickTimer.current !== null) {
+        window.clearTimeout(suppressBackgroundClickTimer.current);
       }
     },
     [],
@@ -2050,19 +2179,6 @@ export function NotificationsHomeCenter({
     hasNotifications &&
     expandedStacks.size === 0 &&
     !shadeOpenedByStack;
-  const abortPointerPull = () => {
-    const px = pullPxRef.current;
-    if (px !== 0) {
-      flushPullPresentation();
-      if (!reduceMotion) {
-        beginPullCancellation(
-          px > 0 ? "expand" : "collapse",
-          PULL_CANCEL_SETTLE_MS,
-        );
-      }
-    }
-    setPullPx(0);
-  };
   const onListPointerDown = (e: React.PointerEvent) => {
     if (e.pointerType !== "mouse" || !e.isPrimary) return;
     const el = scrollRef.current;
@@ -2134,63 +2250,6 @@ export function NotificationsHomeCenter({
     pointerPull.current = null;
     abortPointerPull();
   };
-  const onEmptyPointerDown = (e: React.PointerEvent) => {
-    const list = scrollRef.current;
-    if (
-      e.pointerType !== "mouse" ||
-      !e.isPrimary ||
-      !canCollapse ||
-      !list ||
-      (e.target instanceof Node && list.contains(e.target)) ||
-      isInteractiveGestureTarget(e.target)
-    ) {
-      return;
-    }
-    emptyPointerPull.current = {
-      id: e.pointerId,
-      startX: e.clientX,
-      startY: e.clientY,
-      axis: "none",
-    };
-  };
-  const onEmptyPointerMove = (e: React.PointerEvent) => {
-    const gesture = emptyPointerPull.current;
-    if (!gesture || gesture.id !== e.pointerId) return;
-    if (!shadeGestureRef.current.canCollapse) {
-      emptyPointerPull.current = null;
-      if (pullPxRef.current !== 0) setPullPx(0);
-      return;
-    }
-    const dx = e.clientX - gesture.startX;
-    const dy = e.clientY - gesture.startY;
-    if (
-      gesture.axis === "none" &&
-      (Math.abs(dx) > PULL_SLOP_PX || Math.abs(dy) > PULL_SLOP_PX)
-    ) {
-      gesture.axis = Math.abs(dx) > Math.abs(dy) ? "x" : "y";
-      if (gesture.axis === "y") {
-        e.currentTarget.setPointerCapture?.(e.pointerId);
-      }
-    }
-    if (gesture.axis === "x") {
-      emptyPointerPull.current = null;
-      return;
-    }
-    if (gesture.axis !== "y") return;
-    setPullPx(dy < -PULL_SLOP_PX ? -dampenPull(-dy) : 0, dy >= -PULL_SLOP_PX);
-  };
-  const onEmptyPointerEnd = (e: React.PointerEvent) => {
-    const gesture = emptyPointerPull.current;
-    if (!gesture || gesture.id !== e.pointerId) return;
-    onEmptyPointerMove(e);
-    emptyPointerPull.current = null;
-    commitPull();
-  };
-  const onEmptyPointerCancel = (e: React.PointerEvent) => {
-    if (emptyPointerPull.current?.id !== e.pointerId) return;
-    emptyPointerPull.current = null;
-    abortPointerPull();
-  };
   const onListClickCapture = (e: React.MouseEvent) => {
     if (!suppressNotificationClick.current) return;
     suppressNotificationClick.current = false;
@@ -2247,10 +2306,6 @@ export function NotificationsHomeCenter({
       data-notification-shade-cancelling={
         pullCancellingDirection ? "" : undefined
       }
-      onPointerDown={onEmptyPointerDown}
-      onPointerMove={onEmptyPointerMove}
-      onPointerUp={onEmptyPointerEnd}
-      onPointerCancel={onEmptyPointerCancel}
       // No card chrome on the CONTAINER: the inbox has no fill and no border of
       // its own — the glass lives on each notification card. It sits inline on
       // the home field directly under the time/weather header.

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -17,7 +17,7 @@
  * Two shade modes:
  *
  *  - RESTED is triage: interrupt-tier (`high`/`urgent`) producer stacks remain
- *    visible above the passive total while quieter notifications stay folded
+ *    visible above the interactive total while quieter notifications stay folded
  *    behind the same producer's visible stack depth.
  *  - EXPANDED shows every priority and preserves each producer stack until the
  *    user fans that group out in place; the list is height-capped and scrolls
@@ -29,9 +29,9 @@
  * same-direction gesture in the state it already produced is a no-op — this is
  * what makes trackpad momentum safe (the old toggle re-fired on trailing
  * momentum deltas and snapped the shade shut moments after opening it). The
- * footer is a passive total (for example, "3 Notifications"), never a control;
- * it belongs only to the closed shade, fading away during expansion and back
- * in during collapse. Pull/push gestures exclusively own the transition.
+ * footer total (for example, "3 Notifications") opens the shade directly and
+ * fades away during expansion, then returns during collapse. Pull/push gestures
+ * provide the same directional transition from the surrounding surface.
  *
  * The pull/wheel gesture NEVER fans a stack, and a drag that starts on a stack
  * still belongs to the shade. Tapping a peek fans that producer group and
@@ -57,6 +57,14 @@ import {
   useRef,
   useState,
 } from "react";
+import {
+  getMomentumReleaseVelocity,
+  getVelocityAwareSettleDuration,
+  MOMENTUM_RELEASE_WINDOW_MS,
+  type MomentumSample,
+  shouldCommitMomentumDetent,
+  useRafCoalescer,
+} from "../../gestures";
 import { cn } from "../../lib/utils";
 import {
   isSafeDeepLink,
@@ -107,6 +115,7 @@ import {
   notificationPullRevealStyle,
   PULL_COMMIT_PX,
   PULL_SLOP_PX,
+  PULL_TRAVEL_PX,
   visibleNotificationGroups,
 } from "./notification-shade-presentation";
 
@@ -150,6 +159,17 @@ function isInteractiveGestureTarget(target: EventTarget | null): boolean {
   );
 }
 
+function touchWithIdentifier(
+  touches: TouchList,
+  identifier: number,
+): Touch | undefined {
+  for (let index = 0; index < touches.length; index += 1) {
+    const touch = touches[index];
+    if (touch?.identifier === identifier) return touch;
+  }
+  return undefined;
+}
+
 /**
  * Per-event cap (px) on a wheel delta's contribution toward the COLLAPSE
  * commit. Collapse shares its direction with ordinary downward scrolling, so
@@ -174,13 +194,43 @@ const STACK_PEEK_OFFSET_PX = 7;
 const STACK_BOTTOM_CLEARANCE_PX = 10;
 
 const CLEAR_CONFIRM_TIMEOUT_MS = 5_000;
-const SHADE_CLOSE_FADE_MS = 220;
-const NOTIFICATION_COUNT_RESTORE_MS = 140;
+const SHADE_SETTLE_MS = 340;
+const SHADE_MIN_SETTLE_MS = 260;
+const SHADE_MAX_SETTLE_MS = 440;
+const SHADE_MIN_SETTLE_SPEED_PX_PER_MS = 0.22;
+const SHADE_EASING = "cubic-bezier(0.25,0.1,0.25,1)";
+const PULL_CANCEL_SETTLE_MS = SHADE_SETTLE_MS;
+const SHADE_MIN_FLICK_DISTANCE_PX = 22;
+const SHADE_FLICK_VELOCITY_PX_PER_MS = 0.45;
+const SHADE_MIN_VELOCITY_SAMPLE_MS = 16;
+// The count and clear slots trade the same 40px of list flow space. Their
+// geometry must settle on one clock or a cancelled pull overshoots before the
+// slower slot catches up, making the count reverse direction at the edge.
+const NOTIFICATION_COUNT_RESTORE_MS = SHADE_SETTLE_MS;
 const NOTIFICATION_ROW_SETTLE_MS = 220;
-const STACK_LAYOUT_TRANSITION = {
-  duration: 0.34,
-  ease: [0.22, 1, 0.36, 1],
+/** The stack fan has enough travel to read clearly without feeling delayed. */
+export const STACK_FAN_SETTLE_MS = 300;
+const STACK_FAN_LAYOUT_TRANSITION = {
+  duration: STACK_FAN_SETTLE_MS / 1_000,
+  ease: [0.25, 0.1, 0.25, 1],
 } as const;
+/**
+ * A fold retains the fanned DOM until its rows have reached the stack. Sharing
+ * this clock with the layout settle prevents sibling groups from snapping into
+ * their new positions before the disappearing cards finish converging.
+ */
+export const STACK_FOLD_SETTLE_MS = 340;
+const STACK_FOLD_COMPACTION_BUFFER_MS = 34;
+const STACK_FOLD_LAYOUT_TRANSITION = {
+  duration: STACK_FOLD_SETTLE_MS / 1_000,
+  ease: [0.25, 0.1, 0.25, 1],
+} as const;
+
+interface PendingStackFold {
+  timer: number;
+  mayRestoreRestedShade: boolean;
+  shadeCloseStarted: boolean;
+}
 
 /**
  * Scroll + glass polish for the shade, in one inline block (house pattern —
@@ -199,9 +249,8 @@ const STACK_LAYOUT_TRANSITION = {
  *  - Rows hidden by the closed shade track pull distance with opacity and
  *    vertical settling, so the user's finger reveals content before release.
  *
- * Reduced motion keeps the direct-manipulation transitions that preserve
- * spatial continuity, while omitting scroll-edge decoration and scale-heavy
- * effects.
+ * Reduced motion still tracks direct manipulation under the pointer, but
+ * removes every automated settle and decorative transition.
  */
 const NOTIF_SCROLL_CSS = `
 /* Apple-style entrance: the whole inbox fades + rises a touch the moment it
@@ -232,11 +281,11 @@ const NOTIF_SCROLL_CSS = `
 }
 /* A dense expanded inbox cannot afford one live backdrop-refraction graph per
    card. Keep the full material for the small rested triage; while previewing
-   or expanded, the same sheen/rim sits on an opaque translucent fill so drag
+   or expanded, the same sheen/rim sits on a solid fill so drag
    and scroll stay compositor-cheap even at the 100-row render cap. */
 .eliza-notif-scroll[data-shade-preview] .eliza-notif-glass,
 .eliza-notif-scroll[data-shade-mode="expanded"] .eliza-notif-glass {
-  background-color: rgb(22 22 25 / 88%);
+  background-color: rgb(22 22 25);
   -webkit-backdrop-filter: none;
   backdrop-filter: none;
 }
@@ -251,6 +300,7 @@ const NOTIF_SCROLL_CSS = `
 /* A collapsed stack is a set of physical cards, not translucent glass panes.
    Keep its front card and peeks solid through every shade/pager material
    override so the wallpaper and adjacent rows cannot show through. */
+.eliza-notif-scroll [data-notification-stack-material] .eliza-notif-glass,
 .eliza-notif-scroll [data-notification-stacked] .eliza-notif-glass,
 .eliza-notif-scroll .eliza-notif-glass.eliza-notif-stack-peek {
   background-color: rgb(28 28 30);
@@ -270,19 +320,39 @@ ${liquidGlassRimCss(".eliza-notif-glass")}
 .eliza-notif-shade-transition {
   transform-origin: top center;
   transition:
-    grid-template-rows ${SHADE_CLOSE_FADE_MS}ms cubic-bezier(0.22,1,0.36,1),
-    height ${SHADE_CLOSE_FADE_MS}ms cubic-bezier(0.22,1,0.36,1),
-    margin-bottom ${SHADE_CLOSE_FADE_MS}ms cubic-bezier(0.22,1,0.36,1),
-    padding-bottom ${SHADE_CLOSE_FADE_MS}ms cubic-bezier(0.22,1,0.36,1),
-    bottom ${SHADE_CLOSE_FADE_MS}ms cubic-bezier(0.22,1,0.36,1),
-    opacity ${SHADE_CLOSE_FADE_MS}ms ease-out,
-    transform ${SHADE_CLOSE_FADE_MS}ms cubic-bezier(0.22,1,0.36,1);
+    grid-template-rows var(--eliza-notif-geometry-duration, var(--eliza-notif-settle-duration, ${SHADE_SETTLE_MS}ms)) ${SHADE_EASING},
+    height var(--eliza-notif-geometry-duration, var(--eliza-notif-settle-duration, ${SHADE_SETTLE_MS}ms)) ${SHADE_EASING},
+    margin-bottom var(--eliza-notif-geometry-duration, var(--eliza-notif-settle-duration, ${SHADE_SETTLE_MS}ms)) ${SHADE_EASING},
+    padding-bottom var(--eliza-notif-geometry-duration, var(--eliza-notif-settle-duration, ${SHADE_SETTLE_MS}ms)) ${SHADE_EASING},
+    row-gap var(--eliza-notif-geometry-duration, var(--eliza-notif-settle-duration, ${SHADE_SETTLE_MS}ms)) ${SHADE_EASING},
+    opacity var(--eliza-notif-opacity-duration, var(--eliza-notif-settle-duration, ${SHADE_SETTLE_MS}ms)) ${SHADE_EASING} var(--eliza-notif-opacity-delay, 0ms),
+    transform var(--eliza-notif-geometry-duration, var(--eliza-notif-settle-duration, ${SHADE_SETTLE_MS}ms)) ${SHADE_EASING};
+}
+/* Rows, peeks, controls, and the count badge share the stack's full settle so
+   the physical layers crossfade while they converge instead of swapping near
+   the endpoint. */
+[data-notification-stack-fanned]:not([data-notification-stack-closing]) .eliza-notif-shade-transition {
+  --eliza-notif-geometry-duration: ${STACK_FAN_SETTLE_MS}ms;
+  transition-timing-function: ${SHADE_EASING};
+}
+[data-notification-stack-closing] .eliza-notif-shade-transition {
+  --eliza-notif-geometry-duration: ${STACK_FOLD_SETTLE_MS}ms;
+  transition-timing-function: ${SHADE_EASING};
+}
+[data-notification-stack-fanned]:not([data-notification-stack-closing]) :is([data-notification-stack-peek], [data-notification-source-count], [data-notification-stack-controls], [data-notification-disposable-row]) {
+  --eliza-notif-opacity-duration: ${STACK_FAN_SETTLE_MS}ms;
+  --eliza-notif-opacity-delay: 0ms;
+}
+[data-notification-stack-closing] :is([data-notification-stack-peek], [data-notification-source-count], [data-notification-stack-controls], [data-notification-disposable-row]) {
+  --eliza-notif-opacity-duration: ${STACK_FOLD_SETTLE_MS}ms;
+  --eliza-notif-opacity-delay: 0ms;
 }
 .eliza-notif-count-transition {
   transition:
-    height ${NOTIFICATION_COUNT_RESTORE_MS}ms cubic-bezier(0.22,1,0.36,1),
-    margin-bottom ${NOTIFICATION_COUNT_RESTORE_MS}ms cubic-bezier(0.22,1,0.36,1),
-    opacity ${NOTIFICATION_COUNT_RESTORE_MS}ms ease-out;
+    height var(--eliza-notif-settle-duration, ${NOTIFICATION_COUNT_RESTORE_MS}ms) ${SHADE_EASING},
+    margin-bottom var(--eliza-notif-settle-duration, ${NOTIFICATION_COUNT_RESTORE_MS}ms) ${SHADE_EASING},
+    opacity var(--eliza-notif-opacity-duration, var(--eliza-notif-settle-duration, ${NOTIFICATION_COUNT_RESTORE_MS}ms)) ${SHADE_EASING} var(--eliza-notif-opacity-delay, 0ms),
+    transform var(--eliza-notif-settle-duration, ${NOTIFICATION_COUNT_RESTORE_MS}ms) ${SHADE_EASING};
 }
 .eliza-notif-scroll[data-shade-dragging] .eliza-notif-shade-transition,
 .eliza-notif-scroll[data-shade-dragging] .eliza-notif-count-transition {
@@ -297,7 +367,19 @@ ${liquidGlassRimCss(".eliza-notif-glass")}
   animation: none;
 }
 .eliza-notif-scroll {
+  isolation: isolate;
   scrollbar-width: none;
+}
+/* Count and card shells become independent compositor layers while they trade
+   flow space. Keep cards above the count so its label fades behind their
+   material instead of painting through it during either shade direction. */
+.eliza-notif-scroll [data-notification-count-slot] {
+  position: relative;
+  z-index: 0;
+}
+.eliza-notif-scroll [data-notification-group] {
+  position: relative;
+  z-index: 1;
 }
 .eliza-notif-scroll::-webkit-scrollbar { display: none; }
 @keyframes eliza-notif-fade-in {
@@ -332,47 +414,52 @@ ${liquidGlassRimCss(".eliza-notif-glass")}
   }
 }
 @media (prefers-reduced-motion: reduce) {
-  .eliza-notif-row { animation: none; }
-  .eliza-notif-center-in {
-    animation: eliza-notif-fade-in 240ms ease-out both !important;
-  }
-  .eliza-notif-row-inner {
-    transition:
-      transform ${NOTIFICATION_ROW_SETTLE_MS}ms cubic-bezier(0.22,1,0.36,1),
-      opacity ${NOTIFICATION_ROW_SETTLE_MS}ms linear !important;
-  }
-  .eliza-notif-row-inner[data-swipe-dragging] {
+  .eliza-notif-center,
+  .eliza-notif-center *,
+  .eliza-notif-center *::before,
+  .eliza-notif-center *::after {
+    animation: none !important;
     transition: none !important;
-  }
-  .eliza-notif-shade-transition {
-    transition:
-      grid-template-rows ${SHADE_CLOSE_FADE_MS}ms cubic-bezier(0.22,1,0.36,1),
-      height ${SHADE_CLOSE_FADE_MS}ms cubic-bezier(0.22,1,0.36,1),
-      margin-bottom ${SHADE_CLOSE_FADE_MS}ms cubic-bezier(0.22,1,0.36,1),
-      padding-bottom ${SHADE_CLOSE_FADE_MS}ms cubic-bezier(0.22,1,0.36,1),
-      bottom ${SHADE_CLOSE_FADE_MS}ms cubic-bezier(0.22,1,0.36,1),
-      opacity ${SHADE_CLOSE_FADE_MS}ms ease-out,
-      transform ${SHADE_CLOSE_FADE_MS}ms cubic-bezier(0.22,1,0.36,1) !important;
-  }
-  .eliza-notif-scroll[data-shade-dragging] .eliza-notif-shade-transition {
-    transition: none !important;
-  }
-  .eliza-notif-count-transition {
-    transition:
-      height ${NOTIFICATION_COUNT_RESTORE_MS}ms cubic-bezier(0.22,1,0.36,1),
-      margin-bottom ${NOTIFICATION_COUNT_RESTORE_MS}ms cubic-bezier(0.22,1,0.36,1),
-      opacity ${NOTIFICATION_COUNT_RESTORE_MS}ms ease-out !important;
-  }
-  .eliza-notif-scroll[data-shade-dragging] .eliza-notif-count-transition {
-    transition: none !important;
-  }
-  .eliza-notif-control-transition {
-    transition-duration: 220ms !important;
   }
 }
 `;
 
 let notificationsHomeCenterRenderObserverForTests: (() => void) | null = null;
+
+function usePrefersReducedMotion(): boolean {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(() => {
+    if (
+      typeof window === "undefined" ||
+      typeof window.matchMedia !== "function"
+    ) {
+      return false;
+    }
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  });
+
+  useEffect(() => {
+    if (
+      typeof window === "undefined" ||
+      typeof window.matchMedia !== "function"
+    ) {
+      return undefined;
+    }
+
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const update = () => setPrefersReducedMotion(mediaQuery.matches);
+    update();
+
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", update);
+      return () => mediaQuery.removeEventListener("change", update);
+    }
+
+    mediaQuery.addListener(update);
+    return () => mediaQuery.removeListener(update);
+  }, []);
+
+  return prefersReducedMotion;
+}
 
 export function __setNotificationsHomeCenterRenderObserverForTests(
   observer: (() => void) | null,
@@ -397,24 +484,114 @@ export function NotificationsHomeCenter({
 } = {}): React.JSX.Element | null {
   notificationsHomeCenterRenderObserverForTests?.();
   const { notifications, hydrated, hydrationStatus } = useNotifications();
+  const reduceMotion = usePrefersReducedMotion();
   // Shade mode: rested (interrupt-tier triage) vs expanded (full inbox).
   // Producer groups stay stacked until individually fanned out.
   const [shadeExpanded, setShadeExpanded] = useState(false);
+  const [shadeOpenProgress, setShadeOpenProgress] = useState(1);
   // Per-producer stack expansion (iOS-shade idiom). Tapping a peek fans that
   // stack and enters the expanded shade; folding the shade resets every stack.
   const [expandedStacks, setExpandedStacks] = useState<ReadonlySet<string>>(
     () => new Set(),
   );
+  const [openingStacks, setOpeningStacks] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+  const [closingStacks, setClosingStacks] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+  const [stackPeekOpenOffsets, setStackPeekOpenOffsets] = useState<
+    ReadonlyMap<string, readonly number[]>
+  >(() => new Map());
+  const stackGeometryRevision = useMemo(
+    () =>
+      notifications
+        .map(
+          (notification) =>
+            `${notification.id}\u0000${notification.title}\u0000${notification.body ?? ""}`,
+        )
+        .join("\u0001"),
+    [notifications],
+  );
+  const expandedStacksRef = useRef(expandedStacks);
+  expandedStacksRef.current = expandedStacks;
   const [shadeOpenedByStack, setShadeOpenedByStack] = useState(false);
+  const shadeOpenedByStackRef = useRef(shadeOpenedByStack);
+  shadeOpenedByStackRef.current = shadeOpenedByStack;
   const [confirmingGroupKey, setConfirmingGroupKey] = useState<string | null>(
     null,
   );
   const [confirmingClearAll, setConfirmingClearAll] = useState(false);
   const [shadeClosing, setShadeClosing] = useState(false);
+  const [pullCancellingDirection, setPullCancellingDirection] = useState<
+    "expand" | "collapse" | null
+  >(null);
   const shadeCloseTimer = useRef<number | null>(null);
+  const pullCancelTimer = useRef<number | null>(null);
+  const stackFoldTimers = useRef(new Map<string, PendingStackFold>());
+  const centerRef = useRef<HTMLElement | null>(null);
+  const pendingShadeFocusRef = useRef(false);
+  const pendingStackFocusRef = useRef<string | null>(null);
+  const pendingCollapsedStackFocusRef = useRef<string | null>(null);
+  const pendingRestedCountFocusRef = useRef(false);
+  const cancelPullCancellation = useCallback(() => {
+    if (pullCancelTimer.current !== null) {
+      window.clearTimeout(pullCancelTimer.current);
+      pullCancelTimer.current = null;
+    }
+    setPullCancellingDirection(null);
+  }, []);
+  const cancelStackFold = useCallback((key: string) => {
+    const pending = stackFoldTimers.current.get(key);
+    if (pending) {
+      window.clearTimeout(pending.timer);
+      stackFoldTimers.current.delete(key);
+    }
+    setClosingStacks((prev) => {
+      if (!prev.has(key)) return prev;
+      const next = new Set(prev);
+      next.delete(key);
+      return next;
+    });
+  }, []);
+  const cancelAllStackFolds = useCallback(() => {
+    for (const pending of stackFoldTimers.current.values()) {
+      window.clearTimeout(pending.timer);
+    }
+    stackFoldTimers.current.clear();
+    setClosingStacks((prev) => (prev.size === 0 ? prev : new Set()));
+  }, []);
   const expandStack = useCallback(
-    (key: string) => {
-      if (!shadeExpanded) setShadeOpenedByStack(true);
+    (key: string, moveFocus: boolean) => {
+      if (shadeCloseTimer.current !== null) {
+        // A newly fanned producer supersedes an auto-restore started by an
+        // older fold. Reverse the shared shade settle and let the live stack
+        // projection decide whether a later fold should restore rest.
+        window.clearTimeout(shadeCloseTimer.current);
+        shadeCloseTimer.current = null;
+        setShadeClosing(false);
+        for (const pending of stackFoldTimers.current.values()) {
+          pending.shadeCloseStarted = false;
+        }
+      }
+      cancelPullCancellation();
+      cancelStackFold(key);
+      centerRef.current?.style.setProperty(
+        "--eliza-notif-settle-duration",
+        `${STACK_FAN_SETTLE_MS}ms`,
+      );
+      if (moveFocus) pendingStackFocusRef.current = key;
+      if (!shadeExpanded) {
+        setShadeOpenedByStack(true);
+        setShadeOpenProgress(reduceMotion ? 1 : 0);
+      }
+      if (!reduceMotion) {
+        setOpeningStacks((prev) => {
+          const next = new Set(prev);
+          next.add(key);
+          return next;
+        });
+      }
       setExpandedStacks((prev) => {
         if (prev.has(key)) return prev;
         const next = new Set(prev);
@@ -425,18 +602,213 @@ export function NotificationsHomeCenter({
       setConfirmingClearAll(false);
       setShadeExpanded(true);
     },
-    [shadeExpanded],
+    [cancelPullCancellation, cancelStackFold, reduceMotion, shadeExpanded],
   );
-  const collapseStack = useCallback((key: string) => {
-    setExpandedStacks((prev) => {
-      if (!prev.has(key)) return prev;
-      const next = new Set(prev);
-      next.delete(key);
-      return next;
+  const collapseStack = useCallback(
+    (key: string, moveFocus = false) => {
+      cancelPullCancellation();
+      cancelStackFold(key);
+      if (moveFocus) pendingCollapsedStackFocusRef.current = key;
+      setOpeningStacks((prev) => {
+        if (!prev.has(key)) return prev;
+        const next = new Set(prev);
+        next.delete(key);
+        return next;
+      });
+      setExpandedStacks((prev) => {
+        if (!prev.has(key)) return prev;
+        const next = new Set(prev);
+        next.delete(key);
+        return next;
+      });
+      setConfirmingGroupKey((current) => (current === key ? null : current));
+      setConfirmingClearAll(false);
+    },
+    [cancelPullCancellation, cancelStackFold],
+  );
+
+  useLayoutEffect(() => {
+    const shouldOpenShade =
+      shadeExpanded && shadeOpenProgress === 0 && !reduceMotion;
+    const shouldFanStacks = openingStacks.size > 0 && !reduceMotion;
+    if (!shouldOpenShade && !shouldFanStacks) return;
+
+    // Snapshot the mounted origin once, then launch both targets on the next
+    // frame. This preserves a real CSS transition without two idle frames or
+    // two separate React commits when a stack also opens the shade.
+    centerRef.current?.getBoundingClientRect();
+    const targetFrame = window.requestAnimationFrame(() => {
+      if (shouldOpenShade) setShadeOpenProgress(1);
+      if (shouldFanStacks) setOpeningStacks(new Set());
     });
-    setConfirmingGroupKey((current) => (current === key ? null : current));
-    setConfirmingClearAll(false);
-  }, []);
+    return () => window.cancelAnimationFrame(targetFrame);
+  }, [openingStacks, reduceMotion, shadeExpanded, shadeOpenProgress]);
+
+  useLayoutEffect(() => {
+    if (!reduceMotion) return;
+    if (shadeOpenProgress !== 1) setShadeOpenProgress(1);
+    if (openingStacks.size > 0) setOpeningStacks(new Set());
+  }, [openingStacks.size, reduceMotion, shadeOpenProgress]);
+
+  useLayoutEffect(() => {
+    const center = centerRef.current;
+    if (!center || expandedStacks.size === 0 || stackGeometryRevision === "") {
+      return;
+    }
+
+    let disposed = false;
+    let measureFrame: number | null = null;
+    const stackRows = () =>
+      center.querySelectorAll<HTMLElement>(
+        "[data-notification-group-key][data-notification-stack-fanned] [data-notification-stack-rows]",
+      );
+    const measure = () => {
+      measureFrame = null;
+      if (disposed) return;
+      const measured = new Map<string, readonly number[]>();
+      for (const rowList of stackRows()) {
+        const group = rowList.closest<HTMLElement>(
+          "[data-notification-group-key]",
+        );
+        const key = group?.dataset.notificationGroupKey;
+        if (!key) continue;
+        const rows = Array.from(rowList.children).filter(
+          (child): child is HTMLElement =>
+            child instanceof HTMLElement &&
+            child.hasAttribute("data-notif-row"),
+        );
+        if (rows.length < 2) continue;
+
+        let offsetPx = 0;
+        const offsets: number[] = [];
+        for (
+          let rowIndex = 0;
+          rowIndex < Math.min(rows.length - 1, MAX_VISIBLE_STACK_LAYERS - 1);
+          rowIndex += 1
+        ) {
+          const rowContent = rows[rowIndex]?.querySelector<HTMLElement>(
+            '[data-testid="notification-row"]',
+          );
+          if (!rowContent) break;
+          // The content button retains its natural size while the outer grid
+          // row fans from 0fr. Measuring it avoids sampling an intermediate
+          // transition height and keeps variable-height rows spatially exact.
+          const renderedHeightPx = rowContent.getBoundingClientRect().height;
+          const rowHeightPx =
+            renderedHeightPx > 0 ? renderedHeightPx : rowContent.scrollHeight;
+          if (rowHeightPx <= 0) break;
+          offsetPx += rowHeightPx + 6;
+          offsets.push(offsetPx);
+        }
+        if (offsets.length > 0) measured.set(key, offsets);
+      }
+
+      setStackPeekOpenOffsets((previous) => {
+        let changed = previous.size !== measured.size;
+        if (!changed) {
+          for (const [key, offsets] of measured) {
+            const prior = previous.get(key);
+            if (
+              prior?.length !== offsets.length ||
+              offsets.some((offset, index) => prior[index] !== offset)
+            ) {
+              changed = true;
+              break;
+            }
+          }
+        }
+        return changed ? measured : previous;
+      });
+    };
+    const scheduleMeasure = () => {
+      if (disposed) return;
+      if (measureFrame !== null) window.cancelAnimationFrame(measureFrame);
+      measureFrame = window.requestAnimationFrame(measure);
+    };
+
+    measure();
+    const resizeObserver =
+      typeof ResizeObserver === "function"
+        ? new ResizeObserver(scheduleMeasure)
+        : null;
+    for (const rowList of stackRows()) {
+      for (const row of Array.from(rowList.children)) {
+        const rowContent = row.querySelector<HTMLElement>(
+          '[data-testid="notification-row"]',
+        );
+        if (rowContent) resizeObserver?.observe(rowContent);
+      }
+    }
+    window.addEventListener("resize", scheduleMeasure);
+    void document.fonts?.ready.then(scheduleMeasure);
+    return () => {
+      disposed = true;
+      resizeObserver?.disconnect();
+      window.removeEventListener("resize", scheduleMeasure);
+      if (measureFrame !== null) window.cancelAnimationFrame(measureFrame);
+    };
+  }, [expandedStacks, stackGeometryRevision]);
+
+  useLayoutEffect(() => {
+    if (
+      !pendingShadeFocusRef.current ||
+      !shadeExpanded ||
+      shadeOpenProgress !== 1
+    ) {
+      return;
+    }
+    const firstRow = centerRef.current?.querySelector<HTMLElement>(
+      '[data-testid="notification-row"]',
+    );
+    if (!firstRow) return;
+    pendingShadeFocusRef.current = false;
+    firstRow.focus();
+  }, [shadeExpanded, shadeOpenProgress]);
+
+  useLayoutEffect(() => {
+    const key = pendingStackFocusRef.current;
+    if (!key || openingStacks.has(key) || !expandedStacks.has(key)) return;
+    const group = Array.from(
+      centerRef.current?.querySelectorAll<HTMLElement>(
+        "[data-notification-group-key]",
+      ) ?? [],
+    ).find((candidate) => candidate.dataset.notificationGroupKey === key);
+    const collapseControl = group?.querySelector<HTMLElement>(
+      '[data-testid="notification-stack-collapse"]',
+    );
+    if (!collapseControl) return;
+    pendingStackFocusRef.current = null;
+    collapseControl.focus();
+  }, [expandedStacks, openingStacks]);
+
+  useLayoutEffect(() => {
+    const key = pendingCollapsedStackFocusRef.current;
+    if (!key || (expandedStacks.has(key) && !closingStacks.has(key))) {
+      return;
+    }
+    const group = Array.from(
+      centerRef.current?.querySelectorAll<HTMLElement>(
+        "[data-notification-group-key]",
+      ) ?? [],
+    ).find((candidate) => candidate.dataset.notificationGroupKey === key);
+    pendingCollapsedStackFocusRef.current = null;
+    group
+      ?.querySelector<HTMLElement>('[data-testid="notification-row"]')
+      ?.focus();
+  }, [closingStacks, expandedStacks]);
+
+  useLayoutEffect(() => {
+    if (
+      !pendingRestedCountFocusRef.current ||
+      (shadeExpanded && !shadeClosing)
+    ) {
+      return;
+    }
+    pendingRestedCountFocusRef.current = false;
+    centerRef.current
+      ?.querySelector<HTMLElement>('[data-testid="notifications-count-button"]')
+      ?.focus();
+  }, [shadeClosing, shadeExpanded]);
   // Dampened live pull (px), SIGNED: positive is a downward pull (expand),
   // negative an upward push (collapse). React mounts the preview once when a
   // gesture starts; pointer moves update existing styles directly so a
@@ -446,12 +818,15 @@ export function NotificationsHomeCenter({
   >(null);
   const pullDirectionRef = useRef<"expand" | "collapse" | null>(null);
   const pullPxRef = useRef(0);
-  const pullPresentationFrame = useRef<number | null>(null);
+  const pullMomentumRef = useRef<{
+    direction: "expand" | "collapse";
+    startedAtMs: number;
+    samples: MomentumSample[];
+  } | null>(null);
   // No list-level clock tick here (binding pattern, spec §C.4): relative
   // timestamps live in the `<RelativeTime>` leaf inside each row, which owns the
   // shared visibility-gated ticker. The minute roll re-renders those text nodes
   // only - not this list, not the rows, not the glass surface.
-  const centerRef = useRef<HTMLElement | null>(null);
   const scrollRef = useRef<HTMLUListElement | null>(null);
   const pullVisibleGroupsRef = useRef<HTMLElement[] | undefined>(undefined);
   const pointerPull = useRef<{
@@ -463,6 +838,12 @@ export function NotificationsHomeCenter({
     // pull is measured from here, not from the gesture start, so a drag that
     // first scrolled the list up to its top doesn't arrive already maxed.
     anchorY: number | null;
+  } | null>(null);
+  const emptyPointerPull = useRef<{
+    id: number;
+    startX: number;
+    startY: number;
+    axis: "none" | "x" | "y";
   } | null>(null);
   // A touch drag can end in `pointercancel` before the row sees enough pointer
   // movement to suppress the browser's synthetic click. The list owns the
@@ -493,6 +874,33 @@ export function NotificationsHomeCenter({
     closing: shadeClosing,
   };
 
+  const applyPullPresentation = useCallback((px: number) => {
+    applyNotificationPullPresentation(
+      centerRef.current,
+      px,
+      shadePresentationRef.current.expanded,
+      shadePresentationRef.current.closing,
+      pullVisibleGroupsRef.current,
+    );
+  }, []);
+  const {
+    schedule: schedulePullPresentation,
+    flush: flushScheduledPullPresentation,
+    cancel: cancelScheduledPullPresentation,
+  } = useRafCoalescer(applyPullPresentation);
+
+  const setShadeSettleDuration = useCallback((durationMs: number) => {
+    centerRef.current?.style.setProperty(
+      "--eliza-notif-settle-duration",
+      `${durationMs}ms`,
+    );
+  }, []);
+
+  const flushPullPresentation = useCallback(() => {
+    flushScheduledPullPresentation();
+    centerRef.current?.getBoundingClientRect();
+  }, [flushScheduledPullPresentation]);
+
   const armNotificationClickSuppression = useCallback(() => {
     suppressNotificationClick.current = true;
     if (suppressNotificationClickTimer.current !== null) {
@@ -504,67 +912,137 @@ export function NotificationsHomeCenter({
     }, 500);
   }, []);
 
-  const setPullPx = useCallback((px: number) => {
-    pullPxRef.current = px;
-    const nextDirection = px > 0 ? "expand" : px < 0 ? "collapse" : null;
-    const directionChanged = pullDirectionRef.current !== nextDirection;
-    if (directionChanged) {
-      pullDirectionRef.current = nextDirection;
-      pullVisibleGroupsRef.current = nextDirection
-        ? visibleNotificationGroups(centerRef.current, scrollRef.current)
-        : undefined;
-      setPullDirection(nextDirection);
-    }
-    // The zero state is rendered declaratively after the dragging marker is
-    // removed, allowing the release transition to run. Non-zero movement is
-    // direct manipulation and must update in the current input event.
-    const applyCurrentPull = () => {
-      pullPresentationFrame.current = null;
-      applyNotificationPullPresentation(
-        centerRef.current,
-        pullPxRef.current,
-        shadePresentationRef.current.expanded,
-        shadePresentationRef.current.closing,
-        pullVisibleGroupsRef.current,
-      );
-    };
-    if (!nextDirection) {
-      if (pullPresentationFrame.current !== null) {
-        window.cancelAnimationFrame(pullPresentationFrame.current);
-        pullPresentationFrame.current = null;
+  const setPullPx = useCallback(
+    (px: number, preserveDirectionAtZero = false) => {
+      pullPxRef.current = px;
+      const nextDirection =
+        px > 0
+          ? "expand"
+          : px < 0
+            ? "collapse"
+            : preserveDirectionAtZero
+              ? pullDirectionRef.current
+              : null;
+      const directionChanged = pullDirectionRef.current !== nextDirection;
+      if (nextDirection) {
+        const now = performance.now();
+        let momentum = pullMomentumRef.current;
+        if (!momentum || momentum.direction !== nextDirection) {
+          momentum = {
+            direction: nextDirection,
+            startedAtMs: now,
+            samples: [{ positionPx: 0, timeMs: now }],
+          };
+          pullMomentumRef.current = momentum;
+        }
+        momentum.samples.push({ positionPx: px, timeMs: now });
+        const cutoff = now - MOMENTUM_RELEASE_WINDOW_MS;
+        while (
+          momentum.samples.length > 2 &&
+          (momentum.samples[1]?.timeMs ?? now) < cutoff
+        ) {
+          momentum.samples.shift();
+        }
+      } else {
+        pullMomentumRef.current = null;
       }
-    } else if (directionChanged) {
-      applyCurrentPull();
-    } else if (pullPresentationFrame.current === null) {
-      pullPresentationFrame.current =
-        window.requestAnimationFrame(applyCurrentPull);
-    }
-  }, []);
+      if (directionChanged) {
+        pullDirectionRef.current = nextDirection;
+        pullVisibleGroupsRef.current = nextDirection
+          ? visibleNotificationGroups(centerRef.current, scrollRef.current)
+          : undefined;
+        setPullDirection(nextDirection);
+      }
+      // The zero state is rendered declaratively after the dragging marker is
+      // removed, allowing the release transition to run. Non-zero movement is
+      // direct manipulation and must update in the current input event.
+      if (!nextDirection) {
+        cancelScheduledPullPresentation();
+      } else if (directionChanged) {
+        cancelScheduledPullPresentation();
+        applyPullPresentation(px);
+      } else {
+        schedulePullPresentation(px);
+      }
+    },
+    [
+      applyPullPresentation,
+      cancelScheduledPullPresentation,
+      schedulePullPresentation,
+    ],
+  );
 
   const cancelClearConfirmation = useCallback(() => {
     setConfirmingClearAll(false);
     setConfirmingGroupKey(null);
   }, []);
 
-  const setShade = useCallback((expanded: boolean) => {
-    if (shadeCloseTimer.current) {
-      window.clearTimeout(shadeCloseTimer.current);
-      shadeCloseTimer.current = null;
+  const beginPullCancellation = useCallback(
+    (direction: "expand" | "collapse", settleMs: number) => {
+      if (pullCancelTimer.current !== null) {
+        window.clearTimeout(pullCancelTimer.current);
+      }
+      setShadeSettleDuration(settleMs);
+      // The cancelling direction keeps the preview DOM mounted until every
+      // surface reaches its zero-opacity/zero-layout endpoint. Removing it at
+      // pointer-up would make quiet groups disappear while the count eases.
+      setPullCancellingDirection(direction);
+      pullCancelTimer.current = window.setTimeout(() => {
+        pullCancelTimer.current = null;
+        setPullCancellingDirection(null);
+      }, settleMs + STACK_FOLD_COMPACTION_BUFFER_MS);
+    },
+    [setShadeSettleDuration],
+  );
+
+  const setShade = useCallback(
+    (expanded: boolean) => {
+      if (shadeCloseTimer.current) {
+        window.clearTimeout(shadeCloseTimer.current);
+        shadeCloseTimer.current = null;
+      }
+      cancelPullCancellation();
+      setShadeClosing(false);
+      setShadeExpanded(expanded);
+      setConfirmingClearAll(false);
+      setConfirmingGroupKey(null);
+      setShadeOpenedByStack(false);
+      if (expanded) {
+        pendingRestedCountFocusRef.current = false;
+      } else {
+        cancelAllStackFolds();
+        pendingShadeFocusRef.current = false;
+        pendingStackFocusRef.current = null;
+        // Folding the shade folds every fanned stack with it so the next open
+        // starts from a predictable grouped inbox.
+        setExpandedStacks(new Set());
+        setOpeningStacks(new Set());
+        setShadeOpenProgress(1);
+      }
+      // Collapse completion is deterministic even when a smooth scroll was
+      // interrupted. Expansion resets after the expanded rows mount below.
+      if (!expanded && scrollRef.current) scrollRef.current.scrollTop = 0;
+    },
+    [cancelAllStackFolds, cancelPullCancellation],
+  );
+
+  const beginProgrammaticShadeOpen = useCallback(() => {
+    setShadeSettleDuration(SHADE_SETTLE_MS);
+    if (reduceMotion) {
+      setShadeOpenProgress(1);
+    } else {
+      setShadeOpenProgress(0);
     }
-    setShadeClosing(false);
-    setShadeExpanded(expanded);
-    setConfirmingClearAll(false);
-    setConfirmingGroupKey(null);
-    setShadeOpenedByStack(false);
-    if (!expanded) {
-      // Folding the shade folds every fanned stack with it so the next open
-      // starts from a predictable grouped inbox.
-      setExpandedStacks(new Set());
-    }
-    // Collapse completion is deterministic even when a smooth scroll was
-    // interrupted. Expansion resets after the expanded rows mount below.
-    if (!expanded && scrollRef.current) scrollRef.current.scrollTop = 0;
-  }, []);
+    setShade(true);
+  }, [reduceMotion, setShade, setShadeSettleDuration]);
+
+  const openShadeFromControl = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      pendingShadeFocusRef.current = event.detail === 0;
+      beginProgrammaticShadeOpen();
+    },
+    [beginProgrammaticShadeOpen],
+  );
 
   // Every expansion path must reveal the shade's first row and clear control.
   // Stack taps call expandStack directly (not setShade), and mounting their
@@ -577,6 +1055,9 @@ export function NotificationsHomeCenter({
   }, [shadeExpanded]);
 
   useLayoutEffect(() => {
+    // Settled renders are fully declarative. Direct writes are reserved for an
+    // active drag/close so they cannot overwrite click-entry interpolation.
+    if (!pullDirection && !shadeClosing) return;
     if (pullDirection) {
       pullVisibleGroupsRef.current = visibleNotificationGroups(
         centerRef.current,
@@ -592,50 +1073,152 @@ export function NotificationsHomeCenter({
     );
   });
 
-  const requestShadeCollapse = useCallback(() => {
-    if (!shadeExpanded || shadeClosing) return;
-    const draggedFullyClosed = pullPxRef.current <= -PULL_COMMIT_PX;
-    cancelClearConfirmation();
-    const list = scrollRef.current;
-    if (list && list.scrollTop > 0) {
-      list.scrollTo?.({ top: 0, behavior: "smooth" });
-    }
-    wheelCommitLockUntil.current = Date.now() + WHEEL_COMMIT_LOCK_MS;
-    // End direct manipulation before starting the close settle. Leaving a
-    // non-zero pull marks the shade as dragging, which intentionally disables
-    // child transitions and turns the committed close into a delayed snap.
-    setPullPx(0);
-    // A completed direct gesture has already faded the disposable cards to
-    // zero. Remove their layout immediately instead of making the user wait
-    // through a second, invisible close animation.
-    if (draggedFullyClosed) {
-      setShade(false);
-      return;
-    }
-    setShadeClosing(true);
-    shadeCloseTimer.current = window.setTimeout(() => {
-      shadeCloseTimer.current = null;
-      setShade(false);
-    }, SHADE_CLOSE_FADE_MS);
-  }, [
-    cancelClearConfirmation,
-    setPullPx,
-    setShade,
-    shadeClosing,
-    shadeExpanded,
-  ]);
+  const requestShadeCollapse = useCallback(
+    (settleMs = SHADE_SETTLE_MS) => {
+      if (!shadeExpanded || shadeClosing) return;
+      cancelPullCancellation();
+      cancelClearConfirmation();
+      const list = scrollRef.current;
+      if (list && list.scrollTop > 0) {
+        list.scrollTo?.({
+          top: 0,
+          behavior: reduceMotion ? "auto" : "smooth",
+        });
+      }
+      wheelCommitLockUntil.current = Date.now() + WHEEL_COMMIT_LOCK_MS;
+      // A release can arrive before the last coalesced pointer frame. Paint the
+      // latest direct-manipulation value synchronously and flush its style so
+      // the retained close transition always starts from what the finger did.
+      if (pullPxRef.current !== 0) {
+        flushPullPresentation();
+      }
+      // End direct manipulation before starting the close settle. Leaving a
+      // non-zero pull marks the shade as dragging, which intentionally disables
+      // child transitions and turns the committed close into a delayed snap.
+      setPullPx(0);
+      if (reduceMotion) {
+        setShade(false);
+        return;
+      }
+      // Fanned stacks own longer geometry than the ordinary shade. Retaining
+      // their keyed rows through that endpoint prevents pointer-up from
+      // compacting a still-visible stack into one card.
+      const retainsFannedStacks = expandedStacksRef.current.size > 0;
+      const retainedSettleMs = Math.max(
+        settleMs,
+        retainsFannedStacks ? STACK_FOLD_SETTLE_MS : 0,
+      );
+      setShadeSettleDuration(retainedSettleMs);
+      setShadeClosing(true);
+      shadeCloseTimer.current = window.setTimeout(
+        () => {
+          shadeCloseTimer.current = null;
+          setShade(false);
+        },
+        retainedSettleMs +
+          (retainsFannedStacks ? STACK_FOLD_COMPACTION_BUFFER_MS : 0),
+      );
+    },
+    [
+      cancelClearConfirmation,
+      cancelPullCancellation,
+      flushPullPresentation,
+      reduceMotion,
+      setPullPx,
+      setShade,
+      setShadeSettleDuration,
+      shadeClosing,
+      shadeExpanded,
+    ],
+  );
+
+  useLayoutEffect(() => {
+    if (reduceMotion && shadeClosing) setShade(false);
+  }, [reduceMotion, setShade, shadeClosing]);
+
+  const completeStackFold = useCallback(
+    (key: string) => {
+      const pending = stackFoldTimers.current.get(key);
+      if (!pending) return;
+      window.clearTimeout(pending.timer);
+      stackFoldTimers.current.delete(key);
+      // Another producer can fan while this stack is converging. Restore the
+      // rested shade only when the live projection still makes this the final
+      // expanded stack; the intent captured at click time is not authoritative.
+      const restoresRestedShade =
+        pending.mayRestoreRestedShade &&
+        shadeOpenedByStackRef.current &&
+        expandedStacksRef.current.size === 1 &&
+        expandedStacksRef.current.has(key);
+      collapseStack(key);
+      if (restoresRestedShade && !pending.shadeCloseStarted) {
+        requestShadeCollapse(STACK_FOLD_SETTLE_MS);
+      }
+    },
+    [collapseStack, requestShadeCollapse],
+  );
 
   const foldStack = useCallback(
-    (key: string) => {
+    (key: string, moveFocus = false) => {
+      if (!expandedStacks.has(key) || stackFoldTimers.current.has(key)) return;
       const restoresRestedShade =
         shadeOpenedByStack &&
         expandedStacks.size === 1 &&
         expandedStacks.has(key);
-      collapseStack(key);
-      if (restoresRestedShade) requestShadeCollapse();
+      if (reduceMotion) {
+        collapseStack(key, moveFocus);
+        if (restoresRestedShade) requestShadeCollapse();
+        return;
+      }
+
+      cancelPullCancellation();
+      if (moveFocus) pendingCollapsedStackFocusRef.current = key;
+      setOpeningStacks((prev) => {
+        if (!prev.has(key)) return prev;
+        const next = new Set(prev);
+        next.delete(key);
+        return next;
+      });
+      setClosingStacks((prev) => {
+        const next = new Set(prev);
+        next.add(key);
+        return next;
+      });
+      setConfirmingGroupKey((current) => (current === key ? null : current));
+      setConfirmingClearAll(false);
+      // A stack that opened the shade also closes it, but both layers share
+      // this fold clock. Sequencing the shade afterward creates a visible
+      // second tail even when the stack itself has already reached rest.
+      const pending: PendingStackFold = {
+        timer: 0,
+        mayRestoreRestedShade: shadeOpenedByStack,
+        shadeCloseStarted: restoresRestedShade && !shadeClosing,
+      };
+      pending.timer = window.setTimeout(
+        () => completeStackFold(key),
+        STACK_FOLD_SETTLE_MS + STACK_FOLD_COMPACTION_BUFFER_MS,
+      );
+      stackFoldTimers.current.set(key, pending);
+      if (pending.shadeCloseStarted) {
+        requestShadeCollapse(STACK_FOLD_SETTLE_MS);
+      }
     },
-    [collapseStack, expandedStacks, requestShadeCollapse, shadeOpenedByStack],
+    [
+      cancelPullCancellation,
+      collapseStack,
+      completeStackFold,
+      expandedStacks,
+      reduceMotion,
+      requestShadeCollapse,
+      shadeClosing,
+      shadeOpenedByStack,
+    ],
   );
+
+  useLayoutEffect(() => {
+    if (!reduceMotion || closingStacks.size === 0) return;
+    for (const key of closingStacks) completeStackFold(key);
+  }, [closingStacks, completeStackFold, reduceMotion]);
 
   const hasClearConfirmation =
     confirmingClearAll || confirmingGroupKey !== null;
@@ -681,15 +1264,70 @@ export function NotificationsHomeCenter({
     const { canExpand, canCollapse } = shadeGestureRef.current;
     const commitPx =
       notifications.length === 0 ? EMPTY_PULL_COMMIT_PX : PULL_COMMIT_PX;
+    const canMove = (px > 0 && canExpand) || (px < 0 && canCollapse);
+    const now = performance.now();
+    const momentum = pullMomentumRef.current;
+    const sampleDurationMs = momentum ? now - momentum.startedAtMs : 0;
+    const fallbackVelocity =
+      momentum && sampleDurationMs >= SHADE_MIN_VELOCITY_SAMPLE_MS
+        ? px / sampleDurationMs
+        : 0;
+    const releaseVelocity = momentum
+      ? sampleDurationMs >= SHADE_MIN_VELOCITY_SAMPLE_MS
+        ? getMomentumReleaseVelocity({
+            samples: momentum.samples,
+            endPositionPx: px,
+            endTimeMs: now,
+            fallbackVelocityPxPerMs: fallbackVelocity,
+          })
+        : 0
+      : fallbackVelocity;
+    const shouldCommit =
+      canMove &&
+      shouldCommitMomentumDetent({
+        displacementPx: px,
+        releaseVelocityPxPerMs: releaseVelocity,
+        distanceThresholdPx: commitPx,
+        minimumFlickDistancePx:
+          notifications.length === 0
+            ? EMPTY_PULL_COMMIT_PX / 2
+            : SHADE_MIN_FLICK_DISTANCE_PX,
+        flickVelocityThresholdPxPerMs: SHADE_FLICK_VELOCITY_PX_PER_MS,
+      });
+    const remainingDistancePx = shouldCommit
+      ? Math.max(0, PULL_TRAVEL_PX - Math.abs(px))
+      : Math.abs(px);
+    const settleMs = getVelocityAwareSettleDuration({
+      velocityPxPerMs: releaseVelocity,
+      remainingDistancePx,
+      fallbackDurationMs: PULL_CANCEL_SETTLE_MS,
+      minimumDurationMs: SHADE_MIN_SETTLE_MS,
+      maximumDurationMs: SHADE_MAX_SETTLE_MS,
+      minimumSpeedPxPerMs: SHADE_MIN_SETTLE_SPEED_PX_PER_MS,
+    });
+
+    if (px !== 0) flushPullPresentation();
+    setShadeSettleDuration(settleMs);
     // Directional: a downward pull only expands, an upward push only
     // collapses. A gesture in the direction of the current state is a no-op.
-    if (px >= commitPx && canExpand) setShade(true);
-    else if (px <= -commitPx && canCollapse) {
-      requestShadeCollapse();
+    if (shouldCommit && px > 0 && canExpand) setShade(true);
+    else if (shouldCommit && px < 0 && canCollapse) {
+      requestShadeCollapse(settleMs);
       return;
+    } else if (px !== 0 && !reduceMotion && canMove) {
+      beginPullCancellation(px > 0 ? "expand" : "collapse", settleMs);
     }
     setPullPx(0);
-  }, [notifications.length, requestShadeCollapse, setPullPx, setShade]);
+  }, [
+    beginPullCancellation,
+    flushPullPresentation,
+    notifications.length,
+    reduceMotion,
+    requestShadeCollapse,
+    setPullPx,
+    setShade,
+    setShadeSettleDuration,
+  ]);
 
   // Shared wheel accumulator for both the list and, while empty, the wider
   // home background. Returns whether the shade consumed this delta so the
@@ -731,12 +1369,12 @@ export function NotificationsHomeCenter({
         if (empty) {
           wheelCommitLockUntil.current = Date.now() + WHEEL_COMMIT_LOCK_MS;
         }
-        if (dir === 1) setShade(true);
+        if (dir === 1) beginProgrammaticShadeOpen();
         else requestShadeCollapse();
       }
       return true;
     },
-    [notifications.length, requestShadeCollapse, setShade],
+    [beginProgrammaticShadeOpen, notifications.length, requestShadeCollapse],
   );
 
   const onListWheel = useCallback(
@@ -765,25 +1403,39 @@ export function NotificationsHomeCenter({
         ? emptyGestureTargetRef.current
         : list;
     const usesEmptyBackground = gestureTarget !== list;
-    let start: { x: number; y: number } | null = null;
+    let start: { identifier: number; x: number; y: number } | null = null;
     // clientY where the drag first reached the top; the pull is measured from
     // here so a continuous drag that scrolled the list up to its top doesn't
     // jump the shade by the pre-top travel and instantly commit.
     let expandAnchorY: number | null = null;
     let collapseAnchorY: number | null = null;
     let closeFromBottomEdge = false;
+    const resetTouchState = () => {
+      start = null;
+      expandAnchorY = null;
+      collapseAnchorY = null;
+      closeFromBottomEdge = false;
+    };
+    const abortTouchPull = () => {
+      resetTouchState();
+      setPullPx(0);
+    };
     const onTouchStart = (e: TouchEvent) => {
       const t = e.touches[0];
       const target = e.target;
-      if (usesEmptyBackground && isInteractiveGestureTarget(target)) {
-        start = null;
-        expandAnchorY = null;
-        collapseAnchorY = null;
-        closeFromBottomEdge = false;
+      if (
+        e.touches.length !== 1 ||
+        !t ||
+        (usesEmptyBackground && isInteractiveGestureTarget(target))
+      ) {
+        abortTouchPull();
         return;
       }
-      start =
-        e.touches.length === 1 && t ? { x: t.clientX, y: t.clientY } : null;
+      start = {
+        identifier: t.identifier,
+        x: t.clientX,
+        y: t.clientY,
+      };
       // Already at the top → anchor at the touch start so the whole drag counts
       // as pull. Started scrolled down → leave null; the move handler anchors at
       // the instant scrollTop first reaches 0 (the top crossing).
@@ -815,17 +1467,13 @@ export function NotificationsHomeCenter({
           ? start.y
           : null;
     };
-    const onTouchMove = (e: TouchEvent) => {
-      const t = e.touches[0];
+    const updateTouchPosition = (t: Touch, event?: TouchEvent) => {
       if (!start || !t) return;
       const dx = t.clientX - start.x;
       const dy = t.clientY - start.y;
       // A horizontal gesture belongs to the row swipe; hand it off for good.
       if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > PULL_SLOP_PX) {
-        start = null;
-        expandAnchorY = null;
-        collapseAnchorY = null;
-        closeFromBottomEdge = false;
+        abortTouchPull();
         return;
       }
       if (Math.abs(dy) > PULL_SLOP_PX && Math.abs(dy) >= Math.abs(dx)) {
@@ -835,7 +1483,7 @@ export function NotificationsHomeCenter({
         // Claim the bottom-edge close from its first vertical pixel so the
         // native scroller never moves underneath the gesture before the slop
         // threshold is crossed.
-        e.preventDefault();
+        event?.preventDefault();
       }
       const { canExpand, canCollapse } = shadeGestureRef.current;
       if (dy < -PULL_SLOP_PX) {
@@ -859,14 +1507,14 @@ export function NotificationsHomeCenter({
           if (collapseAnchorY === null) collapseAnchorY = t.clientY;
           const push = collapseAnchorY - t.clientY;
           if (push > PULL_SLOP_PX) {
-            e.preventDefault();
+            event?.preventDefault();
             setPullPx(-dampenPull(push));
           } else if (pullPxRef.current !== 0) {
-            setPullPx(0);
+            setPullPx(0, true);
           }
         } else {
           collapseAnchorY = null;
-          if (pullPxRef.current !== 0) setPullPx(0);
+          if (pullPxRef.current !== 0) setPullPx(0, true);
         }
         return;
       }
@@ -874,36 +1522,49 @@ export function NotificationsHomeCenter({
         if (expandAnchorY === null) expandAnchorY = t.clientY;
         const pull = t.clientY - expandAnchorY;
         if (pull > PULL_SLOP_PX) {
-          e.preventDefault();
+          event?.preventDefault();
           setPullPx(dampenPull(pull));
         } else if (pullPxRef.current !== 0) {
           // Finger reversed back above the anchor — the pull is withdrawn, so
           // the release must not commit from the stale peak (parity with the
           // pointer path).
-          setPullPx(0);
+          setPullPx(0, true);
         }
       } else if (expandAnchorY !== null) {
         // Scrolled back down into content — abandon the pull and re-anchor.
         expandAnchorY = null;
-        if (pullPxRef.current !== 0) setPullPx(0);
+        if (pullPxRef.current !== 0) setPullPx(0, true);
       }
     };
-    const onTouchEnd = () => {
-      start = null;
-      expandAnchorY = null;
-      collapseAnchorY = null;
-      closeFromBottomEdge = false;
+    const onTouchMove = (event: TouchEvent) => {
+      if (!start) return;
+      if (event.touches.length !== 1) {
+        abortTouchPull();
+        return;
+      }
+      const touch = touchWithIdentifier(event.touches, start.identifier);
+      if (touch) updateTouchPosition(touch, event);
+      else abortTouchPull();
+    };
+    const onTouchEnd = (event: TouchEvent) => {
+      if (!start) return;
+      const finalTouch = touchWithIdentifier(
+        event.changedTouches,
+        start.identifier,
+      );
+      if (!finalTouch && event.changedTouches.length > 0) {
+        abortTouchPull();
+        return;
+      }
+      if (finalTouch) updateTouchPosition(finalTouch);
+      resetTouchState();
       commitPull();
     };
     const onTouchCancel = () => {
       // An OS-cancelled gesture (incoming call, edge-gesture takeover, palm
       // rejection) ABORTS: snap back to rest, never change the shade from a
       // gesture the user never completed.
-      start = null;
-      expandAnchorY = null;
-      collapseAnchorY = null;
-      closeFromBottomEdge = false;
-      setPullPx(0);
+      abortTouchPull();
     };
     const onEmptyBackgroundWheel = (e: WheelEvent) => {
       const target = e.target;
@@ -958,7 +1619,7 @@ export function NotificationsHomeCenter({
     const surface = emptyGestureTargetRef?.current;
     const list = scrollRef.current;
     if (!hasNotifications || !surface || !list || surface === list) return;
-    let start: { x: number; y: number } | null = null;
+    let start: { identifier: number; x: number; y: number } | null = null;
     let axis: "none" | "x" | "y" = "none";
     let ownsPull = false;
 
@@ -967,21 +1628,30 @@ export function NotificationsHomeCenter({
       axis = "none";
       ownsPull = false;
     };
+    const abort = () => {
+      reset();
+      setPullPx(0);
+    };
     const onTouchStart = (event: TouchEvent) => {
       const touch = event.touches[0];
       const target = event.target;
-      start =
-        event.touches.length === 1 &&
-        touch &&
-        !isInteractiveGestureTarget(target) &&
-        !(target instanceof Node && list.contains(target))
-          ? { x: touch.clientX, y: touch.clientY }
-          : null;
-      axis = "none";
-      ownsPull = false;
+      if (
+        event.touches.length !== 1 ||
+        !touch ||
+        isInteractiveGestureTarget(target) ||
+        (target instanceof Node && list.contains(target))
+      ) {
+        abort();
+        return;
+      }
+      reset();
+      start = {
+        identifier: touch.identifier,
+        x: touch.clientX,
+        y: touch.clientY,
+      };
     };
-    const onTouchMove = (event: TouchEvent) => {
-      const touch = event.touches[0];
+    const updateTouchPosition = (touch: Touch, event?: TouchEvent) => {
       if (!start || !touch) return;
       const dx = touch.clientX - start.x;
       const dy = touch.clientY - start.y;
@@ -1003,21 +1673,39 @@ export function NotificationsHomeCenter({
         shadeGestureRef.current.canExpand
       ) {
         ownsPull = true;
-        event.preventDefault();
+        event?.preventDefault();
         setPullPx(dampenPull(dy));
       } else if (ownsPull && pullPxRef.current !== 0) {
-        setPullPx(0);
+        setPullPx(0, true);
       }
     };
-    const onTouchEnd = () => {
+    const onTouchMove = (event: TouchEvent) => {
+      if (!start) return;
+      if (event.touches.length !== 1) {
+        abort();
+        return;
+      }
+      const touch = touchWithIdentifier(event.touches, start.identifier);
+      if (touch) updateTouchPosition(touch, event);
+      else abort();
+    };
+    const onTouchEnd = (event: TouchEvent) => {
+      if (!start) return;
+      const finalTouch = touchWithIdentifier(
+        event.changedTouches,
+        start.identifier,
+      );
+      if (!finalTouch && event.changedTouches.length > 0) {
+        abort();
+        return;
+      }
+      if (finalTouch) updateTouchPosition(finalTouch);
       const shouldCommit = ownsPull;
       reset();
       if (shouldCommit) commitPull();
     };
     const onTouchCancel = () => {
-      const shouldResetPull = ownsPull;
-      reset();
-      if (shouldResetPull) setPullPx(0);
+      abort();
     };
     const onWheel = (event: WheelEvent) => {
       const target = event.target;
@@ -1061,24 +1749,41 @@ export function NotificationsHomeCenter({
     const surface = emptyGestureTargetRef?.current;
     const center = centerRef.current;
     const list = scrollRef.current;
-    if (!shadeExpanded || !surface || !center || !list) return;
-    let start: { x: number; y: number } | null = null;
+    if (!shadeExpanded || shadeClosing || !surface || !center || !list) return;
+    let start: { identifier: number; x: number; y: number } | null = null;
+
+    const abort = () => {
+      start = null;
+      setPullPx(0);
+    };
 
     const onTouchStart = (event: TouchEvent) => {
       const touch = event.touches[0];
       const target = event.target;
-      start =
-        event.touches.length === 1 &&
-        touch &&
-        target instanceof Node &&
-        !list.contains(target) &&
-        !isInteractiveGestureTarget(target)
-          ? { x: touch.clientX, y: touch.clientY }
-          : null;
+      if (
+        event.touches.length !== 1 ||
+        !touch ||
+        !shadeGestureRef.current.canCollapse ||
+        !(target instanceof Node) ||
+        list.contains(target) ||
+        isInteractiveGestureTarget(target)
+      ) {
+        abort();
+        return;
+      }
+      start = {
+        identifier: touch.identifier,
+        x: touch.clientX,
+        y: touch.clientY,
+      };
     };
-    const onTouchMove = (event: TouchEvent) => {
-      const touch = event.touches[0];
+    const updateTouchPosition = (touch: Touch, event?: TouchEvent) => {
       if (!start || !touch) return;
+      if (!shadeGestureRef.current.canCollapse) {
+        start = null;
+        if (pullPxRef.current !== 0) setPullPx(0);
+        return;
+      }
       const dx = touch.clientX - start.x;
       const dy = touch.clientY - start.y;
       if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > PULL_SLOP_PX) {
@@ -1086,21 +1791,39 @@ export function NotificationsHomeCenter({
         setPullPx(0);
         return;
       }
-      if (dy < 0 && Math.abs(dy) >= Math.abs(dx)) event.preventDefault();
+      if (dy < 0 && Math.abs(dy) >= Math.abs(dx)) event?.preventDefault();
       if (dy < -PULL_SLOP_PX) {
         setPullPx(-dampenPull(-dy));
       } else if (pullPxRef.current !== 0) {
-        setPullPx(0);
+        setPullPx(0, true);
       }
     };
-    const onTouchEnd = () => {
+    const onTouchMove = (event: TouchEvent) => {
       if (!start) return;
+      if (event.touches.length !== 1) {
+        abort();
+        return;
+      }
+      const touch = touchWithIdentifier(event.touches, start.identifier);
+      if (touch) updateTouchPosition(touch, event);
+      else abort();
+    };
+    const onTouchEnd = (event: TouchEvent) => {
+      if (!start) return;
+      const finalTouch = touchWithIdentifier(
+        event.changedTouches,
+        start.identifier,
+      );
+      if (!finalTouch && event.changedTouches.length > 0) {
+        abort();
+        return;
+      }
+      if (finalTouch) updateTouchPosition(finalTouch);
       start = null;
       commitPull();
     };
     const onTouchCancel = () => {
-      start = null;
-      setPullPx(0);
+      abort();
     };
 
     surface.addEventListener("touchstart", onTouchStart, { passive: true });
@@ -1113,18 +1836,28 @@ export function NotificationsHomeCenter({
       surface.removeEventListener("touchend", onTouchEnd);
       surface.removeEventListener("touchcancel", onTouchCancel);
     };
-  }, [commitPull, emptyGestureTargetRef, setPullPx, shadeExpanded]);
+  }, [
+    commitPull,
+    emptyGestureTargetRef,
+    setPullPx,
+    shadeClosing,
+    shadeExpanded,
+  ]);
 
   // Clear timers that may outlive a single gesture.
   useEffect(
     () => () => {
       if (wheelDecayTimer.current) window.clearTimeout(wheelDecayTimer.current);
       if (shadeCloseTimer.current) window.clearTimeout(shadeCloseTimer.current);
+      if (pullCancelTimer.current !== null) {
+        window.clearTimeout(pullCancelTimer.current);
+      }
+      for (const pending of stackFoldTimers.current.values()) {
+        window.clearTimeout(pending.timer);
+      }
+      stackFoldTimers.current.clear();
       if (suppressNotificationClickTimer.current !== null) {
         window.clearTimeout(suppressNotificationClickTimer.current);
-      }
-      if (pullPresentationFrame.current !== null) {
-        window.cancelAnimationFrame(pullPresentationFrame.current);
       }
     },
     [],
@@ -1164,9 +1897,11 @@ export function NotificationsHomeCenter({
     }
     setConfirmingClearAll(false);
     setConfirmingGroupKey(null);
+    cancelAllStackFolds();
+    setOpeningStacks(new Set());
     setExpandedStacks(new Set());
     void clearNotifications();
-  }, [confirmingClearAll]);
+  }, [cancelAllStackFolds, confirmingClearAll]);
 
   // An emptied-out inbox resets the shade so the next arrival starts rested.
   // `pullPx` is cleared too: if the inbox empties mid-pull the touch effect
@@ -1174,14 +1909,22 @@ export function NotificationsHomeCenter({
   // the next arrival's first paint.
   useEffect(() => {
     if (notifications.length === 0) {
+      cancelAllStackFolds();
       setShadeExpanded(false);
       setShadeOpenedByStack(false);
+      setOpeningStacks(new Set());
       setExpandedStacks(new Set());
       setConfirmingGroupKey(null);
       setConfirmingClearAll(false);
+      cancelPullCancellation();
       setPullPx(0);
     }
-  }, [notifications.length, setPullPx]);
+  }, [
+    cancelAllStackFolds,
+    cancelPullCancellation,
+    notifications.length,
+    setPullPx,
+  ]);
 
   // Build stable rested and expanded projections. During a downward pull,
   // lower-priority groups reveal under the finger while already-visible
@@ -1237,7 +1980,7 @@ export function NotificationsHomeCenter({
       <section
         aria-label="Notifications"
         data-testid="home-notification-center"
-        className="relative flex min-h-20 flex-none items-center px-1.5 py-1 text-white"
+        className="eliza-notif-center relative flex min-h-20 flex-none items-center px-1.5 py-1 text-white"
       >
         <style>{NOTIF_SCROLL_CSS}</style>
         <LiquidGlassRefractionDefs />
@@ -1272,19 +2015,23 @@ export function NotificationsHomeCenter({
   const pullPx = pullPxRef.current;
   const isPulling = pullDirection !== null;
   const canExpand = !shadeExpanded;
-  const previewingExpansion = canExpand && pullDirection === "expand";
+  const canCollapse = shadeExpanded && !shadeClosing;
+  const previewingExpansion =
+    canExpand &&
+    (pullDirection === "expand" || pullCancellingDirection === "expand");
   const groups = shadeExpanded
     ? expandedGroups
     : previewingExpansion
       ? previewGroups
       : restedGroups;
-  shadeGestureRef.current = { canExpand, canCollapse: shadeExpanded };
+  shadeGestureRef.current = { canExpand, canCollapse };
   const {
     shadeCloseProgress,
     committedCloseProgress,
     disposableContentVisibility,
     pullContentVisibility,
     notificationCountVisibility,
+    notificationCountOffset,
     notificationCountLayoutVisibility,
     emptyStateVisibility,
     collapseControlVisibility,
@@ -1292,11 +2039,30 @@ export function NotificationsHomeCenter({
     clearControlLayoutVisibility,
   } = notificationPullPresentation(pullPx, shadeExpanded, shadeClosing);
   const disposableLayoutVisibility = 1 - committedCloseProgress;
+  const stackLayoutTransition =
+    expandedStacks.size > 0 && closingStacks.size === 0
+      ? STACK_FAN_LAYOUT_TRANSITION
+      : STACK_FOLD_LAYOUT_TRANSITION;
+  const collapseControlPresentationVisibility =
+    collapseControlVisibility * shadeOpenProgress;
   const showCollapseControl =
     (shadeExpanded || previewingExpansion) &&
     hasNotifications &&
     expandedStacks.size === 0 &&
     !shadeOpenedByStack;
+  const abortPointerPull = () => {
+    const px = pullPxRef.current;
+    if (px !== 0) {
+      flushPullPresentation();
+      if (!reduceMotion) {
+        beginPullCancellation(
+          px > 0 ? "expand" : "collapse",
+          PULL_CANCEL_SETTLE_MS,
+        );
+      }
+    }
+    setPullPx(0);
+  };
   const onListPointerDown = (e: React.PointerEvent) => {
     if (e.pointerType !== "mouse" || !e.isPrimary) return;
     const el = scrollRef.current;
@@ -1332,25 +2098,98 @@ export function NotificationsHomeCenter({
       // Upward drag: the collapse gesture. A mouse drag never scrolls the
       // list, so it is measured from the gesture start — no top-crossing to
       // re-anchor at, and no scroll position to respect.
-      if (canCollapse) setPullPx(dy < -PULL_SLOP_PX ? -dampenPull(-dy) : 0);
-      else if (pullPxRef.current !== 0) setPullPx(0);
+      if (canCollapse) {
+        setPullPx(
+          dy < -PULL_SLOP_PX ? -dampenPull(-dy) : 0,
+          dy >= -PULL_SLOP_PX,
+        );
+      } else if (pullPxRef.current !== 0) setPullPx(0, true);
       return;
     }
     // Downward drag: the expand gesture, only from the list top.
     if (el.scrollTop <= 0 && mayExpand) {
       if (g.anchorY === null) g.anchorY = e.clientY;
       const pull = e.clientY - g.anchorY;
-      setPullPx(pull > PULL_SLOP_PX ? dampenPull(pull) : 0);
+      setPullPx(
+        pull > PULL_SLOP_PX ? dampenPull(pull) : 0,
+        pull <= PULL_SLOP_PX,
+      );
     } else if (g.anchorY !== null) {
       g.anchorY = null;
-      if (pullPxRef.current !== 0) setPullPx(0);
+      if (pullPxRef.current !== 0) setPullPx(0, true);
     }
   };
   const onListPointerEnd = (e: React.PointerEvent) => {
     const g = pointerPull.current;
     if (!g || g.id !== e.pointerId) return;
+    // Pointerup can carry the final coalesced position. Applying it before the
+    // release decision preserves a last-moment reversal or flick instead of
+    // committing from the previous frame's stale sample.
+    onListPointerMove(e);
     pointerPull.current = null;
     commitPull();
+  };
+  const onListPointerCancel = (e: React.PointerEvent) => {
+    if (pointerPull.current?.id !== e.pointerId) return;
+    pointerPull.current = null;
+    abortPointerPull();
+  };
+  const onEmptyPointerDown = (e: React.PointerEvent) => {
+    const list = scrollRef.current;
+    if (
+      e.pointerType !== "mouse" ||
+      !e.isPrimary ||
+      !canCollapse ||
+      !list ||
+      (e.target instanceof Node && list.contains(e.target)) ||
+      isInteractiveGestureTarget(e.target)
+    ) {
+      return;
+    }
+    emptyPointerPull.current = {
+      id: e.pointerId,
+      startX: e.clientX,
+      startY: e.clientY,
+      axis: "none",
+    };
+  };
+  const onEmptyPointerMove = (e: React.PointerEvent) => {
+    const gesture = emptyPointerPull.current;
+    if (!gesture || gesture.id !== e.pointerId) return;
+    if (!shadeGestureRef.current.canCollapse) {
+      emptyPointerPull.current = null;
+      if (pullPxRef.current !== 0) setPullPx(0);
+      return;
+    }
+    const dx = e.clientX - gesture.startX;
+    const dy = e.clientY - gesture.startY;
+    if (
+      gesture.axis === "none" &&
+      (Math.abs(dx) > PULL_SLOP_PX || Math.abs(dy) > PULL_SLOP_PX)
+    ) {
+      gesture.axis = Math.abs(dx) > Math.abs(dy) ? "x" : "y";
+      if (gesture.axis === "y") {
+        e.currentTarget.setPointerCapture?.(e.pointerId);
+      }
+    }
+    if (gesture.axis === "x") {
+      emptyPointerPull.current = null;
+      return;
+    }
+    if (gesture.axis !== "y") return;
+    setPullPx(dy < -PULL_SLOP_PX ? -dampenPull(-dy) : 0, dy >= -PULL_SLOP_PX);
+  };
+  const onEmptyPointerEnd = (e: React.PointerEvent) => {
+    const gesture = emptyPointerPull.current;
+    if (!gesture || gesture.id !== e.pointerId) return;
+    onEmptyPointerMove(e);
+    emptyPointerPull.current = null;
+    commitPull();
+  };
+  const onEmptyPointerCancel = (e: React.PointerEvent) => {
+    if (emptyPointerPull.current?.id !== e.pointerId) return;
+    emptyPointerPull.current = null;
+    abortPointerPull();
   };
   const onListClickCapture = (e: React.MouseEvent) => {
     if (!suppressNotificationClick.current) return;
@@ -1374,18 +2213,19 @@ export function NotificationsHomeCenter({
         height: `${notificationCountLayoutVisibility * 32}px`,
         marginBottom: `${(notificationCountLayoutVisibility - 1) * 8}px`,
         opacity: notificationCountVisibility,
+        transform: `translate3d(0, ${notificationCountOffset}px, 0)`,
         transition: isPulling ? "none" : undefined,
       }}
-      className="eliza-notif-count-transition flex shrink-0 items-center justify-center overflow-hidden px-3 text-2xs font-medium text-white/50"
+      className="eliza-notif-count-transition flex shrink-0 items-center justify-center px-3 text-2xs font-medium text-white/50"
     >
       <button
         type="button"
         data-testid="notifications-count-button"
         data-notif-control=""
         aria-label={`Show all ${notifications.length} notification${notifications.length === 1 ? "" : "s"}`}
-        aria-expanded={shadeExpanded}
-        onClick={() => setShade(true)}
-        className="flex h-full w-full items-center justify-center gap-1 text-inherit transition-colors hover:text-white/70"
+        aria-expanded={shadeExpanded && !shadeClosing}
+        onClick={openShadeFromControl}
+        className="flex h-8 w-full shrink-0 items-center justify-center gap-1 text-inherit transition-colors hover:text-white/70"
       >
         {notifications.length === 1
           ? "1 Notification"
@@ -1403,6 +2243,14 @@ export function NotificationsHomeCenter({
       ref={centerRef}
       aria-label="Notifications"
       data-testid="home-notification-center"
+      data-notification-reduced-motion={reduceMotion ? "" : undefined}
+      data-notification-shade-cancelling={
+        pullCancellingDirection ? "" : undefined
+      }
+      onPointerDown={onEmptyPointerDown}
+      onPointerMove={onEmptyPointerMove}
+      onPointerUp={onEmptyPointerEnd}
+      onPointerCancel={onEmptyPointerCancel}
       // No card chrome on the CONTAINER: the inbox has no fill and no border of
       // its own — the glass lives on each notification card. It sits inline on
       // the home field directly under the time/weather header.
@@ -1411,7 +2259,7 @@ export function NotificationsHomeCenter({
       // `min-h-0 flex-1` lets a populated inbox fill the home column down to the
       // chat when the parent grows it.
       className={cn(
-        "relative flex min-h-0 flex-1 flex-col overflow-hidden text-white",
+        "eliza-notif-center relative flex min-h-0 flex-1 flex-col overflow-hidden text-white",
         hasNotifications && "eliza-notif-center-in",
         !hasNotifications && "min-h-14 flex-none",
       )}
@@ -1427,7 +2275,7 @@ export function NotificationsHomeCenter({
         onPointerDown={onListPointerDown}
         onPointerMove={onListPointerMove}
         onPointerUp={onListPointerEnd}
-        onPointerCancel={onListPointerEnd}
+        onPointerCancel={onListPointerCancel}
         onClickCapture={onListClickCapture}
         onWheel={onListWheel}
         data-testid="home-notification-list"
@@ -1504,7 +2352,13 @@ export function NotificationsHomeCenter({
           const groupWasRested = restedGroupKeys.has(group.key);
           const pullRevealed = previewingExpansion && !groupWasRested;
           const revealProgress = pullRevealed
-            ? notificationPullRevealProgress(pullPx, groupIndex)
+            ? notificationGroupPullVisibility(
+                pullPx,
+                groupIndex,
+                shadeExpanded,
+                shadeClosing,
+                true,
+              )
             : 1;
           const closeVisibility = notificationGroupPullVisibility(
             pullPx,
@@ -1512,6 +2366,12 @@ export function NotificationsHomeCenter({
             shadeExpanded,
             shadeClosing,
             false,
+          );
+          const shadeOpenVisibility =
+            shadeExpanded && !groupWasRested ? shadeOpenProgress : 1;
+          const groupVisibility = Math.min(
+            closeVisibility,
+            shadeOpenVisibility,
           );
           const groupContainerOffset = notificationGroupContainerOffset(
             pullPx,
@@ -1522,6 +2382,9 @@ export function NotificationsHomeCenter({
           // Every presentation shares one shell, so the top NotificationRow
           // stays under the same parent/key while a fanned stack closes.
           const fanned = stackExpanded && group.rows.length > 1;
+          const stackClosing = closingStacks.has(group.key);
+          const stackFanProgress =
+            openingStacks.has(group.key) || stackClosing ? 0 : 1;
           // A rested priority card keeps the visual depth of every folded
           // sibling from the same producer, including quiet rows. The content
           // remains priority-only; the peeks communicate that tapping fans a
@@ -1532,10 +2395,7 @@ export function NotificationsHomeCenter({
           const stacked = !fanned && collapsedStackRows.length > 1;
           // Resting peeks remain mounted invisibly behind a fan so full cards
           // can fold back into them without a last-frame pop.
-          const peeks = (fanned ? restedStackRows : collapsedStackRows).slice(
-            1,
-            MAX_VISIBLE_STACK_LAYERS,
-          );
+          const peeks = collapsedStackRows.slice(1, MAX_VISIBLE_STACK_LAYERS);
           const expandedStackTailPx =
             peeks.length * STACK_PEEK_OFFSET_PX +
             (peeks.length > 0 ? STACK_BOTTOM_CLEARANCE_PX : 0);
@@ -1556,28 +2416,56 @@ export function NotificationsHomeCenter({
           const stackTailPx =
             restedStackTailPx +
             (expandedStackTailPx - restedStackTailPx) * stackTailRevealProgress;
+          const fannedOpenPaddingPx =
+            expandedStackTailPx + (16 - expandedStackTailPx) * stackFanProgress;
           const rows = fanned
             ? group.rows
             : [group.rows[0] as AgentNotification];
           const collapsedGroupHasMore = !fanned && allGroupRows.length > 1;
+          const stackPeekMode = fanned
+            ? "close"
+            : groupWasRested
+              ? "static"
+              : "disposable";
+          const stackPeekVisibility = fanned
+            ? Math.max(
+                groupWasRested ? shadeCloseProgress : 0,
+                1 - stackFanProgress,
+              )
+            : stackPeekMode === "disposable"
+              ? pullContentVisibility
+              : 1;
+          const stackPeekExpansionProgress = fanned
+            ? Math.min(stackFanProgress, 1 - shadeCloseProgress)
+            : 0;
+          // CSS owns the retained fold from start to finish. Motion layout is
+          // suspended for that interval so the zero-geometry DOM compaction
+          // cannot launch a second settle after the visible fold is complete.
           const groupElement = (
             <motion.li
               key={group.key}
               layout={
-                shadeExpanded && !isPulling && !shadeClosing
+                !reduceMotion &&
+                !isPulling &&
+                !pullCancellingDirection &&
+                !shadeClosing &&
+                !stackClosing
                   ? "position"
                   : false
               }
-              transition={{ layout: STACK_LAYOUT_TRANSITION }}
+              transition={{ layout: stackLayoutTransition }}
               data-notification-group=""
+              data-notification-group-key={group.key}
               data-notification-group-index={groupIndex}
+              data-notification-stack-fanned={fanned ? "" : undefined}
+              data-notification-stack-closing={stackClosing ? "" : undefined}
               data-rested-notification-group={groupWasRested ? "" : undefined}
               data-notification-pull-reveal={pullRevealed ? "" : undefined}
               inert={pullRevealed ? true : undefined}
               className={cn(
                 "relative flex flex-col",
-                pullRevealed && "eliza-notif-pull-reveal pointer-events-none",
-                fanned && "pb-2",
+                pullRevealed &&
+                  "eliza-notif-pull-reveal eliza-notif-shade-transition pointer-events-none",
               )}
               style={
                 pullRevealed || groupContainerOffset !== 0
@@ -1594,40 +2482,47 @@ export function NotificationsHomeCenter({
               <div
                 data-notification-group-content=""
                 data-notification-stacked={stacked ? "" : undefined}
+                data-notification-stack-material={
+                  allGroupRows.length > 1 ? "" : undefined
+                }
                 data-notification-rested-tail-px={restedStackTailPx}
                 data-notification-expanded-tail-px={expandedStackTailPx}
                 data-testid={stacked ? "notification-stack" : undefined}
                 className="eliza-notif-shade-transition relative flex flex-col"
                 style={{
                   paddingBottom: fanned
-                    ? disposableLayoutVisibility * 8 +
+                    ? fannedOpenPaddingPx * disposableLayoutVisibility +
                       shadeCloseProgress * restedStackTailPx
                     : stacked
                       ? stackTailPx
                       : 0,
-                  opacity: groupWasRested ? 1 : closeVisibility,
+                  opacity: groupWasRested ? 1 : groupVisibility,
                   transform: groupWasRested
                     ? undefined
                     : `translate3d(0, ${notificationGroupPullOffset(
                         pullPx,
                         shadeExpanded,
                         shadeClosing,
-                        closeVisibility,
+                        groupVisibility,
                       )}px, 0)`,
-                  transition: isPulling
-                    ? "none"
-                    : `padding-bottom ${SHADE_CLOSE_FADE_MS}ms cubic-bezier(0.22,1,0.36,1), opacity ${SHADE_CLOSE_FADE_MS}ms ease-out, transform ${SHADE_CLOSE_FADE_MS}ms cubic-bezier(0.22,1,0.36,1)`,
+                  transition: isPulling ? "none" : undefined,
                 }}
               >
                 {fanned ? (
                   <div
                     data-testid="notification-stack-controls"
                     data-notification-stack-controls=""
+                    aria-hidden={stackClosing ? true : undefined}
+                    inert={stackClosing ? true : undefined}
                     className="eliza-notif-shade-transition flex items-center justify-between gap-3 overflow-hidden px-2"
                     style={{
-                      height: disposableLayoutVisibility * 36,
-                      opacity: disposableContentVisibility,
-                      transform: `translate3d(0, ${(1 - disposableContentVisibility) * -6}px, 0)`,
+                      height:
+                        stackFanProgress * disposableLayoutVisibility * 36,
+                      opacity: stackFanProgress * disposableContentVisibility,
+                      transform: `translate3d(0, ${
+                        (1 - stackFanProgress * disposableContentVisibility) *
+                        -6
+                      }px, 0)`,
                     }}
                   >
                     <span className="truncate text-xs font-semibold text-white/55">
@@ -1638,7 +2533,10 @@ export function NotificationsHomeCenter({
                         type="button"
                         data-testid="notification-stack-collapse"
                         data-notif-control=""
-                        onClick={() => foldStack(group.key)}
+                        disabled={stackClosing}
+                        onClick={(event) =>
+                          foldStack(group.key, event.detail === 0)
+                        }
                         className="h-8 px-2 text-xs font-medium text-white/60 transition-colors hover:text-white/90"
                       >
                         Show Less
@@ -1675,17 +2573,15 @@ export function NotificationsHomeCenter({
                     </span>
                   </div>
                 ) : null}
-                <motion.ul
-                  layout={
-                    shadeExpanded && !isPulling && !shadeClosing
-                      ? "position"
-                      : false
-                  }
-                  transition={{ layout: STACK_LAYOUT_TRANSITION }}
+                <ul
+                  data-notification-stack-rows=""
                   className={cn(
                     "relative z-[2] flex flex-col",
-                    fanned && "gap-1.5",
+                    fanned && "eliza-notif-shade-transition",
                   )}
+                  style={
+                    fanned ? { rowGap: `${stackFanProgress * 6}px` } : undefined
+                  }
                 >
                   {rows.map((notification, rowIndex) => (
                     <NotificationRow
@@ -1697,13 +2593,38 @@ export function NotificationsHomeCenter({
                           : undefined
                       }
                       stackCount={
-                        rowIndex === 0 && collapsedGroupHasMore
+                        rowIndex === 0 && allGroupRows.length > 1
                           ? allGroupRows.length
+                          : undefined
+                      }
+                      stackCountVisibility={
+                        rowIndex === 0 && allGroupRows.length > 1
+                          ? fanned
+                            ? 1 - stackFanProgress
+                            : 1
+                          : undefined
+                      }
+                      stackPeeks={
+                        rowIndex === 0 && peeks.length > 0
+                          ? {
+                              count: peeks.length,
+                              disabled: stackClosing,
+                              expansionProgress: stackPeekExpansionProgress,
+                              fanned,
+                              groupLabel: group.label,
+                              mode: stackPeekMode,
+                              openOffsetsPx: stackPeekOpenOffsets.get(
+                                group.key,
+                              ),
+                              testIdVisible: !fanned || shadeCloseProgress > 0,
+                              totalCount: allGroupRows.length,
+                              visibility: stackPeekVisibility,
+                            }
                           : undefined
                       }
                       shadeVisibility={
                         fanned && rowIndex > 0
-                          ? disposableLayoutVisibility
+                          ? stackFanProgress * disposableLayoutVisibility
                           : undefined
                       }
                       onExpandStack={expandStack}
@@ -1711,52 +2632,7 @@ export function NotificationsHomeCenter({
                       onDismiss={dismissNotification}
                     />
                   ))}
-                </motion.ul>
-                {peeks.map((peek, i) => {
-                  const peekMode = fanned
-                    ? "close"
-                    : groupWasRested
-                      ? "static"
-                      : "disposable";
-                  const peekCloseVisibility = fanned
-                    ? shadeCloseProgress
-                    : peekMode === "disposable"
-                      ? pullContentVisibility
-                      : 1;
-                  return (
-                    <button
-                      key={peek.id}
-                      type="button"
-                      data-testid={
-                        !fanned || shadeCloseProgress > 0
-                          ? "notification-stack-peek"
-                          : undefined
-                      }
-                      data-notif-control=""
-                      data-notification-stack-peek=""
-                      data-notification-peek-mode={peekMode}
-                      tabIndex={peekCloseVisibility < 1 ? -1 : undefined}
-                      aria-hidden={peekCloseVisibility === 0 ? true : undefined}
-                      aria-label={`Show all ${allGroupRows.length} ${group.label} notifications`}
-                      onClick={() => expandStack(group.key)}
-                      className={cn(
-                        "eliza-notif-glass eliza-notif-stack-peek eliza-notif-shade-transition absolute inset-x-0 top-0 rounded-2xl",
-                        fanned && "pointer-events-none",
-                      )}
-                      style={{
-                        bottom: fanned ? restedStackTailPx : stackTailPx,
-                        zIndex: 1 - i,
-                        opacity: peekCloseVisibility,
-                        transform: `translateY(${(i + 1) * STACK_PEEK_OFFSET_PX}px) scale(${
-                          1 - (i + 1) * 0.015
-                        })`,
-                        transition: isPulling
-                          ? "none"
-                          : `bottom ${SHADE_CLOSE_FADE_MS}ms cubic-bezier(0.22,1,0.36,1), opacity ${SHADE_CLOSE_FADE_MS}ms ease-out`,
-                      }}
-                    />
-                  );
-                })}
+                </ul>
               </div>
             </motion.li>
           );
@@ -1769,18 +2645,26 @@ export function NotificationsHomeCenter({
         <div
           data-testid="notifications-collapse-footer"
           data-notification-collapse-footer=""
-          aria-hidden={collapseControlVisibility === 0 ? true : undefined}
-          inert={collapseControlVisibility < 1 ? true : undefined}
+          aria-hidden={
+            collapseControlPresentationVisibility === 0 ? true : undefined
+          }
+          inert={collapseControlPresentationVisibility < 1 ? true : undefined}
           style={{
-            opacity: collapseControlVisibility,
-            transform: `translateY(${(1 - collapseControlVisibility) * 4}px)`,
+            opacity: collapseControlPresentationVisibility,
+            transform: `translateY(${
+              (1 - collapseControlPresentationVisibility) * 4
+            }px)`,
+            transition: isPulling ? "none" : undefined,
           }}
           className="eliza-notif-shade-transition pointer-events-none flex shrink-0 justify-center px-3"
         >
           <button
             type="button"
             data-testid="notifications-collapse"
-            onClick={requestShadeCollapse}
+            onClick={(event) => {
+              pendingRestedCountFocusRef.current = event.detail === 0;
+              requestShadeCollapse();
+            }}
             className="pointer-events-auto flex min-h-touch items-center justify-center gap-1 px-2 text-2xs font-medium text-white/55 transition-colors hover:text-white/90"
           >
             Collapse

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -293,6 +293,11 @@ const NOTIF_SCROLL_CSS = `
   backdrop-filter: ${LIQUID_GLASS_BLUR};
   transition: background-color 150ms linear;
 }
+/* The global focus reset removes box shadows, but this inset edge is part of
+   the glass material rather than a focus ring and must survive card focus. */
+.eliza-notif-glass:focus-within {
+  box-shadow: ${LIQUID_GLASS_EDGE_SHADOW} !important;
+}
 /* Chromium honors url(#…) on backdrop-filter → refract the background at the
    rim (the "liquid" cue). WebKit can't, so it keeps the frosted blur above. */
 @supports (backdrop-filter: url(#x)) or (-webkit-backdrop-filter: url(#x)) {
@@ -2406,7 +2411,7 @@ export function NotificationsHomeCenter({
               opacity: clearControlVisibility,
               transform: `translate3d(0, ${(1 - clearControlVisibility) * -8}px, 0)`,
             }}
-            className="eliza-notif-shade-transition flex shrink-0 justify-end overflow-hidden px-1"
+            className="eliza-notif-shade-transition flex shrink-0 justify-end overflow-hidden px-2"
           >
             {shadeExpanded || previewingExpansion ? (
               <button

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -1102,7 +1102,13 @@ export function NotificationsHomeCenter({
   useLayoutEffect(() => {
     // Settled renders are fully declarative. Direct writes are reserved for an
     // active drag/close so they cannot overwrite click-entry interpolation.
-    if (!pullDirection && !shadeClosing) return;
+    if (!pullDirection && !shadeClosing) {
+      // Later drag frames mutate this custom property without a React render.
+      // Clear that imperative value after the dragging marker is removed so
+      // the enabled padding transition settles the footer back into place.
+      scrollRef.current?.style.removeProperty("--eliza-notif-pull-overshoot");
+      return;
+    }
     if (pullDirection) {
       if (pullDirection === "expand" && !shadeExpanded && scrollRef.current) {
         scrollRef.current.scrollTop = 0;
@@ -2433,7 +2439,6 @@ export function NotificationsHomeCenter({
         style={
           {
             "--eliza-notif-base-padding": showCollapseControl ? "4px" : "40px",
-            "--eliza-notif-pull-overshoot": `${Math.max(0, pullOvershootOffset)}px`,
           } as CSSProperties
         }
         className={cn(

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -1316,8 +1316,16 @@ export function NotificationsHomeCenter({
       // A background drag may end over a tile that synthesizes a click. The
       // drag already decided the shade state; do not reinterpret that release
       // as a separate outside-tap collapse before the surface can consume it.
-      if (suppressBackgroundClick.current) return;
       const target = event.target;
+      const gestureSurface =
+        emptyGestureTargetRef?.current ?? centerRef.current;
+      if (
+        suppressBackgroundClick.current &&
+        target instanceof Node &&
+        gestureSurface?.contains(target)
+      ) {
+        return;
+      }
       const center = centerRef.current;
       if (target instanceof Node && center && !center.contains(target)) {
         requestShadeCollapse();
@@ -1326,7 +1334,7 @@ export function NotificationsHomeCenter({
     document.addEventListener("click", collapseOnOutsideClick, true);
     return () =>
       document.removeEventListener("click", collapseOnOutsideClick, true);
-  }, [requestShadeCollapse, shadeExpanded]);
+  }, [emptyGestureTargetRef, requestShadeCollapse, shadeExpanded]);
 
   const commitPull = useCallback(() => {
     const px = pullPxRef.current;
@@ -1376,8 +1384,10 @@ export function NotificationsHomeCenter({
     setShadeSettleDuration(settleMs);
     // Directional: a downward pull only expands, an upward push only
     // collapses. A gesture in the direction of the current state is a no-op.
-    if (shouldCommit && px > 0 && canExpand) setShade(true);
-    else if (shouldCommit && px < 0 && canCollapse) {
+    if (shouldCommit && px > 0 && canExpand) {
+      armBackgroundClickSuppression();
+      setShade(true);
+    } else if (shouldCommit && px < 0 && canCollapse) {
       requestShadeCollapse(settleMs);
       return;
     } else if (px !== 0 && !reduceMotion && canMove) {
@@ -1385,6 +1395,7 @@ export function NotificationsHomeCenter({
     }
     setPullPx(0);
   }, [
+    armBackgroundClickSuppression,
     beginPullCancellation,
     flushPullPresentation,
     inboxEmpty,
@@ -1959,6 +1970,11 @@ export function NotificationsHomeCenter({
           window.clearTimeout(suppressBackgroundClickTimer.current);
           suppressBackgroundClickTimer.current = null;
         }
+        suppressNotificationClick.current = false;
+        if (suppressNotificationClickTimer.current !== null) {
+          window.clearTimeout(suppressNotificationClickTimer.current);
+          suppressNotificationClickTimer.current = null;
+        }
         event.preventDefault();
         event.stopPropagation();
         event.stopImmediatePropagation();
@@ -2281,7 +2297,12 @@ export function NotificationsHomeCenter({
     shadeOpenProgress *
     stackCollapseControlVisibility;
   const collapseControlInteractive =
-    collapseControlPresentationVisibility === 1 && expandedStacks.size === 0;
+    shadeExpanded &&
+    !shadeClosing &&
+    !isPulling &&
+    pullCancellingDirection === null &&
+    collapseControlPresentationVisibility === 1 &&
+    expandedStacks.size === 0;
   const showCollapseControl =
     (shadeExpanded || previewingExpansion) && hasNotifications;
   const onListPointerDown = (e: React.PointerEvent) => {

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -957,6 +957,17 @@ export function NotificationsHomeCenter({
     }, 500);
   }, []);
 
+  const armBackgroundClickSuppression = useCallback(() => {
+    suppressBackgroundClick.current = true;
+    if (suppressBackgroundClickTimer.current !== null) {
+      window.clearTimeout(suppressBackgroundClickTimer.current);
+    }
+    suppressBackgroundClickTimer.current = window.setTimeout(() => {
+      suppressBackgroundClick.current = false;
+      suppressBackgroundClickTimer.current = null;
+    }, 500);
+  }, []);
+
   const setPullPx = useCallback(
     (px: number, preserveDirectionAtZero = false) => {
       pullPxRef.current = px;
@@ -1746,6 +1757,7 @@ export function NotificationsHomeCenter({
         const pull = touch.clientY - expandAnchorY;
         if (pull > PULL_SLOP_PX) {
           ownsPull = true;
+          armBackgroundClickSuppression();
           event?.preventDefault();
           if (surface.scrollTop !== 0) surface.scrollTop = 0;
           setPullPx(dampenPull(pull));
@@ -1779,7 +1791,13 @@ export function NotificationsHomeCenter({
       if (finalTouch) updateTouchPosition(finalTouch);
       const shouldCommit = ownsPull;
       reset();
-      if (shouldCommit) commitPull();
+      if (shouldCommit) {
+        // Touch browsers synthesize a click after release. Refresh suppression
+        // here so a deliberate slow pull cannot expire the move-time guard and
+        // immediately look like an outside-tap collapse.
+        armBackgroundClickSuppression();
+        commitPull();
+      }
     };
     const onTouchCancel = () => {
       abort();
@@ -1811,6 +1829,7 @@ export function NotificationsHomeCenter({
       surface.removeEventListener("wheel", onWheel);
     };
   }, [
+    armBackgroundClickSuppression,
     commitPull,
     emptyGestureTargetRef,
     handleWheelDelta,
@@ -1933,16 +1952,6 @@ export function NotificationsHomeCenter({
       axis: "none" | "x" | "y";
       ownsPull: boolean;
     } | null = null;
-    const armClickSuppression = () => {
-      suppressBackgroundClick.current = true;
-      if (suppressBackgroundClickTimer.current !== null) {
-        window.clearTimeout(suppressBackgroundClickTimer.current);
-      }
-      suppressBackgroundClickTimer.current = window.setTimeout(() => {
-        suppressBackgroundClick.current = false;
-        suppressBackgroundClickTimer.current = null;
-      }, 500);
-    };
     const onClick = (event: MouseEvent) => {
       if (suppressBackgroundClick.current) {
         suppressBackgroundClick.current = false;
@@ -2003,7 +2012,7 @@ export function NotificationsHomeCenter({
           return;
         }
         surface.setPointerCapture?.(event.pointerId);
-        armClickSuppression();
+        armBackgroundClickSuppression();
       }
       if (current.axis !== "y") return;
       event.preventDefault();
@@ -2027,7 +2036,7 @@ export function NotificationsHomeCenter({
       onPointerMove(event);
       if (!gesture) return;
       if (current.axis === "y") {
-        armClickSuppression();
+        armBackgroundClickSuppression();
       }
       gesture = null;
       commitPull();
@@ -2052,6 +2061,7 @@ export function NotificationsHomeCenter({
     };
   }, [
     abortPointerPull,
+    armBackgroundClickSuppression,
     commitPull,
     emptyGestureTargetRef,
     requestShadeCollapse,

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -159,6 +159,28 @@ function isInteractiveGestureTarget(target: EventTarget | null): boolean {
   );
 }
 
+function isClickBelowNotificationCards(
+  target: EventTarget | null,
+  clientY: number,
+  center: HTMLElement,
+): boolean {
+  if (!(target instanceof Node) || !center.contains(target)) return false;
+  if (
+    target instanceof Element &&
+    target.closest("[data-notification-group]")
+  ) {
+    return false;
+  }
+  if (isInteractiveGestureTarget(target)) return false;
+  const groups = center.querySelectorAll<HTMLElement>(
+    "[data-notification-group]",
+  );
+  const lastGroup = groups.item(groups.length - 1);
+  if (!lastGroup) return false;
+  const bounds = lastGroup.getBoundingClientRect();
+  return bounds.height > 0 && clientY > bounds.bottom;
+}
+
 function touchWithIdentifier(
   touches: TouchList,
   identifier: number,
@@ -1874,15 +1896,30 @@ export function NotificationsHomeCenter({
       }, 500);
     };
     const onClick = (event: MouseEvent) => {
-      if (!suppressBackgroundClick.current) return;
-      suppressBackgroundClick.current = false;
-      if (suppressBackgroundClickTimer.current !== null) {
-        window.clearTimeout(suppressBackgroundClickTimer.current);
-        suppressBackgroundClickTimer.current = null;
+      if (suppressBackgroundClick.current) {
+        suppressBackgroundClick.current = false;
+        if (suppressBackgroundClickTimer.current !== null) {
+          window.clearTimeout(suppressBackgroundClickTimer.current);
+          suppressBackgroundClickTimer.current = null;
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        event.stopImmediatePropagation();
+        return;
       }
-      event.preventDefault();
-      event.stopPropagation();
-      event.stopImmediatePropagation();
+      // The list's capture handler owns its post-drag synthetic click. A plain
+      // background tap below the final card, however, should feel like the
+      // full-screen shade surface and close from anywhere in that empty band.
+      if (suppressNotificationClick.current) return;
+      const center = centerRef.current;
+      if (
+        shadePresentationRef.current.expanded &&
+        !shadePresentationRef.current.closing &&
+        center &&
+        isClickBelowNotificationCards(event.target, event.clientY, center)
+      ) {
+        requestShadeCollapse();
+      }
     };
     const onPointerDown = (event: PointerEvent) => {
       const target = event.target;
@@ -1966,6 +2003,7 @@ export function NotificationsHomeCenter({
     abortPointerPull,
     commitPull,
     emptyGestureTargetRef,
+    requestShadeCollapse,
     setPullPx,
     surfaceReady,
   ]);
@@ -2172,13 +2210,22 @@ export function NotificationsHomeCenter({
     expandedStacks.size > 0 && closingStacks.size === 0
       ? STACK_FAN_LAYOUT_TRANSITION
       : STACK_FOLD_LAYOUT_TRANSITION;
+  const allExpandedStacksAreClosing =
+    expandedStacks.size > 0 &&
+    expandedStacks.size === closingStacks.size &&
+    Array.from(expandedStacks).every((key) => closingStacks.has(key));
+  // The footer stays in flow while a stack fans so its text can crossfade
+  // instead of changing both the list geometry and DOM ownership in one frame.
+  const stackCollapseControlVisibility =
+    expandedStacks.size === 0 || allExpandedStacksAreClosing ? 1 : 0;
   const collapseControlPresentationVisibility =
-    collapseControlVisibility * shadeOpenProgress;
+    collapseControlVisibility *
+    shadeOpenProgress *
+    stackCollapseControlVisibility;
+  const collapseControlInteractive =
+    collapseControlPresentationVisibility === 1 && expandedStacks.size === 0;
   const showCollapseControl =
-    (shadeExpanded || previewingExpansion) &&
-    hasNotifications &&
-    expandedStacks.size === 0 &&
-    !shadeOpenedByStack;
+    (shadeExpanded || previewingExpansion) && hasNotifications;
   const onListPointerDown = (e: React.PointerEvent) => {
     if (e.pointerType !== "mouse" || !e.isPrimary) return;
     const el = scrollRef.current;
@@ -2700,16 +2747,18 @@ export function NotificationsHomeCenter({
         <div
           data-testid="notifications-collapse-footer"
           data-notification-collapse-footer=""
-          aria-hidden={
-            collapseControlPresentationVisibility === 0 ? true : undefined
-          }
-          inert={collapseControlPresentationVisibility < 1 ? true : undefined}
+          aria-hidden={!collapseControlInteractive ? true : undefined}
+          inert={!collapseControlInteractive ? true : undefined}
           style={{
             opacity: collapseControlPresentationVisibility,
             transform: `translateY(${
               (1 - collapseControlPresentationVisibility) * 4
             }px)`,
-            transition: isPulling ? "none" : undefined,
+            transition: isPulling
+              ? "none"
+              : closingStacks.size > 0
+                ? `opacity ${STACK_FOLD_SETTLE_MS}ms ${SHADE_EASING}, transform ${STACK_FOLD_SETTLE_MS}ms ${SHADE_EASING}`
+                : undefined,
           }}
           className="eliza-notif-shade-transition pointer-events-none flex shrink-0 justify-center px-3"
         >
@@ -2720,7 +2769,12 @@ export function NotificationsHomeCenter({
               pendingRestedCountFocusRef.current = event.detail === 0;
               requestShadeCollapse();
             }}
-            className="pointer-events-auto flex min-h-touch items-center justify-center gap-1 px-2 text-2xs font-medium text-white/55 transition-colors hover:text-white/90"
+            className={cn(
+              "flex min-h-touch items-center justify-center gap-1 px-2 text-2xs font-medium text-white/55 transition-colors hover:text-white/90",
+              collapseControlInteractive
+                ? "pointer-events-auto"
+                : "pointer-events-none",
+            )}
           >
             Collapse
             <ChevronUp aria-hidden className="h-3 w-3 shrink-0" />

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -203,9 +203,6 @@ function touchWithIdentifier(
  */
 const WHEEL_COLLAPSE_STEP_PX = PULL_COMMIT_PX / 2;
 
-/** Ignore trackpad rebound while the committed shade settle is running. */
-const WHEEL_COMMIT_LOCK_MS = 280;
-
 /** iOS-style visual depth: one, two, or three cards, never more. */
 const MAX_VISIBLE_STACK_LAYERS = 3;
 
@@ -216,11 +213,13 @@ const STACK_PEEK_OFFSET_PX = 7;
 const STACK_BOTTOM_CLEARANCE_PX = 10;
 
 const CLEAR_CONFIRM_TIMEOUT_MS = 5_000;
-const SHADE_SETTLE_MS = 340;
-const SHADE_MIN_SETTLE_MS = 260;
-const SHADE_MAX_SETTLE_MS = 440;
-const SHADE_MIN_SETTLE_SPEED_PX_PER_MS = 0.22;
+const SHADE_SETTLE_MS = 460;
+const SHADE_MIN_SETTLE_MS = 320;
+const SHADE_MAX_SETTLE_MS = 600;
+const SHADE_MIN_SETTLE_SPEED_PX_PER_MS = 0.15;
 const SHADE_EASING = "cubic-bezier(0.25,0.1,0.25,1)";
+/** Ignore trackpad rebound while the committed shade settle is running. */
+const WHEEL_COMMIT_LOCK_MS = SHADE_SETTLE_MS;
 const PULL_CANCEL_SETTLE_MS = SHADE_SETTLE_MS;
 const SHADE_MIN_FLICK_DISTANCE_PX = 22;
 const SHADE_FLICK_VELOCITY_PX_PER_MS = 0.45;
@@ -1321,9 +1320,8 @@ export function NotificationsHomeCenter({
             : SHADE_MIN_FLICK_DISTANCE_PX,
         flickVelocityThresholdPxPerMs: SHADE_FLICK_VELOCITY_PX_PER_MS,
       });
-    const remainingDistancePx = shouldCommit
-      ? Math.max(0, PULL_TRAVEL_PX - Math.abs(px))
-      : Math.abs(px);
+    const targetPullPx = shouldCommit ? Math.sign(px) * PULL_TRAVEL_PX : 0;
+    const remainingDistancePx = Math.abs(targetPullPx - px);
     const settleMs = getVelocityAwareSettleDuration({
       velocityPxPerMs: releaseVelocity,
       remainingDistancePx,
@@ -2204,6 +2202,7 @@ export function NotificationsHomeCenter({
     pullContentVisibility,
     notificationCountVisibility,
     notificationCountOffset,
+    pullOvershootOffset,
     notificationCountLayoutVisibility,
     emptyStateVisibility,
     collapseControlVisibility,
@@ -2324,7 +2323,9 @@ export function NotificationsHomeCenter({
         height: `${notificationCountLayoutVisibility * 32}px`,
         marginBottom: `${(notificationCountLayoutVisibility - 1) * 8}px`,
         opacity: notificationCountVisibility,
-        transform: `translate3d(0, ${notificationCountOffset}px, 0)`,
+        transform: `translate3d(0, ${
+          notificationCountOffset + pullOvershootOffset
+        }px, 0)`,
         transition: isPulling ? "none" : undefined,
       }}
       className="eliza-notif-count-transition flex shrink-0 items-center justify-center px-3 text-2xs font-medium text-white/50"
@@ -2409,7 +2410,9 @@ export function NotificationsHomeCenter({
               height: clearControlLayoutVisibility * 32,
               marginBottom: (clearControlLayoutVisibility - 1) * 8,
               opacity: clearControlVisibility,
-              transform: `translate3d(0, ${(1 - clearControlVisibility) * -8}px, 0)`,
+              transform: `translate3d(0, ${
+                (1 - clearControlVisibility) * -8 + pullOvershootOffset
+              }px, 0)`,
             }}
             className="eliza-notif-shade-transition flex shrink-0 justify-end overflow-hidden px-2"
           >
@@ -2445,7 +2448,10 @@ export function NotificationsHomeCenter({
             }
             inert={!shadeExpanded && !previewingExpansion ? true : undefined}
             style={{
-              ...notificationPullRevealStyle(emptyStateVisibility),
+              ...notificationPullRevealStyle(
+                emptyStateVisibility,
+                pullOvershootOffset,
+              ),
               transition: isPulling ? "none" : undefined,
             }}
             className="eliza-notif-pull-reveal eliza-notif-shade-transition flex min-h-14 items-center justify-center px-3 py-3 text-2xs font-medium text-white/45"
@@ -2485,6 +2491,27 @@ export function NotificationsHomeCenter({
             shadeExpanded,
             shadeClosing,
           );
+          const groupContentVisibility = pullRevealed
+            ? revealProgress
+            : groupWasRested
+              ? 1
+              : groupVisibility;
+          const groupContentPullOffset = pullRevealed
+            ? (1 - revealProgress) * -8
+            : groupWasRested
+              ? 0
+              : notificationGroupPullOffset(
+                  pullPx,
+                  shadeExpanded,
+                  shadeClosing,
+                  groupVisibility,
+                );
+          // Framer Motion owns the outer group's layout transform. Keeping the
+          // finger-tracked transform on this stable child lets a committed
+          // preview continue into its CSS settle without either system
+          // replacing the other's transform at pointer-up.
+          const groupContentOffset =
+            groupContainerOffset + groupContentPullOffset + pullOvershootOffset;
           const stackExpanded = expandedStacks.has(group.key);
           // Every presentation shares one shell, so the top NotificationRow
           // stays under the same parent/key while a fanned stack closes.
@@ -2574,17 +2601,6 @@ export function NotificationsHomeCenter({
                 pullRevealed &&
                   "eliza-notif-pull-reveal eliza-notif-shade-transition pointer-events-none",
               )}
-              style={
-                pullRevealed || groupContainerOffset !== 0
-                  ? {
-                      opacity: pullRevealed ? revealProgress : undefined,
-                      transform: `translate3d(0, ${
-                        groupContainerOffset +
-                        (pullRevealed ? (1 - revealProgress) * -8 : 0)
-                      }px, 0)`,
-                    }
-                  : undefined
-              }
             >
               <div
                 data-notification-group-content=""
@@ -2603,15 +2619,8 @@ export function NotificationsHomeCenter({
                     : stacked
                       ? stackTailPx
                       : 0,
-                  opacity: groupWasRested ? 1 : groupVisibility,
-                  transform: groupWasRested
-                    ? undefined
-                    : `translate3d(0, ${notificationGroupPullOffset(
-                        pullPx,
-                        shadeExpanded,
-                        shadeClosing,
-                        groupVisibility,
-                      )}px, 0)`,
+                  opacity: groupContentVisibility,
+                  transform: `translate3d(0, ${groupContentOffset}px, 0)`,
                   transition: isPulling ? "none" : undefined,
                 }}
               >
@@ -2761,7 +2770,8 @@ export function NotificationsHomeCenter({
           style={{
             opacity: collapseControlPresentationVisibility,
             transform: `translateY(${
-              (1 - collapseControlPresentationVisibility) * 4
+              (1 - collapseControlPresentationVisibility) * 4 +
+              pullOvershootOffset
             }px)`,
             transition: isPulling
               ? "none"

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -2687,7 +2687,11 @@ export function NotificationsHomeCenter({
                     fanned && "eliza-notif-shade-transition",
                   )}
                   style={
-                    fanned ? { rowGap: `${stackFanProgress * 6}px` } : undefined
+                    fanned
+                      ? {
+                          rowGap: `${stackFanProgress * disposableLayoutVisibility * 6}px`,
+                        }
+                      : undefined
                   }
                 >
                   {rows.map((notification, rowIndex) => (
@@ -2707,7 +2711,7 @@ export function NotificationsHomeCenter({
                       stackCountVisibility={
                         rowIndex === 0 && allGroupRows.length > 1
                           ? fanned
-                            ? 1 - stackFanProgress
+                            ? Math.max(1 - stackFanProgress, shadeCloseProgress)
                             : 1
                           : undefined
                       }

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -49,6 +49,7 @@ import type { AgentNotification } from "@elizaos/core";
 import { ChevronDown, ChevronUp, RefreshCw } from "lucide-react";
 import { motion } from "motion/react";
 import {
+  type CSSProperties,
   type RefObject,
   useCallback,
   useEffect,
@@ -210,7 +211,7 @@ const MAX_VISIBLE_STACK_LAYERS = 3;
 const STACK_PEEK_OFFSET_PX = 7;
 
 /** Clear space after the final peek before the next notification group. */
-const STACK_BOTTOM_CLEARANCE_PX = 10;
+const STACK_BOTTOM_CLEARANCE_PX = 2;
 
 const CLEAR_CONFIRM_TIMEOUT_MS = 5_000;
 const SHADE_SETTLE_MS = 460;
@@ -396,6 +397,27 @@ ${liquidGlassRimCss(".eliza-notif-glass")}
   isolation: isolate;
   scrollbar-width: none;
 }
+/* Pull previews insert rows above the resting count. Disable scroll anchoring
+   while that projection is mounted so Chromium cannot turn the insertion into
+   a positive scrollTop and revoke a gesture the user already owns. The live
+   overshoot padding keeps translated cards inside the scrollport; the edge mask
+   returns on release, when card opacity owns the close transition. */
+.eliza-notif-scroll[data-shade-preview],
+.eliza-notif-scroll[data-shade-mode="expanded"] {
+  padding-bottom: calc(
+    var(--eliza-notif-base-padding, 0px) +
+    var(--eliza-notif-pull-overshoot, 0px)
+  );
+  transition: padding-bottom var(--eliza-notif-settle-duration, ${SHADE_SETTLE_MS}ms) ${SHADE_EASING};
+}
+.eliza-notif-scroll[data-shade-preview] {
+  overflow-anchor: none;
+}
+.eliza-notif-scroll[data-shade-preview][data-shade-dragging] {
+  -webkit-mask-image: none;
+  mask-image: none;
+  transition: none;
+}
 /* Count and card shells become independent compositor layers while they trade
    flow space. Keep cards above the count so its label fades behind their
    material instead of painting through it during either shade direction. */
@@ -510,6 +532,7 @@ export function NotificationsHomeCenter({
 } = {}): React.JSX.Element | null {
   notificationsHomeCenterRenderObserverForTests?.();
   const { notifications, hydrated, hydrationStatus } = useNotifications();
+  const inboxEmpty = notifications.length === 0;
   const reduceMotion = usePrefersReducedMotion();
   // Shade mode: rested (interrupt-tier triage) vs expanded (full inbox).
   // Producer groups stay stacked until individually fanned out.
@@ -1081,6 +1104,9 @@ export function NotificationsHomeCenter({
     // active drag/close so they cannot overwrite click-entry interpolation.
     if (!pullDirection && !shadeClosing) return;
     if (pullDirection) {
+      if (pullDirection === "expand" && !shadeExpanded && scrollRef.current) {
+        scrollRef.current.scrollTop = 0;
+      }
       pullVisibleGroupsRef.current = visibleNotificationGroups(
         centerRef.current,
         scrollRef.current,
@@ -1288,8 +1314,7 @@ export function NotificationsHomeCenter({
   const commitPull = useCallback(() => {
     const px = pullPxRef.current;
     const { canExpand, canCollapse } = shadeGestureRef.current;
-    const commitPx =
-      notifications.length === 0 ? EMPTY_PULL_COMMIT_PX : PULL_COMMIT_PX;
+    const commitPx = inboxEmpty ? EMPTY_PULL_COMMIT_PX : PULL_COMMIT_PX;
     const canMove = (px > 0 && canExpand) || (px < 0 && canCollapse);
     const now = performance.now();
     const momentum = pullMomentumRef.current;
@@ -1314,10 +1339,9 @@ export function NotificationsHomeCenter({
         displacementPx: px,
         releaseVelocityPxPerMs: releaseVelocity,
         distanceThresholdPx: commitPx,
-        minimumFlickDistancePx:
-          notifications.length === 0
-            ? EMPTY_PULL_COMMIT_PX / 2
-            : SHADE_MIN_FLICK_DISTANCE_PX,
+        minimumFlickDistancePx: inboxEmpty
+          ? EMPTY_PULL_COMMIT_PX / 2
+          : SHADE_MIN_FLICK_DISTANCE_PX,
         flickVelocityThresholdPxPerMs: SHADE_FLICK_VELOCITY_PX_PER_MS,
       });
     const targetPullPx = shouldCommit ? Math.sign(px) * PULL_TRAVEL_PX : 0;
@@ -1346,7 +1370,7 @@ export function NotificationsHomeCenter({
   }, [
     beginPullCancellation,
     flushPullPresentation,
-    notifications.length,
+    inboxEmpty,
     reduceMotion,
     requestShadeCollapse,
     setPullPx,
@@ -1373,7 +1397,7 @@ export function NotificationsHomeCenter({
   // native background listener can suppress browser overscroll.
   const handleWheelDelta = useCallback(
     (deltaY: number, scrollTop: number): boolean => {
-      const empty = notifications.length === 0;
+      const empty = inboxEmpty;
       if (Date.now() < wheelCommitLockUntil.current) return true;
       // Away from the top the scroller owns every wheel event.
       if (scrollTop > 0) {
@@ -1413,7 +1437,7 @@ export function NotificationsHomeCenter({
       }
       return true;
     },
-    [beginProgrammaticShadeOpen, notifications.length, requestShadeCollapse],
+    [beginProgrammaticShadeOpen, inboxEmpty, requestShadeCollapse],
   );
 
   const onListWheel = useCallback(
@@ -1432,7 +1456,7 @@ export function NotificationsHomeCenter({
   // ordinary scrolling (see reference: pan-y pull gestures are dead on arrival
   // without this). `surfaceReady` re-runs the bind when hydration establishes a
   // genuinely empty inbox or when a notification arrives before hydration.
-  const hasNotifications = notifications.length > 0;
+  const hasNotifications = !inboxEmpty;
   const surfaceReady = hydrated || hasNotifications;
   useEffect(() => {
     const list = scrollRef.current;
@@ -1552,11 +1576,15 @@ export function NotificationsHomeCenter({
         }
         return;
       }
-      if (gestureTarget.scrollTop <= 0 && canExpand) {
+      if (
+        canExpand &&
+        (expandAnchorY !== null || gestureTarget.scrollTop <= 0)
+      ) {
         if (expandAnchorY === null) expandAnchorY = t.clientY;
         const pull = t.clientY - expandAnchorY;
         if (pull > PULL_SLOP_PX) {
           event?.preventDefault();
+          if (gestureTarget.scrollTop !== 0) gestureTarget.scrollTop = 0;
           setPullPx(dampenPull(pull));
         } else if (pullPxRef.current !== 0) {
           // Finger reversed back above the anchor — the pull is withdrawn, so
@@ -1653,11 +1681,13 @@ export function NotificationsHomeCenter({
     const list = scrollRef.current;
     if (!hasNotifications || !surface || !list || surface === list) return;
     let start: { identifier: number; x: number; y: number } | null = null;
+    let expandAnchorY: number | null = null;
     let axis: "none" | "x" | "y" = "none";
     let ownsPull = false;
 
     const reset = () => {
       start = null;
+      expandAnchorY = null;
       axis = "none";
       ownsPull = false;
     };
@@ -1683,6 +1713,7 @@ export function NotificationsHomeCenter({
         x: touch.clientX,
         y: touch.clientY,
       };
+      expandAnchorY = surface.scrollTop <= 0 ? touch.clientY : null;
     };
     const updateTouchPosition = (touch: Touch, event?: TouchEvent) => {
       if (!start || !touch) return;
@@ -1702,12 +1733,19 @@ export function NotificationsHomeCenter({
       if (
         axis === "y" &&
         dy > PULL_SLOP_PX &&
-        surface.scrollTop <= 0 &&
+        (expandAnchorY !== null || surface.scrollTop <= 0) &&
         shadeGestureRef.current.canExpand
       ) {
-        ownsPull = true;
-        event?.preventDefault();
-        setPullPx(dampenPull(dy));
+        if (expandAnchorY === null) expandAnchorY = touch.clientY;
+        const pull = touch.clientY - expandAnchorY;
+        if (pull > PULL_SLOP_PX) {
+          ownsPull = true;
+          event?.preventDefault();
+          if (surface.scrollTop !== 0) surface.scrollTop = 0;
+          setPullPx(dampenPull(pull));
+        } else if (ownsPull && pullPxRef.current !== 0) {
+          setPullPx(0, true);
+        }
       } else if (ownsPull && pullPxRef.current !== 0) {
         setPullPx(0, true);
       }
@@ -1887,6 +1925,7 @@ export function NotificationsHomeCenter({
       startX: number;
       startY: number;
       axis: "none" | "x" | "y";
+      ownsPull: boolean;
     } | null = null;
     const armClickSuppression = () => {
       suppressBackgroundClick.current = true;
@@ -1940,6 +1979,7 @@ export function NotificationsHomeCenter({
         startX: event.clientX,
         startY: event.clientY,
         axis: "none",
+        ownsPull: false,
       };
     };
     const onPointerMove = (event: PointerEvent) => {
@@ -1962,7 +2002,9 @@ export function NotificationsHomeCenter({
       if (current.axis !== "y") return;
       event.preventDefault();
       const { canExpand, canCollapse } = shadeGestureRef.current;
-      if (dy > 0 && canExpand && surface.scrollTop <= 0) {
+      if (dy > 0 && canExpand && (current.ownsPull || surface.scrollTop <= 0)) {
+        current.ownsPull = true;
+        if (surface.scrollTop !== 0) surface.scrollTop = 0;
         setPullPx(dy > PULL_SLOP_PX ? dampenPull(dy) : 0, dy <= PULL_SLOP_PX);
       } else if (dy < 0 && canCollapse) {
         setPullPx(
@@ -2078,7 +2120,7 @@ export function NotificationsHomeCenter({
   // unbinds before touchend, so a stale translateY would otherwise ride into
   // the next arrival's first paint.
   useEffect(() => {
-    if (notifications.length === 0) {
+    if (inboxEmpty) {
       cancelAllStackFolds();
       setShadeExpanded(false);
       setShadeOpenedByStack(false);
@@ -2089,12 +2131,7 @@ export function NotificationsHomeCenter({
       cancelPullCancellation();
       setPullPx(0);
     }
-  }, [
-    cancelAllStackFolds,
-    cancelPullCancellation,
-    notifications.length,
-    setPullPx,
-  ]);
+  }, [cancelAllStackFolds, cancelPullCancellation, inboxEmpty, setPullPx]);
 
   // Build stable rested and expanded projections. During a downward pull,
   // lower-priority groups reveal under the finger while already-visible
@@ -2203,6 +2240,7 @@ export function NotificationsHomeCenter({
     notificationCountVisibility,
     notificationCountOffset,
     pullOvershootOffset,
+    collapseControlOvershootOffset,
     notificationCountLayoutVisibility,
     emptyStateVisibility,
     collapseControlVisibility,
@@ -2274,9 +2312,10 @@ export function NotificationsHomeCenter({
       return;
     }
     // Downward drag: the expand gesture, only from the list top.
-    if (el.scrollTop <= 0 && mayExpand) {
+    if (mayExpand && (g.anchorY !== null || el.scrollTop <= 0)) {
       if (g.anchorY === null) g.anchorY = e.clientY;
       const pull = e.clientY - g.anchorY;
+      if (pull > PULL_SLOP_PX && el.scrollTop !== 0) el.scrollTop = 0;
       setPullPx(
         pull > PULL_SLOP_PX ? dampenPull(pull) : 0,
         pull <= PULL_SLOP_PX,
@@ -2391,11 +2430,17 @@ export function NotificationsHomeCenter({
         data-shade-preview={previewingExpansion ? "expanding" : undefined}
         data-shade-dragging={isPulling ? "" : undefined}
         data-shade-settling={shadeClosing ? "" : undefined}
+        style={
+          {
+            "--eliza-notif-base-padding": showCollapseControl ? "4px" : "40px",
+            "--eliza-notif-pull-overshoot": `${Math.max(0, pullOvershootOffset)}px`,
+          } as CSSProperties
+        }
         className={cn(
           // select-none: a mouse pull-drag must read as a gesture, not a text
           // selection sweep across the cards (platform-shade idiom).
           "eliza-notif-scroll relative flex min-h-0 touch-pan-y select-none flex-col gap-2 overflow-y-auto overflow-x-hidden overscroll-y-contain px-1.5 pt-1",
-          showCollapseControl ? "flex-[0_1_auto] pb-2" : "flex-1 pb-10",
+          showCollapseControl ? "flex-[0_1_auto] pb-1" : "flex-1 pb-10",
           hasNotifications &&
             "scroll-fade scroll-fade-t-[1.25rem] scroll-fade-b-[1.5rem]",
           shadeClosing && "pointer-events-none",
@@ -2771,7 +2816,7 @@ export function NotificationsHomeCenter({
             opacity: collapseControlPresentationVisibility,
             transform: `translateY(${
               (1 - collapseControlPresentationVisibility) * 4 +
-              pullOvershootOffset
+              collapseControlOvershootOffset
             }px)`,
             transition: isPulling
               ? "none"

--- a/packages/ui/src/components/shell/__e2e__/home-screen-fixture.tsx
+++ b/packages/ui/src/components/shell/__e2e__/home-screen-fixture.tsx
@@ -8,6 +8,7 @@
 
 import * as React from "react";
 import { createRoot } from "react-dom/client";
+import type { AgentNotification } from "@elizaos/core";
 
 import {
   installHomeWidgetFetchMock,
@@ -16,19 +17,63 @@ import {
 } from "../../../widgets/__fixtures__/home-widget-mock-data";
 import { ShaderBackground } from "../../../backgrounds/ShaderBackground";
 import { LauncherSurface } from "../../pages/LauncherSurface";
+import {
+  __ingestNotificationForTests,
+  __resetNotificationStoreForTests,
+} from "../../../state/notifications/notification-store";
 import { HomeLauncherSurface } from "../HomeLauncherSurface";
 import { HomeScreen, type HomeTileTarget } from "../HomeScreen";
-
-// Inject the home-widget data BEFORE the React tree renders so every widget's
-// mount-time fetch + the WidgetHost's plugin resolution see populated data.
-seedHomeWidgetAppStore();
-seedHomeWidgetNotifications();
-installHomeWidgetFetchMock();
 
 const params =
   typeof location !== "undefined"
     ? new URLSearchParams(location.search)
     : new URLSearchParams();
+
+// Inject the home-widget data BEFORE the React tree renders so every widget's
+// mount-time fetch + the WidgetHost's plugin resolution see populated data.
+seedHomeWidgetAppStore();
+if (params.has("notificationMotion")) {
+  __resetNotificationStoreForTests();
+  const now = Date.now();
+  const notifications: AgentNotification[] = [
+    {
+      id: "notif-motion-1",
+      title: "Motion one",
+      body: "First folded notification",
+      category: "system",
+      priority: "normal",
+      source: "system",
+      createdAt: now,
+      readAt: null,
+    },
+    {
+      id: "notif-motion-2",
+      title: "Motion two",
+      body: "Second folded notification",
+      category: "system",
+      priority: "normal",
+      source: "system",
+      createdAt: now - 1_000,
+      readAt: null,
+    },
+    {
+      id: "notif-motion-3",
+      title: "Motion three",
+      body: "Third folded notification",
+      category: "system",
+      priority: "normal",
+      source: "system",
+      createdAt: now - 2_000,
+      readAt: null,
+    },
+  ];
+  for (const notification of notifications) {
+    __ingestNotificationForTests(notification, notifications.length);
+  }
+} else {
+  seedHomeWidgetNotifications();
+}
+installHomeWidgetFetchMock();
 const showNativeOsTiles = params.has("native");
 
 function Harness(): React.JSX.Element {

--- a/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
@@ -1611,7 +1611,7 @@ try {
       mountedFanFrames[0]?.controls.opacity <= 0.05 &&
       mountedFanFrames[0]?.peeks.length === 2 &&
       mountedFanFrames[0]?.peeks.every((opacity) => opacity >= 0.98) &&
-      mountedFanFrames[0]?.group.paddingBottom >= 23,
+      mountedFanFrames[0]?.group.paddingBottom >= 15,
     "stack fan mounts controls and rows from collapsed geometry",
   );
   console.log(

--- a/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
@@ -27,6 +27,7 @@ import {
   summarizeStability,
 } from "../../../testing/layout-stability.ts";
 import {
+  touchDragHold,
   touchLongPress,
   touchSwipe,
   touchTap,
@@ -720,6 +721,54 @@ try {
       "expanded-only controls stay hidden at rest",
     );
 
+    const countSlot = center.getByTestId("notifications-count");
+    const restedCountBox = await countSlot.boundingBox();
+    if (!restedCountBox) throw new Error("missing notification count bounds");
+    const partialPull = await touchDragHold(
+      mobile,
+      '[data-testid="home-notification-list"]',
+      0,
+      48,
+      { steps: 6, stepDelayMs: 16 },
+    );
+    await mobile.evaluate(
+      () => new Promise((resolve) => requestAnimationFrame(resolve)),
+    );
+    const heldCountBox = await countSlot.boundingBox();
+    if (!heldCountBox) throw new Error("missing pulled count bounds");
+    const heldCountTravel = heldCountBox.y - restedCountBox.y;
+    assert(
+      heldCountTravel > 1 && heldCountTravel < 28,
+      `a partial pull moves the count continuously instead of inserting a 40px row (${heldCountTravel.toFixed(2)}px)`,
+    );
+
+    await partialPull.release();
+    const releaseTrace = await mobile.evaluate(async (restedTop) => {
+      const samples = [];
+      const startedAt = performance.now();
+      // Keep sampling through the gesture's click-suppression window so the
+      // next tap is a distinct user action as well as a settled-state check.
+      while (performance.now() - startedAt < 560) {
+        await new Promise((resolve) => requestAnimationFrame(resolve));
+        const count = document.querySelector(
+          '[data-testid="notifications-count"]',
+        );
+        if (!(count instanceof HTMLElement)) break;
+        samples.push(count.getBoundingClientRect().top - restedTop);
+      }
+      return samples;
+    }, restedCountBox.y);
+    const releasePeak = Math.max(...releaseTrace);
+    const releaseFinal = releaseTrace.at(-1) ?? Number.POSITIVE_INFINITY;
+    assert(
+      releasePeak <= heldCountTravel + 1.5,
+      `a cancelled pull returns without bouncing farther from rest (${releasePeak.toFixed(2)}px peak)`,
+    );
+    assert(
+      Math.abs(releaseFinal) < 0.75,
+      `the notification count settles back at rest (${releaseFinal.toFixed(2)}px)`,
+    );
+
     await touchTap(mobile, '[data-testid="notifications-count-button"]');
     await center
       .locator(
@@ -731,6 +780,12 @@ try {
         (await center.getByTestId("notifications-collapse").count()) === 1,
       "opening the shade reveals clear and collapse controls",
     );
+    await mobile.waitForFunction(() => {
+      const footer = document.querySelector(
+        '[data-testid="notifications-collapse-footer"]',
+      );
+      return footer instanceof HTMLElement && !footer.hasAttribute("inert");
+    });
 
     await touchTap(mobile, '[data-testid="notifications-collapse"]');
     await center
@@ -1039,6 +1094,1163 @@ try {
     await rename(videoPath, stableVideoPath);
     console.log(`  🎥 ${stableVideoPath}`);
   }
+
+  // A dedicated three-row quiet stack exercises the transitions that cannot
+  // exist in the default urgent-row fixture: click-open insertion, producer
+  // fan-out, empty-region collapse/close-race handling, and a cancelled pull
+  // settle.
+  const notificationMotionContext = await browser.newContext({
+    viewport: { width: 402, height: 874 },
+    deviceScaleFactor: 2,
+    hasTouch: true,
+    isMobile: true,
+  });
+  const notificationMotion = await notificationMotionContext.newPage();
+  notificationMotion.on("pageerror", (e) => sink.errors.push(String(e)));
+  await installCoarsePointerMedia(notificationMotion);
+  await notificationMotion.goto(`${url}?notificationMotion`);
+  const notificationCenter = notificationMotion.getByTestId(
+    "home-notification-center",
+  );
+  await notificationCenter.waitFor({ state: "visible", timeout: 5000 });
+  await waitForHomeEnterSettled(notificationMotion);
+  assert(
+    (await notificationCenter.getByTestId("notification-row").count()) === 0,
+    "quiet notification stack starts folded behind the total",
+  );
+
+  await notificationMotion.evaluate(() => {
+    window.__ELIZA_NOTIFICATION_OPEN_TRACE__ = [];
+    const startedAt = performance.now();
+    const sample = () => {
+      const group = document.querySelector(
+        "[data-notification-group-content]",
+      );
+      const count = document.querySelector('[data-testid="notifications-count"]');
+      const groupLayer = group?.closest("[data-notification-group]");
+      const clear = document.querySelector("[data-notification-clear-slot]");
+      window.__ELIZA_NOTIFICATION_OPEN_TRACE__.push({
+        t: performance.now() - startedAt,
+        group: group
+          ? {
+              opacity: Number.parseFloat(getComputedStyle(group).opacity),
+              top: group.getBoundingClientRect().top,
+              duration: getComputedStyle(group).transitionDuration,
+              zIndex: groupLayer
+                ? getComputedStyle(groupLayer).zIndex
+                : null,
+            }
+          : null,
+        count: count
+          ? {
+              opacity: Number.parseFloat(getComputedStyle(count).opacity),
+              height: count.getBoundingClientRect().height,
+              duration: getComputedStyle(count).transitionDuration,
+              zIndex: getComputedStyle(count).zIndex,
+            }
+          : null,
+        clear: clear
+          ? {
+              opacity: Number.parseFloat(getComputedStyle(clear).opacity),
+              height: clear.getBoundingClientRect().height,
+              duration: getComputedStyle(clear).transitionDuration,
+            }
+          : null,
+      });
+      if (performance.now() - startedAt < 420) requestAnimationFrame(sample);
+    };
+    const countButton = document.querySelector(
+      '[data-testid="notifications-count-button"]',
+    );
+    if (!(countButton instanceof HTMLButtonElement)) {
+      throw new Error("missing notification count button");
+    }
+    countButton.click();
+    requestAnimationFrame(sample);
+  });
+  await notificationMotion.waitForTimeout(460);
+  const openTrace = await notificationMotion.evaluate(
+    () => window.__ELIZA_NOTIFICATION_OPEN_TRACE__,
+  );
+  const mountedOpenFrames = openTrace.filter((sample) => sample.group);
+  const openIntermediateOpacity = new Set(
+    mountedOpenFrames
+      .map((sample) => sample.group.opacity)
+      .filter((opacity) => opacity > 0.05 && opacity < 0.95)
+      .map((opacity) => opacity.toFixed(2)),
+  );
+  const openIntermediateCountHeights = new Set(
+    mountedOpenFrames
+      .map((sample) => sample.count.height)
+      .filter((height) => height > 0.75 && height < 31.25)
+      .map((height) => height.toFixed(1)),
+  );
+  const openIntermediateClearHeights = new Set(
+    mountedOpenFrames
+      .map((sample) => sample.clear.height)
+      .filter((height) => height > 0.75 && height < 31.25)
+      .map((height) => height.toFixed(1)),
+  );
+  assert(
+    mountedOpenFrames[0]?.group.opacity <= 0.05,
+    `click-open mounts at the transition origin (${mountedOpenFrames[0]?.group.opacity ?? "missing"})`,
+  );
+  console.log(
+    `  [notification click-open] distinct intermediate frames=${openIntermediateOpacity.size}`,
+  );
+  assert(
+    openIntermediateOpacity.size >= 2 &&
+      openIntermediateCountHeights.size >= 2 &&
+      openIntermediateClearHeights.size >= 2,
+    `click-open produces intermediate group/count/clear frames (${openIntermediateOpacity.size}/${openIntermediateCountHeights.size}/${openIntermediateClearHeights.size})`,
+  );
+  assert(
+    mountedOpenFrames[0]?.group.duration.includes("0.22s") &&
+      mountedOpenFrames[0]?.count.duration.includes("0.22s") &&
+      mountedOpenFrames[0]?.clear.duration.includes("0.22s"),
+    `click-open uses one 220ms group/count/clear settle (${JSON.stringify(mountedOpenFrames[0] ?? null)})`,
+  );
+  assert(
+    mountedOpenFrames.every(
+      (sample) => sample.group.zIndex === "1" && sample.count.zIndex === "0",
+    ),
+    "click-open keeps notification cards above the fading count label",
+  );
+  assert(
+    mountedOpenFrames.every(
+      (sample, index) =>
+        index === 0 ||
+        sample.group.opacity + 0.02 >=
+          mountedOpenFrames[index - 1].group.opacity,
+    ),
+    "click-open opacity advances monotonically",
+  );
+  assert(
+    mountedOpenFrames.at(-1)?.group.opacity >= 0.98 &&
+      mountedOpenFrames.at(-1)?.count.height < 0.75 &&
+      mountedOpenFrames.at(-1)?.clear.height > 31,
+    "click-open settles with the group visible and count/clear slots exchanged",
+  );
+
+  const notificationCenterBox = await notificationCenter.boundingBox();
+  const notificationListBox = await notificationCenter
+    .getByTestId("home-notification-list")
+    .boundingBox();
+  if (!notificationCenterBox || !notificationListBox) {
+    throw new Error("missing notification motion geometry");
+  }
+  const emptyLaneX = notificationCenterBox.x + notificationCenterBox.width / 2;
+  const emptyLaneStartY =
+    notificationCenterBox.y + notificationCenterBox.height - 60;
+  assert(
+    emptyLaneStartY > notificationListBox.y + notificationListBox.height + 8,
+    "mouse collapse starts below the notification list",
+  );
+  const emptyLaneHitsList = await notificationMotion.evaluate(
+    ({ x, y }) => {
+      const list = document.querySelector(
+        '[data-testid="home-notification-list"]',
+      );
+      const target = document.elementFromPoint(x, y);
+      return Boolean(list && target && list.contains(target));
+    },
+    { x: emptyLaneX, y: emptyLaneStartY },
+  );
+  assert(!emptyLaneHitsList, "empty-region drag hit-tests outside the list");
+
+  const emptyTouchLaneSelector =
+    '[data-testid="notification-empty-touch-lane"]';
+  await notificationMotion.evaluate(
+    ({ x, y }) => {
+      const center = document.querySelector(
+        '[data-testid="home-notification-center"]',
+      );
+      if (!(center instanceof HTMLElement)) {
+        throw new Error("missing notification touch-lane center");
+      }
+      const bounds = center.getBoundingClientRect();
+      const target = document.createElement("div");
+      target.dataset.testid = "notification-empty-touch-lane";
+      Object.assign(target.style, {
+        position: "absolute",
+        left: `${x - bounds.left - 12}px`,
+        top: `${y - bounds.top - 12}px`,
+        width: "24px",
+        height: "24px",
+        zIndex: "50",
+      });
+      center.append(target);
+    },
+    { x: emptyLaneX, y: emptyLaneStartY },
+  );
+
+  await notificationMotion.evaluate(() => {
+    window.__ELIZA_NOTIFICATION_CLOSE_TRACE__ = [];
+    const startedAt = performance.now();
+    const sample = () => {
+      const list = document.querySelector(
+        '[data-testid="home-notification-list"]',
+      );
+      const count = document.querySelector(
+        '[data-testid="notifications-count"]',
+      );
+      const clear = document.querySelector("[data-notification-clear-slot]");
+      const group = document.querySelector(
+        "[data-notification-group-content]",
+      );
+      const groupLayer = group?.closest("[data-notification-group]");
+      window.__ELIZA_NOTIFICATION_CLOSE_TRACE__.push({
+        t: performance.now() - startedAt,
+        mode: list?.getAttribute("data-shade-mode"),
+        count: count
+          ? {
+              top: count.getBoundingClientRect().top,
+              height: count.getBoundingClientRect().height,
+              opacity: Number.parseFloat(getComputedStyle(count).opacity),
+              duration: getComputedStyle(count).transitionDuration,
+              zIndex: getComputedStyle(count).zIndex,
+            }
+          : null,
+        clear: clear
+          ? {
+              height: clear.getBoundingClientRect().height,
+              opacity: Number.parseFloat(getComputedStyle(clear).opacity),
+              duration: getComputedStyle(clear).transitionDuration,
+            }
+          : null,
+        group: group
+          ? {
+              opacity: Number.parseFloat(getComputedStyle(group).opacity),
+              duration: getComputedStyle(group).transitionDuration,
+              zIndex: groupLayer
+                ? getComputedStyle(groupLayer).zIndex
+                : null,
+            }
+          : null,
+      });
+      if (performance.now() - startedAt < 420) requestAnimationFrame(sample);
+    };
+    requestAnimationFrame(sample);
+  });
+
+  await notificationCenter.getByTestId("notifications-collapse").click();
+  assert(
+    (await notificationCenter
+      .getByTestId("home-notification-list")
+      .getAttribute("data-shade-settling")) !== null,
+    "notification shade exposes its committed close settle",
+  );
+  const closeRaceState = await notificationMotion.evaluate(
+    ({ x, y }) => {
+      const center = document.querySelector(
+        '[data-testid="home-notification-center"]',
+      );
+      const list = document.querySelector(
+        '[data-testid="home-notification-list"]',
+      );
+      const target = document.elementFromPoint(x, y);
+      if (!(center instanceof HTMLElement) || !(target instanceof Element)) {
+        throw new Error("missing notification close-race target");
+      }
+      const dispatchGesture = (pointerId, endY) => {
+        target.dispatchEvent(
+          new PointerEvent("pointerdown", {
+            bubbles: true,
+            cancelable: true,
+            pointerType: "mouse",
+            pointerId,
+            isPrimary: true,
+            buttons: 1,
+            clientX: x,
+            clientY: y,
+          }),
+        );
+        target.dispatchEvent(
+          new PointerEvent("pointermove", {
+            bubbles: true,
+            cancelable: true,
+            pointerType: "mouse",
+            pointerId,
+            isPrimary: true,
+            buttons: 1,
+            clientX: x,
+            clientY: endY,
+          }),
+        );
+        target.dispatchEvent(
+          new PointerEvent("pointerup", {
+            bubbles: true,
+            cancelable: true,
+            pointerType: "mouse",
+            pointerId,
+            isPrimary: true,
+            clientX: x,
+            clientY: endY,
+          }),
+        );
+      };
+      dispatchGesture(71, y - 30);
+      dispatchGesture(72, y - 160);
+      return {
+        mode: list?.getAttribute("data-shade-mode"),
+        settling: list?.hasAttribute("data-shade-settling"),
+        dragging: list?.hasAttribute("data-shade-dragging"),
+        cancelling: center.hasAttribute(
+          "data-notification-shade-cancelling",
+        ),
+      };
+    },
+    { x: emptyLaneX, y: emptyLaneStartY },
+  );
+  assert(
+    closeRaceState.mode === "expanded" &&
+      closeRaceState.settling &&
+      !closeRaceState.dragging &&
+      !closeRaceState.cancelling,
+    `empty-region swipes cannot interrupt a committed close (${JSON.stringify(closeRaceState)})`,
+  );
+  await notificationMotion.waitForTimeout(460);
+  const closeTrace = await notificationMotion.evaluate(
+    () => window.__ELIZA_NOTIFICATION_CLOSE_TRACE__,
+  );
+  const mountedCloseFrames = closeTrace.filter(
+    (sample) => sample.count && sample.clear && sample.group,
+  );
+  const closeIntermediateCountHeights = new Set(
+    closeTrace
+      .map((sample) => sample.count?.height)
+      .filter((height) => height > 0.75 && height < 31.25)
+      .map((height) => height.toFixed(1)),
+  );
+  const closeIntermediateClearHeights = new Set(
+    mountedCloseFrames
+      .map((sample) => sample.clear.height)
+      .filter((height) => height > 0.75 && height < 31.25)
+      .map((height) => height.toFixed(1)),
+  );
+  const closeIntermediateGroupOpacity = new Set(
+    mountedCloseFrames
+      .map((sample) => sample.group.opacity)
+      .filter((opacity) => opacity > 0.05 && opacity < 0.95)
+      .map((opacity) => opacity.toFixed(2)),
+  );
+  const visibleCloseCountFrames = closeTrace.filter(
+    (sample) => sample.count && sample.count.height > 0.75,
+  );
+  const closeCountTops = visibleCloseCountFrames.map(
+    (sample) => sample.count.top,
+  );
+  const closeMaxUpwardStep = Math.max(
+    0,
+    ...closeCountTops.slice(1).map((top, index) => closeCountTops[index] - top),
+  );
+  const closeMaxDownwardStep = Math.max(
+    0,
+    ...closeCountTops.slice(1).map((top, index) => top - closeCountTops[index]),
+  );
+  const closeFinalTop = closeCountTops.at(-1) ?? Number.POSITIVE_INFINITY;
+  const closeMinTop = Math.min(...closeCountTops);
+  console.log(
+    `  [notification click-close] intermediate=${closeIntermediateCountHeights.size}/${closeIntermediateClearHeights.size}/${closeIntermediateGroupOpacity.size} max-up=${closeMaxUpwardStep.toFixed(2)}px max-down=${closeMaxDownwardStep.toFixed(2)}px`,
+  );
+  assert(
+    closeIntermediateCountHeights.size >= 2 &&
+      closeIntermediateClearHeights.size >= 2 &&
+      closeIntermediateGroupOpacity.size >= 2,
+    `click-close produces intermediate count/clear/group frames (${closeIntermediateCountHeights.size}/${closeIntermediateClearHeights.size}/${closeIntermediateGroupOpacity.size})`,
+  );
+  assert(
+    mountedCloseFrames[0]?.count.duration.includes("0.22s") &&
+      mountedCloseFrames[0]?.clear.duration.includes("0.22s") &&
+      mountedCloseFrames[0]?.group.duration.includes("0.22s"),
+    `click-close uses one 220ms count/clear/group settle (${JSON.stringify(mountedCloseFrames[0] ?? null)})`,
+  );
+  assert(
+    mountedCloseFrames.every(
+      (sample) => sample.group.zIndex === "1" && sample.count.zIndex === "0",
+    ),
+    "click-close keeps notification cards above the fading count label",
+  );
+  assert(
+    closeMaxUpwardStep < 12 &&
+      closeMaxDownwardStep < 1.5 &&
+      closeFinalTop - closeMinTop < 1,
+    `notification count reaches its rested top monotonically without a jump or bounce (${JSON.stringify({ closeMaxUpwardStep, closeMaxDownwardStep, closeFinalTop, closeMinTop })})`,
+  );
+  assert(
+    (await notificationCenter
+      .getByTestId("home-notification-list")
+      .getAttribute("data-shade-mode")) === "rested",
+    "the original close clock completes after rejected empty-region swipes",
+  );
+  await notificationCenter.getByTestId("notifications-count-button").click();
+  await notificationMotion.waitForTimeout(300);
+
+  await notificationMotion.mouse.move(emptyLaneX, emptyLaneStartY);
+  await notificationMotion.mouse.down();
+  await notificationMotion.mouse.move(emptyLaneX, emptyLaneStartY - 160, {
+    steps: 12,
+  });
+  await notificationMotion.mouse.up();
+  await notificationMotion.waitForTimeout(280);
+  assert(
+    (await notificationCenter
+      .getByTestId("home-notification-list")
+      .getAttribute("data-shade-mode")) === "rested",
+    "mouse swipe-up from the empty notification region collapses the shade",
+  );
+  await notificationCenter.getByTestId("notifications-count-button").click();
+  await notificationMotion.waitForTimeout(300);
+  assert(
+    (await notificationCenter
+      .getByTestId("home-notification-list")
+      .getAttribute("data-shade-mode")) === "expanded",
+    "notification shade reopens before the real-touch collapse",
+  );
+
+  await touchSwipe(
+    notificationMotion,
+    emptyTouchLaneSelector,
+    0,
+    -160,
+    { steps: 12, stepDelayMs: 12 },
+  );
+  await notificationMotion.waitForTimeout(280);
+  assert(
+    (await notificationCenter
+      .getByTestId("home-notification-list")
+      .getAttribute("data-shade-mode")) === "rested",
+    "real CDP touch swipe-up from the empty notification region collapses the shade",
+  );
+  await notificationCenter.getByTestId("notifications-count-button").click();
+  await notificationMotion.waitForTimeout(300);
+  assert(
+    (await notificationCenter
+      .getByTestId("home-notification-list")
+      .getAttribute("data-shade-mode")) === "expanded",
+    "notification shade reopens before the stack fan trace",
+  );
+
+  await notificationMotion.evaluate(() => {
+    window.__ELIZA_NOTIFICATION_FAN_TRACE__ = [];
+    const startedAt = performance.now();
+    const sample = () => {
+      const controls = document.querySelector(
+        '[data-testid="notification-stack-controls"]',
+      );
+      const rows = Array.from(
+        document.querySelectorAll("[data-notification-disposable-row]"),
+      );
+      const peeks = Array.from(
+        document.querySelectorAll("[data-notification-stack-peek]"),
+      );
+      const group = document.querySelector(
+        "[data-notification-group-content]",
+      );
+      window.__ELIZA_NOTIFICATION_FAN_TRACE__.push({
+        t: performance.now() - startedAt,
+        group: group
+          ? {
+              height: group.getBoundingClientRect().height,
+              paddingBottom: Number.parseFloat(
+                getComputedStyle(group).paddingBottom,
+              ),
+            }
+          : null,
+        controls: controls
+          ? {
+              height: controls.getBoundingClientRect().height,
+              opacity: Number.parseFloat(getComputedStyle(controls).opacity),
+              duration: getComputedStyle(controls).transitionDuration,
+            }
+          : null,
+        rows: rows.map((row) => ({
+          height: row.getBoundingClientRect().height,
+          opacity: Number.parseFloat(getComputedStyle(row).opacity),
+        })),
+        peeks: peeks.map((peek) =>
+          Number.parseFloat(getComputedStyle(peek).opacity),
+        ),
+      });
+      if (performance.now() - startedAt < 420) requestAnimationFrame(sample);
+    };
+    const stackButton = document.querySelector(
+      '[data-testid="notification-row"]',
+    );
+    if (!(stackButton instanceof HTMLButtonElement)) {
+      throw new Error("missing notification stack button");
+    }
+    stackButton.click();
+    requestAnimationFrame(sample);
+  });
+  await notificationMotion.waitForTimeout(460);
+  const fanTrace = await notificationMotion.evaluate(
+    () => window.__ELIZA_NOTIFICATION_FAN_TRACE__,
+  );
+  const mountedFanFrames = fanTrace.filter((sample) => sample.controls);
+  const fanIntermediateOpacity = new Set(
+    mountedFanFrames
+      .map((sample) => sample.controls.opacity)
+      .filter((opacity) => opacity > 0.05 && opacity < 0.95)
+      .map((opacity) => opacity.toFixed(2)),
+  );
+  const fanIntermediateRowOpacity = new Set(
+    mountedFanFrames
+      .flatMap((sample) => sample.rows.map((row) => row.opacity))
+      .filter((opacity) => opacity > 0.05 && opacity < 0.95)
+      .map((opacity) => opacity.toFixed(2)),
+  );
+  const fanIntermediatePeekOpacity = new Set(
+    mountedFanFrames
+      .flatMap((sample) => sample.peeks)
+      .filter((opacity) => opacity > 0.05 && opacity < 0.95)
+      .map((opacity) => opacity.toFixed(2)),
+  );
+  assert(
+    mountedFanFrames[0]?.controls.height < 1 &&
+      mountedFanFrames[0]?.controls.opacity <= 0.05 &&
+      mountedFanFrames[0]?.peeks.length === 2 &&
+      mountedFanFrames[0]?.peeks.every((opacity) => opacity >= 0.98) &&
+      mountedFanFrames[0]?.group.paddingBottom >= 23,
+    "stack fan mounts controls and rows from collapsed geometry",
+  );
+  console.log(
+    `  [notification stack fan] distinct intermediate frames=${fanIntermediateOpacity.size}`,
+  );
+  assert(
+    fanIntermediateOpacity.size >= 2 &&
+      fanIntermediateRowOpacity.size >= 2 &&
+      fanIntermediatePeekOpacity.size >= 2,
+    `stack fan produces intermediate control/row/peek frames (${fanIntermediateOpacity.size}/${fanIntermediateRowOpacity.size}/${fanIntermediatePeekOpacity.size})`,
+  );
+  assert(
+    mountedFanFrames[0]?.controls.duration.includes("0.3s"),
+    `stack fan uses the balanced 300ms settle (${mountedFanFrames[0]?.controls.duration ?? "missing"})`,
+  );
+  assert(
+    mountedFanFrames.every(
+      (sample, index) =>
+        index === 0 ||
+        sample.controls.opacity + 0.02 >=
+          mountedFanFrames[index - 1].controls.opacity,
+    ) &&
+      mountedFanFrames.every(
+        (sample, index) =>
+          index === 0 ||
+          sample.group.height + 1 >= mountedFanFrames[index - 1].group.height,
+      ) &&
+      mountedFanFrames.every(
+        (sample, index) =>
+          index === 0 ||
+          sample.peeks.every(
+            (opacity, peekIndex) =>
+              opacity <=
+              (mountedFanFrames[index - 1].peeks[peekIndex] ?? opacity) + 0.02,
+          ),
+      ),
+    "stack fan geometry advances monotonically while its peeks fade",
+  );
+  assert(
+    mountedFanFrames.at(-1)?.controls.height > 35 &&
+      mountedFanFrames.at(-1)?.controls.opacity >= 0.98 &&
+      mountedFanFrames.at(-1)?.rows.length === 2 &&
+      mountedFanFrames.at(-1)?.peeks.length === 2 &&
+      mountedFanFrames.at(-1)?.peeks.every((opacity) => opacity <= 0.02) &&
+      Math.abs(mountedFanFrames.at(-1)?.group.paddingBottom - 16) < 0.75,
+    "stack fan settles with controls and both folded rows visible",
+  );
+
+  await notificationMotion.evaluate(() => {
+    window.__ELIZA_NOTIFICATION_FOLD_TRACE__ = [];
+    const startedAt = performance.now();
+    const sample = () => {
+      const controls = document.querySelector(
+        '[data-testid="notification-stack-controls"]',
+      );
+      const rows = Array.from(
+        document.querySelectorAll("[data-notification-disposable-row]"),
+      );
+      const peeks = Array.from(
+        document.querySelectorAll("[data-notification-stack-peek]"),
+      );
+      const group = document.querySelector(
+        "[data-notification-group-content]",
+      );
+      const frontRow = group?.querySelector("[data-notif-row]");
+      const restControl =
+        document.querySelector('[data-testid="notifications-count"]') ??
+        document.querySelector("[data-notification-collapse-footer]");
+      const groupRect = group?.getBoundingClientRect();
+      const frontRowRect = frontRow?.getBoundingClientRect();
+      const groupShell = group?.closest("[data-notification-group]");
+      const runningAnimations = (
+        groupShell?.getAnimations({ subtree: true }) ?? []
+      )
+        .filter((animation) => {
+          if (animation.playState !== "running") return false;
+          const duration = animation.effect?.getComputedTiming().duration;
+          return (
+            typeof duration === "number" &&
+            duration > 16 &&
+            ("transitionProperty" in animation ||
+              !("animationName" in animation))
+          );
+        })
+        .map((animation) => {
+          const target =
+            animation.effect instanceof KeyframeEffect
+              ? animation.effect.target
+              : null;
+          return {
+            type: animation.constructor.name,
+            property:
+              "transitionProperty" in animation
+                ? animation.transitionProperty
+                : null,
+            target:
+              target instanceof Element
+                ? target.getAttribute("data-testid") || target.className
+                : null,
+          };
+        });
+      window.__ELIZA_NOTIFICATION_FOLD_TRACE__.push({
+        t: performance.now() - startedAt,
+        group: groupRect
+          ? { top: groupRect.top, height: groupRect.height }
+          : null,
+        frontRow: frontRowRect
+          ? { top: frontRowRect.top, height: frontRowRect.height }
+          : null,
+        restControlTop: restControl?.getBoundingClientRect().top ?? null,
+        runningAnimations,
+        controls: controls
+          ? {
+              opacity: Number.parseFloat(getComputedStyle(controls).opacity),
+              duration: getComputedStyle(controls).transitionDuration,
+              timing: getComputedStyle(controls).transitionTimingFunction,
+            }
+          : null,
+        rows: rows.map((row) =>
+          Number.parseFloat(getComputedStyle(row).opacity),
+        ),
+        peeks: peeks.map((peek) =>
+          Number.parseFloat(getComputedStyle(peek).opacity),
+        ),
+        peekTops: peeks.map((peek) => peek.getBoundingClientRect().top),
+      });
+      if (performance.now() - startedAt < 760) requestAnimationFrame(sample);
+    };
+    const showLess = document.querySelector(
+      '[data-testid="notification-stack-collapse"]',
+    );
+    if (!(showLess instanceof HTMLButtonElement)) {
+      throw new Error("missing Show Less control");
+    }
+    showLess.click();
+    requestAnimationFrame(sample);
+  });
+  await notificationMotion.waitForTimeout(800);
+  const foldTrace = await notificationMotion.evaluate(
+    () => window.__ELIZA_NOTIFICATION_FOLD_TRACE__,
+  );
+  const mountedFoldFrames = foldTrace.filter((sample) => sample.controls);
+  const foldIntermediateControlOpacity = new Set(
+    mountedFoldFrames
+      .map((sample) => sample.controls.opacity)
+      .filter((opacity) => opacity > 0.05 && opacity < 0.95)
+      .map((opacity) => opacity.toFixed(2)),
+  );
+  const foldIntermediateRowOpacity = new Set(
+    mountedFoldFrames
+      .flatMap((sample) => sample.rows)
+      .filter((opacity) => opacity > 0.05 && opacity < 0.95)
+      .map((opacity) => opacity.toFixed(2)),
+  );
+  const foldIntermediatePeekOpacity = new Set(
+    mountedFoldFrames
+      .flatMap((sample) => sample.peeks)
+      .filter((opacity) => opacity > 0.05 && opacity < 0.95)
+      .map((opacity) => opacity.toFixed(2)),
+  );
+  assert(
+    mountedFoldFrames[0]?.controls.duration.includes("0.34s"),
+    `stack fold uses the 340ms settle (${mountedFoldFrames[0]?.controls.duration ?? "missing"})`,
+  );
+  const foldTimingFunctions = new Set(
+    (mountedFoldFrames[0]?.controls.timing ?? "")
+      .split(",")
+      .map((timing) => timing.trim())
+      .filter(Boolean),
+  );
+  assert(
+    foldTimingFunctions.size === 1 && foldTimingFunctions.has("ease"),
+    `stack fold geometry and opacity share one ease curve (${mountedFoldFrames[0]?.controls.timing ?? "missing"})`,
+  );
+  assert(
+    foldIntermediateControlOpacity.size >= 3 &&
+      foldIntermediateRowOpacity.size >= 3 &&
+      foldIntermediatePeekOpacity.size >= 3,
+    `stack fold produces intermediate control/row/peek frames (${foldIntermediateControlOpacity.size}/${foldIntermediateRowOpacity.size}/${foldIntermediatePeekOpacity.size})`,
+  );
+  assert(
+    mountedFoldFrames.every(
+      (sample, index) =>
+        index === 0 ||
+        sample.controls.opacity <=
+          mountedFoldFrames[index - 1].controls.opacity + 0.02,
+    ) &&
+      mountedFoldFrames.every(
+        (sample, index) =>
+          index === 0 ||
+          sample.group.height <= mountedFoldFrames[index - 1].group.height + 1,
+      ) &&
+      mountedFoldFrames.every(
+        (sample, index) =>
+          index === 0 ||
+          sample.peeks.every(
+            (opacity, peekIndex) =>
+              opacity + 0.02 >=
+              (mountedFoldFrames[index - 1].peeks[peekIndex] ?? opacity),
+          ),
+      ),
+    "stack fold geometry converges monotonically while its peeks return",
+  );
+  const settledFoldFrames = foldTrace.filter(
+    (sample) =>
+      sample.t >= 380 &&
+      !sample.controls &&
+      sample.group &&
+      sample.frontRow &&
+      sample.restControlTop !== null &&
+      sample.peekTops.length === 2,
+  );
+  const settledFoldAnchor = settledFoldFrames[0];
+  const foldTailDrift = settledFoldAnchor
+    ? Math.max(
+        ...settledFoldFrames.flatMap((sample) => [
+          Math.abs(sample.group.top - settledFoldAnchor.group.top),
+          Math.abs(sample.group.height - settledFoldAnchor.group.height),
+          Math.abs(sample.frontRow.top - settledFoldAnchor.frontRow.top),
+          Math.abs(sample.frontRow.height - settledFoldAnchor.frontRow.height),
+          Math.abs(
+            sample.restControlTop - settledFoldAnchor.restControlTop,
+          ),
+          ...sample.peekTops.map((top, index) =>
+            Math.abs(top - settledFoldAnchor.peekTops[index]),
+          ),
+        ]),
+      )
+    : Number.POSITIVE_INFINITY;
+  console.log(
+    `  [notification stack fold tail] frames=${settledFoldFrames.length} max-drift=${foldTailDrift.toFixed(2)}px`,
+  );
+  assert(
+    settledFoldFrames.length >= 20 &&
+      foldTailDrift <= 0.5 &&
+      settledFoldFrames.every(
+        (sample) => sample.runningAnimations.length === 0,
+      ),
+    `stack fold has no second-phase animation or layout tail after its 340ms settle (${settledFoldFrames.length} frames, ${foldTailDrift.toFixed(2)}px drift, ${JSON.stringify(settledFoldFrames.find((sample) => sample.runningAnimations.length > 0)?.runningAnimations ?? [])})`,
+  );
+  assert(
+    (await notificationCenter
+      .getByTestId("notification-stack-collapse")
+      .count()) === 0 &&
+      (await notificationCenter.getByTestId("notification-stack").count()) ===
+        1 &&
+      (await notificationCenter
+        .getByTestId("notification-stack-peek")
+        .count()) === 2,
+    "stack fold settles as one front card with two physical peeks",
+  );
+  await notificationCenter.getByTestId("notifications-collapse").click();
+  await notificationMotion.waitForTimeout(280);
+  assert(
+    (await notificationCenter
+      .getByTestId("home-notification-list")
+      .getAttribute("data-shade-mode")) === "rested",
+    "stack fold and collapse controls restore the rested shade",
+  );
+
+  const restedCountTop = (
+    await notificationCenter.getByTestId("notifications-count").boundingBox()
+  )?.y;
+  if (restedCountTop === undefined) {
+    throw new Error("missing cancelled-pull geometry");
+  }
+  const cancelledTouchPull = await touchDragHold(
+    notificationMotion,
+    '[data-testid="home-notification-list"]',
+    0,
+    48,
+    { steps: 6, stepDelayMs: 16 },
+  );
+  await notificationMotion.waitForTimeout(32);
+  const heldCountTop = (
+    await notificationCenter.getByTestId("notifications-count").boundingBox()
+  )?.y;
+  await notificationMotion.evaluate((restTop) => {
+    window.__ELIZA_NOTIFICATION_CANCEL_TRACE__ = [];
+    const startedAt = performance.now();
+    const sample = () => {
+      const count = document.querySelector('[data-testid="notifications-count"]');
+      const quietGroup = document.querySelector(
+        "[data-notification-pull-reveal]",
+      );
+      const clearSlot = document.querySelector(
+        "[data-notification-clear-slot]",
+      );
+      const clearButton = document.querySelector(
+        '[data-testid="notifications-clear-all"]',
+      );
+      const collapseFooter = document.querySelector(
+        "[data-notification-collapse-footer]",
+      );
+      if (count) {
+        window.__ELIZA_NOTIFICATION_CANCEL_TRACE__.push({
+          t: performance.now() - startedAt,
+          offset: count.getBoundingClientRect().top - restTop,
+          quietOpacity: quietGroup
+            ? Number.parseFloat(getComputedStyle(quietGroup).opacity)
+            : null,
+          clearMounted: Boolean(clearButton),
+          clearOpacity: clearSlot
+            ? Number.parseFloat(getComputedStyle(clearSlot).opacity)
+            : null,
+          collapseMounted: Boolean(collapseFooter),
+          collapseOpacity: collapseFooter
+            ? Number.parseFloat(getComputedStyle(collapseFooter).opacity)
+            : null,
+        });
+      }
+      if (performance.now() - startedAt < 430) requestAnimationFrame(sample);
+    };
+    requestAnimationFrame(sample);
+  }, restedCountTop);
+  const heldDirectManipulation = await notificationMotion.evaluate(() => {
+    const quietGroup = document.querySelector(
+      "[data-notification-pull-reveal]",
+    );
+    const collapseFooter = document.querySelector(
+      "[data-notification-collapse-footer]",
+    );
+    return {
+      quietDuration: quietGroup
+        ? getComputedStyle(quietGroup).transitionDuration
+        : "missing",
+      collapseDuration: collapseFooter
+        ? getComputedStyle(collapseFooter).transitionDuration
+        : "missing",
+    };
+  });
+  assert(
+    heldDirectManipulation.quietDuration === "0s" &&
+      heldDirectManipulation.collapseDuration === "0s",
+    `active pull surfaces track the pointer without easing (${JSON.stringify(heldDirectManipulation)})`,
+  );
+  await cancelledTouchPull.release();
+  const cancelStyle = await notificationMotion.evaluate(() => {
+    const center = document.querySelector(
+      '[data-testid="home-notification-center"]',
+    );
+    const count = document.querySelector('[data-testid="notifications-count"]');
+    const quietGroup = document.querySelector(
+      "[data-notification-pull-reveal]",
+    );
+    const clearButton = document.querySelector(
+      '[data-testid="notifications-clear-all"]',
+    );
+    const collapseFooter = document.querySelector(
+      "[data-notification-collapse-footer]",
+    );
+    return {
+      active: center?.hasAttribute("data-notification-shade-cancelling"),
+      duration: count ? getComputedStyle(count).transitionDuration : "",
+      quietMounted: Boolean(quietGroup),
+      quietDuration: quietGroup
+        ? getComputedStyle(quietGroup).transitionDuration
+        : "",
+      clearMounted: Boolean(clearButton),
+      collapseMounted: Boolean(collapseFooter),
+      collapseDuration: collapseFooter
+        ? getComputedStyle(collapseFooter).transitionDuration
+        : "",
+    };
+  });
+  await notificationMotion.waitForTimeout(450);
+  const cancelTrace = await notificationMotion.evaluate(
+    () => window.__ELIZA_NOTIFICATION_CANCEL_TRACE__,
+  );
+  const heldOffset = (heldCountTop ?? restedCountTop) - restedCountTop;
+  const cancelAt100 = cancelTrace.find((sample) => sample.t >= 100);
+  assert(
+    cancelStyle.active &&
+      cancelStyle.duration.includes("0.34s") &&
+      cancelStyle.quietMounted &&
+      cancelStyle.quietDuration.includes("0.34s") &&
+      cancelStyle.clearMounted &&
+      cancelStyle.collapseMounted &&
+      cancelStyle.collapseDuration.includes("0.34s"),
+    `cancelled pull keeps every preview surface on the softer 340ms settle (${JSON.stringify(cancelStyle)})`,
+  );
+  assert(
+    Math.abs(cancelAt100?.offset ?? 0) > Math.abs(heldOffset) * 0.1,
+    "cancelled pull remains visibly in flight after 100ms",
+  );
+  assert(
+    (cancelAt100?.quietOpacity ?? 0) > 0.01 &&
+      cancelAt100?.clearMounted === true &&
+      (cancelAt100?.clearOpacity ?? 0) > 0.01 &&
+      cancelAt100?.collapseMounted === true &&
+      (cancelAt100?.collapseOpacity ?? 0) > 0.01,
+    "quiet group, clear control, and collapse footer remain visibly in flight after 100ms",
+  );
+  assert(
+    Math.abs(cancelTrace.at(-1)?.offset ?? Number.POSITIVE_INFINITY) < 0.75,
+    "cancelled pull settles exactly back at rest",
+  );
+  assert(
+    cancelTrace.at(-1)?.quietOpacity === null &&
+      cancelTrace.at(-1)?.clearMounted === false &&
+      cancelTrace.at(-1)?.collapseMounted === false,
+    "cancelled pull unmounts preview-only surfaces only after the settle completes",
+  );
+
+  await notificationMotion.emulateMedia({ reducedMotion: "reduce" });
+  await notificationMotion.waitForFunction(() =>
+    document
+      .querySelector('[data-testid="home-notification-center"]')
+      ?.hasAttribute("data-notification-reduced-motion"),
+  );
+  const reducedCountButton = notificationCenter.getByTestId(
+    "notifications-count-button",
+  );
+  await reducedCountButton.focus();
+  await notificationMotion.keyboard.press("Enter");
+  const reducedOpen = await notificationMotion.evaluate(() => {
+    const center = document.querySelector(
+      '[data-testid="home-notification-center"]',
+    );
+    const list = document.querySelector(
+      '[data-testid="home-notification-list"]',
+    );
+    const group = document.querySelector(
+      "[data-notification-group-content]",
+    );
+    const count = document.querySelector('[data-testid="notifications-count"]');
+    return {
+      mode: list?.getAttribute("data-shade-mode"),
+      groupOpacity: group
+        ? Number.parseFloat(getComputedStyle(group).opacity)
+        : -1,
+      groupDuration: group ? getComputedStyle(group).transitionDuration : "",
+      countHeight: count?.getBoundingClientRect().height ?? -1,
+      countDuration: count ? getComputedStyle(count).transitionDuration : "",
+      activeTestId: document.activeElement?.getAttribute("data-testid"),
+      materialRunningAnimations:
+        center instanceof Element
+          ? center
+              .getAnimations({ subtree: true })
+              .filter((animation) => {
+                const duration = animation.effect?.getComputedTiming().duration;
+                return (
+                  animation.playState === "running" &&
+                  typeof duration === "number" &&
+                  duration > 16
+                );
+              })
+              .map((animation) => {
+                const effect = animation.effect;
+                const target =
+                  effect instanceof KeyframeEffect ? effect.target : null;
+                return {
+                  duration: effect?.getComputedTiming().duration,
+                  name:
+                    "animationName" in animation
+                      ? animation.animationName
+                      : undefined,
+                  property:
+                    "transitionProperty" in animation
+                      ? animation.transitionProperty
+                      : undefined,
+                  target:
+                    target instanceof Element
+                      ? target.getAttribute("data-testid") || target.className
+                      : null,
+                };
+              })
+          : [],
+    };
+  });
+  assert(
+    reducedOpen.mode === "expanded" &&
+      reducedOpen.groupOpacity >= 0.98 &&
+      reducedOpen.countHeight < 0.75 &&
+      reducedOpen.groupDuration === "0s" &&
+      reducedOpen.countDuration === "0s" &&
+      reducedOpen.activeTestId === "notification-row" &&
+      reducedOpen.materialRunningAnimations.length === 0,
+    `reduced-motion click-open is immediate and hands keyboard focus to the first row (${JSON.stringify(reducedOpen)})`,
+  );
+  await notificationMotion.keyboard.press("Enter");
+  const reducedFan = await notificationMotion.evaluate(() => {
+    const center = document.querySelector(
+      '[data-testid="home-notification-center"]',
+    );
+    const controls = document.querySelector(
+      '[data-testid="notification-stack-controls"]',
+    );
+    const peeks = Array.from(
+      document.querySelectorAll("[data-notification-stack-peek]"),
+    );
+    return {
+      controlsHeight: controls?.getBoundingClientRect().height ?? -1,
+      controlsOpacity: controls
+        ? Number.parseFloat(getComputedStyle(controls).opacity)
+        : -1,
+      controlsDuration: controls
+        ? getComputedStyle(controls).transitionDuration
+        : "",
+      peekOpacities: peeks.map((peek) =>
+        Number.parseFloat(getComputedStyle(peek).opacity),
+      ),
+      activeTestId: document.activeElement?.getAttribute("data-testid"),
+      materialRunningAnimations:
+        center instanceof Element
+          ? center
+              .getAnimations({ subtree: true })
+              .filter((animation) => {
+                const duration = animation.effect?.getComputedTiming().duration;
+                return (
+                  animation.playState === "running" &&
+                  typeof duration === "number" &&
+                  duration > 16
+                );
+              })
+              .map((animation) => {
+                const effect = animation.effect;
+                const target =
+                  effect instanceof KeyframeEffect ? effect.target : null;
+                return {
+                  duration: effect?.getComputedTiming().duration,
+                  name:
+                    "animationName" in animation
+                      ? animation.animationName
+                      : undefined,
+                  property:
+                    "transitionProperty" in animation
+                      ? animation.transitionProperty
+                      : undefined,
+                  target:
+                    target instanceof Element
+                      ? target.getAttribute("data-testid") || target.className
+                      : null,
+                };
+              })
+          : [],
+    };
+  });
+  assert(
+    reducedFan.controlsHeight > 35 &&
+      reducedFan.controlsOpacity >= 0.98 &&
+      reducedFan.controlsDuration === "0s" &&
+      reducedFan.peekOpacities.length === 2 &&
+      reducedFan.peekOpacities.every((opacity) => opacity <= 0.02) &&
+      reducedFan.activeTestId === "notification-stack-collapse" &&
+      reducedFan.materialRunningAnimations.length === 0,
+    `reduced-motion stack fan is immediate and hands focus to Show Less (${JSON.stringify(reducedFan)})`,
+  );
+  await notificationMotion.keyboard.press("Enter");
+  const reducedFold = await notificationMotion.evaluate(() => ({
+    mode: document
+      .querySelector('[data-testid="home-notification-list"]')
+      ?.getAttribute("data-shade-mode"),
+    stackControls: document.querySelectorAll(
+      '[data-testid="notification-stack-controls"]',
+    ).length,
+    activeTestId: document.activeElement?.getAttribute("data-testid"),
+  }));
+  assert(
+    reducedFold.mode === "expanded" &&
+      reducedFold.stackControls === 0 &&
+      reducedFold.activeTestId === "notification-row",
+    `reduced-motion stack fold immediately returns focus to its top row (${JSON.stringify(reducedFold)})`,
+  );
+  const reducedCollapse = notificationCenter.getByTestId(
+    "notifications-collapse",
+  );
+  await reducedCollapse.focus();
+  await notificationMotion.keyboard.press("Enter");
+  const reducedClose = await notificationMotion.evaluate(() => {
+    const list = document.querySelector(
+      '[data-testid="home-notification-list"]',
+    );
+    const count = document.querySelector('[data-testid="notifications-count"]');
+    const countButton = document.querySelector(
+      '[data-testid="notifications-count-button"]',
+    );
+    return {
+      mode: list?.getAttribute("data-shade-mode"),
+      countHeight: count?.getBoundingClientRect().height ?? -1,
+      expanded: countButton?.getAttribute("aria-expanded"),
+      collapseControls: document.querySelectorAll(
+        '[data-testid="notifications-collapse"]',
+      ).length,
+      activeTestId: document.activeElement?.getAttribute("data-testid"),
+    };
+  });
+  assert(
+    reducedClose.mode === "rested" &&
+      reducedClose.countHeight > 31 &&
+      reducedClose.expanded === "false" &&
+      reducedClose.collapseControls === 0 &&
+      reducedClose.activeTestId === "notifications-count-button",
+    `reduced-motion collapse commits DOM, ARIA, and reverse focus immediately (${JSON.stringify(reducedClose)})`,
+  );
+  await touchSwipe(
+    notificationMotion,
+    '[data-testid="home-notification-list"]',
+    0,
+    48,
+    {
+    steps: 6,
+      stepDelayMs: 8,
+    },
+  );
+  const reducedCancel = await notificationMotion.evaluate(() => ({
+    mode: document
+      .querySelector('[data-testid="home-notification-list"]')
+      ?.getAttribute("data-shade-mode"),
+    cancelling: document
+      .querySelector('[data-testid="home-notification-center"]')
+      ?.hasAttribute("data-notification-shade-cancelling"),
+    previewGroups: document.querySelectorAll(
+      "[data-notification-pull-reveal]",
+    ).length,
+    clearControls: document.querySelectorAll(
+      '[data-testid="notifications-clear-all"]',
+    ).length,
+    collapseControls: document.querySelectorAll(
+      '[data-testid="notifications-collapse"]',
+    ).length,
+  }));
+  assert(
+    reducedCancel.mode === "rested" &&
+      reducedCancel.cancelling === false &&
+      reducedCancel.previewGroups === 0 &&
+      reducedCancel.clearControls === 0 &&
+      reducedCancel.collapseControls === 0,
+    `reduced-motion short pull resets preview DOM immediately (${JSON.stringify(reducedCancel)})`,
+  );
+  await notificationMotion.emulateMedia({ reducedMotion: "no-preference" });
+  await notificationMotion.waitForFunction(
+    () =>
+      !document
+        .querySelector('[data-testid="home-notification-center"]')
+        ?.hasAttribute("data-notification-reduced-motion"),
+  );
+  await notificationMotion.close();
+  await notificationMotionContext.close();
 
   // Measure the rail in a dedicated non-recording context. Video encoding is
   // intentionally excluded from the frame budget: the product never performs

--- a/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
@@ -1492,7 +1492,7 @@ try {
     steps: 12,
   });
   await notificationMotion.mouse.up();
-  await notificationMotion.waitForTimeout(280);
+  await notificationMotion.waitForTimeout(360);
   assert(
     (await notificationCenter
       .getByTestId("home-notification-list")
@@ -1515,7 +1515,7 @@ try {
     -160,
     { steps: 12, stepDelayMs: 12 },
   );
-  await notificationMotion.waitForTimeout(280);
+  await notificationMotion.waitForTimeout(360);
   assert(
     (await notificationCenter
       .getByTestId("home-notification-list")
@@ -1777,13 +1777,15 @@ try {
     `stack fold uses the 340ms settle (${mountedFoldFrames[0]?.controls.duration ?? "missing"})`,
   );
   const foldTimingFunctions = new Set(
-    (mountedFoldFrames[0]?.controls.timing ?? "")
-      .split(",")
+    ((mountedFoldFrames[0]?.controls.timing ?? "").match(
+      /cubic-bezier\([^)]*\)|[^,]+/g,
+    ) ?? [])
       .map((timing) => timing.trim())
       .filter(Boolean),
   );
   assert(
-    foldTimingFunctions.size === 1 && foldTimingFunctions.has("ease"),
+    foldTimingFunctions.size === 1 &&
+      foldTimingFunctions.has("cubic-bezier(0.25, 0.1, 0.25, 1)"),
     `stack fold geometry and opacity share one ease curve (${mountedFoldFrames[0]?.controls.timing ?? "missing"})`,
   );
   assert(

--- a/packages/ui/src/components/shell/notification-shade-content.tsx
+++ b/packages/ui/src/components/shell/notification-shade-content.tsx
@@ -18,6 +18,7 @@ import { notificationPullRevealStyle } from "./notification-shade-presentation";
 import { RelativeTime } from "./RelativeTime";
 
 const SWIPE_DISMISS_PX = 88;
+const STACK_PEEK_LAYERS = ["near", "far"] as const;
 
 /** Stable shade order: priority, recency, then id as a total tiebreak. */
 export function orderDashboardNotifications(
@@ -123,9 +124,11 @@ export function ClearConfirmationContent({
 
 function NotificationSourceIcon({
   count,
+  countVisibility = 1,
   source,
 }: {
   count?: number;
+  countVisibility?: number;
   source: string;
 }): JSX.Element {
   const meta = getChatSourceMeta(source);
@@ -157,8 +160,10 @@ function NotificationSourceIcon({
       {count && count > 1 ? (
         <span
           data-testid="notification-source-count"
+          data-notification-source-count=""
           aria-hidden
-          className="absolute -right-2 -top-2 flex h-5 min-w-5 items-center justify-center rounded-full bg-white/90 px-1.5 text-center text-[11px] font-semibold leading-none tabular-nums text-black shadow-[0_0_0_2px_rgba(0,0,0,0.7),0_1px_4px_rgba(0,0,0,0.45)]"
+          style={{ opacity: countVisibility }}
+          className="eliza-notif-shade-transition absolute -right-2 -top-2 flex h-5 min-w-5 items-center justify-center rounded-full bg-white/90 px-1.5 text-center text-[11px] font-semibold leading-none tabular-nums text-black shadow-[0_0_0_2px_rgba(0,0,0,0.7),0_1px_4px_rgba(0,0,0,0.45)]"
         >
           {count > 99 ? "99+" : count}
         </span>
@@ -171,9 +176,22 @@ export interface NotificationRowProps {
   notification: AgentNotification;
   stackKey?: string;
   stackCount?: number;
+  stackCountVisibility?: number;
+  stackPeeks?: {
+    count: number;
+    disabled: boolean;
+    expansionProgress: number;
+    fanned: boolean;
+    groupLabel: string;
+    mode: "close" | "static" | "disposable";
+    openOffsetsPx?: readonly number[];
+    testIdVisible: boolean;
+    totalCount: number;
+    visibility: number;
+  };
   pullRevealProgress?: number;
   shadeVisibility?: number;
-  onExpandStack?: (key: string) => void;
+  onExpandStack?: (key: string, moveFocus: boolean) => void;
   onOpen: (notification: AgentNotification) => void;
   onDismiss: (id: string) => void;
 }
@@ -192,6 +210,21 @@ export function rowPropsEqual(
     a.source === b.source &&
     previous.stackKey === next.stackKey &&
     previous.stackCount === next.stackCount &&
+    previous.stackCountVisibility === next.stackCountVisibility &&
+    previous.stackPeeks?.count === next.stackPeeks?.count &&
+    previous.stackPeeks?.disabled === next.stackPeeks?.disabled &&
+    previous.stackPeeks?.expansionProgress ===
+      next.stackPeeks?.expansionProgress &&
+    previous.stackPeeks?.fanned === next.stackPeeks?.fanned &&
+    previous.stackPeeks?.groupLabel === next.stackPeeks?.groupLabel &&
+    previous.stackPeeks?.mode === next.stackPeeks?.mode &&
+    previous.stackPeeks?.openOffsetsPx?.[0] ===
+      next.stackPeeks?.openOffsetsPx?.[0] &&
+    previous.stackPeeks?.openOffsetsPx?.[1] ===
+      next.stackPeeks?.openOffsetsPx?.[1] &&
+    previous.stackPeeks?.testIdVisible === next.stackPeeks?.testIdVisible &&
+    previous.stackPeeks?.totalCount === next.stackPeeks?.totalCount &&
+    previous.stackPeeks?.visibility === next.stackPeeks?.visibility &&
     previous.pullRevealProgress === next.pullRevealProgress &&
     previous.shadeVisibility === next.shadeVisibility &&
     previous.onExpandStack === next.onExpandStack &&
@@ -213,6 +246,8 @@ export const NotificationRow = memo(function NotificationRow({
   notification,
   stackKey,
   stackCount,
+  stackCountVisibility,
+  stackPeeks,
   pullRevealProgress,
   shadeVisibility,
   onExpandStack,
@@ -291,7 +326,7 @@ export const NotificationRow = memo(function NotificationRow({
   return (
     <li
       className={cn(
-        "eliza-notif-row relative",
+        "eliza-notif-row relative isolate",
         pullRevealProgress !== undefined &&
           "eliza-notif-pull-reveal pointer-events-none",
         shadeVisibility !== undefined && "eliza-notif-shade-transition grid",
@@ -337,7 +372,7 @@ export const NotificationRow = memo(function NotificationRow({
         onPointerMove={onPointerMove}
         onPointerUp={onPointerEnd}
         onPointerCancel={onPointerEnd}
-        className="eliza-notif-row-inner eliza-notif-glass group relative flex min-h-0 flex-col overflow-hidden rounded-2xl"
+        className="eliza-notif-row-inner eliza-notif-glass group relative z-[2] flex min-h-0 flex-col overflow-hidden rounded-2xl"
       >
         <button
           type="button"
@@ -355,14 +390,16 @@ export const NotificationRow = memo(function NotificationRow({
               event.preventDefault();
               return;
             }
-            if (stackKey && onExpandStack) onExpandStack(stackKey);
-            else onOpen(notification);
+            if (stackKey && onExpandStack) {
+              onExpandStack(stackKey, event.detail === 0);
+            } else onOpen(notification);
           }}
           className="flex min-h-touch min-w-0 items-center gap-3 rounded-2xl px-3 py-2 text-left active:scale-[0.99] motion-reduce:active:scale-100"
         >
           <NotificationSourceIcon
             source={notification.source}
             count={stackCount}
+            countVisibility={stackCountVisibility}
           />
           <span className="flex min-w-0 flex-1 flex-col gap-0.5">
             <span className="flex items-baseline gap-1.5">
@@ -384,6 +421,56 @@ export const NotificationRow = memo(function NotificationRow({
           </span>
         </button>
       </div>
+      {stackPeeks
+        ? STACK_PEEK_LAYERS.slice(0, stackPeeks.count).map((layer, index) => {
+            const collapsedOffsetPx = (index + 1) * 7;
+            const openOffsetPx =
+              stackPeeks.openOffsetsPx?.[index] ?? (index + 1) * 44;
+            const offsetPx =
+              collapsedOffsetPx +
+              (openOffsetPx - collapsedOffsetPx) * stackPeeks.expansionProgress;
+            return (
+              <button
+                key={`${notification.id}-stack-peek-${layer}`}
+                type="button"
+                data-testid={
+                  stackPeeks.testIdVisible
+                    ? "notification-stack-peek"
+                    : undefined
+                }
+                data-notif-control=""
+                data-notification-stack-peek=""
+                data-notification-peek-mode={stackPeeks.mode}
+                disabled={stackPeeks.disabled}
+                tabIndex={
+                  stackPeeks.disabled || stackPeeks.visibility < 1
+                    ? -1
+                    : undefined
+                }
+                aria-hidden={
+                  stackPeeks.disabled || stackPeeks.visibility === 0
+                    ? true
+                    : undefined
+                }
+                aria-label={`Show all ${stackPeeks.totalCount} ${stackPeeks.groupLabel} notifications`}
+                onClick={(event) => {
+                  if (stackKey && onExpandStack) {
+                    onExpandStack(stackKey, event.detail === 0);
+                  }
+                }}
+                className={cn(
+                  "eliza-notif-glass eliza-notif-stack-peek eliza-notif-shade-transition absolute inset-0 rounded-2xl",
+                  stackPeeks.fanned && "pointer-events-none",
+                )}
+                style={{
+                  zIndex: 1 - index,
+                  opacity: stackPeeks.visibility,
+                  transform: `translateY(${offsetPx}px) scale(${1 - (index + 1) * 0.015})`,
+                }}
+              />
+            );
+          })
+        : null}
     </li>
   );
 }, rowPropsEqual);

--- a/packages/ui/src/components/shell/notification-shade-presentation.ts
+++ b/packages/ui/src/components/shell/notification-shade-presentation.ts
@@ -4,16 +4,20 @@
  * groups remains smooth while React remains authoritative for settled states.
  */
 import type { CSSProperties } from "react";
+import { rubberBand } from "../../gestures/recognizers";
 
-/** Dampened pull travel that commits a shade mode change on release. */
-export const PULL_COMMIT_PX = 48;
+/** Full visual travel between the shade's rested and expanded detents. */
+export const PULL_TRAVEL_PX = 88;
+
+/** A slow drag commits at the same halfway point as the home pager. */
+export const PULL_COMMIT_PX = PULL_TRAVEL_PX / 2;
 
 /** Dead zone before a vertical drag starts reading as a pull. */
 export const PULL_SLOP_PX = 8;
 
-/** Rubber-band raw overscroll into the travel rendered by the shade. */
+/** Track the finger directly between detents, resisting only past the end. */
 export function dampenPull(rawDy: number): number {
-  return Math.min(Math.max(0, rawDy - PULL_SLOP_PX) * 0.5, 88);
+  return rubberBand(Math.max(0, rawDy - PULL_SLOP_PX), PULL_TRAVEL_PX, 0.35);
 }
 
 /** Convert live pull travel into a staggered reveal for hidden groups. */
@@ -21,7 +25,7 @@ export function notificationPullRevealProgress(
   pullPx: number,
   groupIndex: number,
 ): number {
-  const progress = Math.min(1, Math.max(0, pullPx / PULL_COMMIT_PX));
+  const progress = Math.min(1, Math.max(0, pullPx / PULL_TRAVEL_PX));
   const stagger = Math.min(Math.max(groupIndex, 0), 4) * 0.06;
   return Math.min(1, Math.max(0, (progress - stagger) / (1 - stagger)));
 }
@@ -48,17 +52,30 @@ export function notificationPullPresentation(
     committedCloseProgress,
   );
   const disposableContentVisibility = 1 - shadeCloseProgress;
+  const pullRevealProgress = notificationPullRevealProgress(pullPx, 0);
   const pullContentVisibility = shadeExpanded
     ? disposableContentVisibility
-    : notificationPullRevealProgress(pullPx, 0);
+    : pullRevealProgress;
+  // The count follows the same continuous travel as the cards but stays much
+  // dimmer while their surfaces overlap. This reads as a fade beneath the
+  // stack without either a hard clipping edge or legible text through glass.
   const notificationCountVisibility = shadeExpanded
-    ? shadeCloseProgress
-    : 1 - notificationPullRevealProgress(pullPx, 0);
+    ? shadeCloseProgress ** 3
+    : (1 - pullRevealProgress) ** 3;
   const clearControlVisibility = shadeExpanded
     ? disposableContentVisibility
     : pullPx > 0
-      ? notificationPullRevealProgress(pullPx, 0)
+      ? pullRevealProgress
       : 0;
+  // The clear-control slot reserves its full row as soon as a drag starts so
+  // notification groups can mount without reflowing under the finger. The
+  // count follows that slot in document flow, so it needs the same inverse
+  // offset as the groups or its first drag frame jumps by the full 40px row.
+  const notificationCountOffset = notificationGroupContainerOffset(
+    pullPx,
+    shadeExpanded,
+    shadeClosing,
+  );
 
   return {
     shadeCloseProgress,
@@ -66,16 +83,19 @@ export function notificationPullPresentation(
     disposableContentVisibility,
     pullContentVisibility,
     notificationCountVisibility,
+    notificationCountOffset,
     notificationCountLayoutVisibility:
       shadeExpanded && pullPx < 0 && !shadeClosing
         ? 1
-        : notificationCountVisibility,
+        : shadeExpanded
+          ? shadeCloseProgress
+          : 1 - pullRevealProgress,
     emptyStateVisibility: shadeExpanded
       ? disposableContentVisibility
       : notificationPullRevealProgress(pullPx, 0),
     collapseControlVisibility: shadeExpanded
       ? disposableContentVisibility
-      : notificationPullRevealProgress(pullPx, 0),
+      : pullRevealProgress,
     clearControlVisibility,
     clearControlLayoutVisibility: shadeExpanded
       ? shadeClosing || pullPx < 0
@@ -127,7 +147,7 @@ export function notificationGroupPullVisibility(
   }
   if (shadeClosing) return 0;
   if (shadeExpanded && pullPx < 0) {
-    return notificationPullRevealProgress(PULL_COMMIT_PX + pullPx, groupIndex);
+    return notificationPullRevealProgress(PULL_TRAVEL_PX + pullPx, groupIndex);
   }
   return 1;
 }
@@ -143,19 +163,20 @@ export function applyNotificationPullPresentation(
   shadeClosing: boolean,
   visibleGroups?: readonly HTMLElement[],
 ): void {
+  const count = root?.querySelector<HTMLElement>(
+    "[data-notification-count-slot]",
+  );
   if (!root) return;
   const presentation = notificationPullPresentation(
     pullPx,
     shadeExpanded,
     shadeClosing,
   );
-  const count = root.querySelector<HTMLElement>(
-    "[data-notification-count-slot]",
-  );
   if (count) {
     count.style.height = `${presentation.notificationCountLayoutVisibility * 32}px`;
     count.style.marginBottom = `${(presentation.notificationCountLayoutVisibility - 1) * 8}px`;
     count.style.opacity = String(presentation.notificationCountVisibility);
+    count.style.transform = `translate3d(0, ${presentation.notificationCountOffset}px, 0)`;
   }
   const clearSlot = root.querySelector<HTMLElement>(
     "[data-notification-clear-slot]",
@@ -238,11 +259,6 @@ export function applyNotificationPullPresentation(
         const tailPx =
           restedTailPx + (expandedTailPx - restedTailPx) * tailProgress;
         content.style.paddingBottom = `${tailPx}px`;
-        for (const peek of content.querySelectorAll<HTMLElement>(
-          "[data-notification-stack-peek]",
-        )) {
-          peek.style.bottom = `${tailPx}px`;
-        }
       }
     }
     const controls = group.querySelector<HTMLElement>(

--- a/packages/ui/src/components/shell/notification-shade-presentation.ts
+++ b/packages/ui/src/components/shell/notification-shade-presentation.ts
@@ -95,6 +95,7 @@ export function notificationPullPresentation(
     notificationCountVisibility,
     notificationCountOffset,
     pullOvershootOffset,
+    collapseControlOvershootOffset: Math.min(0, pullOvershootOffset),
     notificationCountLayoutVisibility:
       shadeExpanded && pullPx < 0 && !shadeClosing
         ? 1
@@ -183,6 +184,13 @@ export function applyNotificationPullPresentation(
     shadeExpanded,
     shadeClosing,
   );
+  const scrollport = root.querySelector<HTMLElement>(
+    "[data-testid='home-notification-list']",
+  );
+  scrollport?.style.setProperty(
+    "--eliza-notif-pull-overshoot",
+    `${Math.max(0, presentation.pullOvershootOffset)}px`,
+  );
   if (count) {
     count.style.height = `${presentation.notificationCountLayoutVisibility * 32}px`;
     count.style.marginBottom = `${(presentation.notificationCountLayoutVisibility - 1) * 8}px`;
@@ -220,7 +228,7 @@ export function applyNotificationPullPresentation(
     collapse.style.opacity = String(presentation.collapseControlVisibility);
     collapse.style.transform = `translateY(${
       (1 - presentation.collapseControlVisibility) * 4 +
-      presentation.pullOvershootOffset
+      presentation.collapseControlOvershootOffset
     }px)`;
   }
   const groups =

--- a/packages/ui/src/components/shell/notification-shade-presentation.ts
+++ b/packages/ui/src/components/shell/notification-shade-presentation.ts
@@ -20,6 +20,12 @@ export function dampenPull(rawDy: number): number {
   return rubberBand(Math.max(0, rawDy - PULL_SLOP_PX), PULL_TRAVEL_PX, 0.35);
 }
 
+/** Preserve the resisted travel past either detent as visible elastic give. */
+export function notificationPullOvershootOffset(pullPx: number): number {
+  const overshoot = Math.max(0, Math.abs(pullPx) - PULL_TRAVEL_PX);
+  return Math.sign(pullPx) * overshoot;
+}
+
 /** Convert live pull travel into a staggered reveal for hidden groups. */
 export function notificationPullRevealProgress(
   pullPx: number,
@@ -30,10 +36,13 @@ export function notificationPullRevealProgress(
   return Math.min(1, Math.max(0, (progress - stagger) / (1 - stagger)));
 }
 
-export function notificationPullRevealStyle(progress: number): CSSProperties {
+export function notificationPullRevealStyle(
+  progress: number,
+  offsetPx = 0,
+): CSSProperties {
   return {
     opacity: progress,
-    transform: `translate3d(0, ${(1 - progress) * -8}px, 0)`,
+    transform: `translate3d(0, ${(1 - progress) * -8 + offsetPx}px, 0)`,
   };
 }
 
@@ -76,6 +85,7 @@ export function notificationPullPresentation(
     shadeExpanded,
     shadeClosing,
   );
+  const pullOvershootOffset = notificationPullOvershootOffset(pullPx);
 
   return {
     shadeCloseProgress,
@@ -84,6 +94,7 @@ export function notificationPullPresentation(
     pullContentVisibility,
     notificationCountVisibility,
     notificationCountOffset,
+    pullOvershootOffset,
     notificationCountLayoutVisibility:
       shadeExpanded && pullPx < 0 && !shadeClosing
         ? 1
@@ -176,7 +187,9 @@ export function applyNotificationPullPresentation(
     count.style.height = `${presentation.notificationCountLayoutVisibility * 32}px`;
     count.style.marginBottom = `${(presentation.notificationCountLayoutVisibility - 1) * 8}px`;
     count.style.opacity = String(presentation.notificationCountVisibility);
-    count.style.transform = `translate3d(0, ${presentation.notificationCountOffset}px, 0)`;
+    count.style.transform = `translate3d(0, ${
+      presentation.notificationCountOffset + presentation.pullOvershootOffset
+    }px, 0)`;
   }
   const clearSlot = root.querySelector<HTMLElement>(
     "[data-notification-clear-slot]",
@@ -185,13 +198,19 @@ export function applyNotificationPullPresentation(
     clearSlot.style.height = `${presentation.clearControlLayoutVisibility * 32}px`;
     clearSlot.style.marginBottom = `${(presentation.clearControlLayoutVisibility - 1) * 8}px`;
     clearSlot.style.opacity = String(presentation.clearControlVisibility);
-    clearSlot.style.transform = `translate3d(0, ${(1 - presentation.clearControlVisibility) * -8}px, 0)`;
+    clearSlot.style.transform = `translate3d(0, ${
+      (1 - presentation.clearControlVisibility) * -8 +
+      presentation.pullOvershootOffset
+    }px, 0)`;
   }
   const empty = root.querySelector<HTMLElement>("[data-notification-empty]");
   if (empty) {
     Object.assign(
       empty.style,
-      notificationPullRevealStyle(presentation.emptyStateVisibility),
+      notificationPullRevealStyle(
+        presentation.emptyStateVisibility,
+        presentation.pullOvershootOffset,
+      ),
     );
   }
   const collapse = root.querySelector<HTMLElement>(
@@ -199,7 +218,10 @@ export function applyNotificationPullPresentation(
   );
   if (collapse) {
     collapse.style.opacity = String(presentation.collapseControlVisibility);
-    collapse.style.transform = `translateY(${(1 - presentation.collapseControlVisibility) * 4}px)`;
+    collapse.style.transform = `translateY(${
+      (1 - presentation.collapseControlVisibility) * 4 +
+      presentation.pullOvershootOffset
+    }px)`;
   }
   const groups =
     visibleGroups ??
@@ -219,41 +241,36 @@ export function applyNotificationPullPresentation(
       shadeExpanded,
       shadeClosing,
     );
-    group.style.transform = `translate3d(0, ${
-      containerOffset + (pullRevealed ? (1 - groupVisibility) * -8 : 0)
-    }px, 0)`;
-    if (pullRevealed) group.style.opacity = String(groupVisibility);
-    if (
-      !pullRevealed &&
-      !group.hasAttribute("data-rested-notification-group")
-    ) {
-      const content = group.querySelector<HTMLElement>(
-        ":scope > [data-notification-group-content]",
-      );
-      if (content) {
-        content.style.opacity = String(groupVisibility);
-        content.style.transform = `translate3d(0, ${notificationGroupPullOffset(
-          pullPx,
-          shadeExpanded,
-          shadeClosing,
-          groupVisibility,
-        )}px, 0)`;
-      }
+    const rested = group.hasAttribute("data-rested-notification-group");
+    const content = group.querySelector<HTMLElement>(
+      ":scope > [data-notification-group-content]",
+    );
+    if (content) {
+      const contentVisibility = pullRevealed || !rested ? groupVisibility : 1;
+      const contentPullOffset = pullRevealed
+        ? (1 - groupVisibility) * -8
+        : rested
+          ? 0
+          : notificationGroupPullOffset(
+              pullPx,
+              shadeExpanded,
+              shadeClosing,
+              groupVisibility,
+            );
+      content.style.opacity = String(contentVisibility);
+      content.style.transform = `translate3d(0, ${
+        containerOffset + contentPullOffset + presentation.pullOvershootOffset
+      }px, 0)`;
     }
     if (!shadeExpanded && pullPx > 0) {
-      const content = group.querySelector<HTMLElement>(
-        ":scope > [data-notification-group-content][data-notification-stacked]",
-      );
-      if (content) {
+      if (content?.hasAttribute("data-notification-stacked")) {
         const restedTailPx = Number(
           content.dataset.notificationRestedTailPx ?? 0,
         );
         const expandedTailPx = Number(
           content.dataset.notificationExpandedTailPx ?? restedTailPx,
         );
-        const tailProgress = group.hasAttribute(
-          "data-rested-notification-group",
-        )
+        const tailProgress = rested
           ? notificationPullRevealProgress(pullPx, groupIndex)
           : 1;
         const tailPx =

--- a/packages/ui/src/gestures/index.ts
+++ b/packages/ui/src/gestures/index.ts
@@ -1,9 +1,10 @@
 /**
- * Barrel for the pointer-gesture utilities (recognizers, press-and-hold, click
- * suppression, raf coalescing).
+ * Barrel for the pointer-gesture utilities (recognizers, momentum, press-and-
+ * hold, click suppression, raf coalescing).
  */
 export * from "./constants";
 export * from "./lost-capture";
+export * from "./momentum";
 export * from "./recognizers";
 export * from "./useClickSuppression";
 export * from "./usePointerPressAndHold";

--- a/packages/ui/src/gestures/momentum.test.ts
+++ b/packages/ui/src/gestures/momentum.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Pure contract coverage for the shared one-dimensional release, settle, and
+ * detent math used by pointer-driven surfaces.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  getMomentumReleaseVelocity,
+  getVelocityAwareSettleDuration,
+  shouldCommitMomentumDetent,
+} from "./momentum";
+
+describe("getMomentumReleaseVelocity", () => {
+  it("uses the trailing samples rather than the whole-gesture fallback", () => {
+    expect(
+      getMomentumReleaseVelocity({
+        samples: [
+          { positionPx: 20, timeMs: 40 },
+          { positionPx: 44, timeMs: 60 },
+        ],
+        endPositionPx: 80,
+        endTimeMs: 80,
+        fallbackVelocityPxPerMs: 0.2,
+      }),
+    ).toBe(1.5);
+  });
+
+  it("falls back when the trailing window cannot carry direction", () => {
+    expect(
+      getMomentumReleaseVelocity({
+        samples: [{ positionPx: 80, timeMs: 80 }],
+        endPositionPx: 80,
+        endTimeMs: 80,
+        fallbackVelocityPxPerMs: 0.35,
+      }),
+    ).toBe(0.35);
+    expect(
+      getMomentumReleaseVelocity({
+        samples: [
+          { positionPx: 80, timeMs: 60 },
+          { positionPx: 90, timeMs: 70 },
+        ],
+        endPositionPx: 80,
+        endTimeMs: 80,
+        fallbackVelocityPxPerMs: -0.2,
+      }),
+    ).toBe(-0.2);
+  });
+});
+
+describe("getVelocityAwareSettleDuration", () => {
+  it("preserves the pager's 320–600 ms velocity curve", () => {
+    expect(
+      getVelocityAwareSettleDuration({
+        velocityPxPerMs: 1.8,
+        remainingDistancePx: 260,
+        fallbackDurationMs: 460,
+      }),
+    ).toBe(320);
+    expect(
+      getVelocityAwareSettleDuration({
+        velocityPxPerMs: 0.18,
+        remainingDistancePx: 260,
+        fallbackDurationMs: 460,
+      }),
+    ).toBe(433);
+    expect(
+      getVelocityAwareSettleDuration({
+        velocityPxPerMs: 0.1,
+        remainingDistancePx: 500,
+        fallbackDurationMs: 460,
+      }),
+    ).toBe(600);
+  });
+
+  it("bounds the fallback when release velocity is unavailable", () => {
+    expect(
+      getVelocityAwareSettleDuration({
+        velocityPxPerMs: 0,
+        remainingDistancePx: 260,
+        fallbackDurationMs: 700,
+      }),
+    ).toBe(600);
+  });
+});
+
+describe("shouldCommitMomentumDetent", () => {
+  const base = {
+    distanceThresholdPx: 200,
+    minimumFlickDistancePx: 48,
+    flickVelocityThresholdPxPerMs: 0.45,
+  };
+
+  it("commits at the distance threshold regardless of release speed", () => {
+    expect(
+      shouldCommitMomentumDetent({
+        ...base,
+        displacementPx: -200,
+        releaseVelocityPxPerMs: 0,
+      }),
+    ).toBe(true);
+  });
+
+  it("commits a short flick only when velocity follows the drag direction", () => {
+    expect(
+      shouldCommitMomentumDetent({
+        ...base,
+        displacementPx: -64,
+        releaseVelocityPxPerMs: -0.5,
+      }),
+    ).toBe(true);
+    expect(
+      shouldCommitMomentumDetent({
+        ...base,
+        displacementPx: -64,
+        releaseVelocityPxPerMs: 0.5,
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects flicks below the travel floor or outside release-axis ownership", () => {
+    expect(
+      shouldCommitMomentumDetent({
+        ...base,
+        displacementPx: 47,
+        releaseVelocityPxPerMs: 1,
+      }),
+    ).toBe(false);
+    expect(
+      shouldCommitMomentumDetent({
+        ...base,
+        displacementPx: 64,
+        releaseVelocityPxPerMs: 1,
+        isFlickAxisDominant: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/ui/src/gestures/momentum.ts
+++ b/packages/ui/src/gestures/momentum.ts
@@ -1,0 +1,121 @@
+/**
+ * Pure one-dimensional momentum math for drag surfaces that settle onto a
+ * detent. The defaults preserve the home pager's release sampling and settle
+ * tuning while allowing vertical and horizontal consumers to share the same
+ * motion model without sharing pointer-event state.
+ */
+
+/** A position sample captured during the trailing edge of a drag. */
+export interface MomentumSample {
+  positionPx: number;
+  timeMs: number;
+}
+
+/** The pager samples only the final 100 ms so release intent wins over the
+ * whole-gesture average. Callers use this while retaining samples. */
+export const MOMENTUM_RELEASE_WINDOW_MS = 100;
+
+/** The home pager's velocity-aware settle band and speed floor. */
+export const MOMENTUM_MIN_SETTLE_MS = 320;
+export const MOMENTUM_MAX_SETTLE_MS = 600;
+export const MOMENTUM_MIN_SETTLE_SPEED_PX_PER_MS = 0.6;
+
+interface ReleaseVelocityOptions {
+  samples: readonly MomentumSample[];
+  endPositionPx: number;
+  endTimeMs: number;
+  fallbackVelocityPxPerMs: number;
+}
+
+/**
+ * Estimates how fast the pointer left the surface from its trailing samples.
+ * Samples are expected to have already been retained within
+ * {@link MOMENTUM_RELEASE_WINDOW_MS}; a whole-gesture average is the fallback
+ * for tap-flicks and degenerate windows.
+ */
+export function getMomentumReleaseVelocity({
+  samples,
+  endPositionPx,
+  endTimeMs,
+  fallbackVelocityPxPerMs,
+}: ReleaseVelocityOptions): number {
+  if (samples.length < 2) return fallbackVelocityPxPerMs;
+
+  const oldest = samples[0];
+  const elapsedMs = endTimeMs - oldest.timeMs;
+  if (elapsedMs <= 0) return fallbackVelocityPxPerMs;
+
+  const velocityPxPerMs = (endPositionPx - oldest.positionPx) / elapsedMs;
+  return velocityPxPerMs === 0 ? fallbackVelocityPxPerMs : velocityPxPerMs;
+}
+
+interface VelocityAwareSettleOptions {
+  velocityPxPerMs: number;
+  remainingDistancePx: number;
+  fallbackDurationMs: number;
+  minimumDurationMs?: number;
+  maximumDurationMs?: number;
+  minimumSpeedPxPerMs?: number;
+}
+
+/**
+ * Converts release speed and remaining travel into a bounded settle duration.
+ * Fast releases land at the short end of the band; a near-still release uses
+ * the caller's bounded fallback rather than manufacturing directional intent.
+ */
+export function getVelocityAwareSettleDuration({
+  velocityPxPerMs,
+  remainingDistancePx,
+  fallbackDurationMs,
+  minimumDurationMs = MOMENTUM_MIN_SETTLE_MS,
+  maximumDurationMs = MOMENTUM_MAX_SETTLE_MS,
+  minimumSpeedPxPerMs = MOMENTUM_MIN_SETTLE_SPEED_PX_PER_MS,
+}: VelocityAwareSettleOptions): number {
+  const clampDuration = (durationMs: number) =>
+    Math.max(
+      minimumDurationMs,
+      Math.min(maximumDurationMs, Math.round(durationMs)),
+    );
+  const remaining = Math.abs(remainingDistancePx);
+  const speed = Math.abs(velocityPxPerMs);
+
+  if (remaining < 1 || speed < 0.01) {
+    return clampDuration(fallbackDurationMs);
+  }
+
+  return clampDuration(remaining / Math.max(minimumSpeedPxPerMs, speed));
+}
+
+interface MomentumDetentOptions {
+  displacementPx: number;
+  releaseVelocityPxPerMs: number;
+  distanceThresholdPx: number;
+  minimumFlickDistancePx: number;
+  flickVelocityThresholdPxPerMs: number;
+  /** Axis ownership is determined by the pointer recognizer; only the
+   * short-distance flick escape hatch requires it again at release. */
+  isFlickAxisDominant?: boolean;
+}
+
+/**
+ * Resolves a detent commit from distance or a same-direction release flick.
+ * Reversing velocity never commits the original drag direction, which keeps a
+ * drag-out-then-fling-back gesture on its current detent.
+ */
+export function shouldCommitMomentumDetent({
+  displacementPx,
+  releaseVelocityPxPerMs,
+  distanceThresholdPx,
+  minimumFlickDistancePx,
+  flickVelocityThresholdPxPerMs,
+  isFlickAxisDominant = true,
+}: MomentumDetentOptions): boolean {
+  if (Math.abs(displacementPx) >= distanceThresholdPx) return true;
+
+  return (
+    isFlickAxisDominant &&
+    Math.abs(displacementPx) >= minimumFlickDistancePx &&
+    Math.abs(releaseVelocityPxPerMs) >= flickVelocityThresholdPxPerMs &&
+    Math.sign(releaseVelocityPxPerMs) === Math.sign(displacementPx)
+  );
+}


### PR DESCRIPTION
# Relates to

Closes #16369

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` passed after sync.
- [x] Focused automated and real-browser evidence is recorded below; full visual audit artifacts are being finalized before ready-for-review.

# Sync with develop

- [x] Rebased onto `origin/develop` at `5151cee78`; zero conflicts.
- [x] `bun run verify` passed. Focused tests and browser E2E passed again after the rebase.

# Risks

Medium. This changes notification-shade gesture ownership, animation timing, stacking, and keyboard/pointer release handling on the shared home surface. Regression coverage exercises click, mouse drag, real CDP touch, cancellation, reduced motion, keyboard focus, and frame timing.

# Background

## What does this PR do?

- Shares momentum projection and settle-duration physics across home gestures.
- Gives the notification shade continuous pull tracking, velocity-aware commit behavior, stable stack fan/fold geometry, and synchronized count/control transitions.
- Prevents a release click from reopening a just-collapsed shade while preserving keyboard activation.
- Adds extensive component and real-browser regression coverage for gesture, timing, accessibility, layout, and performance contracts.

## What kind of change is this?

Bug fix and interaction improvement.

# Documentation changes needed?

No project documentation change is needed; this repairs an existing interaction contract and includes durable code rationale plus executable regression coverage.

# Testing

## Where should a reviewer start?

`packages/ui/src/components/shell/NotificationsHomeCenter.tsx` and `packages/ui/src/gestures/momentum.ts`.

## Detailed testing steps

1. On home with notifications, click the count to expand and collapse.
2. Pull upward from the empty shade area slowly and quickly; verify cancellation and commit settle cleanly.
3. Expand/fold the notification stack and verify cards remain layered without a tail animation.
4. Enable reduced motion and navigate by keyboard; verify immediate transitions and correct focus handoff.

Validated locally:

- `bun run verify`
- `bun run --cwd packages/ui test -- src/gestures/momentum.test.ts src/components/shell/NotificationsHomeCenter.test.tsx src/components/shell/HomeScreen.test.tsx` — 113 passed
- `bun run --cwd packages/ui test:home-screen-e2e` — passed, including real CDP touch and 120 Hz performance sampling
- `bun run --cwd packages/app audit:app` — in progress; final report and links will be added before review

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page desktop and mobile screenshots will be linked before review.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page desktop and mobile screenshots will be linked before review.
<!-- evidence-row:walkthrough-video -->
- [ ] MP4 walkthrough will be linked before review.
<!-- evidence-row:backend-logs -->
- [x] N/A - this is a client-only gesture and presentation change with no backend path.
<!-- evidence-row:frontend-logs -->
- [x] Real-browser output verifies zero page errors; full log artifact will be linked before review.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, scheduled task, wallet, chain, or generated-domain output changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model changes.

## Backend + frontend logs

Backend: N/A - client-only interaction.

Frontend: the real-browser suite completed with zero page errors. The complete log artifact will be linked before review.

## Screenshots (before / after) + video walkthrough

### Before

Pending final evidence upload.

### After

Pending final evidence upload.

### Walkthrough video

Pending MP4 conversion and upload.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio changes.

## Known gaps / failures

The PR is intentionally draft while the required repeated app visual audit and evidence upload finish. No code/test failures are currently known.
