### PR TITLE
fix(ci): restore changed-source classifier equivalent-JS exclusion

### DIFF
--- a/scripts/security/coverage-source-classifier.mjs
+++ b/scripts/security/coverage-source-classifier.mjs
@@ -27,14 +27,20 @@ function runtimeSource(source) {
   return eraseTypeScriptSyntax(source).trim();
 }
 
+// Node's strip mode blanks type-only syntax to whitespace while preserving
+// every comment, which keeps comment anchors invariant to type-annotation
+// edits. Bun ships no comment-preserving type stripper (Bun.Transpiler drops
+// comments), so under Bun the raw source is the anchor basis: a type-length
+// edit can then shift a comment anchor and conservatively retain the module,
+// which only ever widens coverage enforcement. The gate itself runs on Node.
 function stripTypeScriptSyntaxPreservingComments(source) {
-  if (typeof nodeModule.stripTypeScriptTypes !== "function") {
-    throw new Error("comment-preserving TypeScript erasure is unavailable");
+  if (typeof nodeModule.stripTypeScriptTypes === "function") {
+    return nodeModule.stripTypeScriptTypes(source, {
+      mode: "strip",
+      sourceMap: false,
+    });
   }
-  return nodeModule.stripTypeScriptTypes(source, {
-    mode: "strip",
-    sourceMap: false,
-  });
+  return source;
 }
 
 /**

--- a/scripts/security/coverage-source-classifier.test.mjs
+++ b/scripts/security/coverage-source-classifier.test.mjs
@@ -1,4 +1,9 @@
-/** Verifies runtime-source classification in Bun, including TypeScript erasure and conservative failures. */
+/**
+ * Verifies runtime-source classification in Bun, including TypeScript erasure,
+ * comment-directive anchoring, and conservative failures. Bun does not expose
+ * node:module.stripTypeScriptTypes, so this suite exercises the classifier's
+ * runtime fallback that Node-only unit runs never reach.
+ */
 
 import { describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
@@ -7,6 +12,7 @@ import { join } from "node:path";
 import {
   classifyPaths,
   pathRetainsRuntimeCode,
+  sourceChangesRuntimeCode,
   sourceRetainsRuntimeCode,
 } from "./coverage-source-classifier.mjs";
 
@@ -65,5 +71,76 @@ describe("coverage source classifier", () => {
     expect(warnings.join("")).toContain(
       "treating unclassifiable module as executable",
     );
+  });
+});
+
+// Under Bun the comment-preserving type stripper falls back to the raw source
+// (node:module.stripTypeScriptTypes is Node-only), so these cases are the ONLY
+// place the fallback anchor path is exercised. They pin the guarantee the gate
+// depends on: a change with identical emitted JavaScript is dropped, while a
+// comment directive that survives into the bundle or steers coverage is kept.
+describe("comment-anchored runtime-equivalence under the Bun fallback", () => {
+  test("drops a change whose emitted JavaScript is unchanged", () => {
+    expect(
+      sourceChangesRuntimeCode(
+        "export const value: number = 1;\n",
+        "export   const value : number | string = 1;\n",
+      ),
+    ).toBe(false);
+  });
+
+  test("keeps a bundling directive that only appears in a comment", () => {
+    expect(
+      sourceChangesRuntimeCode(
+        'export const load = () => import("./module");\n',
+        'export const load = () => import(/* @vite-ignore */ "./module");\n',
+      ),
+    ).toBe(true);
+  });
+
+  test("keeps an added coverage-steering directive", () => {
+    expect(
+      sourceChangesRuntimeCode(
+        "export const value: number = 1;\n",
+        "/* c8 ignore next */\nexport const value: number = 1;\n",
+      ),
+    ).toBe(true);
+  });
+
+  test("excludes the runtime-equivalent path while retaining the real change", () => {
+    const directory = mkdtempSync(join(tmpdir(), "coverage-source-fallback-"));
+    const equivalentPath = join(directory, "equivalent.ts");
+    const changedPath = join(directory, "changed.ts");
+    const baseSources = new Map([
+      [equivalentPath, "export const value: number = 1;\n"],
+      [changedPath, "export const value: number = 1;\n"],
+    ]);
+    try {
+      writeFileSync(
+        equivalentPath,
+        "export   const value : string | number = 1;\n",
+      );
+      writeFileSync(changedPath, "export const value: number = 2;\n");
+
+      let output = "";
+      let errors = "";
+      classifyPaths(
+        [equivalentPath, changedPath],
+        (message) => {
+          output += message;
+        },
+        (message) => {
+          errors += message;
+        },
+        { readBaseSource: (path) => baseSources.get(path) },
+      );
+
+      expect(output).toBe(`${changedPath}\n`);
+      expect(errors).toContain(
+        `excluding runtime-equivalent source change: ${equivalentPath}`,
+      );
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

Restores the "changed-source runtime classifier" so it once again excludes source changes whose emitted JavaScript is unchanged (comment-only / type-only edits), fixing the 3 failing tests in the **Scenario PR E2E → Zero-Key scenario runner E2E** job (step *packages/scripts test sweep (all `__tests__` suites)*, CI run 29459180820 / job 87499038726).

## Root cause

Commit `92d9270bc33` ("fix(ci): prove runtime-equivalent coverage changes") added `stripTypeScriptSyntaxPreservingComments` / `commentSensitiveRecords` to `scripts/security/coverage-source-classifier.mjs`. That helper calls `node:module.stripTypeScriptTypes` — a **Node-24-only** API — and, unlike the sibling transform-mode `eraseTypeScriptSyntax` (which already falls back to `Bun.Transpiler`), it **`throw`s when the API is absent** instead of degrading.

The `packages/scripts` sweep runs under `bun test`, and Bun does not expose `node:module.stripTypeScriptTypes`. So every `sourceChangesRuntimeCode(base, head)` comparison that reached the comment-anchor step threw. In `classifyPaths`, that throw is caught as *"treating unclassifiable source change as executable"* and the file is **retained** — so a runtime-equivalent `equivalent.ts` was wrongly re-added to the coverage-enforced set, exactly the false coverage-gate requirement the commit set out to remove.

```
error: comment-preserving TypeScript erasure is unavailable
  at stripTypeScriptSyntaxPreservingComments (scripts/security/coverage-source-classifier.mjs:32:75)
```

The production gate is unaffected in CI only because `coverage-changed-files.sh` runs the classifier under `node --no-warnings` (where the API exists) — but the unit sweep that guards it runs under Bun.

## Fix

Give `stripTypeScriptSyntaxPreservingComments` the same Node-preferred / graceful-fallback shape `eraseTypeScriptSyntax` already has: use Node's comment-preserving strip mode when available, otherwise anchor comments on the raw source. The Node path (production) is **bit-for-bit unchanged**; the Bun fallback only ever *widens* enforcement (a type-length edit may shift a comment anchor and conservatively retain the module) — it can never hide a real source change.

## Co-located test for the fallback

`scripts/security/coverage-source-classifier.mjs` is exercised by two suites: the vitest one at `packages/scripts/__tests__/coverage-source-classifier.test.ts` (the sweep that was failing) and the co-located **bun:test** at `scripts/security/coverage-source-classifier.test.mjs`. This PR adds cases to the bun suite — which runs under Bun, the **only** runtime where the new fallback branch actually executes — asserting the anchoring guarantee the gate depends on: a change with identical emitted JavaScript is dropped, while a `/* @vite-ignore */` bundling directive or an added `/* c8 ignore next */` coverage directive is retained, plus a `classifyPaths` integration through the fallback. This satisfies the `coverage-gate` "changed source requires a changed co-located test" ratchet and lifts the file's Bun-lane line coverage from 38% to ~70% (over the 50% floor).

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - CI/test tooling change; scripts/security/coverage-source-classifier.mjs is a Node/Bun classifier with no rendered UI surface`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - CI/test tooling change; no rendered UI surface`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no user-exercisable flow; change is a coverage-classifier helper function`.

<!-- evidence-row:backend-logs -->
- [x] Backend logs — before/after `bun test packages/scripts/__tests__/coverage-source-classifier.test.ts` (the sweep's runtime). Fix commit: https://github.com/elizaOS/eliza/commit/36fd6435bc9

<details><summary>BEFORE (develop tip 0b9faeade0) — 3 fail</summary>

```
(fail) changed-source runtime classifier > excludes changes with equivalent emitted JavaScript
(fail) changed-source runtime classifier > retains comment directives that affect bundling or coverage
(fail) changed-source runtime classifier > excludes only proven runtime-equivalent source changes
error: comment-preserving TypeScript erasure is unavailable
   at stripTypeScriptSyntaxPreservingComments (scripts/security/coverage-source-classifier.mjs:32:75)

 8 pass
 3 fail
Ran 11 tests across 1 file.
```
</details>

<details><summary>AFTER (this branch) — 11 pass</summary>

```
 11 pass
 0 fail
Ran 11 tests across 1 file.
```

Both classifier suites together: **19 pass, 0 fail** across 2 files. Node-side self-test `node scripts/security/coverage-changed-files.self-test.mjs` passes all checks including *"runtime-equivalent source changes are not LCOV-enforced"* and *"semantic comment changes remain LCOV-enforced"*.
</details>

<details><summary>coverage-gate reproduced locally against the branch diff — passes</summary>

```
# scripts/security/coverage-changed-files.sh origin/develop HEAD
files      = scripts/security/coverage-source-classifier.mjs
bun_tests  = scripts/security/coverage-source-classifier.test.mjs   # ratchet no longer fires

# bun test --conditions=eliza-source scripts/security/coverage-source-classifier.test.mjs --coverage
 8 pass, 0 fail

# awk -v threshold=50 -f scripts/security/coverage-gate.awk (COVERAGE_GATE_ENFORCE=1)
   69.85% scripts/security/coverage-source-classifier.mjs
changed files: 1, mean coverage: 69.85%, threshold: 50%
coverage gate OK   (exit 0)
```
</details>

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend/browser surface touched`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent/action/provider/prompt/model behavior changed; pure CI coverage-classifier helper`.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the artifact this code produces is the classifier's emit/exclude decision. After the fix, `classifyPaths` emits the diagnostic `[coverage-source-classifier] excluding runtime-equivalent source change: …/equivalent.ts` and keeps `equivalent.ts` OUT of the coverage-enforced output, verified by the *"excludes only proven runtime-equivalent source changes"* test (see backend logs). Fix commit: https://github.com/elizaOS/eliza/commit/36fd6435bc9

## Risk

Minimal. Single self-contained helper; Node production path unchanged; Bun fallback is strictly conservative (widens enforcement, never hides a change). No public API, schema, or runtime behavior touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
