### PR TITLE
feat(cli-inference): stage-1 envelope mode, all-tiers, and tier metadata for the claude-sdk lane

### DIFF
--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -13,6 +13,10 @@ export * from "./access-control/filter";
 export * from "./account-pool-bridge";
 export * from "./action-names";
 export * from "./actions";
+// The Stage-1 native-tool contract: model-provider plugins that serve
+// RESPONSE_HANDLER structurally (native tool capture) key their detection on
+// this name instead of duplicating the literal.
+export { HANDLE_RESPONSE_TOOL_NAME } from "./actions/to-tool";
 export * from "./activity-plaintext";
 export * from "./api/http-helpers";
 export * from "./api/route-helpers";

--- a/plugins/plugin-cli-inference/AGENTS.md
+++ b/plugins/plugin-cli-inference/AGENTS.md
@@ -155,6 +155,8 @@ plugins/plugin-cli-inference/
 | `ELIZA_CLI_SDK_RESTART_AFTER_TURNS` | No | `20` | `claude-sdk`: restart a warm session after N turns (bounds context) |
 | `ELIZA_CLI_CLAUDE_EFFORT` | No | (SDK default: high) | `claude-sdk`: reasoning effort forwarded to the SDK `effort` option (`low`/`medium`/`high`/`xhigh`/`max`); an unsupported level for the model is silently downgraded by the SDK |
 | `ELIZA_CLI_CLAUDE_PLANNER_EFFORT` | No | (falls back to `ELIZA_CLI_CLAUDE_EFFORT`) | `claude-sdk`: effort for the ROUTE-mode planner tier, so routing depth tunes independently of reply depth |
+| `ELIZA_CLI_CLAUDE_ALL_TIERS` | No | (unset = large tiers only) | `claude-sdk`: also serve the high-frequency triage tiers (TEXT_SMALL/NANO/MEDIUM) on this route so the ENTIRE text brain runs on the one subscription (no cerebras/gemma fallthrough). Higher subscription usage; triage defaults to the cheaper large-tier model, not the planner tier |
+| `ELIZA_CLI_CLAUDE_SMALL_MODEL` | No | (falls back to `ELIZA_CLI_CLAUDE_MODEL`) | `claude-sdk` ALL-TIERS: model for the triage tiers (should-respond gate, callback rewrite) — set a cheaper model (e.g. sonnet/haiku) so high-frequency triage doesn't run on opus |
 | `ELIZA_CLI_CODEX_MODEL` | No | `gpt-5.5` | codex large-tier model (`codex exec -m` / SDK large tier) |
 | `ELIZA_CLI_CODEX_PLANNER_MODEL` | No | (falls back to large) | `codex-sdk` small/planner tier model |
 | `ELIZA_CLI_CODEX_REASONING_EFFORT` | No | (sdk default) | `codex-sdk`: `modelReasoningEffort` (minimal..xhigh) |

--- a/plugins/plugin-cli-inference/CLAUDE.md
+++ b/plugins/plugin-cli-inference/CLAUDE.md
@@ -155,6 +155,8 @@ plugins/plugin-cli-inference/
 | `ELIZA_CLI_SDK_RESTART_AFTER_TURNS` | No | `20` | `claude-sdk`: restart a warm session after N turns (bounds context) |
 | `ELIZA_CLI_CLAUDE_EFFORT` | No | (SDK default: high) | `claude-sdk`: reasoning effort forwarded to the SDK `effort` option (`low`/`medium`/`high`/`xhigh`/`max`); an unsupported level for the model is silently downgraded by the SDK |
 | `ELIZA_CLI_CLAUDE_PLANNER_EFFORT` | No | (falls back to `ELIZA_CLI_CLAUDE_EFFORT`) | `claude-sdk`: effort for the ROUTE-mode planner tier, so routing depth tunes independently of reply depth |
+| `ELIZA_CLI_CLAUDE_ALL_TIERS` | No | (unset = large tiers only) | `claude-sdk`: also serve the high-frequency triage tiers (TEXT_SMALL/NANO/MEDIUM) on this route so the ENTIRE text brain runs on the one subscription (no cerebras/gemma fallthrough). Higher subscription usage; triage defaults to the cheaper large-tier model, not the planner tier |
+| `ELIZA_CLI_CLAUDE_SMALL_MODEL` | No | (falls back to `ELIZA_CLI_CLAUDE_MODEL`) | `claude-sdk` ALL-TIERS: model for the triage tiers (should-respond gate, callback rewrite) — set a cheaper model (e.g. sonnet/haiku) so high-frequency triage doesn't run on opus |
 | `ELIZA_CLI_CODEX_MODEL` | No | `gpt-5.5` | codex large-tier model (`codex exec -m` / SDK large tier) |
 | `ELIZA_CLI_CODEX_PLANNER_MODEL` | No | (falls back to large) | `codex-sdk` small/planner tier model |
 | `ELIZA_CLI_CODEX_REASONING_EFFORT` | No | (sdk default) | `codex-sdk`: `modelReasoningEffort` (minimal..xhigh) |

--- a/plugins/plugin-cli-inference/__tests__/claude-sdk-session.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/claude-sdk-session.test.ts
@@ -95,7 +95,7 @@ const fakeZod = {
 function makeSession(
   scripts: TurnScript[],
   opts: {
-    router?: boolean;
+    mode?: "text" | "route" | "envelope";
     restartAfterTurns?: number;
     turnTimeoutMs?: number;
     subprocessEnv?: Record<string, string | undefined>;
@@ -105,7 +105,7 @@ function makeSession(
   const session = new ClaudeSdkSession({
     model: "test-model",
     systemPrompt: "test system",
-    router: opts.router ?? false,
+    mode: opts.mode ?? "text",
     restartAfterTurns: opts.restartAfterTurns,
     turnTimeoutMs: opts.turnTimeoutMs,
     subprocessEnv: opts.subprocessEnv,
@@ -124,14 +124,14 @@ describe("ClaudeSdkSession — TEXT mode", () => {
       zodModule: fakeZod,
     });
 
-    expect(await session.generate("hi")).toBe("hello world");
+    expect(await session.send("hi")).toBe("hello world");
     expect(queryOptions()[0].model).toBe("claude-opus-4-8");
     await session.dispose();
   });
 
   it("returns streamed assistant text", async () => {
     const { session } = makeSession([{ text: "hello world", subtype: "success" }]);
-    expect(await session.generate("hi")).toBe("hello world");
+    expect(await session.send("hi")).toBe("hello world");
     await session.dispose();
   });
 
@@ -140,14 +140,14 @@ describe("ClaudeSdkSession — TEXT mode", () => {
     const { session, queryOptions } = makeSession([{ text: "hello world", subtype: "success" }], {
       subprocessEnv,
     });
-    expect(await session.generate("hi")).toBe("hello world");
+    expect(await session.send("hi")).toBe("hello world");
     expect(queryOptions()[0].env).toBe(subprocessEnv);
     await session.dispose();
   });
 
   it("falls back to result.result only on a clean success turn", async () => {
     const { session } = makeSession([{ text: "", subtype: "success", resultText: "the answer" }]);
-    expect(await session.generate("hi")).toBe("the answer");
+    expect(await session.send("hi")).toBe("the answer");
     await session.dispose();
   });
 
@@ -155,13 +155,13 @@ describe("ClaudeSdkSession — TEXT mode", () => {
     const { session } = makeSession([
       { text: "", subtype: "error_max_turns", resultText: "Reached maximum turns" },
     ]);
-    await expect(session.generate("hi")).rejects.toThrow(/empty completion/);
+    await expect(session.send("hi")).rejects.toThrow(/empty completion/);
     await session.dispose();
   });
 
   it("THROWS when the generator ends before a result (session died mid-turn)", async () => {
     const { session } = makeSession([{ text: "partial", noResult: true }]);
-    await expect(session.generate("hi")).rejects.toThrow(/session-ended|empty completion/);
+    await expect(session.send("hi")).rejects.toThrow(/session-ended|empty completion/);
     await session.dispose();
   });
 
@@ -173,7 +173,7 @@ describe("ClaudeSdkSession — TEXT mode", () => {
         resultText: "You've hit your session limit · resets 9:30pm (UTC)",
       },
     ]);
-    await expect(session.generate("hi")).rejects.toThrow(/subscription rate limit reached/);
+    await expect(session.send("hi")).rejects.toThrow(/subscription rate limit reached/);
     await session.dispose();
   });
 
@@ -184,7 +184,7 @@ describe("ClaudeSdkSession — TEXT mode", () => {
         subtype: "success",
       },
     ]);
-    await expect(session.generate("hi")).rejects.toMatchObject({
+    await expect(session.send("hi")).rejects.toMatchObject({
       name: "ProviderApiError",
       statusCode: 529,
       retryable: true,
@@ -195,7 +195,7 @@ describe("ClaudeSdkSession — TEXT mode", () => {
   it("bounds a hung SDK turn below connector timeouts", async () => {
     const { session } = makeSession([{ hang: true }], { turnTimeoutMs: 5 });
     const started = Date.now();
-    await expect(session.generate("hi")).rejects.toBeInstanceOf(ProviderApiError);
+    await expect(session.send("hi")).rejects.toBeInstanceOf(ProviderApiError);
     expect(Date.now() - started).toBeLessThan(1_000);
     await session.dispose();
   });
@@ -205,8 +205,8 @@ describe("ClaudeSdkSession — TEXT mode", () => {
       { text: "", subtype: "error_max_turns" }, // turn 1 throws
       { text: "recovered", subtype: "success" }, // turn 2 ok (fresh start)
     ]);
-    await expect(session.generate("a")).rejects.toThrow();
-    expect(await session.generate("b")).toBe("recovered");
+    await expect(session.send("a")).rejects.toThrow();
+    expect(await session.send("b")).toBe("recovered");
     expect(starts()).toBe(2); // re-started after the failure
     await session.dispose();
   });
@@ -220,15 +220,15 @@ describe("ClaudeSdkSession — TEXT mode", () => {
       ],
       { restartAfterTurns: 1 }
     );
-    expect(await session.generate("1")).toBe("one");
-    expect(await session.generate("2")).toBe("two");
+    expect(await session.send("1")).toBe("one");
+    expect(await session.send("2")).toBe("two");
     expect(starts()).toBeGreaterThanOrEqual(2); // restarted between turns
     await session.dispose();
   });
 
   it("rejects an empty prompt body", async () => {
     const { session } = makeSession([{ text: "x", subtype: "success" }]);
-    await expect(session.generate("   ")).rejects.toThrow(/empty prompt body/);
+    await expect(session.send("   ")).rejects.toThrow(/empty prompt body/);
     await session.dispose();
   });
 });
@@ -237,9 +237,9 @@ describe("ClaudeSdkSession — ROUTE mode", () => {
   it("captures the tool decision and returns it as bare {action,params} JSON", async () => {
     const { session } = makeSession(
       [{ toolCall: { action: "WEB_FETCH", params: { url: "u" } }, subtype: "error_max_turns" }],
-      { router: true }
+      { mode: "route" }
     );
-    const out = JSON.parse(await session.route("price?"));
+    const out = JSON.parse(await session.send("price?"));
     expect(out).toEqual({ action: "WEB_FETCH", params: { url: "u" } });
     await session.dispose();
   });
@@ -253,9 +253,9 @@ describe("ClaudeSdkSession — ROUTE mode", () => {
           subtype: "error_max_turns",
         },
       ],
-      { router: true }
+      { mode: "route" }
     );
-    const out = JSON.parse(await session.route("hi"));
+    const out = JSON.parse(await session.send("hi"));
     expect(out.action).toBe("REPLY");
     expect(out.params.text).toBe("real");
     await session.dispose();
@@ -270,9 +270,9 @@ describe("ClaudeSdkSession — ROUTE mode", () => {
           subtype: "error_max_turns",
         },
       ],
-      { router: true }
+      { mode: "route" }
     );
-    const out = JSON.parse(await session.route("price?"));
+    const out = JSON.parse(await session.send("price?"));
     expect(out).toEqual({
       action: "WEB_FETCH",
       params: { url: "https://example.test" },
@@ -283,18 +283,18 @@ describe("ClaudeSdkSession — ROUTE mode", () => {
   it("does NOT surface an agentic preamble as a REPLY when the model skips the tool (error_max_turns)", async () => {
     const { session } = makeSession(
       [{ text: "I'll route this to WEB_FETCH...", subtype: "error_max_turns" }],
-      { router: true }
+      { mode: "route" }
     );
     // No decision + non-success subtype => throw, never leak the thought.
-    await expect(session.route("hi")).rejects.toThrow(/no decision/);
+    await expect(session.send("hi")).rejects.toThrow(/no decision/);
     await session.dispose();
   });
 
   it("accepts a genuine terminal answer (clean success, no tool) as a REPLY", async () => {
     const { session } = makeSession([{ text: "2 + 2 is 4.", subtype: "success" }], {
-      router: true,
+      mode: "route",
     });
-    const out = JSON.parse(await session.route("2+2?"));
+    const out = JSON.parse(await session.send("2+2?"));
     expect(out).toEqual({ action: "REPLY", params: { text: "2 + 2 is 4." } });
     await session.dispose();
   });
@@ -302,9 +302,9 @@ describe("ClaudeSdkSession — ROUTE mode", () => {
   it("coerces malformed params to {} but keeps the action", async () => {
     const { session } = makeSession(
       [{ toolCall: { action: "IGNORE", params: "not-an-object" }, subtype: "error_max_turns" }],
-      { router: true }
+      { mode: "route" }
     );
-    const out = JSON.parse(await session.route("hi"));
+    const out = JSON.parse(await session.send("hi"));
     expect(out).toEqual({ action: "IGNORE", params: {} });
     await session.dispose();
   });
@@ -318,9 +318,9 @@ describe("ClaudeSdkSession — serialization", () => {
         { toolCall: { action: "A", params: {} }, subtype: "error_max_turns" },
         { toolCall: { action: "B", params: {} }, subtype: "error_max_turns" },
       ],
-      { router: true }
+      { mode: "route" }
     );
-    const [r1, r2] = await Promise.all([session.route("one"), session.route("two")]);
+    const [r1, r2] = await Promise.all([session.send("one"), session.send("two")]);
     const actions = [JSON.parse(r1).action, JSON.parse(r2).action].sort();
     expect(actions).toEqual(["A", "B"]); // both distinct, no cross-contamination
     await session.dispose();

--- a/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
@@ -10,9 +10,12 @@ import type { ChatMessage, IAgentRuntime, PluginAutoEnableContext } from "@eliza
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { shouldEnable } from "../auto-enable";
 import {
+  buildCleanRoutingParams,
+  buildCleanRoutingSystemPrompt,
   buildEnvelopeBody,
   buildModelMetadata,
   buildModels,
+  buildRouterBody,
   ClaudeCli,
   ClaudeSdkSession,
   CodexSdkSession,
@@ -1106,6 +1109,71 @@ describe("Stage-1 ENVELOPE mode (claude-sdk handle_response tool)", () => {
         { name: "SOME_OTHER_TOOL", description: "", parameters: {} },
       ] as never)
     ).toBeUndefined();
+  });
+
+  it("buildRouterBody renders the action menu, param hints, and transcript", () => {
+    const body = buildRouterBody({
+      system: "You are the agent.",
+      messages: [
+        { role: "system", content: "steering (dropped)" },
+        { role: "user", content: "whats btc at" },
+        { role: "assistant", content: "Checking now." },
+      ],
+      tools: [
+        {
+          name: "WEB_FETCH",
+          description: "Fetch one URL.",
+          parameters: {
+            type: "object",
+            properties: {
+              url: { type: "string" },
+              extract: { type: "string" },
+              mode: { type: "string", enum: ["fast", "full"] },
+            },
+            required: ["url"],
+          },
+        },
+        { name: "VIEWS", description: "Open a view.", parameters: {} },
+      ],
+    } as never);
+    expect(body).toContain("WEB_FETCH — Fetch one URL.");
+    expect(body).toContain("url: string");
+    expect(body).toContain("extract?: string");
+    expect(body).toContain('one of ["fast", "full"]');
+    expect(body).toContain("VIEWS — Open a view. [params: (no params)]");
+    expect(body).toContain("User: whats btc at");
+    expect(body).toContain("Assistant: Checking now.");
+    expect(body).not.toContain("steering (dropped)");
+    expect(body).toContain("Agent persona / voice");
+  });
+
+  it("buildCleanRoutingParams rewrites a grammar-heavy planner call into the clean routing form", () => {
+    const clean = buildCleanRoutingParams({
+      system: "persona here",
+      messages: [
+        { role: "user", content: "whats eth at" },
+        { role: "user", content: "planner_stage: <grammar blob that must be stripped>" },
+      ],
+      tools: [{ name: "WEB_FETCH", description: "Fetch.", parameters: {} }],
+    } as never);
+    expect(clean.system).toContain("action router");
+    expect(clean.system).toContain("WEB_FETCH");
+    expect(clean.prompt).toContain("whats eth at");
+    expect(clean.prompt).not.toContain("grammar blob");
+    // only system+prompt survive so flattenPrompt forwards exactly the clean form
+    expect(clean.messages).toBeUndefined();
+    expect(clean.tools).toBeUndefined();
+  });
+
+  it("buildCleanRoutingSystemPrompt states the tool requirement only on flagged turns", () => {
+    const menu = "- WEB_FETCH — Fetch. [params: url: string]";
+    const forced = buildCleanRoutingSystemPrompt(menu, "persona", true);
+    expect(forced).toContain("flagged as needing a tool");
+    expect(forced).toContain("Do NOT answer such requests from memory");
+    const free = buildCleanRoutingSystemPrompt(menu, undefined, false);
+    expect(free).toContain("choose REPLY and put the COMPLETE answer");
+    expect(free).not.toContain("flagged as needing a tool");
+    expect(free).not.toContain("persona");
   });
 
   it("buildEnvelopeBody folds the per-turn system into the body and closes with the tool directive", () => {

--- a/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
@@ -10,12 +10,14 @@ import type { ChatMessage, IAgentRuntime, PluginAutoEnableContext } from "@eliza
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { shouldEnable } from "../auto-enable";
 import {
+  buildEnvelopeBody,
   buildModelMetadata,
   buildModels,
   ClaudeCli,
   ClaudeSdkSession,
   CodexSdkSession,
   cliInferencePlugin,
+  findHandleResponseTool,
   LARGE_TIER_MODEL_TYPES,
   resolveCliBackend,
   resolveSdkEffort,
@@ -469,7 +471,7 @@ describe("models map gating (large-tier only)", () => {
 
   it("routes warm Claude SDK handlers through the current default Opus model", async () => {
     let captured: { model?: string; body?: string } = {};
-    vi.spyOn(ClaudeSdkSession.prototype, "generate").mockImplementation(function (
+    vi.spyOn(ClaudeSdkSession.prototype, "send").mockImplementation(function (
       this: ClaudeSdkSession,
       body: string
     ) {
@@ -650,7 +652,7 @@ describe("reasoning effort (SDK effort option)", () => {
       effort: "xhigh",
       sdkModule: fakeSdk as never,
     });
-    await session.generate("hi");
+    await session.send("hi");
     expect(captured?.effort).toBe("xhigh");
     await session.dispose();
   });
@@ -673,7 +675,7 @@ describe("reasoning effort (SDK effort option)", () => {
       model: "claude-opus-4-8",
       sdkModule: fakeSdk as never,
     });
-    await session.generate("hi");
+    await session.send("hi");
     expect(captured && "effort" in captured).toBe(false);
     await session.dispose();
   });
@@ -697,7 +699,7 @@ describe("reasoning effort (SDK effort option)", () => {
       effort: "ultra",
       sdkModule: fakeSdk as never,
     });
-    await session.generate("hi");
+    await session.send("hi");
     expect(captured && "effort" in captured).toBe(false);
     await session.dispose();
   });
@@ -727,7 +729,7 @@ describe("resolveSdkEffort (per-tier effort env precedence)", () => {
 
   it("reply tier (router=false) reads ELIZA_CLI_CLAUDE_EFFORT", () => {
     const runtime = runtimeWith({ ELIZA_CLI_CLAUDE_EFFORT: "high" });
-    expect(resolveSdkEffort(runtime, false)).toBe("high");
+    expect(resolveSdkEffort(runtime, "text")).toBe("high");
   });
 
   it("reply tier ignores the planner override even when it is set", () => {
@@ -735,7 +737,7 @@ describe("resolveSdkEffort (per-tier effort env precedence)", () => {
       ELIZA_CLI_CLAUDE_EFFORT: "medium",
       ELIZA_CLI_CLAUDE_PLANNER_EFFORT: "max",
     });
-    expect(resolveSdkEffort(runtime, false)).toBe("medium");
+    expect(resolveSdkEffort(runtime, "text")).toBe("medium");
   });
 
   it("planner tier (router=true) prefers ELIZA_CLI_CLAUDE_PLANNER_EFFORT", () => {
@@ -743,18 +745,18 @@ describe("resolveSdkEffort (per-tier effort env precedence)", () => {
       ELIZA_CLI_CLAUDE_EFFORT: "low",
       ELIZA_CLI_CLAUDE_PLANNER_EFFORT: "max",
     });
-    expect(resolveSdkEffort(runtime, true)).toBe("max");
+    expect(resolveSdkEffort(runtime, "route")).toBe("max");
   });
 
   it("planner tier falls back to the shared ELIZA_CLI_CLAUDE_EFFORT when its own key is unset", () => {
     const runtime = runtimeWith({ ELIZA_CLI_CLAUDE_EFFORT: "high" });
-    expect(resolveSdkEffort(runtime, true)).toBe("high");
+    expect(resolveSdkEffort(runtime, "route")).toBe("high");
   });
 
   it("returns undefined for both tiers when no effort is configured (SDK keeps its default)", () => {
     const runtime = runtimeWith({});
-    expect(resolveSdkEffort(runtime, false)).toBeUndefined();
-    expect(resolveSdkEffort(runtime, true)).toBeUndefined();
+    expect(resolveSdkEffort(runtime, "text")).toBeUndefined();
+    expect(resolveSdkEffort(runtime, "route")).toBeUndefined();
   });
 
   it("passes an unrecognized level through unvalidated — validation is normalizeEffort's job at the session", () => {
@@ -762,8 +764,8 @@ describe("resolveSdkEffort (per-tier effort env precedence)", () => {
     // (tested above) drops unknown levels. Keeping the two concerns split means a
     // bad env never silently downgrades a valid per-tier override.
     const runtime = runtimeWith({ ELIZA_CLI_CLAUDE_EFFORT: "ultra" });
-    expect(resolveSdkEffort(runtime, false)).toBe("ultra");
-    expect(normalizeEffort(resolveSdkEffort(runtime, false))).toBeNull();
+    expect(resolveSdkEffort(runtime, "text")).toBe("ultra");
+    expect(normalizeEffort(resolveSdkEffort(runtime, "text"))).toBeNull();
   });
 });
 
@@ -818,5 +820,300 @@ describe("buildModelMetadata (RUNTIME_MODEL_CONTEXT self-report)", () => {
     process.env.ELIZA_CLI_CODEX_MODEL = "gpt-5.6-sol";
     const md = buildModelMetadata({ ELIZA_CHAT_VIA_CLI: "codex-sdk" });
     expect(md?.RESPONSE_HANDLER).toEqual({ displayModel: "gpt-5.6-sol" });
+  });
+});
+
+describe("ALL-TIERS mode (ELIZA_CLI_CLAUDE_ALL_TIERS)", () => {
+  const prev = {
+    all: process.env.ELIZA_CLI_CLAUDE_ALL_TIERS,
+    large: process.env.ELIZA_CLI_CLAUDE_MODEL,
+    small: process.env.ELIZA_CLI_CLAUDE_SMALL_MODEL,
+    chat: process.env.ELIZA_CHAT_VIA_CLI,
+    planner: process.env.ELIZA_PLANNER_NATIVE_TOOLS,
+  };
+  afterEach(() => {
+    for (const [k, v] of Object.entries({
+      ELIZA_CLI_CLAUDE_ALL_TIERS: prev.all,
+      ELIZA_CLI_CLAUDE_MODEL: prev.large,
+      ELIZA_CLI_CLAUDE_SMALL_MODEL: prev.small,
+      ELIZA_CHAT_VIA_CLI: prev.chat,
+      ELIZA_PLANNER_NATIVE_TOOLS: prev.planner,
+    })) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  it("does NOT register triage tiers by default (they fall through to the cheap provider)", () => {
+    process.env.ELIZA_CHAT_VIA_CLI = "claude-sdk";
+    delete process.env.ELIZA_CLI_CLAUDE_ALL_TIERS;
+    const models = buildModels({ ELIZA_CHAT_VIA_CLI: "claude-sdk" });
+    expect(models?.TEXT_LARGE).toBeTypeOf("function");
+    expect(models?.TEXT_SMALL).toBeUndefined();
+    expect(models?.TEXT_NANO).toBeUndefined();
+    expect(models?.TEXT_MEDIUM).toBeUndefined();
+  });
+
+  it("registers ALL text tiers when ELIZA_CLI_CLAUDE_ALL_TIERS=1 (single-brain, no fallthrough)", () => {
+    process.env.ELIZA_CHAT_VIA_CLI = "claude-sdk";
+    process.env.ELIZA_CLI_CLAUDE_ALL_TIERS = "1";
+    const models = buildModels({ ELIZA_CHAT_VIA_CLI: "claude-sdk" });
+    for (const t of [
+      "TEXT_LARGE",
+      "TEXT_MEGA",
+      "RESPONSE_HANDLER",
+      "TEXT_SMALL",
+      "TEXT_NANO",
+      "TEXT_MEDIUM",
+    ]) {
+      expect(models?.[t], t).toBeTypeOf("function");
+    }
+  });
+
+  it("triage metadata reports the cheap small model, not the planner tier", () => {
+    process.env.ELIZA_CHAT_VIA_CLI = "claude-sdk";
+    process.env.ELIZA_CLI_CLAUDE_ALL_TIERS = "1";
+    process.env.ELIZA_CLI_CLAUDE_MODEL = "claude-sonnet-5";
+    delete process.env.ELIZA_CLI_CLAUDE_SMALL_MODEL;
+    const md = buildModelMetadata({ ELIZA_CHAT_VIA_CLI: "claude-sdk" });
+    // small tier defaults to the large-tier model (sonnet), NOT the opus planner
+    expect(md?.TEXT_SMALL).toEqual({ displayModel: "claude-sonnet-5" });
+  });
+});
+
+// ENVELOPE mode: the Stage-1 RESPONSE_HANDLER served via the native
+// handle_response MCP tool, so the routing envelope is structurally captured
+// instead of prompt-begged from free text (the free-text lane's prose declines
+// shipped as finished "simple replies" — no planner, no fetch).
+describe("Stage-1 ENVELOPE mode (claude-sdk handle_response tool)", () => {
+  type ToolHandler = (
+    args: Record<string, unknown>
+  ) => Promise<{ content: Array<{ type: string; text: string }> }>;
+
+  /**
+   * Fake SDK whose query stream simulates the model calling the captured tool
+   * handler with `toolArgs` (when provided) before the turn ends — the same
+   * order the real SDK delivers (handler fires in-process mid-turn).
+   */
+  function makeFakeSdk(opts: {
+    toolArgs?: Record<string, unknown>;
+    assistantText?: string;
+    resultSubtype?: string;
+  }) {
+    const captured: {
+      toolName?: string;
+      schema?: Record<string, unknown>;
+      options?: Record<string, unknown>;
+      handler?: ToolHandler;
+    } = {};
+    const fakeSdk = {
+      query: ({ options }: { options: Record<string, unknown> }) => {
+        captured.options = options;
+        return {
+          async *[Symbol.asyncIterator]() {
+            if (opts.toolArgs && captured.handler) {
+              await captured.handler(opts.toolArgs);
+            }
+            if (opts.assistantText) {
+              yield {
+                type: "assistant",
+                message: { content: [{ type: "text", text: opts.assistantText }] },
+              };
+            }
+            yield { type: "result", subtype: opts.resultSubtype ?? "error_max_turns" };
+          },
+        };
+      },
+      tool: (
+        name: string,
+        _desc: string,
+        schema: Record<string, unknown>,
+        handler: ToolHandler
+      ) => {
+        captured.toolName = name;
+        captured.schema = schema;
+        captured.handler = handler;
+        return {};
+      },
+      createSdkMcpServer: () => ({}),
+    };
+    const fakeZod = {
+      z: {
+        string: () => "z.string",
+        any: () => "z.any",
+        record: () => "z.record",
+      },
+    };
+    return { fakeSdk, fakeZod, captured };
+  }
+
+  // The composed field set core's HANDLE_RESPONSE tool carries for a group
+  // channel — the session derives its zod schema and capture filter from it.
+  const STAGE1_FIELDS = {
+    shouldRespond: { type: "string" },
+    contexts: { type: "array" },
+    intents: { type: "array" },
+    replyText: { type: "string" },
+    candidateActionNames: { type: "array" },
+    facts: { type: "array" },
+    relationships: { type: "array" },
+    topics: { type: "array" },
+    addressedTo: { type: "array" },
+    emotion: { type: "string" },
+  };
+
+  it("returns the captured envelope as a JSON string core parses like a native tool call", async () => {
+    const envelope = {
+      shouldRespond: "RESPOND",
+      contexts: ["web"],
+      replyText: "Checking the current BTC price now.",
+      candidateActionNames: ["WEB_FETCH"],
+    };
+    const { fakeSdk, fakeZod, captured } = makeFakeSdk({ toolArgs: envelope });
+    const session = new ClaudeSdkSession({
+      mode: "envelope",
+      envelopeFields: STAGE1_FIELDS,
+      sdkModule: fakeSdk as never,
+      zodModule: fakeZod as never,
+    });
+    const out = await session.send("stage-1 instructions + conversation");
+    expect(JSON.parse(out)).toEqual(envelope);
+    // The session registered the handle_response tool and pinned the tool
+    // surface to it (mirrors ROUTE mode's single-tool contract).
+    expect(captured.toolName).toBe("handle_response");
+    expect(captured.options?.allowedTools).toEqual(["mcp__eliza__handle_response"]);
+    expect(captured.options?.tools).toEqual(["mcp__eliza__handle_response"]);
+    expect(captured.options?.maxTurns).toBe(1);
+    await session.dispose();
+  });
+
+  it("decodes array fields the model emitted as JSON-encoded strings", async () => {
+    // Observed on the first live envelope turn: Claude under MCP stringified
+    // every array field, core's Array.isArray checks defaulted them to [] and
+    // the turn shipped as a bare ack with no planner.
+    const { fakeSdk, fakeZod } = makeFakeSdk({
+      toolArgs: {
+        shouldRespond: "RESPOND",
+        contexts: '["web"]',
+        replyText: "Checking the live XRP price now.",
+        candidateActionNames: '["WEB_SEARCH", "WEB_FETCH"]',
+        facts: "[]",
+      },
+    });
+    const session = new ClaudeSdkSession({
+      mode: "envelope",
+      envelopeFields: STAGE1_FIELDS,
+      sdkModule: fakeSdk as never,
+      zodModule: fakeZod as never,
+    });
+    const out = JSON.parse(await session.send("body"));
+    expect(out.contexts).toEqual(["web"]);
+    expect(out.candidateActionNames).toEqual(["WEB_SEARCH", "WEB_FETCH"]);
+    expect(out.facts).toEqual([]);
+    // Plain strings stay strings — only bracket/brace-shaped ones decode.
+    expect(out.shouldRespond).toBe("RESPOND");
+    expect(out.replyText).toBe("Checking the live XRP price now.");
+    await session.dispose();
+  });
+
+  it("never decodes string-typed fields, even when their value is JSON-shaped", async () => {
+    // A legitimate answer like 'reply with a JSON array of colors' puts
+    // bracket-shaped TEXT in replyText; decoding it would hand core a non-
+    // string and the reply evaluator would empty the turn.
+    const { fakeSdk, fakeZod } = makeFakeSdk({
+      toolArgs: {
+        shouldRespond: "RESPOND",
+        replyText: '["red","green","blue"]',
+      },
+    });
+    const session = new ClaudeSdkSession({
+      mode: "envelope",
+      envelopeFields: STAGE1_FIELDS,
+      sdkModule: fakeSdk as never,
+      zodModule: fakeZod as never,
+    });
+    const out = JSON.parse(await session.send("body"));
+    expect(out.replyText).toBe('["red","green","blue"]');
+    await session.dispose();
+  });
+
+  it("drops stray keys the model invented but keeps every known envelope field", async () => {
+    const { fakeSdk, fakeZod } = makeFakeSdk({
+      toolArgs: {
+        shouldRespond: "RESPOND",
+        replyText: "hi",
+        madeUpField: "junk",
+      },
+    });
+    const session = new ClaudeSdkSession({
+      mode: "envelope",
+      envelopeFields: STAGE1_FIELDS,
+      sdkModule: fakeSdk as never,
+      zodModule: fakeZod as never,
+    });
+    const out = JSON.parse(await session.send("body"));
+    expect(out).toEqual({ shouldRespond: "RESPOND", replyText: "hi" });
+    await session.dispose();
+  });
+
+  it("falls back to the prose text when the model goes off-contract (no tool call)", async () => {
+    const { fakeSdk, fakeZod } = makeFakeSdk({
+      assistantText: "Just a plain chat answer.",
+      resultSubtype: "success",
+    });
+    const session = new ClaudeSdkSession({
+      mode: "envelope",
+      envelopeFields: STAGE1_FIELDS,
+      sdkModule: fakeSdk as never,
+      zodModule: fakeZod as never,
+    });
+    // Core's tolerant parse chain consumes the prose (plain text → simple
+    // reply), so the off-contract turn still lands instead of throwing.
+    expect(await session.send("body")).toBe("Just a plain chat answer.");
+    await session.dispose();
+  });
+
+  it("a captured envelope wins over residual text that smells like a limit message", async () => {
+    const { fakeSdk, fakeZod } = makeFakeSdk({
+      toolArgs: { shouldRespond: "RESPOND", replyText: "ok" },
+      assistantText: "You've hit your session limit · resets 9:30pm (UTC)",
+    });
+    const session = new ClaudeSdkSession({
+      mode: "envelope",
+      envelopeFields: STAGE1_FIELDS,
+      sdkModule: fakeSdk as never,
+      zodModule: fakeZod as never,
+    });
+    const out = JSON.parse(await session.send("body"));
+    expect(out.replyText).toBe("ok");
+    await session.dispose();
+  });
+
+  it("locates core's HANDLE_RESPONSE tool on exactly the Stage-1 call", () => {
+    // Core attaches the HANDLE_RESPONSE native tool to exactly the Stage-1
+    // routing call; the post-tool evaluator reuses RESPONSE_HANDLER with a
+    // responseSchema and NO tools and must stay on the text session (its turn
+    // through envelope mode posted raw envelope JSON to the channel).
+    const stage1Tool = {
+      name: "HANDLE_RESPONSE",
+      description: "Stage 1",
+      parameters: { type: "object", properties: { replyText: { type: "string" } } },
+    };
+    expect(findHandleResponseTool([stage1Tool] as never)).toBe(stage1Tool);
+    expect(findHandleResponseTool(undefined)).toBeUndefined();
+    expect(
+      findHandleResponseTool([
+        { name: "SOME_OTHER_TOOL", description: "", parameters: {} },
+      ] as never)
+    ).toBeUndefined();
+  });
+
+  it("buildEnvelopeBody folds the per-turn system into the body and closes with the tool directive", () => {
+    const body = buildEnvelopeBody("# identity\nYou are X.", "conversation here");
+    expect(body).toContain("# identity");
+    expect(body).toContain("conversation here");
+    expect(body.trimEnd().endsWith("with the completed envelope fields.")).toBe(true);
+    // System-less calls still produce a well-formed body.
+    expect(buildEnvelopeBody(undefined, "just body")).toContain("just body");
   });
 });

--- a/plugins/plugin-cli-inference/index.ts
+++ b/plugins/plugin-cli-inference/index.ts
@@ -1,19 +1,31 @@
 import { createHash } from "node:crypto";
-import type { GenerateTextParams, IAgentRuntime, Plugin } from "@elizaos/core";
-import { logger, ModelType } from "@elizaos/core";
+import type { GenerateTextParams, IAgentRuntime, Plugin, ToolDefinition } from "@elizaos/core";
+import {
+  HANDLE_RESPONSE_TOOL_NAME,
+  isTruthyEnvValue,
+  logger,
+  ModelType,
+  parseBooleanValue,
+} from "@elizaos/core";
 import {
   type RotationSubprocessEnv,
   rotationEnabled,
   withAccountRotation,
 } from "./src/account-rotation";
 import { ClaudeCli } from "./src/claude-cli";
-import { ClaudeSdkSession } from "./src/claude-sdk-session";
+import {
+  ClaudeSdkSession,
+  type EnvelopeFieldSchemas,
+  type SdkSessionMode,
+} from "./src/claude-sdk-session";
 import {
   appendTextDirective,
   buildCleanRoutingParams,
+  buildEnvelopeBody,
   buildRouterBody,
   frameTextSystemPrompt,
   ROUTER_SYSTEM_PROMPT,
+  STAGE1_ENVELOPE_SYSTEM_PROMPT,
 } from "./src/clean-routing-planner";
 import { CodexCli } from "./src/codex-cli-exec";
 import { CodexSdkSession } from "./src/codex-sdk-session";
@@ -72,9 +84,76 @@ const LARGE_TIER_MODEL_TYPES: readonly string[] = [
  */
 const PLANNER_MODEL_TYPES: readonly string[] = [ModelType.ACTION_PLANNER];
 
+/**
+ * High-frequency triage tiers — the should-respond gate, media-description, and
+ * the action-callback voice rewrite. NOT registered by default (they'd spend a
+ * subscription call on every inbound message, including ignored ones); serving
+ * them on the cheap configured provider bounds cost. Registered only in ALL-TIERS
+ * mode for operators who want a single-brain, no-fallthrough deployment — where
+ * leaving triage on a weak provider mangles action-result rewrites into
+ * "couldn't format" placeholder text.
+ */
+const SMALL_TIER_MODEL_TYPES: readonly string[] = [
+  ModelType.TEXT_SMALL,
+  ModelType.TEXT_NANO,
+  ModelType.TEXT_MEDIUM,
+];
+
 /** True when the runtime is set for the XML text planner the free-text CLI can serve. */
 function textPlannerEnabled(): boolean {
   return readEnv("ELIZA_PLANNER_NATIVE_TOOLS")?.trim() === "0";
+}
+
+/**
+ * ALL-TIERS mode: also serve the high-frequency triage tiers on this route so
+ * the ENTIRE text brain (not just the heavy tiers) runs on the one Claude/Codex
+ * subscription — no cerebras/gemma fallthrough. Opt-in because triage volume is
+ * high; the triage model defaults to the cheaper large-tier model, not the
+ * planner tier, so the should-respond gate doesn't run on opus.
+ */
+function allTiersEnabled(): boolean {
+  return isTruthyEnvValue(readEnv("ELIZA_CLI_CLAUDE_ALL_TIERS"));
+}
+
+/**
+ * Stage-1 ENVELOPE mode (claude-sdk only): serve RESPONSE_HANDLER through the
+ * native `handle_response` MCP tool so the routing envelope is structurally
+ * captured instead of prompt-begged from free text. Default ON — it is the
+ * lane's parity fix with every other Stage-1 backend; ELIZA_CLI_CLAUDE_STAGE1_ENVELOPE=0
+ * reverts to the plain text session (core's tolerant parse chain).
+ */
+function stage1EnvelopeEnabled(): boolean {
+  return parseBooleanValue(readEnv("ELIZA_CLI_CLAUDE_STAGE1_ENVELOPE")) ?? true;
+}
+
+/**
+ * Locate core's Stage-1 HANDLE_RESPONSE tool on a RESPONSE_HANDLER call. Core
+ * attaches it (with toolChoice "required") to exactly the Stage-1 ROUTING
+ * call, and to no other — the post-tool evaluator and the failure-reply
+ * helper reuse the same model type WITHOUT the tool, and they expect plain
+ * JSON/text, so they must stay on the text session (observed live: routing
+ * the evaluator through envelope mode posted the raw envelope JSON to the
+ * channel as the reply). The returned tool's composed parameter schema is the
+ * authoritative per-turn envelope field set (core's field REGISTRY lets any
+ * plugin add fields, and the set varies by channel shape).
+ */
+export function findHandleResponseTool(
+  tools: GenerateTextParams["tools"]
+): ToolDefinition | undefined {
+  return (Array.isArray(tools) ? tools : []).find(
+    (tool) => tool.name?.trim().toUpperCase() === HANDLE_RESPONSE_TOOL_NAME
+  );
+}
+
+/** Declared field schemas from the composed HANDLE_RESPONSE tool parameters. */
+function envelopeFieldSchemas(tool: ToolDefinition): EnvelopeFieldSchemas {
+  const properties =
+    (tool.parameters as { properties?: Record<string, { type?: string }> })?.properties ?? {};
+  const fields: EnvelopeFieldSchemas = {};
+  for (const [name, schema] of Object.entries(properties)) {
+    fields[name] = { type: typeof schema?.type === "string" ? schema.type : undefined };
+  }
+  return fields;
 }
 
 // "claude"      → cold `claude --print` per call (TOS-clean, but ~5-15s/call).
@@ -128,9 +207,19 @@ const MAX_SDK_SESSIONS = 8;
 /** The Claude model for a given tier (planner/small can differ from large). */
 function resolveSdkModel(runtime: IAgentRuntime, modelType: string): string {
   const large = getSetting(runtime, "ELIZA_CLI_CLAUDE_MODEL");
-  const small = getSetting(runtime, "ELIZA_CLI_CLAUDE_PLANNER_MODEL");
-  const isSmallTier = modelType === ModelType.ACTION_PLANNER || modelType === ModelType.TEXT_SMALL;
-  return ((isSmallTier ? small : large) || large || "claude-opus-4-8").trim();
+  const planner = getSetting(runtime, "ELIZA_CLI_CLAUDE_PLANNER_MODEL");
+  const fallback = (large || "claude-opus-4-8").trim();
+  // The planner tier keeps its own (typically heavier) model.
+  if (modelType === ModelType.ACTION_PLANNER) {
+    return (planner || fallback).trim();
+  }
+  // ALL-TIERS triage: use the dedicated cheap model, else the large-tier model
+  // (NOT the planner tier) so the high-frequency should-respond gate doesn't
+  // run on opus.
+  if (SMALL_TIER_MODEL_TYPES.includes(modelType)) {
+    return (getSetting(runtime, "ELIZA_CLI_CLAUDE_SMALL_MODEL") || fallback).trim();
+  }
+  return fallback;
 }
 
 function shortHash(value: string): string {
@@ -139,24 +228,34 @@ function shortHash(value: string): string {
 
 /**
  * Lazily create + cache a warm SDK session for a (model, mode, systemPrompt).
- * `router=true` builds a native `route_action` MCP-tool session (the planner);
- * `router=false` builds a plain text-generation session (reply/large tiers).
+ * "route" builds the native `route_action` MCP-tool session (the planner);
+ * "envelope" builds the native `handle_response` session (Stage-1 routing);
+ * "text" builds a plain text-generation session (reply/large tiers).
  */
-function claudeSessionKey(model: string, systemPrompt: string, router: boolean): string {
-  return `${model}\u001f${router ? "route" : "text"}\u001f${shortHash(systemPrompt)}`;
+function claudeSessionKey(
+  model: string,
+  systemPrompt: string,
+  mode: SdkSessionMode,
+  envelopeFields?: EnvelopeFieldSchemas
+): string {
+  // Envelope sessions also freeze their tool schema at query() start, so the
+  // composed field set is part of the identity (direct vs group channel
+  // shapes compose different sets; registry plugins add more).
+  const fieldsPart = envelopeFields ? shortHash(Object.keys(envelopeFields).sort().join(",")) : "";
+  return `${model}\u001f${mode}\u001f${shortHash(systemPrompt)}\u001f${fieldsPart}`;
 }
 
 /**
  * Reasoning effort for a Claude SDK session, forwarded to the SDK's `effort`
- * option (== `claude --effort`). The planner (router) reads
+ * option (== `claude --effort`). The planner (route mode) reads
  * ELIZA_CLI_CLAUDE_PLANNER_EFFORT first so routing depth can be tuned
- * independently of reply depth; both fall back to ELIZA_CLI_CLAUDE_EFFORT, then
+ * independently of reply depth; everything else falls back to ELIZA_CLI_CLAUDE_EFFORT, then
  * to the SDK default (high) when unset. Validation lives in the session
  * (normalizeEffort) so an unknown value is dropped, never forwarded.
  */
-export function resolveSdkEffort(runtime: IAgentRuntime, router: boolean): string | undefined {
+export function resolveSdkEffort(runtime: IAgentRuntime, mode: SdkSessionMode): string | undefined {
   const shared = getSetting(runtime, "ELIZA_CLI_CLAUDE_EFFORT");
-  if (router) {
+  if (mode === "route") {
     return getSetting(runtime, "ELIZA_CLI_CLAUDE_PLANNER_EFFORT") ?? shared;
   }
   return shared;
@@ -179,10 +278,11 @@ function getSdkSession(
   runtime: IAgentRuntime,
   model: string,
   systemPrompt: string,
-  router: boolean,
-  subprocessEnv?: RotationSubprocessEnv
+  mode: SdkSessionMode,
+  subprocessEnv?: RotationSubprocessEnv,
+  envelopeFields?: EnvelopeFieldSchemas
 ): ClaudeSdkSession {
-  const key = claudeSessionKey(model, systemPrompt, router);
+  const key = claudeSessionKey(model, systemPrompt, mode, envelopeFields);
   const existing = sdkSessions.get(key);
   if (existing) {
     // Mark most-recently-used: delete + re-insert moves it to the Map's tail.
@@ -193,13 +293,14 @@ function getSdkSession(
   const session = new ClaudeSdkSession({
     model,
     systemPrompt,
-    router,
+    mode,
+    envelopeFields,
     claudeExecutablePath: getSetting(runtime, "ELIZA_CLI_CLAUDE_BIN"),
     restartAfterTurns: parseTimeout(getSetting(runtime, "ELIZA_CLI_SDK_RESTART_AFTER_TURNS")),
     turnTimeoutMs:
       parseTimeout(getSetting(runtime, "ELIZA_CLI_SDK_TURN_TIMEOUT_MS")) ??
       parseTimeout(getSetting(runtime, "ELIZA_CLI_TIMEOUT_MS")),
-    effort: resolveSdkEffort(runtime, router),
+    effort: resolveSdkEffort(runtime, mode),
     subprocessEnv,
   });
   sdkSessions.set(key, session);
@@ -330,6 +431,37 @@ async function generateViaCli(
     messages: params.messages,
   };
   logger.debug(`[cli-inference] ${modelType} via ${backend}`);
+  const handleResponseTool =
+    backend === "claude-sdk" && modelType === ModelType.RESPONSE_HANDLER && stage1EnvelopeEnabled()
+      ? findHandleResponseTool(params.tools)
+      : undefined;
+  if (backend === "claude-sdk" && handleResponseTool) {
+    // Stage-1 routing envelope via the native `handle_response` MCP tool.
+    // Every other Stage-1 lane structurally forces the envelope (anthropic
+    // native tool_use, cloud tool_choice:required, local GBNF); serving it as
+    // free text let the model answer live-info asks in prose, which core's
+    // tolerance accepted as a finished "simple reply" — no planner, no fetch
+    // (observed live: 49 of 54 live-info turns prose-shaped). The captured
+    // envelope returns as a JSON string core parses identically to a native
+    // tool call; off-contract prose falls back to the tolerant text chain.
+    const model = resolveSdkModel(runtime, modelType);
+    const fields = envelopeFieldSchemas(handleResponseTool);
+    const { system, body } = flattenPrompt(generateParams);
+    const envelopeBody = buildEnvelopeBody(system, body);
+    const key = claudeSessionKey(model, STAGE1_ENVELOPE_SYSTEM_PROMPT, "envelope", fields);
+    return withAccountRotation(
+      (env) =>
+        getSdkSession(runtime, model, STAGE1_ENVELOPE_SYSTEM_PROMPT, "envelope", env, fields).send(
+          envelopeBody
+        ),
+      {
+        backend,
+        getValue: (k) => getSetting(runtime, k),
+        sessionKey: `cli-inference:${key}`,
+        onRotate: () => evictSdkSession(key),
+      }
+    );
+  }
   if (backend === "claude-sdk") {
     // Warm, persistent Agent SDK session. The SDK freezes `systemPrompt` at start,
     // so we flatten system+messages here and hand the session a STABLE system
@@ -343,14 +475,14 @@ async function generateViaCli(
     // 2/4). Keying by the framed system keeps one warm process per tier.
     const framedSystem = frameTextSystemPrompt(system);
     const framedBody = appendTextDirective(body);
-    const key = claudeSessionKey(model, framedSystem, false);
+    const key = claudeSessionKey(model, framedSystem, "text");
     // Pool-first auth: the FIRST warm session already auths as a healthy pooled
     // Claude account when one exists (ambient ~/.claude is the fallback). On a
     // subscription limit, rotate to the next healthy pooled account (evicting
     // the warm session so it re-auths as the new account), then retry; fall
     // through to provider failover only when the pool is exhausted.
     return withAccountRotation(
-      (env) => getSdkSession(runtime, model, framedSystem, false, env).generate(framedBody),
+      (env) => getSdkSession(runtime, model, framedSystem, "text", env).send(framedBody),
       {
         backend,
         getValue: (k) => getSetting(runtime, k),
@@ -408,9 +540,9 @@ async function planViaCli(runtime: IAgentRuntime, params: GenerateTextParams): P
   if (backend === "claude-sdk") {
     const model = resolveSdkModel(runtime, ModelType.ACTION_PLANNER);
     const routerBody = buildRouterBody(params);
-    const key = claudeSessionKey(model, ROUTER_SYSTEM_PROMPT, true);
+    const key = claudeSessionKey(model, ROUTER_SYSTEM_PROMPT, "route");
     return withAccountRotation(
-      (env) => getSdkSession(runtime, model, ROUTER_SYSTEM_PROMPT, true, env).route(routerBody),
+      (env) => getSdkSession(runtime, model, ROUTER_SYSTEM_PROMPT, "route", env).send(routerBody),
       {
         backend,
         getValue: (k) => getSetting(runtime, k),
@@ -454,7 +586,10 @@ export function buildModels(
     string,
     (runtime: IAgentRuntime, params: GenerateTextParams) => Promise<string>
   > = {};
-  for (const modelType of LARGE_TIER_MODEL_TYPES) {
+  const textTiers = allTiersEnabled()
+    ? [...LARGE_TIER_MODEL_TYPES, ...SMALL_TIER_MODEL_TYPES]
+    : LARGE_TIER_MODEL_TYPES;
+  for (const modelType of textTiers) {
     models[modelType] = (runtime, params) => generateViaCli(runtime, params, modelType);
   }
   if (textPlannerEnabled()) {
@@ -491,9 +626,15 @@ export function buildModelMetadata(
     ? readEnv("ELIZA_CLI_CODEX_PLANNER_MODEL")?.trim()
     : readEnv("ELIZA_CLI_CLAUDE_PLANNER_MODEL")?.trim();
   const planner = plannerRaw || large;
+  const small = isCodex ? large : readEnv("ELIZA_CLI_CLAUDE_SMALL_MODEL")?.trim() || large;
   const metadata: Record<string, { displayModel: string }> = {};
   for (const modelType of LARGE_TIER_MODEL_TYPES) {
     metadata[modelType] = { displayModel: large };
+  }
+  if (allTiersEnabled()) {
+    for (const modelType of SMALL_TIER_MODEL_TYPES) {
+      metadata[modelType] = { displayModel: small };
+    }
   }
   if (textPlannerEnabled()) {
     for (const modelType of PLANNER_MODEL_TYPES) {
@@ -573,15 +714,17 @@ export {
   withAccountRotation,
 } from "./src/account-rotation";
 export { ClaudeCli } from "./src/claude-cli";
-export { ClaudeSdkSession } from "./src/claude-sdk-session";
+export { ClaudeSdkSession, type SdkSessionMode } from "./src/claude-sdk-session";
 export {
   appendTextDirective,
   buildCleanRoutingBody,
   buildCleanRoutingParams,
   buildCleanRoutingSystemPrompt,
+  buildEnvelopeBody,
   buildRouterBody,
   frameTextSystemPrompt,
   ROUTER_SYSTEM_PROMPT,
+  STAGE1_ENVELOPE_SYSTEM_PROMPT,
   TEXT_COMPLETION_DIRECTIVE,
   TEXT_COMPLETION_FRAMING,
 } from "./src/clean-routing-planner";

--- a/plugins/plugin-cli-inference/src/claude-sdk-session.ts
+++ b/plugins/plugin-cli-inference/src/claude-sdk-session.ts
@@ -12,9 +12,10 @@
  * of a Claude subscription (the monthly Agent SDK credit), so it is strictly
  * cleaner than the in-process stealth token-replay.
  *
- * TWO MODES (the SDK fixes `systemPrompt` + `mcpServers` at query() start — see
- * the live-proven research wf_3199bde6: there is NO mid-session setSystemPrompt
- * or history-reset, so a session is created per frozen system prompt):
+ * THREE MODES (the SDK fixes `systemPrompt` + `mcpServers` at query() start —
+ * see the live-proven research wf_3199bde6: there is NO mid-session
+ * setSystemPrompt or history-reset, so a session is created per frozen system
+ * prompt):
  *
  *  - TEXT mode (`generate`): pure text generation for the reply / large tiers.
  *    `allowedTools: []` strips Claude Code's own tools so the SDK is a warm
@@ -34,6 +35,15 @@
  *    for a tool-calling turn under `maxTurns: 1`); the captured decision — not
  *    the assistant text — is the result.
  *
+ *  - ENVELOPE mode (`envelope`): the Stage-1 RESPONSE_HANDLER routing envelope
+ *    via the same native-tool pattern (`handle_response`). Every other Stage-1
+ *    lane structurally forces the envelope (anthropic native tool_use, cloud
+ *    tool_choice:required, local GBNF); free text alone let the model answer
+ *    live-info asks in prose, which core's tolerance accepted as a finished
+ *    "simple reply" — no planner, no fetch. The captured envelope is returned
+ *    as a JSON string core parses identically to a native tool call;
+ *    off-contract prose falls back to TEXT-mode semantics.
+ *
  * One instance == one (model, systemPrompt, mode). Calls are SERIALIZED (one in
  * flight per warm session); spin up multiple instances for concurrency. The
  * session is RESTARTED after `restartAfterTurns` turns to bound the accumulating
@@ -49,8 +59,58 @@ import { ProviderApiError, parseProviderApiErrorText } from "./provider-errors";
 const DEFAULT_MODEL = "claude-opus-4-8";
 const DEFAULT_RESTART_AFTER_TURNS = 20;
 const DEFAULT_TURN_TIMEOUT_MS = 90_000;
-/** Fully-qualified name the SDK assigns our in-process MCP tool. */
+/** Fully-qualified names the SDK assigns our in-process MCP tools. */
 const ROUTE_TOOL = "mcp__eliza__route_action";
+const ENVELOPE_TOOL = "mcp__eliza__handle_response";
+
+/**
+ * Session shape. Every other Stage-1 lane structurally forces the routing
+ * envelope (anthropic native tool_use, cloud tool_choice:required, local GBNF);
+ * this free-text lane historically relied on prompt prose alone, and the model
+ * answered live-info asks in prose instead of emitting the envelope — the
+ * decline then shipped as a "simple reply" with no planner and no fetch.
+ * ENVELOPE mode closes that gap the same way ROUTE mode does for the planner:
+ * one in-process MCP tool the model must call, captured in-process.
+ *
+ *  - "text": pure completion engine (reply synthesis, large tiers, triage).
+ *  - "route": ACTION_PLANNER decision via the native `route_action` tool.
+ *  - "envelope": Stage-1 RESPONSE_HANDLER via the native `handle_response`
+ *    tool; the captured arguments are returned as a JSON string that core's
+ *    existing envelope parser consumes exactly like a native tool call.
+ */
+export type SdkSessionMode = "text" | "route" | "envelope";
+
+/**
+ * Declared JSON-schema types of the Stage-1 envelope fields for one session,
+ * derived by the caller from core's composed HANDLE_RESPONSE tool (which
+ * varies per runtime and channel: the response-handler field REGISTRY lets
+ * any plugin add fields, and direct channels omit several builtins). Owning
+ * the list here would silently drop registry-added fields on this lane —
+ * core defaults what it never receives, so the loss is invisible.
+ */
+export type EnvelopeFieldSchemas = Record<string, { type?: string }>;
+
+/**
+ * Decode an envelope field the model emitted as a JSON-encoded STRING back to
+ * its structured value. Applied ONLY to fields whose declared schema type is
+ * array/object: Claude under MCP routinely stringifies structured fields
+ * (`"contexts": "[\"web\"]"` — observed on the first live envelope turn), and
+ * core's field registry checks Array.isArray, silently defaulting the string
+ * to [] and losing the routing. String-typed fields (replyText) pass through
+ * untouched so a legitimately JSON-shaped text answer is never mangled.
+ * error-policy:J3 — a string that fails to parse is kept as-is (an explicit
+ * string value, never fabricated structure).
+ */
+function decodeEnvelopeFieldValue(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("[") && !trimmed.startsWith("{")) return value;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return value;
+  }
+}
 
 /**
  * When the monthly Agent SDK credit runs dry (documented caveat: the subscription
@@ -124,22 +184,18 @@ type SdkQueryFn = (options: {
   prompt: AsyncIterable<SdkUserMessage>;
   options: Record<string, unknown>;
 }) => SdkQuery;
-type SdkToolFn = (
-  name: string,
-  description: string,
-  schema: Record<string, unknown>,
-  handler: (args: {
-    action?: unknown;
-    params?: unknown;
-  }) => Promise<{ content: Array<{ type: string; text: string }> }>
-) => unknown;
-type SdkMcpServerFn = (options: { name: string; version?: string; tools: unknown[] }) => unknown;
-
 /** Minimal shape of the SDK module we load lazily. */
 export interface SdkModule {
   query: SdkQueryFn;
-  tool: SdkToolFn;
-  createSdkMcpServer: SdkMcpServerFn;
+  tool: (
+    name: string,
+    description: string,
+    schema: Record<string, unknown>,
+    handler: (
+      args: Record<string, unknown>
+    ) => Promise<{ content: Array<{ type: string; text: string }> }>
+  ) => unknown;
+  createSdkMcpServer: (options: { name: string; version?: string; tools: unknown[] }) => unknown;
 }
 interface ZodModule {
   z: {
@@ -157,11 +213,16 @@ export interface ClaudeSdkSessionConfig {
    * (one warm process per distinct system prompt).
    */
   systemPrompt?: string | null;
-  /** ROUTE mode (native `route_action` MCP tool) vs TEXT mode (plain generation). */
-  router?: boolean;
-  /** TEXT mode only: `maxTurns` for the SDK query (default 1 — one-shot answer,
-   * no agentic preamble-then-act). Ignored in ROUTE mode (always 1). */
-  textMaxTurns?: number;
+  /** Session shape — see {@link SdkSessionMode}. Default "text". */
+  mode?: SdkSessionMode;
+  /**
+   * ENVELOPE mode only (required there): declared schema types of the Stage-1
+   * fields this session captures, derived from core's composed
+   * HANDLE_RESPONSE tool for the turn that opened the session. The caller
+   * keys its session cache by this set, since the SDK freezes tool schemas at
+   * query() start.
+   */
+  envelopeFields?: EnvelopeFieldSchemas;
   /** Path to the Claude Code executable the SDK drives. */
   claudeExecutablePath?: string | null;
   /** Restart the warm session after this many turns (bounds context growth). */
@@ -250,8 +311,8 @@ export function normalizeEffort(value: string | null | undefined): string | null
 export class ClaudeSdkSession {
   private readonly model: string;
   private readonly systemPrompt: string | null;
-  private readonly router: boolean;
-  private readonly textMaxTurns: number;
+  private readonly mode: SdkSessionMode;
+  private readonly envelopeFields: EnvelopeFieldSchemas;
   private readonly claudeExecutablePath: string | null;
   private readonly restartAfterTurns: number;
   private readonly turnTimeoutMs: number;
@@ -265,16 +326,22 @@ export class ClaudeSdkSession {
   private iterator: AsyncIterator<SdkMessage> | null = null;
   private turns = 0;
   private chain: Promise<unknown> = Promise.resolve();
-  // ROUTE mode: the MCP tool handler writes the current turn's decision here.
-  // Safe to share across turns because calls are serialized on `chain` and it is
-  // reset at the start of every `sendAndRead`.
+  // Tool modes: the MCP tool handler writes the current turn's capture here.
+  // Safe to share across turns because calls are serialized on `chain` and both
+  // are reset at the start of every `sendAndRead`.
   private pendingDecision: RouteDecision | null = null;
+  private pendingEnvelope: Record<string, unknown> | null = null;
 
   constructor(config: ClaudeSdkSessionConfig) {
     this.model = config.model?.trim() || DEFAULT_MODEL;
     this.systemPrompt = config.systemPrompt?.trim() || null;
-    this.router = config.router === true;
-    this.textMaxTurns = config.textMaxTurns && config.textMaxTurns > 0 ? config.textMaxTurns : 1;
+    this.mode = config.mode ?? "text";
+    if (this.mode === "envelope" && !config.envelopeFields) {
+      throw new Error(
+        "[cli-inference:sdk] envelope mode requires the composed Stage-1 field schemas"
+      );
+    }
+    this.envelopeFields = config.envelopeFields ?? {};
     this.claudeExecutablePath = config.claudeExecutablePath?.trim() || null;
     this.restartAfterTurns =
       config.restartAfterTurns && config.restartAfterTurns > 0
@@ -290,19 +357,21 @@ export class ClaudeSdkSession {
     this.zodOverride = config.zodModule;
   }
 
-  /** TEXT mode: generate one completion's text. Serialized. */
-  generate(body: string): Promise<string> {
-    return this.enqueue(() => this.sendOnce(body, "text"));
-  }
-
   /**
-   * ROUTE mode: return `JSON.stringify({action, params})` — the action the model
-   * picked via the native `route_action` tool. The planner loop's text-mode
-   * parser (`parseJsonPlannerOutput` → `normalizeBarePlannerAction`) consumes
-   * this bare shape directly, so no core change is needed.
+   * Run one serialized turn. What comes back is fixed by the session's mode:
+   *  - "text": the completion's text.
+   *  - "route": `JSON.stringify({action, params})` from the native
+   *    `route_action` call — the planner loop's text-mode parser
+   *    (`parseJsonPlannerOutput` → `normalizeBarePlannerAction`) consumes the
+   *    bare shape directly, so no core change is needed.
+   *  - "envelope": the JSON string of the Stage-1 envelope from the native
+   *    `handle_response` call — core's envelope parser
+   *    (`extractMessageHandlerRawParsed` → `parseJsonObject`) consumes a JSON
+   *    string identically to a native tool call. Off-contract prose is
+   *    returned as-is so core's tolerant parse chain still lands the turn.
    */
-  route(body: string): Promise<string> {
-    return this.enqueue(() => this.sendOnce(body, "route"));
+  send(body: string): Promise<string> {
+    return this.enqueue(() => this.sendOnce(body));
   }
 
   private enqueue<T>(fn: () => Promise<T>): Promise<T> {
@@ -316,7 +385,7 @@ export class ClaudeSdkSession {
     return run;
   }
 
-  private async sendOnce(body: string, mode: "text" | "route"): Promise<string> {
+  private async sendOnce(body: string): Promise<string> {
     if (!body.trim()) {
       throw new Error("[cli-inference:sdk] empty prompt body");
     }
@@ -329,7 +398,7 @@ export class ClaudeSdkSession {
     }
     this.turns += 1;
     try {
-      return await this.sendAndRead(body, mode);
+      return await this.sendAndRead(body);
     } catch (err) {
       // error-policy:J2 context-adding rethrow — self-heal (a dead/erroring session
       // must not poison the next turn), then rethrow so the caller sees the failure.
@@ -371,10 +440,11 @@ export class ClaudeSdkSession {
       // permission prompt; pass the explicit flag so the contract is stable
       // across SDK versions rather than relying on the mode alone.
       allowDangerouslySkipPermissions: true,
-      // ROUTE: one tool call ends the turn (subtype=error_max_turns is normal).
-      // TEXT: default 1 — a one-shot answer leaves no room for the agentic
-      // "I'll fetch it…" preamble-then-act pattern that leaks when maxTurns>1.
-      maxTurns: this.router ? 1 : this.textMaxTurns,
+      // Always one turn: in tool modes a single tool call ends the turn
+      // (subtype=error_max_turns is normal), and a one-shot TEXT answer
+      // leaves no room for the agentic "I'll fetch it…" preamble-then-act
+      // pattern that leaks when maxTurns>1.
+      maxTurns: 1,
     };
     // Reasoning depth. Omitted → SDK default (high); an unsupported level for
     // the selected model is silently downgraded by the SDK, not an error.
@@ -388,7 +458,7 @@ export class ClaudeSdkSession {
     if (this.claudeExecutablePath) {
       options.pathToClaudeCodeExecutable = this.claudeExecutablePath;
     }
-    if (this.router) {
+    if (this.mode === "route") {
       const { z } = this.zodOverride ?? (await loadZod());
       const routeTool = sdk.tool(
         "route_action",
@@ -424,6 +494,53 @@ export class ClaudeSdkSession {
       options.mcpServers = { eliza: mcp };
       options.allowedTools = [ROUTE_TOOL];
       options.tools = [ROUTE_TOOL];
+    } else if (this.mode === "envelope") {
+      const { z } = this.zodOverride ?? (await loadZod());
+      // One loose zod slot per field core composed for this turn shape. Loose
+      // (any JSON) because core's field registry defaults/coerces downstream;
+      // the structural win is that the model emits a keyed envelope at all.
+      const envelopeSchema: Record<string, unknown> = {};
+      for (const field of Object.keys(this.envelopeFields)) {
+        envelopeSchema[field] = z.any();
+      }
+      const envelopeTool = sdk.tool(
+        "handle_response",
+        "Submit the Stage-1 response envelope for this turn. Call this EXACTLY " +
+          "ONCE with every field the instructions in the user message define — " +
+          "array fields as real JSON arrays, never JSON-encoded strings — " +
+          "then stop; produce no other output.",
+        envelopeSchema,
+        async (args) => {
+          if (!this.pendingEnvelope && args && typeof args === "object") {
+            // Keep only the composed envelope keys with defined values: core's
+            // field registry defaults what is missing and would choke on
+            // stray keys the model invented. Structured fields pass through
+            // the string-decode boundary.
+            const captured: Record<string, unknown> = {};
+            for (const [field, schema] of Object.entries(this.envelopeFields)) {
+              if (args[field] === undefined) continue;
+              captured[field] =
+                schema.type === "array" || schema.type === "object"
+                  ? decodeEnvelopeFieldValue(args[field])
+                  : args[field];
+            }
+            if (Object.keys(captured).length > 0) {
+              this.pendingEnvelope = captured;
+            }
+          }
+          return {
+            content: [{ type: "text", text: "ACK. Envelope recorded. Stop now." }],
+          };
+        }
+      );
+      const mcp = sdk.createSdkMcpServer({
+        name: "eliza",
+        version: "1.0.0",
+        tools: [envelopeTool],
+      });
+      options.mcpServers = { eliza: mcp };
+      options.allowedTools = [ENVELOPE_TOOL];
+      options.tools = [ENVELOPE_TOOL];
     } else {
       // Pure text generation: NO tools at all. `tools: []` disables the SDK's
       // built-in tool set (matching ROUTE mode, which sets it to the one MCP
@@ -442,7 +559,7 @@ export class ClaudeSdkSession {
       {
         src: "cli-inference:sdk",
         model: this.model,
-        mode: this.router ? "route" : "text",
+        mode: this.mode,
       },
       "warm Claude Agent SDK session started"
     );
@@ -483,11 +600,12 @@ export class ClaudeSdkSession {
   }
 
   /** Push one user message and read the turn's assistant text + result envelope. */
-  private async sendAndRead(body: string, mode: "text" | "route"): Promise<string> {
+  private async sendAndRead(body: string): Promise<string> {
     if (!this.feed || !this.iterator) {
       throw new Error("[cli-inference:sdk] session not started");
     }
     this.pendingDecision = null;
+    this.pendingEnvelope = null;
     this.feed({
       type: "user",
       message: { role: "user", content: body },
@@ -522,7 +640,7 @@ export class ClaudeSdkSession {
       }
     }
 
-    if (mode === "route" && this.pendingDecision) {
+    if (this.mode === "route" && this.pendingDecision) {
       // The decision is captured in the MCP handler the moment the model calls
       // route_action — that IS the success signal (the turn then ends
       // subtype=error_max_turns, which is normal). Return it regardless of how
@@ -530,6 +648,11 @@ export class ClaudeSdkSession {
       // captured decision must never be discarded because residual preamble
       // text happened to mention limits.
       return JSON.stringify(this.pendingDecision);
+    }
+    if (this.mode === "envelope" && this.pendingEnvelope) {
+      // Same contract as the route capture above: the handle_response call IS
+      // the success signal, returned before the limit/error guards.
+      return JSON.stringify(this.pendingEnvelope);
     }
 
     // A dried-up subscription credit ends the turn cleanly but surfaces the
@@ -566,7 +689,7 @@ export class ClaudeSdkSession {
       );
     }
 
-    if (mode === "route") {
+    if (this.mode === "route") {
       // No decision: the model went off-contract (it was told to call the tool
       // and "produce no plain-text answer"), so any residual text is a planning
       // preamble, not a finished reply — never surface it as a user REPLY. Only
@@ -583,13 +706,16 @@ export class ClaudeSdkSession {
       );
     }
 
-    // TEXT mode: trust the streamed assistant text only when the turn TERMINATED
-    // CLEANLY (a `result` message arrived). A generator that ended without one
-    // means the session died mid-stream, so partial text is a truncated reply —
-    // throw instead of surfacing it. The streamed text is the model's real
-    // output regardless of subtype; the `result` echo is only trustworthy on
-    // success (on error_max_turns it may be an SDK meta-string like "Reached
-    // maximum turns", not the completion).
+    // TEXT mode — and the ENVELOPE off-contract fallthrough (model answered in
+    // prose instead of calling handle_response; the prose goes back to core's
+    // tolerant parse chain, which still lands the turn): trust the streamed
+    // assistant text only when the turn TERMINATED CLEANLY (a `result` message
+    // arrived). A generator that ended without one means the session died
+    // mid-stream, so partial text is a truncated reply — throw instead of
+    // surfacing it. The streamed text is the model's real output regardless of
+    // subtype; the `result` echo is only trustworthy on success (on
+    // error_max_turns it may be an SDK meta-string like "Reached maximum
+    // turns", not the completion).
     if (sawResult && text.trim()) return text.trim();
     if (sawResult && resultSubtype === "success" && resultText?.trim()) {
       return resultText.trim();
@@ -609,6 +735,7 @@ export class ClaudeSdkSession {
     this.feed = null;
     this.turns = 0;
     this.pendingDecision = null;
+    this.pendingEnvelope = null;
     if (q?.interrupt) {
       try {
         await q.interrupt();

--- a/plugins/plugin-cli-inference/src/clean-routing-planner.ts
+++ b/plugins/plugin-cli-inference/src/clean-routing-planner.ts
@@ -201,11 +201,19 @@ export function frameTextSystemPrompt(system: string | undefined): string {
  * cancels any pending tool instruction and demands the finished answer is what
  * reliably stops the narration leak (proven: with it, 4/4 correct + 0 narration +
  * 0 empty across the live-shaped probe; without it, 2/4 + intermittent empties).
+ *
+ * The FORMAT CONTRACT clause leads because this directive serves two call
+ * shapes: the post-tool synthesis reply (prose) AND structured calls like the
+ * Stage-1 routing envelope (JSON with contexts/candidates/ack fields).
+ * Without it, a flat demand for "the finished response" makes a plain-prose
+ * decline the only compliant output for a pre-tool live-info ask — observed
+ * live as the bot declining "whats xrp at" in prose instead of emitting the
+ * envelope that routes it to a fetch.
  */
 export const TEXT_COMPLETION_DIRECTIVE = `
 
 ---
-You are now writing the FINAL reply. Any tool calls shown above have ALREADY executed and their results are the authoritative source of truth — read the actual values out of those tool results and use them verbatim; do NOT invent, estimate, or guess a value when the tool result already contains it. Any earlier "do not answer from prior tool output / call a tool" policy applied only to the planning step, which is now COMPLETE — it no longer applies; there are NO tools left to call. Output ONLY the finished response now, in the agent's voice and the requested format. No preamble, no meta-commentary, no "I can't verify / let me pull a live quote", no description of what you are doing or about to do.`;
+You are now writing the FINAL output for the instructions above. The FORMAT CONTRACT WINS: when those instructions demand a structured output (a JSON object or envelope with named fields), emit EXACTLY that structure with every required field and nothing else — fill its fields as those instructions direct, including routing/context fields and brief-ack reply fields when they call for one. Otherwise output only the finished prose reply in the agent's voice. In either case: tool calls shown above have ALREADY executed and their results are the authoritative source of truth — read the actual values out of those tool results and use them verbatim; do NOT invent, estimate, or guess a value when a tool result already contains it. Any earlier "do not answer from prior tool output / call a tool" policy applied only to the planning step, which is now complete — there are no tools for YOU to call here. Never narrate what you are doing or about to do ("let me pull a live quote", "I'll check") in place of the requested output.`;
 
 /** Append the text-completion directive to a TEXT-mode body. */
 export function appendTextDirective(body: string): string {
@@ -223,6 +231,34 @@ export function appendTextDirective(body: string): string {
  * transcript, persona — rides in the body) because the SDK freezes `systemPrompt`
  * at session start, so a constant system keeps ONE warm process per model.
  */
+/**
+ * STABLE system prompt for the Stage-1 ENVELOPE session (warm Agent SDK,
+ * ENVELOPE mode). The model is given exactly ONE tool — `handle_response` —
+ * and must call it once per turn with the routing envelope the per-turn
+ * instructions (riding in the body) define. Kept CONSTANT for the same reason
+ * as ROUTER_SYSTEM_PROMPT below: the SDK freezes `systemPrompt` at session
+ * start, so a constant system keeps ONE warm process serving every Stage-1
+ * turn. All the real routing rules (simple vs planning, live-info, field
+ * docs) come from the framework's own Stage-1 template in the body — this
+ * prompt only pins the OUTPUT CHANNEL to the tool call.
+ */
+export const STAGE1_ENVELOPE_SYSTEM_PROMPT = `You are the Stage-1 message router for an Eliza AI agent. The user message contains the full routing instructions, the agent persona, and the conversation. Follow those instructions exactly, then submit your decision by calling the handle_response tool EXACTLY ONCE with every field those instructions define — never answer in plain text, never skip the tool call.`;
+
+/**
+ * Build the per-turn ENVELOPE-mode body: the flattened Stage-1 prompt (the
+ * framework template + persona + conversation + field docs), closed with the
+ * tool-call directive. Pairs with {@link STAGE1_ENVELOPE_SYSTEM_PROMPT} (the
+ * constant system slot) exactly as buildRouterBody pairs with
+ * ROUTER_SYSTEM_PROMPT.
+ */
+export function buildEnvelopeBody(system: string | undefined, body: string): string {
+  const instructions = system?.trim() ? `${system.trim()}\n\n` : "";
+  return `${instructions}${body}
+
+---
+Now call handle_response exactly once with the completed envelope fields.`;
+}
+
 export const ROUTER_SYSTEM_PROMPT = `You are the action router for an Eliza AI agent. For EVERY user message, call the route_action tool EXACTLY ONCE with the single best next action and its params, then stop — produce no plain-text answer.
 
 How to choose:


### PR DESCRIPTION
## What

Three additive claude-sdk features on top of the merged effort knobs (#16313), the headline being structural Stage-1 parity for the subscription lane.

**Stage-1 ENVELOPE mode** (default on; `ELIZA_CLI_CLAUDE_STAGE1_ENVELOPE=0` opts out). Every other Stage-1 backend structurally forces the routing envelope — anthropic native tool_use, cloud `tool_choice: required`, local GBNF. The free-text claude-sdk lane relied on prompt prose alone, so the model answered live-info asks in prose that core's tolerant parse chain accepted as a finished "simple reply" — no planner, no fetch. Live evidence: 49 of 54 live-info turns on 2026-07-13/14 were prose-shaped; every decline in that day's Discord log is this gap.

RESPONSE_HANDLER calls carrying core's `HANDLE_RESPONSE` tool now run an ENVELOPE session — one in-process MCP tool (`handle_response`), mirroring the plugin's proven ROUTE mode — whose captured envelope returns as a JSON string core parses identically to a native tool call. Design points hardened on live probes:
- The envelope **field set is derived per-turn from core's composed HANDLE_RESPONSE tool** (`params.tools`), not hardcoded — core's response-handler field REGISTRY lets any plugin add Stage-1 fields (lifeops registers `threadOps`), and the set varies by channel shape; sessions are keyed by the field set since the SDK freezes tool schemas at query() start. `HANDLE_RESPONSE_TOOL_NAME` is barrel-exported from core so the contract has one owner.
- **Shape-aware string decode:** Claude under MCP routinely stringifies array fields (`"contexts": "[\"web\"]"`); core's `Array.isArray` checks would silently default them and ship a bare ack. Fields whose declared schema type is array/object decode at the capture boundary; string-typed fields (`replyText`) pass through untouched so a legitimately JSON-shaped text answer is never mangled.
- **Evaluator isolation:** the post-tool evaluator reuses RESPONSE_HANDLER *without* the HANDLE_RESPONSE tool and expects plain JSON — it stays on the text session (routing it through envelope mode posted raw envelope JSON to the channel on a live probe).
- Off-contract prose falls back to core's tolerant text chain, so the mode strictly upgrades the lane.

**ALL-TIERS mode** (`ELIZA_CLI_CLAUDE_ALL_TIERS=1`): also serves the high-frequency triage tiers so the entire text brain runs on the one subscription — no weak-provider fallthrough mangling action-result rewrites. Triage uses `ELIZA_CLI_CLAUDE_SMALL_MODEL` (or the large model), never the planner tier.

**Tier metadata** (`buildModelMetadata`): `displayModel` per tier feeds RUNTIME_MODEL_CONTEXT so the agent self-reports its real serving model.

Session API: mode is fixed at construction (`text` / `route` / `envelope`), so the public surface is one `send()`.

## Evidence

| Type | Evidence |
|---|---|
| Real-LLM trajectories | Live Discord on the Claude Max lane: "whats xrp at" — declined in prose all day (`I don't have a live XRP quote pulled for this turn…`) — routes post-fix: envelope captured → planner → `WEB_FETCH api.coingecko.com/...ids=ripple` → `XRP is at $1.11 right now.` Same for ADA ($0.163), BTC, Tokyo weather. Math and casual chat stay simple-path. <details><summary>captured envelope (live)</summary>`{"shouldRespond":"RESPOND","contexts":["web"],"intents":["get current xrp price"],"replyText":"Checking the live XRP price now.","candidateActionNames":["WEB_SEARCH","FETCH_PRICE"],...}` → toolSearch → planner → WEB_FETCH ok → EVAL FINISH.</details> |
| Backend logs | `[CLI-INFERENCE:SDK] warm Claude Agent SDK session started (model=claude-sonnet-5, mode=envelope)`; pooled-account rotation logs unchanged. |
| Tests | 127 plugin tests green, including the envelope suite against a fake SDK: captured envelope returned as JSON; per-turn field schema drives the zod schema and capture filter; stringified arrays decode while JSON-shaped `replyText` strings do not; stray model-invented keys dropped; off-contract prose falls back; captured envelope wins over residual limit-looking text; `findHandleResponseTool` selects envelope mode for exactly the Stage-1 call. |
| Error paths | Subscription-limit and SDK API-error envelopes still throw to failover ahead of any prose return; a captured envelope returns before those guards (a valid capture is never discarded for residual text). |
| Screenshots / video | N/A - model-provider plugin lane; live trajectories + Discord messages above are the user-visible proof. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Evidence rows

<!-- evidence-row:before-screenshots -->
`N/A - backend-only change, no UI-bearing files touched; the user-visible effect is Discord message content/count, shown in the llm-trajectory and domain-artifacts rows.`

<!-- evidence-row:after-screenshots -->
`N/A - backend-only change, no UI-bearing files touched; the user-visible effect is Discord message content/count, shown in the llm-trajectory and domain-artifacts rows.`

<!-- evidence-row:walkthrough-video -->
`N/A - backend-only change; the complete run-through is the live Discord battery transcript attached under domain artifacts.`

<!-- evidence-row:backend-logs -->
https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16380-backend-log-envelope.txt

<!-- evidence-row:frontend-logs -->
`N/A - no frontend surface touched.`

<!-- evidence-row:llm-trajectory -->
https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16380-trajectory-xrp-envelope.txt

<!-- evidence-row:domain-artifacts -->
https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16380-battery-transcript.txt
