### PR TITLE
fix(logger): repair stripAnsi regex so LOG_FILE output.log is written

### DIFF
--- a/packages/logger/src/logger.test.ts
+++ b/packages/logger/src/logger.test.ts
@@ -6,6 +6,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  __loggerTestHooks,
   addLogListener,
   createLogger,
   type LogEntry,
@@ -101,5 +102,28 @@ describe("logger", () => {
     ).toContain(
       '[CHAT:OUT] #agent:Eliza room=room-123 action=reply len=4 "done" providers=test-provider',
     );
+  });
+});
+
+// #16356: the file-log path's stripAnsi built an invalid regex (an extra escape
+// level made `\\(B` an unterminated group), so `new RegExp` threw on every call
+// and output.log silently stayed empty. Guard the regex compiles and strips.
+describe("stripAnsi", () => {
+  const { stripAnsi } = __loggerTestHooks;
+
+  it("compiles a valid regex and never throws", () => {
+    expect(() => stripAnsi("plain text")).not.toThrow();
+  });
+
+  it("strips SGR color sequences", () => {
+    expect(stripAnsi("\x1b[36mInfo\x1b[39m hi")).toBe("Info hi");
+  });
+
+  it("strips an OSC sequence terminated by BEL", () => {
+    expect(stripAnsi("\x1b]0;window title\x07rest")).toBe("rest");
+  });
+
+  it("leaves text with no escape sequences unchanged", () => {
+    expect(stripAnsi("no ansi here")).toBe("no ansi here");
   });
 });

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -11,6 +11,7 @@
 // Test hook to clear env cache in logger tests (kept internal)
 export const __loggerTestHooks = {
   clearEnvCacheForTests: () => {},
+  stripAnsi: (str: string): string => stripAnsi(str),
 };
 
 import adze, {
@@ -348,6 +349,11 @@ try {
  */
 let _fileLogState: "pending" | "active" | "disabled" = "pending";
 let _fileLogFd: number | null = null;
+// One-shot guard so a persistent file-write failure surfaces exactly once on
+// stderr instead of being swallowed forever by the catch in writeLogEntryToFile
+// (#16356: an invalid stripAnsi regex threw on every write and output.log
+// silently stayed empty for the sink's whole lifetime).
+let _fileLogWriteErrorWarned = false;
 let _promptLogFd: number | null = null;
 let _chatLogFd: number | null = null;
 let _promptLogCounter = 0;
@@ -373,7 +379,7 @@ function stripAnsi(str: string): string {
   const ESC = "\x1b";
   const BEL = "\x07";
   const re = new RegExp(
-    `${ESC}(?:\\[[\\x20-\\x3F]*[\\x40-\\x7E]|\\].*?(?:${BEL}|${ESC}\\\\|\\\\(B))`,
+    `${ESC}(?:\\[[\\x20-\\x3F]*[\\x40-\\x7E]|\\].*?(?:${BEL}|${ESC}\\\\|\\(B))`,
     "g",
   );
   return str.replace(re, "");
@@ -479,8 +485,18 @@ function writeLogEntryToFile(entry: LogEntry): void {
     const levelStr = LEVEL_TO_NAME[entry.level ?? 30] || "info";
     const line = `${timestamp} [${levelStr.toUpperCase().padEnd(8)}] ${stripAnsi(entry.msg)}\n`;
     fs.writeSync(fd, line);
-  } catch {
-    // Silent fail
+  } catch (error) {
+    // A persistent write failure (e.g. #16356's invalid regex, which threw on
+    // every call) must not stay invisible for the sink's whole lifetime — go
+    // straight to stderr once, bypassing the logger that is itself failing.
+    if (!_fileLogWriteErrorWarned) {
+      _fileLogWriteErrorWarned = true;
+      console.error(
+        `[logger] failed to write to the log file; further errors are suppressed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
   }
 }
 


### PR DESCRIPTION
# Relates to

Closes #16356

- [x] Targets `develop`, rebased on latest `origin/develop`, zero conflicts.
- [x] A reviewer can confirm the change from the evidence below without reading the code.

# Risks

Low. A one-character regex fix plus a one-time stderr warning. The regex previously threw on **every** call (so it stripped nothing and the caller silently no-op'd); it now compiles and strips as intended. No public API change beyond adding `stripAnsi` to the existing `__loggerTestHooks`.

# Background

## What does this PR do?

With `LOG_FILE=true`, `output.log` stayed 0 bytes forever while `prompts.log` / `chat.log` worked. Root cause (reported by @noobshow): `stripAnsi` built an invalid regex — the last OSC-terminator alternative `\\\\(B` cooked to the source `\\(B` (an escaped backslash followed by the **unterminated group** `(B`), so `new RegExp` threw `SyntaxError` on every call. `writeLogEntryToFile` is the only caller and its bare `catch {}` swallowed the throw, so every file write died silently for the sink's entire lifetime.

- Drop the extra escape level (`\\(B` → source `\(B`, the intended escaped-paren match) so the regex compiles and strips SGR/OSC sequences.
- Surface a persistent file-write failure **once** on stderr instead of swallowing it forever — the silent `catch {}` is what let a 100%-reproducible failure hide.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/logger/src/logger.ts` `stripAnsi` (the `\\(B` alternative) and the `writeLogEntryToFile` catch. Pinned by the new `stripAnsi` describe block in `logger.test.ts`.

## Detailed testing steps

None — unit tests cover it.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] `N/A - logger library change in packages/logger; no UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - logger library change; no UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; a log-sink regex fix.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - no deployed backend to log; the log-sink code path (stripAnsi compiles + strips) is asserted by the unit run under Evidence Details.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend involvement.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/model behaviour; a logging-sink fix.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - no DB rows/memories; the affected artifact is output.log, whose emptiness this restores. The regression is asserted at the unit level rather than by attaching a log file.`

# Evidence Details

## Backend + frontend logs

<details><summary>Unit run — stripAnsi compiles and strips (9/9 pass)</summary>

```
logger
  … 5 pre-existing cases (listeners, recentLogs, chat/prompt writers)
stripAnsi
  ✓ compiles a valid regex and never throws
  ✓ strips SGR color sequences        ("\x1b[36mInfo\x1b[39m hi" → "Info hi")
  ✓ strips an OSC sequence terminated by BEL   ("\x1b]0;window title\x07rest" → "rest")
  ✓ leaves text with no escape sequences unchanged

 Test Files  1 passed (1)
      Tests  9 passed (9)
```

Before the fix, `new RegExp(...)` in `stripAnsi` threw `SyntaxError: Invalid regular expression: Unterminated group` — the "never throws" and strip assertions all fail. Biome (2.5.1, the repo version) clean; my edits are typecheck-clean (the package's lone `tsgo` error is a pre-existing missing `fast-redact` declaration on an import I didn't touch).

</details>

[stan-cloud]

