### PR TITLE
fix(agent): seed CEREBRAS_MODEL from the shared SMALL model, not large

### DIFF
--- a/packages/agent/src/runtime/__tests__/model-env-seed.test.ts
+++ b/packages/agent/src/runtime/__tests__/model-env-seed.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Provider model-env seeding rules (`applyProviderModelEnvDefaults`).
+ * `CEREBRAS_MODEL` is the fallback for every tier whose explicit
+ * `OPENAI_*_MODEL` var is unset (response-handler, planner, nano, medium), so
+ * it must seed from the shared SMALL model — seeding it from the large model
+ * silently promoted all of those tiers to the large reasoning model (#16402:
+ * Stage-1 latency spiked 1.2s→10s+ on hidden thinking bursts). Env is
+ * snapshotted/restored; deterministic, no runtime boot.
+ */
+
+import { DEFAULT_CEREBRAS_TEXT_MODEL } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { applyProviderModelEnvDefaults } from "../provider-model-defaults";
+
+const originalEnv = { ...process.env };
+
+const MODEL_ENV_KEYS = [
+  "CEREBRAS_MODEL",
+  "GROQ_SMALL_MODEL",
+  "GROQ_LARGE_MODEL",
+  "OPENAI_SMALL_MODEL",
+  "OPENAI_LARGE_MODEL",
+  "SMALL_MODEL",
+  "LARGE_MODEL",
+];
+
+beforeEach(() => {
+  for (const key of MODEL_ENV_KEYS) delete process.env[key];
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+});
+
+describe("provider model-env seeding", () => {
+  it("seeds CEREBRAS_MODEL from the shared SMALL model, never the large model", () => {
+    process.env.OPENAI_SMALL_MODEL = "gemma-4-31b";
+    process.env.OPENAI_LARGE_MODEL = "zai-glm-4.7";
+
+    applyProviderModelEnvDefaults();
+
+    expect(process.env.CEREBRAS_MODEL).toBe("gemma-4-31b");
+  });
+
+  it("falls back to the approved Cerebras default when the shared small model is OpenAI-only", () => {
+    process.env.OPENAI_SMALL_MODEL = "gpt-5.5-mini";
+    process.env.OPENAI_LARGE_MODEL = "zai-glm-4.7";
+
+    applyProviderModelEnvDefaults();
+
+    expect(process.env.CEREBRAS_MODEL).toBe(DEFAULT_CEREBRAS_TEXT_MODEL);
+  });
+
+  it("preserves an explicit CEREBRAS_MODEL override", () => {
+    process.env.CEREBRAS_MODEL = "qwen-3-235b";
+    process.env.OPENAI_SMALL_MODEL = "gemma-4-31b";
+
+    applyProviderModelEnvDefaults();
+
+    expect(process.env.CEREBRAS_MODEL).toBe("qwen-3-235b");
+  });
+
+  it("keeps the Groq tiers seeded from their own shared models", () => {
+    process.env.SMALL_MODEL = "gemma-4-31b";
+    process.env.LARGE_MODEL = "zai-glm-4.7";
+
+    applyProviderModelEnvDefaults();
+
+    expect(process.env.GROQ_SMALL_MODEL).toBe("gemma-4-31b");
+    expect(process.env.GROQ_LARGE_MODEL).toBe("zai-glm-4.7");
+  });
+});

--- a/packages/agent/src/runtime/__tests__/model-env-seed.test.ts
+++ b/packages/agent/src/runtime/__tests__/model-env-seed.test.ts
@@ -8,9 +8,13 @@
  * snapshotted/restored; deterministic, no runtime boot.
  */
 
-import { DEFAULT_CEREBRAS_TEXT_MODEL } from "@elizaos/core";
+import { readFileSync } from "node:fs";
+import { DEFAULT_CEREBRAS_TEXT_MODEL } from "@elizaos/shared";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { applyProviderModelEnvDefaults } from "../provider-model-defaults";
+import {
+  applyProviderModelEnvDefaults,
+  isLikelyOpenAiTextModel,
+} from "../provider-model-defaults";
 
 const originalEnv = { ...process.env };
 
@@ -68,5 +72,59 @@ describe("provider model-env seeding", () => {
 
     expect(process.env.GROQ_SMALL_MODEL).toBe("gemma-4-31b");
     expect(process.env.GROQ_LARGE_MODEL).toBe("zai-glm-4.7");
+  });
+
+  it("recognizes OpenAI reasoning/fine-tune families without rejecting portable GPT OSS ids", () => {
+    for (const model of [
+      "gpt-5.5-mini",
+      "chatgpt-4o-latest",
+      "codex-mini-latest",
+      "o1",
+      "o3-mini",
+      "o4-mini",
+      "ft:gpt-5-mini:org:job",
+      "openai/o3",
+      "openai/gpt-oss-120b:nitro",
+      "openai/gpt-oss-120b:free",
+      "openai/gpt-oss-120b:online",
+      "gpt-oss-120b:nitro",
+      "openai/vendor-specific-model",
+    ]) {
+      expect(isLikelyOpenAiTextModel(model), model).toBe(true);
+    }
+    for (const model of [
+      "gpt-oss-120b",
+      "openai/gpt-oss-120b",
+      "gemma-4-31b",
+      "zai-glm-4.7",
+    ]) {
+      expect(isLikelyOpenAiTextModel(model), model).toBe(false);
+    }
+  });
+
+  it("is invoked once on the synchronous boot path before provider selection", () => {
+    const source = readFileSync(
+      new URL("../eliza.ts", import.meta.url),
+      "utf8",
+    );
+    const calls = [
+      ...source.matchAll(/applyProviderModelEnvDefaults\(\);/g),
+    ].map((match) => match.index);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toBeGreaterThan(
+      source.indexOf("applySubscriptionCredentialsLocal(config)"),
+    );
+    expect(calls[0]).toBeGreaterThan(
+      source.indexOf(
+        "await applyVaultProfilesForAgent(sharedVault(), agentId)",
+      ),
+    );
+    expect(calls[0]).toBeLessThan(
+      source.indexOf("const configuredProviderPluginNames"),
+    );
+    expect(source.indexOf("const warmEmbeddingModel")).toBeGreaterThan(
+      calls[0],
+    );
   });
 });

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -54,6 +54,11 @@ import {
   type ResolvedPlugin as RuntimeResolvedPlugin,
   STATIC_ELIZA_PLUGINS,
 } from "./plugin-types.ts";
+import {
+  applyProviderModelEnvDefaults,
+  isLikelyOpenAiTextModel,
+  setEnvIfMissing,
+} from "./provider-model-defaults.ts";
 import { shouldLoadRemoteCodingRunnerForBoot } from "./remote-coding-runner-gate.ts";
 import {
   buildRuntimeSettingsProjection,
@@ -127,7 +132,6 @@ import {
   warnOnUnmatchedActionRolePolicyKeys,
 } from "@elizaos/core";
 import {
-  DEFAULT_CEREBRAS_TEXT_MODEL,
   DEFAULT_ELIZA_CLOUD_TEXT_MODEL,
   formatError,
   isElizaSettingsDebugEnabled,
@@ -983,10 +987,6 @@ export async function configureLocalEmbeddingPlugin(
     return undefined;
   })();
 
-  const setEnvIfMissing = (key: string, value: string | undefined): void => {
-    if (!value || process.env[key]) return;
-    process.env[key] = value;
-  };
   const setEnvFromConfig = (key: string, value: string | undefined): void => {
     if (!value) return;
     process.env[key] = value;
@@ -1050,52 +1050,7 @@ export async function configureLocalEmbeddingPlugin(
     process.env.EMBEDDING_PROVIDER = "local";
   }
 
-  // Normalize Google AI API key aliases — the elizaOS plugin and @google/genai
-  // SDK expect different env var names. Canonicalize to the long form that
-  // @elizaos/plugin-google-genai reads via runtime.getSetting(). Users can set
-  // any of: GEMINI_API_KEY, GOOGLE_API_KEY, GOOGLE_GENERATIVE_AI_API_KEY.
-  setEnvIfMissing(
-    "GOOGLE_GENERATIVE_AI_API_KEY",
-    process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY,
-  );
-
-  // Default Google model names — the Google GenAI plugin's getSetting() returns
-  // null (not undefined) for missing keys, but the plugin checks !== undefined
-  // causing String(null) = "null" to be sent as the model name. Set sensible
-  // defaults so the plugin always has valid model names.
-  setEnvIfMissing("GOOGLE_SMALL_MODEL", "gemini-3-flash-preview");
-  setEnvIfMissing("GOOGLE_LARGE_MODEL", "gemini-3.1-pro-preview");
-
-  // Default Groq model names — plugin-groq still ships a deprecated large-model
-  // fallback. Seed runtime defaults before plugin init so direct Groq provider
-  // sessions use the approved GPT-OSS default.
-  const currentSharedSmallModel =
-    process.env.OPENAI_SMALL_MODEL ?? process.env.SMALL_MODEL;
-  const currentSharedLargeModel =
-    process.env.OPENAI_LARGE_MODEL ?? process.env.LARGE_MODEL;
-  setEnvIfMissing(
-    "GROQ_SMALL_MODEL",
-    currentSharedSmallModel && !isLikelyOpenAiTextModel(currentSharedSmallModel)
-      ? currentSharedSmallModel
-      : "openai/gpt-oss-120b",
-  );
-  setEnvIfMissing(
-    "GROQ_LARGE_MODEL",
-    currentSharedLargeModel && !isLikelyOpenAiTextModel(currentSharedLargeModel)
-      ? currentSharedLargeModel
-      : "openai/gpt-oss-120b",
-  );
-
-  // Default Cerebras model — plugin-openai's Cerebras mode otherwise falls
-  // back to OpenAI-only ids when CEREBRAS_MODEL is unset. Seed the approved
-  // Gemma default before plugin init while preserving explicit shared model
-  // overrides from OPENAI_LARGE_MODEL / LARGE_MODEL.
-  setEnvIfMissing(
-    "CEREBRAS_MODEL",
-    currentSharedLargeModel && !isLikelyOpenAiTextModel(currentSharedLargeModel)
-      ? currentSharedLargeModel
-      : DEFAULT_CEREBRAS_TEXT_MODEL,
-  );
+  applyProviderModelEnvDefaults();
 
   logger.info(
     `[eliza] Configured local embedding env: ${process.env.LOCAL_EMBEDDING_MODEL} (repo: ${process.env.LOCAL_EMBEDDING_MODEL_REPO ?? "auto"}, dims: ${process.env.LOCAL_EMBEDDING_DIMENSIONS ?? "auto"}, ctx: ${process.env.LOCAL_EMBEDDING_CONTEXT_SIZE ?? "auto"}, GPU: ${process.env.LOCAL_EMBEDDING_GPU_LAYERS}, mmap: ${process.env.LOCAL_EMBEDDING_USE_MMAP})`,
@@ -1451,12 +1406,6 @@ function detectOpenAiBaseUrlProvider(baseUrl: string): "groq" | null {
 
 function looksLikeGroqApiKey(value: string | undefined): boolean {
   return Boolean(value && /^gsk[-_]/i.test(value));
-}
-
-function isLikelyOpenAiTextModel(value: string | undefined): boolean {
-  if (!value) return false;
-  const normalized = value.trim().toLowerCase();
-  return normalized.startsWith("gpt-") || normalized.startsWith("openai/");
 }
 
 /**

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -1050,8 +1050,6 @@ export async function configureLocalEmbeddingPlugin(
     process.env.EMBEDDING_PROVIDER = "local";
   }
 
-  applyProviderModelEnvDefaults();
-
   logger.info(
     `[eliza] Configured local embedding env: ${process.env.LOCAL_EMBEDDING_MODEL} (repo: ${process.env.LOCAL_EMBEDDING_MODEL_REPO ?? "auto"}, dims: ${process.env.LOCAL_EMBEDDING_DIMENSIONS ?? "auto"}, ctx: ${process.env.LOCAL_EMBEDDING_CONTEXT_SIZE ?? "auto"}, GPU: ${process.env.LOCAL_EMBEDDING_GPU_LAYERS}, mmap: ${process.env.LOCAL_EMBEDDING_USE_MMAP})`,
   );
@@ -3871,6 +3869,7 @@ export async function startEliza(
       `[eliza] Failed to apply local subscription credentials (agent will continue without them): ${formatError(err)}`,
     );
   }
+
   subscriptionCredentialsDeferredPromise = (async () => {
     const { applySubscriptionCredentialsDeferred } = await import(
       "@elizaos/auth"
@@ -4007,6 +4006,14 @@ export async function startEliza(
       );
     }
   }
+
+  // Provider plugins snapshot model env during the blocking resolution wave.
+  // Seed set-if-missing defaults only after subscription, account-pool, and
+  // per-agent vault credentials have all been applied, but before provider
+  // enumeration or plugin resolution. This must not live in the deferred local
+  // embedding warmup: that path is skipped on mobile and can run after the
+  // text provider is already initialized.
+  applyProviderModelEnvDefaults();
 
   // 5-pre. Per-agent EVM + Solana wallet bootstrap is DEFERRED off the boot
   // critical path: it runs after the runtime is reachable (fired fire-and-forget

--- a/packages/agent/src/runtime/provider-model-defaults.ts
+++ b/packages/agent/src/runtime/provider-model-defaults.ts
@@ -1,0 +1,79 @@
+/**
+ * Provider model-env defaults seeded at boot, before plugin init. Called from
+ * `configureLocalEmbeddingPlugin` in `eliza.ts`; lives apart from the boot
+ * monolith so the seeding rules are unit-testable and have one owner.
+ *
+ * Seeding order matters: every default here is set-if-missing, so explicit
+ * operator config (env or character settings folded into env) always wins.
+ */
+import { DEFAULT_CEREBRAS_TEXT_MODEL } from "@elizaos/core";
+
+/** Set an env default without clobbering an operator-provided value. */
+export function setEnvIfMissing(key: string, value: string | undefined): void {
+  if (!value || process.env[key]) return;
+  process.env[key] = value;
+}
+
+/**
+ * True for model ids only OpenAI serves (`gpt-*`, `openai/*`) — such a shared
+ * model must not leak into another provider's default, where the id would 404.
+ */
+export function isLikelyOpenAiTextModel(value: string | undefined): boolean {
+  if (!value) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized.startsWith("gpt-") || normalized.startsWith("openai/");
+}
+
+export function applyProviderModelEnvDefaults(): void {
+  // Normalize Google AI API key aliases — the elizaOS plugin and @google/genai
+  // SDK expect different env var names. Canonicalize to the long form that
+  // @elizaos/plugin-google-genai reads via runtime.getSetting(). Users can set
+  // any of: GEMINI_API_KEY, GOOGLE_API_KEY, GOOGLE_GENERATIVE_AI_API_KEY.
+  setEnvIfMissing(
+    "GOOGLE_GENERATIVE_AI_API_KEY",
+    process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY,
+  );
+
+  // Default Google model names — the Google GenAI plugin's getSetting() returns
+  // null (not undefined) for missing keys, but the plugin checks !== undefined
+  // causing String(null) = "null" to be sent as the model name. Set sensible
+  // defaults so the plugin always has valid model names.
+  setEnvIfMissing("GOOGLE_SMALL_MODEL", "gemini-3-flash-preview");
+  setEnvIfMissing("GOOGLE_LARGE_MODEL", "gemini-3.1-pro-preview");
+
+  // Default Groq model names — plugin-groq still ships a deprecated large-model
+  // fallback. Seed runtime defaults before plugin init so direct Groq provider
+  // sessions use the approved GPT-OSS default.
+  const currentSharedSmallModel =
+    process.env.OPENAI_SMALL_MODEL ?? process.env.SMALL_MODEL;
+  const currentSharedLargeModel =
+    process.env.OPENAI_LARGE_MODEL ?? process.env.LARGE_MODEL;
+  setEnvIfMissing(
+    "GROQ_SMALL_MODEL",
+    currentSharedSmallModel && !isLikelyOpenAiTextModel(currentSharedSmallModel)
+      ? currentSharedSmallModel
+      : "openai/gpt-oss-120b",
+  );
+  setEnvIfMissing(
+    "GROQ_LARGE_MODEL",
+    currentSharedLargeModel && !isLikelyOpenAiTextModel(currentSharedLargeModel)
+      ? currentSharedLargeModel
+      : "openai/gpt-oss-120b",
+  );
+
+  // Default Cerebras model — plugin-openai's Cerebras mode otherwise falls
+  // back to OpenAI-only ids when CEREBRAS_MODEL is unset. CEREBRAS_MODEL is
+  // the FALLBACK for every tier whose explicit OPENAI_*_MODEL var is unset
+  // (response-handler, planner, nano, medium), so it must seed from the
+  // shared SMALL model: seeding it from the large model silently promoted
+  // all of those tiers to the large (reasoning) model — nano/medium triage
+  // calls burned zai-glm-4.7 reasoning budgets, and Stage-1 latency spiked
+  // 1.2s→10s+ on its thinking bursts. Tiers that want the large model keep
+  // it explicitly via OPENAI_LARGE_MODEL / LARGE_MODEL.
+  setEnvIfMissing(
+    "CEREBRAS_MODEL",
+    currentSharedSmallModel && !isLikelyOpenAiTextModel(currentSharedSmallModel)
+      ? currentSharedSmallModel
+      : DEFAULT_CEREBRAS_TEXT_MODEL,
+  );
+}

--- a/packages/agent/src/runtime/provider-model-defaults.ts
+++ b/packages/agent/src/runtime/provider-model-defaults.ts
@@ -1,12 +1,12 @@
 /**
- * Provider model-env defaults seeded at boot, before plugin init. Called from
- * `configureLocalEmbeddingPlugin` in `eliza.ts`; lives apart from the boot
+ * Provider model-env defaults seeded synchronously by runtime boot before
+ * provider selection and plugin initialization. Lives apart from the boot
  * monolith so the seeding rules are unit-testable and have one owner.
  *
  * Seeding order matters: every default here is set-if-missing, so explicit
  * operator config (env or character settings folded into env) always wins.
  */
-import { DEFAULT_CEREBRAS_TEXT_MODEL } from "@elizaos/core";
+import { DEFAULT_CEREBRAS_TEXT_MODEL } from "@elizaos/shared";
 
 /** Set an env default without clobbering an operator-provided value. */
 export function setEnvIfMissing(key: string, value: string | undefined): void {
@@ -15,13 +15,34 @@ export function setEnvIfMissing(key: string, value: string | undefined): void {
 }
 
 /**
- * True for model ids only OpenAI serves (`gpt-*`, `openai/*`) — such a shared
- * model must not leak into another provider's default, where the id would 404.
+ * True for model ids that identify OpenAI-only text families. Open-weight GPT
+ * OSS ids are deliberately excluded because Groq, Cerebras, and other
+ * OpenAI-compatible providers serve them too.
  */
 export function isLikelyOpenAiTextModel(value: string | undefined): boolean {
   if (!value) return false;
   const normalized = value.trim().toLowerCase();
-  return normalized.startsWith("gpt-") || normalized.startsWith("openai/");
+  if (!normalized) return false;
+
+  const hasOpenAiNamespace = normalized.startsWith("openai/");
+  const unqualified = hasOpenAiNamespace
+    ? normalized.slice("openai/".length)
+    : normalized;
+  // Only bare, portable GPT-OSS model ids are safe to copy into direct Groq
+  // or Cerebras configuration. Router variants such as :nitro/:free/:online
+  // are provider-specific and must fall through to the conservative path.
+  if (/^gpt-oss-(?:\d+b|safeguard-\d+b)$/.test(unqualified)) return false;
+  if (hasOpenAiNamespace) return true;
+
+  const model = unqualified.startsWith("ft:")
+    ? unqualified.slice("ft:".length)
+    : unqualified;
+  return (
+    model.startsWith("gpt-") ||
+    model.startsWith("chatgpt-") ||
+    model.startsWith("codex-") ||
+    /^o[134](?:-|$)/.test(model)
+  );
 }
 
 export function applyProviderModelEnvDefaults(): void {


### PR DESCRIPTION
## What

At boot, `CEREBRAS_MODEL` was seeded from the shared **LARGE** model. `CEREBRAS_MODEL` is the fallback for every tier whose explicit `OPENAI_*_MODEL` var is unset — response-handler, planner, nano, medium — so all of them were silently promoted to the large reasoning model. TEXT_NANO triage calls ran zai-glm-4.7, and Stage-1 latency spiked 1.2s→10s+ on its hidden thinking bursts (measured: default glm burns ~400 reasoning tokens/813ms on a one-line prompt; `reasoning_effort:none` = 0 tokens/158ms).

Seeding from the shared **SMALL** model restores the intended ladder: everything unset falls back to small; large tiers keep the large model explicitly via `OPENAI_LARGE_MODEL`/`LARGE_MODEL`. The constant the seed references is literally `DEFAULT_CEREBRAS_TEXT_MODEL = "gemma-4-31b"` — seeding it with large defeated it.

## Evidence

| Type | Evidence |
|---|---|
| Backend logs | before: `Using RESPONSE_HANDLER model: zai-glm-4.7`, `Using TEXT_NANO model: zai-glm-4.7`; after: `Using RESPONSE_HANDLER model: gemma-4-31b`, `Using ACTION_PLANNER model: gemma-4-31b` — same deployment, only this change. |
| Real-LLM trajectory | Live before/after (Cerebras direct, InferenceTiming): stage-1 model span 1176–12791ms (glm reasoning bursts) → 472–1156ms (gemma, 6/6 turns, zero outliers); simple-chat time-to-reply 5.9s median → 2.1–3.0s. Routing quality unchanged: live price/weather probes fetch + answer correctly post-change. |
| Tests | provider-switch-config suite green (its cerebras block already documents the small-collapse intent this restores). |
| Screenshots / video / frontend logs | N/A - boot-time env seeding, no UI surface. |
| Domain artifacts | N/A - covered by the before/after model-resolution log lines above. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Evidence rows

<!-- evidence-row:before-screenshots -->
`N/A - backend-only change, no UI-bearing files touched; the user-visible effect is shown in the backend-logs and domain-artifacts rows.`

<!-- evidence-row:after-screenshots -->
`N/A - backend-only change, no UI-bearing files touched; the user-visible effect is shown in the backend-logs and domain-artifacts rows.`

<!-- evidence-row:walkthrough-video -->
`N/A - backend-only change; the complete run-through is the live evidence attached under domain artifacts.`

<!-- evidence-row:backend-logs -->
https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16402-seed-fix-models.txt

<!-- evidence-row:frontend-logs -->
`N/A - no frontend surface touched.`

<!-- evidence-row:llm-trajectory -->
https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16402-seed-battery.txt

<!-- evidence-row:domain-artifacts -->
https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16402-seed-fix-models.txt
