### PR TITLE
fix(ci): classify vitest.harness.config.ts as config, not coverable source

### DIFF
--- a/scripts/security/coverage-changed-files.self-test.mjs
+++ b/scripts/security/coverage-changed-files.self-test.mjs
@@ -208,6 +208,11 @@ try {
   );
   write(
     dir,
+    "plugins/plugin-demo/vitest.harness.config.ts",
+    "export default { test: { include: ['__tests__/**/*.harness.test.ts'] } };\n",
+  );
+  write(
+    dir,
     "packages/demo/src/feature.test.ts",
     "import { test } from 'vitest';\ntest('f', () => {});\n",
   );
@@ -352,6 +357,12 @@ try {
     assert.ok(
       !out.files.includes("plugins/plugin-demo/vite.config.views.ts"),
       `Vite config leaked into changed source: ${out.files.join(",")}`,
+    );
+    // The harness-lane config convention run-changed-vitest-coverage.mjs
+    // defines (HARNESS_CONFIG_NAME) — a config file, never coverable source.
+    assert.ok(
+      !out.files.includes("plugins/plugin-demo/vitest.harness.config.ts"),
+      `vitest harness config leaked into changed source: ${out.files.join(",")}`,
     );
   });
 

--- a/scripts/security/coverage-changed-files.sh
+++ b/scripts/security/coverage-changed-files.sh
@@ -46,7 +46,7 @@ changed_source() {
   {
     git diff --name-only --diff-filter=ACMRT "$MERGE_BASE" "$HEAD" -- \
       '*.ts' '*.tsx' '*.js' '*.jsx' '*.mjs' '*.cjs' '*.mts' '*.cts' \
-      | grep -vE '(^|/)(__tests__|__e2e__|test|tests|generated)/|([.-]e2e|[.]generated|[.]test|[.]spec|[.]stories)[.](ts|tsx|js|jsx|mjs|cjs|mts|cts)$|(^|/)(vite|vitest)[.]config([.][^.]+)?[.](ts|js|mts|mjs|cts|cjs)$|(^|/)scripts/playwright[^/]*[.](ts|js|mts|mjs|cts|cjs)$' || true
+      | grep -vE '(^|/)(__tests__|__e2e__|test|tests|generated)/|([.-]e2e|[.]generated|[.]test|[.]spec|[.]stories)[.](ts|tsx|js|jsx|mjs|cjs|mts|cts)$|(^|/)(vite|vitest)([.][^./]+)?[.]config([.][^.]+)?[.](ts|js|mts|mjs|cts|cjs)$|(^|/)scripts/playwright[^/]*[.](ts|js|mts|mjs|cts|cjs)$' || true
   } \
     | while IFS= read -r file; do
         [ -f "$file" ] || continue


### PR DESCRIPTION
## What

`packages/scripts/run-changed-vitest-coverage.mjs` defines the `vitest.harness.config.ts` convention (`HARNESS_CONFIG_NAME`) so PGlite-runtime harness lanes (`*.harness.test.ts`) run under their own source-aliased config in the changed-file coverage gate. But the changed-source filter in `scripts/security/coverage-changed-files.sh` only excluded the `vitest.config.*` / `vite.config.*` name shapes — so any PR that **adds** a harness config (the documented way to make a harness lane runnable) enrolled the config file itself as changed source requiring ≥50% line coverage. A config file never appears in LCOV, so the gate failed as `MISSING: .../vitest.harness.config.ts` — the convention one script defines was unusable under the gate another script enforces.

The filter now accepts one infix segment — `(vite|vitest)([.][^./]+)?[.]config([.][^.]+)?.<ext>` — which matches `vitest.config.ts`, `vite.config.views.ts` (suffix variant, already covered), and `vitest.harness.config.ts` (infix variant), and nothing else.

## Evidence

| Type | Evidence |
|---|---|
| Repro | `bash scripts/security/coverage-changed-files.sh origin/develop <branch-adding-a-harness-config>` before: emits the config under `files<<EOF` (LCOV-enforced). After: source list contains only real source. Observed live on #16405 (plugin-sql harness lane). |
| Tests | `node scripts/security/coverage-changed-files.self-test.mjs` — new fixture `plugins/plugin-demo/vitest.harness.config.ts` + assertion in the "Vite config changes are not LCOV-enforced source" case; full self-test suite passes. |
| Screenshots / video | N/A - CI classification script; the self-test run is the behavior proof. |

## Evidence rows

<!-- evidence-row:before-screenshots -->
`N/A - CI classification script, no UI surface.`

<!-- evidence-row:after-screenshots -->
`N/A - CI classification script, no UI surface.`

<!-- evidence-row:walkthrough-video -->
`N/A - CI classification script; the self-test run is the complete run-through.`

<!-- evidence-row:backend-logs -->
`N/A - no server path; scripts/security/coverage-changed-files.self-test.mjs output (all cases ok) is the execution proof.`

<!-- evidence-row:frontend-logs -->
`N/A - no frontend surface.`

<!-- evidence-row:llm-trajectory -->
`N/A - no model behavior involved.`

<!-- evidence-row:domain-artifacts -->
`N/A - the domain artifact is the classifier output itself, shown in the Repro row.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
