### PR TITLE
fix(app): repair Scenario PR e2e — wallet hide persistence + settings section anchor

### DIFF
--- a/packages/ui/src/components/pages/SettingsView.test.tsx
+++ b/packages/ui/src/components/pages/SettingsView.test.tsx
@@ -11,6 +11,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import { Settings } from "lucide-react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -379,6 +380,50 @@ describe("SettingsView", () => {
       expect(
         screen.getByRole("button", { name: "Back to launcher" }),
       ).toBeTruthy();
+    } finally {
+      restore();
+    }
+  });
+
+  it("nests the section title h1 inside the #<section.id> deep-link anchor on desktop", () => {
+    // Regression guard (#16354): the persistent desktop rail moved the section
+    // title into a header sibling ABOVE the section body, dropping it out of the
+    // `#<section.id>` deep-link anchor. The title h1 + the body must share one
+    // anchored container so a deep-link/screen-reader landing on the section
+    // reaches its own title.
+    const restore = mockMatchMedia((query) => query.includes("min-width:"));
+    try {
+      const { container } = render(<SettingsView initialSection="runtime" />);
+      const anchor = container.querySelector<HTMLElement>("#runtime");
+      expect(anchor).not.toBeNull();
+      const scoped = within(anchor as HTMLElement);
+      expect(scoped.getByRole("heading", { level: 1 }).textContent).toBe(
+        "Runtime",
+      );
+      expect(scoped.getByTestId("stub-runtime")).toBeTruthy();
+      // Exactly one element carries the anchor id (the wrapper), never a
+      // duplicate on the inner body.
+      expect(container.querySelectorAll("#runtime")).toHaveLength(1);
+    } finally {
+      restore();
+    }
+  });
+
+  it("keeps the section body as the deep-link anchor in the mobile subview", () => {
+    const restore = mockMatchMedia(() => false);
+    try {
+      const { container } = render(<SettingsView initialSection="runtime" />);
+      // Mobile keeps the shared ViewHeader title and anchors `#<id>` on the
+      // section body (the default) — the body still contains the section's
+      // rendered content.
+      const anchor = container.querySelector<HTMLElement>("#runtime");
+      expect(anchor).not.toBeNull();
+      expect(
+        within(anchor as HTMLElement).getByTestId("stub-runtime"),
+      ).toBeTruthy();
+      expect(screen.getByTestId("view-header").textContent).toContain(
+        "Runtime",
+      );
     } finally {
       restore();
     }

--- a/packages/ui/src/components/pages/SettingsView.tsx
+++ b/packages/ui/src/components/pages/SettingsView.tsx
@@ -73,14 +73,24 @@ function SettingsSectionLoading() {
 function SettingsSectionContent({
   section,
   t,
+  anchored = true,
 }: {
   section: SettingsSectionDef;
   t: Translate;
+  // Whether this body carries the `#<section.id>` deep-link/anchor DOM id.
+  // Desktop wraps the section title header + body in one anchored container so
+  // the section's accessible title lives inside `#<section.id>`, and passes
+  // `false` here to keep that id unique. Mobile/modal render the body alone and
+  // keep the anchor on it (default).
+  anchored?: boolean;
 }) {
   const Component = section.Component;
   const title = settingsSectionTitle(section, t);
   return (
-    <div id={section.id} className={section.bodyClassName}>
+    <div
+      id={anchored ? section.id : undefined}
+      className={section.bodyClassName}
+    >
       <ErrorBoundary
         key={section.id}
         fallback={(error, reset) => (
@@ -353,7 +363,12 @@ export function SettingsView({
                 className="mx-auto w-full max-w-[90rem] px-6 pb-10 pt-6 xl:px-8 xl:pt-8"
               >
                 {desktopSectionDef ? (
-                  <>
+                  // The `#<section.id>` anchor wraps the title header + body so
+                  // the section's accessible title (the h1) lives inside the
+                  // section's deep-link anchor, not as a detached sibling above
+                  // it. Header stays outside `bodyClassName` padding, so this is
+                  // structural only — no visual change.
+                  <div id={desktopSectionDef.id}>
                     <header className="mb-8 border-b border-border/60 pb-5">
                       <p className="text-xs font-medium text-muted">
                         {settingsTitle}
@@ -362,8 +377,12 @@ export function SettingsView({
                         {settingsSectionTitle(desktopSectionDef, t)}
                       </h1>
                     </header>
-                    <SettingsSectionContent section={desktopSectionDef} t={t} />
-                  </>
+                    <SettingsSectionContent
+                      section={desktopSectionDef}
+                      t={t}
+                      anchored={false}
+                    />
+                  </div>
                 ) : null}
               </main>
             ) : (

--- a/plugins/plugin-wallet-ui/src/components/InventoryAppView.gui.test.tsx
+++ b/plugins/plugin-wallet-ui/src/components/InventoryAppView.gui.test.tsx
@@ -40,9 +40,29 @@ const appHooks = vi.hoisted(() => ({
   useApp: vi.fn(),
   activityEvents: { events: [] as Array<Record<string, unknown>> },
 }));
+// The view persists its hidden-token set under the shell-reserved
+// `eliza:wallet:` key, which the surface-realm raw-global guard denies for a
+// raw `window.localStorage.setItem` while the view is foreground. The mock
+// mirrors the real `shellLocalStorage` (a privileged pass-through to
+// window.localStorage) so the spy proves the write goes through the sanctioned
+// channel, and the existing persistence/reload assertions still observe the
+// value on the seeded localStorage.
+const bridgeMocks = vi.hoisted(() => ({
+  shellSetItem: vi.fn<(key: string, value: string) => void>((key, value) => {
+    globalThis.window.localStorage.setItem(key, value);
+  }),
+}));
 
+// The plugin vitest config collapses `@elizaos/ui/<subpath>` (incl. `/bridge`)
+// onto this single mock, so `shellLocalStorage` lives here alongside the rest of
+// the `@elizaos/ui` surface the view imports.
 vi.mock("@elizaos/ui", () => ({
   useAgentElement: () => ({ ref: { current: null }, agentProps: {} }),
+  shellLocalStorage: {
+    setItem: bridgeMocks.shellSetItem,
+    removeItem: (key: string) => globalThis.window.localStorage.removeItem(key),
+    clear: () => globalThis.window.localStorage.clear(),
+  },
   client: walletClient,
   // Mirrors the real guard's contract (an ApiError carries a numeric
   // `status`); tests reject fetches with Object.assign(new Error(body),
@@ -500,7 +520,12 @@ describe("InventoryView GUI — hide token", () => {
     expect(state.setActionNotice).toHaveBeenCalledWith(
       "USDC hidden from this wallet view.",
     );
-    // Persisted to the documented localStorage key with the token id.
+    // Persisted through the shell-privileged channel (not a raw reserved-key
+    // write the surface-realm guard would deny), under the documented key.
+    expect(bridgeMocks.shellSetItem).toHaveBeenCalledWith(
+      "eliza:wallet:hidden-token-ids:v1",
+      expect.stringContaining("0xusdc00000000000000000000000000000000000000"),
+    );
     const stored = window.localStorage.getItem(
       "eliza:wallet:hidden-token-ids:v1",
     );

--- a/plugins/plugin-wallet-ui/src/components/InventoryAppView.tsx
+++ b/plugins/plugin-wallet-ui/src/components/InventoryAppView.tsx
@@ -20,6 +20,7 @@ import type {
 } from "@elizaos/shared";
 import { useAgentElement } from "@elizaos/ui/agent-surface";
 import { client, isApiError } from "@elizaos/ui/api";
+import { shellLocalStorage } from "@elizaos/ui/bridge";
 import { Button } from "@elizaos/ui/components";
 import { type ActivityEvent, useActivityEvents } from "@elizaos/ui/hooks";
 import type { InventoryChainFilters } from "@elizaos/ui/state";
@@ -189,12 +190,20 @@ function readHiddenTokenIds(): Set<string> {
 
 function writeHiddenTokenIds(next: Set<string>): void {
   if (typeof window === "undefined") return;
+  // HIDDEN_TOKEN_IDS_KEY is under the shell-reserved `eliza:` namespace, so a
+  // raw localStorage write is denied by the surface-realm raw-global guard
+  // (SurfaceRealmDeniedError) while this view holds the foreground scope, and a
+  // local try/catch would swallow it into silent persistence loss. Route
+  // reserved-key writes through the shell-privileged channel — the sanctioned
+  // path for every reserved-key writer (surface-realm-broker.ts /
+  // scan-reserved-storage-writers.mjs).
   try {
-    window.localStorage.setItem(
-      HIDDEN_TOKEN_IDS_KEY,
-      JSON.stringify([...next]),
-    );
+    shellLocalStorage.setItem(HIDDEN_TOKEN_IDS_KEY, JSON.stringify([...next]));
   } catch {
+    // error-policy:J4 the hide-set is best-effort view preference; a genuine
+    // storage-unavailable environment (quota/private mode) degrades to an
+    // unpersisted hide for this session rather than throwing out of the click
+    // handler.
     return;
   }
 }

--- a/plugins/plugin-wallet-ui/vitest.config.ts
+++ b/plugins/plugin-wallet-ui/vitest.config.ts
@@ -36,7 +36,7 @@ export default defineConfig({
         replacement: require.resolve("react-dom/client"),
       },
       {
-        find: /^@elizaos\/ui\/(agent-surface|api|components(?:\/.*)?|hooks|layouts|state|utils)$/,
+        find: /^@elizaos\/ui\/(agent-surface|api|bridge|components(?:\/.*)?|hooks|layouts|state|utils)$/,
         replacement: "@elizaos/ui",
       },
       {

--- a/plugins/plugin-wallet-ui/vitest.config.ts
+++ b/plugins/plugin-wallet-ui/vitest.config.ts
@@ -1,10 +1,18 @@
 /**
  * Vitest config for plugin-wallet-ui. Forces a single React/ReactDOM copy via
  * explicit aliases (avoids duplicate-React errors across workspace packages),
- * collapses `@elizaos/ui/<subpath>` imports to the single built `@elizaos/ui`
- * package so subpath resolution doesn't depend on the ui package's dist
- * layout, and redirects a plugin-health subpath import to source since that
- * package publishes no matching subpath export.
+ * collapses `@elizaos/ui` and every `@elizaos/ui/<subpath>` import onto the ui
+ * package's SOURCE entry, and redirects a plugin-health subpath import to source
+ * since that package publishes no matching subpath export.
+ *
+ * The ui alias targets `packages/ui/src/index.ts`, not the package's `.` export,
+ * because the changed-files coverage gate (run-changed-vitest-coverage.mjs) runs
+ * this config BEFORE the workspace build, when `@elizaos/ui`'s dist entry does
+ * not exist yet — resolving its `.` export then throws "Failed to resolve entry
+ * for package @elizaos/ui" and the suite collects zero tests. The wallet gui
+ * test fully `vi.mock`s `@elizaos/ui`, so the source file is only resolved (to
+ * key the mock), never loaded; aliasing to a pre-build-present path is what lets
+ * the mock register under both the bare and every subpath specifier.
  */
 import { createRequire } from "node:module";
 import path from "node:path";
@@ -14,6 +22,7 @@ import { defineConfig } from "vitest/config";
 const here = path.dirname(fileURLToPath(import.meta.url));
 const elizaRoot = path.resolve(here, "../..");
 const require = createRequire(import.meta.url);
+const uiSource = path.resolve(elizaRoot, "packages/ui/src/index.ts");
 
 export default defineConfig({
   root: here,
@@ -37,7 +46,11 @@ export default defineConfig({
       },
       {
         find: /^@elizaos\/ui\/(agent-surface|api|bridge|components(?:\/.*)?|hooks|layouts|state|utils)$/,
-        replacement: "@elizaos/ui",
+        replacement: uiSource,
+      },
+      {
+        find: /^@elizaos\/ui$/,
+        replacement: uiSource,
       },
       {
         find: /^@elizaos\/plugin-health\/screen-time\/mobile-signal-setup$/,


### PR DESCRIPTION
## What & why

Two develop-side **Scenario PR E2E** regressions in the Zero-Key app-browser lanes (run 29459180820: `dashboard` device-matrix + `desktop-webkit`), root-caused and fixed:

### 1. `wallet-inventory.spec.ts` — hide state never persisted (all 5 profiles)

Hiding a token removed the row from the view but the hidden id never reached `localStorage["eliza:wallet:hidden-token-ids:v1"]`, so the final poll saw `[]`.

`InventoryAppView` wrote that **shell-reserved** (`eliza:`) key via a raw `window.localStorage.setItem`. The surface-realm raw-global guard (`surface-realm-broker.ts`, #13452/#15247) **denies** a raw reserved-key write while a view holds the foreground scope (`SurfaceRealmDeniedError`), and the writer's own `try/catch` swallowed the throw into silent persistence loss — exactly the failure mode `scan-reserved-storage-writers.mjs` documents. The unit test passed because it renders the view with no active surface scope (no guard); the e2e runs the real shell, where the guard is armed. Trace console showed 10× `SurfaceRealmDenied` / `reserved shell key`.

**Fix:** route the write through the sanctioned `shellLocalStorage` privileged channel (`@elizaos/ui/bridge`) — the same path every shell reserved-key writer uses. The scan only covers `packages/ui` + `packages/app`, so this first-party plugin writer slipped its net.

### 2. `ui-smoke.spec.ts` — `#app-permissions` had no "App Permissions" heading (desktop-webkit)

The persistent desktop settings rail (#16354) moved the section title `<h1>` into a `<header>` **sibling above** the section body, dropping it out of the `#<section.id>` deep-link anchor. `getByText('App Permissions', { exact })` scoped to `#app-permissions` found nothing (reproduced on Chromium too — `ui-smoke` only runs in the webkit lane).

**Fix:** wrap the desktop title header + body in one `<div id={section.id}>` anchor; `SettingsSectionContent` gains an `anchored` prop so the inner body drops its id (no duplicate). The header stays outside `bodyClassName` — **structural only, zero visual change** (before/after screenshots are byte-identical).

## Verification (local, ran as CI does)

- `wallet-inventory.spec.ts` → **green** on `dashboard-mobile-portrait`, `dashboard-mobile-landscape`, `dashboard-desktop-landscape`, `dashboard-ipad-portrait`, and `desktop-webkit` (all 5 CI profiles).
- `ui-smoke.spec.ts` → **green** on `chromium` and `desktop-webkit`.
- Unit: `InventoryAppView.gui.test.tsx` (42 in suite) asserts the hide write goes through `shellLocalStorage`; `SettingsView.test.tsx` (14) asserts the title h1 nests inside `#<section.id>` on desktop and the body stays anchored on mobile.
- Coverage gate (threshold 50, `run-changed-vitest-coverage.mjs` + `coverage-gate.awk`): `InventoryAppView.tsx` **92.98%**, `SettingsView.tsx` **87.50%**.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before (desktop, buggy #16354 code) — App Permissions section renders, but the title h1 sits outside `#app-permissions`: https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/scenario-e2e-permissions-before-app-permissions.png (structural change → pixel-identical to After; the behavioral before/after is the e2e red→green above)
<!-- evidence-row:after-screenshots -->
- [x] After (desktop, fixed) — title h1 now inside the `#app-permissions` anchor: https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/scenario-e2e-permissions-after-app-permissions.png
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough (open Settings → deep-link App Permissions, section renders with title): https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/scenario-e2e-permissions-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [ ] `N/A - no server code path changed; the Zero-Key lanes drive the browser against stubbed routes only.`
<!-- evidence-row:frontend-logs -->
- [ ] `N/A - structural DOM re-parenting + a localStorage write-path swap; no new console/network activity. Behavior is shown by the walkthrough video and the e2e trace (SurfaceRealmDenied gone).`
<!-- evidence-row:llm-trajectory -->
- [ ] `N/A - no agent/action/provider/prompt/model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact = the persisted preference: after the fix `localStorage["eliza:wallet:hidden-token-ids:v1"]` contains `ethereum:native:usdc` (asserted by the wallet-inventory e2e localStorage poll and the gui unit test spy on `shellLocalStorage.setItem`). OCR readout: https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/scenario-e2e-permissions-ocr-review.md
<!-- evidence-row:ocr-review -->
- [x] OCR visual text review (tesseract over the After screenshot) confirms the "App Permissions" heading is legible inside the section body: https://github.com/elizaOS/eliza/releases/download/pr-evidence-2/scenario-e2e-permissions-ocr-review.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
