### PR TITLE
fix(ci): coverage gate excuses config-excluded files visibly, not MISSING

### DIFF
--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -182,8 +182,12 @@ jobs:
             echo "changed tests ran but no coverage/lcov.info files were produced"
             exit 1
           fi
+          # Files coverage collection cannot instrument (#16409): their LCOV
+          # absence is expected — the gate prints EXCLUDED instead of MISSING.
+          LCOV_EXCLUDED_FILES=$(grep -vE '^#|^$' scripts/security/coverage-lcov-excluded.txt || true)
           awk \
             -v changed="${{ steps.changed.outputs.files }}" \
             -v threshold=50 \
+            -v excluded="$LCOV_EXCLUDED_FILES" \
             -f scripts/security/coverage-gate.awk \
             "${lcov_files[@]}"

--- a/scripts/security/coverage-gate.awk
+++ b/scripts/security/coverage-gate.awk
@@ -7,7 +7,15 @@
 #
 # Usage:
 #   awk -v changed="$CHANGED_FILES" -v threshold=70 \
+#       [-v excluded="$LCOV_EXCLUDED_FILES"] \
 #       -f scripts/security/coverage-gate.awk coverage/lcov.info
+#
+# `excluded` (newline-separated) lists files that CANNOT appear in an LCOV
+# report (coverage collection fails on them; see
+# scripts/security/coverage-lcov-excluded.txt, #16409). A changed file on that
+# list that is absent from LCOV prints a visible EXCLUDED line instead of the
+# fail-closed MISSING. If such a file DOES appear in LCOV (collection got
+# fixed), it is gated normally — the escape hatch expires by itself.
 
 BEGIN {
   if (threshold == "") threshold = 70
@@ -18,6 +26,16 @@ BEGIN {
     if (parts[i] != "") {
       gsub(/\\/, "/", parts[i])
       changed_map[parts[i]] = 1
+    }
+  }
+  # Files that can never appear in LCOV (#16409): absence is expected, not a
+  # gate failure. Presence still gates normally.
+  if (excluded == "") excluded = ""
+  n = split(excluded, parts, "\n")
+  for (i = 1; i <= n; i++) {
+    if (parts[i] != "") {
+      gsub(/\\/, "/", parts[i])
+      excluded_map[parts[i]] = 1
     }
   }
 }
@@ -88,6 +106,12 @@ END {
   changed_sum = 0
   for (f in changed_map) {
     if (!(f in file_pct)) {
+      if (f in excluded_map) {
+        # Fail-open but VISIBLE: the file is on the reviewed exclusion manifest
+        # because coverage collection cannot instrument it (#16409).
+        printf "  EXCLUDED (cannot appear in LCOV, see scripts/security/coverage-lcov-excluded.txt): %s\n", f
+        continue
+      }
       printf "  MISSING: %s\n", f
       missing_count++
     } else {

--- a/scripts/security/coverage-gate.self-test.mjs
+++ b/scripts/security/coverage-gate.self-test.mjs
@@ -51,8 +51,11 @@ function writeLcovAs(dir, name, sourcePath, found, hit) {
   return file;
 }
 
-function runGate({ changed, lcov, enforce = true, threshold = 50 }) {
+function runGate({ changed, lcov, enforce = true, threshold = 50, excluded = "" }) {
   const changedArgument = changed
+    .replaceAll("\\", "\\\\")
+    .replaceAll("\n", "\\n");
+  const excludedArgument = excluded
     .replaceAll("\\", "\\\\")
     .replaceAll("\n", "\\n");
   const lcovArgs = Array.isArray(lcov) ? lcov : [lcov];
@@ -63,6 +66,8 @@ function runGate({ changed, lcov, enforce = true, threshold = 50 }) {
       `changed=${changedArgument}`,
       "-v",
       `threshold=${threshold}`,
+      "-v",
+      `excluded=${excludedArgument}`,
       "-f",
       awkScript,
       ...lcovArgs,
@@ -185,6 +190,54 @@ try {
         result.stdout,
         /BELOW: packages\/core\/src\/features\/documents\/service\.ts/,
       );
+    },
+  );
+  assertGate(
+    "excluded changed file absent from LCOV passes with a visible EXCLUDED line (#16409)",
+    () => {
+      // eliza.ts cannot be instrumented; only foo.ts appears in LCOV.
+      const lcov = writeLcov(dir, "packages/demo/src/foo.ts");
+      const result = runGate({
+        changed: "packages/demo/src/foo.ts\npackages/agent/src/runtime/eliza.ts",
+        lcov,
+        excluded: "packages/agent/src/runtime/eliza.ts",
+      });
+      assert.equal(result.status, 0, result.stdout);
+      assert.match(
+        result.stdout,
+        /EXCLUDED \(cannot appear in LCOV.*\): packages\/agent\/src\/runtime\/eliza\.ts/,
+      );
+      assert.doesNotMatch(result.stdout, /MISSING/);
+    },
+  );
+
+  assertGate(
+    "an excluded file that DOES appear in LCOV is gated normally (#16409 — the escape expires)",
+    () => {
+      // Collection got fixed: the file shows up at 25% — below the floor, so
+      // the manifest entry must NOT shield it.
+      const lcov = writeLcov(dir, "packages/agent/src/runtime/eliza.ts", 100, 25);
+      const result = runGate({
+        changed: "packages/agent/src/runtime/eliza.ts",
+        lcov,
+        excluded: "packages/agent/src/runtime/eliza.ts",
+      });
+      assert.equal(result.status, 1, result.stdout);
+      assert.match(result.stdout, /BELOW: packages\/agent\/src\/runtime\/eliza\.ts/);
+    },
+  );
+
+  assertGate(
+    "a non-excluded absent file still hard-fails as MISSING (#16409 — no blanket fail-open)",
+    () => {
+      const lcov = writeLcov(dir, "packages/demo/src/foo.ts");
+      const result = runGate({
+        changed: "packages/demo/src/bar.ts",
+        lcov,
+        excluded: "packages/agent/src/runtime/eliza.ts",
+      });
+      assert.equal(result.status, 1, result.stdout);
+      assert.match(result.stdout, /MISSING: packages\/demo\/src\/bar\.ts/);
     },
   );
 } finally {

--- a/scripts/security/coverage-lcov-excluded.txt
+++ b/scripts/security/coverage-lcov-excluded.txt
@@ -1,0 +1,18 @@
+# Files that CANNOT appear in an LCOV report, so the enforced changed-file
+# coverage gate must not hard-fail them as MISSING (#16409). The gate prints a
+# visible "EXCLUDED (cannot appear in LCOV)" line for these instead — fail-open
+# but auditable, and this manifest is code-reviewed like any source change.
+#
+# Every entry needs a reason and is meant to be DELETED: the real fix is making
+# coverage collection work on the file. If an entry's file starts appearing in
+# LCOV again, the gate automatically resumes gating it (presence always gates;
+# only absence is excused).
+#
+# Rolldown coverage instrumentation fails on these inline type-import files.
+# The vitest base config (packages/test/vitest/default.config.ts) carries
+# matching coverage.exclude entries — note those still use a stale `eliza/`
+# wrapper-repo path prefix, so the files' LCOV absence in practice comes from
+# the collection failure itself, not the config. Either way: structurally
+# absent until the Rolldown issue is fixed.
+packages/agent/src/api/server.ts
+packages/agent/src/runtime/eliza.ts


### PR DESCRIPTION
# Relates to

Closes #16409

- [x] Targets `develop`, rebased on latest `origin/develop`, zero conflicts.
- [x] A reviewer can confirm the change from the evidence below without reading the code.

# Risks

Low, and deliberately narrow. Fail-open applies ONLY to the two manifested files, ONLY when absent from LCOV, and prints a visible `EXCLUDED` line in the gate output. A manifest file that appears in LCOV is gated normally (the escape expires by itself when the Rolldown instrumentation is fixed); every other absent file still hard-fails `MISSING`.

# Background

## What does this PR do?

Two escapes cancelled each other (#16409): Rolldown coverage collection fails on `packages/agent/src/api/server.ts` and `packages/agent/src/runtime/eliza.ts` (the vitest base config carries matching — stale-prefixed — excludes), while the enforced changed-file gate hard-fails any changed source absent from the merged LCOV as `MISSING`. Net effect: **every PR touching those files structurally failed the gate**, even with a changed test genuinely driving the changed lines (live example: #16402).

Fix (the issue's option 2 + 3 blend):
- `scripts/security/coverage-lcov-excluded.txt` — a reviewed, reasons-required exclusion manifest (mirrors the existing `NODE_SELF_TEST_MANIFEST` pattern), documenting the stale `eliza/`-prefix trap and that entries are meant to be deleted.
- The workflow passes it to the awk gate; the gate prints `EXCLUDED (cannot appear in LCOV, see …)` for a manifest file that is absent instead of failing — **fail-open but auditable**.
- Presence always gates: option 1 (fixing collection) remains the real fix and reactivates gating automatically.

## What kind of change is this?

Bug fix (CI infrastructure).

# Documentation changes needed?

No — the manifest header is the documentation, placed where the next affected contributor will find it (the gate output links it).

# Testing

## Where should a reviewer start?

`scripts/security/coverage-gate.awk` (the `excluded_map` branch in END) and the three new self-test cases in `coverage-gate.self-test.mjs`.

## Detailed testing steps

`node scripts/security/coverage-gate.self-test.mjs` — 8/8.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] `N/A - CI gate scripts; no UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - CI gate scripts; no UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; a coverage-gate behavior fix.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - no deployed backend; the gate behavior matrix is asserted by the deterministic self-test run under Evidence Details (spawns the real awk against synthetic LCOV).`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend involvement.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/model behavior; CI tooling.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - the artifact is the gate's own printed output, asserted by the self-test.`

# Evidence Details

## Backend + frontend logs

<details><summary>Self-test run — 8/8 (3 new #16409 cases)</summary>

```
ok - matches identical repo-relative path
ok - matches absolute LCOV path at path boundary
ok - fails when any changed source is absent from LCOV
ok - prefers the longest matching changed path
ok - rejects an executable source reported with LF zero
ok - aggregates a file across lanes: an incidental low record does not fail a file whose real lane clears the floor (#16043)
ok - still fails a file that is genuinely below the floor in every lane (#16043)
ok - excluded changed file absent from LCOV passes with a visible EXCLUDED line (#16409)
ok - an excluded file that DOES appear in LCOV is gated normally (#16409 — the escape expires)
ok - a non-excluded absent file still hard-fails as MISSING (#16409 — no blanket fail-open)
```

</details>

[stan-cloud]
