### PR TITLE
perf(core): stop refetching discarded chat context on the stage-1 critical path

### DIFF
--- a/packages/core/src/features/basic-capabilities/providers/platformContext.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/platformContext.test.ts
@@ -184,6 +184,149 @@ describe("platform context providers", () => {
 		});
 	});
 
+	it("drops the legacy unscoped connector when an account-scoped sibling shares its source", async () => {
+		const legacyChat = vi.fn(async (target) => ({
+			target,
+			label: "#legacy",
+		}));
+		const scopedChat = vi.fn(async (target) => ({
+			target,
+			label: "#scoped",
+		}));
+		const runtime = makeRuntime([
+			makeConnector("slack", { getChatContext: legacyChat }),
+			makeConnector("slack", {
+				accountId: "acct-1",
+				getChatContext: scopedChat,
+			}),
+		]);
+
+		const result = await platformChatContextProvider.get(
+			runtime,
+			makeMessage("slack"),
+			makeState(),
+		);
+
+		expect(legacyChat).not.toHaveBeenCalled();
+		expect(scopedChat).toHaveBeenCalledOnce();
+		expect(result.data).toMatchObject({
+			chatContextCount: 1,
+			relevantConnectorCount: 1,
+		});
+	});
+
+	it("keeps an unscoped connector whose source has no account-scoped sibling", async () => {
+		const slackChat = vi.fn(async (target) => ({
+			target,
+			label: "#general",
+		}));
+		const runtime = makeRuntime([
+			makeConnector("slack", { getChatContext: slackChat }),
+			makeConnector("discord", {
+				accountId: "acct-9",
+				getChatContext: vi.fn(async (target) => ({ target, label: "#d" })),
+			}),
+		]);
+
+		const result = await platformChatContextProvider.get(
+			runtime,
+			makeMessage("slack"),
+			makeState(),
+		);
+
+		expect(slackChat).toHaveBeenCalledOnce();
+		expect(result.data).toMatchObject({ chatContextCount: 1 });
+	});
+
+	it("runs chat-context hooks concurrently across connectors", async () => {
+		// The first connector's hook only resolves once the second connector's
+		// hook has STARTED — serial execution would leave it pending until the
+		// race below times it out and drops its context.
+		let secondStarted: () => void = () => {};
+		const secondStartedPromise = new Promise<void>((resolve) => {
+			secondStarted = resolve;
+		});
+		const firstChat = vi.fn(async (target) => {
+			await Promise.race([
+				secondStartedPromise,
+				new Promise((_resolve, reject) =>
+					setTimeout(() => reject(new Error("hooks ran serially")), 1000),
+				),
+			]);
+			return { target, label: "#first" };
+		});
+		const secondChat = vi.fn(async (target) => {
+			secondStarted();
+			return { target, label: "#second" };
+		});
+		const runtime = makeRuntime([
+			makeConnector("slack", { getChatContext: firstChat }),
+			makeConnector("discord", { getChatContext: secondChat }),
+		]);
+		const message = makeMessage();
+		message.content.metadata = {
+			[CONTEXT_ROUTING_METADATA_KEY]: { primaryContext: "connectors" },
+		};
+		const state = makeState();
+		state.data.room = {
+			id: ROOM_ID,
+			type: ChannelType.GROUP,
+			source: "",
+			channelId: "C999",
+		};
+
+		const result = await platformChatContextProvider.get(
+			runtime,
+			message,
+			state,
+		);
+
+		expect(result.data).toMatchObject({ chatContextCount: 2 });
+	});
+
+	it("runs user-context hooks concurrently across connectors", async () => {
+		let secondStarted: () => void = () => {};
+		const secondStartedPromise = new Promise<void>((resolve) => {
+			secondStarted = resolve;
+		});
+		const firstUser = vi.fn(async (entityId) => {
+			await Promise.race([
+				secondStartedPromise,
+				new Promise((_resolve, reject) =>
+					setTimeout(() => reject(new Error("hooks ran serially")), 1000),
+				),
+			]);
+			return { entityId, label: "First User" };
+		});
+		const secondUser = vi.fn(async (entityId) => {
+			secondStarted();
+			return { entityId, label: "Second User" };
+		});
+		const runtime = makeRuntime([
+			makeConnector("slack", { getUserContext: firstUser }),
+			makeConnector("discord", { getUserContext: secondUser }),
+		]);
+		const message = makeMessage();
+		message.content.metadata = {
+			[CONTEXT_ROUTING_METADATA_KEY]: { primaryContext: "connectors" },
+		};
+		const state = makeState();
+		state.data.room = {
+			id: ROOM_ID,
+			type: ChannelType.GROUP,
+			source: "",
+			channelId: "C999",
+		};
+
+		const result = await platformUserContextProvider.get(
+			runtime,
+			message,
+			state,
+		);
+
+		expect(result.data).toMatchObject({ userContextCount: 2 });
+	});
+
 	it("prefers the current platform source over other connector contexts", async () => {
 		const slackChat = vi.fn(async (target) => ({
 			target,

--- a/packages/core/src/features/basic-capabilities/providers/platformContext.ts
+++ b/packages/core/src/features/basic-capabilities/providers/platformContext.ts
@@ -216,15 +216,37 @@ function filterContextRelevantConnectors(
 	source: string | undefined,
 	activeContexts: AgentContext[],
 ): MessageConnector[] {
-	const sourceMatches = connectors.filter((connector) =>
-		connectorMatchesSource(connector, source),
+	const sourceMatches = dropShadowedLegacyConnectors(
+		connectors.filter((connector) => connectorMatchesSource(connector, source)),
 	);
 	if (source) {
 		return sourceMatches;
 	}
 
-	return connectors.filter((connector) =>
-		connectorMatchesExplicitContext(connector, activeContexts),
+	return dropShadowedLegacyConnectors(
+		connectors.filter((connector) =>
+			connectorMatchesExplicitContext(connector, activeContexts),
+		),
+	);
+}
+
+/**
+ * Drop an accountId-less connector when an account-scoped connector with the
+ * same source is present. Connector plugins register both a legacy unscoped
+ * entry and one entry per account; the pair answers every context hook with
+ * byte-identical work, so keeping both doubles the per-turn connector cost
+ * (observed live: two serial Discord history round-trips per turn).
+ */
+function dropShadowedLegacyConnectors(
+	connectors: MessageConnector[],
+): MessageConnector[] {
+	const scopedSources = new Set(
+		connectors
+			.filter((connector) => connector.accountId)
+			.map((connector) => connector.source),
+	);
+	return connectors.filter(
+		(connector) => connector.accountId || !scopedSources.has(connector.source),
 	);
 }
 
@@ -338,27 +360,35 @@ export const platformChatContextProvider: Provider = {
 			activeContexts,
 		);
 		const target = buildCurrentTarget(message, room, source);
-		const contexts: Record<string, ProviderValue>[] = [];
-
-		for (const connector of relevantConnectors) {
-			try {
-				const context = await connector.getChatContext?.(target, queryContext);
-				if (!context) {
-					continue;
-				}
-				contexts.push(normalizeChatContext(connector, context));
-			} catch (error) {
-				runtime.logger.debug(
-					{
-						src: "provider:platformChatContext",
-						agentId: runtime.agentId,
-						connector: connector.source,
-						error: error instanceof Error ? error.message : String(error),
-					},
-					"Message connector chat context hook failed",
-				);
-			}
-		}
+		// Connector hooks run concurrently: each may do its own I/O, and this
+		// provider sits on the Stage-1 critical path — serializing them stacks
+		// every connector's round-trip into the turn floor.
+		const contexts: Record<string, ProviderValue>[] = (
+			await Promise.all(
+				relevantConnectors.map(async (connector) => {
+					try {
+						const context = await connector.getChatContext?.(
+							target,
+							queryContext,
+						);
+						return context ? normalizeChatContext(connector, context) : null;
+					} catch (error) {
+						runtime.logger.debug(
+							{
+								src: "provider:platformChatContext",
+								agentId: runtime.agentId,
+								connector: connector.source,
+								error: error instanceof Error ? error.message : String(error),
+							},
+							"Message connector chat context hook failed",
+						);
+						return null;
+					}
+				}),
+			)
+		).filter(
+			(context): context is Record<string, ProviderValue> => context !== null,
+		);
 
 		if (contexts.length === 0) {
 			return emptyResult({
@@ -443,30 +473,33 @@ export const platformUserContextProvider: Provider = {
 			source,
 			activeContexts,
 		);
-		const users: Record<string, ProviderValue>[] = [];
-
-		for (const connector of relevantConnectors) {
-			try {
-				const context = await connector.getUserContext?.(
-					message.entityId,
-					queryContext,
-				);
-				if (!context) {
-					continue;
-				}
-				users.push(normalizeUserContext(connector, context));
-			} catch (error) {
-				runtime.logger.debug(
-					{
-						src: "provider:platformUserContext",
-						agentId: runtime.agentId,
-						connector: connector.source,
-						error: error instanceof Error ? error.message : String(error),
-					},
-					"Message connector user context hook failed",
-				);
-			}
-		}
+		// Concurrent for the same reason as the chat-context hooks above.
+		const users: Record<string, ProviderValue>[] = (
+			await Promise.all(
+				relevantConnectors.map(async (connector) => {
+					try {
+						const context = await connector.getUserContext?.(
+							message.entityId,
+							queryContext,
+						);
+						return context ? normalizeUserContext(connector, context) : null;
+					} catch (error) {
+						runtime.logger.debug(
+							{
+								src: "provider:platformUserContext",
+								agentId: runtime.agentId,
+								connector: connector.source,
+								error: error instanceof Error ? error.message : String(error),
+							},
+							"Message connector user context hook failed",
+						);
+						return null;
+					}
+				}),
+			)
+		).filter(
+			(context): context is Record<string, ProviderValue> => context !== null,
+		);
 
 		if (users.length === 0) {
 			return emptyResult({

--- a/plugins/plugin-discord/__tests__/service-account-pool.test.ts
+++ b/plugins/plugin-discord/__tests__/service-account-pool.test.ts
@@ -130,6 +130,10 @@ function makeDiscordGraph() {
 		),
 		sendTyping: vi.fn().mockResolvedValue(undefined),
 		messages: {
+			// The chat-context hook reads the gateway-populated cache (never a
+			// REST fetch — see getConnectorChatContext); fetch remains for the
+			// message operations that do address single messages by id.
+			cache: new Collection(messages),
 			fetch: vi.fn(async (arg?: string | { limit?: number }) => {
 				if (typeof arg === "string") {
 					return messages.get(arg);

--- a/plugins/plugin-discord/__tests__/service-account-pool.test.ts
+++ b/plugins/plugin-discord/__tests__/service-account-pool.test.ts
@@ -608,6 +608,45 @@ describe("DiscordService account-scoped primitives", () => {
 		);
 	});
 
+	it("serves chat-context history from the gateway cache without a REST fetch or room read", async () => {
+		const { graph, runtime, service } = makeService();
+		const getRoom = vi.fn(async () => ({
+			id: "00000000-0000-0000-0000-000000000002",
+			channelId: graph.textChannel.id,
+		}));
+		const context = {
+			runtime: { ...runtime, getRoom },
+			target: {
+				source: "discord",
+				accountId: "default",
+				channelId: graph.textChannel.id,
+			},
+		};
+
+		// Target already carries a channelId: no DB room read, no history REST
+		// fetch — this hook runs on the Stage-1 critical path every turn.
+		const chatContext = await service.getConnectorChatContext(
+			{
+				source: "discord",
+				channelId: graph.textChannel.id,
+				roomId: "00000000-0000-0000-0000-000000000002",
+			},
+			context,
+		);
+		expect(chatContext?.recentMessages[0]?.text).toBe("hello from discord");
+		expect(getRoom).not.toHaveBeenCalled();
+		expect(graph.textChannel.messages.fetch).not.toHaveBeenCalled();
+
+		// Without a channelId the room read is the only way to recover one.
+		const viaRoom = await service.getConnectorChatContext(
+			{ source: "discord", roomId: "00000000-0000-0000-0000-000000000002" },
+			context,
+		);
+		expect(getRoom).toHaveBeenCalledOnce();
+		expect(viaRoom?.recentMessages[0]?.text).toBe("hello from discord");
+		expect(graph.textChannel.messages.fetch).not.toHaveBeenCalled();
+	});
+
 	it("stops account clients, clears retry state, and rejects pending ready waits", async () => {
 		const { graph, service } = makeService();
 		const state = service.accountPool.get("default");

--- a/plugins/plugin-discord/__tests__/service-regression-lane.test.ts
+++ b/plugins/plugin-discord/__tests__/service-regression-lane.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Composes the DiscordService-focused suites for changes to the monolithic
+ * `service.ts`. The changed-file coverage gate runs only tests present in a PR
+ * diff, so this lane keeps service changes attached to the existing behavioral
+ * matrix until the service is decomposed into independently covered modules.
+ * Mirrors `packages/core/src/__tests__/runtime-regression-lane.test.ts`.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import "./channel-allowlist.test.ts";
+import "./connector-rooms.test.ts";
+import "./list-servers-persisted-world.test.ts";
+import "./login-retry.test.ts";
+import "./owner-refresh.test.ts";
+import "./register-slash-commands-guards.test.ts";
+import "./service-account-config-resolution.test.ts";
+import "./service-account-pool.test.ts";
+import "./slash-command-registration-scope.test.ts";
+import "./thread-target-parent-mute.test.ts";
+
+describe("service regression lane composition", () => {
+	it("imports every default-lane suite that exercises ../service", () => {
+		const here = path.dirname(fileURLToPath(import.meta.url));
+		const selfSource = readFileSync(fileURLToPath(import.meta.url), "utf8");
+		const imported = [...selfSource.matchAll(/import "\.\/([^"]+)";/g)]
+			.map((match) => match[1])
+			.sort();
+		const serviceSuites = readdirSync(here)
+			.filter(
+				(name) =>
+					name.endsWith(".test.ts") &&
+					!name.endsWith(".harness.test.ts") &&
+					name !== path.basename(fileURLToPath(import.meta.url)) &&
+					/from "\.\.\/service(\.ts)?"/.test(
+						readFileSync(path.join(here, name), "utf8"),
+					),
+			)
+			.sort();
+		expect(imported).toEqual(serviceSuites);
+	});
+});

--- a/plugins/plugin-discord/service.ts
+++ b/plugins/plugin-discord/service.ts
@@ -2371,8 +2371,12 @@ export class DiscordService extends Service implements IDiscordService {
 			return null;
 		}
 
+		// The room read exists only to recover a channelId the caller did not
+		// resolve — skip the DB round-trip when the target already carries one.
 		const room =
-			target.roomId && typeof context.runtime.getRoom === "function"
+			!target.channelId &&
+			target.roomId &&
+			typeof context.runtime.getRoom === "function"
 				? await context.runtime.getRoom(target.roomId)
 				: null;
 		const channelId = target.channelId ?? room?.channelId;
@@ -2390,44 +2394,38 @@ export class DiscordService extends Service implements IDiscordService {
 			topic?: string | null;
 			guild?: Guild;
 			messages?: {
-				fetch: (options: {
-					limit: number;
-				}) => Promise<Collection<string, Message>>;
+				cache?: Collection<string, Message>;
 			};
 		};
+		// Recent history comes from the gateway-populated message cache, never a
+		// REST fetch: this hook runs on the Stage-1 critical path every turn, a
+		// GET /channels/{id}/messages costs 100ms-3s+ behind discord.js's
+		// rate-limit buckets, and the transcript in the prompt is owned by
+		// RECENT_MESSAGES anyway (the provider strips recentMessages before
+		// rendering — the fetched history was diagnostics-only). The cache holds
+		// the same gateway-delivered messages at zero cost; right after boot it
+		// is simply empty.
 		const recentMessages: MessageConnectorChatContext["recentMessages"] = [];
-		if (channelRecord.messages?.fetch) {
-			try {
-				const fetched = await channelRecord.messages.fetch({ limit: 10 });
-				for (const message of Array.from(fetched.values()).reverse()) {
-					if (!message.content.trim()) {
-						continue;
-					}
-					recentMessages.push({
-						entityId: this.resolveDiscordEntityId(message.author.id),
-						name:
-							message.member?.displayName ||
-							message.author.globalName ||
-							message.author.username,
-						text: message.content,
-						timestamp: message.createdTimestamp,
-						metadata: {
-							accountId,
-							discordMessageId: message.id,
-							discordUserId: message.author.id,
-						},
-					});
+		const cached = channelRecord.messages?.cache;
+		if (cached) {
+			for (const message of Array.from(cached.values()).slice(-10)) {
+				if (!message.content.trim()) {
+					continue;
 				}
-			} catch (error) {
-				this.runtime.logger.debug(
-					{
-						src: "plugin:discord",
-						agentId: this.runtime.agentId,
-						channelId,
-						error: error instanceof Error ? error.message : String(error),
+				recentMessages.push({
+					entityId: this.resolveDiscordEntityId(message.author.id),
+					name:
+						message.member?.displayName ||
+						message.author.globalName ||
+						message.author.username,
+					text: message.content,
+					timestamp: message.createdTimestamp,
+					metadata: {
+						accountId,
+						discordMessageId: message.id,
+						discordUserId: message.author.id,
 					},
-					"Discord connector chat context history fetch failed",
-				);
+				});
 			}
 		}
 


### PR DESCRIPTION
## What

`PLATFORM_CHAT_CONTEXT` cost 328–3394ms on the Stage-1 critical path every turn — doing work whose output is **stripped before the prompt** (`omitRecentMessages`; the transcript is owned by RECENT_MESSAGES, and the fetched history has zero runtime consumers — grepped packages/ + plugins/). Three deterministic fixes, no deadline, no dropped context (the deadline alternative is #16400; root-cause evidence in #16393):

- **plugin-discord `getConnectorChatContext`** reads recent history from the gateway-populated message cache instead of a REST `GET /channels/{id}/messages` that queues behind discord.js's per-route rate-limit buckets (100ms–3s+ per call). Same gateway-delivered data, zero cost; empty only right after boot. The room DB read now only runs when the target carries no channelId.
- **`platformContext` drops shadowed legacy connectors**: connector plugins register a legacy accountId-less entry plus one per account; the pair answers every hook with byte-identical work, so each turn did the full fetch **twice, serially**.
- **Both connector hook loops run concurrently** — each hook may do its own I/O and this provider sits on the compose critical path; serializing stacks every connector's round-trip into the turn floor. Protects every other connector platform implementing these hooks, not just Discord.

## Evidence

| Type | Evidence |
|---|---|
| Real-LLM trajectory | Live before/after on the same deployment (InferenceTiming spans): `provider:PLATFORM_CHAT_CONTEXT` 328–3394ms → **145–235ms**. Live probes post-change: chat + price turns answer correctly with real fetched data (coingecko ETH $1,927.46), one clean message each. |
| Backend logs | span table in #16393 (comment) — before rows show chatctx up to 3394ms; post-restart rows 145/235ms. |
| Tests | plugin-discord suite 433/433 (the account-pool connector test now exercises the gateway-cache contract); core platformContext suite green. |
| Screenshots / video / frontend logs | N/A - provider/runtime change, no UI surface. |
| Domain artifacts | N/A - the InferenceTiming span deltas above are the domain artifact. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Evidence rows

<!-- evidence-row:before-screenshots -->
`N/A - backend-only change, no UI-bearing files touched; the user-visible effect is shown in the backend-logs and domain-artifacts rows.`

<!-- evidence-row:after-screenshots -->
`N/A - backend-only change, no UI-bearing files touched; the user-visible effect is shown in the backend-logs and domain-artifacts rows.`

<!-- evidence-row:walkthrough-video -->
`N/A - backend-only change; the complete run-through is the live evidence attached under domain artifacts.`

<!-- evidence-row:backend-logs -->
https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16403-chatctx-spans.txt

<!-- evidence-row:frontend-logs -->
`N/A - no frontend surface touched.`

<!-- evidence-row:llm-trajectory -->
https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16403-chatctx-spans.txt

<!-- evidence-row:domain-artifacts -->
https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16403-chatctx-spans.txt
