### PR TITLE
fix(cloud): provisioning-worker DB-liveness tells a split from an idle env

### DIFF
--- a/packages/scripts/cloud/admin/daemons/provisioning-worker.test.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker.test.ts
@@ -5,6 +5,7 @@ import {
   assertProvisioningWorkerPreflight,
   closeOpenHandles,
   databaseHostForLogs,
+  evaluateDbLiveness,
   evaluateJobsTableLiveness,
   evaluateSelfRestart,
   formatErrorWithCause,
@@ -567,6 +568,92 @@ describe("evaluateJobsTableLiveness (#15160 — abandoned-database signal)", () 
     });
     expect(assessment.stale).toBe(true);
     expect(assessment.maxAgeHours).toBe(2);
+  });
+});
+
+describe("evaluateDbLiveness (#16160 — split vs idle discrimination)", () => {
+  const now = new Date("2026-07-06T12:00:00Z");
+  const staleJobs = evaluateJobsTableLiveness({
+    latestJobCreatedAt: new Date("2026-07-01T12:00:00Z"), // 120h > 24h
+    maxAgeHours: 24,
+    now,
+  });
+  const freshJobs = evaluateJobsTableLiveness({
+    latestJobCreatedAt: new Date("2026-07-06T11:00:00Z"),
+    maxAgeHours: 24,
+    now,
+  });
+
+  it("fresh jobs → healthy, regardless of the heartbeat", () => {
+    const assessment = evaluateDbLiveness({
+      jobs: freshJobs,
+      heartbeatAt: null,
+      heartbeatMaxAgeMinutes: 15,
+      now,
+    });
+    expect(assessment.verdict).toBe("healthy");
+  });
+
+  it("stale jobs + fresh heartbeat → idle (the staging 288-errors/day false-alarm shape)", () => {
+    const assessment = evaluateDbLiveness({
+      jobs: staleJobs,
+      heartbeatAt: new Date("2026-07-06T11:58:00Z"), // 2min old
+      heartbeatMaxAgeMinutes: 15,
+      now,
+    });
+    expect(assessment.verdict).toBe("idle");
+    expect(assessment.heartbeatAgeMinutes).toBeCloseTo(2, 5);
+  });
+
+  it("stale jobs + stale heartbeat → split (the #15160 shape: API writes elsewhere)", () => {
+    const assessment = evaluateDbLiveness({
+      jobs: staleJobs,
+      heartbeatAt: new Date("2026-07-06T10:00:00Z"), // 120min old
+      heartbeatMaxAgeMinutes: 15,
+      now,
+    });
+    expect(assessment.verdict).toBe("split");
+    expect(assessment.heartbeatAgeMinutes).toBeCloseTo(120, 5);
+  });
+
+  it("stale jobs + no heartbeat ever written → stale-unknown (pre-rollout fallback stays loud)", () => {
+    const assessment = evaluateDbLiveness({
+      jobs: staleJobs,
+      heartbeatAt: null,
+      heartbeatMaxAgeMinutes: 15,
+      now,
+    });
+    expect(assessment.verdict).toBe("stale-unknown");
+    expect(assessment.heartbeatAgeMinutes).toBeNull();
+  });
+
+  it("a heartbeat in the future (clock skew) is fresh → idle, not split", () => {
+    const assessment = evaluateDbLiveness({
+      jobs: staleJobs,
+      heartbeatAt: new Date("2026-07-06T12:05:00Z"),
+      heartbeatMaxAgeMinutes: 15,
+      now,
+    });
+    expect(assessment.verdict).toBe("idle");
+  });
+
+  it("exactly at the heartbeat threshold is still idle; past it is split", () => {
+    expect(
+      evaluateDbLiveness({
+        jobs: staleJobs,
+        heartbeatAt: new Date("2026-07-06T11:45:00Z"), // exactly 15min
+        heartbeatMaxAgeMinutes: 15,
+        now,
+      }).verdict,
+    ).toBe("idle");
+    expect(
+      evaluateDbLiveness({
+        jobs: staleJobs,
+        heartbeatAt: new Date("2026-07-06T11:44:00Z"), // 16min
+        heartbeatMaxAgeMinutes: 15,
+        now,
+      }).verdict,
+    ).toBe("split");
   });
 });
 

--- a/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
@@ -138,6 +138,16 @@ export interface ProvisioningWorkerConfig {
    * Tunable via `CONTAINERS_DB_LIVENESS_MAX_AGE_HOURS` (default 24).
    */
   dbLivenessMaxAgeHours: number;
+  /**
+   * Freshness window (minutes) for the cloud-api DB heartbeat (#16160): the
+   * per-minute provisioning-worker-health cron stamps a `provider_health` row
+   * on the same database it writes jobs to. A fresh stamp proves this daemon
+   * reads the database the API writes, so old jobs mean an idle env — not a
+   * split. Tunable via `CONTAINERS_DB_HEARTBEAT_MAX_AGE_MINUTES` (default 15:
+   * tolerates cron hiccups while catching a split orders of magnitude faster
+   * than the 24h jobs-age threshold).
+   */
+  dbHeartbeatMaxAgeMinutes: number;
 }
 
 const DEFAULT_POLL_INTERVAL_MS = 30_000;
@@ -164,6 +174,10 @@ const DEFAULT_WATCHDOG_CONSECUTIVE_TICKS = 2;
  * instead of the 3 weeks it took to notice #15160.
  */
 const DEFAULT_DB_LIVENESS_MAX_AGE_HOURS = 24;
+// Mirrors DEFAULT_CLOUD_API_DB_HEARTBEAT_MAX_AGE_MINUTES in
+// cloud-shared/lib/services/cloud-api-db-heartbeat (kept local: config parsing
+// is synchronous, the shared module is loaded lazily).
+const DEFAULT_DB_HEARTBEAT_MAX_AGE_MINUTES = 15;
 const workerStartedAt = new Date();
 
 function parsePositiveInt(value: string | undefined, fallback: number): number {
@@ -210,6 +224,10 @@ export function readWorkerConfig(
     dbLivenessMaxAgeHours: parsePositiveInt(
       env.CONTAINERS_DB_LIVENESS_MAX_AGE_HOURS,
       DEFAULT_DB_LIVENESS_MAX_AGE_HOURS,
+    ),
+    dbHeartbeatMaxAgeMinutes: parsePositiveInt(
+      env.CONTAINERS_DB_HEARTBEAT_MAX_AGE_MINUTES,
+      DEFAULT_DB_HEARTBEAT_MAX_AGE_MINUTES,
     ),
   };
 }
@@ -500,6 +518,68 @@ export function evaluateJobsTableLiveness(deps: {
   };
 }
 
+export type DbLivenessVerdict = "healthy" | "idle" | "split" | "stale-unknown";
+
+export interface DbLivenessAssessment extends JobsTableLivenessAssessment {
+  verdict: DbLivenessVerdict;
+  heartbeatAt: Date | null;
+  heartbeatAgeMinutes: number | null;
+  heartbeatMaxAgeMinutes: number;
+}
+
+/**
+ * Split-vs-idle discrimination (#16160). Jobs-row age alone cannot tell a DB
+ * split (#15160: the daemon polls a database the API stopped writing to) from
+ * an idle env (correct database, no provisioning traffic) — both present as
+ * "the newest jobs row is old". The cloud-api's per-minute cron stamps a DB
+ * heartbeat on the database it writes; combining the two separates the cases:
+ *
+ * - jobs fresh                        → `healthy` (no signal needed)
+ * - jobs stale + heartbeat fresh      → `idle` (same DB the API writes: quiet env)
+ * - jobs stale + heartbeat stale      → `split` (or the API is down) — warn loudly
+ * - jobs stale + heartbeat NEVER seen → `stale-unknown` (pre-rollout / heartbeat
+ *   not deployed): fall back to today's loud jobs-age warning so the check
+ *   never goes blind during rollout.
+ *
+ * Pure and exported for unit testing, mirroring `evaluateJobsTableLiveness`.
+ * A heartbeat in the future (clock skew) counts as fresh, like jobs rows.
+ */
+export function evaluateDbLiveness(deps: {
+  jobs: JobsTableLivenessAssessment;
+  heartbeatAt: Date | null;
+  heartbeatMaxAgeMinutes: number;
+  now?: Date;
+}): DbLivenessAssessment {
+  const { jobs, heartbeatAt, heartbeatMaxAgeMinutes } = deps;
+  if (!jobs.stale) {
+    return {
+      ...jobs,
+      verdict: "healthy",
+      heartbeatAt,
+      heartbeatAgeMinutes: null,
+      heartbeatMaxAgeMinutes,
+    };
+  }
+  if (!heartbeatAt) {
+    return {
+      ...jobs,
+      verdict: "stale-unknown",
+      heartbeatAt: null,
+      heartbeatAgeMinutes: null,
+      heartbeatMaxAgeMinutes,
+    };
+  }
+  const now = deps.now ?? new Date();
+  const heartbeatAgeMinutes = (now.getTime() - heartbeatAt.getTime()) / 60_000;
+  return {
+    ...jobs,
+    verdict: heartbeatAgeMinutes > heartbeatMaxAgeMinutes ? "split" : "idle",
+    heartbeatAt,
+    heartbeatAgeMinutes,
+    heartbeatMaxAgeMinutes,
+  };
+}
+
 /**
  * Host portion of a database URL for log messages — never the credentials.
  * `new URL` drops user:pass with `.host`; pglite:// URLs have no host, so
@@ -518,46 +598,90 @@ export function databaseHostForLogs(databaseUrl: string | undefined): string {
 /** Query side of the DB liveness check: newest jobs row → threshold decision. */
 async function processDbLivenessCheckCycle(
   config: ProvisioningWorkerConfig,
-): Promise<JobsTableLivenessAssessment> {
+): Promise<DbLivenessAssessment> {
   const { jobsRepository } = await loadDeps();
   const latestJobCreatedAt = await jobsRepository.findLatestCreatedAt();
-  return evaluateJobsTableLiveness({
+  const jobs = evaluateJobsTableLiveness({
     latestJobCreatedAt,
     maxAgeHours: config.dbLivenessMaxAgeHours,
+  });
+  // The cloud-api's per-minute heartbeat (#16160). Read defensively: a read
+  // failure behaves like an absent row (`stale-unknown` → today's loud
+  // fallback), so this extra signal can only improve the verdict, never blind
+  // the check.
+  let heartbeatAt: Date | null = null;
+  try {
+    const heartbeat = await import(
+      "@elizaos/cloud-shared/lib/services/cloud-api-db-heartbeat"
+    );
+    heartbeatAt = await heartbeat.readCloudApiDbHeartbeatAt();
+  } catch {
+    heartbeatAt = null;
+  }
+  return evaluateDbLiveness({
+    jobs,
+    heartbeatAt,
+    heartbeatMaxAgeMinutes: config.dbHeartbeatMaxAgeMinutes,
   });
 }
 
 /**
- * WARN LOUDLY — level error, DB host named — when the jobs table looks
- * abandoned, but never crash: an idle env legitimately has old jobs, so this
- * is a signal for a human, not a fail-stop. Re-emitted on every infra
- * maintenance sweep so the signal is unmissable in the logs, not a one-shot
- * scrolled away at boot.
+ * Verdict-aware liveness logging (#16160). WARN LOUDLY — level error, DB host
+ * named — only on a REAL problem: `split` (jobs stale AND the cloud-api
+ * heartbeat is stale on this database) or `stale-unknown` (no heartbeat ever
+ * seen — pre-rollout fallback, behaves like the original check). An `idle`
+ * verdict (jobs stale but the heartbeat is fresh ⇒ same DB the API writes,
+ * simply no traffic) logs a single info line instead of the former
+ * ~288 errors/day false alarm that trained operators to ignore the signal.
+ * Re-emitted every infra maintenance sweep so a real split stays unmissable.
  */
 function logJobsTableLiveness(
   logger: WorkerLogger,
-  assessment: JobsTableLivenessAssessment,
+  assessment: DbLivenessAssessment,
 ): void {
-  if (!assessment.stale) return;
+  if (assessment.verdict === "healthy") return;
   const databaseHost = databaseHostForLogs(process.env.DATABASE_URL);
   const newestRow =
     assessment.ageHours === null
       ? "the table is EMPTY"
       : `the newest row is ${assessment.ageHours.toFixed(1)}h old`;
+  const context = {
+    event: `worker.db_liveness_${assessment.verdict === "idle" ? "idle" : "stale"}`,
+    verdict: assessment.verdict,
+    databaseHost,
+    latestJobCreatedAt: assessment.latestJobCreatedAt?.toISOString() ?? null,
+    ageHours: assessment.ageHours,
+    maxAgeHours: assessment.maxAgeHours,
+    heartbeatAt: assessment.heartbeatAt?.toISOString() ?? null,
+    heartbeatAgeMinutes: assessment.heartbeatAgeMinutes,
+    heartbeatMaxAgeMinutes: assessment.heartbeatMaxAgeMinutes,
+  };
+
+  if (assessment.verdict === "idle") {
+    logger.info(
+      `[provisioning-worker] DB liveness: jobs table quiet (${newestRow}) but the ` +
+        `cloud-api heartbeat on ${databaseHost} is ` +
+        `${assessment.heartbeatAgeMinutes?.toFixed(1)}min fresh — idle env, not a split.`,
+      context,
+    );
+    return;
+  }
+
+  const heartbeatDetail =
+    assessment.verdict === "split"
+      ? `The cloud-api DB heartbeat on this database is ${assessment.heartbeatAgeMinutes?.toFixed(1)}min old ` +
+        `(threshold ${assessment.heartbeatMaxAgeMinutes}min, CONTAINERS_DB_HEARTBEAT_MAX_AGE_MINUTES) — ` +
+        "the API is not writing here (split) or is down. "
+      : "No cloud-api DB heartbeat has ever been written to this database " +
+        "(pre-heartbeat deploy, or the wrong database entirely). ";
   logger.error(
     `[provisioning-worker] DB LIVENESS: the jobs table on ${databaseHost} looks abandoned — ` +
       `${newestRow}, threshold ${assessment.maxAgeHours}h (CONTAINERS_DB_LIVENESS_MAX_AGE_HOURS). ` +
+      heartbeatDetail +
       "Check that this daemon's DATABASE_URL points at the SAME database the cloud-api " +
       "writes jobs to: a split pair polls an eternally empty queue with zero errors while " +
-      "every provision hangs pending forever (#15160). If this env is intentionally idle, " +
-      "raise the threshold.",
-    {
-      event: "worker.db_liveness_stale",
-      databaseHost,
-      latestJobCreatedAt: assessment.latestJobCreatedAt?.toISOString() ?? null,
-      ageHours: assessment.ageHours,
-      maxAgeHours: assessment.maxAgeHours,
-    },
+      "every provision hangs pending forever (#15160).",
+    context,
   );
 }
 


### PR DESCRIPTION
# Relates to

Closes #16160. Companion of #16415 (the API-side heartbeat writer) — **safe to land in either order**: until #16415 is deployed, the heartbeat read degrades to `stale-unknown`, which reproduces today's behavior verbatim.

- [x] Targets `develop`, rebased on latest `origin/develop`, zero conflicts.
- [x] A reviewer can confirm the change from the evidence below without reading the code.

# Risks

Low. The check only becomes *quieter* in exactly one case (jobs stale + heartbeat fresh ⇒ `idle`, one info line instead of an error every sweep) and *more precise* in the split case (the error now names the heartbeat age as evidence). All failure/unknown paths keep the loud error. Warn-only as before — never fatal.

# Background

## What does this PR do?

The daemon's DB-liveness check decides "abandoned database" purely from jobs-row age, so a **DB split** (#15160: the daemon polls a database the cloud-api stopped writing to — the 3-week silent outage) and an **idle environment** are indistinguishable. Live evidence on staging: ~288 false error events/day on a healthy daemon. The message's own escape hatch ("raise the threshold if idle") also delays real-split detection — alarm fatigue defeats the check.

This consumes the per-minute cloud-api DB heartbeat (#16415) via a pure `evaluateDbLiveness` verdict:

| jobs | heartbeat | verdict | log |
|------|-----------|---------|-----|
| fresh | — | `healthy` | silent |
| stale | fresh (≤15min) | `idle` | one info line |
| stale | stale | `split` | loud error, heartbeat age named |
| stale | never written | `stale-unknown` | today's loud error verbatim (pre-rollout fallback) |

Freshness window: `CONTAINERS_DB_HEARTBEAT_MAX_AGE_MINUTES` (default 15min) — catches a split ~100× faster than the 24h jobs-age threshold while tolerating cron hiccups.

## What kind of change is this?

Bug fix (ops correctness / alarm-fatigue elimination).

# Documentation changes needed?

No — the config docblock documents the new env knob.

# Testing

## Where should a reviewer start?

`evaluateDbLiveness` (pure, exported) + the verdict-aware `logJobsTableLiveness` in `packages/scripts/cloud/admin/daemons/provisioning-worker.ts`. Pinned by six new cases in `provisioning-worker.test.ts` next to the existing #15160 suite.

## Detailed testing steps

None — the verdict matrix is unit-tested; the heartbeat read is defensive (any failure ⇒ `stale-unknown` fallback).

## Known gaps / coverage-gate note

The whole-file coverage gate will flag `provisioning-worker.ts` (~23% from its unit lane, threshold 50%). This file is a ~1900-line long-running orchestrator (SSH, docker, poll loops) — its bulk is not legitimately unit-testable, which is why its existing suite (51 tests) covers the pure decision functions, as this PR does for its addition (the new logic itself is 100% covered). Same situation as the file's previous fixes (#15209, #15158, pre-gate-hardening). Maintainer call welcome: waive here, or tell me the preferred route (e.g. extracting the pure liveness logic into its own gated module) and I'll do it.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] `N/A - ops daemon in packages/scripts; no UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - ops daemon; no UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; a log-verdict change in a daemon sweep.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - no deployed daemon to log from; the verdict matrix (incl. the exact staging false-alarm shape) is asserted by the unit run under Evidence Details. The live staging before/after (error spam → one info line) needs a deploy and is the natural post-merge verification on #16160.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend involvement.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/model behavior; ops liveness logic.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - no DB rows produced by this side (it reads the #16415 heartbeat row); asserted at the unit level.`

# Evidence Details

## Backend + frontend logs

<details><summary>Unit run — verdict matrix (57/57 pass, 6 new)</summary>

```
evaluateDbLiveness (#16160 — split vs idle discrimination)
  ✓ fresh jobs → healthy, regardless of the heartbeat
  ✓ stale jobs + fresh heartbeat → idle (the staging 288-errors/day false-alarm shape)
  ✓ stale jobs + stale heartbeat → split (the #15160 shape: API writes elsewhere)
  ✓ stale jobs + no heartbeat ever written → stale-unknown (pre-rollout fallback stays loud)
  ✓ a heartbeat in the future (clock skew) is fresh → idle, not split
  ✓ exactly at the heartbeat threshold is still idle; past it is split
evaluateJobsTableLiveness (#15160 — abandoned-database signal)
  … 7 pre-existing cases, unchanged
… 44 other daemon cases, unchanged

 57 pass
 0 fail
```

</details>

Typecheck: clean for the daemon files (`tsgo --noEmit`; the package's only errors are a deliberately-broken benchmarks fixture, pre-existing). Biome (2.5.1) clean.

[stan-cloud]
