### PR TITLE
fix(ci): roll pr-evidence uploads to an overflow release past the 1000-asset cap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,14 +149,22 @@ rebasing when `develop` changes the behavior under review.
 **Headless agents (no browser, cannot drag-and-drop):** upload media to the
 dedicated [`pr-evidence` release](https://github.com/elizaOS/eliza/releases/tag/pr-evidence)
 and embed the asset URLs — they end in a media extension, render inline via
-`![](…)`, and satisfy the evidence gate:
+`![](…)`, and satisfy the evidence gate. Prefer the one-command tool, which
+also patches the PR rows and verifies the gate locally:
 
 ```bash
 # name files <pr-number>-<artifact>.<ext>, then:
-gh release upload pr-evidence 15171-after-desktop.jpg 15171-walkthrough.mp4
+node scripts/pr-evidence.mjs attach 15171 15171-after-desktop.jpg 15171-walkthrough.mp4
 # embed in the PR evidence rows:
 #   ![after](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15171-after-desktop.jpg)
 ```
+
+GitHub caps a release at 1000 assets, so once `pr-evidence` fills, `attach`
+rolls uploads into overflow releases (`pr-evidence-2`, `pr-evidence-3`, …) and
+emits the URL of whichever release holds the asset. The gate accepts the whole
+`pr-evidence`/`pr-evidence-N` family identically, so no manual tag juggling is
+needed — always attach via the script rather than a raw `gh release upload`,
+which fails once the target release is full.
 
 Never delete assets referenced by an open PR. A worked example of a fully
 evidenced PR (before/after screenshots, MP4 walkthroughs, OCR readout,

--- a/scripts/check-pr-evidence.mjs
+++ b/scripts/check-pr-evidence.mjs
@@ -417,7 +417,7 @@ function buildFixtureBody(overrides = {}) {
   ).join("\n\n");
 }
 
-function runSelfTest() {
+export function runSelfTest() {
   const failures = [];
 
   {

--- a/scripts/check-pr-evidence.mjs
+++ b/scripts/check-pr-evidence.mjs
@@ -116,8 +116,7 @@ export function hasOcrEvidenceReference(rows) {
     // actual media artifact or a linked report/log file next to OCR keywords.
     if (
       OCR_EVIDENCE_RE.test(rowText) &&
-      (hasVisualArtifactReference(rowText) ||
-        hasEvidenceFileReference(rowText))
+      (hasVisualArtifactReference(rowText) || hasEvidenceFileReference(rowText))
     ) {
       return true;
     }
@@ -126,13 +125,17 @@ export function hasOcrEvidenceReference(rows) {
 }
 
 // Linked non-media evidence file (an OCR report/JSON/log) — still stricter
-// than "any URL": the link target must look like a file, not a web page.
+// than "any URL": the link target must look like a file, not a web page, OR live
+// on the pr-evidence release family (`PR_EVIDENCE_RELEASE_RE`), where every URL
+// is by construction an uploaded asset rather than a page.
 const EVIDENCE_FILE_RE = /\.(json|txt|log|csv|md)(\?\S*)?(\s|$|\)|"|')/i;
 
 export function hasEvidenceFileReference(text) {
   const value = String(text ?? "");
   return (
-    (EVIDENCE_FILE_RE.test(value) || GITHUB_ATTACHMENT_RE.test(value)) &&
+    (EVIDENCE_FILE_RE.test(value) ||
+      GITHUB_ATTACHMENT_RE.test(value) ||
+      PR_EVIDENCE_RELEASE_RE.test(value)) &&
     !RETIRED_REPO_EVIDENCE_RE.test(value)
   );
 }
@@ -171,6 +174,16 @@ const GITHUB_ATTACHMENT_RE =
 // A URL/path whose tail is an image or video file — a directly-linked media file.
 const MEDIA_EXT_RE =
   /\.(png|jpe?g|gif|webp|apng|avif|bmp|svg|mp4|mov|webm|m4v|ogg)(\?\S*)?(\s|$|\)|"|')/i;
+// The canonical CLI evidence store: the shared `pr-evidence` release plus its
+// `pr-evidence-2`, `pr-evidence-3`, … overflow releases (scripts/pr-evidence.mjs
+// rolls uploads into the next release once GitHub's hard 1000-assets-per-release
+// cap is hit). A `/releases/download/` URL there points at an uploaded asset, not
+// a web page, so the whole family is a first-class evidence host — matched here
+// so an overflow-release link is accepted identically to a primary-release one.
+// The trailing slash after the tag keeps a link to the release *page*
+// (`/releases/tag/pr-evidence`) from matching.
+const PR_EVIDENCE_RELEASE_RE =
+  /(https?:\/\/)?github\.com\/[^/\s)]+\/[^/\s)]+\/releases\/download\/pr-evidence(-\d+)?\//i;
 
 /**
  * Strict media check for the VISUAL evidence rows (screenshots, walkthrough
@@ -187,6 +200,11 @@ export function hasVisualArtifactReference(text) {
   if (GITHUB_ATTACHMENT_RE.test(value)) return true;
   if (/!\[[^\]]*\]\(\s*\S+\s*\)/.test(value)) return true; // ![alt](url) embed
   if (/<(img|video|source|picture)\b[^>]*>/i.test(value)) return true;
+  // A directly-linked media file — including screenshots/videos uploaded to the
+  // pr-evidence release family (primary or `pr-evidence-N` overflow), whose asset
+  // URLs carry a media extension. The extension is required so a non-image
+  // release asset cannot satisfy a screenshot/video row; the retired repo-local
+  // evidence path never counts.
   if (MEDIA_EXT_RE.test(value) && !RETIRED_REPO_EVIDENCE_RE.test(value)) {
     return true;
   }
@@ -299,7 +317,11 @@ export function evaluatePrEvidence(
     const artifactRequired =
       surfaceArtifactsRequired &&
       SURFACE_ARTIFACT_ROW_IDS.includes(id) &&
-      !(id === "before-screenshots" && beforeNaAllowed && hasNaWithReason(rowText));
+      !(
+        id === "before-screenshots" &&
+        beforeNaAllowed &&
+        hasNaWithReason(rowText)
+      );
     // Visual rows on a surface PR demand REAL media (attachment/embed/media
     // URL) — a link to the PR page or a /checks tab is not a screenshot.
     if (artifactRequired && !hasVisualArtifactReference(rowText)) {
@@ -308,8 +330,7 @@ export function evaluatePrEvidence(
     return {
       id,
       label,
-      status:
-        artifactRequired || isRowSatisfied(rowText) ? "ok" : "blank",
+      status: artifactRequired || isRowSatisfied(rowText) ? "ok" : "blank",
     };
   });
   if (surfaceArtifactsRequired && !hasOcrEvidenceReference(rows)) {
@@ -483,13 +504,17 @@ function runSelfTest() {
   }
 
   {
-    const { ok } = evaluatePrEvidence(buildFixtureBody(), REQUIRED_EVIDENCE_ROWS, {
-      changedFiles: [
-        "packages/ui/src/components/Foo.test.tsx",
-        "packages/app-core/src/services/thing.ts",
-        "packages/ui/src/components/Foo.stories.tsx",
-      ],
-    });
+    const { ok } = evaluatePrEvidence(
+      buildFixtureBody(),
+      REQUIRED_EVIDENCE_ROWS,
+      {
+        changedFiles: [
+          "packages/ui/src/components/Foo.test.tsx",
+          "packages/app-core/src/services/thing.ts",
+          "packages/ui/src/components/Foo.stories.tsx",
+        ],
+      },
+    );
     if (!ok) {
       failures.push(
         "test/story/server-only diff should not trigger surface artifacts",
@@ -544,12 +569,45 @@ function runSelfTest() {
     }
   }
 
+  {
+    // An overflow-release (pr-evidence-N) screenshot satisfies a UI-file surface
+    // PR identically to a primary-release one — the storage location moved, the
+    // gate did not.
+    const dl = (tag, name) =>
+      `https://github.com/elizaOS/eliza/releases/download/${tag}/${name}`;
+    const { ok } = evaluatePrEvidence(
+      buildFixtureBody({
+        "before-screenshots": `- [x] ![before](${dl("pr-evidence-2", "16367-before.jpg")})`,
+        "after-screenshots": `- [x] ![after](${dl("pr-evidence-2", "16367-after.jpg")})`,
+        "walkthrough-video": `- [x] ${dl("pr-evidence-2", "16367-walk.mp4")}`,
+        "domain-artifacts": `- [ ] OCR text readout: ${dl("pr-evidence-3", "16367-ocr.jsonl")}`,
+      }),
+      REQUIRED_EVIDENCE_ROWS,
+      { changedFiles: ["packages/ui/src/components/Foo.tsx"] },
+    );
+    if (!ok)
+      failures.push("overflow-release evidence on a surface PR should pass");
+  }
+
+  {
+    // A link to the release PAGE (not a /download/ asset) is not a screenshot.
+    const { ok } = evaluatePrEvidence(
+      buildFixtureBody({
+        "before-screenshots":
+          "- [ ] Before screenshots: https://github.com/elizaOS/eliza/releases/tag/pr-evidence-2",
+      }),
+      REQUIRED_EVIDENCE_ROWS,
+      { changedFiles: ["packages/ui/src/components/Foo.tsx"] },
+    );
+    if (ok) failures.push("release-page link must not satisfy a visual row");
+  }
+
   if (failures.length > 0) {
     console.error("check-pr-evidence self-test FAILED:");
     for (const failure of failures) console.error(`  - ${failure}`);
     process.exit(1);
   }
-  console.log("check-pr-evidence self-test passed (11 cases).");
+  console.log("check-pr-evidence self-test passed (13 cases).");
 }
 
 function main() {

--- a/scripts/check-pr-evidence.test.mjs
+++ b/scripts/check-pr-evidence.test.mjs
@@ -26,6 +26,7 @@ import {
   REQUIRED_EVIDENCE_ROWS,
   requiresSurfaceArtifacts,
   requiresSurfaceArtifactsFromFiles,
+  runSelfTest,
   SURFACE_ARTIFACT_ROW_IDS,
 } from "./check-pr-evidence.mjs";
 
@@ -675,5 +676,157 @@ describe("check-pr-evidence against the real PR template", () => {
     const { ok, findings } = evaluatePrEvidence(template);
     assert.equal(ok, false);
     assert.ok(findings.every((finding) => finding.status === "blank"));
+  });
+});
+
+describe("evaluatePrEvidence verdicts", () => {
+  it("passes a fully evidenced backend-only body with no surface trigger", () => {
+    const { ok, findings } = evaluatePrEvidence(buildBody());
+    assert.equal(ok, true);
+    assert.ok(findings.every((finding) => finding.status === "ok"));
+  });
+
+  it("reports a missing marker as missing and a blank row as blank", () => {
+    const body = buildBody({ "backend-logs": "" });
+    const { ok, findings } = evaluatePrEvidence(body);
+    assert.equal(ok, false);
+    assert.equal(
+      findings.find((finding) => finding.id === "backend-logs")?.status,
+      "blank",
+    );
+    const withoutMarker = buildBody();
+    const truncated = withoutMarker.replace(
+      /<!-- evidence-row:llm-trajectory -->[\s\S]*?(?=\n\n<!-- evidence-row:|$)/,
+      "",
+    );
+    const missing = evaluatePrEvidence(truncated).findings.find(
+      (finding) => finding.id === "llm-trajectory",
+    );
+    assert.equal(missing?.status, "missing");
+  });
+
+  it("path detection overrides labels: a UI .tsx diff forces real media on visual rows", () => {
+    const { ok, findings } = evaluatePrEvidence(
+      buildBody(),
+      REQUIRED_EVIDENCE_ROWS,
+      { changedFiles: ["packages/app/src/views/Home.tsx"] },
+    );
+    assert.equal(ok, false);
+    for (const id of ["before-screenshots", "after-screenshots"]) {
+      assert.equal(
+        findings.find((finding) => finding.id === id)?.status,
+        "artifact-required",
+        `${id} should demand media on a surface diff`,
+      );
+    }
+    // buildBody's domain-artifacts row carries OCR proof, so no ocr-required
+    // finding is appended here; the label-only case below covers that path.
+  });
+
+  it("a non-visual diff under a UI package does NOT force surface artifacts even with a ui label", () => {
+    const { ok } = evaluatePrEvidence(buildBody(), REQUIRED_EVIDENCE_ROWS, {
+      labels: "ui",
+      changedFiles: ["packages/ui/src/state/useThing.ts"],
+    });
+    assert.equal(ok, true);
+  });
+
+  it("label-only invocation still triggers the surface requirement", () => {
+    const { findings } = evaluatePrEvidence(
+      buildBody(),
+      REQUIRED_EVIDENCE_ROWS,
+      {
+        labels: "native",
+      },
+    );
+    assert.equal(
+      findings.find((finding) => finding.id === "before-screenshots")?.status,
+      "artifact-required",
+    );
+    // Without any OCR-referencing row, the surface trigger also appends the
+    // ocr-review requirement.
+    const noOcr = evaluatePrEvidence(
+      buildBody({ "domain-artifacts": "- [ ] `N/A - no domain artifacts`." }),
+      REQUIRED_EVIDENCE_ROWS,
+      { labels: "native" },
+    );
+    assert.equal(
+      noOcr.findings.find((finding) => finding.id === "ocr-review")?.status,
+      "ocr-required",
+    );
+  });
+
+  it("allows N/A before-screenshots when every touched UI file was added", () => {
+    const surface = ["packages/ui/src/components/New.tsx"];
+    const body = buildBody({
+      "before-screenshots":
+        "- [ ] Before screenshots `N/A - brand-new surface, no before state`.",
+      "after-screenshots":
+        "- [x] ![after](https://github.com/elizaOS/eliza/releases/download/pr-evidence/1-a.jpg)",
+      "walkthrough-video":
+        "- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence/1-w.mp4",
+      "domain-artifacts":
+        "- [x] OCR text readout: https://github.com/elizaOS/eliza/releases/download/pr-evidence/1-ocr.json",
+    });
+    const allNew = evaluatePrEvidence(body, REQUIRED_EVIDENCE_ROWS, {
+      changedFiles: surface,
+      addedFiles: surface,
+    });
+    assert.equal(allNew.ok, true);
+    const modified = evaluatePrEvidence(body, REQUIRED_EVIDENCE_ROWS, {
+      changedFiles: surface,
+      addedFiles: [],
+    });
+    assert.equal(
+      modified.findings.find((finding) => finding.id === "before-screenshots")
+        ?.status,
+      "artifact-required",
+    );
+  });
+
+  it("accepts overflow-release (pr-evidence-N) media on a surface PR", () => {
+    const dl = (tag, name) =>
+      `https://github.com/elizaOS/eliza/releases/download/${tag}/${name}`;
+    const { ok } = evaluatePrEvidence(
+      buildBody({
+        "before-screenshots": `- [x] ![before](${dl("pr-evidence-2", "9-b.jpg")})`,
+        "after-screenshots": `- [x] ![after](${dl("pr-evidence-2", "9-a.jpg")})`,
+        "walkthrough-video": `- [x] ${dl("pr-evidence-3", "9-w.mp4")}`,
+        "domain-artifacts": `- [x] OCR readout ${dl("pr-evidence-3", "9-ocr.jsonl")}`,
+      }),
+      REQUIRED_EVIDENCE_ROWS,
+      { changedFiles: ["packages/ui/src/components/Foo.tsx"] },
+    );
+    assert.equal(ok, true);
+  });
+
+  it("rejects a release-page link standing in for a screenshot", () => {
+    const { findings } = evaluatePrEvidence(
+      buildBody({
+        "before-screenshots":
+          "- [ ] https://github.com/elizaOS/eliza/releases/tag/pr-evidence-2",
+      }),
+      REQUIRED_EVIDENCE_ROWS,
+      { changedFiles: ["packages/ui/src/components/Foo.tsx"] },
+    );
+    assert.equal(
+      findings.find((finding) => finding.id === "before-screenshots")?.status,
+      "artifact-required",
+    );
+  });
+
+  it("empty body reports every required row missing", () => {
+    const { ok, findings } = evaluatePrEvidence("");
+    assert.equal(ok, false);
+    assert.equal(findings.length, REQUIRED_EVIDENCE_ROWS.length);
+    assert.ok(findings.every((finding) => finding.status === "missing"));
+  });
+});
+
+describe("planted-fixture self-test", () => {
+  it("passes against the current gate rules", () => {
+    // runSelfTest exercises the same fixtures CI's --self-test flag does and
+    // process.exit(1)s on any regression; completing without exit is the pass.
+    runSelfTest();
   });
 });

--- a/scripts/check-pr-evidence.test.mjs
+++ b/scripts/check-pr-evidence.test.mjs
@@ -15,6 +15,7 @@ import {
   extractEvidenceRows,
   findRetiredRepoEvidenceFiles,
   hasArtifactReference,
+  hasEvidenceFileReference,
   hasNaWithReason,
   hasOcrEvidenceReference,
   hasVisualArtifactReference,
@@ -381,9 +382,7 @@ describe("check-pr-evidence row primitives", () => {
       true,
     );
     assert.equal(
-      requiresSurfaceArtifactsFromFiles([
-        String.raw`apps\app\src\Panel.tsx`,
-      ]),
+      requiresSurfaceArtifactsFromFiles([String.raw`apps\app\src\Panel.tsx`]),
       true,
     );
     // Tests, stories, and server code render nothing a user sees.
@@ -482,7 +481,10 @@ describe("check-pr-evidence row primitives", () => {
     // But a rendered-UI file still forces artifacts regardless of labels.
     const forced = evaluatePrEvidence(body, REQUIRED_EVIDENCE_ROWS, {
       labels: "",
-      changedFiles: ["packages/ui/src/navigation/index.ts", "packages/ui/src/components/Foo.tsx"],
+      changedFiles: [
+        "packages/ui/src/navigation/index.ts",
+        "packages/ui/src/components/Foo.tsx",
+      ],
     });
     assert.equal(forced.ok, false);
   });
@@ -522,6 +524,99 @@ describe("check-pr-evidence row primitives", () => {
     );
   });
 });
+
+describe("check-pr-evidence pr-evidence release family", () => {
+  const dl = (tag, name) =>
+    `https://github.com/elizaOS/eliza/releases/download/${tag}/${name}`;
+
+  it("accepts an overflow-release screenshot on a visual row exactly like the primary release", () => {
+    // The unblock: once `pr-evidence` fills, pr-evidence.mjs emits pr-evidence-N
+    // URLs; a media asset there must satisfy the visual rows identically.
+    assert.equal(
+      hasVisualArtifactReference(dl("pr-evidence", "15171-after-desktop.jpg")),
+      true,
+    );
+    assert.equal(
+      hasVisualArtifactReference(
+        dl("pr-evidence-2", "16367-after-desktop.jpg"),
+      ),
+      true,
+    );
+    assert.equal(
+      hasVisualArtifactReference(dl("pr-evidence-3", "16367-walkthrough.mp4")),
+      true,
+    );
+  });
+
+  it("recognizes any pr-evidence-family asset as an evidence file, even a non-whitelisted extension", () => {
+    // A `.jsonl` is not in EVIDENCE_FILE_RE, so acceptance here comes from the
+    // release-family host matcher — the generalized rule, applied to overflow
+    // releases too.
+    assert.equal(
+      EVIDENCE_FILE_RE_MATCHES(".jsonl"),
+      false,
+      "guard: .jsonl must not be a whitelisted evidence extension",
+    );
+    assert.equal(
+      hasEvidenceFileReference(dl("pr-evidence", "15171-ocr-readout.txt")),
+      true,
+    );
+    assert.equal(
+      hasEvidenceFileReference(dl("pr-evidence-3", "16367-ocr-readout.jsonl")),
+      true,
+    );
+  });
+
+  it("does NOT accept a link to the release PAGE (no /download/ asset path)", () => {
+    // Strictness: the tag page is not an asset. A page link never counts as a
+    // screenshot, and never as an evidence file.
+    const pageLink =
+      "https://github.com/elizaOS/eliza/releases/tag/pr-evidence-2";
+    assert.equal(hasVisualArtifactReference(pageLink), false);
+    assert.equal(hasEvidenceFileReference(pageLink), false);
+  });
+
+  it("passes a UI-file surface PR whose screenshots live on an overflow release", () => {
+    const body = buildBody({
+      "before-screenshots": `- [x] ![before](${dl("pr-evidence-2", "16367-before-desktop.jpg")})`,
+      "after-screenshots": `- [x] ![after](${dl("pr-evidence-2", "16367-after-desktop.jpg")})`,
+      "walkthrough-video": `- [x] ${dl("pr-evidence-2", "16367-walkthrough.mp4")}`,
+      "domain-artifacts": `- [ ] OCR text readout: ${dl("pr-evidence-2", "16367-ocr.txt")}`,
+    });
+    const changedFiles = ["packages/ui/src/components/Foo.tsx"];
+    const { ok } = evaluatePrEvidence(body, REQUIRED_EVIDENCE_ROWS, {
+      changedFiles,
+    });
+    assert.equal(ok, true);
+  });
+
+  it("still FAILS a UI-file surface PR with no real media, even citing the release page", () => {
+    // Invariant: the storage location changed, the strictness did not.
+    const body = buildBody({
+      "before-screenshots":
+        "- [ ] Before screenshots: https://github.com/elizaOS/eliza/releases/tag/pr-evidence-2",
+      "after-screenshots": "- [ ] After screenshots `N/A - nothing to show`.",
+      "walkthrough-video": "- [ ] Walkthrough video `N/A - nothing to show`.",
+    });
+    const { ok, findings } = evaluatePrEvidence(body, REQUIRED_EVIDENCE_ROWS, {
+      changedFiles: ["packages/ui/src/components/Foo.tsx"],
+    });
+    assert.equal(ok, false);
+    for (const id of SURFACE_ARTIFACT_ROW_IDS) {
+      assert.equal(
+        findings.find((finding) => finding.id === id).status,
+        "artifact-required",
+      );
+    }
+  });
+});
+
+// Mirror of check-pr-evidence's internal EVIDENCE_FILE_RE, used only to prove
+// the release-family matcher (not the extension whitelist) is what accepts a
+// pr-evidence `.jsonl` asset above.
+function EVIDENCE_FILE_RE_MATCHES(ext) {
+  return /\.(json|txt|log|csv|md)(\?\S*)?(\s|$|\)|"|')/i.test(`file${ext} `);
+}
 
 describe("check-pr-evidence marker extraction", () => {
   it("captures the checkbox line plus indented continuation lines", () => {

--- a/scripts/pr-evidence.mjs
+++ b/scripts/pr-evidence.mjs
@@ -137,9 +137,9 @@ export function selectPrEvidenceTarget(releases, neededSlots) {
   return { tag: prEvidenceTagForIndex(maxIndex + 1), create: true };
 }
 
-/** Every pr-evidence-family release with its assets (one NDJSON object per release from the paginated releases API). */
-function fetchPrEvidenceReleases() {
-  const out = gh([
+/** Every pr-evidence-family release with its assets (one NDJSON object per release from the paginated releases API). `run` is the `gh` invoker — injectable so the fetch/roll-over pipeline is unit-testable without the network. */
+export function fetchPrEvidenceReleases(run = gh) {
+  const out = run([
     "api",
     "repos/{owner}/{repo}/releases",
     "--paginate",
@@ -181,7 +181,7 @@ function errText(err) {
 // tokens rather than a full sentence. A name-collision 422 (a different message)
 // deliberately does NOT match — that is a real surprise the author should see,
 // not something to paper over by rolling to another release.
-function isReleaseFullError(text) {
+export function isReleaseFullError(text) {
   return (
     /HTTP 422/i.test(text) &&
     /file_count|number of (files|assets)|asset (count|limit)|too many (files|assets)|maximum.*(files|assets)/i.test(
@@ -191,11 +191,11 @@ function isReleaseFullError(text) {
 }
 
 /** Create the next overflow release, tolerating a concurrent lane that beat us to it (the created release is the desired end state either way). */
-function createOverflowReleaseIfAbsent(tag) {
+export function createOverflowReleaseIfAbsent(tag, run = gh) {
   const index = prEvidenceReleaseIndex(tag);
   const notes = `Overflow continuation of the '${PRIMARY_RELEASE_TAG}' evidence asset store. GitHub caps a release at ${MAX_ASSETS_PER_RELEASE} assets, so headless-agent evidence uploads (scripts/pr-evidence.mjs) roll into '${tag}' once '${prEvidenceTagForIndex(index - 1)}' fills. Files are named '<pr>-<artifact>'; embed the asset download URLs in the PR evidence rows. Never delete assets referenced by an open PR.`;
   try {
-    gh(
+    run(
       [
         "release",
         "create",
@@ -225,9 +225,9 @@ function createOverflowReleaseIfAbsent(tag) {
  * next release when the chosen one is full — capacity is read up front, and a
  * 422 `file_count` failure (concurrent-fill race) triggers a rollover retry.
  * `stagedByName` is name → local path. Returns name → download URL on whichever
- * release accepted the batch.
+ * release accepted the batch. `run` is the `gh` invoker (injectable for tests).
  */
-function uploadAssets(stagedByName, releases) {
+export function uploadAssets(stagedByName, releases, run = gh) {
   const names = [...stagedByName.keys()];
   const paths = names.map((name) => stagedByName.get(name));
   const counts = releaseCounts(releases);
@@ -239,13 +239,13 @@ function uploadAssets(stagedByName, releases) {
     );
     const { tag, create } = selectPrEvidenceTarget(visible, names.length);
     if (create) {
-      createOverflowReleaseIfAbsent(tag);
+      createOverflowReleaseIfAbsent(tag, run);
       if (!counts.some((entry) => entry.tag === tag)) {
         counts.push({ tag, count: 0 });
       }
     }
     try {
-      gh(["release", "upload", tag, ...paths], {
+      run(["release", "upload", tag, ...paths], {
         stdio: ["ignore", "inherit", "pipe"],
       });
       const base = releaseDownloadBase(tag);
@@ -272,9 +272,9 @@ function uploadAssets(stagedByName, releases) {
  * PRs are immutable by policy) and keeps its original release URL; only genuinely
  * new assets are uploaded, into the current release with capacity.
  */
-function attach(pr, files) {
+export function attach(pr, files, run = gh) {
   if (files.length === 0) fail("attach needs at least one file");
-  const releases = fetchPrEvidenceReleases();
+  const releases = fetchPrEvidenceReleases(run);
   const index = assetIndex(releases);
   const urls = new Map();
   const stagedByName = new Map();
@@ -303,7 +303,7 @@ function attach(pr, files) {
     }
   }
   if (stagedByName.size > 0) {
-    const uploaded = uploadAssets(stagedByName, releases);
+    const uploaded = uploadAssets(stagedByName, releases, run);
     for (const [name, url] of uploaded) urls.set(name, url);
   }
   for (const name of order) console.log(`  ${urls.get(name)}`);
@@ -315,7 +315,7 @@ function isMediaName(name) {
 }
 
 /** Render the replacement row line for an id + resolved value. */
-function renderRow(id, value) {
+export function renderRow(id, value) {
   if (/^N\/?A\s*[-:]/i.test(value)) return `- [ ] ${value}`;
   if (isMediaName(value) && /^https?:/i.test(value)) {
     // Embed images inline; videos/GIFs render from the bare URL on GitHub.
@@ -330,7 +330,7 @@ function renderRow(id, value) {
 }
 
 /** Replace the block after `<!-- evidence-row:<id> -->` with `line`. */
-function patchRow(body, id, line) {
+export function patchRow(body, id, line) {
   const marker = `<!-- evidence-row:${id} -->`;
   const at = body.indexOf(marker);
   if (at === -1) {

--- a/scripts/pr-evidence.mjs
+++ b/scripts/pr-evidence.mjs
@@ -15,7 +15,13 @@
  *   node scripts/pr-evidence.mjs verify <pr>                   run the gate locally
  *
  * `attach` prefixes every asset `<pr>-` so one release serves all PRs, and
- * skips re-uploading an asset that already exists with identical bytes.
+ * skips re-uploading an asset that already exists on ANY pr-evidence release.
+ * GitHub caps a release at 1000 assets, so once the primary `pr-evidence`
+ * release fills, uploads roll deterministically into `pr-evidence-2`,
+ * `pr-evidence-3`, … — the newest release with free capacity, creating the next
+ * one when none has room. Every emitted URL points at whichever release actually
+ * holds the asset, and the evidence gate (check-pr-evidence.mjs) accepts the
+ * whole `pr-evidence`/`pr-evidence-N` family identically.
  * `rows` accepts a local file (uploaded automatically), an existing URL, or an
  * `N/A - reason` string per row; rows not named are left untouched. Every
  * mutation is previewed and the gate verdict printed; `--dry-run` stops before
@@ -23,15 +29,23 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { createHash } from "node:crypto";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { basename } from "node:path";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { pathToFileURL } from "node:url";
 
-const RELEASE_TAG = "pr-evidence";
-const ASSET_BASE = `https://github.com/elizaOS/eliza/releases/download/${RELEASE_TAG}`;
+const PRIMARY_RELEASE_TAG = "pr-evidence";
+const REPO = "elizaOS/eliza";
+// GitHub caps a single release at 1000 assets. Keep headroom below that so a
+// normal multi-file batch never straddles the boundary; roll to the next
+// overflow release before the wall. The 422 fallback in `uploadAssets` covers
+// the residual race where concurrent lanes fill a release between our capacity
+// read and our upload.
+export const MAX_ASSETS_PER_RELEASE = 1000;
+export const ASSET_CAPACITY_THRESHOLD = 990;
+const releaseDownloadBase = (tag) =>
+  `https://github.com/${REPO}/releases/download/${tag}`;
+const PRIMARY_ASSET_BASE = releaseDownloadBase(PRIMARY_RELEASE_TAG);
 const ROW_IDS = [
   "before-screenshots",
   "after-screenshots",
@@ -55,8 +69,10 @@ function fail(message) {
 function usage() {
   console.log(`Usage:
   node scripts/pr-evidence.mjs attach <pr> <files...>
-      Upload files to the '${RELEASE_TAG}' release as <pr>-<name> and print
-      the asset URLs ready to paste into evidence rows.
+      Upload files to the '${PRIMARY_RELEASE_TAG}' release as <pr>-<name> and
+      print the asset URLs ready to paste into evidence rows. Once the primary
+      release is full, uploads roll into '${PRIMARY_RELEASE_TAG}-2', '-3', … and
+      the printed URLs point at whichever release holds the asset.
 
   node scripts/pr-evidence.mjs rows <pr> [--dry-run] --row <id>=<value> [...]
       Patch the PR body's evidence rows and verify the gate locally.
@@ -68,37 +84,201 @@ function usage() {
       Fetch the PR body/labels/files and run the local evidence gate exactly
       as CI does.
 
-Assets land on: ${ASSET_BASE}/<pr>-<filename>
+Assets land on: ${PRIMARY_ASSET_BASE}/<pr>-<filename>
+  (or the current '${PRIMARY_RELEASE_TAG}-N' overflow release once it fills)
 Worked example of a fully evidenced PR: https://github.com/elizaOS/eliza/pull/15171`);
 }
 
-/** Existing release assets, name → { sha? } (sha lazily unavailable via API — name match only). */
-function existingAssetNames() {
-  const out = gh([
-    "release",
-    "view",
-    RELEASE_TAG,
-    "--json",
-    "assets",
-    "-q",
-    ".assets[].name",
-  ]);
-  return new Set(out.split("\n").filter(Boolean));
+/** Sequence index of a pr-evidence-family tag: `pr-evidence` → 1, `pr-evidence-N` → N; null for any other tag. A stray `pr-evidence-1` is not the canonical primary and is ignored. */
+export function prEvidenceReleaseIndex(tag) {
+  if (tag === PRIMARY_RELEASE_TAG) return 1;
+  const match = /^pr-evidence-(\d+)$/.exec(tag ?? "");
+  if (!match) return null;
+  const index = Number(match[1]);
+  return index >= 2 ? index : null;
+}
+
+/** The tag for a sequence index: 1 → `pr-evidence`, N≥2 → `pr-evidence-N`. */
+export function prEvidenceTagForIndex(index) {
+  return index <= 1 ? PRIMARY_RELEASE_TAG : `${PRIMARY_RELEASE_TAG}-${index}`;
 }
 
 /**
- * Upload local files as `<pr>-<basename>`; returns name → URL. A name
- * collision uploads with `--clobber` only when the local bytes differ from a
- * previous upload this run cannot verify — so collide loudly instead:
- * existing names are reused as-is (assets referenced by open PRs are
- * immutable by policy), and a genuinely different file must be renamed.
+ * Choose which pr-evidence-family release receives `neededSlots` new assets.
+ * Prefers the highest-indexed EXISTING release that still has capacity (packs
+ * uploads into the newest release); when none has room, returns the next tag in
+ * the deterministic sequence with `create: true`. Never selects a release whose
+ * post-upload count would exceed GitHub's hard cap. Pure — the caller supplies
+ * the observed `{tag, count}` list — so the selection rule is unit-testable
+ * without touching the network.
+ *
+ * @param {{tag: string, count: number}[]} releases
+ * @param {number} neededSlots
+ * @returns {{ tag: string, create: boolean }}
+ */
+export function selectPrEvidenceTarget(releases, neededSlots) {
+  const family = releases
+    .map((release) => ({
+      ...release,
+      index: prEvidenceReleaseIndex(release.tag),
+    }))
+    .filter((release) => release.index !== null)
+    .sort((a, b) => a.index - b.index);
+
+  const withRoom = family.filter(
+    (release) =>
+      release.count < ASSET_CAPACITY_THRESHOLD &&
+      release.count + neededSlots <= MAX_ASSETS_PER_RELEASE,
+  );
+  if (withRoom.length > 0) {
+    return { tag: withRoom[withRoom.length - 1].tag, create: false };
+  }
+  const maxIndex = family.length > 0 ? family[family.length - 1].index : 0;
+  return { tag: prEvidenceTagForIndex(maxIndex + 1), create: true };
+}
+
+/** Every pr-evidence-family release with its assets (one NDJSON object per release from the paginated releases API). */
+function fetchPrEvidenceReleases() {
+  const out = gh([
+    "api",
+    "repos/{owner}/{repo}/releases",
+    "--paginate",
+    "-q",
+    '.[] | select(.tag_name|test("^pr-evidence(-[0-9]+)?$")) | {tag: .tag_name, assets: [.assets[]? | {name, url: .browser_download_url}]}',
+  ]);
+  return out
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function releaseCounts(releases) {
+  return releases.map((release) => ({
+    tag: release.tag,
+    count: release.assets.length,
+  }));
+}
+
+/** Asset name → {tag, url} across ALL pr-evidence releases, so an asset already uploaded to any release (primary or overflow) is reused in place rather than duplicated onto a newer one — the invariant that keeps existing evidence links stable. */
+function assetIndex(releases) {
+  const index = new Map();
+  for (const release of releases) {
+    for (const asset of release.assets) {
+      if (!index.has(asset.name)) {
+        index.set(asset.name, { tag: release.tag, url: asset.url });
+      }
+    }
+  }
+  return index;
+}
+
+function errText(err) {
+  return String(err?.stderr ?? err?.stdout ?? err?.message ?? "");
+}
+
+// GitHub answers an over-cap release upload with HTTP 422 naming the asset
+// count; the phrasing has drifted across API versions, so match the stable
+// tokens rather than a full sentence. A name-collision 422 (a different message)
+// deliberately does NOT match — that is a real surprise the author should see,
+// not something to paper over by rolling to another release.
+function isReleaseFullError(text) {
+  return (
+    /HTTP 422/i.test(text) &&
+    /file_count|number of (files|assets)|asset (count|limit)|too many (files|assets)|maximum.*(files|assets)/i.test(
+      text,
+    )
+  );
+}
+
+/** Create the next overflow release, tolerating a concurrent lane that beat us to it (the created release is the desired end state either way). */
+function createOverflowReleaseIfAbsent(tag) {
+  const index = prEvidenceReleaseIndex(tag);
+  const notes = `Overflow continuation of the '${PRIMARY_RELEASE_TAG}' evidence asset store. GitHub caps a release at ${MAX_ASSETS_PER_RELEASE} assets, so headless-agent evidence uploads (scripts/pr-evidence.mjs) roll into '${tag}' once '${prEvidenceTagForIndex(index - 1)}' fills. Files are named '<pr>-<artifact>'; embed the asset download URLs in the PR evidence rows. Never delete assets referenced by an open PR.`;
+  try {
+    gh(
+      [
+        "release",
+        "create",
+        tag,
+        "--title",
+        `PR evidence assets ${index} (headless-agent attachments)`,
+        "--notes",
+        notes,
+        "--prerelease",
+      ],
+      { stdio: ["ignore", "inherit", "pipe"] },
+    );
+    console.log(`  + created overflow release '${tag}'`);
+  } catch (err) {
+    if (
+      !/already exists|already_exists|tag_name.*exist|Validation Failed/i.test(
+        errText(err),
+      )
+    ) {
+      throw err;
+    }
+  }
+}
+
+/**
+ * Upload staged, correctly-named files to the pr-evidence family, rolling to the
+ * next release when the chosen one is full — capacity is read up front, and a
+ * 422 `file_count` failure (concurrent-fill race) triggers a rollover retry.
+ * `stagedByName` is name → local path. Returns name → download URL on whichever
+ * release accepted the batch.
+ */
+function uploadAssets(stagedByName, releases) {
+  const names = [...stagedByName.keys()];
+  const paths = names.map((name) => stagedByName.get(name));
+  const counts = releaseCounts(releases);
+  const full = new Set();
+  const maxAttempts = releases.length + 4;
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    const visible = counts.map((entry) =>
+      full.has(entry.tag) ? { ...entry, count: MAX_ASSETS_PER_RELEASE } : entry,
+    );
+    const { tag, create } = selectPrEvidenceTarget(visible, names.length);
+    if (create) {
+      createOverflowReleaseIfAbsent(tag);
+      if (!counts.some((entry) => entry.tag === tag)) {
+        counts.push({ tag, count: 0 });
+      }
+    }
+    try {
+      gh(["release", "upload", tag, ...paths], {
+        stdio: ["ignore", "inherit", "pipe"],
+      });
+      const base = releaseDownloadBase(tag);
+      return new Map(names.map((name) => [name, `${base}/${name}`]));
+    } catch (err) {
+      if (isReleaseFullError(errText(err))) {
+        console.log(
+          `  release '${tag}' is full; rolling over to the next overflow release`,
+        );
+        full.add(tag);
+        continue;
+      }
+      throw err;
+    }
+  }
+  fail(
+    "could not upload evidence assets: every candidate pr-evidence release is full",
+  );
+}
+
+/**
+ * Upload local files as `<pr>-<basename>`; returns name → URL. An asset already
+ * present on ANY pr-evidence release is reused as-is (assets referenced by open
+ * PRs are immutable by policy) and keeps its original release URL; only genuinely
+ * new assets are uploaded, into the current release with capacity.
  */
 function attach(pr, files) {
   if (files.length === 0) fail("attach needs at least one file");
-  const existing = existingAssetNames();
+  const releases = fetchPrEvidenceReleases();
+  const index = assetIndex(releases);
   const urls = new Map();
-  const toUpload = [];
-  const staged = [];
+  const stagedByName = new Map();
+  const order = [];
   for (const file of files) {
     if (!existsSync(file)) fail(`no such file: ${file}`);
     // GitHub rejects zero-byte release assets with an opaque 400
@@ -108,22 +288,25 @@ function attach(pr, files) {
       fail(`refusing to upload empty file (0 bytes): ${file}`);
     }
     const name = `${pr}-${basename(file).replace(new RegExp(`^${pr}-`), "")}`;
-    const url = `${ASSET_BASE}/${name}`;
-    urls.set(name, url);
-    if (existing.has(name)) {
-      console.log(`  = ${name} (already uploaded, reusing)`);
+    if (!order.includes(name)) order.push(name);
+    const existing = index.get(name);
+    if (existing) {
+      urls.set(name, existing.url);
+      console.log(`  = ${name} (already on '${existing.tag}', reusing)`);
       continue;
     }
-    // gh names the asset after the file, so stage a correctly-named copy.
-    const stagedPath = join(tmpdir(), name);
-    writeFileSync(stagedPath, readFileSync(file));
-    staged.push(stagedPath);
-    toUpload.push(stagedPath);
+    if (!stagedByName.has(name)) {
+      // gh names the asset after the file, so stage a correctly-named copy.
+      const stagedPath = join(tmpdir(), name);
+      writeFileSync(stagedPath, readFileSync(file));
+      stagedByName.set(name, stagedPath);
+    }
   }
-  if (toUpload.length > 0) {
-    gh(["release", "upload", RELEASE_TAG, ...toUpload], { stdio: "inherit" });
+  if (stagedByName.size > 0) {
+    const uploaded = uploadAssets(stagedByName, releases);
+    for (const [name, url] of uploaded) urls.set(name, url);
   }
-  for (const [name, url] of urls) console.log(`  ${url}`);
+  for (const name of order) console.log(`  ${urls.get(name)}`);
   return urls;
 }
 
@@ -141,7 +324,9 @@ function renderRow(id, value) {
       : `- [x] ${value}`;
   }
   if (/^https?:/i.test(value)) return `- [x] [${basename(value)}](${value})`;
-  fail(`row ${id}: value must be a file, URL, or 'N/A - <reason>' (got: ${value})`);
+  fail(
+    `row ${id}: value must be a file, URL, or 'N/A - <reason>' (got: ${value})`,
+  );
 }
 
 /** Replace the block after `<!-- evidence-row:<id> -->` with `line`. */
@@ -157,7 +342,12 @@ function patchRow(body, id, line) {
   // The row block ends at the next blank line, heading, or marker.
   const end = rest.search(/\n\s*\n|\n#|\n<!-- evidence-row:/);
   const blockEnd = end === -1 ? rest.length : end;
-  return body.slice(0, afterMarker) + "\n" + line + body.slice(afterMarker + blockEnd);
+  return (
+    body.slice(0, afterMarker) +
+    "\n" +
+    line +
+    body.slice(afterMarker + blockEnd)
+  );
 }
 
 async function runGate(pr, body) {
@@ -171,7 +361,7 @@ async function runGate(pr, body) {
     "--json",
     "labels",
     "-q",
-    "[.labels[].name]|join(\",\")",
+    '[.labels[].name]|join(",")',
   ]).trim();
   // `gh pr diff` 406s past GitHub's 300-file diff cap (hit live on the 350-file
   // #15291); the paginated files API has no such limit.
@@ -199,7 +389,9 @@ async function runGate(pr, body) {
     addedFiles,
   });
   for (const f of findings) {
-    console.log(`  [${f.status === "ok" ? "ok  " : "FAIL"}] ${f.id}: ${f.status}`);
+    console.log(
+      `  [${f.status === "ok" ? "ok  " : "FAIL"}] ${f.id}: ${f.status}`,
+    );
   }
   return ok;
 }
@@ -213,7 +405,8 @@ async function rows(pr, args) {
       const eq = spec.indexOf("=");
       if (eq === -1) fail(`--row needs <id>=<value>, got: ${spec}`);
       const id = spec.slice(0, eq);
-      if (!ROW_IDS.includes(id)) fail(`unknown row id '${id}' (valid: ${ROW_IDS.join(", ")})`);
+      if (!ROW_IDS.includes(id))
+        fail(`unknown row id '${id}' (valid: ${ROW_IDS.join(", ")})`);
       rowArgs.push({ id, value: spec.slice(eq + 1) });
       i += 1;
     }
@@ -221,10 +414,17 @@ async function rows(pr, args) {
   if (rowArgs.length === 0) fail("rows needs at least one --row <id>=<value>");
 
   // Resolve local files to uploaded asset URLs first.
-  const localFiles = rowArgs.filter((r) => !/^https?:/i.test(r.value) && !/^N\/?A\s*[-:]/i.test(r.value));
+  const localFiles = rowArgs.filter(
+    (r) => !/^https?:/i.test(r.value) && !/^N\/?A\s*[-:]/i.test(r.value),
+  );
   if (localFiles.length > 0) {
-    console.log(`Uploading ${localFiles.length} local file(s) to '${RELEASE_TAG}':`);
-    const urls = attach(pr, localFiles.map((r) => r.value));
+    console.log(
+      `Uploading ${localFiles.length} local file(s) to '${PRIMARY_RELEASE_TAG}':`,
+    );
+    const urls = attach(
+      pr,
+      localFiles.map((r) => r.value),
+    );
     for (const r of localFiles) {
       const name = `${pr}-${basename(r.value).replace(new RegExp(`^${pr}-`), "")}`;
       r.value = urls.get(name);
@@ -239,13 +439,17 @@ async function rows(pr, args) {
   console.log("\nLocal gate verdict on the new body:");
   const ok = await runGate(pr, body);
   if (dryRun) {
-    console.log(`\n--dry-run: PR #${pr} not edited. Gate ${ok ? "would PASS" : "would FAIL"}.`);
+    console.log(
+      `\n--dry-run: PR #${pr} not edited. Gate ${ok ? "would PASS" : "would FAIL"}.`,
+    );
     return;
   }
   const bodyFile = join(tmpdir(), `pr-${pr}-body.md`);
   writeFileSync(bodyFile, body);
   gh(["pr", "edit", String(pr), "--body-file", bodyFile], { stdio: "inherit" });
-  console.log(`\nPR #${pr} updated. Gate ${ok ? "PASSES" : "still FAILS — fix the rows above"}.`);
+  console.log(
+    `\nPR #${pr} updated. Gate ${ok ? "PASSES" : "still FAILS — fix the rows above"}.`,
+  );
   if (!ok) process.exit(1);
 }
 
@@ -270,4 +474,11 @@ async function main() {
   else fail(`unknown command: ${cmd}`);
 }
 
-await main();
+// Only run the CLI when invoked directly; importing (e.g. from the test) must
+// not execute `main` with no argv.
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  await main();
+}

--- a/scripts/pr-evidence.test.mjs
+++ b/scripts/pr-evidence.test.mjs
@@ -1,0 +1,141 @@
+/**
+ * Tests for the pr-evidence uploader's release-selection logic — the pure rule
+ * that decides which `pr-evidence`/`pr-evidence-N` release receives an upload
+ * once GitHub's 1000-asset cap forces overflow. Deterministic: the selection
+ * function takes an observed release list, so no network or `gh` is touched.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  ASSET_CAPACITY_THRESHOLD,
+  MAX_ASSETS_PER_RELEASE,
+  prEvidenceReleaseIndex,
+  prEvidenceTagForIndex,
+  selectPrEvidenceTarget,
+} from "./pr-evidence.mjs";
+
+describe("pr-evidence tag <-> sequence index", () => {
+  it("maps the primary tag to index 1 and overflow tags to their number", () => {
+    assert.equal(prEvidenceReleaseIndex("pr-evidence"), 1);
+    assert.equal(prEvidenceReleaseIndex("pr-evidence-2"), 2);
+    assert.equal(prEvidenceReleaseIndex("pr-evidence-10"), 10);
+  });
+
+  it("rejects non-family tags and the ambiguous pr-evidence-1", () => {
+    assert.equal(prEvidenceReleaseIndex("pr-evidence-1"), null);
+    assert.equal(prEvidenceReleaseIndex("pr-evidence-x"), null);
+    assert.equal(prEvidenceReleaseIndex("v2.0.0"), null);
+    assert.equal(prEvidenceReleaseIndex(""), null);
+    assert.equal(prEvidenceReleaseIndex(undefined), null);
+  });
+
+  it("round-trips index -> tag", () => {
+    assert.equal(prEvidenceTagForIndex(1), "pr-evidence");
+    assert.equal(prEvidenceTagForIndex(2), "pr-evidence-2");
+    assert.equal(prEvidenceTagForIndex(7), "pr-evidence-7");
+    // Defensive: index 0 / negative collapse to the primary tag.
+    assert.equal(prEvidenceTagForIndex(0), "pr-evidence");
+  });
+});
+
+describe("selectPrEvidenceTarget", () => {
+  const BELOW = ASSET_CAPACITY_THRESHOLD - 100; // comfortably has room
+  const FULL = MAX_ASSETS_PER_RELEASE; // hard cap reached
+
+  it("uploads to the primary release while it has room", () => {
+    assert.deepEqual(
+      selectPrEvidenceTarget([{ tag: "pr-evidence", count: BELOW }], 3),
+      {
+        tag: "pr-evidence",
+        create: false,
+      },
+    );
+  });
+
+  it("packs into the highest-indexed existing release that has room", () => {
+    const releases = [
+      { tag: "pr-evidence", count: BELOW },
+      { tag: "pr-evidence-2", count: BELOW },
+      { tag: "pr-evidence-3", count: BELOW },
+    ];
+    assert.deepEqual(selectPrEvidenceTarget(releases, 2), {
+      tag: "pr-evidence-3",
+      create: false,
+    });
+  });
+
+  it("skips a full primary to the existing overflow release with capacity", () => {
+    const releases = [
+      { tag: "pr-evidence", count: FULL },
+      { tag: "pr-evidence-2", count: BELOW },
+    ];
+    assert.deepEqual(selectPrEvidenceTarget(releases, 4), {
+      tag: "pr-evidence-2",
+      create: false,
+    });
+  });
+
+  it("creates pr-evidence-2 when only the full primary exists", () => {
+    assert.deepEqual(
+      selectPrEvidenceTarget([{ tag: "pr-evidence", count: FULL }], 1),
+      {
+        tag: "pr-evidence-2",
+        create: true,
+      },
+    );
+  });
+
+  it("creates the next tag when every existing release is full", () => {
+    const releases = [
+      { tag: "pr-evidence", count: FULL },
+      { tag: "pr-evidence-2", count: FULL },
+    ];
+    assert.deepEqual(selectPrEvidenceTarget(releases, 1), {
+      tag: "pr-evidence-3",
+      create: true,
+    });
+  });
+
+  it("treats a release at/over the headroom threshold as having no room", () => {
+    const releases = [{ tag: "pr-evidence", count: ASSET_CAPACITY_THRESHOLD }];
+    assert.deepEqual(selectPrEvidenceTarget(releases, 1), {
+      tag: "pr-evidence-2",
+      create: true,
+    });
+  });
+
+  it("rolls over when a large batch would exceed the hard cap even below threshold", () => {
+    // Under the soft threshold, but the batch itself would push past 1000.
+    const count = ASSET_CAPACITY_THRESHOLD - 5; // < threshold, so threshold alone allows it
+    const neededSlots = 20; // count + neededSlots > MAX_ASSETS_PER_RELEASE
+    assert.ok(count < ASSET_CAPACITY_THRESHOLD);
+    assert.ok(count + neededSlots > MAX_ASSETS_PER_RELEASE);
+    assert.deepEqual(
+      selectPrEvidenceTarget([{ tag: "pr-evidence", count }], neededSlots),
+      { tag: "pr-evidence-2", create: true },
+    );
+  });
+
+  it("ignores non-family releases entirely", () => {
+    const releases = [
+      { tag: "v2.0.0-beta.1", count: 5 },
+      { tag: "pr-evidence", count: BELOW },
+    ];
+    assert.deepEqual(selectPrEvidenceTarget(releases, 1), {
+      tag: "pr-evidence",
+      create: false,
+    });
+  });
+
+  it("creates the primary when no pr-evidence release exists yet", () => {
+    assert.deepEqual(selectPrEvidenceTarget([], 1), {
+      tag: "pr-evidence",
+      create: true,
+    });
+    assert.deepEqual(selectPrEvidenceTarget([{ tag: "v1.0.0", count: 1 }], 1), {
+      tag: "pr-evidence",
+      create: true,
+    });
+  });
+});

--- a/scripts/pr-evidence.test.mjs
+++ b/scripts/pr-evidence.test.mjs
@@ -1,18 +1,28 @@
 /**
- * Tests for the pr-evidence uploader's release-selection logic — the pure rule
- * that decides which `pr-evidence`/`pr-evidence-N` release receives an upload
- * once GitHub's 1000-asset cap forces overflow. Deterministic: the selection
- * function takes an observed release list, so no network or `gh` is touched.
+ * Tests for the pr-evidence uploader's overflow logic: the pure release-
+ * selection rule plus the upload/rollover pipeline (uploadAssets, attach,
+ * createOverflowReleaseIfAbsent) driven through an injected `gh` runner.
+ * Deterministic: no network or real `gh` process is touched.
  */
 
 import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, it } from "node:test";
 import {
   ASSET_CAPACITY_THRESHOLD,
+  attach,
+  createOverflowReleaseIfAbsent,
+  fetchPrEvidenceReleases,
+  isReleaseFullError,
   MAX_ASSETS_PER_RELEASE,
+  patchRow,
   prEvidenceReleaseIndex,
   prEvidenceTagForIndex,
+  renderRow,
   selectPrEvidenceTarget,
+  uploadAssets,
 } from "./pr-evidence.mjs";
 
 describe("pr-evidence tag <-> sequence index", () => {
@@ -137,5 +147,279 @@ describe("selectPrEvidenceTarget", () => {
       tag: "pr-evidence",
       create: true,
     });
+  });
+});
+
+/**
+ * Scripted `gh` stand-in: answers `api` calls with canned NDJSON release
+ * listings, records every `release create`/`release upload`, and throws the
+ * queued error (a 422, a race, …) on the matching upload attempt.
+ */
+function fakeGh({ releases = [], failUploads = [], createError = null } = {}) {
+  const calls = [];
+  let uploadAttempt = 0;
+  const run = (args) => {
+    calls.push(args);
+    if (args[0] === "api") {
+      return releases
+        .map((release) =>
+          JSON.stringify({ tag: release.tag, assets: release.assets ?? [] }),
+        )
+        .join("\n");
+    }
+    if (args[0] === "release" && args[1] === "create") {
+      if (createError) throw createError;
+      return "";
+    }
+    if (args[0] === "release" && args[1] === "upload") {
+      const failure = failUploads[uploadAttempt];
+      uploadAttempt += 1;
+      if (failure) throw failure;
+      return "";
+    }
+    throw new Error(`unexpected gh call: ${args.join(" ")}`);
+  };
+  return { run, calls };
+}
+
+function http422FileCount() {
+  const err = new Error("gh: release upload failed");
+  err.stderr =
+    "HTTP 422: Validation Failed — file_count exceeds the maximum number of files per release";
+  return err;
+}
+
+/** Runs `fn` with process.exit stubbed to throw, so `fail()` paths are assertable. */
+function withExitTrap(fn) {
+  const realExit = process.exit;
+  process.exit = (code) => {
+    const err = new Error(`process.exit(${code})`);
+    err.exitCode = code;
+    throw err;
+  };
+  try {
+    return fn();
+  } finally {
+    process.exit = realExit;
+  }
+}
+
+function stagedFile(name, contents = "evidence-bytes") {
+  const dir = mkdtempSync(join(tmpdir(), "pr-evidence-test-"));
+  const path = join(dir, name);
+  writeFileSync(path, contents);
+  return path;
+}
+
+describe("isReleaseFullError", () => {
+  it("matches the over-cap 422 but not a name-collision 422", () => {
+    assert.ok(isReleaseFullError(http422FileCount().stderr));
+    assert.ok(
+      !isReleaseFullError("HTTP 422: Validation Failed — already_exists"),
+    );
+    assert.ok(!isReleaseFullError("file_count exceeded")); // no HTTP 422 token
+  });
+});
+
+describe("uploadAssets (injected gh runner)", () => {
+  const staged = () => new Map([["77-shot.png", stagedFile("77-shot.png")]]);
+
+  it("pre-selects a release below the 990 headroom threshold and uploads once", () => {
+    const { run, calls } = fakeGh();
+    const urls = uploadAssets(
+      staged(),
+      [
+        {
+          tag: "pr-evidence",
+          assets: Array(ASSET_CAPACITY_THRESHOLD).fill({}),
+        },
+        { tag: "pr-evidence-2", assets: Array(10).fill({}) },
+      ],
+      run,
+    );
+    const uploads = calls.filter(
+      (c) => c[0] === "release" && c[1] === "upload",
+    );
+    assert.equal(uploads.length, 1);
+    assert.equal(uploads[0][2], "pr-evidence-2");
+    assert.equal(
+      urls.get("77-shot.png"),
+      "https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/77-shot.png",
+    );
+  });
+
+  it("creates the next overflow release when every observed release is at capacity", () => {
+    const { run, calls } = fakeGh();
+    const urls = uploadAssets(
+      staged(),
+      [{ tag: "pr-evidence", assets: Array(MAX_ASSETS_PER_RELEASE).fill({}) }],
+      run,
+    );
+    const create = calls.find((c) => c[0] === "release" && c[1] === "create");
+    assert.equal(create?.[2], "pr-evidence-2");
+    assert.match(
+      urls.get("77-shot.png"),
+      /\/releases\/download\/pr-evidence-2\/77-shot\.png$/,
+    );
+  });
+
+  it("rolls over on a 422 file_count race and retries on the next release", () => {
+    const { run, calls } = fakeGh({ failUploads: [http422FileCount()] });
+    const urls = uploadAssets(
+      staged(),
+      [{ tag: "pr-evidence", assets: [] }],
+      run,
+    );
+    const uploads = calls.filter(
+      (c) => c[0] === "release" && c[1] === "upload",
+    );
+    assert.deepEqual(
+      uploads.map((c) => c[2]),
+      ["pr-evidence", "pr-evidence-2"],
+    );
+    assert.match(urls.get("77-shot.png"), /pr-evidence-2/);
+  });
+
+  it("rethrows a non-capacity upload error instead of rolling over", () => {
+    const err = new Error("boom");
+    err.stderr =
+      "HTTP 422: Validation Failed — already_exists (name collision)";
+    const { run } = fakeGh({ failUploads: [err] });
+    assert.throws(
+      () => uploadAssets(staged(), [{ tag: "pr-evidence", assets: [] }], run),
+      /boom/,
+    );
+  });
+
+  it("gives up after a bounded number of re-selections when everything 422s", () => {
+    const attempts = 1 + 4; // releases.length + 4
+    const { run, calls } = fakeGh({
+      failUploads: Array(attempts + 5)
+        .fill(null)
+        .map(() => http422FileCount()),
+    });
+    withExitTrap(() => {
+      assert.throws(
+        () => uploadAssets(staged(), [{ tag: "pr-evidence", assets: [] }], run),
+        /process\.exit\(1\)/,
+      );
+    });
+    const uploads = calls.filter(
+      (c) => c[0] === "release" && c[1] === "upload",
+    );
+    assert.equal(uploads.length, attempts);
+  });
+});
+
+describe("createOverflowReleaseIfAbsent", () => {
+  it("tolerates a concurrent lane that created the release first", () => {
+    const raced = new Error("gh: release create failed");
+    raced.stderr = "HTTP 422: Validation Failed — tag_name already exists";
+    const { run } = fakeGh({ createError: raced });
+    assert.doesNotThrow(() =>
+      createOverflowReleaseIfAbsent("pr-evidence-2", run),
+    );
+  });
+
+  it("rethrows a create failure that is not an already-exists race", () => {
+    const denied = new Error("HTTP 403: forbidden");
+    const { run } = fakeGh({ createError: denied });
+    assert.throws(
+      () => createOverflowReleaseIfAbsent("pr-evidence-3", run),
+      /403/,
+    );
+  });
+});
+
+describe("attach (injected gh runner)", () => {
+  it("reuses an asset already on any family release without re-uploading", () => {
+    const existingUrl =
+      "https://github.com/elizaOS/eliza/releases/download/pr-evidence/123-shot.png";
+    const { run, calls } = fakeGh({
+      releases: [
+        {
+          tag: "pr-evidence",
+          assets: [{ name: "123-shot.png", url: existingUrl }],
+        },
+      ],
+    });
+    const urls = attach(123, [stagedFile("shot.png")], run);
+    assert.equal(urls.get("123-shot.png"), existingUrl);
+    assert.ok(!calls.some((c) => c[0] === "release" && c[1] === "upload"));
+  });
+
+  it("uploads a genuinely new asset under the <pr>- prefix", () => {
+    const { run, calls } = fakeGh({
+      releases: [{ tag: "pr-evidence", assets: [] }],
+    });
+    const urls = attach(124, [stagedFile("walk.mp4")], run);
+    assert.equal(
+      urls.get("124-walk.mp4"),
+      "https://github.com/elizaOS/eliza/releases/download/pr-evidence/124-walk.mp4",
+    );
+    const upload = calls.find((c) => c[0] === "release" && c[1] === "upload");
+    assert.equal(upload?.[2], "pr-evidence");
+  });
+
+  it("refuses an empty (0-byte) artifact", () => {
+    const { run } = fakeGh({ releases: [{ tag: "pr-evidence", assets: [] }] });
+    withExitTrap(() => {
+      assert.throws(
+        () => attach(125, [stagedFile("empty.log", "")], run),
+        /process\.exit\(1\)/,
+      );
+    });
+  });
+
+  it("parses the paginated NDJSON release listing", () => {
+    const { run } = fakeGh({
+      releases: [
+        { tag: "pr-evidence", assets: [{ name: "a", url: "u" }] },
+        { tag: "pr-evidence-2", assets: [] },
+      ],
+    });
+    const releases = fetchPrEvidenceReleases(run);
+    assert.deepEqual(
+      releases.map((release) => release.tag),
+      ["pr-evidence", "pr-evidence-2"],
+    );
+    assert.equal(releases[0].assets[0].name, "a");
+  });
+});
+
+describe("row rendering and body patching", () => {
+  it("renders media URLs, file links, and N/A rows distinctly", () => {
+    assert.equal(
+      renderRow("after-screenshots", "https://x.test/a.png"),
+      "- [x] ![after-screenshots](https://x.test/a.png)",
+    );
+    assert.equal(
+      renderRow("walkthrough-video", "https://x.test/w.mp4"),
+      "- [x] https://x.test/w.mp4",
+    );
+    assert.equal(
+      renderRow("backend-logs", "https://x.test/b.log"),
+      "- [x] [b.log](https://x.test/b.log)",
+    );
+    assert.equal(
+      renderRow("frontend-logs", "N/A - no frontend change"),
+      "- [ ] N/A - no frontend change",
+    );
+  });
+
+  it("replaces the block after an existing marker and appends when absent", () => {
+    const body =
+      "intro\n\n<!-- evidence-row:backend-logs -->\n- [ ] old row\n\n## next";
+    const patched = patchRow(body, "backend-logs", "- [x] new row");
+    assert.match(
+      patched,
+      /<!-- evidence-row:backend-logs -->\n- \[x\] new row/,
+    );
+    assert.ok(!patched.includes("old row"));
+    const appended = patchRow("no markers here", "llm-trajectory", "- [x] t");
+    assert.match(
+      appended,
+      /<!-- evidence-row:llm-trajectory -->\n- \[x\] t\n$/,
+    );
   });
 });


### PR DESCRIPTION
## What & why

The shared `pr-evidence` GitHub release hit GitHub's hard **1000-assets-per-release** cap. `gh release upload pr-evidence` now returns HTTP 422, so `scripts/pr-evidence.mjs` cannot attach media and **no surface-`.tsx` PR can satisfy the `check-pr-evidence` surface-artifact gate**. This is a repo-wide CI-infra blocker for every contributor.

## Fix

- **`scripts/pr-evidence.mjs`** — when the target release has no capacity (≥ 990-asset headroom, or a 422 `file_count` on upload), roll deterministically to the next overflow release: `pr-evidence-2`, `pr-evidence-3`, … Selection (`selectPrEvidenceTarget`) picks the highest-indexed existing release with room and creates the next one only when none has room. Dedup and URL emission span the whole family, so an asset already uploaded to any release keeps its original URL. Behavior is identical when the primary has room.
- **`scripts/check-pr-evidence.mjs`** — add `PR_EVIDENCE_RELEASE_RE` recognizing the whole `pr-evidence`/`pr-evidence-N` **download-URL** family as a first-class evidence host. Overflow-release media already validated via the media-extension check; this generalizes the non-media evidence-file recognition too. **Nothing looser**: a surface PR with no real media still fails, a link to the release *page* still fails, arbitrary hosts are not newly accepted.

Two invariants held and proven: (1) the gate stays exactly as strict; (2) existing `pr-evidence` links keep validating.

## Evidence

CI-tooling change (scripts + docs), no UI surface — visual rows are N/A. Backend-logs row points at the test/dry-run output below.

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - CI tooling change (scripts/*.mjs + CONTRIBUTING.md), no UI surface`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - CI tooling change (scripts/*.mjs + CONTRIBUTING.md), no UI surface`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - CI tooling change, no UI surface`.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - CI tooling change, no server runtime; unit + dry-run output in the Evidence Details block below`.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs `N/A - no frontend change`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent/action/model change`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no domain artifacts; release-selection + gate behavior shown in the Evidence Details block below`.

## Evidence Details

<details>
<summary>Unit + self-test (50 tests, 13 self-test cases) and end-to-end gate/upload proof</summary>

- `node --test scripts/check-pr-evidence.test.mjs scripts/pr-evidence.test.mjs` → 50 pass / 0 fail
- `node scripts/check-pr-evidence.mjs --self-test` → passed (13 cases)
- Gate CLI: surface PR (UI `.tsx` diff) with **primary** `pr-evidence` links → PASS; with **overflow** `pr-evidence-2` links → PASS; with a blank before-screenshots row → FAIL (`artifact-required`)
- Live selection against real releases (`pr-evidence`=1000 full, `pr-evidence-2`=87) → targets `pr-evidence-2`, `create:false`
- Real upload via `pr-evidence.mjs attach` → emitted `.../releases/download/pr-evidence-2/...`; re-run deduped; URL returned HTTP 302 to the release-assets CDN

</details>
