### PR TITLE
fix(ci): format OpenRouter cache breakpoint tests

### DIFF
--- a/plugins/plugin-openrouter/__tests__/anthropic-cache.shape.test.ts
+++ b/plugins/plugin-openrouter/__tests__/anthropic-cache.shape.test.ts
@@ -13,11 +13,15 @@ function createRuntime(settings: Record<string, string> = {}) {
     character: { system: "system prompt" },
     emitEvent: vi.fn(async () => undefined),
     getSetting: vi.fn((key: string) => {
-      return ({
-        OPENROUTER_API_KEY: "test-key",
-        OPENROUTER_LARGE_MODEL: "anthropic/claude-opus-4-8",
-        ...settings,
-      } as Record<string, string>)[key] ?? null;
+      return (
+        (
+          {
+            OPENROUTER_API_KEY: "test-key",
+            OPENROUTER_LARGE_MODEL: "anthropic/claude-opus-4-8",
+            ...settings,
+          } as Record<string, string>
+        )[key] ?? null
+      );
     }),
   } as IAgentRuntime;
 }
@@ -62,15 +66,15 @@ describe("Anthropic cache injection — runtime cacheControl fallback", () => {
     const { generateText } = mockModules();
     const { handleTextLarge } = await import("../models/text");
 
-    await handleTextLarge(
-      createRuntime({ ANTHROPIC_PROMPT_CACHE_TTL: "1h" }),
-      { prompt: "hello" } as never,
-    );
+    await handleTextLarge(createRuntime({ ANTHROPIC_PROMPT_CACHE_TTL: "1h" }), {
+      prompt: "hello",
+    } as never);
 
     const call = generateText.mock.calls[0][0] as Record<string, unknown>;
     const messages = call.messages as Array<Record<string, unknown>>;
-    const anthropicOpts = (messages?.[0]?.providerOptions as Record<string, unknown>)
-      ?.anthropic as Record<string, unknown> | undefined;
+    const anthropicOpts = (messages?.[0]?.providerOptions as Record<string, unknown>)?.anthropic as
+      | Record<string, unknown>
+      | undefined;
     expect(anthropicOpts?.cacheControl).toEqual({ type: "ephemeral", ttl: "1h" });
   });
 
@@ -83,7 +87,7 @@ describe("Anthropic cache injection — runtime cacheControl fallback", () => {
         OPENROUTER_LARGE_MODEL: "google/gemini-2.5-flash",
         ANTHROPIC_PROMPT_CACHE_TTL: "1h",
       }),
-      { prompt: "hello" } as never,
+      { prompt: "hello" } as never
     );
 
     const call = generateText.mock.calls[0][0] as Record<string, unknown>;
@@ -130,18 +134,15 @@ describe("Anthropic cache injection — internal field stripping", () => {
     const { generateText } = mockModules();
     const { handleTextLarge } = await import("../models/text");
 
-    await handleTextLarge(
-      createRuntime({ OPENROUTER_LARGE_MODEL: "anthropic/claude-opus-4-8" }),
-      {
-        messages: [
-          { role: "system", content: "system prompt" },
-          { role: "user", content: "hello" },
-        ],
-        providerOptions: {
-          anthropic: { cacheSystem: true, thinking: { type: "enabled" } },
-        },
-      } as never,
-    );
+    await handleTextLarge(createRuntime({ OPENROUTER_LARGE_MODEL: "anthropic/claude-opus-4-8" }), {
+      messages: [
+        { role: "system", content: "system prompt" },
+        { role: "user", content: "hello" },
+      ],
+      providerOptions: {
+        anthropic: { cacheSystem: true, thinking: { type: "enabled" } },
+      },
+    } as never);
 
     const call = generateText.mock.calls[0][0] as Record<string, unknown>;
     const wireAnthropic = (call.providerOptions as Record<string, unknown> | undefined)
@@ -175,8 +176,9 @@ describe("Anthropic cache injection — segmented user content", () => {
     const content = userMsg?.content as Array<Record<string, unknown>>;
     expect(content).toHaveLength(2);
     expect(content[0]?.text).toBe("seg1");
-    const seg0Opts = (content[0]?.providerOptions as Record<string, unknown>)
-      ?.anthropic as Record<string, unknown> | undefined;
+    const seg0Opts = (content[0]?.providerOptions as Record<string, unknown>)?.anthropic as
+      | Record<string, unknown>
+      | undefined;
     expect(seg0Opts?.cacheControl).toEqual({ type: "ephemeral" });
     expect(content[1]?.text).toBe("seg2");
     expect(content[1]?.providerOptions).toBeUndefined();
@@ -242,8 +244,7 @@ describe("Anthropic cache injection — segmented user content", () => {
     const userMsg = messages?.[1];
     const content = userMsg?.content as Array<Record<string, unknown>>;
     const cachedBlocks = content?.filter(
-      (b) =>
-        (b.providerOptions as Record<string, unknown> | undefined)?.anthropic !== undefined,
+      (b) => (b.providerOptions as Record<string, unknown> | undefined)?.anthropic !== undefined
     );
     // Only segmentIndex 0 survives the cap of 1
     expect(cachedBlocks).toHaveLength(1);

--- a/plugins/plugin-openrouter/models/text.ts
+++ b/plugins/plugin-openrouter/models/text.ts
@@ -317,7 +317,7 @@ function isAnthropicCacheBreakpoint(value: unknown): value is AnthropicCacheBrea
 
 function readAnthropicCacheBreakpoints(
   anthropicOptions: Record<string, unknown> | undefined,
-  maxBreakpoints: number,
+  maxBreakpoints: number
 ): AnthropicCacheBreakpoint[] {
   const raw = anthropicOptions?.cacheBreakpoints;
   if (!Array.isArray(raw)) return [];
@@ -333,13 +333,13 @@ function readAnthropicCacheBreakpoints(
  */
 function buildSegmentedPromptUserContent(
   promptSegments: Array<{ content: string; stable?: boolean }>,
-  cacheBreakpoints: AnthropicCacheBreakpoint[],
+  cacheBreakpoints: AnthropicCacheBreakpoint[]
 ): CacheableTextPart[] {
   if (cacheBreakpoints.length === 0) {
     return promptSegments.map((seg) => ({ type: "text" as const, text: seg.content }));
   }
   const breakpointMap = new Map<number, AnthropicCacheControl>(
-    cacheBreakpoints.map((bp) => [bp.segmentIndex, bp.cacheControl]),
+    cacheBreakpoints.map((bp) => [bp.segmentIndex, bp.cacheControl])
   );
   return promptSegments.map((seg, index) => {
     const cc = breakpointMap.get(index);
@@ -609,9 +609,10 @@ function buildGenerateParams(
       : 3;
   const cacheBreakpoints = readAnthropicCacheBreakpoints(anthropicOptions, maxBreakpoints);
   const promptSegments = Array.isArray(
-    (paramsWithAttachments as { promptSegments?: unknown }).promptSegments,
+    (paramsWithAttachments as { promptSegments?: unknown }).promptSegments
   )
-    ? ((paramsWithAttachments as { promptSegments?: Array<{ content: string; stable?: boolean }> }).promptSegments ?? [])
+    ? ((paramsWithAttachments as { promptSegments?: Array<{ content: string; stable?: boolean }> })
+        .promptSegments ?? [])
     : [];
 
   let finalWireMessages = wireMessages;
@@ -648,7 +649,10 @@ function buildGenerateParams(
                 // additional breakpoints under Anthropic's four-block cap).
                 content:
                   promptSegments.length > 0 && cacheBreakpoints.length > 0 && !userContent
-                    ? (buildSegmentedPromptUserContent(promptSegments, cacheBreakpoints) as UserContent)
+                    ? (buildSegmentedPromptUserContent(
+                        promptSegments,
+                        cacheBreakpoints
+                      ) as UserContent)
                     : (userContent ?? buildUserContent(paramsWithAttachments)),
               },
             ],


### PR DESCRIPTION
# Relates to

Fixes the current develop CI formatter failure in Quality (Extended) / Format + Type Safety Ratchet.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. This is a formatter-only patch in `plugins/plugin-openrouter` and does not change runtime behavior.

# Background

## What does this PR do?

Applies Biome formatting to the OpenRouter Anthropic cache-breakpoint implementation and shape tests so the develop `@elizaos/plugin-openrouter#format:check` lane passes again.

## What kind of change is this?

Bug fix / CI fix.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Start with `plugins/plugin-openrouter/models/text.ts` and `plugins/plugin-openrouter/__tests__/anthropic-cache.shape.test.ts`; every diff hunk is Biome formatting.

## Detailed testing steps

- `bun run --cwd plugins/plugin-openrouter format:check`
- `git diff --check`

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - formatter-only TypeScript test/provider diff; no UI surface changes`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - formatter-only TypeScript test/provider diff; no UI surface changes`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - formatter-only TypeScript test/provider diff; no user flow changes`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - formatter-only CI repair; no backend runtime path changes`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - formatter-only TypeScript test/provider diff; no frontend runtime changes`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no model behavior change; Biome-only formatting of existing OpenRouter cache code and tests`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - formatter-only CI repair; no domain artifacts produced`.

# Evidence Details

## Real LLM-call trajectory

N/A - no model behavior change; Biome-only formatting of existing OpenRouter cache code and tests.

## Backend + frontend logs

N/A - formatter-only CI repair; no runtime request path changed.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface changed.

### Before

N/A - formatter-only TypeScript diff.

### After

N/A - formatter-only TypeScript diff.

### Walkthrough video

N/A - formatter-only TypeScript diff.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice changes.

## Known gaps / failures

- `bun install` and full `bun run verify` were not run in the clean temp worktree because it intentionally does not have workspace dependencies installed.
- `bun run --cwd plugins/plugin-openrouter typecheck` could not run in the clean temp worktree: `tsgo` is not installed there.
- A focused direct `bun test plugins/plugin-openrouter/__tests__/anthropic-cache.shape.test.ts` is not a valid command for this file because it uses Vitest-only `vi.doMock` / `vi.doUnmock`.
- A focused Vitest attempt could not load `vitest/config` because the clean temp worktree has no installed workspace dependencies.

