### PR TITLE
fix(app): green the Pixel-7 real-touch notification + launcher-loop e2e lane

### DIFF
--- a/packages/app/test/ui-smoke/gesture-matrix.spec.ts
+++ b/packages/app/test/ui-smoke/gesture-matrix.spec.ts
@@ -173,6 +173,13 @@ interface SeededNotification {
  * digest" on recency) to prove read state never participates in the sort. No
  * row carries a deepLink, so a tap is exactly "mark read". (The pan-scroll test
  * needs an overflowing list and seeds its own taller fixture below.)
+ *
+ * Each row carries a DISTINCT `source` so the shade groups it as its own
+ * single-row producer stack — the realistic many-producer inbox. Same-source
+ * rows collapse into one Z-stacked producer card (1 visible row + peeks) that
+ * only fans on a tap, so a shared source would render one row where these
+ * gesture tests need every seeded row flat (`NotificationsHomeCenter.test.tsx`
+ * pins the stacking behaviour).
  */
 function seedInboxNotifications(): SeededNotification[] {
   const base = Date.now();
@@ -188,7 +195,7 @@ function seedInboxNotifications(): SeededNotification[] {
     body: `${title} — seeded by gesture-matrix`,
     category: "system",
     priority,
-    source: "ui-smoke",
+    source: `ui-smoke-${id}`,
     createdAt: base - ageMs,
     readAt,
   });
@@ -225,6 +232,12 @@ const OVERFLOW_ROWS = 24;
  * enough rows — one interrupt-tier so the rested shade arms its expand
  * affordance, the rest sub-interrupt — that the EXPANDED list always exceeds the
  * column and has real scroll travel to pan.
+ *
+ * Every row uses a DISTINCT `source` so each is its own single-row producer
+ * group: the expanded shade then renders all OVERFLOW_ROWS rows flat (a genuine
+ * multi-producer overflow) instead of one Z-stacked producer card. A shared
+ * source would collapse the whole fixture into a single tap-to-fan stack and the
+ * list would never overflow.
  */
 function seedOverflowInboxNotifications(): SeededNotification[] {
   const base = Date.now();
@@ -235,7 +248,7 @@ function seedOverflowInboxNotifications(): SeededNotification[] {
       body: "Payment failed — seeded by gesture-matrix",
       category: "system",
       priority: "urgent",
-      source: "ui-smoke",
+      source: "ui-smoke-n-urgent",
       createdAt: base - 10_000,
       readAt: null,
     },
@@ -247,7 +260,7 @@ function seedOverflowInboxNotifications(): SeededNotification[] {
       body: `Notice ${i} — seeded by gesture-matrix`,
       category: "system",
       priority: "normal",
-      source: "ui-smoke",
+      source: `ui-smoke-n-fill-${i}`,
       createdAt: base - 20_000 - i * 1_000,
       readAt: null,
     });
@@ -534,9 +547,13 @@ test.describe("real touch (hasTouch project)", () => {
     await installSeededInboxRoutes(page, seedOverflowInboxNotifications());
     await openHome(page);
 
-    // Fan the shade out and seed a tall inbox so the home-screen scroller
-    // genuinely overflows — the column CAN scroll, which makes the containment
-    // assertion below meaningful rather than vacuous.
+    // Fan the shade out and seed a tall inbox so the notification LIST — the
+    // internal scroller under the finger — genuinely overflows. The home column
+    // itself intentionally does NOT overflow: the inbox is `flex-1 min-h-0` and
+    // scrolls in place so it never grows behind the floating composer, so the
+    // definite-height column has no scroll travel. Overflowing the list is what
+    // gives the contained pan real travel and keeps the assertions below
+    // meaningful rather than vacuous.
     const center = page.getByTestId("home-notification-center");
     await expect(center).toBeVisible({ timeout: 15_000 });
     await expandNotificationShade(page);
@@ -545,29 +562,33 @@ test.describe("real touch (hasTouch project)", () => {
       OVERFLOW_ROWS,
       { timeout: 15_000 },
     );
-    const homeScreen = page.getByTestId("home-screen");
-    const overflows = await homeScreen.evaluate(
+    const listOverflows = await list.evaluate(
       (el) => el.scrollHeight > el.clientHeight + 8,
     );
     expect(
-      overflows,
-      "seeded home column must overflow so containment is not vacuous",
+      listOverflows,
+      "seeded notification list must overflow so the contained pan has real scroll travel",
     ).toBe(true);
+    const homeScreen = page.getByTestId("home-screen");
     const homeScrollBefore = await homeScreen.evaluate((el) => el.scrollTop);
+    const listScrollBefore = await list.evaluate((el) => el.scrollTop);
 
     // Genuine touch pan UP over the notification list (a slight horizontal
     // wobble, like a real finger). The list is `overscroll-y-contain`, so the pan
-    // is CONTAINED to the notification area: it must not be hijacked into the
-    // horizontal home↔launcher rail, must not chain into the (scrollable) home
-    // column beneath, and its touch release must not ghost-tap the row under the
-    // finger.
+    // is CONTAINED to the notification area: it scrolls the list IN PLACE, must
+    // not be hijacked into the horizontal home↔launcher rail, must not chain into
+    // the home column beneath, and its touch release must not ghost-tap the row
+    // under the finger.
     await cdpTouchDrag(page, list, 4, -160, 10);
     await page.waitForTimeout(400);
 
-    // Rail did not flip; the home column beneath did not scroll (the pan was
-    // contained); every seeded row is still present and none expanded its option
-    // strip (a tap would expand `notification-row-options`); the chat overlay
-    // stayed closed.
+    // The pan was consumed by the list (it scrolled internally) — the positive
+    // proof it stayed contained there. The rail did not flip; the home column
+    // beneath did not scroll; every seeded row is still present and none expanded
+    // its option strip (a tap would expand `notification-row-options`); the chat
+    // overlay stayed closed.
+    const listScrollAfter = await list.evaluate((el) => el.scrollTop);
+    expect(listScrollAfter).toBeGreaterThan(listScrollBefore);
     await expect(page.getByTestId("home-launcher-surface")).toHaveAttribute(
       "data-page",
       "home",
@@ -600,8 +621,9 @@ test.describe("real touch (hasTouch project)", () => {
     // The inbox is inline on the home column — no shade to open.
     const center = page.getByTestId("home-notification-center");
     await expect(center).toBeVisible({ timeout: 15_000 });
-    // Fan the priority-triaged shade out so the sub-interrupt "Backup finished"
-    // row is present to swipe (rested it stays stacked behind the top card).
+    // Expand the priority-triaged shade so the sub-interrupt "Backup finished"
+    // row is present to swipe (rested, only interrupt-tier producers show, so
+    // this normal-priority producer stays hidden until the shade fans out).
     await expandNotificationShade(page);
     await expect(center.getByTestId("notification-row")).toHaveCount(8, {
       timeout: 15_000,

--- a/packages/app/test/ui-smoke/launcher-gesture-loop.spec.ts
+++ b/packages/app/test/ui-smoke/launcher-gesture-loop.spec.ts
@@ -85,6 +85,16 @@ test.describe("launcher gesture loop (real app, shared engine)", () => {
   // loop's real-touch gestures work on the desktop chromium project too.
   test.use({ hasTouch: true });
 
+  // This is a real-CDP-touch FUZZ lane: a 60-command seeded gesture stream. Under
+  // CI compositor load a single committing rail flick can be dropped or coalesced
+  // even after the driver's own bounded re-dispatch (see cdp-gestures.ts
+  // `railSwipe`), so the loop occasionally reds on an environmental drop rather
+  // than a product defect. A genuine invariant violation is deterministic and
+  // fails every retry, so a bounded outer retry — the driver's per-swipe policy
+  // applied to the whole sequence — keeps the lane honest while immune to the
+  // rare dropped touch (the global config runs with retries: 0).
+  test.describe.configure({ retries: 2 });
+
   test.beforeEach(async ({ page }) => {
     // Skip the once-ever first-run tour so its spotlight never intercepts input.
     await seedAppStorage(page, { "eliza:tutorial-autolaunched": "1" });


### PR DESCRIPTION
# Relates to

Greens the **Zero-Key app browser Pixel-7 real-touch lane** (Scenario PR E2E) on
`develop` — job `87499038689` (run `29459180820`), which deterministically failed
three `mobile-chromium` (Pixel 7, hasTouch) real-touch specs.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched off the latest `origin/develop`
      (tip `0b9faeade00`) with zero conflicts.
- [x] `bun run verify` — see **Known gaps** (biome clean on the two changed
      specs; full-workspace verify not run — test-only diff).
- [x] A reviewer can confirm the change works from the e2e output below.

# Sync with develop

- [x] Branched off the latest `origin/develop` (tip `0b9faeade00`); zero conflicts.
- [x] Biome clean on both changed specs; see **Known gaps** re: full verify.

# Risks

**Low.** Test-only change — no runtime/product code touched. Two `.spec.ts`
files: notification-inbox seed data + one containment precondition (gesture-matrix),
and a bounded retry on one real-touch fuzz spec (launcher-gesture-loop). No
rendered surface, API, or agent behaviour changes.

# Background

## What does this PR do?

Fixes three deterministically/intermittently failing real-touch specs on the
Pixel-7 lane.

**gesture-matrix `523` (pan-contained) + `587` (swipe-row) — deterministic.**
The seeded inboxes gave every notification the same `source` (`"ui-smoke"`).
Under the intentional per-producer shade redesign (#15332 / #15039, pinned by
`packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx`), same-source
rows Z-stack into ONE producer card that shows a single flat `notification-row`
+ peeks and only fans on a tap. So an expanded shade rendered **1** row where the
specs asserted **8** / **24** (CI: `34 × locator resolved to 1 element`).
Fix: seed a **distinct `source` per row** so each notification is its own
single-row producer group and the expanded shade renders every row flat — the
realistic many-producer inbox these gesture tests intend.

A second, layout regression the count-fix surfaced in `523`: the containment
precondition checked the `home-screen` column for overflow, but the Jul-10 layout
(#16073) made the inbox `flex-1 min-h-0` with **internal** scroll, so the
definite-height column never overflows by design. Point the precondition at the
notification **list** (the scroller actually under the finger) and add a positive
proof that the pan scrolled the list in place — keeping every containment
invariant (no rail flip, no home-column scroll, all rows present, no ghost-tap,
chat closed).

**launcher-gesture-loop `94` — intermittent.** A real-CDP-touch **fuzz** lane
(60-command seeded gesture stream). It passed 2/3 recent CI runs and 6× locally;
the one CI red was a committing rail flick the compositor dropped even after the
driver's own bounded re-dispatch. Added a bounded outer retry (`retries: 2`) to
this single fuzz spec — the driver's per-swipe policy applied to the whole
sequence. A genuine invariant violation is deterministic and fails every retry,
so the lane stays honest while immune to the rare dropped touch (global config
runs `retries: 0`).

## What kind of change is this?

Bug fix (green a failing CI lane) — test-only.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/app/test/ui-smoke/gesture-matrix.spec.ts` (seed `source` fields +
pan-containment precondition) and
`packages/app/test/ui-smoke/launcher-gesture-loop.spec.ts` (fuzz-spec retry).

## Detailed testing steps

```bash
bun run --cwd packages/app test:e2e \
  test/ui-smoke/gesture-matrix.spec.ts \
  test/ui-smoke/launcher-gesture-loop.spec.ts \
  --project=mobile-chromium
```

Ran green locally across a single pass, `--repeat-each=3`, and repeated full
runs (each target spec passed 5–6×). Before the fix, `523`/`587` failed every run
(`toHaveCount` got `1`); `94` failed intermittently.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] `N/A - test-only diff (.spec.ts); no rendered UI surface changed. "Before" = the CI failure log excerpt under Known gaps.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - test-only diff; no rendered UI surface changed. "After" = the local green e2e output under Known gaps.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow changed; the change is e2e seed data + assertions + a fuzz-spec retry.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - no backend/server code path changed.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no renderer/frontend code changed.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model change.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - no domain artifacts (DB rows/memories/wallet/on-chain/files); the produced artifact is the e2e run output, pasted inline under Known gaps / failures below.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - no backend or frontend code changed; this is a test-data + assertion fix.`

## Screenshots (before / after) + video walkthrough

`N/A - test-only diff (.spec.ts); no rendered .tsx/.css/.svg surface in the diff.`

## Known gaps / failures

**Before (CI, Pixel-7 lane, run 29454550173 / job 87484818220):**

```
✘ 20 gesture-matrix.spec.ts:523 › vertical pan over the notification list is contained
    Error: expect(locator).toHaveCount(expected) failed
    Expected: 24   Received: 1   (34 × locator resolved to 1 element)
✘ 21 gesture-matrix.spec.ts:587 › swipe an inline row sideways throws it away
    Error: expect(locator).toHaveCount(expected) failed
    Expected: 8    Received: 1
✘ 27 launcher-gesture-loop.spec.ts:94 › seeded gesture loop holds every invariant
    invariant violation(s):
      - rail transformX=0.00 but expected -412.00 (page="launcher") ← dropped CDP flick
3 failed / 22 passed
```

**After (local, this branch, mobile-chromium):**

```
✓ vertical pan over the notification list is contained — no rail flip, no home scroll, no ghost row-tap
✓ swipe an inline row sideways throws it away
✓ launcher gesture loop (real app, shared engine) › seeded gesture loop holds every invariant
6 passed / 1 skipped   (mouse-only notification test skips on the touch project)
```

`--repeat-each=3`: 18 passed / 3 skipped. Each target spec verified green 5–6×
across runs.

**Full-workspace `bun run verify` not run:** test-only diff; `biome check` is
clean on both changed specs and the specs execute green under Playwright. Not a
blocker.
