### PR TITLE
feat(registry): add @wealthville/plugin-wealthville

### DIFF
--- a/packages/registry/entries/third-party/wealthville__plugin-wealthville.json
+++ b/packages/registry/entries/third-party/wealthville__plugin-wealthville.json
@@ -1,0 +1,10 @@
+{
+  "package": "@wealthville/plugin-wealthville",
+  "repository": "github:amitesh-m/wealthville-integrations",
+  "kind": "plugin",
+  "description": "Wealthville liquidity-pool scores, ENTER/HOLD/EXIT verdicts, and public miss-inclusive track record for DeFi agents (Solana + EVM).",
+  "homepage": "https://wealthville.net/developers",
+  "version": "0.2.0",
+  "directory": "elizaos-plugin",
+  "tags": ["solana", "defi", "liquidity-pools", "scoring", "wealthville"]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -419,6 +419,51 @@
       "registryKind": "plugin",
       "directory": "packages/eliza-rollout-plugin"
     },
+    "@wealthville/plugin-wealthville": {
+      "git": {
+        "repo": "amitesh-m/wealthville-integrations",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "@wealthville/plugin-wealthville",
+        "v0": null,
+        "v1": null,
+        "v2": "0.2.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Wealthville liquidity-pool scores, ENTER/HOLD/EXIT verdicts, and public miss-inclusive track record for DeFi agents (Solana + EVM).",
+      "homepage": "https://wealthville.net/developers",
+      "topics": [
+        "solana",
+        "defi",
+        "liquidity-pools",
+        "scoring",
+        "wealthville"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": "elizaos-plugin"
+    },
     "@xynqai/plugin-eliza": {
       "git": {
         "repo": "visionsXBT/xynq",


### PR DESCRIPTION
Adds **@wealthville/plugin-wealthville** (v0.2.0) to the third-party registry.

**What it does:** gives Eliza agents live liquidity-pool intelligence — Enter/Hold/Exit verdicts and a composite 0–100 Wealthville Score for Solana (Raydium/Orca/Meteora) and EVM pools, plus the public track record. Three actions: `GET_POOL_SCORE` (triggers on a pool address in the message), `GET_TOP_POOLS`, `GET_WEALTHVILLE_TRACK_RECORD`.

**Safety/trust:**
- Strictly read-only public `GET` endpoints — no wallet access, no signing, no secrets required (optional free `WEALTHVILLE_API_KEY` raises the rate limit).
- Every response carries a not-financial-advice note and links the public, immutable, **miss-inclusive** track record: https://www.wealthville.net/track-record
- Built to @elizaos/core v2 signatures: handlers return `ActionResult`, v2 `{name, content}` example shape, `elizaos.plugin.json` manifest shipped, `@elizaos/core` peer `>=2.0.0-alpha`.

**Links:** repo (monorepo `elizaos-plugin/` subdir, supported via the `directory` field): https://github.com/amitesh-m/wealthville-integrations · npm: https://www.npmjs.com/package/@wealthville/plugin-wealthville · docs: https://wealthville.net/developers

`validate` (24 entries OK) and `generate` were run; the regenerated `generated-registry.json` is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
