### PR TITLE
fix(plugin-computeruse): validate action input before the approval gate (headless-safe)

### DIFF
--- a/plugins/plugin-computeruse/src/__tests__/service-browser-routing.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/service-browser-routing.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Browser command dispatch of ComputerUseService, driven against a mocked
+ * platform/browser module (deterministic, no real CDP/Chromium — a headless CI
+ * runner has no browser to launch). Mirrors browser-auto-open.test.ts: only the
+ * CDP boundary is mocked; the service's routing, approval-command lookup, verb
+ * dispatch, and normalization run for real.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("../platform/browser.js", () => {
+  const state = (url = "about:blank") => ({
+    url,
+    title: "Example",
+    isOpen: true,
+    is_open: true,
+  });
+  return {
+    clickBrowser: vi.fn(async () => {}),
+    closeBrowser: vi.fn(async () => {}),
+    closeBrowserTab: vi.fn(async () => {}),
+    executeBrowser: vi.fn(async () => "ok"),
+    getBrowserClickables: vi.fn(async () => []),
+    getBrowserContext: vi.fn(async () => state()),
+    getBrowserDom: vi.fn(async () => "<html></html>"),
+    getBrowserInfo: vi.fn(async () => ({ success: true, ...state() })),
+    getBrowserState: vi.fn(async () => state()),
+    isBrowserAvailable: vi.fn(() => true),
+    listBrowserTabs: vi.fn(async () => []),
+    navigateBrowser: vi.fn(async (url: string) => state(url)),
+    openBrowser: vi.fn(async (url?: string) => state(url)),
+    openBrowserTab: vi.fn(async (url?: string) => ({
+      id: "1",
+      url: url ?? "about:blank",
+      title: "Example",
+      active: true,
+    })),
+    screenshotBrowser: vi.fn(async () => "base64"),
+    scrollBrowser: vi.fn(async () => {}),
+    setBrowserRuntimeOptions: vi.fn(),
+    switchBrowserTab: vi.fn(async () => state()),
+    typeBrowser: vi.fn(async () => {}),
+    waitBrowser: vi.fn(async () => {}),
+  };
+});
+
+const { ComputerUseService } = await import(
+  "../services/computer-use-service.js"
+);
+
+function createRuntime(): IAgentRuntime {
+  return {
+    character: {},
+    getSetting(key: string) {
+      return key === "COMPUTER_USE_APPROVAL_MODE" ? "full_control" : undefined;
+    },
+    getService() {
+      return null;
+    },
+  } as unknown as IAgentRuntime;
+}
+
+const approvalConfigPath = path.join(
+  os.homedir(),
+  ".eliza",
+  "computer-use-approval.json",
+);
+
+describe("ComputerUseService browser command dispatch", () => {
+  let service: InstanceType<typeof ComputerUseService>;
+  let savedApprovalConfig: string | null;
+
+  beforeAll(async () => {
+    savedApprovalConfig = readApprovalConfig();
+    service = (await ComputerUseService.start(createRuntime())) as InstanceType<
+      typeof ComputerUseService
+    >;
+  });
+
+  afterAll(async () => {
+    await service.stop();
+    restoreApprovalConfig(savedApprovalConfig);
+  });
+
+  it("dispatches every browser verb through executeBrowserAction", async () => {
+    const params: Array<Record<string, unknown> & { action: string }> = [
+      { action: "open", url: "https://example.com" },
+      { action: "connect" },
+      { action: "navigate", url: "https://example.com" },
+      { action: "state" },
+      { action: "info" },
+      { action: "context" },
+      { action: "get_context" },
+      { action: "dom" },
+      { action: "get_dom" },
+      { action: "clickables" },
+      { action: "get_clickables" },
+      { action: "click", coordinate: [10, 10] },
+      { action: "type", text: "hello" },
+      { action: "scroll", coordinate: [10, 10] },
+      { action: "screenshot" },
+      { action: "wait" },
+      { action: "list_tabs" },
+      { action: "open_tab", url: "https://example.com" },
+      { action: "switch_tab", tabId: "1" },
+      { action: "close_tab", tabId: "1" },
+      { action: "execute", script: "1+1" },
+      { action: "close" },
+    ];
+    for (const param of params) {
+      const result = await service.executeBrowserAction(
+        param as Parameters<
+          InstanceType<typeof ComputerUseService>["executeBrowserAction"]
+        >[0],
+      );
+      expect(typeof result.success).toBe("boolean");
+    }
+  }, 20_000);
+
+  it("keeps browser_execute disabled regardless of approval mode", async () => {
+    const result = await service.executeBrowserAction({
+      action: "execute",
+      script: "alert(1)",
+    } as Parameters<
+      InstanceType<typeof ComputerUseService>["executeBrowserAction"]
+    >[0]);
+    expect(result.success).toBe(false);
+  });
+
+  it("routes browser command strings through executeCommand", async () => {
+    for (const command of [
+      "browser_open",
+      "browser_navigate",
+      "browser_state",
+      "browser_info",
+      "browser_get_dom",
+      "browser_get_clickables",
+      "browser_screenshot",
+      "browser_list_tabs",
+      "browser_open_tab",
+      "browser_switch_tab",
+      "browser_close_tab",
+      "browser_close",
+    ]) {
+      const result = await service.executeCommand(command, {
+        url: "https://example.com",
+        tabId: "1",
+      });
+      expect(typeof result.success).toBe("boolean");
+    }
+  }, 20_000);
+});
+
+function readApprovalConfig(): string | null {
+  try {
+    return fs.readFileSync(approvalConfigPath, "utf8");
+  } catch (err) {
+    // error-policy:J3 a missing file is the expected CI/first-run shape; any
+    // other read error means restore is unsafe, so surface it.
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+function restoreApprovalConfig(saved: string | null): void {
+  if (saved === null) {
+    fs.rmSync(approvalConfigPath, { force: true });
+    return;
+  }
+  fs.writeFileSync(approvalConfigPath, saved, "utf8");
+}

--- a/plugins/plugin-computeruse/src/__tests__/service.integration.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/service.integration.test.ts
@@ -1,8 +1,13 @@
 /**
  * Exercises ComputerUseService through a real AgentRuntime and in-memory
- * database without capturing or actuating the host desktop.
+ * database without capturing or actuating the host desktop. The final block is
+ * a regression guard for the headless-CI hang: input validation must run before
+ * the approval gate, which blocks on a decision no headless runner can produce.
  */
 
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import type { AgentRuntime } from "@elizaos/core";
 import {
   afterAll,
@@ -195,3 +200,77 @@ describe("ComputerUseService window validation", () => {
     expect(result.error).toContain("Unknown window action");
   });
 });
+
+// Regression guard for the CI Plugin-lane hang. The approval gate awaits a
+// human/API decision; the default smart_approve mode gives a headless runner no
+// way to produce one, so any destructive action requested before its input is
+// validated blocks until the 90s test timeout. This pins "off" (deny-all): the
+// gate resolves immediately, so instead of hanging we get an observable
+// distinction — with validation running first, malformed input yields the
+// *field* error; if the gate ran first it would yield the deny message. The
+// host's persisted approval mode is saved and restored (setMode persists to
+// ~/.eliza), and this block runs last so its transient on-disk mode cannot leak
+// into the earlier blocks.
+describe("ComputerUseService validates input before the approval gate", () => {
+  const approvalConfigPath = path.join(
+    os.homedir(),
+    ".eliza",
+    "computer-use-approval.json",
+  );
+  let savedApprovalConfig: string | null = null;
+  let runtime: AgentRuntime;
+  let service: ComputerUseService;
+
+  beforeAll(async () => {
+    savedApprovalConfig = readApprovalConfig(approvalConfigPath);
+    ({ runtime, service } = await startComputerUseRuntime({
+      COMPUTER_USE_APPROVAL_MODE: "off",
+    }));
+  });
+
+  afterAll(async () => {
+    await stopComputerUseRuntime(runtime);
+    restoreApprovalConfig(approvalConfigPath, savedApprovalConfig);
+  });
+
+  it("runs deny-all so the gate cannot auto-approve", () => {
+    expect(service.getApprovalMode()).toBe("off");
+  });
+
+  it("rejects a coordinate-less click at validation, not the gate", async () => {
+    const result = await service.executeDesktopAction({ action: "click" });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("coordinate");
+    expect(result.error).not.toContain("paused");
+  }, 10_000);
+
+  it("rejects a targetless window focus at validation, not the gate", async () => {
+    const result = await service.executeWindowAction({ action: "focus" });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("windowId");
+    expect(result.error).not.toContain("paused");
+  }, 10_000);
+});
+
+/** Reads the persisted approval-mode config, or null when none exists. */
+function readApprovalConfig(configPath: string): string | null {
+  try {
+    return fs.readFileSync(configPath, "utf8");
+  } catch (err) {
+    // error-policy:J3 a missing file is the expected first-run/CI shape; a
+    // different read error means we cannot safely restore, so surface it.
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+/** Restores the approval-mode config to its pre-test contents (or absence). */
+function restoreApprovalConfig(configPath: string, saved: string | null): void {
+  if (saved === null) {
+    fs.rmSync(configPath, { force: true });
+    return;
+  }
+  fs.writeFileSync(configPath, saved, "utf8");
+}

--- a/plugins/plugin-computeruse/src/__tests__/service.integration.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/service.integration.test.ts
@@ -491,20 +491,42 @@ describe("ComputerUseService file and terminal execution (real host I/O)", () =>
     expect(result.success).toBe(true);
   }, 15_000);
 
-  it("reads a file with an explicit encoding", async () => {
+  it("reads a file across every supported encoding", async () => {
     const target = path.join(workdir, "enc.txt");
     await service.executeFileAction({
       action: "write",
       path: target,
       content: "encoded",
     });
-    const read = await service.executeFileAction({
-      action: "read",
-      path: target,
-      encoding: "base64",
-    });
-    expect(read.success).toBe(true);
+    for (const encoding of [
+      "utf8",
+      "ascii",
+      "base64",
+      "hex",
+      "latin1",
+      "binary",
+      "ucs2",
+      "utf16le",
+      "unknown-encoding",
+    ]) {
+      const read = await service.executeFileAction({
+        action: "read",
+        path: target,
+        encoding,
+      });
+      expect(read.success).toBe(true);
+    }
   });
+
+  it("runs terminal execute with an explicit cwd and timeout", async () => {
+    const result = await service.executeTerminalAction({
+      action: "execute",
+      command: "pwd",
+      cwd: workdir,
+      timeout: 5,
+    });
+    expect(result.success).toBe(true);
+  }, 15_000);
 
   // executeCommand maps each command string onto an action and dispatches it.
   // Malformed desktop/window commands fail fast at validation (no display or
@@ -608,26 +630,6 @@ describe("ComputerUseService file and terminal execution (real host I/O)", () =>
     }
   }, 20_000);
 
-  it("routes read-only browser command strings through executeCommand", async () => {
-    // No browser is open, so each safe read returns a structured failure — the
-    // routing + mapBrowserCommandToAction + not-open guard run without launching
-    // a real browser.
-    const commands = [
-      "browser_state",
-      "browser_info",
-      "browser_get_context",
-      "browser_get_dom",
-      "browser_dom",
-      "browser_get_clickables",
-      "browser_clickables",
-      "browser_list_tabs",
-    ];
-    for (const command of commands) {
-      const result = await service.executeCommand(command, {});
-      expect(typeof result.success).toBe("boolean");
-    }
-  }, 20_000);
-
   it("exercises window read and getter actions", async () => {
     for (const action of [
       "list",
@@ -648,6 +650,43 @@ describe("ComputerUseService file and terminal execution (real host I/O)", () =>
       const result = await service.executeWindowAction({ action });
       expect(result.success).toBe(false);
     }
+  }, 20_000);
+
+  // Window management verbs against a window id that matches nothing: the verb
+  // dispatch, its approval-command lookup, and the platform call all run and
+  // fail fast (no window to act on) — no real window is moved or closed on the
+  // host, and the shell-outs are bounded (absent WM tooling errors immediately).
+  it("dispatches window management verbs for a non-matching window", async () => {
+    const windowId = "computeruse-nonexistent-window-id";
+    for (const action of [
+      "focus",
+      "switch",
+      "minimize",
+      "maximize",
+      "restore",
+      "close",
+    ] as const) {
+      const result = await service.executeWindowAction({ action, windowId });
+      expect(typeof result.success).toBe("boolean");
+    }
+
+    const moved = await service.executeWindowAction({
+      action: "move",
+      windowId,
+      x: 0,
+      y: 0,
+    });
+    expect(typeof moved.success).toBe("boolean");
+
+    const bounded = await service.executeWindowAction({
+      action: "set_bounds",
+      windowId,
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+    });
+    expect(typeof bounded.success).toBe("boolean");
   }, 20_000);
 
   it("exposes approval and display introspection", () => {

--- a/plugins/plugin-computeruse/src/__tests__/service.integration.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/service.integration.test.ts
@@ -254,6 +254,417 @@ describe("ComputerUseService validates input before the approval gate", () => {
   }, 10_000);
 });
 
+// Real filesystem + child-process execution driven end to end through the
+// service under full_control (so destructive verbs actually run). These paths
+// are host-desktop-independent — no display, no input driver — so they exercise
+// the executeFileAction / executeTerminalAction dispatch and its
+// routing/normalization/approval/finish helpers deterministically on a headless
+// runner. The persisted approval mode is saved and restored.
+describe("ComputerUseService file and terminal execution (real host I/O)", () => {
+  const approvalConfigPath = path.join(
+    os.homedir(),
+    ".eliza",
+    "computer-use-approval.json",
+  );
+  let savedApprovalConfig: string | null = null;
+  let runtime: AgentRuntime;
+  let service: ComputerUseService;
+  let workdir: string;
+
+  beforeAll(async () => {
+    savedApprovalConfig = readApprovalConfig(approvalConfigPath);
+    workdir = fs.mkdtempSync(path.join(os.tmpdir(), "computeruse-io-"));
+    ({ runtime, service } = await startComputerUseRuntime({
+      COMPUTER_USE_APPROVAL_MODE: "full_control",
+      COMPUTER_USE_SCREENSHOT_AFTER_ACTION: "false",
+    }));
+  });
+
+  afterAll(async () => {
+    await stopComputerUseRuntime(runtime);
+    restoreApprovalConfig(approvalConfigPath, savedApprovalConfig);
+    fs.rmSync(workdir, { recursive: true, force: true });
+  });
+
+  it("writes a file and reads the same bytes back", async () => {
+    const target = path.join(workdir, "note.txt");
+    const write = await service.executeFileAction({
+      action: "write",
+      path: target,
+      content: "hello world",
+    });
+    expect(write.success).toBe(true);
+
+    const read = await service.executeFileAction({
+      action: "read",
+      path: target,
+    });
+    expect(read.success).toBe(true);
+    expect(read.content).toContain("hello world");
+
+    const size = await service.executeFileAction({
+      action: "get_file_size",
+      path: target,
+    });
+    expect(size.success).toBe(true);
+  });
+
+  it("appends then edits file content in place", async () => {
+    const target = path.join(workdir, "edit.txt");
+    await service.executeFileAction({
+      action: "write",
+      path: target,
+      content: "alpha",
+    });
+    const append = await service.executeFileAction({
+      action: "append",
+      path: target,
+      content: "-beta",
+    });
+    expect(append.success).toBe(true);
+
+    const edit = await service.executeFileAction({
+      action: "edit",
+      path: target,
+      old_text: "alpha",
+      new_text: "omega",
+    });
+    expect(edit.success).toBe(true);
+
+    const read = await service.executeFileAction({
+      action: "read",
+      path: target,
+    });
+    expect(read.content).toContain("omega-beta");
+  });
+
+  it("round-trips raw bytes through write_bytes/read_bytes", async () => {
+    const target = path.join(workdir, "bytes.bin");
+    const write = await service.executeFileAction({
+      action: "write_bytes",
+      path: target,
+      base64: Buffer.from("bytes!").toString("base64"),
+    });
+    expect(write.success).toBe(true);
+
+    const read = await service.executeFileAction({
+      action: "read_bytes",
+      path: target,
+      offset: 0,
+      length: 6,
+    });
+    expect(read.success).toBe(true);
+  });
+
+  it("creates, probes, lists, and removes a directory", async () => {
+    const dir = path.join(workdir, "sub");
+    const create = await service.executeFileAction({
+      action: "create_dir",
+      path: dir,
+    });
+    expect(create.success).toBe(true);
+
+    const dirExists = await service.executeFileAction({
+      action: "directory_exists",
+      path: dir,
+    });
+    expect(dirExists.success).toBe(true);
+
+    await service.executeFileAction({
+      action: "write",
+      path: path.join(dir, "a.txt"),
+      content: "a",
+    });
+    const list = await service.executeFileAction({ action: "list", path: dir });
+    expect(list.success).toBe(true);
+
+    const remove = await service.executeFileAction({
+      action: "delete_directory",
+      path: dir,
+    });
+    expect(remove.success).toBe(true);
+  });
+
+  it("reports existence and deletes a file", async () => {
+    const target = path.join(workdir, "gone.txt");
+    await service.executeFileAction({
+      action: "write",
+      path: target,
+      content: "x",
+    });
+    const exists = await service.executeFileAction({
+      action: "exists",
+      path: target,
+    });
+    expect(exists.success).toBe(true);
+
+    const del = await service.executeFileAction({
+      action: "delete",
+      path: target,
+    });
+    expect(del.success).toBe(true);
+  });
+
+  it("rejects a write without content and an unknown file action", async () => {
+    const noContent = await service.executeFileAction({
+      action: "write",
+      path: path.join(workdir, "x.txt"),
+    });
+    expect(noContent.success).toBe(false);
+
+    const unknown = await (
+      service.executeFileAction as (p: {
+        action: string;
+        path: string;
+      }) => ReturnType<ComputerUseService["executeFileAction"]>
+    ).call(service, {
+      action: "nonexistent",
+      path: path.join(workdir, "x.txt"),
+    });
+    expect(unknown.success).toBe(false);
+    expect(unknown.error).toContain("Unknown file action");
+  });
+
+  it("routes file commands through executeCommand", async () => {
+    const target = path.join(workdir, "routed.txt");
+    const write = await service.executeCommand("file_write", {
+      path: target,
+      content: "routed",
+    });
+    expect(write.success).toBe(true);
+
+    const read = await service.executeCommand("file_read", { path: target });
+    expect(read.success).toBe(true);
+
+    const unknown = await service.executeCommand("not_a_real_command", {});
+    expect(unknown.success).toBe(false);
+    expect(unknown.error).toContain("Unknown computer-use command");
+  });
+
+  it("runs a real shell command through the terminal", async () => {
+    const result = await service.executeTerminalAction({
+      action: "execute",
+      command: "echo computeruse-ok",
+    });
+    expect(result.success).toBe(true);
+    expect(JSON.stringify(result)).toContain("computeruse-ok");
+  }, 15_000);
+
+  it("connects, reads, types, clears, and closes a terminal session", async () => {
+    expect(
+      (await service.executeTerminalAction({ action: "connect" })).success,
+    ).toBe(true);
+    expect(
+      (await service.executeTerminalAction({ action: "read" })).success,
+    ).toBe(true);
+    expect(
+      (await service.executeTerminalAction({ action: "type", text: "echo hi" }))
+        .success,
+    ).toBe(true);
+    expect(
+      (await service.executeTerminalAction({ action: "clear" })).success,
+    ).toBe(true);
+    expect(
+      (await service.executeTerminalAction({ action: "close" })).success,
+    ).toBe(true);
+  }, 15_000);
+
+  it("rejects a command-less terminal execute and an unknown terminal action", async () => {
+    const noCommand = await service.executeTerminalAction({
+      action: "execute",
+    });
+    expect(noCommand.success).toBe(false);
+
+    const unknown = await (
+      service.executeTerminalAction as (p: {
+        action: string;
+      }) => ReturnType<ComputerUseService["executeTerminalAction"]>
+    ).call(service, { action: "nonexistent" });
+    expect(unknown.success).toBe(false);
+    expect(unknown.error).toContain("Unknown terminal action");
+  });
+
+  it("routes a terminal command through executeCommand", async () => {
+    const result = await service.executeCommand("execute_command", {
+      command: "echo routed-terminal",
+    });
+    expect(result.success).toBe(true);
+  }, 15_000);
+
+  it("reads a file with an explicit encoding", async () => {
+    const target = path.join(workdir, "enc.txt");
+    await service.executeFileAction({
+      action: "write",
+      path: target,
+      content: "encoded",
+    });
+    const read = await service.executeFileAction({
+      action: "read",
+      path: target,
+      encoding: "base64",
+    });
+    expect(read.success).toBe(true);
+  });
+
+  // executeCommand maps each command string onto an action and dispatches it.
+  // Malformed desktop/window commands fail fast at validation (no display or
+  // input driver touched); the maps and per-verb approval-command lookups run
+  // for every string, so the routing switch and its helper switches are covered
+  // without actuating the host. Each dispatch returns a structured result.
+  it("routes every desktop command string through executeCommand", async () => {
+    const commands = [
+      "click",
+      "click_with_modifiers",
+      "double_click",
+      "right_click",
+      "mouse_move",
+      "middle_click",
+      "mouse_down",
+      "mouse_up",
+      "type",
+      "key_press",
+      "key_combo",
+      "key_down",
+      "key_up",
+      "scroll",
+      "drag",
+      "detect_elements",
+      "ocr",
+      "open",
+      "launch",
+      "kill_app",
+      "set_value",
+    ];
+    for (const command of commands) {
+      const result = await service.executeCommand(command, {});
+      expect(typeof result.success).toBe("boolean");
+    }
+  }, 20_000);
+
+  it("routes every window command string through executeCommand", async () => {
+    const commands = [
+      "list_windows",
+      "switch_to_window",
+      "arrange_windows",
+      "move_window",
+      "minimize_window",
+      "maximize_window",
+      "restore_window",
+      "close_window",
+    ];
+    for (const command of commands) {
+      const result = await service.executeCommand(command, {});
+      expect(typeof result.success).toBe("boolean");
+    }
+  }, 20_000);
+
+  it("routes every file command string through executeCommand", async () => {
+    const target = path.join(workdir, "routing.txt");
+    const commands = [
+      "file_write",
+      "file_read",
+      "file_edit",
+      "file_append",
+      "file_exists",
+      "file_get_file_size",
+      "file_read_bytes",
+      "file_write_bytes",
+      "file_create_dir",
+      "file_directory_exists",
+      "directory_list",
+      "file_list_downloads",
+      "file_download",
+      "file_upload",
+      "file_delete",
+      "directory_delete",
+    ];
+    for (const command of commands) {
+      const result = await service.executeCommand(command, {
+        path: target,
+        content: "routing",
+        base64: Buffer.from("routing").toString("base64"),
+        old_text: "routing",
+        new_text: "changed",
+      });
+      expect(typeof result.success).toBe("boolean");
+    }
+  }, 20_000);
+
+  it("routes every terminal command string through executeCommand", async () => {
+    const commands = [
+      "terminal_connect",
+      "terminal_execute",
+      "terminal_read",
+      "terminal_type",
+      "terminal_clear",
+      "terminal_close",
+    ];
+    for (const command of commands) {
+      const result = await service.executeCommand(command, {
+        command: "echo routed",
+        text: "echo hi",
+      });
+      expect(typeof result.success).toBe("boolean");
+    }
+  }, 20_000);
+
+  it("routes read-only browser command strings through executeCommand", async () => {
+    // No browser is open, so each safe read returns a structured failure — the
+    // routing + mapBrowserCommandToAction + not-open guard run without launching
+    // a real browser.
+    const commands = [
+      "browser_state",
+      "browser_info",
+      "browser_get_context",
+      "browser_get_dom",
+      "browser_dom",
+      "browser_get_clickables",
+      "browser_clickables",
+      "browser_list_tabs",
+    ];
+    for (const command of commands) {
+      const result = await service.executeCommand(command, {});
+      expect(typeof result.success).toBe("boolean");
+    }
+  }, 20_000);
+
+  it("exercises window read and getter actions", async () => {
+    for (const action of [
+      "list",
+      "get_current_window_id",
+      "get_window_size",
+      "get_window_position",
+      "arrange",
+    ] as const) {
+      const result = await service.executeWindowAction({ action });
+      expect(typeof result.success).toBe("boolean");
+    }
+
+    for (const action of [
+      "move",
+      "set_bounds",
+      "get_application_windows",
+    ] as const) {
+      const result = await service.executeWindowAction({ action });
+      expect(result.success).toBe(false);
+    }
+  }, 20_000);
+
+  it("exposes approval and display introspection", () => {
+    expect(service.setApprovalMode("full_control")).toBe("full_control");
+    const snapshot = service.getApprovalSnapshot();
+    expect(snapshot).toHaveProperty("mode");
+    const unsubscribe = service.subscribeApprovals(() => {});
+    expect(typeof unsubscribe).toBe("function");
+    unsubscribe();
+    expect(service.resolveApproval("does-not-exist", true)).toBeNull();
+
+    expect(service.getScreenDimensions()).toHaveProperty("width");
+    expect(Array.isArray(service.getDisplays())).toBe(true);
+    expect(service.getConfig()).toHaveProperty("approvalMode");
+  });
+});
+
 /** Reads the persisted approval-mode config, or null when none exists. */
 function readApprovalConfig(configPath: string): string | null {
   try {

--- a/plugins/plugin-computeruse/src/services/computer-use-service.ts
+++ b/plugins/plugin-computeruse/src/services/computer-use-service.ts
@@ -166,6 +166,35 @@ const COORDINATE_BEARING_ACTIONS = new Set<DesktopActionParams["action"]>([
   "set_value",
 ]);
 
+// Every verb the desktop dispatch switch can execute. Used to reject an unknown
+// action up front, before the approval gate blocks on a decision that a
+// malformed request will never earn (see validateDesktopActionInput).
+const KNOWN_DESKTOP_ACTIONS = new Set<DesktopActionParams["action"]>([
+  "screenshot",
+  "click",
+  "click_with_modifiers",
+  "double_click",
+  "right_click",
+  "mouse_move",
+  "middle_click",
+  "mouse_down",
+  "mouse_up",
+  "type",
+  "key",
+  "key_combo",
+  "key_down",
+  "key_up",
+  "scroll",
+  "drag",
+  "get_cursor_position",
+  "detect_elements",
+  "ocr",
+  "open",
+  "launch",
+  "kill_app",
+  "set_value",
+]);
+
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -430,6 +459,13 @@ export class ComputerUseService extends Service {
     const entry = this.createEntry(params.action, this.toParamsRecord(params));
 
     try {
+      // Reject malformed input before requesting approval or resolving a
+      // display: the approval gate awaits a human/API decision that never
+      // arrives on a non-interactive or headless host (no approval UI), so
+      // asking approval for input the dispatch switch would reject anyway
+      // hangs the action forever. Validating first fails such input fast.
+      this.validateDesktopActionInput(params);
+
       const approvalError = await this.awaitApproval(
         this.desktopApprovalCommand(params.action),
         this.toParamsRecord(params),
@@ -1095,6 +1131,11 @@ export class ComputerUseService extends Service {
     );
 
     try {
+      // Validate before approval for the same reason as executeDesktopAction:
+      // the approval gate blocks on a decision a malformed window request will
+      // never receive on a headless/non-interactive host.
+      this.validateWindowActionInput(params);
+
       const approvalError = await this.awaitApproval(
         this.windowApprovalCommand(params.action),
         this.toParamsRecord(params),
@@ -1579,6 +1620,108 @@ export class ComputerUseService extends Service {
         return "context";
       default:
         return action;
+    }
+  }
+
+  /**
+   * Presence/enum check for a desktop action's required input, run before the
+   * approval gate. Throws a typed error (caught by the J1 boundary in
+   * executeDesktopAction and returned as {success:false,error}) for an unknown
+   * verb or a missing required field, so a malformed request fails fast instead
+   * of blocking on an approval decision that a headless/non-interactive host
+   * cannot produce. The dispatch switch keeps its own require* assertions for
+   * type narrowing; this is the gate that decides accept/reject.
+   */
+  private validateDesktopActionInput(params: DesktopActionParams): void {
+    const { action } = params;
+    if (!KNOWN_DESKTOP_ACTIONS.has(action)) {
+      throw new Error(`Unknown desktop action: ${action}`);
+    }
+    if (action === "drag") {
+      // A ≥2-point polyline supersedes the start→end pair (see the drag case).
+      if (params.path && params.path.length >= 2) return;
+      this.requireCoordinate(params.startCoordinate, "drag", "startCoordinate");
+      this.requireCoordinate(params.coordinate, "drag");
+      return;
+    }
+    if (COORDINATE_BEARING_ACTIONS.has(action)) {
+      this.requireCoordinate(params.coordinate, action);
+    }
+    switch (action) {
+      case "type":
+        if (!params.text) throw new Error("text is required for type action");
+        break;
+      case "key":
+      case "key_combo":
+      case "key_down":
+      case "key_up":
+        if (!params.key) {
+          throw new Error(`key is required for ${action} action`);
+        }
+        break;
+      case "set_value":
+        if (typeof params.text !== "string") {
+          throw new Error("text (the value) is required for set_value action");
+        }
+        break;
+      case "open":
+        if (!params.target) {
+          throw new Error("target is required for open action");
+        }
+        break;
+      case "launch":
+        if (!params.app) throw new Error("app is required for launch action");
+        break;
+      case "kill_app":
+        if (!(params.target ?? params.app)) {
+          throw new Error(
+            "target (pid or app name) is required for kill_app action",
+          );
+        }
+        break;
+    }
+  }
+
+  /**
+   * Presence check for a window action's required input, run before the
+   * approval gate — same rationale as validateDesktopActionInput. Throws a
+   * typed error the J1 boundary returns as {success:false,error}.
+   */
+  private validateWindowActionInput(params: WindowActionParams): void {
+    switch (params.action) {
+      case "list":
+      case "arrange":
+      case "get_current_window_id":
+      case "get_window_size":
+      case "get_window_position":
+        return;
+      case "focus":
+      case "switch":
+      case "minimize":
+      case "maximize":
+      case "restore":
+      case "close":
+        this.requireWindowTarget(params);
+        return;
+      case "move":
+        this.requireWindowTarget(params);
+        this.requireNumber(params.x, "x is required for window move");
+        this.requireNumber(params.y, "y is required for window move");
+        return;
+      case "set_bounds":
+        this.requireWindowTarget(params);
+        this.requireNumber(params.x, "x is required for set_bounds");
+        this.requireNumber(params.y, "y is required for set_bounds");
+        return;
+      case "get_application_windows":
+        if (!(params.appName ?? params.title ?? params.window)) {
+          throw new Error("appName is required for get_application_windows");
+        }
+        return;
+      default:
+        throw new Error(
+          `Unknown window action: ${(params as { action: string }).action}`,
+        );
     }
   }
 


### PR DESCRIPTION
# Summary

Fixes a consistent CI failure on `develop`: the Plugin **Tests** lane (shard
2/4) times out (~90s) on
`plugins/plugin-computeruse/src/__tests__/service.integration.test.ts`.

## Root cause (corrected diagnosis)

The hang is **not** display enumeration. It is the **approval gate running
before input validation**.

`ComputerUseService.executeDesktopAction` / `executeWindowAction` call
`awaitApproval(...)` as the first step inside their `try` block, *before* any
input is validated. `awaitApproval` → `ComputerUseApprovalManager.requestApproval`
returns a Promise that only resolves when a human/API approves via the approval
UI. In the **default `smart_approve` mode**, destructive verbs (`click`, `type`,
`key`, `drag`, window `focus`, …) are **not** in `SAFE_COMMANDS`, so they are
**not** auto-approved — the Promise never resolves and the action blocks until
the 90s per-test timeout.

Why it only fails on CI: the approval mode is loaded from
`~/.eliza/computer-use-approval.json`. Developer machines that have used
computer-use have a persisted `{"mode":"full_control"}`, which auto-approves
everything, so the tests pass locally. A fresh CI runner has no such file →
default `smart_approve` → the coordinate-less `click`/`type`/`key`/`focus`
dispatches in the test hang forever.

Proven locally by pointing `HOME` at an empty dir (the exact CI condition) —
the test then times out on macOS **with a real display**, ruling out display
enumeration and isolating the approval gate as the sole cause.

## Fix

- Validate required action input **up front**, before `awaitApproval` and before
  display resolution, in both `executeDesktopAction` and `executeWindowAction`
  (`validateDesktopActionInput` / `validateWindowActionInput`). An unknown verb
  or a missing required field now **fails fast** as a typed
  `{ success:false, error }`, never entering the approval flow — no fabricated
  values, matching the repo fail-fast error policy.
- The dispatch switches keep their `require*` assertions for type narrowing /
  defense-in-depth; the new methods are the accept/reject gate. Coordinate
  requirements reuse the existing `COORDINATE_BEARING_ACTIONS` set.
- Real behavior on a host **with** a display and an approving mode is unchanged
  (valid input still validates → approves → dispatches).

## Test

- Existing tests now pass deterministically under the CI condition (empty
  `HOME` = default `smart_approve`).
- Added a regression guard that pins **deny-all `off`** mode — where the gate
  resolves *immediately* — and asserts malformed input yields the **field**
  error, not the deny message. This proves validation runs before the gate
  **without depending on a hang**, and would fail fast if the ordering
  regresses (verified: reverting the fix flips the assertion to
  `"Computer use is paused…"`). The host's approval config is saved and restored.
- The changed-file coverage gate requires ≥50% line coverage on the changed
  `computer-use-service.ts`; the prior suite only exercised validation paths
  (17.67%). `service.integration.test.ts` (mock-free, real AgentRuntime) now
  drives real, headless-safe end-to-end paths — actual filesystem I/O
  (`executeFileAction`), real child-process execution (`executeTerminalAction`),
  `executeCommand` routing across desktop/window/file/terminal, window
  read/getter/management verbs, all `normalizeEncoding` branches, and
  approval/display introspection. Browser dispatch can't be driven for real on a
  headless runner (auto-open launches a headful Chromium that hangs), so a
  dedicated `service-browser-routing.test.ts` covers it against a mocked
  `platform/browser.js` CDP boundary — exactly the pattern the package's existing
  `browser-auto-open.test.ts` uses. The changed-test gate unions both files'
  coverage of `computer-use-service.ts` to ~64% (floor 50%).

Files: plugin `.ts` + `.test.ts` only (no UI surface).

# Evidence

<!-- evidence-row:before-screenshots -->
- [x] `N/A - backend plugin logic + integration test, no UI surface`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - backend plugin logic + integration test, no UI surface`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - backend plugin logic + integration test, no UI surface`
<!-- evidence-row:backend-logs -->
- [x] Before/after `vitest` output for
      [`service.integration.test.ts`](plugins/plugin-computeruse/src/__tests__/service.integration.test.ts),
      run under the CI condition (empty `HOME` → default `smart_approve`):

<details>
<summary>BEFORE (approval gate before validation) — hangs to the timeout</summary>

```
# HOME=<empty> vitest run … -t "rejects click without a coordinate" --testTimeout=8000
 ❯ service.integration.test.ts (10 tests | 1 failed | 9 skipped) 8298ms
     × rejects click without a coordinate 8297ms
 Error: Test timed out in 8000ms.
# (on CI the real per-test timeout is 90000ms — this is the lane failure)
```
</details>

<details>
<summary>AFTER (validation before the gate) — passes fast</summary>

```
# HOME=<empty> vitest run … service.integration.test.ts service-browser-routing.test.ts
 Test Files  2 passed (2)
      Tests  36 passed (36)
   Duration  5.69s
# merged line coverage of computer-use-service.ts: 410/634 = 64.67% (gate floor 50%)
```

Regression-guard proof (fix reverted → assertion flips, no hang):
```
AssertionError: expected 'Computer use is paused. "click" was b…' to contain 'coordinate'
```
</details>

<!-- evidence-row:frontend-logs -->
- [x] `N/A - backend plugin logic + integration test, no UI surface`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model behavior change; this reorders service-level input validation ahead of the approval gate`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - no persisted domain artifacts; the service's in-memory recent-action history is asserted by the integration test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
