### PR TITLE
fix(ui): stop intermittent unhandled errors on the Client Tests ui shard

### DIFF
--- a/packages/ui/src/App.screen-background-fuzz.test.tsx
+++ b/packages/ui/src/App.screen-background-fuzz.test.tsx
@@ -37,6 +37,15 @@
 import { act, cleanup, render } from "@testing-library/react";
 import type * as React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { stubOfflineAppFetch } from "../test/offline-app-fetch";
+
+// The offline fetch stub keeps every probe permanently pending; withTimeout's
+// real timer would fire seconds later — after this file's jsdom env is torn
+// down — and reject that pending probe into a post-teardown setState that reads
+// the deleted `window`. Pass it through so the probe simply stays pending.
+vi.mock("./utils/with-timeout", () => ({
+  withTimeout: <T,>(promise: Promise<T>): Promise<T> => promise,
+}));
 import { getShaderPreset } from "./backgrounds/shader-presets";
 import { BACKGROUND_APPLY_EVENT } from "./backgrounds/useBackgroundApplyChannel";
 import type { BuiltinTab } from "./navigation";
@@ -622,6 +631,7 @@ describe("App screen-background fuzz — color invariant across view switching",
     desktopTabsState.tabs = [];
     glslRuntimeState.compileOk = true;
     glslRuntimeState.rendererCount = 0;
+    stubOfflineAppFetch();
     vi.stubGlobal("cancelAnimationFrame", vi.fn());
     vi.stubGlobal(
       "requestAnimationFrame",
@@ -868,6 +878,7 @@ describe("App view-surface mutation isolation — rogue view cannot leak global 
     glslRuntimeState.compileOk = true;
     glslRuntimeState.rendererCount = 0;
     bgState.config = { mode: "shader", color: "#059669" };
+    stubOfflineAppFetch();
     vi.stubGlobal("cancelAnimationFrame", vi.fn());
     vi.stubGlobal(
       "requestAnimationFrame",

--- a/packages/ui/src/App.surface-manifest-wallpaper.test.tsx
+++ b/packages/ui/src/App.surface-manifest-wallpaper.test.tsx
@@ -22,6 +22,16 @@
 import { act, cleanup, render } from "@testing-library/react";
 import type * as React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// This suite keeps every probe permanently pending (the forever-pending `fetch`
+// below); withTimeout's real timer would fire seconds later — after this file's
+// jsdom env is torn down — and reject that pending probe into a post-teardown
+// setState that reads the deleted `window`. Pass it through so the probe simply
+// stays pending.
+vi.mock("./utils/with-timeout", () => ({
+  withTimeout: <T,>(promise: Promise<T>): Promise<T> => promise,
+}));
+
 import { BACKGROUND_APPLY_EVENT } from "./backgrounds/useBackgroundApplyChannel";
 import type { BuiltinTab } from "./navigation";
 import type { BackgroundConfig } from "./state/ui-preferences";

--- a/packages/ui/src/App.surface-mutation-fuzz.test.tsx
+++ b/packages/ui/src/App.surface-mutation-fuzz.test.tsx
@@ -35,6 +35,15 @@
 import { act, cleanup, render } from "@testing-library/react";
 import type * as React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { stubOfflineAppFetch } from "../test/offline-app-fetch";
+
+// The offline fetch stub keeps every probe permanently pending; withTimeout's
+// real timer would fire seconds later — after this file's jsdom env is torn
+// down — and reject that pending probe into a post-teardown setState that reads
+// the deleted `window`. Pass it through so the probe simply stays pending.
+vi.mock("./utils/with-timeout", () => ({
+  withTimeout: <T,>(promise: Promise<T>): Promise<T> => promise,
+}));
 import type { BuiltinTab } from "./navigation";
 import type { BackgroundConfig } from "./state/ui-preferences";
 import {
@@ -487,6 +496,7 @@ describe("App in-process host-realm mutation isolation (#14179)", () => {
       value: new MemoryStorage(),
     });
     window.localStorage.setItem(SHELL_STORAGE_KEY, SHELL_STORAGE_VALUE);
+    stubOfflineAppFetch();
     vi.stubGlobal("cancelAnimationFrame", vi.fn());
     vi.stubGlobal(
       "requestAnimationFrame",

--- a/packages/ui/src/chat/useSlashCommandController.catalog.test.ts
+++ b/packages/ui/src/chat/useSlashCommandController.catalog.test.ts
@@ -14,7 +14,7 @@
  */
 
 import type { CustomActionDef } from "@elizaos/shared";
-import { renderHook, waitFor } from "@testing-library/react";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   CommandSurface,
@@ -94,6 +94,14 @@ beforeEach(() => {
   listCustomActions.mockResolvedValue([]);
   window.localStorage.clear();
 });
+
+// Unmount the hook root after each test. The catalog effect setStates when its
+// (mocked) fetch resolves; the protected-probe test only awaits the fetch being
+// CALLED, so it returns with a React update still queued on setImmediate.
+// Without this unmount that task flushes after jsdom is torn down and React
+// dereferences `window`, surfacing as an "unhandled" ReferenceError that fails
+// the shard even though every assertion passed.
+afterEach(cleanup);
 
 describe("useSlashCommandController — catalog load (#11112)", () => {
   it("resolves commands whenever the catalog fetch resolves, hiding auth-gated commands under the fail-closed defaults (#12087 Item 20)", async () => {

--- a/packages/ui/src/hooks/useProtectedAgentProbesEnabled.test.tsx
+++ b/packages/ui/src/hooks/useProtectedAgentProbesEnabled.test.tsx
@@ -16,7 +16,7 @@
  * so probes fire there exactly as before.
  */
 
-import { act, render, waitFor } from "@testing-library/react";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../api/runtime-mode-client", () => ({
@@ -140,6 +140,13 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  // Unmount every probe root before jsdom tears down. The gated hooks fire a
+  // catalog fetch whose resolution setStates on a still-mounted root; a test
+  // that only awaits the fetch being CALLED returns before that update commits,
+  // leaving React work queued on setImmediate. Without this unmount the queued
+  // task flushes after the environment is gone and React reads `window` —
+  // surfacing as an "unhandled" ReferenceError that fails the whole shard.
+  cleanup();
   __resetAuthStatusForTests();
   __resetRuntimeModeCacheForTests();
   if (originalLocationDescriptor) {

--- a/packages/ui/test/offline-app-fetch.ts
+++ b/packages/ui/test/offline-app-fetch.ts
@@ -1,0 +1,33 @@
+/**
+ * Offline test doubles for the full-`<App />` fuzz suites.
+ *
+ * Those suites mount the entire authenticated shell, which renders ~two dozen
+ * home/sidebar widgets plus the notification/slash-command shell — all of which
+ * probe the agent over the network on mount. With no backend the probes settle
+ * on their own schedule, often AFTER the file's jsdom environment is torn down,
+ * and the widget's post-teardown `setState` throws `ReferenceError: window is
+ * not defined` from react-dom's scheduler — which vitest reports as an unhandled
+ * error and fails the whole Client Tests shard even though every assertion
+ * passed.
+ *
+ * `stubOfflineAppFetch` keeps every request permanently pending (the same
+ * approach the wallpaper-manifest suite already uses): a request that never
+ * settles never rejects, so retry-on-failure components (the notification store)
+ * never enter a backoff-retry storm and nothing is left to setState after
+ * teardown. It is paired with `mockNeverTimeout` because three widgets
+ * (calendar-upcoming, model-download, agent-provisioning) wrap their probe in
+ * `withTimeout`, whose real timer WOULD fire seconds later — after teardown —
+ * and reject the otherwise-pending probe; the pass-through neutralises that
+ * timer so the probe simply stays pending too (see the inline
+ * `vi.mock("./utils/with-timeout", …)` in each suite — it must be hoisted, so it
+ * can't live here). Restore the fetch stub with `vi.unstubAllGlobals()` (the
+ * suites already do in `afterEach`).
+ */
+import { vi } from "vitest";
+
+export function stubOfflineAppFetch(): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((): Promise<Response> => new Promise<Response>(() => {})),
+  );
+}

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -237,6 +237,16 @@ export default defineConfig({
   },
   test: {
     setupFiles: ["./vitest.setup.ts"],
+    // Write worker console output straight to stdout instead of shipping every
+    // line to the main process over birpc. The heavy `<App />` suites emit
+    // console output (React act/unmounted-update warnings from data-loader
+    // effects that resolve after a test) right as the file's jsdom environment
+    // is torn down; an in-flight `onUserConsoleLog` RPC at that moment aborts
+    // with `EnvironmentTeardownError: Closing rpc while "onUserConsoleLog" was
+    // pending`, which vitest counts as an unhandled error and fails the whole
+    // shard even though every test passed. No test asserts through the intercept
+    // (they spy on `console` directly), so bypassing it is lossless here.
+    disableConsoleIntercept: true,
     pool: "forks",
     poolOptions: {
       forks: {


### PR DESCRIPTION
## What this fixes

The **Client Tests** lane's `@elizaos/ui#test` shard failed intermittently with
`Vitest caught N unhandled errors during the test run` (exit 1) **even though
every ui test file passed** (825 files, 0 assertion failures). Vitest fails a run
when an async error escapes a test's lifecycle. The shard had **three
independent, intermittent async leaks**; this PR removes all three at the source.
Every change is test-only (test files + a test helper + the vitest config) — no
runtime/UI surface change. Not caused by #16367 (the orchestrator-task-widget
test fully mocks its transport and never leaks).

### Fix 1 — `ReferenceError: window is not defined` from the slash-command probe tests

Two files render `useSlashCommandController`, whose catalog effect `setState`s
when its mocked fetch resolves. Their probe-gate tests `await` the fetch being
*called*, not the resulting state, and never unmount the root — so a React render
stays queued on `setImmediate` and flushes in a later node-env file (no
`window`), where react-dom's scheduler dereferences `window` and throws.
**Fix:** `cleanup()` in `afterEach` (cancels the queued scheduler callback).
Files: `useProtectedAgentProbesEnabled.test.tsx`, `useSlashCommandController.catalog.test.ts`.

### Fix 2 — `EnvironmentTeardownError: Closing rpc while "onUserConsoleLog" was pending`

The heavy `<App/>` suites emit console output (React warnings from late-resolving
effects) as the jsdom env tears down; the in-flight `onUserConsoleLog` birpc call
aborts. **Fix:** `test.disableConsoleIntercept: true` in `vitest.config.ts` —
worker console goes straight to stdout instead of over birpc (documented vitest
remedy). No test asserts through the intercept (`vi.spyOn(console,…)`), so it is
lossless.

### Fix 3 — `ReferenceError: window is not defined` from the full-`<App/>` fuzz suites

`App.screen-background-fuzz` / `App.surface-mutation-fuzz` /
`App.surface-manifest-wallpaper` mount the whole authenticated `<App/>`, which
renders ~two dozen home/shell widgets that each probe the agent on mount. With no
backend those probes settled after teardown and the widget's post-teardown
`setState` threw the same `window is not defined` (traced to
`components/chat/widgets/calendar-upcoming.tsx`). **Fix (test-only, no widget
surgery):**
- `stubOfflineAppFetch` (`test/offline-app-fetch.ts`): a **forever-pending**
  `fetch` — a request that never settles never rejects, so retry-on-failure
  components (the notification store) never enter a backoff-retry storm (which
  also OOM'd the heavy fuzz worker) and nothing is left to `setState` after
  teardown. Matches the approach `surface-manifest-wallpaper` already used inline.
- `vi.mock("./utils/with-timeout")` pass-through in each suite: the only three
  probing widgets that wrap their fetch in `withTimeout` (calendar-upcoming,
  model-download, agent-provisioning) would otherwise have `withTimeout`'s real
  timer fire seconds later — after teardown — and reject the pending probe. The
  pass-through drops the timer so those probes stay pending too.

The fuzz suites still assert exactly what they did (background/wallpaper/
surface-realm policy), all 20 of their tests pass, and they now run ~4x faster
(no real-timer waits / retry storms).

## Testing / evidence

Verified with the real CI command (`vitest run --config ./vitest.config.ts`, i.e.
`bun run --cwd packages/ui test`) on develop-tip, before vs. after.

- **Before:** intermittent exit 1. Observed failing classes across runs: (A)
  `window is not defined` from `useProtectedAgentProbesEnabled.test.tsx`; (B)
  `onUserConsoleLog` teardown error from `App.surface-mutation-fuzz.test.tsx`;
  (C) `window is not defined` from `App.screen-background-fuzz.test.tsx`
  (calendar-upcoming). Combined base failure rate ≈ 1 in 2 full runs.
- **After:** classes A + B verified across 26 full-suite runs + 15 heavy-`<App/>`
  harness runs (0 recurrences); the 3 full-`<App/>` fuzz files pass 20/20 in
  isolation with Fix 3 (no OOM, no retry storm); recent full-suite runs on this
  branch exit 0 / 825 pass / 0 unhandled. The authoritative full-shard gate is
  **this PR's own Client Tests CI shard**, which runs the exact real shard on the
  CI runner.

<details>
<summary>ui vitest output — before vs after (real CI command)</summary>

```
BEFORE (develop @ ccc78f53737), representative failing runs:
  exit=1  Vitest caught 3 unhandled errors
    ReferenceError: window is not defined
      at performWorkOnRootViaSchedulerTask (react-dom-client.development.js:18936)
    originated in "src/hooks/useProtectedAgentProbesEnabled.test.tsx"     (class A)
  exit=1  Vitest caught 2 unhandled errors
    EnvironmentTeardownError: Closing rpc while "onUserConsoleLog" was pending
    originated in "src/App.surface-mutation-fuzz.test.tsx"                 (class B)
  exit=1  Vitest caught 1 unhandled error
    ReferenceError: window is not defined
      at ... dispatchSetState -> src/components/chat/widgets/calendar-upcoming.tsx:243
    originated in "src/App.screen-background-fuzz.test.tsx"                (class C)

AFTER (all three fixes):
  3 fuzz files:  Test Files 3 passed (3)  Tests 20 passed (20)   (isolation, with Fix 3)
  A/B verification: 0 unhandled across 26 full-suite + 15 heavy-<App/> harness runs
  full-suite runs on this branch: exit=0, Test Files 825 passed (825), 0 unhandled
```
</details>

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only fix (test files + test helper + vitest config); no UI surface change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only fix (test files + test helper + vitest config); no UI surface change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - test-only fix; no user-facing flow. Evidence is the before/after ui vitest output above.
<!-- evidence-row:backend-logs -->
- [x] N/A - test-only fix (offline-fetch mock + withTimeout passthrough + cleanup); no backend code path. Verification: 3 fuzz files 20/20 in isolation + classes A/B 0/26 full-suite runs; full-shard verification is this PR's Client Tests CI. Before/after output in the details block above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no runtime frontend change; test-lifecycle-only fix.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain artifacts; the artifact is the green ui shard (before/after run output above).
