### PR TITLE
fix(agent): web-fetch/web-search deliver via ActionResult only — no success-callback double-send

### DIFF
--- a/packages/agent/src/runtime/actions/web-fetch.test.ts
+++ b/packages/agent/src/runtime/actions/web-fetch.test.ts
@@ -69,7 +69,7 @@ describe("WEB_FETCH action", () => {
     }
   });
 
-  it("returns the fetched text snippet and fires the callback", async () => {
+  it("returns the fetched value in the result WITHOUT a user-facing callback", async () => {
     __setPinnedFetchImplForTests(
       async () => new Response("hello world", { status: 200 }),
     );
@@ -78,12 +78,15 @@ describe("WEB_FETCH action", () => {
 
     expect(result.success).toBe(true);
     expect(result.text).toBe("hello world");
-    expect(captured.text).toBe("hello world");
     expect(result.data).toMatchObject({
       actionName: "WEB_FETCH",
       url: TEST_URL,
       value: "hello world",
     });
+    // Data-gathering action: the value flows to the reply via the ActionResult,
+    // not a standalone user message. No success callback fires (which would be a
+    // spurious raw-value message before the synthesized answer).
+    expect(captured.text).toBeUndefined();
   });
 
   it("caps an oversized response body (streaming read, not full buffer)", async () => {

--- a/packages/agent/src/runtime/actions/web-fetch.ts
+++ b/packages/agent/src/runtime/actions/web-fetch.ts
@@ -19,7 +19,6 @@
 import {
   type Action,
   type ActionResult,
-  type Content,
   type HandlerCallback,
   type IAgentRuntime,
   logger,
@@ -200,12 +199,12 @@ export const webFetch: Action & Record<string, unknown> = {
       }
 
       const value = extractValue(result.text, extract);
-      const content: Content = {
-        text: value,
-        actions: ["WEB_FETCH"],
-        data: { actionName: "WEB_FETCH", url, value },
-      };
-      callback?.(content);
+      // Data-gathering action: the fetched value is returned in the ActionResult
+      // (below) and reaches the reply through the RESPONSE_HANDLER synthesis, so
+      // it does NOT deliver a user-facing callback on success. Delivering the raw
+      // value here produced a spurious extra message before the synthesized
+      // answer (the "62330" then "BTC's at $62,330" double-send). Errors DO
+      // still call back so failures stay visible.
       return {
         text: value,
         success: true,

--- a/packages/agent/src/runtime/actions/web-search.test.ts
+++ b/packages/agent/src/runtime/actions/web-search.test.ts
@@ -149,7 +149,10 @@ describe("WEB_SEARCH action", () => {
     const { result, captured } = await runHandler({ query: "ramen" });
     expect(result.success).toBe(true);
     expect(result.text).toContain("Tabelog");
-    expect(captured.text).toContain("Tabelog");
+    // Data-gathering action: results flow to the reply via the ActionResult,
+    // not a standalone user message — delivering them dumped raw search JSON
+    // into the chat ahead of the synthesized reply. No success callback.
+    expect(captured.text).toBeUndefined();
     expect(result.data).toMatchObject({
       actionName: "WEB_SEARCH",
       provider: "parallel",

--- a/packages/agent/src/runtime/actions/web-search.ts
+++ b/packages/agent/src/runtime/actions/web-search.ts
@@ -23,7 +23,6 @@
 import {
   type Action,
   type ActionResult,
-  type Content,
   type HandlerCallback,
   type IAgentRuntime,
   logger,
@@ -237,12 +236,11 @@ export const webSearch: Action & Record<string, unknown> = {
       }
 
       const value = results.slice(0, WEB_SEARCH_RESULT_CHARS);
-      const content: Content = {
-        text: value,
-        actions: ["WEB_SEARCH"],
-        data: { actionName: "WEB_SEARCH", query, provider, value },
-      };
-      callback?.(content);
+      // Data-gathering action: the raw results are returned in the ActionResult
+      // (below) for the RESPONSE_HANDLER to synthesize an answer from, and are
+      // NOT delivered as a user-facing callback. Delivering them dumped the raw
+      // search JSON/article text straight into the chat (chunked into several
+      // messages) before the synthesized reply. Errors DO still call back.
       return {
         text: value,
         success: true,


### PR DESCRIPTION
## What

`WEB_FETCH` / `WEB_SEARCH` delivered their raw fetched value as a user-facing callback message on success, producing a spurious extra Discord message before the synthesized reply — observed live as `62330` followed by `BTC's at $62,330`, and raw search JSON dumped into chat ahead of the answer.

Data-gathering actions return their value through the `ActionResult` (which feeds RESPONSE_HANDLER synthesis); the success-path `callback?.()` was a second, unformatted delivery of the same data. This removes the success callback on both actions. Error callbacks stay so failures remain visible.

## Why not keep the callback

The callback path is for actions whose output IS the user-facing message. For data-gathering actions the planner/evaluator synthesizes the reply from the `ActionResult`; delivering the raw value too guarantees a double-send on every successful fetch.

## Evidence

| Type | Evidence |
|---|---|
| Real-LLM trajectory | Live Discord turn (before): two messages per fetch — raw `62330` then the synthesized reply. After: single clean message per turn across a 9-probe battery (BTC/ETH/SOL/DOGE prices, Tokyo/NYC weather), each trajectory showing `WEB_FETCH → ok:true → evaluation FINISH → one send`. <details><summary>sample post-fix trajectory</summary>`stages: [messageHandler, toolSearch, planner, tool, evaluation]` — `TOOL: WEB_FETCH https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd | ok: true` — `EVAL: FINISH — "BTC is at $64,439 right now."` — Discord shows exactly one bot message.</details> |
| Backend logs | `[BASIC-CAPABILITIES] Message sent` fires once per turn post-fix (was twice). |
| Tests | `web-fetch.test.ts` / `web-search.test.ts` updated: success path asserts NO user-facing callback fires (`captured.text` undefined) while `result.text`/`result.data.value` carry the fetched value; error paths still assert callbacks. 26/26 green. |
| Screenshots / video | N/A - backend action delivery change; the user-visible effect is message COUNT, covered by the trajectory + live battery evidence above. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Evidence rows

<!-- evidence-row:before-screenshots -->
`N/A - backend-only change, no UI-bearing files touched; the user-visible effect is Discord message content/count, shown in the llm-trajectory and domain-artifacts rows.`

<!-- evidence-row:after-screenshots -->
`N/A - backend-only change, no UI-bearing files touched; the user-visible effect is Discord message content/count, shown in the llm-trajectory and domain-artifacts rows.`

<!-- evidence-row:walkthrough-video -->
`N/A - backend-only change; the complete run-through is the live Discord battery transcript attached under domain artifacts.`

<!-- evidence-row:backend-logs -->
https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16378-backend-log-delivery.txt

<!-- evidence-row:frontend-logs -->
`N/A - no frontend surface touched.`

<!-- evidence-row:llm-trajectory -->
https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16378-trajectory-btc-cerebras.txt

<!-- evidence-row:domain-artifacts -->
https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16378-battery-transcript.txt
