### PR TITLE
fix(android): pin debug signing identity [sol-orch]

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -61,6 +61,18 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699
 
+      - name: Restore pinned debug keystore
+        env:
+          ELIZA_ANDROID_DEBUG_KEYSTORE_BASE64: ${{ vars.ELIZA_ANDROID_DEBUG_KEYSTORE_BASE64 }}
+        run: |
+          if [[ -z "$ELIZA_ANDROID_DEBUG_KEYSTORE_BASE64" ]]; then
+            echo "Repository variable ELIZA_ANDROID_DEBUG_KEYSTORE_BASE64 is required" >&2
+            exit 1
+          fi
+          install -d -m 700 "$HOME/.android"
+          printf '%s' "$ELIZA_ANDROID_DEBUG_KEYSTORE_BASE64" | base64 -d > "$HOME/.android/eliza-debug.keystore"
+          chmod 600 "$HOME/.android/eliza-debug.keystore"
+
       - name: Cache Gradle
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:

--- a/packages/app-core/platforms/android/README.md
+++ b/packages/app-core/platforms/android/README.md
@@ -151,3 +151,17 @@ service declarations.
 The release APK is staged at
 `<repoRoot>/packages/os/android/vendor/eliza/apps/Eliza/Eliza.apk` (or
 the brand-aware vendor dir resolved from `app.config.ts > aosp:`).
+## Pinned debug signing key
+
+Debug APKs use one repository-managed, non-production signing key so `adb install -r` works across CI and local rebuilds. Debug keystores are public development credentials, not release secrets. The release signing path remains separate and secret-backed.
+
+CI restores the key from the `ELIZA_ANDROID_DEBUG_KEYSTORE_BASE64` repository variable. For a local build, install the same key once with GitHub CLI access:
+
+```bash
+mkdir -p "$HOME/.android"
+gh variable get ELIZA_ANDROID_DEBUG_KEYSTORE_BASE64 -R elizaOS/eliza \
+  | base64 -d > "$HOME/.android/eliza-debug.keystore"
+chmod 600 "$HOME/.android/eliza-debug.keystore"
+```
+
+To keep it elsewhere, set `ELIZAOS_DEBUG_KEYSTORE_PATH` to the decoded keystore path. The fixed debug alias is `androiddebugkey`; store and key passwords are the conventional Android debug password, `android`. When the pinned file is absent, Gradle warns and falls back to its machine-local debug identity so unrelated Android workflows remain usable; those APKs are not guaranteed to upgrade CI artifacts in place.

--- a/packages/app-core/platforms/android/app/build.gradle
+++ b/packages/app-core/platforms/android/app/build.gradle
@@ -117,6 +117,22 @@ android {
     ndkVersion "28.2.13676358"
 
     signingConfigs {
+        debug {
+            // A repository variable restores this public, non-production debug key in CI.
+            // Local developers install the same key at this path so debug APKs remain
+            // upgrade-compatible across machines and workflow runs.
+            def pinnedDebugKeystore = System.getenv("ELIZAOS_DEBUG_KEYSTORE_PATH")
+                ? file(System.getenv("ELIZAOS_DEBUG_KEYSTORE_PATH"))
+                : new File(System.getProperty("user.home"), ".android/eliza-debug.keystore")
+            if (pinnedDebugKeystore.isFile()) {
+                storeFile pinnedDebugKeystore
+                storePassword "android"
+                keyAlias "androiddebugkey"
+                keyPassword "android"
+            } else {
+                logger.warn("[debug-signing] pinned Eliza debug keystore not found at ${pinnedDebugKeystore}; using Gradle's machine-local debug identity. See platforms/android/README.md for upgrade-compatible setup.")
+            }
+        }
         release {
             // For Google Play App Signing: use an upload keystore.
             // CI provides these via environment variables; local builds fall back to debug signing.
@@ -130,6 +146,9 @@ android {
     }
 
     buildTypes {
+        debug {
+            signingConfig signingConfigs.debug
+        }
         release {
             minifyEnabled true
             shrinkResources true


### PR DESCRIPTION
## Summary

- restore one pinned, non-production debug keystore from the repository variable `ELIZA_ANDROID_DEBUG_KEYSTORE_BASE64`
- wire Gradle debug signing to the same identity in CI and local builds
- document one-time local setup and preserve a warning-backed fallback for unrelated workflows

## Why a repository variable

The Android subtree explicitly ignores `*.jks` and `*.keystore` with the policy comment “never commit signing keys,” so this PR does not add a binary key file. The key is a debug-only development credential, not a release secret; Android debug keystores are conventionally public and use the well-known `androiddebugkey` / `android` credentials. Release signing remains fully separate and secret-backed.

This fixes the 2026-07-14 LP3 incident where a fresh runner-generated key caused `INSTALL_FAILED_UPDATE_INCOMPATIBLE` and blocked `adb install -r`.

## Evidence

- [x] `ELIZA_ANDROID_DEBUG_KEYSTORE_BASE64` repository variable created
- [x] key fingerprint: `SHA-256 AF:A5:AF:B6:BA:58:2F:67:22:25:48:87:22:92:34:1D:F0:BF:6D:62:5F:70:59:04:85:8B:81:05:1D:DE:91:F4`
- [x] `git diff --check`
- [x] Codex review, no findings after fixing the initial cross-workflow configuration concern
- [x] two independent workflow builds and `apksigner verify --print-certs` outputs compared byte-for-byte; evidence posted in follow-up comment

## Review gate

This changes `.github/workflows/build-android.yml`. **Do not auto-merge.** Orchestrator review is required.

[sol-orch]


## Required evidence rows

<!-- evidence-row:before-screenshots -->
- [x] N/A - signing and CI workflow change only; no UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - signing and CI workflow change only; no UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow changed.
<!-- evidence-row:backend-logs -->
- [x] Two complete Android workflow runs succeeded: https://github.com/elizaOS/eliza/actions/runs/29447662056 and https://github.com/elizaOS/eliza/actions/runs/29448677577.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] `apksigner verify --print-certs` outputs and byte-for-byte comparison are attached in https://github.com/elizaOS/eliza/pull/16411#issuecomment-4985164740.

<!-- evidence-updated: 2026-07-15T20:55Z -->
