### PR TITLE
feat(cloud): org-scoped idempotency key on credit reservations

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts
@@ -642,6 +642,135 @@ describe("CreditsService.reconcile idempotency (#10846)", () => {
   );
 });
 
+describe("CreditsService.reserve idempotency key (#16425)", () => {
+  const ORG_B = "00000000-0000-0000-0000-0000000000c3";
+
+  test(
+    "the same key replays the committed reservation — deducted exactly once",
+    async () => {
+      if (!pgliteReady) return;
+      await seedOrg("10");
+
+      const first = await creditsService.reserve({
+        organizationId: ORG_ID,
+        userId: USER_ID,
+        amount: 0.5,
+        description: "tts utterance",
+        idempotencyKey: "utt-1",
+      });
+      // The client's fallback transport re-POSTs the same logical utterance.
+      const replay = await creditsService.reserve({
+        organizationId: ORG_ID,
+        userId: USER_ID,
+        amount: 0.5,
+        description: "tts utterance",
+        idempotencyKey: "utt-1",
+      });
+
+      expect(replay.reservationTransactionId).toBe(first.reservationTransactionId);
+      // One upfront deduction, not two: balance = 10 - 0.5, one transaction row.
+      expect(await getBalance()).toBeCloseTo(9.5, 6);
+      expect(await countTransactions()).toBe(1);
+
+      // Whichever request settles, settlement stays exactly-once (#10846).
+      await first.reconcile(0.2);
+      await replay.reconcile(0.2);
+      expect(await getBalance()).toBeCloseTo(9.8, 6);
+      expect(await countByType("refund")).toBe(1);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a replay carries the ORIGINAL reserved amount so reconcile math settles the deducted row",
+    async () => {
+      if (!pgliteReady) return;
+      await seedOrg("10");
+
+      const first = await creditsService.reserve({
+        organizationId: ORG_ID,
+        userId: USER_ID,
+        amount: 0.4,
+        description: "tts utterance",
+        idempotencyKey: "utt-2",
+      });
+      // The retry re-estimated higher — the handle must still be the 0.4 row.
+      const replay = await creditsService.reserve({
+        organizationId: ORG_ID,
+        userId: USER_ID,
+        amount: 0.9,
+        description: "tts utterance",
+        idempotencyKey: "utt-2",
+      });
+
+      expect(replay.reservationTransactionId).toBe(first.reservationTransactionId);
+      expect(replay.reservedAmount).toBeCloseTo(0.4, 6);
+      expect(await getBalance()).toBeCloseTo(9.6, 6);
+
+      // Settling via the REPLAY handle refunds against the original 0.4.
+      await replay.reconcile(0.1);
+      expect(await getBalance()).toBeCloseTo(9.9, 6);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "keys are org-scoped — the same key in another org reserves independently",
+    async () => {
+      if (!pgliteReady) return;
+      await seedOrg("10");
+      await dbWrite.execute(`DELETE FROM credit_transactions WHERE organization_id = '${ORG_B}';`);
+      await dbWrite.execute(`DELETE FROM organizations WHERE id = '${ORG_B}';`);
+      await dbWrite.execute(
+        `INSERT INTO organizations (id, credit_balance) VALUES ('${ORG_B}', '10');`,
+      );
+
+      const a = await creditsService.reserve({
+        organizationId: ORG_ID,
+        amount: 0.5,
+        description: "tts utterance",
+        idempotencyKey: "utt-3",
+      });
+      const b = await creditsService.reserve({
+        organizationId: ORG_B,
+        amount: 0.5,
+        description: "tts utterance",
+        idempotencyKey: "utt-3",
+      });
+
+      // Two DIFFERENT reservations: a cross-tenant key can never attach to
+      // another org's reservation.
+      expect(b.reservationTransactionId).not.toBe(a.reservationTransactionId);
+      expect(await getBalance()).toBeCloseTo(9.5, 6);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "without a key, repeated reserves stay independent (behavior unchanged)",
+    async () => {
+      if (!pgliteReady) return;
+      await seedOrg("10");
+
+      const a = await creditsService.reserve({
+        organizationId: ORG_ID,
+        amount: 0.5,
+        description: "tts utterance",
+      });
+      const b = await creditsService.reserve({
+        organizationId: ORG_ID,
+        amount: 0.5,
+        description: "tts utterance",
+      });
+
+      expect(b.reservationTransactionId).not.toBe(a.reservationTransactionId);
+      expect(await getBalance()).toBeCloseTo(9.0, 6);
+      expect(await countTransactions()).toBe(2);
+    },
+    PGLITE_TIMEOUT,
+  );
+});
+
 describe("CreditsService reservation settlement marker (#11169)", () => {
   test(
     "real reservation rows are claimed and refunded once",

--- a/packages/cloud/shared/src/lib/services/credits.ts
+++ b/packages/cloud/shared/src/lib/services/credits.ts
@@ -112,6 +112,20 @@ export interface ReserveCreditsParams {
   estimatedOutputTokens?: number;
   /** Multiplies model-estimated reservations for caller-known markups. */
   estimatedCostMultiplier?: number;
+  /**
+   * Optional idempotency key for the LOGICAL operation — e.g. one TTS
+   * utterance whose client retries the same request over a fallback transport
+   * after an ambiguous network outcome (#16425). A reserve whose key already
+   * committed returns a handle bound to the ORIGINAL reservation (same
+   * transaction id, reservedAmount recovered from its metadata) instead of
+   * deducting a second time; settlement stays exactly-once per reservation via
+   * the reconcile dedupe (#10846). Namespaced per organization into
+   * `stripe_payment_intent_id` (`reserve:<orgId>:<key>`), whose unique index is
+   * the concurrency backstop — so a key replayed from another org can never
+   * attach to this org's reservation. Omit for the unchanged per-request
+   * behavior.
+   */
+  idempotencyKey?: string;
 }
 
 export interface ReservationSweepStats {
@@ -2103,22 +2117,44 @@ export class CreditsService {
       throw new Error("reserve() requires either `amount` or `model`");
     }
 
-    const result = await this.reserveAndDeductCredits({
-      organizationId,
-      amount: reservedAmount,
-      description: `${description} (reserved)`,
-      metadata: {
-        user_id: userId,
-        type: "reservation",
-        settlement_marker: RESERVATION_SETTLEMENT_MARKER,
-        estimated_cost: estimatedCost,
-        reserved_amount: reservedAmount,
-        ...(estimatedCostMultiplier !== 1 && {
-          estimated_cost_multiplier: estimatedCostMultiplier,
-        }),
-        ...(model && { model }),
-      },
-    });
+    // #16425: an idempotency key names the LOGICAL operation so a client retry
+    // (e.g. the forced-cloud TTS direct→proxy fallback after an ambiguous
+    // network outcome) replays the committed reservation instead of deducting
+    // again. Org-scoped so a key from another tenant can never attach here.
+    const idempotencyMarker = params.idempotencyKey
+      ? `reserve:${organizationId}:${params.idempotencyKey}`
+      : undefined;
+
+    const reserveOnce = () =>
+      this.reserveAndDeductCredits({
+        organizationId,
+        amount: reservedAmount,
+        description: `${description} (reserved)`,
+        ...(idempotencyMarker && { stripePaymentIntentId: idempotencyMarker }),
+        metadata: {
+          user_id: userId,
+          type: "reservation",
+          settlement_marker: RESERVATION_SETTLEMENT_MARKER,
+          estimated_cost: estimatedCost,
+          reserved_amount: reservedAmount,
+          ...(estimatedCostMultiplier !== 1 && {
+            estimated_cost_multiplier: estimatedCostMultiplier,
+          }),
+          ...(model && { model }),
+        },
+      });
+
+    let result: Awaited<ReturnType<typeof reserveOnce>>;
+    try {
+      result = await reserveOnce();
+    } catch (error) {
+      // Keyed concurrency backstop (#10846 pattern): a racing duplicate aborts
+      // the whole atomic statement on the stripe_payment_intent_id unique
+      // index. Retry once — the pre-committed-transaction check then resolves
+      // to the winner's reservation and this call replays it.
+      if (!idempotencyMarker) throw error;
+      result = await reserveOnce();
+    }
 
     if (!result.success) {
       logger.warn("[Credits] Insufficient credits for reservation", {
@@ -2134,10 +2170,25 @@ export class CreditsService {
     }
     const reservationTransactionId = result.transaction.id;
 
+    // On a keyed REPLAY the transaction is the original reservation, whose
+    // reserved amount may differ from this call's estimate (e.g. a retried
+    // utterance re-estimated after a pricing refresh). The handle must carry
+    // the ORIGINAL amount so reconcile's refund/overage math settles the row
+    // that was actually deducted.
+    if (idempotencyMarker) {
+      const originalReserved = Number(
+        (result.transaction.metadata as { reserved_amount?: unknown } | null)?.reserved_amount,
+      );
+      if (Number.isFinite(originalReserved) && originalReserved > 0) {
+        reservedAmount = originalReserved;
+      }
+    }
+
     logger.info("[Credits] Reserved", {
       organizationId,
       reservedAmount,
       ...(model && { model }),
+      ...(idempotencyMarker && { keyed: true }),
     });
 
     return {


### PR DESCRIPTION
# Relates to

Refs #16425 (the reservation-dedupe rail; the header threading — route, proxy, client — follows in a companion PR).

- [x] Targets `develop`, rebased on latest `origin/develop`, zero conflicts.
- [x] A reviewer can confirm the change from the evidence below without reading the code.

# Risks

Low. Opt-in parameter: unkeyed callers (every existing call site) are byte-identical to before. The keyed path rides the existing #10846 keyed-deduction rail (`stripe_payment_intent_id` unique index as the concurrency backstop) rather than introducing a new mechanism, and keys are org-scoped so a replayed key from another tenant can never attach to this org's reservation.

# Background

## What does this PR do?

The forced-cloud TTS fallback (#16324) re-POSTs the same logical utterance through a second transport after an ambiguous network outcome. Each request creates its own reservation, so a lost response after the direct request settled means the utterance is synthesized **and charged twice** (#16425) — the correctness blocker that got #16118 closed as unsafe.

This adds the missing primitive: `reserve({ idempotencyKey })` naming the *logical operation*. A keyed reserve whose key already committed returns a handle bound to the **original** reservation — same transaction id, `reservedAmount` recovered from the original's metadata so reconcile's refund/overage math settles the row that was actually deducted — instead of deducting a second time. Settlement stays exactly-once per reservation via the existing reconcile dedupe. A raced duplicate aborts on the unique index and retries once into the pre-committed check.

## Scope

Deliberately the rail only — inert until a caller passes a key. The companion PR threads the client-minted `Idempotency-Key` header through the TTS route, the on-device proxy, and `useVoiceChat` (with the header already present in `CORS_ALLOW_HEADER_NAMES`), plus the missing test lanes for those files.

## What kind of change is this?

Feature (billing-correctness primitive; opt-in, non-breaking).

# Documentation changes needed?

No — the param docblock carries the contract.

# Testing

## Where should a reviewer start?

`ReserveCreditsParams.idempotencyKey` docs, then the keyed branch in `reserve()`. Pinned by the new describe in `__tests__/credits-reconcile.test.ts` (real PGlite — the unique index and the atomic CTE actually execute).

## Detailed testing steps

None — `bun test src/lib/services/__tests__/credits-reconcile.test.ts` (34/34).

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] `N/A - billing service in packages/cloud/shared; no UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - billing service; no UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; a reservation-dedupe primitive.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - no deployed backend to log; the money paths are asserted against a real PGlite database under Evidence Details (real SQL, real unique index, balances read back to the cent).`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend involvement in this half.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/model behavior; credit-ledger logic.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - the domain artifacts are credit_transactions rows, asserted directly in the PGlite tests (row counts + balances per case).`

# Evidence Details

## Backend + frontend logs

<details><summary>Real-PGlite run — keyed reservation matrix (34/34 pass, 4 new)</summary>

```
CreditsService.reserve idempotency key (#16425)
  ✓ the same key replays the committed reservation — deducted exactly once
  ✓ a replay carries the ORIGINAL reserved amount so reconcile math settles the deducted row
  ✓ keys are org-scoped — the same key in another org reserves independently
  ✓ without a key, repeated reserves stay independent (behavior unchanged)
… 30 pre-existing reconcile/settlement/marker cases, unchanged

 34 pass
 0 fail
```

Assertions read balances and `credit_transactions` row counts back from the database: one deduction for a replayed key (10 → 9.5, one row), exactly-once settlement across both handles (refund row count 1), the replay handle carrying the original 0.4 (not the retry's 0.9), and cross-org independence.

</details>

Typecheck: `tsgo --noEmit` clean across `packages/cloud/shared` (0 errors). Biome (2.5.1) clean. Whole-file coverage of `credits.ts` from the changed-test lane: 86%+.

[stan-cloud]
