### PR TITLE
fix(ui): unify speaking status shimmer

### DIFF
--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -300,6 +300,10 @@ This package mostly reads config injected by the host, not raw env vars:
 - `ConnectionStatus` exists twice (cloud-ui string union vs. the composite
   component) — the cloud-ui one is intentionally NOT re-exported from the root
   barrel to avoid the collision (see comment in `index.ts`).
+- **Chat turn status is phase-neutral.** `TurnStatus` uses the same neutral
+  shimmer and spinner for thinking, tool work, and speaking so transport-phase
+  changes do not flash the app accent. Preserve its `motion-reduce` fallback
+  when changing the status treatment.
 - **Builtin view mutations need semantic action twins.** First-party shell views
   are covered by `src/testing/builtin-view-action-ratchet.ts`: every local
   mutation site in the baseline either maps to a semantic action (`SETTINGS`,

--- a/packages/ui/CLAUDE.md
+++ b/packages/ui/CLAUDE.md
@@ -300,6 +300,10 @@ This package mostly reads config injected by the host, not raw env vars:
 - `ConnectionStatus` exists twice (cloud-ui string union vs. the composite
   component) — the cloud-ui one is intentionally NOT re-exported from the root
   barrel to avoid the collision (see comment in `index.ts`).
+- **Chat turn status is phase-neutral.** `TurnStatus` uses the same neutral
+  shimmer and spinner for thinking, tool work, and speaking so transport-phase
+  changes do not flash the app accent. Preserve its `motion-reduce` fallback
+  when changing the status treatment.
 - **Builtin view mutations need semantic action twins.** First-party shell views
   are covered by `src/testing/builtin-view-action-ratchet.ts`: every local
   mutation site in the baseline either maps to a semantic action (`SETTINGS`,

--- a/packages/ui/src/components/composites/chat/chat-typing-indicator.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-typing-indicator.test.tsx
@@ -103,4 +103,21 @@ describe("TurnStatus working indicator", () => {
     expect(screen.queryByTestId("typing-dots")).toBeNull();
     expect(screen.queryByTestId("turn-status-spinner")).toBeNull();
   });
+
+  it("keeps the speaking phase neutral and shimmering", () => {
+    const { rerender } = render(
+      <TurnStatus status={{ kind: "speaking" }} showLabel={false} />,
+    );
+    const compactLabel = screen.getByTestId("turn-status-label");
+    expect(compactLabel.textContent).toBe("Speaking");
+    expect(compactLabel.className).toContain("shimmer");
+    expect(compactLabel.className).not.toContain("255,200,150");
+
+    rerender(<TurnStatus status={{ kind: "speaking" }} />);
+    const fullLabel = screen.getByTestId("turn-status-label");
+    expect(fullLabel.className).toContain("shimmer");
+    expect(
+      screen.getByTestId("turn-status-spinner").getAttribute("class"),
+    ).toContain("text-white/70");
+  });
 });

--- a/packages/ui/src/components/composites/chat/chat-typing-indicator.tsx
+++ b/packages/ui/src/components/composites/chat/chat-typing-indicator.tsx
@@ -8,13 +8,12 @@
  * Codex-style working indicator (#13535). All three render paths share the
  * single `TypingDots` triad so there is exactly one dots implementation.
  *
- * Brand rule: orange (the accent) tints TurnStatus ONLY for `speaking`; every
- * other phase is neutral. No blue anywhere.
+ * Every TurnStatus phase uses the same neutral shimmer so transport state never
+ * changes the chat's accent color or flashes between unrelated treatments.
  */
 import { useEffect, useRef, useState } from "react";
 
 import type { ChatTurnStatus } from "../../../api/client-types-chat";
-import { cn } from "../../../lib/utils";
 import { Marker, MarkerContent, MarkerIcon } from "../../ui/marker";
 import { Spinner } from "../../ui/spinner";
 import { ChatBubble } from "./chat-bubble";
@@ -233,7 +232,6 @@ export function TurnStatus({
   showLabel?: boolean;
 }) {
   const shown = useDebouncedTurnStatus(status);
-  const speaking = shown?.kind === "speaking";
   // Clock is driven by the raw (un-debounced) status so it starts at turn open,
   // not after the label's min-dwell debounce.
   const elapsed = useElapsedSeconds(status !== null);
@@ -252,12 +250,7 @@ export function TurnStatus({
         aria-live="polite"
       >
         <MarkerContent
-          className={cn(
-            "text-[13px] font-medium",
-            speaking
-              ? "text-[rgba(255,200,150,0.95)]"
-              : "shimmer motion-reduce:shimmer-none",
-          )}
+          className="shimmer text-[13px] font-medium motion-reduce:shimmer-none"
           data-testid="turn-status-label"
         >
           {label}
@@ -278,19 +271,12 @@ export function TurnStatus({
         <Spinner
           size={14}
           data-testid="turn-status-spinner"
-          className={cn(
-            "motion-reduce:animate-none",
-            speaking ? "text-[rgba(255,200,150,0.95)]" : "text-white/70",
-          )}
+          className="text-white/70 motion-reduce:animate-none"
         />
       </MarkerIcon>
       <MarkerContent className="inline-flex items-baseline text-[13px] font-medium tabular-nums">
         <span
-          className={cn(
-            speaking
-              ? "text-[rgba(255,200,150,0.95)]"
-              : "shimmer motion-reduce:shimmer-none",
-          )}
+          className="shimmer motion-reduce:shimmer-none"
           data-testid="turn-status-label"
         >
           {label}


### PR DESCRIPTION
# Relates to

Closes #16375

# What changed

- Use the established neutral shimmer and spinner for the speaking turn phase.
- Document the phase-neutral chat status convention.

# Why

Speaking was the only active turn phase using a one-off orange treatment, causing a distracting color flash as a response moved from generation to speech.

# Testing

- `bun run --cwd packages/ui test -- src/components/composites/chat/chat-typing-indicator.test.tsx` — 7 passed
- `bun run --cwd packages/ui test:chat-sheet-e2e` — passed; 72 desktop/touch states, zero page or console errors
- `CI=1 bun run verify` — passed; 573 Turbo tasks plus all repository audits
- `bun run --cwd packages/app audit:app` — 246 passed; broken=0, needs-work=0
- `bun run check:agents-claude` — 296 documentation pairs identical

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] [Before full-page speaking state](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16377-before-speaking.jpg).
<!-- evidence-row:after-screenshots -->
- [x] [After full-page speaking state](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16377-after-speaking.jpg).
<!-- evidence-row:walkthrough-video -->
- [x] [MP4 real-browser chat-sheet walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16377-speaking-walkthrough.mp4).
<!-- evidence-row:backend-logs -->
- [x] N/A - presentational client-only change; no backend path changed.
<!-- evidence-row:frontend-logs -->
- [x] [16377-app-audit-report.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16377-app-audit-report.json)
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, scheduling, wallet, or generated-domain output changed.

# Known gaps / failures

None.

<!-- evidence-row:ocr-review -->
- [x] [16377-ocr-triage.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16377-ocr-triage.json)
