### PR TITLE
feat(cloud): stamp a per-minute cloud-api DB heartbeat (#16160, API side)

### DIFF
--- a/packages/cloud/shared/src/lib/services/cloud-api-db-heartbeat.test.ts
+++ b/packages/cloud/shared/src/lib/services/cloud-api-db-heartbeat.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Cloud-api DB heartbeat (#16160): the write upserts the reserved
+ * provider_health row and never throws (a missed beat only degrades the
+ * daemon's idle-vs-split discrimination); the read returns the row's
+ * updated_at or null when the row has never been written.
+ */
+import { describe, expect, mock, test } from "bun:test";
+import * as repoActual from "../../db/repositories/provider-health";
+
+let createOrUpdateImpl: (data: Record<string, unknown>) => Promise<unknown> = async () => ({});
+let findByProviderImpl: (provider: string) => Promise<unknown> = async () => undefined;
+
+mock.module("../../db/repositories/provider-health", () => ({
+  ...repoActual,
+  providerHealthRepository: {
+    createOrUpdate: (data: Record<string, unknown>) => createOrUpdateImpl(data),
+    findByProvider: (provider: string) => findByProviderImpl(provider),
+  },
+}));
+
+const { CLOUD_API_DB_HEARTBEAT_PROVIDER, readCloudApiDbHeartbeatAt, writeCloudApiDbHeartbeat } =
+  await import("./cloud-api-db-heartbeat");
+
+describe("cloud-api DB heartbeat (#16160)", () => {
+  test("write upserts the reserved provider row as healthy", async () => {
+    const writes: Record<string, unknown>[] = [];
+    createOrUpdateImpl = async (data) => {
+      writes.push(data);
+      return data;
+    };
+    await writeCloudApiDbHeartbeat();
+    expect(writes).toHaveLength(1);
+    expect(writes[0].provider).toBe(CLOUD_API_DB_HEARTBEAT_PROVIDER);
+    expect(writes[0].status).toBe("healthy");
+    expect(writes[0].last_checked).toBeInstanceOf(Date);
+  });
+
+  test("write never throws — a DB failure is logged, not propagated into the cron", async () => {
+    createOrUpdateImpl = async () => {
+      throw new Error("db down");
+    };
+    await expect(writeCloudApiDbHeartbeat()).resolves.toBeUndefined();
+  });
+
+  test("read returns the row's updated_at, and null when never written", async () => {
+    const beat = new Date("2026-07-15T12:00:00Z");
+    findByProviderImpl = async (provider) => {
+      expect(provider).toBe(CLOUD_API_DB_HEARTBEAT_PROVIDER);
+      return { updated_at: beat };
+    };
+    expect(await readCloudApiDbHeartbeatAt()).toEqual(beat);
+
+    findByProviderImpl = async () => undefined;
+    expect(await readCloudApiDbHeartbeatAt()).toBeNull();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/cloud-api-db-heartbeat.ts
+++ b/packages/cloud/shared/src/lib/services/cloud-api-db-heartbeat.ts
@@ -1,0 +1,55 @@
+/**
+ * Cloud-api → shared-DB heartbeat (#16160).
+ *
+ * The provisioning-worker daemon's DB-liveness check cannot distinguish a DB
+ * split (the daemon polls a database the cloud-api stopped writing to, #15160)
+ * from an idle environment (correct database, simply no provisioning traffic)
+ * using jobs-row age alone — both present as "the newest jobs row is old".
+ *
+ * This module gives the check a signal that survives idle: the per-minute
+ * `provisioning-worker-health` cron upserts this row on every fire regardless
+ * of provisioning traffic, and the daemon reads it. Fresh heartbeat ⇒ the
+ * daemon is on the same database the API writes to ⇒ old jobs mean idle, not
+ * split. Stale/absent heartbeat + old jobs ⇒ a real split (or the API is
+ * down) — warn loudly.
+ *
+ * Reuses the existing `provider_health` table (a keyed status row with an
+ * `updated_at` the repository refreshes on every upsert), so no migration on
+ * the shared database is needed.
+ */
+import { providerHealthRepository } from "../../db/repositories/provider-health";
+import { logger } from "../utils/logger";
+
+/** `provider_health.provider` key reserved for the cloud-api DB heartbeat. */
+export const CLOUD_API_DB_HEARTBEAT_PROVIDER = "cloud-api-db-heartbeat";
+
+/**
+ * Default freshness window (minutes) for the heartbeat. It is written every
+ * minute; 15 minutes tolerates cron hiccups and deploy gaps without going
+ * blind, while still detecting a split orders of magnitude faster than the
+ * 24h jobs-age threshold.
+ */
+export const DEFAULT_CLOUD_API_DB_HEARTBEAT_MAX_AGE_MINUTES = 15;
+
+/** Upsert the heartbeat row; never throws (a missed beat only delays idle-vs-split discrimination). */
+export async function writeCloudApiDbHeartbeat(): Promise<void> {
+  try {
+    await providerHealthRepository.createOrUpdate({
+      provider: CLOUD_API_DB_HEARTBEAT_PROVIDER,
+      status: "healthy",
+      last_checked: new Date(),
+    });
+  } catch (error) {
+    // The heartbeat must never break the health cron carrying it. When it is
+    // missing/stale the daemon falls back to today's jobs-age-only heuristic.
+    logger.warn("[CloudApiDbHeartbeat] Failed to write heartbeat", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/** Latest heartbeat write time, or null when the row has never been written. */
+export async function readCloudApiDbHeartbeatAt(): Promise<Date | null> {
+  const row = await providerHealthRepository.findByProvider(CLOUD_API_DB_HEARTBEAT_PROVIDER);
+  return row?.updated_at ?? null;
+}

--- a/packages/cloud/shared/src/lib/services/provisioning-worker-health-monitor.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-worker-health-monitor.test.ts
@@ -49,6 +49,7 @@ describe("monitorProvisioningWorkerHealth", () => {
     const { alerts, alert } = captureAlerts();
     const health: ProvisioningWorkerHealth = { ok: true, required: false };
     const result = await monitorProvisioningWorkerHealth({
+      writeDbHeartbeat: async () => {},
       check: async () => health,
       alert,
       now: () => NOW,
@@ -66,6 +67,7 @@ describe("monitorProvisioningWorkerHealth", () => {
       lastHeartbeatAt: new Date(NOW - 1_000).toISOString(),
     };
     const result = await monitorProvisioningWorkerHealth({
+      writeDbHeartbeat: async () => {},
       check: async () => health,
       alert,
       now: () => NOW,
@@ -85,6 +87,7 @@ describe("monitorProvisioningWorkerHealth", () => {
       error: "Provisioning worker has not reported a heartbeat in the last 60 seconds.",
     };
     const result = await monitorProvisioningWorkerHealth({
+      writeDbHeartbeat: async () => {},
       check: async () => health,
       alert,
       now: () => NOW,
@@ -102,6 +105,7 @@ describe("monitorProvisioningWorkerHealth", () => {
       lastHeartbeatAt: new Date(NOW - HEARTBEAT_MAX_AGE_MS - 10_000).toISOString(),
     };
     const result = await monitorProvisioningWorkerHealth({
+      writeDbHeartbeat: async () => {},
       check: async () => health,
       alert,
       now: () => NOW,
@@ -110,5 +114,65 @@ describe("monitorProvisioningWorkerHealth", () => {
     expect(result.stale).toBe(true);
     expect(alerts).toHaveLength(1);
     expect(alerts[0].details.code).toBe("PROVISIONING_WORKER_STALE_HEARTBEAT");
+  });
+
+  // #16160: this per-minute monitor doubles as the cloud-api DB heartbeat
+  // writer the provisioning-worker daemon reads to tell idle from split — it
+  // must stamp the heartbeat on EVERY invocation, including the not-required
+  // early return (the daemon may be optional while the DB signal still matters).
+  it("stamps the DB heartbeat on every invocation, even when the daemon is not required", async () => {
+    let writes = 0;
+    const health: ProvisioningWorkerHealth = { ok: true, required: false };
+    await monitorProvisioningWorkerHealth({
+      writeDbHeartbeat: async () => {
+        writes += 1;
+      },
+      check: async () => health,
+      alert: async () => {},
+      now: () => NOW,
+    });
+    expect(writes).toBe(1);
+  });
+
+  it("sendProvisioningWorkerAlert posts to every configured channel and resolves without any", async () => {
+    const { sendProvisioningWorkerAlert } = await import("./provisioning-worker-health-monitor");
+    const prevSlack = process.env.PROVISIONING_ALERT_SLACK_WEBHOOK;
+    const prevPd = process.env.PROVISIONING_ALERT_PAGERDUTY_KEY;
+    const realFetch = globalThis.fetch;
+    const posted: string[] = [];
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      posted.push(String(url));
+      return new Response("ok");
+    }) as typeof fetch;
+    try {
+      // No channels configured: structured log only, no fetch, no throw.
+      delete process.env.PROVISIONING_ALERT_SLACK_WEBHOOK;
+      delete process.env.PROVISIONING_ALERT_PAGERDUTY_KEY;
+      await sendProvisioningWorkerAlert({
+        title: "t",
+        message: "m",
+        details: { code: "TEST" },
+      });
+      expect(posted).toHaveLength(0);
+
+      // Both channels configured: one POST each (Slack webhook + PagerDuty).
+      process.env.PROVISIONING_ALERT_SLACK_WEBHOOK = "https://hooks.slack.example/T/B/x";
+      process.env.PROVISIONING_ALERT_PAGERDUTY_KEY = "pd-routing-key";
+      await sendProvisioningWorkerAlert({
+        title: "t",
+        message: "m",
+        details: { code: "TEST" },
+        dedupKey: "test-dedup",
+      });
+      expect(posted).toHaveLength(2);
+      expect(posted[0]).toBe("https://hooks.slack.example/T/B/x");
+      expect(posted[1]).toBe("https://events.pagerduty.com/v2/enqueue");
+    } finally {
+      globalThis.fetch = realFetch;
+      if (prevSlack === undefined) delete process.env.PROVISIONING_ALERT_SLACK_WEBHOOK;
+      else process.env.PROVISIONING_ALERT_SLACK_WEBHOOK = prevSlack;
+      if (prevPd === undefined) delete process.env.PROVISIONING_ALERT_PAGERDUTY_KEY;
+      else process.env.PROVISIONING_ALERT_PAGERDUTY_KEY = prevPd;
+    }
   });
 });

--- a/packages/cloud/shared/src/lib/services/provisioning-worker-health-monitor.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-worker-health-monitor.ts
@@ -16,6 +16,7 @@
  */
 
 import { logger } from "../utils/logger";
+import { writeCloudApiDbHeartbeat } from "./cloud-api-db-heartbeat";
 import {
   checkProvisioningWorkerHealth,
   PROVISIONING_WORKER_HEARTBEAT_TTL_S,
@@ -141,11 +142,17 @@ export async function monitorProvisioningWorkerHealth(
     check?: () => Promise<ProvisioningWorkerHealth>;
     alert?: (alert: DaemonHealthAlert) => void | Promise<void>;
     now?: () => number;
+    writeDbHeartbeat?: () => Promise<void>;
   } = {},
 ): Promise<{ healthy: boolean; stale: boolean; health: ProvisioningWorkerHealth }> {
   const check = deps.check ?? checkProvisioningWorkerHealth;
   const alert = deps.alert ?? sendProvisioningWorkerAlert;
   const nowMs = (deps.now ?? Date.now)();
+
+  // #16160: this cron fires every minute regardless of provisioning traffic —
+  // stamp the shared-DB heartbeat the daemon's DB-liveness check reads to tell
+  // an idle env apart from a DB split. Never throws (logged inside).
+  await (deps.writeDbHeartbeat ?? writeCloudApiDbHeartbeat)();
 
   const health = await check();
 


### PR DESCRIPTION
# Relates to

Refs #16160 (API side — the daemon-side consumer follows separately; see Scope).

- [x] Targets `develop`, rebased on latest `origin/develop`, zero conflicts.
- [x] A reviewer can confirm the change from the evidence below without reading the code.

# Risks

Low. One additional single-row upsert per minute on the existing `provider_health` table (reserved key `cloud-api-db-heartbeat`), injected into the existing per-minute monitor. The write never throws; a failure is logged and the daemon side (when it lands) falls back to today's jobs-age heuristic. **No migration** — the shared database schema is untouched.

# Background

## What does this PR do?

The provisioning-worker daemon's DB-liveness check (#15160's guard) cannot distinguish a **DB split** (the daemon polls a database the cloud-api stopped writing to) from an **idle environment** — both present as "the newest jobs row is old". On staging this fires **~288 false error events/day** on a healthy daemon, training operators to ignore the exact signal that exists to catch the next #15160 (alarm fatigue defeats the check).

This is the API half of the fix from #16160's spec: the per-minute `provisioning-worker-health` cron now stamps a DB heartbeat (a reserved `provider_health` row, `updated_at` refreshed on every upsert) on the same database it writes jobs to — a signal that survives idle. The daemon half (verdict `split|idle|healthy` from jobs age + heartbeat freshness) follows in a companion PR; the heartbeat must be accruing before the daemon reads it, so this side lands first.

## Scope

- `cloud-api-db-heartbeat.ts` — reserved key, freshness default, `write` (never throws) + `read` helpers, contract in one module.
- `provisioning-worker-health-monitor.ts` — stamps the heartbeat on every invocation (injectable for tests), including the daemon-not-required early return.

## What kind of change is this?

Feature / ops-observability groundwork (non-breaking; additive single-row write).

# Documentation changes needed?

No (module-level docs carry the contract).

# Testing

## Where should a reviewer start?

`cloud-api-db-heartbeat.ts` (57 lines) then the 4-line wiring in the monitor. Pinned by both test files.

## Detailed testing steps

None — unit tests cover it.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] `N/A - backend cron/service in packages/cloud/shared; no UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - backend cron/service; no UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; a per-minute DB heartbeat stamp.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - no deployed backend to log; the write/read/never-throws contract is asserted by the unit runs under Evidence Details (repository mocked at the module seam).`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend involvement.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/model behavior; infra heartbeat plumbing.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - the produced artifact is one provider_health row per environment, refreshed in place each minute; asserted at the unit level.`

# Evidence Details

## Backend + frontend logs

<details><summary>Unit runs — heartbeat contract + monitor wiring (14/14 pass)</summary>

```
cloud-api DB heartbeat (#16160)
  ✓ write upserts the reserved provider row as healthy
  ✓ write never throws — a DB failure is logged, not propagated into the cron
  ✓ read returns the row's updated_at, and null when never written
monitorProvisioningWorkerHealth
  … 4 pre-existing cases (not-required, fresh, absent, stale heartbeat)
  ✓ stamps the DB heartbeat on every invocation, even when the daemon is not required
  ✓ sendProvisioningWorkerAlert posts to every configured channel and resolves without any
isHeartbeatStale
  … 5 pre-existing cases

 14 pass
 0 fail
```

</details>

Typecheck: `tsgo --noEmit` clean across `packages/cloud/shared` (0 errors). Biome (2.5.1) clean. Whole-file coverage from the changed-test lane: `cloud-api-db-heartbeat.ts` 100%, `provisioning-worker-health-monitor.ts` 98.8%.

[stan-cloud]
