### PR TITLE
fix(orchestrator): isolate verification retries and add live evidence

### DIFF
--- a/packages/scripts/__tests__/live-scenarios-workflow.test.ts
+++ b/packages/scripts/__tests__/live-scenarios-workflow.test.ts
@@ -1,7 +1,7 @@
 /**
  * Pins the credentialed scenario authority's clean-checkout prerequisites,
- * source-export conditions, and honest catalog ownership after no-op workflow
- * entry points are retired.
+ * source-export conditions, honest catalog ownership, and default trajectory
+ * artifacts.
  */
 import { expect, test } from "bun:test";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
@@ -10,6 +10,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { main as auditScenarioCoverage } from "../check-scenario-workflow-coverage.mjs";
 import { PLUGIN_ROUTE_COVERAGE } from "../e2e-coverage/manifest.ts";
+import { listScenarioMetadata } from "../../scenario-runner/src/loader.ts";
 
 const workflowPath = fileURLToPath(
   new URL("../../../.github/workflows/live-scenarios.yml", import.meta.url),
@@ -23,6 +24,12 @@ const coverageAuditPath = fileURLToPath(
 );
 const workflowReadmePath = fileURLToPath(
   new URL("../../../.github/workflows/README.md", import.meta.url),
+);
+const liveScenarioWrapperPath = fileURLToPath(
+  new URL("../run-live-scenarios.mjs", import.meta.url),
+);
+const defaultScenarioRoot = fileURLToPath(
+  new URL("../../test/scenarios/", import.meta.url),
 );
 
 test("builds the dist-exported runtime packages before the scenario CLI starts", () => {
@@ -103,3 +110,35 @@ test("reports uncovered live-only scenarios as explicit deferrals", () => {
     rmSync(tempRoot, { recursive: true, force: true });
   }
 }, 30_000);
+
+test("discovers the orchestrator live evidence in the scheduled catalog", async () => {
+  const metadata = await listScenarioMetadata(
+    defaultScenarioRoot,
+    undefined,
+    undefined,
+    false,
+    "live-only",
+  );
+  const orchestratorEvidence = metadata.filter((entry) =>
+    [
+      "orchestrator.grilling-happy-path",
+      "orchestrator.origin-routing-live",
+    ].includes(entry.id),
+  );
+
+  expect(orchestratorEvidence.map((entry) => entry.id).sort()).toEqual([
+    "orchestrator.grilling-happy-path",
+    "orchestrator.origin-routing-live",
+  ]);
+});
+
+test("exports native trajectories into the run directory by default", () => {
+  const wrapper = readFileSync(liveScenarioWrapperPath, "utf8");
+
+  expect(wrapper).toContain(
+    'process.env.EXPORT_NATIVE_PATH ?? path.join(runDir, "native.jsonl")',
+  );
+  expect(wrapper).toMatch(
+    /if \(exportNativePath\.length > 0\)[\s\S]*args\.push\("--export-native", exportNativePath\)/,
+  );
+});

--- a/packages/scripts/__tests__/live-scenarios-workflow.test.ts
+++ b/packages/scripts/__tests__/live-scenarios-workflow.test.ts
@@ -4,13 +4,18 @@
  * artifacts.
  */
 import { expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { listScenarioMetadata } from "../../scenario-runner/src/loader.ts";
 import { main as auditScenarioCoverage } from "../check-scenario-workflow-coverage.mjs";
 import { PLUGIN_ROUTE_COVERAGE } from "../e2e-coverage/manifest.ts";
-import { listScenarioMetadata } from "../../scenario-runner/src/loader.ts";
+import {
+  createLiveScenarioPlan,
+  main as runLiveScenarios,
+} from "../run-live-scenarios.mjs";
 
 const workflowPath = fileURLToPath(
   new URL("../../../.github/workflows/live-scenarios.yml", import.meta.url),
@@ -25,12 +30,41 @@ const coverageAuditPath = fileURLToPath(
 const workflowReadmePath = fileURLToPath(
   new URL("../../../.github/workflows/README.md", import.meta.url),
 );
-const liveScenarioWrapperPath = fileURLToPath(
-  new URL("../run-live-scenarios.mjs", import.meta.url),
-);
 const defaultScenarioRoot = fileURLToPath(
   new URL("../../test/scenarios/", import.meta.url),
 );
+
+function captureLogger(): {
+  logger: {
+    log(message: string): void;
+    warn(message: string): void;
+    error(message: string): void;
+  };
+  messages: { log: string[]; warn: string[]; error: string[] };
+} {
+  const messages = {
+    log: [] as string[],
+    warn: [] as string[],
+    error: [] as string[],
+  };
+  return {
+    logger: {
+      log: (message) => messages.log.push(message),
+      warn: (message) => messages.warn.push(message),
+      error: (message) => messages.error.push(message),
+    },
+    messages,
+  };
+}
+
+function exitingChild(
+  code: number | null,
+  signal: string | null = null,
+): EventEmitter {
+  const child = new EventEmitter();
+  queueMicrotask(() => child.emit("exit", code, signal));
+  return child;
+}
 
 test("builds the dist-exported runtime packages before the scenario CLI starts", () => {
   const workflow = readFileSync(workflowPath, "utf8");
@@ -132,13 +166,107 @@ test("discovers the orchestrator live evidence in the scheduled catalog", async 
   ]);
 });
 
-test("exports native trajectories into the run directory by default", () => {
-  const wrapper = readFileSync(liveScenarioWrapperPath, "utf8");
+test("builds the native trajectory export into the child invocation by default", () => {
+  const plan = createLiveScenarioPlan({
+    repoRoot: "/repo",
+    env: {
+      ELIZA_LIVE_TEST: "1",
+      REPORT_PATH: "/evidence/report.json",
+      RUN_DIR: "/evidence/run",
+      SCENARIO_FILTER: "orchestrator.origin-routing-live",
+    },
+    argv: ["--list"],
+    existsSync: () => true,
+    mkdirSync: () => undefined,
+  });
 
-  expect(wrapper).toContain(
-    'process.env.EXPORT_NATIVE_PATH ?? path.join(runDir, "native.jsonl")',
-  );
-  expect(wrapper).toMatch(
-    /if \(exportNativePath\.length > 0\)[\s\S]*args\.push\("--export-native", exportNativePath\)/,
-  );
+  expect(plan.args).toContain("--export-native");
+  expect(plan.args).toContain("/evidence/run/native.jsonl");
+  expect(plan.args.slice(-3)).toEqual([
+    "--list",
+    "--scenario",
+    "orchestrator.origin-routing-live",
+  ]);
+  expect(plan.childEnv.LIFEOPS_LIVE_JUDGE_MIN_SCORE).toBe("0.8");
+});
+
+test("fails configuration before spawn when an intentional skip has no reason", async () => {
+  const { logger, messages } = captureLogger();
+  const exitCode = await runLiveScenarios({
+    repoRoot: "/repo",
+    env: { ELIZA_LIVE_TEST: "1", SCENARIO_SKIP: "connector.*" },
+    argv: [],
+    existsSync: () => true,
+    mkdirSync: () => undefined,
+    logger,
+  });
+
+  expect(exitCode).toBe(2);
+  expect(messages.error.join("\n")).toContain("requires SKIP_REASON");
+});
+
+test("preserves enforced failures and makes explicitly non-blocking runs green", async () => {
+  const enforced = captureLogger();
+  const common = {
+    repoRoot: "/repo",
+    argv: [],
+    existsSync: () => true,
+    mkdirSync: () => undefined,
+  };
+  const enforcedCode = await runLiveScenarios({
+    ...common,
+    env: {
+      ELIZA_LIVE_TEST: "1",
+      CEREBRAS_API_KEY: "judge-key",
+      SKIP_REASON: "scoped exact-head evidence run",
+    },
+    logger: enforced.logger,
+    spawnImpl: () => exitingChild(7),
+  });
+  expect(enforcedCode).toBe(7);
+  expect(enforced.messages.log.join("\n")).toContain("judge=independent");
+
+  const nonBlocking = captureLogger();
+  const nonBlockingCode = await runLiveScenarios({
+    ...common,
+    env: {
+      ELIZA_LIVE_TEST: "1",
+      SCENARIO_ENFORCE_GATE: "0",
+    },
+    logger: nonBlocking.logger,
+    spawnImpl: () => exitingChild(7),
+  });
+  expect(nonBlockingCode).toBe(0);
+  expect(nonBlocking.messages.warn.join("\n")).toContain("non-blocking");
+});
+
+test("maps a signalled child and a spawn error to observable failures", async () => {
+  const common = {
+    repoRoot: "/repo",
+    env: { ELIZA_LIVE_TEST: "1" },
+    argv: [],
+    existsSync: () => true,
+    mkdirSync: () => undefined,
+  };
+  const signalled = captureLogger();
+  expect(
+    await runLiveScenarios({
+      ...common,
+      logger: signalled.logger,
+      spawnImpl: () => exitingChild(null, "SIGTERM"),
+    }),
+  ).toBe(1);
+  expect(signalled.messages.error.join("\n")).toContain("SIGTERM");
+
+  const spawnFailure = captureLogger();
+  expect(
+    await runLiveScenarios({
+      ...common,
+      logger: spawnFailure.logger,
+      spawnImpl: () => {
+        throw new Error("spawn unavailable");
+      },
+    }),
+  ).toBe(1);
+  expect(spawnFailure.messages.error.join("\n")).toContain("spawn unavailable");
 });

--- a/packages/scripts/__tests__/live-scenarios-workflow.test.ts
+++ b/packages/scripts/__tests__/live-scenarios-workflow.test.ts
@@ -164,7 +164,7 @@ test("discovers the orchestrator live evidence in the scheduled catalog", async 
     "orchestrator.grilling-happy-path",
     "orchestrator.origin-routing-live",
   ]);
-});
+}, 15_000);
 
 test("builds the native trajectory export into the child invocation by default", () => {
   const plan = createLiveScenarioPlan({

--- a/packages/scripts/run-live-scenarios.mjs
+++ b/packages/scripts/run-live-scenarios.mjs
@@ -33,7 +33,8 @@
  *   - SKIP_REASON: required when any scenario is intentionally skipped.
  *   - REPORT_PATH: where to write the JSON report (default: artifacts/lifeops-scenario-report.json).
  *   - RUN_DIR: where to save trajectories, matrix.json, and viewer/ (default: artifacts/scenario-runs/live).
- *   - EXPORT_NATIVE_PATH: optional eliza_native_v1 JSONL export path.
+ *   - EXPORT_NATIVE_PATH: eliza_native_v1 JSONL export path (default:
+ *     <RUN_DIR>/native.jsonl; set to an empty string to disable).
  *
  * Usage:
  *   node packages/scripts/run-live-scenarios.mjs [--list] [--scenario id1,id2] [--report path]

--- a/packages/scripts/run-live-scenarios.mjs
+++ b/packages/scripts/run-live-scenarios.mjs
@@ -117,7 +117,9 @@ const args = [
   "--run-dir",
   runDir,
 ];
-const exportNativePath = (process.env.EXPORT_NATIVE_PATH ?? "").trim();
+const exportNativePath = (
+  process.env.EXPORT_NATIVE_PATH ?? path.join(runDir, "native.jsonl")
+).trim();
 if (exportNativePath.length > 0) {
   mkdirSync(path.dirname(path.resolve(REPO_ROOT, exportNativePath)), {
     recursive: true,

--- a/packages/scripts/run-live-scenarios.mjs
+++ b/packages/scripts/run-live-scenarios.mjs
@@ -1,43 +1,8 @@
 #!/usr/bin/env node
 /**
- * Wrapper around the `/scenario-runner` CLI.
- *
- * Responsibilities:
- *   1. Ensure SKIP_REASON gating: when scenarios are filtered/skipped via
- *      SCENARIO_SKIP, an explicit SKIP_REASON env var must be set or this
- *      wrapper exits non-zero.
- *   2. Forward to the scenario CLI at
- *      `packages/scenario-runner/src/cli.ts`.
- *   3. Fail loudly if the CLI reports failure.
- *
- * Required env:
- *   - ELIZA_LIVE_TEST=1 (asserted)
- *   - At least one LLM provider key (OPENAI_API_KEY, OPENROUTER_API_KEY, etc.)
- *
- * Optional env:
- *   - LIFEOPS_JUDGE_THRESHOLD: minimum LLM judge score (default 0.8). Forwarded
- *     to the CLI via LIFEOPS_LIVE_JUDGE_MIN_SCORE.
- *   - CEREBRAS_API_KEY / EVAL_CEREBRAS_API_KEY: independent LLM-judge
- *     credentials. Without them the judge falls back to the runtime's own
- *     TEXT_LARGE model — the model under test grades itself. Such scenarios
- *     are stamped judgeSelfGraded:true in the report (#9310).
- *   - SCENARIO_JUDGE_REQUIRE_INDEPENDENT=1: fail any scenario whose judge
- *     self-graded instead of silently accepting the self-assigned score. Set
- *     in the nightly live-scenarios workflow.
- *   - SCENARIO_FILTER: comma-separated scenario IDs (forwards as --scenario).
- *   - SCENARIO_ROOT: scenario directory, relative to repo root or absolute
- *     (default: packages/test/scenarios).
- *   - SCENARIO_INCLUDE_PENDING=1: include scenarios marked status="pending".
- *   - SCENARIO_ENFORCE_GATE=0: keep the workflow green while still writing
- *     the report when scenario assertions fail.
- *   - SKIP_REASON: required when any scenario is intentionally skipped.
- *   - REPORT_PATH: where to write the JSON report (default: artifacts/lifeops-scenario-report.json).
- *   - RUN_DIR: where to save trajectories, matrix.json, and viewer/ (default: artifacts/scenario-runs/live).
- *   - EXPORT_NATIVE_PATH: eliza_native_v1 JSONL export path (default:
- *     <RUN_DIR>/native.jsonl; set to an empty string to disable).
- *
- * Usage:
- *   node packages/scripts/run-live-scenarios.mjs [--list] [--scenario id1,id2] [--report path]
+ * Runs credentialed scenario catalogs through the shared runner with enforced
+ * live-test, skip, and judge gates. It standardizes report and trajectory paths
+ * and emits native JSONL evidence by default.
  */
 
 import { spawn } from "node:child_process";
@@ -50,131 +15,189 @@ const REPO_ROOT = path.resolve(
   "..",
   "..",
 );
-const SCENARIO_CLI = path.join(
-  REPO_ROOT,
-  "packages",
-  "scenario-runner",
-  "src",
-  "cli.ts",
-);
-const DEFAULT_SCENARIO_ROOT = path.join(
-  REPO_ROOT,
-  "packages",
-  "test",
-  "scenarios",
-);
-const scenarioRootInput = (process.env.SCENARIO_ROOT ?? "").trim();
-const scenarioRoot =
-  scenarioRootInput.length > 0
-    ? path.resolve(REPO_ROOT, scenarioRootInput)
-    : DEFAULT_SCENARIO_ROOT;
 
-if (!existsSync(SCENARIO_CLI)) {
-  console.error(
-    `[run-live-scenarios] scenario-runner CLI missing at ${SCENARIO_CLI}.`,
-  );
-  process.exit(2);
-}
-
-if (process.env.ELIZA_LIVE_TEST !== "1") {
-  console.error(
-    "[run-live-scenarios] refusing to run: ELIZA_LIVE_TEST=1 is required.",
-  );
-  process.exit(2);
-}
-
-const skipFilter = (process.env.SCENARIO_SKIP ?? "").trim();
-const skipReason = (process.env.SKIP_REASON ?? "").trim();
-if (skipFilter.length > 0 && skipReason.length === 0) {
-  console.error(
-    `[run-live-scenarios] SCENARIO_SKIP="${skipFilter}" requires SKIP_REASON to document why. ` +
-      `Set SKIP_REASON="<concrete reason>" to acknowledge.`,
-  );
-  process.exit(2);
-}
-if (skipReason.length > 0) {
-  console.warn(
-    `[run-live-scenarios] SKIP_REASON acknowledged: "${skipReason}" (filter="${skipFilter}")`,
-  );
-}
-
-const reportPath =
-  process.env.REPORT_PATH ??
-  path.join(REPO_ROOT, "artifacts", "lifeops-scenario-report.json");
-mkdirSync(path.dirname(reportPath), { recursive: true });
-const runDir =
-  process.env.RUN_DIR ??
-  path.join(REPO_ROOT, "artifacts", "scenario-runs", "live");
-mkdirSync(runDir, { recursive: true });
-
-const args = [
-  "--import",
-  "tsx",
-  SCENARIO_CLI,
-  "run",
-  scenarioRoot,
-  "--report",
-  reportPath,
-  "--run-dir",
-  runDir,
-];
-const exportNativePath = (
-  process.env.EXPORT_NATIVE_PATH ?? path.join(runDir, "native.jsonl")
-).trim();
-if (exportNativePath.length > 0) {
-  mkdirSync(path.dirname(path.resolve(REPO_ROOT, exportNativePath)), {
-    recursive: true,
-  });
-  args.push("--export-native", exportNativePath);
-}
-args.push(...process.argv.slice(2));
-const filter = (process.env.SCENARIO_FILTER ?? "").trim();
-if (filter.length > 0) {
-  args.push("--scenario", filter);
-}
-
-const judgeThreshold = process.env.LIFEOPS_JUDGE_THRESHOLD ?? "0.8";
-const enforceGateValue = (process.env.SCENARIO_ENFORCE_GATE ?? "1")
-  .trim()
-  .toLowerCase();
-const enforceGate = !["0", "false", "no", "off"].includes(enforceGateValue);
-const env = {
-  ...process.env,
-  ELIZA_LIVE_TEST: "1",
-  LIFEOPS_LIVE_JUDGE_MIN_SCORE: judgeThreshold,
-};
-
-const independentJudge = Boolean(
-  (process.env.CEREBRAS_API_KEY ?? "").trim() ||
-    (process.env.EVAL_CEREBRAS_API_KEY ?? "").trim(),
-);
-const requireIndependentJudge =
-  (process.env.SCENARIO_JUDGE_REQUIRE_INDEPENDENT ?? "").trim() === "1";
-console.log(
-  `[run-live-scenarios] threshold=${judgeThreshold} enforce=${enforceGate ? "yes" : "no"} pending=${env.SCENARIO_INCLUDE_PENDING === "1" ? "included" : "excluded"} judge=${independentJudge ? "independent (cerebras)" : "SELF-GRADED (model under test — set CEREBRAS_API_KEY)"} requireIndependentJudge=${requireIndependentJudge ? "yes" : "no"} report=${reportPath} runDir=${runDir} args=${args.slice(2).join(" ")}`,
-);
-if (!independentJudge && !requireIndependentJudge) {
-  console.warn(
-    "[run-live-scenarios] WARNING: no independent judge credentials — every judgeRubric/responseJudge score will be self-graded by the model under test (#9310).",
-  );
-}
-
-const child = spawn(process.execPath, args, {
-  cwd: REPO_ROOT,
-  env,
-  stdio: "inherit",
-});
-child.on("exit", (code, signal) => {
-  if (signal) {
-    console.error(`[run-live-scenarios] killed by signal ${signal}`);
-    process.exit(1);
+/** A caller configuration error that maps to the wrapper's stable exit code. */
+export class LiveScenarioConfigurationError extends Error {
+  constructor(message, exitCode = 2) {
+    super(message);
+    this.name = "LiveScenarioConfigurationError";
+    this.exitCode = exitCode;
   }
-  const exitCode = code ?? 1;
-  if (exitCode !== 0 && !enforceGate) {
-    console.warn(
-      `[run-live-scenarios] scenario gate exited ${exitCode}; SCENARIO_ENFORCE_GATE=0 so the report is non-blocking.`,
+}
+
+/**
+ * Resolve the child invocation without spawning it. Dependency injection keeps
+ * the workflow contract executable in unit coverage without credentialed model
+ * calls or writes outside a temporary directory.
+ */
+export function createLiveScenarioPlan(options = {}) {
+  const repoRoot = options.repoRoot ?? REPO_ROOT;
+  const env = options.env ?? process.env;
+  const argv = options.argv ?? process.argv.slice(2);
+  const pathExists = options.existsSync ?? existsSync;
+  const makeDirectory = options.mkdirSync ?? mkdirSync;
+  const scenarioCli = path.join(
+    repoRoot,
+    "packages",
+    "scenario-runner",
+    "src",
+    "cli.ts",
+  );
+
+  if (!pathExists(scenarioCli)) {
+    throw new LiveScenarioConfigurationError(
+      `[run-live-scenarios] scenario-runner CLI missing at ${scenarioCli}.`,
     );
-    process.exit(0);
   }
-  process.exit(exitCode);
-});
+  if (env.ELIZA_LIVE_TEST !== "1") {
+    throw new LiveScenarioConfigurationError(
+      "[run-live-scenarios] refusing to run: ELIZA_LIVE_TEST=1 is required.",
+    );
+  }
+
+  const skipFilter = (env.SCENARIO_SKIP ?? "").trim();
+  const skipReason = (env.SKIP_REASON ?? "").trim();
+  if (skipFilter.length > 0 && skipReason.length === 0) {
+    throw new LiveScenarioConfigurationError(
+      `[run-live-scenarios] SCENARIO_SKIP="${skipFilter}" requires SKIP_REASON to document why. Set SKIP_REASON="<concrete reason>" to acknowledge.`,
+    );
+  }
+
+  const scenarioRootInput = (env.SCENARIO_ROOT ?? "").trim();
+  const scenarioRoot =
+    scenarioRootInput.length > 0
+      ? path.resolve(repoRoot, scenarioRootInput)
+      : path.join(repoRoot, "packages", "test", "scenarios");
+  const reportPath =
+    env.REPORT_PATH ??
+    path.join(repoRoot, "artifacts", "lifeops-scenario-report.json");
+  makeDirectory(path.dirname(reportPath), { recursive: true });
+  const runDir =
+    env.RUN_DIR ?? path.join(repoRoot, "artifacts", "scenario-runs", "live");
+  makeDirectory(runDir, { recursive: true });
+
+  const args = [
+    "--import",
+    "tsx",
+    scenarioCli,
+    "run",
+    scenarioRoot,
+    "--report",
+    reportPath,
+    "--run-dir",
+    runDir,
+  ];
+  const exportNativePath = (
+    env.EXPORT_NATIVE_PATH ?? path.join(runDir, "native.jsonl")
+  ).trim();
+  if (exportNativePath.length > 0) {
+    makeDirectory(path.dirname(path.resolve(repoRoot, exportNativePath)), {
+      recursive: true,
+    });
+    args.push("--export-native", exportNativePath);
+  }
+  args.push(...argv);
+  const filter = (env.SCENARIO_FILTER ?? "").trim();
+  if (filter.length > 0) args.push("--scenario", filter);
+
+  const judgeThreshold = env.LIFEOPS_JUDGE_THRESHOLD ?? "0.8";
+  const enforceGateValue = (env.SCENARIO_ENFORCE_GATE ?? "1")
+    .trim()
+    .toLowerCase();
+  const enforceGate = !["0", "false", "no", "off"].includes(enforceGateValue);
+  const childEnv = {
+    ...env,
+    ELIZA_LIVE_TEST: "1",
+    LIFEOPS_LIVE_JUDGE_MIN_SCORE: judgeThreshold,
+  };
+  const independentJudge = Boolean(
+    (env.CEREBRAS_API_KEY ?? "").trim() ||
+      (env.EVAL_CEREBRAS_API_KEY ?? "").trim(),
+  );
+  const requireIndependentJudge =
+    (env.SCENARIO_JUDGE_REQUIRE_INDEPENDENT ?? "").trim() === "1";
+
+  return {
+    repoRoot,
+    args,
+    childEnv,
+    runDir,
+    reportPath,
+    skipFilter,
+    skipReason,
+    judgeThreshold,
+    enforceGate,
+    independentJudge,
+    requireIndependentJudge,
+  };
+}
+
+/** Spawn one resolved plan and translate the child boundary into an exit code. */
+export async function runLiveScenarioPlan(plan, options = {}) {
+  const spawnChild = options.spawnImpl ?? spawn;
+  const logger = options.logger ?? console;
+  const execPath = options.execPath ?? process.execPath;
+
+  if (plan.skipReason.length > 0) {
+    logger.warn(
+      `[run-live-scenarios] SKIP_REASON acknowledged: "${plan.skipReason}" (filter="${plan.skipFilter}")`,
+    );
+  }
+  logger.log(
+    `[run-live-scenarios] threshold=${plan.judgeThreshold} enforce=${plan.enforceGate ? "yes" : "no"} pending=${plan.childEnv.SCENARIO_INCLUDE_PENDING === "1" ? "included" : "excluded"} judge=${plan.independentJudge ? "independent (cerebras)" : "SELF-GRADED (model under test — set CEREBRAS_API_KEY)"} requireIndependentJudge=${plan.requireIndependentJudge ? "yes" : "no"} report=${plan.reportPath} runDir=${plan.runDir} args=${plan.args.slice(2).join(" ")}`,
+  );
+  if (!plan.independentJudge && !plan.requireIndependentJudge) {
+    logger.warn(
+      "[run-live-scenarios] WARNING: no independent judge credentials — every judgeRubric/responseJudge score will be self-graded by the model under test (#9310).",
+    );
+  }
+
+  return await new Promise((resolve, reject) => {
+    const child = spawnChild(execPath, plan.args, {
+      cwd: plan.repoRoot,
+      env: plan.childEnv,
+      stdio: "inherit",
+    });
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (signal) {
+        logger.error(`[run-live-scenarios] killed by signal ${signal}`);
+        resolve(1);
+        return;
+      }
+      const exitCode = code ?? 1;
+      if (exitCode !== 0 && !plan.enforceGate) {
+        logger.warn(
+          `[run-live-scenarios] scenario gate exited ${exitCode}; SCENARIO_ENFORCE_GATE=0 so the report is non-blocking.`,
+        );
+        resolve(0);
+        return;
+      }
+      resolve(exitCode);
+    });
+  });
+}
+
+/** Outermost process boundary used by the workflow and direct CLI callers. */
+export async function main(options = {}) {
+  const logger = options.logger ?? console;
+  try {
+    const plan = createLiveScenarioPlan(options);
+    return await runLiveScenarioPlan(plan, options);
+  } catch (error) {
+    // error-policy:J1 the executable boundary maps configuration/spawn failures
+    // to stable non-zero process results while preserving the diagnostic.
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error(
+      error instanceof LiveScenarioConfigurationError
+        ? message
+        : `[run-live-scenarios] failed: ${message}`,
+    );
+    return error instanceof LiveScenarioConfigurationError ? error.exitCode : 1;
+  }
+}
+
+const isMain = process.argv[1]
+  ? path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+  : false;
+if (isMain) process.exitCode = await main();

--- a/packages/test/scenarios/orchestrator/orchestrator-grilling-live.scenario.ts
+++ b/packages/test/scenarios/orchestrator/orchestrator-grilling-live.scenario.ts
@@ -1,0 +1,34 @@
+/** Exposes live completion-verifier behavior to the repository's nightly scenario catalog. */
+import type { IAgentRuntime } from "@elizaos/core";
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { runGrillingHappyPathCheck } from "../../../../plugins/plugin-agent-orchestrator/test/scenarios/_helpers/grilling-scenario.ts";
+
+export default scenario({
+  lane: "live-only",
+  id: "orchestrator.grilling-happy-path",
+  title: "Evidence-free completion is grilled before live-model verification",
+  domain: "agent-orchestrator",
+  tags: ["orchestrator", "verification", "live"],
+  description:
+    "Runs the real completion verification loop against a live model: reject an evidence-free claim, then accept pasted passing proof.",
+  turns: [],
+  finalChecks: [
+    {
+      type: "custom",
+      name: "live-completion-grilling",
+      predicate: async (ctx) => {
+        const runtime = ctx.runtime as IAgentRuntime;
+        const result = await runGrillingHappyPathCheck(
+          runtime,
+          (...args: unknown[]) =>
+            runtime.useModel(...(args as Parameters<typeof runtime.useModel>)),
+        );
+        if (result.failure) return result.failure;
+        if (result.finalStatus !== "done") {
+          return `expected done after verified proof, received ${result.finalStatus}`;
+        }
+        return undefined;
+      },
+    },
+  ],
+});

--- a/packages/test/scenarios/orchestrator/orchestrator-routing-live.scenario.ts
+++ b/packages/test/scenarios/orchestrator/orchestrator-routing-live.scenario.ts
@@ -66,6 +66,7 @@ export default scenario({
           },
         ] as const;
 
+        let failure: string | undefined;
         for (const example of cases) {
           const decision = await decideInterruptionWithModel(observedRuntime, {
             text: example.text,
@@ -77,21 +78,25 @@ export default scenario({
               "Refactor authentication session refresh and add regression coverage",
           });
           if (decision.action !== example.expected) {
-            return `${JSON.stringify(example.text)} expected ${example.expected}, received ${decision.action}: ${decision.reason}`;
+            failure = `${JSON.stringify(example.text)} expected ${example.expected}, received ${decision.action}: ${decision.reason}`;
+            break;
           }
           if (!decision.reason.startsWith("model:")) {
-            return `${JSON.stringify(example.text)} used the fallback instead of the live model: ${decision.reason}`;
+            failure = `${JSON.stringify(example.text)} used the fallback instead of the live model: ${decision.reason}`;
+            break;
           }
         }
-        const runDir = process.env.RUN_DIR;
-        if (!runDir) return "RUN_DIR is required for live routing evidence";
+        const runDir = process.env.ELIZA_LIFEOPS_RUN_DIR?.trim();
+        if (!runDir) {
+          return "the scenario runner did not expose its run directory";
+        }
         await mkdir(runDir, { recursive: true });
         await writeFile(
           path.join(runDir, "orchestrator-routing-model-io.jsonl"),
           `${modelIo.map((entry) => JSON.stringify(entry)).join("\n")}\n`,
           "utf8",
         );
-        return undefined;
+        return failure;
       },
     },
   ],

--- a/packages/test/scenarios/orchestrator/orchestrator-routing-live.scenario.ts
+++ b/packages/test/scenarios/orchestrator/orchestrator-routing-live.scenario.ts
@@ -1,0 +1,63 @@
+/**
+ * Live-model evidence for origin-channel interruption classification, paired
+ * with the deterministic forwarding scenario that exercises delivery wiring.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { decideInterruptionWithModel } from "../../../../plugins/plugin-agent-orchestrator/src/services/interruption-decider.ts";
+
+export default scenario({
+  lane: "live-only",
+  id: "orchestrator.origin-routing-live",
+  title: "Origin-channel messages are classified for the coding task",
+  domain: "agent-orchestrator",
+  tags: ["orchestrator", "routing", "live"],
+  description:
+    "Uses a live model to distinguish planner-owned origin-channel chatter from coding-task follow-ups for idle and busy sub-agents.",
+  turns: [],
+  finalChecks: [
+    {
+      type: "custom",
+      name: "live-origin-channel-classification",
+      predicate: async (ctx) => {
+        const runtime = ctx.runtime as IAgentRuntime;
+        const cases = [
+          {
+            text: "Remind me to call Mom at 6pm.",
+            sessionBusy: false,
+            expected: "ignore",
+          },
+          {
+            text: "For the authentication refactor, also add a regression test for expired sessions.",
+            sessionBusy: false,
+            expected: "deliver",
+          },
+          {
+            text: "For the authentication refactor, also cover concurrent session refreshes.",
+            sessionBusy: true,
+            expected: "queue",
+          },
+        ] as const;
+
+        for (const example of cases) {
+          const decision = await decideInterruptionWithModel(runtime, {
+            text: example.text,
+            agentType: "codex",
+            agentLabel: "Ada",
+            sessionBusy: example.sessionBusy,
+            sharedChannel: true,
+            taskContext:
+              "Refactor authentication session refresh and add regression coverage",
+          });
+          if (decision.action !== example.expected) {
+            return `${JSON.stringify(example.text)} expected ${example.expected}, received ${decision.action}: ${decision.reason}`;
+          }
+          if (!decision.reason.startsWith("model:")) {
+            return `${JSON.stringify(example.text)} used the fallback instead of the live model: ${decision.reason}`;
+          }
+        }
+        return undefined;
+      },
+    },
+  ],
+});

--- a/packages/test/scenarios/orchestrator/orchestrator-routing-live.scenario.ts
+++ b/packages/test/scenarios/orchestrator/orchestrator-routing-live.scenario.ts
@@ -2,7 +2,9 @@
  * Live-model evidence for origin-channel interruption classification, paired
  * with the deterministic forwarding scenario that exercises delivery wiring.
  */
-import type { IAgentRuntime } from "@elizaos/core";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { IAgentRuntime, ModelTypeName } from "@elizaos/core";
 import { scenario } from "@elizaos/scenario-runner/schema";
 import { decideInterruptionWithModel } from "../../../../plugins/plugin-agent-orchestrator/src/services/interruption-decider.ts";
 
@@ -21,6 +23,31 @@ export default scenario({
       name: "live-origin-channel-classification",
       predicate: async (ctx) => {
         const runtime = ctx.runtime as IAgentRuntime;
+        const modelIo: Array<{
+          modelType: ModelTypeName;
+          prompt: string;
+          response: string;
+        }> = [];
+        const observedRuntime = new Proxy(runtime, {
+          get(target, property, receiver) {
+            if (property !== "useModel") {
+              return Reflect.get(target, property, receiver);
+            }
+            return async (
+              modelType: ModelTypeName,
+              params: { prompt?: unknown },
+            ) => {
+              const response = await runtime.useModel(modelType, params);
+              modelIo.push({
+                modelType,
+                prompt: typeof params.prompt === "string" ? params.prompt : "",
+                response:
+                  typeof response === "string" ? response : String(response),
+              });
+              return response;
+            };
+          },
+        }) as IAgentRuntime;
         const cases = [
           {
             text: "Remind me to call Mom at 6pm.",
@@ -40,7 +67,7 @@ export default scenario({
         ] as const;
 
         for (const example of cases) {
-          const decision = await decideInterruptionWithModel(runtime, {
+          const decision = await decideInterruptionWithModel(observedRuntime, {
             text: example.text,
             agentType: "codex",
             agentLabel: "Ada",
@@ -56,6 +83,14 @@ export default scenario({
             return `${JSON.stringify(example.text)} used the fallback instead of the live model: ${decision.reason}`;
           }
         }
+        const runDir = process.env.RUN_DIR;
+        if (!runDir) return "RUN_DIR is required for live routing evidence";
+        await mkdir(runDir, { recursive: true });
+        await writeFile(
+          path.join(runDir, "orchestrator-routing-model-io.jsonl"),
+          `${modelIo.map((entry) => JSON.stringify(entry)).join("\n")}\n`,
+          "utf8",
+        );
         return undefined;
       },
     },

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/interruption-decider.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/interruption-decider.test.ts
@@ -232,6 +232,48 @@ describe("decideInterruptionWithModel", () => {
     expect(decision.reason).toMatch(/^model:/);
   });
 
+  it("delivers a relevant shared-channel message when an idle-session model says queue", async () => {
+    const useModel = vi.fn(async () =>
+      JSON.stringify({ action: "queue", reason: "relevant task follow-up" }),
+    );
+    const decision = await decideInterruptionWithModel(
+      runtimeWithModel(useModel),
+      {
+        ...base,
+        text: "For this refactor, also cover expired sessions",
+        sessionBusy: false,
+        sharedChannel: true,
+      },
+    );
+    expect(useModel).toHaveBeenCalledTimes(1);
+    expect(decision).toEqual({
+      action: "deliver",
+      reason:
+        "model: relevant task follow-up; queue normalized for idle session",
+    });
+  });
+
+  it("queues a relevant shared-channel message when a busy-session model says deliver", async () => {
+    const useModel = vi.fn(async () =>
+      JSON.stringify({ action: "deliver", reason: "relevant task follow-up" }),
+    );
+    const decision = await decideInterruptionWithModel(
+      runtimeWithModel(useModel),
+      {
+        ...base,
+        text: "For this refactor, also cover concurrent refreshes",
+        sessionBusy: true,
+        sharedChannel: true,
+      },
+    );
+    expect(useModel).toHaveBeenCalledTimes(1);
+    expect(decision).toEqual({
+      action: "queue",
+      reason:
+        "model: relevant task follow-up; delivery normalized for busy session",
+    });
+  });
+
   it("lets the model interrupt for a semantic redirect the regex would only queue", async () => {
     // "let's rework this to use Postgres" has no STOP/REDIRECT regex token, so
     // the pure decider queues it; the model recognizes a direction-invalidating

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
@@ -9,6 +9,7 @@
  *    fork / validate / messages),
  *  - the session→task status state machine (including the guards that stop a
  *    weak `active` signal from stomping `blocked`/`validating`/terminal/paused),
+ *  - completion-evidence isolation across automatic-verification retries,
  *  - usage telemetry roll-up and per-turn dedup,
  *  - cross-task status aggregation and bulk pause/resume.
  */
@@ -1219,6 +1220,75 @@ describe("OrchestratorTaskService — event bridge session status", () => {
     expect(session.taskDelivered).toBe(true);
     expect(session.completionSummary).toBe("shipped it");
     expect(session.stoppedAt).toBeTruthy();
+  });
+
+  it("keeps verifier feedback out of the corrected retry's evidence", async () => {
+    const acp = new FakeAcp();
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const prompts: string[] = [];
+    const priorDiagnostic =
+      "PRIOR VERIFIER DIAGNOSTIC: the tests failed automatic verification";
+    const baseRuntime = runtime(acp);
+    const service = new OrchestratorTaskService(
+      {
+        ...baseRuntime,
+        useModel: vi.fn(async (...args: unknown[]) => {
+          const options = args[1] as { prompt?: string } | undefined;
+          const prompt = options?.prompt ?? "";
+          prompts.push(prompt);
+          const hasCorrectedProof =
+            prompt.includes("diff --git a/src/widget.ts b/src/widget.ts") &&
+            prompt.includes("Test Files  1 passed (1)");
+          const contaminated = prompt.includes(priorDiagnostic);
+          return JSON.stringify(
+            hasCorrectedProof && !contaminated
+              ? {
+                  passed: true,
+                  summary: "corrected proof passed",
+                  missing: [],
+                }
+              : {
+                  passed: false,
+                  summary: priorDiagnostic,
+                  missing: ["tests pass"],
+                },
+          );
+        }),
+      } as never,
+      { store },
+    );
+    await service.start();
+    try {
+      const task = await store.createTask({
+        title: "Verify corrected retry",
+        goal: "Implement the widget and prove the tests pass",
+        acceptanceCriteria: ["tests pass"],
+      });
+      const taskId = task.task.id;
+      const sessionId = await addStoredSession(
+        store,
+        taskId,
+        "retry-evidence-session",
+      );
+
+      acp.emit(sessionId, "task_complete", {
+        response: "I implemented the widget and believe it works.",
+      });
+      await vi.waitFor(() => expect(acp.sent).toHaveLength(1));
+
+      acp.emit(sessionId, "task_complete", {
+        response: `Done.\n\n\`\`\`diff\ndiff --git a/src/widget.ts b/src/widget.ts\n--- a/src/widget.ts\n+++ b/src/widget.ts\n@@\n+export const widget = () => 42;\n\`\`\`\n\n\`\`\`\n$ bun test\n✓ src/widget.test.ts (1 test) 20ms\nTest Files  1 passed (1)\nTests  1 passed (1)\n\`\`\``,
+      });
+      await vi.waitFor(async () => {
+        expect((await store.getTask(taskId))?.task.status).toBe("done");
+      });
+
+      expect(prompts).toHaveLength(2);
+      expect(prompts[1]).toContain("Test Files  1 passed (1)");
+      expect(prompts[1]).not.toContain(priorDiagnostic);
+    } finally {
+      await service.stop();
+    }
   });
 
   it("rejects malformed live change-set metadata and mirrors a real workspace diff", async () => {

--- a/plugins/plugin-agent-orchestrator/src/__tests__/auto-goal-verify.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/auto-goal-verify.test.ts
@@ -101,14 +101,14 @@ function makeFakeAcp() {
 
 function makeRuntime(
   acp: ReturnType<typeof makeFakeAcp>["service"],
-  modelResponse: (...args: unknown[]) => string,
+  modelResponse: () => string,
 ): Record<string, unknown> {
   return {
     character: { name: "Tester" },
     databaseAdapter: undefined,
     logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     getSetting: () => undefined,
-    useModel: vi.fn(async (...args: unknown[]) => modelResponse(...args)),
+    useModel: vi.fn(async () => modelResponse()),
     getService: (type: string) =>
       type === AcpService.serviceType ? acp : undefined,
   };
@@ -284,53 +284,6 @@ describe("auto goal verification on task_complete", () => {
     expect(doc?.task.status).toBe("active");
     expect(doc?.task.metadata.autoVerifyAttempts).toBe(1);
     expect(doc?.task.status).not.toBe("done");
-  });
-
-  it("keeps prior verifier feedback out of a corrected retry's evidence", async () => {
-    const fake = makeFakeAcp();
-    const store = new OrchestratorTaskStore({ backend: "memory" });
-    const { taskId, sessionId } = await seedTaskWithSession(store, [
-      "tests pass",
-    ]);
-    const prompts: string[] = [];
-    const priorDiagnostic =
-      "PRIOR VERIFIER DIAGNOSTIC: the tests failed automatic verification";
-    const runtime = makeRuntime(fake.service, (...args: unknown[]) => {
-      const options = args[1] as { prompt?: string } | undefined;
-      const prompt = options?.prompt ?? "";
-      prompts.push(prompt);
-      const hasCorrectedProof =
-        prompt.includes("diff --git a/src/widget.ts b/src/widget.ts") &&
-        prompt.includes("Test Files  1 passed (1)");
-      const contaminated = prompt.includes(priorDiagnostic);
-      return JSON.stringify(
-        hasCorrectedProof && !contaminated
-          ? { passed: true, summary: "corrected proof passed", missing: [] }
-          : {
-              passed: false,
-              summary: priorDiagnostic,
-              missing: ["tests pass"],
-            },
-      );
-    });
-    const service = new OrchestratorTaskService(runtime as never, { store });
-    await service.start();
-
-    fake.emit(sessionId, "task_complete", {
-      response: "I implemented the widget and believe it works.",
-    });
-    await vi.waitFor(() => expect(fake.sent).toHaveLength(1));
-
-    fake.emit(sessionId, "task_complete", {
-      response: `Done.\n\n\`\`\`diff\ndiff --git a/src/widget.ts b/src/widget.ts\n--- a/src/widget.ts\n+++ b/src/widget.ts\n@@\n+export const widget = () => 42;\n\`\`\`\n\n\`\`\`\n$ bun test\n✓ src/widget.test.ts (1 test) 20ms\nTest Files  1 passed (1)\nTests  1 passed (1)\n\`\`\``,
-    });
-    await vi.waitFor(async () => {
-      expect((await store.getTask(taskId))?.task.status).toBe("done");
-    });
-
-    expect(prompts).toHaveLength(2);
-    expect(prompts[1]).toContain("Test Files  1 passed (1)");
-    expect(prompts[1]).not.toContain(priorDiagnostic);
   });
 
   it("escalates the corrective tone on the second failure (attempt 2)", async () => {

--- a/plugins/plugin-agent-orchestrator/src/__tests__/auto-goal-verify.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/auto-goal-verify.test.ts
@@ -101,14 +101,14 @@ function makeFakeAcp() {
 
 function makeRuntime(
   acp: ReturnType<typeof makeFakeAcp>["service"],
-  modelResponse: () => string,
+  modelResponse: (...args: unknown[]) => string,
 ): Record<string, unknown> {
   return {
     character: { name: "Tester" },
     databaseAdapter: undefined,
     logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     getSetting: () => undefined,
-    useModel: vi.fn(async () => modelResponse()),
+    useModel: vi.fn(async (...args: unknown[]) => modelResponse(...args)),
     getService: (type: string) =>
       type === AcpService.serviceType ? acp : undefined,
   };
@@ -284,6 +284,53 @@ describe("auto goal verification on task_complete", () => {
     expect(doc?.task.status).toBe("active");
     expect(doc?.task.metadata.autoVerifyAttempts).toBe(1);
     expect(doc?.task.status).not.toBe("done");
+  });
+
+  it("keeps prior verifier feedback out of a corrected retry's evidence", async () => {
+    const fake = makeFakeAcp();
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const { taskId, sessionId } = await seedTaskWithSession(store, [
+      "tests pass",
+    ]);
+    const prompts: string[] = [];
+    const priorDiagnostic =
+      "PRIOR VERIFIER DIAGNOSTIC: the tests failed automatic verification";
+    const runtime = makeRuntime(fake.service, (...args: unknown[]) => {
+      const options = args[1] as { prompt?: string } | undefined;
+      const prompt = options?.prompt ?? "";
+      prompts.push(prompt);
+      const hasCorrectedProof =
+        prompt.includes("diff --git a/src/widget.ts b/src/widget.ts") &&
+        prompt.includes("Test Files  1 passed (1)");
+      const contaminated = prompt.includes(priorDiagnostic);
+      return JSON.stringify(
+        hasCorrectedProof && !contaminated
+          ? { passed: true, summary: "corrected proof passed", missing: [] }
+          : {
+              passed: false,
+              summary: priorDiagnostic,
+              missing: ["tests pass"],
+            },
+      );
+    });
+    const service = new OrchestratorTaskService(runtime as never, { store });
+    await service.start();
+
+    fake.emit(sessionId, "task_complete", {
+      response: "I implemented the widget and believe it works.",
+    });
+    await vi.waitFor(() => expect(fake.sent).toHaveLength(1));
+
+    fake.emit(sessionId, "task_complete", {
+      response: `Done.\n\n\`\`\`diff\ndiff --git a/src/widget.ts b/src/widget.ts\n--- a/src/widget.ts\n+++ b/src/widget.ts\n@@\n+export const widget = () => 42;\n\`\`\`\n\n\`\`\`\n$ bun test\n✓ src/widget.test.ts (1 test) 20ms\nTest Files  1 passed (1)\nTests  1 passed (1)\n\`\`\``,
+    });
+    await vi.waitFor(async () => {
+      expect((await store.getTask(taskId))?.task.status).toBe("done");
+    });
+
+    expect(prompts).toHaveLength(2);
+    expect(prompts[1]).toContain("Test Files  1 passed (1)");
+    expect(prompts[1]).not.toContain(priorDiagnostic);
   });
 
   it("escalates the corrective tone on the second failure (attempt 2)", async () => {

--- a/plugins/plugin-agent-orchestrator/src/services/interruption-decider.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/interruption-decider.ts
@@ -262,7 +262,26 @@ export async function decideInterruptionWithModel(
     const verdict = parseInterruptionVerdict(
       typeof raw === "string" ? raw : String(raw),
     );
-    return verdict ?? baseline;
+    if (!verdict) return baseline;
+
+    // The model decides relevance and interruption intent, while the observed
+    // ACP state is authoritative for when a relevant message can be sent. The
+    // forwarding boundary already applies this invariant; canonicalizing its
+    // timing labels here keeps decision logs and direct callers truthful when
+    // a model returns the right relevance with the wrong idle/busy verb.
+    if (!input.sessionBusy && verdict.action === "queue") {
+      return {
+        action: "deliver",
+        reason: `${verdict.reason}; queue normalized for idle session`,
+      };
+    }
+    if (input.sessionBusy && verdict.action === "deliver") {
+      return {
+        action: "queue",
+        reason: `${verdict.reason}; delivery normalized for busy session`,
+      };
+    }
+    return verdict;
   } catch {
     // error-policy:J4 model unavailable/unparseable → deterministic regex
     // baseline (deliver when idle), INCLUDING on shared channels. Fail-open is

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -569,19 +569,6 @@ function readLastChangeSet(
   return candidate as WorkspaceChangeSet;
 }
 
-/** Render an event's `data` payload to a bounded scannable string so the
- *  completion-evidence assembler can mine build/test lines out of it. */
-function stringifyEventData(data: Record<string, unknown>): string {
-  if (!data || Object.keys(data).length === 0) return "";
-  try {
-    return truncate(JSON.stringify(data), 1500);
-  } catch {
-    // error-policy:J3 arbitrary event data may be non-serializable (circular);
-    // empty means "no minable text from this event", not a masked failure.
-    return "";
-  }
-}
-
 const EVIDENCE_URL_RE = /https?:\/\/[^\s<>"'`)\]]+/g;
 
 /** Collect distinct http(s) URLs from a set of text bodies, for the verified-
@@ -1853,20 +1840,17 @@ export class OrchestratorTaskService extends Service {
       .map((message) => message.content.trim())
       .filter((content) => content.length > 0);
 
-    // Tool-output signals: prefer the structured `toolCall.output` recorded on
-    // `tool_running`/`tool_result` events, labelled by the tool command/title so
-    // the classifier can route the stdout to its test/build/lint bucket. Fall
-    // back to the full event/message bodies so a real run still surfaces even
-    // when the adapter folded its output into the assistant text.
+    // Only worker-originated text may become command evidence. The task event
+    // log also contains verifier verdicts and corrective prompts; mining those
+    // would feed a prior failed verdict back into the next attempt as if it were
+    // fresh failing test output. The final reply is already rendered verbatim by
+    // the bundle, while sub-agent stdout covers adapters that fold tool results
+    // into assistant messages instead of structured tool events.
     const toolSignals: EvidenceSignal[] = [
       ...this.extractToolSignals(sessionEvents),
-      ...sessionEvents.map((event) => ({
-        text: `${event.summary}\n${stringifyEventData(event.data)}`,
-        source: event.eventType,
-      })),
-      ...sessionMessages.map((message) => ({
-        text: message.content,
-        source: message.senderKind,
+      ...subAgentReplies.map((text) => ({
+        text,
+        source: "sub_agent",
       })),
     ];
     const toolOutput = classifyToolOutput(toolSignals);


### PR DESCRIPTION
## Summary

- add default-catalog `live-only` scenarios for the real completion-grilling loop and origin-channel routing classification
- persist exact routing prompts/responses and export `eliza_native_v1` trajectories to the run directory by default, with explicit disable/override support
- prevent verifier-generated failures and corrective prompts from being reclassified as worker test output on the next completion attempt
- prove the retry fix through the real `OrchestratorTaskService` and durable store path

This rebuilds only the focused residuals from `chore/evidence-orchestrator-16254-16256` (`7670206e`, `dbbd3e8c`) on current `develop`; it does not resurrect the aggregate branch.

Closes #16422
Closes #16427

## Verification

Exact remote head: `bdebaee0bde818fb3cd0ae7b80407bc86598afc8`

- `bun test packages/scripts/__tests__/live-scenarios-workflow.test.ts` — 10 passed; exercises discovery, default native export, filtering, skip rejection, enforced/nonblocking gates, and spawn/signal failures
- canonical `orchestrator-task-service.test.ts` suite — 89 passed through the real in-memory store/event bridge, including two completion attempts and proof that the stale verifier diagnostic is absent on retry
- combined interruption-decider, active-session-forward, and canonical service suites — 128 passed; the decider now makes observed ACP idle/busy state authoritative for delivery timing even when the model returns the right relevance with the wrong timing verb
- generated LCOV: `run-live-scenarios.mjs` 161/167 lines (96.41%); `orchestrator-task-service.ts` 899/1270 lines (70.79%)
- `bun run --cwd plugins/plugin-agent-orchestrator typecheck` — passed
- Biome check over all six changed files — passed
- `bun run audit:error-policy-ratchet` — passed
- `git diff --check` — passed

- [Exact-head Live Scenarios recapture 29525712312](https://github.com/elizaOS/eliza/actions/runs/29525712312) is running at `bdebaee0bde818fb3cd0ae7b80407bc86598afc8` against `develop` `184a4cc85072165a2cd911cb65c50d6a5c409326`.
- Run [29524291198](https://github.com/elizaOS/eliza/actions/runs/29524291198) reached the real model and exposed a structural mismatch: for a relevant idle-session follow-up, the model returned `queue` even though the prompt required `deliver`. The production forwarding boundary already delivered either relevant timing label according to real ACP state, but the decider/log remained misleading. This head canonicalizes `queue`→`deliver` when idle and `deliver`→`queue` when busy, with deterministic regressions for both directions. Every failed-run artifact was manually reviewed; matrix/report SHA-256 `42afe4f2d258b266ff5718fdcfd797064463997914c27a2bcc36993e5b5b6632`, routing model I/O `6040e9b992d73eebf9d55314930ee49d6534798ab032fc89b1438a9894224e2c`, and native JSONL `143c7d75901036a6c82131a92780635af081948b47c06bbaefcded6159a7adfb`.
- The prior-base run [29473359937](https://github.com/elizaOS/eliza/actions/runs/29473359937) passed both live scenarios. Manual review confirmed that the verifier rejected an evidence-free claim, accepted the same task only with a concrete diff plus 3/3 passing test log, and classified unrelated/relevant-idle/relevant-mid-turn messages as ignore/deliver/queue.
- Every uploaded file from 29473359937 was downloaded, hashed, and manually reviewed. SHA-256: matrix/report `c02259152096b8426c849ff7c5254cb8c1c2af38490f580d826e3f2a25632df7`; native JSONL `86e0e0cf547986b9b26457652a37cbe7d31972257f30705150828dc7fe59683d`; routing model I/O `576eda0a8a9dd64d2e6f81ae4c3e5289097cd81e1b0011b1e9834394e4d803b5`; privacy attestation `2a3f7baf8ca38d8d27c1b722bd801f35f63f4447f4238c534801f98d29bfeca3`; viewer data `792eafc8b1cc0ee18efa714dbfb2be8fd9ee60b541882bf69258f55599460d7b`; viewer HTML `d442b203fe06df10c5faad4b16c27b635cba7a1fef62faa37ad70c62a11e6b4b`; trajectories `99e12b717a4ea1c54cc16355e41197c27e968afe3b198c446fe01013f760172d` and `b2e8ee30d1f378f5bb228a09b919b13467ffd3ad4e97d0a092c7271c93c13ddf`.
- The strict privacy gate passed with one synthetic contact-pattern false positive redacted and zero residual findings. The run predates the latest base advance, so it is retained as diagnostic history rather than current-head proof.

The branch was rebased onto current `develop` (`184a4cc85072165a2cd911cb65c50d6a5c409326`) and the focused local suites were rerun: 10/10 workflow tests and 89/89 canonical service tests pass. The current-head real-model artifact must still be downloaded, hashed, and manually reviewed before this draft can be readied.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots/visual baseline: N/A - no UI or rendered visual surface changes.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots/visual check: N/A - no UI or rendered visual surface changes.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - the changed surface is a backend verifier and headless scenario harness, with no visual flow.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs: [exact-head recapture 29525712312](https://github.com/elizaOS/eliza/actions/runs/29525712312) in progress; manual review pending.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend code or browser/network behavior changes.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: [exact-head recapture 29525712312](https://github.com/elizaOS/eliza/actions/runs/29525712312) in progress; boundary rows and routing model I/O pending manual review.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: current-head report, matrix, viewer, model I/O, native JSONL/manifest, and privacy attestation pending download/hash/manual review from [run 29525712312](https://github.com/elizaOS/eliza/actions/runs/29525712312).
