### PR TITLE
fix(app): unblock zero-key plugin-view e2e for model-tester and orchestrator

### DIFF
--- a/packages/app/test/ui-smoke/helpers.ts
+++ b/packages/app/test/ui-smoke/helpers.ts
@@ -2790,6 +2790,47 @@ export async function installDefaultAppRoutes(page: Page): Promise<void> {
     await route.fallback();
   });
 
+  // Orchestrator task-progress rail (orchestrator-task-widget) — polls a compact
+  // snapshot (`GET /api/orchestrator/widgets`) and subscribes to its SSE stream
+  // (`/widgets/stream`) wherever it mounts. The Node-only agent-orchestrator
+  // plugin is absent from the keyless smoke stack, so these routes answer 501
+  // exactly like /orchestrator/status and /tasks above; a fresh agent has no
+  // orchestrator tasks, so the canonical empty snapshot matches real zero-state
+  // and keeps the diagnostics guard clean.
+  const emptyOrchestratorWidgetSnapshot = {
+    version: "orchestrator.widgets.v1",
+    generatedAt: SMOKE_GENERATED_AT,
+    totalTaskCount: 0,
+    tasks: [],
+  };
+  await page.route("**/api/orchestrator/widgets**", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    const pathname = new URL(route.request().url()).pathname;
+    if (pathname === "/api/orchestrator/widgets/stream") {
+      await route.fulfill({
+        status: 200,
+        contentType: "text/event-stream",
+        headers: { "cache-control": "no-cache, no-transform" },
+        body: `event: snapshot\ndata: ${JSON.stringify(
+          emptyOrchestratorWidgetSnapshot,
+        )}\n\n`,
+      });
+      return;
+    }
+    if (pathname === "/api/orchestrator/widgets") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(emptyOrchestratorWidgetSnapshot),
+      });
+      return;
+    }
+    await route.fallback();
+  });
+
   await page.route("**/api/auth/status", async (route) => {
     if (route.request().method() !== "GET") {
       await route.fallback();

--- a/plugins/app-model-tester/src/model-tester-app.test.ts
+++ b/plugins/app-model-tester/src/model-tester-app.test.ts
@@ -1,9 +1,15 @@
-/** Verifies model-tester-app.ts registers the overlay app and shell page on import; the UI registries are mocked, so this is a deterministic registration check. */
+/** Verifies model-tester-app.ts registers the overlay app and shell page on import and that its exit affordance navigates through the shell's navigate-view event (not raw history) — the UI registries and the navigate-view dispatch are mocked, so this is a deterministic check. */
 
+import type { ReactElement } from "react";
 import { describe, expect, it, vi } from "vitest";
 
 const registerAppShellPage = vi.hoisted(() => vi.fn());
 const registerOverlayApp = vi.hoisted(() => vi.fn());
+const dispatchNavigateViewEvent = vi.hoisted(() => vi.fn());
+
+vi.mock("@elizaos/shared/events", () => ({
+  dispatchNavigateViewEvent,
+}));
 
 vi.mock("@elizaos/ui/app-shell-registry", () => ({
   registerAppShellPage,
@@ -39,5 +45,27 @@ describe("model tester app registration", () => {
         path: "/model-tester",
       }),
     );
+  });
+
+  it("exits to the apps launcher via the shell navigate-view event, never raw history", async () => {
+    // The shell page hands the view an `exitToApps` prop. A view mounted under a
+    // surface-realm scope may not call history.pushState directly (the #15247
+    // guard denies it without the `navigate` grant); it must ask the shell. This
+    // pins that contract so a regression back to raw pushState fails here rather
+    // than only in the app-window e2e.
+    await import("./model-tester-app");
+    const registration = registerAppShellPage.mock.calls[0]?.[0] as {
+      loader: () => Promise<{ default: () => ReactElement }>;
+    };
+    const loaded = await registration.loader();
+    const element = loaded.default();
+    const exitToApps = (element.props as { exitToApps: () => void }).exitToApps;
+
+    exitToApps();
+
+    expect(dispatchNavigateViewEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchNavigateViewEvent).toHaveBeenCalledWith({
+      viewPath: "/apps",
+    });
   });
 });

--- a/plugins/app-model-tester/src/model-tester-app.ts
+++ b/plugins/app-model-tester/src/model-tester-app.ts
@@ -5,6 +5,7 @@
  * this module for its side effects is intentional; do not tree-shake it.
  */
 
+import { dispatchNavigateViewEvent } from "@elizaos/shared/events";
 import { registerAppShellPage } from "@elizaos/ui/app-shell-registry";
 import type { OverlayApp } from "@elizaos/ui/components/apps/overlay-app-api";
 import { registerOverlayApp } from "@elizaos/ui/components/apps/overlay-app-registry";
@@ -28,9 +29,12 @@ export const modelTesterApp: OverlayApp = {
 registerOverlayApp(modelTesterApp);
 
 function exitToApps(): void {
-  if (typeof window === "undefined") return;
-  window.history.pushState({}, "", "/apps");
-  window.dispatchEvent(new PopStateEvent("popstate"));
+  // Return to the apps launcher through the shell's navigate-view event. A view
+  // mounted under a surface-realm scope may not drive raw history.pushState —
+  // the navigation guard (#15247) denies it without the `navigate` grant — so
+  // it asks the shell, which listens for this event and owns the privileged
+  // route change.
+  dispatchNavigateViewEvent({ viewPath: "/apps" });
 }
 
 function translate(key: string, opts?: Record<string, unknown>): string {


### PR DESCRIPTION
## What & why

The **Zero-Key app browser** lane (`.github/workflows/test.yml` → `zero-key-browser` → "Actual app plugin view browser coverage") is red on `develop`. Its `plugin-views-interaction.spec.ts` runs an "exercise every control, no crash" pass over every plugin GUI view and asserts `[...pageErrors, ...actionFailures, ...networkFailures] === []`. Two views trip it:

1. **model-tester** — a page error:
   > `View "model-tester" denied navigate: raw history.pushState to "/apps" without the "navigate" grant — views use scope.navigate; shell code uses shellHistory`

   `exitToApps()` in `plugins/app-model-tester/src/model-tester-app.ts` drove **raw `window.history.pushState("/apps")`**, which the surface-realm navigation guard added in **#15247** denies for a view mounted under a scope without the `navigate` grant. Fix: route through the shell's navigate-view event (`dispatchNavigateViewEvent({ viewPath: "/apps" })`). The shell already listens for it and performs the privileged navigation, so the user-visible behavior is unchanged (still lands on `/apps`) but there is no guard violation.

2. **orchestrator** — a network failure:
   > `http 501: /api/orchestrator/widgets`

   The `orchestrator-task-widget` polls `GET /api/orchestrator/widgets` (+ `/widgets/stream`). That route is **real and correctly implemented** (`plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts`), and the widget already **degrades gracefully to a J4 error state** on failure. But the Node-only `plugin-agent-orchestrator` is absent from the keyless smoke stack, so the route answers **501** — exactly like `/api/orchestrator/status` and `/api/orchestrator/tasks`, which `installDefaultAppRoutes` already mocks. The gap was purely in the harness. Fix: mock `/widgets` + `/widgets/stream` with the canonical **empty** snapshot (`version: "orchestrator.widgets.v1"`, `tasks: []`) — the real zero-state of a fresh agent. No production fallback is added; the pipeline stays healthy and fails-loud in a real backend.

A unit test pins that model-tester's exit navigates via the navigate-view event and never raw history.

## Files
- `plugins/app-model-tester/src/model-tester-app.ts` — `exitToApps` → `dispatchNavigateViewEvent({ viewPath: "/apps" })` (non-surface `.ts`).
- `plugins/app-model-tester/src/model-tester-app.test.ts` — new test asserting the navigate-view dispatch, no raw `pushState`.
- `packages/app/test/ui-smoke/helpers.ts` — harness mock for `/api/orchestrator/widgets` + `/widgets/stream` (test helper).

## Verification (local)

Ran `bun run --cwd packages/app test:e2e test/ui-smoke/plugin-views-interaction.spec.ts --project=chromium` against the real keyless live-stack.

<details><summary>plugin-views-interaction.spec.ts — before vs after</summary>

```
BEFORE (develop):  2 failed | 26 passed
  x model-tester   -> pageError: View "model-tester" denied navigate: raw history.pushState to "/apps" ...
  x orchestrator   -> networkFailure: http 501: /api/orchestrator/widgets

AFTER (this PR):    28 passed
  ok model-tester — exercise every control, no crash
  ok orchestrator — exercise every control, no crash
Stable across a rerun of both cases: 2 passed.
```
</details>

- Unit: `bun run --cwd plugins/app-model-tester test -- model-tester-app` -> 2 passed (registration + navigate-via-event/no-pushState). Changed-file coverage on `model-tester-app.ts` = LF 9 / LH 7 (78%), clears the 50% floor.
- `bunx biome check` on the three files: clean. `tsgo --noEmit` (app-model-tester): clean. `audit:error-policy-ratchet`: no new fallback-slop.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots `N/A - no user-visible surface changed. This is a navigation-mechanism swap (raw history -> shell navigate-view event, identical destination) plus a test-harness route mock; neither renders anything new. Proven headless by the plugin-views-interaction e2e before/after above.`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots `N/A - no user-visible surface changed (see before-screenshots reason); verified via the headless plugin-views-interaction e2e, not pixels.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video `N/A - no interactive flow changed; the e2e "exercise every control" pass is the mechanical walkthrough (28 views driven, 0 crashes).`
<!-- evidence-row:backend-logs -->
- [x] Backend logs `N/A - no server code changed. The 501 is the keyless stack's expected "Not Implemented" for the Node-only orchestrator plugin's routes; the fix lives entirely in the browser test harness and a plugin renderer module.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs `N/A - captured mechanically by the e2e pageerror + response listeners; the before/after in the Verification section IS that console/network diff (pageError gone, /api/orchestrator/widgets no longer 501).`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory `N/A - no agent/action/provider/prompt/model path is touched; this is UI navigation-guard compliance plus an e2e route mock.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts `N/A - no memory/DB/scheduled-task/wallet/on-chain artifact is produced; the change is a navigation event and a deterministic test stub.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
