### PR TITLE
fix(core): open the model-call timing window at the handler invocation

### DIFF
--- a/packages/core/src/__tests__/runtime-regression-lane.test.ts
+++ b/packages/core/src/__tests__/runtime-regression-lane.test.ts
@@ -23,6 +23,7 @@ import "../runtime/__tests__/embedding-dimension.test";
 import "../runtime/__tests__/guarded-stream-use-model.test";
 import "../runtime/__tests__/model-provider-failover.test";
 import "../runtime/__tests__/model-registrations.test";
+import "../runtime/__tests__/model-span-window.test";
 import "../runtime/__tests__/model-stream-chunk-hooks.test";
 import "../runtime/__tests__/pii-swap-use-model.test";
 import "../runtime/__tests__/run-actions-by-mode.test";

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -5558,7 +5558,7 @@ export class AgentRuntime implements IAgentRuntime {
 						}
 					}
 				}
-				const startTime =
+				let startTime =
 					typeof performance !== "undefined" &&
 					typeof performance.now === "function"
 						? performance.now()
@@ -5933,6 +5933,16 @@ export class AgentRuntime implements IAgentRuntime {
 					"Using model",
 				);
 
+				// The model-call timing window opens HERE, not at useModel entry:
+				// everything above (streaming setup, secret/PII swap sessions,
+				// pre_model hooks, prompt extraction) is runtime work, and charging
+				// it to the provider span makes `model:*` timings unreadable as
+				// provider latency (#16394).
+				startTime =
+					typeof performance !== "undefined" &&
+					typeof performance.now === "function"
+						? performance.now()
+						: Date.now();
 				const rawResponse = await handler(
 					this,
 					modelParams as Record<string, JsonValue | object>,

--- a/packages/core/src/runtime/__tests__/model-span-window.test.ts
+++ b/packages/core/src/runtime/__tests__/model-span-window.test.ts
@@ -1,0 +1,112 @@
+/**
+ * The model-call timing window opens at the handler invocation, not at
+ * `useModel` entry. Everything before the handler — pre_model hooks,
+ * secret/PII swap sessions, streaming setup, prompt extraction — is runtime
+ * work, and charging it to the provider span made `model:*` timings unreadable
+ * as provider latency (#16394). These tests pin the window with a deliberately
+ * slow pre_model hook and a handler of known duration: the `post_model`
+ * `durationMs` must reflect the handler alone. Real runtime over the in-memory
+ * adapter with registered fake model handlers; deterministic.
+ */
+import { describe, expect, it } from "vitest";
+import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
+import { AgentRuntime } from "../../runtime";
+import { type Character, ModelType } from "../../types";
+
+const PRE_HOOK_DELAY_MS = 250;
+const HANDLER_DELAY_MS = 40;
+// Generous ceiling between the handler's real duration and the pre-hook
+// delay: timers can overshoot, but never by the full 250ms pre-hook cost.
+const SPAN_CEILING_MS = PRE_HOOK_DELAY_MS - 50;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function makeRuntime(): AgentRuntime {
+	return new AgentRuntime({
+		character: {
+			name: "SpanWindowAgent",
+			bio: "test",
+		} as Character,
+		adapter: new InMemoryDatabaseAdapter(),
+		logLevel: "fatal",
+	});
+}
+
+function captureModelSpan(runtime: AgentRuntime): { durationMs: number[] } {
+	const captured: { durationMs: number[] } = { durationMs: [] };
+	runtime.registerPipelineHook({
+		id: "capture-span",
+		phase: "post_model",
+		handler: (_rt, ctx) => {
+			if (ctx.phase === "post_model") captured.durationMs.push(ctx.durationMs);
+		},
+	});
+	return captured;
+}
+
+describe("AgentRuntime.useModel span window", () => {
+	it("excludes a slow pre_model hook from the reported model duration", async () => {
+		const runtime = makeRuntime();
+		runtime.registerModel(
+			ModelType.TEXT_SMALL,
+			async () => {
+				await sleep(HANDLER_DELAY_MS);
+				return "handler-result";
+			},
+			"test",
+			0,
+		);
+		runtime.registerPipelineHook({
+			id: "slow-pre-model",
+			phase: "pre_model",
+			handler: async () => {
+				await sleep(PRE_HOOK_DELAY_MS);
+			},
+		});
+		const span = captureModelSpan(runtime);
+
+		const result = await runtime.useModel(ModelType.TEXT_SMALL, {
+			prompt: "measure me",
+		});
+
+		expect(result).toBe("handler-result");
+		expect(span.durationMs).toHaveLength(1);
+		expect(span.durationMs[0]).toBeGreaterThanOrEqual(HANDLER_DELAY_MS - 5);
+		expect(span.durationMs[0]).toBeLessThan(SPAN_CEILING_MS);
+	});
+
+	it("keeps the handler-only window on the streaming path", async () => {
+		const runtime = makeRuntime();
+		runtime.registerModel(
+			ModelType.TEXT_SMALL,
+			async (
+				_rt,
+				params: { onStreamChunk?: (chunk: string) => Promise<void> | void },
+			) => {
+				await sleep(HANDLER_DELAY_MS);
+				await params.onStreamChunk?.("streamed");
+				return "streamed";
+			},
+			"test",
+			0,
+			{ streamable: true },
+		);
+		runtime.registerPipelineHook({
+			id: "slow-pre-model-stream",
+			phase: "pre_model",
+			handler: async () => {
+				await sleep(PRE_HOOK_DELAY_MS);
+			},
+		});
+		const span = captureModelSpan(runtime);
+
+		const result = await runtime.useModel(ModelType.TEXT_SMALL, {
+			prompt: "measure the stream",
+			onStreamChunk: () => {},
+		});
+
+		expect(result).toBe("streamed");
+		expect(span.durationMs).toHaveLength(1);
+		expect(span.durationMs[0]).toBeLessThan(SPAN_CEILING_MS);
+	});
+});


### PR DESCRIPTION
## What

The `model:*` inference span started at `useModel` entry, so streaming setup, secret/PII swap sessions, `pre_model` hooks, and prompt extraction were all charged to the provider. That makes `InferenceTiming` unreadable as provider latency — during the #16393 investigation, "slow embedding" spans were runtime/event-loop time wearing a provider label. The window now opens at the handler invocation. Part 1 of #16394 (span honesty); reasoning-token surfacing is the remaining half.

## Evidence

| Type | Evidence |
|---|---|
| Tests | runtime regression lane 210/210 (covers the logModelCall/telemetry paths). |
| Backend logs | Live: `model:TEXT_EMBEDDING` spans post-change track the actual fetch window; pre-handler runtime work no longer inflates them. |
| Screenshots / video / frontend logs / trajectory / domain artifacts | N/A - telemetry window fix, one call site, no behavior change. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Evidence rows

<!-- evidence-row:before-screenshots -->
`N/A - backend-only change, no UI-bearing files touched; the user-visible effect is shown in the backend-logs and domain-artifacts rows.`

<!-- evidence-row:after-screenshots -->
`N/A - backend-only change, no UI-bearing files touched; the user-visible effect is shown in the backend-logs and domain-artifacts rows.`

<!-- evidence-row:walkthrough-video -->
`N/A - backend-only change; the complete run-through is the live evidence attached under domain artifacts.`

<!-- evidence-row:backend-logs -->
https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16406-span-window.txt

<!-- evidence-row:frontend-logs -->
`N/A - no frontend surface touched.`

<!-- evidence-row:llm-trajectory -->
`N/A - telemetry accounting change; no model-behavior surface. The backend-logs row shows the real InferenceTiming spans before/after.`

<!-- evidence-row:domain-artifacts -->
https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/16406-span-window.txt
